### PR TITLE
refactor(model-providers): 模型调用标准层 P1 —— 统一清单派生/分类徽章/调用合成

### DIFF
--- a/packages/model-providers/package.json
+++ b/packages/model-providers/package.json
@@ -13,7 +13,10 @@
     "./branding": "./src/providerBranding.ts",
     "./registry": "./src/registry.ts",
     "./types": "./src/types.ts",
-    "./effort-resolution": "./src/effortResolution.ts"
+    "./effort-resolution": "./src/effortResolution.ts",
+    "./model-list": "./src/modelList.ts",
+    "./classification": "./src/classification.ts",
+    "./invocation": "./src/invocation.ts"
   },
   "scripts": {
     "build": "tsc --noEmit",

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -116,6 +116,14 @@ describe('isBudgetModel — 目录 group 优先,codex/ 前缀兜底', () => {
     expect(isBudgetModel({ id: 'codex/gpt-5.5' })).toBe(true);
     expect(isBudgetModel({ id: 'gpt-5.5' })).toBe(false);
   });
+  // 与 groupOf 同一「数据优先」契约(2026-07 Greptile review):目录显式给出合法的
+  // 非 budget 分组时,前缀不再 override —— 否则徽章显示 budget、分组却归非 budget,自相矛盾。
+  it('codex/ 前缀 + 合法非 budget 分组 → 尊重目录,不打 budget 徽章', () => {
+    expect(isBudgetModel({ id: 'codex/gpt-5.5', group: 'gpt' })).toBe(false);
+  });
+  it('codex/ 前缀 + 未知 group 值 → 视同缺失,前缀兜底(与 groupOf 的未知回退一致)', () => {
+    expect(isBudgetModel({ id: 'codex/gpt-5.5', group: 'not-a-category' })).toBe(true);
+  });
 });
 
 describe('modelBadges — 徽章唯一口径', () => {

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -149,6 +149,17 @@ describe('modelBadges — 徽章唯一口径', () => {
     });
   });
 
+  // 2026-07 Copilot review: 分段模式下段供应商无 access 元数据时,不得回读条目的
+  // sourceAccess(那可能是 flat 首见的**另一家**供应商)——否则当前段的行会挂上别家的订阅徽章。
+  it('分段模式: provider 无 access 时不回读 sourceAccess,徽章按当前段诚实为空', () => {
+    expect(
+      modelBadges(
+        { id: 'claude-opus-5', sourceAccess: { kind: 'subscription', product: 'Claude.ai' } },
+        {},
+      ),
+    ).toEqual({ subscription: false, budget: false });
+  });
+
   it('骨折徽章与订阅徽章独立判定', () => {
     expect(modelBadges({ id: 'codex/gpt-5.5' }, { access: { kind: 'managed' } })).toEqual({
       subscription: false,

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -1,0 +1,165 @@
+/**
+ * classification 单点语义的行为锁。
+ *
+ * categorize / groupOf / groupModelsForDisplay 三组用例**原文移植**自
+ * apps/desktop/src/renderer/__tests__/sourceSwitch.test.ts —— P1 期间 renderer 原实现暂留,
+ * 两份实现由同一套用例锁定等价;P2 renderer 改 re-export 后原测试继续跑这份下沉实现。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHATGPT_MODEL_PREFIX,
+  SUBSCRIPTION_DIRECT_MODEL_PREFIXES,
+  XAI_MODEL_PREFIX,
+  categorize,
+  formatContextWindow,
+  groupModelsForDisplay,
+  groupOf,
+  isBudgetModel,
+  isSubscriptionDirectModel,
+  modelBadges,
+} from '../classification.js';
+
+// ── 原文移植: sourceSwitch.test.ts 的 categorize / groupOf / groupModelsForDisplay ──
+
+describe('categorize', () => {
+  it('按 id 前缀归类', () => {
+    expect(categorize('claude-opus-4-8')).toBe('anthropic');
+    expect(categorize('gpt-5.4')).toBe('gpt');
+    expect(categorize('codex/gpt-5.4')).toBe('gpt-budget');
+    expect(categorize('gemini-3-pro')).toBe('google');
+    expect(categorize('moonshotai/kimi-k2')).toBe('china');
+  });
+
+  it('非对话类型先于厂商前缀判定(网关杂项模型按类型归组,不误入 gpt/google)', () => {
+    expect(categorize('gpt-image-2')).toBe('image');
+    expect(categorize('gemini-3-pro-image')).toBe('image');
+    expect(categorize('gpt-4o-transcribe')).toBe('audio');
+    expect(categorize('elevenlabs/scribe_v2')).toBe('audio');
+    expect(categorize('gemini-omni-flash-preview')).toBe('audio');
+    expect(categorize('voyage/voyage-context-4')).toBe('embedding');
+    expect(categorize('doubao-seedance-2-0-260128')).toBe('video');
+    expect(categorize('happyhorse-1.1-t2v')).toBe('video');
+    expect(categorize('ai-gateway-doc')).toBe('other');
+  });
+
+  it('订阅直连前缀归组: chatgpt/ → gpt,xai/ → grok', () => {
+    expect(categorize(`${CHATGPT_MODEL_PREFIX}gpt-5.5`)).toBe('gpt');
+    expect(categorize(`${XAI_MODEL_PREFIX}grok-4`)).toBe('grok');
+  });
+});
+
+describe('groupOf — 数据优先,前缀兜底', () => {
+  it('合法 group 字段优先于 id 前缀', () => {
+    // id 看着像 gpt,但目录把它归到 china → 以 group 为准
+    expect(groupOf({ id: 'gpt-weird', group: 'china' })).toBe('china');
+    expect(groupOf({ id: 'codex/gpt-5.5', group: 'gpt-budget' })).toBe('gpt-budget');
+  });
+  it('无 group / 未知 group → 回退 categorize', () => {
+    expect(groupOf({ id: 'claude-opus-4-8' })).toBe('anthropic');
+    expect(groupOf({ id: 'gemini-3-flash' })).toBe('google');
+    expect(groupOf({ id: 'gpt-5.5', group: 'mistral' })).toBe('gpt'); // 未知 group 忽略,按前缀
+  });
+});
+
+describe('groupModelsForDisplay — sortOrder 升序 + group 分桶 + 桶序按最小 sortOrder', () => {
+  it('按 sortOrder 排序并分桶,桶序 = 桶内首个出现序', () => {
+    const out = groupModelsForDisplay([
+      { id: 'qwen/q', group: 'china', sortOrder: 40 },
+      { id: 'gpt-5.5', group: 'gpt', sortOrder: 20 },
+      { id: 'codex/gpt-5.5', group: 'gpt-budget', sortOrder: 10 },
+      { id: 'claude-opus-4-8', group: 'anthropic', sortOrder: 0 },
+      { id: 'gpt-5.4', group: 'gpt', sortOrder: 21 },
+    ]);
+    // 桶序:anthropic(0) → gpt-budget(10) → gpt(20) → china(40)
+    expect(out.map((g) => g.category)).toEqual(['anthropic', 'gpt-budget', 'gpt', 'china']);
+    // gpt 桶内按 sortOrder:5.5(20) 在 5.4(21) 前
+    expect(out.find((g) => g.category === 'gpt')!.models.map((m) => m.id)).toEqual([
+      'gpt-5.5',
+      'gpt-5.4',
+    ]);
+  });
+
+  it('缺 sortOrder 的排末尾;group 缺省回退前缀', () => {
+    const out = groupModelsForDisplay([
+      { id: 'gpt-5.5', sortOrder: 20 }, // 无 group → 前缀 gpt
+      { id: 'claude-opus-4-8' }, // 无 group 无 sortOrder → anthropic,排末尾
+    ]);
+    expect(out.map((g) => g.category)).toEqual(['gpt', 'anthropic']);
+  });
+});
+
+// ── 新增语义 ─────────────────────────────────────────────────────────────────
+
+describe('isSubscriptionDirectModel(下沉自 shared/subscriptionModels,签名一致)', () => {
+  it('前缀命中', () => {
+    expect(isSubscriptionDirectModel('chatgpt/gpt-5.5')).toBe(true);
+    expect(isSubscriptionDirectModel('xai/grok-4')).toBe(true);
+    expect(isSubscriptionDirectModel('gpt-5.5')).toBe(false);
+  });
+  it('null / undefined / 空串 → false(历史签名)', () => {
+    expect(isSubscriptionDirectModel(null)).toBe(false);
+    expect(isSubscriptionDirectModel(undefined)).toBe(false);
+    expect(isSubscriptionDirectModel('')).toBe(false);
+  });
+  it('前缀清单恒为 chatgpt/ + xai/(路由/记账/排除三方共用,改动即破坏)', () => {
+    expect(SUBSCRIPTION_DIRECT_MODEL_PREFIXES).toEqual(['chatgpt/', 'xai/']);
+  });
+});
+
+describe('isBudgetModel — 目录 group 优先,codex/ 前缀兜底', () => {
+  it('group 标注优先(网关新数据)', () => {
+    expect(isBudgetModel({ id: 'whatever', group: 'gpt-budget' })).toBe(true);
+  });
+  it('无 group 时按前缀(网关旧数据)', () => {
+    expect(isBudgetModel({ id: 'codex/gpt-5.5' })).toBe(true);
+    expect(isBudgetModel({ id: 'gpt-5.5' })).toBe(false);
+  });
+});
+
+describe('modelBadges — 徽章唯一口径', () => {
+  it('分段模式: 用段 provider 的 access', () => {
+    expect(
+      modelBadges({ id: 'claude-opus-5' }, { access: { kind: 'subscription', product: 'Claude.ai' } }),
+    ).toEqual({ subscription: true, budget: false });
+  });
+
+  it('flat 模式: provider 缺失时读条目 sourceAccess(真实溯源,标签不再消失)', () => {
+    expect(
+      modelBadges(
+        { id: 'claude-opus-5', sourceAccess: { kind: 'subscription', product: 'Claude.ai' } },
+        null,
+      ),
+    ).toEqual({ subscription: true, budget: false });
+  });
+
+  it('两者都拿不到(device-link 旧被控端拍平清单)→ 不显示,诚实降级', () => {
+    expect(modelBadges({ id: 'claude-opus-5' }, null)).toEqual({
+      subscription: false,
+      budget: false,
+    });
+  });
+
+  it('骨折徽章与订阅徽章独立判定', () => {
+    expect(modelBadges({ id: 'codex/gpt-5.5' }, { access: { kind: 'managed' } })).toEqual({
+      subscription: false,
+      budget: true,
+    });
+  });
+});
+
+describe('formatContextWindow(下沉自 ModelSelector,输出逐字一致)', () => {
+  it('M 档: 整数不带小数,非整取 1 位', () => {
+    expect(formatContextWindow(1_000_000)).toBe('1M');
+    expect(formatContextWindow(1_500_000)).toBe('1.5M');
+  });
+  it('K 档: 整数不带小数,非整四舍五入取整', () => {
+    expect(formatContextWindow(272_000)).toBe('272K');
+    expect(formatContextWindow(200_000)).toBe('200K');
+    expect(formatContextWindow(8_192)).toBe('8K');
+  });
+  it('<1000 原样', () => {
+    expect(formatContextWindow(512)).toBe('512');
+  });
+});

--- a/packages/model-providers/src/__tests__/invocation.test.ts
+++ b/packages/model-providers/src/__tests__/invocation.test.ts
@@ -642,3 +642,34 @@ describe('resolveModelInvocation — codex review 四轮:无点名路径与 prov
     expect(r.providerId).toBeNull();
   });
 });
+
+describe('resolveModelInvocation — codex review 五轮:native 兜底行级可见性 + 场景权限档校验', () => {
+  it('native 源上首模型被隐藏 → 跳到该源下一个可见模型,不经他源路由漂移', () => {
+    // xd(native)目录 [opus, sonnet]:opus 在 xd 被隐藏(anthropic 可见)。兜底必须选
+    // xd 的 sonnet —— 选 opus 会被 provider 步骤路由去 anthropic,换掉订阅/计费路由。
+    const r = resolveModelInvocation(
+      { model: 'gone' },
+      { ...SCENARIO, modelFor: () => 'also-gone' },
+      ctx({ isVisible: (pid, m) => !(pid === 'xd' && m.id === 'claude-opus-5') }),
+    );
+    expect(r.model).toBe('claude-sonnet-4-6');
+    expect(r.fallbacksApplied).toContain('model:first-available');
+  });
+
+  it('无显式权限档时,场景默认档不被最终 agent 支持 → 回落该 agent 最严档', () => {
+    const r = resolveModelInvocation(
+      { agentKind: 'codex' },
+      { ...SCENARIO, agentKind: 'codex', permissionMode: 'acceptEdits' },
+      ctx(),
+    );
+    // codex 不支持 acceptEdits(PERM_MODES) → 最严档 ask,不裸透传
+    expect(r.permissionMode).toBe('ask');
+    expect(r.fallbacksApplied).toContain('permission:scenario-strictest-fallback');
+  });
+
+  it('场景默认档被支持 → 原样(既有语义不变)', () => {
+    const r = resolveModelInvocation({}, SCENARIO, ctx());
+    expect(r.permissionMode).toBe('bypassPermissions');
+    expect(r.fallbacksApplied).not.toContain('permission:scenario-strictest-fallback');
+  });
+});

--- a/packages/model-providers/src/__tests__/invocation.test.ts
+++ b/packages/model-providers/src/__tests__/invocation.test.ts
@@ -584,3 +584,61 @@ describe('resolveModelInvocation — codex review 三轮:回落保真度', () =>
     expect(r.fallbacksApplied).toContain('model:first-available');
   });
 });
+
+describe('resolveModelInvocation — codex review 四轮:无点名路径与 provider 偏好作废', () => {
+  it('无点名 + native 源上模型被隐藏、他源可见 → 显式收敛到可见源(null 会被下游路由进隐藏源)', () => {
+    // claude-code 的 native 默认源是 xd;(xd, claude-opus-5) 被隐藏,anthropic 可见。
+    // 下游 effectiveSourceIdForModel(null) 不看可见性会选回 xd —— 必须显式定到 anthropic。
+    const r = resolveModelInvocation(
+      { model: 'claude-opus-5' },
+      SCENARIO,
+      ctx({ isVisible: (pid, m) => !(pid === 'xd' && m.id === 'claude-opus-5') }),
+    );
+    expect(r.model).toBe('claude-opus-5');
+    expect(r.providerId).toBe('anthropic');
+    expect(r.fallbacksApplied).toContain('provider:visible-fallback');
+  });
+
+  it('无点名 + 下游默认落点本就可见 → 维持 null(「null=默认路由」契约不变)', () => {
+    const r = resolveModelInvocation(
+      { model: 'claude-opus-5' },
+      SCENARIO,
+      ctx({ isVisible: (pid, m) => !(pid === 'anthropic' && m.id === 'claude-sonnet-4-6') }),
+    );
+    expect(r.providerId).toBeNull();
+    expect(r.fallbacksApplied).not.toContain('provider:visible-fallback');
+  });
+
+  it('无点名 + 未注入可见性 → 维持 null(既有契约)', () => {
+    const r = resolveModelInvocation({ model: 'claude-opus-5' }, SCENARIO, ctx());
+    expect(r.providerId).toBeNull();
+  });
+
+  it('agent 回落时 providerId 偏好一并作废,不把原 agent 的路由强加给回落 agent', () => {
+    const provs = [
+      {
+        id: 'pa',
+        name: 'pa',
+        agents: ['codex'],
+        models: { codex: [] },
+        connected: true,
+      },
+      {
+        id: 'pb',
+        name: 'pb',
+        agents: ['claude-code'],
+        models: { 'claude-code': [model('claude-sonnet-4-6')] },
+        connected: true,
+      },
+    ] as unknown as ProviderView[];
+    const r = resolveModelInvocation(
+      { agentKind: 'codex', providerId: 'pb' },
+      SCENARIO,
+      { providers: provs, getPermissionModes: PERM_MODES },
+    );
+    expect(r.agentKind).toBe('claude-code');
+    expect(r.fallbacksApplied).toContain('agent:model-less-fallback');
+    // 原 agent 的 providerId 偏好作废;无 scenario.providerIdFor → null 默认路由
+    expect(r.providerId).toBeNull();
+  });
+});

--- a/packages/model-providers/src/__tests__/invocation.test.ts
+++ b/packages/model-providers/src/__tests__/invocation.test.ts
@@ -400,3 +400,112 @@ describe('resolveModelInvocation — 六元组回落链', () => {
     expect(r.effort).toBe('low');
   });
 });
+
+// ── 2026-07 review 修正的行为锁(#433 第二轮) ─────────────────────────────────
+
+describe('resolveModelInvocation — 空权限档位表不放宽(Greptile P2 + codex P1 同点)', () => {
+  it('显式档 + 空档位表 → 原样保留,绝不落场景默认 bypass', () => {
+    const r = resolveModelInvocation(
+      { permissionMode: 'acceptEdits' },
+      SCENARIO,
+      ctx({ getPermissionModes: () => [] }),
+    );
+    expect(r.permissionMode).toBe('acceptEdits');
+    expect(r.fallbacksApplied).toContain('permission:modes-unavailable');
+  });
+
+  it('无显式档 + 空档位表 → 场景默认(该分支语义不变)', () => {
+    const r = resolveModelInvocation({}, SCENARIO, ctx({ getPermissionModes: () => [] }));
+    expect(r.permissionMode).toBe('bypassPermissions');
+  });
+});
+
+describe('resolveModelInvocation — explicitModelPolicy(Orca 严格拒绝语义)', () => {
+  const STRICT = { ...SCENARIO, explicitModelPolicy: 'reject' as const };
+
+  it('显式模型经校验不可用 → rejected 置位;其余字段仍按回落链合成(纯诊断)', () => {
+    const r = resolveModelInvocation({ model: 'gone-model' }, STRICT, ctx());
+    expect(r.rejected).toEqual({
+      field: 'model',
+      value: 'gone-model',
+      reason: 'explicit-model-unavailable',
+    });
+    expect(r.fallbacksApplied).toContain('model:explicit-rejected');
+    expect(r.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('显式模型可用 → 不触发 rejected', () => {
+    const r = resolveModelInvocation({ model: 'claude-opus-5' }, STRICT, ctx());
+    expect(r.rejected).toBeUndefined();
+  });
+
+  it('目录与 caps 全不可用 → 未经校验采纳显式值,不触发 rejected', () => {
+    const r = resolveModelInvocation({ model: 'gone-model' }, STRICT, ctx({ providers: null }));
+    expect(r.rejected).toBeUndefined();
+    expect(r.model).toBe('gone-model');
+    expect(r.fallbacksApplied).toContain('model:explicit-unverified');
+  });
+
+  it("缺省策略('fallback')下不可用显式模型静默落场景默认(IM/hook 历史语义,不变)", () => {
+    const r = resolveModelInvocation({ model: 'gone-model' }, SCENARIO, ctx());
+    expect(r.rejected).toBeUndefined();
+    expect(r.model).toBe('claude-sonnet-4-6');
+  });
+});
+
+describe('resolveModelInvocation — 显式 agent 无可用模型时回落能跑的 agent(IM pickModel 语义)', () => {
+  it('显式 codex 零可用模型、场景默认 claude-code 有 → 回落并记录', () => {
+    // isVisible 把 codex 模型全部藏掉 → codex available=[](非 null)
+    const r = resolveModelInvocation(
+      { agentKind: 'codex' },
+      SCENARIO,
+      ctx({ isVisible: (_pid, m) => !m.id.startsWith('gpt') && !m.id.startsWith('codex/') }),
+    );
+    expect(r.agentKind).toBe('claude-code');
+    expect(r.fallbacksApplied).toContain('agent:model-less-fallback');
+    expect(r.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('场景默认 agent 同样无模型 → 保持显式选择(回落无意义)', () => {
+    const r = resolveModelInvocation(
+      { agentKind: 'codex' },
+      SCENARIO,
+      ctx({ isVisible: () => false }),
+    );
+    expect(r.agentKind).toBe('codex');
+    expect(r.fallbacksApplied).not.toContain('agent:model-less-fallback');
+  });
+
+  it('能力数据不可用(available=null)→ 不猜,维持显式 agent', () => {
+    const r = resolveModelInvocation(
+      { agentKind: 'codex' },
+      SCENARIO,
+      ctx({ providers: null }),
+    );
+    expect(r.agentKind).toBe('codex');
+    expect(r.fallbacksApplied).not.toContain('agent:model-less-fallback');
+  });
+});
+
+describe('resolveModelInvocation — providerId 校验含 per-provider 可见性(codex review)', () => {
+  it('模型经他源可用、点名来源被 isVisible 排除 → 回默认路由,不绕过来源级契约', () => {
+    // claude-opus-5 在 anthropic 可见、在 xd 被隐藏;显式点名 xd 不能放行
+    const r = resolveModelInvocation(
+      { model: 'claude-opus-5', providerId: 'xd' },
+      SCENARIO,
+      ctx({ isVisible: (pid, m) => !(pid === 'xd' && m.id === 'claude-opus-5') }),
+    );
+    expect(r.model).toBe('claude-opus-5');
+    expect(r.providerId).toBeNull();
+    expect(r.fallbacksApplied).toContain('provider:default-route');
+  });
+
+  it('点名来源可见 → 照常保留(既有语义不变)', () => {
+    const r = resolveModelInvocation(
+      { model: 'claude-opus-5', providerId: 'xd' },
+      SCENARIO,
+      ctx({ isVisible: () => true }),
+    );
+    expect(r.providerId).toBe('xd');
+  });
+});

--- a/packages/model-providers/src/__tests__/invocation.test.ts
+++ b/packages/model-providers/src/__tests__/invocation.test.ts
@@ -1,0 +1,402 @@
+/**
+ * 调用合成标准(invocation.ts)+ effort 新语义(effortResolution.ts 扩充部分)的行为锁。
+ *
+ * effort 三个新函数的用例放本文件而非 effortResolution.test.ts —— 该文件保持**零修改**,
+ * 作为「P1 不动既有语义」的证明之一。
+ *
+ * nearestSupportedEffort 的级联全分支与
+ * apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts 的 normalizeResolvedEffort
+ * 非显式分支逐字节对齐(P4 切换时那边的既有测试是第二道锁)。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  EFFORT_VALUES,
+  effortRank,
+  lowestEffort,
+  nearestSupportedEffort,
+  reconcileInvocationEffort,
+} from '../effortResolution.js';
+import { resolveModelInvocation, type InvocationCatalogContext } from '../invocation.js';
+import type { AgentKind, CatalogModel } from '../types.js';
+import type { ProviderView } from '../registry.js';
+
+// ── effort 扩充 ──────────────────────────────────────────────────────────────
+
+describe('EFFORT_VALUES / effortRank / lowestEffort', () => {
+  it('七档强弱序单一来源', () => {
+    expect(EFFORT_VALUES).toEqual(['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+  });
+  it('未知档排最高之上(保守不上调,与 clamp 的历史行为一致)', () => {
+    expect(effortRank('nonsense')).toBe(EFFORT_VALUES.length);
+    expect(effortRank('ultra')).toBeLessThan(effortRank('nonsense'));
+  });
+  it('lowestEffort: 最低档;空 → null(title-one-shot 语义)', () => {
+    expect(lowestEffort(['high', 'low', 'max'])).toBe('low');
+    expect(lowestEffort([])).toBeNull();
+  });
+});
+
+describe('nearestSupportedEffort — Orca 跨引擎词表翻译(双向就近,全分支)', () => {
+  it('支持 → 原样', () => {
+    expect(nearestSupportedEffort('high', ['low', 'high'])).toBe('high');
+  });
+  it('minimal → low', () => {
+    expect(nearestSupportedEffort('minimal', ['low', 'medium', 'high'])).toBe('low');
+  });
+  it('ultra → max(Claude 词表)', () => {
+    expect(nearestSupportedEffort('ultra', ['low', 'high', 'max'])).toBe('max');
+  });
+  it('ultra → xhigh(模型无 max,级联到最高兼容档而不是丢回默认)', () => {
+    expect(nearestSupportedEffort('ultra', ['low', 'high', 'xhigh'])).toBe('xhigh');
+  });
+  it('max → xhigh(Claude 意图落 GPT 词表)', () => {
+    expect(nearestSupportedEffort('max', ['low', 'high', 'xhigh'])).toBe('xhigh');
+  });
+  it('xhigh → max(GPT 意图落 Claude 词表 —— 这是**上调**,在翻译语义里正确)', () => {
+    expect(nearestSupportedEffort('xhigh', ['low', 'high', 'max'])).toBe('max');
+  });
+  it('命不中级联映射 → null(由调用方决定回落默认还是报错)', () => {
+    expect(nearestSupportedEffort('medium', ['xhigh'])).toBeNull();
+    expect(nearestSupportedEffort('ultra', ['low', 'medium'])).toBeNull();
+  });
+});
+
+describe('reconcileInvocationEffort — 无人值守统一回落链', () => {
+  const MODEL = { efforts: ['low', 'high'] as const, defaultEffort: 'high' as string | null };
+
+  it('requested ∈ 支持档 → 先于 override(用户显式选择不被运营表压过;IM resolveEffort 语义)', () => {
+    expect(
+      reconcileInvocationEffort({
+        requested: 'low',
+        model: MODEL,
+        overrides: { 'm-1': 'high' },
+        modelId: 'm-1',
+        noEffortFallback: 'high',
+      }),
+    ).toBe('low');
+  });
+
+  it('requested 非法时 override 作为回落生效', () => {
+    expect(
+      reconcileInvocationEffort({
+        requested: 'ultra',
+        model: MODEL,
+        overrides: { 'm-1': 'high' },
+        modelId: 'm-1',
+        noEffortFallback: 'high',
+      }),
+    ).toBe('high');
+  });
+
+  it('模型未知/无档的三种历史语义按 noEffortsBehavior 显式选择', () => {
+    const base = {
+      requested: 'low' as const,
+      model: undefined,
+      overrides: { 'm-1': 'xhigh' } as const,
+      modelId: 'm-1',
+      noEffortFallback: 'high' as const,
+    };
+    // hook 语义(默认): 无档就不看 requested/override,恒 fallback
+    expect(reconcileInvocationEffort(base)).toBe('high');
+    // IM resolveEffort 语义: requested || fallback
+    expect(reconcileInvocationEffort({ ...base, noEffortsBehavior: 'requested-first' })).toBe('low');
+    expect(
+      reconcileInvocationEffort({ ...base, requested: null, noEffortsBehavior: 'requested-first' }),
+    ).toBe('high');
+    // getImDefaultEffortFor 语义: override || fallback(该场景 requested 恒空)
+    expect(
+      reconcileInvocationEffort({ ...base, requested: null, noEffortsBehavior: 'override-first' }),
+    ).toBe('xhigh');
+  });
+
+  it('overrides 表不受原型链污染(model id 为 constructor 等原型键时不取 Object 原型)', () => {
+    expect(
+      reconcileInvocationEffort({
+        requested: null,
+        model: undefined,
+        overrides: {},
+        modelId: 'constructor',
+        noEffortFallback: 'high',
+        noEffortsBehavior: 'override-first',
+      }),
+    ).toBe('high');
+  });
+
+  it('override 不被支持档接受 → 跳过,走后续链', () => {
+    expect(
+      reconcileInvocationEffort({
+        requested: 'low',
+        model: MODEL,
+        overrides: { 'm-1': 'ultra' },
+        modelId: 'm-1',
+        noEffortFallback: 'high',
+      }),
+    ).toBe('low');
+  });
+
+  it('无 effort 档 → noEffortFallback 参数化(IM=high / hook=undefined / mobile=空串)', () => {
+    const noEfforts = { efforts: [] as const, defaultEffort: null };
+    expect(
+      reconcileInvocationEffort({ requested: 'high', model: noEfforts, noEffortFallback: 'high' }),
+    ).toBe('high');
+    expect(
+      reconcileInvocationEffort({
+        requested: 'high',
+        model: noEfforts,
+        noEffortFallback: undefined,
+      }),
+    ).toBeUndefined();
+    expect(
+      reconcileInvocationEffort({ requested: 'high', model: noEfforts, noEffortFallback: '' }),
+    ).toBe('');
+  });
+
+  it('requested ∈ 支持档 → requested;否则模型默认;默认非法 → 首档', () => {
+    expect(reconcileInvocationEffort({ requested: 'low', model: MODEL, noEffortFallback: undefined })).toBe('low');
+    expect(reconcileInvocationEffort({ requested: 'ultra', model: MODEL, noEffortFallback: undefined })).toBe('high');
+    expect(
+      reconcileInvocationEffort({
+        requested: 'ultra',
+        model: { efforts: ['low', 'medium'], defaultEffort: 'xhigh' },
+        noEffortFallback: undefined,
+      }),
+    ).toBe('low');
+  });
+});
+
+// ── resolveModelInvocation ───────────────────────────────────────────────────
+
+function model(id: string, extra: Partial<CatalogModel> = {}): CatalogModel {
+  return {
+    id,
+    name: id,
+    contextWindow: 200_000,
+    efforts: ['low', 'high'],
+    defaultEffort: 'high',
+    ...extra,
+  } as CatalogModel;
+}
+
+function providers(): ProviderView[] {
+  return [
+    {
+      id: 'anthropic',
+      name: 'anthropic',
+      agents: ['claude-code'],
+      models: { 'claude-code': [model('claude-opus-5')] },
+      connected: true,
+      access: { kind: 'subscription', product: 'Claude.ai' },
+    },
+    {
+      id: 'xd',
+      name: 'xd',
+      agents: ['claude-code', 'codex'],
+      models: {
+        'claude-code': [model('claude-opus-5'), model('claude-sonnet-4-6')],
+        codex: [model('gpt-5.5', { efforts: ['low', 'medium', 'high', 'xhigh'] })],
+      },
+      connected: true,
+      access: { kind: 'managed' },
+    },
+    {
+      id: 'openai',
+      name: 'openai',
+      agents: ['codex'],
+      models: { codex: [model('gpt-5.5')] },
+      connected: false,
+    },
+  ] as ProviderView[];
+}
+
+const SCENARIO = {
+  agentKind: 'claude-code' as AgentKind,
+  modelFor: (agent: AgentKind) => (agent === 'codex' ? 'gpt-5.5' : 'claude-sonnet-4-6'),
+  noEffortFallback: undefined,
+  permissionMode: 'bypassPermissions',
+};
+
+const PERM_MODES = (agent: AgentKind): readonly string[] =>
+  agent === 'codex' ? ['ask', 'auto', 'bypassPermissions'] : ['ask', 'acceptEdits', 'auto', 'bypassPermissions'];
+
+function ctx(over: Partial<InvocationCatalogContext> = {}): InvocationCatalogContext {
+  return { providers: providers(), getPermissionModes: PERM_MODES, ...over };
+}
+
+describe('resolveModelInvocation — 六元组回落链', () => {
+  it('全显式且全可用 → 原样直传,零回落', () => {
+    const r = resolveModelInvocation(
+      {
+        agentKind: 'claude-code',
+        model: 'claude-opus-5',
+        effort: 'low',
+        providerId: 'anthropic',
+        permissionMode: 'acceptEdits',
+        fastMode: true,
+      },
+      SCENARIO,
+      ctx(),
+    );
+    expect(r).toMatchObject({
+      agentKind: 'claude-code',
+      model: 'claude-opus-5',
+      effort: 'low',
+      providerId: 'anthropic',
+      permissionMode: 'acceptEdits',
+      fastMode: true,
+    });
+    expect(r.fallbacksApplied).toEqual([]);
+  });
+
+  it('全空 → 场景默认(model 过可用性校验;permission 落场景默认;effort 落模型默认)', () => {
+    const r = resolveModelInvocation({}, SCENARIO, ctx());
+    expect(r).toMatchObject({
+      agentKind: 'claude-code',
+      model: 'claude-sonnet-4-6',
+      effort: 'high',
+      providerId: null,
+      permissionMode: 'bypassPermissions',
+      fastMode: false,
+    });
+  });
+
+  it('agent 非法 → 场景默认 agent,并记录回落轨迹', () => {
+    const r = resolveModelInvocation({ agentKind: 'weird' }, SCENARIO, ctx());
+    expect(r.agentKind).toBe('claude-code');
+    expect(r.fallbacksApplied).toContain('agent:scenario-default');
+  });
+
+  it('显式 model 不可用 → 场景默认;场景默认也不可用 → 该 agent 首个可用', () => {
+    const r1 = resolveModelInvocation({ model: 'gone-model' }, SCENARIO, ctx());
+    expect(r1.model).toBe('claude-sonnet-4-6');
+    expect(r1.fallbacksApplied).toContain('model:scenario-default');
+
+    const r2 = resolveModelInvocation(
+      { model: 'gone-model' },
+      { ...SCENARIO, modelFor: () => 'also-gone' },
+      ctx(),
+    );
+    expect(r2.model).toBe('claude-opus-5'); // anthropic 段首个
+    expect(r2.fallbacksApplied).toContain('model:first-available');
+  });
+
+  it('目录与 caps 全不可用 → 场景默认裸值(宁发可能非法的 id 不发空串,历史降级)', () => {
+    const r = resolveModelInvocation({}, SCENARIO, ctx({ providers: null }));
+    expect(r.model).toBe('claude-sonnet-4-6');
+    expect(r.fallbacksApplied).toContain('model:scenario-default-unverified');
+  });
+
+  it('目录不可用但有 caps → caps 兜底清单参与校验', () => {
+    const r = resolveModelInvocation(
+      { model: 'caps-model' },
+      SCENARIO,
+      ctx({
+        providers: null,
+        getCapabilityModels: () => [{ id: 'caps-model', efforts: ['medium'], defaultEffort: 'medium' }],
+      }),
+    );
+    expect(r.model).toBe('caps-model');
+    expect(r.effort).toBe('medium');
+  });
+
+  it('providerId: 已连接且提供最终模型 → 保留;不提供 → null 默认路由', () => {
+    const keep = resolveModelInvocation(
+      { model: 'claude-opus-5', providerId: 'anthropic' },
+      SCENARIO,
+      ctx(),
+    );
+    expect(keep.providerId).toBe('anthropic');
+
+    // anthropic 不提供 sonnet → 回默认路由,并记录
+    const drop = resolveModelInvocation(
+      { model: 'claude-sonnet-4-6', providerId: 'anthropic' },
+      SCENARIO,
+      ctx(),
+    );
+    expect(drop.providerId).toBeNull();
+    expect(drop.fallbacksApplied).toContain('provider:default-route');
+  });
+
+  it('providerId: 断开的来源不算可用', () => {
+    const r = resolveModelInvocation(
+      { agentKind: 'codex', model: 'gpt-5.5', providerId: 'openai' },
+      { ...SCENARIO, agentKind: 'codex' },
+      ctx(),
+    );
+    expect(r.providerId).toBeNull();
+  });
+
+  it('providerId: 目录不可用 → 透传原值(路由层兜底,与 IM/hook 历史降级一致)', () => {
+    const r = resolveModelInvocation(
+      { providerId: 'anthropic' },
+      SCENARIO,
+      ctx({ providers: null }),
+    );
+    expect(r.providerId).toBe('anthropic');
+    expect(r.fallbacksApplied).toContain('provider:unverified-passthrough');
+  });
+
+  it('permissionMode: 显式档不被支持 → 该 agent **最严**档,绝不落场景默认 bypass', () => {
+    const r = resolveModelInvocation(
+      { agentKind: 'codex', permissionMode: 'acceptEdits' },
+      { ...SCENARIO, agentKind: 'codex' },
+      ctx(),
+    );
+    expect(r.permissionMode).toBe('ask');
+    expect(r.permissionMode).not.toBe('bypassPermissions');
+    expect(r.fallbacksApplied).toContain('permission:strictest-fallback');
+  });
+
+  it('permissionMode: 未注入档位表时显式值原样放行(无从校验,不瞎猜)', () => {
+    const r = resolveModelInvocation(
+      { permissionMode: 'acceptEdits' },
+      SCENARIO,
+      ctx({ getPermissionModes: undefined }),
+    );
+    expect(r.permissionMode).toBe('acceptEdits');
+  });
+
+  it('isVisible 注入时,隐藏模型不算「可用」(与选择器口径一致)', () => {
+    const r = resolveModelInvocation(
+      { model: 'claude-opus-5' },
+      SCENARIO,
+      ctx({ isVisible: (_pid, m) => m.id !== 'claude-opus-5' }),
+    );
+    expect(r.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('场景 effort(effortFor)在显式 effort 缺失时参与回落', () => {
+    const r = resolveModelInvocation(
+      { model: 'claude-opus-5' },
+      { ...SCENARIO, effortFor: () => 'low' },
+      ctx(),
+    );
+    expect(r.effort).toBe('low');
+  });
+
+  it('effortOverrides 只在显式档非法时生效(用户显式选择优先于运营表)', () => {
+    const keep = resolveModelInvocation(
+      { model: 'claude-opus-5', effort: 'low' },
+      { ...SCENARIO, effortOverrides: { 'claude-opus-5': 'high' } },
+      ctx(),
+    );
+    expect(keep.effort).toBe('low');
+
+    const fall = resolveModelInvocation(
+      { model: 'claude-opus-5', effort: 'ultra' },
+      { ...SCENARIO, effortOverrides: { 'claude-opus-5': 'high' } },
+      ctx(),
+    );
+    expect(fall.effort).toBe('high');
+  });
+
+  it('显式 effort 非法时先试场景默认档,再落模型默认(hook 的显式>草稿>默认链)', () => {
+    const r = resolveModelInvocation(
+      { model: 'claude-opus-5', effort: 'ultra' },
+      { ...SCENARIO, effortFor: () => 'low' },
+      ctx(),
+    );
+    expect(r.effort).toBe('low');
+  });
+});

--- a/packages/model-providers/src/__tests__/invocation.test.ts
+++ b/packages/model-providers/src/__tests__/invocation.test.ts
@@ -300,7 +300,7 @@ describe('resolveModelInvocation — 六元组回落链', () => {
     expect(r.effort).toBe('medium');
   });
 
-  it('providerId: 已连接且提供最终模型 → 保留;不提供 → null 默认路由', () => {
+  it('providerId: 已连接且提供最终模型 → 保留;不提供 → 收敛到可见替代源', () => {
     const keep = resolveModelInvocation(
       { model: 'claude-opus-5', providerId: 'anthropic' },
       SCENARIO,
@@ -308,23 +308,26 @@ describe('resolveModelInvocation — 六元组回落链', () => {
     );
     expect(keep.providerId).toBe('anthropic');
 
-    // anthropic 不提供 sonnet → 回默认路由,并记录
+    // anthropic 不提供 sonnet → 不再回 null(下游默认路由不看可见性),直接收敛到
+    // 提供该模型的可见替代源(2026-07 codex review 行为升级)
     const drop = resolveModelInvocation(
       { model: 'claude-sonnet-4-6', providerId: 'anthropic' },
       SCENARIO,
       ctx(),
     );
-    expect(drop.providerId).toBeNull();
-    expect(drop.fallbacksApplied).toContain('provider:default-route');
+    expect(drop.providerId).toBe('xd');
+    expect(drop.fallbacksApplied).toContain('provider:visible-fallback');
   });
 
-  it('providerId: 断开的来源不算可用', () => {
+  it('providerId: 断开的来源不算可用,收敛到提供该模型的可见替代源', () => {
     const r = resolveModelInvocation(
       { agentKind: 'codex', model: 'gpt-5.5', providerId: 'openai' },
       { ...SCENARIO, agentKind: 'codex' },
       ctx(),
     );
-    expect(r.providerId).toBeNull();
+    // openai 断开 → xd(已连接且提供 gpt-5.5)顶上,不回 null
+    expect(r.providerId).toBe('xd');
+    expect(r.fallbacksApplied).toContain('provider:visible-fallback');
   });
 
   it('providerId: 目录不可用 → 透传原值(路由层兜底,与 IM/hook 历史降级一致)', () => {
@@ -488,16 +491,18 @@ describe('resolveModelInvocation — 显式 agent 无可用模型时回落能跑
 });
 
 describe('resolveModelInvocation — providerId 校验含 per-provider 可见性(codex review)', () => {
-  it('模型经他源可用、点名来源被 isVisible 排除 → 回默认路由,不绕过来源级契约', () => {
-    // claude-opus-5 在 anthropic 可见、在 xd 被隐藏;显式点名 xd 不能放行
+  it('模型经他源可用、点名来源被 isVisible 排除 → 收敛到可见替代源,不绕过来源级契约', () => {
+    // claude-opus-5 在 anthropic 可见、在 xd 被隐藏;显式点名 xd 不能放行。
+    // 也不能回 null:下游默认路由(nativeDefaultSourceId,claude-code 优先 xd)不看可见性,
+    // 会又选回被隐藏的 xd —— 必须显式收敛到可见的 anthropic(codex review 二轮)。
     const r = resolveModelInvocation(
       { model: 'claude-opus-5', providerId: 'xd' },
       SCENARIO,
       ctx({ isVisible: (pid, m) => !(pid === 'xd' && m.id === 'claude-opus-5') }),
     );
     expect(r.model).toBe('claude-opus-5');
-    expect(r.providerId).toBeNull();
-    expect(r.fallbacksApplied).toContain('provider:default-route');
+    expect(r.providerId).toBe('anthropic');
+    expect(r.fallbacksApplied).toContain('provider:visible-fallback');
   });
 
   it('点名来源可见 → 照常保留(既有语义不变)', () => {
@@ -516,5 +521,66 @@ describe('resolveModelInvocation — 诊断标记区分 unverified 与零可选(
     expect(r.model).toBe('claude-sonnet-4-6');
     expect(r.fallbacksApplied).toContain('model:no-available-models');
     expect(r.fallbacksApplied).not.toContain('model:scenario-default-unverified');
+  });
+});
+
+describe('resolveModelInvocation — codex review 三轮:回落保真度', () => {
+  it('agent 回落后,原 agent 的 model/effort 配对偏好作废(不跨 agent 采纳同名 id)', () => {
+    // pa(codex)零模型 → 回落 claude-code;显式 'gpt-5.5' 在 pb 的 claude-code 目录恰好
+    // 也存在 —— 修复前会被当作新 agent 的显式选择采纳(拿原 agent 的偏好跑新 agent,
+    // 还能绕过 reject 策略),修复后作废,落场景默认链。
+    const provs = [
+      {
+        id: 'pa',
+        name: 'pa',
+        agents: ['codex'],
+        models: { codex: [] },
+        connected: true,
+      },
+      {
+        id: 'pb',
+        name: 'pb',
+        agents: ['claude-code'],
+        models: { 'claude-code': [model('claude-sonnet-4-6'), model('gpt-5.5')] },
+        connected: true,
+      },
+    ] as unknown as ProviderView[];
+    const r = resolveModelInvocation(
+      { agentKind: 'codex', model: 'gpt-5.5', effort: 'low' },
+      SCENARIO,
+      { providers: provs, getPermissionModes: PERM_MODES },
+    );
+    expect(r.agentKind).toBe('claude-code');
+    expect(r.fallbacksApplied).toContain('agent:model-less-fallback');
+    expect(r.model).toBe('claude-sonnet-4-6');
+    expect(r.effort).not.toBe('low');
+  });
+
+  it('first-available 兜底优先 native 默认源(claude-code 优先 xd),不用 rail 序首个', () => {
+    // rail 序 anthropic 在前(首见 'a-first'),但 native 源是 xd —— 兜底必须取 xd 目录序
+    // 首个可用('xd-first'),与 IM 现行 nativeDefaultSourceId 口径一致,否则换来源/计费路由。
+    const provs = [
+      {
+        id: 'anthropic',
+        name: 'anthropic',
+        agents: ['claude-code'],
+        models: { 'claude-code': [model('a-first')] },
+        connected: true,
+      },
+      {
+        id: 'xd',
+        name: 'xd',
+        agents: ['claude-code'],
+        models: { 'claude-code': [model('xd-first'), model('a-first')] },
+        connected: true,
+      },
+    ] as unknown as ProviderView[];
+    const r = resolveModelInvocation(
+      { model: 'gone' },
+      { ...SCENARIO, modelFor: () => 'also-gone' },
+      { providers: provs, getPermissionModes: PERM_MODES },
+    );
+    expect(r.model).toBe('xd-first');
+    expect(r.fallbacksApplied).toContain('model:first-available');
   });
 });

--- a/packages/model-providers/src/__tests__/invocation.test.ts
+++ b/packages/model-providers/src/__tests__/invocation.test.ts
@@ -509,3 +509,12 @@ describe('resolveModelInvocation — providerId 校验含 per-provider 可见性
     expect(r.providerId).toBe('xd');
   });
 });
+
+describe('resolveModelInvocation — 诊断标记区分 unverified 与零可选(Copilot review)', () => {
+  it('清单可用但为空 → model:no-available-models,不再误标 unverified', () => {
+    const r = resolveModelInvocation({}, SCENARIO, ctx({ isVisible: () => false }));
+    expect(r.model).toBe('claude-sonnet-4-6');
+    expect(r.fallbacksApplied).toContain('model:no-available-models');
+    expect(r.fallbacksApplied).not.toContain('model:scenario-default-unverified');
+  });
+});

--- a/packages/model-providers/src/__tests__/modelList.test.ts
+++ b/packages/model-providers/src/__tests__/modelList.test.ts
@@ -1,0 +1,339 @@
+/**
+ * modelList 标准派生的行为锁:
+ *   1. parity 矩阵 —— visibleModelUnion / buildProviderSections 薄壳化后,输出必须与
+ *      改写前的历史实现**深等含顺序**(历史实现在本文件内联保存为 legacy* 参照物,
+ *      来源 = 改写前 sections.ts 的原文,勿改);
+ *   2. 溯源元数据(sourceProviderId / sourceAccess / sourceConnected)的正确性 ——
+ *      flat 清单订阅徽章的数据地基;
+ *   3. options 各口径(providerScope / dedupe / exclude / keepSelected)的边界。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { deriveModelList, deriveModelSections } from '../modelList.js';
+import { buildProviderSections, visibleModelUnion, type SectionModel } from '../sections.js';
+import { connectedProvidersForAgent, type ProviderView } from '../registry.js';
+import { BUNDLED_CATALOG } from '../catalog.js';
+import type { AgentKind, CatalogModel } from '../types.js';
+
+// ── 历史实现参照物(改写前 sections.ts 原文,只删 export;parity 的对照组,勿动)──
+
+function legacyVisibleModelUnion(
+  providers: readonly ProviderView[],
+  agent: AgentKind,
+  isVisible: (providerId: string, model: CatalogModel) => boolean,
+): CatalogModel[] {
+  const seen = new Set<string>();
+  const out: CatalogModel[] = [];
+  for (const provider of connectedProvidersForAgent([...providers], agent)) {
+    for (const m of provider.models[agent] ?? []) {
+      if (seen.has(m.id)) continue;
+      if (!isVisible(provider.id, m)) continue;
+      seen.add(m.id);
+      out.push(m);
+    }
+  }
+  return out;
+}
+
+function legacyBuildProviderSections(args: {
+  providers: readonly ProviderView[];
+  agent: AgentKind;
+  selectedModelId?: string;
+  selectedProviderId?: string | null;
+  isVisible: (providerId: string, modelId: string) => boolean;
+  query?: string;
+}): Array<{ provider: ProviderView; models: SectionModel[] }> {
+  const q = (args.query ?? '').trim().toLowerCase();
+  const sections: Array<{ provider: ProviderView; models: SectionModel[] }> = [];
+  for (const provider of args.providers) {
+    const catalog = provider.models[args.agent] ?? [];
+    const models: SectionModel[] = [];
+    for (const m of catalog) {
+      const isSelected = m.id === args.selectedModelId && provider.id === args.selectedProviderId;
+      if (!isSelected && !args.isVisible(provider.id, m.id)) continue;
+      if (q && !m.name.toLowerCase().includes(q) && !m.id.toLowerCase().includes(q)) continue;
+      const sm: SectionModel = {
+        id: m.id,
+        displayName: m.name,
+        efforts: m.efforts,
+        defaultEffort: m.defaultEffort,
+        contextWindow: m.contextWindow,
+      };
+      if (m.description !== undefined) sm.description = m.description;
+      if (m.effortDisplayNames !== undefined) sm.effortDisplayNames = m.effortDisplayNames;
+      if (m.supportsFastMode !== undefined) sm.supportsFastMode = m.supportsFastMode;
+      if (m.icon !== undefined) sm.icon = m.icon;
+      models.push(sm);
+    }
+    if (models.length > 0) sections.push({ provider, models });
+  }
+  return sections;
+}
+
+// ── fixture:合成一个带跨供应商同名模型/订阅来源/隐藏模型的目录 ────────────────
+
+function model(id: string, extra: Partial<CatalogModel> = {}): CatalogModel {
+  return {
+    id,
+    name: extra.name ?? id.toUpperCase(),
+    contextWindow: 200_000,
+    efforts: ['low', 'high'],
+    defaultEffort: 'high',
+    ...extra,
+  } as CatalogModel;
+}
+
+function provider(
+  id: string,
+  agents: AgentKind[],
+  models: Partial<Record<AgentKind, CatalogModel[]>>,
+  extra: Partial<ProviderView> = {},
+): ProviderView {
+  return {
+    id,
+    name: id,
+    agents,
+    models,
+    connected: true,
+    ...extra,
+  } as ProviderView;
+}
+
+/** anthropic(订阅) + xd(托管) 同 offer opus;xd 另有独占与默认隐藏模型;custom 无 access。 */
+function fixtureProviders(): ProviderView[] {
+  return [
+    provider(
+      'anthropic',
+      ['claude-code'],
+      { 'claude-code': [model('claude-opus-5'), model('claude-haiku-4-5')] },
+      { access: { kind: 'subscription', product: 'Claude.ai' } },
+    ),
+    provider(
+      'xd',
+      ['claude-code', 'codex'],
+      {
+        'claude-code': [
+          model('claude-opus-5'),
+          model('xd-only-model'),
+          model('hidden-model', { defaultEnabled: false }),
+        ],
+        codex: [model('gpt-5.5'), model('codex/gpt-5.5', { group: 'gpt-budget' })],
+      },
+      { access: { kind: 'managed' } },
+    ),
+    provider('custom-a', ['codex'], { codex: [model('gpt-5.5'), model('custom-only')] }),
+    provider('disconnected-p', ['claude-code'], { 'claude-code': [model('dc-only')] }, {
+      connected: false,
+    }),
+  ];
+}
+
+const VISIBLE_ALL = () => true;
+const VISIBILITY_BY_DEFAULT = (_pid: string, m: CatalogModel) => m.defaultEnabled !== false;
+
+// ── 1. parity 矩阵 ───────────────────────────────────────────────────────────
+
+describe('parity: visibleModelUnion 薄壳 vs 历史实现', () => {
+  const agents: AgentKind[] = ['claude-code', 'codex'];
+  const visibilities = [VISIBLE_ALL, VISIBILITY_BY_DEFAULT];
+  const connectionCombos = [
+    (p: ProviderView) => p, // 原样
+    (p: ProviderView) => ({ ...p, connected: p.id !== 'xd' }), // xd 断开
+    (p: ProviderView) => ({ ...p, connected: false }), // 全断
+  ];
+
+  it('全矩阵深等(含顺序)', () => {
+    for (const agent of agents) {
+      for (const vis of visibilities) {
+        for (const combo of connectionCombos) {
+          const providers = fixtureProviders().map(combo);
+          const legacy = legacyVisibleModelUnion(providers, agent, vis);
+          const current = visibleModelUnion(providers, agent, vis);
+          // 薄壳返回 ModelListEntry(超集);目录字段部分必须与 legacy 深等含顺序。
+          expect(current.map((m) => m.id)).toEqual(legacy.map((m) => m.id));
+          current.forEach((m, i) => expect(m).toMatchObject(legacy[i]));
+        }
+      }
+    }
+  });
+
+  it('BUNDLED_CATALOG 真实目录同样深等', () => {
+    for (const agent of ['claude-code', 'codex'] as AgentKind[]) {
+      const providers: ProviderView[] = BUNDLED_CATALOG.providers.map((p) => ({
+        ...p,
+        connected: true,
+      }));
+      const legacy = legacyVisibleModelUnion(providers, agent, VISIBLE_ALL);
+      const current = visibleModelUnion(providers, agent, VISIBLE_ALL);
+      expect(current.map((m) => m.id)).toEqual(legacy.map((m) => m.id));
+    }
+  });
+});
+
+describe('parity: buildProviderSections 薄壳 vs 历史实现', () => {
+  const cases: Array<Parameters<typeof buildProviderSections>[0]> = [
+    // 常规: 已连接列表(调用方口径)
+    {
+      providers: fixtureProviders().filter((p) => p.connected),
+      agent: 'claude-code',
+      isVisible: () => true,
+    },
+    // 可见性过滤 + 选中豁免(选中的 hidden-model 保留)
+    {
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      selectedModelId: 'hidden-model',
+      selectedProviderId: 'xd',
+      isVisible: (_pid, mid) => mid !== 'hidden-model',
+    },
+    // 选中豁免不生效: selectedProviderId 为 null(历史语义: null 不豁免任何行)
+    {
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      selectedModelId: 'hidden-model',
+      selectedProviderId: null,
+      isVisible: (_pid, mid) => mid !== 'hidden-model',
+    },
+    // query 过滤
+    { providers: fixtureProviders(), agent: 'codex', isVisible: () => true, query: 'gpt' },
+    // **未收窄列表**(含 disconnected):历史实现不收窄,薄壳必须保持
+    { providers: fixtureProviders(), agent: 'claude-code', isVisible: () => true },
+  ];
+
+  it('全用例深等(含顺序与字段存在性)', () => {
+    for (const args of cases) {
+      expect(buildProviderSections(args)).toEqual(legacyBuildProviderSections(args));
+    }
+  });
+});
+
+// ── 2. 溯源元数据 ────────────────────────────────────────────────────────────
+
+describe('ModelListEntry 溯源', () => {
+  it('first-wins 去重时溯源 = 首见供应商(订阅 access 保真)', () => {
+    const list = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+    });
+    const opus = list.find((m) => m.id === 'claude-opus-5');
+    // anthropic 在数组序里先于 xd → 首见胜出,溯源是订阅来源
+    expect(opus?.sourceProviderId).toBe('anthropic');
+    expect(opus?.sourceAccess).toEqual({ kind: 'subscription', product: 'Claude.ai' });
+    const xdOnly = list.find((m) => m.id === 'xd-only-model');
+    expect(xdOnly?.sourceProviderId).toBe('xd');
+    expect(xdOnly?.sourceAccess).toEqual({ kind: 'managed' });
+  });
+
+  it('custom provider 无 access → sourceAccess 键不写入(诚实缺省,非 undefined 值)', () => {
+    const list = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'codex',
+      providerScope: 'connected-for-agent',
+    });
+    const customOnly = list.find((m) => m.id === 'custom-only');
+    expect(customOnly?.sourceProviderId).toBe('custom-a');
+    expect(customOnly && 'sourceAccess' in customOnly).toBe(false);
+  });
+
+  it('all-for-agent 范围下 sourceConnected 如实反映连接态', () => {
+    const list = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'all-for-agent',
+    });
+    expect(list.find((m) => m.id === 'dc-only')?.sourceConnected).toBe(false);
+    expect(list.find((m) => m.id === 'claude-opus-5')?.sourceConnected).toBe(true);
+  });
+});
+
+// ── 3. options 边界 ──────────────────────────────────────────────────────────
+
+describe('deriveModelList options', () => {
+  it("providerScope: 'connected-for-agent' 剔除断开来源;'all-for-agent' 保留", () => {
+    const connected = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+    });
+    expect(connected.some((m) => m.id === 'dc-only')).toBe(false);
+    const all = deriveModelList({ providers: fixtureProviders(), agent: 'claude-code' });
+    expect(all.some((m) => m.id === 'dc-only')).toBe(true);
+  });
+
+  it("dedupe:'none' 时同 id 每供应商各一行", () => {
+    const rows = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+      dedupe: 'none',
+    });
+    const opusRows = rows.filter((m) => m.id === 'claude-opus-5');
+    expect(opusRows.map((r) => r.sourceProviderId)).toEqual(['anthropic', 'xd']);
+  });
+
+  it('excludeProvider 被排除者不占 first-wins 的 seen(同 id 由后续供应商补上)', () => {
+    const rows = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+      excludeProvider: (p) => p.id === 'anthropic',
+    });
+    const opus = rows.find((m) => m.id === 'claude-opus-5');
+    expect(opus?.sourceProviderId).toBe('xd');
+  });
+
+  it('excludeModel 同样不占 seen', () => {
+    const rows = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'codex',
+      providerScope: 'connected-for-agent',
+      excludeModel: (m, p) => p.id === 'xd' && m.id === 'gpt-5.5',
+    });
+    const gpt = rows.find((m) => m.id === 'gpt-5.5');
+    expect(gpt?.sourceProviderId).toBe('custom-a');
+  });
+
+  it('keepSelected(providerId=null)在 flat 语义下按 model id 豁免任意供应商行', () => {
+    const rows = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+      isVisible: (_pid, m) => m.id !== 'hidden-model',
+      keepSelected: { providerId: null, modelId: 'hidden-model' },
+    });
+    expect(rows.some((m) => m.id === 'hidden-model')).toBe(true);
+  });
+});
+
+describe('溯源字段键集锁(visibleModelUnion 薄壳的 wire 安全前提)', () => {
+  it('条目额外键恰为 {sourceProviderId, sourceConnected[, sourceAccess]},新增即警报', () => {
+    // visibleModelUnion 的条目会流经 main/renderer 消费方;它们过 wire 前做显式投影的
+    // 前提是「额外字段就这三个」。这里锁死键集 —— 未来往 ModelListEntry 加字段时,
+    // 必须重新核查全部消费方的投影完整性后再更新本断言。
+    const providersFx = fixtureProviders();
+    const withAccess = deriveModelList({
+      providers: providersFx,
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+    }).find((m) => m.id === 'claude-opus-5')!;
+    const catalogKeys = new Set(
+      Object.keys(providersFx[0].models['claude-code']!.find((m) => m.id === 'claude-opus-5')!),
+    );
+    const extraKeys = Object.keys(withAccess).filter((k) => !catalogKeys.has(k));
+    expect(extraKeys.sort()).toEqual(['sourceAccess', 'sourceConnected', 'sourceProviderId']);
+  });
+});
+
+describe('deriveModelSections', () => {
+  it('逐供应商独立出段,空段剔除,段序 = rail 序', () => {
+    const sections = deriveModelSections({
+      providers: fixtureProviders(),
+      agent: 'codex',
+      providerScope: 'connected-for-agent',
+    });
+    expect(sections.map((s) => s.provider.id)).toEqual(['xd', 'custom-a']);
+    expect(sections[0].models.every((m) => m.sourceProviderId === 'xd')).toBe(true);
+  });
+});

--- a/packages/model-providers/src/__tests__/modelList.test.ts
+++ b/packages/model-providers/src/__tests__/modelList.test.ts
@@ -305,6 +305,36 @@ describe('deriveModelList options', () => {
     });
     expect(rows.some((m) => m.id === 'hidden-model')).toBe(true);
   });
+
+  // 2026-07 codex review: 选中 (provider, model) 排在 rail 后位时,不能被前位供应商的
+  // 同 id 首见行去重掉 —— 否则 flat 列表带着**错误来源**的溯源与徽章(选订阅版显示成
+  // 托管版同款事故形状)。选中行原位替换首见行:位置守首见槽(顺序契约),溯源归选中方。
+  it('keepSelected 点名后位供应商时,选中行替换首见行而非被 first-wins 丢弃', () => {
+    const rows = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+      keepSelected: { providerId: 'xd', modelId: 'claude-opus-5' },
+    });
+    const opusRows = rows.filter((m) => m.id === 'claude-opus-5');
+    expect(opusRows).toHaveLength(1);
+    // anthropic 先见,但选中方是 xd → 溯源必须是 xd(managed),不是 anthropic(subscription)
+    expect(opusRows[0].sourceProviderId).toBe('xd');
+    expect(opusRows[0].sourceAccess).toEqual({ kind: 'managed' });
+    // 位置守首见槽:仍是列表第一行(anthropic 段位),顺序契约不因替换漂移
+    expect(rows[0].id).toBe('claude-opus-5');
+  });
+
+  it('keepSelected 点名首见供应商本身时行为不变(不触发替换)', () => {
+    const rows = deriveModelList({
+      providers: fixtureProviders(),
+      agent: 'claude-code',
+      providerScope: 'connected-for-agent',
+      keepSelected: { providerId: 'anthropic', modelId: 'claude-opus-5' },
+    });
+    const opus = rows.find((m) => m.id === 'claude-opus-5');
+    expect(opus?.sourceProviderId).toBe('anthropic');
+  });
 });
 
 describe('溯源字段键集锁(visibleModelUnion 薄壳的 wire 安全前提)', () => {

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -164,7 +164,10 @@ export function modelBadges(
   model: { id: string; group?: string } & Partial<Pick<ModelSourceMeta, 'sourceAccess'>>,
   provider?: { access?: ProviderAccess } | null,
 ): ModelBadges {
-  const access = provider?.access ?? model.sourceAccess;
+  // 传了 provider(分段模式)就**只看**该段的 access —— 段供应商无 access 元数据时不得
+  // 回读 model.sourceAccess:溯源可能来自另一家供应商(flat 首见者),混用会给当前段的行
+  // 打上别家的订阅徽章(Copilot review)。仅 provider 缺席(flat)才读溯源。
+  const access = provider != null ? provider.access : model.sourceAccess;
   return {
     subscription: access?.kind === 'subscription',
     budget: isBudgetModel(model),

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -1,0 +1,187 @@
+/**
+ * classification —— 模型分类 / 来源徽章 / 展示格式的**单点语义**(纯逻辑,跨端共享)。
+ *
+ * 背景(2026-07 全仓盘点): 「骨折版 = `codex/` 前缀」在 desktop sourceSwitch.categorize、
+ * ModelSelector.renderModelItem、mobile modelPickerRows、lizi-mcps list_available_models 各写
+ * 一遍;「订阅」判定依赖分段模式的 provider 上下文,flat 清单下整个失效;`formatContextWindow`
+ * 复制了 3 份。本模块把这些语义收成单点,i18n 标签表仍留各端(本包零依赖不碰 i18n)。
+ *
+ * categorize / groupOf / groupModelsForDisplay 从 apps/desktop renderer 的 sourceSwitch.ts
+ * **原样下沉**(P1 期间 renderer 原实现暂留,有等价测试锁;P2 改 re-export 删旧)。
+ */
+
+import type { ProviderAccess } from './types.js';
+import type { ModelSourceMeta } from './modelList.js';
+
+/**
+ * 订阅直连模型的 id 前缀(经本地 responses-bridge 翻译的 `chatgpt/` 与 `xai/`)。
+ * 路由 gate、用量记账、SSH 远程排除必须共用这份前缀 —— 三者漂移会造成「列出了但发送必失败」
+ * 或「记账记错通道」。原正本在 apps/desktop/src/shared/subscriptionModels.ts,下沉后该文件为
+ * re-export shim(P2 落地)。
+ */
+export const CHATGPT_MODEL_PREFIX = 'chatgpt/';
+export const XAI_MODEL_PREFIX = 'xai/';
+export const SUBSCRIPTION_DIRECT_MODEL_PREFIXES = [
+  CHATGPT_MODEL_PREFIX,
+  XAI_MODEL_PREFIX,
+] as const;
+
+/**
+ * model id 是否为「订阅直连」(bridge)模型。传归一化后或原始 id 均可(只看前缀)。
+ * 签名与 apps/desktop/src/shared/subscriptionModels.ts 的历史实现逐字一致(下沉收口)。
+ */
+export function isSubscriptionDirectModel(model: string | null | undefined): boolean {
+  if (!model) return false;
+  return SUBSCRIPTION_DIRECT_MODEL_PREFIXES.some((prefix) => model.startsWith(prefix));
+}
+
+// 仅用于分组展示, 不参与持久化或 onModelChange 数据流。
+// 对话厂商组(anthropic..china)在前;非对话类型组(image/audio/video/embedding/other)在后——
+// 后者收纳网关多出的图像 / 语音 / 视频 / 向量等模型(它们默认关、不能当 agent 用,仅分类展示)。
+export type ModelCategory =
+  | 'anthropic'
+  | 'gpt'
+  | 'gpt-budget'
+  | 'grok'
+  | 'google'
+  | 'china'
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'embedding'
+  | 'other';
+
+export const CATEGORY_ORDER: ModelCategory[] = [
+  'anthropic',
+  'gpt-budget',
+  'gpt',
+  'grok',
+  'google',
+  'china',
+  'image',
+  'audio',
+  'video',
+  'embedding',
+  'other',
+];
+
+// 按 model.id 前缀粗分类: claude-* → Anthropic, gpt-* → GPT, codex/* → 骨折GPT (gateway 低价路由),
+// gemini-* → Google, 其余 (moonshotai/qwen/glm/...) 一律落到 China。新增国产模型不需要改这里。
+export function categorize(id: string): ModelCategory {
+  if (id.startsWith('claude-')) return 'anthropic';
+  // 非对话类型(向量/图像/音频语音/视频)必须在通用 gpt- / gemini- 厂商规则**之前**判定,
+  // 否则 gpt-image-2 / gemini-3-pro-image / gpt-4o-transcribe 会被误归到 gpt / google。
+  // 这些是网关多返回的、不能当 agent 用的模型,默认关、仅按类型归类展示。
+  if (/embedding/.test(id) || id.startsWith('voyage/')) return 'embedding';
+  if (/image/.test(id)) return 'image';
+  if (
+    id.startsWith('elevenlabs/') ||
+    id.startsWith('gpt-4o-realtime') ||
+    /transcribe|audio|speech|tts|whisper|asr|gemini-omni/.test(id)
+  )
+    return 'audio';
+  if (/seedance|happyhorse|video|-t2v|-i2v|-r2v/.test(id)) return 'video';
+  if (id === 'ai-gateway-doc') return 'other';
+  // 订阅直连 GPT(chatgpt/ 前缀,经 responses-bridge)与网关 gpt- 同归 GPT 组;前缀常量与
+  // 路由 / 记账 gate 同源(本文件顶部),防漂移。
+  if (id.startsWith('gpt-') || id.startsWith(CHATGPT_MODEL_PREFIX)) return 'gpt';
+  if (id.startsWith('codex/')) return 'gpt-budget';
+  if (id.startsWith(XAI_MODEL_PREFIX) || id.startsWith('grok')) return 'grok';
+  if (id.startsWith('gemini-')) return 'google';
+  return 'china';
+}
+
+const KNOWN_CATEGORIES = new Set<string>(CATEGORY_ORDER);
+
+/**
+ * 决定一个模型的厂商分组 —— **数据优先**:目录里带了合法 `group` 就用它,
+ * 否则回退到 id 前缀归类(categorize)。未知的 group 值(渲染层没有对应标签)也回退,
+ * 避免出现没有 i18n 标签的空分组。
+ */
+export function groupOf(model: { id: string; group?: string }): ModelCategory {
+  if (model.group && KNOWN_CATEGORIES.has(model.group)) return model.group as ModelCategory;
+  return categorize(model.id);
+}
+
+/** groupModelsForDisplay 的最小模型形状(只需 id + 可选 group / sortOrder)。 */
+export interface DisplayModel {
+  id: string;
+  group?: string;
+  sortOrder?: number;
+}
+
+/**
+ * 选择器右栏的「分组 + 排序」纯逻辑 —— **完全由目录数据驱动**:
+ *   1. 先按 `sortOrder` 升序稳定排序(缺省排末尾,相等时保持入参顺序);
+ *   2. 按 `groupOf`(group 字段优先 / 前缀兜底)分桶;
+ *   3. 桶的先后 = 桶内首个模型在已排序列表里的出现序(= 该桶最小 sortOrder)。
+ * 返回有序的 { category, models } 列表;不依赖写死的 CATEGORY_ORDER 决定展示顺序。
+ */
+export function groupModelsForDisplay<T extends DisplayModel>(
+  models: readonly T[],
+): Array<{ category: ModelCategory; models: T[] }> {
+  const sorted = [...models].sort(
+    (a, b) =>
+      (a.sortOrder ?? Number.POSITIVE_INFINITY) - (b.sortOrder ?? Number.POSITIVE_INFINITY),
+  );
+  const map = new Map<ModelCategory, T[]>();
+  for (const m of sorted) {
+    const cat = groupOf(m);
+    const list = map.get(cat) ?? [];
+    list.push(m);
+    map.set(cat, list);
+  }
+  return [...map.entries()].map(([category, list]) => ({ category, models: list }));
+}
+
+/**
+ * 骨折版(网关 85% off 低价路由)判定 —— 目录 `group === 'gpt-budget'` 优先,
+ * `codex/` 前缀兜底(网关旧数据可能没标 group)。替代 4 处独立的前缀判断。
+ */
+export function isBudgetModel(model: { id: string; group?: string }): boolean {
+  if (model.group === 'gpt-budget') return true;
+  return model.id.startsWith('codex/');
+}
+
+/** 一行模型的来源徽章语义(渲染层只管画,不再自判)。 */
+export interface ModelBadges {
+  /** 订阅来源(Claude.ai / ChatGPT 等订阅额度)。 */
+  subscription: boolean;
+  /** 骨折版(网关低价路由)。 */
+  budget: boolean;
+}
+
+/**
+ * 徽章判定的**唯一口径**。
+ *
+ * 订阅: 分段模式传该段 `provider`;flat 清单不再有 provider 上下文,改读条目上的
+ * `sourceAccess`(deriveModelList 附带的真实溯源)。两者都拿不到(device-link 旧被控端的
+ * 拍平 capabilities)→ false,诚实降级不猜。
+ */
+export function modelBadges(
+  model: { id: string; group?: string } & Partial<Pick<ModelSourceMeta, 'sourceAccess'>>,
+  provider?: { access?: ProviderAccess } | null,
+): ModelBadges {
+  const access = provider?.access ?? model.sourceAccess;
+  return {
+    subscription: access?.kind === 'subscription',
+    budget: isBudgetModel(model),
+  };
+}
+
+/**
+ * 上下文窗口 tokens → 紧凑展示("1M" / "272K" / "8192")—— desktop ModelSelector /
+ * UnifiedModelList 与 mobile modelPickerRows 三份副本的收口,实现从 ModelSelector 原样下沉,
+ * 输出逐字一致。
+ */
+export function formatContextWindow(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000;
+    return `${Number.isInteger(m) ? m : Number(m.toFixed(1))}M`;
+  }
+  if (tokens >= 1000) {
+    const k = tokens / 1000;
+    return `${Number.isInteger(k) ? k : Number(k.toFixed(0))}K`;
+  }
+  return String(tokens);
+}

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -135,11 +135,13 @@ export function groupModelsForDisplay<T extends DisplayModel>(
 }
 
 /**
- * 骨折版(网关 85% off 低价路由)判定 —— 目录 `group === 'gpt-budget'` 优先,
- * `codex/` 前缀兜底(网关旧数据可能没标 group)。替代 4 处独立的前缀判断。
+ * 骨折版(网关 85% off 低价路由)判定 —— 与 groupOf 同一「数据优先」契约:目录带**合法**
+ * `group` 时徽章完全跟 group 走(显式非 budget 分组不再被 `codex/` 前缀 override,否则会
+ * 出现「显示 budget 徽章却归入非 budget 分组」的自相矛盾,2026-07 Greptile review);
+ * group 缺失/未知时才用前缀兜底(网关旧数据可能没标 group)。替代 4 处独立的前缀判断。
  */
 export function isBudgetModel(model: { id: string; group?: string }): boolean {
-  if (model.group === 'gpt-budget') return true;
+  if (model.group && KNOWN_CATEGORIES.has(model.group)) return model.group === 'gpt-budget';
   return model.id.startsWith('codex/');
 }
 

--- a/packages/model-providers/src/effortResolution.ts
+++ b/packages/model-providers/src/effortResolution.ts
@@ -115,7 +115,12 @@ export function effortRank(e: Effort): number {
 /** 取一组 effort 里的最低档;空 → null。(title-one-shot 的 EFFORT_RANK/lowestEffort 收口。) */
 export function lowestEffort(efforts: readonly Effort[]): Effort | null {
   if (!efforts.length) return null;
-  return [...efforts].sort((a, b) => effortRank(a) - effortRank(b))[0];
+  // 线性取最小(严格小于:平级保留先出现者,与原 copy+稳定 sort 语义一致,省 O(n log n)+拷贝)。
+  let best = efforts[0];
+  for (const e of efforts) {
+    if (effortRank(e) < effortRank(best)) best = e;
+  }
+  return best;
 }
 
 /**

--- a/packages/model-providers/src/effortResolution.ts
+++ b/packages/model-providers/src/effortResolution.ts
@@ -76,12 +76,46 @@ export function resolveProviderSwitchEffort(args: {
   return efforts[0];
 }
 
-/** effort 强弱序(低 → 高);未知档排在最高之上(保守不上调)。 */
-const EFFORT_ORDER: readonly Effort[] = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
+/**
+ * effort 全档位的**单一来源**(序即强弱序,低 → 高)。types.ts 的 `Effort` 字面量联合与此
+ * 逐项对应,由下方类型级断言在包内锁死双向一致(改任一边不改另一边 → 编译失败)。
+ * 历史上这份枚举在 imDefaultSettings / title-one-shot(EFFORT_RANK)/ active-catalog
+ * (VALID_EFFORTS)等处有 6 份字面量副本,P2-P4 分期改为从这里派生。
+ */
+export const EFFORT_VALUES = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+] as const;
 
-function effortRank(e: Effort): number {
+// 类型级双向锁: EFFORT_VALUES ⊆ types.Effort 且 types.Effort ⊆ EFFORT_VALUES。
+// (本文件的运行时 Effort 故意是 string 别名 —— 见文件头;锁只针对目录侧联合。)
+type CatalogEffort = import('./types.js').Effort;
+type _EffortValuesCoverUnion = CatalogEffort extends (typeof EFFORT_VALUES)[number]
+  ? true
+  : ['EFFORT_VALUES 缺少 types.Effort 的档位', CatalogEffort];
+type _EffortValuesNoExtra = (typeof EFFORT_VALUES)[number] extends CatalogEffort
+  ? true
+  : ['EFFORT_VALUES 含 types.Effort 没有的档位'];
+const _effortEnumLock: [_EffortValuesCoverUnion, _EffortValuesNoExtra] = [true, true];
+void _effortEnumLock;
+
+const EFFORT_ORDER: readonly Effort[] = EFFORT_VALUES;
+
+/** effort 强弱序名次(低 → 高);未知档排在最高之上(保守不上调)。 */
+export function effortRank(e: Effort): number {
   const i = EFFORT_ORDER.indexOf(e);
   return i === -1 ? EFFORT_ORDER.length : i;
+}
+
+/** 取一组 effort 里的最低档;空 → null。(title-one-shot 的 EFFORT_RANK/lowestEffort 收口。) */
+export function lowestEffort(efforts: readonly Effort[]): Effort | null {
+  if (!efforts.length) return null;
+  return [...efforts].sort((a, b) => effortRank(a) - effortRank(b))[0];
 }
 
 /**
@@ -131,4 +165,83 @@ export function clampEffortToSupported(
     if (effortRank(e) < effortRank(lowest)) lowest = e;
   }
   return lowest;
+}
+
+/**
+ * 跨引擎词表的「就近档」翻译 —— Orca lead → worker 语义(与 clampEffortToSupported 是
+ * **两种并立的正当语义**,不是二选一):
+ *
+ *   - `clampEffortToSupported`(上方): **绝不上调**。用于「用户显式存过的档必须只降不升」的
+ *     场景(定时任务省钱意图,issue #456)。
+ *   - `nearestSupportedEffort`(本函数): **双向就近**。用于「把一个引擎的 effort 意图翻译到
+ *     另一个引擎的词表」——GPT 的 xhigh ≈ Claude 的 max,lead 用 Claude(max)开 GPT worker 时
+ *     落 xhigh 是翻译,不是降级;反向 xhigh→max 是**上调**,在这个语义里同样正确。
+ *
+ * 行为与 orcaWorkerCreationService.normalizeResolvedEffort 的非显式分支逐字节一致
+ * (minimal→low、ultra→max→xhigh、max→xhigh、xhigh→max;命不中级联映射 → null,由调用方
+ * 决定回落模型默认还是报错)。历史上这套级联只存在于 orca 一处且与 clamp 的方向"冲突",
+ * 收口成有名字有测试的标准函数后,冲突变成两个可显式选择的语义。
+ */
+export function nearestSupportedEffort(
+  effort: Effort,
+  efforts: readonly Effort[],
+): Effort | null {
+  if (efforts.includes(effort)) return effort;
+  if (effort === 'minimal' && efforts.includes('low')) return 'low';
+  if (effort === 'ultra' && efforts.includes('max')) return 'max';
+  // ultra 但模型无 max(只到 xhigh)时,级联到 xhigh,别掉回默认档丢掉最高兼容档。
+  if (effort === 'ultra' && efforts.includes('xhigh')) return 'xhigh';
+  if (effort === 'max' && efforts.includes('xhigh')) return 'xhigh';
+  if (effort === 'xhigh' && efforts.includes('max')) return 'max';
+  return null;
+}
+
+/**
+ * 无人值守派发场景(IM 新会话 / hook 建会话 / mobile 草稿 reconcile)的「请求档 → 实际落档」
+ * 统一回落链(2026-07 对抗审查两轮修正后的定稿)。
+ *
+ * 模型**有** effort 档时,链是唯一的一份(方向与 IM defaultSessionSettings.resolveEffort
+ * 逐分支对齐 —— 初版曾把 override 排在 requested 之前,会让运营表压过用户显式选择;
+ * override 是 requested 非法时的回落,不是覆盖):
+ *
+ *   1. 显式请求档 ∈ 支持档 → 用它(用户/协议显式意图最高);
+ *   2. per-model override(如 IM_DEFAULT_EFFORT_OVERRIDES)∈ 支持档 → 用它;
+ *   3. 模型默认档 ∈ 支持档 → 用它;
+ *   4. 支持档首项。
+ *
+ * 模型**未知或无档**时,三份历史实现的行为是三种,且都是各自 wire 契约的一部分,
+ * **不能拉平**,故显式参数化(`noEffortsBehavior`,默认最保守的 'fallback-only'):
+ *   - 'fallback-only'    → 恒 noEffortFallback(hook defaults.ts: 无档就不传,显式档也不传
+ *                          —— 模型不支持,传了会被上游拒);
+ *   - 'requested-first'  → requested(truthy)|| noEffortFallback(IM resolveEffort 的
+ *                          `requested || 'high'`: 目录暂缺时别丢用户选择);
+ *   - 'override-first'   → override(truthy)|| noEffortFallback(IM getImDefaultEffortFor:
+ *                          该场景 requested 恒空,元数据缺失时运营 override 仍生效)。
+ */
+export function reconcileInvocationEffort<TFallback extends Effort | null | undefined>(args: {
+  requested: Effort | null | undefined;
+  model: { efforts: readonly Effort[]; defaultEffort: Effort | null } | undefined;
+  overrides?: Readonly<Partial<Record<string, Effort>>>;
+  modelId?: string;
+  noEffortFallback: TFallback;
+  noEffortsBehavior?: 'fallback-only' | 'requested-first' | 'override-first';
+}): Effort | TFallback {
+  const { requested, model, overrides, modelId, noEffortFallback } = args;
+  // Object.hasOwn: model id 可能来自用户可输入的自定义供应商('constructor' 等原型键
+  // 会从 Object.prototype 取到函数)。原 IM 实现同病,标准化时一并修。
+  const override =
+    modelId !== undefined && overrides !== undefined && Object.hasOwn(overrides, modelId)
+      ? overrides[modelId]
+      : undefined;
+  if (!model || model.efforts.length === 0) {
+    const behavior = args.noEffortsBehavior ?? 'fallback-only';
+    if (behavior === 'requested-first' && requested) return requested;
+    if (behavior === 'override-first' && override) return override;
+    return noEffortFallback;
+  }
+  const ok = (e: Effort | null | undefined): e is Effort => !!e && model.efforts.includes(e);
+  if (ok(requested)) return requested;
+  if (ok(override)) return override;
+  if (ok(model.defaultEffort)) return model.defaultEffort;
+  return model.efforts[0];
 }

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -61,4 +61,48 @@ export type { ConnectionState, ProviderView, ResolvedRoute } from './registry.js
 export { isModelVisible, buildProviderSections, visibleModelUnion, resolveModelIconKind } from './sections.js';
 export type { SectionModel, ProviderSection, ModelIconKind } from './sections.js';
 
-export { resolveEffort, resolveProviderSwitchEffort, clampEffortToSupported } from './effortResolution.js';
+export {
+  resolveEffort,
+  resolveProviderSwitchEffort,
+  clampEffortToSupported,
+  EFFORT_VALUES,
+  effortRank,
+  lowestEffort,
+  nearestSupportedEffort,
+  reconcileInvocationEffort,
+} from './effortResolution.js';
+
+// ── 模型调用标准(2026-07 统一层)─────────────────────────────────────────────
+// 清单派生 / 分类徽章 / 调用合成的单点语义,desktop renderer+main 与 mobile 的全部
+// 模型消费面分期收口到这里(见 modelList.ts / classification.ts / invocation.ts 头注)。
+export { deriveModelList, deriveModelSections } from './modelList.js';
+export type {
+  ModelSourceMeta,
+  ModelListEntry,
+  ModelListSection,
+  DeriveModelListOptions,
+  ProviderScope,
+} from './modelList.js';
+
+export {
+  CHATGPT_MODEL_PREFIX,
+  XAI_MODEL_PREFIX,
+  SUBSCRIPTION_DIRECT_MODEL_PREFIXES,
+  isSubscriptionDirectModel,
+  CATEGORY_ORDER,
+  categorize,
+  groupOf,
+  groupModelsForDisplay,
+  isBudgetModel,
+  modelBadges,
+  formatContextWindow,
+} from './classification.js';
+export type { ModelCategory, DisplayModel, ModelBadges } from './classification.js';
+
+export { resolveModelInvocation } from './invocation.js';
+export type {
+  InvocationPreferences,
+  ScenarioDefaults,
+  InvocationCatalogContext,
+  ResolvedInvocation,
+} from './invocation.js';

--- a/packages/model-providers/src/invocation.ts
+++ b/packages/model-providers/src/invocation.ts
@@ -1,0 +1,230 @@
+/**
+ * invocation —— 「无人值守派发的调用请求合成」标准(纯逻辑,跨端共享)。
+ *
+ * 背景(2026-07 全仓盘点): 「按 (显式偏好, 场景默认, 目录可用性) 合成新会话的
+ * agent/model/effort/providerId/permissionMode/fastMode」这件事在 desktop main 里被独立实现
+ * 了 6+ 份(IM defaultSessionSettings / hook-control defaults / scheduler runner / orca
+ * workerCreation / IM cardActionHandler / newMakerDraft),每份回落链略有差异、硬编码默认
+ * 互不一致,并且已经产生过真实事故(hook 权限档回落方向写反 → 显示最严实际最宽)。
+ *
+ * 本模块收口回落链本体;**场景默认全部由调用方传入**(ScenarioDefaults),共享包内零模型 id
+ * 字面量 —— scheduler 想默认 Sonnet、IM 想默认 Opus,那是场景决策,不是标准的一部分。
+ *
+ * 安全语义(适用于一切无人值守入口):
+ *   - permissionMode: 显式档不被该 agent 支持时回落该 agent 的**最严**档(permissionModes
+ *     按从严到宽声明,取 [0]),绝不回落场景默认(场景默认往往是 bypass)。用户填过显式档
+ *     = 表达过「不要默认的完全访问」,不支持时只能更严不能更宽。
+ *     注意这对 upstream/main 的 hook 现行实现(defaults.ts: 非法档回落 bypass)是**刻意
+ *     收紧**,与 PR #403(32b8edf)的修正同语义;P3 把 hook 迁到本函数时,若 #403 未先合并,
+ *     迁移 PR 必须把该收紧作为行为变更显式声明,不许当"无行为变化"混过。
+ *   - providerId: 必须收敛到「已连接且真实提供最终模型」的来源,否则回 null(默认路由),
+ *     不落一个路由层解析不了、或与 model 错配的 id。
+ */
+
+import type { AgentKind, CatalogModel } from './types.js';
+import {
+  connectedProvidersForAgent,
+  providerOffersModel,
+  type ProviderView,
+} from './registry.js';
+import { reconcileInvocationEffort } from './effortResolution.js';
+
+/** 显式偏好(用户设置 / 协议 override),全可空;null/undefined = 该字段无显式意图。 */
+export interface InvocationPreferences {
+  agentKind?: string | null;
+  model?: string | null;
+  effort?: string | null;
+  providerId?: string | null;
+  permissionMode?: string | null;
+  fastMode?: boolean | null;
+}
+
+/** 场景默认 —— 每个派发面自己的产品决策,作为参数传入,不散落硬编码。 */
+export interface ScenarioDefaults {
+  agentKind: AgentKind;
+  /** 场景默认模型(scheduler=Sonnet、IM=渠道草稿…)。返回值仍要过可用性校验。 */
+  modelFor: (agent: AgentKind) => string;
+  /** 场景默认 effort(如 IM 渠道草稿档);缺省 = 直接走模型默认档。 */
+  effortFor?: (agent: AgentKind, modelId: string) => string | null;
+  /** per-model effort 运营 override(如 IM_DEFAULT_EFFORT_OVERRIDES)。 */
+  effortOverrides?: Readonly<Partial<Record<string, string>>>;
+  /** 模型无 effort 档时的返回值 —— 各面 wire 契约的一部分(IM='high'、hook=undefined)。 */
+  noEffortFallback: string | null | undefined;
+  /** 模型未知/无档时对 requested/override 的取舍(三种历史语义,见 reconcileInvocationEffort)。 */
+  noEffortsBehavior?: 'fallback-only' | 'requested-first' | 'override-first';
+  /** 场景默认权限档(hook='bypassPermissions'、card='acceptEdits'…),仅在无显式档时使用。 */
+  permissionMode: string;
+  /** 场景默认来源(如 IM 草稿的 providerId);与显式值同样要过收敛校验。 */
+  providerIdFor?: (agent: AgentKind, modelId: string) => string | null;
+  fastMode?: boolean;
+}
+
+/** 目录上下文。providers=null = 目录不可用 → capabilities 兜底 + providerId 透传降级。 */
+export interface InvocationCatalogContext {
+  providers: readonly ProviderView[] | null;
+  /** 目录不可用时的模型清单兜底(agent capabilities 冻结快照)。 */
+  getCapabilityModels?: (
+    agent: AgentKind,
+  ) => readonly { id: string; efforts: readonly string[]; defaultEffort: string | null }[];
+  /** 该 agent 支持的权限档(**从严到宽**声明;permissionMode 校验与最严档回落依赖此序)。 */
+  getPermissionModes?: (agent: AgentKind) => readonly string[];
+  /** 可见性过滤(决定「可用模型」是否剔除用户隐藏项);缺省 = 不过滤。 */
+  isVisible?: (providerId: string, model: CatalogModel) => boolean;
+}
+
+export interface ResolvedInvocation {
+  agentKind: AgentKind;
+  model: string;
+  effort: string | null | undefined;
+  providerId: string | null;
+  permissionMode: string;
+  fastMode: boolean;
+  /**
+   * 诊断轨迹: 各字段命中了哪级回落(如 'model:scenario-default'、
+   * 'permission:strictest-fallback')。调用方打日志用,不参与任何逻辑。
+   */
+  fallbacksApplied: readonly string[];
+}
+
+interface AvailableModel {
+  id: string;
+  efforts: readonly string[];
+  defaultEffort: string | null;
+}
+
+function availableModelsFor(
+  agent: AgentKind,
+  ctx: InvocationCatalogContext,
+): AvailableModel[] | null {
+  if (ctx.providers !== null) {
+    const seen = new Set<string>();
+    const out: AvailableModel[] = [];
+    for (const provider of connectedProvidersForAgent([...ctx.providers], agent)) {
+      for (const m of provider.models[agent] ?? []) {
+        if (seen.has(m.id)) continue;
+        if (ctx.isVisible && !ctx.isVisible(provider.id, m)) continue;
+        seen.add(m.id);
+        out.push({ id: m.id, efforts: m.efforts, defaultEffort: m.defaultEffort });
+      }
+    }
+    return out;
+  }
+  const caps = ctx.getCapabilityModels?.(agent);
+  return caps ? [...caps] : null;
+}
+
+function isKnownAgent(v: string | null | undefined): v is AgentKind {
+  return v === 'claude-code' || v === 'codex';
+}
+
+/**
+ * 标准调用合成。回落链每一级都要求候选值可用;`fallbacksApplied` 记录实际命中级。
+ *
+ * model 链: 显式∈可用 > 场景默认∈可用 > 该 agent 首个可用 > 场景默认裸值(目录/caps 全
+ * 不可用时的兼容兜底 —— 与 IM/hook 历史行为一致,宁可发一个可能非法的 id 也不发空串)。
+ */
+export function resolveModelInvocation(
+  prefs: InvocationPreferences,
+  scenario: ScenarioDefaults,
+  ctx: InvocationCatalogContext,
+): ResolvedInvocation {
+  const fallbacks: string[] = [];
+
+  // 1. agentKind: 显式合法 > 场景默认。
+  let agentKind: AgentKind;
+  if (isKnownAgent(prefs.agentKind)) {
+    agentKind = prefs.agentKind;
+  } else {
+    agentKind = scenario.agentKind;
+    if (prefs.agentKind != null) fallbacks.push('agent:scenario-default');
+  }
+
+  // 2. model。
+  const available = availableModelsFor(agentKind, ctx);
+  const has = (id: string | null | undefined): id is string =>
+    !!id && (available === null || available.some((m) => m.id === id));
+  const scenarioModel = scenario.modelFor(agentKind);
+  let model: string;
+  if (has(prefs.model)) {
+    model = prefs.model;
+    // 目录与 caps 全不可用时 has() 放行一切 —— 值被采纳但未经校验,记入诊断轨迹。
+    if (available === null) fallbacks.push('model:explicit-unverified');
+  } else if (has(scenarioModel)) {
+    model = scenarioModel;
+    if (prefs.model != null) fallbacks.push('model:scenario-default');
+    if (available === null) fallbacks.push('model:scenario-default-unverified');
+  } else if (available !== null && available.length > 0) {
+    model = available[0].id;
+    fallbacks.push('model:first-available');
+  } else {
+    model = scenarioModel;
+    fallbacks.push('model:scenario-default-unverified');
+  }
+
+  // 3. effort。requested 槽位是**两级候选**: 显式档非法时先试场景默认档(hook 的
+  //    「显式 > 草稿 > 模型默认」历史链;初版 `prefs.effort ?? scenarioEffort` 会在显式档
+  //    非法时直接跳过草稿档,2026-07 对抗审查修正),再交给统一回落链。
+  const descriptor = available?.find((m) => m.id === model);
+  const scenarioEffort = scenario.effortFor?.(agentKind, model) ?? null;
+  let requestedEffort: string | null | undefined;
+  if (descriptor && descriptor.efforts.length > 0) {
+    requestedEffort =
+      [prefs.effort, scenarioEffort].find((c) => !!c && descriptor.efforts.includes(c)) ??
+      prefs.effort;
+  } else {
+    requestedEffort = prefs.effort ?? scenarioEffort;
+  }
+  const effort = reconcileInvocationEffort({
+    requested: requestedEffort,
+    model: descriptor,
+    overrides: scenario.effortOverrides,
+    modelId: model,
+    noEffortFallback: scenario.noEffortFallback,
+    ...(scenario.noEffortsBehavior !== undefined
+      ? { noEffortsBehavior: scenario.noEffortsBehavior }
+      : {}),
+  });
+  if (prefs.effort != null && effort !== prefs.effort) fallbacks.push('effort:reconciled');
+
+  // 4. providerId: 显式 / 场景值收敛到「已连接且真实提供最终模型」的来源,失败回 null。
+  //    目录不可用时透传原值(路由层仍有兜底)—— 与 IM/hook 历史降级一致。
+  const requestedProvider = prefs.providerId ?? scenario.providerIdFor?.(agentKind, model) ?? null;
+  let providerId: string | null = null;
+  if (requestedProvider) {
+    if (ctx.providers === null) {
+      providerId = requestedProvider;
+      fallbacks.push('provider:unverified-passthrough');
+    } else {
+      const usable = connectedProvidersForAgent([...ctx.providers], agentKind).some(
+        (p) => p.id === requestedProvider && providerOffersModel(p, model, agentKind),
+      );
+      if (usable) {
+        providerId = requestedProvider;
+      } else {
+        providerId = null;
+        fallbacks.push('provider:default-route');
+      }
+    }
+  }
+
+  // 5. permissionMode: 显式且支持 > 显式但不支持时回落该 agent **最严**档 > 场景默认。
+  //    (安全方向硬要求,见文件头;permissionModes 未注入时无从校验,显式值原样放行。)
+  const supportedModes = ctx.getPermissionModes?.(agentKind);
+  let permissionMode: string;
+  if (prefs.permissionMode != null) {
+    if (!supportedModes || supportedModes.includes(prefs.permissionMode)) {
+      permissionMode = prefs.permissionMode;
+    } else {
+      permissionMode = supportedModes[0] ?? scenario.permissionMode;
+      fallbacks.push('permission:strictest-fallback');
+    }
+  } else {
+    permissionMode = scenario.permissionMode;
+  }
+
+  // 6. fastMode: 请求值直传(per-provider 的 supportsFastMode 门控需要来源上下文,
+  //    由派发端在确定最终 (providerId, model) 后另行叠加 —— 本函数不越权猜)。
+  const fastMode = prefs.fastMode ?? scenario.fastMode ?? false;
+
+  return { agentKind, model, effort, providerId, permissionMode, fastMode, fallbacksApplied: fallbacks };
+}

--- a/packages/model-providers/src/invocation.ts
+++ b/packages/model-providers/src/invocation.ts
@@ -57,6 +57,16 @@ export interface ScenarioDefaults {
   /** 场景默认来源(如 IM 草稿的 providerId);与显式值同样要过收敛校验。 */
   providerIdFor?: (agent: AgentKind, modelId: string) => string | null;
   fastMode?: boolean;
+  /**
+   * 显式模型经目录/caps 校验确认不可用时的策略:
+   *   - 'fallback'(默认)= 落场景默认链继续派发 —— IM/hook 无人值守历史语义(宁可换模型
+   *     也要把会话建起来);
+   *   - 'reject' = 在返回值标记 `rejected`,调用方**不得**用合成结果开工 —— Orca
+   *     resolveWorkerConfig 语义(用户点名模型跑 worker,静默换模型 = 花错钱,必须拒绝)。
+   * 仅在目录/caps 可用且显式模型确实不在清单时生效;目录全不可用时显式值未经校验直接
+   * 采纳('model:explicit-unverified'),不触发 reject。
+   */
+  explicitModelPolicy?: 'fallback' | 'reject';
 }
 
 /** 目录上下文。providers=null = 目录不可用 → capabilities 兜底 + providerId 透传降级。 */
@@ -84,6 +94,11 @@ export interface ResolvedInvocation {
    * 'permission:strictest-fallback')。调用方打日志用,不参与任何逻辑。
    */
   fallbacksApplied: readonly string[];
+  /**
+   * `explicitModelPolicy: 'reject'` 且显式模型经校验不可用时置位。置位时其余字段仍按
+   * 回落链合成(纯诊断价值,便于日志说明"本来会跑什么"),但调用方**不得**据此开工。
+   */
+  rejected?: { field: 'model'; value: string; reason: 'explicit-model-unavailable' };
 }
 
 interface AvailableModel {
@@ -139,26 +154,53 @@ export function resolveModelInvocation(
     if (prefs.agentKind != null) fallbacks.push('agent:scenario-default');
   }
 
+  // 1b. 显式 agent 合法但目录/caps 证实它**一个可用模型都没有**,而场景默认 agent 有 →
+  //     回落到能跑的 agent。这是 IM resolveImSessionDefaults.pickModel 的现行语义(codex
+  //     review):不回落的话会合成一个「无可执行来源」的会话,比换 agent 更糟。
+  //     清单为 null(能力数据不可用)时不猜,维持显式选择。
+  let available = availableModelsFor(agentKind, ctx);
+  if (
+    isKnownAgent(prefs.agentKind) &&
+    agentKind !== scenario.agentKind &&
+    available !== null &&
+    available.length === 0
+  ) {
+    const scenarioAvailable = availableModelsFor(scenario.agentKind, ctx);
+    if (scenarioAvailable !== null && scenarioAvailable.length > 0) {
+      agentKind = scenario.agentKind;
+      available = scenarioAvailable;
+      fallbacks.push('agent:model-less-fallback');
+    }
+  }
+
   // 2. model。
-  const available = availableModelsFor(agentKind, ctx);
   const has = (id: string | null | undefined): id is string =>
     !!id && (available === null || available.some((m) => m.id === id));
   const scenarioModel = scenario.modelFor(agentKind);
   let model: string;
+  let rejected: ResolvedInvocation['rejected'];
   if (has(prefs.model)) {
     model = prefs.model;
     // 目录与 caps 全不可用时 has() 放行一切 —— 值被采纳但未经校验,记入诊断轨迹。
     if (available === null) fallbacks.push('model:explicit-unverified');
-  } else if (has(scenarioModel)) {
-    model = scenarioModel;
-    if (prefs.model != null) fallbacks.push('model:scenario-default');
-    if (available === null) fallbacks.push('model:scenario-default-unverified');
-  } else if (available !== null && available.length > 0) {
-    model = available[0].id;
-    fallbacks.push('model:first-available');
   } else {
-    model = scenarioModel;
-    fallbacks.push('model:scenario-default-unverified');
+    // 显式模型经校验确认不可用(available 必非 null,否则上分支已放行):按策略标记拒绝。
+    // 其余字段照常合成 —— rejected 是给调用方的硬信号,不是让链条中断。
+    if (prefs.model != null && scenario.explicitModelPolicy === 'reject') {
+      rejected = { field: 'model', value: prefs.model, reason: 'explicit-model-unavailable' };
+      fallbacks.push('model:explicit-rejected');
+    }
+    if (has(scenarioModel)) {
+      model = scenarioModel;
+      if (prefs.model != null) fallbacks.push('model:scenario-default');
+      if (available === null) fallbacks.push('model:scenario-default-unverified');
+    } else if (available !== null && available.length > 0) {
+      model = available[0].id;
+      fallbacks.push('model:first-available');
+    } else {
+      model = scenarioModel;
+      fallbacks.push('model:scenario-default-unverified');
+    }
   }
 
   // 3. effort。requested 槽位是**两级候选**: 显式档非法时先试场景默认档(hook 的
@@ -195,9 +237,18 @@ export function resolveModelInvocation(
       providerId = requestedProvider;
       fallbacks.push('provider:unverified-passthrough');
     } else {
-      const usable = connectedProvidersForAgent([...ctx.providers], agentKind).some(
-        (p) => p.id === requestedProvider && providerOffersModel(p, model, agentKind),
+      // 「真实提供」必须含 per-provider 可见性:同一模型在 B 可见、在 A 被用户隐藏时,
+      // 显式点名 A 不能只靠「已连接 + 目录含该模型」就放行 —— 那会绕过 isVisible 的
+      // 来源级契约,路由到用户明确排除的来源(codex review)。
+      const providerView = connectedProvidersForAgent([...ctx.providers], agentKind).find(
+        (p) => p.id === requestedProvider,
       );
+      const catalogModel = providerView?.models[agentKind]?.find((m) => m.id === model);
+      const usable =
+        providerView !== undefined &&
+        catalogModel !== undefined &&
+        providerOffersModel(providerView, model, agentKind) &&
+        (!ctx.isVisible || ctx.isVisible(providerView.id, catalogModel));
       if (usable) {
         providerId = requestedProvider;
       } else {
@@ -209,13 +260,19 @@ export function resolveModelInvocation(
 
   // 5. permissionMode: 显式且支持 > 显式但不支持时回落该 agent **最严**档 > 场景默认。
   //    (安全方向硬要求,见文件头;permissionModes 未注入时无从校验,显式值原样放行。)
+  //    **空档位表 = 能力数据异常,同「未注入」处理,显式值原样保留** —— 此前空表会落
+  //    scenario.permissionMode(常为 bypass),把显式限制静默放宽,与本函数的安全保证
+  //    正相反(Greptile + codex review 同点)。
   const supportedModes = ctx.getPermissionModes?.(agentKind);
   let permissionMode: string;
   if (prefs.permissionMode != null) {
-    if (!supportedModes || supportedModes.includes(prefs.permissionMode)) {
+    if (!supportedModes || supportedModes.length === 0) {
+      permissionMode = prefs.permissionMode;
+      if (supportedModes) fallbacks.push('permission:modes-unavailable');
+    } else if (supportedModes.includes(prefs.permissionMode)) {
       permissionMode = prefs.permissionMode;
     } else {
-      permissionMode = supportedModes[0] ?? scenario.permissionMode;
+      permissionMode = supportedModes[0];
       fallbacks.push('permission:strictest-fallback');
     }
   } else {
@@ -226,5 +283,14 @@ export function resolveModelInvocation(
   //    由派发端在确定最终 (providerId, model) 后另行叠加 —— 本函数不越权猜)。
   const fastMode = prefs.fastMode ?? scenario.fastMode ?? false;
 
-  return { agentKind, model, effort, providerId, permissionMode, fastMode, fallbacksApplied: fallbacks };
+  return {
+    agentKind,
+    model,
+    effort,
+    providerId,
+    permissionMode,
+    fastMode,
+    fallbacksApplied: fallbacks,
+    ...(rejected !== undefined ? { rejected } : {}),
+  };
 }

--- a/packages/model-providers/src/invocation.ts
+++ b/packages/model-providers/src/invocation.ts
@@ -24,6 +24,7 @@
 import type { AgentKind, CatalogModel } from './types.js';
 import {
   connectedProvidersForAgent,
+  nativeDefaultSourceId,
   providerOffersModel,
   type ProviderView,
 } from './registry.js';
@@ -159,6 +160,9 @@ export function resolveModelInvocation(
   //     review):不回落的话会合成一个「无可执行来源」的会话,比换 agent 更糟。
   //     清单为 null(能力数据不可用)时不猜,维持显式选择。
   let available = availableModelsFor(agentKind, ctx);
+  // model/effort 显式偏好经局部变量参与后续链:agent 回落时置空(见下),不改 prefs 入参。
+  let modelPref = prefs.model ?? null;
+  let effortPref = prefs.effort ?? null;
   if (
     isKnownAgent(prefs.agentKind) &&
     agentKind !== scenario.agentKind &&
@@ -170,6 +174,12 @@ export function resolveModelInvocation(
       agentKind = scenario.agentKind;
       available = scenarioAvailable;
       fallbacks.push('agent:model-less-fallback');
+      // 显式 model/effort 是与**原 agent 配对**的偏好,跨 agent 作废(IM pickModel 换
+      // agent 时用渠道默认,不搬旧模型)。不作废的话,恰好同 id 的模型(gpt-5.5 /
+      // codex/gpt-5.5 两个 agent 目录都有)会被当作新 agent 的显式选择采纳,还会
+      // 绕过 explicitModelPolicy: 'reject' 的严格校验(codex review)。
+      modelPref = null;
+      effortPref = null;
     }
   }
 
@@ -179,23 +189,36 @@ export function resolveModelInvocation(
   const scenarioModel = scenario.modelFor(agentKind);
   let model: string;
   let rejected: ResolvedInvocation['rejected'];
-  if (has(prefs.model)) {
-    model = prefs.model;
+  if (has(modelPref)) {
+    model = modelPref;
     // 目录与 caps 全不可用时 has() 放行一切 —— 值被采纳但未经校验,记入诊断轨迹。
     if (available === null) fallbacks.push('model:explicit-unverified');
   } else {
     // 显式模型经校验确认不可用(available 必非 null,否则上分支已放行):按策略标记拒绝。
     // 其余字段照常合成 —— rejected 是给调用方的硬信号,不是让链条中断。
-    if (prefs.model != null && scenario.explicitModelPolicy === 'reject') {
-      rejected = { field: 'model', value: prefs.model, reason: 'explicit-model-unavailable' };
+    if (modelPref != null && scenario.explicitModelPolicy === 'reject') {
+      rejected = { field: 'model', value: modelPref, reason: 'explicit-model-unavailable' };
       fallbacks.push('model:explicit-rejected');
     }
     if (has(scenarioModel)) {
       model = scenarioModel;
-      if (prefs.model != null) fallbacks.push('model:scenario-default');
+      if (modelPref != null) fallbacks.push('model:scenario-default');
       if (available === null) fallbacks.push('model:scenario-default-unverified');
     } else if (available !== null && available.length > 0) {
-      model = available[0].id;
+      // 「首个可用」的口径与 IM 现行兜底一致:优先 **native 默认源**(claude-code 优先
+      // 'xd'、codex 优先 'openai')上的首个可见模型,该源无可选才退 rail 序首个 ——
+      // raw 目录序首个会把兜底模型换到不同来源/计费路由(codex review)。
+      let fromNative: string | null = null;
+      if (ctx.providers !== null) {
+        const rail = connectedProvidersForAgent([...ctx.providers], agentKind);
+        const nativeId = nativeDefaultSourceId(rail, agentKind);
+        const availableIds = new Set(available.map((m) => m.id));
+        fromNative =
+          rail
+            .find((p) => p.id === nativeId)
+            ?.models[agentKind]?.find((m) => availableIds.has(m.id))?.id ?? null;
+      }
+      model = fromNative ?? available[0].id;
       fallbacks.push('model:first-available');
     } else {
       model = scenarioModel;
@@ -217,10 +240,10 @@ export function resolveModelInvocation(
   let requestedEffort: string | null | undefined;
   if (descriptor && descriptor.efforts.length > 0) {
     requestedEffort =
-      [prefs.effort, scenarioEffort].find((c) => !!c && descriptor.efforts.includes(c)) ??
-      prefs.effort;
+      [effortPref, scenarioEffort].find((c) => !!c && descriptor.efforts.includes(c)) ??
+      effortPref;
   } else {
-    requestedEffort = prefs.effort ?? scenarioEffort;
+    requestedEffort = effortPref ?? scenarioEffort;
   }
   const effort = reconcileInvocationEffort({
     requested: requestedEffort,
@@ -232,7 +255,7 @@ export function resolveModelInvocation(
       ? { noEffortsBehavior: scenario.noEffortsBehavior }
       : {}),
   });
-  if (prefs.effort != null && effort !== prefs.effort) fallbacks.push('effort:reconciled');
+  if (effortPref != null && effort !== effortPref) fallbacks.push('effort:reconciled');
 
   // 4. providerId: 显式 / 场景值收敛到「已连接且真实提供最终模型」的来源,失败回 null。
   //    目录不可用时透传原值(路由层仍有兜底)—— 与 IM/hook 历史降级一致。
@@ -246,20 +269,29 @@ export function resolveModelInvocation(
       // 「真实提供」必须含 per-provider 可见性:同一模型在 B 可见、在 A 被用户隐藏时,
       // 显式点名 A 不能只靠「已连接 + 目录含该模型」就放行 —— 那会绕过 isVisible 的
       // 来源级契约,路由到用户明确排除的来源(codex review)。
-      const providerView = connectedProvidersForAgent([...ctx.providers], agentKind).find(
-        (p) => p.id === requestedProvider,
-      );
-      const catalogModel = providerView?.models[agentKind]?.find((m) => m.id === model);
-      const usable =
-        providerView !== undefined &&
-        catalogModel !== undefined &&
-        providerOffersModel(providerView, model, agentKind) &&
-        (!ctx.isVisible || ctx.isVisible(providerView.id, catalogModel));
-      if (usable) {
+      const rail = connectedProvidersForAgent([...ctx.providers], agentKind);
+      const visiblyOffers = (p: (typeof rail)[number]): boolean => {
+        if (!providerOffersModel(p, model, agentKind)) return false;
+        if (!ctx.isVisible) return true;
+        const cm = p.models[agentKind]?.find((m) => m.id === model);
+        return cm !== undefined && ctx.isVisible(p.id, cm);
+      };
+      const providerView = rail.find((p) => p.id === requestedProvider);
+      if (providerView !== undefined && visiblyOffers(providerView)) {
         providerId = requestedProvider;
       } else {
-        providerId = null;
-        fallbacks.push('provider:default-route');
+        // 点名源不可用(断开/不提供/被隐藏)。回 null 不足以执行可见性决定 —— 下游默认
+        // 路由(nativeDefaultSourceId)不看可见性,可能又选回同一个被隐藏的源:这里直接
+        // 收敛到 native 优先的**可见**替代源;完全没有可见源才回 null 默认路由
+        // (codex review, 2026-07)。
+        const alternatives = rail.filter(visiblyOffers);
+        if (alternatives.length > 0) {
+          providerId = nativeDefaultSourceId(alternatives, agentKind) ?? alternatives[0].id;
+          fallbacks.push('provider:visible-fallback');
+        } else {
+          providerId = null;
+          fallbacks.push('provider:default-route');
+        }
       }
     }
   }

--- a/packages/model-providers/src/invocation.ts
+++ b/packages/model-providers/src/invocation.ts
@@ -216,11 +216,15 @@ export function resolveModelInvocation(
       if (ctx.providers !== null) {
         const rail = connectedProvidersForAgent([...ctx.providers], agentKind);
         const nativeId = nativeDefaultSourceId(rail, agentKind);
+        const native = rail.find((p) => p.id === nativeId);
         const availableIds = new Set(available.map((m) => m.id));
+        // 可见性按 **native 源上的那一行**判,不能只看联合清单:某 id 在 native 源被隐藏、
+        // 他源可见时,选它会让 provider 步骤路由去他源 —— 跳过了 native 源后面还有的
+        // 可见模型,订阅/计费路由被悄悄换掉(codex review 五轮)。
         fromNative =
-          rail
-            .find((p) => p.id === nativeId)
-            ?.models[agentKind]?.find((m) => availableIds.has(m.id))?.id ?? null;
+          native?.models[agentKind]?.find(
+            (m) => availableIds.has(m.id) && (!ctx.isVisible || ctx.isVisible(native.id, m)),
+          )?.id ?? null;
       }
       model = fromNative ?? available[0].id;
       fallbacks.push('model:first-available');
@@ -334,6 +338,17 @@ export function resolveModelInvocation(
     }
   } else {
     permissionMode = scenario.permissionMode;
+    // 场景默认档同样要对**最终 agent** 校验:Claude 场景默认 acceptEdits + 显式 Codex
+    // agent 会合成 Codex 不支持的档,无人值守派发直接被运行时拒绝或误解 —— 不支持时
+    // 与显式分支同方向回落该 agent 最严档(codex review);空表/未注入 = 数据缺失,原样。
+    if (
+      supportedModes !== undefined &&
+      supportedModes.length > 0 &&
+      !supportedModes.includes(permissionMode)
+    ) {
+      permissionMode = supportedModes[0];
+      fallbacks.push('permission:scenario-strictest-fallback');
+    }
   }
 
   // 6. fastMode: 请求值直传(per-provider 的 supportsFastMode 门控需要来源上下文,

--- a/packages/model-providers/src/invocation.ts
+++ b/packages/model-providers/src/invocation.ts
@@ -160,9 +160,10 @@ export function resolveModelInvocation(
   //     review):不回落的话会合成一个「无可执行来源」的会话,比换 agent 更糟。
   //     清单为 null(能力数据不可用)时不猜,维持显式选择。
   let available = availableModelsFor(agentKind, ctx);
-  // model/effort 显式偏好经局部变量参与后续链:agent 回落时置空(见下),不改 prefs 入参。
+  // model/effort/providerId 显式偏好经局部变量参与后续链:agent 回落时置空(见下),不改 prefs 入参。
   let modelPref = prefs.model ?? null;
   let effortPref = prefs.effort ?? null;
+  let providerPref = prefs.providerId ?? null;
   if (
     isKnownAgent(prefs.agentKind) &&
     agentKind !== scenario.agentKind &&
@@ -174,12 +175,15 @@ export function resolveModelInvocation(
       agentKind = scenario.agentKind;
       available = scenarioAvailable;
       fallbacks.push('agent:model-less-fallback');
-      // 显式 model/effort 是与**原 agent 配对**的偏好,跨 agent 作废(IM pickModel 换
-      // agent 时用渠道默认,不搬旧模型)。不作废的话,恰好同 id 的模型(gpt-5.5 /
-      // codex/gpt-5.5 两个 agent 目录都有)会被当作新 agent 的显式选择采纳,还会
-      // 绕过 explicitModelPolicy: 'reject' 的严格校验(codex review)。
+      // 显式 model/effort/providerId 是与**原 agent 配对**的偏好,跨 agent 全部作废
+      // (IM 换 agent 后读 raw.agents[新agent] 的整组配置,defaultSessionSettings.ts)。
+      // model/effort 不作废会让恰好同 id 的模型(gpt-5.5 双 agent 目录都有)被当作新
+      // agent 的显式选择采纳,还会绕过 explicitModelPolicy: 'reject';providerId 不作废
+      // 会把原 agent 的路由/计费选择(如 xd)强加给回落 agent,压掉场景为新 agent 配置
+      // 的 providerIdFor(codex review 两轮)。
       modelPref = null;
       effortPref = null;
+      providerPref = null;
     }
   }
 
@@ -259,38 +263,53 @@ export function resolveModelInvocation(
 
   // 4. providerId: 显式 / 场景值收敛到「已连接且真实提供最终模型」的来源,失败回 null。
   //    目录不可用时透传原值(路由层仍有兜底)—— 与 IM/hook 历史降级一致。
-  const requestedProvider = prefs.providerId ?? scenario.providerIdFor?.(agentKind, model) ?? null;
+  const requestedProvider = providerPref ?? scenario.providerIdFor?.(agentKind, model) ?? null;
   let providerId: string | null = null;
-  if (requestedProvider) {
-    if (ctx.providers === null) {
+  if (ctx.providers === null) {
+    if (requestedProvider) {
       providerId = requestedProvider;
       fallbacks.push('provider:unverified-passthrough');
-    } else {
-      // 「真实提供」必须含 per-provider 可见性:同一模型在 B 可见、在 A 被用户隐藏时,
-      // 显式点名 A 不能只靠「已连接 + 目录含该模型」就放行 —— 那会绕过 isVisible 的
-      // 来源级契约,路由到用户明确排除的来源(codex review)。
-      const rail = connectedProvidersForAgent([...ctx.providers], agentKind);
-      const visiblyOffers = (p: (typeof rail)[number]): boolean => {
-        if (!providerOffersModel(p, model, agentKind)) return false;
-        if (!ctx.isVisible) return true;
-        const cm = p.models[agentKind]?.find((m) => m.id === model);
-        return cm !== undefined && ctx.isVisible(p.id, cm);
-      };
-      const providerView = rail.find((p) => p.id === requestedProvider);
-      if (providerView !== undefined && visiblyOffers(providerView)) {
-        providerId = requestedProvider;
+    }
+  } else if (requestedProvider || ctx.isVisible) {
+    // 「真实提供」必须含 per-provider 可见性:同一模型在 B 可见、在 A 被用户隐藏时,
+    // 显式点名 A 不能只靠「已连接 + 目录含该模型」就放行 —— 那会绕过 isVisible 的
+    // 来源级契约,路由到用户明确排除的来源(codex review)。
+    const rail = connectedProvidersForAgent([...ctx.providers], agentKind);
+    const visiblyOffers = (p: (typeof rail)[number]): boolean => {
+      if (!providerOffersModel(p, model, agentKind)) return false;
+      if (!ctx.isVisible) return true;
+      const cm = p.models[agentKind]?.find((m) => m.id === model);
+      return cm !== undefined && ctx.isVisible(p.id, cm);
+    };
+    const named = requestedProvider ? rail.find((p) => p.id === requestedProvider) : undefined;
+    if (requestedProvider && named !== undefined && visiblyOffers(named)) {
+      providerId = requestedProvider;
+    } else if (requestedProvider) {
+      // 点名源不可用(断开/不提供/被隐藏)。回 null 不足以执行可见性决定 —— 下游默认
+      // 路由(nativeDefaultSourceId)不看可见性,可能又选回同一个被隐藏的源:这里直接
+      // 收敛到 native 优先的**可见**替代源;完全没有可见源才回 null 默认路由
+      // (codex review, 2026-07)。
+      const alternatives = rail.filter(visiblyOffers);
+      if (alternatives.length > 0) {
+        providerId = nativeDefaultSourceId(alternatives, agentKind) ?? alternatives[0].id;
+        fallbacks.push('provider:visible-fallback');
       } else {
-        // 点名源不可用(断开/不提供/被隐藏)。回 null 不足以执行可见性决定 —— 下游默认
-        // 路由(nativeDefaultSourceId)不看可见性,可能又选回同一个被隐藏的源:这里直接
-        // 收敛到 native 优先的**可见**替代源;完全没有可见源才回 null 默认路由
-        // (codex review, 2026-07)。
+        providerId = null;
+        fallbacks.push('provider:default-route');
+      }
+    } else {
+      // 无点名但可见性过滤激活:下游把 null 解析成 nativeDefaultSourceId 时**不看可见性**
+      // (registry.ts effectiveSourceIdForModel),若 native 源上该模型恰被隐藏、他源可见,
+      // null 会路由进被隐藏的源 —— 仅在这种「下游默认落点不可见」的情况下显式收敛到
+      // 可见源;默认落点本就可见(绝大多数)时维持 null,不改「null=默认路由」契约
+      // (codex review 三轮补全)。
+      const offering = rail.filter((p) => providerOffersModel(p, model, agentKind));
+      const downstream = offering.find((p) => p.id === nativeDefaultSourceId(offering, agentKind));
+      if (downstream !== undefined && !visiblyOffers(downstream)) {
         const alternatives = rail.filter(visiblyOffers);
         if (alternatives.length > 0) {
           providerId = nativeDefaultSourceId(alternatives, agentKind) ?? alternatives[0].id;
           fallbacks.push('provider:visible-fallback');
-        } else {
-          providerId = null;
-          fallbacks.push('provider:default-route');
         }
       }
     }

--- a/packages/model-providers/src/invocation.ts
+++ b/packages/model-providers/src/invocation.ts
@@ -199,7 +199,13 @@ export function resolveModelInvocation(
       fallbacks.push('model:first-available');
     } else {
       model = scenarioModel;
-      fallbacks.push('model:scenario-default-unverified');
+      // 诊断标记区分两种「硬发场景默认裸值」:available === null 是数据不可用未经校验;
+      // 空数组是数据可用但**确认零可选**(Copilot review:混用 unverified 会误导排查)。
+      fallbacks.push(
+        available === null
+          ? 'model:scenario-default-unverified'
+          : 'model:no-available-models',
+      );
     }
   }
 

--- a/packages/model-providers/src/modelList.ts
+++ b/packages/model-providers/src/modelList.ts
@@ -126,17 +126,30 @@ export function deriveModelList(opts: DeriveModelListOptions): ModelListEntry[] 
   for (const provider of resolveRail(providers, agent, providerScope)) {
     if (excludeProvider?.(provider)) continue;
     for (const m of provider.models[agent] ?? []) {
-      if (dedupe === 'first-wins' && seen.has(m.id)) continue;
       if (excludeModel?.(m, provider)) continue;
       const selected = matchesSelected(keepSelected, provider.id, m.id);
       if (!selected && isVisible && !isVisible(provider.id, m)) continue;
-      if (dedupe === 'first-wins') seen.add(m.id);
       const entry: ModelListEntry = {
         ...m,
         sourceProviderId: provider.id,
         sourceConnected: provider.connected,
       };
       if (provider.access !== undefined) entry.sourceAccess = provider.access;
+      if (dedupe === 'first-wins') {
+        if (seen.has(m.id)) {
+          // 首见行已占坑。keepSelected 点名 provider 且选中行排在后面时,首见行必须让位——
+          // 否则选中 (provider, model) 被去重丢弃,flat 列表带着错误来源/徽章(codex review):
+          // 用选中行**原位替换**首见行(位置守首见槽,输出顺序契约不变)。
+          if (selected) {
+            const i = out.findIndex((e) => e.id === m.id);
+            if (i !== -1 && !matchesSelected(keepSelected, out[i].sourceProviderId, out[i].id)) {
+              out[i] = entry;
+            }
+          }
+          continue;
+        }
+        seen.add(m.id);
+      }
       out.push(entry);
     }
   }

--- a/packages/model-providers/src/modelList.ts
+++ b/packages/model-providers/src/modelList.ts
@@ -128,29 +128,32 @@ export function deriveModelList(opts: DeriveModelListOptions): ModelListEntry[] 
     for (const m of provider.models[agent] ?? []) {
       if (excludeModel?.(m, provider)) continue;
       const selected = matchesSelected(keepSelected, provider.id, m.id);
-      if (!selected && isVisible && !isVisible(provider.id, m)) continue;
-      const entry: ModelListEntry = {
-        ...m,
-        sourceProviderId: provider.id,
-        sourceConnected: provider.connected,
+      // entry 构造延后到确定要用时(push / 替换):被 first-wins 丢弃的重复行不做无谓 spread。
+      const makeEntry = (): ModelListEntry => {
+        const entry: ModelListEntry = {
+          ...m,
+          sourceProviderId: provider.id,
+          sourceConnected: provider.connected,
+        };
+        if (provider.access !== undefined) entry.sourceAccess = provider.access;
+        return entry;
       };
-      if (provider.access !== undefined) entry.sourceAccess = provider.access;
-      if (dedupe === 'first-wins') {
-        if (seen.has(m.id)) {
-          // 首见行已占坑。keepSelected 点名 provider 且选中行排在后面时,首见行必须让位——
-          // 否则选中 (provider, model) 被去重丢弃,flat 列表带着错误来源/徽章(codex review):
-          // 用选中行**原位替换**首见行(位置守首见槽,输出顺序契约不变)。
-          if (selected) {
-            const i = out.findIndex((e) => e.id === m.id);
-            if (i !== -1 && !matchesSelected(keepSelected, out[i].sourceProviderId, out[i].id)) {
-              out[i] = entry;
-            }
+      if (dedupe === 'first-wins' && seen.has(m.id)) {
+        // 首见行已占坑。keepSelected 点名 provider 且选中行排在后面时,首见行必须让位——
+        // 否则选中 (provider, model) 被去重丢弃,flat 列表带着错误来源/徽章(codex review):
+        // 用选中行**原位替换**首见行(位置守首见槽,输出顺序契约不变;选中行豁免
+        // isVisible,与 push 路径同规则)。普通重复行直接丢弃。
+        if (selected) {
+          const i = out.findIndex((e) => e.id === m.id);
+          if (i !== -1 && !matchesSelected(keepSelected, out[i].sourceProviderId, out[i].id)) {
+            out[i] = makeEntry();
           }
-          continue;
         }
-        seen.add(m.id);
+        continue;
       }
-      out.push(entry);
+      if (!selected && isVisible && !isVisible(provider.id, m)) continue;
+      if (dedupe === 'first-wins') seen.add(m.id);
+      out.push(makeEntry());
     }
   }
   return out;

--- a/packages/model-providers/src/modelList.ts
+++ b/packages/model-providers/src/modelList.ts
@@ -121,7 +121,9 @@ export function deriveModelList(opts: DeriveModelListOptions): ModelListEntry[] 
     keepSelected,
   } = opts;
 
-  const seen = new Set<string>();
+  // first-wins 的占坑表直接记「id → 首见行在 out 里的下标」,选中行替换时 O(1) 定位
+  // (findIndex 线性扫在大目录下会让派生退化 O(n²),Greptile review)。
+  const seenIndex = new Map<string, number>();
   const out: ModelListEntry[] = [];
   for (const provider of resolveRail(providers, agent, providerScope)) {
     if (excludeProvider?.(provider)) continue;
@@ -138,21 +140,21 @@ export function deriveModelList(opts: DeriveModelListOptions): ModelListEntry[] 
         if (provider.access !== undefined) entry.sourceAccess = provider.access;
         return entry;
       };
-      if (dedupe === 'first-wins' && seen.has(m.id)) {
+      if (dedupe === 'first-wins' && seenIndex.has(m.id)) {
         // 首见行已占坑。keepSelected 点名 provider 且选中行排在后面时,首见行必须让位——
         // 否则选中 (provider, model) 被去重丢弃,flat 列表带着错误来源/徽章(codex review):
         // 用选中行**原位替换**首见行(位置守首见槽,输出顺序契约不变;选中行豁免
         // isVisible,与 push 路径同规则)。普通重复行直接丢弃。
         if (selected) {
-          const i = out.findIndex((e) => e.id === m.id);
-          if (i !== -1 && !matchesSelected(keepSelected, out[i].sourceProviderId, out[i].id)) {
+          const i = seenIndex.get(m.id)!;
+          if (!matchesSelected(keepSelected, out[i].sourceProviderId, out[i].id)) {
             out[i] = makeEntry();
           }
         }
         continue;
       }
       if (!selected && isVisible && !isVisible(provider.id, m)) continue;
-      if (dedupe === 'first-wins') seen.add(m.id);
+      if (dedupe === 'first-wins') seenIndex.set(m.id, out.length);
       out.push(makeEntry());
     }
   }

--- a/packages/model-providers/src/modelList.ts
+++ b/packages/model-providers/src/modelList.ts
@@ -1,0 +1,192 @@
+/**
+ * modelList —— 「从供应商目录派生模型清单」的**唯一标准入口**(纯逻辑,跨端共享)。
+ *
+ * 背景(2026-07 全仓盘点): 同一个「取某 agent 的模型清单」语义在 desktop/mobile/main 里被独立
+ * 实现了 8+ 份(deriveAvailableModels / deriveModelsFromProviders / selectVisibleModels /
+ * visibleModelUnion / buildProviderSections / selectWorkerModels / IM slashCommands / hook
+ * session-runner),连接态过滤、可见性过滤、去重三条规则排列组合出 ≥4 种口径,直接导致
+ * 「设置页看到的清单 ≠ 会话选择器 ≠ IM /model 卡」一类线上事故。
+ *
+ * 本模块把三条规则收成**显式 options**,所有派生统一走 `deriveModelList` /
+ * `deriveModelSections`;既有共享函数(visibleModelUnion / buildProviderSections)改写为本模块
+ * 的薄壳,签名与输出逐字节不变(有 parity 测试锁),消费方无感收口。
+ *
+ * 设计约束:
+ *   - 纯函数、零依赖(包不变量),mobile 与 main 均可直接消费;
+ *   - 不做隐式默认的「聪明行为」: 供应商范围/可见性/去重全部由调用方显式声明,
+ *     每个旧口径都能被一组 options 精确表达(映射表见各薄壳注释)。
+ */
+
+import type { AgentKind, CatalogModel, ProviderAccess } from './types.js';
+import {
+  connectedProvidersForAgent,
+  providersForAgent,
+  type ProviderView,
+} from './registry.js';
+
+/**
+ * 清单条目的来源溯源 —— flat(拍平去重)清单里「订阅」「立省85%」等来源徽章的**真实依据**。
+ *
+ * 历史问题: 拍平清单丢掉了 provider 上下文,`provider?.access?.kind === 'subscription'` 判定
+ * 恒 false,订阅标签整个消失 —— 用户误以为订阅绑定失效(2026-07 实测)。派生时每一行的来源
+ * 供应商是确定已知的(first-wins 首见者 / 分段模式的段供应商),附上即是溯源不是猜测。
+ * 拿不到目录、只有拍平 capabilities 的场景(device-link 旧被控端)没有这份元数据 → 渲染层
+ * 不显示来源徽章,诚实降级。
+ */
+export interface ModelSourceMeta {
+  /** 该行来源供应商 id。 */
+  sourceProviderId: string;
+  /** 来源供应商的 access(订阅/API/托管);custom provider 可能缺省。 */
+  sourceAccess?: ProviderAccess;
+  /** 派生时该来源是否已连接(providerScope 非 connected 的清单才有区分意义)。 */
+  sourceConnected: boolean;
+}
+
+/** 标准清单条目 = 目录条目全字段 + 来源溯源。对按 CatalogModel 形状消费的代码是协变加宽。 */
+export interface ModelListEntry extends CatalogModel, ModelSourceMeta {}
+
+/**
+ * 供应商范围 —— 三种历史口径的显式化:
+ *   - 'all-for-agent'(默认): 该 agent 兼容的全部供应商,不看连接(capabilities 快照口径);
+ *   - 'connected-for-agent': 已连接且兼容该 agent(选择器 / IM /model 卡口径);
+ *   - 'as-given': 完全按传入数组遍历、不做任何收窄 —— buildProviderSections 的历史语义
+ *     (它假设调用方已自行收窄;薄壳必须保持,否则「调用方传了未收窄列表」时行为漂移)。
+ */
+export type ProviderScope = 'all-for-agent' | 'connected-for-agent' | 'as-given';
+
+export interface DeriveModelListOptions {
+  providers: readonly ProviderView[];
+  agent: AgentKind;
+  /** 供应商范围,默认 'all-for-agent'。 */
+  providerScope?: ProviderScope;
+  /**
+   * 可见性过滤(用户「设置 → 模型供应商」的显隐 override);决策统一走 isModelVisible,
+   * 数据源由调用方按自己进程能读到的存储注入。缺省 = 不过滤。
+   */
+  isVisible?: (providerId: string, model: CatalogModel) => boolean;
+  /**
+   * 'first-wins'(默认): 同 id 跨供应商去重,按供应商序 + 目录序首见胜出 —— 拍平单列清单;
+   * 'none': 不去重,同 id 在每个提供它的供应商下各出一行 —— 分段清单。
+   */
+  dedupe?: 'first-wins' | 'none';
+  /** 整供应商排除(如 SSH 远程排除 chat-bridged Codex 源);被排除者**不占** first-wins 的 seen。 */
+  excludeProvider?: (provider: ProviderView) => boolean;
+  /** 单模型排除(如 SSH 远程排除订阅直连前缀);被排除者同样不占 seen。 */
+  excludeModel?: (model: CatalogModel, provider: ProviderView) => boolean;
+  /**
+   * 选中豁免: 该 (供应商, 模型) 即便被 isVisible 隐藏也保留 —— 避免「当前选中项不在列表」
+   * 的空选态(分段选择器契约)。providerId 为 null 时按 model id 匹配任意供应商行。
+   */
+  keepSelected?: { providerId: string | null; modelId: string };
+}
+
+function resolveRail(
+  providers: readonly ProviderView[],
+  agent: AgentKind,
+  scope: ProviderScope,
+): readonly ProviderView[] {
+  switch (scope) {
+    case 'connected-for-agent':
+      return connectedProvidersForAgent([...providers], agent);
+    case 'as-given':
+      return providers;
+    default:
+      return providersForAgent([...providers], agent);
+  }
+}
+
+function matchesSelected(
+  keep: DeriveModelListOptions['keepSelected'],
+  providerId: string,
+  modelId: string,
+): boolean {
+  if (!keep) return false;
+  if (keep.modelId !== modelId) return false;
+  return keep.providerId === null || keep.providerId === providerId;
+}
+
+/**
+ * 标准清单派生。输出顺序契约与历史一致: 供应商按 rail 序(= catalog 序),
+ * 供应商内模型按目录序,**绝不二次排序**(展示层的分组排序另走 groupModelsForDisplay)。
+ */
+export function deriveModelList(opts: DeriveModelListOptions): ModelListEntry[] {
+  const {
+    providers,
+    agent,
+    providerScope = 'all-for-agent',
+    isVisible,
+    dedupe = 'first-wins',
+    excludeProvider,
+    excludeModel,
+    keepSelected,
+  } = opts;
+
+  const seen = new Set<string>();
+  const out: ModelListEntry[] = [];
+  for (const provider of resolveRail(providers, agent, providerScope)) {
+    if (excludeProvider?.(provider)) continue;
+    for (const m of provider.models[agent] ?? []) {
+      if (dedupe === 'first-wins' && seen.has(m.id)) continue;
+      if (excludeModel?.(m, provider)) continue;
+      const selected = matchesSelected(keepSelected, provider.id, m.id);
+      if (!selected && isVisible && !isVisible(provider.id, m)) continue;
+      if (dedupe === 'first-wins') seen.add(m.id);
+      const entry: ModelListEntry = {
+        ...m,
+        sourceProviderId: provider.id,
+        sourceConnected: provider.connected,
+      };
+      if (provider.access !== undefined) entry.sourceAccess = provider.access;
+      out.push(entry);
+    }
+  }
+  return out;
+}
+
+/** 分段清单条目: 段供应商 + 该段下的标准条目(溯源即段供应商)。 */
+export interface ModelListSection {
+  provider: ProviderView;
+  models: ModelListEntry[];
+}
+
+/**
+ * 分段派生(dedupe:'none' 的分桶形状)。与 deriveModelList 同一套过滤规则,逐供应商独立出段
+ * (不经「拍平再分桶」—— 保证与历史 buildProviderSections 在任意输入下同构,含病态的重复
+ * provider id);`query` 命中 name / id(大小写不敏感)。只返回有 ≥1 个模型的段;段顺序 = rail 序。
+ * sections.ts 的 buildProviderSections 是本函数的投影薄壳(SectionModel 字段裁剪)。
+ */
+export function deriveModelSections(
+  opts: Omit<DeriveModelListOptions, 'dedupe'> & { query?: string },
+): ModelListSection[] {
+  const {
+    providers,
+    agent,
+    providerScope = 'all-for-agent',
+    isVisible,
+    excludeProvider,
+    excludeModel,
+    keepSelected,
+  } = opts;
+  const q = (opts.query ?? '').trim().toLowerCase();
+
+  const sections: ModelListSection[] = [];
+  for (const provider of resolveRail(providers, agent, providerScope)) {
+    if (excludeProvider?.(provider)) continue;
+    const models: ModelListEntry[] = [];
+    for (const m of provider.models[agent] ?? []) {
+      if (excludeModel?.(m, provider)) continue;
+      const selected = matchesSelected(keepSelected, provider.id, m.id);
+      if (!selected && isVisible && !isVisible(provider.id, m)) continue;
+      if (q && !m.name.toLowerCase().includes(q) && !m.id.toLowerCase().includes(q)) continue;
+      const entry: ModelListEntry = {
+        ...m,
+        sourceProviderId: provider.id,
+        sourceConnected: provider.connected,
+      };
+      if (provider.access !== undefined) entry.sourceAccess = provider.access;
+      models.push(entry);
+    }
+    if (models.length > 0) sections.push({ provider, models });
+  }
+  return sections;
+}

--- a/packages/model-providers/src/sections.ts
+++ b/packages/model-providers/src/sections.ts
@@ -95,7 +95,9 @@ export function resolveModelIconKind(icon: string | undefined): ModelIconKind | 
  *   - 按供应商序 + 目录序,同 id **首见胜出**去重(与 renderer providerModels /
  *     main deriveAvailableModels 的顺序契约一致):某供应商下被隐藏、另一供应商下
  *     可见的模型仍会出现(取可见那家的元数据)。
- * 返回 CatalogModel 引用(含 group / efforts / defaultEffort 等全部元数据),纯函数可单测。
+ * 返回 CatalogModel 形状的**拷贝**(含 group / efforts / defaultEffort 等全部元数据;
+ * 不是 catalog 对象引用 —— 按引用 memo/相等比较会失配,详见函数体内的物理差异警告),
+ * 纯函数可单测。
  */
 export function visibleModelUnion(
   providers: readonly ProviderView[],

--- a/packages/model-providers/src/sections.ts
+++ b/packages/model-providers/src/sections.ts
@@ -11,7 +11,8 @@
  */
 
 import type { AgentKind, CatalogModel, Effort } from './types.js';
-import { connectedProvidersForAgent, type ProviderView } from './registry.js';
+import type { ProviderView } from './registry.js';
+import { deriveModelList, deriveModelSections } from './modelList.js';
 
 /**
  * 单个模型的可见性决策 —— **纯函数,唯一真相**。
@@ -101,17 +102,22 @@ export function visibleModelUnion(
   agent: AgentKind,
   isVisible: (providerId: string, model: CatalogModel) => boolean,
 ): CatalogModel[] {
-  const seen = new Set<string>();
-  const out: CatalogModel[] = [];
-  for (const provider of connectedProvidersForAgent([...providers], agent)) {
-    for (const m of provider.models[agent] ?? []) {
-      if (seen.has(m.id)) continue;
-      if (!isVisible(provider.id, m)) continue;
-      seen.add(m.id);
-      out.push(m);
-    }
-  }
-  return out;
+  // 薄壳: 标准派生的「已连接 + 可见性 + first-wins 去重」口径(modelList.ts)。
+  // 返回类型保持 CatalogModel[](ModelListEntry 是其超集,协变加宽,消费方无感);
+  // 输出顺序与历史实现逐字节一致,由 sections.test.ts(零修改)与 parity 测试锁定。
+  //
+  // ⚠ 两个与历史实现的物理差异(语义等价,但消费方不得依赖):
+  //   1. 条目是**拷贝**而非 catalog 对象引用 —— 按引用做 memo/相等比较会失配;
+  //   2. 条目带 3 个额外可枚举字段(sourceProviderId / sourceConnected / 可选 sourceAccess),
+  //      类型层不可见 —— **禁止把条目整对象 JSON.stringify / spread 进 IPC・协议・持久化**,
+  //      过 wire 前必须显式投影字段(现存 5 个消费方已核查合规;键集有测试锁)。
+  return deriveModelList({
+    providers,
+    agent,
+    providerScope: 'connected-for-agent',
+    isVisible,
+    dedupe: 'first-wins',
+  });
 }
 
 export function buildProviderSections(args: {
@@ -122,15 +128,27 @@ export function buildProviderSections(args: {
   isVisible: (providerId: string, modelId: string) => boolean;
   query?: string;
 }): ProviderSection[] {
-  const q = (args.query ?? '').trim().toLowerCase();
-  const sections: ProviderSection[] = [];
-  for (const provider of args.providers) {
-    const catalog = provider.models[args.agent] ?? [];
-    const models: SectionModel[] = [];
-    for (const m of catalog) {
-      const isSelected = m.id === args.selectedModelId && provider.id === args.selectedProviderId;
-      if (!isSelected && !args.isVisible(provider.id, m.id)) continue;
-      if (q && !m.name.toLowerCase().includes(q) && !m.id.toLowerCase().includes(q)) continue;
+  // 薄壳: 标准分段派生(modelList.ts)+ SectionModel 字段投影。历史语义逐项保持:
+  //   - providerScope 'as-given': 本函数从不收窄供应商(调用方已自行收窄),薄壳不得
+  //     擅自加 connectedProvidersForAgent —— 否则调用方传未收窄列表时行为漂移;
+  //   - 选中豁免仅在 selectedProviderId **非空**时生效(旧实现 provider.id === null
+  //     恒 false,即 flat 语义的「null = 匹配任意行」在这里不适用);
+  //   - 字段拷贝保持条件性(undefined 字段不写 key),对象形状逐字节一致。
+  const sections = deriveModelSections({
+    providers: args.providers,
+    agent: args.agent,
+    providerScope: 'as-given',
+    isVisible: (providerId, model) => args.isVisible(providerId, model.id),
+    ...(args.selectedModelId !== undefined &&
+    args.selectedProviderId !== undefined &&
+    args.selectedProviderId !== null
+      ? { keepSelected: { providerId: args.selectedProviderId, modelId: args.selectedModelId } }
+      : {}),
+    ...(args.query !== undefined ? { query: args.query } : {}),
+  });
+  return sections.map(({ provider, models }) => ({
+    provider,
+    models: models.map((m) => {
       const sm: SectionModel = {
         id: m.id,
         displayName: m.name,
@@ -142,9 +160,7 @@ export function buildProviderSections(args: {
       if (m.effortDisplayNames !== undefined) sm.effortDisplayNames = m.effortDisplayNames;
       if (m.supportsFastMode !== undefined) sm.supportsFastMode = m.supportsFastMode;
       if (m.icon !== undefined) sm.icon = m.icon;
-      models.push(sm);
-    }
-    if (models.length > 0) sections.push({ provider, models });
-  }
-  return sections;
+      return sm;
+    }),
+  }));
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

「全局模型调用统一标准」重构第 1 期（P1/P5）：把 `@cindy/model-providers` 升级为全 Cindy 的模型调用标准层。**纯 additive，不触碰 `apps/` 下任何文件**，现有消费方行为零变化。

背景是最近连环事故暴露的系统性问题（IM 偏好页私搭清单混入 ASR/视频模型、分段模式「选订阅版落到 Cindy AI」、权限档「显示最严实际最宽」，见 #403/#404），根因做过一次全仓盘点：

- 同一个「模型描述」有 **7 种类型形状**，每层各丢不同字段，丢失口径互相矛盾；
- **8+ 份清单派生函数**，连接态/可见性/去重三条规则排列组合出 ≥4 种口径；
- **12+ 份 effort 解释器**，空档兜底有 4 种结果；Orca 的档位级联与共享 `clampEffortToSupported` 方向相反；
- **6+ 份「新会话默认」合成器**，硬编码默认互不一致（scheduler=Sonnet、对话=Opus 4.8、CreateWorkerPopover=Opus 4.7 过时值）；
- 「骨折版 = `codex/` 前缀」独立实现 4+ 处；`formatContextWindow` 3 份副本；flat 清单下订阅标签因丢失 provider 上下文而消失。

本期新增四个标准模块（后续 P2-P5 分期把 desktop renderer/main 的全部消费方切过来，计划见 PR 描述末尾）：

**1. `modelList.ts` — 统一清单派生**

`deriveModelList` / `deriveModelSections`，把三条历史上隐式分叉的规则收成显式 options：`providerScope`（'all-for-agent' / 'connected-for-agent' / 'as-given'）、`isVisible`、`dedupe`（'first-wins' / 'none'）+ `excludeProvider` / `excludeModel` / `keepSelected`。

核心新类型 `ModelListEntry = CatalogModel + 来源溯源`（`sourceProviderId` / `sourceAccess` / `sourceConnected`）——flat 清单里「订阅」徽章的**真实数据依据**（派生时首见供应商是确定已知的，是溯源不是猜测），P2 用它恢复 flat 模式下消失的订阅标签。

**2. `classification.ts` — 分类/徽章/格式单点**

- `categorize` / `groupOf` / `groupModelsForDisplay` 从 renderer `sourceSwitch.ts` **原样下沉**（P1 期间 renderer 原实现暂留，renderer 测试用例原文移植进包测试锁两份等价；P2 改 re-export 删旧）；
- `isBudgetModel`（目录 `group==='gpt-budget'` 优先、`codex/` 前缀兜底）、`modelBadges`（订阅/骨折徽章唯一口径，分段用段 provider、flat 用 sourceAccess、都没有则诚实降级不显示）；
- `SUBSCRIPTION_DIRECT_MODEL_PREFIXES` / `isSubscriptionDirectModel` 下沉（签名与 `shared/subscriptionModels.ts` 逐字一致，P2 该文件变 shim）；
- `formatContextWindow` 从 ModelSelector 原样下沉。

**3. `invocation.ts` — 统一调用合成**

`resolveModelInvocation(prefs, scenario, ctx) → {agentKind, model, effort, providerId, permissionMode, fastMode, fallbacksApplied}`，替代 6 份「新会话默认」合成器的标准。**场景默认全部由调用方传入**（`ScenarioDefaults`），共享包内零模型 id 字面量。安全语义：显式权限档不被目标 agent 支持时回落该 agent **最严**档（与 #403 的修正同语义，绝不回落 bypass）；providerId 必须收敛到「已连接且真实提供最终模型」的来源，否则 null。`fallbacksApplied` 输出诊断轨迹供派发端打日志。

**4. `effortResolution.ts` 扩充**（现有 3 函数一字未动）

- `EFFORT_VALUES` 七档单一来源 + 包内类型级双向断言锁（与 `types.Effort` 联合互相约束，改一边不改另一边编译失败）+ `effortRank` / `lowestEffort`；
- `nearestSupportedEffort`：Orca 跨引擎词表翻译语义（GPT xhigh ≈ Claude max，双向就近），与 `orcaWorkerCreationService.normalizeResolvedEffort` 非显式分支逐字节一致。**与 `clampEffortToSupported`（绝不上调，#456 省钱语义）是两种并立的正当语义**——消灭「方向冲突」的方式是让两种语义都有名字、有测试、有文档，而不是强行合并；
- `reconcileInvocationEffort`：无人值守场景统一回落链。模型有档时链唯一（requested > override > default > 首档——**用户显式选择优先于运营 override**）；模型未知/无档时三份历史实现行为是三种（hook=恒 fallback、IM resolveEffort=requested 优先、getImDefaultEffortFor=override 优先），**不能拉平**，显式参数化为 `noEffortsBehavior`（默认最保守的 'fallback-only'）。

**5. `sections.ts` 薄壳改写**

`visibleModelUnion` / `buildProviderSections` 内部转调标准派生，**签名与输出逐字节不变**。历史语义逐项保真：`buildProviderSections` 不收窄供应商（'as-given'）、选中豁免仅 `selectedProviderId` 非空时生效、`SectionModel` 字段条件拷贝。两个物理差异已在注释里标注红线（条目是拷贝非引用；带 3 个类型层不可见的溯源字段，**禁止整对象过 wire**——现存 5 个消费方逐个核查过均为显式投影，键集有测试锁死）。

### 开发过程中对抗审查修掉的 4 个设计错误（值得记录）

发 PR 前跑了一轮对抗式 self-review，抓到 4 处「统一链与被统一的真实语义不符」——这些函数当时零消费方，是唯一一次零成本改语义的机会：

1. 初版把 effort override 排在 requested 之前 → 运营表会压过用户显式选择（IM 真实语义是 requested-first，override 只是非法时的回落）；
2. 初版在模型未知时直接回 fallback → 丢掉 IM `requested || 'high'` 的「目录暂缺别丢用户选择」；进一步发现三份实现该分支行为完全不同 → 参数化为 `noEffortsBehavior` 而不是假装一致；
3. 初版 `prefs.effort ?? scenarioEffort` 把 hook 的「显式 > 草稿 > 模型默认」两级候选压扁 → 显式非法时会跳过草稿档直落模型默认；
4. permissionMode 最严档回落的 docstring 误写为「从 hook 现行实现继承」→ 已如实改为「对 upstream/main 现行实现是刻意收紧、与 PR #403 同语义，P3 迁移时若 #403 未合并必须显式声明为行为变更」。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#404（模型供应体系的系统性问题；本期是客户端侧标准层的地基）
- 本 PR 包含：`packages/model-providers` 新增 `modelList.ts` / `classification.ts` / `invocation.ts`、`effortResolution.ts` 扩充、`sections.ts` 薄壳改写、导出与子路径注册、3 个新测试文件（+60 用例）。
- 明确不包含：`apps/desktop` / `apps/mobile` 的任何改动（P2 起分期切换）；持久化 schema / localStorage 键 / IM hook 协议（全程不动）；voice/utility/embedding 独立模型体系。
- 用户可见变化：**无**。本期纯地基。
- 是否存在 breaking change：无。`visibleModelUnion` / `buildProviderSections` 签名不变、输出逐字节等价（见验证）。

### 分期计划（后续 PR 预告，供 reviewer 评估本期接口设计）

P2 renderer 清单/徽章切换（flat 恢复订阅标签是唯一有意可见变化）→ P3 IM+hook 合成统一（行为锁测试先行）→ P4 scheduler/orca/cardActionHandler/MCP → P5 UI 壳收口+删旧。每期独立可合、合一期开下一期。

### UI 变化

不涉及（纯共享包，无任何 UI 代码）。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/model-providers test   → 197 passed(10 files)
  其中既有 7 个测试文件(145 用例)零修改通过 —— 含 sections.test.ts(薄壳等价第一道证明)
  与 effortResolution.test.ts(现有 3 函数未动的证明)
pnpm --filter desktop run typecheck          → 通过
pnpm --filter mobile run typecheck           → 通过(mobile 直接依赖本包,20 个文件)
pnpm test:unit                               → 全绿(exit 0, 无 FAIL)
```

新增测试的关键锁：

- **parity 矩阵**（`modelList.test.ts`）：`visibleModelUnion` / `buildProviderSections` 的新薄壳 vs **改写前原实现**（原文内联保存为 legacy 参照物）在 {合成目录 × 连接组合 × 可见性 × agent} 与 BUNDLED_CATALOG 真实目录上深等含顺序；覆盖「未收窄列表」「selectedProviderId=null 不豁免」等历史边界；
- **溯源键集锁**：`ModelListEntry` 额外键恰为 `{sourceProviderId, sourceConnected[, sourceAccess]}`，未来加字段必须先重新核查全部消费方的 wire 投影；
- **`nearestSupportedEffort` 全分支**（与 orca 现行为逐字节对齐，P4 切换时 orca 既有测试是第二道锁）；
- **`resolveModelInvocation` 表驱动**：六元组全回落分支，含目录不可用降级、providerId 收敛、权限最严档回落（`not.toBe('bypassPermissions')` 安全断言）。

### 手工验证

不涉及（无 UI、无运行时行为变化；等价性由 parity 测试与既有测试零修改证明）。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `packages/model-providers`。两个被薄壳化的共享函数有 desktop main / renderer / mobile 共 5 个消费方，全部经逐个核查（读值方式均为字段级访问或显式投影，无整对象过 wire / 深比较 / 按引用 memo）。
- 唯一值得 reviewer 注意的物理变化：`visibleModelUnion` 的返回条目从「catalog 对象引用」变为「带 3 个溯源字段的拷贝」。类型层不可见，已在函数注释标注红线并加键集锁测试；现存消费方合规。
- 回滚 / 降级方式：单 commit revert，零数据、零协议、零 UI 影响。

### 提交前检查

- [x] 已 review 完整 diff（含一轮对抗式 self-review，修掉 4 处设计错误后才提交）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（四个新模块的头注均写明背景、语义与迁移约束）
- [x] 已确认测试结果或说明未执行原因
