### PR TITLE
docs(dev-rules): chrome-sandbox 提权前先断开 pnpm store 硬链接

### DIFF
--- a/docs/dev-rules/environment-setup.md
+++ b/docs/dev-rules/environment-setup.md
@@ -41,15 +41,21 @@ SUID sandbox，dev 启动时报
 `The SUID sandbox helper binary was found, but is not configured correctly`。修复：
 
 ```bash
-sudo chown root:root node_modules/electron/dist/chrome-sandbox
-sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
+cd node_modules/electron/dist
+# 先原位复制一次，断开与 pnpm store 的硬链接——pnpm 的 side-effects cache 会把
+# electron postinstall 产物 hardlink 进共享 store，直接 chown/chmod 会把 store 副本
+# 一并改成 root+setuid，波及本机其它复用同版本 Electron 的项目/worktree。
+cp chrome-sandbox chrome-sandbox.tmp && mv -f chrome-sandbox.tmp chrome-sandbox
+sudo chown root:root chrome-sandbox
+sudo chmod 4755 chrome-sandbox
 ```
 
 注意：
 
-- `node_modules/electron/dist` 由 electron postinstall 解包，**每次重装依赖或 electron
-  升版本后该权限都会被重置**，需要重跑上面两条命令（每个 worktree 各自独立）。
-- 只做这两条针对性修复；不要放开系统级 user namespace 限制，更不要用 `--no-sandbox`
+- `node_modules/electron/dist` 由 electron postinstall 解包／从 store 链接，**每次重装
+  依赖或 electron 升版本后该权限都会被重置**，每个 worktree 需要各自重跑上面的步骤
+  （包括断链那一步）。
+- 只做上述针对性修复；不要放开系统级 user namespace 限制，更不要用 `--no-sandbox`
   绕过（违反 Electron 安全边界，参见
   [`electron-security-and-process-boundaries.md`](electron-security-and-process-boundaries.md)）。
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

#251 被 squash 合并时带入了「Linux:Electron SUID sandbox 权限」一节的初版,其中的修复步骤是直接对 `node_modules/electron/dist/chrome-sandbox` 执行 `chown/chmod`。review 中指出(实测证实,`nlink=2`):pnpm 的 side-effects cache 会把 electron postinstall 产物 hardlink 进共享 store,直接提权会把 store 副本一并改成 root+setuid,波及本机其它复用同版本 Electron 的项目/worktree,且与"每个 worktree 各自独立"的表述矛盾。

本 PR 修订该节:提权前先原位复制一次断开硬链接(`cp` + `mv -f`),再 `chown root:root` + `chmod 4755`;注意事项同步修正为"每个 worktree 各自重跑全部步骤(含断链)"。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求:#251 的 review 意见(sandbox 提权波及 pnpm store)
- 本 PR 包含:`docs/dev-rules/environment-setup.md` 该节修复步骤与注意事项修订(+11/-5)
- 明确不包含:任何代码改动
- 用户可见变化:无(仅开发文档)
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:全部 PASS(exit 0),含 scripts/__tests__/dev-docs-contract.test.mjs
```

### 手工验证

linux-arm64 (Ubuntu, glibc, pnpm 10) 实机:`stat` 确认 chrome-sandbox 与 store 副本 `nlink=2` 同 inode;按修订后的步骤断链再提权,`node_modules` 副本 `nlink=1` root+4755,store 副本不受影响,Electron 正常拉起 sandbox。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅开发文档。
- 回滚 / 降级方式:revert 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)