### PR TITLE
fix(desktop): 冷启动后恢复 Slack Hook 会话创建

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -5296,6 +5296,22 @@ app.on('ready', async () => {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+      // Hook ingress has the same hard dependency on the current owner's DB as
+      // the personal IM channel. Activate it from this authoritative Main-side
+      // readiness point instead of relying only on the renderer's later
+      // fire-and-forget app:ready-for-bot signal. That signal can be lost during
+      // cold-start auto-login or an owner remount, leaving an enabled Hook
+      // permanently disconnected until the user toggles it.
+      try {
+        startHookControlAccount();
+      } catch (err) {
+        // Hook is an optional account integration. A damaged config or endpoint
+        // must not roll back an otherwise healthy owner DB; the renderer's
+        // compatibility signal below provides a later retry.
+        dbClientLog.warn('hook-control activation after owner DB ready failed (non-fatal)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       attemptStartScheduler();
       attemptStartEmbeddingHost();
       // 旧「资料本地覆写」方案退役(2026-07)的一次性清理:清当前账号名下的
@@ -5435,14 +5451,12 @@ app.on('ready', async () => {
   im.registerIpc();
   // 挂业务 orchestrator: 订阅 feishuIm.onMessage / .onCardAction。orchestrator
   // 必须在 createWindow 前挂好,避免 renderer 起来后第一波 IPC / event 找不到
-  // handler。bot 的 WS 长连接此处不启动 —— 由 renderer 在用户登录 + localDb 就绪
-  // 后通过 'app:ready-for-bot' IPC 触发(见下方 handler)。
+  // handler。FeishuBot 的 WS 长连接此处不启动 —— 由 renderer 在用户登录 +
+  // localDb 就绪后通过 'app:ready-for-bot' IPC 触发(见下方 handler)。
   startImOrchestrators();
-  // Renderer → main 的 "应用真正就绪" 信号。LocalDbGate 在 localDb.ensureReady
-  // 成功之后调一次。在此之前 bot 不上线 —— 否则会出现"bot 已上线但 localDb 未
-  // ready, 用户回消息直接 500"的 race(2026-05-07 王韬反馈)。
-  // 多次调用是幂等的(startImConnection 内部 connectionStarted 守卫),
-  // renderer remount / 切账号都不会重复连。
+  // Renderer → main 的 "应用真正就绪" 兼容信号。LocalDbGate 在
+  // localDb.ensureReady 成功之后调一次。Hook 已在 localDb onReady 的 Main
+  // 权威时点激活，这里保留幂等兜底；FeishuBot 仍由本信号启动。
   ipcMain.handle('app:ready-for-bot', (event) => {
     assertTrustedAppRendererEvent(event);
     startHookControlAccount();

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -157,6 +157,112 @@ describe('hook-control runtime capability gate', () => {
     expect(createTransport).not.toHaveBeenCalled();
     manager.dispose();
   });
+
+  it('cold-start activation connects an enabled Hook after the owner DB becomes ready', () => {
+    const dispose = vi.fn();
+    const createTransport = vi.fn((_opts: HookTransportOpts) => ({
+      send: () => true,
+      dispose,
+    }));
+    const manager = makeManager(
+      memoryStore({
+        url: 'wss://hook.example',
+        enabled: true,
+      }),
+      {
+        accountInitiallyActive: false,
+        isAvailable: () => true,
+        createTransport,
+      },
+    );
+
+    manager.sync();
+    expect(createTransport).not.toHaveBeenCalled();
+
+    manager.activateAccount();
+    expect(createTransport).toHaveBeenCalledOnce();
+    expect(manager.snapshot().status).toBe('connecting');
+
+    manager.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it('leaving local mode reconnects only after a cloud account lifecycle activates', async () => {
+    let available = false;
+    const createTransport = vi.fn((_opts: HookTransportOpts) => ({
+      send: () => true,
+      dispose: () => {},
+    }));
+    const manager = makeManager(
+      memoryStore({
+        url: 'wss://hook.example',
+        enabled: true,
+      }),
+      {
+        accountInitiallyActive: false,
+        isAvailable: () => available,
+        createTransport,
+      },
+    );
+
+    manager.activateAccount();
+    expect(createTransport).not.toHaveBeenCalled();
+
+    await manager.deactivateAccount();
+    available = true;
+    manager.activateAccount();
+    expect(createTransport).toHaveBeenCalledOnce();
+
+    manager.dispose();
+  });
+
+  it('late dispatch during owner shutdown receives a structured disabled ack', async () => {
+    const transportOpts: HookTransportOpts[] = [];
+    const createTransport = vi.fn((opts: HookTransportOpts) => {
+      transportOpts.push(opts);
+      return {
+        send: () => true,
+        dispose: () => {},
+      };
+    });
+    const manager = makeManager(
+      memoryStore({
+        url: 'wss://hook.example',
+        enabled: true,
+      }),
+      { createTransport },
+    );
+    manager.sync();
+    await manager.deactivateAccount();
+
+    const staleOnMessage = transportOpts[0]?.onMessage;
+    if (!staleOnMessage) throw new Error('transport callback was not captured');
+    const sent: HookMessage[] = [];
+    staleOnMessage(
+      makeTaskDispatch({
+        requestId: 'late-owner-dispatch',
+        externalKey: 'slack:C1:1.1',
+        workspace: 'chat',
+        prompt: 'must not cross the owner boundary',
+      }),
+      (message) => {
+        sent.push(message);
+        return true;
+      },
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: 'task.ack',
+      payload: {
+        requestId: 'late-owner-dispatch',
+        result: 'rejected',
+        reason: 'disabled',
+      },
+    });
+
+    manager.dispose();
+  });
 });
 
 async function startServer(): Promise<{ wss: WebSocketServer; url: string }> {

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -681,8 +681,9 @@ export function registerHookControlIpc(): void {
   });
 
   // Account teardown is orchestrated before its DB closes. This listener is a
-  // fail-closed backstop for signed-out/local sessions; activation still waits
-  // for app:ready-for-bot after the next owner DB is ready.
+  // fail-closed backstop for signed-out/local sessions; activation waits for
+  // the next owner DB readiness callback (with app:ready-for-bot as a
+  // compatibility retry).
   disposeAuthListener = authManager.onAuthStateChange(() => {
     if (!hookControlAvailable()) {
       void stopHookControlAccount().catch((err: unknown) => {
@@ -696,7 +697,7 @@ export function registerHookControlIpc(): void {
   log.info('hook-control ipc registered');
 }
 
-/** Called by app:ready-for-bot after the current account DB is ready. */
+/** Called after the current account DB is ready; app:ready-for-bot may retry it. */
 export function startHookControlAccount(): void {
   if (!hookControlAvailable()) return;
   ensureInstances().manager.activateAccount();

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -1465,6 +1465,21 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
     send: (m: HookMessage) => boolean,
   ): void {
     if (!accountActive) {
+      if (msg.type === 'task.dispatch') {
+        log.info(
+          `task.dispatch rejected after account ingress closed: requestId=${msg.payload.requestId}`,
+        );
+        send(
+          makeTaskAck({
+            requestId: msg.payload.requestId,
+            result: 'rejected',
+            reason: 'disabled',
+            sessionId: null,
+            queuePosition: null,
+          }),
+        );
+        return;
+      }
       log.info(`hook frame dropped after account ingress closed: ${msg.type}`);
       return;
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复已启用的 Slack Hook 在冷启动自动登录或 owner 重新挂载后可能一直不连接的问题。

根因是 Hook 账号激活只依赖 renderer 稍后 fire-and-forget 的 `app:ready-for-bot` 信号；该信号在冷启动自动登录或 owner remount 期间可能丢失，导致已保存的 Hook 配置保持断开，Slack 消息无法进入 `task.dispatch` 和会话创建链路。

本 PR 将 Hook 激活移到 Main 侧 owner DB ready 的权威时点，同时保留原 renderer 信号作为幂等兼容重试；账号入口关闭后若仍收到迟到的 `task.dispatch`，会返回结构化 `disabled` ack，而不是静默丢弃。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #217
- 本 PR 包含：owner DB ready 后激活 Hook；保留 `app:ready-for-bot` 兼容重试；迟到 dispatch 的结构化拒绝；冷启动、退出 local mode、owner shutdown 回归测试
- 明确不包含：Slack `/new` 被旧 Cindy-Maker 应用接管的问题（#286）；Telegram provider prefs 错误文案问题（#279）
- 用户可见变化：冷启动后无需手动切换 Hook 开关，Slack 普通消息即可创建/继续 Cindy Hook 会话并执行 Agent turn
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
$env:PATH = 'C:\Users\XINDONG\AppData\Local\Programs\Python\Python312;' + $env:PATH
pnpm test:unit
结果：Windows 原生环境全部通过（Python 3.12.2，退出码 0）

pnpm --filter desktop run --if-present typecheck
结果：通过

git diff --check upstream/main...HEAD
结果：通过
```

### 手工验证

Windows，已登录 cloud owner 且 Slack Hook 已绑定：

1. 冷启动 Desktop；
2. 日志出现 `handshake complete with cindy-slack-hook`，绑定状态为 1；
3. 在 Slack 直接发送普通消息；
4. Desktop 收到 `task.dispatch`，创建/继续 Hook 会话并执行 Agent turn；
5. Slack 收到新版 **Cindy** 的正常回复。

手工测试通过。`/new` 由旧 **Cindy-Maker** 回复的现象属于独立的 Slack App 命令归属问题，已由 #286 跟踪，不是本 PR 回归。

### 未执行的验证

- 未在 macOS 实机手工验证；改动使用跨平台 TypeScript/Node 生命周期逻辑，无平台专属 API。
- 账号切换和退出 local mode 未逐项手工验证，已补对应 manager 回归测试。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：账号生命周期与 Hook 连接启动时序

### 影响与回滚

- 影响范围：Desktop Main 的 Hook account activation、owner shutdown 后迟到 dispatch 的 ack，以及相关单元测试。
- 回滚 / 降级方式：回滚本提交即可恢复由 `app:ready-for-bot` 单独触发 Hook 激活的旧行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需用户文档变更）
- [x] 已确认测试结果或说明未执行原因
