### PR TITLE
fix(mobile/ios): archive 关闭 Explicitly Built Modules 规避 WechatOpenSDK 解析失败

### DIFF
--- a/apps/mobile/scripts/build-ios.mjs
+++ b/apps/mobile/scripts/build-ios.mjs
@@ -161,6 +161,10 @@ function buildIpa(env, region) {
     '-archivePath', archivePath, '-sdk', 'iphoneos', 'archive',
     'CODE_SIGN_STYLE=Manual', `DEVELOPMENT_TEAM=${sign.teamId}`,
     `PROVISIONING_PROFILE_SPECIFIER=${sign.profileName}`, `CODE_SIGN_IDENTITY=${sign.identity}`,
+    // Xcode 26 默认开 Explicitly Built Modules,冷构建下 Swift 预扫描解析不到
+    // WechatOpenSDK(post_install 临时落位的手写 modulemap),报 unable to resolve
+    // module dependency。回退隐式模块构建规避(命令行 override,不进包/不影响 fingerprint)。
+    'SWIFT_ENABLE_EXPLICIT_MODULES=NO', 'CLANG_ENABLE_EXPLICIT_MODULES=NO',
   ], { env });
   run('xcodebuild', ['-exportArchive', '-archivePath', archivePath, '-exportOptionsPlist', plistPath, '-exportPath', exportDir], { env });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

打包机升级到 Xcode 26.6 / Swift 6.3.3 后,iOS 冷构建 archive 失败:

```
error: unable to resolve module dependency: 'WechatOpenSDK'
error: Unable to resolve module dependency: 'WechatOpenSDK' (in target 'Cindy' from project 'Cindy')
** ARCHIVE FAILED **
```

Xcode 26 默认开启 **Explicitly Built Modules(显式预建模块)**。`WechatOpenSDK` 是纯 ObjC 静态库、自身不带 modulemap,靠 `with-wechat-opensdk-modulemap` 插件在 Podfile `post_install` 期把手写 `module.modulemap` 临时拷到 SDK 头文件旁(非标准布局)。冷构建时 Swift 依赖预扫描解析不到这个模块 → Cindy target 编译失败。

本 PR 给 `apps/mobile/scripts/build-ios.mjs` 的 `xcodebuild archive` 加两个命令行 build setting override(`SWIFT_ENABLE_EXPLICIT_MODULES=NO` / `CLANG_ENABLE_EXPLICIT_MODULES=NO`),回退隐式模块构建规避该问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(打包机 Xcode 26 工具链导致的构建环境问题)
- 本 PR 包含:仅 `build-ios.mjs` 的 `xcodebuild archive` 增加两个显式模块开关 override
- 明确不包含:发布链 `release-ios-local.mjs`(由打包脚本仓 kit 投放、本仓 gitignore,已在打包脚本仓同步同样修复)
- 用户可见变化:无(仅影响构建期,不进包)
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run typecheck   # tsc --noEmit
结果:通过(无 error TS)

pnpm test:unit                        # 仓库根全量单元测试
结果:各 workspace 全 PASS / SKIP,无 FAIL
```

### 手工验证

打包机(macOS + Xcode 26.6)通过发布链跑冷构建:archive 不再报 `unable to resolve module dependency: 'WechatOpenSDK'`,成功产出签名 `.ipa`。
(注:打包机实际走的是发布链 `release-ios-local.mjs`,与本 PR 的 `build-ios.mjs` 是同一处 `xcodebuild archive`、同一 override;发布链侧修复已合入打包脚本仓。)

### 未执行的验证

`pnpm mobile:build:ios`(即 `build-ios.mjs` 路径)未在本机单独完整跑一遍 archive:当前出包链路走发布链脚本,而本文件的 archive 命令与发布链逐字一致、加的是同一 override,故未重复执行整包构建。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

> 说明:改动是 `xcodebuild` 的命令行 build setting override,**只作用于 archive 编译阶段,不写入 app.json / xcodeproj / Podfile,不进包**,因此不改变 Expo fingerprint、不影响 runtimeVersion / OTA 兼容;对旧版 Xcode 该 setting 被忽略,无副作用。

### 影响与回滚

- 影响范围:仅 iOS `xcodebuild archive` 编译阶段(`build-ios.mjs`);不影响 `-exportArchive`、不影响产物内容。
- 回滚 / 降级方式:删除新增的 `SWIFT_ENABLE_EXPLICIT_MODULES=NO` / `CLANG_ENABLE_EXPLICIT_MODULES=NO` 两个参数即可完全还原。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
