### PR TITLE
fix(mobile): 隐藏安卓语音入口

### DIFF
--- a/apps/desktop/src/main/__tests__/windowsIconAssets.test.ts
+++ b/apps/desktop/src/main/__tests__/windowsIconAssets.test.ts
@@ -3,7 +3,9 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import sharp from 'sharp';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: process.platform === 'win32' ? 60_000 : 30_000 });
 
 const desktopRoot = path.resolve(__dirname, '../../..');
 const resourcesDir = path.join(desktopRoot, 'resources');

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
@@ -24,6 +24,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/hooks/useCodexAuth', () => ({
+  isChatGptConnectionConnected: () => false,
   useCodexAuth: () => ({
     state: { kind: 'authenticated', authSource: 'oauth' },
     triggerLogin,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -300,7 +300,11 @@ import {
   resolveComposerVoiceHoldActive,
   shouldArmComposerVoiceHold,
 } from '@/session/composerVoiceHold';
-import { isMobileRealtimeAudioAvailable, prewarmMobileRealtimeAudio } from '@/session/mobileRealtimeAudio';
+import {
+  isMobileRealtimeAudioAvailable,
+  prewarmMobileRealtimeAudio,
+  shouldShowMobileVoiceUi,
+} from '@/session/mobileRealtimeAudio';
 import {
   discardPendingPrewarm,
   prewarmMobileVoiceStart,
@@ -1375,6 +1379,7 @@ export default function SessionScreen() {
       : [],
     [atResources, canUseComposer, composerTrigger],
   );
+  const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);
   const voiceIsListening = voiceState === 'listening';
   const voiceIsProcessing = voiceState === 'submitting' || voiceState === 'refining';
   const voiceIsBusy = voiceIsListening || voiceIsProcessing;
@@ -1605,15 +1610,17 @@ export default function SessionScreen() {
   const composerFloatingVoiceButtonStyle = composerShowInlineStop && composerShowSendButton
     ? styles.composerFloatingVoiceButtonWithInlineStop
     : undefined;
-  const composerVoicePlacement = resolveMobileComposerVoiceButtonPlacement({
-    // 行尾有发送或占发送位的停止按钮时让位;附件-only(无文字)同样命中。
-    hasTrailingAction: composerSendSlotIsStop || composerShowSendButton,
-  });
+  const composerVoicePlacement = voiceUiAvailable
+    ? resolveMobileComposerVoiceButtonPlacement({
+      // 行尾有发送或占发送位的停止按钮时让位;附件-only(无文字)同样命中。
+      hasTrailingAction: composerSendSlotIsStop || composerShowSendButton,
+    })
+    : undefined;
   const composerEffectiveContentHeight = composerInputContentHeight;
   const voiceDraftShowsListeningPrompt = voiceIsListening && draft.length === 0;
   // 状态行只承载错误信息;「正在听 / 转写中」不再占一行,对齐桌面版——
   // 录音状态由输入框内的语音按钮形态(Mic / Square / spinner)表达。
-  const voiceStatusVisible = Boolean(voiceError);
+  const voiceStatusVisible = voiceUiAvailable && Boolean(voiceError);
   const nativeShellLayout = useMemo(() => buildSessionNativeShellLayout({
     attachmentPickerOpen: false,
     keyboardHeight: keyboardState.height,
@@ -1809,7 +1816,7 @@ export default function SessionScreen() {
         />
       ) : null}
       <ComposerToolbarSpacer />
-      {composerVoicePlacement.inline || composerVoicePlacement.floating
+      {composerVoicePlacement?.inline || composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot />
         : null}
       {renderComposerTrailingActions()}
@@ -7000,7 +7007,7 @@ export default function SessionScreen() {
                     caretHidden={voiceIsListening}
                     compact={compactComposer && !composerCardActive}
                     editable={!composerLayout.input.disabled}
-                    floatingVoiceButton={renderComposerVoiceButton}
+                    floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}
                     floatingVoiceButtonStyle={composerFloatingVoiceButtonStyle}
                     cursorColor={colors.inputCaret}
                     inputFrameHeight={composerResize.frameHeight}

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -194,7 +194,11 @@ import {
   resolveComposerVoiceHoldActive,
   shouldArmComposerVoiceHold,
 } from '@/session/composerVoiceHold';
-import { isMobileRealtimeAudioAvailable, prewarmMobileRealtimeAudio } from '@/session/mobileRealtimeAudio';
+import {
+  isMobileRealtimeAudioAvailable,
+  prewarmMobileRealtimeAudio,
+  shouldShowMobileVoiceUi,
+} from '@/session/mobileRealtimeAudio';
 import {
   discardPendingPrewarm,
   prewarmMobileVoiceStart,
@@ -734,6 +738,7 @@ export default function NewRemoteSessionScreen() {
   );
   const composerHasMessage = draft.firstMessage.trim().length > 0;
   const composerShowCreateButton = composerHasMessage || attachments.length > 0 || pendingUploads.length > 0;
+  const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);
   const voiceIsListening = voiceState === 'listening';
   const voiceIsProcessing = voiceState === 'submitting' || voiceState === 'refining';
   // 只有一台可选设备时无可切换项:禁用下拉、隐藏 ⇕(用户反馈:单选项不要出选框)。
@@ -747,11 +752,13 @@ export default function NewRemoteSessionScreen() {
   const canOpenVoiceSettings = isMobileVoiceMicPermissionError(voiceError);
   // 状态行只承载错误信息;「正在听 / 转写中」不再占一行,对齐桌面版——
   // 录音状态由输入框内的语音按钮形态(Mic / Square / spinner)表达。
-  const voiceStatusVisible = Boolean(voiceError);
-  const composerVoicePlacement = resolveMobileComposerVoiceButtonPlacement({
-    // 行尾有创建按钮时让位;附件-only(无文字)同样命中(composerShowCreateButton 含附件判定)。
-    hasTrailingAction: composerShowCreateButton,
-  });
+  const voiceStatusVisible = voiceUiAvailable && Boolean(voiceError);
+  const composerVoicePlacement = voiceUiAvailable
+    ? resolveMobileComposerVoiceButtonPlacement({
+      // 行尾有创建按钮时让位;附件-only(无文字)同样命中(composerShowCreateButton 含附件判定)。
+      hasTrailingAction: composerShowCreateButton,
+    })
+    : undefined;
   const composerInputContentHeight = firstMessageInputContentHeight;
   const keyboardState = useMobileKeyboardState();
   const windowDimensions = useWindowDimensions();
@@ -1692,7 +1699,7 @@ export default function NewRemoteSessionScreen() {
         <ChevronDown color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
       </Pressable>
       <ComposerToolbarSpacer />
-      {composerVoicePlacement.inline || composerVoicePlacement.floating
+      {composerVoicePlacement?.inline || composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot />
         : null}
       {composerShowCreateButton ? renderCreateButton() : null}
@@ -2729,7 +2736,7 @@ export default function NewRemoteSessionScreen() {
                   trailing={composerCardActive || !composerShowCreateButton ? null : renderCreateButton()}
                   value={draft.firstMessage}
                   voicePlacement={composerVoicePlacement}
-                  floatingVoiceButton={renderComposerVoiceButton}
+                  floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}
                 />
               </View>
             </View>

--- a/apps/mobile/src/__tests__/chatQuoteCrossDevice.test.ts
+++ b/apps/mobile/src/__tests__/chatQuoteCrossDevice.test.ts
@@ -19,7 +19,10 @@ describe('mobile cross-device quote wiring', () => {
   });
 
   it('propagates quote metadata through direct and attachment-outbox sends', () => {
-    const source = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8');
+    const source = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8').replace(
+      /\r\n/g,
+      '\n',
+    );
 
     expect(source).toContain('quotesEncoded: quotesEncodedAtSend');
     expect(source).toContain('pastedTextRanges: pastedTextRangesAtSend');

--- a/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
+++ b/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
@@ -42,6 +42,13 @@ describe('mobileRealtimeAudio', () => {
       .rejects.toThrow('realtime microphone PCM capture');
   });
 
+  it('hides voice UI on Android without changing the supported iOS surface', async () => {
+    const { shouldShowMobileVoiceUi } = await import('@/session/mobileRealtimeAudio');
+
+    expect(shouldShowMobileVoiceUi('android')).toBe(false);
+    expect(shouldShowMobileVoiceUi('ios')).toBe(true);
+  });
+
   it('keeps the iOS native realtime recorder wired for interruption cleanup', () => {
     const source = readFileSync(
       resolve(process.cwd(), 'modules/xdt-mobile-realtime-audio/ios/XdtMobileRealtimeAudioModule.swift'),

--- a/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
+++ b/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('expo-modules-core', () => ({
   EventEmitter: class {
@@ -18,6 +18,10 @@ vi.mock('expo-modules-core', () => ({
     throw new Error('native module not linked');
   }),
 }));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('mobileRealtimeAudio', () => {
   it('decodes native PCM base64 payloads into ArrayBuffer chunks', async () => {
@@ -42,11 +46,19 @@ describe('mobileRealtimeAudio', () => {
       .rejects.toThrow('realtime microphone PCM capture');
   });
 
-  it('hides voice UI on Android without changing the supported iOS surface', async () => {
+  it('hides voice UI on Android without changing existing non-Android surfaces', async () => {
     const { shouldShowMobileVoiceUi } = await import('@/session/mobileRealtimeAudio');
 
     expect(shouldShowMobileVoiceUi('android')).toBe(false);
     expect(shouldShowMobileVoiceUi('ios')).toBe(true);
+    expect(shouldShowMobileVoiceUi('web')).toBe(true);
+  });
+
+  it('keeps the Android voice entry available to explicit E2E mock runs', async () => {
+    vi.stubEnv('EXPO_PUBLIC_XDT_MOBILE_E2E_MOCK_AUDIO', '1');
+    const { shouldShowMobileVoiceUi } = await import('@/session/mobileRealtimeAudio');
+
+    expect(shouldShowMobileVoiceUi('android')).toBe(true);
   });
 
   it('keeps the iOS native realtime recorder wired for interruption cleanup', () => {

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -802,7 +802,7 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('cardActive={composerCardActive}');
     expect(newComposerSource).toContain('toolbar={renderComposerToolbar()}');
     expect(newComposerSource).toContain('voicePlacement={composerVoicePlacement}');
-    expect(newComposerSource).toContain('floatingVoiceButton={renderComposerVoiceButton}');
+    expect(newComposerSource).toContain('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
     expect(newComposerSource).toContain('cursorColor={colors.inputCaret}');
     expect(newComposerSource).toContain('selectionColor={colors.inputCaret}');
     expect(newComposerSource).toContain('inputRef={firstMessageInputRef}');
@@ -939,9 +939,11 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('connectionProvider: (providerId: string) => voiceContext.createAsrConnection(providerId),');
     expect(newSource).toContain('voiceContext.createRefinerTarget(providerId, options),');
     expect(newSource).toContain('voiceContext.warmRefiner(input),');
-    expect(newSource).toContain('const composerVoicePlacement = resolveMobileComposerVoiceButtonPlacement({');
+    expect(newSource).toContain('const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);');
+    expect(newSource).toContain('const composerVoicePlacement = voiceUiAvailable');
     expect(newSource).toContain('hasTrailingAction: composerShowCreateButton');
-    expect(newSource).toContain('const voiceStatusVisible = Boolean(voiceError);');
+    expect(newSource).toContain('const voiceStatusVisible = voiceUiAvailable && Boolean(voiceError);');
+    expect(newSource).toContain('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
     expect(sessionSource).toContain('voicePlacement={composerVoicePlacement}');
     expect(sharedSource).toContain('export const MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES = 12;');
     expect(sharedSource).toContain('export const MOBILE_COMPOSER_CONTROL_SIZE = 34;');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -29,7 +29,7 @@ describe('mobile session composer desktop-first surface', () => {
     const voiceButtonStart = source.indexOf('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
     const voiceButtonEnd = source.indexOf('const removeRemoteFileAttachment = useCallback', voiceButtonStart);
     const voiceButtonSource = source.slice(voiceButtonStart, voiceButtonEnd);
-    const floatingVoiceIndex = composerInputSource.indexOf('floatingVoiceButton={renderComposerVoiceButton}');
+    const floatingVoiceIndex = composerInputSource.indexOf('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
     const floatingVoiceStyleIndex = composerInputSource.indexOf('floatingVoiceButtonStyle={composerFloatingVoiceButtonStyle}');
     const sendIndex = composerInputSource.indexOf('trailing={composerCardActive ? null : renderComposerTrailingActions()}');
     const composerSurfaceStart = source.indexOf('composerSurface: {');
@@ -294,11 +294,12 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('const canStopComposer = canStopQueue || canStopCurrentRun;');
     expect(source).toContain('canStop: canUseComposer && canStopComposer,');
     expect(source).not.toContain('canStop: canUseComposer && canStopQueue,');
-    expect(source).toContain('const composerVoicePlacement = resolveMobileComposerVoiceButtonPlacement({');
+    expect(source).toContain('const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);');
+    expect(source).toContain('const composerVoicePlacement = voiceUiAvailable');
     expect(source).toContain('hasTrailingAction: composerSendSlotIsStop || composerShowSendButton');
     expect(source).toContain('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
     // 录音状态由语音按钮形态表达（Mic / Square / spinner），状态行只承载错误。
-    expect(source).toContain('const voiceStatusVisible = Boolean(voiceError);');
+    expect(source).toContain('const voiceStatusVisible = voiceUiAvailable && Boolean(voiceError);');
     expect(voiceButtonSource).toContain(') : voiceIsListening ? (');
     expect(voiceButtonSource).toContain('<Square');
     expect(voiceStatusIndex).toBeGreaterThan(-1);
@@ -396,7 +397,7 @@ describe('mobile session composer desktop-first surface', () => {
       finishVoiceSource.indexOf('const latestDraft = await controller.stop();'),
     );
     expect(finishVoiceSource).toContain('voiceStopInFlightRef.current = false;');
-    expect(composerInputSource).toContain('floatingVoiceButton={renderComposerVoiceButton}');
+    expect(composerInputSource).toContain('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
     expect(composerInputSource).toContain('floatingVoiceButtonStyle={composerFloatingVoiceButtonStyle}');
     expect(composerInputSource).toContain('voicePlacement={composerVoicePlacement}');
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');

--- a/apps/mobile/src/session/mobileRealtimeAudio.ts
+++ b/apps/mobile/src/session/mobileRealtimeAudio.ts
@@ -66,6 +66,7 @@ export function isMobileRealtimeAudioAvailable(): boolean {
 export function shouldShowMobileVoiceUi(
   platform: string,
 ): boolean {
+  if (isE2eMockRealtimeAudioEnabled()) return true;
   return platform !== 'android';
 }
 

--- a/apps/mobile/src/session/mobileRealtimeAudio.ts
+++ b/apps/mobile/src/session/mobileRealtimeAudio.ts
@@ -57,6 +57,18 @@ export function isMobileRealtimeAudioAvailable(): boolean {
   return getNativeBinding() !== null;
 }
 
+/**
+ * Keeps unfinished platform implementations out of the product surface. This
+ * is intentionally a UI-only gate; the native permission and runtime fallback
+ * stay unchanged so Android can be re-enabled without a native configuration
+ * migration.
+ */
+export function shouldShowMobileVoiceUi(
+  platform: string,
+): boolean {
+  return platform !== 'android';
+}
+
 export async function startMobileRealtimeAudio(
   options: {
     onChunk: (chunk: MobileRealtimeAudioChunk) => void;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android 端实时语音能力尚未完整可用，但新建会话和已有会话仍展示语音入口。此 PR 增加纯 UI 平台开关，在 Android 上不挂载语音按钮、工具栏占位、语音错误状态和麦克风权限设置入口；iOS 与底层语音实现保持不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#261
- 本 PR 包含：Android 新建会话、已有会话及语音错误设置入口的 UI 隐藏；平台开关与回归测试。
- 明确不包含：原生权限、`app.json`、runtime fingerprint、语音底层能力或 iOS 行为调整。
- 用户可见变化：Android 聊天输入区不再显示语音按钮，也不会出现语音错误与麦克风权限设置入口。
- 是否存在 breaking change：无。

### UI 变化

Android 新建会话与已有会话的 composer 不再显示语音入口；Light / Dark 共用同一渲染 gate，未修改样式或主题 token。未附截图：本地未启动 Android 模拟器，自动化测试覆盖入口挂载条件。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/mobileRealtimeAudio.test.ts src/__tests__/newSession.test.ts src/__tests__/sessionComposerDesktopFirst.test.ts
结果：3 个测试文件、51 条测试全部通过

pnpm --filter mobile exec vitest run src/__tests__/chatQuoteCrossDevice.test.ts
结果：1 个测试文件、4 条测试全部通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过
```

### 手工验证

未执行 Android 模拟器手工验证；本次仅修改平台渲染条件，无样式、原生配置或权限变化。

### 未执行的验证

- 未启动 Metro / Android 模拟器，因此没有 branch/worktree、Metro 归属或 `__DEV__` build label 证据。
- 未做 iOS 真机验证；iOS 分支由平台 gate 单测锁定为继续显示，原有语音实现未改。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Android 的语音相关 UI 挂载；iOS、底层录音与原生权限配置不变。
- 回滚 / 降级方式：移除 `shouldShowMobileVoiceUi` 平台 gate 及两处 composer 条件即可恢复 Android 入口。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因