### PR TITLE
feat(plugins): cindy 槽生图代办新增可选 aspectRatio 画幅参数

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
@@ -164,6 +164,43 @@ describe('载荷校验', () => {
     expect(bad).toMatchObject({ ok: false });
     expect((bad as { message: string }).message).toContain('档位');
   });
+
+  it('画幅意图:合法比例透传;不传时载荷无 aspectRatio 键;未知比例拒', async () => {
+    const { slot, generateImage } = makeSlot();
+    const ok = await slot.handleModelRequest('art', { ...REQ, aspectRatio: '3:2' });
+    expect(ok).toMatchObject({ ok: true });
+    expect(generateImage).toHaveBeenLastCalledWith({
+      prompt: '一只猫',
+      model: 'gpt-image-2',
+      aspectRatio: '3:2',
+    });
+
+    // 不传 = 与老协议同形(连键都没有),后端走缺省 auto。
+    await slot.handleModelRequest('art', REQ);
+    expect(generateImage).toHaveBeenLastCalledWith({ prompt: '一只猫', model: 'gpt-image-2' });
+
+    const bad = await slot.handleModelRequest('art', { ...REQ, aspectRatio: '21:9' });
+    expect(bad).toMatchObject({ ok: false });
+    expect((bad as { message: string }).message).toContain('画幅');
+    expect(generateImage).toHaveBeenCalledTimes(2);
+  });
+
+  it('画幅意图仅生图收:改图/视频带 aspectRatio → 明拒且不触发生成', async () => {
+    const { slot, editImage, generateVideo } = makeSlot();
+    const editBad = await slot.handleModelRequest('art', { ...EDIT_REQ, aspectRatio: '1:1' });
+    expect(editBad).toMatchObject({ ok: false });
+    expect((editBad as { message: string }).message).toContain('gen_image');
+    expect(editImage).not.toHaveBeenCalled();
+
+    const videoBad = await slot.handleModelRequest('art', {
+      type: 'cindy-request',
+      kind: 'gen_video',
+      prompt: '一只猫奔跑',
+      aspectRatio: '2:3',
+    });
+    expect(videoBad).toMatchObject({ ok: false });
+    expect(generateVideo).not.toHaveBeenCalled();
+  });
 });
 
 describe('意识专属后端覆盖(解析表第②层)', () => {

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -27,7 +27,9 @@ import { randomUUID } from 'node:crypto';
 import {
   GHOST_CINDY_JOB_TTL_MS,
   GHOST_CINDY_MAX_ASYNC_JOBS,
+  GHOST_IMAGE_ASPECT_RATIOS,
   GHOST_MODEL_TIERS,
+  type GhostImageAspectRatio,
   type GhostModelTier,
   type GhostPipeModelResult,
   type InstalledGhost,
@@ -42,8 +44,13 @@ export interface CindyMediaConfig {
 
 export interface CindySlotDeps {
   getGhost(id: string): InstalledGhost | null;
-  /** 主机统一图片通道(art 底层客户端);返回图片字节与 mime。 */
-  generateImage(params: { prompt: string; model: string }): Promise<{ buffer: Uint8Array; mimeType: string }>;
+  /** 主机统一图片通道(art 底层客户端);返回图片字节与 mime。
+   *  aspectRatio 是意识的画幅意图,注入实现负责翻译成后端具体尺寸。 */
+  generateImage(params: {
+    prompt: string;
+    model: string;
+    aspectRatio?: GhostImageAspectRatio;
+  }): Promise<{ buffer: Uint8Array; mimeType: string }>;
   /** 主机统一图片通道·改图;源图以磁盘路径喂给网关(意识摸不到路径)。 */
   editImage(params: {
     prompt: string;
@@ -216,6 +223,7 @@ export class GhostCindySlot {
       prompt?: unknown;
       tier?: unknown;
       model?: unknown;
+      aspectRatio?: unknown;
       hashes?: unknown;
       callId?: unknown;
       mode?: unknown;
@@ -255,6 +263,22 @@ export class GhostCindySlot {
       return { ok: false, message: 'callId 不合法(1–128 字符的字符串,或不传)' };
     }
     const callId = (p.callId as string | undefined) ?? 'unattributed';
+
+    // 画幅意图(可选,仅生图):意识声明比例,注入实现翻译成后端具体尺寸。
+    // 改图跟随源图画幅、视频画幅由 provider 层自治——带了就是用错协议,
+    // 明拒好过静默忽略(将来放开支持是向后兼容的放宽)。
+    if (p.aspectRatio !== undefined) {
+      if (kind !== 'gen_image') {
+        return { ok: false, message: 'aspectRatio 仅支持 gen_image(改图跟随源图画幅,视频不收比例)' };
+      }
+      if (
+        typeof p.aspectRatio !== 'string' ||
+        !(GHOST_IMAGE_ASPECT_RATIOS as readonly string[]).includes(p.aspectRatio)
+      ) {
+        return { ok: false, message: `未知画幅比例(可用:${GHOST_IMAGE_ASPECT_RATIOS.join(' / ')})` };
+      }
+    }
+    const aspectRatio = p.aspectRatio as GhostImageAspectRatio | undefined;
 
     // 选型优先级(低 → 高逐层覆盖):出厂默认 → 档位(意识意图,主机翻译)
     // → 意识专属覆盖(用户在详情页钉的)→ 调用显式点名(用户当场说的)。
@@ -368,7 +392,12 @@ export class GhostCindySlot {
         if (kind === 'edit_image') {
           generated = await this.deps.editImage({ prompt, model, imagePaths });
         } else if (kind === 'gen_image') {
-          generated = await this.deps.generateImage({ prompt, model });
+          // 画幅意图条件展开:不传时载荷里连键都没有,与老协议逐字节同形。
+          generated = await this.deps.generateImage({
+            prompt,
+            model,
+            ...(aspectRatio !== undefined ? { aspectRatio } : {}),
+          });
         } else if (kind === 'edit_video') {
           generated = await this.deps.editVideo({ prompt, model, imagePaths });
         } else {

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1113,6 +1113,11 @@ const r = await cindy.send({ type: 'cindy-request', kind: 'gen_image', prompt: '
 //     交卷 note,让用户看得见"这单是谁画的"。
 //     width/height = 图片真实像素宽高(仅图片代办;主机解析不出时缺省)——供
 //     聊天卡片时用它按比例精确声明卡高(见 §4.5),别拿去写进交卷文案。
+// 生图可选画幅 aspectRatio:'1:1' 方图 / '3:2' 横图 / '2:3' 竖图,不传 = 模型自定:
+//   { kind: 'gen_image', prompt: '一只猫', aspectRatio: '3:2' }
+//   比例是意图声明(同 tier 哲学),主机翻译成该模型支持的具体尺寸,真实像素
+//   以返回的 width/height 为准。**仅生图收**——改图跟随源图画幅、视频不收比例,
+//   带上会被拒;用户没提横竖要求时别自作主张,不传让模型自定。
 // 改图(需详单含 "edit";源图必须是本意识名下的,1–4 张——含用户过户给你的
 // args.attachments 指纹):
 //   { kind: 'edit_image', prompt, hashes: ['<指纹>'] }

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -19,6 +19,7 @@ import {
   isValidGhostId,
   layoutWithGhostPanel,
   type GhostHostNoticeKey,
+  type GhostImageAspectRatio,
   type GhostManifest,
   type GhostSetupAllowedAction,
   type GhostSetupAssessment,
@@ -1498,6 +1499,17 @@ async function runGhostVideo(params: {
   return { buffer: r.buffer, mimeType: r.mimeType };
 }
 
+/**
+ * 意识画幅意图 → XD Gateway size。三档尺寸是 gpt-image 系的原生枚举
+ * (1024x1024 / 1536x1024 / 1024x1536,比例即枚举名);Gemini 系由网关按
+ * 比例转译。意识侧枚举扩值域时此表必须同步补齐(Record 穷尽性由类型锁住)。
+ */
+const GHOST_ASPECT_TO_GATEWAY_SIZE: Record<GhostImageAspectRatio, string> = {
+  '1:1': '1024x1024',
+  '3:2': '1536x1024',
+  '2:3': '1024x1536',
+};
+
 /** XD Gateway 图片响应 → 字节 + mime(gen / edit 同一解码口径)。 */
 function decodeImageResponse(res: {
   data: Array<{ b64_json?: string }>;
@@ -1519,10 +1531,15 @@ export function getGhostCindySlot(): GhostCindySlot {
         getAppCapabilities().canUseCindyGateway ? findAvailableGhost(id) : null,
       // model 已在 modelSlot 按白名单校验(白名单 = GatewayImageModel 全集),
       // 这里收窄类型是安全的。
-      generateImage: async ({ prompt, model }) => {
+      generateImage: async ({ prompt, model, aspectRatio }) => {
         try {
           return decodeImageResponse(
-            await getCindyProxyMediaService().backend.generateImage({ model: model as GatewayImageModel, prompt }),
+            await getCindyProxyMediaService().backend.generateImage({
+              model: model as GatewayImageModel,
+              prompt,
+              // 不带画幅意图时不传 size,网关缺省 'auto'(模型自定)。
+              ...(aspectRatio ? { size: GHOST_ASPECT_TO_GATEWAY_SIZE[aspectRatio] } : {}),
+            }),
           );
         } catch (err) {
           humanizeImageChannelError(err);

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -4532,6 +4532,15 @@ export const GHOST_MODEL_TIERS = ['draft', 'standard', 'best'] as const;
 export type GhostModelTier = (typeof GHOST_MODEL_TIERS)[number];
 
 /**
+ * cindy 槽生图代办的画幅意图:方图 / 横图 / 竖图。与 tier 同一哲学——意识
+ * 只声明比例意图,主机翻译成当前后端支持的具体像素尺寸(枚举值即真实产出
+ * 比例,当前三档全后端可兑现,不做"最近似"降级)。将来扩值域(如 16:9)
+ * 是向后兼容的加法,老意识不受影响。
+ */
+export const GHOST_IMAGE_ASPECT_RATIOS = ['1:1', '3:2', '2:3'] as const;
+export type GhostImageAspectRatio = (typeof GHOST_IMAGE_ASPECT_RATIOS)[number];
+
+/**
  * 异步代办(mode:'submit')完成结果的保留时长(毫秒,30 分钟):完成后
  * 过期即清,query_job 查无此单。TTL 之外还有每意识完成记录条数上限
  * (cindySlot 的 settled-job eviction):快速提交循环下最旧的完成记录会
@@ -4564,6 +4573,13 @@ export type GhostPipeCindyRequest =
       prompt: string;
       tier?: GhostModelTier;
       model?: string;
+      /**
+       * 画幅比例(可选):'1:1' 方图 / '3:2' 横图 / '2:3' 竖图;不传 =
+       * 后端自定(auto)。比例是意图声明,主机映射为该后端的具体尺寸,
+       * 实际像素以返回的 width/height 为准。仅生图支持——改图跟随源图
+       * 画幅,视频画幅由 provider 层自治,带了会被明拒。
+       */
+      aspectRatio?: GhostImageAspectRatio;
       /**
        * 归因号(可选):这单代办由哪次 tool-call 触发,把收到的
        * callId 原样带上——配额记账、日志、用量面板由此对上"哪次调用花的


### PR DESCRIPTION
## 这次改了什么

### 摘要

给插件(`.cindy`)的 cindy 槽生图代办(`cindy-request` / `kind:'gen_image'`)新增可选参数 `aspectRatio`,让插件能声明画幅意图:`'1:1'` 方图 / `'3:2'` 横图 / `'2:3'` 竖图。不传时行为与现状完全一致(网关 `size:'auto'`,模型自定)。

设计沿用 `tier` 的意图哲学:插件只声明比例,主机翻译成该模型支持的具体像素尺寸(当前映射 1024x1024 / 1536x1024 / 1024x1536,即 gpt-image 系原生尺寸枚举;Gemini 系由 XD Gateway 按比例转译)。值域只放三档全后端可兑现的比例,不做"要 16:9 给你 3:2"的静默降级;将来扩值域是向后兼容的加法。

背景:画布类插件场景经常需要指定横竖屏,此前生图单只收 prompt/tier/model。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:画布类插件需要生图时指定横竖屏(内部需求,无 Issue)
- 本 PR 包含:
  - `shared/ghost.ts`:`GHOST_IMAGE_ASPECT_RATIOS` 枚举 + `GhostPipeCindyRequest` gen_image 分支新增 `aspectRatio?` 字段
  - `cindySlot.ts`:载荷校验(非法值 / 用在 `edit_image`・视频上 → 结构化明拒)+ 条件透传(不传时 deps 载荷与老协议逐字节同形)
  - `index.ts`:比例 → 网关 `size` 映射表(`Record<GhostImageAspectRatio, string>`,穷尽性由类型锁住)
  - `forge.ts`:FORGE_GUIDE 手册已同步(§4 cindy 代办章节,新增 aspectRatio 用法与"仅生图收"边界说明)
  - `cindySlot.test.ts`:新增合法透传 / 缺省同形 / 非法值拒 / 错误 kind 拒共 2 组用例
- 明确不包含:`edit_image` 与视频类代办的画幅参数(改图跟随源图画幅,视频画幅归 provider 层);mask 局部重绘、persist 分区等后续画布相关产品决策
- 用户可见变化:对最终用户无直接可见变化;插件作者可用新参数
- 是否存在 breaking change:无。纯可选字段加法,老插件载荷不受影响;`aspectRatio` 校验仅在显式携带该字段时生效

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit(仓库根,分支基于最新 origin/main)
结果:全部通过

pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm --filter desktop exec vitest run src/main/cindy-brain src/shared
结果:83 files / 1203 tests 全部通过(含本 PR 新增用例)
```

备注:验证过程中 `ghostOauthAccounts.test.ts` 曾出现一次高负载下的偶发超时;经 stash 对照与复跑确认与本改动无关(干净 main 同组合无法复现,带改动复跑全绿)。

### 手工验证

不涉及(改动为管子协议参数透传,单测已覆盖校验与透传链路;真实出图链路依赖 XD Gateway 线上通道,由现网插件调用验证)。

### 未执行的验证

未对 XD Gateway 实际发起带 `size` 的生图请求验证三档尺寸的线上兑现(需要真实网关凭证与计费调用)。映射值 1536x1024 有历史用例佐证(`mediaToolResultFallback.test.ts` 记录的历史请求形态),其余两档为 OpenAI Images API 标准枚举。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:cindy 槽管子协议(`GhostPipeCindyRequest`)的向后兼容扩展。老插件不带新字段,行为零变化;新字段仅影响显式携带它的 gen_image 代办。作者契约命中「管子协议 + 模型 slot 参数」,FORGE_GUIDE 已在同一改动内同步(§4 cindy 代办)。
- 回滚 / 降级方式:直接 revert 本 PR 即可。已按新手册使用 `aspectRatio` 的插件不会炸单:回滚后的老代码不读取该字段(载荷解构无此键,静默忽略),生图退化为 auto 画幅,功能面平滑降级。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(FORGE_GUIDE 手册同步)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
