### PR TITLE
fix(new-chat): 快速开始卡片区随输入框同宽(去掉 800px 封顶)

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -62,8 +62,10 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(source).toContain('style={{ maxWidth: inputWidth || 800 }}');
     expect(source).not.toContain('max-w-[800px]');
     expect(source).toContain('absolute right-0 top-[22px]');
-    // 快捷入口只有 4 项,不随内容列铺满全宽——封顶 800px 左对齐,保持卡片紧凑比例。
-    expect(source).toMatch(/data-testid="create-agent-quick-starts"[\s\S]*?style=\{\{ maxWidth: 800 \}\}/);
+    // 快捷入口随内容列同宽(用户拍板 2026-07-24,推翻旧「封顶 800 左对齐」):
+    // 容器 w-full 吃满父列(= inputWidth),禁止再套独立 maxWidth。
+    expect(source).toMatch(/data-testid="create-agent-quick-starts" className="mt-\[42px\] w-full"/);
+    expect(source).not.toMatch(/data-testid="create-agent-quick-starts"[\s\S]{0,120}?maxWidth: 800/);
   });
 
   it('preserves New Maker behavior-critical props on ChatInput', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2204,14 +2204,11 @@ export function NewMakerDraftRoute() {
                     }
                   />
                 </div>
-                {/* 输入框跟随 inputWidth 变宽后,快捷入口只有 4 项,若也铺满全宽
-                    会被撑成又宽又空的短卡。这里把卡片区封顶在 800px、左对齐(与输入框
-                    左缘齐),保持每张卡当前的紧凑比例;输入框仍独立用满可用宽度。 */}
-                <div
-                  data-testid="create-agent-quick-starts"
-                  className="mt-[42px] w-full"
-                  style={{ maxWidth: 800 }}
-                >
+                {/* 快捷入口随内容列同宽(用户拍板 2026-07-24,推翻旧「封顶 800 左对齐」
+                    口径):卡片区吃满父列宽 = 输入框宽(inputWidth,封顶 1220),
+                    grid-cols-4 均分,与输入框左右缘对齐——大屏下不再出现"输入框宽、
+                    卡片区短一截"的错位观感。 */}
+                <div data-testid="create-agent-quick-starts" className="mt-[42px] w-full">
                   {/* 标题字号 12→14px(DESIGN §3 Caption),与卡片间距 16→10px 收近
                       (DESIGN §5 间距档)——用户改稿 2026-07-22。 */}
                   <div className="mb-2.5 px-0.5">


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复新会话页（NewMakerDraftRoute）的宽度适配错位：内容列宽度早已改为跟随 `useProportionalWidth` 的 `inputWidth`（封顶 1220px），但「快速开始」4 张卡的容器还独立封顶在 `maxWidth: 800` 左对齐——大屏下输入框变宽后，卡片区短一截贴在左侧（见实机截图）。按 2026-07-24 拍板改为：**卡片区吃满父内容列宽（= 输入框宽），`grid-cols-4` 均分，与输入框左右缘对齐**；窄屏（1 列）/ 中屏（2 列）断点行为不变。

实现 = 删掉容器上的 `style={{ maxWidth: 800 }}`（父列已有 `maxWidth: inputWidth || 800`，`w-full` 自然跟随）；视觉契约测试 `newMakerCreateAgentVisualContract` 同步反转（断言容器为纯 `w-full`、禁止再套独立 maxWidth），把新拍板钉进测试。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：2026-07-24 用户实机反馈（大屏下快速开始卡与输入框宽度错位）
- 本 PR 包含：2 文件（+9/−10）——容器封顶删除 + 契约测试反转
- 明确不包含：卡片内部样式 / 断点阈值 / 文案；手机版（其新会话页为单列窄屏布局，无此错位场景）
- 用户可见变化：大屏下 4 张快速开始卡拉伸至与输入框同宽；≤800px 可用宽度时与原来完全一致
- 是否存在 breaking change：无

### 远程 / 手机适配说明（AGENTS 规则）

纯桌面 renderer 布局改动：不涉及 workdir / agent 进程 / 会话数据（SSH 远程工作区同一 renderer，行为一致）；无新增 IPC channel（device-link allowlist 不涉及）；手机版新会话页为独立单列布局，不存在「卡片区与输入框宽度错位」场景，无需适配。

### UI 变化

修复前（实机截图，用户提供）：输入框 ~1220px 宽，卡片区仅 800px 贴左。修复后：卡片区与输入框左右缘对齐，4 卡均分。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
结果：13 passed（含反转后的快捷卡宽度契约断言）
pnpm --filter desktop typecheck
结果：通过
pnpm test:unit
结果：通过（exit 0）
```

### 手工验证

布局推演：父列 `maxWidth: inputWidth || 800` 不变——窄窗（inputWidth ≤ 800）下卡片区宽度与改动前逐像素一致，仅大屏（>800）时卡片区随列变宽；断点类（`grid-cols-1/2/4`）未触碰。

### 未执行的验证

未在运行实例实拍修复后效果（worktree 无 HMR）；改动为单一 CSS 约束删除，由契约测试锁定。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

单容器布局约束，revert 即回滚。卡片变宽后为「宽卡」观感——这正是本次拍板要的效果（推翻旧「防宽卡封顶 800」决策，决策记录在代码注释与契约测试内）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
