### PR TITLE
fix(desktop): AskUserQuestion 问答卡双主题对比度整改(badge 语义修复+选项列表面+按钮线框化)

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -174,14 +174,12 @@ export function AskUserQuestionPrompt({
     // Capture a static copy of the current button bar's DOM via a frozen JSX snapshot.
     // This uses the current values at call time, not reactive state.
     const btnClass = 'rounded-[9999px] px-[20px] py-[8px] text-13 font-medium';
-    const skipClass = cn(btnClass, 'bg-[var(--ask-skip-bg)] text-[var(--ask-skip-text)]');
+    const skipClass = cn(btnClass, 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]');
     const showNext = isMultiSelect || (existingAnswer !== undefined && !isMultiSelect) || isLastQuestion;
     const nextDisabled = isMultiSelect
       ? selectedLabels.size === 0 && !customInput.trim()
       : existingAnswer === undefined;
-    const nextClass = cn(btnClass, nextDisabled
-      ? 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]'
-      : 'bg-[var(--ask-next-bg)] text-[var(--ask-next-text)]');
+    const nextClass = cn(btnClass, nextDisabled ? 'cursor-not-allowed border border-[var(--border-default)] bg-transparent text-[var(--text-disabled-tertiary)] opacity-50' : 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]');
 
     buttonsSnapshotRef.current = (
       <>
@@ -428,7 +426,7 @@ export function AskUserQuestionPrompt({
         <div className="flex h-[32px] items-center justify-between">
           <div className="flex items-center">
             {currentQ?.header && (
-              <span className="inline-block rounded-[6px] bg-[var(--ask-badge-bg)] px-[8px] py-[2px] text-[12px] font-medium text-[var(--ask-badge-text)]">
+              <span className="inline-block rounded-[6px] bg-[var(--ask-header-chip-bg)] px-[8px] py-[2px] text-[12px] font-medium text-[var(--ask-badge-text)]">
                 {currentQ.header}
               </span>
             )}
@@ -440,8 +438,10 @@ export function AskUserQuestionPrompt({
             aria-label="Minimize question prompt"
             className={cn(
               'flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[6px]',
-              'text-[var(--plan-toolbar-btn-icon)] transition-colors',
-              'hover:bg-[var(--plan-toolbar-btn-hover-bg)]',
+              // 线框图标钮(2026-07-23 用户拍板): 与 Skip/Submit 同描边族,静默透明底
+              'border border-[var(--confirm-btn-secondary-border)] bg-transparent',
+              'text-[var(--confirm-btn-secondary-text)] transition-colors',
+              'hover:bg-[var(--confirm-btn-secondary-hover)]',
               isAnimating && 'cursor-not-allowed opacity-40 hover:bg-transparent',
             )}
           >
@@ -467,7 +467,7 @@ export function AskUserQuestionPrompt({
 
           {/* Options Container */}
           {options.length > 0 && (
-            <div className="overflow-hidden rounded-[12px] border border-[var(--ask-option-border)]">
+            <div className="overflow-hidden rounded-[12px] border border-[var(--ask-option-border)] bg-[var(--ask-option-list-bg)]">
               {options.map((opt, idx) => (
                 <div key={opt.label}>
                   {idx > 0 && (
@@ -661,7 +661,7 @@ export function AskUserQuestionPrompt({
                   onClick={handleBack}
                   className={cn(
                     'rounded-[9999px] px-[20px] py-[8px] text-13 font-medium',
-                    'bg-[var(--ask-skip-bg)] text-[var(--ask-skip-text)]',
+                    'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]',
                   )}
                 >
                   <span className="flex items-center gap-[6px]">
@@ -676,7 +676,7 @@ export function AskUserQuestionPrompt({
                 onClick={handleSkip}
                 className={cn(
                   'rounded-[9999px] px-[20px] py-[8px] text-13 font-medium',
-                  'bg-[var(--ask-skip-bg)] text-[var(--ask-skip-text)]',
+                  'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]',
                 )}
               >
                 Skip
@@ -700,8 +700,8 @@ export function AskUserQuestionPrompt({
                   className={cn(
                     'rounded-[9999px] px-[20px] py-[8px] text-13 font-medium',
                     (isMultiSelect ? (selectedLabels.size === 0 && !customInput.trim()) : existingAnswer === undefined)
-                      ? 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]'
-                      : 'bg-[var(--ask-next-bg)] text-[var(--ask-next-text)]',
+                      ? 'cursor-not-allowed border border-[var(--border-default)] bg-transparent text-[var(--text-disabled-tertiary)] opacity-50'
+                      : 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]',
                   )}
                 >
                   {isLastQuestion ? 'Submit' : 'Next'}

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -173,13 +173,13 @@ export function AskUserQuestionPrompt({
   const snapshotButtons = useCallback(() => {
     // Capture a static copy of the current button bar's DOM via a frozen JSX snapshot.
     // This uses the current values at call time, not reactive state.
-    const btnClass = 'rounded-[9999px] px-[20px] py-[8px] text-13 font-medium';
-    const skipClass = cn(btnClass, 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]');
+    const btnClass = 'rounded-[9999px] px-[20px] py-[8px] text-13 font-medium pointer-events-none';
+    const skipClass = cn(btnClass, 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)]');
     const showNext = isMultiSelect || (existingAnswer !== undefined && !isMultiSelect) || isLastQuestion;
     const nextDisabled = isMultiSelect
       ? selectedLabels.size === 0 && !customInput.trim()
       : existingAnswer === undefined;
-    const nextClass = cn(btnClass, nextDisabled ? 'cursor-not-allowed border border-[var(--border-default)] bg-transparent text-[var(--text-disabled-tertiary)] opacity-50' : 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]');
+    const nextClass = cn(btnClass, nextDisabled ? 'cursor-not-allowed border border-[var(--border-default)] bg-transparent text-[var(--text-disabled-tertiary)] opacity-50' : 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)]');
 
     buttonsSnapshotRef.current = (
       <>

--- a/apps/desktop/src/renderer/themes/__tests__/cindyDecisionData.ts
+++ b/apps/desktop/src/renderer/themes/__tests__/cindyDecisionData.ts
@@ -266,7 +266,7 @@ export const CINDY_EXPECTED_VALUES: Record<string, { light: string; dark: string
   'perm-code-bg': { light: '#F5F5F5', dark: '#2B2929' },
   'perm-item-selected-bg': { light: '#F1F1F1', dark: '#2F2D2D' },
   'plan-outline-active-bg': { light: '#F1F1F1', dark: '#2F2D2D' },
-  'plan-toolbar-btn-hover-bg': { light: '#F1F1F1', dark: '#2F2D2D' },
+  'plan-toolbar-btn-hover-bg': { light: '#E2E2E2', dark: '#444242' }, // 用户改稿 2026-07-23(ask 卡整改):原值贴着卡底(#F8F8F8/#312F2F)不可见,借 settings-menu-bg-hover(light)/send-btn-disabled-bg(dark)同档
   popover: { light: '0.0 0.0% 97.3%', dark: '0.0 2.1% 18.8%' },
   'primary-foreground': { light: '0.0 0.0% 100.0%', dark: '0.0 0.0% 100.0%' },
   'search-match-fg': { light: '214.3 5.5% 24.9%', dark: '0.0 0.0% 83.1%' },

--- a/apps/desktop/src/renderer/themes/__tests__/tokenRegistry.test.ts
+++ b/apps/desktop/src/renderer/themes/__tests__/tokenRegistry.test.ts
@@ -55,3 +55,16 @@ describe('主题注册表 · Plan 操作卡文字语义', () => {
     },
   );
 });
+
+// 2026-07-23 ask 卡整改防回潮:浅灰 chip/badge 上的文字必须接主文字槽位。
+// 换肤层把 --text-primary-on-dark 定义为「深底/红底前景白」双模式恒白,
+// chip 文字一旦回接该槽位,light 下即白字压浅底隐形(当日用户实测事故)。
+describe('主题注册表 · Ask/Plan badge 文字语义', () => {
+  it.each(['ask-badge-text', 'plan-bubble-badge-text'])(
+    '"%s" 使用主文字而非 on-dark 前景(防 light 白字压浅底回潮)',
+    (id) => {
+      expect(colorRegistry.resolveDefault(id, 'light')).toBe('var(--text-primary)');
+      expect(colorRegistry.resolveDefault(id, 'dark')).toBe('var(--text-primary)');
+    },
+  );
+});

--- a/apps/desktop/src/renderer/themes/builtin/cindy-dark.ts
+++ b/apps/desktop/src/renderer/themes/builtin/cindy-dark.ts
@@ -48,6 +48,10 @@ const overrides = {
   accent: '0.0 2.2% 18.0%', // 裁决: shadcn 中性 hover
   'agent-actions-rail': '#434343', // 边框/rail
   'ask-checkbox-border': '#BFC1C4', // AA checkbox border
+  'ask-header-chip-bg': '#3A3838', // ask 卡 header chip 底: surface-chip #2F2D2D 与卡底 #312F2F 撞色不可辨,借 settings-menu-bg-hover 同档提亮值(2026-07-21 已验证在 #312F2F 上可分辨);序号角标(ask-badge-bg)落在 #3A3838 列表面上,维持默认 #2F2D2D 反而可辨,不随
+  'ask-send-disabled-bg': '#3A3838', // ask 卡自由输入行禁用圆形 Send 底: 同 chip 提亮档(禁用感由 text-disabled-tertiary 文字承担)
+  'ask-option-list-bg': '#3A3838', // ask 卡选项列表面: 同 chip 提亮档,浮在 #312F2F 卡底上
+  'ask-option-hover': '#444242', // ask 卡选项行 hover: 需高于列表面 #3A3838 一档,借 send-btn-disabled-bg 同档(2026-07-23 ask 卡整改)
   background: '0.0 2.4% 16.1%', // 背景 -> HSL
   'chat-input-bg': '#312F2F', // 输入框
   'chat-input-border-focus': 'rgba(191, 193, 196, 0.30)', // 用户改稿 2026-07-20:输入框聚焦描边降至 30%
@@ -83,7 +87,7 @@ const overrides = {
   'perm-code-bg': '#2B2929', // code bg
   'perm-item-selected-bg': '#2F2D2D', // selected bg
   'plan-outline-active-bg': '#2F2D2D', // active bg
-  'plan-toolbar-btn-hover-bg': '#2F2D2D', // hover bg
+  'plan-toolbar-btn-hover-bg': '#444242', // hover bg: 原 #2F2D2D 比卡底 #312F2F 更暗近不可辨,且低于 ask 卡按钮静默底 #3A3838 会反向变暗,提亮到已有禁用灰底档 #444242(2026-07-23 ask 卡整改)
   popover: '0.0 2.1% 18.8%', // elevated -> HSL
   'primary-foreground': '0.0 0.0% 100.0%', // 白前景
   'search-match-fg': '0.0 0.0% 83.1%', // search fg

--- a/apps/desktop/src/renderer/themes/builtin/cindy-dark.ts
+++ b/apps/desktop/src/renderer/themes/builtin/cindy-dark.ts
@@ -48,7 +48,7 @@ const overrides = {
   accent: '0.0 2.2% 18.0%', // 裁决: shadcn 中性 hover
   'agent-actions-rail': '#434343', // 边框/rail
   'ask-checkbox-border': '#BFC1C4', // AA checkbox border
-  'ask-header-chip-bg': '#3A3838', // ask 卡 header chip 底: surface-chip #2F2D2D 与卡底 #312F2F 撞色不可辨,借 settings-menu-bg-hover 同档提亮值(2026-07-21 已验证在 #312F2F 上可分辨);序号角标(ask-badge-bg)落在 #3A3838 列表面上,维持默认 #2F2D2D 反而可辨,不随
+  'ask-header-chip-bg': '#3A3838', // ask 卡 header chip 底: surface-chip #2F2D2D 与卡底 #312F2F 撞色不可辨,借 settings-menu-bg-hover 同档提亮值(2026-07-21 已验证在 #312F2F 上可分辨);序号角标(ask-badge-bg)落在 #3A3838 列表面上,维持默认 #2F2D2D 反而可辨,不随 header chip 提亮档调整
   'ask-send-disabled-bg': '#3A3838', // ask 卡自由输入行禁用圆形 Send 底: 同 chip 提亮档(禁用感由 text-disabled-tertiary 文字承担)
   'ask-option-list-bg': '#3A3838', // ask 卡选项列表面: 同 chip 提亮档,浮在 #312F2F 卡底上
   'ask-option-hover': '#444242', // ask 卡选项行 hover: 需高于列表面 #3A3838 一档,借 send-btn-disabled-bg 同档(2026-07-23 ask 卡整改)

--- a/apps/desktop/src/renderer/themes/builtin/cindy-light.ts
+++ b/apps/desktop/src/renderer/themes/builtin/cindy-light.ts
@@ -48,6 +48,7 @@ const overrides = {
   accent: '0.0 0.0% 94.5%', // 裁决: shadcn 中性 hover
   'agent-actions-rail': '#DCDFE3', // 边框/rail
   'ask-checkbox-border': '#686B72', // AA checkbox border
+  'ask-option-list-bg': '#FFFFFF', // ask 卡选项列表面: 纯白浮在 #F8F8F8 卡底上(2026-07-23 ask 卡整改)
   background: '0.0 0.0% 92.9%', // 背景 -> HSL
   'chat-input-bg': '#F8F8F8', // 输入框
   'chat-input-border-focus': 'rgba(104, 107, 114, 0.30)', // 用户改稿 2026-07-20:输入框聚焦描边降至 30%
@@ -82,7 +83,7 @@ const overrides = {
   'perm-code-bg': '#F5F5F5', // code bg
   'perm-item-selected-bg': '#F1F1F1', // selected bg
   'plan-outline-active-bg': '#F1F1F1', // active bg
-  'plan-toolbar-btn-hover-bg': '#F1F1F1', // hover bg
+  'plan-toolbar-btn-hover-bg': '#E2E2E2', // hover bg: 原 #F1F1F1 与 chip 静默底同色无反馈、在 #F8F8F8 卡底上也近不可辨,借 settings-menu-bg-hover 同档往暗压(2026-07-23 ask 卡整改)
   popover: '0.0 0.0% 97.3%', // elevated -> HSL
   'primary-foreground': '0.0 0.0% 100.0%', // 白前景
   'search-match-fg': '214.3 5.5% 24.9%', // search fg

--- a/apps/desktop/src/renderer/themes/colors.ts
+++ b/apps/desktop/src/renderer/themes/colors.ts
@@ -1490,17 +1490,17 @@ registerColor('ask-badge-bg', {
   dark: 'var(--surface-chip)',
 }, 'Light Gray');
 registerColor('ask-badge-text', {
-  light: 'var(--text-primary-on-dark)',
-  dark: 'var(--text-primary-on-dark)',
-}, 'Near Black');
-registerColor('ask-skip-bg', {
+  light: 'var(--text-primary)',
+  dark: 'var(--text-primary)',
+}, '主文字 — chip/角标文字随主题(勿接 on-dark 槽位,light 会白字压浅底)');
+registerColor('ask-header-chip-bg', {
   light: 'var(--surface-chip)',
   dark: 'var(--surface-chip)',
-}, 'Light Gray');
-registerColor('ask-skip-text', {
-  light: 'var(--text-primary-on-dark)',
-  dark: 'var(--text-primary-on-dark)',
-}, 'Near Black');
+}, 'header chip 底 — 落在卡底上,与选项行上的序号角标(ask-badge-bg)分家,皮肤可各自调档');
+registerColor('ask-option-list-bg', {
+  light: 'var(--surface-elevated)',
+  dark: 'var(--surface-elevated)',
+}, '选项列表面 — 原透明露卡底在 dark 下成一坨深色(2026-07-23 用户实测),给独立列表面');
 registerColor('ask-input-bg', {
   light: 'var(--surface-elevated)',
   dark: 'var(--surface-elevated)',
@@ -1559,16 +1559,6 @@ registerColor('ask-checkbox-checked-icon', {
   light: 'var(--surface-on-card)',
   dark: 'var(--surface-on-card)',
 }, 'Pure White — checkmark');
-
-// Next button — inverted/反色: Light mode = dark bg + white text
-registerColor('ask-next-bg', {
-  light: 'var(--accent-cta-bg)',
-  dark: 'var(--accent-cta-bg)',
-}, 'Near Black');
-registerColor('ask-next-text', {
-  light: 'var(--surface-on-card)',
-  dark: 'var(--surface-on-card)',
-}, 'Pure White');
 
 // Plan Viewer / Plan Action cards (FP-5/FP-6) — Light
 registerColor('plan-card-bg', {
@@ -1698,9 +1688,9 @@ registerColor('plan-bubble-badge-bg', {
   dark: 'var(--surface-chip)',
 }, 'Light Gray chip');
 registerColor('plan-bubble-badge-text', {
-  light: 'var(--text-primary-on-dark)',
-  dark: 'var(--text-primary-on-dark)',
-}, 'Near Black');
+  light: 'var(--text-primary)',
+  dark: 'var(--text-primary)',
+}, '主文字 — badge 文字随主题(勿接 on-dark 槽位)');
 registerColor('plan-bubble-body-text', {
   light: 'var(--text-primary-body-strong)',
   dark: 'var(--text-primary-body-strong)',


### PR DESCRIPTION
> 迁移自原私有仓 PR #580（原作者 @aj0928）。原仓库已下线，评论与 review 记录未随迁。

## 这次改了什么

### 摘要

AskUserQuestion 问答卡在 CINDY 双主题下多处元素"看不见":header chip 与序号角标在 Light 下白字压浅底完全隐形,Dark 下 chip/按钮/选项列表底色与卡底撞色导致形状消失,最小化按钮无静默可供性,Submit 禁用态与可用态难以区分。本 PR 按用户逐项拍板整改:

- **badge 文字语义修复(事故根因)**:`ask-badge-text`/`ask-skip-text`/`plan-bubble-badge-text` 原错接 `--text-primary-on-dark`——该槽位在换肤层被定义为「深底/红底前景白」双模式恒白,Light 下即白字压 #F1F1F1 隐形。改接 `--text-primary`,并在 tokenRegistry 增加防回潮冻结测试。
- **选项列表补独立列表面**:新 token `ask-option-list-bg`(cindy-dark #3A3838 / cindy-light 纯白),原容器透明露卡底,Dark 下与卡面 #312F2F 撞色成一坨;行 hover 同步提档(#444242)防"越 hover 越暗"。
- **header chip 与序号角标分家**:新 token `ask-header-chip-bg`(chip 落卡底,dark 取 #3A3838 提亮档);角标维持 `ask-badge-bg`(落列表面,默认 surface-chip 反而可辨)。
- **按钮线框化(用户拍板)**:Skip/Back/Submit/最小化钮统一改透明底+1px 描边,复用全 app 描边先例 `confirm-btn-secondary-*` 族;Submit disabled 按仓内「禁用视觉用 opacity」约定整体减淡 50% + `cursor-not-allowed`;最小化钮保留 — 图标(与收起横条上的 + 成对,语义为可还原收起)。退役 `ask-skip-*`/`ask-next-*` 孤儿 token。
- **plan-toolbar-btn-hover-bg 双模式提档**:dark 原 #2F2D2D 贴卡底不可见且低于线框钮静默态会反向变暗,提至 #444242;light 原 #F1F1F1 与 chip 同色无反馈,借 settings-menu-bg-hover 已验证档 #E2E2E2。决策表(cindyDecisionData)同步冻结值并注明来由。

新增 dark 档位值均复用仓内已考古档(#3A3838 = settings-menu-bg-hover 2026-07-21 验证档,#444242 = send-btn-disabled-bg 同档),无自由裁量新色。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:用户 2026-07-23 实测反馈(双模式截图标注)
- 本 PR 包含:AskUserQuestionPrompt 样式接线、themes token 注册/退役、cindy 双皮肤 scoped 档位、决策表同步、防回潮测试
- 明确不包含:AskUserQuestionBubble(已回答气泡)与 minimized 横条的视觉调整;IM/Slack 渠道问答卡;plan-bubble-badge-bg 底色(仅同病修其文字)
- 用户可见变化:AskUserQuestion 问答卡双主题下 chip/角标/选项列表/按钮全部可辨;Skip/Submit/最小化钮改线框形态
- 是否存在 breaking change:无

### UI 变化

macOS 桌面端,CINDY Dark/Light 均实测。修复前:Light 下 chip 与角标白字隐形、Dark 下 chip/按钮/选项区融进卡底(见用户反馈截图);修复后:双模式全部元素可辨,按钮线框化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit(仓库根)
结果:exit=0,全部 PASS(desktop 含 themes 44/44,新增 2 条防回潮断言)

pnpm --filter desktop run --if-present typecheck
结果:exit=0,0 error

node scripts/hardcoded-color-audit.mjs
结果:PASS unexpected=0(raw 25 全部落在皮肤/决策表既有豁免位)
```

### 手工验证

macOS 沙盒(XDT_ISOLATED cindy-skin,CN 真实数据):真实 Claude Code 会话触发 ask_user_question,选项形态(header chip + 双选项 + Type something else + 序号角标)双主题逐项目检;CDP 实测计算样式确认 token 接线(Skip 透明底+1px 描边、Submit disabled opacity 0.5 + not-allowed、列表面 dark #3A3838/light #FFFFFF)。用户本人已在沙盒双模式验收通过。

### 未执行的验证

Windows 端视觉未验(纯 token/类名改动,无平台分支逻辑);多选形态(checkbox+Next)与 minimized 横条仅代码走查未实测——按钮与列表面 token 与单选形态同源。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 AskUserQuestion 问答卡与 plan 卡工具钮 hover 视觉;`plan-toolbar-btn-hover-bg` 提档会同时作用于 PlanActionCard 工具钮 hover(原值本就贴底不可见,属同病顺修)
- 回滚 / 降级方式:revert 单 commit 即可,无数据/协议/持久化涉及

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(token 语义均落在 colors.ts 描述与决策表注释;DESIGN.md 无该组件条目,不涉及)

