### PR TITLE
fix(codex): 修复任务卡片成功结束后仍停在首个步骤

### DIFF
--- a/apps/desktop/src/renderer/__tests__/planReviewDoneRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planReviewDoneRace.test.ts
@@ -151,13 +151,18 @@ function emitDone(
   source: 'codex' | 'claude-code',
   plan?: Array<{ step: string; status: string }>,
   turnId = 'turn-1',
+  turnStatus?: string,
 ): void {
   onEvent?.({
     sessionId: SESSION_ID,
     event: {
       type: 'done',
       source,
-      data: { type: 'task_complete', raw: { id: turnId }, ...(plan ? { plan } : {}) },
+      data: {
+        type: 'task_complete',
+        raw: { id: turnId, ...(turnStatus ? { status: turnStatus } : {}) },
+        ...(plan ? { plan } : {}),
+      },
     },
   });
 }
@@ -261,6 +266,15 @@ describe('plan_review 与 done 的时序', () => {
     emitDone('codex');
 
     expect(latestPlanStatuses()).toEqual(['in_progress', 'pending']);
+  });
+
+  it('codex:成功完成但缺少最终 plan 快照时收口计划卡片', () => {
+    makerChatStore.setSessionRuntime(SESSION_ID, { agentKind: 'codex' });
+    emitPlanUpdate('codex', ['in_progress', 'pending']);
+
+    emitDone('codex', undefined, 'turn-1', 'completed');
+
+    expect(latestPlanStatuses()).toEqual(['completed', 'completed']);
   });
 
   it('claude:done 不改 Codex update_plan 展示状态', () => {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2255,10 +2255,18 @@ export function handleStreamEvent(
         return next;
       });
 
-      const terminalData = event.data as { plan?: unknown; raw?: { id?: unknown } } | null | undefined;
+      const terminalData =
+        event.data as { plan?: unknown; raw?: { id?: unknown; status?: unknown } } | null | undefined;
       const terminalTurnId = typeof terminalData?.raw?.id === 'string' ? terminalData.raw.id : null;
+      const terminalTurnStatus =
+        typeof terminalData?.raw?.status === 'string' ? terminalData.raw.status : null;
       const doneMessages = event.source === 'codex'
-        ? applyCodexPlanSnapshotOnDone(cleanedMessages, terminalData?.plan, terminalTurnId).messages
+        ? applyCodexPlanSnapshotOnDone(
+            cleanedMessages,
+            terminalData?.plan,
+            terminalTurnId,
+            terminalTurnStatus,
+          ).messages
         : cleanedMessages;
 
       // F1-a Option C: tool-result-image 孤儿 flush(turn 末残留 pendingFullText)已收口

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -843,6 +843,111 @@ describe('remoteSessionStore', () => {
     });
   });
 
+  it('keeps synthetic completion when done precedes the initial plan DB row', () => {
+    remoteSessionStore.applyRemotePush('dev-1', 'maker:event', {
+      sessionId: 's1',
+      persistId: 'plan-row-1',
+      event: {
+        type: 'tool_use',
+        data: {
+          toolUseId: 'plan:turn-1',
+          toolName: 'update_plan',
+          input: {
+            plan: [
+              { step: 'Inspect', status: 'in_progress' },
+              { step: 'Patch', status: 'pending' },
+            ],
+          },
+        },
+      },
+    });
+    remoteSessionStore.applyRemotePush('dev-1', 'maker:event', {
+      sessionId: 's1',
+      event: {
+        type: 'done',
+        source: 'codex',
+        data: {
+          raw: { id: 'turn-1', status: 'completed' },
+          plan: [
+            { step: 'Inspect', status: 'in_progress' },
+            { step: 'Patch', status: 'pending' },
+          ],
+        },
+      },
+    });
+
+    remoteSessionStore.applyRemotePush('dev-1', 'local-db:messages:created', {
+      sessionId: 's1',
+      message: {
+        ...message('plan-row-1', 's1'),
+        role: 'tool_use',
+        toolUseId: 'plan:turn-1',
+        content: {
+          toolUseId: 'plan:turn-1',
+          toolName: 'update_plan',
+          input: {
+            plan: [
+              { step: 'Inspect', status: 'in_progress' },
+              { step: 'Patch', status: 'pending' },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(remoteSessionStore.getMessages('s1')[0].content).toMatchObject({
+      input: {
+        plan: [
+          { step: 'Inspect', status: 'completed' },
+          { step: 'Patch', status: 'completed' },
+        ],
+      },
+    });
+  });
+
+  it('does not let a delayed message window revert synthetic completion', () => {
+    const stalePlanRow = {
+      ...message('plan-row-1', 's1'),
+      role: 'tool_use' as const,
+      toolUseId: 'plan:turn-1',
+      content: {
+        toolUseId: 'plan:turn-1',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Inspect', status: 'in_progress' }] },
+      },
+    };
+    remoteSessionStore.setMessages('s1', [stalePlanRow]);
+    remoteSessionStore.applyRemotePush('dev-1', 'maker:event', {
+      sessionId: 's1',
+      persistId: 'plan-row-1',
+      event: {
+        type: 'tool_use',
+        data: {
+          toolUseId: 'plan:turn-1',
+          toolName: 'update_plan',
+          input: { plan: [{ step: 'Inspect', status: 'in_progress' }] },
+        },
+      },
+    });
+    remoteSessionStore.applyRemotePush('dev-1', 'maker:event', {
+      sessionId: 's1',
+      event: {
+        type: 'done',
+        source: 'codex',
+        data: {
+          raw: { id: 'turn-1', status: 'completed' },
+          plan: [{ step: 'Inspect', status: 'in_progress' }],
+        },
+      },
+    });
+
+    remoteSessionStore.setLatestMessageWindow('s1', [stalePlanRow]);
+
+    expect(remoteSessionStore.getMessages('s1')[0].content).toMatchObject({
+      input: { plan: [{ step: 'Inspect', status: 'completed' }] },
+    });
+  });
+
   it('finalizes pre-compact streaming rows and de-duplicates the same boundary replay', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -255,6 +255,19 @@ function rememberLivePlanSnapshot(sessionId: string, snapshot: LivePlanSnapshot)
   if (snapshot.persistId) sessionSnapshots.set(`persist:${snapshot.persistId}`, snapshot);
 }
 
+function rememberLivePlanContent(
+  sessionId: string,
+  toolUseId: string,
+  content: Record<string, unknown>,
+): void {
+  const previous = livePlanSnapshots.get(sessionId)?.get(`tool:${toolUseId}`);
+  rememberLivePlanSnapshot(sessionId, {
+    content,
+    toolUseId,
+    ...(previous?.persistId ? { persistId: previous.persistId } : {}),
+  });
+}
+
 function overlayLivePlanSnapshot(sessionId: string, message: RemoteMessage): RemoteMessage {
   if (message.role !== 'tool_use') return message;
   const sessionSnapshots = livePlanSnapshots.get(sessionId);
@@ -267,6 +280,29 @@ function overlayLivePlanSnapshot(sessionId: string, message: RemoteMessage): Rem
   return snapshot
     ? { ...message, content: snapshot.content, toolUseId: snapshot.toolUseId }
     : message;
+}
+
+function completeLivePlanSnapshotOnDone(
+  sessionId: string,
+  snapshot: unknown,
+  turnId: string | null,
+  terminalStatus: string | null,
+): boolean {
+  if (!turnId) return false;
+  const toolUseId = `plan:${turnId}`;
+  const liveSnapshot = livePlanSnapshots.get(sessionId)?.get(`tool:${toolUseId}`);
+  if (!liveSnapshot) return false;
+
+  const completed = applyCodexPlanSnapshotOnDone(
+    [{ role: 'tool_use', toolUseId, content: liveSnapshot.content }],
+    snapshot,
+    turnId,
+    terminalStatus,
+  );
+  const content = completed.messages[0]?.content;
+  if (!completed.changed || !isRecord(content)) return false;
+  rememberLivePlanContent(sessionId, toolUseId, content);
+  return true;
 }
 
 /** End any pre-compaction streaming rows without changing the overall running turn. */
@@ -1699,18 +1735,25 @@ export const remoteSessionStore = {
           turnId,
           turnStatus,
         );
+        completeLivePlanSnapshotOnDone(
+          sessionId,
+          data?.plan,
+          turnId,
+          turnStatus,
+        );
         terminalPlanChanged = completed.changed;
         if (completed.changed) {
           messages.set(sessionId, [...completed.messages]);
-          if (Array.isArray(data?.plan) && completed.toolUseId) {
-            rememberLivePlanSnapshot(sessionId, {
-              toolUseId: completed.toolUseId,
-              content: {
-                toolUseId: completed.toolUseId,
-                toolName: 'update_plan',
-                input: { plan: data.plan },
-              },
-            });
+          const completedMessage = completed.messages.find((message) => {
+            if (message.toolUseId === completed.toolUseId) return true;
+            return readString(message.content, 'toolUseId') === completed.toolUseId;
+          });
+          if (completed.toolUseId && isRecord(completedMessage?.content)) {
+            rememberLivePlanContent(
+              sessionId,
+              completed.toolUseId,
+              completedMessage.content,
+            );
           }
         }
       }

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1691,8 +1691,14 @@ export const remoteSessionStore = {
         const data = isRecord(event.data) ? event.data : null;
         const rawTurn = isRecord(data?.raw) ? data.raw : null;
         const turnId = readString(rawTurn, 'id');
+        const turnStatus = readString(rawTurn, 'status');
         const currentMessages = messages.get(sessionId) ?? [];
-        const completed = applyCodexPlanSnapshotOnDone(currentMessages, data?.plan, turnId);
+        const completed = applyCodexPlanSnapshotOnDone(
+          currentMessages,
+          data?.plan,
+          turnId,
+          turnStatus,
+        );
         terminalPlanChanged = completed.changed;
         if (completed.changed) {
           messages.set(sessionId, [...completed.messages]);

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -88,4 +88,47 @@ describe('applyCodexPlanSnapshotOnDone', () => {
       toolUseId: null,
     });
   });
+
+  it('marks the matching plan complete when a successful turn has no final snapshot', () => {
+    const message = planMessage('plan:done', [
+      { step: 'Inspect', status: 'in_progress' },
+      { step: 'Patch', status: 'pending' },
+    ]);
+    const result = applyCodexPlanSnapshotOnDone(
+      [message],
+      null,
+      'done',
+      'completed',
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.toolUseId).toBe('plan:done');
+    expect(result.messages[0]).toMatchObject({
+      toolInput: {
+        plan: [
+          { step: 'Inspect', status: 'completed' },
+          { step: 'Patch', status: 'completed' },
+        ],
+      },
+      content: {
+        input: {
+          plan: [
+            { step: 'Inspect', status: 'completed' },
+            { step: 'Patch', status: 'completed' },
+          ],
+        },
+      },
+    });
+  });
+
+  it('does not infer completion for a failed or interrupted turn', () => {
+    const message = planMessage('plan:stopped', [{ step: 'Inspect', status: 'in_progress' }]);
+    const messages = [message];
+
+    expect(applyCodexPlanSnapshotOnDone(messages, null, 'stopped', 'interrupted')).toEqual({
+      messages,
+      changed: false,
+      toolUseId: null,
+    });
+  });
 });

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -121,6 +121,48 @@ describe('applyCodexPlanSnapshotOnDone', () => {
     });
   });
 
+  it('treats an unfinished done snapshot as cached progress for a successful turn', () => {
+    const message = planMessage('plan:done', [
+      { step: 'Inspect', status: 'in_progress' },
+      { step: 'Patch', status: 'pending' },
+    ]);
+    const cachedProgress = [
+      { step: 'Inspect', status: 'completed', description: 'kept from latest update' },
+      { step: 'Patch', status: 'in_progress' },
+    ];
+
+    const result = applyCodexPlanSnapshotOnDone(
+      [message],
+      cachedProgress,
+      'done',
+      'completed',
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.messages[0]).toMatchObject({
+      toolInput: {
+        plan: [
+          { step: 'Inspect', status: 'completed', description: 'kept from latest update' },
+          { step: 'Patch', status: 'completed' },
+        ],
+      },
+    });
+  });
+
+  it('does not infer completion without a matching turn id', () => {
+    const message = planMessage('plan:unrelated', [
+      { step: 'Inspect', status: 'in_progress' },
+    ]);
+    const messages = [message];
+
+    expect(applyCodexPlanSnapshotOnDone(
+      messages,
+      null,
+      null,
+      'completed',
+    )).toEqual({ messages, changed: false, toolUseId: null });
+  });
+
   it('does not infer completion for a failed or interrupted turn', () => {
     const message = planMessage('plan:stopped', [{ step: 'Inspect', status: 'in_progress' }]);
     const messages = [message];

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -440,8 +440,12 @@ export function applyCodexPlanSnapshotOnDone<
   messages: readonly TMessage[],
   snapshot: unknown,
   turnId?: string | null,
+  terminalStatus?: unknown,
 ): CodexPlanSnapshotApplyResult<TMessage> {
-  if (!Array.isArray(snapshot)) return { messages, changed: false, toolUseId: null };
+  const hasAuthoritativeSnapshot = Array.isArray(snapshot);
+  if (!hasAuthoritativeSnapshot && terminalStatus !== 'completed') {
+    return { messages, changed: false, toolUseId: null };
+  }
   const expectedToolUseId = turnId ? `plan:${turnId}` : null;
 
   for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -454,7 +458,19 @@ export function applyCodexPlanSnapshotOnDone<
 
     const input = readRecord(toolInputOf(message));
     if (!Array.isArray(input?.plan)) continue;
-    if (samePlanSnapshot(input.plan, snapshot)) {
+    // Some Codex hosts finish a successful turn without echoing the final
+    // turn/plan/updated notification. The plan card must still converge after
+    // the turn has completed; otherwise it remains stuck on the first
+    // in_progress/pending snapshot forever. Only synthesize this fallback for
+    // the matching successful turn. Failed/interrupted turns intentionally keep
+    // their last known state.
+    const nextSnapshot = hasAuthoritativeSnapshot
+      ? snapshot
+      : input.plan.map((item) => {
+          const record = readRecord(item);
+          return record ? { ...record, status: 'completed' } : item;
+        });
+    if (samePlanSnapshot(input.plan, nextSnapshot)) {
       return { messages, changed: false, toolUseId };
     }
 
@@ -462,10 +478,10 @@ export function applyCodexPlanSnapshotOnDone<
     next[index] = {
       ...message,
       ...(message.toolInput !== undefined
-        ? { toolInput: { ...input, plan: snapshot } }
+        ? { toolInput: { ...input, plan: nextSnapshot } }
         : {}),
       ...(content
-        ? { content: { ...content, input: { ...input, plan: snapshot } } }
+        ? { content: { ...content, input: { ...input, plan: nextSnapshot } } }
         : {}),
     };
     return { messages: next, changed: true, toolUseId };

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -442,11 +442,17 @@ export function applyCodexPlanSnapshotOnDone<
   turnId?: string | null,
   terminalStatus?: unknown,
 ): CodexPlanSnapshotApplyResult<TMessage> {
-  const hasAuthoritativeSnapshot = Array.isArray(snapshot);
-  if (!hasAuthoritativeSnapshot && terminalStatus !== 'completed') {
+  const authoritativeSnapshot = Array.isArray(snapshot) ? snapshot : null;
+  const hasAuthoritativeSnapshot = authoritativeSnapshot !== null;
+  const canInferCompletion = terminalStatus === 'completed' && Boolean(turnId);
+  if (!hasAuthoritativeSnapshot && !canInferCompletion) {
     return { messages, changed: false, toolUseId: null };
   }
   const expectedToolUseId = turnId ? `plan:${turnId}` : null;
+  const shouldInferCompletion = canInferCompletion && (
+    !hasAuthoritativeSnapshot
+    || authoritativeSnapshot.some((item) => readRecord(item)?.status !== 'completed')
+  );
 
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
@@ -458,18 +464,23 @@ export function applyCodexPlanSnapshotOnDone<
 
     const input = readRecord(toolInputOf(message));
     if (!Array.isArray(input?.plan)) continue;
-    // Some Codex hosts finish a successful turn without echoing the final
-    // turn/plan/updated notification. The plan card must still converge after
-    // the turn has completed; otherwise it remains stuck on the first
-    // in_progress/pending snapshot forever. Only synthesize this fallback for
-    // the matching successful turn. Failed/interrupted turns intentionally keep
-    // their last known state.
-    const nextSnapshot = hasAuthoritativeSnapshot
-      ? snapshot
-      : input.plan.map((item) => {
+    // maker-core attaches the latest cached turn/plan/updated snapshot to done.
+    // When Codex omits its final plan update, that array still contains open
+    // items and is in progress rather than a terminal snapshot. Converge that
+    // cached progress (or the persisted row when no snapshot exists) only for a
+    // matching, explicitly successful turn. Without a turn id, an array can
+    // still be applied as supplied but completion must never be inferred for an
+    // unrelated last plan row.
+    const snapshotSource = authoritativeSnapshot ?? input.plan;
+    const nextSnapshot = shouldInferCompletion
+      ? snapshotSource.map((item) => {
           const record = readRecord(item);
           return record ? { ...record, status: 'completed' } : item;
-        });
+        })
+      : authoritativeSnapshot;
+    if (!nextSnapshot) {
+      return { messages, changed: false, toolUseId: null };
+    }
     if (samePlanSnapshot(input.plan, nextSnapshot)) {
       return { messages, changed: false, toolUseId };
     }


### PR DESCRIPTION
## 这次改了什么

Fixes #325.

Codex 成功结束时，maker-core 会把该 turn 最近一次 `turn/plan/updated` 缓存放进 `done.data.plan`。如果 Codex 没有发最后一次全完成更新，这个数组仍是 `in_progress` / `pending` 的过程快照；原实现把“存在数组”等同于“已有最终快照”，所以任务实际跑完后卡片仍显示 `0/N`。

本 PR：

- 在 shared 收口层识别成功终态中的未完成缓存快照，并基于快照保留步骤内容、将匹配的 `plan:<turnId>` 收口为全部完成。
- 只有 `raw.status === completed` 且存在可匹配的 `turnId` 时才推断完成；缺少 turnId、failed、interrupted 或 turn 不匹配时不推断，避免误改其他计划卡片。
- Desktop 与 mobile 都把 Codex 终态 status 传给 shared helper。
- Mobile 同步更新 `livePlanSnapshots`，覆盖两类乱序：`done` 早于初始 DB 行，以及旧 DB/window 回声晚到，避免已完成卡片再次回退。
- 新增 shared、Desktop store 与 mobile remote-session 回归测试。

## 怎么验证的

- `pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/planCompletion.test.ts` — 9/9 通过
- `pnpm --filter mobile exec vitest run src/__tests__/remoteSessionStore.test.ts` — 93/93 通过
- `pnpm --filter desktop exec vitest run src/renderer/__tests__/planReviewDoneRace.test.ts` — 13/13 通过
- `pnpm --filter mobile typecheck` — 通过
- `pnpm --filter desktop typecheck` — 通过
- `pnpm --filter @cindy/maker-shared lint` — 通过

## UI 证据

这是 UI 状态收敛修复，不修改 `TodoListCard` 的 DOM、样式或布局；效果由同一张卡片的数据状态变化体现：

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| 成功终态，最后一次 plan 更新缺失 | `0/N`，首项 spinner，其余 pending | `N/N`，所有步骤为 completed，无进行中动画 |
| Mobile 的旧 DB 行/窗口晚到 | 已完成卡片可能回退为 `0/N` | live-plan 终态覆盖旧回声，保持 `N/N` |
| failed / interrupted / turn 不匹配 | 保留最后已知状态 | 保持不变，不伪造完成 |

对应 UI 投影已由 Desktop store 测试断言，Mobile 两个新增用例分别模拟 `done → DB create` 和 `done → stale window` 的真实乱序路径。

## 风险

- 推断范围严格限制在“明确成功 + 匹配 turnId”；失败、中断和无匹配计划不会被标为完成。
- 成功终态中仍包含未完成项时，会按该 turn 的完成事实收口；这是本修复的预期语义。
- Mobile cache 复用现有 `toolUseId` / `persistId` 双键，不改变持久化协议，只防止延迟回声覆盖较新的内存状态。
