### PR TITLE
fix(im): 正确处理飞书连接冲突信号

### DIFF
--- a/packages/lizi-im/src/feishu/__tests__/wsClientConflict.test.ts
+++ b/packages/lizi-im/src/feishu/__tests__/wsClientConflict.test.ts
@@ -1,0 +1,179 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { feishuEvents } from '../events.js';
+
+interface CapturingLogger {
+  info: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+interface MockSdkOptions {
+  logger: CapturingLogger;
+  onReady?: () => void;
+  onError?: (error: Error) => void;
+}
+
+const mocks = {
+  options: [] as MockSdkOptions[],
+  start: vi.fn(async () => undefined),
+  close: vi.fn(),
+  bindClient: vi.fn(),
+  unbindClient: vi.fn(),
+  getBoundClient: vi.fn(() => null),
+  sendText: vi.fn(),
+  firstAllowed: vi.fn(() => null),
+  checkOwner: vi.fn(() => true),
+  tryClaimOwner: vi.fn(() => false),
+  log: {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+};
+
+vi.doMock('@larksuiteoapi/node-sdk', () => ({
+  WSClient: class {
+    readonly start = mocks.start;
+    readonly close = mocks.close;
+
+    constructor(options: MockSdkOptions) {
+      mocks.options.push(options);
+    }
+  },
+  EventDispatcher: class {
+    register(): this {
+      return this;
+    }
+  },
+  LoggerLevel: { info: 'info' },
+}));
+
+vi.doMock('../outbound.js', () => ({
+  bindClient: mocks.bindClient,
+  unbindClient: mocks.unbindClient,
+  getBoundClient: mocks.getBoundClient,
+  sendText: mocks.sendText,
+}));
+
+vi.doMock('../ownerGuard.js', () => ({
+  firstAllowed: mocks.firstAllowed,
+  check: mocks.checkOwner,
+  tryClaimOwner: mocks.tryClaimOwner,
+}));
+
+vi.doMock('../moduleScope.js', () => ({
+  getLog: () => mocks.log,
+}));
+
+let wsClient: typeof import('../wsClient.js');
+
+const credentials = {
+  appId: 'cli_conflict_test',
+  appSecret: 'secret',
+};
+
+function latestClient() {
+  const options = mocks.options.at(-1);
+  if (!options) throw new Error('expected WSClient to be constructed');
+  return {
+    options,
+    logger: options.logger,
+    start: mocks.start,
+    close: mocks.close,
+  };
+}
+
+beforeEach(async () => {
+  await wsClient.stop({ announceOffline: false, reason: 'test-reset' });
+  mocks.options.length = 0;
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await wsClient.stop({ announceOffline: false, reason: 'test-cleanup' });
+});
+
+beforeAll(async () => {
+  wsClient = await import('../wsClient.js');
+});
+
+afterAll(() => {
+  vi.doUnmock('@larksuiteoapi/node-sdk');
+  vi.doUnmock('../outbound.js');
+  vi.doUnmock('../ownerGuard.js');
+  vi.doUnmock('../moduleScope.js');
+});
+
+describe('Feishu WebSocket conflict handling', () => {
+  it('maps exceed_conn_limit during initial connection to conflict and closes the socket', async () => {
+    const onConflict = vi.fn();
+    feishuEvents.on('conflict', onConflict);
+
+    try {
+      const connecting = wsClient.start(credentials, { announceLifecycle: false });
+      const sdkClient = latestClient();
+
+      sdkClient.options.onError?.(
+        new Error(
+          'pullConnectConfig failed: code=1000040350, msg=exceed_conn_limit',
+        ),
+      );
+      sdkClient.options.onReady?.();
+      expect(wsClient.getCurrentStatus()).not.toBe('connected');
+
+      await expect(connecting).resolves.toBe('conflict');
+      expect(wsClient.getCurrentStatus()).toBe('conflict');
+      expect(sdkClient.close).toHaveBeenCalledWith({ force: true });
+      expect(onConflict).toHaveBeenCalledOnce();
+      expect(onConflict).toHaveBeenCalledWith({ appId: credentials.appId });
+    } finally {
+      feishuEvents.off('conflict', onConflict);
+    }
+  });
+
+  it('revokes an already-ready connection when a late conflict signal arrives', async () => {
+    const onConflict = vi.fn();
+    feishuEvents.on('conflict', onConflict);
+
+    try {
+      const connecting = wsClient.start(credentials, { announceLifecycle: false });
+      const sdkClient = latestClient();
+      sdkClient.options.onReady?.();
+
+      await expect(connecting).resolves.toBe('connected');
+      expect(wsClient.getCurrentStatus()).toBe('connected');
+
+      sdkClient.options.onError?.(new Error('exceed_conn_limit'));
+
+      await vi.waitFor(() => expect(wsClient.getCurrentStatus()).toBe('conflict'));
+      expect(sdkClient.close).toHaveBeenCalledWith({ force: true });
+      expect(onConflict).toHaveBeenCalledOnce();
+      expect(onConflict).toHaveBeenCalledWith({ appId: credentials.appId });
+    } finally {
+      feishuEvents.off('conflict', onConflict);
+    }
+  });
+
+  it('keeps SDK error-log parsing as a conflict fallback', async () => {
+    const connecting = wsClient.start(credentials, { announceLifecycle: false });
+    const sdkClient = latestClient();
+
+    sdkClient.logger.error('[ws]', 'code: 1000040350, exceed_conn_limit');
+
+    await expect(connecting).resolves.toBe('conflict');
+    expect(wsClient.getCurrentStatus()).toBe('conflict');
+    expect(sdkClient.close).toHaveBeenCalledWith({ force: true });
+  });
+});

--- a/packages/lizi-im/src/feishu/conflictDetector.ts
+++ b/packages/lizi-im/src/feishu/conflictDetector.ts
@@ -30,6 +30,7 @@ export class ConflictDetector {
   private readonly reconnectThreshold: number;
   private reconnectCount = 0;
   private resolved = false;
+  private verdict: ConnectVerdict | null = null;
   private resolver: ((v: ConnectVerdict) => void) | null = null;
   private timer: NodeJS.Timeout | null = null;
   private readonly verdictPromise: Promise<ConnectVerdict>;
@@ -56,37 +57,44 @@ export class ConflictDetector {
     }, this.readyTimeoutMs);
   }
 
-  markReady(): void {
-    if (this.resolved) return;
-    this.resolve({ kind: 'connected' });
+  markReady(): boolean {
+    return this.resolve({ kind: 'connected' });
   }
 
-  markReconnecting(): void {
-    if (this.resolved) return;
+  markReconnecting(): boolean {
+    if (this.resolved) return false;
     this.reconnectCount++;
+    return true;
   }
 
-  markReconnected(): void {
-    if (this.resolved) return;
-    this.resolve({ kind: 'connected' });
+  markReconnected(): boolean {
+    return this.resolve({ kind: 'connected' });
   }
 
-  markError(err: Error): void {
-    if (this.resolved) return;
-    this.resolve({ kind: 'error', message: err.message ?? 'Unknown error' });
+  markConflict(): boolean {
+    return this.resolve({ kind: 'conflict' });
+  }
+
+  markError(err: Error): boolean {
+    return this.resolve({ kind: 'error', message: err.message ?? 'Unknown error' });
+  }
+
+  getVerdict(): ConnectVerdict | null {
+    return this.verdict;
   }
 
   waitForVerdict(): Promise<ConnectVerdict> {
     return this.verdictPromise;
   }
 
-  abandon(): void {
-    if (this.resolved) return;
-    this.resolve({ kind: 'error', message: 'Abandoned by caller.' });
+  abandon(): boolean {
+    return this.resolve({ kind: 'error', message: 'Abandoned by caller.' });
   }
 
-  private resolve(v: ConnectVerdict): void {
+  private resolve(v: ConnectVerdict): boolean {
+    if (this.resolved) return false;
     this.resolved = true;
+    this.verdict = v;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
@@ -95,5 +103,6 @@ export class ConflictDetector {
       this.resolver(v);
       this.resolver = null;
     }
+    return true;
   }
 }

--- a/packages/lizi-im/src/feishu/wsClient.ts
+++ b/packages/lizi-im/src/feishu/wsClient.ts
@@ -3,9 +3,9 @@
  * ---------------------------------------------------------------------------
  * Lark.WSClient + Lark.EventDispatcher wrapper.
  *
- * 关键设计：SDK 既不暴露 EventEmitter 也不接受连接生命周期 callback。
- * 我们注入一个**自定义 Logger** 包装 SDK 内部日志，按消息内容关键字
- * 触发 ConflictDetector：
+ * 关键设计：连接生命周期优先使用 SDK 的 onReady / onError /
+ * onReconnecting / onReconnected callback。自定义 Logger 仍保留同一套
+ * 信号解析作为兼容兜底：
  *
  *   info  '[ws] ws client ready'    → detector.markReady()
  *   info  '[ws] reconnect success'  → detector.markReconnected()
@@ -52,6 +52,7 @@ let currentBotAppId: string | null = null;
 let currentStatus: FeishuConnectionStatus = 'idle';
 let acceptingInbound = false;
 let lifecycleGeneration = 0;
+let conflictTransitionGeneration: number | null = null;
 
 let lifecycleAnnouncementEnabled = true;
 let pendingOfflineNotice = false;
@@ -87,6 +88,106 @@ export function setLifecycleAnnouncement(enabled: boolean): void {
   getLog().info(`[feishu/wsClient] lifecycleAnnouncement set to ${enabled}`);
 }
 
+const FEISHU_CONFLICT_ERROR = '该 App 已被另一台设备占用 (exceed_conn_limit)';
+
+function isConflictSignal(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes('1000040350') || normalized.includes('exceed_conn_limit');
+}
+
+function isActiveConnection(generation: number, appId: string): boolean {
+  return (
+    acceptingInbound &&
+    lifecycleGeneration === generation &&
+    currentBotAppId === appId
+  );
+}
+
+async function transitionToConflict(
+  generation: number,
+  appId: string,
+): Promise<void> {
+  if (
+    conflictTransitionGeneration === generation ||
+    !isActiveConnection(generation, appId)
+  ) {
+    return;
+  }
+
+  conflictTransitionGeneration = generation;
+  setStatus('conflict', FEISHU_CONFLICT_ERROR);
+  await stop({
+    keepStatus: true,
+    announceOffline: false,
+    reason: 'connection-conflict',
+  });
+  feishuEvents.emit('conflict', { appId });
+}
+
+function handleReadySignal(
+  activeDetector: ConflictDetector,
+  generation: number,
+  appId: string,
+): void {
+  if (!isActiveConnection(generation, appId)) return;
+  activeDetector.markReady();
+  if (
+    activeDetector.getVerdict()?.kind === 'connected' &&
+    currentStatus !== 'connected'
+  ) {
+    setStatus('connected');
+  }
+}
+
+function handleReconnectingSignal(
+  activeDetector: ConflictDetector,
+  generation: number,
+  appId: string,
+): void {
+  if (!isActiveConnection(generation, appId)) return;
+  activeDetector.markReconnecting();
+  if (
+    activeDetector.getVerdict()?.kind !== 'conflict' &&
+    currentStatus === 'connected'
+  ) {
+    setStatus('reconnecting');
+  }
+}
+
+function handleReconnectedSignal(
+  activeDetector: ConflictDetector,
+  generation: number,
+  appId: string,
+): void {
+  if (!isActiveConnection(generation, appId)) return;
+  activeDetector.markReconnected();
+  if (
+    activeDetector.getVerdict()?.kind === 'connected' &&
+    currentStatus !== 'connected'
+  ) {
+    setStatus('connected');
+  }
+}
+
+function handleErrorSignal(
+  error: Error,
+  activeDetector: ConflictDetector,
+  generation: number,
+  appId: string,
+): void {
+  if (!isActiveConnection(generation, appId)) return;
+  if (isConflictSignal(error.message)) {
+    if (
+      !activeDetector.markConflict() &&
+      activeDetector.getVerdict()?.kind !== 'conflict'
+    ) {
+      void transitionToConflict(generation, appId);
+    }
+    return;
+  }
+  activeDetector.markError(error);
+}
+
 // ── SDK logger interceptor ────────────────────────────────────────────────────
 
 interface SdkLogger {
@@ -97,7 +198,11 @@ interface SdkLogger {
   error: (...msg: unknown[]) => void | Promise<void>;
 }
 
-function makeCapturingLogger(activeDetector: ConflictDetector): SdkLogger {
+function makeCapturingLogger(
+  activeDetector: ConflictDetector,
+  generation: number,
+  appId: string,
+): SdkLogger {
   const log = getLog();
   return {
     trace: () => {},
@@ -107,15 +212,13 @@ function makeCapturingLogger(activeDetector: ConflictDetector): SdkLogger {
         .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
         .join(' ');
       log.debug('[feishu/sdk-info]', msg);
+      if (!isActiveConnection(generation, appId)) return;
       if (msg.includes('ws client ready')) {
-        activeDetector.markReady();
-        if (currentStatus !== 'connected') setStatus('connected');
+        handleReadySignal(activeDetector, generation, appId);
       } else if (msg.includes('reconnect success')) {
-        activeDetector.markReconnected();
-        if (currentStatus !== 'connected') setStatus('connected');
+        handleReconnectedSignal(activeDetector, generation, appId);
       } else if (msg.includes('reconnect') && !msg.includes('success')) {
-        activeDetector.markReconnecting();
-        if (currentStatus === 'connected') setStatus('reconnecting');
+        handleReconnectingSignal(activeDetector, generation, appId);
       } else if (msg.includes('unable to connect to the server')) {
         activeDetector.markError(new Error('unable to connect after retries'));
         setStatus('error', '连接失败：飞书服务无法访问，请检查网络');
@@ -132,14 +235,19 @@ function makeCapturingLogger(activeDetector: ConflictDetector): SdkLogger {
         .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
         .join(' ');
       log.error('[feishu/sdk-error]', msg);
+      if (!isActiveConnection(generation, appId)) return;
+      if (isConflictSignal(msg)) {
+        handleErrorSignal(
+          new Error(FEISHU_CONFLICT_ERROR),
+          activeDetector,
+          generation,
+          appId,
+        );
+        return;
+      }
       if (msg.includes('code: 514')) {
         activeDetector.markError(new Error('App ID / App Secret 不正确（auth_failed）'));
         setStatus('error', 'App ID 或 App Secret 不正确');
-      }
-      if (msg.includes('1000040350')) {
-        activeDetector.markError(
-          new Error('该 App 已被另一台设备占用 (exceed_conn_limit)'),
-        );
       }
     },
   };
@@ -175,7 +283,19 @@ export async function start(
     appSecret: creds.appSecret,
     loggerLevel: Lark.LoggerLevel.info,
     autoReconnect: true,
-    logger: makeCapturingLogger(startDetector),
+    logger: makeCapturingLogger(startDetector, startedGeneration, creds.appId),
+    onReady: () => {
+      handleReadySignal(startDetector, startedGeneration, creds.appId);
+    },
+    onError: (error) => {
+      handleErrorSignal(error, startDetector, startedGeneration, creds.appId);
+    },
+    onReconnecting: () => {
+      handleReconnectingSignal(startDetector, startedGeneration, creds.appId);
+    },
+    onReconnected: () => {
+      handleReconnectedSignal(startDetector, startedGeneration, creds.appId);
+    },
   });
 
   outbound.bindClient(creds);
@@ -223,9 +343,7 @@ export async function start(
       }
       return 'connected';
     case 'conflict':
-      setStatus('conflict', '该 App ID 似乎已被另一台设备使用');
-      await stop({ keepStatus: true });
-      feishuEvents.emit('conflict', { appId: creds.appId });
+      await transitionToConflict(startedGeneration, creds.appId);
       return 'conflict';
     case 'error':
       setStatus('error', verdict.message);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复飞书 WebSocket 冲突信号在客户端被误判或漏报的问题：将 1000040350 / exceed_conn_limit 明确映射为 conflict，并允许已经收到初始 connected 判定的连接在后续收到冲突信号时切换为冲突状态。发生冲突后会关闭 WebSocket、阻止后续入站事件，并广播 feishuBot:conflict。

冲突识别优先使用 SDK 生命周期回调，同时保留日志解析作为兼容兜底；连接代次发生变化后，旧连接的迟到事件不会污染当前状态。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#18
- 本 PR 包含：飞书冲突信号映射、晚到冲突处理、旧连接事件隔离，以及初始冲突、晚到冲突、日志兜底回归测试
- 明确不包含：跨设备 Bot 占用权、租约、心跳和释放机制；这些能力仍需在 cindy-server 独立实现
- 用户可见变化：飞书明确拒绝重复连接时，客户端会展示冲突而不是错误或已连接，并停止本机 WebSocket
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 代码；复用现有 feishuBot:conflict 展示链路。

## 怎么验证的

### 自动验证

- pnpm --filter @cindy/im test：150 tests passed
- pnpm --filter @cindy/im build：通过
- pnpm --filter @cindy/im lint：通过
- pnpm --filter @cindy/im run --if-present typecheck：通过（该 package 当前无 typecheck script，自动跳过）
- git diff --check：通过
- 最新 makecindy/main 基线上的 pnpm test:unit：packages/lizi-im 通过；全仓命令因与本 PR 无关的 Windows 环境问题整体失败，详见“未执行的验证”

### 手工验证

不涉及。

### 未执行的验证

全仓 pnpm test:unit 未整体通过，失败项均不触及本 PR 的 3 个文件：

- Desktop Python protocol 测试由本机默认 Python 3.6 执行，不支持 from __future__ import annotations；改用 Python 3.12 的定向复跑已通过（35 passed、2 skipped）
- Mobile 源码字符串断言受 Windows CRLF 影响
- @cindy/anthropic-compat-proxy 随机命中 Windows 排除端口并报 EACCES

后两项已由独立 PR #272 处理，本 PR 不重复包含其改动。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅飞书客户端 WebSocket 冲突识别和连接生命周期
- 回滚 / 降级方式：回滚本 PR 即恢复原有一次性判定与错误映射行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认并如实说明测试结果
