### PR TITLE
fix(plugins): 完善 Skill 协议对齐与只读门禁

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
@@ -435,6 +435,7 @@ describe('FORGE_GUIDE', () => {
       // 2026-07-23 通用能力四件套:会话上下文 / node 多入口 / 目录选择 / 面板预览。
       '会话上下文(session-context 槽)',
       'workdir_is_local',
+      'workdir_is_read_only',
       'node.entries',
       'node.secretBindings',
       'request.cindy.secrets',

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -824,7 +824,7 @@ my-ghost/
 见 §4.7)、\`notify\`(弹系统轻提示,主机画壳带你的身份头,见 §4.9)、\`fs\`(请主机
 代写文件:私有数据目录/会话工作目录/过户目录三档,见 §4.10)、\`node\`(运行随包
 Node 工作进程或 stdio MCP,见 §4.12)、\`session-context\`(派活时主机把当前会话的
-可信 session_id / workdir 注入 args,见 §4.13)、\`pick\`(请主机弹系统选文件夹窗口,
+可信 session_id / workdir / 只读状态注入 args,见 §4.13)、\`pick\`(请主机弹系统选文件夹窗口,
 用户亲选即授权,见 §4.14)、\`preview\`(请主机在右侧栏内置浏览器打开白名单网站的
 预览标签,见 §4.15)、\`skill\`(捆绑 Agent Skills:随包 SKILL.md 技能,启用后
 Claude Code 与 Codex 都能发现,见 §4.16)。
@@ -2210,9 +2210,9 @@ const maker = require('@taptap/maker'); // 之后它的自启动全部走了正�
 cindy.onHostMessage(async (msg) => {
   if (msg.type !== 'tool-call') return;
   const ctx = msg.args.session_context;
-  // ctx = { session_id, workdir, workdir_is_local }
-  if (ctx?.workdir_is_local && ctx.workdir) {
-    // 只有 workdir_is_local === true 才能把 workdir 当本机路径交给 Node 侧
+  // ctx = { session_id, workdir, workdir_is_local, workdir_is_read_only }
+  if (ctx?.workdir_is_local && !ctx.workdir_is_read_only && ctx.workdir) {
+    // 只有本地且非只读时才能把 workdir 交给 Node 侧修改
     await cindy.node.request({ method: 'project/build', params: { dir: ctx.workdir } });
   }
 });
@@ -2225,6 +2225,8 @@ cindy.onHostMessage(async (msg) => {
 - \`workdir_is_local\` 是安全核心:会话跑在 SSH 远程工作区(或主机证明不了是本地)
   时为 \`false\`,此时 \`workdir\` 是远端路径,**绝不能**当本机路径读写——同名本机
   目录可能存在,写下去就是事故;
+- \`workdir_is_read_only\` 来自宿主对会话 permission / plan 状态的统一裁决;
+  为 \`true\` 时只允许检查、列举等只读操作,不得初始化、构建或以其它方式修改 workdir;
 - 这只是"位置信息",不是文件访问权:读写仍走 fs 槽 / node 槽各自的守门;
 - 未声明本槽的插件,args 里永远没有 \`session_context\` 字段。
 

--- a/apps/desktop/src/main/cindy-brain/skillSlot.ts
+++ b/apps/desktop/src/main/cindy-brain/skillSlot.ts
@@ -182,7 +182,10 @@ export async function reconcileGhostSkillLinks(
       // 活链接:目标在当前 brainRoot 内才归我们管;他 owner / 外来链接不碰。
       if (!isSameOrInside(real, brainRootCompare)) continue;
       const want = desired.get(entName);
-      if (want !== undefined && real === normalizeForCompare(want.target)) {
+      const wantCompare = want
+        ? ((await realPathOrNull(want.target)) ?? normalizeForCompare(want.target))
+        : null;
+      if (want !== undefined && real === wantCompare) {
         managedLive.set(entName, real);
       } else {
         toRemove.push(entName);

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../logger.js', () => ({
 // ALS 语境:恒缺省 → resolveSessionContext 走建线闭包 ctx(claude 路径同款)。
 vi.mock('@cindy/mcps', () => ({ getLiziMcpSessionContext: () => undefined }));
 
+const WORKDIR = '/proj/alpha';
 const listMock = vi.fn<() => unknown[]>(() => []);
 const dispatchMock = vi.fn(async () => ({ ok: true as const, result: 'done' }));
 const setupAssessmentMock = vi.fn((_ghostId: string) => ({
@@ -50,6 +51,12 @@ const ensureReadyMock = vi.fn(
     assessment: { state: 'ready' as const, revision: 0, groups: [] },
   }),
 );
+const sessionSnapshotMock = vi.fn(async () => ({
+  workingDir: WORKDIR,
+  permissionMode: 'auto',
+  planModeEnabled: false,
+  remoteHostId: null,
+}));
 vi.mock('../../cindy-brain/index.js', () => ({
   getGhostManager: () => ({ list: listMock }),
   getGhostPipeDispatcher: () => ({ callGhostTool: dispatchMock }),
@@ -80,6 +87,9 @@ vi.mock('../../cindy-brain/ghostLocalPathGrant.js', () => ({ classifyLocalAttach
 vi.mock('../../cindy-brain/cardService.js', () => ({ withCardToken: (r: unknown) => r }));
 vi.mock('../../cindy-brain/forge.js', () => ({ FORGE_GUIDE: 'guide', packGhostDir: vi.fn() }));
 vi.mock('../../cindy-brain/openFileInstall.js', () => ({ handleIncomingCindyFile: vi.fn() }));
+vi.mock('../../localDb/ipc/sessions.js', () => ({
+  getSessionFsSnapshot: sessionSnapshotMock,
+}));
 vi.mock('../../cindy-media/blobStore.js', () => ({}));
 vi.mock('../../cindy-media/ledger.js', () => ({}));
 vi.mock('../../cindy-media/attachmentGrantGate.js', () => ({ chatAttachmentOrigin: vi.fn() }));
@@ -90,12 +100,16 @@ const { setGhostDisabledForWorkdir, listDisabledGhostIdsForWorkdir, isGhostDisab
   await import('../../cindy-brain/ghostWorkdirPrefs');
 import type { LiziMcpSessionContext } from '@cindy/mcps';
 
-const WORKDIR = '/proj/alpha';
-
-function chipGhost(id: string): unknown {
+function chipGhost(id: string, slots: string[] = ['tool']): unknown {
   return {
     enabled: true,
-    manifest: { id, name: `Ghost ${id}`, kind: 'chip', tools: [{ name: 'run', description: 'd' }] },
+    manifest: {
+      id,
+      name: `Ghost ${id}`,
+      kind: 'chip',
+      slots,
+      tools: [{ name: 'run', description: 'd' }],
+    },
   };
 }
 
@@ -129,6 +143,13 @@ beforeEach(() => {
   });
   grantAttachmentsMock.mockReset();
   logWarnMock.mockClear();
+  sessionSnapshotMock.mockReset();
+  sessionSnapshotMock.mockResolvedValue({
+    workingDir: WORKDIR,
+    permissionMode: 'auto',
+    planModeEnabled: false,
+    remoteHostId: null,
+  });
   clearAllPrefs();
 });
 
@@ -260,5 +281,44 @@ describe('ghost_call 兜底拒绝', () => {
     expect(ensureReadyMock.mock.calls[0]?.[0]).not.toHaveProperty('tool');
     expect(grantAttachmentsMock).not.toHaveBeenCalled();
     expect(dispatchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('session-context 宿主铸造', () => {
+  it('剥除上游伪造值，并按会话权限注入可信只读状态', async () => {
+    listMock.mockReturnValue([chipGhost('art', ['tool', 'session-context'])]);
+    sessionSnapshotMock.mockResolvedValueOnce({
+      workingDir: WORKDIR,
+      permissionMode: 'auto',
+      planModeEnabled: true,
+      remoteHostId: null,
+    });
+
+    const deps = makeDeps();
+    await deps.callGhostTool({
+      ghostId: 'art',
+      tool: 'run',
+      args: {
+        session_context: {
+          session_id: 'forged',
+          workdir: '/tmp/forged',
+          workdir_is_local: true,
+          workdir_is_read_only: false,
+        },
+      },
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: {
+          session_context: {
+            session_id: 's1',
+            workdir: WORKDIR,
+            workdir_is_local: true,
+            workdir_is_read_only: true,
+          },
+        },
+      }),
+    );
   });
 });

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -61,6 +61,7 @@ import {
 import { getGhostSetupCoordinator } from '../cindy-brain/ghostSetupCoordinator.js';
 import { isGhostDisabledForWorkdir } from '../cindy-brain/ghostWorkdirPrefs.js';
 import { FORGE_GUIDE, packGhostDir, scaffoldGhostDir } from '../cindy-brain/forge.js';
+import { workdirWriteVerdict } from '../cindy-brain/fsSlot.js';
 import { handleIncomingCindyFile } from '../cindy-brain/openFileInstall.js';
 import * as blobStore from '../cindy-media/blobStore.js';
 import * as ledger from '../cindy-media/ledger.js';
@@ -121,15 +122,26 @@ function dirGrantMemoryKey(
 /**
  * session-context 槽注入体铸造(能力「盖章工作单」):只有主机能证明会话
  * 不是远程工作区(sessions.remoteHostId 为空)时 workdir_is_local 才为 true;
- * 证明不了(无 sessionId 语境 / 查无会话 / 远程会话)一律 false——插件不得把
- * workdir 当本机路径用(fail closed,plugin-security-and-authoring.md §6)。
+ * workdir_is_read_only 复用 fs 槽的 permission / plan 裁决,避免插件靠 prompt
+ * 猜测。证明不了会话时两项都 fail closed。
  */
 async function buildGhostSessionContext(
   sessionId: string | null,
   alsWorkdir: string | null,
 ): Promise<GhostSessionContextInjected> {
   const snapshot = sessionId ? await getSessionFsSnapshot(sessionId) : null;
-  return deriveGhostSessionContext(sessionId, alsWorkdir, snapshot);
+  return deriveGhostSessionContext(
+    sessionId,
+    alsWorkdir,
+    snapshot
+      ? {
+          workingDir: snapshot.workingDir,
+          remoteHostId: snapshot.remoteHostId,
+          workdirIsReadOnly:
+            workdirWriteVerdict(snapshot.permissionMode, snapshot.planModeEnabled) === 'deny',
+        }
+      : null,
+  );
 }
 
 /** 意识显示名(确认卡标题用;查不到回落 id)。 */

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -2289,25 +2289,67 @@ describe('ghost · 2026-07-23 通用能力四件套(session-context / pick / pre
       session_id: null,
       workdir: '/als/dir',
       workdir_is_local: false,
+      workdir_is_read_only: true,
     });
     // 有 sessionId 但查无会话:同样不可当本地
     expect(deriveGhostSessionContext('s1', '/als/dir', null)).toEqual({
       session_id: 's1',
       workdir: '/als/dir',
       workdir_is_local: false,
+      workdir_is_read_only: true,
     });
     // 本地会话:workdir 取会话真身,可当本地
     expect(
-      deriveGhostSessionContext('s1', null, { workingDir: '/proj', remoteHostId: null }),
-    ).toEqual({ session_id: 's1', workdir: '/proj', workdir_is_local: true });
+      deriveGhostSessionContext('s1', null, {
+        workingDir: '/proj',
+        remoteHostId: null,
+        workdirIsReadOnly: false,
+      }),
+    ).toEqual({
+      session_id: 's1',
+      workdir: '/proj',
+      workdir_is_local: true,
+      workdir_is_read_only: false,
+    });
+    // 计划 / 只读会话:位置仍是本地,但插件不得修改 workdir
+    expect(
+      deriveGhostSessionContext('s1', null, {
+        workingDir: '/proj',
+        remoteHostId: null,
+        workdirIsReadOnly: true,
+      }),
+    ).toEqual({
+      session_id: 's1',
+      workdir: '/proj',
+      workdir_is_local: true,
+      workdir_is_read_only: true,
+    });
     // SSH 远程会话:路径给(远端事实),但绝不许当本地
     expect(
-      deriveGhostSessionContext('s1', null, { workingDir: '/remote/proj', remoteHostId: 'h1' }),
-    ).toEqual({ session_id: 's1', workdir: '/remote/proj', workdir_is_local: false });
+      deriveGhostSessionContext('s1', null, {
+        workingDir: '/remote/proj',
+        remoteHostId: 'h1',
+        workdirIsReadOnly: false,
+      }),
+    ).toEqual({
+      session_id: 's1',
+      workdir: '/remote/proj',
+      workdir_is_local: false,
+      workdir_is_read_only: false,
+    });
     // 会话存在但没 workdir:没有可当本地的对象
     expect(
-      deriveGhostSessionContext('s1', null, { workingDir: null, remoteHostId: null }),
-    ).toEqual({ session_id: 's1', workdir: null, workdir_is_local: false });
+      deriveGhostSessionContext('s1', null, {
+        workingDir: null,
+        remoteHostId: null,
+        workdirIsReadOnly: false,
+      }),
+    ).toEqual({
+      session_id: 's1',
+      workdir: null,
+      workdir_is_local: false,
+      workdir_is_read_only: false,
+    });
   });
 });
 

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -72,7 +72,8 @@ const GHOST_ID_RE = /^[a-z0-9][a-z0-9-]{0,31}$/;
  * 字节永远由主机落盘,沙箱本身仍无 fs——本槽是"申请主机代写"的资格,
  * 不是文件系统访问权。
  * 'session-context' = 会话上下文(2026-07-23):agent 派活(tool-call)时,主机把
- * 当次会话的可信 {session_id, workdir, workdir_is_local} 注入 args.session_context。
+ * 当次会话的可信 {session_id, workdir, workdir_is_local, workdir_is_read_only}
+ * 注入 args.session_context。
  * 只注入宿主认证过的事实,插件与 agent 自报的同名字段一律被剥除;远程工作区
  * (workdir 不在本机)时 workdir_is_local=false,插件不得把它当本机路径用。
  * 'pick' = 目录选择(2026-07-23):插件经管子申请主机弹**系统级**选文件夹窗口,
@@ -4091,38 +4092,56 @@ export type GhostPipeNodeResult =
  * session-context 槽注入到 tool-call args.session_context 的形态(主机铸造,
  * snake_case 与 dir_deposit / save_deposit 同风格)。
  *
- * workdir_is_local 是本注入的安全核心:只有主机能证明「该会话不是远程工作区
+ * workdir_is_local 是本注入的位置安全核心:只有主机能证明「该会话不是远程工作区
  * (sessions.remoteHostId 为空)」时才为 true;证明不了(远程会话 / 查无会话 /
  * 无 sessionId 语境)一律 false——插件此时**不得**把 workdir 当本机路径交给
  * Node 侧读写(fail closed,见 docs/dev-rules/plugin-security-and-authoring.md §6)。
+ * workdir_is_read_only 则由同一份会话 permission / plan 状态铸造;为 true 时
+ * 插件不得修改当前 workdir。证明不了会话状态时同样 fail closed 为 true。
  */
 export interface GhostSessionContextInjected {
   session_id: string | null;
   workdir: string | null;
   workdir_is_local: boolean;
+  workdir_is_read_only: boolean;
 }
 
 /**
  * session-context 注入体推导(纯函数;main 侧查会话快照后调用):
- * - 无 sessionId 语境 / 查无会话:回落 ALS workdir 且恒 workdir_is_local=false
- *   (证明不了就不许当本机路径,fail closed);
+ * - 无 sessionId 语境 / 查无会话:回落 ALS workdir,但恒 workdir_is_local=false
+ *   且 workdir_is_read_only=true(证明不了就不许当本机路径或修改,fail closed);
  * - 有快照:workdir 取会话真身,只有 remoteHostId 为空且 workdir 非空才算本地。
  */
 export function deriveGhostSessionContext(
   sessionId: string | null,
   fallbackWorkdir: string | null,
-  snapshot: { workingDir: string | null; remoteHostId: string | null } | null,
+  snapshot: {
+    workingDir: string | null;
+    remoteHostId: string | null;
+    workdirIsReadOnly: boolean;
+  } | null,
 ): GhostSessionContextInjected {
   if (!sessionId) {
-    return { session_id: null, workdir: fallbackWorkdir, workdir_is_local: false };
+    return {
+      session_id: null,
+      workdir: fallbackWorkdir,
+      workdir_is_local: false,
+      workdir_is_read_only: true,
+    };
   }
   if (!snapshot) {
-    return { session_id: sessionId, workdir: fallbackWorkdir, workdir_is_local: false };
+    return {
+      session_id: sessionId,
+      workdir: fallbackWorkdir,
+      workdir_is_local: false,
+      workdir_is_read_only: true,
+    };
   }
   return {
     session_id: sessionId,
     workdir: snapshot.workingDir,
     workdir_is_local: snapshot.remoteHostId === null && snapshot.workingDir !== null,
+    workdir_is_read_only: snapshot.workdirIsReadOnly,
   };
 }
 

--- a/docs/dev-rules/plugin-security-and-authoring.md
+++ b/docs/dev-rules/plugin-security-and-authoring.md
@@ -122,10 +122,6 @@
 
 - `networkSlot.ts` 的 `as: 'media'` 不能只信任 Content-Type（GLB 常见
   `application/octet-stream`），需要安全的 magic-byte／扩展名嗅探。
-- `skill` 槽尚未镜像进协议仓（`cindy-protocol/packages/plugin-protocol/src/manifest.ts`
-  的 `GHOST_SLOTS` 与校验器是桌面端的手工双份）：本地／手动安装不受影响，但
-  plugin-market 分发声明了 skill 槽的包会被服务端校验拒绝，需与 plugin-server
-  协调后升级 submodule 指针（见 `protocol-and-submodules.md`）。
 - SSH 远程场景必须让 `LiziMcpSessionContext` 携带 remote 标识；目录过户不得回退读取本机
   同名路径，无法证明来源时 **fail closed**。
 - 手机版仍需把历史 mivo 动作按钮降级为纯展示。


### PR DESCRIPTION
## 这次改了什么

### 摘要

补齐插件拆分后的客户端协议对齐：插件可通过可选 `skill` 槽携带 Skill，宿主向插件注入可信的工作区只读状态，并统一复用 filesystem 槽的 permission/plan 裁决；同时修复 macOS `/var` 与 `/private/var` 实路径差异导致 Skill 链接反复重建的问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：TapTap Maker 插件拆分后的协议对齐与回归修复
- 本 PR 包含：可选 Skill 槽、`workdir_is_read_only` session context、filesystem 权限/计划模式门禁复用、Skill 链接实路径比较、必要测试与作者手册同步（`FORGE_GUIDE` §4.13）
- 明确不包含：TapTap Maker `.cindy` 插件包实现（见 makecindy/cindy-official-plugins#18）、插件市场/服务端逻辑、UI 改动
- 用户可见变化：支持该协议的插件 Skill 可被宿主加载；只读或计划模式下插件写操作会被宿主拒绝
- 是否存在 breaking change：无；`skill` 槽与 `workdir_is_read_only` 均为增量能力，未适配插件无需改动

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
cd apps/desktop && pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/forge.test.ts src/main/cindy-brain/__tests__/skillSlot.test.ts src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts src/shared/__tests__/ghost.test.ts
结果：4 files / 178 tests passed

pnpm --filter desktop typecheck
结果：通过

git diff HEAD^ --check
结果：通过
```

### 手工验证

不涉及 UI；协议兼容与只读门禁由定向单测覆盖。

### 未执行的验证

最新 `main` 基线执行全量 `pnpm test:unit` 时有 3 个与本 PR 零 diff 的既有失败：`deviceLinkInteractionScenarios.test.ts` 的 2 个源码字符串断言，以及 `makerChatStoreTextDeltaBatching.test.ts` 的 setup 数量上限断言。本 PR 未夹带修复这些无关失败。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 插件 manifest/session context、Skill 链接对账和工作区写门禁。SSH/远程工作区仍由 `workdir_is_local=false` fail closed；未新增 Device Link IPC/push；未新增 Mobile 插件执行入口或 UI。
- 回滚 / 降级方式：回退提交 `3737a1a`；旧插件因新增字段与槽均为可选项，可继续按原协议运行。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因