### PR TITLE
fix(desktop): strip unsupported Seed reasoning summary

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -662,7 +662,7 @@ describe('codex proxy host', () => {
     clearSessionProvider('session-openai-custom-tool');
   });
 
-  it('normalizes the Codex tool set to ByteDance Seed Responses capabilities', async () => {
+  it('normalizes requests to ByteDance Seed Responses capabilities', async () => {
     const host = await freshCodexProxyHost();
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
     mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
@@ -676,6 +676,7 @@ describe('codex proxy host', () => {
     const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
     let current: unknown = {
       model: 'bytedance-seed/seed-2.1-pro',
+      reasoning: { effort: 'high', summary: 'auto' },
       tools: [
         { type: 'function', name: 'exec_command' },
         { type: 'function', name: 'write_stdin' },
@@ -703,6 +704,7 @@ describe('codex proxy host', () => {
 
     expect(current).toEqual({
       model: 'bytedance-seed/seed-2.1-pro',
+      reasoning: { effort: 'high' },
       tools: [
         { type: 'function', name: 'exec_command' },
         { type: 'function', name: 'write_stdin' },
@@ -721,6 +723,17 @@ describe('codex proxy host', () => {
         { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
       ],
     });
+
+    let summaryOnlyReasoning: unknown = {
+      model: 'bytedance-seed/seed-2.1-pro',
+      reasoning: { summary: 'auto' },
+    };
+    for (const transform of transforms) {
+      const next = transform(summaryOnlyReasoning, ctx);
+      if (next !== null && next !== undefined) summaryOnlyReasoning = next;
+    }
+    expect(summaryOnlyReasoning).toEqual({ model: 'bytedance-seed/seed-2.1-pro' });
+
     clearSessionProvider('session-seed');
   });
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -661,6 +661,21 @@ function normalizeByteDanceSeedInput(body: Record<string, unknown>): Record<stri
   return changed ? { ...body, input } : null;
 }
 
+/** Seed accepts the reasoning effort, but rejects Responses' summary selector. */
+function sanitizeByteDanceSeedReasoning(body: Record<string, unknown>): Record<string, unknown> | null {
+  if (!isByteDanceSeedModel(body.model) || !isPlainObject(body.reasoning) || !('summary' in body.reasoning)) {
+    return null;
+  }
+
+  const reasoning = { ...body.reasoning };
+  delete reasoning.summary;
+
+  const next: Record<string, unknown> = { ...body };
+  if (Object.keys(reasoning).length > 0) next.reasoning = reasoning;
+  else delete next.reasoning;
+  return next;
+}
+
 function createByteDanceSeedResponsesCompatTransform(): RequestTransform {
   return (body) => {
     if (!isPlainObject(body)) return null;
@@ -674,6 +689,11 @@ function createByteDanceSeedResponsesCompatTransform(): RequestTransform {
     const withNormalizedInput = normalizeByteDanceSeedInput(current);
     if (withNormalizedInput) {
       current = withNormalizedInput;
+      changed = true;
+    }
+    const withSanitizedReasoning = sanitizeByteDanceSeedReasoning(current);
+    if (withSanitizedReasoning) {
+      current = withSanitizedReasoning;
       changed = true;
     }
     return changed ? current : null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

ByteDance Seed 2.1 Pro 接受 Responses API 的 `reasoning.effort`，但会拒绝 `reasoning.summary`。本 PR 在现有 Seed 请求兼容转换中移除 `summary`，同时保留 `effort` 和其他 reasoning 字段，并补充回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：ByteDance Seed 2.1 Pro 兼容性
- 本 PR 包含：仅清理 ByteDance Seed 模型请求中的顶层 `reasoning.summary`
- 明确不包含：namespace tool 兼容改动；`minimal` reasoning effort 映射
- 用户可见变化：Seed 2.1 Pro 请求不再因不支持 `reasoning.summary` 而失败
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，所有适用 workspace 均 PASS

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：通过，49/49 tests

git diff --check
结果：通过
```

### 手工验证

Desktop remote dev app（region=cn）已在改动后启动；确认运行进程使用当前 checkout，编译产物包含 Seed reasoning 清理逻辑。

### 未执行的验证

未使用真实 Volcengine 凭证发送计费请求；行为由请求转换回归测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 ByteDance Seed 模型的 Responses API 代理请求；其他模型不变。
- 回滚 / 降级方式：回滚本提交即可恢复原请求透传行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因