### PR TITLE
revert(desktop): revert PR #409 shared dev migration changes

### DIFF
--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -5,10 +5,8 @@ import { join } from 'node:path';
 import {
   resolveDevCliFlags,
   resolveSingleInstanceLockUserDataDir,
-  shouldBlockSharedPrimaryDev,
   shouldEnforcePassiveMigrationCompatibility,
   shouldRequestSingleInstanceLock,
-  userDataPathsReferToSameDirectory,
 } from '../devCliFlags';
 
 const base = {
@@ -247,116 +245,6 @@ describe('shouldEnforcePassiveMigrationCompatibility', () => {
         isolated: false,
       }),
     ).toBe(false);
-  });
-});
-
-describe('shouldBlockSharedPrimaryDev', () => {
-  it('只阻止共用正式版 userData 的 primary dev', () => {
-    expect(
-      shouldBlockSharedPrimaryDev({
-        isPackaged: false,
-        schedulerPassive: false,
-        isolated: false,
-      }),
-    ).toBe(true);
-    expect(
-      shouldBlockSharedPrimaryDev({
-        isPackaged: false,
-        schedulerPassive: true,
-        isolated: false,
-      }),
-    ).toBe(false);
-    expect(
-      shouldBlockSharedPrimaryDev({
-        isPackaged: false,
-        schedulerPassive: false,
-        isolated: true,
-      }),
-    ).toBe(false);
-    expect(
-      shouldBlockSharedPrimaryDev({
-        isPackaged: true,
-        schedulerPassive: false,
-        isolated: false,
-      }),
-    ).toBe(false);
-  });
-
-  it('手动 XDT_USER_DATA_DIR 不等于 isolated，不能绕过 primary dev 启动闸', () => {
-    const flags = resolveDevCliFlags({
-      ...base,
-      envUserDataDir: '/AppData/xdt-maker',
-    });
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker');
-    expect(flags.isolated).toBe(false);
-    expect(
-      shouldBlockSharedPrimaryDev({
-        isPackaged: false,
-        schedulerPassive: flags.schedulerPassive,
-        isolated: flags.isolated,
-      }),
-    ).toBe(true);
-  });
-
-  it('isolated 声明不能把覆写目录指回正式版 userData', () => {
-    const protectedUserDataDirs = [
-      '/AppData/Cindy',
-      '/AppData/CindyGlobal',
-      '/AppData/xdt-maker',
-    ];
-    expect(
-      shouldBlockSharedPrimaryDev({
-        isPackaged: false,
-        schedulerPassive: false,
-        isolated: true,
-        userDataDirOverride: '/AppData/xdt-maker',
-        protectedUserDataDirs,
-      }),
-    ).toBe(true);
-    expect(
-      shouldBlockSharedPrimaryDev({
-        isPackaged: false,
-        schedulerPassive: false,
-        isolated: true,
-        userDataDirOverride: '/AppData/xdt-maker-dev-feature',
-        protectedUserDataDirs,
-      }),
-    ).toBe(false);
-  });
-
-  it('passive 不能放行 isolated 声明指回任何正式版或历史 userData', () => {
-    const protectedUserDataDirs = [
-      '/AppData/Cindy',
-      '/AppData/CindyGlobal',
-      '/AppData/xdt-maker',
-    ];
-    for (const userDataDirOverride of protectedUserDataDirs) {
-      expect(
-        shouldBlockSharedPrimaryDev({
-          isPackaged: false,
-          schedulerPassive: true,
-          isolated: true,
-          userDataDirOverride,
-          protectedUserDataDirs,
-        }),
-      ).toBe(true);
-    }
-  });
-
-  it('路径身份检查会解析符号链接并按大小写不敏感平台比较', () => {
-    const shared = String.raw`C:\AppData\Cindy`;
-    const linked = String.raw`C:\AppData\release-link`;
-    expect(
-      userDataPathsReferToSameDirectory({
-        candidate: linked,
-        shared,
-        platform: 'win32',
-        realpath: (value) =>
-          value.toLowerCase().endsWith('release-link')
-            ? `${value.slice(0, -'release-link'.length)}Cindy`
-            : value,
-      }),
-    ).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/legacyUserDataMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/legacyUserDataMigration.test.ts
@@ -566,29 +566,11 @@ describe('shouldSkipLegacyMigrationForDevSandbox', () => {
     ).toBe(false);
   });
 
-  it('共享 passive dev → 跳过,不探测、复制或写 marker', () => {
-    expect(
-      shouldSkipLegacyMigrationForDevSandbox({
-        isPackaged: false,
-        envUserDataDir: undefined,
-        envPassiveSharedUserData: '1',
-      }),
-    ).toBe(true);
-    expect(
-      shouldSkipLegacyMigrationForDevSandbox({
-        isPackaged: false,
-        envUserDataDir: undefined,
-        envPassiveSharedUserData: '0',
-      }),
-    ).toBe(false);
-  });
-
   it('packaged 永不跳过(即使残留同名 env)', () => {
     expect(
       shouldSkipLegacyMigrationForDevSandbox({
         isPackaged: true,
         envUserDataDir: path.join(BASE, 'anything'),
-        envPassiveSharedUserData: '1',
       }),
     ).toBe(false);
   });

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -14,8 +14,7 @@
  * 纯函数、零 electron 依赖 —— index.ts 注入 argv / env / 默认 userData 目录,
  * 便于单元测试。packaged 版本一律返回"无覆写",线上零影响。
  */
-import { realpathSync } from 'node:fs';
-import { join, posix, win32 } from 'node:path';
+import { join } from 'node:path';
 
 /**
  * 沙箱名字白名单:字母数字下划线连字符、≤32。同时约束两件事——
@@ -100,9 +99,12 @@ export function shouldRequestSingleInstanceLock(input: {
  *
  * packaged 用真实 userData —— release 之间单实例，双击第二份安装包会聚焦已运行
  * 窗口。dev 用 `<userData>/dev-single-instance-lock` 子目录 —— dev 之间仍单实例
- * （深链 second-instance redirect 保持有效），并与 packaged 锁分域。共享正式版
- * userData 只允许 `--passive`，而 passive 会跳过获取锁；primary dev 必须使用
- * `--isolated`，其 userData 本身独立，锁子目录随之独立。
+ * （深链 second-instance redirect 保持有效），但**不再与共库的正式版互斥**：
+ * dev + release 共享 userData 双开是明确支持的工作流（2026-07-19 dev 改为与
+ * packaged 抢同一把锁曾误伤该工作流，2026-07-20 按 flavor 分域恢复）。跨实例
+ * 并发由 SQLite WAL + busy_timeout、scheduler DB 级原子认领、auth
+ * replacement-retry 等既有仲裁收敛，与 `--passive` 共库多开走的是同一套机制。
+ * `--isolated` 沙箱的 userData 本身独立，锁子目录随之独立，语义不变。
  */
 export function resolveSingleInstanceLockUserDataDir(input: {
   isPackaged: boolean;
@@ -126,60 +128,6 @@ export function shouldEnforcePassiveMigrationCompatibility(input: {
   isolated: boolean;
 }): boolean {
   return !input.isPackaged && input.schedulerPassive && !input.isolated;
-}
-
-/**
- * Primary dev must not open the packaged release's userData. A newer checkout
- * can migrate that database past the installed release's migration history.
- * Isolated dev owns a separate database; passive shared dev is compatibility
- * checked and never runs migrations.
- */
-export function shouldBlockSharedPrimaryDev(input: {
-  isPackaged: boolean;
-  schedulerPassive: boolean;
-  isolated: boolean;
-  userDataDirOverride?: string | null;
-  protectedUserDataDirs?: readonly string[];
-}): boolean {
-  if (input.isPackaged) return false;
-  const override = input.userDataDirOverride;
-  const overrideTargetsProtectedUserData = override
-    ? input.protectedUserDataDirs?.some((shared) =>
-        userDataPathsReferToSameDirectory({
-          candidate: override,
-          shared,
-        }),
-      ) === true
-    : false;
-  // A contradictory passive + isolated launch must fail before passive can
-  // bypass this guard: isolated mode would otherwise keep migrations enabled.
-  if (input.isolated && overrideTargetsProtectedUserData) return true;
-  if (input.schedulerPassive) return false;
-  if (!input.isolated) return true;
-  return false;
-}
-
-export function userDataPathsReferToSameDirectory(input: {
-  candidate: string;
-  shared: string;
-  platform?: NodeJS.Platform;
-  realpath?: (value: string) => string;
-}): boolean {
-  const platform = input.platform ?? process.platform;
-  const realpath = input.realpath ?? realpathSync.native;
-  const pathApi = platform === 'win32' ? win32 : posix;
-  const canonicalize = (value: string): string => {
-    let canonical = pathApi.resolve(value);
-    try {
-      canonical = realpath(canonical);
-    } catch {
-      // A not-yet-created directory still gets a stable lexical identity.
-    }
-    return platform === 'win32' || platform === 'darwin'
-      ? canonical.toLocaleLowerCase('en-US')
-      : canonical;
-  };
-  return canonicalize(input.candidate) === canonicalize(input.shared);
 }
 
 export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -71,49 +71,22 @@ installInvokeCapture();
 //   - --passive / XDT_SCHEDULER_PASSIVE:定时任务自动触发让位给同机另一实例。
 // 必须在 app 'ready' 前调用。仅 dev(非 packaged)生效,生产忽略,零线上影响。
 import { machineIdSync } from 'node-machine-id';
-import { BRAND_IDENTITY } from '@cindy/maker-shared/brand-identity';
 import {
   resolveDevCliFlags,
-  shouldBlockSharedPrimaryDev,
   shouldEnforcePassiveMigrationCompatibility,
 } from './devCliFlags.js';
 
-const defaultUserDataDir = app.getPath('userData');
 const devFlags = resolveDevCliFlags({
   argv: process.argv,
   isPackaged: app.isPackaged,
   envUserDataDir: process.env.XDT_USER_DATA_DIR,
-  defaultUserDataDir,
+  defaultUserDataDir: app.getPath('userData'),
   envIsolated: process.env.XDT_ISOLATED,
   envIsolationName: process.env.XDT_ISOLATED_NAME,
   envDeviceIdOverride: process.env.XDT_DEVICE_ID_OVERRIDE,
   envSchedulerPassive: process.env.XDT_SCHEDULER_PASSIVE,
   envEndpointsCdn: process.env.XDT_ENDPOINTS_CDN,
 });
-const protectedUserDataDirs = [
-  defaultUserDataDir,
-  ...Array.from(
-    new Set([
-      ...Object.values(BRAND_IDENTITY.userDataDirNameByRegion),
-      ...BRAND_IDENTITY.legacyUserDataDirNames,
-    ]),
-  ).map((dirName) => path.join(app.getPath('appData'), dirName)),
-];
-if (shouldBlockSharedPrimaryDev({
-  isPackaged: app.isPackaged,
-  schedulerPassive: devFlags.schedulerPassive,
-  isolated: devFlags.isolated,
-  userDataDirOverride: devFlags.userDataDirOverride,
-  protectedUserDataDirs,
-})) {
-  stderr.write(
-    '[cindy] Primary desktop dev cannot use shared Cindy userData because it may upgrade ' +
-      'the release database and prevent an older release from opening it.\n' +
-      '[cindy] Restart with --isolated=<name>, or use --passive / --preserve-running ' +
-      'for a shared read-only preview.\n',
-  );
-  exit(1);
-}
 if (devFlags.schedulerPassive) {
   // 统一收敛到 env:scheduler-host 只认 XDT_SCHEDULER_PASSIVE,不重复解析 argv。
   process.env.XDT_SCHEDULER_PASSIVE = '1';
@@ -171,10 +144,10 @@ if (devFlags.needsIsolatedDeviceId) {
   stderr.write(`[cindy] dev isolated deviceId → ${isolatedDeviceId}\n`);
 }
 
-// 实例注册表对 dev 与 packaged 一律登记：passive dev / release 共享 userData 时，
-// owner-namespace 迁移的独占检查靠本注册表发现「还有谁共享这份 userData」。
-// packaged 不登记的话，后续 primary 实例会在 release 仍存活时误判独占并搬走
-// legacy 配置。
+// 实例注册表对 dev 与 packaged 一律登记:dev/release 按 flavor 分锁域、共享同一
+// userData 双开是受支持的工作流(bootstrap-electron 单例锁注释),owner-namespace
+// 迁移的独占检查靠本注册表发现「还有谁共享这份 userData」——packaged 不登记的话,
+// dev 实例会在 release 实例仍存活时误判独占并搬走 legacy 配置。
 {
   const rootDir = app.isPackaged
     ? path.resolve(app.getAppPath())

--- a/apps/desktop/src/main/legacyUserDataMigration.ts
+++ b/apps/desktop/src/main/legacyUserDataMigration.ts
@@ -18,8 +18,7 @@
  *  - 老目录不存在(全新用户):静默写 marker 返回,不弹窗打扰。
  *  - 老目录存在:推送 confirm 态给 renderer 弹确认窗,await 用户确认(IPC
  *    `legacy-migration:confirm`)后才开始复制。
- *  - dev userData 覆写(--isolated 沙箱 / XDT_USER_DATA_DIR)或共享 passive 模式下
- *    整个迁移跳过,
+ *  - dev userData 覆写(--isolated 沙箱 / XDT_USER_DATA_DIR)下整个迁移跳过,
  *    不探测不弹窗(见 shouldSkipLegacyMigrationForDevSandbox)。
  *
  * 可测试性(docs/dev-rules/engineering-conventions.md):核心流程 `runLegacyUserDataMigration` 全部依赖
@@ -572,28 +571,21 @@ export function registerLegacyMigrationIpc(): void {
 }
 
 /**
- * dev userData 覆写(--isolated 沙箱 / 手动 XDT_USER_DATA_DIR)和共享 passive 模式下
- * 必须跳过首登迁移。
+ * dev userData 覆写(--isolated 沙箱 / 手动 XDT_USER_DATA_DIR)下必须跳过首登迁移。
  *
  * 沙箱目录(如 <userData>-dev)与真实 userData 同级,首次登录时沙箱里没有 mToc
  * marker,探测会命中同级的真实老 xdt-maker 目录 → 弹确认窗并把用户真实主库 /
  * cindy-media / dialogues / 浏览器 profile 整套复制进临时沙箱。这既不是沙箱的
  * 语义(隔离、不动正式数据),也会产生 GB 级无意义复制。isolated 的 argv 与 env
  * 两条声明通道最终都会把生效目录同步进 XDT_USER_DATA_DIR(main/index.ts),
- * 因此这里以该 env 为检测面。共享 passive 由 index.ts 在加载 bootstrap 前同步
- * XDT_PASSIVE_SHARED_USER_DATA=1，同样不得探测、复制或写 marker。packaged 永不
- * 跳过(线上升级迁移不受影响)。
+ * 因此这里以该 env 为唯一检测面。packaged 永不跳过(线上升级迁移不受影响)。
  * 纯函数、零 electron 依赖,便于单测。
  */
 export function shouldSkipLegacyMigrationForDevSandbox(input: {
   isPackaged: boolean;
   envUserDataDir: string | undefined;
-  envPassiveSharedUserData?: string | undefined;
 }): boolean {
-  return (
-    !input.isPackaged &&
-    (Boolean(input.envUserDataDir?.trim()) || input.envPassiveSharedUserData === '1')
-  );
+  return !input.isPackaged && Boolean(input.envUserDataDir?.trim());
 }
 
 /**
@@ -605,15 +597,14 @@ export async function runLegacyUserDataMigrationForUser(userId: string): Promise
   // global 构建(同机双装)是全新身份,把 cn 的历史数据导进 global 库会
   // 跨区域串台(两边 auth 后端不同,会话 / 凭证对不上)。
   if (CURRENT_CINDY_REGION !== 'cn') return;
-  // dev 沙箱 / userData 覆写 / 共享 passive:不探测、不弹窗、不写 marker,纯跳过。
+  // dev 沙箱 / userData 覆写:不探测、不弹窗、不写 marker,纯跳过(见上方谓词注释)。
   if (
     shouldSkipLegacyMigrationForDevSandbox({
       isPackaged: app.isPackaged,
       envUserDataDir: process.env.XDT_USER_DATA_DIR,
-      envPassiveSharedUserData: process.env.XDT_PASSIVE_SHARED_USER_DATA,
     })
   ) {
-    log.info('legacy userData migration: dev sandbox/passive mode active, skipped');
+    log.info('legacy userData migration: dev userData override active, skipped');
     return;
   }
   if (inFlight != null) {

--- a/docs/dev-rules/database-and-migrations.md
+++ b/docs/dev-rules/database-and-migrations.md
@@ -82,12 +82,10 @@ companion CommonJS 格式和历史 runtime identity 冻结；不能用单独 typ
 - companion 接收同步 `better-sqlite3` 实例，在受控 migration 事务内使用 `.get()`、
   `.all()`、`.run()` 是契约的一部分；不要把这种同步写法复制到运行期业务代码。
 
-## Dev Migration 与本地数据
+## 未合入 Migration 与本地数据
 
-- primary dev 禁止连接共享 Cindy userData 运行 migration，即使 migration 已进入 `main`；
-  本机安装的 release 仍可能更旧，新 checkout 升级数据库后会让旧 release 无法打开。
-- 未进入 `main` 的 migration 还可能因分支换号或回退，让本地 `schema_version` 与真实结构
-  永久分叉。
+- 未进入 `main` 的 migration 禁止连接共享 Cindy userData 运行；否则分支换号或回退后会让
+  本地 `schema_version` 与真实结构永久分叉。
 - 需要启动验证时，按照 `desktop-development.md` 的参数说明使用显式
   `--isolated[=<名字>]` 沙箱。migration replay 自身使用临时数据库，不污染用户数据。
 - 不得为了测试 migration 临时改写、降级或删除用户数据库；需要历史状态时新增最小 fixture。

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -7,11 +7,11 @@
 
 ## Agent 启动入口
 
-Agent 启动 Desktop 只使用仓库根的安全包装命令，并显式选择目标区域与隔离沙箱：
+Agent 启动 Desktop 只使用仓库根的安全包装命令，并显式选择目标区域：
 
 ```bash
-pnpm restart:desktop:remote --region=cn --isolated=cn-<名字>
-pnpm restart:desktop:remote --region=global --isolated=global-<名字>
+pnpm restart:desktop:remote --region=cn
+pnpm restart:desktop:remote --region=global
 ```
 
 Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录页中免 Cindy 账号的
@@ -23,37 +23,31 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
 
 ## 可选启动参数
 
-两个 restart 命令都支持下列参数。primary dev 必须显式使用 `--isolated[=<名字>]`；无隔离
-参数的共享 primary 会在启动前被拒绝，避免新 checkout 迁移正式版数据库、导致旧 release
-无法打开。只有 `--passive` / `--preserve-running` 可以只读共享正式版 userData。
+两个 restart 命令都支持下列参数；**用户没提就不要主动加**（不带 = 共库 + 正常调度）。
 这些参数只对 dev 生效，不影响用户机器上的正式版。
 
 - `--region=cn|global`（默认 `cn`）：切换构建身份与仓内端点清单（`global` 读
   `config/endpoint.global.json`）。
-- `--isolated` / `--isolated=<名字>`：primary dev 的必选参数，使用独立 userData 沙箱，数据库、登录态、会话、定时
+- `--isolated` / `--isolated=<名字>`：使用独立 userData 沙箱，数据库、登录态、会话、定时
   任务与设备身份都与正式版彻底隔离（首次需重新登录）；命名沙箱每个名字一条独立沙箱，
   名字限 `A-Za-z0-9_-`、≤32 字符。用户说「独立数据库／隔离数据／沙箱启动／不要动正式版
-  数据」时用。**primary dev 的 migration 必须在 `--isolated` 沙箱里跑，不得连接共享 userData**
+  数据」时用。**未合入主干的 migration 必须在 `--isolated` 沙箱里跑，不得连共享 userData**
   （见 [`database-and-migrations.md`](database-and-migrations.md)）。沙箱（及任何 dev
   userData 覆写）内不触发首登旧数据迁移（mToc）：不探测老目录、不弹确认窗、不把正式
-  数据复制进沙箱。dev 沙箱目录沿用既有的“按名字复用”契约，不自动按 region 改名；同一
-  机器同时开发 cn / global 时，名字必须分别使用 `cn-<名字>` / `global-<名字>`，避免两区
-  复用数据库和登录态。
-- `--passive`：共享 userData 的只读预览模式，本实例不执行 migration，也不自动触发 schedule；
+  数据复制进沙箱。
+- `--passive`：定时任务被动模式，本实例不自动触发 schedule，但数据仍与其它实例共享；
   多开导致定时任务重复、需要让位给 primary 时用。共享 userData 的 passive 实例对
   userData 布局保持只读：不执行 owner-namespace 迁移（claim 推迟到下次独占启动），
   legacy 数据导入（`hasLegacyOwnerNamespaceClaim` 门控的 secret／IM／brain 搬账）
   一并等待。非 passive 实例执行该迁移前也会先查 `.dev-instances` 实例注册表
-  （dev 与 packaged 实例都登记——passive dev 与正式版可只读共库双开），发现其它存活实例
+  （dev 与 packaged 实例都登记——dev 与正式版共库双开受支持），发现其它存活实例
   共享同一 userData 时同样推迟——搬家式迁移必须独占 userData 才能执行，否则会打断
   还在运行的旧版本实例（2026-07-23 slack-hook.json／网关凭证被搬走事故）。
 - `--preserve-running`：并行 dev，不停止任何已有 Cindy dev 进程，每个新实例强制 passive
   并共享当前 userData／登录态；仅供能证明实例归属的上层编排，或用户明确「不要关当前
   实例／不要重新登录」时用。仅支持 remote，禁止与 `--isolated` 组合。
 
-已手动设 `XDT_USER_DATA_DIR` 时仍须同时声明 `--isolated` / `XDT_ISOLATED=1`；脚本会尊重
-该目录值而不覆盖，但该路径（包括解析符号链接后）不得指向正式版 userData。仅设置目录或
-隔离标记都不足以绕过启动闸。
+已手动设 `XDT_USER_DATA_DIR` 时尊重用户值，不覆盖。
 
 ### 并行多开 dev
 

--- a/scripts/__tests__/brand-identity-sync.test.mjs
+++ b/scripts/__tests__/brand-identity-sync.test.mjs
@@ -28,12 +28,6 @@ function extractLiteral(source, regex, label) {
   return match[1];
 }
 
-function extractStringLiterals(source, regex, label) {
-  const match = regex.exec(source);
-  assert.ok(match, `pattern not found: ${label} (${regex})`);
-  return [...match[1].matchAll(/'([^']+)'/g)].map((entry) => entry[1]);
-}
-
 const brandIdentitySource = readSource('packages/maker-shared/src/brandIdentity.ts');
 const EXECUTABLE_NAME = extractLiteral(
   brandIdentitySource,
@@ -63,29 +57,6 @@ test('restart-desktop-remote.mjs BRAND_USER_DATA_DIR_NAME mirrors brandIdentity.
     'restart-desktop-remote.mjs BRAND_USER_DATA_DIR_NAME',
   );
   assert.equal(value, USER_DATA_DIR_NAME);
-});
-
-test('dev migration policy protects every current and legacy release userData directory', () => {
-  const current = extractStringLiterals(
-    brandIdentitySource,
-    /userDataDirNameByRegion:\s*Object\.freeze\(\{([\s\S]*?)\}\),/,
-    'brandIdentity.ts userDataDirNameByRegion',
-  );
-  const legacy = extractStringLiterals(
-    brandIdentitySource,
-    /legacyUserDataDirNames:\s*Object\.freeze\(\[([\s\S]*?)\]\)/,
-    'brandIdentity.ts legacyUserDataDirNames',
-  );
-  const policySource = readSource('scripts/dev-migration-policy.mjs');
-  const protectedNames = extractStringLiterals(
-    policySource,
-    /PROTECTED_USER_DATA_DIR_NAMES = Object\.freeze\(\[([\s\S]*?)\]\)/,
-    'dev-migration-policy.mjs PROTECTED_USER_DATA_DIR_NAMES',
-  );
-  assert.deepEqual(
-    [...new Set(protectedNames)].sort(),
-    [...new Set([...current, ...legacy])].sort(),
-  );
 });
 
 test('desktop package.json productName mirrors brandIdentity.userDataDirName', () => {

--- a/scripts/__tests__/dev-migration-policy.test.mjs
+++ b/scripts/__tests__/dev-migration-policy.test.mjs
@@ -34,7 +34,7 @@ function createFixture() {
   };
 }
 
-test('shared primary dev is blocked even without migration artifacts', () => {
+test('shared dev allows branches without migration artifacts', () => {
   const fixture = createFixture();
   try {
     fs.writeFileSync(path.join(fixture.repo, 'README.md'), 'feature\n');
@@ -45,163 +45,27 @@ test('shared primary dev is blocked even without migration artifacts', () => {
       committed: [],
       workingTree: [],
     });
-    assert.throws(
-      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']),
-      /may upgrade the release database and prevent an older release from opening/,
-    );
+    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']));
   } finally {
     fixture.cleanup();
   }
 });
 
-test('migration artifact discovery remains available for diagnostics', () => {
+test('shared dev rejects committed or working-tree migration artifacts before restart', () => {
   const fixture = createFixture();
   try {
     const migrationPath = path.join(fixture.drizzleDir, '0001_feature.sql');
     fs.writeFileSync(migrationPath, 'SELECT 1;\n');
-    assert.deepEqual(findUnmergedMigrationArtifacts(fixture.repo).workingTree, [
-      '?? apps/desktop/drizzle/0001_feature.sql',
-    ]);
+    assert.throws(
+      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']),
+      /working tree: \?\? apps\/desktop\/drizzle\/0001_feature\.sql/,
+    );
     git(fixture.repo, 'add', '.');
     git(fixture.repo, 'commit', '-m', 'feature migration');
-    assert.deepEqual(findUnmergedMigrationArtifacts(fixture.repo).committed, [
-      'apps/desktop/drizzle/0001_feature.sql',
-    ]);
-  } finally {
-    fixture.cleanup();
-  }
-});
-
-test('passive shared dev may start without running migrations', () => {
-  const fixture = createFixture();
-  try {
-    fs.writeFileSync(path.join(fixture.drizzleDir, '0001_feature.sql'), 'SELECT 1;\n');
-    assert.doesNotThrow(() =>
-      assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready', '--passive']),
-    );
-    assert.doesNotThrow(() =>
-      assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready', '--preserve-running']),
-    );
-    assert.doesNotThrow(() =>
-      assertSharedDevMigrationPolicy(
-        fixture.repo,
-        ['--wait-ready'],
-        { XDT_SCHEDULER_PASSIVE: '1' },
-      ),
-    );
-  } finally {
-    fixture.cleanup();
-  }
-});
-
-test('a userData override alone cannot bypass shared primary protection', () => {
-  const fixture = createFixture();
-  try {
     assert.throws(
-      () =>
-        assertSharedDevMigrationPolicy(
-          fixture.repo,
-          ['--wait-ready'],
-          { XDT_USER_DATA_DIR: path.join(fixture.repo, 'Cindy') },
-        ),
-      /may upgrade the release database and prevent an older release from opening/,
+      () => assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready']),
+      /committed: apps\/desktop\/drizzle\/0001_feature\.sql/,
     );
-    assert.doesNotThrow(() =>
-      assertSharedDevMigrationPolicy(
-        fixture.repo,
-        ['--wait-ready'],
-        {
-          XDT_ISOLATED: '1',
-          XDT_USER_DATA_DIR: path.join(fixture.repo, 'Cindy-dev'),
-        },
-      ),
-    );
-  } finally {
-    fixture.cleanup();
-  }
-});
-
-test('an isolated declaration cannot point its override back to shared release userData', () => {
-  const fixture = createFixture();
-  try {
-    const appData = String.raw`C:\Users\dev\AppData\Roaming`;
-    const sharedUserData = path.win32.join(appData, 'Cindy');
-    const linkedUserData = path.win32.join(appData, 'release-link');
-    const env = {
-      APPDATA: appData,
-      XDT_ISOLATED: '1',
-      XDT_USER_DATA_DIR: sharedUserData,
-    };
-    const windowsPathOptions = {
-      platform: 'win32',
-      realpath: (value) => value,
-    };
-    assert.throws(
-      () =>
-        assertSharedDevMigrationPolicy(fixture.repo, ['--wait-ready'], env, windowsPathOptions),
-      /may upgrade the release database and prevent an older release from opening/,
-    );
-    assert.throws(
-      () =>
-        assertSharedDevMigrationPolicy(
-          fixture.repo,
-          ['--wait-ready'],
-          { ...env, XDT_USER_DATA_DIR: linkedUserData },
-          {
-            platform: 'win32',
-            realpath: (value) =>
-              value.toLowerCase().endsWith('release-link') ? sharedUserData : value,
-          },
-        ),
-      /may upgrade the release database and prevent an older release from opening/,
-    );
-  } finally {
-    fixture.cleanup();
-  }
-});
-
-test('passive cannot bypass an isolated override targeting release userData', () => {
-  const fixture = createFixture();
-  try {
-    const appData = String.raw`C:\Users\dev\AppData\Roaming`;
-    assert.throws(
-      () =>
-        assertSharedDevMigrationPolicy(
-          fixture.repo,
-          ['--wait-ready', '--passive', '--isolated=feature'],
-          {
-            APPDATA: appData,
-            XDT_USER_DATA_DIR: path.win32.join(appData, 'Cindy'),
-          },
-          { platform: 'win32', realpath: (value) => value },
-        ),
-      /may upgrade the release database and prevent an older release from opening/,
-    );
-  } finally {
-    fixture.cleanup();
-  }
-});
-
-test('all current and legacy release userData directories are protected', () => {
-  const fixture = createFixture();
-  try {
-    const appData = String.raw`C:\Users\dev\AppData\Roaming`;
-    for (const dirName of ['Cindy', 'CindyGlobal', 'CindyDev', 'xdt-maker']) {
-      assert.throws(
-        () =>
-          assertSharedDevMigrationPolicy(
-            fixture.repo,
-            ['--wait-ready', '--isolated=feature'],
-            {
-              APPDATA: appData,
-              XDT_USER_DATA_DIR: path.win32.join(appData, dirName),
-            },
-            { platform: 'win32', realpath: (value) => value },
-          ),
-        /may upgrade the release database and prevent an older release from opening/,
-        dirName,
-      );
-    }
   } finally {
     fixture.cleanup();
   }
@@ -219,15 +83,15 @@ test('named isolated dev may run an unmerged migration', () => {
   }
 });
 
-test('isolated dev remains allowed after migration becomes canonical on origin/main', () => {
+test('migration becomes shared-safe only after it is canonical on origin/main', () => {
   const fixture = createFixture();
   try {
     fs.writeFileSync(path.join(fixture.drizzleDir, '0001_feature.sql'), 'SELECT 1;\n');
     git(fixture.repo, 'add', '.');
     git(fixture.repo, 'commit', '-m', 'feature migration');
-    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, ['--isolated=feature']));
+    assert.throws(() => assertSharedDevMigrationPolicy(fixture.repo, []));
     git(fixture.repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD');
-    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, ['--isolated=feature']));
+    assert.doesNotThrow(() => assertSharedDevMigrationPolicy(fixture.repo, []));
   } finally {
     fixture.cleanup();
   }
@@ -255,7 +119,7 @@ test('stale origin/HEAD cannot replace origin/main as the migration baseline', (
     });
     assert.throws(
       () => assertSharedDevMigrationPolicy(fixture.repo, []),
-      /may upgrade the release database and prevent an older release from opening/,
+      /committed: apps\/desktop\/drizzle\/0001_release_only\.sql/,
     );
   } finally {
     fixture.cleanup();

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,7 +8,6 @@ import { fileURLToPath } from "node:url";
 
 import {
 	applyDesktopStartupConfigForPhase,
-	defaultIsolatedUserDataDir,
 	devEnvPrefix,
 	isRepositoryDesktopDevProcess,
 	formatDesktopStartupFailure,
@@ -25,36 +25,6 @@ import {
 	buildDesktopRestartSteps,
 	runDesktopRestart,
 } from "../desktop-restart-runner.mjs";
-
-test("isolated userData uses an absolute OS config root when env vars are absent", () => {
-	assert.equal(
-		defaultIsolatedUserDataDir("feature", {
-			env: {},
-			platform: "linux",
-			homedir: () => "/home/dev",
-		}),
-		"/home/dev/.config/Cindy-dev-feature",
-	);
-	assert.equal(
-		defaultIsolatedUserDataDir("feature", {
-			env: {},
-			platform: "win32",
-			homedir: () => String.raw`C:\Users\dev`,
-		}),
-		String.raw`C:\Users\dev\AppData\Roaming\Cindy-dev-feature`,
-	);
-	for (const platform of ["linux", "win32"]) {
-		assert.throws(
-			() =>
-				defaultIsolatedUserDataDir("feature", {
-					env: {},
-					platform,
-					homedir: () => "",
-				}),
-			/cannot resolve an absolute OS userData root/,
-		);
-	}
-});
 
 function appleScriptLines(args) {
 	const lines = [];
@@ -157,23 +127,33 @@ test("desktop restart process-control phase does not initialize startup configur
 	});
 });
 
-test("desktop restart blocks shared primary dev before the kill step", () => {
+test("desktop restart rejects an unmerged migration before the kill step", () => {
+	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "cindy-restart-policy-"));
 	const calls = [];
-	assert.throws(
-		() => runDesktopRestart(["--wait-ready"], "/repo/cindy", (step) => calls.push(step)),
-		/may upgrade the release database and prevent an older release from opening/,
-	);
-	assert.deepEqual(calls, []);
-});
+	try {
+		fs.mkdirSync(path.join(repo, "apps", "desktop", "drizzle"), { recursive: true });
+		fs.writeFileSync(path.join(repo, "apps", "desktop", "drizzle", "0000_init.sql"), "SELECT 0;\n");
+		const git = (...args) => {
+			const result = spawnSync("git", args, { cwd: repo, encoding: "utf8" });
+			assert.equal(result.status, 0, result.stderr);
+		};
+		git("init", "-b", "main");
+		git("config", "user.name", "Restart Policy Test");
+		git("config", "user.email", "restart-policy@example.invalid");
+		git("add", ".");
+		git("commit", "-m", "base");
+		git("update-ref", "refs/remotes/origin/main", "HEAD");
+		git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main");
+		git("switch", "-c", "feature");
+		fs.writeFileSync(path.join(repo, "apps", "desktop", "drizzle", "0001_feature.sql"), "SELECT 1;\n");
 
-test("desktop restart allows isolated and passive dev modes", () => {
-	const root = "/repo/cindy";
-	for (const modeArg of ["--isolated=feature", "--passive", "--preserve-running"]) {
-		const calls = [];
-		assert.doesNotThrow(() =>
-			runDesktopRestart(["--wait-ready", modeArg], root, (step) => calls.push(step)),
+		assert.throws(
+			() => runDesktopRestart(["--wait-ready"], repo, (step) => calls.push(step)),
+			/Shared Cindy userData cannot run migration artifacts/,
 		);
-		assert.ok(calls.length > 0, `${modeArg} should reach the restart pipeline`);
+		assert.deepEqual(calls, []);
+	} finally {
+		fs.rmSync(repo, { recursive: true, force: true });
 	}
 });
 

--- a/scripts/dev-migration-policy.mjs
+++ b/scripts/dev-migration-policy.mjs
@@ -1,17 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { realpathSync } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 
 const DRIZZLE_PATH = 'apps/desktop/drizzle';
-// Mirrors BRAND_IDENTITY.userDataDirNameByRegion + legacyUserDataDirNames.
-// scripts/__tests__/brand-identity-sync.test.mjs prevents drift from the TS source.
-export const PROTECTED_USER_DATA_DIR_NAMES = Object.freeze([
-  'Cindy',
-  'CindyGlobal',
-  'CindyDev',
-  'xdt-maker',
-]);
 
 function git(repoRoot, args, { allowFailure = false } = {}) {
   const result = spawnSync('git', args, {
@@ -68,123 +57,26 @@ export function findUnmergedMigrationArtifacts(repoRoot) {
   };
 }
 
-export function resolveDesktopUserDataRoot(
-  env = process.env,
-  platform = process.platform,
-  homedir = os.homedir,
-) {
-  const pathApi = platform === 'win32' ? path.win32 : path.posix;
-  const fallbackHome = () => {
-    try {
-      return homedir();
-    } catch {
-      return '';
-    }
-  };
-  let root;
-  if (platform === 'win32') {
-    if (env.APPDATA) {
-      root = env.APPDATA;
-    } else {
-      const home = env.USERPROFILE || fallbackHome();
-      root = home ? pathApi.join(home, 'AppData', 'Roaming') : '';
-    }
-  } else if (platform === 'darwin') {
-    const home = env.HOME || fallbackHome();
-    root = home ? pathApi.join(home, 'Library', 'Application Support') : '';
-  } else if (env.XDG_CONFIG_HOME) {
-    root = env.XDG_CONFIG_HOME;
-  } else {
-    const home = env.HOME || fallbackHome();
-    root = home ? pathApi.join(home, '.config') : '';
-  }
-  if (!root || !pathApi.isAbsolute(root)) {
-    throw new Error(
-      'cannot resolve an absolute OS userData root; set APPDATA/USERPROFILE on Windows, ' +
-        'HOME on macOS, or XDG_CONFIG_HOME/HOME on Linux',
-    );
-  }
-  return root;
-}
-
-function defaultSharedUserDataDirs(env, platform, homedir) {
-  const pathApi = platform === 'win32' ? path.win32 : path.posix;
-  const root = resolveDesktopUserDataRoot(env, platform, homedir);
-  return PROTECTED_USER_DATA_DIR_NAMES.map((dirName) => pathApi.join(root, dirName));
-}
-
-function canonicalUserDataPath(value, { platform, realpath }) {
-  const pathApi = platform === 'win32' ? path.win32 : path.posix;
-  let canonical = pathApi.resolve(value);
-  try {
-    canonical = realpath(canonical);
-  } catch {
-    // A not-yet-created directory still gets a stable lexical identity.
-  }
-  return platform === 'win32' || platform === 'darwin'
-    ? canonical.toLocaleLowerCase('en-US')
-    : canonical;
-}
-
-export function userDataOverrideTargetsSharedUserData(
-  override,
-  env = process.env,
-  {
-    platform = process.platform,
-    realpath = realpathSync.native,
-    homedir = os.homedir,
-  } = {},
-) {
-  if (!override?.trim()) return false;
-  const options = { platform, realpath };
-  const candidate = canonicalUserDataPath(override, options);
-  return defaultSharedUserDataDirs(env, platform, homedir).some(
-    (shared) => candidate === canonicalUserDataPath(shared, options),
-  );
-}
-
-function declaresIsolatedUserData(argv, env) {
-  return (
-    argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated=')) ||
-    env.XDT_ISOLATED === '1'
-  );
-}
-
-export function usesIsolatedUserData(argv, env = process.env, options = {}) {
-  const declaredIsolated = declaresIsolatedUserData(argv, env);
-  if (!declaredIsolated) return false;
-  return !userDataOverrideTargetsSharedUserData(env.XDT_USER_DATA_DIR, env, options);
-}
-
-export function usesPassiveUserData(argv, env = process.env) {
-  return (
-    argv.includes('--passive') ||
-    argv.includes('--preserve-running') ||
-    env.XDT_SCHEDULER_PASSIVE === '1'
-  );
+export function usesIsolatedUserData(argv) {
+  return argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated='));
 }
 
 /**
- * A primary dev process must never migrate the shared userData directory. The
- * directory may belong to an older packaged release, and a migration from this
- * checkout can make that release unable to open it. Passive previews remain
- * read-only, while isolated dev gets its own migration history.
- *
+ * Shared userData may only execute migrations that are already canonical on origin/main.
  * Run this before the restart pipeline stops any existing Cindy instance.
  */
-export function assertSharedDevMigrationPolicy(
-  _repoRoot,
-  argv,
-  env = process.env,
-  options = {},
-) {
-  const declaredIsolated = declaresIsolatedUserData(argv, env);
-  if (usesIsolatedUserData(argv, env, options)) return;
-  // Passive may share release data only when it is not also claiming isolated
-  // semantics. The contradictory combination would leave migrations enabled.
-  if (!declaredIsolated && usesPassiveUserData(argv, env)) return;
+export function assertSharedDevMigrationPolicy(repoRoot, argv) {
+  if (usesIsolatedUserData(argv)) return;
+  const artifacts = findUnmergedMigrationArtifacts(repoRoot);
+  if (artifacts.committed.length === 0 && artifacts.workingTree.length === 0) return;
+  const detail = [
+    ...artifacts.committed.map((file) => `committed: ${file}`),
+    ...artifacts.workingTree.map((line) => `working tree: ${line}`),
+  ].join('\n  ');
   throw new Error(
-    'Primary desktop dev cannot migrate shared Cindy userData because it may upgrade the release database and prevent an older release from opening it.\n' +
-      'Restart with --isolated=<name> for writable dev data, or use --passive / --preserve-running for a shared read-only preview.',
+    `Shared Cindy userData cannot run migration artifacts that are not canonical on ${artifacts.baseRef}.\n` +
+      `  ${detail}\n` +
+      'Rebase and renumber the migration before shared testing, or explicitly use a named sandbox: ' +
+      'pnpm restart:desktop:remote -- --isolated=<name>',
   );
 }

--- a/scripts/help.mjs
+++ b/scripts/help.mjs
@@ -7,16 +7,16 @@ export function printHelp(log = console.log) {
   log('\n  桌面端启动:');
   log('    # 推荐：先清理已有 Cindy dev 进程，再启动远程 API 模式');
   log('    # 国内版，读取仓内 config/endpoint.json');
-  log('    pnpm restart:desktop:remote --region=cn --isolated=cn-<name>');
+  log('    pnpm restart:desktop:remote --region=cn');
   log('    # 海外版，读取仓内 config/endpoint.global.json');
-  log('    pnpm restart:desktop:remote --region=global --isolated=global-<name>');
+  log('    pnpm restart:desktop:remote --region=global');
   log('    # 海外版，读取对应区域的线上 CDN 端点清单');
-  log('    pnpm restart:desktop:remote --region=global --endpoints-cdn --isolated=global-<name>');
+  log('    pnpm restart:desktop:remote --region=global --endpoints-cdn');
   log('    # Human 可直接启动；不会先清旧进程，Agent 不要使用');
-  log('    pnpm dev:desktop:remote --region=cn --isolated=cn-<name>');
-  log('    pnpm dev:desktop:remote --region=global --isolated=global-<name>');
+  log('    pnpm dev:desktop:remote --region=cn');
+  log('    pnpm dev:desktop:remote --region=global');
   log('    # 连接本地 http://localhost:3333（只起客户端，不起 server）');
-  log('    pnpm restart:desktop:local --region=cn --isolated=cn-<name>');
+  log('    pnpm restart:desktop:local --region=cn');
 
   log('\n  Agent 二进制安装 / 升级（Claude Code、Codex、ripgrep）:');
   log('    # 按 latest.json 当前 pin 安装到本机，不修改 pin');

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -4,7 +4,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveDesktopUserDataRoot } from './dev-migration-policy.mjs';
 import { applyDesktopDevStartupConfig } from './shared/desktop-dev-region.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -392,17 +391,17 @@ function closeDarwinTerminalTtys(ttys) {
  * `-<名字>` 后缀,每个名字一条完全独立的沙箱。只在 dev 生效——主进程入口只在
  * 非 packaged 时应用该覆写。
  */
-export function defaultIsolatedUserDataDir(
-  isolationName,
-  {
-    env = process.env,
-    platform = process.platform,
-    homedir = os.homedir,
-  } = {},
-) {
-  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+function defaultIsolatedUserDataDir(isolationName) {
   const dirName = `${BRAND_USER_DATA_DIR_NAME}-dev${isolationName ? `-${isolationName}` : ''}`;
-  return pathApi.join(resolveDesktopUserDataRoot(env, platform, homedir), dirName);
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(process.env.USERPROFILE || '', 'AppData', 'Roaming');
+    return path.join(appData, dirName);
+  }
+  if (process.platform === 'darwin') {
+    return path.join(process.env.HOME || '', 'Library', 'Application Support', dirName);
+  }
+  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME || '', '.config');
+  return path.join(xdgConfig, dirName);
 }
 
 function devScriptForMode(mode) {


### PR DESCRIPTION
## 这次改了什么？

### 摘要

Revert merged PR #409 (`fix(desktop): block shared primary dev migrations`) and restore the pre-#409 desktop development migration behavior and related guidance/tests.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [x] 其他：revert

### 范围

- 关联 PR：#409
- 本 PR 包含：对 PR #409 squash merge commit `a629cd90de4afa7ad215611fc6eabf969f753ba9` 的完整 revert，共 13 个文件
- 明确不包含：PR #409 之后 main 上的其他提交
- 用户可见变化：恢复 PR #409 之前的 Desktop 开发环境迁移行为与文档
- breaking change：无

### UI 变化

不涉及。

## 怎么验证的？

### 自动验证

```text
pnpm check:dco
结果：通过（1 个提交带 Signed-off-by）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过；适用 workspace 全部 PASS，manifest 标记 notApplicable 的 workspace 按规则跳过
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：Desktop 开发环境的 migration/data-isolation guard、相关脚本、测试与开发文档。
- 回滚方式：关闭或 revert 本 PR 即可恢复 PR #409 的行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 不涉及 UI
- [x] 未提交凭证、令牌或授权文件
- [x] 已完成必要验证