### PR TITLE
fix(device-link): 修复远程会话底部 $ 消耗/价值不显示

### DIFF
--- a/apps/desktop/src/main/sessionSpendBroadcaster.ts
+++ b/apps/desktop/src/main/sessionSpendBroadcaster.ts
@@ -24,6 +24,7 @@ import { sql } from 'drizzle-orm';
 import { sessions } from './localDb/schema';
 import { getDbClient } from './localDb/client/current';
 import { createLogger } from './logger';
+import { tapWindowBroadcast } from './device-link/broadcast-tap.js';
 
 const log = createLogger('sessionSpendBroadcaster');
 
@@ -90,6 +91,9 @@ export async function recordSessionTurnSpend(sessionId: string, costUsdDelta: nu
 }
 
 function broadcast(payload: SessionSpendPayload): void {
+  // device-link 旁路:控制端打开的远程会话按 session:<id> topic 收到累计 cost 镜像
+  // (本模块走裸 UPDATE、不发 sessions:patched,没有这条 tap 控制端的 $ 永远不更新)。
+  tapWindowBroadcast(USAGE_SESSION_SPEND_CHANGED, payload);
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed()) {
       win.webContents.send(USAGE_SESSION_SPEND_CHANGED, payload);
@@ -122,6 +126,7 @@ export async function recordSessionTurnTokens(sessionId: string, tokenDelta: num
 }
 
 function broadcastTokens(payload: SessionTokensPayload): void {
+  tapWindowBroadcast(USAGE_SESSION_TOKENS_CHANGED, payload);
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed()) {
       win.webContents.send(USAGE_SESSION_TOKENS_CHANGED, payload);

--- a/apps/desktop/src/main/sessionSpendBroadcaster.ts
+++ b/apps/desktop/src/main/sessionSpendBroadcaster.ts
@@ -91,8 +91,9 @@ export async function recordSessionTurnSpend(sessionId: string, costUsdDelta: nu
 }
 
 function broadcast(payload: SessionSpendPayload): void {
-  // device-link 旁路:控制端打开的远程会话按 session:<id> topic 收到累计 cost 镜像
-  // (本模块走裸 UPDATE、不发 sessions:patched,没有这条 tap 控制端的 $ 永远不更新)。
+  // device-link 旁路:控制端经 sessions topic(列表订阅常开,会话未打开也不丢)收到
+  // 累计 cost 镜像(本模块走裸 UPDATE、不发 sessions:patched,没有这条 tap 控制端的
+  // $ 永远不更新)。
   tapWindowBroadcast(USAGE_SESSION_SPEND_CHANGED, payload);
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed()) {

--- a/apps/desktop/src/renderer/__tests__/deviceLinkControllerScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkControllerScenarios.test.ts
@@ -128,6 +128,16 @@ function makeFakeHost(deviceId: string, deviceName: string) {
       sessionsMeta.set(sid, { ...(sessionsMeta.get(sid) ?? {}), ...patch });
       pushCb?.({ deviceId, channel: 'local-db:sessions:patched', payload: { sessionId: sid, patch } });
     },
+    /** 被控端 turn 结束落库累计 cost → usage:session-spend-changed(sessionSpendBroadcaster tap)。 */
+    hostSessionSpend(sid: string, totalCostUsd: number): void {
+      sessionsMeta.set(sid, { ...(sessionsMeta.get(sid) ?? {}), totalCostUsd });
+      pushCb?.({ deviceId, channel: 'usage:session-spend-changed', payload: { sessionId: sid, totalCostUsd } });
+    },
+    /** 被控端 turn 结束落库累计 token → usage:session-tokens-changed。 */
+    hostSessionTokens(sid: string, totalTokens: number): void {
+      sessionsMeta.set(sid, { ...(sessionsMeta.get(sid) ?? {}), totalTokenUsage: totalTokens });
+      pushCb?.({ deviceId, channel: 'usage:session-tokens-changed', payload: { sessionId: sid, totalTokens } });
+    },
   };
 }
 
@@ -215,6 +225,21 @@ describe('device-link controller mirror — end-to-end scenarios', () => {
     await flush();
     const mirrored = remoteProjectsStore.getMergedRemoteSessions().find((x) => x.id === s);
     expect(mirrored?.model).toBe('claude-opus-4-8');
+  });
+
+  it('被控端累计 cost / token 推送 → 控制端远程会话行镜像(底部 $ chip 数据源)', async () => {
+    const s = sid();
+    host.seedSession(s, {});
+    remoteProjectsStore.setDeviceSessions(DEVICE_ID, 'Mac A', [{ id: s } as Session]);
+
+    // 被控端 sessionSpendBroadcaster 落库后 tap 转发(裸 UPDATE 不发 sessions:patched,
+    // 控制端只有这条通道能看到累计值增长)。
+    host.hostSessionSpend(s, 1.23);
+    host.hostSessionTokens(s, 45_000);
+    await flush();
+    const mirrored = remoteProjectsStore.getMergedRemoteSessions().find((x) => x.id === s);
+    expect(mirrored?.totalCostUsd).toBe(1.23);
+    expect(mirrored?.totalTokenUsage).toBe(45_000);
   });
 
   it('丢帧后 reconcile 是合并而非替换:本机已有的不被清、in-flight 顺序不乱', async () => {

--- a/apps/desktop/src/renderer/__tests__/makerTransportRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerTransportRouting.test.ts
@@ -37,15 +37,18 @@ function stubElectron() {
     endTeam: vi.fn(),
     getCollaborationSettings: vi.fn(),
   };
+  const localMessages = {
+    estimatedSessionValue: vi.fn().mockResolvedValue({ totalValueUsd: 0, entries: [] }),
+  };
   const invoke = vi.fn().mockResolvedValue(undefined);
   vi.stubGlobal('window', {
     electronAPI: {
       maker: makerSpies,
-      localDb: { orcaWorkflows },
+      localDb: { orcaWorkflows, messages: localMessages },
       deviceLink: { invoke },
     },
   });
-  return { makerSpies, orcaWorkflows, invoke };
+  return { makerSpies, orcaWorkflows, localMessages, invoke };
 }
 
 const sess = (id: string): Session => ({ id }) as unknown as Session;
@@ -175,6 +178,27 @@ describe('makerApiFor 路由(完整对等会话级操作)', () => {
     invoke.mockClear();
     // 未注册 → 本机会话:直接 false,不经隧道(看门狗对本机会话整体不生效)
     await expect(isSessionTurnRunningFor('local-sess')).resolves.toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('estimatedSessionValueFor:远程经隧道查被控端汇总;本机查本地库(不经隧道)', async () => {
+    const { localMessages, invoke } = stubElectron();
+    invoke.mockResolvedValue({ totalValueUsd: 1.5, entries: [{ clientId: 'a', costUsd: 1.5 }] });
+    const { estimatedSessionValueFor } = await import('@/lib/makerTransport');
+    const { remoteProjectsStore } = await import('@/features/device-link/remoteProjectsStore');
+    remoteProjectsStore.setDeviceSessions('dev-1', 'Mac', [sess('rs')]);
+
+    // 远程会话:查本机是空库恒 0,必须隧道到被控端
+    await expect(estimatedSessionValueFor('rs')).resolves.toEqual({
+      totalValueUsd: 1.5,
+      entries: [{ clientId: 'a', costUsd: 1.5 }],
+    });
+    expect(invoke).toHaveBeenCalledWith('dev-1', 'local-db:messages:estimatedSessionValue', ['rs']);
+    expect(localMessages.estimatedSessionValue).not.toHaveBeenCalled();
+
+    invoke.mockClear();
+    await estimatedSessionValueFor('local-sess');
+    expect(localMessages.estimatedSessionValue).toHaveBeenCalledWith('local-sess');
     expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -73,6 +73,25 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).not.toContain("codexAuthState.authSource === 'oauth'");
   });
 
+  it('renders device-link remote sessions data-driven without local-account classification', () => {
+    // device-link 远程会话:计费形态事实在被控端,本机 route 观察 / 账号状态一律不用。
+    expect(source).toContain('const isDeviceLinkRemote = Boolean(deviceLinkDeviceId);');
+    // 本机 Codex runtime route 观察对 device-link 关闭(否则按控制端账号形态张冠李戴)
+    expect(source).toContain("enabled: vendorKey === 'codex' && !isDeviceLinkRemote,");
+    // Claude 默认路由观察(proxy 观察值 / OAuth / 网关 key 启发式)对 device-link 关闭
+    expect(source).toContain(
+      "vendorKey === 'cc' && !isRemoteClaudeSession && !isDeviceLinkRemote && providerId == null",
+    );
+    // 订阅形态分类整体排除 device-link(专属分支接管渲染)
+    expect(source).toContain(
+      "const isClaudeSubscription = vendorKey === 'cc' && !isRemoteClaudeSession && !isDeviceLinkRemote && (",
+    );
+    // 渲染走专属分支:估算价值 / 累计 cost 有哪个显哪个,不显示本机限额窗口
+    expect(source).toContain('if (isDeviceLinkRemote) {');
+    // 看板链接对 device-link 落 null(额度属于被控端账号,本机浏览器打开的是控制端账号)
+    expect(source).toMatch(/usageDashboardUrl: string \| null = isDeviceLinkRemote\s*\?\s*null/);
+  });
+
   it('does not classify remote Codex sessions from the local runtime route', () => {
     expect(source).toContain('remoteHostId?: string | null');
     expect(source).toContain("const isRemoteCodexSession = vendorKey === 'codex' && Boolean(remoteHostId);");
@@ -97,9 +116,10 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain("session: { label: t('todaySpend.sessionCostLabel', { cost: '$—' })");
     expect(source).toContain("(vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi ? sessionId : undefined");
     expect(source).toContain("(vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi ? sessionInitialCostUsd : null");
-    // 订阅"本会话价值"估算: Codex OAuth / Claude 订阅 / bridge 订阅共用同一管道
+    // 订阅"本会话价值"估算: Codex OAuth / Claude 订阅 / bridge 订阅共用同一管道;
+    // device-link 远程会话形态未知(被控端账号事实拿不到)→ 无条件启用
     expect(source).toMatch(
-      /useSessionEstimatedValue\(\s*sessionId,\s*isCodexSubscription \|\| isClaudeSubscription \|\| isSubscriptionBridge,?\s*\)/,
+      /useSessionEstimatedValue\(\s*sessionId,\s*isCodexSubscription \|\| isClaudeSubscription \|\| isSubscriptionBridge \|\| isDeviceLinkRemote,?\s*\)/,
     );
     expect(source).toContain('function getCodexChipWindows(');
     expect(source).toContain("'todaySpend.codex.windowSegment'");
@@ -125,7 +145,7 @@ describe('TodaySpendChip dashboard routing', () => {
 
   it('uses token and explicit empty-state fallbacks for Codex API sessions', () => {
     expect(source).toContain(
-      'isCodexApi || isCodexSubscription || isSubscriptionBridge ? sessionId : undefined',
+      'isCodexApi || isCodexSubscription || isSubscriptionBridge || isDeviceLinkRemote',
     );
     expect(source).toContain('function hasPositiveSessionTokens(sessionTokens: number | null)');
     expect(source).toContain('const codexApiHasTokenFallback = isCodexApi');

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -114,8 +114,13 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain("t('todaySpend.sessionCostLabel', { cost: `$${sessionCostUsd.toFixed(2)}` })");
     expect(source).toContain("tooltipLabel: t('todaySpend.tooltip.sessionUsed'");
     expect(source).toContain("session: { label: t('todaySpend.sessionCostLabel', { cost: '$—' })");
-    expect(source).toContain("(vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi ? sessionId : undefined");
-    expect(source).toContain("(vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi ? sessionInitialCostUsd : null");
+    // spend hook 对 device-link 远程会话无条件启用(形态未知,累计 cost 镜像不可丢)
+    expect(source).toMatch(
+      /\(vendorKey === 'cc' && !isSubscriptionBridge\) \|\| isCodexApi \|\| isDeviceLinkRemote\s*\?\s*sessionId\s*:\s*undefined/,
+    );
+    expect(source).toMatch(
+      /\(vendorKey === 'cc' && !isSubscriptionBridge\) \|\| isCodexApi \|\| isDeviceLinkRemote\s*\?\s*sessionInitialCostUsd\s*:\s*null/,
+    );
     // 订阅"本会话价值"估算: Codex OAuth / Claude 订阅 / bridge 订阅共用同一管道;
     // device-link 远程会话形态未知(被控端账号事实拿不到)→ 无条件启用
     expect(source).toMatch(

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1002,9 +1002,15 @@ export function TodaySpendChip({
   // 配额与之无关。
   const shouldReadLocalCodexAccountUsage = usesCodexQuotaForm && !isAnyRemoteSession;
   // 订阅直连 bridge 轮真实计费恒 0(不写 sessions.total_cost_usd),spend hook 无意义 → 关。
+  // device-link 远程会话形态未知 → 无条件启用(与 tokens / 估算价值同口径),否则被控端
+  // 若是本机判不出的形态(如 codex+xai)累计 cost 镜像永远不展示。
   const sessionCostUsd = useSessionSpend(
-    (vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi ? sessionId : undefined,
-    (vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi ? sessionInitialCostUsd : null,
+    (vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi || isDeviceLinkRemote
+      ? sessionId
+      : undefined,
+    (vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi || isDeviceLinkRemote
+      ? sessionInitialCostUsd
+      : null,
   );
   const sessionTokens = useSessionTokens(
     isCodexApi || isCodexSubscription || isSubscriptionBridge || isDeviceLinkRemote

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -925,8 +925,11 @@ export function TodaySpendChip({
   deviceLinkDeviceId,
 }: TodaySpendChipProps) {
   const { t } = useTranslation();
+  // device-link 远程会话:turn 跑在被控端、消耗被控端账号,计费形态(订阅/网关)与账号
+  // 余量的事实都在被控端 —— 本机的 route 观察 / 账号快照与之无关,一律不读、不据此分类。
+  const isDeviceLinkRemote = Boolean(deviceLinkDeviceId);
   const { authInjection: codexAuthInjection } = useCodexRuntimeRoute({
-    enabled: vendorKey === 'codex',
+    enabled: vendorKey === 'codex' && !isDeviceLinkRemote,
     refreshKey: sessionId,
   });
   // cc 订阅判定对齐 main 的 isClaudeSubscriptionSession(register.ts)+ proxy 实际路由:
@@ -946,14 +949,16 @@ export function TodaySpendChip({
   // 远端 Claude 会话恒走网关(runtime-configs 的 remoteEndpoint),本机订阅快照与实际
   // 服务账号无关 —— 排除出订阅形态,回落 gateway quota 展示(与 Codex 远端口径一致)。
   const isRemoteClaudeSession = vendorKey === 'cc' && Boolean(remoteHostId);
+  // device-link 远程会话不参与默认路由观察:本机 proxy 永远看不到被控端会话的请求,
+  // 用本机 OAuth / 网关 key 状态推断只会张冠李戴(形态由下方 device-link 专属分支接管)。
   const isDefaultRouteClaudeSession =
-    vendorKey === 'cc' && !isRemoteClaudeSession && providerId == null;
+    vendorKey === 'cc' && !isRemoteClaudeSession && !isDeviceLinkRemote && providerId == null;
   const { hasSavedKey: hasGatewayKey, isReconciling: gatewayKeyReconciling } = useApiKey();
   const claudeOAuthConnected = useClaudeOAuthConnected(isDefaultRouteClaudeSession);
   const observedClaudeRoute = useClaudeSessionRoute(sessionId, isDefaultRouteClaudeSession);
   const ccBillingFormPending = isDefaultRouteClaudeSession && observedClaudeRoute == null
     && (gatewayKeyReconciling || (!hasGatewayKey && claudeOAuthConnected == null));
-  const isClaudeSubscription = vendorKey === 'cc' && !isRemoteClaudeSession && (
+  const isClaudeSubscription = vendorKey === 'cc' && !isRemoteClaudeSession && !isDeviceLinkRemote && (
     providerId === 'anthropic'
     || (providerId == null && (
       observedClaudeRoute != null
@@ -991,10 +996,10 @@ export function TodaySpendChip({
   // 远程会话不读本机账户快照 —— 额度事实在远端:SSH 用 remoteHostId 判,device-link 用
   // deviceLinkDeviceId 判(两者互斥,任一非空即远程,turn 消耗的是远端账号的额度)。
   const isAnyRemoteSession = Boolean(remoteHostId) || Boolean(deviceLinkDeviceId);
-  // Claude 网关/订阅配额的本地读取只对 device-link 加门:SSH 远程 cc 维持既有口径
-  // (isRemoteClaudeSession 已排除订阅形态、回落 gateway quota 展示);device-link 的 turn
-  // 与凭证都在被控端,控制端本机的 LiteLLM / Claude.ai 配额与之无关。
-  const isDeviceLinkRemote = Boolean(deviceLinkDeviceId);
+  // Claude 网关/订阅配额的本地读取只对 device-link 加门(isDeviceLinkRemote,声明在组件
+  // 顶部):SSH 远程 cc 维持既有口径(isRemoteClaudeSession 已排除订阅形态、回落 gateway
+  // quota 展示);device-link 的 turn 与凭证都在被控端,控制端本机的 LiteLLM / Claude.ai
+  // 配额与之无关。
   const shouldReadLocalCodexAccountUsage = usesCodexQuotaForm && !isAnyRemoteSession;
   // 订阅直连 bridge 轮真实计费恒 0(不写 sessions.total_cost_usd),spend hook 无意义 → 关。
   const sessionCostUsd = useSessionSpend(
@@ -1002,13 +1007,16 @@ export function TodaySpendChip({
     (vendorKey === 'cc' && !isSubscriptionBridge) || isCodexApi ? sessionInitialCostUsd : null,
   );
   const sessionTokens = useSessionTokens(
-    isCodexApi || isCodexSubscription || isSubscriptionBridge ? sessionId : undefined,
+    isCodexApi || isCodexSubscription || isSubscriptionBridge || isDeviceLinkRemote
+      ? sessionId
+      : undefined,
     sessionInitialTokens,
   );
   // 订阅会话的"本会话价值"估算 (isEstimate 消息汇总): Codex OAuth / Claude 订阅 / bridge 订阅同管道。
+  // device-link 远程会话形态未知(被控端账号事实拿不到)→ 无条件启用,有估算数据就显示。
   const sessionEstimatedValueUsd = useSessionEstimatedValue(
     sessionId,
-    isCodexSubscription || isClaudeSubscription || isSubscriptionBridge,
+    isCodexSubscription || isClaudeSubscription || isSubscriptionBridge || isDeviceLinkRemote,
   );
   // 按会话形态选配额槽: chatgpt/ bridge 消耗 WHAM(openai-web)报告的配额,
   // Codex CLI 会话消耗 app-server 报告的配额 —— 不跨槽回退, 绝不显示不是这个
@@ -1035,22 +1043,27 @@ export function TodaySpendChip({
   const latestTurnUsage = useLatestTurnUsageSummary(sessionId);
   // codex-oauth / cc+chatgpt bridge → ChatGPT 用量看板; cc+xai bridge → xAI 账户页;
   // cc Claude 订阅 → claude.ai 用量页; 其余(cc 网关 / codex-api)→ 暂无看板(null,见文件头 TODO)。
-  const usageDashboardUrl: string | null = usesXaiQuotaForm
-    ? XAI_ACCOUNT_URL
-    : isCodexOauth || isChatgptBridge
-      ? CODEX_USAGE_DASHBOARD_URL
-      : isClaudeSubscription
-        ? CLAUDE_USAGE_DASHBOARD_URL
-        : null;
+  // device-link 远程会话额度属于被控端账号,本机浏览器打开的看板是控制端自己的账号 → 不跳。
+  const usageDashboardUrl: string | null = isDeviceLinkRemote
+    ? null
+    : usesXaiQuotaForm
+      ? XAI_ACCOUNT_URL
+      : isCodexOauth || isChatgptBridge
+        ? CODEX_USAGE_DASHBOARD_URL
+        : isClaudeSubscription
+          ? CLAUDE_USAGE_DASHBOARD_URL
+          : null;
   // 看板链接行文案:与 usageDashboardUrl 一一对应;网关账号无看板 → null
   // (tooltip 不显示"打开看板"行,chip 也不可点)。
-  const usageDashboardLabel: string | null = usesXaiQuotaForm
-    ? t('todaySpend.openXaiUsage')
-    : isCodexOauth || isChatgptBridge
-      ? t('todaySpend.openCodexUsage')
-      : isClaudeSubscription
-        ? t('todaySpend.openClaudeUsage')
-        : null;
+  const usageDashboardLabel: string | null = isDeviceLinkRemote
+    ? null
+    : usesXaiQuotaForm
+      ? t('todaySpend.openXaiUsage')
+      : isCodexOauth || isChatgptBridge
+        ? t('todaySpend.openCodexUsage')
+        : isClaudeSubscription
+          ? t('todaySpend.openClaudeUsage')
+          : null;
   const [windowLabelNowMs, setWindowLabelNowMs] = React.useState(() => Date.now());
 
   // 当前形态下 chip 展示的限额窗口段 (Codex 订阅 / Claude 订阅共用结构);
@@ -1176,7 +1189,31 @@ export function TodaySpendChip({
 
   let labelNode: React.ReactNode;
   let tooltipNode: React.ReactNode = usageDashboardLabel;
-  if (usesCodexQuotaForm) {
+  if (isDeviceLinkRemote) {
+    // device-link 远程会话:不做订阅/网关形态分类(计费事实在被控端,本机账号状态无关),
+    // 数据驱动展示镜像值 —— 订阅估算价值(estimatedSessionValueFor 隧道汇总 + 转发的
+    // turn-cost 推送)与真实累计 cost(usage:session-spend-changed 镜像)有哪个显哪个;
+    // 被控端账号的限额窗口本机拿不到,不显示、不猜。
+    const chipSegments: string[] = [];
+    if (typeof sessionEstimatedValueUsd === 'number' && sessionEstimatedValueUsd > 0) {
+      chipSegments.push(t('todaySpend.codex.sessionValueLabel', {
+        cost: `$${sessionEstimatedValueUsd.toFixed(2)}`,
+      }));
+    }
+    if (typeof sessionCostUsd === 'number' && sessionCostUsd > 0) {
+      chipSegments.push(t('todaySpend.sessionCostLabel', { cost: `$${sessionCostUsd.toFixed(2)}` }));
+    }
+    labelNode = chipSegments.length > 0
+      ? renderSegmentedLabel(chipSegments)
+      : <span className="tabular-nums opacity-60">$</span>;
+    const tooltipLines: string[] = [];
+    pushSessionValueLines(tooltipLines, sessionEstimatedValueUsd, sessionTokens, t);
+    if (typeof sessionCostUsd === 'number' && sessionCostUsd > 0) {
+      tooltipLines.push(t('todaySpend.tooltip.sessionUsed', { cost: `$${sessionCostUsd.toFixed(2)}` }));
+    }
+    appendLatestTurnUsageLines(tooltipLines, latestTurnUsage, t);
+    tooltipNode = tooltipLines.length > 0 ? buildTooltipNode(tooltipLines) : null;
+  } else if (usesCodexQuotaForm) {
     // codex-oauth 与 cc+chatgpt/ bridge 共用同一 ChatGPT 账户,复用同一套限额窗口 + 价值估算渲染。
     const chipSegments = [...windowSegments];
     if (typeof sessionEstimatedValueUsd === 'number' && sessionEstimatedValueUsd > 0) {

--- a/apps/desktop/src/renderer/hooks/__tests__/useCCAgentChatHiddenFreeze.test.tsx
+++ b/apps/desktop/src/renderer/hooks/__tests__/useCCAgentChatHiddenFreeze.test.tsx
@@ -60,6 +60,10 @@ vi.mock('@/lib/makerTransport', () => ({
   aroundMessagesByClientIdFor: vi.fn(async () => []),
   dismissErrorMessageFor: vi.fn(async () => undefined),
   isRemoteSession: vi.fn(() => false),
+  // useSessionEstimatedValue 的历史初值入口:本套测试全部按本机会话走,直接委托给
+  // 下方 messageService mock(既有用例继续用它驱动/断言调用次数)。
+  estimatedSessionValueFor: vi.fn(async (sessionId: string) =>
+    (await import('@/lib/messageService')).estimatedSessionValue(sessionId)),
 }));
 
 vi.mock('@/lib/messageService', () => ({

--- a/apps/desktop/src/renderer/hooks/useSessionEstimatedValue.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionEstimatedValue.ts
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from '
 
 import { useChatDisplaySnapshot } from '@/components/chat/ChatDisplaySnapshotContext';
 import { makerChatStore, type ChatMessage } from '@/lib/makerChatStore';
-import * as messageService from '@/lib/messageService';
+import { estimatedSessionValueFor } from '@/lib/makerTransport';
 import { resolveStaleCodexSubscriptionValueEstimate } from '../../shared/codexSubscriptionValue';
 import { normalizeTurnUsageDetails } from '../../shared/turnUsageDetails';
 
@@ -209,8 +209,8 @@ export function useSessionEstimatedValue(
       if (payload.sessionId !== sessionId) return;
       mergeEntry(resolveEstimatedValueTurnCostEntry(payload));
     });
-    void messageService
-      .estimatedSessionValue(sessionId)
+    // 按会话来源路由:device-link 远程会话查被控端(本地库无该会话的行,查本机恒 0)。
+    void estimatedSessionValueFor(sessionId)
       .then((snapshot) => {
         if (cancelled) return;
         for (const entry of snapshot.entries) mergeEntry(entry);

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -3638,6 +3638,28 @@ function initGlobalListeners(): void {
         case 'usage:message-model-mismatch':
           handleUsageMessageModelMismatchRaw(push.payload);
           break;
+        case 'usage:session-spend-changed': {
+          // 被控端 session 终身累计 cost 落库推送(sessionSpendBroadcaster 走裸 UPDATE、
+          // 不发 sessions:patched)→ 镜像进远程项目分片;打开中的远程会话底部 $ chip 经
+          // session.totalCostUsd → useSessionSpend 初值重置显示最新值。
+          const p = push.payload as { sessionId?: string; totalCostUsd?: number } | null;
+          if (push.deviceId && p?.sessionId && typeof p.totalCostUsd === 'number') {
+            remoteProjectsStore.applyPatch(push.deviceId, p.sessionId, {
+              totalCostUsd: p.totalCostUsd,
+            });
+          }
+          break;
+        }
+        case 'usage:session-tokens-changed': {
+          // 同上:session 终身累计 token 镜像(chip tooltip 的 token 累计行)。
+          const p = push.payload as { sessionId?: string; totalTokens?: number } | null;
+          if (push.deviceId && p?.sessionId && typeof p.totalTokens === 'number') {
+            remoteProjectsStore.applyPatch(push.deviceId, p.sessionId, {
+              totalTokenUsage: p.totalTokens,
+            });
+          }
+          break;
+        }
         case 'local-db:sessions:patched': {
           // 被控端会话元数据 / 设置变更 → 就地镜像到远程项目分片(取代乐观覆盖)。
           const p = push.payload as { sessionId?: string; patch?: Record<string, unknown> } | null;

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -3643,7 +3643,12 @@ function initGlobalListeners(): void {
           // 不发 sessions:patched)→ 镜像进远程项目分片;打开中的远程会话底部 $ chip 经
           // session.totalCostUsd → useSessionSpend 初值重置显示最新值。
           const p = push.payload as { sessionId?: string; totalCostUsd?: number } | null;
-          if (push.deviceId && p?.sessionId && typeof p.totalCostUsd === 'number') {
+          // 跨设备 payload 防御:NaN / 负数不入镜像(否则 chip 显示 $NaN / 污染后续计算)。
+          if (
+            push.deviceId && p?.sessionId
+            && typeof p.totalCostUsd === 'number'
+            && Number.isFinite(p.totalCostUsd) && p.totalCostUsd >= 0
+          ) {
             remoteProjectsStore.applyPatch(push.deviceId, p.sessionId, {
               totalCostUsd: p.totalCostUsd,
             });
@@ -3653,7 +3658,11 @@ function initGlobalListeners(): void {
         case 'usage:session-tokens-changed': {
           // 同上:session 终身累计 token 镜像(chip tooltip 的 token 累计行)。
           const p = push.payload as { sessionId?: string; totalTokens?: number } | null;
-          if (push.deviceId && p?.sessionId && typeof p.totalTokens === 'number') {
+          if (
+            push.deviceId && p?.sessionId
+            && typeof p.totalTokens === 'number'
+            && Number.isFinite(p.totalTokens) && p.totalTokens >= 0
+          ) {
             remoteProjectsStore.applyPatch(push.deviceId, p.sessionId, {
               totalTokenUsage: p.totalTokens,
             });

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -192,6 +192,23 @@ export function listMessagesFor(
   return invokeRemote(deviceId, 'local-db:messages:list', [sessionId, opts]) as Promise<Message[]>;
 }
 
+/**
+ * 订阅形态会话「本会话价值」历史汇总:远程走隧道(否则查控制端空库恒为 0,底部 $ chip
+ * 的历史初值永远缺失)。归属用粘滞解析(relay 瞬时重连清空注册表的窗口内不误判为本机,
+ * 与 goal/learn 链路同款);老被控端无此 channel → CHANNEL_NOT_ALLOWED,调用方 catch
+ * 后退化为只显示已加载消息 + 实时推送的部分值。
+ */
+export function estimatedSessionValueFor(sessionId: string): Promise<{
+  totalValueUsd: number;
+  entries: Array<{ clientId: string; costUsd: number }>;
+}> {
+  const deviceId = getStickySessionDeviceId(sessionId);
+  if (!deviceId) return messageService.estimatedSessionValue(sessionId);
+  return invokeRemote(deviceId, 'local-db:messages:estimatedSessionValue', [
+    sessionId,
+  ]) as Promise<{ totalValueUsd: number; entries: Array<{ clientId: string; costUsd: number }> }>;
+}
+
 /** 会话内搜索跳转定位:远程走隧道 local-db:messages:around(否则查控制端空库,跳转必失败)。 */
 export function aroundMessagesFor(
   sessionId: string,

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -149,6 +149,39 @@ describe('remoteSessionStore', () => {
     expect(remoteSessionStore.getSessionDeviceId('s1')).toBe('dev-1');
   });
 
+  it('mirrors session-level usage pushes into totalCostUsd / totalTokenUsage', () => {
+    remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
+
+    // 被控端裸 UPDATE 不发 sessions:patched,这两条(sessions topic)是唯一更新通道。
+    remoteSessionStore.applyRemotePush('dev-1', 'usage:session-spend-changed', {
+      sessionId: 's1',
+      totalCostUsd: 1.23,
+    });
+    remoteSessionStore.applyRemotePush('dev-1', 'usage:session-tokens-changed', {
+      sessionId: 's1',
+      totalTokens: 45_000,
+    });
+    expect(remoteSessionStore.getSessions()[0]).toMatchObject({
+      id: 's1',
+      totalCostUsd: 1.23,
+      totalTokenUsage: 45_000,
+    });
+
+    // 跨设备 payload 防御:NaN / 负数不入镜像。
+    remoteSessionStore.applyRemotePush('dev-1', 'usage:session-spend-changed', {
+      sessionId: 's1',
+      totalCostUsd: Number.NaN,
+    });
+    remoteSessionStore.applyRemotePush('dev-1', 'usage:session-tokens-changed', {
+      sessionId: 's1',
+      totalTokens: -1,
+    });
+    expect(remoteSessionStore.getSessions()[0]).toMatchObject({
+      totalCostUsd: 1.23,
+      totalTokenUsage: 45_000,
+    });
+  });
+
   it('removes archived sessions from the active mirror', () => {
     remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1'), session('s2')]);
     remoteSessionStore.applySessionPatch('dev-1', 's1', { status: 'archived' });

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1633,6 +1633,26 @@ export const remoteSessionStore = {
       }
       return;
     }
+    if (channel === 'usage:session-spend-changed' && isRecord(payload)) {
+      // session 终身累计 cost 镜像:被控端 sessionSpendBroadcaster 走裸 UPDATE、不发
+      // sessions:patched,这条(sessions topic,列表订阅常开)是唯一更新通道;不处理则
+      // 会话菜单用量摘要停在旧值直到 reseed。readNumber 已挡 NaN,负数不入镜像。
+      const sessionId = readString(payload, 'sessionId');
+      const totalCostUsd = readNumber(payload, 'totalCostUsd');
+      if (sessionId && totalCostUsd !== null && totalCostUsd >= 0) {
+        this.applySessionPatch(deviceId, sessionId, { totalCostUsd });
+      }
+      return;
+    }
+    if (channel === 'usage:session-tokens-changed' && isRecord(payload)) {
+      // 同上:session 终身累计 token 镜像。
+      const sessionId = readString(payload, 'sessionId');
+      const totalTokens = readNumber(payload, 'totalTokens');
+      if (sessionId && totalTokens !== null && totalTokens >= 0) {
+        this.applySessionPatch(deviceId, sessionId, { totalTokenUsage: totalTokens });
+      }
+      return;
+    }
     if (channel === 'usage:message-model-mismatch' && isRecord(payload)) {
       // 本轮模型降级标记(桌面被控端 turn 结束检测命中时推送):patch 进
       // agent_meta,messageNormalize 的 readModelMismatch 据此渲染降级提示行。

--- a/packages/device-link/src/__tests__/allowlist.test.ts
+++ b/packages/device-link/src/__tests__/allowlist.test.ts
@@ -41,6 +41,10 @@ describe('REMOTE_INVOKE_ALLOWLIST', () => {
     }
   });
 
+  it('放行订阅价值历史汇总只读聚合(远程会话底部 $ chip 的历史初值查被控端)', () => {
+    expect(REMOTE_INVOKE_ALLOWLIST.has('local-db:messages:estimatedSessionValue')).toBe(true);
+  });
+
   it('放行 per-session turn 态只读查询(控制端 stall 看门狗核实被控端用)', () => {
     expect(REMOTE_INVOKE_ALLOWLIST.has('maker:session-in-turn')).toBe(true);
     expect(REMOTE_INVOKE_ALLOWLIST.has('maker:any-session-in-turn')).toBe(true);
@@ -268,6 +272,8 @@ describe('PUSH_FORWARD_ALLOWLIST', () => {
       'maker:schedule:event',
       'maker:orca:worker-changed',
       'usage:message-turn-cost',
+      'usage:session-spend-changed',
+      'usage:session-tokens-changed',
       'local-db:messages:created',
       'local-db:messages:deleted',
       'local-db:session:error-persisted',

--- a/packages/device-link/src/__tests__/topics.test.ts
+++ b/packages/device-link/src/__tests__/topics.test.ts
@@ -81,12 +81,15 @@ describe('topicForPush', () => {
     expect(topicForPush('usage:message-turn-cost', { sessionId: 's7', clientId: 'm1' })).toBe(
       'session:s7',
     );
-    // session 终身累计 cost / token 镜像:payload 顶层 sessionId → 默认路由到 session:<id>。
+  });
+
+  it('session 累计 cost / token 镜像 → sessions(列表订阅常开,会话未打开也不丢更新)', () => {
+    // 若走 session:<id>,未打开的会话无人订阅 → 镜像停在旧值,下次打开 chip 先显示过期累计。
     expect(topicForPush('usage:session-spend-changed', { sessionId: 's8', totalCostUsd: 1.23 })).toBe(
-      'session:s8',
+      'sessions',
     );
     expect(topicForPush('usage:session-tokens-changed', { sessionId: 's8', totalTokens: 42 })).toBe(
-      'session:s8',
+      'sessions',
     );
   });
 

--- a/packages/device-link/src/__tests__/topics.test.ts
+++ b/packages/device-link/src/__tests__/topics.test.ts
@@ -81,6 +81,13 @@ describe('topicForPush', () => {
     expect(topicForPush('usage:message-turn-cost', { sessionId: 's7', clientId: 'm1' })).toBe(
       'session:s7',
     );
+    // session 终身累计 cost / token 镜像:payload 顶层 sessionId → 默认路由到 session:<id>。
+    expect(topicForPush('usage:session-spend-changed', { sessionId: 's8', totalCostUsd: 1.23 })).toBe(
+      'session:s8',
+    );
+    expect(topicForPush('usage:session-tokens-changed', { sessionId: 's8', totalTokens: 42 })).toBe(
+      'session:s8',
+    );
   });
 
   it('orca:worker-changed 用 leadSessionId(不同 key)', () => {

--- a/packages/device-link/src/allowlist.ts
+++ b/packages/device-link/src/allowlist.ts
@@ -405,9 +405,9 @@ export const PUSH_FORWARD_ALLOWLIST: ReadonlySet<string> = new Set([
   // 本轮模型降级标记(payload 顶层 sessionId → 默认路由到 session:<id> topic):
   // 控制端把 agent_meta.modelMismatch 实时 patch 进已打开的远程会话消息流。
   'usage:message-model-mismatch',
-  // session 终身累计 cost / token(payload 顶层 sessionId → 默认路由到 session:<id> topic):
-  // 被控端 sessionSpendBroadcaster 走裸 UPDATE 落库、不发 sessions:patched,控制端打开的
-  // 远程会话底部 $ chip 依赖这两条把累计值镜像成被控端真相。
+  // session 终身累计 cost / token(topics.ts 归入 sessions topic:列表订阅常开,会话
+  // 未打开也保持镜像新鲜):被控端 sessionSpendBroadcaster 走裸 UPDATE 落库、不发
+  // sessions:patched,控制端远程会话底部 $ chip 依赖这两条把累计值镜像成被控端真相。
   'usage:session-spend-changed',
   'usage:session-tokens-changed',
   // local-db 推送(读模型增量)

--- a/packages/device-link/src/allowlist.ts
+++ b/packages/device-link/src/allowlist.ts
@@ -167,6 +167,11 @@ const CORE_INVOKE_CHANNELS: readonly string[] = [
   'local-db:messages:around',
   // 以 message clientId 定位上下文,供移动端轻量跳转 / fork 来源定位；只读,与 messages:around 同安全级。
   'local-db:messages:around-client-id',
+  // 订阅形态会话「本会话价值」历史汇总(assistant agent_meta 估算值求和):只读聚合,
+  // 无 sender 依赖、无副作用,与 messages:list 同安全级。控制端底部 $ chip 的历史初值
+  // 必须查被控端(查本机是空库恒 0);老被控端无此 channel → CHANNEL_NOT_ALLOWED →
+  // 控制端吞错,仅靠已加载消息 + 实时 turn-cost 推送呈现部分值。
+  'local-db:messages:estimatedSessionValue',
   'local-db:recent-workdirs:list',
   // 窄口径写:从被控端「最近项目」列表移除一条(专用 handler,path 归一后按主键删,
   // 幂等,不动 sessions / 磁盘)。控制端项目选择器的删除入口与本机语义对等;
@@ -400,6 +405,11 @@ export const PUSH_FORWARD_ALLOWLIST: ReadonlySet<string> = new Set([
   // 本轮模型降级标记(payload 顶层 sessionId → 默认路由到 session:<id> topic):
   // 控制端把 agent_meta.modelMismatch 实时 patch 进已打开的远程会话消息流。
   'usage:message-model-mismatch',
+  // session 终身累计 cost / token(payload 顶层 sessionId → 默认路由到 session:<id> topic):
+  // 被控端 sessionSpendBroadcaster 走裸 UPDATE 落库、不发 sessions:patched,控制端打开的
+  // 远程会话底部 $ chip 依赖这两条把累计值镜像成被控端真相。
+  'usage:session-spend-changed',
+  'usage:session-tokens-changed',
   // local-db 推送(读模型增量)
   'local-db:sessions:created',
   'local-db:sessions:patched',

--- a/packages/device-link/src/topics.ts
+++ b/packages/device-link/src/topics.ts
@@ -72,6 +72,12 @@ const SESSION_LIST_CHANNELS: ReadonlySet<string> = new Set([
   'local-db:sessions:patched',
   'local-db:session:error-persisted',
   SESSION_ACTIVITY_CHANNEL,
+  // session 终身累计 cost / token(sessions 行级字段的裸 UPDATE 补偿推送):归 sessions
+  // topic 而非 session:<id> —— 会话未在控制端打开时 session:<id> 无人订阅,镜像会停在
+  // 旧值,下次打开 chip 先显示过期累计;列表订阅常开保证镜像始终新鲜。低频(turn 结束
+  // 各一条)、payload 极小。
+  'usage:session-spend-changed',
+  'usage:session-tokens-changed',
 ]);
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 device-link 远程会话(控制端打开被控端的对话)底部状态栏「$」消耗/价值取不到、永远只显示灰色占位的问题。根因是 session 级 usage 数据整条链路没有跨隧道:

1. **实时累计推送没转发**:被控端 `sessionSpendBroadcaster` 落库(裸 UPDATE,不发 `sessions:patched`)后只广播本机窗口,`usage:session-spend-changed` / `usage:session-tokens-changed` 不在 `PUSH_FORWARD_ALLOWLIST`,控制端永远收不到累计值。→ 被控端广播点接入 `tapWindowBroadcast`,两个 channel 进转发白名单并归 `sessions` topic(列表订阅常开,会话未打开时镜像同样收敛,review 后从 `session:<id>` 调整);控制端 `onRemotePush` 把它们镜像进 `remoteProjectsStore` 的会话行(`totalCostUsd` / `totalTokenUsage`)。
2. **订阅价值历史汇总查了本机空库**:`useSessionEstimatedValue` 的历史初值走 `local-db:messages:estimatedSessionValue`,永远查控制端本地 SQLite,远程会话恒 0。→ 新增 `makerTransport.estimatedSessionValueFor`(粘滞归属解析,relay 重连窗口不误判为本机),该 channel 进 `REMOTE_INVOKE_ALLOWLIST`(只读聚合、无 sender 依赖,与 `messages:list` 同安全级)。
3. **chip 形态按本机账号状态误分类**:`TodaySpendChip` 用本机网关 key / OAuth / proxy 观察路由给 device-link 远程会话分类(张冠李戴,误入网关形态后显示恒 0 的 cost → 空白 `$`)。→ device-link 会话不再参与本机形态分类与 route 观察,走专属数据驱动分支:订阅估算价值 / 真实累计 cost 有哪个显哪个,tooltip 带 token 累计与最近一轮明细;看板链接落 null(额度属于被控端账号)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:用户实报(Mac-Studio 被控,控制端打开远程线程 `$` 一直空占位)
- 本 PR 包含:被控端 usage 广播 tap、device-link 白名单登记(push +2 / invoke +1)、控制端镜像与传输层路由、TodaySpendChip device-link 分支、对应回归测试
- 明确不包含:SSH 远程会话 chip 口径(维持既有行为)、被控端账号限额窗口的跨设备读取(本机不显示、不猜)、移动端新增用量 UI(仅补既有摘要的数据镜像)
- 用户可见变化:device-link 远程会话底部 `$` 正常显示本会话价值/累计消耗并实时增长;chip 不再可点跳转本机账号看板
- 是否存在 breaking change:无(白名单为增量;老被控端对新 invoke 回 `CHANNEL_NOT_ALLOWED`,控制端吞错降级为部分值)

### UI 变化

仅 device-link 远程会话底部状态栏 `$` chip 内容(从空占位变为显示数值);无新布局/组件,Light/Dark 复用既有 token 样式,无样式改动。未附截图:见「未执行的验证」。

### 远程连接 / 手机版适配说明(规则 26)

1. SSH 远程工作区:不涉及 workdir 文件/agent 进程读写;SSH 远程会话的 chip 口径(`remoteHostId` 分支)未改动。
2. IPC/推送白名单:本 PR 即登记本身 —— push 白名单 +`usage:session-spend-changed` / `usage:session-tokens-changed`(归 `sessions` topic,列表订阅常开,有 topics 单测),invoke 白名单 +`local-db:messages:estimatedSessionValue`(准入论证见 allowlist 注释)。
3. 手机版:已一并适配(review 后补)—— mobile `remoteSessionStore.applyRemotePush` 处理两个 usage channel,会话行 `totalCostUsd` / `totalTokenUsage` 镜像保持新鲜(会话菜单用量摘要不再停旧值),含回归测试;mobile typecheck + 全量测试通过。

## 怎么验证的

### 自动验证

```text
pnpm test:unit(仓库根,清 CLAUDE* 环境变量)
结果:全部通过(含新增/更新的回归测试)

pnpm --filter desktop typecheck
结果:通过

定向:packages/device-link vitest(allowlist/topics)、desktop vitest
(makerTransportRouting / todaySpendChip / useSessionEstimatedValue /
 deviceLinkControllerScenarios / sessionSpendBroadcaster / goalLearnTransportRouting)
结果:全部通过
```

新增回归测试:
- allowlist:两个 usage push channel 入转发白名单、estimatedSessionValue 入 invoke 白名单
- topics:`usage:session-*-changed` 归 `sessions` topic(列表订阅常开,会话未打开不丢更新)
- makerTransport:`estimatedSessionValueFor` 远程走隧道 / 本机走本地库(drift 守卫自动覆盖新 channel)
- deviceLinkControllerScenarios:被控端 spend/tokens 推送 → 控制端会话行镜像
- mobile remoteSessionStore:usage 推送镜像 + NaN/负数防御
- todaySpendChip source 契约:device-link 不用本机账号分类、专属渲染分支、看板链接落 null

### 手工验证

不涉及(未在双机 device-link 环境实测,见下)。

### 未执行的验证

双机(控制端 + 被控端)真实 device-link 环境的端到端目测未执行(本机单实例无法构造)。用户可执行的验证步骤:两端都升到本分支 → 控制端打开 Mac-Studio 上的远程会话 → 底部 `$` 应显示「本会话价值 $X」(订阅会话)或「本会话 $X」(网关会话),跑一轮对话后数值增长;老被控端 + 新控制端时显示已加载消息的部分价值(不再恒空)。

## 风险

### 风险分类

- [x] 协议兼容
- [ ] 其他

### 影响与回滚

- 影响范围:device-link 推送转发白名单与 invoke 白名单(增量登记);被控端 usage 广播路径加一行 tap(无控制链路时 O(1) no-op,不进热路径成本);控制端仅影响 device-link 远程会话的 chip 与镜像,SSH 远程与本机会话零改动
- 协议兼容:新 invoke channel 对老被控端回 `CHANNEL_NOT_ALLOWED`,控制端 catch 后降级;新 push channel 老控制端收不到(不订阅/不识别则忽略),双向不破坏;`computeAllowlistHash` 随 invoke 表变化,两端版本不一致时按既有机制提示
- 回滚 / 降级方式:revert 本 PR 即回到「远程会话 $ 空占位」的旧行为,无数据/schema 变更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(allowlist 准入注释即协议文档)
- [x] 已确认测试结果或说明未执行原因
