### PR TITLE
feat(models): enable DeepSeek V4 Flash by default

### DIFF
--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -1196,8 +1196,7 @@
         ],
         "defaultEffort": "high",
         "sortOrder": 45,
-        "supportsFastMode": false,
-        "defaultEnabled": false
+        "supportsFastMode": false
       },
       "gpt-5.6-luna": {
         "agents": [

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -170,6 +170,13 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     }
   });
 
+  it('enables DeepSeek V4 Flash by default', () => {
+    const metadata = BUNDLED_CATALOG.cindyModelMeta as {
+      models?: Record<string, { defaultEnabled?: boolean }>;
+    };
+    expect(metadata.models?.['deepseek/deepseek-v4-flash']?.defaultEnabled).toBeUndefined();
+  });
+
   it('models are grouped per-agent (no flat array, no rogue agent keys)', () => {
     for (const p of BUNDLED_CATALOG.providers) {
       expect(Array.isArray(p.models), `${p.id} models must be a per-agent map`).toBe(false);


### PR DESCRIPTION
## 这次改了什么

### 摘要

将内置模型 `deepseek/deepseek-v4-flash` 改为默认启用，并补充目录回归测试，锁定“未设置 `defaultEnabled` 即采用默认可见”的约定。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（直接需求）
- 本 PR 包含：调整 DeepSeek V4 Flash 的内置模型默认可见性；增加对应 catalog 回归测试。
- 明确不包含：网关能力、模型参数、服务端、UI 视觉或文案改动。
- 用户可见变化：未自定义该模型可见性的用户将默认看到并可选择 DeepSeek V4 Flash。已有本地显式启用/禁用配置仍优先于系统默认；恢复默认后会跟随新的系统默认并显示该模型。
- 是否存在 breaking change：无。

### UI 变化

不涉及：仅修改模型目录默认可见性元数据及其单元测试，没有修改 UI 视觉、布局、交互或文案。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
NODE_OPTIONS=--require=/private/tmp/cindy-localhost-dns.cjs pnpm test:unit
结果：通过；workspace 中全部适用单测套件 PASS。

NODE_OPTIONS=--require=/private/tmp/cindy-localhost-dns.cjs pnpm --filter @cindy/model-providers run --if-present typecheck
结果：通过；该 package 没有 typecheck script，按仓库门禁命令自动跳过。

NODE_OPTIONS=--require=/private/tmp/cindy-localhost-dns.cjs pnpm --filter @cindy/model-providers build
结果：通过（tsc --noEmit）。

NODE_OPTIONS=--require=/private/tmp/cindy-localhost-dns.cjs pnpm --filter @cindy/model-providers test -- src/__tests__/catalog.test.ts
结果：通过（7 个测试文件，134 个测试）。

pnpm check:dco
结果：通过；1 个 commit 已签名。
```

### 手工验证

不涉及：这是模型目录元数据变更，默认值与配置覆盖行为由现有测试和新增回归测试覆盖。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响尚未对 DeepSeek V4 Flash 设置本地可见性覆盖的用户；已有显式启用/禁用选择保持不变。
- 回滚 / 降级方式：恢复该模型的 `"defaultEnabled": false`，并移除对应回归断言。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及文档变更）
- [x] 已确认测试结果或说明未执行原因
