### PR TITLE
fix(desktop): 新建会话页 device-link 提示条移到输入框下方并水平居中

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2089,26 +2089,6 @@ export function NewMakerDraftRoute() {
               />
 
               <div className={cn('flex w-full flex-col items-start gap-0', isDraftNarrow && 'order-3')}>
-                {/* device-link:为远程设备项目新建对话时的明显标识。让用户清楚这条对话会建在
-                    被控设备上、属于那台机器的项目,而不是本机。 */}
-                {isDeviceLinkDraft && (
-                  <div className="mb-3 flex max-w-full items-center gap-2 rounded-full border border-[var(--border-default)] bg-[var(--surface-chip)] px-3 py-1 text-[12px] text-[var(--text-secondary)]">
-                    <MonitorSmartphone
-                      size={14}
-                      strokeWidth={2}
-                      className="shrink-0 text-[var(--folder-item-icon)]"
-                    />
-                    <span className="min-w-0 truncate">
-                      {t('ccAgent.draft.remoteProjectBanner', {
-                        device: effectiveDeviceLinkDeviceName ?? effectiveDeviceLinkDeviceId ?? '',
-                        project:
-                          effectiveWorkingDir?.split(/[\\/]/).filter(Boolean).pop() ??
-                          effectiveWorkingDir ??
-                          '',
-                      })}
-                    </span>
-                  </div>
-                )}
                 <div className="w-full">
                   <ChatInput
                     onSend={handleSend}
@@ -2204,6 +2184,27 @@ export function NewMakerDraftRoute() {
                     }
                   />
                 </div>
+                {/* device-link:为远程设备项目新建对话时的明显标识。让用户清楚这条对话会建在
+                    被控设备上、属于那台机器的项目,而不是本机。放输入框正下方并与其水平居中
+                    (父列 items-start,靠 self-center 相对 w-full 的输入框居中)。 */}
+                {isDeviceLinkDraft && (
+                  <div className="mt-3 flex max-w-full items-center gap-2 self-center rounded-full border border-[var(--border-default)] bg-[var(--surface-chip)] px-3 py-1 text-[12px] text-[var(--text-secondary)]">
+                    <MonitorSmartphone
+                      size={14}
+                      strokeWidth={2}
+                      className="shrink-0 text-[var(--folder-item-icon)]"
+                    />
+                    <span className="min-w-0 truncate">
+                      {t('ccAgent.draft.remoteProjectBanner', {
+                        device: effectiveDeviceLinkDeviceName ?? effectiveDeviceLinkDeviceId ?? '',
+                        project:
+                          effectiveWorkingDir?.split(/[\\/]/).filter(Boolean).pop() ??
+                          effectiveWorkingDir ??
+                          '',
+                      })}
+                    </span>
+                  </div>
+                )}
                 {/* 输入框跟随 inputWidth 变宽后,快捷入口只有 4 项,若也铺满全宽
                     会被撑成又宽又空的短卡。这里把卡片区封顶在 800px、左对齐(与输入框
                     左缘齐),保持每张卡当前的紧凑比例;输入框仍独立用满可用宽度。 */}


### PR DESCRIPTION
## 这次改了什么

### 摘要

新建会话页(create-agent hero)里,device-link 远程草稿的「在 xx 的 xx 中新建会话」提示条原先渲染在输入框**上方**、随 `items-start` 列**左对齐**,视觉上悬空、和输入框没有归属关系。本 PR 把它移到**输入框正下方**并与输入框**水平居中**(`mb-3` → `mt-3 self-center`),「快速开始」模块随之整体下移约 38px(提示条高度 + 12px 间距)。输入框与上方组件(品牌锁定等)的间距与列结构不变;非 device-link 草稿零差异。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(用户反馈的 UI bug)
- 本 PR 包含:`NewMakerDraftRoute.tsx` 中 device-link 提示条的 JSX 渲染位置调整(上方左对齐 → 下方居中)
- 明确不包含:提示条自身样式 / 文案 / i18n、ChatInput、快速开始卡片、任何逻辑或 IPC 变更
- 用户可见变化:仅 device-link 远程项目草稿页的提示条位置变化
- 是否存在 breaking change:无

### UI 变化

**1:1 高保真前后对照页(按真实组件结构 + `themes/colors.ts` token 值还原,红圈标注改动点,支持 Dark / Light 切换)**:

👉 https://cindy-pr-banner-demo.workers.xd.team (公司内网可访问;首次部署 DNS 生效可能需 1-3 分钟)

| 项 | 修改前 | 修改后 |
|---|---|---|
| 提示条位置 | 输入框上方,`mb-3`,父列 `items-start` → 左对齐 | 输入框下方,`mt-3 self-center` → 与输入框水平居中 |
| 提示条样式 | 不变(`rounded-full` + `--surface-chip` / `--border-default` / `--text-secondary` token) | 同左 |
| 快速开始 | `mt-[42px]` 紧跟输入框 | `mt-[42px]` 改为紧跟提示条 → 整体下移约 38px |

Light / Dark 双模式:位置改动与配色无关,两模式共用同一布局,对照页可切换验证。

### 远程连接 / 手机版适配说明(按 remote-and-mobile-adaptation 规则)

1. **SSH 远程工作区**:纯 renderer 布局调整,不涉及 workdir 文件、agent 进程或会话数据的读取路径;本提示条本身就是 device-link 远程草稿的标识,改动只影响其展示位置。
2. **IPC / device-link allowlist**:未新增、未修改任何 IPC channel 或推送事件,无需登记。
3. **手机版**:`apps/mobile` 不复用该 desktop 组件,无对应入口变化,不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果:通过(tsc --noEmit 无错误)

pnpm test:unit(仓库根,完整跑)
结果:通过,EXIT_CODE=0;26 个 workspace PASS,其余 SKIP(无可收集测试),无 FAIL
```

### 手工验证

以修改后的 JSX 结构 + 真实 token 值构建 1:1 对照页(上方链接),Dark / Light 双模式下确认:提示条位于输入框正下方且水平居中、提示条自身样式不变、快速开始随之下移、其余组件位置不变。

### 未执行的验证

未在真实双设备 device-link 草稿场景下运行验证(本次开发环境无第二台可控设备;改动为纯静态布局,`isDeviceLinkDraft` 分支条件未动,风险极低)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 desktop 新建会话页 device-link 草稿态的一个提示条位置;不触及 maker-core / system prompt / 协议 / 数据库 / i18n
- 回滚 / 降级方式:revert 本 commit 即可,无状态迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(无需:未改行为契约)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
