### PR TITLE
fix(desktop): support ByteDance Seed tools in Codex proxy

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -452,8 +452,8 @@ describe('codex proxy host', () => {
         // upstream 是函数形态(每请求现取,model-access 下发可运行期换 endpoint);
         // 断言其当前求值 = 网关 base + /v1
         upstream: expect.any(Function),
-        // [encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, xAI Responses 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields]
-        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
+        // [encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields]
+        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
         routingTransform: expect.any(Function),
         recoveryRules: expect.arrayContaining([
           expect.objectContaining({ id: 'encrypted_content' }),
@@ -660,6 +660,198 @@ describe('codex proxy host', () => {
       input: originalInput,
     });
     clearSessionProvider('session-openai-custom-tool');
+  });
+
+  it('normalizes the Codex tool set to ByteDance Seed Responses capabilities', async () => {
+    const host = await freshCodexProxyHost();
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-seed', 'thread-seed', 'PRODUCT_PROMPT');
+    setSessionProvider('session-seed', 'xd');
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'function', name: 'write_stdin' },
+        { type: 'namespace', name: 'multi_agent_v1', tools: [{ type: 'function', name: 'close_agent' }] },
+        { type: 'web_search', external_web_access: true },
+        { type: 'image_generation' },
+      ],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      input: [
+        { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'earlier answer' }] },
+        { type: 'reasoning', summary: [], content: null },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+      ],
+    };
+    const ctx = {
+      method: 'POST',
+      url: '/responses',
+      headers: { 'thread-id': 'thread-seed' },
+    };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'function', name: 'write_stdin' },
+        { type: 'web_search' },
+      ],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      input: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'earlier answer' }],
+        },
+        { type: 'reasoning', summary: [], content: null },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+      ],
+    });
+    clearSessionProvider('session-seed');
+  });
+
+  it('removes Seed tool controls when every declared tool is unsupported', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [{ type: 'namespace', name: 'multi_agent_v1', tools: [] }],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      input: 'hello',
+    };
+    const ctx = { method: 'POST', url: '/responses', headers: {} };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'bytedance-seed/seed-2.1-pro',
+      input: 'hello',
+    });
+  });
+
+  it('drops Seed web search when Codex explicitly disables live web access', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'web_search', external_web_access: false },
+      ],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      input: 'hello',
+    };
+    const ctx = { method: 'POST', url: '/responses', headers: {} };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [{ type: 'function', name: 'exec_command' }],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      input: 'hello',
+    });
+  });
+
+  it('resets a Seed tool choice that references a filtered tool', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'image_generation' },
+      ],
+      tool_choice: { type: 'image_generation' },
+      parallel_tool_calls: false,
+      input: 'hello',
+    };
+    const ctx = { method: 'POST', url: '/responses', headers: {} };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [{ type: 'function', name: 'exec_command' }],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      input: 'hello',
+    });
+  });
+
+  it('keeps a Seed tool choice that references a retained function', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'namespace', name: 'multi_agent_v1', tools: [] },
+      ],
+      tool_choice: { type: 'function', name: 'exec_command' },
+      parallel_tool_calls: false,
+      input: 'hello',
+    };
+    const ctx = { method: 'POST', url: '/responses', headers: {} };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'bytedance-seed/seed-2.1-pro',
+      tools: [{ type: 'function', name: 'exec_command' }],
+      tool_choice: { type: 'function', name: 'exec_command' },
+      parallel_tool_calls: false,
+      input: 'hello',
+    });
   });
 
   it('keeps Codex namespace tools for non-xAI requests', async () => {
@@ -1008,7 +1200,7 @@ describe('codex proxy host', () => {
     await host.ensureCodexProxyReady();
 
     const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
-    expect(transforms).toHaveLength(9); // encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, xAI Responses 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields, dump
+    expect(transforms).toHaveLength(10); // encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields, dump
     const ctx = {
       method: 'POST',
       url: '/v1/responses',

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -576,6 +576,110 @@ function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown
   return next;
 }
 
+/**
+ * ByteDance Seed accepts standard function tools and web search. Codex also
+ * emits namespaced and other built-in descriptors that Volcengine rejects
+ * before the request reaches the model. Its web-search descriptor must also
+ * be reduced to the standard shape: Codex's `external_web_access` extension
+ * is rejected as an unknown field.
+ */
+function isByteDanceSeedModel(model: unknown): boolean {
+  return typeof model === 'string' && model.startsWith('bytedance-seed/');
+}
+
+function seedToolChoiceReferencesRemovedTool(
+  toolChoice: unknown,
+  tools: Record<string, unknown>[],
+): boolean {
+  if (!isPlainObject(toolChoice) || typeof toolChoice.type !== 'string') return false;
+
+  return !tools.some((tool) => {
+    if (tool.type !== toolChoice.type) return false;
+    if (toolChoice.type !== 'function') return true;
+    return typeof toolChoice.name === 'string' && tool.name === toolChoice.name;
+  });
+}
+
+function sanitizeByteDanceSeedTools(body: Record<string, unknown>): Record<string, unknown> | null {
+  if (!isByteDanceSeedModel(body.model) || !Array.isArray(body.tools)) return null;
+
+  let changed = false;
+  const tools: Record<string, unknown>[] = [];
+  for (const tool of body.tools) {
+    if (!isPlainObject(tool)) {
+      changed = true;
+      continue;
+    }
+    if (tool.type === 'function') {
+      tools.push(tool);
+      continue;
+    }
+    if (tool.type === 'web_search') {
+      // Seed cannot represent Codex's cache-only search policy. Dropping the
+      // tool preserves the caller's explicit prohibition on live web access.
+      if (tool.external_web_access === false) {
+        changed = true;
+        continue;
+      }
+      tools.push({ type: 'web_search' });
+      if (Object.keys(tool).length !== 1) changed = true;
+      continue;
+    }
+    changed = true;
+  }
+  if (!changed) return null;
+
+  const next: Record<string, unknown> = { ...body };
+  if (tools.length > 0) {
+    next.tools = tools;
+    if (seedToolChoiceReferencesRemovedTool(next.tool_choice, tools)) next.tool_choice = 'auto';
+  } else {
+    delete next.tools;
+    delete next.tool_choice;
+    delete next.parallel_tool_calls;
+  }
+  return next;
+}
+
+/** Volcengine requires replayed assistant messages to carry their output status. */
+function normalizeByteDanceSeedInput(body: Record<string, unknown>): Record<string, unknown> | null {
+  if (!isByteDanceSeedModel(body.model) || !Array.isArray(body.input)) return null;
+
+  let changed = false;
+  const input = body.input.map((item) => {
+    if (
+      !isPlainObject(item) ||
+      item.type !== 'message' ||
+      item.role !== 'assistant' ||
+      typeof item.status === 'string'
+    ) {
+      return item;
+    }
+    changed = true;
+    return { ...item, status: 'completed' };
+  });
+  return changed ? { ...body, input } : null;
+}
+
+function createByteDanceSeedResponsesCompatTransform(): RequestTransform {
+  return (body) => {
+    if (!isPlainObject(body)) return null;
+    let changed = false;
+    let current = body;
+    const withSanitizedTools = sanitizeByteDanceSeedTools(current);
+    if (withSanitizedTools) {
+      current = withSanitizedTools;
+      changed = true;
+    }
+    const withNormalizedInput = normalizeByteDanceSeedInput(current);
+    if (withNormalizedInput) {
+      current = withNormalizedInput;
+      changed = true;
+    }
+    return changed ? current : null;
+  };
+}
+
 function createXaiResponsesCompatTransform(): RequestTransform {
   return (body, ctx) => {
     if (!isPlainObject(body)) return null;
@@ -1041,6 +1145,7 @@ function createTransformRequestChain(): RequestTransform[] {
     // 针对具体供应商的 input 归一化才能按标准 message 处理它。
     createCrossProviderCompactionCompatTransform(),
     createXaiResponsesCompatTransform(),
+    createByteDanceSeedResponsesCompatTransform(),
     createMiniMaxResponsesCompatTransform(),
     createProviderModelRewriteTransform(),
     stripNonAnthropicFields,


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Codex 通过 Cindy AI Gateway 调用 ByteDance Seed 增加请求兼容处理。Seed 请求现在保留标准 function tools，将 Codex web search 收敛为 Seed 接受的标准形态，移除不支持的 namespace、image generation、local shell 等 tool 描述，并为缺少状态的历史 assistant message 补上 `status: "completed"`。

兼容处理只作用于 `bytedance-seed/*`，不会改变其他供应商请求。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：ByteDance Seed 无法接受 Codex 原始 tool descriptors 和缺少 status 的历史 assistant message
- 本 PR 包含：Seed 专用 Responses 请求转换与回归测试
- 明确不包含：Aliyun WAF 配置或绕过逻辑、其他供应商的工具转换
- 用户可见变化：Codex 使用 Seed 模型时可以执行受支持的 function/web-search tools，并可继续多轮 tool 会话
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm test:unit
结果：通过，所有 unit workspaces PASS

PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter desktop run --if-present typecheck
结果：通过

PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：46/46 tests passed

PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter desktop exec eslint src/main/maker-host/codex-proxy-host.ts src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：通过

PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm release:package -- --platform darwin --arch arm64 --region cn --no-sign
结果：通过；packaged app smoke test 通过，schema_version=79

hdiutil verify apps/desktop/release/artifacts/cn/unversioned/darwin-arm64/cindy-unversioned-arm64.dmg
codesign --verify --verbose=2 apps/desktop/release/artifacts/cn/unversioned/darwin-arm64/cindy-unversioned-arm64.dmg
结果：DMG checksum 与 ad-hoc signature 均通过
```

### 手工验证

- 通过本地 Cindy Codex proxy 和真实 Cindy AI Gateway 调用 Seed，完成多轮 `exec_command`，返回 `SEED_TOOL_OK`。
- 使用 `pnpm restart:desktop:remote --region=cn` 启动真实桌面应用验证 Seed 会话。
- 只读挂载新 DMG，确认包含 `Cindy.app` 和 Applications 快捷方式，且 app deep signature 校验通过。

### 未执行的验证

- 未做 Developer ID 签名、公证或 x64 打包；本次产物是本机验证用的 arm64、0.0.0、ad-hoc signed build。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `bytedance-seed/*` 的 Codex Responses 请求转换。
- 回滚 / 降级方式：revert 本 PR；其他供应商不经过该转换。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
