### PR TITLE
feat(desktop): 展示商品目录销售状态

### DIFF
--- a/apps/desktop/src/main/billing/__tests__/projection.test.ts
+++ b/apps/desktop/src/main/billing/__tests__/projection.test.ts
@@ -323,6 +323,114 @@ describe('billing response projection', () => {
     });
   });
 
+  it('keeps server-visible unavailable offers and rejects inconsistent availability fields', () => {
+    const projected = projectBillingCatalog({
+      products: [
+        {
+          code: 'subscription',
+          name: 'Subscription',
+          kind: 'SUBSCRIPTION',
+          level: 1,
+          sortOrder: 1,
+          offers: [
+            {
+              code: 'coming_soon',
+              salesState: 'COMING_SOON',
+              purchasable: false,
+              unavailableReason: 'OFFER_COMING_SOON',
+              interval: 'MONTH',
+              currency: 'usd',
+              amount: '9',
+              minAmount: null,
+              maxAmount: null,
+              creditAmount: '100',
+              rolloverCap: '0',
+              purchaseOptions: [],
+            },
+            {
+              code: 'no_available_channel',
+              salesState: 'AVAILABLE',
+              purchasable: false,
+              unavailableReason: 'NO_AVAILABLE_PAYMENT_CHANNEL',
+              interval: 'MONTH',
+              currency: 'usd',
+              amount: '19',
+              minAmount: null,
+              maxAmount: null,
+              creditAmount: '250',
+              rolloverCap: '0',
+              purchaseOptions: [],
+            },
+            {
+              code: 'available',
+              salesState: 'AVAILABLE',
+              purchasable: true,
+              unavailableReason: null,
+              interval: 'MONTH',
+              currency: 'usd',
+              amount: '25',
+              minAmount: null,
+              maxAmount: null,
+              creditAmount: '350',
+              rolloverCap: '0',
+              purchaseOptions: [
+                {
+                  id: 'listing_stripe',
+                  provider: 'stripe',
+                  capability: 'PROVIDER_MANAGED_SUBSCRIPTION',
+                  paymentAction: 'REDIRECT',
+                },
+              ],
+            },
+            {
+              code: 'inconsistent',
+              salesState: 'COMING_SOON',
+              purchasable: true,
+              unavailableReason: null,
+              interval: 'MONTH',
+              currency: 'usd',
+              amount: '29',
+              minAmount: null,
+              maxAmount: null,
+              creditAmount: '500',
+              rolloverCap: '0',
+              purchaseOptions: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(projected.products[0]?.offers).toEqual([
+      expect.objectContaining({
+        code: 'coming_soon',
+        salesState: 'COMING_SOON',
+        purchasable: false,
+        unavailableReason: 'OFFER_COMING_SOON',
+        purchaseOptions: [],
+      }),
+      expect.objectContaining({
+        code: 'no_available_channel',
+        salesState: 'AVAILABLE',
+        purchasable: false,
+        unavailableReason: 'NO_AVAILABLE_PAYMENT_CHANNEL',
+        purchaseOptions: [],
+      }),
+      expect.objectContaining({
+        code: 'available',
+        salesState: 'AVAILABLE',
+        purchasable: true,
+        unavailableReason: null,
+        purchaseOptions: [
+          expect.objectContaining({
+            id: 'listing_stripe',
+            provider: 'stripe',
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it('enforces the server contract that offer codes are globally unique', () => {
     const purchaseOption = {
       id: 'listing_stripe',

--- a/apps/desktop/src/main/billing/projection.ts
+++ b/apps/desktop/src/main/billing/projection.ts
@@ -439,9 +439,63 @@ function projectOffer(
       optionIds.add(option.id);
       return true;
     });
-  if (purchaseOptions.length === 0) return null;
+  const hasAvailabilityProjection =
+    value.salesState !== undefined ||
+    value.purchasable !== undefined ||
+    value.unavailableReason !== undefined;
+  let availability: Pick<BillingCatalogOffer, 'salesState' | 'purchasable' | 'unavailableReason'> =
+    {};
+  if (hasAvailabilityProjection) {
+    const salesState =
+      value.salesState === 'COMING_SOON' || value.salesState === 'AVAILABLE'
+        ? value.salesState
+        : null;
+    const purchasable = typeof value.purchasable === 'boolean' ? value.purchasable : null;
+    const unavailableReason =
+      value.unavailableReason === null ||
+      value.unavailableReason === 'OFFER_COMING_SOON' ||
+      value.unavailableReason === 'NO_AVAILABLE_PAYMENT_CHANNEL'
+        ? value.unavailableReason
+        : undefined;
+    if (salesState === 'COMING_SOON') {
+      if (
+        purchasable !== false ||
+        unavailableReason !== 'OFFER_COMING_SOON' ||
+        value.purchaseOptions.length !== 0
+      ) {
+        return null;
+      }
+      availability = {
+        salesState,
+        purchasable: false,
+        unavailableReason: 'OFFER_COMING_SOON',
+      };
+    } else if (salesState === 'AVAILABLE') {
+      if (purchasable === true && unavailableReason === null && value.purchaseOptions.length > 0) {
+        availability = { salesState, purchasable: true, unavailableReason: null };
+      } else if (
+        purchasable === false &&
+        unavailableReason === 'NO_AVAILABLE_PAYMENT_CHANNEL' &&
+        value.purchaseOptions.length === 0
+      ) {
+        availability = {
+          salesState,
+          purchasable: false,
+          unavailableReason: 'NO_AVAILABLE_PAYMENT_CHANNEL',
+        };
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  } else if (purchaseOptions.length === 0) {
+    // Older servers only returned purchasable offers and had no availability projection.
+    return null;
+  }
   return {
     code: offerCode,
+    ...availability,
     interval: isSubscription ? interval : null,
     currency: offerCurrency,
     amount,

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -19,6 +19,7 @@ import { extractIpcError } from '@/utils/ipcError';
 import type {
   BillingCatalog,
   BillingCatalogOffer,
+  BillingCatalogOfferUnavailableReason,
   BillingCatalogProduct,
   BillingPendingPlanChange,
   BillingPurchaseOption,
@@ -42,7 +43,7 @@ import {
 import { useBillingCheckout } from './useBillingCheckout';
 import { usePlanChange, type PlanChangeSettledKind } from './usePlanChange';
 
-type PurchasableOffer = {
+type CatalogOfferEntry = {
   product: BillingCatalogProduct;
   offer: BillingCatalogOffer;
   purchaseOptions: SupportedPurchaseOption[];
@@ -128,6 +129,30 @@ function formatLedgerTimestamp(value: string): string {
 
 function isCustomTopup(offer: BillingCatalogOffer): boolean {
   return offer.amount === null && offer.minAmount !== null && offer.maxAmount !== null;
+}
+
+function hasServerAvailabilityProjection(offer: BillingCatalogOffer): boolean {
+  return (
+    offer.salesState !== undefined &&
+    offer.purchasable !== undefined &&
+    offer.unavailableReason !== undefined
+  );
+}
+
+function isCatalogOfferVisible(entry: CatalogOfferEntry): boolean {
+  return hasServerAvailabilityProjection(entry.offer) || entry.purchaseOptions.length > 0;
+}
+
+function isCatalogOfferPurchasable(entry: CatalogOfferEntry): boolean {
+  if (!hasServerAvailabilityProjection(entry.offer)) return entry.purchaseOptions.length > 0;
+  return entry.offer.purchasable === true && entry.purchaseOptions.length > 0;
+}
+
+function catalogOfferUnavailableReason(
+  entry: CatalogOfferEntry,
+): BillingCatalogOfferUnavailableReason | null {
+  if (isCatalogOfferPurchasable(entry)) return null;
+  return entry.offer.unavailableReason ?? 'NO_AVAILABLE_PAYMENT_CHANNEL';
 }
 
 function isSupportedPurchaseOption(
@@ -281,7 +306,7 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
   );
   const planChange = usePlanChange(accountId, handlePlanChangeSettled);
 
-  const offers = useMemo<PurchasableOffer[]>(() => {
+  const offers = useMemo<CatalogOfferEntry[]>(() => {
     if (!catalog) return [];
     return catalog.products
       .flatMap((product) =>
@@ -295,7 +320,7 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
             : [],
         })),
       )
-      .filter(({ purchaseOptions }) => purchaseOptions.length > 0)
+      .filter(isCatalogOfferVisible)
       .sort((left, right) => {
         const productOrder = left.product.sortOrder - right.product.sortOrder;
         if (productOrder !== 0) return productOrder;
@@ -313,7 +338,10 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
   );
 
   const selected = useMemo(
-    () => offers.find(({ offer }) => offer.code === selectedOfferCode) ?? null,
+    () =>
+      offers.find(
+        (entry) => entry.offer.code === selectedOfferCode && isCatalogOfferPurchasable(entry),
+      ) ?? null,
     [offers, selectedOfferCode],
   );
   const selectedOption = useMemo(
@@ -324,7 +352,8 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
 
   useEffect(() => {
     if (!selectedOfferCode) return;
-    if (!offers.some(({ offer }) => offer.code === selectedOfferCode)) {
+    const selectedEntry = offers.find(({ offer }) => offer.code === selectedOfferCode);
+    if (!selectedEntry || !isCatalogOfferPurchasable(selectedEntry)) {
       resetSelection();
     }
   }, [offers, resetSelection, selectedOfferCode]);
@@ -403,13 +432,14 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     const currentProvider = currentSubscription?.provider ?? null;
     return subscriptionOffers
       .filter(
-        ({ product, offer }) =>
-          offer.interval === currentPlan.offer.interval &&
-          offer.code !== currentPlan.offer.code &&
-          product.level !== null &&
-          product.level !== currentPlan.product.level &&
+        (entry) =>
+          isCatalogOfferPurchasable(entry) &&
+          entry.offer.interval === currentPlan.offer.interval &&
+          entry.offer.code !== currentPlan.offer.code &&
+          entry.product.level !== null &&
+          entry.product.level !== currentPlan.product.level &&
           (currentProvider === null ||
-            offer.purchaseOptions.some((option) => option.provider === currentProvider)),
+            entry.purchaseOptions.some((option) => option.provider === currentProvider)),
       )
       .map(({ product, offer }) => ({
         product,
@@ -432,6 +462,8 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
 
   const selectOffer = (offerCode: string) => {
     if (selectedOfferCode === offerCode) return;
+    const entry = offers.find(({ offer }) => offer.code === offerCode);
+    if (!entry || !isCatalogOfferPurchasable(entry)) return;
     setSelectedOfferCode(offerCode);
     setSelectedPurchaseOptionId(null);
     setCustomAmount('');
@@ -1111,10 +1143,10 @@ function BillingOfferDialog({
 }: {
   open: boolean;
   kind: PurchaseKind;
-  offers: PurchasableOffer[];
+  offers: CatalogOfferEntry[];
   loading: boolean;
   catalogError: boolean;
-  selected: PurchasableOffer | null;
+  selected: CatalogOfferEntry | null;
   selectedPurchaseOptionId: string | null;
   customAmount: string;
   amountError: string | null;
@@ -1196,19 +1228,23 @@ function BillingOfferDialog({
             ) : (
               <>
                 <div className="space-y-2.5">
-                  {offers.map(({ product, offer }) => {
+                  {offers.map((entry) => {
+                    const { product, offer } = entry;
                     const active = selected?.offer.code === offer.code;
+                    const unavailableReason = catalogOfferUnavailableReason(entry);
                     return (
                       <button
                         key={offer.code}
                         type="button"
                         onClick={() => onSelectOffer(offer.code)}
+                        disabled={unavailableReason !== null}
                         aria-pressed={active}
                         className={cn(
                           'group relative flex min-h-[88px] w-full items-center gap-5 rounded-xl border px-4 py-3.5 text-left',
                           'transition-[background-color,border-color,box-shadow] focus-visible:outline-none',
                           'focus-visible:ring-2 focus-visible:ring-[var(--text-primary)] focus-visible:ring-offset-2',
                           'focus-visible:ring-offset-[var(--surface-elevated)]',
+                          'disabled:cursor-not-allowed disabled:bg-[var(--surface)] disabled:hover:bg-[var(--surface)]',
                           active
                             ? 'border-[var(--text-primary)] bg-[var(--surface)] shadow-[inset_3px_0_0_var(--text-primary)]'
                             : 'border-[var(--border-default)] hover:bg-[var(--surface-hover-soft)]',
@@ -1218,11 +1254,18 @@ function BillingOfferDialog({
                           <p className="truncate text-sm font-medium text-[var(--text-primary)]">
                             {product.name}
                           </p>
-                          <p className="mt-1 text-11 text-[var(--text-tertiary)]">
-                            {kind === 'SUBSCRIPTION'
-                              ? t('billing.offerKinds.subscription')
-                              : t('billing.offerKinds.topup')}
-                          </p>
+                          <div className="mt-1 flex flex-wrap items-center gap-2">
+                            <span className="text-11 text-[var(--text-tertiary)]">
+                              {kind === 'SUBSCRIPTION'
+                                ? t('billing.offerKinds.subscription')
+                                : t('billing.offerKinds.topup')}
+                            </span>
+                            {unavailableReason && (
+                              <span className="rounded-full bg-[var(--surface-chip)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
+                                {t(`billing.catalog.unavailableReasons.${unavailableReason}`)}
+                              </span>
+                            )}
+                          </div>
                         </div>
                         <div className="flex shrink-0 items-center gap-4">
                           <div className="text-right">
@@ -1242,7 +1285,7 @@ function BillingOfferDialog({
                               </p>
                             )}
                           </div>
-                          <SelectionMark active={active} />
+                          {unavailableReason === null && <SelectionMark active={active} />}
                         </div>
                       </button>
                     );

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -170,11 +170,57 @@ describe('BillingPage remote catalog rendering', () => {
                 ],
               },
               {
+                code: 'coming_soon',
+                name: 'Coming soon top-up',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 4,
+                offers: [
+                  {
+                    code: 'coming_soon_offer',
+                    salesState: 'COMING_SOON',
+                    purchasable: false,
+                    unavailableReason: 'OFFER_COMING_SOON',
+                    interval: null,
+                    currency: 'cny',
+                    amount: '30',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '30',
+                    rolloverCap: null,
+                    purchaseOptions: [],
+                  },
+                ],
+              },
+              {
+                code: 'no_available_channel',
+                name: 'No-channel top-up',
+                kind: 'CREDIT_TOPUP',
+                level: null,
+                sortOrder: 5,
+                offers: [
+                  {
+                    code: 'no_available_channel_offer',
+                    salesState: 'AVAILABLE',
+                    purchasable: false,
+                    unavailableReason: 'NO_AVAILABLE_PAYMENT_CHANNEL',
+                    interval: null,
+                    currency: 'cny',
+                    amount: '40',
+                    minAmount: null,
+                    maxAmount: null,
+                    creditAmount: '40',
+                    rolloverCap: null,
+                    purchaseOptions: [],
+                  },
+                ],
+              },
+              {
                 code: 'hidden',
                 name: 'Unconfigured offer',
                 kind: 'CREDIT_TOPUP',
                 level: null,
-                sortOrder: 4,
+                sortOrder: 6,
                 offers: [
                   {
                     code: 'hidden_offer',
@@ -194,7 +240,7 @@ describe('BillingPage remote catalog rendering', () => {
                 name: 'Legacy offer without channel projection',
                 kind: 'CREDIT_TOPUP',
                 level: null,
-                sortOrder: 5,
+                sortOrder: 7,
                 offers: [
                   {
                     code: 'legacy_offer',
@@ -213,7 +259,7 @@ describe('BillingPage remote catalog rendering', () => {
                 name: 'Unsupported payment action',
                 kind: 'CREDIT_TOPUP',
                 level: null,
-                sortOrder: 6,
+                sortOrder: 8,
                 offers: [
                   {
                     code: 'unsupported_action_offer',
@@ -240,7 +286,7 @@ describe('BillingPage remote catalog rendering', () => {
                 name: 'Unsupported payment capability',
                 kind: 'CREDIT_TOPUP',
                 level: null,
-                sortOrder: 7,
+                sortOrder: 9,
                 offers: [
                   {
                     code: 'unsupported_capability_offer',
@@ -392,7 +438,7 @@ describe('BillingPage remote catalog rendering', () => {
     );
   });
 
-  it('shows only configured offers and only the selected offer channels', async () => {
+  it('shows server-visible unavailable offers and only enables purchasable offers', async () => {
     render(<BillingPage />);
 
     expect(screen.getByText('billing.settings.subscriptionCard.action')).toBeTruthy();
@@ -402,6 +448,18 @@ describe('BillingPage remote catalog rendering', () => {
 
     fireEvent.click(screen.getByText('billing.settings.topupCard.action'));
     await screen.findByText('Configured top-up');
+    expect(screen.getByText('Coming soon top-up').closest('button')).toHaveProperty(
+      'disabled',
+      true,
+    );
+    expect(screen.getByText('No-channel top-up').closest('button')).toHaveProperty(
+      'disabled',
+      true,
+    );
+    expect(screen.getByText('billing.catalog.unavailableReasons.OFFER_COMING_SOON')).toBeTruthy();
+    expect(
+      screen.getByText('billing.catalog.unavailableReasons.NO_AVAILABLE_PAYMENT_CHANNEL'),
+    ).toBeTruthy();
     expect(screen.queryByText('Unknown-provider offer')).toBeNull();
     expect(screen.queryByText('Unconfigured offer')).toBeNull();
     expect(screen.queryByText('Legacy offer without channel projection')).toBeNull();
@@ -753,6 +811,29 @@ describe('BillingPage plan change', () => {
           },
         ],
       },
+      {
+        code: 'future_max',
+        name: 'Coming soon Max',
+        kind: 'SUBSCRIPTION' as const,
+        level: 3,
+        sortOrder: 4,
+        offers: [
+          {
+            code: 'future_max_month',
+            salesState: 'COMING_SOON' as const,
+            purchasable: false,
+            unavailableReason: 'OFFER_COMING_SOON' as const,
+            interval: 'MONTH' as const,
+            currency: 'usd',
+            amount: '30',
+            minAmount: null,
+            maxAmount: null,
+            creditAmount: '500',
+            rolloverCap: '0',
+            purchaseOptions: [],
+          },
+        ],
+      },
     ],
   };
 
@@ -839,6 +920,7 @@ describe('BillingPage plan change', () => {
     await screen.findByText('billing.planChange.targetTitle');
     expect(screen.getByText('Max plan')).toBeTruthy();
     expect(screen.queryByText('Alipay-only Max')).toBeNull();
+    expect(screen.queryByText('Coming soon Max')).toBeNull();
     // The current plan renders in the summary card but must not be a candidate.
     expect(screen.getByText('billing.planChange.upgradeBadge')).toBeTruthy();
 

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7034,11 +7034,11 @@
     "dialogs": {
       "subscription": {
         "title": "Choose a subscription plan",
-        "description": "Only currently configured server plans are shown. Choose a plan before selecting its payment method."
+        "description": "Server-published subscription plans are shown. Plans that cannot be purchased yet include a status."
       },
       "topup": {
         "title": "Buy credits",
-        "description": "Only currently configured server credit products are shown. Choose a product before selecting its payment method."
+        "description": "Server-published credit products are shown. Products that cannot be purchased yet include a status."
       }
     },
     "eyebrow": "Account & usage",
@@ -7047,7 +7047,7 @@
     "steps": {
       "offer": {
         "title": "Choose a plan",
-        "description": "Only currently purchasable credit and subscription offers are shown."
+        "description": "Server-published credit and subscription offers are shown."
       },
       "channel": {
         "title": "Choose a payment method",
@@ -7071,8 +7071,12 @@
     "catalog": {
       "errorTitle": "Plans are temporarily unavailable",
       "errorDescription": "Check your connection and retry. Local fallback plans will not be used.",
-      "emptyTitle": "No plans are available",
-      "emptyDescription": "The server has not configured a purchasable plan and payment method yet."
+      "emptyTitle": "No Plans Available",
+      "emptyDescription": "The server has not published any plans yet.",
+      "unavailableReasons": {
+        "OFFER_COMING_SOON": "Coming Soon",
+        "NO_AVAILABLE_PAYMENT_CHANNEL": "No Payment Method Available"
+      }
     },
     "offerKinds": {
       "topup": "Credit top-up",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7023,11 +7023,11 @@
     "dialogs": {
       "subscription": {
         "title": "サブスクリプションプランを選択",
-        "description": "サーバーで現在設定されているプランのみ表示します。プランを選択すると支払い方法が表示されます。"
+        "description": "サーバーで公開中のサブスクリプションプランを表示します。購入できないプランには状態を表示します。"
       },
       "topup": {
         "title": "クレジットを購入",
-        "description": "サーバーで現在設定されているクレジット商品のみ表示します。商品を選択すると支払い方法が表示されます。"
+        "description": "サーバーで公開中のクレジット商品を表示します。購入できない商品には状態を表示します。"
       }
     },
     "eyebrow": "アカウントと使用量",
@@ -7036,7 +7036,7 @@
     "steps": {
       "offer": {
         "title": "プランを選択",
-        "description": "現在購入できるチャージとサブスクリプションのみ表示します。"
+        "description": "サーバーで公開中のチャージとサブスクリプションを表示します。"
       },
       "channel": {
         "title": "支払い方法を選択",
@@ -7060,8 +7060,12 @@
     "catalog": {
       "errorTitle": "プランを取得できません",
       "errorDescription": "接続を確認して再試行してください。ローカルの代替プランは表示しません。",
-      "emptyTitle": "利用可能なプランはありません",
-      "emptyDescription": "購入可能なプランと支払い方法がまだ設定されていません。"
+      "emptyTitle": "プランはまだありません",
+      "emptyDescription": "サーバーで公開中のプランはまだありません。",
+      "unavailableReasons": {
+        "OFFER_COMING_SOON": "近日提供",
+        "NO_AVAILABLE_PAYMENT_CHANNEL": "利用可能な支払い方法なし"
+      }
     },
     "offerKinds": {
       "topup": "クレジットチャージ",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7023,11 +7023,11 @@
     "dialogs": {
       "subscription": {
         "title": "구독 요금제 선택",
-        "description": "서버에 현재 설정된 구독 요금제만 표시합니다. 요금제를 선택하면 결제 수단이 표시됩니다."
+        "description": "서버에서 공개한 구독 요금제를 표시합니다. 아직 구매할 수 없는 요금제에는 상태가 표시됩니다."
       },
       "topup": {
         "title": "크레딧 구매",
-        "description": "서버에 현재 설정된 크레딧 상품만 표시합니다. 상품을 선택하면 결제 수단이 표시됩니다."
+        "description": "서버에서 공개한 크레딧 상품을 표시합니다. 아직 구매할 수 없는 상품에는 상태가 표시됩니다."
       }
     },
     "eyebrow": "계정 및 사용량",
@@ -7036,7 +7036,7 @@
     "steps": {
       "offer": {
         "title": "요금제 선택",
-        "description": "현재 구매 가능한 충전 및 구독만 표시합니다."
+        "description": "서버에서 공개한 충전 및 구독 상품을 표시합니다."
       },
       "channel": {
         "title": "결제 수단 선택",
@@ -7060,8 +7060,12 @@
     "catalog": {
       "errorTitle": "요금제를 불러올 수 없습니다",
       "errorDescription": "네트워크를 확인하고 다시 시도하세요. 로컬 대체 요금제는 표시하지 않습니다.",
-      "emptyTitle": "사용 가능한 요금제가 없습니다",
-      "emptyDescription": "서버에 구매 가능한 요금제와 결제 수단이 아직 설정되지 않았습니다."
+      "emptyTitle": "요금제가 없습니다",
+      "emptyDescription": "서버에서 공개한 요금제가 아직 없습니다.",
+      "unavailableReasons": {
+        "OFFER_COMING_SOON": "출시 예정",
+        "NO_AVAILABLE_PAYMENT_CHANNEL": "사용 가능한 결제 수단 없음"
+      }
     },
     "offerKinds": {
       "topup": "크레딧 충전",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7023,11 +7023,11 @@
     "dialogs": {
       "subscription": {
         "title": "选择订阅套餐",
-        "description": "仅展示服务端当前配置且可用的订阅套餐。选择套餐后再选择支付方式。"
+        "description": "展示服务端当前公开的订阅套餐；暂不可购买的套餐会标注状态。"
       },
       "topup": {
         "title": "购买点数",
-        "description": "仅展示服务端当前配置且可用的点数商品。选择商品后再选择支付方式。"
+        "description": "展示服务端当前公开的点数商品；暂不可购买的商品会标注状态。"
       }
     },
     "eyebrow": "账户与用量",
@@ -7036,7 +7036,7 @@
     "steps": {
       "offer": {
         "title": "选择套餐",
-        "description": "仅展示当前可购买的充值和订阅方案。"
+        "description": "展示服务端当前公开的充值和订阅方案。"
       },
       "channel": {
         "title": "选择支付方式",
@@ -7060,8 +7060,12 @@
     "catalog": {
       "errorTitle": "暂时无法获取套餐",
       "errorDescription": "请检查网络后重试。不会使用本地套餐替代。",
-      "emptyTitle": "当前暂无可用套餐",
-      "emptyDescription": "服务端尚未配置可购买的套餐和支付方式。"
+      "emptyTitle": "当前暂无套餐",
+      "emptyDescription": "服务端尚未配置公开的套餐。",
+      "unavailableReasons": {
+        "OFFER_COMING_SOON": "敬请期待",
+        "NO_AVAILABLE_PAYMENT_CHANNEL": "暂无可用支付方式"
+      }
     },
     "offerKinds": {
       "topup": "点数充值",

--- a/apps/desktop/src/shared/billing.ts
+++ b/apps/desktop/src/shared/billing.ts
@@ -40,8 +40,19 @@ export type BillingPurchaseOption = {
   paymentAction: BillingPaymentAction['type'];
 };
 
+export type BillingCatalogOfferSalesState = 'COMING_SOON' | 'AVAILABLE';
+export type BillingCatalogOfferUnavailableReason =
+  'OFFER_COMING_SOON' | 'NO_AVAILABLE_PAYMENT_CHANNEL';
+
 export type BillingCatalogOffer = {
   code: string;
+  /**
+   * Optional only while Desktop remains compatible with older Model Access
+   * servers. New servers always send the three availability fields together.
+   */
+  salesState?: BillingCatalogOfferSalesState;
+  purchasable?: boolean;
+  unavailableReason?: BillingCatalogOfferUnavailableReason | null;
   interval: 'MONTH' | 'YEAR' | null;
   currency: string;
   amount: string | null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

客户端接入服务端商品目录的 `salesState`、`purchasable` 和 `unavailableReason` 字段，不再过滤“敬请期待”或暂无可用支付渠道的公开套餐，并在界面上展示状态、禁用购买入口。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：服务端商品目录销售状态适配
- 本 PR 包含：目录协议投影、状态组合校验、套餐状态展示、购买/套餐变更禁用逻辑、多语言文案和测试
- 明确不包含：服务端目录或销售状态逻辑调整
- 用户可见变化：`COMING_SOON` 套餐显示“敬请期待”；无可用支付渠道的套餐显示“暂无可用支付方式”；两者均不可选择或购买
- 是否存在 breaking change：无；销售状态字段按可选字段接入，兼容旧服务端响应

### UI 变化

套餐卡片新增不可购买状态徽标并禁用选择；未附截图。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test -- src/main/billing/__tests__/projection.test.ts src/renderer/features/billing/__tests__/BillingPage.test.tsx
结果：2 个测试文件、39 项测试通过

pnpm --filter desktop typecheck
结果：通过

pnpm check:i18n
结果：通过，4 种语言共 5388 个 key 一致；仅有仓库存量警告

git diff --check
结果：通过
```

### 手工验证

未执行。

### 未执行的验证

`pnpm test:unit` 未完整重跑：首次执行时因新 worktree 未初始化 `cindy-protocol` submodule，在 workspace manifest 校验阶段失败；submodule 已完成初始化，按要求直接创建 PR。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Billing 商品目录投影和套餐选择界面
- 回滚 / 降级方式：回滚本 PR；旧服务端未下发销售状态字段时仍沿用历史投影行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因