### PR TITLE
feat(desktop): 设置页资料卡显式展示并缩写用户 ID

### DIFF
--- a/apps/desktop/src/main/__tests__/codexFileRewindExecutor.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRewindExecutor.test.ts
@@ -19,7 +19,12 @@ const REAL_GIT_TEST_TIMEOUT_MS = process.platform === 'win32' ? 60_000 : 20_000;
 let repoPath: string;
 async function initRepo() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'xdt-codex-rewind-'));
-  for (const args of [['init'], ['config', 'user.email', 'test@xdt.local'], ['config', 'user.name', 'XDT Test'], ['config', 'commit.gpgsign', 'false'], ['config', 'core.autocrlf', 'false']]) await gitExec(args, dir);
+  await gitExec(['init'], dir);
+  // 仓库级覆写 core.excludesFile:宿主机全局 gitignore(常见如 *.tmp)会吞掉
+  // 未跟踪文件,让 status 断言在部分开发机上失真。
+  const excludesOverride = path.join(dir, '.git', 'xdt-test-empty-excludes');
+  await fs.writeFile(excludesOverride, '', 'utf8');
+  for (const args of [['config', 'core.excludesFile', excludesOverride], ['config', 'user.email', 'test@xdt.local'], ['config', 'user.name', 'XDT Test'], ['config', 'commit.gpgsign', 'false'], ['config', 'core.autocrlf', 'false']]) await gitExec(args, dir);
   return dir;
 }
 

--- a/apps/desktop/src/renderer/__tests__/userProfileCardCopyUserId.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/userProfileCardCopyUserId.test.tsx
@@ -34,7 +34,11 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    // 带 id 插值的 key(copyUserId.display)拼上实际值,便于断言 ID 真的渲染了出来。
+    t: (key: string, params?: Record<string, unknown>) =>
+      params && 'id' in params ? `${key}:${String(params.id)}` : key,
+  }),
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({
@@ -85,19 +89,42 @@ describe('UserProfileCard copy user ID', () => {
     vi.clearAllMocks();
   });
 
-  it('copies the user ID and shows a success toast when the name is clicked', async () => {
+  it('shows the user ID and copies it with a success toast when the ID row is clicked', async () => {
     renderCard();
 
-    const nameButton = screen.getByRole('button', {
+    // ID 显式展示在卡片上,且名字本身不再是可点击控件。
+    expect(screen.getByText('settings.userProfile.copyUserId.display:user-123')).toBeTruthy();
+    expect(screen.getByText('Lizi').closest('button')).toBeNull();
+
+    const idButton = screen.getByRole('button', {
       name: 'settings.userProfile.copyUserId.action',
     });
-    expect(nameButton.className).toContain('cursor-pointer');
-    expect(nameButton.className).toContain('hover:bg-[var(--settings-profile-avatar-bg)]');
+    expect(idButton.className).toContain('cursor-pointer');
+    expect(idButton.className).toContain('hover:bg-[var(--settings-profile-avatar-bg)]');
 
-    fireEvent.click(nameButton);
+    fireEvent.click(idButton);
 
     await waitFor(() => expect(mocks.writeText).toHaveBeenCalledWith('user-123'));
     expect(mocks.toastSuccess).toHaveBeenCalledWith('settings.userProfile.copyUserId.success');
+  });
+
+  it('abbreviates a long user ID in the display while copying the full value', async () => {
+    mocks.authState.user!.id = 'mem_0123456789abcdef0123456789abcdef';
+    renderCard();
+
+    // 展示只露头 6 + 尾 4,完整值不直接渲染。
+    expect(screen.getByText('settings.userProfile.copyUserId.display:mem_01…cdef')).toBeTruthy();
+    expect(
+      screen.queryByText(
+        'settings.userProfile.copyUserId.display:mem_0123456789abcdef0123456789abcdef',
+      ),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.userProfile.copyUserId.action' }));
+
+    await waitFor(() =>
+      expect(mocks.writeText).toHaveBeenCalledWith('mem_0123456789abcdef0123456789abcdef'),
+    );
   });
 
   it('opens the profile edit dialog when the avatar is clicked', () => {

--- a/apps/desktop/src/renderer/__tests__/userProfileCardCopyUserId.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/userProfileCardCopyUserId.test.tsx
@@ -101,6 +101,14 @@ describe('UserProfileCard copy user ID', () => {
     });
     expect(idButton.className).toContain('cursor-pointer');
     expect(idButton.className).toContain('hover:bg-[var(--settings-profile-avatar-bg)]');
+    // 交互件圆角走 pill 档(DESIGN.md Border Radius Scale,无 6px 档)。
+    expect(idButton.className).toContain('rounded-full');
+    // 可见 ID 经 aria-describedby 暴露给辅助技术(aria-label 只承载动作名)。
+    const describedById = idButton.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+    expect(document.getElementById(describedById!)?.textContent).toBe(
+      'settings.userProfile.copyUserId.display:user-123',
+    );
 
     fireEvent.click(idButton);
 

--- a/apps/desktop/src/renderer/components/settings/UserProfileCard.tsx
+++ b/apps/desktop/src/renderer/components/settings/UserProfileCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Building2, Copy, Pencil } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -36,6 +36,9 @@ export function UserProfileCard() {
   const [orgLogoError, setOrgLogoError] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const { t } = useTranslation();
+  // aria-label(动作)会覆盖子文本作为可访问名称;可见的 ID 文本经 aria-describedby
+  // 暴露给辅助技术,让读屏用户复制前也能核对 ID。
+  const userIdDescriptionId = useId();
 
   // 换头像(服务端资料更新)后给新地址重试的机会,
   // 不让一次历史加载失败永远钉死在首字母兜底上。
@@ -164,15 +167,16 @@ export function UserProfileCard() {
           type="button"
           onClick={() => void handleCopyUserId()}
           aria-label={t('settings.userProfile.copyUserId.action')}
+          aria-describedby={userIdDescriptionId}
           title={t('settings.userProfile.copyUserId.action')}
           className={cn(
-            '-ml-1.5 mt-0.5 flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 text-left',
+            '-ml-1.5 mt-0.5 flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-full px-1.5 py-0.5 text-left',
             'text-12 text-[var(--text-tertiary)] transition-colors',
             'hover:bg-[var(--settings-profile-avatar-bg)] hover:text-[var(--text-secondary)]',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]',
           )}
         >
-          <span className="min-w-0 truncate">
+          <span id={userIdDescriptionId} className="min-w-0 truncate">
             {t('settings.userProfile.copyUserId.display', { id: abbreviateUserId(user.id) })}
           </span>
           <Copy aria-hidden="true" size={11} className="shrink-0" />

--- a/apps/desktop/src/renderer/components/settings/UserProfileCard.tsx
+++ b/apps/desktop/src/renderer/components/settings/UserProfileCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Building2, Pencil } from 'lucide-react';
+import { Building2, Copy, Pencil } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { cn } from '@/lib/utils';
@@ -22,6 +22,11 @@ function isOrganizationRole(role: string): role is OrganizationRole {
 
 function getOrganizationRoleI18nKey(role: string) {
   return ORGANIZATION_ROLE_I18N_KEYS[isOrganizationRole(role) ? role : 'member'];
+}
+
+// 展示用缩写:长 ID 只露头尾便于目视比对,点击复制的仍是完整值。
+function abbreviateUserId(id: string): string {
+  return id.length > 14 ? `${id.slice(0, 6)}…${id.slice(-4)}` : id;
 }
 
 export function UserProfileCard() {
@@ -150,22 +155,27 @@ export function UserProfileCard() {
         )}
       </button>
 
-      {/* User name — 点击复制用户 ID;hover / cursor 明示可交互。 */}
       <div className="min-w-0 flex-1">
+        <p className="min-w-0 truncate text-18 font-medium leading-[1.2] text-[var(--settings-profile-name)]">
+          {displayName}
+        </p>
+        {/* User ID — 显式展示,整行点击复制;常驻小图标明示可复制。 */}
         <button
           type="button"
           onClick={() => void handleCopyUserId()}
           aria-label={t('settings.userProfile.copyUserId.action')}
           title={t('settings.userProfile.copyUserId.action')}
           className={cn(
-            '-ml-2 flex min-w-0 max-w-full cursor-pointer items-center rounded-lg px-2 py-1 text-left',
-            'transition-colors hover:bg-[var(--settings-profile-avatar-bg)]',
+            '-ml-1.5 mt-0.5 flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 text-left',
+            'text-12 text-[var(--text-tertiary)] transition-colors',
+            'hover:bg-[var(--settings-profile-avatar-bg)] hover:text-[var(--text-secondary)]',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]',
           )}
         >
-          <span className="min-w-0 truncate text-18 font-medium leading-[1.2] text-[var(--settings-profile-name)]">
-            {displayName}
+          <span className="min-w-0 truncate">
+            {t('settings.userProfile.copyUserId.display', { id: abbreviateUserId(user.id) })}
           </span>
+          <Copy aria-hidden="true" size={11} className="shrink-0" />
         </button>
         {organizationName && organizationRole && (
           <div className="mt-1 flex min-w-0 items-center gap-1.5 text-sm leading-5 text-[var(--text-secondary)]">

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -556,6 +556,7 @@
       },
       "copyUserId": {
         "action": "Copy user ID",
+        "display": "ID: {{id}}",
         "success": "User ID copied",
         "failed": "Failed to copy user ID"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -556,6 +556,7 @@
       },
       "copyUserId": {
         "action": "ユーザー ID をコピー",
+        "display": "ID: {{id}}",
         "success": "ユーザー ID をコピーしました",
         "failed": "ユーザー ID をコピーできませんでした"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -556,6 +556,7 @@
       },
       "copyUserId": {
         "action": "사용자 ID 복사",
+        "display": "ID: {{id}}",
         "success": "사용자 ID를 복사했습니다",
         "failed": "사용자 ID를 복사하지 못했습니다"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -556,6 +556,7 @@
       },
       "copyUserId": {
         "action": "复制用户 ID",
+        "display": "ID：{{id}}",
         "success": "用户 ID 已复制",
         "failed": "复制用户 ID 失败"
       },


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置页用户资料卡此前是「点击名字复制用户 ID」的隐性交互，ID 本身不可见。本 PR 把名字恢复为纯文本，将 ID（auth-server membership ID）以单独一行显式展示：长 ID 缩写为「头 6 + … + 尾 4」（≤14 字符原样显示），点击整行复制**完整** ID，并常驻 Copy 小图标明示可复制。`copyUserId.display` 文案四语（en / ja / ko / zh-CN）同步补齐。

另附带一笔测试环境健壮性修复：`codexFileRewindExecutor` 测试的临时仓库以仓库级 `core.excludesFile` 覆写宿主机全局 gitignore。部分开发机全局忽略 `*.tmp`，会吞掉测试断言依赖的未跟踪文件 `scratch.tmp`，导致本地提交门禁（`pnpm test:unit`）失败；该修复是本 PR 能通过本地门禁的前置条件，故合并提交。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：设置页资料卡 ID 展示与复制交互调整（组件、单测、四语文案）；`codexFileRewindExecutor.test.ts` 对宿主全局 gitignore 的隔离。
- 明确不包含：设置页其它区域；服务端；`passportId` 的展示。
- 用户可见变化：资料卡名字下方新增一行「ID：xxxxxx…xxxx」，可点击复制完整 ID；名字不再是可点击控件。
- 是否存在 breaking change：无

### UI 变化

macOS CN remote dev 实例验证。ID 行为 12px 三级文本色，hover 提亮并带背景，颜色全部复用既有语义 token（`--text-tertiary` / `--settings-profile-avatar-bg` / `--focus-ring-soft`），无新增颜色值，Light / Dark 随主题生效。未附截图（见「未执行的验证」）。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部通过（26 个 workspace PASS，6 个 SKIP 为无可收集测试）
pnpm --filter desktop run typecheck
结果：通过
pnpm --filter desktop exec vitest run src/renderer/__tests__/userProfileCardCopyUserId.test.tsx
结果：8/8 通过（含新增「长 ID 显示缩写、复制完整值」用例）
pnpm --filter desktop exec vitest run src/main/__tests__/codexFileRewindExecutor.test.ts
结果：12/12 通过（修复前 1 例在全局 gitignore 含 *.tmp 的机器上失败）
```

### 手工验证

macOS、CN remote dev 实例：确认资料卡 ID 行渲染及点击复制（在加入缩写逻辑之前走查）；缩写后的展示由 HMR 生效，未再次人工走查。

### 未执行的验证

- Light / Dark 双模式截图走查未执行：本次未新增任何颜色值，仅复用既有语义 token，双模式由 token 体系保证；如需可在 review 时补截图。
- Windows 未验证：纯 renderer 文本行改动，无平台分支逻辑。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：设置页用户资料卡展示与复制交互；一个 main 侧测试文件的初始化方式（不影响被测逻辑）。
- 回滚 / 降级方式：revert 本 PR 即可，无数据或协议影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
