### PR TITLE
fix(desktop): 补齐 Opus 5 客户端两处缺口并补充测试

### DIFF
--- a/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
@@ -372,6 +372,28 @@ describe('parseClaudeCodeMessageLine', () => {
     expect(rows[0].agentMeta).toMatchObject({ model: 'claude-opus-4-8' });
   });
 
+  it('normalizes opus-5 [1m] wire model id to catalog id', () => {
+    const rows = parseClaudeCodeMessageLine(
+      line({
+        type: 'assistant',
+        uuid: 'assistant-opus5',
+        message: {
+          id: 'msg_opus5',
+          model: 'claude-opus-5[1m]',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+          content: [{ type: 'text', text: 'ok' }],
+        },
+      }),
+      10,
+      sdkSessionId,
+      'claude-sonnet-4-6',
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].agentMeta).toMatchObject({ model: 'claude-opus-5' });
+  });
+
   it('maps Claude task notifications back to tool_result instead of user text', () => {
     const rows = parseClaudeCodeMessageLine(
       line({

--- a/apps/desktop/src/main/git-review/__tests__/diffReader.test.ts
+++ b/apps/desktop/src/main/git-review/__tests__/diffReader.test.ts
@@ -144,7 +144,8 @@ describe('git-review diffReader', () => {
         isTooLarge: false,
       });
       expect(diff?.size).toBe(outsidePath.length);
-      expect(diff?.rawPatch).toContain(`+${outsidePath}`);
+      // git 把 symlink 目标以 POSIX 分隔符写入 blob,Windows 路径按同规则规范化后比较。
+      expect(diff?.rawPatch).toContain(`+${outsidePath.split(path.sep).join('/')}`);
     } finally {
       await fs.rm(outsidePath, { force: true });
     }

--- a/apps/desktop/src/main/maker-host/claude-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/claude-local-sessions.ts
@@ -992,6 +992,7 @@ function usageTokenCount(usage: unknown): number {
 function normalizeClaudeModel(raw: string): string {
   const model = raw.trim();
   if (!model) return '';
+  if (model.includes('opus-5')) return 'claude-opus-5';
   if (model.includes('opus-4-8')) return 'claude-opus-4-8';
   if (model.includes('opus-4-7')) return 'claude-opus-4-7';
   if (model.includes('opus-4-6')) return 'claude-opus-4-6';

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@/components/icons/ProviderLogoMark', () => ({
 }));
 
 import { AddProviderWizard } from '@/components/settings/AddProviderWizard';
+import { createCustomProvider } from '@/lib/customProviders';
 
 const anthropicProvider = {
   id: 'anthropic',
@@ -153,12 +154,47 @@ describe('AddProviderWizard — preset 直达', () => {
       expect(screen.getByText('settings.providers.wizard.fetchFailed')).not.toBeNull(),
     );
     // 降级:推荐模型仍在清单里,完成按钮可用(不被空列表堵死)。
+    expect(screen.getByText('Claude Opus 5')).not.toBeNull();
     expect(screen.getByText('Claude Sonnet 5')).not.toBeNull();
     expect(screen.getByText('Claude Haiku 4.5')).not.toBeNull();
     expect(
       (screen.getByText('settings.providers.wizard.finish').closest('button') as HTMLButtonElement)
         .disabled,
     ).toBe(false);
+  });
+
+  it('官方 API 预设:完成保存 → 模型带目录口径 contextWindow(Codex P1 回归)', async () => {
+    render(
+      React.createElement(AddProviderWizard, {
+        providers: [anthropicProvider],
+        entry: { kind: 'builtin' as const, providerId: 'anthropic' },
+        onOpenCustomForm: vi.fn(),
+        onClose: vi.fn(),
+        onDone: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(await screen.findByText('settings.providers.wizard.useApiKey'));
+    await waitFor(() =>
+      expect(screen.getByText('settings.providers.wizard.nameLabel')).not.toBeNull(),
+    );
+    fireEvent.change(screen.getByPlaceholderText('sk-…'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByText('settings.providers.wizard.next'));
+    await waitFor(() => expect(screen.getByText('Claude Opus 5')).not.toBeNull());
+    fireEvent.click(screen.getByText('settings.providers.wizard.finish'));
+
+    // 保存产物必须带预设声明的 contextWindow:它是唯一窗口来源,缺省会落
+    // 200k 默认导致 1M 模型丢 [1m] 路由(toSdkModelString 按窗口剥后缀)。
+    await waitFor(() => expect(createCustomProvider).toHaveBeenCalledTimes(1));
+    const config = vi.mocked(createCustomProvider).mock.calls[0][0];
+    const models = config.runtimes['claude-code']?.models ?? [];
+    expect(models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'claude-opus-5', contextWindow: 1_000_000 }),
+        expect.objectContaining({ id: 'claude-sonnet-5', contextWindow: 1_000_000 }),
+        expect.objectContaining({ id: 'claude-haiku-4-5', contextWindow: 200_000 }),
+      ]),
+    );
   });
 
   it('presetId 不存在 → 回落目录第一步', async () => {

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -82,10 +82,13 @@ const OFFICIAL_API_PRESETS: Record<string, ProviderPreset> = {
     runtimes: {
       'claude-code': {
         baseUrl: 'https://api.anthropic.com',
+        // contextWindow 必须与目录(providers.json)一致:保存时它是窗口的唯一来源
+        // (拉取的模型列表不带窗口),缺省会落 200k 默认 → toSdkModelString 剥掉
+        // 1M 模型的 [1m] 路由,用户拿到 1/5 窗口。
         models: [
-          { id: 'claude-opus-5', name: 'Claude Opus 5' },
-          { id: 'claude-sonnet-5', name: 'Claude Sonnet 5' },
-          { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5' },
+          { id: 'claude-opus-5', name: 'Claude Opus 5', contextWindow: 1_000_000 },
+          { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', contextWindow: 1_000_000 },
+          { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', contextWindow: 200_000 },
         ],
       },
     },

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -83,6 +83,7 @@ const OFFICIAL_API_PRESETS: Record<string, ProviderPreset> = {
       'claude-code': {
         baseUrl: 'https://api.anthropic.com',
         models: [
+          { id: 'claude-opus-5', name: 'Claude Opus 5' },
           { id: 'claude-sonnet-5', name: 'Claude Sonnet 5' },
           { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5' },
         ],

--- a/apps/desktop/src/shared/__tests__/modelMismatch.test.ts
+++ b/apps/desktop/src/shared/__tests__/modelMismatch.test.ts
@@ -8,6 +8,8 @@ describe('canonicalModelFamilyKey', () => {
     expect(canonicalModelFamilyKey('claude-opus-4-8-20260301')).toBe('opus-4-8');
     expect(canonicalModelFamilyKey('us.anthropic.claude-fable-5-20260115')).toBe('fable-5');
     expect(canonicalModelFamilyKey('Claude-Sonnet-5-LATEST')).toBe('sonnet-5');
+    expect(canonicalModelFamilyKey('claude-opus-5[1m]')).toBe('opus-5');
+    expect(canonicalModelFamilyKey('claude-opus-4-5')).toBe('opus-4-5');
   });
 
   it('点横等价,非字符串 / 空串安全返回空', () => {
@@ -48,6 +50,11 @@ describe('detectClaudeModelMismatch', () => {
     expect(
       detectClaudeModelMismatch('claude-fable-5[1m]', [
         { model: 'claude-fable-5-20260115', outputTokens: 500 },
+      ]),
+    ).toBeNull();
+    expect(
+      detectClaudeModelMismatch('claude-opus-5', [
+        { model: 'claude-opus-5[1m]', outputTokens: 500 },
       ]),
     ).toBeNull();
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

Opus 5 发布后客户端仍有两处缺口，本 PR 补齐并补充测试：

1. `normalizeClaudeModel()`（`apps/desktop/src/main/maker-host/claude-local-sessions.ts`）缺 `opus-5` 分支，导致本地会话 transcript 里 SDK 上报的 `claude-opus-5[1m]` 等 wire 值无法归一为目录 id，影响历史会话模型展示与漂移检测。现新增该分支（置于 `opus-4-8` 之前，避免误匹配）。
2. 官方 Anthropic API 接入向导的推荐模型兜底列表（`AddProviderWizard.tsx` 的 `OFFICIAL_API_PRESETS.anthropic`）缺 Opus 5，网络拉取模型列表失败降级时用户看不到该选项。现在列表头部加入 `claude-opus-5`。

按 Codex review P1 追加一处修复（`acf22a9`）：向导保存时 `contextWindow` 的唯一来源是预设条目（网络拉取的模型列表不带窗口），缺省会落 200k 默认，`toSdkModelString` 随之剥掉 1M 模型的 `[1m]` 路由——经该向导添加的 Opus 5 / Sonnet 5 实际只拿到 1/5 窗口（Sonnet 5 为本 PR 之前既有问题，同池顺手修复）。现在三个预设条目显式声明与目录 `providers.json` 一致的窗口，并补充保存产物断言。

另含一个独立 commit（`ac5623e`）：修复 `diffReader.test.ts` symlink 用例在 Windows 下的路径分隔符断言。git 把 symlink 目标以 POSIX 正斜杠写入 blob，原断言直接用 Windows 原生路径比对必然失败。这是既有问题、非本分支引入，但会阻塞全量测试门禁，故顺手修复。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（Opus 5 客户端支持收尾，接续 #372 / #376）
- 本 PR 包含：`normalizeClaudeModel` 新增 opus-5 分支；官方 API 向导推荐列表新增 Claude Opus 5，且三个预设条目补目录口径 `contextWindow`（Codex review P1）；对应单元测试（含 `[1m]` 后缀归一、opus-5 与 opus-4-5 家族不混淆、保存产物 contextWindow 断言）；diffReader symlink 测试的 Windows 断言修复。
- 明确不包含：默认模型切换到 opus-5、`stop_reason: "refusal"` 处理、fast mode 开关（属产品决策 / 服务端协调项，另行讨论）。
- 用户可见变化：官方 API 向导降级兜底列表可见 Claude Opus 5；经向导添加的 Opus 5 / Sonnet 5 正确获得 1M 上下文窗口与 `[1m]` 路由；本地历史会话中 Opus 5 模型名正确识别。
- 是否存在 breaking change：无

### UI 变化

仅 AddProviderWizard 推荐模型列表新增一个文本条目，复用现有列表组件与样式，Light / Dark 均为既有渲染路径，无新增视觉元素，不附截图。

## 怎么验证的

### 自动验证

```text
pnpm test:unit（仓库根，全量单元测试；review 修复后重跑）
结果：全部通过（含新增用例；addProviderWizardPresetEntry 5 passed）

pnpm --filter desktop run --if-present typecheck（review 修复后重跑）
结果：通过
```

### 手工验证

已使用 Claude 订阅号实际验证 Opus 5 可用（Windows 11 桌面端）。

### 未执行的验证

未在 macOS 上手工验证：改动为纯 TypeScript 数据 / 字符串逻辑，无平台分支；diffReader 测试修复反而使断言平台无关。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：本地会话模型名归一、官方 API 向导兜底列表与保存的模型窗口元数据、单元测试；不触及数据库、协议、权限边界。已存在的用户自定义供应商配置不受影响（预设仅在创建时快照）。
- 回滚 / 降级方式：直接 revert 本 PR 三个 commit 即可，无数据迁移或状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)