### PR TITLE
fix(desktop): block shared primary dev migrations

### DIFF
--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -274,19 +274,27 @@ describe('shouldBlockSharedPrimaryDev', () => {
     ).toBe(false);
     expect(
       shouldBlockSharedPrimaryDev({
-        isPackaged: false,
-        schedulerPassive: false,
-        isolated: false,
-        hasUserDataOverride: true,
-      }),
-    ).toBe(false);
-    expect(
-      shouldBlockSharedPrimaryDev({
         isPackaged: true,
         schedulerPassive: false,
         isolated: false,
       }),
     ).toBe(false);
+  });
+
+  it('手动 XDT_USER_DATA_DIR 不等于 isolated，不能绕过 primary dev 启动闸', () => {
+    const flags = resolveDevCliFlags({
+      ...base,
+      envUserDataDir: '/AppData/xdt-maker',
+    });
+    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker');
+    expect(flags.isolated).toBe(false);
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: false,
+        schedulerPassive: flags.schedulerPassive,
+        isolated: flags.isolated,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   resolveDevCliFlags,
   resolveSingleInstanceLockUserDataDir,
+  shouldBlockSharedPrimaryDev,
   shouldEnforcePassiveMigrationCompatibility,
   shouldRequestSingleInstanceLock,
 } from '../devCliFlags';
@@ -242,6 +243,47 @@ describe('shouldEnforcePassiveMigrationCompatibility', () => {
       shouldEnforcePassiveMigrationCompatibility({
         isPackaged: true,
         schedulerPassive: true,
+        isolated: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('shouldBlockSharedPrimaryDev', () => {
+  it('只阻止共用正式版 userData 的 primary dev', () => {
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: false,
+        schedulerPassive: false,
+        isolated: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: false,
+        schedulerPassive: true,
+        isolated: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: false,
+        schedulerPassive: false,
+        isolated: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: false,
+        schedulerPassive: false,
+        isolated: false,
+        hasUserDataOverride: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: true,
+        schedulerPassive: false,
         isolated: false,
       }),
     ).toBe(false);

--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -8,6 +8,7 @@ import {
   shouldBlockSharedPrimaryDev,
   shouldEnforcePassiveMigrationCompatibility,
   shouldRequestSingleInstanceLock,
+  userDataPathsReferToSameDirectory,
 } from '../devCliFlags';
 
 const base = {
@@ -293,6 +294,43 @@ describe('shouldBlockSharedPrimaryDev', () => {
         isPackaged: false,
         schedulerPassive: flags.schedulerPassive,
         isolated: flags.isolated,
+      }),
+    ).toBe(true);
+  });
+
+  it('isolated 声明不能把覆写目录指回正式版 userData', () => {
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: false,
+        schedulerPassive: false,
+        isolated: true,
+        userDataDirOverride: '/AppData/xdt-maker',
+        defaultUserDataDir: '/AppData/xdt-maker',
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockSharedPrimaryDev({
+        isPackaged: false,
+        schedulerPassive: false,
+        isolated: true,
+        userDataDirOverride: '/AppData/xdt-maker-dev-feature',
+        defaultUserDataDir: '/AppData/xdt-maker',
+      }),
+    ).toBe(false);
+  });
+
+  it('路径身份检查会解析符号链接并按大小写不敏感平台比较', () => {
+    const shared = join('/AppData', 'Cindy');
+    const linked = join('/AppData', 'release-link');
+    expect(
+      userDataPathsReferToSameDirectory({
+        candidate: linked,
+        shared,
+        platform: 'win32',
+        realpath: (value) =>
+          value.toLowerCase().endsWith('release-link')
+            ? `${value.slice(0, -'release-link'.length)}Cindy`
+            : value,
       }),
     ).toBe(true);
   });

--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -299,13 +299,18 @@ describe('shouldBlockSharedPrimaryDev', () => {
   });
 
   it('isolated 声明不能把覆写目录指回正式版 userData', () => {
+    const protectedUserDataDirs = [
+      '/AppData/Cindy',
+      '/AppData/CindyGlobal',
+      '/AppData/xdt-maker',
+    ];
     expect(
       shouldBlockSharedPrimaryDev({
         isPackaged: false,
         schedulerPassive: false,
         isolated: true,
         userDataDirOverride: '/AppData/xdt-maker',
-        defaultUserDataDir: '/AppData/xdt-maker',
+        protectedUserDataDirs,
       }),
     ).toBe(true);
     expect(
@@ -314,14 +319,33 @@ describe('shouldBlockSharedPrimaryDev', () => {
         schedulerPassive: false,
         isolated: true,
         userDataDirOverride: '/AppData/xdt-maker-dev-feature',
-        defaultUserDataDir: '/AppData/xdt-maker',
+        protectedUserDataDirs,
       }),
     ).toBe(false);
   });
 
+  it('passive 不能放行 isolated 声明指回任何正式版或历史 userData', () => {
+    const protectedUserDataDirs = [
+      '/AppData/Cindy',
+      '/AppData/CindyGlobal',
+      '/AppData/xdt-maker',
+    ];
+    for (const userDataDirOverride of protectedUserDataDirs) {
+      expect(
+        shouldBlockSharedPrimaryDev({
+          isPackaged: false,
+          schedulerPassive: true,
+          isolated: true,
+          userDataDirOverride,
+          protectedUserDataDirs,
+        }),
+      ).toBe(true);
+    }
+  });
+
   it('路径身份检查会解析符号链接并按大小写不敏感平台比较', () => {
-    const shared = join('/AppData', 'Cindy');
-    const linked = join('/AppData', 'release-link');
+    const shared = String.raw`C:\AppData\Cindy`;
+    const linked = String.raw`C:\AppData\release-link`;
     expect(
       userDataPathsReferToSameDirectory({
         candidate: linked,

--- a/apps/desktop/src/main/__tests__/legacyUserDataMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/legacyUserDataMigration.test.ts
@@ -566,11 +566,29 @@ describe('shouldSkipLegacyMigrationForDevSandbox', () => {
     ).toBe(false);
   });
 
+  it('共享 passive dev → 跳过,不探测、复制或写 marker', () => {
+    expect(
+      shouldSkipLegacyMigrationForDevSandbox({
+        isPackaged: false,
+        envUserDataDir: undefined,
+        envPassiveSharedUserData: '1',
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipLegacyMigrationForDevSandbox({
+        isPackaged: false,
+        envUserDataDir: undefined,
+        envPassiveSharedUserData: '0',
+      }),
+    ).toBe(false);
+  });
+
   it('packaged 永不跳过(即使残留同名 env)', () => {
     expect(
       shouldSkipLegacyMigrationForDevSandbox({
         isPackaged: true,
         envUserDataDir: path.join(BASE, 'anything'),
+        envPassiveSharedUserData: '1',
       }),
     ).toBe(false);
   });

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -99,12 +99,9 @@ export function shouldRequestSingleInstanceLock(input: {
  *
  * packaged 用真实 userData —— release 之间单实例，双击第二份安装包会聚焦已运行
  * 窗口。dev 用 `<userData>/dev-single-instance-lock` 子目录 —— dev 之间仍单实例
- * （深链 second-instance redirect 保持有效），但**不再与共库的正式版互斥**：
- * dev + release 共享 userData 双开是明确支持的工作流（2026-07-19 dev 改为与
- * packaged 抢同一把锁曾误伤该工作流，2026-07-20 按 flavor 分域恢复）。跨实例
- * 并发由 SQLite WAL + busy_timeout、scheduler DB 级原子认领、auth
- * replacement-retry 等既有仲裁收敛，与 `--passive` 共库多开走的是同一套机制。
- * `--isolated` 沙箱的 userData 本身独立，锁子目录随之独立，语义不变。
+ * （深链 second-instance redirect 保持有效），并与 packaged 锁分域。共享正式版
+ * userData 只允许 `--passive`，而 passive 会跳过获取锁；primary dev 必须使用
+ * `--isolated`，其 userData 本身独立，锁子目录随之独立。
  */
 export function resolveSingleInstanceLockUserDataDir(input: {
   isPackaged: boolean;
@@ -128,6 +125,27 @@ export function shouldEnforcePassiveMigrationCompatibility(input: {
   isolated: boolean;
 }): boolean {
   return !input.isPackaged && input.schedulerPassive && !input.isolated;
+}
+
+/**
+ * Primary dev must not open the packaged release's userData. A newer checkout
+ * can migrate that database past the installed release's migration history.
+ * Isolated dev owns a separate database; passive shared dev is compatibility
+ * checked and never runs migrations.
+ */
+export function shouldBlockSharedPrimaryDev(input: {
+  isPackaged: boolean;
+  schedulerPassive: boolean;
+  isolated: boolean;
+  /** 手动 XDT_USER_DATA_DIR 也代表用户明确选择了 dev 数据目录。 */
+  hasUserDataOverride?: boolean;
+}): boolean {
+  return (
+    !input.isPackaged &&
+    !input.schedulerPassive &&
+    !input.isolated &&
+    !input.hasUserDataOverride
+  );
 }
 
 export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -14,7 +14,8 @@
  * 纯函数、零 electron 依赖 —— index.ts 注入 argv / env / 默认 userData 目录,
  * 便于单元测试。packaged 版本一律返回"无覆写",线上零影响。
  */
-import { join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 /**
  * 沙箱名字白名单:字母数字下划线连字符、≤32。同时约束两件事——
@@ -137,8 +138,38 @@ export function shouldBlockSharedPrimaryDev(input: {
   isPackaged: boolean;
   schedulerPassive: boolean;
   isolated: boolean;
+  userDataDirOverride?: string | null;
+  defaultUserDataDir?: string;
 }): boolean {
-  return !input.isPackaged && !input.schedulerPassive && !input.isolated;
+  if (input.isPackaged || input.schedulerPassive) return false;
+  if (!input.isolated) return true;
+  if (!input.userDataDirOverride || !input.defaultUserDataDir) return false;
+  return userDataPathsReferToSameDirectory({
+    candidate: input.userDataDirOverride,
+    shared: input.defaultUserDataDir,
+  });
+}
+
+export function userDataPathsReferToSameDirectory(input: {
+  candidate: string;
+  shared: string;
+  platform?: NodeJS.Platform;
+  realpath?: (value: string) => string;
+}): boolean {
+  const platform = input.platform ?? process.platform;
+  const realpath = input.realpath ?? realpathSync.native;
+  const canonicalize = (value: string): string => {
+    let canonical = resolve(value);
+    try {
+      canonical = realpath(canonical);
+    } catch {
+      // A not-yet-created directory still gets a stable lexical identity.
+    }
+    return platform === 'win32' || platform === 'darwin'
+      ? canonical.toLocaleLowerCase('en-US')
+      : canonical;
+  };
+  return canonicalize(input.candidate) === canonicalize(input.shared);
 }
 
 export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -137,15 +137,8 @@ export function shouldBlockSharedPrimaryDev(input: {
   isPackaged: boolean;
   schedulerPassive: boolean;
   isolated: boolean;
-  /** 手动 XDT_USER_DATA_DIR 也代表用户明确选择了 dev 数据目录。 */
-  hasUserDataOverride?: boolean;
 }): boolean {
-  return (
-    !input.isPackaged &&
-    !input.schedulerPassive &&
-    !input.isolated &&
-    !input.hasUserDataOverride
-  );
+  return !input.isPackaged && !input.schedulerPassive && !input.isolated;
 }
 
 export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -15,7 +15,7 @@
  * 便于单元测试。packaged 版本一律返回"无覆写",线上零影响。
  */
 import { realpathSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, posix, win32 } from 'node:path';
 
 /**
  * 沙箱名字白名单:字母数字下划线连字符、≤32。同时约束两件事——
@@ -139,15 +139,24 @@ export function shouldBlockSharedPrimaryDev(input: {
   schedulerPassive: boolean;
   isolated: boolean;
   userDataDirOverride?: string | null;
-  defaultUserDataDir?: string;
+  protectedUserDataDirs?: readonly string[];
 }): boolean {
-  if (input.isPackaged || input.schedulerPassive) return false;
+  if (input.isPackaged) return false;
+  const override = input.userDataDirOverride;
+  const overrideTargetsProtectedUserData = override
+    ? input.protectedUserDataDirs?.some((shared) =>
+        userDataPathsReferToSameDirectory({
+          candidate: override,
+          shared,
+        }),
+      ) === true
+    : false;
+  // A contradictory passive + isolated launch must fail before passive can
+  // bypass this guard: isolated mode would otherwise keep migrations enabled.
+  if (input.isolated && overrideTargetsProtectedUserData) return true;
+  if (input.schedulerPassive) return false;
   if (!input.isolated) return true;
-  if (!input.userDataDirOverride || !input.defaultUserDataDir) return false;
-  return userDataPathsReferToSameDirectory({
-    candidate: input.userDataDirOverride,
-    shared: input.defaultUserDataDir,
-  });
+  return false;
 }
 
 export function userDataPathsReferToSameDirectory(input: {
@@ -158,8 +167,9 @@ export function userDataPathsReferToSameDirectory(input: {
 }): boolean {
   const platform = input.platform ?? process.platform;
   const realpath = input.realpath ?? realpathSync.native;
+  const pathApi = platform === 'win32' ? win32 : posix;
   const canonicalize = (value: string): string => {
-    let canonical = resolve(value);
+    let canonical = pathApi.resolve(value);
     try {
       canonical = realpath(canonical);
     } catch {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -92,7 +92,6 @@ if (shouldBlockSharedPrimaryDev({
   isPackaged: app.isPackaged,
   schedulerPassive: devFlags.schedulerPassive,
   isolated: devFlags.isolated,
-  hasUserDataOverride: devFlags.userDataDirOverride !== null,
 })) {
   stderr.write(
     '[cindy] Primary desktop dev cannot use shared Cindy userData because it may upgrade ' +

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -71,6 +71,7 @@ installInvokeCapture();
 //   - --passive / XDT_SCHEDULER_PASSIVE:定时任务自动触发让位给同机另一实例。
 // 必须在 app 'ready' 前调用。仅 dev(非 packaged)生效,生产忽略,零线上影响。
 import { machineIdSync } from 'node-machine-id';
+import { BRAND_IDENTITY } from '@cindy/maker-shared/brand-identity';
 import {
   resolveDevCliFlags,
   shouldBlockSharedPrimaryDev,
@@ -89,17 +90,27 @@ const devFlags = resolveDevCliFlags({
   envSchedulerPassive: process.env.XDT_SCHEDULER_PASSIVE,
   envEndpointsCdn: process.env.XDT_ENDPOINTS_CDN,
 });
+const protectedUserDataDirs = [
+  defaultUserDataDir,
+  ...Array.from(
+    new Set([
+      ...Object.values(BRAND_IDENTITY.userDataDirNameByRegion),
+      ...BRAND_IDENTITY.legacyUserDataDirNames,
+    ]),
+  ).map((dirName) => path.join(app.getPath('appData'), dirName)),
+];
 if (shouldBlockSharedPrimaryDev({
   isPackaged: app.isPackaged,
   schedulerPassive: devFlags.schedulerPassive,
   isolated: devFlags.isolated,
   userDataDirOverride: devFlags.userDataDirOverride,
-  defaultUserDataDir,
+  protectedUserDataDirs,
 })) {
   stderr.write(
     '[cindy] Primary desktop dev cannot use shared Cindy userData because it may upgrade ' +
       'the release database and prevent an older release from opening it.\n' +
-      '[cindy] Restart with --isolated=<name>, or use --passive for a shared read-only preview.\n',
+      '[cindy] Restart with --isolated=<name>, or use --passive / --preserve-running ' +
+      'for a shared read-only preview.\n',
   );
   exit(1);
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -77,11 +77,12 @@ import {
   shouldEnforcePassiveMigrationCompatibility,
 } from './devCliFlags.js';
 
+const defaultUserDataDir = app.getPath('userData');
 const devFlags = resolveDevCliFlags({
   argv: process.argv,
   isPackaged: app.isPackaged,
   envUserDataDir: process.env.XDT_USER_DATA_DIR,
-  defaultUserDataDir: app.getPath('userData'),
+  defaultUserDataDir,
   envIsolated: process.env.XDT_ISOLATED,
   envIsolationName: process.env.XDT_ISOLATED_NAME,
   envDeviceIdOverride: process.env.XDT_DEVICE_ID_OVERRIDE,
@@ -92,6 +93,8 @@ if (shouldBlockSharedPrimaryDev({
   isPackaged: app.isPackaged,
   schedulerPassive: devFlags.schedulerPassive,
   isolated: devFlags.isolated,
+  userDataDirOverride: devFlags.userDataDirOverride,
+  defaultUserDataDir,
 })) {
   stderr.write(
     '[cindy] Primary desktop dev cannot use shared Cindy userData because it may upgrade ' +

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -73,6 +73,7 @@ installInvokeCapture();
 import { machineIdSync } from 'node-machine-id';
 import {
   resolveDevCliFlags,
+  shouldBlockSharedPrimaryDev,
   shouldEnforcePassiveMigrationCompatibility,
 } from './devCliFlags.js';
 
@@ -87,6 +88,19 @@ const devFlags = resolveDevCliFlags({
   envSchedulerPassive: process.env.XDT_SCHEDULER_PASSIVE,
   envEndpointsCdn: process.env.XDT_ENDPOINTS_CDN,
 });
+if (shouldBlockSharedPrimaryDev({
+  isPackaged: app.isPackaged,
+  schedulerPassive: devFlags.schedulerPassive,
+  isolated: devFlags.isolated,
+  hasUserDataOverride: devFlags.userDataDirOverride !== null,
+})) {
+  stderr.write(
+    '[cindy] Primary desktop dev cannot use shared Cindy userData because it may upgrade ' +
+      'the release database and prevent an older release from opening it.\n' +
+      '[cindy] Restart with --isolated=<name>, or use --passive for a shared read-only preview.\n',
+  );
+  exit(1);
+}
 if (devFlags.schedulerPassive) {
   // 统一收敛到 env:scheduler-host 只认 XDT_SCHEDULER_PASSIVE,不重复解析 argv。
   process.env.XDT_SCHEDULER_PASSIVE = '1';
@@ -144,10 +158,10 @@ if (devFlags.needsIsolatedDeviceId) {
   stderr.write(`[cindy] dev isolated deviceId → ${isolatedDeviceId}\n`);
 }
 
-// 实例注册表对 dev 与 packaged 一律登记:dev/release 按 flavor 分锁域、共享同一
-// userData 双开是受支持的工作流(bootstrap-electron 单例锁注释),owner-namespace
-// 迁移的独占检查靠本注册表发现「还有谁共享这份 userData」——packaged 不登记的话,
-// dev 实例会在 release 实例仍存活时误判独占并搬走 legacy 配置。
+// 实例注册表对 dev 与 packaged 一律登记：passive dev / release 共享 userData 时，
+// owner-namespace 迁移的独占检查靠本注册表发现「还有谁共享这份 userData」。
+// packaged 不登记的话，后续 primary 实例会在 release 仍存活时误判独占并搬走
+// legacy 配置。
 {
   const rootDir = app.isPackaged
     ? path.resolve(app.getAppPath())

--- a/apps/desktop/src/main/legacyUserDataMigration.ts
+++ b/apps/desktop/src/main/legacyUserDataMigration.ts
@@ -18,7 +18,8 @@
  *  - 老目录不存在(全新用户):静默写 marker 返回,不弹窗打扰。
  *  - 老目录存在:推送 confirm 态给 renderer 弹确认窗,await 用户确认(IPC
  *    `legacy-migration:confirm`)后才开始复制。
- *  - dev userData 覆写(--isolated 沙箱 / XDT_USER_DATA_DIR)下整个迁移跳过,
+ *  - dev userData 覆写(--isolated 沙箱 / XDT_USER_DATA_DIR)或共享 passive 模式下
+ *    整个迁移跳过,
  *    不探测不弹窗(见 shouldSkipLegacyMigrationForDevSandbox)。
  *
  * 可测试性(docs/dev-rules/engineering-conventions.md):核心流程 `runLegacyUserDataMigration` 全部依赖
@@ -571,21 +572,28 @@ export function registerLegacyMigrationIpc(): void {
 }
 
 /**
- * dev userData 覆写(--isolated 沙箱 / 手动 XDT_USER_DATA_DIR)下必须跳过首登迁移。
+ * dev userData 覆写(--isolated 沙箱 / 手动 XDT_USER_DATA_DIR)和共享 passive 模式下
+ * 必须跳过首登迁移。
  *
  * 沙箱目录(如 <userData>-dev)与真实 userData 同级,首次登录时沙箱里没有 mToc
  * marker,探测会命中同级的真实老 xdt-maker 目录 → 弹确认窗并把用户真实主库 /
  * cindy-media / dialogues / 浏览器 profile 整套复制进临时沙箱。这既不是沙箱的
  * 语义(隔离、不动正式数据),也会产生 GB 级无意义复制。isolated 的 argv 与 env
  * 两条声明通道最终都会把生效目录同步进 XDT_USER_DATA_DIR(main/index.ts),
- * 因此这里以该 env 为唯一检测面。packaged 永不跳过(线上升级迁移不受影响)。
+ * 因此这里以该 env 为检测面。共享 passive 由 index.ts 在加载 bootstrap 前同步
+ * XDT_PASSIVE_SHARED_USER_DATA=1，同样不得探测、复制或写 marker。packaged 永不
+ * 跳过(线上升级迁移不受影响)。
  * 纯函数、零 electron 依赖,便于单测。
  */
 export function shouldSkipLegacyMigrationForDevSandbox(input: {
   isPackaged: boolean;
   envUserDataDir: string | undefined;
+  envPassiveSharedUserData?: string | undefined;
 }): boolean {
-  return !input.isPackaged && Boolean(input.envUserDataDir?.trim());
+  return (
+    !input.isPackaged &&
+    (Boolean(input.envUserDataDir?.trim()) || input.envPassiveSharedUserData === '1')
+  );
 }
 
 /**
@@ -597,14 +605,15 @@ export async function runLegacyUserDataMigrationForUser(userId: string): Promise
   // global 构建(同机双装)是全新身份,把 cn 的历史数据导进 global 库会
   // 跨区域串台(两边 auth 后端不同,会话 / 凭证对不上)。
   if (CURRENT_CINDY_REGION !== 'cn') return;
-  // dev 沙箱 / userData 覆写:不探测、不弹窗、不写 marker,纯跳过(见上方谓词注释)。
+  // dev 沙箱 / userData 覆写 / 共享 passive:不探测、不弹窗、不写 marker,纯跳过。
   if (
     shouldSkipLegacyMigrationForDevSandbox({
       isPackaged: app.isPackaged,
       envUserDataDir: process.env.XDT_USER_DATA_DIR,
+      envPassiveSharedUserData: process.env.XDT_PASSIVE_SHARED_USER_DATA,
     })
   ) {
-    log.info('legacy userData migration: dev userData override active, skipped');
+    log.info('legacy userData migration: dev sandbox/passive mode active, skipped');
     return;
   }
   if (inFlight != null) {

--- a/docs/dev-rules/database-and-migrations.md
+++ b/docs/dev-rules/database-and-migrations.md
@@ -82,10 +82,12 @@ companion CommonJS 格式和历史 runtime identity 冻结；不能用单独 typ
 - companion 接收同步 `better-sqlite3` 实例，在受控 migration 事务内使用 `.get()`、
   `.all()`、`.run()` 是契约的一部分；不要把这种同步写法复制到运行期业务代码。
 
-## 未合入 Migration 与本地数据
+## Dev Migration 与本地数据
 
-- 未进入 `main` 的 migration 禁止连接共享 Cindy userData 运行；否则分支换号或回退后会让
-  本地 `schema_version` 与真实结构永久分叉。
+- primary dev 禁止连接共享 Cindy userData 运行 migration，即使 migration 已进入 `main`；
+  本机安装的 release 仍可能更旧，新 checkout 升级数据库后会让旧 release 无法打开。
+- 未进入 `main` 的 migration 还可能因分支换号或回退，让本地 `schema_version` 与真实结构
+  永久分叉。
 - 需要启动验证时，按照 `desktop-development.md` 的参数说明使用显式
   `--isolated[=<名字>]` 沙箱。migration replay 自身使用临时数据库，不污染用户数据。
 - 不得为了测试 migration 临时改写、降级或删除用户数据库；需要历史状态时新增最小 fixture。

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -7,11 +7,11 @@
 
 ## Agent 启动入口
 
-Agent 启动 Desktop 只使用仓库根的安全包装命令，并显式选择目标区域：
+Agent 启动 Desktop 只使用仓库根的安全包装命令，并显式选择目标区域与隔离沙箱：
 
 ```bash
-pnpm restart:desktop:remote --region=cn
-pnpm restart:desktop:remote --region=global
+pnpm restart:desktop:remote --region=cn --isolated=<名字>
+pnpm restart:desktop:remote --region=global --isolated=<名字>
 ```
 
 Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录页中免 Cindy 账号的
@@ -23,24 +23,26 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
 
 ## 可选启动参数
 
-两个 restart 命令都支持下列参数；**用户没提就不要主动加**（不带 = 共库 + 正常调度）。
+两个 restart 命令都支持下列参数。primary dev 必须显式使用 `--isolated[=<名字>]`；无隔离
+参数的共享 primary 会在启动前被拒绝，避免新 checkout 迁移正式版数据库、导致旧 release
+无法打开。只有 `--passive` / `--preserve-running` 可以只读共享正式版 userData。
 这些参数只对 dev 生效，不影响用户机器上的正式版。
 
 - `--region=cn|global`（默认 `cn`）：切换构建身份与仓内端点清单（`global` 读
   `config/endpoint.global.json`）。
-- `--isolated` / `--isolated=<名字>`：使用独立 userData 沙箱，数据库、登录态、会话、定时
+- `--isolated` / `--isolated=<名字>`：primary dev 的必选参数，使用独立 userData 沙箱，数据库、登录态、会话、定时
   任务与设备身份都与正式版彻底隔离（首次需重新登录）；命名沙箱每个名字一条独立沙箱，
   名字限 `A-Za-z0-9_-`、≤32 字符。用户说「独立数据库／隔离数据／沙箱启动／不要动正式版
-  数据」时用。**未合入主干的 migration 必须在 `--isolated` 沙箱里跑，不得连共享 userData**
+  数据」时用。**primary dev 的 migration 必须在 `--isolated` 沙箱里跑，不得连接共享 userData**
   （见 [`database-and-migrations.md`](database-and-migrations.md)）。沙箱（及任何 dev
   userData 覆写）内不触发首登旧数据迁移（mToc）：不探测老目录、不弹确认窗、不把正式
   数据复制进沙箱。
-- `--passive`：定时任务被动模式，本实例不自动触发 schedule，但数据仍与其它实例共享；
+- `--passive`：共享 userData 的只读预览模式，本实例不执行 migration，也不自动触发 schedule；
   多开导致定时任务重复、需要让位给 primary 时用。共享 userData 的 passive 实例对
   userData 布局保持只读：不执行 owner-namespace 迁移（claim 推迟到下次独占启动），
   legacy 数据导入（`hasLegacyOwnerNamespaceClaim` 门控的 secret／IM／brain 搬账）
   一并等待。非 passive 实例执行该迁移前也会先查 `.dev-instances` 实例注册表
-  （dev 与 packaged 实例都登记——dev 与正式版共库双开受支持），发现其它存活实例
+  （dev 与 packaged 实例都登记——passive dev 与正式版可只读共库双开），发现其它存活实例
   共享同一 userData 时同样推迟——搬家式迁移必须独占 userData 才能执行，否则会打断
   还在运行的旧版本实例（2026-07-23 slack-hook.json／网关凭证被搬走事故）。
 - `--preserve-running`：并行 dev，不停止任何已有 Cindy dev 进程，每个新实例强制 passive

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -50,7 +50,8 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
   实例／不要重新登录」时用。仅支持 remote，禁止与 `--isolated` 组合。
 
 已手动设 `XDT_USER_DATA_DIR` 时仍须同时声明 `--isolated` / `XDT_ISOLATED=1`；脚本会尊重
-该目录值而不覆盖。仅设置目录不足以证明它与正式版 userData 隔离，因此不能绕过启动闸。
+该目录值而不覆盖，但该路径（包括解析符号链接后）不得指向正式版 userData。仅设置目录或
+隔离标记都不足以绕过启动闸。
 
 ### 并行多开 dev
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -49,7 +49,8 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
   并共享当前 userData／登录态；仅供能证明实例归属的上层编排，或用户明确「不要关当前
   实例／不要重新登录」时用。仅支持 remote，禁止与 `--isolated` 组合。
 
-已手动设 `XDT_USER_DATA_DIR` 时尊重用户值，不覆盖。
+已手动设 `XDT_USER_DATA_DIR` 时仍须同时声明 `--isolated` / `XDT_ISOLATED=1`；脚本会尊重
+该目录值而不覆盖。仅设置目录不足以证明它与正式版 userData 隔离，因此不能绕过启动闸。
 
 ### 并行多开 dev
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -10,8 +10,8 @@
 Agent 启动 Desktop 只使用仓库根的安全包装命令，并显式选择目标区域与隔离沙箱：
 
 ```bash
-pnpm restart:desktop:remote --region=cn --isolated=<名字>
-pnpm restart:desktop:remote --region=global --isolated=<名字>
+pnpm restart:desktop:remote --region=cn --isolated=cn-<名字>
+pnpm restart:desktop:remote --region=global --isolated=global-<名字>
 ```
 
 Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录页中免 Cindy 账号的
@@ -36,7 +36,9 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
   数据」时用。**primary dev 的 migration 必须在 `--isolated` 沙箱里跑，不得连接共享 userData**
   （见 [`database-and-migrations.md`](database-and-migrations.md)）。沙箱（及任何 dev
   userData 覆写）内不触发首登旧数据迁移（mToc）：不探测老目录、不弹确认窗、不把正式
-  数据复制进沙箱。
+  数据复制进沙箱。dev 沙箱目录沿用既有的“按名字复用”契约，不自动按 region 改名；同一
+  机器同时开发 cn / global 时，名字必须分别使用 `cn-<名字>` / `global-<名字>`，避免两区
+  复用数据库和登录态。
 - `--passive`：共享 userData 的只读预览模式，本实例不执行 migration，也不自动触发 schedule；
   多开导致定时任务重复、需要让位给 primary 时用。共享 userData 的 passive 实例对
   userData 布局保持只读：不执行 owner-namespace 迁移（claim 推迟到下次独占启动），

--- a/scripts/__tests__/brand-identity-sync.test.mjs
+++ b/scripts/__tests__/brand-identity-sync.test.mjs
@@ -28,6 +28,12 @@ function extractLiteral(source, regex, label) {
   return match[1];
 }
 
+function extractStringLiterals(source, regex, label) {
+  const match = regex.exec(source);
+  assert.ok(match, `pattern not found: ${label} (${regex})`);
+  return [...match[1].matchAll(/'([^']+)'/g)].map((entry) => entry[1]);
+}
+
 const brandIdentitySource = readSource('packages/maker-shared/src/brandIdentity.ts');
 const EXECUTABLE_NAME = extractLiteral(
   brandIdentitySource,
@@ -57,6 +63,29 @@ test('restart-desktop-remote.mjs BRAND_USER_DATA_DIR_NAME mirrors brandIdentity.
     'restart-desktop-remote.mjs BRAND_USER_DATA_DIR_NAME',
   );
   assert.equal(value, USER_DATA_DIR_NAME);
+});
+
+test('dev migration policy protects every current and legacy release userData directory', () => {
+  const current = extractStringLiterals(
+    brandIdentitySource,
+    /userDataDirNameByRegion:\s*Object\.freeze\(\{([\s\S]*?)\}\),/,
+    'brandIdentity.ts userDataDirNameByRegion',
+  );
+  const legacy = extractStringLiterals(
+    brandIdentitySource,
+    /legacyUserDataDirNames:\s*Object\.freeze\(\[([\s\S]*?)\]\)/,
+    'brandIdentity.ts legacyUserDataDirNames',
+  );
+  const policySource = readSource('scripts/dev-migration-policy.mjs');
+  const protectedNames = extractStringLiterals(
+    policySource,
+    /PROTECTED_USER_DATA_DIR_NAMES = Object\.freeze\(\[([\s\S]*?)\]\)/,
+    'dev-migration-policy.mjs PROTECTED_USER_DATA_DIR_NAMES',
+  );
+  assert.deepEqual(
+    [...new Set(protectedNames)].sort(),
+    [...new Set([...current, ...legacy])].sort(),
+  );
 });
 
 test('desktop package.json productName mirrors brandIdentity.userDataDirName', () => {

--- a/scripts/__tests__/dev-migration-policy.test.mjs
+++ b/scripts/__tests__/dev-migration-policy.test.mjs
@@ -82,6 +82,40 @@ test('passive shared dev may start without running migrations', () => {
     assert.doesNotThrow(() =>
       assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready', '--preserve-running']),
     );
+    assert.doesNotThrow(() =>
+      assertSharedDevMigrationPolicy(
+        fixture.repo,
+        ['--wait-ready'],
+        { XDT_SCHEDULER_PASSIVE: '1' },
+      ),
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('a userData override alone cannot bypass shared primary protection', () => {
+  const fixture = createFixture();
+  try {
+    assert.throws(
+      () =>
+        assertSharedDevMigrationPolicy(
+          fixture.repo,
+          ['--wait-ready'],
+          { XDT_USER_DATA_DIR: path.join(fixture.repo, 'Cindy') },
+        ),
+      /may upgrade the release database and prevent an older release from opening/,
+    );
+    assert.doesNotThrow(() =>
+      assertSharedDevMigrationPolicy(
+        fixture.repo,
+        ['--wait-ready'],
+        {
+          XDT_ISOLATED: '1',
+          XDT_USER_DATA_DIR: path.join(fixture.repo, 'Cindy-dev'),
+        },
+      ),
+    );
   } finally {
     fixture.cleanup();
   }

--- a/scripts/__tests__/dev-migration-policy.test.mjs
+++ b/scripts/__tests__/dev-migration-policy.test.mjs
@@ -121,6 +121,39 @@ test('a userData override alone cannot bypass shared primary protection', () => 
   }
 });
 
+test('an isolated declaration cannot point its override back to shared release userData', () => {
+  const fixture = createFixture();
+  try {
+    const sharedUserData = path.join(fixture.repo, 'Cindy');
+    const linkedUserData = path.join(fixture.repo, 'release-link');
+    const env = {
+      APPDATA: fixture.repo,
+      XDT_ISOLATED: '1',
+      XDT_USER_DATA_DIR: sharedUserData,
+    };
+    assert.throws(
+      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready'], env),
+      /may upgrade the release database and prevent an older release from opening/,
+    );
+    assert.throws(
+      () =>
+        assertSharedDevMigrationPolicy(
+          fixture.repo,
+          ['--wait-ready'],
+          { ...env, XDT_USER_DATA_DIR: linkedUserData },
+          {
+            platform: 'win32',
+            realpath: (value) =>
+              value.toLowerCase().endsWith('release-link') ? sharedUserData : value,
+          },
+        ),
+      /may upgrade the release database and prevent an older release from opening/,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 test('named isolated dev may run an unmerged migration', () => {
   const fixture = createFixture();
   try {

--- a/scripts/__tests__/dev-migration-policy.test.mjs
+++ b/scripts/__tests__/dev-migration-policy.test.mjs
@@ -132,11 +132,13 @@ test('an isolated declaration cannot point its override back to shared release u
       XDT_ISOLATED: '1',
       XDT_USER_DATA_DIR: sharedUserData,
     };
+    const windowsPathOptions = {
+      platform: 'win32',
+      realpath: (value) => value,
+    };
     assert.throws(
       () =>
-        assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready'], env, {
-          platform: 'win32',
-        }),
+        assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready'], env, windowsPathOptions),
       /may upgrade the release database and prevent an older release from opening/,
     );
     assert.throws(
@@ -171,7 +173,7 @@ test('passive cannot bypass an isolated override targeting release userData', ()
             APPDATA: appData,
             XDT_USER_DATA_DIR: path.win32.join(appData, 'Cindy'),
           },
-          { platform: 'win32' },
+          { platform: 'win32', realpath: (value) => value },
         ),
       /may upgrade the release database and prevent an older release from opening/,
     );
@@ -194,7 +196,7 @@ test('all current and legacy release userData directories are protected', () => 
               APPDATA: appData,
               XDT_USER_DATA_DIR: path.win32.join(appData, dirName),
             },
-            { platform: 'win32' },
+            { platform: 'win32', realpath: (value) => value },
           ),
         /may upgrade the release database and prevent an older release from opening/,
         dirName,

--- a/scripts/__tests__/dev-migration-policy.test.mjs
+++ b/scripts/__tests__/dev-migration-policy.test.mjs
@@ -124,15 +124,19 @@ test('a userData override alone cannot bypass shared primary protection', () => 
 test('an isolated declaration cannot point its override back to shared release userData', () => {
   const fixture = createFixture();
   try {
-    const sharedUserData = path.join(fixture.repo, 'Cindy');
-    const linkedUserData = path.join(fixture.repo, 'release-link');
+    const appData = String.raw`C:\Users\dev\AppData\Roaming`;
+    const sharedUserData = path.win32.join(appData, 'Cindy');
+    const linkedUserData = path.win32.join(appData, 'release-link');
     const env = {
-      APPDATA: fixture.repo,
+      APPDATA: appData,
       XDT_ISOLATED: '1',
       XDT_USER_DATA_DIR: sharedUserData,
     };
     assert.throws(
-      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready'], env),
+      () =>
+        assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready'], env, {
+          platform: 'win32',
+        }),
       /may upgrade the release database and prevent an older release from opening/,
     );
     assert.throws(
@@ -149,6 +153,53 @@ test('an isolated declaration cannot point its override back to shared release u
         ),
       /may upgrade the release database and prevent an older release from opening/,
     );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('passive cannot bypass an isolated override targeting release userData', () => {
+  const fixture = createFixture();
+  try {
+    const appData = String.raw`C:\Users\dev\AppData\Roaming`;
+    assert.throws(
+      () =>
+        assertSharedDevMigrationPolicy(
+          fixture.repo,
+          ['--wait-ready', '--passive', '--isolated=feature'],
+          {
+            APPDATA: appData,
+            XDT_USER_DATA_DIR: path.win32.join(appData, 'Cindy'),
+          },
+          { platform: 'win32' },
+        ),
+      /may upgrade the release database and prevent an older release from opening/,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('all current and legacy release userData directories are protected', () => {
+  const fixture = createFixture();
+  try {
+    const appData = String.raw`C:\Users\dev\AppData\Roaming`;
+    for (const dirName of ['Cindy', 'CindyGlobal', 'CindyDev', 'xdt-maker']) {
+      assert.throws(
+        () =>
+          assertSharedDevMigrationPolicy(
+            fixture.repo,
+            ['--wait-ready', '--isolated=feature'],
+            {
+              APPDATA: appData,
+              XDT_USER_DATA_DIR: path.win32.join(appData, dirName),
+            },
+            { platform: 'win32' },
+          ),
+        /may upgrade the release database and prevent an older release from opening/,
+        dirName,
+      );
+    }
   } finally {
     fixture.cleanup();
   }

--- a/scripts/__tests__/dev-migration-policy.test.mjs
+++ b/scripts/__tests__/dev-migration-policy.test.mjs
@@ -34,7 +34,7 @@ function createFixture() {
   };
 }
 
-test('shared dev allows branches without migration artifacts', () => {
+test('shared primary dev is blocked even without migration artifacts', () => {
   const fixture = createFixture();
   try {
     fs.writeFileSync(path.join(fixture.repo, 'README.md'), 'feature\n');
@@ -45,26 +45,42 @@ test('shared dev allows branches without migration artifacts', () => {
       committed: [],
       workingTree: [],
     });
-    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']));
+    assert.throws(
+      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']),
+      /may upgrade the release database and prevent an older release from opening/,
+    );
   } finally {
     fixture.cleanup();
   }
 });
 
-test('shared dev rejects committed or working-tree migration artifacts before restart', () => {
+test('migration artifact discovery remains available for diagnostics', () => {
   const fixture = createFixture();
   try {
     const migrationPath = path.join(fixture.drizzleDir, '0001_feature.sql');
     fs.writeFileSync(migrationPath, 'SELECT 1;\n');
-    assert.throws(
-      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']),
-      /working tree: \?\? apps\/desktop\/drizzle\/0001_feature\.sql/,
-    );
+    assert.deepEqual(findUnmergedMigrationArtifacts(fixture.repo).workingTree, [
+      '?? apps/desktop/drizzle/0001_feature.sql',
+    ]);
     git(fixture.repo, 'add', '.');
     git(fixture.repo, 'commit', '-m', 'feature migration');
-    assert.throws(
-      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']),
-      /committed: apps\/desktop\/drizzle\/0001_feature\.sql/,
+    assert.deepEqual(findUnmergedMigrationArtifacts(fixture.repo).committed, [
+      'apps/desktop/drizzle/0001_feature.sql',
+    ]);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('passive shared dev may start without running migrations', () => {
+  const fixture = createFixture();
+  try {
+    fs.writeFileSync(path.join(fixture.drizzleDir, '0001_feature.sql'), 'SELECT 1;\n');
+    assert.doesNotThrow(() =>
+      assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready', '--passive']),
+    );
+    assert.doesNotThrow(() =>
+      assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready', '--preserve-running']),
     );
   } finally {
     fixture.cleanup();
@@ -83,15 +99,15 @@ test('named isolated dev may run an unmerged migration', () => {
   }
 });
 
-test('migration becomes shared-safe only after it is canonical on origin/main', () => {
+test('isolated dev remains allowed after migration becomes canonical on origin/main', () => {
   const fixture = createFixture();
   try {
     fs.writeFileSync(path.join(fixture.drizzleDir, '0001_feature.sql'), 'SELECT 1;\n');
     git(fixture.repo, 'add', '.');
     git(fixture.repo, 'commit', '-m', 'feature migration');
-    assert.throws(() => assertSharedDevMigrationPolicy(fixture.repo, []));
+    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, ['--isolated=feature']));
     git(fixture.repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD');
-    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, []));
+    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, ['--isolated=feature']));
   } finally {
     fixture.cleanup();
   }
@@ -119,7 +135,7 @@ test('stale origin/HEAD cannot replace origin/main as the migration baseline', (
     });
     assert.throws(
       () => assertSharedDevMigrationPolicy(fixture.repo, []),
-      /committed: apps\/desktop\/drizzle\/0001_release_only\.sql/,
+      /may upgrade the release database and prevent an older release from opening/,
     );
   } finally {
     fixture.cleanup();

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+	defaultIsolatedUserDataDir,
 	devEnvPrefix,
 	isRepositoryDesktopDevProcess,
 	formatDesktopStartupFailure,
@@ -23,6 +24,36 @@ import {
 	buildDesktopRestartSteps,
 	runDesktopRestart,
 } from "../desktop-restart-runner.mjs";
+
+test("isolated userData uses an absolute OS config root when env vars are absent", () => {
+	assert.equal(
+		defaultIsolatedUserDataDir("feature", {
+			env: {},
+			platform: "linux",
+			homedir: () => "/home/dev",
+		}),
+		"/home/dev/.config/Cindy-dev-feature",
+	);
+	assert.equal(
+		defaultIsolatedUserDataDir("feature", {
+			env: {},
+			platform: "win32",
+			homedir: () => String.raw`C:\Users\dev`,
+		}),
+		String.raw`C:\Users\dev\AppData\Roaming\Cindy-dev-feature`,
+	);
+	for (const platform of ["linux", "win32"]) {
+		assert.throws(
+			() =>
+				defaultIsolatedUserDataDir("feature", {
+					env: {},
+					platform,
+					homedir: () => "",
+				}),
+			/cannot resolve an absolute OS userData root/,
+		);
+	}
+});
 
 function appleScriptLines(args) {
 	const lines = [];

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -95,33 +94,23 @@ test("desktop restart runner keeps the kill-before-deps order by default", () =>
 	]);
 });
 
-test("desktop restart rejects an unmerged migration before the kill step", () => {
-	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "cindy-restart-policy-"));
+test("desktop restart blocks shared primary dev before the kill step", () => {
 	const calls = [];
-	try {
-		fs.mkdirSync(path.join(repo, "apps", "desktop", "drizzle"), { recursive: true });
-		fs.writeFileSync(path.join(repo, "apps", "desktop", "drizzle", "0000_init.sql"), "SELECT 0;\n");
-		const git = (...args) => {
-			const result = spawnSync("git", args, { cwd: repo, encoding: "utf8" });
-			assert.equal(result.status, 0, result.stderr);
-		};
-		git("init", "-b", "main");
-		git("config", "user.name", "Restart Policy Test");
-		git("config", "user.email", "restart-policy@example.invalid");
-		git("add", ".");
-		git("commit", "-m", "base");
-		git("update-ref", "refs/remotes/origin/main", "HEAD");
-		git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main");
-		git("switch", "-c", "feature");
-		fs.writeFileSync(path.join(repo, "apps", "desktop", "drizzle", "0001_feature.sql"), "SELECT 1;\n");
+	assert.throws(
+		() => runDesktopRestart(["--wait-ready"], "/repo/cindy", (step) => calls.push(step)),
+		/may upgrade the release database and prevent an older release from opening/,
+	);
+	assert.deepEqual(calls, []);
+});
 
-		assert.throws(
-			() => runDesktopRestart(["--wait-ready"], repo, (step) => calls.push(step)),
-			/Shared Cindy userData cannot run migration artifacts/,
+test("desktop restart allows isolated and passive dev modes", () => {
+	const root = "/repo/cindy";
+	for (const modeArg of ["--isolated=feature", "--passive", "--preserve-running"]) {
+		const calls = [];
+		assert.doesNotThrow(() =>
+			runDesktopRestart(["--wait-ready", modeArg], root, (step) => calls.push(step)),
 		);
-		assert.deepEqual(calls, []);
-	} finally {
-		fs.rmSync(repo, { recursive: true, force: true });
+		assert.ok(calls.length > 0, `${modeArg} should reach the restart pipeline`);
 	}
 });
 

--- a/scripts/dev-migration-policy.mjs
+++ b/scripts/dev-migration-policy.mjs
@@ -60,13 +60,16 @@ export function findUnmergedMigrationArtifacts(repoRoot) {
 export function usesIsolatedUserData(argv, env = process.env) {
   return (
     argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated=')) ||
-    env.XDT_ISOLATED === '1' ||
-    Boolean(env.XDT_USER_DATA_DIR?.trim())
+    env.XDT_ISOLATED === '1'
   );
 }
 
-export function usesPassiveUserData(argv) {
-  return argv.includes('--passive') || argv.includes('--preserve-running');
+export function usesPassiveUserData(argv, env = process.env) {
+  return (
+    argv.includes('--passive') ||
+    argv.includes('--preserve-running') ||
+    env.XDT_SCHEDULER_PASSIVE === '1'
+  );
 }
 
 /**
@@ -78,7 +81,7 @@ export function usesPassiveUserData(argv) {
  * Run this before the restart pipeline stops any existing Cindy instance.
  */
 export function assertSharedDevMigrationPolicy(_repoRoot, argv, env = process.env) {
-  if (usesIsolatedUserData(argv, env) || usesPassiveUserData(argv)) return;
+  if (usesIsolatedUserData(argv, env) || usesPassiveUserData(argv, env)) return;
   throw new Error(
     'Primary desktop dev cannot migrate shared Cindy userData because it may upgrade the release database and prevent an older release from opening it.\n' +
       'Use pnpm restart:desktop:remote -- --isolated=<name> for dev migrations, or --passive for a shared read-only preview.',

--- a/scripts/dev-migration-policy.mjs
+++ b/scripts/dev-migration-policy.mjs
@@ -1,6 +1,9 @@
 import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import path from 'node:path';
 
 const DRIZZLE_PATH = 'apps/desktop/drizzle';
+const SHARED_USER_DATA_DIR_NAME = 'Cindy';
 
 function git(repoRoot, args, { allowFailure = false } = {}) {
   const result = spawnSync('git', args, {
@@ -57,11 +60,52 @@ export function findUnmergedMigrationArtifacts(repoRoot) {
   };
 }
 
-export function usesIsolatedUserData(argv, env = process.env) {
+function defaultSharedUserDataDir(env, platform) {
+  if (platform === 'win32') {
+    const appData = env.APPDATA || path.join(env.USERPROFILE || '', 'AppData', 'Roaming');
+    return path.join(appData, SHARED_USER_DATA_DIR_NAME);
+  }
+  if (platform === 'darwin') {
+    return path.join(env.HOME || '', 'Library', 'Application Support', SHARED_USER_DATA_DIR_NAME);
+  }
+  const xdgConfig = env.XDG_CONFIG_HOME || path.join(env.HOME || '', '.config');
+  return path.join(xdgConfig, SHARED_USER_DATA_DIR_NAME);
+}
+
+function canonicalUserDataPath(value, { platform, realpath }) {
+  let canonical = path.resolve(value);
+  try {
+    canonical = realpath(canonical);
+  } catch {
+    // A not-yet-created directory still gets a stable lexical identity.
+  }
+  return platform === 'win32' || platform === 'darwin'
+    ? canonical.toLocaleLowerCase('en-US')
+    : canonical;
+}
+
+export function userDataOverrideTargetsSharedUserData(
+  override,
+  env = process.env,
+  {
+    platform = process.platform,
+    realpath = realpathSync.native,
+  } = {},
+) {
+  if (!override?.trim()) return false;
+  const options = { platform, realpath };
   return (
-    argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated=')) ||
-    env.XDT_ISOLATED === '1'
+    canonicalUserDataPath(override, options) ===
+    canonicalUserDataPath(defaultSharedUserDataDir(env, platform), options)
   );
+}
+
+export function usesIsolatedUserData(argv, env = process.env, options = {}) {
+  const declaredIsolated =
+    argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated=')) ||
+    env.XDT_ISOLATED === '1';
+  if (!declaredIsolated) return false;
+  return !userDataOverrideTargetsSharedUserData(env.XDT_USER_DATA_DIR, env, options);
 }
 
 export function usesPassiveUserData(argv, env = process.env) {
@@ -80,8 +124,13 @@ export function usesPassiveUserData(argv, env = process.env) {
  *
  * Run this before the restart pipeline stops any existing Cindy instance.
  */
-export function assertSharedDevMigrationPolicy(_repoRoot, argv, env = process.env) {
-  if (usesIsolatedUserData(argv, env) || usesPassiveUserData(argv, env)) return;
+export function assertSharedDevMigrationPolicy(
+  _repoRoot,
+  argv,
+  env = process.env,
+  options = {},
+) {
+  if (usesIsolatedUserData(argv, env, options) || usesPassiveUserData(argv, env)) return;
   throw new Error(
     'Primary desktop dev cannot migrate shared Cindy userData because it may upgrade the release database and prevent an older release from opening it.\n' +
       'Restart with --isolated=<name> for writable dev data, or use --passive / --preserve-running for a shared read-only preview.',

--- a/scripts/dev-migration-policy.mjs
+++ b/scripts/dev-migration-policy.mjs
@@ -84,6 +84,6 @@ export function assertSharedDevMigrationPolicy(_repoRoot, argv, env = process.en
   if (usesIsolatedUserData(argv, env) || usesPassiveUserData(argv, env)) return;
   throw new Error(
     'Primary desktop dev cannot migrate shared Cindy userData because it may upgrade the release database and prevent an older release from opening it.\n' +
-      'Use pnpm restart:desktop:remote -- --isolated=<name> for dev migrations, or --passive for a shared read-only preview.',
+      'Restart with --isolated=<name> for writable dev data, or use --passive / --preserve-running for a shared read-only preview.',
   );
 }

--- a/scripts/dev-migration-policy.mjs
+++ b/scripts/dev-migration-policy.mjs
@@ -57,26 +57,30 @@ export function findUnmergedMigrationArtifacts(repoRoot) {
   };
 }
 
-export function usesIsolatedUserData(argv) {
-  return argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated='));
+export function usesIsolatedUserData(argv, env = process.env) {
+  return (
+    argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated=')) ||
+    env.XDT_ISOLATED === '1' ||
+    Boolean(env.XDT_USER_DATA_DIR?.trim())
+  );
+}
+
+export function usesPassiveUserData(argv) {
+  return argv.includes('--passive') || argv.includes('--preserve-running');
 }
 
 /**
- * Shared userData may only execute migrations that are already canonical on origin/main.
+ * A primary dev process must never migrate the shared userData directory. The
+ * directory may belong to an older packaged release, and a migration from this
+ * checkout can make that release unable to open it. Passive previews remain
+ * read-only, while isolated dev gets its own migration history.
+ *
  * Run this before the restart pipeline stops any existing Cindy instance.
  */
-export function assertSharedDevMigrationPolicy(repoRoot, argv) {
-  if (usesIsolatedUserData(argv)) return;
-  const artifacts = findUnmergedMigrationArtifacts(repoRoot);
-  if (artifacts.committed.length === 0 && artifacts.workingTree.length === 0) return;
-  const detail = [
-    ...artifacts.committed.map((file) => `committed: ${file}`),
-    ...artifacts.workingTree.map((line) => `working tree: ${line}`),
-  ].join('\n  ');
+export function assertSharedDevMigrationPolicy(_repoRoot, argv, env = process.env) {
+  if (usesIsolatedUserData(argv, env) || usesPassiveUserData(argv)) return;
   throw new Error(
-    `Shared Cindy userData cannot run migration artifacts that are not canonical on ${artifacts.baseRef}.\n` +
-      `  ${detail}\n` +
-      'Rebase and renumber the migration before shared testing, or explicitly use a named sandbox: ' +
-      'pnpm restart:desktop:remote -- --isolated=<name>',
+    'Primary desktop dev cannot migrate shared Cindy userData because it may upgrade the release database and prevent an older release from opening it.\n' +
+      'Use pnpm restart:desktop:remote -- --isolated=<name> for dev migrations, or --passive for a shared read-only preview.',
   );
 }

--- a/scripts/dev-migration-policy.mjs
+++ b/scripts/dev-migration-policy.mjs
@@ -1,9 +1,17 @@
 import { spawnSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 const DRIZZLE_PATH = 'apps/desktop/drizzle';
-const SHARED_USER_DATA_DIR_NAME = 'Cindy';
+// Mirrors BRAND_IDENTITY.userDataDirNameByRegion + legacyUserDataDirNames.
+// scripts/__tests__/brand-identity-sync.test.mjs prevents drift from the TS source.
+export const PROTECTED_USER_DATA_DIR_NAMES = Object.freeze([
+  'Cindy',
+  'CindyGlobal',
+  'CindyDev',
+  'xdt-maker',
+]);
 
 function git(repoRoot, args, { allowFailure = false } = {}) {
   const result = spawnSync('git', args, {
@@ -60,20 +68,54 @@ export function findUnmergedMigrationArtifacts(repoRoot) {
   };
 }
 
-function defaultSharedUserDataDir(env, platform) {
+export function resolveDesktopUserDataRoot(
+  env = process.env,
+  platform = process.platform,
+  homedir = os.homedir,
+) {
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  const fallbackHome = () => {
+    try {
+      return homedir();
+    } catch {
+      return '';
+    }
+  };
+  let root;
   if (platform === 'win32') {
-    const appData = env.APPDATA || path.join(env.USERPROFILE || '', 'AppData', 'Roaming');
-    return path.join(appData, SHARED_USER_DATA_DIR_NAME);
+    if (env.APPDATA) {
+      root = env.APPDATA;
+    } else {
+      const home = env.USERPROFILE || fallbackHome();
+      root = home ? pathApi.join(home, 'AppData', 'Roaming') : '';
+    }
+  } else if (platform === 'darwin') {
+    const home = env.HOME || fallbackHome();
+    root = home ? pathApi.join(home, 'Library', 'Application Support') : '';
+  } else if (env.XDG_CONFIG_HOME) {
+    root = env.XDG_CONFIG_HOME;
+  } else {
+    const home = env.HOME || fallbackHome();
+    root = home ? pathApi.join(home, '.config') : '';
   }
-  if (platform === 'darwin') {
-    return path.join(env.HOME || '', 'Library', 'Application Support', SHARED_USER_DATA_DIR_NAME);
+  if (!root || !pathApi.isAbsolute(root)) {
+    throw new Error(
+      'cannot resolve an absolute OS userData root; set APPDATA/USERPROFILE on Windows, ' +
+        'HOME on macOS, or XDG_CONFIG_HOME/HOME on Linux',
+    );
   }
-  const xdgConfig = env.XDG_CONFIG_HOME || path.join(env.HOME || '', '.config');
-  return path.join(xdgConfig, SHARED_USER_DATA_DIR_NAME);
+  return root;
+}
+
+function defaultSharedUserDataDirs(env, platform, homedir) {
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  const root = resolveDesktopUserDataRoot(env, platform, homedir);
+  return PROTECTED_USER_DATA_DIR_NAMES.map((dirName) => pathApi.join(root, dirName));
 }
 
 function canonicalUserDataPath(value, { platform, realpath }) {
-  let canonical = path.resolve(value);
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  let canonical = pathApi.resolve(value);
   try {
     canonical = realpath(canonical);
   } catch {
@@ -90,20 +132,26 @@ export function userDataOverrideTargetsSharedUserData(
   {
     platform = process.platform,
     realpath = realpathSync.native,
+    homedir = os.homedir,
   } = {},
 ) {
   if (!override?.trim()) return false;
   const options = { platform, realpath };
+  const candidate = canonicalUserDataPath(override, options);
+  return defaultSharedUserDataDirs(env, platform, homedir).some(
+    (shared) => candidate === canonicalUserDataPath(shared, options),
+  );
+}
+
+function declaresIsolatedUserData(argv, env) {
   return (
-    canonicalUserDataPath(override, options) ===
-    canonicalUserDataPath(defaultSharedUserDataDir(env, platform), options)
+    argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated=')) ||
+    env.XDT_ISOLATED === '1'
   );
 }
 
 export function usesIsolatedUserData(argv, env = process.env, options = {}) {
-  const declaredIsolated =
-    argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated=')) ||
-    env.XDT_ISOLATED === '1';
+  const declaredIsolated = declaresIsolatedUserData(argv, env);
   if (!declaredIsolated) return false;
   return !userDataOverrideTargetsSharedUserData(env.XDT_USER_DATA_DIR, env, options);
 }
@@ -130,7 +178,11 @@ export function assertSharedDevMigrationPolicy(
   env = process.env,
   options = {},
 ) {
-  if (usesIsolatedUserData(argv, env, options) || usesPassiveUserData(argv, env)) return;
+  const declaredIsolated = declaresIsolatedUserData(argv, env);
+  if (usesIsolatedUserData(argv, env, options)) return;
+  // Passive may share release data only when it is not also claiming isolated
+  // semantics. The contradictory combination would leave migrations enabled.
+  if (!declaredIsolated && usesPassiveUserData(argv, env)) return;
   throw new Error(
     'Primary desktop dev cannot migrate shared Cindy userData because it may upgrade the release database and prevent an older release from opening it.\n' +
       'Restart with --isolated=<name> for writable dev data, or use --passive / --preserve-running for a shared read-only preview.',

--- a/scripts/help.mjs
+++ b/scripts/help.mjs
@@ -7,16 +7,16 @@ export function printHelp(log = console.log) {
   log('\n  桌面端启动:');
   log('    # 推荐：先清理已有 Cindy dev 进程，再启动远程 API 模式');
   log('    # 国内版，读取仓内 config/endpoint.json');
-  log('    pnpm restart:desktop:remote --region=cn --isolated=<name>');
+  log('    pnpm restart:desktop:remote --region=cn --isolated=cn-<name>');
   log('    # 海外版，读取仓内 config/endpoint.global.json');
-  log('    pnpm restart:desktop:remote --region=global --isolated=<name>');
+  log('    pnpm restart:desktop:remote --region=global --isolated=global-<name>');
   log('    # 海外版，读取对应区域的线上 CDN 端点清单');
-  log('    pnpm restart:desktop:remote --region=global --endpoints-cdn --isolated=<name>');
+  log('    pnpm restart:desktop:remote --region=global --endpoints-cdn --isolated=global-<name>');
   log('    # Human 可直接启动；不会先清旧进程，Agent 不要使用');
-  log('    pnpm dev:desktop:remote --region=cn --isolated=<name>');
-  log('    pnpm dev:desktop:remote --region=global --isolated=<name>');
+  log('    pnpm dev:desktop:remote --region=cn --isolated=cn-<name>');
+  log('    pnpm dev:desktop:remote --region=global --isolated=global-<name>');
   log('    # 连接本地 http://localhost:3333（只起客户端，不起 server）');
-  log('    pnpm restart:desktop:local --region=cn --isolated=<name>');
+  log('    pnpm restart:desktop:local --region=cn --isolated=cn-<name>');
 
   log('\n  Agent 二进制安装 / 升级（Claude Code、Codex、ripgrep）:');
   log('    # 按 latest.json 当前 pin 安装到本机，不修改 pin');

--- a/scripts/help.mjs
+++ b/scripts/help.mjs
@@ -7,16 +7,16 @@ export function printHelp(log = console.log) {
   log('\n  桌面端启动:');
   log('    # 推荐：先清理已有 Cindy dev 进程，再启动远程 API 模式');
   log('    # 国内版，读取仓内 config/endpoint.json');
-  log('    pnpm restart:desktop:remote --region=cn');
+  log('    pnpm restart:desktop:remote --region=cn --isolated=<name>');
   log('    # 海外版，读取仓内 config/endpoint.global.json');
-  log('    pnpm restart:desktop:remote --region=global');
+  log('    pnpm restart:desktop:remote --region=global --isolated=<name>');
   log('    # 海外版，读取对应区域的线上 CDN 端点清单');
-  log('    pnpm restart:desktop:remote --region=global --endpoints-cdn');
+  log('    pnpm restart:desktop:remote --region=global --endpoints-cdn --isolated=<name>');
   log('    # Human 可直接启动；不会先清旧进程，Agent 不要使用');
-  log('    pnpm dev:desktop:remote --region=cn');
-  log('    pnpm dev:desktop:remote --region=global');
+  log('    pnpm dev:desktop:remote --region=cn --isolated=<name>');
+  log('    pnpm dev:desktop:remote --region=global --isolated=<name>');
   log('    # 连接本地 http://localhost:3333（只起客户端，不起 server）');
-  log('    pnpm restart:desktop:local --region=cn');
+  log('    pnpm restart:desktop:local --region=cn --isolated=<name>');
 
   log('\n  Agent 二进制安装 / 升级（Claude Code、Codex、ripgrep）:');
   log('    # 按 latest.json 当前 pin 安装到本机，不修改 pin');

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveDesktopUserDataRoot } from './dev-migration-policy.mjs';
 import { applyDesktopDevStartupConfig } from './shared/desktop-dev-region.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -391,17 +392,17 @@ function closeDarwinTerminalTtys(ttys) {
  * `-<名字>` 后缀,每个名字一条完全独立的沙箱。只在 dev 生效——主进程入口只在
  * 非 packaged 时应用该覆写。
  */
-function defaultIsolatedUserDataDir(isolationName) {
+export function defaultIsolatedUserDataDir(
+  isolationName,
+  {
+    env = process.env,
+    platform = process.platform,
+    homedir = os.homedir,
+  } = {},
+) {
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
   const dirName = `${BRAND_USER_DATA_DIR_NAME}-dev${isolationName ? `-${isolationName}` : ''}`;
-  if (process.platform === 'win32') {
-    const appData = process.env.APPDATA || path.join(process.env.USERPROFILE || '', 'AppData', 'Roaming');
-    return path.join(appData, dirName);
-  }
-  if (process.platform === 'darwin') {
-    return path.join(process.env.HOME || '', 'Library', 'Application Support', dirName);
-  }
-  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME || '', '.config');
-  return path.join(xdgConfig, dirName);
+  return pathApi.join(resolveDesktopUserDataRoot(env, platform, homedir), dirName);
 }
 
 function devScriptForMode(mode) {


### PR DESCRIPTION
## 这次改了什么
### 摘要
禁止普通 primary dev 使用与 release 共享的 userData 执行 migration，避免新 checkout 升级数据库后旧 release 无法打开。
### 变更类型
- [x] ix 缺陷修复
### 范围
- 关联 Issue / 需求：#175
- 本 PR 包含：restart 前置政策、Electron 主进程启动拦截、回归测试和开发文档同步。
- 明确不包含：migration SQL、schema、updater 和 release 数据回滚。
- 用户可见变化：普通 dev 启动会提示使用 --isolated 或 --passive。
- 是否存在 breaking change：无。
### UI 变化
不涉及：仅修改终端启动提示和开发文档，无 UI 组件或交互布局变更。
- 引用的设计规范：不涉及。
## 怎么验证的
### 自动验证
`	ext
pnpm --filter desktop typecheck
pnpm test:unit
node --test scripts/__tests__/dev-migration-policy.test.mjs scripts/__tests__/restart-desktop-remote.test.mjs
结果：通过。
`
### 手工验证
未执行：本 PR 不涉及 UI 或打包运行验证。
### 未执行的验证
无。
## 风险
### 风险分类
- [x] SQLite / migration
- [x] 权限 / 安全 / 用户数据
### 影响与回滚
- 影响范围：仅 dev 启动流程；packaged release 不受影响。
- 回滚 / 降级方式：回滚本 PR 即可恢复原有启动行为。
### 提交前检查
- [x] 已 review 完整 diff
- [x] UI 改动已标注（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果