### PR TITLE
fix(codex): 修复正文消息无法流式输出

### DIFF
--- a/packages/maker-core/src/agents/codex/app-server/client.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { AppServerClient, detectAuthInvalidationReason } from './client.js';
+import { AppServerHost } from './host.js';
 import type { Logger } from '../../../interfaces/logger.js';
 import type { Transport, LineHandler, StderrHandler, CloseHandler } from './transport.js';
 
@@ -58,6 +59,49 @@ const logger: Logger = {
   fatal: vi.fn(),
   child: () => logger,
 };
+
+describe('AppServerHost agent message delta subscription', () => {
+  it('keeps agent message delta enabled and routes it to the thread subscriber', async () => {
+    const transport = new FakeTransport();
+    const deltaHandler = vi.fn();
+    const host = new AppServerHost({
+      createTransport: () => transport,
+      logger,
+      clientInfo: { name: 'test', title: 'Test', version: '0.0.0' },
+    });
+    host.subscribeThread('thread-1', { agentMessageDelta: deltaHandler });
+
+    const started = host.ensureStarted();
+    expect(transport.lines).toHaveLength(1);
+    const initializeRequest = JSON.parse(transport.lines[0]!) as {
+      id: number;
+      params: { capabilities: { optOutNotificationMethods: string[] } };
+    };
+    expect(initializeRequest.params.capabilities.optOutNotificationMethods)
+      .not.toContain('item/agentMessage/delta');
+    transport.emitLine({
+      id: initializeRequest.id,
+      result: {
+        userAgent: 'codex-test',
+        codexHome: '/tmp/codex',
+        platformFamily: 'unix',
+        platformOs: 'linux',
+      },
+    });
+    await started;
+
+    const params = {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'message-1',
+      delta: 'streamed',
+    };
+    transport.emitLine({ method: 'item/agentMessage/delta', params });
+    expect(deltaHandler).toHaveBeenCalledWith(params);
+
+    await host.shutdown('test complete');
+  });
+});
 
 describe('detectAuthInvalidationReason', () => {
   const cloudAuthError = (message: string, data: Record<string, unknown> = {}) => ({

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -47,6 +47,7 @@ import {
   type ToolRequestUserInputResponse,
   type InitializeCapabilities,
   type InitializeResponse,
+  type AgentMessageDeltaNotification,
   type ItemCompletedNotification,
   type ItemStartedNotification,
   type ItemUpdatedNotification,
@@ -68,7 +69,7 @@ import {
  * 我们订阅的 notification 方法集 — 这之外的 (大部分 delta + plan/diff/hook/etc.)
  * 在 initialize 时通过 optOutNotificationMethods 告诉 server 别推, 省 IPC 带宽。
  *
- * agentMessage 文本流我们仍走 item/updated 全量字段算 diff (省一类 delta);
+ * agentMessage 和 reasoning 都订阅专用 delta; item/updated 仍作兼容性全量快照;
  * reasoning summary 流必须订阅 delta — claude code 等价体验需要逐字出 thinking 文本,
  * item/completed 给的是终态全文 (用来校准), 中间过程靠 delta 才能动起来。
  */
@@ -80,6 +81,7 @@ const SUBSCRIBED_METHODS = [
   'item/started',
   'item/updated',
   'item/completed',
+  'item/agentMessage/delta',
   'turn/plan/updated',             // Codex update_plan snapshots
   'item/reasoning/summaryTextDelta', // 流式 reasoning 文本增量 (OpenAI summary)
   'item/reasoning/summaryPartAdded', // summary 分段标记 (插 \n\n 分隔用)
@@ -92,7 +94,6 @@ const SUBSCRIBED_METHODS = [
 ] as const;
 
 const NOTIFICATIONS_TO_OPT_OUT = [
-  'item/agentMessage/delta',
   'item/plan/delta',
   'item/commandExecution/outputDelta',
   'item/fileChange/outputDelta',
@@ -120,6 +121,7 @@ export interface ThreadEventHandlers {
   itemStarted?: (params: ItemStartedNotification['params']) => void;
   itemUpdated?: (params: ItemUpdatedNotification['params']) => void;
   itemCompleted?: (params: ItemCompletedNotification['params']) => void;
+  agentMessageDelta?: (params: AgentMessageDeltaNotification['params']) => void;
   /** Codex native update_plan snapshots. */
   turnPlanUpdated?: (params: TurnPlanUpdatedNotification['params']) => void;
   /** OpenAI reasoning summary 单段内的文本增量 (按 summaryIndex 区分段)。 */
@@ -629,6 +631,7 @@ export class AppServerHost {
       case 'item/started': fn = handlers.itemStarted as (p: never) => void; break;
       case 'item/updated': fn = handlers.itemUpdated as (p: never) => void; break;
       case 'item/completed': fn = handlers.itemCompleted as (p: never) => void; break;
+      case 'item/agentMessage/delta': fn = handlers.agentMessageDelta as (p: never) => void; break;
       case 'turn/plan/updated': fn = handlers.turnPlanUpdated as (p: never) => void; break;
       case 'item/reasoning/summaryTextDelta': fn = handlers.reasoningSummaryTextDelta as (p: never) => void; break;
       case 'item/reasoning/summaryPartAdded': fn = handlers.reasoningSummaryPartAdded as (p: never) => void; break;

--- a/packages/maker-core/src/agents/codex/app-server/protocol.ts
+++ b/packages/maker-core/src/agents/codex/app-server/protocol.ts
@@ -809,6 +809,12 @@ export interface ItemCompletedNotification {
   params: { threadId: string; turnId: string; item: ItemEnvelope; completedAtMs?: number };
 }
 
+/** Streaming assistant text emitted before the final agentMessage item completes. */
+export interface AgentMessageDeltaNotification {
+  method: 'item/agentMessage/delta';
+  params: { threadId: string; turnId: string; itemId: string; delta: string };
+}
+
 export type PlanEntryStatus = 'pending' | 'in_progress' | 'completed';
 
 export interface PlanEntry {
@@ -955,6 +961,7 @@ export type ServerNotification =
   | ItemStartedNotification
   | ItemUpdatedNotification
   | ItemCompletedNotification
+  | AgentMessageDeltaNotification
   | ReasoningSummaryTextDeltaNotification
   | ReasoningSummaryPartAddedNotification
   | ReasoningTextDeltaNotification

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4502,6 +4502,46 @@ describe('CodexAgent rewind', () => {
 });
 
 describe('CodexAgent turn lifecycle', () => {
+  it('routes agent message deltas into streaming text before final calibration', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-agent-message-delta',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    expect(handlers).toBeDefined();
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1' },
+    });
+    handlers.agentMessageDelta?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'message-1',
+      delta: 'streamed text',
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'text',
+      data: { text: 'streamed text', isFinal: false },
+    });
+
+    handlers.itemCompleted?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: { type: 'agentMessage', id: 'message-1', text: 'streamed text' },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'text',
+      data: { text: 'streamed text', isFinal: true },
+    });
+    await handle.close();
+  });
+
   it('clears running state and emits done status after terminal error notification', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -78,6 +78,7 @@ import { commandExecutionDisplayInput } from './command-display.js';
 import {
   newCodexRuntimeState,
   translateErrorNotification,
+  translateAgentMessageDelta,
   translateItemNotification,
   translateReasoningSummaryTextDelta,
   translateReasoningSummaryPartAdded,
@@ -3620,6 +3621,10 @@ export class CodexAgent extends BaseAgent {
         // item 完成后, 若 turn 仍在跑, 先回到 'Generating...' 兜底 — 下一条 item 起来会再覆盖。
         // turn/completed 在 turn 结束时会 push 'Done' 终态, 不需要在这里特判。
         if (isTurnInFlight) pushStatus('Generating...');
+      },
+      agentMessageDelta: (params) => {
+        if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
+        translateAgentMessageDelta(params, eventQueue, { rt: translatorRt, log });
       },
       turnPlanUpdated: (params) => {
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractRolloutUpdatePlanFunctionCallEvent,
   newCodexRuntimeState,
+  translateAgentMessageDelta,
   translateErrorNotification,
   translateAccountRateLimitsUpdated,
   translateItemNotification,
@@ -389,6 +390,44 @@ describe('translateItemNotification contextCompaction', () => {
         data: expect.objectContaining({ boundaryId: 'compact-item-1' }),
       }),
     ]);
+  });
+});
+
+describe('translateAgentMessageDelta', () => {
+  it('streams deltas, deduplicates a later full update, and keeps final calibration', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(rt);
+
+    translateAgentMessageDelta({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'message-1',
+      delta: 'Hello',
+    }, q, ctx);
+    translateAgentMessageDelta({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'message-1',
+      delta: ' world',
+    }, q, ctx);
+    translateItemNotification('updated', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: { type: 'agentMessage', id: 'message-1', text: 'Hello world' },
+    }, q, ctx);
+    translateItemNotification('completed', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: { type: 'agentMessage', id: 'message-1', text: 'Hello world' },
+    }, q, ctx);
+
+    expect(await collect(q)).toEqual([
+      expect.objectContaining({ type: 'text', data: { text: 'Hello', isFinal: false } }),
+      expect.objectContaining({ type: 'text', data: { text: ' world', isFinal: false } }),
+      expect.objectContaining({ type: 'text', data: { text: 'Hello world', isFinal: true } }),
+    ]);
+    expect(rt.itemTextLen.has('message-1')).toBe(false);
   });
 });
 

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -34,6 +34,7 @@ import { stripTerminalControlSequences } from '../shared/terminal-output.js';
 import { isNetworkishErrorMessage } from '../shared/network-error.js';
 import { commandExecutionDisplayInput, type CommandExecutionDisplayInput } from './command-display.js';
 import type {
+  AgentMessageDeltaNotification,
   ItemCompletedNotification,
   ItemStartedNotification,
   ItemUpdatedNotification,
@@ -518,8 +519,8 @@ interface ContextCompactionItem {
 }
 
 // ── agentMessage → text {isFinal} ───────────────────────────────────────────
-// item.started / item.updated 出 delta (isFinal=false), item.completed 出 final 全文。
-// Phase 1 没订阅 item/agentMessage/delta, 增量靠 item.updated 的 text 全量字段算 diff。
+// Dedicated delta notifications stream text; item.updated remains a full-snapshot fallback.
+// item.completed emits the authoritative final text so renderers can calibrate the stream.
 
 function handleAgentMessage(
   phase: ItemPhase,
@@ -546,6 +547,21 @@ function handleAgentMessage(
   queue.push({
     type: 'text',
     data: { text: delta, isFinal: false },
+    source: 'codex',
+  });
+}
+
+export function translateAgentMessageDelta(
+  params: AgentMessageDeltaNotification['params'],
+  queue: AsyncQueue<AgentEvent>,
+  ctx: CodexTranslateContext,
+): void {
+  if (!params.delta) return;
+  const prevLen = ctx.rt.itemTextLen.get(params.itemId) ?? 0;
+  ctx.rt.itemTextLen.set(params.itemId, prevLen + params.delta.length);
+  queue.push({
+    type: 'text',
+    data: { text: params.delta, isFinal: false },
     source: 'codex',
   });
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

恢复 Codex `item/agentMessage/delta` 订阅和端到端路由，使助手正文在生成期间按增量输出，而不是等到 `item/completed` 后一次性显示。

保留 `item/updated` 全量快照兼容路径，并让 `item/completed` 继续作为最终全文校准。增量和全量快照共用已输出长度，避免未来两类事件同时出现时重复追加。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #203
- 本 PR 包含：Codex app-server 正文 delta 协议类型、host 订阅/分发、translator 翻译、turn 路由与回归测试
- 明确不包含：reasoning、plan、命令输出、文件 diff 的流式策略变更
- 用户可见变化：Codex 正文从完成后一次性显示改为生成期间流式显示
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 布局或样式变更。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/app-server/client.test.ts src/agents/codex/translator.test.ts src/agents/codex/index.test.ts
结果：3 个测试文件通过，205 项测试通过。

pnpm --filter @cindy/maker-core build
结果：通过。

pnpm --filter @cindy/maker-core exec eslint src/agents/codex/app-server/client.test.ts src/agents/codex/app-server/host.ts src/agents/codex/app-server/protocol.ts src/agents/codex/index.ts src/agents/codex/translator.ts src/agents/codex/index.test.ts src/agents/codex/translator.test.ts
结果：通过。
```

### 手工验证

Windows 11，Codex app-server `0.144.1`，使用同一固定长文请求对照抓取 notification：

- 保留原有 `item/agentMessage/delta` opt-out：正文期间收到 0 个增量事件，只在结束时收到完整 `item/completed`。
- 取消该 opt-out：收到 199 个 `item/agentMessage/delta`，共 759 个字符，之后收到完整 `item/completed` 校准。

### 未执行的验证

未执行完整 Electron 安装包回归；本次改动位于 maker-core Codex 协议层，已通过真实 app-server 事件对照、host 路由测试和 CodexAgent 集成测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Codex app-server 通道的 assistant 正文事件；其他 Agent 和 Codex 工具/reasoning 事件不受影响。
- 回滚 / 降级方式：回退本 PR，恢复对 `item/agentMessage/delta` 的 opt-out，系统将回到 completed 终态全文输出。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码内协议说明与测试）
- [x] 已确认测试结果或说明未执行原因
