### PR TITLE
fix(desktop): 设置页 LSP 代码智能卡片补全四语言 i18n 词条

### DIFF
--- a/apps/desktop/src/renderer/__tests__/i18nCompleteness.test.ts
+++ b/apps/desktop/src/renderer/__tests__/i18nCompleteness.test.ts
@@ -31,10 +31,6 @@ const KNOWN_MISSING: ReadonlySet<string> = new Set([
   'ccAgent.workdirBrowse.fileBody.drawioLoading',
   'ccAgent.workdirBrowse.fileBody.pdfLoading',
   'chat.media.clickToZoom',
-  'settings.lspMode.cell.description',
-  'settings.lspMode.cell.title',
-  'settings.lspMode.toast.toggleFailed',
-  'settings.lspMode.toggleAria',
 ]);
 
 function loadLocales(): Record<string, unknown>[] {

--- a/apps/desktop/src/renderer/components/settings/LspBetaCell.tsx
+++ b/apps/desktop/src/renderer/components/settings/LspBetaCell.tsx
@@ -43,11 +43,6 @@ export function LspBetaCell() {
             next
               ? 'settings.lspMode.toast.enabled'
               : 'settings.lspMode.toast.disabled',
-            {
-              defaultValue: next
-                ? 'LSP 已开启,新建 session 后生效'
-                : 'LSP 已关闭,新建 session 后生效',
-            },
           ),
         );
       } catch (err) {
@@ -55,9 +50,7 @@ export function LspBetaCell() {
         toast.error(
           err instanceof Error
             ? err.message
-            : t('settings.lspMode.toast.toggleFailed', {
-                defaultValue: '切换 LSP 开关失败',
-              }),
+            : t('settings.lspMode.toast.toggleFailed'),
         );
         setEnabled(prev);
       } finally {
@@ -67,15 +60,8 @@ export function LspBetaCell() {
     [enabled, setEnabled, t],
   );
 
-  const title = t('settings.lspMode.cell.title', {
-    defaultValue: '代码智能 (LSP) · Beta',
-  });
-  const description = t('settings.lspMode.cell.description', {
-    defaultValue:
-      '通过 typescript-language-server 给 agent 提供精确的符号引用、跳转、call hierarchy。' +
-      '仅在 TypeScript 项目里生效 (自动检测 tsconfig.json / package.json 依赖)。' +
-      '非 TS 项目里此开关无效果,agent 工具列表不会出现 lsp_*。',
-  });
+  const title = t('settings.lspMode.cell.title');
+  const description = t('settings.lspMode.cell.description');
 
   return (
     <div
@@ -102,9 +88,7 @@ export function LspBetaCell() {
           checked={enabled}
           disabled={pending}
           onCheckedChange={(v) => void handleToggle(v)}
-          aria-label={t('settings.lspMode.toggleAria', {
-            defaultValue: 'LSP 代码智能开关',
-          })}
+          aria-label={t('settings.lspMode.toggleAria')}
         />
       </div>
     </div>

--- a/apps/desktop/src/renderer/components/settings/LspBetaCell.tsx
+++ b/apps/desktop/src/renderer/components/settings/LspBetaCell.tsx
@@ -39,11 +39,9 @@ export function LspBetaCell() {
       try {
         await window.electronAPI.maker.lspModeSet(next);
         toast.success(
-          t(
-            next
-              ? 'settings.lspMode.toast.enabled'
-              : 'settings.lspMode.toast.disabled',
-          ),
+          next
+            ? t('settings.lspMode.toast.enabled')
+            : t('settings.lspMode.toast.disabled'),
         );
       } catch (err) {
         log.warn('lspModeSet failed', err);

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1332,6 +1332,18 @@
       "toggleAria": "Toggle experimental feature: {{title}}",
       "features": {}
     },
+    "lspMode": {
+      "cell": {
+        "title": "Code Intelligence (LSP) · Beta",
+        "description": "Gives the agent precise symbol references, go-to-definition, and call hierarchy via typescript-language-server. Only takes effect in TypeScript projects (auto-detected from tsconfig.json / package.json dependencies). In non-TS projects this switch does nothing and lsp_* tools won't appear in the agent's tool list."
+      },
+      "toggleAria": "Toggle LSP code intelligence",
+      "toast": {
+        "enabled": "LSP enabled — takes effect in new sessions",
+        "disabled": "LSP disabled — takes effect in new sessions",
+        "toggleFailed": "Failed to toggle LSP"
+      }
+    },
     "gitSafety": {
       "title": "Git Safety",
       "autoSnapshotTitle": "Git safety snapshots",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1331,6 +1331,18 @@
       "toggleAria": "実験的機能を切り替え: {{title}}",
       "features": {}
     },
+    "lspMode": {
+      "cell": {
+        "title": "コードインテリジェンス (LSP) · Beta",
+        "description": "typescript-language-server を通じて、エージェントに正確なシンボル参照・定義ジャンプ・コールヒエラルキーを提供します。TypeScript プロジェクトでのみ有効です (tsconfig.json / package.json の依存関係を自動検出)。TS 以外のプロジェクトではこのスイッチは効果がなく、エージェントのツール一覧に lsp_* は表示されません。"
+      },
+      "toggleAria": "LSP コードインテリジェンスを切り替え",
+      "toast": {
+        "enabled": "LSP を有効にしました。新しいセッションから反映されます",
+        "disabled": "LSP を無効にしました。新しいセッションから反映されます",
+        "toggleFailed": "LSP の切り替えに失敗しました"
+      }
+    },
     "gitSafety": {
       "title": "Git セーフティ",
       "autoSnapshotTitle": "Git セーフティ保存点",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1331,6 +1331,18 @@
       "toggleAria": "실험적 기능 전환: {{title}}",
       "features": {}
     },
+    "lspMode": {
+      "cell": {
+        "title": "코드 인텔리전스 (LSP) · Beta",
+        "description": "typescript-language-server를 통해 에이전트에 정확한 심볼 참조, 정의 이동, 호출 계층(call hierarchy)을 제공합니다. TypeScript 프로젝트에서만 동작합니다(tsconfig.json / package.json 의존성 자동 감지). TS 프로젝트가 아니면 이 스위치는 효과가 없으며 에이전트 도구 목록에 lsp_*가 표시되지 않습니다."
+      },
+      "toggleAria": "LSP 코드 인텔리전스 전환",
+      "toast": {
+        "enabled": "LSP가 활성화되었습니다. 새 세션부터 적용됩니다",
+        "disabled": "LSP가 비활성화되었습니다. 새 세션부터 적용됩니다",
+        "toggleFailed": "LSP 전환에 실패했습니다"
+      }
+    },
     "gitSafety": {
       "title": "Git 안전",
       "autoSnapshotTitle": "Git 안전 저장점",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1331,6 +1331,18 @@
       "toggleAria": "切换实验功能：{{title}}",
       "features": {}
     },
+    "lspMode": {
+      "cell": {
+        "title": "代码智能 (LSP) · Beta",
+        "description": "通过 typescript-language-server 给 agent 提供精确的符号引用、跳转、call hierarchy。仅在 TypeScript 项目里生效 (自动检测 tsconfig.json / package.json 依赖)。非 TS 项目里此开关无效果,agent 工具列表不会出现 lsp_*。"
+      },
+      "toggleAria": "LSP 代码智能开关",
+      "toast": {
+        "enabled": "LSP 已开启,新建 session 后生效",
+        "disabled": "LSP 已关闭,新建 session 后生效",
+        "toggleFailed": "切换 LSP 开关失败"
+      }
+    },
     "gitSafety": {
       "title": "Git 安全",
       "autoSnapshotTitle": "Git 安全保存点",


### PR DESCRIPTION
## 这次改了什么

### 摘要

Settings → 实验性功能 → 「代码智能 (LSP) · Beta」卡片的 6 条文案（标题、描述、开关 aria-label、3 条 toast）此前只有组件内的中文 `defaultValue`，四个语言包里都没有 `settings.lspMode.*` 词条，导致英/日/韩界面也显示中文。本 PR 补齐四语言词条，组件改为纯 `t()` 消费，语言包成为唯一文案来源。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`settings.lspMode.*` 6 词条 × 4 语言（zh-CN / en / ja / ko）；`LspBetaCell.tsx` 移除 6 处冗余中文 `defaultValue`；`i18nCompleteness.test.ts` 的 `KNOWN_MISSING` 按「修一条删一条」规则移除已补齐的 4 条登记
- 明确不包含：main 上已存在的 desktop typecheck 断裂修复（见「风险」）
- 用户可见变化：en/ja/ko 界面下该卡片及其 toast 显示对应语言文案；zh-CN 文案与原 `defaultValue` 逐字一致，无变化
- 是否存在 breaking change：无

### UI 变化

<img width="942" height="168" alt="lsp-en" src="https://github.com/user-attachments/assets/fb6a8ba9-44d4-42b7-80d5-d092c63f7b6b" />
<img width="938" height="148" alt="lsp-cn" src="https://github.com/user-attachments/assets/dcc896ce-28af-444d-bd8b-bb2411da3ed9" />
<img width="941" height="143" alt="lsp-jp" src="https://github.com/user-attachments/assets/1c3cb9f0-9e8d-4af7-9f7b-8c408b5393ff" />
<img width="936" height="150" alt="lsp-ko" src="https://github.com/user-attachments/assets/b2d32458-fe08-4051-bb81-63a8f21c6ac6" />

## 怎么验证的

### 自动验证

```text
pnpm check:i18n
结果：✅ 5392 个 key 四语一致（429 处均为存量警告）

pnpm --filter desktop exec vitest run src/renderer/__tests__/i18nCompleteness.test.ts
结果：✅ 2 passed（含防 KNOWN_MISSING 腐化断言）

pnpm test:unit
结果：❌ 1 failed — src/main/git-review/__tests__/diffReader.test.ts
「classifies worktree symlinks without probing the linked target content」。
Windows 环境存量失败：git 将 symlink 目标记录为正斜杠路径，断言期望反斜杠。
已在干净 main（e576b58，stash 本改动后）定向复跑，失败一致，与本 PR 无关。
其余测试全部通过。

pnpm --filter desktop run --if-present typecheck
结果：❌ 存量失败 — src/main/cindy-brain/index.ts(1855) 引用的
requestNodeInstallAuthorization 未定义。成因是合并语义冲突：#333（da184a4）
删除了 nodeInstallAuthorization.ts 模块及 nodeRisk 四语词条，其后合入的
#256（0339f94）插件市场安装路径仍引用该函数（且 marketGhostSessionBoundary
边界测试静态断言该调用必须存在）。本地 main 与上游 main 均如此（已在干净
main 上复跑确认）。与本 PR 无关，建议单独修复（倾向恢复模块以保住市场路径
的 Node 插件显式授权闸门，手动安装路径维持 #333 的无弹窗定案）。
```

### 手工验证

不涉及：改动仅为词条数据与等价的 `t()` 调用收敛，zh-CN 渲染结果逐字不变。

### 未执行的验证

未在运行中的 app 内逐语言切换目检 en/ja/ko 渲染；原因：改动不含布局/逻辑，key 结构由 `pnpm check:i18n` 与 `i18nCompleteness` 静态闸门覆盖。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Settings LSP 卡片文案与四个 `common.json` 的 `settings.lspMode` 组
- 回滚 / 降级方式：revert 本 commit 即可，无数据、协议或权限影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
