### PR TITLE
fix(maker-core): release Codex thread runtime on close (#324)

### DIFF
--- a/packages/maker-core/src/agents/codex/app-server/client.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.test.ts
@@ -227,6 +227,35 @@ describe('AppServerClient auth invalidation', () => {
   });
 });
 
+describe('AppServerClient request timeout', () => {
+  it('rejects and removes a pending request when the server stays connected without responding', async () => {
+    vi.useFakeTimers();
+    try {
+      const transport = new FakeTransport();
+      const client = new AppServerClient({
+        createTransport: () => transport,
+        logger,
+      });
+      client.start();
+
+      const request = client.request(
+        'thread/unsubscribe',
+        { threadId: 'thread-1' },
+        { timeoutMs: 25 },
+      );
+      const rejection = expect(request).rejects.toThrow(
+        'codex app-server thread/unsubscribe timed out after 25ms',
+      );
+      await vi.advanceTimersByTimeAsync(25);
+
+      await rejection;
+      await expect(client.close()).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('AppServerClient server requests', () => {
   it('passes request id/method metadata to handlers and answers the original JSON-RPC request', async () => {
     const transport = new FakeTransport();

--- a/packages/maker-core/src/agents/codex/app-server/client.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.ts
@@ -149,6 +149,7 @@ interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
   method: string;
+  timeoutId: ReturnType<typeof setTimeout> | null;
 }
 
 /**
@@ -258,6 +259,7 @@ export class AppServerClient {
     // reject 所有挂起 request — 上层 await 不会无限等。
     const err = new Error(`codex app-server closed: ${reason}`);
     for (const [, pending] of this.pending) {
+      if (pending.timeoutId) clearTimeout(pending.timeoutId);
       pending.reject(err);
     }
     this.pending.clear();
@@ -278,7 +280,11 @@ export class AppServerClient {
    * 发送一个 JSON-RPC request, 等待对应 id 的 response。
    * server 返回 error 时 reject 一个携带 code+message 的 Error。
    */
-  request<R = unknown>(method: string, params?: unknown): Promise<R> {
+  request<R = unknown>(
+    method: string,
+    params?: unknown,
+    opts?: { timeoutMs?: number },
+  ): Promise<R> {
     if (this.closed) {
       return Promise.reject(new Error(`AppServerClient.request(${method}) after close()`));
     }
@@ -288,18 +294,38 @@ export class AppServerClient {
     const transport = this.transport;
     const id = this.nextId++;
     const payload = JSON.stringify({ id, method, params });
+    const timeoutMs = opts?.timeoutMs;
+    if (
+      timeoutMs !== undefined &&
+      (!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+    ) {
+      return Promise.reject(
+        new Error(`AppServerClient.request(${method}): timeoutMs must be a positive finite number`),
+      );
+    }
     return new Promise<R>((resolve, reject) => {
-      this.pending.set(id, {
+      const pending: PendingRequest = {
         resolve: resolve as (v: unknown) => void,
         reject,
         method,
-      });
+        timeoutId: null,
+      };
+      this.pending.set(id, pending);
+      if (timeoutMs !== undefined) {
+        pending.timeoutId = setTimeout(() => {
+          if (this.pending.get(id) !== pending) return;
+          this.pending.delete(id);
+          reject(new Error(`codex app-server ${method} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        pending.timeoutId.unref?.();
+      }
       transport.writeLine(payload).then(undefined, (err: Error) => {
         // transport 拒绝就立刻 reject 这一 request, 不要让它在 pending 里等到 close。
         // 只有 response 尚未先到时才留 tombstone；否则迟到的 write callback 不应
         // 重新关联已经完成的 id。
-        if (!this.pending.has(id)) return;
+        if (this.pending.get(id) !== pending) return;
         this.pending.delete(id);
+        if (pending.timeoutId) clearTimeout(pending.timeoutId);
         this.rememberWriteFailure(id, method);
         reject(err);
       });
@@ -407,6 +433,7 @@ export class AppServerClient {
       return;
     }
     this.pending.delete(id);
+    if (pending.timeoutId) clearTimeout(pending.timeoutId);
     if (error) {
       this.notifyAuthInvalidated(error);
       const err = new Error(`codex app-server ${pending.method} error ${error.code}: ${error.message}`);

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -9,8 +9,8 @@
  * Lifecycle (用户明确要求, 比 refcount 模型更简单):
  *   - 懒启动: 第一个 acquire/subscribeThread 触发 spawn + initialize
  *   - server 一旦起来, 跟 CodexAgent (= app 进程) 同生命周期, **不随 session 数升降**
- *   - session.close → subscription.release(): 仅从路由表删掉 + 不再收 notification
- *     server 端 thread state 仍在内存中 (server 自己 GC, 我们不主动 thread/unsubscribe — Phase 2 再优化)
+ *   - session.close → subscription.release(): 删除本地路由并发送 thread/unsubscribe,
+ *     释放该 thread 的 live runtime；共享 app-server 继续服务其他 session
  *   - app.before-quit → 上层显式调 host.shutdown() (Windows 子进程不会随父进程死)
  *
  * 真值参考:
@@ -519,8 +519,8 @@ export class AppServerHost {
   // ── 订阅 / 路由 ───────────────────────────────────────────────────────────
 
   /**
- * 为 thread_id 注册一组 handler。release() 先移除本地路由，再通知 app-server
- * 解除这个 thread 的 live subscription；rollout/history 不会被 archive 或 delete。
+   * 为 thread_id 注册一组 handler。release() 先移除本地路由，再通知 app-server
+   * 解除这个 thread 的 live subscription；rollout/history 不会被 archive 或 delete。
    * 如果 thread/started (或更早的 notification) 在 subscribe 之前就到了, drain
    * buffered 队列里匹配的项, 按到达顺序 dispatch — 保证不丢事件。
    *

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -53,6 +53,7 @@ import {
   type JsonRpcId,
   type ThreadStartedNotification,
   type ThreadTokenUsageUpdatedNotification,
+  type ThreadUnsubscribeResponse,
   type TurnPlanUpdatedNotification,
   type TurnCompletedNotification,
   type TurnStartedNotification,
@@ -184,8 +185,8 @@ export interface ServerRequestMeta {
 }
 
 export interface ThreadSubscription {
-  /** 幂等; 调用后不再收到 notification + 触发 refcount 递减 (可能触发 idle 关停)。 */
-  release(): void;
+  /** 幂等地解除本地路由，并释放 app-server 内对应 thread 的 live runtime。 */
+  release(): Promise<void>;
 }
 
 export interface AppServerHostOptions {
@@ -518,14 +519,13 @@ export class AppServerHost {
   // ── 订阅 / 路由 ───────────────────────────────────────────────────────────
 
   /**
-   * 为 thread_id 注册一组 handler, release() 仅取消订阅 (不影响 server 生命周期)。
+ * 为 thread_id 注册一组 handler。release() 先移除本地路由，再通知 app-server
+ * 解除这个 thread 的 live subscription；rollout/history 不会被 archive 或 delete。
    * 如果 thread/started (或更早的 notification) 在 subscribe 之前就到了, drain
    * buffered 队列里匹配的项, 按到达顺序 dispatch — 保证不丢事件。
    *
-   * **不**做 refcount → shutdown — server 只跟 host.shutdown() 绑定。session.close
-   * 仅清掉路由表, server 自己会 GC 闲置 ThreadState。Phase 2 可考虑发
-   * `thread/unsubscribe` 给 server 显式释放 listener (当前 server-side 内存
-   * 占用极小, 跳过)。
+ * 不做 refcount → shutdown：共享 server 仍只跟 host.shutdown() 绑定。这里仅释放
+ * 已关闭 session 对应的 thread state，避免它继续持有 MCP/app-server 子进程资源。
    */
   subscribeThread(threadId: string, handlers: ThreadEventHandlers): ThreadSubscription {
     if (this.retired) {
@@ -559,13 +559,17 @@ export class AppServerHost {
 
     let released = false;
     return {
-      release: () => {
+      release: async () => {
         if (released) return;
         released = true;
         const cur = this.subscribers.get(threadId);
-        if (cur === handlers) {
-          this.subscribers.delete(threadId);
-        }
+        // A later subscription for the same thread owns the live server state now.
+        if (cur !== handlers) return;
+        this.subscribers.delete(threadId);
+        this.buffered.delete(threadId);
+        const client = this.client;
+        if (!client) return;
+        await client.request<ThreadUnsubscribeResponse>(Method.ThreadUnsubscribe, { threadId });
       },
     };
   }

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -101,6 +101,8 @@ const NOTIFICATIONS_TO_OPT_OUT = [
   'turn/diff/updated',
 ];
 
+const DEFAULT_THREAD_UNSUBSCRIBE_TIMEOUT_MS = 5_000;
+
 /** thread/started 之外的 notification 都直接 params.threadId; thread/started 走 params.thread.id。 */
 function extractThreadId(method: string, params: unknown): string | null {
   if (!params || typeof params !== 'object') return null;
@@ -204,6 +206,8 @@ export interface AppServerHostOptions {
    * 解决 thread/started 比 subscribeThread() 早到的固有竞争。
    */
   notificationBufferTtlMs?: number;
+  /** thread/unsubscribe 的最大等待时间，避免 session close 被失联 app-server 卡死。 */
+  threadUnsubscribeTimeoutMs?: number;
   /**
    * 关联中的 JSON-RPC response 明确返回 cloudRequirements Auth/relogin 时调用一次
    * (单次 latch 在 client 内)。stderr 始终只作为诊断日志。
@@ -226,6 +230,7 @@ export class AppServerHost {
   private readonly connectionId = randomUUID();
   private readonly logger: Logger;
   private readonly bufferTtlMs: number;
+  private readonly threadUnsubscribeTimeoutMs: number;
 
   private client: AppServerClient | null = null;
   /** 同次 ensureStarted 并发调用共享一个 init Promise (避免重复 spawn)。 */
@@ -249,6 +254,8 @@ export class AppServerHost {
     }
     this.logger = opts.logger.child('codex-app-server-host');
     this.bufferTtlMs = opts.notificationBufferTtlMs ?? 5_000;
+    this.threadUnsubscribeTimeoutMs =
+      opts.threadUnsubscribeTimeoutMs ?? DEFAULT_THREAD_UNSUBSCRIBE_TIMEOUT_MS;
   }
 
   isCodexProxyActive(): boolean {
@@ -464,6 +471,17 @@ export class AppServerHost {
     return this.client.request<R>(method, params);
   }
 
+  /** Release one thread's live runtime without archiving or deleting its history. */
+  async unsubscribeThread(threadId: string): Promise<void> {
+    const client = this.client;
+    if (!client) return;
+    await client.request<ThreadUnsubscribeResponse>(
+      Method.ThreadUnsubscribe,
+      { threadId },
+      { timeoutMs: this.threadUnsubscribeTimeoutMs },
+    );
+  }
+
   /**
    * 强制关停 (app.before-quit / 测试 cleanup / transport error 恢复)。幂等。
    * 清空 subscribers + close client (杀子进程)。**结束后允许 ensureStarted 重新 spawn**
@@ -557,19 +575,38 @@ export class AppServerHost {
       }
     }
 
-    let released = false;
+    let localReleased = false;
+    let serverReleased = false;
+    let releasePromise: Promise<void> | null = null;
     return {
-      release: async () => {
-        if (released) return;
-        released = true;
-        const cur = this.subscribers.get(threadId);
-        // A later subscription for the same thread owns the live server state now.
-        if (cur !== handlers) return;
-        this.subscribers.delete(threadId);
-        this.buffered.delete(threadId);
-        const client = this.client;
-        if (!client) return;
-        await client.request<ThreadUnsubscribeResponse>(Method.ThreadUnsubscribe, { threadId });
+      release: () => {
+        if (serverReleased) return Promise.resolve();
+        if (releasePromise) return releasePromise;
+
+        if (!localReleased) {
+          const cur = this.subscribers.get(threadId);
+          // A later subscription for the same thread owns the live server state now.
+          if (cur !== handlers) {
+            serverReleased = true;
+            return Promise.resolve();
+          }
+          this.subscribers.delete(threadId);
+          this.buffered.delete(threadId);
+          localReleased = true;
+        } else if (this.subscribers.has(threadId)) {
+          // A retry must not unsubscribe a newer local owner for the same thread.
+          serverReleased = true;
+          return Promise.resolve();
+        }
+
+        releasePromise = this.unsubscribeThread(threadId)
+          .then(() => {
+            serverReleased = true;
+          })
+          .finally(() => {
+            releasePromise = null;
+          });
+        return releasePromise;
       },
     };
   }

--- a/packages/maker-core/src/agents/codex/app-server/protocol.ts
+++ b/packages/maker-core/src/agents/codex/app-server/protocol.ts
@@ -427,6 +427,17 @@ export interface ThreadRollbackResponse {
   [k: string]: unknown;
 }
 
+/** Release the app-server's live state for a thread without archiving its history. */
+export interface ThreadUnsubscribeParams {
+  threadId: string;
+}
+
+export type ThreadUnsubscribeStatus = 'notLoaded' | 'notSubscribed' | 'unsubscribed';
+
+export interface ThreadUnsubscribeResponse {
+  status: ThreadUnsubscribeStatus;
+}
+
 // ── ThreadSettingsUpdate (v2.rs ThreadSettingsUpdateParams) ──────────────────
 // 会话中途单独推 model / serviceTier / effort 等设置, server 写入后续 turn 的
 // sticky context (不必等下一个 turn/start 携带)。需要 experimentalApi capability
@@ -960,6 +971,7 @@ export const Method = {
   ThreadResume: 'thread/resume',
   ThreadFork: 'thread/fork',
   ThreadRollback: 'thread/rollback',
+  ThreadUnsubscribe: 'thread/unsubscribe',
   ThreadSettingsUpdate: 'thread/settings/update',
   TurnStart: 'turn/start',
   TurnSteer: 'turn/steer',

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -112,6 +112,10 @@ const { MockCodexTransport, createdTransports } = vi.hoisted(() => {
         });
         return;
       }
+      if (req.method === 'thread/unsubscribe') {
+        this.emitLine({ id: req.id, result: { status: 'unsubscribed' } });
+        return;
+      }
       if (req.method === 'skills/list') {
         const params = req.params as { cwds?: string[] } | undefined;
         const cwds = params?.cwds ?? ['/repo'];
@@ -2848,6 +2852,30 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
     expect(unregisterCodexMcpThreadContext).toHaveBeenCalledTimes(1);
     expect(unregisterCodexMcpThreadContext).toHaveBeenCalledWith('start-thread-id');
+  });
+
+  it('unsubscribes the app-server thread when closing a local session without stopping the shared host', async () => {
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({
+      sessionId: 'session-codex-mcp-runtime-release',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      vendorOptions: { orcaRole: 'worker' },
+    });
+
+    const transport = createdTransports[0];
+    expect(transport).toBeDefined();
+
+    await handle.close();
+
+    const unsubscribe = transport!.lines
+      .map((line) => JSON.parse(line) as { method?: string; params?: unknown })
+      .find((request) => request.method === Method.ThreadUnsubscribe);
+    expect(unsubscribe).toMatchObject({
+      method: Method.ThreadUnsubscribe,
+      params: { threadId: 'thread-1' },
+    });
+    expect(transport!.closed).toBe(false);
   });
 
   it('skips Codex MCP thread context registration for remote sessions', async () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -19,6 +19,7 @@ const { MockCodexTransport, createdTransports } = vi.hoisted(() => {
   class MockCodexTransport {
     static threadSeq = 1;
     static failThreadStart = false;
+    static dropThreadUnsubscribe = false;
     static beforeThreadStartResponse: ((transport: MockCodexTransport) => Promise<void> | void) | null = null;
     static onCreate: ((transport: MockCodexTransport) => void) | null = null;
 
@@ -113,6 +114,7 @@ const { MockCodexTransport, createdTransports } = vi.hoisted(() => {
         return;
       }
       if (req.method === 'thread/unsubscribe') {
+        if (MockCodexTransport.dropThreadUnsubscribe) return;
         this.emitLine({ id: req.id, result: { status: 'unsubscribed' } });
         return;
       }
@@ -225,6 +227,7 @@ beforeEach(() => {
   createdTransports.length = 0;
   MockCodexTransport.threadSeq = 1;
   MockCodexTransport.failThreadStart = false;
+  MockCodexTransport.dropThreadUnsubscribe = false;
   MockCodexTransport.beforeThreadStartResponse = null;
   MockCodexTransport.onCreate = null;
 });
@@ -346,11 +349,13 @@ function installFakeHost(
     threadHandlers = handlers;
     return { release: vi.fn() };
   });
+  const unsubscribeThread = vi.fn(async (_threadId: string) => {});
   const isCodexProxyActive = vi.fn(() => opts.codexProxyActive === true);
   const host = {
     ensureStarted,
     request,
     subscribeThread,
+    unsubscribeThread,
     isCodexProxyActive,
     getConnectionId: () => 'test-connection',
     getThreadHandlers: () => threadHandlers,
@@ -2878,6 +2883,28 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(transport!.closed).toBe(false);
   });
 
+  it('finishes closing when the app-server stays connected without answering thread/unsubscribe', async () => {
+    vi.useFakeTimers();
+    try {
+      MockCodexTransport.dropThreadUnsubscribe = true;
+      const agent = new CodexAgent(createDeps());
+      const handle = await agent.startSession({
+        sessionId: 'session-codex-mcp-runtime-release-timeout',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+        vendorOptions: { orcaRole: 'worker' },
+      });
+
+      const closePromise = handle.close();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(closePromise).resolves.toBeUndefined();
+      expect(createdTransports[0]?.closed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('skips Codex MCP thread context registration for remote sessions', async () => {
     const registerCodexMcpThreadContext = vi.fn();
     const unregisterCodexMcpThreadContext = vi.fn();
@@ -4404,6 +4431,38 @@ describe('CodexAgent rewind', () => {
       text: registeredText,
     });
     await handle.close();
+  });
+
+  it('discards the replacement thread when close races with rollback cleanup', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-rewind-close-race',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const commitRewindFiles = handle.commitRewindFiles;
+    if (!commitRewindFiles) throw new Error('expected commitRewindFiles');
+
+    let resolveRelease: (() => void) | undefined;
+    const releaseGate = new Promise<void>((resolve) => {
+      resolveRelease = resolve;
+    });
+    const initialSubscription = host.subscribeThread.mock.results[0]?.value;
+    const release = initialSubscription?.release;
+    if (!release) throw new Error('expected initial subscription');
+    release.mockImplementation(() => releaseGate);
+
+    const rewindPromise = commitRewindFiles('', '', { tailTurnsToDrop: 1 });
+    await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+    const closePromise = handle.close();
+    await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(2));
+    resolveRelease?.();
+
+    await expect(rewindPromise).resolves.toEqual({ sdkSessionId: 'start-thread-id' });
+    await closePromise;
+    expect(host.subscribeThread).toHaveBeenCalledTimes(1);
+    expect(host.unsubscribeThread).toHaveBeenCalledWith('rollback-thread-id');
   });
 });
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1735,7 +1735,7 @@ export class CodexAgent extends BaseAgent {
     if (opts?.maxTokens !== undefined) {
       log.warn(`maxTokens=${opts.maxTokens} ignored — Codex host protocol does not expose max_tokens`);
     }
-    let subscription: { release: () => void } | null = null;
+    let subscription: ThreadSubscription | null = null;
     try {
       const { host } = await this.getUtilityHost();
       await host.ensureStarted();
@@ -4241,6 +4241,21 @@ export class CodexAgent extends BaseAgent {
             // no-op: stale subscription cleanup should not fail a successful rollback.
           }
           unregisterCodexMcpContext(previousThreadId);
+          if (closed) {
+            try {
+              await host.unsubscribeThread(nextThreadId);
+            } catch (e) {
+              log.warn('thread/unsubscribe replacement after close threw', {
+                error: String(e),
+                threadId: nextThreadId,
+              });
+            }
+            log.info('commitRewindFiles discarded replacement after concurrent close', {
+              previousThreadId,
+              nextThreadId,
+            });
+            return sdkSessionId ? { sdkSessionId } : {};
+          }
           threadId = nextThreadId;
           sdkSessionId = nextThreadId;
           subscription = host.subscribeThread(threadId, handlers);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1842,7 +1842,7 @@ export class CodexAgent extends BaseAgent {
       // 网络/host 启动等未分类失败统一归 'network' (跟 claude 端 mapAnthropicError 一致)
       throw new OneShotError('network', err instanceof Error ? err.message : String(err));
     } finally {
-      try { subscription?.release(); } catch { /* no-op */ }
+      try { await subscription?.release(); } catch { /* no-op */ }
     }
   }
 
@@ -4099,7 +4099,7 @@ export class CodexAgent extends BaseAgent {
         try { dismissAllPending('session_closed', 'deny'); } catch (e) { log.warn('dismissAllPending threw', { error: String(e) }); }
         try { dismissAllPendingUserInput('session_closed'); } catch (e) { log.warn('dismissAllPendingUserInput threw', { error: String(e) }); }
         try { stopActiveRolloutPlanFallback(); } catch (e) { log.warn('stop rollout plan fallback threw', { error: String(e) }); }
-        try { subscription?.release(); } catch (e) { log.warn('release threw', { error: String(e) }); }
+        try { await subscription?.release(); } catch (e) { log.warn('release threw', { error: String(e) }); }
         try { eventQueue.end(); } catch (e) { log.warn('eventQueue.end threw', { error: String(e) }); }
       },
 
@@ -4236,7 +4236,7 @@ export class CodexAgent extends BaseAgent {
         const nextThreadId = rollbackResp.thread.id || previousThreadId;
         if (nextThreadId !== previousThreadId) {
           try {
-            subscription?.release();
+            await subscription?.release();
           } catch {
             // no-op: stale subscription cleanup should not fail a successful rollback.
           }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex Worker 关闭时，原来的 `ThreadSubscription.release()` 只移除 Cindy 本地的 notification 路由，没有通知 Codex app-server 释放对应 thread 的 live runtime，导致该 thread 使用的 MCP 子进程仍可能存活。

本 PR 将 release 改为异步闭环：先清理本地 subscriber 与 buffered notification，再调用 Codex app-server 的 `thread/unsubscribe`。所有 session close、one-shot 收尾和 rollback 换 thread 的路径都会等待释放完成；共享 app-server 本身继续运行，不影响其他 session，也不删除 thread 历史。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #324
- 本 PR 包含：
  - 增加 `thread/unsubscribe` request/response 类型与 method 常量。
  - 让 Codex thread subscription release 异步释放 app-server live runtime。
  - 覆盖 session close 发出 unsubscribe、但不关闭共享 transport 的回归测试。
- 明确不包含：Windows 性能采集复测、JavaScript heap snapshot、共享 app-server 的整体生命周期调整。
- 用户可见变化：Orca Codex Worker idle release 后，对应 MCP runtime 可以随 thread unsubscribe 释放，不再因历史 Worker 持续累积。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；Desktop、Mobile、maker-core 及协议子包的 unit tier 均 PASS。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：退出码 0；当前 package 没有 typecheck script，按仓库门禁自动跳过。

pnpm --filter @cindy/maker-core run build
结果：通过（tsc --noEmit）。

定向 ESLint（本 PR 4 个 TypeScript 文件）
结果：通过。
```

### 手工验证

不涉及；本地没有 Issue 所述 Windows 性能采集环境。

### 未执行的验证

- 未执行 Windows 上连续 3 轮 Worker 创建、idle release 与资源稳定段采集；需由具备原复现环境的验收方执行。
- 未采集 JavaScript heap snapshot；本 PR 仅处理已由源码链路确认的 app-server thread/MCP runtime 释放缺口。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Codex app-server thread subscription 的关闭路径。调用的是仓库固定 Codex 版本已提供的 `thread/unsubscribe`，不会 archive/delete thread 历史；unsubscribe 失败会被现有关闭路径捕获并记录，不阻断其他本地清理。
- 回滚 / 降级方式：回滚本 PR 即恢复为只移除 Cindy 本地路由的旧行为；共享 app-server shutdown 行为未改变。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
