### PR TITLE
fix(plugins): 修复市场卡片元数据异常换行

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -846,7 +846,7 @@ export function GhostPluginPage() {
   );
 }
 
-function MarketPluginCard({
+export function MarketPluginCard({
   item,
   busy,
   onSelect,
@@ -886,18 +886,24 @@ function MarketPluginCard({
               {item.name}
             </span>
           </span>
-          <span className="mt-1 flex min-w-0 items-center gap-1.5 text-11 text-[var(--text-tertiary)]">
-            <span>
+          <span className="mt-1 flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap text-11 text-[var(--text-tertiary)]">
+            <span className="shrink-0">
               {t(`settings.ghosts.page.origin.${pluginPresentationOrigin(item)}`)}
             </span>
-            <span aria-hidden="true">·</span>
-            <span>v{item.version}</span>
-            <span aria-hidden="true">·</span>
-            <span className="truncate font-mono">{item.ghostId}</span>
+            <span className="shrink-0" aria-hidden="true">
+              ·
+            </span>
+            <span className="shrink-0">v{item.version}</span>
+            <span className="shrink-0" aria-hidden="true">
+              ·
+            </span>
+            <span className="min-w-0 truncate font-mono">{item.ghostId}</span>
             {item.author ? (
               <>
-                <span aria-hidden="true">·</span>
-                <span className="truncate">{item.author}</span>
+                <span className="shrink-0" aria-hidden="true">
+                  ·
+                </span>
+                <span className="min-w-0 truncate">{item.author}</span>
               </>
             ) : null}
           </span>

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Regression coverage for installed Plugin card actions.
+ * Regression coverage for Plugin card actions and compact marketplace metadata.
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  * @vitest-environment jsdom
  */
@@ -20,8 +20,9 @@ vi.mock('@/components/ui/tooltip', () => ({
   ),
 }));
 
-import { GhostPluginCard, InstalledGhostShortcut } from '../GhostPluginPage';
+import { GhostPluginCard, InstalledGhostShortcut, MarketPluginCard } from '../GhostPluginPage';
 import type { GhostPluginListItem } from '../lib/ghostPluginViewModel';
+import type { PluginMarketItem } from '../../../../shared/pluginMarket';
 
 const installedPlugin: GhostPluginListItem = {
   id: 'filo-google',
@@ -30,6 +31,23 @@ const installedPlugin: GhostPluginListItem = {
   version: '1.0.0',
   enabled: true,
   canUse: true,
+};
+
+const marketPlugin: PluginMarketItem = {
+  pluginId: 'release-google-calendar',
+  ghostId: 'google-calendar',
+  name: 'Google Calendar',
+  description: 'Connect Google Calendar',
+  author: 'Cindy',
+  scope: 'public',
+  organizationId: null,
+  defaultInstall: false,
+  releaseId: 'release-1',
+  version: '1.3.11',
+  publishedAt: '2026-07-25T00:00:00.000Z',
+  icon: null,
+  installState: 'not-installed',
+  enabled: null,
 };
 
 describe('GhostPluginCard', () => {
@@ -115,5 +133,26 @@ describe('GhostPluginCard', () => {
     const fallbackIcon = container.querySelector('.lucide-workflow');
     expect(fallbackIcon).toBeTruthy();
     expect(fallbackIcon?.parentElement?.className).toContain('var(--surface-elevated)');
+  });
+
+  it('keeps fixed market metadata on one line while truncating long identities', () => {
+    render(
+      <MarketPluginCard
+        item={marketPlugin}
+        busy={false}
+        onSelect={vi.fn()}
+        onIconLoadError={vi.fn()}
+      />,
+    );
+
+    const origin = screen.getByText('settings.ghosts.page.origin.public');
+    const metadata = origin.parentElement;
+    expect(metadata?.className).toContain('whitespace-nowrap');
+    expect(metadata?.className).toContain('overflow-hidden');
+    expect(origin.className).toContain('shrink-0');
+    expect(screen.getByText('v1.3.11').className).toContain('shrink-0');
+    expect(screen.getByText('google-calendar').className).toContain('truncate');
+    expect(screen.getByText('google-calendar').className).toContain('min-w-0');
+    expect(screen.getByText('Cindy').className).toContain('truncate');
   });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复插件市场卡片在可用宽度收窄时，来源标签（例如“公开”）被逐字拆成多行的问题。

根因是元数据行中的所有 flex 子项都允许收缩，右侧“详情”按钮占用空间后，来源、版本和分隔符也会参与压缩。现在固定来源、版本和分隔符为单行不可收缩，仅让较长的插件 ID 与作者在剩余空间中省略。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：插件市场卡片元数据异常换行
- 本 PR 包含：`MarketPluginCard` 元数据布局约束及对应回归测试
- 明确不包含：PR #425 的插件更新入口显性化及其并发互斥改动
- 用户可见变化：来源标签、版本和分隔符保持单行；长插件 ID / 作者继续省略
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 Typography Rules（元数据使用 Small / Micro 层级并保持可读性）与 §8 Window & Adaptive Behavior（桌面窗口收窄时内容应流式重排且保持可读）。本次不改变卡片尺寸、字号、间距、颜色或交互，仅修正 flex 收缩优先级。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/plugin --reporter=dot
结果：9 files / 45 tests passed

pnpm --filter desktop typecheck
结果：通过

git diff --check
结果：通过
```

### 手工验证

基于用户提供的 Google Calendar 市场卡片窄宽度场景核对：来源与版本保持单行，长 ID / 作者仍在剩余空间内省略。

### 未执行的验证

未单独启动该分支的 Electron 实例；本次为局部 CSS flex 约束，并有 DOM class 回归测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅插件市场未安装卡片的元数据行
- 回滚 / 降级方式：回滚本提交即可恢复原布局

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要的回归测试
- [x] 已确认测试结果
