### PR TITLE
test(desktop): 补齐 modelSelectorTriggerVariant 对 providerModels 的 mock 导出

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -236,6 +236,9 @@ vi.mock('@/hooks/useDeviceProviders', () => ({
 
 vi.mock('@/lib/providerModels', () => ({
   providerMonogram: (name: string) => name.slice(0, 1).toUpperCase(),
+  // #245 新增:ModelSelector 渲染路径直接调用;fixture providers 无 routing,按不过滤透传。
+  isChatBridgedCodexProvider: () => false,
+  filterChatBridgedCodexProviders: (providers: unknown[]) => providers,
   resolveVisibleModelAgentKind: ({
     agentKind,
   }: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

#245 给 `@/lib/providerModels` 新增了 `filterChatBridgedCodexProviders` 并在 `ModelSelector` 渲染路径直接调用,但没有同步更新 `modelSelectorTriggerVariant.test.ts` 的模块 mock。当前 main 上该测试文件 3 个用例全红(`No "filterChatBridgedCodexProviders" export is defined on the "@/lib/providerModels" mock`),会殃及所有 open PR 的 test:unit 验证。本 PR 只补 mock 导出恢复基线:透传实现(fixture providers 无 `routing` 字段,本就不参与桥接过滤),同时补 `isChatBridgedCodexProvider` 防同源再炸。

### 变更类型

- [x] `test` 测试修复

### 范围

- 关联 Issue / 需求:#245 的测试基线跟进
- 本 PR 包含:仅 `modelSelectorTriggerVariant.test.ts` mock 补齐(3 行)
- 明确不包含:任何运行时行为变化
- 用户可见变化:无
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果:17 passed(修复前 3 failed:lets inactive provider rows edit... /
keeps target-agent provider rows... / shares inactive model presets...)
```

### 手工验证

不涉及(纯测试 mock)。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅单测;远程连接/手机版适配(规则 26)不涉及。
- 回滚 / 降级方式:revert 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(不需要)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
