### PR TITLE
fix(models): 修复 Anthropic 元数据与远端 runtime 兼容性

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -581,7 +581,7 @@ describe('noteAnthropicSdkSupportedModels(登录态门控 + 合并纪律)', () =
     });
   });
 
-  it('HTTP 刷新用当前目录基线替换旧版缓存的三档合成值', async () => {
+  it('磁盘恢复即用当前目录基线替换旧版缓存的三档合成值', async () => {
     const cacheDir = path.join(TEST_USER_DATA, 'model-discovery');
     const cacheFile = path.join(cacheDir, 'anthropic-models.json');
     await fsp.mkdir(cacheDir, { recursive: true });
@@ -592,7 +592,7 @@ describe('noteAnthropicSdkSupportedModels(登录态门控 + 合并纪律)', () =
         models: [
           {
             id: 'claude-fable-5',
-            name: 'Fable 5',
+            name: 'Fable from stale cache',
             group: 'anthropic',
             sortOrder: 0,
             contextWindow: 1_000_000,
@@ -608,7 +608,13 @@ describe('noteAnthropicSdkSupportedModels(登录态门控 + 合并纪律)', () =
       'utf-8',
     );
     await loadAnthropicModelsFromDiskCache();
-    expect(anthropicModel('claude-fable-5')?.efforts).toEqual(['low', 'medium', 'high']);
+    expect(anthropicModel('claude-fable-5')?.efforts).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+    ]);
 
     oauthRefreshMock.getValidClaudeAiOAuth.mockResolvedValue({ accessToken: 'test-token' });
     vi.stubGlobal(
@@ -731,6 +737,54 @@ describe('noteAnthropicSdkSupportedModels(登录态门控 + 合并纪律)', () =
     await loadAnthropicModelsFromDiskCache();
 
     expect(anthropicModel('claude-sonnet-4-5')?.contextWindow).toBe(200_000);
+  });
+
+  it('磁盘缓存按当前目录刷新非明确 effort,同时保留明确能力', async () => {
+    const cacheDir = path.join(TEST_USER_DATA, 'model-discovery');
+    await fsp.mkdir(cacheDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(cacheDir, 'anthropic-models.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-22T00:00:00.000Z',
+        models: [
+          {
+            id: 'claude-sonnet-5',
+            name: 'Sonnet 5',
+            group: 'anthropic',
+            sortOrder: 0,
+            contextWindow: 1_000_000,
+            efforts: ['low', 'medium', 'high'],
+            defaultEffort: 'high',
+            supportsFastMode: false,
+            status: 'active',
+          },
+          {
+            id: 'claude-opus-5',
+            name: 'Opus 5',
+            group: 'anthropic',
+            sortOrder: 1,
+            contextWindow: 1_000_000,
+            efforts: ['low', 'high'],
+            defaultEffort: 'high',
+            supportsFastMode: false,
+            status: 'active',
+          },
+        ],
+        explicitEffortModelIds: ['claude-opus-5'],
+      }),
+      'utf-8',
+    );
+
+    await loadAnthropicModelsFromDiskCache();
+
+    expect(anthropicModel('claude-sonnet-5')).toMatchObject({
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'high',
+    });
+    expect(anthropicModel('claude-opus-5')).toMatchObject({
+      efforts: ['low', 'high'],
+      defaultEffort: 'high',
+    });
   });
 
   it('磁盘缓存恢复 explicitWindows:重启后 SDK 捕获不把 HTTP 明说窗口打回猜测值(review P2 回归)', async () => {

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -47,7 +47,7 @@ const discoveredByProvider = new Map<string, Partial<Record<AgentKind, CatalogMo
 export interface XdGatewayAgentOverride {
   contextWindow?: number;
   efforts?: string[];
-  defaultEffort?: string;
+  defaultEffort?: string | null;
   supportsFastMode?: boolean;
   defaultEnabled?: boolean;
 }
@@ -62,7 +62,7 @@ export interface XdGatewayModelInfo {
   description?: string;
   contextWindow?: number;
   efforts?: string[];
-  defaultEffort?: string;
+  defaultEffort?: string | null;
   sortOrder?: number;
   /** Fast 支持;缺省按 true(未登记模型的确定性默认:开了没效果无害)。 */
   supportsFastMode?: boolean;
@@ -453,7 +453,8 @@ function computeMerged(): Catalog {
           rawEfforts === undefined
             ? ['low', 'medium', 'high']
             : rawEfforts.filter((e): e is Effort => VALID_EFFORTS.has(e));
-        const rawDefault = ov.defaultEffort ?? gm.defaultEffort;
+        const rawDefault =
+          ov.defaultEffort !== undefined ? ov.defaultEffort : gm.defaultEffort;
         const defaultEffort: Effort | null =
           rawDefault && VALID_EFFORTS.has(rawDefault) && efforts.includes(rawDefault as Effort)
             ? (rawDefault as Effort)

--- a/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
@@ -543,14 +543,7 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
         Array.isArray((m as CatalogModel).efforts),
     );
     if (valid.length === 0) return;
-    // Cache versions before explicitWindows did not distinguish an HTTP-declared
-    // window from the mapper's old fallback. Recompute only non-explicit windows
-    // so catalog corrections take effect immediately after an app upgrade.
-    const normalized = valid.map((model) => ({
-      ...model,
-      contextWindow: contextWindowFor(model.id, explicitWindows.get(model.id)),
-    }));
-    const validIds = new Set(normalized.map((model) => model.id));
+    const validIds = new Set(valid.map((model) => model.id));
     const restoreIds = (value: unknown): Set<string> => {
       const restored = new Set<string>();
       if (Array.isArray(value)) {
@@ -568,6 +561,20 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
     const restoredExplicitFastModeIds = restoreIds(
       (raw as { explicitFastModeModelIds?: unknown }).explicitFastModeModelIds,
     );
+    // Cache versions before per-field provenance did not distinguish
+    // mapper fallbacks from API/SDK-declared capabilities. Refresh every
+    // non-explicit effort baseline and context window from the current
+    // catalog so app upgrades cannot preserve stale model metadata.
+    const normalized = valid.map((model) => {
+      const effortBaseline = restoredExplicitEffortIds.has(model.id)
+        ? null
+        : fallbackEffortBaseline(model.id);
+      return {
+        ...model,
+        contextWindow: contextWindowFor(model.id, explicitWindows.get(model.id)),
+        ...(effortBaseline ?? {}),
+      };
+    });
     await applyModels(
       normalized,
       false,

--- a/apps/desktop/src/main/model-access/__tests__/devMetaOverlay.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/devMetaOverlay.test.ts
@@ -159,8 +159,16 @@ describe('overlayCindyModelMeta', () => {
   it('efforts 显式空数组(不可调)被尊重透传', () => {
     const [m] = overlayCindyModelMeta(
       [SERVER_MODEL],
-      envelope({ 'gpt-5.5': { agents: ['claude-code'], name: 'X', efforts: [] } }),
+      envelope({
+        'gpt-5.5': {
+          agents: ['claude-code'],
+          name: 'X',
+          efforts: [],
+          defaultEffort: null,
+        },
+      }),
     );
     expect(m.efforts).toEqual([]);
+    expect(m.defaultEffort).toBeNull();
   });
 });

--- a/apps/desktop/src/main/model-access/devMetaOverlay.ts
+++ b/apps/desktop/src/main/model-access/devMetaOverlay.ts
@@ -62,20 +62,18 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
  * Gateway 价格。这样本地 overlay 或 null 撤销登记都不会把同快照里的价格静默丢掉。
  */
 function gatewayFields(m: ModelAccessGatewayModel): ModelAccessGatewayModel {
-  const {
-    agents: _agents,
-    name: _name,
-    group: _group,
-    description: _description,
-    icon: _icon,
-    efforts: _efforts,
-    defaultEffort: _defaultEffort,
-    sortOrder: _sortOrder,
-    supportsFastMode: _supportsFastMode,
-    defaultEnabled: _defaultEnabled,
-    perAgent: _perAgent,
-    ...fields
-  } = m;
+  const fields = { ...m };
+  delete fields.agents;
+  delete fields.name;
+  delete fields.group;
+  delete fields.description;
+  delete fields.icon;
+  delete fields.efforts;
+  delete fields.defaultEffort;
+  delete fields.sortOrder;
+  delete fields.supportsFastMode;
+  delete fields.defaultEnabled;
+  delete fields.perAgent;
   return fields;
 }
 
@@ -97,10 +95,13 @@ function readOverrideFields(
     out.efforts = o.efforts as string[];
   }
   if (o.defaultEffort !== undefined) {
-    if (typeof o.defaultEffort !== 'string' || !VALID_EFFORTS.has(o.defaultEffort)) {
+    if (
+      o.defaultEffort !== null &&
+      (typeof o.defaultEffort !== 'string' || !VALID_EFFORTS.has(o.defaultEffort))
+    ) {
       return 'defaultEffort 非法';
     }
-    out.defaultEffort = o.defaultEffort;
+    out.defaultEffort = o.defaultEffort as string | null;
   }
   if (o.supportsFastMode !== undefined) {
     if (typeof o.supportsFastMode !== 'boolean') return 'supportsFastMode 必须是布尔';
@@ -174,7 +175,7 @@ function rebuildModel(m: ModelAccessGatewayModel, meta: MetaEntry): ModelAccessG
     ...(meta.description ? { description: meta.description } : {}),
     ...(meta.icon ? { icon: meta.icon } : {}),
     ...(meta.efforts ? { efforts: meta.efforts } : {}),
-    ...(meta.defaultEffort ? { defaultEffort: meta.defaultEffort } : {}),
+    ...(meta.defaultEffort !== undefined ? { defaultEffort: meta.defaultEffort } : {}),
     ...(meta.sortOrder !== undefined ? { sortOrder: meta.sortOrder } : {}),
     ...(meta.supportsFastMode !== undefined ? { supportsFastMode: meta.supportsFastMode } : {}),
     ...(meta.defaultEnabled !== undefined ? { defaultEnabled: meta.defaultEnabled } : {}),

--- a/apps/desktop/src/main/remote-ssh/__tests__/ccManagerInstallSource.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/ccManagerInstallSource.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('cc-manager install source contract', () => {
+  const source = readFileSync(
+    resolve(process.cwd(), 'src/main/remote-ssh/cc-manager-install.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+
+  it('checks the managed Claude Code pin before taking the cc-manager fast path', () => {
+    const start = source.indexOf(
+      'export async function ensureCcManagerInstalledOrInstall(',
+    );
+    const end = source.indexOf(
+      '\nexport function clearCcManagerInstallCache',
+      start,
+    );
+    const body = source.slice(start, end);
+
+    const agentProbe = body.indexOf(
+      "await probeRemoteAgent(host, 'claude-code')",
+    );
+    const guardedFastPath = body.indexOf(
+      'if (!forceReinstall && claudeRuntimeReady) {',
+    );
+    const ccManagerProbe = body.indexOf('await probeCcManager(host)');
+    const runtimeInstall = body.indexOf(
+      "await installRemoteAgent(host, 'claude-code'",
+    );
+
+    expect(agentProbe).toBeGreaterThan(-1);
+    expect(agentProbe).toBeLessThan(guardedFastPath);
+    expect(guardedFastPath).toBeLessThan(ccManagerProbe);
+    expect(ccManagerProbe).toBeLessThan(runtimeInstall);
+  });
+});

--- a/apps/desktop/src/main/remote-ssh/cc-manager-install.ts
+++ b/apps/desktop/src/main/remote-ssh/cc-manager-install.ts
@@ -10,17 +10,19 @@
  *
  * Flow:
  *   1. Cache hit → return immediately.
- *   2. Probe remote for cc-mgr.mjs + bundled node.
+ *   2. Probe Cindy-managed Claude Code runtime against the current pin.
+ *      - Current → continue to cc-manager probe.
+ *      - Missing / stale → run the full install pipeline.
+ *   3. Probe remote for cc-mgr.mjs + bundled node.
  *      - Both present → cache + return.
  *      - Manager present + node missing → unrecoverable (someone wiped node);
- *        fall through to step 3.
- *      - Manager missing → step 3.
- *   3. If bundled node missing, piggy-back `installRemoteAgent('claude-code')`
+ *        fall through to step 4.
+ *      - Manager missing → step 4.
+ *   4. Piggy-back `installRemoteAgent('claude-code')`
  *      which downloads the sandboxed node into `~/.xdt-server/<v>/node/`.
- *      Side effect: also installs a `claude` shim under `node_modules/.bin/` —
- *      harmless for cc remote (we don't use it), trivial disk cost (~80MB).
- *   4. Upload cc-mgr.mjs bundle via `installCcManagerBundle` (SSH stdin pipe).
- *   5. Cache the host as ready.
+ *      It also installs the pinned `claude` shim under `node_modules/.bin/`.
+ *   5. Upload cc-mgr.mjs bundle via `installCcManagerBundle` (SSH stdin pipe).
+ *   6. Cache the host as ready.
  *
  * Concurrency: same-host concurrent installs deduplicated via in-flight Map,
  * matching the pattern in `ensureRemoteAgentInstalledOrInstall` (index.ts).
@@ -264,12 +266,38 @@ export async function ensureCcManagerInstalledOrInstall(opts: {
     throwIpcError('SSH_NOT_CONNECTED', `ssh host ${hostId} not connected`);
   }
 
+  // cc-manager 的存在性和版本只证明 daemon bundle 可用，不证明它将启动的
+  // Claude Code binary 符合当前 Desktop pin。应用升级后 in-memory cache 为空，
+  // cold path 必须先做 agent probe；旧 runtime 直接跳过下面的 cc-manager fast
+  // path，进入统一 install pipeline 自动升级 binary。
+  let claudeRuntimeReady = forceReinstall;
+  if (!forceReinstall) {
+    try {
+      const agentProbe = await probeRemoteAgent(host, 'claude-code');
+      claudeRuntimeReady = agentProbe.installed;
+      if (agentProbe.installed && agentProbe.binaryPath) {
+        claudeBinaryPathCache.set(hostId, agentProbe.binaryPath);
+      } else {
+        log.info('cc-mgr install: Claude Code runtime missing or stale, installing current pin', {
+          hostId,
+          installedVersion: agentProbe.installedVersion,
+        });
+      }
+    } catch (err) {
+      claudeRuntimeReady = false;
+      log.warn('cc-mgr install: Claude Code version probe failed (will attempt install)', {
+        hostId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   // Fast path: probe + cache if both bundle and node already there. Also
   // compare bundle version — mismatch surfaces an UpgradeBanner via push, but
   // does NOT force-restart the daemon here (would kill any alive sessions
   // mid-turn). User accepts upgrade explicitly via the banner's button →
   // `runCcMgrUpgrade` calls back with forceReinstall=true to skip this path.
-  if (!forceReinstall) {
+  if (!forceReinstall && claudeRuntimeReady) {
     try {
       const probe = await probeCcManager(host);
       if (probe.ccManagerInstalled && probe.nodeReady) {

--- a/apps/desktop/src/main/remote-ssh/index.ts
+++ b/apps/desktop/src/main/remote-ssh/index.ts
@@ -253,8 +253,9 @@ const remoteAgentInstalledCache = new Map<string, Set<RemoteAgentKind>>();
  * 把"binary not installed"这类问题从 daemon 启动失败的 stack trace 转成 renderer
  * 能正确 toast 的 SSH_AGENT_NOT_INSTALLED IPC error, 引导用户去 Settings 安装。
  *
- * 实现走 `test -x` 而非完整 probeRemoteAgent — 后者 ~200ms 包含 node version
- * 检查, 这里我们只关心"binary 是否在该路径", 命中 cache 后续 ~0ms。
+ * Claude Code 首次检查走完整 probeRemoteAgent,确保 Cindy 管理的远端 runtime
+ * 与当前 pin 一致；否则客户端升级后旧 binary 会永久命中 `test -x`。Codex 仍
+ * 只做存在性检查。两者命中内存 cache 后续都是 ~0ms。
  */
 export async function ensureRemoteAgentInstalled(
   hostId: string,
@@ -269,15 +270,17 @@ export async function ensureRemoteAgentInstalled(
     throwIpcError('SSH_NOT_CONNECTED', `ssh host ${hostId} not connected`);
   }
 
-  const binPath = agentKind === 'codex'
-    ? '$HOME/.xdt-server/v1/codex-home/packages/standalone/current/codex'
-    : '$HOME/.xdt-server/v1/node_modules/.bin/claude';
-  // 用 test -x; 退出码 0=存在&可执行, 非 0=不存在/不可执行。stdout 不读, exitCode 已足。
-  const result = await host.exec(`test -x ${binPath} && echo OK || echo MISSING`, {
-    timeoutMs: 5_000,
-    label: 'check-agent-installed',
-  });
-  const ok = result.stdout.trim() === 'OK';
+  let ok: boolean;
+  if (agentKind === 'claude-code') {
+    ok = (await probeRemoteAgent(host, agentKind)).installed;
+  } else {
+    const binPath = '$HOME/.xdt-server/v1/codex-home/packages/standalone/current/codex';
+    const result = await host.exec(`test -x ${binPath} && echo OK || echo MISSING`, {
+      timeoutMs: 5_000,
+      label: 'check-agent-installed',
+    });
+    ok = result.stdout.trim() === 'OK';
+  }
   if (!ok) {
     const friendlyKind = agentKind === 'codex' ? 'Codex' : 'Claude Code';
     throwIpcError(

--- a/apps/desktop/src/shared/modelAccess.ts
+++ b/apps/desktop/src/shared/modelAccess.ts
@@ -94,7 +94,7 @@ export const MODEL_ACCESS_STATUS_CHANNEL = 'model-access:status-change';
 export interface ModelAccessAgentOverride {
   contextWindow?: number;
   efforts?: string[];
-  defaultEffort?: string;
+  defaultEffort?: string | null;
   supportsFastMode?: boolean;
   defaultEnabled?: boolean;
 }
@@ -161,7 +161,7 @@ export interface ModelAccessGatewayModel extends ModelGroupPricing {
   contextWindow?: number;
   maxOutputTokens?: number;
   efforts?: string[];
-  defaultEffort?: string;
+  defaultEffort?: string | null;
   sortOrder?: number;
   /** Fast(加速档)支持;缺省按 true 处理(开了没效果无害,但不能没有)。 */
   supportsFastMode?: boolean;

--- a/packages/maker-remote-ssh/src/__tests__/remote-agent-installer.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remote-agent-installer.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { BOOTSTRAP_SH } from '../bootstrap/bootstrap-script.js';
 import {
   installRemoteAgent,
+  PINNED_CLAUDE_CODE_VERSION,
   PINNED_CODEX_RELEASE_VERSION,
+  probeRemoteAgent,
 } from '../bootstrap/installer.js';
 import type { RemoteHost } from '../RemoteHost.js';
 
@@ -37,5 +39,38 @@ describe('remote agent installer', () => {
   it('runs install.sh with --release when a Codex release arg is present', () => {
     expect(BOOTSTRAP_SH).toContain('INSTALLER_URL="https://github.com/openai/codex/releases/download/rust-v$CODEX_RELEASE/install.sh"');
     expect(BOOTSTRAP_SH).toContain('sh "$INSTALLER_TMP" --release "$CODEX_RELEASE"');
+  });
+
+  it('pins Claude Code for probe and install, and rejects a stale sentinel version', async () => {
+    const calls: Array<{ command: string; input: string }> = [];
+    const host = {
+      exec: async (command: string, opts: { input?: string }) => {
+        calls.push({ command, input: opts.input ?? '' });
+        return {
+          exitCode: 0,
+          stdout: [
+            'INSTALL_DIR /home/u/.xdt-server/v1',
+            'NOT_INSTALLED',
+          ].join('\n'),
+          stderr: '',
+        };
+      },
+    } as Pick<RemoteHost, 'exec'> as RemoteHost;
+
+    const probe = await probeRemoteAgent(host, 'claude-code');
+    expect(probe.installed).toBe(false);
+    expect(calls[0].command).toContain(`'${PINNED_CLAUDE_CODE_VERSION}'`);
+    expect(calls[0].input).toContain(
+      '[ "${V%% *}" = "$CLAUDE_RELEASE" ]',
+    );
+
+    await installRemoteAgent(host, 'claude-code');
+    expect(calls[1].command).toContain(`'${PINNED_CLAUDE_CODE_VERSION}'`);
+    expect(calls[1].input).toContain(
+      'NPM_PKG="@anthropic-ai/claude-code@$CLAUDE_RELEASE"',
+    );
+    expect(calls[1].input).toContain(
+      'Claude Code version ${V%% *} != managed pin $CLAUDE_RELEASE',
+    );
   });
 });

--- a/packages/maker-remote-ssh/src/bootstrap/bootstrap-script.ts
+++ b/packages/maker-remote-ssh/src/bootstrap/bootstrap-script.ts
@@ -80,6 +80,7 @@ export const CODEX_LATEST_INSTALLER_URL = 'https://chatgpt.com/codex/install.sh'
  *   $3 = bundled node version (BUNDLED_NODE_VERSION)
  *   $4 = node dist base URL (NODE_DIST_BASE_URL_DEFAULT)
  *   $5 = codex release version (tools/codex/latest.json pin; codex only)
+ *   $6 = Claude Code version (tools/claude/latest.json pin; claude-code only)
  *
  * The version + URL are passed as args (not hardcoded) so a host-side
  * config knob can later override them without changing this file.
@@ -93,6 +94,7 @@ SERVER_VER="${'$'}{2:-v1}"
 NODE_VER="${'$'}{3:-22.13.0}"
 NODE_BASE_URL="${'$'}{4:-https://nodejs.org/dist}"
 CODEX_RELEASE="${'$'}{5:-}"
+CLAUDE_RELEASE="${'$'}{6:-}"
 
 emit() { printf '%s\n' "$*"; }
 
@@ -105,7 +107,14 @@ emit() { printf '%s\n' "$*"; }
 #                 The npm @openai/codex package does NOT create that layout
 #                 (see codex-rs/app-server-daemon/src/managed_install.rs).
 case "$AGENT_KIND" in
-  claude-code) NPM_PKG="@anthropic-ai/claude-code"; BIN_NAME="claude" ;;
+  claude-code)
+    if [ -z "$CLAUDE_RELEASE" ]; then
+      emit "ERROR missing Claude Code release"
+      exit 4
+    fi
+    NPM_PKG="@anthropic-ai/claude-code@$CLAUDE_RELEASE"
+    BIN_NAME="claude"
+    ;;
   codex)       NPM_PKG="";                          BIN_NAME="codex"  ;;
   *) emit "ERROR unknown agent kind: $AGENT_KIND"; exit 10 ;;
 esac
@@ -255,10 +264,14 @@ verify_binary() {
     V="$("$NODE_BIN" "$BIN_PATH" --version 2>>"$_STDERR_LOG" | head -1 || true)"
   fi
 
-  if [ -n "$V" ]; then
+  if [ -n "$V" ] &&
+     { [ "$AGENT_KIND" != "claude-code" ] || [ "${'$'}{V%% *}" = "$CLAUDE_RELEASE" ]; }; then
     emit "READY $V"
     rm -f "$_STDERR_LOG"
     return 0
+  fi
+  if [ -n "$V" ]; then
+    emit "INSTALL_LOG [verify-fail] Claude Code version ${'$'}{V%% *} != managed pin $CLAUDE_RELEASE"
   fi
   # Diagnostics on failure — these go to INSTALL_LOG so the desktop main process
   # logs them (silent install pipeline forwards INSTALL_LOG lines verbatim).

--- a/packages/maker-remote-ssh/src/bootstrap/installer.ts
+++ b/packages/maker-remote-ssh/src/bootstrap/installer.ts
@@ -16,6 +16,7 @@
  */
 
 import type { RemoteHost } from '../RemoteHost.js';
+import claudeLatest from '../../../../tools/claude/latest.json';
 import codexLatest from '../../../../tools/codex/latest.json';
 import {
   BOOTSTRAP_SH,
@@ -29,6 +30,7 @@ export { REMOTE_SERVER_SCHEMA_VERSION };
 
 export type RemoteAgentKind = 'claude-code' | 'codex';
 
+export const PINNED_CLAUDE_CODE_VERSION = claudeLatest.version;
 export const PINNED_CODEX_RELEASE_VERSION = codexLatest.version;
 
 export interface ProbeResult {
@@ -85,6 +87,7 @@ export async function probeRemoteAgent(
 set -u
 AGENT_KIND="${'$'}{1:-}"
 SERVER_VER="${'$'}{2:-v1}"
+CLAUDE_RELEASE="${'$'}{3:-}"
 case "$AGENT_KIND" in
   claude-code) BIN_NAME="claude" ;;
   codex)       BIN_NAME="codex"  ;;
@@ -110,7 +113,12 @@ ${PROBE_BUNDLED_NODE_SH}
 export PATH="$NODE_DIR/bin:$PATH"
 if [ -f "$SENTINEL" ] && { [ -x "$BIN_PATH" ] || [ -f "$BIN_PATH" ]; }; then
   V="$("$BIN_PATH" --version 2>/dev/null | head -1 || true)"
-  if [ -n "$V" ]; then printf 'READY %s\n' "$V"; exit 0; fi
+  if [ -n "$V" ]; then
+    if [ "$AGENT_KIND" != "claude-code" ] || [ "${'$'}{V%% *}" = "$CLAUDE_RELEASE" ]; then
+      printf 'READY %s\n' "$V"
+      exit 0
+    fi
+  fi
 fi
 printf 'NOT_INSTALLED\n'; exit 0
 `;
@@ -118,7 +126,12 @@ printf 'NOT_INSTALLED\n'; exit 0
   // `bash -l` so login profile (~/.bash_profile / ~/.profile) gets sourced.
   // Mostly defensive — bundled Node design means we don't actually depend on
   // the user's profile setting PATH. Kept for parity with install command.
-  const result = await host.exec(`bash -l -s -- ${agentKind} ${REMOTE_SERVER_SCHEMA_VERSION}`, {
+  const args = [
+    agentKind,
+    REMOTE_SERVER_SCHEMA_VERSION,
+    PINNED_CLAUDE_CODE_VERSION,
+  ].map(shellQuoteArg).join(' ');
+  const result = await host.exec(`bash -l -s -- ${args}`, {
     input: probeScript,
     timeoutMs: PROBE_TIMEOUT_MS,
   });
@@ -152,7 +165,8 @@ export async function installRemoteAgent(
     REMOTE_SERVER_SCHEMA_VERSION,
     BUNDLED_NODE_VERSION,
     NODE_DIST_BASE_URL_DEFAULT,
-    agentKind === 'codex' ? PINNED_CODEX_RELEASE_VERSION : '',
+    PINNED_CODEX_RELEASE_VERSION,
+    PINNED_CLAUDE_CODE_VERSION,
   ].map(shellQuoteArg).join(' ');
 
   const result = await host.exec(`bash -l -s -- ${args}`, {


### PR DESCRIPTION
## 这次改了什么

### 摘要

收口 #372 合并后 Codex review 发现的三处兼容问题：

- dev `cindyModelMeta` overlay 现在接受并保留 `defaultEffort: null`，不可调模型不会因本地覆盖条目被判非法。
- Anthropic 磁盘缓存恢复时会用当前目录刷新非明确来源的 `efforts/defaultEffort`，同时保留 HTTP / SDK 明确返回的能力。
- SSH 远端 Claude Code 改为使用 `tools/claude/latest.json` 的精确版本；实际的 cc-manager 首次消息准备路径会先校验 pin，识别旧版本并触发自修复安装。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#372 的 post-merge review feedback
- 本 PR 包含：Desktop model-access / Anthropic discovery cache、SSH remote Claude Code bootstrap 与回归测试
- 明确不包含：模型目录名称、effort 产品档位、Claude Code 本机 bundled runtime 的进一步调整
- 用户可见变化：旧远端 Claude Code 会在首次使用时自动升级；dev overlay 与缓存恢复不再丢失正确 effort 能力
- 是否存在 breaking change：无

### UI 变化

不涉及。没有修改 UI 组件、布局、样式、交互或文案。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：通过

pnpm --filter desktop exec vitest run src/main/remote-ssh/__tests__/ccManagerInstallSource.test.ts src/main/model-access/__tests__/devMetaOverlay.test.ts src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
结果：3 files / 42 tests 通过

pnpm --filter @cindy/maker-remote-ssh test
结果：8 files / 70 tests 通过

pnpm --filter @cindy/maker-remote-ssh run build
结果：通过

pnpm --filter desktop exec eslint <本 PR 涉及的 Desktop 文件>
结果：通过

git diff --check
结果：通过

bash -n <生成的 BOOTSTRAP_SH>
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

`pnpm --filter desktop run --if-present typecheck` 未通过，但已在未改动的 #372 合并分支复现相同两项基线错误：

- `src/main/cindy-brain/index.ts`: `requestNodeInstallAuthorization` 未定义
- `src/renderer/cindy-brain/__tests__/installFlow.test.tsx`: `canceled` fixture 类型不匹配

本 PR 未触及上述插件安装代码；全量 `pnpm test:unit` 门禁已通过，CI checks 继续作为权威结论。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 的 XD dev 模型元数据、Anthropic 动态发现缓存，以及 macOS / Linux SSH 远端 Claude Code 安装。
- 回滚 / 降级方式：回滚本提交后恢复旧 overlay、缓存与远端 runtime 探测行为；不涉及数据 schema 或不可逆迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需同步：未修改作者可见契约或 UI）
- [x] 已确认测试结果或说明未执行原因
