### PR TITLE
fix(login): 修复免登录入口与第三方按钮重叠

### DIFF
--- a/apps/desktop/src/renderer/components/login/LoginBrandStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginBrandStage.tsx
@@ -17,7 +17,14 @@ import sloganDarkPng from '@/assets/login/slogan-dark.png';
 import sloganDarkPng2x from '@/assets/login/slogan-dark@2x.png';
 
 import { brandPlacement, sloganShiftX } from './loginScale';
-import { HERO, LOGIN_COLORS, SLOGAN, STAGE, WORDMARK } from './loginDesignTokens';
+import {
+  HERO,
+  LOGIN_COLORS,
+  LOGIN_LOCAL_MODE,
+  SLOGAN,
+  STAGE,
+  WORDMARK,
+} from './loginDesignTokens';
 import { useViewportSize } from './LoginStage';
 
 /**
@@ -46,7 +53,11 @@ export function LoginBrandStage() {
   const handoff = useLoginHandoff();
   const { width, height } = useViewportSize();
   // 品牌块整体让位(scale+translateY,构图冻结;用户拍板 2026-07-23,design.md §11)
-  const { scale, translateY } = brandPlacement(width, height);
+  const { scale, translateY } = brandPlacement(
+    width,
+    height,
+    LOGIN_LOCAL_MODE.reservedHeight,
+  );
   const sloganShift = sloganShiftX(width, scale);
   // 暗色画布用白字版字标/SLOGAN(figma 532:585 CINDY_Standard_White / SLOGAN #FBFBFB;
   // 深浅判定同 useBrandLogo:跟随 theme-service 挂的 dark class)。立绘两模式同资产。

--- a/apps/desktop/src/renderer/components/login/LoginBrandStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginBrandStage.tsx
@@ -52,12 +52,10 @@ import { useViewportSize } from './LoginStage';
 export function LoginBrandStage() {
   const handoff = useLoginHandoff();
   const { width, height } = useViewportSize();
+  const panelBottomReserve =
+    handoff.panelBottomReserve ?? LOGIN_LOCAL_MODE.reservedHeight;
   // 品牌块整体让位(scale+translateY,构图冻结;用户拍板 2026-07-23,design.md §11)
-  const { scale, translateY } = brandPlacement(
-    width,
-    height,
-    LOGIN_LOCAL_MODE.reservedHeight,
-  );
+  const { scale, translateY } = brandPlacement(width, height, panelBottomReserve);
   const sloganShift = sloganShiftX(width, scale);
   // 暗色画布用白字版字标/SLOGAN(figma 532:585 CINDY_Standard_White / SLOGAN #FBFBFB;
   // 深浅判定同 useBrandLogo:跟随 theme-service 挂的 dark class)。立绘两模式同资产。

--- a/apps/desktop/src/renderer/components/login/LoginPage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginPage.tsx
@@ -116,8 +116,10 @@ export function LoginPage() {
   const { reportPanelBottomReserve } = handoff;
   useLayoutEffect(() => {
     reportPanelBottomReserve(panelBottomReserve);
-    return () => reportPanelBottomReserve(null);
   }, [panelBottomReserve, reportPanelBottomReserve]);
+  useLayoutEffect(() => {
+    return () => reportPanelBottomReserve(null);
+  }, [reportPanelBottomReserve]);
   const isGlobalBuild = import.meta.env.VITE_CINDY_AUTH_REGION === 'global';
   // identifier 形态 = 构建区域确定性推导(用户拍板 2026-07-21:手机/邮箱分区互斥,
   // 双 tab 切换移除);providers 仅兜底区域首选方式未下发的场景。

--- a/apps/desktop/src/renderer/components/login/LoginPage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginPage.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
   type CSSProperties,
@@ -109,6 +110,14 @@ export function LoginPage() {
     reportLoginPanelMounted();
     return () => reportLoginPanelUnmounted();
   }, [reportLoginPanelMounted, reportLoginPanelUnmounted]);
+  const showLocalModeFooter =
+    loginState?.step !== 'browser-redirect' && loginState?.step !== 'completed';
+  const panelBottomReserve = showLocalModeFooter ? LOGIN_LOCAL_MODE.reservedHeight : 0;
+  const { reportPanelBottomReserve } = handoff;
+  useLayoutEffect(() => {
+    reportPanelBottomReserve(panelBottomReserve);
+    return () => reportPanelBottomReserve(null);
+  }, [panelBottomReserve, reportPanelBottomReserve]);
   const isGlobalBuild = import.meta.env.VITE_CINDY_AUTH_REGION === 'global';
   // identifier 形态 = 构建区域确定性推导(用户拍板 2026-07-21:手机/邮箱分区互斥,
   // 双 tab 切换移除);providers 仅兜底区域首选方式未下发的场景。
@@ -789,7 +798,7 @@ export function LoginPage() {
       : undefined,
   };
   const localModeFooter =
-    loginState?.step !== 'browser-redirect' ? (
+    showLocalModeFooter ? (
       <>
         <button
           data-testid="login-local-mode"
@@ -804,7 +813,7 @@ export function LoginPage() {
         </button>
         <span
           id="login-local-mode-description"
-          className="mt-2 max-w-full text-12 text-[var(--text-secondary)]"
+          className="mt-2 line-clamp-2 max-w-full text-12 text-[var(--text-secondary)]"
           style={{ lineHeight: `${LOGIN_LOCAL_MODE.descriptionLineHeight}px` }}
         >
           {t('login.localModeDescription')}
@@ -821,6 +830,7 @@ export function LoginPage() {
         ssoOrgGroupY={ssoOrgGroupY}
         groupStyle={groupStyle}
         footer={localModeFooter}
+        bottomReserve={panelBottomReserve}
       >
         {accountDeletionStatus && (
           <AccountDeletionStatusPanel

--- a/apps/desktop/src/renderer/components/login/LoginPage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginPage.tsx
@@ -45,7 +45,13 @@ import {
 import { useResendCountdown } from './useResendCountdown';
 import { CURRENT_CINDY_REGION } from '../../../shared/brandRegion';
 import { resolveIdentifierMethod } from '../../../shared/loginIdentifierMethod';
-import { DRAG_BAR_HEIGHT, LOADING_RING, LOGIN_COLORS, TEXT_LINK } from './loginDesignTokens';
+import {
+  DRAG_BAR_HEIGHT,
+  LOADING_RING,
+  LOGIN_COLORS,
+  LOGIN_LOCAL_MODE,
+  TEXT_LINK,
+} from './loginDesignTokens';
 
 /**
  * LoginPage — 桌面登录(wave4 白底体系 + figma §4 组件库,PR1 stage 框架)。
@@ -782,13 +788,40 @@ export function LoginPage() {
       ? `opacity ${LOGIN_HANDOFF_TIMINGS.panelMs}ms ${LOGIN_HANDOFF_TIMINGS.panelEasing}, transform ${LOGIN_HANDOFF_TIMINGS.panelMs}ms ${LOGIN_HANDOFF_TIMINGS.panelEasing}`
       : undefined,
   };
+  const localModeFooter =
+    loginState?.step !== 'browser-redirect' ? (
+      <>
+        <button
+          data-testid="login-local-mode"
+          type="button"
+          disabled={localModePending || isLoading}
+          onClick={() => void openLocalMode()}
+          aria-describedby="login-local-mode-description"
+          className="select-none rounded-full border border-[var(--border-default)] bg-[var(--surface-elevated)] px-6 py-2.5 text-13 font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)] disabled:cursor-not-allowed disabled:opacity-60"
+          style={{ minHeight: 40 }}
+        >
+          {localModePending ? t('login.localModeOpening') : t('login.localModeEntry')}
+        </button>
+        <span
+          id="login-local-mode-description"
+          className="mt-2 max-w-full text-12 text-[var(--text-secondary)]"
+          style={{ lineHeight: `${LOGIN_LOCAL_MODE.descriptionLineHeight}px` }}
+        >
+          {t('login.localModeDescription')}
+        </span>
+      </>
+    ) : null;
 
   return (
     // 根级 z-[9990] 建立 LoginPage 自己的 stacking context:整体压过品牌 overlay
     // (LoginBrandStage z-[9980])、低于 SplashScreen(z-[9999]);内部 stage(z-auto)
     // / 窗框描边(z-30)/ 拖拽条(z-40)沿 PR2a 相对层序不变(PR2b handoff 合流)。
     <div className="relative z-[9990] min-h-screen">
-      <LoginStage ssoOrgGroupY={ssoOrgGroupY} groupStyle={groupStyle}>
+      <LoginStage
+        ssoOrgGroupY={ssoOrgGroupY}
+        groupStyle={groupStyle}
+        footer={localModeFooter}
+      >
         {accountDeletionStatus && (
           <AccountDeletionStatusPanel
             status={accountDeletionStatus}
@@ -818,21 +851,6 @@ export function LoginPage() {
           </div>
         )}
       </div>
-      {loginState?.step !== 'browser-redirect' && (
-        <div className="absolute bottom-8 left-0 right-0 z-30 flex flex-col items-center gap-2">
-          <button
-            type="button"
-            disabled={localModePending || isLoading}
-            onClick={() => void openLocalMode()}
-            className="rounded-full border border-[var(--border-default)] bg-[var(--surface-elevated)] px-5 py-2 text-13 font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {localModePending ? t('login.localModeOpening') : t('login.localModeEntry')}
-          </button>
-          <span className="text-12 text-[var(--text-secondary)]">
-            {t('login.localModeDescription')}
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/login/LoginStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginStage.tsx
@@ -35,6 +35,7 @@ export function LoginStage({
   ssoOrgGroupY = false,
   groupStyle,
   footer,
+  bottomReserve = 0,
 }: {
   children: ReactNode;
   /** sso-org 族状态登录组 y=1227,其余 1229(figma §5.1 / demo loginY)。 */
@@ -43,15 +44,12 @@ export function LoginStage({
   groupStyle?: CSSProperties;
   /** 登录组下方的辅助操作区；相对于 stage 定位并参与视口底部避让计算。 */
   footer?: ReactNode;
+  /** 登录组下方内容需要预留的屏幕高度，由 LoginPage 与品牌层共享同一值。 */
+  bottomReserve?: number;
 }) {
   const { width, height } = useViewportSize();
   const groupY = ssoOrgGroupY ? LOGIN_GROUP.ySsoOrg : LOGIN_GROUP.yDefault;
-  const placement = panelPlacement(
-    width,
-    height,
-    groupY,
-    footer ? LOGIN_LOCAL_MODE.reservedHeight : 0,
-  );
+  const placement = panelPlacement(width, height, groupY, bottomReserve);
 
   return (
     <div
@@ -92,8 +90,8 @@ export function LoginStage({
               LOGIN_GROUP.height * placement.scale +
               LOGIN_LOCAL_MODE.gap,
             width: `min(${LOGIN_GROUP.width}px, calc(100vw - 32px))`,
-            // footer 与登录面板共享 handoff 入场态，避免品牌 splash 期间先露出
-            // “跳过登录”而面板仍不可点击。
+            // footer 只共享面板的可见性、交互门控与过渡时长；不复用 translateY，
+            // 避免它与父级 scale 下的面板产生不同步位移。
             opacity: groupStyle?.opacity,
             transform: 'translateX(-50%)',
             pointerEvents: groupStyle?.pointerEvents,

--- a/apps/desktop/src/renderer/components/login/LoginStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginStage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 
 import { panelPlacement } from './loginScale';
-import { LOGIN_GROUP } from './loginDesignTokens';
+import { LOGIN_GROUP, LOGIN_LOCAL_MODE } from './loginDesignTokens';
 
 /**
  * LoginStage — 桌面登录 1819×2098 设计画布的「面板宿主」层(demo v3.1 缩放)。
@@ -34,16 +34,24 @@ export function LoginStage({
   children,
   ssoOrgGroupY = false,
   groupStyle,
+  footer,
 }: {
   children: ReactNode;
   /** sso-org 族状态登录组 y=1227,其余 1229(figma §5.1 / demo loginY)。 */
   ssoOrgGroupY?: boolean;
   /** handoff 面板入场样式(opacity/transform/transition,LoginPage 消费 context 注入)。 */
   groupStyle?: CSSProperties;
+  /** 登录组下方的辅助操作区；相对于 stage 定位并参与视口底部避让计算。 */
+  footer?: ReactNode;
 }) {
   const { width, height } = useViewportSize();
   const groupY = ssoOrgGroupY ? LOGIN_GROUP.ySsoOrg : LOGIN_GROUP.yDefault;
-  const placement = panelPlacement(width, height, groupY);
+  const placement = panelPlacement(
+    width,
+    height,
+    groupY,
+    footer ? LOGIN_LOCAL_MODE.reservedHeight : 0,
+  );
 
   return (
     <div
@@ -73,6 +81,30 @@ export function LoginStage({
           {children}
         </div>
       </div>
+      {footer && (
+        <div
+          data-testid="login-stage-footer"
+          className="absolute z-30 flex flex-col items-center text-center"
+          style={{
+            left: '50%',
+            top:
+              placement.topY +
+              LOGIN_GROUP.height * placement.scale +
+              LOGIN_LOCAL_MODE.gap,
+            width: `min(${LOGIN_GROUP.width}px, calc(100vw - 32px))`,
+            // footer 与登录面板共享 handoff 入场态，避免品牌 splash 期间先露出
+            // “跳过登录”而面板仍不可点击。
+            opacity: groupStyle?.opacity,
+            transform: groupStyle?.transform
+              ? `translateX(-50%) ${groupStyle.transform}`
+              : 'translateX(-50%)',
+            pointerEvents: groupStyle?.pointerEvents,
+            transition: groupStyle?.transition,
+          }}
+        >
+          {footer}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/login/LoginStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginStage.tsx
@@ -95,9 +95,7 @@ export function LoginStage({
             // footer 与登录面板共享 handoff 入场态，避免品牌 splash 期间先露出
             // “跳过登录”而面板仍不可点击。
             opacity: groupStyle?.opacity,
-            transform: groupStyle?.transform
-              ? `translateX(-50%) ${groupStyle.transform}`
-              : 'translateX(-50%)',
+            transform: 'translateX(-50%)',
             pointerEvents: groupStyle?.pointerEvents,
             transition: groupStyle?.transition,
           }}

--- a/apps/desktop/src/renderer/components/login/LoginStage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginStage.tsx
@@ -84,7 +84,7 @@ export function LoginStage({
           data-testid="login-stage-footer"
           className="absolute z-30 flex flex-col items-center text-center"
           style={{
-            left: '50%',
+            left: placement.centerX,
             top:
               placement.topY +
               LOGIN_GROUP.height * placement.scale +

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
@@ -167,6 +167,13 @@ describe('identifier 态(附录 A providers 场景)', () => {
     expect(screen.getByTestId('login-social-row')).toBeTruthy();
   });
 
+  it('本地模式入口挂在登录 stage footer，不再脱离内容固定到底部', async () => {
+    mount(await identifierState('providers:both'));
+    const footer = screen.getByTestId('login-stage-footer');
+    expect(footer.contains(screen.getByTestId('login-local-mode'))).toBe(true);
+    expect(footer.contains(screen.getByText('login.localModeDescription'))).toBe(true);
+  });
+
   it('providers:phone-only → 无 tabs,placeholder 为手机号', async () => {
     mount(await identifierState('providers:phone-only'));
     expect(screen.queryByTestId('login-id-tabs')).toBeNull();

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
@@ -171,7 +171,9 @@ describe('identifier 态(附录 A providers 场景)', () => {
     mount(await identifierState('providers:both'));
     const footer = screen.getByTestId('login-stage-footer');
     expect(footer.contains(screen.getByTestId('login-local-mode'))).toBe(true);
-    expect(footer.contains(screen.getByText('login.localModeDescription'))).toBe(true);
+    const description = screen.getByText('login.localModeDescription');
+    expect(footer.contains(description)).toBe(true);
+    expect(description.className).toContain('line-clamp-2');
   });
 
   it('providers:phone-only → 无 tabs,placeholder 为手机号', async () => {

--- a/apps/desktop/src/renderer/components/login/__tests__/loginScale.test.ts
+++ b/apps/desktop/src/renderer/components/login/__tests__/loginScale.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { brandPlacement, desktopScale, panelPlacement, PANEL_FIXED_SCALE, sloganShiftX } from '../loginScale';
+import {
+  brandPlacement,
+  desktopScale,
+  panelPlacement,
+  PANEL_FIXED_SCALE,
+  sloganShiftX,
+} from '../loginScale';
 
 /**
  * 缩放公式行为单测(implementation-plan Step 2 WHAT1 锚点数值,demo v3.1 拍板)。
@@ -61,6 +67,12 @@ describe('panelPlacement(面板恒定 1x,用户拍板 2026-07-23,design.md §11)
     expect(panelPlacement(800, 600, 1229).topY).toBe(296);
   });
 
+  it('底部有本地模式操作区时，视口 clamp 为 footer 预留安全空间', () => {
+    const placement = panelPlacement(800, 600, 1229, 124);
+    expect(placement.topY).toBe(172);
+    expect(placement.topY + 560 * placement.scale + 124).toBe(576);
+  });
+
   it('高窗时锚点主导(不触发任何 clamp):(1300, 1400) top = 锚点中心-140', () => {
     const s14 = 1400 / 2098;
     const anchorTop = 700 + (1229 + 280 - 1049) * s14 - 140;
@@ -99,5 +111,12 @@ describe('brandPlacement(品牌块整体让位,用户拍板 2026-07-23 第二轮
     const r = brandPlacement(800, 600);
     const blockBottomAfter = 300 + 160 * s6 + r.translateY;
     expect(blockBottomAfter).toBeCloseTo(296 - 12, 2);
+  });
+
+  it('品牌让位与登录 footer 使用同一 bottom reserve，避免面板上移后再次遮挡品牌', () => {
+    const panelTop = panelPlacement(800, 600, 1229, 124).topY;
+    const r = brandPlacement(800, 600, 124);
+    const blockBottomAfter = 300 + 160 * r.scale + r.translateY;
+    expect(blockBottomAfter).toBeLessThanOrEqual(panelTop - 12);
   });
 });

--- a/apps/desktop/src/renderer/components/login/loginDesignTokens.ts
+++ b/apps/desktop/src/renderer/components/login/loginDesignTokens.ts
@@ -37,6 +37,19 @@ export const LOGIN_GROUP = {
   height: 560,
 } as const;
 
+/**
+ * 登录面板下方的本地模式操作区。
+ *
+ * 这块区域不再脱离登录 stage 固定在窗口底部：stage 会为它预留空间，避免小窗口
+ * 中与第三方登录圆钮重叠。reservedHeight 包含 stage 与操作区间距、两行文案的
+ * 最大高度，以及窗口底部安全边距。
+ */
+export const LOGIN_LOCAL_MODE = {
+  gap: 16,
+  reservedHeight: 124,
+  descriptionLineHeight: 18,
+} as const;
+
 /** 面板与面板内组件几何(figma §5.1/§4;wave4 面板描边 1px inside 368:1383)。 */
 export const PANEL = { width: 680, height: 440, radius: 36 } as const;
 export const TITLE = { y: 31, height: 38, fontSize: 32 } as const;

--- a/apps/desktop/src/renderer/components/login/loginScale.ts
+++ b/apps/desktop/src/renderer/components/login/loginScale.ts
@@ -56,17 +56,25 @@ export interface PanelPlacement {
  *   - 垂直锚点跟随品牌层 desktopScale 画布(组中心 y=groupY+280 映射到屏幕),
  *     再依次 clamp:① 品牌避让——面板顶 ≥ 立绘底(设计 y=1209,figma §4.11)+24;
  *     ② 功能优先——面板底 ≤ 视口底-24(压过品牌避让,小窗允许叠上立绘渐隐区,
- *     面板层 z-[9990] 本就盖品牌层 z-[9980]);③ 顶部保底 24。
+ *     面板层 z-[9990] 本就盖品牌层 z-[9980]);额外底部内容通过 bottomReserve
+ *     参与此 clamp;③ 顶部保底 24。
  *   - 水平:组中心 x=910 与画布中线 909.5 的 0.5 设计px 偏移按恒定缩放折算。
  */
-export function panelPlacement(w: number, h: number, groupY: number): PanelPlacement {
+export function panelPlacement(
+  w: number,
+  h: number,
+  groupY: number,
+  bottomReserve = 0,
+): PanelPlacement {
   const { scale: brandScale } = desktopScale(w, h);
   const panelHeight = 560 * PANEL_FIXED_SCALE; // 登录整体组高 560(figma §5.1)
   const anchorCenterY = h / 2 + (groupY + 280 - LOGIN_STAGE_HEIGHT / 2) * brandScale;
   const brandBottomY = h / 2 + (1209 - LOGIN_STAGE_HEIGHT / 2) * brandScale;
   let topY = anchorCenterY - panelHeight / 2;
   topY = Math.max(topY, brandBottomY + 24);
-  topY = Math.min(topY, h - 24 - panelHeight);
+  // 额外底部内容(例如本地模式入口)属于登录组的一部分，必须在这里预留空间；
+  // 否则视口底 clamp 会把它和 social row 压到同一条垂直区域。
+  topY = Math.min(topY, h - 24 - panelHeight - bottomReserve);
   topY = Math.max(topY, 24);
   return {
     scale: PANEL_FIXED_SCALE,
@@ -92,9 +100,9 @@ export interface BrandPlacement {
  *   ③ 极矮窗:上移仍不够 → 整块等比压缩至恰好塞进 [12, 面板顶-12]。
  * 面板锚点取 yDefault(sso 态差 2 设计px,由 12px gap 吸收)。
  */
-export function brandPlacement(w: number, h: number): BrandPlacement {
+export function brandPlacement(w: number, h: number, bottomReserve = 0): BrandPlacement {
   const { scale: base } = desktopScale(w, h);
-  const { topY: panelTop } = panelPlacement(w, h, 1229);
+  const { topY: panelTop } = panelPlacement(w, h, 1229, bottomReserve);
   const blockTop = h / 2 + (275 - LOGIN_STAGE_HEIGHT / 2) * base;
   const blockBottom = h / 2 + (1209 - LOGIN_STAGE_HEIGHT / 2) * base;
   const limit = panelTop - 12;

--- a/apps/desktop/src/renderer/contexts/LoginHandoffContext.tsx
+++ b/apps/desktop/src/renderer/contexts/LoginHandoffContext.tsx
@@ -73,6 +73,11 @@ export type LoginHandoffBranch = 'unauthenticated' | 'authenticated' | null;
 export interface LoginHandoffContextValue {
   phase: LoginHandoffPhase;
   branch: LoginHandoffBranch;
+  /**
+   * 登录面板下方内容需要预留的高度；null 表示 LoginPage 尚未上报，
+   * 品牌层应使用常态本地模式 footer 的预留值。
+   */
+  panelBottomReserve: number | null;
   /** 播放中(boot 之后、done 之前)——面板/Slogan 的入场 transition 只在此期挂。 */
   isPlaying: boolean;
   /** 品牌 overlay 是否应挂载(startup 期恒挂;done 后跟随 login 面板存在;authenticated 淡出后卸载)。 */
@@ -87,6 +92,7 @@ export interface LoginHandoffContextValue {
   reportSplashExited: () => void;
   reportLoginPanelMounted: () => void;
   reportLoginPanelUnmounted: () => void;
+  reportPanelBottomReserve: (reserve: number | null) => void;
 }
 
 const LoginHandoffContext = createContext<LoginHandoffContextValue | null>(null);
@@ -98,6 +104,7 @@ const LoginHandoffContext = createContext<LoginHandoffContextValue | null>(null)
 const FALLBACK_VALUE: LoginHandoffContextValue = Object.freeze({
   phase: 'done',
   branch: null,
+  panelBottomReserve: null,
   isPlaying: false,
   brandStageMounted: true,
   brandExiting: false,
@@ -107,6 +114,7 @@ const FALLBACK_VALUE: LoginHandoffContextValue = Object.freeze({
   reportSplashExited: () => {},
   reportLoginPanelMounted: () => {},
   reportLoginPanelUnmounted: () => {},
+  reportPanelBottomReserve: () => {},
 });
 
 function prefersReducedMotion(): boolean {
@@ -133,6 +141,7 @@ export function LoginHandoffProvider({
   const [brandReady, setBrandReady] = useState(false);
   const [splashExited, setSplashExited] = useState(false);
   const [panelMounted, setPanelMounted] = useState(false);
+  const [panelBottomReserve, setPanelBottomReserve] = useState<number | null>(null);
 
   // 冷启动只播一次:进程生命周期内 resize/reset/登出重回 /login 均不重播。
   const playedRef = useRef(false);
@@ -163,6 +172,10 @@ export function LoginHandoffProvider({
     panelMountedRef.current = false;
     setPanelMounted(false);
   }, []);
+  const reportPanelBottomReserve = useCallback(
+    (reserve: number | null) => setPanelBottomReserve(reserve),
+    [],
+  );
 
   // ── 推进锚:品牌资产 onload ∧ auth 初始化完成 ∧ Splash 退场 → 起播(一次) ──
   useEffect(() => {
@@ -219,6 +232,7 @@ export function LoginHandoffProvider({
     return {
       phase,
       branch,
+      panelBottomReserve,
       isPlaying,
       // startup 期(含 boot/播放中/brand-exit)恒挂以维持不透明白底全盖;done 后
       // 一律跟随登录面板存在:authenticated 淡出完成且无面板 → 卸载;之后登出
@@ -234,15 +248,18 @@ export function LoginHandoffProvider({
       reportSplashExited,
       reportLoginPanelMounted,
       reportLoginPanelUnmounted,
+      reportPanelBottomReserve,
     };
   }, [
     phase,
     branch,
     panelMounted,
+    panelBottomReserve,
     reportBrandAssetsReady,
     reportSplashExited,
     reportLoginPanelMounted,
     reportLoginPanelUnmounted,
+    reportPanelBottomReserve,
   ]);
 
   return <LoginHandoffContext.Provider value={value}>{children}</LoginHandoffContext.Provider>;

--- a/apps/desktop/src/renderer/contexts/__tests__/LoginHandoffContext.test.tsx
+++ b/apps/desktop/src/renderer/contexts/__tests__/LoginHandoffContext.test.tsx
@@ -74,6 +74,7 @@ import { AuthProvider, useAuth } from '../AuthContext';
 import { LoginBrandStage } from '@/components/login/LoginBrandStage';
 import { SplashScreen } from '@/components/splash/SplashScreen';
 import { LoginPage } from '@/components/login/LoginPage';
+import { brandPlacement, panelPlacement } from '@/components/login/loginScale';
 
 /* ── 探针:抓取 context 值供命令式驱动 ── */
 const probe: { current: LoginHandoffContextValue | null } = { current: null };
@@ -100,6 +101,10 @@ beforeEach(() => {
   setReducedMotion(false);
   probe.current = null;
   svc.env.status = 'passed';
+  svc.loginHook.loginState = {
+    step: 'identifier',
+    providers: { email: true, phone: true, attribution: 'email', social: [] },
+  };
   svc.authListener = null;
   svc.service.initialize.mockReset();
   svc.service.onAuthStateChange.mockReset();
@@ -247,6 +252,21 @@ describe('LoginHandoff 时序(fake-timer)', () => {
     expect(probe.current!.isPlaying).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it('登录面板与品牌层通过 context 共享同一 bottom reserve', () => {
+    render(
+      <LoginHandoffProvider authResolved authenticated={false}>
+        <Probe />
+      </LoginHandoffProvider>,
+    );
+    expect(probe.current!.panelBottomReserve).toBeNull();
+    act(() => probe.current!.reportPanelBottomReserve(124));
+    expect(probe.current!.panelBottomReserve).toBe(124);
+    act(() => probe.current!.reportPanelBottomReserve(0));
+    expect(probe.current!.panelBottomReserve).toBe(0);
+    act(() => probe.current!.reportPanelBottomReserve(null));
+    expect(probe.current!.panelBottomReserve).toBeNull();
+  });
 });
 
 /* ── 冷启动集成(real AuthProvider + LoginBrandStage + SplashScreen + LoginPage) ── */
@@ -296,6 +316,29 @@ function loadBrandAssets() {
 }
 
 describe('冷启动集成(resolved snapshot,禁 mock-reject)', () => {
+  it('browser-redirect 无 footer 时，面板与品牌层统一使用 0 bottom reserve', async () => {
+    svc.loginHook.loginState = { step: 'browser-redirect', label: 'Google' };
+    svc.service.initialize.mockResolvedValue({
+      isAuthenticated: false,
+      isCanary: false,
+      deviceId: 'test-device',
+      user: null,
+    });
+    renderColdStart();
+    await flush();
+
+    expect(probe.current!.panelBottomReserve).toBe(0);
+    expect(screen.queryByTestId('login-stage-footer')).toBeNull();
+
+    const panel = panelPlacement(window.innerWidth, window.innerHeight, 1229, 0);
+    expect(screen.getByTestId('login-stage').style.top).toBe(`${panel.topY}px`);
+
+    const brand = brandPlacement(window.innerWidth, window.innerHeight, 0);
+    expect(screen.getByTestId('login-brand-canvas').style.transform).toBe(
+      `translate(-50%, calc(-50% + ${brand.translateY}px)) scale(${brand.scale})`,
+    );
+  });
+
   it('unauthenticated 冷启动:品牌屏→完整衔接播放;全程单一品牌 DOM/最多一个可见 panel/done 后可点击/overlay 不拦截', async () => {
     // 集成层异常路径口径 = resolved-unauthenticated snapshot(v6.8 消歧)
     svc.service.initialize.mockResolvedValue({


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 未登录首屏中“跳过登录”入口与第三方登录按钮重叠的问题。入口现在位于登录 stage 的底部辅助操作区，并参与统一的视口避让计算。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：登录 stage footer、底部空间预留、品牌舞台同步避让、回归测试；并按 Copilot 建议移除 footer 对面板 handoff transform 的复用、统一面板与品牌层的 bottom reserve，并限制描述最多两行
- 明确不包含：登录协议、认证逻辑、本地模式业务逻辑、文案和 i18n 资源
- 用户可见变化：第三方登录按钮与“跳过登录”入口分层显示，不再叠在一起；小窗口优先保证操作可见
- 是否存在 breaking change：无

### UI 变化

![登录首屏布局修复截图](https://github.com/Xzhhhh414/cindy/blob/main/assets/pr/login-skip-button-layout.webp?raw=1)

截图为用户提供的 Desktop Light 模式验证图；按钮顺序为登录卡片 → 第三方登录 → 跳过登录 → 本地模式说明。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；Desktop 1098 个测试文件、11638 个测试通过，2 个跳过；其余 unit workspace 全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec vitest run src/renderer/contexts/__tests__/LoginHandoffContext.test.tsx src/renderer/components/login/__tests__/LoginPage.harness.test.tsx src/renderer/components/login/__tests__/LoginPage.browserRedirect.test.tsx src/renderer/components/login/__tests__/loginScale.test.ts
结果：通过；55 个测试通过（包含 handoff transform、bottom reserve 同步与两行文案约束的回归验证）。
```

### 手工验证

- 用户提供了 Desktop Light 模式截图，确认第三方登录按钮与“跳过登录”入口已分开。
- 代码层验证了 Light/Dark 均消费语义 token，并为面板、品牌块和 footer 使用同一底部避让参数。

### 未执行的验证

- 未在本次会话中重启 Desktop 做独立实机截图；当前没有运行中的 Desktop 实例，避免改动共享 userData。
- 未单独完成 Windows 实机验证；布局未引入平台分支，待 CI/维护者环境验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 未登录首屏及登录流程中的本地模式入口位置；不改变认证和本地模式业务逻辑。
- 回滚 / 降级方式：回滚 commit `790e5a0` 即可恢复原布局定位。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

## CI 结果

- 最终状态：未触发；截至 2026-07-24，GitHub API 未为该 fork 分支触发 check run；最新 head 为 6bc169d。