### PR TITLE
fix(desktop): 运行中工作组无更多内容可展开时隐藏折叠交互

### DIFF
--- a/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
@@ -221,7 +221,7 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     expect(screen.getByText(/chat\.workGroup\.exploration\.search:1/)).toBeTruthy();
   });
 
-  it('expands running actions directly and keeps the same detail after completion', () => {
+  it('offers no toggle while running when the preview already shows everything', () => {
     const childItems = [
       tools('seg-1', [mkTool('t1', 'git status')]),
       thinking(mkThinking('th1', 'checking the current state')),
@@ -236,19 +236,17 @@ describe('WorkGroupBlock — running latest-five preview', () => {
 
     expect(screen.getByText('chat.workGroup.working')).toBeTruthy();
     expect(document.querySelector('[data-live-work-preview="true"]')).toBeTruthy();
-    expect(
-      screen.getByText('chat.workGroup.working').closest('button')?.getAttribute('aria-expanded'),
-    ).toBe('true');
-
-    // The first click replaces the compact latest-five window with full details.
-    clickGroup('chat.workGroup.working');
-    expect(document.querySelector('[data-live-work-preview="true"]')).toBeNull();
-    expect(screen.getByTestId('direct-tool').textContent).toBe('git status');
-    expect(screen.getByText('checking the current state')).toBeTruthy();
-    expect(
-      screen.getByText('chat.workGroup.working').closest('button')?.getAttribute('aria-expanded'),
-    ).toBe('true');
     expect(screen.getByTestId('direct-tool').getAttribute('data-show-raw')).toBe('true');
+
+    // ≤5 条活动且没有 preview 之外的子项:展开不会露出更多内容,组头不再
+    // 提供折叠交互 — 无箭头、禁用、点击后预览保持原样。
+    const runningButton = screen.getByText('chat.workGroup.working').closest('button');
+    if (!runningButton) throw new Error('Missing work-group header button');
+    expect(runningButton.hasAttribute('disabled')).toBe(true);
+    expect(runningButton.getAttribute('aria-expanded')).toBeNull();
+    expect(runningButton.querySelector('svg.lucide-chevron-right')).toBeNull();
+    fireEvent.click(runningButton);
+    expect(document.querySelector('[data-live-work-preview="true"]')).toBeTruthy();
 
     rerender(
       createElement(WorkGroupBlock, {
@@ -258,9 +256,42 @@ describe('WorkGroupBlock — running latest-five preview', () => {
         childItems,
       }),
     );
-    expect(screen.getByText('chat.workGroup.worked:12s')).toBeTruthy();
+    // 完成态恢复正常折叠交互:默认收起,点开显示完整明细。
+    const doneButton = screen.getByText('chat.workGroup.worked:12s').closest('button');
+    expect(doneButton?.hasAttribute('disabled')).toBe(false);
+    expect(doneButton?.querySelector('svg.lucide-chevron-right')).toBeTruthy();
+    expect(screen.queryByTestId('direct-tool')).toBeNull();
+    clickGroup('chat.workGroup.worked:12s');
     expect(screen.getByTestId('direct-tool').textContent).toBe('git status');
     expect(screen.getByText('checking the current state')).toBeTruthy();
+  });
+
+  it('keeps the toggle while running when expansion can reveal more than the preview', () => {
+    render(
+      createElement(WorkGroupBlock, {
+        blockId: 'work:t1',
+        isStreaming: true,
+        childItems: [
+          tools('seg-1', [
+            mkTool('t1'),
+            mkTool('t2'),
+            mkTool('t3'),
+            mkTool('t4'),
+            mkTool('t5'),
+            mkTool('t6'),
+          ]),
+        ],
+      }),
+    );
+
+    const button = screen.getByText('chat.workGroup.working').closest('button');
+    if (!button) throw new Error('Missing work-group header button');
+    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(button.querySelector('svg.lucide-chevron-right')).toBeTruthy();
+
+    clickGroup('chat.workGroup.working');
+    expect(screen.getAllByTestId('direct-tool')).toHaveLength(6);
   });
 
   it('keeps full details across remounts and collapses back to latest five', async () => {

--- a/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
@@ -8,6 +8,8 @@
  * 交互契约:
  *   - 运行中动作组默认露出 latest-five preview;点组头在最近 5 条与全部明细
  *     之间切换,不会把活动完全隐藏。完成态默认 collapsed。
+ *   - 运行中若展开也不会露出更多内容(全部活动 ≤ 5 条且没有 preview 之外的
+ *     子项),组头不提供折叠交互也不显示箭头,避免"点了闪一下又弹回来"。
  *   - 完成态外组展开后直接显示 assistant 文字,动作仍是内层「已工作 Xs」。
  *   - 运行态或完成态的动作组展开后直接显示 thinking 内容和工具行;长 thinking
  *     可再点行展开全文,工具行沿用 AgentActionRow 的详情交互。
@@ -278,16 +280,43 @@ export function WorkGroupBlock({
     return () => window.clearInterval(id);
   }, [isStreaming, startedAtMs]);
 
-  const liveActivities = useMemo(
-    () => projectRecentWorkActivities(childItems, isStreaming, MAX_LIVE_WORK_ACTIVITIES),
+  // 多取一条即可判断展开是否能露出更多活动，显示仍只取最近 5 条。
+  const recentActivities = useMemo(
+    () => projectRecentWorkActivities(childItems, isStreaming, MAX_LIVE_WORK_ACTIVITIES + 1),
     [childItems, isStreaming],
   );
-  const isLivePreviewVisible = isStreaming && !expanded && liveActivities.length > 0;
+  const liveActivities = useMemo(
+    () => recentActivities.slice(-MAX_LIVE_WORK_ACTIVITIES),
+    [recentActivities],
+  );
+  // preview 只投影 tools / thinking；嵌套组、rendered 文字和 redacted thinking
+  // 只在展开态可见，存在它们时展开仍有意义。
+  const hasBeyondPreviewChild = useMemo(
+    () =>
+      childItems.some(
+        (child) =>
+          child.kind === 'group'
+          || child.kind === 'rendered'
+          || (child.kind === 'thinking' && child.message.thinkingRedacted === true),
+      ),
+    [childItems],
+  );
+  // 运行中预览已经等于全部内容时，折叠/展开是视觉空操作 — 组头不提供交互。
+  const canToggle =
+    !isStreaming
+    || hasBeyondPreviewChild
+    || recentActivities.length > MAX_LIVE_WORK_ACTIVITIES;
+  const effectiveExpanded = expanded && canToggle;
+  const isLivePreviewVisible =
+    isStreaming && !effectiveExpanded && liveActivities.length > 0;
   // 完成态只计算一次完整摘要；运行态保持折叠时走上面的反向 latest-five
   // 热路径，用户主动展开后才投影全部历史。
   const activityProjection = useMemo(
-    () => (expanded || !isStreaming ? projectWorkActivities(childItems, isStreaming) : null),
-    [childItems, expanded, isStreaming],
+    () =>
+      effectiveExpanded || !isStreaming
+        ? projectWorkActivities(childItems, isStreaming)
+        : null,
+    [childItems, effectiveExpanded, isStreaming],
   );
 
   // 外层完成态组展开成文字 + 内层动作组;内层动作组与运行态组复用本组件,
@@ -333,14 +362,18 @@ export function WorkGroupBlock({
       <div className="w-full">
         <button
           type="button"
-          onClick={onToggle}
+          onClick={canToggle ? onToggle : undefined}
+          disabled={!canToggle}
           className={cn(
             'flex w-full items-center gap-[6px] py-[2px]',
-            'select-none cursor-pointer',
-            'hover:opacity-80 transition-opacity',
+            'select-none',
             'text-left',
+            canToggle && 'cursor-pointer hover:opacity-80 transition-opacity',
+            !canToggle && 'cursor-default',
           )}
-          aria-expanded={expanded || isLivePreviewVisible}
+          aria-expanded={
+            canToggle ? effectiveExpanded || isLivePreviewVisible : undefined
+          }
         >
           <span className="inline-flex h-[1lh] items-center shrink-0">
             {isStreaming ? (
@@ -358,14 +391,16 @@ export function WorkGroupBlock({
               {formatDuration(elapsedMs)}
             </span>
           )}
-          <ChevronRight
-            size={14}
-            className={cn(
-              'shrink-0 text-[var(--msg-tool-card-chevron)]',
-              'transition-transform duration-[var(--motion-fast,150ms)]',
-              expanded && 'rotate-90',
-            )}
-          />
+          {canToggle && (
+            <ChevronRight
+              size={14}
+              className={cn(
+                'shrink-0 text-[var(--msg-tool-card-chevron)]',
+                'transition-transform duration-[var(--motion-fast,150ms)]',
+                effectiveExpanded && 'rotate-90',
+              )}
+            />
+          )}
         </button>
 
         {isLivePreviewVisible && (
@@ -386,7 +421,7 @@ export function WorkGroupBlock({
           </div>
         )}
 
-        <Collapse open={expanded}>
+        <Collapse open={effectiveExpanded}>
           <div
             className={cn(
               'mt-1 pl-3 py-[2px]',


### PR DESCRIPTION
## 这次改了什么

### 摘要

「正在工作…」工作组在运行中点击折叠时,交互契约是「全部明细 ⇄ 最近 5 条预览」切换、不完全隐藏。但当全部活动 ≤ 5 条且没有预览之外的子项时,两种状态内容完全一致,点击表现为"闪一下又自动弹回来",用户以为折叠坏了。

本 PR 在这种「折叠是视觉空操作」的情况下隐藏组头折叠箭头并禁用点击(去掉 hover 效果与 `aria-expanded`);一旦活动超过 5 条、或出现预览显示不了的内容(嵌套工作组 / rendered 文字 / redacted thinking),箭头自动恢复。完成态(「已工作 Xs」)的折叠行为完全不变。

实现上只是把运行中的 latest-five 投影多取一条(显示仍取最近 5 条),用第 6 条是否存在判断「展开是否能露出更多」,无额外投影开销。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(对话中用户反馈)
- 本 PR 包含:`WorkGroupBlock.tsx` 组头交互调整 + 对应单测更新
- 明确不包含:mobile 端同款交互(`apps/mobile/src/session/MessageRenderer.tsx` 仍是旧行为,后续可单独跟进)
- 用户可见变化:运行中的工作组在没有更多内容可展开时不再显示折叠箭头,点击组头无反应;其余场景交互不变
- 是否存在 breaking change:无

### UI 变化

Desktop 聊天流「正在工作…」组头:仅隐藏/恢复右侧 ChevronRight 箭头与点击态,无新增颜色或布局,Light/Dark 两模式同一逻辑,不涉及新样式。

## 怎么验证的

### 自动验证

在干净 worktree(main + 本 PR 改动)执行:

```text
pnpm test:unit(仓库根)
结果:通过(desktop 含本次新增/改写的 workGroupBlockLivePreview 11 例;首轮 ghostOauthAccounts 有 1 例 20s 超时,为并发负载下的 flaky,单跑 211ms 通过,复跑整轮全绿)

pnpm --filter desktop run --if-present typecheck
结果:通过
```

主工作区另跑 `workGroupBlockLivePreview.test.tsx`(11 例)与 `workGroupBlockInteraction.test.ts`(4 例)均通过。

### 手工验证

未做运行时手工验证(逻辑由单测覆盖:≤5 条运行组无箭头/禁用/点击无效、>5 条保留切换、完成态恢复正常折叠)。

### 未执行的验证

- 未在运行中的 app 里人工复现截图场景(交互路径已由 jsdom 单测覆盖)。
- 本地全量门禁首轮在主工作区跑时 `apps/mobile` 13 个测试文件失败,经排查全部由工作区内**未提交的 mobile i18n 迁移 WIP**(不属于本 PR)引起;在干净 worktree 验证 mobile 全部通过。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 Desktop 聊天流工作组组头的折叠 affordance,纯渲染层,不触及数据、协议、持久化
- 回滚 / 降级方式:revert 本 PR 即恢复原交互

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(组件头部交互契约注释同步更新)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)