### PR TITLE
chore: 清理折扣相关内部黑话与折价百分比展示

### DIFF
--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -374,7 +374,7 @@ function ensureInstances(): { store: SlackHookStore; manager: HookControlManager
               displayName: m.name,
               efforts: m.efforts,
               defaultEffort: m.defaultEffort,
-              // 分组随行: 骨折版(gpt-budget)与官方版 displayName 故意同名,
+              // 分组随行: 折扣版(gpt-budget)与官方版 displayName 故意同名,
               // Slack 卡与 Tina 下拉都靠 group 加区分后缀
               ...(m.group !== undefined ? { group: m.group } : {}),
             })),

--- a/apps/desktop/src/main/hook-control/queryResponder.ts
+++ b/apps/desktop/src/main/hook-control/queryResponder.ts
@@ -27,7 +27,7 @@ export interface AgentModelSource {
     displayName: string;
     efforts: readonly string[];
     defaultEffort: string | null;
-    /** 目录分组 id(如 'gpt-budget'): 骨折版与官方版同名, server 靠它加区分后缀。 */
+    /** 目录分组 id(如 'gpt-budget'): 折扣版与官方版同名, server 靠它加区分后缀。 */
     group?: string;
   }>;
   /** 该 agent 支持的权限档(capabilities.permissionModes; label 用 displayName 原样透传)。 */

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -244,7 +244,7 @@ describe('decideCodexRoute', () => {
     expect(decideCodexRoute({ model: 'codex/gpt-5.5', authInjection: 'env-key', gatewayKey: 'k' })).toBeNull();
   });
 
-  it('oauth-bearer + codex/ 骨折模型 → 换 gateway key', async () => {
+  it('oauth-bearer + codex/ 折扣模型 → 换 gateway key', async () => {
     const { decideCodexRoute } = await import('../codex-proxy-host.js');
     expect(decideCodexRoute({ model: 'codex/gpt-5.5', authInjection: 'oauth-bearer', gatewayKey: 'gw' }))
       .toEqual({ headerOverride: { authorization: 'Bearer gw' } });
@@ -256,7 +256,7 @@ describe('decideCodexRoute', () => {
       .toEqual({ upstreamOverride: CHATGPT });
   });
 
-  it('oauth-bearer + codex/ 骨折但无 gateway key → null(passthrough)', async () => {
+  it('oauth-bearer + codex/ 折扣但无 gateway key → null(passthrough)', async () => {
     const { decideCodexRoute } = await import('../codex-proxy-host.js');
     expect(decideCodexRoute({ model: 'codex/gpt-5.5', authInjection: 'oauth-bearer', gatewayKey: null })).toBeNull();
   });
@@ -317,7 +317,7 @@ describe('createModelRoutingTransform —— session-less 控制面请求(桶③
     host.setCodexProxyAuthInjection('oauth-bearer');
     host.setCodexProxyGatewayKeyReader(() => 'gw');
     const transform = host.createModelRoutingTransform();
-    // codex/ 骨折模型 + 无 session: 若被桶③劫持会返回 { upstreamOverride: CHATGPT };
+    // codex/ 折扣模型 + 无 session: 若被桶③劫持会返回 { upstreamOverride: CHATGPT };
     // 正确行为是落 ② decideCodexRoute → 换 gateway key。
     expect(transform({ model: 'codex/gpt-5.5', input: [] }, { reqId: 1, method: 'POST', url: '/responses', headers: {} }))
       .toEqual({ headerOverride: { authorization: 'Bearer gw' } });

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -911,7 +911,7 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
       }
       return localState;
     }
-    // proxy 路线: 无 OAuth 登录但配了 api key → 仍放行 codex 进程(骨折模型经 proxy 走 gateway 可用)。
+    // proxy 路线: 无 OAuth 登录但配了 api key → 仍放行 codex 进程(折扣模型经 proxy 走 gateway 可用)。
     // 单条 model 的可用性由 ModelSelector + proxy 路由把关, 不在这道全局 gate 上拦。
     if (readClaudeApiKey()) {
       return { authenticated: true, identity: 'API Key · Cindy AI', authSource: 'api-key' };
@@ -1208,7 +1208,7 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
     //   - oauth-bearer (有 OAuth 登录): provider 用 requires_openai_auth, codex 带 auth.json 的 OAuth
     //     token; XDT_CODEX_API_KEY 此时 codex 不读(provider 无 env_key 配置), 注入无害。
     //   - env-key (纯 api key、无 OAuth): provider 用 env_key=XDT_CODEX_API_KEY, codex 带 gateway key。
-    // proxy 自身给骨折 / api 流量换的 gateway key 走 readClaudeApiKey(), 不经此 env。
+    // proxy 自身给折扣 / api 流量换的 gateway key 走 readClaudeApiKey(), 不经此 env。
     const env: Record<string, string> = { CODEX_HOME: this.codexHome };
     const apiKey = readClaudeApiKey();
     if (apiKey) env[CODEX_GATEWAY_ENV_KEY] = apiKey;

--- a/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
+++ b/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
@@ -12,7 +12,7 @@
  * 因此去重取首个即可，不会丢信息。
  *
  * 顺序契约（no-break）：派生结果必须逐字逐序复现迁移前的有效列表
- * （cc = 旧 CLAUDE_MODELS 序 then XD 追加序；codex = 旧 CODEX_MODELS 序 then 骨折追加序）。
+ * （cc = 旧 CLAUDE_MODELS 序 then XD 追加序；codex = 旧 CODEX_MODELS 序 then 折扣追加序）。
  * 由 maker-host 的 catalogDerivedModels.test.ts 守。
  */
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -117,7 +117,7 @@ export function getCodexProxyAuthInjection(): CodexProxyAuthInjection {
 }
 
 // gateway api key reader —— 由 host 注入(readClaudeApiKey), 避免 codex-proxy-host 直接 import
-// auth-adapters(重模块, 会拖累单测加载 / 埋循环依赖)。proxy 给骨折 / api 流量换 gateway key 时调它。
+// auth-adapters(重模块, 会拖累单测加载 / 埋循环依赖)。proxy 给折扣 / api 流量换 gateway key 时调它。
 let _readGatewayKey: () => string | null = () => null;
 export function setCodexProxyGatewayKeyReader(fn: () => string | null): void {
   _readGatewayKey = fn;
@@ -1193,7 +1193,7 @@ function createCodexResponseObserver(): ResponseObserver {
  * (会话显式选了供应商时由 resolveSessionRouteDecision 优先接管,不会走到这里。)
  *   - env-key spawn(codex 已带 gateway key): 全程 null(走默认上游 gateway, 不动 header)。
  *   - oauth-bearer spawn(codex 带 OAuth token):
- *       codex/ 骨折模型 → 换 gateway key, 默认上游(gateway); 无 key 则 null(passthrough, 上游会 401)。
+ *       codex/ 折扣模型 → 换 gateway key, 默认上游(gateway); 无 key 则 null(passthrough, 上游会 401)。
  *       普通模型        → override 上游到 ChatGPT, 透传 OAuth token(不动 header)= 订阅默认。
  * 退役了全局 api 开关:「普通模型也走网关」改由 per-session 显式选 XD 来源触发,不再是全局默认。
  */
@@ -1279,7 +1279,7 @@ export function createModelRoutingTransform(): RoutingTransform {
 
     // ② 未显式选供应商 → 回落默认路由(decideCodexRoute,与未升级行为字节级一致)。
     const decision = decideCodexRoute({ model, authInjection, gatewayKey });
-    // codex/ 骨折模型该走 gateway 换 key 但没配 key → null(passthrough), 上游大概率 401, 记一条诊断。
+    // codex/ 折扣模型该走 gateway 换 key 但没配 key → null(passthrough), 上游大概率 401, 记一条诊断。
     if (decision === null && authInjection === 'oauth-bearer' && model
       && model.startsWith('codex/') && !gatewayKey) {
       log.warn('codex routing → gateway but no api key configured; passthrough (可能 401)', { model });

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -423,7 +423,7 @@ export function getMaker(): Maker {
       makerMemory: makerMemoryManager,
       // 模型清单 SSoT = 目录（providers.json，OSS 运行时真源 / bundled 兜底）。maker-core 的
       // CODEX_MODELS 已删、availableModels 起始为空；host 从账号可选目录派生 codex 列表注入
-      // （gpt 原生 + codex/ 骨折网关路由）。「骨折GPT」codex/ 仍是「XD 网关来源」,渲染层按
+      // （gpt 原生 + codex/ 折扣网关路由）。「折扣GPT」codex/ 仍是「XD 网关来源」,渲染层按
       // 「XD 网关已连接」gate 可见性（ModelSelector onlyConnected / CreateWorkerPopover / ScheduleChips）。
       capabilityAdditions: {
         availableModels: deriveAvailableModels(getDesktopSelectableCatalog(), 'codex'),

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -531,7 +531,7 @@ describe('applyRuntimeSetModelChange', () => {
   });
 
   it('cancels a stale pending switch when a model-only change no longer crosses families', async () => {
-    // review P1(2026-07-04 第二轮):骨折模型(codex/ 前缀)登记 pending 后,用户
+    // review P1(2026-07-04 第二轮):折扣模型(codex/ 前缀)登记 pending 后,用户
     // 通过模型选择器切回普通模型 —— model-only 调用不带 providerId,必须以 pending
     // 的 providerId 为基准重评估;不再跨族 → 取消 pending。
     const sessionId = rememberSession('runtime-set-model-cancel-pending-model-only');

--- a/apps/desktop/src/main/maker-ipc/authHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/authHandlers.ts
@@ -52,7 +52,7 @@ export function registerMakerAuthHandlers(
   });
 
   // presence-only:只回「有没有配 key」,绝不回密钥本体。device-link 控制端(手机 / 远程桌面)
-  // 用它决定骨折版(codex/)行是否置灰 —— key 与请求都在被控端,这里才是判定真相。
+  // 用它决定折扣版(codex/)行是否置灰 —— key 与请求都在被控端,这里才是判定真相。
   registry.handle(MAKER_INVOKE.API_KEY_PRESENT, async (): Promise<{ present: boolean }> => {
     return { present: !!readApiKey() };
   });

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -216,7 +216,7 @@ export const MAKER_INVOKE = {
   AUTH_CANCEL_LOGIN: 'maker:auth:cancel-login',
   AUTH_LOGOUT: 'maker:auth:logout',
   // 网关 API key presence-only 探测(只回 { present: boolean },不回密钥材料)——
-  // 供 device-link 控制端(手机 / 远程桌面)判断骨折版是否置灰;判定真相在被控端
+  // 供 device-link 控制端(手机 / 远程桌面)判断折扣版是否置灰;判定真相在被控端
   // (key 存被控端 safeStorage)。见 device-link allowlist 的窄口径例外注释。
   API_KEY_PRESENT: 'maker:api-key:present',
   // Agent 联合状态 (取代老 codex:binary:status) —— 走 Maker.getAgentStatus

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -2999,7 +2999,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           }).finally(() => rebroadcastCodexTodayUsage());
 
           // Codex SDK 不报 $, 用价格表折算。普通模型 + oauth(订阅)显示为 token 价值;api 模式和 codex/
-          // 骨折模型走 gateway API, 显示为 API cost。远端 Codex 由远端 daemon
+          // 折扣模型走 gateway API, 显示为 API cost。远端 Codex 由远端 daemon
           // 路由,本机不知道远端 OAuth/API 事实,因此只显示 token 价值,不写本地
           // gateway cost。只有真实本地 API cost 写入 sessions.total_cost_usd,
           // 避免 scheduler 的 Cost 汇总混入订阅价值或远端账号消耗。

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -54,7 +54,7 @@ export interface ApplyRuntimeSetModelChangeInput {
   /**
    * 「无需切换」分支清掉旧 pending(后选覆盖先选)。典型场景:deferred 登记后
    * renderer 持久化失败发起回滚 set-model、用户改选回与当前进程同族的来源、或
-   * model-only 变更后 pending 的目标形态与当前进程重新同族(如从骨折模型切回
+   * model-only 变更后 pending 的目标形态与当前进程重新同族(如从折扣模型切回
    * 普通模型)—— 不清会让已被放弃的 pending 在 turn 结束时照样生效。
    */
   clearPendingCredentialSwitch?: (sessionId: string, opts?: { wake?: boolean }) => void;
@@ -68,7 +68,7 @@ export interface ApplyRuntimeSetModelChangeInput {
    * 读取该会话当前登记的 pending 目标。model-only 调用(providerId=undefined)时
    * pending.providerId 代表用户已选定、尚未生效的来源意图,必须以它为基准评估新
    * 模型是否仍需切换 —— 仍需则更新 pending 的模型,不需则取消 pending(review
-   * P1 2026-07-04:骨折模型 pending 后切回普通模型,旧实现不清 pending)。
+   * P1 2026-07-04:折扣模型 pending 后切回普通模型,旧实现不清 pending)。
    */
   getPendingCredentialSwitch?: (
     sessionId: string,
@@ -241,7 +241,7 @@ export async function applyRuntimeSetModelChange(
     input.clearPendingCredentialSwitch?.(sessionId);
   } else if (pendingTarget !== undefined) {
     // model-only 变更 + 已有 pending:能走到无需切换分支,说明按 pending 来源 +
-    // 新模型评估后凭证形态已与当前进程同族(典型:骨折模型 pending 后切回普通
+    // 新模型评估后凭证形态已与当前进程同族(典型:折扣模型 pending 后切回普通
     // 模型)→ 切换意图不复存在,取消 pending(review P1)。
     input.clearPendingCredentialSwitch?.(sessionId);
     logger?.info('set-model: cancelled stale pending credential switch after model-only change', {

--- a/apps/desktop/src/renderer/__tests__/modelDefinitionsDeviceId.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelDefinitionsDeviceId.test.ts
@@ -1,6 +1,6 @@
 /**
  * modelDefinitions 的 deviceId 透传单测(device-link「以被控端为准」)。
- * 模型 id 跨设备不唯一(fork 自定义 contextWindow / 骨折路由),远程会话必须读被控端 caps —— 不能用本地替代。
+ * 模型 id 跨设备不唯一(fork 自定义 contextWindow / 折扣路由),远程会话必须读被控端 caps —— 不能用本地替代。
  * 复用 useAgentCapabilities 的同一份模块级缓存(同一 module graph 下 import),vi.resetModules 保证干净。
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -20,8 +20,6 @@ vi.mock('react-i18next', async (importOriginal) => ({
         model?: string;
         effort?: string;
         price?: string;
-        percent?: string;
-        rate?: string;
       },
     ) => {
       const translations: Record<string, string> = {
@@ -44,9 +42,6 @@ vi.mock('react-i18next', async (importOriginal) => ({
       }
       if (key === 'newChat.modelSelector.trigger.ariaWithEffort') {
         return `Select model. Current: ${options?.model}, effort: ${options?.effort}`;
-      }
-      if (key === 'newChat.modelSelector.pricing.discount') {
-        return `立省 ${options?.percent}%`;
       }
       return translations[key] ?? options?.defaultValue ?? key;
     },
@@ -465,7 +460,7 @@ describe('ModelSelector trigger variants', () => {
     expect(pricingRef.renderCalls).toBe(1);
   });
 
-  it('shows Gateway discount and free promotions in the selected-model trigger', () => {
+  it('shows only the free promotion in the selected-model trigger', () => {
     providersRef.providers = [
       {
         id: 'xd',
@@ -510,7 +505,7 @@ describe('ModelSelector trigger variants', () => {
     };
 
     try {
-      const discounted = render(
+      const belowStandardPrice = render(
         React.createElement(ModelSelector, {
           modelId: 'claude-opus-4-8',
           effort: 'high',
@@ -521,12 +516,10 @@ describe('ModelSelector trigger variants', () => {
           onProviderChange: vi.fn(),
         }),
       );
-      const discountTrigger = screen.getByRole('button', { name: /Current: Opus 4\.8/ });
-      const discountBadge = within(discountTrigger).getByText('立省 50%');
-      expect(discountBadge.hasAttribute('data-model-promotion-badge')).toBe(true);
-      expect(discountBadge.className).toContain('bg-[var(--accent-cta-bg)]');
-      expect(discountBadge.className).toContain('text-[var(--accent-pure-cta-fg)]');
-      discounted.unmount();
+      // 折价不再有徽标:实际价低于标准价的模型,trigger 上不挂任何促销徽标。
+      const belowStandardTrigger = screen.getByRole('button', { name: /Current: Opus 4\.8/ });
+      expect(belowStandardTrigger.querySelector('[data-model-promotion-badge]')).toBeNull();
+      belowStandardPrice.unmount();
 
       pricingRef.pricing = {};
       render(
@@ -620,7 +613,7 @@ describe('ModelSelector trigger variants', () => {
       const row = screen.getByRole('option', { name: /Opus 4\.8/ });
       expect(row.textContent).not.toContain('¥12 / ¥36');
       expect(row.textContent).not.toContain('¥6 / ¥18');
-      expect(within(row).queryByText('立省 50%')).toBeNull();
+      expect(row.querySelector('[data-model-promotion-badge]')).toBeNull();
 
       fireEvent.pointerEnter(row);
       expect(
@@ -798,7 +791,7 @@ describe('ModelSelector trigger variants', () => {
     vi.useRealTimers();
   });
 
-  it('keeps discounted Gateway prices aligned between the row and model details', () => {
+  it('shows the effective Gateway price without an original-price comparison', () => {
     providersRef.providers = [
       {
         id: 'xd',
@@ -847,28 +840,19 @@ describe('ModelSelector trigger variants', () => {
         }),
       );
 
+      // 行内只显示实际价:标准价不再以划线形式并排,也不再挂折价徽标。
       const row = screen.getByRole('option', { name: /Qwen 3\.7/ });
       expect(row.textContent).toContain('¥6 / ¥18');
-      expect(row.textContent).toContain('¥12 / ¥36');
-      const rowBadge = within(row).getByText('立省 50%');
-      expect(rowBadge.hasAttribute('data-model-promotion-badge')).toBe(true);
-      expect(rowBadge.parentElement?.hasAttribute('data-model-tags')).toBe(true);
-      const priceStack = within(row).getByText('¥6 / ¥18').parentElement;
-      expect(priceStack?.getAttribute('data-model-price-stack')).toBe('true');
-      expect(priceStack).not.toBe(rowBadge.parentElement);
-      expect(rowBadge.compareDocumentPosition(priceStack as Node)).toBe(
-        Node.DOCUMENT_POSITION_FOLLOWING,
-      );
+      expect(row.textContent).not.toContain('¥12 / ¥36');
+      expect(row.querySelector('[data-model-promotion-badge]')).toBeNull();
 
       fireEvent.pointerEnter(row);
       const details = screen.getByRole('group', { name: /Qwen 3\.7/ });
       expect(within(details).getByText('¥6')).toBeTruthy();
       expect(within(details).getByText('¥18')).toBeTruthy();
-      expect(within(details).getByText('¥12').className).toContain('line-through');
-      expect(within(details).getByText('¥36').className).toContain('line-through');
-      const detailsBadge = within(details).getByText('立省 50%');
-      expect(detailsBadge.parentElement?.hasAttribute('data-model-tags')).toBe(true);
-      expect(detailsBadge.parentElement?.className).toContain('ml-auto');
+      expect(within(details).queryByText('¥12')).toBeNull();
+      expect(within(details).queryByText('¥36')).toBeNull();
+      expect(details.querySelector('[data-model-promotion-badge]')).toBeNull();
     } finally {
       providersRef.providers = providersRef.DEFAULT_PROVIDERS;
       pricingRef.pricing = pricingRef.DEFAULT_PRICING;
@@ -933,7 +917,7 @@ describe('ModelSelector trigger variants', () => {
       const rowBadge = within(row).getByText('限时免费');
       expect(rowBadge.hasAttribute('data-model-promotion-badge')).toBe(true);
       expect(rowBadge.parentElement?.hasAttribute('data-model-tags')).toBe(true);
-      expect(row.textContent).not.toContain('立省 100%');
+      expect(row.querySelectorAll('[data-model-promotion-badge]')).toHaveLength(1);
 
       fireEvent.pointerEnter(row);
       const details = screen.getByRole('group', { name: /Free Gateway Model/ });

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -48,8 +48,8 @@ interface ErrorBannerProps {
   remoteHostId?: string;
   /** device-link 被控端设备 id。非空表示 turn 不在本机执行，本机认证恢复入口必须禁用。 */
   deviceLinkDeviceId?: string | null;
-  /** 当前 session 的 model id。骨折版 GPT (budget, `codex/` 前缀) 报错时,在通用
-   *  错误文案后追加一句「可切到普通版 GPT 试试」的引导 (骨折版走 gateway, 偶发
+  /** 当前 session 的 model id。折扣版 GPT (budget, `codex/` 前缀) 报错时,在通用
+   *  错误文案后追加一句「可切到普通版 GPT 试试」的引导 (折扣版走 gateway, 偶发
    *  限流/不可用时,普通版往往能正常出)。仅对没有专属引导的通用错误分支生效,
    *  避免和 auth/stale/encrypted 等分支的具体指引打架。 */
   modelId?: string;
@@ -197,7 +197,7 @@ export function ErrorBanner({
 
   // hasSpecialGuidance: 是否命中下面任一「有专属可操作指引」的特殊分支。用一个在
   // else 兜底里翻转的标志, 而不是另写一遍 5 个条件取反 —— 将来新增特殊分支只要照常
-  // 加 else if, 标志自动保持 true, 骨折版提示不会误叠加 (无需记得同步维护条件表)。
+  // 加 else if, 标志自动保持 true, 折扣版提示不会误叠加 (无需记得同步维护条件表)。
   let displayError: string;
   let hasSpecialGuidance = true;
   if (isCredentialSwitchBusy) {
@@ -233,11 +233,11 @@ export function ErrorBanner({
     hasSpecialGuidance = false;
   }
 
-  // 骨折版 GPT (budget, `codex/` 前缀) 走 gateway, 偶发限流 / 后端不可用时, 普通版
+  // 折扣版 GPT (budget, `codex/` 前缀) 走 gateway, 偶发限流 / 后端不可用时, 普通版
   // 往往能正常出。仅在通用错误分支 (上面没命中任何特殊分支) 追加一句切普通版的引导
   // —— auth/stale/encrypted/session-expired 分支各自已有指引, 叠加会噪 / 打架。
   // budget 判定与全项目一致: `codex/` 前缀。
-  // 例外:网络类分支(终止态)仍叠加 —— 骨折版 gateway 挂掉恰恰多表现为 502 /
+  // 例外:网络类分支(终止态)仍叠加 —— 折扣版 gateway 挂掉恰恰多表现为 502 /
   // upstream unreachable,「切普通版试试」对症;自动重试中不叠(用户无需行动)。
   const isBudgetModel = !!modelId && modelId.startsWith('codex/');
   const showBudgetHint =

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -4439,7 +4439,7 @@ export function ChatInput({
       const isSourceSessionCurrent = () =>
         isSessionScopeCurrent(sourceSessionId, currentSessionIdRef.current);
       // 容量护栏(与 handleModelChange 同款): 切来源若连带换到更小窗口的模型
-      // (典型: 官方 Claude 1M → 骨折 GPT 272K, 在选择器里是跨分组点击、走本路径而非
+      // (典型: 官方 Claude 1M → 折扣 GPT 272K, 在选择器里是跨分组点击、走本路径而非
       // handleModelChange —— 2026-07-06 实测踩中), 同样要先过上下文容量确认。
       // 同模型只切来源不拦: 窗口按 model id 取自目录, 来源不变窗口, 无新增风险。
       // 放在函数最前: 本地分支此前无任何乐观状态写入, 用户取消 = 零副作用直接 return。

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -28,7 +28,6 @@ import { useProviders } from '@/hooks/useProviders';
 import { useDeviceProviders } from '@/hooks/useDeviceProviders';
 import {
   formatModelPricePair,
-  modelPriceDiscountLabelValues,
   modelPriceDetailRows,
   modelPricePresentation,
 } from '@/lib/modelPriceFormat';
@@ -451,7 +450,7 @@ function ModelSelectorContentView({
   // 同时拉两个 agent —— vendorKey 不传时把两边模型一起展示。hooks 必须按固定顺序调用。
   const cc = useAgentCapabilities('claude-code', deviceId);
   const codex = useAgentCapabilities('codex', deviceId);
-  // 本机骨折 GPT 仍按本机 API key gate；device-link 必须只看被控端 provider 状态。
+  // 本机折扣 GPT 仍按本机 API key gate；device-link 必须只看被控端 provider 状态。
   // 旧被控端不支持 provider:list 时按远端 capabilities 退化，不得误用控制端 key。
   const { hasSavedKey } = useApiKey();
   // 供应商来源:本机会话用本机 useProviders;device-link 远程会话用**被控端**供应商目录
@@ -915,17 +914,8 @@ function ModelSelectorContentView({
   const editingPricePresentation = editingModel
     ? pricePresentationOf(editingProvider?.id ?? editingProviderId, editingModel.id)
     : null;
-  const editingDiscount =
-    editingPricePresentation?.kind === 'priced' ? editingPricePresentation.discount : undefined;
   const editingPromotionLabel =
-    editingPricePresentation?.kind === 'free'
-      ? t('newChat.modelSelector.pricing.free')
-      : editingDiscount !== undefined
-        ? t(
-            'newChat.modelSelector.pricing.discount',
-            modelPriceDiscountLabelValues(editingDiscount),
-          )
-        : null;
+    editingPricePresentation?.kind === 'free' ? t('newChat.modelSelector.pricing.free') : null;
 
   // 每个模型行的信息 / 配置内容由一个独立的 portaled Popover 承载,而不是拼进主菜单宽度。
   // 这样浮层会像 Hermes 的 Radix submenu 一样贴着当前行移动,切行不触发主菜单重排。
@@ -1027,10 +1017,7 @@ function ModelSelectorContentView({
             {editingPricePresentation.kind === 'priced' && (
               <>
                 <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-1 text-12 leading-[1.4]">
-                  {modelPriceDetailRows(
-                    editingPricePresentation.current,
-                    editingPricePresentation.original,
-                  ).map((row) => (
+                  {modelPriceDetailRows(editingPricePresentation.current).map((row) => (
                     <div key={row.kind} className="contents">
                       <span className="text-[var(--text-secondary)]">
                         {t(`newChat.modelSelector.pricing.${row.kind}`)}
@@ -1040,11 +1027,6 @@ function ModelSelectorContentView({
                           {editingPricePresentation.current.approximate ? '≈' : ''}
                           {row.value}
                         </span>
-                        {row.originalValue && (
-                          <span className="text-[var(--text-tertiary)] line-through">
-                            {row.originalValue}
-                          </span>
-                        )}
                       </span>
                     </div>
                   ))}
@@ -1091,21 +1073,13 @@ function ModelSelectorContentView({
   const renderModelItem = (provider: ProviderView | null, model: RowModel) => {
     const providerId = provider?.id ?? null;
     const isSelected = isSelectedRow(providerId, model.id);
-    const isBudgetModel = model.id.startsWith('codex/');
     const isSubscriptionModel = provider?.access?.kind === 'subscription';
     const disabled = modelDisabledOf(model.id);
     const rowEffort = rowEffortOf(providerId, model);
     const rowFastOn = fastOnOf(providerId, model);
     const rowPrice = pricePresentationOf(providerId, model.id);
     const rowPromotionLabel =
-      rowPrice?.kind === 'free'
-        ? t('newChat.modelSelector.pricing.free')
-        : rowPrice?.kind === 'priced' && rowPrice.discount !== undefined
-          ? t(
-              'newChat.modelSelector.pricing.discount',
-              modelPriceDiscountLabelValues(rowPrice.discount),
-            )
-          : null;
+      rowPrice?.kind === 'free' ? t('newChat.modelSelector.pricing.free') : null;
     // 信息面板对所有可用模型开放;能否编辑 effort / Fast 在面板内部另行判定。
     // session-agent-switch 浏览目标引擎态同样开放:选模型前正需要看描述/上下文/价格/来源;
     // 面板内配置写的是**目标引擎**的 per-(来源,模型) 全局预设(currentAgentKind 已随浏览态
@@ -1217,16 +1191,11 @@ function ModelSelectorContentView({
                     />
                   )}
                 </span>
-                {(isSubscriptionModel || isBudgetModel || rowPromotionLabel) && (
+                {(isSubscriptionModel || rowPromotionLabel) && (
                   <span data-model-tags className="ml-auto flex shrink-0 items-center gap-1.5">
                     {isSubscriptionModel && (
                       <span className="inline-flex shrink-0 items-center rounded-full bg-[var(--surface-chip)] px-2 py-[1px] text-[11px] font-medium text-[var(--text-secondary)]">
                         {t('settings.providers.models.subscription')}
-                      </span>
-                    )}
-                    {isBudgetModel && (
-                      <span className="inline-flex shrink-0 items-center rounded-full bg-[var(--model-budget-badge-bg)] px-2 py-[1px] text-[11px] font-medium text-[var(--model-budget-badge-text)]">
-                        {t('newChat.modelSelector.meta.budgetDiscount')}
                       </span>
                     )}
                     {rowPromotionLabel && (
@@ -1239,21 +1208,10 @@ function ModelSelectorContentView({
             {(rowPrice?.kind === 'priced' || isSelected) && (
               <span className="ml-2 flex shrink-0 items-center gap-1.5">
                 {rowPrice?.kind === 'priced' && (
-                  <span
-                    data-model-price-stack={rowPrice.original ? 'true' : undefined}
-                    className={cn(
-                      'flex tabular-nums text-11 font-normal leading-[1.25]',
-                      rowPrice.original ? 'flex-col items-end' : 'items-center',
-                    )}
-                  >
+                  <span className="flex items-center tabular-nums text-11 font-normal leading-[1.25]">
                     <span className="text-[var(--text-secondary)]">
                       {formatModelPricePair(rowPrice.current)}
                     </span>
-                    {rowPrice.original && (
-                      <span className="text-[var(--text-tertiary)] line-through">
-                        {formatModelPricePair(rowPrice.original)}
-                      </span>
-                    )}
                   </span>
                 )}
                 {isSelected && (
@@ -1617,15 +1575,7 @@ export function ModelSelector({
     );
   })();
   const triggerPromotionLabel =
-    triggerPricePresentation?.kind === 'free'
-      ? t('newChat.modelSelector.pricing.free')
-      : triggerPricePresentation?.kind === 'priced' &&
-          triggerPricePresentation.discount !== undefined
-        ? t(
-            'newChat.modelSelector.pricing.discount',
-            modelPriceDiscountLabelValues(triggerPricePresentation.discount),
-          )
-        : null;
+    triggerPricePresentation?.kind === 'free' ? t('newChat.modelSelector.pricing.free') : null;
   // 断开态同一规则,只是来源取「真实断开来源」(currentProviderId)。
   const disconnectedProvider = currentProviderId
     ? providers.find((p) => p.id === currentProviderId)

--- a/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
+++ b/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
@@ -68,7 +68,7 @@ export const CATEGORY_LABEL_KEY: Record<ModelCategory, string> = {
   other: 'newChat.modelSelector.category.other',
 };
 
-// 按 model.id 前缀粗分类: claude-* → Anthropic, gpt-* → GPT, codex/* → 骨折GPT (gateway 低价路由),
+// 按 model.id 前缀粗分类: claude-* → Anthropic, gpt-* → GPT, codex/* → 折扣GPT (gateway 低价路由),
 // gemini-* → Google, 其余 (moonshotai/qwen/glm/...) 一律落到 China。新增国产模型不需要改这里。
 export function categorize(id: string): ModelCategory {
   if (id.startsWith('claude-')) return 'anthropic';

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -11,8 +11,8 @@
  * imDefaultSettingsGet('slack')(桌面新会话默认)+ 本机 capabilities; 权限默认恒
  * bypassPermissions(完全访问)。
  *
- * 模型显示名带分组区分: 骨折版(group='gpt-budget')与官方版 displayName
- * 故意同名, 下拉里给骨折版加「(骨折GPT)」后缀(复用桌面模型选择器的分组
+ * 模型显示名带分组区分: 折扣版(group='gpt-budget')与官方版 displayName
+ * 故意同名, 下拉里给折扣版加「(GPT 折扣)」后缀(复用桌面模型选择器的分组
  * 文案), 否则出现两个一模一样的 GPT-5.5(线上实撞)。
  *
  * 数据正本在 IM hook server 的 provider prefs 表：Slack 与 Telegram 按
@@ -455,7 +455,7 @@ export function WorkspacePrefsEditor({
         null)
       : null;
 
-  /** 模型显示名(骨折版加分组后缀区分同名官方版); 不在清单显示裸 id。 */
+  /** 模型显示名(折扣版加分组后缀区分同名官方版); 不在清单显示裸 id。 */
   const modelLabel = useCallback(
     (id: string | null): string => {
       if (id === null) return t('settings.tina.prefs.none');

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -15,13 +15,13 @@
  * Codex 订阅形态主 chip 显示服务端下发的各限额窗口剩余 / 当前会话 USD 折算金额。
  * 窗口构成不做任何假设,完全以上游接口返回为准 —— OpenAI 会调整窗口策略
  * (典型:5h + 周双窗;2026-07 曾一度取消 5h 窗口,且可能随时恢复)。
- * 订阅模式下 USD 是 token 价值,API / codex/ 骨折 GPT 下是 gateway API 单价折算 cost。
+ * 订阅模式下 USD 是 token 价值,API / codex/ 折扣 GPT 下是 gateway API 单价折算 cost。
  * credits / token 明细只放 tooltip,不占主 chip。
  *
  * Codex tooltip 按当前会话实际 runtime route + 当前模型分两种:
  *   - oauth 模式 + 当前 app-server 以 OAuth bearer 启动 + 普通模型: 显示各限额窗口
  *     剩余额度、当前会话 token 累计、credits 明细。订阅没有单一 per-token 余额。
- *   - api 模式、app-server 以 gateway key 启动、或当前模型是 codex/ 骨折 GPT:
+ *   - api 模式、app-server 以 gateway key 启动、或当前模型是 codex/ 折扣 GPT:
  *     与 cc 同一把 XD key、同一套 LiteLLM 计费,直接复用 cc 的 daily/monthly/key
  *     cost 形态 (session 仍显示 USD 折算累计)。
  *
@@ -907,7 +907,7 @@ function renderSegmentedLabel(segments: React.ReactNode[]): React.ReactNode {
 
 interface TodaySpendChipProps {
   vendorKey?: 'cc' | 'codex';
-  /** 当前会话模型;codex/ 骨折 GPT 恒走 gateway API, 即使 oauth-bearer spawn 也按 API 形态显示。 */
+  /** 当前会话模型;codex/ 折扣 GPT 恒走 gateway API, 即使 oauth-bearer spawn 也按 API 形态显示。 */
   modelId?: string | null;
   /**
    * 本会话显式选定的供应商('anthropic' / 'openai' / 'xd' / null=默认路由)。
@@ -1001,7 +1001,7 @@ export function TodaySpendChip({
   const isCodexXaiProvider =
     vendorKey === 'codex' && typeof modelId === 'string' && modelId.startsWith(XAI_MODEL_PREFIX);
   // codex 走订阅价值估算:ChatGPT 订阅需要 oauth-bearer 且未显式选 XD;xAI 由 proxy 注入
-  // SuperGrok OAuth,不依赖 Codex 子进程凭证。env-key fallback、codex/ 骨折、或显式选 XD
+  // SuperGrok OAuth,不依赖 Codex 子进程凭证。env-key fallback、codex/ 折扣、或显式选 XD
   // → 复用 cc 的 cost tooltip 形态。远端 Codex 的事实在远端 daemon 上,本机只记录 token
   // 价值估算,不写本地 gateway cost。
   const isCodexOauth = vendorKey === 'codex' && !isCodexXaiProvider && (

--- a/apps/desktop/src/renderer/features/scheduler/components/ScheduleChips.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/ScheduleChips.tsx
@@ -1088,7 +1088,7 @@ export function ModelEffortChip({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const caps = useAgentCapabilities(agentKind);
-  // 触发器(trigger)展示用:仍按 codex/ 骨折模型的 XD 网关来源可见性过滤,算出当前
+  // 触发器(trigger)展示用:仍按 codex/ 折扣模型的 XD 网关来源可见性过滤,算出当前
   // 选中模型名。下拉内容本体改用聊天的 ModelSelectorContent(它内部按来源/api-key 自行
   // 过滤 + 分组),这里只为 trigger 文案保留最小化 model 解析。
   const { providers } = useProviders();

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -24,7 +24,7 @@ export type AgentKind = 'claude-code' | 'codex';
 export interface ModelDescriptor {
   id: string;
   displayName: string;
-  /** 目录分组 id(如 'gpt-budget'): 骨折版与官方版 displayName 同名, 靠它区分。 */
+  /** 目录分组 id(如 'gpt-budget'): 折扣版与官方版 displayName 同名, 靠它区分。 */
   group?: string;
   description?: string;
   contextWindow: number;

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3847,7 +3847,6 @@
         "cacheRead": "Cache read",
         "cacheCreate": "Cache write",
         "free": "Limited-time free",
-        "discount": "Save {{percent}}%",
         "perMillion": "Standard model pricing",
         "fixedFx": "Estimated at the fixed rate of 1 USD = 6.7 CNY",
         "subscriptionEstimate": "Value estimate, not an actual bill"
@@ -3860,7 +3859,7 @@
       "category": {
         "anthropic": "Anthropic",
         "gpt": "OpenAI",
-        "budget": "85% off",
+        "budget": "GPT Discount",
         "grok": "xAI",
         "google": "Google",
         "china": "Domestic",
@@ -3878,8 +3877,7 @@
       "meta": {
         "context": "{{value}} context",
         "price": "{{input}}/{{output}} per 1M",
-        "fastBadge": "Fast",
-        "budgetDiscount": "85% off"
+        "fastBadge": "Fast"
       },
       "source": {
         "railLabel": "Source",
@@ -5859,7 +5857,7 @@
         "category": {
           "anthropic": "Anthropic",
           "gpt": "GPT",
-          "gpt-budget": "GPT (85% off)",
+          "gpt-budget": "GPT Discount",
           "google": "Google",
           "china": "China"
         },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3846,7 +3846,6 @@
         "cacheRead": "キャッシュ読み取り",
         "cacheCreate": "キャッシュ書き込み",
         "free": "期間限定無料",
-        "discount": "{{percent}}%お得",
         "perMillion": "モデル標準価格",
         "fixedFx": "固定レート 1 USD = 6.7 CNY による概算",
         "subscriptionEstimate": "価値の推定であり、実際の請求額ではありません"
@@ -3859,7 +3858,7 @@
       "category": {
         "anthropic": "Anthropic",
         "gpt": "OpenAI",
-        "budget": "85%オフ",
+        "budget": "GPT 割引",
         "grok": "xAI",
         "google": "Google",
         "china": "国内",
@@ -3877,8 +3876,7 @@
       "meta": {
         "context": "コンテキスト {{value}}",
         "price": "{{input}}/{{output}} / 100万",
-        "fastBadge": "高速",
-        "budgetDiscount": "85%オフ"
+        "fastBadge": "高速"
       },
       "source": {
         "railLabel": "ソース",
@@ -5849,7 +5847,7 @@
         "category": {
           "anthropic": "Anthropic",
           "gpt": "GPT",
-          "gpt-budget": "GPT（85%オフ）",
+          "gpt-budget": "GPT 割引",
           "google": "Google",
           "china": "China"
         },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3846,7 +3846,6 @@
         "cacheRead": "캐시 읽기",
         "cacheCreate": "캐시 쓰기",
         "free": "기간 한정 무료",
-        "discount": "{{percent}}% 절약",
         "perMillion": "모델 표준 가격",
         "fixedFx": "고정 환율 1 USD = 6.7 CNY 기준 추정",
         "subscriptionEstimate": "가치 추정치이며 실제 청구 금액이 아닙니다"
@@ -3859,7 +3858,7 @@
       "category": {
         "anthropic": "Anthropic",
         "gpt": "OpenAI",
-        "budget": "85% 할인",
+        "budget": "GPT 할인",
         "grok": "xAI",
         "google": "Google",
         "china": "국내",
@@ -3877,8 +3876,7 @@
       "meta": {
         "context": "컨텍스트 {{value}}",
         "price": "{{input}}/{{output}} / 100만",
-        "fastBadge": "고속",
-        "budgetDiscount": "85% 할인"
+        "fastBadge": "고속"
       },
       "source": {
         "railLabel": "소스",
@@ -5849,7 +5847,7 @@
         "category": {
           "anthropic": "Anthropic",
           "gpt": "GPT",
-          "gpt-budget": "GPT (85% 할인)",
+          "gpt-budget": "GPT 할인",
           "google": "Google",
           "china": "China"
         },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3846,7 +3846,6 @@
         "cacheRead": "缓存读取",
         "cacheCreate": "缓存写入",
         "free": "限时免费",
-        "discount": "立省 {{percent}}%",
         "perMillion": "模型标准价格",
         "fixedFx": "按固定汇率 1 USD = 6.7 CNY 约算",
         "subscriptionEstimate": "价值估算，不代表实际账单"
@@ -3859,7 +3858,7 @@
       "category": {
         "anthropic": "Anthropic",
         "gpt": "OpenAI",
-        "budget": "立省 85%",
+        "budget": "GPT 折扣",
         "grok": "xAI",
         "google": "Google",
         "china": "国内",
@@ -3877,8 +3876,7 @@
       "meta": {
         "context": "{{value}} 上下文",
         "price": "{{input}}/{{output}} / 百万",
-        "fastBadge": "快速",
-        "budgetDiscount": "立省 85%"
+        "fastBadge": "快速"
       },
       "source": {
         "railLabel": "来源",
@@ -5849,7 +5847,7 @@
         "category": {
           "anthropic": "Anthropic",
           "gpt": "GPT",
-          "gpt-budget": "GPT（立省 85%）",
+          "gpt-budget": "GPT 折扣",
           "google": "Google",
           "china": "China"
         },

--- a/apps/desktop/src/renderer/lib/__tests__/modelPriceFormat.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/modelPriceFormat.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import type { ModelPriceQuote } from '../../../shared/regionalMoney';
 import {
   formatModelPricePair,
-  modelPriceDiscountLabelValues,
   modelPriceDetailRows,
   modelPricePresentation,
 } from '../modelPriceFormat';
@@ -50,30 +49,17 @@ describe('modelPriceFormat', () => {
     ]);
   });
 
-  it('uses the effective price while retaining the original for a 50% discount', () => {
-    const original = quote({ inputPerMtok: 12, outputPerMtok: 36 });
-    expect(modelPricePresentation(original, { input: 6, output: 18 })).toEqual({
+  it('uses the effective price when it is a uniform scaling of the standard price', () => {
+    const standard = quote({ inputPerMtok: 12, outputPerMtok: 36 });
+    expect(modelPricePresentation(standard, { input: 6, output: 18 })).toEqual({
       kind: 'priced',
       current: quote({ inputPerMtok: 6, outputPerMtok: 18 }),
-      original,
-      discount: 0.5,
-    });
-    expect(modelPriceDiscountLabelValues(0.5)).toEqual({
-      percent: '50',
-      rate: '5',
-    });
-    expect(modelPriceDiscountLabelValues(0.2)).toEqual({
-      percent: '20',
-      rate: '8',
     });
     expect(
-      modelPriceDetailRows(
-        quote({ inputPerMtok: 6, outputPerMtok: 18, cacheReadPerMtok: 0.3 }),
-        original,
-      ),
+      modelPriceDetailRows(quote({ inputPerMtok: 6, outputPerMtok: 18, cacheReadPerMtok: 0.3 })),
     ).toEqual([
-      { kind: 'input', value: '¥6', originalValue: '¥12' },
-      { kind: 'output', value: '¥18', originalValue: '¥36' },
+      { kind: 'input', value: '¥6' },
+      { kind: 'output', value: '¥18' },
       { kind: 'cacheRead', value: '¥0.3' },
     ]);
   });
@@ -85,17 +71,15 @@ describe('modelPriceFormat', () => {
     expect(modelPricePresentation(undefined, { input: 0, output: 0 })).toBeNull();
   });
 
-  it('keeps double-zero effective prices as a 100% discount when the quote is nonzero', () => {
-    const original = quote({ inputPerMtok: 12, outputPerMtok: 36 });
-    expect(modelPricePresentation(original, { input: 0, output: 0 })).toEqual({
+  it('shows double-zero effective prices as zero when the quote is nonzero', () => {
+    const standard = quote({ inputPerMtok: 12, outputPerMtok: 36 });
+    expect(modelPricePresentation(standard, { input: 0, output: 0 })).toEqual({
       kind: 'priced',
       current: quote({ inputPerMtok: 0, outputPerMtok: 0 }),
-      original,
-      discount: 1,
     });
   });
 
-  it('preserves the standard price when there is no discount', () => {
+  it('preserves the standard price when the effective price matches it', () => {
     const standard = quote({ inputPerMtok: 12, outputPerMtok: 36 });
     expect(modelPricePresentation(standard, { input: 12, output: 36 })).toEqual({
       kind: 'priced',
@@ -103,7 +87,7 @@ describe('modelPriceFormat', () => {
     });
   });
 
-  it('ignores sub-threshold floating-point discount noise', () => {
+  it('ignores sub-threshold floating-point price noise', () => {
     const standard = quote({ inputPerMtok: 12, outputPerMtok: 36 });
     expect(
       modelPricePresentation(standard, {

--- a/apps/desktop/src/renderer/lib/__tests__/modelShortLabel.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/modelShortLabel.test.ts
@@ -23,7 +23,7 @@ describe('formatModelShortLabel', () => {
     ['claude-nova-5-0', 'Nova 5.0'],
     // vendor/route 前缀剥掉后仍能识别
     ['us.anthropic.claude-haiku-4-5-20251001', 'Haiku 4.5'],
-    // GPT:版本 + 可选 mini/nano,骨折版 codex/ 前缀剥掉
+    // GPT:版本 + 可选 mini/nano,折扣版 codex/ 前缀剥掉
     ['gpt-5.5', 'GPT-5.5'],
     ['gpt-5.4-mini', 'GPT-5.4 Mini'],
     ['codex/gpt-5.5', 'GPT-5.5'],

--- a/apps/desktop/src/renderer/lib/modelPriceFormat.ts
+++ b/apps/desktop/src/renderer/lib/modelPriceFormat.ts
@@ -5,15 +5,14 @@ interface EffectiveModelCost {
   output?: number;
 }
 
-const MIN_DISPLAY_DISCOUNT = 0.0005;
+// input / output 缩放比例小于这个阈值时视为浮点噪声,按标准价展示。
+const MIN_EFFECTIVE_PRICE_GAP = 0.0005;
 
 export type ModelPricePresentation =
   | { kind: 'free' }
   | {
       kind: 'priced';
       current: ModelPriceQuote;
-      original?: ModelPriceQuote;
-      discount?: number;
     };
 
 function compactNumber(value: number): string {
@@ -33,53 +32,43 @@ export function formatModelPricePair(quote: ModelPriceQuote): string {
   return `${quote.approximate ? '≈' : ''}${input} / ${output}`;
 }
 
-export function modelPriceDiscountLabelValues(discount: number): {
-  percent: string;
-  rate: string;
-} {
-  return {
-    percent: compactNumber(discount * 100),
-    rate: compactNumber((1 - discount) * 10),
-  };
-}
-
 function isNonNegativeFinite(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
 
-function inferDiscount(
+/**
+ * effectiveCost 能否直接当展示价:要求 input / output 相对标准价是同一个缩放比例。
+ * effectiveCost 不带缓存维度,若 quote 有非零缓存价就不敢覆盖 —— 否则明细里的
+ * input / output 来自实际价、缓存行来自标准价,两套价表混在一张表上。
+ */
+function effectiveCostIsConsistent(
   quote: ModelPriceQuote,
   cost: Required<EffectiveModelCost>,
-): number | undefined {
-  // effectiveCost 无法提供缓存维度;若 quote 含非零缓存价,无法验证缓存折扣
-  // 是否一致,不推断折扣以避免 badge 与缓存行价格不一致。
+): boolean {
   if ((quote.cacheReadPerMtok && quote.cacheReadPerMtok > 0) ||
       (quote.cacheCreatePerMtok && quote.cacheCreatePerMtok > 0)) {
-    return undefined;
+    return false;
   }
-  const candidates: number[] = [];
-  for (const [original, current] of [
+  const gaps: number[] = [];
+  for (const [standard, effective] of [
     [quote.inputPerMtok, cost.input],
     [quote.outputPerMtok, cost.output],
   ] as const) {
-    if (original === 0) {
-      if (current !== 0) return undefined;
+    if (standard === 0) {
+      if (effective !== 0) return false;
       continue;
     }
-    const candidate = 1 - current / original;
-    if (candidate < MIN_DISPLAY_DISCOUNT || candidate > 1) return undefined;
-    candidates.push(candidate);
+    const gap = 1 - effective / standard;
+    if (gap < MIN_EFFECTIVE_PRICE_GAP || gap > 1) return false;
+    gaps.push(gap);
   }
-  if (candidates.length === 0) return undefined;
-  const discount = candidates[0];
-  return candidates.every((candidate) => Math.abs(candidate - discount) < 1e-9)
-    ? discount
-    : undefined;
+  if (gaps.length === 0) return false;
+  return gaps.every((gap) => Math.abs(gap - gaps[0]) < 1e-9);
 }
 
 /**
  * 构建模型选择器的展示价格。quote 继续保留用量估算所需的标准价；
- * CatalogModel.cost 只承载 XD 模型的折后展示价。
+ * CatalogModel.cost 承载 XD 模型的实际展示价，一致时直接覆盖 input / output。
  */
 export function modelPricePresentation(
   quote: ModelPriceQuote | null | undefined,
@@ -107,8 +96,9 @@ export function modelPricePresentation(
   if (quote === null) return null;
   if (!hasEffectiveCost) return { kind: 'priced', current: quote };
 
-  const discount = inferDiscount(quote, { input, output });
-  if (discount === undefined) return { kind: 'priced', current: quote };
+  if (!effectiveCostIsConsistent(quote, { input, output })) {
+    return { kind: 'priced', current: quote };
+  }
   return {
     kind: 'priced',
     current: {
@@ -116,43 +106,23 @@ export function modelPricePresentation(
       inputPerMtok: input,
       outputPerMtok: output,
     },
-    original: quote,
-    discount,
   };
 }
 
 export function modelPriceDetailRows(
   quote: ModelPriceQuote,
-  originalQuote?: ModelPriceQuote,
 ): Array<{
   kind: 'input' | 'output' | 'cacheRead' | 'cacheCreate';
   value: string;
-  originalValue?: string;
 }> {
   return [
     {
       kind: 'input' as const,
       value: formatModelPriceAmount(quote.inputPerMtok, quote.currency),
-      ...(originalQuote
-        ? {
-            originalValue: formatModelPriceAmount(
-              originalQuote.inputPerMtok,
-              originalQuote.currency,
-            ),
-          }
-        : {}),
     },
     {
       kind: 'output' as const,
       value: formatModelPriceAmount(quote.outputPerMtok, quote.currency),
-      ...(originalQuote
-        ? {
-            originalValue: formatModelPriceAmount(
-              originalQuote.outputPerMtok,
-              originalQuote.currency,
-            ),
-          }
-        : {}),
     },
     ...(quote.cacheReadPerMtok === undefined
       ? []

--- a/apps/desktop/src/renderer/lib/modelShortLabel.ts
+++ b/apps/desktop/src/renderer/lib/modelShortLabel.ts
@@ -55,7 +55,7 @@ export function formatModelShortLabel(modelId: string | undefined | null): strin
   id = id.replace(/\[1m\]$/i, '');
   // 2) 去尾部 dated 后缀(如 -20251001)
   id = id.replace(/-\d{8}$/, '');
-  // 3) 去已知 vendor/route 前缀(Bedrock/Vertex route、骨折版 codex/ 前缀)
+  // 3) 去已知 vendor/route 前缀(Bedrock/Vertex route、折扣版 codex/ 前缀)
   id = id.replace(/^us\.anthropic\./i, '').replace(/^anthropic\./i, '').replace(/^codex\//i, '');
 
   // 4) Claude <family>-<major>(-<minor>)? → 'Family major.minor' / 'Family major'

--- a/apps/desktop/src/shared/modelPriceQuote.ts
+++ b/apps/desktop/src/shared/modelPriceQuote.ts
@@ -71,8 +71,8 @@ export function gatewayModelPriceQuote(
   ) {
     return undefined;
   }
-  // quote 保留未折扣的标准价:UI 通过对比 quote(原价) vs CatalogModel.cost(折后价)
-  // 推断折扣 badge;costDiscount 仅在 effectiveGatewayModelCost 侧应用到 cost。
+  // quote 是用量估算用的标准价;costDiscount 只在 effectiveGatewayModelCost 侧应用到
+  // cost,UI 展示价一致时取 cost(见 modelPriceFormat),不再并排展示标准价。
   return applyCodexBudgetDiscount({
     providerId: 'xd',
     modelId,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1424,7 +1424,7 @@ export default function SessionScreen() {
       : null,
     [composerDeviceProviders.providers, composerDeviceProviders.modelVisibilityOverrides, currentSession],
   );
-  // 模型列表元信息(单价 / 骨折版 key presence)—— 与新建会话页同一套隧道缓存 hook。
+  // 模型列表元信息(单价 / 折扣版 key presence)—— 与新建会话页同一套隧道缓存 hook。
   const deviceModelPricing = useDeviceModelPricing(deviceId || undefined);
   const deviceApiKeyStatus = useDeviceApiKeyStatus(deviceId || undefined);
   // 会话「非选中模型」effort/fast 的镜像 accessors:乐观写本地镜像 + 双写穿被控端

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -491,7 +491,7 @@ export default function NewRemoteSessionScreen() {
   );
   // 被控端供应商目录 → provider-aware 模型分段(对齐桌面)。0 供应商 / 旧被控端 → 回退扁平列表。
   const deviceProviders = useDeviceProviders(selectedDeviceId || undefined);
-  // 模型列表元信息(单价 / 骨折版 key presence)+ 草稿 per-(agent,来源,模型) 记忆(对齐桌面)。
+  // 模型列表元信息(单价 / 折扣版 key presence)+ 草稿 per-(agent,来源,模型) 记忆(对齐桌面)。
   const deviceModelPricing = useDeviceModelPricing(selectedDeviceId || undefined);
   const deviceApiKeyStatus = useDeviceApiKeyStatus(selectedDeviceId || undefined);
   const draftMemory = useMemo(() => draftModelMemoryFor(selectedDeviceId), [selectedDeviceId]);

--- a/apps/mobile/src/__tests__/modelPickerRows.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerRows.test.ts
@@ -170,7 +170,7 @@ describe('rowFastEditable / rowFastOn(严格 per-(供应商, 模型))', () => {
   });
 });
 
-describe('budgetRowDisabled(骨折版置灰三态)', () => {
+describe('budgetRowDisabled(折扣版置灰三态)', () => {
   it("只有 codex/ 前缀且被控端明确 absent 才置灰;unknown 不误伤", () => {
     expect(budgetRowDisabled('codex/gpt-5.5', 'absent')).toBe(true);
     expect(budgetRowDisabled('codex/gpt-5.5', 'present')).toBe(false);

--- a/apps/mobile/src/device-link/deviceModelMetaCache.ts
+++ b/apps/mobile/src/device-link/deviceModelMetaCache.ts
@@ -9,7 +9,7 @@
  * 与 providers 缓存的关键差异:**失败即降级值、不进缓存、不抛错**——
  *   - 单价表失败(典型:旧被控端 CHANNEL_NOT_ALLOWED)→ null,UI 隐藏价格(对齐桌面
  *     useModelPricing「无价不显示」口径);
- *   - key presence 失败 → 'unknown',骨折版不置灰(宁可放行到被控端请求期报错,也不误伤)。
+ *   - key presence 失败 → 'unknown',折扣版不置灰(宁可放行到被控端请求期报错,也不误伤)。
  */
 import type { MobileModelPricingMap } from './mobileMakerTransport';
 

--- a/apps/mobile/src/device-link/useDeviceModelMeta.ts
+++ b/apps/mobile/src/device-link/useDeviceModelMeta.ts
@@ -3,7 +3,7 @@
  *
  * 缓存 / 去重 / 代际驱逐核心在 `./deviceModelMetaCache`(纯逻辑、node 可测)。两个 hook 都
  * 优雅降级:旧被控端不识别通道 / 拉取失败 → 单价 null(隐藏价格)、key 状态 'unknown'
- * (骨折版不置灰),与桌面「无价不显示」「宁可放行不误伤」的口径一致,不出 loading 态
+ * (折扣版不置灰),与桌面「无价不显示」「宁可放行不误伤」的口径一致,不出 loading 态
  * (数据未到时界面不变化,符合设计规范 7)。
  */
 import { useEffect, useState } from 'react';
@@ -50,7 +50,7 @@ export function useDeviceModelPricing(deviceId?: string): MobileModelPricingMap 
   return pricing;
 }
 
-/** 被控端网关 API key presence;'unknown' = 还没拿到 / 拉不到(消费方不置灰骨折版)。 */
+/** 被控端网关 API key presence;'unknown' = 还没拿到 / 拉不到(消费方不置灰折扣版)。 */
 export function useDeviceApiKeyStatus(deviceId?: string): DeviceApiKeyStatus {
   const maker = useMobileMakerTransport(deviceId ?? '');
   const [status, setStatus] = useState<DeviceApiKeyStatus>(

--- a/apps/mobile/src/session/MobileModelPickerList.tsx
+++ b/apps/mobile/src/session/MobileModelPickerList.tsx
@@ -3,11 +3,11 @@
  * 由 ModelPickerSheet 装配)。
  *
  * 展现内容对齐桌面 ModelSelector 的 renderModelItem:每行 = 来源官方 mark + 模型名 +
- * `订阅`(订阅制来源)+ `85% off`(骨折版)+ 当前 effort 标签 + Fast 闪电(点亮时)+
- * 选中 Check + 行内「配置」入口。
+ * `订阅`(订阅制来源)+ 当前 effort 标签 + Fast 闪电(点亮时)+
+ * 选中 Check + 行内「配置」入口。折扣版不带行内徽标,靠分组标题区分。
  * 触屏适配:桌面 hover「Edit」→ 每行右侧常驻配置图标,点击经 `onOpenOptions` 通知浮窗
  * 打开二级「模型选项」SheetSurface(元信息 / 快速开关 / 推理强度,见 ModelOptionsSheetView),
- * 本组件不再承载行内展开。骨折版被控端无 gateway key → 整行置灰 + 行内提示。
+ * 本组件不再承载行内展开。折扣版被控端无 gateway key → 整行置灰 + 行内提示。
  *
  * 三态:① 供应商分段(providerRows 非空,选行 = 选「来源 + 模型」);② 扁平回退(flatOptions,
  * 旧被控端,无来源 mark、无记忆,仅选中行可配置);③ 空 → 加载中 / 暂无文案。
@@ -73,7 +73,7 @@ export interface MobileModelPickerListProps {
   selectedFastMode?: boolean;
   /** 非选中行 effort/fast 记忆读取器(草稿 = draftModelMemory / 会话 = sessionModelMirror)。 */
   modelMemory?: MobileModelMemoryAccessors;
-  /** 被控端网关 key presence('absent' 才置灰骨折版,缺省 'unknown' 不置灰)。 */
+  /** 被控端网关 key presence('absent' 才置灰折扣版,缺省 'unknown' 不置灰)。 */
   apiKeyStatus?: DeviceApiKeyStatus;
   /** 行内配置图标点击(打开二级「模型选项」浮窗);不传则不显示配置入口。 */
   onOpenOptions?(target: ModelOptionsOpenTarget): void;
@@ -193,7 +193,6 @@ export function MobileModelPickerList({
       <>
         {providerRows.map((row) => {
           const selected = row.model.id === activeModelId && row.provider.id === activeSourceId;
-          const isBudget = row.model.id.startsWith('codex/');
           // 对齐桌面 ModelSelector:订阅制来源(Claude.ai / ChatGPT 等)的模型带「订阅」徽标。
           const isSubscription = row.provider.access?.kind === 'subscription';
           const rowDisabled = budgetRowDisabled(row.model.id, apiKeyStatus);
@@ -272,11 +271,6 @@ export function MobileModelPickerList({
                   {isSubscription ? (
                     <View style={styles.budgetBadge}>
                       <Text style={styles.budgetBadgeText}>{t('models.picker.subscriptionBadge')}</Text>
-                    </View>
-                  ) : null}
-                  {isBudget ? (
-                    <View style={styles.budgetBadge}>
-                      <Text style={styles.budgetBadgeText}>85% off</Text>
                     </View>
                   ) : null}
                   {rowEffort ? (

--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -679,7 +679,7 @@ describe('anthropic-compat-proxy routingTransform', () => {
       transformRequest: [],
       routingTransform: (body) => {
         const model = (body as { model?: string }).model ?? '';
-        // 骨折: 默认 upstream(gateway) + 换 gateway key; 普通: override 到 chatgpt + 透传原 auth
+        // 折扣: 默认 upstream(gateway) + 换 gateway key; 普通: override 到 chatgpt + 透传原 auth
         if (model.startsWith('codex/')) return { headerOverride: { authorization: 'Bearer gw-key' } };
         return { upstreamOverride: chatgpt.url };
       },

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -449,7 +449,7 @@ const stripGpt54Mini: ModelStripHandler = (body) => {
 const STRIP_HANDLERS: Readonly<Record<string, ModelStripHandler>> = {
   'gpt-5.4': stripGpt54,
   'gpt-5.4-mini': stripGpt54Mini,
-  // 「骨折GPT」低价路由 —— 与 gpt-5.4 打同一个 Azure 后端, 同样会因 output_config 报 400,
+  // 「折扣GPT」低价路由 —— 与 gpt-5.4 打同一个 Azure 后端, 同样会因 output_config 报 400,
   // 镜像 gpt-5.4 的 strip 行为 (复用同一 handler)。codex/gpt-5.5 暂不加, 与 gpt-5.5 一致。
   'codex/gpt-5.4': stripGpt54,
 };

--- a/packages/device-link/src/allowlist.ts
+++ b/packages/device-link/src/allowlist.ts
@@ -299,7 +299,7 @@ const EXTENDED_INVOKE_CHANNELS: readonly string[] = [
   'maker:usage:model-pricing',
   // 网关 API key **presence-only** 探测:只回 { present: boolean },不回、也永不扩展为读取
   // 密钥材料 —— 这是「账号与密钥永不放行」大类下的窄口径例外(同 DL_VOICE_CREDENTIAL_SYNC
-  // 的例外定位,禁止泛化)。用途:控制端模型选择器判断骨折版(codex/)是否该置灰,判定依据
+  // 的例外定位,禁止泛化)。用途:控制端模型选择器判断折扣版(codex/)是否该置灰,判定依据
   // 在被控端(key 存被控端 safeStorage、请求也从被控端发)。老被控端无此 channel →
   // CHANNEL_NOT_ALLOWED → 控制端按 unknown 处理(不置灰)。
   'maker:api-key:present',

--- a/packages/lizi-mcps/src/xdt-helper/list_available_models.ts
+++ b/packages/lizi-mcps/src/xdt-helper/list_available_models.ts
@@ -15,7 +15,7 @@ export interface ModelDescriptor {
   label: string;
 }
 
-/** tier: 'budget' = codex/ 前缀的 gateway 折扣路由 (85% off), 'standard' = 官方原版。仅出现在返回值, 供 agent 精准选型。 */
+/** tier: 'budget' = codex/ 前缀的 gateway 折扣路由, 'standard' = 官方原版。仅出现在返回值, 供 agent 精准选型。 */
 type ModelTier = 'budget' | 'standard';
 
 interface TaggedModel extends ModelDescriptor {
@@ -26,7 +26,7 @@ interface TaggedModel extends ModelDescriptor {
  * 给每个 model 打 tier 标记。
  *
  * tier='budget'(gateway 折扣 codex 路由) 的唯一判定依据是 model id 的 `codex/` 前缀 ——
- * 与 renderer ModelSelector.categorize() 的归类规则保持一致 (codex/* → 85% off 分组),
+ * 与 renderer ModelSelector.categorize() 的归类规则保持一致 (codex/* → 折扣分组),
  * 也与 host CODEX_BUDGET_MODELS 的 id 命名约定一致。据此打 tier 后, agent 不必再从
  * label / description 里语义推断, 直接按 tier 精准匹配用户指定的档位。
  * label (= host displayName, 同时是 UI 下拉展示名) 不受影响, 保持干净。
@@ -60,9 +60,9 @@ const DESCRIPTION = [
   '- claude_code: Claude Code agent 的可用 model 列表 [{id, label, tier}]',
   '',
   'tier 字段 (用于精准选型, 不要靠 label 推断):',
-  "- tier='budget': codex/ 前缀的 gateway 折扣路由 (85% off, 如 codex/gpt-5.5)",
+  "- tier='budget': codex/ 前缀的 gateway 折扣路由 (如 codex/gpt-5.5)",
   "- tier='standard': 官方原版 (如 gpt-5.5)",
-  '选型规则: 用户明确要求折扣 / 85% off 路由 → 选 tier=budget 的模型; 说「官方 / 原版 / 普通版」→ 选 tier=standard。',
+  '选型规则: 用户明确要求折扣路由 → 选 tier=budget 的模型; 说「官方 / 原版 / 普通版」→ 选 tier=standard。',
   '默认规则: 用户只报模型名 (如 "gpt-5.5") 时, 一律默认 tier=standard (官方原版); 只有用户明确要求折扣路由才允许选 tier=budget。',
   '注意 budget 与 standard 可能 label 同名 (都叫 GPT-5.5), 必须用 tier 区分, 不能只看 label。',
   'tier=budget 仅在 Codex「API key 模式」下可用; OAuth 模式下 create_worker 会返 BUDGET_MODEL_REQUIRES_API_MODE。用户要 budget 档时, 若被拒就如实告知需切到 API key 模式。',

--- a/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
@@ -90,7 +90,7 @@ describe('ClaudeCodeAgent model capabilities', () => {
 
   it('does NOT add [1m] to budget codex/* models (real window 272k, not 1M)', () => {
     // [1m] 会让 cc-code 的 has1mContext 把窗口判成 1M, 撑大 auto-compact 阈值,
-    // 对话冲过骨折网关真实上限后空转。骨折版必须保持原样、不带 [1m]。
+    // 对话冲过折扣网关真实上限后空转。折扣版必须保持原样、不带 [1m]。
     expect(toSdkModelString('codex/gpt-5.5')).toBe('codex/gpt-5.5');
     expect(toSdkModelString('codex/gpt-5.4')).toBe('codex/gpt-5.4');
   });
@@ -105,7 +105,7 @@ describe('ClaudeCodeAgent model capabilities', () => {
   });
 
   it('never emits [1m] when catalog window < 1M (strips a stray suffix too)', () => {
-    // 骨折 codex/*(272k/372k)带 [1m] 会让 cc 把窗口误判 1M → 会话假死,窗口规则兜死这一类。
+    // 折扣 codex/*(272k/372k)带 [1m] 会让 cc 把窗口误判 1M → 会话假死,窗口规则兜死这一类。
     expect(toSdkModelString('codex/gpt-5.5', 272_000)).toBe('codex/gpt-5.5');
     expect(toSdkModelString('codex/gpt-5.6-sol', 372_000)).toBe('codex/gpt-5.6-sol');
     expect(toSdkModelString('qwen/qwen3.7-max', 992_000)).toBe('qwen/qwen3.7-max');

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-context-window.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-context-window.test.ts
@@ -209,7 +209,7 @@ describe('Claude Code translator context window', () => {
     // 回归(防御性): 即便 SDK modelUsage 仍按 [1m] 历史口径上报 1M(toSdkModelString
     // 已不再给 codex/* 加 [1m], 但此处保留对"SDK 若上报 1M"的兜底覆盖),
     // catalog cc 侧权威值 272k 必须向下覆盖, 否则 auto-compact / memory-flush ratio
-    // 按 1M 算永不触发, 对话冲过骨折网关真实上限(~24 万 token)后空转, 会话"假死"。
+    // 按 1M 算永不触发, 对话冲过折扣网关真实上限(~24 万 token)后空转, 会话"假死"。
     const tracker = new UsageTracker();
     const queue = createAsyncQueue<AgentEvent>();
 
@@ -274,7 +274,7 @@ describe('Claude Code translator context window', () => {
         rt: newRuntimeState(),
         turn: createTurnState(),
         log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
-        getModel: () => 'codex/gpt-5.5', // 切到骨折版后, 旧的 gpt-5.5[1m] turn 才收口
+        getModel: () => 'codex/gpt-5.5', // 切到折扣版后, 旧的 gpt-5.5[1m] turn 才收口
         getEffort: () => 'high',
         getPermissionMode: () => 'auto',
         onSessionId: vi.fn(),

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-empty-response.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-empty-response.test.ts
@@ -50,7 +50,7 @@ async function drain(queue: ReturnType<typeof createAsyncQueue<AgentEvent>>): Pr
 
 describe('Claude Code translator empty-response guard', () => {
   it('surfaces an empty-response error when an API call returns no content and zero usage', async () => {
-    // 模拟骨折网关短路: message_start 发起一次 API call, 但整轮 0 文本 / 0 tool / usage 全 0。
+    // 模拟折扣网关短路: message_start 发起一次 API call, 但整轮 0 文本 / 0 tool / usage 全 0。
     const tracker = new UsageTracker();
     const queue = createAsyncQueue<AgentEvent>();
     const ctx = createCtx(tracker);

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -104,7 +104,7 @@ type ClaudeSdkEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
  * [1m] 后缀的唯一决策依据是目录(providers.json)的 contextWindow:
  *   - 窗口已知且 ≥1M → 带 [1m];已知且 <1M → 绝不带(已带的强制剥掉)。
  *     窗口 <1M 却带 [1m] 会让 cc-code 的 has1mContext 把窗口判成 1M,撑大
- *     auto-compact 阈值 → 对话冲过上游真实上限后空转,会话"假死"(骨折 GPT 实踩)。
+ *     auto-compact 阈值 → 对话冲过上游真实上限后空转,会话"假死"(折扣 GPT 实踩)。
  *     真实窗口口径已由 catalog 经 env-builder(XDT_MAKER_MODEL_CONTEXT_WINDOWS,
  *     id 与 id[1m] 双键)注入 cc,[1m] 不再承担窗口语义,只是 wire 串的一部分。
  *   - 窗口未知(目录外模型 / 未传窗口的老调用方)→ 回落下方硬编码映射链,行为不变。
@@ -139,10 +139,10 @@ function legacyToSdkModelString(model: string): string {
   if (model.includes('sonnet')) return `${model}[1m]`;
   // 官方 gpt-5.5 / gpt-5.4 真实支持 1M, 走 [1m] beta 通道。
   if (model === 'gpt-5.5' || model === 'gpt-5.4') return `${model}[1m]`;
-  // 骨折GPT(codex/* 经骨折网关)真实上下文上限远低于 1M(catalog cc 侧 = 272k),
+  // 折扣GPT(codex/* 经折扣网关)真实上下文上限远低于 1M(catalog cc 侧 = 272k),
   // 绝不能带 [1m]: cc-code 的 has1mContext 只要在 model 串里见到 [1m] 就把窗口判成 1M
   // (getContextWindowForModel 直接 return 1_000_000), 撑大 auto-compact 阈值 →
-  // 对话冲过骨折网关真实上限(~24 万 token)后空转, 用户侧表现为会话"假死"。
+  // 对话冲过折扣网关真实上限(~24 万 token)后空转, 用户侧表现为会话"假死"。
   // 路由不依赖 [1m]: isAnthropicWireModel 只按 claude-/sonnet/opus/haiku/fable 前缀判定,
   // codex/ 前缀始终走 provider 网关、不命中 Anthropic wire, 去掉 [1m] 不改变路由判定;
   // 真实窗口由 catalog 经 translator 窗口口径注入(=272k)。

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -1318,7 +1318,7 @@ function handleResult(
   // 窗口口径: catalog(host 按 agent 声明的 capabilities.availableModels[].contextWindow,
   // 经 ctx.getModelContextWindow 透传)是权威值, 但**只在以下两种情形**覆盖 SDK 上报值:
   //  (a) SDK 的窗口确实属于**当前模型**(modelUsage 里有 key 去 [1m] 后与当前模型完全相等
-  //      且带正窗口)—— 这是骨折模型被 [1m] 误报 1M 的主场景, 用 catalog 锁回真实窗口
+  //      且带正窗口)—— 这是折扣模型被 [1m] 误报 1M 的主场景, 用 catalog 锁回真实窗口
   //      (如 codex/gpt-5.5 cc=272k), 让 auto-compact / memory-flush 按真实窗口触发。
   //  (b) SDK 没给窗口或只给了 unknown-model 默认小窗口(≤200K)—— 升级到 catalog。
   // **不覆盖** SDK 给了某个**别的模型**的非默认窗口(>200K)的情形: 典型是 turn 运行中途切了
@@ -1381,7 +1381,7 @@ function handleResult(
   }
 
   // 空响应判定(提前到 endTurn 之前算): 本轮发起过 API call 但 0 产出(无 UI 文本 /
-  // 无 result 兜底文本 / 无 tool 调用)且本轮 usage 增量全 0 —— 典型是模型网关(尤其骨折
+  // 无 result 兜底文本 / 无 tool 调用)且本轮 usage 增量全 0 —— 典型是模型网关(尤其折扣
   // 网关)在大上下文 / 高负载下短路返回 HTTP 200 + 空 SSE 流(input_tokens=0)。提前算的原因:
   //  (a) 让下面的 endTurn 在空响应轮**不要** replaceLastApi(守卫加 !isEmptyResponseTurn),
   //      否则会用本轮 0 增量覆盖 tracker.lastApi、把 contextTokens 清成 0 —— auto-compact /

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -782,7 +782,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(oauthParams.modelProvider).toBe('cindy_openai');
     await oauthHandle.close();
 
-    // 骨折 codex/(gateway-key 家族)→ 保持默认 provider(本地压缩)。
+    // 折扣 codex/(gateway-key 家族)→ 保持默认 provider(本地压缩)。
     host.request.mock.calls.length = 0;
     const gatewayHandle = await agent.startSession({
       sessionId: 'session-gateway',

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1581,7 +1581,7 @@ export class CodexAgent extends BaseAgent {
       throw new Error(`Codex app-server host creation was superseded before ${stage}`);
     };
     // 方案 A(订阅超集 spawn):本地 gateway-key 诉求且 auth fallback 实际持有 OAuth 时,
-    // 升格为 oauth-bearer spawn。超集进程经 proxy 按会话换网关 key(XD/骨折计费不变),
+    // 升格为 oauth-bearer spawn。超集进程经 proxy 按会话换网关 key(XD/折扣计费不变),
     // 同时还能服务订阅会话 —— 订阅/API 会话真正并行,不再因来源切换重建 host 排队。
     let spawnCredentialMode = credentialMode;
     let requestedGatewayState: AuthState | null = null;
@@ -2310,7 +2310,7 @@ export class CodexAgent extends BaseAgent {
     // CodexExtraSpawnConfig.codexRemoteCompactionProviderId),② 本会话的凭证家族
     // 解析为 oauth-bearer(显式 openai 来源,或隐式来源 + host 归一化形态为订阅)
     // 时,才让 thread 选 OpenAI 身份 provider → codex 走 OpenAI 远端压缩。
-    // codex/ 骨折(gateway-key)、xai/、chatgpt/ 与显式第三方来源(provider-oauth)
+    // codex/ 折扣(gateway-key)、xai/、chatgpt/ 与显式第三方来源(provider-oauth)
     // 都被 resolveAgentCredentialMode 排除 —— 它们的上游不支持远端压缩,且 codex
     // 远端压缩失败无本地回退,错配会打断长会话。
     const threadModelProvider = (() => {

--- a/packages/maker-core/src/agents/credential-mode.ts
+++ b/packages/maker-core/src/agents/credential-mode.ts
@@ -77,7 +77,7 @@ export function canReuseHostForCredentialMode(
 /**
  * Codex 专用的共享 host 复用判定:在通用规则之上增加「订阅超集 host」放宽 ——
  * oauth-bearer spawn 的本地 app-server 经 loopback proxy 具备按请求换网关 key 的
- * 能力(骨折模型分支与 per-session 显式 XD 路由均为已上线行为),因此 gateway-key
+ * 能力(折扣模型分支与 per-session 显式 XD 路由均为已上线行为),因此 gateway-key
  * 诉求的会话可以直接复用 oauth-bearer host,不再触发全 host 重建 —— 这是消除
  * 「订阅/API 会话切换排队」的关键(方案 A,2026-07)。
  *

--- a/packages/maker-shared/src/agentCapabilities.ts
+++ b/packages/maker-shared/src/agentCapabilities.ts
@@ -49,7 +49,7 @@ export type MobileModelCategory = 'anthropic' | 'gpt' | 'gpt-budget' | 'google' 
 export const MOBILE_MODEL_CATEGORY_LABEL: Record<MobileModelCategory, string> = {
   anthropic: 'Anthropic',
   gpt: 'GPT',
-  'gpt-budget': 'GPT（立省 85%）',
+  'gpt-budget': 'GPT 折扣',
   google: 'Google',
   china: 'China',
 };

--- a/packages/maker-shared/src/deviceLinkContract.ts
+++ b/packages/maker-shared/src/deviceLinkContract.ts
@@ -257,7 +257,7 @@ export const MOBILE_REMOTE_INVOKE_CHANNELS = [
   // reset 使用 desktop 预签发、账号绑定的幂等 offer,手机不能自行指定 creditId。
   'maker:usage:codex-rate-limits',
   'maker:usage:codex-rate-limit-reset',
-  // 网关 API key presence-only 探测(只回 boolean;拉不到 → unknown,骨折版不置灰)。
+  // 网关 API key presence-only 探测(只回 boolean;拉不到 → unknown,折扣版不置灰)。
   'maker:api-key:present',
   'maker:list-agent-commands',
   'maker:list-agent-skills',


### PR DESCRIPTION
## 这次改了什么

### 摘要

开源仓里「骨折 / 骨折GPT」这类内部口语散在 41 个文件的注释里，用户可见文案又把折扣幅度写死成「立省 85% / 85% off」。本 PR 把内部黑话换成中性表述，并把折价百分比从 UI 上收掉。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无（开源仓措辞与展示口径清理）
- 本 PR 包含：
  - 注释与 MCP 工具描述：`骨折` → `折扣`（70 处 / 41 文件，纯注释），去掉 `85% off` 具体数字
  - 模型分组名统一「GPT 折扣」（en/ja/ko 同步 `GPT Discount` / `GPT 割引` / `GPT 할인`）：`newChat.modelSelector.category.budget`、`scheduler.chips.model.category.gpt-budget`、`MOBILE_MODEL_CATEGORY_LABEL`
  - 下掉折价展示层：桌面模型行「立省 85%」徽标、通用「立省 N%」促销徽标（trigger / 行 / 详情三处）、行内与详情的原价划线对比；移动端模型行「85% off」徽标。i18n key `pricing.discount` / `meta.budgetDiscount` 四语言删除
  - `inferDiscount()` → `effectiveCostIsConsistent()`：只判断实际价能否覆盖标准价，不再对外吐折扣比例
- 明确不包含：
  - 计价数学。`costDiscount`、`CODEX_BUDGET_PRICE_MULTIPLIER` 参与实际花费计算（`turnCostCalculator` / 今日花费），删掉会让金额按原价显示，故原样保留
  - 主题 token `--model-budget-badge-bg/-text`：现无引用，但进了本地主题导出，删除会静默丢弃用户自定义值，保留
  - 子模块 `cindy-protocol` 里剩余 1 处「骨折」，属独立仓库，另行处理
- 用户可见变化：模型分组名改为「GPT 折扣」；折扣徽标与原价划线对比不再显示；折后价照常显示；「限时免费」徽标不受影响
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：本次只删除既有徽标/划线元素与替换分组文案，未新增或改动任何组件、布局、间距、配色与状态样式；删除项在 Light / Dark 两模式下同时消失，无单模式残留。

## 怎么验证的

### 自动验证

```text
pnpm check:i18n
结果：✅ zh-CN / en / ja / ko 共 5517 个 key 全部一致、无孤儿 key

pnpm --filter desktop run typecheck
pnpm --filter mobile run typecheck
结果：均通过

env -u XDT_ISOLATED -u XDT_ISOLATED_NAME -u XDT_USER_DATA_DIR -u XDT_SCHEDULER_PASSIVE pnpm test:unit
结果：本 PR 涉及的用例全绿（modelPriceFormat / modelSelectorTriggerVariant / sourceSwitch / modelPickerRows 等）。
      本地另有 1 处与本 PR 无关的既有失败：
      apps/desktop/src/renderer/__tests__/builtinToolsWorkingDirScope.test.ts
      —— 它对 BuiltinToolsSection.tsx 源码做字面量断言、断言里写死 \n，而 Windows 检出为
      CRLF，故仅在 Windows 本地失败；该文件与该测试均来自 034c78b (#402)，不在本 PR diff 内。
```

补充说明：在 Cindy 隔离会话里跑 `pnpm test:unit` 会因环境注入的 `XDT_ISOLATED` / `XDT_USER_DATA_DIR` 让 `scripts/__tests__` 的 dev-guard 测试误失败，并因 `&&` 短路导致 vitest 那一档根本不执行，故上面显式 unset。

### 手工验证

不涉及：改动为文案替换与元素删除，已由渲染层单测覆盖（徽标缺失、原价不再并排、详情价格行）。

### 未执行的验证

未跑 `pnpm test:all`；本次不触及 DB / 原生层 / 协议，按风险等级以 `test:unit` + 双端 typecheck + `check:i18n` 收口，最终以 CI 为准。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：桌面与移动端模型选择器的展示文案与徽标；不涉及模型可用性、路由、凭证与计费金额计算。
- 回滚 / 降级方式：单 commit，`git revert` 即可完全回退；不涉及数据迁移与协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（本次为「不涉及」并说明理由）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
