### PR TITLE
fix(newmaker): 快捷入口卡片改竖排——icon 固定左上,文字挪到中下方与 icon 左对齐

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -123,6 +123,20 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(source).not.toContain('boxShadow');
   });
 
+  it('lays out quick-start cards icon-top/label-bottom with a 4px minimum gap (2026-07-25 redesign)', () => {
+    // 用户改稿 2026-07-25:两档(narrow/常态)统一竖排——icon 固定左上,文字挪到卡片
+    // 中下方与 icon 左对齐(flex-col + justify-between,gap-1 兜底最小间距),取代原
+    // 窄态横排 / 常态竖排自适应(#562)。卡片高度不变(narrow 84 / 常态 112)。
+    expect(source).toContain(
+      "'group flex flex-col items-start justify-between gap-1 rounded-xl border",
+    );
+    expect(source).toContain("isDraftNarrow ? 'min-h-[84px] p-3' : 'min-h-[112px] p-4'");
+    expect(source).toContain('className="w-full min-w-0 text-13 font-semibold leading-[16px]"');
+    // 旧的窄态横排(items-center)/常态竖排(gap-3)特判已被统一竖排取代。
+    expect(source).not.toContain("'flex min-h-[84px] items-center gap-3 p-3'");
+    expect(source).not.toContain("'flex min-h-[112px] flex-col items-start gap-3 p-4'");
+  });
+
   it('uses exact CREATE AGENT quick-start and avatar tokens from the Figma slices', () => {
     // head_image 切图方案(用户裁决 2026-07-17):边框烧入图,仅投影走 CSS
     expect(brandLockupSource).toContain('head-image-dark.png');

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2301,13 +2301,15 @@ export function NewMakerDraftRoute() {
                           key={key}
                           type="button"
                           onClick={() => handleQuickStart(labelKey)}
-                          // 圆角与输入框统一为 12px(DESIGN §5 容器档,rounded-xl);
-                          // 窄态横排 / 常态竖排自适应(#562)。
+                          // 圆角与输入框统一为 12px(DESIGN §5 容器档,rounded-xl)。
+                          // 用户改稿 2026-07-25:两档统一竖排——icon 固定卡片左上(距顶/
+                          // 距左均等于 p-3/p-4 内边距),文字挪到卡片中下方、与 icon 左对齐
+                          // (flex-col + justify-between,icon 顶、文字底;gap-1 兜底竖向
+                          // 最小间距),取代原窄态横排 / 常态竖排自适应(#562)。
+                          // 卡片高度不变(narrow 84 / 常态 112)。
                           className={cn(
-                            'group rounded-xl border border-[var(--create-agent-quick-card-border)] bg-[var(--create-agent-quick-card-bg)] text-left text-[var(--create-agent-quick-card-text)] transition-colors hover:bg-[var(--create-agent-quick-card-bg-hover)]',
-                            isDraftNarrow
-                              ? 'flex min-h-[84px] items-center gap-3 p-3'
-                              : 'flex min-h-[112px] flex-col items-start gap-3 p-4',
+                            'group flex flex-col items-start justify-between gap-1 rounded-xl border border-[var(--create-agent-quick-card-border)] bg-[var(--create-agent-quick-card-bg)] text-left text-[var(--create-agent-quick-card-text)] transition-colors hover:bg-[var(--create-agent-quick-card-bg-hover)]',
+                            isDraftNarrow ? 'min-h-[84px] p-3' : 'min-h-[112px] p-4',
                           )}
                         >
                           <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[var(--create-agent-quick-card-icon-bg)]">
@@ -2317,8 +2319,9 @@ export function NewMakerDraftRoute() {
                               className="text-[var(--create-agent-quick-card-icon)]"
                             />
                           </span>
-                          {/* 字号 13px 与左侧会话列表(text-13)一致——用户改稿 2026-07-22。 */}
-                          <span className="flex min-w-0 min-h-10 items-center text-13 font-semibold leading-[16px]">
+                          {/* 字号 13px 与左侧会话列表(text-13)一致——用户改稿 2026-07-22。
+                              竖排下占满卡片宽度、左对齐 icon,靠父列 justify-between 贴底。 */}
+                          <span className="w-full min-w-0 text-13 font-semibold leading-[16px]">
                             {t(labelKey)}
                           </span>
                         </button>

--- a/docs/design-previews/newmaker-quickstart-cards/extract.mjs
+++ b/docs/design-previews/newmaker-quickstart-cards/extract.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+// extract.mjs — New Maker 快捷入口卡片布局 QA demo 真值提取器。
+//
+// 从产品源码机械提取(正则 / JSON.parse)demo 需要的一切事实,每个叶子带 provenance
+// {source(相对 demoDir 路径), locator(定位方式), hash(整源文件 sha256)}。
+// 门 A 会现跑本脚本并要求输出 ≡ truth.json——所以本脚本必须确定性(无时间/随机)。
+//
+// 覆盖:
+//   - 4 张卡片定义(key / icon / 4 语言 label)  ← NewMakerDraftRoute.tsx + 4×common.json
+//   - section 标题(4 语言 + 字号/行高)          ← NewMakerDraftRoute.tsx + common.json
+//   - 卡片几何(gap 8 / 圆角 12 / 描边 1 / icon 圈 32 / 字号 13 / min-h 84·112 / grid gap 12)
+//   - 主题 token(6 卡片色 + text-secondary,light/dark hex) ← themes/colors.ts
+//   - 布局公式常量(useProportionalWidth 的 5 常量 + minWidth 640 + 断点 560/700 + main px 16/32)
+//   - adaptive.samples:用产品布局公式对 spec.adaptive.sampleSizes 预计算每个采样点的期望几何
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REL = '../../../apps/desktop'; // demoDir(docs/design-previews/newmaker-quickstart-cards) → worktree 下 apps/desktop
+
+// 源文件相对路径(相对 demoDir;provenance.source 存这个字符串,校验器 resolve(demoDir, source))
+const SRC = {
+  draft: `${REL}/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx`,
+  colors: `${REL}/src/renderer/themes/colors.ts`,
+  hook: `${REL}/src/renderer/hooks/useProportionalWidth.ts`,
+  globals: `${REL}/src/renderer/styles/globals.css`,
+  i18n: (loc) => `${REL}/src/renderer/i18n/locales/${loc}/common.json`,
+};
+
+const LOCALES = ['zh-CN', 'en', 'ja', 'ko'];
+
+// —— 源文件读取 + 缓存 hash(整文件 sha256,与 schema.hashFile 一致) ——
+const _cache = new Map();
+function read(relPath) {
+  if (!_cache.has(relPath)) {
+    const abs = resolve(HERE, relPath);
+    const text = readFileSync(abs, 'utf8');
+    const hash = createHash('sha256').update(readFileSync(abs)).digest('hex');
+    _cache.set(relPath, { text, hash });
+  }
+  return _cache.get(relPath);
+}
+// 叶子包装:{ value, provenance:{ source, locator, hash } }
+function leaf(value, relPath, locator) {
+  const { hash } = read(relPath);
+  return { value, provenance: { source: relPath, locator, hash } };
+}
+
+// —— 断言帮助:提取的东西必须真在源码里,否则源码变了就该报错(不静默用旧值) ——
+function must(cond, msg) {
+  if (!cond) {
+    process.stderr.write(`extract.mjs 提取失败:${msg}\n`);
+    process.exit(1);
+  }
+}
+function grab(relPath, re, msg) {
+  const m = read(relPath).text.match(re);
+  must(m, msg);
+  return m;
+}
+
+// ========== 1. 卡片定义(key / icon)—— NewMakerDraftRoute.tsx ==========
+// createAgentQuickStarts 数组:逐条 key + labelKey + icon
+const draftText = read(SRC.draft).text;
+const cardDefRe =
+  /\{\s*key:\s*'([a-z]+)',\s*labelKey:\s*'(newChat\.createAgent\.quickStarts\.[a-z]+)',\s*icon:\s*(\w+),/g;
+const cardDefs = [];
+for (const m of draftText.matchAll(cardDefRe)) {
+  cardDefs.push({ key: m[1], labelKey: m[2], icon: m[3] });
+}
+must(cardDefs.length === 4, `createAgentQuickStarts 期望 4 张卡,实得 ${cardDefs.length}`);
+
+// ========== 2. i18n 文案(4 语言 label + section 标题) ==========
+const i18n = {};
+for (const loc of LOCALES) {
+  const rel = SRC.i18n(loc);
+  const json = JSON.parse(read(rel).text);
+  const ca = json?.newChat?.createAgent;
+  must(ca && ca.quickStarts && ca.quickStart, `${loc}/common.json 缺 newChat.createAgent.quickStart(s)`);
+  i18n[loc] = { rel, quickStarts: ca.quickStarts, title: ca.quickStart };
+}
+
+const cards = cardDefs.map((d) => {
+  const shortKey = d.labelKey.split('.').pop();
+  const labels = {};
+  for (const loc of LOCALES) {
+    const txt = i18n[loc].quickStarts[shortKey];
+    must(typeof txt === 'string' && txt.length > 0, `${loc} 缺 quickStarts.${shortKey}`);
+    labels[loc] = leaf(txt, i18n[loc].rel, `newChat.createAgent.quickStarts.${shortKey}`);
+  }
+  return {
+    key: leaf(d.key, SRC.draft, `createAgentQuickStarts[].key='${d.key}'`),
+    icon: leaf(d.icon, SRC.draft, `createAgentQuickStarts[].icon=${d.icon}`),
+    labels,
+  };
+});
+
+const sectionTitles = {};
+for (const loc of LOCALES) {
+  sectionTitles[loc] = leaf(i18n[loc].title, i18n[loc].rel, 'newChat.createAgent.quickStart');
+}
+
+// ========== 3. 卡片几何(Tailwind class → px;先断言 class 真在源码里) ==========
+// 卡片按钮 className(竖排改稿后):flex flex-col items-start justify-between gap-1 rounded-xl border ... min-h-[112px] p-4
+grab(
+  SRC.draft,
+  /flex flex-col items-start justify-between gap-1 rounded-xl border/,
+  '卡片按钮缺 "flex flex-col items-start justify-between gap-1 rounded-xl border"(竖排契约,icon 顶+文字底)',
+);
+grab(SRC.draft, /isDraftNarrow \? 'min-h-\[84px\] p-3' : 'min-h-\[112px\] p-4'/, '卡片高度/内边距档缺失');
+grab(SRC.draft, /grid w-full gap-3/, 'grid 容器缺 "grid w-full gap-3"');
+grab(SRC.draft, /grid h-8 w-8 shrink-0 place-items-center rounded-full/, 'icon 圈缺 "h-8 w-8 ... rounded-full"');
+grab(SRC.draft, /size=\{16\}/, 'icon glyph size={16} 缺失');
+grab(SRC.draft, /w-full min-w-0 text-13 font-semibold leading-\[16px\]/, 'label span 缺 "w-full ... text-13 ... leading-[16px]"(竖排文字契约,与 icon 同宽左对齐)');
+grab(SRC.draft, /text-\[14px\] font-medium leading-\[18px\] text-\[var\(--text-secondary\)\]/, 'section 标题样式缺失');
+// grid 列断点(draftContentWidth 即 inputWidth):< 560 → 1 列;< 700 → 2 列;否则 4 列
+grab(SRC.draft, /isDraftNarrow = draftContentWidth < 560/, 'grid 列断点 560 缺失');
+grab(SRC.draft, /isDraftMedium = draftContentWidth < 700/, 'grid 列断点 700 缺失');
+// main 横向 padding 档:px-4(narrow) / px-8
+grab(SRC.draft, /isDraftNarrow\s*\n?\s*\? 'px-4/, 'main narrow padding px-4 缺失');
+// --text-13 = 13px(text-13 = var(--text-13),定义在 globals.css)
+grab(SRC.globals, /--text-13:\s*13px/, 'globals.css 缺 --text-13: 13px');
+
+const card = {
+  gapPx: leaf(4, SRC.draft, 'className gap-1 → 4px(Tailwind spacing 1 = 0.25rem)'),
+  radiusPx: leaf(12, SRC.draft, 'className rounded-xl → 12px(与输入框统一,见代码注释)'),
+  borderPx: leaf(1, SRC.draft, 'className border → 1px'),
+  iconCirclePx: leaf(32, SRC.draft, 'className h-8 w-8 → 32px icon 圆圈'),
+  iconGlyphPx: leaf(16, SRC.draft, 'Icon size={16} → 16px glyph'),
+  labelFontPx: leaf(13, SRC.globals, 'text-13 = var(--text-13) = 13px(globals.css)'),
+  labelLinePx: leaf(16, SRC.draft, 'className leading-[16px] → 16px'),
+  padNarrowPx: leaf(12, SRC.draft, 'narrow 档 p-3 → 12px'),
+  padNormalPx: leaf(16, SRC.draft, '常态 p-4 → 16px'),
+  minHNarrowPx: leaf(84, SRC.draft, 'narrow 档 min-h-[84px]'),
+  minHNormalPx: leaf(112, SRC.draft, '常态 min-h-[112px]'),
+  gridGapPx: leaf(12, SRC.draft, 'grid gap-3 → 12px'),
+};
+
+const section = {
+  titleFontPx: leaf(14, SRC.draft, 'section 标题 text-[14px]'),
+  titleLinePx: leaf(18, SRC.draft, 'section 标题 leading-[18px]'),
+  titles: sectionTitles,
+};
+
+// ========== 4. 主题 token(colors.ts registerColor 的 light/dark hex) ==========
+function color(tokenName) {
+  const re = new RegExp(
+    `registerColor\\('${tokenName.replace(/[-]/g, '\\-')}',\\s*\\{\\s*light:\\s*'([^']+)',\\s*dark:\\s*'([^']+)'`,
+  );
+  const m = grab(SRC.colors, re, `colors.ts 缺 token ${tokenName}`);
+  return { light: m[1], dark: m[2] };
+}
+const T = {
+  cardBg: color('create-agent-quick-card-bg'),
+  cardBorder: color('create-agent-quick-card-border'),
+  cardText: color('create-agent-quick-card-text'),
+  iconBg: color('create-agent-quick-card-icon-bg'),
+  icon: color('create-agent-quick-card-icon'),
+  cardBgHover: color('create-agent-quick-card-bg-hover'),
+  textSecondary: color('text-secondary'),
+};
+const colorLeaf = (name, mode) => leaf(T[name][mode], SRC.colors, `registerColor('${name === 'textSecondary' ? 'text-secondary' : 'create-agent-quick-card-' + kebab(name)}').${mode}`);
+function kebab(n) {
+  return ({ cardBg: 'bg', cardBorder: 'border', cardText: 'text', iconBg: 'icon-bg', icon: 'icon', cardBgHover: 'bg-hover' })[n];
+}
+const colors = {
+  light: {
+    cardBg: colorLeaf('cardBg', 'light'),
+    cardBorder: colorLeaf('cardBorder', 'light'),
+    cardText: colorLeaf('cardText', 'light'),
+    iconBg: colorLeaf('iconBg', 'light'),
+    icon: colorLeaf('icon', 'light'),
+    cardBgHover: colorLeaf('cardBgHover', 'light'),
+    textSecondary: colorLeaf('textSecondary', 'light'),
+  },
+  dark: {
+    cardBg: colorLeaf('cardBg', 'dark'),
+    cardBorder: colorLeaf('cardBorder', 'dark'),
+    cardText: colorLeaf('cardText', 'dark'),
+    iconBg: colorLeaf('iconBg', 'dark'),
+    icon: colorLeaf('icon', 'dark'),
+    cardBgHover: colorLeaf('cardBgHover', 'dark'),
+    textSecondary: colorLeaf('textSecondary', 'dark'),
+  },
+};
+
+// ========== 5. 布局公式常量(useProportionalWidth.ts + 调用点 minWidth) ==========
+const numFrom = (relPath, re, name) => {
+  const m = grab(relPath, re, `${name} 常量缺失`);
+  return Number(m[1]);
+};
+const MAX_MESSAGE_WIDTH = numFrom(SRC.hook, /MAX_MESSAGE_WIDTH\s*=\s*(\d+)/, 'MAX_MESSAGE_WIDTH');
+const INPUT_OUTSET = numFrom(SRC.hook, /INPUT_OUTSET\s*=\s*(\d+)/, 'INPUT_OUTSET');
+const DEFAULT_MESSAGE_PAD = numFrom(SRC.hook, /DEFAULT_MESSAGE_PAD\s*=\s*(\d+)/, 'DEFAULT_MESSAGE_PAD');
+const COMPACT_MESSAGE_PAD = numFrom(SRC.hook, /COMPACT_MESSAGE_PAD\s*=\s*(\d+)/, 'COMPACT_MESSAGE_PAD');
+const AUTO_COMPACT_THRESHOLD = numFrom(SRC.hook, /AUTO_COMPACT_THRESHOLD\s*=\s*(\d+)/, 'AUTO_COMPACT_THRESHOLD');
+const MIN_WIDTH = numFrom(SRC.draft, /useProportionalWidth\(914,\s*\{\s*minWidth:\s*(\d+)\s*\}\)/, 'minWidth 地板');
+
+const layout = {
+  maxMessageWidthPx: leaf(MAX_MESSAGE_WIDTH, SRC.hook, 'MAX_MESSAGE_WIDTH'),
+  inputOutsetPx: leaf(INPUT_OUTSET, SRC.hook, 'INPUT_OUTSET'),
+  defaultMessagePadPx: leaf(DEFAULT_MESSAGE_PAD, SRC.hook, 'DEFAULT_MESSAGE_PAD'),
+  compactMessagePadPx: leaf(COMPACT_MESSAGE_PAD, SRC.hook, 'COMPACT_MESSAGE_PAD'),
+  autoCompactThresholdPx: leaf(AUTO_COMPACT_THRESHOLD, SRC.hook, 'AUTO_COMPACT_THRESHOLD'),
+  minWidthFloorPx: leaf(MIN_WIDTH, SRC.draft, 'useProportionalWidth(914,{minWidth:640})'),
+  colBreak1Px: leaf(560, SRC.draft, 'isDraftNarrow = draftContentWidth < 560(1↔2 列 + narrow 档)'),
+  colBreak2Px: leaf(700, SRC.draft, 'isDraftMedium = draftContentWidth < 700(2↔4 列)'),
+  mainPadNarrowPx: leaf(16, SRC.draft, 'main narrow px-4 → 16px/侧'),
+  mainPadNormalPx: leaf(32, SRC.draft, 'main 常态 px-8 → 32px/侧'),
+};
+
+// —— 产品布局公式(复刻 useProportionalWidth.compute + 草稿页 grid/main padding) ——
+// oracle:验收侧不重写,只 resize→量 DOM 比对本表。
+function inputWidthFor(C) {
+  const useCompact = C < AUTO_COMPACT_THRESHOLD;
+  const pad = useCompact ? COMPACT_MESSAGE_PAD : DEFAULT_MESSAGE_PAD;
+  const msgAvail = Math.max(0, C - 2 * pad);
+  const msg = Math.min(MAX_MESSAGE_WIDTH, msgAvail);
+  let input = msg + INPUT_OUTSET;
+  if (MIN_WIDTH > input) input = Math.min(MIN_WIDTH, C);
+  return input;
+}
+function layoutFor(C) {
+  const input = inputWidthFor(C);
+  const narrow = input < 560;
+  const mainPx = narrow ? 16 : 32;
+  const avail = Math.max(0, C - 2 * mainPx);
+  const columnW = Math.min(input, avail); // 列 maxWidth=input,但受 main 可用宽钳制
+  const cols = input < 560 ? 1 : input < 700 ? 2 : 4;
+  const gap = 12;
+  const cardW = (columnW - (cols - 1) * gap) / cols;
+  const cardH = narrow ? 84 : 112;
+  return { columnW, cardW, cardH };
+}
+
+// ========== 6. adaptive.samples(免 provenance:门 A extractor-drift 覆盖) ==========
+// sampleSizes 必须与 spec.json 的 adaptive.sampleSizes 完全一致(手动保持同步)。
+const SAMPLE_SIZES = [
+  [480, 700], [540, 700], [559, 700], [560, 700], [561, 700],
+  [640, 700], [680, 700], [699, 700], [700, 700], [720, 700],
+  [779, 700], [780, 700], [781, 700], [1000, 700], [1299, 700],
+  [1300, 700], [1440, 900],
+];
+const round1 = (n) => Math.round(n * 100) / 100;
+const samples = SAMPLE_SIZES.map(([w, h]) => {
+  const L = layoutFor(w);
+  return {
+    w,
+    h,
+    probes: {
+      quickstarts: { w: round1(L.columnW) },
+      input: { w: round1(L.columnW) },
+      card0: { w: round1(L.cardW), h: L.cardH },
+    },
+  };
+});
+
+// ========== 输出 ==========
+const truth = {
+  cards,
+  section,
+  card,
+  colors,
+  layout,
+  adaptive: { samples },
+};
+
+process.stdout.write(JSON.stringify(truth));

--- a/docs/design-previews/newmaker-quickstart-cards/index.html
+++ b/docs/design-previews/newmaker-quickstart-cards/index.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>New Maker 快捷入口卡片 · 可交互 Demo</title>
+<!-- 内嵌真值:由 `node scripts/truth.mjs --demo <dir> --embed` 写入,禁止手改。 -->
+<script id="qa-truth" type="application/json">{"adaptive":{"samples":[{"h":700,"probes":{"card0":{"h":84,"w":448},"input":{"w":448},"quickstarts":{"w":448}},"w":480},{"h":700,"probes":{"card0":{"h":84,"w":508},"input":{"w":508},"quickstarts":{"w":508}},"w":540},{"h":700,"probes":{"card0":{"h":84,"w":527},"input":{"w":527},"quickstarts":{"w":527}},"w":559},{"h":700,"probes":{"card0":{"h":112,"w":242},"input":{"w":496},"quickstarts":{"w":496}},"w":560},{"h":700,"probes":{"card0":{"h":112,"w":242.5},"input":{"w":497},"quickstarts":{"w":497}},"w":561},{"h":700,"probes":{"card0":{"h":112,"w":282},"input":{"w":576},"quickstarts":{"w":576}},"w":640},{"h":700,"probes":{"card0":{"h":112,"w":302},"input":{"w":616},"quickstarts":{"w":616}},"w":680},{"h":700,"probes":{"card0":{"h":112,"w":311.5},"input":{"w":635},"quickstarts":{"w":635}},"w":699},{"h":700,"probes":{"card0":{"h":112,"w":312},"input":{"w":636},"quickstarts":{"w":636}},"w":700},{"h":700,"probes":{"card0":{"h":112,"w":314},"input":{"w":640},"quickstarts":{"w":640}},"w":720},{"h":700,"probes":{"card0":{"h":112,"w":343.5},"input":{"w":699},"quickstarts":{"w":699}},"w":779},{"h":700,"probes":{"card0":{"h":112,"w":166},"input":{"w":700},"quickstarts":{"w":700}},"w":780},{"h":700,"probes":{"card0":{"h":112,"w":166.25},"input":{"w":701},"quickstarts":{"w":701}},"w":781},{"h":700,"probes":{"card0":{"h":112,"w":221},"input":{"w":920},"quickstarts":{"w":920}},"w":1000},{"h":700,"probes":{"card0":{"h":112,"w":295.75},"input":{"w":1219},"quickstarts":{"w":1219}},"w":1299},{"h":700,"probes":{"card0":{"h":112,"w":296},"input":{"w":1220},"quickstarts":{"w":1220}},"w":1300},{"h":900,"probes":{"card0":{"h":112,"w":296},"input":{"w":1220},"quickstarts":{"w":1220}},"w":1440}]},"card":{"borderPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"className border → 1px","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":1},"gapPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"className gap-1 → 4px(Tailwind spacing 1 = 0.25rem)","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":4},"gridGapPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"grid gap-3 → 12px","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":12},"iconCirclePx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"className h-8 w-8 → 32px icon 圆圈","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":32},"iconGlyphPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"Icon size={16} → 16px glyph","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":16},"labelFontPx":{"provenance":{"hash":"fe6f62619ba903fc76270b68979232bda870f575bdd0ca97bda2087a29e6f4e7","locator":"text-13 = var(--text-13) = 13px(globals.css)","source":"../../../apps/desktop/src/renderer/styles/globals.css"},"value":13},"labelLinePx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"className leading-[16px] → 16px","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":16},"minHNarrowPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"narrow 档 min-h-[84px]","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":84},"minHNormalPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"常态 min-h-[112px]","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":112},"padNarrowPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"narrow 档 p-3 → 12px","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":12},"padNormalPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"常态 p-4 → 16px","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":16},"radiusPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"className rounded-xl → 12px(与输入框统一,见代码注释)","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":12}},"cards":[{"icon":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].icon=SearchCode","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"SearchCode"},"key":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].key='explore'","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"explore"},"labels":{"en":{"provenance":{"hash":"2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd","locator":"newChat.createAgent.quickStarts.explore","source":"../../../apps/desktop/src/renderer/i18n/locales/en/common.json"},"value":"Explore and understand code"},"ja":{"provenance":{"hash":"5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192","locator":"newChat.createAgent.quickStarts.explore","source":"../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"},"value":"コードを探索して理解"},"ko":{"provenance":{"hash":"b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0","locator":"newChat.createAgent.quickStarts.explore","source":"../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"},"value":"코드 탐색 및 이해"},"zh-CN":{"provenance":{"hash":"56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48","locator":"newChat.createAgent.quickStarts.explore","source":"../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"},"value":"探索并理解代码"}}},{"icon":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].icon=Code2","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"Code2"},"key":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].key='build'","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"build"},"labels":{"en":{"provenance":{"hash":"2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd","locator":"newChat.createAgent.quickStarts.build","source":"../../../apps/desktop/src/renderer/i18n/locales/en/common.json"},"value":"Build a feature, app, or tool"},"ja":{"provenance":{"hash":"5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192","locator":"newChat.createAgent.quickStarts.build","source":"../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"},"value":"新機能、アプリ、ツールを構築"},"ko":{"provenance":{"hash":"b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0","locator":"newChat.createAgent.quickStarts.build","source":"../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"},"value":"새 기능, 앱 또는 도구 만들기"},"zh-CN":{"provenance":{"hash":"56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48","locator":"newChat.createAgent.quickStarts.build","source":"../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"},"value":"构建新功能、应用或工具"}}},{"icon":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].icon=MessageSquareCode","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"MessageSquareCode"},"key":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].key='review'","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"review"},"labels":{"en":{"provenance":{"hash":"2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd","locator":"newChat.createAgent.quickStarts.review","source":"../../../apps/desktop/src/renderer/i18n/locales/en/common.json"},"value":"Review code and suggest changes"},"ja":{"provenance":{"hash":"5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192","locator":"newChat.createAgent.quickStarts.review","source":"../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"},"value":"コードをレビューして修正を提案"},"ko":{"provenance":{"hash":"b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0","locator":"newChat.createAgent.quickStarts.review","source":"../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"},"value":"코드 검토 및 수정 제안"},"zh-CN":{"provenance":{"hash":"56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48","locator":"newChat.createAgent.quickStarts.review","source":"../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"},"value":"审查代码并提出修改建议"}}},{"icon":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].icon=Hammer","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"Hammer"},"key":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"createAgentQuickStarts[].key='fix'","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":"fix"},"labels":{"en":{"provenance":{"hash":"2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd","locator":"newChat.createAgent.quickStarts.fix","source":"../../../apps/desktop/src/renderer/i18n/locales/en/common.json"},"value":"Fix issues and failures"},"ja":{"provenance":{"hash":"5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192","locator":"newChat.createAgent.quickStarts.fix","source":"../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"},"value":"問題や失敗を修正"},"ko":{"provenance":{"hash":"b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0","locator":"newChat.createAgent.quickStarts.fix","source":"../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"},"value":"문제와 실패 수정"},"zh-CN":{"provenance":{"hash":"56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48","locator":"newChat.createAgent.quickStarts.fix","source":"../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"},"value":"修复问题和失败"}}}],"colors":{"dark":{"cardBg":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-bg').dark","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#312F2F"},"cardBgHover":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-bg-hover').dark","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#3B3A3A"},"cardBorder":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-border').dark","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#434343"},"cardText":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-text').dark","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#D4D4D4"},"icon":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-icon').dark","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#D4D4D4"},"iconBg":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-icon-bg').dark","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#2A2828"},"textSecondary":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('text-secondary').dark","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#a3a3a3"}},"light":{"cardBg":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-bg').light","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#F8F8F8"},"cardBgHover":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-bg-hover').light","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#FCFCFC"},"cardBorder":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-border').light","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#DCDFE3"},"cardText":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-text').light","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#3C3F43"},"icon":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-icon').light","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#3C3F43"},"iconBg":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('create-agent-quick-card-icon-bg').light","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#EDEDED"},"textSecondary":{"provenance":{"hash":"2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f","locator":"registerColor('text-secondary').light","source":"../../../apps/desktop/src/renderer/themes/colors.ts"},"value":"#737373"}}},"layout":{"autoCompactThresholdPx":{"provenance":{"hash":"a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e","locator":"AUTO_COMPACT_THRESHOLD","source":"../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"},"value":700},"colBreak1Px":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"isDraftNarrow = draftContentWidth \u003c 560(1↔2 列 + narrow 档)","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":560},"colBreak2Px":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"isDraftMedium = draftContentWidth \u003c 700(2↔4 列)","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":700},"compactMessagePadPx":{"provenance":{"hash":"a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e","locator":"COMPACT_MESSAGE_PAD","source":"../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"},"value":20},"defaultMessagePadPx":{"provenance":{"hash":"a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e","locator":"DEFAULT_MESSAGE_PAD","source":"../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"},"value":50},"inputOutsetPx":{"provenance":{"hash":"a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e","locator":"INPUT_OUTSET","source":"../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"},"value":20},"mainPadNarrowPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"main narrow px-4 → 16px/侧","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":16},"mainPadNormalPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"main 常态 px-8 → 32px/侧","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":32},"maxMessageWidthPx":{"provenance":{"hash":"a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e","locator":"MAX_MESSAGE_WIDTH","source":"../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"},"value":1200},"minWidthFloorPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"useProportionalWidth(914,{minWidth:640})","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":640}},"section":{"titleFontPx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"section 标题 text-[14px]","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":14},"titleLinePx":{"provenance":{"hash":"647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb","locator":"section 标题 leading-[18px]","source":"../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"},"value":18},"titles":{"en":{"provenance":{"hash":"2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd","locator":"newChat.createAgent.quickStart","source":"../../../apps/desktop/src/renderer/i18n/locales/en/common.json"},"value":"Quick start"},"ja":{"provenance":{"hash":"5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192","locator":"newChat.createAgent.quickStart","source":"../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"},"value":"クイックスタート"},"ko":{"provenance":{"hash":"b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0","locator":"newChat.createAgent.quickStart","source":"../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"},"value":"빠른 시작"},"zh-CN":{"provenance":{"hash":"56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48","locator":"newChat.createAgent.quickStart","source":"../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"},"value":"快速开始"}}}}</script>
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, "PingFang SC", "Hiragino Sans", "Noto Sans CJK", "Malgun Gothic", Segoe UI, Roboto, sans-serif;
+    background: #ececec; color: #1e1e1e; -webkit-font-smoothing: antialiased;
+  }
+  /* ---------- chrome ---------- */
+  .chrome { padding: 14px 20px 10px; border-bottom: 1px solid #d8d8d8; background: #f6f6f6; }
+  .chrome h1 { font-size: 15px; margin: 0 0 6px; display: flex; align-items: center; gap: 10px; }
+  .badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; background: #e2e8f0; color: #334155; }
+  .summary { font-size: 12px; color: #555; line-height: 1.5; }
+  .summary b { color: #333; }
+  .switchers { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 10px; }
+  .seg { display: flex; align-items: center; gap: 4px; }
+  .seg .lbl { font-size: 11px; color: #888; margin-right: 2px; }
+  .seg button {
+    font: inherit; font-size: 12px; padding: 3px 10px; border: 1px solid #cfcfcf; background: #fff;
+    color: #333; border-radius: 7px; cursor: pointer;
+  }
+  .seg button[aria-pressed="true"] { background: #1e1e1e; color: #fff; border-color: #1e1e1e; }
+  /* ---------- stage / frame ---------- */
+  .stage { padding: 24px; overflow: auto; }
+  .frame {
+    position: relative; margin: 0; border-radius: 12px; overflow: hidden;
+    background: var(--frame-bg); color: var(--frame-fg);
+    box-shadow: 0 10px 40px rgba(0,0,0,.18);
+    transition: none;
+  }
+  .frame[data-mode="light"] { --frame-bg: #ffffff; --frame-fg: #1e1e1e; }
+  .frame[data-mode="dark"]  { --frame-bg: #1e1e1e; --frame-fg: #e6e6e6; }
+  .frame-badge {
+    position: absolute; right: 8px; bottom: 8px; z-index: 5; pointer-events: none;
+    font-size: 11px; padding: 2px 8px; border-radius: 6px;
+    background: rgba(0,0,0,.55); color: #fff; font-variant-numeric: tabular-nums;
+  }
+  .handle-r, .handle-b, .handle-br { position: absolute; z-index: 6; background: transparent; }
+  .handle-r  { top: 0; right: 0; width: 10px; height: 100%; cursor: ew-resize; }
+  .handle-b  { left: 0; bottom: 0; width: 100%; height: 10px; cursor: ns-resize; }
+  .handle-br { right: 0; bottom: 0; width: 16px; height: 16px; cursor: nwse-resize; }
+  .handle-br::after { content: ""; position: absolute; right: 3px; bottom: 3px; width: 7px; height: 7px; border-right: 2px solid rgba(128,128,128,.7); border-bottom: 2px solid rgba(128,128,128,.7); }
+
+  /* ---------- New Maker 帧内(高保真) ---------- */
+  .qa-main { width: 100%; padding: var(--main-pt) var(--main-px) 40px; }
+  .qa-brand { text-align: center; font-weight: 700; letter-spacing: 2px; font-size: 26px; color: var(--frame-fg); margin-bottom: 22px; opacity: .9; }
+  .qa-column { width: 100%; max-width: var(--column-max); margin: 0 auto; }
+  .qa-input {
+    width: 100%; min-height: 92px; border-radius: 12px; border: 1px solid var(--card-border);
+    background: var(--card-bg); padding: 12px 14px; display: flex; align-items: flex-start;
+    color: var(--frame-fg);
+  }
+  .qa-input .ph { color: var(--text-secondary); font-size: 14px; }
+  .qa-input .txt { font-size: 14px; white-space: pre-wrap; }
+  .qa-quickstarts { width: 100%; margin-top: 42px; }
+  .qa-section-title { font-size: var(--title-font); line-height: 18px; font-weight: 500; color: var(--text-secondary); margin: 0 2px 10px; }
+  .qa-grid { display: grid; width: 100%; gap: var(--grid-gap); grid-template-columns: var(--grid-cols); }
+  .qa-card {
+    display: flex; flex-direction: column; align-items: flex-start; justify-content: space-between;
+    gap: var(--card-gap);
+    border-radius: var(--card-radius); border: var(--card-border-w) solid var(--card-border);
+    background: var(--card-bg); color: var(--card-text);
+    min-height: var(--card-minh); padding: var(--card-pad);
+    text-align: left; cursor: pointer; font: inherit; transition: background-color .12s;
+  }
+  .qa-card:hover { background: var(--card-bg-hover); }
+  .qa-card-icon {
+    display: grid; place-items: center; flex: 0 0 auto;
+    width: var(--icon-size); height: var(--icon-size); border-radius: 999px;
+    background: var(--icon-bg); color: var(--icon);
+  }
+  .qa-card-icon svg { width: var(--icon-glyph); height: var(--icon-glyph); }
+  .qa-card-label { width: 100%; min-width: 0; font-size: var(--label-font); line-height: 16px; font-weight: 600; }
+</style>
+</head>
+<body>
+  <div class="chrome">
+    <h1>New Maker 快捷入口卡片 · 可交互 Demo <span class="badge" id="prBadge">PR</span></h1>
+    <div class="summary" id="summary"></div>
+    <div class="switchers" id="switchers"></div>
+  </div>
+  <div class="stage">
+    <div class="frame" data-mode="light" id="frame">
+      <div class="qa-main" id="main">
+        <div class="qa-brand">CINDY</div>
+        <div class="qa-column" id="column">
+          <div class="qa-input" id="qaInput"><span class="ph" id="inputPh"></span><span class="txt" id="inputTxt"></span></div>
+          <div class="qa-quickstarts" id="quickstarts">
+            <div class="qa-section-title" id="sectionTitle"></div>
+            <div class="qa-grid" id="grid"></div>
+          </div>
+        </div>
+      </div>
+      <div class="handle-r" data-h="r"></div>
+      <div class="handle-b" data-h="b"></div>
+      <div class="handle-br" data-h="br"></div>
+      <div class="frame-badge" id="frameBadge"></div>
+    </div>
+  </div>
+
+<script>
+(function () {
+  // ---------- 读内嵌真值并解包 ----------
+  const RAW = JSON.parse(document.getElementById('qa-truth').textContent || '{}');
+  function unwrap(x) {
+    if (x && typeof x === 'object' && !Array.isArray(x) && Object.prototype.hasOwnProperty.call(x, 'value')) return x.value;
+    if (Array.isArray(x)) return x.map(unwrap);
+    if (x && typeof x === 'object') { const o = {}; for (const k in x) o[k] = unwrap(x[k]); return o; }
+    return x;
+  }
+  const T = unwrap(RAW);
+  const L = T.layout || {};
+  const cards = T.cards || [];
+  const C = T.card || {};
+
+  // ---------- lucide 简化图标(stroke=currentColor,color=var(--icon)) ----------
+  const ICONS = {
+    SearchCode: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 9-2 2 2 2"/><path d="m13 13 2-2-2-2"/><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>',
+    Code2: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/></svg>',
+    MessageSquareCode: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 7.5 8 10l2 2.5"/><path d="m14 7.5 2 2.5-2 2.5"/><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+    Hammer: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.4 8.4a2.1 2.1 0 0 1-3-3L12 9"/><path d="M17.6 6.8 22 2.4"/><path d="m21.6 10.4-4-4"/><path d="M13 3 8 8l3 3 5-5z"/></svg>',
+  };
+  const PLACEHOLDER = { 'zh-CN': '给 Cindy 一个任务…', en: 'Give Cindy a task…', ja: 'Cindy にタスクを…', ko: 'Cindy에게 작업을…' };
+
+  // ---------- 偏好 / 状态 ----------
+  const NAME = 'cindy-newmaker-cards-hifi';
+  const STORAGE_KEY = 'qa-hifi:' + NAME + ':prefs';
+  const DEFAULT_PREFS = { plat: 'desk', region: 'na', os: 'desktop', mode: 'light', lang: 'zh-CN' };
+  const PREF_KEYS = ['plat', 'region', 'os', 'mode', 'lang'];
+  let prefs = { ...DEFAULT_PREFS };
+  let step = 'id';       // 'id' | 'filled'
+  let draftText = '';    // 输入框内容(点卡片后 = 该卡文案)
+  let frameW = 1000, frameH = 700;
+
+  function loadPrefs() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) { const p = JSON.parse(raw); for (const k of PREF_KEYS) if (typeof p[k] === 'string') prefs[k] = p[k]; }
+    } catch (e) {}
+  }
+  function savePrefs() { try { localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs)); } catch (e) {} }
+
+  // ---------- 产品布局公式(复刻 useProportionalWidth.compute + 草稿页断点) ----------
+  function inputWidthFor(cw) {
+    const useCompact = cw < L.autoCompactThresholdPx;
+    const pad = useCompact ? L.compactMessagePadPx : L.defaultMessagePadPx;
+    const msgAvail = Math.max(0, cw - 2 * pad);
+    const msg = Math.min(L.maxMessageWidthPx, msgAvail);
+    let input = msg + L.inputOutsetPx;
+    if (L.minWidthFloorPx > input) input = Math.min(L.minWidthFloorPx, cw);
+    return input;
+  }
+  function computeLayout(cw) {
+    const input = inputWidthFor(cw);
+    const narrow = input < L.colBreak1Px;               // <560 → 1 列 + narrow 档
+    const cols = input < L.colBreak1Px ? 1 : input < L.colBreak2Px ? 2 : 4;
+    return { input, narrow, cols };
+  }
+
+  // ---------- 主题 token(从 truth 注入 CSS 变量,杜绝手抄漂移) ----------
+  function applyThemeVars() {
+    const frame = document.getElementById('frame');
+    const c = (T.colors && T.colors[prefs.mode]) || {};
+    frame.setAttribute('data-mode', prefs.mode);
+    frame.style.setProperty('--card-bg', c.cardBg);
+    frame.style.setProperty('--card-border', c.cardBorder);
+    frame.style.setProperty('--card-text', c.cardText);
+    frame.style.setProperty('--icon-bg', c.iconBg);
+    frame.style.setProperty('--icon', c.icon);
+    frame.style.setProperty('--card-bg-hover', c.cardBgHover);
+    frame.style.setProperty('--text-secondary', c.textSecondary);
+  }
+  function applyGeometryVars() {
+    const frame = document.getElementById('frame');
+    frame.style.setProperty('--card-gap', C.gapPx + 'px');
+    frame.style.setProperty('--card-radius', C.radiusPx + 'px');
+    frame.style.setProperty('--card-border-w', C.borderPx + 'px');
+    frame.style.setProperty('--icon-size', C.iconCirclePx + 'px');
+    frame.style.setProperty('--icon-glyph', C.iconGlyphPx + 'px');
+    frame.style.setProperty('--label-font', C.labelFontPx + 'px');
+    frame.style.setProperty('--title-font', (T.section && T.section.titleFontPx) + 'px');
+    frame.style.setProperty('--grid-gap', C.gridGapPx + 'px');
+  }
+
+  // ---------- 渲染 ----------
+  function renderCards() {
+    const grid = document.getElementById('grid');
+    grid.innerHTML = '';
+    for (const card of cards) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'qa-card';
+      btn.setAttribute('data-qa-card', card.key);
+      const icon = document.createElement('span');
+      icon.className = 'qa-card-icon';
+      icon.innerHTML = ICONS[card.icon] || '';
+      const label = document.createElement('span');
+      label.className = 'qa-card-label';
+      label.textContent = (card.labels && card.labels[prefs.lang]) || '';
+      btn.appendChild(icon); btn.appendChild(label);
+      btn.addEventListener('click', () => { fillFromCard(card); });
+      grid.appendChild(btn);
+    }
+  }
+  function renderTexts() {
+    document.getElementById('sectionTitle').textContent = (T.section && T.section.titles && T.section.titles[prefs.lang]) || '';
+    document.getElementById('inputPh').textContent = draftText ? '' : (PLACEHOLDER[prefs.lang] || '');
+    document.getElementById('inputTxt').textContent = draftText || '';
+  }
+  function applyLayout() {
+    const frame = document.getElementById('frame');
+    const main = document.getElementById('main');
+    const column = document.getElementById('column');
+    const { input, narrow, cols } = computeLayout(frameW);
+    frame.style.width = frameW + 'px';
+    frame.style.height = frameH + 'px';
+    main.style.setProperty('--main-px', (narrow ? L.mainPadNarrowPx : L.mainPadNormalPx) + 'px');
+    main.style.setProperty('--main-pt', (narrow ? 40 : 64) + 'px');
+    column.style.setProperty('--column-max', input + 'px');
+    frame.style.setProperty('--card-pad', (narrow ? C.padNarrowPx : C.padNormalPx) + 'px');
+    frame.style.setProperty('--card-minh', (narrow ? C.minHNarrowPx : C.minHNormalPx) + 'px');
+    document.getElementById('grid').style.setProperty('--grid-cols', 'repeat(' + cols + ', minmax(0, 1fr))');
+    const tier = cols === 1 ? '压缩档·1列' : cols === 2 ? '中档·2列' : '宽档·4列';
+    document.getElementById('frameBadge').textContent = frameW + '×' + frameH + ' · ' + tier + ' · input ' + Math.round(input);
+  }
+  function renderSwitchers() {
+    const groups = [
+      ['plat', '端', [['desk', 'Desktop']]],
+      ['region', '区域', [['na', '不区分']]],
+      ['os', '系统', [['desktop', 'Desktop']]],
+      ['mode', '主题', [['light', '亮'], ['dark', '暗']]],
+      ['lang', '语言', [['zh-CN', '中'], ['en', 'EN'], ['ja', '日'], ['ko', '한']]],
+    ];
+    const host = document.getElementById('switchers');
+    host.innerHTML = '';
+    for (const [key, lbl, opts] of groups) {
+      const seg = document.createElement('div'); seg.className = 'seg';
+      const l = document.createElement('span'); l.className = 'lbl'; l.textContent = lbl; seg.appendChild(l);
+      for (const [val, text] of opts) {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.textContent = text;
+        b.setAttribute('data-qa-pref', key + ':' + val);
+        b.setAttribute('aria-pressed', String(prefs[key] === val));
+        b.addEventListener('click', () => setPref(key, val));
+        seg.appendChild(b);
+      }
+      host.appendChild(seg);
+    }
+  }
+  function render() {
+    applyThemeVars();
+    applyGeometryVars();
+    renderTexts();
+    renderCards();
+    applyLayout();
+    // 刷新 seg 高亮
+    for (const b of document.querySelectorAll('[data-qa-pref]')) {
+      const [k, v] = b.getAttribute('data-qa-pref').split(':');
+      b.setAttribute('aria-pressed', String(prefs[k] === v));
+    }
+  }
+
+  function setPref(key, val) {
+    if (!PREF_KEYS.includes(key)) return;
+    prefs[key] = val;
+    savePrefs();
+    render();
+  }
+  function fillFromCard(card) {
+    draftText = (card.labels && card.labels[prefs.lang]) || '';
+    step = 'filled';
+    render();
+  }
+
+  // ---------- resize(拖拽手柄 + __qa.resize 同一路径) ----------
+  const MIN_W = 480, MIN_H = 560;
+  function resize(w, h) {
+    frameW = Math.max(MIN_W, Math.round(Number(w) || 0));
+    frameH = Math.max(MIN_H, Math.round(Number(h) || 0));
+    applyLayout();
+  }
+  function initDrag() {
+    let active = null, sx = 0, sy = 0, sw = 0, sh = 0;
+    for (const h of document.querySelectorAll('[data-h]')) {
+      h.addEventListener('mousedown', (e) => {
+        active = h.getAttribute('data-h'); sx = e.clientX; sy = e.clientY; sw = frameW; sh = frameH;
+        e.preventDefault();
+      });
+    }
+    window.addEventListener('mousemove', (e) => {
+      if (!active) return;
+      let w = frameW, hh = frameH;
+      if (active === 'r' || active === 'br') w = sw + (e.clientX - sx);
+      if (active === 'b' || active === 'br') hh = sh + (e.clientY - sy);
+      resize(w, hh);
+    });
+    window.addEventListener('mouseup', () => { active = null; });
+  }
+
+  // ---------- 头部 meta ----------
+  function renderMeta() {
+    const meta = (RAW.meta) || {};
+    // meta 不带 provenance(它是 demo 元信息不是产品真值),这里直接从 spec 复述
+  }
+
+  // ---------- __qa 契约 ----------
+  window.__qa = {
+    current: () => step,
+    goto: (id) => {
+      if (id === 'id') { draftText = ''; step = 'id'; render(); return; }
+      if (id === 'filled') { draftText = (cards[0] && cards[0].labels[prefs.lang]) || ''; step = 'filled'; render(); return; }
+      throw new Error('unknown state: ' + id);
+    },
+    prefs: () => ({ ...prefs }),
+    scale: () => 1,
+    resize: (w, h) => resize(w, h),
+  };
+
+  // ---------- 启动 ----------
+  loadPrefs();
+  step = 'id';
+  draftText = '';
+  document.documentElement.lang = prefs.lang;
+  renderSwitchers();
+  render();
+  initDrag();
+  // 头部徽标 + 摘要(从 body 里静态填,或留给部署时可读)——摘要走 DOM 注入避免与 truth 混淆
+})();
+</script>
+<script>
+// 头部 PR 徽标 + 三段摘要:从静态常量填(demo 元信息,非产品真值,不进 truth/provenance)。
+(function () {
+  document.getElementById('prBadge').textContent = 'PR #369 · fix/newmaker-quickstart-card-layout';
+  document.getElementById('summary').innerHTML =
+    '<b>做了什么:</b> 快捷入口 4 卡改竖排(icon 固定左上、文字挪到卡片中下方与 icon 左对齐)+ 去 800px 封顶随输入框等比拉伸<br>' +
+    '<b>怎么做:</b> flex-col + justify-between(icon 顶、文字底,gap-1 兜底最小间距)/rounded-xl/min-h 不变;卡片区 w-full 填满内容列(= useProportionalWidth 的 inputWidth,与输入框同宽同缘);grid 按 inputWidth 断点 560/700 切 1/2/4 列<br>' +
+    '<b>怎么验收:</b> A/B/C/D/F 门 — truth 提取自源码 · 状态覆盖 · 4 语言无截断 · computed-style 绑定(4px·12px·13px·token)· 拉伸几何 oracle 比对';
+})();
+</script>
+</body>
+</html>

--- a/docs/design-previews/newmaker-quickstart-cards/report.json
+++ b/docs/design-previews/newmaker-quickstart-cards/report.json
@@ -1,0 +1,251 @@
+{
+  "ok": true,
+  "toolVersion": "qa-hifi-demo@2026-07-25-p0-hardening",
+  "demo": "cindy-newmaker-cards-hifi",
+  "inputHashes": {
+    "spec.json": "c123e8d31b9fe6e0e4ac530c6936be9250d550fb74ffbffae630e803b2d52fcc",
+    "truth.json": "57f870b8f33005b26c1ca0caae7b8c01c5401943eb929099d573590e2ef2616e",
+    "index.html": "bc3bb55d11dfe9e18c29bcaa80579e6d728082e32871aa590bbf296d5bb51a48",
+    "baselines": {
+      "declared": [],
+      "files": []
+    }
+  },
+  "statesResult": {
+    "total": 2,
+    "viaReachable": 2,
+    "tabOnly": 0
+  },
+  "coverage": {
+    "cases": [
+      {
+        "id": "zh-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "zh-CN"
+        },
+        "source": "verify.cases"
+      },
+      {
+        "id": "en-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "en"
+        },
+        "source": "verify.cases"
+      },
+      {
+        "id": "ja-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "ja"
+        },
+        "source": "verify.cases"
+      },
+      {
+        "id": "ko-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "ko"
+        },
+        "source": "verify.cases"
+      }
+    ]
+  },
+  "gateA": {
+    "name": "真值一致",
+    "pass": true,
+    "detail": "",
+    "provenance": "required",
+    "extractorDrift": "none"
+  },
+  "gateB": {
+    "name": "状态覆盖",
+    "pass": true,
+    "total": 8,
+    "passed": 8,
+    "failures": [],
+    "cases": [
+      {
+        "id": "zh-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "zh-CN"
+        },
+        "passed": 2,
+        "total": 2,
+        "failures": []
+      },
+      {
+        "id": "en-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "en"
+        },
+        "passed": 2,
+        "total": 2,
+        "failures": []
+      },
+      {
+        "id": "ja-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "ja"
+        },
+        "passed": 2,
+        "total": 2,
+        "failures": []
+      },
+      {
+        "id": "ko-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "ko"
+        },
+        "passed": 2,
+        "total": 2,
+        "failures": []
+      }
+    ]
+  },
+  "gateC": {
+    "name": "交互鲁棒",
+    "pass": true,
+    "checks": [
+      {
+        "id": "no-clip",
+        "pass": true,
+        "failures": []
+      },
+      {
+        "id": "persistence",
+        "pass": true,
+        "failures": []
+      }
+    ],
+    "cases": [
+      {
+        "id": "zh-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "zh-CN"
+        }
+      },
+      {
+        "id": "en-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "en"
+        }
+      },
+      {
+        "id": "ja-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "ja"
+        }
+      },
+      {
+        "id": "ko-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "ko"
+        }
+      }
+    ]
+  },
+  "gateD": {
+    "name": "渲染绑定",
+    "pass": true,
+    "total": 68,
+    "passed": 68,
+    "failures": [],
+    "cases": [
+      {
+        "id": "zh-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "zh-CN"
+        }
+      },
+      {
+        "id": "en-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "en"
+        }
+      },
+      {
+        "id": "ja-light",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "light",
+          "lang": "ja"
+        }
+      },
+      {
+        "id": "ko-dark",
+        "prefs": {
+          "plat": "desk",
+          "region": "na",
+          "os": "desktop",
+          "mode": "dark",
+          "lang": "ko"
+        }
+      }
+    ]
+  },
+  "gateF": {
+    "name": "适配还原",
+    "pass": true,
+    "total": 18,
+    "passed": 18,
+    "failures": [],
+    "cases": []
+  },
+  "generatedAt": "2026-07-24T21:00:41.416Z"
+}

--- a/docs/design-previews/newmaker-quickstart-cards/spec.json
+++ b/docs/design-previews/newmaker-quickstart-cards/spec.json
@@ -1,0 +1,85 @@
+{
+  "meta": {
+    "name": "cindy-newmaker-cards-hifi",
+    "pr": 369,
+    "summary": {
+      "what": "New Maker 主界面「快速开始」4 张快捷入口卡片的竖排(icon 左上/文字中下)+ 等比拉伸布局改稿",
+      "how": "卡片改为竖排:icon 固定卡片左上(位置不变,距顶=距左=内边距),文字挪到卡片中下方、与 icon 左对齐(flex-col + justify-between);卡片区去掉 800px 封顶,随 useProportionalWidth 的 inputWidth 等比拉伸、与输入框同宽同缘;grid 按 inputWidth 断点 560/700 切 1/2/4 列,高度不变(narrow 84 / 常态 112)",
+      "accept": "A/B/C/D/F 五门:truth 提取自源码带 provenance / 状态覆盖 / 4 语言无截断 / computed-style 绑定(4px·12px·13px·主题 token) / 拉伸几何 oracle 比对(卡片宽随 inputWidth、与输入框同宽、高度恒定)"
+    }
+  },
+
+  "matrix": {
+    "platforms": ["desk"],
+    "regions": ["na"],
+    "systems": ["desktop"],
+    "themes": ["light", "dark"],
+    "langs": ["zh-CN", "en", "ja", "ko"]
+  },
+
+  "states": [
+    { "id": "id", "via": [{ "expect": "id" }] },
+    { "id": "filled", "via": [
+      { "click": "[data-qa-card='explore']" },
+      { "expect": "filled" }
+    ] }
+  ],
+
+  "verify": {
+    "cases": [
+      { "id": "zh-light", "prefs": { "plat": "desk", "region": "na", "os": "desktop", "mode": "light", "lang": "zh-CN" } },
+      { "id": "en-dark",  "prefs": { "plat": "desk", "region": "na", "os": "desktop", "mode": "dark",  "lang": "en" } },
+      { "id": "ja-light", "prefs": { "plat": "desk", "region": "na", "os": "desktop", "mode": "light", "lang": "ja" } },
+      { "id": "ko-dark",  "prefs": { "plat": "desk", "region": "na", "os": "desktop", "mode": "dark",  "lang": "ko" } }
+    ],
+    "noClip": [".qa-card-label", ".qa-section-title"],
+    "persistence": {
+      "via": [
+        { "click": "[data-qa-pref='mode:dark']" },
+        { "click": "[data-qa-pref='lang:ja']" }
+      ],
+      "expected": { "plat": "desk", "region": "na", "os": "desktop", "mode": "dark", "lang": "ja" },
+      "storageKey": "qa-hifi:cindy-newmaker-cards-hifi:prefs",
+      "reloads": 2,
+      "initialState": "id"
+    }
+  },
+
+  "bindings": [
+    { "sel": ".qa-card", "prop": "column-gap", "truth": "card.gapPx", "kind": "length" },
+    { "sel": ".qa-card", "prop": "border-top-left-radius", "truth": "card.radiusPx", "kind": "length" },
+    { "sel": ".qa-card", "prop": "border-top-width", "truth": "card.borderPx", "kind": "length" },
+    { "sel": ".qa-card-icon", "prop": "width", "truth": "card.iconCirclePx", "kind": "length" },
+    { "sel": ".qa-card-icon", "prop": "height", "truth": "card.iconCirclePx", "kind": "length" },
+    { "sel": ".qa-card-label", "prop": "font-size", "truth": "card.labelFontPx", "kind": "length" },
+    { "sel": ".qa-section-title", "prop": "font-size", "truth": "section.titleFontPx", "kind": "length" },
+
+    { "sel": ".qa-card", "prop": "background-color", "truth": "colors.light.cardBg", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:light']" }] },
+    { "sel": ".qa-card", "prop": "border-top-color", "truth": "colors.light.cardBorder", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:light']" }] },
+    { "sel": ".qa-card-label", "prop": "color", "truth": "colors.light.cardText", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:light']" }] },
+    { "sel": ".qa-card-icon", "prop": "background-color", "truth": "colors.light.iconBg", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:light']" }] },
+    { "sel": ".qa-section-title", "prop": "color", "truth": "colors.light.textSecondary", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:light']" }] },
+
+    { "sel": ".qa-card", "prop": "background-color", "truth": "colors.dark.cardBg", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:dark']" }] },
+    { "sel": ".qa-card", "prop": "border-top-color", "truth": "colors.dark.cardBorder", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:dark']" }] },
+    { "sel": ".qa-card-label", "prop": "color", "truth": "colors.dark.cardText", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:dark']" }] },
+    { "sel": ".qa-card-icon", "prop": "background-color", "truth": "colors.dark.iconBg", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:dark']" }] },
+    { "sel": ".qa-section-title", "prop": "color", "truth": "colors.dark.textSecondary", "kind": "color", "via": [{ "click": "[data-qa-pref='mode:dark']" }] }
+  ],
+
+  "adaptive": {
+    "min": { "w": 480, "h": 560 },
+    "sampleSizes": [
+      [480, 700], [540, 700], [559, 700], [560, 700], [561, 700],
+      [640, 700], [680, 700], [699, 700], [700, 700], [720, 700],
+      [779, 700], [780, 700], [781, 700], [1000, 700], [1299, 700],
+      [1300, 700], [1440, 900]
+    ],
+    "probes": [
+      { "id": "quickstarts", "sel": ".qa-quickstarts" },
+      { "id": "input", "sel": ".qa-input" },
+      { "id": "card0", "sel": ".qa-card" }
+    ],
+    "tolerancePx": 1
+  }
+}

--- a/docs/design-previews/newmaker-quickstart-cards/truth.json
+++ b/docs/design-previews/newmaker-quickstart-cards/truth.json
@@ -1,0 +1,838 @@
+{
+  "adaptive": {
+    "samples": [
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 84,
+            "w": 448
+          },
+          "input": {
+            "w": 448
+          },
+          "quickstarts": {
+            "w": 448
+          }
+        },
+        "w": 480
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 84,
+            "w": 508
+          },
+          "input": {
+            "w": 508
+          },
+          "quickstarts": {
+            "w": 508
+          }
+        },
+        "w": 540
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 84,
+            "w": 527
+          },
+          "input": {
+            "w": 527
+          },
+          "quickstarts": {
+            "w": 527
+          }
+        },
+        "w": 559
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 242
+          },
+          "input": {
+            "w": 496
+          },
+          "quickstarts": {
+            "w": 496
+          }
+        },
+        "w": 560
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 242.5
+          },
+          "input": {
+            "w": 497
+          },
+          "quickstarts": {
+            "w": 497
+          }
+        },
+        "w": 561
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 282
+          },
+          "input": {
+            "w": 576
+          },
+          "quickstarts": {
+            "w": 576
+          }
+        },
+        "w": 640
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 302
+          },
+          "input": {
+            "w": 616
+          },
+          "quickstarts": {
+            "w": 616
+          }
+        },
+        "w": 680
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 311.5
+          },
+          "input": {
+            "w": 635
+          },
+          "quickstarts": {
+            "w": 635
+          }
+        },
+        "w": 699
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 312
+          },
+          "input": {
+            "w": 636
+          },
+          "quickstarts": {
+            "w": 636
+          }
+        },
+        "w": 700
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 314
+          },
+          "input": {
+            "w": 640
+          },
+          "quickstarts": {
+            "w": 640
+          }
+        },
+        "w": 720
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 343.5
+          },
+          "input": {
+            "w": 699
+          },
+          "quickstarts": {
+            "w": 699
+          }
+        },
+        "w": 779
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 166
+          },
+          "input": {
+            "w": 700
+          },
+          "quickstarts": {
+            "w": 700
+          }
+        },
+        "w": 780
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 166.25
+          },
+          "input": {
+            "w": 701
+          },
+          "quickstarts": {
+            "w": 701
+          }
+        },
+        "w": 781
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 221
+          },
+          "input": {
+            "w": 920
+          },
+          "quickstarts": {
+            "w": 920
+          }
+        },
+        "w": 1000
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 295.75
+          },
+          "input": {
+            "w": 1219
+          },
+          "quickstarts": {
+            "w": 1219
+          }
+        },
+        "w": 1299
+      },
+      {
+        "h": 700,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 296
+          },
+          "input": {
+            "w": 1220
+          },
+          "quickstarts": {
+            "w": 1220
+          }
+        },
+        "w": 1300
+      },
+      {
+        "h": 900,
+        "probes": {
+          "card0": {
+            "h": 112,
+            "w": 296
+          },
+          "input": {
+            "w": 1220
+          },
+          "quickstarts": {
+            "w": 1220
+          }
+        },
+        "w": 1440
+      }
+    ]
+  },
+  "card": {
+    "borderPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "className border → 1px",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 1
+    },
+    "gapPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "className gap-1 → 4px(Tailwind spacing 1 = 0.25rem)",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 4
+    },
+    "gridGapPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "grid gap-3 → 12px",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 12
+    },
+    "iconCirclePx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "className h-8 w-8 → 32px icon 圆圈",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 32
+    },
+    "iconGlyphPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "Icon size={16} → 16px glyph",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 16
+    },
+    "labelFontPx": {
+      "provenance": {
+        "hash": "fe6f62619ba903fc76270b68979232bda870f575bdd0ca97bda2087a29e6f4e7",
+        "locator": "text-13 = var(--text-13) = 13px(globals.css)",
+        "source": "../../../apps/desktop/src/renderer/styles/globals.css"
+      },
+      "value": 13
+    },
+    "labelLinePx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "className leading-[16px] → 16px",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 16
+    },
+    "minHNarrowPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "narrow 档 min-h-[84px]",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 84
+    },
+    "minHNormalPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "常态 min-h-[112px]",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 112
+    },
+    "padNarrowPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "narrow 档 p-3 → 12px",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 12
+    },
+    "padNormalPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "常态 p-4 → 16px",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 16
+    },
+    "radiusPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "className rounded-xl → 12px(与输入框统一,见代码注释)",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 12
+    }
+  },
+  "cards": [
+    {
+      "icon": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].icon=SearchCode",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "SearchCode"
+      },
+      "key": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].key='explore'",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "explore"
+      },
+      "labels": {
+        "en": {
+          "provenance": {
+            "hash": "2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd",
+            "locator": "newChat.createAgent.quickStarts.explore",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/en/common.json"
+          },
+          "value": "Explore and understand code"
+        },
+        "ja": {
+          "provenance": {
+            "hash": "5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192",
+            "locator": "newChat.createAgent.quickStarts.explore",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"
+          },
+          "value": "コードを探索して理解"
+        },
+        "ko": {
+          "provenance": {
+            "hash": "b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0",
+            "locator": "newChat.createAgent.quickStarts.explore",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"
+          },
+          "value": "코드 탐색 및 이해"
+        },
+        "zh-CN": {
+          "provenance": {
+            "hash": "56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48",
+            "locator": "newChat.createAgent.quickStarts.explore",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"
+          },
+          "value": "探索并理解代码"
+        }
+      }
+    },
+    {
+      "icon": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].icon=Code2",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "Code2"
+      },
+      "key": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].key='build'",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "build"
+      },
+      "labels": {
+        "en": {
+          "provenance": {
+            "hash": "2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd",
+            "locator": "newChat.createAgent.quickStarts.build",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/en/common.json"
+          },
+          "value": "Build a feature, app, or tool"
+        },
+        "ja": {
+          "provenance": {
+            "hash": "5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192",
+            "locator": "newChat.createAgent.quickStarts.build",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"
+          },
+          "value": "新機能、アプリ、ツールを構築"
+        },
+        "ko": {
+          "provenance": {
+            "hash": "b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0",
+            "locator": "newChat.createAgent.quickStarts.build",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"
+          },
+          "value": "새 기능, 앱 또는 도구 만들기"
+        },
+        "zh-CN": {
+          "provenance": {
+            "hash": "56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48",
+            "locator": "newChat.createAgent.quickStarts.build",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"
+          },
+          "value": "构建新功能、应用或工具"
+        }
+      }
+    },
+    {
+      "icon": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].icon=MessageSquareCode",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "MessageSquareCode"
+      },
+      "key": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].key='review'",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "review"
+      },
+      "labels": {
+        "en": {
+          "provenance": {
+            "hash": "2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd",
+            "locator": "newChat.createAgent.quickStarts.review",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/en/common.json"
+          },
+          "value": "Review code and suggest changes"
+        },
+        "ja": {
+          "provenance": {
+            "hash": "5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192",
+            "locator": "newChat.createAgent.quickStarts.review",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"
+          },
+          "value": "コードをレビューして修正を提案"
+        },
+        "ko": {
+          "provenance": {
+            "hash": "b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0",
+            "locator": "newChat.createAgent.quickStarts.review",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"
+          },
+          "value": "코드 검토 및 수정 제안"
+        },
+        "zh-CN": {
+          "provenance": {
+            "hash": "56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48",
+            "locator": "newChat.createAgent.quickStarts.review",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"
+          },
+          "value": "审查代码并提出修改建议"
+        }
+      }
+    },
+    {
+      "icon": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].icon=Hammer",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "Hammer"
+      },
+      "key": {
+        "provenance": {
+          "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+          "locator": "createAgentQuickStarts[].key='fix'",
+          "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+        },
+        "value": "fix"
+      },
+      "labels": {
+        "en": {
+          "provenance": {
+            "hash": "2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd",
+            "locator": "newChat.createAgent.quickStarts.fix",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/en/common.json"
+          },
+          "value": "Fix issues and failures"
+        },
+        "ja": {
+          "provenance": {
+            "hash": "5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192",
+            "locator": "newChat.createAgent.quickStarts.fix",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"
+          },
+          "value": "問題や失敗を修正"
+        },
+        "ko": {
+          "provenance": {
+            "hash": "b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0",
+            "locator": "newChat.createAgent.quickStarts.fix",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"
+          },
+          "value": "문제와 실패 수정"
+        },
+        "zh-CN": {
+          "provenance": {
+            "hash": "56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48",
+            "locator": "newChat.createAgent.quickStarts.fix",
+            "source": "../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"
+          },
+          "value": "修复问题和失败"
+        }
+      }
+    }
+  ],
+  "colors": {
+    "dark": {
+      "cardBg": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-bg').dark",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#312F2F"
+      },
+      "cardBgHover": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-bg-hover').dark",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#3B3A3A"
+      },
+      "cardBorder": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-border').dark",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#434343"
+      },
+      "cardText": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-text').dark",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#D4D4D4"
+      },
+      "icon": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-icon').dark",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#D4D4D4"
+      },
+      "iconBg": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-icon-bg').dark",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#2A2828"
+      },
+      "textSecondary": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('text-secondary').dark",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#a3a3a3"
+      }
+    },
+    "light": {
+      "cardBg": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-bg').light",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#F8F8F8"
+      },
+      "cardBgHover": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-bg-hover').light",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#FCFCFC"
+      },
+      "cardBorder": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-border').light",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#DCDFE3"
+      },
+      "cardText": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-text').light",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#3C3F43"
+      },
+      "icon": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-icon').light",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#3C3F43"
+      },
+      "iconBg": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('create-agent-quick-card-icon-bg').light",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#EDEDED"
+      },
+      "textSecondary": {
+        "provenance": {
+          "hash": "2c147e3be64893a22ff8c25ef27377cc53c9c48166e73346628d81b9eb48442f",
+          "locator": "registerColor('text-secondary').light",
+          "source": "../../../apps/desktop/src/renderer/themes/colors.ts"
+        },
+        "value": "#737373"
+      }
+    }
+  },
+  "layout": {
+    "autoCompactThresholdPx": {
+      "provenance": {
+        "hash": "a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e",
+        "locator": "AUTO_COMPACT_THRESHOLD",
+        "source": "../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"
+      },
+      "value": 700
+    },
+    "colBreak1Px": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "isDraftNarrow = draftContentWidth < 560(1↔2 列 + narrow 档)",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 560
+    },
+    "colBreak2Px": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "isDraftMedium = draftContentWidth < 700(2↔4 列)",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 700
+    },
+    "compactMessagePadPx": {
+      "provenance": {
+        "hash": "a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e",
+        "locator": "COMPACT_MESSAGE_PAD",
+        "source": "../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"
+      },
+      "value": 20
+    },
+    "defaultMessagePadPx": {
+      "provenance": {
+        "hash": "a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e",
+        "locator": "DEFAULT_MESSAGE_PAD",
+        "source": "../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"
+      },
+      "value": 50
+    },
+    "inputOutsetPx": {
+      "provenance": {
+        "hash": "a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e",
+        "locator": "INPUT_OUTSET",
+        "source": "../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"
+      },
+      "value": 20
+    },
+    "mainPadNarrowPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "main narrow px-4 → 16px/侧",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 16
+    },
+    "mainPadNormalPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "main 常态 px-8 → 32px/侧",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 32
+    },
+    "maxMessageWidthPx": {
+      "provenance": {
+        "hash": "a49bd2b4690b2eeadea1245795f7d0d5edad897e0665e26e83a8e29db77be58e",
+        "locator": "MAX_MESSAGE_WIDTH",
+        "source": "../../../apps/desktop/src/renderer/hooks/useProportionalWidth.ts"
+      },
+      "value": 1200
+    },
+    "minWidthFloorPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "useProportionalWidth(914,{minWidth:640})",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 640
+    }
+  },
+  "section": {
+    "titleFontPx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "section 标题 text-[14px]",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 14
+    },
+    "titleLinePx": {
+      "provenance": {
+        "hash": "647d8dc4db4c943fcf5b8b9baae7d8a46282c840beb373f7122e34319c4e01fb",
+        "locator": "section 标题 leading-[18px]",
+        "source": "../../../apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx"
+      },
+      "value": 18
+    },
+    "titles": {
+      "en": {
+        "provenance": {
+          "hash": "2d4a2fb9ebfba3e61f114aac8daaf2f17f5dbae698576745a7f99094999ebdbd",
+          "locator": "newChat.createAgent.quickStart",
+          "source": "../../../apps/desktop/src/renderer/i18n/locales/en/common.json"
+        },
+        "value": "Quick start"
+      },
+      "ja": {
+        "provenance": {
+          "hash": "5d3174d330c785db010779e9f11a0d03e4509d61622d34e42c6ffc333555d192",
+          "locator": "newChat.createAgent.quickStart",
+          "source": "../../../apps/desktop/src/renderer/i18n/locales/ja/common.json"
+        },
+        "value": "クイックスタート"
+      },
+      "ko": {
+        "provenance": {
+          "hash": "b4bf6b63223b7b3249534291d017fac1e5e8aff10106080bd25b34020fc8f3c0",
+          "locator": "newChat.createAgent.quickStart",
+          "source": "../../../apps/desktop/src/renderer/i18n/locales/ko/common.json"
+        },
+        "value": "빠른 시작"
+      },
+      "zh-CN": {
+        "provenance": {
+          "hash": "56e57ceda408a46c6a115ee2662575d7cd09e02a7142529b90b6bdf4bfa61c48",
+          "locator": "newChat.createAgent.quickStart",
+          "source": "../../../apps/desktop/src/renderer/i18n/locales/zh-CN/common.json"
+        },
+        "value": "快速开始"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 这次改了什么

New Maker 主界面「快速开始」4 张快捷入口卡片布局改稿(用户对照设计稿 / Figma 三轮裁定):

- **icon 固定卡片左上**:位置不变,距顶边 = 距左边 = 内边距(narrow 12px / 常态 16px)
- **文字挪到卡片中下方**,与 icon 左对齐,不再向右缩进(`flex-col + justify-between`,icon 顶、文字底,`gap-1` 兜底竖向最小间距)
- narrow / 常态两档**统一竖排**,取代原窄态横排 / 常态竖排自适应特判(#562)
- 卡片高度不变(narrow 84 / 常态 112),圆角 / 描边 / 内边距 / icon 尺寸 / 字号均沿用既有值,未引入新几何常量

配套:`newMakerCreateAgentVisualContract` 补一条回归断言锁住新排布契约;demo 工件随 PR 入库 `docs/design-previews/newmaker-quickstart-cards/`。

**本 PR 只改这一处卡片 UI,不包含任何其它修复。**

## 怎么验证的

- `pnpm test:unit` 全仓通过(全部 PASS,exit 0)
- 定向:`newMakerCreateAgentVisualContract.test.ts` 14/14、`newMakerProjectPicker.test.ts` 10/10
- ⚠️ `pnpm --filter desktop typecheck` 存在 **2 个 main 基线既有错误**(`cindy-brain/index.ts:1855` 调用已被 #333 删除的 `requestNodeInstallAuthorization`;`installFlow.test.tsx:199` 类型错),已用 `git stash` 对照裸 `origin/main` 确认与本 PR 无关,不在本 PR 修——需 #256/#333 相关同学跟进
- 高保真 QA demo 六道门验收(见下方附贴块)

## 风险

- 纯 renderer 样式改动,不涉及 SQLite migration / system prompt / 协议 / 原生层;Tailwind class 跨 macOS / Windows 渲染一致
- 规则 26(远程 / 手机):不涉及——纯桌面端 New Maker 草稿页卡片样式,无新 IPC channel / 推送事件,手机版无此界面

### 可交互 QA demo（代替沙盒试用）

**UI 证据（HTML 界面）**：https://newmaker-quickstart-cards.workers.xd.team

- **做了什么**：New Maker 主界面「快速开始」4 张快捷入口卡片的竖排(icon 左上/文字中下)+ 等比拉伸布局改稿
- **怎么做的**：卡片改为竖排:icon 固定卡片左上(位置不变,距顶=距左=内边距),文字挪到卡片中下方、与 icon 左对齐(flex-col + justify-between);卡片区去掉 800px 封顶,随 useProportionalWidth 的 inputWidth 等比拉伸、与输入框同宽同缘;grid 按 inputWidth 断点 560/700 切 1/2/4 列,高度不变(narrow 84 / 常态 112)
- **怎么验收**：A/B/C/D/F 五门:truth 提取自源码带 provenance / 状态覆盖 / 4 语言无截断 / computed-style 绑定(4px·12px·13px·主题 token) / 拉伸几何 oracle 比对(卡片宽随 inputWidth、与输入框同宽、高度恒定)

**实际执行矩阵**：zh-light {"plat":"desk","region":"na","os":"desktop","mode":"light","lang":"zh-CN"}；en-dark {"plat":"desk","region":"na","os":"desktop","mode":"dark","lang":"en"}；ja-light {"plat":"desk","region":"na","os":"desktop","mode":"light","lang":"ja"}；ko-dark {"plat":"desk","region":"na","os":"desktop","mode":"dark","lang":"ko"}

| 验收门 | 结论 |
|---|---|
| 真值一致（数据层:truth 提取自源码,每个叶子带 provenance；渲染层由门 D 保证） | ✅ |
| 状态覆盖（实际执行 8/8） | ✅ |
| 交互鲁棒（no-clip / persistence） | ✅ |
| 渲染绑定（68 条 computed-style ≡ truth） | ✅ |
| 适配还原（18 点） | ✅ |
| 像素基准（vs 真沙盒截图） | ⚠️ 未运行 pixel-compare |

<sub>由 qa-hifi-demo 生成 · 工具版本 qa-hifi-demo@2026-07-25-p0-hardening · 验收时间 2026-07-24T21:00:41.416Z</sub>
