### PR TITLE
feat(desktop): 会话自动起名改为 Codex 式立即占位,空消息不生成标题

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts
@@ -21,7 +21,12 @@ vi.mock('../../maker-host/title-one-shot.js', () => ({
   generateTitleViaProvider: vi.fn(),
 }));
 
-import { regenerateMakerSessionTitle, type RegenerateTitleDeps } from '../title.js';
+import {
+  generateMakerSessionTitle,
+  regenerateMakerSessionTitle,
+  type RegenerateTitleDeps,
+} from '../title.js';
+import { generateTitleViaProvider } from '../../maker-host/title-one-shot.js';
 import type { RegenerateTitleMaterial } from '../../localDb/latestMessageText.js';
 
 /** 默认素材:短会话——最近窗口已覆盖会话开头(开场消息就是窗口第一条)。 */
@@ -200,5 +205,31 @@ describe('regenerateMakerSessionTitle', () => {
     });
 
     expect(await regenerateMakerSessionTitle('s1', deps)).toBeNull();
+  });
+});
+
+describe('generateMakerSessionTitle', () => {
+  it('空/全空白消息(如仅图片附件的首条输入)→ null 且不发标题请求', async () => {
+    vi.mocked(generateTitleViaProvider).mockClear();
+
+    expect(await generateMakerSessionTitle('', 'claude-code', 's1')).toBeNull();
+    expect(await generateMakerSessionTitle('   \n  ', 'codex', 's1')).toBeNull();
+    expect(generateTitleViaProvider).not.toHaveBeenCalled();
+  });
+
+  it('非空消息走 provider oneShot,prompt 使用 trim 后的消息', async () => {
+    vi.mocked(generateTitleViaProvider).mockClear();
+    vi.mocked(generateTitleViaProvider).mockResolvedValueOnce('登录失败排查');
+
+    expect(await generateMakerSessionTitle('  帮我排查登录失败  ', 'claude-code', 's1')).toBe(
+      '登录失败排查',
+    );
+    const [request] = vi.mocked(generateTitleViaProvider).mock.calls[0] as [
+      { sessionId: string; agentKind: string; prompt: string },
+    ];
+    expect(request.sessionId).toBe('s1');
+    expect(request.agentKind).toBe('claude-code');
+    expect(request.prompt).toContain('帮我排查登录失败');
+    expect(request.prompt).not.toContain('  帮我排查登录失败');
   });
 });

--- a/apps/desktop/src/main/maker-ipc/title.ts
+++ b/apps/desktop/src/main/maker-ipc/title.ts
@@ -96,11 +96,15 @@ export async function generateMakerSessionTitle(
   agentKind: AgentKind,
   sessionId?: string,
 ): Promise<string | null> {
+  // 空消息(如仅图片/附件的首条输入)不发标题请求:LLM 收到空素材会把
+  // "请提供用户消息内容"式回复当标题返回。直接放弃,调用方保留默认名。
+  const trimmed = message.trim();
+  if (!trimmed) return null;
   return generateTitleViaProvider(
     {
       sessionId: sessionId ?? '',
       agentKind,
-      prompt: TITLE_PROMPT_TEMPLATE(message),
+      prompt: TITLE_PROMPT_TEMPLATE(trimmed),
     },
     {
       readSessionProviderId: readSessionProviderIdFromDb,

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreAutoName.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreAutoName.test.ts
@@ -1,0 +1,180 @@
+/**
+ * makerChatStoreAutoName.test.ts
+ * ---------------------------------------------------------------------------
+ * 自动起名(Codex 式立即占位)契约:
+ *   - 首条消息发送后立即用原话前 40 字占位改名,不停留在 "New Maker";
+ *   - 智能标题后台出结果后覆盖占位;
+ *   - 用户中途手动改名 wins,后台智能标题不得静默冲掉;
+ *   - 无文本首条消息(纯附件)不起名。
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/messageService', () => ({
+  list: vi.fn(async () => []),
+  create: vi.fn(async () => ({}) as unknown),
+  updateContent: vi.fn(async () => ({}) as unknown),
+  dismissError: vi.fn(async () => ({}) as unknown),
+}));
+
+vi.mock('@/lib/sessionService', () => ({
+  get: vi.fn(async () => ({
+    agentKind: 'claude-code',
+    remoteHostId: null,
+    sdkSessionId: null,
+    fastMode: false,
+    contextTokens: 0,
+    contextWindow: 0,
+    totalCostUsd: 0,
+    title: 'New Maker',
+  })),
+  update: vi.fn(async () => ({})),
+  touchUserSend: vi.fn(async () => ({})),
+}));
+
+vi.mock('@/lib/sessionsBus', () => ({
+  emitPatch: vi.fn(),
+}));
+
+vi.mock('@/lib/userPromptStore', () => ({
+  getUserPrompt: () => '',
+}));
+
+vi.mock('@/lib/memorySettingsStore', () => ({
+  getMakerMemoryEnabled: () => true,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/composerDraftStore', () => ({
+  saveDraft: vi.fn(),
+  plainTextToTiptapDoc: (s: string) => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: s }] }],
+  }),
+}));
+
+import { makerChatStore } from '@/lib/makerChatStore';
+import * as sessionService from '@/lib/sessionService';
+import { emitPatch } from '@/lib/sessionsBus';
+
+const SESSION_ID = 'auto-name-session';
+
+let resolveTitle: (result: { title: string | null }) => void;
+let rejectTitle: (err: unknown) => void;
+const generateTitle = vi.fn(
+  () =>
+    new Promise<{ title: string | null }>((resolve, reject) => {
+      resolveTitle = resolve;
+      rejectTitle = reject;
+    }),
+);
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const w = globalThis as unknown as { window: Record<string, unknown> };
+  w.window = {
+    electronAPI: {
+      maker: { generateTitle },
+    },
+  };
+});
+
+describe('makerChatStore auto-name (Codex-style immediate placeholder)', () => {
+  it('immediately renames the session to the truncated first message', async () => {
+    makerChatStore.autoNameSession(SESSION_ID, 'fix the login bug\nwhen token expires', 'claude-code');
+    await flushPromises();
+
+    // 占位立即落库 + patch sidebar,不等 LLM。换行折叠成空格。
+    expect(sessionService.update).toHaveBeenCalledWith(SESSION_ID, {
+      title: 'fix the login bug when token expires',
+    });
+    expect(emitPatch).toHaveBeenCalledWith(SESSION_ID, {
+      title: 'fix the login bug when token expires',
+    });
+  });
+
+  it('truncates the placeholder to 40 characters', async () => {
+    makerChatStore.autoNameSession(SESSION_ID, 'x'.repeat(60), 'claude-code');
+    await flushPromises();
+
+    expect(sessionService.update).toHaveBeenCalledWith(SESSION_ID, {
+      title: 'x'.repeat(40),
+    });
+  });
+
+  it('overwrites the placeholder once the smart title arrives', async () => {
+    vi.mocked(sessionService.get).mockResolvedValue({
+      title: 'first message text',
+    } as Awaited<ReturnType<typeof sessionService.get>>);
+
+    makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'codex');
+    await flushPromises();
+    expect(sessionService.update).toHaveBeenCalledWith(SESSION_ID, {
+      title: 'first message text',
+    });
+
+    resolveTitle({ title: ' 登录令牌过期修复 ' });
+    await flushPromises();
+
+    // 智能标题 trim 后覆盖占位。
+    expect(sessionService.update).toHaveBeenLastCalledWith(SESSION_ID, {
+      title: '登录令牌过期修复',
+    });
+    expect(sessionService.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a manual rename over the late smart title', async () => {
+    vi.mocked(sessionService.get).mockResolvedValue({
+      title: '用户手动改的名字',
+    } as Awaited<ReturnType<typeof sessionService.get>>);
+
+    makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'claude-code');
+    await flushPromises();
+    expect(sessionService.update).toHaveBeenCalledTimes(1);
+
+    resolveTitle({ title: '智能标题' });
+    await flushPromises();
+
+    // 等待窗口内用户改过名 → 智能标题不覆盖。
+    expect(sessionService.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the placeholder when title generation fails or returns null', async () => {
+    vi.mocked(sessionService.get).mockResolvedValue({
+      title: 'first message text',
+    } as Awaited<ReturnType<typeof sessionService.get>>);
+
+    makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'claude-code');
+    await flushPromises();
+
+    rejectTitle(new Error('oneShot failed'));
+    await flushPromises();
+
+    expect(sessionService.update).toHaveBeenCalledTimes(1);
+    expect(sessionService.update).toHaveBeenCalledWith(SESSION_ID, {
+      title: 'first message text',
+    });
+  });
+
+  it('skips auto-naming for text-less first messages', async () => {
+    makerChatStore.autoNameSession(SESSION_ID, '  \n  ', 'claude-code');
+    await flushPromises();
+
+    expect(generateTitle).not.toHaveBeenCalled();
+    expect(sessionService.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreAutoName.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreAutoName.test.ts
@@ -116,6 +116,19 @@ describe('makerChatStore auto-name (Codex-style immediate placeholder)', () => {
     });
   });
 
+  it('trims leading whitespace before truncating (long indent must not defeat naming)', async () => {
+    makerChatStore.autoNameSession(
+      SESSION_ID,
+      `\n\n${' '.repeat(50)}real message text`,
+      'claude-code',
+    );
+    await flushPromises();
+
+    expect(sessionService.update).toHaveBeenCalledWith(SESSION_ID, {
+      title: 'real message text',
+    });
+  });
+
   it('overwrites the placeholder once the smart title arrives', async () => {
     vi.mocked(sessionService.get).mockResolvedValue({
       title: 'first message text',

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreAutoName.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreAutoName.test.ts
@@ -129,10 +129,40 @@ describe('makerChatStore auto-name (Codex-style immediate placeholder)', () => {
     });
   });
 
-  it('overwrites the placeholder once the smart title arrives', async () => {
-    vi.mocked(sessionService.get).mockResolvedValue({
-      title: 'first message text',
+  it('does not auto-name a session the user already renamed before the first message', async () => {
+    vi.mocked(sessionService.get).mockResolvedValueOnce({
+      title: '我的自定义标题',
     } as Awaited<ReturnType<typeof sessionService.get>>);
+
+    makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'claude-code');
+    await flushPromises();
+
+    // pre-check 命中用户改名 → 占位与智能标题都不写,连生成请求也不发。
+    expect(generateTitle).not.toHaveBeenCalled();
+    expect(sessionService.update).not.toHaveBeenCalled();
+  });
+
+  it('still auto-names fork-placeholder sessions', async () => {
+    vi.mocked(sessionService.get).mockResolvedValueOnce({
+      title: '[Fork] 源会话标题',
+    } as Awaited<ReturnType<typeof sessionService.get>>);
+
+    makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'claude-code');
+    await flushPromises();
+
+    expect(sessionService.update).toHaveBeenCalledWith(SESSION_ID, {
+      title: 'first message text',
+    });
+  });
+
+  it('overwrites the placeholder once the smart title arrives', async () => {
+    vi.mocked(sessionService.get)
+      .mockResolvedValueOnce({
+        title: 'New Maker',
+      } as Awaited<ReturnType<typeof sessionService.get>>)
+      .mockResolvedValueOnce({
+        title: 'first message text',
+      } as Awaited<ReturnType<typeof sessionService.get>>);
 
     makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'codex');
     await flushPromises();
@@ -151,9 +181,13 @@ describe('makerChatStore auto-name (Codex-style immediate placeholder)', () => {
   });
 
   it('keeps a manual rename over the late smart title', async () => {
-    vi.mocked(sessionService.get).mockResolvedValue({
-      title: '用户手动改的名字',
-    } as Awaited<ReturnType<typeof sessionService.get>>);
+    vi.mocked(sessionService.get)
+      .mockResolvedValueOnce({
+        title: 'New Maker',
+      } as Awaited<ReturnType<typeof sessionService.get>>)
+      .mockResolvedValueOnce({
+        title: '用户手动改的名字',
+      } as Awaited<ReturnType<typeof sessionService.get>>);
 
     makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'claude-code');
     await flushPromises();
@@ -167,8 +201,8 @@ describe('makerChatStore auto-name (Codex-style immediate placeholder)', () => {
   });
 
   it('keeps the placeholder when title generation fails or returns null', async () => {
-    vi.mocked(sessionService.get).mockResolvedValue({
-      title: 'first message text',
+    vi.mocked(sessionService.get).mockResolvedValueOnce({
+      title: 'New Maker',
     } as Awaited<ReturnType<typeof sessionService.get>>);
 
     makerChatStore.autoNameSession(SESSION_ID, 'first message text', 'claude-code');

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -1765,6 +1765,20 @@ export function NewMakerDraftRoute() {
             // 无文本目标(理论不可达,goal 对话框必填)不起名:被控端旧版本的
             // maker:generate-title 没有空消息防线,LLM 会把"请提供内容"当标题。
             if (!placeholderTitle) return;
+            // 覆写守卫:仅当远端标题仍是默认占位时才自动起名(user rename wins,
+            // PR #296 review)。刚 create-session 建出的会话标题必为 'New Maker',
+            // 此检查防御极端 race;读取失败时按默认占位继续,不中断起名。
+            try {
+              const preCheck = (await window.electronAPI.deviceLink.invoke(
+                deviceId,
+                'local-db:sessions:get',
+                [remoteSessionId],
+              )) as { title?: string | null } | null;
+              const preTitle = preCheck?.title?.trim();
+              if (preTitle && preTitle !== 'New Maker') return;
+            } catch {
+              // 读不到当前标题时按"仍是默认占位"继续。
+            }
             // 占位写入失败(旧被控端无此窄口径 / 瞬时通道错误)单独吞掉,不中断
             // 后续智能起名——生成与写回不依赖占位成功(PR #296 review P1)。
             try {
@@ -1782,7 +1796,10 @@ export function NewMakerDraftRoute() {
               [{ message: objective, agentKind: titleAgentKind, sessionId: remoteSessionId }],
             )) as { title: string | null } | null;
             const title = gen?.title?.trim();
-            if (!title || title === placeholderTitle) return;
+            // 智能标题与占位相同也照走写回:占位写入允许失败(上方 catch),
+            // 此时远端仍是 'New Maker',跳过会让标题永久停在默认名(PR #296
+            // review P1);占位已成功时重写同值幂等无害。
+            if (!title) return;
             const current = (await window.electronAPI.deviceLink.invoke(
               deviceId,
               'local-db:sessions:get',

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -1758,17 +1758,24 @@ export function NewMakerDraftRoute() {
         // 'New Maker'),再经隧道生成智能标题窄口径覆盖。fire-and-forget;
         // 覆盖前 re-read,仅在标题仍是占位/默认时落盘(用户手动改名 wins)。
         const titleAgentKind = persistedAgentKind === 'codex' ? 'codex' : 'claude-code';
-        const placeholderTitle = objective.replace(/\n/g, ' ').slice(0, 40).trim();
+        // 先折叠空白并 trim 再截断,避免前导空白吃满 40 字符得到空占位(PR #296 review)。
+        const placeholderTitle = objective.replace(/\s+/g, ' ').trim().slice(0, 40).trimEnd();
         void (async () => {
           try {
             // 无文本目标(理论不可达,goal 对话框必填)不起名:被控端旧版本的
             // maker:generate-title 没有空消息防线,LLM 会把"请提供内容"当标题。
             if (!placeholderTitle) return;
-            await window.electronAPI.deviceLink.invoke(
-              deviceId,
-              'local-db:sessions:patch-meta',
-              [remoteSessionId, { title: placeholderTitle }],
-            );
+            // 占位写入失败(旧被控端无此窄口径 / 瞬时通道错误)单独吞掉,不中断
+            // 后续智能起名——生成与写回不依赖占位成功(PR #296 review P1)。
+            try {
+              await window.electronAPI.deviceLink.invoke(
+                deviceId,
+                'local-db:sessions:patch-meta',
+                [remoteSessionId, { title: placeholderTitle }],
+              );
+            } catch {
+              // 占位失败仅暂留默认名,智能标题仍会尝试生成并写回。
+            }
             const gen = (await window.electronAPI.deviceLink.invoke(
               deviceId,
               'maker:generate-title',

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -1754,33 +1754,49 @@ export function NewMakerDraftRoute() {
         setPendingGoal(remoteSessionId, { objective, limits });
         // 自动起名:goal 首轮走 GoalController 的 session.send、不经 maker:input:enqueue,
         // 被控端 deviceLinkAutoTitle 不会触发(Codex review #548)—— 与本地分支的
-        // autoNameSession 对位,经隧道生成标题并窄口径写回。fire-and-forget;
-        // 写回前 re-read,仅在会话仍无标题时落盘(用户手动改名 wins)。
+        // autoNameSession 对位:先立即用目标文案截断占位(Codex 式,侧边栏不停留在
+        // 'New Maker'),再经隧道生成智能标题窄口径覆盖。fire-and-forget;
+        // 覆盖前 re-read,仅在标题仍是占位/默认时落盘(用户手动改名 wins)。
         const titleAgentKind = persistedAgentKind === 'codex' ? 'codex' : 'claude-code';
+        const placeholderTitle = objective.replace(/\n/g, ' ').slice(0, 40).trim();
         void (async () => {
           try {
+            // 无文本目标(理论不可达,goal 对话框必填)不起名:被控端旧版本的
+            // maker:generate-title 没有空消息防线,LLM 会把"请提供内容"当标题。
+            if (!placeholderTitle) return;
+            await window.electronAPI.deviceLink.invoke(
+              deviceId,
+              'local-db:sessions:patch-meta',
+              [remoteSessionId, { title: placeholderTitle }],
+            );
             const gen = (await window.electronAPI.deviceLink.invoke(
               deviceId,
               'maker:generate-title',
               [{ message: objective, agentKind: titleAgentKind, sessionId: remoteSessionId }],
             )) as { title: string | null } | null;
-            const title = gen?.title?.trim() || objective.replace(/\n/g, ' ').slice(0, 40).trim();
-            if (!title) return;
+            const title = gen?.title?.trim();
+            if (!title || title === placeholderTitle) return;
             const current = (await window.electronAPI.deviceLink.invoke(
               deviceId,
               'local-db:sessions:get',
               [remoteSessionId],
             )) as { title?: string | null } | null;
             const existingTitle = current?.title?.trim();
-            // 'New Maker' 是 maker:create-session 的默认占位符标题,允许覆写;
+            // 占位标题与 'New Maker'(maker:create-session 的默认占位符)都允许覆写;
             // 用户已手动改过的真实标题则保留(user rename wins)。
-            if (existingTitle && existingTitle !== 'New Maker') return;
+            if (
+              existingTitle &&
+              existingTitle !== 'New Maker' &&
+              existingTitle !== placeholderTitle
+            ) {
+              return;
+            }
             await window.electronAPI.deviceLink.invoke(deviceId, 'local-db:sessions:patch-meta', [
               remoteSessionId,
               { title },
             ]);
           } catch {
-            // 起名失败不影响目标流程,侧边栏保留默认名。
+            // 起名失败不影响目标流程,侧边栏保留占位/默认名。
           }
         })();
         clearComposerDraftAndNotify(NEW_MAKER_DRAFT_KEY);
@@ -1831,7 +1847,7 @@ export function NewMakerDraftRoute() {
       // setGoal 内部 ensureSession(拉起 agent)+ 发首轮(带目标指令)。
       await window.electronAPI.maker.setGoal({ sessionId: newSession.id, objective, limits });
       // 自动起名:/goal 新建的会话不经普通发送路径,scheduleAutoName 漏触发 → 标题会停在默认。
-      // 这里用目标文案补一次,与普通会话同款(宽限期 + 占位 + 不覆盖手动改名)。
+      // 这里用目标文案补一次,与普通会话同款(立即占位 + 智能标题后台覆盖 + 不覆盖手动改名)。
       makerChatStore.autoNameSession(newSession.id, objective, capabilityAgentKind);
       clearComposerDraftAndNotify(NEW_MAKER_DRAFT_KEY);
       resetDraftWorkspaceAfterSend();

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5480,12 +5480,19 @@ function scheduleAutoName(
   const fallbackTitle = text.replace(/\s+/g, ' ').trim().slice(0, 40).trimEnd();
   // 纯附件等无文本首条消息起不出有意义的标题,保留默认标题。
   if (!fallbackTitle) return;
-  const titlePromise = window.electronAPI.maker
-    .generateTitle(text, agentKind, sessionId)
-    .then((result) => result.title)
-    .catch(() => null);
   void (async () => {
     try {
+      // 覆写守卫:仅当标题仍是系统占位(默认 'New Maker' / fork 占位)时才自动
+      // 起名。用户可以在发首条消息前就手动改名(空会话也能重命名),此时整条
+      // 链路放弃——占位与智能标题都不写(user rename wins,PR #296 review)。
+      const before = await sessionService.get(sessionId);
+      if (before.title && before.title !== 'New Maker' && !before.title.startsWith('[Fork')) {
+        return;
+      }
+      const titlePromise = window.electronAPI.maker
+        .generateTitle(text, agentKind, sessionId)
+        .then((result) => result.title)
+        .catch(() => null);
       await applyAutoNameTitle(sessionId, fallbackTitle);
       const smart = (await titlePromise)?.trim();
       if (smart && smart !== fallbackTitle) {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5475,7 +5475,9 @@ function scheduleAutoName(
   // device-link 远程会话由被控端 main 负责基于本机 DB 自动起名，控制端 renderer
   // 不再额外生成标题，避免两端并发覆盖同一 session title。
   if (isRemoteSession(sessionId)) return;
-  const fallbackTitle = text.replace(/\n/g, ' ').slice(0, 40).trim();
+  // 先折叠空白并 trim,再截断——先截断会让"前 40 字符全是空白"的消息(如粘贴
+  // 大段缩进/多行文本)得到空占位,误跳过起名(PR #296 review)。
+  const fallbackTitle = text.replace(/\s+/g, ' ').trim().slice(0, 40).trimEnd();
   // 纯附件等无文本首条消息起不出有意义的标题,保留默认标题。
   if (!fallbackTitle) return;
   const titlePromise = window.electronAPI.maker

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5450,13 +5450,6 @@ function updateQueueItem(sessionId: string, clientId: string, newText: string): 
     .catch((err) => log.warn('updateQueueItem failed:', err));
 }
 
-// 自动起名的"无中间态宽限期":LLM 在此窗口内出结果就直接用智能标题、不闪原话
-// (Claude haiku 实测常 2-3s 命中);超过则先用原话前 40 字占位,再后台等 oneShot
-// 真正出结果(靠其自身 30s 超时)异步覆盖成智能标题。这样 Claude 快路径无跳变,
-// Codex 慢路径(临时 thread 冷启动 + 可能重连,常 >3s)也能最终拿到智能标题,而
-// 不是像旧的"等够 N 秒否则 fallback"那样永远停在原话。
-const TITLE_AUTONAME_GRACE_MS = 3000;
-
 const forkAutoNameChecked = new Set<string>();
 
 /** 落库 + patch sidebar 标题 — 自动起名链路的统一出口。 */
@@ -5467,9 +5460,11 @@ async function applyAutoNameTitle(sessionId: string, title: string): Promise<voi
 }
 
 /**
- * 宽限期 + 后台覆盖式自动起名:
- *   - 宽限期(TITLE_AUTONAME_GRACE_MS)内 LLM 出非空标题 → 直接用,无原话中间态。
- *   - 超宽限期 → 先用原话前 40 字占位改名,后台继续等 oneShot 出结果再覆盖。
+ * 立即占位 + 后台覆盖式自动起名(Codex 式):
+ *   - 发送瞬间就用原话前 40 字占位改名,侧边栏不停留在 "New Maker" 默认标题。
+ *   - 后台等 oneShot 出非空智能标题(靠其自身 30s 超时)再覆盖占位;占位→智能
+ *     标题的一次跳变是有意为之——立即反映"这个会话是关于什么的"优于先看数秒
+ *     默认名。
  * 整条链路 fire-and-forget,失败只打日志,不阻塞发送主流程。
  */
 function scheduleAutoName(
@@ -5480,26 +5475,18 @@ function scheduleAutoName(
   // device-link 远程会话由被控端 main 负责基于本机 DB 自动起名，控制端 renderer
   // 不再额外生成标题，避免两端并发覆盖同一 session title。
   if (isRemoteSession(sessionId)) return;
-  const fallbackTitle = text.replace(/\n/g, ' ').slice(0, 40);
+  const fallbackTitle = text.replace(/\n/g, ' ').slice(0, 40).trim();
+  // 纯附件等无文本首条消息起不出有意义的标题,保留默认标题。
+  if (!fallbackTitle) return;
   const titlePromise = window.electronAPI.maker
     .generateTitle(text, agentKind, sessionId)
     .then((result) => result.title)
     .catch(() => null);
   void (async () => {
     try {
-      const graceP = new Promise<null>((resolve) =>
-        setTimeout(() => resolve(null), TITLE_AUTONAME_GRACE_MS),
-      );
-      const within = await Promise.race([titlePromise, graceP]);
-      if (within && within.trim()) {
-        // 宽限期内命中 → 直接智能标题,无中间态。
-        await applyAutoNameTitle(sessionId, within);
-        return;
-      }
-      // 宽限期超时 → 先用原话占位,后台等智能标题再覆盖。
       await applyAutoNameTitle(sessionId, fallbackTitle);
-      const smart = await titlePromise;
-      if (smart && smart.trim() && smart !== fallbackTitle) {
+      const smart = (await titlePromise)?.trim();
+      if (smart && smart !== fallbackTitle) {
         // 覆盖前 re-read 确认标题仍是我们写的占位 —— 等待窗口(Codex oneShot 最长
         // ~30s)内用户若从 header/sidebar 手动改名,标题已不等于 fallbackTitle,
         // 此时不覆盖,让用户的手动改名 wins(避免后台智能标题静默冲掉用户改名)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

新会话发出首条消息后,侧边栏标题此前会停留在默认的 "New Maker":自动起名有一个 3 秒"宽限期",LLM 在窗口内出结果才替换,超时才用原话前 40 字占位。本 PR 借鉴 Codex 的做法,改为**发送瞬间立即用首条消息截断(前 40 字)当标题**,智能标题后台生成完成后再覆盖;用户中途手动改名依然优先,不会被后台智能标题冲掉。

同时修一个真实出过的 bug:标题 oneShot 收到**空消息**(如首条消息只发图片没有文字)时,LLM 会把"我准备好为你生成标题,但是我没有看到用户消息的内容…"这类回复直接当标题写回会话。现在三层防御:

- main 侧 `generateMakerSessionTitle` 对 trim 后为空的消息直接返回 `null`、不发请求(根本防线,覆盖本地 IPC、device-link 隧道、被控端远控起名、FBot 等全部调用方,各调用方对 `null` 均已有"保留占位/默认名"的回落);
- renderer 侧 `scheduleAutoName` 对无文本首条消息直接跳过,不写占位、不发 IPC(顺带修掉旧逻辑会把标题写成空串的问题);
- device-link「新建目标」分支在目标文案为空时完全跳过起名——单独防这一层是因为被控端可能是旧版本,没有 main 侧防线。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(来自 Dash 的直接反馈,附截图)
- 本 PR 包含:renderer `scheduleAutoName` 立即占位改造(普通首条消息 / fork 会话 / 本地新建目标共用);`NewMakerDraftRoute` device-link 新建目标分支同款改造;main `generateMakerSessionTitle` 空消息防线;配套单测
- 明确不包含:被控端远控输入起名链路(`deviceLinkAutoTitle`)的行为改造——它由被控端 main 直接落库,不存在 "New Maker" 中间态,且已有空文本防线
- 用户可见变化:发送首条消息的瞬间,侧边栏标题立即变为消息前 40 字截断,数秒后跳变为 AI 智能标题(此跳变为有意设计,与 Codex 一致);只发图片时标题保持 "New Maker",不再出现"请提供用户消息内容"式错误标题
- 是否存在 breaking change:无

### UI 变化

仅标题文案的时序变化,无布局/样式/组件改动,Light/Dark 均不涉及新视觉。未附截图。

## 怎么验证的

### 自动验证

```text
bash run-unit-gate.sh <worktree>   # 仓库根 pnpm test:unit 全量门禁
结果:通过(exit 0;在第一轮改动后预跑,第二轮为小改动,按下述定向测试补跑)

pnpm --filter desktop typecheck
结果:通过(两轮改动后各跑一次)

pnpm exec vitest run <定向>(desktop)
结果:全部通过 ——
- makerChatStoreAutoName.test.ts(新增,6 用例:立即占位/40 字截断/智能标题覆盖/手动改名优先/生成失败保留占位/无文本跳过)
- regenerateSessionTitle.test.ts(新增 2 用例:空消息 null 且不发请求、非空消息 trim 后走 provider;原 10 用例不变)
- deviceLinkAutoTitle.test.ts、makerChatStoreTextDeltaBatching.test.ts(53)、newMakerDraft.test.ts(27)、newMakerWorktreeSend / newMakerCreateAgentVisualContract / newMakerOrcaCreateOrder、src/main/im/shared/__tests__ 全目录(125)
```

### 手工验证

未执行,待 Dash 真机验证侧边栏标题时序(可在功能 worktree 用 `pnpm restart:desktop:remote -- --preserve-running` 起测试版)。

### 未执行的验证

真机手工验证(见上);device-link 双端联调未执行——该分支改动为窄口径写回顺序调整,已由单测与 typecheck 覆盖,双端行为以 CI 与后续真机验证为准。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:会话自动起名链路(renderer 起名调度、main 标题 oneShot 入口、device-link 新建目标起名)。整条链路 fire-and-forget,失败只打日志,不影响发送/目标主流程。
- 回滚 / 降级方式:revert 本 PR 即恢复"宽限期 + New Maker 中间态"旧行为,无数据/schema 变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(行为注释随代码更新,无独立文档需要)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
