### PR TITLE
fix(desktop): 修复会话引用 chip 与范围摘要挤成竖排

### DIFF
--- a/apps/desktop/src/renderer/components/chat/SessionLinkChip.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionLinkChip.tsx
@@ -150,13 +150,25 @@ export function SessionLinkChip({ href, label, referenceMetadata }: SessionLinkC
     // A Markdown label is explicit author intent and must survive anchored
     // links even when no persisted reference metadata is available yet.
     const visibleMessageLabel = explicitLabel ?? messageLabel;
-    const messageContent = <QuoteChip quote={{ text: visibleMessageLabel }} />;
+    // 宽度上限只能加在 pill 这一侧:pill 和 summary 是同一 flex 行的两个 item,
+    // 把 240px 加在外层会让两者抢同一份宽度——summary 没有 nowrap,会被压到
+    // min-content(中文逐字换行)竖成一列,再把 pill 沿 stretch 拉成大椭圆。
+    const messageContent = (
+      <span className="inline-flex min-w-0 max-w-[min(240px,55vw)]">
+        <QuoteChip quote={{ text: visibleMessageLabel }} />
+      </span>
+    );
+    // summary 单行截断:窄气泡里退化成省略号,完整内容仍在 title / aria-label。
     const referenceSummary = referenceDetails.length > 0 ? (
-      <span data-session-reference-summary="" className="ml-1 text-[11px] text-[var(--text-tertiary)]">
+      <span
+        data-session-reference-summary=""
+        className="ml-1 min-w-0 truncate text-[11px] text-[var(--text-tertiary)]"
+      >
         {referenceDetails.join(' · ')}
       </span>
     ) : null;
-    const messageClass = 'inline-flex max-w-[min(240px,55vw)] align-middle';
+    // items-center 保证 pill 保持自身高度(不被 align-items: stretch 撑成椭圆)。
+    const messageClass = 'inline-flex max-w-full items-center align-middle';
     if (navigationMode === 'sidebar-embedded') {
       return (
         <span data-session-message-link="" title={tooltip} className={cn(messageClass, 'cursor-default')}>

--- a/apps/desktop/src/renderer/components/chat/__tests__/embeddedSessionNavigation.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/embeddedSessionNavigation.test.tsx
@@ -113,6 +113,35 @@ describe('sidebar-embedded session navigation boundary', () => {
     ).toBeTruthy();
   });
 
+  it('keeps the anchored pill and its range summary on a single line', () => {
+    const { container } = render(
+      <SessionLinkChip
+        href="cindy://session/session-a?message=message-1"
+        label="Session A"
+        referenceMetadata={{
+          sessionId: 'session-a',
+          messageClientId: 'message-1',
+          range: 'around-anchor',
+          messageCount: 11,
+          truncated: true,
+        }}
+      />,
+    );
+
+    // 宽度上限必须留在 pill 一侧:加回外层会让 pill 与 summary 抢同一份 240px,
+    // summary 被压成逐字竖排、pill 被 stretch 拉成大椭圆。
+    const link = container.querySelector('button[data-session-message-link]');
+    expect(link?.className).toContain('items-center');
+    expect(link?.className).not.toContain('max-w-[min(240px,55vw)]');
+    expect(
+      container.querySelector('[data-inline-reference-chip]')?.parentElement?.className,
+    ).toContain('max-w-[min(240px,55vw)]');
+    // summary 单行截断,不参与换行。
+    expect(container.querySelector('[data-session-reference-summary]')?.className).toContain(
+      'truncate',
+    );
+  });
+
   it('renders handoff cards as static content without resolving or navigating', () => {
     render(
       embedded(


### PR DESCRIPTION
## 这次改了什么

### 摘要

聊天里带 `?message=` 锚点的会话深链（引用某条消息）在渲染范围摘要时布局塌陷：引用胶囊被拉成一个巨大的椭圆，右边的「链接消息附近 · 11 条消息 · 已截断」被压成一字一行的竖排。

根因是 `SessionLinkChip` 把 `max-w-[min(240px,55vw)]` 加在了最外层 `inline-flex` 容器上，而这个容器里有两个 flex item —— 引用胶囊（QuoteChip）和范围摘要。两者抢同一份 240px：摘要那个 `<span>` 没有 `whitespace-nowrap`，min-content 就是单个汉字宽，于是被压成竖排；摘要撑高行高后，容器又缺 `items-center`，`align-items: stretch` 把 `rounded-full` 的胶囊沿垂直方向拉满，变成大椭圆。

修法是把宽度约束放回正确的层级：240px 上限只加在胶囊一侧，摘要单行截断，容器锁 `items-center`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（使用中发现）
- 本 PR 包含：`SessionLinkChip` 锚点分支的布局修复 + 对应回归测试
- 明确不包含：不改胶囊配色、字号、文案、跳转行为；不动 mobile（那边深链渲染的是 WebView 里的 `<a class="xdt-session-chip">` 纯 inline 元素，没有这个 flex 结构，不受影响）
- 用户可见变化：带范围摘要的会话引用链接恢复为「单行胶囊 + 单行摘要」，不再出现拉伸椭圆和竖排文字
- 是否存在 breaking change：无

### UI 变化

平台：Desktop（聊天消息流内的行内引用 chip）。

改动前后（同一条消息、同一宽度气泡）：

- 改动前：胶囊高度约等于三行文字，呈竖向椭圆；摘要「链接消息附近 · 11 条消息 · 已截断」逐字换行成一列；正文被挤到右侧。
- 改动后：胶囊恢复单行 pill（内容超长时省略号截断，上限仍是 `min(240px,55vw)`），摘要单行紧随其后；气泡收窄到 300px 时摘要退化为省略号，完整内容仍在 `title` / `aria-label`。

下面是与改动后组件类名等价的自包含 HTML：单文件带 `prefers-color-scheme`，Light / Dark 一份覆盖，含 before / after 对照、320px 窄气泡、以及无范围摘要的回归对照。保存为 `.html` 直接打开即可复核（胶囊本体与配色沿用 Default 主题 token 的实际值）。

<details>
<summary>展开：before / after 对照页（HTML）</summary>

```html
<!doctype html>
<html lang="zh-CN">
<head>
<meta charset="utf-8" />
<title>SessionLinkChip — 锚点引用 chip 布局 before / after</title>
<style>
  :root { color-scheme: light dark; }
  body { font-family: -apple-system, "PingFang SC", "Inter", sans-serif; margin: 0; padding: 24px;
         background: #f8f8f6; color: #262626; }
  .pane { display: grid; grid-template-columns: 1fr; gap: 8px; max-width: 900px; }
  h2 { font-size: 13px; font-weight: 500; color: #737373; margin: 24px 0 4px; }
  h1 { font-size: 15px; font-weight: 500; margin: 0 0 4px; }
  .note { font-size: 12px; color: #737373; margin: 0 0 16px; }
  .bubble { background: #fff; border: 1px solid #d7d7d4; border-radius: 12px; padding: 16px;
            font-size: 15px; line-height: 1.7; }
  .narrow { max-width: 320px; }

  /* InlineReferenceChip 的胶囊本体 —— 本次未改动 */
  .chip { display: inline-flex; min-width: 0; max-width: 100%; align-items: center; gap: 6px;
          border-radius: 9999px; border: 1px solid #d7d7d4; padding: 2px 8px;
          font-size: 12px; line-height: 20px; background: #e5e5e5; color: #262626; }
  .chip-icon { display: inline-flex; height: 14px; width: 14px; flex-shrink: 0;
               align-items: center; justify-content: center; font-size: 11px; }
  .chip-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

  /* BEFORE: messageClass = 'inline-flex max-w-[min(240px,55vw)] align-middle' */
  .before { display: inline-flex; max-width: min(240px, 55vw); vertical-align: middle;
            border: 0; background: none; padding: 0; font: inherit; text-align: left; color: inherit; }
  .before .summary { margin-left: 4px; font-size: 11px; color: #a3a3a3; }

  /* AFTER: messageClass = 'inline-flex max-w-full items-center align-middle' */
  .after { display: inline-flex; max-width: 100%; align-items: center; vertical-align: middle;
           border: 0; background: none; padding: 0; font: inherit; text-align: left; color: inherit; }
  .after .chip-slot { display: inline-flex; min-width: 0; max-width: min(240px, 55vw); }
  .after .summary { margin-left: 4px; min-width: 0; font-size: 11px; color: #a3a3a3;
                    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

  @media (prefers-color-scheme: dark) {
    body { background: #1f1f1e; color: #d4d4d4; }
    .bubble { background: #2c2c2a; border-color: #3c3c3a; }
    .chip { background: #2c2c2a; border-color: #3c3c3a; color: #d4d4d4; }
  }
</style>
</head>
<body>
<h1>SessionLinkChip — 带范围摘要的锚点引用 chip</h1>
<p class="note">
  同一条消息、同一宽度气泡下的 before / after。胶囊本体样式未改动，仅调整宽度约束层级与对齐。
  颜色取自 Default Light / Dark 主题的 token 实际值；本页跟随系统深浅色，切换系统外观即可看另一模式。
</p>

<div class="pane">
  <h2>BEFORE — 宽气泡</h2>
  <div class="bubble">
    <button class="before">
      <span class="chip"><span class="chip-icon">▤</span><span class="chip-label">周报草稿已更新：`.../notes/weekly-draft.md` 已经写好了</span></span>
      <span class="summary">链接消息附近 · 11 条消息 · 已截断</span>
    </button>
    这段正文接在引用之后，用来观察 chip 在文本流里的表现。
  </div>

  <h2>AFTER — 宽气泡</h2>
  <div class="bubble">
    <button class="after">
      <span class="chip-slot"><span class="chip"><span class="chip-icon">▤</span><span class="chip-label">周报草稿已更新：`.../notes/weekly-draft.md` 已经写好了</span></span></span>
      <span class="summary">链接消息附近 · 11 条消息 · 已截断</span>
    </button>
    这段正文接在引用之后，用来观察 chip 在文本流里的表现。
  </div>

  <h2>BEFORE — 窄气泡 320px</h2>
  <div class="bubble narrow">
    <button class="before">
      <span class="chip"><span class="chip-icon">▤</span><span class="chip-label">周报草稿已更新：`.../notes/weekly-draft.md` 已经写好了</span></span>
      <span class="summary">链接消息附近 · 11 条消息 · 已截断</span>
    </button>
    正文
  </div>

  <h2>AFTER — 窄气泡 320px</h2>
  <div class="bubble narrow">
    <button class="after">
      <span class="chip-slot"><span class="chip"><span class="chip-icon">▤</span><span class="chip-label">周报草稿已更新：`.../notes/weekly-draft.md` 已经写好了</span></span></span>
      <span class="summary">链接消息附近 · 11 条消息 · 已截断</span>
    </button>
    正文
  </div>

  <h2>AFTER — 无范围摘要（回归对照，应与改动前一致）</h2>
  <div class="bubble">
    <button class="after">
      <span class="chip-slot"><span class="chip"><span class="chip-icon">▤</span><span class="chip-label">周报草稿已更新：`.../notes/weekly-draft.md` 已经写好了</span></span></span>
    </button>
    这段正文接在引用之后，用来观察 chip 在文本流里的表现。
  </div>
</div>
</body>
</html>
```

</details>

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §5 Border Radius Scale — Pill (9999px)：可套胶囊的交互件必须是胶囊。原实现里胶囊被 `stretch` 拉成多行高的椭圆，违反这一档几何；修复后 `items-center` 保证它保持单行 pill 高度。
  - `docs/design-rules/DESIGN.md` §7 Don't —「Don't invent arbitrary radii」：被纵向拉伸的 `rounded-full` 在视觉上等价于引入了一个规范外的圆角形状，同样要避免。
  - `docs/design-rules/DESIGN.md` §8 Responsive Behavior / Collapsing Strategy：窄容器下靠截断（省略号）而不是逐字换行来收敛，行内元素保持单行。
  - `docs/design-rules/DESIGN.md` §10 Light / Dark 双模式交付门槛：两种模式都已验证（见下）。本次没有引入任何新色值，配色全部沿用既有 token（`--surface-chip` / `--text-primary` / `--text-tertiary` / `--border-default`）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/embeddedSessionNavigation.test.tsx
结果：Test Files 1 passed | Tests 13 passed（含本 PR 新增的 1 条回归测试）

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm test:unit（仓库根全量单元测试门禁）
结果：通过（GATE_EXIT=0）
```

新增回归测试 `keeps the anchored pill and its range summary on a single line` 锁住三件事：宽度上限留在 pill 一侧、外层不再带 240px 上限、摘要带 `truncate`、容器带 `items-center`。jsdom 不做布局，因此断言的是产生该布局的类名契约。

### 手工验证

用 Playwright（Chromium）渲染与组件类名等价的 CSS，在 960px 视口下对比 before / after：

- Light 模式：before 完整复现了线上塌陷（椭圆胶囊 + 三行竖排摘要）；after 为单行胶囊 + 单行摘要。
- Dark 模式：同上，布局一致，配色沿用 Dark token 无异常。
- 窄气泡（300px / 320px）：after 下胶囊与摘要各自省略号截断，不换行、不溢出气泡。
- 无 reference metadata 的普通引用链接：渲染结果与改动前一致（有效上限仍为 240px）。

### 未执行的验证

- 未在 Electron 实机聊天流中回放这条具体消息。改动是纯 CSS flex 布局（无逻辑分支、无数据流变化），已通过等价 CSS 的浏览器渲染 + 组件测试覆盖；实机复核可在合入后随日常使用确认。
- 未做 mobile 验证：本 PR 不触碰 mobile 代码路径（见「范围」）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 聊天消息流里 `SessionLinkChip` 的锚点分支（`cindy://session/<id>?message=<clientId>`）。同文件的整段会话链接分支、跳转逻辑、tooltip / aria-label 内容均未改动。
- 回滚 / 降级方式：单文件 CSS 类名改动，`git revert` 本 PR 即可完全恢复原行为，无数据或状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次为局部样式修复，无需新增文档）
- [x] 已确认测试结果或说明未执行原因
