### PR TITLE
fix(desktop): 金额展示去掉 ≈ 前缀,充值弹窗移除「取消支付」按钮

### DIFF
--- a/apps/desktop/src/renderer/__tests__/usageFormat.test.ts
+++ b/apps/desktop/src/renderer/__tests__/usageFormat.test.ts
@@ -35,6 +35,6 @@ describe('formatTurnCostMoney', () => {
         approximate: true,
         kind: 'value-estimate',
       }),
-    ).toBe('≈$0.00');
+    ).toBe('$0.00');
   });
 });

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1024,7 +1024,6 @@ function ModelSelectorContentView({
                       </span>
                       <span className="flex items-center justify-end gap-1.5 tabular-nums">
                         <span className="text-[var(--model-item-text)]">
-                          {editingPricePresentation.current.approximate ? '≈' : ''}
                           {row.value}
                         </span>
                       </span>

--- a/apps/desktop/src/renderer/components/new-chat/UsageDailyBars.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/UsageDailyBars.tsx
@@ -60,7 +60,7 @@ interface DayBar {
    * 纯 Codex 订阅日 costUsd 为 0, 仍按估算分段撑起柱子。
    */
   effectiveAmount: number;
-  /** 总额包含 Codex 订阅价值估算 → 总额前缀 ≈ 并展示 tooltip 解释。 */
+  /** 总额包含 Codex 订阅价值估算 → tooltip 展示估算解释。 */
   approximate: boolean;
 }
 

--- a/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
@@ -14,7 +14,6 @@ interface BillingCheckoutDialogProps {
   onClose: () => void;
   onRefresh: () => void;
   onRetry: () => void;
-  onCancel: () => void;
 }
 
 function actionOf(state: BillingCheckoutState) {
@@ -26,7 +25,6 @@ export function BillingCheckoutDialog({
   onClose,
   onRefresh,
   onRetry,
-  onCancel,
 }: BillingCheckoutDialogProps) {
   const { t } = useTranslation();
   const action = actionOf(state);
@@ -85,10 +83,6 @@ export function BillingCheckoutDialog({
     (state.error && state.intent !== null && state.order === null && state.subscription === null) ||
     (state.kind === 'TOPUP' &&
       (state.order?.status === 'FAILED' || state.order?.status === 'EXPIRED'));
-  const canCancel =
-    state.kind === 'TOPUP' &&
-    state.order !== null &&
-    (state.order.status === 'CREATED' || state.order.status === 'PENDING');
 
   return (
     <Dialog.Root
@@ -220,18 +214,7 @@ export function BillingCheckoutDialog({
             )}
           </div>
 
-          <div className="flex min-h-16 items-center justify-between gap-3 border-t border-[var(--border-default)] px-6 py-3">
-            <div>
-              {canCancel && (
-                <button
-                  type="button"
-                  onClick={onCancel}
-                  className="h-9 rounded-full px-3 text-12 text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-hover-soft)]"
-                >
-                  {t('billing.actions.cancelPayment')}
-                </button>
-              )}
-            </div>
+          <div className="flex min-h-16 items-center justify-end gap-3 border-t border-[var(--border-default)] px-6 py-3">
             <div className="flex items-center gap-2">
               {state.phase === 'AWAITING_PAYMENT' && (
                 <button

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -756,7 +756,6 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
         onClose={checkout.close}
         onRefresh={() => void checkout.refreshActive()}
         onRetry={() => void checkout.retry()}
-        onCancel={() => void checkout.cancel()}
       />
 
       <PlanChangeTargetDialog

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7236,7 +7236,6 @@
       "retry": "Retry",
       "pay": "Review and pay",
       "refresh": "Refresh status",
-      "cancelPayment": "Cancel payment",
       "close": "Close"
     },
     "catalog": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7225,7 +7225,6 @@
       "retry": "再試行",
       "pay": "確認して支払う",
       "refresh": "状態を更新",
-      "cancelPayment": "支払いをキャンセル",
       "close": "閉じる"
     },
     "catalog": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7225,7 +7225,6 @@
       "retry": "다시 시도",
       "pay": "확인 및 결제",
       "refresh": "상태 새로고침",
-      "cancelPayment": "결제 취소",
       "close": "닫기"
     },
     "catalog": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7225,7 +7225,6 @@
       "retry": "重试",
       "pay": "确认并支付",
       "refresh": "刷新状态",
-      "cancelPayment": "取消支付",
       "close": "关闭"
     },
     "catalog": {

--- a/apps/desktop/src/renderer/lib/__tests__/modelPriceFormat.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/modelPriceFormat.test.ts
@@ -25,7 +25,7 @@ describe('modelPriceFormat', () => {
     expect(formatModelPricePair(quote())).toBe('¥3 / ¥15');
   });
 
-  it('adds the approximate marker only once', () => {
+  it('renders approximate quotes without an approximate marker', () => {
     expect(
       formatModelPricePair(
         quote({
@@ -35,7 +35,7 @@ describe('modelPriceFormat', () => {
           outputPerMtok: 100.5,
         }),
       ),
-    ).toBe('≈¥20.1 / ¥100.5');
+    ).toBe('¥20.1 / ¥100.5');
   });
 
   it('includes configured cache prices in details', () => {

--- a/apps/desktop/src/renderer/lib/__tests__/turnUsageTooltip.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/turnUsageTooltip.test.ts
@@ -64,7 +64,7 @@ describe('buildTurnUsageTooltipLines — 按模型成本明细', () => {
         (l) =>
           l.startsWith('usageDetails.modelCostLine') &&
           l.includes('Opus 4.8') &&
-          l.includes('≈¥6.30'),
+          l.includes('¥6.30'),
       ),
     ).toBe(true);
     expect(
@@ -72,7 +72,7 @@ describe('buildTurnUsageTooltipLines — 按模型成本明细', () => {
         (l) =>
           l.startsWith('usageDetails.modelCostLine') &&
           l.includes('Haiku 4.5') &&
-          l.includes('≈¥5.36'),
+          l.includes('¥5.36'),
       ),
     ).toBe(true);
     expect(out.some((l) => l.startsWith('usageDetails.modelLine'))).toBe(false);

--- a/apps/desktop/src/renderer/lib/modelPriceFormat.ts
+++ b/apps/desktop/src/renderer/lib/modelPriceFormat.ts
@@ -29,7 +29,7 @@ export function formatModelPriceAmount(amount: number, currency: MoneyCurrency):
 export function formatModelPricePair(quote: ModelPriceQuote): string {
   const input = formatModelPriceAmount(quote.inputPerMtok, quote.currency);
   const output = formatModelPriceAmount(quote.outputPerMtok, quote.currency);
-  return `${quote.approximate ? '≈' : ''}${input} / ${output}`;
+  return `${input} / ${output}`;
 }
 
 function isNonNegativeFinite(value: unknown): value is number {

--- a/apps/desktop/src/renderer/lib/usageFormat.ts
+++ b/apps/desktop/src/renderer/lib/usageFormat.ts
@@ -37,10 +37,10 @@ export function formatTurnCostUsd(n: number): string {
 }
 
 function moneyPrefix(money: RegionalMoney): string {
-  return `${money.approximate ? '≈' : ''}${money.currency === 'CNY' ? '¥' : '$'}`;
+  return money.currency === 'CNY' ? '¥' : '$';
 }
 
-/** 区域金额的紧凑展示；币种与约值语义来自金额本身。 */
+/** 区域金额的紧凑展示；币种来自金额本身。 */
 export function formatCompactMoney(money: RegionalMoney): string {
   const prefix = moneyPrefix(money);
   if (money.amount >= 1000) return `${prefix}${(money.amount / 1000).toFixed(1)}k`;
@@ -56,14 +56,13 @@ export function formatMoney(money: RegionalMoney): string {
 /** 每轮 / 每模型金额：固定两位；小于最小货币展示单位时显示下界。 */
 export function formatTurnCostMoney(money: RegionalMoney): string {
   const symbol = money.currency === 'CNY' ? '¥' : '$';
-  const approximate = money.approximate ? '≈' : '';
   if (money.amount === 0) {
-    return `${approximate}${symbol}0.00`;
+    return `${symbol}0.00`;
   }
   if (money.amount >= 0.01) {
-    return `${approximate}${symbol}${money.amount.toFixed(2)}`;
+    return `${symbol}${money.amount.toFixed(2)}`;
   }
-  return `${approximate}<${symbol}0.01`;
+  return `<${symbol}0.01`;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

清理金额展示中的「≈」约等号前缀：固定汇率折算（fixed-fx）与订阅价值估算会让 CNY 环境下几乎所有金额（会话价值、每轮成本、模型单价、用量看板）都带 ≈ 前缀，视觉噪声大且信息量低。展示层不再渲染该前缀；`RegionalMoney.approximate` / `ModelPriceQuote.approximate` 数据语义保留，仍驱动 tooltip 估算说明（如 fixedFx、subscriptionEstimate 文案）与相关逻辑判断。

顺带按需求删除充值支付弹窗（BillingCheckoutDialog）左下角的「取消支付」按钮：移除按钮与 onCancel 传参链路，底栏改为右对齐，弹窗仍可通过右上角 × 关闭；`useBillingCheckout.cancel` 能力保留，仅移除 UI 入口；同步清理四语言不再使用的 `billing.actions.cancelPayment` 文案。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（口头需求，见截图：会话列表「价值 ≈¥7.37」、充值等待支付弹窗）
- 本 PR 包含：usageFormat / modelPriceFormat / ModelSelector 价格明细的 ≈ 前缀移除；BillingCheckoutDialog「取消支付」按钮删除及 locale 清理；相关单测断言更新
- 明确不包含：`approximate` / `estimateReasons` 数据字段的删除或语义变更；estimateReasons 相关 tooltip 说明文案；`useBillingCheckout.cancel` 与服务端取消能力
- 用户可见变化：所有金额展示不再带 ≈ 前缀；充值支付弹窗左下角不再有「取消支付」按钮
- 是否存在 breaking change：无

### UI 变化

纯文案/元素移除，无新增视觉元素（macOS Desktop）：
- 金额文本：`≈¥7.37` → `¥7.37`（会话价值、每轮成本 tooltip、模型价格明细、用量看板同口径）
- 充值支付弹窗底栏：移除左下角「取消支付」文字按钮，右侧「刷新状态」等按钮保持右对齐

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Layout Principles — Whitespace Philosophy（低内容密度、去除低信息量元素）。本次仅删除文本字符与冗余按钮，不涉及配色/字体/间距 token 变更；改动为无主题分支的文本节点删除，Light/Dark 两模式行为一致（双模式交付门槛不受影响）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过（exit 0）

pnpm test:unit
结果：通过（exit 0，无 FAIL，含 PASS apps/desktop unit）

npx vitest run usageFormat.test.ts modelPriceFormat.test.ts turnUsageTooltip.test.ts modelSelectorTriggerVariant.test.ts
结果：4 files / 47 tests 全部通过
```

### 手工验证

未执行：改动在独立 worktree 内完成，无法热更到运行中的 dev 实例。变更均为纯展示层文本/元素删除，行为由上述单测覆盖（含 approximate:true 输入不再输出 ≈ 的断言）。

### 未执行的验证

运行时 UI 目测（原因同上）；四语言 locale 仅删除一个 key，已用 JSON.parse 校验四个文件合法。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop renderer 金额展示与充值弹窗底栏；不触及数据模型、持久化与协议
- 回滚 / 降级方式：revert 本 PR 两个 commit 即可完整恢复

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
