### PR TITLE
fix(plugins): preserve setup completion snapshot

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupCoordinator.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupCoordinator.test.ts
@@ -16,6 +16,7 @@ import {
   GhostSetupInteractionBridge,
   type GhostSetupInteractionCommand,
   type GhostSetupInteractionResponseTarget,
+  type GhostSetupInteractionSnapshot,
 } from '../ghostSetupInteractionBridge';
 
 function required(revision = 0): GhostSetupAssessment {
@@ -286,6 +287,40 @@ describe('GhostSetupCoordinator', () => {
     h.changeBus.emit('gmail', { source: 'oauth', ref: 'google' });
     await expect(waiting).resolves.toMatchObject({ ok: true });
     expect(h.bridge.pendingSnapshots()).toEqual([]);
+  });
+
+  it('preserves non-empty satisfied steps in the ready terminal snapshot', async () => {
+    const h = harness(required());
+    const waiting = h.coordinator.ensureReady({
+      sessionId: 'session-1',
+      ghostId: 'gmail',
+      tool: 'search',
+    });
+    await vi.waitFor(() => expect(h.bridge.pendingSnapshots()).toHaveLength(1));
+    const initial = h.bridge.pendingSnapshots()[0].request;
+
+    h.setAssessment(ready(1));
+    h.changeBus.emit('gmail', { source: 'oauth', ref: 'google' });
+    await expect(waiting).resolves.toMatchObject({ ok: true });
+
+    const terminalSnapshots = h.broadcast.mock.calls
+      .filter(([channel]) => channel === MAKER_PUSH.INTERACTION_REQUEST)
+      .map(
+        ([, payload]) =>
+          (payload as { request: GhostSetupInteractionSnapshot }).request,
+      )
+      .filter((request) => request.terminal === true);
+    expect(terminalSnapshots).toHaveLength(1);
+    expect(terminalSnapshots[0].steps).toEqual([
+      {
+        id: initial.steps[0].id,
+        groupId: initial.steps[0].groupId,
+        groupMode: initial.steps[0].groupMode,
+        title: initial.steps[0].title,
+        description: initial.steps[0].description,
+        phase: 'satisfied',
+      },
+    ]);
   });
 
   it('run_action is single-flight and only a later ready assessment settles', async () => {

--- a/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
@@ -249,6 +249,28 @@ export class GhostSetupCoordinator {
         this.deps.bridge.update(snapshot);
       };
 
+      const publishSatisfied = (nextAssessment: GhostSetupAssessment): void => {
+        assessment = nextAssessment;
+        const nextRevision = Math.max(snapshot.revision + 1, assessment.revision);
+        // A ready assessment has no actionable plan, but Renderer still
+        // requires the terminal snapshot to retain the interaction's steps.
+        // Preserve the last authoritative presentation and strip every
+        // action/error while projecting the completed state.
+        snapshot = {
+          ...snapshot,
+          revision: nextRevision,
+          steps: snapshot.steps.map((step) => ({
+            id: step.id,
+            groupId: step.groupId,
+            groupMode: step.groupMode,
+            title: step.title,
+            description: step.description,
+            phase: 'satisfied',
+          })),
+        };
+        this.deps.bridge.update(snapshot);
+      };
+
       const verify = (requiredPhase?: GhostSetupInteractionStep['phase']): Promise<void> => {
         if (settled) return Promise.resolve();
         if (verifying) return verifying;
@@ -275,7 +297,7 @@ export class GhostSetupCoordinator {
           }
           const next = current.assessment;
           if (next.state === 'ready') {
-            publish(next, 'satisfied');
+            publishSatisfied(next);
             settle({ ok: true, assessment: next }, 'ready');
             return;
           }

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -7,6 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentInputProjection, AgentInputQueuedMessage } from '../../shared/agentInputQueue';
+import { GHOST_SETUP_MAX_INTERACTION_STEPS } from '../../shared/ghost';
 import type { Message } from '@/lib/ccAgent.types';
 import type { AttachedFile, MentionedResource } from '@/lib/fileTypes';
 
@@ -827,23 +828,25 @@ describe('makerChatStore text delta batching', () => {
     expect(makerChatStore.getSnapshot(SESSION_ID).pendingPluginSetup).toBeNull();
   });
 
-  it('accepts all 64 manifest-valid setup steps and rejects a 65th', () => {
+  it('accepts the full setup interaction capacity and rejects one extra step', () => {
     const step = pluginSetupRequest(1).steps[0];
     emitInteractionRequest({
       ...pluginSetupRequest(1),
-      steps: Array.from({ length: 64 }, (_, index) => ({
+      steps: Array.from({ length: GHOST_SETUP_MAX_INTERACTION_STEPS }, (_, index) => ({
         ...step,
         id: `setup-${index}`,
         action: { ...step.action, id: `oauth:${index}` },
       })),
     });
-    expect(makerChatStore.getSnapshot(SESSION_ID).pendingPluginSetup?.steps).toHaveLength(64);
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingPluginSetup?.steps).toHaveLength(
+      GHOST_SETUP_MAX_INTERACTION_STEPS,
+    );
 
     makerChatStore.purgeSession(SESSION_ID);
     emitInteractionRequest({
       ...pluginSetupRequest(1),
       requestId: 'plugin-setup-oversized',
-      steps: Array.from({ length: 65 }, (_, index) => ({
+      steps: Array.from({ length: GHOST_SETUP_MAX_INTERACTION_STEPS + 1 }, (_, index) => ({
         ...step,
         id: `setup-${index}`,
         action: { ...step.action, id: `oauth:${index}` },


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #329 合入后发现的 Setup Runtime 终态快照问题：插件配置完成后，ready assessment 不再重新生成空 plan，而是保留最后一次已发布的步骤结构，将所有步骤转换为无 action、无 error 的 `satisfied` 状态。这样 Renderer 能接受 `terminal: true` 快照，及时清除 pending 语义并展示完成态。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#136；#329 的 post-merge review [discussion_r3649817544](https://github.com/makecindy/cindy/pull/329#discussion_r3649817544)
- 本 PR 包含：Setup coordinator ready 终态投影修复及对应 Main 回归测试
- 明确不包含：UI 重设计、插件专属逻辑、协议扩张、Secret 存储或传输边界变更
- 用户可见变化：配置完成后 Setup 卡能立即收到完成态，不再短暂残留旧的可操作状态，也不会压掉任务完成标记
- 是否存在 breaking change：无

### UI 变化

不涉及：没有修改 Renderer UI、交互或文案，只修复 Main 下发的通用终态生命周期数据。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test src/main/cindy-brain/__tests__/ghostSetupCoordinator.test.ts src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
结果：2 files passed，96 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全仓门禁通过
- Desktop：1184 files passed，12658 tests passed，2 skipped
- Mobile：250 files passed，2357 tests passed
- 其余收集到测试的 workspace 全部通过

git diff --check
结果：通过
```

### 手工验证

不涉及：本次没有视觉变化；终态快照结构由 coordinator 回归测试直接断言。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Setup interaction 终态生命周期

### 影响与回滚

- 影响范围：Cindy Desktop 中从 required setup 转为 ready 的通用插件设置流程
- 回滚 / 降级方式：回滚本 PR commit；不会涉及数据迁移或凭证数据变更

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不改变插件作者契约，无需同步 `FORGE_GUIDE`）
- [x] 已确认测试结果或说明未执行原因
