### PR TITLE
fix(desktop): 新建对话框留出左右呼吸空间,不再顶满全宽

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -57,7 +57,7 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(source).toContain('pt-[calc(max(96px,28vh)_+_46px_-_var(--content-header-h,46px))]');
     expect(source).not.toContain('pt-[clamp(96px,25.5vh,268px)]');
     // 内容列宽度从死锁 800px 改为跟随 useProportionalWidth 的 inputWidth(与进行中
-    // 对话页同源,封顶 1220px):大屏自适应变宽、发送后同一 ChatInput 无宽度跳变。
+    // 对话页同源,封顶 914+20=934px):大屏留出左右呼吸空间、发送后同一 ChatInput 无宽度跳变。
     expect(source).toContain('relative flex w-full flex-col items-start');
     expect(source).toContain('style={{ maxWidth: inputWidth || 800 }}');
     expect(source).not.toContain('max-w-[800px]');

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -327,8 +327,10 @@ export function NewMakerDraftRoute() {
   const { t } = useTranslation();
   const draft = useNewMakerDraft();
   const navigate = useNavigate();
-  // minWidth=640:自适应内容列在大屏封顶 1220(hook 内 MAX),小屏兜一个体面下限
-  // (与对话页的 max 对称);窄于下限时 hook 自动回落成"填满容器",不溢出。
+  // 首参 914=内容封顶宽(→ inputWidth 封顶 934):大屏留出左右呼吸空间,不再顶满全宽;
+  // 与进行中对话页(CCAgentSessionView 同传 914)一致,发送首条消息时输入框宽度不跳变。
+  // minWidth=640:小屏兜一个体面下限(与对话页对称);窄于下限时 hook 自动回落成
+  // "填满容器",不溢出。
   const { containerRef, inputWidth } = useProportionalWidth(914, { minWidth: 640 });
   // The available rail can shrink when either sidebar opens while the
   // viewport itself remains wide. Keep the draft layout responsive to that
@@ -2074,8 +2076,9 @@ export function NewMakerDraftRoute() {
             <div
               className="relative flex w-full flex-col items-start"
               // 与进行中对话页同源:内容列宽度跟随 useProportionalWidth 算出的
-              // inputWidth(封顶 1220px),不再死锁 800——大屏自适应变宽,且发送后
-              // 同一个 ChatInput 无宽度跳变。inputWidth 由 useLayoutEffect 同步量出
+              // inputWidth(封顶 914+20=934px,见 hook 首参),不再死锁 800——大屏留出
+              // 左右呼吸空间、窄屏自适应收窄,且发送后同一个 ChatInput 无宽度跳变。
+              // inputWidth 由 useLayoutEffect 同步量出
               // (paint 前已就绪);极端未量到(0)时回落旧默认 800,不放大到全宽。
               style={{ maxWidth: inputWidth || 800 }}
             >

--- a/apps/desktop/src/renderer/hooks/useProportionalWidth.ts
+++ b/apps/desktop/src/renderer/hooks/useProportionalWidth.ts
@@ -4,8 +4,12 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react';
  * 主区域内容宽度 hook
  *
  * 同时返回两个宽度：
- *   messageWidth = min(1200, containerWidth - sidePadding*2)   // 普通模式 50px/侧
+ *   messageWidth = min(maxWidth, containerWidth - sidePadding*2)   // 普通模式 50px/侧
  *   inputWidth   = messageWidth + INPUT_OUTSET (输入框每侧少 10px)
+ *
+ * maxWidth 为内容封顶宽（首参）：容器再宽,内容列也不超过它,超出部分靠 mx-auto
+ * 居中留白。不传时回落到 MAX_MESSAGE_WIDTH(1200) 的历史默认。新建对话页与进行中
+ * 对话页传同一个值(914),保证发送首条消息时输入框宽度不跳变,同时左右留出呼吸空间。
  *
  * - 消息流侧 (50px)：MessageStream 是 overflow-y-auto 的原生滚动容器,占满
  *   全宽 containerWidth，内部 contentRef `mx-auto` + `maxWidth=messageWidth`
@@ -30,6 +34,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react';
  *     messageWidth 先扩出去顶过 parent"的中间帧。doc rail 走显式 `compact: true`
  *     仍恒 compact,行为不变。
  */
+// 内容封顶宽的历史默认值:调用方不传首参时回落到它(旧行为)。
 const MAX_MESSAGE_WIDTH = 1200;
 const INPUT_OUTSET = 20; // 输入框比消息流每侧宽 10px（共 20px）
 const DEFAULT_MESSAGE_PAD = 50;
@@ -57,7 +62,7 @@ export interface UseProportionalWidthOptions {
 }
 
 export function useProportionalWidth(
-  _maxWidth?: number,
+  maxWidth?: number,
   opts: UseProportionalWidthOptions = {},
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -83,7 +88,9 @@ export function useProportionalWidth(
       const messagePad = useCompact ? COMPACT_MESSAGE_PAD : DEFAULT_MESSAGE_PAD;
       const nextInputPad = Math.max(0, messagePad - INPUT_OUTSET / 2);
       const messageAvailable = Math.max(0, containerWidth - messagePad * 2);
-      const nextMessage = Math.min(MAX_MESSAGE_WIDTH, messageAvailable);
+      // 首参 maxWidth 为内容封顶宽;非法/未传时回落到历史默认 1200。
+      const cap = maxWidth && maxWidth > 0 ? maxWidth : MAX_MESSAGE_WIDTH;
+      const nextMessage = Math.min(cap, messageAvailable);
       let nextInput = nextMessage + INPUT_OUTSET;
       if (opts.minWidth && opts.minWidth > nextInput) {
         // 地板夹到实测容器宽以内:窄窗仍是"填满容器",不会溢出/裁切。
@@ -94,7 +101,7 @@ export function useProportionalWidth(
       setInputPad(nextInputPad);
       setIsCompact(useCompact);
     },
-    [opts.compact, opts.minWidth],
+    [maxWidth, opts.compact, opts.minWidth],
   );
 
   // useLayoutEffect + 同步量一次:消除 mount 第一帧 width=0 的视觉跳变。


### PR DESCRIPTION
## 这次改了什么

### 摘要

新建对话界面的对话框此前在常见窗口下几乎顶满整个内容区、左右只剩约 50px,缺少呼吸感。根因是 `useProportionalWidth` 的首参(内容封顶宽)是**死代码**——参数名带 `_` 前缀从未被使用,新建对话页与进行中对话页虽然都传了 `914`,却被忽略,实际一直用硬编码的 `1200`(输入框 1220)。在 ~1214px 的内容区上该封顶几乎不生效,于是视觉上顶满整页。

本 PR 把该首参接上作为内容封顶宽(未传时回落历史默认 1200)。两处调用点本就都传 `914`,无需改动:内容列封顶 914、输入框封顶 934,大屏留出左右呼吸空间;窄屏仍走原有 `ResizeObserver` 自适应逻辑跟着收窄。两页共用同一个 914,发送首条消息进入对话页时输入框宽度不跳变(保留既有"无跳变"设计)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:用户反馈"新建对话框不该左右顶满,要有呼吸感,且侧边栏展开时能自适应"
- 本 PR 包含:接上 `useProportionalWidth` 首参并同步过期注释/测试注释
- 明确不包含:不改任何颜色 token、不动 ResizeObserver 自适应与按钮排布逻辑
- 用户可见变化:新建对话框(及进行中对话页)内容列封顶由 1220 → 934px,大屏左右留白;窄屏与侧边栏展开时行为不变
- 是否存在 breaking change:无

### UI 变化

平台:Desktop(macOS)。新建对话界面对话框收窄、左右留出呼吸空间;侧边栏展开时仍自适应收窄、内部按钮排布不受影响。纯宽度调整不涉及颜色,Light/Dark 表现完全一致。

**新建对话界面(收窄后):**

<!-- 把截图拖到这一行下方即可 -->
<img width="3024" height="1718" alt="e7a1d702627f4117e766698865c6cb76372b99464ce54f10e79ba0b62657f590" src="https://github.com/user-attachments/assets/d3dd59d8-4e13-4cc7-a6f2-db70a0d8afc5" />


## 怎么验证的

### 自动验证

```text
pnpm test:unit                                   → EXIT=0, 0 failing
pnpm --filter desktop run --if-present typecheck → EXIT=0
（含 src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts 13 passed）
```

### 手工验证

Desktop dev 模式实机查看:新建对话界面对话框已两侧留白、不再顶满;发送首条消息后输入框宽度无跳变。Light/Dark 均为纯宽度调整,表现一致。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅新建对话页与进行中对话页的内容列/输入框封顶宽度(`useProportionalWidth` 消费方)。
- 回滚 / 降级方式:还原本 PR 3 个文件的改动即可(首参回到被忽略状态,封顶回落 1200)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(同步了代码与测试内注释)
- [x] 已确认测试结果或说明未执行原因
