### PR TITLE
feat(desktop): enable Codex for Cindy gateway models

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -728,6 +728,55 @@ describe('codex proxy host', () => {
     });
   });
 
+  it('keeps parallel strict-gateway tool calls grouped before their matched outputs', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model: 'moonshot/kimi-k3',
+      parallel_tool_calls: true,
+      input: [
+        { type: 'function_call', name: 'exec_command', call_id: 'call_1', arguments: '{"cmd":"pwd"}' },
+        { type: 'function_call', name: 'exec_command', call_id: 'call_2', arguments: '{"cmd":"git status"}' },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '两个命令都在执行。' }],
+        },
+        { type: 'function_call_output', call_id: 'call_1', output: '/repo' },
+        { type: 'function_call_output', call_id: 'call_2', output: 'clean' },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '继续' }] },
+      ],
+    };
+    const ctx = { method: 'POST', url: '/responses', headers: {} };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'moonshot/kimi-k3',
+      parallel_tool_calls: true,
+      input: [
+        { type: 'function_call', name: 'exec_command', call_id: 'call_1', arguments: '{"cmd":"pwd"}' },
+        { type: 'function_call', name: 'exec_command', call_id: 'call_2', arguments: '{"cmd":"git status"}' },
+        { type: 'function_call_output', call_id: 'call_1', output: '/repo' },
+        { type: 'function_call_output', call_id: 'call_2', output: 'clean' },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '两个命令都在执行。' }],
+        },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '继续' }] },
+      ],
+    });
+  });
+
   it('keeps interleaved tool history unchanged for non-strict gateway models', async () => {
     const host = await freshCodexProxyHost();
     mockState.createAnthropicCompatProxy.mockResolvedValueOnce({

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -452,8 +452,8 @@ describe('codex proxy host', () => {
         // upstream 是函数形态(每请求现取,model-access 下发可运行期换 endpoint);
         // 断言其当前求值 = 网关 base + /v1
         upstream: expect.any(Function),
-        // [encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields]
-        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
+        // [encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields]
+        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
         routingTransform: expect.any(Function),
         recoveryRules: expect.arrayContaining([
           expect.objectContaining({ id: 'encrypted_content' }),
@@ -662,6 +662,97 @@ describe('codex proxy host', () => {
     clearSessionProvider('session-openai-custom-tool');
   });
 
+  it.each([
+    'moonshot/kimi-k3',
+    'deepseek/deepseek-v4-pro',
+    'deepseek/deepseek-v4-flash',
+  ])('normalizes strict gateway history for model %s', async (model) => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model,
+      input: [
+        { type: 'function_call', name: 'exec_command', call_id: 'call_1', arguments: '{"cmd":"pwd"}' },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '我先检查项目目录。' }],
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '' }],
+        },
+        { type: 'function_call', name: 'exec_command', call_id: 'call_2', arguments: '{"cmd":"git status"}' },
+        { type: 'function_call_output', call_id: 'call_1', output: '/repo' },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '接着检查工作区。' }],
+        },
+        { type: 'function_call_output', call_id: 'call_2', output: 'clean' },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '继续' }] },
+      ],
+    };
+    const ctx = { method: 'POST', url: '/responses', headers: {} };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model,
+      input: [
+        { type: 'function_call', name: 'exec_command', call_id: 'call_1', arguments: '{"cmd":"pwd"}' },
+        { type: 'function_call_output', call_id: 'call_1', output: '/repo' },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '我先检查项目目录。' }],
+        },
+        { type: 'function_call', name: 'exec_command', call_id: 'call_2', arguments: '{"cmd":"git status"}' },
+        { type: 'function_call_output', call_id: 'call_2', output: 'clean' },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '接着检查工作区。' }],
+        },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '继续' }] },
+      ],
+    });
+  });
+
+  it('keeps interleaved tool history unchanged for non-strict gateway models', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    const input = [
+      { type: 'function_call', name: 'exec_command', call_id: 'call_1', arguments: '{"cmd":"pwd"}' },
+      { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'checking' }] },
+      { type: 'function_call_output', call_id: 'call_1', output: '/repo' },
+    ];
+    const original = { model: 'qwen/qwen3.7-max', input };
+    let current: unknown = original;
+    const ctx = { method: 'POST', url: '/responses', headers: {} };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual(original);
+  });
+
   it('normalizes requests to ByteDance Seed Responses capabilities', async () => {
     const host = await freshCodexProxyHost();
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
@@ -688,6 +779,15 @@ describe('codex proxy host', () => {
       parallel_tool_calls: false,
       input: [
         { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'earlier answer' }] },
+        { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '' }] },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [
+            { type: 'output_text', text: '' },
+            { type: 'output_text', text: 'non-empty remainder' },
+          ],
+        },
         { type: 'reasoning', summary: [], content: null },
         { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
       ],
@@ -718,6 +818,12 @@ describe('codex proxy host', () => {
           role: 'assistant',
           status: 'completed',
           content: [{ type: 'output_text', text: 'earlier answer' }],
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'non-empty remainder' }],
         },
         { type: 'reasoning', summary: [], content: null },
         { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
@@ -1213,7 +1319,7 @@ describe('codex proxy host', () => {
     await host.ensureCodexProxyReady();
 
     const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
-    expect(transforms).toHaveLength(10); // encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields, dump
+    expect(transforms).toHaveLength(11); // encrypted activeStrip, image generation activeStrip, instructions 注入, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields, dump
     const ctx = {
       method: 'POST',
       url: '/v1/responses',

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -641,24 +641,133 @@ function sanitizeByteDanceSeedTools(body: Record<string, unknown>): Record<strin
   return next;
 }
 
-/** Volcengine requires replayed assistant messages to carry their output status. */
+const STRICT_GATEWAY_TOOL_HISTORY_MODELS = new Set([
+  'moonshot/kimi-k3',
+  'deepseek/deepseek-v4-pro',
+  'deepseek/deepseek-v4-flash',
+]);
+const RESPONSE_TOOL_CALL_TYPES = new Set(['function_call', 'custom_tool_call']);
+const RESPONSE_TOOL_OUTPUT_TYPES = new Set(['function_call_output', 'custom_tool_call_output']);
+
+function responseToolCallId(item: unknown, output: boolean): string | null {
+  if (!isPlainObject(item)) return null;
+  const supportedTypes = output ? RESPONSE_TOOL_OUTPUT_TYPES : RESPONSE_TOOL_CALL_TYPES;
+  if (!supportedTypes.has(typeof item.type === 'string' ? item.type : '')) return null;
+  return typeof item.call_id === 'string' && item.call_id.length > 0 ? item.call_id : null;
+}
+
+function stripEmptyResponseMessage(item: unknown): { item: unknown; changed: boolean } | null {
+  if (!isPlainObject(item) || item.type !== 'message') return { item, changed: false };
+  if (item.content === '') return null;
+  if (!Array.isArray(item.content)) return { item, changed: false };
+
+  const content = item.content.filter((part) => !(
+    isPlainObject(part) &&
+    (part.type === 'input_text' || part.type === 'output_text') &&
+    part.text === ''
+  ));
+  if (content.length === 0) return null;
+  return content.length === item.content.length
+    ? { item, changed: false }
+    : { item: { ...item, content }, changed: true };
+}
+
+/** Volcengine requires replayed assistant messages to carry their output status and non-empty text. */
 function normalizeByteDanceSeedInput(body: Record<string, unknown>): Record<string, unknown> | null {
   if (!isByteDanceSeedModel(body.model) || !Array.isArray(body.input)) return null;
 
   let changed = false;
-  const input = body.input.map((item) => {
-    if (
-      !isPlainObject(item) ||
-      item.type !== 'message' ||
-      item.role !== 'assistant' ||
-      typeof item.status === 'string'
-    ) {
-      return item;
+  const input: unknown[] = [];
+  for (const item of body.input) {
+    const normalized = stripEmptyResponseMessage(item);
+    if (!normalized) {
+      changed = true;
+      continue;
     }
-    changed = true;
-    return { ...item, status: 'completed' };
-  });
+    if (normalized.changed) changed = true;
+
+    const nextItem = normalized.item;
+    if (
+      isPlainObject(nextItem) &&
+      nextItem.type === 'message' &&
+      nextItem.role === 'assistant' &&
+      typeof nextItem.status !== 'string'
+    ) {
+      changed = true;
+      input.push({ ...nextItem, status: 'completed' });
+      continue;
+    }
+    input.push(nextItem);
+  }
   return changed ? { ...body, input } : null;
+}
+
+/**
+ * LiteLLM converts gateway Responses history to Chat Completions for these models.
+ * Their native APIs require every assistant tool call to be followed immediately
+ * by its tool result, while Codex may persist an assistant progress message between
+ * the Responses function_call and function_call_output items. Codex may also persist
+ * empty assistant output_text items, which Moonshot rejects after history conversion.
+ */
+function normalizeStrictGatewayHistory(body: Record<string, unknown>): Record<string, unknown> | null {
+  if (
+    typeof body.model !== 'string' ||
+    !STRICT_GATEWAY_TOOL_HISTORY_MODELS.has(body.model) ||
+    !Array.isArray(body.input)
+  ) {
+    return null;
+  }
+
+  const matchedOutputs = new Map<number, number>();
+  const usedOutputIndexes = new Set<number>();
+  const outputIndexesByCallId = new Map<string, number[]>();
+  const outputCursorByCallId = new Map<string, number>();
+  for (let index = 0; index < body.input.length; index += 1) {
+    const outputCallId = responseToolCallId(body.input[index], true);
+    if (!outputCallId) continue;
+    const indexes = outputIndexesByCallId.get(outputCallId) ?? [];
+    indexes.push(index);
+    outputIndexesByCallId.set(outputCallId, indexes);
+  }
+
+  for (let callIndex = 0; callIndex < body.input.length; callIndex += 1) {
+    const callId = responseToolCallId(body.input[callIndex], false);
+    if (!callId) continue;
+
+    const outputIndexes = outputIndexesByCallId.get(callId);
+    if (!outputIndexes) continue;
+    let cursor = outputCursorByCallId.get(callId) ?? 0;
+    while (cursor < outputIndexes.length && outputIndexes[cursor] <= callIndex) cursor += 1;
+    if (cursor >= outputIndexes.length) continue;
+
+    const outputIndex = outputIndexes[cursor];
+    outputCursorByCallId.set(callId, cursor + 1);
+    matchedOutputs.set(callIndex, outputIndex);
+    usedOutputIndexes.add(outputIndex);
+  }
+
+  let changed = [...matchedOutputs].some(([callIndex, outputIndex]) => outputIndex !== callIndex + 1);
+  const input: unknown[] = [];
+  for (let index = 0; index < body.input.length; index += 1) {
+    if (usedOutputIndexes.has(index)) continue;
+    const normalized = stripEmptyResponseMessage(body.input[index]);
+    if (!normalized) {
+      changed = true;
+    } else {
+      if (normalized.changed) changed = true;
+      input.push(normalized.item);
+    }
+    const outputIndex = matchedOutputs.get(index);
+    if (outputIndex !== undefined) input.push(body.input[outputIndex]);
+  }
+  return changed ? { ...body, input } : null;
+}
+
+function createStrictGatewayHistoryCompatTransform(): RequestTransform {
+  return (body) => {
+    if (!isPlainObject(body)) return null;
+    return normalizeStrictGatewayHistory(body);
+  };
 }
 
 /** Seed accepts the reasoning effort, but rejects Responses' summary selector. */
@@ -1164,6 +1273,7 @@ function createTransformRequestChain(): RequestTransform[] {
     // 必须先于 xAI/MiniMax 兼容改写:加密压缩块换成明文占位 message 后,后续
     // 针对具体供应商的 input 归一化才能按标准 message 处理它。
     createCrossProviderCompactionCompatTransform(),
+    createStrictGatewayHistoryCompatTransform(),
     createXaiResponsesCompatTransform(),
     createByteDanceSeedResponsesCompatTransform(),
     createMiniMaxResponsesCompatTransform(),

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -708,6 +708,8 @@ function normalizeByteDanceSeedInput(body: Record<string, unknown>): Record<stri
  * by its tool result, while Codex may persist an assistant progress message between
  * the Responses function_call and function_call_output items. Codex may also persist
  * empty assistant output_text items, which Moonshot rejects after history conversion.
+ * Consecutive calls form one parallel assistant group, so their matched outputs must
+ * be moved after the whole group rather than inserted between calls.
  */
 function normalizeStrictGatewayHistory(body: Record<string, unknown>): Record<string, unknown> | null {
   if (
@@ -718,20 +720,27 @@ function normalizeStrictGatewayHistory(body: Record<string, unknown>): Record<st
     return null;
   }
 
+  const originalInput = body.input;
+  const normalizedInput: unknown[] = [];
+  for (const item of originalInput) {
+    const normalized = stripEmptyResponseMessage(item);
+    if (normalized) normalizedInput.push(normalized.item);
+  }
+
   const matchedOutputs = new Map<number, number>();
   const usedOutputIndexes = new Set<number>();
   const outputIndexesByCallId = new Map<string, number[]>();
   const outputCursorByCallId = new Map<string, number>();
-  for (let index = 0; index < body.input.length; index += 1) {
-    const outputCallId = responseToolCallId(body.input[index], true);
+  for (let index = 0; index < normalizedInput.length; index += 1) {
+    const outputCallId = responseToolCallId(normalizedInput[index], true);
     if (!outputCallId) continue;
     const indexes = outputIndexesByCallId.get(outputCallId) ?? [];
     indexes.push(index);
     outputIndexesByCallId.set(outputCallId, indexes);
   }
 
-  for (let callIndex = 0; callIndex < body.input.length; callIndex += 1) {
-    const callId = responseToolCallId(body.input[callIndex], false);
+  for (let callIndex = 0; callIndex < normalizedInput.length; callIndex += 1) {
+    const callId = responseToolCallId(normalizedInput[callIndex], false);
     if (!callId) continue;
 
     const outputIndexes = outputIndexesByCallId.get(callId);
@@ -746,20 +755,42 @@ function normalizeStrictGatewayHistory(body: Record<string, unknown>): Record<st
     usedOutputIndexes.add(outputIndex);
   }
 
-  let changed = [...matchedOutputs].some(([callIndex, outputIndex]) => outputIndex !== callIndex + 1);
-  const input: unknown[] = [];
-  for (let index = 0; index < body.input.length; index += 1) {
-    if (usedOutputIndexes.has(index)) continue;
-    const normalized = stripEmptyResponseMessage(body.input[index]);
-    if (!normalized) {
-      changed = true;
-    } else {
-      if (normalized.changed) changed = true;
-      input.push(normalized.item);
+  const outputIndexesByGroupEnd = new Map<number, number[]>();
+  for (let groupStart = 0; groupStart < normalizedInput.length;) {
+    if (!responseToolCallId(normalizedInput[groupStart], false)) {
+      groupStart += 1;
+      continue;
     }
-    const outputIndex = matchedOutputs.get(index);
-    if (outputIndex !== undefined) input.push(body.input[outputIndex]);
+    let groupEnd = groupStart;
+    while (
+      groupEnd + 1 < normalizedInput.length &&
+      responseToolCallId(normalizedInput[groupEnd + 1], false)
+    ) {
+      groupEnd += 1;
+    }
+    const outputIndexes: number[] = [];
+    for (let callIndex = groupStart; callIndex <= groupEnd; callIndex += 1) {
+      const outputIndex = matchedOutputs.get(callIndex);
+      if (outputIndex !== undefined) outputIndexes.push(outputIndex);
+    }
+    if (outputIndexes.length > 0) {
+      outputIndexesByGroupEnd.set(groupEnd, outputIndexes.sort((a, b) => a - b));
+    }
+    groupStart = groupEnd + 1;
   }
+
+  const input: unknown[] = [];
+  for (let index = 0; index < normalizedInput.length; index += 1) {
+    if (usedOutputIndexes.has(index)) continue;
+    input.push(normalizedInput[index]);
+    const outputIndexes = outputIndexesByGroupEnd.get(index);
+    if (outputIndexes) {
+      for (const outputIndex of outputIndexes) input.push(normalizedInput[outputIndex]);
+    }
+  }
+  const changed =
+    input.length !== originalInput.length ||
+    input.some((item, index) => item !== originalInput[index]);
   return changed ? { ...body, input } : null;
 }
 

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -1110,7 +1110,8 @@
       },
       "qwen/qwen3.7-max": {
         "agents": [
-          "claude-code"
+          "claude-code",
+          "codex"
         ],
         "name": "Qwen 3.7 Max",
         "group": "china",
@@ -1148,7 +1149,8 @@
       },
       "z-ai/glm-5.2": {
         "agents": [
-          "claude-code"
+          "claude-code",
+          "codex"
         ],
         "name": "GLM-5.2",
         "group": "china",
@@ -1164,7 +1166,8 @@
       },
       "deepseek/deepseek-v4-pro": {
         "agents": [
-          "claude-code"
+          "claude-code",
+          "codex"
         ],
         "name": "DeepSeek V4 Pro",
         "group": "china",
@@ -1180,7 +1183,8 @@
       },
       "deepseek/deepseek-v4-flash": {
         "agents": [
-          "claude-code"
+          "claude-code",
+          "codex"
         ],
         "name": "DeepSeek V4 Flash",
         "group": "china",
@@ -1226,7 +1230,8 @@
       },
       "moonshot/kimi-k3": {
         "agents": [
-          "claude-code"
+          "claude-code",
+          "codex"
         ],
         "name": "Kimi K3",
         "group": "china",

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -147,20 +147,27 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     expect(presets.map((p) => p.id)).toContain('openrouter');
   });
 
-  it('ships product display names for newly discovered XD gateway models', () => {
+  it('ships Codex support metadata for the current XD gateway model set', () => {
     const metadata = BUNDLED_CATALOG.cindyModelMeta as {
       version?: unknown;
       models?: Record<string, unknown>;
     };
     expect(metadata.version).toBe(1);
-    expect(metadata.models?.['bytedance-seed/seed-2.1-pro']).toMatchObject({
-      agents: ['claude-code', 'codex'],
-      name: 'Seed 2.1 Pro',
-    });
-    expect(metadata.models?.['qwen/qwen3.8-max-preview']).toMatchObject({
-      agents: ['claude-code', 'codex'],
-      name: 'Qwen 3.8 Max Preview',
-    });
+    const expected = {
+      'qwen/qwen3.7-max': 'Qwen 3.7 Max',
+      'moonshot/kimi-k3': 'Kimi K3',
+      'z-ai/glm-5.2': 'GLM-5.2',
+      'deepseek/deepseek-v4-pro': 'DeepSeek V4 Pro',
+      'deepseek/deepseek-v4-flash': 'DeepSeek V4 Flash',
+      'bytedance-seed/seed-2.1-pro': 'Seed 2.1 Pro',
+      'qwen/qwen3.8-max-preview': 'Qwen 3.8 Max Preview',
+    };
+    for (const [id, name] of Object.entries(expected)) {
+      expect(metadata.models?.[id], id).toMatchObject({
+        agents: ['claude-code', 'codex'],
+        name,
+      });
+    }
   });
 
   it('models are grouped per-agent (no flat array, no rogue agent keys)', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Cindy AI 当前 5 个仅支持 Claude Code 的网关模型开放 Codex，并补齐 Kimi、DeepSeek 与 Seed 在 Codex Responses 历史回放中的兼容转换，避免长会话或跨模型切换时因工具结果顺序、空文本消息触发上游 400。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Cindy AI 网关模型 Codex 支持
- 本 PR 包含：
  - 为 Qwen 3.7 Max、Kimi K3、GLM-5.2、DeepSeek V4 Pro、DeepSeek V4 Flash 增加 Codex 元数据
  - 对 Kimi/DeepSeek 严格历史进行工具调用结果就近重排，并清理空文本消息
  - Seed 复用空文本清理，避免跨模型历史触发 `input.content.text` 缺失
  - 增加 catalog 与代理回归测试
- 明确不包含：服务端/LiteLLM 改动、系统提示词、UI 样式或文案改动
- 用户可见变化：上述 5 个模型可在 Codex 中选择；Kimi、DeepSeek、Seed 的长会话与跨模型切换不再因相关历史格式返回 400
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 结构或视觉改动；模型选择器沿用现有 catalog 元数据渲染。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部必跑 workspace 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：通过（该 package 无 typecheck script，按 --if-present 跳过）

pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/skillSlot.test.ts src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：2 files / 66 tests passed

pnpm --filter @cindy/model-providers exec vitest run src/__tests__/catalog.test.ts
结果：1 file / 28 tests passed

git diff --check
结果：通过
```

### 手工验证

- macOS Desktop remote dev（region=cn）已重启并处于 ready
- Kimi K3 在原问题长会话中完成工具调用与回复，上游返回 200
- Seed 2.1 Pro 在同一跨模型历史中完成回复，上游返回 200
- 拉取最新主干后 Vite 依赖预打包缓存已清理，Desktop 正常启动

### 未执行的验证

- 未在 Windows 手工验证；改动位于跨平台请求转换和模型目录，已由单测与 Desktop typecheck 覆盖

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Cindy 网关 Codex 请求。Kimi/DeepSeek 的历史归一化按明确模型 ID 生效；Seed 仅增加空文本清理；Qwen 等非严格模型保持原历史顺序。
- 性能：工具结果匹配使用线性索引扫描；未修改 prompt、tool 定义或缓存键，缓存命中口径不变。
- 回滚 / 降级方式：回退本 PR 提交，或从 catalog 中移除对应模型的 `codex` agent 元数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档更新）
- [x] 已确认测试结果或说明未执行原因
