### PR TITLE
fix(models): 更新 Anthropic 模型名称与 effort

### DIFF
--- a/apps/desktop/resources/THIRD-PARTY-RESTRICTED.txt
+++ b/apps/desktop/resources/THIRD-PARTY-RESTRICTED.txt
@@ -7,7 +7,7 @@ Cindy desktop application — all supported platforms
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.215
+Claude Code CLI@2.1.219
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts
@@ -38,8 +38,8 @@ function singleFileTar(name: string, content: Buffer): Buffer {
 
 describe('runtimeVersionMatchesPin', () => {
   it('requires Cindy-managed Claude and Codex binaries to match their pins exactly', () => {
-    expect(runtimeVersionMatchesPin('claude-code', '2.1.215 (Claude Code)')).toBe(true);
-    expect(runtimeVersionMatchesPin('claude-code', '2.1.214 (Claude Code)')).toBe(false);
+    expect(runtimeVersionMatchesPin('claude-code', '2.1.219 (Claude Code)')).toBe(true);
+    expect(runtimeVersionMatchesPin('claude-code', '2.1.218 (Claude Code)')).toBe(false);
     expect(runtimeVersionMatchesPin('codex', 'codex-cli 0.144.6')).toBe(true);
     expect(runtimeVersionMatchesPin('codex', 'codex-cli 0.144.5')).toBe(false);
   });
@@ -66,7 +66,7 @@ describeOnLinuxFileSystem('install path helpers', () => {
 
   it('resolves the exact legacy CDN cache path for migration', () => {
     expect(legacyManagedBinaryPath('/userdata', 'claude-code')).toBe(
-      path.join('/userdata', 'claude-code', '2.1.215', 'claude'),
+      path.join('/userdata', 'claude-code', '2.1.219', 'claude'),
     );
     expect(legacyManagedBinaryPath('/userdata', 'codex')).toBe(
       path.join('/userdata', 'codex', '0.144.6', 'codex'),
@@ -84,16 +84,16 @@ describeOnLinuxFileSystem('install path helpers', () => {
 describe('official asset descriptors', () => {
   it('uses the trusted Claude asset committed with the version pin', () => {
     const sha256 = 'a'.repeat(64);
-    expect(pinnedOfficialAssetDescriptor('claude-code', '2.1.215', {
+    expect(pinnedOfficialAssetDescriptor('claude-code', '2.1.219', {
       runtimeAssets: {
         'linux-x64': {
-          url: 'https://downloads.claude.ai/claude-code-releases/2.1.215/linux-x64/claude',
+          url: 'https://downloads.claude.ai/claude-code-releases/2.1.219/linux-x64/claude',
           sha256,
           size: 123,
         },
       },
     })).toEqual({
-      url: 'https://downloads.claude.ai/claude-code-releases/2.1.215/linux-x64/claude',
+      url: 'https://downloads.claude.ai/claude-code-releases/2.1.219/linux-x64/claude',
       sha256,
       size: 123,
     });

--- a/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts
@@ -12,6 +12,7 @@ import {
   privateBinaryPath,
   runtimeInstallRoot,
   runtimeVersionMatchesPin,
+  systemRuntimeVersionSupportsPin,
 } from '../linux-runtime-fallback';
 
 const tempDirs: string[] = [];
@@ -47,6 +48,16 @@ describe('runtimeVersionMatchesPin', () => {
   it('rejects empty or unparsable version output', () => {
     expect(runtimeVersionMatchesPin('claude-code', '')).toBe(false);
     expect(runtimeVersionMatchesPin('codex', 'development build')).toBe(false);
+  });
+});
+
+describe('systemRuntimeVersionSupportsPin', () => {
+  it('accepts the pinned or newer Claude runtime and rejects older or prerelease-equivalent builds', () => {
+    expect(systemRuntimeVersionSupportsPin('claude-code', '2.1.219 (Claude Code)')).toBe(true);
+    expect(systemRuntimeVersionSupportsPin('claude-code', '2.2.0 (Claude Code)')).toBe(true);
+    expect(systemRuntimeVersionSupportsPin('claude-code', '2.1.218 (Claude Code)')).toBe(false);
+    expect(systemRuntimeVersionSupportsPin('claude-code', '2.1.219-beta.1')).toBe(false);
+    expect(systemRuntimeVersionSupportsPin('claude-code', '2.2.0-beta.1')).toBe(false);
   });
 });
 

--- a/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeMigration.test.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeMigration.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
       callback(new Error('system lookup disabled in migration test'), '', '');
       return;
     }
-    callback(null, '2.1.215 (Claude Code)\n', '');
+    callback(null, '2.1.219 (Claude Code)\n', '');
   });
 });
 
@@ -55,14 +55,14 @@ describe('legacy managed binary migration', () => {
   it('reuses and atomically migrates the exact pinned Claude cache without network access', async () => {
     const legacyPath = fallback.legacyManagedBinaryPath(tempDir, 'claude-code');
     fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
-    fs.writeFileSync(legacyPath, '#!/bin/sh\necho "2.1.215 (Claude Code)"\n', { mode: 0o755 });
+    fs.writeFileSync(legacyPath, '#!/bin/sh\necho "2.1.219 (Claude Code)"\n', { mode: 0o755 });
     fs.writeFileSync(path.join(path.dirname(legacyPath), '.verified'), '');
 
     const result = await fallback.prepareLinuxRuntimeFallback('claude-code');
 
     expect(result).toMatchObject({ ready: true, installed: false, source: 'legacy' });
     expect(result.binaryPath).toBe(fallback.privateBinaryPath(tempDir, 'claude-code'));
-    expect(fs.readFileSync(result.binaryPath, 'utf8')).toContain('2.1.215');
+    expect(fs.readFileSync(result.binaryPath, 'utf8')).toContain('2.1.219');
     expect(downloadMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeMigration.test.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeMigration.test.ts
@@ -65,4 +65,44 @@ describe('legacy managed binary migration', () => {
     expect(fs.readFileSync(result.binaryPath, 'utf8')).toContain('2.1.219');
     expect(downloadMock).not.toHaveBeenCalled();
   });
+
+  it('installs the pin instead of selecting an older system Claude runtime', async () => {
+    const systemClaude = '/usr/local/bin/claude';
+    execFileMock.mockImplementation((
+      command: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (command === '/bin/sh') {
+        callback(null, `${systemClaude}\n`, '');
+        return;
+      }
+      callback(
+        null,
+        command === systemClaude
+          ? '2.1.218 (Claude Code)\n'
+          : '2.1.219 (Claude Code)\n',
+        '',
+      );
+    });
+    downloadMock.mockImplementationOnce(async ({ targetPath }: { targetPath: string }) => {
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.writeFileSync(targetPath, '#!/bin/sh\necho "2.1.219 (Claude Code)"\n', { mode: 0o755 });
+      return {
+        path: targetPath,
+        size: fs.statSync(targetPath).size,
+        sha256: 'test',
+        fromCache: false,
+        durationMs: 0,
+        resumedFromBytes: 0,
+      };
+    });
+
+    const result = await fallback.prepareLinuxRuntimeFallback('claude-code');
+
+    expect(result).toMatchObject({ ready: true, installed: true, source: 'installed' });
+    expect(result.binaryPath).toBe(fallback.privateBinaryPath(tempDir, 'claude-code'));
+    expect(downloadMock).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/desktop/src/main/agent-binaries/linux-runtime-fallback.ts
+++ b/apps/desktop/src/main/agent-binaries/linux-runtime-fallback.ts
@@ -156,6 +156,25 @@ export function runtimeVersionMatchesPin(
   return parseVersionOutput(versionOutput) === CONFIG[kind].version;
 }
 
+/** User-managed runtimes may be newer than the pin, but not older or prerelease-equivalent. */
+export function systemRuntimeVersionSupportsPin(
+  kind: LinuxRuntimeFallbackKind,
+  versionOutput: string,
+): boolean {
+  const candidate = parseVersionOutput(versionOutput);
+  const pinned = parseVersionOutput(CONFIG[kind].version);
+  if (!candidate || !pinned) return false;
+  if (candidate.includes('-')) return false;
+  const candidateCore = candidate.split(/[-+]/, 1)[0].split('.').map(Number);
+  const pinnedCore = pinned.split(/[-+]/, 1)[0].split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (candidateCore[index] !== pinnedCore[index]) {
+      return candidateCore[index] > pinnedCore[index];
+    }
+  }
+  return true;
+}
+
 function probeCancelledError(command: string): Error {
   return new Error(`${path.basename(command)} install cancelled`);
 }
@@ -233,9 +252,11 @@ async function findSystemBinaryAsync(
   if (!candidate) return null;
   const versionOutput = await readExecutableVersion(candidate, signal);
   if (!versionOutput) return null;
-  // Preserve the historical behavior for a user-managed Claude CLI. Codex's
-  // app-server protocol is versioned and must match the repository pin.
+  // Preserve compatible newer user-managed Claude CLIs. Older binaries can
+  // reject newly visible models, while Codex's app-server protocol requires
+  // an exact repository-pin match.
   if (kind === 'claude-code') {
+    if (!systemRuntimeVersionSupportsPin(kind, versionOutput)) return null;
     const nodePath = await findCommandAsync('node', signal);
     if (!nodePath) return candidate;
     try {

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -279,6 +279,35 @@ describe('anthropic 发现条目的 cindyModelMeta 元数据基线', () => {
     expect(anthropicList().find((m) => m.id === 'claude-unknown')?.name).toBe('Unknown Raw');
   });
 
+  it('远端 v1 元数据不完整时按模型、按字段回落 bundled v1', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    catalog.cindyModelMeta = {
+      version: 1,
+      models: {
+        // 模拟旧远端只认识展示名，不带 4.5 的窗口与 effort 能力。
+        'claude-sonnet-4-5': { name: 'Remote Sonnet 4.5' },
+      },
+    };
+    setActiveCatalog(catalog);
+    setAnthropicDiscoveredModels([
+      anthro('claude-sonnet-4-5', 'Sonnet Raw', 0),
+      anthro('claude-opus-5', 'Opus Raw', 1),
+    ]);
+
+    expect(anthropicList().find((m) => m.id === 'claude-sonnet-4-5')?.name).toBe('Remote Sonnet 4.5');
+    expect(getCindyModelContextWindow('claude-sonnet-4-5')).toBe(200_000);
+    expect(getCindyModelEffortBaseline('claude-sonnet-4-5')).toEqual({
+      efforts: [],
+      defaultEffort: null,
+    });
+    // 远端完全缺席的 bundled 新模型也必须保留完整能力基线。
+    expect(getCindyModelContextWindow('claude-opus-5')).toBe(1_000_000);
+    expect(getCindyModelEffortBaseline('claude-opus-5')).toEqual({
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'high',
+    });
+  });
+
   it('版本门禁:cindyModelMeta.version !== 1 整段忽略;坏信封安全跳过', () => {
     const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
     catalog.cindyModelMeta = { version: 2, models: { 'claude-fable-5': { name: 'V2 Name' } } };

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -324,4 +324,18 @@ describe('anthropic 发现条目的 cindyModelMeta 元数据基线', () => {
     expect(getCindyModelEffortBaseline('claude-fable-5')).toBeNull();
     expect(getCindyModelContextWindow('claude-fable-5')).toBeNull();
   });
+
+  it('active 目录未携带 cindyModelMeta 时回落 bundled v1 基线', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    delete catalog.cindyModelMeta;
+    setActiveCatalog(catalog);
+    setAnthropicDiscoveredModels([anthro('claude-fable-5', 'Fable Raw', 0)]);
+
+    expect(anthropicList()[0]?.name).toBe('Fable 5');
+    expect(getCindyModelContextWindow('claude-fable-5')).toBe(1_000_000);
+    expect(getCindyModelEffortBaseline('claude-fable-5')).toEqual({
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'high',
+    });
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -12,6 +12,7 @@ import { BUNDLED_CATALOG, type Catalog, type CatalogModel } from '@cindy/model-p
 
 import {
   getActiveCatalog,
+  getCindyModelContextWindow,
   getCindyModelEffortBaseline,
   setActiveCatalog,
   setAnthropicDiscoveredModels,
@@ -274,6 +275,7 @@ describe('anthropic 发现条目的 cindyModelMeta 元数据基线', () => {
       efforts: ['max'],
       defaultEffort: 'max',
     });
+    expect(getCindyModelContextWindow('claude-known')).toBe(123);
     expect(anthropicList().find((m) => m.id === 'claude-unknown')?.name).toBe('Unknown Raw');
   });
 
@@ -284,11 +286,13 @@ describe('anthropic 发现条目的 cindyModelMeta 元数据基线', () => {
     setAnthropicDiscoveredModels([anthro('claude-fable-5', 'Fable', 0)]);
     expect(anthropicList()[0]?.name).toBe('Fable');
     expect(getCindyModelEffortBaseline('claude-fable-5')).toBeNull();
+    expect(getCindyModelContextWindow('claude-fable-5')).toBeNull();
 
     catalog.cindyModelMeta = 'not-an-object';
     setActiveCatalog(JSON.parse(JSON.stringify(catalog)) as Catalog);
     setAnthropicDiscoveredModels([anthro('claude-fable-5', 'Fable', 0)]);
     expect(anthropicList()[0]?.name).toBe('Fable');
     expect(getCindyModelEffortBaseline('claude-fable-5')).toBeNull();
+    expect(getCindyModelContextWindow('claude-fable-5')).toBeNull();
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -166,16 +166,87 @@ describe('anthropic 发现条目的 cindyModelMeta 元数据基线', () => {
     setAnthropicDiscoveredModels([]);
   });
 
-  it('基线覆盖名字与排序:上游家族级命名("Fable")归位产品命名("Fable 5"),按 meta sortOrder 重排', () => {
-    setActiveCatalog(BUNDLED_CATALOG); // bundled cindyModelMeta:claude-fable-5 → "Fable 5" (sortOrder 0)
+  it('基线统一 Anthropic 名字与排序,新模型不透传 Claude 前缀', () => {
+    setActiveCatalog(BUNDLED_CATALOG);
     setAnthropicDiscoveredModels([
-      anthro('claude-opus-4-8', 'Opus', 0),
-      anthro('claude-fable-5', 'Fable', 1),
+      anthro('claude-opus-5', 'Claude Opus 5', 0),
+      anthro('claude-sonnet-5', 'Claude Sonnet 5', 1),
+      anthro('claude-fable-5', 'Claude Fable 5', 2),
+      anthro('claude-opus-4-8', 'Claude Opus 4.8', 3),
+      anthro('claude-opus-4-7', 'Claude Opus 4.7', 4),
+      anthro('claude-sonnet-4-6', 'Claude Sonnet 4.6', 5),
+      anthro('claude-opus-4-6', 'Claude Opus 4.6', 6),
+      anthro('claude-opus-4-5', 'Claude Opus 4.5', 7),
+      anthro('claude-haiku-4-5', 'Claude Haiku 4.5', 8),
+      anthro('claude-sonnet-4-5', 'Claude Sonnet 4.5', 9),
     ]);
     expect(anthropicList().map((m) => [m.id, m.name])).toEqual([
+      ['claude-opus-5', 'Opus 5'],
       ['claude-fable-5', 'Fable 5'],
       ['claude-opus-4-8', 'Opus 4.8'],
+      ['claude-opus-4-7', 'Opus 4.7'],
+      ['claude-opus-4-6', 'Opus 4.6'],
+      ['claude-opus-4-5', 'Opus 4.5'],
+      ['claude-sonnet-5', 'Sonnet 5'],
+      ['claude-sonnet-4-6', 'Sonnet 4.6'],
+      ['claude-sonnet-4-5', 'Sonnet 4.5'],
+      ['claude-haiku-4-5', 'Haiku 4.5'],
     ]);
+    expect(Object.fromEntries([
+      'claude-fable-5',
+      'claude-opus-5',
+      'claude-opus-4-8',
+      'claude-opus-4-7',
+      'claude-opus-4-6',
+      'claude-opus-4-5',
+      'claude-sonnet-5',
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-5',
+      'claude-haiku-4-5',
+    ].map((id) => [id, getCindyModelEffortBaseline(id)]))).toEqual({
+      'claude-fable-5': {
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+        defaultEffort: 'high',
+      },
+      'claude-opus-5': {
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+        defaultEffort: 'high',
+      },
+      'claude-opus-4-8': {
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+        defaultEffort: 'high',
+      },
+      'claude-opus-4-7': {
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+        defaultEffort: 'high',
+      },
+      'claude-opus-4-6': {
+        efforts: ['low', 'medium', 'high', 'max'],
+        defaultEffort: 'high',
+      },
+      'claude-opus-4-5': {
+        efforts: ['low', 'medium', 'high'],
+        defaultEffort: 'high',
+      },
+      'claude-sonnet-5': {
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+        defaultEffort: 'high',
+      },
+      'claude-sonnet-4-6': {
+        efforts: ['low', 'medium', 'high', 'max'],
+        defaultEffort: 'high',
+      },
+      'claude-sonnet-4-5': {
+        efforts: [],
+        defaultEffort: null,
+      },
+      'claude-haiku-4-5': {
+        efforts: [],
+        defaultEffort: null,
+      },
+    });
+    expect(anthropicList().find((m) => m.id === 'claude-opus-4-5')?.defaultEnabled).toBe(false);
+    expect(anthropicList().find((m) => m.id === 'claude-sonnet-4-5')?.defaultEnabled).toBe(false);
   });
 
   it('active overlay 不覆盖能力;发现模块可单独读取 effort 基线', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -137,6 +137,22 @@ describe('mapAnthropicSdkModels', () => {
     });
   });
 
+  it('目录未知且能力缺席时,非 Haiku 新模型先开放 5 档,Haiku 仍保持 0 档', () => {
+    const out = mapAnthropicSdkModels([
+      { value: 'claude-opus-6', displayName: 'Opus 6' },
+      { value: 'claude-haiku-5', displayName: 'Haiku 5' },
+    ]);
+    expect(out[0]).toMatchObject({ hasEffortInfo: false });
+    expect(out[0].model).toMatchObject({
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'high',
+    });
+    expect(out[1].model).toMatchObject({
+      efforts: [],
+      defaultEffort: null,
+    });
+  });
+
   it('过滤别名与非 claude id(规则 10:禁止裸别名进目录);dated id 归一去重', () => {
     const out = mapAnthropicSdkModels([
       { value: 'opus', displayName: 'Opus' },
@@ -199,6 +215,17 @@ describe('mapAnthropicHttpModels', () => {
       contextWindow: 900_000, // max_input_tokens 优先于 1M 规则
       efforts: ['low', 'high', 'max'],
       supportsFastMode: true,
+    });
+  });
+
+  it('HTTP 未知新模型缺 capability 时同样使用 5 档临时基线', () => {
+    const out = mapAnthropicHttpModels([
+      { id: 'claude-sonnet-6', display_name: 'Sonnet 6', type: 'model' },
+    ]);
+    expect(out[0]).toMatchObject({ hasEffortInfo: false });
+    expect(out[0].model).toMatchObject({
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'high',
     });
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -3,7 +3,8 @@
  *
  * 覆盖:SDK ModelInfo 映射(别名过滤 / dated id 归一 / 能力字段在场 = 权威、全缺席 =
  * 未知按确定性默认合成 / haiku 默认收起)、HTTP /v1/models 映射(能力字段容错 / haiku
- * 例外 / max_input_tokens 优先 / dated 去重)、contextWindow 规则(默认 1M,haiku 200k)、
+ * 例外 / max_input_tokens 优先 / dated 去重)、contextWindow 规则(HTTP 明示 > 目录 >
+ * 默认 1M / haiku 200k)、
  * SDK 捕获入口的登录态门控与合并纪律(登出不注入 / 无能力信息保留已精化条目 /
  * HTTP 明说窗口不被 SDK 打回猜测值 / 磁盘缓存恢复 explicitWindows)。
  * HTTP 拉取的网络路径不在此测(登录态 + fetch 依赖,行为由代码注释契约覆盖)。
@@ -118,6 +119,19 @@ describe('mapAnthropicSdkModels', () => {
     expect(out[1].model).toMatchObject({ efforts: [], defaultEnabled: false });
   });
 
+  it('SDK 未下发窗口时使用目录中的官方窗口', () => {
+    const out = mapAnthropicSdkModels([
+      { value: 'claude-opus-5', displayName: 'Opus 5' },
+      { value: 'claude-opus-4-5', displayName: 'Opus 4.5' },
+      { value: 'claude-sonnet-4-5', displayName: 'Sonnet 4.5' },
+    ]);
+    expect(out.map(({ model }) => [model.id, model.contextWindow])).toEqual([
+      ['claude-opus-5', 1_000_000],
+      ['claude-opus-4-5', 200_000],
+      ['claude-sonnet-4-5', 200_000],
+    ]);
+  });
+
   it('supportsEffort=true 但缺档位清单:使用目录基线,不解读为不可调', () => {
     const out = mapAnthropicSdkModels([
       { value: 'claude-opus-4-8', displayName: 'Opus', supportsEffort: true },
@@ -216,6 +230,19 @@ describe('mapAnthropicHttpModels', () => {
       efforts: ['low', 'high', 'max'],
       supportsFastMode: true,
     });
+  });
+
+  it('HTTP 未下发 max_input_tokens 时使用目录中的官方窗口', () => {
+    const out = mapAnthropicHttpModels([
+      { id: 'claude-opus-5', display_name: 'Opus 5', type: 'model' },
+      { id: 'claude-opus-4-5', display_name: 'Opus 4.5', type: 'model' },
+      { id: 'claude-sonnet-4-5', display_name: 'Sonnet 4.5', type: 'model' },
+    ]);
+    expect(out.map(({ model }) => [model.id, model.contextWindow])).toEqual([
+      ['claude-opus-5', 1_000_000],
+      ['claude-opus-4-5', 200_000],
+      ['claude-sonnet-4-5', 200_000],
+    ]);
   });
 
   it('HTTP 未知新模型缺 capability 时同样使用 5 档临时基线', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -704,6 +704,35 @@ describe('noteAnthropicSdkSupportedModels(登录态门控 + 合并纪律)', () =
     expect(persisted.explicitFastModeModelIds).toEqual(['claude-fable-5']);
   });
 
+  it('磁盘缓存会按当前目录修正未明确声明的旧窗口', async () => {
+    const cacheDir = path.join(TEST_USER_DATA, 'model-discovery');
+    await fsp.mkdir(cacheDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(cacheDir, 'anthropic-models.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-19T00:00:00.000Z',
+        models: [
+          {
+            id: 'claude-sonnet-4-5',
+            name: 'Sonnet 4.5',
+            group: 'anthropic',
+            sortOrder: 0,
+            contextWindow: 1_000_000,
+            efforts: [],
+            defaultEffort: null,
+            supportsFastMode: false,
+            status: 'active',
+          },
+        ],
+      }),
+      'utf-8',
+    );
+
+    await loadAnthropicModelsFromDiskCache();
+
+    expect(anthropicModel('claude-sonnet-4-5')?.contextWindow).toBe(200_000);
+  });
+
   it('磁盘缓存恢复 explicitWindows:重启后 SDK 捕获不把 HTTP 明说窗口打回猜测值(review P2 回归)', async () => {
     const cacheDir = path.join(TEST_USER_DATA, 'model-discovery');
     await fsp.mkdir(cacheDir, { recursive: true });

--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 import fsp from 'node:fs/promises';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BUNDLED_CATALOG, type Catalog } from '@cindy/model-providers';
 
 // 规则 23:测试涉及路径一律用 os.tmpdir() 下的临时目录,收尾清理。
 const TEST_USER_DATA = path.join(os.tmpdir(), `cindy-anthropic-discovery-test-${process.pid}`);
@@ -47,7 +48,11 @@ import {
   resetAnthropicDiscoveryForTest,
   waitForAnthropicDiscoveryIdleForTest,
 } from '../model-discovery/anthropic.js';
-import { getActiveCatalog, setAnthropicDiscoveredModels } from '../active-catalog.js';
+import {
+  getActiveCatalog,
+  setActiveCatalog,
+  setAnthropicDiscoveredModels,
+} from '../active-catalog.js';
 
 function anthropicIds(): string[] {
   const p = getActiveCatalog().providers.find((x) => x.id === 'anthropic');
@@ -61,6 +66,10 @@ function anthropicModel(id: string) {
 
 afterAll(async () => {
   await fsp.rm(TEST_USER_DATA, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  setActiveCatalog(BUNDLED_CATALOG);
 });
 
 describe('mapAnthropicSdkModels', () => {
@@ -129,6 +138,35 @@ describe('mapAnthropicSdkModels', () => {
       ['claude-opus-5', 1_000_000],
       ['claude-opus-4-5', 200_000],
       ['claude-sonnet-4-5', 200_000],
+    ]);
+  });
+
+  it('active v1 元数据缺字段时仍从 bundled v1 取得窗口和 effort', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    catalog.cindyModelMeta = {
+      version: 1,
+      models: {
+        'claude-sonnet-4-5': { name: 'Remote Sonnet 4.5' },
+      },
+    };
+    setActiveCatalog(catalog);
+
+    const out = mapAnthropicSdkModels([
+      { value: 'claude-sonnet-4-5', displayName: 'Sonnet 4.5' },
+      { value: 'claude-opus-5', displayName: 'Opus 5' },
+    ]);
+
+    expect(out.map(({ model }) => ({
+      id: model.id,
+      contextWindow: model.contextWindow,
+      efforts: model.efforts,
+    }))).toEqual([
+      { id: 'claude-sonnet-4-5', contextWindow: 200_000, efforts: [] },
+      {
+        id: 'claude-opus-5',
+        contextWindow: 1_000_000,
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      },
     ]);
   });
 

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -266,6 +266,33 @@ function buildCindyModelMetaIndex(meta: unknown): Map<string, CindyModelMetaFiel
   return index;
 }
 
+/**
+ * 远端 v1 元数据允许按模型、按字段增量覆盖 bundled v1。旧远端目录经常只带
+ * 部分新字段或缺少新模型；缺口必须回落 bundled，否则已知 200k 模型会落入
+ * 1M 启发式。非 v1 active 信封仍整段忽略，不能拿 bundled v1 混入未知 schema。
+ */
+function buildEffectiveCindyModelMetaIndex(): Map<string, CindyModelMetaFields> {
+  const bundled = buildCindyModelMetaIndex(BUNDLED_CATALOG.cindyModelMeta);
+  if (!base) return bundled;
+
+  const activeMeta = base.cindyModelMeta;
+  if (
+    !activeMeta ||
+    typeof activeMeta !== 'object' ||
+    Array.isArray(activeMeta) ||
+    (activeMeta as { version?: unknown }).version !== 1
+  ) {
+    return new Map();
+  }
+
+  const effective = new Map<string, CindyModelMetaFields>();
+  for (const [id, fields] of bundled) effective.set(id, { ...fields });
+  for (const [id, fields] of buildCindyModelMetaIndex(activeMeta)) {
+    effective.set(id, { ...effective.get(id), ...fields });
+  }
+  return effective;
+}
+
 export interface CindyModelEffortBaseline {
   efforts: Effort[];
   defaultEffort: Effort | null;
@@ -273,7 +300,7 @@ export interface CindyModelEffortBaseline {
 
 /** 返回当前目录的已知上下文窗口；只供动态发现缺少上游明确值时兜底。 */
 export function getCindyModelContextWindow(modelId: string): number | null {
-  return buildCindyModelMetaIndex((base ?? BUNDLED_CATALOG).cindyModelMeta).get(modelId)?.contextWindow ?? null;
+  return buildEffectiveCindyModelMetaIndex().get(modelId)?.contextWindow ?? null;
 }
 
 /**
@@ -281,7 +308,7 @@ export function getCindyModelContextWindow(modelId: string): number | null {
  * 模型是否存在仍完全由 HTTP / SDK 动态清单决定。
  */
 export function getCindyModelEffortBaseline(modelId: string): CindyModelEffortBaseline | null {
-  const fields = buildCindyModelMetaIndex((base ?? BUNDLED_CATALOG).cindyModelMeta).get(modelId);
+  const fields = buildEffectiveCindyModelMetaIndex().get(modelId);
   if (!fields?.efforts) return null;
   const efforts = [...fields.efforts];
   const defaultEffort =
@@ -376,7 +403,7 @@ function computeMerged(): Catalog {
   // 三层合并:存在性=发现,展示=产品目录,用户 override 永远最高)——订阅通道返回的
   // 家族级名字("Fable")在此归位为产品命名("Fable 5");能力字段仍以发现为准。
   if (anthropicModels.length > 0) {
-    const metaIndex = buildCindyModelMetaIndex(b.cindyModelMeta);
+    const metaIndex = buildEffectiveCindyModelMetaIndex();
     const overlaid = sortModelsByOrder(
       anthropicModels.map((m) => overlayCindyMeta(m, metaIndex.get(m.id))),
     );

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -109,6 +109,8 @@ const VALID_EFFORTS: ReadonlySet<string> = new Set([
 type Effort = CatalogModel['efforts'][number];
 /** base + custom + discovered augment 的合并缓存;null = 待重算(惰性)。 */
 let merged: Catalog | null = null;
+/** bundled + active v1 `cindyModelMeta` 的合并索引；目录变化时与 merged 一起失效。 */
+let effectiveCindyModelMetaIndex: Map<string, CindyModelMetaFields> | null = null;
 
 /**
  * 目录修订号。所有会改变 getActiveCatalog() 结果的写入都必须经过 markChanged，
@@ -121,6 +123,7 @@ let changedListener: ((nextRevision: number) => void) | null = null;
 
 function markChanged(): void {
   merged = null;
+  effectiveCindyModelMetaIndex = null;
   revision += 1;
   changedListener?.(revision);
 }
@@ -272,8 +275,13 @@ function buildCindyModelMetaIndex(meta: unknown): Map<string, CindyModelMetaFiel
  * 1M 启发式。非 v1 active 信封仍整段忽略，不能拿 bundled v1 混入未知 schema。
  */
 function buildEffectiveCindyModelMetaIndex(): Map<string, CindyModelMetaFields> {
+  if (effectiveCindyModelMetaIndex) return effectiveCindyModelMetaIndex;
+
   const bundled = buildCindyModelMetaIndex(BUNDLED_CATALOG.cindyModelMeta);
-  if (!base) return bundled;
+  if (!base || base.cindyModelMeta === undefined) {
+    effectiveCindyModelMetaIndex = bundled;
+    return effectiveCindyModelMetaIndex;
+  }
 
   const activeMeta = base.cindyModelMeta;
   if (
@@ -282,7 +290,8 @@ function buildEffectiveCindyModelMetaIndex(): Map<string, CindyModelMetaFields> 
     Array.isArray(activeMeta) ||
     (activeMeta as { version?: unknown }).version !== 1
   ) {
-    return new Map();
+    effectiveCindyModelMetaIndex = new Map();
+    return effectiveCindyModelMetaIndex;
   }
 
   const effective = new Map<string, CindyModelMetaFields>();
@@ -290,7 +299,8 @@ function buildEffectiveCindyModelMetaIndex(): Map<string, CindyModelMetaFields> 
   for (const [id, fields] of buildCindyModelMetaIndex(activeMeta)) {
     effective.set(id, { ...effective.get(id), ...fields });
   }
-  return effective;
+  effectiveCindyModelMetaIndex = effective;
+  return effectiveCindyModelMetaIndex;
 }
 
 export interface CindyModelEffortBaseline {

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -211,9 +211,10 @@ function projectCodexModelsToClaude(p: Provider): Provider {
 const DYNAMIC_LIST_PROVIDER_IDS: ReadonlySet<string> = new Set(['anthropic', 'openai', 'xd']);
 
 /**
- * cindyModelMeta 里客户端认识的字段子集。展示字段直接覆盖发现条目；effort 字段只在
- * Anthropic 动态通道**没有能力信息**时作为基线，由 model-discovery/anthropic 消费。
- * 上游显式能力始终优先，meta 不在 active catalog overlay 阶段改写能力。
+ * cindyModelMeta 里客户端认识的字段子集。展示字段直接覆盖发现条目；context / effort
+ * 字段只在 Anthropic 动态通道**没有能力信息**时作为基线，由
+ * model-discovery/anthropic 消费。上游显式能力始终优先，meta 不在 active catalog
+ * overlay 阶段改写能力。
  */
 interface CindyModelMetaFields {
   name?: string;
@@ -221,6 +222,7 @@ interface CindyModelMetaFields {
   description?: string;
   sortOrder?: number;
   defaultEnabled?: boolean;
+  contextWindow?: number;
   efforts?: Effort[];
   defaultEffort?: Effort | null;
 }
@@ -247,6 +249,9 @@ function buildCindyModelMetaIndex(meta: unknown): Map<string, CindyModelMetaFiel
     if (typeof e.description === 'string' && e.description.length > 0) fields.description = e.description;
     if (typeof e.sortOrder === 'number' && Number.isFinite(e.sortOrder)) fields.sortOrder = e.sortOrder;
     if (typeof e.defaultEnabled === 'boolean') fields.defaultEnabled = e.defaultEnabled;
+    if (typeof e.contextWindow === 'number' && Number.isFinite(e.contextWindow) && e.contextWindow > 0) {
+      fields.contextWindow = e.contextWindow;
+    }
     if (Array.isArray(e.efforts)) {
       const efforts = e.efforts.filter((value): value is Effort =>
         typeof value === 'string' && VALID_EFFORTS.has(value));
@@ -264,6 +269,11 @@ function buildCindyModelMetaIndex(meta: unknown): Map<string, CindyModelMetaFiel
 export interface CindyModelEffortBaseline {
   efforts: Effort[];
   defaultEffort: Effort | null;
+}
+
+/** 返回当前目录的已知上下文窗口；只供动态发现缺少上游明确值时兜底。 */
+export function getCindyModelContextWindow(modelId: string): number | null {
+  return buildCindyModelMetaIndex((base ?? BUNDLED_CATALOG).cindyModelMeta).get(modelId)?.contextWindow ?? null;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
@@ -30,9 +30,10 @@
  * 作废一切在途写回,并让新账号拉取不被旧 single-flight 吞掉。磁盘缓存写删经同一
  * 串行队列 + 原子 rename,保证登出删缓存不会被较早的 SDK 持久化反向覆盖。
  *
- * contextWindow 规则(Anthropic 无任何动态通道下发窗口,2026-07-19 与 Lizi 定案):
- *   HTTP 响应带 max_input_tokens 用之;否则默认 1M,仅 id 含 "haiku" 例外 200k。
- *   猜错 1M 的后果是该模型请求被拒(带 [1m] 后缀),由会话报错 + usage 校准暴露。
+ * contextWindow 规则:
+ *   HTTP 响应带 max_input_tokens 用之;否则读取当前 cindyModelMeta 的已知窗口；
+ *   目录未知时默认 1M,仅 id 含 "haiku" 例外 200k。这样已知旧模型不会被错误提升到
+ *   1M,未来新模型仍可在目录更新前按当代默认工作。
  *
  * 磁盘缓存:`<userData>/model-discovery/anthropic-models.json`
  * ({ fetchedAt, models, explicitEffortModelIds, explicitFastModeModelIds });只缓存动态获取的
@@ -48,6 +49,7 @@ import type { CatalogModel, Effort } from '@cindy/model-providers';
 import { createLogger } from '../../logger.js';
 import {
   getActiveCatalog,
+  getCindyModelContextWindow,
   getCindyModelEffortBaseline,
   setAnthropicDiscoveredModels,
 } from '../active-catalog.js';
@@ -102,9 +104,11 @@ function normalizeModelId(raw: string): string {
   return raw.replace(/-20\d{6}$/, '');
 }
 
-/** contextWindow 规则:默认 1M,仅 haiku 系例外 200k(定案见文件头)。 */
+/** contextWindow 规则:HTTP 明示 > 目录已知值 > 未知模型启发式(默认 1M,Haiku 200k)。 */
 function contextWindowFor(id: string, explicit?: number): number {
   if (typeof explicit === 'number' && explicit > 0) return explicit;
+  const catalogWindow = getCindyModelContextWindow(id);
+  if (catalogWindow !== null) return catalogWindow;
   return /haiku/.test(id) ? 200_000 : 1_000_000;
 }
 

--- a/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
@@ -219,11 +219,17 @@ export interface SdkMappedModel {
   hasFastModeInfo: boolean;
 }
 
-/** 动态通道无能力信息时:产品目录基线优先,未知模型才合成 3 档(haiku 0 档)。 */
+/**
+ * 动态通道无能力信息时:产品目录基线优先；未知非 Haiku 模型按当代旗舰能力合成
+ * 5 档，让新 Opus / Sonnet 上线后无需等客户端目录更新即可使用 xhigh / max。
+ * Haiku 保持 0 档；上游后续明确返回能力时仍会逐字段覆盖此临时基线。
+ */
 function fallbackEffortBaseline(id: string): { efforts: Effort[]; defaultEffort: Effort | null } {
   const catalogBaseline = getCindyModelEffortBaseline(id);
   if (catalogBaseline) return catalogBaseline;
-  const efforts: Effort[] = /haiku/.test(id) ? [] : ['low', 'medium', 'high'];
+  const efforts: Effort[] = /haiku/.test(id)
+    ? []
+    : ['low', 'medium', 'high', 'xhigh', 'max'];
   return { efforts, defaultEffort: pickDefaultEffort(efforts) };
 }
 
@@ -360,8 +366,8 @@ function mergeCapabilitiesWithPrevious(
 /**
  * HTTP `GET /v1/models` 单页条目数组 → 映射结果。纯函数,对响应形状容错:
  * 能力字段(capabilities.efforts / fast_mode)是 Anthropic 侧未固化的扩展,逐字段识别；
- * effort 认不出时按 cindyModelMeta 能力基线合成,目录也没有才回落 3 档
- * (low/medium/high,默认 high),haiku 系例外 0 档。fastMode 未知时先为 false,
+ * effort 认不出时按 cindyModelMeta 能力基线合成,目录也没有才回落当代旗舰 5 档
+ * (low/medium/high/xhigh/max,默认 high),haiku 系例外 0 档。fastMode 未知时先为 false,
  * 合并阶段会保留已明确探测过的旧值。
  */
 export function mapAnthropicHttpModels(raw: unknown): HttpMappedModel[] {

--- a/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
@@ -543,7 +543,14 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
         Array.isArray((m as CatalogModel).efforts),
     );
     if (valid.length === 0) return;
-    const validIds = new Set(valid.map((model) => model.id));
+    // Cache versions before explicitWindows did not distinguish an HTTP-declared
+    // window from the mapper's old fallback. Recompute only non-explicit windows
+    // so catalog corrections take effect immediately after an app upgrade.
+    const normalized = valid.map((model) => ({
+      ...model,
+      contextWindow: contextWindowFor(model.id, explicitWindows.get(model.id)),
+    }));
+    const validIds = new Set(normalized.map((model) => model.id));
     const restoreIds = (value: unknown): Set<string> => {
       const restored = new Set<string>();
       if (Array.isArray(value)) {
@@ -562,13 +569,13 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
       (raw as { explicitFastModeModelIds?: unknown }).explicitFastModeModelIds,
     );
     await applyModels(
-      valid,
+      normalized,
       false,
       generation,
       restoredExplicitEffortIds,
       restoredExplicitFastModeIds,
     );
-    log.info(`anthropic models loaded from disk cache: ${valid.length}`);
+    log.info(`anthropic models loaded from disk cache: ${normalized.length}`);
   } catch {
     /* 缓存缺失 / 损坏:等动态通道,不影响启动 */
   }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5291,7 +5291,7 @@
     "low": "Low",
     "medium": "Medium",
     "high": "High",
-    "xhigh": "Extra",
+    "xhigh": "Extra High",
     "max": "Max",
     "ultra": "Ultra"
   },

--- a/docs/legal/notices/THIRD-PARTY-RESTRICTED.txt
+++ b/docs/legal/notices/THIRD-PARTY-RESTRICTED.txt
@@ -7,7 +7,7 @@ Cindy project distributions
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.215
+Claude Code CLI@2.1.219
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/desktop-linux-restricted.txt
+++ b/docs/legal/notices/desktop-linux-restricted.txt
@@ -7,7 +7,7 @@ Cindy desktop application — Linux x64 glibc
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.215
+Claude Code CLI@2.1.219
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/desktop-macos-restricted.txt
+++ b/docs/legal/notices/desktop-macos-restricted.txt
@@ -7,7 +7,7 @@ Cindy desktop application — macOS x64/arm64
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.215
+Claude Code CLI@2.1.219
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/desktop-win-restricted.txt
+++ b/docs/legal/notices/desktop-win-restricted.txt
@@ -7,7 +7,7 @@ Cindy desktop application — Windows x64
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.215
+Claude Code CLI@2.1.219
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
@@ -121,6 +121,7 @@ describe('ClaudeCodeAgent model capabilities', () => {
 
   it('falls back to the legacy hardcoded chain when window is unknown', () => {
     // 目录外模型 / 未传窗口的老调用方(title-one-shot)行为不变
+    expect(toSdkModelString('claude-opus-5')).toBe('claude-opus-5[1m]');
     expect(toSdkModelString('claude-sonnet-5')).toBe('claude-sonnet-5[1m]');
     expect(toSdkModelString('codex/gpt-5.5')).toBe('codex/gpt-5.5');
     expect(toSdkModelString('totally-unknown-model')).toBe('totally-unknown-model');

--- a/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
@@ -51,6 +51,17 @@ describe('ClaudeCodeAgent model capabilities', () => {
     expect(agent.capabilities.availableModels).toEqual([]);
   });
 
+  it('uses unambiguous display names for every Anthropic effort level', () => {
+    const agent = new ClaudeCodeAgent(createDeps());
+    expect(agent.capabilities.effortLevels.map(({ id, displayName }) => [id, displayName])).toEqual([
+      ['low', 'Low'],
+      ['medium', 'Medium'],
+      ['high', 'High'],
+      ['xhigh', 'Extra High'],
+      ['max', 'Max'],
+    ]);
+  });
+
   // sonnet 必须映射到显式版本号:裸 'sonnet[1m]' 别名会随 cc-code 二进制漂移
   // (Sonnet 5 上线后别名仍指 4.6,用户选 Sonnet 5 实际发出 claude-sonnet-4-6)。
   it('maps every catalog sonnet model to its explicit versioned SDK string', () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -281,6 +281,20 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     await handle.close();
   });
 
+  it('does not retry max when applyFlagSettings fails at the transport layer', async () => {
+    const { handle, firstQuery } = await startRewindableSession();
+    firstQuery.applyFlagSettings.mockRejectedValueOnce(
+      new Error('ProcessTransport is not ready for writing'),
+    );
+
+    await expect(handle.setEffort?.('max')).rejects.toThrow(
+      'ProcessTransport is not ready for writing',
+    );
+    expect(firstQuery.applyFlagSettings).toHaveBeenCalledTimes(1);
+
+    await handle.close();
+  });
+
   it('does not retry failures for non-max effort levels', async () => {
     const { handle, firstQuery } = await startRewindableSession();
     firstQuery.applyFlagSettings.mockRejectedValueOnce(new Error('transport failed'));

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -61,7 +61,7 @@ const TEST_MODELS: ModelDescriptor[] = [
     id: 'claude-sonnet-5',
     displayName: 'Claude Sonnet 5',
     contextWindow: 500_000,
-    efforts: ['low', 'medium', 'high'],
+    efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
     defaultEffort: 'high',
   },
 ];
@@ -237,6 +237,35 @@ afterEach(async () => {
 });
 
 describe('ClaudeCodeAgent runtime settings during rewind window', () => {
+  it('passes max through when changing effort in a live Sonnet 5 session', async () => {
+    const { handle, firstQuery } = await startRewindableSession();
+
+    await handle.setModel?.('claude-sonnet-5');
+    await handle.setEffort?.('max');
+
+    expect(firstQuery.applyFlagSettings).toHaveBeenLastCalledWith({ effortLevel: 'max' });
+
+    await handle.close();
+  });
+
+  it('replays max without downgrading it when effort changes during query rebuild', async () => {
+    const { handle } = await startRewindableSession();
+    await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');
+
+    const secondQuery = createFakeQuery();
+    sdkMock.query.mockImplementationOnce(() => {
+      void handle.setModel?.('claude-sonnet-5');
+      void handle.setEffort?.('max');
+      return secondQuery;
+    });
+
+    await handle.send({ type: 'user', content: 'use max after rewind' });
+
+    expect(secondQuery.applyFlagSettings).toHaveBeenCalledWith({ effortLevel: 'max' });
+
+    await handle.close();
+  });
+
   it('setModel / setEffort / setFastMode / setPermissionMode skip the closed query and apply on rebuild', async () => {
     const { handle, firstQuery } = await startRewindableSession();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -54,7 +54,7 @@ const TEST_MODELS: ModelDescriptor[] = [
     id: 'claude-opus-4-6',
     displayName: 'Claude Opus 4.6',
     contextWindow: 1_000_000,
-    efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+    efforts: ['low', 'medium', 'high', 'max'],
     defaultEffort: 'high',
   },
   {
@@ -244,6 +244,49 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     await handle.setEffort?.('max');
 
     expect(firstQuery.applyFlagSettings).toHaveBeenLastCalledWith({ effortLevel: 'max' });
+
+    await handle.close();
+  });
+
+  it('falls back to the model-supported xhigh when an older runtime rejects max', async () => {
+    const { handle, firstQuery } = await startRewindableSession();
+    firstQuery.applyFlagSettings
+      .mockRejectedValueOnce(new Error('invalid effortLevel: max'))
+      .mockResolvedValueOnce(undefined);
+
+    await handle.setModel?.('claude-sonnet-5');
+    await expect(handle.setEffort?.('max')).resolves.toBeUndefined();
+
+    expect(firstQuery.applyFlagSettings.mock.calls.slice(-2)).toEqual([
+      [{ effortLevel: 'max' }],
+      [{ effortLevel: 'xhigh' }],
+    ]);
+
+    await handle.close();
+  });
+
+  it('falls back to high when the selected model does not support xhigh', async () => {
+    const { handle, firstQuery } = await startRewindableSession();
+    firstQuery.applyFlagSettings
+      .mockRejectedValueOnce(new Error('invalid effortLevel: max'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(handle.setEffort?.('max')).resolves.toBeUndefined();
+
+    expect(firstQuery.applyFlagSettings.mock.calls.slice(-2)).toEqual([
+      [{ effortLevel: 'max' }],
+      [{ effortLevel: 'high' }],
+    ]);
+
+    await handle.close();
+  });
+
+  it('does not retry failures for non-max effort levels', async () => {
+    const { handle, firstQuery } = await startRewindableSession();
+    firstQuery.applyFlagSettings.mockRejectedValueOnce(new Error('transport failed'));
+
+    await expect(handle.setEffort?.('high')).rejects.toThrow('transport failed');
+    expect(firstQuery.applyFlagSettings).toHaveBeenCalledTimes(1);
 
     await handle.close();
   });

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -371,11 +371,11 @@ const WAKE_BACKGROUND_TASK_TYPES: ReadonlySet<string> = new Set(['local_agent', 
 // (见 apps/desktop/src/main/maker-host/catalog-to-descriptors.ts)。
 
 const CLAUDE_EFFORTS: EffortDescriptor[] = [
-  { id: 'low',    displayName: 'Low',    description: 'Fast responses with minimal reasoning' },
-  { id: 'medium', displayName: 'Medium', description: 'Balanced reasoning depth' },
-  { id: 'high',   displayName: 'High',   description: 'Deeper reasoning for harder tasks' },
-  { id: 'xhigh',  displayName: 'Extra',  description: 'Extended reasoning (Opus only)' },
-  { id: 'max',    displayName: 'Max',    description: 'Maximum reasoning budget' },
+  { id: 'low',    displayName: 'Low',        description: 'Most efficient, with lower token use' },
+  { id: 'medium', displayName: 'Medium',     description: 'Balanced capability and token use' },
+  { id: 'high',   displayName: 'High',       description: 'High capability for complex work' },
+  { id: 'xhigh',  displayName: 'Extra High', description: 'Extended capability for long-horizon work' },
+  { id: 'max',    displayName: 'Max',        description: 'Maximum capability with unconstrained token use' },
 ];
 
 // 注: plan 不再作为权限档暴露 —— 计划模式已独立成 Capabilities.planMode 一级开关

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -213,6 +213,13 @@ function clampEffortForClaude(e: Effort): ClaudeSdkEffort {
   return e;
 }
 
+async function applyClaudeEffortFlagSettings(q: Query, effort: ClaudeSdkEffort): Promise<void> {
+  // Claude Code 2.1.219 accepts session-scoped `max` through apply_flag_settings.
+  // The pinned Agent SDK's persisted Settings type still omits `max`, so keep
+  // the compatibility cast isolated at this control-protocol boundary.
+  await q.applyFlagSettings({ effortLevel: effort } as Settings);
+}
+
 function rawMentionText(block: { path: string; kind?: 'file' | 'dir' | 'agent' }): string {
   const suffix = block.kind === 'dir' && !block.path.endsWith('/') ? '/' : '';
   return `@${block.path}${suffix}`;
@@ -2748,10 +2755,9 @@ export class ClaudeCodeAgent extends BaseAgent {
           replayed = true;
           const targetEffort = mutableEffort;
           const sdkEffort = getSdkEffortForModel(mutableModel, targetEffort);
-          const clamped = sdkEffort === 'max' ? 'xhigh' : sdkEffort;
-          if (clamped) {
+          if (sdkEffort) {
             try {
-              await q.applyFlagSettings({ effortLevel: clamped });
+              await applyClaudeEffortFlagSettings(q, sdkEffort);
               log.debug(`${label}: replayed setEffort`, { effort: targetEffort });
             } catch (e) {
               log.warn(`${label}: replay setEffort failed`, { error: String(e) });
@@ -3400,18 +3406,17 @@ export class ClaudeCodeAgent extends BaseAgent {
       },
 
       async setEffort(newEffort: Effort) {
-        // applyFlagSettings 不接受 'max' / 'minimal' —— clamp 同 startSession 时
-        // 'minimal' 降 'low', 'max' 降 'xhigh' (最接近的 runtime 可设值)
+        // maker 的 minimal / ultra 先归一成 Claude 的 low / max；2.1.219 起
+        // applyFlagSettings 可原样接收 max，不能再静默降成 xhigh。
         const sdkEffort = getSdkEffortForModel(mutableModel, newEffort);
-        const clamped = sdkEffort === 'max' ? 'xhigh' : sdkEffort;
         const isControlBlocked = controlRequestsBlocked();
-        log.debug('setEffort', { from: mutableEffort, to: newEffort, sdk: clamped, controlRequestsBlocked: isControlBlocked });
-        if (!clamped) {
+        log.debug('setEffort', { from: mutableEffort, to: newEffort, sdk: sdkEffort, controlRequestsBlocked: isControlBlocked });
+        if (!sdkEffort) {
           mutableEffort = newEffort;
           return;
         }
         if (!isControlBlocked) {
-          await q.applyFlagSettings({ effortLevel: clamped });
+          await applyClaudeEffortFlagSettings(q, sdkEffort);
         }
         mutableEffort = newEffort;
       },

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -213,11 +213,22 @@ function clampEffortForClaude(e: Effort): ClaudeSdkEffort {
   return e;
 }
 
-async function applyClaudeEffortFlagSettings(q: Query, effort: ClaudeSdkEffort): Promise<void> {
+async function applyClaudeEffortFlagSettings(
+  q: Query,
+  effort: ClaudeSdkEffort,
+  maxFallback: Exclude<ClaudeSdkEffort, 'max'>,
+): Promise<ClaudeSdkEffort> {
   // Claude Code 2.1.219 accepts session-scoped `max` through apply_flag_settings.
-  // The pinned Agent SDK's persisted Settings type still omits `max`, so keep
-  // the compatibility cast isolated at this control-protocol boundary.
-  await q.applyFlagSettings({ effortLevel: effort } as Settings);
+  // Linux may still use an older system binary, so retry only a rejected `max`
+  // with the best lower effort supported by the selected model.
+  try {
+    await q.applyFlagSettings({ effortLevel: effort } as Settings);
+    return effort;
+  } catch (error) {
+    if (effort !== 'max') throw error;
+    await q.applyFlagSettings({ effortLevel: maxFallback } as Settings);
+    return maxFallback;
+  }
 }
 
 function rawMentionText(block: { path: string; kind?: 'file' | 'dir' | 'agent' }): string {
@@ -489,6 +500,16 @@ export class ClaudeCodeAgent extends BaseAgent {
     const descriptor = this.capabilities.availableModels.find((m) => m.id === model);
     if (descriptor && descriptor.efforts.length === 0) return undefined;
     return clampEffortForClaude(effort);
+  }
+
+  private sdkMaxEffortFallbackForModel(model: string): Exclude<ClaudeSdkEffort, 'max'> {
+    const descriptor = this.capabilities.availableModels.find((m) => m.id === model);
+    if (!descriptor) return 'xhigh';
+    const supported = new Set(descriptor.efforts.map(clampEffortForClaude));
+    for (const candidate of ['xhigh', 'high', 'medium', 'low'] as const) {
+      if (supported.has(candidate)) return candidate;
+    }
+    return 'high';
   }
 
   /**
@@ -1089,6 +1110,8 @@ export class ClaudeCodeAgent extends BaseAgent {
     const enableFileCheckpointing = this.capabilities.rewind.supported;
     const getSdkEffortForModel = (model: string, effort: Effort) =>
       this.sdkEffortForModel(model, effort);
+    const getSdkMaxEffortFallbackForModel = (model: string) =>
+      this.sdkMaxEffortFallbackForModel(model);
 
     // memoryOverride 闭包以前抽过 getter, buildSettings 接管后直接读 this.memoryOverride。
 
@@ -2757,8 +2780,16 @@ export class ClaudeCodeAgent extends BaseAgent {
           const sdkEffort = getSdkEffortForModel(mutableModel, targetEffort);
           if (sdkEffort) {
             try {
-              await applyClaudeEffortFlagSettings(q, sdkEffort);
-              log.debug(`${label}: replayed setEffort`, { effort: targetEffort });
+              const appliedEffort = await applyClaudeEffortFlagSettings(
+                q,
+                sdkEffort,
+                getSdkMaxEffortFallbackForModel(mutableModel),
+              );
+              log.debug(`${label}: replayed setEffort`, {
+                effort: targetEffort,
+                sdk: appliedEffort,
+                downgraded: appliedEffort !== sdkEffort,
+              });
             } catch (e) {
               log.warn(`${label}: replay setEffort failed`, { error: String(e) });
             }
@@ -3416,7 +3447,18 @@ export class ClaudeCodeAgent extends BaseAgent {
           return;
         }
         if (!isControlBlocked) {
-          await applyClaudeEffortFlagSettings(q, sdkEffort);
+          const appliedEffort = await applyClaudeEffortFlagSettings(
+            q,
+            sdkEffort,
+            getSdkMaxEffortFallbackForModel(mutableModel),
+          );
+          if (appliedEffort !== sdkEffort) {
+            log.warn('setEffort: runtime rejected max; applied model-compatible fallback', {
+              model: mutableModel,
+              requested: sdkEffort,
+              applied: appliedEffort,
+            });
+          }
         }
         mutableEffort = newEffort;
       },

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -213,19 +213,32 @@ function clampEffortForClaude(e: Effort): ClaudeSdkEffort {
   return e;
 }
 
+function isUnsupportedClaudeEffortError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  return (
+    /effort(?:Level|[ _-]level)/i.test(message) &&
+    /\b(?:invalid|unsupported|not supported|unknown|unrecognized)\b/i.test(message)
+  );
+}
+
 async function applyClaudeEffortFlagSettings(
   q: Query,
   effort: ClaudeSdkEffort,
   maxFallback: Exclude<ClaudeSdkEffort, 'max'>,
 ): Promise<ClaudeSdkEffort> {
   // Claude Code 2.1.219 accepts session-scoped `max` through apply_flag_settings.
-  // Linux may still use an older system binary, so retry only a rejected `max`
-  // with the best lower effort supported by the selected model.
+  // Only an explicit effort-level rejection is compatibility evidence; transport
+  // and process failures must keep their original failure semantics.
   try {
     await q.applyFlagSettings({ effortLevel: effort } as Settings);
     return effort;
   } catch (error) {
-    if (effort !== 'max') throw error;
+    if (effort !== 'max' || !isUnsupportedClaudeEffortError(error)) throw error;
     await q.applyFlagSettings({ effortLevel: maxFallback } as Settings);
     return maxFallback;
   }

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -124,6 +124,7 @@ export function toSdkModelString(model: string, contextWindow?: number | null): 
 
 /** 目录窗口未知时的兜底映射链(与窗口规则引入前一致;haiku 日期重写已移除,见函数头)。 */
 function legacyToSdkModelString(model: string): string {
+  if (model === 'claude-opus-5') return 'claude-opus-5[1m]';
   if (model.includes('opus-4-8')) return 'claude-opus-4-8[1m]';
   if (model.includes('opus-4-7')) return 'claude-opus-4-7[1m]';
   if (model.includes('opus-4-6')) return 'claude-opus-4-6[1m]';

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -620,7 +620,7 @@ const CODEX_EFFORTS: EffortDescriptor[] = [
   { id: 'low', displayName: 'Low', description: 'Fast responses with minimal reasoning' },
   { id: 'medium', displayName: 'Medium', description: 'Balanced reasoning depth' },
   { id: 'high', displayName: 'High', description: 'Deeper reasoning for harder tasks' },
-  { id: 'xhigh', displayName: 'Extra', description: 'Extended reasoning budget' },
+  { id: 'xhigh', displayName: 'Extra High', description: 'Extended reasoning budget' },
   // max/ultra 仅部分模型支持(如 GPT-5.6 Sol);实际是否可选由该模型目录 efforts 决定,
   // 这里只提供 agent 级档名/描述兜底(桌面 i18n effortLevels.* 优先)。
   { id: 'max', displayName: 'Max', description: 'Very high reasoning budget (model-dependent)' },

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -740,7 +740,7 @@
         "name": "Sonnet 4.5",
         "group": "anthropic",
         "description": "Earlier Sonnet generation",
-        "contextWindow": 1000000,
+        "contextWindow": 200000,
         "efforts": [],
         "defaultEffort": null,
         "sortOrder": 8,

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -581,6 +581,25 @@
   "cindyModelMeta": {
     "version": 1,
     "models": {
+      "claude-opus-5": {
+        "agents": [
+          "claude-code"
+        ],
+        "name": "Opus 5",
+        "group": "anthropic",
+        "description": "Latest Opus for ambitious work",
+        "contextWindow": 1000000,
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "defaultEffort": "high",
+        "sortOrder": 0,
+        "supportsFastMode": false
+      },
       "claude-fable-5": {
         "agents": [
           "claude-code"
@@ -597,7 +616,7 @@
           "max"
         ],
         "defaultEffort": "high",
-        "sortOrder": 0,
+        "sortOrder": 1,
         "supportsFastMode": false
       },
       "claude-opus-4-8": {
@@ -616,7 +635,7 @@
           "max"
         ],
         "defaultEffort": "high",
-        "sortOrder": 1,
+        "sortOrder": 2,
         "supportsFastMode": false
       },
       "claude-opus-4-7": {
@@ -635,7 +654,7 @@
           "max"
         ],
         "defaultEffort": "high",
-        "sortOrder": 2,
+        "sortOrder": 3,
         "supportsFastMode": false,
         "defaultEnabled": false
       },
@@ -654,7 +673,25 @@
           "max"
         ],
         "defaultEffort": "high",
-        "sortOrder": 3,
+        "sortOrder": 4,
+        "supportsFastMode": false,
+        "defaultEnabled": false
+      },
+      "claude-opus-4-5": {
+        "agents": [
+          "claude-code"
+        ],
+        "name": "Opus 4.5",
+        "group": "anthropic",
+        "description": "Earlier Opus generation",
+        "contextWindow": 200000,
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "defaultEffort": "high",
+        "sortOrder": 5,
         "supportsFastMode": false,
         "defaultEnabled": false
       },
@@ -669,10 +706,12 @@
         "efforts": [
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh",
+          "max"
         ],
         "defaultEffort": "high",
-        "sortOrder": 4,
+        "sortOrder": 6,
         "supportsFastMode": false
       },
       "claude-sonnet-4-6": {
@@ -686,10 +725,25 @@
         "efforts": [
           "low",
           "medium",
-          "high"
+          "high",
+          "max"
         ],
         "defaultEffort": "high",
-        "sortOrder": 5,
+        "sortOrder": 7,
+        "supportsFastMode": false,
+        "defaultEnabled": false
+      },
+      "claude-sonnet-4-5": {
+        "agents": [
+          "claude-code"
+        ],
+        "name": "Sonnet 4.5",
+        "group": "anthropic",
+        "description": "Earlier Sonnet generation",
+        "contextWindow": 1000000,
+        "efforts": [],
+        "defaultEffort": null,
+        "sortOrder": 8,
         "supportsFastMode": false,
         "defaultEnabled": false
       },
@@ -702,7 +756,8 @@
         "description": "Fastest for quick answers",
         "contextWindow": 200000,
         "efforts": [],
-        "sortOrder": 6,
+        "defaultEffort": null,
+        "sortOrder": 9,
         "supportsFastMode": false,
         "defaultEnabled": false
       },

--- a/tools/claude/latest.json
+++ b/tools/claude/latest.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.215",
+  "version": "2.1.219",
   "author": {
     "name": "Anthropic",
     "email": "support@anthropic.com"
   },
   "license": "SEE LICENSE IN README.md",
-  "_id": "@anthropic-ai/claude-code@2.1.215",
+  "_id": "@anthropic-ai/claude-code@2.1.219",
   "maintainers": [
     {
       "name": "zak-anthropic",
@@ -69,34 +69,26 @@
     "claude": "bin/claude.exe"
   },
   "dist": {
-    "shasum": "c349d13afa43e6cf6f147f36bec121dc9824ed89",
-    "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.215.tgz",
+    "shasum": "7849f29b80da65065a14f16d520a7f8c433f895b",
+    "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.219.tgz",
     "fileCount": 7,
-    "integrity": "sha512-lsWBvyMyBqg/rOZ06o/HEhlpOzHsH8IBf9RH4u5gzizQ1LWS/oXAh5nqWNUu3hn2d8QkyYg0aseNzMDlGD+3qg==",
+    "integrity": "sha512-6PVBrRsKHFi0gzv5bCabVL+XSqI3F8AR6ekFx4gpzdE5a9XotqewolID0PbcdD9IyWVYCIDET4GDCcUdA89i3Q==",
     "signatures": [
       {
-        "sig": "MEUCIDMhAnHnwQOkVShX93Vrlg1V0yWFmKoxXZEO2vaxoF2JAiEAiIPDb+5n1XvwFBJcQP3COvZVkZ8qfqzEFP0W4VmUOjk=",
+        "sig": "MEQCIG75mrsMxC3YQTnCcPmBeHwr1f9g7ePFmyx5w2CXKvG4AiAhugEXOCz+p4i9ah/rKGNQ7W6bD1P91J1ZN9KRzVJdSg==",
+        "keyid": "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"
+      },
+      {
+        "sig": "MEUCIQCWsFSESf0pIESXKkYOlZvGH6SGYGzsslI7QD7g/aeEYwIgHlgHLYRj4GcQ51PyprSajcWQk0yZ7B34NupQZ6b6eWQ=",
         "keyid": "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"
       }
     ],
-    "unpackedSize": 165282
+    "unpackedSize": 165478
   },
   "type": "module",
-  "_from": "file:staged-npm/anthropic-ai-claude-code-2.1.215.tgz",
+  "_from": "file:staged-npm/anthropic-ai-claude-code-2.1.219.tgz",
   "engines": {
     "node": ">=22.0.0"
-  },
-  "runtimeAssets": {
-    "linux-x64": {
-      "url": "https://downloads.claude.ai/claude-code-releases/2.1.215/linux-x64/claude",
-      "sha256": "c1efffaaf370aa187cb6a09dd93d4e511c646899b0078476f83791b664bde7fe",
-      "size": 265239536
-    },
-    "linux-arm64": {
-      "url": "https://downloads.claude.ai/claude-code-releases/2.1.215/linux-arm64/claude",
-      "sha256": "2b43a3d5b0787217e5d7381fad42c7314292546fe9db9eb8b9b379de90509b30",
-      "size": 262060960
-    }
   },
   "scripts": {
     "prepare": "node -e \"if (!process.env.AUTHORIZED) { console.error('ERROR: Direct publishing is not allowed.\\nPlease see the release workflow documentation to publish this package.'); process.exit(1); }\"",
@@ -106,26 +98,54 @@
     "name": "wolffiex",
     "email": "wolffiex@anthropic.com"
   },
-  "_resolved": "/home/runner/work/claude-cli-internal/claude-cli-internal/staged-npm/anthropic-ai-claude-code-2.1.215.tgz",
-  "_integrity": "sha512-lsWBvyMyBqg/rOZ06o/HEhlpOzHsH8IBf9RH4u5gzizQ1LWS/oXAh5nqWNUu3hn2d8QkyYg0aseNzMDlGD+3qg==",
+  "_resolved": "/home/runner/work/claude-cli-internal/claude-cli-internal/staged-npm/anthropic-ai-claude-code-2.1.219.tgz",
+  "_integrity": "sha512-6PVBrRsKHFi0gzv5bCabVL+XSqI3F8AR6ekFx4gpzdE5a9XotqewolID0PbcdD9IyWVYCIDET4GDCcUdA89i3Q==",
   "_npmVersion": "11.16.0",
   "description": "Use Claude, Anthropic's AI assistant, right from your terminal. Claude can understand your codebase, edit files, run terminal commands, and handle entire workflows for you.",
   "directories": {},
   "_nodeVersion": "24.18.0",
   "dependencies": {},
   "_hasShrinkwrap": false,
+  "readmeFilename": "README.md",
   "optionalDependencies": {
-    "@anthropic-ai/claude-code-linux-x64": "2.1.215",
-    "@anthropic-ai/claude-code-win32-x64": "2.1.215",
-    "@anthropic-ai/claude-code-darwin-x64": "2.1.215",
-    "@anthropic-ai/claude-code-linux-arm64": "2.1.215",
-    "@anthropic-ai/claude-code-win32-arm64": "2.1.215",
-    "@anthropic-ai/claude-code-darwin-arm64": "2.1.215",
-    "@anthropic-ai/claude-code-linux-x64-musl": "2.1.215",
-    "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.215"
+    "@anthropic-ai/claude-code-linux-x64": "2.1.219",
+    "@anthropic-ai/claude-code-win32-x64": "2.1.219",
+    "@anthropic-ai/claude-code-darwin-x64": "2.1.219",
+    "@anthropic-ai/claude-code-linux-arm64": "2.1.219",
+    "@anthropic-ai/claude-code-win32-arm64": "2.1.219",
+    "@anthropic-ai/claude-code-darwin-arm64": "2.1.219",
+    "@anthropic-ai/claude-code-linux-x64-musl": "2.1.219",
+    "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.219"
   },
   "_npmOperationalInternal": {
-    "tmp": "tmp/claude-code_2.1.215_1784422417038_0.7779043961753329",
+    "tmp": "tmp/claude-code_2.1.219_1784909509727_0.3364890058271168",
     "host": "s3://npm-registry-packages-npm-production"
+  },
+  "runtimeAssets": {
+    "darwin-arm64": {
+      "url": "https://downloads.claude.ai/claude-code-releases/2.1.219/darwin-arm64/claude",
+      "sha256": "a8e806faaefac53c7a0f26523d8a45c60dbef3407b14ef990c75765d08febc82",
+      "size": 256908272
+    },
+    "darwin-x64": {
+      "url": "https://downloads.claude.ai/claude-code-releases/2.1.219/darwin-x64/claude",
+      "sha256": "03be9f988ed88391b4a5f08e4c5dc317ce2fffa4a9dc66c01106326e7698ee76",
+      "size": 266381200
+    },
+    "linux-x64": {
+      "url": "https://downloads.claude.ai/claude-code-releases/2.1.219/linux-x64/claude",
+      "sha256": "22cfd6f5b3061c0391ba84e9cf8c9deaa37783aac18b004d42ec061e98f00691",
+      "size": 275004400
+    },
+    "linux-arm64": {
+      "url": "https://downloads.claude.ai/claude-code-releases/2.1.219/linux-arm64/claude",
+      "sha256": "1f834b322ba9d1291cc7ffeff16a6795a59145bda279dbd59cd7ecebc7b7f15a",
+      "size": 271825824
+    },
+    "win32-x64": {
+      "url": "https://downloads.claude.ai/claude-code-releases/2.1.219/win32-x64/claude.exe",
+      "sha256": "10f4c1f85b07f3cf6b8fff930fd26ecd475bd146a378acfafa559a6db9d89637",
+      "size": 265714848
+    }
   }
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

整理 Anthropic 动态模型的产品元数据，并按 Anthropic 官方文档补齐能力、上下文窗口与运行时支持：

- 去掉模型展示名里重复的 `Claude` 前缀，新增并排序 Opus 5、Sonnet 5 等当前授权模型
- 为 Opus 5、Sonnet 5 补齐 `xhigh` / `max`，为 Opus 4.6、Sonnet 4.6 补齐 `max`
- Opus 4.5 按官方 effort 手册保留 `low` / `medium` / `high`；Sonnet 4.5、Haiku 4.5 不显示不支持的 effort 控件
- Sonnet 5 在 live session 和 rewind replay 中优先原样传递 `max`；只有 runtime 明确返回 effort 档位不支持时才按模型能力回退到 `xhigh` 或 `high`，传输或进程错误保持原错误
- 目录未知且上游未声明 capability 的非 Haiku 新模型临时开放五档，避免每次新模型上线都等待客户端更新
- 将英文 `xhigh` 展示名从含糊的 `Extra` 统一为 `Extra High`
- 动态发现按 HTTP `max_input_tokens` > `cindyModelMeta` > 未知模型启发式确定窗口，磁盘缓存中的非明确窗口也会按当前目录重新归一化，避免 Opus 4.5 / Sonnet 4.5 被旧缓存误判为 1M
- 远端 v1 `cindyModelMeta` 缺模型或字段时逐字段回落 bundled v1；完全未携带 metadata 时也回落 bundled，坏信封或非 v1 信封仍整段忽略
- effective metadata index 使用进程级惰性缓存，并随 active catalog revision 失效，避免动态发现按模型重复构建索引
- 补齐 Opus 5 在目录窗口缺失时的 `[1m]` SDK fallback
- 将 bundled Claude Code 从 `2.1.215` 升级到首个支持 Opus 5 的 `2.1.219`，并让 packaged Linux 只复用不低于该 pin 的稳定版 system Claude runtime
- 重新生成 restricted notices，并增加模型名称、排序、默认可见性、effort、窗口、runtime pin 与 Linux fallback 回归测试

官方依据：

- https://platform.claude.com/docs/en/build-with-claude/effort
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://code.claude.com/docs/en/changelog
- https://code.claude.com/docs/en/model-config

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Anthropic 授权清单新增 Opus 5 后的模型名称与 effort 能力更新
- 本 PR 包含：Anthropic 动态模型元数据、上下文窗口 fallback、effort 通用展示名、Claude Code runtime pin、Linux runtime version gate、受限组件声明和相应回归测试
- 明确不包含：授权流程、上游接口协议、服务端改动
- 用户可见变化：Anthropic 模型名称更整齐；支持的模型显示并实际执行正确的 `xhigh` / `max` 档位；旧 200k 模型不再误走 1M 通道；bundled runtime 可实际启动 Opus 5
- 是否存在 breaking change：无

### UI 变化

没有新增或修改 UI 组件、布局、样式或交互；既有模型选择器读取的模型名称、排序和 effort 文案会发生可见变化。

macOS Desktop 模型选择器：

<img width="250" height="340" alt="000-pr372-anthropic-model-menu" src="https://github.com/user-attachments/assets/b6413c8a-9aa2-43c1-aa3d-8688a663c8e2" />

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：通过，仓库全量单元测试门禁退出码 0

pnpm --filter desktop exec vitest run \
  src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts \
  src/main/agent-binaries/__tests__/linuxRuntimeMigration.test.ts \
  src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
结果：42 tests passed

pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
结果：36 tests passed

pnpm --filter @cindy/maker-core build
结果：通过

pnpm --filter desktop exec eslint <本次修改的 desktop 文件>
pnpm --filter @cindy/maker-core exec eslint <本次修改的 maker-core 文件>
结果：通过

pnpm --filter @cindy/model-providers test
结果：132 tests passed

pnpm check:i18n
结果：通过，四种语言 5389 个 key 一致；仅有仓库既有非阻塞警告

pnpm --filter @cindy/model-providers build
结果：通过

apps/claude-code-bin/darwin-arm64/claude --version
结果：2.1.219 (Claude Code)；下载内容通过官方 manifest SHA-256 校验

pnpm --filter desktop run --if-present typecheck
结果：未通过；同一 origin/main 可复现两处既有错误：
- src/main/cindy-brain/index.ts：requestNodeInstallAuthorization 未定义
- src/renderer/cindy-brain/__tests__/installFlow.test.tsx：canceled fixture 类型不匹配
```

`@cindy/maker-core` 和 `@cindy/model-providers` 没有 `typecheck` script，`--if-present` 正常跳过。

maker-core 核心指标评估：未改 system prompt、tool、translator、event loop 或 usage，不增加正常请求路径的网络往返，不影响事件吞吐与计量。模型路由准确性由 `toSdkModelString` 回归测试覆盖；live effort 回归测试确认 `max` 在即时切换与 rewind replay 两条控制路径都先原样发送，只在明确的 effort 档位拒绝时追加一次本地 control fallback，传输失败不重试。用户主动切换 effort 本就会改变后续请求的缓存前缀，本次不改变该缓存语义。

### 手工验证

在 macOS Desktop 打开 Anthropic 模型选择器，确认模型名称、排序和英文 `Extra High` 文案按新元数据呈现；效果见上方截图。

### 未执行的验证

未使用 Anthropic 授权账号发起真实 Opus 5 端到端请求；能力矩阵与窗口来自 Anthropic 官方文档，并由 SDK / HTTP 动态发现及 SDK wire/control 回归测试覆盖。未逐个平台下载并启动 2.1.219；各平台 URL、size 与 SHA-256 由官方 release manifest 生成，Linux / Windows 交付路径由 runtime fallback 测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：模型能力、SDK wire/control fallback 与 bundled Claude Code 版本

### 影响与回滚

- 影响范围：Anthropic 动态模型的名称、排序、默认可见性、effort 选项与上下文窗口；磁盘缓存窗口恢复；未知非 Haiku 模型的临时 effort 基线；通用英文 `xhigh` 展示词；live `max` 控制值及旧 runtime 回退；Opus 5 无目录窗口时的 SDK wire 字符串；bundled Claude Code runtime pin、packaged Linux system runtime 复用条件和 restricted notices
- 回滚 / 降级方式：回滚目录元数据、动态窗口 baseline、缓存归一化、远端 v1 元数据合并与缓存、未知模型 effort 兜底、live effort 透传/回退、Opus 5 legacy 映射、Linux runtime gate 与 `tools/claude/latest.json` pin；上游明确下发的 capability / `max_input_tokens` 始终优先

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（restricted notices 已由生成器更新）
- [x] 已确认测试结果或说明未执行原因
