### PR TITLE
fix(mobile): 移除 iOS 会话输入框键盘上方的系统表单导航条

### DIFF
--- a/dependency-patches/README.md
+++ b/dependency-patches/README.md
@@ -10,7 +10,7 @@
 
 | 依赖 | 用途 |
 | --- | --- |
-| `expo-paste-input@0.2.2` | 优化移动端粘贴图片的处理时序，将耗时的解码、压缩和写盘移出 UI 线程，并补充加载中与失败事件；同时清空被接管输入框的 iOS `inputAssistantItem`，避免依赖为支持 Genmoji 把输入框标成富文本后，系统在键盘上方多挂一条只有禁用态上下箭头和「完成」的表单导航条。 |
+| `expo-paste-input@0.2.2` | 优化移动端粘贴图片的处理时序，将耗时的解码、压缩和写盘移出 UI 线程，并补充加载中与失败事件；同时在 iPhone 上清空被接管输入框的 iOS `inputAssistantItem`，去掉系统在键盘上方多挂的一条只有禁用态上下箭头和「完成」的表单导航条（iPad 的辅助条含撤销／重做／粘贴等实际功能，保持不动）。 |
 | `harmonyos-sans-sc-webfont-splitted` | 移除依赖按语言全局覆盖 `font-family` 的规则，由 Cindy 自己决定界面字体。 |
 | `react-native@0.85.3` | 回移 Yoga 对 `display: none` 与 `display: contents` 测量过程的布局状态修复，避免 Fabric 布局阶段因错误的 owner 关系触发断言崩溃（上游 `6fa330693fba313a2fe1121545c1efd558b60983`、`2546ce4d8219050fcd1bf432c7c830c9fd70c9af`）。移动端 iOS 通过 `expo-build-properties` 的 `buildReactNativeFromSource` 编译该补丁，不能改回预编译 RN Core。 |
 | `react-native-uitextview@2.2.0` | 修复 iOS 长文本渲染闪烁、布局性能、文本选择与选择手柄滚动等问题，并支持自定义选择菜单操作。 |

--- a/dependency-patches/README.md
+++ b/dependency-patches/README.md
@@ -10,7 +10,7 @@
 
 | 依赖 | 用途 |
 | --- | --- |
-| `expo-paste-input@0.2.2` | 优化移动端粘贴图片的处理时序，将耗时的解码、压缩和写盘移出 UI 线程，并补充加载中与失败事件。 |
+| `expo-paste-input@0.2.2` | 优化移动端粘贴图片的处理时序，将耗时的解码、压缩和写盘移出 UI 线程，并补充加载中与失败事件；同时清空被接管输入框的 iOS `inputAssistantItem`，避免依赖为支持 Genmoji 把输入框标成富文本后，系统在键盘上方多挂一条只有禁用态上下箭头和「完成」的表单导航条。 |
 | `harmonyos-sans-sc-webfont-splitted` | 移除依赖按语言全局覆盖 `font-family` 的规则，由 Cindy 自己决定界面字体。 |
 | `react-native@0.85.3` | 回移 Yoga 对 `display: none` 与 `display: contents` 测量过程的布局状态修复，避免 Fabric 布局阶段因错误的 owner 关系触发断言崩溃（上游 `6fa330693fba313a2fe1121545c1efd558b60983`、`2546ce4d8219050fcd1bf432c7c830c9fd70c9af`）。移动端 iOS 通过 `expo-build-properties` 的 `buildReactNativeFromSource` 编译该补丁，不能改回预编译 RN Core。 |
 | `react-native-uitextview@2.2.0` | 修复 iOS 长文本渲染闪烁、布局性能、文本选择与选择手柄滚动等问题，并支持自定义选择菜单操作。 |

--- a/dependency-patches/expo-paste-input@0.2.2.patch
+++ b/dependency-patches/expo-paste-input@0.2.2.patch
@@ -159,7 +159,7 @@ index 4c430a252ef3e938622e6c56421ed283c6167913..4d5c561a5d117e7459cb0f83ca1c213c
      type: "unsupported";
  };
 diff --git a/ios/ExpoPasteInputView.swift b/ios/ExpoPasteInputView.swift
-index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb491bab9386 100644
+index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d893d2716f 100644
 --- a/ios/ExpoPasteInputView.swift
 +++ b/ios/ExpoPasteInputView.swift
 @@ -38,6 +38,8 @@ class ExpoPasteInputView: ExpoView {
@@ -171,7 +171,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
    private let gifTypes: Set<String> = ["com.compuserve.gif", "public.gif", "image/gif"]
    private let webpTypes: Set<String> = ["org.webmproject.webp", "public.webp", "image/webp"]
    // Track which classes have been swizzled (once per class, never unswizzle)
-@@ -145,6 +147,19 @@ class ExpoPasteInputView: ExpoView {
+@@ -145,6 +147,27 @@ class ExpoPasteInputView: ExpoView {
        originalAdaptiveImageGlyphSupport = nil
      }
  
@@ -183,15 +183,23 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
 +    // This must be an empty array — a UIBarButtonItemGroup with no items
 +    // hides the buttons but keeps the bar itself taking up space. Reported on
 +    // iOS 27; does not reproduce on the iOS 26.5 iPhone simulator.
-+    originalLeadingBarButtonGroups = view.inputAssistantItem.leadingBarButtonGroups
-+    originalTrailingBarButtonGroups = view.inputAssistantItem.trailingBarButtonGroups
-+    view.inputAssistantItem.leadingBarButtonGroups = []
-+    view.inputAssistantItem.trailingBarButtonGroups = []
++    //
++    // iPhone only: on iPad the shortcuts bar is a permanent part of the
++    // keyboard and carries real editing affordances (undo/redo, paste,
++    // formatting), so clearing it there would take away working functionality
++    // rather than an empty row. restoreTextInput() keys off the saved groups
++    // being non-nil, so skipping the capture here also skips the restore.
++    if UIDevice.current.userInterfaceIdiom == .phone {
++      originalLeadingBarButtonGroups = view.inputAssistantItem.leadingBarButtonGroups
++      originalTrailingBarButtonGroups = view.inputAssistantItem.trailingBarButtonGroups
++      view.inputAssistantItem.leadingBarButtonGroups = []
++      view.inputAssistantItem.trailingBarButtonGroups = []
++    }
 +
      if let textView = view as? UITextView {
        observeTextViewChanges(for: textView)
      } else {
-@@ -162,6 +177,17 @@ class ExpoPasteInputView: ExpoView {
+@@ -162,6 +185,17 @@ class ExpoPasteInputView: ExpoView {
      }
      originalAdaptiveImageGlyphSupport = nil
  
@@ -209,7 +217,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
      if let textView = view as? UITextView,
         observedTextView === textView {
        stopObservingTextView()
-@@ -252,77 +278,20 @@ class ExpoPasteInputView: ExpoView {
+@@ -252,77 +286,20 @@ class ExpoPasteInputView: ExpoView {
            }
            
            let pasteboard = UIPasteboard.general
@@ -301,7 +309,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
              return // Don't call original paste for images
            }
            
-@@ -550,7 +519,12 @@ class ExpoPasteInputView: ExpoView {
+@@ -550,12 +527,80 @@ class ExpoPasteInputView: ExpoView {
      emitImagesAsync(for: mediaPayloads)
    }
  
@@ -311,14 +319,19 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
 +  // happen on the background queue.
    private func emitImagesAsync(for payloads: [MediaPayload]) {
 +    emitImagesLoading(count: payloads.count)
-     mediaProcessingQueue.async { [weak self] in
-       guard let self else {
-         return
-@@ -564,7 +538,70 @@ class ExpoPasteInputView: ExpoView {
-         }
- 
-         if uris.isEmpty {
--          self.handleUnsupportedPaste()
++    mediaProcessingQueue.async { [weak self] in
++      guard let self else {
++        return
++      }
++
++      let uris = self.temporaryFileURIs(for: payloads)
++
++      DispatchQueue.main.async { [weak self] in
++        guard let self else {
++          return
++        }
++
++        if uris.isEmpty {
 +          // A placeholder was already emitted — resolve it as failed instead
 +          // of the generic unsupported event so JS can retract the cards.
 +          self.emitImagesLoadFailed()
@@ -361,11 +374,11 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
 +    // UIPasteboard keeps no history, so the original data is gone — resolve
 +    // the placeholder as failed instead of mis-attaching the wrong image.
 +    let capturedChangeCount = UIPasteboard.general.changeCount
-+    mediaProcessingQueue.async { [weak self] in
-+      guard let self else {
-+        return
-+      }
-+
+     mediaProcessingQueue.async { [weak self] in
+       guard let self else {
+         return
+       }
+ 
 +      guard UIPasteboard.general.changeCount == capturedChangeCount else {
 +        DispatchQueue.main.async { [weak self] in
 +          self?.emitImagesLoadFailed()
@@ -374,19 +387,19 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
 +      }
 +
 +      let payloads = self.collectPasteboardMediaPayloads()
-+      let uris = self.temporaryFileURIs(for: payloads)
-+
-+      DispatchQueue.main.async { [weak self] in
-+        guard let self else {
-+          return
-+        }
-+
-+        if uris.isEmpty {
+       let uris = self.temporaryFileURIs(for: payloads)
+ 
+       DispatchQueue.main.async { [weak self] in
+@@ -564,7 +609,7 @@ class ExpoPasteInputView: ExpoView {
+         }
+ 
+         if uris.isEmpty {
+-          self.handleUnsupportedPaste()
 +          self.emitImagesLoadFailed()
            return
          }
  
-@@ -700,8 +737,11 @@ class ExpoPasteInputView: ExpoView {
+@@ -700,8 +745,11 @@ class ExpoPasteInputView: ExpoView {
      return true
    }
    
@@ -400,7 +413,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
      let pasteboard = UIPasteboard.general
      
      let staticImageTypes = [
-@@ -832,15 +872,7 @@ class ExpoPasteInputView: ExpoView {
+@@ -832,15 +880,7 @@ class ExpoPasteInputView: ExpoView {
        staticImagePayloads.append(.image(image))
      }
      
@@ -417,7 +430,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
    }
    
    /// Detects if the given data is a GIF by checking for GIF87a or GIF89a header
-@@ -922,6 +954,23 @@ class ExpoPasteInputView: ExpoView {
+@@ -922,6 +962,23 @@ class ExpoPasteInputView: ExpoView {
      ])
    }
  
@@ -441,7 +454,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb49
    private func temporaryFileURIs(for payloads: [MediaPayload]) -> [String] {
      var uris: [String] = []
  
-@@ -1013,15 +1062,6 @@ class ExpoPasteInputView: ExpoView {
+@@ -1013,15 +1070,6 @@ class ExpoPasteInputView: ExpoView {
      stopMonitoring()
      stopObservingTextView()
    }

--- a/dependency-patches/expo-paste-input@0.2.2.patch
+++ b/dependency-patches/expo-paste-input@0.2.2.patch
@@ -159,10 +159,57 @@ index 4c430a252ef3e938622e6c56421ed283c6167913..4d5c561a5d117e7459cb0f83ca1c213c
      type: "unsupported";
  };
 diff --git a/ios/ExpoPasteInputView.swift b/ios/ExpoPasteInputView.swift
-index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58832f8c3d 100644
+index 39b2302ed42bdd56db6084e333b9581e08c18689..ac817662d5bf8b3f475f0c2ec954eb491bab9386 100644
 --- a/ios/ExpoPasteInputView.swift
 +++ b/ios/ExpoPasteInputView.swift
-@@ -252,77 +252,20 @@ class ExpoPasteInputView: ExpoView {
+@@ -38,6 +38,8 @@ class ExpoPasteInputView: ExpoView {
+   private weak var observedTextView: UITextView?
+   private var isSanitizingAttachments: Bool = false
+   private var originalAdaptiveImageGlyphSupport: Bool?
++  private var originalLeadingBarButtonGroups: [UIBarButtonItemGroup]?
++  private var originalTrailingBarButtonGroups: [UIBarButtonItemGroup]?
+   private let gifTypes: Set<String> = ["com.compuserve.gif", "public.gif", "image/gif"]
+   private let webpTypes: Set<String> = ["org.webmproject.webp", "public.webp", "image/webp"]
+   // Track which classes have been swizzled (once per class, never unswizzle)
+@@ -145,6 +147,19 @@ class ExpoPasteInputView: ExpoView {
+       originalAdaptiveImageGlyphSupport = nil
+     }
+ 
++    // Recent iOS versions attach the system form-navigation shortcuts bar to
++    // the inputs this wrapper takes over, drawn since iOS 26 as a standalone
++    // floating capsule above the keyboard. A single-field composer therefore
++    // gets an extra row holding nothing but permanently disabled prev/next
++    // chevrons and a Done checkmark. Drop both groups so the bar goes away.
++    // This must be an empty array — a UIBarButtonItemGroup with no items
++    // hides the buttons but keeps the bar itself taking up space. Reported on
++    // iOS 27; does not reproduce on the iOS 26.5 iPhone simulator.
++    originalLeadingBarButtonGroups = view.inputAssistantItem.leadingBarButtonGroups
++    originalTrailingBarButtonGroups = view.inputAssistantItem.trailingBarButtonGroups
++    view.inputAssistantItem.leadingBarButtonGroups = []
++    view.inputAssistantItem.trailingBarButtonGroups = []
++
+     if let textView = view as? UITextView {
+       observeTextViewChanges(for: textView)
+     } else {
+@@ -162,6 +177,17 @@ class ExpoPasteInputView: ExpoView {
+     }
+     originalAdaptiveImageGlyphSupport = nil
+ 
++    // Fabric recycles backing text views across TextInput instances, so hand
++    // the shortcuts bar back exactly as we found it.
++    if let originalLeadingBarButtonGroups {
++      view.inputAssistantItem.leadingBarButtonGroups = originalLeadingBarButtonGroups
++    }
++    if let originalTrailingBarButtonGroups {
++      view.inputAssistantItem.trailingBarButtonGroups = originalTrailingBarButtonGroups
++    }
++    originalLeadingBarButtonGroups = nil
++    originalTrailingBarButtonGroups = nil
++
+     if let textView = view as? UITextView,
+        observedTextView === textView {
+       stopObservingTextView()
+@@ -252,77 +278,20 @@ class ExpoPasteInputView: ExpoView {
            }
            
            let pasteboard = UIPasteboard.general
@@ -254,7 +301,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58
              return // Don't call original paste for images
            }
            
-@@ -550,7 +493,12 @@ class ExpoPasteInputView: ExpoView {
+@@ -550,7 +519,12 @@ class ExpoPasteInputView: ExpoView {
      emitImagesAsync(for: mediaPayloads)
    }
  
@@ -267,7 +314,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58
      mediaProcessingQueue.async { [weak self] in
        guard let self else {
          return
-@@ -564,7 +512,70 @@ class ExpoPasteInputView: ExpoView {
+@@ -564,7 +538,70 @@ class ExpoPasteInputView: ExpoView {
          }
  
          if uris.isEmpty {
@@ -339,7 +386,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58
            return
          }
  
-@@ -700,8 +711,11 @@ class ExpoPasteInputView: ExpoView {
+@@ -700,8 +737,11 @@ class ExpoPasteInputView: ExpoView {
      return true
    }
    
@@ -353,7 +400,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58
      let pasteboard = UIPasteboard.general
      
      let staticImageTypes = [
-@@ -832,15 +846,7 @@ class ExpoPasteInputView: ExpoView {
+@@ -832,15 +872,7 @@ class ExpoPasteInputView: ExpoView {
        staticImagePayloads.append(.image(image))
      }
      
@@ -370,7 +417,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58
    }
    
    /// Detects if the given data is a GIF by checking for GIF87a or GIF89a header
-@@ -922,6 +928,23 @@ class ExpoPasteInputView: ExpoView {
+@@ -922,6 +954,23 @@ class ExpoPasteInputView: ExpoView {
      ])
    }
  
@@ -394,7 +441,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58
    private func temporaryFileURIs(for payloads: [MediaPayload]) -> [String] {
      var uris: [String] = []
  
-@@ -1013,15 +1036,6 @@ class ExpoPasteInputView: ExpoView {
+@@ -1013,15 +1062,6 @@ class ExpoPasteInputView: ExpoView {
      stopMonitoring()
      stopObservingTextView()
    }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
 
 patchedDependencies:
   expo-paste-input@0.2.2:
-    hash: f2bfa7eec0c3fe851eb9b6ca1ceb5b7f6930cbfc753828d7d0c3546ba97514f4
+    hash: d3eb498564b85f9db254b4ccc74c3398d8f45706a8dd2e37f194f22992a00387
     path: dependency-patches/expo-paste-input@0.2.2.patch
   harmonyos-sans-sc-webfont-splitted:
     hash: 272e3ded46880ee2f9eaff39327b8465de6df4072271de03caf73950e6e57822
@@ -600,7 +600,7 @@ importers:
         version: 56.0.22(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-paste-input:
         specifier: 0.2.2
-        version: 0.2.2(patch_hash=f2bfa7eec0c3fe851eb9b6ca1ceb5b7f6930cbfc753828d7d0c3546ba97514f4)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 0.2.2(patch_hash=d3eb498564b85f9db254b4ccc74c3398d8f45706a8dd2e37f194f22992a00387)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-router:
         specifier: ^56.2.11
         version: 56.2.15(600de089274a49ab6ec9549ee6c8284a)
@@ -17020,7 +17020,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-paste-input@0.2.2(patch_hash=f2bfa7eec0c3fe851eb9b6ca1ceb5b7f6930cbfc753828d7d0c3546ba97514f4)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  expo-paste-input@0.2.2(patch_hash=d3eb498564b85f9db254b4ccc74c3398d8f45706a8dd2e37f194f22992a00387)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       expo: 56.0.16(bedb3dfb85b4bb5081482612eab0a2c6)
       react: 19.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
 
 patchedDependencies:
   expo-paste-input@0.2.2:
-    hash: 53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8
+    hash: f2bfa7eec0c3fe851eb9b6ca1ceb5b7f6930cbfc753828d7d0c3546ba97514f4
     path: dependency-patches/expo-paste-input@0.2.2.patch
   harmonyos-sans-sc-webfont-splitted:
     hash: 272e3ded46880ee2f9eaff39327b8465de6df4072271de03caf73950e6e57822
@@ -600,7 +600,7 @@ importers:
         version: 56.0.22(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-paste-input:
         specifier: 0.2.2
-        version: 0.2.2(patch_hash=53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 0.2.2(patch_hash=f2bfa7eec0c3fe851eb9b6ca1ceb5b7f6930cbfc753828d7d0c3546ba97514f4)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-router:
         specifier: ^56.2.11
         version: 56.2.15(600de089274a49ab6ec9549ee6c8284a)
@@ -17020,7 +17020,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-paste-input@0.2.2(patch_hash=53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  expo-paste-input@0.2.2(patch_hash=f2bfa7eec0c3fe851eb9b6ca1ceb5b7f6930cbfc753828d7d0c3546ba97514f4)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       expo: 56.0.16(bedb3dfb85b4bb5081482612eab0a2c6)
       react: 19.2.3


### PR DESCRIPTION
## 这次改了什么

### 摘要

iOS 上聚焦会话输入框时，键盘上方会多出一条系统「表单导航条」（UIKit 的
`inputAssistantItem` / shortcuts bar）：左侧是恒为禁用态的上一项 / 下一项箭头，右侧是一个
「完成」勾。iOS 26 起这条被重画成键盘上方的独立浮动胶囊，于是在单字段的 composer 上就成了
凭空多占的一行，且里面没有任何对用户有用的东西。

排查结论：只有会话输入框有这条，其它输入框（登录、搜索、重命名等）没有。差异点在
`MobileComposerInputRow.tsx:264` —— 只有传了 `onPasteImages` 的输入框才会被
`expo-paste-input` 的 `TextInputWrapper` 接管（全仓仅 `app/sessions/new.tsx:2812` 与
`app/sessions/[sessionId].tsx:7061 / 7095`），而该 wrapper 会在原生侧改写被接管的
`UITextView`（为支持 Genmoji / 图片粘贴设 `supportsAdaptiveImageGlyph`、swizzle
`paste`）。

本 PR 在同一个 patch 的 `enhanceTextInput()` 里把被接管输入框的
`inputAssistantItem.leadingBarButtonGroups` / `trailingBarButtonGroups` 清空，`restoreTextInput()`
里原样还原（Fabric 会跨 TextInput 复用 backing text view，必须还原）。必须赋空数组：赋一个
不含按钮的 `UIBarButtonItemGroup` 只会隐藏按钮，条本身仍然占位。

**仅在 iPhone 生效**：iPad 上这条 shortcuts bar 是键盘的常驻组成部分，带撤销／重做／粘贴等
真实编辑能力，不是 iPhone 上那种空行，所以只在 `UIDevice.current.userInterfaceIdiom == .phone`
时清空（本 app `apps/mobile/app.json:35` 声明了 `supportsTablet: true`）。`restoreTextInput()`
的还原条件是「保存值非 nil」，iPad 既不保存也就不会还原，两条路径自然对齐。

粘贴图片、Genmoji 插入等既有能力不动。

> **给 reviewer 的提示**：`pnpm patch-commit` 重新生成 patch 时会重排 hunk，导致
> `dependency-patches/expo-paste-input@0.2.2.patch` 的文件 diff 看起来把粘贴链路（
> `emitImagesLoading`、`mediaProcessingQueue` 后台化、`emitImagesLoadFailed` 等）也一并改了
> ——那些在 `main` 上早已存在，本 PR 一行未动。以 patch **应用后**的源码为准：
>
> ```bash
> npm pack expo-paste-input@0.2.2
> mkdir a b && tar xzf expo-paste-input-0.2.2.tgz -C a --strip-components=1
> tar xzf expo-paste-input-0.2.2.tgz -C b --strip-components=1
> git show origin/main:dependency-patches/expo-paste-input@0.2.2.patch > main.patch
> (cd a && git apply -p1 ../main.patch)
> (cd b && git apply -p1 ../../dependency-patches/expo-paste-input@0.2.2.patch)
> diff -r a b
> ```
>
> 整包唯一差异是 `ios/ExpoPasteInputView.swift` 里 33 行新增，全部属于 `inputAssistantItem`
> 的保存／清空／还原及其注释。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户在 iOS 27 真机上反馈）
- 本 PR 包含：`dependency-patches/expo-paste-input@0.2.2.patch` 增补 iOS 侧
  `inputAssistantItem` 的清空与还原（限 iPhone）；`dependency-patches/README.md` 补充该 patch
  的用途说明；`pnpm-lock.yaml` 同步 patch hash。
- 明确不包含：不改 JS/TS 代码，不改其它输入框，不改 iPad 行为，不动
  `supportsAdaptiveImageGlyph` 与粘贴链路，不做全局（所有 `RCTUITextView` /
  `RCTUITextField`）的 swizzle 方案。
- 用户可见变化：iPhone 上会话输入框聚焦时，键盘上方不再出现那条只有禁用箭头和「完成」勾的
  条；iPad 无变化。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：本改动只移除 iOS 系统键盘辅助条，不新增或修改任何 Cindy
  自绘界面、布局、样式或文案；改动文件也不在 UI 代码路径下。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全绿（GATE_EXIT=0，两版改动各跑一轮）

pnpm --filter mobile run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm install --frozen-lockfile
结果：通过，确认 patch 与 lockfile hash 自洽、patch 可干净应用
```

### 手工验证

平台：iOS 26.5 iPhone 17 Pro 模拟器（Xcode 26.6），worktree
`dash/fix-mobile-composer-keyboard-assistant-bar`，Metro 归属本 worktree 的 8081，
应用内 `__DEV__` build label 显示 `dash/fix-mobile-composer-keyboard-assistant-bar@1aac39ede`。

- `pnpm mobile:sim:rebuild` 原生构建通过，安装并启动成功。
- 用 Maestro 打开 `cindycn://sessions/new`，点中 `newSession.firstMessageInput`、输入文字：
  输入框正常聚焦、键盘正常弹出、文字正常上屏，无崩溃，键盘上方无异常条。

### 未执行的验证

- **本地未能复现该问题，因此修复有效性未经验证**：本机 Xcode 26.6 只有 iOS 26.5 runtime，
  而报告来自 iOS 27 真机。在 iOS 26.5 iPhone 模拟器上，把本改动临时禁用后重新出原生包
  （before）与打上本改动（after）两种情况下，键盘上方都不出现这条 bar —— 即模拟器上该条
  本就不显示。
- 曾尝试用 iPad 模拟器作对照（iPad 一直显示 shortcuts bar），但该模拟器无登录态，进不到
  会话输入框，作罢。
- 因此需要在 **iOS 27 真机**上用带本改动的包复核：会话输入框聚焦时那条应消失，且粘贴图片、
  Genmoji 插入、语音输入仍正常。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 iOS iPhone，且仅限被 `TextInputWrapper` 接管的两个 composer 输入框。iPad 走
  原路径不变（keyboard shortcuts bar 保留）；Android 侧 patch 未改动（Android 无此系统条）。改动落在 `dependency-patches/`，属原生层，会改变
  mobile runtime fingerprint —— **必须冷更出包，存量装机拿不到该次热更**；合并后请以
  `pnpm mobile:release:check` 的判定为准（CI 的 fingerprint guard 也会给出 base 对比）。
- 回滚 / 降级方式：还原 `dependency-patches/expo-paste-input@0.2.2.patch` 与
  `pnpm-lock.yaml` 中的 patch hash，重新 `pnpm install` 并出包即可；改动是纯增量，不依赖
  其它变更。
- 另一处不确定性：「这条 bar 源自 `TextInputWrapper` 对输入框的改写」是从代码差异倒推的
  （只有这两个输入框被接管，也只有它们有这条），未在能复现的环境上确证。若 iOS 27 真机
  上验证后这条仍在，说明它不是 `inputAssistantItem`，需要换方向重查。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
