### PR TITLE
fix(mobile): 用 hideKeyboardAccessoryView 去掉会话输入框的键盘导航条，撤销 #390

### DIFF
--- a/apps/mobile/src/session/ComposerRichInput.tsx
+++ b/apps/mobile/src/session/ComposerRichInput.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import { File, Paths } from 'expo-file-system';
 import * as Clipboard from 'expo-clipboard';
@@ -366,7 +366,10 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
         // 完成),iOS 26 起画成键盘上方的独立浮动胶囊。composer 只有这一个字段,
         // 前后导航恒为禁用态,整条对用户没有任何价值却占掉一行。RN TextInput
         // 没有这条,所以只有会话页这个富文本输入框会出现。
-        hideKeyboardAccessoryView
+        //
+        // 仅 iPhone:iPad 上同一个 accessory view 承载撤销 / 重做 / 粘贴等真实
+        // 编辑能力(本 app app.json 声明了 supportsTablet),清掉是功能回退。
+        hideKeyboardAccessoryView={Platform.OS === 'ios' && !Platform.isPad}
         javaScriptEnabled
         keyboardDisplayRequiresUserAction={false}
         onMessage={handleMessage}

--- a/apps/mobile/src/session/ComposerRichInput.tsx
+++ b/apps/mobile/src/session/ComposerRichInput.tsx
@@ -362,6 +362,11 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
         accessibilityHint={accessibilityHint}
         accessibilityLabel={accessibilityLabel}
         allowFileAccess={false}
+        // iOS 给 WKWebView 里的可编辑区域挂一条系统表单导航条(上一项 / 下一项 /
+        // 完成),iOS 26 起画成键盘上方的独立浮动胶囊。composer 只有这一个字段,
+        // 前后导航恒为禁用态,整条对用户没有任何价值却占掉一行。RN TextInput
+        // 没有这条,所以只有会话页这个富文本输入框会出现。
+        hideKeyboardAccessoryView
         javaScriptEnabled
         keyboardDisplayRequiresUserAction={false}
         onMessage={handleMessage}

--- a/dependency-patches/README.md
+++ b/dependency-patches/README.md
@@ -10,7 +10,7 @@
 
 | 依赖 | 用途 |
 | --- | --- |
-| `expo-paste-input@0.2.2` | 优化移动端粘贴图片的处理时序，将耗时的解码、压缩和写盘移出 UI 线程，并补充加载中与失败事件；同时在 iPhone 上清空被接管输入框的 iOS `inputAssistantItem`，去掉系统在键盘上方多挂的一条只有禁用态上下箭头和「完成」的表单导航条（iPad 的辅助条含撤销／重做／粘贴等实际功能，保持不动）。 |
+| `expo-paste-input@0.2.2` | 优化移动端粘贴图片的处理时序，将耗时的解码、压缩和写盘移出 UI 线程，并补充加载中与失败事件。 |
 | `harmonyos-sans-sc-webfont-splitted` | 移除依赖按语言全局覆盖 `font-family` 的规则，由 Cindy 自己决定界面字体。 |
 | `react-native@0.85.3` | 回移 Yoga 对 `display: none` 与 `display: contents` 测量过程的布局状态修复，避免 Fabric 布局阶段因错误的 owner 关系触发断言崩溃（上游 `6fa330693fba313a2fe1121545c1efd558b60983`、`2546ce4d8219050fcd1bf432c7c830c9fd70c9af`）。移动端 iOS 通过 `expo-build-properties` 的 `buildReactNativeFromSource` 编译该补丁，不能改回预编译 RN Core。 |
 | `react-native-uitextview@2.2.0` | 修复 iOS 长文本渲染闪烁、布局性能、文本选择与选择手柄滚动等问题，并支持自定义选择菜单操作。 |

--- a/dependency-patches/expo-paste-input@0.2.2.patch
+++ b/dependency-patches/expo-paste-input@0.2.2.patch
@@ -159,65 +159,10 @@ index 4c430a252ef3e938622e6c56421ed283c6167913..4d5c561a5d117e7459cb0f83ca1c213c
      type: "unsupported";
  };
 diff --git a/ios/ExpoPasteInputView.swift b/ios/ExpoPasteInputView.swift
-index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d893d2716f 100644
+index 39b2302ed42bdd56db6084e333b9581e08c18689..c08b8ba08ebb9650d7a013ac7257dc58832f8c3d 100644
 --- a/ios/ExpoPasteInputView.swift
 +++ b/ios/ExpoPasteInputView.swift
-@@ -38,6 +38,8 @@ class ExpoPasteInputView: ExpoView {
-   private weak var observedTextView: UITextView?
-   private var isSanitizingAttachments: Bool = false
-   private var originalAdaptiveImageGlyphSupport: Bool?
-+  private var originalLeadingBarButtonGroups: [UIBarButtonItemGroup]?
-+  private var originalTrailingBarButtonGroups: [UIBarButtonItemGroup]?
-   private let gifTypes: Set<String> = ["com.compuserve.gif", "public.gif", "image/gif"]
-   private let webpTypes: Set<String> = ["org.webmproject.webp", "public.webp", "image/webp"]
-   // Track which classes have been swizzled (once per class, never unswizzle)
-@@ -145,6 +147,27 @@ class ExpoPasteInputView: ExpoView {
-       originalAdaptiveImageGlyphSupport = nil
-     }
- 
-+    // Recent iOS versions attach the system form-navigation shortcuts bar to
-+    // the inputs this wrapper takes over, drawn since iOS 26 as a standalone
-+    // floating capsule above the keyboard. A single-field composer therefore
-+    // gets an extra row holding nothing but permanently disabled prev/next
-+    // chevrons and a Done checkmark. Drop both groups so the bar goes away.
-+    // This must be an empty array — a UIBarButtonItemGroup with no items
-+    // hides the buttons but keeps the bar itself taking up space. Reported on
-+    // iOS 27; does not reproduce on the iOS 26.5 iPhone simulator.
-+    //
-+    // iPhone only: on iPad the shortcuts bar is a permanent part of the
-+    // keyboard and carries real editing affordances (undo/redo, paste,
-+    // formatting), so clearing it there would take away working functionality
-+    // rather than an empty row. restoreTextInput() keys off the saved groups
-+    // being non-nil, so skipping the capture here also skips the restore.
-+    if UIDevice.current.userInterfaceIdiom == .phone {
-+      originalLeadingBarButtonGroups = view.inputAssistantItem.leadingBarButtonGroups
-+      originalTrailingBarButtonGroups = view.inputAssistantItem.trailingBarButtonGroups
-+      view.inputAssistantItem.leadingBarButtonGroups = []
-+      view.inputAssistantItem.trailingBarButtonGroups = []
-+    }
-+
-     if let textView = view as? UITextView {
-       observeTextViewChanges(for: textView)
-     } else {
-@@ -162,6 +185,17 @@ class ExpoPasteInputView: ExpoView {
-     }
-     originalAdaptiveImageGlyphSupport = nil
- 
-+    // Fabric recycles backing text views across TextInput instances, so hand
-+    // the shortcuts bar back exactly as we found it.
-+    if let originalLeadingBarButtonGroups {
-+      view.inputAssistantItem.leadingBarButtonGroups = originalLeadingBarButtonGroups
-+    }
-+    if let originalTrailingBarButtonGroups {
-+      view.inputAssistantItem.trailingBarButtonGroups = originalTrailingBarButtonGroups
-+    }
-+    originalLeadingBarButtonGroups = nil
-+    originalTrailingBarButtonGroups = nil
-+
-     if let textView = view as? UITextView,
-        observedTextView === textView {
-       stopObservingTextView()
-@@ -252,77 +286,20 @@ class ExpoPasteInputView: ExpoView {
+@@ -252,77 +252,20 @@ class ExpoPasteInputView: ExpoView {
            }
            
            let pasteboard = UIPasteboard.general
@@ -309,7 +254,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d8
              return // Don't call original paste for images
            }
            
-@@ -550,12 +527,80 @@ class ExpoPasteInputView: ExpoView {
+@@ -550,7 +493,12 @@ class ExpoPasteInputView: ExpoView {
      emitImagesAsync(for: mediaPayloads)
    }
  
@@ -319,19 +264,14 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d8
 +  // happen on the background queue.
    private func emitImagesAsync(for payloads: [MediaPayload]) {
 +    emitImagesLoading(count: payloads.count)
-+    mediaProcessingQueue.async { [weak self] in
-+      guard let self else {
-+        return
-+      }
-+
-+      let uris = self.temporaryFileURIs(for: payloads)
-+
-+      DispatchQueue.main.async { [weak self] in
-+        guard let self else {
-+          return
-+        }
-+
-+        if uris.isEmpty {
+     mediaProcessingQueue.async { [weak self] in
+       guard let self else {
+         return
+@@ -564,7 +512,70 @@ class ExpoPasteInputView: ExpoView {
+         }
+ 
+         if uris.isEmpty {
+-          self.handleUnsupportedPaste()
 +          // A placeholder was already emitted — resolve it as failed instead
 +          // of the generic unsupported event so JS can retract the cards.
 +          self.emitImagesLoadFailed()
@@ -374,11 +314,11 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d8
 +    // UIPasteboard keeps no history, so the original data is gone — resolve
 +    // the placeholder as failed instead of mis-attaching the wrong image.
 +    let capturedChangeCount = UIPasteboard.general.changeCount
-     mediaProcessingQueue.async { [weak self] in
-       guard let self else {
-         return
-       }
- 
++    mediaProcessingQueue.async { [weak self] in
++      guard let self else {
++        return
++      }
++
 +      guard UIPasteboard.general.changeCount == capturedChangeCount else {
 +        DispatchQueue.main.async { [weak self] in
 +          self?.emitImagesLoadFailed()
@@ -387,19 +327,19 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d8
 +      }
 +
 +      let payloads = self.collectPasteboardMediaPayloads()
-       let uris = self.temporaryFileURIs(for: payloads)
- 
-       DispatchQueue.main.async { [weak self] in
-@@ -564,7 +609,7 @@ class ExpoPasteInputView: ExpoView {
-         }
- 
-         if uris.isEmpty {
--          self.handleUnsupportedPaste()
++      let uris = self.temporaryFileURIs(for: payloads)
++
++      DispatchQueue.main.async { [weak self] in
++        guard let self else {
++          return
++        }
++
++        if uris.isEmpty {
 +          self.emitImagesLoadFailed()
            return
          }
  
-@@ -700,8 +745,11 @@ class ExpoPasteInputView: ExpoView {
+@@ -700,8 +711,11 @@ class ExpoPasteInputView: ExpoView {
      return true
    }
    
@@ -413,7 +353,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d8
      let pasteboard = UIPasteboard.general
      
      let staticImageTypes = [
-@@ -832,15 +880,7 @@ class ExpoPasteInputView: ExpoView {
+@@ -832,15 +846,7 @@ class ExpoPasteInputView: ExpoView {
        staticImagePayloads.append(.image(image))
      }
      
@@ -430,7 +370,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d8
    }
    
    /// Detects if the given data is a GIF by checking for GIF87a or GIF89a header
-@@ -922,6 +962,23 @@ class ExpoPasteInputView: ExpoView {
+@@ -922,6 +928,23 @@ class ExpoPasteInputView: ExpoView {
      ])
    }
  
@@ -454,7 +394,7 @@ index 39b2302ed42bdd56db6084e333b9581e08c18689..4479d6d3dd64350355008689871132d8
    private func temporaryFileURIs(for payloads: [MediaPayload]) -> [String] {
      var uris: [String] = []
  
-@@ -1013,15 +1070,6 @@ class ExpoPasteInputView: ExpoView {
+@@ -1013,15 +1036,6 @@ class ExpoPasteInputView: ExpoView {
      stopMonitoring()
      stopObservingTextView()
    }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
 
 patchedDependencies:
   expo-paste-input@0.2.2:
-    hash: d3eb498564b85f9db254b4ccc74c3398d8f45706a8dd2e37f194f22992a00387
+    hash: 53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8
     path: dependency-patches/expo-paste-input@0.2.2.patch
   harmonyos-sans-sc-webfont-splitted:
     hash: 272e3ded46880ee2f9eaff39327b8465de6df4072271de03caf73950e6e57822
@@ -600,7 +600,7 @@ importers:
         version: 56.0.22(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-paste-input:
         specifier: 0.2.2
-        version: 0.2.2(patch_hash=d3eb498564b85f9db254b4ccc74c3398d8f45706a8dd2e37f194f22992a00387)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 0.2.2(patch_hash=53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-router:
         specifier: ^56.2.11
         version: 56.2.15(600de089274a49ab6ec9549ee6c8284a)
@@ -17020,7 +17020,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-paste-input@0.2.2(patch_hash=d3eb498564b85f9db254b4ccc74c3398d8f45706a8dd2e37f194f22992a00387)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  expo-paste-input@0.2.2(patch_hash=53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8)(expo@56.0.16)(react-native@0.85.3(patch_hash=9442031604caa9cd185e0b2be6867055459fc3a6d2781296027989db098f972d)(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       expo: 56.0.16(bedb3dfb85b4bb5081482612eab0a2c6)
       react: 19.2.3


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 #390：那个 PR 的**根因判断是错的，改动无效**。本 PR 撤销它，换成真正有效的一行修复。

**真正的根因**：会话页的 composer 不是 RN `TextInput`，而是一个 `react-native-webview` 的可编辑
WebView（`ComposerRichInput`）。iOS 会给 WKWebView 里的可编辑区域挂一条系统表单导航条
（上一项 / 下一项 / 完成），iOS 26 起画成键盘上方的独立浮动胶囊。composer 只有这一个字段，
前后导航恒为禁用态，整条对用户毫无价值却占掉一行。RN `TextInput` 在 iPhone 上没有这条——
这正好解释了用户观察到的「只有对话内的回复输入框有，其它输入框都没有」。

**#390 为什么无效**：它改的是 `expo-paste-input` 的 `TextInputWrapper`（清空 `inputAssistantItem`），
但 `MobileComposerInputRow.tsx:264` 是 `inputElement ?? (onPasteImages ? <TextInputWrapper>…)`
——会话页传了 `inputElement={<ComposerRichInput/>}`（`app/sessions/[sessionId].tsx:7041`），
**直接绕过 wrapper**。也就是说 #390 的改动这条路径根本不经过会话页；它只作用于新建会话页的
RN TextInput，而那里本来就没有这条 bar。

**本 PR 的修法**：给这个 WebView 加 `hideKeyboardAccessoryView`
（`react-native-webview` 的 iOS prop，原生侧 swizzle `WKContentView` 的 `inputAccessoryView`
返回 nil，见 `node_modules/react-native-webview/apple/RNCWebViewImpl.m:1013`）。只影响这一个
WebView 实例，不碰其它 WebView。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：修正 #390（已合并的错误修复）
- 本 PR 包含：`revert` #390 的全部改动（`dependency-patches/expo-paste-input@0.2.2.patch`、
  `dependency-patches/README.md`、`pnpm-lock.yaml` 回到 #390 之前）；
  `apps/mobile/src/session/ComposerRichInput.tsx` 给 WebView 加 `hideKeyboardAccessoryView`
  （限 iPhone：`Platform.OS === 'ios' && !Platform.isPad`）。
- 明确不包含：不改其它 WebView（`MarkdownFileReader`、`AnnotationBurnInWebView` 等），
  不改新建会话页的 RN TextInput 路径，不改粘贴 / Genmoji 链路。
- 用户可见变化：iPhone 上会话页输入框聚焦时，键盘上方不再出现那条只有禁用箭头和「完成」勾
  的条；iPad 无变化。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：本改动只移除 iOS 系统键盘辅助条，不新增或修改任何 Cindy 自绘
  界面、布局、样式或文案。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全绿（GATE_EXIT=0）

pnpm --filter mobile run --if-present typecheck
结果：通过（tsc --noEmit 无输出）
```

### 手工验证

平台：**iOS 27.0 iPhone 17 Pro 模拟器**（runtime 24A5390f）——即问题报告的同一个大版本。
worktree `dash/fix-composer-webview-keyboard-accessory`，Metro 归属本 worktree 的 8081，
`mobile:sim:whoami` PASS（源码指纹 `f5da2b646+beb24bfcd3`）。

1. **会话页 composer（本 PR 修的目标）**：同一台 iOS 27 模拟器上，
   - 加 prop 前：聚焦输入框 → 键盘上方出现那条 `^ ∨ ✓` 胶囊（复现成功）
   - 加 prop 后（Fast Refresh）：同一会话、同一输入框 → **那条消失**，键盘直接贴住输入框
2. **新建会话页 composer（RN TextInput）**：iOS 27 上聚焦输入框，无该条。
3. **登录页手机号输入框（纯 RN TextInput，不经任何本次改动的路径）**：iOS 27 上聚焦，无该条，
   只有 RN 自己为数字键盘挂的 "Go" 按钮（`RCTTextInputComponentView.mm:644` 的既有行为）。
   这条佐证了 RN TextInput 在 iOS 27 iPhone 上**本来就不显示**这条 bar，因此撤销 #390 的原生
   改动不会让任何 TextInput 冒出这条。
4. 原生包在撤销 #390 后重新构建（`mobile:sim:rebuild`）通过并安装启动正常。

### 未执行的验证

- 撤销 #390 后**没有**在 iOS 27 上再单独复测一次新建会话页的 composer：该设备在验证后期
  连不上可控电脑（会话列表为空、进不去新建页）。依据是上面第 3 条——不走 wrapper 的纯 RN
  TextInput 在 iOS 27 上就没有这条 bar，而 #390 的原生改动只作用于 wrapper 接管的输入框，
  故撤销它不改变 TextInput 的表现。
- 未在 iOS 27 **真机**上复核（本机只有模拟器 runtime）。模拟器已能稳定复现并验证该问题，
  证据强度足够。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 iOS 会话页的 composer WebView，且仅 iPhone（iPad 保留系统 accessory view，
  那里承载撤销／重做／粘贴等真实编辑能力）。Android 不受影响
  （`hideKeyboardAccessoryView` 是 iOS-only prop）。
- **fingerprint 与 OTA 送达**：新增的那个 prop 是纯 JS、不影响 runtime fingerprint；但本 PR
  同时撤销了 #390 的原生 patch，相对当前 `main` 是会改变 fingerprint 的。这**恰恰是让修复能
  通过 OTA 送达存量装机的必要条件**：
  - 存量装机的基线是 `apps/mobile/app.json` 的 `buildNumber: "2026072301"`，即 **07-23** 出的包；
  - #390 合并于 **07-25 14:03:49 +0800**（merge commit `c0b4a2b`），晚于该出包时间；且
    `git log c0b4a2b..origin/main -- apps/mobile/app.json apps/mobile/android-version.json`
    为空——#390 之后没有出过新包；
  - 所以存量装机的原生态 = #390 **之前**的状态。撤销 #390 让仓库回到同一状态、fingerprint
    与存量包对齐，OTA 可达；反过来**保留** #390 的原生 patch 才会造成 fingerprint 不一致，
    使这次键盘修复送不出去、必须等冷更。
  - 最终判定以 `pnpm mobile:release:check` 与 CI fingerprint guard 为准。
- 回滚 / 降级方式：移除该 prop 即可，纯增量、无状态、无迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

