### PR TITLE
fix(desktop): 同步会话标题到远程镜像

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -1,11 +1,11 @@
 /**
- * sessionsUpdateTranscriptRelocation.test.ts — 会话移动触发 CLI 转录迁移的接线。
- * ------------------------------------------------------------------------------------
- * `local-db:sessions:update` 在 patch 导致 workingDir 实际变化、且会话是本机 cc 会话时,
- * 必须在查询返回行之前调用 relocateClaudeTranscriptsForSessionMove(旧值 → 新值),
- * 且迁移中持久化的最新 sdkSessionId 要并入返回行与广播 patch(renderer 不能留旧
- * resume id,PR #472 Codex review);以下情况一律不调用:workingDir 未变 / patch 不含
- * workingDir / codex 会话 / remote 会话。
+ * sessionsUpdate.test.ts — `local-db:sessions:update` handler 集成接线。
+ * -------------------------------------------------------------------
+ * 覆盖持久化后需要广播的增量字段，以及会话移动触发 CLI 转录迁移的边界：
+ * workingDir 实际变化、且会话是本机 cc 会话时，必须在查询返回行之前调用
+ * relocateClaudeTranscriptsForSessionMove(旧值 → 新值)，并把迁移中持久化的最新
+ * sdkSessionId 并入返回行与广播 patch；其它会话或未实际移动时不得调用。
+ *
  * 通过 mock electron ipcMain 捕获真实 handler + 内存 sqlite 全列 sessions 表做集成断言。
  */
 import Database from 'better-sqlite3';
@@ -137,7 +137,7 @@ beforeEach(() => {
   registerSessionIpc();
 });
 
-describe('local-db:sessions:update transcript relocation wiring', () => {
+describe('local-db:sessions:update handler wiring', () => {
   it('persists and broadcasts title-only patches to device-link subscribers', async () => {
     await invokeUpdate('codex-local', { title: '排查远程标题同步' });
 
@@ -145,10 +145,13 @@ describe('local-db:sessions:update transcript relocation wiring', () => {
       .prepare('SELECT title FROM sessions WHERE id = ?')
       .get('codex-local') as { title: string };
     expect(persisted.title).toBe('排查远程标题同步');
-    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
-      sessionId: 'codex-local',
-      patch: { title: '排查远程标题同步' },
-    });
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith(
+      'local-db:sessions:patched',
+      expect.objectContaining({
+        sessionId: 'codex-local',
+        patch: expect.objectContaining({ title: '排查远程标题同步' }),
+      }),
+    );
   });
 
   it('broadcasts permission setting patches to every mounted client', async () => {

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdateTranscriptRelocation.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdateTranscriptRelocation.test.ts
@@ -138,6 +138,19 @@ beforeEach(() => {
 });
 
 describe('local-db:sessions:update transcript relocation wiring', () => {
+  it('persists and broadcasts title-only patches to device-link subscribers', async () => {
+    await invokeUpdate('codex-local', { title: '排查远程标题同步' });
+
+    const persisted = h.sqlite!
+      .prepare('SELECT title FROM sessions WHERE id = ?')
+      .get('codex-local') as { title: string };
+    expect(persisted.title).toBe('排查远程标题同步');
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { title: '排查远程标题同步' },
+    });
+  });
+
   it('broadcasts permission setting patches to every mounted client', async () => {
     await invokeUpdate('codex-local', { permissionMode: 'ask' });
 

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -883,6 +883,7 @@ export function registerSessionIpc(): void {
     if (!row) throwIpcError('NOT_FOUND', 'Session 不存在');
     const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
     const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
+    const titleChanged = p.title !== undefined;
     if (
       projectTargetChanged &&
       row.workspaceKind === 'project' &&
@@ -891,7 +892,7 @@ export function registerSessionIpc(): void {
     ) {
       await upsertRecentWorkdir(row.workingDir, Date.now());
     }
-    if (projectTargetChanged || settingsChanged) {
+    if (projectTargetChanged || settingsChanged || titleChanged) {
       broadcastSessionPatched(sid, p);
     }
     // sidebar-card-mode: 会话被置顶那一刻补生成任务摘要(turn-done 路径只覆盖


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复本机会话自动标题已写入 SQLite、但 device-link 控制端远程镜像仍停留在 `New Maker` 的问题。

根因是 `local-db:sessions:update` 只在项目目标或远程设置字段变化时广播 `local-db:sessions:patched`；纯 `{ title }` 更新成功持久化后没有进入标准增量广播出口。本 PR 将标题变化纳入广播条件，并补充回归测试，验证标题落库后会向 device-link subscribers 发送正确 patch。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #73
- 本 PR 包含：`sessions:update` 标题增量广播；SQLite 持久化与广播 payload 回归测试
- 明确不包含：新增 IPC channel、device-link 协议或 allowlist；数据库 schema/migration；UI 改动
- 用户可见变化：原端自动标题生成完成后，控制端远程会话镜像自动更新，无需切换“我控制它”或重连
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 结构或样式变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
结果：通过，9 tests

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过（测试进程使用本机 Python 3.12；默认 Python 3.6 不支持仓库脚本的 future annotations）
```

### 手工验证

Windows 本机启动两个独立的 `--isolated` Desktop 实例，登录同一账号并建立 device-link 控制关系。在原端新建会话并发送首条消息，确认自动标题生成后控制端远程镜像无需刷新、重连或切换控制权即可同步最新标题。验证通过。

多端适配结论：

- SSH 远程工作区：不涉及 workdir 文件或 agent 进程访问。
- 设备互联远程控制：复用已准入的 `local-db:sessions:patched` sessions topic，无新增 channel/allowlist。
- 手机版：复用同一 device-link sessions 增量链路，无需新增 UI 入口。

### 未执行的验证

未在两台物理设备上执行 Windows ↔ macOS 实测；已用两个独立 Windows isolated 实例覆盖双端 device-link 增量同步链路。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `local-db:sessions:update` 的纯标题更新会额外发送一次现有 `sessions:patched` 事件；本机 Renderer 与 device-link 控制端均按既有 shallow patch 语义消费。
- 回滚 / 降级方式：回滚本提交即可恢复原广播条件；无 schema、协议或持久数据兼容问题。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因
