### PR TITLE
fix(desktop): show effective prices for cache-priced models

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -476,7 +476,7 @@ describe('ModelSelector trigger variants', () => {
               contextWindow: 200000,
               efforts: ['high'],
               defaultEffort: 'high',
-              cost: { input: 6, output: 18 },
+              cost: { input: 6, output: 18, cacheRead: 1.2, cacheWrite: 7.5 },
             },
             {
               id: 'claude-sonnet-4-6',
@@ -500,6 +500,8 @@ describe('ModelSelector trigger variants', () => {
           approximate: false,
           inputPerMtok: 12,
           outputPerMtok: 36,
+          cacheReadPerMtok: 2.4,
+          cacheCreatePerMtok: 15,
         },
       },
     };
@@ -807,7 +809,7 @@ describe('ModelSelector trigger variants', () => {
               contextWindow: 200000,
               efforts: ['high'],
               defaultEffort: 'high',
-              cost: { input: 6, output: 18 },
+              cost: { input: 6, output: 18, cacheRead: 1.2, cacheWrite: 7.5 },
             },
           ],
         },
@@ -823,6 +825,8 @@ describe('ModelSelector trigger variants', () => {
           approximate: false,
           inputPerMtok: 12,
           outputPerMtok: 36,
+          cacheReadPerMtok: 2.4,
+          cacheCreatePerMtok: 15,
         },
       },
     };
@@ -852,6 +856,10 @@ describe('ModelSelector trigger variants', () => {
       expect(within(details).getByText('¥18')).toBeTruthy();
       expect(within(details).queryByText('¥12')).toBeNull();
       expect(within(details).queryByText('¥36')).toBeNull();
+      expect(within(details).getByText('¥1.2')).toBeTruthy();
+      expect(within(details).queryByText('¥2.4')).toBeNull();
+      expect(within(details).getByText('¥7.5')).toBeTruthy();
+      expect(within(details).queryByText('¥15')).toBeNull();
       expect(details.querySelector('[data-model-promotion-badge]')).toBeNull();
     } finally {
       providersRef.providers = providersRef.DEFAULT_PROVIDERS;

--- a/apps/desktop/src/renderer/lib/__tests__/modelPriceFormat.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/modelPriceFormat.test.ts
@@ -64,6 +64,66 @@ describe('modelPriceFormat', () => {
     ]);
   });
 
+  it('uses the effective Gateway price across Qwen cache dimensions', () => {
+    const standard = quote({
+      modelId: 'qwen/qwen3.7-max',
+      inputPerMtok: 12,
+      outputPerMtok: 36,
+      cacheReadPerMtok: 2.4,
+      cacheCreatePerMtok: 15,
+    });
+    const presentation = modelPricePresentation(standard, {
+      input: 6,
+      output: 18,
+      cacheRead: 1.2,
+      cacheWrite: 7.5,
+    });
+
+    expect(presentation).toEqual({
+      kind: 'priced',
+      current: quote({
+        modelId: 'qwen/qwen3.7-max',
+        inputPerMtok: 6,
+        outputPerMtok: 18,
+        cacheReadPerMtok: 1.2,
+        cacheCreatePerMtok: 7.5,
+      }),
+    });
+    expect(
+      presentation?.kind === 'priced' ? modelPriceDetailRows(presentation.current) : [],
+    ).toEqual([
+      { kind: 'input', value: '¥6' },
+      { kind: 'output', value: '¥18' },
+      { kind: 'cacheRead', value: '¥1.2' },
+      { kind: 'cacheCreate', value: '¥7.5' },
+    ]);
+  });
+
+  it('falls back to the standard price when a cache dimension cannot confirm the effective price', () => {
+    const standard = quote({
+      inputPerMtok: 12,
+      outputPerMtok: 36,
+      cacheReadPerMtok: 2.4,
+      cacheCreatePerMtok: 15,
+    });
+
+    expect(
+      modelPricePresentation(standard, {
+        input: 6,
+        output: 18,
+        cacheRead: 1.2,
+      }),
+    ).toEqual({ kind: 'priced', current: standard });
+    expect(
+      modelPricePresentation(standard, {
+        input: 6,
+        output: 18,
+        cacheRead: 2.4,
+        cacheWrite: 7.5,
+      }),
+    ).toEqual({ kind: 'priced', current: standard });
+  });
+
   it('marks only an explicit double-zero model price with a confirmed missing quote as free', () => {
     expect(modelPricePresentation(null, { input: 0, output: 0 })).toEqual({
       kind: 'free',

--- a/apps/desktop/src/renderer/lib/modelPriceFormat.ts
+++ b/apps/desktop/src/renderer/lib/modelPriceFormat.ts
@@ -3,9 +3,18 @@ import type { ModelPriceQuote, MoneyCurrency } from '../../shared/regionalMoney'
 interface EffectiveModelCost {
   input?: number;
   output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
 }
 
-// input / output 缩放比例小于这个阈值时视为浮点噪声,按标准价展示。
+interface CompleteEffectiveModelCost {
+  input: number;
+  output: number;
+  cacheRead: number | undefined;
+  cacheWrite: number | undefined;
+}
+
+// 各价格维度的缩放比例小于这个阈值时视为浮点噪声,按标准价展示。
 const MIN_EFFECTIVE_PRICE_GAP = 0.0005;
 
 export type ModelPricePresentation =
@@ -37,23 +46,25 @@ function isNonNegativeFinite(value: unknown): value is number {
 }
 
 /**
- * effectiveCost 能否直接当展示价:要求 input / output 相对标准价是同一个缩放比例。
- * effectiveCost 不带缓存维度,若 quote 有非零缓存价就不敢覆盖 —— 否则明细里的
- * input / output 来自实际价、缓存行来自标准价,两套价表混在一张表上。
+ * effectiveCost 能否直接当展示价:要求已展示的 input / output / 缓存价格
+ * 相对标准价都是同一个缩放比例。标准价中的非零缓存维度必须有实际价对应,
+ * 避免在同一张明细表中混用实际价与标准价。
  */
 function effectiveCostIsConsistent(
   quote: ModelPriceQuote,
-  cost: Required<EffectiveModelCost>,
+  cost: CompleteEffectiveModelCost,
 ): boolean {
-  if ((quote.cacheReadPerMtok && quote.cacheReadPerMtok > 0) ||
-      (quote.cacheCreatePerMtok && quote.cacheCreatePerMtok > 0)) {
-    return false;
-  }
   const gaps: number[] = [];
   for (const [standard, effective] of [
     [quote.inputPerMtok, cost.input],
     [quote.outputPerMtok, cost.output],
+    [quote.cacheReadPerMtok, cost.cacheRead],
+    [quote.cacheCreatePerMtok, cost.cacheWrite],
   ] as const) {
+    if (standard === undefined) continue;
+    if (!isNonNegativeFinite(standard)) return false;
+    if (effective === undefined && standard === 0) continue;
+    if (!isNonNegativeFinite(effective)) return false;
     if (standard === 0) {
       if (effective !== 0) return false;
       continue;
@@ -84,19 +95,20 @@ export function modelPricePresentation(
     hasEffectiveCost &&
     input === 0 &&
     output === 0 &&
-    (quote === null || (
-      quote.inputPerMtok === 0 &&
-      quote.outputPerMtok === 0 &&
-      (!quote.cacheReadPerMtok || quote.cacheReadPerMtok === 0) &&
-      (!quote.cacheCreatePerMtok || quote.cacheCreatePerMtok === 0)
-    ))
+    (quote === null ||
+      (quote.inputPerMtok === 0 &&
+        quote.outputPerMtok === 0 &&
+        (!quote.cacheReadPerMtok || quote.cacheReadPerMtok === 0) &&
+        (!quote.cacheCreatePerMtok || quote.cacheCreatePerMtok === 0)))
   ) {
     return { kind: 'free' };
   }
   if (quote === null) return null;
   if (!hasEffectiveCost) return { kind: 'priced', current: quote };
 
-  if (!effectiveCostIsConsistent(quote, { input, output })) {
+  const cacheRead = effectiveCost?.cacheRead;
+  const cacheWrite = effectiveCost?.cacheWrite;
+  if (!effectiveCostIsConsistent(quote, { input, output, cacheRead, cacheWrite })) {
     return { kind: 'priced', current: quote };
   }
   return {
@@ -105,13 +117,17 @@ export function modelPricePresentation(
       ...quote,
       inputPerMtok: input,
       outputPerMtok: output,
+      ...(quote.cacheReadPerMtok !== undefined
+        ? { cacheReadPerMtok: cacheRead ?? quote.cacheReadPerMtok }
+        : {}),
+      ...(quote.cacheCreatePerMtok !== undefined
+        ? { cacheCreatePerMtok: cacheWrite ?? quote.cacheCreatePerMtok }
+        : {}),
     },
   };
 }
 
-export function modelPriceDetailRows(
-  quote: ModelPriceQuote,
-): Array<{
+export function modelPriceDetailRows(quote: ModelPriceQuote): Array<{
   kind: 'input' | 'output' | 'cacheRead' | 'cacheCreate';
   value: string;
 }> {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 XD Gateway 模型带缓存价格时，客户端无法采用并展示实际价格的问题。

此前价格展示层只能校验输入和输出价格；只要标准报价包含非零缓存读写价格，就会放弃采用 `CatalogModel.cost`，因此 Qwen 3.7 Max 虽然已从网关拿到完整实际价，模型选择器仍显示标准价。

现在客户端会同时校验输入、输出、缓存读取和缓存写入四个价格维度。只有所有已展示维度都采用同一缩放比例时才使用实际价；缓存维度缺失或比例不一致时仍安全回退标准价。

本 PR 已按最新 `main`（#453）的产品语义处理：只展示实际价，不恢复折扣徽标或划线原价。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Qwen 3.7 Max 实际价格未在客户端展示
- 本 PR 包含：Desktop 模型实际价一致性校验、缓存读写实际价展示，以及对应单元和组件回归测试
- 明确不包含：网关价格接口、计费计算、用量统计、Mobile 模型选择器
- 用户可见变化：Qwen 3.7 Max 行展示实际输入/输出价 `¥6 / ¥18`，详情展示缓存读取 `¥1.2` 和缓存写入 `¥7.5`；不显示折扣徽标或标准价对比
- 是否存在 breaking change：无

### UI 变化

- macOS Desktop 模型选择器：带缓存报价的模型可以正确展示 Gateway 实际价
- 复用现有价格行与详情样式，没有新增布局、视觉 token、徽标或原价对比
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Component Stylings、§10 Light / Dark Dual-Mode Delivery Gate

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/modelPriceFormat.test.ts src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：2 个测试文件、33 项测试全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：所有可运行 workspace 均通过

pnpm --filter desktop exec eslint src/renderer/lib/modelPriceFormat.ts src/renderer/lib/__tests__/modelPriceFormat.test.ts src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过

pnpm --filter desktop exec prettier --check src/renderer/lib/modelPriceFormat.ts src/renderer/lib/__tests__/modelPriceFormat.test.ts src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过
```

### 手工验证

- macOS Desktop CN 开发环境中已完成 Qwen 实际输入/输出价及缓存明细的 Light / Dark 双模式验收
- rebase 后按最新 `main` 移除折扣徽标和原价对比的行为由组件测试覆盖

### 未执行的验证

- 未在 Windows 实机验证；改动为纯 Renderer 价格展示逻辑，未修改平台相关代码

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 XD Gateway 模型选择器中的价格展示，不改变标准报价、实际计费或用量估算
- 回滚 / 降级方式：回滚本提交即可恢复原有展示逻辑；缓存维度无法完整校验时仍会自动回退标准价

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档；已补充回归测试）
- [x] 已确认测试结果或说明未执行原因
