### PR TITLE
docs(design-rules): DESIGN.md 整体梳理——去 Ollama 叙事、追平代码、决策史分离与英文化

### DIFF
--- a/apps/mobile/src/session/mobileHomeListCache.ts
+++ b/apps/mobile/src/session/mobileHomeListCache.ts
@@ -3,7 +3,7 @@ import type { RemoteSession } from '@/session/types';
 
 // 「首页设备 + 会话列表」冷启动持久缓存:冷启动时先用上次 loadHome 成功后的 last-known 快照
 // 乐观画出列表(消除首屏强制 spinner),fresh loadHome 回来后由 store 正常对账覆盖并回写缓存。
-// 后端与 mobileSessionMessageCache 保持一致(AsyncStorage),遵守仓库根 DESIGN.md:
+// 后端与 mobileSessionMessageCache 保持一致(AsyncStorage),遵守 docs/design-rules/DESIGN.md:
 // 先画缓存、拿到新数据再刷新、绝不闪空白。
 // 瘦身原则:只存列表渲染 / 分组 / 跳转需要的字段白名单(coerceCachedSession),不 dump 整个 store;
 // 长文本字段截断、live-only 状态(attached / 运行态)一律不缓存——缓存的设备不是 live 设备,

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -590,7 +590,7 @@ Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`;
 
 > This section records the CINDY skin family; it does **not** rewrite the §1–7 default-skin rules. Values were finalized from design-stage working files (`skin-docs/10-specs/` desktop, `skin-docs/30-mobile/` mobile errata — **not in this repo**, same status as the §16 login working files) plus the user's final sign-off of 2026-07-18. Zero discretion at implementation time: within the repo, the authoritative encodings are the theme files (`cindy-light.ts` / `cindy-dark.ts`), `cindyDecisionData.ts`, and the frozen tests — this section is their prose summary.
 >
-> Subsection numbers are **stable identifiers** (referenced by §16, code comments, and other documents; 15.9 was never assigned) — do not renumber. Decision history for this section is archived in [`design-decision-log.md`](./design-decision-log.md).
+> Subsection numbers are **stable identifiers** (referenced by §16, code comments, frozen tests, and other documents; 15.9 was never assigned) — do not renumber. Decision history for this section is archived in [`design-decision-log.md`](./design-decision-log.md).
 
 ### 15.1 Palette (extracted from Figma text nodes)
 
@@ -737,7 +737,7 @@ The execution rulebook for subsequent desktop / mobile UI updates. Sources: the 
 #### Process gates
 
 - New or changed colors go through tokens — desktop via ColorRegistry / CSS variables, mobile via `ThemeColors` / `useTheme`; no hex/rgba in components.
-- `hardcoded-color-audit` must be fully green to merge. Genuine exceptions (asset-intrinsic or platform-semantic) must be whitelisted with reasons.
+- `hardcoded-color-audit` (`scripts/hardcoded-color-audit.mjs`) must pass before merging. ⚠ Not yet wired into CI as a required check — run it manually for now; CI enforcement is tracked as a follow-up (modularization plan P6-3'). Genuine exceptions (asset-intrinsic or platform-semantic) must be whitelisted with reasons.
 - When a design mock conflicts with existing tokens, list it as "pending ruling" in the spec / PR and request a decision — never self-adjudicate or substitute a near color.
 - Shared-component restyles default to variant / prop isolation. Pages, states, and platforms not covered by the mock keep the status quo.
 

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -1,26 +1,30 @@
-# Design System Inspired by Ollama
+# Cindy Design System
+
+> Heritage note: this visual language was originally derived from an external
+> minimalist reference (2025). It has since evolved into Cindy's own system —
+> no external site or product is a reference for new design decisions.
 
 ## 1. Visual Theme & Atmosphere
 
-Ollama's interface is radical minimalism taken to its logical conclusion — a pure-white void where content floats without decoration, shadow, or color. The design philosophy mirrors the product itself: strip away everything unnecessary until only the essential tool remains. This is the digital equivalent of a Dieter Rams object — every pixel earns its place, and the absence of design IS the design.
+Cindy's interface is radical minimalism applied to an AI-agent workbench — a quiet, near-monochrome canvas where the user's content and the agent's output are the only things that demand attention. The design philosophy mirrors the product: strip away everything unnecessary until only the essential tool remains. This is the digital equivalent of a Dieter Rams object — every pixel earns its place, and the absence of decoration IS the design.
 
-The entire page exists in pure grayscale. There is zero chromatic color in the interface — no brand blue, no accent green, no semantic red. The only colors that exist are shades between pure black (`#000000`) and pure white (`#ffffff`), creating a monochrome environment that lets the user's mental model of "open models" remain uncolored by brand opinion. The Ollama llama mascot, rendered in simple black line art, is the only illustration — and even it's monochrome.
+The default theme lives almost entirely in grayscale. Chromatic color is reserved for a small, explicitly sanctioned set of semantic signals (status, diff, focus — see §2); everything else is shades between near-black and near-white. Long working sessions stay calm, and color means something whenever it does appear.
 
-What makes this system distinctive is the combination of a single geometric sans-serif (Inter) with an exclusively pill-shaped geometry (9999px radius on everything interactive). The clean letterforms + rounded buttons + rounded containers create a cohesive "softness language" that makes a developer-oriented tool feel approachable and friendly rather than intimidating. This is minimalism with warmth — not cold Swiss-style grid minimalism, but the kind where the edges are literally softened.
+What makes this system distinctive is the combination of a single geometric sans-serif (Inter) with a pill-first geometry (9999px radius on interactive elements). The clean letterforms + rounded buttons + rounded containers create a cohesive "softness language" that makes a developer-oriented tool feel approachable and friendly rather than intimidating. This is minimalism with warmth — not cold Swiss-style grid minimalism, but the kind where the edges are literally softened.
 
 **Key Characteristics:**
 
-- Pure white canvas with zero chromatic color — completely grayscale
+- Near-monochrome default theme; chromatic color only via the sanctioned semantic set (§2), always consumed through tokens (§10)
 - Inter as the single sans family, carrying both display headlines and body text
 - Tight border-radius system: 8px (inner controls) / 12px (containers) / 9999px (pill) — three values, nothing else
-- Zero shadows — depth comes exclusively from background color shifts and borders
+- Zero shadows in the base language — depth comes from background color shifts and 1px borders (narrow token-gated exceptions live in §10)
 - Pill-shaped geometry on all interactive elements (buttons, tabs, inputs, tags)
-- The Ollama llama as the sole illustration — black line art, no color
-- Extreme content restraint — the homepage is short, focused, and uncluttered
+- No mascots or decorative artwork in the working UI — brand imagery appears only on sanctioned brand surfaces (see §15.7 / §16)
+- Extreme content restraint — each surface presents one clear idea
 
 ## 2. Color Palette & Roles
 
-> **多主题架构注意**:本节列出的色值是 **Default Light / Default Dark**(默认主题,设计灵感来自 Ollama 官网)的具体值,作为视觉规范的参考样本。运行时**每个色值都通过 token 引用**(见第 10 节 Theme System & Token Reference),所以同一组件在其它主题(如 Eclipse / One Dark Pro / Monokai Pro)下会自动呈现该主题的对应色。**实现组件时永远写 token 不写 hex**——具体规则见第 10 节。
+> **多主题架构注意**:本节列出的色值是 **Default Light / Default Dark**(默认主题)的具体值,作为视觉规范的参考样本。运行时**每个色值都通过 token 引用**(见第 10 节 Theme System & Token Reference),所以同一组件在其它主题(如 Eclipse / One Dark Pro / Monokai Pro)下会自动呈现该主题的对应色。**实现组件时永远写 token 不写 hex**——具体规则见第 10 节。
 
 ### Primary Text
 
@@ -81,7 +85,7 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 
 ### Gradient System
 
-- **None.** Ollama uses absolutely no gradients. Visual separation comes from flat color blocks and single-pixel borders. This is a deliberate, almost philosophical design choice.
+- **None in the core UI.** Cindy uses no gradients; visual separation comes from flat color blocks and single-pixel borders. This is a deliberate, almost philosophical design choice. (The login canvas is also flat by ruling — see §16.5.)
 
 ## 3. Typography Rules
 
@@ -90,7 +94,7 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 - **Display / Body / UI**: `Inter`, with fallbacks: `system-ui, -apple-system, "Segoe UI", sans-serif`
 - **Monospace**: `JetBrains Mono`, with fallbacks: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`
 
-*Note: The entire interface uses a single sans font — Inter — for both display headlines and body text. Inter is chosen for (a) its neutral, geometric character that stays out of the way, (b) its excellent legibility at small sizes, and (c) its wide availability in both web and design tooling (including the Pencil .pen editor). A single font keeps the hierarchy clean — separation comes from size and weight, not typeface contrast.*
+*Note: The entire interface uses a single sans font — Inter — for both display headlines and body text. Inter is chosen for (a) its neutral, geometric character that stays out of the way, (b) its excellent legibility at small sizes, and (c) its wide availability in both web and design tooling. A single font keeps the hierarchy clean — separation comes from size and weight, not typeface contrast.*
 
 ### Hierarchy
 
@@ -110,6 +114,8 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 | Code Caption    | JetBrains Mono | 14px (0.88rem) | 400     | 1.43         | normal                                 | Code snippets, secondary                                                                                                                                                                                                                                     |
 | Code Small      | JetBrains Mono | 11–12px        | 400–500 | 1.40–1.63    | normal                                 | Tags, labels, in-tree paths                                                                                                                                                                                                                                  |
 
+
+*Positioning note: the Display / Section Heading / Sub-heading rows are for brand-scale surfaces (login, splash, empty states); everyday app chrome lives in the Body / Caption / Small / Micro rows.*
 
 ### Principles
 
@@ -145,7 +151,6 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 - Background: Pure Black (`#000000`)
 - Text: Pure White (`#ffffff`)
 - Radius: pill-shaped (9999px)
-- Inferred from "Create account" and "Explore" buttons
 - Maximum emphasis — black on white
 
 ### Cards & Containers
@@ -182,71 +187,34 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 - **按钮**: pill(9999px);主按钮 = 实心 CTA(`--confirm-btn-primary-*`),次按钮 / 取消 = 描边(`--confirm-btn-secondary-*`,透明底 + Board 边框);底部 `justify-end`。
 - **打开时焦点**: 落在该弹窗的**主输入或主按钮**,不要默认停在取消键(见 §14.2 + ConfirmDialog 的 `autoFocusConfirm` / `onOpenAutoFocus`)。
 
-### Navigation
-
-- Clean horizontal nav with minimal elements
-- Logo: Ollama llama icon + wordmark in black
-- Links: "Models", "Docs", "Pricing" in black at 16px, weight 400
-- Search bar: pill-shaped with placeholder text
-- Right side: "Sign in" link + "Download" black pill CTA
-- No borders, no background — transparent nav on white page
-
-### Image Treatment
-
-- The Ollama llama mascot is the only illustration — black line art on white
-- Code screenshots/terminal outputs shown in bordered containers (12px radius)
-- Integration logos displayed as simple icons in a grid
-- No photographs, no gradients, no decorative imagery
-
-### Distinctive Components
+### Tabs
 
 **Tab Pills**
 
-- Pill-shaped tab selectors (e.g., "Coding" | "OpenClaw")
-- Active: Light Gray bg; Inactive: transparent
+- Pill-shaped tab selectors (e.g. the Claude | Codex agent switch on the new-session screen)
+- Active: Light Gray bg (`--surface-chip`); Inactive: transparent
 - All pill-shaped (9999px)
-
-**Model Tags**
-
-- Small pill-shaped tags (e.g., "ollama", "launch", "claude")
-- Light Gray background, dark text
-- The primary way to browse models
-
-**Terminal Command Block**
-
-- Monospace code showing `ollama run` commands
-- Minimal styling — just a bordered 12px-radius container
-- Copy button integrated
-
-**Integration Grid**
-
-- Grid of integration logos (Codex, Claude Code, OpenCode, LangChain, etc.)
-- Each in a bordered pill or card with icon + name
-- Tabbed by category (Coding, Documents & RAG, Automation, Chat)
 
 ## 5. Layout Principles
 
 ### Spacing System
 
 - Base unit: 8px
-- Scale: 4px, 6px, 8px, 9px, 10px, 12px, 14px, 16px, 20px, 24px, 32px, 40px, 48px, 88px, 112px
+- Scale: 4px, 6px, 8px, 10px, 12px, 14px, 16px, 20px, 24px, 32px, 40px, 48px
 - Button padding: 10px 24px (consistent across all buttons)
-- Card internal padding: approximately 24–32px
-- Section vertical spacing: very generous (88px–112px)
+- Container padding: dialogs 16px (`p-4`, see §4 Dialog & Modal); dropdown panels 6–8px (see §4 Select & Dropdown)
 
-### Grid & Container
+### Layout Structure (App)
 
-- Max container width: approximately 1024–1280px, centered
-- Hero: centered single-column with llama illustration
-- Feature sections: 2-column layout (text left, code right)
-- Integration grid: responsive multi-column
-- Footer: clean single-row
+- Full-window three-region structure: sidebar + content area (+ optional right panel), separated by 1px Board dividers on a single flat Surface — never by background shifts (see §2 layer rule).
+- Centered-card layouts (login, empty states) follow the Surface + Card two-layer rule in §2.
+- Reading-width content (settings forms, document previews) is centered with a comfortable max width; full-bleed content (chat stream, file tree) fills its region.
 
 ### Whitespace Philosophy
 
-- **Emptiness as luxury**: The page is remarkably short and sparse — no feature section overstays its welcome. Each concept gets minimal but sufficient space.
-- **Content density is low by design**: Where other AI companies pack feature after feature, Ollama presents three ideas (run models, use with apps, integrations) and stops.
-- **The white space IS the brand**: Pure white space with zero decoration communicates "this tool gets out of your way."
+- **Emptiness as luxury**: no surface overstays its welcome — each concept gets minimal but sufficient space.
+- **Content density is low by design**: one clear idea per surface. When a screen needs more, split it into progressive disclosure (§14) instead of packing it tighter.
+- **The white space IS the brand**: calm, undecorated space communicates "this tool gets out of your way."
 
 ### Border Radius Scale
 
@@ -268,7 +236,7 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 | Lifted (Card)      | Card fill (`#ffffff` Light / `#2c2c2a` Dark) + optional 1px Board outline | Login cards, modals, raised panels             |
 
 
-**Shadow Philosophy**: Ollama uses **zero shadows**. This is not an oversight — it's a deliberate design decision. Every other major AI product site uses at least subtle shadows. Ollama's flat, shadowless approach creates a paper-like experience where elements are distinguished purely by background color and single-pixel borders. Depth is communicated through **content hierarchy and typography weight**, not visual layering.
+**Shadow Philosophy**: Cindy's base visual language uses **zero shadows**. This is not an oversight — it's a deliberate design decision. The flat, shadowless approach creates a paper-like experience where elements are distinguished purely by background color and single-pixel borders. Depth is communicated through **content hierarchy and typography weight**, not visual layering. (The only shadows in the system are the token-gated floating-layer exceptions registered in §10 — `--shadow-menu` / `--cmd-palette-shadow` / `--confirm-shadow`; never add ad-hoc shadows to in-page elements.)
 
 ## 7. Do's and Don'ts
 
@@ -278,7 +246,7 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 - Use pill-shaped (9999px) radius on all interactive elements — buttons, tabs, inputs, tags
 - Use 12px radius on all non-interactive containers — code blocks, cards, panels
 - Use 8px radius only for inner controls that can't be a pill — multi-line inputs, dropdown/menu rows (see §5)
-- Keep the palette strictly grayscale — no chromatic colors except the blue focus ring
+- Keep the palette strictly grayscale — chromatic color only via the sanctioned semantic set in §2, always through tokens
 - Use Inter at weight 500 for display headings — hierarchy comes from size + weight, not typeface switching
 - Maintain zero shadows — depth comes from borders and background shifts only
 - Keep content density low — each section should present one clear idea
@@ -291,46 +259,26 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 - Don't invent arbitrary radii — only three values exist: 8px (inner controls), 12px (containers), 9999px (pill). Nothing in between, nothing else.
 - Don't add shadows to any element — the flat aesthetic is intentional
 - Don't use font weights above 500 — no bold, no black weight
-- Don't add decorative illustrations beyond the llama mascot
+- Don't add decorative illustrations — Cindy's working UI carries no mascots or artwork; brand imagery appears only on sanctioned brand surfaces (login, splash, new-session brand block — see §15.7 / §16)
 - Don't use gradients anywhere — flat blocks and borders only
-- Don't overcomplicate the layout — two columns maximum, no complex grids
+- Don't overcomplicate the layout — stick to the region structure in §5; no complex nested grids
 - Don't use borders heavier than 1px — containment is always the lightest possible touch
 - Don't add decorative or large-motion animation — no bounce, parallax, looping, or gratuitous movement. Short **functional** state transitions (color / background / opacity, ≤150ms) are fine and expected — see §14.4.
 
-## 8. Responsive Behavior
+## 8. Window & Adaptive Behavior
 
-### Breakpoints
+Cindy Desktop is an Electron app: layout responds to window resizing, not page breakpoints.
 
+### Desktop Window
 
-| Name          | Width       | Key Changes                                      |
-| ------------- | ----------- | ------------------------------------------------ |
-| Mobile        | <640px      | Single column, stacked everything, hamburger nav |
-| Small Tablet  | 640–768px   | Minor adjustments to spacing                     |
-| Tablet        | 768–850px   | 2-column layouts begin                           |
-| Desktop       | 850–1024px  | Standard layout, expanded features               |
-| Large Desktop | 1024–1280px | Maximum content width                            |
+- Minimum window size: **800 × 600** (enforced at the BrowserWindow level — `apps/desktop/src/main/bootstrap-electron.ts`; secondary windows share the same floor)
+- The sidebar is collapsible; region dividers and paddings hold as the window narrows, and content reflows fluidly
+- Chat stream and composer reflow with the window; code blocks keep horizontal scroll instead of wrapping
+- Control sizes and paddings follow §4 at every window size — targets never shrink below their specified geometry
 
+### Mobile
 
-### Touch Targets
-
-- All buttons are pill-shaped with generous padding (10px 24px)
-- Navigation links at comfortable 16px size
-- Minimum touch area easily exceeds 44x44px
-
-### Collapsing Strategy
-
-- **Navigation**: Collapses to hamburger menu on mobile
-- **Feature sections**: 2-column → stacked single column
-- **Hero text**: 48px → 36px → 30px progressive scaling
-- **Integration grid**: Multi-column → 2-column → single column
-- **Code blocks**: Horizontal scroll maintained
-
-### Image Behavior
-
-- Llama mascot scales proportionally
-- Code blocks maintain monospace formatting
-- Integration icons reflow to fewer columns
-- No art direction changes
+Cindy Mobile (React Native) has its own device-class rules (phone / pad portrait / pad landscape). The surfaces specified so far are documented in §15.13 (cross-platform skin rules) and §16 (login); mobile layout beyond those surfaces follows `apps/mobile` as implemented.
 
 ## 9. Agent Prompt Guide
 
@@ -347,11 +295,12 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 
 ### Example Component Prompts
 
-- "Create a hero section on Surface (#f8f8f6) with an illustration centered above a headline at 48px Inter weight 500, line-height 1.0. Use Pure Black (#000000) text. Below, add a black pill-shaped CTA button (9999px radius, 10px 24px padding) and a gray pill button."
-- "Design a code block with a 12px border-radius, 1px solid Board (#d7d7d4 Light / #3c3c3a Dark) border on Card background. Use JetBrains Mono at 16px for the terminal command. No shadow."
+- "Create a settings section: an ivory Card (--surface-card-ivory, 12px radius, 1px --border-default outline) on the Surface page background; section title 14px Inter 500, body rows 14px 400."
+- "Design a code block with a 12px border-radius, 1px solid Board (#d7d7d4 Light / #3c3c3a Dark) border on Card background. Use JetBrains Mono for the code. No shadow."
 - "Build a tab bar with pill-shaped tabs (9999px radius). Active tab: Light Gray (#e5e5e5) background, Near Black (#262626) text. Inactive: transparent background, Stone (#737373) text."
-- "Create an integration card grid. Each card is a bordered pill (9999px radius) or a 12px-radius card with 1px solid Board (#d7d7d4) border. Icon + name inside. Grid of 4 columns on desktop."
-- "Design a navigation bar: transparent background, no border. Ollama logo on the left, 3 text links (Pure Black, 16px, weight 400), pill search input in the center, 'Sign in' text link and black pill 'Download' button on the right."
+- "Build a chat composer: a Card-colored (--surface-elevated) 12px-radius container; inside, pill control chips (9999px) that are borderless at rest and gain a --border-default outline on hover."
+- "Design a confirm dialog: 12px-radius container, max-width 400px, pill buttons — solid CTA on the right, outlined secondary beside it; focus lands on the primary button."
+- "Create a dropdown: pill trigger; panel width bound to the trigger; 12px-radius Card panel with 1px Board border; option rows highlighted with 8px inner radius via --model-item-hover."
 
 ### Iteration Guide
 
@@ -360,7 +309,7 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 3. Always specify radius from the three tiers — pill (9999px) / container (12px) / inner control (8px, only for textareas & dropdown rows). Nothing else.
 4. Shadows are always zero — never add them
 5. Weight is always 400 or 500 — never bold
-6. If something feels too decorated, remove it — less is always more for Ollama
+6. If something feels too decorated, remove it — less is always more
 
 ## 10. Theme System & Token Reference
 
@@ -394,7 +343,7 @@ Cindy 桌面端用 **VSCode 风格的 ColorRegistry + Theme override** 模型管
 
 **Tier 1 — Semantic slot (39 个)**:跨语境复用的核心语义槽,加新主题时这一层是 override 的主战场。
 
-| 类目 | Slot | Ollama Light | Ollama Dark | 主要用途 |
+| 类目 | Slot | Default Light | Default Dark | 主要用途 |
 |---|---|---|---|---|
 | **Surface (12)** | `--surface` | `#f8f8f6` | `#1f1f1e` | 页面 Surface(hex 形式) |
 | | `--surface-hsl` | `60 12.5% 97%` | `60 2% 12%` | 同上 HSL 形式,`hsl(var(--xxx))` 消费 |

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -270,7 +270,7 @@ Three tiers — **these three only**:
 
 ### Don't
 
-- Don't introduce any chromatic color — no brand blue, no accent green, no warm tones
+- Don't introduce any chromatic color outside the sanctioned semantic set in §2 — no brand blue, no accent green, no warm tones beyond the registered exceptions
 - Don't invent arbitrary radii — only three values exist: 8px (inner controls), 12px (containers), 9999px (pill). Nothing in between, nothing else.
 - Don't add shadows to any element — the flat aesthetic is intentional
 - Don't use font weights above 500 — no bold, no black weight
@@ -286,7 +286,7 @@ Cindy Desktop is an Electron app: layout responds to window resizing, not page b
 
 ### Desktop Window
 
-- Minimum window size: **800 × 600** (enforced at the BrowserWindow level — `apps/desktop/src/main/bootstrap-electron.ts`; secondary windows share the same floor)
+- Minimum window size: **800 × 600** for the main window and secondary session windows (enforced at the BrowserWindow level — `apps/desktop/src/main/bootstrap-electron.ts` / `secondary-windows.ts`). The detached right-sidebar window has its own smaller floor of **360 × 480** (`right-sidebar-window/window.ts`) — layouts hosted there must stay legible down to that width
 - The sidebar is collapsible; region dividers and paddings hold as the window narrows, and content reflows fluidly
 - Chat stream and composer reflow with the window; code blocks keep horizontal scroll instead of wrapping
 - Control sizes and paddings follow §4 at every window size — targets never shrink below their specified geometry

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -55,7 +55,8 @@ The interface is built from a three-tier layer system that applies symmetrically
 Small interactive chips (button backgrounds, tag pills, avatar fills, selected-nav pills) sit outside the layer system — they're foreground elements, not background layers.
 
 - **Light Gray** (`#e5e5e5`): Chip/button backgrounds in Light Mode — the workhorse neutral for pressed states, filled pills, tag backgrounds, and avatar fills.
-- **Dark Chip** (`#2c2c2a`): Chip/button backgrounds in Dark Mode — equal to Dark Card; the lifted-pill color against a `#1f1f1e` Surface. (In Dark Mode, the Card layer color and the chip color collapse to the same value — both represent "one step lifted off Surface.")
+- **Dark Chip** (`#3c3c3a`, token `--surface-chip`): the primary chip/button background in Dark Mode — one step lifted above a Card or Surface context.
+- **Dark Chip Alt** (`#2c2c2a`, token `--surface-chip-alt`): the variant that collapses to the Dark Card value — used where a chip sits directly on Surface and only needs the Card-level lift. When in doubt, use `--surface-chip`; see §10 for both slots.
 
 > ~~**Border Light** (`#d4d4d4`)~~ —— 已废弃(2026-06,G2)。原称"white-button 专用边框色",但全仓库无真实组件使用(只有 experimental 视图裸 hardcode)。White Pill 次按钮边框统一走 **Board**(`--border-default` `#d7d7d4`)。
 
@@ -63,7 +64,7 @@ Small interactive chips (button backgrounds, tag pills, avatar fills, selected-n
 
 - **Stone** (`#737373`): Secondary body text, footer links, and de-emphasized content. The primary "muted" tone.
 - **Mid Gray** (`#525252`): Emphasized secondary text, slightly darker than Stone.
-- **Silver** (`#a3a3a3`): Tertiary text and deeply de-emphasized metadata. **不要用作 placeholder**——太显眼、读着像已填(见 §4 Inputs + §13 G3,placeholder 走 `--text-placeholder` `#c4c4c4`)。
+- **Silver** (`#a3a3a3`): Tertiary text and deeply de-emphasized metadata. **不要用作 placeholder**——太显眼、读着像已填(见 §4 Inputs;G3 勘误已归档 [`design-decision-log.md`](./design-decision-log.md),placeholder 走 `--text-placeholder` `#c4c4c4`)。
 
 > ~~**Button Text Dark** (`#404040`)~~ —— 已废弃(2026-06,G1)。原称"white-surface 按钮文字专用色",但全仓库无真实按钮使用(只有 experimental 视图裸 hardcode)。White Pill 次按钮文字统一走 **Near Black**(`--text-primary` `#262626`)。
 
@@ -71,8 +72,8 @@ Small interactive chips (button backgrounds, tag pills, avatar fills, selected-n
 
 The grayscale rule is near-absolute. The following are the **only** sanctioned non-gray colors in the system — each tightly scoped to a specific surface. New semantic colors must not be introduced without being recorded here first.
 
-- **Ring Blue** (`#3b82f6` at 50%): Tailwind's default focus ring, used exclusively for keyboard accessibility. Never visible in normal interaction flow.
-- **Thinking Orange** (`#EA6B17`,设计定稿 2026-07-17 取代 `#FF6600` 冻结红线): Used exclusively for the Running Status Bar in ChatView when the Claude Code SDK is actively processing (streaming / tool_use). Applies only to the sparkles icon and status text (e.g. `Spelunking...`); no background fill, no use outside this surface.
+- **Focus Blue** (`#417CDD` at 50%; tokens `--focus-ring` / `--focus-ring-soft`): the keyboard-accessibility focus ring, finalized 2026-07-17 (replaces Tailwind's default `#3b82f6`). Never visible in normal interaction flow.
+- **Thinking / Warning Orange** (`#EA6B17`, finalized 2026-07-17, replaces the frozen `#FF6600`): the shared warning-accent family, identical in both modes. Sanctioned consumers only — the ChatView Running Status Bar (sparkles icon + status text, e.g. `Spelunking...`, no background fill), running-state breathing icons in the sidebar, the collaboration toggle ON state, the plan-approve icon, the Full Access permission highlight, and the settings integration warning (see the §10 exemption table and §15 for the full token list: `--warning-accent` and its follower tokens). Any NEW consumer must be registered in §10 first.
 
 > **Additional narrowly-scoped exceptions** (documented in their respective component specs, do NOT generalize as system semantic colors):
 >
@@ -81,7 +82,7 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 > - **Permission Selector Mode Highlights** — selected risky permission modes may color only the option text/icon/checkmark and the collapsed trigger text/icon. The selected row background remains grayscale. Auto Approval uses `#417CDD` in both modes(设计定稿 2026-07-17 扩簇,light/dark 同值;取代 light #000050/dark #00D9C5). Full Access uses Heart Orange `#EA6B17` in both modes(随 warning-accent 自动跟随,定稿 2026-07-17). These hex values are the **default-theme palette only** — other themes may override `--perm-auto-selected-text` and `--perm-bypass-selected-text` with their own accent colors, provided both modes remain color-coded, distinguishable from each other, and visually distinct from neutral text. Tokens: `--perm-auto-selected-text` and `--perm-bypass-selected-text` in `apps/desktop/src/renderer/styles/globals.css`.
 > - **Diff Add Green / Diff Del Red** — GitHub-standard diff syntax colors, used on the `+` / `-` symbol glyph, the changed-line text foreground, **and the full row background** inside code-diff renderings. Applied in three places: (1) the Edit-tool DiffView card (F-MSG-6), (2) markdown ````diff` fenced code blocks in the message stream, and (3) `.diff` / `.patch` files opened in TextLightbox (the document previewer) — there hljs `.hljs-addition` / `.hljs-deletion` are forced `display: block` so the background fills to the right edge instead of stopping at the last glyph. Line-number gutter and ctx (unchanged) lines remain strictly grayscale per the layer system. **Foreground** — Add: `#22863a` Light / `#7ee787` Dark; Del: `#b31d28` Light / `#ff7b72` Dark. **Background** — Add: `#f0fff4` Light / `#033a16` Dark; Del: `#ffeef0` Light / `#67060c` Dark. Tokens: `--diff-add-fg/-bg` and `--diff-del-fg/-bg` in `apps/desktop/src/renderer/styles/globals.css`. Updated 2026-04-21: backgrounds switched from grayscale → GitHub red/green for full-row fill so additions / deletions are unambiguous at a glance.
 
-*Dark Mode text uses softened neutrals to reduce eye strain: **Soft Gray** (`#d4d4d4`) for primary text, Stone (`#737373`) for secondary, Silver (`#a3a3a3`) for tertiary. Pure White (`#ffffff`) is reserved for button labels and high-contrast UI elements on dark backgrounds.*
+*Dark Mode text uses softened neutrals to reduce eye strain: **Soft Gray** (`#d4d4d4`) for primary text, **Silver** (`#a3a3a3`) for secondary, **Stone** (`#737373`) for tertiary (per `--text-secondary` / `--text-tertiary` in `colors.ts` — the two swap between modes). Pure White (`#ffffff`) is reserved for button labels and high-contrast UI elements on dark backgrounds.*
 
 ### Gradient System
 
@@ -126,48 +127,62 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 
 ## 4. Component Stylings
 
+> 以下 Buttons / Cards / Inputs 采用结构化键值规格(2026-07 自 §12 试点采纳并入):`字段 → token → Default Light / Default Dark 解析值`。token 名以 §10 为准。
+
 ### Buttons
 
-**Gray Pill (Primary)**
+```
+button/primary  (Gray Pill — 主按钮)
+  fill      --surface-chip        #e5e5e5 / #3c3c3a
+  text      --text-primary        #262626 / #d4d4d4
+  border    1px solid --surface-chip   (同 fill)
+  radius    9999px (pill)
+  padding   10px 24px
+  height    ⚠ 未定义(规范只给 padding)
+  note      低调、灰阶、永远胶囊
 
-- Background: Light Gray (`#e5e5e5`)
-- Text: Near Black (`#262626`)
-- Padding: 10px 24px
-- Border: thin solid Light Gray (`1px solid #e5e5e5`)
-- Radius: pill-shaped (9999px)
-- The primary action button — understated, grayscale, always pill-shaped
+button/secondary  (White Pill — 次按钮)
+  fill      --surface-elevated    #ffffff / #2c2c2a
+  text      --text-primary        #262626 / #d4d4d4
+  border    --border-default      #d7d7d4 / #3c3c3a
+  radius    9999px (pill)
+  padding   10px 24px
+  note      比主按钮视觉更轻
 
-**White Pill (Secondary)**
-
-- Background: Pure White (`#ffffff`) — `--surface-elevated`
-- Text: Near Black (`#262626`) — `--text-primary`
-- Padding: 10px 24px
-- Border: thin solid Board (`1px solid #d7d7d4`) — `--border-default`
-- Radius: pill-shaped (9999px)
-- Secondary action — visually lighter than Gray Pill
-
-**Black Pill (CTA)**
-
-- Background: Pure Black (`#000000`)
-- Text: Pure White (`#ffffff`)
-- Radius: pill-shaped (9999px)
-- Maximum emphasis — black on white
+button/cta  (Black Pill — 最高强调)
+  fill      --accent-cta-bg-pure  #000000 / #ffffff
+  text      --accent-pure-cta-fg  #ffffff / #000000
+  radius    9999px (pill)
+  padding   10px 24px
+  note      纯黑底白字(dark 反相)
+```
 
 ### Cards & Containers
 
-- Background: Card (`#ffffff` Light / `#2c2c2a` Dark) or Surface (`#f8f8f6` Light / `#1f1f1e` Dark) depending on layer context
-- Border: thin solid Board (`1px solid #d7d7d4` Light / `1px solid #3c3c3a` Dark) when needed
-- Radius: comfortably rounded (12px) — the container radius (see §5 three-tier scale; 8px is reserved for inner controls like textareas / dropdown rows, pill for interactive elements)
-- Shadow: **none** — zero shadows on any element
-- Hover: likely subtle background shift or border darkening
+```
+card/container
+  fill      --surface-elevated    #ffffff / #2c2c2a   (页面级 flat 布局下用 --surface,见 §2 layer rule)
+  border    1px solid --border-default   #d7d7d4 / #3c3c3a   (需要分隔时才加)
+  radius    12px(容器档,Tailwind rounded-xl 直接量)
+            ⚠ 别用 §10 的 --radius——那是 shadcn 原语的 0.5rem(8px),与本 12px 容器圆角是两回事
+  shadow    none
+  hover     --surface-hover       #e5e5e5 / #3c3c3a
+```
 
 ### Inputs & Forms
 
-- Background: Card (`#ffffff` Light / `#2c2c2a` Dark)
-- Border: `1px solid` Board (`#d7d7d4` Light / `#3c3c3a` Dark)
-- Radius: pill-shaped (9999px) — single-line search inputs and form fields are pill-shaped. **多行输入框(textarea)套不了胶囊**(高框会变形),改用 8px 内层圆角(见 §5 三档圆角)。
-- Focus: Ring Blue (`#3b82f6` at 50%) ring
-- Placeholder: **`--text-placeholder`** slot — **Faded Light** (`#c4c4c4`) Light / **Mid Gray** (`#525252`) Dark — must read as clearly empty, not pre-filled. Silver (`#a3a3a3`) is too prominent against either Card surface (≈5:1 in Dark, ≈2.6:1 in Light) and reads as real input. **所有输入面的 placeholder(chat / ask / settings / plan-action-fb)统一收口于此 slot**(2026-06 G3);非默认主题通过 override `text-placeholder` 表达各自的 placeholder 色。
+```
+input/text
+  fill        --surface-elevated  #ffffff / #2c2c2a
+  text        --text-primary      #262626 / #d4d4d4
+  border      --border-default    #d7d7d4 / #3c3c3a
+  radius      9999px (pill,单行输入)
+  focus       --focus-ring        #417CDD @50%
+  placeholder --text-placeholder  #c4c4c4 / #525252
+```
+
+- **多行输入框(textarea)套不了胶囊**(高框会变形),改用 8px 内层圆角(见 §5 三档圆角)。
+- Placeholder 必须"读着像空"——Silver(`#a3a3a3`)对两种 Card 底都太显眼(≈5:1 Dark / ≈2.6:1 Light),读着像已填,禁用。**所有输入面的 placeholder(chat / ask / settings / plan-action-fb)统一收口于 `--text-placeholder`**(2026-06 G3,归档见 `design-decision-log.md`);非默认主题通过 override `text-placeholder` 表达各自的 placeholder 色。
 
 ### Select & Dropdown
 
@@ -288,10 +303,10 @@ Cindy Mobile (React Native) has its own device-class rules (phone / pad portrait
 - **Surface** (page bg): "Light Surface (#f8f8f6)" / "Dark Surface (#1f1f1e)"
 - **Card** (elevated layer): "Pure White (#ffffff)" / "Dark Card (#2c2c2a)"
 - **Board** (1px dividers/borders): "Light Board (#d7d7d4)" / "Dark Board (#3c3c3a)"
-- Secondary Text: "Dark Gray (#525252)" Light / "Silver (#a3a3a3)" Dark
-- Tertiary Text: "Stone (#737373)" Light / "Stone (#737373)" Dark
+- Secondary Text: "Stone (#737373)" Light / "Silver (#a3a3a3)" Dark — `--text-secondary`
+- Tertiary Text: "Silver (#a3a3a3)" Light / "Stone (#737373)" Dark — `--text-tertiary`
 - Near Black: (#262626) — Light primary reading text
-- Chip/Button Background: "Light Gray (#e5e5e5)" Light / "Dark Chip (#2c2c2a)" Dark
+- Chip/Button Background: "Light Gray (#e5e5e5)" Light / "Dark Chip (#3c3c3a)" Dark — `--surface-chip`(塌缩到 Card 的变体 `--surface-chip-alt` #2c2c2a 见 §2)
 
 ### Example Component Prompts
 
@@ -332,7 +347,7 @@ Cindy 桌面端用 **VSCode 风格的 ColorRegistry + Theme override** 模型管
 
 源码:`apps/desktop/src/renderer/themes/`
 - `color-registry.ts` — `ColorRegistry` 单例和 `registerColor(id, defaults, description)` API
-- `colors.ts` — 注册全部 token(目前 352 个:40 semantic slot + 228 alias + 84 singleton),按"semantic slot 在前,alias 和 singleton 在后"组织
+- `colors.ts` — 注册全部 token,按"semantic slot 在前,alias 和 singleton 在后"组织(计数持续漂移,**数量一律以 `colors.ts` 为准**,本文档不维护总数)
 - `theme-service.ts` — `applyTheme(theme)` 把所有 token 序列化成 `:root{}` 注入 `<style id="theme-vars">`
 - `builtin/` — 内置主题对象(`cindy-light.ts` / `cindy-dark.ts` / `eclipse.ts` / `default-light.ts` / `default-dark.ts` 及各社区配色)
 - `registry.ts` — `builtinThemes` 注册表 + `listThemesByType('light' | 'dark')`
@@ -341,11 +356,11 @@ Cindy 桌面端用 **VSCode 风格的 ColorRegistry + Theme override** 模型管
 
 ### Token 分层
 
-**Tier 1 — Semantic slot (39 个)**:跨语境复用的核心语义槽,加新主题时这一层是 override 的主战场。
+**Tier 1 — Semantic slot**:跨语境复用的核心语义槽,加新主题时这一层是 override 的主战场。下表穷举全部 slot,即 Tier-1 名录。
 
 | 类目 | Slot | Default Light | Default Dark | 主要用途 |
 |---|---|---|---|---|
-| **Surface (12)** | `--surface` | `#f8f8f6` | `#1f1f1e` | 页面 Surface(hex 形式) |
+| **Surface** | `--surface` | `#f8f8f6` | `#1f1f1e` | 页面 Surface(hex 形式) |
 | | `--surface-hsl` | `60 12.5% 97%` | `60 2% 12%` | 同上 HSL 形式,`hsl(var(--xxx))` 消费 |
 | | `--surface-elevated` | `#ffffff` | `#2c2c2a` | Card 抬一层 / 弹窗 / popover |
 | | `--surface-elevated-soft` | `#e5e5e5` | `#2c2c2a` | Disabled 状态 Card |
@@ -356,11 +371,11 @@ Cindy 桌面端用 **VSCode 风格的 ColorRegistry + Theme override** 模型管
 | | `--surface-hover-soft` | `#f8f8f6` | `#3c3c3a` | 柔和 hover bg |
 | | `--surface-hover-hsl` | `0 0% 90%` | `60 2% 17%` | hover HSL 形式 |
 | | `--surface-on-card` | `#ffffff` | `#1f1f1e` | CTA / checked icon 深色前景 |
-| **Border (4)** | `--border-default` | `#d7d7d4` | `#3c3c3a` | 本规范 Board 1px 边框 |
+| **Border** | `--border-default` | `#d7d7d4` | `#3c3c3a` | 本规范 Board 1px 边框 |
 | | `--border-default-hsl` | `60 3% 84%` | `60 2% 23%` | Board HSL 形式 |
 | | `--border-shadcn-hsl` | `0 0% 90%` | `30 4% 28%` | shadcn input/border HSL |
 | | `--border-transparent-mixed` | `transparent` | `#3c3c3a` | progress track 等单边边框 |
-| **Text (16)** | `--text-primary` | `#262626` | `#d4d4d4` | 主标题 / 主正文 |
+| **Text** | `--text-primary` | `#262626` | `#d4d4d4` | 主标题 / 主正文 |
 | | `--text-primary-hsl` | `0 0% 9%` | `0 0% 83%` | Primary HSL 形式 |
 | | `--text-primary-on-dark` | `#262626` | `#ffffff` | 反相文本(stop button icon 等) |
 | | `--text-primary-emphasis` | `#1a1a1a` | `#d4d4d4` | Plan 强调主文字 |
@@ -376,24 +391,24 @@ Cindy 桌面端用 **VSCode 风格的 ColorRegistry + Theme override** 模型管
 | | `--text-disabled` | `#d4d4d4` | `#525252` | Disabled / failed |
 | | `--text-disabled-tertiary` | `#a3a3a3` | `#737373` | Disabled placeholder 变体 |
 | | `--text-placeholder` | `#c4c4c4` | `#525252` | 统一 placeholder slot(比 tertiary 更淡,读着像空);chat/ask/settings/plan-action-fb 输入框 placeholder 均收口于此 |
-| **Accent (7)** | `--accent-cta-bg` | `#262626` | `#ffffff` | 反相 CTA bg |
+| **Accent** | `--accent-cta-bg` | `#262626` | `#ffffff` | 反相 CTA bg |
 | | `--accent-cta-bg-pure` | `#000000` | `#ffffff` | Pure CTA bg |
 | | `--accent-emphasis` | `#262626` | `#d4d4d4` | settings primary button 等 |
 | | `--accent-soft` | `#262626` | `#ffffff` | Soft accent(folder btn 等) |
 | | `--accent-hover` | `#262626` | `#e5e5e5` | CTA pressed/hover |
 | | `--accent-pure-cta-fg` | `#ffffff` | `#000000` | CTA 文字 pure 反相 |
-| | `--accent-fg-on-pure` | `#ffffff` | `#1f1f1e` | CTA 文字 light 白 / dark 沉 |
 
-**Tier 2 — Alias (228 个)**:大量 component-scoped token(如 `--cmd-palette-bg`、`--msg-tool-card-text`、`--settings-input-border`)的 default 改写为 `var(--slot)`。浏览器自动 forward-resolve。组件不感知,**继续直接消费 alias 名字即可**。
+**Tier 2 — Alias**:大量 component-scoped token(如 `--cmd-palette-bg`、`--msg-tool-card-text`、`--settings-input-border`)的 default 改写为 `var(--slot)`。浏览器自动 forward-resolve。组件不感知,**继续直接消费 alias 名字即可**。
 
-**Tier 3 — Singleton (84 个)**:真独立的色值,无法收敛到 slot:语义豁免色(`--destructive` / `--diff-add-*` / `--status-bar-accent` 等)、平台特定色、splash 时长、`--radius` 等非颜色 token。
+**Tier 3 — Singleton**:真独立的色值,无法收敛到 slot:语义豁免色(`--destructive` / `--diff-add-*` / `--status-bar-accent` 等)、平台特定色、splash 时长、`--radius` 等非颜色 token。
 
 ### 语义豁免色(跨主题不变)
 
 | Token | Light | Dark | 用途 |
 |---|---|---|---|
 | `--destructive` (HSL) | `0 84% 60%` | `0 72% 63%` | 通用 destructive 文本/边 |
-| `--login-error-text` 等 5 个 | `#ef4444` | `#ef4444` | 错误文本 |
+| `--error-flat` | `#ef4444` | `#ef4444` | 扁平 danger 前景 |
+| `--login-error-fg` | `#D91F37` | `#D91F37` | 登录错误文本/描边(见 §16.1) |
 | `--error-bg/-border/-fg/-fg-strong` | (red) | (red) | Error alert 卡片子系统 |
 | `--diff-add-fg/-bg`, `--diff-del-fg/-bg` | GitHub palette | GitHub palette | Diff 渲染 |
 | `--status-bar-accent` | `#EA6B17` | `#EA6B17` | Thinking Orange,跨主题统一(定稿 2026-07-17) |
@@ -483,72 +498,19 @@ Cindy 的产品气质和视觉一致:**克制、直接、不自夸**。文案是
 - [ ] 进行中态是"现在进行时 + …"
 - [ ] 4 个 `common.json` 都补齐且符合本语言的大小写/标点(见 `docs/dev-rules/engineering-conventions.md` §5)
 
-## 12. Component Spec(结构化样板 — 待定)
+## 12. Component Spec(已并入 §4)
 
-> **状态:样板,待你 review。** 本节是把 §4 组件散文规格改写成 **Vercel `design.md` 那种「可机读 / 可执行」结构化键值**的试点,先做 Buttons / Inputs / Cards 三个。**确认采用后,就地替换 §4 的散文描述并删除本节**;不采用则整节删掉,§4 不受影响。
->
-> 读法:`字段  →  token  →  Default Light / Default Dark 解析值`。token 名以 §10 表为准;`⚠` 标记"规范里有值但 §10 暂无对应 token / 字段在 §4 未定义"的缺口——这正是结构化格式相对散文的价值:把隐性缺口显性化。
+> 本节的结构化组件规格试点(Buttons / Inputs / Cards)已于 2026-07 采纳并**就地并入 §4**;
+> 编号保留占位,避免 §13–§16 重编号导致仓库内外引用断链(章节编号的最终整理随 §15 重构
+> 一并处理,见 `design-decision-log.md`)。
 
-```
-button/primary  (Gray Pill — 主按钮)
-  fill      --surface-chip        #e5e5e5 / #3c3c3a
-  text      --text-primary        #262626 / #d4d4d4
-  border    1px solid --surface-chip   (同 fill)
-  radius    9999px (pill)
-  padding   10px 24px
-  height    ⚠ §4 未定义(§4 仅给 padding)
+## 13. Open Spec / Token Gaps
 
-button/secondary  (White Pill — 次按钮)
-  fill      --surface-elevated    #ffffff / #2c2c2a
-  text      --text-primary        #262626 / #d4d4d4   (G1 已解决:原 #404040「Button Text Dark」是漂移)
-  border    --border-default      #d7d7d4 / #3c3c3a   (G2 已解决:原 #d4d4d4「Border Light」是漂移)
-  radius    9999px (pill)
-  padding   10px 24px
+No gaps are currently open.
 
-button/cta  (Black Pill — 最高强调)
-  fill      --accent-cta-bg-pure  #000000 / #ffffff
-  text      --accent-pure-cta-fg  #ffffff / #000000
-  radius    9999px (pill)
-  padding   10px 24px
+Resolved items (G1–G4, 2026-06 — button-text drift, border drift, placeholder unification, radius tiering) are archived in [`design-decision-log.md`](./design-decision-log.md); each entry records the drift, the ruling, and where the conclusion was folded back (§2 / §4 / §5 / §10).
 
-input/text
-  fill        --surface-elevated  #ffffff / #2c2c2a
-  text        --text-primary      #262626 / #d4d4d4
-  border      --border-default    #d7d7d4 / #3c3c3a
-  radius      9999px (pill)
-  focus       --focus-ring        #3b82f6 @50%(双层带缝 ring 见外部讨论 ③,待定)
-  placeholder --text-placeholder   #c4c4c4 / #525252   (G3 已解决:新增统一 slot,4 个输入面 alias 全部收口)
-
-card/container
-  fill      --surface-elevated    #ffffff / #2c2c2a   (页面级 flat 布局下改用 --surface,见 §2 layer rule)
-  border    1px solid --border-default   #d7d7d4 / #3c3c3a   (需要分隔时才加)
-  radius    12px (Tailwind rounded-xl,直接量) — 容器档圆角(三档之一,见 §5;8px 仅内层控件 textarea / 下拉行,pill 给交互件)
-            ⚠ 不要用 §10 的 --radius:那是 shadcn 原语用的 0.5rem(8px),与本 12px 容器圆角是两回事
-  shadow    none
-  hover     --surface-hover       #e5e5e5 / #3c3c3a   (§4 原文是「likely」,此处给出可用 token)
-```
-
-## 13. Known Spec / Token Gaps（跟踪中）
-
-> §12 结构化重写过程中暴露的设计系统欠债。本节**持久存在**(独立于 §12 是否被采用),每条解决后打勾并把结论并入 §2 / §4 / §10。下列"现状"均已 grep 源码核实(以源码为准),非臆测。涉及新增/改 token 的(G3 / G4)按第 10 节的 token 规则须先与 owner 确认再动 `colors.ts`。
-
-- [x] **G1 — 白底次按钮文字 `#404040`「Button Text Dark」是文档漂移,非真 token**(已解决 2026-06)
-  现状:§2 / §4 称其"专用于白底按钮文字",但全仓库只有 `features/maker-experimental/MakerExperimentalView.tsx`(实验视图,裸 hardcode)出现 #404040,**无任何真实次按钮**用它做文字色;§10 也无对应 token。
-  处理:§2 标废弃、§4 White Pill 文字改引 `--text-primary`(#262626)。未动 token,纯文档。
-
-- [x] **G2 — 次按钮边框 `#d4d4d4`「Border Light」同为漂移**(已解决 2026-06)
-  现状:§4 称白底按钮边框 `1px solid #d4d4d4`,但无真实组件这么用;#d4d4d4 的线上出现要么在实验视图(裸 hardcode),要么是**暗色主文字**(`--text-primary` dark = #d4d4d4,如 SchedulerPage CTA 注释),与"边框"无关。真边框 token 是 `--border-default`(#d7d7d4)。
-  处理:§2 标废弃、§4 White Pill 边框改引 `--border-default`(#d7d7d4)。纯文档。
-
-- [x] **G3 — placeholder token 碎片化 + 取值自相矛盾(真欠债)**(已解决 2026-06)
-  现状:4 个 per-surface alias 无统一 slot,且取值打架——`--settings-input-placeholder` = #c4c4c4(§4 认证的"淡到读着像空"),但 `--chat-input-placeholder` = `var(--text-tertiary)` = **#a3a3a3(Silver)**,而 §4 白纸黑字说 Silver **太显眼、读着像已填、不可做 placeholder**。即聊天输入框 placeholder 实际违反了我们自己的 §4 规范。
-  处理:`colors.ts` 新增语义 slot `--text-placeholder`(#c4c4c4 / #525252),4 个 alias(chat/ask/settings/plan-action-fb)default 收口为 `var(--text-placeholder)`;7 套非默认主题原 `settings-input-placeholder` override 就地改名为 `text-placeholder`(沿用原常量,避免回退,符合第 10 节对每套主题的 override 评估)。默认主题下 chat placeholder 由 #a3a3a3 修正为 #c4c4c4。2 套亮色主题(atom-one-light / solarized-light)的 `text-placeholder` 进一步从 tertiary 改用各自 **disabled 档**(更淡)——亮色背景下 tertiary≈2.6:1 命中 §4 禁用 Silver 的对比度,placeholder 须更淡才读着像空(2026-06 review 反馈)。**本地/复制主题兼容**:slot 引入前创建的本地主题快照只冻结了旧 per-surface placeholder key、无 `text-placeholder`,加载期 `mapWireTheme` 经 `local-themes-normalize.ts` 归一化——缺 `text-placeholder` 时从旧 `settings-input-placeholder`(或任一 per-surface 值)播种并丢弃 4 个旧 per-surface override,使四个输入面统一走新 slot(不改写盘上 JSON、幂等;2026-06 review 反馈)。
-
-- [x] **G4 — `--radius`(8px)与容器圆角同名不同义(已解决 2026-06)**
-  现状:`--radius` 实为 `0.5rem`(8px,shadcn 原语用);容器 12px 圆角实际靠 Tailwind `rounded-xl` 直接量实现。
-  处理:**圆角体系正式从"二元"改为"三档"**(8px 内层控件 / 12px 容器 / 9999px pill,见 §5 + §7 + §1)。8px 这一档窄范围限定多行输入框、下拉 / 菜单选中行、段内小单元,实现为 `rounded-lg`;shadcn `--radius`(8px)与这个内层档数值相同但语义独立(原语专用),容器仍走 `rounded-xl`(12px)。**本次纯文档,未动 token**。是否进一步 token 化为 `--radius-inner`(8px)/ `--radius-container`(12px)/ `--radius-pill`(9999px),收益偏低、**暂缓**,要做走第 10 节的新增 token 流程。
-
-> **旁注(不在本次范围,仅记录)**:`MakerExperimentalView.tsx` 通篇裸 hardcode hex(#404040 / #d4d4d4 / #262626 / #333),违反第 10 节 token 规则。因是 experimental 视图、且非本次任务,**不在此清理**,仅备忘。
+Known but deliberately-deferred cleanups (e.g. hardcoded hex in `MakerExperimentalView.tsx`) are tracked in the decision log's backlog section, not here.
 
 ## 14. Interaction Conventions(交互约定)
 
@@ -602,13 +564,13 @@ card/container
 | 列表重排 | FLIP,transform 平移 | `components/ui/toast/ToastContainer.tsx` |
 | 按压 | `active:scale-[0.98]`(交互 pill / 按钮通用) | ConfirmDialog 按钮 |
 | 完成 | **全 app 唯一允许 overshoot 的语义**(`status-done-pop`) | `globals.css` |
-| 运行中 | opacity 呼吸,必须挂 HTML wrapper(AGENTS.md 规则 7) | `session-breathing` |
+| 运行中 | opacity 呼吸,必须挂 HTML wrapper(`docs/dev-rules/engineering-conventions.md` §7) | `session-breathing` |
 | hover / 状态色 | `transition-colors`,≤ fast(150ms) | 全 app 现状 |
 | 容器形变(chip 长成弹层) | 220ms,见下方独立类目(显式例外) | composer 权限/模型选择器 |
 
 #### 红线(性能与克制)
 
-- **常驻/循环动画只允许 HTML 元素上的 `transform` / `opacity`**(compositor-only,AGENTS.md 规则 7 全文适用;SVG 上不挂任何动画)。
+- **常驻/循环动画只允许 HTML 元素上的 `transform` / `opacity`**(compositor-only,`docs/dev-rules/engineering-conventions.md` §7 全文适用;SVG 上不挂任何动画)。
 - 高度/grid 等非 compositor 属性只允许**一次性瞬态动画**(用户触发、有明确结束),不允许常驻。
 - 新增 `@keyframes` / `animate-*` 类必须同步登记 `globals.css` 的 `prefers-reduced-motion` 白名单(全局 `* { transition: none }` 兜不住 keyframes)。
 - 实时跟手的交互(resizer 拖动、拖拽跟随)**不加缓动**——跟手即反馈。
@@ -635,9 +597,12 @@ card/container
 
 ## 15. CINDY 皮肤族(品牌化可选 family)
 
-> 本节为 CINDY 皮肤族的规范记录,**不改写 §1-7 默认皮肤规范**。值的权威来源:
-> `skin-docs/10-specs/` 桌面端体系、`skin-docs/30-mobile/2026-07-18-m0-color-mapping.md`
-> 移动端勘误版,以及 2026-07-18 双端验收后的用户最终口头定稿。实现时零自由裁量。
+> 本节为 CINDY 皮肤族的规范记录,**不改写 §1-7 默认皮肤规范**。取值定稿依据为
+> 设计阶段工作文件(`skin-docs/10-specs/` 桌面端体系、`skin-docs/30-mobile/`
+> 移动端勘误版——**均不入仓库**,地位同 §16 的登录工作文件)以及 2026-07-18 双端
+> 验收后的用户最终口头定稿。实现时零自由裁量:仓库内的权威编码是主题文件
+> (`cindy-light.ts` / `cindy-dark.ts`)、`cindyDecisionData.ts` 与各冻结测试,
+> 本节是其散文摘要。
 
 ### 15.1 色板(Figma 文本节点提取)
 
@@ -723,7 +688,7 @@ Splash 品牌块字标是另一套素材(`assets/splash/wordmark.png` 白字 DAR
   - 选中胶囊 = 反相胶囊(2026-07-20 定稿):`sidebar-item-active` light `#3C3F43`/dark `#EEEEEE`,前景 `sidebar-item-active-foreground` light `#FCFCFC`/dark `#252222`,描边 `sidebar-item-active-border` transparent;**凡 `bg-sidebar-item-active` 上的前景必须配 `text-sidebar-item-active-foreground`,禁用 `text-foreground`**(PR#190 全量整改,该 token 缺省=foreground,非 CINDY 零变化);
   - 强调行(running)行首图标(厂商 glyph/Puzzle/RadioTower/Clock)= **Thinking Orange `--warning-accent` `#EA6B17`**(用户拍板 2026-07-20,取代红系时期规则),呼吸动画 `session-status-breathing`;**选中态同样橙(running 取色优先级高于反相前景)**;移动端 `statusAccent` 同值同规则。常驻呼吸动画必须挂 HTML wrapper,SVG 保持静态(常驻动画 compositor-only 红线,见 `docs/dev-rules/engineering-conventions.md` §7;PR#226 治理)。
   - 断言:③ CINDY_EXPECTED 守 4 token 值;⑦ 新增层级断言(二级暗灰 contrast 明显弱于正文 + 选中胶囊前景×红底 ≥4.5)。
-- **backlog(R2 §4.3 五点差异,lead 裁决 2026-07-17 本轮不做,入 backlog)**:Project_List 三态拆分(active-task-pill/project-card/flat-list-row 不共用 `sidebar-item-active`);项目 header/list card 选中应中性底(#312F2F/#F6F6F6 非 #DF0C27 大红);去 Project_List 选中组 `focus-ring-soft` 蓝 ring,改 card stroke #DCDFE3/#434343;小箭头 #A61629 强调(非整行红底)。详见 `2026-07-17-r2-ui-specs.md` §4.3。本轮收敛不扩战线,后续另开。
+- **backlog(R2 §4.3 五点差异,lead 裁决 2026-07-17 本轮不做,入 backlog)**:Project_List 三态拆分(active-task-pill/project-card/flat-list-row 不共用 `sidebar-item-active`);项目 header/list card 选中应中性底(#312F2F/#F6F6F6 非 #DF0C27 大红);去 Project_List 选中组 `focus-ring-soft` 蓝 ring,改 card stroke #DCDFE3/#434343;小箭头 #A61629 强调(非整行红底)。详见设计阶段工作文件 `2026-07-17-r2-ui-specs.md` §4.3(不入仓库)。本轮收敛不扩战线,后续另开。
 
 三份新 map(`NEUTRAL_PRIMARY_EXPECTED_BY_ID`/`FOREGROUND` + `RED_EXCEPTION_ALLOWED_IDS`)替代旧 `BRAND_RED_*`。D2T ⑤/⑦/⑧ 改用新 map(中性 exact + 红例外白名单 + 中性对比度 + 可证伪)。
 
@@ -887,13 +852,13 @@ Splash 品牌块字标是另一套素材(`assets/splash/wordmark.png` 白字 DAR
 
 **平台差异**：桌面 = Web renderer（Electron，Win / Mac 同套）；手机 = React Native（iOS / Android，含 phone / pad-portrait / pad-landscape）。两端同参数源、同 token 语义（手机 `loginColors` 与桌面 `LOGIN_COLORS` 同名同值），仅实现宿主不同（RN 用 `StyleSheet` + `Animated`，桌面用 CSS + Tailwind）。
 
-**交互态**：hover（仅桌面）/ pressed（双端）/ disabled / loading 五态。态叠层挂伪元素（桌面 `::after`）/ overlay View（手机），**不动图标 / 文本子节点**；disabled 叠层走 `--login-disabled-button-overlay` token。hover / pressed 叠层**暗色落地前**为 figma 实测 rgba 字面值（亮色 as-built 现状）；**暗色 PR 起 token 化为 `--login-overlay-*` 二态 token**（叠层方向随模式反转，见 §16.5），此后组件内禁止新增字面 rgba 叠层。态系细则见 `DESIGN.md §2`。
+**交互态**：hover（仅桌面）/ pressed（双端）/ disabled / loading 五态。态叠层挂伪元素（桌面 `::after`）/ overlay View（手机），**不动图标 / 文本子节点**；disabled 叠层走 `--login-disabled-button-overlay` token。hover / pressed 叠层**暗色落地前**为 figma 实测 rgba 字面值（亮色 as-built 现状）；**暗色 PR 起 token 化为 `--login-overlay-*` 二态 token**（叠层方向随模式反转，见 §16.5），此后组件内禁止新增字面 rgba 叠层。态系细则见设计阶段工作文件 `DESIGN-login §2`(不入仓库)。
 
 **常驻动画 compositor-only**：spinner / loading 环动画挂 HTML（桌面）/ `Animated.View`（手机）外层 wrapper，SVG 图形保持静态（呼应 §14.4）；`prefers-reduced-motion` 直落静止。面板入场 handoff 动画是 §14.4 容器形变的窄变体（双端冻结 420ms 升起 + 渐显，`LOGIN_HANDOFF_TIMINGS.panelMs` / `panelInMs`）。
 
 **Apple「Sign in with Apple」按钮**：iOS HIG 硬性要求使用 Apple 官方按钮样式，**不可皮肤化**——iOS 上 Apple 槽位保持原生 `ASAuthorizationAppleIDButton`，不套 `LoginSocialButton` 皮。这是合规底线，非视觉遗漏。其余社交圆钮（Google / WeChat / SSO）正常上皮。
 
-**i18n**：登录文案走 `react-i18next`（桌面 `common.json` `login.*` 节）/ `loginMessages`（手机），4 语对齐 `zh-CN` / `en` / `ja` / `ko`（zh-TW 已随 #488 回退对齐主干四语基线——设计阶段旧文（不在仓库内）的五语门为回退前遗留，待清理，以本节四语为准）。4 语全部翻准，不留空（空 key 静默回退英文）。
+**i18n**：登录文案走 `react-i18next`（桌面 `common.json` `login.*` 节）/ `loginMessages`（手机），4 语对齐 `zh-CN` / `en` / `ja` / `ko`（zh-TW 已随旧仓 #488 回退对齐主干四语基线——设计阶段旧文（不在仓库内）的五语门为回退前遗留，待清理，以本节四语为准）。4 语全部翻准，不留空（空 key 静默回退英文）。
 
 **多语言长文本与翻译长度预算（2026-07-24 拍板）**：
 

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -24,7 +24,7 @@ What makes this system distinctive is the combination of a single geometric sans
 
 ## 2. Color Palette & Roles
 
-> **多主题架构注意**:本节列出的色值是 **Default Light / Default Dark**(默认主题)的具体值,作为视觉规范的参考样本。运行时**每个色值都通过 token 引用**(见第 10 节 Theme System & Token Reference),所以同一组件在其它主题(如 Eclipse / One Dark Pro / Monokai Pro)下会自动呈现该主题的对应色。**实现组件时永远写 token 不写 hex**——具体规则见第 10 节。
+> **Multi-theme note**: the values in this section are the concrete **Default Light / Default Dark** (base theme) palette, given as the visual-spec reference sample. At runtime **every color is consumed through a token** (see §10 Theme System & Token Reference), so the same component automatically renders each theme's own colors under other themes (Eclipse / One Dark Pro / Monokai Pro, …). **When implementing components, always write tokens, never hex** — rules in §10.
 
 ### Primary Text
 
@@ -58,15 +58,15 @@ Small interactive chips (button backgrounds, tag pills, avatar fills, selected-n
 - **Dark Chip** (`#3c3c3a`, token `--surface-chip`): the primary chip/button background in Dark Mode — one step lifted above a Card or Surface context.
 - **Dark Chip Alt** (`#2c2c2a`, token `--surface-chip-alt`): the variant that collapses to the Dark Card value — used where a chip sits directly on Surface and only needs the Card-level lift. When in doubt, use `--surface-chip`; see §10 for both slots.
 
-> ~~**Border Light** (`#d4d4d4`)~~ —— 已废弃(2026-06,G2)。原称"white-button 专用边框色",但全仓库无真实组件使用(只有 experimental 视图裸 hardcode)。White Pill 次按钮边框统一走 **Board**(`--border-default` `#d7d7d4`)。
+> ~~**Border Light** (`#d4d4d4`)~~ — deprecated (2026-06, G2). Once labeled the "white-button border color", but no real component ever used it (only bare hardcodes in the experimental view). White Pill secondary borders uniformly use **Board** (`--border-default` `#d7d7d4`).
 
 ### Neutrals & Text
 
 - **Stone** (`#737373`): Secondary body text, footer links, and de-emphasized content. The primary "muted" tone.
 - **Mid Gray** (`#525252`): Emphasized secondary text, slightly darker than Stone.
-- **Silver** (`#a3a3a3`): Tertiary text and deeply de-emphasized metadata. **不要用作 placeholder**——太显眼、读着像已填(见 §4 Inputs;G3 勘误已归档 [`design-decision-log.md`](./design-decision-log.md),placeholder 走 `--text-placeholder` `#c4c4c4`)。
+- **Silver** (`#a3a3a3`): Tertiary text and deeply de-emphasized metadata. **Never use it as a placeholder** — too prominent, reads as filled-in (see §4 Inputs; the G3 erratum is archived in [`design-decision-log.md`](./design-decision-log.md); placeholders use `--text-placeholder` `#c4c4c4`).
 
-> ~~**Button Text Dark** (`#404040`)~~ —— 已废弃(2026-06,G1)。原称"white-surface 按钮文字专用色",但全仓库无真实按钮使用(只有 experimental 视图裸 hardcode)。White Pill 次按钮文字统一走 **Near Black**(`--text-primary` `#262626`)。
+> ~~**Button Text Dark** (`#404040`)~~ — deprecated (2026-06, G1). Once labeled the "white-surface button text color", but no real button ever used it (only bare hardcodes in the experimental view). White Pill secondary text uniformly uses **Near Black** (`--text-primary` `#262626`).
 
 ### Semantic & Accent
 
@@ -77,9 +77,9 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 
 > **Additional narrowly-scoped exceptions** (documented in their respective component specs, do NOT generalize as system semantic colors):
 >
-> - **Toast Info / Success / Warning / Error** — `#417CDD` / `#2AAE5B` / `#F3A115` / `#D91F37`(E5D 定稿 2026-07-17 扩簇,Toast 豁免解除)used ONLY on the 16×16 lucide icon inside Toast pill notifications. The pill body (background, text, border, close icon) remains strictly grayscale. info 蓝 #417CDD 与 focus-ring/Auto Approval 同值(原 #3B82F6 2026-07-14 增,现定稿);success/warning/error 与全局状态色同值(done 绿/状态 error/warning 前景)。
+> - **Toast Info / Success / Warning / Error** — `#417CDD` / `#2AAE5B` / `#F3A115` / `#D91F37`(finalized 2026-07-17; Toast exemption lifted) — used ONLY on the 16×16 lucide icon inside Toast pill notifications. The pill body (background, text, border, close icon) remains strictly grayscale. Info blue #417CDD equals the focus-ring / Auto Approval value (originally #3B82F6, added 2026-07-14, now finalized); success/warning/error equal the global status colors (done green / status error / warning foreground).
 > - **ConfirmDialog Danger** — `#EF4444` used ONLY on the confirm button background in the Danger variant. The cancel button and rest of the dialog remain grayscale.
-> - **Permission Selector Mode Highlights** — selected risky permission modes may color only the option text/icon/checkmark and the collapsed trigger text/icon. The selected row background remains grayscale. Auto Approval uses `#417CDD` in both modes(设计定稿 2026-07-17 扩簇,light/dark 同值;取代 light #000050/dark #00D9C5). Full Access uses Heart Orange `#EA6B17` in both modes(随 warning-accent 自动跟随,定稿 2026-07-17). These hex values are the **default-theme palette only** — other themes may override `--perm-auto-selected-text` and `--perm-bypass-selected-text` with their own accent colors, provided both modes remain color-coded, distinguishable from each other, and visually distinct from neutral text. Tokens: `--perm-auto-selected-text` and `--perm-bypass-selected-text` in `apps/desktop/src/renderer/styles/globals.css`.
+> - **Permission Selector Mode Highlights** — selected risky permission modes may color only the option text/icon/checkmark and the collapsed trigger text/icon. The selected row background remains grayscale. Auto Approval uses `#417CDD` in both modes (finalized 2026-07-17, same value light/dark; replaces light #000050 / dark #00D9C5). Full Access uses Heart Orange `#EA6B17` in both modes (auto-follows warning-accent, finalized 2026-07-17). These hex values are the **default-theme palette only** — other themes may override `--perm-auto-selected-text` and `--perm-bypass-selected-text` with their own accent colors, provided both modes remain color-coded, distinguishable from each other, and visually distinct from neutral text. Tokens: `--perm-auto-selected-text` and `--perm-bypass-selected-text` in `apps/desktop/src/renderer/styles/globals.css`.
 > - **Diff Add Green / Diff Del Red** — GitHub-standard diff syntax colors, used on the `+` / `-` symbol glyph, the changed-line text foreground, **and the full row background** inside code-diff renderings. Applied in three places: (1) the Edit-tool DiffView card (F-MSG-6), (2) markdown ````diff` fenced code blocks in the message stream, and (3) `.diff` / `.patch` files opened in TextLightbox (the document previewer) — there hljs `.hljs-addition` / `.hljs-deletion` are forced `display: block` so the background fills to the right edge instead of stopping at the last glyph. Line-number gutter and ctx (unchanged) lines remain strictly grayscale per the layer system. **Foreground** — Add: `#22863a` Light / `#7ee787` Dark; Del: `#b31d28` Light / `#ff7b72` Dark. **Background** — Add: `#f0fff4` Light / `#033a16` Dark; Del: `#ffeef0` Light / `#67060c` Dark. Tokens: `--diff-add-fg/-bg` and `--diff-del-fg/-bg` in `apps/desktop/src/renderer/styles/globals.css`. Updated 2026-04-21: backgrounds switched from grayscale → GitHub red/green for full-row fill so additions / deletions are unambiguous at a glance.
 
 *Dark Mode text uses softened neutrals to reduce eye strain: **Soft Gray** (`#d4d4d4`) for primary text, **Silver** (`#a3a3a3`) for secondary, **Stone** (`#737373`) for tertiary (per `--text-secondary` / `--text-tertiary` in `colors.ts` — the two swap between modes). Pure White (`#ffffff`) is reserved for button labels and high-contrast UI elements on dark backgrounds.*
@@ -127,44 +127,44 @@ The grayscale rule is near-absolute. The following are the **only** sanctioned n
 
 ## 4. Component Stylings
 
-> 以下 Buttons / Cards / Inputs 采用结构化键值规格(2026-07 自 §12 试点采纳并入):`字段 → token → Default Light / Default Dark 解析值`。token 名以 §10 为准。
+> Buttons / Cards / Inputs below use the structured key-value format (adopted from the §12 pilot, 2026-07): `field → token → Default Light / Default Dark resolved values`. Token names per §10.
 
 ### Buttons
 
 ```
-button/primary  (Gray Pill — 主按钮)
+button/primary  (Gray Pill)
   fill      --surface-chip        #e5e5e5 / #3c3c3a
   text      --text-primary        #262626 / #d4d4d4
-  border    1px solid --surface-chip   (同 fill)
+  border    1px solid --surface-chip   (same as fill)
   radius    9999px (pill)
   padding   10px 24px
-  height    ⚠ 未定义(规范只给 padding)
-  note      低调、灰阶、永远胶囊
+  height    ⚠ not yet specified (only padding is normative)
+  note      understated, grayscale, always a pill
 
-button/secondary  (White Pill — 次按钮)
+button/secondary  (White Pill)
   fill      --surface-elevated    #ffffff / #2c2c2a
   text      --text-primary        #262626 / #d4d4d4
   border    --border-default      #d7d7d4 / #3c3c3a
   radius    9999px (pill)
   padding   10px 24px
-  note      比主按钮视觉更轻
+  note      visually lighter than primary
 
-button/cta  (Black Pill — 最高强调)
+button/cta  (Black Pill — maximum emphasis)
   fill      --accent-cta-bg-pure  #000000 / #ffffff
   text      --accent-pure-cta-fg  #ffffff / #000000
   radius    9999px (pill)
   padding   10px 24px
-  note      纯黑底白字(dark 反相)
+  note      pure black on white (inverts in Dark)
 ```
 
 ### Cards & Containers
 
 ```
 card/container
-  fill      --surface-elevated    #ffffff / #2c2c2a   (页面级 flat 布局下用 --surface,见 §2 layer rule)
-  border    1px solid --border-default   #d7d7d4 / #3c3c3a   (需要分隔时才加)
-  radius    12px(容器档,Tailwind rounded-xl 直接量)
-            ⚠ 别用 §10 的 --radius——那是 shadcn 原语的 0.5rem(8px),与本 12px 容器圆角是两回事
+  fill      --surface-elevated    #ffffff / #2c2c2a   (page-level flat layouts use --surface instead — §2 layer rule)
+  border    1px solid --border-default   #d7d7d4 / #3c3c3a   (only when separation is needed)
+  radius    12px (container tier; Tailwind rounded-xl literal)
+            ⚠ do NOT use §10's --radius — that is shadcn's 0.5rem (8px) primitive, unrelated to this 12px container radius
   shadow    none
   hover     --surface-hover       #e5e5e5 / #3c3c3a
 ```
@@ -176,31 +176,31 @@ input/text
   fill        --surface-elevated  #ffffff / #2c2c2a
   text        --text-primary      #262626 / #d4d4d4
   border      --border-default    #d7d7d4 / #3c3c3a
-  radius      9999px (pill,单行输入)
+  radius      9999px (pill — single-line inputs)
   focus       --focus-ring        #417CDD @50%
   placeholder --text-placeholder  #c4c4c4 / #525252
 ```
 
-- **多行输入框(textarea)套不了胶囊**(高框会变形),改用 8px 内层圆角(见 §5 三档圆角)。
-- Placeholder 必须"读着像空"——Silver(`#a3a3a3`)对两种 Card 底都太显眼(≈5:1 Dark / ≈2.6:1 Light),读着像已填,禁用。**所有输入面的 placeholder(chat / ask / settings / plan-action-fb)统一收口于 `--text-placeholder`**(2026-06 G3,归档见 `design-decision-log.md`);非默认主题通过 override `text-placeholder` 表达各自的 placeholder 色。
+- **Multi-line inputs (textarea) cannot wear the pill** (tall frames deform it) — use the 8px inner-control radius instead (§5 three-tier scale).
+- Placeholders must **read as clearly empty** — Silver (`#a3a3a3`) is too prominent against either Card surface (≈5:1 Dark / ≈2.6:1 Light) and reads as real input; forbidden. **Every input surface's placeholder (chat / ask / settings / plan-action-fb) resolves to `--text-placeholder`** (2026-06 G3, archived in `design-decision-log.md`); non-default themes express their own placeholder color by overriding `text-placeholder`.
 
 ### Select & Dropdown
 
-- **Trigger**: 同单行输入 —— pill(9999px),Card bg,1px Board 边框,承载当前值 + chevron。
-- **弹出面板**: 是个容器 —— 12px 圆角,Card bg(`--surface-elevated`),1px Board 边框,无阴影(靠 overlay / 层色分隔),内边距 6–8px。
-- **面板宽度必须绑定 trigger 宽度** —— 不许比触发它的控件更窄或更宽。Radix Select 用 `position="popper"` + `width: var(--radix-select-trigger-width)`;其它原语则取 trigger 实测宽度对齐。(反复踩的点:下拉宽度要跟上方一致。)
-- **选项行**: 选中 / 悬浮的高亮底色用 **8px 内层圆角**(见 §5 —— 面板是 12px 容器,行高亮是内层 8px,内层必须比面板小才嵌套协调)。高亮 bg 走 `--surface-hover` / Radix `data-[highlighted]`;选中行给 chip 填充,未选中行透明。
-- **composer 下拉菜单行(模型 / 权限 / + 三个 MorphPopover 菜单)统一规约**(2026-07-22):这三个菜单的所有选项行必须**逐字一致**——横向内边距 `px-3`、圆角 `rounded-[8px]`、hover 与选中底都走**同一个 token `--model-item-hover`**,选中态仅额外靠对勾 + `font-medium` 区分(危险权限档的橙 / 蓝只染**文字**,不改底色)。**为什么不用 `--surface-chip` 做选中底**:cindy 默认皮肤把 `--surface-hover` / `--surface-chip` 调成"压在页面底上"的值,比抬起的弹层面板(`--surface-elevated`)还暗,行高亮会隐形;故菜单行 hover 收口到组件级 token `--model-item-hover`,并在 cindy-dark / cindy-light 里单独 override 到"面板之上一档"(dark 抬亮、light 压深)保证清晰。改这三个菜单的行样式时三处必须同步,不许只改一个导致又不统一。
+- **Trigger**: same as a single-line input — pill (9999px), Card bg, 1px Board border, carrying the current value + a chevron.
+- **Panel**: a container — 12px radius, Card bg (`--surface-elevated`), 1px Board border, no shadow (separation comes from the overlay / layer colors), 6–8px padding.
+- **Panel width must bind to the trigger width** — never narrower or wider than the control that opened it. Radix Select: `position="popper"` + `width: var(--radix-select-trigger-width)`; other primitives measure the trigger. (A repeatedly-tripped rule: dropdown width must match the control above.)
+- **Option rows**: selected / hovered highlight fills use the **8px inner radius** (see §5 — the panel is a 12px container, the row highlight is the inner 8px tier; the inner radius must be smaller than the container's to nest cleanly). Highlight bg via `--surface-hover` / Radix `data-[highlighted]`; selected rows get the chip fill, unselected rows stay transparent.
+- **Composer dropdown rows (the model / permission / + MorphPopover menus) — one unified contract** (2026-07-22): every option row in these three menus must match **verbatim** — horizontal padding `px-3`, radius `rounded-[8px]`, and both hover and selected fills on the **same token `--model-item-hover`**; the selected state is additionally marked only by a check + `font-medium` (danger-tier orange / blue tints **text only**, never the fill). **Why not `--surface-chip` for the selected fill**: the cindy default skins tune `--surface-hover` / `--surface-chip` to sit-on-page values that are darker than the lifted panel (`--surface-elevated`), which would make row highlights invisible; so menu-row hover resolves to the component-level token `--model-item-hover`, overridden in cindy-dark / cindy-light to "one step above the panel" (dark lifts lighter, light presses darker). When touching any of these three menus' row styles, change all three in sync — never just one.
 
 ### Dialog & Modal
 
-参照实现 `components/ui/confirm-dialog.tsx`(通用确认弹窗);新建弹窗沿用它的结构,不另起一套。
+Reference implementation: `components/ui/confirm-dialog.tsx` (the shared confirm dialog); new dialogs reuse its structure — do not invent a parallel one.
 
-- **Overlay**: 全屏遮罩走 `--overlay-modal` token(ConfirmDialog 现用 `neutral-900/40` 硬编码 pair 是历史遗留,**新弹窗一律走 token**,别照抄)。
-- **容器**: 是个容器 —— 12px 圆角(`rounded-xl`),`--confirm-bg`,`--confirm-shadow`,16px 内边距(`p-4`),居中。宽度:确认 / 提示类 ≈ 400px(`max-w-[400px]`);带输入 / 表单的可放宽到 ≈ 460px 并随视口收窄(`min(460px, 100vw-32px)`)。
-- **标题 / 描述**: `--confirm-title` / `--confirm-desc`,medium 字重。
-- **按钮**: pill(9999px);主按钮 = 实心 CTA(`--confirm-btn-primary-*`),次按钮 / 取消 = 描边(`--confirm-btn-secondary-*`,透明底 + Board 边框);底部 `justify-end`。
-- **打开时焦点**: 落在该弹窗的**主输入或主按钮**,不要默认停在取消键(见 §14.2 + ConfirmDialog 的 `autoFocusConfirm` / `onOpenAutoFocus`)。
+- **Overlay**: the full-screen scrim uses the `--overlay-modal` token (ConfirmDialog\'s current `neutral-900/40` hardcoded pair is legacy — **new dialogs always use the token**; do not copy the legacy pair).
+- **Container**: a container — 12px radius (`rounded-xl`), `--confirm-bg`, `--confirm-shadow`, 16px padding (`p-4`), centered. Width: confirm/notice dialogs ≈ 400px (`max-w-[400px]`); dialogs with inputs/forms may widen to ≈ 460px and shrink with the viewport (`min(460px, 100vw-32px)`).
+- **Title / description**: `--confirm-title` / `--confirm-desc`, medium weight.
+- **Buttons**: pill (9999px); primary = solid CTA (`--confirm-btn-primary-*`), secondary/cancel = outlined (`--confirm-btn-secondary-*`, transparent fill + Board border); footer `justify-end`.
+- **Focus on open**: lands on the dialog\'s **primary input or primary button**, never defaults to Cancel (see §14.2 + ConfirmDialog\'s `autoFocusConfirm` / `onOpenAutoFocus`).
 
 ### Tabs
 
@@ -233,13 +233,13 @@ input/text
 
 ### Border Radius Scale
 
-三档圆角,**仅此三档**:
+Three tiers — **these three only**:
 
-- **Inner control (8px)**: 窄第三档,**只**给"做不成胶囊"的小交互件:多行输入框(textarea)、下拉 / 菜单的选中行高亮、段内小单元格。实现为 Tailwind `rounded-lg`(8px)。
-- **Container (12px)**: 盒子圆角 — 代码块、卡片、面板、弹窗。实现为 Tailwind `rounded-xl`(12px)。
-- **Pill (9999px)**: 能套胶囊的所有交互件 — 按钮、Tab、单行输入、标签、徽标。
+- **Inner control (8px)**: the narrow third tier, **only** for small interactive pieces that cannot wear the pill: multi-line inputs (textarea), selected/hover row highlights in dropdowns/menus, small in-block cells. Implemented as Tailwind `rounded-lg` (8px).
+- **Container (12px)**: box radius — code blocks, cards, panels, dialogs. Implemented as Tailwind `rounded-xl` (12px).
+- **Pill (9999px)**: every interactive element that can wear the pill — buttons, tabs, single-line inputs, tags, badges.
 
-*没有 4px / 6px / 10px,也不开放任意圆角。绝大多数元素仍只在 12px 容器和 pill 里二选一;8px 是给"塞不进胶囊的小控件"的窄例外。注意嵌套:8px 行高亮套在 12px 面板里时,内层圆角必须比容器小才协调(所以是 8 而非 12),做成胶囊则会变成药丸、做成 12px 会显得鼓。*
+*No 4px / 6px / 10px, and no arbitrary radii. Most elements still pick between the 12px container and the pill; 8px is a narrow exception for controls that don\'t fit the pill. Mind nesting: an 8px row highlight inside a 12px panel must stay smaller than its container to nest cleanly (hence 8, not 12) — a pill there becomes a lozenge, 12px looks bloated.*
 
 ## 6. Depth & Elevation
 
@@ -306,7 +306,7 @@ Cindy Mobile (React Native) has its own device-class rules (phone / pad portrait
 - Secondary Text: "Stone (#737373)" Light / "Silver (#a3a3a3)" Dark — `--text-secondary`
 - Tertiary Text: "Silver (#a3a3a3)" Light / "Stone (#737373)" Dark — `--text-tertiary`
 - Near Black: (#262626) — Light primary reading text
-- Chip/Button Background: "Light Gray (#e5e5e5)" Light / "Dark Chip (#3c3c3a)" Dark — `--surface-chip`(塌缩到 Card 的变体 `--surface-chip-alt` #2c2c2a 见 §2)
+- Chip/Button Background: "Light Gray (#e5e5e5)" Light / "Dark Chip (#3c3c3a)" Dark — `--surface-chip` (the collapse-to-Card variant `--surface-chip-alt` #2c2c2a: see §2)
 
 ### Example Component Prompts
 
@@ -328,181 +328,173 @@ Cindy Mobile (React Native) has its own device-class rules (phone / pad portrait
 
 ## 10. Theme System & Token Reference
 
-### Light / Dark 双模式交付门槛
+### Light / Dark Dual-Mode Delivery Gate(双模式交付门槛)
 
-- **所有 UI 必须同时支持 Light 与 Dark 两种模式。**新增或修改页面、组件、布局、样式、
-  动效或 UI 文案时，必须在同一项工作中完成两种模式；只设计、只实现或只验证一种模式，
-  均视为未完成。
-- 两种模式都必须覆盖本次改动涉及的默认态、hover、pressed、selected、focus、disabled、
-  loading、empty、error、弹层与遮罩等实际状态；没有涉及的状态不要求为凑检查而改造。
-- 颜色必须通过语义 token 消费，禁止用仅适配一种模式的硬编码色值或条件分支补丁。设计稿
-  只提供一种模式时，也必须按现有 token 体系补齐另一种模式；若缺少明确的语义映射，先请求
-  设计裁决，不得省略另一种模式。
-- 交付前至少对本次受影响界面的 Light 与 Dark 模式分别完成验证，并在提交或 PR 的验证说明
-  中如实记录；任一模式存在不可读、不可辨、状态缺失或明显视觉回退时，不得视为完成。
+- **Every UI must support both Light and Dark modes.** When adding or changing any page, component, layout, style, motion, or UI copy, both modes must be completed within the same piece of work; designing, implementing, or verifying only one mode counts as incomplete.
+- Both modes must cover every state actually touched by the change — default, hover, pressed, selected, focus, disabled, loading, empty, error, overlays and scrims. States the change does not touch need not be retrofitted just to tick a box.
+- Colors must be consumed through semantic tokens; hardcoded values or conditional patches that only fit one mode are forbidden. When the design mock provides only one mode, the other mode must still be filled in through the existing token system; if a clear semantic mapping is missing, request a design ruling first — never ship with a mode omitted.
+- Before delivery, verify the affected surfaces in both Light and Dark and record it honestly in the commit / PR verification notes. If either mode is unreadable, indistinguishable, missing states, or visibly regressed, the work is not done.
 
-### 架构
+### Architecture
 
-Cindy 桌面端用 **VSCode 风格的 ColorRegistry + Theme override** 模型管理颜色。所有颜色都通过 CSS variable 以 token 形式被组件消费,**永远不允许在组件里硬编码 hex / rgba**(违反规则会让该组件在非默认主题下无法切色)。
+Cindy Desktop manages color with a **VSCode-style ColorRegistry + theme-override** model. Every color reaches components as a CSS-variable token; **hardcoding hex / rgba inside a component is never allowed** (it makes the component un-themeable outside the default theme).
 
-源码:`apps/desktop/src/renderer/themes/`
-- `color-registry.ts` — `ColorRegistry` 单例和 `registerColor(id, defaults, description)` API
-- `colors.ts` — 注册全部 token,按"semantic slot 在前,alias 和 singleton 在后"组织(计数持续漂移,**数量一律以 `colors.ts` 为准**,本文档不维护总数)
-- `theme-service.ts` — `applyTheme(theme)` 把所有 token 序列化成 `:root{}` 注入 `<style id="theme-vars">`
-- `builtin/` — 内置主题对象(`cindy-light.ts` / `cindy-dark.ts` / `eclipse.ts` / `default-light.ts` / `default-dark.ts` 及各社区配色)
-- `registry.ts` — `builtinThemes` 注册表 + `listThemesByType('light' | 'dark')`
+Source: `apps/desktop/src/renderer/themes/`
+- `color-registry.ts` — the `ColorRegistry` singleton and the `registerColor(id, defaults, description)` API
+- `colors.ts` — registers every token, organized "semantic slots first, aliases and singletons after" (counts drift constantly — **`colors.ts` itself is the only authoritative inventory**; this document does not track totals)
+- `theme-service.ts` — `applyTheme(theme)` serializes all tokens into `:root{}` and injects `<style id="theme-vars">`
+- `builtin/` — built-in theme objects (`cindy-light.ts` / `cindy-dark.ts` / `eclipse.ts` / `default-light.ts` / `default-dark.ts` and the community palettes)
+- `registry.ts` — the `builtinThemes` registry + `listThemesByType('light' | 'dark')`
 
-切主题:`useTheme.ts` 提供 `theme`(System / Light / Dark mode) + `lightThemeId` / `darkThemeId`(具体哪套主题)。Settings → Appearance 是 UI 入口。
+Theme switching: `useTheme.ts` provides `theme` (System / Light / Dark mode) plus `lightThemeId` / `darkThemeId` (which concrete theme). Settings → Appearance is the UI entry.
 
-### Token 分层
+### Token Tiers
 
-**Tier 1 — Semantic slot**:跨语境复用的核心语义槽,加新主题时这一层是 override 的主战场。下表穷举全部 slot,即 Tier-1 名录。
+**Tier 1 — Semantic slots**: the core cross-context slots; when adding a theme, this tier is the main override battleground. The table below lists every slot exhaustively — it IS the Tier-1 registry.
 
-| 类目 | Slot | Default Light | Default Dark | 主要用途 |
+| Category | Slot | Default Light | Default Dark | Primary use |
 |---|---|---|---|---|
-| **Surface** | `--surface` | `#f8f8f6` | `#1f1f1e` | 页面 Surface(hex 形式) |
-| | `--surface-hsl` | `60 12.5% 97%` | `60 2% 12%` | 同上 HSL 形式,`hsl(var(--xxx))` 消费 |
-| | `--surface-elevated` | `#ffffff` | `#2c2c2a` | Card 抬一层 / 弹窗 / popover |
-| | `--surface-elevated-soft` | `#e5e5e5` | `#2c2c2a` | Disabled 状态 Card |
-| | `--surface-card-ivory` | `#faf9f5` | `#2c2c2a` | Settings 微暖 ivory Card |
-| | `--surface-chip` | `#e5e5e5` | `#3c3c3a` | Chip / pill / 选中行 |
-| | `--surface-chip-alt` | `#e5e5e5` | `#2c2c2a` | Chip 暗态塌缩到 Card 变体 |
-| | `--surface-hover` | `#e5e5e5` | `#3c3c3a` | 通用 hover bg |
-| | `--surface-hover-soft` | `#f8f8f6` | `#3c3c3a` | 柔和 hover bg |
-| | `--surface-hover-hsl` | `0 0% 90%` | `60 2% 17%` | hover HSL 形式 |
-| | `--surface-on-card` | `#ffffff` | `#1f1f1e` | CTA / checked icon 深色前景 |
-| **Border** | `--border-default` | `#d7d7d4` | `#3c3c3a` | 本规范 Board 1px 边框 |
-| | `--border-default-hsl` | `60 3% 84%` | `60 2% 23%` | Board HSL 形式 |
+| **Surface** | `--surface` | `#f8f8f6` | `#1f1f1e` | Page Surface (hex form) |
+| | `--surface-hsl` | `60 12.5% 97%` | `60 2% 12%` | Same, HSL triplet — consume via `hsl(var(--xxx))` |
+| | `--surface-elevated` | `#ffffff` | `#2c2c2a` | Card lift / dialogs / popovers |
+| | `--surface-elevated-soft` | `#e5e5e5` | `#2c2c2a` | Disabled-state Card |
+| | `--surface-card-ivory` | `#faf9f5` | `#2c2c2a` | Slightly warm ivory Card (Settings) |
+| | `--surface-chip` | `#e5e5e5` | `#3c3c3a` | Chips / pills / selected rows |
+| | `--surface-chip-alt` | `#e5e5e5` | `#2c2c2a` | Chip variant that collapses to Card in Dark |
+| | `--surface-hover` | `#e5e5e5` | `#3c3c3a` | General hover bg |
+| | `--surface-hover-soft` | `#f8f8f6` | `#3c3c3a` | Soft hover bg |
+| | `--surface-hover-hsl` | `0 0% 90%` | `60 2% 17%` | Hover, HSL form |
+| | `--surface-on-card` | `#ffffff` | `#1f1f1e` | Dark foreground on CTAs / checked icons |
+| **Border** | `--border-default` | `#d7d7d4` | `#3c3c3a` | This spec's Board 1px border |
+| | `--border-default-hsl` | `60 3% 84%` | `60 2% 23%` | Board, HSL form |
 | | `--border-shadcn-hsl` | `0 0% 90%` | `30 4% 28%` | shadcn input/border HSL |
-| | `--border-transparent-mixed` | `transparent` | `#3c3c3a` | progress track 等单边边框 |
-| **Text** | `--text-primary` | `#262626` | `#d4d4d4` | 主标题 / 主正文 |
-| | `--text-primary-hsl` | `0 0% 9%` | `0 0% 83%` | Primary HSL 形式 |
-| | `--text-primary-on-dark` | `#262626` | `#ffffff` | 反相文本(stop button icon 等) |
-| | `--text-primary-emphasis` | `#1a1a1a` | `#d4d4d4` | Plan 强调主文字 |
+| | `--border-transparent-mixed` | `transparent` | `#3c3c3a` | Single-side borders (progress track etc.) |
+| **Text** | `--text-primary` | `#262626` | `#d4d4d4` | Primary headings / body |
+| | `--text-primary-hsl` | `0 0% 9%` | `0 0% 83%` | Primary, HSL form |
+| | `--text-primary-on-dark` | `#262626` | `#ffffff` | Inverse text (stop-button icon etc.) |
+| | `--text-primary-emphasis` | `#1a1a1a` | `#d4d4d4` | Plan emphasized primary text |
 | | `--text-primary-inv` | `#1a1a1a` | `#ffffff` | Plan-action approve text |
-| | `--text-primary-body-strong` | `#525252` | `#d4d4d4` | Plan content body 加重 |
-| | `--text-secondary` | `#737373` | `#a3a3a3` | Secondary 文字 / icon |
-| | `--text-secondary-cross` | `#a3a3a3` | `#a3a3a3` | 跨主题更浅 secondary |
-| | `--text-secondary-mid` | `#525252` | `#a3a3a3` | Muted body 文字 |
+| | `--text-primary-body-strong` | `#525252` | `#d4d4d4` | Plan content body, strong |
+| | `--text-secondary` | `#737373` | `#a3a3a3` | Secondary text / icons |
+| | `--text-secondary-cross` | `#a3a3a3` | `#a3a3a3` | Lighter cross-theme secondary |
+| | `--text-secondary-mid` | `#525252` | `#a3a3a3` | Muted body text |
 | | `--text-tertiary` | `#a3a3a3` | `#737373` | Placeholder / tertiary |
-| | `--text-tertiary-stone` | `#737373` | `#737373` | Stone 跨主题三级 |
+| | `--text-tertiary-stone` | `#737373` | `#737373` | Cross-theme Stone tertiary |
 | | `--text-tertiary-mid` | `#525252` | `#737373` | Mid-gray tertiary |
-| | `--text-tertiary-hsl` | `0 0% 45%` | `0 0% 45%` | Tertiary HSL |
+| | `--text-tertiary-hsl` | `0 0% 45%` | `0 0% 45%` | Tertiary, HSL form |
 | | `--text-disabled` | `#d4d4d4` | `#525252` | Disabled / failed |
-| | `--text-disabled-tertiary` | `#a3a3a3` | `#737373` | Disabled placeholder 变体 |
-| | `--text-placeholder` | `#c4c4c4` | `#525252` | 统一 placeholder slot(比 tertiary 更淡,读着像空);chat/ask/settings/plan-action-fb 输入框 placeholder 均收口于此 |
-| **Accent** | `--accent-cta-bg` | `#262626` | `#ffffff` | 反相 CTA bg |
+| | `--text-disabled-tertiary` | `#a3a3a3` | `#737373` | Disabled placeholder variant |
+| | `--text-placeholder` | `#c4c4c4` | `#525252` | Unified placeholder slot (lighter than tertiary — reads as empty); chat/ask/settings/plan-action-fb inputs all resolve here |
+| **Accent** | `--accent-cta-bg` | `#262626` | `#ffffff` | Inverse CTA bg |
 | | `--accent-cta-bg-pure` | `#000000` | `#ffffff` | Pure CTA bg |
-| | `--accent-emphasis` | `#262626` | `#d4d4d4` | settings primary button 等 |
-| | `--accent-soft` | `#262626` | `#ffffff` | Soft accent(folder btn 等) |
+| | `--accent-emphasis` | `#262626` | `#d4d4d4` | Settings primary button etc. |
+| | `--accent-soft` | `#262626` | `#ffffff` | Soft accent (folder button etc.) |
 | | `--accent-hover` | `#262626` | `#e5e5e5` | CTA pressed/hover |
-| | `--accent-pure-cta-fg` | `#ffffff` | `#000000` | CTA 文字 pure 反相 |
+| | `--accent-pure-cta-fg` | `#ffffff` | `#000000` | Pure-inverse CTA text |
 
-**Tier 2 — Alias**:大量 component-scoped token(如 `--cmd-palette-bg`、`--msg-tool-card-text`、`--settings-input-border`)的 default 改写为 `var(--slot)`。浏览器自动 forward-resolve。组件不感知,**继续直接消费 alias 名字即可**。
+**Tier 2 — Aliases**: the many component-scoped tokens (`--cmd-palette-bg`, `--msg-tool-card-text`, `--settings-input-border`, …) whose defaults resolve to `var(--slot)`. The browser forward-resolves automatically; components are unaware — **keep consuming the alias names directly**.
 
-**Tier 3 — Singleton**:真独立的色值,无法收敛到 slot:语义豁免色(`--destructive` / `--diff-add-*` / `--status-bar-accent` 等)、平台特定色、splash 时长、`--radius` 等非颜色 token。
+**Tier 3 — Singletons**: genuinely independent values that cannot collapse into a slot: semantic exemption colors (`--destructive` / `--diff-add-*` / `--status-bar-accent` …), platform-specific colors, splash durations, and non-color tokens such as `--radius`.
 
-### 语义豁免色(跨主题不变)
+### Semantic Exemption Colors (theme-invariant)
 
-| Token | Light | Dark | 用途 |
+| Token | Light | Dark | Use |
 |---|---|---|---|
-| `--destructive` (HSL) | `0 84% 60%` | `0 72% 63%` | 通用 destructive 文本/边 |
-| `--error-flat` | `#ef4444` | `#ef4444` | 扁平 danger 前景 |
-| `--login-error-fg` | `#D91F37` | `#D91F37` | 登录错误文本/描边(见 §16.1) |
-| `--error-bg/-border/-fg/-fg-strong` | (red) | (red) | Error alert 卡片子系统 |
-| `--diff-add-fg/-bg`, `--diff-del-fg/-bg` | GitHub palette | GitHub palette | Diff 渲染 |
-| `--status-bar-accent` | `#EA6B17` | `#EA6B17` | Thinking Orange,跨主题统一(定稿 2026-07-17) |
-| `--plan-action-approve-icon-bg` | `#EA6B17` | `#EA6B17` | Plan approve,同 thinking 语义(随 warning-accent,定稿 2026-07-17) |
-| `--perm-bypass-selected-text` | `#EA6B17` | `#EA6B17` | Heart Orange,permission 语义(var(--warning-accent) 自动跟随,定稿 2026-07-17) |
-| `--settings-integration-warning` | `#EA6B17` | `#EA6B17` | warning 语义(var(--warning-accent) 自动跟随,定稿 2026-07-17) |
+| `--destructive` (HSL) | `0 84% 60%` | `0 72% 63%` | Generic destructive text/border |
+| `--error-flat` | `#ef4444` | `#ef4444` | Flat danger foreground |
+| `--login-error-fg` | `#D91F37` | `#D91F37` | Login error text/border (see §16.1) |
+| `--error-bg/-border/-fg/-fg-strong` | (red) | (red) | Error alert card subsystem |
+| `--diff-add-fg/-bg`, `--diff-del-fg/-bg` | GitHub palette | GitHub palette | Diff rendering |
+| `--status-bar-accent` | `#EA6B17` | `#EA6B17` | Thinking Orange, theme-invariant (finalized 2026-07-17) |
+| `--plan-action-approve-icon-bg` | `#EA6B17` | `#EA6B17` | Plan approve — same thinking semantics (follows warning-accent, finalized 2026-07-17) |
+| `--perm-bypass-selected-text` | `#EA6B17` | `#EA6B17` | Heart Orange, permission semantics (auto-follows `var(--warning-accent)`, finalized 2026-07-17) |
+| `--settings-integration-warning` | `#EA6B17` | `#EA6B17` | Warning semantics (auto-follows `var(--warning-accent)`, finalized 2026-07-17) |
 | `--warning-bg-soft` | rgba(255,102,0,0.12) | rgba(255,102,0,0.18) | Warning alpha surface |
-| `--focus-ring` / `--focus-ring-soft` | `#417CDD` / @50% | 同左 | a11y 焦点 ring,定稿 2026-07-17(取代 #3b82f6),跨主题统一 |
-| `--shadow-menu` / `--cmd-palette-shadow` / `--confirm-shadow` | rgba | rgba(更深) | Shadow,跨主题统一 |
-| `--overlay-modal` / `--overlay-lightbox` | rgba | rgba(更深) | Modal / lightbox backdrop |
-| `--perm-auto-selected-text` | `#417CDD` | `#417CDD` | Auto Approval accent,定稿 2026-07-17(light/dark 同值,取代 #000050/#00D9C5) |
-| Toast `#417CDD / #2AAE5B / #F3A115 / #D91F37` | (在 Toast.tsx hardcode,已导出 VARIANT_MAP) | 同左 | E5D 定稿 2026-07-17(Toast 豁免解除,并入状态色族) |
+| `--focus-ring` / `--focus-ring-soft` | `#417CDD` / @50% | same | A11y focus ring, finalized 2026-07-17 (replaces #3b82f6), theme-invariant |
+| `--shadow-menu` / `--cmd-palette-shadow` / `--confirm-shadow` | rgba | rgba (deeper) | Shadows, theme-invariant |
+| `--overlay-modal` / `--overlay-lightbox` | rgba | rgba (deeper) | Modal / lightbox backdrop |
+| `--perm-auto-selected-text` | `#417CDD` | `#417CDD` | Auto Approval accent, finalized 2026-07-17 (same value both modes; replaces #000050/#00D9C5) |
+| Toast `#417CDD / #2AAE5B / #F3A115 / #D91F37` | (hardcoded in Toast.tsx, VARIANT_MAP exported) | same | Finalized 2026-07-17 (Toast exemption lifted, merged into the status-color family) |
 
-实现组件时**永远不要在硬编码 hex 上自由发挥这些语义色**——必须走对应 token。
+Never freestyle these semantic colors as hardcoded hex — always go through the corresponding token.
 
-### 内置主题
+### Built-in Themes
 
-当前实现以 `apps/desktop/src/renderer/themes/registry.ts` 的 `builtinThemes` 为准,新增/移除主题不要求同步本文档。默认的 light/dark 主题(基础主题)就是本文 §2 列的色值。
+The implementation truth is `builtinThemes` in `apps/desktop/src/renderer/themes/registry.ts`; adding or removing themes does not require updating this document. The default light/dark (base) themes are exactly the §2 palette.
 
-### 新主题怎么加(完整流程)
+### Adding a New Theme (full flow)
 
-1. 新建 `apps/desktop/src/renderer/themes/builtin/<id>.ts`,导出 `Theme` 对象:
+1. Create `apps/desktop/src/renderer/themes/builtin/<id>.ts` exporting a `Theme` object:
    ```ts
    export const myTheme: Theme = {
      id: 'my-theme',
      name: 'My Theme',
      type: 'light' | 'dark',
      colors: {
-       // 只 override 跟基础主题不同的 token,空对象 {} 也合法(完全等于基础主题)
+       // Override only the tokens that differ from the base theme;
+       // an empty object {} is also valid (identical to base).
        'surface': '#xxx',
        'text-primary': '#xxx',
-       // ... 大概率只需要 override 30-90 个 token
+       // ... most themes only need to override 30–90 tokens
      },
    };
    ```
-2. 注册到 `themes/registry.ts` 的 `builtinThemes`
-3. 设置页 Appearance 的 Light/Dark Theme dropdown 自动 pick up
+2. Register it in `builtinThemes` in `themes/registry.ts`
+3. The Light/Dark Theme dropdowns in Settings → Appearance pick it up automatically
 
-参考 `themes/builtin/` 下任一已存在的非默认主题作为模板。
+Use any existing non-default theme under `themes/builtin/` as a template.
 
-### Token 命名约定
+### Token Naming Conventions
 
-- **slot**:`{category}-{subkind}[-{variant}]`,如 `text-primary-emphasis` / `surface-chip-alt`。`-hsl` 后缀表示 HSL 三元组形式。
-- **alias**:沿用历史 component-scoped 命名(`--cmd-palette-bg` / `--settings-back-text` 等),无前缀。
-- **singleton**:语义清晰即可,通常带 component 前缀。
+- **slot**: `{category}-{subkind}[-{variant}]`, e.g. `text-primary-emphasis` / `surface-chip-alt`. The `-hsl` suffix marks the HSL-triplet form.
+- **alias**: keeps its historical component-scoped name (`--cmd-palette-bg` / `--settings-back-text` …), no prefix.
+- **singleton**: any clear semantic name, usually component-prefixed.
 
-CSS variable 名一律 kebab-case。点号风格(如 VSCode 的 `sidebar.itemActive`)由于 CSS variable 不支持暂未采用。
+CSS variable names are always kebab-case. Dot-style ids (VSCode's `sidebar.itemActive`) are not used — CSS variables don't support them.
 
-### 实现新 UI 时的 token 选择规则
+### Token Selection Rules for New UI
 
-1. **先 grep `colors.ts`**:你的 UI 类型常对应已有 slot/alias(card bg = `--cmd-palette-bg` / `--surface-elevated`,等)
-2. **slot 优先**:能用 slot 就别用 component-scoped alias(slot 跨主题表现更可控)
-3. **HSL token 必须 wrap**:`hsl(var(--background))` 不能写成 `var(--background)`(后者会得到原始 HSL 字符串,不是合法 CSS color)
-4. **找不到合适 token 时,不要硬塞**:跟用户讨论是否要新增 slot/singleton
-5. **不接受** `bg-[#xxx] dark:bg-[#xxx]` 这种硬编码 pair——这是 P2 前的反模式,已经全量迁移过一次,新代码不允许引入
+1. **grep `colors.ts` first**: your UI type usually maps to an existing slot/alias (card bg = `--cmd-palette-bg` / `--surface-elevated`, …)
+2. **Slots first**: prefer a slot over a component-scoped alias (slots behave more predictably across themes)
+3. **HSL tokens must be wrapped**: `hsl(var(--background))`, never bare `var(--background)` (the latter yields a raw HSL string, not a valid CSS color)
+4. **No suitable token? Don't force one**: discuss adding a slot/singleton with the user instead
+5. **Never** use `bg-[#xxx] dark:bg-[#xxx]` hardcoded pairs — the pre-P2 anti-pattern; it was migrated away once and new code must not reintroduce it
 
-本节即 token 使用规则的权威正文；UI 文案的 i18n 落地规则见
-`docs/dev-rules/engineering-conventions.md` §5。
+This section is the authoritative token-usage text; i18n rules for UI copy live in `docs/dev-rules/engineering-conventions.md` §5.
 
-## 11. Voice & Content（微文案规范）
+## 11. Voice & Content(微文案规范)
 
-> **状态:草案**,2026-06 引入(参考 Vercel Geist `design.md` 的 Voice & Content 一节)。本节规定**界面文案怎么写**,与 `docs/dev-rules/engineering-conventions.md` §5(i18n 体系)配套——那边管"文案必须 4 语言对齐、经 i18n key 落地",本节管"每条文案本身的语气/措辞"。本节不新增任何 UI 字符串,只约束写法。
+> **Status: draft**, introduced 2026-06 (after the Voice & Content section of Vercel Geist's `design.md`). This section governs **how interface copy is written** and pairs with `docs/dev-rules/engineering-conventions.md` §5 (the i18n system) — that side enforces "copy lands via i18n keys, aligned across 4 languages"; this side governs each string's tone and wording. It adds no UI strings, only constraints.
 
-Cindy 的产品气质和视觉一致:**克制、直接、不自夸**。文案是工具的一部分,不是营销。
+Cindy's product voice matches its visuals: **restrained, direct, never self-congratulatory**. Copy is part of the tool, not marketing.
 
-### 11.1 语言无关原则(zh-CN / en / ja / ko 全部适用)
+### 11.1 Language-Independent Principles (zh-CN / en / ja / ko alike)
 
-- **动作 = 动词 + 宾语,不要裸动词**。按钮/菜单项说清"对什么做什么":`Deploy Project` / `删除会话` / `セッションを削除`,**禁止** `Confirm` / `OK` / `确定` / `提交` 这类无宾语的孤立动词(确认弹窗的主按钮尤其要带宾语,让用户脱离上下文也能看懂)。
-- **错误信息 = 发生了什么 + 怎么办**。只报"出错了 / Failed"不合格;要给出下一步("连接超时,检查网络后重试")。对应 `docs/dev-rules/engineering-conventions.md` §2(IPC 错误协议):IPC 错误码是给代码用的,面向用户的那句话必须人话 + 可操作。
-- **进行中态 = 现在进行时 + 省略号**。`Deploying…` / `正在部署…` / `デプロイ中…`。我们 ChatView 的 Thinking 状态栏(`Spelunking…`,Thinking Orange)已是这个范式,新增加载/处理态沿用。
-- **结果反馈点名对象、不说"成功"**。Toast 说"变了什么"而不是"操作成功了":`会话已删除` 而非 `删除成功`;`Project deleted` 而非 `Deleted successfully`。**禁止** "successfully / 成功了" 这类废话词。(Toast 的视觉规范见 §2,本条只管文案。)
-- **空状态指向第一个动作**,别只画一句"暂无数据"——告诉用户现在能做什么("还没有会话,点 + 新建一个")。
-- **不卑不亢,但分语言**:英文不写 "Please"(界面不是在求用户)。**中文的"请"是地道礼貌用法,不在此列**——"请输入…""请先授权""请选择文件"这类该保留,不要为了套规则把中文改得生硬。两种语言都不写营销级形容词("强大的 / 极致 / 全新")。
+- **Actions = verb + object, never a bare verb.** Buttons and menu items say what is done to what: `Deploy Project` / `删除会话` / `セッションを削除`. **Forbidden**: objectless verbs like `Confirm` / `OK` / `确定` / `提交` (confirm-dialog primary buttons especially must carry the object so they read correctly out of context).
+- **Errors = what happened + what to do.** A bare "Failed / 出错了" is not acceptable — give the next step ("Connection timed out — check your network and retry"). Pairs with `docs/dev-rules/engineering-conventions.md` §2 (IPC error protocol): error codes are for code; the user-facing sentence must be human and actionable.
+- **In-progress = present continuous + ellipsis.** `Deploying…` / `正在部署…` / `デプロイ中…`. The ChatView Thinking status bar (`Spelunking…`, Thinking Orange) already is this pattern; new loading/processing states follow it.
+- **Results name the object — never say "success".** Toasts say what changed, not that an operation succeeded: `会话已删除` not `删除成功`; `Project deleted` not `Deleted successfully`. **Forbidden**: filler like "successfully / 成功了". (Toast visuals are §2; this rule is copy only.)
+- **Empty states point at the first action** — never just "No data"; tell the user what they can do now ("No sessions yet — hit + to create one").
+- **Neither servile nor cold — per language**: English never writes "Please" (the interface isn't begging). **Chinese 「请」 is idiomatic politeness and is exempt** — keep "请输入…" "请先授权" "请选择文件"; don't stiffen Chinese to satisfy the English rule. Neither language uses marketing adjectives ("强大的 / 极致 / 全新").
 
-### 11.2 各语言的大小写与标点(语言相关,不可照搬)
+### 11.2 Casing & Punctuation Per Language (not transferable)
 
-- **English**:标签 / 按钮 / 标题 / Tab 用 **Title Case**(`Deploy Project`);正文 / 帮助文字 / Toast 用 **sentence case**(只首字母大写)。用弯引号 `" "` 和省略号字符 `…`,不用 `"` 和 `...`。
-- **zh-CN**:**没有 Title Case 概念**,不要逐词首字母大写、不要给中文塞英文式标点;中英混排时英文术语保留原样(`部署 Project`)。句末 Toast / 标签不加句号。
-- **ja / ko**:同样无 Title Case;遵循各自的助词/敬体习惯,术语译法没把握时先查证(对应 `docs/dev-rules/engineering-conventions.md` §5:ja/ko 不许硬凑)。
-- **数字 / 单位**:四语言都用阿拉伯数字 + 半角,数字与单位间距按各语言习惯。
+- **English**: labels / buttons / titles / tabs use **Title Case** (`Deploy Project`); body / help text / toasts use **sentence case**. Curly quotes and the ellipsis character `…`, never straight quotes or `...`.
+- **zh-CN**: **no Title Case concept** — no per-word capitalization, no English-style punctuation in Chinese; keep English terms as-is in mixed text (`部署 Project`). No full stop at the end of toasts / labels.
+- **ja / ko**: likewise no Title Case; follow each language's particle / politeness conventions, and verify terminology when unsure (per `docs/dev-rules/engineering-conventions.md` §5: no improvised ja/ko).
+- **Numbers / units**: Arabic numerals + half-width in all four languages; number-to-unit spacing per language convention.
 
-### 11.3 自查清单(改动文案时)
+### 11.3 Self-Check (when touching copy)
 
-- [ ] 动作按钮带宾语,不是裸 `确定` / `OK`
-- [ ] 错误文案给了"怎么办",不是只报错
-- [ ] 没有 "successfully / 成功" 废话词
-- [ ] 进行中态是"现在进行时 + …"
-- [ ] 4 个 `common.json` 都补齐且符合本语言的大小写/标点(见 `docs/dev-rules/engineering-conventions.md` §5)
+- [ ] Action buttons carry an object — not a bare `确定` / `OK`
+- [ ] Error copy says what to do next, not just that it failed
+- [ ] No "successfully / 成功" filler
+- [ ] In-progress states read "present continuous + …"
+- [ ] All 4 `common.json` files updated, each matching its language's casing/punctuation (see `docs/dev-rules/engineering-conventions.md` §5)
 
-## 12. Component Spec(已并入 §4)
+## 12. Component Spec (merged into §4)
 
-> 本节的结构化组件规格试点(Buttons / Inputs / Cards)已于 2026-07 采纳并**就地并入 §4**;
-> 编号保留占位,避免 §13–§16 重编号导致仓库内外引用断链(章节编号的最终整理随 §15 重构
-> 一并处理,见 `design-decision-log.md`)。
+> The structured component-spec pilot (Buttons / Inputs / Cards) was adopted in 2026-07 and folded into §4 in place. This section number is kept as a placeholder: section numbers in this document are stable identifiers referenced by other documents, code comments, and frozen tests — do not renumber (see `design-decision-log.md`).
 
 ## 13. Open Spec / Token Gaps
 
@@ -514,283 +506,264 @@ Known but deliberately-deferred cleanups (e.g. hardcoded hex in `MakerExperiment
 
 ## 14. Interaction Conventions(交互约定)
 
-> 2026-06 引入。本规范此前只规范"长什么样"(色 / 圆角 / 字体 / 间距),不规范"怎么交互"——文本能不能选中、弹窗开了焦点落哪、回车是发送还是换行,这些反复要靠人逐个指出。本节把这些**非视觉的交互行为**钉成全局约定,与 §11(文案语气)互补。能用代码统一保证的就别靠人记(对应 `docs/dev-rules/maker-core-and-agent-behavior.md` 的「代码优先确定性」)。
+> Introduced 2026-06. This spec used to govern only how things look (color / radius / type / spacing), not how they behave — whether text is selectable, where focus lands when a dialog opens, whether Enter sends or breaks the line; these kept needing case-by-case human correction. This section pins those **non-visual interaction behaviors** as global conventions, complementing §11 (copy tone). Whatever code can guarantee uniformly should not rely on human memory (per "code-first determinism" in `docs/dev-rules/maker-core-and-agent-behavior.md`).
 
-### 14.1 文本可选性(user-select)
+### 14.1 Text Selectability (user-select)
 
-- **正文内容可选**:消息气泡正文、代码块、文档预览、用户会"读句子 / 想复制"的文字 —— 默认可选,不要动。
-- **Chrome 不可选**:按钮、菜单项、标签 / chip、状态条、徽标、工具条、侧栏项这类**界面骨架文字**一律 `select-none`。它们是控件不是内容,能被选中只会碍事(典型:goal 状态 chip 的文字)。
-- 判断标准:用户会想"复制这段话"吗?会 → 可选;不会(它只是个控件)→ `select-none`。
+- **Content is selectable**: message body text, code blocks, document previews — anything the user reads sentence-by-sentence or may want to copy. Selectable by default; leave it alone.
+- **Chrome is not selectable**: buttons, menu items, labels/chips, status bars, badges, toolbars, sidebar rows — interface-skeleton text gets `select-none`. They are controls, not content; being selectable only gets in the way (typical offender: the goal-status chip label).
+- Litmus test: would the user ever think "let me copy this"? Yes → selectable; no (it's just a control) → `select-none`.
 
-### 14.2 焦点管理(focus)
+### 14.2 Focus Management
 
-- 弹窗 / 抽屉 / popover 打开时,焦点落到**首要输入框**(没有输入框则落主按钮),**不要**默认停在"取消"上。Radix 默认会聚焦第一个可聚焦元素 / Cancel —— 用 `onOpenAutoFocus`(`preventDefault()` + 手动 `focus()`)或 ConfirmDialog 的 `autoFocusConfirm` 覆盖。
-- 关闭后焦点归还触发它的元素(Radix 默认行为,别破坏)。
+- When a dialog / drawer / popover opens, focus lands on the **primary input** (or the primary button if there is no input) — **never** defaults to "Cancel". Radix focuses the first focusable element / Cancel by default — override with `onOpenAutoFocus` (`preventDefault()` + manual `focus()`) or ConfirmDialog's `autoFocusConfirm`.
+- On close, focus returns to the triggering element (Radix default — don't break it).
 
-### 14.3 键盘与输入法(发送型文本框)
+### 14.3 Keyboard & IME (send-type text fields)
 
-适用于"敲完就发"的提交型文本框:聊天 composer、目标输入、ask 输入等。**不含**普通设置项里的单行编辑框 —— 那种 Enter 不应触发提交。
+Applies to submit-on-Enter fields: the chat composer, goal input, ask input, etc. **Not** ordinary single-line editors in Settings — there Enter must not submit.
 
-- **Enter = 提交**,**Shift+Enter = 换行**。
-- **输入法组字期间的 Enter 不触发提交** —— 判 `event.nativeEvent.isComposing`(中 / 日 / 韩用户选字按的回车不能被当成发送)。
-- 这套逻辑用代码统一,不要每个框各写一遍导致行为漂移(对应 `docs/dev-rules/maker-core-and-agent-behavior.md` 的「代码优先确定性」)。
+- **Enter = submit**, **Shift+Enter = newline**.
+- **Enter during IME composition must not submit** — check `event.nativeEvent.isComposing` (a CJK user confirming a candidate must not accidentally send).
+- Centralize this logic in code; do not re-implement it per field and let behavior drift (per "code-first determinism" in `docs/dev-rules/maker-core-and-agent-behavior.md`).
 
-### 14.4 动效与过渡(motion)
+### 14.4 Motion & Transitions
 
-> 2026-07 扩写。Cindy 的动效性格承接 §1 / §7 的纸感与克制:**东西不飞不弹,只淡入、只轻推、只平滑改变尺寸**。允许功能性状态过渡,禁止装饰性动效;本节把"功能性"钉成可执行的档位与原型,避免各组件时长/曲线各自为政。
+> Expanded 2026-07. Cindy's motion character extends the paper-like restraint of §1 / §7: **nothing flies or bounces — things only fade, nudge, and resize smoothly**. Functional state transitions are allowed; decorative motion is forbidden. This section pins "functional" into executable tiers and prototypes so components stop inventing their own durations and curves.
 
-#### Motion token(唯一档位来源)
+#### Motion tokens (the only tier source)
 
-全局 token 定义在 `apps/desktop/src/renderer/styles/globals.css` 的 `:root`;移动端(`apps/mobile`)应在 `src/theme/tokens.ts` 落同名同值常量(双端同构,与颜色 token 的双端策略一致,随移动端动效改造落地)。**新增过渡/动画一律引用 token,不再硬编码时长与 cubic-bezier**;5 档时长 + 3 条曲线,与 §5 三档圆角同一哲学,档位之外的值先过设计评审。
+Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`; mobile (`apps/mobile`) mirrors same-name same-value constants in `src/theme/tokens.ts` (dual-platform isomorphism, same policy as color tokens, landing with the mobile motion overhaul). **New transitions/animations must reference tokens — no hardcoded durations or cubic-beziers**; 5 duration tiers + 3 curves, the same philosophy as the §5 three-tier radius. Values outside the tiers require design review first.
 
-| Token | 值 | 用途 |
+| Token | Value | Use |
 |---|---|---|
-| `--motion-instant` | 80ms | hover 即时反馈、轻浮层退场 |
-| `--motion-fast` | 150ms | 颜色/透明度状态切换(`transition-colors` 即此档)、轻浮层入场 |
-| `--motion-base` | 200ms | 尺寸变化:展开折叠、面板收展 |
-| `--motion-enter` | 250ms | 重浮层(弹窗)入场 |
-| `--motion-exit` | 150ms | 重浮层(弹窗)退场 |
-| `--motion-ease-out` | `cubic-bezier(0.16, 1, 0.3, 1)` | 入场/展开 |
-| `--motion-ease-in` | `cubic-bezier(0.4, 0, 1, 1)` | 退场 |
-| `--motion-ease-move` | `cubic-bezier(0.4, 0, 0.2, 1)` | 位置/尺寸插值 |
+| `--motion-instant` | 80ms | Instant hover feedback; light-overlay exit |
+| `--motion-fast` | 150ms | Color/opacity state changes (`transition-colors` = this tier); light-overlay enter |
+| `--motion-base` | 200ms | Size changes: expand/collapse, panel open/close |
+| `--motion-enter` | 250ms | Heavy-overlay (dialog) enter |
+| `--motion-exit` | 150ms | Heavy-overlay (dialog) exit |
+| `--motion-ease-out` | `cubic-bezier(0.16, 1, 0.3, 1)` | Enter / expand |
+| `--motion-ease-in` | `cubic-bezier(0.4, 0, 1, 1)` | Exit |
+| `--motion-ease-move` | `cubic-bezier(0.4, 0, 0.2, 1)` | Position/size interpolation |
 
-#### 语义 → 动效原型(同一语义全 app 同一动效)
+#### Semantics → motion prototypes (one semantic, one motion, app-wide)
 
-| 语义 | 规格 | 参照实现 |
+| Semantic | Spec | Reference implementation |
 |---|---|---|
-| 轻浮层(menu / popover / tooltip) | 入 `animate-float-in`(opacity + scale 0.97→1,fast/ease-out;tooltip 纯 opacity 用 `animate-fade-in`),出 `animate-float-out`(纯 opacity,instant/ease-in)。**退场永远快于入场,退场不缩放**(缩放退场读作"被吸走",纸应该原地淡掉) | `components/ui/dropdown-menu.tsx` |
-| 重浮层(modal / confirm) | 入 250ms 淡入+scale 0.95→1,出 150ms | `components/ui/confirm-dialog.tsx` |
-| 展开/折叠 | base/ease-move,grid `0fr↔1fr` 高度 + opacity | `features/cc-agent/sidebar/SectionCollapse.tsx` |
-| 列表重排 | FLIP,transform 平移 | `components/ui/toast/ToastContainer.tsx` |
-| 按压 | `active:scale-[0.98]`(交互 pill / 按钮通用) | ConfirmDialog 按钮 |
-| 完成 | **全 app 唯一允许 overshoot 的语义**(`status-done-pop`) | `globals.css` |
-| 运行中 | opacity 呼吸,必须挂 HTML wrapper(`docs/dev-rules/engineering-conventions.md` §7) | `session-breathing` |
-| hover / 状态色 | `transition-colors`,≤ fast(150ms) | 全 app 现状 |
-| 容器形变(chip 长成弹层) | 220ms,见下方独立类目(显式例外) | composer 权限/模型选择器 |
+| Light overlay (menu / popover / tooltip) | In: `animate-float-in` (opacity + scale 0.97→1, fast/ease-out; pure-opacity tooltips use `animate-fade-in`). Out: `animate-float-out` (opacity only, instant/ease-in). **Exit is always faster than enter, and never scales** (a scaling exit reads as "sucked away" — paper fades in place) | `components/ui/dropdown-menu.tsx` |
+| Heavy overlay (modal / confirm) | In: 250ms fade + scale 0.95→1; out: 150ms | `components/ui/confirm-dialog.tsx` |
+| Expand / collapse | base/ease-move, grid `0fr↔1fr` height + opacity | `features/cc-agent/sidebar/SectionCollapse.tsx` |
+| List reorder | FLIP, transform translation | `components/ui/toast/ToastContainer.tsx` |
+| Press | `active:scale-[0.98]` (all interactive pills/buttons) | ConfirmDialog buttons |
+| Done | **the app's only sanctioned overshoot** (`status-done-pop`) | `globals.css` |
+| Running | Opacity breathing; must sit on an HTML wrapper (`docs/dev-rules/engineering-conventions.md` §7) | `session-breathing` |
+| Hover / state colors | `transition-colors`, ≤ fast (150ms) | App-wide status quo |
+| Container transform (chip grows into panel) | 220ms — see the dedicated category below (explicit exception) | Composer permission/model selectors |
 
-#### 红线(性能与克制)
+#### Red lines (performance & restraint)
 
-- **常驻/循环动画只允许 HTML 元素上的 `transform` / `opacity`**(compositor-only,`docs/dev-rules/engineering-conventions.md` §7 全文适用;SVG 上不挂任何动画)。
-- 高度/grid 等非 compositor 属性只允许**一次性瞬态动画**(用户触发、有明确结束),不允许常驻。
-- 新增 `@keyframes` / `animate-*` 类必须同步登记 `globals.css` 的 `prefers-reduced-motion` 白名单(全局 `* { transition: none }` 兜不住 keyframes)。
-- 实时跟手的交互(resizer 拖动、拖拽跟随)**不加缓动**——跟手即反馈。
-- 禁止:无意义位移、弹跳、视差、循环装饰动画、`transition-all`、给流式文本加打字机逐字动画(流式本身已是动效)。交互仍应"快、直接"。
+- **Persistent/looping animation may only touch `transform` / `opacity` on HTML elements** (compositor-only; `docs/dev-rules/engineering-conventions.md` §7 applies in full; nothing animates on SVG).
+- Non-compositor properties (height/grid …) are allowed only in **one-shot transient animations** (user-triggered, with a definite end) — never persistent.
+- Every new `@keyframes` / `animate-*` class must be registered in the `prefers-reduced-motion` whitelist in `globals.css` (the global `* { transition: none }` does not catch keyframes).
+- Real-time direct-manipulation interactions (resizer drag, drag-follow) get **no easing** — following the hand IS the feedback.
+- Forbidden: pointless displacement, bouncing, parallax, looping decoration, `transition-all`, and typewriter per-character animation on streamed text (streaming already is the motion). Interactions stay fast and direct.
 
-#### 例外类目:容器形变(container transform,脱身上浮式)
+#### Exception category: container transform (chip lifts off and grows)
 
-- 2026-07-21 新增、2026-07-22 修订的第二类 sanctioned motion,专用于 composer 工具条上「chip 脱身上浮长成弹层」的开合(权限选择器 / 模型选择器 / + 菜单这类 trigger 即弹层锚点的控件):
-  - **定义**:弹层不是"凭空浮现盖在 trigger 上",而是以 trigger chip 的精确几何(位置 / 尺寸 / 胶囊圆角 / pill 底色)为形变起点,一边生长一边**整体位移脱身**,最终停靠在 chip 的打开侧、与 chip 留 6px 间隙;关闭时反向缩回 chip。**trigger chip 全程可见、可交互** —— 面板打开后再点 chip 即关闭(保住"原地再点一下收起"的肌肉记忆)。曾试过"原位取代"式(chip 隐藏、面板占据原位),因丢失 toggle 关闭且时序复杂已废弃,不要回退。**开合两端均做与位移耦合的整体淡入/淡出**(面板与 chip 重叠的端部帧若不透明,会把 chip 内容盖没一下造成"按钮闪烁";淡入随上浮显形、淡出随缩回溶解)——禁止无位移的纯 fade-in/out。
-  - **参数**:时长 **220ms**(开合对称,2026-07-22 自 300ms 调快定稿),缓动 `cubic-bezier(0.3, 0.9, 0.25, 1)`(快起步长缓收);菜单行淡入可带 ≤20ms/行 的错峰。这是 ≤150ms 基线的**显式例外**,仅限本类目,不得外溢到其它过渡。形变期间面板内容区必须禁滚(滚动条闪现会挤压行宽,行尾元素抖动),动画完成后再开自滚。
-  - **圆角插值**:形变起点圆角写 chip 高度的一半(如 30px chip → 15px),**禁止写 9999px**(9999→12 的插值会让中途帧圆成一坨);终点为容器 12px。
-  - **实现红线**:(a) 必须 `prefers-reduced-motion` 降级为直切;(b) 测量目标几何时必须临时禁用 transition(否则 offsetHeight 在宽度过渡第 0 帧按旧宽度排版,含换行文本时量出假高度);(c) 属一次性开合动画,不受"常驻动画 compositor-only"红线(`docs/dev-rules/engineering-conventions.md` §7)约束,但仍需在低端 Windows 实测 300ms 内不掉帧;(d) 焦点 / Esc / outside-click / 焦点归还语义与 §14.2 相同,形变不豁免任何 a11y 要求。
-  - **适用边界**:仅限"trigger 长成弹层"的控件。普通 Dialog / ConfirmDialog / Toast / lightbox 不适用(它们没有 chip 锚点,维持现状)。窄变体(按钮宽度展开)仅允许**承载信息的展开**(如语音录音中的红点 + 计时,≤240ms);纯装饰性的 hover 展出文字标签(如 + 展出"添加")已评估并移除,不要再加。
-- **composer 工具条控件两档 chrome + 会话内/新建对话框共用一套(2026-07-22 用户定稿)**:
-  - **变形下拉档(+/权限/模型)**:静息**裸态无框**(`border border-transparent bg-transparent`),hover 才浮现胶囊外框(`hover:border-[var(--border-default)]` + `composer-pill-bg`);选中/危险档只染文字色,不改底。
-  - **常驻工具档(语音/发送)**:常驻外框 / 实心 CTA(语音 `composer-pill-bg`+`border-default`,hover `model-trigger-hover`,录音态 `surface-chip` 填充+红点计时展开;发送 `send-btn-*` 中性反相实心)。
-  - **会话内(default)与新建对话框(create-agent)必须逐字一致**:两处共享控件(+/权限/模型/语音/发送)不再按 `visualVariant` 分叉样式,`create-agent-control-*` / `create-agent-send-*` 不得再用于这五个控件(仅剩新建对话框独有的 Claude|Codex 分段切换、顶部 模式/项目/分支 pills 继续用 create-agent 私有 token)。改任一控件的 chrome,两端一起改。合同测试 `newMakerCreateAgentVisualContract.test.ts` 守此不变量。
-- **限额重置撒花(quota reset confetti)** —— 2026-07-23 用户拍板新增的第三类 sanctioned motion,**仅限**状态栏用量 chip 的「限额窗口重置揭晓」时刻(倒计时归零 → 悬念期「重置中…」→ 新快照落地):
-  - **定义**:新快照确认重置的一瞬间,以**正在揭晓的窗口段中心**为原点撒一次花,与剩余百分比 0%→100% 滚动同时开始 —— 把"额度回来了"做成一个可感知的庆祝点。
-  - **形态**(用户四/五轮拍板 2026-07-23):**真实抛物线上抛 + 落地即隐** —— 全部粒子同时从段中心以约 **100° 扇形**(正上方 ±50°)同速率抛出,**水平匀速 + 垂直恒定重力**(上升恒减速、过顶点恒加速回落),从爆出到下落全程速度感一致;角度大的粒子弧低、飞得远、先落地,错落由物理自然给出。落到地面线的最后一小段以**短渐隐**消失:可以落地,但禁止落定后停留("躺尸")或不带渐隐地突然消失;地面线带随机抖动,落点不排队。
-  - **参数红线**:一次性庆祝,同时起飞、无错峰 delay;单粒时长由弧高物理决定并 clamp 进 0.9s-1.6s、总时长约 1.6s 收尾(数字滚动 1.2s 站定后纸屑再落零点几秒;弧尺度与节奏为用户微调定稿 2026-07-23);粒子 ≤18 颗、3-5px,放完即拆,不循环不常驻;粒子为 HTML 元素、只动 `transform` / `opacity`(compositor-only,工程规范 §7;x/y 分离在两层 span 上实现匀速水平);颜色仅取「小状态点 hue 豁免簇」四色(done 绿 / awaiting 青 / thinking 橙 / error 红),light/dark 同值;必须 `prefers-reduced-motion` 整体跳过。
-  - **适用边界**:仅此一处。撒花不得外溢到任务完成、发送成功等其它时刻 —— 那些场景维持 §14.4 基线(需要新豁免必须回到本节逐条新增)。实现见 `apps/desktop/src/renderer/components/status/QuotaResetConfetti.tsx`。
+- The second sanctioned motion class (added 2026-07-21, revised 2026-07-22), exclusively for composer-toolbar controls whose trigger chip anchors the panel (permission selector / model selector / the + menu):
+  - **Definition**: the panel does not simply appear over the trigger — it morphs from the trigger chip's exact geometry (position / size / pill radius / pill fill), growing while **translating away as a whole**, docking on the chip's opening side with a 6px gap; closing reverses back into the chip. **The trigger chip stays visible and interactive throughout** — clicking the chip while the panel is open closes it (preserving the "tap again in place to dismiss" muscle memory). An "in-place replacement" variant (chip hidden, panel occupying its spot) was tried and retired — it loses toggle-to-close and complicates timing; do not regress to it. **Both open and close must fade as a whole, coupled with the translation** (if the frames where panel and chip overlap were opaque, the chip content would flash-hide — fade in while lifting, dissolve while shrinking back); positionless pure fade-in/out is forbidden.
+  - **Parameters**: **220ms** (symmetric open/close; tightened from 300ms, finalized 2026-07-22), easing `cubic-bezier(0.3, 0.9, 0.25, 1)` (fast start, long settle); menu rows may stagger fade-in ≤20ms/row. This is an **explicit exception** to the ≤150ms baseline, confined to this category — it must not leak into other transitions. While morphing, the panel content must not scroll (a flashing scrollbar squeezes row width and jitters row ends); enable scrolling only after the animation completes.
+  - **Radius interpolation**: the morph's starting radius is half the chip height (e.g. 30px chip → 15px), **never 9999px** (interpolating 9999→12 balloons the mid-frames); the end value is the container 12px.
+  - **Implementation red lines**: (a) must degrade to a hard cut under `prefers-reduced-motion`; (b) temporarily disable transitions while measuring target geometry (otherwise `offsetHeight` at frame 0 of a width transition lays out at the old width and measures a false height when text wraps); (c) as a one-shot open/close animation it is exempt from the "persistent animations are compositor-only" red line (`docs/dev-rules/engineering-conventions.md` §7), but must still hold 300ms without dropped frames on low-end Windows, verified on hardware; (d) focus / Esc / outside-click / focus-return semantics are identical to §14.2 — morphing exempts nothing in a11y.
+  - **Scope boundary**: only "trigger grows into panel" controls. Ordinary Dialog / ConfirmDialog / Toast / lightbox do not qualify (no chip anchor — they keep their current motion). The narrow variant (button-width expansion) is allowed only for **information-bearing expansion** (e.g. the recording red dot + timer, ≤240ms); purely decorative hover label reveal (e.g. + expanding the word "Add") was evaluated and removed — do not re-add.
+- **Composer toolbar: two chrome tiers, one set shared between in-session and the create dialog (finalized 2026-07-22)**:
+  - **Morphing-dropdown tier (+/permission/model)**: bare at rest (`border border-transparent bg-transparent`); the pill outline appears only on hover (`hover:border-[var(--border-default)]` + `composer-pill-bg`); selected/danger tiers tint the text only, never the fill.
+  - **Persistent-tool tier (voice/send)**: permanent outline / solid CTA (voice: `composer-pill-bg` + `border-default`, hover `model-trigger-hover`, recording state `surface-chip` fill + red-dot timer expansion; send: `send-btn-*` neutral-inverse solid).
+  - **In-session (default) and the create dialog (create-agent) must match verbatim**: the five shared controls (+/permission/model/voice/send) no longer fork styles by `visualVariant`; `create-agent-control-*` / `create-agent-send-*` must not be used for these five controls (they remain only for the create dialog's own Claude|Codex segmented switch and its top mode/project/branch pills). Changing any control's chrome changes both surfaces. Contract test: `newMakerCreateAgentVisualContract.test.ts`.
+- **Quota-reset confetti** — the third sanctioned motion class (approved 2026-07-23), **only** for the status-bar usage chip's "quota window reset reveal" (countdown hits zero → suspense "resetting…" → new snapshot lands):
+  - **Definition**: the instant the new snapshot confirms the reset, throw confetti once from the center of the revealing window segment, simultaneous with the 0%→100% percentage roll — making "the quota is back" a perceptible moment of celebration.
+  - **Form** (finalized over four/five review rounds, 2026-07-23): **true parabolic toss + vanish on landing** — all particles launch simultaneously from the segment center in a ~**100° fan** (±50° of straight up) at equal speed, **constant horizontal velocity + constant vertical gravity** (decelerating up, accelerating down past the apex), so perceived speed is consistent from burst to fall; wider-angle particles fly lower arcs, travel farther, land earlier — the scatter comes from physics, not scripting. The final stretch before the ground line ends in a **short fade**: landing is fine, but lingering after landing ("corpsing") or vanishing without a fade is forbidden; the ground line jitters randomly so landing points don't queue up.
+  - **Parameter red lines**: a one-shot celebration — simultaneous launch, no stagger delay; per-particle duration follows arc physics clamped to 0.9s–1.6s, total ≈1.6s (the number roll settles at 1.2s, then the last confetti falls a few tenths more; arc scale and rhythm are user-tuned, finalized 2026-07-23); ≤18 particles, 3–5px, torn down when done, never looping or persistent; particles are HTML elements animating only `transform` / `opacity` (compositor-only, engineering conventions §7; x/y split across two nested spans keeps horizontal velocity constant); colors come only from the four status-dot hue exemptions (done green / awaiting teal / thinking orange / error red), same values in both modes; must skip entirely under `prefers-reduced-motion`.
+  - **Scope boundary**: this one spot only. Confetti must not leak into task completion, send success, or anywhere else — those stay on the §14.4 baseline (a new exemption requires a new entry here). Implementation: `apps/desktop/src/renderer/components/status/QuotaResetConfetti.tsx`.
 
+## 15. CINDY Skin Family(品牌化可选 family)
 
-## 15. CINDY 皮肤族(品牌化可选 family)
+> This section records the CINDY skin family; it does **not** rewrite the §1–7 default-skin rules. Values were finalized from design-stage working files (`skin-docs/10-specs/` desktop, `skin-docs/30-mobile/` mobile errata — **not in this repo**, same status as the §16 login working files) plus the user's final sign-off of 2026-07-18. Zero discretion at implementation time: within the repo, the authoritative encodings are the theme files (`cindy-light.ts` / `cindy-dark.ts`), `cindyDecisionData.ts`, and the frozen tests — this section is their prose summary.
+>
+> Subsection numbers are **stable identifiers** (referenced by §16, code comments, and other documents; 15.9 was never assigned) — do not renumber. Decision history for this section is archived in [`design-decision-log.md`](./design-decision-log.md).
 
-> 本节为 CINDY 皮肤族的规范记录,**不改写 §1-7 默认皮肤规范**。取值定稿依据为
-> 设计阶段工作文件(`skin-docs/10-specs/` 桌面端体系、`skin-docs/30-mobile/`
-> 移动端勘误版——**均不入仓库**,地位同 §16 的登录工作文件)以及 2026-07-18 双端
-> 验收后的用户最终口头定稿。实现时零自由裁量:仓库内的权威编码是主题文件
-> (`cindy-light.ts` / `cindy-dark.ts`)、`cindyDecisionData.ts` 与各冻结测试,
-> 本节是其散文摘要。
+### 15.1 Palette (extracted from Figma text nodes)
 
-### 15.1 色板(Figma 文本节点提取)
-
-| 语义 | Light | Dark |
+| Semantic | Light | Dark |
 |---|---|---|
-| 品牌红 | `#DF0C27` | `#DF0C27` |
-| 品牌深红(hover/pressed) | `#A61629` | `#A61629` |
-| 背景 | `#EDEDED` | `#2A2828` |
-| 卡片/输入框 | `#F8F8F8` | `#312F2F` |
-| 边框 | `#DCDFE3`(desktop;mobile light 为全局例外 `#C6C9CE`,见「双端颜色同构」) | `#434343` |
-| 二级信息 | `#8C8E94`(用户调参 2026-07-20,自 Figma `#9A9DA3` 两轮加深) | `#6F6F6F` |
-| 正文 | `#3C3F43` | `#D4D4D4` |
-| 纯白 | `#FFFFFF` | `#FFFFFF` |
+| Brand red | `#DF0C27` | `#DF0C27` |
+| Deep brand red (hover/pressed) | `#A61629` | `#A61629` |
+| Background | `#EDEDED` | `#2A2828` |
+| Card / input | `#F8F8F8` | `#312F2F` |
+| Border | `#DCDFE3` (desktop; mobile light is a global exception `#C6C9CE` — see 15.13 "Cross-platform color isomorphism") | `#434343` |
+| Secondary info | `#8C8E94` (re-tuned from Figma `#9A9DA3` in two rounds, finalized 2026-07-20) | `#6F6F6F` |
+| Body text | `#3C3F43` | `#D4D4D4` |
+| Pure white | `#FFFFFF` | `#FFFFFF` |
 
-### 15.2 三份红 exact map(品牌红边界)
+### 15.2 Red-Boundary Test Maps(品牌红边界)
 
-- **BRAND_RED_EXPECTED_BY_ID**(必须等于品牌红/深红):`accent-cta-bg`/`accent-cta-bg-pure`/`accent-emphasis`/`confirm-btn-primary-bg`/`perm-allow-btn-bg`/`update-btn-border`/`update-btn-text`(均 `#DF0C27`);`primary`(HSL,RGB 归一等价品牌红)。`sidebar-item-active` 已于 2026-07-20 随反相胶囊定稿退出红 map(见 §15.10 勘误);`migration-bar-fill` 已随主干迁移条退役移出(2026-07-19)。
-- **BRAND_RED_ALLOWED_IDS**(允许含红全集 = EXPECTED ∪ 派生):上述 + `accent-soft`/`accent-hover`/`confirm-btn-primary-hover`/`settings-btn-primary-bg`/`settings-btn-primary-border`/`settings-btn-primary-hover-bg`。`drop-overlay-bg` 已于 2026-07-19 撤红移出名单(见 §15.13 C 类勘误)。
-- **CTA_FOREGROUND_WHITE_IDS**(红底白前景):`accent-pure-cta-fg`/`confirm-btn-primary-text`/`perm-allow-btn-text`/`primary-foreground`/`settings-btn-primary-text`。
+- Current authority (post-E1D, see 15.10): `NEUTRAL_PRIMARY_EXPECTED_BY_ID` / `NEUTRAL_PRIMARY_FOREGROUND_BY_ID` (exact neutral values for primary actions) + `RED_EXCEPTION_ALLOWED_IDS` (the complete set of tokens allowed to contain red), all in `apps/desktop/src/renderer/themes/__tests__/cindyDecisionData.ts`.
+- One-way ban: any token outside `RED_EXCEPTION_ALLOWED_IDS` containing `#DF0C27` / `#A61629` fails the suite.
+- The pre-E1D `BRAND_RED_*` maps are retained in `cindyDecisionData.ts` only for D2T migration and are marked for deletion; their contents are archived in the decision log — do not treat them as current rules.
 
-单向禁止:`ALLOWED` 之外任何 token 出现 `#DF0C27`/`#A61629` = 测试红。
+### 15.3 Interpolation Table (sRGB per-channel `round(A+(B-A)*t)`)
 
-### 15.3 插值表(sRGB 每通道 `round(A+(B-A)*t)`)
+See the skin decision table §2 (design-stage working file, not in repo). The Light/Dark 20/40/65/75% shades are frozen with exact values in unit tests (`#EFEFEF/#F1F1F1/#F4F4F4/#F5F5F5`, `#2B2929/#2D2B2B/#2F2D2D/#2F2D2D`).
 
-详见决策表 §2。Light/Dark 各 20/40/65/75% 档已冻结精确值进单测(`#EFEFEF/#F1F1F1/#F4F4F4/#F5F5F5`、`#2B2929/#2D2B2B/#2F2D2D/#2F2D2D`)。
+### 15.4 Cross-Theme Exemptions (not covered by CINDY overrides)
 
-### 15.4 豁免(不纳入 CINDY 覆盖,跨主题统一)
+- Semantic colors: `warning-accent` `#EA6B17` (finalized 2026-07-17, replaces `#FF6600`) / `annotation-accent` `#FF3B30` (image-annotation burn-in ink — exempt, do not change) / `status-bar-accent` (alias of warning orange, auto-follows).
+- The status four (finalized 2026-07-17; same values both modes, all 9 themes follow with no override): running `#EA6B17` / awaiting `#19D2C1` / error (status family) `#D91F37` / done `#2AAE5B`; warning foreground `warning-fg` `#F3A115` (decoupled from Toast amber `#F59E0B` — Toast keeps its group-B status quo).
+- `focus-ring` `#417CDD` (blue — never red); diff red/green; modal scrim/shadows; `overlay-lightbox`; the four Toast colors.
+- `destructive` / `search-match-bg` stay outside HSL_FORMAT_IDS coverage.
+- **hljs syntax colors** (light = highlight.js `github.css`; dark = globals.css `.dark .hljs-*` mirroring github-dark) — dual-threshold ruling (2026-07-17): syntax colors ≥3:1, body text ≥4.5:1. The hljs palettes were designed for GitHub's default canvases; CINDY's code-block canvas (`surface-elevated` `#F8F8F8`/`#312F2F`) sits close to default's, so marginal shortfalls are inherited, not CINDY-introduced (default is equally affected). Light: all syntax colors ≥3 — no remediation, itemized as exemptions. Dark: `[data-theme="cindy-dark"]` overrides `.hljs-section` to `#2573ec` (reaches 3.00:1) and sets `.hljs-punctuation` / `.hljs-tag` explicitly to `#c9d1d9` (defensive). Guarded by `cindyCodeBlockContrast.test.ts` (≥2 baseline + text ≥4.5). Full derivation: decision log.
+- model-budget spectrum bar / GhostTool shimmer: explicitly exempt (neutral shimmer, theme-invariant).
 
-- 语义色:`warning-accent` `#EA6B17`(定稿 2026-07-17,取代 `#FF6600`)/ `annotation-accent` `#FF3B30`(图片标注烧录笔迹色,语义豁免,不改)/ `status-bar-accent`(alias warning orange,自动跟随)。
-- 状态四色(设计定稿 2026-07-17,取代冻结红线;全局 light/dark 同值,9 主题无 override 自动跟随):running `#EA6B17` / awaiting `#19D2C1` / error(状态族)`#D91F37` / done `#2AAE5B`;warning 前景 `warning-fg` `#F3A115`(与 Toast amber `#F59E0B` 解耦,Toast 维持 B 组现状)。
-- `focus-ring` `#417CDD`(蓝,E5D 定稿 2026-07-17 取代 #3b82f6,不染红);diff 红绿;modal scrim/阴影;`overlay-lightbox`;Toast 四色定稿(豁免解除)。
-- `destructive`/`search-match-bg` 语义色不纳入 HSL_FORMAT_IDS 覆盖。
-- **hljs 语法高亮色**(light=highlight.js/styles/github.css;dark=globals.css `.dark .hljs-*` mirror github-dark):hljs 主题色为 default 代码块底设计,CINDY 代码块底(surface-elevated #F8F8F8/#312F2F)接近 default(#ffffff/#2c2c2a),边缘不达标(light -keyword 4.31/-built_in 3.29/-name 4.36;dark -punctuation 2.47/-tag 2.99/-section 2.87)是 hljs 既有折损(用 design surface 而非 github 默认 #ffffff/#0d1117),非 CINDY 引入——default 同源也不达标。CINDY 不补 [data-theme] 整改(与 default 同源,补整改值需重新过用户关卡);落档见 cindyCodeBlockContrast.test.ts(≥2 基线 + text ≥4.5 守卫)。
-**双门槛口径(D 裁决 2026-07-17)**:hljs 语法高亮色属辅助性视觉编码,对齐 selection/边界 3:1 口径——语法色 ≥3:1、正文文本 ≥4.5:1。CINDY 代码块底(surface-elevated)接近 default,hljs 主题色为 github 默认底(#ffffff/#0d1117)设计,固有折损非 CINDY 引入(default 同源)。
-- light:语法色全 ≥3(4.31/3.29/4.36),<4.5 但 ≥3 门槛通过,**不整改**,逐项落豁免档(default 同源折损);
-- dark:`.hljs-section` #1f6feb × #312F2F = 2.87 <3,补 `[data-theme="cindy-dark"] .hljs-section` 提亮 `#2573ec`(保持蓝 H212 S84% L52→53.5%,× #312F2F=3.00 ≥3);`.hljs-punctuation`/`.hljs-tag` github-dark "purposely ignored" 无显式色,dark 继承 .dark .hljs text `#c9d1d9`(× #312F2F=8.62 ≥3 达标),补 `[data-theme="cindy-dark"]` 显式覆盖 `#c9d1d9` 防御性(D 裁决三项覆盖,值同 text 不降对比度)。
-- model-budget 光谱条 / GhostTool shimmer:显式豁免(中性 shimmer,跨主题统一)。
+### 15.5 U2 Explicit Exception (secondary-info color stays true to Figma)
 
-### 15.5 U2 显式例外记录(二级信息色忠于 Figma 原值)
+- Tokens: `text-secondary` (light `#8C8E94` / dark `#6F6F6F`) / `text-secondary-cross` (light stays `#9A9DA3`, not re-tuned).
+- Measured contrast (WCAG): × surface `2.32/2.92:1`, × elevated `2.56/2.65:1`, × chip `2.41/2.72:1` — all below the 4.5:1 body-text AA. Ruling **U2 (2026-07-16): stay true to the Figma values**, readability loss accepted as a recorded explicit deviation. (Light was later re-tuned in two rounds to `#8C8E94`, finalized 2026-07-20, desktop and mobile in sync — see decision log.)
+- Constraint: **never darken unilaterally** (`#686B72` was tried and rejected, kept only as an archived sample); changing the value requires a fresh user ruling.
+- Reverse-frozen test: `cindyThemes.test.ts` group ⑦ asserts the exact finalized values (light `#8C8E94` / dark `#6F6F6F`); injecting `#686B72` must fail; update the baseline only after a user ruling.
 
-- token:`text-secondary`(light `#8C8E94` / dark `#6F6F6F`)/ `text-secondary-cross`(light 仍 `#9A9DA3`,未随调)。
-- 改值史:light 原 Figma `#9A9DA3`(U2 忠于原值)→ `#919399` → `#8C8E94`(用户两轮调参定稿 2026-07-20,桌面 cindy-light 与移动 tokens.ts 同步);dark 不变。对比度仍低于 AA,沿用 U2 显式例外口径。
-- 实测对比度(WCAG):× surface `2.32/2.92:1`、× elevated `2.56/2.65:1`、× chip `2.41/2.72:1`,均低于普通文本 AA `4.5:1`。
-- 裁决:用户 **U2(2026-07-16 拍板)=(b) 忠于 Figma 原值**,接受可读性折损,作为记录在案的显式偏离。
-- 约束:**不得擅自调深**(如 `#686B72` 已证伪且仅存档备查),改值须重新过用户关卡。
-- 反向冻结单测:`cindyThemes.test.ts` 第 ⑦ 组断言该值必须恰等定稿值(light `#8C8E94`/dark `#6F6F6F`),注入 `#686B72` 必须变红;改值须过用户关卡后同步基准。
+### 15.6 HSL Format Contract
 
-### 15.6 HSL 格式合约
+The 42 `HSL_FORMAT_IDS` must be HSL triplets (`h s% l%`, `h∈[0,360)`, grays use `hue=0`, 1 decimal place); every other token is hex/rgba. Round-trip HSL→RGB channel error ≤1. Nothing outside `HSL_FORMAT_IDS` may be written as an HSL triplet.
 
-42 个 `HSL_FORMAT_IDS` 必须 HSL 三元组(`h s% l%`,`h∈[0,360)`、灰色 `hue=0`、1 位小数);其余 token 走 hex/rgba。round-trip HSL→RGB 通道误差 ≤1。HSL_FORMAT_IDS 之外不得误填 HSL 三元组。
+### 15.7 Brand Assets (icon + logo)
 
-### 15.7 品牌标识资产(icon + logo)
+The new-session brand block is fixed at a 50×50px square icon + 110×37.5px horizontal logo with a 9px gap (2026-07 design). `ThemeBrandLockup` is the sole renderer. Themes swap artwork only via `theme.brand.icon/logo` — never rescale the finalized lockup; local images are cropped at load time to their alpha visible bounds (source files untouched). cindy-light uses the black-text logo (`cindy-logo-light.png`), cindy-dark the white-text one (`cindy-logo-dark.png`).
 
-新建对话页品牌区按 2026-07 新设计固定为 50×50px 方形 icon + 110×37.5px 横向 logo,间距 9px。`ThemeBrandLockup` 是新建页的唯一渲染实现。主题只通过 `theme.brand.icon/logo` 替换素材,不得通过 scale 改变定稿版式;本地图片透明留白按 alpha 可见边界在加载期裁切,不改写源文件。cindy-light 用黑字版(`cindy-logo-light.png`)、cindy-dark 用白字版(`cindy-logo-dark.png`)作为 logo。
+The brand block reads only `brand.icon/logo` — no compatibility with the legacy top-level `logo`, `logoScale`, or the interim `brand.mark/wordmark`; the structures differ semantically, never guess a mapping. Settings → Appearance keeps only three light entries (local theme copy, open folder, refresh) — no brand preview or asset picker. Exported standard JSON ships self-describing example paths (`icon-square-50x50px.png` / `logo-horizontal-110x37.5px.png`) so the config file documents both purpose and final display area; sources may export 2x/3x at the same aspect ratio. No extra README, no JSONC.
 
-新版品牌区只读取 `brand.icon/logo`,不兼容旧顶层 `logo`、`logoScale` 或开发过程中的 `brand.mark/wordmark`;旧配置与新版组合结构语义不同,禁止猜测映射。「设置 → 外观」只保留本地主题副本、打开目录和刷新三个轻量入口,不放品牌预览或素材选择器。新导出的标准 JSON 在 `brand.icon/logo` 中直接放 `icon-square-50x50px.png` / `logo-horizontal-110x37.5px.png` 示例路径,让配置文件自身同时说明用途与最终显示区域;源图可按同宽高比导出 2x/3x。不另生成 README 或改用 JSONC。
+> The logo-asset red `#F70121` is intrinsic to the official brand artwork (the WORD MARK arrow glyph); it coexists with — and differs from — UI brand red `#DF0C27`. Logos are image assets outside the token system; keep the original color. Do not "correct" it to `#DF0C27`.
 
-> logo 资产红 `#F70121` 是官方品牌资产固有色(WORD MARK frame 红箭头符号),与 UI 品牌红 `#DF0C27` **并存、不同值**——logo 是图片资产不进 token 体系,保持原色不改色。后人勿误改为 `#DF0C27`。
+The splash wordmark is a separate asset pair (`assets/splash/wordmark.png`, white text, for DARK / `wordmark-light.png`, dark text, for LIGHT): both 459×156 (@2x) with a 229.5×78 render frame (its exact 2x full frame), and **neither carries a drop shadow** — `SplashScreen.test.tsx` asserts the absence. (Asset-size and shadow history: decision log.)
 
-Splash 品牌块字标是另一套素材(`assets/splash/wordmark.png` 白字 DARK 用 / `wordmark-light.png` 深字 LIGHT 用),2026-07-22 起两版统一为 459×156(@2x),渲染框 `229.5×78` 恰为其 2x 满框——此前白字版为 486×184,塞同框被 object-contain 缩小 ~10%,DARK 字标偏小(用户实机发现,已换图修复)。同日用户拍板:splash 字标 DARK/LIGHT **均不带投影**(原 `drop-shadow-[0_2px_6.5px_rgba(0,0,0,0.25)]` 移除),冻结测试 `SplashScreen.test.tsx` 已同步反向断言。
+### 15.8 status-badge-fg
 
-### 15.8 status-badge-fg(§7 必炸点,用户确认 2026-07-17)
+- The orange badge (bg `status-bar-accent` `#EA6B17`) has its own foreground token `status-badge-fg`: **default mirrors `accent-pure-cta-fg`** (light white / dark black — zero change for the 9 existing themes); **CINDY overrides both modes to `#1F1F1F`** (near-black), contrast × `#EA6B17` = **5.19:1 ≥ 4.5** (user-approved; darken toward `#000000` if a future orange fails 4.5).
+- Consumers: `ContactsListPane:150` uses `status-badge-fg`; the `surface-on-card` consumers that sat on red CTAs (`RolePillDropdown:543/544`, `SkillhubDetailView:504`) moved to `accent-pure-cta-fg` (white); `surface-on-card` stays neutral-inverse (Fast toggle thumb). Registered in `cindyDecisionData` (a D2-phase addition).
 
-橙徽章(bg `status-bar-accent` `#EA6B17`,设计定稿 2026-07-17 取代 `#FF6600`)此前借用 `accent-pure-cta-fg`(白字)→ `#FFFFFF`×`#FF6600`=2.94:1 不达标(历史值,旧橙 #FF6600)。拆独立 `status-badge-fg`:
-- **default 镜像 `accent-pure-cta-fg`**(light 白 / dark 黑),既有 9 主题行为零变化;
-- **CINDY 两模式 override `#1F1F1F`**(深色近黑),× `status-bar-accent` `#EA6B17` = **5.19:1 ≥4.5**(用户亲批方案 #1F1F1F;设计定稿 2026-07-17 新橙 #EA6B17 实算 5.19:1,取代旧 #FF6600×5.61:1;不达 4.5 则加深 #000000);
-- 覆盖数组 115→116(`cindyDecisionData` 注明 D2 期新增,源自 §7 必炸点方案);
-- 消费点(`ContactsListPane:150`)从 `accent-pure-cta-fg` 切到 `status-badge-fg`;红 CTA 上的 `surface-on-card` 消费者(`RolePillDropdown:543/544`、`SkillhubDetailView:504`)迁到 `accent-pure-cta-fg`(白),`surface-on-card` 保留中性反相(Fast toggle thumb)。
+### 15.10 Red-System Boundary & Neutral CTAs — current state(E1D 红色边界)
 
-### 15.10 E1D 红色体系重构(用户批准 2026-07-17)
+- Ordinary primary actions never use brand red — they are neutral-inverse. **Neutral button four states**: light bg `#3C3F43` / text `#FCFCFC`, hover `#2E3237`, pressed `#25282C`; dark bg `#EEEEEE` / text `#252222`, hover `#E2E2E2`, pressed `#D4D4D4` (WCAG 10.32/13.60:1).
+- Red is confined to semantic exceptions: `destructive`/delete, `error-*`, warning, diff red, status dots — plus the login brand accent via `--login-brand-accent` (§16). The older `brand-login-*` tokens were retired with the wave4 white-canvas login and survive only as whitelist strings in `cindyDecisionData.ts` (harmless — the whitelist permits, it does not require).
+- **send-btn family**: `send-btn-bg/-icon/-hover-bg/-pressed-bg/-disabled-bg/-disabled-icon` — CINDY overrides the whole family to the neutral four states + disabled grays `#444242`/`#585555`; defaults keep `--accent-cta-bg` with the opacity-85 hover. Whole family sits in `cindyDecisionData` REQUIRED_IDS + CINDY_EXPECTED, guarded by assertion ③.
+- **Sidebar color hierarchy** (same set for light/dark):
+  - Body (session titles) = `text-foreground` (= `text-primary`: light `#3C3F43` / dark `#D4D4D4`).
+  - Secondary gray (leading icons at rest / timestamps / meta / group labels) = light `#9A9DA3` / dark `#6F6F6F` (same as `text-secondary`); CINDY overrides `sidebar-muted` / `sidebar-action-icon` (HSL `220.0 4.7% 62.2%` / `0 0% 43.5%`) + `cmd-palette-item-meta` (hex).
+  - Selected pill = inverse pill: `sidebar-item-active` light `#3C3F43` / dark `#EEEEEE`, foreground `sidebar-item-active-foreground` light `#FCFCFC` / dark `#252222`, border transparent. **Any foreground sitting on `bg-sidebar-item-active` must use `text-sidebar-item-active-foreground` — `text-foreground` is forbidden there** (the token defaults to foreground, so non-CINDY themes see zero change).
+  - Running-state leading icons (vendor glyph / Puzzle / RadioTower / Clock) = **Thinking Orange `--warning-accent` `#EA6B17`**, breathing via `session-status-breathing`; the selected state stays orange (running outranks the inverse foreground). Mobile `statusAccent` mirrors value and priority. Persistent breathing sits on an HTML wrapper; SVG stays static (engineering conventions §7).
+  - Assertions: ③ CINDY_EXPECTED locks the 4 token values; ⑦ adds hierarchy assertions (secondary gray clearly weaker than body; selected-pill foreground ≥4.5 on its fill).
+- Test maps: `NEUTRAL_PRIMARY_EXPECTED_BY_ID` / `NEUTRAL_PRIMARY_FOREGROUND_BY_ID` + `RED_EXCEPTION_ALLOWED_IDS` (replacing the pre-E1D `BRAND_RED_*` maps — archived in the decision log). Assertions ⑤/⑦/⑧ enforce exact neutrals, the red whitelist, neutral contrast, and falsifiability.
+- Backlog: the five R2 §4.3 Project_List deviations stay deferred (see the decision log backlog).
 
-常规主操作不再用品牌红,改反相中性(light 底 `#3C3F43`/字 `#FCFCFC`,dark 底 `#EEEEEE`/字 `#252222`;WCAG 10.32/13.60:1)。红色仅限语义例外:
-- **A 类(保留红)**:`brand-login-bg`/`brand-login-error-border`/`brand-login-error-text`(品牌海报/错误);
-- **C 类**:~~`sidebar-item-active` 红胶囊~~ 已于 2026-07-20 撤红改**反相胶囊**(light 深底 `#3C3F43`+浅字 `#FCFCFC`/dark 浅底 `#EEEEEE`+深字 `#252222`,描边 transparent,与 CTA 反相中性同族;用户三轮改稿定稿,PR #174/#190 落地);~~`migration-bar-fill`~~ 已随主干迁移条退役(2026-07-19,token 已删非撤红);~~`drop-overlay-bg` 红10%~~ 已于 2026-07-19 撤红(用户实机否决:整窗红罩语义似警报,回落 default 中性灰遮罩);
-- **语义色**:`destructive`/delete、`error-*`、warning、diff 红、status 点;
-- **B 类(改中性 11 项)**:`accent-cta-bg`/`-pure`/`-emphasis`/`-soft`/`-hover`、`update-btn-border`/`-text`、`confirm-btn-primary`、`perm-allow-btn`、`primary`、`settings-btn-primary`(alias)、`accent-pure-cta-fg`/`settings-btn-primary-text`(中性字);
-- **C 类裁决**:confirm(普通中性,danger 另设)、perm-allow(中性,警示橙 chip)、primary(中性)、sidebar-item-active(light 红胶囊/dark 深红)、migration-bar-fill(保留红)、drop-overlay(原保留红10%,2026-07-19 撤红改中性)、brand-login-cta(不动);
-- **中性按钮四态**:light 底`#3C3F43`/字`#FCFCFC`、hover`#2E3237`、pressed`#25282C`;dark 底`#EEEEEE`/字`#252222`、hover`#E2E2E2`、pressed`#D4D4D4`。
-- **send-btn 族纳入值表(E1D 扩,lead 裁决 2026-07-17)**:`send-btn-bg`(default alias `--accent-cta-bg`)/`-icon`/`-hover-bg`/`-pressed-bg`/`-disabled-bg`/`-disabled-icon` CINDY override 全族走上述四态反相中性 + disabled 灰 `#444242`/`#585555`(R4 D1 实证);hover/pressed 为 E1D 新增 token(default 同 bg,默认皮肤维持 opacity-85 hover,膘叔 E3 组件层消费 var() 即全局生效);全族入 cindyDecisionData REQUIRED_IDS + CINDY_EXPECTED,③ 断言守。
-- **侧栏颜色层级整改(E1D 扩,用户并排指错 2026-07-17,lead 钉死 light/dark 同套)**:
-  - 正文(会话标题)= `text-foreground`(=`text-primary` light `#3C3F43`/dark `#D4D4D4`,不动);
-  - 二级暗灰(行首图标普通态/时间戳/meta/分组标签)= light `#9A9DA3`/dark `#6F6F6F`(与 `text-secondary` 同值);CINDY override `sidebar-muted`/`sidebar-action-icon`(HSL `220.0 4.7% 62.2%`/`0 0% 43.5%`)+ 新增 `cmd-palette-item-meta` CINDY override(hex);
-  - 选中胶囊 = 反相胶囊(2026-07-20 定稿):`sidebar-item-active` light `#3C3F43`/dark `#EEEEEE`,前景 `sidebar-item-active-foreground` light `#FCFCFC`/dark `#252222`,描边 `sidebar-item-active-border` transparent;**凡 `bg-sidebar-item-active` 上的前景必须配 `text-sidebar-item-active-foreground`,禁用 `text-foreground`**(PR#190 全量整改,该 token 缺省=foreground,非 CINDY 零变化);
-  - 强调行(running)行首图标(厂商 glyph/Puzzle/RadioTower/Clock)= **Thinking Orange `--warning-accent` `#EA6B17`**(用户拍板 2026-07-20,取代红系时期规则),呼吸动画 `session-status-breathing`;**选中态同样橙(running 取色优先级高于反相前景)**;移动端 `statusAccent` 同值同规则。常驻呼吸动画必须挂 HTML wrapper,SVG 保持静态(常驻动画 compositor-only 红线,见 `docs/dev-rules/engineering-conventions.md` §7;PR#226 治理)。
-  - 断言:③ CINDY_EXPECTED 守 4 token 值;⑦ 新增层级断言(二级暗灰 contrast 明显弱于正文 + 选中胶囊前景×红底 ≥4.5)。
-- **backlog(R2 §4.3 五点差异,lead 裁决 2026-07-17 本轮不做,入 backlog)**:Project_List 三态拆分(active-task-pill/project-card/flat-list-row 不共用 `sidebar-item-active`);项目 header/list card 选中应中性底(#312F2F/#F6F6F6 非 #DF0C27 大红);去 Project_List 选中组 `focus-ring-soft` 蓝 ring,改 card stroke #DCDFE3/#434343;小箭头 #A61629 强调(非整行红底)。详见设计阶段工作文件 `2026-07-17-r2-ui-specs.md` §4.3(不入仓库)。本轮收敛不扩战线,后续另开。
+### 15.11 Input Caret (`--caret-accent`)
 
-三份新 map(`NEUTRAL_PRIMARY_EXPECTED_BY_ID`/`FOREGROUND` + `RED_EXCEPTION_ALLOWED_IDS`)替代旧 `BRAND_RED_*`。D2T ⑤/⑦/⑧ 改用新 map(中性 exact + 红例外白名单 + 中性对比度 + 可证伪)。
+- Every editable input surface takes its caret color from the `--caret-accent` token. `globals.css` owns this globally (native `caret-color` plus the ProseMirror pseudo-caret); components MUST NOT set their own caret color.
+- Value: default themes = `var(--accent-cta-bg)` (neutral inverse, follows the theme). CINDY overrides both modes to `#417CDD` (information blue, same value as the focus ring); removed from `RED_EXCEPTION_ALLOWED_IDS`, value locked by `cindyDecisionData.ts`.
+- Do not wire the caret to any red token — red is not in the caret's allowed palette.
+- Do not alias the caret to `--focus-ring` even though the values match: the semantics differ, and `--caret-accent` must stay independently adjustable.
+- Mobile parity: `inputCaret` in `apps/mobile/src/theme/tokens.ts` carries the same value in both modes, consumed via TextInput `cursorColor` / `selectionColor`; `themeTokens.test.ts` locks it.
 
-### 15.11 caret-accent 光标(用户二次改稿 2026-07-18 定稿:蓝,跨端规则)
+*(Finalized 2026-07-18 after two same-day revisions — earlier "brand-red caret" wording anywhere is void; see design-decision-log.md.)*
 
-> 决策史:07-18 日间"光标品牌红 #DF0C27"→ 07-18 晚**红 caret 定稿已被用户覆盖为蓝 `#417CDD`,双端一致**。以下为现行有效版本,历史文档中"caret 品牌红"表述一律作废。
+### 15.12 Vibrancy (frosted glass) System (macOS; finalized 2026-07-18)
 
-- 全部可编辑输入面的光标(caret)统一消费 `--caret-accent` token——globals.css 已全局接管(原生 `caret-color` + ProseMirror 伪光标),**组件内不许另设 caret-color**。
-- 取值:default 主题 = `var(--accent-cta-bg)`(中性反相,随主题走);**CINDY 两模式 override `#417CDD`**(与 focus ring 同值的信息蓝;已从 `RED_EXCEPTION_ALLOWED_IDS` 红例外白名单移除,`cindyDecisionData.ts` 断言锁值)。
-- **易踩点**:①光标不再是红——红色白名单里没有光标,不要把 caret 接任何红 token;②虽然值与 `--focus-ring` 相同,**不要**把 caret 直接接 `--focus-ring`——语义不同,光标唯一合法出口仍是 `caret-accent`(便于日后独立调整)。
-- **跨端对齐**:移动端(`apps/mobile` `src/theme/tokens.ts` 的 `inputCaret`)同值 `#417CDD` 双模式,RN 侧经 TextInput `cursorColor`/`selectionColor` 消费,`themeTokens.test.ts` 锁值。
+- **The only translucent-surface token**: `surface-translucent-sidebar` — CINDY light `rgba(255, 255, 255, 0.85)` / dark `rgba(18, 15, 15, 0.75)` (defaults to opaque `var(--surface)` in the default theme; zero effect on non-CINDY themes). Consumer: the left sidebar (`aside.bg-sidebar`); any future translucent surface **reuses this token by default** — no new ad-hoc rgba. The splash root is opaque `--surface` (it must fully cover the mounted UI until loading completes — ruling 2026-07-19).
+- **Wallpaper-through triple pipeline — missing any one yields dead black** (verified by on-device A/B, 2026-07-18):
+  1. Set `backgroundColor: '#00000000'` + vibrancy **at window creation** (`bootstrap-electron.ts` / `vibrancyConfig.ts`); changing alpha via `setBackgroundColor` at runtime is unreliable.
+  2. Under CINDY themes the **root container steps aside**: globals.css sets `.h-screen.bg-content-area` (and the splash backing layer while present) to transparent — otherwise the opaque root blocks everything.
+  3. **No CSS `backdrop-filter`** — it renders the transparent window backing as a black box; wallpaper blur is entirely the native vibrancy material's job, CSS only lays the translucent tint.
+- Material selected via the `XDT_VIBRANCY_MATERIAL` env knob, **code default `hud`** (user-tested). Windows: Win11+ uses `backgroundMaterial` (default `acrylic`, `XDT_BACKDROP_MATERIAL` knob — not yet device-verified); Win10 / non-CINDY fall back to opaque `--surface`.
+- **No gradient overlays on translucent surfaces** — the light-red gradient layer was confirmed absent from the design and removed wholesale (2026-07-18); the splash gradient glow is likewise unimplemented (backlog, awaiting a ruling).
+- The `surface-translucent-sidebar` alpha is the **only open look-and-feel knob** in the theme-frozen zone; adjusting it requires synchronized changes in three places (`cindy-light.ts` / `cindy-dark.ts` / `cindyDecisionData.ts`) with the themes suite green.
 
-### 15.12 毛玻璃(vibrancy)体系(用户定稿 2026-07-18,macOS)
+### 15.13 Cross-Platform Skin Rules(双端换肤定稿规则,2026-07-18)
 
-- **唯一半透面 token**:`surface-translucent-sidebar`——CINDY light `rgba(255, 255, 255, 0.85)` / dark `rgba(18, 15, 15, 0.75)`(default 主题下 = `var(--surface)` 不透明,非 CINDY 主题零影响)。消费方为左侧栏(`aside.bg-sidebar`);后续新增半透明表面**默认复用此 token**,不另造 rgba 值。splash 根容器已于 2026-07-19 改为不透明 `--surface`(用户拍板:加载完成前必须完全遮盖底下已挂载的主界面,不再共用半透 token)。
-- **透壁纸三重管线,缺一即死黑**(2026-07-18 实机 A/B 实证,详证据见换肤工程 sidebar-glass 补编终稿追记):
-  1. **窗口创建期**即设 `backgroundColor: '#00000000'` + vibrancy(`bootstrap-electron.ts` / `vibrancyConfig.ts`);运行时再 setBackgroundColor 改 alpha 不可靠。
-  2. CINDY 主题下**根容器让路**:globals.css 把 `.h-screen.bg-content-area`(及 splash 在场垫层)置 transparent,否则整窗不透明垫底挡死。
-  3. **禁止 CSS `backdrop-filter`**——它会把透明窗背衬渲染成黑箱;壁纸模糊完全由原生 vibrancy 材质负责,CSS 层只铺半透底色。
-- 材质经 `XDT_VIBRANCY_MATERIAL` 环境旋钮选择,**代码缺省 hud**(用户实测定稿,2026-07-19 由 sidebar 回写为缺省值)。Windows 侧 Win11+ 走 `backgroundMaterial`(缺省 acrylic,`XDT_BACKDROP_MATERIAL` 旋钮,未经实机验证);Win10/非 CINDY 回退不透明 `--surface`。
-- 半透面上**不叠渐变覆盖层**——浅色红渐变层 2026-07-18 经用户确认设计稿无此元素,已整层砍除;splash 的渐变辉光层同样未实现(backlog 待用户表态)。
-- `surface-translucent-sidebar` 的 alpha 是主题冻结区**唯一开放的观感旋钮**,调整必须三处同步(`cindy-light.ts` / `cindy-dark.ts` / `cindyDecisionData.ts`)且 themes 套件跑绿。
+The execution rulebook for subsequent desktop / mobile UI updates. Sources: the skin-docs working files (not in repo) plus the 2026-07-18 dual-platform acceptance.
 
-### 15.14 running/协同 橙色体系(用户拍板 2026-07-20)
+#### Red boundary
 
-- **running 呼吸图标一律 Thinking Orange**(`--warning-accent` `#EA6B17`,全主题同值):VendorIcon、SessionStatusIcon(Puzzle/RadioTower)、AutomationSessionGroupItem(Clock);选中态也橙,优先级 running > 选中反相前景 > 普通态。移动端 `statusAccent` 同值同规则(glyphColor 同优先级)。
-- **协同按钮 ON 态橙**:CollaborationModeToggle 开启态文字+Puzzle 图标 `warning-accent`(覆盖 2026-07-17「composer pill 去橙中性」规范,仅 ON 态;OFF 入口态保持中性)。
-- **SVG 常驻动画红线**:呼吸类常驻动画一律挂 HTML wrapper(span),SVG 保持静态。
+- Brand red `#DF0C27` only for brand display / splash, destructive actions, running/thinking emphasis, and the list active glyph (dark uses `#A61629` for the glyph).
+- Ordinary CTAs, FABs, send buttons, and confirm-style primaries are neutral-inverse: light bg `#3C3F43` / text `#FCFCFC`, dark bg `#EEEEEE` / text `#252222`. Never brand-red these.
+- The red whitelist does not include carets, focus rings, ordinary buttons, or ordinary selected backgrounds. A new red consumer must document its semantics and enter the token/test whitelist first; no component-level hardcoding.
 
-### 15.15 新建页内容区定位 + 顶栏 hover 消费纪律(用户拍板 2026-07-21)
+#### Caret & focus
 
-- **新建页(CREATE AGENT)内容组垂直定位**:距**窗口顶**恒为 `max(96px, 28vh) + 46px`。
-  实现 = 路由容器 `pt-[calc(max(96px,28vh)+46px-var(--content-header-h,46px))]`:
-  - 268px 封顶已废(Figma 定稿画框高度遗留,大窗口下内容"偏高"的根因);28% 为用户实机调参定稿(原 25.5%);
-  - `--content-header-h` 由 `ContentHeaderSlot`(FeatureSidebarSlotProvider 内)经 display:contents 包裹层广播(顶栏渲染 46px / 隐藏 0px,与 ContentHeader `h-[46px]` 同源)——选中项目引发顶栏显隐时内容区**零跳动**,恒定在"有顶栏时"位置;
-  - 顶栏显隐判定单一决策源 = `useContentHeaderHidden`(mac + Sidebar 展开 + 无注入内容 + 无右栏开关,沿用 2026-06-11"空 header 隐藏"决策);
-  - 守卫:`newMakerCreateAgentVisualContract` 锁定位公式 + 防回退断言。
-- **hover token 消费纪律**:`--update-btn-hover` 是升级按钮(反相深色 CTA)专用 hover,**禁止**用于普通 ghost 按钮/徽章(CINDY light 下近黑 `#2E3237`,吞字吞图标;2026-07-21 清理 6 处误用)。正确选型:
-  - 顶栏(ContentHeader 一带)ghost 元素 → `titlebar-button-hover`(与 ChromeActions 窗口按钮组同款);
-  - 内容区通用浅 hover → `--surface-hover`。
+- All input carets (`cursorColor` / `selectionColor`) are blue `#417CDD`, equal to `permAutoAccent` / desktop `caret-accent`; same value both modes.
+- Focus ring, Auto Approval, and info blue share the `#417CDD` family. Figma's older blue `#426BF2` is not adopted.
+- Red-family carets are forbidden.
 
-### 15.13 CINDY 双端换肤定稿规则(2026-07-18)
+#### Cross-platform color isomorphism
 
-本节是后续桌面端 / 手机端 UI 更新的执行规则。若本节与上方历史小节有冲突,以后续用户验收定稿为准;不要按早期红 CTA / 红 caret 口径回退。出处见 `skin-docs/10-specs/`、`skin-docs/30-mobile/2026-07-18-m0-color-mapping.md`、`skin-docs/30-mobile/2026-07-18-m3-chat-tasksheet-impl-plan.md`。
+- Mobile color semantics must mirror the desktop token decisions: the base layers (background, body, secondary info, borders) map directly from CINDY desktop semantics — never invent a parallel mobile palette for the same meanings.
+- **`colors.border` light is a mobile-wide exception, not a homepage-scoped token** (ruling 2026-07-21, PR #266): mobile light `border` / `borderTranslucent` = `#C6C9CE` / `rgba(198,201,206,0.62)`, deviating from desktop `#DCDFE3` — desktop borders usually sit on `#F8F8F8` cards, while mobile hairlines sit directly on the `#EDEDED` background, where `#DCDFE3` reads at a nearly invisible 1.14:1; the darkened 1.42:1 is device-verified legible. The value lives in `apps/mobile/src/theme/tokens.ts` global `lightColors.border`, applying to every mobile-light hairline; dark stays `#434343`, isomorphic with desktop. `chatCodeBorder` / `sheetActionBorder` / `sheetGrabber` keep independent values and do not follow this exception.
+- Mobile-only tokens carry only mobile-specific layers or geometry:
 
-#### 红色边界
-
-- 品牌红 `#DF0C27` 只用于品牌展示 / splash、破坏性操作、运行 / 思考状态强调、列表 active glyph。列表 active glyph 在 dark 使用 `#A61629`。
-- 普通 CTA、FAB、发送钮、确认类主操作一律使用中性反相:light 底 `#3C3F43` / 字 `#FCFCFC`,dark 底 `#EEEEEE` / 字 `#252222`。禁止把这些操作染成品牌红。
-- 红色白名单不包含输入光标、focus ring、普通按钮、普通选中态背景。新增红色消费必须先写明语义并进入对应 token / 测试白名单;不能在组件中硬编码。
-
-#### 光标与焦点
-
-- 所有输入光标 `cursorColor` / `selectionColor` 统一为蓝 `#417CDD`,等于 `permAutoAccent` / Mac `caret-accent`;light / dark 同值。
-- focus ring、Auto Approval、信息蓝同属 `#417CDD` 体系。Figma 旧蓝 `#426BF2` 不采用。
-- 禁止红色系光标。备注:2026-07-18 早前红 caret 口径已于同日晚被用户最终定稿覆盖。
-
-#### 双端颜色同构
-
-- 手机端颜色语义必须与桌面端 token 决策表同构:主背景、正文、二级信息、边框等基础层级按 CINDY desktop 语义直映,不要为移动端另造一套相同含义的颜色。
-- **`colors.border` light 是 mobile 全局例外,不是首页 scoped token**(裁决记录 2026-07-21,PR #266):mobile light `border` / `borderTranslucent` 取 `#C6C9CE` / `rgba(198,201,206,0.62)`,偏离 desktop `#DCDFE3`。原因:desktop 边框多衬 `#F8F8F8` 卡片,而 mobile 分割线直接衬 `#EDEDED` 主背景,`#DCDFE3` 对比仅 1.14:1 几乎不可见,加深到 1.42:1 后实机可辨。该值落在 `apps/mobile/src/theme/tokens.ts` 全局 `lightColors.border`,所有 mobile light 边框 / hairline 消费方一体生效;dark 维持 `#434343` 与 desktop 同构。`chatCodeBorder` / `sheetActionBorder` / `sheetGrabber` 等专用边框 token 独立取值,不随本例外联动。
-- 移动端专用 token 只承载移动端特有层级或几何语境:
-
-| Mobile token | Light | Dark | 用途 |
+| Mobile token | Light | Dark | Use |
 |---|---|---|---|
-| `surfaceListRow` | `#F6F6F6` | `#312F2F` | list 项目行 / 任务行 |
-| `surfaceListExpanded` | `#EAEAEA` | `#2A2828` | list 展开块 |
-| `activeGlyph` | `#DF0C27` | `#A61629` | list 行首 active glyph |
-| `chatCodeSurface` | `#F8F8F8` | `#353333` | chat / task code card |
-| `chatCodeBorder` | `#DCDFE3` | `#3C3C3C` | chat / task code card 边框 |
-| `inputCaret` | `#417CDD` | `#417CDD` | 所有输入光标 |
-| `sheetSurface` | `rgba(248,248,248,0.95)` | `rgba(59,59,59,0.95)` | bottom sheet root |
-| `sheetActionSurface` | `#F6F6F6` | `rgba(59,59,59,0.5)` | sheet action group / row |
-| `sheetActionBorder` | `#DCDFE3` | `#505050` | sheet action group / row 边框 |
-| `sheetActionText` | `#3C3F43` | `#C1C1C1` | sheet action row label |
-| `sheetGrabber` | `#DCDFE3` | `#6F6F6F` | sheet / composer grabber |
+| `surfaceListRow` | `#F6F6F6` | `#312F2F` | List project/task rows |
+| `surfaceListExpanded` | `#EAEAEA` | `#2A2828` | Expanded list block |
+| `activeGlyph` | `#DF0C27` | `#A61629` | Leading active glyph in lists |
+| `chatCodeSurface` | `#F8F8F8` | `#353333` | Chat / task code card |
+| `chatCodeBorder` | `#DCDFE3` | `#3C3C3C` | Chat / task code card border |
+| `inputCaret` | `#417CDD` | `#417CDD` | All input carets |
+| `sheetSurface` | `rgba(248,248,248,0.95)` | `rgba(59,59,59,0.95)` | Bottom-sheet root |
+| `sheetActionSurface` | `#F6F6F6` | `rgba(59,59,59,0.5)` | Sheet action group / row |
+| `sheetActionBorder` | `#DCDFE3` | `#505050` | Sheet action group / row border |
+| `sheetActionText` | `#3C3F43` | `#C1C1C1` | Sheet action row label |
+| `sheetGrabber` | `#DCDFE3` | `#6F6F6F` | Sheet / composer grabber |
 
-#### 图标规范
+#### Iconography
 
-- 会话行首 Agent 图标按运行时身份区分:Claude Code 官方像素脸 / Codex CLI `>_` 多瓣花,Mac(`VendorIcon`)与移动端(`MobileVendorIcon`)同源资产(2026-07-20 定稿)。Agent 身份 mark 不得与 Anthropic / OpenAI provider 或 model brand mark 混用;`BrandArrow` 仅保留给品牌装饰场景。
-- 模型选择按 model brand 出图。Mac 已替换过的品牌图标,移动端直接复用同源资产;其余使用现有图标库(lucide)中语义等价的图形。
-- 发送语义统一使用填充纸飞机 `Send`,颜色跟随中性反相 CTA token;不要用红色发送按钮或红色发送图标表达普通发送。
+- Session leading agent icons follow runtime identity: the Claude Code official pixel face / the Codex CLI `>_` multi-petal mark; desktop (`VendorIcon`) and mobile (`MobileVendorIcon`) share source assets (finalized 2026-07-20). Agent identity marks must not be mixed with Anthropic / OpenAI provider or model brand marks; `BrandArrow` is reserved for brand decoration.
+- Model selection renders by model brand. Brand icons already replaced on desktop are reused on mobile from the same source; everything else uses semantically equivalent lucide glyphs.
+- Send semantics use the filled paper plane `Send`, colored by the neutral-inverse CTA tokens; never a red send button or icon for ordinary send.
 
-#### 排版与布局要点
+#### Type & layout
 
-- List 页采用卡片化密度:20pt gutter、60pt 行高、12pt 圆角、55pt FAB。不要回退到旧的松散列表或红色普通 CTA。
-- Chat 顶栏使用毛玻璃 / 半透明玻璃体系:优先复用 `BlurBackdrop` 与专用 chat header token;未接线 blur 的位置使用半透明实色 token + hairline,不要新增未经验证的 blur 接入点。
-- Sheet 系统一致使用 sheet token。共享 `SheetSurface` 等组件改新样式时默认走 variant 隔离,只让设计稿覆盖到的 tasksheet / `SessionActionSheet` / `SessionMenuSheet` 使用新样式;ContextSheet、ModelPicker、info sheet 等未覆盖页面不自动跟随。
-- 展开块内部使用 hairline 分隔:非末行有线,末行无线;边框颜色走对应 token,不要写死(mobile light 全局 border 例外口径见上方「双端颜色同构」的 `colors.border` 条)。
+- List pages use card density: 20pt gutter, 60pt row height, 12pt radius, 55pt FAB. Never regress to the loose legacy list or red ordinary CTAs.
+- Chat headers use the frosted / translucent glass system: prefer `BlurBackdrop` + the dedicated chat-header tokens; where blur is not wired up, use translucent solid tokens + hairline — no unverified new blur entry points.
+- Sheets consistently use the sheet tokens. Restyling shared components (`SheetSurface` …) defaults to variant isolation: only the surfaces the design covered (tasksheet / `SessionActionSheet` / `SessionMenuSheet`) take the new style; ContextSheet, ModelPicker, info sheets do not auto-follow.
+- Hairline separators inside expanded blocks: every row but the last; colors via tokens, never hardcoded (see the mobile-light global border exception above).
 
-#### 流程门禁
+#### Process gates
 
-- 新增 / 修改颜色必须走 token,桌面端走 ColorRegistry / CSS variable,移动端走 `ThemeColors` / `useTheme`;组件里禁止硬编码 hex / rgba。
-- `hardcoded-color-audit` 必须全绿才允许合入。若因资产固有色或平台语义确需例外,必须登记白名单并说明原因。
-- 设计稿与既有 token 冲突时,先在规格或 PR 说明中列出"待拍板"并请求裁决;不得自行定案或用相近色偷换。
-- 共享组件样式改动默认用 variant / prop 隔离影响面。设计稿没有覆盖的页面、状态、平台,默认保持现状。
+- New or changed colors go through tokens — desktop via ColorRegistry / CSS variables, mobile via `ThemeColors` / `useTheme`; no hex/rgba in components.
+- `hardcoded-color-audit` must be fully green to merge. Genuine exceptions (asset-intrinsic or platform-semantic) must be whitelisted with reasons.
+- When a design mock conflicts with existing tokens, list it as "pending ruling" in the spec / PR and request a decision — never self-adjudicate or substitute a near color.
+- Shared-component restyles default to variant / prop isolation. Pages, states, and platforms not covered by the mock keep the status quo.
+
+### 15.14 Running / Collaboration Orange (finalized 2026-07-20)
+
+- **Running breathing icons are always Thinking Orange** (`--warning-accent` `#EA6B17`, all themes): VendorIcon, SessionStatusIcon (Puzzle/RadioTower), AutomationSessionGroupItem (Clock); the selected state stays orange — priority: running > selected inverse foreground > rest. Mobile `statusAccent` mirrors value and priority (glyphColor same).
+- **Collaboration toggle ON state is orange**: CollaborationModeToggle's active text + Puzzle icon use `warning-accent` (an explicit carve-out from the 2026-07-17 "composer pills go neutral" rule — ON state only; the OFF entry state stays neutral).
+- **SVG persistent-animation red line**: breathing-type persistent animation sits on an HTML wrapper (span); SVG stays static.
+
+### 15.15 Create-Page Content Position + Titlebar Hover Discipline (finalized 2026-07-21)
+
+- **CREATE AGENT content-group vertical position**: constant `max(96px, 28vh) + 46px` from the window top.
+  Implementation = route container `pt-[calc(max(96px,28vh)+46px-var(--content-header-h,46px))]`:
+  - the 268px cap is dead (a leftover of the Figma frame height — the root cause of content sitting high on large windows); 28% is device-tuned (from 25.5%);
+  - `--content-header-h` is broadcast by `ContentHeaderSlot` (inside FeatureSidebarSlotProvider) through a display:contents wrapper (46px rendered / 0px hidden, same source as ContentHeader `h-[46px]`) — content stays pinned at the "header present" position with **zero jump** when selecting a project toggles the header;
+  - header visibility has a single decision source = `useContentHeaderHidden` (mac + sidebar expanded + no injected content + no right-panel toggle; continues the 2026-06-11 "hide empty header" ruling);
+  - guard: `newMakerCreateAgentVisualContract` locks the position formula + anti-regression assertions.
+- **Hover-token discipline**: `--update-btn-hover` is exclusively the upgrade button's hover (inverse dark CTA) — **forbidden** on ordinary ghost buttons/badges (near-black `#2E3237` under CINDY light swallows text and icons; 6 misuses cleaned up 2026-07-21). Correct picks:
+  - titlebar-area (ContentHeader) ghost elements → `titlebar-button-hover` (same as the ChromeActions window buttons);
+  - general light hover in the content area → `--surface-hover`.
 
 ## 16. Login Flow (登录链路)
 
 > 本节是登录全链路的设计系统规范。逐参数权威 = 同目录的 [`figma-component-spec.md`](./figma-component-spec.md)（组件 / 色板速查，nodeId 溯源）与 [`token-decision-table.md`](./token-decision-table.md)（token / 尺寸决策）——两份自 2026-07-24 起随 `docs/design-rules/` 入仓维护；`DESIGN-login`（逐屏规格）、`flow-map`（状态机）、`fidelity-matrix`（保真度验收矩阵）仍为设计阶段工作文件，不入仓库。本节不重复抄全表，只钉死设计规则与组件契约，逐参数值以 Figma 组件库及本节色板表为准。
 >
-> **交付状态**：**亮色** as-built 已合并入 main；**深色**为目标规格（色值经 Figma 组件库 Dark symbol 逐个核验，见 §16.1 双态表 / §16.5），token 已注册但 dark 槽位当前为 light 占位值，待实现 PR 填入真实深色值。两模式均受 §2「Light / Dark 双模式交付门槛」约束——非可选愿景。
+> **交付状态**：**亮色** as-built 已合并入 main；**深色**为目标规格（色值经 Figma 组件库 Dark symbol 逐个核验，见 §16.1 双态表 / §16.5），token 已注册但 dark 槽位当前为 light 占位值，待实现 PR 填入真实深色值。两模式均受 §10「Light / Dark 双模式交付门槛」约束——非可选愿景。
 >
 > 本节独立于 §1–§15 默认皮肤与 CINDY 皮肤族——登录页是独立白底 / 深底反色体系，**不消费编辑器主题的 `--surface` / `--text-*` 等 slot**，只走本节定义的 `--login-*` token（light / dark 二态已注册于 `apps/desktop/src/renderer/themes/colors.ts`；见 §10）。`--login-*` 随基础 light / dark **二态**切换，但**不跟随具体扩展主题**（登录页只认 light / dark 模式；首次亮、后续跟随见 §16.5）。
 
@@ -925,7 +898,7 @@ Splash 品牌块字标是另一套素材(`assets/splash/wordmark.png` 白字 DAR
 
 ### 16.5 深色模式与主题跟随
 
-> 深色受 §2「Light / Dark 双模式交付门槛」约束，是**必须交付**的另一模式，非可选愿景。深色色值经 Figma 组件库 Dark symbol 逐个核验（见 §16.1 双态表），为目标规格——token dark 槽位已预留，待实现 PR 填入真实值并补齐 overlay token、深色资产切换及主题跟随逻辑。落地机制如下。
+> 深色受 §10「Light / Dark 双模式交付门槛」约束，是**必须交付**的另一模式，非可选愿景。深色色值经 Figma 组件库 Dark symbol 逐个核验（见 §16.1 双态表），为目标规格——token dark 槽位已预留，待实现 PR 填入真实值并补齐 overlay token、深色资产切换及主题跟随逻辑。落地机制如下。
 
 **深色 = 黑白反色在深底的镜像**：面板 / 控件深底、主按钮与社交圆钮反相白、文字反相米白，几何 / 布局 / props / 状态机 / i18n **零改动**——只换色值。
 

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -177,7 +177,7 @@ input/text
   text        --text-primary      #262626 / #d4d4d4
   border      --border-default    #d7d7d4 / #3c3c3a
   radius      9999px (pill — single-line inputs)
-  focus       --focus-ring        #417CDD @50%
+  focus       --focus-ring-soft   rgba(65,124,221,0.5)   (50% of #417CDD; opaque border variant = --focus-ring)
   placeholder --text-placeholder  #c4c4c4 / #525252
 ```
 
@@ -194,13 +194,13 @@ input/text
 
 ### Dialog & Modal
 
-Reference implementation: `components/ui/confirm-dialog.tsx` (the shared confirm dialog); new dialogs reuse its structure — do not invent a parallel one.
+Reference implementation: `apps/desktop/src/renderer/components/ui/confirm-dialog.tsx` (the shared confirm dialog); new dialogs reuse its structure — do not invent a parallel one.
 
-- **Overlay**: the full-screen scrim uses the `--overlay-modal` token (ConfirmDialog\'s current `neutral-900/40` hardcoded pair is legacy — **new dialogs always use the token**; do not copy the legacy pair).
+- **Overlay**: the full-screen scrim uses the `--overlay-modal` token (ConfirmDialog's current `neutral-900/40` hardcoded pair is legacy — **new dialogs always use the token**; do not copy the legacy pair).
 - **Container**: a container — 12px radius (`rounded-xl`), `--confirm-bg`, `--confirm-shadow`, 16px padding (`p-4`), centered. Width: confirm/notice dialogs ≈ 400px (`max-w-[400px]`); dialogs with inputs/forms may widen to ≈ 460px and shrink with the viewport (`min(460px, 100vw-32px)`).
 - **Title / description**: `--confirm-title` / `--confirm-desc`, medium weight.
 - **Buttons**: pill (9999px); primary = solid CTA (`--confirm-btn-primary-*`), secondary/cancel = outlined (`--confirm-btn-secondary-*`, transparent fill + Board border); footer `justify-end`.
-- **Focus on open**: lands on the dialog\'s **primary input or primary button**, never defaults to Cancel (see §14.2 + ConfirmDialog\'s `autoFocusConfirm` / `onOpenAutoFocus`).
+- **Focus on open**: lands on the dialog's **primary input or primary button**, never defaults to Cancel (see §14.2 + ConfirmDialog's `autoFocusConfirm` / `onOpenAutoFocus`).
 
 ### Tabs
 
@@ -239,7 +239,7 @@ Three tiers — **these three only**:
 - **Container (12px)**: box radius — code blocks, cards, panels, dialogs. Implemented as Tailwind `rounded-xl` (12px).
 - **Pill (9999px)**: every interactive element that can wear the pill — buttons, tabs, single-line inputs, tags, badges.
 
-*No 4px / 6px / 10px, and no arbitrary radii. Most elements still pick between the 12px container and the pill; 8px is a narrow exception for controls that don\'t fit the pill. Mind nesting: an 8px row highlight inside a 12px panel must stay smaller than its container to nest cleanly (hence 8, not 12) — a pill there becomes a lozenge, 12px looks bloated.*
+*No 4px / 6px / 10px, and no arbitrary radii. Most elements still pick between the 12px container and the pill; 8px is a narrow exception for controls that don't fit the pill. Mind nesting: an 8px row highlight inside a 12px panel must stay smaller than its container to nest cleanly (hence 8, not 12) — a pill there becomes a lozenge, 12px looks bloated.*
 
 ## 6. Depth & Elevation
 
@@ -409,7 +409,7 @@ Theme switching: `useTheme.ts` provides `theme` (System / Light / Dark mode) plu
 | `--plan-action-approve-icon-bg` | `#EA6B17` | `#EA6B17` | Plan approve — same thinking semantics (follows warning-accent, finalized 2026-07-17) |
 | `--perm-bypass-selected-text` | `#EA6B17` | `#EA6B17` | Heart Orange, permission semantics (auto-follows `var(--warning-accent)`, finalized 2026-07-17) |
 | `--settings-integration-warning` | `#EA6B17` | `#EA6B17` | Warning semantics (auto-follows `var(--warning-accent)`, finalized 2026-07-17) |
-| `--warning-bg-soft` | rgba(255,102,0,0.12) | rgba(255,102,0,0.18) | Warning alpha surface |
+| `--warning-bg-soft` | rgba(234,107,23,0.12) | rgba(234,107,23,0.18) | Warning alpha surface (alpha recomputed against `#EA6B17`, 2026-07-17) |
 | `--focus-ring` / `--focus-ring-soft` | `#417CDD` / @50% | same | A11y focus ring, finalized 2026-07-17 (replaces #3b82f6), theme-invariant |
 | `--shadow-menu` / `--cmd-palette-shadow` / `--confirm-shadow` | rgba | rgba (deeper) | Shadows, theme-invariant |
 | `--overlay-modal` / `--overlay-lightbox` | rgba | rgba (deeper) | Modal / lightbox backdrop |
@@ -559,6 +559,8 @@ Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`;
 | Running | Opacity breathing; must sit on an HTML wrapper (`docs/dev-rules/engineering-conventions.md` §7) | `session-breathing` |
 | Hover / state colors | `transition-colors`, ≤ fast (150ms) | App-wide status quo |
 | Container transform (chip grows into panel) | 220ms — see the dedicated category below (explicit exception) | Composer permission/model selectors |
+
+*Reference-implementation paths in this table are relative to `apps/desktop/src/renderer/`.*
 
 #### Red lines (performance & restraint)
 

--- a/docs/design-rules/cindy-design-system.md
+++ b/docs/design-rules/cindy-design-system.md
@@ -10,7 +10,7 @@
 | [`DESIGN.md`](./DESIGN.md) | 权威视觉规范全文：视觉语言（§1）、颜色（§2）、排版（§3）、组件（§4）、布局（§5）、交互约定与 Motion token（§14）、主题系统与 Token 参考（§10）、CINDY 皮肤族（§15）、登录链路（§16） | **权威正本**（原仓库根文件，根目录 `DESIGN.md` 保留为跳转入口） |
 | [`figma-component-spec.md`](./figma-component-spec.md) | 登录链路 Figma 组件与色彩速查手册：全组件逐态参数、nodeId 溯源、wave1–wave5 读取记录 | 权威（登录域逐参数） |
 | [`token-decision-table.md`](./token-decision-table.md) | 登录链路色值 / 尺寸 → token 决策记录（新增 / 复用 / 豁免的判定理由 + 各 wave 增补台账） | 决策记录（现行 token 清单与值以 `DESIGN.md §16.1` + `colors.ts` 为准） |
-| [`design-decision-log.md`](./design-decision-log.md) | 全局设计决策史台账：被推翻的方案、勘误过程、backlog（首批为原 `DESIGN.md §13` G1–G4 归档；§15 决策史待迁入） | 决策台账（只增不改；与 `DESIGN.md` 冲突时以 `DESIGN.md` 为准） |
+| [`design-decision-log.md`](./design-decision-log.md) | 全局设计决策史台账：被推翻的方案、勘误过程、backlog（已收录原 `DESIGN.md §13` G1–G4 归档与 §15 决策史全量） | 决策台账（只增不改；与 `DESIGN.md` 冲突时以 `DESIGN.md` 为准） |
 | [`README.md`](./README.md) | 本目录使用规则 | 说明 |
 
 ## 版本记录

--- a/docs/design-rules/cindy-design-system.md
+++ b/docs/design-rules/cindy-design-system.md
@@ -10,9 +10,11 @@
 | [`DESIGN.md`](./DESIGN.md) | 权威视觉规范全文：视觉语言（§1）、颜色（§2）、排版（§3）、组件（§4）、布局（§5）、交互约定与 Motion token（§14）、主题系统与 Token 参考（§10）、CINDY 皮肤族（§15）、登录链路（§16） | **权威正本**（原仓库根文件，根目录 `DESIGN.md` 保留为跳转入口） |
 | [`figma-component-spec.md`](./figma-component-spec.md) | 登录链路 Figma 组件与色彩速查手册：全组件逐态参数、nodeId 溯源、wave1–wave5 读取记录 | 权威（登录域逐参数） |
 | [`token-decision-table.md`](./token-decision-table.md) | 登录链路色值 / 尺寸 → token 决策记录（新增 / 复用 / 豁免的判定理由 + 各 wave 增补台账） | 决策记录（现行 token 清单与值以 `DESIGN.md §16.1` + `colors.ts` 为准） |
+| [`design-decision-log.md`](./design-decision-log.md) | 全局设计决策史台账：被推翻的方案、勘误过程、backlog（首批为原 `DESIGN.md §13` G1–G4 归档；§15 决策史待迁入） | 决策台账（只增不改；与 `DESIGN.md` 冲突时以 `DESIGN.md` 为准） |
 | [`README.md`](./README.md) | 本目录使用规则 | 说明 |
 
 ## 版本记录
 
+- **2026-07-24（梳理批次 1）**：`DESIGN.md` 整体梳理第一批落地——去除 Ollama 官网叙事（标题改 `Cindy Design System`，§1/§4/§5/§8/§9 重写或删除官网内容）；focus ring 文档追平代码（`#3b82f6` → `#417CDD`）；§2/§9 二级三级文字与 chip 双 slot 表述按 `colors.ts` 修正；§10 移除写死 token 计数与过时豁免行；§12 结构化规格并入 §4（§12 编号留占位）；§13 G1–G4 归档至新建 [`design-decision-log.md`](./design-decision-log.md)；§14/§15/§16 若干失效指向修正。
 - **2026-07-24**：目录整编（设计 md 统一归位 `docs/design-rules/`，本文件升级为索引）。同步 Figma 组件库更新：hover 统一「叠白变亮」口径（旧「白底钮 hover 叠黑」作废）、新增协议勾选 `radiobutton` 四态与双色模式小按钮四母版、`SSO 登录_企业` / `back` 扩 Dark 三态、`white_button` 增 loading 五态（`figma-component-spec §11`、`DESIGN.md §16.5`）。`figma-component-spec.md` / `token-decision-table.md` 自迁移前仓库最后版本恢复并更新至 wave5。
 - **2026-07-23**：`DESIGN.md` 新增 §16 登录链路（登录全链路设计规范、`--login-*` 双态 token 表、深色模式落地机制）。

--- a/docs/design-rules/design-decision-log.md
+++ b/docs/design-rules/design-decision-log.md
@@ -6,18 +6,91 @@
 > 本文件是只增不改的台账,不承载任何现行规范——**与 `DESIGN.md` 冲突时以
 > `DESIGN.md` 为准**。
 >
-> 范围现状(2026-07-24 建档):首批归档为原 `DESIGN.md §13` 的 G1–G4 勘误全文与
-> 旁注 backlog。`§15` CINDY 皮肤族的决策史(红色体系重构、caret 改稿、vibrancy
-> 定稿等)仍留存于 `DESIGN.md §15` 各小节内,待 §15 重构(梳理 C5)时迁入本文件。
+> 范围现状:2026-07-24 建档,首批归档原 `DESIGN.md §13` 的 G1–G4 勘误全文;
+> 2026-07-25 起 `§15` CINDY 皮肤族的决策史(红色体系重构、caret 改稿、vibrancy
+> 定稿等)已随 §15 保号重构迁入本文件,`DESIGN.md §15` 只保留现行规范。
 
 ## 2026-07
 
-- **07-24** 设计文档整体梳理启动:DESIGN.md 去除 Ollama 官网叙事(标题改
+- **07-25(梳理批次 2)** `DESIGN.md §15` 保号重构:小节编号冻结为稳定标识
+  (15.9 从未分配;15.13 物理位置移回 15.12 与 15.14 之间),各小节只留现行规范,
+  决策史迁入本文件;§10/§11/§14/§15 及 §2/§4/§5 残留中文段英文化(§16 冻结暂缓,
+  外部引用的关键标题保留中文括注);§16 两处「§2 双模式交付门槛」误指修正为 §10
+  (门槛正文在 §10,冻结例外,一行级)。
+- **07-24(梳理批次 1)** 设计文档整体梳理启动:DESIGN.md 去除 Ollama 官网叙事(标题改
   `Cindy Design System`,§4/§5/§8/§9 官网内容删除或重写为 Cindy 自述);
   §12 结构化组件规格试点采纳并入 §4(§12 编号保留占位);§13 G1–G4 归档至本文件;
   focus ring 文档追平代码(`#3b82f6` → `#417CDD`,代码 2026-07-17 已定稿,文档滞后);
   §2/§9 二级三级文字与 chip 双 slot 表述修正(以 `colors.ts` 为准);
-  §10 写死 token 计数移除(以 `colors.ts` 为准)。
+  §10 写死 token 计数移除(以 `colors.ts` 为准);§10 Tier-1 表删除幽灵行
+  `--accent-fg-on-pure`(colors.ts 无注册,值与 `--surface-on-card` 重复)。
+- **07-22** splash 字标资产统一:白字(DARK 用)/深字(LIGHT 用)两版统一为
+  459×156(@2x),渲染框 229.5×78 恰为 2x 满框——此前白字版 486×184 塞同框被
+  object-contain 缩小 ~10%,DARK 字标偏小(用户实机发现,换图修复);同日拍板
+  splash 字标双模式**均不带投影**(原 drop-shadow 移除),`SplashScreen.test.tsx`
+  反向断言。(→ §15.7)
+- **07-20** U2 二级信息色 light 两轮调参定稿:`#9A9DA3`(Figma 原值)→ `#919399`
+  → `#8C8E94`,桌面 cindy-light 与移动 tokens.ts 同步;dark `#6F6F6F` 不变;
+  `text-secondary-cross` light 未随调仍 `#9A9DA3`。`cindyThemes.test.ts` ⑦ 锁值。(→ §15.5)
+- **07-20** `sidebar-item-active` 撤红改反相胶囊(light 深底 `#3C3F43`+浅字
+  `#FCFCFC` / dark 浅底 `#EEEEEE`+深字 `#252222`,描边 transparent;用户三轮改稿
+  定稿,PR #174/#190 落地),同时退出红例外 map。(→ §15.10)
+- **07-19** `drop-overlay-bg` 红 10% 撤红回中性灰遮罩(用户实机否决:整窗红罩语义
+  似警报);`migration-bar-fill` 随主干迁移条退役(token 已删,非撤红);splash 根
+  容器由半透改**不透明 `--surface`**(加载完成前必须完全遮盖已挂载主界面);vibrancy
+  材质缺省定稿 `hud`(sidebar 实测回写)。(→ §15.10/§15.12)
+- **07-18** caret 光标:日间定品牌红 `#DF0C27`、当晚被用户覆盖定稿为蓝 `#417CDD`
+  (与 focus ring 同值,双端一致);历史文档中「caret 品牌红」表述一律作废。(→ §15.11)
+- **07-18** vibrancy 体系定稿:透壁纸三重管线经实机 A/B 实证(窗口创建期设透明底
+  + 根容器让路 + 禁 CSS backdrop-filter);唯一半透面 token
+  `surface-translucent-sidebar`;浅色红渐变层经用户确认设计稿无此元素整层砍除,
+  splash 渐变辉光层未实现入 backlog。同日发布双端换肤定稿规则(§15.13)。(→ §15.12/§15.13)
+- **07-17** E1D 红色体系重构(用户批准):常规主操作弃品牌红改反相中性四态
+  (light `#3C3F43`/`#FCFCFC`,hover `#2E3237`,pressed `#25282C`;dark `#EEEEEE`/
+  `#252222`,hover `#E2E2E2`,pressed `#D4D4D4`)。B 类改中性 11 项:
+  `accent-cta-bg`/`-pure`/`-emphasis`/`-soft`/`-hover`、`update-btn-border`/`-text`、
+  `confirm-btn-primary`、`perm-allow-btn`、`primary`、`settings-btn-primary`(alias)、
+  `accent-pure-cta-fg`/`settings-btn-primary-text`(中性字)。C 类逐项裁决:confirm
+  普通中性(danger 另设)/ perm-allow 中性+警示橙 chip / primary 中性 /
+  sidebar-item-active 当时 light 红胶囊、dark 深红(07-20 撤红,见上)/
+  migration-bar-fill 保留红(07-19 退役)/ drop-overlay 保留红 10%(07-19 撤红)/
+  brand-login-cta 不动。send-btn 族六 token 纳入 CINDY override 值表 + disabled 灰
+  `#444242`/`#585555`;侧栏颜色层级整改(正文/二级暗灰/选中胶囊/running 橙,
+  详见 §15.10 现行文)。三份新 map(`NEUTRAL_PRIMARY_EXPECTED_BY_ID`/
+  `NEUTRAL_PRIMARY_FOREGROUND_BY_ID` + `RED_EXCEPTION_ALLOWED_IDS`)取代旧
+  `BRAND_RED_*`;D2T ⑤/⑦/⑧ 迁移。(→ §15.2/§15.10)
+- **07-17** 〔归档〕E1D 前的旧 `BRAND_RED_*` 三份名单原文(cindyDecisionData.ts 中
+  保留供 D2T 迁移、迁完删):
+  - `BRAND_RED_EXPECTED_BY_ID`(必须等于品牌红/深红):`accent-cta-bg`/
+    `accent-cta-bg-pure`/`accent-emphasis`/`confirm-btn-primary-bg`/
+    `perm-allow-btn-bg`/`update-btn-border`/`update-btn-text`(均 `#DF0C27`);
+    `primary`(HSL,RGB 归一等价品牌红)。
+  - `BRAND_RED_ALLOWED_IDS`(允许含红全集 = EXPECTED ∪ 派生):上述 +
+    `accent-soft`/`accent-hover`/`confirm-btn-primary-hover`/
+    `settings-btn-primary-bg`/`-border`/`-hover-bg`。
+  - `CTA_FOREGROUND_WHITE_IDS`(红底白前景):`accent-pure-cta-fg`/
+    `confirm-btn-primary-text`/`perm-allow-btn-text`/`primary-foreground`/
+    `settings-btn-primary-text`。
+- **07-17** `status-badge-fg` 拆分推导:橙徽章此前借用 `accent-pure-cta-fg` 白字,
+  `#FFFFFF`×旧橙 `#FF6600`=2.94:1 不达标 → 拆独立 token,default 镜像
+  `accent-pure-cta-fg`(9 主题零变化),CINDY 两模式 override `#1F1F1F`
+  (×新橙 `#EA6B17`=5.19:1 ≥4.5,用户亲批;不达 4.5 则加深 `#000000`);覆盖数组
+  115→116;消费点迁移见 §15.8 现行文。(→ §15.8)
+- **07-17** hljs 语法高亮双门槛 D 裁决全推导:hljs 属辅助性视觉编码,对齐
+  selection/边界 3:1 口径(语法色 ≥3:1、正文 ≥4.5:1)。light 三项 <4.5 但 ≥3
+  (keyword 4.31 / built_in 3.29 / name 4.36)判 default 同源折损不整改,逐项落
+  豁免档;dark `.hljs-section` `#1f6feb`×`#312F2F`=2.87 <3 补
+  `[data-theme="cindy-dark"]` 提亮 `#2573ec`(H212 S84% L52→53.5%,=3.00);
+  `.hljs-punctuation`/`.hljs-tag` github-dark 无显式色,继承 text `#c9d1d9`
+  (8.62 达标),防御性补显式覆盖。落档 `cindyCodeBlockContrast.test.ts`。(→ §15.4)
+- **07-16** U2 裁决:二级信息色 (b) 忠于 Figma 原值,接受可读性折损(实测
+  × surface 2.32/2.92:1 等,均低于 AA 4.5:1),作为记录在案的显式偏离;
+  `#686B72` 加深方案证伪仅存档。(→ §15.5)
+- **〔勘误注记〕`brand-login-*` 已退役**:`brand-login-bg`/`brand-login-error-border`/
+  `brand-login-error-text`(E1D A 类「保留红」)已随 wave4 登录白底改版退役——
+  `colors.ts` 无注册,仅存于 `cindyDecisionData.ts` 红例外白名单字符串(白名单语义
+  是"允许存在",token 不存在时无害);现行品牌红唯一出口为 `--login-brand-accent`
+  (§16.1)。
 
 ## 2026-06 · Spec / Token Gaps 勘误(原 DESIGN.md §13 全文归档)
 
@@ -43,4 +116,5 @@
 ## Backlog(已知、刻意搁置)
 
 - `MakerExperimentalView.tsx` 通篇裸 hardcode hex(#404040 / #d4d4d4 / #262626 / #333),违反 DESIGN.md 第 10 节 token 规则。因是 experimental 视图,暂不清理,仅备忘(原 §13 旁注,2026-06)。
-- R2 §4.3 Project_List 五点差异(2026-07-17 lead 裁决本轮不做):Project_List 三态拆分、项目 header/list card 选中中性底、去选中组 focus-ring 蓝 ring、小箭头 #A61629 强调等。详见 DESIGN.md §15.10 backlog 段(§15 重构时迁入本文件)。
+- R2 §4.3 Project_List 五点差异(2026-07-17 lead 裁决本轮不做,出处为设计阶段工作文件 `2026-07-17-r2-ui-specs.md` §4.3,不入仓库):① Project_List 三态拆分(active-task-pill / project-card / flat-list-row 不共用 `sidebar-item-active`);② 项目 header / list card 选中应中性底(`#312F2F`/`#F6F6F6`,非 `#DF0C27` 大红);③ 去 Project_List 选中组 `focus-ring-soft` 蓝 ring,改 card stroke `#DCDFE3`/`#434343`;④ 小箭头 `#A61629` 强调(非整行红底);⑤ 本轮收敛不扩战线,后续另开。
+- splash 渐变辉光层未实现(2026-07-18 backlog,待用户表态)。

--- a/docs/design-rules/design-decision-log.md
+++ b/docs/design-rules/design-decision-log.md
@@ -1,0 +1,46 @@
+# Cindy 设计决策史(design-decision-log)
+
+> `DESIGN.md` 只保留「现行有效」的规范;历史决策、被推翻的方案、勘误过程按日期
+> 归档在本文件(中文)。每条记录:日期 / 决策 / 背景与被取代方案 / 现行落点
+> (DESIGN.md 章节 + token / 冻结测试)。
+> 本文件是只增不改的台账,不承载任何现行规范——**与 `DESIGN.md` 冲突时以
+> `DESIGN.md` 为准**。
+>
+> 范围现状(2026-07-24 建档):首批归档为原 `DESIGN.md §13` 的 G1–G4 勘误全文与
+> 旁注 backlog。`§15` CINDY 皮肤族的决策史(红色体系重构、caret 改稿、vibrancy
+> 定稿等)仍留存于 `DESIGN.md §15` 各小节内,待 §15 重构(梳理 C5)时迁入本文件。
+
+## 2026-07
+
+- **07-24** 设计文档整体梳理启动:DESIGN.md 去除 Ollama 官网叙事(标题改
+  `Cindy Design System`,§4/§5/§8/§9 官网内容删除或重写为 Cindy 自述);
+  §12 结构化组件规格试点采纳并入 §4(§12 编号保留占位);§13 G1–G4 归档至本文件;
+  focus ring 文档追平代码(`#3b82f6` → `#417CDD`,代码 2026-07-17 已定稿,文档滞后);
+  §2/§9 二级三级文字与 chip 双 slot 表述修正(以 `colors.ts` 为准);
+  §10 写死 token 计数移除(以 `colors.ts` 为准)。
+
+## 2026-06 · Spec / Token Gaps 勘误(原 DESIGN.md §13 全文归档)
+
+> §12 结构化重写过程中暴露的设计系统欠债。下列"现状"均已 grep 源码核实(以源码
+> 为准),非臆测。四条均已解决,结论已并入 §2 / §4 / §5 / §10。
+
+- [x] **G1 — 白底次按钮文字 `#404040`「Button Text Dark」是文档漂移,非真 token**(已解决 2026-06)
+  现状:§2 / §4 称其"专用于白底按钮文字",但全仓库只有 `features/maker-experimental/MakerExperimentalView.tsx`(实验视图,裸 hardcode)出现 #404040,**无任何真实次按钮**用它做文字色;§10 也无对应 token。
+  处理:§2 标废弃、§4 White Pill 文字改引 `--text-primary`(#262626)。未动 token,纯文档。
+
+- [x] **G2 — 次按钮边框 `#d4d4d4`「Border Light」同为漂移**(已解决 2026-06)
+  现状:§4 称白底按钮边框 `1px solid #d4d4d4`,但无真实组件这么用;#d4d4d4 的线上出现要么在实验视图(裸 hardcode),要么是**暗色主文字**(`--text-primary` dark = #d4d4d4,如 SchedulerPage CTA 注释),与"边框"无关。真边框 token 是 `--border-default`(#d7d7d4)。
+  处理:§2 标废弃、§4 White Pill 边框改引 `--border-default`(#d7d7d4)。纯文档。
+
+- [x] **G3 — placeholder token 碎片化 + 取值自相矛盾(真欠债)**(已解决 2026-06)
+  现状:4 个 per-surface alias 无统一 slot,且取值打架——`--settings-input-placeholder` = #c4c4c4(§4 认证的"淡到读着像空"),但 `--chat-input-placeholder` = `var(--text-tertiary)` = **#a3a3a3(Silver)**,而 §4 白纸黑字说 Silver **太显眼、读着像已填、不可做 placeholder**。即聊天输入框 placeholder 实际违反了我们自己的 §4 规范。
+  处理:`colors.ts` 新增语义 slot `--text-placeholder`(#c4c4c4 / #525252),4 个 alias(chat/ask/settings/plan-action-fb)default 收口为 `var(--text-placeholder)`;7 套非默认主题原 `settings-input-placeholder` override 就地改名为 `text-placeholder`(沿用原常量,避免回退,符合第 10 节对每套主题的 override 评估)。默认主题下 chat placeholder 由 #a3a3a3 修正为 #c4c4c4。2 套亮色主题(atom-one-light / solarized-light)的 `text-placeholder` 进一步从 tertiary 改用各自 **disabled 档**(更淡)——亮色背景下 tertiary≈2.6:1 命中 §4 禁用 Silver 的对比度,placeholder 须更淡才读着像空(2026-06 review 反馈)。**本地/复制主题兼容**:slot 引入前创建的本地主题快照只冻结了旧 per-surface placeholder key、无 `text-placeholder`,加载期 `mapWireTheme` 经 `local-themes-normalize.ts` 归一化——缺 `text-placeholder` 时从旧 `settings-input-placeholder`(或任一 per-surface 值)播种并丢弃 4 个旧 per-surface override,使四个输入面统一走新 slot(不改写盘上 JSON、幂等;2026-06 review 反馈)。
+
+- [x] **G4 — `--radius`(8px)与容器圆角同名不同义(已解决 2026-06)**
+  现状:`--radius` 实为 `0.5rem`(8px,shadcn 原语用);容器 12px 圆角实际靠 Tailwind `rounded-xl` 直接量实现。
+  处理:**圆角体系正式从"二元"改为"三档"**(8px 内层控件 / 12px 容器 / 9999px pill,见 §5 + §7 + §1)。8px 这一档窄范围限定多行输入框、下拉 / 菜单选中行、段内小单元,实现为 `rounded-lg`;shadcn `--radius`(8px)与这个内层档数值相同但语义独立(原语专用),容器仍走 `rounded-xl`(12px)。**本次纯文档,未动 token**。是否进一步 token 化为 `--radius-inner`(8px)/ `--radius-container`(12px)/ `--radius-pill`(9999px),收益偏低、**暂缓**,要做走第 10 节的新增 token 流程。
+
+## Backlog(已知、刻意搁置)
+
+- `MakerExperimentalView.tsx` 通篇裸 hardcode hex(#404040 / #d4d4d4 / #262626 / #333),违反 DESIGN.md 第 10 节 token 规则。因是 experimental 视图,暂不清理,仅备忘(原 §13 旁注,2026-06)。
+- R2 §4.3 Project_List 五点差异(2026-07-17 lead 裁决本轮不做):Project_List 三态拆分、项目 header/list card 选中中性底、去选中组 focus-ring 蓝 ring、小箭头 #A61629 强调等。详见 DESIGN.md §15.10 backlog 段(§15 重构时迁入本文件)。

--- a/docs/design-rules/token-decision-table.md
+++ b/docs/design-rules/token-decision-table.md
@@ -111,7 +111,7 @@ registerColor('login-control-bg', { light: '#eeeeee', dark: '#eeeeee' }, 'Cindy 
 
 | 主题类别 | 建议 |
 |---|---|
-| Default Light / Default Dark | 新 login alias 直接解析为 Figma 值；不继承黑白 Ollama login token |
+| Default Light / Default Dark | 新 login alias 直接解析为 Figma 值；不继承默认主题的旧黑白 login token |
 | Cindy Light / Cindy Dark | 对已有 Cindy 主题基础色无冲突；login alias 保持 Figma 帧值 |
 | Atom One Light / Solarized Light / Eclipse / One Dark Pro / GitHub Dark / Monokai Pro / Material Ocean HC | 不 override login alias。登录是品牌场景，主题只影响登录后工作区 |
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

对 `docs/design-rules/DESIGN.md` 做一次整体梳理(基线 = #288 合并后的 main),分三个 commit,每个单一主题:

1. **`e98e4f1a` 去 Ollama 官网叙事**:标题改 `Cindy Design System` + 血统注记;§1 氛围段重写为 Cindy 自述(近单色 + 批准语义集,替代失真的「纯白零彩色」表述);删除 §4 Navigation / Image Treatment / Model Tags / Terminal Command Block / Integration Grid 五块官网内容(Tab Pills 保留);§5 间距清单去官网噪声值(9px/88px/112px),Grid 一节重写为 App 三区布局;§8 官网断点表 + 汉堡菜单整节重写为窗口自适应(最小 800×600 取自 `bootstrap-electron.ts:2026` 实测);§9 官网示例 prompt 换为 Cindy 真实组件示例;§10 表头 `Ollama Light/Dark` → `Default Light/Dark`;token-decision-table 清除唯一字面残留。
2. **`1f7e28d3` 文档追平代码 + 结构收口**(每条均对照源码核实):focus ring `#3b82f6` → `#417CDD`(代码 2026-07-17 已定稿,文档滞后);§2/§9 Dark 二级/三级文字**对调修正**(与 `colors.ts:116-131` 一致);chip 表述改双 slot(`--surface-chip` #3c3c3a 主 / `--surface-chip-alt` #2c2c2a 变体);Thinking Orange「仅状态条」改批准清单制;§10 删写死 token 计数(写 352,实际已 454)、删 Tier-1 幽灵行 `--accent-fg-on-pure`(colors.ts 无注册)、豁免表已退役 `--login-error-text` 行改现行 token;§14.4 两处「AGENTS.md 规则 7」失效指向改 `engineering-conventions.md` §7;§12 结构化规格采纳并入 §4(§12 留编号占位防 §13–§16 断链);§13 G1–G4 归档至**新建** `design-decision-log.md`;索引登记 + mobile 缓存注释指向修正。
3. **`b18f068b` §15 保号重构 + 全文英文化**:§15 小节编号冻结为稳定标识(`§15.10` 被 `cindy-dark/light.ts` 注释引用、`§15.7/15.10/15.13` 被 §16 引用,重编号会断链;15.9 从未分配已注记),15.13 物理归位,各小节剥离决策史迁入 decision-log、只留现行规范;15.2 由已被 E1D 取代的 `BRAND_RED_*` 改写为现行 `NEUTRAL_PRIMARY_*` + `RED_EXCEPTION_ALLOWED_IDS`;§10/§11/§14/§15 及 §2/§4/§5 残留中文段逐段对译英文(外部引用的标题保留中文括注锚,§11 四语示例不译);§16 两处「§2 双模式交付门槛」误指修正为 §10。

4. **review 修正**(回应首轮 review):§7 Don't 彩色禁令限定为「批准语义集之外」(与同节 Do 条对齐,Greptile);§8 窗口下限表述修正——800×600 仅限主窗口与会话次窗口,**右侧栏独立窗口下限为 360×480**(`right-sidebar-window/window.ts:45-46` 实测,Greptile);索引表「§15 决策史待迁入」更新为已收录(Copilot/Greptile)。

**§16 登录链路刻意冻结未动**(除上述两处一行级指向修正)——暗色实现 PR 活跃迭代中,英文化与内容整理待其合并后另行处理。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求:#288 合并后的设计文档整体梳理(方案经内网评审页 design-md-plan.workers.xd.team 同步团队)
- 本 PR 包含:`docs/design-rules/DESIGN.md`、新建 `docs/design-rules/design-decision-log.md`、`docs/design-rules/cindy-design-system.md`、`docs/design-rules/token-decision-table.md`(1 行)、`apps/mobile/src/session/mobileHomeListCache.ts`(1 行注释)
- 明确不包含:任何 token / 主题 / 测试代码改动;§16 内容整理与英文化(待暗色 PR);wave5「文档超前代码」两处已知差异(有意保留)
- 用户可见变化:无(纯文档 + 1 行源码注释)
- 是否存在 breaking change:无

### UI 变化

不涉及。本 PR 唯一命中 UI 路径的文件 `apps/mobile/src/session/mobileHomeListCache.ts` 仅第 6 行**注释**中的文档路径字面量变更(「仓库根 DESIGN.md」→ `docs/design-rules/DESIGN.md`;该文件属缓存层,不含任何渲染代码),不产生任何可见 UI 变化,故无截图/录屏。验证方式:`git diff` 确认该文件唯一 hunk 为注释行;`pnpm --filter mobile run --if-present typecheck` 通过。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:四个 commit 各跑一轮,均通过(exit 0,25 包 PASS)。第三轮首次运行时
deviceOp.test.ts 的 watcher 时序测试超时(vi.waitFor 3s),单独重跑 35/35 通过、
全量重跑通过,判定 flaky 与本改动无关(本批仅 .md 改动)。
pnpm --filter mobile run --if-present typecheck
结果:通过(commit② 动了 mobile 一行注释)
git diff --check
结果:通过
```

### 手工验证

- **UI 路径源码文件无视觉变化说明(格式门)**:`apps/mobile/src/session/mobileHomeListCache.ts` 仅修改第 6 行**注释**中的文档路径字面量(「仓库根 DESIGN.md」→ `docs/design-rules/DESIGN.md`),不触碰任何逻辑、样式或渲染代码,**无任何视觉变化**,故无截图/录屏。验证方式:`git diff` 确认该文件唯一 hunk 为注释行;`pnpm --filter mobile run --if-present typecheck` 通过。
- 残留扫描:`grep -i "ollama|llama|hamburger|pencil"` 全文 0 命中(仅剩刻意写入的「无吉祥物」否定句);`#3b82f6` 仅剩 4 处「取代/replaces」历史注。
- §10 Tier-1 表 37 行与 `colors.ts` 的 registerColor 默认值**逐行脚本对拍**,三次复检全部一致(修复过程中即由此发现幽灵行 `--accent-fg-on-pure`)。
- §15 外部引用面实测(`grep -rn "§15\."` docs+apps):`cindy-dark/light.ts` 注释与 §16 的全部 `§15.x` 引用在保号重构后逐一验证仍指向正确小节。
- 本地 markdown 链接存在性脚本检查:无断链;§1–§16 章节号完整、§15 小节顺序连续。
- §1–§15 中文残留复查:仅剩双语标题括注(AGENTS.md 等以中文名引用)与 §11 四语文案示例(内容本体)。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:纯文档(+1 行源码注释),不影响运行时行为。治理面变化:①「设计决策史」正式落户 `design-decision-log.md`(只增不改台账);② DESIGN.md 章节/小节编号声明为稳定标识,§12 留占位、§15.9 缺号注记,禁止重编号。
- 回滚 / 降级方式:revert 对应 commit(三个 commit 单一主题,可独立 revert)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

---

**请 @PraiseZhu 重点复核一处**:§16.2 原文「态系细则见 `DESIGN.md §2`」被改为「设计阶段工作文件 `DESIGN-login §2`(不入仓库)」——本文件 §2 是 Color Palette、无态系内容,figma-component-spec §2 是排版系统,DESIGN-login 是唯一合理候选;如实际所指不同请指正,一行即可改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
