### PR TITLE
feat(tools): agent 二进制更新脚本支持 linux-arm64

### DIFF
--- a/tools/claude/latest.json
+++ b/tools/claude/latest.json
@@ -91,6 +91,11 @@
       "url": "https://downloads.claude.ai/claude-code-releases/2.1.215/linux-x64/claude",
       "sha256": "c1efffaaf370aa187cb6a09dd93d4e511c646899b0078476f83791b664bde7fe",
       "size": 265239536
+    },
+    "linux-arm64": {
+      "url": "https://downloads.claude.ai/claude-code-releases/2.1.215/linux-arm64/claude",
+      "sha256": "2b43a3d5b0787217e5d7381fad42c7314292546fe9db9eb8b9b379de90509b30",
+      "size": 262060960
     }
   },
   "scripts": {

--- a/tools/claude/update.mjs
+++ b/tools/claude/update.mjs
@@ -47,6 +47,9 @@ const PLATFORMS = [
   // Verified 2026-06-17 by HEAD request against downloads.claude.ai for the
   // latest npm version: linux-x64 uses the same plain `claude` binary name.
   { key: 'linux-x64', file: 'claude' },
+  // Verified 2026-07-24 against the official manifest.json for 2.1.215:
+  // linux-arm64 (glibc, same family as linux-x64) is published with a checksum.
+  { key: 'linux-arm64', file: 'claude' },
   { key: 'win32-x64', file: 'claude.exe' },
 ];
 

--- a/tools/codex/latest.json
+++ b/tools/codex/latest.json
@@ -8,6 +8,11 @@
       "url": "https://github.com/openai/codex/releases/download/rust-v0.144.6/codex-x86_64-unknown-linux-musl.tar.gz",
       "sha256": "6a9def51a0ad8cea6684d8eb3bf033c89f33e3bc5cfe492f1a1e0a718451a1c6",
       "size": 109369631
+    },
+    "linux-arm64": {
+      "url": "https://github.com/openai/codex/releases/download/rust-v0.144.6/codex-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "8eddae5e6c009dff9ba51ae1bfe3bdd9ff4c1ccc93a48cc6860db1cd9fdf11be",
+      "size": 101269986
     }
   }
 }

--- a/tools/codex/update.mjs
+++ b/tools/codex/update.mjs
@@ -61,6 +61,13 @@ const PLATFORMS = [
     binFile: 'codex',
   },
   {
+    key: 'linux-arm64',
+    // Verified 2026-07-24 from the official openai/codex GitHub release asset
+    // list (rust-v0.144.6): aarch64 Linux is also published as a musl tarball.
+    asset: 'codex-aarch64-unknown-linux-musl.tar.gz',
+    binFile: 'codex',
+  },
+  {
     key: 'win32-x64',
     asset: 'codex-x86_64-pc-windows-msvc.exe.tar.gz',
     binFile: 'codex.exe',

--- a/tools/ripgrep/update.mjs
+++ b/tools/ripgrep/update.mjs
@@ -53,6 +53,14 @@ const PLATFORMS = [
     binFile: 'rg',
   },
   {
+    key: 'linux-arm64',
+    // Verified 2026-07-24 from the official BurntSushi/ripgrep release asset
+    // list (15.1.0): aarch64 Linux only ships a gnu/glibc tarball, no musl one.
+    triple: 'aarch64-unknown-linux-gnu',
+    archiveExt: 'tar.gz',
+    binFile: 'rg',
+  },
+  {
     key: 'win32-x64',
     triple: 'x86_64-pc-windows-msvc',
     archiveExt: 'zip',


### PR DESCRIPTION
## 这次改了什么

### 摘要

claude / codex / ripgrep 三个二进制更新脚本(`tools/*/update.mjs`)的平台表新增 `linux-arm64`,并补上 `tools/{claude,codex}/latest.json` 的 `runtimeAssets.linux-arm64` pin(url + 官方 sha256 + size)。此后可用 `--platform=linux-arm64` 下载/安装 ARM64 Linux 的 agent 二进制,sha256 校验链路(claude 走官方 manifest、codex 走 release asset digest、ripgrep 走官方 .sha256 asset)对新平台自动生效。

上游资产来源(均已实际核对):
- claude 2.1.215:官方 manifest.json 含 `linux-arm64`(glibc,与现有 linux-x64 同体系),checksum/size 取自 manifest
- codex rust-v0.144.6:`codex-aarch64-unknown-linux-musl.tar.gz`(aarch64 Linux 同 x64 只发 musl),sha256 取自 GitHub asset digest
- ripgrep 15.1.0:`aarch64-unknown-linux-gnu.tar.gz`(上游 aarch64 只有 gnu 包,无 musl)

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:无
- 本 PR 包含:三个 update.mjs 的 PLATFORMS 各加一条 linux-arm64;claude/codex latest.json 补 runtimeAssets.linux-arm64 pin
- 明确不包含:桌面端打包 Linux 兜底安装(`linux-runtime-fallback.ts`)仍硬编码 `linux-x64`,按 arch 选 key 属后续改动;CDN/release 链路发 arm64 .gz 亦不在本 PR
- 用户可见变化:无(开发/构建工具链变化)
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:全部 workspace PASS(exit 0)

pnpm --filter desktop run --if-present typecheck
结果:通过(latest.json 被 desktop linux-runtime-fallback.ts import,确认无类型问题)

node --test scripts/__tests__/ensure-agent-binaries.test.mjs scripts/__tests__/ensure-binary-fallback.test.mjs scripts/__tests__/agent-binary-cdn-fallback.test.mjs
结果:19 pass / 0 fail

pnpm --filter desktop exec vitest run src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts src/main/__tests__/agentBinaryLinuxPrepare.test.ts
结果:8 passed | 4 skipped(skip 为 linux-only 用例,本机 win32)
```

### 手工验证

- 对三个新资产 URL 做 HEAD 请求均返回 200;codex 的 Content-Length(101269986)与 pin 的 size 一致
- claude linux-arm64 的 sha256 与官方 manifest.json 逐字核对;codex 与 GitHub API asset digest 逐字核对

### 未执行的验证

未在真实 ARM64 Linux 机器上实际下载并运行二进制(手头无该环境);下载与校验逻辑为平台无关代码,已被现有单测覆盖。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围:仅 dev/CI 工具链。默认全量 `pnpm update:claude|codex|ripgrep`(不带 --platform)会多下载一份 arm64 二进制(claude ~262MB、codex ~101MB、ripgrep 数 MB);下次 bump pin 时 latest.json 的 runtimeAssets 会包含 linux-arm64 条目(消费方 `pinnedOfficialAssetDescriptor` 只读 linux-x64 key,新增 key 无影响)
- 回滚 / 降级方式:revert 本 PR 即可,无数据/协议/持久化影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(平台表内注明上游资产核实来源与日期)
- [x] 已确认测试结果或说明未执行原因