### PR TITLE
fix(mobile): 稳定 Android 模型选择浮窗键盘缩放

### DIFF
--- a/apps/mobile/src/__tests__/modelPickerSheetResize.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerSheetResize.test.ts
@@ -12,11 +12,11 @@ describe('ModelPickerSheet window resize stability', () => {
       'utf8',
     );
     const resetEffect = source.match(
-      /\/\/ 每次重新打开重置[\s\S]*?useEffect\(\(\) => \{[\s\S]*?\}, \[([^\]]*)\]\);/,
+      /\/\/ 每次重新打开重置[\s\S]*?useEffect\(\(\) => \{[\s\S]*?\}\s*,\s*\[([^\]]*)\]\);/,
     );
 
     expect(resetEffect).not.toBeNull();
-    expect(resetEffect?.[1]).not.toContain('windowHeight');
+    expect(resetEffect?.[1]).not.toMatch(/\bwindowHeight\b/);
     expect(source).toContain('windowHeightRef.current = windowHeight;');
     expect(source).toContain('secondaryTranslate.setValue(windowHeightRef.current);');
   });

--- a/apps/mobile/src/__tests__/modelPickerSheetResize.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerSheetResize.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const readTextLf = (...args: Parameters<typeof readFileSync>): string =>
+  String(readFileSync(...args)).replace(/\r\n/g, '\n');
+
+describe('ModelPickerSheet window resize stability', () => {
+  it('does not reset the open sheet when Android adjustResize changes window height', () => {
+    const source = readTextLf(
+      resolve(process.cwd(), 'src/session/ModelPickerSheet.tsx'),
+      'utf8',
+    );
+    const resetEffect = source.match(
+      /\/\/ 每次重新打开重置[\s\S]*?useEffect\(\(\) => \{[\s\S]*?\}, \[([^\]]*)\]\);/,
+    );
+
+    expect(resetEffect).not.toBeNull();
+    expect(resetEffect?.[1]).not.toContain('windowHeight');
+    expect(source).toContain('windowHeightRef.current = windowHeight;');
+    expect(source).toContain('secondaryTranslate.setValue(windowHeightRef.current);');
+  });
+});

--- a/apps/mobile/src/session/ModelPickerSheet.tsx
+++ b/apps/mobile/src/session/ModelPickerSheet.tsx
@@ -159,6 +159,14 @@ export function ModelPickerSheet({
   const secondaryTranslate = useRef(new Animated.Value(windowHeight)).current;
   const secondaryAnimatingRef = useRef(false);
 
+  // Android adjustResize 会在键盘开合时改变 windowHeight。重置 effect 只应由一次新的
+  // visible 周期触发；否则浮窗打开期间的缩窗会把二级视图、snap 和搜索状态全部重置，
+  // 并与 SheetSurface 对新高度的正常吸附动画叠加。最新高度只供下次打开时初始化位移。
+  const windowHeightRef = useRef(windowHeight);
+  useEffect(() => {
+    windowHeightRef.current = windowHeight;
+  }, [windowHeight]);
+
   // 每次重新打开重置(view 回一级、snap 回 half、清搜索、允许再次自动滚到选中行)。
   useEffect(() => {
     if (!visible) return;
@@ -167,9 +175,9 @@ export function ModelPickerSheet({
     setSecondarySnap('half');
     setQuery('');
     didAutoScrollRef.current = false;
-    secondaryTranslate.setValue(windowHeight);
+    secondaryTranslate.setValue(windowHeightRef.current);
     secondaryAnimatingRef.current = false;
-  }, [visible, secondaryTranslate, windowHeight]);
+  }, [visible, secondaryTranslate]);
 
   const heights = useMemo(
     () => computeContextSheetSnapHeights({ safeAreaTopInset: insets.top, screenHeight: windowHeight }),


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android `adjustResize` 会在键盘开合时改变 `useWindowDimensions().height`。模型选择浮窗原本把该高度放在“每次打开时重置状态”的 effect 依赖中，导致浮窗仍打开时重复重置一级/二级视图、snap、搜索状态和二级位移，并与面板对新高度的正常吸附动画叠加。

本 PR 将最新窗口高度保存在 ref 中，仅用于下一次打开时初始化二级浮窗位移；窗口高度变化不再触发整段状态重置，同时保留浮窗对当前 viewport 的高度自适应。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes makecindy/cindy#223
- 本 PR 包含：稳定 `ModelPickerSheet` 在 Android 键盘缩窗期间的内部状态；补充窗口高度变化不得重新触发打开重置的回归测试。
- 明确不包含：不修改共享 `SheetModal` 键盘避让策略，不移除 composer `LayoutAnimation`，不调整浮窗样式或文案。
- 用户可见变化：键盘显示期间操作模型选择浮窗时，不再因窗口高度变化重置视图、snap 或搜索状态。
- 是否存在 breaking change：无。

### UI 变化

仅涉及既有交互稳定性，无样式变化。当前环境缺少 `adb`，未生成 Android 实机/模拟器录屏；见“未执行的验证”。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/modelPickerSheetResize.test.ts src/__tests__/modelPickerSheetModel.test.ts
结果：2 个测试文件、12 个测试通过。

pnpm --filter mobile typecheck
结果：通过。

pnpm --filter mobile test
结果：246 个测试文件、2289 个测试通过。

pnpm test:unit
结果：仓库测试 runner 与全部配置为 required 的 unit workspace 通过。
```

### 手工验证

未执行 Android 真机或模拟器验证。自动回归测试已确认窗口高度不再进入浮窗打开重置 effect 的依赖，并锁定最新高度仅用于下一次打开初始化。

### 未执行的验证

- Android 真机/模拟器录屏与时序验证：`pnpm --filter mobile test:e2e:doctor:android` 检查显示 Expo CLI 与 Maestro CLI 可用，但当前环境找不到 `adb`，没有连接的 Android emulator/device。
- Light / Dark 实机视觉验证：本次无样式或颜色改动，但受影响交互仍需在 Android 两种模式下各走一遍 Issue 验收路径。
- iOS 手工回归：未执行；改动不改变 iOS 键盘避让或浮窗高度计算路径。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 的模型选择浮窗打开周期；主要修复 Android `adjustResize`，iOS 共享同一组件但保持既有高度自适应。
- 回滚 / 降级方式：回滚本 PR commit 即可；不涉及 schema、协议、原生配置或持久数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因
