### PR TITLE
fix(desktop): Windows 上 Node 插件 worker 虚拟 stdin 装载崩溃

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeVirtualStdin.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeVirtualStdin.test.ts
@@ -1,0 +1,74 @@
+/**
+ * nodeRuntimeVirtualStdin.test — 虚拟 stdin 装载的两条路径。
+ *
+ * Windows 上 Electron(lib/common/init.ts)把 process.stdin 钉成
+ * configurable: false 的 getter,返回一条创建时即 EOF 的假 Readable;
+ * 直接 defineProperty 会抛 "Cannot redefine property: stdin"。这里用
+ * 同形状的假体验证原地复活路径,防 Node 升级悄悄改掉 _readableState
+ * 的 bitfield setter 行为。
+ */
+
+import { Readable } from 'node:stream';
+
+import { describe, expect, it } from 'vitest';
+
+import { installVirtualStdin } from '../nodeRuntimeVirtualStdin';
+
+type ProcessLike = Pick<NodeJS.Process, 'stdin'>;
+
+async function collectUntilEnd(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+  await new Promise<void>((resolve) => stream.on('end', resolve));
+  return Buffer.concat(chunks);
+}
+
+describe('installVirtualStdin', () => {
+  it('stdin 可配置时整体替换,喂入的字节按序可读', async () => {
+    const proc = {} as ProcessLike;
+    const sink = installVirtualStdin(proc);
+    const stream = proc.stdin as unknown as Readable;
+    expect(stream).toBeInstanceOf(Readable);
+
+    const done = collectUntilEnd(stream);
+    sink.feed('{"jsonrpc":"2.0"}\n');
+    sink.feed(Buffer.from('第二行\n', 'utf8'));
+    sink.end();
+    expect((await done).toString('utf8')).toBe('{"jsonrpc":"2.0"}\n第二行\n');
+  });
+
+  it('stdin 被钉成不可配置 EOF 流时原地复活(Electron win32 形状)', async () => {
+    // 复刻 Electron common/init 的 win32 行为:EOF Readable + 不可配置 getter。
+    const stub = new Readable();
+    stub.push(null);
+    // 让 EOF 引发的 nextTick 排水先跑完,贴近真实装载时机。
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const proc = {} as ProcessLike;
+    Object.defineProperty(proc, 'stdin', {
+      configurable: false,
+      enumerable: true,
+      get: () => stub,
+    });
+
+    const sink = installVirtualStdin(proc);
+    // 属性无法重定义,插件读到的必须仍是同一个对象。
+    expect(proc.stdin as unknown).toBe(stub);
+
+    const done = collectUntilEnd(stub);
+    sink.feed('hello ');
+    sink.feed(Buffer.from('world'));
+    sink.end();
+    expect((await done).toString('utf8')).toBe('hello world');
+  });
+
+  it('stdin 不可重定义且形状不符时抛错,不让插件读到静默 EOF', () => {
+    const proc = {} as ProcessLike;
+    Object.defineProperty(proc, 'stdin', {
+      configurable: false,
+      enumerable: true,
+      get: () => 42,
+    });
+    expect(() => installVirtualStdin(proc)).toThrow(/stdin/);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeVirtualStdin.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeVirtualStdin.ts
@@ -1,0 +1,66 @@
+/**
+ * nodeRuntimeVirtualStdin — 把 process.stdin 接管为宿主可喂字节的虚拟流。
+ *
+ * macOS / Linux:Node 自身把 stdin 定义为可配置属性,直接整体替换成 PassThrough。
+ * Windows:Electron 的 lib/common/init.ts 在 win32 把 process.stdin 钉成
+ * configurable: false 的 getter,返回一条创建时即压入 EOF 的假 Readable
+ * (browser / utility 进程一律如此),此时 defineProperty 会抛
+ * "Cannot redefine property: stdin"。属性无法重定义,唯一出路是把这条假流
+ * 原地复活:清掉 EOF 标志、补上空 _read,之后按 Readable.push 喂字节——
+ * 插件从 process.stdin 读到的仍是同一个对象,require('node:process') 一致。
+ * 复活依赖 _readableState.ended 的 setter(Node 22 / 24 的 bitfield 属性
+ * 描述符均提供);复活失败时抛错让 worker 明确退出,不让插件读到静默 EOF。
+ */
+
+import { PassThrough } from 'node:stream';
+import type { Readable } from 'node:stream';
+
+export interface VirtualStdinSink {
+  /** 宿主送来的插件方向字节从这里写入。 */
+  feed(chunk: string | Buffer): void;
+  /** 宿主宣布 stdin 结束。 */
+  end(): void;
+}
+
+type StdinStub = Readable & {
+  _read?: (size: number) => void;
+  _readableState?: { ended?: boolean; endEmitted?: boolean };
+};
+
+export function installVirtualStdin(proc: Pick<NodeJS.Process, 'stdin'>): VirtualStdinSink {
+  const descriptor = Object.getOwnPropertyDescriptor(proc, 'stdin');
+  if (!descriptor || descriptor.configurable) {
+    const virtual = new PassThrough();
+    Object.defineProperty(proc, 'stdin', {
+      configurable: true,
+      enumerable: true,
+      value: virtual,
+    });
+    return {
+      feed(chunk) {
+        virtual.write(chunk);
+      },
+      end() {
+        virtual.end();
+      },
+    };
+  }
+  const stub = proc.stdin as unknown as StdinStub;
+  const state = stub?._readableState;
+  if (!state || typeof stub.push !== 'function' || state.endEmitted) {
+    throw new Error('process.stdin 不可重定义且流形状不符合预期,虚拟 stdin 装载失败');
+  }
+  stub._read = () => {};
+  state.ended = false;
+  if (state.ended !== false) {
+    throw new Error('process.stdin 的 EOF 标志清除失败,虚拟 stdin 装载失败');
+  }
+  return {
+    feed(chunk) {
+      stub.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+    },
+    end() {
+      stub.push(null);
+    },
+  };
+}

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeWorkerProcess.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeWorkerProcess.ts
@@ -27,6 +27,7 @@ import { PassThrough } from 'node:stream';
 
 import type { GhostNodeChildToWorkerMessage } from '../../shared/ghost.js';
 import { GHOST_NODE_CHILD_MODE_FLAG } from '../../shared/ghost.js';
+import { installVirtualStdin } from './nodeRuntimeVirtualStdin.js';
 
 interface ParentPortLike {
   postMessage(message: unknown): void;
@@ -51,12 +52,9 @@ if (
   throw new Error('Node 插件工作进程入口不合法');
 }
 
-const virtualStdin = new PassThrough();
-Object.defineProperty(process, 'stdin', {
-  configurable: true,
-  enumerable: true,
-  value: virtualStdin,
-});
+// Windows 上 Electron 把 process.stdin 钉成不可配置 getter,不能整体替换;
+// 替换或原地复活的分支收敛在 installVirtualStdin 里。
+const virtualStdin = installVirtualStdin(process);
 
 /* ── spawnEntry 窄接口(仅普通 worker 模式;子进程模式不给,树深恒为 1)── */
 
@@ -183,12 +181,12 @@ parentPort.on('message', (event) => {
   const data = event.data;
   if (!isRecord(data)) return;
   if (data.type === 'stdin' && typeof data.chunk === 'string') {
-    if (Buffer.byteLength(data.chunk, 'utf8') <= 1024 * 1024) virtualStdin.write(data.chunk);
+    if (Buffer.byteLength(data.chunk, 'utf8') <= 1024 * 1024) virtualStdin.feed(data.chunk);
     return;
   }
   // 子进程原样模式的字节口(base64,防多字节字符被 chunk 边界切坏)。
   if (data.type === 'stdin-b64' && typeof data.chunk === 'string') {
-    if (data.chunk.length <= 2 * 1024 * 1024) virtualStdin.write(Buffer.from(data.chunk, 'base64'));
+    if (data.chunk.length <= 2 * 1024 * 1024) virtualStdin.feed(Buffer.from(data.chunk, 'base64'));
     return;
   }
   if (data.type === 'stdin-end') {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 上随包 Node 插件(如 taptap-maker)的 utilityProcess worker 启动即崩:

```
TypeError: Cannot redefine property: stdin
    at Object.defineProperty (nodeRuntimeWorkerProcess.js:19)
```

根因:Electron 的 `lib/common/init.ts` **仅在 win32** 把 `process.stdin` 定义成 `configurable: false` 的 getter,返回一条创建时即压入 EOF 的假 Readable(browser / utility 进程一律如此)。引导层原来的 `Object.defineProperty(process, 'stdin', ...)` 在 macOS 上正常(Node 自身的 stdin 是可配置属性),在 Windows 上必抛。这不是 Electron 41 新引入的行为,而是该链路第一次在 Windows 上被跑到。

修法:把虚拟 stdin 装载收敛到新模块 `nodeRuntimeVirtualStdin.ts`,按能力探测分支——

- 描述符可配置(macOS / Linux):保持原行为,整体替换为 PassThrough;
- 不可配置(Windows):把 Electron 的 EOF 假流**原地复活**——清 `_readableState.ended` 标志(Node 22 / 24 的 bitfield 属性描述符均提供 setter,已对照 v24.x 源码确认)、补空 `_read`,宿主字节改走 `Readable.push` 喂入。插件读到的仍是同一个 `process.stdin` 对象,与 `require('node:process')` 一致;复活失败抛明确错误,不让插件读到静默 EOF。

`nodeRuntimeWorkerProcess.ts` 的 stdin / stdin-b64 / stdin-end 三种帧改走 sink 的 `feed` / `end`,1MB / 2MB 上限与其余协议行为不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(本机 Windows dev 实测崩溃日志)
- 本 PR 包含:worker 引导层虚拟 stdin 装载的跨平台修复 + 单测
- 明确不包含:①同文件里 `process.parentPort` 隐藏逻辑在所有平台静默失效的问题(Electron 把 parentPort 定义为不可配置,try/catch 吞掉;真正边界在 broker 侧帧校验,另行处理);② worker 启动瞬时 EPERM 重试(在途 PR `xdt/auto-yy8yyl`,改的是 nodeRuntimeBroker,与本 PR 无文件交集)
- 用户可见变化:Windows 上随包 Node 插件可以正常启动
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/nodeRuntimeVirtualStdin.test.ts \
  src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts \
  src/main/cindy-brain/__tests__/nodeRuntimePackaging.test.ts
结果:3 files / 32 tests 全过(含新增 3 个:可配置替换、Electron win32 形状原地复活、形状不符抛错)

pnpm --filter desktop run typecheck
结果:通过

仓库根 pnpm test:unit
结果:desktop、mobile 之外全部 PASS。desktop 挂 2 个(agent-island macOS
protected-folder guidance ×2)、mobile 挂 1 个(newSession.test.ts 源码文本断言,
期望 LF 与本机 CRLF checkout 不符)——三者均为本机 Windows 环境上 main 既有失败:
已 git stash 后在干净工作区复跑确认同样失败,与本 diff 无关(diff 不含 mobile,
agent-island 测试文件正由在途 PR xdt/auto-yy8yyl 修改)。CI(ubuntu)上 main 为绿。
```

### 手工验证

未执行(见下)。

### 未执行的验证

Windows dev 实例重启后实际拉起 taptap-maker 插件的运行时验证未执行:worker bundle 由启动 dev 实例的 checkout 重新打包,agent 无法重启宿主 app;修复机制已由复刻 Electron win32 形状(EOF Readable + 不可配置 getter)的单测覆盖。请 merge 前在 Windows dev 实例重启验证插件拉起。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他:Windows 分支依赖 Node stream 内部字段(`_readableState.ended` 的 bitfield setter)

### 影响与回滚

- 影响范围:仅随包 Node 插件 worker 的 stdin 装载路径;macOS / Linux 走的仍是原替换逻辑,行为零变化;Windows 从必崩变为可用。
- 回滚 / 降级方式:revert 本 commit 即回到旧行为(Windows 回到启动即崩,与修复前一致,无数据风险)。内部字段依赖失效的失败模式是装载时抛明确错误、worker 退出,不会静默吞字节;Electron 版本升级时由 nodeRuntimeVirtualStdin.test 的 win32 形状复刻用例看护。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(模块头注释即为行为说明,未触及 docs/ 规则面)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
