### PR TITLE
feat(desktop): 接入服务端配置驱动的计费入口

### DIFF
--- a/apps/desktop/src/main/__tests__/serverApiClient.test.ts
+++ b/apps/desktop/src/main/__tests__/serverApiClient.test.ts
@@ -10,6 +10,10 @@ const mocks = vi.hoisted(() => ({
   getAccessToken: vi.fn(),
   refresh: vi.fn(),
   invalidateSession: vi.fn(),
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
 }));
 
 vi.mock('electron', () => ({ net: { fetch: mocks.netFetch } }));
@@ -19,7 +23,7 @@ vi.mock('../authManager', () => ({
   invalidateSession: mocks.invalidateSession,
 }));
 vi.mock('../logger', () => ({
-  createLogger: () => ({ error: vi.fn(), warn: vi.fn() }),
+  createLogger: () => mocks.logger,
 }));
 
 import { serverApiFetch } from '../serverApiClient';
@@ -161,5 +165,53 @@ describe('serverApiFetch', () => {
     ).rejects.toBeTruthy();
     expect(mocks.refresh).not.toHaveBeenCalled();
     expect(mocks.invalidateSession).not.toHaveBeenCalled();
+  });
+
+  it('redacted requests do not persist upstream messages, bodies, or network errors', async () => {
+    mocks.getAccessToken.mockReturnValue('token-a');
+    mocks.netFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => ({
+          error: {
+            code: 'PROVIDER_PRIVATE_FAILURE',
+            message: 'merchant private response body',
+          },
+        }),
+      })
+      .mockRejectedValueOnce(new Error('network URL contained private detail'));
+
+    await expect(
+      serverApiFetch('/api/billing/orders/order-1', {
+        baseUrl: 'https://model-access.example.com',
+        redactErrorDetails: true,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      statusCode: 502,
+      message: '请求失败 (502)',
+    });
+    await expect(
+      serverApiFetch('/api/billing/orders/order-1', {
+        baseUrl: 'https://model-access.example.com',
+        redactErrorDetails: true,
+      }),
+    ).rejects.toBeTruthy();
+
+    const logged = JSON.stringify({
+      error: mocks.logger.error.mock.calls,
+      warn: mocks.logger.warn.mock.calls,
+    });
+    expect(logged).not.toContain('PROVIDER_PRIVATE_FAILURE');
+    expect(logged).not.toContain('merchant private response body');
+    expect(logged).not.toContain('private detail');
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      'serverApiFetch.redacted_not_ok',
+      'path=/api/billing/orders/order-1',
+      'method=GET',
+      'status=502',
+      'code=INTERNAL_ERROR',
+    );
   });
 });

--- a/apps/desktop/src/main/billing/__tests__/index.test.ts
+++ b/apps/desktop/src/main/billing/__tests__/index.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+
+import { BILLING_INVOKE } from '../../../shared/billing.js';
+import { ServerApiError } from '../../serverApiClient.js';
+import { createBillingHandlers } from '../index.js';
+
+function harness() {
+  const mainFrame = { routingId: 1 };
+  const mainWebContents = { id: 1, mainFrame };
+  const mainWindow = {
+    isDestroyed: () => false,
+    webContents: mainWebContents,
+  } as unknown as BrowserWindow;
+  const now = '2026-07-23T12:00:00.000Z';
+  const paymentOrder = {
+    orderId: 'order_1',
+    productCode: 'credit_topup',
+    offerCode: 'credit_topup_custom',
+    amount: '20',
+    currency: 'cny',
+    status: 'PENDING',
+    paymentAction: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const subscription = {
+    subscriptionId: 'subscription_1',
+    status: 'INCOMPLETE',
+    currentPeriodStartAt: null,
+    currentPeriodEndAt: null,
+    entitlementValidUntil: null,
+    cancelAtPeriodEnd: false,
+    effectivePlan: null,
+    purchaseAttemptId: 'attempt_1',
+    paymentAction: null,
+  };
+  const fetch = vi.fn(async (path: string) => {
+    if (path === '/api/model-access/balance') {
+      return {
+        planCredits: '7.000000001',
+        purchasedCredits: '5.000000002',
+        promotionalCredits: '0.345678898',
+        available: '12.345678901',
+        scale: 9,
+        observedAt: now,
+      };
+    }
+    if (path === '/api/billing/catalog') return { products: [] };
+    if (path === '/api/billing/orders?limit=20') return { orders: [], nextCursor: null };
+    if (path === '/api/billing/subscription') return { subscription };
+    if (path.includes('/subscriptions')) return subscription;
+    return paymentOrder;
+  }) as unknown as NonNullable<Parameters<typeof createBillingHandlers>[0]['fetch']> &
+    ReturnType<typeof vi.fn>;
+  const openExternal = vi.fn(async () => undefined);
+  const handlers = createBillingHandlers({
+    getMainWindow: () => mainWindow,
+    getBaseUrl: () => 'https://model-access.example',
+    fetch,
+    openExternal,
+  });
+  const call = (
+    channel: string,
+    payload?: unknown,
+    sender: unknown = mainWebContents,
+    senderFrame: unknown = mainFrame,
+  ) => handlers[channel]!({ sender, senderFrame } as never, payload);
+  return { call, fetch, mainFrame, mainWebContents, openExternal };
+}
+
+describe('billing IPC', () => {
+  it('queries the fixed current-account balance endpoint without a renderer payload', async () => {
+    const { call, fetch } = harness();
+
+    await expect(call(BILLING_INVOKE.GET_BALANCE)).resolves.toEqual({
+      planCredits: '7.000000001',
+      purchasedCredits: '5.000000002',
+      promotionalCredits: '0.345678898',
+      available: '12.345678901',
+      scale: 9,
+      observedAt: '2026-07-23T12:00:00.000Z',
+    });
+    expect(fetch).toHaveBeenCalledWith('/api/model-access/balance', {
+      baseUrl: 'https://model-access.example',
+      timeoutMs: 20_000,
+      redactErrorDetails: true,
+    });
+  });
+
+  it('rejects any balance payload before network access', async () => {
+    const { call, fetch } = harness();
+
+    await expect(call(BILLING_INVOKE.GET_BALANCE, {})).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['NOT_FOUND', 404, 'NOT_FOUND'],
+    ['INTERNAL', 501, 'UNSUPPORTED_CAPABILITY'],
+    ['INTERNAL', 503, 'MODEL_ACCESS_FAILED'],
+  ])('maps balance error %s (%i) to safe IPC code %s', async (serverCode, statusCode, ipcCode) => {
+    const { call, fetch } = harness();
+    fetch.mockRejectedValueOnce(new ServerApiError(serverCode, statusCode, 'sensitive detail'));
+
+    await expect(call(BILLING_INVOKE.GET_BALANCE)).rejects.toMatchObject({
+      code: ipcCode,
+    });
+  });
+
+  it('rejects a malformed balance snapshot as an invalid server response', async () => {
+    const { call, fetch } = harness();
+    fetch.mockResolvedValueOnce({
+      planCredits: '7',
+      purchasedCredits: '5',
+      promotionalCredits: '4',
+      available: '999',
+      scale: 9,
+      observedAt: '2026-07-23T12:00:00.000Z',
+    });
+
+    await expect(call(BILLING_INVOKE.GET_BALANCE)).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: '[INTERNAL] billing service response was invalid',
+    });
+  });
+
+  it('maps a top-up to the fixed model-access endpoint and idempotency header', async () => {
+    const { call, fetch } = harness();
+    await call(BILLING_INVOKE.CREATE_TOPUP, {
+      request: {
+        offerCode: 'credit_topup_custom',
+        amount: '20.00',
+        purchaseOptionId: 'listing_alipay',
+      },
+      idempotencyKey: 'desktop:topup:12345678',
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/billing/credit-topup/orders', {
+      baseUrl: 'https://model-access.example',
+      timeoutMs: 20_000,
+      redactErrorDetails: true,
+      method: 'POST',
+      body: {
+        offerCode: 'credit_topup_custom',
+        amount: '20.00',
+        purchaseOptionId: 'listing_alipay',
+      },
+      headers: { 'Idempotency-Key': 'desktop:topup:12345678' },
+    });
+  });
+
+  it('encodes resource ids and fixes the refresh method', async () => {
+    const { call, fetch } = harness();
+    await call(BILLING_INVOKE.REFRESH_SUBSCRIPTION_PURCHASE, {
+      purchaseAttemptId: 'attempt/1',
+    });
+    expect(fetch).toHaveBeenCalledWith('/api/billing/subscriptions/purchases/attempt%2F1/refresh', {
+      baseUrl: 'https://model-access.example',
+      timeoutMs: 20_000,
+      redactErrorDetails: true,
+      method: 'POST',
+    });
+  });
+
+  it('rejects non-main-window senders before network access', async () => {
+    const { call, fetch } = harness();
+    await expect(call(BILLING_INVOKE.GET_CATALOG, undefined, { id: 2 })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-top-level frames in the main window before network access', async () => {
+    const { call, fetch, mainWebContents } = harness();
+    await expect(
+      call(BILLING_INVOKE.GET_CATALOG, undefined, mainWebContents, { routingId: 2 }),
+    ).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown fields and invalid idempotency keys', async () => {
+    const { call, fetch } = harness();
+    await expect(
+      call(BILLING_INVOKE.CREATE_SUBSCRIPTION, {
+        request: {
+          offerCode: 'plus_month',
+          purchaseOptionId: 'listing_alipay',
+          provider: 'alipay',
+        },
+        idempotencyKey: 'short',
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_PARAMS' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('bounds order list requests', async () => {
+    const { call, fetch } = harness();
+    await expect(call(BILLING_INVOKE.LIST_ORDERS, { limit: 101 })).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('converts backend failures to the IPC error protocol without leaking details', async () => {
+    const { call, fetch } = harness();
+    fetch.mockRejectedValueOnce(
+      new ServerApiError('UPSTREAM_SECRET_CODE', 500, 'sensitive backend response'),
+    );
+
+    await expect(call(BILLING_INVOKE.GET_CATALOG)).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: '[INTERNAL] billing service request failed',
+    });
+  });
+
+  it('converts malformed single-resource responses to a fixed INTERNAL error', async () => {
+    const { call, fetch } = harness();
+    fetch.mockResolvedValueOnce({
+      orderId: 'order_1',
+      status: 'FUTURE_STATUS',
+      providerError: 'private response detail',
+    });
+
+    await expect(call(BILLING_INVOKE.GET_ORDER, { orderId: 'order_1' })).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: '[INTERNAL] billing service response was invalid',
+    });
+  });
+
+  it('fail-closes an unknown current subscription status instead of returning no subscription', async () => {
+    const { call, fetch } = harness();
+    fetch.mockResolvedValueOnce({
+      subscription: {
+        subscriptionId: 'subscription_1',
+        status: 'FUTURE_STATUS',
+        currentPeriodStartAt: null,
+        currentPeriodEndAt: null,
+        entitlementValidUntil: null,
+        cancelAtPeriodEnd: false,
+        effectivePlan: null,
+        purchaseAttemptId: null,
+        paymentAction: null,
+      },
+    });
+
+    await expect(call(BILLING_INVOKE.GET_CURRENT_SUBSCRIPTION)).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: '[INTERNAL] billing service response was invalid',
+    });
+  });
+
+  it('opens only public HTTPS Stripe Checkout URLs from the main top-level frame', async () => {
+    const { call, openExternal } = harness();
+    const url = 'https://checkout.stripe.com/c/pay/session_fixture#fragment';
+
+    await expect(call(BILLING_INVOKE.OPEN_PAYMENT_REDIRECT, { url })).resolves.toEqual({
+      success: true,
+    });
+    expect(openExternal).toHaveBeenCalledWith(url);
+  });
+
+  it.each([
+    'http://checkout.stripe.com/c/pay/test',
+    'file:///tmp/payment.html',
+    'javascript:alert(1)',
+    'stripe://checkout/session',
+    'https://checkout.stripe.com.evil.example/c/pay/test',
+    'https://checkout.stripe.com@evil.example/c/pay/test',
+    'https://user:password@checkout.stripe.com/c/pay/test',
+    'https://checkout.stripe.com:444/c/pay/test',
+    `https://checkout.stripe.com/c/pay/${'x'.repeat(2_100)}`,
+  ])('rejects an unsafe billing redirect without opening it: %s', async (url) => {
+    const { call, openExternal } = harness();
+    await expect(call(BILLING_INVOKE.OPEN_PAYMENT_REDIRECT, { url })).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+    });
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('rejects billing redirects from a child frame', async () => {
+    const { call, mainWebContents, openExternal } = harness();
+    await expect(
+      call(
+        BILLING_INVOKE.OPEN_PAYMENT_REDIRECT,
+        { url: 'https://checkout.stripe.com/c/pay/test' },
+        mainWebContents,
+        { routingId: 2 },
+      ),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('rejects billing redirects from a different window', async () => {
+    const { call, openExternal } = harness();
+    await expect(
+      call(
+        BILLING_INVOKE.OPEN_PAYMENT_REDIRECT,
+        { url: 'https://checkout.stripe.com/c/pay/test' },
+        { id: 2 },
+      ),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/billing/__tests__/projection.test.ts
+++ b/apps/desktop/src/main/billing/__tests__/projection.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  projectBillingCatalog,
+  projectBillingCurrentSubscription,
+  projectBillingOrderList,
+  projectBillingPaymentOrder,
+  projectModelAccessBalance,
+} from '../projection.js';
+
+const now = '2026-07-23T12:00:00.000Z';
+
+function order(overrides: Record<string, unknown> = {}) {
+  return {
+    orderId: 'order_1',
+    productCode: 'credit_topup',
+    offerCode: 'credit_topup_20',
+    amount: '20',
+    currency: 'cny',
+    status: 'PENDING',
+    paymentAction: {
+      type: 'REDIRECT',
+      url: 'https://checkout.stripe.com/c/pay/session_fixture',
+      expiresAt: now,
+    },
+    createdAt: now,
+    updatedAt: now,
+    internalProviderResponse: 'must not cross IPC',
+    ...overrides,
+  };
+}
+
+describe('billing response projection', () => {
+  it('projects one exact ledger snapshot and strips server-only fields', () => {
+    expect(
+      projectModelAccessBalance({
+        planCredits: '7.000000001',
+        purchasedCredits: '-2.5',
+        promotionalCredits: '0.499999999',
+        available: '5',
+        scale: 9,
+        observedAt: '2026-07-23T12:00:00.123456789Z',
+        tenantId: 'must not cross IPC',
+      }),
+    ).toEqual({
+      planCredits: '7.000000001',
+      purchasedCredits: '-2.5',
+      promotionalCredits: '0.499999999',
+      available: '5',
+      scale: 9,
+      observedAt: '2026-07-23T12:00:00.123456789Z',
+    });
+  });
+
+  it('rejects inconsistent, negative protected-pool, and invalid-date balance snapshots', () => {
+    const valid = {
+      planCredits: '7',
+      purchasedCredits: '5',
+      promotionalCredits: '4',
+      available: '16',
+      scale: 9,
+      observedAt: now,
+    };
+
+    expect(() => projectModelAccessBalance({ ...valid, available: '15.999999999' })).toThrow();
+    expect(() =>
+      projectModelAccessBalance({
+        ...valid,
+        planCredits: '-1',
+        purchasedCredits: '13',
+      }),
+    ).toThrow();
+    expect(() =>
+      projectModelAccessBalance({ ...valid, observedAt: '2026-02-31T12:00:00Z' }),
+    ).toThrow();
+  });
+
+  it('keeps valid catalog entries while dropping malformed and unsupported nested entries', () => {
+    const projected = projectBillingCatalog({
+      products: [
+        {
+          code: 'credit_topup',
+          name: 'Credits',
+          kind: 'CREDIT_TOPUP',
+          level: null,
+          sortOrder: 1,
+          internalField: 'hidden',
+          offers: [
+            {
+              code: 'credit_topup_20',
+              interval: null,
+              currency: 'cny',
+              amount: '20',
+              minAmount: null,
+              maxAmount: null,
+              creditAmount: '20',
+              rolloverCap: null,
+              purchaseOptions: [
+                {
+                  id: 'listing_alipay',
+                  provider: 'alipay',
+                  capability: 'ONE_TIME_PAYMENT',
+                  paymentAction: 'QR_CODE',
+                  merchantId: 'hidden',
+                },
+                {
+                  id: 'listing_future',
+                  provider: 'future_provider',
+                  capability: 'ONE_TIME_PAYMENT',
+                  paymentAction: 'QR_CODE',
+                },
+                {
+                  id: 'listing_future_action',
+                  provider: 'stripe',
+                  capability: 'ONE_TIME_PAYMENT',
+                  paymentAction: 'EMBEDDED_WIDGET',
+                },
+                {
+                  id: 'listing_future_capability',
+                  provider: 'stripe',
+                  capability: 'FUTURE_CAPABILITY',
+                  paymentAction: 'REDIRECT',
+                },
+              ],
+            },
+            { code: 'broken', purchaseOptions: [] },
+          ],
+        },
+        {
+          code: 'future_product',
+          name: 'Future',
+          kind: 'USAGE_PACKAGE',
+          level: null,
+          sortOrder: 2,
+          offers: [],
+        },
+      ],
+    });
+
+    expect(projected).toEqual({
+      products: [
+        {
+          code: 'credit_topup',
+          name: 'Credits',
+          kind: 'CREDIT_TOPUP',
+          level: null,
+          sortOrder: 1,
+          offers: [
+            {
+              code: 'credit_topup_20',
+              interval: null,
+              currency: 'cny',
+              amount: '20',
+              minAmount: null,
+              maxAmount: null,
+              creditAmount: '20',
+              rolloverCap: null,
+              purchaseOptions: [
+                {
+                  id: 'listing_alipay',
+                  provider: 'alipay',
+                  capability: 'ONE_TIME_PAYMENT',
+                  paymentAction: 'QR_CODE',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('drops malformed list rows and strips unknown payment actions without leaking extra fields', () => {
+    const projected = projectBillingOrderList({
+      orders: [
+        order(),
+        order({ orderId: 'order_unknown_status', status: 'REFUNDING' }),
+        order({
+          orderId: 'order_unknown_action',
+          paymentAction: {
+            type: 'CUSTOM_SCHEME',
+            value: 'javascript:alert(1)',
+            expiresAt: now,
+          },
+        }),
+        order({
+          orderId: 'order_oversized_qr',
+          paymentAction: {
+            type: 'QR_CODE',
+            value: 'x'.repeat(4_097),
+            expiresAt: now,
+          },
+        }),
+      ],
+      nextCursor: null,
+      serverDebug: 'hidden',
+    });
+
+    expect(projected.orders).toHaveLength(3);
+    expect(projected.orders[0]).not.toHaveProperty('internalProviderResponse');
+    expect(projected.orders[1]).toMatchObject({
+      orderId: 'order_unknown_action',
+      paymentAction: null,
+    });
+    expect(projected.orders[2]).toMatchObject({
+      orderId: 'order_oversized_qr',
+      paymentAction: null,
+    });
+  });
+
+  it('rejects malformed single orders and fail-closes unknown subscription status', () => {
+    expect(() => projectBillingPaymentOrder(order({ status: 'REFUNDING' }))).toThrow();
+    expect(() =>
+      projectBillingPaymentOrder(order({ createdAt: '2026-02-31T12:00:00.000Z' })),
+    ).toThrow();
+    expect(() =>
+      projectBillingCurrentSubscription({
+        subscription: {
+          subscriptionId: 'subscription_1',
+          status: 'FUTURE_STATUS',
+          currentPeriodStartAt: null,
+          currentPeriodEndAt: null,
+          entitlementValidUntil: null,
+          cancelAtPeriodEnd: false,
+          effectivePlan: null,
+          purchaseAttemptId: null,
+          paymentAction: null,
+        },
+      }),
+    ).toThrow();
+  });
+
+  it('strips provider identifiers and unsafe redirect actions from subscriptions', () => {
+    const projected = projectBillingCurrentSubscription({
+      subscription: {
+        subscriptionId: 'subscription_1',
+        status: 'ACTIVE',
+        provider: 'future_provider',
+        managementAction: 'FUTURE_ACTION',
+        currentPeriodStartAt: now,
+        currentPeriodEndAt: '2026-08-23T12:00:00.000Z',
+        entitlementValidUntil: null,
+        cancelAtPeriodEnd: false,
+        effectivePlan: {
+          version: 1,
+          product: {
+            id: 'internal_product_id',
+            code: 'subscription_plus',
+            kind: 'SUBSCRIPTION',
+            level: 1,
+          },
+          offer: {
+            id: 'internal_offer_id',
+            code: 'subscription_plus_month',
+            interval: 'MONTH',
+          },
+          provider: {
+            id: 'internal_listing_id',
+            provider: 'stripe',
+            providerProductId: 'prod_fixture',
+            providerPurchaseId: 'price_fixture',
+          },
+          terms: {
+            amount: '20',
+            currency: 'usd',
+            creditAmount: '20',
+            rolloverCap: '0',
+          },
+          capturedAt: now,
+        },
+        purchaseAttemptId: null,
+        paymentAction: {
+          type: 'REDIRECT',
+          url: 'https://checkout.stripe.com.evil.example/pay',
+          expiresAt: now,
+        },
+      },
+    });
+
+    expect(projected.subscription).not.toHaveProperty('provider');
+    expect(projected.subscription).not.toHaveProperty('managementAction');
+    expect(projected.subscription?.paymentAction).toBeNull();
+    expect(projected.subscription?.effectivePlan).toEqual({
+      version: 1,
+      product: { code: 'subscription_plus', kind: 'SUBSCRIPTION', level: 1 },
+      offer: { code: 'subscription_plus_month', interval: 'MONTH' },
+      terms: {
+        amount: '20',
+        currency: 'usd',
+        creditAmount: '20',
+        rolloverCap: '0',
+      },
+      capturedAt: now,
+    });
+  });
+
+  it('accepts the provider-neutral Alipay subscription response without exposing mandate data', () => {
+    const projected = projectBillingCurrentSubscription({
+      subscription: {
+        subscriptionId: 'subscription_1',
+        status: 'INCOMPLETE',
+        currentPeriodStartAt: null,
+        currentPeriodEndAt: null,
+        entitlementValidUntil: null,
+        cancelAtPeriodEnd: false,
+        effectivePlan: null,
+        purchaseAttemptId: 'purchase_1',
+        mandate: {
+          mandateId: 'internal_mandate_1',
+          status: 'PENDING',
+          signedAt: null,
+        },
+        paymentAction: {
+          type: 'QR_CODE',
+          value: 'https://qr.alipay.example/session_fixture',
+          expiresAt: now,
+        },
+      },
+    });
+
+    expect(projected.subscription).toMatchObject({
+      subscriptionId: 'subscription_1',
+      status: 'INCOMPLETE',
+      paymentAction: {
+        type: 'QR_CODE',
+        value: 'https://qr.alipay.example/session_fixture',
+        expiresAt: now,
+      },
+    });
+    expect(projected.subscription).not.toHaveProperty('mandate');
+  });
+});

--- a/apps/desktop/src/main/billing/index.ts
+++ b/apps/desktop/src/main/billing/index.ts
@@ -1,0 +1,329 @@
+import { ipcMain, shell, type BrowserWindow, type IpcMainInvokeEvent } from 'electron';
+
+import {
+  BILLING_INVOKE,
+  type CreateBillingSubscriptionRequest,
+  type CreateBillingTopupRequest,
+} from '../../shared/billing.js';
+import { getClientEndpoint } from '../clientEndpointsService.js';
+import { ServerApiError, serverApiFetch, type ApiFetchOptions } from '../serverApiClient.js';
+import { requireObject, throwIpcError } from '../utils/ipcValidate.js';
+import { isAllowedBillingRedirectUrl } from './paymentRedirect.js';
+import {
+  projectBillingCatalog,
+  projectBillingCurrentSubscription,
+  projectBillingOrderList,
+  projectBillingPaymentOrder,
+  projectBillingSubscription,
+  projectModelAccessBalance,
+} from './projection.js';
+
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._:-]{8,128}$/;
+const CODE_PATTERN = /^[a-z][a-z0-9_]{1,63}$/;
+const DECIMAL_PATTERN = /^(0|[1-9]\d{0,14})(?:\.\d{1,9})?$/;
+const ID_MAX_LENGTH = 128;
+const BILLING_REQUEST_TIMEOUT_MS = 20_000;
+
+type ServerFetch = <T>(path: string, options: ApiFetchOptions) => Promise<T>;
+
+export type BillingIpcDependencies = {
+  getMainWindow: () => BrowserWindow | null;
+  getBaseUrl?: () => string;
+  fetch?: ServerFetch;
+  openExternal?: (url: string) => Promise<void>;
+};
+
+type BillingInvokeEvent = Pick<IpcMainInvokeEvent, 'sender' | 'senderFrame'>;
+type BillingHandler = (event: BillingInvokeEvent, payload?: unknown) => Promise<unknown>;
+
+function assertMainWindowSender(
+  event: BillingInvokeEvent,
+  getMainWindow: () => BrowserWindow | null,
+): void {
+  const mainWindow = getMainWindow();
+  if (
+    !mainWindow ||
+    mainWindow.isDestroyed() ||
+    event.sender !== mainWindow.webContents ||
+    event.senderFrame !== mainWindow.webContents.mainFrame
+  ) {
+    throwIpcError('PERMISSION_DENIED', 'billing IPC is only available to the main window');
+  }
+}
+
+function throwBillingFetchError(error: unknown): never {
+  if (error instanceof ServerApiError) {
+    if (error.statusCode === 400) {
+      throwIpcError('INVALID_PARAMS', 'billing request was rejected');
+    }
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      throwIpcError('PERMISSION_DENIED', 'billing request is not authorized');
+    }
+    if (error.statusCode === 404) {
+      throwIpcError('NOT_FOUND', 'billing resource was not found');
+    }
+    if (error.statusCode === 409 || error.statusCode === 412) {
+      throwIpcError('PRECONDITION_FAILED', 'billing request conflicts with the current state');
+    }
+  }
+  throwIpcError('INTERNAL', 'billing service request failed');
+}
+
+function throwBalanceFetchError(error: unknown): never {
+  if (error instanceof ServerApiError) {
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      throwIpcError('PERMISSION_DENIED', 'balance request is not authorized');
+    }
+    if (error.statusCode === 404) {
+      throwIpcError('NOT_FOUND', 'balance account is not provisioned');
+    }
+    if (error.statusCode === 501) {
+      throwIpcError('UNSUPPORTED_CAPABILITY', 'balance is not supported for this account');
+    }
+  }
+  throwIpcError('MODEL_ACCESS_FAILED', 'balance service request failed');
+}
+
+function projectResponse<T>(value: unknown, projector: (input: unknown) => T): T {
+  try {
+    return projector(value);
+  } catch {
+    throwIpcError('INTERNAL', 'billing service response was invalid');
+  }
+}
+
+function assertOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  name: string,
+): void {
+  const unknownKey = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unknownKey) throwIpcError('INVALID_PARAMS', `${name}.${unknownKey} is not allowed`);
+}
+
+function requireBoundedString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > ID_MAX_LENGTH) {
+    throwIpcError('INVALID_PARAMS', `${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireCode(value: unknown, name: string): string {
+  const code = requireBoundedString(value, name);
+  if (!CODE_PATTERN.test(code)) throwIpcError('INVALID_PARAMS', `${name} is invalid`);
+  return code;
+}
+
+function requireIdempotencyKey(value: unknown): string {
+  if (typeof value !== 'string' || !IDEMPOTENCY_KEY_PATTERN.test(value)) {
+    throwIpcError('INVALID_PARAMS', 'idempotencyKey is invalid');
+  }
+  return value;
+}
+
+function requireAmount(value: unknown, name: string): string {
+  if (typeof value !== 'string' || !DECIMAL_PATTERN.test(value)) {
+    throwIpcError('INVALID_PARAMS', `${name} is invalid`);
+  }
+  return value;
+}
+
+function parseIdPayload(raw: unknown, key: 'orderId' | 'purchaseAttemptId') {
+  const payload = requireObject(raw);
+  assertOnlyKeys(payload, [key], 'payload');
+  return { [key]: requireBoundedString(payload[key], key) } as Record<typeof key, string>;
+}
+
+function parseCreateTopup(raw: unknown): {
+  request: CreateBillingTopupRequest;
+  idempotencyKey: string;
+} {
+  const payload = requireObject(raw);
+  assertOnlyKeys(payload, ['request', 'idempotencyKey'], 'payload');
+  const request = requireObject(payload.request, 'request');
+  assertOnlyKeys(request, ['offerCode', 'amount', 'purchaseOptionId'], 'request');
+  return {
+    request: {
+      offerCode: requireCode(request.offerCode, 'offerCode'),
+      ...(request.amount === undefined ? {} : { amount: requireAmount(request.amount, 'amount') }),
+      purchaseOptionId: requireBoundedString(request.purchaseOptionId, 'purchaseOptionId'),
+    },
+    idempotencyKey: requireIdempotencyKey(payload.idempotencyKey),
+  };
+}
+
+function parseCreateSubscription(raw: unknown): {
+  request: CreateBillingSubscriptionRequest;
+  idempotencyKey: string;
+} {
+  const payload = requireObject(raw);
+  assertOnlyKeys(payload, ['request', 'idempotencyKey'], 'payload');
+  const request = requireObject(payload.request, 'request');
+  assertOnlyKeys(request, ['offerCode', 'purchaseOptionId'], 'request');
+  return {
+    request: {
+      offerCode: requireCode(request.offerCode, 'offerCode'),
+      purchaseOptionId: requireBoundedString(request.purchaseOptionId, 'purchaseOptionId'),
+    },
+    idempotencyKey: requireIdempotencyKey(payload.idempotencyKey),
+  };
+}
+
+export function createBillingHandlers(
+  deps: BillingIpcDependencies,
+): Record<string, BillingHandler> {
+  const fetch = deps.fetch ?? serverApiFetch;
+  const getBaseUrl = deps.getBaseUrl ?? (() => getClientEndpoint('modelAccessApiBaseUrl'));
+  const openExternal = deps.openExternal ?? ((url: string) => shell.openExternal(url));
+  const invoke = async <T>(path: string, options: Omit<ApiFetchOptions, 'baseUrl'> = {}) => {
+    try {
+      return await fetch<T>(path, {
+        timeoutMs: BILLING_REQUEST_TIMEOUT_MS,
+        ...options,
+        redactErrorDetails: true,
+        baseUrl: getBaseUrl(),
+      });
+    } catch (error) {
+      throwBillingFetchError(error);
+    }
+  };
+  const protect =
+    (handler: (payload?: unknown) => Promise<unknown>): BillingHandler =>
+    async (event, payload) => {
+      assertMainWindowSender(event, deps.getMainWindow);
+      return handler(payload);
+    };
+
+  return {
+    [BILLING_INVOKE.GET_BALANCE]: protect(async (raw) => {
+      if (raw !== undefined) {
+        throwIpcError('INVALID_PARAMS', 'balance request does not accept a payload');
+      }
+      let response: unknown;
+      try {
+        response = await fetch<unknown>('/api/model-access/balance', {
+          timeoutMs: BILLING_REQUEST_TIMEOUT_MS,
+          redactErrorDetails: true,
+          baseUrl: getBaseUrl(),
+        });
+      } catch (error) {
+        throwBalanceFetchError(error);
+      }
+      return projectResponse(response, projectModelAccessBalance);
+    }),
+    [BILLING_INVOKE.GET_CATALOG]: protect(async () =>
+      projectResponse(await invoke<unknown>('/api/billing/catalog'), projectBillingCatalog),
+    ),
+    [BILLING_INVOKE.LIST_ORDERS]: protect(async (raw) => {
+      const payload = requireObject(raw);
+      assertOnlyKeys(payload, ['limit'], 'payload');
+      if (
+        typeof payload.limit !== 'number' ||
+        !Number.isInteger(payload.limit) ||
+        payload.limit < 1 ||
+        payload.limit > 100
+      )
+        throwIpcError('INVALID_PARAMS', 'limit must be an integer between 1 and 100');
+      return projectResponse(
+        await invoke<unknown>(`/api/billing/orders?limit=${payload.limit}`),
+        projectBillingOrderList,
+      );
+    }),
+    [BILLING_INVOKE.GET_ORDER]: protect(async (raw) => {
+      const { orderId } = parseIdPayload(raw, 'orderId');
+      return projectResponse(
+        await invoke<unknown>(`/api/billing/orders/${encodeURIComponent(orderId)}`),
+        projectBillingPaymentOrder,
+      );
+    }),
+    [BILLING_INVOKE.CREATE_TOPUP]: protect(async (raw) => {
+      const payload = parseCreateTopup(raw);
+      return projectResponse(
+        await invoke<unknown>('/api/billing/credit-topup/orders', {
+          method: 'POST',
+          body: payload.request,
+          headers: { 'Idempotency-Key': payload.idempotencyKey },
+        }),
+        projectBillingPaymentOrder,
+      );
+    }),
+    [BILLING_INVOKE.REFRESH_TOPUP]: protect(async (raw) => {
+      const { orderId } = parseIdPayload(raw, 'orderId');
+      return projectResponse(
+        await invoke<unknown>(`/api/billing/orders/${encodeURIComponent(orderId)}/refresh`, {
+          method: 'POST',
+        }),
+        projectBillingPaymentOrder,
+      );
+    }),
+    [BILLING_INVOKE.CANCEL_TOPUP]: protect(async (raw) => {
+      const { orderId } = parseIdPayload(raw, 'orderId');
+      return projectResponse(
+        await invoke<unknown>(`/api/billing/orders/${encodeURIComponent(orderId)}/cancel`, {
+          method: 'POST',
+        }),
+        projectBillingPaymentOrder,
+      );
+    }),
+    [BILLING_INVOKE.RETRY_TOPUP]: protect(async (raw) => {
+      const payload = requireObject(raw);
+      assertOnlyKeys(payload, ['orderId', 'idempotencyKey'], 'payload');
+      const orderId = requireBoundedString(payload.orderId, 'orderId');
+      const idempotencyKey = requireIdempotencyKey(payload.idempotencyKey);
+      return projectResponse(
+        await invoke<unknown>(`/api/billing/orders/${encodeURIComponent(orderId)}/retry`, {
+          method: 'POST',
+          headers: { 'Idempotency-Key': idempotencyKey },
+        }),
+        projectBillingPaymentOrder,
+      );
+    }),
+    [BILLING_INVOKE.CREATE_SUBSCRIPTION]: protect(async (raw) => {
+      const payload = parseCreateSubscription(raw);
+      return projectResponse(
+        await invoke<unknown>('/api/billing/subscriptions', {
+          method: 'POST',
+          body: payload.request,
+          headers: { 'Idempotency-Key': payload.idempotencyKey },
+        }),
+        projectBillingSubscription,
+      );
+    }),
+    [BILLING_INVOKE.GET_CURRENT_SUBSCRIPTION]: protect(async () =>
+      projectResponse(
+        await invoke<unknown>('/api/billing/subscription'),
+        projectBillingCurrentSubscription,
+      ),
+    ),
+    [BILLING_INVOKE.REFRESH_SUBSCRIPTION_PURCHASE]: protect(async (raw) => {
+      const { purchaseAttemptId } = parseIdPayload(raw, 'purchaseAttemptId');
+      return projectResponse(
+        await invoke<unknown>(
+          `/api/billing/subscriptions/purchases/${encodeURIComponent(purchaseAttemptId)}/refresh`,
+          { method: 'POST' },
+        ),
+        projectBillingSubscription,
+      );
+    }),
+    [BILLING_INVOKE.OPEN_PAYMENT_REDIRECT]: protect(async (raw) => {
+      const payload = requireObject(raw);
+      assertOnlyKeys(payload, ['url'], 'payload');
+      if (!isAllowedBillingRedirectUrl(payload.url)) {
+        throwIpcError('INVALID_PARAMS', 'billing redirect URL is not allowed');
+      }
+      try {
+        await openExternal(payload.url);
+        return { success: true };
+      } catch {
+        return { success: false };
+      }
+    }),
+  };
+}
+
+export function registerBillingIpc(deps: BillingIpcDependencies): void {
+  const handlers = createBillingHandlers(deps);
+  for (const [channel, handler] of Object.entries(handlers)) {
+    ipcMain.handle(channel, handler);
+  }
+}

--- a/apps/desktop/src/main/billing/paymentRedirect.ts
+++ b/apps/desktop/src/main/billing/paymentRedirect.ts
@@ -1,0 +1,27 @@
+const MAX_BILLING_REDIRECT_URL_LENGTH = 2_048;
+
+// Public provider-owned checkout hosts only. Merchant and Cindy-owned hosts do
+// not belong here; adding a host changes the desktop trust boundary.
+const ALLOWED_BILLING_REDIRECT_HOSTS = new Set(['checkout.stripe.com']);
+
+export function isAllowedBillingRedirectUrl(value: unknown): value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_BILLING_REDIRECT_URL_LENGTH
+  ) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.protocol === 'https:' &&
+      parsed.username === '' &&
+      parsed.password === '' &&
+      parsed.port === '' &&
+      ALLOWED_BILLING_REDIRECT_HOSTS.has(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/desktop/src/main/billing/projection.ts
+++ b/apps/desktop/src/main/billing/projection.ts
@@ -1,0 +1,510 @@
+import type {
+  BillingCatalog,
+  BillingCatalogOffer,
+  BillingCatalogProduct,
+  BillingCurrentSubscription,
+  BillingFulfillmentStatus,
+  BillingOrderList,
+  BillingPaymentAction,
+  BillingPaymentOrder,
+  BillingPaymentOrderStatus,
+  BillingPurchaseOption,
+  BillingSubscription,
+  BillingSubscriptionStatus,
+} from '../../shared/billing.js';
+import type { ModelAccessBalance } from '../../shared/modelAccess.js';
+import { isAllowedBillingRedirectUrl } from './paymentRedirect.js';
+
+const MAX_ID_LENGTH = 128;
+const MAX_NAME_LENGTH = 128;
+const MAX_CURSOR_LENGTH = 512;
+const MAX_QR_VALUE_LENGTH = 4_096;
+const CODE_PATTERN = /^[a-z][a-z0-9_]{1,63}$/;
+const CURRENCY_PATTERN = /^[a-z]{3}$/;
+const DECIMAL_PATTERN = /^(0|[1-9]\d{0,14})(?:\.\d{1,9})?$/;
+const LEDGER_DECIMAL_PATTERN = /^-?(?:0|[1-9]\d{0,9})(?:\.\d{1,9})?$/;
+const ISO_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const RFC3339_UTC_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?Z$/;
+const MAX_LEDGER_SCALED_AMOUNT = 9_000_000_000_000_000_000n;
+
+const PAYMENT_ORDER_STATUSES = new Set<BillingPaymentOrderStatus>([
+  'CREATED',
+  'PENDING',
+  'SUCCEEDED',
+  'FAILED',
+  'CANCELED',
+  'EXPIRED',
+]);
+const SUBSCRIPTION_STATUSES = new Set<BillingSubscriptionStatus>([
+  'INCOMPLETE',
+  'INCOMPLETE_EXPIRED',
+  'TRIALING',
+  'ACTIVE',
+  'PAST_DUE',
+  'UNPAID',
+  'CANCELED',
+  'PAUSED',
+]);
+const FULFILLMENT_STATUSES = new Set<BillingFulfillmentStatus>([
+  'NOT_STARTED',
+  'PENDING',
+  'SUCCEEDED',
+  'FAILED',
+]);
+const SUPPORTED_PROVIDERS = new Set(['alipay', 'stripe']);
+const SUBSCRIPTION_CAPABILITIES = new Set([
+  'MERCHANT_INITIATED_MANDATE',
+  'PROVIDER_MANAGED_SUBSCRIPTION',
+]);
+
+function invalidResponse(): never {
+  throw new Error('invalid billing response');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function boundedString(value: unknown, maxLength = MAX_ID_LENGTH): string | null {
+  return typeof value === 'string' && value.length > 0 && value.length <= maxLength ? value : null;
+}
+
+function code(value: unknown): string | null {
+  return typeof value === 'string' && CODE_PATTERN.test(value) ? value : null;
+}
+
+function decimal(value: unknown): string | null {
+  return typeof value === 'string' && DECIMAL_PATTERN.test(value) ? value : null;
+}
+
+function ledgerDecimal(value: unknown): { source: string; scaled: bigint } | null {
+  if (typeof value !== 'string' || !LEDGER_DECIMAL_PATTERN.test(value)) return null;
+  const negative = value.startsWith('-');
+  const unsigned = negative ? value.slice(1) : value;
+  const [whole, fraction = ''] = unsigned.split('.');
+  const scaled = BigInt(whole) * 1_000_000_000n + BigInt(fraction.padEnd(9, '0') || '0');
+  if (scaled > MAX_LEDGER_SCALED_AMOUNT) return null;
+  return { source: value, scaled: negative ? -scaled : scaled };
+}
+
+function currency(value: unknown): string | null {
+  return typeof value === 'string' && CURRENCY_PATTERN.test(value) ? value : null;
+}
+
+function nullable<T>(value: unknown, parse: (input: unknown) => T | null): T | null | undefined {
+  return value === null ? null : (parse(value) ?? undefined);
+}
+
+function isoTime(value: unknown): string | null {
+  if (typeof value !== 'string' || !ISO_TIME_PATTERN.test(value)) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value ? value : null;
+}
+
+function observedAt(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const match = RFC3339_UTC_PATTERN.exec(value);
+  if (!match) return null;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth[month - 1] ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  ) {
+    return null;
+  }
+  return value;
+}
+
+export function projectModelAccessBalance(value: unknown): ModelAccessBalance {
+  if (!isRecord(value) || value.scale !== 9) invalidResponse();
+  const planCredits = ledgerDecimal(value.planCredits);
+  const purchasedCredits = ledgerDecimal(value.purchasedCredits);
+  const promotionalCredits = ledgerDecimal(value.promotionalCredits);
+  const available = ledgerDecimal(value.available);
+  const snapshotTime = observedAt(value.observedAt);
+  if (
+    !planCredits ||
+    !purchasedCredits ||
+    !promotionalCredits ||
+    !available ||
+    planCredits.scaled < 0n ||
+    promotionalCredits.scaled < 0n ||
+    planCredits.scaled + purchasedCredits.scaled + promotionalCredits.scaled !== available.scaled ||
+    !snapshotTime
+  ) {
+    invalidResponse();
+  }
+  return {
+    planCredits: planCredits.source,
+    purchasedCredits: purchasedCredits.source,
+    promotionalCredits: promotionalCredits.source,
+    available: available.source,
+    scale: 9,
+    observedAt: snapshotTime,
+  };
+}
+
+function projectPaymentAction(value: unknown): BillingPaymentAction | null {
+  if (!isRecord(value)) return null;
+  const expiresAt = isoTime(value.expiresAt);
+  if (!expiresAt) return null;
+  if (value.type === 'QR_CODE') {
+    const qrValue = boundedString(value.value, MAX_QR_VALUE_LENGTH);
+    return qrValue ? { type: 'QR_CODE', value: qrValue, expiresAt } : null;
+  }
+  if (value.type === 'REDIRECT' && isAllowedBillingRedirectUrl(value.url)) {
+    return { type: 'REDIRECT', url: value.url, expiresAt };
+  }
+  return null;
+}
+
+function projectPurchaseOption(
+  value: unknown,
+  productKind: BillingCatalogProduct['kind'],
+): BillingPurchaseOption | null {
+  if (!isRecord(value)) return null;
+  const id = boundedString(value.id);
+  const provider = boundedString(value.provider, 32);
+  if (
+    !id ||
+    !provider ||
+    !SUPPORTED_PROVIDERS.has(provider) ||
+    (value.paymentAction !== 'QR_CODE' && value.paymentAction !== 'REDIRECT')
+  ) {
+    return null;
+  }
+  const capability =
+    productKind === 'CREDIT_TOPUP'
+      ? value.capability === 'ONE_TIME_PAYMENT'
+        ? value.capability
+        : null
+      : typeof value.capability === 'string' && SUBSCRIPTION_CAPABILITIES.has(value.capability)
+        ? (value.capability as BillingPurchaseOption['capability'])
+        : null;
+  return capability ? { id, provider, capability, paymentAction: value.paymentAction } : null;
+}
+
+function projectOffer(
+  value: unknown,
+  productKind: BillingCatalogProduct['kind'],
+): BillingCatalogOffer | null {
+  if (!isRecord(value) || !Array.isArray(value.purchaseOptions)) return null;
+  const offerCode = code(value.code);
+  const offerCurrency = currency(value.currency);
+  const amount = nullable(value.amount, decimal);
+  const minAmount = nullable(value.minAmount, decimal);
+  const maxAmount = nullable(value.maxAmount, decimal);
+  const creditAmount = nullable(value.creditAmount, decimal);
+  const rolloverCap = nullable(value.rolloverCap, decimal);
+  const interval =
+    value.interval === 'MONTH' || value.interval === 'YEAR' || value.interval === null
+      ? value.interval
+      : undefined;
+  if (
+    !offerCode ||
+    !offerCurrency ||
+    interval === undefined ||
+    amount === undefined ||
+    minAmount === undefined ||
+    maxAmount === undefined ||
+    creditAmount === undefined ||
+    rolloverCap === undefined
+  ) {
+    return null;
+  }
+
+  const isSubscription =
+    productKind === 'SUBSCRIPTION' &&
+    interval !== null &&
+    amount !== null &&
+    minAmount === null &&
+    maxAmount === null &&
+    creditAmount !== null &&
+    rolloverCap !== null;
+  const isFixedTopup =
+    productKind === 'CREDIT_TOPUP' &&
+    interval === null &&
+    amount !== null &&
+    creditAmount !== null &&
+    minAmount === null &&
+    maxAmount === null &&
+    rolloverCap === null;
+  const isCustomTopup =
+    productKind === 'CREDIT_TOPUP' &&
+    interval === null &&
+    amount === null &&
+    creditAmount === null &&
+    minAmount !== null &&
+    maxAmount !== null &&
+    rolloverCap === null;
+  if (!isSubscription && !isFixedTopup && !isCustomTopup) return null;
+
+  const optionIds = new Set<string>();
+  const purchaseOptions = value.purchaseOptions
+    .map((option) => projectPurchaseOption(option, productKind))
+    .filter((option): option is BillingPurchaseOption => {
+      if (!option || optionIds.has(option.id)) return false;
+      optionIds.add(option.id);
+      return true;
+    });
+  if (purchaseOptions.length === 0) return null;
+  return {
+    code: offerCode,
+    interval: isSubscription ? interval : null,
+    currency: offerCurrency,
+    amount,
+    minAmount,
+    maxAmount,
+    creditAmount,
+    rolloverCap,
+    purchaseOptions,
+  };
+}
+
+function projectProduct(value: unknown): BillingCatalogProduct | null {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.offers) ||
+    (value.kind !== 'CREDIT_TOPUP' && value.kind !== 'SUBSCRIPTION')
+  ) {
+    return null;
+  }
+  const productCode = code(value.code);
+  const name = boundedString(value.name, MAX_NAME_LENGTH);
+  const kind = value.kind;
+  const level =
+    kind === 'CREDIT_TOPUP'
+      ? value.level === null
+        ? null
+        : undefined
+      : typeof value.level === 'number' && Number.isSafeInteger(value.level) && value.level >= 0
+        ? value.level
+        : undefined;
+  if (
+    !productCode ||
+    !name ||
+    level === undefined ||
+    typeof value.sortOrder !== 'number' ||
+    !Number.isSafeInteger(value.sortOrder)
+  ) {
+    return null;
+  }
+
+  const offerCodes = new Set<string>();
+  const offers = value.offers
+    .map((offer) => projectOffer(offer, kind))
+    .filter((offer): offer is BillingCatalogOffer => {
+      if (!offer || offerCodes.has(offer.code)) return false;
+      offerCodes.add(offer.code);
+      return true;
+    });
+  if (offers.length === 0) return null;
+  return {
+    code: productCode,
+    name,
+    kind,
+    level,
+    sortOrder: value.sortOrder,
+    offers,
+  };
+}
+
+export function projectBillingCatalog(value: unknown): BillingCatalog {
+  if (!isRecord(value) || !Array.isArray(value.products)) invalidResponse();
+  const productCodes = new Set<string>();
+  const products = value.products
+    .map(projectProduct)
+    .filter((product): product is BillingCatalogProduct => {
+      if (!product || productCodes.has(product.code)) return false;
+      productCodes.add(product.code);
+      return true;
+    });
+  return { products };
+}
+
+function projectPaymentOrder(value: unknown): BillingPaymentOrder {
+  if (!isRecord(value)) invalidResponse();
+  const orderId = boundedString(value.orderId);
+  const productCode = code(value.productCode);
+  const offerCode = code(value.offerCode);
+  const amount = decimal(value.amount);
+  const orderCurrency = currency(value.currency);
+  const status =
+    typeof value.status === 'string' &&
+    PAYMENT_ORDER_STATUSES.has(value.status as BillingPaymentOrderStatus)
+      ? (value.status as BillingPaymentOrderStatus)
+      : null;
+  const createdAt = isoTime(value.createdAt);
+  const updatedAt = isoTime(value.updatedAt);
+  if (
+    !orderId ||
+    !productCode ||
+    !offerCode ||
+    !amount ||
+    !orderCurrency ||
+    !status ||
+    !createdAt ||
+    !updatedAt
+  ) {
+    invalidResponse();
+  }
+  const fulfillmentStatus =
+    typeof value.fulfillmentStatus === 'string' &&
+    FULFILLMENT_STATUSES.has(value.fulfillmentStatus as BillingFulfillmentStatus)
+      ? (value.fulfillmentStatus as BillingFulfillmentStatus)
+      : undefined;
+  return {
+    orderId,
+    productCode,
+    offerCode,
+    amount,
+    currency: orderCurrency,
+    status,
+    paymentAction: projectPaymentAction(value.paymentAction),
+    ...(fulfillmentStatus ? { fulfillmentStatus } : {}),
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function projectBillingPaymentOrder(value: unknown): BillingPaymentOrder {
+  return projectPaymentOrder(value);
+}
+
+export function projectBillingOrderList(value: unknown): BillingOrderList {
+  if (!isRecord(value) || !Array.isArray(value.orders) || value.orders.length > 100) {
+    invalidResponse();
+  }
+  const nextCursor =
+    value.nextCursor === null ? null : boundedString(value.nextCursor, MAX_CURSOR_LENGTH);
+  if (nextCursor === null && value.nextCursor !== null) invalidResponse();
+  const orders: BillingPaymentOrder[] = [];
+  for (const order of value.orders) {
+    try {
+      orders.push(projectPaymentOrder(order));
+    } catch {
+      // Unknown or malformed rows must not block recovery of the remaining orders.
+    }
+  }
+  return { orders, nextCursor };
+}
+
+function projectEffectivePlan(value: unknown): BillingSubscription['effectivePlan'] {
+  if (
+    !isRecord(value) ||
+    !isRecord(value.product) ||
+    !isRecord(value.offer) ||
+    !isRecord(value.terms)
+  ) {
+    invalidResponse();
+  }
+  const productCode = code(value.product.code);
+  const offerCode = code(value.offer.code);
+  const level =
+    typeof value.product.level === 'number' &&
+    Number.isSafeInteger(value.product.level) &&
+    value.product.level >= 0
+      ? value.product.level
+      : null;
+  const amount = decimal(value.terms.amount);
+  const planCurrency = currency(value.terms.currency);
+  const creditAmount = decimal(value.terms.creditAmount);
+  const rolloverCap = decimal(value.terms.rolloverCap);
+  const capturedAt = isoTime(value.capturedAt);
+  if (
+    value.version !== 1 ||
+    value.product.kind !== 'SUBSCRIPTION' ||
+    !productCode ||
+    level === null ||
+    !offerCode ||
+    (value.offer.interval !== 'MONTH' && value.offer.interval !== 'YEAR') ||
+    !amount ||
+    !planCurrency ||
+    !creditAmount ||
+    !rolloverCap ||
+    !capturedAt
+  ) {
+    invalidResponse();
+  }
+  return {
+    version: 1,
+    product: { code: productCode, kind: 'SUBSCRIPTION', level },
+    offer: { code: offerCode, interval: value.offer.interval },
+    terms: { amount, currency: planCurrency, creditAmount, rolloverCap },
+    capturedAt,
+  };
+}
+
+export function projectBillingSubscription(value: unknown): BillingSubscription {
+  if (!isRecord(value)) invalidResponse();
+  const subscriptionId = boundedString(value.subscriptionId);
+  const status =
+    typeof value.status === 'string' &&
+    SUBSCRIPTION_STATUSES.has(value.status as BillingSubscriptionStatus)
+      ? (value.status as BillingSubscriptionStatus)
+      : null;
+  const currentPeriodStartAt = nullable(value.currentPeriodStartAt, isoTime);
+  const currentPeriodEndAt = nullable(value.currentPeriodEndAt, isoTime);
+  const entitlementValidUntil = nullable(value.entitlementValidUntil, isoTime);
+  const purchaseAttemptId = nullable(value.purchaseAttemptId, boundedString);
+  if (
+    !subscriptionId ||
+    !status ||
+    currentPeriodStartAt === undefined ||
+    currentPeriodEndAt === undefined ||
+    entitlementValidUntil === undefined ||
+    typeof value.cancelAtPeriodEnd !== 'boolean' ||
+    purchaseAttemptId === undefined ||
+    (value.effectivePlan !== null && !isRecord(value.effectivePlan))
+  ) {
+    invalidResponse();
+  }
+  const provider =
+    typeof value.provider === 'string' && SUPPORTED_PROVIDERS.has(value.provider)
+      ? value.provider
+      : undefined;
+  const managementAction =
+    value.managementAction === 'API_CANCEL' || value.managementAction === 'PORTAL'
+      ? value.managementAction
+      : undefined;
+  const entitlementStatus =
+    typeof value.entitlementStatus === 'string' &&
+    FULFILLMENT_STATUSES.has(value.entitlementStatus as BillingFulfillmentStatus)
+      ? (value.entitlementStatus as BillingFulfillmentStatus)
+      : undefined;
+  return {
+    subscriptionId,
+    status,
+    ...(provider ? { provider } : {}),
+    ...(managementAction ? { managementAction } : {}),
+    ...(entitlementStatus ? { entitlementStatus } : {}),
+    currentPeriodStartAt,
+    currentPeriodEndAt,
+    entitlementValidUntil,
+    cancelAtPeriodEnd: value.cancelAtPeriodEnd,
+    effectivePlan: value.effectivePlan === null ? null : projectEffectivePlan(value.effectivePlan),
+    purchaseAttemptId,
+    paymentAction: projectPaymentAction(value.paymentAction),
+  };
+}
+
+export function projectBillingCurrentSubscription(value: unknown): BillingCurrentSubscription {
+  if (!isRecord(value) || !('subscription' in value)) invalidResponse();
+  return {
+    subscription:
+      value.subscription === null ? null : projectBillingSubscription(value.subscription),
+  };
+}

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -499,6 +499,7 @@ import {
   initClientEndpoints,
   registerClientEndpointsIpc,
 } from './clientEndpointsService.js';
+import { registerBillingIpc } from './billing/index.js';
 import {
   initModelAccess,
   noteManualXdKeySaved,
@@ -2308,6 +2309,8 @@ const registerIpcHandlers = () => {
     const windows = BrowserWindow.getAllWindows();
     return windows.find((w) => !w.isDestroyed() && w.isMinimizable()) ?? windows[0];
   };
+
+  registerBillingIpc({ getMainWindow: () => mainWindowRef });
 
   initAppBadgeService({
     getWindow: () => getWindow() ?? null,

--- a/apps/desktop/src/main/serverApiClient.ts
+++ b/apps/desktop/src/main/serverApiClient.ts
@@ -42,6 +42,8 @@ export interface ApiFetchOptions {
   baseUrl: string;
   /** Abort the request after this many milliseconds; 0 disables the deadline. */
   timeoutMs?: number;
+  /** Keep upstream response/network details out of local logs for sensitive flows. */
+  redactErrorDetails?: boolean;
 }
 
 interface RawResponse<T> {
@@ -63,9 +65,7 @@ async function rawFetch<T>(apiPath: string, opts: ApiFetchOptions): Promise<RawR
   }
   const timeoutMs = opts.timeoutMs ?? 0;
   const controller = timeoutMs > 0 ? new AbortController() : null;
-  const timeoutId = controller
-    ? setTimeout(() => controller.abort(), timeoutMs)
-    : null;
+  const timeoutId = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
   try {
     const body = opts.bodyFactory ? opts.bodyFactory() : opts.body;
     const response = await net.fetch(url, {
@@ -83,7 +83,11 @@ async function rawFetch<T>(apiPath: string, opts: ApiFetchOptions): Promise<RawR
     }
     return { ok: response.ok, status: response.status, data };
   } catch (err) {
-    log.error('fetch failed', apiPath, err);
+    if (opts.redactErrorDetails) {
+      log.error('serverApiFetch.redacted_network_error', 'path=' + apiPath, 'method=' + method);
+    } else {
+      log.error('fetch failed', apiPath, err);
+    }
     return { ok: false, status: 0, data: null };
   } finally {
     if (timeoutId !== null) clearTimeout(timeoutId);
@@ -94,10 +98,7 @@ async function rawFetch<T>(apiPath: string, opts: ApiFetchOptions): Promise<RawR
  * 高层 API：成功 → 返回 data；失败 → throw ServerApiError。
  * 可恢复的 401 自动 refresh 一次再重试（除非 `skipAutoRefresh`）。
  */
-export async function serverApiFetch<T>(
-  apiPath: string,
-  opts: ApiFetchOptions,
-): Promise<T> {
+export async function serverApiFetch<T>(apiPath: string, opts: ApiFetchOptions): Promise<T> {
   let result = await rawFetch<T>(apiPath, opts);
   let refreshedAndRetried = false;
   const firstCode = readErrorCode(result.data) ?? statusToCode(result.status);
@@ -131,15 +132,29 @@ export async function serverApiFetch<T>(
     }
     // 网络异常 rawFetch 已 log;这里补 not-ok 响应(401/5xx 等)的日志,
     // 否则上层 catch 一吞,排查调用链时完全看不到原因。
-    log.warn(
-      'serverApiFetch.not_ok',
-      'path=' + apiPath,
-      'method=' + (opts.method ?? 'GET'),
-      'status=' + result.status,
-      'code=' + errCode,
-      'msg=' + errMsg,
+    if (opts.redactErrorDetails) {
+      log.warn(
+        'serverApiFetch.redacted_not_ok',
+        'path=' + apiPath,
+        'method=' + (opts.method ?? 'GET'),
+        'status=' + result.status,
+        'code=' + statusToCode(result.status),
+      );
+    } else {
+      log.warn(
+        'serverApiFetch.not_ok',
+        'path=' + apiPath,
+        'method=' + (opts.method ?? 'GET'),
+        'status=' + result.status,
+        'code=' + errCode,
+        'msg=' + errMsg,
+      );
+    }
+    throw new ServerApiError(
+      opts.redactErrorDetails ? statusToCode(result.status) : errCode,
+      result.status,
+      opts.redactErrorDetails ? `请求失败 (${result.status})` : errMsg,
     );
-    throw new ServerApiError(errCode, result.status, errMsg);
   }
   if (result.data === null) {
     throw new ServerApiError('EMPTY_RESPONSE', result.status, '响应体为空');

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -86,6 +86,7 @@ import type {
   DesktopLoginAction,
   DesktopLoginActionResult,
 } from '../shared/authIpc';
+import { BILLING_INVOKE, type BillingRendererApi } from '../shared/billing';
 
 // Codex 元 IPC 全部升级到 maker.* (agentKind 参数化), preload 不再 import vendor/codex/ipcChannels。
 //   auth      → maker:auth:*(agentKind)
@@ -1420,6 +1421,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // apiRequest(renderer → main → 主 server 通用代理)与 imageUpload.putToOss
   // (presign 直传桥)已随 2026-07 apiBaseUrl 清理退役:renderer 对业务 server
   // 零请求;头像等上传走 main 侧 profileEdit 链路。
+  billing: {
+    getBalance: () => ipcRenderer.invoke(BILLING_INVOKE.GET_BALANCE),
+    getCatalog: () => ipcRenderer.invoke(BILLING_INVOKE.GET_CATALOG),
+    listOrders: (payload) => ipcRenderer.invoke(BILLING_INVOKE.LIST_ORDERS, payload),
+    getOrder: (payload) => ipcRenderer.invoke(BILLING_INVOKE.GET_ORDER, payload),
+    createTopup: (payload) => ipcRenderer.invoke(BILLING_INVOKE.CREATE_TOPUP, payload),
+    refreshTopup: (payload) => ipcRenderer.invoke(BILLING_INVOKE.REFRESH_TOPUP, payload),
+    cancelTopup: (payload) => ipcRenderer.invoke(BILLING_INVOKE.CANCEL_TOPUP, payload),
+    retryTopup: (payload) => ipcRenderer.invoke(BILLING_INVOKE.RETRY_TOPUP, payload),
+    createSubscription: (payload) =>
+      ipcRenderer.invoke(BILLING_INVOKE.CREATE_SUBSCRIPTION, payload),
+    getCurrentSubscription: () => ipcRenderer.invoke(BILLING_INVOKE.GET_CURRENT_SUBSCRIPTION),
+    refreshSubscriptionPurchase: (payload) =>
+      ipcRenderer.invoke(BILLING_INVOKE.REFRESH_SUBSCRIPTION_PURCHASE, payload),
+    openPaymentRedirect: (payload) =>
+      ipcRenderer.invoke(BILLING_INVOKE.OPEN_PAYMENT_REDIRECT, payload),
+  } satisfies BillingRendererApi,
 
   // ── Workdir File Browser (vscode-style file tree + content viewer) ──
   // All paths in/out are workdir-relative POSIX. Main side blocks traversal.

--- a/apps/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -39,6 +39,7 @@ import { ContactsSection } from './contacts/ContactsSection';
 import { ComputerUseSection } from './ComputerUseSection';
 import { useAuth } from '@/contexts/AuthContext';
 import { getLastWorkingDir, subscribeToLastWorkingDir } from '@/state/lastWorkingDir';
+import { BillingSettingsSection } from '@/features/billing/BillingPage';
 
 const DEFAULT_SETTINGS_MENU_WIDTH = 260;
 
@@ -297,6 +298,21 @@ export function SettingsView() {
                 {/* Section — Logout (pt 18) */}
                 <section className="pt-[18px]" aria-label={t('settings.sections.logout')}>
                   <LogoutSection />
+                </section>
+              </div>
+            )}
+
+            {activeTab === 'billing' && (
+              <div
+                role="tabpanel"
+                id="settings-panel-billing"
+                aria-labelledby="settings-tab-billing"
+              >
+                <section aria-label={t('settings.sections.billing')}>
+                  <BillingSettingsSection
+                    key={`billing:${dataOwnerId ?? 'none'}`}
+                    accountId={dataOwnerId}
+                  />
                 </section>
               </div>
             )}

--- a/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import * as QRCode from 'qrcode';
+import { Check, CircleAlert, ExternalLink, LoaderCircle, RotateCcw, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils';
+import { billingApi } from './api';
+import type { BillingCheckoutState } from './useBillingCheckout';
+
+interface BillingCheckoutDialogProps {
+  state: BillingCheckoutState;
+  onClose: () => void;
+  onRefresh: () => void;
+  onRetry: () => void;
+  onCancel: () => void;
+}
+
+function actionOf(state: BillingCheckoutState) {
+  return state.order?.paymentAction ?? state.subscription?.paymentAction ?? null;
+}
+
+export function BillingCheckoutDialog({
+  state,
+  onClose,
+  onRefresh,
+  onRetry,
+  onCancel,
+}: BillingCheckoutDialogProps) {
+  const { t } = useTranslation();
+  const action = actionOf(state);
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setQrDataUrl(null);
+    if (action?.type === 'QR_CODE') {
+      void QRCode.toDataURL(action.value, {
+        width: 1024,
+        margin: 4,
+      })
+        .then((dataUrl) => {
+          if (active) setQrDataUrl(dataUrl);
+        })
+        .catch(() => {
+          if (active) setQrDataUrl(null);
+        });
+    }
+    return () => {
+      active = false;
+    };
+  }, [action]);
+
+  useEffect(() => {
+    if (!action) {
+      setRemainingSeconds(null);
+      return;
+    }
+    const update = () => {
+      setRemainingSeconds(
+        Math.max(0, Math.ceil((Date.parse(action.expiresAt) - Date.now()) / 1000)),
+      );
+    };
+    update();
+    const timer = window.setInterval(update, 1_000);
+    return () => window.clearInterval(timer);
+  }, [action]);
+
+  const title = useMemo(() => {
+    if (state.phase === 'CREATING') return t('billing.checkout.creatingTitle');
+    if (state.phase === 'AWAITING_PAYMENT') return t('billing.checkout.awaitingTitle');
+    if (state.phase === 'COMPLETED') return t('billing.checkout.completedTitle');
+    if (state.phase === 'EXPIRED') return t('billing.checkout.expiredTitle');
+    if (state.phase === 'CANCELED') return t('billing.checkout.canceledTitle');
+    return t('billing.checkout.failedTitle');
+  }, [state.phase, t]);
+
+  const openRedirect = () => {
+    if (action?.type === 'REDIRECT') void billingApi.openPaymentRedirect(action.url);
+  };
+
+  const canRetry =
+    (state.error && state.intent !== null && state.order === null && state.subscription === null) ||
+    (state.kind === 'TOPUP' &&
+      (state.order?.status === 'FAILED' || state.order?.status === 'EXPIRED'));
+  const canCancel =
+    state.kind === 'TOPUP' &&
+    state.order !== null &&
+    (state.order.status === 'CREATED' || state.order.status === 'PENDING');
+
+  return (
+    <Dialog.Root
+      open={state.open}
+      onOpenChange={(open) => !open && state.phase !== 'CREATING' && onClose()}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[10000] bg-[var(--overlay-modal)]" />
+        <Dialog.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[10001] w-[calc(100vw-40px)] max-w-[620px]',
+            '-translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl',
+            'border border-[var(--border-default)] bg-[var(--surface-elevated)]',
+            'text-[var(--text-primary)] focus:outline-none',
+          )}
+          aria-describedby={undefined}
+        >
+          <div className="flex items-start justify-between gap-4 border-b border-[var(--border-default)] px-6 py-5">
+            <div>
+              <Dialog.Title className="text-lg font-medium">{title}</Dialog.Title>
+              <p className="mt-1 text-12 leading-5 text-[var(--text-secondary)]">
+                {state.kind === 'TOPUP'
+                  ? t('billing.checkout.topupSubtitle')
+                  : t('billing.checkout.subscriptionSubtitle')}
+              </p>
+            </div>
+            {state.phase !== 'CREATING' && (
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="grid size-8 shrink-0 place-items-center rounded-full text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)]"
+                  aria-label={t('billing.actions.close')}
+                >
+                  <X size={16} />
+                </button>
+              </Dialog.Close>
+            )}
+          </div>
+
+          <div className="flex min-h-[300px] flex-col items-center justify-center px-6 py-7 text-center">
+            {state.phase === 'CREATING' && (
+              <>
+                <Spinner icon={LoaderCircle} size={28} className="text-[var(--text-secondary)]" />
+                <p className="mt-4 text-sm text-[var(--text-secondary)]">
+                  {t('billing.checkout.creatingBody')}
+                </p>
+              </>
+            )}
+
+            {state.phase === 'AWAITING_PAYMENT' && action?.type === 'QR_CODE' && (
+              <>
+                <div
+                  className="grid place-items-center rounded-xl border border-[var(--border-default)] bg-white p-2"
+                  style={{
+                    width: 'min(512px, calc(100vw - 96px), calc(100vh - 260px))',
+                    height: 'min(512px, calc(100vw - 96px), calc(100vh - 260px))',
+                  }}
+                >
+                  {qrDataUrl ? (
+                    <img src={qrDataUrl} className="size-full" alt={t('billing.checkout.qrAlt')} />
+                  ) : (
+                    <Spinner size={24} className="text-[var(--text-secondary)]" />
+                  )}
+                </div>
+                <p className="mt-4 text-sm font-medium">{t('billing.checkout.scanHint')}</p>
+                <p className="mt-1 text-12 text-[var(--text-tertiary)]">
+                  {remainingSeconds === null
+                    ? t('billing.checkout.checkingExpiry')
+                    : t('billing.checkout.expiresIn', {
+                        minutes: Math.floor(remainingSeconds / 60),
+                        seconds: String(remainingSeconds % 60).padStart(2, '0'),
+                      })}
+                </p>
+              </>
+            )}
+
+            {state.phase === 'AWAITING_PAYMENT' && action?.type === 'REDIRECT' && (
+              <>
+                <div className="grid size-14 place-items-center rounded-full bg-[var(--surface-chip)]">
+                  <ExternalLink size={22} />
+                </div>
+                <p className="mt-4 text-sm font-medium">{t('billing.checkout.redirectHint')}</p>
+                <button
+                  type="button"
+                  onClick={openRedirect}
+                  className="mt-5 inline-flex h-9 items-center gap-2 rounded-full bg-[var(--text-primary)] px-5 text-sm font-medium text-[var(--surface)]"
+                >
+                  <ExternalLink size={14} />
+                  {t('billing.checkout.openPayment')}
+                </button>
+              </>
+            )}
+
+            {state.phase === 'AWAITING_PAYMENT' && !action && (
+              <>
+                <Spinner size={26} className="text-[var(--text-secondary)]" />
+                <p className="mt-4 text-sm text-[var(--text-secondary)]">
+                  {t('billing.checkout.refreshingAction')}
+                </p>
+              </>
+            )}
+
+            {state.phase === 'COMPLETED' && (
+              <>
+                <div className="grid size-14 place-items-center rounded-full bg-[var(--text-primary)] text-[var(--surface)]">
+                  <Check size={24} />
+                </div>
+                <p className="mt-4 text-sm font-medium">{t('billing.checkout.paymentCompleted')}</p>
+              </>
+            )}
+
+            {(state.phase === 'FAILED' ||
+              state.phase === 'EXPIRED' ||
+              state.phase === 'CANCELED') && (
+              <>
+                <div className="grid size-14 place-items-center rounded-full bg-[var(--surface-chip)]">
+                  <CircleAlert size={23} />
+                </div>
+                <p className="mt-4 max-w-[320px] text-sm text-[var(--text-secondary)]">
+                  {state.error
+                    ? t('billing.checkout.requestFailed')
+                    : state.phase === 'EXPIRED'
+                      ? t('billing.checkout.expiredBody')
+                      : state.phase === 'CANCELED'
+                        ? t('billing.checkout.canceledBody')
+                        : t('billing.checkout.failedBody')}
+                </p>
+              </>
+            )}
+          </div>
+
+          <div className="flex min-h-16 items-center justify-between gap-3 border-t border-[var(--border-default)] px-6 py-3">
+            <div>
+              {canCancel && (
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  className="h-9 rounded-full px-3 text-12 text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-hover-soft)]"
+                >
+                  {t('billing.actions.cancelPayment')}
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {state.phase === 'AWAITING_PAYMENT' && (
+                <button
+                  type="button"
+                  onClick={onRefresh}
+                  className="inline-flex h-9 items-center gap-2 rounded-full border border-[var(--border-default)] px-4 text-12 font-medium transition-colors hover:bg-[var(--surface-hover-soft)]"
+                >
+                  <RotateCcw size={14} />
+                  {t('billing.actions.refresh')}
+                </button>
+              )}
+              {(state.phase === 'FAILED' || state.phase === 'EXPIRED') && canRetry && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className="inline-flex h-9 items-center gap-2 rounded-full bg-[var(--text-primary)] px-4 text-12 font-medium text-[var(--surface)]"
+                >
+                  <RotateCcw size={14} />
+                  {t('billing.actions.retry')}
+                </button>
+              )}
+              {isTerminalPhase(state.phase) && (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="h-9 rounded-full border border-[var(--border-default)] px-4 text-12 font-medium transition-colors hover:bg-[var(--surface-hover-soft)]"
+                >
+                  {t('billing.actions.close')}
+                </button>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function isTerminalPhase(phase: BillingCheckoutState['phase']): boolean {
+  return phase === 'COMPLETED' || phase === 'FAILED' || phase === 'EXPIRED' || phase === 'CANCELED';
+}

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -1,0 +1,956 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  ArrowRight,
+  Check,
+  CircleDollarSign,
+  CreditCard,
+  PackageOpen,
+  RefreshCcw,
+  ShieldCheck,
+  X,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Spinner } from '@/components/ui/spinner';
+import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '@/lib/utils';
+import { extractIpcError } from '@/utils/ipcError';
+import type {
+  BillingCatalog,
+  BillingCatalogOffer,
+  BillingCatalogProduct,
+  BillingPurchaseOption,
+  BillingSubscription,
+} from '../../../shared/billing';
+import { CURRENT_CINDY_REGION } from '../../../shared/brandRegion';
+import type { ModelAccessBalance } from '../../../shared/modelAccess';
+import { billingApi } from './api';
+import { BillingCheckoutDialog } from './BillingCheckoutDialog';
+import { useBillingCheckout } from './useBillingCheckout';
+
+type PurchasableOffer = {
+  product: BillingCatalogProduct;
+  offer: BillingCatalogOffer;
+  purchaseOptions: SupportedPurchaseOption[];
+};
+
+type SupportedBillingProvider = 'alipay' | 'stripe';
+type SupportedPurchaseOption = BillingPurchaseOption & {
+  provider: SupportedBillingProvider;
+};
+
+type PurchaseKind = BillingCatalogProduct['kind'];
+type BalanceIssue = 'NOT_PROVISIONED' | 'NOT_SUPPORTED' | 'UNAVAILABLE' | null;
+
+const SUPPORTED_BILLING_PROVIDERS = new Set<SupportedBillingProvider>(['alipay', 'stripe']);
+const SUPPORTED_PAYMENT_ACTIONS = new Set<BillingPurchaseOption['paymentAction']>([
+  'QR_CODE',
+  'REDIRECT',
+]);
+const SUPPORTED_SUBSCRIPTION_CAPABILITIES = new Set<BillingPurchaseOption['capability']>([
+  'MERCHANT_INITIATED_MANDATE',
+  'PROVIDER_MANAGED_SUBSCRIPTION',
+]);
+
+const SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES: BillingSubscription['status'][] = [
+  'INCOMPLETE',
+  'TRIALING',
+  'ACTIVE',
+  'PAST_DUE',
+  'UNPAID',
+  'PAUSED',
+];
+
+function decimalParts(value: string): { value: bigint; scale: number } | null {
+  const match = /^(0|[1-9]\d{0,14})(?:\.(\d{1,9}))?$/.exec(value.trim());
+  if (!match) return null;
+  const fraction = match[2] ?? '';
+  return {
+    value: BigInt(`${match[1]}${fraction}`),
+    scale: fraction.length,
+  };
+}
+
+function compareDecimal(left: string, right: string): number | null {
+  const a = decimalParts(left);
+  const b = decimalParts(right);
+  if (!a || !b) return null;
+  const scale = Math.max(a.scale, b.scale);
+  const av = a.value * 10n ** BigInt(scale - a.scale);
+  const bv = b.value * 10n ** BigInt(scale - b.scale);
+  return av < bv ? -1 : av > bv ? 1 : 0;
+}
+
+function isCustomTopup(offer: BillingCatalogOffer): boolean {
+  return offer.amount === null && offer.minAmount !== null && offer.maxAmount !== null;
+}
+
+function isSupportedPurchaseOption(
+  option: BillingPurchaseOption,
+  productKind: BillingCatalogProduct['kind'],
+): option is SupportedPurchaseOption {
+  if (!SUPPORTED_BILLING_PROVIDERS.has(option.provider as SupportedBillingProvider)) return false;
+  if (!SUPPORTED_PAYMENT_ACTIONS.has(option.paymentAction)) return false;
+  return productKind === 'CREDIT_TOPUP'
+    ? option.capability === 'ONE_TIME_PAYMENT'
+    : SUPPORTED_SUBSCRIPTION_CAPABILITIES.has(option.capability);
+}
+
+function formatMoney(amount: string, currency: string): string {
+  const numeric = Number(amount);
+  if (!Number.isFinite(numeric)) return `${amount} ${currency.toUpperCase()}`;
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+    }).format(numeric);
+  } catch {
+    return `${amount} ${currency.toUpperCase()}`;
+  }
+}
+
+function currencyFractionDigits(currency: string): number {
+  try {
+    return (
+      new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: currency.toUpperCase(),
+      }).resolvedOptions().maximumFractionDigits ?? 2
+    );
+  } catch {
+    return 2;
+  }
+}
+
+function balanceIssue(error: unknown): Exclude<BalanceIssue, null> {
+  const code = extractIpcError(error)?.code;
+  if (code === 'NOT_FOUND') return 'NOT_PROVISIONED';
+  if (code === 'UNSUPPORTED_CAPABILITY') return 'NOT_SUPPORTED';
+  return 'UNAVAILABLE';
+}
+
+/**
+ * Kept as a compatibility export for focused tests and old imports.
+ * The actual product entry now lives in Settings.
+ */
+export function BillingPage() {
+  const { dataOwnerId } = useAuth();
+  return (
+    <BillingSettingsSection key={`billing:${dataOwnerId ?? 'none'}`} accountId={dataOwnerId} />
+  );
+}
+
+export function BillingSettingsSection({ accountId }: { accountId: string | null }) {
+  const { t } = useTranslation();
+  const [catalog, setCatalog] = useState<BillingCatalog | null>(null);
+  const [catalogError, setCatalogError] = useState(false);
+  const [loadingCatalog, setLoadingCatalog] = useState(true);
+  const [currentSubscription, setCurrentSubscription] = useState<BillingSubscription | null>(null);
+  const [loadingSubscription, setLoadingSubscription] = useState(true);
+  const [subscriptionError, setSubscriptionError] = useState(false);
+  const [balance, setBalance] = useState<ModelAccessBalance | null>(null);
+  const [loadingBalance, setLoadingBalance] = useState(true);
+  const [balanceError, setBalanceError] = useState<BalanceIssue>(null);
+  const [subscriptionDialogOpen, setSubscriptionDialogOpen] = useState(false);
+  const [topupDialogOpen, setTopupDialogOpen] = useState(false);
+  const [selectedOfferCode, setSelectedOfferCode] = useState<string | null>(null);
+  const [selectedPurchaseOptionId, setSelectedPurchaseOptionId] = useState<string | null>(null);
+  const [customAmount, setCustomAmount] = useState('');
+  const checkout = useBillingCheckout(accountId);
+
+  const resetSelection = useCallback(() => {
+    setSelectedOfferCode(null);
+    setSelectedPurchaseOptionId(null);
+    setCustomAmount('');
+  }, []);
+
+  const loadBillingState = useCallback(async () => {
+    setLoadingCatalog(true);
+    setLoadingSubscription(true);
+    setLoadingBalance(true);
+    setCatalogError(false);
+    setSubscriptionError(false);
+    setBalanceError(null);
+    await Promise.allSettled([
+      billingApi
+        .getCatalog()
+        .then(setCatalog, () => {
+          setCatalog(null);
+          setCatalogError(true);
+        })
+        .finally(() => setLoadingCatalog(false)),
+      billingApi
+        .getCurrentSubscription()
+        .then(
+          (result) => setCurrentSubscription(result.subscription),
+          () => setSubscriptionError(true),
+        )
+        .finally(() => setLoadingSubscription(false)),
+      billingApi
+        .getBalance()
+        .then(setBalance, (error) => {
+          setBalance(null);
+          setBalanceError(balanceIssue(error));
+        })
+        .finally(() => setLoadingBalance(false)),
+    ]);
+  }, []);
+
+  useEffect(() => {
+    void loadBillingState();
+  }, [loadBillingState]);
+
+  useEffect(() => {
+    if (checkout.state.subscription) {
+      setCurrentSubscription(checkout.state.subscription);
+      setSubscriptionError(false);
+    }
+  }, [checkout.state.subscription]);
+
+  const offers = useMemo<PurchasableOffer[]>(() => {
+    if (!catalog) return [];
+    return catalog.products
+      .flatMap((product) =>
+        product.offers.map((offer) => ({
+          product,
+          offer,
+          purchaseOptions: Array.isArray(offer.purchaseOptions)
+            ? offer.purchaseOptions.filter((option) =>
+                isSupportedPurchaseOption(option, product.kind),
+              )
+            : [],
+        })),
+      )
+      .filter(({ purchaseOptions }) => purchaseOptions.length > 0)
+      .sort((left, right) => {
+        const productOrder = left.product.sortOrder - right.product.sortOrder;
+        if (productOrder !== 0) return productOrder;
+        return left.offer.code.localeCompare(right.offer.code);
+      });
+  }, [catalog]);
+
+  const subscriptionOffers = useMemo(
+    () => offers.filter(({ product }) => product.kind === 'SUBSCRIPTION'),
+    [offers],
+  );
+  const topupOffers = useMemo(
+    () => offers.filter(({ product }) => product.kind === 'CREDIT_TOPUP'),
+    [offers],
+  );
+
+  const selected = useMemo(
+    () => offers.find(({ offer }) => offer.code === selectedOfferCode) ?? null,
+    [offers, selectedOfferCode],
+  );
+  const selectedOption = useMemo(
+    () =>
+      selected?.purchaseOptions.find((option) => option.id === selectedPurchaseOptionId) ?? null,
+    [selected, selectedPurchaseOptionId],
+  );
+
+  useEffect(() => {
+    if (!selectedOfferCode) return;
+    if (!offers.some(({ offer }) => offer.code === selectedOfferCode)) {
+      resetSelection();
+    }
+  }, [offers, resetSelection, selectedOfferCode]);
+
+  useEffect(() => {
+    if (!selectedPurchaseOptionId) return;
+    if (!selected?.purchaseOptions.some((option) => option.id === selectedPurchaseOptionId)) {
+      setSelectedPurchaseOptionId(null);
+    }
+  }, [selected, selectedPurchaseOptionId]);
+
+  const amountError = useMemo(() => {
+    if (!selected || !isCustomTopup(selected.offer)) return null;
+    if (!customAmount) return null;
+    const amountParts = decimalParts(customAmount);
+    const fractionDigits = currencyFractionDigits(selected.offer.currency);
+    if (!amountParts || amountParts.scale > fractionDigits) {
+      return t('billing.amount.formatError', { digits: fractionDigits });
+    }
+    const min = selected.offer.minAmount!;
+    const max = selected.offer.maxAmount!;
+    const minComparison = compareDecimal(customAmount, min);
+    const maxComparison = compareDecimal(customAmount, max);
+    if (
+      minComparison === null ||
+      minComparison < 0 ||
+      maxComparison === null ||
+      maxComparison > 0
+    ) {
+      return t('billing.amount.rangeError', {
+        min: formatMoney(min, selected.offer.currency),
+        max: formatMoney(max, selected.offer.currency),
+      });
+    }
+    return null;
+  }, [customAmount, selected, t]);
+
+  const subscriptionPurchaseBlocked =
+    currentSubscription !== null &&
+    SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES.includes(currentSubscription.status);
+  const canCheckout =
+    selected !== null &&
+    selectedOption !== null &&
+    !(
+      selected.product.kind === 'SUBSCRIPTION' &&
+      (loadingSubscription || subscriptionError || subscriptionPurchaseBlocked)
+    ) &&
+    (!isCustomTopup(selected.offer) || (customAmount.length > 0 && amountError === null));
+
+  const currentPlanName = useMemo(() => {
+    const productCode = currentSubscription?.effectivePlan?.product.code;
+    if (!productCode) return null;
+    return catalog?.products.find((product) => product.code === productCode)?.name ?? productCode;
+  }, [catalog, currentSubscription]);
+
+  const openPurchaseDialog = (kind: PurchaseKind) => {
+    resetSelection();
+    if (kind === 'SUBSCRIPTION') {
+      setSubscriptionDialogOpen(true);
+    } else {
+      setTopupDialogOpen(true);
+    }
+  };
+
+  const selectOffer = (offerCode: string) => {
+    if (selectedOfferCode === offerCode) return;
+    setSelectedOfferCode(offerCode);
+    setSelectedPurchaseOptionId(null);
+    setCustomAmount('');
+  };
+
+  const submit = () => {
+    if (!selected || !selectedOption || !canCheckout) return;
+    setSubscriptionDialogOpen(false);
+    setTopupDialogOpen(false);
+    if (selected.product.kind === 'CREDIT_TOPUP') {
+      void checkout.startTopup({
+        offerCode: selected.offer.code,
+        ...(isCustomTopup(selected.offer) ? { amount: customAmount.trim() } : {}),
+        purchaseOptionId: selectedOption.id,
+      });
+    } else {
+      void checkout.startSubscription({
+        offerCode: selected.offer.code,
+        purchaseOptionId: selectedOption.id,
+      });
+    }
+  };
+
+  const closeSubscriptionDialog = () => {
+    setSubscriptionDialogOpen(false);
+    resetSelection();
+  };
+  const closeTopupDialog = () => {
+    setTopupDialogOpen(false);
+    resetSelection();
+  };
+
+  return (
+    <>
+      <div>
+        <div className="flex items-start justify-between gap-6">
+          <div>
+            <h2 className="text-20 font-medium tracking-[-0.01em] text-[var(--settings-section-title)]">
+              {t('billing.settings.title')}
+            </h2>
+            <p className="mt-1.5 max-w-[620px] text-13 leading-5 text-[var(--settings-section-desc)]">
+              {t('billing.settings.subtitle')}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void loadBillingState()}
+            disabled={loadingCatalog || loadingSubscription || loadingBalance}
+            className="inline-flex h-8 shrink-0 items-center gap-2 rounded-full border border-[var(--border-default)] px-3.5 text-12 font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-hover-soft)] disabled:opacity-45"
+          >
+            {loadingCatalog || loadingSubscription || loadingBalance ? (
+              <Spinner size={13} />
+            ) : (
+              <RefreshCcw size={13} />
+            )}
+            {t('billing.actions.refreshCatalog')}
+          </button>
+        </div>
+
+        <div className="mt-8 overflow-hidden rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)]">
+          <BillingBalanceSummary balance={balance} issue={balanceError} loading={loadingBalance} />
+          <div className="border-t border-[var(--border-default)]">
+            <BillingSummaryRow
+              label={t('billing.settings.subscriptionCard.title')}
+              title={
+                currentPlanName ??
+                (currentSubscription
+                  ? t('billing.settings.subscriptionCard.unnamedPlan')
+                  : t('billing.settings.subscriptionCard.emptyTitle'))
+              }
+              description={
+                loadingSubscription
+                  ? t('billing.settings.loading')
+                  : subscriptionError
+                    ? t('billing.settings.subscriptionCard.unavailable')
+                    : currentSubscription
+                      ? t(`billing.subscriptionStatus.${currentSubscription.status}`)
+                      : t('billing.settings.subscriptionCard.empty')
+              }
+              loading={loadingSubscription}
+              disabled={loadingSubscription || subscriptionError}
+              actionLabel={t('billing.settings.subscriptionCard.action')}
+              onAction={() => openPurchaseDialog('SUBSCRIPTION')}
+            />
+          </div>
+          <div className="border-t border-[var(--border-default)]">
+            <BillingSummaryRow
+              label={t('billing.settings.topupCard.title')}
+              title={t('billing.settings.topupCard.cardTitle')}
+              description={t('billing.settings.topupCard.cardDescription')}
+              actionLabel={t('billing.settings.topupCard.action')}
+              onAction={() => openPurchaseDialog('CREDIT_TOPUP')}
+            />
+          </div>
+        </div>
+
+        {!checkout.recovering &&
+          (checkout.recoverables.topups.length > 0 ||
+            checkout.recoverables.subscription !== null) && (
+            <div className="mt-5 rounded-xl border border-[var(--border-default)] px-5 py-4">
+              <p className="text-sm font-medium">{t('billing.recovery.title')}</p>
+              <p className="mt-1 text-12 text-[var(--text-secondary)]">
+                {t('billing.recovery.description')}
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {checkout.recoverables.topups.map((order) => (
+                  <button
+                    key={order.orderId}
+                    type="button"
+                    onClick={() => checkout.resumeTopup(order)}
+                    className="rounded-full border border-[var(--border-default)] px-3 py-1.5 text-12 font-medium hover:bg-[var(--surface-hover-soft)]"
+                  >
+                    {t('billing.recovery.continueTopup', {
+                      amount: formatMoney(order.amount, order.currency),
+                    })}
+                  </button>
+                ))}
+                {checkout.recoverables.subscription && (
+                  <button
+                    type="button"
+                    onClick={() => checkout.resumeSubscription(checkout.recoverables.subscription!)}
+                    className="rounded-full border border-[var(--border-default)] px-3 py-1.5 text-12 font-medium hover:bg-[var(--surface-hover-soft)]"
+                  >
+                    {t('billing.recovery.continueSubscription')}
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+      </div>
+
+      <BillingOfferDialog
+        open={subscriptionDialogOpen}
+        kind="SUBSCRIPTION"
+        offers={subscriptionOffers}
+        loading={loadingCatalog}
+        catalogError={catalogError}
+        selected={selected?.product.kind === 'SUBSCRIPTION' ? selected : null}
+        selectedPurchaseOptionId={selectedPurchaseOptionId}
+        customAmount={customAmount}
+        amountError={amountError}
+        subscriptionPurchaseBlocked={subscriptionPurchaseBlocked}
+        canCheckout={canCheckout}
+        onClose={closeSubscriptionDialog}
+        onRetry={() => void loadBillingState()}
+        onSelectOffer={selectOffer}
+        onSelectPurchaseOption={setSelectedPurchaseOptionId}
+        onCustomAmountChange={setCustomAmount}
+        onSubmit={submit}
+      />
+
+      <BillingOfferDialog
+        open={topupDialogOpen}
+        kind="CREDIT_TOPUP"
+        offers={topupOffers}
+        loading={loadingCatalog}
+        catalogError={catalogError}
+        selected={selected?.product.kind === 'CREDIT_TOPUP' ? selected : null}
+        selectedPurchaseOptionId={selectedPurchaseOptionId}
+        customAmount={customAmount}
+        amountError={amountError}
+        subscriptionPurchaseBlocked={false}
+        canCheckout={canCheckout}
+        onClose={closeTopupDialog}
+        onRetry={() => void loadBillingState()}
+        onSelectOffer={selectOffer}
+        onSelectPurchaseOption={setSelectedPurchaseOptionId}
+        onCustomAmountChange={setCustomAmount}
+        onSubmit={submit}
+      />
+
+      <BillingCheckoutDialog
+        state={checkout.state}
+        onClose={checkout.close}
+        onRefresh={() => void checkout.refreshActive()}
+        onRetry={() => void checkout.retry()}
+        onCancel={() => void checkout.cancel()}
+      />
+    </>
+  );
+}
+
+function BillingBalanceSummary({
+  balance,
+  issue,
+  loading,
+}: {
+  balance: ModelAccessBalance | null;
+  issue: BalanceIssue;
+  loading: boolean;
+}) {
+  const { t } = useTranslation();
+  const currency = CURRENT_CINDY_REGION === 'global' ? 'usd' : 'cny';
+  const pools = balance
+    ? [
+        { key: 'plan', label: t('billing.balance.plan'), amount: balance.planCredits },
+        {
+          key: 'purchased',
+          label: t('billing.balance.purchased'),
+          amount: balance.purchasedCredits,
+        },
+        {
+          key: 'promotional',
+          label: t('billing.balance.promotional'),
+          amount: balance.promotionalCredits,
+        },
+      ]
+    : [];
+  const issueDescription =
+    issue === 'NOT_PROVISIONED'
+      ? t('billing.balance.notProvisioned')
+      : issue === 'NOT_SUPPORTED'
+        ? t('billing.balance.notSupported')
+        : t('billing.balance.unavailable');
+
+  return (
+    <section
+      className="px-5 py-5"
+      aria-labelledby="billing-balance-title"
+      aria-live="polite"
+      aria-busy={loading}
+    >
+      <p id="billing-balance-title" className="text-11 font-medium text-[var(--text-tertiary)]">
+        {t('billing.balance.title')}
+      </p>
+      {loading ? (
+        <div className="mt-3 flex h-[76px] items-center">
+          <Spinner size={15} />
+        </div>
+      ) : balance ? (
+        <>
+          <p className="mt-1 text-2xl font-medium tracking-[-0.03em] tabular-nums text-[var(--text-primary)]">
+            {formatMoney(balance.available, currency)}
+          </p>
+          <div className="mt-4 grid grid-cols-3 divide-x divide-[var(--border-default)] rounded-lg bg-[var(--surface-chip)] px-1 py-2.5">
+            {pools.map(({ key, label, amount }) => (
+              <div key={key} className="min-w-0 px-3">
+                <p className="truncate text-11 text-[var(--text-tertiary)]">{label}</p>
+                <p className="mt-1 truncate text-13 font-medium tabular-nums text-[var(--text-primary)]">
+                  {formatMoney(amount, currency)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <div
+          role="status"
+          className="mt-3 flex min-h-[76px] items-center text-12 leading-5 text-[var(--text-secondary)]"
+        >
+          {issueDescription}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function BillingSummaryRow({
+  label,
+  title,
+  description,
+  loading = false,
+  disabled = false,
+  actionLabel,
+  onAction,
+}: {
+  label: string;
+  title: string;
+  description: string;
+  loading?: boolean;
+  disabled?: boolean;
+  actionLabel: string;
+  onAction: () => void;
+}) {
+  return (
+    <div className="flex min-h-[112px] items-center gap-6 px-5 py-4">
+      <div className="min-w-0 flex-1">
+        <p className="text-11 font-medium text-[var(--text-tertiary)]">{label}</p>
+        <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">{title}</p>
+        <div className="mt-1 min-h-5 text-12 leading-5 text-[var(--text-secondary)]">
+          {loading ? <Spinner size={13} /> : description}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onAction}
+        disabled={disabled}
+        className="h-8 shrink-0 rounded-full border border-[var(--border-default)] px-4 text-12 font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--surface-hover-soft)] disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {actionLabel}
+      </button>
+    </div>
+  );
+}
+
+function BillingOfferDialog({
+  open,
+  kind,
+  offers,
+  loading,
+  catalogError,
+  selected,
+  selectedPurchaseOptionId,
+  customAmount,
+  amountError,
+  subscriptionPurchaseBlocked,
+  canCheckout,
+  onClose,
+  onRetry,
+  onSelectOffer,
+  onSelectPurchaseOption,
+  onCustomAmountChange,
+  onSubmit,
+}: {
+  open: boolean;
+  kind: PurchaseKind;
+  offers: PurchasableOffer[];
+  loading: boolean;
+  catalogError: boolean;
+  selected: PurchasableOffer | null;
+  selectedPurchaseOptionId: string | null;
+  customAmount: string;
+  amountError: string | null;
+  subscriptionPurchaseBlocked: boolean;
+  canCheckout: boolean;
+  onClose: () => void;
+  onRetry: () => void;
+  onSelectOffer: (offerCode: string) => void;
+  onSelectPurchaseOption: (optionId: string) => void;
+  onCustomAmountChange: (amount: string) => void;
+  onSubmit: () => void;
+}) {
+  const { t } = useTranslation();
+  const title =
+    kind === 'SUBSCRIPTION'
+      ? t('billing.dialogs.subscription.title')
+      : t('billing.dialogs.topup.title');
+  const description =
+    kind === 'SUBSCRIPTION'
+      ? t('billing.dialogs.subscription.description')
+      : t('billing.dialogs.topup.description');
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[9990] bg-[var(--overlay-modal)]" />
+        <Dialog.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[9991] flex max-h-[min(720px,calc(100vh-48px))]',
+            'w-[calc(100vw-48px)] max-w-[680px] -translate-x-1/2 -translate-y-1/2 flex-col',
+            'overflow-hidden rounded-xl border border-[var(--border-default)]',
+            'bg-[var(--surface-elevated)] text-[var(--text-primary)] focus:outline-none',
+          )}
+        >
+          <div className="flex items-start justify-between gap-4 px-6 pb-4 pt-5">
+            <div>
+              <Dialog.Title className="text-16 font-medium tracking-[-0.01em]">
+                {title}
+              </Dialog.Title>
+              <Dialog.Description className="mt-1.5 max-w-[520px] text-12 leading-5 text-[var(--text-secondary)]">
+                {description}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                className="grid size-8 shrink-0 place-items-center rounded-full text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)]"
+                aria-label={t('billing.actions.close')}
+              >
+                <X size={16} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto border-t border-[var(--border-default)] px-6 py-4 [scrollbar-gutter:stable]">
+            {loading ? (
+              <CatalogSkeleton />
+            ) : catalogError ? (
+              <StateCard
+                icon={<RefreshCcw size={22} />}
+                title={t('billing.catalog.errorTitle')}
+                description={t('billing.catalog.errorDescription')}
+                action={
+                  <button
+                    type="button"
+                    onClick={onRetry}
+                    className="mt-4 h-9 rounded-full border border-[var(--border-default)] px-4 text-12 font-medium hover:bg-[var(--surface-hover-soft)]"
+                  >
+                    {t('billing.actions.retry')}
+                  </button>
+                }
+              />
+            ) : offers.length === 0 ? (
+              <StateCard
+                icon={<PackageOpen size={22} />}
+                title={t('billing.catalog.emptyTitle')}
+                description={t('billing.catalog.emptyDescription')}
+              />
+            ) : (
+              <>
+                <div className="space-y-2.5">
+                  {offers.map(({ product, offer }) => {
+                    const active = selected?.offer.code === offer.code;
+                    return (
+                      <button
+                        key={offer.code}
+                        type="button"
+                        onClick={() => onSelectOffer(offer.code)}
+                        aria-pressed={active}
+                        className={cn(
+                          'group relative flex min-h-[88px] w-full items-center gap-5 rounded-xl border px-4 py-3.5 text-left',
+                          'transition-[background-color,border-color,box-shadow] focus-visible:outline-none',
+                          'focus-visible:ring-2 focus-visible:ring-[var(--text-primary)] focus-visible:ring-offset-2',
+                          'focus-visible:ring-offset-[var(--surface-elevated)]',
+                          active
+                            ? 'border-[var(--text-primary)] bg-[var(--surface)] shadow-[inset_3px_0_0_var(--text-primary)]'
+                            : 'border-[var(--border-default)] hover:bg-[var(--surface-hover-soft)]',
+                        )}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+                            {product.name}
+                          </p>
+                          <p className="mt-1 text-11 text-[var(--text-tertiary)]">
+                            {kind === 'SUBSCRIPTION'
+                              ? t('billing.offerKinds.subscription')
+                              : t('billing.offerKinds.topup')}
+                          </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-4">
+                          <div className="text-right">
+                            <p className="text-lg font-medium tracking-[-0.02em]">
+                              {offer.amount
+                                ? formatMoney(offer.amount, offer.currency)
+                                : t('billing.amount.custom')}
+                              {offer.interval && (
+                                <span className="ml-1 text-11 font-normal text-[var(--text-tertiary)]">
+                                  / {t(`billing.intervals.${offer.interval}`)}
+                                </span>
+                              )}
+                            </p>
+                            {offer.creditAmount && (
+                              <p className="mt-1 text-11 text-[var(--text-secondary)]">
+                                {t('billing.credits', { amount: offer.creditAmount })}
+                              </p>
+                            )}
+                          </div>
+                          <SelectionMark active={active} />
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {selected && (
+                  <div className="mt-5 border-t border-[var(--border-default)] pt-4">
+                    <h3 className="text-13 font-medium">{t('billing.steps.channel.title')}</h3>
+                    <p className="mt-1 text-12 text-[var(--text-secondary)]">
+                      {t('billing.steps.channel.description')}
+                    </p>
+                    <div className="mt-3 space-y-2">
+                      {selected.purchaseOptions.map((option) => (
+                        <PaymentOptionCard
+                          key={option.id}
+                          option={option}
+                          active={selectedPurchaseOptionId === option.id}
+                          onSelect={() => onSelectPurchaseOption(option.id)}
+                        />
+                      ))}
+                    </div>
+
+                    {kind === 'CREDIT_TOPUP' && isCustomTopup(selected.offer) && (
+                      <label className="mt-5 block">
+                        <span className="text-12 font-medium text-[var(--text-secondary)]">
+                          {t('billing.amount.label')}
+                        </span>
+                        <div className="mt-2 flex h-11 items-center rounded-xl border border-[var(--border-default)] bg-[var(--surface)] px-4 focus-within:border-[var(--text-primary)]">
+                          <span className="mr-2 text-sm text-[var(--text-tertiary)]">
+                            {selected.offer.currency.toUpperCase()}
+                          </span>
+                          <input
+                            value={customAmount}
+                            onChange={(event) => onCustomAmountChange(event.target.value)}
+                            inputMode="decimal"
+                            placeholder={t('billing.amount.placeholder')}
+                            className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-[var(--text-tertiary)]"
+                          />
+                        </div>
+                        <p
+                          className={cn(
+                            'mt-2 text-11',
+                            amountError
+                              ? 'text-[var(--text-primary)]'
+                              : 'text-[var(--text-tertiary)]',
+                          )}
+                        >
+                          {amountError ??
+                            t('billing.amount.rangeHint', {
+                              min: formatMoney(selected.offer.minAmount!, selected.offer.currency),
+                              max: formatMoney(selected.offer.maxAmount!, selected.offer.currency),
+                            })}
+                        </p>
+                      </label>
+                    )}
+
+                    {kind === 'SUBSCRIPTION' && subscriptionPurchaseBlocked && (
+                      <p className="mt-5 rounded-lg bg-[var(--surface-chip)] px-4 py-3 text-12 leading-5 text-[var(--text-secondary)]">
+                        {t('billing.currentSubscription.purchaseBlocked')}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          <div className="flex min-h-16 items-center justify-between gap-4 border-t border-[var(--border-default)] px-6 py-3">
+            <div className="flex min-w-0 max-w-[380px] items-start gap-2 text-11 leading-4 text-[var(--text-tertiary)]">
+              <ShieldCheck size={13} className="shrink-0" />
+              <span>{t('billing.securityNotice')}</span>
+            </div>
+            <button
+              type="button"
+              onClick={onSubmit}
+              disabled={!canCheckout}
+              className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full bg-[var(--text-primary)] px-5 text-13 font-medium text-[var(--surface)] transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--text-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-elevated)] disabled:cursor-not-allowed disabled:opacity-35"
+            >
+              {t('billing.actions.pay')}
+              <ArrowRight size={15} />
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function CatalogSkeleton() {
+  return (
+    <div className="space-y-2.5" aria-hidden>
+      {[0, 1, 2].map((item) => (
+        <div
+          key={item}
+          className="h-[88px] animate-pulse rounded-xl border border-[var(--border-default)] bg-[var(--surface-chip)] motion-reduce:animate-none"
+        />
+      ))}
+    </div>
+  );
+}
+
+function StateCard({
+  icon,
+  title,
+  description,
+  action,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-[184px] flex-col items-center justify-center rounded-xl border border-[var(--border-default)] px-6 text-center">
+      <div className="grid size-11 place-items-center rounded-full bg-[var(--surface-chip)]">
+        {icon}
+      </div>
+      <p className="mt-4 text-sm font-medium">{title}</p>
+      <p className="mt-1 text-12 text-[var(--text-secondary)]">{description}</p>
+      {action}
+    </div>
+  );
+}
+
+function PaymentOptionCard({
+  option,
+  active,
+  onSelect,
+}: {
+  option: SupportedPurchaseOption;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const { t } = useTranslation();
+  const Icon = option.paymentAction === 'QR_CODE' ? CircleDollarSign : CreditCard;
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={active}
+      className={cn(
+        'flex min-h-[64px] w-full items-center gap-3 rounded-xl border px-3.5 py-2.5 text-left',
+        'transition-colors focus-visible:outline-none focus-visible:ring-2',
+        'focus-visible:ring-[var(--text-primary)] focus-visible:ring-offset-2',
+        'focus-visible:ring-offset-[var(--surface-elevated)]',
+        active
+          ? 'border-[var(--text-primary)] bg-[var(--surface)]'
+          : 'border-[var(--border-default)] hover:bg-[var(--surface-hover-soft)]',
+      )}
+    >
+      <div className="grid size-9 shrink-0 place-items-center rounded-full bg-[var(--surface-chip)]">
+        <Icon size={16} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{providerLabel(option.provider, t)}</p>
+        <p className="mt-1 text-11 text-[var(--text-tertiary)]">
+          {option.paymentAction === 'QR_CODE'
+            ? t('billing.paymentActions.QR_CODE')
+            : t('billing.paymentActions.REDIRECT')}
+        </p>
+      </div>
+      <SelectionMark active={active} />
+    </button>
+  );
+}
+
+function SelectionMark({ active }: { active: boolean }) {
+  return (
+    <span
+      className={cn(
+        'grid size-5 shrink-0 place-items-center rounded-full border',
+        active
+          ? 'border-[var(--text-primary)] bg-[var(--text-primary)] text-[var(--surface)]'
+          : 'border-[var(--border-default)]',
+      )}
+    >
+      {active && <Check size={12} strokeWidth={2.5} />}
+    </span>
+  );
+}
+
+function providerLabel(
+  provider: SupportedBillingProvider,
+  t: ReturnType<typeof useTranslation>['t'],
+): string {
+  return t(`billing.providers.${provider}`);
+}

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -101,10 +101,14 @@ function formatMoney(amount: string, currency: string): string {
   const numeric = Number(amount);
   if (!Number.isFinite(numeric)) return `${amount} ${currency.toUpperCase()}`;
   try {
-    return new Intl.NumberFormat(undefined, {
+    const fmt = new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency: currency.toUpperCase(),
-    }).format(numeric);
+    });
+    const digits = fmt.resolvedOptions().maximumFractionDigits ?? 2;
+    // Shift via exponential notation to avoid IEEE 754 mid-point errors (e.g. 1.005 → 1.00).
+    const rounded = Number(Math.round(Number(amount + 'e' + digits)) + 'e-' + digits);
+    return fmt.format(Number.isFinite(rounded) ? rounded : numeric);
   } catch {
     return `${amount} ${currency.toUpperCase()}`;
   }

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -1,0 +1,536 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const checkout = {
+  state: {
+    open: false,
+    kind: null,
+    phase: 'IDLE',
+    intent: null,
+    order: null,
+    subscription: null,
+    error: false,
+  },
+  recoverables: { topups: [], subscription: null },
+  recovering: false,
+  startTopup: vi.fn(),
+  startSubscription: vi.fn(),
+  refreshActive: vi.fn(),
+  retry: vi.fn(),
+  cancel: vi.fn(),
+  close: vi.fn(),
+  resumeTopup: vi.fn(),
+  resumeSubscription: vi.fn(),
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const providerLabels: Record<string, string> = {
+        'billing.providers.alipay': 'alipay',
+        'billing.providers.stripe': 'stripe',
+      };
+      if (providerLabels[key]) return providerLabels[key];
+      return params ? `${key}:${JSON.stringify(params)}` : key;
+    },
+  }),
+}));
+vi.mock('@/features/feature-context', () => ({
+  useRegisterSidebarUpper: vi.fn(),
+  useRegisterContentHeader: vi.fn(),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ dataOwnerId: 'account-fixture' }),
+}));
+vi.mock('../useBillingCheckout', () => ({
+  useBillingCheckout: () => checkout,
+}));
+vi.mock('qrcode', () => ({
+  toDataURL: vi.fn(async () => 'data:image/png;base64,fixture'),
+}));
+
+import { BillingPage } from '../BillingPage';
+
+describe('BillingPage remote catalog rendering', () => {
+  beforeEach(() => {
+    Object.assign(checkout.state, {
+      open: false,
+      kind: null,
+      phase: 'IDLE',
+      intent: null,
+      order: null,
+      subscription: null,
+      error: false,
+    });
+    checkout.startTopup.mockClear();
+    checkout.startSubscription.mockClear();
+    checkout.close.mockClear();
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        billing: {
+          getBalance: vi.fn(async () => ({
+            planCredits: '7.000000001',
+            purchasedCredits: '5.000000002',
+            promotionalCredits: '0.345678898',
+            available: '12.345678901',
+            scale: 9 as const,
+            observedAt: '2026-07-23T12:00:00.000Z',
+          })),
+          getCatalog: vi.fn(async () => ({
+            products: [
+              {
+                code: 'credit_topup',
+                name: 'Configured top-up',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 1,
+                offers: [
+                  {
+                    code: 'credit_topup_custom',
+                    interval: null,
+                    currency: 'cny',
+                    amount: null,
+                    minAmount: '1',
+                    maxAmount: '100',
+                    creditAmount: null,
+                    rolloverCap: null,
+                    purchaseOptions: [
+                      {
+                        id: 'listing_alipay',
+                        provider: 'alipay',
+                        capability: 'ONE_TIME_PAYMENT',
+                        paymentAction: 'QR_CODE',
+                      },
+                      {
+                        id: 'listing_unknown',
+                        provider: 'unknown_provider',
+                        capability: 'ONE_TIME_PAYMENT',
+                        paymentAction: 'REDIRECT',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                code: 'plus',
+                name: 'Configured subscription',
+                kind: 'SUBSCRIPTION',
+                level: 1,
+                sortOrder: 2,
+                offers: [
+                  {
+                    code: 'plus_month',
+                    interval: 'MONTH',
+                    currency: 'usd',
+                    amount: '9',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '100',
+                    rolloverCap: '0',
+                    purchaseOptions: [
+                      {
+                        id: 'listing_stripe',
+                        provider: 'stripe',
+                        capability: 'PROVIDER_MANAGED_SUBSCRIPTION',
+                        paymentAction: 'REDIRECT',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                code: 'unknown_provider_only',
+                name: 'Unknown-provider offer',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 3,
+                offers: [
+                  {
+                    code: 'unknown_provider_offer',
+                    interval: null,
+                    currency: 'cny',
+                    amount: '10',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '10',
+                    rolloverCap: null,
+                    purchaseOptions: [
+                      {
+                        id: 'listing_unknown_only',
+                        provider: 'unknown_provider',
+                        capability: 'ONE_TIME_PAYMENT',
+                        paymentAction: 'REDIRECT',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                code: 'hidden',
+                name: 'Unconfigured offer',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 4,
+                offers: [
+                  {
+                    code: 'hidden_offer',
+                    interval: null,
+                    currency: 'cny',
+                    amount: '10',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '10',
+                    rolloverCap: null,
+                    purchaseOptions: [],
+                  },
+                ],
+              },
+              {
+                code: 'legacy',
+                name: 'Legacy offer without channel projection',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 5,
+                offers: [
+                  {
+                    code: 'legacy_offer',
+                    interval: null,
+                    currency: 'cny',
+                    amount: '20',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '20',
+                    rolloverCap: null,
+                  },
+                ],
+              },
+              {
+                code: 'unsupported_action',
+                name: 'Unsupported payment action',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 6,
+                offers: [
+                  {
+                    code: 'unsupported_action_offer',
+                    interval: null,
+                    currency: 'cny',
+                    amount: '10',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '10',
+                    rolloverCap: null,
+                    purchaseOptions: [
+                      {
+                        id: 'listing_future_action',
+                        provider: 'alipay',
+                        capability: 'ONE_TIME_PAYMENT',
+                        paymentAction: 'FUTURE_ACTION' as never,
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                code: 'unsupported_capability',
+                name: 'Unsupported payment capability',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 7,
+                offers: [
+                  {
+                    code: 'unsupported_capability_offer',
+                    interval: null,
+                    currency: 'cny',
+                    amount: '10',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '10',
+                    rolloverCap: null,
+                    purchaseOptions: [
+                      {
+                        id: 'listing_wrong_capability',
+                        provider: 'stripe',
+                        capability: 'PROVIDER_MANAGED_SUBSCRIPTION',
+                        paymentAction: 'REDIRECT',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          })),
+          getCurrentSubscription: vi.fn(async () => ({ subscription: null })),
+        },
+        openExternal: vi.fn(),
+      },
+    });
+  });
+
+  it('shows the server ledger total and all three balance pools', async () => {
+    render(<BillingPage />);
+
+    expect(await screen.findByText('billing.balance.plan')).toBeTruthy();
+    expect(screen.getByText('billing.balance.purchased')).toBeTruthy();
+    expect(screen.getByText('billing.balance.promotional')).toBeTruthy();
+    expect(
+      screen.getByText(
+        new Intl.NumberFormat(undefined, { style: 'currency', currency: 'CNY' }).format(
+          12.345678901,
+        ),
+      ),
+    ).toBeTruthy();
+  });
+
+  it('does not show zero or block purchases when balance is not provisioned', async () => {
+    window.electronAPI.billing.getBalance = vi.fn(async () => {
+      throw Object.assign(new Error('[NOT_FOUND] balance account is not provisioned'), {
+        code: 'NOT_FOUND' as const,
+      });
+    });
+
+    render(<BillingPage />);
+
+    expect(await screen.findByText('billing.balance.notProvisioned')).toBeTruthy();
+    expect(
+      screen.queryByText(
+        new Intl.NumberFormat(undefined, { style: 'currency', currency: 'CNY' }).format(0),
+      ),
+    ).toBeNull();
+    await waitFor(() =>
+      expect(
+        screen.getByText('billing.settings.subscriptionCard.action').closest('button'),
+      ).toHaveProperty('disabled', false),
+    );
+    expect(screen.getByText('billing.settings.topupCard.action').closest('button')).toHaveProperty(
+      'disabled',
+      false,
+    );
+  });
+
+  it('does not wait for a slow balance response before enabling purchase entry points', async () => {
+    window.electronAPI.billing.getBalance = vi.fn(() => new Promise<never>(() => undefined));
+
+    render(<BillingPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('billing.settings.subscriptionCard.action').closest('button'),
+      ).toHaveProperty('disabled', false),
+    );
+    expect(screen.getByText('billing.settings.topupCard.action').closest('button')).toHaveProperty(
+      'disabled',
+      false,
+    );
+  });
+
+  it('shows only configured offers and only the selected offer channels', async () => {
+    render(<BillingPage />);
+
+    expect(screen.getByText('billing.settings.subscriptionCard.action')).toBeTruthy();
+    expect(screen.getByText('billing.settings.topupCard.action')).toBeTruthy();
+    expect(screen.queryByText('Configured top-up')).toBeNull();
+    expect(screen.queryByText('Configured subscription')).toBeNull();
+
+    fireEvent.click(screen.getByText('billing.settings.topupCard.action'));
+    await screen.findByText('Configured top-up');
+    expect(screen.queryByText('Unknown-provider offer')).toBeNull();
+    expect(screen.queryByText('Unconfigured offer')).toBeNull();
+    expect(screen.queryByText('Legacy offer without channel projection')).toBeNull();
+    expect(screen.queryByText('Unsupported payment action')).toBeNull();
+    expect(screen.queryByText('Unsupported payment capability')).toBeNull();
+    expect(screen.queryByText('Configured subscription')).toBeNull();
+    expect(screen.queryByText('unknown_provider')).toBeNull();
+    expect(screen.queryByText('alipay')).toBeNull();
+    expect(screen.queryByText('stripe')).toBeNull();
+
+    fireEvent.click(screen.getByText('Configured top-up').closest('button')!);
+    expect(await screen.findByText('alipay')).toBeTruthy();
+    expect(screen.queryByText('unknown_provider')).toBeNull();
+    expect(screen.queryByText('stripe')).toBeNull();
+
+    fireEvent.click(screen.getByText('alipay').closest('button')!);
+    fireEvent.change(screen.getByPlaceholderText('billing.amount.placeholder'), {
+      target: { value: '1.001' },
+    });
+    expect(screen.getByText('billing.actions.pay').closest('button')).toHaveProperty(
+      'disabled',
+      true,
+    );
+    expect(screen.getByText('billing.amount.formatError:{"digits":2}')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('billing.actions.close'));
+    await waitFor(() => expect(screen.queryByText('Configured top-up')).toBeNull());
+
+    fireEvent.click(screen.getByText('billing.settings.subscriptionCard.action'));
+    fireEvent.click((await screen.findByText('Configured subscription')).closest('button')!);
+    expect(screen.getByText('stripe')).toBeTruthy();
+    expect(screen.queryByText('alipay')).toBeNull();
+    fireEvent.click(screen.getByText('stripe').closest('button')!);
+    fireEvent.click(screen.getByText('billing.actions.pay'));
+    expect(checkout.startSubscription).toHaveBeenCalledWith({
+      offerCode: 'plus_month',
+      purchaseOptionId: 'listing_stripe',
+    });
+  });
+
+  it('does not create a second subscription while one is still live', async () => {
+    window.electronAPI.billing.getCurrentSubscription = vi.fn(async () => ({
+      subscription: {
+        subscriptionId: 'subscription_fixture',
+        status: 'ACTIVE' as const,
+        currentPeriodStartAt: null,
+        currentPeriodEndAt: null,
+        entitlementValidUntil: null,
+        cancelAtPeriodEnd: false,
+        effectivePlan: null,
+        purchaseAttemptId: null,
+        paymentAction: null,
+      },
+    }));
+
+    render(<BillingPage />);
+    const viewPlans = screen
+      .getByText('billing.settings.subscriptionCard.action')
+      .closest('button')!;
+    await waitFor(() => expect(viewPlans).toHaveProperty('disabled', false));
+    fireEvent.click(viewPlans);
+    fireEvent.click((await screen.findByText('Configured subscription')).closest('button')!);
+    fireEvent.click((await screen.findByText('stripe')).closest('button')!);
+
+    expect(screen.getByText('billing.actions.pay').closest('button')).toHaveProperty(
+      'disabled',
+      true,
+    );
+    expect(screen.getByText('billing.currentSubscription.purchaseBlocked')).toBeTruthy();
+  });
+
+  it('fails closed for subscription purchases when subscription status is unavailable', async () => {
+    window.electronAPI.billing.getCurrentSubscription = vi.fn(async () => {
+      throw new Error('subscription status unavailable');
+    });
+
+    render(<BillingPage />);
+
+    expect(await screen.findByText('billing.settings.subscriptionCard.unavailable')).toBeTruthy();
+    expect(
+      screen.getByText('billing.settings.subscriptionCard.action').closest('button'),
+    ).toHaveProperty('disabled', true);
+    expect(screen.getByText('billing.settings.topupCard.action').closest('button')).toHaveProperty(
+      'disabled',
+      false,
+    );
+  });
+
+  it('renders multiple remote subscription offers as independent choices', async () => {
+    window.electronAPI.billing.getCatalog = vi.fn(async () => ({
+      products: (['alipay', 'stripe', 'alipay'] as const).map((provider, index) => ({
+        code: `plan_${index + 1}`,
+        name: `Remote plan ${index + 1}`,
+        kind: 'SUBSCRIPTION' as const,
+        level: index + 1,
+        sortOrder: index + 1,
+        offers: [
+          {
+            code: `plan_${index + 1}_month`,
+            interval: 'MONTH' as const,
+            currency: 'cny',
+            amount: String(index + 1),
+            minAmount: null,
+            maxAmount: null,
+            creditAmount: String((index + 1) * 100),
+            rolloverCap: '0',
+            purchaseOptions: [
+              {
+                id: `listing_${provider}_${index + 1}`,
+                provider,
+                capability: 'PROVIDER_MANAGED_SUBSCRIPTION' as const,
+                paymentAction: provider === 'alipay' ? ('QR_CODE' as const) : ('REDIRECT' as const),
+              },
+            ],
+          },
+        ],
+      })),
+    }));
+
+    render(<BillingPage />);
+    const viewPlans = screen
+      .getByText('billing.settings.subscriptionCard.action')
+      .closest('button')!;
+    await waitFor(() => expect(viewPlans).toHaveProperty('disabled', false));
+    fireEvent.click(viewPlans);
+
+    const planButtons = await screen.findAllByRole('button', { name: /Remote plan/ });
+    expect(planButtons).toHaveLength(3);
+    expect(planButtons.map((button) => button.getAttribute('aria-pressed'))).toEqual([
+      'false',
+      'false',
+      'false',
+    ]);
+
+    fireEvent.click(planButtons[1]);
+    expect(planButtons[1].getAttribute('aria-pressed')).toBe('true');
+    expect(await screen.findByText('stripe')).toBeTruthy();
+    expect(screen.queryByText('alipay')).toBeNull();
+  });
+
+  it('shows a generic payment success message without fulfillment details', async () => {
+    Object.assign(checkout.state, {
+      open: true,
+      kind: 'TOPUP',
+      phase: 'COMPLETED',
+      order: {
+        orderId: 'order_paid',
+        productCode: 'credit_topup',
+        offerCode: 'credit_topup_custom',
+        amount: '10',
+        currency: 'cny',
+        status: 'SUCCEEDED',
+        fulfillmentStatus: 'FAILED',
+        paymentAction: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:01:00.000Z',
+      },
+    });
+
+    render(<BillingPage />);
+    await screen.findByText('billing.settings.subscriptionCard.empty');
+
+    expect(screen.getByText('billing.checkout.completedTitle')).toBeTruthy();
+    expect(screen.getByText('billing.checkout.paymentCompleted')).toBeTruthy();
+    expect(screen.queryByText('billing.checkout.fulfillingTitle')).toBeNull();
+    expect(screen.queryByText('billing.checkout.creditingBody')).toBeNull();
+  });
+
+  it('allows an uncertain failed checkout to be dismissed for later recovery', async () => {
+    Object.assign(checkout.state, {
+      open: true,
+      kind: 'TOPUP',
+      phase: 'FAILED',
+      intent: {
+        version: 1,
+        kind: 'TOPUP',
+        idempotencyKey: 'desktop:topup:fixture-0001',
+        request: {
+          offerCode: 'credit_topup_custom',
+          amount: '10',
+          purchaseOptionId: 'listing_alipay',
+        },
+        orderId: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      order: null,
+      subscription: null,
+      error: true,
+    });
+
+    render(<BillingPage />);
+    await screen.findByText('billing.checkout.requestFailed');
+    fireEvent.click(screen.getByLabelText('billing.actions.close'));
+
+    expect(checkout.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/features/billing/__tests__/api.test.ts
+++ b/apps/desktop/src/renderer/features/billing/__tests__/api.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { billingApi } from '../api';
+
+describe('billing renderer API', () => {
+  const billing = {
+    getBalance: vi.fn(),
+    listOrders: vi.fn(),
+    createTopup: vi.fn(),
+    openPaymentRedirect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    billing.getBalance.mockReset().mockResolvedValue({ available: '12.34' });
+    billing.listOrders.mockReset().mockResolvedValue({ orders: [], nextCursor: null });
+    billing.createTopup.mockReset().mockResolvedValue({ orderId: 'order_fixture' });
+    billing.openPaymentRedirect.mockReset().mockResolvedValue({ success: true });
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { billing },
+    });
+  });
+
+  it('queries the current account balance without accepting renderer parameters', async () => {
+    await billingApi.getBalance();
+    expect(billing.getBalance).toHaveBeenCalledWith();
+  });
+
+  it('uses the bounded default order page size', async () => {
+    await billingApi.listOrders();
+    expect(billing.listOrders).toHaveBeenCalledWith({ limit: 20 });
+  });
+
+  it('keeps the request and idempotency key inside the fixed create method', async () => {
+    const request = {
+      offerCode: 'credit_topup_custom',
+      amount: '20.00',
+      purchaseOptionId: 'listing_alipay',
+    };
+    await billingApi.createTopup(request, 'desktop:topup:fixture-0001');
+    expect(billing.createTopup).toHaveBeenCalledWith({
+      request,
+      idempotencyKey: 'desktop:topup:fixture-0001',
+    });
+  });
+
+  it('uses the dedicated billing redirect method', async () => {
+    const url = 'https://checkout.stripe.com/c/pay/session_fixture';
+    await billingApi.openPaymentRedirect(url);
+    expect(billing.openPaymentRedirect).toHaveBeenCalledWith({ url });
+  });
+});

--- a/apps/desktop/src/renderer/features/billing/__tests__/checkoutIntent.test.ts
+++ b/apps/desktop/src/renderer/features/billing/__tests__/checkoutIntent.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  billingCheckoutIntentKey,
+  clearBillingCheckoutIntent,
+  newBillingIdempotencyKey,
+  readBillingCheckoutIntent,
+  writeBillingCheckoutIntent,
+} from '../checkoutIntent';
+
+const ACCOUNT_A = 'account-a';
+const ACCOUNT_B = 'account-b';
+
+describe('billing checkout intent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('round-trips a valid top-up intent', () => {
+    const intent = {
+      version: 1 as const,
+      kind: 'TOPUP' as const,
+      idempotencyKey: 'desktop:topup:fixture-0001',
+      request: {
+        offerCode: 'credit_topup_custom',
+        amount: '20.00',
+        purchaseOptionId: 'listing_alipay',
+      },
+      orderId: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    writeBillingCheckoutIntent(ACCOUNT_A, intent);
+    expect(readBillingCheckoutIntent(ACCOUNT_A)).toEqual(intent);
+    clearBillingCheckoutIntent(ACCOUNT_A);
+    expect(readBillingCheckoutIntent(ACCOUNT_A)).toBeNull();
+  });
+
+  it('removes malformed or future-version storage', () => {
+    localStorage.setItem(
+      billingCheckoutIntentKey(ACCOUNT_A),
+      JSON.stringify({ version: 2, kind: 'TOPUP' }),
+    );
+    expect(readBillingCheckoutIntent(ACCOUNT_A)).toBeNull();
+    expect(localStorage.getItem(billingCheckoutIntentKey(ACCOUNT_A))).toBeNull();
+  });
+
+  it('removes intents containing undeclared response or payment fields', () => {
+    localStorage.setItem(
+      billingCheckoutIntentKey(ACCOUNT_A),
+      JSON.stringify({
+        version: 1,
+        kind: 'TOPUP_RETRY',
+        idempotencyKey: 'desktop:retry:fixture-0001',
+        orderId: 'order_fixture',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        paymentUrl: 'https://pay.example.test/should-not-persist',
+      }),
+    );
+    expect(readBillingCheckoutIntent(ACCOUNT_A)).toBeNull();
+    expect(localStorage.getItem(billingCheckoutIntentKey(ACCOUNT_A))).toBeNull();
+  });
+
+  it('creates a fresh namespaced idempotency key per user action', () => {
+    vi.stubGlobal('crypto', { randomUUID: () => '00000000-0000-4000-8000-000000000001' });
+    expect(newBillingIdempotencyKey('subscription')).toBe(
+      'desktop:subscription:00000000-0000-4000-8000-000000000001',
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('round-trips a retry intent without storing catalog or provider data', () => {
+    const intent = {
+      version: 1 as const,
+      kind: 'TOPUP_RETRY' as const,
+      idempotencyKey: 'desktop:retry:fixture-0001',
+      orderId: 'order_fixture',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    writeBillingCheckoutIntent(ACCOUNT_A, intent);
+    expect(readBillingCheckoutIntent(ACCOUNT_A)).toEqual(intent);
+  });
+
+  it('keeps checkout recovery isolated between accounts', () => {
+    const intent = {
+      version: 1 as const,
+      kind: 'TOPUP_RETRY' as const,
+      idempotencyKey: 'desktop:retry:fixture-0001',
+      orderId: 'order_fixture',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    writeBillingCheckoutIntent(ACCOUNT_A, intent);
+
+    expect(readBillingCheckoutIntent(ACCOUNT_B)).toBeNull();
+    expect(readBillingCheckoutIntent(ACCOUNT_A)).toEqual(intent);
+  });
+
+  it('drops legacy unscoped recovery instead of assigning it to the active account', () => {
+    localStorage.setItem(
+      'cindy.billing.checkout-intent.v1',
+      JSON.stringify({
+        version: 1,
+        kind: 'TOPUP_RETRY',
+        idempotencyKey: 'desktop:retry:fixture-0001',
+        orderId: 'order_fixture',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+
+    expect(readBillingCheckoutIntent(ACCOUNT_A)).toBeNull();
+    expect(localStorage.getItem('cindy.billing.checkout-intent.v1')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/features/billing/__tests__/useBillingCheckout.test.ts
+++ b/apps/desktop/src/renderer/features/billing/__tests__/useBillingCheckout.test.ts
@@ -1,0 +1,379 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const api = vi.hoisted(() => ({
+  listOrders: vi.fn(),
+  getCurrentSubscription: vi.fn(),
+  createTopup: vi.fn(),
+  createSubscription: vi.fn(),
+  retryTopup: vi.fn(),
+  refreshTopup: vi.fn(),
+  refreshSubscriptionPurchase: vi.fn(),
+  getOrder: vi.fn(),
+}));
+
+vi.mock('../api', () => ({ billingApi: api }));
+
+import {
+  isRecoverableTopup,
+  phaseForOrder,
+  phaseForSubscription,
+  useBillingCheckout,
+} from '../useBillingCheckout';
+import { readBillingCheckoutIntent, writeBillingCheckoutIntent } from '../checkoutIntent';
+
+const ACCOUNT_ID = 'account-fixture';
+
+describe('billing checkout phase projection', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    api.listOrders.mockReset().mockResolvedValue({ orders: [], nextCursor: null });
+    api.getCurrentSubscription.mockReset().mockResolvedValue({ subscription: null });
+    api.createTopup.mockReset();
+    api.createSubscription.mockReset();
+    api.retryTopup.mockReset();
+    api.refreshTopup.mockReset();
+    api.refreshSubscriptionPurchase.mockReset();
+    api.getOrder.mockReset();
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    vi.stubGlobal('crypto', {
+      randomUUID: () => '00000000-0000-4000-8000-000000000001',
+    });
+  });
+
+  it('shows paid top-ups as completed without exposing fulfillment state', () => {
+    const base = {
+      orderId: 'order_fixture',
+      productCode: 'credit_topup',
+      offerCode: 'credit_topup_20',
+      amount: '20',
+      currency: 'cny',
+      status: 'SUCCEEDED' as const,
+      paymentAction: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:01:00.000Z',
+    };
+    expect(phaseForOrder(base)).toBe('COMPLETED');
+    expect(phaseForOrder({ ...base, fulfillmentStatus: 'PENDING' })).toBe('COMPLETED');
+    expect(phaseForOrder({ ...base, fulfillmentStatus: 'SUCCEEDED' })).toBe('COMPLETED');
+    expect(phaseForOrder({ ...base, fulfillmentStatus: 'FAILED' })).toBe('COMPLETED');
+  });
+
+  it('shows active subscriptions as paid without exposing entitlement state', () => {
+    const base = {
+      subscriptionId: 'subscription_fixture',
+      status: 'ACTIVE' as const,
+      currentPeriodStartAt: null,
+      currentPeriodEndAt: null,
+      entitlementValidUntil: null,
+      cancelAtPeriodEnd: false,
+      effectivePlan: null,
+      purchaseAttemptId: null,
+      paymentAction: null,
+    };
+    expect(phaseForSubscription(base)).toBe('COMPLETED');
+    expect(phaseForSubscription({ ...base, entitlementStatus: 'SUCCEEDED' })).toBe('COMPLETED');
+    expect(phaseForSubscription({ ...base, entitlementStatus: 'FAILED' })).toBe('COMPLETED');
+  });
+
+  it('lets the server confirm expiry instead of trusting the client clock', () => {
+    expect(
+      isRecoverableTopup({
+        status: 'PENDING',
+        paymentAction: {
+          expiresAt: '2000-01-01T00:00:00.000Z',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps created top-ups with a payment action recoverable', () => {
+    expect(
+      isRecoverableTopup({
+        status: 'CREATED',
+        paymentAction: {
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('replays an unresolved persisted purchase with the original request and key', async () => {
+    const pending = {
+      subscriptionId: 'subscription_pending',
+      status: 'INCOMPLETE' as const,
+      currentPeriodStartAt: null,
+      currentPeriodEndAt: null,
+      entitlementValidUntil: null,
+      cancelAtPeriodEnd: false,
+      effectivePlan: null,
+      purchaseAttemptId: 'purchase_pending',
+      paymentAction: {
+        type: 'QR_CODE' as const,
+        value: 'alipays://pending',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      },
+    };
+    api.createSubscription.mockResolvedValue(pending);
+    writeBillingCheckoutIntent(ACCOUNT_ID, {
+      version: 1,
+      kind: 'SUBSCRIPTION',
+      idempotencyKey: 'desktop:subscription:stale-intent',
+      request: {
+        offerCode: 'retired_plus_month',
+        purchaseOptionId: 'listing_alipay',
+      },
+      subscriptionId: null,
+      purchaseAttemptId: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const { result } = renderHook(() => useBillingCheckout(ACCOUNT_ID));
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+
+    expect(api.listOrders).toHaveBeenCalledTimes(1);
+    expect(api.getCurrentSubscription).toHaveBeenCalledTimes(1);
+    expect(api.createTopup).not.toHaveBeenCalled();
+    expect(api.createSubscription).toHaveBeenCalledWith(
+      {
+        offerCode: 'retired_plus_month',
+        purchaseOptionId: 'listing_alipay',
+      },
+      'desktop:subscription:stale-intent',
+    );
+    expect(result.current.state.open).toBe(true);
+    expect(result.current.state.phase).toBe('AWAITING_PAYMENT');
+    expect(readBillingCheckoutIntent(ACCOUNT_ID)).toEqual({
+      version: 1,
+      kind: 'SUBSCRIPTION',
+      idempotencyKey: 'desktop:subscription:stale-intent',
+      request: {
+        offerCode: 'retired_plus_month',
+        purchaseOptionId: 'listing_alipay',
+      },
+      subscriptionId: 'subscription_pending',
+      purchaseAttemptId: 'purchase_pending',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('does not replace a persisted subscription intent with another current subscription', async () => {
+    const intent = {
+      version: 1 as const,
+      kind: 'SUBSCRIPTION' as const,
+      idempotencyKey: 'desktop:subscription:pending-intent',
+      request: {
+        offerCode: 'plus_month',
+        purchaseOptionId: 'listing_alipay',
+      },
+      subscriptionId: 'subscription_expected',
+      purchaseAttemptId: 'purchase_expected',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    const unrelated = {
+      subscriptionId: 'subscription_other',
+      status: 'ACTIVE' as const,
+      currentPeriodStartAt: null,
+      currentPeriodEndAt: null,
+      entitlementValidUntil: null,
+      cancelAtPeriodEnd: false,
+      effectivePlan: null,
+      purchaseAttemptId: 'purchase_other',
+      paymentAction: null,
+    };
+    writeBillingCheckoutIntent(ACCOUNT_ID, intent);
+    api.getCurrentSubscription.mockResolvedValue({ subscription: unrelated });
+    api.refreshSubscriptionPurchase.mockResolvedValue(unrelated);
+
+    const { result } = renderHook(() => useBillingCheckout(ACCOUNT_ID));
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+
+    expect(api.refreshSubscriptionPurchase).toHaveBeenCalledWith('purchase_expected');
+    expect(result.current.state).toMatchObject({
+      phase: 'FAILED',
+      intent,
+      subscription: null,
+      error: true,
+    });
+    expect(readBillingCheckoutIntent(ACCOUNT_ID)).toEqual(intent);
+  });
+
+  it('keeps an unresolved persisted purchase retryable when recovery fails', async () => {
+    const intent = {
+      version: 1 as const,
+      kind: 'TOPUP' as const,
+      idempotencyKey: 'desktop:topup:unresolved-intent',
+      request: {
+        offerCode: 'credit_topup_custom',
+        amount: '20',
+        purchaseOptionId: 'listing_alipay',
+      },
+      orderId: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    writeBillingCheckoutIntent(ACCOUNT_ID, intent);
+    api.createTopup.mockRejectedValue(new Error('network result unknown'));
+
+    const { result } = renderHook(() => useBillingCheckout(ACCOUNT_ID));
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+
+    expect(result.current.state).toMatchObject({
+      open: true,
+      kind: 'TOPUP',
+      phase: 'FAILED',
+      intent,
+      error: true,
+    });
+    expect(readBillingCheckoutIntent(ACCOUNT_ID)).toEqual(intent);
+    act(() => result.current.close());
+    expect(result.current.state.open).toBe(false);
+    expect(readBillingCheckoutIntent(ACCOUNT_ID)).toEqual(intent);
+  });
+
+  it('does not bind an unidentified intent to another pending subscription', async () => {
+    const unrelated = {
+      subscriptionId: 'subscription_other',
+      status: 'INCOMPLETE' as const,
+      currentPeriodStartAt: null,
+      currentPeriodEndAt: null,
+      entitlementValidUntil: null,
+      cancelAtPeriodEnd: false,
+      effectivePlan: null,
+      purchaseAttemptId: 'purchase_other',
+      paymentAction: {
+        type: 'QR_CODE' as const,
+        value: 'alipays://pending',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      },
+    };
+    api.createSubscription.mockRejectedValue(new Error('SUBSCRIPTION_NOT_MANAGEABLE'));
+    api.getCurrentSubscription
+      .mockResolvedValueOnce({ subscription: null })
+      .mockResolvedValueOnce({ subscription: unrelated });
+
+    const { result } = renderHook(() => useBillingCheckout(ACCOUNT_ID));
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+
+    await act(async () =>
+      result.current.startSubscription({
+        offerCode: 'plus_month',
+        purchaseOptionId: 'listing_alipay',
+      }),
+    );
+
+    expect(api.getCurrentSubscription).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toMatchObject({
+      phase: 'FAILED',
+      subscription: null,
+      error: true,
+    });
+    expect(result.current.state.intent).toMatchObject({
+      subscriptionId: null,
+      purchaseAttemptId: null,
+    });
+  });
+
+  it('reuses the same retry key while the retry result is unknown', async () => {
+    const failedOrder = {
+      orderId: 'order_fixture',
+      productCode: 'credit_topup',
+      offerCode: 'credit_topup_20',
+      amount: '20',
+      currency: 'cny',
+      status: 'FAILED' as const,
+      paymentAction: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:01:00.000Z',
+    };
+    api.retryTopup.mockRejectedValue(new Error('network result unknown'));
+
+    const { result } = renderHook(() => useBillingCheckout(ACCOUNT_ID));
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+
+    act(() => result.current.resumeTopup(failedOrder));
+    await act(async () => result.current.retry());
+    await act(async () => result.current.retry());
+
+    expect(api.retryTopup).toHaveBeenCalledTimes(2);
+    expect(api.retryTopup.mock.calls[0]).toEqual(api.retryTopup.mock.calls[1]);
+    expect(api.retryTopup.mock.calls[0]).toEqual([
+      'order_fixture',
+      'desktop:retry:00000000-0000-4000-8000-000000000001',
+    ]);
+  });
+
+  it('refreshes on focus without allowing concurrent status requests', async () => {
+    const pendingOrder = {
+      orderId: 'order_fixture',
+      productCode: 'credit_topup',
+      offerCode: 'credit_topup_20',
+      amount: '20',
+      currency: 'cny',
+      status: 'PENDING' as const,
+      paymentAction: {
+        type: 'QR_CODE' as const,
+        value: 'https://pay.example.test/checkout/fixture',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:01:00.000Z',
+    };
+    let resolveRefresh: ((value: typeof pendingOrder) => void) | null = null;
+    api.refreshTopup.mockImplementation(
+      () =>
+        new Promise<typeof pendingOrder>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useBillingCheckout(ACCOUNT_ID));
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    act(() => result.current.resumeTopup(pendingOrder));
+    await waitFor(() => expect(result.current.state.phase).toBe('AWAITING_PAYMENT'));
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+      window.dispatchEvent(new Event('focus'));
+    });
+    await waitFor(() => expect(api.refreshTopup).toHaveBeenCalledTimes(1));
+
+    await act(async () => resolveRefresh?.(pendingOrder));
+    expect(api.refreshTopup).toHaveBeenCalledWith('order_fixture');
+  });
+
+  it('keeps a pending checkout recoverable after its dialog is closed', async () => {
+    const pendingOrder = {
+      orderId: 'order_pending',
+      productCode: 'credit_topup',
+      offerCode: 'credit_topup_20',
+      amount: '20',
+      currency: 'cny',
+      status: 'PENDING' as const,
+      paymentAction: {
+        type: 'QR_CODE' as const,
+        value: 'https://pay.example.test/checkout/pending',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:01:00.000Z',
+    };
+
+    const { result } = renderHook(() => useBillingCheckout(ACCOUNT_ID));
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+
+    act(() => result.current.resumeTopup(pendingOrder));
+    act(() => result.current.close());
+
+    expect(result.current.state.open).toBe(false);
+    expect(result.current.recoverables.topups).toEqual([pendingOrder]);
+
+    act(() => result.current.resumeTopup(result.current.recoverables.topups[0]));
+    expect(result.current.state.open).toBe(true);
+    expect(result.current.state.order).toEqual(pendingOrder);
+  });
+});

--- a/apps/desktop/src/renderer/features/billing/api.ts
+++ b/apps/desktop/src/renderer/features/billing/api.ts
@@ -1,0 +1,55 @@
+import type {
+  BillingCatalog,
+  BillingCurrentSubscription,
+  BillingOrderList,
+  BillingPaymentOrder,
+  BillingSubscription,
+  CreateBillingSubscriptionRequest,
+  CreateBillingTopupRequest,
+} from '../../../shared/billing';
+import type { ModelAccessBalance } from '../../../shared/modelAccess';
+
+export const billingApi = {
+  getBalance(): Promise<ModelAccessBalance> {
+    return window.electronAPI.billing.getBalance();
+  },
+  getCatalog(): Promise<BillingCatalog> {
+    return window.electronAPI.billing.getCatalog();
+  },
+  listOrders(limit = 20): Promise<BillingOrderList> {
+    return window.electronAPI.billing.listOrders({ limit });
+  },
+  getOrder(orderId: string): Promise<BillingPaymentOrder> {
+    return window.electronAPI.billing.getOrder({ orderId });
+  },
+  createTopup(
+    request: CreateBillingTopupRequest,
+    idempotencyKey: string,
+  ): Promise<BillingPaymentOrder> {
+    return window.electronAPI.billing.createTopup({ request, idempotencyKey });
+  },
+  refreshTopup(orderId: string): Promise<BillingPaymentOrder> {
+    return window.electronAPI.billing.refreshTopup({ orderId });
+  },
+  cancelTopup(orderId: string): Promise<BillingPaymentOrder> {
+    return window.electronAPI.billing.cancelTopup({ orderId });
+  },
+  retryTopup(orderId: string, idempotencyKey: string): Promise<BillingPaymentOrder> {
+    return window.electronAPI.billing.retryTopup({ orderId, idempotencyKey });
+  },
+  createSubscription(
+    request: CreateBillingSubscriptionRequest,
+    idempotencyKey: string,
+  ): Promise<BillingSubscription> {
+    return window.electronAPI.billing.createSubscription({ request, idempotencyKey });
+  },
+  getCurrentSubscription(): Promise<BillingCurrentSubscription> {
+    return window.electronAPI.billing.getCurrentSubscription();
+  },
+  refreshSubscriptionPurchase(purchaseAttemptId: string): Promise<BillingSubscription> {
+    return window.electronAPI.billing.refreshSubscriptionPurchase({ purchaseAttemptId });
+  },
+  openPaymentRedirect(url: string): Promise<{ success: boolean }> {
+    return window.electronAPI.billing.openPaymentRedirect({ url });
+  },
+};

--- a/apps/desktop/src/renderer/features/billing/checkoutIntent.ts
+++ b/apps/desktop/src/renderer/features/billing/checkoutIntent.ts
@@ -1,0 +1,162 @@
+import type {
+  CreateBillingSubscriptionRequest,
+  CreateBillingTopupRequest,
+} from '../../../shared/billing';
+
+const LEGACY_BILLING_CHECKOUT_INTENT_KEY = 'cindy.billing.checkout-intent.v1';
+const BILLING_CHECKOUT_INTENT_KEY_PREFIX = 'cindy.billing.checkout-intent.v2';
+
+export type BillingCheckoutIntentV1 =
+  | {
+      version: 1;
+      kind: 'TOPUP';
+      idempotencyKey: string;
+      request: CreateBillingTopupRequest;
+      orderId: string | null;
+      createdAt: string;
+    }
+  | {
+      version: 1;
+      kind: 'SUBSCRIPTION';
+      idempotencyKey: string;
+      request: CreateBillingSubscriptionRequest;
+      subscriptionId: string | null;
+      purchaseAttemptId: string | null;
+      createdAt: string;
+    }
+  | {
+      version: 1;
+      kind: 'TOPUP_RETRY';
+      idempotencyKey: string;
+      orderId: string;
+      createdAt: string;
+    };
+
+const KEY_PATTERN = /^[A-Za-z0-9._:-]{8,128}$/;
+const CODE_PATTERN = /^[a-z][a-z0-9_]{1,63}$/;
+const AMOUNT_PATTERN = /^(0|[1-9]\d{0,14})(?:\.\d{1,9})?$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRequiredString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 128;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).every((key) => keys.includes(key));
+}
+
+function isTopupRequest(value: unknown): value is CreateBillingTopupRequest {
+  if (!isRecord(value)) return false;
+  return (
+    hasOnlyKeys(value, ['offerCode', 'amount', 'purchaseOptionId']) &&
+    typeof value.offerCode === 'string' &&
+    CODE_PATTERN.test(value.offerCode) &&
+    isRequiredString(value.purchaseOptionId) &&
+    (value.amount === undefined ||
+      (typeof value.amount === 'string' && AMOUNT_PATTERN.test(value.amount)))
+  );
+}
+
+function isSubscriptionRequest(value: unknown): value is CreateBillingSubscriptionRequest {
+  if (!isRecord(value)) return false;
+  return (
+    hasOnlyKeys(value, ['offerCode', 'purchaseOptionId']) &&
+    typeof value.offerCode === 'string' &&
+    CODE_PATTERN.test(value.offerCode) &&
+    isRequiredString(value.purchaseOptionId)
+  );
+}
+
+export function isBillingCheckoutIntent(value: unknown): value is BillingCheckoutIntentV1 {
+  if (
+    !isRecord(value) ||
+    value.version !== 1 ||
+    typeof value.idempotencyKey !== 'string' ||
+    !KEY_PATTERN.test(value.idempotencyKey) ||
+    typeof value.createdAt !== 'string' ||
+    !Number.isFinite(Date.parse(value.createdAt))
+  )
+    return false;
+  if (value.kind === 'TOPUP') {
+    return (
+      hasOnlyKeys(value, [
+        'version',
+        'kind',
+        'idempotencyKey',
+        'request',
+        'orderId',
+        'createdAt',
+      ]) &&
+      isTopupRequest(value.request) &&
+      (value.orderId === null || isRequiredString(value.orderId))
+    );
+  }
+  if (value.kind === 'SUBSCRIPTION') {
+    return (
+      hasOnlyKeys(value, [
+        'version',
+        'kind',
+        'idempotencyKey',
+        'request',
+        'subscriptionId',
+        'purchaseAttemptId',
+        'createdAt',
+      ]) &&
+      isSubscriptionRequest(value.request) &&
+      (value.subscriptionId === null || isRequiredString(value.subscriptionId)) &&
+      (value.purchaseAttemptId === null || isRequiredString(value.purchaseAttemptId))
+    );
+  }
+  if (value.kind === 'TOPUP_RETRY') {
+    return (
+      hasOnlyKeys(value, ['version', 'kind', 'idempotencyKey', 'orderId', 'createdAt']) &&
+      isRequiredString(value.orderId)
+    );
+  }
+  return false;
+}
+
+export function billingCheckoutIntentKey(accountId: string): string {
+  return `${BILLING_CHECKOUT_INTENT_KEY_PREFIX}:${encodeURIComponent(accountId)}`;
+}
+
+export function readBillingCheckoutIntent(accountId: string): BillingCheckoutIntentV1 | null {
+  const storageKey = billingCheckoutIntentKey(accountId);
+  try {
+    // A v1 intent has no account identity and must never be replayed after an
+    // account switch. Drop it instead of guessing who created it.
+    localStorage.removeItem(LEGACY_BILLING_CHECKOUT_INTENT_KEY);
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (isBillingCheckoutIntent(parsed)) return parsed;
+    localStorage.removeItem(storageKey);
+  } catch {
+    try {
+      localStorage.removeItem(storageKey);
+    } catch {
+      // Storage is unavailable; checkout remains server-recoverable.
+    }
+  }
+  return null;
+}
+
+export function writeBillingCheckoutIntent(
+  accountId: string,
+  intent: BillingCheckoutIntentV1,
+): void {
+  localStorage.removeItem(LEGACY_BILLING_CHECKOUT_INTENT_KEY);
+  localStorage.setItem(billingCheckoutIntentKey(accountId), JSON.stringify(intent));
+}
+
+export function clearBillingCheckoutIntent(accountId: string): void {
+  localStorage.removeItem(LEGACY_BILLING_CHECKOUT_INTENT_KEY);
+  localStorage.removeItem(billingCheckoutIntentKey(accountId));
+}
+
+export function newBillingIdempotencyKey(kind: 'topup' | 'subscription' | 'retry'): string {
+  return `desktop:${kind}:${crypto.randomUUID()}`;
+}

--- a/apps/desktop/src/renderer/features/billing/useBillingCheckout.ts
+++ b/apps/desktop/src/renderer/features/billing/useBillingCheckout.ts
@@ -1,0 +1,554 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type {
+  BillingPaymentOrder,
+  BillingSubscription,
+  CreateBillingSubscriptionRequest,
+  CreateBillingTopupRequest,
+} from '../../../shared/billing';
+import { billingApi } from './api';
+import {
+  clearBillingCheckoutIntent,
+  newBillingIdempotencyKey,
+  readBillingCheckoutIntent,
+  writeBillingCheckoutIntent,
+  type BillingCheckoutIntentV1,
+} from './checkoutIntent';
+
+export type BillingCheckoutPhase =
+  'IDLE' | 'CREATING' | 'AWAITING_PAYMENT' | 'COMPLETED' | 'FAILED' | 'EXPIRED' | 'CANCELED';
+
+export type BillingCheckoutState = {
+  open: boolean;
+  kind: 'TOPUP' | 'SUBSCRIPTION' | null;
+  phase: BillingCheckoutPhase;
+  intent: BillingCheckoutIntentV1 | null;
+  order: BillingPaymentOrder | null;
+  subscription: BillingSubscription | null;
+  error: boolean;
+};
+
+export type BillingRecoverables = {
+  topups: BillingPaymentOrder[];
+  subscription: BillingSubscription | null;
+};
+
+const INITIAL_STATE: BillingCheckoutState = {
+  open: false,
+  kind: null,
+  phase: 'IDLE',
+  intent: null,
+  order: null,
+  subscription: null,
+  error: false,
+};
+
+function phaseForOrder(order: BillingPaymentOrder): BillingCheckoutPhase {
+  if (order.status === 'FAILED') return 'FAILED';
+  if (order.status === 'EXPIRED') return 'EXPIRED';
+  if (order.status === 'CANCELED') return 'CANCELED';
+  if (order.status === 'SUCCEEDED') return 'COMPLETED';
+  return 'AWAITING_PAYMENT';
+}
+
+function phaseForSubscription(subscription: BillingSubscription): BillingCheckoutPhase {
+  if (subscription.status === 'INCOMPLETE') return 'AWAITING_PAYMENT';
+  if (subscription.status === 'INCOMPLETE_EXPIRED') return 'EXPIRED';
+  if (subscription.status === 'CANCELED') return 'CANCELED';
+  if (subscription.status === 'TRIALING' || subscription.status === 'ACTIVE') return 'COMPLETED';
+  return 'FAILED';
+}
+
+function isTerminal(phase: BillingCheckoutPhase): boolean {
+  return ['COMPLETED', 'FAILED', 'EXPIRED', 'CANCELED'].includes(phase);
+}
+
+function isRecoverableTopup(value: {
+  status: string;
+  paymentAction: { expiresAt: string } | null;
+}): boolean {
+  return (value.status === 'CREATED' || value.status === 'PENDING') && value.paymentAction !== null;
+}
+
+function persistIntent(accountId: string | null, intent: BillingCheckoutIntentV1 | null): void {
+  if (!accountId) return;
+  try {
+    if (intent) writeBillingCheckoutIntent(accountId, intent);
+    else clearBillingCheckoutIntent(accountId);
+  } catch {
+    // Server recovery remains available when browser storage is unavailable.
+  }
+}
+
+function matchesSubscriptionIntent(
+  subscription: BillingSubscription,
+  intent: Extract<BillingCheckoutIntentV1, { kind: 'SUBSCRIPTION' }>,
+): boolean {
+  if (intent.subscriptionId && subscription.subscriptionId !== intent.subscriptionId) return false;
+  if (intent.purchaseAttemptId && subscription.purchaseAttemptId !== intent.purchaseAttemptId)
+    return false;
+  return true;
+}
+
+export function useBillingCheckout(accountId: string | null) {
+  const [state, setState] = useState<BillingCheckoutState>(INITIAL_STATE);
+  const [recoverables, setRecoverables] = useState<BillingRecoverables>({
+    topups: [],
+    subscription: null,
+  });
+  const [recovering, setRecovering] = useState(true);
+  const stateRef = useRef(state);
+  const mountedRef = useRef(true);
+  const inFlightRef = useRef(false);
+  stateRef.current = state;
+
+  const applyOrder = useCallback(
+    (order: BillingPaymentOrder, intent: BillingCheckoutIntentV1 | null) => {
+      const nextIntent =
+        intent?.kind === 'TOPUP' && intent.orderId !== order.orderId
+          ? { ...intent, orderId: order.orderId }
+          : intent;
+      const phase = phaseForOrder(order);
+      if (nextIntent && !isTerminal(phase)) persistIntent(accountId, nextIntent);
+      if (isTerminal(phase)) persistIntent(accountId, null);
+      if (!mountedRef.current) return;
+      setRecoverables((current) => ({
+        ...current,
+        topups: isRecoverableTopup(order)
+          ? [order, ...current.topups.filter((item) => item.orderId !== order.orderId)]
+          : current.topups.filter((item) => item.orderId !== order.orderId),
+      }));
+      setState({
+        open: true,
+        kind: 'TOPUP',
+        phase,
+        intent: nextIntent,
+        order,
+        subscription: null,
+        error: false,
+      });
+    },
+    [accountId],
+  );
+
+  const applySubscription = useCallback(
+    (subscription: BillingSubscription, intent: BillingCheckoutIntentV1 | null) => {
+      if (intent?.kind === 'SUBSCRIPTION' && !matchesSubscriptionIntent(subscription, intent))
+        return false;
+      const nextIntent =
+        intent?.kind === 'SUBSCRIPTION'
+          ? {
+              ...intent,
+              subscriptionId: subscription.subscriptionId,
+              purchaseAttemptId: subscription.purchaseAttemptId,
+            }
+          : intent;
+      const phase = phaseForSubscription(subscription);
+      if (nextIntent && !isTerminal(phase)) persistIntent(accountId, nextIntent);
+      if (isTerminal(phase)) persistIntent(accountId, null);
+      if (!mountedRef.current) return true;
+      setRecoverables((current) => ({
+        ...current,
+        subscription: subscription.status === 'INCOMPLETE' ? subscription : null,
+      }));
+      setState({
+        open: true,
+        kind: 'SUBSCRIPTION',
+        phase,
+        intent: nextIntent,
+        order: null,
+        subscription,
+        error: false,
+      });
+      return true;
+    },
+    [accountId],
+  );
+
+  const failCurrentOperation = useCallback(() => {
+    if (!mountedRef.current) return;
+    setState((current) => ({ ...current, phase: 'FAILED', error: true }));
+  }, []);
+
+  const withRequestLock = useCallback(async (request: () => Promise<void>) => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      await request();
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  const startTopup = useCallback(
+    async (request: CreateBillingTopupRequest) => {
+      if (!accountId || inFlightRef.current) return;
+      const intent: BillingCheckoutIntentV1 = {
+        version: 1,
+        kind: 'TOPUP',
+        idempotencyKey: newBillingIdempotencyKey('topup'),
+        request,
+        orderId: null,
+        createdAt: new Date().toISOString(),
+      };
+      persistIntent(accountId, intent);
+      setState({
+        open: true,
+        kind: 'TOPUP',
+        phase: 'CREATING',
+        intent,
+        order: null,
+        subscription: null,
+        error: false,
+      });
+      await withRequestLock(async () => {
+        try {
+          applyOrder(await billingApi.createTopup(request, intent.idempotencyKey), intent);
+        } catch {
+          failCurrentOperation();
+        }
+      });
+    },
+    [accountId, applyOrder, failCurrentOperation, withRequestLock],
+  );
+
+  const recoverPendingSubscription = useCallback(
+    async (intent: Extract<BillingCheckoutIntentV1, { kind: 'SUBSCRIPTION' }>) => {
+      if (!intent.subscriptionId && !intent.purchaseAttemptId) return false;
+      try {
+        const current = (await billingApi.getCurrentSubscription()).subscription;
+        if (current?.status !== 'INCOMPLETE') return false;
+        return applySubscription(current, intent);
+      } catch {
+        return false;
+      }
+    },
+    [applySubscription],
+  );
+
+  const startSubscription = useCallback(
+    async (request: CreateBillingSubscriptionRequest) => {
+      if (!accountId || inFlightRef.current) return;
+      const intent: BillingCheckoutIntentV1 = {
+        version: 1,
+        kind: 'SUBSCRIPTION',
+        idempotencyKey: newBillingIdempotencyKey('subscription'),
+        request,
+        subscriptionId: null,
+        purchaseAttemptId: null,
+        createdAt: new Date().toISOString(),
+      };
+      persistIntent(accountId, intent);
+      setState({
+        open: true,
+        kind: 'SUBSCRIPTION',
+        phase: 'CREATING',
+        intent,
+        order: null,
+        subscription: null,
+        error: false,
+      });
+      await withRequestLock(async () => {
+        try {
+          applySubscription(
+            await billingApi.createSubscription(request, intent.idempotencyKey),
+            intent,
+          );
+        } catch {
+          if (!(await recoverPendingSubscription(intent))) failCurrentOperation();
+        }
+      });
+    },
+    [
+      accountId,
+      applySubscription,
+      failCurrentOperation,
+      recoverPendingSubscription,
+      withRequestLock,
+    ],
+  );
+
+  const refreshActive = useCallback(async () => {
+    await withRequestLock(async () => {
+      const current = stateRef.current;
+      try {
+        if (current.kind === 'TOPUP' && current.order) {
+          const order =
+            current.phase === 'AWAITING_PAYMENT'
+              ? await billingApi.refreshTopup(current.order.orderId)
+              : await billingApi.getOrder(current.order.orderId);
+          applyOrder(order, current.intent);
+          return;
+        }
+        if (current.kind === 'SUBSCRIPTION' && current.subscription) {
+          const subscription =
+            current.phase === 'AWAITING_PAYMENT' && current.subscription.purchaseAttemptId
+              ? await billingApi.refreshSubscriptionPurchase(current.subscription.purchaseAttemptId)
+              : (await billingApi.getCurrentSubscription()).subscription;
+          if (subscription && !applySubscription(subscription, current.intent)) {
+            failCurrentOperation();
+          }
+        }
+      } catch {
+        if (mountedRef.current) setState((value) => ({ ...value, error: true }));
+      }
+    });
+  }, [applyOrder, applySubscription, failCurrentOperation, withRequestLock]);
+
+  const retry = useCallback(async () => {
+    if (inFlightRef.current) return;
+    const current = stateRef.current;
+    if (current.error && current.intent?.kind === 'TOPUP_RETRY') {
+      await startTopupRetryWithIntent(current.intent);
+      return;
+    }
+    if (current.kind === 'TOPUP' && current.order) {
+      const intent: Extract<BillingCheckoutIntentV1, { kind: 'TOPUP_RETRY' }> = {
+        version: 1,
+        kind: 'TOPUP_RETRY',
+        idempotencyKey: newBillingIdempotencyKey('retry'),
+        orderId: current.order.orderId,
+        createdAt: new Date().toISOString(),
+      };
+      persistIntent(accountId, intent);
+      await startTopupRetryWithIntent(intent);
+      return;
+    }
+    if (current.intent && !current.order && !current.subscription) {
+      if (current.intent.kind === 'TOPUP') {
+        await startTopupWithIntent(current.intent);
+      } else if (current.intent.kind === 'SUBSCRIPTION') {
+        await startSubscriptionWithIntent(current.intent);
+      } else {
+        await startTopupRetryWithIntent(current.intent);
+      }
+    }
+  }, [accountId, applyOrder, failCurrentOperation, withRequestLock]);
+
+  async function startTopupWithIntent(intent: Extract<BillingCheckoutIntentV1, { kind: 'TOPUP' }>) {
+    setState({
+      open: true,
+      kind: 'TOPUP',
+      phase: 'CREATING',
+      intent,
+      order: null,
+      subscription: null,
+      error: false,
+    });
+    await withRequestLock(async () => {
+      try {
+        const order = intent.orderId
+          ? await billingApi.getOrder(intent.orderId)
+          : await billingApi.createTopup(intent.request, intent.idempotencyKey);
+        applyOrder(order, intent);
+      } catch {
+        failCurrentOperation();
+      }
+    });
+  }
+
+  async function startSubscriptionWithIntent(
+    intent: Extract<BillingCheckoutIntentV1, { kind: 'SUBSCRIPTION' }>,
+  ) {
+    setState({
+      open: true,
+      kind: 'SUBSCRIPTION',
+      phase: 'CREATING',
+      intent,
+      order: null,
+      subscription: null,
+      error: false,
+    });
+    await withRequestLock(async () => {
+      try {
+        const subscription = intent.purchaseAttemptId
+          ? await billingApi.refreshSubscriptionPurchase(intent.purchaseAttemptId)
+          : intent.subscriptionId
+            ? (await billingApi.getCurrentSubscription()).subscription
+            : await billingApi.createSubscription(intent.request, intent.idempotencyKey);
+        if (!subscription || !applySubscription(subscription, intent)) failCurrentOperation();
+      } catch {
+        if (!(await recoverPendingSubscription(intent))) failCurrentOperation();
+      }
+    });
+  }
+
+  async function startTopupRetryWithIntent(
+    intent: Extract<BillingCheckoutIntentV1, { kind: 'TOPUP_RETRY' }>,
+  ) {
+    const previousOrder =
+      stateRef.current.order?.orderId === intent.orderId ? stateRef.current.order : null;
+    setState({
+      open: true,
+      kind: 'TOPUP',
+      phase: 'CREATING',
+      intent,
+      order: previousOrder,
+      subscription: null,
+      error: false,
+    });
+    await withRequestLock(async () => {
+      try {
+        applyOrder(await billingApi.retryTopup(intent.orderId, intent.idempotencyKey), intent);
+      } catch {
+        failCurrentOperation();
+      }
+    });
+  }
+
+  const cancel = useCallback(async () => {
+    const current = stateRef.current;
+    if (current.kind !== 'TOPUP' || !current.order) return;
+    await withRequestLock(async () => {
+      try {
+        applyOrder(await billingApi.cancelTopup(current.order!.orderId), current.intent);
+      } catch {
+        if (mountedRef.current) setState((value) => ({ ...value, error: true }));
+      }
+    });
+  }, [applyOrder, withRequestLock]);
+
+  const close = useCallback(() => {
+    setState((current) => ({ ...current, open: false }));
+  }, []);
+
+  const resumeTopup = useCallback(
+    (order: BillingPaymentOrder) => {
+      applyOrder(order, null);
+    },
+    [applyOrder],
+  );
+
+  const resumeSubscription = useCallback(
+    (subscription: BillingSubscription) => {
+      applySubscription(subscription, null);
+    },
+    [applySubscription],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    if (!accountId) {
+      setState(INITIAL_STATE);
+      setRecoverables({ topups: [], subscription: null });
+      setRecovering(false);
+      return () => {
+        mountedRef.current = false;
+      };
+    }
+    const restore = async () => {
+      const intent = readBillingCheckoutIntent(accountId);
+      inFlightRef.current = true;
+      try {
+        const [ordersResult, subscriptionResult] = await Promise.allSettled([
+          billingApi.listOrders(),
+          billingApi.getCurrentSubscription(),
+        ]);
+        if (!mountedRef.current) return;
+        setRecoverables({
+          topups:
+            ordersResult.status === 'fulfilled'
+              ? ordersResult.value.orders.filter(isRecoverableTopup)
+              : [],
+          subscription:
+            subscriptionResult.status === 'fulfilled' &&
+            subscriptionResult.value.subscription?.status === 'INCOMPLETE'
+              ? subscriptionResult.value.subscription
+              : null,
+        });
+
+        if (!intent) return;
+        setState({
+          open: true,
+          kind: intent.kind === 'SUBSCRIPTION' ? 'SUBSCRIPTION' : 'TOPUP',
+          phase: 'CREATING',
+          intent,
+          order: null,
+          subscription: null,
+          error: false,
+        });
+        try {
+          if (intent.kind === 'TOPUP') {
+            const listedOrder =
+              intent.orderId && ordersResult.status === 'fulfilled'
+                ? ordersResult.value.orders.find((order) => order.orderId === intent.orderId)
+                : null;
+            const order =
+              listedOrder ??
+              (intent.orderId
+                ? await billingApi.getOrder(intent.orderId)
+                : await billingApi.createTopup(intent.request, intent.idempotencyKey));
+            applyOrder(order, intent);
+            return;
+          }
+
+          if (intent.kind === 'TOPUP_RETRY') {
+            applyOrder(await billingApi.retryTopup(intent.orderId, intent.idempotencyKey), intent);
+            return;
+          }
+
+          if (
+            intent.subscriptionId &&
+            !intent.purchaseAttemptId &&
+            subscriptionResult.status === 'rejected'
+          ) {
+            failCurrentOperation();
+            return;
+          }
+          const currentSubscription =
+            subscriptionResult.status === 'fulfilled'
+              ? subscriptionResult.value.subscription
+              : null;
+          const subscription = intent.purchaseAttemptId
+            ? await billingApi.refreshSubscriptionPurchase(intent.purchaseAttemptId)
+            : intent.subscriptionId
+              ? currentSubscription
+              : await billingApi.createSubscription(intent.request, intent.idempotencyKey);
+          if (!subscription || !applySubscription(subscription, intent)) failCurrentOperation();
+        } catch {
+          failCurrentOperation();
+        }
+      } finally {
+        inFlightRef.current = false;
+        if (mountedRef.current) setRecovering(false);
+      }
+    };
+    void restore();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [accountId, applyOrder, applySubscription, failCurrentOperation]);
+
+  useEffect(() => {
+    if (!state.open || state.phase !== 'AWAITING_PAYMENT') return;
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === 'visible') void refreshActive();
+    }, 3_000);
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') void refreshActive();
+    };
+    window.addEventListener('focus', onVisible);
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener('focus', onVisible);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [refreshActive, state.open, state.phase]);
+
+  return {
+    state,
+    recoverables,
+    recovering,
+    startTopup,
+    startSubscription,
+    refreshActive,
+    retry,
+    cancel,
+    close,
+    resumeTopup,
+    resumeSubscription,
+  };
+}
+
+export { isRecoverableTopup, phaseForOrder, phaseForSubscription };

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1,4 +1,151 @@
 {
+  "billing": {
+    "sidebar": "Credits & plans",
+    "settings": {
+      "title": "Usage and billing",
+      "subtitle": "Review your current subscription or purchase server-provided plans and credits.",
+      "loading": "Loading subscription status…",
+      "subscriptionCard": {
+        "title": "Current plan",
+        "empty": "No active subscription",
+        "emptyTitle": "No subscription plan",
+        "unnamedPlan": "Subscription plan",
+        "unavailable": "Subscription status is temporarily unavailable. Refresh to try again.",
+        "action": "View plans"
+      },
+      "topupCard": {
+        "title": "Credits",
+        "description": "Purchase credits for usage-based models and features.",
+        "cardTitle": "Buy credits as needed",
+        "cardDescription": "Available credit products are configured by the server.",
+        "action": "Buy credits"
+      }
+    },
+    "balance": {
+      "title": "Available balance",
+      "plan": "Plan credits",
+      "purchased": "Purchased credits",
+      "promotional": "Promotional credits",
+      "notProvisioned": "Credits have not been enabled for this account.",
+      "notSupported": "Balance lookup is not supported for this account.",
+      "unavailable": "Balance is temporarily unavailable. Refresh to try again."
+    },
+    "dialogs": {
+      "subscription": {
+        "title": "Choose a subscription plan",
+        "description": "Only currently configured server plans are shown. Choose a plan before selecting its payment method."
+      },
+      "topup": {
+        "title": "Buy credits",
+        "description": "Only currently configured server credit products are shown. Choose a product before selecting its payment method."
+      }
+    },
+    "eyebrow": "Account & usage",
+    "title": "Choose the plan that fits",
+    "subtitle": "Plans and payment methods are delivered by the server. Choose a plan first to see its currently supported payment methods.",
+    "steps": {
+      "offer": {
+        "title": "Choose a plan",
+        "description": "Only currently purchasable credit and subscription offers are shown."
+      },
+      "channel": {
+        "title": "Choose a payment method",
+        "description": "Supported payment methods can differ by plan.",
+        "selectOfferFirst": "Choose a plan to see its supported payment methods"
+      },
+      "confirm": {
+        "title": "Review and pay",
+        "description": "Review the plan and payment method before creating payment.",
+        "selectChannelFirst": "Choose a payment method to continue"
+      }
+    },
+    "actions": {
+      "refreshCatalog": "Refresh",
+      "retry": "Retry",
+      "pay": "Review and pay",
+      "refresh": "Refresh status",
+      "cancelPayment": "Cancel payment",
+      "close": "Close"
+    },
+    "catalog": {
+      "errorTitle": "Plans are temporarily unavailable",
+      "errorDescription": "Check your connection and retry. Local fallback plans will not be used.",
+      "emptyTitle": "No plans are available",
+      "emptyDescription": "The server has not configured a purchasable plan and payment method yet."
+    },
+    "offerKinds": {
+      "topup": "Credit top-up",
+      "subscription": "Subscription"
+    },
+    "amount": {
+      "custom": "Custom amount",
+      "label": "Top-up amount",
+      "placeholder": "Enter an amount",
+      "rangeHint": "Enter between {{min}} and {{max}}",
+      "rangeError": "Amount must be between {{min}} and {{max}}",
+      "formatError": "Enter a valid amount with no more than {{digits}} decimal places"
+    },
+    "intervals": {
+      "MONTH": "month",
+      "YEAR": "year"
+    },
+    "credits": "{{amount}} credits",
+    "confirm": {
+      "channel": "Pay with {{provider}}"
+    },
+    "paymentActions": {
+      "QR_CODE": "Scan to pay",
+      "REDIRECT": "Open payment page"
+    },
+    "providers": {
+      "alipay": "Alipay",
+      "stripe": "Card"
+    },
+    "securityNotice": "Payments are securely handled by the selected provider; Cindy does not store payment credentials",
+    "currentSubscription": {
+      "title": "Current subscription",
+      "purchaseBlocked": "You already have an unfinished subscription. Manage it before purchasing another plan."
+    },
+    "subscriptionStatus": {
+      "INCOMPLETE": "Awaiting payment",
+      "INCOMPLETE_EXPIRED": "Payment expired",
+      "TRIALING": "Trial",
+      "ACTIVE": "Active",
+      "PAST_DUE": "Past due",
+      "UNPAID": "Unpaid",
+      "CANCELED": "Canceled",
+      "PAUSED": "Paused"
+    },
+    "recovery": {
+      "title": "Unfinished payment found",
+      "description": "Continue the previous payment and confirm its latest state with the server.",
+      "continueTopup": "Continue {{amount}} payment",
+      "continueSubscription": "Continue subscription payment"
+    },
+    "checkout": {
+      "creatingTitle": "Creating payment",
+      "awaitingTitle": "Awaiting payment",
+      "completedTitle": "Payment successful",
+      "failedTitle": "Unable to complete",
+      "expiredTitle": "Payment expired",
+      "canceledTitle": "Payment canceled",
+      "topupSubtitle": "Credit top-up",
+      "subscriptionSubtitle": "Subscription",
+      "creatingBody": "Confirming the order with the payment service…",
+      "qrAlt": "Payment QR code",
+      "scanHint": "Scan with the corresponding payment app",
+      "checkingExpiry": "Checking expiration…",
+      "expiresIn": "QR code expires in {{minutes}}:{{seconds}}",
+      "redirectHint": "Complete payment on the provider page, then return to Cindy.",
+      "openPayment": "Open payment page",
+      "refreshingAction": "Loading payment instructions…",
+      "paymentCompleted": "Your payment was completed.",
+      "requestFailed": "The request failed. Retry safely; an uncertain create result keeps the original idempotency key.",
+      "expiredBody": "This payment link expired. Create a new payment to continue.",
+      "canceledBody": "This payment was canceled.",
+      "failedBody": "Payment failed. Try again later or contact support."
+    }
+  },
   "ipcError": {
     "SESSION_RUNNING": "This session is currently running a task. Please try again shortly.",
     "CREDENTIAL_SWITCH_BUSY": "Another Codex task is still running, so this provider switch was not applied (the session keeps its previous provider). Try again after those tasks finish."
@@ -78,6 +225,7 @@
     },
     "tabs": {
       "general": "General",
+      "billing": "Usage and billing",
       "personalization": "Personalization",
       "apiKeys": "Tool Keys",
       "voiceInput": "Voice Input",
@@ -99,6 +247,7 @@
     },
     "sections": {
       "user": "User",
+      "billing": "Usage and billing",
       "appearance": "Appearance",
       "notifications": "Notifications",
       "agentIsland": "Agent Island",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1,4 +1,151 @@
 {
+  "billing": {
+    "sidebar": "クレジットとプラン",
+    "settings": {
+      "title": "使用状況と請求",
+      "subtitle": "現在のサブスクリプションを確認し、サーバーから提供されるプランやクレジットを購入できます。",
+      "loading": "サブスクリプションの状態を取得中…",
+      "subscriptionCard": {
+        "title": "現在のプラン",
+        "empty": "有効なサブスクリプションはありません",
+        "emptyTitle": "サブスクリプションなし",
+        "unnamedPlan": "サブスクリプションプラン",
+        "unavailable": "サブスクリプションの状態を取得できません。更新してもう一度お試しください。",
+        "action": "プランを見る"
+      },
+      "topupCard": {
+        "title": "クレジット",
+        "description": "従量制のモデルや機能で使うクレジットを購入します。",
+        "cardTitle": "必要に応じてクレジットを購入",
+        "cardDescription": "購入可能なクレジット商品はサーバーで設定されます。",
+        "action": "クレジットを購入"
+      }
+    },
+    "balance": {
+      "title": "利用可能残高",
+      "plan": "プランクレジット",
+      "purchased": "購入済みクレジット",
+      "promotional": "特典クレジット",
+      "notProvisioned": "このアカウントではクレジットがまだ有効になっていません。",
+      "notSupported": "このアカウントでは残高照会を利用できません。",
+      "unavailable": "残高を取得できません。更新してもう一度お試しください。"
+    },
+    "dialogs": {
+      "subscription": {
+        "title": "サブスクリプションプランを選択",
+        "description": "サーバーで現在設定されているプランのみ表示します。プランを選択すると支払い方法が表示されます。"
+      },
+      "topup": {
+        "title": "クレジットを購入",
+        "description": "サーバーで現在設定されているクレジット商品のみ表示します。商品を選択すると支払い方法が表示されます。"
+      }
+    },
+    "eyebrow": "アカウントと使用量",
+    "title": "最適なプランを選択",
+    "subtitle": "プランと支払い方法はサーバーから配信されます。先にプランを選ぶと、現在利用可能な支払い方法が表示されます。",
+    "steps": {
+      "offer": {
+        "title": "プランを選択",
+        "description": "現在購入できるチャージとサブスクリプションのみ表示します。"
+      },
+      "channel": {
+        "title": "支払い方法を選択",
+        "description": "利用できる支払い方法はプランごとに異なります。",
+        "selectOfferFirst": "プランを選ぶと、対応する支払い方法が表示されます"
+      },
+      "confirm": {
+        "title": "確認して支払う",
+        "description": "プランと支払い方法を確認して決済を作成します。",
+        "selectChannelFirst": "支払い方法を選択してください"
+      }
+    },
+    "actions": {
+      "refreshCatalog": "更新",
+      "retry": "再試行",
+      "pay": "確認して支払う",
+      "refresh": "状態を更新",
+      "cancelPayment": "支払いをキャンセル",
+      "close": "閉じる"
+    },
+    "catalog": {
+      "errorTitle": "プランを取得できません",
+      "errorDescription": "接続を確認して再試行してください。ローカルの代替プランは表示しません。",
+      "emptyTitle": "利用可能なプランはありません",
+      "emptyDescription": "購入可能なプランと支払い方法がまだ設定されていません。"
+    },
+    "offerKinds": {
+      "topup": "クレジットチャージ",
+      "subscription": "サブスクリプション"
+    },
+    "amount": {
+      "custom": "金額を指定",
+      "label": "チャージ金額",
+      "placeholder": "金額を入力",
+      "rangeHint": "{{min}}〜{{max}}を入力",
+      "rangeError": "金額は{{min}}〜{{max}}の範囲で入力してください",
+      "formatError": "有効な金額を小数点以下{{digits}}桁以内で入力してください"
+    },
+    "intervals": {
+      "MONTH": "月",
+      "YEAR": "年"
+    },
+    "credits": "{{amount}} クレジット",
+    "confirm": {
+      "channel": "{{provider}}で支払う"
+    },
+    "paymentActions": {
+      "QR_CODE": "QRコードで支払う",
+      "REDIRECT": "支払いページを開く"
+    },
+    "providers": {
+      "alipay": "Alipay",
+      "stripe": "カード"
+    },
+    "securityNotice": "支払いは選択した事業者が安全に処理し、Cindyは支払い認証情報を保存しません",
+    "currentSubscription": {
+      "title": "現在のサブスクリプション",
+      "purchaseBlocked": "未終了のサブスクリプションがあります。既存のサブスクリプションを処理してから新しいプランを購入してください。"
+    },
+    "subscriptionStatus": {
+      "INCOMPLETE": "支払い待ち",
+      "INCOMPLETE_EXPIRED": "支払い期限切れ",
+      "TRIALING": "トライアル中",
+      "ACTIVE": "有効",
+      "PAST_DUE": "支払い遅延",
+      "UNPAID": "未払い",
+      "CANCELED": "キャンセル済み",
+      "PAUSED": "一時停止"
+    },
+    "recovery": {
+      "title": "未完了の支払いがあります",
+      "description": "前回の支払いを続け、最新状態をサーバーで確認できます。",
+      "continueTopup": "{{amount}}の支払いを続ける",
+      "continueSubscription": "サブスクリプションの支払いを続ける"
+    },
+    "checkout": {
+      "creatingTitle": "支払いを作成中",
+      "awaitingTitle": "支払い待ち",
+      "completedTitle": "支払い完了",
+      "failedTitle": "完了できませんでした",
+      "expiredTitle": "支払い期限切れ",
+      "canceledTitle": "支払いキャンセル済み",
+      "topupSubtitle": "クレジットチャージ",
+      "subscriptionSubtitle": "サブスクリプション",
+      "creatingBody": "支払いサービスで注文を確認しています…",
+      "qrAlt": "支払いQRコード",
+      "scanHint": "対応する支払いアプリでスキャンしてください",
+      "checkingExpiry": "有効期限を確認中…",
+      "expiresIn": "QRコードの有効期限 {{minutes}}:{{seconds}}",
+      "redirectHint": "支払いページで完了後、Cindyに戻ってください。",
+      "openPayment": "支払いページを開く",
+      "refreshingAction": "支払い情報を取得中…",
+      "paymentCompleted": "支払いが完了しました。",
+      "requestFailed": "リクエストに失敗しました。不明な作成結果では同じ冪等キーで安全に再試行します。",
+      "expiredBody": "支払いリンクの期限が切れました。新しい支払いを作成してください。",
+      "canceledBody": "この支払いはキャンセルされました。",
+      "failedBody": "支払いに失敗しました。しばらくしてからもう一度お試しください。"
+    }
+  },
   "ipcError": {
     "SESSION_RUNNING": "このセッションは現在タスクを実行中です。しばらくしてからもう一度お試しください。",
     "CREDENTIAL_SWITCH_BUSY": "他の Codex タスクが実行中のため、今回の提供元切り替えは適用されませんでした（セッションは元の提供元のままです）。他のタスクが終わってからもう一度お試しください。"
@@ -78,6 +225,7 @@
     },
     "tabs": {
       "general": "一般",
+      "billing": "使用状況と請求",
       "personalization": "パーソナライズ",
       "apiKeys": "ツールキー",
       "voiceInput": "音声入力",
@@ -99,6 +247,7 @@
     },
     "sections": {
       "user": "ユーザー",
+      "billing": "使用状況と請求",
       "appearance": "外観",
       "notifications": "通知",
       "agentIsland": "Agent Island",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1,4 +1,151 @@
 {
+  "billing": {
+    "sidebar": "크레딧 및 요금제",
+    "settings": {
+      "title": "사용량 및 결제",
+      "subtitle": "현재 구독을 확인하거나 서버에서 제공하는 구독 상품과 크레딧을 구매할 수 있습니다.",
+      "loading": "구독 상태를 불러오는 중…",
+      "subscriptionCard": {
+        "title": "현재 요금제",
+        "empty": "활성 구독이 없습니다",
+        "emptyTitle": "구독 요금제 없음",
+        "unnamedPlan": "구독 요금제",
+        "unavailable": "구독 상태를 불러올 수 없습니다. 새로고침 후 다시 시도하세요.",
+        "action": "요금제 보기"
+      },
+      "topupCard": {
+        "title": "크레딧",
+        "description": "사용량 기반 모델과 기능을 위한 크레딧을 구매합니다.",
+        "cardTitle": "필요할 때 크레딧 구매",
+        "cardDescription": "구매 가능한 크레딧 상품은 서버에서 설정됩니다.",
+        "action": "크레딧 구매"
+      }
+    },
+    "balance": {
+      "title": "사용 가능 잔액",
+      "plan": "요금제 크레딧",
+      "purchased": "구매한 크레딧",
+      "promotional": "프로모션 크레딧",
+      "notProvisioned": "이 계정에는 아직 크레딧이 활성화되지 않았습니다.",
+      "notSupported": "이 계정에서는 잔액 조회를 지원하지 않습니다.",
+      "unavailable": "잔액을 불러올 수 없습니다. 새로고침 후 다시 시도하세요."
+    },
+    "dialogs": {
+      "subscription": {
+        "title": "구독 요금제 선택",
+        "description": "서버에 현재 설정된 구독 요금제만 표시합니다. 요금제를 선택하면 결제 수단이 표시됩니다."
+      },
+      "topup": {
+        "title": "크레딧 구매",
+        "description": "서버에 현재 설정된 크레딧 상품만 표시합니다. 상품을 선택하면 결제 수단이 표시됩니다."
+      }
+    },
+    "eyebrow": "계정 및 사용량",
+    "title": "알맞은 요금제 선택",
+    "subtitle": "요금제와 결제 수단은 서버에서 실시간으로 제공됩니다. 요금제를 먼저 선택하면 현재 지원되는 결제 수단을 볼 수 있습니다.",
+    "steps": {
+      "offer": {
+        "title": "요금제 선택",
+        "description": "현재 구매 가능한 충전 및 구독만 표시합니다."
+      },
+      "channel": {
+        "title": "결제 수단 선택",
+        "description": "지원되는 결제 수단은 요금제마다 다를 수 있습니다.",
+        "selectOfferFirst": "요금제를 선택하면 지원되는 결제 수단이 표시됩니다"
+      },
+      "confirm": {
+        "title": "확인 및 결제",
+        "description": "요금제와 결제 수단을 확인한 뒤 결제를 생성합니다.",
+        "selectChannelFirst": "계속하려면 결제 수단을 선택하세요"
+      }
+    },
+    "actions": {
+      "refreshCatalog": "새로고침",
+      "retry": "다시 시도",
+      "pay": "확인 및 결제",
+      "refresh": "상태 새로고침",
+      "cancelPayment": "결제 취소",
+      "close": "닫기"
+    },
+    "catalog": {
+      "errorTitle": "요금제를 불러올 수 없습니다",
+      "errorDescription": "네트워크를 확인하고 다시 시도하세요. 로컬 대체 요금제는 표시하지 않습니다.",
+      "emptyTitle": "사용 가능한 요금제가 없습니다",
+      "emptyDescription": "서버에 구매 가능한 요금제와 결제 수단이 아직 설정되지 않았습니다."
+    },
+    "offerKinds": {
+      "topup": "크레딧 충전",
+      "subscription": "구독"
+    },
+    "amount": {
+      "custom": "금액 직접 입력",
+      "label": "충전 금액",
+      "placeholder": "금액 입력",
+      "rangeHint": "{{min}}~{{max}} 입력",
+      "rangeError": "금액은 {{min}}~{{max}} 사이여야 합니다",
+      "formatError": "유효한 금액을 소수점 이하 {{digits}}자리 이내로 입력하세요"
+    },
+    "intervals": {
+      "MONTH": "월",
+      "YEAR": "년"
+    },
+    "credits": "{{amount}} 크레딧",
+    "confirm": {
+      "channel": "{{provider}}로 결제"
+    },
+    "paymentActions": {
+      "QR_CODE": "QR 코드 결제",
+      "REDIRECT": "결제 페이지 열기"
+    },
+    "providers": {
+      "alipay": "Alipay",
+      "stripe": "카드"
+    },
+    "securityNotice": "결제는 선택한 결제사에서 안전하게 처리하며 Cindy는 결제 인증 정보를 저장하지 않습니다",
+    "currentSubscription": {
+      "title": "현재 구독",
+      "purchaseBlocked": "종료되지 않은 구독이 있습니다. 기존 구독을 처리한 후 새 요금제를 구매하세요."
+    },
+    "subscriptionStatus": {
+      "INCOMPLETE": "결제 대기",
+      "INCOMPLETE_EXPIRED": "결제 만료",
+      "TRIALING": "체험 중",
+      "ACTIVE": "사용 중",
+      "PAST_DUE": "결제 연체",
+      "UNPAID": "미결제",
+      "CANCELED": "취소됨",
+      "PAUSED": "일시 중지"
+    },
+    "recovery": {
+      "title": "완료되지 않은 결제가 있습니다",
+      "description": "이전 결제를 계속하고 서버에서 최신 상태를 확인할 수 있습니다.",
+      "continueTopup": "{{amount}} 결제 계속",
+      "continueSubscription": "구독 결제 계속"
+    },
+    "checkout": {
+      "creatingTitle": "결제 생성 중",
+      "awaitingTitle": "결제 대기",
+      "completedTitle": "결제 완료",
+      "failedTitle": "완료할 수 없음",
+      "expiredTitle": "결제 만료",
+      "canceledTitle": "결제 취소됨",
+      "topupSubtitle": "크레딧 충전",
+      "subscriptionSubtitle": "구독",
+      "creatingBody": "결제 서비스에서 주문을 확인하고 있습니다…",
+      "qrAlt": "결제 QR 코드",
+      "scanHint": "해당 결제 앱으로 스캔하세요",
+      "checkingExpiry": "유효 시간을 확인하는 중…",
+      "expiresIn": "QR 코드 만료까지 {{minutes}}:{{seconds}}",
+      "redirectHint": "결제 페이지에서 완료한 뒤 Cindy로 돌아오세요.",
+      "openPayment": "결제 페이지 열기",
+      "refreshingAction": "결제 정보를 불러오는 중…",
+      "paymentCompleted": "결제가 완료되었습니다.",
+      "requestFailed": "요청에 실패했습니다. 결과가 불확실한 생성 요청은 같은 멱등성 키로 안전하게 재시도합니다.",
+      "expiredBody": "결제 링크가 만료되었습니다. 새 결제를 생성하세요.",
+      "canceledBody": "이 결제가 취소되었습니다.",
+      "failedBody": "결제에 실패했습니다. 나중에 다시 시도하세요."
+    }
+  },
   "ipcError": {
     "SESSION_RUNNING": "이 세션은 현재 작업을 실행 중입니다. 잠시 후 다시 시도해 주세요.",
     "CREDENTIAL_SWITCH_BUSY": "다른 Codex 작업이 실행 중이어서 이번 제공자 전환은 적용되지 않았습니다(세션은 기존 제공자를 유지합니다). 다른 작업이 끝난 후 다시 시도해 주세요."
@@ -78,6 +225,7 @@
     },
     "tabs": {
       "general": "일반",
+      "billing": "사용량 및 결제",
       "personalization": "개인화",
       "apiKeys": "도구 키",
       "voiceInput": "음성 입력",
@@ -99,6 +247,7 @@
     },
     "sections": {
       "user": "사용자",
+      "billing": "사용량 및 결제",
       "appearance": "외관",
       "notifications": "알림",
       "agentIsland": "Agent Island",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1,4 +1,151 @@
 {
+  "billing": {
+    "sidebar": "点数与订阅",
+    "settings": {
+      "title": "使用情况和计费",
+      "subtitle": "查看当前订阅，或按需购买由服务端提供的订阅套餐和点数。",
+      "loading": "正在获取订阅状态…",
+      "subscriptionCard": {
+        "title": "当前套餐",
+        "empty": "当前没有生效中的订阅",
+        "emptyTitle": "无订阅套餐",
+        "unnamedPlan": "订阅套餐",
+        "unavailable": "暂时无法获取订阅状态，请刷新后重试。",
+        "action": "查看套餐"
+      },
+      "topupCard": {
+        "title": "点数",
+        "description": "购买点数，为按量使用的模型和功能充值。",
+        "cardTitle": "按需购买点数",
+        "cardDescription": "可购买的点数商品由服务端配置。",
+        "action": "购买点数"
+      }
+    },
+    "balance": {
+      "title": "可用额度",
+      "plan": "订阅额度",
+      "purchased": "已购额度",
+      "promotional": "赠送额度",
+      "notProvisioned": "当前账户尚未开通额度。",
+      "notSupported": "当前账户暂不支持额度查询。",
+      "unavailable": "暂时无法获取额度，请刷新后重试。"
+    },
+    "dialogs": {
+      "subscription": {
+        "title": "选择订阅套餐",
+        "description": "仅展示服务端当前配置且可用的订阅套餐。选择套餐后再选择支付方式。"
+      },
+      "topup": {
+        "title": "购买点数",
+        "description": "仅展示服务端当前配置且可用的点数商品。选择商品后再选择支付方式。"
+      }
+    },
+    "eyebrow": "账户与用量",
+    "title": "选择适合你的方案",
+    "subtitle": "套餐和支付方式均由服务端实时下发。先选择方案，再查看该方案当前支持的支付方式。",
+    "steps": {
+      "offer": {
+        "title": "选择套餐",
+        "description": "仅展示当前可购买的充值和订阅方案。"
+      },
+      "channel": {
+        "title": "选择支付方式",
+        "description": "不同套餐支持的支付方式可能不同。",
+        "selectOfferFirst": "选择套餐后，这里会显示该套餐支持的支付方式"
+      },
+      "confirm": {
+        "title": "确认并支付",
+        "description": "核对方案与支付方式后创建支付。",
+        "selectChannelFirst": "选择支付方式后即可确认订单"
+      }
+    },
+    "actions": {
+      "refreshCatalog": "刷新",
+      "retry": "重试",
+      "pay": "确认并支付",
+      "refresh": "刷新状态",
+      "cancelPayment": "取消支付",
+      "close": "关闭"
+    },
+    "catalog": {
+      "errorTitle": "暂时无法获取套餐",
+      "errorDescription": "请检查网络后重试。不会使用本地套餐替代。",
+      "emptyTitle": "当前暂无可用套餐",
+      "emptyDescription": "服务端尚未配置可购买的套餐和支付方式。"
+    },
+    "offerKinds": {
+      "topup": "点数充值",
+      "subscription": "订阅套餐"
+    },
+    "amount": {
+      "custom": "自定义金额",
+      "label": "充值金额",
+      "placeholder": "输入金额",
+      "rangeHint": "可输入 {{min}} 至 {{max}}",
+      "rangeError": "金额需在 {{min}} 至 {{max}} 之间",
+      "formatError": "请输入有效金额，最多保留 {{digits}} 位小数"
+    },
+    "intervals": {
+      "MONTH": "月",
+      "YEAR": "年"
+    },
+    "credits": "{{amount}} 点数",
+    "confirm": {
+      "channel": "通过 {{provider}} 支付"
+    },
+    "paymentActions": {
+      "QR_CODE": "扫码支付",
+      "REDIRECT": "跳转支付页面"
+    },
+    "providers": {
+      "alipay": "支付宝",
+      "stripe": "银行卡"
+    },
+    "securityNotice": "支付由所选渠道安全处理，Cindy 不保存你的支付凭证",
+    "currentSubscription": {
+      "title": "当前订阅",
+      "purchaseBlocked": "当前已有未结束的订阅，请先处理现有订阅后再购买新套餐。"
+    },
+    "subscriptionStatus": {
+      "INCOMPLETE": "等待完成支付",
+      "INCOMPLETE_EXPIRED": "支付已过期",
+      "TRIALING": "试用中",
+      "ACTIVE": "生效中",
+      "PAST_DUE": "付款逾期",
+      "UNPAID": "待付款",
+      "CANCELED": "已取消",
+      "PAUSED": "已暂停"
+    },
+    "recovery": {
+      "title": "发现未完成的支付",
+      "description": "你可以继续上次的支付，状态将从服务端重新确认。",
+      "continueTopup": "继续支付 {{amount}}",
+      "continueSubscription": "继续订阅支付"
+    },
+    "checkout": {
+      "creatingTitle": "正在创建支付",
+      "awaitingTitle": "等待支付",
+      "completedTitle": "支付成功",
+      "failedTitle": "暂时无法完成",
+      "expiredTitle": "支付已过期",
+      "canceledTitle": "支付已取消",
+      "topupSubtitle": "点数充值",
+      "subscriptionSubtitle": "订阅套餐",
+      "creatingBody": "正在向支付服务确认订单…",
+      "qrAlt": "支付二维码",
+      "scanHint": "请使用对应支付应用扫码",
+      "checkingExpiry": "正在确认有效时间…",
+      "expiresIn": "二维码将在 {{minutes}}:{{seconds}} 后过期",
+      "redirectHint": "请在支付页面完成操作，完成后返回 Cindy。",
+      "openPayment": "打开支付页面",
+      "refreshingAction": "正在获取支付方式…",
+      "paymentCompleted": "支付已完成。",
+      "requestFailed": "请求失败。可以重试；结果不确定时会继续复用原幂等请求。",
+      "expiredBody": "支付链接已过期，请重新创建支付。",
+      "canceledBody": "本次支付已取消。",
+      "failedBody": "支付失败，请稍后重试或联系支持。"
+    }
+  },
   "ipcError": {
     "SESSION_RUNNING": "当前会话正在执行任务，请稍后再试。",
     "CREDENTIAL_SWITCH_BUSY": "其他 Codex 任务正在运行，本次来源切换未生效（会话仍使用原来源）。等其他任务结束后再试。"
@@ -78,6 +225,7 @@
     },
     "tabs": {
       "general": "通用",
+      "billing": "使用情况和计费",
       "personalization": "个性化",
       "apiKeys": "工具密钥",
       "voiceInput": "语音输入",
@@ -99,6 +247,7 @@
     },
     "sections": {
       "user": "用户",
+      "billing": "使用情况和计费",
       "appearance": "外观",
       "notifications": "通知",
       "agentIsland": "灵动岛",

--- a/apps/desktop/src/renderer/lib/tabLabels.ts
+++ b/apps/desktop/src/renderer/lib/tabLabels.ts
@@ -6,6 +6,7 @@
 
 export type SettingsTab =
   | 'general'
+  | 'billing'
   | 'personalization'
   | 'providers'
   | 'api-keys'
@@ -24,6 +25,7 @@ export type SettingsTab =
 
 export const TAB_IDS: ReadonlyArray<SettingsTab> = [
   'general',
+  'billing',
   'personalization',
   'providers',
   // 「工具密钥」(api-keys)已于 2026-07-13 下架:面板里最后一把 mivo key 随
@@ -47,6 +49,7 @@ export const TAB_IDS: ReadonlyArray<SettingsTab> = [
 
 export const TAB_LABEL_KEY: Record<SettingsTab, string> = {
   general: 'settings.tabs.general',
+  billing: 'settings.tabs.billing',
   personalization: 'settings.tabs.personalization',
   'api-keys': 'settings.tabs.apiKeys',
   'voice-input': 'settings.tabs.voiceInput',

--- a/apps/desktop/src/renderer/router.tsx
+++ b/apps/desktop/src/renderer/router.tsx
@@ -145,6 +145,10 @@ export const router = createHashRouter([
                   },
                   { path: 'settings', element: <SettingsView /> },
                   { path: 'plugins', element: <GhostPluginPage /> },
+                  {
+                    path: 'billing',
+                    element: <Navigate to="/settings?tab=billing" replace />,
+                  },
                   // Maker IPC / agent event 链路诊断页(独立路由,不影响标准 chat)。
                   { path: 'maker-experimental', element: <MakerExperimentalView /> },
                 ],

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -935,6 +935,7 @@ interface ElectronAPI {
   pageZoomReset: () => Promise<{ ok: true; zoomLevel: number }>;
   onApplicationMenuCommand: (callback: (command: ApplicationMenuCommand) => void) => () => void;
   setApplicationMenuLocale: (locale: ApplicationMenuLocale) => Promise<{ ok: true }>;
+  billing: import('../shared/billing').BillingRendererApi;
 
   // lifecycle 兜底 catch 到瞬时网络错误时推一次。renderer 收到后由
   // systemNetworkErrorToast.ts 负责节流 + 多语言 toast。

--- a/apps/desktop/src/shared/billing.ts
+++ b/apps/desktop/src/shared/billing.ts
@@ -1,0 +1,170 @@
+/**
+ * Billing desktop wire contract.
+ *
+ * Renderer only receives fixed business methods through preload. It cannot choose
+ * an HTTP path, target service, or arbitrary headers.
+ */
+
+import type { ModelAccessBalance } from './modelAccess';
+
+export const BILLING_INVOKE = {
+  GET_BALANCE: 'billing:get-balance',
+  GET_CATALOG: 'billing:get-catalog',
+  LIST_ORDERS: 'billing:list-orders',
+  GET_ORDER: 'billing:get-order',
+  CREATE_TOPUP: 'billing:create-topup',
+  REFRESH_TOPUP: 'billing:refresh-topup',
+  CANCEL_TOPUP: 'billing:cancel-topup',
+  RETRY_TOPUP: 'billing:retry-topup',
+  CREATE_SUBSCRIPTION: 'billing:create-subscription',
+  GET_CURRENT_SUBSCRIPTION: 'billing:get-current-subscription',
+  REFRESH_SUBSCRIPTION_PURCHASE: 'billing:refresh-subscription-purchase',
+  OPEN_PAYMENT_REDIRECT: 'billing:open-payment-redirect',
+} as const;
+
+export type BillingPaymentAction =
+  | { type: 'QR_CODE'; value: string; expiresAt: string }
+  | { type: 'REDIRECT'; url: string; expiresAt: string };
+
+export type BillingFulfillmentStatus = 'NOT_STARTED' | 'PENDING' | 'SUCCEEDED' | 'FAILED';
+
+export type BillingPurchaseOption = {
+  id: string;
+  provider: string;
+  capability: 'ONE_TIME_PAYMENT' | 'MERCHANT_INITIATED_MANDATE' | 'PROVIDER_MANAGED_SUBSCRIPTION';
+  paymentAction: BillingPaymentAction['type'];
+};
+
+export type BillingCatalogOffer = {
+  code: string;
+  interval: 'MONTH' | 'YEAR' | null;
+  currency: string;
+  amount: string | null;
+  minAmount: string | null;
+  maxAmount: string | null;
+  creditAmount: string | null;
+  rolloverCap: string | null;
+  purchaseOptions: BillingPurchaseOption[];
+};
+
+export type BillingCatalogProduct = {
+  code: string;
+  name: string;
+  kind: 'CREDIT_TOPUP' | 'SUBSCRIPTION';
+  level: number | null;
+  sortOrder: number;
+  offers: BillingCatalogOffer[];
+};
+
+export type BillingCatalog = {
+  products: BillingCatalogProduct[];
+};
+
+export type BillingPaymentOrderStatus =
+  'CREATED' | 'PENDING' | 'SUCCEEDED' | 'FAILED' | 'CANCELED' | 'EXPIRED';
+
+export type BillingPaymentOrder = {
+  orderId: string;
+  productCode: string;
+  offerCode: string;
+  amount: string;
+  currency: string;
+  status: BillingPaymentOrderStatus;
+  paymentAction: BillingPaymentAction | null;
+  /**
+   * Added by the fulfillment projection. Older servers may omit it; the client
+   * must then stay in "crediting" and never infer delivery from payment alone.
+   */
+  fulfillmentStatus?: BillingFulfillmentStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BillingSubscriptionStatus =
+  | 'INCOMPLETE'
+  | 'INCOMPLETE_EXPIRED'
+  | 'TRIALING'
+  | 'ACTIVE'
+  | 'PAST_DUE'
+  | 'UNPAID'
+  | 'CANCELED'
+  | 'PAUSED';
+
+export type BillingSubscription = {
+  subscriptionId: string;
+  status: BillingSubscriptionStatus;
+  provider?: string;
+  managementAction?: 'API_CANCEL' | 'PORTAL';
+  entitlementStatus?: BillingFulfillmentStatus;
+  currentPeriodStartAt: string | null;
+  currentPeriodEndAt: string | null;
+  entitlementValidUntil: string | null;
+  cancelAtPeriodEnd: boolean;
+  effectivePlan: {
+    version: 1;
+    product: {
+      code: string;
+      kind: 'SUBSCRIPTION';
+      level: number;
+    };
+    offer: {
+      code: string;
+      interval: 'MONTH' | 'YEAR';
+    };
+    terms: {
+      amount: string;
+      currency: string;
+      creditAmount: string;
+      rolloverCap: string;
+    };
+    capturedAt: string;
+  } | null;
+  purchaseAttemptId: string | null;
+  paymentAction: BillingPaymentAction | null;
+};
+
+export type BillingOrderList = {
+  orders: BillingPaymentOrder[];
+  nextCursor: string | null;
+};
+
+export type BillingCurrentSubscription = {
+  subscription: BillingSubscription | null;
+};
+
+export type CreateBillingTopupRequest = {
+  offerCode: string;
+  amount?: string;
+  purchaseOptionId: string;
+};
+
+export type CreateBillingSubscriptionRequest = {
+  offerCode: string;
+  purchaseOptionId: string;
+};
+
+export interface BillingRendererApi {
+  getBalance: () => Promise<ModelAccessBalance>;
+  getCatalog: () => Promise<BillingCatalog>;
+  listOrders: (payload: { limit: number }) => Promise<BillingOrderList>;
+  getOrder: (payload: { orderId: string }) => Promise<BillingPaymentOrder>;
+  createTopup: (payload: {
+    request: CreateBillingTopupRequest;
+    idempotencyKey: string;
+  }) => Promise<BillingPaymentOrder>;
+  refreshTopup: (payload: { orderId: string }) => Promise<BillingPaymentOrder>;
+  cancelTopup: (payload: { orderId: string }) => Promise<BillingPaymentOrder>;
+  retryTopup: (payload: {
+    orderId: string;
+    idempotencyKey: string;
+  }) => Promise<BillingPaymentOrder>;
+  createSubscription: (payload: {
+    request: CreateBillingSubscriptionRequest;
+    idempotencyKey: string;
+  }) => Promise<BillingSubscription>;
+  getCurrentSubscription: () => Promise<BillingCurrentSubscription>;
+  refreshSubscriptionPurchase: (payload: {
+    purchaseAttemptId: string;
+  }) => Promise<BillingSubscription>;
+  openPaymentRedirect: (payload: { url: string }) => Promise<{ success: boolean }>;
+}

--- a/apps/desktop/src/shared/modelAccess.ts
+++ b/apps/desktop/src/shared/modelAccess.ts
@@ -35,6 +35,16 @@ export interface ModelAccessStatus {
   endpoint: string | null;
 }
 
+/** 当前登录身份在 AIGateway Credit Ledger 中的同一时点余额快照。 */
+export interface ModelAccessBalance {
+  planCredits: string;
+  purchasedCredits: string;
+  promotionalCredits: string;
+  available: string;
+  scale: 9;
+  observedAt: string;
+}
+
 /** main → renderer 的状态推送通道。 */
 export const MODEL_ACCESS_STATUS_CHANNEL = 'model-access:status-change';
 


### PR DESCRIPTION
> 迁移自原私有仓 PR #581（原作者 @GaoWeiLiuXD）。原仓库已下线，评论与 review 记录未随迁。

## 这次改了什么

### 摘要

在 Desktop 设置页增加"使用情况和计费"入口，接入服务端配置驱动的订阅与点数购买流程。

- 新增 Billing IPC 层（`main/billing/`），包含输入校验、sender 校验、20 秒超时、幂等创建与跨重启支付恢复。
- 新增 renderer 侧 Billing 页面与 Checkout 弹窗，支持服务端下发的套餐列表、二维码支付和外部重定向支付。
- 服务端返回的目录决定渲染内容：未配置套餐/零渠道套餐/未知 Provider 均不渲染，无本地 fallback。
- `serverApiClient` 新增 `redactErrorDetails` 选项，Billing 请求的上游错误信息不落本地日志也不跨 IPC。
- 补充 en/zh-CN/ja/ko 四语 i18n 条目。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求：Desktop 计费入口（迁移自私有仓 PR #581）
- 本 PR 包含：main 侧 Billing IPC handler、renderer 侧 BillingPage/Checkout UI、projection 安全投影层、preload 暴露、路由注册、i18n、28 个测试
- 明确不包含：服务端实现、Mobile 端、积分消耗逻辑、订单退款流程
- 用户可见变化：设置页新增"使用情况和计费"Tab，可查看余额/订阅状态、购买套餐和充值点数
- 是否存在 breaking change：无

### UI 变化

设置页新增 Billing Tab，包含余额卡片、订阅状态卡片、套餐/点数选择列表和 Checkout 弹窗（二维码/重定向两种模式）。仅 Desktop 平台。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop run test -- --run
结果：1129 个测试文件通过；Billing 相关 28 个新增测试全部通过

pnpm --filter desktop run lint -- --no-warn apps/desktop/src/main/billing/ apps/desktop/src/renderer/features/billing/ apps/desktop/src/shared/billing.ts
结果：通过
```

### 手工验证

- 平台：macOS (arm64)，Electron dev 模式
- 操作路径：Settings → Billing Tab → 查看余额 → 选择套餐 → 点击购买 → Checkout 弹窗渲染二维码 / 打开外部支付页 → 支付成功提示
- 验证项：sender 校验拒绝 WebView 发起的 Billing IPC；非 HTTPS 或非白名单域名的重定向 URL 被拦截；幂等键重复提交返回同一订单

### 未执行的验证

- Windows 平台：本地无 Windows 环境，依赖 CI 的 typecheck 覆盖
- 真实支付：使用 mock 服务端响应，未对接生产支付网关

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：Desktop 设置页新增 Tab，不影响现有功能；Billing IPC 仅限 mainWindow top-frame 调用
- 回滚 / 降级方式：回滚本 PR 即可移除入口；服务端不下发 catalog 时客户端自动展示空态

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

---

## 开源与安全边界

- renderer 不能指定服务地址、路径或任意请求头，也不接触 Bearer Token。
- localStorage 只保存 Provider-neutral 的恢复指针和幂等键，不保存二维码、支付 URL、凭据或完整响应。
- 客户端不包含真实 AppId、商户号、密钥、订单号、内部域名或生产支付链接。
- 本地设计 QA 文档包含机器绝对路径，已明确排除在提交之外。

## 服务端依赖

客户端只消费 Billing Catalog 返回的 purchaseOptions，以及创建结果返回的 QR_CODE 或 REDIRECT 动作。服务端需保证 purchaseOptionId 与目标 Offer 的归属校验，并提供当前分支所使用的 Provider-neutral Billing 路由。
