### PR TITLE
fix(desktop): 默认向 Codex 开放未标注模型

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -6,7 +6,7 @@
  *       efforts 缺失 → 合成 3 档(low/medium/high,默认 high);显式 [] → 不可调;
  *       supportsFastMode 缺失 → true;defaultEnabled 缺失 → 默认可见;
  *   - perAgent 覆盖块按 tab 应用(gpt 系 cc/codex 的 Fast / 窗口分叉);
- *   - tab 归属:服务端 agents > 仅 claude-code;
+ *   - tab 归属:服务端 agents > claude-code + codex 双 runtime;
  *   - 其它供应商永不受影响。
  * 另含 anthropic 权威清单 setter 的同款语义单测。
  */
@@ -45,20 +45,21 @@ describe('XD 网关权威模型清单重建', () => {
     expect(xdModels('codex')).toEqual([]);
   });
 
-  it('未登记模型的确定性默认:3 档 effort + fast=true + 仅 cc tab + 200k 窗口', () => {
+  it('未登记模型的确定性默认:3 档 effort + fast=true + 双 runtime + 200k 窗口', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([{ id: 'brand-new-model' }]);
 
-    const cc = xdModels('claude-code');
-    expect(cc.map((m) => m.id)).toEqual(['brand-new-model']);
-    expect(cc[0]).toMatchObject({
-      name: 'brand-new-model',
-      contextWindow: 200_000,
-      efforts: ['low', 'medium', 'high'],
-      defaultEffort: 'high',
-      supportsFastMode: true,
-    });
-    expect(xdModels('codex')).toEqual([]);
+    for (const agent of ['claude-code', 'codex'] as const) {
+      const models = xdModels(agent);
+      expect(models.map((m) => m.id)).toEqual(['brand-new-model']);
+      expect(models[0]).toMatchObject({
+        name: 'brand-new-model',
+        contextWindow: 200_000,
+        efforts: ['low', 'medium', 'high'],
+        defaultEffort: 'high',
+        supportsFastMode: true,
+      });
+    }
   });
 
   it('显式登记 efforts=[] 表示不可调,不合成 3 档;fast 显式 false 尊重', () => {

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -55,7 +55,7 @@ export interface XdGatewayAgentOverride {
 /** 服务端下发的 XD 网关聊天模型条目(shared/modelAccess ModelAccessGatewayModel 同形)。 */
 export interface XdGatewayModelInfo {
   id: string;
-  /** 进哪些 runtime tab;缺省 = 仅 claude-code 兜底。 */
+  /** 进哪些 runtime tab;缺省 = claude-code + codex。 */
   agents?: AgentKind[];
   name?: string;
   group?: string;
@@ -80,8 +80,7 @@ export interface XdGatewayModelInfo {
  * 列表完全以网关为准,不再由 OSS 产品目录决定)。未登录 / 拉取失败 / 空响应时
  * 保持空数组,绝不把产品目录里的静态模型冒充成网关实时可用模型。有值时 xd
  * 供应商的模型列表整体重建,每个条目:
- *  - tab 归属:服务端 `agents` > 目录同 id 条目的归属 > 仅 claude-code 兜底
- *    (网关 /v1/messages 跨供应商翻译覆盖面最广;Responses 协议不猜);
+ *  - tab 归属:服务端 `agents` > claude-code + codex 双 runtime 兜底;
  *  - 展示元数据逐字段:服务端条目 > 目录同 id 条目 > 合成默认(id 当展示名,
  *    口径同自定义 OAuth 模型发现,见 maker-ipc/register.ts oauthLogin);
  *  - 目录里有、网关没有 → 不展示。
@@ -395,8 +394,9 @@ function computeMerged(): Catalog {
     const models: Provider['models'] = {};
     for (const agent of agentKeys) models[agent] = [];
     for (const gm of gwModels) {
-      // tab 归属:服务端 agents > 仅 claude-code(网关 /v1/messages 翻译覆盖面最广,不猜)
-      const targetAgents: AgentKind[] = gm.agents && gm.agents.length > 0 ? gm.agents : ['claude-code'];
+      // 服务端未声明 runtime 时，默认同时开放给 Claude Code 与 Codex。
+      const targetAgents: AgentKind[] =
+        gm.agents && gm.agents.length > 0 ? gm.agents : ['claude-code', 'codex'];
       for (const agent of targetAgents) {
         if (!models[agent]) continue; // 未知 agent 键防御(wire 数据)
         const ov = gm.perAgent?.[agent] ?? {};

--- a/apps/desktop/src/shared/modelAccess.ts
+++ b/apps/desktop/src/shared/modelAccess.ts
@@ -56,7 +56,7 @@ export interface ModelAccessAgentOverride {
 
 export interface ModelAccessGatewayModel {
   id: string;
-  /** 进哪些 runtime tab;缺省 = 仅 claude-code(网关 /v1/messages 翻译覆盖面最广)。 */
+  /** 进哪些 runtime tab;缺省 = claude-code + codex。 */
   agents?: ('claude-code' | 'codex')[];
   name?: string;
   group?: string;


### PR DESCRIPTION
## 这次改了什么

### 摘要

当 model-access-server 返回的 XD 网关模型没有声明 `agents` 时，客户端此前只把模型放入 Claude Code。现在缺省同时投影到 Claude Code 和 Codex；服务端显式返回的单 runtime 或双 runtime 配置仍然优先。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：XD/Cindy 网关模型缺失 `agents` 时 Codex 不可选
- 本 PR 包含：调整 Desktop 模型目录 fallback；同步共享类型注释和回归测试
- 明确不包含：model-access-server 元数据和网关模型配置变更
- 用户可见变化：未声明 `agents` 的 Cindy 模型会同时出现在 Claude Code 与 Codex 模型列表
- 是否存在 breaking change：无；服务端显式 `agents` 继续拥有最高优先级

### UI 变化

不涉及 UI 结构或样式变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
结果：1 个测试文件通过，14 个测试通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全部 workspace 单元测试通过；Desktop 1111 个文件、11740 个测试通过（2 skipped），Mobile 244 个文件、2280 个测试通过，其余 workspace 全部 PASS
```

### 手工验证

不涉及。

### 未执行的验证

未启动 Desktop 做界面手工验证；本次为纯模型目录投影逻辑，已由定向测试和全量单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：缺失 runtime 元数据的模型默认开放范围扩大

### 影响与回滚

- 影响范围：仅 XD/Cindy 网关模型缺失或返回空 `agents` 时的客户端 tab 归属；显式 runtime 声明不受影响。
- 回滚 / 降级方式：回退本提交即可恢复仅 Claude Code 的 fallback；服务端也可显式下发 `agents` 收紧单个模型。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
