### PR TITLE
feat(desktop): 国区个人账号隐藏 IM 机器人 Cindy 分栏与 Discord 入口

### DIFF
--- a/apps/desktop/src/renderer/components/settings/ImBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImBotSection.tsx
@@ -12,6 +12,10 @@
  * 分栏选择经 ?imGroup= 参数由 SettingsView 驱动(深链可直达某分栏);缺省/非法
  * 时 SettingsView 落到默认分栏(旧「飞书机器人」深链落「个人」,其余落「Cindy」)。
  * Beta 标识用一颗 pill(主题 token,无硬编码 hex),表示整块功能处于 Beta。
+ *
+ * 可见性(imBotVisibility 单点):本地模式与「国区构建 + 个人账号登录」都
+ * 没有 Cindy 分栏(深链/兜底一律落「个人」);国区个人账号的个人分栏进一步
+ * 隐藏 Discord 机器人,只剩飞书(Tips 换 personalFeishuOnly 文案)。
  */
 
 import { Lightbulb } from 'lucide-react';
@@ -19,18 +23,20 @@ import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
+import { CURRENT_CINDY_REGION } from '../../../shared/brandRegion';
 import { DiscordBotSection } from './DiscordBotSection';
 import { FeishuBotSection } from './FeishuBotSection';
 import { FeishuBotNotificationSection } from './FeishuBotNotificationSection';
 import { HookConnectionsSection } from './HookConnectionsSection';
 import { ImDefaultSettingsSection } from './ImDefaultSettingsSection';
+import { showCindyGroup, showDiscordBot, type ImBotIdentity } from './imBotVisibility';
 
 /** 「IM 机器人」页内分栏 id(tab 与 ?imGroup= 参数共用)。 */
 export type ImBotSettingsGroup = 'cindy' | 'personal';
 
 /** 分栏 tab 的固定顺序(Cindy 在前为默认)。 */
 export const IM_BOT_SETTINGS_GROUPS: readonly ImBotSettingsGroup[] = ['cindy', 'personal'];
-const LOCAL_IM_BOT_SETTINGS_GROUPS: readonly ImBotSettingsGroup[] = ['personal'];
+const PERSONAL_ONLY_IM_BOT_SETTINGS_GROUPS: readonly ImBotSettingsGroup[] = ['personal'];
 
 /** 分栏标题的 i18n key(tab 文案)。 */
 export const IM_BOT_GROUP_LABEL_KEY: Record<ImBotSettingsGroup, string> = {
@@ -48,8 +54,8 @@ export function isImBotSettingsGroup(value: string | null): value is ImBotSettin
   return value === 'cindy' || value === 'personal';
 }
 
-/** 个人栏内容 —— 用户自配凭证的机器人。 */
-function PersonalGroupContent() {
+/** 个人栏内容 —— 用户自配凭证的机器人(国区个人账号无 Discord)。 */
+function PersonalGroupContent({ showDiscord }: { showDiscord: boolean }) {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col gap-8">
@@ -62,11 +68,15 @@ function PersonalGroupContent() {
         </section>
       </div>
 
-      <div className="h-px w-full bg-[var(--border-default)]" />
+      {showDiscord && (
+        <>
+          <div className="h-px w-full bg-[var(--border-default)]" />
 
-      <section aria-label={t('settings.sections.discordBot')}>
-        <DiscordBotSection />
-      </section>
+          <section aria-label={t('settings.sections.discordBot')}>
+            <DiscordBotSection />
+          </section>
+        </>
+      )}
     </div>
   );
 }
@@ -79,9 +89,18 @@ export function ImBotSection({
   onGroupChange: (group: ImBotSettingsGroup) => void;
 }) {
   const { t } = useTranslation();
-  const { mode, dataOwnerId } = useAuth();
-  const availableGroups = mode === 'local' ? LOCAL_IM_BOT_SETTINGS_GROUPS : IM_BOT_SETTINGS_GROUPS;
-  const effectiveGroup = mode === 'local' ? 'personal' : group;
+  const { mode, dataOwnerId, user } = useAuth();
+  const identity: ImBotIdentity = {
+    region: CURRENT_CINDY_REGION,
+    mode,
+    membershipKind: user?.membershipKind ?? null,
+  };
+  const cindyGroupAvailable = showCindyGroup(identity);
+  const discordVisible = showDiscordBot(identity);
+  const availableGroups = cindyGroupAvailable
+    ? IM_BOT_SETTINGS_GROUPS
+    : PERSONAL_ONLY_IM_BOT_SETTINGS_GROUPS;
+  const effectiveGroup = cindyGroupAvailable ? group : 'personal';
 
   return (
     <div className="flex flex-col gap-2 px-1">
@@ -131,7 +150,11 @@ export function ImBotSection({
       <div className="mt-2 flex items-start gap-2 rounded-lg bg-[var(--surface-chip)] px-3.5 py-2.5">
         <Lightbulb size={14} className="mt-[2px] shrink-0 text-[var(--text-tertiary)]" />
         <p className="text-[12.5px] leading-[1.6] text-[var(--text-secondary)]">
-          {t(IM_BOT_GROUP_TIP_KEY[effectiveGroup])}
+          {t(
+            effectiveGroup === 'personal' && !discordVisible
+              ? 'settings.imBot.tips.personalFeishuOnly'
+              : IM_BOT_GROUP_TIP_KEY[effectiveGroup],
+          )}
         </p>
       </div>
 
@@ -149,7 +172,7 @@ export function ImBotSection({
             {/* 新会话默认配置为 IM 全局项,固定放个人分栏顶部 */}
             <ImDefaultSettingsSection />
             <div className="h-px w-full bg-[var(--border-default)]" />
-            <PersonalGroupContent />
+            <PersonalGroupContent showDiscord={discordVisible} />
           </>
         )}
       </div>

--- a/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
@@ -17,6 +17,8 @@ import { ClaudeMark } from '@/components/icons/ClaudeMark';
 import { CodexMark } from '@/components/icons/CodexMark';
 import { ModelSelector } from '@/components/new-chat/ModelSelector';
 import { useAuth } from '@/contexts/AuthContext';
+import { CURRENT_CINDY_REGION } from '../../../shared/brandRegion';
+import { showDiscordBot } from './imBotVisibility';
 import { type ModelDescriptor, useAgentCapabilities } from '@/hooks/useAgentCapabilities';
 import { useProviders } from '@/hooks/useProviders';
 import { deriveModelsFromProviders } from '@/lib/providerModels';
@@ -52,7 +54,13 @@ function vendorKeyFor(agentKind: ImDefaultAgentKind): 'cc' | 'codex' {
 
 export function ImDefaultSettingsSection() {
   const { t } = useTranslation();
-  const { mode, dataOwnerId } = useAuth();
+  const { mode, dataOwnerId, user } = useAuth();
+  // 国区个人账号既没有 Cindy(Slack)分栏也没有 Discord —— 描述只提飞书。
+  const feishuOnly = !showDiscordBot({
+    region: CURRENT_CINDY_REGION,
+    mode,
+    membershipKind: user?.membershipKind ?? null,
+  });
   const { providers } = useProviders();
   const cc = useAgentCapabilities('claude-code');
   const codex = useAgentCapabilities('codex');
@@ -209,9 +217,11 @@ export function ImDefaultSettingsSection() {
             </h3>
             <p className="mt-2 text-[12px] leading-[1.45] text-[var(--settings-section-desc)]">
               {t(
-                mode === 'local'
-                  ? 'settings.imBot.defaults.localDescription'
-                  : 'settings.imBot.defaults.description',
+                feishuOnly
+                  ? 'settings.imBot.defaults.feishuOnlyDescription'
+                  : mode === 'local'
+                    ? 'settings.imBot.defaults.localDescription'
+                    : 'settings.imBot.defaults.description',
               )}
             </p>
           </div>

--- a/apps/desktop/src/renderer/components/settings/__tests__/imBotVisibility.test.ts
+++ b/apps/desktop/src/renderer/components/settings/__tests__/imBotVisibility.test.ts
@@ -1,0 +1,55 @@
+// imBotVisibility —— 「IM 机器人」分栏/渠道可见性规则:
+//  - 国区构建(cn/dev)+ 个人账号 cloud 登录:无 Cindy 分栏、无 Discord
+//  - 企业账号 / global 构建:全量
+//  - 本地模式:无 Cindy 分栏(既有规则),Discord 保留
+import { describe, expect, it } from 'vitest';
+
+import {
+  isCnPersonalIdentity,
+  showCindyGroup,
+  showDiscordBot,
+  type ImBotIdentity,
+} from '../imBotVisibility';
+
+function identity(overrides: Partial<ImBotIdentity>): ImBotIdentity {
+  return { region: 'cn', mode: 'cloud', membershipKind: 'personal', ...overrides };
+}
+
+describe('imBotVisibility', () => {
+  it('hides both the Cindy group and Discord for cn-build personal cloud accounts', () => {
+    const cnPersonal = identity({});
+    expect(isCnPersonalIdentity(cnPersonal)).toBe(true);
+    expect(showCindyGroup(cnPersonal)).toBe(false);
+    expect(showDiscordBot(cnPersonal)).toBe(false);
+  });
+
+  it('treats the dev region as cn for the personal-account rule', () => {
+    const devPersonal = identity({ region: 'dev' });
+    expect(showCindyGroup(devPersonal)).toBe(false);
+    expect(showDiscordBot(devPersonal)).toBe(false);
+  });
+
+  it('keeps everything for cn-build org accounts', () => {
+    const cnOrg = identity({ membershipKind: 'org' });
+    expect(isCnPersonalIdentity(cnOrg)).toBe(false);
+    expect(showCindyGroup(cnOrg)).toBe(true);
+    expect(showDiscordBot(cnOrg)).toBe(true);
+  });
+
+  it('keeps everything for global-build personal accounts', () => {
+    const globalPersonal = identity({ region: 'global' });
+    expect(showCindyGroup(globalPersonal)).toBe(true);
+    expect(showDiscordBot(globalPersonal)).toBe(true);
+  });
+
+  it('keeps the existing local-mode rule: no Cindy group, Discord stays', () => {
+    const cnLocal = identity({ mode: 'local', membershipKind: null });
+    expect(isCnPersonalIdentity(cnLocal)).toBe(false);
+    expect(showCindyGroup(cnLocal)).toBe(false);
+    expect(showDiscordBot(cnLocal)).toBe(true);
+
+    const globalLocal = identity({ region: 'global', mode: 'local', membershipKind: null });
+    expect(showCindyGroup(globalLocal)).toBe(false);
+    expect(showDiscordBot(globalLocal)).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/imBotVisibility.ts
+++ b/apps/desktop/src/renderer/components/settings/imBotVisibility.ts
@@ -1,0 +1,41 @@
+/**
+ * imBotVisibility —— 「IM 机器人」页按构建区域 + 登录身份的分栏/渠道可见性单点。
+ *
+ * 产品规则(2026-07-24):中国区构建(cn;dev 行为归 cn 系,见 brandIdentity)
+ * 下的**个人账号**(cloud 登录且 membershipKind='personal')不提供官方共享
+ * Cindy 机器人分栏与 Discord 机器人入口——个人分栏只保留飞书机器人。
+ * 企业账号(org)与 global 构建不受影响;本地模式沿用既有规则(无 Cindy
+ * 分栏,Discord 保留)。
+ *
+ * 纯函数、零组件依赖:ImBotSection 与 ImDefaultSettingsSection 共用,避免
+ * 两处条件漂移(ImBotSection 已 import ImDefaultSettingsSection,把条件放
+ * 组件文件里会成环)。
+ */
+
+import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
+
+/** 判定可见性所需的最小身份快照(全部来自 useAuth + 构建期区域常量)。 */
+export interface ImBotIdentity {
+  region: CindyRegion;
+  mode: 'signed-out' | 'local' | 'cloud';
+  membershipKind: 'personal' | 'org' | null;
+}
+
+/** 中国区构建 + 个人账号 cloud 登录(不含企业账号与本地模式)。 */
+export function isCnPersonalIdentity(identity: ImBotIdentity): boolean {
+  return (
+    identity.region !== 'global' &&
+    identity.mode === 'cloud' &&
+    identity.membershipKind === 'personal'
+  );
+}
+
+/** 是否提供「Cindy」分栏(官方共享机器人;本地模式与国区个人账号都没有)。 */
+export function showCindyGroup(identity: ImBotIdentity): boolean {
+  return identity.mode !== 'local' && !isCnPersonalIdentity(identity);
+}
+
+/** 个人分栏是否提供 Discord 机器人配置(国区个人账号没有)。 */
+export function showDiscordBot(identity: ImBotIdentity): boolean {
+  return !isCnPersonalIdentity(identity);
+}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2063,12 +2063,14 @@
       },
       "tips": {
         "cindy": "Cindy is the official shared bot — no credentials needed. Connect Slack and just @Cindy to hand off tasks.",
-        "personal": "Personal bots connect to Feishu / Discord with your own credentials — the bot is fully yours, but you create the app and fill in its config yourself."
+        "personal": "Personal bots connect to Feishu / Discord with your own credentials — the bot is fully yours, but you create the app and fill in its config yourself.",
+        "personalFeishuOnly": "Personal bots connect to Feishu with your own credentials — the bot is fully yours, but you create the app and fill in its config yourself."
       },
       "defaults": {
         "title": "New Conversation Configuration",
         "description": "New conversations started from Feishu, Slack, or Discord use this agent and model configuration. Changes apply only to new conversations; send /new in an existing Discord DM to apply them.",
         "localDescription": "New conversations started from Feishu or Discord use this agent and model configuration. Changes apply only to new conversations; send /new in an existing Discord DM to apply them.",
+        "feishuOnlyDescription": "New conversations started from Feishu use this agent and model configuration. Changes apply only to new conversations.",
         "agentLabel": "Agent",
         "modelLabel": "Model Configuration",
         "loading": "Loading new conversation configuration…",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2062,12 +2062,14 @@
       },
       "tips": {
         "cindy": "Cindy は公式提供の共有ボットです。認証情報の申請は不要で、Slack を連携して @Cindy にメンションするだけでタスクを任せられます。",
-        "personal": "個人ボットは自分で申請した認証情報で Feishu / Discord に接続します。ボットは完全に自分専用ですが、アプリの作成と設定の入力が必要です。"
+        "personal": "個人ボットは自分で申請した認証情報で Feishu / Discord に接続します。ボットは完全に自分専用ですが、アプリの作成と設定の入力が必要です。",
+        "personalFeishuOnly": "個人ボットは自分で申請した認証情報で Feishu に接続します。ボットは完全に自分専用ですが、アプリの作成と設定の入力が必要です。"
       },
       "defaults": {
         "title": "新規会話設定",
         "description": "Feishu、Slack、または Discord から開始する新規会話では、この Agent とモデル設定を使用します。変更は新規会話にのみ適用されます。既存の Discord DM に適用するには /new を送信してください。",
         "localDescription": "Feishu または Discord から開始する新規会話では、この Agent とモデル設定を使用します。変更は新規会話にのみ適用されます。既存の Discord DM に適用するには /new を送信してください。",
+        "feishuOnlyDescription": "Feishu から開始する新規会話では、この Agent とモデル設定を使用します。変更は新規会話にのみ適用されます。",
         "agentLabel": "Agent",
         "modelLabel": "モデル設定",
         "loading": "新規会話設定を読み込み中…",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2062,12 +2062,14 @@
       },
       "tips": {
         "cindy": "Cindy는 공식 제공 공유 봇입니다. 자격 증명을 신청할 필요 없이 Slack을 연결하고 @Cindy를 멘션하면 바로 작업을 맡길 수 있습니다.",
-        "personal": "개인 봇은 직접 발급한 자격 증명으로 Feishu / Discord에 연결합니다. 봇은 온전히 내 전용이지만, 앱 생성과 설정 입력은 직접 해야 합니다."
+        "personal": "개인 봇은 직접 발급한 자격 증명으로 Feishu / Discord에 연결합니다. 봇은 온전히 내 전용이지만, 앱 생성과 설정 입력은 직접 해야 합니다.",
+        "personalFeishuOnly": "개인 봇은 직접 발급한 자격 증명으로 Feishu에 연결합니다. 봇은 온전히 내 전용이지만, 앱 생성과 설정 입력은 직접 해야 합니다."
       },
       "defaults": {
         "title": "새 대화 설정",
         "description": "Feishu, Slack 또는 Discord에서 시작하는 새 대화는 이 Agent와 모델 설정을 사용합니다. 변경 사항은 새 대화에만 적용되며, 기존 Discord DM에서 적용하려면 /new를 보내세요.",
         "localDescription": "Feishu 또는 Discord에서 시작하는 새 대화는 이 Agent와 모델 설정을 사용합니다. 변경 사항은 새 대화에만 적용되며, 기존 Discord DM에서 적용하려면 /new를 보내세요.",
+        "feishuOnlyDescription": "Feishu에서 시작하는 새 대화는 이 Agent와 모델 설정을 사용합니다. 변경 사항은 새 대화에만 적용됩니다.",
         "agentLabel": "Agent",
         "modelLabel": "모델 설정",
         "loading": "새 대화 설정을 불러오는 중…",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2062,12 +2062,14 @@
       },
       "tips": {
         "cindy": "Cindy 是官方提供的共享机器人:无需申请任何凭证,连接 Slack 后 @Cindy 即可直接派活。",
-        "personal": "个人机器人用你自己申请的凭证接入飞书 / Discord:机器人完全归你,需要自行创建应用并填写配置。"
+        "personal": "个人机器人用你自己申请的凭证接入飞书 / Discord:机器人完全归你,需要自行创建应用并填写配置。",
+        "personalFeishuOnly": "个人机器人用你自己申请的凭证接入飞书:机器人完全归你,需要自行创建应用并填写配置。"
       },
       "defaults": {
         "title": "新会话配置",
         "description": "从飞书、Slack 或 Discord 发起新会话时，会使用这里的 Agent 和模型配置。修改后只影响新会话；已有 Discord 私聊请发送 /new 才会应用新配置。",
         "localDescription": "从飞书或 Discord 发起新会话时，会使用这里的 Agent 和模型配置。修改后只影响新会话；已有 Discord 私聊请发送 /new 才会应用新配置。",
+        "feishuOnlyDescription": "从飞书发起新会话时，会使用这里的 Agent 和模型配置。修改后只影响新会话。",
         "agentLabel": "Agent",
         "modelLabel": "模型配置",
         "loading": "正在读取新会话配置…",


### PR DESCRIPTION
## 这次改了什么

### 摘要

中国区构建下用**个人账号**登录时,「IM 机器人」设置页不再提供官方共享 Cindy 机器人与 Discord 机器人入口:Cindy 分栏整体隐藏(pill tab 只剩「个人」,`imGroup=cindy` 深链兜底落「个人」),「个人」分栏移除 Discord 机器人区块,只保留飞书。判定条件为:构建区域非 `global`(cn/dev,dev 按 brandIdentity 约定行为归 cn 系)+ cloud 登录 + `membershipKind === 'personal'`。

可见性条件收敛到纯函数单点 `imBotVisibility.ts`,由 `ImBotSection` 与 `ImDefaultSettingsSection` 共用(后者的「新会话配置」描述在该状态下换成只提飞书的文案);个人分栏 Tips 同步换用不提 Discord 的新文案。新增 2 个 i18n key,zh-CN / en / ja / ko 四语言补齐。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:无(口头需求:国区个人登录隐藏 IM 机器人中的 Cindy,个人分栏隐藏 Discord)
- 本 PR 包含:IM 机器人设置页分栏/区块可见性门控、配套文案与单测
- 明确不包含:main 侧 IM transport 行为(已配置的 Discord bot 运行不受影响,仅隐藏配置入口);本地模式行为(维持既有规则:无 Cindy 分栏、Discord 保留);About 页 Discord 社区链接
- 用户可见变化:国区构建个人账号在设置页看不到 Cindy 分栏与 Discord 机器人配置;企业账号、global 构建、本地模式无变化
- 是否存在 breaking change:无

### UI 变化

仅条件隐藏既有区块,无新增视觉;Light/Dark 均为既有组件,无样式改动。

## 怎么验证的

### 自动验证

```text
pnpm test:unit(干净 worktree:main + 本 PR 8 个文件,规避同工作区其他进行中改动)
结果:exit 0,全部通过

pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm check:i18n
结果:5100 个 key 四语言一致

pnpm vitest run src/renderer/components/settings/__tests__(含新增 imBotVisibility.test.ts 5 条)+ i18nCompleteness
结果:13 个文件 56 条全部通过
```

### 手工验证

未做(本机为 dev 环境,未构建 global 包对照;逻辑分支已由单测覆盖)。

### 未执行的验证

未在打包后的 cn/global 真机构建上人工核对设置页;未验证 mobile(本 PR 不涉及)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 renderer 设置页「IM 机器人」的分栏/区块可见性与两处描述文案;不触碰 main 进程、协议、数据库
- 回滚 / 降级方式:revert 本 PR 即恢复原状,无数据/状态残留

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释;无需独立文档)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)