### PR TITLE
fix(desktop): renew expiring plugin icons

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/GhostPluginIcon.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginIcon.tsx
@@ -61,11 +61,13 @@ export function GhostPluginIcon({
   iconDataUrl,
   iconId,
   iconName,
+  onIconLoadError,
   size = 'md',
 }: {
   iconDataUrl?: string;
   iconId: string;
   iconName: string;
+  onIconLoadError?: () => void;
   size?: GhostPluginIconSize;
 }) {
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
@@ -93,7 +95,10 @@ export function GhostPluginIcon({
           alt=""
           draggable={false}
           referrerPolicy="no-referrer"
-          onError={() => setFailedSrc(resolvedIconDataUrl)}
+          onError={() => {
+            setFailedSrc(resolvedIconDataUrl);
+            onIconLoadError?.();
+          }}
           className={cn(
             svg ? SVG_ICON_CLASSES[size] : 'size-full object-cover',
             iconId === 'cindy-github' && 'plugin-icon--github',

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -109,7 +109,14 @@ export function GhostPluginPage() {
     const requestId = ++marketRefreshRequestRef.current;
     try {
       const snapshot = await window.electronAPI.pluginMarket.snapshot();
-      if (requestId === marketRefreshRequestRef.current) setMarketSnapshot(snapshot);
+      if (requestId !== marketRefreshRequestRef.current) return;
+      // Main intentionally represents market outages as data so the initial page can render a
+      // non-blocking empty state. During icon renewal, convert that fulfilled unavailable result
+      // back into a failure: the catch path preserves the visible snapshot and the hook retries.
+      if (preserveOnError && snapshot.unavailableReason !== null) {
+        throw new Error(snapshot.unavailableReason);
+      }
+      setMarketSnapshot(snapshot);
     } catch (error) {
       if (requestId !== marketRefreshRequestRef.current) return;
       setMarketSnapshot((current) =>

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -111,16 +111,18 @@ export function GhostPluginPage() {
       const snapshot = await window.electronAPI.pluginMarket.snapshot();
       if (requestId === marketRefreshRequestRef.current) setMarketSnapshot(snapshot);
     } catch (error) {
-      if (requestId === marketRefreshRequestRef.current) {
-        setMarketSnapshot((current) =>
-          preserveOnError && current
-            ? current
-            : {
-                items: [],
-                unavailableReason: error instanceof Error ? error.message : String(error),
-              },
-        );
-      }
+      if (requestId !== marketRefreshRequestRef.current) return;
+      setMarketSnapshot((current) =>
+        preserveOnError && current
+          ? current
+          : {
+              items: [],
+              unavailableReason: error instanceof Error ? error.message : String(error),
+            },
+      );
+      // Background icon renewal keeps the current snapshot visible, but must still report
+      // failure to the renewal hook so it can schedule a bounded retry.
+      if (preserveOnError) throw error;
     }
   }, []);
   useEffect(() => {
@@ -516,13 +518,16 @@ export function GhostPluginPage() {
   );
 
   const refreshVisibleMarketDetail = useCallback(async (pluginId: string) => {
-    const requestId = ++marketDetailRequestRef.current;
+    // A background icon renewal may observe navigation, but must never invalidate a
+    // user-initiated detail request by advancing its request generation.
+    const requestId = marketDetailRequestRef.current;
     try {
       const detail = await window.electronAPI.pluginMarket.detail(pluginId);
       if (requestId !== marketDetailRequestRef.current) return;
       setMarketDetail((current) => (current?.pluginId === pluginId ? detail : current));
-    } catch {
+    } catch (error) {
       // A background URL renewal must not close an otherwise usable detail page.
+      if (requestId === marketDetailRequestRef.current) throw error;
     }
   }, []);
   const visibleMarketIcons = useMemo(

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -67,6 +67,7 @@ import {
   type PluginPresentationOrigin,
 } from './lib/pluginMarketPresentation';
 import { pluginMarketErrorKey } from './lib/pluginMarketErrorKey';
+import { usePluginIconRefresh } from './lib/usePluginIconRefresh';
 import './plugin-motion.css';
 
 const MAX_VISIBLE_INSTALLED_GHOSTS = 5;
@@ -104,17 +105,21 @@ export function GhostPluginPage() {
   const [marketBusyId, setMarketBusyId] = useState<string | null>(null);
   const marketRefreshRequestRef = useRef(0);
   const marketDetailRequestRef = useRef(0);
-  const refreshMarket = useCallback(async () => {
+  const refreshMarket = useCallback(async (preserveOnError = false) => {
     const requestId = ++marketRefreshRequestRef.current;
     try {
       const snapshot = await window.electronAPI.pluginMarket.snapshot();
       if (requestId === marketRefreshRequestRef.current) setMarketSnapshot(snapshot);
     } catch (error) {
       if (requestId === marketRefreshRequestRef.current) {
-        setMarketSnapshot({
-          items: [],
-          unavailableReason: error instanceof Error ? error.message : String(error),
-        });
+        setMarketSnapshot((current) =>
+          preserveOnError && current
+            ? current
+            : {
+                items: [],
+                unavailableReason: error instanceof Error ? error.message : String(error),
+              },
+        );
       }
     }
   }, []);
@@ -510,6 +515,32 @@ export function GhostPluginPage() {
     [t],
   );
 
+  const refreshVisibleMarketDetail = useCallback(async (pluginId: string) => {
+    const requestId = ++marketDetailRequestRef.current;
+    try {
+      const detail = await window.electronAPI.pluginMarket.detail(pluginId);
+      if (requestId !== marketDetailRequestRef.current) return;
+      setMarketDetail((current) => (current?.pluginId === pluginId ? detail : current));
+    } catch {
+      // A background URL renewal must not close an otherwise usable detail page.
+    }
+  }, []);
+  const visibleMarketIcons = useMemo(
+    () => [...marketItems.map((item) => item.icon), marketDetail?.icon],
+    [marketDetail?.icon, marketItems],
+  );
+  const refreshVisibleMarketIcons = useCallback(async () => {
+    const refreshes: Promise<void>[] = [refreshMarket(true)];
+    if (marketDetail?.pluginId) {
+      refreshes.push(refreshVisibleMarketDetail(marketDetail.pluginId));
+    }
+    await Promise.all(refreshes);
+  }, [marketDetail?.pluginId, refreshMarket, refreshVisibleMarketDetail]);
+  const handleMarketIconLoadError = usePluginIconRefresh(
+    visibleMarketIcons,
+    refreshVisibleMarketIcons,
+  );
+
   const handleInstallFromMarket = useCallback(async () => {
     if (!marketDetail) return;
     const confirmed = await confirm({
@@ -550,6 +581,7 @@ export function GhostPluginPage() {
           setMarketDetail(null);
         }}
         onInstall={() => void handleInstallFromMarket()}
+        onIconLoadError={handleMarketIconLoadError}
       />
     );
   }
@@ -777,6 +809,7 @@ export function GhostPluginPage() {
                     item={item}
                     busy={marketBusyId === item.pluginId}
                     onSelect={() => void handleSelectMarket(item.pluginId)}
+                    onIconLoadError={handleMarketIconLoadError}
                   />
                 ))}
               </div>
@@ -805,10 +838,12 @@ function MarketPluginCard({
   item,
   busy,
   onSelect,
+  onIconLoadError,
 }: {
   item: PluginMarketItem;
   busy: boolean;
   onSelect: () => void;
+  onIconLoadError: () => void;
 }) {
   const { t } = useTranslation();
   return (
@@ -831,6 +866,7 @@ function MarketPluginCard({
           iconDataUrl={item.icon?.url}
           iconId={item.ghostId}
           iconName={item.name}
+          onIconLoadError={onIconLoadError}
         />
         <span className="flex min-w-0 flex-1 flex-col self-stretch pt-0.5">
           <span className="flex min-w-0 items-center gap-2">

--- a/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
@@ -13,6 +13,7 @@ interface MarketPluginDetailViewProps {
   busy: boolean;
   onBack: () => void;
   onInstall: () => void;
+  onIconLoadError: () => void;
 }
 /** 尚未安装的市场 Plugin 详情；只展示协议事实，不创建 renderer 侧安装逻辑。 */
 export function MarketPluginDetailView({
@@ -20,6 +21,7 @@ export function MarketPluginDetailView({
   busy,
   onBack,
   onInstall,
+  onIconLoadError,
 }: MarketPluginDetailViewProps) {
   const { t } = useTranslation();
   const permissions = ghostPermissionItems(detail.manifest);
@@ -54,6 +56,7 @@ export function MarketPluginDetailView({
               iconDataUrl={detail.icon?.url}
               iconId={detail.ghostId}
               iconName={detail.name}
+              onIconLoadError={onIconLoadError}
               size="detail"
             />
             <div className="min-w-0">

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginIcon.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginIcon.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * Regression coverage for signed Plugin icon failure and recovery.
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GhostPluginIcon } from '../GhostPluginIcon';
+
+describe('GhostPluginIcon', () => {
+  it('requests metadata renewal after a signed URL fails and accepts the replacement URL', () => {
+    const onIconLoadError = vi.fn();
+    const { container, rerender } = render(
+      <GhostPluginIcon
+        iconDataUrl="https://oss.example/old-icon?signature=old"
+        iconId="cindy-github"
+        iconName="Cindy GitHub"
+        onIconLoadError={onIconLoadError}
+      />,
+    );
+
+    fireEvent.error(container.querySelector('img')!);
+    expect(onIconLoadError).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('img')).toBeNull();
+
+    rerender(
+      <GhostPluginIcon
+        iconDataUrl="https://oss.example/new-icon?signature=new"
+        iconId="cindy-github"
+        iconName="Cindy GitHub"
+        onIconLoadError={onIconLoadError}
+      />,
+    );
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://oss.example/new-icon?signature=new',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginIconRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginIconRefresh.test.tsx
@@ -73,6 +73,32 @@ describe('usePluginIconRefresh', () => {
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 
+  it('retries a failed scheduled renewal after a bounded delay', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const refresh = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValue(undefined);
+
+    renderHook(() => usePluginIconRefresh([icon(START_MS + 60_000)], refresh));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(29_999);
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
   it('deduplicates concurrent image failures and cools down retries', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(START_MS);

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginIconRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginIconRefresh.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Regression coverage for renewing short-lived Plugin market icon URLs.
+ * @vitest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { earliestPluginIconRefreshAtMs, usePluginIconRefresh } from '../usePluginIconRefresh';
+
+const START_MS = Date.parse('2026-07-25T00:00:00.000Z');
+
+function icon(expiresAtMs: number): { expiresAt: string } {
+  return { expiresAt: new Date(expiresAtMs).toISOString() };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('earliestPluginIconRefreshAtMs', () => {
+  it('renews thirty seconds before the earliest valid icon expiry', () => {
+    expect(
+      earliestPluginIconRefreshAtMs([
+        icon(START_MS + 300_000),
+        icon(START_MS + 120_000),
+        { expiresAt: 'invalid' },
+        null,
+      ]),
+    ).toBe(START_MS + 90_000);
+  });
+
+  it('returns null when no signed icon is visible', () => {
+    expect(earliestPluginIconRefreshAtMs([null, undefined])).toBeNull();
+  });
+});
+
+describe('usePluginIconRefresh', () => {
+  it('uses one timer to renew visible icons before expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const refresh = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => usePluginIconRefresh([icon(START_MS + 300_000)], refresh));
+
+    await act(async () => {
+      vi.advanceTimersByTime(269_999);
+      await Promise.resolve();
+    });
+    expect(refresh).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('renews an overdue icon when the renderer becomes visible again', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+
+    renderHook(() => usePluginIconRefresh([icon(START_MS + 60_000)], refresh));
+    vi.setSystemTime(START_MS + 31_000);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates concurrent image failures and cools down retries', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    let finishRefresh: (() => void) | undefined;
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRefresh = resolve;
+        }),
+    );
+    const { result } = renderHook(() => usePluginIconRefresh([], refresh));
+
+    await act(async () => {
+      result.current();
+      result.current();
+      await Promise.resolve();
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      finishRefresh?.();
+      await Promise.resolve();
+    });
+    result.current();
+    await Promise.resolve();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(START_MS + 30_001);
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+    });
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/renderer/features/plugin/lib/usePluginIconRefresh.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/usePluginIconRefresh.ts
@@ -1,0 +1,73 @@
+import type { PluginIconMetadata } from '@cindy/plugin-protocol';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+const ICON_REFRESH_LEAD_MS = 30_000;
+const ICON_REFRESH_MIN_DELAY_MS = 1_000;
+const ICON_ERROR_RECOVERY_COOLDOWN_MS = 30_000;
+
+type ExpiringPluginIcon = Pick<PluginIconMetadata, 'expiresAt'> | null | undefined;
+
+/**
+ * Finds the first time at which any visible signed icon should be renewed.
+ * Invalid timestamps are ignored defensively; protocol parsing normally rejects them earlier.
+ */
+export function earliestPluginIconRefreshAtMs(icons: readonly ExpiringPluginIcon[]): number | null {
+  let earliestRefreshAt = Number.POSITIVE_INFINITY;
+  for (const icon of icons) {
+    if (!icon) continue;
+    const expiresAt = Date.parse(icon.expiresAt);
+    if (!Number.isFinite(expiresAt)) continue;
+    earliestRefreshAt = Math.min(earliestRefreshAt, expiresAt - ICON_REFRESH_LEAD_MS);
+  }
+  return Number.isFinite(earliestRefreshAt) ? earliestRefreshAt : null;
+}
+
+/**
+ * Keeps short-lived market icon URLs renewed with one page-level timer.
+ * The returned error handler shares the same in-flight request and applies a cooldown so a
+ * missing OSS object cannot create a refresh loop when each response has a new signature.
+ */
+export function usePluginIconRefresh(
+  icons: readonly ExpiringPluginIcon[],
+  refresh: () => void | Promise<void>,
+): () => void {
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+  const inFlightRef = useRef<Promise<void> | null>(null);
+  const lastErrorRecoveryAtRef = useRef(Number.NEGATIVE_INFINITY);
+  const refreshAtMs = useMemo(() => earliestPluginIconRefreshAtMs(icons), [icons]);
+
+  const requestRefresh = useCallback(() => {
+    if (inFlightRef.current) return;
+    const request = Promise.resolve().then(() => refreshRef.current());
+    inFlightRef.current = request;
+    void request
+      .catch(() => undefined)
+      .finally(() => {
+        if (inFlightRef.current === request) inFlightRef.current = null;
+      });
+  }, []);
+
+  useEffect(() => {
+    if (refreshAtMs === null) return;
+    const delayMs = Math.max(ICON_REFRESH_MIN_DELAY_MS, refreshAtMs - Date.now());
+    const timer = window.setTimeout(requestRefresh, delayMs);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && refreshAtMs <= Date.now()) {
+        requestRefresh();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [refreshAtMs, requestRefresh]);
+
+  return useCallback(() => {
+    const now = Date.now();
+    if (now - lastErrorRecoveryAtRef.current < ICON_ERROR_RECOVERY_COOLDOWN_MS) return;
+    lastErrorRecoveryAtRef.current = now;
+    requestRefresh();
+  }, [requestRefresh]);
+}

--- a/apps/desktop/src/renderer/features/plugin/lib/usePluginIconRefresh.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/usePluginIconRefresh.ts
@@ -1,9 +1,10 @@
 import type { PluginIconMetadata } from '@cindy/plugin-protocol';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const ICON_REFRESH_LEAD_MS = 30_000;
 const ICON_REFRESH_MIN_DELAY_MS = 1_000;
 const ICON_ERROR_RECOVERY_COOLDOWN_MS = 30_000;
+const ICON_REFRESH_RETRY_DELAY_MS = 30_000;
 
 type ExpiringPluginIcon = Pick<PluginIconMetadata, 'expiresAt'> | null | undefined;
 
@@ -35,6 +36,7 @@ export function usePluginIconRefresh(
   refreshRef.current = refresh;
   const inFlightRef = useRef<Promise<void> | null>(null);
   const lastErrorRecoveryAtRef = useRef(Number.NEGATIVE_INFINITY);
+  const [retryAtMs, setRetryAtMs] = useState<number | null>(null);
   const refreshAtMs = useMemo(() => earliestPluginIconRefreshAtMs(icons), [icons]);
 
   const requestRefresh = useCallback(() => {
@@ -42,7 +44,10 @@ export function usePluginIconRefresh(
     const request = Promise.resolve().then(() => refreshRef.current());
     inFlightRef.current = request;
     void request
-      .catch(() => undefined)
+      .then(
+        () => setRetryAtMs(null),
+        () => setRetryAtMs(Date.now() + ICON_REFRESH_RETRY_DELAY_MS),
+      )
       .finally(() => {
         if (inFlightRef.current === request) inFlightRef.current = null;
       });
@@ -50,10 +55,11 @@ export function usePluginIconRefresh(
 
   useEffect(() => {
     if (refreshAtMs === null) return;
-    const delayMs = Math.max(ICON_REFRESH_MIN_DELAY_MS, refreshAtMs - Date.now());
+    const scheduledAtMs = retryAtMs ?? refreshAtMs;
+    const delayMs = Math.max(ICON_REFRESH_MIN_DELAY_MS, scheduledAtMs - Date.now());
     const timer = window.setTimeout(requestRefresh, delayMs);
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible' && refreshAtMs <= Date.now()) {
+      if (document.visibilityState === 'visible' && scheduledAtMs <= Date.now()) {
         requestRefresh();
       }
     };
@@ -62,7 +68,7 @@ export function usePluginIconRefresh(
       window.clearTimeout(timer);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [refreshAtMs, requestRefresh]);
+  }, [refreshAtMs, requestRefresh, retryAtMs]);
 
   return useCallback(() => {
     const now = Date.now();


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Plugin 市场图标在页面放置约 5 分钟后消失的问题。

plugin-server 下发的 icon 是短期 OSS 签名 URL，并通过 `expiresAt` 明确有效期；客户端此前只在进入页面、账号变化或安装操作后刷新市场快照，没有消费该到期时间。URL 过期后，图片一旦因页面重载、应用休眠或缓存回收而重新请求，就会失败并退回默认图标。

本 PR 在客户端按 `expiresAt` 提前续签，同时保留图片失败时的有界恢复路径。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#256 合并后的 Plugin 市场 icon 长时间展示稳定性跟进。
- 本 PR 包含：
  - 按当前页面最早的 `icon.expiresAt`，提前 30 秒刷新市场 icon 元数据。
  - Renderer 从后台恢复时，若签名已进入续签窗口则立即刷新。
  - 图片加载失败时使用同一刷新入口，并通过 in-flight 去重和 30 秒冷却避免多个图片同时失败或 OSS 对象缺失造成请求风暴。
  - 列表与当前打开的市场详情同时更新签名 URL。
  - 后台续签失败时保留当前市场内容，不因一次瞬时网络错误清空页面。
  - 补充定时续签、后台恢复、并发失败去重、冷却和新 URL 恢复测试。
- 明确不包含：
  - plugin-server、OSS TTL、Plugin Protocol、数据库 migration、环境变量或 endpoint 调整。
  - Plugin 页面布局、样式、文案或产品流程改造。
- 用户可见变化：市场 icon 长时间停留、应用休眠恢复或缓存重载后仍能持续显示；正常状态下页面视觉不变。
- 是否存在 breaking change：无。

### UI 变化

平台：Electron desktop（跨平台 renderer 行为）。

没有布局或样式变化，仅修复同一图标节点在签名 URL 轮换后的持续展示：

```html
<!-- 修复前：旧签名到期并重新加载后只能显示 fallback -->
<span class="plugin-icon"><svg aria-hidden="true"><!-- fallback --></svg></span>

<!-- 修复后：到期前取得新签名，图标节点继续显示原图 -->
<span class="plugin-icon">
  <img src="https://oss.example/icon?signature=renewed" referrerpolicy="no-referrer" />
</span>
```

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/plugin
结果：9 个测试文件、43 项测试全部通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm --filter desktop exec eslint \
  src/renderer/features/plugin/GhostPluginIcon.tsx \
  src/renderer/features/plugin/GhostPluginPage.tsx \
  src/renderer/features/plugin/MarketPluginDetailView.tsx \
  src/renderer/features/plugin/lib/usePluginIconRefresh.ts \
  src/renderer/features/plugin/lib/__tests__/usePluginIconRefresh.test.tsx \
  src/renderer/features/plugin/__tests__/GhostPluginIcon.test.tsx
结果：通过。

git diff --check
结果：通过。
```

### 手工验证

- 在 macOS Electron production endpoint 环境复现并确认根因：
  - `https://plugin.cindy.com.cn/api/plugins` 返回的 icon URL 带 OSS `Expires`。
  - 实测签名有效期为 300 秒，与返回的 `icon.expiresAt` 一致。
  - 旧客户端长时间停留后会在图片重新请求失败时切换到 fallback。

### 未执行的验证

- 尚未用本 PR 分支执行持续 5 分钟的 Electron 黑盒验收；自动测试使用 fake timer 覆盖提前续签、后台恢复与错误恢复完整时序。
- 未执行 desktop 全仓 ESLint；当前主线存在 67 个与本 PR 无关的既有错误。本 PR 涉及文件已单独执行 ESLint 并通过。
- 未在 Windows / Linux 上执行手工 UI 验收；本次没有平台 API 或样式差异，逻辑位于共享 renderer。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：后台定时刷新与瞬时网络失败处理

### 影响与回滚

- 影响范围：desktop Plugin 市场列表、市场详情及共享 Plugin icon renderer；本地插件图标不触发远程刷新。
- 网络影响：页面挂载期间每批签名 URL 只维护一个定时器，默认约每 4.5 分钟刷新一次；多个图片失败共用一个 in-flight 请求，并有冷却保护。
- 失败行为：后台续签失败时保留现有市场快照；图片仍可按原逻辑回退默认图标，不阻断插件浏览、安装或使用。
- 跨平台差异：使用标准 React effect、`setTimeout` 和 `visibilitychange`，无平台专用实现；手工验收仅在 macOS 完成。
- 回滚 / 降级方式：回滚本 PR 即恢复 #256 的原有行为；不涉及持久化数据、数据库或服务端回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
