### PR TITLE
fix(login): 长文本口径落地——sso-org 帮助行外溢修复 + 副标题禁省略号双端 2 行

### DIFF
--- a/apps/desktop/src/renderer/components/login/LoginControls.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginControls.tsx
@@ -119,19 +119,26 @@ export function LoginTitleBlock({
         )}
       </div>
       {subtitle != null && (
+        // 副标题(2026-07-24 拍板):禁省略号截断,长语言完整展示——顶对齐 + ≤2 行
+        // clamp + 只向下伸展(y75 + 2×23 = 121,距输入框顶 158 留 37px),宽度对齐
+        // 下方控件列(540@70)。单行时行高 23 与旧 23px 槽同位,视觉零变化;
+        // 超两行按登录长文本口径属文案超预算(修文案不改布局)。
         <div
-          className="absolute overflow-hidden whitespace-nowrap text-center"
+          data-testid="login-subtitle"
+          className="absolute overflow-hidden text-center"
           style={{
             left: SUBTITLE.x,
             top: SUBTITLE.y,
             width: SUBTITLE.width,
-            height: 23,
-            // 同标题:显式行高 = 容器高,避免继承行高溢出后被 overflow-hidden 裁字形
-            // (与回调页 .body line-height:23px 同款)。
+            maxHeight: 46,
+            // 显式行高(避免继承行高溢出后被 overflow-hidden 裁字形,
+            // 与回调页 .body line-height:23px 同款)。
             lineHeight: '23px',
             fontSize: SUBTITLE.fontSize,
             color: LOGIN_COLORS.secondaryText,
-            textOverflow: 'ellipsis',
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: 2,
           }}
         >
           {subtitle}

--- a/apps/desktop/src/renderer/components/login/LoginPage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginPage.tsx
@@ -388,16 +388,25 @@ export function LoginPage() {
           error={!!errorCode}
           testId="login-sso-org-input"
         />
-        {/* 帮助行(demo ssoOrgPanel:text-link 位、无下划线、次级色) */}
+        {/* 帮助行(demo ssoOrgPanel:text-link 位、无下划线、次级色)。长语言(en/ja)会
+            折行:按登录长文本口径(DESIGN.md §16.2 分级②)顶对齐 + ≤2 行 clamp + 只向下
+            伸展——旧写法「36px 固定槽 + flex 垂直居中」让两行文本上下双向外溢压到输入框
+            下缘(2026-07-24 实拍)。top +6 让单行视觉位与旧居中版持平;两行时底缘
+            244+46=290,距按钮顶(300)仍有 10px,不越界。 */}
         <span
-          className="absolute flex items-center justify-center"
+          data-testid="login-sso-org-hint"
+          className="absolute overflow-hidden text-center"
           style={{
             left: TEXT_LINK.x,
-            top: TEXT_LINK.y,
+            top: TEXT_LINK.y + 6,
             width: TEXT_LINK.width,
-            height: 36,
+            maxHeight: 46,
+            lineHeight: '23px',
             fontSize: TEXT_LINK.fontSize,
             color: LOGIN_COLORS.secondaryText,
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: 2,
           }}
         >
           {t('login.ssoOrgHint')}

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
@@ -245,7 +245,14 @@ describe('ssoOrgMode 子视图', () => {
     const input = screen.getByTestId('login-sso-org-input') as HTMLInputElement;
     expect(input.placeholder).toBe('login.ssoOrgPlaceholder');
     expect((screen.getByTestId('login-sso-org-continue') as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText('login.ssoOrgHint')).toBeTruthy();
+    // 帮助行长文本约束(DESIGN.md §16.2 分级②):顶对齐 + ≤2 行 clamp + 只向下伸展。
+    // 回归锚:禁止回到「固定小槽 + flex 垂直居中」写法(长语言两行时双向外溢压输入框)。
+    const hint = screen.getByTestId('login-sso-org-hint');
+    expect(hint.textContent).toBe('login.ssoOrgHint');
+    expect(hint.style.maxHeight).toBe('46px');
+    expect(hint.style.webkitLineClamp).toBe('2');
+    expect(hint.style.display).toBe('-webkit-box');
+    expect(hint.className).not.toContain('items-center');
   });
 
   it('sso-org 填写态:输入企业 ID 后继续可用,提交派发 discover-sso-org', async () => {

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
@@ -253,6 +253,15 @@ describe('ssoOrgMode 子视图', () => {
     expect(hint.style.webkitLineClamp).toBe('2');
     expect(hint.style.display).toBe('-webkit-box');
     expect(hint.className).not.toContain('items-center');
+    // 副标题(2026-07-24 拍板):禁省略号,完整展示 ≤2 行顶对齐,宽度对齐控件列 540@70。
+    // 回归锚:禁止回到 599@41 单行 nowrap+ellipsis 写法。
+    const subtitle = screen.getByTestId('login-subtitle');
+    expect(subtitle.textContent).toBe('login.ssoOrgSubtitle');
+    expect(subtitle.style.left).toBe('70px');
+    expect(subtitle.style.width).toBe('540px');
+    expect(subtitle.style.maxHeight).toBe('46px');
+    expect(subtitle.style.webkitLineClamp).toBe('2');
+    expect(subtitle.className).not.toContain('whitespace-nowrap');
   });
 
   it('sso-org 填写态:输入企业 ID 后继续可用,提交派发 discover-sso-org', async () => {

--- a/apps/desktop/src/renderer/components/login/loginDesignTokens.ts
+++ b/apps/desktop/src/renderer/components/login/loginDesignTokens.ts
@@ -53,7 +53,9 @@ export const LOGIN_LOCAL_MODE = {
 /** 面板与面板内组件几何(figma §5.1/§4;wave4 面板描边 1px inside 368:1383)。 */
 export const PANEL = { width: 680, height: 440, radius: 36 } as const;
 export const TITLE = { y: 31, height: 38, fontSize: 32 } as const;
-export const SUBTITLE = { x: 41, y: 75, width: 599, fontSize: 20 } as const;
+// 2026-07-24 拍板:副标题禁省略号、完整展示 ≤2 行,宽度对齐下方控件列(540@70);
+// 原 figma 单行几何 599@41 作废(长语言单行必省略,违反登录长文本口径)。
+export const SUBTITLE = { x: 70, y: 75, width: 540, fontSize: 20 } as const;
 export const GLOBAL_PILL = { left: 425, top: 4, width: 70, height: 30, radius: 40 } as const; // §4.10
 export const GLOBAL_TITLE_SPAN = { left: 185, width: 236 } as const; // demo titleBlock global 变体
 export const CONTROL = {

--- a/apps/mobile/src/auth/loginSkinLayout.ts
+++ b/apps/mobile/src/auth/loginSkinLayout.ts
@@ -338,8 +338,9 @@ export function resolveLoginSurface(
 export const LOGIN_GROUP = { x: 35, width: 680, height: 560 } as const;
 /** 标题(figma §5.1:y=31 h=38 32 Bold 居中)。 */
 export const LOGIN_TITLE = { y: 31, height: 38, font: 32 } as const;
-/** 副标题(figma §5.1:x=41 y=75 w=599 20 Regular 居中)。 */
-export const LOGIN_SUBTITLE = { x: 41, y: 75, width: 599, height: 23, font: 20 } as const;
+/** 副标题(2026-07-24 拍板:禁省略号完整展示 ≤2 行,宽度对齐控件列 540@70;
+ *  原 figma 单行几何 599@41 作废;height=单行行高,折行只向下)。 */
+export const LOGIN_SUBTITLE = { x: 70, y: 75, width: 540, height: 23, font: 20 } as const;
 /** 输入/主按钮(figma §4.1/§4.3:540×80 r40;文本 x=31 §4.1)。 */
 export const LOGIN_CONTROL = {
   x: 70,

--- a/apps/mobile/src/components/LoginSkinControls.tsx
+++ b/apps/mobile/src/components/LoginSkinControls.tsx
@@ -115,7 +115,9 @@ export function LoginTitleBlock({
         {title}
       </Text>
       {subtitle != null ? (
-        <Text numberOfLines={1} style={styles.subtitle}>
+        // 2026-07-24 拍板:副标题禁省略号,长语言完整展示 ≤2 行——RN Text 从 top 锚点
+        // 向下生长天然顶对齐;numberOfLines={2} 与桌面 clamp 同约束。
+        <Text numberOfLines={2} style={styles.subtitle}>
           {subtitle}
         </Text>
       ) : null}


### PR DESCRIPTION
## 这次改了什么

### 摘要

登录链路多语言长文本口径（`DESIGN.md §16.2`，随 #288 入仓）的两项落地，均为布局约束、**文案零改动**：

**1. sso-org 帮助行外溢修复（fix）**：旧写法「36px 固定槽 + flex 垂直居中」无行数限制，英文/日文折两行后上下双向外溢，顶行压在企业 ID 输入框下缘（实机截图确认）。改为顶对齐 + `maxHeight 46`（2×23 行高）+ 2 行 clamp，`top +6` 保持中文单行视觉位持平；两行底缘 290 距按钮顶 300 留 10px。

**2. 副标题禁省略号（2026-07-24 拍板，双端）**：登录副标题不允许省略号截断（如英文 "Enter a company ID, organization slug, or verified domain to c..."），长语言必须完整展示：
- 桌面 `LoginTitleBlock`：`599@41` 单行 nowrap+ellipsis → **`540@70`（宽度对齐下方输入框/帮助行控件列）+ 顶对齐 + ≤2 行 clamp**，折行只向下（y75+46=121，距输入框顶 158 留 37px）；单行语言视觉零变化
- 手机 `LOGIN_SUBTITLE` 同几何改判，`Text numberOfLines` 1→2（RN 顶锚下生长天然顶对齐）

均补 harness 回归断言（`login-sso-org-hint` / `login-subtitle`），防写法回退。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `feat` 新功能（副标题 2 行完整展示为新口径落地）

### 范围

- 关联 Issue / 需求：登录链路多语言长文本口径（规范正文见 #288 `DESIGN.md §16.2`，副标题新口径同步入 #288）
- 本 PR 包含：桌面 LoginTitleBlock 副标题 + sso-org 帮助行布局约束、手机副标题同步、harness 断言（5 文件）
- 明确不包含：任何 i18n 文案改动；其它超预算文案的压缩（按 §16.2 走文案侧任务）
- 用户可见变化：副标题长语言完整显示为两行（不再截断出 "…"）；sso-org 帮助行不再压输入框；中文单行位置不变
- 是否存在 breaking change：无

### 远程 / 手机适配说明（AGENTS 规则）

纯视觉布局约束：不涉及 workdir / agent 进程 / 会话数据（SSH 远程工作区不受影响）；无新增 IPC channel（device-link allowlist 不涉及）；**手机版已在本 PR 同步适配**（LOGIN_SUBTITLE 几何 + numberOfLines 2）。

### UI 变化

修复前：英文副标题单行截断出 "…"；sso-org 帮助行两行外溢压输入框。修复后：副标题完整两行顶对齐、宽度与输入框列一致；帮助行只向下折行。中文单行位置均持平。

**1:1 对照演示页（内网，合并者可直接目验）**：https://pr298-login-longtext-demo.workers.xd.team ——左为 main 病灶复现、右为本 PR 修复，附 y238/y290/y300 基准线标尺。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
结果：22 passed（含帮助行 + 副标题契约断言）
pnpm --filter desktop typecheck / pnpm --filter mobile typecheck
结果：均通过
pnpm test:unit
结果：通过（exit 0；首轮 authAdaptersImportPurity 5s 超时为负载性偶发，单跑复核通过后完整重跑全绿，与本改动无关）
```

### 手工验证

几何推演核对：副标题 y75 + 两行 46 = 121，距输入框顶 158 留 37px；帮助行顶 244 + 46 = 290，距按钮顶 300 留 10px。四语副标题按 §16.2 估宽公式核算均 ≤2 行（en 最长 ≈88 拉丁字符 < 102 两行预算）。

### 未执行的验证

未在运行实例实拍（worktree 无 HMR；几何由常量推演 + 断言锁定）。Windows / Android 端未实测——纯标准 CSS / RN 属性，无平台分支，风险极低。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

登录皮组件布局约束，revert 即回滚。极端超两行 locale 会被 clamp——按 §16.2 属文案超预算（修文案）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

