### PR TITLE
fix(desktop): 语音录音时停止按钮改到语音键左边,消除位置跳变

### DIFF
--- a/apps/desktop/src/renderer/__tests__/voiceInputButtonAnchor.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputButtonAnchor.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const chatInputSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'new-chat', 'ChatInput.tsx'),
+  'utf8',
+).replace(/\r\n?/g, '\n');
+
+/**
+ * composer 右下按钮组右对齐,所以「语音按钮与最右主槽之间夹着几个按钮」直接决定语音按钮
+ * 自己的屏幕位置。次槽 Stop 只在 streaming 时出现,若它夹在语音与 Send 之间,语音按钮就会
+ * 随 streaming / 草稿 / 录音状态整格横跳,而它让出的位置正好被 Stop 占据 —— 用户点完语音想
+ * 「原地再点一下停止录音」会误停正在跑的任务。
+ * 约束:次槽 Stop 一律在语音按钮左边,语音按钮永远是主槽的左邻。
+ */
+describe('ChatInput voice button anchor contract', () => {
+  // 从次槽 Stop 起、到主槽 sendButtonRef 止,即右下按钮组里语音按钮所在的区间。
+  const buttonGroupBlock = extractBetween(
+    chatInputSource,
+    '{showSecondaryStop && (',
+    '<span ref={sendButtonRef}',
+  );
+
+  it('renders the secondary stop button to the left of the voice input button', () => {
+    const secondaryStopIndex = buttonGroupBlock.indexOf('<SendButton');
+    const voiceButtonIndex = buttonGroupBlock.indexOf('<VoiceInputButton');
+
+    expect(secondaryStopIndex).toBeGreaterThanOrEqual(0);
+    expect(voiceButtonIndex).toBeGreaterThan(secondaryStopIndex);
+  });
+
+  it('keeps the voice input button as the immediate left neighbour of the main send slot', () => {
+    const afterVoiceButton = buttonGroupBlock.slice(
+      buttonGroupBlock.indexOf('<VoiceInputButton'),
+    );
+
+    // 语音按钮与主槽之间不得再插入任何 Send/Stop 控件。
+    expect(afterVoiceButton).not.toContain('<SendButton');
+  });
+
+  it('does not fork the secondary stop placement on listening state', () => {
+    // 只在录音态挪 Stop 是不够的:录音结束且草稿非空时 Stop 会跳回右边,语音按钮同样
+    // 左移一格,只是把误点风险推迟到「刚点完停止录音」那一刻。
+    expect(chatInputSource).toContain(
+      'const showSecondaryStop =\n    showStopButton && (canSend || voiceInput.isBusy) && !sendDispatchInFlight;',
+    );
+    expect(chatInputSource).toContain(
+      'const mainSlotIsStop =\n    showStopButton && (sendDispatchInFlight || (!canSend && !voiceInput.isBusy));',
+    );
+  });
+
+  it('keeps the slot assignment stable across the whole voice lifecycle', () => {
+    // 停止录音 → submitting/refining → 草稿落地之间 canSend 仍为 false;若按 isListening
+    // 判定,这一段会退化成 streaming idle,Stop 弹回主槽再弹走,肉眼可见闪一下。
+    // isBusy = listening || submitting || refining,覆盖整段生命周期。
+    const slotDecisionBlock = extractBetween(
+      chatInputSource,
+      'const mainSlotIsStop =',
+      'useEffect(() => {\n    voiceInputCanStopAndSendRef.current = !sendButtonDisabled;',
+    );
+
+    expect(slotDecisionBlock).not.toContain('voiceInput.isListening');
+    expect(slotDecisionBlock).toContain('voiceInput.isBusy');
+  });
+});
+
+function extractBetween(sourceBlock: string, startNeedle: string, endNeedle: string): string {
+  const start = sourceBlock.indexOf(startNeedle);
+  const end = sourceBlock.indexOf(endNeedle, start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return sourceBlock.slice(start, end);
+}

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -4814,12 +4814,13 @@ export function ChatInput({
     voiceInput.state === 'submitting' ||
     voiceInput.state === 'refining',
   );
-  // Send / Stop 双槽语义:
+  // Send / Stop 双槽语义 (voice busy = voiceInput.isBusy = listening|submitting|refining,
+  // 判定为何用 isBusy 而不是 isListening 见下方第三段):
   // - 主槽 (最右, 永远占位, sendButtonRef 钉在这里):
   //     · 发送瞬间 (inflight=true) → Stop  (Send 原位被替换, 不抖左侧 layout)
-  //     · streaming idle (无内容 / 无 voice) → Stop  (取代 Send 占主槽)
-  //     · 其它 (idle / streaming+canSend / voice listening) → Send
-  // - 次槽 (语音按钮左边, 即本组最左; 仅 streaming+(canSend||listening)+!inflight 时出现): Stop
+  //     · streaming idle (无内容 且 无 voice busy) → Stop  (取代 Send 占主槽)
+  //     · 其它 (idle / streaming+canSend / voice busy) → Send
+  // - 次槽 (语音按钮左边, 即本组最左; 仅 streaming+(canSend||voice busy)+!inflight 时出现): Stop
   // 设计意图: Send 是最显眼的主行动按钮, 应当永远在最右; streaming idle 时由 Stop 顶替
   // Send 主槽 (原位替换, 不抖); streaming 中用户输入下一条要送入 PendingQueue 时, Send 回
   // 到主槽, Stop 退到次槽. sendDispatchInFlight 锁次槽, 避免 send 瞬间主槽 Send→Stop 切换

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -4814,6 +4814,33 @@ export function ChatInput({
     voiceInput.state === 'submitting' ||
     voiceInput.state === 'refining',
   );
+  // Send / Stop 双槽语义:
+  // - 主槽 (最右, 永远占位, sendButtonRef 钉在这里):
+  //     · 发送瞬间 (inflight=true) → Stop  (Send 原位被替换, 不抖左侧 layout)
+  //     · streaming idle (无内容 / 无 voice) → Stop  (取代 Send 占主槽)
+  //     · 其它 (idle / streaming+canSend / voice listening) → Send
+  // - 次槽 (语音按钮左边, 即本组最左; 仅 streaming+(canSend||listening)+!inflight 时出现): Stop
+  // 设计意图: Send 是最显眼的主行动按钮, 应当永远在最右; streaming idle 时由 Stop 顶替
+  // Send 主槽 (原位替换, 不抖); streaming 中用户输入下一条要送入 PendingQueue 时, Send 回
+  // 到主槽, Stop 退到次槽. sendDispatchInFlight 锁次槽, 避免 send 瞬间主槽 Send→Stop 切换
+  // 的同帧再多出一个 Stop 把模型选择推一下又复位的 bug.
+  //
+  // 次槽必须在语音按钮**左边**, 不能夹在语音与 Send 之间 (2026-07-25): 本组右对齐, 语音
+  // 按钮永远紧邻主槽左侧, 于是它的右边缘恒等于「容器右 - 主槽宽 - gap」, 与是否 streaming /
+  // 是否有草稿 / 是否录音全部无关 —— 录音时计时胶囊只向左生长, 原来的麦克风命中点始终留在
+  // 按钮内, 用户可以"原地再点一下"停止录音. 若把 Stop 塞进语音与 Send 之间, 语音按钮会随
+  // Stop 的出现/消失整格横跳, 而它让出的位置正好被 Stop 占据, 原地再点一下就会误停任务.
+  //
+  // 槽位判定用 isBusy 而不是 isListening (2026-07-25): 停止录音的瞬间 state 就离开
+  // listening 进入 submitting/refining, 但转写文本要等润色完才落进草稿, 中间这一小段
+  // canSend 仍是 false —— 若按 isListening 判定, 这一帧会退化成"streaming idle", Stop 弹
+  // 回主槽、Send 消失, 等草稿落地再弹回来, 肉眼可见闪一下. isBusy 覆盖整个语音生命周期
+  // (listening + submitting + refining), 让槽位从开录到润色结束保持不变; 润色期间主槽是
+  // 禁用态 Send (见 sendButtonDisabled), 停止任务的能力由次槽 Stop 承担.
+  const mainSlotIsStop =
+    showStopButton && (sendDispatchInFlight || (!canSend && !voiceInput.isBusy));
+  const showSecondaryStop =
+    showStopButton && (canSend || voiceInput.isBusy) && !sendDispatchInFlight;
   useEffect(() => {
     voiceInputCanStopAndSendRef.current = !sendButtonDisabled;
     composerCanSubmitRef.current = !sendButtonDisabled;
@@ -5370,6 +5397,16 @@ export function ChatInput({
                       : 'flex items-center gap-2'
                   }
                 >
+                  {/* 次槽 Stop 必须在语音按钮左边 —— 见 showSecondaryStop 定义处的
+                 双槽语义与"语音按钮位置守恒"说明, 不要挪到语音与 Send 之间。 */}
+                  {showSecondaryStop && (
+                    <SendButton
+                      disabled={false}
+                      onClick={onStop ?? (() => {})}
+                      isStreaming
+                      visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
+                    />
+                  )}
                   <VoiceInputButton
                     state={voiceInput.state}
                     disabled={!!disabled || !editor}
@@ -5384,87 +5421,55 @@ export function ChatInput({
                     visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
                     className={isCreateAgentVariant && !useNarrowToolbar ? 'ml-[7px]' : undefined}
                   />
-                  {/* Send / Stop 双槽语义:
-                 - 主槽 (最右, 永远占位, sendButtonRef 钉在这里):
-                     · 发送瞬间 (inflight=true) → Stop  (Send 原位被替换, 不抖左侧 layout)
-                     · streaming idle (无内容 / 无 voice) → Stop  (取代 Send 占主槽)
-                     · 其它 (idle / streaming+canSend / voice listening) → Send
-                 - 次槽 (主槽左边, 仅 streaming+(canSend||listening)+!inflight 时出现): Stop
-                 设计意图: Send 是最显眼的主行动按钮, 应当永远在最右; streaming
-                 idle 时由 Stop 顶替 Send 主槽 (原位替换, 不抖); streaming 中用户输入
-                 下一条要送入 PendingQueue 时, Send 回到主槽, Stop 退到次槽 (Send 在
-                 Stop 右边). dispatchSendInFlight 锁次槽, 避免 send 瞬间主槽
-                 Send→Stop 切换的同帧再多出一个 Stop 把模型选择推一下又复位的 bug. */}
-                  {(() => {
-                    const mainSlotIsStop =
-                      showStopButton &&
-                      (sendDispatchInFlight || (!canSend && !voiceInput.isListening));
-                    const showSecondaryStop =
-                      showStopButton &&
-                      (canSend || voiceInput.isListening) &&
-                      !sendDispatchInFlight;
-                    return (
-                      <>
-                        {showSecondaryStop && (
-                          <SendButton
-                            disabled={false}
-                            onClick={onStop ?? (() => {})}
-                            isStreaming
-                            visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
-                          />
-                        )}
-                        <span ref={sendButtonRef} className="inline-flex rounded-full">
-                          {mainSlotIsStop ? (
-                            <SendButton
-                              disabled={false}
-                              onClick={onStop ?? (() => {})}
-                              isStreaming
-                              visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
-                            />
-                          ) : (
-                            <Tip
-                              text={
-                                voiceReleaseToSendActive
-                                  ? t('newChat.chatInput.voiceInput.releaseToSend')
-                                  : voiceInput.isListening && !sendButtonDisabled
-                                    ? `${t('newChat.chatInput.voiceInput.finishAndSend')} · Enter`
-                                    : showStopButton
-                                      ? t('newChat.sendButton.queueTooltip', {
-                                          shortcut: steerShortcutLabel,
-                                        })
-                                      : !sendButtonDisabled
-                                        ? `${t('newChat.sendButton.send')} · Enter`
-                                        : selectedSourceDisconnected
-                                          ? t('newChat.sourceDisconnected.sendBlocked')
-                                          : null
-                              }
-                              side="top"
-                              forceOpen={voiceReleaseToSendActive}
-                            >
-                              {/* Tip 的 trigger 放在稳定 wrapper 上，而不是 button 本身。
+                  <span ref={sendButtonRef} className="inline-flex rounded-full">
+                    {mainSlotIsStop ? (
+                      <SendButton
+                        disabled={false}
+                        onClick={onStop ?? (() => {})}
+                        isStreaming
+                        visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
+                      />
+                    ) : (
+                      <Tip
+                        text={
+                          voiceReleaseToSendActive
+                            ? t('newChat.chatInput.voiceInput.releaseToSend')
+                            : voiceInput.isListening && !sendButtonDisabled
+                              ? `${t('newChat.chatInput.voiceInput.finishAndSend')} · Enter`
+                              : showStopButton
+                                ? t('newChat.sendButton.queueTooltip', {
+                                    shortcut: steerShortcutLabel,
+                                  })
+                                : !sendButtonDisabled
+                                  ? `${t('newChat.sendButton.send')} · Enter`
+                                  : selectedSourceDisconnected
+                                    ? t('newChat.sourceDisconnected.sendBlocked')
+                                    : null
+                        }
+                        side="top"
+                        forceOpen={voiceReleaseToSendActive}
+                      >
+                        {/* Tip 的 trigger 放在稳定 wrapper 上，而不是 button 本身。
                             disabled button 不会可靠地产生 hover/focus 事件；曾经因此让
                             running 时“排队/快捷键插话”提示完全不出现。 */}
-                              <span className="inline-flex rounded-full">
-                                <SendButton
-                                  disabled={sendButtonDisabled}
-                                  highlighted={voiceReleaseToSendActive}
-                                  visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
-                                  ariaLabel={
-                                    showStopButton
-                                      ? t('newChat.sendButton.queue')
-                                      : t('newChat.sendButton.send')
-                                  }
-                                  onClick={() => {
-                                    void handleClickSend();
-                                  }}
-                                />
-                              </span>
-                            </Tip>
-                          )}
+                        <span className="inline-flex rounded-full">
+                          <SendButton
+                            disabled={sendButtonDisabled}
+                            highlighted={voiceReleaseToSendActive}
+                            visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
+                            ariaLabel={
+                              showStopButton
+                                ? t('newChat.sendButton.queue')
+                                : t('newChat.sendButton.send')
+                            }
+                            onClick={() => {
+                              void handleClickSend();
+                            }}
+                          />
                         </span>
-                      </>
-                    );
-                  })()}
+                      </Tip>
+                    )}
+                  </span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 这次改了什么

### 摘要

有任务正在执行时点语音输入，「停止任务」按钮会跳到语音输入按钮原来的位置，用户想「原地再点一下停止录音」就会误停正在跑的任务。

原因是 composer 右下按钮组右对齐，而次槽 Stop 夹在语音与 Send 之间：录音让 Send 归位主槽、Stop 退到次槽，整组多出一格宽度，语音按钮被整格左移，它让出的位置正好被 Stop 占据。

改为次槽 Stop 一律渲染在语音按钮**左边**。语音按钮由此永远是最右主槽的左邻，右边缘恒等于「容器右 − 主槽宽 − gap」，与是否 streaming / 是否有草稿 / 是否录音全部无关；录音时计时胶囊只向左生长，原来的麦克风命中点始终留在按钮内。

只在录音态挪是不够的：那样跳变只是推迟到「录音结束且草稿非空」那一刻，而彼时鼠标恰好正停在语音按钮上，误点风险一样。

槽位判定同时从 `isListening` 换成 `isBusy`。停止录音的瞬间 state 就离开 `listening` 进入 `submitting`/`refining`，但转写文本要等润色完才落进草稿，中间这一小段 `canSend` 仍是 `false` —— 按 `isListening` 判定会让这一帧退化成「streaming idle」，Stop 弹回主槽、Send 消失，等草稿落地再弹回来，肉眼可见闪一下。`isBusy` 覆盖 `listening + submitting + refining` 整段生命周期，槽位从开录到润色结束保持不变；润色期间主槽是禁用态 Send（`sendButtonDisabled` 本就把 `submitting`/`refining` 算作禁用），停止任务的能力由次槽 Stop 承担。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户直接反馈的体验问题）
- 本 PR 包含：desktop composer 右下按钮组的次槽 Stop 位置调整；槽位判定改用 `isBusy`；`mainSlotIsStop` / `showSecondaryStop` 从 JSX 内的 IIFE 提到组件 body；新增 `voiceInputButtonAnchor.test.ts` 回归测试
- 明确不包含：
  - **mobile 的同类问题**。排查时发现 mobile 也存在语音按钮跳变，且更危险：语音按钮是绝对定位，`right` 按 trailing 按钮数量跳三档（12 / 52 / 92），录音刚开始不跳，但**第一段转写文字落进草稿的瞬间** trailing 从 1 颗变 2 颗，语音按钮向左跳 40pt，跳完之后「停止任务」的圆心与跳变前麦克风的圆心完全重合。本 PR 按维护者要求只做 desktop，mobile 另行处理。
  - 无关的基线 typecheck 错误（见「未执行的验证」）
- 用户可见变化：任务执行中使用语音输入时，「停止任务」按钮出现在语音输入按钮左侧而非右侧；语音按钮自身位置在整个录音 + 润色过程中不再移动
- 是否存在 breaking change：无

### UI 变化

按钮组从左到右的排列变化（composer 右下角，右对齐）：

| 状态 | 改动前 | 改动后 |
|---|---|---|
| 任务执行中、草稿空 | `[麦克风] [Stop]` | `[麦克风] [Stop]` |
| 任务执行中、录音中 | `[计时胶囊] [Stop] [Send]` | `[Stop] [计时胶囊] [Send]` |
| 任务执行中、润色中 | `[麦克风] [Stop]`（闪一下） | `[Stop] [麦克风] [Send(禁用)]` |
| 任务执行中、草稿非空 | `[麦克风] [Stop] [Send]` | `[Stop] [麦克风] [Send]` |

改动后语音按钮的右边缘在以上所有状态下恒定不变。

改动后录音中的实拍（macOS，Light）：从左到右为「模型选择器 → 停止任务 → `0:09` 计时胶囊 → 发送」，计时胶囊向左生长，右边缘紧贴发送键。

<img width="321" height="177" alt="录音中的 composer 右下按钮组：Stop 在计时胶囊左侧" src="https://github.com/user-attachments/assets/44566432-a9bd-4790-babd-9d36b86d9364" />

改动只调整同一组既有控件的 DOM 顺序与槽位判定条件，不新增样式、颜色或文案，不涉及任何 theme token 变更，Light / Dark 两种模式表现一致。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/voiceInputButtonAnchor.test.ts \
  src/renderer/__tests__/voiceInputEnterToSend.test.ts \
  src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts \
  src/renderer/__tests__/chatInputSteerShortcut.test.ts \
  src/renderer/__tests__/voiceInputDraftDecoration.test.ts
结果：Test Files 5 passed (5)，Tests 35 passed (35)

pnpm test:unit（仓库根全量门禁）
结果：GATE_EXIT=0，全绿。改用 isBusy 之后复跑一次，仍为 GATE_EXIT=0

pnpm --filter desktop typecheck
结果：未通过，剩 1 条基线错误（详见「未执行的验证」）
```

新增的 `voiceInputButtonAnchor.test.ts` 守四条不变量：次槽 Stop 渲染在语音按钮之前；语音按钮与主槽之间不得再插入任何 Send/Stop 控件；placement 不按 listening 分叉；槽位判定块不得再出现 `isListening`。

### 手工验证

平台 macOS，在功能 worktree 直接启动开发版：

```text
pnpm restart:desktop:remote -- --preserve-running
pnpm desktop:whoami
结果：Desktop source: MATCH
      root=/Users/dash/Code/Cindy/cindy-voice-stop-button-anchor
      commit=8dfaaeca24cf06d5bf1c7681cdc53dbed0723aa6 state=ready passive=true
```

由维护者在该实例上实测确认：任务执行中点语音输入，停止按钮出现在语音键左侧、语音按钮位置不动；录音结束的瞬间不再出现停止按钮弹回原位的闪烁。

### 未执行的验证

- `pnpm --filter desktop typecheck` 未通过，剩余唯一一条错误是 `apps/desktop/src/renderer/cindy-brain/__tests__/installFlow.test.tsx(199,32): error TS2353`。该文件同文件内定义的 `setupWindow` 第二参数类型是 `{ ghost: { manifest: object } }`，199 行传入 `{ canceled: true }` 不匹配。由 `713d6c6`（#332）引入，本 PR 未触及该文件，属基线问题，未混入无关修复。
- 未做 mobile 验证：本 PR 不含 mobile 改动。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop renderer 的 composer 右下按钮组渲染顺序与槽位判定条件。不涉及数据、协议、权限或原生层。`sendButtonRef` 仍钉在主槽，语音长按「拖到发送键松手即发」的命中目标未变。
- 回滚 / 降级方式：`git revert` 本 commit 即可，无状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动理由与「位置守恒」推导写在 `showSecondaryStop` 定义处的注释里，并由回归测试固化）
- [x] 已确认测试结果或说明未执行原因


