### PR TITLE
feat(desktop): 后台任务可见展示与精确停止(消息流卡片 + 状态栏入口)

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/stopAgentTaskHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/stopAgentTaskHandler.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { MAKER_INVOKE } from '../channels';
+import { registerStopAgentTaskHandler } from '../stopAgentTaskHandler';
+import { IpcHarness } from './helpers/ipcHarness';
+
+describe('stop agent task IPC handler', () => {
+  it('validates sessionId and taskId before touching the session', async () => {
+    const harness = new IpcHarness();
+    const getLiveSession = vi.fn();
+    registerStopAgentTaskHandler(harness, { getLiveSession });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.STOP_AGENT_TASK, undefined, 'task-1'),
+    ).rejects.toMatchObject({ code: 'INVALID_PARAMS' });
+    await expect(
+      harness.invoke(MAKER_INVOKE.STOP_AGENT_TASK, 'session-1', ''),
+    ).rejects.toMatchObject({ code: 'INVALID_PARAMS' });
+    expect(getLiveSession).not.toHaveBeenCalled();
+  });
+
+  it('stops the named task on the live session', async () => {
+    const harness = new IpcHarness();
+    const stopBackgroundTask = vi.fn().mockResolvedValue(undefined);
+    registerStopAgentTaskHandler(harness, {
+      getLiveSession: vi.fn(() => ({ stopBackgroundTask })),
+    });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.STOP_AGENT_TASK, 'session-1', 'task-1'),
+    ).resolves.toEqual({ ok: true });
+    expect(stopBackgroundTask).toHaveBeenCalledWith('task-1');
+  });
+
+  it('is idempotent when the session is not loaded (task cannot be alive)', async () => {
+    const harness = new IpcHarness();
+    registerStopAgentTaskHandler(harness, { getLiveSession: vi.fn(() => undefined) });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.STOP_AGENT_TASK, 'session-1', 'task-1'),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it('maps NotSupportedError to UNSUPPORTED_CAPABILITY', async () => {
+    const harness = new IpcHarness();
+    const err = new Error('stopBackgroundTask not supported');
+    err.name = 'NotSupportedError';
+    registerStopAgentTaskHandler(harness, {
+      getLiveSession: vi.fn(() => ({ stopBackgroundTask: vi.fn().mockRejectedValue(err) })),
+    });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.STOP_AGENT_TASK, 'session-1', 'task-1'),
+    ).rejects.toMatchObject({ code: 'UNSUPPORTED_CAPABILITY' });
+  });
+
+  it('maps plain "not supported" failures (old SDK / old remote daemon) to UNSUPPORTED_CAPABILITY', async () => {
+    const harness = new IpcHarness();
+    registerStopAgentTaskHandler(harness, {
+      getLiveSession: vi.fn(() => ({
+        stopBackgroundTask: vi
+          .fn()
+          .mockRejectedValue(new Error('stopTask is not supported by the current Claude SDK or remote daemon')),
+      })),
+    });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.STOP_AGENT_TASK, 'session-1', 'task-1'),
+    ).rejects.toMatchObject({ code: 'UNSUPPORTED_CAPABILITY' });
+  });
+
+  it('maps other failures to INTERNAL', async () => {
+    const harness = new IpcHarness();
+    registerStopAgentTaskHandler(harness, {
+      getLiveSession: vi.fn(() => ({
+        stopBackgroundTask: vi.fn().mockRejectedValue(new Error('rpc timeout')),
+      })),
+    });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.STOP_AGENT_TASK, 'session-1', 'task-1'),
+    ).rejects.toMatchObject({ code: 'INTERNAL' });
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -86,6 +86,20 @@ export const MAKER_INVOKE = {
    */
   STOP_SESSION_BACKGROUND_TASKS: 'maker:session-background-tasks:stop',
   /**
+   * 精确停止会话内**单个**后台任务(run_in_background 的 Bash / 后台 subagent)。
+   * 入参 (sessionId, taskId)。与 STOP_SESSION_BACKGROUND_TASKS(关闭整个 agent 进程)
+   * 不同:只停指定 taskId,当前 turn 与其他后台任务不受影响。任务已结束 / 会话未
+   * 加载(子进程不存在,后台任务必然已死)→ 幂等成功;旧 SDK / 旧远端 daemon 不支持
+   * → UNSUPPORTED_CAPABILITY。
+   */
+  STOP_AGENT_TASK: 'maker:agent-task:stop',
+  /**
+   * 列出会话当前仍在运行的后台任务({taskId, taskType?, toolUseId?, title?})。只读;
+   * renderer 挂载或 reloadMessages 清空 taskUpdates 后,用它补回「订阅前已启动」的
+   * 存量任务(事件流仍是唯一实时源)。maker 未 init / 未知会话 → { tasks: [] }。
+   */
+  LIST_SESSION_BACKGROUND_TASKS: 'maker:session-background-tasks:list',
+  /**
    * 读取某个 workflow(Workflow 工具的 local_workflow 任务)的逐 agent 进度树。只读。
    * 入参 (sessionId, taskId);main 从活跃会话拿 workDir + sdkSessionId,推导出 Claude Code
    * 的 workflows 记录目录、按 taskId 匹配 wf_*.json 解析。数据源是 SDK 内部产物(无公开契约),

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -324,6 +324,7 @@ import { agentHandoffPending } from './agentHandoffPendingSingleton.js';
 import { type MakerSessionCreateOpts, withCreateSessionStderr } from './sessionRequest.js';
 import { persistAndHydrateSessionProvider } from './sessionProviderBootstrap.js';
 import { registerMakerSessionSendHandler } from './sessionSendHandler.js';
+import { registerStopAgentTaskHandler } from './stopAgentTaskHandler.js';
 import { registerStopSessionBackgroundTasksHandler } from './stopSessionBackgroundTasksHandler.js';
 import { registerProviderHandlers } from './providerHandlers.js';
 import { createLocalCliScanDeps, scanLocalCliAuth } from './localCliDetect.js';
@@ -2973,6 +2974,20 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     clearBackgroundActivity: clearClaudeSessionBackgroundActivity,
     noteSessionReset: (sessionId) => silentStopAutoResumeGuard.noteSessionReset(sessionId),
     notifyGoalStop: (sessionId) => goalStopObserver?.(sessionId),
+  });
+
+  // 单个后台任务的精确停止(消息流任务卡 / 状态栏停止按钮)。只停指定 taskId,
+  // 当前 turn 与其他后台任务不受影响 —— 与上面的会话级止损入口互补。
+  registerStopAgentTaskHandler(createElectronIpcHandlerRegistry(), {
+    getLiveSession: (sessionId) => maker.getSession(sessionId) ?? undefined,
+  });
+
+  // 会话仍在运行的后台任务快照(只读)。renderer 挂载 / reloadMessages 清空
+  // taskUpdates 后据此补回存量任务(实时增量仍走 agent_task_update 事件流)。
+  ipcMain.handle(MAKER_INVOKE.LIST_SESSION_BACKGROUND_TASKS, (_e, sessionId: unknown) => {
+    if (typeof sessionId !== 'string') throwIpcError('INVALID_PARAMS', 'sessionId required');
+    const live = maker.getSession(sessionId);
+    return { tasks: live ? live.listBackgroundTasks() : [] };
   });
 
   // workflow 逐 agent 进度树(只读)。从活跃会话拿 workDir + sdkSessionId → 推导 Claude Code

--- a/apps/desktop/src/main/maker-ipc/stopAgentTaskHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/stopAgentTaskHandler.ts
@@ -1,0 +1,53 @@
+import { throwIpcError } from '../utils/ipcValidate.js';
+import { MAKER_INVOKE } from './channels.js';
+import type { IpcHandlerRegistry } from './ipcHandlerRegistry.js';
+
+/** 精确停止只需要拿到 live session 的 stopBackgroundTask;拿不到 = 任务必然已死。 */
+export interface StopAgentTaskHandlerDeps {
+  getLiveSession(
+    sessionId: string,
+  ): { stopBackgroundTask(taskId: string): Promise<void> } | undefined;
+}
+
+/**
+ * 注册单个后台任务的精确停止入口(消息流任务卡 / 状态栏的停止按钮)。
+ *
+ * 与 STOP_SESSION_BACKGROUND_TASKS(关闭整个 agent 进程的会话级止损)不同:本入口
+ * 只停指定 taskId,当前 turn 与其他后台任务不受影响。幂等语义:会话未加载(子进程
+ * 不存在,后台任务必然已死)或任务已到终态 → 直接成功;不支持(旧 SDK / 旧远端
+ * daemon / 非 claude-code agent)→ UNSUPPORTED_CAPABILITY,按钮不得假装成功。
+ */
+export function registerStopAgentTaskHandler(
+  registry: IpcHandlerRegistry,
+  deps: StopAgentTaskHandlerDeps,
+): void {
+  registry.handle(
+    MAKER_INVOKE.STOP_AGENT_TASK,
+    async (_event, sessionId: unknown, taskId: unknown) => {
+      if (typeof sessionId !== 'string' || !sessionId) {
+        throwIpcError('INVALID_PARAMS', 'sessionId required');
+      }
+      if (typeof taskId !== 'string' || !taskId) {
+        throwIpcError('INVALID_PARAMS', 'taskId required');
+      }
+
+      const session = deps.getLiveSession(sessionId);
+      if (!session) {
+        return { ok: true as const };
+      }
+      try {
+        await session.stopBackgroundTask(taskId);
+      } catch (e) {
+        // NotSupportedError(Session 层)与 claude handle 的 'not supported' 明文
+        // 都归一到 UNSUPPORTED_CAPABILITY;其余(stopTask RPC 失败等)走 INTERNAL,
+        // 不把内部堆栈原样透出。
+        const message = e instanceof Error ? e.message : String(e);
+        if ((e instanceof Error && e.name === 'NotSupportedError') || /not supported/i.test(message)) {
+          throwIpcError('UNSUPPORTED_CAPABILITY', 'stopBackgroundTask is not supported for this session');
+        }
+        throwIpcError('INTERNAL', `failed to stop background task: ${message}`);
+      }
+      return { ok: true as const };
+    },
+  );
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3477,6 +3477,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('maker:session-background-tasks:stop', sessionId),
     /** 会话后台活动翻转订阅(payload = { sessionId, active },返回 off)。 */
     onSessionBackgroundActivityChanged: fanOutMakerSessionBackgroundActivityChanged,
+    /** 精确停止会话内单个后台任务(不中断当前 turn;任务已结束幂等成功)。 */
+    stopAgentTask: (sessionId: string, taskId: string): Promise<{ ok: true }> =>
+      ipcRenderer.invoke('maker:agent-task:stop', sessionId, taskId),
+    /** 会话仍在运行的后台任务快照(挂载 / 重载后补回存量;实时增量走事件流)。 */
+    listSessionBackgroundTasks: (
+      sessionId: string,
+    ): Promise<{ tasks: Array<{ taskId: string; taskType?: string; toolUseId?: string; title?: string }> }> =>
+      ipcRenderer.invoke('maker:session-background-tasks:list', sessionId),
     /** 通用 OAuth 供应商（目录 auth.oauth 描述符驱动）登录 / 登出 / 取消。 */
     providerOAuthLogin: (providerId: string): Promise<{ ok: boolean; reason?: string }> =>
       ipcRenderer.invoke('maker:provider:oauth:login', providerId),

--- a/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
@@ -114,5 +114,76 @@ describe('AgentTaskCard', () => {
       }),
     );
     expect(modelChip(container)).toBeNull();
+  });
+
+  // bash-task-card + 停止按钮 ---------------------------------------------------
+  const stopButton = (container: HTMLElement) =>
+    container.querySelector<HTMLButtonElement>('[data-agent-task-stop="true"]');
+
+  it('renders local_bash tasks as a background command with a stop button while running', async () => {
+    const stopAgentTask = vi.fn().mockResolvedValue({ ok: true });
+    (window as unknown as { electronAPI?: unknown }).electronAPI = {
+      maker: { stopAgentTask },
+    };
+    try {
+      const { container } = render(
+        React.createElement(AgentTaskCard, {
+          sessionId: 'session-1',
+          update: {
+            provider: 'claude-code',
+            taskId: 'bash-1',
+            status: 'running',
+            title: 'pnpm test:unit',
+            taskType: 'local_bash',
+          },
+        }),
+      );
+      expect(container.textContent).toContain('chat.agentTask.provider.shell');
+      const btn = stopButton(container);
+      expect(btn).not.toBeNull();
+      // stop 的 finally(setStopping)在微任务里落地,await 到位避免 act 泄漏警告。
+      await act(async () => {
+        btn!.click();
+        await Promise.resolve();
+      });
+      expect(stopAgentTask).toHaveBeenCalledWith('session-1', 'bash-1');
+    } finally {
+      delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    }
+  });
+
+  it('hides the stop button for terminal tasks, codex tasks, and when sessionId is missing', () => {
+    const terminal = render(
+      React.createElement(AgentTaskCard, {
+        sessionId: 'session-1',
+        update: {
+          provider: 'claude-code',
+          taskId: 'bash-1',
+          status: 'completed',
+          taskType: 'local_bash',
+        },
+      }),
+    );
+    expect(stopButton(terminal.container)).toBeNull();
+
+    const codex = render(
+      React.createElement(AgentTaskCard, {
+        sessionId: 'session-1',
+        update: { provider: 'codex', taskId: 'c1', status: 'running' },
+      }),
+    );
+    expect(stopButton(codex.container)).toBeNull();
+
+    const noSession = render(
+      React.createElement(AgentTaskCard, {
+        update: {
+          provider: 'claude-code',
+          taskId: 'bash-1',
+          status: 'running',
+          taskType: 'local_bash',
+        },
+      }),
+    );
+    expect(stopButton(noSession.container)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTaskUpdates.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTaskUpdates.test.ts
@@ -435,6 +435,51 @@ describe('getRunningSnapshot 后台 subagent 折算(真 store)', () => {
     }
   });
 
+  it('seedBackgroundTaskSnapshots 只补未见过的任务,绝不复活已终态条目', () => {
+    const sid = `seed-${Math.random().toString(36).slice(2, 8)}`;
+    try {
+      // b1 已经走完整生命周期(running → completed),快照(可能落后)仍报 running。
+      applyTask(sid, { taskId: 'b1', status: 'running', taskType: 'local_bash' });
+      applyTask(sid, { taskId: 'b1', status: 'completed' });
+
+      makerChatStore.seedBackgroundTaskSnapshots(sid, [
+        { taskId: 'b1', taskType: 'local_bash', title: 'stale snapshot' },
+        { taskId: 'b2', taskType: 'local_bash', toolUseId: 'tu-b2', title: 'pnpm test:unit' },
+      ]);
+
+      const tasks = makerChatStore.getSnapshot(sid).taskUpdates;
+      // 已存在的 b1 不被快照的 running 复活
+      expect(tasks?.get('b1')?.status).toBe('completed');
+      // 未见过的 b2 补进来,taskId / toolUseId 双 key 命中
+      expect(tasks?.get('b2')?.status).toBe('running');
+      expect(tasks?.get('b2')?.taskType).toBe('local_bash');
+      expect(tasks?.get('b2')?.title).toBe('pnpm test:unit');
+      expect(tasks?.get('tu-b2')?.taskId).toBe('b2');
+    } finally {
+      makerChatStore.purgeSession(sid);
+    }
+  });
+
+  it('seedBackgroundTaskSnapshots 按 toolUseId 命中已存在条目时同样跳过', () => {
+    const sid = `seed2-${Math.random().toString(36).slice(2, 8)}`;
+    try {
+      applyTask(sid, {
+        taskId: 'b1',
+        parentToolUseId: 'tu-b1',
+        status: 'stopped',
+        taskType: 'local_bash',
+      });
+      makerChatStore.seedBackgroundTaskSnapshots(sid, [
+        { taskId: 'b1-renamed', toolUseId: 'tu-b1', taskType: 'local_bash' },
+      ]);
+      const tasks = makerChatStore.getSnapshot(sid).taskUpdates;
+      expect(tasks?.get('tu-b1')?.status).toBe('stopped');
+      expect(tasks?.has('b1-renamed')).toBe(false);
+    } finally {
+      makerChatStore.purgeSession(sid);
+    }
+  });
+
   it('session closed 兜底(finalizeStuckRemoteTurn → forceFinalize):running 任务全收口、桥接清零', () => {
     const sid = `remote-closed-${Math.random().toString(36).slice(2, 8)}`;
     try {

--- a/apps/desktop/src/renderer/__tests__/useBackgroundBashTasks.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useBackgroundBashTasks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { listRunningClaudeBashTasks } from '@/hooks/useBackgroundBashTasks';
+import type { AgentTaskUpdate } from '@/lib/makerChatStore';
+
+function toMap(updates: AgentTaskUpdate[]): ReadonlyMap<string, AgentTaskUpdate> {
+  // 与 makerChatStore 同构:同一任务按 taskId / parentToolUseId 双 key 存两份。
+  const map = new Map<string, AgentTaskUpdate>();
+  for (const u of updates) {
+    map.set(u.taskId, u);
+    if (u.parentToolUseId) map.set(u.parentToolUseId, u);
+  }
+  return map;
+}
+
+describe('listRunningClaudeBashTasks', () => {
+  it('lists only running claude-code local_bash tasks, deduped across alias keys', () => {
+    const tasks = listRunningClaudeBashTasks(
+      toMap([
+        {
+          provider: 'claude-code',
+          taskId: 'b1',
+          parentToolUseId: 'tu-b1',
+          status: 'running',
+          taskType: 'local_bash',
+          title: 'pnpm test:unit',
+        },
+        // 终态 bash 不进列表
+        { provider: 'claude-code', taskId: 'b2', status: 'completed', taskType: 'local_bash' },
+        // wake 型任务不属于 bash 列表(状态栏另有 proxy 活动信号覆盖)
+        { provider: 'claude-code', taskId: 'a1', status: 'running', taskType: 'local_agent' },
+        // codex 任务没有 stopTask 通道,不列
+        { provider: 'codex', taskId: 'c1', status: 'running', taskType: 'local_bash' },
+      ]),
+    );
+    expect(tasks).toEqual([{ taskId: 'b1', title: 'pnpm test:unit' }]);
+  });
+
+  it('returns an empty list for empty or missing maps', () => {
+    expect(listRunningClaudeBashTasks(undefined)).toEqual([]);
+    expect(listRunningClaudeBashTasks(new Map())).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useCallback } from 'react';
+import { Fragment, useMemo, useCallback, useState } from 'react';
 import {
   AlertCircle,
   Bot,
@@ -6,6 +6,8 @@ import {
   ChevronRight,
   CircleStop,
   LoaderCircle,
+  Square,
+  SquareTerminal,
   Workflow,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +16,7 @@ import { useExpandedBlockMemory } from '@/hooks/useExpandedBlockMemory';
 import { Collapse } from '@/components/ui/collapse';
 import { Spinner } from '@/components/ui/spinner';
 import type { AgentTaskUpdate, ChatMessage } from '@/hooks/useCCAgentChat';
+import { isRemoteSession } from '@/lib/makerTransport';
 import { cn } from '@/lib/utils';
 import { formatModelShortLabel } from '@/lib/modelShortLabel';
 import { WorkflowAgentTree } from './WorkflowAgentTree';
@@ -98,7 +101,11 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
   // workflowName、头像换 Workflow 图标、provider 标签显示 "Workflow";其余(状态 / 聚合
   // usage / 展开详情)复用本卡既有逻辑。
   const isWorkflow = update?.taskType === 'local_workflow' || toolCall?.toolName === 'Workflow';
-  const AvatarIcon = isWorkflow ? Workflow : Bot;
+  // bash-task-card: 后台 Bash(run_in_background)与子 Agent 共用本卡,但视觉上
+  // 是「后台命令」—— 终端图标 + shell provider 标签,避免用户把跑测试的 bash
+  // 误读成一个子 Agent。
+  const isBash = update?.taskType === 'local_bash';
+  const AvatarIcon = isWorkflow ? Workflow : isBash ? SquareTerminal : Bot;
   const title = compactText(
     (isWorkflow ? update?.workflowName : undefined) ??
       update?.title ??
@@ -115,9 +122,35 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
   const provider = update?.provider ?? (toolCall?.toolName?.startsWith('collab:') ? 'codex' : 'claude-code');
   const providerLabel = isWorkflow
     ? t('chat.agentTask.provider.workflow')
-    : provider === 'codex'
-      ? t('chat.agentTask.provider.codex')
-      : t('chat.agentTask.provider.claude');
+    : isBash
+      ? t('chat.agentTask.provider.shell')
+      : provider === 'codex'
+        ? t('chat.agentTask.provider.codex')
+        : t('chat.agentTask.provider.claude');
+
+  // 停止按钮:running + 本会话可定位 + claude-code(codex 无 stopTask 通道)。
+  // 点击后交给 main 的 stopAgentTask;成功与否都由 task_notification 事件流收口
+  // (状态翻 stopped → 按钮自然消失),这里只管在飞态防连点。失败静默恢复 ——
+  // 任务恰好自然结束时 stop 是幂等成功,真失败(不支持等)保持 running 状态可重试。
+  const [stopping, setStopping] = useState(false);
+  const canStop =
+    status === 'running' &&
+    Boolean(sessionId) &&
+    Boolean(update?.taskId) &&
+    update?.provider === 'claude-code' &&
+    // device-link 镜像会话:session 活在被控端,本地 stopAgentTask 会假成功 —— 不给按钮。
+    !(sessionId && isRemoteSession(sessionId));
+  const handleStop = useCallback(() => {
+    const api = window.electronAPI?.maker;
+    if (!sessionId || !update?.taskId || !api?.stopAgentTask) return;
+    setStopping(true);
+    void api
+      .stopAgentTask(sessionId, update.taskId)
+      .catch(() => {
+        // 静默:失败时卡片仍显示 running,用户可重试;不弹打断式错误。
+      })
+      .finally(() => setStopping(false));
+  }, [sessionId, update?.taskId]);
 
   const meta = useMemo(() => {
     const parts: Array<{ key: string; text: string }> = [
@@ -149,10 +182,13 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
           : {})}
         className="w-full rounded-[12px] border border-[var(--border-default)] bg-[var(--surface-elevated)] px-3 py-2"
       >
+        {/* 折叠头 = 展开 toggle + 可选的停止按钮。button 不能嵌套,停止按钮以
+            兄弟节点挂在 toggle 右侧(仅 running 时出现)。 */}
+        <div className="flex w-full items-start gap-2">
         <button
           type="button"
           onClick={toggle}
-          className="flex w-full items-start gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+          className="flex min-w-0 flex-1 items-start gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
           aria-expanded={expanded}
           aria-label={expanded ? t('chat.agentTask.hideDetails') : t('chat.agentTask.showDetails')}
         >
@@ -201,6 +237,25 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
             aria-hidden="true"
           />
         </button>
+        {canStop && (
+          <button
+            type="button"
+            onClick={handleStop}
+            disabled={stopping}
+            title={t('chat.agentTask.stop')}
+            aria-label={t('chat.agentTask.stop')}
+            data-agent-task-stop="true"
+            className={cn(
+              'mt-[2px] inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px]',
+              'text-[var(--text-secondary)] hover:bg-[var(--surface-chip)] hover:text-[var(--text-primary)]',
+              'transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+            )}
+          >
+            <Square size={11} aria-hidden="true" />
+          </button>
+        )}
+        </div>
 
         <Collapse open={expanded}>
           <div className="mt-2 border-l-2 border-[var(--agent-actions-rail)] pl-3 text-13 leading-5 text-[var(--text-secondary)]">

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -68,6 +68,7 @@ import {
   ErrorTailErrorBanner,
   InterruptedTurnBanner,
 } from '@/components/chat/InterruptedTurnBanner';
+import { useBackgroundBashTasks } from '@/hooks/useBackgroundBashTasks';
 import { useSessionBackgroundActivity } from '@/hooks/useSessionBackgroundActivity';
 import { VendorIcon } from '@/components/sidebar/VendorIcon';
 import {
@@ -1153,10 +1154,17 @@ export function CCAgentSessionView({
   // 消耗用量)。main 侧按 proxy 活动信号判定并推送;消费点是 RunningStatusBar 的
   // 后台模式(呼吸 + 「全部停止」);「全部停止」= 关闭常驻子进程(会话可续)。
   const backgroundActivity = useSessionBackgroundActivity(sessionId);
+  // 后台 Bash 任务(run_in_background 的 Bash,taskType=local_bash):不调模型,
+  // proxy 活动信号覆盖不到 —— 从 taskUpdates 事件流折算,并在挂载/重载后用 main
+  // 快照补回存量。与上面的 proxy 信号一起点亮状态栏后台模式。
+  const backgroundBash = useBackgroundBashTasks(sessionId, taskUpdates, historyLoaded);
   // 与运行态互斥(turn 一开跑 main 即广播熄灭,这里再加一道渲染守卫防瞬时竞态):
   // 只在「无 turn 在跑」时才把状态栏切到后台子任务模式。
   const backgroundTasksActive =
-    backgroundActivity.active && !agentStatus.isRunning && !isStreaming && Boolean(sessionId);
+    (backgroundActivity.active || backgroundBash.tasks.length > 0) &&
+    !agentStatus.isRunning &&
+    !isStreaming &&
+    Boolean(sessionId);
 
   // error-tail-banner:会话尾部停在未忽略的 role='error' 行 → 输入框上方显示
   // 可操作红条(与 live ErrorBanner 同风格;2026-07-05 产品决策统一——所有尾部
@@ -2812,8 +2820,17 @@ export function CCAgentSessionView({
                 inputWidth={inputWidth}
                 sideTaskRunning={agentStatus.sideTaskRunning ?? false}
                 backgroundTasksRunning={backgroundTasksActive}
-                backgroundStopping={backgroundActivity.stopping}
-                onStopBackgroundTasks={() => void backgroundActivity.stopAll()}
+                // 仅后台 Bash 在跑(无模型调用)时换专属文案 + 温和停止语义:
+                // 逐任务 stopTask,不关常驻子进程。proxy 信号在时维持原语义
+                // (关子进程止损,bash 任务随之终止,无需再逐个停)。
+                backgroundBashOnlyCount={
+                  backgroundActivity.active ? 0 : backgroundBash.tasks.length
+                }
+                backgroundStopping={backgroundActivity.stopping || backgroundBash.stopping}
+                onStopBackgroundTasks={() => {
+                  if (backgroundActivity.active) void backgroundActivity.stopAll();
+                  else void backgroundBash.stopAll();
+                }}
                 // 被控端可见性 chip 嵌进状态栏中央槽位,与 thinking / 时间 token 同行
                 // (不再单独占一行)。中央槽位独立于状态栏淡入淡出 → 空闲时仍显示。
                 centerSlot={showInlineControlledBanner ? <ControlledBanner placement="statusbar" /> : null}
@@ -3455,6 +3472,7 @@ function RunningStatusBar({
   inputWidth,
   sideTaskRunning = false,
   backgroundTasksRunning = false,
+  backgroundBashOnlyCount = 0,
   backgroundStopping = false,
   onStopBackgroundTasks,
   centerSlot = null,
@@ -3478,6 +3496,12 @@ function RunningStatusBar({
    * 计数在此语义下都是误导信息。替代原独立横幅(2026-07-13 假停止治理)。
    */
   backgroundTasksRunning?: boolean;
+  /**
+   * 后台模式细分:>0 表示当前只有后台 Bash 任务在跑(无模型调用)。左段换
+   * 「后台任务运行中(N 个)」文案,「全部停止」tooltip 换成逐任务停止语义
+   * (不关常驻子进程)。0 = 维持原「仍在调模型」文案与止损语义。
+   */
+  backgroundBashOnlyCount?: number;
   /** 全停请求在飞(按钮禁用,防连点)。 */
   backgroundStopping?: boolean;
   /** 「全部停止」入口(关闭常驻 CC 子进程,会话可续)。 */
@@ -3538,8 +3562,13 @@ function RunningStatusBar({
   // 是 "Done", 此时任务还在跑, 显示 ✓ 完成图标会让用户以为已经做完)。
   const isDone = status === 'Done' && !sideTaskRunning && !backgroundTasksRunning;
   // 后台子任务模式的左段文案:上一轮残留的 status(多半是 "Done")在此语义下是
-  // 误导信息,整体替换为后台运行提示。
-  const displayStatus = backgroundTasksRunning ? t('chat.backgroundActivity.status') : status;
+  // 误导信息,整体替换为后台运行提示。仅后台 Bash 时用带数量的专属文案 ——
+  // 「模型用量仍在消耗」对不调模型的 bash 任务是错误陈述。
+  const displayStatus = backgroundTasksRunning
+    ? backgroundBashOnlyCount > 0
+      ? t('chat.backgroundActivity.bashStatus', { count: backgroundBashOnlyCount })
+      : t('chat.backgroundActivity.status')
+    : status;
   // F-COMPACT-1: when SDK is auto-summarizing the conversation, give the
   // status bar a distinct icon so the user can tell "Compacting..." apart
   // from "Thinking..." — both share the shimmer animation by design, but
@@ -3657,7 +3686,11 @@ function RunningStatusBar({
               'text-[var(--text-primary)] hover:opacity-70 transition-opacity',
               'disabled:opacity-50 disabled:cursor-not-allowed',
             )}
-            title={t('chat.backgroundActivity.stopAllTitle')}
+            title={t(
+              backgroundBashOnlyCount > 0
+                ? 'chat.backgroundActivity.stopBashTitle'
+                : 'chat.backgroundActivity.stopAllTitle',
+            )}
           >
             <Square size={12} />
             {backgroundStopping

--- a/apps/desktop/src/renderer/hooks/useBackgroundBashTasks.ts
+++ b/apps/desktop/src/renderer/hooks/useBackgroundBashTasks.ts
@@ -1,0 +1,113 @@
+/**
+ * useBackgroundBashTasks —— 会话内仍在运行的后台 Bash 任务(taskType=local_bash,
+ * 即 run_in_background 的 Bash 工具)的响应式列表 + 一键全停。
+ *
+ * 与 useSessionBackgroundActivity 互补:那边的信号源是「CC 子进程仍在调模型」
+ * (loopback proxy 活动),只覆盖后台 subagent;后台 Bash 不调模型,永远点不亮那个
+ * 信号。本 hook 直接从 makerChatStore 的 taskUpdates(agent_task_update 事件流)
+ * 折算,并在挂载 / 历史重载后用 main 的 listSessionBackgroundTasks 快照补回
+ * 「订阅前已启动 / reloadMessages 清空」的存量任务(store 侧只补未见过的条目,
+ * 不会复活已终态任务)。
+ *
+ * 注意:这里的折算是纯 UI 信号,不参与 makerChatStore 的 running 语义(local_bash
+ * 不折算 running 的既有决策不变 —— dev server 不能把会话 spinner 永转)。
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { makerChatStore } from '@/lib/makerChatStore';
+import type { AgentTaskUpdate } from '@/lib/makerChatStore';
+import { isRemoteSession } from '@/lib/makerTransport';
+
+export interface RunningBashTask {
+  taskId: string;
+  title?: string;
+}
+
+/**
+ * 从 taskUpdates 折算「仍在运行的后台 Bash 任务」列表(纯函数,供单测)。
+ * Map 里同一任务按 taskId / parentToolUseId 双 key 存两份 —— 按 taskId 去重。
+ * 只认 claude-code:codex 会话没有对应的 stopTask 通道,列出来也停不掉。
+ */
+export function listRunningClaudeBashTasks(
+  taskUpdates: ReadonlyMap<string, AgentTaskUpdate> | undefined,
+): RunningBashTask[] {
+  if (!taskUpdates || taskUpdates.size === 0) return [];
+  const out = new Map<string, RunningBashTask>();
+  for (const update of taskUpdates.values()) {
+    if (update.provider !== 'claude-code') continue;
+    if (update.taskType !== 'local_bash') continue;
+    if (update.status !== 'running') continue;
+    if (out.has(update.taskId)) continue;
+    out.set(update.taskId, {
+      taskId: update.taskId,
+      ...(update.title ? { title: update.title } : {}),
+    });
+  }
+  return [...out.values()];
+}
+
+export function useBackgroundBashTasks(
+  sessionId: string | undefined,
+  taskUpdates: ReadonlyMap<string, AgentTaskUpdate> | undefined,
+  /** historyLoaded 翻 true 时重新水合(reloadMessages 会清空 taskUpdates 再重载)。 */
+  historyLoaded?: boolean,
+): {
+  tasks: RunningBashTask[];
+  stopping: boolean;
+  stopAll: () => Promise<void>;
+} {
+  const [stopping, setStopping] = useState(false);
+
+  // device-link 镜像会话:session 活在被控端,本地 main 拿不到 handle(快照返回
+  // 空、stop 假成功),且镜像事件有设计内丢失窗口 —— 与「远程会话豁免 running
+  // 折算」同口径,整个信号在控制端关闭,由被控端自己的 UI 承载。
+  const remoteMirror = Boolean(sessionId) && isRemoteSession(sessionId as string);
+
+  // 快照水合:挂载 / 切会话 / 历史重载完成后拉一次存量。maker 未 init 等瞬态失败
+  // 保持现状 —— 实时事件流仍会自然补上。
+  useEffect(() => {
+    if (!sessionId || remoteMirror) return;
+    const api = window.electronAPI?.maker;
+    if (!api?.listSessionBackgroundTasks) return;
+    let disposed = false;
+    void api
+      .listSessionBackgroundTasks(sessionId)
+      .then(({ tasks }) => {
+        if (disposed || !Array.isArray(tasks) || tasks.length === 0) return;
+        makerChatStore.seedBackgroundTaskSnapshots(sessionId, tasks);
+      })
+      .catch(() => {
+        // 静默:与 useSessionBackgroundActivity 的快照失败同口径。
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [sessionId, remoteMirror, historyLoaded]);
+
+  const tasks = useMemo(
+    () => (remoteMirror ? [] : listRunningClaudeBashTasks(taskUpdates)),
+    [remoteMirror, taskUpdates],
+  );
+
+  // stopAll 读 ref 而非闭包列表:按钮点击时以最新运行集为准,避免陈旧闭包重复停。
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
+
+  const stopAll = useCallback(async () => {
+    const api = window.electronAPI?.maker;
+    if (!sessionId || !api?.stopAgentTask) return;
+    const targets = tasksRef.current;
+    if (targets.length === 0) return;
+    setStopping(true);
+    try {
+      // 逐个停,单个失败不拦其余;成功与否都交给 task_notification 事件流收口,
+      // 这里不改本地状态(单一事实源)。
+      await Promise.allSettled(targets.map((t) => api.stopAgentTask(sessionId, t.taskId)));
+    } finally {
+      setStopping(false);
+    }
+  }, [sessionId]);
+
+  return { tasks, stopping, stopAll };
+}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3959,7 +3959,8 @@
       "provider": {
         "claude": "Claude Code",
         "codex": "Codex",
-        "workflow": "Workflow"
+        "workflow": "Workflow",
+        "shell": "Background command"
       },
       "status": {
         "running": "Running",
@@ -3967,6 +3968,7 @@
         "failed": "Failed",
         "stopped": "Stopped"
       },
+      "stop": "Stop this task",
       "tokens": "{{count}} tokens",
       "toolUses_one": "{{count}} tool use",
       "toolUses_other": "{{count}} tool uses",
@@ -4050,8 +4052,11 @@
     },
     "backgroundActivity": {
       "status": "Background subtasks running, still consuming model usage…",
+      "bashStatus_one": "{{count}} background task running…",
+      "bashStatus_other": "{{count}} background tasks running…",
       "stopAll": "Stop all",
       "stopAllTitle": "Shut down this session's background process and stop all background subtasks (the session stays usable)",
+      "stopBashTitle": "Stop the background tasks still running in this session (keeps the session process)",
       "stopping": "Stopping…"
     },
     "interruptedBanner": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3958,7 +3958,8 @@
       "provider": {
         "claude": "Claude Code",
         "codex": "Codex",
-        "workflow": "Workflow"
+        "workflow": "Workflow",
+        "shell": "バックグラウンドコマンド"
       },
       "status": {
         "running": "実行中",
@@ -3966,6 +3967,7 @@
         "failed": "失敗",
         "stopped": "停止済み"
       },
+      "stop": "このタスクを停止",
       "tokens": "{{count}} tokens",
       "toolUses_one": "{{count}} 回のツール使用",
       "toolUses_other": "{{count}} 回のツール使用",
@@ -4049,8 +4051,11 @@
     },
     "backgroundActivity": {
       "status": "バックグラウンドのサブタスクが実行中、モデル使用量を消費しています…",
+      "bashStatus_one": "バックグラウンドタスク実行中（{{count}} 件）…",
+      "bashStatus_other": "バックグラウンドタスク実行中（{{count}} 件）…",
       "stopAll": "すべて停止",
       "stopAllTitle": "このセッションのバックグラウンドプロセスを終了し、すべてのサブタスクを停止します（セッションは引き続き使用できます）",
+      "stopBashTitle": "このセッションで実行中のバックグラウンドタスクを停止します（セッションのプロセスは終了しません）",
       "stopping": "停止中…"
     },
     "interruptedBanner": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3958,7 +3958,8 @@
       "provider": {
         "claude": "Claude Code",
         "codex": "Codex",
-        "workflow": "Workflow"
+        "workflow": "Workflow",
+        "shell": "백그라운드 명령"
       },
       "status": {
         "running": "실행 중",
@@ -3966,6 +3967,7 @@
         "failed": "실패",
         "stopped": "중지됨"
       },
+      "stop": "이 작업 중지",
       "tokens": "{{count}} tokens",
       "toolUses_one": "도구 호출 {{count}}회",
       "toolUses_other": "도구 호출 {{count}}회",
@@ -4049,8 +4051,11 @@
     },
     "backgroundActivity": {
       "status": "백그라운드 하위 작업 실행 중, 모델 사용량을 소비하고 있습니다…",
+      "bashStatus_one": "백그라운드 작업 실행 중({{count}}개)…",
+      "bashStatus_other": "백그라운드 작업 실행 중({{count}}개)…",
       "stopAll": "모두 중지",
       "stopAllTitle": "이 세션의 백그라운드 프로세스를 종료하고 모든 하위 작업을 중지합니다(세션은 계속 사용할 수 있습니다)",
+      "stopBashTitle": "이 세션에서 실행 중인 백그라운드 작업을 중지합니다(세션 프로세스는 유지됩니다)",
       "stopping": "중지 중…"
     },
     "interruptedBanner": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3958,7 +3958,8 @@
       "provider": {
         "claude": "Claude Code",
         "codex": "Codex",
-        "workflow": "Workflow"
+        "workflow": "Workflow",
+        "shell": "后台命令"
       },
       "status": {
         "running": "运行中",
@@ -3966,6 +3967,7 @@
         "failed": "失败",
         "stopped": "已停止"
       },
+      "stop": "停止该任务",
       "tokens": "{{count}} tokens",
       "toolUses_one": "{{count}} 次工具调用",
       "toolUses_other": "{{count}} 次工具调用",
@@ -4049,8 +4051,11 @@
     },
     "backgroundActivity": {
       "status": "后台子任务运行中，模型用量仍在消耗…",
+      "bashStatus_one": "后台任务运行中（{{count}} 个）…",
+      "bashStatus_other": "后台任务运行中（{{count}} 个）…",
       "stopAll": "全部停止",
       "stopAllTitle": "关闭该会话的后台进程，停止全部后台子任务（会话可继续使用）",
+      "stopBashTitle": "停止该会话仍在运行的后台任务（不关闭会话进程）",
       "stopping": "停止中…"
     },
     "interruptedBanner": {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -7302,6 +7302,42 @@ export const makerChatStore = {
   setAskUserDraft,
   setTitleUpdateCallback,
   syncActiveTurnsFromMain,
+  /**
+   * 后台任务快照水合:把 main 的 listSessionBackgroundTasks 结果补进 taskUpdates。
+   * 只补「store 里完全没见过」的任务 —— 事件流是唯一实时源,快照可能落后于刚到
+   * 的终态事件,已存在的条目(无论何状态)绝不用快照的 running 覆盖复活。
+   * 消费方:useBackgroundBashTasks(会话挂载 / reloadMessages 清空 taskUpdates 后)。
+   */
+  seedBackgroundTaskSnapshots: (
+    sessionId: string,
+    tasks: Array<{ taskId: string; taskType?: string; toolUseId?: string; title?: string }>,
+  ): void => {
+    if (!tasks.length) return;
+    setState(sessionId, (s) => {
+      let next = s;
+      for (const t of tasks) {
+        if (!t || typeof t.taskId !== 'string' || !t.taskId) continue;
+        const seen =
+          next.taskUpdates?.has(t.taskId) ||
+          (t.toolUseId ? next.taskUpdates?.has(t.toolUseId) : false);
+        if (seen) continue;
+        next = handleStreamEvent(next, {
+          sessionId,
+          type: 'agent_task_update',
+          source: 'claude-code',
+          data: {
+            provider: 'claude-code',
+            taskId: t.taskId,
+            status: 'running',
+            ...(t.taskType ? { taskType: t.taskType } : {}),
+            ...(t.toolUseId ? { parentToolUseId: t.toolUseId } : {}),
+            ...(t.title ? { title: t.title } : {}),
+          },
+        } as CCAgentStreamEvent);
+      }
+      return next;
+    });
+  },
   /** Exposed for tests only. */
   __teardownGlobalListeners,
   /** Exposed for tests only: 把 stream event 打进真实 store(驱动 getRunningSnapshot 等)。 */

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3461,6 +3461,12 @@ interface ElectronAPI {
     onSessionBackgroundActivityChanged: (
       cb: (payload: { sessionId: string; active: boolean }) => void,
     ) => () => void;
+    /** 精确停止会话内单个后台任务(不中断当前 turn;任务已结束幂等成功)。 */
+    stopAgentTask: (sessionId: string, taskId: string) => Promise<{ ok: true }>;
+    /** 会话仍在运行的后台任务快照(挂载 / 重载后补回存量;实时增量走事件流)。 */
+    listSessionBackgroundTasks: (sessionId: string) => Promise<{
+      tasks: Array<{ taskId: string; taskType?: string; toolUseId?: string; title?: string }>;
+    }>;
     /**
      * renderer → main 单向镜像「模型显示/隐藏」override 整张快照(modelVisibilityPrefs)。
      * 让 IM /model 在 main 侧复用同一套可见性过滤,与应用内模型列表逐模型一致。fire-and-forget。

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -592,6 +592,19 @@ export interface SendOptions {
 }
 
 /**
+ * 会话内仍在运行的单个后台任务快照(listBackgroundTasks 的元素)。字段与
+ * agent_task_update 事件同源:taskId 是 SDK task_id;toolUseId 是派生该任务的
+ * 工具调用 id(renderer 用它对回消息流里的工具行);title 是 SDK description。
+ */
+export interface BackgroundTaskSnapshot {
+  taskId: string;
+  /** SDK task_type(local_bash / local_agent / local_workflow 等),缺失表示未知。 */
+  taskType?: string;
+  toolUseId?: string;
+  title?: string;
+}
+
+/**
  * 一个已启动的 agent 会话句柄。
  * 上层 Session 类持有此句柄并对外暴露 UI 友好的 API。
  */
@@ -627,6 +640,23 @@ export interface AgentSessionHandle {
 
   /** 中断当前 turn */
   abort(): Promise<void>;
+
+  /**
+   * 停止会话内单个后台任务(SDK Query.stopTask 透传)。
+   * 与 abort() 的区别:abort 是"用户 Stop"的全停语义(只连带 wake 型任务、并
+   * 中断当前 turn);本方法精确停一个后台任务(含 local_bash —— 用户在 UI 上
+   * 对着具体任务点停,不存在 abort 那种误杀 dev server 的顾虑),不碰当前 turn。
+   * 幂等:任务已到终态时静默成功。不支持的 agent 留空(Session 层抛
+   * NotSupportedError)。
+   */
+  stopBackgroundTask?(taskId: string): Promise<void>;
+
+  /**
+   * 当前仍在运行的后台任务快照(含 local_bash)。事件流(agent_task_update)是
+   * 唯一实时源;本方法只服务「订阅者挂载/重载晚于任务启动」的存量补齐场景。
+   * 不支持的 agent 留空(Session 层回退为空数组)。
+   */
+  listBackgroundTasks?(): BackgroundTaskSnapshot[];
 
   /** 关闭会话，清理子进程 */
   close(): Promise<void>;

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -301,6 +301,55 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('stopBackgroundTask stops a single running task (including local_bash) without interrupting the turn', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-bash', 'local_bash'));
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 2, 'task_started events observed');
+
+    await handle.stopBackgroundTask!('task-bash');
+
+    // 精确停单个任务:只停被点名的 bash,不碰其他任务、不 interrupt 当前 turn。
+    expect(fakeQuery.stopTask!.mock.calls.map((c) => c[0])).toEqual(['task-bash']);
+    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('stopBackgroundTask is idempotent for terminal / unknown tasks', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-1', 'local_bash'));
+    stream.emit(taskNotification('task-1', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'task terminal event observed');
+
+    // 已终态与从未存在的任务都静默成功(UI 点击与 task_notification 天然竞态)。
+    await expect(handle.stopBackgroundTask!('task-1')).resolves.toBeUndefined();
+    await expect(handle.stopBackgroundTask!('task-unknown')).resolves.toBeUndefined();
+    expect(fakeQuery.stopTask).not.toHaveBeenCalled();
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('stopBackgroundTask rejects when the query has no stopTask (old SDK / old remote daemon)', async () => {
+    const { handle, stream, events } = await startSessionWithStream({ omitStopTask: true });
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-1', 'local_bash'));
+    await waitFor(() => taskEvents(events).length >= 1, 'task_started observed');
+
+    // 不支持时明确失败,按钮不能假装成功(与 abort 的降级容忍语义不同)。
+    await expect(handle.stopBackgroundTask!('task-1')).rejects.toThrow(/not supported/);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('degrades to interrupt-only when the query has no stopTask (old SDK / old remote daemon)', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream({ omitStopTask: true });
 

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1958,21 +1958,42 @@ export class ClaudeCodeAgent extends BaseAgent {
     // local_bash 不调模型(dev server 等长驻进程不能被 Stop 误杀);remote_agent
     // 生命周期不在本进程。q.close() 会连 CLI 子进程一起杀(任务随之死亡),
     // 换代 / teardown / close 时清表。
-    const runningBackgroundTasks = new Map<string, { wake: boolean }>();
+    // 元数据(taskType / toolUseId / title)与 wake 同口径锁存:task_started 全量携带,
+    // 后续 task_updated 补丁可能缺失,补丁不得把已知字段冲掉 —— listBackgroundTasks
+    // 快照(renderer 挂载/重载后重新水合任务卡)依赖这些字段还原展示。
+    const runningBackgroundTasks = new Map<
+      string,
+      { wake: boolean; taskType?: string; toolUseId?: string; title?: string }
+    >();
     function noteBackgroundTaskEvent(e: AgentEvent): void {
       if (e.type !== 'agent_task_update') return;
       const data = e.data as
-        | { taskId?: unknown; status?: unknown; taskType?: unknown }
+        | {
+            taskId?: unknown;
+            status?: unknown;
+            taskType?: unknown;
+            parentToolUseId?: unknown;
+            title?: unknown;
+          }
         | null
         | undefined;
       const taskId = typeof data?.taskId === 'string' ? data.taskId : undefined;
       if (!taskId) return;
       const status = data?.status;
       if (status === 'running') {
+        const prev = runningBackgroundTasks.get(taskId);
         const wake =
-          runningBackgroundTasks.get(taskId)?.wake === true ||
+          prev?.wake === true ||
           (typeof data?.taskType === 'string' && WAKE_BACKGROUND_TASK_TYPES.has(data.taskType));
-        runningBackgroundTasks.set(taskId, { wake });
+        runningBackgroundTasks.set(taskId, {
+          wake,
+          taskType: typeof data?.taskType === 'string' && data.taskType ? data.taskType : prev?.taskType,
+          toolUseId:
+            typeof data?.parentToolUseId === 'string' && data.parentToolUseId
+              ? data.parentToolUseId
+              : prev?.toolUseId,
+          title: typeof data?.title === 'string' && data.title ? data.title : prev?.title,
+        });
       } else if (status === 'completed' || status === 'failed' || status === 'stopped') {
         runningBackgroundTasks.delete(taskId);
       }
@@ -3229,6 +3250,34 @@ export class ClaudeCodeAgent extends BaseAgent {
           turnState.interruptRequested = false;
           log.warn('abort threw', { error: String(e) });
         }
+      },
+
+      async stopBackgroundTask(taskId: string) {
+        // 精确停单个后台任务(UI 对着具体任务卡点停)。与 abort 的全停语义不同:
+        // 不碰当前 turn、不限 wake 型 —— local_bash 也允许(用户明确指着它停,
+        // 不存在 abort 误杀 dev server 的顾虑)。
+        // 幂等:任务已终态 / 未知(UI 点击与 task_notification 天然竞态)→ 静默成功。
+        if (closed) return;
+        if (!runningBackgroundTasks.has(taskId)) return;
+        // 远端老 daemon / 老 SDK 没有 stopTask:明确失败(按钮不该假装成功)。
+        if (typeof q.stopTask !== 'function') {
+          throw new Error('stopTask is not supported by the current Claude SDK or remote daemon');
+        }
+        // 成功后 SDK 会回吐 status:'stopped' 的 task_notification → 现有事件链
+        // 把任务出表并让 UI 收口;这里不主动改表,保持单一事实源。
+        await q.stopTask(taskId);
+      },
+
+      listBackgroundTasks() {
+        // 当前仍在运行的后台任务快照(renderer 挂载 / reloadMessages 后重新水合
+        // 任务卡与状态栏信号)。事件流才是实时源,这里只补「订阅之前已启动」的存量。
+        if (closed) return [];
+        return Array.from(runningBackgroundTasks, ([taskId, info]) => ({
+          taskId,
+          ...(info.taskType ? { taskType: info.taskType } : {}),
+          ...(info.toolUseId ? { toolUseId: info.toolUseId } : {}),
+          ...(info.title ? { title: info.title } : {}),
+        }));
       },
 
       async close() {

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -36,7 +36,7 @@ import type {
 } from './types/events.js';
 import { isTerminalAgentErrorEvent } from './types/events.js';
 import type { ContextUsageData } from './types/context-usage.js';
-import type { AgentSessionHandle, SendOptions } from './agents/base-agent.js';
+import type { AgentSessionHandle, BackgroundTaskSnapshot, SendOptions } from './agents/base-agent.js';
 import type { Logger } from './interfaces/logger.js';
 
 export type SessionStatus = 'active' | 'aborting' | 'closed' | 'error';
@@ -337,6 +337,28 @@ export class Session {
         this.setStatus('active');
       }
     }
+  }
+
+  /**
+   * 停止本会话内单个后台任务(run_in_background 的 Bash / 后台 subagent 等)。
+   * 与 abort() 不同:不中断当前 turn,只停指定 taskId;任务已到终态时幂等成功。
+   * 会话已关闭 / 出错时静默返回 —— 此时子进程已死,后台任务必然随之终止。
+   */
+  async stopBackgroundTask(taskId: string): Promise<void> {
+    if (this.status === 'closed' || this.status === 'error') return;
+    if (!this.handle.stopBackgroundTask) {
+      throw new NotSupportedError('stopBackgroundTask', { supported: false, reason: 'not-implemented' });
+    }
+    await this.handle.stopBackgroundTask(taskId);
+  }
+
+  /**
+   * 当前仍在运行的后台任务快照。不支持的 agent / 已关闭会话 → 空数组(此时
+   * 子进程不存在,后台任务必然已死,空数组即事实)。
+   */
+  listBackgroundTasks(): BackgroundTaskSnapshot[] {
+    if (this.status === 'closed' || this.status === 'error') return [];
+    return this.handle.listBackgroundTasks?.() ?? [];
   }
 
   close(): Promise<void> {


### PR DESCRIPTION
## 这次改了什么

### 摘要

后台 Bash 任务(Bash 工具 `run_in_background`,SDK `taskType=local_bash`,典型场景:后台跑单测 / dev server)此前对用户几乎不可见:消息流的任务卡在会话切走再切回(reloadMessages 清空 taskUpdates)后彻底消失,而进程还在跑;输入栏上方状态栏的后台模式信号只看「CC 子进程是否在调模型」(loopback proxy 活动),bash 不调模型永远点不亮;并且全链路没有任何「停掉一个卡死的后台任务」的入口(会话级 Stop 刻意不杀 bash,防误杀 dev server)。

本 PR 打通「可见 + 可停」:

- **maker-core**:`AgentSessionHandle` 新增可选 `stopBackgroundTask(taskId)` / `listBackgroundTasks()`;claude-code 实现复用 `q.stopTask` 与既有 `runningBackgroundTasks` 表(表内元数据扩展 taskType/toolUseId/title)。终态/未知任务幂等成功;旧 SDK / 旧远端 daemon 无 stopTask 时明确失败,不假装成功。`Session` 层转发,不支持的 agent 抛 `NotSupportedError`。
- **desktop main**:新增 `maker:agent-task:stop`(精确停单个任务,不中断当前 turn,与会话级止损入口 `maker:session-background-tasks:stop` 互补)与 `maker:session-background-tasks:list`(只读快照)。handler 走 deps 注入 + IpcHarness 单测,错误走 `throwIpcError`(INVALID_PARAMS / UNSUPPORTED_CAPABILITY / INTERNAL)。
- **renderer**:
  - 消息流任务卡(AgentTaskCard)对 `local_bash` 换终端图标 + 「后台命令」标签;running 时卡上有停止按钮;
  - 状态栏后台模式并上「running 的 local_bash」信号:显示「后台任务运行中(N 个)…」+「全部停止」(逐任务 stopTask,**不**关会话进程;原 proxy 信号在时维持原文案与关进程止损语义);
  - 挂载 / 历史重载后从 main 快照水合 taskUpdates(只补 store 里未见过的任务,绝不复活已终态条目),修掉「切走切回卡片消失」;
  - i18n 四语言齐全。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:无(用户反馈:后台任务不可见、卡死无法停止)
- 本 PR 包含:maker-core handle/Session API、两条新 IPC、renderer 展示与停止入口、快照水合、i18n、单测
- 明确不包含:侧边栏跨会话 bash 呼吸指示(现有呼吸仍只覆盖 proxy 模型活动信号);Bash 工具行(AgentActionRow)内联状态;workflow/subagent 卡片停止按钮以外的批量管理 UI
- 用户可见变化:后台 Bash 任务在消息流有实时状态卡(可停);turn 结束后若有后台任务,输入栏上方状态栏点亮并提供「全部停止」
- 是否存在 breaking change:无(新 handle 方法均为可选;既有 IPC 行为不变)

### UI 变化

涉及。新 UI 全部复用现有 CSS token(--surface-chip / --text-secondary 等),Light/Dark 双模式由变量体系保证,无硬编码颜色。截图待补(见「未执行的验证」)。

## 怎么验证的

### 自动验证

```text
pnpm test:unit                         结果:全部 PASS(EXIT:0)
pnpm --filter desktop typecheck        结果:通过
pnpm check:i18n                        结果:5102 key 四语言一致,无新增警告
定向:maker-core abort-stops-background-tasks(8 例,含新增 3 例)、
     desktop stopAgentTaskHandler(新增 6 例)、
     AgentTaskCard / makerChatStoreTaskUpdates / useBackgroundBashTasks(新增 6 例)
```

### 手工验证

未做(见下)。

### 未执行的验证

- 真机手工验证(后台跑长命令 → 状态栏点亮 → 逐任务/全部停止 → 卡片翻 stopped;Light/Dark 截图):实现全程在无 GUI 会话中完成,待 reviewer 或后续自测补充。
- SSH 远程会话实测:代码路径经 RemoteQuery.stopTask(协议已有 query/stopTask,老 daemon 降级为明确报错),未实测真实远端。

### 多端适配(remote-and-mobile-adaptation 三问)

1. SSH 远程工作区:适配 —— stopTask 经 cc-manager `query/stopTask` RPC 透传,与本地同一 handle 路径。
2. device-link / 手机:两条新 IPC **不登记** allowlist(桌面端专用)。控制端镜像会话已在 UI 层屏蔽停止按钮与快照水合(session 活在被控端,本地调用会假成功),被控端本机 UI 自行承载该能力。
3. 手机版入口:不需要(手机是纯控制端,同上由被控端承载)。

## 风险

### 风险分类

- [x] 其他:后台任务停止语义(新增能力,不改既有路径)

### 影响与回滚

- 影响范围:后台任务的展示与停止为**新增**链路;既有语义零变化 —— local_bash 仍不折算会话 running(dev server 不永转)、用户 Stop(abort)仍只停 wake 型任务、原「仍在调模型」后台模式文案与关进程止损语义原样保留。停止结果统一由 SDK `task_notification` 事件收口,UI 不自造状态。
- 回滚 / 降级方式:revert 本 PR 即可;无数据、协议、migration 变更。旧 SDK/旧 daemon 环境下停止按钮报 UNSUPPORTED_CAPABILITY,其余功能(展示/水合)不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释;无需规则文档变更)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)