### PR TITLE
fix(mobile): 修复 Android 相册图片位置权限失败

### DIFF
--- a/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
+++ b/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
@@ -64,6 +64,15 @@ describe('resolveContextSheetMediaAssetForUpload', () => {
     expect(imageManipulator.manipulate).not.toHaveBeenCalled();
   });
 
+  it('Android 非 ERR_UNABLE_TO_LOAD 错误继续抛出,不延后真实故障', async () => {
+    const failure = Object.assign(new Error('Media library internal failure'), {
+      code: 'ERR_INTERNAL',
+    });
+    mediaLibrary.getAssetInfoAsync.mockRejectedValue(failure);
+
+    await expect(resolveContextSheetMediaAssetForUpload(asset())).rejects.toBe(failure);
+  });
+
   it('正常路径优先使用 full info 的 localUri 与尺寸', async () => {
     mediaLibrary.getAssetInfoAsync.mockResolvedValue({
       localUri: 'file:///storage/emulated/0/Pictures/Screenshot.png',

--- a/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
+++ b/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const platform = vi.hoisted(() => ({ os: 'android' }));
+const mediaLibrary = vi.hoisted(() => ({
+  getAssetInfoAsync: vi.fn(),
+}));
+const imageManipulator = vi.hoisted(() => ({
+  manipulate: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  Linking: { openSettings: vi.fn() },
+  Platform: { get OS() { return platform.os; } },
+}));
+vi.mock('expo-media-library/legacy', () => ({
+  getAssetInfoAsync: mediaLibrary.getAssetInfoAsync,
+  MediaType: { photo: 'photo' },
+  SortBy: { creationTime: 'creationTime' },
+}));
+vi.mock('expo-image-manipulator', () => ({
+  ImageManipulator: { manipulate: imageManipulator.manipulate },
+  SaveFormat: { JPEG: 'jpeg' },
+}));
+vi.mock('@/i18n', () => ({
+  i18n: { t: (key: string) => key },
+}));
+
+import {
+  resolveContextSheetMediaAssetForUpload,
+  type ContextSheetMediaAsset,
+} from '@/session/useContextSheetMediaAssets';
+
+function asset(overrides: Partial<ContextSheetMediaAsset> = {}): ContextSheetMediaAsset {
+  return {
+    id: 'asset-1',
+    filename: 'Screenshot.png',
+    uri: 'content://media/external/images/media/1',
+    width: 1080,
+    height: 2400,
+    ...overrides,
+  };
+}
+
+describe('resolveContextSheetMediaAssetForUpload', () => {
+  beforeEach(() => {
+    platform.os = 'android';
+    mediaLibrary.getAssetInfoAsync.mockReset();
+    imageManipulator.manipulate.mockReset();
+  });
+
+  it('Android 缺少媒体位置权限时回退列表 URI 与尺寸,继续图片上传解析', async () => {
+    mediaLibrary.getAssetInfoAsync.mockRejectedValue(Object.assign(
+      new Error('Unable to load asset'),
+      { code: 'ERR_UNABLE_TO_LOAD' },
+    ));
+
+    await expect(resolveContextSheetMediaAssetForUpload(asset())).resolves.toEqual({
+      filename: 'Screenshot.png',
+      uri: 'content://media/external/images/media/1',
+      width: 1080,
+      height: 2400,
+    });
+    expect(mediaLibrary.getAssetInfoAsync).toHaveBeenCalledWith('asset-1');
+    expect(imageManipulator.manipulate).not.toHaveBeenCalled();
+  });
+
+  it('正常路径优先使用 full info 的 localUri 与尺寸', async () => {
+    mediaLibrary.getAssetInfoAsync.mockResolvedValue({
+      localUri: 'file:///storage/emulated/0/Pictures/Screenshot.png',
+      width: 1440,
+      height: 3200,
+    });
+
+    await expect(resolveContextSheetMediaAssetForUpload(asset())).resolves.toEqual({
+      filename: 'Screenshot.png',
+      uri: 'file:///storage/emulated/0/Pictures/Screenshot.png',
+      width: 1440,
+      height: 3200,
+    });
+  });
+
+  it('iOS full info 失败时保留原错误,不把 ph:// 交给上传层', async () => {
+    platform.os = 'ios';
+    const failure = new Error('iCloud asset unavailable');
+    mediaLibrary.getAssetInfoAsync.mockRejectedValue(failure);
+
+    await expect(resolveContextSheetMediaAssetForUpload(asset({
+      uri: 'ph://asset-1',
+    }))).rejects.toBe(failure);
+  });
+});

--- a/apps/mobile/src/session/useContextSheetMediaAssets.ts
+++ b/apps/mobile/src/session/useContextSheetMediaAssets.ts
@@ -169,6 +169,14 @@ const HEIC_JPEG_COMPRESS = 0.9;
  * race 超时后系统下载仍在后台继续,用户重试时大概率已就位,重试即成功。
  */
 const ASSET_INFO_TIMEOUT_MS = 60_000;
+const ANDROID_ASSET_INFO_FALLBACK_ERROR_CODE = 'ERR_UNABLE_TO_LOAD';
+
+function isAndroidAssetInfoFallbackError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === ANDROID_ASSET_INFO_FALLBACK_ERROR_CODE;
+}
 
 async function getAssetInfoWithTimeout(assetId: string): Promise<MediaLibrary.AssetInfo> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -192,8 +200,9 @@ async function getAssetInfoWithTimeout(assetId: string): Promise<MediaLibrary.As
  * 把相册资产解析成可上传的 file:// 信息。iOS 的 ph:// 不是文件路径,
  * 必须经 getAssetInfoAsync 换 localUri(带 iCloud 下载超时兜底);iOS 拿不到
  * localUri 时直接报错——ph:// 喂给原生上传层只会变成下游玄学失败,就地把
- * 「照片没就位」说清楚;Android 的 full info 可能因未授予媒体位置权限失败,
- * 此时回退列表查询已返回的 content:// 与尺寸(原生上传可读),不为普通附件扩大权限。
+ * 「照片没就位」说清楚;Android 的 full info 可能因未授予媒体位置权限返回
+ * ERR_UNABLE_TO_LOAD,此时回退列表查询已返回的 content:// 与尺寸(原生上传可读),
+ * 不为普通附件扩大权限;其它错误继续抛出,避免把真实故障延后到下游。
  * HEIC / HEIF(iOS 相机默认格式)在这里就地转成 JPEG——附件类型白名单与模型图像
  * 接口都只认 jpeg/png/gif/webp,直接放行 HEIC 会在链路下游变成不可用附件。
  * 转 JPEG 的同一次 manipulate 里顺带把长边压到上传上限(见 mobileImagePreprocess),
@@ -206,7 +215,7 @@ export async function resolveContextSheetMediaAssetForUpload(
   try {
     info = await getAssetInfoWithTimeout(asset.id);
   } catch (error) {
-    if (Platform.OS !== 'android') throw error;
+    if (Platform.OS !== 'android' || !isAndroidAssetInfoFallbackError(error)) throw error;
   }
   const localUri = info?.localUri?.trim();
   if (!localUri && Platform.OS === 'ios') {

--- a/apps/mobile/src/session/useContextSheetMediaAssets.ts
+++ b/apps/mobile/src/session/useContextSheetMediaAssets.ts
@@ -13,6 +13,9 @@ export interface ContextSheetMediaAsset {
   filename: string;
   /** 展示用 URI(iOS ph:// / Android content://);渲染走 expo-image,RN Image 在新架构下不支持 ph://。 */
   uri: string;
+  /** 列表查询已返回的尺寸;Android full info 权限失败时供上传预处理继续使用。 */
+  width?: number;
+  height?: number;
 }
 
 export type ContextSheetMediaKind = 'recent' | 'screenshots';
@@ -59,6 +62,8 @@ async function fetchAssets(kind: ContextSheetMediaKind, first: number): Promise<
     id: asset.id,
     filename: asset.filename,
     uri: asset.uri,
+    width: asset.width,
+    height: asset.height,
   }));
 }
 
@@ -187,7 +192,8 @@ async function getAssetInfoWithTimeout(assetId: string): Promise<MediaLibrary.As
  * 把相册资产解析成可上传的 file:// 信息。iOS 的 ph:// 不是文件路径,
  * 必须经 getAssetInfoAsync 换 localUri(带 iCloud 下载超时兜底);iOS 拿不到
  * localUri 时直接报错——ph:// 喂给原生上传层只会变成下游玄学失败,就地把
- * 「照片没就位」说清楚;Android 保留 content:// 回退(原生上传可读)。
+ * 「照片没就位」说清楚;Android 的 full info 可能因未授予媒体位置权限失败,
+ * 此时回退列表查询已返回的 content:// 与尺寸(原生上传可读),不为普通附件扩大权限。
  * HEIC / HEIF(iOS 相机默认格式)在这里就地转成 JPEG——附件类型白名单与模型图像
  * 接口都只认 jpeg/png/gif/webp,直接放行 HEIC 会在链路下游变成不可用附件。
  * 转 JPEG 的同一次 manipulate 里顺带把长边压到上传上限(见 mobileImagePreprocess),
@@ -196,20 +202,27 @@ async function getAssetInfoWithTimeout(assetId: string): Promise<MediaLibrary.As
 export async function resolveContextSheetMediaAssetForUpload(
   asset: ContextSheetMediaAsset,
 ): Promise<{ uri: string; filename: string; width?: number; height?: number; optimized?: boolean }> {
-  const info = await getAssetInfoWithTimeout(asset.id);
-  const localUri = info.localUri?.trim();
+  let info: MediaLibrary.AssetInfo | undefined;
+  try {
+    info = await getAssetInfoWithTimeout(asset.id);
+  } catch (error) {
+    if (Platform.OS !== 'android') throw error;
+  }
+  const localUri = info?.localUri?.trim();
   if (!localUri && Platform.OS === 'ios') {
     throw new Error(i18n.t('interaction.contextSheet.photoNotReadable'));
   }
   const uri = localUri || asset.uri;
+  const width = typeof info?.width === 'number' ? info.width : asset.width;
+  const height = typeof info?.height === 'number' ? info.height : asset.height;
   if (!HEIC_EXT_PATTERN.test(asset.filename) && !HEIC_EXT_PATTERN.test(uri)) {
-    return { filename: asset.filename, uri, width: info.width, height: info.height };
+    return { filename: asset.filename, uri, width, height };
   }
   const context = ImageManipulator.manipulate(uri);
-  const width = typeof info.width === 'number' ? info.width : 0;
-  const height = typeof info.height === 'number' ? info.height : 0;
-  if (Math.max(width, height) > MOBILE_IMAGE_UPLOAD_MAX_LONG_EDGE) {
-    context.resize(width >= height
+  const resolvedWidth = width ?? 0;
+  const resolvedHeight = height ?? 0;
+  if (Math.max(resolvedWidth, resolvedHeight) > MOBILE_IMAGE_UPLOAD_MAX_LONG_EDGE) {
+    context.resize(resolvedWidth >= resolvedHeight
       ? { width: MOBILE_IMAGE_UPLOAD_MAX_LONG_EDGE }
       : { height: MOBILE_IMAGE_UPLOAD_MAX_LONG_EDGE });
   }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android 从“最近照片 / 截图”附加图片时，`expo-media-library` 的 `getAssetInfoAsync` 可能因为未授予 `ACCESS_MEDIA_LOCATION` 返回 `ERR_UNABLE_TO_LOAD`，导致上传在本地解析阶段中断。

本 PR 在 Android 资源信息读取返回 `ERR_UNABLE_TO_LOAD` 时退回相册列表已经返回的 URI 和尺寸，继续既有预处理与上传链路；其它错误仍原样抛出，且不新增媒体位置权限。iOS 仍要求把 `ph://` 解析成可读的 `localUri`，原有失败语义不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #282
- 本 PR 包含：Android 指定错误码回退、列表尺寸透传、Android 权限失败 / 非目标错误 / 正常解析 / iOS 失败语义回归测试
- 明确不包含：申请 `ACCESS_MEDIA_LOCATION`、修改 Expo 原生配置、改动 presign / OSS 上传协议
- 用户可见变化：未授予媒体位置权限时，从“最近照片 / 截图”选择的 Android 图片仍可继续上传
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/contextSheetMediaAssets.test.ts
结果：通过（1 file / 4 tests）

pnpm --filter mobile typecheck
结果：通过

pnpm --filter mobile test:scope
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree-root>
结果：通过（完整 pnpm test:unit 门禁，GATE_EXIT=0）
```

### 手工验证

不涉及：当前环境没有已连接的 Android 设备，也没有已启动的 iOS Simulator。

### 未执行的验证

- Android target SDK 36 真机从“最近照片 / 截图”选图上传：当前没有已连接 Android 设备。
- iOS 图片附件上传回归：当前没有已启动的 iOS Simulator 或可操作真机。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Mobile Context 面板相册图片的上传前资源解析。Android 新增失败回退；iOS 逻辑保持严格失败。
- 回滚 / 降级方式：回滚本 PR 即恢复旧行为。回退 URI 若已失效，既有预处理 / 本地文件读取仍会在 presign 前失败，不会发起无效上传请求。
- 原生层 / fingerprint：未修改 `app.json`、Expo plugin 或依赖，runtime fingerprint 不变。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次行为由代码注释与回归测试说明，无需独立文档）
- [x] 已确认测试结果或说明未执行原因
