### PR TITLE
fix(desktop): 点 composer 空白区可进入输入且不移动光标

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -136,6 +136,11 @@ import {
 import { upgradePastedPathsToChips, type PendingPathRange } from './pathPaste';
 import { docContainsAtomChip } from './composerDocState';
 import {
+  isComposerBlankPointerTarget,
+  isInteractiveFocusedElement,
+  resolveComposerBlankFocusIntent,
+} from './composerBlankPointerFocus';
+import {
   applyPastedTextChipEdit,
   PastedTextChipNode,
   replacePastedTextChipWithPlainText,
@@ -143,6 +148,7 @@ import {
 } from './PastedTextChipNode';
 import { ToolPayloadLightbox } from '@/components/chat/ToolPayloadLightbox';
 import { Fragment, Slice, type Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Selection } from '@tiptap/pm/state';
 import * as sessionService from '@/lib/sessionService';
 import { getModelById } from '@/lib/modelDefinitions';
 import { loadAllCommands, filterSlashCommands, type UnifiedCommand } from '@/lib/slashCommands';
@@ -608,28 +614,6 @@ function scrollVoiceInputDraftEndIntoView(editor: Editor): void {
   } else if (draftBox.bottom < scrollerBox.top + PAD) {
     scroller.scrollTop -= scrollerBox.top + PAD - draftBox.bottom;
   }
-}
-
-function isInteractiveFocusedElement(element: Element | null): boolean {
-  if (!(element instanceof HTMLElement)) return false;
-  if (element.isContentEditable) return true;
-  const tagName = element.tagName.toLowerCase();
-  if (['button', 'input', 'select', 'textarea'].includes(tagName)) return true;
-  if (tagName === 'a' && element.hasAttribute('href')) return true;
-  if (element.tabIndex >= 0) return true;
-  const role = element.getAttribute('role');
-  return (
-    role === 'button' ||
-    role === 'textbox' ||
-    role === 'searchbox' ||
-    role === 'combobox' ||
-    role === 'menuitem' ||
-    role === 'tab' ||
-    role === 'checkbox' ||
-    role === 'radio' ||
-    role === 'switch' ||
-    role === 'option'
-  );
 }
 
 function hasFocusMovedToInteractiveElement(focusAnchor: Element | null, editor: Editor): boolean {
@@ -4976,6 +4960,36 @@ export function ChatInput({
                       : 'focus-within:border-[var(--chat-input-border-focus)]',
                   ],
             )}
+            // 卡片里的空白(文字行下方的空隙、工具栏两组按钮之间的空档、四周
+            // padding)没有元素承接点击:浏览器默认会把焦点从 contenteditable 撤到
+            // <body>,正在输入的光标凭空消失;而点空白又该能进入输入态。所以先
+            // preventDefault 掉这次默认的焦点转移,再按需补一次不带坐标的 focus ——
+            // 「进入输入态」归空白区,「定位插入点」只归点击文字那一行。
+            onMouseDown={(event) => {
+              if (event.button !== 0) return;
+              if (
+                !isComposerBlankPointerTarget(
+                  event.target,
+                  event.currentTarget,
+                  editor && !editor.isDestroyed ? editor.view.dom : null,
+                  event,
+                )
+              ) {
+                return;
+              }
+              event.preventDefault();
+              if (!editor || editor.isDestroyed) return;
+              const { selection, doc } = editor.state;
+              const intent = resolveComposerBlankFocusIntent({
+                isDestroyed: editor.isDestroyed,
+                isEditable: editor.isEditable,
+                isFocused: editor.isFocused,
+                caretAtDocStart:
+                  selection.empty && selection.from === Selection.atStart(doc).from,
+              });
+              if (intent === 'keep-caret') editor.commands.focus();
+              else if (intent === 'doc-end') editor.commands.focus('end');
+            }}
             onDragEnter={(e) => {
               e.preventDefault();
               e.stopPropagation();

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerBlankPointerFocus.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerBlankPointerFocus.test.ts
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  isComposerBlankPointerTarget,
+  isInteractiveFocusedElement,
+  resolveComposerBlankFocusIntent,
+  type ComposerFocusSnapshot,
+} from '../composerBlankPointerFocus';
+
+/**
+ * 搭一个跟 ChatInput 输入卡片同形的最小 DOM:
+ *
+ *   card (min-h 撑高 + justify-between → 内部有空白),视口矩形 0,0 → 420,86
+ *   ├── overlay                   absolute bottom-full 悬浮预览(视觉上在卡片上方)
+ *   │   └── overlayText
+ *   ├── thumbnails
+ *   │   └── img[draggable]        附件缩略图,靠原生拖拽换位
+ *   ├── editorHost
+ *   │   └── editor (.ProseMirror) → 内含一行文字
+ *   ├── blank                     文字行与工具栏之间的空隙
+ *   └── toolbar                   两组按钮 + 中间空档
+ *       ├── button > buttonIcon
+ *       ├── roleButton
+ *       ├── tabbable
+ *       └── toolbarGap
+ *
+ * 注意两处 jsdom 限制,也正是被测函数收 editorDom / point 两个显式参数的原因:
+ * - jsdom 不实现 contentEditable / isContentEditable,「编辑器内」只能靠显式传入
+ *   的 editorDom 判定;
+ * - jsdom 不做布局,getBoundingClientRect 恒为全 0,这里给 card 打桩成真实几何。
+ */
+function buildCard() {
+  const outside = document.createElement('div');
+  const card = document.createElement('div');
+
+  const thumbnails = document.createElement('div');
+  const thumbnail = document.createElement('img');
+  thumbnail.draggable = true;
+  thumbnails.append(thumbnail);
+
+  const editorHost = document.createElement('div');
+  const editor = document.createElement('div');
+  editor.className = 'ProseMirror';
+  const editorText = document.createElement('p');
+  editorText.textContent = 'hello';
+  editor.append(editorText);
+  editorHost.append(editor);
+
+  const blank = document.createElement('div');
+
+  const toolbar = document.createElement('div');
+  const button = document.createElement('button');
+  const buttonIcon = document.createElement('span');
+  button.append(buttonIcon);
+  const roleButton = document.createElement('div');
+  roleButton.setAttribute('role', 'button');
+  const tabbable = document.createElement('div');
+  tabbable.tabIndex = 0;
+  const toolbarGap = document.createElement('div');
+  toolbar.append(button, roleButton, tabbable, toolbarGap);
+
+  const overlay = document.createElement('div');
+  const overlayText = document.createElement('span');
+  overlayText.textContent = 'comment preview';
+  overlay.append(overlayText);
+
+  card.append(overlay, thumbnails, editorHost, blank, toolbar);
+  document.body.append(outside, card);
+
+  // jsdom 不做布局:给卡片打桩成 420x86 的视口矩形(与真实 min-h-[86px] 一致)。
+  card.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 420,
+      bottom: 86,
+      width: 420,
+      height: 86,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
+  return {
+    card,
+    editor,
+    editorText,
+    editorHost,
+    blank,
+    toolbar,
+    toolbarGap,
+    button,
+    buttonIcon,
+    roleButton,
+    tabbable,
+    thumbnail,
+    overlay,
+    overlayText,
+    outside,
+  };
+}
+
+/** 卡片矩形内部的一点(默认落在文字行与工具栏之间那条空隙上)。 */
+const INSIDE = { clientX: 210, clientY: 40 };
+/** 卡片矩形上方的一点 —— 悬浮预览(absolute bottom-full)所在的视觉区域。 */
+const ABOVE_CARD = { clientX: 210, clientY: -30 };
+
+describe('isComposerBlankPointerTarget', () => {
+  it('把卡片空白、编辑器外壳与工具栏空档判为空白', () => {
+    const dom = buildCard();
+
+    // 文字行下方的空隙、工具栏两组按钮之间的空档、卡片自身(四周 padding)都是
+    // 「点了就丢焦点」的死区,全部要判为空白。
+    expect(isComposerBlankPointerTarget(dom.card, dom.card, dom.editor, INSIDE)).toBe(true);
+    expect(isComposerBlankPointerTarget(dom.blank, dom.card, dom.editor, INSIDE)).toBe(true);
+    expect(isComposerBlankPointerTarget(dom.toolbar, dom.card, dom.editor, INSIDE)).toBe(true);
+    expect(isComposerBlankPointerTarget(dom.toolbarGap, dom.card, dom.editor, INSIDE)).toBe(true);
+    // 编辑器外壳(EditorContent 的包装层,负 margin 破出的那一圈)也是空白。
+    expect(isComposerBlankPointerTarget(dom.editorHost, dom.card, dom.editor, INSIDE)).toBe(true);
+  });
+
+  it('放过编辑器自身与其内部节点,让 ProseMirror 自己定位光标', () => {
+    const dom = buildCard();
+
+    expect(isComposerBlankPointerTarget(dom.editor, dom.card, dom.editor, INSIDE)).toBe(false);
+    expect(isComposerBlankPointerTarget(dom.editorText, dom.card, dom.editor, INSIDE)).toBe(false);
+  });
+
+  it('放过交互控件及其内部图标,不夺按钮的 mousedown', () => {
+    const dom = buildCard();
+
+    expect(isComposerBlankPointerTarget(dom.button, dom.card, dom.editor, INSIDE)).toBe(false);
+    expect(isComposerBlankPointerTarget(dom.buttonIcon, dom.card, dom.editor, INSIDE)).toBe(false);
+    expect(isComposerBlankPointerTarget(dom.roleButton, dom.card, dom.editor, INSIDE)).toBe(false);
+    expect(isComposerBlankPointerTarget(dom.tabbable, dom.card, dom.editor, INSIDE)).toBe(false);
+  });
+
+  it('放过可拖拽元素,附件缩略图仍能拖动换位', () => {
+    const dom = buildCard();
+
+    expect(isComposerBlankPointerTarget(dom.thumbnail, dom.card, dom.editor, INSIDE)).toBe(false);
+  });
+
+  it('放过卡片矩形之外的悬浮预览,那里的文字仍可拖选', () => {
+    const dom = buildCard();
+
+    // overlay 在 DOM 上是卡片后代,但 absolute bottom-full 让它飘在卡片上方;
+    // 死区只在卡片矩形内,浮层上的 mousedown 必须原样交给浏览器。
+    expect(isComposerBlankPointerTarget(dom.overlay, dom.card, dom.editor, ABOVE_CARD)).toBe(false);
+    expect(isComposerBlankPointerTarget(dom.overlayText, dom.card, dom.editor, ABOVE_CARD)).toBe(
+      false,
+    );
+    // 同一个 overlay 元素,落点回到卡片矩形内就仍按空白处理(纯几何判定,不看身份)。
+    expect(isComposerBlankPointerTarget(dom.overlay, dom.card, dom.editor, INSIDE)).toBe(true);
+  });
+
+  it('卡片矩形四边之外的落点一律不算空白', () => {
+    const dom = buildCard();
+
+    expect(isComposerBlankPointerTarget(dom.blank, dom.card, dom.editor, ABOVE_CARD)).toBe(false);
+    expect(
+      isComposerBlankPointerTarget(dom.blank, dom.card, dom.editor, { clientX: 210, clientY: 120 }),
+    ).toBe(false);
+    expect(
+      isComposerBlankPointerTarget(dom.blank, dom.card, dom.editor, { clientX: -5, clientY: 40 }),
+    ).toBe(false);
+    expect(
+      isComposerBlankPointerTarget(dom.blank, dom.card, dom.editor, { clientX: 500, clientY: 40 }),
+    ).toBe(false);
+    // 边界(含边)算内部:卡片边缘那一像素也是死区。
+    expect(
+      isComposerBlankPointerTarget(dom.blank, dom.card, dom.editor, { clientX: 0, clientY: 86 }),
+    ).toBe(true);
+  });
+
+  it('卡片外的落点与非 Element 目标一律不算空白', () => {
+    const dom = buildCard();
+
+    expect(isComposerBlankPointerTarget(dom.outside, dom.card, dom.editor, INSIDE)).toBe(false);
+    expect(isComposerBlankPointerTarget(null, dom.card, dom.editor, INSIDE)).toBe(false);
+    expect(isComposerBlankPointerTarget(document, dom.card, dom.editor, INSIDE)).toBe(false);
+    expect(isComposerBlankPointerTarget(window, dom.card, dom.editor, INSIDE)).toBe(false);
+  });
+
+  it('编辑器还没挂载(editorDom 为 null)时,空白判定依旧生效', () => {
+    const dom = buildCard();
+
+    expect(isComposerBlankPointerTarget(dom.blank, dom.card, null, INSIDE)).toBe(true);
+    expect(isComposerBlankPointerTarget(dom.button, dom.card, null, INSIDE)).toBe(false);
+  });
+});
+
+describe('isInteractiveFocusedElement', () => {
+  it('认按钮 / 表单控件 / 带 href 的链接 / 可聚焦项 / ARIA 控件', () => {
+    const button = document.createElement('button');
+    const input = document.createElement('input');
+    const select = document.createElement('select');
+    const textarea = document.createElement('textarea');
+    const linkWithHref = document.createElement('a');
+    linkWithHref.setAttribute('href', '#');
+    const tabbable = document.createElement('div');
+    tabbable.tabIndex = 0;
+    const switchRole = document.createElement('div');
+    switchRole.setAttribute('role', 'switch');
+
+    for (const element of [button, input, select, textarea, linkWithHref, tabbable, switchRole]) {
+      expect(isInteractiveFocusedElement(element)).toBe(true);
+    }
+  });
+
+  // 无 href 的 <a> 不在这里断言:真实浏览器给它 tabIndex = -1(不可聚焦),jsdom
+  // 却报 0,断言只会测出 jsdom 的偏差。composer 里也没有裸 <a>。
+  it('不认纯装饰节点、负 tabIndex 与非元素', () => {
+    const plain = document.createElement('div');
+    const negativeTab = document.createElement('div');
+    negativeTab.tabIndex = -1;
+
+    expect(isInteractiveFocusedElement(plain)).toBe(false);
+    expect(isInteractiveFocusedElement(negativeTab)).toBe(false);
+    expect(isInteractiveFocusedElement(null)).toBe(false);
+    expect(isInteractiveFocusedElement(document.createTextNode('x') as unknown as Element)).toBe(
+      false,
+    );
+  });
+});
+
+describe('resolveComposerBlankFocusIntent', () => {
+  const snapshot = (patch: Partial<ComposerFocusSnapshot> = {}): ComposerFocusSnapshot => ({
+    isDestroyed: false,
+    isEditable: true,
+    isFocused: false,
+    caretAtDocStart: false,
+    ...patch,
+  });
+
+  it('没焦点且光标停过位置 → 补 focus 并保留光标', () => {
+    expect(resolveComposerBlankFocusIntent(snapshot())).toBe('keep-caret');
+  });
+
+  it('没焦点且光标还在文档起点(没人动过)→ 补 focus 并落到文末', () => {
+    expect(resolveComposerBlankFocusIntent(snapshot({ caretAtDocStart: true }))).toBe('doc-end');
+  });
+
+  it('已经有焦点 → 什么都不做(preventDefault 已经保住光标)', () => {
+    expect(resolveComposerBlankFocusIntent(snapshot({ isFocused: true }))).toBe('none');
+    expect(
+      resolveComposerBlankFocusIntent(snapshot({ isFocused: true, caretAtDocStart: true })),
+    ).toBe('none');
+  });
+
+  it('只读态(disabled / 语音听写占用)与已销毁、未挂载 → 不抢焦点', () => {
+    expect(resolveComposerBlankFocusIntent(snapshot({ isEditable: false }))).toBe('none');
+    expect(
+      resolveComposerBlankFocusIntent(snapshot({ isEditable: false, caretAtDocStart: true })),
+    ).toBe('none');
+    expect(resolveComposerBlankFocusIntent(snapshot({ isDestroyed: true }))).toBe('none');
+    expect(resolveComposerBlankFocusIntent(null)).toBe('none');
+  });
+});
+
+describe('ChatInput 空白区守卫接线', () => {
+  const chatInputSource = readFileSync(resolve(__dirname, '..', 'ChatInput.tsx'), 'utf8').replace(
+    /\r\n?/g,
+    '\n',
+  );
+
+  it('输入卡片用 isComposerBlankPointerTarget 守卫 mousedown 并按 intent 补 focus', () => {
+    const start = chatInputSource.indexOf('onMouseDown={(event) => {');
+    expect(start).toBeGreaterThan(0);
+    const end = chatInputSource.indexOf('onDragEnter={(e) => {', start);
+    expect(end).toBeGreaterThan(start);
+    const guardBlock = chatInputSource.slice(start, end);
+
+    expect(guardBlock).toContain('if (event.button !== 0) return;');
+    expect(guardBlock).toContain('isComposerBlankPointerTarget(');
+    expect(guardBlock).toContain('event.currentTarget');
+    expect(guardBlock).toContain('editor && !editor.isDestroyed ? editor.view.dom : null,');
+    expect(guardBlock).toContain('event.preventDefault();');
+    expect(guardBlock).toContain('resolveComposerBlankFocusIntent({');
+    expect(guardBlock).toContain('isEditable: editor.isEditable,');
+    expect(guardBlock).toContain('isFocused: editor.isFocused,');
+    expect(guardBlock).toContain(
+      'selection.empty && selection.from === Selection.atStart(doc).from',
+    );
+    expect(guardBlock).toContain("if (intent === 'keep-caret') editor.commands.focus();");
+    expect(guardBlock).toContain("else if (intent === 'doc-end') editor.commands.focus('end');");
+    // 契约:补 focus 一律不带坐标 —— 插入点只由点击文字那一行决定,空白区不参与定位。
+    expect(guardBlock).not.toContain('posAtCoords');
+    expect(guardBlock).not.toContain('setTextSelection');
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/composerBlankPointerFocus.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerBlankPointerFocus.ts
@@ -1,0 +1,126 @@
+/**
+ * Composer 空白区指针守卫 —— 修掉「只有点中文字那一行才能进输入」。
+ *
+ * composer 的输入体是 Tiptap 的 contenteditable,高度只跟内容走
+ * (`.ProseMirror` 是 `min-h-[22px]`);外层输入卡片却撑着 `min-h-[86px]`
+ * (create-agent 变体 140px)并用 `justify-between` 把工具栏压到底边,于是
+ * 文字行下方的空隙、工具栏两组按钮之间的空档、卡片四周的 padding 全是
+ * 「没有元素承接点击」的空白。原生 `<textarea>` 时代整块卡片就是输入体,
+ * 点哪都落在输入里;换成 contenteditable 之后,点这些空白会让浏览器把焦点
+ * 从 contenteditable 撤到 `<body>`,正在输入的光标凭空消失。
+ *
+ * 本模块回答两个问题:
+ * 1. 这次 mousedown 是否落在 composer 的空白区(`isComposerBlankPointerTarget`)。
+ *    调用方据此 `preventDefault()`,把浏览器默认的焦点转移吃掉。
+ * 2. 吃掉之后该不该补一次 focus、补到哪(`resolveComposerBlankFocusIntent`)。
+ *
+ * 关键是「进入输入态」与「定位插入点」两件事分开:点空白要能开始打字,但插入点
+ * 不由空白区决定 —— 那只归「点击文字那一行」。所以补 focus 时不带坐标,光标沿用
+ * 编辑器自己的 selection。
+ */
+
+/**
+ * 元素本身是否是「会自己吃焦点」的交互控件。空白区判定要放过这些目标,
+ * 否则 `preventDefault()` 会连按钮聚焦、文本框选字一起废掉。
+ */
+export function isInteractiveFocusedElement(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  if (element.isContentEditable) return true;
+  const tagName = element.tagName.toLowerCase();
+  if (['button', 'input', 'select', 'textarea'].includes(tagName)) return true;
+  if (tagName === 'a' && element.hasAttribute('href')) return true;
+  if (element.tabIndex >= 0) return true;
+  const role = element.getAttribute('role');
+  return (
+    role === 'button' ||
+    role === 'textbox' ||
+    role === 'searchbox' ||
+    role === 'combobox' ||
+    role === 'menuitem' ||
+    role === 'tab' ||
+    role === 'checkbox' ||
+    role === 'radio' ||
+    role === 'switch' ||
+    role === 'option'
+  );
+}
+
+/** 指针落点(视口坐标),对齐 MouseEvent 的字段名。 */
+export interface ComposerPointerPoint {
+  clientX: number;
+  clientY: number;
+}
+
+/**
+ * 这次指针事件的落点是否是 composer 卡片里的「空白」。
+ *
+ * @param target    事件的 `event.target`
+ * @param container composer 输入卡片(事件绑定所在的那层)
+ * @param editorDom 编辑器根节点(`editor.view.dom`);为 null 时按「编辑器未就绪」处理
+ * @param point     事件的视口坐标(`event.clientX` / `clientY`)
+ *
+ * 判 false(即放过默认行为)的情形:
+ * - 落点不是 Element,或不在卡片内(理论上不会,冒泡边界兜一层);
+ * - 落点在卡片矩形之外 —— 卡片里挂着 `absolute bottom-full` 的悬浮预览(页面评论
+ *   /引用),它们 DOM 上是卡片后代、视觉上却飘在卡片外。死区问题只存在于卡片
+ *   矩形内部,浮层上的 mousedown 必须原样放过,否则那里的文字连拖选都做不了;
+ * - 落在编辑器内 —— 那正是要走 ProseMirror 自己的光标定位;
+ * - 落点到卡片之间的任一祖先是交互控件(按钮 / 输入框 / role 控件 / 可聚焦项),
+ *   或是可拖拽元素(附件缩略图靠原生拖拽换位,吃掉 mousedown 会拖不动)。
+ */
+export function isComposerBlankPointerTarget(
+  target: EventTarget | null,
+  container: Element,
+  editorDom: Element | null,
+  point: ComposerPointerPoint,
+): boolean {
+  if (!(target instanceof Element)) return false;
+  if (!container.contains(target)) return false;
+  const box = container.getBoundingClientRect();
+  if (
+    point.clientX < box.left ||
+    point.clientX > box.right ||
+    point.clientY < box.top ||
+    point.clientY > box.bottom
+  ) {
+    return false;
+  }
+  if (editorDom && (editorDom === target || editorDom.contains(target))) return false;
+  for (let node: Element | null = target; node && node !== container; node = node.parentElement) {
+    if (isInteractiveFocusedElement(node)) return false;
+    if (node instanceof HTMLElement && node.draggable) return false;
+  }
+  return true;
+}
+
+/** 判定补 focus 需要的编辑器状态快照(只取布尔量,便于单测覆盖决策矩阵)。 */
+export interface ComposerFocusSnapshot {
+  isDestroyed: boolean;
+  /** `disabled` 与语音听写 busy 都会把编辑器置为不可编辑。 */
+  isEditable: boolean;
+  isFocused: boolean;
+  /** 光标是否还停在文档起点这个「没人动过」的默认位置。 */
+  caretAtDocStart: boolean;
+}
+
+/**
+ * 点空白之后要对焦点做什么:
+ * - `none`      什么都不做。编辑器已经有焦点(光标本来就在,`preventDefault()` 已经
+ *               替它保住了),或编辑器不可用/只读(disabled、语音听写占用)—— 只读态
+ *               下抢焦点没有意义,也会把语音输入的 caret 装饰搅乱。
+ * - `keep-caret` 补 focus,光标沿用编辑器当前的 selection(上次停在哪就还在哪)。
+ * - `doc-end`   补 focus 并落到文末。只在光标还停在文档起点这个默认位置时用:那说明
+ *               这个编辑器还没被人动过(例如刚恢复草稿、autofocus 关着),此时把光标
+ *               放到草稿末尾才是「接着写」。代价是用户真把光标停在文首、离开、再点
+ *               空白时光标会跳到文末 —— 这个边角情形不值得为它引入额外状态。
+ */
+export type ComposerBlankFocusIntent = 'none' | 'keep-caret' | 'doc-end';
+
+export function resolveComposerBlankFocusIntent(
+  snapshot: ComposerFocusSnapshot | null,
+): ComposerBlankFocusIntent {
+  if (!snapshot) return 'none';
+  if (snapshot.isDestroyed || !snapshot.isEditable) return 'none';
+  if (snapshot.isFocused) return 'none';
+  return snapshot.caretAtDocStart ? 'doc-end' : 'keep-caret';
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

桌面端聊天输入框只有点中文字那一行才能进入输入：点文字行下方的空隙、工具栏两组按钮之间的空档、卡片四周的 padding，正在输入时会让光标凭空消失（焦点被浏览器撤到 `<body>`），没焦点时也拿不到焦点。

原因是编辑器本体 `.ProseMirror` 的高度只跟内容走（`min-h-[22px]`），而输入卡片撑着 `min-h-[86px]`（create-agent 变体 140px）并用 `justify-between` 把工具栏压到底边，中间那 ~15px 是没有任何元素承接点击的空白（Chromium 实测 15.0px；新建对话框变体约 69px）。原生 `<textarea>` 时代整块卡片就是输入体，这是换成 Tiptap contenteditable 后的回归。

修法是给卡片挂一个 mousedown 守卫：命中空白时先 `preventDefault()` 吃掉默认的焦点转移，再按 intent 补一次**不带坐标**的 focus。「进入输入态」归空白区，「定位插入点」只归点击文字那一行——点空白不会重新定位光标。

补 focus 的决策抽成纯函数 `resolveComposerBlankFocusIntent`：

| 编辑器状态 | intent | 行为 |
|---|---|---|
| 已有焦点 | `none` | 不动（`preventDefault` 已经替它保住光标） |
| 只读（`disabled` / 语音听写占用）、已销毁、未挂载 | `none` | 不抢焦点 |
| 无焦点、光标停过位置 | `keep-caret` | `focus()`，沿用编辑器 selection |
| 无焦点、光标还在文档起点 | `doc-end` | `focus('end')` |

最后一条是唯一带判断的地方：光标停在 `Selection.atStart(doc)` 说明这个编辑器还没被人动过（草稿刚恢复、autofocus 关着），此时落到草稿末尾才是「接着写」；否则光标会停在文首、打字插到开头。取舍写在函数注释里。

守卫放过四类落点：编辑器内（交给 ProseMirror 自己定位光标）、交互控件及其内部图标、`draggable` 元素（附件缩略图靠原生拖拽换位）、以及**落在卡片矩形之外**的点——卡片里挂着 `absolute bottom-full` 的悬浮预览（页面评论 / 引用），DOM 上是卡片后代但视觉上飘在卡片外，死区只在卡片矩形内，那里的 mousedown 必须原样放过，否则文字连拖选都做不了。

顺带把 `ChatInput` 里原有的 `isInteractiveFocusedElement` 挪进新模块共用（逻辑未改）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #411
- 本 PR 包含：`composerBlankPointerFocus.ts`（新增空白判定 + focus intent 决策）、`ChatInput.tsx` 卡片 mousedown 接线、对应单测（15 条）
- 明确不包含：mobile 端 composer（`ComposerRichInput`，未验证是否同源问题）；`ChatInput.tsx:5591` 那条 `main` 上既有的 `'visualVariant' is defined but never used` lint 错误（已用 `git show HEAD:… | eslint --stdin` 确认与本 PR 无关，未顺手修）
- 用户可见变化：点输入框卡片内任何空白处都能进入输入态；已在输入时点空白不再丢光标；插入点定位行为不变（仍只由点击文字行决定）
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及：本 PR 只改指针事件的默认行为（mousedown 的焦点转移），无视觉、布局、动效或文案变化，Light / Dark 两模式表现完全一致，未新增或调整任何 token、尺寸与状态样式。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：exit 0，25 个 workspace 全绿（0 failed）

pnpm --filter desktop run typecheck
结果：exit 0

pnpm --filter desktop exec vitest run \
  src/renderer/components/new-chat/__tests__/composerBlankPointerFocus.test.ts \
  src/renderer/__tests__/chatInputSessionFocus.test.ts
结果：exit 0（24 passed —— 新增守卫 15 条 + 既有焦点契约 9 条）

pnpm --filter desktop exec eslint <两个新文件>
结果：exit 0

pnpm --filter desktop exec prettier --check <两个新文件>
结果：clean
```

新增单测覆盖：空白判定（卡片自身 / 文字行下方空隙 / 工具栏空档 / 编辑器外壳）、编辑器内放行、交互控件与内部图标放行、`draggable` 放行、卡片矩形外浮层放行、矩形四边与边界坐标、`editorDom` 为 null、以及 focus intent 的完整决策矩阵。

补充说明：jsdom 不实现「mousedown 把焦点从 contenteditable 撤到 `<body>`」也不做布局，所以这一层用真实 Chromium（Edge，与 Electron 同引擎）跑了一份 playwright 探针，把 `composerBlankPointerFocus.ts` 原样 bundle 进页面、复刻卡片几何后用真实鼠标点击验证，11 条全 PASS：对照组（不挂守卫）复现死区 15.0px + 焦点丢到 `<body>`；挂守卫后点空隙 / 工具栏空档 / 顶部 padding 焦点与光标偏移都不变；失焦后点空白拿到焦点且光标不动（`keep-caret`）；光标在默认起点时落到文末（`doc-end`）；只读态不抢焦点（`none`）；点按钮 click 照常触发并拿到焦点；点文字行照常定位光标；点空白后继续打字进原光标位置；卡片矩形外浮层 `defaultPrevented === false` 且能拖选文字。该探针依赖本机 Edge 路径，不适合入 CI，故未入仓。

### 手工验证

Windows 11 桌面端实测：在会话输入框输入文字后点文字行下方空白，光标保持不动、可继续输入；未聚焦时点空白可进入输入态。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop renderer 的 `ChatInput` 卡片 mousedown 行为（会话页 + 新建草稿页两个消费方）。不触及 main 进程、IPC、数据库、协议与任何持久化。
- 回滚 / 降级方式：撤掉 `ChatInput.tsx` 卡片上那一处 `onMouseDown` 接线即可恢复原行为；新模块无其他引用方（`isInteractiveFocusedElement` 除外，那是原地搬移）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
