### PR TITLE
fix(proxy): 上游连接支持代理环境变量与系统代理,修复非 TUN 代理下 502 AggregateError

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/outboundProxyResolver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/outboundProxyResolver.test.ts
@@ -5,6 +5,23 @@ const electronState = vi.hoisted(() => ({
   resolveProxy: vi.fn<(url: string) => Promise<string>>(async () => 'DIRECT'),
 }));
 
+const loggerState = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('../logger-adapter.js', () => ({
+  createMakerLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: loggerState.info,
+    warn: loggerState.warn,
+    error: vi.fn(),
+    child: vi.fn(),
+    isDebugEnabled: () => false,
+  }),
+}));
+
 // 覆盖全局 electron stub 的 app.isReady / session.resolveProxy,其余成员沿用 stub
 // (logger 等模块还要用 app.getPath)。
 vi.mock('electron', async (importOriginal) => {
@@ -46,6 +63,8 @@ beforeEach(() => {
   electronState.ready = true;
   electronState.resolveProxy.mockReset();
   electronState.resolveProxy.mockResolvedValue('DIRECT');
+  loggerState.info.mockClear();
+  loggerState.warn.mockClear();
   resetOutboundProxyResolverStateForTest();
 });
 
@@ -85,6 +104,14 @@ describe('resolveDesktopOutboundProxy', () => {
     process.env.HTTPS_PROXY = 'http://127.0.0.1:6152';
     await expect(resolveDesktopOutboundProxy('https://chatgpt.com:443')).resolves.toBe('http://127.0.0.1:6152');
     expect(electronState.resolveProxy).not.toHaveBeenCalled();
+  });
+
+  it('returns credentialed env proxy verbatim but only logs the redacted form', async () => {
+    process.env.HTTPS_PROXY = 'http://user:sekret@127.0.0.1:6152';
+    await expect(resolveDesktopOutboundProxy('https://chatgpt.com:443')).resolves.toBe('http://user:sekret@127.0.0.1:6152');
+    const logged = JSON.stringify([...loggerState.info.mock.calls, ...loggerState.warn.mock.calls]);
+    expect(logged).not.toContain('sekret');
+    expect(logged).toContain('http://127.0.0.1:6152');
   });
 
   it('treats env NO_PROXY hits as direct without falling back to the system proxy', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/outboundProxyResolver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/outboundProxyResolver.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const electronState = vi.hoisted(() => ({
+  ready: true,
+  resolveProxy: vi.fn<(url: string) => Promise<string>>(async () => 'DIRECT'),
+}));
+
+// 覆盖全局 electron stub 的 app.isReady / session.resolveProxy,其余成员沿用 stub
+// (logger 等模块还要用 app.getPath)。
+vi.mock('electron', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    app: Object.assign(Object.create(actual.app as object), {
+      isReady: () => electronState.ready,
+    }),
+    session: {
+      defaultSession: {
+        resolveProxy: (url: string) => electronState.resolveProxy(url),
+      },
+    },
+  };
+});
+
+import {
+  parseChromiumProxyResult,
+  resetOutboundProxyResolverStateForTest,
+  resolveDesktopOutboundProxy,
+} from '../outbound-proxy-resolver.js';
+
+const PROXY_ENV_KEYS = [
+  'HTTPS_PROXY', 'https_proxy',
+  'HTTP_PROXY', 'http_proxy',
+  'ALL_PROXY', 'all_proxy',
+  'NO_PROXY', 'no_proxy',
+] as const;
+
+// 开发机 shell 可能真的设了代理 env;逐 key 摘除并在测试后恢复,防止环境泄漏进断言。
+const savedEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  electronState.ready = true;
+  electronState.resolveProxy.mockReset();
+  electronState.resolveProxy.mockResolvedValue('DIRECT');
+  resetOutboundProxyResolverStateForTest();
+});
+
+afterEach(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    const value = savedEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('parseChromiumProxyResult', () => {
+  it('parses PROXY entries into http urls', () => {
+    expect(parseChromiumProxyResult('PROXY 127.0.0.1:7890')).toBe('http://127.0.0.1:7890');
+  });
+
+  it('returns null for DIRECT', () => {
+    expect(parseChromiumProxyResult('DIRECT')).toBe(null);
+  });
+
+  it('skips unsupported SOCKS/HTTPS entries and picks the next supported one', () => {
+    expect(parseChromiumProxyResult('SOCKS5 127.0.0.1:7891; PROXY 127.0.0.1:7890; DIRECT'))
+      .toBe('http://127.0.0.1:7890');
+    expect(parseChromiumProxyResult('HTTPS secure.proxy:443; DIRECT')).toBe(null);
+    expect(parseChromiumProxyResult('SOCKS 127.0.0.1:1080')).toBe(null);
+  });
+
+  it('tolerates malformed input', () => {
+    expect(parseChromiumProxyResult('')).toBe(null);
+    expect(parseChromiumProxyResult(';;')).toBe(null);
+    expect(parseChromiumProxyResult('PROXY')).toBe(null);
+  });
+});
+
+describe('resolveDesktopOutboundProxy', () => {
+  it('prefers proxy env vars and does not consult the system proxy', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:6152';
+    await expect(resolveDesktopOutboundProxy('https://chatgpt.com:443')).resolves.toBe('http://127.0.0.1:6152');
+    expect(electronState.resolveProxy).not.toHaveBeenCalled();
+  });
+
+  it('treats env NO_PROXY hits as direct without falling back to the system proxy', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:6152';
+    process.env.NO_PROXY = 'chatgpt.com';
+    electronState.resolveProxy.mockResolvedValue('PROXY 127.0.0.1:7890');
+    await expect(resolveDesktopOutboundProxy('https://chatgpt.com:443')).resolves.toBe(null);
+    expect(electronState.resolveProxy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the system proxy when no proxy env is set', async () => {
+    electronState.resolveProxy.mockResolvedValue('PROXY 127.0.0.1:7890; DIRECT');
+    await expect(resolveDesktopOutboundProxy('https://chatgpt.com:443')).resolves.toBe('http://127.0.0.1:7890');
+    expect(electronState.resolveProxy).toHaveBeenCalledWith('https://chatgpt.com:443');
+  });
+
+  it('caches system proxy resolutions per upstream origin', async () => {
+    electronState.resolveProxy.mockResolvedValue('PROXY 127.0.0.1:7890');
+    await resolveDesktopOutboundProxy('https://chatgpt.com:443');
+    await resolveDesktopOutboundProxy('https://chatgpt.com:443');
+    expect(electronState.resolveProxy).toHaveBeenCalledTimes(1);
+    await resolveDesktopOutboundProxy('https://api.x.ai:443');
+    expect(electronState.resolveProxy).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails open to direct when system resolution throws or app is not ready', async () => {
+    electronState.resolveProxy.mockRejectedValue(new Error('boom'));
+    await expect(resolveDesktopOutboundProxy('https://chatgpt.com:443')).resolves.toBe(null);
+
+    resetOutboundProxyResolverStateForTest();
+    electronState.ready = false;
+    electronState.resolveProxy.mockReset();
+    await expect(resolveDesktopOutboundProxy('https://chatgpt.com:443')).resolves.toBe(null);
+    expect(electronState.resolveProxy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -56,6 +56,7 @@ import {
   encryptedStripController,
 } from './thread-strip-controllers.js';
 import { createMakerLogger } from './logger-adapter.js';
+import { resolveDesktopOutboundProxy } from './outbound-proxy-resolver.js';
 import {
   createClaudeFastModeRequestTransform,
   createClaudeFastModeResponseObserver,
@@ -325,6 +326,9 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       // 请求体 dump 默认关(dev trace 级别 + agent 高并发会刷爆 main event loop
       // 与日志盘);诊断请求体时设 XDT_PROXY_DUMP_REQUEST_BODY=1 显式开启。
       debugDumpRequestBody: process.env.XDT_PROXY_DUMP_REQUEST_BODY === '1',
+      // 上游连接跟随代理环境变量 / 系统代理(非 TUN 的代理软件场景);无代理配置时直连,
+      // 行为与之前字节级一致。见 outbound-proxy-resolver.ts。
+      resolveOutboundProxy: resolveDesktopOutboundProxy,
     });
     log.debug('proxy ready', { url: _handle.url, upstream: claudeUpstreamEndpoint() });
   } catch (err) {

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -61,6 +61,7 @@ import { composeResponseObservers } from './claude-rate-limit-headers-observer.j
 import { createProviderUpstreamErrorObserver, reportProviderUpstreamError } from './provider-upstream-error-observer.js';
 import { encryptedStripController, imageGenerationStripController } from './thread-strip-controllers.js';
 import { createMakerLogger } from './logger-adapter.js';
+import { resolveDesktopOutboundProxy } from './outbound-proxy-resolver.js';
 import { readSilentEncryptedRetrySettings } from './silent-encrypted-retry-store.js';
 import { getLogDir } from '../logger.js';
 import { recordXaiRateLimitSnapshot } from '../usageBroadcaster.js';
@@ -1013,6 +1014,9 @@ export async function ensureCodexProxyReady(): Promise<void> {
           }),
         ],
         logger: log,
+        // 上游连接跟随代理环境变量 / 系统代理(非 TUN 的代理软件场景);无代理配置时直连,
+        // 行为与之前字节级一致。见 outbound-proxy-resolver.ts。
+        resolveOutboundProxy: resolveDesktopOutboundProxy,
       });
       if (generation !== _disposeGeneration) {
         await handle.dispose().catch((err) => {

--- a/apps/desktop/src/main/maker-host/outbound-proxy-resolver.ts
+++ b/apps/desktop/src/main/maker-host/outbound-proxy-resolver.ts
@@ -24,6 +24,7 @@ import { app, session } from 'electron';
 import {
   createEnvOutboundProxyResolver,
   hasProxyEnvConfig,
+  redactProxyUrlForLog,
   type OutboundProxyResolver,
 } from '@cindy/anthropic-compat-proxy';
 
@@ -66,7 +67,8 @@ const systemProxyCache = new Map<string, CachedResolution>();
 const lastLoggedByOrigin = new Map<string, string>();
 
 function logIfChanged(upstreamUrl: string, source: 'env' | 'system', value: string | null): void {
-  const rendered = value ?? 'direct';
+  // env 值可能是 http://user:pass@host 形态,持久化日志只允许脱敏形态(scheme://host:port)。
+  const rendered = value === null ? 'direct' : redactProxyUrlForLog(value);
   if (lastLoggedByOrigin.get(upstreamUrl) === `${source}:${rendered}`) return;
   lastLoggedByOrigin.set(upstreamUrl, `${source}:${rendered}`);
   log.info('outbound proxy resolved', { upstream: upstreamUrl, source, proxy: rendered });

--- a/apps/desktop/src/main/maker-host/outbound-proxy-resolver.ts
+++ b/apps/desktop/src/main/maker-host/outbound-proxy-resolver.ts
@@ -1,0 +1,124 @@
+/**
+ * Desktop 出站代理解析器 ——
+ *
+ * 本地 loopback proxy(anthropic-compat-proxy / codex proxy)转发上游用的是 Node http
+ * 栈,不读系统代理也不读代理环境变量;用户代理软件跑「系统代理」模式(非 TUN)时,
+ * 浏览器 / Codex CLI 正常而 Cindy 上游连接裸直连失败(502 upstream unreachable:
+ * AggregateError)。本模块给两个 proxy host 注入统一的解析器,分两层:
+ *
+ *   1. 代理环境变量(HTTPS_PROXY / HTTP_PROXY / ALL_PROXY / NO_PROXY):终端 dev
+ *      启动、用户显式配置的场景。只要设置了任一代理 env,就以 env 的判定为准
+ *      (包括 NO_PROXY 命中 = 直连,不再落到系统代理 —— 用户显式豁免的域不该被
+ *      系统代理接管)。
+ *   2. 系统代理(Electron session.resolveProxy):GUI 启动拿不到 shell env 的主场景。
+ *      Chromium 按系统设置 / PAC 逐 URL 解析,结果做短 TTL 缓存;只支持 PROXY
+ *      (明文 HTTP 代理)条目,HTTPS(TLS-to-proxy)/ SOCKS 条目跳过并继续找下一个
+ *      候选,全部不支持则直连(与今天行为一致,fail-open)。
+ *
+ * 解析结果变化时记一条 info(每个 origin 只在值变化时记),排查网络问题时 grep
+ * "outbound proxy" 即可看到当前生效路径。
+ */
+
+import { app, session } from 'electron';
+
+import {
+  createEnvOutboundProxyResolver,
+  hasProxyEnvConfig,
+  type OutboundProxyResolver,
+} from '@cindy/anthropic-compat-proxy';
+
+import { createMakerLogger } from './logger-adapter.js';
+
+const log = createMakerLogger('outbound-proxy');
+
+// 系统代理解析结果的 TTL:用户切换代理软件开关后最迟 30s 生效;Chromium 侧
+// resolveProxy 本身有缓存,这层主要省 per-request 的 Promise/IPC 往返。
+const SYSTEM_PROXY_CACHE_TTL_MS = 30 * 1000;
+
+/**
+ * 解析 Chromium resolveProxy 返回的 PAC 结果串(例 "PROXY 127.0.0.1:7890; SOCKS5
+ * 127.0.0.1:7891; DIRECT")→ 第一个受支持条目的 http:// 代理地址;DIRECT 或全部
+ * 不支持 → null(直连)。导出仅供单测。
+ */
+export function parseChromiumProxyResult(result: string): string | null {
+  for (const rawEntry of result.split(';')) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+    const spaceIdx = entry.indexOf(' ');
+    const kind = (spaceIdx === -1 ? entry : entry.slice(0, spaceIdx)).toUpperCase();
+    if (kind === 'DIRECT') return null;
+    const hostPort = spaceIdx === -1 ? '' : entry.slice(spaceIdx + 1).trim();
+    if (!hostPort) continue;
+    // PROXY = 明文 HTTP 代理(CONNECT 隧道可用)。HTTPS(TLS-to-proxy)与 SOCKS
+    // 系列暂不支持,跳过看下一个候选。
+    if (kind === 'PROXY') return `http://${hostPort}`;
+  }
+  return null;
+}
+
+interface CachedResolution {
+  value: string | null;
+  expiresAt: number;
+}
+
+const systemProxyCache = new Map<string, CachedResolution>();
+// 每个 origin 上次记录过日志的生效值;仅在变化时记 info,避免 per-request 刷日志。
+const lastLoggedByOrigin = new Map<string, string>();
+
+function logIfChanged(upstreamUrl: string, source: 'env' | 'system', value: string | null): void {
+  const rendered = value ?? 'direct';
+  if (lastLoggedByOrigin.get(upstreamUrl) === `${source}:${rendered}`) return;
+  lastLoggedByOrigin.set(upstreamUrl, `${source}:${rendered}`);
+  log.info('outbound proxy resolved', { upstream: upstreamUrl, source, proxy: rendered });
+}
+
+async function resolveViaSystemProxy(upstreamUrl: string): Promise<string | null> {
+  const cached = systemProxyCache.get(upstreamUrl);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  // app 未 ready 时 session 不可用;此时按直连处理(splash 极早期,正常请求不会赶在这)。
+  if (!app.isReady()) return null;
+  const ses = session.defaultSession;
+  if (!ses || typeof ses.resolveProxy !== 'function') return null;
+  let value: string | null = null;
+  try {
+    value = parseChromiumProxyResult(await ses.resolveProxy(upstreamUrl));
+  } catch (err) {
+    log.warn('system proxy resolution failed — using direct connection', {
+      upstream: upstreamUrl,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    value = null;
+  }
+  systemProxyCache.set(upstreamUrl, { value, expiresAt: Date.now() + SYSTEM_PROXY_CACHE_TTL_MS });
+  return value;
+}
+
+// 惰性初始化:单测可能对 @cindy/anthropic-compat-proxy 做部分 mock(如 codexProxyHost
+// 测试只 mock 了 createAnthropicCompatProxy),模块加载期不能调用包函数。
+let _envResolver: ((upstreamUrl: string) => string | null) | null = null;
+function envResolver(upstreamUrl: string): string | null {
+  _envResolver ??= createEnvOutboundProxyResolver();
+  return _envResolver(upstreamUrl);
+}
+
+/**
+ * 两个 proxy host 共用的出站代理解析器(单例,系统代理缓存共享)。
+ * per-request 由 anthropic-compat-proxy 以最终上游 origin 调用;loopback 上游
+ * 在包侧已被过滤,不会到这里。
+ */
+export const resolveDesktopOutboundProxy: OutboundProxyResolver = async (upstreamUrl) => {
+  if (hasProxyEnvConfig()) {
+    const fromEnv = envResolver(upstreamUrl);
+    logIfChanged(upstreamUrl, 'env', fromEnv);
+    return fromEnv;
+  }
+  const fromSystem = await resolveViaSystemProxy(upstreamUrl);
+  logIfChanged(upstreamUrl, 'system', fromSystem);
+  return fromSystem;
+};
+
+/** @internal 单测用:清空系统代理解析缓存与日志去重状态。 */
+export function resetOutboundProxyResolverStateForTest(): void {
+  systemProxyCache.clear();
+  lastLoggedByOrigin.clear();
+}

--- a/packages/anthropic-compat-proxy/package.json
+++ b/packages/anthropic-compat-proxy/package.json
@@ -26,6 +26,7 @@
     "@types/node": "*",
     "esbuild": "^0.27.0",
     "eslint": "^9.0.0",
+    "selfsigned": "^5.5.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.0.0",
     "vitest": "^3.2.4"

--- a/packages/anthropic-compat-proxy/src/bin/proxy.ts
+++ b/packages/anthropic-compat-proxy/src/bin/proxy.ts
@@ -19,6 +19,7 @@
  */
 
 import { createAnthropicCompatProxy } from '../server.js';
+import { createEnvOutboundProxyResolver } from '../outbound-proxy.js';
 import { ALLOW_NON_LOOPBACK_ENV, resolveListenHost } from '../host-guard.js';
 
 interface ParsedArgs {
@@ -101,6 +102,9 @@ async function runServe(upstream: string, host?: string): Promise<void> {
   const handle = await createAnthropicCompatProxy({
     upstream,
     host: guard.host,
+    // CLI 场景(远端 cc-manager 等)按惯例吃代理环境变量:HTTPS_PROXY / HTTP_PROXY /
+    // ALL_PROXY / NO_PROXY。未设置 = 直连,行为与之前一致。
+    resolveOutboundProxy: createEnvOutboundProxyResolver(),
     logger: {
       // Send all logs to stderr; stdout reserved for the JSON listen line.
       info: (msg, ctx) => process.stderr.write(`[proxy][info] ${msg} ${JSON.stringify(ctx ?? {})}\n`),

--- a/packages/anthropic-compat-proxy/src/index.ts
+++ b/packages/anthropic-compat-proxy/src/index.ts
@@ -15,6 +15,13 @@
 
 export { createAnthropicCompatProxy } from './server.js';
 export {
+  createEnvOutboundProxyResolver,
+  hasProxyEnvConfig,
+  parseOutboundProxyUrl,
+  redactProxyUrlForLog,
+} from './outbound-proxy.js';
+export type { OutboundProxyResolver, OutboundProxyTarget } from './outbound-proxy.js';
+export {
   createInstructionsInjectionTransform,
   createInstructionsRegistry,
 } from './instructions-injection.js';

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, afterEach } from 'vitest';
 import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
 import {
   createEnvOutboundProxyResolver,
+  formatAuthority,
   hasProxyEnvConfig,
   isLoopbackHostname,
   parseOutboundProxyUrl,
@@ -14,8 +15,9 @@ import {
 } from './outbound-proxy.js';
 
 // ─── 测试专用自签名证书(CN/SAN = upstream.test,有效期 100 年)────────────────
-// 仅供本测试文件的本地 TLS 桩使用,非任何真实凭证。客户端以 rejectAuthorized:false
-// 连接,证书内容本身不参与断言。
+// 仅供本测试文件的本地 TLS 桩使用,非任何真实凭证。客户端把它同时当 CA 用
+// (自签 = 自己就是根),配合 servername=upstream.test 走完整证书校验,
+// 不关闭 rejectUnauthorized。
 const TEST_TLS_KEY = `-----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCs7jn9/xp6anHr
 73FSJP5Z4Z6rsqFmdp6x6P8737CUzK+HZPhLv1Csd0ssmVpr/01AkTP+Fo000cf5
@@ -92,6 +94,21 @@ describe('parseOutboundProxyUrl', () => {
     expect(parseOutboundProxyUrl('not a url')).toBeNull();
     expect(parseOutboundProxyUrl('')).toBeNull();
     expect(parseOutboundProxyUrl(undefined)).toBeNull();
+  });
+
+  it('never throws on malformed percent-encoding in userinfo (regression: URIError escaped fail-open)', () => {
+    const parsed = parseOutboundProxyUrl('http://user%GG:pa%ZZss@127.0.0.1:8080');
+    expect(parsed?.hostname).toBe('127.0.0.1');
+    // 解不开的按原文进 Basic,不抛 URIError。
+    expect(parsed?.authHeader).toBe(`Basic ${Buffer.from('user%GG:pa%ZZss').toString('base64')}`);
+  });
+});
+
+describe('formatAuthority', () => {
+  it('brackets IPv6 literals and leaves hostnames/IPv4 alone', () => {
+    expect(formatAuthority('2001:db8::1', 443)).toBe('[2001:db8::1]:443');
+    expect(formatAuthority('example.com', 8080)).toBe('example.com:8080');
+    expect(formatAuthority('10.0.0.1', 80)).toBe('10.0.0.1:80');
   });
 });
 
@@ -204,10 +221,14 @@ describe('TunnelingHttpsAgent', () => {
 
   function requestViaAgent(agent: TunnelingHttpsAgent, host: string, port: number): Promise<number> {
     return new Promise<number>((resolve, reject) => {
-      const req = httpsRequest({ host, port, path: '/probe', agent, rejectUnauthorized: false }, (res) => {
-        res.resume();
-        res.on('end', () => resolve(res.statusCode ?? 0));
-      });
+      // ca + servername:对测试自签证书走完整 TLS 校验(链 + 身份),不禁用证书验证。
+      const req = httpsRequest(
+        { host, port, path: '/probe', agent, ca: TEST_TLS_CERT, servername: 'upstream.test' },
+        (res) => {
+          res.resume();
+          res.on('end', () => resolve(res.statusCode ?? 0));
+        },
+      );
       req.on('error', reject);
       req.end();
     });

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
@@ -97,6 +97,18 @@ describe('parseOutboundProxyUrl', () => {
     expect(parseOutboundProxyUrl(undefined)).toBeNull();
   });
 
+  it('unbrackets IPv6 proxy hostnames for TCP connect while keeping the bracketed url form', () => {
+    // WHATWG URL.hostname 对 IPv6 带方括号;connect host 必须是裸地址(回归:
+    // 带括号的 hostname 直接交给 net.connect 会解析失败)。
+    const parsed = parseOutboundProxyUrl('http://[::1]:7890');
+    expect(parsed).toEqual({
+      url: 'http://[::1]:7890',
+      hostname: '::1',
+      port: 7890,
+      authHeader: undefined,
+    });
+  });
+
   it('never throws on malformed percent-encoding in userinfo (regression: URIError escaped fail-open)', () => {
     const parsed = parseOutboundProxyUrl('http://user%GG:pa%ZZss@127.0.0.1:8080');
     expect(parsed?.hostname).toBe('127.0.0.1');

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
@@ -7,6 +7,7 @@ import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
 import {
   createEnvOutboundProxyResolver,
   formatAuthority,
+  formatHostHeader,
   hasProxyEnvConfig,
   isLoopbackHostname,
   parseOutboundProxyUrl,
@@ -109,6 +110,18 @@ describe('formatAuthority', () => {
     expect(formatAuthority('2001:db8::1', 443)).toBe('[2001:db8::1]:443');
     expect(formatAuthority('example.com', 8080)).toBe('example.com:8080');
     expect(formatAuthority('10.0.0.1', 80)).toBe('10.0.0.1:80');
+    // URL.hostname 已带方括号的形态不能二次包裹。
+    expect(formatAuthority('[2001:db8::1]', 443)).toBe('[2001:db8::1]:443');
+  });
+});
+
+describe('formatHostHeader', () => {
+  it('omits default ports, keeps non-default ports, brackets IPv6', () => {
+    expect(formatHostHeader('example.com', 80, 'http:')).toBe('example.com');
+    expect(formatHostHeader('example.com', 443, 'https:')).toBe('example.com');
+    expect(formatHostHeader('example.com', 8080, 'http:')).toBe('example.com:8080');
+    expect(formatHostHeader('2001:db8::1', 80, 'http:')).toBe('[2001:db8::1]');
+    expect(formatHostHeader('2001:db8::1', 8080, 'http:')).toBe('[2001:db8::1]:8080');
   });
 });
 
@@ -126,6 +139,8 @@ describe('isLoopbackHostname', () => {
     expect(isLoopbackHostname('localhost')).toBe(true);
     expect(isLoopbackHostname('sub.localhost')).toBe(true);
     expect(isLoopbackHostname('::1')).toBe(true);
+    // WHATWG URL.hostname 的 IPv6 形态带方括号,同样要识别。
+    expect(isLoopbackHostname('[::1]')).toBe(true);
     expect(isLoopbackHostname('api.anthropic.com')).toBe(false);
     expect(isLoopbackHostname('10.0.0.1')).toBe(false);
   });
@@ -158,6 +173,19 @@ describe('createEnvOutboundProxyResolver', () => {
     expect(r('example.com:8443', 'https://example.com:8443')).toBeNull();
     expect(r('example.com:8443', 'https://example.com')).toBe('http://127.0.0.1:1');
     expect(r('*', 'https://anything.test')).toBeNull();
+  });
+
+  it('matches bare IPv6 literals in NO_PROXY without misparsing the tail as a port', () => {
+    const env = { HTTPS_PROXY: 'http://127.0.0.1:1' };
+    const r = (noProxy: string, url: string) =>
+      createEnvOutboundProxyResolver({ ...env, NO_PROXY: noProxy })(url);
+    // 裸 IPv6:末段纯数字也不能被拆成端口(回归:`2001:db8::1` 曾被拆成 host `2001:db8::` + port 1)。
+    expect(r('2001:db8::1', 'https://[2001:db8::1]')).toBeNull();
+    expect(r('2001:db8::1', 'https://[2001:db8::99]')).toBe('http://127.0.0.1:1');
+    // [v6]:port 无歧义带端口形式:端口一致命中,不一致不命中。
+    expect(r('[2001:db8::1]:8443', 'https://[2001:db8::1]:8443')).toBeNull();
+    expect(r('[2001:db8::1]:8443', 'https://[2001:db8::1]')).toBe('http://127.0.0.1:1');
+    expect(r('[2001:db8::1]', 'https://[2001:db8::1]')).toBeNull();
   });
 
   it('never proxies loopback targets and tolerates bad urls', () => {

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
@@ -1,0 +1,263 @@
+import { createServer as createHttpsServer, request as httpsRequest } from 'node:https';
+import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
+import { connect as netConnect } from 'node:net';
+import { describe, expect, it, afterEach } from 'vitest';
+
+import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
+import {
+  createEnvOutboundProxyResolver,
+  hasProxyEnvConfig,
+  isLoopbackHostname,
+  parseOutboundProxyUrl,
+  redactProxyUrlForLog,
+  TunnelingHttpsAgent,
+} from './outbound-proxy.js';
+
+// ─── 测试专用自签名证书(CN/SAN = upstream.test,有效期 100 年)────────────────
+// 仅供本测试文件的本地 TLS 桩使用,非任何真实凭证。客户端以 rejectAuthorized:false
+// 连接,证书内容本身不参与断言。
+const TEST_TLS_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCs7jn9/xp6anHr
+73FSJP5Z4Z6rsqFmdp6x6P8737CUzK+HZPhLv1Csd0ssmVpr/01AkTP+Fo000cf5
+IDrPdD/DUj+OCEmfXRxJp8HhydunT1rkvlox6Ih+L1UWUBpX4EdC3AeNJPe/lEFe
+Jg/9nc2RRlPHw7gm6L2+Hd7Ip/SjPf0yvwELmx8Go2WfJ1q211Y/1T24nRw1PEV1
+kTZsY+C232JRQfbl0lK8soEdWiZmWSLHbkn0ULQXIhI7Z60rb8xs2xIILsUynoea
+2ooa9nnu9Rjq9iiuDAmLORcNkQNNMSX3mpctLg9sEEfUs+NpOZ8t/iMir1DwxT5N
+fybMh4SFAgMBAAECggEAEGKEASJmHloukBXATXGu3dJIR+llbIFpuN6kLEaeAwM/
+0FrLQdYPLUAiUcf37sqiRa9cV0NIvsvvoBWjLNvNXNLSrcDwRNa8IuhvsNaA5uHY
+cVrtzdPD9vzCGZqeXFwmNFoHpyJtDOxdoy+FDVkhzJV2w7MyJBGiRLysyqNLRRom
+6WOCD5UDQwV/8L1XYK3LSrV9cTy0l5cKcY1FQIdQ3a+dt+6PLD+yuGBIWLvvyggq
+flRSktRNxaRlFatUIheEdO06VI6UFXla2vDNpu4a1rp7AMJzWRd3gLF/PzyENhjO
+ov5loSDlerU+lX5FNWRJoiquwVVBHbs9B4KRpn0qMwKBgQDpRvz59vVGIyAW8OPW
+fKhZ7E/XWpB/BwSpdX9kNj+oK4/k8W37MzKLgueE7frdE40OB3+GevKqm0AsNN+L
+v6NvEzVh/Gi4FyP3dH2ILiFFYU/tdKvD27PiNLgg4uzW+Cdfyh2DPTmMGj0gjXvb
+eO/NjzrVd9IkkzX0CEZmsmBaCwKBgQC9xm4XXJYQS+41/xP0xs1hrt5sdaqVNiXh
+XHNp9NBzn2OM+hFoRwGHcbzwJWIxJR6OD5IMNpBUenQE0c5JZOL0gwgbXn/rAqRV
+TniF16bv9Uw2cHAx17De3+SsAol7EkUhsIcXS9lxYarcyqLsuNaGq8xbIKEBHmfd
+wBMVMU9FrwKBgCSPMpB+SrxePuY5hIuV59CH/49RqzmtQObJ+lgbRGi3wwpvZ/wp
+bu98aYpkvZ8uNDoRpMPPuv5P7IPBGZPOSe/bg89CfqrzPXjHsfDIwgAcmyks0sqU
+QSHff0fwKIwcQhd6Fpv92WoCprfWVKX10ydVHjRcXfvLcnY3YckwhXc3AoGAcmW1
+Y5vKUhSTijUzgHB+yg2xwsvDgqLbfthOMmcDaU+BoS/1Yli7UTx82n6OjHWFz7kP
+HxGdO299lJIsug14ylBaiLUUg0Rab5oYCQaQeUHzKTXqTAFre06X+CCnY2sGBWL2
+bFKqxzBK4UG9qNlbaF8TlzM6GwSLNB9e4X2R/b0CgYAqoXMa2MeXaA5GzIg9/PeU
+UEkXjU841pQbdw49wTiMrk8qm24aiWxu1Z5R79DKpY0jeNxuc03ChzYIXksylQ/L
+oMATHYy8OlLJ3j4eQNIwSWh1bIyGXV7Jkv/swynh0VzTGf4UyV4K/v0DErcVO9rP
+W0ETJ1ulu43omEuNGkCkdQ==
+-----END PRIVATE KEY-----`;
+
+const TEST_TLS_CERT = `-----BEGIN CERTIFICATE-----
+MIIDLTCCAhWgAwIBAgIUIEXWlocxnpLV63aHJin8lDGkJtEwDQYJKoZIhvcNAQEL
+BQAwGDEWMBQGA1UEAwwNdXBzdHJlYW0udGVzdDAgFw0yNjA3MjQwODQ2MjFaGA8y
+MTI2MDYzMDA4NDYyMVowGDEWMBQGA1UEAwwNdXBzdHJlYW0udGVzdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKzuOf3/GnpqcevvcVIk/lnhnquyoWZ2
+nrHo/zvfsJTMr4dk+Eu/UKx3SyyZWmv/TUCRM/4WjTTRx/kgOs90P8NSP44ISZ9d
+HEmnweHJ26dPWuS+WjHoiH4vVRZQGlfgR0LcB40k97+UQV4mD/2dzZFGU8fDuCbo
+vb4d3sin9KM9/TK/AQubHwajZZ8nWrbXVj/VPbidHDU8RXWRNmxj4LbfYlFB9uXS
+UryygR1aJmZZIsduSfRQtBciEjtnrStvzGzbEgguxTKeh5raihr2ee71GOr2KK4M
+CYs5Fw2RA00xJfealy0uD2wQR9Sz42k5ny3+IyKvUPDFPk1/JsyHhIUCAwEAAaNt
+MGswHQYDVR0OBBYEFOMEEoDze4qD05At9+bjkHfP3+HwMB8GA1UdIwQYMBaAFOME
+EoDze4qD05At9+bjkHfP3+HwMA8GA1UdEwEB/wQFMAMBAf8wGAYDVR0RBBEwD4IN
+dXBzdHJlYW0udGVzdDANBgkqhkiG9w0BAQsFAAOCAQEAaiSXH428BzaOf+4D34V+
+j6Sisp4j2Zeo/DILTOG/TN9kYS3twTzXgAZ62EsvBEPmIuivI6rzOdmYGAHKM+RH
+MH/NZG6D5REdRnoJA9UUOxSGYO6MIAZMb3OzUl0EjWTKnFuDq39Cko6e5+SkM+Pr
+e5s74zkHfTJVmhViyWFls/3UYO5dB/CpiHA0/lUZF1tAEsvm1iPGvXjQRSvi7GCy
+5T5F2ERHMZ7vla/ijDGwPz4dI5pFfbSFbbx+0dAKZsper5sWdxh9iq5fITlGgaGR
+WZ55rszyYN4IK5//d86AdI6N3eYVVf0L0N6PH7zv+vuMr46qO93skYlSbnU7RIos
+lg==
+-----END CERTIFICATE-----`;
+
+describe('parseOutboundProxyUrl', () => {
+  it('parses plain http proxy urls', () => {
+    expect(parseOutboundProxyUrl('http://127.0.0.1:7890')).toEqual({
+      url: 'http://127.0.0.1:7890',
+      hostname: '127.0.0.1',
+      port: 7890,
+      authHeader: undefined,
+    });
+  });
+
+  it('defaults to port 80 when omitted', () => {
+    expect(parseOutboundProxyUrl('http://proxy.corp')?.port).toBe(80);
+  });
+
+  it('turns userinfo into a basic Proxy-Authorization header and strips it from url', () => {
+    const parsed = parseOutboundProxyUrl('http://user:p%40ss@127.0.0.1:8080');
+    expect(parsed?.url).toBe('http://127.0.0.1:8080');
+    expect(parsed?.authHeader).toBe(`Basic ${Buffer.from('user:p@ss').toString('base64')}`);
+  });
+
+  it('rejects unsupported schemes and garbage', () => {
+    expect(parseOutboundProxyUrl('https://127.0.0.1:7890')).toBeNull();
+    expect(parseOutboundProxyUrl('socks5://127.0.0.1:7891')).toBeNull();
+    expect(parseOutboundProxyUrl('not a url')).toBeNull();
+    expect(parseOutboundProxyUrl('')).toBeNull();
+    expect(parseOutboundProxyUrl(undefined)).toBeNull();
+  });
+});
+
+describe('redactProxyUrlForLog', () => {
+  it('drops credentials, keeps scheme and host', () => {
+    expect(redactProxyUrlForLog('http://user:secret@10.0.0.1:8080')).toBe('http://10.0.0.1:8080');
+    expect(redactProxyUrlForLog('garbage')).toBe('<unparseable proxy url>');
+  });
+});
+
+describe('isLoopbackHostname', () => {
+  it('matches loopback shapes only', () => {
+    expect(isLoopbackHostname('127.0.0.1')).toBe(true);
+    expect(isLoopbackHostname('127.1.2.3')).toBe(true);
+    expect(isLoopbackHostname('localhost')).toBe(true);
+    expect(isLoopbackHostname('sub.localhost')).toBe(true);
+    expect(isLoopbackHostname('::1')).toBe(true);
+    expect(isLoopbackHostname('api.anthropic.com')).toBe(false);
+    expect(isLoopbackHostname('10.0.0.1')).toBe(false);
+  });
+});
+
+describe('createEnvOutboundProxyResolver', () => {
+  it('routes https targets via HTTPS_PROXY and http targets via HTTP_PROXY', () => {
+    const resolve = createEnvOutboundProxyResolver({
+      HTTPS_PROXY: 'http://127.0.0.1:1',
+      HTTP_PROXY: 'http://127.0.0.1:2',
+    });
+    expect(resolve('https://chatgpt.com:443')).toBe('http://127.0.0.1:1');
+    expect(resolve('http://gateway.corp:80')).toBe('http://127.0.0.1:2');
+  });
+
+  it('supports lowercase spellings and ALL_PROXY fallback', () => {
+    expect(createEnvOutboundProxyResolver({ https_proxy: 'http://127.0.0.1:3' })('https://x.test')).toBe('http://127.0.0.1:3');
+    expect(createEnvOutboundProxyResolver({ ALL_PROXY: 'http://127.0.0.1:4' })('https://x.test')).toBe('http://127.0.0.1:4');
+    expect(createEnvOutboundProxyResolver({ all_proxy: 'http://127.0.0.1:5' })('http://x.test')).toBe('http://127.0.0.1:5');
+  });
+
+  it('honors NO_PROXY exact host, subdomain, leading dot, port and wildcard forms', () => {
+    const env = { HTTPS_PROXY: 'http://127.0.0.1:1' };
+    const r = (noProxy: string, url: string) =>
+      createEnvOutboundProxyResolver({ ...env, NO_PROXY: noProxy })(url);
+    expect(r('example.com', 'https://example.com')).toBeNull();
+    expect(r('example.com', 'https://api.example.com')).toBeNull();
+    expect(r('.example.com', 'https://api.example.com')).toBeNull();
+    expect(r('example.com', 'https://notexample.com')).toBe('http://127.0.0.1:1');
+    expect(r('example.com:8443', 'https://example.com:8443')).toBeNull();
+    expect(r('example.com:8443', 'https://example.com')).toBe('http://127.0.0.1:1');
+    expect(r('*', 'https://anything.test')).toBeNull();
+  });
+
+  it('never proxies loopback targets and tolerates bad urls', () => {
+    const resolve = createEnvOutboundProxyResolver({ HTTPS_PROXY: 'http://127.0.0.1:1' });
+    expect(resolve('https://127.0.0.1:9999')).toBeNull();
+    expect(resolve('http://localhost:3333')).toBeNull();
+    expect(resolve('not-a-url')).toBeNull();
+  });
+});
+
+describe('hasProxyEnvConfig', () => {
+  it('detects any proxy env var, ignoring NO_PROXY alone', () => {
+    expect(hasProxyEnvConfig({})).toBe(false);
+    expect(hasProxyEnvConfig({ NO_PROXY: '*' })).toBe(false);
+    expect(hasProxyEnvConfig({ HTTPS_PROXY: 'http://x:1' })).toBe(true);
+    expect(hasProxyEnvConfig({ all_proxy: 'http://x:1' })).toBe(true);
+    expect(hasProxyEnvConfig({ HTTPS_PROXY: '   ' })).toBe(false);
+  });
+});
+
+describe('TunnelingHttpsAgent', () => {
+  const cleanups: Array<() => Promise<void> | void> = [];
+  afterEach(async () => {
+    while (cleanups.length) await cleanups.pop()!();
+  });
+
+  /** 起一个最小 CONNECT 代理:记录 CONNECT 目标,把隧道打到本地指定端口。 */
+  async function startConnectProxy(tunnelToPort: number): Promise<{
+    port: number;
+    connects: string[];
+    authHeaders: Array<string | undefined>;
+  }> {
+    const connects: string[] = [];
+    const authHeaders: Array<string | undefined> = [];
+    const proxy = createHttpServer();
+    proxy.on('connect', (req, clientSocket) => {
+      connects.push(req.url ?? '');
+      authHeaders.push(req.headers['proxy-authorization']);
+      const upstreamSocket = netConnect(tunnelToPort, '127.0.0.1', () => {
+        clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        upstreamSocket.pipe(clientSocket);
+        clientSocket.pipe(upstreamSocket);
+      });
+      upstreamSocket.on('error', () => clientSocket.destroy());
+      clientSocket.on('error', () => upstreamSocket.destroy());
+    });
+    const port = await listenOnAvailableLoopbackPort(proxy);
+    cleanups.push(() => new Promise<void>((r) => proxy.close(() => r())));
+    return { port, connects, authHeaders };
+  }
+
+  async function startTlsUpstream(): Promise<number> {
+    const tls = createHttpsServer({ key: TEST_TLS_KEY, cert: TEST_TLS_CERT }, (_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const port = await listenOnAvailableLoopbackPort(tls as unknown as HttpServer);
+    cleanups.push(() => new Promise<void>((r) => tls.close(() => r())));
+    return port;
+  }
+
+  function requestViaAgent(agent: TunnelingHttpsAgent, host: string, port: number): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+      const req = httpsRequest({ host, port, path: '/probe', agent, rejectUnauthorized: false }, (res) => {
+        res.resume();
+        res.on('end', () => resolve(res.statusCode ?? 0));
+      });
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  it('tunnels https requests through CONNECT and reuses the keep-alive tunnel', async () => {
+    const tlsPort = await startTlsUpstream();
+    const { port: proxyPort, connects, authHeaders } = await startConnectProxy(tlsPort);
+    const agent = new TunnelingHttpsAgent({
+      url: `http://127.0.0.1:${proxyPort}`,
+      hostname: '127.0.0.1',
+      port: proxyPort,
+      authHeader: 'Basic dGVzdDp0ZXN0',
+    });
+    cleanups.push(() => agent.destroy());
+
+    expect(await requestViaAgent(agent, '127.0.0.1', tlsPort)).toBe(200);
+    expect(await requestViaAgent(agent, '127.0.0.1', tlsPort)).toBe(200);
+
+    // keep-alive:第二个请求复用隧道,CONNECT 只发生一次;鉴权头透传。
+    expect(connects).toEqual([`127.0.0.1:${tlsPort}`]);
+    expect(authHeaders).toEqual(['Basic dGVzdDp0ZXN0']);
+  });
+
+  it('surfaces CONNECT rejection as a request error', async () => {
+    const proxy = createHttpServer();
+    proxy.on('connect', (_req, clientSocket) => {
+      clientSocket.end('HTTP/1.1 403 Forbidden\r\n\r\n');
+    });
+    const proxyPort = await listenOnAvailableLoopbackPort(proxy);
+    cleanups.push(() => new Promise<void>((r) => proxy.close(() => r())));
+    const agent = new TunnelingHttpsAgent({
+      url: `http://127.0.0.1:${proxyPort}`,
+      hostname: '127.0.0.1',
+      port: proxyPort,
+    });
+    cleanups.push(() => agent.destroy());
+
+    await expect(requestViaAgent(agent, '127.0.0.1', 443)).rejects.toThrow(/CONNECT .* failed: HTTP 403/);
+  });
+
+  it('surfaces unreachable proxy as a request error', async () => {
+    // 端口 1 基本必然拒绝连接;错误信息应指向代理不可达而非上游。
+    const agent = new TunnelingHttpsAgent({
+      url: 'http://127.0.0.1:1',
+      hostname: '127.0.0.1',
+      port: 1,
+    });
+    cleanups.push(() => agent.destroy());
+
+    await expect(requestViaAgent(agent, '127.0.0.1', 443)).rejects.toThrow(/outbound proxy http:\/\/127\.0\.0\.1:1 unreachable/);
+  });
+});

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.test.ts
@@ -1,7 +1,8 @@
 import { createServer as createHttpsServer, request as httpsRequest } from 'node:https';
 import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
 import { connect as netConnect } from 'node:net';
-import { describe, expect, it, afterEach } from 'vitest';
+import { generate as generateSelfSignedCert } from 'selfsigned';
+import { beforeAll, describe, expect, it, afterEach } from 'vitest';
 
 import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
 import {
@@ -14,60 +15,6 @@ import {
   redactProxyUrlForLog,
   TunnelingHttpsAgent,
 } from './outbound-proxy.js';
-
-// ─── 测试专用自签名证书(CN/SAN = upstream.test,有效期 100 年)────────────────
-// 仅供本测试文件的本地 TLS 桩使用,非任何真实凭证。客户端把它同时当 CA 用
-// (自签 = 自己就是根),配合 servername=upstream.test 走完整证书校验,
-// 不关闭 rejectUnauthorized。
-const TEST_TLS_KEY = `-----BEGIN PRIVATE KEY-----
-MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCs7jn9/xp6anHr
-73FSJP5Z4Z6rsqFmdp6x6P8737CUzK+HZPhLv1Csd0ssmVpr/01AkTP+Fo000cf5
-IDrPdD/DUj+OCEmfXRxJp8HhydunT1rkvlox6Ih+L1UWUBpX4EdC3AeNJPe/lEFe
-Jg/9nc2RRlPHw7gm6L2+Hd7Ip/SjPf0yvwELmx8Go2WfJ1q211Y/1T24nRw1PEV1
-kTZsY+C232JRQfbl0lK8soEdWiZmWSLHbkn0ULQXIhI7Z60rb8xs2xIILsUynoea
-2ooa9nnu9Rjq9iiuDAmLORcNkQNNMSX3mpctLg9sEEfUs+NpOZ8t/iMir1DwxT5N
-fybMh4SFAgMBAAECggEAEGKEASJmHloukBXATXGu3dJIR+llbIFpuN6kLEaeAwM/
-0FrLQdYPLUAiUcf37sqiRa9cV0NIvsvvoBWjLNvNXNLSrcDwRNa8IuhvsNaA5uHY
-cVrtzdPD9vzCGZqeXFwmNFoHpyJtDOxdoy+FDVkhzJV2w7MyJBGiRLysyqNLRRom
-6WOCD5UDQwV/8L1XYK3LSrV9cTy0l5cKcY1FQIdQ3a+dt+6PLD+yuGBIWLvvyggq
-flRSktRNxaRlFatUIheEdO06VI6UFXla2vDNpu4a1rp7AMJzWRd3gLF/PzyENhjO
-ov5loSDlerU+lX5FNWRJoiquwVVBHbs9B4KRpn0qMwKBgQDpRvz59vVGIyAW8OPW
-fKhZ7E/XWpB/BwSpdX9kNj+oK4/k8W37MzKLgueE7frdE40OB3+GevKqm0AsNN+L
-v6NvEzVh/Gi4FyP3dH2ILiFFYU/tdKvD27PiNLgg4uzW+Cdfyh2DPTmMGj0gjXvb
-eO/NjzrVd9IkkzX0CEZmsmBaCwKBgQC9xm4XXJYQS+41/xP0xs1hrt5sdaqVNiXh
-XHNp9NBzn2OM+hFoRwGHcbzwJWIxJR6OD5IMNpBUenQE0c5JZOL0gwgbXn/rAqRV
-TniF16bv9Uw2cHAx17De3+SsAol7EkUhsIcXS9lxYarcyqLsuNaGq8xbIKEBHmfd
-wBMVMU9FrwKBgCSPMpB+SrxePuY5hIuV59CH/49RqzmtQObJ+lgbRGi3wwpvZ/wp
-bu98aYpkvZ8uNDoRpMPPuv5P7IPBGZPOSe/bg89CfqrzPXjHsfDIwgAcmyks0sqU
-QSHff0fwKIwcQhd6Fpv92WoCprfWVKX10ydVHjRcXfvLcnY3YckwhXc3AoGAcmW1
-Y5vKUhSTijUzgHB+yg2xwsvDgqLbfthOMmcDaU+BoS/1Yli7UTx82n6OjHWFz7kP
-HxGdO299lJIsug14ylBaiLUUg0Rab5oYCQaQeUHzKTXqTAFre06X+CCnY2sGBWL2
-bFKqxzBK4UG9qNlbaF8TlzM6GwSLNB9e4X2R/b0CgYAqoXMa2MeXaA5GzIg9/PeU
-UEkXjU841pQbdw49wTiMrk8qm24aiWxu1Z5R79DKpY0jeNxuc03ChzYIXksylQ/L
-oMATHYy8OlLJ3j4eQNIwSWh1bIyGXV7Jkv/swynh0VzTGf4UyV4K/v0DErcVO9rP
-W0ETJ1ulu43omEuNGkCkdQ==
------END PRIVATE KEY-----`;
-
-const TEST_TLS_CERT = `-----BEGIN CERTIFICATE-----
-MIIDLTCCAhWgAwIBAgIUIEXWlocxnpLV63aHJin8lDGkJtEwDQYJKoZIhvcNAQEL
-BQAwGDEWMBQGA1UEAwwNdXBzdHJlYW0udGVzdDAgFw0yNjA3MjQwODQ2MjFaGA8y
-MTI2MDYzMDA4NDYyMVowGDEWMBQGA1UEAwwNdXBzdHJlYW0udGVzdDCCASIwDQYJ
-KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKzuOf3/GnpqcevvcVIk/lnhnquyoWZ2
-nrHo/zvfsJTMr4dk+Eu/UKx3SyyZWmv/TUCRM/4WjTTRx/kgOs90P8NSP44ISZ9d
-HEmnweHJ26dPWuS+WjHoiH4vVRZQGlfgR0LcB40k97+UQV4mD/2dzZFGU8fDuCbo
-vb4d3sin9KM9/TK/AQubHwajZZ8nWrbXVj/VPbidHDU8RXWRNmxj4LbfYlFB9uXS
-UryygR1aJmZZIsduSfRQtBciEjtnrStvzGzbEgguxTKeh5raihr2ee71GOr2KK4M
-CYs5Fw2RA00xJfealy0uD2wQR9Sz42k5ny3+IyKvUPDFPk1/JsyHhIUCAwEAAaNt
-MGswHQYDVR0OBBYEFOMEEoDze4qD05At9+bjkHfP3+HwMB8GA1UdIwQYMBaAFOME
-EoDze4qD05At9+bjkHfP3+HwMA8GA1UdEwEB/wQFMAMBAf8wGAYDVR0RBBEwD4IN
-dXBzdHJlYW0udGVzdDANBgkqhkiG9w0BAQsFAAOCAQEAaiSXH428BzaOf+4D34V+
-j6Sisp4j2Zeo/DILTOG/TN9kYS3twTzXgAZ62EsvBEPmIuivI6rzOdmYGAHKM+RH
-MH/NZG6D5REdRnoJA9UUOxSGYO6MIAZMb3OzUl0EjWTKnFuDq39Cko6e5+SkM+Pr
-e5s74zkHfTJVmhViyWFls/3UYO5dB/CpiHA0/lUZF1tAEsvm1iPGvXjQRSvi7GCy
-5T5F2ERHMZ7vla/ijDGwPz4dI5pFfbSFbbx+0dAKZsper5sWdxh9iq5fITlGgaGR
-WZ55rszyYN4IK5//d86AdI6N3eYVVf0L0N6PH7zv+vuMr46qO93skYlSbnU7RIos
-lg==
------END CERTIFICATE-----`;
 
 describe('parseOutboundProxyUrl', () => {
   it('parses plain http proxy urls', () => {
@@ -224,6 +171,24 @@ describe('TunnelingHttpsAgent', () => {
     while (cleanups.length) await cleanups.pop()!();
   });
 
+  // 测试自签证书运行时生成(CN/SAN = upstream.test),不在仓库里存任何 PEM 私钥
+  // (即使是测试专用的假密钥也会触发 secret scanning / push protection)。
+  let tlsKey = '';
+  let tlsCert = '';
+  beforeAll(async () => {
+    // 有效期用默认(365 天)—— 每次运行现生成,不存在过期问题。
+    const pems = await generateSelfSignedCert([{ name: 'commonName', value: 'upstream.test' }], {
+      keySize: 2048,
+      algorithm: 'sha256',
+      extensions: [
+        { name: 'basicConstraints', cA: true },
+        { name: 'subjectAltName', altNames: [{ type: 2, value: 'upstream.test' }] },
+      ],
+    });
+    tlsKey = pems.private;
+    tlsCert = pems.cert;
+  });
+
   /** 起一个最小 CONNECT 代理:记录 CONNECT 目标,把隧道打到本地指定端口。 */
   async function startConnectProxy(tunnelToPort: number): Promise<{
     port: number;
@@ -250,7 +215,7 @@ describe('TunnelingHttpsAgent', () => {
   }
 
   async function startTlsUpstream(): Promise<number> {
-    const tls = createHttpsServer({ key: TEST_TLS_KEY, cert: TEST_TLS_CERT }, (_req, res) => {
+    const tls = createHttpsServer({ key: tlsKey, cert: tlsCert }, (_req, res) => {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
     });
@@ -263,7 +228,7 @@ describe('TunnelingHttpsAgent', () => {
     return new Promise<number>((resolve, reject) => {
       // ca + servername:对测试自签证书走完整 TLS 校验(链 + 身份),不禁用证书验证。
       const req = httpsRequest(
-        { host, port, path: '/probe', agent, ca: TEST_TLS_CERT, servername: 'upstream.test' },
+        { host, port, path: '/probe', agent, ca: tlsCert, servername: 'upstream.test' },
         (res) => {
           res.resume();
           res.on('end', () => resolve(res.statusCode ?? 0));

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.ts
@@ -1,0 +1,285 @@
+/**
+ * 出站(上游方向)HTTP 代理支持 ——
+ *
+ * 背景:proxy 转发上游用的是 node:http/https 直连,而 Node 的 http 栈不读系统代理、
+ * 也不读代理环境变量。用户的代理软件跑在「系统代理」模式(非 TUN)时,浏览器 / Codex CLI
+ * (reqwest 自动吃 env)都正常,唯独本代理的上游连接裸直连 → 高墙网络下 AggregateError
+ * → 客户端收 502 "upstream unreachable"。本模块提供:
+ *
+ *   - parseOutboundProxyUrl:解析 `http://[user:pass@]host:port` 形式的代理地址
+ *     (当前只支持 HTTP 代理;https/socks 代理返回 null,由调用方回落直连并告警)
+ *   - createEnvOutboundProxyResolver:按惯例读 HTTPS_PROXY / HTTP_PROXY / ALL_PROXY /
+ *     NO_PROXY(大小写两种拼写),给非 Electron 宿主(CLI / 远端 cc-manager)直接用
+ *   - TunnelingHttpsAgent:经代理 CONNECT 隧道连 https 上游的 keep-alive Agent
+ *     (TLS 端到端,由 https.Agent 原生逻辑完成,代理只见密文)
+ *   - OutboundProxyAgentPool:按代理地址缓存 agent,复用连接池,随 proxy dispose 销毁
+ *
+ * 边界:代理鉴权只支持 URL userinfo → Proxy-Authorization: Basic;系统代理的
+ * 解析(Electron session.resolveProxy)由宿主注入 resolver,本包不依赖 Electron。
+ */
+
+import { request as httpRequest, type ClientRequestArgs, type RequestOptions } from 'node:http';
+import { Agent as HttpsAgent, type AgentOptions } from 'node:https';
+import type { TcpSocketConnectOpts } from 'node:net';
+import type { Duplex } from 'node:stream';
+import { URL } from 'node:url';
+
+/** 解析后的出站代理目标。authHeader 是现成的 Proxy-Authorization 值(含 "Basic " 前缀)。 */
+export interface OutboundProxyTarget {
+  /** 规范化代理地址(不含 userinfo,可安全进日志),例 "http://127.0.0.1:7890"。 */
+  url: string;
+  hostname: string;
+  port: number;
+  authHeader?: string;
+}
+
+/**
+ * 出站代理解析器 —— per-request 以最终上游 origin(`https://host:port`)现取代理地址。
+ * 返回 http:// 代理 URL = 该请求经代理转发;null/undefined = 直连。
+ * 抛错按直连处理(fail-open,代理解析故障不断链路)。loopback 上游不会被调用。
+ */
+export type OutboundProxyResolver = (
+  upstreamUrl: string,
+) => string | null | undefined | Promise<string | null | undefined>;
+
+/**
+ * loopback 上游永不走代理:本机 bridge / gateway 与代理软件无关,而且系统代理的
+ * bypass 规则(localhost 默认直连)在 env 层不可见,这里必须自兜。
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return h === 'localhost' || h.endsWith('.localhost') || h === '::1' || h.startsWith('127.');
+}
+
+/**
+ * 解析代理地址。只接受 http: 协议(CONNECT 隧道 / 绝对形式都建立在明文 HTTP 代理上);
+ * https:(TLS-to-proxy)与 socks: 暂不支持,返回 null 由调用方回落直连。
+ */
+export function parseOutboundProxyUrl(raw: string | null | undefined): OutboundProxyTarget | null {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  if (!trimmed) return null;
+  let u: URL;
+  try {
+    u = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'http:') return null;
+  if (!u.hostname) return null;
+  const port = u.port ? Number(u.port) : 80;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  let authHeader: string | undefined;
+  if (u.username) {
+    // URL 里的 userinfo 是百分号编码的,先解码再进 Basic。
+    const user = decodeURIComponent(u.username);
+    const pass = u.password ? decodeURIComponent(u.password) : '';
+    authHeader = `Basic ${Buffer.from(`${user}:${pass}`, 'utf8').toString('base64')}`;
+  }
+  return { url: `http://${u.host}`, hostname: u.hostname, port, authHeader };
+}
+
+/** 把可能带凭证的代理地址脱敏成可进日志的形式(只留 scheme://host:port)。 */
+export function redactProxyUrlForLog(raw: string): string {
+  try {
+    const u = new URL(raw.trim());
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return '<unparseable proxy url>';
+  }
+}
+
+const ENV_HTTPS_KEYS = ['HTTPS_PROXY', 'https_proxy'] as const;
+const ENV_HTTP_KEYS = ['HTTP_PROXY', 'http_proxy'] as const;
+const ENV_ALL_KEYS = ['ALL_PROXY', 'all_proxy'] as const;
+const ENV_NO_PROXY_KEYS = ['NO_PROXY', 'no_proxy'] as const;
+
+function firstEnvValue(env: NodeJS.ProcessEnv, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+/** 宿主是否配置了任何代理环境变量(用于「env 有配置就以 env 为准」的分层判断)。 */
+export function hasProxyEnvConfig(env: NodeJS.ProcessEnv = process.env): boolean {
+  return firstEnvValue(env, [...ENV_HTTPS_KEYS, ...ENV_HTTP_KEYS, ...ENV_ALL_KEYS]) !== null;
+}
+
+/**
+ * NO_PROXY 匹配(逗号分隔)。支持惯例语义:
+ *   - `*` 全部直连
+ *   - `example.com` / `.example.com` 匹配该域及其子域
+ *   - `host:port` 额外要求端口一致
+ * IP 段(CIDR)不支持 —— 与多数实现一致,按普通字面 host 处理。
+ */
+function noProxyMatches(noProxy: string, hostname: string, port: number): boolean {
+  const host = hostname.toLowerCase();
+  for (const rawEntry of noProxy.split(',')) {
+    const entry = rawEntry.trim().toLowerCase();
+    if (!entry) continue;
+    if (entry === '*') return true;
+    let entryHost = entry;
+    let entryPort: number | null = null;
+    const colon = entry.lastIndexOf(':');
+    // IPv6 字面量里也有冒号;只有「冒号后是纯数字」才当端口拆。
+    if (colon > 0 && /^\d+$/.test(entry.slice(colon + 1))) {
+      entryHost = entry.slice(0, colon);
+      entryPort = Number(entry.slice(colon + 1));
+    }
+    if (entryPort !== null && entryPort !== port) continue;
+    const bare = entryHost.startsWith('.') ? entryHost.slice(1) : entryHost;
+    if (!bare) continue;
+    if (host === bare || host.endsWith(`.${bare}`)) return true;
+  }
+  return false;
+}
+
+/**
+ * 环境变量代理解析器。语义与 curl / reqwest 等惯例对齐:
+ *   https 上游 → HTTPS_PROXY ?? ALL_PROXY;http 上游 → HTTP_PROXY ?? ALL_PROXY;
+ *   NO_PROXY 命中或 loopback 上游 → 直连。
+ * env 值在每次调用时现读(默认 process.env),宿主运行期改 env 即时生效。
+ */
+export function createEnvOutboundProxyResolver(
+  env: NodeJS.ProcessEnv = process.env,
+): (upstreamUrl: string) => string | null {
+  return (upstreamUrl: string): string | null => {
+    let u: URL;
+    try {
+      u = new URL(upstreamUrl);
+    } catch {
+      return null;
+    }
+    if (isLoopbackHostname(u.hostname)) return null;
+    const port = u.port ? Number(u.port) : (u.protocol === 'https:' ? 443 : 80);
+    const noProxy = firstEnvValue(env, ENV_NO_PROXY_KEYS);
+    if (noProxy && noProxyMatches(noProxy, u.hostname, port)) return null;
+    const primary = u.protocol === 'https:' ? ENV_HTTPS_KEYS : ENV_HTTP_KEYS;
+    return firstEnvValue(env, primary) ?? firstEnvValue(env, ENV_ALL_KEYS);
+  };
+}
+
+// CONNECT 握手整体超时。代理通常在本机/局域网,正常毫秒级完成;上限只防代理软件假死
+// 时无限悬挂。不宜过短:代理背后可能还要现拨远端节点。
+const PROXY_CONNECT_TIMEOUT_MS = 15 * 1000;
+
+// 连接代理自身的 Happy Eyeballs 单地址握手超时,与 server.ts 对上游直连的放宽一致
+// (代理若配了 DNS 名且解析出多地址,同样会被 Node 默认 250ms per-attempt 砍死)。
+const PROXY_CONNECT_ATTEMPT_TIMEOUT_MS = 2500;
+
+/**
+ * 经 HTTP 代理 CONNECT 隧道连 https 上游的 keep-alive Agent。
+ *
+ * 工作方式:对代理发 `CONNECT host:port`,200 后拿到隧道 socket,把它交回
+ * https.Agent 原生 createConnection(带 `socket` 选项)完成 TLS 握手 —— TLS 端到端,
+ * SNI / 证书校验 / session 复用全部沿用 Node 原生逻辑,代理只见密文。
+ * 连接池语义与直连时的 globalAgent 一致(keepAlive,按 host:port 分 key)。
+ */
+export class TunnelingHttpsAgent extends HttpsAgent {
+  private readonly proxy: OutboundProxyTarget;
+
+  constructor(proxy: OutboundProxyTarget, opts?: AgentOptions) {
+    super({ keepAlive: true, ...opts });
+    this.proxy = proxy;
+  }
+
+  override createConnection(
+    options: ClientRequestArgs,
+    callback?: (err: Error | null, stream: Duplex) => void,
+  ): Duplex | null | undefined {
+    // http.Agent 运行时恒以 callback 形态调用(createSocket → oncreate);无 callback
+    // 时无法异步建连,直接失败比静默直连安全。
+    if (!callback) throw new Error('TunnelingHttpsAgent requires callback-style createConnection');
+    const targetHost = options.host ?? 'localhost';
+    const targetPort = Number(options.port) || 443;
+    const authority = `${targetHost}:${targetPort}`;
+    let settled = false;
+    const settle = (err: Error | null, stream?: Duplex): void => {
+      if (settled) return;
+      settled = true;
+      // @types/node 的 callback 把 stream 声明为必选;错误分支按运行时约定传 err 即可。
+      (callback as (err: Error | null, stream?: Duplex) => void)(err, stream);
+    };
+
+    const connectOptions: RequestOptions & Pick<TcpSocketConnectOpts, 'autoSelectFamilyAttemptTimeout'> = {
+      host: this.proxy.hostname,
+      port: this.proxy.port,
+      method: 'CONNECT',
+      path: authority,
+      headers: {
+        host: authority,
+        ...(this.proxy.authHeader ? { 'proxy-authorization': this.proxy.authHeader } : {}),
+      },
+      // CONNECT 会劫持底层 socket,绝不能进共享连接池。
+      agent: false,
+      timeout: PROXY_CONNECT_TIMEOUT_MS,
+      autoSelectFamilyAttemptTimeout: PROXY_CONNECT_ATTEMPT_TIMEOUT_MS,
+    };
+    const connectReq = httpRequest(connectOptions);
+
+    connectReq.on('connect', (res, socket, head) => {
+      if (res.statusCode !== 200) {
+        socket.destroy();
+        settle(new Error(`outbound proxy ${this.proxy.url} CONNECT ${authority} failed: HTTP ${res.statusCode}`));
+        return;
+      }
+      // CONNECT 成功后代理不应再发字节;万一有(不合规代理提前送了上游数据)塞回流里。
+      if (head.length > 0) socket.unshift(head);
+      try {
+        // 委托 https.Agent 原生 createConnection 做 TLS:`socket` 选项让 tls.connect
+        // 直接包装隧道 socket 而不再自行拨号,servername / 证书校验 / session 缓存照旧。
+        const tlsSocket = (HttpsAgent.prototype as unknown as {
+          createConnection: (opts: unknown) => Duplex;
+        }).createConnection.call(this, { ...options, socket });
+        settle(null, tlsSocket);
+      } catch (err) {
+        socket.destroy();
+        settle(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    connectReq.on('timeout', () => {
+      connectReq.destroy(new Error(`outbound proxy ${this.proxy.url} CONNECT ${authority} timed out`));
+    });
+    connectReq.on('error', (err) => {
+      settle(new Error(`outbound proxy ${this.proxy.url} unreachable: ${err.message}`));
+    });
+    connectReq.end();
+    // socket 走异步 callback 交付;返回 undefined 告知调用方等 callback。
+    return undefined;
+  }
+}
+
+// 正常场景同一时刻只有一个系统代理;上限只防 resolver 返回值抖动(PAC 按 host 给不同
+// 出口)时 agent 无限累积。超限逐出最旧的并销毁其连接池。
+const AGENT_POOL_MAX_ENTRIES = 8;
+
+/**
+ * 按代理地址缓存 TunnelingHttpsAgent,复用其 keep-alive 连接池。
+ * 生命周期随 proxy server:dispose 时销毁全部 agent(断开空闲隧道)。
+ */
+export class OutboundProxyAgentPool {
+  private readonly agents = new Map<string, TunnelingHttpsAgent>();
+
+  get(proxy: OutboundProxyTarget): TunnelingHttpsAgent {
+    // authHeader 参与 key:同地址不同凭证不能共享隧道池。
+    const key = `${proxy.url} ${proxy.authHeader ?? ''}`;
+    const existing = this.agents.get(key);
+    if (existing) return existing;
+    if (this.agents.size >= AGENT_POOL_MAX_ENTRIES) {
+      const oldest = this.agents.keys().next().value;
+      if (oldest !== undefined) {
+        this.agents.get(oldest)?.destroy();
+        this.agents.delete(oldest);
+      }
+    }
+    const agent = new TunnelingHttpsAgent(proxy);
+    this.agents.set(key, agent);
+    return agent;
+  }
+
+  destroy(): void {
+    for (const agent of this.agents.values()) agent.destroy();
+    this.agents.clear();
+  }
+}

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.ts
@@ -118,7 +118,9 @@ export function parseOutboundProxyUrl(raw: string | null | undefined): OutboundP
     const pass = u.password ? safeDecodeUserinfo(u.password) : '';
     authHeader = `Basic ${Buffer.from(`${user}:${pass}`, 'utf8').toString('base64')}`;
   }
-  return { url: `http://${u.host}`, hostname: u.hostname, port, authHeader };
+  // hostname 去掉 IPv6 方括号:它会被直接用作 TCP connect host(net/tls 只认裸地址);
+  // url 保留带括号的 u.host 形态(仅用于日志与 pool key)。
+  return { url: `http://${u.host}`, hostname: stripIpv6Brackets(u.hostname), port, authHeader };
 }
 
 /** 把可能带凭证的代理地址脱敏成可进日志的形式(只留 scheme://host:port)。 */

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.ts
@@ -52,8 +52,30 @@ export function isLoopbackHostname(hostname: string): boolean {
 }
 
 /**
+ * 拼 host:port authority。IPv6 字面量按 RFC 3986 加方括号 —— resolver URL、
+ * CONNECT 目标、绝对形式 URL 与 Host 头共用,裸拼 `v6:port` 会被代理当成非法目标。
+ */
+export function formatAuthority(hostname: string, port: number): string {
+  return hostname.includes(':') ? `[${hostname}]:${port}` : `${hostname}:${port}`;
+}
+
+/**
+ * userinfo 解码。decodeURIComponent 对非法百分号编码(如 `user%GG`)会抛 URIError;
+ * 解析器绝不能抛(在请求热路径上,抛了就是未处理 rejection 而非直连回退),
+ * 解不开就按用户原文使用。
+ */
+function safeDecodeUserinfo(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
  * 解析代理地址。只接受 http: 协议(CONNECT 隧道 / 绝对形式都建立在明文 HTTP 代理上);
  * https:(TLS-to-proxy)与 socks: 暂不支持,返回 null 由调用方回落直连。
+ * 任何输入都不抛错:解析失败一律返回 null。
  */
 export function parseOutboundProxyUrl(raw: string | null | undefined): OutboundProxyTarget | null {
   const trimmed = typeof raw === 'string' ? raw.trim() : '';
@@ -71,8 +93,8 @@ export function parseOutboundProxyUrl(raw: string | null | undefined): OutboundP
   let authHeader: string | undefined;
   if (u.username) {
     // URL 里的 userinfo 是百分号编码的,先解码再进 Basic。
-    const user = decodeURIComponent(u.username);
-    const pass = u.password ? decodeURIComponent(u.password) : '';
+    const user = safeDecodeUserinfo(u.username);
+    const pass = u.password ? safeDecodeUserinfo(u.password) : '';
     authHeader = `Basic ${Buffer.from(`${user}:${pass}`, 'utf8').toString('base64')}`;
   }
   return { url: `http://${u.host}`, hostname: u.hostname, port, authHeader };
@@ -193,7 +215,7 @@ export class TunnelingHttpsAgent extends HttpsAgent {
     if (!callback) throw new Error('TunnelingHttpsAgent requires callback-style createConnection');
     const targetHost = options.host ?? 'localhost';
     const targetPort = Number(options.port) || 443;
-    const authority = `${targetHost}:${targetPort}`;
+    const authority = formatAuthority(targetHost, targetPort);
     let settled = false;
     const settle = (err: Error | null, stream?: Duplex): void => {
       if (settled) return;
@@ -263,7 +285,7 @@ export class OutboundProxyAgentPool {
 
   get(proxy: OutboundProxyTarget): TunnelingHttpsAgent {
     // authHeader 参与 key:同地址不同凭证不能共享隧道池。
-    const key = `${proxy.url} ${proxy.authHeader ?? ''}`;
+    const key = `${proxy.url} ${proxy.authHeader ?? ''}`;
     const existing = this.agents.get(key);
     if (existing) return existing;
     if (this.agents.size >= AGENT_POOL_MAX_ENTRIES) {

--- a/packages/anthropic-compat-proxy/src/outbound-proxy.ts
+++ b/packages/anthropic-compat-proxy/src/outbound-proxy.ts
@@ -43,11 +43,20 @@ export type OutboundProxyResolver = (
 ) => string | null | undefined | Promise<string | null | undefined>;
 
 /**
+ * 去掉 IPv6 字面量的方括号。WHATWG URL 的 `hostname` 对 IPv6 返回**带方括号**的
+ * 形式(`new URL('https://[::1]').hostname === '[::1]'`),而比较 / 重组 authority
+ * 都需要裸地址;所有消费 hostname 的入口先过这里归一化。
+ */
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}
+
+/**
  * loopback 上游永不走代理:本机 bridge / gateway 与代理软件无关,而且系统代理的
  * bypass 规则(localhost 默认直连)在 env 层不可见,这里必须自兜。
  */
 export function isLoopbackHostname(hostname: string): boolean {
-  const h = hostname.toLowerCase();
+  const h = stripIpv6Brackets(hostname.toLowerCase());
   return h === 'localhost' || h.endsWith('.localhost') || h === '::1' || h.startsWith('127.');
 }
 
@@ -56,7 +65,19 @@ export function isLoopbackHostname(hostname: string): boolean {
  * CONNECT 目标、绝对形式 URL 与 Host 头共用,裸拼 `v6:port` 会被代理当成非法目标。
  */
 export function formatAuthority(hostname: string, port: number): string {
-  return hostname.includes(':') ? `[${hostname}]:${port}` : `${hostname}:${port}`;
+  const bare = stripIpv6Brackets(hostname);
+  return bare.includes(':') ? `[${bare}]:${port}` : `${bare}:${port}`;
+}
+
+/**
+ * 按 RFC 9110 语义拼 Host 头:默认端口省略,非默认端口带上;IPv6 字面量加方括号。
+ * 经代理的绝对形式请求用 —— 该分支 socket 连的是代理,Host 头只能靠显式设置。
+ */
+export function formatHostHeader(hostname: string, port: number, protocol: 'http:' | 'https:'): string {
+  const defaultPort = protocol === 'https:' ? 443 : 80;
+  const bare = stripIpv6Brackets(hostname);
+  const bracketed = bare.includes(':') ? `[${bare}]` : bare;
+  return port === defaultPort ? bracketed : `${bracketed}:${port}`;
 }
 
 /**
@@ -132,22 +153,38 @@ export function hasProxyEnvConfig(env: NodeJS.ProcessEnv = process.env): boolean
  * NO_PROXY 匹配(逗号分隔)。支持惯例语义:
  *   - `*` 全部直连
  *   - `example.com` / `.example.com` 匹配该域及其子域
- *   - `host:port` 额外要求端口一致
+ *   - `host:port` 额外要求端口一致(仅在恰好一个冒号时按 host:port 拆,
+ *     裸 IPv6 字面量如 `::1` / `2001:db8::1` 整体当 host,不误拆末段为端口)
+ *   - `[v6]` / `[v6]:port` 的无歧义 IPv6 带端口形式
  * IP 段(CIDR)不支持 —— 与多数实现一致,按普通字面 host 处理。
  */
 function noProxyMatches(noProxy: string, hostname: string, port: number): boolean {
-  const host = hostname.toLowerCase();
+  // URL.hostname 的 IPv6 带方括号,先归一成裸地址再与条目比较。
+  const host = stripIpv6Brackets(hostname.toLowerCase());
   for (const rawEntry of noProxy.split(',')) {
     const entry = rawEntry.trim().toLowerCase();
     if (!entry) continue;
     if (entry === '*') return true;
     let entryHost = entry;
     let entryPort: number | null = null;
-    const colon = entry.lastIndexOf(':');
-    // IPv6 字面量里也有冒号;只有「冒号后是纯数字」才当端口拆。
-    if (colon > 0 && /^\d+$/.test(entry.slice(colon + 1))) {
-      entryHost = entry.slice(0, colon);
-      entryPort = Number(entry.slice(colon + 1));
+    if (entry.startsWith('[')) {
+      // [v6] / [v6]:port —— 唯一无歧义的 IPv6 带端口写法。
+      const close = entry.indexOf(']');
+      if (close === -1) continue;  // 括号没闭合,条目非法,跳过
+      entryHost = entry.slice(1, close);
+      const rest = entry.slice(close + 1);
+      if (rest.startsWith(':') && /^\d+$/.test(rest.slice(1))) {
+        entryPort = Number(rest.slice(1));
+      } else if (rest) {
+        continue;  // `]` 后跟了端口以外的东西,条目非法,跳过
+      }
+    } else {
+      const first = entry.indexOf(':');
+      // 恰好一个冒号且后缀纯数字才按 host:port 拆;多个冒号 = 裸 IPv6 字面量整体当 host。
+      if (first !== -1 && first === entry.lastIndexOf(':') && /^\d+$/.test(entry.slice(first + 1))) {
+        entryHost = entry.slice(0, first);
+        entryPort = Number(entry.slice(first + 1));
+      }
     }
     if (entryPort !== null && entryPort !== port) continue;
     const bare = entryHost.startsWith('.') ? entryHost.slice(1) : entryHost;

--- a/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
@@ -1,0 +1,147 @@
+import { createServer as createHttpServer } from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createAnthropicCompatProxy } from './server.js';
+import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
+import type { ProxyHandle } from './types.js';
+
+/**
+ * 出站代理链路的 server 级验证。技巧:上游统一用保证不可解析的 `.invalid` 假域 ——
+ * 经代理转发时压根不需要解析上游域名(http 走绝对形式、https 由代理端拨号),
+ * 因此「请求打到了 mini 代理」本身就证明代理路径生效;直连分支则以 DNS 失败收尾,
+ * 验证 fail-open 不炸链路。
+ */
+describe('anthropic-compat-proxy outbound proxy wiring', () => {
+  let proxy: ProxyHandle | null = null;
+  const cleanups: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    if (proxy) { await proxy.dispose(); proxy = null; }
+    while (cleanups.length) await cleanups.pop()!();
+  });
+
+  it('forwards http upstreams via absolute-form request to the outbound proxy', async () => {
+    const seen: Array<{ url: string; host?: string; proxyAuth?: string }> = [];
+    const miniProxy = createHttpServer((req, res) => {
+      seen.push({
+        url: req.url ?? '',
+        host: req.headers.host,
+        proxyAuth: req.headers['proxy-authorization'] as string | undefined,
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ via: 'outbound-proxy' }));
+    });
+    const miniProxyPort = await listenOnAvailableLoopbackPort(miniProxy);
+    cleanups.push(() => new Promise<void>((r) => miniProxy.close(() => r())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://upstream.invalid:8080/v1',
+      transformRequest: [],
+      resolveOutboundProxy: () => `http://user:secret@127.0.0.1:${miniProxyPort}`,
+    });
+
+    const res = await fetch(`${proxy.url}/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ via: 'outbound-proxy' });
+
+    expect(seen).toHaveLength(1);
+    // 绝对形式 URL 指向真实上游;Host 头保持上游;凭证进 Proxy-Authorization。
+    expect(seen[0].url).toBe('http://upstream.invalid:8080/v1/messages');
+    expect(seen[0].host).toBe('upstream.invalid');
+    expect(seen[0].proxyAuth).toBe(`Basic ${Buffer.from('user:secret').toString('base64')}`);
+  });
+
+  it('routes https upstreams through a CONNECT tunnel to the outbound proxy', async () => {
+    const connects: string[] = [];
+    const miniProxy = createHttpServer();
+    miniProxy.on('connect', (req, clientSocket) => {
+      connects.push(req.url ?? '');
+      // 拒绝隧道:断言只关心「CONNECT 打到了代理」;成功隧道路径由
+      // outbound-proxy.test.ts 的 TunnelingHttpsAgent 用例覆盖。
+      clientSocket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+    });
+    const miniProxyPort = await listenOnAvailableLoopbackPort(miniProxy);
+    cleanups.push(() => new Promise<void>((r) => miniProxy.close(() => r())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'https://upstream.invalid',
+      transformRequest: [],
+      resolveOutboundProxy: () => `http://127.0.0.1:${miniProxyPort}`,
+    });
+
+    const res = await fetch(`${proxy.url}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    expect(res.status).toBe(502);
+    const body = await res.json() as { error: { message: string } };
+    expect(body.error.message).toContain('upstream unreachable');
+    expect(body.error.message).toContain('CONNECT');
+    expect(connects).toEqual(['upstream.invalid:443']);
+  });
+
+  it('never consults the resolver for loopback upstreams', async () => {
+    const upstream = createHttpServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ direct: true }));
+    });
+    const upstreamPort = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((r) => upstream.close(() => r())));
+
+    const resolver = vi.fn(() => 'http://127.0.0.1:1');
+    proxy = await createAnthropicCompatProxy({
+      upstream: `http://127.0.0.1:${upstreamPort}`,
+      transformRequest: [],
+      resolveOutboundProxy: resolver,
+    });
+
+    const res = await fetch(`${proxy.url}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    expect(res.status).toBe(200);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('falls back to direct connection when the resolver throws or returns unsupported urls', async () => {
+    const warns: string[] = [];
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://upstream.invalid:8080',
+      transformRequest: [],
+      resolveOutboundProxy: () => { throw new Error('resolver boom'); },
+      logger: { warn: (msg) => { warns.push(msg); } },
+    });
+
+    // 直连假域必然失败,但必须是 502(fail-open 走到了直连),而非 resolver 异常炸链路。
+    const res = await fetch(`${proxy.url}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    expect(res.status).toBe(502);
+    expect(warns.some((m) => m.includes('outbound proxy resolver threw'))).toBe(true);
+
+    await proxy.dispose();
+
+    const warns2: string[] = [];
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://upstream.invalid:8080',
+      transformRequest: [],
+      resolveOutboundProxy: () => 'socks5://127.0.0.1:1080',
+      logger: { warn: (msg) => { warns2.push(msg); } },
+    });
+    const res2 = await fetch(`${proxy.url}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'x', messages: [] }),
+    });
+    expect(res2.status).toBe(502);
+    expect(warns2.some((m) => m.includes('unsupported outbound proxy url'))).toBe(true);
+  });
+});

--- a/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
@@ -49,9 +49,9 @@ describe('anthropic-compat-proxy outbound proxy wiring', () => {
     expect(await res.json()).toEqual({ via: 'outbound-proxy' });
 
     expect(seen).toHaveLength(1);
-    // 绝对形式 URL 指向真实上游;Host 头保持上游;凭证进 Proxy-Authorization。
+    // 绝对形式 URL 指向真实上游;Host 头按 RFC 9110 带非默认端口;凭证进 Proxy-Authorization。
     expect(seen[0].url).toBe('http://upstream.invalid:8080/v1/messages');
-    expect(seen[0].host).toBe('upstream.invalid');
+    expect(seen[0].host).toBe('upstream.invalid:8080');
     expect(seen[0].proxyAuth).toBe(`Basic ${Buffer.from('user:secret').toString('base64')}`);
   });
 

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -21,6 +21,7 @@ import { brotliDecompressSync, gunzipSync, inflateRawSync, inflateSync } from 'n
 
 import { DEFAULT_THREAD_ID_HEADERS, selectedHeaderValue } from './headers.js';
 import {
+  formatAuthority,
   isLoopbackHostname,
   OutboundProxyAgentPool,
   parseOutboundProxyUrl,
@@ -646,7 +647,7 @@ function forward(
       // http 上游:按 HTTP 代理惯例改发绝对形式请求给代理;Host 头保持指向真实上游。
       upstreamOptions.hostname = outboundProxy.target.hostname;
       upstreamOptions.port = outboundProxy.target.port;
-      upstreamOptions.path = `http://${actualTarget.hostname}:${actualTarget.port}${upstreamPath}`;
+      upstreamOptions.path = `http://${formatAuthority(actualTarget.hostname, actualTarget.port)}${upstreamPath}`;
       if (outboundProxy.target.authHeader) {
         (upstreamOptions.headers as Record<string, string>)['proxy-authorization'] = outboundProxy.target.authHeader;
       }
@@ -1027,9 +1028,11 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     const resolver = opts.resolveOutboundProxy;
     if (!resolver) return undefined;
     if (isLoopbackHostname(target.hostname)) return undefined;
+    // IPv6 字面量上游要按 [addr]:port 拼 origin,否则 resolver 拿到非法 URL。
+    const upstreamOrigin = `${target.protocol}//${formatAuthority(target.hostname, target.port)}`;
     let raw: string | null | undefined;
     try {
-      raw = await resolver(`${target.protocol}//${target.hostname}:${target.port}`);
+      raw = await resolver(upstreamOrigin);
     } catch (err) {
       logger.warn?.('outbound proxy resolver threw — using direct connection', { reqId, err: String(err) });
       return undefined;
@@ -1047,7 +1050,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     logger.debug?.('using outbound proxy for upstream', {
       reqId,
       proxy: parsed.url,
-      upstream: `${target.protocol}//${target.hostname}:${target.port}`,
+      upstream: upstreamOrigin,
     });
     return {
       target: parsed,

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -20,6 +20,14 @@ import { URL } from 'node:url';
 import { brotliDecompressSync, gunzipSync, inflateRawSync, inflateSync } from 'node:zlib';
 
 import { DEFAULT_THREAD_ID_HEADERS, selectedHeaderValue } from './headers.js';
+import {
+  isLoopbackHostname,
+  OutboundProxyAgentPool,
+  parseOutboundProxyUrl,
+  redactProxyUrlForLog,
+  type OutboundProxyTarget,
+  type TunnelingHttpsAgent,
+} from './outbound-proxy.js';
 import { stripNonAnthropicFields, stripToolUseProviderSpecificFields } from './transform.js';
 import type {
   LocalRequestHandler,
@@ -93,6 +101,16 @@ interface UpstreamTarget {
   port: number;
   protocol: 'http:' | 'https:';
   basePath: string;  // 上游路径前缀(例 "" 或 "/v1")
+}
+
+/**
+ * 一次请求已解析好的出站代理。在请求处理层(路由决策后)解析一次,透明重试沿用同一份,
+ * 保证重试与首发走同一条网络路径。
+ */
+interface ResolvedOutboundProxy {
+  target: OutboundProxyTarget;
+  /** https 上游用的 CONNECT 隧道 agent;http 上游走绝对形式请求,不需要 agent。 */
+  agent?: TunnelingHttpsAgent;
 }
 
 function parseUpstream(upstream: string): UpstreamTarget {
@@ -582,6 +600,8 @@ function forward(
   // 原始客户端 model id。provider transform 可能在出站前去掉命名空间；recovery
   // controller 必须记原值，才能和下一轮主动 strip 看到的入站 model 对上。
   clientModel = '',
+  // 请求处理层解析好的出站代理;undefined = 直连(与扩展前字节级一致)。
+  outboundProxy?: ResolvedOutboundProxy,
 ): void {
   // 客户端已断开(典型:400 缓冲期间断开后走到透明重试)——'close' 已经发过,
   // 下面挂的中断传播 listener 永远不会触发,直接不发起上游请求。
@@ -618,6 +638,20 @@ function forward(
     timeout: UPSTREAM_SOCKET_TIMEOUT_MS,
     autoSelectFamilyAttemptTimeout: UPSTREAM_CONNECT_ATTEMPT_TIMEOUT_MS,
   };
+  if (outboundProxy) {
+    if (actualTarget.protocol === 'https:') {
+      // https 上游:经 CONNECT 隧道 agent 转发(TLS 端到端,代理只见密文)。
+      upstreamOptions.agent = outboundProxy.agent;
+    } else {
+      // http 上游:按 HTTP 代理惯例改发绝对形式请求给代理;Host 头保持指向真实上游。
+      upstreamOptions.hostname = outboundProxy.target.hostname;
+      upstreamOptions.port = outboundProxy.target.port;
+      upstreamOptions.path = `http://${actualTarget.hostname}:${actualTarget.port}${upstreamPath}`;
+      if (outboundProxy.target.authHeader) {
+        (upstreamOptions.headers as Record<string, string>)['proxy-authorization'] = outboundProxy.target.authHeader;
+      }
+    }
+  }
   const upstreamReq = reqFn(upstreamOptions);
 
   // ── 客户端中断传播 ────────────────────────────────────────────────────────
@@ -718,6 +752,7 @@ function forward(
             headerDelete,
             responseObserver,
             clientModel,
+            outboundProxy,
           );
           return;
         }
@@ -886,7 +921,13 @@ function forward(
     // 客户端主动断开触发的 destroy 是预期路径:客户端已不在,不写 502、不按
     // 上游故障记 error(上面 'close' 处已记过 info)。
     if (clientAborted) return;
-    logger.error?.('upstream request failed', { reqId, err: String(err), method, path: upstreamPath });
+    logger.error?.('upstream request failed', {
+      reqId,
+      err: String(err),
+      method,
+      path: upstreamPath,
+      ...(outboundProxy ? { viaProxy: outboundProxy.target.url } : {}),
+    });
     if (!clientRes.headersSent) {
       clientRes.writeHead(502, { 'content-type': 'application/json' });
       clientRes.end(JSON.stringify({ error: { type: 'proxy_error', message: `upstream unreachable: ${String(err)}` } }));
@@ -971,6 +1012,49 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     };
   };
 
+  // 出站代理:CONNECT 隧道 agent 按代理地址缓存(keep-alive 连接池),随 dispose 销毁。
+  const outboundAgentPool = new OutboundProxyAgentPool();
+
+  /**
+   * per-request 解析本次转发的出站代理。任何一步失败(resolver 抛错 / 返回不支持的
+   * 代理形态)都回落直连 —— 代理解析问题绝不能比今天的裸直连更糟。loopback 上游
+   * (本机 bridge / gateway / 测试桩)恒直连,不打扰 resolver。
+   */
+  const resolveOutboundForTarget = async (
+    target: UpstreamTarget,
+    reqId: number,
+  ): Promise<ResolvedOutboundProxy | undefined> => {
+    const resolver = opts.resolveOutboundProxy;
+    if (!resolver) return undefined;
+    if (isLoopbackHostname(target.hostname)) return undefined;
+    let raw: string | null | undefined;
+    try {
+      raw = await resolver(`${target.protocol}//${target.hostname}:${target.port}`);
+    } catch (err) {
+      logger.warn?.('outbound proxy resolver threw — using direct connection', { reqId, err: String(err) });
+      return undefined;
+    }
+    if (!raw) return undefined;
+    const parsed = parseOutboundProxyUrl(raw);
+    if (!parsed) {
+      // raw 可能带凭证,只记脱敏形态。
+      logger.warn?.('unsupported outbound proxy url — using direct connection', {
+        reqId,
+        proxy: redactProxyUrlForLog(String(raw)),
+      });
+      return undefined;
+    }
+    logger.debug?.('using outbound proxy for upstream', {
+      reqId,
+      proxy: parsed.url,
+      upstream: `${target.protocol}//${target.hostname}:${target.port}`,
+    });
+    return {
+      target: parsed,
+      agent: target.protocol === 'https:' ? outboundAgentPool.get(parsed) : undefined,
+    };
+  };
+
   // in-flight 请求计数 —— dispose 时等清零或 2s 超时
   let inflight = 0;
   const inflightSockets = new Set<Socket>();
@@ -1044,6 +1128,8 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         route.headerOverride,
         route.headerDelete,
         opts.responseObserver,
+        '',
+        await resolveOutboundForTarget(route.target, reqId),
       );
       return;
     }
@@ -1169,6 +1255,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       route.headerDelete,
       opts.responseObserver,
       extractBodyModel(rawBody),
+      await resolveOutboundForTarget(route.target, reqId),
     );
   });
 
@@ -1198,6 +1285,8 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       for (const s of inflightSockets) {
         try { s.destroy(); } catch { /* no-op */ }
       }
+      // 出站代理的 keep-alive 隧道池一并断开,不留空闲 CONNECT 连接。
+      outboundAgentPool.destroy();
       await new Promise<void>((resolve) => server.close(() => resolve()));
     },
   };

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -22,6 +22,7 @@ import { brotliDecompressSync, gunzipSync, inflateRawSync, inflateSync } from 'n
 import { DEFAULT_THREAD_ID_HEADERS, selectedHeaderValue } from './headers.js';
 import {
   formatAuthority,
+  formatHostHeader,
   isLoopbackHostname,
   OutboundProxyAgentPool,
   parseOutboundProxyUrl,
@@ -644,10 +645,13 @@ function forward(
       // https 上游:经 CONNECT 隧道 agent 转发(TLS 端到端,代理只见密文)。
       upstreamOptions.agent = outboundProxy.agent;
     } else {
-      // http 上游:按 HTTP 代理惯例改发绝对形式请求给代理;Host 头保持指向真实上游。
+      // http 上游:按 HTTP 代理惯例改发绝对形式请求给代理;Host 头指向真实上游。
+      // socket 连的是代理,Host 头只能显式设置 —— 按 RFC 9110 带非默认端口 / IPv6 方括号。
       upstreamOptions.hostname = outboundProxy.target.hostname;
       upstreamOptions.port = outboundProxy.target.port;
       upstreamOptions.path = `http://${formatAuthority(actualTarget.hostname, actualTarget.port)}${upstreamPath}`;
+      (upstreamOptions.headers as Record<string, string>).host =
+        formatHostHeader(actualTarget.hostname, actualTarget.port, actualTarget.protocol);
       if (outboundProxy.target.authHeader) {
         (upstreamOptions.headers as Record<string, string>)['proxy-authorization'] = outboundProxy.target.authHeader;
       }

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -12,6 +12,8 @@
 import type { Buffer } from 'node:buffer';
 import type { ServerResponse } from 'node:http';
 
+import type { OutboundProxyResolver } from './outbound-proxy.js';
+
 /**
  * 请求 transform 上下文。
  * - method/url/headers 是只读快照,transform 不应该尝试通过这些改写 outbound 请求
@@ -206,6 +208,14 @@ export interface ProxyOptions {
    * 注意: body 会整段缓冲进内存并 JSON.parse,该值同时就是单请求的内存 / 解析停顿预算。
    */
   maxRequestBodyBytes?: number;
+  /**
+   * 可选: 出站(上游方向)代理解析器。per-request 以最终上游 origin 现取:返回
+   * http:// 代理地址 = 该请求经代理转发(https 上游走 CONNECT 隧道、http 上游走
+   * 绝对形式);返回 null / 抛错 = 直连(fail-open)。loopback 上游不会被调用。
+   * 宿主用它接系统代理(Electron resolveProxy)或代理环境变量
+   * (createEnvOutboundProxyResolver)。不传 = 永远直连,与扩展前字节级一致。
+   */
+  resolveOutboundProxy?: OutboundProxyResolver;
   /**
    * 可选: debug 级别下是否 dump 入站请求 body(截断到 64KiB)。默认 false ——
    * dev 的日志级别默认 trace,若默认 dump,agent 高并发场景(code-review 扇出 +

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,9 @@ importers:
       eslint:
         specifier: ^9.0.0
         version: 9.39.5(jiti@2.7.0)
+      selfsigned:
+        specifier: ^5.5.0
+        version: 5.5.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -3633,6 +3636,10 @@ packages:
     resolution: {integrity: sha512-dJst7XDaCsXjz9y8UYQhg120cloaKDSH+fS96M87HutzO/RdK9E1JNKq9JGNYWRCiYOlDRX0rUqJnL0rLDsOCw==}
     engines: {node: '>= 10'}
 
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -3739,6 +3746,43 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@peculiar/asn1-cms@2.8.0':
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+
+  '@peculiar/asn1-csr@2.8.0':
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-pfx@2.8.0':
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5185,6 +5229,10 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
@@ -5409,6 +5457,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  bytestreamjs@2.0.1:
+    resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
+    engines: {node: '>=6.0.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -8860,6 +8912,10 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
+  pkijs@3.4.0:
+    resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
+    engines: {node: '>=16.0.0'}
+
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
@@ -9053,6 +9109,13 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
 
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
@@ -9326,6 +9389,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
@@ -9503,6 +9569,10 @@ packages:
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
+
+  selfsigned@5.5.0:
+    resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
+    engines: {node: '>=18'}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -10032,6 +10102,9 @@ packages:
   ts-mixer@6.0.4:
     resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -10043,6 +10116,10 @@ packages:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -13337,6 +13414,8 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  '@noble/hashes@1.4.0': {}
+
   '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -13414,6 +13493,100 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@peculiar/asn1-cms@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -15102,6 +15275,12 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+
   assert-plus@1.0.0:
     optional: true
 
@@ -15391,6 +15570,8 @@ snapshots:
   byte-size@8.2.1: {}
 
   bytes@3.1.2: {}
+
+  bytestreamjs@2.0.1: {}
 
   cac@6.7.14: {}
 
@@ -19410,6 +19591,15 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
+  pkijs@3.4.0:
+    dependencies:
+      '@noble/hashes': 1.4.0
+      asn1js: 3.0.10
+      bytestreamjs: 2.0.1
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+
   platform@1.3.6: {}
 
   playwright-core@1.60.0: {}
@@ -19639,6 +19829,12 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
 
   qrcode@1.5.4:
     dependencies:
@@ -20001,6 +20197,8 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  reflect-metadata@0.2.2: {}
+
   regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
@@ -20252,6 +20450,11 @@ snapshots:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+
+  selfsigned@5.5.0:
+    dependencies:
+      '@peculiar/x509': 1.14.3
+      pkijs: 3.4.0
 
   semver-compare@1.0.0:
     optional: true
@@ -20837,6 +21040,8 @@ snapshots:
 
   ts-mixer@6.0.4: {}
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tslog@4.11.0: {}
@@ -20846,6 +21051,10 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   tunnel-agent@0.6.0:
     dependencies:


### PR DESCRIPTION
## 这次改了什么

### 摘要

本地 loopback proxy(Claude / Codex 共用的 `anthropic-compat-proxy` 引擎)转发上游时用的是 Node http 栈直连——Node 既不读系统代理,也不读代理环境变量。用户的代理软件跑「系统代理」模式(非 TUN)时,浏览器和 Codex CLI(reqwest 自动吃 env / 系统代理)都正常,唯独 Cindy 的上游连接裸直连,在直连不通的网络下所有地址握手失败,客户端收到 `502 Bad Gateway: upstream unreachable: AggregateError, url: http://127.0.0.1:PORT/responses`(线上真实用户复现,只能靠开 TUN 模式绕过)。

本 PR 让上游连接跟随代理配置,分两层:

1. **代理环境变量**(`HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` / `NO_PROXY`,大小写两种拼写,语义与 curl / reqwest 惯例对齐):终端 dev 启动、用户显式配置的场景;env 有代理配置时以 env 判定为准(含 `NO_PROXY` 豁免)。
2. **系统代理**(Electron `session.resolveProxy`,支持 PAC):GUI 启动拿不到 shell env 的主场景;结果 30s TTL 缓存,解析值变化时记 info 日志。

传输实现:https 上游经 HTTP 代理 **CONNECT 隧道**(TLS 端到端、代理只见密文,keep-alive 隧道池复用,连接语义与直连时的 globalAgent 一致);http 上游按惯例改发**绝对形式**请求。URL userinfo 转 `Proxy-Authorization: Basic`。

安全边界:loopback 上游恒直连(不打扰 resolver);解析链路任何失败(resolver 抛错 / 不支持的代理形态如 socks)一律 **fail-open 回落直连**,不会比现状更糟;透明重试(400 recovery)沿用与首发同一条网络路径;`upstream request failed` 日志新增 `viaProxy` 字段便于排查;带凭证的代理地址只以脱敏形态进日志。宿主不注入 resolver 时行为与之前**字节级一致**。

接线:desktop 的 Claude(`anthropic-compat-proxy-host`)与 Codex(`codex-proxy-host`)两个 host 注入同一 resolver;包 CLI(`bin/proxy.ts`,远端 cc-manager 场景)直接接环境变量解析器。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无 Issue;线上用户复现报障(Codex OAuth 直连 chatgpt.com,非 TUN 系统代理下 502 AggregateError)
- 本 PR 包含:`@cindy/anthropic-compat-proxy` 出站代理支持(`outbound-proxy.ts` + `server.ts` 注入点 + CLI 接线)、desktop 侧 `outbound-proxy-resolver.ts` 及两个 proxy host 注入、配套单测
- 明确不包含:走 `fetch` 的进程内 bridge(Claude 的 `chatgpt/`/`xai/` 订阅直连 `anthropic-responses-bridge`、Codex 的 openai-chat 供应商 `responses-chat-bridge`)仍为直连,修法不同(注入 fetch dispatcher 或 Electron `net.fetch`),作为 follow-up 另行处理;SOCKS / TLS-to-proxy 代理形态暂不支持(解析到时跳过该候选,回落直连);代理设置 UI
- 用户可见变化:代理软件开「系统代理」模式(或设了代理环境变量)时,Claude / Codex 上游请求自动走代理,不再要求 TUN;无代理配置的用户行为不变
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
bash run-unit-gate.sh(仓库根 pnpm test:unit 全量,统一门禁脚本)
结果:GATE_EXIT=0 全部通过

pnpm --filter @cindy/anthropic-compat-proxy run typecheck / lint / test
结果:全部通过(131 tests,含 18 个新增:CONNECT 隧道真实建连 + keep-alive 复用
断言、绝对形式转发、loopback 跳过 resolver、resolver 抛错 / 不支持形态 fail-open、
NO_PROXY 各形态、代理凭证透传与脱敏)

pnpm --filter desktop run typecheck
结果:通过

vitest run(desktop 受影响测试:codexProxyHost / claudeProxyScopeGate / providerRoute /
claudeAuthAdapterOAuthEnv / claudeSessionRouteObservation / outboundProxyResolver)
结果:107 tests 全部通过(其中 outboundProxyResolver 9 个为新增:env 优先、
NO_PROXY 不回落系统代理、resolveProxy 解析 / 缓存 / 抛错 fail-open / app 未 ready)
```

说明:全量门禁启动后对一个测试文件做过 lint 级小修(`vi.fn` 类型注解),已按规则补跑该受影响测试文件与 desktop typecheck,均通过。

### 手工验证

不涉及(见下)。

### 未执行的验证

真机端到端(代理软件开「系统代理」模式 + 直连不通的网络环境)未复现验证——本机无法模拟直连被墙的网络;协议层行为(CONNECT 隧道、绝对形式、鉴权、fail-open)已由单测中的 mini CONNECT 代理 / mini HTTP 代理覆盖,「无代理配置行为不变」由存量 54 个 server 测试兜底。建议由能复现原始 502 的用户环境做最终确认。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他:出站网络路径变化(仅在检测到代理配置时)

### 影响与回滚

- 影响范围:所有经本地 proxy 转发的 Claude / Codex 上游请求。无代理配置(无代理 env、系统代理 DIRECT)时字节级不变;检测到代理配置时上游连接改经代理。跨平台:代理 env 读取兼容 Windows 大小写不敏感语义(两种拼写都读),`session.resolveProxy` 为 Electron 跨平台 API,无路径 / 子进程差异;Windows 未实测,标注待验证。
- 回滚 / 降级方式:revert 本 PR 即回到直连;不改协议、不落盘数据、无迁移。用户侧临时降级:去掉代理 env / 关闭系统代理即回直连路径。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件(测试内嵌的自签名证书为测试专用固定物,CN=upstream.test,非任何真实凭证)
- [x] 已补充必要文档(实现均带职责注释;无需新增规则文档)
- [x] 已确认测试结果或说明未执行原因
