### PR TITLE
fix(desktop): Codex 本机 CLI 凭证自动继承补绑定,消除「已连接」假报

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexAuthBindingClaim.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexAuthBindingClaim.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Codex OAuth 绑定自愈(claimDetectedCodexOAuthBinding)+ readState 绑定 gate 集成测试。
+ *
+ * 背景 bug:一次性 legacy 迁移(migrateLegacyNativeProviderAuthBindings)在 reconcile
+ * 硬链建立之前快照 hasCodexOAuthLoginUnbound(),openai 名额以 false 被永久消费;local
+ * 模式 owner 则从不跑该迁移。结果 getState 报 authenticated(直读 auth.json)而
+ * provider connected=false(查绑定)—— 设置页「已连接」与聊天门禁「无来源」自相矛盾。
+ *
+ * 修复后的期望:reconcile 收口为首个 owner 补绑定,getState / getAccessToken /
+ * provider connected 三者同口径;换账号(绑定归属他人)保持 fail-closed,且 getState
+ * 不再以 OAuth 已连接示人。
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const dirs: string[] = [];
+const h = vi.hoisted(() => ({ userDataDir: '', dataOwnerId: null as string | null }));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => h.userDataDir,
+    getAppPath: () => h.userDataDir,
+    isPackaged: false,
+  },
+  safeStorage: { isEncryptionAvailable: () => false },
+}));
+
+vi.mock('@cindy/maker-core', () => ({}));
+
+// 只覆写 getActiveAppSession(绑定判定的唯一输入);其余导出保持原实现,供
+// appCapabilities / providerSecretStore 等传递依赖正常加载。mode 用 'local':
+// 绑定逻辑只看 dataOwnerId,而 local 模式关闭网关能力,readState 的网关 key
+// fallback 分支确定性返回未认证,不触碰任何真实凭证存储。
+vi.mock('../../appSessionState.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../appSessionState.js')>();
+  return {
+    ...actual,
+    getActiveAppSession: () => ({
+      mode: h.dataOwnerId ? ('local' as const) : ('signed-out' as const),
+      dataOwnerId: h.dataOwnerId,
+      generation: 1,
+    }),
+  };
+});
+
+function fixture(): { codexHome: string; systemAuth: string; localAuth: string; bindingFile: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xdt-codex-binding-claim-'));
+  dirs.push(root);
+  h.userDataDir = path.join(root, 'user-data');
+  fs.mkdirSync(h.userDataDir, { recursive: true });
+  const home = path.join(root, 'home');
+  fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+  vi.spyOn(os, 'homedir').mockReturnValue(home);
+  const systemAuth = path.join(home, '.codex', 'auth.json');
+  // reconcile 的账号识别需要 account_id;access_token 是 OAuth 判定与绑定 claim 的凭证。
+  fs.writeFileSync(
+    systemAuth,
+    JSON.stringify({
+      account: { email: 'dev@example.test' },
+      tokens: { access_token: 'system-token', account_id: 'acct-1' },
+    }),
+  );
+  const codexHome = path.join(h.userDataDir, 'codex-home');
+  return {
+    codexHome,
+    systemAuth,
+    localAuth: path.join(codexHome, 'auth.json'),
+    bindingFile: path.join(h.userDataDir, 'native-provider-auth.json'),
+  };
+}
+
+function readBindingFile(bindingFile: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(bindingFile, 'utf8')) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  h.dataOwnerId = null;
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('codex OAuth binding auto-claim on reconcile', () => {
+  it('binds the detected system CLI credential to the current owner within one getState call', async () => {
+    const { bindingFile } = fixture();
+    h.dataOwnerId = 'owner-a';
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+
+    await expect(adapter.getState()).resolves.toMatchObject({
+      authenticated: true,
+      authSource: 'oauth',
+      identity: 'dev@example.test',
+    });
+    expect(readBindingFile(bindingFile)).toMatchObject({ openai: 'owner-a' });
+    await expect(adapter.getAccessToken()).resolves.toBe('system-token');
+  });
+
+  it('repairs a claim that the one-shot migration consumed before the reconcile hardlink existed', async () => {
+    const { bindingFile } = fixture();
+    // 竞态残局:legacyClaimOwner 已写下,openai 名额被 false 消费。
+    fs.writeFileSync(bindingFile, JSON.stringify({ legacyClaimOwner: 'owner-a' }));
+    h.dataOwnerId = 'owner-a';
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+
+    await expect(adapter.getState()).resolves.toMatchObject({
+      authenticated: true,
+      authSource: 'oauth',
+    });
+    expect(readBindingFile(bindingFile)).toMatchObject({
+      openai: 'owner-a',
+      legacyClaimOwner: 'owner-a',
+    });
+  });
+
+  it('keeps another owner fail-closed and stops reporting the unbound OAuth as connected', async () => {
+    const { bindingFile } = fixture();
+    fs.writeFileSync(
+      bindingFile,
+      JSON.stringify({ openai: 'owner-a', legacyClaimOwner: 'owner-a' }),
+    );
+    h.dataOwnerId = 'owner-b';
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+
+    await expect(adapter.getState()).resolves.toEqual({
+      authenticated: false,
+      errorReason: 'oauth_not_bound',
+    });
+    await expect(adapter.getAccessToken()).resolves.toBeNull();
+    // 归属绝不被改写。
+    expect(readBindingFile(bindingFile)).toMatchObject({ openai: 'owner-a' });
+  });
+
+  it('does not claim while a durable user disconnect suppresses the local credential', async () => {
+    const { codexHome, systemAuth, localAuth, bindingFile } = fixture();
+    fs.mkdirSync(codexHome, { recursive: true });
+    fs.copyFileSync(systemAuth, localAuth);
+    const { CODEX_USER_DISCONNECT_REASON, writeInvalidatedSystemCodexAuthMarker } = await import(
+      '../codex-auth-invalidation.js'
+    );
+    expect(
+      writeInvalidatedSystemCodexAuthMarker(
+        codexHome,
+        systemAuth,
+        CODEX_USER_DISCONNECT_REASON,
+        localAuth,
+      ),
+    ).toBe(true);
+    h.dataOwnerId = 'owner-a';
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+
+    await expect(adapter.getState()).resolves.toMatchObject({ authenticated: false });
+    expect(fs.existsSync(bindingFile)).toBe(false);
+  });
+
+  it('keeps pre-session behavior without writing any binding when no owner is committed', async () => {
+    const { bindingFile } = fixture();
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+
+    await expect(adapter.getState()).resolves.toMatchObject({
+      authenticated: true,
+      authSource: 'oauth',
+    });
+    expect(fs.existsSync(bindingFile)).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/codexAuthBindingClaim.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexAuthBindingClaim.test.ts
@@ -157,6 +157,24 @@ describe('codex OAuth binding auto-claim on reconcile', () => {
     expect(fs.existsSync(bindingFile)).toBe(false);
   });
 
+  it('drops the claim when the app session switches owners during an in-flight reconcile', async () => {
+    // review P1:claim 只允许写给「reconcile 发起时」的会话;在途期间切换账号必须放弃,
+    // 绝不把 A 时代发起的认领写到 B 名下。B 自己的下一次 reconcile 会按 B 的规则重试。
+    const { bindingFile } = fixture();
+    h.dataOwnerId = 'owner-a';
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+
+    // getState 的同步段捕获 sessionAtStart(owner-a);首个 await 挂起后切到 owner-b。
+    const statePromise = adapter.getState();
+    h.dataOwnerId = 'owner-b';
+    await expect(statePromise).resolves.toEqual({
+      authenticated: false,
+      errorReason: 'oauth_not_bound',
+    });
+    expect(fs.existsSync(bindingFile)).toBe(false);
+  });
+
   it('keeps pre-session behavior without writing any binding when no owner is committed', async () => {
     const { bindingFile } = fixture();
     const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');

--- a/apps/desktop/src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts
@@ -102,4 +102,15 @@ describe('claimDetectedNativeProviderAuth', () => {
     expect(claimDetectedNativeProviderAuth('openai', () => false)).toBe(false);
     expect(fs.existsSync(bindingFile)).toBe(false);
   });
+
+  it('treats corrupted falsy slot values as claimed-by-unknown and fails closed', () => {
+    // 键存在但值为假(损坏 / 异常写入):按「归属不明」拒绝,绝不重认领。
+    fs.mkdirSync(userDataDir, { recursive: true });
+    fs.writeFileSync(bindingFile, JSON.stringify({ openai: '' }));
+    expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(false);
+
+    fs.writeFileSync(bindingFile, JSON.stringify({ legacyClaimOwner: '' }));
+    expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(bindingFile, 'utf8'))).toEqual({ legacyClaimOwner: '' });
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../appSessionState.js', () => ({
 }));
 
 import {
+  claimDetectedNativeProviderAuth,
   isNativeProviderAuthBound,
   migrateLegacyNativeProviderAuthBindings,
   unbindNativeProviderAuth,
@@ -54,5 +55,51 @@ describe('native provider auth legacy binding', () => {
     migrateLegacyNativeProviderAuthBindings('owner-b', { xai: true });
 
     expect(isNativeProviderAuthBound('xai')).toBe(false);
+  });
+});
+
+describe('claimDetectedNativeProviderAuth', () => {
+  it('repairs the binding when the one-shot migration consumed the claim before the credential appeared', () => {
+    // 复现主 bug:legacy 迁移在 reconcile 硬链建立之前跑掉,openai 名额以 false 被消费。
+    migrateLegacyNativeProviderAuthBindings('owner-a', { openai: false });
+    expect(isNativeProviderAuthBound('openai')).toBe(false);
+
+    expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(true);
+    expect(isNativeProviderAuthBound('openai')).toBe(true);
+    expect(JSON.parse(fs.readFileSync(bindingFile, 'utf8'))).toMatchObject({
+      openai: 'owner-a',
+      legacyClaimOwner: 'owner-a',
+    });
+  });
+
+  it('claims for the current owner when no legacy claim ever ran (local mode path)', () => {
+    expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(bindingFile, 'utf8'))).toMatchObject({ openai: 'owner-a' });
+  });
+
+  it('stays fail-closed for an account that did not win the legacy claim', () => {
+    migrateLegacyNativeProviderAuthBindings('owner-a', {});
+    session.dataOwnerId = 'owner-b';
+
+    expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(false);
+    expect(isNativeProviderAuthBound('openai')).toBe(false);
+  });
+
+  it('never overwrites a binding held by another owner', () => {
+    migrateLegacyNativeProviderAuthBindings('owner-a', { openai: true });
+    session.dataOwnerId = 'owner-b';
+
+    expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(false);
+    session.dataOwnerId = 'owner-a';
+    expect(isNativeProviderAuthBound('openai')).toBe(true);
+  });
+
+  it('writes nothing without a committed owner or without a credential', () => {
+    session.dataOwnerId = null;
+    expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(false);
+
+    session.dataOwnerId = 'owner-a';
+    expect(claimDetectedNativeProviderAuth('openai', () => false)).toBe(false);
+    expect(fs.existsSync(bindingFile)).toBe(false);
   });
 });

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -59,6 +59,11 @@ import { claudeUpstreamEndpoint } from './runtime-configs.js';
 import { getProviderSecretStore } from '../secrets/providerSecretStore.js';
 import { getAppCapabilities } from '../appCapabilities.js';
 import {
+  getActiveAppSession,
+  isAppSessionBoundaryPending,
+  type ActiveAppSession,
+} from '../appSessionState.js';
+import {
   bindNativeProviderAuth,
   claimDetectedNativeProviderAuth,
   isNativeProviderAuthBound,
@@ -630,8 +635,11 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
    */
   private reconcileWithSystemCodex(): Promise<void> {
     if (this.pendingReconcile) return this.pendingReconcile;
+    // 发起时刻固定会话快照:reconcile 是异步的,期间可能发生账号切换;绑定自愈
+    // 只允许写给「发起时与完成时都是同一个已提交会话」的 owner(见 claim 内校验)。
+    const sessionAtStart = getActiveAppSession();
     const run = this.runReconcileWithSystemCodex()
-      .then(() => this.claimDetectedCodexOAuthBinding())
+      .then(() => this.claimDetectedCodexOAuthBinding(sessionAtStart))
       .finally(() => {
         if (this.pendingReconcile === run) this.pendingReconcile = null;
       });
@@ -652,8 +660,21 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
    * 安全边界不变:已有归属(含别的账号)/ legacyClaimOwner 是别的账号 / durable
    * disconnect 抑制中,一律不写(见 claimDetectedNativeProviderAuth),换账号继续
    * fail-closed。写失败只记日志,不让 reconcile 链路抛穿。
+   *
+   * 会话边界防护(review P1):claim 在异步 reconcile 完成后执行,期间可能发生账号
+   * 切换。只在「发起时与完成时是同一个已提交会话(owner + generation 均未变)、且
+   * 没有会话边界切换在途」时才允许写入;否则放弃本轮 —— 新会话自己的下一次
+   * reconcile 会带着自己的快照重试,自愈不丢,只是绝不把 A 时代发起的认领写到 B 名下。
    */
-  private claimDetectedCodexOAuthBinding(): void {
+  private claimDetectedCodexOAuthBinding(sessionAtStart: ActiveAppSession): void {
+    const session = getActiveAppSession();
+    if (isAppSessionBoundaryPending()) return;
+    if (
+      session.generation !== sessionAtStart.generation ||
+      session.dataOwnerId !== sessionAtStart.dataOwnerId
+    ) {
+      return;
+    }
     if (this.oauthInvalidatedReason) return;
     const authPath = path.join(this.codexHome, 'auth.json');
     if (shouldSuppressLocalCodexAuth(this.codexHome, authPath)) return;

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -58,7 +58,12 @@ import { isAnthropicCompatProxyHandleReady } from './anthropic-compat-proxy-host
 import { claudeUpstreamEndpoint } from './runtime-configs.js';
 import { getProviderSecretStore } from '../secrets/providerSecretStore.js';
 import { getAppCapabilities } from '../appCapabilities.js';
-import { bindNativeProviderAuth, isNativeProviderAuthBound, unbindNativeProviderAuth } from './nativeProviderAuthBinding.js';
+import {
+  bindNativeProviderAuth,
+  claimDetectedNativeProviderAuth,
+  isNativeProviderAuthBound,
+  unbindNativeProviderAuth,
+} from './nativeProviderAuthBinding.js';
 
 const execFileP = promisify(execFile);
 const log = createLogger('auth-adapters');
@@ -625,11 +630,42 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
    */
   private reconcileWithSystemCodex(): Promise<void> {
     if (this.pendingReconcile) return this.pendingReconcile;
-    const run = this.runReconcileWithSystemCodex().finally(() => {
-      if (this.pendingReconcile === run) this.pendingReconcile = null;
-    });
+    const run = this.runReconcileWithSystemCodex()
+      .then(() => this.claimDetectedCodexOAuthBinding())
+      .finally(() => {
+        if (this.pendingReconcile === run) this.pendingReconcile = null;
+      });
     this.pendingReconcile = run;
     return run;
+  }
+
+  /**
+   * reconcile 收口后的绑定自愈:codex-home 里存在可用 OAuth token(硬链自本机 CLI 或
+   * 早年隔离登录)、而 openai 尚无任何 owner 绑定时,把它绑给当前 owner。
+   *
+   * 修复的时序竞态:一次性 legacy 迁移(migrateLegacyNativeProviderAuthBindings)在
+   * 首次登录时快照 hasCodexOAuthLoginUnbound(),但 reconcile 硬链往往还没建立 ——
+   * 名额被以 openai:false 永久消费,首个 owner 从此拿不到设计内的自动继承;local 模式
+   * owner 更是从不跑该迁移。结果是 getState 报 authenticated(读 auth.json)而
+   * provider connected=false(查绑定),设置页「已连接」与聊天门禁「无来源」自相矛盾。
+   *
+   * 安全边界不变:已有归属(含别的账号)/ legacyClaimOwner 是别的账号 / durable
+   * disconnect 抑制中,一律不写(见 claimDetectedNativeProviderAuth),换账号继续
+   * fail-closed。写失败只记日志,不让 reconcile 链路抛穿。
+   */
+  private claimDetectedCodexOAuthBinding(): void {
+    if (this.oauthInvalidatedReason) return;
+    const authPath = path.join(this.codexHome, 'auth.json');
+    if (shouldSuppressLocalCodexAuth(this.codexHome, authPath)) return;
+    try {
+      if (claimDetectedNativeProviderAuth('openai', () => this.hasCodexOAuthLoginUnbound())) {
+        log.info('codex OAuth credential auto-bound to current owner after reconcile');
+      }
+    } catch (err) {
+      log.warn('codex OAuth binding claim failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**
@@ -822,6 +858,22 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
       return { authenticated: false, errorReason: localState.errorReason ?? 'no_oauth' };
     }
     const localState = await this.readLocalCodexAuthState();
+    // 绑定 gate(与 provider 目录 connected / getAccessToken 同口径,对齐 Anthropic 侧
+    // readClaudeAiOAuth 的读取层校验):auth.json 是与系统 CLI 共享的存储,凭证在、但
+    // openai 未绑定到当前 owner 时,不得以 OAuth 已连接示人 —— 否则设置页显示「已连接」
+    // 而聊天门禁按无来源拦截,状态自相矛盾。上方 reconcile 收口已把「首个 owner 检测到
+    // 本机 CLI 凭证」的合法自动继承补好绑定(claimDetectedCodexOAuthBinding);走到这里
+    // 仍未绑定的只剩换账号等 fail-closed 场景,按无 OAuth 处理,可退网关 key。
+    if (
+      localState.authenticated &&
+      localState.authSource === 'oauth' &&
+      !isNativeProviderAuthBound('openai')
+    ) {
+      if (readClaudeApiKey()) {
+        return { authenticated: true, identity: 'API Key · Cindy AI', authSource: 'api-key' };
+      }
+      return { authenticated: false, errorReason: 'oauth_not_bound' };
+    }
     if (localState.authenticated) {
       // api-key 型 auth.json(可解析但无 access_token)且配了网关 key:fallback spawn
       // 实际会走 gateway key(hasCodexOAuthLogin=false),authSource 补成 'api-key'
@@ -1178,13 +1230,16 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
    * are covered by the active Codex login.
    */
   async getAccessToken(): Promise<string | null> {
-    if (!isNativeProviderAuthBound('openai')) return null;
     this.ensureInvalidationMarkerLoaded();
     if (this.oauthInvalidatedReason) {
       await this.clearStaleInvalidationIfSystemCodexChanged();
     }
     if (this.oauthInvalidatedReason) return null;
+    // 绑定校验放在 reconcile 之后:reconcile 收口会为首个 owner 补绑定
+    // (claimDetectedCodexOAuthBinding),同一次调用内即可生效;校验仍在 token
+    // 读取之前,未绑定(换账号等)保持 fail-closed 返回 null。
     await this.reconcileWithSystemCodex();
+    if (!isNativeProviderAuthBound('openai')) return null;
     const authPath = path.join(this.codexHome, 'auth.json');
     if (shouldSuppressLocalCodexAuth(this.codexHome, authPath)) return null;
     try {
@@ -1209,13 +1264,14 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
    * user id, not a workspace id, and must not bind reset-credit operations.
    */
   async getAccountId(): Promise<string | null> {
-    if (!isNativeProviderAuthBound('openai')) return null;
     this.ensureInvalidationMarkerLoaded();
     if (this.oauthInvalidatedReason) {
       await this.clearStaleInvalidationIfSystemCodexChanged();
     }
     if (this.oauthInvalidatedReason) return null;
+    // 同 getAccessToken:绑定校验在 reconcile(含首个 owner 补绑定)之后、读取之前。
     await this.reconcileWithSystemCodex();
+    if (!isNativeProviderAuthBound('openai')) return null;
     const authPath = path.join(this.codexHome, 'auth.json');
     if (shouldSuppressLocalCodexAuth(this.codexHome, authPath)) return null;
     return readCodexAccountId(authPath);

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -312,7 +312,11 @@ export function getDesktopProviderService(): ProviderService {
     connection: {
       xd: () => getAppCapabilities().canUseCindyGateway && readClaudeApiKey() != null,
       anthropic: () => isNativeProviderAuthBound('anthropic') && hasClaudeAiOAuth(),
-      openai: () => isNativeProviderAuthBound('openai') && desktopCodexAuthAdapter.hasCodexOAuthLogin(),
+      // openai 不再前置 isNativeProviderAuthBound 短路:hasCodexOAuthLogin →
+      // getAccessToken 内部已是「reconcile(含首个 owner 绑定自愈)→ 绑定校验 → 读
+      // token」的完整口径,未绑定仍 fail-closed 返回 null;前置短路反而会拦掉
+      // listProviders 路径触发绑定自愈的机会(claimDetectedCodexOAuthBinding)。
+      openai: () => desktopCodexAuthAdapter.hasCodexOAuthLogin(),
       xai: () => isNativeProviderAuthBound('xai') && hasGrokOAuthLogin(),
     },
     // 通用 OAuth 供应商（目录 auth.oauth 描述符驱动）：连接态 = 本机凭证 blob 是否存在。

--- a/apps/desktop/src/main/maker-host/nativeProviderAuthBinding.ts
+++ b/apps/desktop/src/main/maker-host/nativeProviderAuthBinding.ts
@@ -73,3 +73,29 @@ export function migrateLegacyNativeProviderAuthBindings(
   }
   writeBindings(next);
 }
+
+/**
+ * Claim an auto-detected local CLI credential for the current owner.
+ *
+ * The Codex import channel materializes its credential lazily (the ~/.codex
+ * reconcile hardlink is created after startup), so the one-shot legacy
+ * migration above can consume `legacyClaimOwner` while the credential is not
+ * visible yet — stranding the intended first-owner auto-connect forever, and
+ * local-mode owners never run that migration at all. This repairs exactly
+ * that: only when the slot has no owner, the credential exists, and no OTHER
+ * account won the legacy claim. An existing binding is never overwritten, so
+ * account switches stay fail-closed like migrateLegacyNativeProviderAuthBindings.
+ */
+export function claimDetectedNativeProviderAuth(
+  provider: NativeProviderId,
+  hasCredential: () => boolean,
+): boolean {
+  const owner = getActiveAppSession().dataOwnerId;
+  if (!owner) return false;
+  const bindings = readBindings();
+  if (bindings[provider]) return false;
+  if (bindings.legacyClaimOwner && bindings.legacyClaimOwner !== owner) return false;
+  if (!hasCredential()) return false;
+  writeBindings({ ...bindings, [provider]: owner });
+  return true;
+}

--- a/apps/desktop/src/main/maker-host/nativeProviderAuthBinding.ts
+++ b/apps/desktop/src/main/maker-host/nativeProviderAuthBinding.ts
@@ -93,8 +93,11 @@ export function claimDetectedNativeProviderAuth(
   const owner = getActiveAppSession().dataOwnerId;
   if (!owner) return false;
   const bindings = readBindings();
-  if (bindings[provider]) return false;
-  if (bindings.legacyClaimOwner && bindings.legacyClaimOwner !== owner) return false;
+  // Key-presence, not truthiness: a corrupted/empty-string slot must count as
+  // "claimed by unknown" and fail closed, never as re-claimable (matches
+  // unbindNativeProviderAuth's `in` pattern).
+  if (provider in bindings) return false;
+  if ('legacyClaimOwner' in bindings && bindings.legacyClaimOwner !== owner) return false;
   if (!hasCredential()) return false;
   writeBindings({ ...bindings, [provider]: owner });
   return true;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复新用户反馈的状态矛盾:本机 Codex CLI 已登录时,设置页 / 供应商向导显示 OpenAI「已连接」,但聊天发送被门禁拦截提示「无可用来源,去连接」,断开重连一次才能恢复。

根因是「已连接」存在两套口径 + 一次性绑定迁移的时序竞态:

- `migrateLegacyNativeProviderAuthBindings` 在首次登录时快照 `hasCodexOAuthLoginUnbound()`,但把本机 `~/.codex/auth.json` 硬链进 codex-home 的 reconcile 往往还没执行(warmUp 是 fire-and-forget,maker 甚至可能尚未构造),openai 名额被以 `false` 永久消费(`legacyClaimOwner` 写入后 early-return);local 模式 owner 则从不运行该迁移。
- 此后设置页徽标走 `maker.auth.getState('codex')` 直读 auth.json 报 `authenticated + oauth`(不查绑定),而聊天门禁走 `listProviders` 的 `connected`(查绑定)得 false —— 一真一假。

修复(三处,同一件事):

1. **绑定自愈**(`claimDetectedNativeProviderAuth` + `claimDetectedCodexOAuthBinding`):reconcile 收口后,若 codex-home 存在可用 OAuth token、openai 无任何归属、且 `legacyClaimOwner` 不是别的账号,则绑给当前 owner。覆盖首个 cloud owner、local 模式 owner,已中招用户下次启动 warmUp 即自愈,无需手动重连。
2. **读取层绑定 gate**(`readState`):未绑定的 OAuth 凭证不再报 authenticated(对齐 Anthropic 侧 `readClaudeAiOAuth` 在读取层查绑定的既有姿势),可退网关 key,否则报 `oauth_not_bound`。换账号场景设置页从此如实显示未连接并引导显式连接。
3. **口径归一**:`getAccessToken` / `getAccountId` 的绑定校验移到 reconcile 之后(同一次调用内自愈即生效、校验仍在 token 读取之前);`connection.openai` 去掉前置 `isNativeProviderAuthBound` 短路,`hasCodexOAuthLogin` 内部已是完整口径,让 listProviders 路径也能触发自愈。

安全边界不变:已有归属(含别的账号)绝不改写;`legacyClaimOwner` 归他人时 fail-closed;durable disconnect / invalidation 抑制期间不绑;显式 `codex login` 的 `bindNativeProviderAuth` 语义不动。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户实测反馈(截图:供应商页「已连接」、聊天提示未连接、断开重连后恢复)
- 本 PR 包含：Codex/OpenAI 凭证绑定自愈、`readState` 绑定 gate、`connection.openai` 口径归一,及配套单测/集成测试
- 明确不包含：Anthropic / xAI 侧改动(Anthropic 读取层已查绑定,无此 bug;xAI 无本机 CLI 自动继承通道);renderer 改动(徽标经 `getState` 自动跟随新口径)
- 用户可见变化：本机 Codex CLI 已登录的新用户 / local 模式用户开箱即连,聊天直接可用;换账号后设置页不再假报「已连接」
- 是否存在 breaking change：无

### UI 变化

不涉及(显示逻辑未改,数据口径修正后徽标自动如实)。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/ src/main/im/__tests__/defaultSessionSettings.test.ts src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts src/main/hook-control/__tests__/session-runner.test.ts
结果：60 files / 620 tests 全部通过

pnpm --filter desktop run typecheck
结果：通过

仓库根 pnpm test:unit（run-unit-gate.sh）
结果：通过（GATE_EXIT=0，全部 workspace PASS）
```

新增测试:

- `codexAuthBindingClaim.test.ts`(集成,5 例):首次检测到本机 CLI 凭证在一次 `getState` 内完成绑定与认证;迁移竞态残局(`legacyClaimOwner` 已消费)被修复;另一账号 fail-closed 且 `getState` 不再假报、归属不被改写;durable disconnect 抑制期间不绑;无 owner(signed-out)保持旧行为且不写绑定文件。
- `nativeProviderAuthBinding.test.ts`(单测,+5 例):claim 的授权/拒绝矩阵(名额被消费后修复、local 首绑、非首账号拒绝、不覆写他人归属、无 owner / 无凭证不写)。

### 手工验证

不涉及(无 UI 改动;状态机路径已被集成测试按用户复现场景覆盖)。

### 未执行的验证

未在真机做「全新用户 + 本机 CLI 已登录」的端到端首启验证(需要干净 userData 与真实 ChatGPT 凭证);该链路的时序竞态与自愈已由 `codexAuthBindingClaim.test.ts` 按真实文件布局(mkdtemp 沙箱内的 userData / ~/.codex)覆盖。测试遵守凭证规则,仅使用假凭证、不触碰真实 HOME。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Codex/OpenAI 连接态判定与凭证绑定文件(`native-provider-auth.json`)的 openai 条目。绑定自愈的写入条件是「无任何归属 + legacyClaimOwner 非他人 + 凭证可用 + 无断开抑制」,与显式 `codex login` 成功后写入的内容等价;账号切换的 fail-closed 边界、durable disconnect 语义均不变,并新增测试锁定。
- 回滚 / 降级方式：revert 本 PR 即可。自愈写入的 openai 绑定与显式登录写入等价,不需要数据清理;回滚后行为退回「需手动断开重连」的旧状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码内注释说明口径与竞态;无需独立文档）
- [x] 已确认测试结果或说明未执行原因
