### PR TITLE
feat(plugins): 对话内通用 Setup Runtime(集成 #329 至最新 main)

### DIFF
--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -912,11 +912,14 @@ export class AgentIslandService {
     // only update the detail string without resetting the dismissal state.
     const existing = this.state.sessions.get(hydrated.sessionId);
     if (existing?.pendingInteractionIds.has(requestId)) {
+      const prevDetail = existing.pendingInteractionDetails.get(requestId);
       existing.pendingInteractionDetails.set(requestId, detail);
+      // Only update the displayed detail if this requestId is the one
+      // currently shown (its previous value matches session.detail).
       if (
-        existing.detail !== detail &&
         existing.phase === 'needs-interaction' &&
-        existing.interactionKind === 'plugin_setup'
+        existing.interactionKind === 'plugin_setup' &&
+        existing.detail === prevDetail
       ) {
         existing.detail = detail;
       }

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -912,17 +912,7 @@ export class AgentIslandService {
     // only update the detail string without resetting the dismissal state.
     const existing = this.state.sessions.get(hydrated.sessionId);
     if (existing?.pendingInteractionIds.has(requestId)) {
-      const prevDetail = existing.pendingInteractionDetails.get(requestId);
       existing.pendingInteractionDetails.set(requestId, detail);
-      // Only update the displayed detail if this requestId is the one
-      // currently shown (its previous value matches session.detail).
-      if (
-        existing.phase === 'needs-interaction' &&
-        existing.interactionKind === 'plugin_setup' &&
-        existing.detail === prevDetail
-      ) {
-        existing.detail = detail;
-      }
       this.publish();
       return;
     }

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -908,6 +908,17 @@ export class AgentIslandService {
   ): void {
     const hydrated = this.hydrateMeta({ sessionId });
     setAgentIslandStrings(this.state, buildAgentIslandStrings());
+    // If the requestId is already pending (revision update from the coordinator),
+    // only update the detail string without resetting the dismissal state.
+    const existing = this.state.sessions.get(hydrated.sessionId);
+    if (existing?.pendingInteractionIds.has(requestId)) {
+      existing.pendingInteractionDetails.set(requestId, detail);
+      if (existing.detail !== detail && existing.phase === 'needs-interaction') {
+        existing.detail = detail;
+      }
+      this.publish();
+      return;
+    }
     applyAgentIslandInteractionRequest(
       this.state,
       hydrated,

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -913,7 +913,11 @@ export class AgentIslandService {
     const existing = this.state.sessions.get(hydrated.sessionId);
     if (existing?.pendingInteractionIds.has(requestId)) {
       existing.pendingInteractionDetails.set(requestId, detail);
-      if (existing.detail !== detail && existing.phase === 'needs-interaction') {
+      if (
+        existing.detail !== detail &&
+        existing.phase === 'needs-interaction' &&
+        existing.interactionKind === 'plugin_setup'
+      ) {
         existing.detail = detail;
       }
       this.publish();

--- a/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
@@ -91,6 +91,7 @@ export interface GhostSetupCoordinatorDeps {
   }) => Promise<GhostSetupActionResult>;
   timeoutMs?: number;
   terminalGraceMs?: number;
+  timeoutMessage?: () => string;
   createRequestId?: () => string;
   logger?: {
     warn: (message: string, context?: Record<string, unknown>) => void;
@@ -450,7 +451,7 @@ export class GhostSetupCoordinator {
           {
             ok: false,
             errorCode: 'TIMEOUT',
-            message: '插件设置等待超时，本次调用未执行。',
+            message: this.deps.timeoutMessage?.() ?? 'Setup timed out',
           },
           'timeout',
         );

--- a/apps/desktop/src/main/cindy-brain/ghostSetupInlineExecutor.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupInlineExecutor.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../shared/ghost.js';
 import { GHOST_SECRET_VALUE_MAX_CHARS } from '../../shared/ghost.js';
 import type { GhostSetupActionResult } from './ghostSetupCoordinator.js';
+import { t } from '../i18n.js';
 
 export interface GhostSetupInlineExecutorDeps {
   getAssessment: (ghostId: string) => GhostSetupAssessment;
@@ -31,7 +32,7 @@ export function executeGhostSetupInlineSubmission(
 ): GhostSetupActionResult {
   const trimmed = args.value.trim();
   if (trimmed.length === 0 || trimmed.length > GHOST_SECRET_VALUE_MAX_CHARS) {
-    return { ok: false, errorCode: 'INLINE_INVALID', message: '凭证内容无效' };
+    return { ok: false, errorCode: 'INLINE_INVALID', message: t('newChat.pluginSetup.inlineSecretInvalid') };
   }
 
   const manifest = deps.getManifest(args.ghostId);
@@ -39,7 +40,7 @@ export function executeGhostSetupInlineSubmission(
     return {
       ok: false,
       errorCode: 'TARGET_UNAVAILABLE',
-      message: '目标插件已卸载或不可用',
+      message: t('newChat.pluginSetup.pluginUnavailable'),
     };
   }
 
@@ -64,7 +65,7 @@ export function executeGhostSetupInlineSubmission(
     return {
       ok: false,
       errorCode: 'ACTION_STALE',
-      message: '配置动作已失效，请重新尝试',
+      message: t('newChat.pluginSetup.inlineActionExpired'),
     };
   }
 
@@ -81,11 +82,11 @@ export function executeGhostSetupInlineSubmission(
     return {
       ok: false,
       errorCode: 'ACTION_STALE',
-      message: '凭证声明已变更，请重新尝试',
+      message: t('newChat.pluginSetup.inlineSecretDeclChanged'),
     };
   }
   if (!deps.storeSecret(args.ghostId, secretKey, trimmed)) {
-    return { ok: false, errorCode: 'SAVE_FAILED', message: '凭证保存失败' };
+    return { ok: false, errorCode: 'SAVE_FAILED', message: t('newChat.pluginSetup.inlineSecretStoreFailed') };
   }
   deps.emitChange(args.ghostId, secretKey);
   try {

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1699,7 +1699,7 @@ export async function executeGhostSetupAction(args: {
     return {
       ok: false,
       errorCode: 'TARGET_UNAVAILABLE',
-      message: '目标插件已卸载或不可用',
+      message: t('newChat.pluginSetup.pluginUninstalledDuringOauth'),
     };
   }
   if (args.action.kind === 'oauth_connect') {
@@ -1731,8 +1731,8 @@ export async function executeGhostSetupAction(args: {
           errorCode: connected.error === 'CANCELLED' ? 'AUTH_CANCELLED' : 'AUTH_FAILED',
           message:
             connected.error === 'CANCELLED'
-              ? '授权已取消'
-              : connected.detail ?? `授权失败：${connected.error}`,
+              ? t('newChat.pluginSetup.oauthCancelled')
+              : connected.detail ?? t('newChat.pluginSetup.oauthFailed').replace('{{detail}}', connected.error),
         };
   }
 

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1699,7 +1699,7 @@ export async function executeGhostSetupAction(args: {
     return {
       ok: false,
       errorCode: 'TARGET_UNAVAILABLE',
-      message: t('newChat.pluginSetup.pluginUninstalledDuringOauth'),
+      message: t('newChat.pluginSetup.pluginUnavailable'),
     };
   }
   if (args.action.kind === 'oauth_connect') {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -1209,7 +1209,7 @@ initGhostSetupCoordinator({
       return {
         ok: false,
         errorCode: 'TOOL_NOT_FOUND',
-        message: t('newChat.pluginSetup.targetToolNotFound'),
+        message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})`,
       };
     }
     return { ok: true };

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -156,6 +156,7 @@ import {
   updateWorkerStatus,
 } from '../localDb/orcaTeamStore.js';
 import { messages, orcaTeams, orcaWorkers, sessions } from '../localDb/schema.js';
+import { t } from '../i18n.js';
 import { createLogger } from '../logger.js';
 import { desktopClaudeAuthAdapter, desktopCodexAuthAdapter, readClaudeApiKey } from '../maker-host/auth-adapters.js';
 import { prepareSharedProjectSkillLinks } from '../maker-host/shared-global-skills.js';
@@ -1158,7 +1159,7 @@ const ghostSetupInteractionBridge = initGhostSetupInteractionBridge({
       getAgentIslandService()?.handlePluginSetupInteraction(
         value.sessionId,
         value.request.requestId,
-        activeStep?.title ?? `${value.request.ghost.name} 设置`,
+        activeStep?.title ?? t('newChat.pluginSetup.title').replace('{{name}}', value.request.ghost.name),
       );
       return;
     }
@@ -1187,28 +1188,28 @@ initGhostSetupCoordinator({
       return {
         ok: false,
         errorCode: 'GHOST_NOT_FOUND',
-        message: '目标插件已卸载或当前不可用',
+        message: t('newChat.pluginSetup.targetNotFound'),
       };
     }
     if (!ghost.enabled) {
       return {
         ok: false,
         errorCode: 'GHOST_ASLEEP',
-        message: '目标插件已被停用',
+        message: t('newChat.pluginSetup.targetDisabled'),
       };
     }
     if (isGhostDisabledForWorkdir(ghostId, workingDir)) {
       return {
         ok: false,
         errorCode: 'GHOST_DISABLED_IN_WORKDIR',
-        message: '用户已在当前工作目录停用该插件;不要重试。',
+        message: t('newChat.pluginSetup.targetDisabledInWorkdir'),
       };
     }
     if (tool && !(ghost.manifest.tools ?? []).some((candidate) => candidate.name === tool)) {
       return {
         ok: false,
         errorCode: 'TOOL_NOT_FOUND',
-        message: `目标插件不再提供工具 ${tool}`,
+        message: t('newChat.pluginSetup.targetToolNotFound'),
       };
     }
     return { ok: true };
@@ -1232,6 +1233,7 @@ initGhostSetupCoordinator({
     }),
   executeInlineAction: ({ sessionId, ghostId, action, value }) =>
     executeGhostSetupInlineAction({ sessionId, ghostId, action, value }),
+  timeoutMessage: () => t('newChat.pluginSetup.timeout'),
   logger: log,
 });
 

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ghostSetupInteractionSurface.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ghostSetupInteractionSurface.test.ts
@@ -17,7 +17,7 @@ describe('ghostSetupInteractionSessionId', () => {
     ).toBe('desktop-session');
   });
 
-  it.each(['feishu', 'discord', 'scheduler', 'slack-hook', 'telegram'])(
+  it.each(['feishu', 'discord', 'slack-hook', 'telegram'])(
     'treats %s turns as non-interactive even when they have a business session id',
     (source) => {
       expect(
@@ -30,6 +30,17 @@ describe('ghostSetupInteractionSessionId', () => {
       ).toBeNull();
     },
   );
+
+  it('treats scheduler turns as interactive (headless marker is turn-scoped)', () => {
+    expect(
+      ghostSetupInteractionSessionId({
+        agentKind: 'codex',
+        workingDir: '/repo',
+        sessionId: 'scheduler-session',
+        vendorOptions: { source: 'scheduler' },
+      }),
+    ).toBe('scheduler-session');
+  });
 
   it('treats a missing session context as non-interactive', () => {
     expect(ghostSetupInteractionSessionId(undefined)).toBeNull();

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -67,6 +67,7 @@ import * as ledger from '../cindy-media/ledger.js';
 import { chatAttachmentOrigin } from '../cindy-media/attachmentGrantGate.js';
 import { resolveGhostAttachmentUrl } from './ghostAttachmentResolve.js';
 import { ghostSetupInteractionSessionId } from './ghostSetupInteractionSurface.js';
+import { t } from '../i18n.js';
 import { createLogger } from '../logger.js';
 
 const log = createLogger('mcp/cindy');
@@ -694,7 +695,12 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
       ) {
         return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `目标插件不再提供工具 ${tool}` };
       }
-      const finalAssessment = getGhostSetupAssessment(ghostId);
+      let finalAssessment;
+      try {
+        finalAssessment = getGhostSetupAssessment(ghostId);
+      } catch {
+        return { ok: false, errorCode: 'INTERNAL', message: 'Failed to read plugin setup state after setup completed.' };
+      }
       if (finalAssessment.state !== 'ready') {
         return {
           ok: false,
@@ -706,6 +712,16 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
       // 批量预授权(grant_only):只过户不派发。它与普通调用共用上面的
       // Host-authoritative setup gate，确保任何授权副作用之前插件已经 ready。
       if (grantOnly) {
+        // Setup gate: confirm target is still available before creating grants.
+        const grantTarget = getGhostManager()
+          .list()
+          .find((g) => g.manifest.id === ghostId);
+        if (!grantTarget || !isGhostAvailableForActiveSession(ghostId)) {
+          return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: '目标插件已卸载或当前不可用' };
+        }
+        if (!grantTarget.enabled) {
+          return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
+        }
         const grant = await grantAttachmentUrls({
           ghostId,
           urls: attachments!,
@@ -715,6 +731,16 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         });
         if (!grant.ok) {
           return { ok: false, errorCode: 'ATTACHMENT_INVALID', message: grant.message };
+        }
+        // Post-grant revalidation: the grant process may have taken time.
+        const postGrant = getGhostManager()
+          .list()
+          .find((g) => g.manifest.id === ghostId);
+        if (!postGrant || !isGhostAvailableForActiveSession(ghostId)) {
+          return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: '目标插件已卸载或当前不可用' };
+        }
+        if (!postGrant.enabled) {
+          return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
         }
         log.info('ghost grant-only: batch pre-granted', { ghostId, count: grant.hashes.length });
         return {
@@ -799,10 +825,30 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         const { session_context: _dropped, ...rest } = mergedArgs;
         mergedArgs = rest;
       }
-      const targetManifest = getGhostManager()
+      // Pre-dispatch revalidation: attachment grants and dir tickets may have
+      // taken time; confirm the target is still available before committing the
+      // callId and dispatching to the sandbox.
+      const preDispatch = getGhostManager()
         .list()
-        .find((g) => g.manifest.id === ghostId)?.manifest;
-      if (targetManifest?.slots?.includes('session-context')) {
+        .find((g) => g.manifest.id === ghostId);
+      if (!preDispatch || !isGhostAvailableForActiveSession(ghostId)) {
+        return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: '目标插件已卸载或当前不可用' };
+      }
+      if (!preDispatch.enabled) {
+        return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
+      }
+      if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
+        return {
+          ok: false,
+          errorCode: 'GHOST_DISABLED_IN_WORKDIR',
+          message: t('newChat.pluginSetup.targetDisabledInWorkdir'),
+        };
+      }
+      if (!(preDispatch.manifest.tools ?? []).some((c) => c.name === tool)) {
+        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: t('newChat.pluginSetup.targetToolNotFound') };
+      }
+      // Session-context slot: use the revalidated manifest to decide injection
+      if (preDispatch.manifest.slots?.includes('session-context')) {
         mergedArgs = {
           ...mergedArgs,
           session_context: await buildGhostSessionContext(sessionIdForConfirm, sessionWorkdir),

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -896,9 +896,24 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
           mergedArgs = { ...mergedArgs, session_context: ctx };
         }
       }
-      // Final availability check after the session-context await
-      if (!getGhostManager().list().some((g) => g.manifest.id === ghostId && g.enabled)) {
+      // Full revalidation after session-context await (DB query may take time)
+      const postCtx = getGhostManager().list().find((g) => g.manifest.id === ghostId);
+      if (!postCtx || !postCtx.enabled) {
         return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: t('newChat.pluginSetup.targetNotFound') };
+      }
+      if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
+        return { ok: false, errorCode: 'GHOST_DISABLED_IN_WORKDIR', message: t('newChat.pluginSetup.targetDisabledInWorkdir') };
+      }
+      if (!(postCtx.manifest.tools ?? []).some((c) => c.name === tool)) {
+        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})` };
+      }
+      try {
+        const postCtxAssessment = getGhostSetupAssessment(ghostId);
+        if (postCtxAssessment.state !== 'ready') {
+          return { ok: false, errorCode: 'SETUP_REQUIRED', message: t('newChat.pluginSetup.setupChangedDuringResume'), setup: postCtxAssessment };
+        }
+      } catch {
+        return { ok: false, errorCode: 'INTERNAL', message: t('newChat.pluginSetup.assessmentReadFailed') };
       }
       // ── 卡槽③:callId 在这里预铸并登记给卡片服务 ────────────────────
       // 时序契约:register(供片窗开)→ dispatch(意识拿到同一 callId,执行

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -896,6 +896,10 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
           mergedArgs = { ...mergedArgs, session_context: ctx };
         }
       }
+      // Final availability check after the session-context await
+      if (!getGhostManager().list().some((g) => g.manifest.id === ghostId && g.enabled)) {
+        return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: t('newChat.pluginSetup.targetNotFound') };
+      }
       // ── 卡槽③:callId 在这里预铸并登记给卡片服务 ────────────────────
       // 时序契约:register(供片窗开)→ dispatch(意识拿到同一 callId,执行
       // 中可 card-update)→ finalize(问"这单供过卡吗",开晚到宽限窗)→

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -699,7 +699,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
       try {
         finalAssessment = getGhostSetupAssessment(ghostId);
       } catch {
-        return { ok: false, errorCode: 'INTERNAL', message: 'Failed to read plugin setup state after setup completed.' };
+        return { ok: false, errorCode: 'INTERNAL', message: t('newChat.pluginSetup.assessmentReadFailed') };
       }
       if (finalAssessment.state !== 'ready') {
         return {
@@ -712,7 +712,8 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
       // 批量预授权(grant_only):只过户不派发。它与普通调用共用上面的
       // Host-authoritative setup gate，确保任何授权副作用之前插件已经 ready。
       if (grantOnly) {
-        // Setup gate: confirm target is still available before creating grants.
+        // Full pre-grant gate: confirm target, workdir, and setup readiness
+        // BEFORE grantAttachmentUrls creates durable ledger entries.
         const grantTarget = getGhostManager()
           .list()
           .find((g) => g.manifest.id === ghostId);
@@ -721,6 +722,17 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         }
         if (!grantTarget.enabled) {
           return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
+        }
+        if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
+          return { ok: false, errorCode: 'GHOST_DISABLED_IN_WORKDIR', message: t('newChat.pluginSetup.targetDisabledInWorkdir') };
+        }
+        try {
+          const grantOnlyAssessment = getGhostSetupAssessment(ghostId);
+          if (grantOnlyAssessment.state !== 'ready') {
+            return { ok: false, errorCode: 'SETUP_REQUIRED', message: '插件尚未完成配置。', setup: grantOnlyAssessment };
+          }
+        } catch {
+          return { ok: false, errorCode: 'INTERNAL', message: t('newChat.pluginSetup.assessmentReadFailed') };
         }
         const grant = await grantAttachmentUrls({
           ghostId,
@@ -845,7 +857,20 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         };
       }
       if (!(preDispatch.manifest.tools ?? []).some((c) => c.name === tool)) {
-        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: t('newChat.pluginSetup.targetToolNotFound') };
+        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})` };
+      }
+      try {
+        const preDispatchAssessment = getGhostSetupAssessment(ghostId);
+        if (preDispatchAssessment.state !== 'ready') {
+          return {
+            ok: false,
+            errorCode: 'SETUP_REQUIRED',
+            message: '插件配置在调用恢复前发生变化，请完成设置后重试。',
+            setup: preDispatchAssessment,
+          };
+        }
+      } catch {
+        return { ok: false, errorCode: 'INTERNAL', message: t('newChat.pluginSetup.assessmentReadFailed') };
       }
       // Session-context slot: use the revalidated manifest to decide injection
       if (preDispatch.manifest.slots?.includes('session-context')) {

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -617,8 +617,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         return {
           ok: false,
           errorCode: 'GHOST_DISABLED_IN_WORKDIR',
-          message:
-            '用户已在当前工作目录停用该插件;不要重试,改用其它可用方式完成任务,必要时如实转告用户。',
+          message: t('newChat.pluginSetup.targetDisabledInWorkdir'),
         };
       }
       // Runtime setup gate: resolve the target before creating any durable
@@ -686,7 +685,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         return {
           ok: false,
           errorCode: 'GHOST_DISABLED_IN_WORKDIR',
-          message: '用户已在当前工作目录停用该插件;不要重试。',
+          message: t('newChat.pluginSetup.targetDisabledInWorkdir'),
         };
       }
       if (
@@ -898,8 +897,11 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
       }
       // Full revalidation after session-context await (DB query may take time)
       const postCtx = getGhostManager().list().find((g) => g.manifest.id === ghostId);
-      if (!postCtx || !postCtx.enabled) {
+      if (!postCtx || !isGhostAvailableForActiveSession(ghostId)) {
         return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: t('newChat.pluginSetup.targetNotFound') };
+      }
+      if (!postCtx.enabled) {
+        return { ok: false, errorCode: 'GHOST_ASLEEP', message: t('newChat.pluginSetup.targetDisabled') };
       }
       if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
         return { ok: false, errorCode: 'GHOST_DISABLED_IN_WORKDIR', message: t('newChat.pluginSetup.targetDisabledInWorkdir') };

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -705,7 +705,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         return {
           ok: false,
           errorCode: 'SETUP_REQUIRED',
-          message: '插件配置在调用恢复前发生变化，请完成设置后重试。',
+          message: t('newChat.pluginSetup.setupChangedDuringResume'),
           setup: finalAssessment,
         };
       }
@@ -729,7 +729,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         try {
           const grantOnlyAssessment = getGhostSetupAssessment(ghostId);
           if (grantOnlyAssessment.state !== 'ready') {
-            return { ok: false, errorCode: 'SETUP_REQUIRED', message: '插件尚未完成配置。', setup: grantOnlyAssessment };
+            return { ok: false, errorCode: 'SETUP_REQUIRED', message: t('newChat.pluginSetup.setupIncomplete'), setup: grantOnlyAssessment };
           }
         } catch {
           return { ok: false, errorCode: 'INTERNAL', message: t('newChat.pluginSetup.assessmentReadFailed') };
@@ -865,7 +865,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
           return {
             ok: false,
             errorCode: 'SETUP_REQUIRED',
-            message: '插件配置在调用恢复前发生变化，请完成设置后重试。',
+            message: t('newChat.pluginSetup.setupChangedDuringResume'),
             setup: preDispatchAssessment,
           };
         }

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -677,10 +677,10 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         .list()
         .find((g) => g.manifest.id === ghostId);
       if (!refreshed || !isGhostAvailableForActiveSession(ghostId)) {
-        return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: '目标插件已卸载或当前不可用' };
+        return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: t('newChat.pluginSetup.targetNotFound') };
       }
       if (!refreshed.enabled) {
-        return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
+        return { ok: false, errorCode: 'GHOST_ASLEEP', message: t('newChat.pluginSetup.targetDisabled') };
       }
       if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
         return {
@@ -718,10 +718,10 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
           .list()
           .find((g) => g.manifest.id === ghostId);
         if (!grantTarget || !isGhostAvailableForActiveSession(ghostId)) {
-          return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: '目标插件已卸载或当前不可用' };
+          return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: t('newChat.pluginSetup.targetNotFound') };
         }
         if (!grantTarget.enabled) {
-          return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
+          return { ok: false, errorCode: 'GHOST_ASLEEP', message: t('newChat.pluginSetup.targetDisabled') };
         }
         if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
           return { ok: false, errorCode: 'GHOST_DISABLED_IN_WORKDIR', message: t('newChat.pluginSetup.targetDisabledInWorkdir') };
@@ -749,10 +749,10 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
           .list()
           .find((g) => g.manifest.id === ghostId);
         if (!postGrant || !isGhostAvailableForActiveSession(ghostId)) {
-          return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: '目标插件已卸载或当前不可用' };
+          return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: t('newChat.pluginSetup.targetNotFound') };
         }
         if (!postGrant.enabled) {
-          return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
+          return { ok: false, errorCode: 'GHOST_ASLEEP', message: t('newChat.pluginSetup.targetDisabled') };
         }
         log.info('ghost grant-only: batch pre-granted', { ghostId, count: grant.hashes.length });
         return {
@@ -844,10 +844,10 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         .list()
         .find((g) => g.manifest.id === ghostId);
       if (!preDispatch || !isGhostAvailableForActiveSession(ghostId)) {
-        return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: '目标插件已卸载或当前不可用' };
+        return { ok: false, errorCode: 'GHOST_NOT_FOUND', message: t('newChat.pluginSetup.targetNotFound') };
       }
       if (!preDispatch.enabled) {
-        return { ok: false, errorCode: 'GHOST_ASLEEP', message: '目标插件已被停用' };
+        return { ok: false, errorCode: 'GHOST_ASLEEP', message: t('newChat.pluginSetup.targetDisabled') };
       }
       if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
         return {
@@ -872,12 +872,17 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
       } catch {
         return { ok: false, errorCode: 'INTERNAL', message: t('newChat.pluginSetup.assessmentReadFailed') };
       }
-      // Session-context slot: use the revalidated manifest to decide injection
+      // Session-context slot: use the revalidated manifest to decide injection.
+      // Re-read manifest after the async buildGhostSessionContext to guard against
+      // a same-ID plugin replacement removing the slot during the await.
       if (preDispatch.manifest.slots?.includes('session-context')) {
-        mergedArgs = {
-          ...mergedArgs,
-          session_context: await buildGhostSessionContext(sessionIdForConfirm, sessionWorkdir),
-        };
+        const ctx = await buildGhostSessionContext(sessionIdForConfirm, sessionWorkdir);
+        const postCtxManifest = getGhostManager()
+          .list()
+          .find((g) => g.manifest.id === ghostId)?.manifest;
+        if (postCtxManifest?.slots?.includes('session-context')) {
+          mergedArgs = { ...mergedArgs, session_context: ctx };
+        }
       }
       // ── 卡槽③:callId 在这里预铸并登记给卡片服务 ────────────────────
       // 时序契约:register(供片窗开)→ dispatch(意识拿到同一 callId,执行

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -693,7 +693,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         !grantOnly &&
         !(refreshed.manifest.tools ?? []).some((candidate) => candidate.name === tool)
       ) {
-        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `目标插件不再提供工具 ${tool}` };
+        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})` };
       }
       let finalAssessment;
       try {
@@ -744,7 +744,8 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         if (!grant.ok) {
           return { ok: false, errorCode: 'ATTACHMENT_INVALID', message: grant.message };
         }
-        // Post-grant revalidation: the grant process may have taken time.
+        // Post-grant revalidation: the grant process includes an async user
+        // confirmation step; re-check everything before returning success.
         const postGrant = getGhostManager()
           .list()
           .find((g) => g.manifest.id === ghostId);
@@ -753,6 +754,17 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         }
         if (!postGrant.enabled) {
           return { ok: false, errorCode: 'GHOST_ASLEEP', message: t('newChat.pluginSetup.targetDisabled') };
+        }
+        if (isGhostDisabledForWorkdir(ghostId, sessionWorkdir)) {
+          return { ok: false, errorCode: 'GHOST_DISABLED_IN_WORKDIR', message: t('newChat.pluginSetup.targetDisabledInWorkdir') };
+        }
+        try {
+          const postGrantAssessment = getGhostSetupAssessment(ghostId);
+          if (postGrantAssessment.state !== 'ready') {
+            return { ok: false, errorCode: 'SETUP_REQUIRED', message: t('newChat.pluginSetup.setupChangedDuringResume'), setup: postGrantAssessment };
+          }
+        } catch {
+          return { ok: false, errorCode: 'INTERNAL', message: t('newChat.pluginSetup.assessmentReadFailed') };
         }
         log.info('ghost grant-only: batch pre-granted', { ghostId, count: grant.hashes.length });
         return {

--- a/apps/desktop/src/main/mcp-integrations/ghostSetupInteractionSurface.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghostSetupInteractionSurface.ts
@@ -1,9 +1,12 @@
 import type { LiziMcpSessionContext } from '@cindy/mcps';
 
+// Scheduler is intentionally excluded: it uses the headless turn marker
+// (beginHeadlessGhostSetupTurn) acquired in onAccepted instead of a static
+// source-based blocklist, so it can participate in interactive setup when
+// triggered from a Desktop session.
 const NON_DESKTOP_SETUP_SOURCES = new Set([
   'feishu',
   'discord',
-  'scheduler',
   'slack-hook',
   'telegram',
 ]);

--- a/apps/desktop/src/renderer/__tests__/PluginSetupPrompt.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/PluginSetupPrompt.test.tsx
@@ -157,7 +157,7 @@ describe('PluginSetupPrompt', () => {
     expect(
       parsePendingPluginSetup({
         ...pending,
-        steps: Array.from({ length: 73 }, (_, index) => ({
+        steps: Array.from({ length: 89 }, (_, index) => ({
           ...pending.steps[0],
           id: `oversized-step-${index}`,
         })),

--- a/apps/desktop/src/renderer/components/new-chat/PluginSetupPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PluginSetupPrompt.tsx
@@ -37,7 +37,7 @@ function isTerminalPhase(phase: GhostSetupStepPhase): boolean {
 }
 
 function normalizedCopy(value: string | undefined): string {
-  return (value ?? '').trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+  return (value ?? '').trim().replace(/\s+/g, ' ').toLowerCase();
 }
 
 export function PluginSetupPrompt({ pending, ...props }: PluginSetupPromptProps) {
@@ -89,7 +89,7 @@ function PluginSetupPromptStateful({
   const cancelledTerminal =
     pending.steps.some((step) => step.phase === 'cancelled') &&
     pending.steps.every((step) => isTerminalPhase(step.phase));
-  const terminal = allSatisfied || cancelledTerminal;
+  const terminal = pending.terminal === true || allSatisfied || cancelledTerminal;
   const busy = !!commandInFlight || (!!currentStep && RUNNING_PHASES.has(currentStep.phase));
   const title = t('newChat.pluginSetup.title', { name: pending.ghost.name });
   const inlineFormAction = currentStep?.action?.kind === 'inline_form' ? currentStep.action : null;

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3671,6 +3671,7 @@
     },
     "pluginSetup": {
       "title": "{{name}} Settings",
+      "assessmentReadFailed": "Couldn't read the plugin setup status.",
       "chooseOne": "Choose one setup method",
       "restoreAria": "Restore {{name}} settings",
       "minimizeAria": "Minimize {{name}} settings",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3720,7 +3720,20 @@
         "satisfied": "Completed",
         "failed": "Failed",
         "cancelled": "Cancelled"
-      }
+      },
+      "timeout": "Setup timed out",
+      "oauthCancelled": "Authorization was cancelled",
+      "oauthFailed": "Authorization failed: {{detail}}",
+      "pluginUninstalledDuringOauth": "The target plugin was uninstalled or is unavailable",
+      "inlineSecretInvalid": "Credential value is invalid",
+      "pluginUnavailable": "The target plugin was uninstalled or is unavailable",
+      "inlineActionExpired": "This setup action has expired; please try again",
+      "inlineSecretDeclChanged": "Credential declaration has changed; please try again",
+      "inlineSecretStoreFailed": "Failed to save credential",
+      "targetNotFound": "The target plugin was uninstalled or is currently unavailable",
+      "targetDisabled": "The target plugin has been disabled",
+      "targetDisabledInWorkdir": "The user has disabled this plugin in the current working directory; do not retry.",
+      "targetToolNotFound": "The target plugin no longer provides this tool"
     },
     "createAgent": {
       "quickStart": "Quick start",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3672,6 +3672,8 @@
     "pluginSetup": {
       "title": "{{name}} Settings",
       "assessmentReadFailed": "Couldn't read the plugin setup status.",
+      "setupIncomplete": "Plugin setup is not complete.",
+      "setupChangedDuringResume": "Plugin setup changed while the call was resuming. Please complete setup and try again.",
       "chooseOne": "Choose one setup method",
       "restoreAria": "Restore {{name}} settings",
       "minimizeAria": "Minimize {{name}} settings",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3671,6 +3671,8 @@
     "pluginSetup": {
       "title": "{{name}} の設定",
       "assessmentReadFailed": "プラグインの設定状態を読み取れませんでした。",
+      "setupIncomplete": "プラグインの設定が完了していません。",
+      "setupChangedDuringResume": "呼び出し再開中にプラグインの設定が変更されました。設定を完了してから再試行してください。",
       "chooseOne": "設定方法を1つ選択してください",
       "restoreAria": "{{name}} の設定を展開",
       "minimizeAria": "{{name}} の設定を折りたたむ",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3670,6 +3670,7 @@
     },
     "pluginSetup": {
       "title": "{{name}} の設定",
+      "assessmentReadFailed": "プラグインの設定状態を読み取れませんでした。",
       "chooseOne": "設定方法を1つ選択してください",
       "restoreAria": "{{name}} の設定を展開",
       "minimizeAria": "{{name}} の設定を折りたたむ",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3719,7 +3719,20 @@
         "satisfied": "完了",
         "failed": "失敗",
         "cancelled": "キャンセル済み"
-      }
+      },
+      "timeout": "設定がタイムアウトしました",
+      "oauthCancelled": "認証がキャンセルされました",
+      "oauthFailed": "認証に失敗しました：{{detail}}",
+      "pluginUninstalledDuringOauth": "対象プラグインがアンインストールされたか利用不可です",
+      "inlineSecretInvalid": "認証情報の値が無効です",
+      "pluginUnavailable": "対象プラグインがアンインストールされたか利用不可です",
+      "inlineActionExpired": "設定アクションの有効期限が切れました。もう一度お試しください",
+      "inlineSecretDeclChanged": "認証情報の宣言が変更されました。もう一度お試しください",
+      "inlineSecretStoreFailed": "認証情報の保存に失敗しました",
+      "targetNotFound": "対象プラグインがアンインストールされたか現在利用不可です",
+      "targetDisabled": "対象プラグインが無効化されています",
+      "targetDisabledInWorkdir": "ユーザーが現在のワーキングディレクトリでこのプラグインを無効にしています。リトライしないでください。",
+      "targetToolNotFound": "対象プラグインはこのツールを提供していません"
     },
     "createAgent": {
       "quickStart": "クイックスタート",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3719,7 +3719,20 @@
         "satisfied": "완료",
         "failed": "실패",
         "cancelled": "취소됨"
-      }
+      },
+      "timeout": "설정 시간이 초과되었습니다",
+      "oauthCancelled": "인증이 취소되었습니다",
+      "oauthFailed": "인증 실패: {{detail}}",
+      "pluginUninstalledDuringOauth": "대상 플러그인이 제거되었거나 사용할 수 없습니다",
+      "inlineSecretInvalid": "자격 증명 값이 유효하지 않습니다",
+      "pluginUnavailable": "대상 플러그인이 제거되었거나 사용할 수 없습니다",
+      "inlineActionExpired": "설정 작업이 만료되었습니다. 다시 시도해 주세요",
+      "inlineSecretDeclChanged": "자격 증명 선언이 변경되었습니다. 다시 시도해 주세요",
+      "inlineSecretStoreFailed": "자격 증명 저장에 실패했습니다",
+      "targetNotFound": "대상 플러그인이 제거되었거나 현재 사용할 수 없습니다",
+      "targetDisabled": "대상 플러그인이 비활성화되었습니다",
+      "targetDisabledInWorkdir": "사용자가 현재 작업 디렉토리에서 이 플러그인을 비활성화했습니다. 재시도하지 마세요.",
+      "targetToolNotFound": "대상 플러그인이 더 이상 이 도구를 제공하지 않습니다"
     },
     "createAgent": {
       "quickStart": "빠른 시작",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3670,6 +3670,7 @@
     },
     "pluginSetup": {
       "title": "{{name}} 설정",
+      "assessmentReadFailed": "플러그인 설정 상태를 읽을 수 없습니다.",
       "chooseOne": "설정 방법을 하나 선택하세요",
       "restoreAria": "{{name}} 설정 펼치기",
       "minimizeAria": "{{name}} 설정 접기",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3671,6 +3671,8 @@
     "pluginSetup": {
       "title": "{{name}} 설정",
       "assessmentReadFailed": "플러그인 설정 상태를 읽을 수 없습니다.",
+      "setupIncomplete": "플러그인 설정이 완료되지 않았습니다.",
+      "setupChangedDuringResume": "호출 재개 중 플러그인 설정이 변경되었습니다. 설정을 완료한 후 다시 시도하세요.",
       "chooseOne": "설정 방법을 하나 선택하세요",
       "restoreAria": "{{name}} 설정 펼치기",
       "minimizeAria": "{{name}} 설정 접기",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3670,6 +3670,7 @@
     },
     "pluginSetup": {
       "title": "{{name}} 设置",
+      "assessmentReadFailed": "无法读取插件配置状态。",
       "chooseOne": "选择一种配置方式",
       "restoreAria": "展开 {{name}} 设置",
       "minimizeAria": "收起 {{name}} 设置",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3671,6 +3671,8 @@
     "pluginSetup": {
       "title": "{{name}} 设置",
       "assessmentReadFailed": "无法读取插件配置状态。",
+      "setupIncomplete": "插件尚未完成配置。",
+      "setupChangedDuringResume": "插件配置在调用恢复前发生变化，请完成设置后重试。",
       "chooseOne": "选择一种配置方式",
       "restoreAria": "展开 {{name}} 设置",
       "minimizeAria": "收起 {{name}} 设置",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3719,7 +3719,20 @@
         "satisfied": "已完成",
         "failed": "失败",
         "cancelled": "已取消"
-      }
+      },
+      "timeout": "等待超时",
+      "oauthCancelled": "授权已取消",
+      "oauthFailed": "授权失败：{{detail}}",
+      "pluginUninstalledDuringOauth": "目标插件已卸载或不可用",
+      "inlineSecretInvalid": "凭证内容无效",
+      "pluginUnavailable": "目标插件已卸载或不可用",
+      "inlineActionExpired": "配置动作已失效，请重新尝试",
+      "inlineSecretDeclChanged": "凭证声明已变更，请重新尝试",
+      "inlineSecretStoreFailed": "凭证保存失败",
+      "targetNotFound": "目标插件已卸载或当前不可用",
+      "targetDisabled": "目标插件已被停用",
+      "targetDisabledInWorkdir": "用户已在当前工作目录停用该插件;不要重试。",
+      "targetToolNotFound": "目标插件不再提供该工具"
     },
     "createAgent": {
       "quickStart": "快速开始",

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -865,11 +865,13 @@ export const GHOST_NETWORK_FORBIDDEN_INJECT_HEADERS: readonly string[] = [
 
 /** setup.requires 需求组条数上限。 */
 export const GHOST_SETUP_MAX_GROUPS = 8;
+/** Host-owned requirement groups (e.g. model-provider capability). */
+export const GHOST_SETUP_MAX_HOST_GROUPS = 2;
 /** 每个需求组内 anyOf 条目上限。 */
 export const GHOST_SETUP_MAX_ITEMS_PER_GROUP = 8;
 /** 一张 setup 卡最多需要覆盖 manifest 合法声明的全部可操作条目。 */
 export const GHOST_SETUP_MAX_STEPS =
-  GHOST_SETUP_MAX_GROUPS * GHOST_SETUP_MAX_ITEMS_PER_GROUP;
+  (GHOST_SETUP_MAX_GROUPS + GHOST_SETUP_MAX_HOST_GROUPS) * GHOST_SETUP_MAX_ITEMS_PER_GROUP;
 /**
  * Host-owned setup providers may append requirements that do not exist in the
  * plugin manifest (for example, a shared client capability). Reserve a bounded

--- a/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
+++ b/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
@@ -846,7 +846,7 @@ describe("ghost_call · setup_plan MCP 边界", () => {
     expect(
       ghostSetupPlanInputSchema.safeParse({
         ...validPlan,
-        steps: Array.from({ length: 72 }, (_, i) => ({
+        steps: Array.from({ length: 80 }, (_, i) => ({
           ...validPlan.steps[0],
           id: `step-${i}`,
         })),
@@ -855,7 +855,7 @@ describe("ghost_call · setup_plan MCP 边界", () => {
     expect(
       ghostSetupPlanInputSchema.safeParse({
         ...validPlan,
-        steps: Array.from({ length: 73 }, (_, i) => ({
+        steps: Array.from({ length: 81 }, (_, i) => ({
           ...validPlan.steps[0],
           id: `step-${i}`,
         })),

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -84,10 +84,10 @@ const ROSTER_MAX_ITEMS = 16;
 
 /**
  * Agent setup plan 的 MCP 边界上限。须覆盖 Desktop manifest 的
- * max groups × max any-of items (8 × 8) 和 Host-owned reserve (8)；
+ * (max groups + host groups) × max any-of items ((8+2) × 8 = 80)；
  * 本包刻意不依赖 Desktop。
  */
-const SETUP_PLAN_MAX_STEPS = 72;
+const SETUP_PLAN_MAX_STEPS = 80;
 const SETUP_PLAN_MAX_REFS_PER_STEP = 8;
 const SETUP_PLAN_MAX_ID_LENGTH = 128;
 const SETUP_PLAN_MAX_INTRO_LENGTH = 500;


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 #329「对话内通用 Setup Runtime」集成到当前 `main`（分支落后 65 个提交且有冲突，无法直接合并）。本 PR = #329 的功能内容 merge 最新 `main` + 冲突解决 + review 问题修复，作为可正常过 CI 的落地分支。

原功能：为 `ghost_call` 增加通用 Setup 运行时门。插件调用前由 Host 按 manifest 和真实存储判定 OAuth / Secret / Connection / plugin_config / client_config 是否就绪；缺失时在输入区复用 Ask 卡壳展示 Setup 卡收单，保存后 Host 权威重判并恢复原挂起调用，不重新唤醒 LLM。Secret 仅经 trusted Renderer → Main 专用 IPC 短暂传递。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Closes #136；集成并取代 #329
- 本 PR 包含：
  - #329 全部 Setup Runtime 内容（assessment / coordinator / change bus / 原调用恢复、Ask-shell Setup 卡、OAuth / inline Secret / 设置导航、专用 inline Secret IPC、四语言文案、作者与技术设计文档）
  - 与最新 `main`（65 提交）的冲突解决
  - review 修复（见下）
- 明确不包含：
  - **不采用 #329 的 `cindy-protocol` 子模块指针** `0f511cf0`（未合入协议仓 main、未打 tag、内容为无关的 content-moderation-protocol）；保留 `main` 现有指针 `f9eff5a`
  - **不恢复 #329 对 Node 安装二次确认（`nodeInstallAuthorization`）的改动**——`main` 已在 #333 整体移除该特性，honor 其删除
  - Mobile 原生 Setup 卡与跨设备填 Secret；外部 OAuth 服务端联调
- 用户可见变化：插件配置不完整时不再直接失败/跳出对话，可在输入区完成配置
- 是否存在 breaking change：无。`ghost_call.setup_plan` 为可选字段，缺失时 Host 生成安全默认 plan

### UI 变化

复用 Ask 卡壳，不新增独立视觉；截图见原始 PR #329。

- 引用的设计规范：`docs/design-rules/DESIGN.md` —— 颜色一律用注册的 `var(--…)` token（`themes/colors.ts` 的 `registerColor({light,dark})`），满足双模式交付门槛（Light/Dark 均实现且经自动化结构/交互契约覆盖）；卡片容器、尺寸、位置沿用 Ask 卡壳；正文最大高度滚动、Header/Action 常驻。本 PR 额外给共享滚动区补 `overflow-x-hidden`，消除 Ask 卡横向滑动过渡时可能闪现的横向滚动条（DESIGN 交互规范：杜绝跳变与空白帧）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过（merge + 修复后）

packages/cindy-tools：tsc --noEmit -p tsconfig.json
结果：通过（该包无 typecheck script，直接跑 build 的 tsc）

node scripts/check-i18n.mjs
结果：通过，zh-CN / en / ja / ko 共 5444 个 key 全部一致

pnpm test:unit（仓库根全部单元测试）
结果：通过，25 个 workspace 全绿、0 失败（约 17,573 个测试）。首轮曾因本机未装 bundled ripgrep（安装时 XDT_SKIP_AGENT_BIN_INSTALL=1）导致 maker-host 套件加载失败，装回 pinned ripgrep 后复跑全绿
```

### 手工验证

- 未在本 worktree 运行 Electron 真机（worktree 改动不随宿主 dev 实例热更/重启生效）；真机验收沿用 #329 记录，运行时验证交由 CI 与后续。

### 未执行的验证

- Electron 真机运行时验证（见上）；外部 OAuth 回流与真实 Provider 保存需连真实服务联调；Mobile 原生 UI 本 PR 明确 deferred。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异

### 影响与回滚

- 影响范围：Desktop `ghost_list` / `ghost_call`、插件配置写入通知、聊天 interaction；Mobile / IM / headless fail-closed 降级
- 协议兼容：**未升级 `cindy-protocol` 指针**（保留 main 的 `f9eff5a`），避免 #329 带入的无关/未合入协议提交造成漂移；`setup_plan` 仅扩展一次 MCP 工具 schema
- 权限/安全：Secret 不进入 Agent / Ghost / snapshot / session store / 日志 / 远程通道；专用 inline IPC 校验 trusted frame + request + action + revision。本 PR 额外补齐 `executeGhostSetupAction` 的 `tokenBroker` 第一方门控（与 `/oauth` 连接端点一致的运行时兜底）
- 回滚 / 降级方式：回滚本 PR 即恢复调用时按现有插件路径处理；旧 Agent 不传 `setup_plan` 仍兼容

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

---

集成来源：PR #329 (`nanaco666:feat/issue-136-plugin-setup-runtime`, head `56363ee`) merged 到 `main` (`03fce4a`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
