### PR TITLE
fix(voice-input): 电源释放同样关闭非保活的采集流

### DIFF
--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -149,6 +149,31 @@ export function currentPowerReleaseGeneration(): number {
   return powerReleaseGeneration;
 }
 
+/**
+ * Tear down everything this module instance owns, for the HMR swap.
+ *
+ * Bumping the generation first is what covers acquisitions that are still
+ * awaiting enumeration or getUserMedia: they have not reached
+ * liveDirectCaptureEngines yet, so releasing the registry alone would let them
+ * resolve afterwards and register into this *disposed* module's set — where the
+ * replacement module's power listener can never reach them, leaving the
+ * microphone open across a later suspend.
+ *
+ * Exported for the tests; the dev-only `import.meta.hot` block below is the
+ * real caller.
+ */
+export function disposeVoiceInputAudioModuleForHmr(): Promise<void> {
+  powerReleaseGeneration += 1;
+  keepAlivePowerReleaseUnsubscribe?.();
+  keepAlivePowerReleaseUnsubscribe = undefined;
+  keepAlivePowerReleaseListening = false;
+  // React Fast Refresh can keep the component and its engine ref alive across
+  // the swap, and the new module instance has an empty registry — so without
+  // this the old direct stream stays live with nothing able to reach it.
+  releaseDirectCaptureEngines('hmr');
+  return disposeKeepAliveVoiceInputMicrophone('hmr');
+}
+
 export function isPowerReleaseCancellation(error: unknown): boolean {
   if (!isKeepAliveSessionDisposedError(error)) return false;
   const reason = readErrorString(error, 'reason');
@@ -1642,13 +1667,6 @@ function flushWorkletBufferedAudio(worklet?: AudioWorkletNode): Promise<void> {
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
-    keepAlivePowerReleaseUnsubscribe?.();
-    keepAlivePowerReleaseUnsubscribe = undefined;
-    keepAlivePowerReleaseListening = false;
-    // React Fast Refresh can keep the component and its engine ref alive across
-    // the swap, and the new module instance has an empty registry — so without
-    // this the old direct stream stays live with nothing able to reach it.
-    releaseDirectCaptureEngines('hmr');
-    void disposeKeepAliveVoiceInputMicrophone('hmr');
+    void disposeVoiceInputAudioModuleForHmr();
   });
 }

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -1074,11 +1074,22 @@ export class WebMicAudioEngine {
     const benchmarkFixturePromise = BENCHMARK_FIXTURE_ENABLED
       ? prewarmVoiceInputBenchmarkFixture().catch(() => null)
       : Promise.resolve(null);
-    await assertSelectedMicrophoneAvailable(this.deviceId);
-    const streamPromise = navigator.mediaDevices.getUserMedia({
-      audio,
-      video: false,
-    }).catch((error) => {
+    await this.awaitDirectStartupStep(
+      assertSelectedMicrophoneAvailable(this.deviceId),
+      powerGenerationAtStart,
+    );
+    const streamPromise = this.awaitDirectStartupStep(
+      navigator.mediaDevices.getUserMedia({
+        audio,
+        video: false,
+      }),
+      powerGenerationAtStart,
+    ).catch((error) => {
+      // A release that won this race takes priority: suspend routinely makes
+      // the pending request reject (AbortError / NotReadableError), and
+      // reporting that as a device failure would make captureSession show an
+      // error instead of following its silent power-cancellation path.
+      if (isPowerReleaseCancellation(error)) throw error;
       throw normalizeMicrophoneStartError(error, this.deviceId);
     });
 
@@ -1187,6 +1198,27 @@ export class WebMicAudioEngine {
    * leave it running for the whole suspend. Tear it down and report the same
    * cancellation the keep-alive path uses.
    */
+  /**
+   * Await one direct-startup step, letting an in-flight power release win.
+   *
+   * Mirrors KeepAliveMicSession.awaitStartupStep: the raw error would send the
+   * caller down its device-failure paths (error surface, or automatic fallback
+   * to the default microphone) after the one-shot event has already passed.
+   */
+  private async awaitDirectStartupStep<T>(step: Promise<T>, generationAtStart: number): Promise<T> {
+    try {
+      return await step;
+    } catch (error) {
+      if (
+        currentPowerReleaseGeneration() !== generationAtStart &&
+        !isPowerReleaseCancellation(error)
+      ) {
+        throw powerReleaseCancellation();
+      }
+      throw error;
+    }
+  }
+
   private assertNoPowerReleaseDuringStartup(generationAtStart: number): void {
     if (currentPowerReleaseGeneration() === generationAtStart) return;
     throw powerReleaseCancellation();
@@ -1588,6 +1620,10 @@ if (import.meta.hot) {
     keepAlivePowerReleaseUnsubscribe?.();
     keepAlivePowerReleaseUnsubscribe = undefined;
     keepAlivePowerReleaseListening = false;
+    // React Fast Refresh can keep the component and its engine ref alive across
+    // the swap, and the new module instance has an empty registry — so without
+    // this the old direct stream stays live with nothing able to reach it.
+    releaseDirectCaptureEngines('hmr');
     void disposeKeepAliveVoiceInputMicrophone('hmr');
   });
 }

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -1083,61 +1083,77 @@ export class WebMicAudioEngine {
     });
 
     const directStream = await streamPromise;
-    if (currentPowerReleaseGeneration() !== powerGenerationAtStart) {
-      // Suspend/lock won the race with the device handshake. Nothing has this
-      // stream registered yet, so it would stay live for the whole sleep.
-      directStream.getTracks().forEach((track) => track.stop());
-      throw powerReleaseCancellation();
-    }
+    // Assigned before the guarded section so the cleanup below can reach it.
     this.stream = directStream;
-    this.stream.getAudioTracks().forEach((track) => this.watchTrack(track));
-    this.onStateChange?.('stream_started', {
-      tracks: this.stream.getAudioTracks().map((track) => ({
-        label: track.label,
-        enabled: track.enabled,
-        muted: track.muted,
-        readyState: track.readyState,
-        settings: track.getSettings(),
-      })),
-    });
+    try {
+      this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
+      this.stream.getAudioTracks().forEach((track) => this.watchTrack(track));
+      this.onStateChange?.('stream_started', {
+        tracks: this.stream.getAudioTracks().map((track) => ({
+          label: track.label,
+          enabled: track.enabled,
+          muted: track.muted,
+          readyState: track.readyState,
+          settings: track.getSettings(),
+        })),
+      });
 
-    const sharedState = await sharedContextPromise;
-    if (sharedState) {
-      this.context = sharedState.context;
-      this.usingSharedContext = true;
-      this.onStateChange?.('shared_audio_context_used', {
+      const sharedState = await sharedContextPromise;
+      if (sharedState) {
+        this.context = sharedState.context;
+        this.usingSharedContext = true;
+        this.onStateChange?.('shared_audio_context_used', {
+          state: this.context.state,
+          sampleRate: this.context.sampleRate,
+        });
+      } else {
+        this.context = new AudioContext();
+        this.usingSharedContext = false;
+      }
+      this.context.onstatechange = () => {
+        this.onStateChange?.('context_state_changed', {
+          state: this.context?.state,
+          sampleRate: this.context?.sampleRate,
+        });
+        if (this.ready && !this.stopped && this.context?.state !== 'running') {
+          this.interrupt(`Microphone audio context stopped (${this.context?.state ?? 'unknown'}). Please try again.`);
+        }
+      };
+      this.onStateChange?.('context_created', {
         state: this.context.state,
         sampleRate: this.context.sampleRate,
       });
-    } else {
-      this.context = new AudioContext();
-      this.usingSharedContext = false;
-    }
-    this.context.onstatechange = () => {
-      this.onStateChange?.('context_state_changed', {
-        state: this.context?.state,
-        sampleRate: this.context?.sampleRate,
-      });
-      if (this.ready && !this.stopped && this.context?.state !== 'running') {
-        this.interrupt(`Microphone audio context stopped (${this.context?.state ?? 'unknown'}). Please try again.`);
-      }
-    };
-    this.onStateChange?.('context_created', {
-      state: this.context.state,
-      sampleRate: this.context.sampleRate,
-    });
 
-    // Benchmark mode still starts the real MediaStream above so the measurement
-    // includes OS microphone permission/device startup. Only the bytes sent to
-    // ASR are replaced with deterministic fixture audio, keeping latency A/B
-    // runs comparable without asking a human to repeat the exact same phrase.
-    const benchmarkFixture = await benchmarkFixturePromise;
-    if (benchmarkFixture) {
-      this.onStateChange?.('benchmark_fixture_ready', {
-        path: benchmarkFixture.path,
-        sourceSampleRate: benchmarkFixture.sampleRate,
-        durationMs: Math.round(benchmarkFixture.durationMs),
-      });
+      // Benchmark mode still starts the real MediaStream above so the measurement
+      // includes OS microphone permission/device startup. Only the bytes sent to
+      // ASR are replaced with deterministic fixture audio, keeping latency A/B
+      // runs comparable without asking a human to repeat the exact same phrase.
+      const benchmarkFixture = await benchmarkFixturePromise;
+      if (benchmarkFixture) {
+        this.onStateChange?.('benchmark_fixture_ready', {
+          path: benchmarkFixture.path,
+          sourceSampleRate: benchmarkFixture.sampleRate,
+          durationMs: Math.round(benchmarkFixture.durationMs),
+        });
+        if (this.context.state !== 'running') {
+          await this.context.resume();
+        }
+        this.onStateChange?.('context_ready', {
+          state: this.context.state,
+          sampleRate: this.context.sampleRate,
+        });
+        this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
+        this.ready = true;
+        liveDirectCaptureEngines.add(this);
+        this.startWatchdog();
+        void this.playBenchmarkFixture(benchmarkFixture);
+        return;
+      }
+
+      this.sink = this.context.createGain();
+      this.sink.gain.value = 0;
+      this.source = this.context.createMediaStreamSource(this.stream);
+      await this.connectProcessor();
       if (this.context.state !== 'running') {
         await this.context.resume();
       }
@@ -1149,25 +1165,18 @@ export class WebMicAudioEngine {
       this.ready = true;
       liveDirectCaptureEngines.add(this);
       this.startWatchdog();
-      void this.playBenchmarkFixture(benchmarkFixture);
-      return;
+    } catch (error) {
+      // Everything acquired above — the device, the audio nodes, and a
+      // non-shared AudioContext — has no owner yet: this engine is not in
+      // liveDirectCaptureEngines, and callers treat a power cancellation as
+      // silent, so stop() would never run. Tear it down here instead of
+      // leaking a live microphone for the rest of the session.
+      await this.stop().catch(() => undefined);
+      if (currentPowerReleaseGeneration() !== powerGenerationAtStart) {
+        throw powerReleaseCancellation();
+      }
+      throw error;
     }
-
-    this.sink = this.context.createGain();
-    this.sink.gain.value = 0;
-    this.source = this.context.createMediaStreamSource(this.stream);
-    await this.connectProcessor();
-    if (this.context.state !== 'running') {
-      await this.context.resume();
-    }
-    this.onStateChange?.('context_ready', {
-      state: this.context.state,
-      sampleRate: this.context.sampleRate,
-    });
-    this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
-    this.ready = true;
-    liveDirectCaptureEngines.add(this);
-    this.startWatchdog();
   }
 
   /**
@@ -1180,11 +1189,6 @@ export class WebMicAudioEngine {
    */
   private assertNoPowerReleaseDuringStartup(generationAtStart: number): void {
     if (currentPowerReleaseGeneration() === generationAtStart) return;
-    this.stream?.getTracks().forEach((track) => track.stop());
-    this.worklet?.disconnect();
-    this.processor?.disconnect();
-    this.sink?.disconnect();
-    this.source?.disconnect();
     throw powerReleaseCancellation();
   }
 

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -386,8 +386,9 @@ function ensureKeepAliveDeviceChangeListener(): void {
  * Both mean the user walked away, so holding the capture device buys no
  * latency while still lighting the OS privacy indicator and holding an
  * idle-sleep assertion through coreaudiod. Mirrors the devicechange listener
- * above: one process-wide subscription, installed lazily with the first
- * keep-alive session, never torn down.
+ * above: one process-wide subscription, never torn down. Installed lazily by
+ * whichever capture starts first — the keep-alive session *or* a direct
+ * (keepAlive: false) capture, which relies on it just as much.
  */
 function ensureKeepAlivePowerReleaseListener(): void {
   if (keepAlivePowerReleaseListening) return;
@@ -1084,6 +1085,7 @@ export class WebMicAudioEngine {
         video: false,
       }),
       powerGenerationAtStart,
+      (stream) => stream.getTracks().forEach((track) => track.stop()),
     ).catch((error) => {
       // A release that won this race takes priority: suspend routinely makes
       // the pending request reject (AbortError / NotReadableError), and
@@ -1096,6 +1098,11 @@ export class WebMicAudioEngine {
     const directStream = await streamPromise;
     // Assigned before the guarded section so the cleanup below can reach it.
     this.stream = directStream;
+    // Registered immediately, not at the end of startup: every await below
+    // (context warmup, worklet module, resume) can stay pending for the whole
+    // suspend, and the power callback can only traverse this registry. Failure
+    // paths remove it again through stop().
+    liveDirectCaptureEngines.add(this);
     try {
       this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
       this.stream.getAudioTracks().forEach((track) => this.watchTrack(track));
@@ -1155,7 +1162,6 @@ export class WebMicAudioEngine {
         });
         this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
         this.ready = true;
-        liveDirectCaptureEngines.add(this);
         this.startWatchdog();
         void this.playBenchmarkFixture(benchmarkFixture);
         return;
@@ -1174,7 +1180,6 @@ export class WebMicAudioEngine {
       });
       this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
       this.ready = true;
-      liveDirectCaptureEngines.add(this);
       this.startWatchdog();
     } catch (error) {
       // Everything acquired above — the device, the audio nodes, and a
@@ -1205,9 +1210,21 @@ export class WebMicAudioEngine {
    * caller down its device-failure paths (error surface, or automatic fallback
    * to the default microphone) after the one-shot event has already passed.
    */
-  private async awaitDirectStartupStep<T>(step: Promise<T>, generationAtStart: number): Promise<T> {
+  private async awaitDirectStartupStep<T>(
+    step: Promise<T>,
+    generationAtStart: number,
+    disposeValue?: (value: T) => void,
+  ): Promise<T> {
     try {
-      return await step;
+      const value = await step;
+      // Fulfilled awaits matter as much as rejected ones: a successful device
+      // enumeration would otherwise let us call getUserMedia *after* the
+      // one-shot release, reopening the microphone while the user is away.
+      if (currentPowerReleaseGeneration() !== generationAtStart) {
+        disposeValue?.(value);
+        throw powerReleaseCancellation();
+      }
+      return value;
     } catch (error) {
       if (
         currentPowerReleaseGeneration() !== generationAtStart &&

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -1079,6 +1079,10 @@ export class WebMicAudioEngine {
       assertSelectedMicrophoneAvailable(this.deviceId),
       powerGenerationAtStart,
     );
+    // The enumeration above passed its own check, but a release can land in the
+    // gap before we ask for the device. Without this the request would be made
+    // after the one-shot event and only be closed once it resolves.
+    this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
     const streamPromise = this.awaitDirectStartupStep(
       navigator.mediaDevices.getUserMedia({
         audio,
@@ -1182,11 +1186,10 @@ export class WebMicAudioEngine {
       this.ready = true;
       this.startWatchdog();
     } catch (error) {
-      // Everything acquired above — the device, the audio nodes, and a
-      // non-shared AudioContext — has no owner yet: this engine is not in
-      // liveDirectCaptureEngines, and callers treat a power cancellation as
-      // silent, so stop() would never run. Tear it down here instead of
-      // leaking a live microphone for the rest of the session.
+      // Callers treat a power cancellation as silent, so they will never call
+      // stop() themselves. Do it here: it closes the device and the non-shared
+      // AudioContext, clears the track listeners, and removes this engine from
+      // liveDirectCaptureEngines (which it joined right after acquisition).
       await this.stop().catch(() => undefined);
       if (currentPowerReleaseGeneration() !== powerGenerationAtStart) {
         throw powerReleaseCancellation();
@@ -1248,7 +1251,15 @@ export class WebMicAudioEngine {
    */
   releaseForPowerEvent(reason: string): void {
     this.onStateChange?.('direct_capture_power_release', { reason });
-    this.interrupt('Microphone input stopped unexpectedly. Please try again.');
+    // Only a capture that actually reached `ready` is a live recording worth
+    // interrupting. One still starting up is registered (so its device can be
+    // closed here) but must surface as a *silent* cancellation through
+    // start()'s generation check — both UIs wire onInterrupted to their
+    // active-recording failure path, and that visible error cannot be undone
+    // by the cancellation that follows.
+    if (this.ready) {
+      this.interrupt('Microphone input stopped unexpectedly. Please try again.');
+    }
     void this.stop().catch((error: unknown) => {
       // Detached on purpose (the power callback must not await teardown), so an
       // AudioContext.close() failure here would otherwise surface as an

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -131,6 +131,20 @@ const DO_NOT_REBUILD_REASONS: ReadonlySet<string> = new Set([
  */
 let powerReleaseGeneration = 0;
 
+/**
+ * Engines capturing outside the keep-alive session (fast activation off, or a
+ * cold fallback). A power release only tears down the module-level keep-alive
+ * session, so without this registry those streams would keep the microphone —
+ * and the privacy indicator — open until the user comes back.
+ */
+const liveDirectCaptureEngines = new Set<WebMicAudioEngine>();
+
+function releaseDirectCaptureEngines(reason: string): void {
+  for (const engine of [...liveDirectCaptureEngines]) {
+    engine.releaseForPowerEvent(reason);
+  }
+}
+
 export function currentPowerReleaseGeneration(): number {
   return powerReleaseGeneration;
 }
@@ -385,6 +399,7 @@ function ensureKeepAlivePowerReleaseListener(): void {
   // so one lock event would fan out to N stale callbacks.
   keepAlivePowerReleaseUnsubscribe = subscribe((payload) => {
     powerReleaseGeneration += 1;
+    releaseDirectCaptureEngines(payload.reason);
     void disposeKeepAliveVoiceInputMicrophone(payload.reason);
   });
 }
@@ -1036,6 +1051,10 @@ export class WebMicAudioEngine {
     this.interrupted = false;
     this.ready = false;
     this.lastAudioFrameAt = Date.now();
+    // Also needed on this path: with fast activation off no keep-alive session
+    // is ever created, so this would otherwise be the only capture in the
+    // renderer and nothing would subscribe to power releases.
+    ensureKeepAlivePowerReleaseListener();
 
     const audio = buildMediaConstraints({
       deviceId: this.deviceId,
@@ -1116,6 +1135,7 @@ export class WebMicAudioEngine {
         sampleRate: this.context.sampleRate,
       });
       this.ready = true;
+      liveDirectCaptureEngines.add(this);
       this.startWatchdog();
       void this.playBenchmarkFixture(benchmarkFixture);
       return;
@@ -1133,10 +1153,23 @@ export class WebMicAudioEngine {
       sampleRate: this.context.sampleRate,
     });
     this.ready = true;
+    liveDirectCaptureEngines.add(this);
     this.startWatchdog();
   }
 
+  /**
+   * Suspend / lock reached us while capturing outside the keep-alive session.
+   * Interrupt the caller so it cancels its ASR run, then close the stream —
+   * the keep-alive release path cannot see this one.
+   */
+  releaseForPowerEvent(reason: string): void {
+    this.onStateChange?.('direct_capture_power_release', { reason });
+    this.interrupt('Microphone input stopped unexpectedly. Please try again.');
+    void this.stop();
+  }
+
   async stop(): Promise<void> {
+    liveDirectCaptureEngines.delete(this);
     this.stopped = true;
     this.ready = false;
     this.clearWatchdog();

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -1055,6 +1055,10 @@ export class WebMicAudioEngine {
     // is ever created, so this would otherwise be the only capture in the
     // renderer and nothing would subscribe to power releases.
     ensureKeepAlivePowerReleaseListener();
+    // The registry below only covers engines that finished starting. A release
+    // landing mid-startup would not see this one, so snapshot the generation
+    // and re-check at each point where a live device could survive.
+    const powerGenerationAtStart = currentPowerReleaseGeneration();
 
     const audio = buildMediaConstraints({
       deviceId: this.deviceId,
@@ -1078,7 +1082,14 @@ export class WebMicAudioEngine {
       throw normalizeMicrophoneStartError(error, this.deviceId);
     });
 
-    this.stream = await streamPromise;
+    const directStream = await streamPromise;
+    if (currentPowerReleaseGeneration() !== powerGenerationAtStart) {
+      // Suspend/lock won the race with the device handshake. Nothing has this
+      // stream registered yet, so it would stay live for the whole sleep.
+      directStream.getTracks().forEach((track) => track.stop());
+      throw powerReleaseCancellation();
+    }
+    this.stream = directStream;
     this.stream.getAudioTracks().forEach((track) => this.watchTrack(track));
     this.onStateChange?.('stream_started', {
       tracks: this.stream.getAudioTracks().map((track) => ({
@@ -1134,6 +1145,7 @@ export class WebMicAudioEngine {
         state: this.context.state,
         sampleRate: this.context.sampleRate,
       });
+      this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
       this.ready = true;
       liveDirectCaptureEngines.add(this);
       this.startWatchdog();
@@ -1152,9 +1164,28 @@ export class WebMicAudioEngine {
       state: this.context.state,
       sampleRate: this.context.sampleRate,
     });
+    this.assertNoPowerReleaseDuringStartup(powerGenerationAtStart);
     this.ready = true;
     liveDirectCaptureEngines.add(this);
     this.startWatchdog();
+  }
+
+  /**
+   * Final gate before this engine becomes discoverable by the power callback.
+   *
+   * Everything built above (stream, context nodes, worklet) exists but is not
+   * registered yet, so a release that landed during startup would otherwise
+   * leave it running for the whole suspend. Tear it down and report the same
+   * cancellation the keep-alive path uses.
+   */
+  private assertNoPowerReleaseDuringStartup(generationAtStart: number): void {
+    if (currentPowerReleaseGeneration() === generationAtStart) return;
+    this.stream?.getTracks().forEach((track) => track.stop());
+    this.worklet?.disconnect();
+    this.processor?.disconnect();
+    this.sink?.disconnect();
+    this.source?.disconnect();
+    throw powerReleaseCancellation();
   }
 
   /**
@@ -1165,7 +1196,14 @@ export class WebMicAudioEngine {
   releaseForPowerEvent(reason: string): void {
     this.onStateChange?.('direct_capture_power_release', { reason });
     this.interrupt('Microphone input stopped unexpectedly. Please try again.');
-    void this.stop();
+    void this.stop().catch((error: unknown) => {
+      // Detached on purpose (the power callback must not await teardown), so an
+      // AudioContext.close() failure here would otherwise surface as an
+      // unhandled rejection.
+      this.onStateChange?.('direct_capture_power_release_stop_failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 
   async stop(): Promise<void> {

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -1199,14 +1199,6 @@ export class WebMicAudioEngine {
   }
 
   /**
-   * Final gate before this engine becomes discoverable by the power callback.
-   *
-   * Everything built above (stream, context nodes, worklet) exists but is not
-   * registered yet, so a release that landed during startup would otherwise
-   * leave it running for the whole suspend. Tear it down and report the same
-   * cancellation the keep-alive path uses.
-   */
-  /**
    * Await one direct-startup step, letting an in-flight power release win.
    *
    * Mirrors KeepAliveMicSession.awaitStartupStep: the raw error would send the
@@ -1239,6 +1231,11 @@ export class WebMicAudioEngine {
     }
   }
 
+  /**
+   * Check for a release at the synchronous points no await can cover: right
+   * before opening the device, and right before flipping `ready` (which is what
+   * makes the release path treat this engine as an interruptible recording).
+   */
   private assertNoPowerReleaseDuringStartup(generationAtStart: number): void {
     if (currentPowerReleaseGeneration() === generationAtStart) return;
     throw powerReleaseCancellation();

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
@@ -436,6 +436,80 @@ describe('keep-alive microphone idle window', () => {
     expect(track.stopped).toBe(false);
   });
 
+  it('does not open the microphone when enumeration outlives a power release', async () => {
+    let resolveEnumerate: (value: unknown) => void = () => undefined;
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        enumerateDevices: vi.fn(() => new Promise((resolve) => {
+          resolveEnumerate = resolve;
+        })),
+        getUserMedia,
+        addEventListener: vi.fn(),
+      },
+    });
+
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      deviceId: 'specific-device',
+      onInterrupted: vi.fn(),
+    });
+    const starting = engine.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(powerCallback).toBeDefined();
+
+    powerCallback?.({ reason: 'screen_locked' });
+    await vi.advanceTimersByTimeAsync(0);
+    // Enumeration succeeds *after* the release, reporting the device as present.
+    resolveEnumerate([{ kind: 'audioinput', deviceId: 'specific-device' }]);
+
+    await expect(starting).rejects.toThrow(/disposed/i);
+    // The one-shot event has passed; nothing may reopen the device now.
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it('can release a stream acquired before context warmup settles', async () => {
+    let resolvePool: (value: unknown) => void = () => undefined;
+    const pool = await import('../audioContextPool');
+    vi.mocked(pool.prewarmVoiceInputAudio).mockReturnValue(
+      new Promise((resolve) => {
+        resolvePool = resolve as (value: unknown) => void;
+      }) as ReturnType<typeof pool.prewarmVoiceInputAudio>,
+    );
+
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      onInterrupted: vi.fn(),
+    });
+    const starting = engine.start();
+    // getUserMedia has resolved; the shared context warmup is still pending and
+    // could stay that way for the whole suspend.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(powerCallback).toBeDefined();
+
+    powerCallback?.({ reason: 'system_suspend' });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The device is already open, so the release must reach it now rather than
+    // waiting for warmup to settle.
+    expect(track.stopped).toBe(true);
+
+    resolvePool({
+      context: {
+        currentTime: 0,
+        state: 'running',
+        destination,
+        createGain: vi.fn(() => sink),
+        createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+        resume: vi.fn(async () => undefined),
+      },
+      workletReady: Promise.resolve(),
+      workletUrl: WORKLET_URL,
+    });
+    await starting.catch(() => undefined);
+  });
+
   it('reports cancellation when direct getUserMedia rejects after a release', async () => {
     let rejectStream: (error: unknown) => void = () => undefined;
     getUserMedia.mockImplementationOnce(() => new Promise((_resolve, reject) => {

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
@@ -436,6 +436,35 @@ describe('keep-alive microphone idle window', () => {
     expect(track.stopped).toBe(false);
   });
 
+  it('stops the direct stream when a later startup step fails', async () => {
+    const pool = await import('../audioContextPool');
+    vi.mocked(pool.prewarmVoiceInputAudio).mockResolvedValue({
+      context: {
+        currentTime: 0,
+        state: 'suspended',
+        destination,
+        createGain: vi.fn(() => sink),
+        createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+        resume: vi.fn(async () => {
+          throw new Error('resume failed');
+        }),
+      } as unknown as AudioContext,
+      workletReady: Promise.resolve(),
+      workletUrl: WORKLET_URL,
+    });
+
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      onInterrupted: vi.fn(),
+    });
+
+    // The device is already open by the time this step fails, and the engine
+    // never made it into the registry — the failure path has to close it.
+    await expect(engine.start()).rejects.toThrow(/resume failed/i);
+    expect(track.stopped).toBe(true);
+  });
+
   it('aborts a direct startup interrupted by a power release', async () => {
     let resolveStream: (value: unknown) => void = () => undefined;
     getUserMedia.mockImplementationOnce(() => new Promise((resolve) => {

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
@@ -436,6 +436,25 @@ describe('keep-alive microphone idle window', () => {
     expect(track.stopped).toBe(false);
   });
 
+  it('releases a direct capture stream on a power event', async () => {
+    const onInterrupted = vi.fn();
+    // fast activation off: this capture never touches the keep-alive session,
+    // so only the direct-engine registry can close it on suspend/lock.
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      onInterrupted,
+    });
+    await engine.start();
+    expect(powerCallback).toBeDefined();
+
+    powerCallback?.({ reason: 'system_suspend' });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onInterrupted).toHaveBeenCalled();
+    expect(track.stopped).toBe(true);
+  });
+
   it('shares one startup between concurrent callers', async () => {
     let resolveStream: (value: unknown) => void = () => undefined;
     getUserMedia.mockImplementationOnce(() => new Promise((resolve) => {

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
@@ -436,6 +436,32 @@ describe('keep-alive microphone idle window', () => {
     expect(track.stopped).toBe(false);
   });
 
+  it('aborts a direct startup interrupted by a power release', async () => {
+    let resolveStream: (value: unknown) => void = () => undefined;
+    getUserMedia.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveStream = resolve;
+    }));
+
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      onInterrupted: vi.fn(),
+    });
+    const starting = engine.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(powerCallback).toBeDefined();
+
+    // The lock lands while the device handshake is still pending, so this
+    // engine is not in the registry yet and the one-shot callback cannot see
+    // it. Startup must abort itself rather than come up after the event.
+    powerCallback?.({ reason: 'screen_locked' });
+    await vi.advanceTimersByTimeAsync(0);
+    resolveStream({ getAudioTracks: () => [track], getTracks: () => [track] });
+
+    await expect(starting).rejects.toThrow(/disposed/i);
+    expect(track.stopped).toBe(true);
+  });
+
   it('releases a direct capture stream on a power event', async () => {
     const onInterrupted = vi.fn();
     // fast activation off: this capture never touches the keep-alive session,

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
@@ -632,6 +632,31 @@ describe('keep-alive microphone idle window', () => {
     expect(track.stopped).toBe(true);
   });
 
+  it('stops a direct stream that arrives after an HMR swap', async () => {
+    let resolveStream: (value: unknown) => void = () => undefined;
+    getUserMedia.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveStream = resolve;
+    }));
+
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      onInterrupted: vi.fn(),
+    });
+    const starting = engine.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Vite swaps the module while the device handshake is still pending. The
+    // engine has not reached the registry, so releasing the registry alone
+    // would let the stream arrive afterwards and open the microphone inside a
+    // module whose power listener is already gone.
+    await mod.disposeVoiceInputAudioModuleForHmr();
+    resolveStream({ getAudioTracks: () => [track], getTracks: () => [track] });
+
+    await expect(starting).rejects.toThrow(/disposed/i);
+    expect(track.stopped).toBe(true);
+  });
+
   it('releases a direct capture stream on a power event', async () => {
     const onInterrupted = vi.fn();
     // fast activation off: this capture never touches the keep-alive session,

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
@@ -436,6 +436,30 @@ describe('keep-alive microphone idle window', () => {
     expect(track.stopped).toBe(false);
   });
 
+  it('reports cancellation when direct getUserMedia rejects after a release', async () => {
+    let rejectStream: (error: unknown) => void = () => undefined;
+    getUserMedia.mockImplementationOnce(() => new Promise((_resolve, reject) => {
+      rejectStream = reject;
+    }));
+
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      onInterrupted: vi.fn(),
+    });
+    const starting = engine.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(powerCallback).toBeDefined();
+
+    powerCallback?.({ reason: 'system_suspend' });
+    await vi.advanceTimersByTimeAsync(0);
+    // Suspend routinely makes the pending request reject rather than resolve.
+    // That must read as cancellation, not as a device failure worth surfacing.
+    rejectStream(Object.assign(new Error('The request is not allowed'), { name: 'AbortError' }));
+
+    await expect(starting).rejects.toThrow(/disposed/i);
+  });
+
   it('stops the direct stream when a later startup step fails', async () => {
     const pool = await import('../audioContextPool');
     vi.mocked(pool.prewarmVoiceInputAudio).mockResolvedValue({

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.keepAliveIdle.test.ts
@@ -468,6 +468,49 @@ describe('keep-alive microphone idle window', () => {
     expect(getUserMedia).not.toHaveBeenCalled();
   });
 
+  it('does not report an error when a release hits a still-starting capture', async () => {
+    let resolvePool: (value: unknown) => void = () => undefined;
+    const pool = await import('../audioContextPool');
+    vi.mocked(pool.prewarmVoiceInputAudio).mockReturnValue(
+      new Promise((resolve) => {
+        resolvePool = resolve as (value: unknown) => void;
+      }) as ReturnType<typeof pool.prewarmVoiceInputAudio>,
+    );
+    const onInterrupted = vi.fn();
+
+    const engine = new mod.WebMicAudioEngine({
+      workletUrl: WORKLET_URL,
+      keepAlive: false,
+      onInterrupted,
+    });
+    const starting = engine.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    powerCallback?.({ reason: 'screen_locked' });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The device must be closed, but a capture that never reached `ready` has
+    // to surface as a silent cancellation: both UIs route onInterrupted to
+    // their active-recording failure path, and that error would outlive the
+    // cancellation that follows.
+    expect(track.stopped).toBe(true);
+    expect(onInterrupted).not.toHaveBeenCalled();
+
+    resolvePool({
+      context: {
+        currentTime: 0,
+        state: 'running',
+        destination,
+        createGain: vi.fn(() => sink),
+        createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+        resume: vi.fn(async () => undefined),
+      },
+      workletReady: Promise.resolve(),
+      workletUrl: WORKLET_URL,
+    });
+    await expect(starting).rejects.toThrow(/disposed/i);
+  });
+
   it('can release a stream acquired before context warmup settles', async () => {
     let resolvePool: (value: unknown) => void = () => undefined;
     const pool = await import('../audioContextPool');
@@ -557,8 +600,8 @@ describe('keep-alive microphone idle window', () => {
       onInterrupted: vi.fn(),
     });
 
-    // The device is already open by the time this step fails, and the engine
-    // never made it into the registry — the failure path has to close it.
+    // The device is already open by the time this step fails. Whether or not
+    // the engine reached the registry, the failure path has to close it.
     await expect(engine.start()).rejects.toThrow(/resume failed/i);
     expect(track.stopped).toBe(true);
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

#373 的 follow-up：补上那个 PR 没覆盖的最后一处电源释放缺口。

#373 让挂起 / 锁屏能立即释放语音输入的**保活**麦克风，但释放只作用于模块级的
keep-alive 会话。**不走保活的普通采集流完全不受影响**：

- 用户关掉「快速启动语音输入」后，录音走的就是普通路径，整条链路没有任何电源释放
  保护；
- 选定麦克风不可用时自动回退产生的冷启动流同样如此。

这两种情况下锁屏或挂起后麦克风继续占用，系统隐私指示灯常亮，`coreaudiod` 的
idle-sleep assertion 也一直留到用户回来——正是 #373 想消除的那类占用，只是换了条
路径。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#373 的 follow-up
- 本 PR 包含：
  1. 新增直连采集引擎登记表：普通路径 `ready` 后登记、`stop()` 注销，电源事件遍历
     中断（走引擎既有的 `interrupt()` 路径去取消 ASR run）并关闭流。
  2. 普通路径同样确保电源监听器已安装。fast activation 关闭时从不创建 keep-alive
     会话，否则这个 renderer 里没有任何地方会去订阅 `voice-input:power-state-change`。
- 明确不包含：不改 #373 已合入的保活链路行为，不改 fast activation 默认值。
- 用户可见变化：关闭 fast activation 时录音，锁屏 / 挂起同样会立即停止并释放麦克风，
  与开启时的行为一致。
- 是否存在 breaking change：无

### UI 变化

引用的设计规范：不涉及 —— 纯逻辑修复，无视觉、交互与文案变化。

改动只命中 `WebMicAudioEngine.ts` 与其单测，属于音频设备生命周期逻辑，不新增或修改
任何组件、布局、样式与文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/voice-input/__tests__/ src/main/voice-input/__tests__/
结果：35 files / 224 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过，无错误

pnpm test:unit(仓库门禁全量，run-unit-gate.sh)
结果：通过，GATE_EXIT=0
```

新增回归测试 `releases a direct capture stream on a power event`：以
`keepAlive: false` 启动（即 fast activation 关闭的路径），触发 `system_suspend`，
断言 `onInterrupted` 被调用且 track 被停止。已反向验证：去掉电源事件里的遍历后该
用例失败（`onInterrupted` 未被调用）。

### 手工验证

不涉及——纯逻辑改动，行为差异是「关闭 fast activation 时锁屏是否释放麦克风」，已由
单测覆盖。

### 未执行的验证

- **真机锁屏复核未执行**：合入后可用 `pmset -g assertions | grep -A2 coreaudiod`
  确认关闭 fast activation 录音时锁屏后 audio-in assertion 立即消失。
- **Windows 未实测**：`suspend` 两端语义一致，`lock-screen` 在 Windows 为工作站锁定，
  「用户已离开」的判断两端成立。macOS 侧逻辑已由单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异
- [ ] 原生层 / fingerprint / OTA
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 renderer 侧语音输入的采集流生命周期。麦克风占用时间**变短**，方向上
  是隐私与能耗正向；最坏退化是锁屏时一段录音被中断——而那正是期望行为。
- 不涉及新增 IPC：复用 #373 已登记的 `voice-input:power-state-change` 推送，
  `packages/device-link/src/allowlist.ts` 的结论不变（本机电源状态，不可远程调用）。
- 回滚 / 降级方式：整体 revert 即可，无数据迁移、无持久化状态、无协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(关键约束以代码注释就地记录)
- [x] 已确认测试结果或说明未执行原因
