### PR TITLE
fix(mobile): 修复 Android 首次语音授权竞态

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -3385,6 +3385,11 @@ export default function SessionScreen() {
           requestPermission: requestRecordingPermissionsAsync,
           isRequestCurrent: () => voicePermissionRequestSeqRef.current === permissionRequestSeq,
           isAppActive: () => AppState.currentState === 'active',
+          subscribeToAppState: (listener) => {
+            const subscription = AppState.addEventListener('change', listener);
+            return () => subscription.remove();
+          },
+          signal: currentPermissionAbortController.signal,
           waitForAppActive: () => waitForMobileVoiceAppActive({
             isAppActive: () => AppState.currentState === 'active',
             subscribe: (listener) => {

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -27,6 +27,7 @@ import {
   X,
 } from 'lucide-react-native';
 import {
+  getRecordingPermissionsAsync,
   requestRecordingPermissionsAsync,
   setAudioModeAsync,
 } from 'expo-audio';
@@ -311,6 +312,10 @@ import {
   takePrewarmedMobileVoiceAsr,
   type PrewarmedMobileVoiceAsr,
 } from '@/session/mobileVoicePrewarm';
+import {
+  resolveMobileVoiceRecordingPermission,
+  shouldCancelMobileVoiceForBackground,
+} from '@/session/mobileVoiceStartup';
 import {
   CINDY_MANAGED_REFINER_PROVIDER,
   createMobileCindyVoiceCredential,
@@ -1123,6 +1128,8 @@ export default function SessionScreen() {
     }), [deleteRemoteMediaObject]);
   remoteMediaQueueRef.current ??= createRemoteMediaQueue();
   const voiceRecordingActiveRef = useRef(false);
+  const voicePermissionRequestInFlightRef = useRef(false);
+  const voicePermissionRequestSeqRef = useRef(0);
   const voiceStartupInFlightRef = useRef(false);
   // Increments whenever a startup is superseded (screen unmount / session
   // switch). startVoiceRecording re-checks it after each await so a startup
@@ -3331,7 +3338,8 @@ export default function SessionScreen() {
 
   const startVoiceRecording = useCallback(async () => {
     if (
-      voiceStartupInFlightRef.current
+      voicePermissionRequestInFlightRef.current
+      || voiceStartupInFlightRef.current
       || voiceStopInFlightRef.current
       || voiceRecordingActiveRef.current
       || voiceState === 'listening'
@@ -3341,6 +3349,7 @@ export default function SessionScreen() {
     setVoiceError(null);
     setVoiceReleaseToSendActive(false);
     let claimedPrewarm: PrewarmedMobileVoiceAsr | null = null;
+    let permissionRequestSeq: number | null = null;
     let startupSeq: number | null = null;
     // The controller THIS startup created. Stale-teardown paths must only touch
     // this one: by the time a superseded continuation resumes, the shared ref
@@ -3359,24 +3368,33 @@ export default function SessionScreen() {
         setVoiceError(mobileVoiceRealtimeAudioUnavailableError());
         return;
       }
-      startupSeq = voiceStartupSeqRef.current + 1;
-      voiceStartupSeqRef.current = startupSeq;
-      voiceStartupInFlightRef.current = true;
-      const permission = await requestRecordingPermissionsAsync();
-      if (voiceStartupSeqRef.current !== startupSeq) {
-        // Unmounted / superseded while the permission prompt was up: bail out
-        // before touching audio mode so a stale continuation can't re-enable
-        // recording mode on a dead screen.
-        return;
+      permissionRequestSeq = voicePermissionRequestSeqRef.current + 1;
+      voicePermissionRequestSeqRef.current = permissionRequestSeq;
+      voicePermissionRequestInFlightRef.current = true;
+      let permissionResult;
+      try {
+        permissionResult = await resolveMobileVoiceRecordingPermission({
+          getPermission: getRecordingPermissionsAsync,
+          requestPermission: requestRecordingPermissionsAsync,
+          isRequestCurrent: () => voicePermissionRequestSeqRef.current === permissionRequestSeq,
+          isAppActive: () => AppState.currentState === 'active',
+        });
+      } finally {
+        if (voicePermissionRequestSeqRef.current === permissionRequestSeq) {
+          voicePermissionRequestInFlightRef.current = false;
+        }
       }
-      if (!permission.granted) {
-        voiceStartupInFlightRef.current = false;
+      if (permissionResult === 'cancelled') return;
+      if (permissionResult === 'denied') {
         voiceRecordingActiveRef.current = false;
         voiceStopAfterStartRef.current = false;
         setVoiceState('error');
         setVoiceError(mobileVoiceMicPermissionError());
         return;
       }
+      startupSeq = voiceStartupSeqRef.current + 1;
+      voiceStartupSeqRef.current = startupSeq;
+      voiceStartupInFlightRef.current = true;
       await setAudioModeAsync({
         allowsRecording: true,
         playsInSilentMode: true,
@@ -3492,6 +3510,10 @@ export default function SessionScreen() {
       // (e.g. session construction threw); closing it again after the
       // controller's own teardown is harmless — provider stop is idempotent.
       void claimedPrewarm?.asr.stop().catch(() => undefined);
+      if (
+        permissionRequestSeq !== null
+        && voicePermissionRequestSeqRef.current !== permissionRequestSeq
+      ) return;
       if (startupSeq !== null && voiceStartupSeqRef.current !== startupSeq) {
         // Superseded: tear down only what THIS startup created; the shared ref
         // may already belong to a newer session's recording.
@@ -3520,11 +3542,12 @@ export default function SessionScreen() {
 
   const cancelVoiceForAppBackground = useCallback(() => {
     const controller = voiceControllerSessionRef.current;
-    const ownsActiveRun = Boolean(
-      controller
-      || voiceStartupInFlightRef.current
-      || voiceRecordingActiveRef.current,
-    );
+    const ownsActiveRun = shouldCancelMobileVoiceForBackground({
+      permissionRequestInFlight: voicePermissionRequestInFlightRef.current,
+      startupInFlight: voiceStartupInFlightRef.current,
+      recordingActive: voiceRecordingActiveRef.current,
+      hasController: Boolean(controller),
+    });
     if (!ownsActiveRun) {
       // pressIn may have opened a speculative ASR connection without creating
       // a controller yet; backgrounding must not leave that parked connection.
@@ -3552,7 +3575,8 @@ export default function SessionScreen() {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
       // iOS permission sheets and Control Center can briefly report `inactive`.
-      // Only a real background transition owns the foreground-only voice teardown.
+      // Android permission sheets can report `background`, but permission
+      // resolution has not claimed audio resources and must survive that event.
       if (nextState !== 'background') return;
       cancelVoiceForAppBackground();
     });
@@ -3565,6 +3589,8 @@ export default function SessionScreen() {
       voiceControllerSessionRef.current = null;
       // Supersede any in-flight startup so its post-await re-checks tear down
       // the resources it acquired for this now-dead screen.
+      voicePermissionRequestSeqRef.current += 1;
+      voicePermissionRequestInFlightRef.current = false;
       voiceStartupSeqRef.current += 1;
       voiceStartupInFlightRef.current = false;
       voiceStopInFlightRef.current = false;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -3415,6 +3415,10 @@ export default function SessionScreen() {
         setVoiceError(mobileVoiceMicPermissionError());
         return;
       }
+      if (
+        voicePermissionRequestSeqRef.current !== permissionRequestSeq
+        || AppState.currentState !== 'active'
+      ) return;
       startupSeq = voiceStartupSeqRef.current + 1;
       voiceStartupSeqRef.current = startupSeq;
       voiceStartupInFlightRef.current = true;
@@ -3577,7 +3581,6 @@ export default function SessionScreen() {
   const cancelVoiceForAppBackground = useCallback(() => {
     const controller = voiceControllerSessionRef.current;
     const ownsActiveRun = shouldCancelMobileVoiceForBackground({
-      permissionRequestInFlight: voicePermissionRequestInFlightRef.current,
       startupInFlight: voiceStartupInFlightRef.current,
       recordingActive: voiceRecordingActiveRef.current,
       hasController: Boolean(controller),

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -3378,7 +3378,7 @@ export default function SessionScreen() {
       permissionRequestAbortController = currentPermissionAbortController;
       voicePermissionRequestAbortRef.current = currentPermissionAbortController;
       voicePermissionRequestInFlightRef.current = true;
-      let permissionResult;
+      let permissionResult: Awaited<ReturnType<typeof resolveMobileVoiceRecordingPermission>>;
       try {
         permissionResult = await resolveMobileVoiceRecordingPermission({
           getPermission: getRecordingPermissionsAsync,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -315,6 +315,7 @@ import {
 import {
   resolveMobileVoiceRecordingPermission,
   shouldCancelMobileVoiceForBackground,
+  waitForMobileVoiceAppActive,
 } from '@/session/mobileVoiceStartup';
 import {
   CINDY_MANAGED_REFINER_PROVIDER,
@@ -1130,6 +1131,7 @@ export default function SessionScreen() {
   const voiceRecordingActiveRef = useRef(false);
   const voicePermissionRequestInFlightRef = useRef(false);
   const voicePermissionRequestSeqRef = useRef(0);
+  const voicePermissionRequestAbortRef = useRef<AbortController | null>(null);
   const voiceStartupInFlightRef = useRef(false);
   // Increments whenever a startup is superseded (screen unmount / session
   // switch). startVoiceRecording re-checks it after each await so a startup
@@ -3350,7 +3352,9 @@ export default function SessionScreen() {
     setVoiceReleaseToSendActive(false);
     let claimedPrewarm: PrewarmedMobileVoiceAsr | null = null;
     let permissionRequestSeq: number | null = null;
+    let permissionRequestAbortController: AbortController | null = null;
     let startupSeq: number | null = null;
+    let audioModeEnabled = false;
     // The controller THIS startup created. Stale-teardown paths must only touch
     // this one: by the time a superseded continuation resumes, the shared ref
     // may already point at a newer session's live recording. Read through the
@@ -3370,6 +3374,9 @@ export default function SessionScreen() {
       }
       permissionRequestSeq = voicePermissionRequestSeqRef.current + 1;
       voicePermissionRequestSeqRef.current = permissionRequestSeq;
+      const currentPermissionAbortController = new AbortController();
+      permissionRequestAbortController = currentPermissionAbortController;
+      voicePermissionRequestAbortRef.current = currentPermissionAbortController;
       voicePermissionRequestInFlightRef.current = true;
       let permissionResult;
       try {
@@ -3378,10 +3385,21 @@ export default function SessionScreen() {
           requestPermission: requestRecordingPermissionsAsync,
           isRequestCurrent: () => voicePermissionRequestSeqRef.current === permissionRequestSeq,
           isAppActive: () => AppState.currentState === 'active',
+          waitForAppActive: () => waitForMobileVoiceAppActive({
+            isAppActive: () => AppState.currentState === 'active',
+            subscribe: (listener) => {
+              const subscription = AppState.addEventListener('change', listener);
+              return () => subscription.remove();
+            },
+            signal: currentPermissionAbortController.signal,
+          }),
         });
       } finally {
         if (voicePermissionRequestSeqRef.current === permissionRequestSeq) {
           voicePermissionRequestInFlightRef.current = false;
+        }
+        if (voicePermissionRequestAbortRef.current === permissionRequestAbortController) {
+          voicePermissionRequestAbortRef.current = null;
         }
       }
       if (permissionResult === 'cancelled') return;
@@ -3399,6 +3417,7 @@ export default function SessionScreen() {
         allowsRecording: true,
         playsInSilentMode: true,
       });
+      audioModeEnabled = true;
       // Open the device link in the background: voice dictation writes into the
       // local composer via the cloud ASR proxy and does not need the mobile↔desktop
       // link (only submitting the composed message later does). Awaiting it used
@@ -3511,7 +3530,8 @@ export default function SessionScreen() {
       // controller's own teardown is harmless — provider stop is idempotent.
       void claimedPrewarm?.asr.stop().catch(() => undefined);
       if (
-        permissionRequestSeq !== null
+        startupSeq === null
+        && permissionRequestSeq !== null
         && voicePermissionRequestSeqRef.current !== permissionRequestSeq
       ) return;
       if (startupSeq !== null && voiceStartupSeqRef.current !== startupSeq) {
@@ -3521,8 +3541,17 @@ export default function SessionScreen() {
         if (created) {
           if (voiceControllerSessionRef.current === created) {
             voiceControllerSessionRef.current = null;
+            voiceRecordingActiveRef.current = false;
           }
           await created.cancel().catch(() => undefined);
+        }
+        if (
+          audioModeEnabled
+          && !voiceControllerSessionRef.current
+          && !voiceStartupInFlightRef.current
+          && !voiceRecordingActiveRef.current
+        ) {
+          await setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
         }
         return;
       }
@@ -3590,6 +3619,8 @@ export default function SessionScreen() {
       // Supersede any in-flight startup so its post-await re-checks tear down
       // the resources it acquired for this now-dead screen.
       voicePermissionRequestSeqRef.current += 1;
+      voicePermissionRequestAbortRef.current?.abort();
+      voicePermissionRequestAbortRef.current = null;
       voicePermissionRequestInFlightRef.current = false;
       voiceStartupSeqRef.current += 1;
       voiceStartupInFlightRef.current = false;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -45,6 +45,7 @@ import {
   Zap,
 } from 'lucide-react-native';
 import {
+  getRecordingPermissionsAsync,
   requestRecordingPermissionsAsync,
   setAudioModeAsync,
 } from 'expo-audio';
@@ -205,6 +206,10 @@ import {
   takePrewarmedMobileVoiceAsr,
   type PrewarmedMobileVoiceAsr,
 } from '@/session/mobileVoicePrewarm';
+import {
+  resolveMobileVoiceRecordingPermission,
+  shouldCancelMobileVoiceForBackground,
+} from '@/session/mobileVoiceStartup';
 import {
   CINDY_MANAGED_REFINER_PROVIDER,
   createMobileCindyVoiceCredential,
@@ -460,6 +465,8 @@ export default function NewRemoteSessionScreen() {
   const firstMessageInputRef = useRef<NativeTextInput>(null);
   const voiceDraftScrollRef = useRef<ScrollView>(null);
   const voiceRecordingActiveRef = useRef(false);
+  const voicePermissionRequestInFlightRef = useRef(false);
+  const voicePermissionRequestSeqRef = useRef(0);
   const voiceStartupInFlightRef = useRef(false);
   const voiceStopInFlightRef = useRef(false);
   const voiceStartupSeqRef = useRef(0);
@@ -880,6 +887,8 @@ export default function NewRemoteSessionScreen() {
   }, []);
 
   const cancelVoiceForDeviceSwitch = useCallback(() => {
+    voicePermissionRequestSeqRef.current += 1;
+    voicePermissionRequestInFlightRef.current = false;
     voiceStartupSeqRef.current += 1;
     const controller = voiceControllerSessionRef.current;
     voiceControllerSessionRef.current = null;
@@ -897,13 +906,15 @@ export default function NewRemoteSessionScreen() {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
       // iOS permission sheets and Control Center can briefly report `inactive`.
-      // Only a real background transition owns the foreground-only voice teardown.
+      // Android permission sheets can report `background`, but permission
+      // resolution has not claimed audio resources and must survive that event.
       if (nextState !== 'background') return;
-      if (
-        voiceStartupInFlightRef.current
-        || voiceRecordingActiveRef.current
-        || voiceControllerSessionRef.current
-      ) {
+      if (shouldCancelMobileVoiceForBackground({
+        permissionRequestInFlight: voicePermissionRequestInFlightRef.current,
+        startupInFlight: voiceStartupInFlightRef.current,
+        recordingActive: voiceRecordingActiveRef.current,
+        hasController: Boolean(voiceControllerSessionRef.current),
+      })) {
         cancelVoiceForDeviceSwitch();
       } else {
         // pressIn may have opened a speculative ASR connection without creating
@@ -916,7 +927,11 @@ export default function NewRemoteSessionScreen() {
 
   const selectDevice = useCallback((option: NewSessionDeviceOption) => {
     if (creating) return;
-    if (voiceStopInFlightRef.current || voiceIsProcessing) return;
+    if (
+      voicePermissionRequestInFlightRef.current
+      || voiceStopInFlightRef.current
+      || voiceIsProcessing
+    ) return;
     if (voiceStartupInFlightRef.current || voiceRecordingActiveRef.current || voiceState === 'listening') {
       cancelVoiceForDeviceSwitch();
     }
@@ -1360,13 +1375,15 @@ export default function NewRemoteSessionScreen() {
 
   const startVoiceRecording = useCallback(async () => {
     if (
-      voiceStartupInFlightRef.current
+      voicePermissionRequestInFlightRef.current
+      || voiceStartupInFlightRef.current
       || voiceStopInFlightRef.current
       || voiceRecordingActiveRef.current
       || voiceState === 'listening'
       || voiceIsProcessing
     ) return;
     setVoiceError(null);
+    let permissionRequestSeq: number | null = null;
     let startupSeq: number | null = null;
     let claimedPrewarm: PrewarmedMobileVoiceAsr | null = null;
     try {
@@ -1380,19 +1397,33 @@ export default function NewRemoteSessionScreen() {
         setVoiceError(mobileVoiceRealtimeAudioUnavailableError());
         return;
       }
-      startupSeq = voiceStartupSeqRef.current + 1;
-      voiceStartupSeqRef.current = startupSeq;
-      voiceStartupInFlightRef.current = true;
-      const permission = await requestRecordingPermissionsAsync();
-      if (voiceStartupSeqRef.current !== startupSeq) return;
-      if (!permission.granted) {
-        voiceStartupInFlightRef.current = false;
+      permissionRequestSeq = voicePermissionRequestSeqRef.current + 1;
+      voicePermissionRequestSeqRef.current = permissionRequestSeq;
+      voicePermissionRequestInFlightRef.current = true;
+      let permissionResult;
+      try {
+        permissionResult = await resolveMobileVoiceRecordingPermission({
+          getPermission: getRecordingPermissionsAsync,
+          requestPermission: requestRecordingPermissionsAsync,
+          isRequestCurrent: () => voicePermissionRequestSeqRef.current === permissionRequestSeq,
+          isAppActive: () => AppState.currentState === 'active',
+        });
+      } finally {
+        if (voicePermissionRequestSeqRef.current === permissionRequestSeq) {
+          voicePermissionRequestInFlightRef.current = false;
+        }
+      }
+      if (permissionResult === 'cancelled') return;
+      if (permissionResult === 'denied') {
         voiceStopInFlightRef.current = false;
         voiceRecordingActiveRef.current = false;
         setVoiceState('error');
         setVoiceError(mobileVoiceMicPermissionError());
         return;
       }
+      startupSeq = voiceStartupSeqRef.current + 1;
+      voiceStartupSeqRef.current = startupSeq;
+      voiceStartupInFlightRef.current = true;
       await setAudioModeAsync({
         allowsRecording: true,
         playsInSilentMode: true,
@@ -1492,6 +1523,10 @@ export default function NewRemoteSessionScreen() {
       // (e.g. session construction threw); closing it again after the
       // controller's own teardown is harmless — provider stop is idempotent.
       void claimedPrewarm?.asr.stop().catch(() => undefined);
+      if (
+        permissionRequestSeq !== null
+        && voicePermissionRequestSeqRef.current !== permissionRequestSeq
+      ) return;
       if (startupSeq !== null && voiceStartupSeqRef.current !== startupSeq) return;
       const controller = voiceControllerSessionRef.current;
       voiceControllerSessionRef.current = null;
@@ -1577,6 +1612,8 @@ export default function NewRemoteSessionScreen() {
     return () => {
       const controller = voiceControllerSessionRef.current;
       voiceControllerSessionRef.current = null;
+      voicePermissionRequestSeqRef.current += 1;
+      voicePermissionRequestInFlightRef.current = false;
       voiceStartupSeqRef.current += 1;
       voiceStartupInFlightRef.current = false;
       voiceStopInFlightRef.current = false;
@@ -2069,6 +2106,7 @@ export default function NewRemoteSessionScreen() {
   const create = useCallback(async () => {
     if (
       creatingRef.current
+      || voicePermissionRequestInFlightRef.current
       || voiceStartupInFlightRef.current
       || voiceStopInFlightRef.current
       || voiceIsProcessing

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -914,7 +914,6 @@ export default function NewRemoteSessionScreen() {
       // resolution has not claimed audio resources and must survive that event.
       if (nextState !== 'background') return;
       if (shouldCancelMobileVoiceForBackground({
-        permissionRequestInFlight: voicePermissionRequestInFlightRef.current,
         startupInFlight: voiceStartupInFlightRef.current,
         recordingActive: voiceRecordingActiveRef.current,
         hasController: Boolean(voiceControllerSessionRef.current),
@@ -1447,6 +1446,10 @@ export default function NewRemoteSessionScreen() {
         setVoiceError(mobileVoiceMicPermissionError());
         return;
       }
+      if (
+        voicePermissionRequestSeqRef.current !== permissionRequestSeq
+        || AppState.currentState !== 'active'
+      ) return;
       startupSeq = voiceStartupSeqRef.current + 1;
       voiceStartupSeqRef.current = startupSeq;
       voiceStartupInFlightRef.current = true;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1417,6 +1417,11 @@ export default function NewRemoteSessionScreen() {
           requestPermission: requestRecordingPermissionsAsync,
           isRequestCurrent: () => voicePermissionRequestSeqRef.current === permissionRequestSeq,
           isAppActive: () => AppState.currentState === 'active',
+          subscribeToAppState: (listener) => {
+            const subscription = AppState.addEventListener('change', listener);
+            return () => subscription.remove();
+          },
+          signal: currentPermissionAbortController.signal,
           waitForAppActive: () => waitForMobileVoiceAppActive({
             isAppActive: () => AppState.currentState === 'active',
             subscribe: (listener) => {

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1410,7 +1410,7 @@ export default function NewRemoteSessionScreen() {
       permissionRequestAbortController = currentPermissionAbortController;
       voicePermissionRequestAbortRef.current = currentPermissionAbortController;
       voicePermissionRequestInFlightRef.current = true;
-      let permissionResult;
+      let permissionResult: Awaited<ReturnType<typeof resolveMobileVoiceRecordingPermission>>;
       try {
         permissionResult = await resolveMobileVoiceRecordingPermission({
           getPermission: getRecordingPermissionsAsync,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -209,6 +209,7 @@ import {
 import {
   resolveMobileVoiceRecordingPermission,
   shouldCancelMobileVoiceForBackground,
+  waitForMobileVoiceAppActive,
 } from '@/session/mobileVoiceStartup';
 import {
   CINDY_MANAGED_REFINER_PROVIDER,
@@ -467,6 +468,7 @@ export default function NewRemoteSessionScreen() {
   const voiceRecordingActiveRef = useRef(false);
   const voicePermissionRequestInFlightRef = useRef(false);
   const voicePermissionRequestSeqRef = useRef(0);
+  const voicePermissionRequestAbortRef = useRef<AbortController | null>(null);
   const voiceStartupInFlightRef = useRef(false);
   const voiceStopInFlightRef = useRef(false);
   const voiceStartupSeqRef = useRef(0);
@@ -888,6 +890,8 @@ export default function NewRemoteSessionScreen() {
 
   const cancelVoiceForDeviceSwitch = useCallback(() => {
     voicePermissionRequestSeqRef.current += 1;
+    voicePermissionRequestAbortRef.current?.abort();
+    voicePermissionRequestAbortRef.current = null;
     voicePermissionRequestInFlightRef.current = false;
     voiceStartupSeqRef.current += 1;
     const controller = voiceControllerSessionRef.current;
@@ -1384,8 +1388,11 @@ export default function NewRemoteSessionScreen() {
     ) return;
     setVoiceError(null);
     let permissionRequestSeq: number | null = null;
+    let permissionRequestAbortController: AbortController | null = null;
     let startupSeq: number | null = null;
     let claimedPrewarm: PrewarmedMobileVoiceAsr | null = null;
+    let audioModeEnabled = false;
+    let createdController: MobileVoiceControllerSession | null = null;
     try {
       if (!selectedDeviceId) {
         setVoiceState('error');
@@ -1399,6 +1406,9 @@ export default function NewRemoteSessionScreen() {
       }
       permissionRequestSeq = voicePermissionRequestSeqRef.current + 1;
       voicePermissionRequestSeqRef.current = permissionRequestSeq;
+      const currentPermissionAbortController = new AbortController();
+      permissionRequestAbortController = currentPermissionAbortController;
+      voicePermissionRequestAbortRef.current = currentPermissionAbortController;
       voicePermissionRequestInFlightRef.current = true;
       let permissionResult;
       try {
@@ -1407,10 +1417,21 @@ export default function NewRemoteSessionScreen() {
           requestPermission: requestRecordingPermissionsAsync,
           isRequestCurrent: () => voicePermissionRequestSeqRef.current === permissionRequestSeq,
           isAppActive: () => AppState.currentState === 'active',
+          waitForAppActive: () => waitForMobileVoiceAppActive({
+            isAppActive: () => AppState.currentState === 'active',
+            subscribe: (listener) => {
+              const subscription = AppState.addEventListener('change', listener);
+              return () => subscription.remove();
+            },
+            signal: currentPermissionAbortController.signal,
+          }),
         });
       } finally {
         if (voicePermissionRequestSeqRef.current === permissionRequestSeq) {
           voicePermissionRequestInFlightRef.current = false;
+        }
+        if (voicePermissionRequestAbortRef.current === permissionRequestAbortController) {
+          voicePermissionRequestAbortRef.current = null;
         }
       }
       if (permissionResult === 'cancelled') return;
@@ -1428,6 +1449,7 @@ export default function NewRemoteSessionScreen() {
         allowsRecording: true,
         playsInSilentMode: true,
       });
+      audioModeEnabled = true;
       // Open the device link in the background: voice dictation writes into the
       // local composer via the cloud ASR proxy and does not need the mobile↔desktop
       // link (only submitting the composed message later does). Awaiting it here
@@ -1504,6 +1526,7 @@ export default function NewRemoteSessionScreen() {
           });
         },
       });
+      createdController = controller;
       voiceControllerSessionRef.current = controller;
       voiceRecordingActiveRef.current = true;
       await controller.start();
@@ -1524,10 +1547,28 @@ export default function NewRemoteSessionScreen() {
       // controller's own teardown is harmless — provider stop is idempotent.
       void claimedPrewarm?.asr.stop().catch(() => undefined);
       if (
-        permissionRequestSeq !== null
+        startupSeq === null
+        && permissionRequestSeq !== null
         && voicePermissionRequestSeqRef.current !== permissionRequestSeq
       ) return;
-      if (startupSeq !== null && voiceStartupSeqRef.current !== startupSeq) return;
+      if (startupSeq !== null && voiceStartupSeqRef.current !== startupSeq) {
+        if (createdController) {
+          if (voiceControllerSessionRef.current === createdController) {
+            voiceControllerSessionRef.current = null;
+            voiceRecordingActiveRef.current = false;
+          }
+          await createdController.cancel().catch(() => undefined);
+        }
+        if (
+          audioModeEnabled
+          && !voiceControllerSessionRef.current
+          && !voiceStartupInFlightRef.current
+          && !voiceRecordingActiveRef.current
+        ) {
+          await setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
+        }
+        return;
+      }
       const controller = voiceControllerSessionRef.current;
       voiceControllerSessionRef.current = null;
       await controller?.cancel().catch(() => undefined);
@@ -1613,6 +1654,8 @@ export default function NewRemoteSessionScreen() {
       const controller = voiceControllerSessionRef.current;
       voiceControllerSessionRef.current = null;
       voicePermissionRequestSeqRef.current += 1;
+      voicePermissionRequestAbortRef.current?.abort();
+      voicePermissionRequestAbortRef.current = null;
       voicePermissionRequestInFlightRef.current = false;
       voiceStartupSeqRef.current += 1;
       voiceStartupInFlightRef.current = false;

--- a/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   resolveMobileVoiceRecordingPermission,
   shouldCancelMobileVoiceForBackground,
+  waitForMobileVoiceAppActive,
 } from '@/session/mobileVoiceStartup';
 
-function deferredPermission(): {
-  promise: Promise<{ granted: boolean }>;
-  resolve: (permission: { granted: boolean }) => void;
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
 } {
-  let resolve!: (permission: { granted: boolean }) => void;
-  const promise = new Promise<{ granted: boolean }>((settle) => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
     resolve = settle;
   });
   return { promise, resolve };
@@ -24,18 +25,21 @@ describe('mobileVoiceStartup', () => {
       requestPermission,
       isRequestCurrent: () => true,
       isAppActive: () => true,
+      waitForAppActive: async () => true,
     })).resolves.toBe('granted');
     expect(requestPermission).not.toHaveBeenCalled();
   });
 
-  it('survives Android background/active transitions caused by the first permission prompt', async () => {
-    const pendingPermission = deferredPermission();
+  it('waits for Android to publish active after the first permission prompt resolves', async () => {
+    const pendingPermission = deferred<{ granted: boolean }>();
+    const pendingForeground = deferred<boolean>();
     let appActive = true;
     const result = resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: false }),
       requestPermission: () => pendingPermission.promise,
       isRequestCurrent: () => true,
       isAppActive: () => appActive,
+      waitForAppActive: () => pendingForeground.promise,
     });
 
     await Promise.resolve();
@@ -47,8 +51,16 @@ describe('mobileVoiceStartup', () => {
       hasController: false,
     })).toBe(false);
 
-    appActive = true;
     pendingPermission.resolve({ granted: true });
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    appActive = true;
+    pendingForeground.resolve(true);
     await expect(result).resolves.toBe('granted');
   });
 
@@ -58,16 +70,20 @@ describe('mobileVoiceStartup', () => {
       requestPermission: async () => ({ granted: false }),
       isRequestCurrent: () => true,
       isAppActive: () => true,
+      waitForAppActive: async () => true,
     })).resolves.toBe('denied');
   });
 
-  it('does not start recording while the app is genuinely backgrounded', async () => {
+  it('cancels an already-granted request that genuinely backgrounds', async () => {
+    const waitForAppActive = vi.fn(async () => true);
     await expect(resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: true }),
       requestPermission: async () => ({ granted: true }),
       isRequestCurrent: () => true,
       isAppActive: () => false,
+      waitForAppActive,
     })).resolves.toBe('cancelled');
+    expect(waitForAppActive).not.toHaveBeenCalled();
     expect(shouldCancelMobileVoiceForBackground({
       permissionRequestInFlight: false,
       startupInFlight: true,
@@ -77,18 +93,38 @@ describe('mobileVoiceStartup', () => {
   });
 
   it('cancels a granted request when the screen is superseded while the prompt is open', async () => {
-    const pendingPermission = deferredPermission();
+    const pendingPermission = deferred<{ granted: boolean }>();
     let requestCurrent = true;
     const result = resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: false }),
       requestPermission: () => pendingPermission.promise,
       isRequestCurrent: () => requestCurrent,
       isAppActive: () => true,
+      waitForAppActive: async () => true,
     });
 
     await Promise.resolve();
     requestCurrent = false;
     pendingPermission.resolve({ granted: true });
     await expect(result).resolves.toBe('cancelled');
+  });
+
+  it('removes the foreground listener when a waiting screen is superseded', async () => {
+    let appStateListener: ((state: string) => void) | null = null;
+    const unsubscribe = vi.fn();
+    const abortController = new AbortController();
+    const result = waitForMobileVoiceAppActive({
+      isAppActive: () => false,
+      subscribe: (listener) => {
+        appStateListener = listener;
+        return unsubscribe;
+      },
+      signal: abortController.signal,
+    });
+
+    expect(appStateListener).not.toBeNull();
+    abortController.abort();
+    await expect(result).resolves.toBe(false);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
@@ -16,6 +16,16 @@ function deferred<T>(): {
   return { promise, resolve };
 }
 
+function stableAppStateLifecycle(): {
+  signal: AbortSignal;
+  subscribeToAppState: () => () => void;
+} {
+  return {
+    signal: new AbortController().signal,
+    subscribeToAppState: () => () => undefined,
+  };
+}
+
 describe('mobileVoiceStartup', () => {
   it('uses an existing microphone grant without opening the system prompt', async () => {
     const requestPermission = vi.fn(async () => ({ granted: true }));
@@ -23,6 +33,7 @@ describe('mobileVoiceStartup', () => {
     await expect(resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: true }),
       requestPermission,
+      ...stableAppStateLifecycle(),
       isRequestCurrent: () => true,
       isAppActive: () => true,
       waitForAppActive: async () => true,
@@ -33,20 +44,52 @@ describe('mobileVoiceStartup', () => {
   it('does not open the system prompt after backgrounding during permission preflight', async () => {
     const pendingPermission = deferred<{ granted: boolean }>();
     const requestPermission = vi.fn(async () => ({ granted: true }));
+    const abortController = new AbortController();
+    const unsubscribe = vi.fn();
+    let publishAppState = (_state: string): void => undefined;
     let appActive = true;
     const result = resolveMobileVoiceRecordingPermission({
       getPermission: () => pendingPermission.promise,
       requestPermission,
       isRequestCurrent: () => true,
       isAppActive: () => appActive,
+      subscribeToAppState: (listener) => {
+        publishAppState = listener;
+        return unsubscribe;
+      },
+      signal: abortController.signal,
       waitForAppActive: async () => true,
     });
 
     appActive = false;
+    publishAppState('background');
+    appActive = true;
     pendingPermission.resolve({ granted: false });
 
     await expect(result).resolves.toBe('cancelled');
     expect(requestPermission).not.toHaveBeenCalled();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the preflight listener when the permission request is aborted', async () => {
+    const pendingPermission = deferred<{ granted: boolean }>();
+    const abortController = new AbortController();
+    const unsubscribe = vi.fn();
+    const result = resolveMobileVoiceRecordingPermission({
+      getPermission: () => pendingPermission.promise,
+      requestPermission: async () => ({ granted: true }),
+      isRequestCurrent: () => true,
+      isAppActive: () => true,
+      subscribeToAppState: () => unsubscribe,
+      signal: abortController.signal,
+      waitForAppActive: async () => true,
+    });
+
+    abortController.abort();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    pendingPermission.resolve({ granted: false });
+    await expect(result).resolves.toBe('cancelled');
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it('waits for Android to publish active after the first permission prompt resolves', async () => {
@@ -56,6 +99,7 @@ describe('mobileVoiceStartup', () => {
     const result = resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: false }),
       requestPermission: () => pendingPermission.promise,
+      ...stableAppStateLifecycle(),
       isRequestCurrent: () => true,
       isAppActive: () => appActive,
       waitForAppActive: () => pendingForeground.promise,
@@ -87,6 +131,7 @@ describe('mobileVoiceStartup', () => {
     await expect(resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: false }),
       requestPermission: async () => ({ granted: false }),
+      ...stableAppStateLifecycle(),
       isRequestCurrent: () => true,
       isAppActive: () => true,
       waitForAppActive: async () => true,
@@ -98,6 +143,7 @@ describe('mobileVoiceStartup', () => {
     await expect(resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: true }),
       requestPermission: async () => ({ granted: true }),
+      ...stableAppStateLifecycle(),
       isRequestCurrent: () => true,
       isAppActive: () => false,
       waitForAppActive,
@@ -117,6 +163,7 @@ describe('mobileVoiceStartup', () => {
     const result = resolveMobileVoiceRecordingPermission({
       getPermission: async () => ({ granted: false }),
       requestPermission: () => pendingPermission.promise,
+      ...stableAppStateLifecycle(),
       isRequestCurrent: () => requestCurrent,
       isAppActive: () => true,
       waitForAppActive: async () => true,

--- a/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  resolveMobileVoiceRecordingPermission,
+  shouldCancelMobileVoiceForBackground,
+} from '@/session/mobileVoiceStartup';
+
+function deferredPermission(): {
+  promise: Promise<{ granted: boolean }>;
+  resolve: (permission: { granted: boolean }) => void;
+} {
+  let resolve!: (permission: { granted: boolean }) => void;
+  const promise = new Promise<{ granted: boolean }>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+describe('mobileVoiceStartup', () => {
+  it('uses an existing microphone grant without opening the system prompt', async () => {
+    const requestPermission = vi.fn(async () => ({ granted: true }));
+
+    await expect(resolveMobileVoiceRecordingPermission({
+      getPermission: async () => ({ granted: true }),
+      requestPermission,
+      isRequestCurrent: () => true,
+      isAppActive: () => true,
+    })).resolves.toBe('granted');
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('survives Android background/active transitions caused by the first permission prompt', async () => {
+    const pendingPermission = deferredPermission();
+    let appActive = true;
+    const result = resolveMobileVoiceRecordingPermission({
+      getPermission: async () => ({ granted: false }),
+      requestPermission: () => pendingPermission.promise,
+      isRequestCurrent: () => true,
+      isAppActive: () => appActive,
+    });
+
+    await Promise.resolve();
+    appActive = false;
+    expect(shouldCancelMobileVoiceForBackground({
+      permissionRequestInFlight: true,
+      startupInFlight: false,
+      recordingActive: false,
+      hasController: false,
+    })).toBe(false);
+
+    appActive = true;
+    pendingPermission.resolve({ granted: true });
+    await expect(result).resolves.toBe('granted');
+  });
+
+  it('reports a denied microphone request', async () => {
+    await expect(resolveMobileVoiceRecordingPermission({
+      getPermission: async () => ({ granted: false }),
+      requestPermission: async () => ({ granted: false }),
+      isRequestCurrent: () => true,
+      isAppActive: () => true,
+    })).resolves.toBe('denied');
+  });
+
+  it('does not start recording while the app is genuinely backgrounded', async () => {
+    await expect(resolveMobileVoiceRecordingPermission({
+      getPermission: async () => ({ granted: true }),
+      requestPermission: async () => ({ granted: true }),
+      isRequestCurrent: () => true,
+      isAppActive: () => false,
+    })).resolves.toBe('cancelled');
+    expect(shouldCancelMobileVoiceForBackground({
+      permissionRequestInFlight: false,
+      startupInFlight: true,
+      recordingActive: false,
+      hasController: false,
+    })).toBe(true);
+  });
+
+  it('cancels a granted request when the screen is superseded while the prompt is open', async () => {
+    const pendingPermission = deferredPermission();
+    let requestCurrent = true;
+    const result = resolveMobileVoiceRecordingPermission({
+      getPermission: async () => ({ granted: false }),
+      requestPermission: () => pendingPermission.promise,
+      isRequestCurrent: () => requestCurrent,
+      isAppActive: () => true,
+    });
+
+    await Promise.resolve();
+    requestCurrent = false;
+    pendingPermission.resolve({ granted: true });
+    await expect(result).resolves.toBe('cancelled');
+  });
+});

--- a/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
@@ -30,6 +30,25 @@ describe('mobileVoiceStartup', () => {
     expect(requestPermission).not.toHaveBeenCalled();
   });
 
+  it('does not open the system prompt after backgrounding during permission preflight', async () => {
+    const pendingPermission = deferred<{ granted: boolean }>();
+    const requestPermission = vi.fn(async () => ({ granted: true }));
+    let appActive = true;
+    const result = resolveMobileVoiceRecordingPermission({
+      getPermission: () => pendingPermission.promise,
+      requestPermission,
+      isRequestCurrent: () => true,
+      isAppActive: () => appActive,
+      waitForAppActive: async () => true,
+    });
+
+    appActive = false;
+    pendingPermission.resolve({ granted: false });
+
+    await expect(result).resolves.toBe('cancelled');
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
   it('waits for Android to publish active after the first permission prompt resolves', async () => {
     const pendingPermission = deferred<{ granted: boolean }>();
     const pendingForeground = deferred<boolean>();

--- a/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
@@ -108,7 +108,6 @@ describe('mobileVoiceStartup', () => {
     await Promise.resolve();
     appActive = false;
     expect(shouldCancelMobileVoiceForBackground({
-      permissionRequestInFlight: true,
       startupInFlight: false,
       recordingActive: false,
       hasController: false,
@@ -150,7 +149,6 @@ describe('mobileVoiceStartup', () => {
     })).resolves.toBe('cancelled');
     expect(waitForAppActive).not.toHaveBeenCalled();
     expect(shouldCancelMobileVoiceForBackground({
-      permissionRequestInFlight: false,
       startupInFlight: true,
       recordingActive: false,
       hasController: false,

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -864,6 +864,8 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('const voiceStopInFlightRef = useRef(false);');
     expect(newSource).toContain('const voiceStartupSeqRef = useRef(0);');
     expect(newSource).toContain('|| voiceStopInFlightRef.current');
+    expect(newSource).toContain('resolveMobileVoiceRecordingPermission({');
+    expect(newSource).toContain('voiceStartupInFlightRef.current = true;');
     expect(newSource.indexOf('resolveMobileVoiceRecordingPermission({')).toBeLessThan(
       newSource.indexOf('voiceStartupInFlightRef.current = true;'),
     );

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -871,6 +871,12 @@ describe('new session composer surface', () => {
     );
     expect(newSource).toContain('getPermission: getRecordingPermissionsAsync');
     expect(newSource).toContain("isAppActive: () => AppState.currentState === 'active'");
+    expect(newSource).toContain(
+      "voicePermissionRequestSeqRef.current !== permissionRequestSeq\n"
+      + "        || AppState.currentState !== 'active'\n"
+      + "      ) return;\n"
+      + "      startupSeq = voiceStartupSeqRef.current + 1;",
+    );
     expect(newSource).toContain('const cancelVoiceForDeviceSwitch = useCallback(() => {');
     expect(selectDeviceSource).toContain('voicePermissionRequestInFlightRef.current');
     expect(selectDeviceSource).toContain('|| voiceStopInFlightRef.current');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -860,15 +860,19 @@ describe('new session composer surface', () => {
     expect(voiceButtonSource).toContain('disabled={creating || voiceIsProcessing}');
     expect(newSource).toContain('const startVoiceRecording = useCallback(async () => {');
     expect(newSource).toContain('const voiceStartupInFlightRef = useRef(false);');
+    expect(newSource).toContain('const voicePermissionRequestInFlightRef = useRef(false);');
     expect(newSource).toContain('const voiceStopInFlightRef = useRef(false);');
     expect(newSource).toContain('const voiceStartupSeqRef = useRef(0);');
     expect(newSource).toContain('|| voiceStopInFlightRef.current');
-    expect(newSource.indexOf('voiceStartupInFlightRef.current = true;')).toBeLessThan(
-      newSource.indexOf('const permission = await requestRecordingPermissionsAsync();'),
+    expect(newSource.indexOf('resolveMobileVoiceRecordingPermission({')).toBeLessThan(
+      newSource.indexOf('voiceStartupInFlightRef.current = true;'),
     );
-    expect(newSource).toContain('if (voiceStartupSeqRef.current !== startupSeq) return;');
+    expect(newSource).toContain('getPermission: getRecordingPermissionsAsync');
+    expect(newSource).toContain("isAppActive: () => AppState.currentState === 'active'");
     expect(newSource).toContain('const cancelVoiceForDeviceSwitch = useCallback(() => {');
-    expect(selectDeviceSource).toContain('if (voiceStopInFlightRef.current || voiceIsProcessing) return;');
+    expect(selectDeviceSource).toContain('voicePermissionRequestInFlightRef.current');
+    expect(selectDeviceSource).toContain('|| voiceStopInFlightRef.current');
+    expect(selectDeviceSource).toContain('|| voiceIsProcessing');
     expect(selectDeviceSource).toContain('cancelVoiceForDeviceSwitch();');
     expect(newSource).toContain('voiceStartupInFlightRef.current = false;');
     expect(newSource).toContain('createMobileVoiceControllerSession({');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -551,16 +551,19 @@ describe('mobile session composer desktop-first surface', () => {
 
     expect(voiceSource).toContain('readCurrentDraft: () => draftRef.current');
     expect(source).toContain('const voiceStartupInFlightRef = useRef(false);');
+    expect(source).toContain('const voicePermissionRequestInFlightRef = useRef(false);');
     expect(source).toContain('const voiceStopInFlightRef = useRef(false);');
     expect(voiceSource).toContain('|| voiceStopInFlightRef.current');
-    expect(voiceSource.indexOf('voiceStartupInFlightRef.current = true;')).toBeLessThan(
-      voiceSource.indexOf('const permission = await requestRecordingPermissionsAsync();'),
+    expect(voiceSource.indexOf('resolveMobileVoiceRecordingPermission({')).toBeLessThan(
+      voiceSource.indexOf('voiceStartupInFlightRef.current = true;'),
     );
+    expect(voiceSource).toContain('getPermission: getRecordingPermissionsAsync');
+    expect(voiceSource).toContain("isAppActive: () => AppState.currentState === 'active'");
     expect(voiceSource).toContain('voiceStartupInFlightRef.current = false;');
     expect(voiceSource).toContain('onDraftChanged: setComposerDraft');
     expect(voiceSource).toContain('isMobileRealtimeAudioAvailable()');
     expect(voiceSource.indexOf('isMobileRealtimeAudioAvailable()')).toBeLessThan(
-      voiceSource.indexOf('requestRecordingPermissionsAsync()'),
+      voiceSource.indexOf('resolveMobileVoiceRecordingPermission({'),
     );
     expect(voiceSource).toContain('mobileVoiceRealtimeAudioUnavailableError()');
     expect(voiceSource).toContain('const documentBeforeStop = composerDocumentRef.current;');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -561,6 +561,12 @@ describe('mobile session composer desktop-first surface', () => {
     );
     expect(voiceSource).toContain('getPermission: getRecordingPermissionsAsync');
     expect(voiceSource).toContain("isAppActive: () => AppState.currentState === 'active'");
+    expect(voiceSource).toContain(
+      "voicePermissionRequestSeqRef.current !== permissionRequestSeq\n"
+      + "        || AppState.currentState !== 'active'\n"
+      + "      ) return;\n"
+      + "      startupSeq = voiceStartupSeqRef.current + 1;",
+    );
     expect(voiceSource).toContain('voiceStartupInFlightRef.current = false;');
     expect(voiceSource).toContain('onDraftChanged: setComposerDraft');
     expect(voiceSource).toContain('isMobileRealtimeAudioAvailable()');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -554,6 +554,8 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('const voicePermissionRequestInFlightRef = useRef(false);');
     expect(source).toContain('const voiceStopInFlightRef = useRef(false);');
     expect(voiceSource).toContain('|| voiceStopInFlightRef.current');
+    expect(voiceSource).toContain('resolveMobileVoiceRecordingPermission({');
+    expect(voiceSource).toContain('voiceStartupInFlightRef.current = true;');
     expect(voiceSource.indexOf('resolveMobileVoiceRecordingPermission({')).toBeLessThan(
       voiceSource.indexOf('voiceStartupInFlightRef.current = true;'),
     );

--- a/apps/mobile/src/session/mobileVoiceStartup.ts
+++ b/apps/mobile/src/session/mobileVoiceStartup.ts
@@ -15,7 +15,6 @@ type ResolveMobileVoiceRecordingPermissionOptions = {
 };
 
 type MobileVoiceBackgroundState = {
-  permissionRequestInFlight: boolean;
   startupInFlight: boolean;
   recordingActive: boolean;
   hasController: boolean;

--- a/apps/mobile/src/session/mobileVoiceStartup.ts
+++ b/apps/mobile/src/session/mobileVoiceStartup.ts
@@ -79,6 +79,7 @@ export async function resolveMobileVoiceRecordingPermission(
 
   let openedSystemPrompt = false;
   if (!permission.granted) {
+    if (!options.isAppActive()) return 'cancelled';
     openedSystemPrompt = true;
     permission = await options.requestPermission();
     if (!options.isRequestCurrent()) return 'cancelled';

--- a/apps/mobile/src/session/mobileVoiceStartup.ts
+++ b/apps/mobile/src/session/mobileVoiceStartup.ts
@@ -9,6 +9,7 @@ type ResolveMobileVoiceRecordingPermissionOptions = {
   requestPermission: () => Promise<MobileVoiceRecordingPermission>;
   isRequestCurrent: () => boolean;
   isAppActive: () => boolean;
+  waitForAppActive: () => Promise<boolean>;
 };
 
 type MobileVoiceBackgroundState = {
@@ -18,11 +19,57 @@ type MobileVoiceBackgroundState = {
   hasController: boolean;
 };
 
+type WaitForMobileVoiceAppActiveOptions = {
+  isAppActive: () => boolean;
+  subscribe: (listener: (state: string) => void) => () => void;
+  signal: AbortSignal;
+};
+
+/**
+ * Waits for React Native to publish the foreground transition that can trail
+ * Android's permission result. The caller aborts this wait when its screen or
+ * permission request is superseded, which also removes the AppState listener.
+ */
+export function waitForMobileVoiceAppActive(
+  options: WaitForMobileVoiceAppActiveOptions,
+): Promise<boolean> {
+  if (options.isAppActive()) return Promise.resolve(true);
+  if (options.signal.aborted) return Promise.resolve(false);
+
+  return new Promise<boolean>((resolve) => {
+    let unsubscribe: (() => void) | null = null;
+    let settled = false;
+    const finish = (active: boolean): void => {
+      if (settled) return;
+      settled = true;
+      unsubscribe?.();
+      options.signal.removeEventListener('abort', onAbort);
+      resolve(active);
+    };
+    const onAbort = (): void => finish(false);
+
+    options.signal.addEventListener('abort', onAbort, { once: true });
+    const removeSubscription = options.subscribe((state) => {
+      if (state === 'active') finish(true);
+    });
+    // A synchronous subscription callback may settle before subscribe returns.
+    if (settled) {
+      removeSubscription();
+      return;
+    }
+    unsubscribe = removeSubscription;
+    // Close the gap between the initial check and listener registration.
+    if (options.isAppActive()) finish(true);
+    else if (options.signal.aborted) finish(false);
+  });
+}
+
 /**
  * Resolves microphone permission before voice startup claims any audio
  * resources. Android may report the app as backgrounded while its system
- * permission sheet is open, so cancellation is checked after each await and
- * foreground state is required only when permission resolution completes.
+ * permission sheet is open, and the permission promise can resolve before the
+ * matching foreground event. Only that first-request path waits for active;
+ * an already-granted request that genuinely backgrounds is cancelled.
  */
 export async function resolveMobileVoiceRecordingPermission(
   options: ResolveMobileVoiceRecordingPermissionOptions,
@@ -30,13 +77,24 @@ export async function resolveMobileVoiceRecordingPermission(
   let permission = await options.getPermission();
   if (!options.isRequestCurrent()) return 'cancelled';
 
+  let openedSystemPrompt = false;
   if (!permission.granted) {
+    openedSystemPrompt = true;
     permission = await options.requestPermission();
     if (!options.isRequestCurrent()) return 'cancelled';
   }
 
   if (!permission.granted) return 'denied';
-  return options.isAppActive() ? 'granted' : 'cancelled';
+  if (!options.isAppActive()) {
+    if (!openedSystemPrompt) return 'cancelled';
+    const becameActive = await options.waitForAppActive();
+    if (
+      !becameActive
+      || !options.isRequestCurrent()
+      || !options.isAppActive()
+    ) return 'cancelled';
+  }
+  return 'granted';
 }
 
 /**

--- a/apps/mobile/src/session/mobileVoiceStartup.ts
+++ b/apps/mobile/src/session/mobileVoiceStartup.ts
@@ -9,6 +9,8 @@ type ResolveMobileVoiceRecordingPermissionOptions = {
   requestPermission: () => Promise<MobileVoiceRecordingPermission>;
   isRequestCurrent: () => boolean;
   isAppActive: () => boolean;
+  subscribeToAppState: (listener: (state: string) => void) => () => void;
+  signal: AbortSignal;
   waitForAppActive: () => Promise<boolean>;
 };
 
@@ -68,21 +70,48 @@ export function waitForMobileVoiceAppActive(
  * Resolves microphone permission before voice startup claims any audio
  * resources. Android may report the app as backgrounded while its system
  * permission sheet is open, and the permission promise can resolve before the
- * matching foreground event. Only that first-request path waits for active;
- * an already-granted request that genuinely backgrounds is cancelled.
+ * matching foreground event. Only backgrounding after the system prompt opens
+ * may wait for active; a tap that backgrounds during permission preflight is
+ * stale even if the app returns before the permission query resolves.
  */
 export async function resolveMobileVoiceRecordingPermission(
   options: ResolveMobileVoiceRecordingPermissionOptions,
 ): Promise<MobileVoicePermissionResult> {
-  let permission = await options.getPermission();
-  if (!options.isRequestCurrent()) return 'cancelled';
+  if (
+    options.signal.aborted
+    || !options.isRequestCurrent()
+    || !options.isAppActive()
+  ) return 'cancelled';
+
+  let backgroundedDuringPreflight = false;
+  let removePreflightSubscription: (() => void) | null = options.subscribeToAppState((state) => {
+    if (state === 'background') backgroundedDuringPreflight = true;
+  });
+  const stopObservingPreflight = (): void => {
+    removePreflightSubscription?.();
+    removePreflightSubscription = null;
+  };
+  const onAbort = (): void => stopObservingPreflight();
+  options.signal.addEventListener('abort', onAbort, { once: true });
+  let permission: MobileVoiceRecordingPermission;
+  try {
+    permission = await options.getPermission();
+  } finally {
+    stopObservingPreflight();
+    options.signal.removeEventListener('abort', onAbort);
+  }
+  if (
+    options.signal.aborted
+    || !options.isRequestCurrent()
+    || backgroundedDuringPreflight
+    || !options.isAppActive()
+  ) return 'cancelled';
 
   let openedSystemPrompt = false;
   if (!permission.granted) {
-    if (!options.isAppActive()) return 'cancelled';
     openedSystemPrompt = true;
     permission = await options.requestPermission();
-    if (!options.isRequestCurrent()) return 'cancelled';
+    if (options.signal.aborted || !options.isRequestCurrent()) return 'cancelled';
   }
 
   if (!permission.granted) return 'denied';

--- a/apps/mobile/src/session/mobileVoiceStartup.ts
+++ b/apps/mobile/src/session/mobileVoiceStartup.ts
@@ -1,0 +1,51 @@
+export type MobileVoiceRecordingPermission = {
+  granted: boolean;
+};
+
+export type MobileVoicePermissionResult = 'granted' | 'denied' | 'cancelled';
+
+type ResolveMobileVoiceRecordingPermissionOptions = {
+  getPermission: () => Promise<MobileVoiceRecordingPermission>;
+  requestPermission: () => Promise<MobileVoiceRecordingPermission>;
+  isRequestCurrent: () => boolean;
+  isAppActive: () => boolean;
+};
+
+type MobileVoiceBackgroundState = {
+  permissionRequestInFlight: boolean;
+  startupInFlight: boolean;
+  recordingActive: boolean;
+  hasController: boolean;
+};
+
+/**
+ * Resolves microphone permission before voice startup claims any audio
+ * resources. Android may report the app as backgrounded while its system
+ * permission sheet is open, so cancellation is checked after each await and
+ * foreground state is required only when permission resolution completes.
+ */
+export async function resolveMobileVoiceRecordingPermission(
+  options: ResolveMobileVoiceRecordingPermissionOptions,
+): Promise<MobileVoicePermissionResult> {
+  let permission = await options.getPermission();
+  if (!options.isRequestCurrent()) return 'cancelled';
+
+  if (!permission.granted) {
+    permission = await options.requestPermission();
+    if (!options.isRequestCurrent()) return 'cancelled';
+  }
+
+  if (!permission.granted) return 'denied';
+  return options.isAppActive() ? 'granted' : 'cancelled';
+}
+
+/**
+ * Permission prompts do not own a controller or an active audio session.
+ * Backgrounding cancels only startup work that has moved past permission, or
+ * a recording that is already active.
+ */
+export function shouldCancelMobileVoiceForBackground(
+  state: MobileVoiceBackgroundState,
+): boolean {
+  return state.startupInFlight || state.recordingActive || state.hasController;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Android 首次使用语音输入时，系统麦克风授权弹窗触发 AppState background、导致录音启动被错误取消的问题。权限请求现在与真正的录音启动分阶段管理：授权弹窗期间不占用录音启动状态，授权完成且页面仍有效、App 已回到前台后才开始录音。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #284；覆盖 issue comment 5068769481 报告的首次授权失败
- 本 PR 包含：新建会话与已有会话的权限/录音启动分阶段生命周期、AppState 后台取消规则、回归测试
- 明确不包含：原生录音模块、权限声明、iOS 语音流程或服务端改动
- 用户可见变化：Android 首次允许麦克风权限后，同一次点击会继续启动录音，不再静默失败
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/mobileVoiceStartup.test.ts src/__tests__/newSession.test.ts src/__tests__/sessionComposerDesktopFirst.test.ts src/__tests__/mobileRealtimeAudio.test.ts
结果：4 个测试文件、60 个测试全部通过

pnpm --filter mobile typecheck
结果：通过

pnpm --filter mobile test:scope
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-android-voice-permission-race
结果：仓库根 test:unit 完整门禁通过

git diff --check
结果：通过
```

### 手工验证

未执行；本次自动化会话未占用 Android 真机/模拟器。建议重点验证全新安装后，在新建会话和已有会话中首次点击语音、允许麦克风权限，录音是否直接开始。

### 未执行的验证

Android 真机首次授权流程待 reviewer/测试同事验证；改动仅为 JS/TS 生命周期，不改变 Expo 原生配置或 runtime fingerprint。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 新建会话与已有会话的语音启动生命周期。Android 权限弹窗期间不再被误判为活跃录音；真正开始启动/录音后，后台切换仍会立即取消。iOS 已有语音行为保持不变。
- 回滚 / 降级方式：回滚本 PR 即恢复旧权限启动顺序；不涉及数据迁移、协议或原生配置。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及文档变更）
- [x] 已确认测试结果或说明未执行原因