### PR TITLE
fix(mobile): Android 底部 sheet 键盘避让闪烁与模型浮窗搜索遮挡

### DIFF
--- a/apps/mobile/src/session/ModelPickerSheet.tsx
+++ b/apps/mobile/src/session/ModelPickerSheet.tsx
@@ -25,6 +25,7 @@ import {
   View,
   useWindowDimensions,
 } from 'react-native';
+import type { TextInput as RNTextInput } from 'react-native';
 import { Text, TextInput } from '@/components/AppText';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -155,6 +156,7 @@ export function ModelPickerSheet({
   const [secondarySnap, setSecondarySnap] = useState<ContextSheetSnap>('half');
   const [query, setQuery] = useState('');
   const scrollRef = useRef<ScrollView | null>(null);
+  const searchInputRef = useRef<RNTextInput>(null);
   const didAutoScrollRef = useRef(false);
   // 二级 Surface 滑入/滑出动画(0 = 就位;windowHeight = 屏下)。动画期间锁交互防连点。
   const secondaryTranslate = useRef(new Animated.Value(windowHeight)).current;
@@ -285,6 +287,15 @@ export function ModelPickerSheet({
     if (view.kind === 'options' && !optionsTarget) backToModels();
   }, [view, optionsTarget, backToModels]);
 
+  // Android:搜索聚焦(→full,键盘开)后再把面板拖回 half,列表会重新被键盘挤成一条,
+  // 而 onFocus 不会再触发(见搜索框注释)。把「拖到 half」当作用户想收起键盘——blur 搜索框
+  // 让键盘落下,adjustResize 恢复窗高后 half 即正常半屏,不再被遮挡。iOS 无此路径(不吸 full、
+  // 由 KAV 处理),原样透传。blur 对未聚焦输入是 no-op,故无需额外跟踪聚焦态。
+  const handlePrimarySnapChange = useCallback((next: ContextSheetSnap) => {
+    if (next === 'half' && Platform.OS === 'android') searchInputRef.current?.blur();
+    setPrimarySnap(next);
+  }, []);
+
   const handleSelectedRowLayout = useCallback(
     (y: number): void => {
       if (didAutoScrollRef.current || hasQuery) return;
@@ -320,6 +331,7 @@ export function ModelPickerSheet({
         onChangeText={setQuery}
         placeholder={t('models.picker.searchPlaceholder')}
         placeholderTextColor={colors.textTertiary}
+        ref={searchInputRef}
         style={styles.searchInput}
         testID={`${testID}.search`}
         value={query}
@@ -397,7 +409,7 @@ export function ModelPickerSheet({
         headerTrailing={permissionTrigger}
         heights={heights}
         onClose={onClose}
-        onSnapChange={setPrimarySnap}
+        onSnapChange={handlePrimarySnapChange}
         pinnedTop={primaryPinnedTop}
         scrollRef={scrollRef}
         snap={primarySnap}

--- a/apps/mobile/src/session/ModelPickerSheet.tsx
+++ b/apps/mobile/src/session/ModelPickerSheet.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { ChevronDown, Search } from 'lucide-react-native';
 import {
   Animated,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -310,6 +311,12 @@ export function ModelPickerSheet({
         accessibilityLabel={t('models.picker.searchAccessibility')}
         autoCapitalize="none"
         autoCorrect={false}
+        // Android 靠原生 adjustResize 避让键盘(SheetModal 在 Android 不套 KAV,见其头注释):
+        // 停在 half 档时键盘一开,面板缩成「0.56 ×(屏高−键盘)」的一小条,列表几乎没了。
+        // 聚焦搜索时吸到 full,铺满键盘上方全部可用高度,边打字边看列表。失焦不收回(留 full,
+        // 少一次跳动)。iOS 走 KAV padding 把 half 面板顶到键盘上方即可,吸 full 反而会把面板
+        // 顶部(含搜索框)推出屏幕外,故不在 iOS 触发。
+        onFocus={Platform.OS === 'android' ? () => setPrimarySnap('full') : undefined}
         onChangeText={setQuery}
         placeholder={t('models.picker.searchPlaceholder')}
         placeholderTextColor={colors.textTertiary}

--- a/apps/mobile/src/session/SheetModal.tsx
+++ b/apps/mobile/src/session/SheetModal.tsx
@@ -18,6 +18,7 @@ import {
   Animated,
   KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   StyleSheet,
   useWindowDimensions,
@@ -127,7 +128,12 @@ export function SheetModal({
           testID={backdropTestID}
         />
       </Animated.View>
-      {keyboardAvoiding ? (
+      {/* Android:windowSoftInputMode=adjustResize 已在原生层处理键盘避让,若再套
+          KeyboardAvoidingView(behavior='height')会与之对同一键盘反复调整高度,在 Modal 里
+          触发每帧 relayout 的布局回环 → 整窗持续重绘闪烁(用户 2026-07 报「+」/模型选择弹层
+          键盘开着时一直闪;logcat 实测键盘不开合、但 MainActivity 每帧重绘)。故 Android 直接
+          用 content、不套 KAV;iOS(adjustResize 不适用)仍需 KAV 走 padding 避让。 */}
+      {keyboardAvoiding && Platform.OS !== 'android' ? (
         <KeyboardAvoidingView
           behavior={keyboardAvoidingBehavior}
           keyboardVerticalOffset={0}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修移动端底部 sheet 的两个键盘相关问题(都只在 Android 上表现):

1. **闪烁**:`SheetModal` 在 Android 上套了 `KeyboardAvoidingView(behavior='height')`,而 App 原生已是 `windowSoftInputMode=adjustResize`。两者对同一个键盘反复调整高度,在 Modal 里形成每帧 relayout 的布局回环 → 整窗持续重绘,「+」面板 / 模型选择弹层在键盘开着时一直闪。改为 Android 直接渲染内容、不套 KAV,交给原生 `adjustResize`;iOS 不适用 adjustResize,仍走 KAV padding 避让。
2. **模型浮窗搜索被遮挡**:去掉 Android 的 KAV 后,模型浮窗停在 half 档时键盘一开,`adjustResize` 把面板缩成「0.56 ×(屏高−键盘)」的一小条,列表几乎没了。聚焦搜索框时把主档位吸到 full,铺满键盘上方可用高度,边打字边看列表;失焦不收回。仅 Android 触发(iOS 吸 full 反而会把搜索框推出屏幕外)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:用户真机(三星 SM-S9380,Android)报「+」面板与模型选择弹层在键盘开着时一直闪;后续发现模型搜索框聚焦时列表被键盘遮挡
- 本 PR 包含:`SheetModal.tsx`(Android 去 KAV)、`ModelPickerSheet.tsx`(搜索聚焦吸 full)
- 明确不包含:iOS 分支行为(保持原 KAV padding 路径,未改);个人本地构建脚本
- 用户可见变化:Android 上底部 sheet 开键盘不再闪;模型浮窗搜索时自动升到全高
- 是否存在 breaking change:无

### UI 变化

Android 真机行为修复,无新增视觉设计;交互上模型浮窗在搜索聚焦时由 half 平滑吸附到 full(走既有 snap 动画)。

- 引用的设计规范:`docs/design-rules/DESIGN.md` §14.4 Motion & Transitions —「nothing flies or bounces — things only fade, nudge, and resize smoothly」。本 PR 消除的是一个非受控的每帧 relayout 重绘回环(违反该节「平滑 resize、无抖动」的约束);模型浮窗吸 full 复用现有 `SNAP_ANIMATION_DURATION_MS`(180ms,对应「Size changes: panel open/close」档),未引入新的时长或曲线。

## 怎么验证的

### 自动验证

```text
pnpm install                                  # lockfile 已最新
pnpm test:unit                                # exit=0 全绿(含 apps/mobile unit;#305 的 modelPickerSheetResize 回归测试仍通过)
pnpm --filter mobile run typecheck            # exit=0(tsc --noEmit)
```

### 手工验证

- 平台:Android 真机(Samsung SM-S9380,自签 release APK)。
- 路径:会话页点「+」面板、点模型选择弹层,键盘开着时观察——不再闪(修复前用户报「一直闪」,修复后确认「确实不闪了」)。
- 模型浮窗点搜索框:面板自动升到全高,列表在键盘上方完整可见。

### 未执行的验证

- iOS 未在本机验证。iOS 走的是未改动的 KAV padding 分支(`Platform.OS !== 'android'`),行为与改动前一致;但 iOS 真机/模拟器未回归。
- mobile 本地真机验证使用自签 release APK(非 Metro dev client),故无 `__DEV__` build label / Metro 归属证据;闪烁本身在 release 包上复现并确认修复。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅移动端底部 sheet(共用 `SheetModal` 的所有 sheet + 模型浮窗)的键盘避让行为;纯 JS/RN 改动,不改原生代码、不影响 fingerprint/OTA。
- 跨平台差异:改动以 `Platform.OS === 'android'` 分支隔离,iOS 路径完全不变。
- 回滚 / 降级方式:`git revert` 这两个 commit 即可恢复到 Android 走 KAV 的旧行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(改动点头注释已说明 adjustResize/KAV 取舍与 logcat 依据)
- [x] 已确认测试结果或说明未执行原因
