### PR TITLE
fix(desktop): 用量 chip 只在当前会话真受限时变红

### DIFF
--- a/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
@@ -343,6 +343,20 @@ describe('isClaudeSubscriptionAlerting', () => {
     expect(isClaudeUsageWindowAlerting(undefined)).toBe(false);
     expect(isClaudeUsageWindowAlerting({ utilization: 87, severity: 'warning' })).toBe(true);
   });
+
+  it('ignores non-finite utilization instead of treating it as exhausted', () => {
+    // 持久化快照是 JSON.parse 后直接断言的, 不重新校验字段: 脏值不能被 clampPercent
+    // 夹成 100 而误判额度耗尽。severity 缺失时一律不告警。
+    expect(isClaudeUsageWindowAlerting({ utilization: Number.POSITIVE_INFINITY })).toBe(false);
+    expect(isClaudeUsageWindowAlerting({ utilization: Number.NaN })).toBe(false);
+    expect(isClaudeSubscriptionAlerting(
+      { fiveHour: { utilization: Number.POSITIVE_INFINITY } },
+      'claude-opus-5',
+    )).toBe(false);
+    // 脏 utilization 不影响 severity 这条独立判据
+    expect(isClaudeUsageWindowAlerting({ utilization: Number.NaN, severity: 'warning' }))
+      .toBe(true);
+  });
 });
 
 describe('fetchClaudeSubscriptionUsageSnapshot', () => {

--- a/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
@@ -298,18 +298,36 @@ describe('isClaudeSubscriptionAlerting', () => {
       { fiveHour: { utilization: 100 } },
       'claude-opus-5',
     )).toBe(true);
-    expect(isClaudeSubscriptionAlerting(
-      { sevenDay: { utilization: 99.96 } },
-      'claude-opus-5',
-    )).toBe(true);
     // 总周限 severity 非 normal —— 所有模型共用, 与当前模型无关
     expect(isClaudeSubscriptionAlerting(
       { sevenDay: { utilization: 80, severity: 'warning' } },
       'claude-opus-5',
     )).toBe(true);
-    // severity=normal 且远未打满 → 不告警
+    // 水位远未见底且 severity=normal → 不告警
     expect(isClaudeSubscriptionAlerting(
-      { fiveHour: { utilization: 90, severity: 'normal' }, sevenDay: { utilization: 95 } },
+      { fiveHour: { utilization: 60, severity: 'normal' }, sevenDay: { utilization: 44 } },
+      'claude-opus-5',
+    )).toBe(false);
+  });
+
+  it('alerts when a displayed window runs down to the last 10%', () => {
+    // unified-headers 源不带 per-window severity, 只有 utilization: 光靠「打满」会让
+    // chip 一直到 99.95% 才变红。剩余 ≤10% 即告警, 判据是 chip 上正在显示的那个数字。
+    expect(isClaudeSubscriptionAlerting({ fiveHour: { utilization: 90 } }, 'claude-opus-5'))
+      .toBe(true);
+    expect(isClaudeSubscriptionAlerting({ sevenDay: { utilization: 92 } }, 'claude-opus-5'))
+      .toBe(true);
+    // 水位判定优先于服务端 severity: 只剩 5% 时说 normal 也照样提醒
+    expect(isClaudeSubscriptionAlerting(
+      { fiveHour: { utilization: 95, severity: 'normal' } },
+      'claude-opus-5',
+    )).toBe(true);
+    // 阈值下方不告警(89% 已用 = 剩余 11%)
+    expect(isClaudeSubscriptionAlerting({ fiveHour: { utilization: 89 } }, 'claude-opus-5'))
+      .toBe(false);
+    // 其它模型的 scoped 窗口即使见底也不染红当前会话 —— 与阈值无关
+    expect(isClaudeSubscriptionAlerting(
+      { fiveHour: { utilization: 10 }, scoped: [{ utilization: 99, modelDisplayName: 'Fable' }] },
       'claude-opus-5',
     )).toBe(false);
   });

--- a/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
@@ -6,6 +6,7 @@
  *   - parseClaudeUnifiedRateLimitHeaders: headers 0.0-1.0 分数 ×100 归一化
  *   - mergeClaudeSubscriptionUsageSnapshot: headers 增量 / endpoint 全量的双源语义
  *   - claudeModelFamily / matchScopedWindowForModel: 方案 B 的模型 → scoped 窗口匹配
+ *   - isClaudeSubscriptionAlerting: chip 变红口径(只看影响当前会话的窗口 + rejected)
  *   - fetchClaudeSubscriptionUsageSnapshot: UA / beta 头、401→Unauthorized、429→RateLimited
  */
 
@@ -13,6 +14,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   claudeModelFamily,
+  hasAlertingClaudeSessionWindow,
+  isClaudeSubscriptionAlerting,
+  isClaudeUsageWindowAlerting,
   matchScopedWindowForModel,
   mergeClaudeSubscriptionUsageSnapshot,
   parseClaudeOAuthUsageResponse,
@@ -243,6 +247,83 @@ describe('claudeModelFamily / matchScopedWindowForModel', () => {
     expect(matchScopedWindowForModel(scoped, 'claude-opus-4-8')?.utilization).toBe(5);
     expect(matchScopedWindowForModel(scoped, 'claude-sonnet-4-6')).toBeNull();
     expect(matchScopedWindowForModel(undefined, 'claude-fable-5')).toBeNull();
+  });
+});
+
+describe('isClaudeSubscriptionAlerting', () => {
+  /**
+   * 2026-07-25 实测快照:5h / 总周限都很宽裕,只有 Fable 的分模型周限 87% 且服务端
+   * 给了 severity=warning。chip 上只显示 5h + 周限两段,所以这份数据只该让 Fable
+   * 会话变红。
+   */
+  const SNAPSHOT: ClaudeSubscriptionUsageSnapshot = {
+    fiveHour: { utilization: 10 },
+    sevenDay: { utilization: 44 },
+    scoped: [{ utilization: 87, severity: 'warning', modelDisplayName: 'Fable' }],
+    rateLimitStatus: 'allowed',
+    subscriptionType: 'max',
+  };
+
+  it('only alerts the model whose scoped weekly window is warning', () => {
+    expect(isClaudeSubscriptionAlerting(SNAPSHOT, 'claude-fable-5[1m]')).toBe(true);
+    // 跑 Opus / Sonnet 的会话不受 Fable 周限影响 —— chip 上也没有那一段, 不能染红
+    expect(isClaudeSubscriptionAlerting(SNAPSHOT, 'claude-opus-5[1m]')).toBe(false);
+    expect(isClaudeSubscriptionAlerting(SNAPSHOT, 'claude-sonnet-5')).toBe(false);
+    // 家族识别不出来时回退总周限(44%,不告警)
+    expect(isClaudeSubscriptionAlerting(SNAPSHOT, null)).toBe(false);
+    expect(isClaudeSubscriptionAlerting(null, 'claude-fable-5')).toBe(false);
+  });
+
+  it('ignores allowed_warning but honors rejected', () => {
+    // allowed_warning 是服务端综合全部窗口(含其它模型周限)的模糊信号:chip 只显示
+    // 5h + 周限, 拿它染红会出现「剩余 91% / 56% 却是红的」
+    expect(isClaudeSubscriptionAlerting(
+      { ...SNAPSHOT, rateLimitStatus: 'allowed_warning' },
+      'claude-opus-5[1m]',
+    )).toBe(false);
+    // 真限流(请求已被拒)与当前模型无关, 一律告警
+    expect(isClaudeSubscriptionAlerting(
+      { ...SNAPSHOT, rateLimitStatus: 'rejected' },
+      'claude-opus-5[1m]',
+    )).toBe(true);
+    expect(isClaudeSubscriptionAlerting(
+      { ...SNAPSHOT, rateLimitStatus: 'REJECTED ' },
+      'claude-opus-5[1m]',
+    )).toBe(true);
+  });
+
+  it('alerts on exhausted or non-normal session-scope windows', () => {
+    // 打满(headers 源不带 severity, 只能靠 utilization)
+    expect(isClaudeSubscriptionAlerting(
+      { fiveHour: { utilization: 100 } },
+      'claude-opus-5',
+    )).toBe(true);
+    expect(isClaudeSubscriptionAlerting(
+      { sevenDay: { utilization: 99.96 } },
+      'claude-opus-5',
+    )).toBe(true);
+    // 总周限 severity 非 normal —— 所有模型共用, 与当前模型无关
+    expect(isClaudeSubscriptionAlerting(
+      { sevenDay: { utilization: 80, severity: 'warning' } },
+      'claude-opus-5',
+    )).toBe(true);
+    // severity=normal 且远未打满 → 不告警
+    expect(isClaudeSubscriptionAlerting(
+      { fiveHour: { utilization: 90, severity: 'normal' }, sevenDay: { utilization: 95 } },
+      'claude-opus-5',
+    )).toBe(false);
+  });
+
+  it('hasAlertingClaudeSessionWindow excludes the overall status signal', () => {
+    // tooltip 用它 + status 分流, chip 用 isClaudeSubscriptionAlerting; 窗口维度本身
+    // 不看 status(rejected 也不例外)
+    expect(hasAlertingClaudeSessionWindow(
+      { ...SNAPSHOT, rateLimitStatus: 'rejected' },
+      'claude-opus-5[1m]',
+    )).toBe(false);
+    expect(hasAlertingClaudeSessionWindow(SNAPSHOT, 'claude-fable-5[1m]')).toBe(true);
+    expect(isClaudeUsageWindowAlerting(undefined)).toBe(false);
+    expect(isClaudeUsageWindowAlerting({ utilization: 87, severity: 'warning' })).toBe(true);
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -193,10 +193,20 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain('weekly.modelDisplayName ? `${weekly.modelDisplayName} ${countdown}` : countdown');
     expect(source).toContain('todaySpend.claude.sessionValueLabel');
     expect(source).toContain('todaySpend.claude.planLine');
-    // 告警只看影响当前会话的窗口 (5h / 总周限 / 当前模型 scoped);headers 的
-    // allowed_warning 是 turn 内唯一的「接近限额」实时信号, 必须纳入告警态
-    expect(source).toContain('isClaudeSubscriptionAlerting(');
-    expect(source).toContain("status === 'rejected' || status === 'allowed_warning'");
+    // 告警判定是纯数据判定, 统一收在 shared/claudeSubscriptionUsage.ts (有直接单测:
+    // main/usage/__tests__/claudeSubscriptionUsage.test.ts), 组件只消费, 不再本地重写。
+    expect(source).toContain('isClaudeSubscriptionAlerting,');
+    expect(source).toContain('hasAlertingClaudeSessionWindow,');
+    expect(source).not.toContain('function isClaudeSubscriptionAlerting(');
+    expect(source).not.toContain('function hasAlertingClaudeSessionWindow(');
+    // chip 变红只看当前会话真受限 (rejected / 影响本会话的窗口告警); headers 的
+    // allowed_warning 综合了其它模型的分模型周限, 不得单独染红 —— 否则跑 Opus 的
+    // 会话会因 Fable 周限吃紧变红, 而 chip 上根本没有那一段。
+    expect(source).not.toContain("status === 'rejected' || status === 'allowed_warning'");
+    // tooltip 比 chip 宽一档: allowed_warning 仍提示 (紧邻全量窗口列表, 有上下文)
+    expect(source).toContain(
+      "status === 'allowed_warning' || hasAlertingClaudeSessionWindow(snapshot, modelId)",
+    );
     // Claude 订阅 / bridge 订阅不读 gateway quota (不反映订阅花费); 默认路由 key reconcile
     // 完成前形态未定, 同样不放行网关 quota 读 (避免形态闪切)
     expect(source).toContain("vendorKey === 'cc' && !isClaudeSubscription && !isSubscriptionBridge && !ccBillingFormPending");

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -66,6 +66,9 @@ import {
   type ClaudeSubscriptionUsageSnapshot,
 } from '@/hooks/useClaudeSubscriptionUsage';
 import {
+  hasAlertingClaudeSessionWindow,
+  isClaudeSubscriptionAlerting,
+  isClaudeUsageWindowAlerting,
   matchScopedWindowForModel,
   type ClaudeUsageWindow,
 } from '../../../shared/claudeSubscriptionUsage';
@@ -535,13 +538,6 @@ interface ClaudeWindowUsage {
   alerting: boolean;
 }
 
-function isClaudeWindowAlerting(window: ClaudeUsageWindow | null | undefined): boolean {
-  if (!window) return false;
-  if (clampPercent(window.utilization) >= 99.95) return true;
-  const severity = window.severity?.trim().toLowerCase();
-  return Boolean(severity && severity !== 'normal');
-}
-
 function toClaudeWindowUsage(
   label: string,
   window: ClaudeUsageWindow | null | undefined,
@@ -555,7 +551,7 @@ function toClaudeWindowUsage(
     used: formatPercent(usedPercent),
     remaining: formatPercent(100 - usedPercent),
     resetAt: formatResetAt(window.resetsAt),
-    alerting: isClaudeWindowAlerting(window),
+    alerting: isClaudeUsageWindowAlerting(window),
   };
 }
 
@@ -632,26 +628,9 @@ function getClaudeChipWindows(
   return windows;
 }
 
-/**
- * chip 警示态: 只看影响当前会话的窗口 (5h / 总周限 / 当前模型 scoped) 与 headers
- * 的整体 status —— 其它模型的窗口打满不限流当前会话, 只在 tooltip 里可见。
- * headers 源的窗口不带 severity, turn 内实时阶段「接近限额」只由整体 status 的
- * allowed_warning 表达, 因此 warning / rejected 都纳入告警 (rejected 在 tooltip
- * 文案分流里优先)。
- */
-function isClaudeSubscriptionAlerting(
-  snapshot: ClaudeSubscriptionUsageSnapshot | null,
-  modelId: string | null | undefined,
-): boolean {
-  if (!snapshot) return false;
-  const status = snapshot.rateLimitStatus?.trim().toLowerCase();
-  if (status === 'rejected' || status === 'allowed_warning') return true;
-  return (
-    isClaudeWindowAlerting(snapshot.fiveHour)
-    || isClaudeWindowAlerting(snapshot.sevenDay)
-    || isClaudeWindowAlerting(matchScopedWindowForModel(snapshot.scoped, modelId))
-  );
-}
+// 告警判定 (chip 变红 / tooltip 高亮的口径, 含 allowed_warning 为何不染红的取舍)
+// 已收进 shared/claudeSubscriptionUsage.ts: isClaudeUsageWindowAlerting /
+// hasAlertingClaudeSessionWindow / isClaudeSubscriptionAlerting (纯数据判定, 有直接单测)。
 
 function buildClaudeSubscriptionTooltipNode(
   snapshot: ClaudeSubscriptionUsageSnapshot | null,
@@ -705,10 +684,13 @@ function buildClaudeSubscriptionTooltipNode(
     );
   }
 
+  // tooltip 比 chip 宽一档: allowed_warning (服务端综合全部窗口的模糊信号) 也提示 ——
+  // 上面刚列完全量窗口, 用户能自己看出是哪个窗口吃紧; chip 颜色不吃这个信号 (见
+  // isClaudeSubscriptionAlerting)。
   const status = snapshot.rateLimitStatus?.trim().toLowerCase();
   if (status === 'rejected') {
     lines.push(t('todaySpend.claude.limitRejected'));
-  } else if (isClaudeSubscriptionAlerting(snapshot, modelId)) {
+  } else if (status === 'allowed_warning' || hasAlertingClaudeSessionWindow(snapshot, modelId)) {
     lines.push(t('todaySpend.claude.limitWarning'));
   }
 
@@ -1394,6 +1376,8 @@ export function TodaySpendChip({
 
   // Claude 订阅告警态: 影响当前会话的窗口 (5h / 总周限 / 当前模型 scoped) 任一逼近 /
   // 打满, 或 headers 报 rejected → chip 变 error 色 (语义豁免色, 跨主题一致)。
+  // 其它模型的周限吃紧不染红 —— chip 上没有那一段, 红了也无从解释 (见
+  // isClaudeSubscriptionAlerting 对 allowed_warning 的取舍)。
   const claudeSubscriptionAlerting = isClaudeSubscription
     && isClaudeSubscriptionAlerting(claudeSubscriptionUsage, modelId);
 

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -68,7 +68,6 @@ import {
 import {
   hasAlertingClaudeSessionWindow,
   isClaudeSubscriptionAlerting,
-  isClaudeUsageWindowAlerting,
   matchScopedWindowForModel,
   type ClaudeUsageWindow,
 } from '../../../shared/claudeSubscriptionUsage';
@@ -527,15 +526,17 @@ function buildCodexTooltipNode(
 // 不到回退总周限并标注口径) · 本会话价值 $。tooltip 列全量窗口 (含非当前模型的
 // scoped 条目) + 套餐 + extra usage。utilization 语义 = 已用百分比 (0-100)。
 
-/** Claude 窗口 → 展示行素材;窗口缺失 / 数据不可解析 → null (调用方过滤)。 */
+/**
+ * Claude 窗口 → tooltip 行素材;窗口缺失 / 数据不可解析 → null (调用方过滤)。
+ * tooltip 的窗口行不做逐行高亮 (纯文本 tooltip), 告警只体现在 chip 配色与末尾的
+ * 「接近限额」行 —— 故这里不带 alerting 标记。
+ */
 interface ClaudeWindowUsage {
   label: string;
   used: string;
   remaining: string;
   /** tooltip 用的精确 reset 时间点;无数据 → null。 */
   resetAt: string | null;
-  /** 服务端 severity 非 normal, 或已打满 —— tooltip 高亮 / chip 变警示色的依据。 */
-  alerting: boolean;
 }
 
 function toClaudeWindowUsage(
@@ -551,7 +552,6 @@ function toClaudeWindowUsage(
     used: formatPercent(usedPercent),
     remaining: formatPercent(100 - usedPercent),
     resetAt: formatResetAt(window.resetsAt),
-    alerting: isClaudeUsageWindowAlerting(window),
   };
 }
 

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -628,9 +628,11 @@ function getClaudeChipWindows(
   return windows;
 }
 
-// 告警判定 (chip 变红 / tooltip 高亮的口径, 含 allowed_warning 为何不染红的取舍)
-// 已收进 shared/claudeSubscriptionUsage.ts: isClaudeUsageWindowAlerting /
+// 告警判定 (chip 变红的口径 + allowed_warning 为何不染红、为何不用 representativeClaim
+// 的取舍) 已收进 shared/claudeSubscriptionUsage.ts: isClaudeUsageWindowAlerting /
 // hasAlertingClaudeSessionWindow / isClaudeSubscriptionAlerting (纯数据判定, 有直接单测)。
+// tooltip 不逐行高亮, 它比 chip 宽一档的那一档在 buildClaudeSubscriptionTooltipNode 里
+// (整体 status 的 allowed_warning 也出「接近限额」行)。
 
 function buildClaudeSubscriptionTooltipNode(
   snapshot: ClaudeSubscriptionUsageSnapshot | null,

--- a/apps/desktop/src/shared/claudeSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/claudeSubscriptionUsage.ts
@@ -366,13 +366,21 @@ export function matchScopedWindowForModel(
  */
 const WINDOW_ALERT_UTILIZATION_PERCENT = 90;
 
-/** 单个窗口告警:剩余水位见底,或服务端 severity 明确非 normal。 */
+/**
+ * 单个窗口告警:剩余水位见底,或服务端 severity 明确非 normal。
+ *
+ * utilization 走 Number.isFinite 而不只是 typeof —— 与本文件其它调用点同口径。解析层
+ * (toFiniteNumber / parseHeaderUtilization)本就只放行有限数, 但持久化快照是 JSON.parse
+ * 后直接断言成 snapshot 的(见 usageBroadcaster hydration), 不重新校验字段; 万一有脏值
+ * 滑进来, +Infinity 会被 clampPercent 夹成 100 并误判成额度耗尽而染红。
+ */
 export function isClaudeUsageWindowAlerting(
   window: ClaudeUsageWindow | null | undefined,
 ): boolean {
   if (!window) return false;
   if (
     typeof window.utilization === 'number'
+    && Number.isFinite(window.utilization)
     && clampPercent(window.utilization) >= WINDOW_ALERT_UTILIZATION_PERCENT
   ) {
     return true;

--- a/apps/desktop/src/shared/claudeSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/claudeSubscriptionUsage.ts
@@ -354,14 +354,27 @@ export function matchScopedWindowForModel(
   return scoped.find((w) => w.modelDisplayName.trim().toLowerCase() === family) ?? null;
 }
 
-// ── 告警判定(chip 变红 / tooltip 高亮的唯一口径) ────────────────────────────
+// ── 告警判定(chip 变红的口径;tooltip 另有 status 分流,见 TodaySpendChip) ───
 
-/** 单个窗口告警:已打满,或服务端 severity 明确非 normal。 */
+/**
+ * 窗口进入告警的剩余水位:剩余 ≤10%(已用 ≥90%)。
+ *
+ * 兜的是 unified-headers 源没有 per-window `severity` 这个事实 —— 该源只给 utilization,
+ * 光靠「打满」判定会让 chip 一直到 99.95% 才变红。用固定水位而不是 headers 的整体
+ * `allowed_warning`:水位对着 chip 上正在显示的那个数字,「剩余 8%」是红的能自证;
+ * 整体 status 综合了 chip 上没有的窗口,红了无从解释(见 isClaudeSubscriptionAlerting)。
+ */
+const WINDOW_ALERT_UTILIZATION_PERCENT = 90;
+
+/** 单个窗口告警:剩余水位见底,或服务端 severity 明确非 normal。 */
 export function isClaudeUsageWindowAlerting(
   window: ClaudeUsageWindow | null | undefined,
 ): boolean {
   if (!window) return false;
-  if (typeof window.utilization === 'number' && clampPercent(window.utilization) >= 99.95) {
+  if (
+    typeof window.utilization === 'number'
+    && clampPercent(window.utilization) >= WINDOW_ALERT_UTILIZATION_PERCENT
+  ) {
     return true;
   }
   const severity = window.severity?.trim().toLowerCase();
@@ -394,6 +407,12 @@ export function hasAlertingClaudeSessionWindow(
  * Opus 的会话染红,用户看到的是「剩余 91% / 56% 却是红的」,颜色与数字自相矛盾且无处
  * 解释(chip 上没有那个窗口)。真限流时 rejected 会立刻到,不需要它兜底;「接近限额」
  * 提示仍留在 tooltip —— 那里紧邻全量窗口列表,有上下文。
+ *
+ * 也没有走 `representativeClaim`(「只在 claim 指向 chip 上的窗口时才认 allowed_warning」):
+ * 2026-07-25 实测快照里 claim=`five_hour`,而当时真正吃紧的是 Fable 周限(87%,
+ * severity=warning),5h 只用了 10% —— 这个字段并不指向触发 warning 的窗口,以它为条件
+ * 会原样退回误红。headers 源缺 severity 的预警缺口改由 WINDOW_ALERT_UTILIZATION_PERCENT
+ * 的剩余水位兜住,判据始终是 chip 上看得见的那个数字。
  */
 export function isClaudeSubscriptionAlerting(
   snapshot: ClaudeSubscriptionUsageSnapshot | null,

--- a/apps/desktop/src/shared/claudeSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/claudeSubscriptionUsage.ts
@@ -353,3 +353,53 @@ export function matchScopedWindowForModel(
   if (!family) return null;
   return scoped.find((w) => w.modelDisplayName.trim().toLowerCase() === family) ?? null;
 }
+
+// ── 告警判定(chip 变红 / tooltip 高亮的唯一口径) ────────────────────────────
+
+/** 单个窗口告警:已打满,或服务端 severity 明确非 normal。 */
+export function isClaudeUsageWindowAlerting(
+  window: ClaudeUsageWindow | null | undefined,
+): boolean {
+  if (!window) return false;
+  if (typeof window.utilization === 'number' && clampPercent(window.utilization) >= 99.95) {
+    return true;
+  }
+  const severity = window.severity?.trim().toLowerCase();
+  return Boolean(severity && severity !== 'normal');
+}
+
+/**
+ * 影响当前会话的窗口是否告警:只看 5h / 总周限 / **当前模型**的 scoped 周限 ——
+ * 其它模型的 scoped 窗口打满不限流当前会话(跑 Opus 时 Fable 周限见底与本会话无关),
+ * 只在 tooltip 的全量窗口列表里可见,不参与判定。
+ */
+export function hasAlertingClaudeSessionWindow(
+  snapshot: ClaudeSubscriptionUsageSnapshot | null,
+  modelId: string | null | undefined,
+): boolean {
+  if (!snapshot) return false;
+  return (
+    isClaudeUsageWindowAlerting(snapshot.fiveHour)
+    || isClaudeUsageWindowAlerting(snapshot.sevenDay)
+    || isClaudeUsageWindowAlerting(matchScopedWindowForModel(snapshot.scoped, modelId))
+  );
+}
+
+/**
+ * chip 警示态(变红):只在当前会话**真的**受限时亮 —— 请求已被拒(headers 整体
+ * status = rejected),或影响当前会话的窗口告警(见上)。
+ *
+ * headers 的 `allowed_warning` **不**单独染红:它是服务端综合全部窗口(含其它模型的
+ * 分模型周限)给出的模糊信号,而 chip 只显示 5h + 周限两段 —— 拿 Fable 周限 87% 把跑
+ * Opus 的会话染红,用户看到的是「剩余 91% / 56% 却是红的」,颜色与数字自相矛盾且无处
+ * 解释(chip 上没有那个窗口)。真限流时 rejected 会立刻到,不需要它兜底;「接近限额」
+ * 提示仍留在 tooltip —— 那里紧邻全量窗口列表,有上下文。
+ */
+export function isClaudeSubscriptionAlerting(
+  snapshot: ClaudeSubscriptionUsageSnapshot | null,
+  modelId: string | null | undefined,
+): boolean {
+  if (!snapshot) return false;
+  if (snapshot.rateLimitStatus?.trim().toLowerCase() === 'rejected') return true;
+  return hasAlertingClaudeSessionWindow(snapshot, modelId);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude 订阅会话的右下角用量 chip 会在额度明显充裕时误变红：实测快照里 5h 窗口只用了
10%、总周限用了 44%，chip 显示「3小时 剩余 91% · 6天 剩余 56%」，却是 error 红色。

根因是告警判定吃了 `anthropic-ratelimit-unified-status` 的 `allowed_warning`。这个 status 是
服务端综合**全部**窗口（含各模型的 `weekly_scoped` 周限）给出的模糊信号，而 chip 只显示
5h + 周限两段。当时真正吃紧的是 Fable 的分模型周限（已用 87%，服务端 `severity=warning`），
于是一个跑 Opus 的会话被 Fable 的额度染红，用户在 chip 上完全看不到红色从何而来。

本 PR 把 chip 变红收窄到「当前会话真的受限」：

1. headers 报 `rejected`（请求已被拒，与模型无关）；
2. **影响当前会话的窗口**告警 —— 5h / 总周限 / **当前模型**的 scoped 周限，任一剩余水位
   见底（剩余 ≤10%）或服务端 `severity` 非 normal。

`allowed_warning` 不再单独染红。tooltip 仍照常提示「接近限额」—— 那里紧邻全量窗口列表
（含非当前模型的 scoped 条目），用户能自己看出是哪个窗口吃紧，信息不丢。

水位阈值（剩余 ≤10%）是 review 跟进时补的，兜的是 unified-headers 源没有 per-window
`severity` 这个事实：该源只给 utilization，光靠「已打满」判定会让 chip 一直到 99.95% 才变红。
没有采用「`representativeClaim` 指向 chip 上的窗口时才认 `allowed_warning`」这个方案 ——
实测快照里 claim 是 `five_hour`，而当时真正吃紧的是 Fable 周限、5h 只用了 10%，该字段并不
指向触发告警的窗口，以它为条件会原样退回误红。水位的判据始终对着 chip 上正在显示的那个
数字，「剩余 8%」是红的，用户自己就能验证红色从哪来。

顺带把这几个纯数据判定从 `TodaySpendChip.tsx` 收进 `shared/claudeSubscriptionUsage.ts`。
原先它们埋在组件里、只能靠源码字符串断言（`toContain("status === 'rejected' || ...")`）
兜着，判定改错测不出来；搬到 shared 后可以直接写行为单测。同时删掉
`ClaudeWindowUsage.alerting` —— 一个只写不读的死字段，也是「tooltip 逐行高亮」这个错误
注释表述的来源（tooltip 是纯文本，从不逐行高亮）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（使用中发现）
- 本 PR 包含：
  - `isClaudeSubscriptionAlerting` 收窄（不再吃 `allowed_warning`），chip 颜色与 tooltip
    文案判定解耦（tooltip 比 chip 宽一档）
  - 新增剩余水位阈值（剩余 ≤10% 即告警），替代原先 99.95% 的「已打满」判据
  - 三个判定函数迁入 `shared/claudeSubscriptionUsage.ts`，补行为单测
  - 删掉 `ClaudeWindowUsage.alerting` 死字段与相关误导注释
- 明确不包含：
  - chip 显示哪几个窗口不变（仍是 5h + 当前模型周限 / 回退总周限）。「变红时把触发告警
    的窗口顶到 chip 上」是另一种方案，需产品拍板，不在本 PR
  - 不含任何界面呈现改动（见「UI 变化」）
- 用户可见变化：Claude 订阅会话的用量 chip 不再因其它模型的周限吃紧而变红；反过来，
  chip 上显示的窗口剩余 ≤10% 时会变红（此前要等到 99.95%）。tooltip 内容不变
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Theme System & Token Reference →
  「语义豁免色（跨主题不变）」。`--error-bg/-border/-fg/-fg-strong` 属 Error alert 语义色族，
  Light / Dark 同值，该节明确要求「永远不要在硬编码 hex 上自由发挥这些语义色 —— 必须走
  对应 token」。本 PR 继续通过 `var(--error-fg)` / `var(--error-fg-strong)` 消费该 token，
  未新增色值、未改 className、未动排版与文案，因此该 token 在两种模式下的表现与改动前
  完全一致（§「Light / Dark 双模式交付门槛」的双模式要求由该 token 跨主题同值满足）。
  本次改的只是这个颜色的**触发条件**（`isClaudeSubscriptionAlerting()` 的判定口径），
  不涉及视觉、交互或文案变化。

**不涉及界面呈现改动，不附截图 / 录屏。**

本 PR 没有新增或修改任何界面元素、布局、样式 token 或 UI 文案：不动 DOM 结构、不动
className、不动 i18n key。唯一改动是既有 `--error-fg` 语义豁免色（Light / Dark 已定义、
跨模式一致）的**触发条件** —— 也就是 `isClaudeSubscriptionAlerting()` 这个纯数据判定函数
返回 true / false 的口径。渲染层一行没改。

真机截图在这里也提供不了有意义的证据：

- **「不再误变红」侧**：截出来就是一张常规色的 chip。它无法说明改动生效 —— 一张常规色
  chip 与「该函数返回了 false」之间没有可验证的对应关系，看图的人无从判断是改动起了作用，
  还是这个账号当时本来就没有告警。
- **「该红时仍红」侧**：复现需要账号处于特定的服务端额度状态（某个窗口被下发
  `severity != normal`，或 5h / 周限剩余跌到 10% 以内）。这个状态由 Anthropic 服务端决定，
  本地无法按需构造，也不该为了截图把真实订阅额度烧到见底。

判定行为改由单测钉住（见下），覆盖「什么情况下红、什么情况下不红」的每个分支，比截图
更能说明问题。

## 怎么验证的

### 自动验证

已 rebase 到 `bec0510`（含 `fa6cb19`，Lizi 补完 #333 漏删的 Node 授权调用点）。此前 CI
verify 失败的两个 typecheck 错误来自那个基线问题，与本 PR 无关，现已随 rebase 消失。

```text
pnpm test:unit（仓库根，全量）
结果：GATE_EXIT=0，零失败项

pnpm --filter desktop run typecheck
结果：零错误（rebase 前受 main 基线的 cindy-brain 两处错误影响，现已修复）

pnpm --filter desktop exec vitest run \
  src/main/usage/__tests__/claudeSubscriptionUsage.test.ts \
  src/renderer/__tests__/todaySpendChip.test.ts
结果：2 files / 38 tests passed
```

新增单测以实测快照当 fixture（5h 10% / 总周限 44% / Fable scoped 87% severity=warning），
覆盖的判定分支：

| 输入 | 期望 |
| --- | --- |
| Fable 会话 + Fable 周限 severity=warning | 告警 |
| Opus / Sonnet 会话 + 同一份快照 | 不告警（其它模型周限与本会话无关） |
| 模型家族识别不出（回退总周限 44%） | 不告警 |
| `rateLimitStatus=allowed_warning` | 不告警 |
| `rateLimitStatus=rejected`（含大小写 / 空格变体） | 告警 |
| 显示窗口已用 90% / 92% / 95%+severity=normal | 告警（剩余 ≤10%） |
| 显示窗口已用 89% | 不告警 |
| 其它模型 scoped 已用 99%，5h 仅 10% | 不告警 |

### 手工验证

不涉及。

### 未执行的验证

未在运行中的客户端上确认 chip 配色。原因见「UI 变化」：本 PR 不含界面呈现改动，且两侧
状态都无法构造出有说明力的截图。判定口径由上表的单测覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Claude 订阅（Anthropic OAuth）会话右下角 chip 的告警配色与 tooltip 的
  「接近限额」提示条件。不触碰数据源、解析、合并、持久化与广播链路，网关 / Codex / xAI /
  device-link 各形态不受影响。
- 回滚 / 降级方式：纯渲染期判定，revert 本 PR 即恢复，无数据或状态迁移。
- 取舍：`allowed_warning` 曾是 turn 内唯一的「提前预警」信号（headers 源的窗口不带
  `severity`）。收窄后该源的预警由剩余水位阈值承担，代价是水位线（10%）是我们自己定的、
  不随服务端策略变化；好处是红色永远对得上 chip 上显示的数字。若日后服务端在 headers 里
  补上 per-window `severity`，可以让 severity 优先、水位退为兜底。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（判定口径与两处方案取舍写在 `shared/claudeSubscriptionUsage.ts` 的
      函数注释里，无需新增文档文件）
- [x] 已确认测试结果或说明未执行原因
