### PR TITLE
perf(desktop): 文件名筛选索引改为惰性拉取,切会话不再全量扫描 workdir

### DIFF
--- a/apps/desktop/src/renderer/__tests__/workdirBrowseRemoteSafety.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workdirBrowseRemoteSafety.test.ts
@@ -97,7 +97,7 @@ describe('workdir browse remote safety', () => {
     // sidebar 侧同理:树 / 文件名索引 / 搜索 / 增删改全部带 remoteHostId,
     // 且"显示所在文件夹"这类本机-only 菜单在 remote 下不可用。
     expect(sidebarBrowseSource).toContain('useFileTree({ workdir, remoteHostId, deviceId,');
-    expect(sidebarBrowseSource).toContain('useProjectFileList(workdir, remoteHostId, deviceId)');
+    expect(sidebarBrowseSource).toContain('useProjectFileList(workdir, remoteHostId, deviceId, {');
     expect(sidebarBrowseSource).toContain('remoteHostId || deviceId ? undefined : handleRevealInFolder');
   });
 

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
@@ -218,12 +218,16 @@ export function WorkdirBrowseSidebar({
   // 流式增量返回再启用。scanner.ts 的过滤逻辑保留,改回 true 即可恢复。
   const tree = useFileTree({ workdir, remoteHostId, deviceId, hideMetaFiles: true, docMode: false });
 
-  // 项目级文件名扁平列表(走 ripgrep --files honor .gitignore),给"筛选文件"用。
-  // 模块级 cache 跨 doc 模式 / RSB plugin 共享同一份索引;tree refresh 时同步 invalidate。
-  const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId);
   // 文件名筛选 query —— tree 模式下用,独立于内容搜索。空 query 显示文件树,有
   // 内容显示筛选结果列表。workdir 切换时自动清空(下方 useEffect)。
   const [filterQuery, setFilterQuery] = useState('');
+  // 项目级文件名扁平列表(走 ripgrep --files honor .gitignore),给"筛选文件"用。
+  // 模块级 cache 跨 doc 模式 / RSB plugin 共享同一份索引;tree refresh 时同步 invalidate。
+  // enabled 惰性拉取:query 为空(FilterResultList 不显示)时不扫描 —— 切会话
+  // 不再为用不上的索引付 rg + IPC + 建索引的主线程成本。
+  const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId, {
+    enabled: filterQuery !== '',
+  });
   const filteredFiles = useMemo(
     () => filterFiles(filterQuery, projectFiles.files),
     [filterQuery, projectFiles.files],

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
@@ -224,9 +224,10 @@ export function WorkdirBrowseSidebar({
   // 项目级文件名扁平列表(走 ripgrep --files honor .gitignore),给"筛选文件"用。
   // 模块级 cache 跨 doc 模式 / RSB plugin 共享同一份索引;tree refresh 时同步 invalidate。
   // enabled 惰性拉取:query 为空(FilterResultList 不显示)时不扫描 —— 切会话
-  // 不再为用不上的索引付 rg + IPC + 建索引的主线程成本。
+  // 不再为用不上的索引付 rg + IPC + 建索引的主线程成本。trim 与 filterFiles
+  // 的匹配语义对齐:纯空格 query 结果必为空,不值得为它扫描。
   const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId, {
-    enabled: filterQuery !== '',
+    enabled: filterQuery.trim() !== '',
   });
   const filteredFiles = useMemo(
     () => filterFiles(filterQuery, projectFiles.files),

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
@@ -137,4 +137,61 @@ describe('useProjectFileList', () => {
     });
     await waitFor(() => expect(mocks.listAllFiles).toHaveBeenCalledTimes(2));
   });
+
+  it('error token(如 RG_UNAVAILABLE)随缓存保留:enabled 翻转 + 缓存命中后不丢', async () => {
+    mocks.listAllFiles.mockResolvedValue({ files: [], truncated: false, elapsedMs: 5, error: 'RG_UNAVAILABLE' });
+    const { result, rerender } = renderList({ workdir: '/remote', enabled: true });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe('RG_UNAVAILABLE');
+
+    // 清空筛选(enabled=false)再输入(enabled=true,缓存 30s 内命中):error 必须
+    // 还原,否则空 files + null error 会把"未索引"占位显示成"无匹配"。
+    rerender({ workdir: '/remote', enabled: false });
+    expect(result.current.error).toBe('RG_UNAVAILABLE');
+    rerender({ workdir: '/remote', enabled: true });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1); // 缓存命中,无新 IPC
+    expect(result.current.error).toBe('RG_UNAVAILABLE');
+    expect(result.current.files).toEqual([]);
+  });
+
+  it('disabled refresh 清空 state:重新 enabled 拉取期间不闪 stale 结果', async () => {
+    const { result, rerender } = renderList({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(result.current.files.length).toBe(2));
+
+    rerender({ workdir: '/repo', enabled: false });
+    act(() => {
+      result.current.refresh();
+    });
+    // FilterResultList 只在 files 为空时显示"正在索引"占位,refresh 后必须清空。
+    expect(result.current.files).toEqual([]);
+
+    rerender({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(mocks.listAllFiles).toHaveBeenCalledTimes(2));
+  });
+
+  it('refresh 期间完成的在途请求不得把旧快照写回缓存', async () => {
+    let resolveFetch!: (v: { files: string[]; truncated: boolean; elapsedMs: number }) => void;
+    mocks.listAllFiles.mockImplementationOnce(
+      () => new Promise((done) => { resolveFetch = done; }),
+    );
+    const { result, rerender } = renderList({ workdir: '/repo', enabled: true });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+
+    // 拉取尚未完成时用户清空筛选并点了树刷新(失效缓存)。
+    rerender({ workdir: '/repo', enabled: false });
+    act(() => {
+      result.current.refresh();
+    });
+    // 在途请求此刻才完成:结果已因失效代数不匹配而不进缓存。
+    await act(async () => {
+      resolveFetch(listResult(['stale.ts']));
+      await Promise.resolve();
+    });
+
+    // 重新 enabled:缓存里没有可复用的快照 → 必须重新拉,而不是复用 stale.ts。
+    mocks.listAllFiles.mockResolvedValue(listResult(['fresh.ts']));
+    rerender({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(result.current.files).toEqual(['fresh.ts']));
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
@@ -212,6 +212,50 @@ describe('useProjectFileList', () => {
     expect(second.result.current.isLoading).toBe(false);
   });
 
+  it('另一实例 refresh 时,在途实例不卡 loading,追上新请求的结果', async () => {
+    let resolveOld!: (v: { files: string[]; truncated: boolean; elapsedMs: number }) => void;
+    mocks.listAllFiles.mockImplementationOnce(
+      () => new Promise((done) => { resolveOld = done; }),
+    );
+    // X 发起请求(pending);Y 共享同一 cacheKey。
+    const x = renderList({ workdir: '/repo', enabled: true });
+    const y = renderList({ workdir: '/repo', enabled: true });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+
+    // Y 触发 refresh:作废在途请求并发起新扫描。
+    mocks.listAllFiles.mockResolvedValue(listResult(['fresh.ts']));
+    act(() => {
+      y.result.current.refresh();
+    });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(2);
+
+    // 旧请求此刻完成:X 的回调因失效代数不匹配不能直接丢弃 —— 必须追上新请求,
+    // 否则 X 永久停在 isLoading(没有其它回调会再喂它)。
+    await act(async () => {
+      resolveOld(listResult(['stale.ts']));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(x.result.current.isLoading).toBe(false));
+    expect(x.result.current.files).toEqual(['fresh.ts']);
+    await waitFor(() => expect(y.result.current.files).toEqual(['fresh.ts']));
+  });
+
+  it('拉取失败回退缓存时保留 truncated 标志', async () => {
+    mocks.listAllFiles.mockResolvedValue(listResult(['a.ts'], true));
+    const { result, rerender } = renderList({ workdir: '/big', enabled: true });
+    await waitFor(() => expect(result.current.truncated).toBe(true));
+
+    // truncated 快照 5 分钟 TTL 过期后重拉失败:回退缓存 files 时"结果过多"
+    // 标志不能静默消失 —— 列表仍是截断的。
+    rerender({ workdir: '/big', enabled: false });
+    vi.setSystemTime(new Date('2026-07-25T12:06:00Z'));
+    mocks.listAllFiles.mockRejectedValueOnce(new Error('boom'));
+    rerender({ workdir: '/big', enabled: true });
+    await waitFor(() => expect(result.current.error).toContain('boom'));
+    expect(result.current.files).toEqual(['a.ts']);
+    expect(result.current.truncated).toBe(true);
+  });
+
   it('refresh 期间完成的在途请求不得把旧快照写回缓存', async () => {
     let resolveFetch!: (v: { files: string[]; truncated: boolean; elapsedMs: number }) => void;
     mocks.listAllFiles.mockImplementationOnce(

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
@@ -192,6 +192,26 @@ describe('useProjectFileList', () => {
     await waitFor(() => expect(result.current.files).toEqual(['fresh.ts']));
   });
 
+  it('piggyback 消费 inflight 的解析值:fetch 失败(不写缓存)时搭车方同样拿到 error', async () => {
+    let rejectFetch!: (err: Error) => void;
+    mocks.listAllFiles.mockImplementationOnce(
+      () => new Promise((_done, fail) => { rejectFetch = fail; }),
+    );
+    const first = renderList({ workdir: '/repo', enabled: true });
+    // 第二个实例在第一个 pending 时挂载:走 piggyback,不发新 IPC。
+    const second = renderList({ workdir: '/repo', enabled: true });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rejectFetch(new Error('boom'));
+      await Promise.resolve();
+    });
+    // 失败结果不进缓存,搭车方必须从 inflight 解析值拿到 error,而不是回读空缓存。
+    await waitFor(() => expect(first.result.current.error).toContain('boom'));
+    await waitFor(() => expect(second.result.current.error).toContain('boom'));
+    expect(second.result.current.isLoading).toBe(false);
+  });
+
   it('refresh 期间完成的在途请求不得把旧快照写回缓存', async () => {
     let resolveFetch!: (v: { files: string[]; truncated: boolean; elapsedMs: number }) => void;
     mocks.listAllFiles.mockImplementationOnce(

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
@@ -169,6 +169,29 @@ describe('useProjectFileList', () => {
     await waitFor(() => expect(mocks.listAllFiles).toHaveBeenCalledTimes(2));
   });
 
+  it('enabled=true 的 refresh 作废在途请求并发起新扫描,最终展示新快照', async () => {
+    let resolveOld!: (v: { files: string[]; truncated: boolean; elapsedMs: number }) => void;
+    mocks.listAllFiles.mockImplementationOnce(
+      () => new Promise((done) => { resolveOld = done; }),
+    );
+    const { result } = renderList({ workdir: '/repo', enabled: true });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+
+    // 旧请求未完成时点刷新:必须发起第二次扫描(不 piggyback 已失效请求)。
+    mocks.listAllFiles.mockResolvedValue(listResult(['fresh.ts']));
+    act(() => {
+      result.current.refresh();
+    });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(2);
+
+    // 旧请求此刻才完成:其结果不得覆盖 state,最终展示的是新快照。
+    await act(async () => {
+      resolveOld(listResult(['stale.ts']));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.files).toEqual(['fresh.ts']));
+  });
+
   it('refresh 期间完成的在途请求不得把旧快照写回缓存', async () => {
     let resolveFetch!: (v: { files: string[]; truncated: boolean; elapsedMs: number }) => void;
     mocks.listAllFiles.mockImplementationOnce(

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listAllFiles: vi.fn(),
+}));
+
+vi.mock('@/lib/fileBrowserTransport', () => ({
+  fileBrowserApiFor: () => ({
+    listAllFiles: mocks.listAllFiles,
+  }),
+}));
+
+import { _resetProjectFileListCache, useProjectFileList } from '../useProjectFileList';
+
+type HookProps = {
+  workdir: string;
+  enabled?: boolean;
+};
+
+function renderList(initial: HookProps) {
+  return renderHook(
+    ({ workdir, enabled }: HookProps) =>
+      useProjectFileList(workdir, null, null, enabled === undefined ? undefined : { enabled }),
+    { initialProps: initial },
+  );
+}
+
+function listResult(files: string[], truncated = false) {
+  return { files, truncated, elapsedMs: 5 };
+}
+
+describe('useProjectFileList', () => {
+  beforeEach(() => {
+    _resetProjectFileListCache();
+    mocks.listAllFiles.mockReset();
+    mocks.listAllFiles.mockResolvedValue(listResult(['a.ts', 'src/b.ts']));
+    // hook 用 window.electronAPI 存在性判断 IPC 可用;实际调用走被 mock 的
+    // fileBrowserApiFor,这里只需要占位真值。
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      fileBrowser: { listAllFiles: () => undefined },
+    };
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-25T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it('不传 options 时保持旧语义:挂载即拉', async () => {
+    const { result } = renderList({ workdir: '/repo' });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+    expect(result.current.files).toEqual(['a.ts', 'src/b.ts']);
+  });
+
+  it('enabled=false 时不发 IPC,不进入 loading', () => {
+    const { result } = renderList({ workdir: '/repo', enabled: false });
+    expect(mocks.listAllFiles).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.files).toEqual([]);
+  });
+
+  it('enabled 翻 true 时才发起首次拉取', async () => {
+    const { result, rerender } = renderList({ workdir: '/repo', enabled: false });
+    expect(mocks.listAllFiles).not.toHaveBeenCalled();
+
+    rerender({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(result.current.files).toEqual(['a.ts', 'src/b.ts']));
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('true→false→true 且缓存新鲜:不重复拉取', async () => {
+    const { result, rerender } = renderList({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(result.current.files.length).toBe(2));
+
+    rerender({ workdir: '/repo', enabled: false });
+    rerender({ workdir: '/repo', enabled: true });
+    // fresh 缓存直接命中,不新增 IPC。
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+    expect(result.current.files).toEqual(['a.ts', 'src/b.ts']);
+  });
+
+  it('普通快照 30s 过期:重新 enabled 时重拉', async () => {
+    const { result, rerender } = renderList({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(result.current.files.length).toBe(2));
+
+    rerender({ workdir: '/repo', enabled: false });
+    vi.setSystemTime(new Date('2026-07-25T12:00:31Z'));
+    rerender({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(mocks.listAllFiles).toHaveBeenCalledTimes(2));
+  });
+
+  it('truncated 快照放宽到 5 分钟:31s 不重拉,5 分钟后重拉', async () => {
+    mocks.listAllFiles.mockResolvedValue(listResult(['a.ts'], true));
+    const { result, rerender } = renderList({ workdir: '/big', enabled: true });
+    await waitFor(() => expect(result.current.truncated).toBe(true));
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+
+    // 31 秒后:普通 TTL 已过,但 truncated 快照仍然有效 → 不重拉。
+    rerender({ workdir: '/big', enabled: false });
+    vi.setSystemTime(new Date('2026-07-25T12:00:31Z'));
+    rerender({ workdir: '/big', enabled: true });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1);
+
+    // 超过 5 分钟:truncated TTL 也过期 → 重拉。
+    rerender({ workdir: '/big', enabled: false });
+    vi.setSystemTime(new Date('2026-07-25T12:05:32Z'));
+    rerender({ workdir: '/big', enabled: true });
+    await waitFor(() => expect(mocks.listAllFiles).toHaveBeenCalledTimes(2));
+  });
+
+  it('refresh 在 enabled=false 时只失效缓存不扫描;下次 enabled 拉新', async () => {
+    const { result, rerender } = renderList({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(result.current.files.length).toBe(2));
+
+    rerender({ workdir: '/repo', enabled: false });
+    act(() => {
+      result.current.refresh();
+    });
+    expect(mocks.listAllFiles).toHaveBeenCalledTimes(1); // 没有新扫描
+
+    rerender({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(mocks.listAllFiles).toHaveBeenCalledTimes(2)); // 缓存已失效 → 拉新
+  });
+
+  it('refresh 在 enabled=true 时立即重拉(旧语义)', async () => {
+    const { result } = renderList({ workdir: '/repo', enabled: true });
+    await waitFor(() => expect(result.current.files.length).toBe(2));
+
+    act(() => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(mocks.listAllFiles).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
@@ -60,7 +60,10 @@ interface Snapshot {
 
 // Module-level singleton cache —— 同 workdir 跨 component 实例 / 跨 RSB tab 共享。
 const cache = new Map<string, Snapshot>();
-const inflight = new Map<string, Promise<void>>();
+// inflight 携带结果本身:piggyback 方直接消费 promise 的解析值,不从 cache 回读
+// —— fetch 失败(catch 分支)或被 refresh 失效(gen 不匹配)时都不写 cache,回读
+// 会拿到空快照,把搭车方的 UI 置空、丢掉 error。
+const inflight = new Map<string, Promise<{ snap: Snapshot; error: string | null }>>();
 // 失效代数:refresh 失效缓存时递增。fetchOnce 只在"启动以来没有新的失效"时才
 // 把结果写回缓存 —— 防止 refresh 删掉缓存后,在途请求完成又把旧快照写回,
 // 让下次筛选把刷新前的数据当成新鲜缓存。
@@ -166,41 +169,30 @@ export function useProjectFileList(
     // 捕获发起时的失效代数:期间发生 refresh 时丢弃本回调的 setState —— 刷新后
     // 的新请求会带最新数据,旧数据闪现一帧再被覆盖是可感知的视觉抖动。
     const genAtStart = invalidationGen.get(key) ?? 0;
-    // dedupe 并发 fetch:同 (端点, workdir) 在 inflight 中就 piggyback。
+    // dedupe 并发 fetch:同 (端点, workdir) 在 inflight 中就 piggyback。发起方与
+    // 搭车方消费同一个解析值(fetchOnce 内部全兜底,永不 reject),不从 cache
+    // 回读 —— fetch 失败或被 refresh 失效时结果不进 cache,回读会拿到空快照。
     let p = inflight.get(key);
     if (!p) {
-      const started = (async () => {
-        const { snap, error } = await fetchOnce(wd, remoteHostId, deviceId, key);
-        if (cacheKeyRef.current !== key) return; // 端点/目录已切换:丢弃过期结果
-        if ((invalidationGen.get(key) ?? 0) !== genAtStart) return; // 已被 refresh 失效
-        setState({
-          files: snap.files,
-          truncated: snap.truncated,
-          isLoading: false,
-          error,
-        });
-      })();
+      const started = fetchOnce(wd, remoteHostId, deviceId, key);
       p = started;
       inflight.set(key, started);
       // 只清理自己:refresh 可能已把 inflight 换成了新请求,无条件 delete 会把
       // 新请求的 entry 误删,让后续并发 doFetch 重复 spawn rg。
-      started.finally(() => {
+      void started.finally(() => {
         if (inflight.get(key) === started) inflight.delete(key);
       });
-    } else {
-      // 已有 inflight:等同一个 promise 完后从 cache 取最新值。
-      void p.then(() => {
-        if (cacheKeyRef.current !== key) return; // 端点/目录已切换:丢弃过期结果
-        if ((invalidationGen.get(key) ?? 0) !== genAtStart) return; // 已被 refresh 失效
-        const fresh = cache.get(key);
-        setState({
-          files: fresh?.files ?? [],
-          truncated: fresh?.truncated ?? false,
-          isLoading: false,
-          error: fresh?.error ?? null,
-        });
-      });
     }
+    void p.then(({ snap, error }) => {
+      if (cacheKeyRef.current !== key) return; // 端点/目录已切换:丢弃过期结果
+      if ((invalidationGen.get(key) ?? 0) !== genAtStart) return; // 已被 refresh 失效
+      setState({
+        files: snap.files,
+        truncated: snap.truncated,
+        isLoading: false,
+        error,
+      });
+    });
   }, [remoteHostId, deviceId]);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
@@ -50,11 +50,25 @@ interface Snapshot {
   files: readonly string[];
   truncated: boolean;
   fetchedAt: number;
+  /**
+   * 上次拉取的 error token(如 'RG_UNAVAILABLE':远端无 rg,files 为空但拉取
+   * "成功")。必须随快照缓存并在命中时还原 —— 否则空 files + null error 会让
+   * FilterResultList 的"未索引/失败"占位退化成误导性的"无匹配"。
+   */
+  error: string | null;
 }
 
 // Module-level singleton cache —— 同 workdir 跨 component 实例 / 跨 RSB tab 共享。
 const cache = new Map<string, Snapshot>();
 const inflight = new Map<string, Promise<void>>();
+// 失效代数:refresh 失效缓存时递增。fetchOnce 只在"启动以来没有新的失效"时才
+// 把结果写回缓存 —— 防止 refresh 删掉缓存后,在途请求完成又把旧快照写回,
+// 让下次筛选把刷新前的数据当成新鲜缓存。
+const invalidationGen = new Map<string, number>();
+
+function bumpInvalidation(cacheKey: string): void {
+  invalidationGen.set(cacheKey, (invalidationGen.get(cacheKey) ?? 0) + 1);
+}
 
 function isStale(snap: Snapshot, now: number): boolean {
   const ttl = snap.truncated ? TRUNCATED_CACHE_TTL_MS : CACHE_TTL_MS;
@@ -71,18 +85,23 @@ async function fetchOnce(
   if (!ipc) {
     // 未挂 preload / SSR — 直接给空数组兜底。
     return {
-      snap: { files: [], truncated: false, fetchedAt: Date.now() },
+      snap: { files: [], truncated: false, fetchedAt: Date.now(), error: 'fileBrowser IPC not available' },
       error: 'fileBrowser IPC not available',
     };
   }
+  const genAtStart = invalidationGen.get(cacheKey) ?? 0;
   try {
     const res = await fileBrowserApiFor(deviceId).listAllFiles({ workdir, remoteHostId });
     const snap: Snapshot = {
       files: res.files,
       truncated: res.truncated,
       fetchedAt: Date.now(),
+      error: res.error ?? null,
     };
-    cache.set(cacheKey, snap);
+    // 启动以来发生过 refresh 失效 → 这份结果已过期,只用于本次展示,不进缓存。
+    if ((invalidationGen.get(cacheKey) ?? 0) === genAtStart) {
+      cache.set(cacheKey, snap);
+    }
     return { snap, error: res.error ?? null };
   } catch (err) {
     log.error('listAllFiles failed', { workdir, err });
@@ -90,6 +109,7 @@ async function fetchOnce(
       files: cache.get(cacheKey)?.files ?? [],
       truncated: false,
       fetchedAt: Date.now(),
+      error: String(err),
     };
     return { snap, error: String(err) };
   }
@@ -130,7 +150,7 @@ export function useProjectFileList(
     files: initial?.files ?? [],
     truncated: initial?.truncated ?? false,
     isLoading: enabled && !initial,
-    error: null,
+    error: initial?.error ?? null,
   }));
   // 用 ref 防止 useEffect deps 漂移导致重复 fetch(workdir 不变情况下)。
   const lastFetchedWorkdirRef = useRef<string | null>(null);
@@ -167,7 +187,7 @@ export function useProjectFileList(
           files: fresh?.files ?? [],
           truncated: fresh?.truncated ?? false,
           isLoading: false,
-          error: null,
+          error: fresh?.error ?? null,
         });
       });
     }
@@ -185,7 +205,7 @@ export function useProjectFileList(
         files: snap?.files ?? [],
         truncated: snap?.truncated ?? false,
         isLoading: false,
-        error: null,
+        error: snap?.error ?? null,
       });
       // 清防重 ref:翻回 enabled 后 stale 缓存才能触发重拉。
       if (lastFetchedWorkdirRef.current === cacheKey) lastFetchedWorkdirRef.current = null;
@@ -194,12 +214,13 @@ export function useProjectFileList(
     const snap = cache.get(cacheKey);
     const now = Date.now();
     if (snap && !isStale(snap, now)) {
-      // cache hit & fresh:同步上 snapshot,跳过 IPC。
+      // cache hit & fresh:同步上 snapshot(含上次的 error token —— 空 files +
+      // 丢失 error 会把"未索引"占位误显示成"无匹配"),跳过 IPC。
       setState({
         files: snap.files,
         truncated: snap.truncated,
         isLoading: false,
-        error: null,
+        error: snap.error,
       });
       lastFetchedWorkdirRef.current = cacheKey;
       return;
@@ -212,8 +233,14 @@ export function useProjectFileList(
   const refresh = useCallback(() => {
     if (!workdir) return;
     cache.delete(cacheKey);
+    // 同时递增失效代数:refresh 时可能仍有在途请求,不 bump 的话它完成后会把
+    // 刷新前的旧快照写回缓存,下次筛选被当成新鲜数据。
+    bumpInvalidation(cacheKey);
     if (!enabled) {
       // 树刷新时用户并没在筛选:只失效缓存,不触发扫描 —— 下次 enabled 自然拉新。
+      // state 一并清空:留着旧 files 会让下次 doFetch 的 isLoading 期间闪 stale
+      // 结果(FilterResultList 只在 files 为空时才显示"正在索引"占位)。
+      setState({ files: [], truncated: false, isLoading: false, error: null });
       lastFetchedWorkdirRef.current = null;
       return;
     }
@@ -228,4 +255,5 @@ export function useProjectFileList(
 export function _resetProjectFileListCache(): void {
   cache.clear();
   inflight.clear();
+  invalidationGen.clear();
 }

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
@@ -3,10 +3,17 @@
  *
  * 走 main 进程 `maker:file-browser:list-all`(ripgrep `--files` honor .gitignore)。
  * 缓存策略:
+ *  - **惰性拉取**:`options.enabled=false`(筛选框为空)时不发 IPC —— 索引只服务
+ *    文件名筛选,用户没在筛选时拉全量清单纯属浪费。2026-07 实测:切会话即拉的
+ *    旧行为一天打满 30000-cap 扫描 68 次,大 workdir 场景是会话切换卡顿的主要
+ *    renderer 侧成本。enabled 翻 true(用户输入首字符)才启动首次拉取,
+ *    FilterResultList 的 isLoading 占位天然承接这段等待。
  *  - 模块级 Map<workdir, Snapshot> singleton —— 跨 component 实例共享(同 workdir
  *    不同 file-browser tab 共享一份索引,省一次 rg 子进程开销)。
- *  - 30 秒内同 workdir 直接命中缓存,不重发 IPC。
- *  - hook 暴露 `refresh()`,文件树点刷新按钮时调用 → 强制重新拉。
+ *  - 30 秒内同 workdir 直接命中缓存,不重发 IPC;打满 cap 的截断快照放宽到
+ *    5 分钟 —— 重扫也不会更完整,却是最贵的一种扫描。
+ *  - hook 暴露 `refresh()`,文件树点刷新按钮时调用 → 强制失效;正在筛选才立即
+ *    重拉,否则留给下次 enabled 时自然拉新。
  *
  * 性能:大型 monorepo 实测 rg --files < 500ms / 数万文件,前端只持有路径字符串
  * 数组,5w 路径 × ~80 bytes ≈ 4MB,可接受。
@@ -21,6 +28,13 @@ const log = createLogger('useProjectFileList');
 
 /** 缓存有效期 ms。超过就重新拉 —— 配合文件树点刷新可以手动 invalidate。 */
 const CACHE_TTL_MS = 30_000;
+
+/**
+ * 打满 cap 的截断快照的缓存有效期。截断意味着 rg 扫到上限被 kill,重扫一遍
+ * 结果同样不完整,但扫描本身却是最贵的(30000 条收集 + IPC + 前端建索引)。
+ * 手动 refresh() 不受此 TTL 影响,仍然立即失效。
+ */
+const TRUNCATED_CACHE_TTL_MS = 5 * 60_000;
 
 export interface ProjectFileListState {
   files: readonly string[];
@@ -43,7 +57,8 @@ const cache = new Map<string, Snapshot>();
 const inflight = new Map<string, Promise<void>>();
 
 function isStale(snap: Snapshot, now: number): boolean {
-  return now - snap.fetchedAt > CACHE_TTL_MS;
+  const ttl = snap.truncated ? TRUNCATED_CACHE_TTL_MS : CACHE_TTL_MS;
+  return now - snap.fetchedAt > ttl;
 }
 
 async function fetchOnce(
@@ -80,6 +95,15 @@ async function fetchOnce(
   }
 }
 
+export interface UseProjectFileListOptions {
+  /**
+   * false = 用户当前没在筛选(筛选框为空),不发 IPC、不跑 rg;有缓存(含过期)
+   * 就静态展示,没有就空数组。翻回 true(输入首字符)时按缓存新鲜度决定是否
+   * 拉取。默认 true 保持旧语义。
+   */
+  enabled?: boolean;
+}
+
 /**
  * @param remoteHostId 非空 = SSH remote 会话:索引在远端 daemon 内跑远端 rg;
  *   远端无 rg 时返回空 + error(筛选面板显示"未索引"占位)。cache key 对远程
@@ -91,9 +115,11 @@ export function useProjectFileList(
   workdir: string,
   remoteHostId: string | null = null,
   deviceId: string | null = null,
+  options?: UseProjectFileListOptions,
 ): ProjectFileListState & {
   refresh: () => void;
 } {
+  const enabled = options?.enabled ?? true;
   const cacheKey = deviceId
     ? `dev:${deviceId}|${workdir}`
     : remoteHostId
@@ -103,7 +129,7 @@ export function useProjectFileList(
   const [state, setState] = useState<ProjectFileListState>(() => ({
     files: initial?.files ?? [],
     truncated: initial?.truncated ?? false,
-    isLoading: !initial,
+    isLoading: enabled && !initial,
     error: null,
   }));
   // 用 ref 防止 useEffect deps 漂移导致重复 fetch(workdir 不变情况下)。
@@ -152,6 +178,19 @@ export function useProjectFileList(
       setState({ files: [], truncated: false, isLoading: false, error: null });
       return;
     }
+    if (!enabled) {
+      // 惰性模式:不发 IPC。有缓存(哪怕 stale)静态展示,没有就空。
+      const snap = cache.get(cacheKey);
+      setState({
+        files: snap?.files ?? [],
+        truncated: snap?.truncated ?? false,
+        isLoading: false,
+        error: null,
+      });
+      // 清防重 ref:翻回 enabled 后 stale 缓存才能触发重拉。
+      if (lastFetchedWorkdirRef.current === cacheKey) lastFetchedWorkdirRef.current = null;
+      return;
+    }
     const snap = cache.get(cacheKey);
     const now = Date.now();
     if (snap && !isStale(snap, now)) {
@@ -168,14 +207,19 @@ export function useProjectFileList(
     if (lastFetchedWorkdirRef.current === cacheKey) return;
     lastFetchedWorkdirRef.current = cacheKey;
     doFetch(workdir, cacheKey);
-  }, [workdir, cacheKey, doFetch]);
+  }, [workdir, cacheKey, doFetch, enabled]);
 
   const refresh = useCallback(() => {
     if (!workdir) return;
     cache.delete(cacheKey);
+    if (!enabled) {
+      // 树刷新时用户并没在筛选:只失效缓存,不触发扫描 —— 下次 enabled 自然拉新。
+      lastFetchedWorkdirRef.current = null;
+      return;
+    }
     lastFetchedWorkdirRef.current = cacheKey;
     doFetch(workdir, cacheKey);
-  }, [workdir, cacheKey, doFetch]);
+  }, [workdir, cacheKey, doFetch, enabled]);
 
   return { ...state, refresh };
 }

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
@@ -108,9 +108,12 @@ async function fetchOnce(
     return { snap, error: res.error ?? null };
   } catch (err) {
     log.error('listAllFiles failed', { workdir, err });
+    // 回退复用缓存时 truncated 一并保留:截断快照拉取失败后丢标志会让
+    // "结果过多"提示静默消失,列表却仍是截断的。
+    const cached = cache.get(cacheKey);
     const snap: Snapshot = {
-      files: cache.get(cacheKey)?.files ?? [],
-      truncated: false,
+      files: cached?.files ?? [],
+      truncated: cached?.truncated ?? false,
       fetchedAt: Date.now(),
       error: String(err),
     };
@@ -163,6 +166,12 @@ export function useProjectFileList(
   useEffect(() => {
     cacheKeyRef.current = cacheKey;
   }, [cacheKey]);
+  // 异步回调里读最新 enabled:失效后的"追新"只在用户仍在筛选时进行,
+  // 否则会在 enabled=false 时发起违背惰性原则的扫描。
+  const enabledRef = useRef(enabled);
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
 
   const doFetch = useCallback((wd: string, key: string) => {
     setState((prev) => ({ ...prev, isLoading: true }));
@@ -185,7 +194,21 @@ export function useProjectFileList(
     }
     void p.then(({ snap, error }) => {
       if (cacheKeyRef.current !== key) return; // 端点/目录已切换:丢弃过期结果
-      if ((invalidationGen.get(key) ?? 0) !== genAtStart) return; // 已被 refresh 失效
+      if ((invalidationGen.get(key) ?? 0) !== genAtStart) {
+        // 期间被 refresh 失效。不能只丢弃:refresh 可能来自共享同一份缓存的
+        // 另一个实例(doc sidebar / RSB 同 workdir),本实例已置 isLoading 且
+        // 没有别的回调会再喂它 —— 直接 return 会永久卡在加载态。
+        if (enabledRef.current) {
+          // 仍在筛选:重新走 doFetch 追上刷新后的新请求(有 inflight 就
+          // piggyback,已完成则命中新缓存路径重新捕获代数)。
+          doFetch(wd, key);
+        } else {
+          // 已退出筛选:追新会发起违背惰性原则的扫描,只防御性退出 loading
+          // (disabled effect 通常已把 state 置为缓存/空)。
+          setState((prev) => (prev.isLoading ? { ...prev, isLoading: false } : prev));
+        }
+        return;
+      }
       setState({
         files: snap.files,
         truncated: snap.truncated,

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useProjectFileList.ts
@@ -163,12 +163,16 @@ export function useProjectFileList(
 
   const doFetch = useCallback((wd: string, key: string) => {
     setState((prev) => ({ ...prev, isLoading: true }));
+    // 捕获发起时的失效代数:期间发生 refresh 时丢弃本回调的 setState —— 刷新后
+    // 的新请求会带最新数据,旧数据闪现一帧再被覆盖是可感知的视觉抖动。
+    const genAtStart = invalidationGen.get(key) ?? 0;
     // dedupe 并发 fetch:同 (端点, workdir) 在 inflight 中就 piggyback。
     let p = inflight.get(key);
     if (!p) {
-      p = (async () => {
+      const started = (async () => {
         const { snap, error } = await fetchOnce(wd, remoteHostId, deviceId, key);
         if (cacheKeyRef.current !== key) return; // 端点/目录已切换:丢弃过期结果
+        if ((invalidationGen.get(key) ?? 0) !== genAtStart) return; // 已被 refresh 失效
         setState({
           files: snap.files,
           truncated: snap.truncated,
@@ -176,12 +180,18 @@ export function useProjectFileList(
           error,
         });
       })();
-      inflight.set(key, p);
-      p.finally(() => inflight.delete(key));
+      p = started;
+      inflight.set(key, started);
+      // 只清理自己:refresh 可能已把 inflight 换成了新请求,无条件 delete 会把
+      // 新请求的 entry 误删,让后续并发 doFetch 重复 spawn rg。
+      started.finally(() => {
+        if (inflight.get(key) === started) inflight.delete(key);
+      });
     } else {
       // 已有 inflight:等同一个 promise 完后从 cache 取最新值。
       void p.then(() => {
         if (cacheKeyRef.current !== key) return; // 端点/目录已切换:丢弃过期结果
+        if ((invalidationGen.get(key) ?? 0) !== genAtStart) return; // 已被 refresh 失效
         const fresh = cache.get(key);
         setState({
           files: fresh?.files ?? [],
@@ -236,6 +246,9 @@ export function useProjectFileList(
     // 同时递增失效代数:refresh 时可能仍有在途请求,不 bump 的话它完成后会把
     // 刷新前的旧快照写回缓存,下次筛选被当成新鲜数据。
     bumpInvalidation(cacheKey);
+    // 在途请求也一并作废:留在 inflight 里会被紧随的 doFetch piggyback,用户
+    // 看到旧数据闪现后变空,且永远拿不到刷新后的新快照。
+    inflight.delete(cacheKey);
     if (!enabled) {
       // 树刷新时用户并没在筛选:只失效缓存,不触发扫描 —— 下次 enabled 自然拉新。
       // state 一并清空:留着旧 files 会让下次 doFetch 的 isLoading 期间闪 stale

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
@@ -141,11 +141,6 @@ function FileBrowserBodyWithWorkdir({
   const fileDragDepthRef = useRef(0);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const confirmSwitchAway = useConfirmSwitchAwayIfDirty();
-  // 项目级文件名扁平列表(走 ripgrep --files honor .gitignore),给文件名筛选用。
-  // 缓存 30 秒,跨 tab 共享同 workdir 索引;tree.refresh 时同步 invalidate。
-  // remote:daemon 内跑远端 rg;远端没有 rg 时返回空 + error,走"未索引"占位。
-  const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId);
-
   // 文件树 / 搜索 双模式 —— 跟 doc 模式 sidebar 同 ergonomics(参考 WorkdirBrowseSidebar
   // L124 的 mode state)。mode 不持久化,关 tab 重开默认 tree(合理预期:用户切到
   // 新 tab 期望"看文件",不是"接着上次的搜索状态")。
@@ -155,6 +150,14 @@ function FileBrowserBodyWithWorkdir({
   // 文件名筛选 query —— tree 模式下用,独立于内容搜索。空 query 显示文件树,有
   // 内容显示筛选结果列表。不持久化(关 tab 重开默认空)。
   const [filterQuery, setFilterQuery] = useState('');
+  // 项目级文件名扁平列表(走 ripgrep --files honor .gitignore),给文件名筛选用。
+  // 缓存 30 秒,跨 tab 共享同 workdir 索引;tree.refresh 时同步 invalidate。
+  // remote:daemon 内跑远端 rg;远端没有 rg 时返回空 + error,走"未索引"占位。
+  // enabled 惰性拉取:query 为空(FilterResultList 不显示)时不扫描 —— 切会话
+  // 不再为用不上的索引付 rg + IPC + 建索引的主线程成本。
+  const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId, {
+    enabled: filterQuery !== '',
+  });
   const filteredFiles = useMemo(
     () => filterFiles(filterQuery, projectFiles.files),
     [filterQuery, projectFiles.files],

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
@@ -154,9 +154,10 @@ function FileBrowserBodyWithWorkdir({
   // 缓存 30 秒,跨 tab 共享同 workdir 索引;tree.refresh 时同步 invalidate。
   // remote:daemon 内跑远端 rg;远端没有 rg 时返回空 + error,走"未索引"占位。
   // enabled 惰性拉取:query 为空(FilterResultList 不显示)时不扫描 —— 切会话
-  // 不再为用不上的索引付 rg + IPC + 建索引的主线程成本。
+  // 不再为用不上的索引付 rg + IPC + 建索引的主线程成本。trim 与 filterFiles
+  // 的匹配语义对齐:纯空格 query 结果必为空,不值得为它扫描。
   const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId, {
-    enabled: filterQuery !== '',
+    enabled: filterQuery.trim() !== '',
   });
   const filteredFiles = useMemo(
     () => filterFiles(filterQuery, projectFiles.files),


### PR DESCRIPTION
## 这次改了什么

### 摘要

`useProjectFileList`(文件名筛选的全量索引)此前在组件挂载时无条件跑 `rg --files`,但索引只服务文件名筛选,筛选框为空时完全用不上。日志实测一天内 30000-cap 全量扫描被触发 68 次;在大 workdir(如多仓聚合目录 `~/Code/XD`)场景下,3 万条路径的 IPC + renderer 主线程建索引与会话切换首屏抢主线程,是切会话 longtask(实测 1655ms)的主要成分之一。本 PR 把索引改为惰性拉取:用户真正开始筛选(输入首字符)才建索引,切会话零扫描成本。

同场调查结论(不在本 PR 内动代码):消息流首屏(MessageStream)已有 render-window 两段式与 streaming 节流,基线中位 42ms / P90 152ms 健康;当天 3 次秒级 longtask 均发生在系统 CPU 饥饿时段(clang×34 / 双 vitest / Spotlight 索引风暴),属外部放大,不动。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求:无(源自 2026-07-25 卡顿现场诊断)
- 本 PR 包含:`useProjectFileList` 惰性拉取 option + truncated 快照 TTL 分级 + refresh 非筛选态只失效;两个消费方接线;单测
- 明确不包含:MessageStream 渲染路径、watcher 驱动的缓存失效(现有 TTL 方案已够)、`listAllFiles` main 侧实现
- 用户可见变化:首次在文件筛选框输入时,大 workdir 会短暂显示既有的「正在索引」占位(此前索引在切会话时预拉,输入时通常已就绪);切会话不再有后台 rg 扫描
- 是否存在 breaking change:无(`enabled` 默认 true,不传时旧语义不变)

### UI 变化

不涉及:无视觉样式改动;「正在索引」占位为既有 UI(FilterResultList),仅出现时机随索引拉取时机改变。

- 引用的设计规范:不涉及(无视觉/文案变化)

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useProjectFileList.test.tsx src/renderer/__tests__/workdirBrowseRemoteSafety.test.ts
结果:2 files, 18 tests passed

pnpm --filter desktop run typecheck
结果:通过

pnpm test:unit(仓库根)
结果:exit 0,全部 PASS

### 手工验证

未执行(worktree 会话无法重启宿主 dev 实例)。建议验证路径:RSB 文件浏览器 / doc 模式打开大 workdir → 切会话观察 main 日志不再出现 listAllFiles rg 扫描;在筛选框输入,首次显示「正在索引」后出结果;树刷新按钮在未筛选时不触发扫描。

### 未执行的验证

手工运行时验证(原因同上);`pnpm test:all` 未跑(改动仅 renderer 单 hook + 两处接线,风险低,以 CI 门禁为准)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:文件名筛选索引的拉取时机与缓存 TTL;不涉及数据、协议、权限
- 回滚 / 降级方式:revert 本 commit 即回到挂载即拉的旧行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(hook 头注释即行为文档)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)