### PR TITLE
test(desktop): 补齐 OpenAI 授权边界测试缺失的 isChatGptConnectionConnected mock(修 main 基线红)

### DIFF
--- a/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
@@ -24,6 +24,10 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/hooks/useCodexAuth', () => ({
+  // 与真实实现同判定:仅 authenticated + oauth 视为 ChatGPT 已连接
+  // (#268 起向导直接消费此 helper,mock 必须同步导出)。
+  isChatGptConnectionConnected: (state: { kind: string; authSource?: string }) =>
+    state.kind === 'authenticated' && state.authSource === 'oauth',
   useCodexAuth: () => ({
     state: { kind: 'authenticated', authSource: 'oauth' },
     triggerLogin,

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
@@ -153,6 +153,11 @@ describe('AddProviderWizard — OpenAI 授权边界', () => {
     fireEvent.click(screen.getByText('settings.providers.button.authorize'));
 
     await waitFor(() => expect(triggerLogin).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(onDone).not.toHaveBeenCalled());
+    // 先等授权流程 settle(按钮从「取消」回到「授权」= loggingIn 已复位),
+    // 再做负向断言——避免「负向 waitFor」首查即过、断言早于异步流程收尾。
+    await waitFor(() =>
+      expect(screen.getByText('settings.providers.button.authorize')).not.toBeNull(),
+    );
+    expect(onDone).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
@@ -32,10 +32,16 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/hooks/useCodexAuth', () => ({
-  // 与真实实现同判定:仅 authenticated + oauth 视为 ChatGPT 已连接
-  // (#268 起向导直接消费此 helper,mock 必须同步导出)。
-  isChatGptConnectionConnected: (state: { kind: string; authSource?: string }) =>
-    state.kind === 'authenticated' && state.authSource === 'oauth',
+  // 与真实实现同签名同判定(loading 沿用 providerConnected,其余仅
+  // authenticated + oauth 视为已连接;#268 起向导直接消费此 helper,
+  // mock 必须同步导出)。
+  isChatGptConnectionConnected: (
+    state: { kind: string; authSource?: string },
+    providerConnected: boolean,
+  ) =>
+    state.kind === 'loading'
+      ? providerConnected
+      : state.kind === 'authenticated' && state.authSource === 'oauth',
   useCodexAuth: () => ({
     state: codexAuthMock.state,
     triggerLogin,
@@ -127,5 +133,26 @@ describe('AddProviderWizard — OpenAI 授权边界', () => {
 
     await waitFor(() => expect(triggerLogin).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(onDone).toHaveBeenCalledWith('openai'));
+  });
+
+  it('点击授权但本次登录被取消时不完成绑定', async () => {
+    // 负向边界:点击本身不算完成——登录取消、状态未翻转,不得收口。
+    codexAuthMock.state = { kind: 'unauthenticated' };
+    triggerLogin.mockImplementation(async () => 'cancelled');
+    const onDone = vi.fn();
+    render(
+      <AddProviderWizard
+        providers={[OPENAI_PROVIDER]}
+        entry={{ kind: 'builtin', providerId: 'openai' }}
+        onOpenCustomForm={vi.fn()}
+        onClose={vi.fn()}
+        onDone={onDone}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('settings.providers.button.authorize'));
+
+    await waitFor(() => expect(triggerLogin).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onDone).not.toHaveBeenCalled());
   });
 });

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
@@ -14,9 +14,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ProviderView } from '@cindy/model-providers';
 
-const { triggerLogin, cancelLogin } = vi.hoisted(() => ({
+const { triggerLogin, cancelLogin, codexAuthMock } = vi.hoisted(() => ({
   triggerLogin: vi.fn(),
   cancelLogin: vi.fn(),
+  // 可变快照:各用例自行设定初始态;登录成功用例只有 triggerLogin 翻转
+  // 到 authenticated 后才算连接,防止「既有快照」冒充「本次登录成功」。
+  codexAuthMock: {
+    state: { kind: 'authenticated', authSource: 'oauth' } as {
+      kind: string;
+      authSource?: string;
+    },
+  },
 }));
 
 vi.mock('react-i18next', () => ({
@@ -29,7 +37,7 @@ vi.mock('@/hooks/useCodexAuth', () => ({
   isChatGptConnectionConnected: (state: { kind: string; authSource?: string }) =>
     state.kind === 'authenticated' && state.authSource === 'oauth',
   useCodexAuth: () => ({
-    state: { kind: 'authenticated', authSource: 'oauth' },
+    state: codexAuthMock.state,
     triggerLogin,
     cancelLogin,
     logout: vi.fn(),
@@ -65,7 +73,12 @@ const OPENAI_PROVIDER = {
 beforeEach(() => {
   triggerLogin.mockReset();
   cancelLogin.mockReset();
-  triggerLogin.mockResolvedValue('authenticated');
+  codexAuthMock.state = { kind: 'authenticated', authSource: 'oauth' };
+  // 登录成功 = 快照翻转到 authenticated;完成边界必须由这次翻转驱动。
+  triggerLogin.mockImplementation(async () => {
+    codexAuthMock.state = { kind: 'authenticated', authSource: 'oauth' };
+    return 'authenticated';
+  });
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     maker: {
       listProviderPresets: vi.fn(async () => ({ presets: [] })),
@@ -96,6 +109,9 @@ describe('AddProviderWizard — OpenAI 授权边界', () => {
   });
 
   it('仅在用户点击授权且本次登录成功后完成绑定流程', async () => {
+    // 从未认证起步:完成只能由本次 triggerLogin 成功后的状态翻转驱动,
+    // 既有 authenticated 快照(上一用例的场景)不能冒充登录成功。
+    codexAuthMock.state = { kind: 'unauthenticated' };
     const onDone = vi.fn();
     render(
       <AddProviderWizard


### PR DESCRIPTION
## 这次改了什么

修复 main 基线单测失败:#268 (c03be7f) 让 `AddProviderWizard` 直接调用 `useCodexAuth` 的 `isChatGptConnectionConnected`,但没同步更新 `addProviderWizardOpenAiAuth.test.tsx` 对该模块的 `vi.mock`,缺 export 导致该用例在 main 上必挂(`No "isChatGptConnectionConnected" export is defined on the "@/hooks/useCodexAuth" mock`),会殃及所有 open PR 的 verify。

按同目录 `addProviderWizardOpenaiEntry.test.tsx`(#268 自带的新测试)的同款判定补齐 mock。测试原有意图不变:向导侧有 `openaiLoginStartedRef` 门,mock 返回 connected 不会把「本机已有凭证」误判成完成。

## 怎么验证的

- `npx vitest run src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx src/renderer/__tests__/addProviderWizardOpenaiEntry.test.tsx` → 2 files / 5 tests 全绿(修复前前者必挂)。

## 风险

- 纯测试 mock 补齐,无产品代码改动;风险极低。

## 远程连接/手机版适配说明(规则 26)

不涉及——仅补测试 mock,无功能 / IPC / UI 改动。
