### PR TITLE
fix(desktop): prevent browser topbar overlap when sidebar is collapsed

### DIFF
--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -1208,6 +1208,7 @@ export function MainLayout() {
                   onCloseSidebar={isMac ? undefined : handleToggleRightSidebar}
                   onMaximize={handleMaximizeRightSidebar}
                   isMaximized={isRightSidebarMaximized}
+                  reserveLeftChromeActions={isRightSidebarMaximized && isSidebarCollapsed}
                   sessionId={rightSidebarSessionId}
                   workdir={rightSidebarWorkdirInfo.workdir}
                   remoteHostId={rightSidebarWorkdirInfo.remoteHostId}

--- a/apps/desktop/src/renderer/components/layout/RightSidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/RightSidebar.tsx
@@ -66,6 +66,8 @@ interface RightSidebarProps {
   /** Maximize 态(Phase 6):RSB 撑满整个非左栏区,主区 hidden。本组件用来隐藏
    *  resize handle(maximize 不允许拖宽)+ 把 TabBar maximize 按钮图标切到"还原"。 */
   isMaximized?: boolean;
+  /** 左侧栏完全收起且 RSB maximize 时，为顶栏左上角浮动 ChromeActions 让位。 */
+  reserveLeftChromeActions?: boolean;
   /** 「在新窗口中打开侧边栏」:开偏好 + 弹出子窗口。Win 端 TabBar 内渲染按钮
    *  (Mac 走 MainLayout 浮层,不经此 prop)。 */
   onDetach?: () => void;
@@ -84,6 +86,7 @@ export const RightSidebar = forwardRef<RightSidebarHandle, RightSidebarProps>(fu
     onCloseSidebar,
     onMaximize,
     isMaximized,
+    reserveLeftChromeActions = false,
     sessionId,
     workdir,
     remoteHostId,
@@ -254,6 +257,7 @@ export const RightSidebar = forwardRef<RightSidebarHandle, RightSidebarProps>(fu
           onCloseSidebar={onCloseSidebar}
           onMaximize={onMaximize}
           isMaximized={isMaximized}
+          reserveLeftChromeActions={reserveLeftChromeActions}
           onDetach={onDetach}
           // B3:主窗口内嵌形态 Tab 条空白处 = 拖面板手势面(窗口拖动走左栏顶行)。
           chromeWindowDrag={false}

--- a/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
@@ -24,8 +24,10 @@ import { useTranslation } from 'react-i18next';
 
 import { createLogger } from '@/lib/logger';
 import { useAppShortcut } from '@/hooks/useAppShortcut';
+import { useMacFullscreen } from '@/hooks/useMacFullscreen';
 import { RightSidebarDetach } from '@/components/layout/RightSidebarDetach';
 import { RightSidebarMaximize } from '@/components/layout/RightSidebarMaximize';
+import { CHROME_ACTIONS_GEOMETRY } from '@/components/layout/chromeActionsGeometry';
 import { TabBar, TabStrip } from './TabBar';
 import { EmptyState } from './EmptyState';
 import {
@@ -92,6 +94,12 @@ interface RightSidebarShellProps {
   onMaximize?: () => void;
   /** maximize 态 — 用来让 TabBar 把 maximize 按钮换图标(Maximize2 ↔ Minimize2)。 */
   isMaximized?: boolean;
+  /**
+   * 主窗口左栏完全收起且当前面板 maximize 时，右栏 unified topbar 需要为
+   * MainLayout 的浮动 ChromeActions 预留左侧 no-drag 占位；普通右栏/rail/独立
+   * 子窗口不应消费这段空间。
+   */
+  reserveLeftChromeActions?: boolean;
   /** 「在新窗口中打开侧边栏」;仅 Win 端 TabBar 内渲染按钮(Mac 走 MainLayout 浮层)。 */
   onDetach?: () => void;
   /** TabBar 横带是否作为窗口拖拽区(见 TabBar 同名 prop):主窗口内嵌形态传
@@ -124,7 +132,19 @@ export function RightSidebarShell({
   chromeWindowDrag = true,
   panelSide = 'right',
   onAllTabsClosed,
+  reserveLeftChromeActions = false,
 }: RightSidebarShellProps) {
+  const { isFullscreen } = useMacFullscreen();
+  const chromeActionsLeft =
+    isMac && !isFullscreen
+      ? CHROME_ACTIONS_GEOMETRY.macTrafficLightLeft
+      : CHROME_ACTIONS_GEOMETRY.defaultLeft;
+  // unifiedTopbar 本身有 px-2(8px) 左内边距。加上 chromeActionsLeft 后，
+  // spacer 的布局起点正好落在 ChromeActions 簇之前，并在簇后保留 8px 呼吸间距。
+  const leftChromeActionsSpacerWidth =
+    unifiedTopbar && reserveLeftChromeActions
+      ? chromeActionsLeft + CHROME_ACTIONS_GEOMETRY.clusterWidth
+      : 0;
   const { t } = useTranslation();
 
   // RSB browser bridge (Phase 2):在 Shell 整个生命周期内只 init 一次。bridge 内部
@@ -363,6 +383,19 @@ export function RightSidebarShell({
           className="relative flex h-[46px] shrink-0 flex-none items-center border-b border-[var(--border-default)] bg-[var(--panel-bg)] px-2"
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         >
+          {leftChromeActionsSpacerWidth > 0 && (
+            <div
+              aria-hidden
+              data-testid="right-sidebar-left-chrome-actions-spacer"
+              className="h-full shrink-0"
+              style={
+                {
+                  width: leftChromeActionsSpacerWidth,
+                  WebkitAppRegion: 'no-drag',
+                } as React.CSSProperties
+              }
+            />
+          )}
           {/* pillVariant="chip":pills 垂直居中的浮动 chip(完整圆角 + 四边框),
               与「+」、右侧浮层按钮共享宿主栏水平中线(对齐 Codex)——贴底 flush
               样式在 46px 高栏里会与居中控件错位。

--- a/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
@@ -21,6 +21,7 @@ vi.mock('../plugins', () => ({}));
 import { RightSidebarShell } from '../RightSidebarShell';
 import { _resetRsbBrowserBridgeForTests } from '../lib/rsbBrowserBridge';
 import { _resetStore, closeTab } from '../store';
+import { CHROME_ACTIONS_GEOMETRY } from '@/components/layout/chromeActionsGeometry';
 
 interface RightSidebarTabsIpcStub {
   list: ReturnType<typeof vi.fn>;
@@ -50,7 +51,7 @@ function makeRightSidebarTabsIpc(): RightSidebarTabsIpcStub {
   };
 }
 
-function installElectronApi(tabsIpc: RightSidebarTabsIpcStub): void {
+function installElectronApi(tabsIpc: RightSidebarTabsIpcStub, fullscreen = false): void {
   (
     window as unknown as {
       electronAPI: {
@@ -69,6 +70,8 @@ function installElectronApi(tabsIpc: RightSidebarTabsIpcStub): void {
         onRsbBrowserCommand: (
           callback: (payload: { command: RsbBrowserCommand }) => void,
         ) => () => void;
+        getFullscreenState: () => Promise<boolean>;
+        onFullscreenChange: (callback: (fullscreen: boolean) => void) => () => void;
         appShortcuts: {
           getState: () => { platform: string; overrides: AppShortcutOverrides };
           onChanged: ReturnType<typeof vi.fn>;
@@ -120,6 +123,8 @@ function installElectronApi(tabsIpc: RightSidebarTabsIpcStub): void {
         rsbBrowserCommandListeners = rsbBrowserCommandListeners.filter((cb) => cb !== callback);
       };
     },
+    getFullscreenState: vi.fn(async () => fullscreen),
+    onFullscreenChange: vi.fn(() => () => undefined),
     appShortcuts: {
       getState: () => ({ platform: 'darwin', overrides: {} }),
       onChanged: vi.fn(() => () => undefined),
@@ -327,6 +332,61 @@ describe('RightSidebarShell empty state', () => {
     // 合并顶栏走 chip 变体:strip 垂直居中,与「+」/ 浮层按钮同一水平中线。
     expect(strip.className).toContain('items-center');
     expect(screen.getByRole('button', { name: 'rightSidebar.tabs.addAria' })).toBeTruthy();
+  });
+
+  it('reserves the fullscreen ChromeActions area in the maximized unified topbar', async () => {
+    installElectronApi(tabsIpc, true);
+    const { rerender } = render(
+      createElement(RightSidebarShell, {
+        sessionId: 's1',
+        workdir: '/tmp/repo',
+        remoteHostId: null,
+        isMac: true,
+        unifiedTopbar: true,
+        reserveLeftChromeActions: true,
+      }),
+    );
+
+    await waitFor(() => {
+      const spacer = screen.getByTestId('right-sidebar-left-chrome-actions-spacer');
+      expect(spacer.style.width).toBe(
+        `${CHROME_ACTIONS_GEOMETRY.defaultLeft + CHROME_ACTIONS_GEOMETRY.clusterWidth}px`,
+      );
+    });
+    const spacer = screen.getByTestId('right-sidebar-left-chrome-actions-spacer');
+    expect(
+      (spacer.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
+    ).toBe('no-drag');
+
+    rerender(
+      createElement(RightSidebarShell, {
+        sessionId: 's1',
+        workdir: '/tmp/repo',
+        remoteHostId: null,
+        isMac: true,
+        unifiedTopbar: true,
+        reserveLeftChromeActions: false,
+      }),
+    );
+    expect(screen.queryByTestId('right-sidebar-left-chrome-actions-spacer')).toBeNull();
+  });
+
+  it('keeps the traffic-light offset when reserving ChromeActions outside fullscreen', async () => {
+    render(
+      createElement(RightSidebarShell, {
+        sessionId: 's1',
+        workdir: '/tmp/repo',
+        remoteHostId: null,
+        isMac: true,
+        unifiedTopbar: true,
+        reserveLeftChromeActions: true,
+      }),
+    );
+
+    const spacer = await screen.findByTestId('right-sidebar-left-chrome-actions-spacer');
+    expect(spacer.style.width).toBe(
+      `${CHROME_ACTIONS_GEOMETRY.macTrafficLightLeft + CHROME_ACTIONS_GEOMETRY.clusterWidth}px`,
+    );
   });
 
   it('renders detach/maximize in the topbar when panel is docked left (mac M2), spacer when right or maximized', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 主窗口全屏、左侧栏完全收起且右侧浏览器最大化时，左上角 `ChromeActions` 与首个浏览器 Tab 图标/标题重叠的问题。

根因是 `ChromeActions` 作为 `MainLayout` 顶层绝对定位浮层固定在窗口左上角，而最大化后的右侧 `unifiedTopbar` 同样从窗口左边缘开始渲染 `TabStrip`，两者没有共享左侧占位。

本 PR：

- 由 `MainLayout` 在“右栏最大化 + 左栏完全收起”时显式下发 `reserveLeftChromeActions`。
- 在 macOS `RightSidebarShell` 的统一顶栏内按需增加左侧 `no-drag` spacer。
- 复用 `CHROME_ACTIONS_GEOMETRY` 和 `useMacFullscreen`，分别覆盖全屏 68px 与非全屏交通灯让位后的 138px 占位，不引入新的魔法数。
- 增加全屏、非全屏及关闭让位三条组件回归断言。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #318
- 本 PR 包含：Desktop Renderer 的 `MainLayout` → `RightSidebar` → `RightSidebarShell` 状态透传、macOS 统一顶栏左侧占位及回归测试。
- 明确不包含：BrowserWindow、WebView、IPC、导航、安全策略及浏览器功能逻辑调整。
- 用户可见变化：目标组合状态下，首个浏览器 Tab 从左上角按钮簇右侧开始布局，不再重叠或溢出。
- 是否存在 breaking change：无。

### UI 变化

macOS Desktop 顶栏布局修复。未新增颜色或主题 token；Light / Dark 共用同一几何逻辑。

本地未录制运行态截图或视频，自动测试覆盖了全屏/非全屏占位宽度与 `no-drag` 命中区域。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
结果：1 个测试文件、13 个用例全部通过（rebase 最新 main 后复跑）。

pnpm --filter desktop typecheck
结果：通过（rebase 最新 main 后复跑）。

pnpm test:unit
结果：全部 unit-tier workspace 通过；Desktop 1111 个测试文件、11745 个用例通过，2 个跳过；Mobile 245 个测试文件、2288 个用例通过，其余共享包及协议包均 PASS。

pnpm --filter desktop exec eslint <4 个本次修改文件>
结果：通过。

git diff upstream/main...HEAD --check
结果：通过。
```

### 手工验证

完成代码路径与布局状态复核：

1. `ChromeActions` 在 macOS 全屏时位于 x=8，非全屏时位于 x=78。
2. 仅 `isRightSidebarMaximized && isSidebarCollapsed` 时启用左侧让位。
3. 普通右栏、左栏展开、rail、detached sidebar 与 Windows 路径不渲染新增 spacer。

### 未执行的验证

- 未启动打包后的 Desktop 应用进行 macOS 全屏视觉回归或录屏。
- 未在 Windows 真机上手工回归；Windows 不进入 `unifiedTopbar` 新分支，自动测试与条件守卫保持既有路径。
- 未分别手工查看 Light / Dark；本次没有新增颜色，只增加透明几何占位。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 中 macOS 主窗口统一顶栏，并且只在右栏最大化、左栏完全收起时生效。
- 风险控制：占位复用 `ChromeActions` 的共享几何常量，并保持为 drag region 的 `no-drag` 后代；Windows、普通右栏及独立侧栏窗口不消费该状态。
- 回滚 / 降级方式：revert 本 PR 提交即可恢复原布局，不涉及数据或协议迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本修复无需额外用户文档）
- [x] 已确认测试结果或说明未执行原因
