### PR TITLE
fix(desktop): 供应商向导 OpenAI 检测建议直达不再静默自关

### DIFF
--- a/apps/desktop/src/renderer/__tests__/addProviderWizardOpenaiEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardOpenaiEntry.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+/**
+ * AddProviderWizard —— OpenAI 检测建议直达的关键不变量:
+ *
+ *   1. 本机已有 ChatGPT 凭证(codexAuth 已是 oauth connected)但当前账号未绑定时,
+ *      向导**不得**挂载即自关:codexAuth 是整机凭证态,不含按账号的 native binding,
+ *      自关会既不弹 UI 也不补绑定,「去授权」从此点不出任何效果(回归:换账号死循环)。
+ *   2. 本向导内点「授权」发起登录并成功 → 正常收口 onDone('openai')。
+ *   3. anthropic entry 直达 → 授权步正常渲染(对照组,证明弹窗结构本身可用)。
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProviderView } from '@cindy/model-providers';
+
+const { codexState, triggerLoginMock } = vi.hoisted(() => ({
+  codexState: { kind: 'unauthenticated' } as { kind: string; authSource?: string },
+  triggerLoginMock: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'zh-CN' } }),
+}));
+
+vi.mock('@/hooks/useCodexAuth', () => ({
+  // 与真实实现同判定:仅 authenticated + oauth 视为 ChatGPT 已连接。
+  isChatGptConnectionConnected: (state: { kind: string; authSource?: string }) =>
+    state.kind === 'authenticated' && state.authSource === 'oauth',
+  useCodexAuth: () => ({
+    state: codexState,
+    triggerLogin: triggerLoginMock,
+    cancelLogin: vi.fn(),
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/lib/customProviders', () => ({
+  createCustomProvider: vi.fn(),
+}));
+
+vi.mock('@/lib/customProviderId', () => ({
+  uniqueCustomProviderId: (name: string) => name,
+}));
+
+vi.mock('@/lib/providerModels', () => ({
+  providerMonogram: () => 'X',
+}));
+
+vi.mock('@/components/icons/ProviderLogoMark', () => ({
+  hasProviderLogo: () => false,
+  ProviderLogoMark: () => null,
+}));
+
+import { AddProviderWizard } from '@/components/settings/AddProviderWizard';
+
+const anthropicProvider = {
+  id: 'anthropic',
+  name: 'Anthropic',
+  source: 'builtin',
+  agents: ['claude-code'],
+  auth: { method: 'oauth' },
+  routing: {},
+  models: { 'claude-code': [] },
+  connected: false,
+} as unknown as ProviderView;
+
+const openaiProvider = {
+  ...anthropicProvider,
+  id: 'openai',
+  name: 'OpenAI',
+  agents: ['claude-code', 'codex'],
+} as unknown as ProviderView;
+
+function renderWizard(providerId: string, onDone: (id?: string) => void) {
+  return render(
+    React.createElement(AddProviderWizard, {
+      providers: [anthropicProvider, openaiProvider],
+      entry: { kind: 'builtin' as const, providerId },
+      onOpenCustomForm: vi.fn(),
+      onClose: vi.fn(),
+      onDone,
+    }),
+  );
+}
+
+beforeEach(() => {
+  codexState.kind = 'unauthenticated';
+  delete codexState.authSource;
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    maker: {
+      listProviderPresets: vi.fn(async () => ({ presets: [] })),
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('AddProviderWizard — OpenAI 检测建议直达', () => {
+  it('本机已有 ChatGPT 凭证但账号未绑定 → 向导保持打开,不静默自关', () => {
+    codexState.kind = 'authenticated';
+    codexState.authSource = 'oauth';
+    const onDone = vi.fn();
+    renderWizard('openai', onDone);
+
+    // 授权步可见、可交互;onDone 不得被立即触发。
+    expect(screen.getByText('settings.providers.button.authorize')).not.toBeNull();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('本向导内点「授权」登录成功 → onDone(openai) 收口', async () => {
+    triggerLoginMock.mockResolvedValue('authenticated');
+    const onDone = vi.fn();
+    renderWizard('openai', onDone);
+
+    fireEvent.click(screen.getByText('settings.providers.button.authorize'));
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith('openai'));
+    expect(triggerLoginMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('anthropic entry 直达 → 授权步正常渲染(对照组)', () => {
+    const onDone = vi.fn();
+    renderWizard('anthropic', onDone);
+
+    expect(screen.getByText('settings.providers.wizard.titleWith')).not.toBeNull();
+    expect(screen.getByText('settings.providers.button.authorize')).not.toBeNull();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -25,7 +25,7 @@ import { Tip } from '@/components/ui/tooltip';
 import { createCustomProvider, type RuntimeKeys } from '@/lib/customProviders';
 import { uniqueCustomProviderId } from '@/lib/customProviderId';
 import { providerMonogram } from '@/lib/providerModels';
-import { useCodexAuth } from '@/hooks/useCodexAuth';
+import { isChatGptConnectionConnected, useCodexAuth } from '@/hooks/useCodexAuth';
 import { hasProviderLogo, ProviderLogoMark } from '@/components/icons/ProviderLogoMark';
 
 import { sortPresetsForLocale } from '@cindy/model-providers';
@@ -261,6 +261,14 @@ export function AddProviderWizard({
     setStep(2);
   }, []);
 
+  /**
+   * 本向导内是否发起过 OpenAI 登录。codexAuth 反映的是整机 ChatGPT 凭证,不含
+   * 「凭证归哪个账号」的 native binding —— 换账号后本机可能已有别人绑定的登录,
+   * 此时 codexAuth 一挂载就是 connected;若不加此限定,检测建议直达打开的向导会
+   * 挂载即自关,既不弹任何 UI 也不给当前账号补绑定,「去授权」永远点不出效果。
+   */
+  const openaiLoginStartedRef = useRef(false);
+
   // ── OAuth 授权(复用既有鉴权流;成功即完成,无第 3 步)────────────────────
   const handleAuthorize = useCallback(async () => {
     if (!sel || sel.kind !== 'oauth') return;
@@ -277,6 +285,7 @@ export function AddProviderWizard({
         }
         if (!r.ok && r.reason === 'login_cancelled') return;
       } else if (id === 'openai') {
+        openaiLoginStartedRef.current = true;
         const outcome = await codexAuth.triggerLogin();
         ok = outcome === 'authenticated';
         if (outcome === 'cancelled') return;
@@ -321,6 +330,22 @@ export function AddProviderWizard({
     if (loggingIn) cancelAuthorize();
     onClose();
   }, [loggingIn, cancelAuthorize, onClose]);
+
+  // OpenAI 走 useCodexAuth:hook 状态翻 connected 时视为完成(triggerLogin 也会返回,
+  // oneshot ref 保证只收口一次)。只收口本向导内发起的登录(openaiLoginStartedRef),
+  // 不把「本机已有凭证」误当成完成 —— 见 openaiLoginStartedRef 的注释。
+  const openaiDoneRef = useRef(false);
+  useEffect(() => {
+    if (openaiDoneRef.current || !openaiLoginStartedRef.current) return;
+    if (
+      sel?.kind === 'oauth' &&
+      sel.provider.id === 'openai' &&
+      isChatGptConnectionConnected(codexAuth.state, false)
+    ) {
+      openaiDoneRef.current = true;
+      onDone('openai');
+    }
+  }, [codexAuth.state, sel, onDone]);
 
   // ── 预设:进入 Step 3 时自动拉取模型 ─────────────────────────────────────
   const startFetch = useCallback(async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

「设置 → 模型供应商」左栏「检测到本机 CLI」的 OpenAI「去授权」行,在**本机已有 ChatGPT 凭证但当前 Cindy 账号未绑定**时(典型:企业账号授权过,切到个人账号),点击后向导弹窗会挂载即自关:`AddProviderWizard` 里的 OpenAI 自动收口 effect 只看 `codexAuth`(整机凭证态,不含按账号的 native binding,连接判定见 `createDesktopProviderService.ts:315`),把「本机已有凭证」误当成「本次授权已完成」,于是不弹任何 UI、也不给当前账号补绑定,「去授权」从此点不出任何效果(死循环)。

修复:自动收口 effect 增加「本向导内发起过登录」(`openaiLoginStartedRef`)限定。直达打开时向导正常显示授权步;点「授权」走完整 `codex login` 流程,成功后由 main 侧 `bindNativeProviderAuth('openai')` 把凭证绑定到当前账号。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(用户现场排查:个人账号点「去授权」无任何反应,企业账号正常)
- 本 PR 包含:`AddProviderWizard` OpenAI 自动收口条件收紧 + 回归测试
- 明确不包含:main 侧绑定/凭证逻辑改动;Anthropic / xAI 流程(无此 effect,不受影响)
- 用户可见变化:未绑定账号点 OpenAI「去授权」现在能看到向导授权步并完成授权
- 是否存在 breaking change:无

### UI 变化

不涉及新 UI;仅修复既有弹窗被立即关闭的问题,无样式改动(Light/Dark 均为既有样式)。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm test:unit(仓库根)
结果:desktop 11649 passed / 3 failed;3 个失败均为 modelSelectorTriggerVariant.test.ts,
系本地验证工作区(feat/mobile-i18n 合并树)丢失了 #245 新增的 providerModels mock 导出所致,
与本 PR 无关;用 origin/main 版本的该测试文件在同一工作区重跑 17/17 全过。
其余 workspace 全部 PASS/SKIP。

pnpm --filter desktop vitest run addProviderWizardOpenaiEntry providersSectionUnavailableModels
结果:5/5 通过(含新增 3 个回归用例:已有凭证不自关、向导内登录成功正常收口、anthropic 对照组)
```

注:本地验证工作区基于 feat/mobile-i18n 合并树,但本 PR 触及的两个文件与 origin/main 内容一致,提交本身基于最新 origin/main 构建,最终以 CI 为准。

### 手工验证

不涉及(修复场景需要双 Cindy 账号 + 已绑定凭证的机器态;行为已由回归测试覆盖,现场机器上复核过日志与绑定文件状态)。

### 未执行的验证

未在真机上以「个人账号 + 企业账号已绑定」组合手工走完整授权流(需要第二个 ChatGPT 登录会话);风险由单测覆盖。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅「添加供应商」向导的 OpenAI 授权步收口时机;不改任何凭证读写与绑定逻辑
- 回滚 / 降级方式:revert 本 commit 即回到旧行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释说明约束)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)