### PR TITLE
fix: 修复一次性 Node 子进程无法退出

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/fixtures/nodeRuntimeExitImmediately.cjs
+++ b/apps/desktop/src/main/cindy-brain/__tests__/fixtures/nodeRuntimeExitImmediately.cjs
@@ -1,0 +1,1 @@
+'use strict';

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeWorkerProcess.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeWorkerProcess.test.ts
@@ -1,0 +1,64 @@
+/**
+ * nodeRuntimeWorkerProcess.test — utilityProcess child mode 的端口生命周期回归测试。
+ */
+
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { GHOST_NODE_CHILD_MODE_FLAG } from '../../../shared/ghost';
+
+type ParentMessageListener = (event: { data: unknown }) => void;
+
+const originalArgv = process.argv;
+const originalStdin = Object.getOwnPropertyDescriptor(process, 'stdin');
+const originalParentPort = Object.getOwnPropertyDescriptor(process, 'parentPort');
+
+function restoreProcessProperty(name: 'stdin' | 'parentPort', descriptor?: PropertyDescriptor): void {
+  if (descriptor) {
+    Object.defineProperty(process, name, descriptor);
+  } else {
+    delete (process as unknown as Record<string, unknown>)[name];
+  }
+}
+
+afterEach(() => {
+  process.argv = originalArgv;
+  restoreProcessProperty('stdin', originalStdin);
+  restoreProcessProperty('parentPort', originalParentPort);
+  vi.resetModules();
+});
+
+describe('nodeRuntimeWorkerProcess · child mode 生命周期', () => {
+  it('收到 stdin-end 后解除 ParentPort 监听，让一次性 CLI 能自然退出', async () => {
+    const listeners = new Set<ParentMessageListener>();
+    const parentPort = {
+      postMessage: vi.fn(),
+      on: vi.fn((_event: 'message', listener: ParentMessageListener) => {
+        listeners.add(listener);
+      }),
+      off: vi.fn((_event: 'message', listener: ParentMessageListener) => {
+        listeners.delete(listener);
+      }),
+    };
+    Object.defineProperty(process, 'parentPort', {
+      configurable: true,
+      value: parentPort,
+    });
+    process.argv = [
+      process.execPath,
+      'nodeRuntimeWorkerProcess.js',
+      path.join(__dirname, 'fixtures/nodeRuntimeExitImmediately.cjs'),
+      GHOST_NODE_CHILD_MODE_FLAG,
+    ];
+
+    await import('../nodeRuntimeWorkerProcess');
+
+    expect(parentPort.postMessage).toHaveBeenCalledWith({ type: 'ready' });
+    expect(listeners).toHaveLength(1);
+    const [listener] = listeners;
+    listener({ data: { type: 'stdin-end' } });
+    expect(parentPort.off).toHaveBeenCalledWith('message', listener);
+    expect(listeners).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeWorkerProcess.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeWorkerProcess.ts
@@ -31,6 +31,7 @@ import { GHOST_NODE_CHILD_MODE_FLAG } from '../../shared/ghost.js';
 interface ParentPortLike {
   postMessage(message: unknown): void;
   on(event: 'message', listener: (event: { data: unknown }) => void): void;
+  off(event: 'message', listener: (event: { data: unknown }) => void): void;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -179,7 +180,7 @@ function spawnEntry(entry: string, args?: string[]): Promise<unknown> {
 
 /* ── parentPort 分发与就绪握手 ─────────────────────────────────────── */
 
-parentPort.on('message', (event) => {
+function handleParentMessage(event: { data: unknown }): void {
   const data = event.data;
   if (!isRecord(data)) return;
   if (data.type === 'stdin' && typeof data.chunk === 'string') {
@@ -193,6 +194,9 @@ parentPort.on('message', (event) => {
   }
   if (data.type === 'stdin-end') {
     virtualStdin.end();
+    // Electron ParentPort 没有 unref()。child mode 收到 EOF 后已不再需要任何
+    // 上行控制帧，解除监听才能像普通 Node 子进程一样在任务完成后自然退出。
+    if (childMode) parentPort!.off('message', handleParentMessage);
     return;
   }
   if (!childMode && typeof data.type === 'string' && data.type.startsWith('child-')) {
@@ -202,7 +206,9 @@ parentPort.on('message', (event) => {
   if (!childMode && data.type === 'spawn-child-result') {
     handleChildControlMessage(data as unknown as GhostNodeChildToWorkerMessage);
   }
-});
+}
+
+parentPort.on('message', handleParentMessage);
 
 // 主机只等这条固定就绪消息;普通模式下引导层继续私用 parentPort 走子进程
 // 控制帧,但随后把公开引用从 process 上拿掉——插件代码的正式通信面只剩


### PR DESCRIPTION
## 概要

- child mode 收到虚拟 stdin EOF 后解除 Electron ParentPort 监听，让已完成的一次性 CLI 自然退出。
- 增加 utilityProcess 生命周期回归测试，覆盖 ready、stdin-end 与监听器回收。

## 架构边界

- 本 PR 只修改 Cindy 通用 Node Runtime 生命周期，不包含 TapTap Maker 业务、Runtime 或专用 Bridge。
- 普通插件 worker 仍保留 ParentPort 监听；只对不再接收控制帧的 child mode 执行回收。
- TapTap Maker 的完整业务实现位于独立官方插件仓 Draft PR：makecindy/cindy-official-plugins#4。

## 验证

- Node Runtime 测试：23/23 通过。
- Desktop TypeScript typecheck 通过。
- `git diff --check` 通过。

## 风险与回滚

- 行为变化仅发生在 child mode 收到 stdin EOF 之后；宿主仍可直接终止 utilityProcess。
- 如出现兼容问题，可单独回滚本提交，不影响插件数据与协议。