### PR TITLE
fix(desktop): Telegram 偏好查询失败不再误报 Slack Hook 未连接 (#279)

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -2548,8 +2548,9 @@ describe('provider-specific not-connected 映射(issue #279)', () => {
   it('IPC 文案随 provider 区分: Telegram 不再复用 Slack 文案', () => {
     expect(hookNotConnectedIpcMessage('telegram')).toBe('Telegram provider is not connected');
     expect(hookNotConnectedIpcMessage('slack')).toBe('slack hook is not connected');
-    // 未指定 provider 的通用 Hook 失败保留原 Slack 语义(不回归旧调用点)。
-    expect(hookNotConnectedIpcMessage(null)).toBe('slack hook is not connected');
+    // 未指定 provider(null = 通用 Hook 失败)返回中性文案, 不把非 Slack 失败
+    // 误报成 Slack —— 与 HookNotConnectedError 的 null 语义一致(issue #279 review)。
+    expect(hookNotConnectedIpcMessage(null)).toBe('hook is not connected');
   });
 
   it('Telegram 未启用: getProviderWorkspacePrefs 拒绝 HookNotConnectedError(provider=telegram)', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -38,6 +38,7 @@ import {
 
 import {
   createHookControlManager,
+  hookNotConnectedIpcMessage,
   HookNotConnectedError,
   HookPrefsTimeoutError,
   providerForExternalKey,
@@ -2495,11 +2496,14 @@ describe('目录偏好远程读写(prefs.get / prefs.set / prefs.state 往返)',
     await expect(manager.getWorkspacePrefs()).rejects.toBeInstanceOf(HookPrefsTimeoutError);
   });
 
-  it('未连接: 立即拒绝 HookNotConnectedError', async () => {
+  it('未连接: 立即拒绝 HookNotConnectedError(provider=slack)', async () => {
     const store = memoryStore({ url: 'ws://127.0.0.1:1', enabled: false });
     const manager = makeManager(store);
     cleanups.push(() => manager.dispose());
-    await expect(manager.getWorkspacePrefs()).rejects.toBeInstanceOf(HookNotConnectedError);
+    const rejection = await manager.getWorkspacePrefs().catch((err: unknown) => err);
+    expect(rejection).toBeInstanceOf(HookNotConnectedError);
+    // Slack prefs 失败必须携带 slack provider —— IPC 层据此映射 Slack 文案。
+    expect((rejection as HookNotConnectedError).provider).toBe('slack');
   });
 
   it('主动推送(replyTo null): 只广播, 不惊动在途请求', async () => {
@@ -2532,6 +2536,39 @@ describe('目录偏好远程读写(prefs.get / prefs.set / prefs.state 往返)',
     await server.waitFor('prefs.get');
     sock.close(); // server 掉线
     await expect(promise).rejects.toBeInstanceOf(HookNotConnectedError);
+  });
+});
+
+describe('provider-specific not-connected 映射(issue #279)', () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    for (const c of cleanups.splice(0)) c();
+  });
+
+  it('IPC 文案随 provider 区分: Telegram 不再复用 Slack 文案', () => {
+    expect(hookNotConnectedIpcMessage('telegram')).toBe('Telegram provider is not connected');
+    expect(hookNotConnectedIpcMessage('slack')).toBe('slack hook is not connected');
+    // 未指定 provider 的通用 Hook 失败保留原 Slack 语义(不回归旧调用点)。
+    expect(hookNotConnectedIpcMessage(null)).toBe('slack hook is not connected');
+  });
+
+  it('Telegram 未启用: getProviderWorkspacePrefs 拒绝 HookNotConnectedError(provider=telegram)', async () => {
+    const store = memoryStore({
+      url: 'ws://127.0.0.1:1',
+      enabled: true,
+      telegramEnabled: false,
+    });
+    const manager = makeManager(store);
+    cleanups.push(() => manager.dispose());
+    const rejection = await manager
+      .getProviderWorkspacePrefs('telegram')
+      .catch((err: unknown) => err);
+    expect(rejection).toBeInstanceOf(HookNotConnectedError);
+    // Telegram 偏好失败必须指向 Telegram provider —— 否则 Slack 在线时会被误诊断线。
+    expect((rejection as HookNotConnectedError).provider).toBe('telegram');
+    expect(hookNotConnectedIpcMessage((rejection as HookNotConnectedError).provider)).toBe(
+      'Telegram provider is not connected',
+    );
   });
 });
 

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -53,6 +53,7 @@ import {
 } from './store.js';
 import {
   createHookControlManager,
+  hookNotConnectedIpcMessage,
   HookNotConnectedError,
   HookPrefsTimeoutError,
   type HookControlManager,
@@ -199,10 +200,11 @@ function currentAccountFingerprint(): string | null {
   return createHash('sha256').update(fingerprintSource).digest('base64url').slice(0, 22);
 }
 
-/** prefs 往返错误 -> IPC 错误码(规则 13)。 */
+/** prefs 往返错误 -> IPC 错误码(规则 13)。not-connected 文案随 provider 区分,
+ *  Telegram 偏好查询失败不再误报 Slack Hook 断线(issue #279)。 */
 function throwHookPrefsError(err: unknown): never {
   if (err instanceof HookNotConnectedError) {
-    throwIpcError('HOOK_NOT_CONNECTED', 'slack hook is not connected');
+    throwIpcError('HOOK_NOT_CONNECTED', hookNotConnectedIpcMessage(err.provider));
   }
   if (err instanceof HookPrefsTimeoutError) {
     throwIpcError(

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -304,12 +304,37 @@ export interface HookSlackToolAvailability {
   bindings: Array<{ teamId: string; teamName: string | null }>;
 }
 
-/** 连接不在线时的 prefs 读写失败(IPC 层映射 HOOK_NOT_CONNECTED)。 */
+/**
+ * 连接不在线时的 prefs 读写失败(IPC 层映射 HOOK_NOT_CONNECTED)。
+ *
+ * provider 记录失败发生在哪条 transport / 服务上: Slack 与 Telegram 各自独立
+ * 部署, 复用同一个错误类时必须带上来源, 否则 Telegram 偏好查询失败会被
+ * 误诊成 Slack 断线(见 issue #279)。null = 未指定 provider 的通用 Hook 失败。
+ */
 export class HookNotConnectedError extends Error {
-  constructor() {
-    super('slack hook connection is not connected');
+  readonly provider: HookProvider | null;
+  constructor(provider: HookProvider | null = null) {
+    super(
+      provider === 'telegram'
+        ? 'telegram provider connection is not connected'
+        : provider === 'slack'
+          ? 'slack hook connection is not connected'
+          : 'hook connection is not connected',
+    );
     this.name = 'HookNotConnectedError';
+    this.provider = provider;
   }
+}
+
+/**
+ * not-connected 失败的 IPC 面向文案(provider-specific)。Telegram 走独立服务,
+ * 失败必须明确指向 Telegram provider 而不是 Slack Hook; Slack / 未指定 provider
+ * 保留原 Slack 语义。抽成纯函数以便在 IPC 组装层复用并单测(不牵扯 electron)。
+ */
+export function hookNotConnectedIpcMessage(provider: HookProvider | null): string {
+  return provider === 'telegram'
+    ? 'Telegram provider is not connected'
+    : 'slack hook is not connected';
 }
 
 /** prefs 往返超时 —— server 大概率是不认识 prefs.* 帧的旧版本(丢帧不应答)。 */
@@ -597,7 +622,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
   function drainPendingPrefs(): void {
     for (const [, pending] of pendingPrefs) {
       clearTimeout(pending.timer);
-      pending.reject(new HookNotConnectedError());
+      pending.reject(new HookNotConnectedError('slack'));
     }
     pendingPrefs.clear();
   }
@@ -606,7 +631,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
   function drainPendingProviderPrefs(): void {
     for (const [, pending] of pendingProviderPrefs) {
       clearTimeout(pending.timer);
-      pending.reject(new HookNotConnectedError());
+      pending.reject(new HookNotConnectedError('telegram'));
     }
     pendingProviderPrefs.clear();
   }
@@ -627,13 +652,13 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
   function sendPrefsRequest(build: (requestId: string) => HookMessage): Promise<HookPrefsView> {
     const t = transport;
     if (t === null || status !== 'connected') {
-      return Promise.reject(new HookNotConnectedError());
+      return Promise.reject(new HookNotConnectedError('slack'));
     }
     const requestId = randomUUID();
     const frame = build(requestId);
     return new Promise<HookPrefsView>((resolve, reject) => {
       if (!t.send(frame)) {
-        reject(new HookNotConnectedError());
+        reject(new HookNotConnectedError('slack'));
         return;
       }
       const timer = setTimeout(() => {
@@ -657,12 +682,12 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       !store.get().telegramEnabled ||
       bindingId === null
     ) {
-      return Promise.reject(new HookNotConnectedError());
+      return Promise.reject(new HookNotConnectedError('telegram'));
     }
     const requestId = randomUUID();
     return new Promise<ProviderPrefsView>((resolve, reject) => {
       if (!t.send(build(requestId, bindingId))) {
-        reject(new HookNotConnectedError());
+        reject(new HookNotConnectedError('telegram'));
         return;
       }
       const timer = setTimeout(() => {
@@ -1621,7 +1646,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
         if (msg.payload.bindingId !== pending.bindingId) {
           pendingProviderPrefs.delete(msg.payload.replyTo);
           clearTimeout(pending.timer);
-          pending.reject(new HookNotConnectedError());
+          pending.reject(new HookNotConnectedError('telegram'));
           log.warn('provider prefs state bindingId mismatch, dropped');
           return;
         }
@@ -1630,7 +1655,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
         if (msg.payload.bindingId !== currentBindingId) {
           pendingProviderPrefs.delete(msg.payload.replyTo);
           clearTimeout(pending.timer);
-          pending.reject(new HookNotConnectedError());
+          pending.reject(new HookNotConnectedError('telegram'));
           log.warn('provider prefs reply for a superseded binding, dropped');
           return;
         }

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -328,13 +328,17 @@ export class HookNotConnectedError extends Error {
 
 /**
  * not-connected 失败的 IPC 面向文案(provider-specific)。Telegram 走独立服务,
- * 失败必须明确指向 Telegram provider 而不是 Slack Hook; Slack / 未指定 provider
- * 保留原 Slack 语义。抽成纯函数以便在 IPC 组装层复用并单测(不牵扯 electron)。
+ * 失败必须明确指向 Telegram provider 而不是 Slack Hook; Slack 保留原 Slack 语义;
+ * provider 未指定(null = 通用 Hook 失败, 见 HookNotConnectedError)返回中性文案,
+ * 避免任何默认参数或未来新增调用点又把非 Slack 失败误报成 Slack(issue #279)。
+ * 抽成纯函数以便在 IPC 组装层复用并单测(不牵扯 electron)。
  */
 export function hookNotConnectedIpcMessage(provider: HookProvider | null): string {
   return provider === 'telegram'
     ? 'Telegram provider is not connected'
-    : 'slack hook is not connected';
+    : provider === 'slack'
+      ? 'slack hook is not connected'
+      : 'hook is not connected';
 }
 
 /** prefs 往返超时 —— server 大概率是不认识 prefs.* 帧的旧版本(丢帧不应答)。 */

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -148,6 +148,11 @@ export function useHookWorkspacePrefs(
         : 'slack'
       : null;
   const lastReadyIdentityRef = useRef<string | null>(readyIdentity);
+  // Mount-time fetch gate: mirror the latest ready identity so the mount effect
+  // can skip the initial fetch when this provider is disabled/unbound, without
+  // taking readyIdentity as an effect dependency (which would re-subscribe).
+  const readyIdentityRef = useRef<string | null>(readyIdentity);
+  readyIdentityRef.current = readyIdentity;
   const fetchRevisionRef = useRef(0);
   const mutationRevisionRef = useRef(0);
   const telegramBindingIdRef = useRef<string | null>(telegramBindingId);
@@ -208,7 +213,12 @@ export function useHookWorkspacePrefs(
             if (view.provider === 'telegram') applyIncoming(view);
           })
         : window.electronAPI.hookControl.onPrefsChanged(applyIncoming);
-    void fetchPrefs();
+    // Only fetch on mount when the provider is actually reachable (connected and,
+    // for Telegram, a confirmed binding). A disabled/unbound provider would
+    // otherwise issue a meaningless prefs IPC that fails HOOK_NOT_CONNECTED and
+    // logs a misleading Main ERROR (issue #279); the ready-edge effect below
+    // fetches once the provider later becomes reachable.
+    if (readyIdentityRef.current !== null) void fetchPrefs();
     // 桌面新会话默认设置: 未显式设置字段的生效值解析源, 面板打开时取一次即可
     void window.electronAPI.maker
       .imDefaultSettingsGet()

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -147,12 +147,11 @@ export function useHookWorkspacePrefs(
           : `telegram:${telegramBindingId}`
         : 'slack'
       : null;
-  const lastReadyIdentityRef = useRef<string | null>(readyIdentity);
-  // Mount-time fetch gate: mirror the latest ready identity so the mount effect
-  // can skip the initial fetch when this provider is disabled/unbound, without
-  // taking readyIdentity as an effect dependency (which would re-subscribe).
-  const readyIdentityRef = useRef<string | null>(readyIdentity);
-  readyIdentityRef.current = readyIdentity;
+  // Initialised to null (never a real identity) so the ready-edge effect below
+  // is the single fetch trigger: it performs the first fetch on mount only when
+  // the provider is actually reachable, and cannot double-fetch with a separate
+  // mount effect (issue #279 review).
+  const lastReadyIdentityRef = useRef<string | null>(null);
   const fetchRevisionRef = useRef(0);
   const mutationRevisionRef = useRef(0);
   const telegramBindingIdRef = useRef<string | null>(telegramBindingId);
@@ -213,12 +212,9 @@ export function useHookWorkspacePrefs(
             if (view.provider === 'telegram') applyIncoming(view);
           })
         : window.electronAPI.hookControl.onPrefsChanged(applyIncoming);
-    // Only fetch on mount when the provider is actually reachable (connected and,
-    // for Telegram, a confirmed binding). A disabled/unbound provider would
-    // otherwise issue a meaningless prefs IPC that fails HOOK_NOT_CONNECTED and
-    // logs a misleading Main ERROR (issue #279); the ready-edge effect below
-    // fetches once the provider later becomes reachable.
-    if (readyIdentityRef.current !== null) void fetchPrefs();
+    // The ready-edge effect below performs the initial prefs fetch (only when
+    // reachable). The subscription set up here just needs to exist first so no
+    // server push is missed before that fetch resolves.
     // 桌面新会话默认设置: 未显式设置字段的生效值解析源, 面板打开时取一次即可
     void window.electronAPI.maker
       .imDefaultSettingsGet()
@@ -234,8 +230,12 @@ export function useHookWorkspacePrefs(
     };
   }, [fetchPrefs, provider]);
 
-  // 断线 -> 重连成功或 Telegram 绑定身份变化：自动重拉对应 provider 快照。
-  // 只看布尔 ready 会让 A 换绑 B 时继续展示 A 的偏好。
+  // 唯一的拉取触发点: 初次挂载、断线 -> 重连成功、或 Telegram 绑定身份变化时,
+  // 拉取对应 provider 的快照。readyIdentity 为 null(provider 未连接/未绑定)时
+  // 不发起无意义的 prefs IPC —— 否则会以 HOOK_NOT_CONNECTED 失败并在 Main 侧
+  // 打出误导性的 Slack ERROR(issue #279)。lastReadyIdentityRef 初始为 null,
+  // 保证 provider 首次可用即拉取且同一身份不重复触发; 只看布尔 ready 会让 A
+  // 换绑 B 时继续展示 A 的偏好。
   useEffect(() => {
     if (readyIdentity !== null && readyIdentity !== lastReadyIdentityRef.current) {
       void fetchPrefs();

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
@@ -111,9 +111,15 @@ describe('useHookWorkspacePrefs provider isolation', () => {
 
     // Telegram disabled/unbound: 不发起无意义的 provider prefs IPC(issue #279)——
     // 否则会以 HOOK_NOT_CONNECTED 失败并在 Main 侧打出误导性的 Slack ERROR。
-    await waitFor(() => expect(result.current.editable).toBe(false));
+    // 用 effect 侧信号(imDefaultSettingsGet 在挂载 effect 内无条件调用)确认 effect
+    // 已 flush 再做否定断言 —— editable 首帧即为 false, 直接 waitFor 它会在 effect
+    // 跑之前 resolve, 捕捉不到「挂载即发 IPC」的回归(issue #279 review)。
+    await waitFor(() =>
+      expect(window.electronAPI.maker.imDefaultSettingsGet).toHaveBeenCalled(),
+    );
     expect(getProviderWorkspacePrefs).not.toHaveBeenCalled();
     expect(getWorkspacePrefs).not.toHaveBeenCalled();
+    expect(result.current.editable).toBe(false);
 
     rerender({ hook: TELEGRAM_CONFIRMED });
     await waitFor(() => expect(getProviderWorkspacePrefs).toHaveBeenCalledTimes(1));

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
@@ -104,19 +104,28 @@ describe('useHookWorkspacePrefs provider isolation', () => {
     };
   });
 
-  it('Slack 已连接时再确认 Telegram 绑定，也会沿 provider-ready 边沿重新拉偏好', async () => {
+  it('Telegram 未连接时不发起 provider prefs 请求，绑定确认后沿 ready 边沿首次拉取', async () => {
     const { result, rerender } = renderHook(({ hook }) => useHookWorkspacePrefs(hook, 'telegram'), {
       initialProps: { hook: BASE_HOOK },
     });
 
-    await waitFor(() => expect(getProviderWorkspacePrefs).toHaveBeenCalledTimes(1));
+    // Telegram disabled/unbound: 不发起无意义的 provider prefs IPC(issue #279)——
+    // 否则会以 HOOK_NOT_CONNECTED 失败并在 Main 侧打出误导性的 Slack ERROR。
+    await waitFor(() => expect(result.current.editable).toBe(false));
+    expect(getProviderWorkspacePrefs).not.toHaveBeenCalled();
     expect(getWorkspacePrefs).not.toHaveBeenCalled();
-    expect(result.current.editable).toBe(false);
 
     rerender({ hook: TELEGRAM_CONFIRMED });
-    await waitFor(() => expect(getProviderWorkspacePrefs).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getProviderWorkspacePrefs).toHaveBeenCalledTimes(1));
+    expect(getWorkspacePrefs).not.toHaveBeenCalled();
     await waitFor(() => expect(result.current.editable).toBe(true));
     expect(result.current.hint).toBeNull();
+  });
+
+  it('Slack 已连接时挂载即拉取偏好，不触碰 Telegram 通道', async () => {
+    renderHook(() => useHookWorkspacePrefs(BASE_HOOK, 'slack'));
+    await waitFor(() => expect(getWorkspacePrefs).toHaveBeenCalledTimes(1));
+    expect(getProviderWorkspacePrefs).not.toHaveBeenCalled();
   });
 
   it('Telegram 换绑时立即隔离旧偏好，直到新 binding 的快照返回', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Telegram provider 未启用或未绑定时，设置页会触发 `maker:hook-control:provider-prefs-get`，Main 侧却把失败记成 `[HOOK_NOT_CONNECTED] slack hook is not connected`——因为 `HookNotConnectedError` 对 Slack / Telegram 复用了同一句硬编码 Slack 文案。结果：Slack 已成功握手且存在 confirmed 绑定，却被误诊为断线。

本 PR 让 not-connected 失败按 provider 区分文案，并在 Renderer 侧对未连接/未绑定的 provider 不再发起无意义的 prefs IPC，从根上消除这条误导性 Main ERROR。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#279
- 本 PR 包含：
  - `HookNotConnectedError` 携带 `provider`（`slack` / `telegram` / `null`），8 处构造点按来源标注；新增纯函数 `hookNotConnectedIpcMessage(provider)` 供 IPC 层按 provider 生成文案。
  - `throwHookPrefsError` 依据 `err.provider` 输出 Telegram / Slack 对应文案；Slack 绑定类 handler 保留原 Slack 语义。
  - Renderer `useHookWorkspacePrefs` 挂载拉取加 `readyIdentity` 门禁：provider 未连接/未绑定时不发起 prefs IPC，变为可用后由 ready 边沿拉取一次。
  - 补充 provider-specific 错误映射测试、Telegram disabled 不发 IPC 的回归测试，以及 Slack 已连接仍挂载拉取的守护测试。
- 明确不包含：不改变 Slack / Telegram 的 transport、绑定与 prefs 协议行为。
- 用户可见变化：Slack 在线、Telegram 关闭时设置页不再产生误导性的 Main ERROR；Telegram 偏好查询真正失败时错误明确指向 Telegram。
- 是否存在 breaking change：无。

### UI 变化

不涉及（仅错误文案与 IPC 触发时机，UI 布局/样式无变化）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/main/hook-control/__tests__/transport-manager.test.ts \
  src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
结果：2 文件通过，84 tests passed（含新增 provider-specific 映射与 Telegram disabled 门禁用例）

pnpm --filter desktop run typecheck
结果：通过（tsc --noEmit 无报错）
```

### 手工验证

不涉及（worktree 会话内改动不随宿主 dev 实例热更/重启生效，运行时验证交由 reviewer / CI）。

### 未执行的验证

仓库根 `pnpm test:unit` 全量运行本地实际退出码为 1，失败项均为**本机环境性/既有失败，与本改动无关**，且都不在 hook-control 或本 PR 触碰的任何文件内：

- `scriptRunnerPythonProtocol.test.ts`（3 项）：本机 Python 为 3.6.8，`from __future__ import annotations` 需 Python ≥ 3.7。
- `server.test.ts`（1 项）：`EACCES: permission denied 127.0.0.1:<port>`，Windows 环回端口绑定权限限制。
- mobile `chatQuoteCrossDevice.test.ts`（1 项）：mobile composer 源码字符串断言漂移。
- `right-sidebar/plugins/review/plugin.test.ts`（1 项）：`beforeEach` 在全量并发下 hook 超时。

本改动相关的 hook-control 单测（84）与 desktop typecheck 均已通过；全量门禁以 CI 为准。

## 风险

### 风险分类

- [x] 无已知风险

（不涉及 SQLite/migration、system prompt、协议兼容、原生层/OTA、跨平台差异；错误文案与 IPC 触发时机调整不改变 wire 协议。）

### 影响与回滚

- 影响范围：Desktop IM Hook 设置页的 Slack/Telegram 偏好查询错误文案与 Telegram 侧 prefs IPC 触发时机。
- 回滚 / 降级方式：直接 revert 本 PR 即可，无数据/协议迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
