### PR TITLE
fix(mobile): 补回纯构建脚本缺失的 release-lib 公开版

### DIFF
--- a/apps/mobile/scripts/release-lib.mjs
+++ b/apps/mobile/scripts/release-lib.mjs
@@ -1,0 +1,135 @@
+// =============================================================================
+// release-lib.mjs —— 纯构建脚本共用的参数解析 / git 闸门 / 公开 env 校验与展示
+//
+// 公开版说明:内部发布线(release-*.mjs:OTA 判定、OSS/CDN 上传、商店分发)不随
+// 开源仓发布,原 release-lib 中的发布专用函数(computeFingerprint、版本基线拉取等)
+// 也随之移除。本文件只保留 build-android.mjs / build-ios.mjs 这两个「本机纯构建」
+// 脚本仍需要的通用工具,全部离线、零机密:
+//   - parseArgs                  通用 CLI 参数解析(kebab-case 自动转 camelCase)
+//   - assertProductionGitGate    main / clean / 与 origin/main 一致 三项闸门
+//   - SELF_HOST_PUBLIC_ENV_KEYS  自建构建必须齐全的公开 EXPO_PUBLIC_ 键
+//   - assertPublicEnv            构建 env 的公开键完整性 + variant 防呆校验
+//   - formatBakedEnvLines        dry-run 计划里展示 baked 公开变量(过滤非公开键)
+//
+// ⚠️ ci-fingerprint.mjs 会被单文件复制到 RUNNER_TEMP 运行,不得 import 本文件
+// (它自带 parseFingerprintArgs);同理本文件不 import 仓内其他模块,保持自包含。
+// =============================================================================
+
+import { spawnSync } from 'node:child_process';
+
+/**
+ * 解析 CLI 参数。支持 `--flag`、`--key value`、`--key=value`;裸词进 `_`;
+ * kebab-case 键名转 camelCase(`--skip-git-gate` → `args.skipGitGate`)。
+ * @param {string[]} argv
+ * @returns {{ _: string[], [key: string]: string | boolean | string[] }}
+ */
+export function parseArgs(argv) {
+  /** @type {{ _: string[]; [key: string]: string | boolean | string[] }} */
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--') continue;
+    if (!arg.startsWith('--')) {
+      args._.push(arg);
+      continue;
+    }
+    const [rawKey, inlineValue] = arg.slice(2).split(/=(.*)/s, 2);
+    const key = rawKey.replace(/-+([a-z0-9])/g, (_, ch) => ch.toUpperCase());
+    if (inlineValue != null) {
+      args[key] = inlineValue;
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next != null && !next.startsWith('--')) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+/** 默认 git 执行器(可注入替身供单测)。失败即抛错,stderr 带回原因。 */
+function runGit(gitArgs, cwd) {
+  const r = spawnSync('git', gitArgs, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error(`git ${gitArgs.join(' ')} 失败: ${r.stderr?.trim() || r.error?.message || `exit ${r.status}`}`);
+  }
+  return r.stdout.trim();
+}
+
+/**
+ * 生产构建 git 闸门:必须在 main 分支、工作区 clean、且 HEAD 与本地 origin/main
+ * 引用一致(不做网络 fetch;要求构建前自行同步远端)。任何一项不满足即抛错。
+ * 本地迭代绕过方式是脚本参数 --skip-git-gate,不在这里提供开关。
+ * @param {{ cwd?: string, git?: (args: string[], cwd?: string) => string }} [options]
+ */
+export function assertProductionGitGate({ cwd = process.cwd(), git = runGit } = {}) {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+  if (branch !== 'main') {
+    throw new Error(`发布级构建必须在 main 分支(当前 ${branch});本地迭代请传 --skip-git-gate`);
+  }
+  const dirty = git(['status', '--porcelain'], cwd);
+  if (dirty) {
+    throw new Error('工作区不干净(git status --porcelain 非空);发布级构建要求 clean checkout,本地迭代请传 --skip-git-gate');
+  }
+  const head = git(['rev-parse', 'HEAD'], cwd);
+  const originMain = git(['rev-parse', 'origin/main'], cwd);
+  if (head !== originMain) {
+    throw new Error(
+      `HEAD(${head.slice(0, 7)})与本地 origin/main 引用(${originMain.slice(0, 7)})不一致;` +
+        '请先 git fetch && 对齐远端后再构建,本地迭代请传 --skip-git-gate',
+    );
+  }
+  return { branch, head };
+}
+
+/**
+ * 自建纯构建必须齐全的公开构建变量:region 身份、端点清单自举基址、自建门控标志。
+ * 值全部来自仓内 config/endpoint*.json 与脚本字面量(见 build 脚本的 selfhostEnv)。
+ */
+export const SELF_HOST_PUBLIC_ENV_KEYS = Object.freeze([
+  'EXPO_PUBLIC_CINDY_AUTH_REGION',
+  'EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL',
+  'EXPO_PUBLIC_XDT_OTA_SELFHOST',
+]);
+
+/**
+ * 校验构建 env:requiredKeys 必须逐个非空;variant 'production' 额外要求
+ * EXPO_PUBLIC_APP_VARIANT 未设或为 'production'(app.config.js 会对 'beta' 改名 /
+ * 改配置,混入生产构建会烤出错版包且事后难察觉)。
+ * @param {Record<string, string | undefined>} env
+ * @param {{ variant?: 'production', requiredKeys?: readonly string[] }} [options]
+ */
+export function assertPublicEnv(env, { variant, requiredKeys = [] } = {}) {
+  const missing = requiredKeys.filter((key) => !String(env?.[key] ?? '').trim());
+  if (missing.length > 0) {
+    throw new Error(`构建 env 缺少必需公开变量:${missing.join(', ')}(应由构建脚本从仓内配置注入,不要手工 export)`);
+  }
+  if (variant === 'production') {
+    const appVariant = String(env?.EXPO_PUBLIC_APP_VARIANT ?? '').trim();
+    if (appVariant && appVariant !== 'production') {
+      throw new Error(
+        `EXPO_PUBLIC_APP_VARIANT=${appVariant} 与 production 构建冲突(beta 变体会改应用名/配置);请清理 shell / .env 残留后重试`,
+      );
+    }
+  }
+}
+
+/**
+ * 生成 dry-run 计划里展示 baked 变量的行。只展示 EXPO_PUBLIC_ 前缀键与 extraKeys
+ * 显式点名的键——兜底防止调用方误把机密 env 混进日志(调用方本就应只传公开值)。
+ * @param {Record<string, string>} bakedEnv
+ * @param {{ extraKeys?: readonly string[] }} [options]
+ * @returns {string[]}
+ */
+export function formatBakedEnvLines(bakedEnv, { extraKeys = [] } = {}) {
+  const keys = Object.keys(bakedEnv ?? {}).filter(
+    (key) => key.startsWith('EXPO_PUBLIC_') || extraKeys.includes(key),
+  );
+  return [
+    'baked env(本脚本注入的公开构建变量,均为非机密值):',
+    ...keys.map((key) => `  ${key}=${bakedEnv[key]}`),
+  ];
+}

--- a/apps/mobile/src/__tests__/releaseLib.test.ts
+++ b/apps/mobile/src/__tests__/releaseLib.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertProductionGitGate,
+  assertPublicEnv,
+  formatBakedEnvLines,
+  parseArgs,
+  SELF_HOST_PUBLIC_ENV_KEYS,
+} from '../../scripts/release-lib.mjs';
+
+/** 造一个只认预置命令的 git 替身,build 脚本闸门单测不碰真实仓库。 */
+function fakeGit(overrides: Partial<Record<string, string>> = {}) {
+  const outputs: Record<string, string> = {
+    'rev-parse --abbrev-ref HEAD': 'main',
+    'status --porcelain': '',
+    'rev-parse HEAD': 'a'.repeat(40),
+    'rev-parse origin/main': 'a'.repeat(40),
+    ...overrides,
+  };
+  return (args: string[]) => {
+    const key = args.join(' ');
+    const out = outputs[key];
+    if (out == null) throw new Error(`unexpected git ${key}`);
+    return out;
+  };
+}
+
+describe('release-lib parseArgs', () => {
+  it('camelCases kebab-case keys used by the build scripts', () => {
+    expect(
+      parseArgs([
+        'positional',
+        '--region', 'cn',
+        '--version-code=42',
+        '--desktop-version', '1.2.3',
+        '--skip-git-gate',
+        '--execute',
+      ]),
+    ).toEqual({
+      _: ['positional'],
+      region: 'cn',
+      versionCode: '42',
+      desktopVersion: '1.2.3',
+      skipGitGate: true,
+      execute: true,
+    });
+  });
+
+  it('treats a trailing flag and `--` separator like ci-fingerprint parsing', () => {
+    expect(parseArgs(['--', '--out'])).toEqual({ _: [], out: true });
+    expect(parseArgs(['--out', 'dist', '--execute'])).toEqual({ _: [], out: 'dist', execute: true });
+  });
+});
+
+describe('release-lib assertProductionGitGate', () => {
+  it('passes on main + clean + HEAD synced with origin/main', () => {
+    expect(assertProductionGitGate({ git: fakeGit() })).toEqual({
+      branch: 'main',
+      head: 'a'.repeat(40),
+    });
+  });
+
+  it('rejects non-main branches', () => {
+    expect(() =>
+      assertProductionGitGate({ git: fakeGit({ 'rev-parse --abbrev-ref HEAD': 'feat/x' }) }),
+    ).toThrow('main 分支');
+  });
+
+  it('rejects a dirty worktree', () => {
+    expect(() =>
+      assertProductionGitGate({ git: fakeGit({ 'status --porcelain': ' M app.json' }) }),
+    ).toThrow('工作区不干净');
+  });
+
+  it('rejects HEAD drift from origin/main', () => {
+    expect(() =>
+      assertProductionGitGate({ git: fakeGit({ 'rev-parse origin/main': 'b'.repeat(40) }) }),
+    ).toThrow('origin/main');
+  });
+});
+
+describe('release-lib assertPublicEnv', () => {
+  const baked = {
+    EXPO_PUBLIC_CINDY_AUTH_REGION: 'cn',
+    EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL: 'https://cdn.example.com',
+    EXPO_PUBLIC_XDT_OTA_SELFHOST: '1',
+  };
+
+  it('accepts a complete self-host build env', () => {
+    expect(() =>
+      assertPublicEnv(baked, { variant: 'production', requiredKeys: SELF_HOST_PUBLIC_ENV_KEYS }),
+    ).not.toThrow();
+  });
+
+  it('lists every missing or blank required key', () => {
+    expect(() =>
+      assertPublicEnv(
+        { EXPO_PUBLIC_CINDY_AUTH_REGION: ' ' },
+        { requiredKeys: SELF_HOST_PUBLIC_ENV_KEYS },
+      ),
+    ).toThrow(
+      'EXPO_PUBLIC_CINDY_AUTH_REGION, EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL, EXPO_PUBLIC_XDT_OTA_SELFHOST',
+    );
+  });
+
+  it('rejects a leftover beta variant in production builds', () => {
+    expect(() =>
+      assertPublicEnv(
+        { ...baked, EXPO_PUBLIC_APP_VARIANT: 'beta' },
+        { variant: 'production', requiredKeys: SELF_HOST_PUBLIC_ENV_KEYS },
+      ),
+    ).toThrow('EXPO_PUBLIC_APP_VARIANT=beta');
+  });
+});
+
+describe('release-lib formatBakedEnvLines', () => {
+  it('shows EXPO_PUBLIC_ keys plus explicitly allowed extras only', () => {
+    const lines = formatBakedEnvLines(
+      {
+        EXPO_PUBLIC_CINDY_AUTH_REGION: 'cn',
+        XDT_ANDROID_VERSION_CODE: '42',
+        XDT_ANDROID_KEYSTORE_PASSWORD: 'secret',
+      },
+      { extraKeys: ['XDT_ANDROID_VERSION_CODE'] },
+    );
+    expect(lines[0]).toContain('baked env');
+    expect(lines).toContain('  EXPO_PUBLIC_CINDY_AUTH_REGION=cn');
+    expect(lines).toContain('  XDT_ANDROID_VERSION_CODE=42');
+    expect(lines.join('\n')).not.toContain('secret');
+  });
+});

--- a/docs/dev-rules/protocol-and-submodules.md
+++ b/docs/dev-rules/protocol-and-submodules.md
@@ -27,8 +27,11 @@
 - 协议定义以 `cindy-protocol` submodule 为准；desktop 通过 `@cindy/slack-hook-protocol`
   消费，device-link 复用 `@cindy/device-link-protocol` 的 relay 层定义。客户端重连、IPC
   allowlist 与隧道 payload 留在 `packages/device-link`，不在客户端另造一套协议。
-- `makecindy/cindy-protocol` 以新历史公开；父仓当前锁定的 `436a45f` 由公开 tag
-  `client-baseline-436a45f` 保持可拉取。升级父仓指针前不要删除这个兼容 tag。
+- `makecindy/cindy-protocol` 以新历史公开；父仓锁定的 submodule commit 必须始终
+  可从公开仓拉取——合入协议仓 `main`，或打 `client-baseline-<sha>` tag，不允许只
+  停在 feature 分支上（分支删除会让 gitlink 失效）。当前锁定的 `4468730` 已在协议
+  仓 `main` 上；历史 tag `client-baseline-436a45f` 仍可能被旧 checkout 依赖，不要
+  删除。
 - **升级 submodule 指针前必须确认服务端同步升级**，避免两端 wire protocol 漂移。协议是
   跨仓契约，单端先行会让线上连接对不上。
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

开源初始提交移除了内部发布线的 `apps/mobile/scripts/release-lib.mjs`,但 `build-android.mjs` / `build-ios.mjs` 仍 import 其中 5 个通用工具,导致移动端纯构建脚本一跑就 `ERR_MODULE_NOT_FOUND`。本 PR 按两个脚本的实际用法重建了公开版 release-lib(只含纯构建所需工具,零机密、全离线,不含任何发布/上传逻辑),并补单测。

顺带解决同批遗留的 submodule 隐患:cindy-protocol 的 pin `4468730` 此前只在两个 feature 分支上可达,分支一删 gitlink 就失效。已把该 pin fast-forward 合入协议仓 `main`(纯 ff、无内容变化,gitlink 本身不变),本 PR 同步更新 `docs/dev-rules/protocol-and-submodules.md` 里过期的 pin 保护说明(原文还写着旧 pin `436a45f`)。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求:开源首发遗留待办(build 脚本断链 + submodule pin 不在 main)
- 本 PR 包含:重建 `release-lib.mjs`(parseArgs / assertProductionGitGate / SELF_HOST_PUBLIC_ENV_KEYS / assertPublicEnv / formatBakedEnvLines)、新增 `releaseLib.test.ts`、更新 protocol-and-submodules.md
- 明确不包含:任何内部发布线脚本(OTA/OSS/分发);cindy-protocol gitlink 未变更
- 用户可见变化:自建构建者可正常运行 `build-android.mjs` / `build-ios.mjs`
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit(仓库根)
结果:全部 PASS(含 apps/desktop、apps/mobile 及全部 packages,exit 0)

pnpm --filter mobile run --if-present typecheck
结果:通过

pnpm --filter mobile exec vitest run src/__tests__/releaseLib.test.ts src/__tests__/ciFingerprintScript.test.ts
结果:18 个用例全部通过(新增 10 个)
```

### 手工验证

- 用临时填充的 self-host-regions 文件(`CINDY_SELF_HOST_REGIONS_FILE` 指向仓外临时文件)分别跑 `build-android.mjs --region cn --skip-git-gate` 与 `build-ios.mjs --region cn --skip-git-gate --desktop-version 9.9.9` 完整 dry-run:参数 camelCase 解析、baked env 展示、公开 env 校验全链路正常;无参运行两脚本可到达各自的 `--region` 引导错误(证明 import 断链已修复)。Windows 11 本机。
- 协议仓:`git merge-base --is-ancestor 4468730 origin/main` 确认 pin 已可从 `main` 可达(ff-only 更新,`force=false`)。

### 未执行的验证

- 未跑 `--execute` 真实出包(需 Android SDK/keystore、macOS/Xcode 及签名材料);本 PR 不改构建步骤本身,只恢复被移除的工具函数。

## 风险

### 风险分类

- [x] 其他:`assertProductionGitGate` / `assertPublicEnv` 为按调用方语义重建的公开版,闸门细节(main / clean / 与本地 origin/main 一致;production 拦 `EXPO_PUBLIC_APP_VARIANT=beta`)可能与内部原版存在差异,只影响自建构建者的防呆强度,不影响产物内容。

### 影响与回滚

- 影响范围:仅 `apps/mobile` 纯构建脚本与开发规则文档;运行时代码零改动。
- 回滚 / 降级方式:revert 本 PR 即可;协议仓 main 的 ff 无需回滚(pin 未变,只是可达性增强)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)