### PR TITLE
fix: play visible session completion sounds

### DIFF
--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -1714,6 +1714,52 @@ describe('AgentIslandService native publishing', () => {
     expect(playSound).toHaveBeenNthCalledWith(2, customSound('complete.wav'));
   });
 
+  it('plays the completion sound when the completed visible session is smart-suppressed', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const playSound = vi.fn<(sound: AgentIslandSoundChoice) => boolean>(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish, playSound },
+    });
+    syncEnabledForTest(service, publish);
+    service.setSoundSettings({
+      enabled: true,
+      sounds: {
+        ...DEFAULT_AGENT_ISLAND_SOUND_SETTINGS.sounds,
+        start: customSound('start.wav'),
+        complete: customSound('complete.wav'),
+      },
+    });
+    service.setAppFocused(true);
+    service.registerIpc();
+    const focusedWindow = {
+      isDestroyed: () => false,
+      isFocused: () => true,
+    } as unknown as BrowserWindow;
+    mocks.browserWindowFromWebContents.mockReturnValue(focusedWindow);
+    await registeredIpcHandler(AGENT_ISLAND_SET_VISIBLE_SESSION_CHANNEL)(
+      { sender: {} },
+      's1',
+    );
+    playSound.mockClear();
+
+    service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+    service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
+
+    expect(playSound).toHaveBeenNthCalledWith(1, customSound('start.wav'));
+    expect(playSound).toHaveBeenNthCalledWith(2, customSound('complete.wav'));
+    expect(publish.mock.calls.at(-1)?.[0].sessions[0]).toMatchObject({
+      sessionId: 's1',
+      phase: 'completed',
+      attention: false,
+    });
+  });
+
   it('keeps an unplanned remote daemon close in error and does not play completion sound', async () => {
     const { AgentIslandService } = await import('../service.js');
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -1802,8 +1802,9 @@ function getAgentIslandSoundEventForTransition(
     const prev = previousById.get(session.sessionId);
     if (prev?.phase !== 'error') return 'error';
   }
+  // Visual smart suppression controls unread/reveal state, not configured completion sounds.
   for (const session of next.sessions) {
-    if (!session.attention || session.phase !== 'completed') continue;
+    if (session.phase !== 'completed') continue;
     if (mutedCompletionSessionIds.has(session.sessionId)) continue;
     const prev = previousById.get(session.sessionId);
     if (prev?.phase !== 'completed') return 'complete';


### PR DESCRIPTION
> 迁移自原私有仓 PR #567（原作者 @ganlingyao）。原仓库已下线，评论与 review 记录未随迁。

## 这次改了什么

### 摘要

Agent Island 的完成音效在「当前可见 session 完成但被 smart suppress」场景下不会播放。原因是 `getAgentIslandSoundEventForTransition` 在判断 `completed` 时额外检查了 `session.attention`，而 smart suppress 会把 attention 置为 false——导致用户明明盯着这个 session 却听不到完成提示音。

本 PR 移除 completion sound 路径上的 `session.attention` 门控，使完成音效只看 session 是否真正从非完成态进入 `completed`，不再被视觉层的 smart suppression 影响。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无独立 issue，来源为内部使用反馈
- 本 PR 包含：service.ts 中 completion sound 逻辑修复 + 对应单元测试
- 明确不包含：smart suppress 对 attention/unread/reveal 的影响未改动
- 用户可见变化：当前可见 session 完成时，即使 smart suppress 生效也能听到完成音效
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run test -- --run apps/desktop/src/main/agent-island/__tests__/service.test.ts
结果：新增测试 "plays the completion sound when the completed visible session is smart-suppressed" 通过；
既有 agent-island sound 相关测试全部通过。
```

### 手工验证

1. macOS，启动 Desktop dev 模式
2. 打开 Agent Island，让一个 session 运行至完成（此时 window focused，session 为 visible session）
3. 确认完成音效正常播放
4. 对比修复前同场景无声

### 未执行的验证

Windows 平台未本地验证，依赖 CI。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Agent Island 完成音效播放条件，不影响 error sound、start sound 或 smart suppress 的其余行为（unread badge、reveal）。
- 回滚 / 降级方式：revert 本 commit 即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因