### PR TITLE
docs(support): Discussions 保持关闭,支持入口统一为 question issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/makecindy/cindy/security/advisories/new
     about: Do not disclose security vulnerabilities publicly.
-  - name: Discussions
-    url: https://github.com/makecindy/cindy/discussions
-    about: Ask usage questions and discuss ideas with the community.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -3,11 +3,6 @@ description: "Ask a non-security usage question / 提一个与安全无关的使
 title: "question: "
 labels: [question]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        一般性讨论建议优先使用 [Discussions](../discussions)。
-        For open-ended discussion, prefer GitHub Discussions.
   - type: textarea
     id: goal
     attributes:

--- a/SUPPORT.en.md
+++ b/SUPPORT.en.md
@@ -18,7 +18,7 @@ custom environment or commercial support is not guaranteed.
   steps, and redacted logs.
 - Feature requests: use the feature request template and describe the use case
   and expected outcome.
-- Usage questions: open a question issue.
+- Usage questions: open an issue with the “Usage question / 使用问题” form.
 
 Do not post real user data, access tokens, private keys, or internal addresses
 in public issues, discussions, or logs.

--- a/SUPPORT.en.md
+++ b/SUPPORT.en.md
@@ -18,7 +18,7 @@ custom environment or commercial support is not guaranteed.
   steps, and redacted logs.
 - Feature requests: use the feature request template and describe the use case
   and expected outcome.
-- Usage questions: use GitHub Discussions or a question issue.
+- Usage questions: open a question issue.
 
 Do not post real user data, access tokens, private keys, or internal addresses
 in public issues, discussions, or logs.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,6 +14,6 @@ Cindy 是开源客户端，社区可以帮助确认可复现的问题和改进�
 - 安全漏洞、凭证或可利用细节：按照 [SECURITY.md](SECURITY.md) 私下报告；
 - 普通 Bug：提交 GitHub issue，并提供版本、平台、复现步骤和脱敏日志；
 - 功能建议：提交 feature request，说明使用场景和期望结果；
-- 使用问题：提交 question issue 提问。
+- 使用问题：用「Usage question / 使用问题」issue 模板提问。
 
 请不要在公开 issue、讨论或日志中提交真实用户数据、访问令牌、私钥或内部地址。

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,6 +14,6 @@ Cindy 是开源客户端，社区可以帮助确认可复现的问题和改进�
 - 安全漏洞、凭证或可利用细节：按照 [SECURITY.md](SECURITY.md) 私下报告；
 - 普通 Bug：提交 GitHub issue，并提供版本、平台、复现步骤和脱敏日志；
 - 功能建议：提交 feature request，说明使用场景和期望结果；
-- 使用问题：在 GitHub Discussions 或 question issue 中提问。
+- 使用问题：提交 question issue 提问。
 
 请不要在公开 issue、讨论或日志中提交真实用户数据、访问令牌、私钥或内部地址。


### PR DESCRIPTION
## 这次改了什么

### 摘要

维护者已确认本仓库**不开启 GitHub Discussions**。清理全部指向 Discussions 的入口，避免公开后出现断链承诺：

- `SUPPORT.md` / `SUPPORT.en.md`：使用问题入口改为直接引用 issue 模板名——中文「用「Usage question / 使用问题」issue 模板提问」，英文 "open an issue with the “Usage question / 使用问题” form"
- `.github/ISSUE_TEMPLATE/config.yml`：移除指向 `/discussions` 的 contact link（该链接在 Discussions 关闭时为 404）；Security 入口保留
- `.github/ISSUE_TEMPLATE/question.yml`：移除模板正文中仍推荐 Discussions 并链接 `../discussions` 的引导段（review 中发现的漏网引用）

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Discussions 保持关闭的维护者决定（2026-07-25）
- 本 PR 包含：`SUPPORT.md`、`SUPPORT.en.md`、`.github/ISSUE_TEMPLATE/config.yml`、`.github/ISSUE_TEMPLATE/question.yml`
- 明确不包含：其他社区文档、README、其余 issue 模板（bug_report / feature_request）
- 用户可见变化：SUPPORT 文档措辞、issue 创建页 contact 链接（少一个 Discussions 入口）、question 模板不再推荐 Discussions
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
bash run-unit-gate.sh <worktree>（根 pnpm test:unit 全量）
结果：apps/desktop 4 个用例失败（deviceLinkInteractionScenarios / makerChatStoreTextDeltaBatching / skillSlot），
两次运行失败项完全一致，经核实为 main 基线问题（基线 4f9dcce，发布前连续合入所致），与本 PR 无关——
本 diff 仅 4 个社区文档/模板文件，无任何测试读取。其余全部 workspace 通过。以本 PR CI 为权威结论。
```

### 手工验证

- `grep -ri discussion` 对 SUPPORT 中英与 `.github/ISSUE_TEMPLATE/` 全量核对：Discussions 入口引用清零（SUPPORT 尾段「公开 issue、讨论或日志」为泛指表述，保留）；
- SUPPORT 引用的模板名与 `question.yml` 的 `name` 字段逐字一致；
- config.yml 结构核对（blank_issues_enabled 与 Security 链接不变）。

### 未执行的验证

- 涉及 package 的 `typecheck`：未触及任何 package 源码，无适用对象。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅支持文档、issue 创建页链接与 question 模板引导段。
- 回滚 / 降级方式：revert 本 PR；若未来决定开启 Discussions，恢复这几处即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
