### PR TITLE
fix(desktop): Codex 用量分槽收尾加固 (#259 review follow-up)

### DIFF
--- a/apps/desktop/src/main/__tests__/usageBroadcasterCodexAccount.test.ts
+++ b/apps/desktop/src/main/__tests__/usageBroadcasterCodexAccount.test.ts
@@ -103,6 +103,18 @@ describe('codex account usage source slots', () => {
     expect(payload?.accountId).toBe('acc-1');
   });
 
+  it('rejects a corrupted array webSnapshot on hydration (与 renderer 守卫同口径)', async () => {
+    const broadcaster = await import('../usageBroadcaster');
+    mocks.queryOne.mockResolvedValue({
+      snapshot: JSON.stringify({ ...APP_SERVER_SNAPSHOT, webSnapshot: [] }),
+    });
+
+    const payload = await broadcaster.readCodexAccountUsageSnapshot();
+    expect(payload?.primary?.usedPercent).toBe(82);
+    // 数组不是合法快照: 归 null, 不得被再次广播 / 回写
+    expect(payload?.webSnapshot ?? null).toBeNull();
+  });
+
   it('hydrates a legacy app-server row into the top-level slot', async () => {
     const broadcaster = await import('../usageBroadcaster');
     mocks.queryOne.mockResolvedValue({ snapshot: JSON.stringify(APP_SERVER_SNAPSHOT) });

--- a/apps/desktop/src/main/usageBroadcaster.ts
+++ b/apps/desktop/src/main/usageBroadcaster.ts
@@ -342,7 +342,11 @@ export function splitPersistedCodexAccountUsage(parsed: Record<string, unknown>)
     const { webSnapshot, ...rest } = parsed as CodexAccountUsagePayload;
     return {
       appServer: hasCodexSnapshotContent(rest) ? rest : null,
-      web: webSnapshot && typeof webSnapshot === 'object' ? webSnapshot : null,
+      // 拒绝数组等畸形持久化值(与 renderer 的 isRateLimitSnapshot 守卫同口径),
+      // 否则损坏行会被当有效快照再次广播 + 回写。
+      web: webSnapshot && typeof webSnapshot === 'object' && !Array.isArray(webSnapshot)
+        ? webSnapshot
+        : null,
     };
   }
   const legacy = parsed as RateLimitSnapshot;

--- a/apps/desktop/src/renderer/__tests__/accountUsageSnapshot.test.ts
+++ b/apps/desktop/src/renderer/__tests__/accountUsageSnapshot.test.ts
@@ -216,9 +216,12 @@ describe('mergeCodexAccountUsageSnapshot', () => {
     // 白耗后台请求; review 反馈) —— bridge 槽保鲜走 main 的 bridge turn-done
     // 触发 + mount 读 + 悬念期催刷
     expect(hookSource).not.toContain('refreshWebUsage');
-    // module 常驻订阅: chip 全部卸载期间的换号清空广播不丢 (与 claude hook 同语义)
+    // module 常驻订阅: chip 全部卸载期间的换号清空广播不丢 (与 claude hook 同语义)。
+    // 只在 codex 会话安装 —— 非 codex 会话没有可残留的缓存, 常驻监听白耗 (review 反馈)
     expect(hookSource).toContain('function ensureModuleSubscription(');
-    expect(hookSource).toContain('ensureModuleSubscription();');
+    expect(hookSource).toContain("if (vendorKey === 'codex') ensureModuleSubscription();");
+    // main 侧持久化水合拒绝数组等畸形 webSnapshot (review 反馈)
+    expect(mainSource).toContain('!Array.isArray(webSnapshot)');
     // web-only 组合 payload 上浮归属字段, WHAM reader 的 accountId 归属判断不失配
     expect(mainSource).toContain('accountId: web.accountId');
   });

--- a/apps/desktop/src/renderer/__tests__/accountUsageSnapshot.test.ts
+++ b/apps/desktop/src/renderer/__tests__/accountUsageSnapshot.test.ts
@@ -216,12 +216,9 @@ describe('mergeCodexAccountUsageSnapshot', () => {
     // 白耗后台请求; review 反馈) —— bridge 槽保鲜走 main 的 bridge turn-done
     // 触发 + mount 读 + 悬念期催刷
     expect(hookSource).not.toContain('refreshWebUsage');
-    // module 常驻订阅: chip 全部卸载期间的换号清空广播不丢 (与 claude hook 同语义)。
-    // 只在 codex 会话安装 —— 非 codex 会话没有可残留的缓存, 常驻监听白耗 (review 反馈)
+    // module 常驻订阅的安装行为由下方 'module subscription install' 行为测试
+    // 覆盖 (renderToString 挂真 hook), 不再用脆弱的源码字符串断言 (review 反馈)。
     expect(hookSource).toContain('function ensureModuleSubscription(');
-    expect(hookSource).toContain("if (vendorKey === 'codex') ensureModuleSubscription();");
-    // main 侧持久化水合拒绝数组等畸形 webSnapshot (review 反馈)
-    expect(mainSource).toContain('!Array.isArray(webSnapshot)');
     // web-only 组合 payload 上浮归属字段, WHAM reader 的 accountId 归属判断不失配
     expect(mainSource).toContain('accountId: web.accountId');
   });
@@ -275,5 +272,53 @@ describe('splitCodexAccountUsagePayload', () => {
       source: 'codex-app-server',
     });
     expect('web' in bare).toBe(false);
+  });
+});
+
+describe('module subscription install (behavior)', () => {
+  // 真行为测试 (review 反馈: 源码字符串断言验不出等价重构 / 回归):
+  // ensureModuleSubscription 在 hook render 阶段安装, renderToString 即可驱动
+  // (不需要 effects / jsdom)。stub window.electronAPI 统计注册次数。
+  it('installs the codex usage listener once, and only for codex sessions', async () => {
+    const listeners: unknown[] = [];
+    const previousWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = {
+      electronAPI: {
+        maker: {
+          usage: {
+            onCodexAccountChanged: (cb: unknown) => {
+              listeners.push(cb);
+              return () => {};
+            },
+          },
+        },
+      },
+    };
+    try {
+      const { resetModules } = await import('vitest').then((m) => ({ resetModules: m.vi.resetModules }));
+      resetModules();
+      const [{ useAccountUsage: freshUseAccountUsage }, { renderToString }, React] =
+        await Promise.all([
+          import('@/hooks/useAccountUsage'),
+          import('react-dom/server'),
+          import('react'),
+        ]);
+      function Probe({ vendor }: { vendor?: 'cc' | 'codex' }) {
+        freshUseAccountUsage(undefined, vendor);
+        return null;
+      }
+      // 非 codex 会话: 不注册
+      renderToString(React.createElement(Probe, { vendor: 'cc' }));
+      renderToString(React.createElement(Probe, {}));
+      expect(listeners.length).toBe(0);
+      // 首个 codex 会话: 注册一次
+      renderToString(React.createElement(Probe, { vendor: 'codex' }));
+      expect(listeners.length).toBe(1);
+      // 幂等: 再挂 codex 实例不重复注册
+      renderToString(React.createElement(Probe, { vendor: 'codex' }));
+      expect(listeners.length).toBe(1);
+    } finally {
+      (globalThis as { window?: unknown }).window = previousWindow;
+    }
   });
 });

--- a/apps/desktop/src/renderer/hooks/useAccountUsage.ts
+++ b/apps/desktop/src/renderer/hooks/useAccountUsage.ts
@@ -264,8 +264,10 @@ export function useAccountUsage(
   vendorKey: 'cc' | 'codex' | undefined,
   quotaSource: CodexQuotaSource = 'app-server',
 ): RateLimitSnapshot | null {
-  // 幂等; 首个实例装上 module 常驻订阅, 保证卸载窗口内的广播(尤其换号清空)不丢。
-  ensureModuleSubscription();
+  // 幂等; 首个 codex 实例装上 module 常驻订阅, 保证之后卸载窗口内的广播(尤其
+  // 换号清空)不丢。非 codex 会话不装 —— 从没有 codex chip 消费过就没有可残留
+  // 的缓存, 常驻监听纯属白耗(review 反馈)。
+  if (vendorKey === 'codex') ensureModuleSubscription();
   const [snapshot, setSnapshot] = useState<RateLimitSnapshot | null>(() =>
     vendorKey === 'codex' ? selectCodexSlot(quotaSource) : null,
   );


### PR DESCRIPTION
## 这次改了什么

### 摘要

#259（Codex 用量快照按来源分槽）合并后遗留两条 review 反馈的收尾加固，都成立、都很小：

1. **main 侧持久化水合拒绝畸形值**：`splitPersistedCodexAccountUsage` 原先的 `typeof webSnapshot === 'object'` 会放过数组——损坏的持久化行（如 `webSnapshot: []`）会被当有效快照再次广播 + 回写。补 `!Array.isArray` 守卫，与 renderer 侧 `isRateLimitSnapshot` 同口径。
2. **module 常驻订阅收窄到 codex 会话**：`useAccountUsage` 原先无条件安装 module 级 `onCodexAccountChanged` 常驻监听，非 Codex 会话（如纯 Claude 用户）也会为用不到的缓存长期处理每条 push。改为首个 `vendorKey === 'codex'` 实例才安装——从没有 codex chip 消费过就没有可残留的缓存，保护语义不受影响。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#259 合并后的两条 unresolved review threads（copilot-pull-request-reviewer）
- 本 PR 包含：上述两处守卫 + 对应单测（畸形数组水合归 null；契约锁定条件安装）。
- 明确不包含：分槽架构的其它变化。
- 用户可见变化：无（防御性加固与后台开销收敛）。
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
apps/desktop: npx vitest run src/renderer/__tests__/accountUsageSnapshot.test.ts src/main/__tests__/usageBroadcasterCodexAccount.test.ts src/renderer/__tests__/todaySpendChip.test.ts
结果：3 文件 / 34 tests 全部通过（新增畸形数组水合 1 例）

仓库根 pnpm test:unit（统一门禁脚本）
结果：GATE_EXIT=0

pnpm --filter desktop run --if-present typecheck
结果：0 error
```

### 手工验证

不涉及（纯守卫逻辑，单测覆盖两个分支）。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Codex 用量快照水合守卫与 renderer 订阅安装时机，均为收窄性变化。
- 回滚 / 降级方式：revert 本 PR，回到 #259 合并时的行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码内注释）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
