### PR TITLE
fix(desktop): 登录页小窗可读性三修——面板恒定缩放/品牌块让位/placeholder 接线

### DIFF
--- a/apps/desktop/src/renderer/components/login/LoginBrandStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginBrandStage.tsx
@@ -11,7 +11,7 @@ import wordmarkPng2x from '@/assets/login/wordmark@2x.png';
 import sloganPng from '@/assets/login/slogan.png';
 import sloganPng2x from '@/assets/login/slogan@2x.png';
 
-import { desktopScale, sloganShiftX } from './loginScale';
+import { brandPlacement, sloganShiftX } from './loginScale';
 import { HERO, LOGIN_COLORS, SLOGAN, STAGE, WORDMARK } from './loginDesignTokens';
 import { useViewportSize } from './LoginStage';
 
@@ -39,7 +39,8 @@ import { useViewportSize } from './LoginStage';
 export function LoginBrandStage() {
   const handoff = useLoginHandoff();
   const { width, height } = useViewportSize();
-  const { scale } = desktopScale(width, height);
+  // 品牌块整体让位(scale+translateY,构图冻结;用户拍板 2026-07-23,design.md §11)
+  const { scale, translateY } = brandPlacement(width, height);
   const sloganShift = sloganShiftX(width, scale);
 
   // 品牌资产推进锚:立绘/字标/Slogan 三图全部 settle(load 或 error 均计,防死锁)。
@@ -111,7 +112,7 @@ export function LoginBrandStage() {
           style={{
             width: STAGE.width,
             height: STAGE.height,
-            transform: `translate(-50%, -50%) scale(${scale})`,
+            transform: `translate(-50%, calc(-50% + ${translateY}px)) scale(${scale})`,
             transformOrigin: '50% 50%',
           }}
         >

--- a/apps/desktop/src/renderer/components/login/LoginControls.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginControls.tsx
@@ -231,6 +231,9 @@ export function LoginInput({
         className={cn(
           'absolute box-border appearance-none overflow-hidden whitespace-nowrap outline-none',
           'login-skin-input transition-none',
+          // placeholder 接 token(figma §4.1 定稿值);漏接时被 Tailwind preflight
+          // 默认 placeholder 灰顶替(2026-07-23 用户实测发现)。
+          'placeholder:text-[var(--login-control-placeholder)]',
           // hover 黑 5% 叠层(§2.2 照抄 347:2529;input 无法用伪元素,叠 background-image)
           'hover:enabled:[background-image:linear-gradient(rgba(0,0,0,0.05),rgba(0,0,0,0.05))]',
           'disabled:cursor-not-allowed',

--- a/apps/desktop/src/renderer/components/login/LoginStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginStage.tsx
@@ -9,7 +9,7 @@ import { LOGIN_GROUP } from './loginDesignTokens';
  * PR2b 所有权拆分(implementation-plan Step 3b WHAT2):品牌视觉层(白底体系背景
  * 渐变/立绘/字标/Slogan)已整体迁入 `LoginBrandStage`(App 级 overlay,唯一渲染者);
  * 本组件只承载 LoginPage 唯一拥有的白色输入面板与第三方圆钮行(children),
- * 与品牌层共用同一 desktopScale 公式,保证 1819×2098 坐标系逐像素对齐。
+ * 面板恒定 0.5 缩放,垂直锚点/避让计算引用 desktopScale 来映射品牌坐标系。
  *
  * - 面板恒定 0.5 缩放(用户拍板 2026-07-23,design.md §11):文字/输入框在任何窗口
  *   保持设计标准大小;垂直锚点跟随品牌层 desktopScale 画布 + 品牌避让/视口 clamp

--- a/apps/desktop/src/renderer/components/login/LoginStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginStage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 
-import { desktopScale } from './loginScale';
-import { LOGIN_GROUP, STAGE } from './loginDesignTokens';
+import { panelPlacement } from './loginScale';
+import { LOGIN_GROUP } from './loginDesignTokens';
 
 /**
  * LoginStage — 桌面登录 1819×2098 设计画布的「面板宿主」层(demo v3.1 缩放)。
@@ -11,8 +11,10 @@ import { LOGIN_GROUP, STAGE } from './loginDesignTokens';
  * 本组件只承载 LoginPage 唯一拥有的白色输入面板与第三方圆钮行(children),
  * 与品牌层共用同一 desktopScale 公式,保证 1819×2098 坐标系逐像素对齐。
  *
- * - stage 居中纯等比缩放(desktopScale,宽度不参与);
- * - children 渲染在登录整体组位置(x=570,y=1229/1227,680×560);
+ * - 面板恒定 0.5 缩放(用户拍板 2026-07-23,design.md §11):文字/输入框在任何窗口
+ *   保持设计标准大小;垂直锚点跟随品牌层 desktopScale 画布 + 品牌避让/视口 clamp
+ *   (公式见 loginScale.panelPlacement),不再与品牌层共用整画布缩放;
+ * - children 渲染在登录整体组坐标系内(680×560 设计px);
  * - 本层自身 z-auto:LoginPage 根建立 z-[9990] stacking context 整体压过品牌
  *   overlay(LoginBrandStage z-[9980]),内部与窗框描边(z-30)/拖拽条(z-40)
  *   沿 PR2a 相对层序。
@@ -40,36 +42,33 @@ export function LoginStage({
   groupStyle?: CSSProperties;
 }) {
   const { width, height } = useViewportSize();
-  const { scale } = desktopScale(width, height);
   const groupY = ssoOrgGroupY ? LOGIN_GROUP.ySsoOrg : LOGIN_GROUP.yDefault;
+  const placement = panelPlacement(width, height, groupY);
 
   return (
     <div
       className="fixed inset-0 overflow-hidden"
       data-testid="login-panel-stage-root"
     >
-      {/* 1819×2098 设计画布:居中纯等比缩放(与 LoginBrandStage 同公式对齐) */}
+      {/* 登录整体组(680×560 设计px):恒定 0.5 缩放,垂直锚点跟随品牌画布并
+          做品牌避让/视口 clamp(用户拍板 2026-07-23,design.md §11) */}
       <div
         data-testid="login-stage"
-        className="absolute left-1/2 top-1/2"
+        className="absolute"
         style={{
-          width: STAGE.width,
-          height: STAGE.height,
-          transform: `translate(-50%, -50%) scale(${scale})`,
-          transformOrigin: '50% 50%',
+          left: placement.centerX,
+          top: placement.topY,
+          width: LOGIN_GROUP.width,
+          height: LOGIN_GROUP.height,
+          transform: `translateX(-50%) scale(${placement.scale})`,
+          transformOrigin: 'top center',
         }}
       >
-        {/* 登录整体组(680×560):面板 + 第三方圆钮行由 children 提供 */}
+        {/* 面板 + 第三方圆钮行由 children 提供;groupStyle 承载 handoff 入场样式 */}
         <div
           data-testid="login-group"
-          className="absolute"
-          style={{
-            left: LOGIN_GROUP.x,
-            top: groupY,
-            width: LOGIN_GROUP.width,
-            height: LOGIN_GROUP.height,
-            ...groupStyle,
-          }}
+          className="absolute inset-0"
+          style={groupStyle}
         >
           {children}
         </div>

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginControls.placeholder.test.ts
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginControls.placeholder.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * placeholder 颜色接线冻结(2026-07-23 用户实测发现修复):
+ * `--login-control-placeholder` token 自登录换皮落地起注册但从未被消费,
+ * placeholder 实渲染为 Tailwind preflight 默认 placeholder 灰而非设计稿定稿值。
+ * 本测试按仓内静态源码断言先例(loginScenarioHarness.test.ts)锁住接线,
+ * 防止工具类再次脱落回默认灰。
+ */
+const source = readFileSync(
+  resolve(process.cwd(), 'src/renderer/components/login/LoginControls.tsx'),
+  'utf8',
+);
+
+describe('LoginControls placeholder 接线冻结', () => {
+  it('输入框 placeholder 颜色必须消费 --login-control-placeholder token', () => {
+    expect(source).toContain('placeholder:text-[var(--login-control-placeholder)]');
+  });
+});

--- a/apps/desktop/src/renderer/components/login/__tests__/loginScale.test.ts
+++ b/apps/desktop/src/renderer/components/login/__tests__/loginScale.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { desktopScale, sloganShiftX } from '../loginScale';
+import { brandPlacement, desktopScale, panelPlacement, PANEL_FIXED_SCALE, sloganShiftX } from '../loginScale';
 
 /**
  * 缩放公式行为单测(implementation-plan Step 2 WHAT1 锚点数值,demo v3.1 拍板)。
@@ -42,5 +42,62 @@ describe('sloganShiftX(窄窗左移只平移不缩放,demo applyDesktopScale 移
     expect(shift).toBeLessThan(0);
     const visibleHalf = 560 / 2 / scale;
     expect(shift).toBe(-Math.ceil(1647.22 - 909.5 + 20 - visibleHalf));
+  });
+});
+
+describe('panelPlacement(面板恒定 1x,用户拍板 2026-07-23,design.md §11)', () => {
+  it('scale 恒为 0.5,与窗口尺寸无关', () => {
+    expect(panelPlacement(1280, 800, 1229).scale).toBe(PANEL_FIXED_SCALE);
+    expect(panelPlacement(800, 600, 1229).scale).toBe(PANEL_FIXED_SCALE);
+    expect(panelPlacement(4000, 4000, 1229).scale).toBe(PANEL_FIXED_SCALE);
+  });
+
+  it('(1280, 800) 品牌避让主导:top = 立绘底(400+160×0.3813)+24 ≈ 485.01', () => {
+    const { topY } = panelPlacement(1280, 800, 1229);
+    expect(topY).toBeCloseTo(400 + 160 * (800 / 2098) + 24, 2);
+  });
+
+  it('(800, 600) 视口底 clamp 主导(功能优先压过品牌避让):top = 600-24-280 = 296', () => {
+    expect(panelPlacement(800, 600, 1229).topY).toBe(296);
+  });
+
+  it('高窗时锚点主导(不触发任何 clamp):(1300, 1400) top = 锚点中心-140', () => {
+    const s14 = 1400 / 2098;
+    const anchorTop = 700 + (1229 + 280 - 1049) * s14 - 140;
+    expect(panelPlacement(1300, 1400, 1229).topY).toBeCloseTo(anchorTop, 2);
+  });
+
+  it('水平中心 = 视口中线 + 组中心偏移 0.5 设计px × 0.5', () => {
+    expect(panelPlacement(1280, 800, 1229).centerX).toBeCloseTo(640.25, 6);
+  });
+});
+
+describe('brandPlacement(品牌块整体让位,用户拍板 2026-07-23 第二轮,design.md §11)', () => {
+  it('① 常态(1280,800):块底 461 < 面板顶 485-12,零让位 = v3.1 原值', () => {
+    const r = brandPlacement(1280, 800);
+    expect(r.scale).toBe(desktopScale(1280, 800).scale);
+    expect(r.translateY).toBe(0);
+  });
+
+  it('② 上移档(800,600):面板顶 296,块底 300+160×s 越界 → 整块上移,不压缩', () => {
+    const s6 = 600 / 2098;
+    const r = brandPlacement(800, 600);
+    expect(r.scale).toBe(s6); // 不压缩
+    expect(r.translateY).toBeCloseTo(-(300 + 160 * s6 - (296 - 12)), 2);
+  });
+
+  it('③ 压缩档(800,500):上移到顶仍不够 → 块高压进 [12, 面板顶-12]', () => {
+    const r = brandPlacement(800, 500);
+    const limit = 500 - 24 - 280 - 12; // 面板顶(视口底 clamp) - gap = 184
+    expect(r.scale).toBeCloseTo((limit - 12) / 934, 6);
+    const blockTop2 = 250 + (275 - 1049) * r.scale;
+    expect(r.translateY).toBeCloseTo(12 - blockTop2, 2);
+  });
+
+  it('让位后块底恰好贴面板顶-12(上移档守恒式)', () => {
+    const s6 = 600 / 2098;
+    const r = brandPlacement(800, 600);
+    const blockBottomAfter = 300 + 160 * s6 + r.translateY;
+    expect(blockBottomAfter).toBeCloseTo(296 - 12, 2);
   });
 });

--- a/apps/desktop/src/renderer/components/login/loginScale.ts
+++ b/apps/desktop/src/renderer/components/login/loginScale.ts
@@ -15,9 +15,9 @@
 export const LOGIN_STAGE_WIDTH = 1819;
 export const LOGIN_STAGE_HEIGHT = 2098;
 
-/** demo desktopScale 逐字移植:min(1, h/2098, (w-24)/680)。 */
+/** demo desktopScale 逐字移植:min(1, h/LOGIN_STAGE_HEIGHT, (w-24)/680)。 */
 export function desktopScale(w: number, h: number): { scale: number } {
-  const heightFit = h / 2098;
+  const heightFit = h / LOGIN_STAGE_HEIGHT;
   const panelGuard = (w - 24) / 680; // 唯一宽度介入:极端窄高组合下保障 680 宽功能面板不被裁
   return { scale: Math.min(1, heightFit, panelGuard) };
 }
@@ -62,15 +62,15 @@ export interface PanelPlacement {
 export function panelPlacement(w: number, h: number, groupY: number): PanelPlacement {
   const { scale: brandScale } = desktopScale(w, h);
   const panelHeight = 560 * PANEL_FIXED_SCALE; // 登录整体组高 560(figma §5.1)
-  const anchorCenterY = h / 2 + (groupY + 280 - 2098 / 2) * brandScale;
-  const brandBottomY = h / 2 + (1209 - 2098 / 2) * brandScale;
+  const anchorCenterY = h / 2 + (groupY + 280 - LOGIN_STAGE_HEIGHT / 2) * brandScale;
+  const brandBottomY = h / 2 + (1209 - LOGIN_STAGE_HEIGHT / 2) * brandScale;
   let topY = anchorCenterY - panelHeight / 2;
   topY = Math.max(topY, brandBottomY + 24);
   topY = Math.min(topY, h - 24 - panelHeight);
   topY = Math.max(topY, 24);
   return {
     scale: PANEL_FIXED_SCALE,
-    centerX: w / 2 + (910 - 1819 / 2) * PANEL_FIXED_SCALE,
+    centerX: w / 2 + (910 - LOGIN_STAGE_WIDTH / 2) * PANEL_FIXED_SCALE,
     topY,
   };
 }
@@ -95,8 +95,8 @@ export interface BrandPlacement {
 export function brandPlacement(w: number, h: number): BrandPlacement {
   const { scale: base } = desktopScale(w, h);
   const { topY: panelTop } = panelPlacement(w, h, 1229);
-  const blockTop = h / 2 + (275 - 2098 / 2) * base;
-  const blockBottom = h / 2 + (1209 - 2098 / 2) * base;
+  const blockTop = h / 2 + (275 - LOGIN_STAGE_HEIGHT / 2) * base;
+  const blockBottom = h / 2 + (1209 - LOGIN_STAGE_HEIGHT / 2) * base;
   const limit = panelTop - 12;
   const overflow = blockBottom - limit;
   if (overflow <= 0) return { scale: base, translateY: 0 };
@@ -104,6 +104,6 @@ export function brandPlacement(w: number, h: number): BrandPlacement {
   if (overflow <= maxShift) return { scale: base, translateY: -overflow };
   // 压缩档:块高(934 设计px)恰好塞进 [12, limit];画布仍中心缩放,位移把块顶放到 12。
   const scale2 = Math.max(limit - 12, 0) / 934;
-  const blockTop2 = h / 2 + (275 - 2098 / 2) * scale2;
+  const blockTop2 = h / 2 + (275 - LOGIN_STAGE_HEIGHT / 2) * scale2;
   return { scale: scale2, translateY: 12 - blockTop2 };
 }

--- a/apps/desktop/src/renderer/components/login/loginScale.ts
+++ b/apps/desktop/src/renderer/components/login/loginScale.ts
@@ -33,3 +33,77 @@ export function sloganShiftX(viewportWidth: number, scale: number): number {
   const overflow = 1647.22 - 909.5 + 20 - visibleHalf;
   return overflow > 0 ? -Math.ceil(overflow) : 0;
 }
+
+/**
+ * 面板恒定缩放(用户拍板 2026-07-23,design.md §11):1819×2098 为 2x 稿,
+ * 0.5 = 标准 1:1 逻辑尺寸——输入框/文字在任何窗口下保持设计标准大小,
+ * 不再随窗口高度线性缩小(desktopScale 仅品牌层继续使用)。
+ */
+export const PANEL_FIXED_SCALE = 0.5;
+
+export interface PanelPlacement {
+  /** 恒定 PANEL_FIXED_SCALE。 */
+  scale: number;
+  /** 面板水平中心(屏幕 px,配合 translateX(-50%))。 */
+  centerX: number;
+  /** 面板顶边(屏幕 px,已含品牌避让与视口 clamp)。 */
+  topY: number;
+}
+
+/**
+ * 面板定位(用户拍板 2026-07-23,design.md §11):
+ *   - 尺寸恒定 0.5(登录整体组 680×560 设计px → 340×280 逻辑px);
+ *   - 垂直锚点跟随品牌层 desktopScale 画布(组中心 y=groupY+280 映射到屏幕),
+ *     再依次 clamp:① 品牌避让——面板顶 ≥ 立绘底(设计 y=1209,figma §4.11)+24;
+ *     ② 功能优先——面板底 ≤ 视口底-24(压过品牌避让,小窗允许叠上立绘渐隐区,
+ *     面板层 z-[9990] 本就盖品牌层 z-[9980]);③ 顶部保底 24。
+ *   - 水平:组中心 x=910 与画布中线 909.5 的 0.5 设计px 偏移按恒定缩放折算。
+ */
+export function panelPlacement(w: number, h: number, groupY: number): PanelPlacement {
+  const { scale: brandScale } = desktopScale(w, h);
+  const panelHeight = 560 * PANEL_FIXED_SCALE; // 登录整体组高 560(figma §5.1)
+  const anchorCenterY = h / 2 + (groupY + 280 - 2098 / 2) * brandScale;
+  const brandBottomY = h / 2 + (1209 - 2098 / 2) * brandScale;
+  let topY = anchorCenterY - panelHeight / 2;
+  topY = Math.max(topY, brandBottomY + 24);
+  topY = Math.min(topY, h - 24 - panelHeight);
+  topY = Math.max(topY, 24);
+  return {
+    scale: PANEL_FIXED_SCALE,
+    centerX: w / 2 + (910 - 1819 / 2) * PANEL_FIXED_SCALE,
+    topY,
+  };
+}
+
+export interface BrandPlacement {
+  /** 品牌画布缩放(常态 = desktopScale;压缩档小于它)。 */
+  scale: number;
+  /** 画布垂直位移(屏幕 px,负值上移;常态 0)。 */
+  translateY: number;
+}
+
+/**
+ * 品牌块整体让位(用户拍板 2026-07-23 第二轮,design.md §11):
+ * 字标任何窗口必须完整可见,且绝不遮挡立绘脸部/黑猫——后者由「构图冻结」保证:
+ * 品牌块(立绘 275..1209,字标底 1191 / Slogan 底 995 均在其内)只作为整体
+ * 移动/缩放,字标与立绘的设计相对位(压胸口渐隐区)永不改变。三级规则:
+ *   ① 常态:v3.1 desktopScale + 画布居中(translateY=0),大窗零变化;
+ *   ② 面板上侵:块底越过面板顶-12 → 整块上移补偿,至块顶触及视口顶 12 为止;
+ *   ③ 极矮窗:上移仍不够 → 整块等比压缩至恰好塞进 [12, 面板顶-12]。
+ * 面板锚点取 yDefault(sso 态差 2 设计px,由 12px gap 吸收)。
+ */
+export function brandPlacement(w: number, h: number): BrandPlacement {
+  const { scale: base } = desktopScale(w, h);
+  const { topY: panelTop } = panelPlacement(w, h, 1229);
+  const blockTop = h / 2 + (275 - 2098 / 2) * base;
+  const blockBottom = h / 2 + (1209 - 2098 / 2) * base;
+  const limit = panelTop - 12;
+  const overflow = blockBottom - limit;
+  if (overflow <= 0) return { scale: base, translateY: 0 };
+  const maxShift = blockTop - 12;
+  if (overflow <= maxShift) return { scale: base, translateY: -overflow };
+  // 压缩档:块高(934 设计px)恰好塞进 [12, limit];画布仍中心缩放,位移把块顶放到 12。
+  const scale2 = Math.max(limit - 12, 0) / 934;
+  const blockTop2 = h / 2 + (275 - 2098 / 2) * scale2;
+  return { scale: scale2, translateY: 12 - blockTop2 };
+}


### PR DESCRIPTION
> 迁移自原私有仓 PR #531（原作者 @aj0928）。原仓库已下线，评论与 review 记录未随迁。

## 这次改了什么

用户实测发现登录页窗口缩小时文字/输入框/卡片随整画布线性缩小(800×600 时 scale≈0.286,文字完全不可读),连带排查出 placeholder 颜色脱线。三项修正(均为用户拍板,design.md §11/§11.1 已记录):

1. **登录面板恒定 1x 缩放**:白色面板(输入框/按钮/文案/第三方圆钮)恒定 scale=0.5(1819×2098 为 2x 稿,0.5=标准 1:1 逻辑尺寸),任何窗口下文字保持设计标准大小,不再参与 desktopScale。定位 = 锚点跟随品牌画布 + 品牌避让 + 视口 clamp 三级(功能优先)。`loginScale.panelPlacement()` 纯函数承载,LoginControls 内部坐标系零改动。
2. **品牌块整体让位(字标永现)**:面板上侵时品牌块(立绘+字标+Slogan)整块上移,极矮窗整块等比压缩——**构图冻结**,字标与立绘设计相对位永不变,天然满足「字标任何环境完整可见,且绝不遮挡人物脸部/黑猫」约束。`loginScale.brandPlacement()` 三级规则,大窗零视觉变化。
3. **placeholder 接线修复**:`--login-control-placeholder` token 自登录换皮落地起注册但从未被消费(git 全历史无 ::placeholder 规则,原生缺口非合并丢失),实渲染为 Tailwind preflight 默认灰。补 `placeholder:text-[var(--login-control-placeholder)]` 接线,CDP 实测已渲染 figma §4.1 定稿值;加静态源码冻结测试防再脱线。

参数权威链合规:三项拍板均已回写 `docs/login-redesign/design.md` §11/§11.1(覆盖 v3.1 缩放拍板的面板部分,品牌层保留;fidelity 口径同步声明)。

## 怎么验证的

- 单测:loginScale 新增 panelPlacement 5 例 + brandPlacement 4 例(三级让位锚点/守恒式);placeholder 冻结测试 1 例;login 全量 97/97 通过(含 LoginHandoffContext 动画契约)。
- 仓库根 `pnpm test:unit`:**exit=0 完全通过**(零 flaky)。
- 硬编码色审计(diff 制,基线 origin/main):PASS unexpected=0。
- 实机(CDP,沙盒 cn 区):1280×800 面板标准尺寸/品牌区不触发让位;800×600 面板恒定清晰、品牌块上移、字标完整可见;placeholder computed style 实测 rgb(212,212,212)。用户在沙盒逐档窗口手测验收通过。
- scenario harness(XDT_LOGIN_SCENARIO)遍历 providers/sso/outcome/error 各态,面板恒定缩放下各状态渲染正常。
- typecheck:仅剩主干既有的 7 个 sharp 类型基线错误(inlineImageCompressor/mediaFetch/thumbnail/image-resizer 等,与本 PR 文件零交集),非本 PR 引入。

## 风险

- 纯桌面 renderer 布局/样式,不涉及 SQLite migration / system prompt / 协议 / 原生层 / auth 状态机(登录逻辑零改动,只动呈现层)。
- 覆盖已拍板的 demo v3.1 缩放公式(面板部分)——已按四层权威链在 design.md §11/§11.1 落拍板记录,demo 对面板缩放的呈现自拍板起作废。
- 远程连接/手机版:不涉及——桌面登录缩放公式独立,移动端有独立布局(750 基准)与缩放规则,本 PR 未触碰;回调页不涉及。
- Windows 端视觉待验(与登录线既有未覆盖面一致,mac 已实测)。
