### PR TITLE
fix(desktop): global 桌面包全部可见名称统一为 Cindy

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -38,10 +38,11 @@ process.env.VITE_CINDY_AUTH_REGION = CINDY_REGION;
 const CINDY_APP_ID = brandAppId(CINDY_REGION);
 const CINDY_UTI_PREFIX = brandBundleIdPrefix(CINDY_REGION);
 /**
- * 可执行文件基名,按区域派生(cn 'Cindy' / global 'CindyGlobal'):同机双装时
- * exe / mac .app 包名 / NSIS 安装目录与快捷方式若同名,第二个安装会覆盖第一个,
- * 更新器按 exe 名杀进程也会误伤另一区域。运行时 userData 目录由 main 入口按
- * 同一区域切换(src/main/regionUserData.ts),两端从 brand-identity 同源派生。
+ * 可执行文件基名,按区域派生(cn/global 同值 'Cindy',dev 'CindyDev';
+ * 2026-07-26 显示名统一决策,cn/global 文件层双装隔离随之放弃,见
+ * brandIdentity.ts executableNameByRegion doc)。运行时 userData 目录由 main
+ * 入口按同一区域切换(src/main/regionUserData.ts),两端从 brand-identity
+ * 同源派生,cn/global 数据仍分库。
  */
 const CINDY_EXE = brandExecutableName(CINDY_REGION);
 /** 更新器二进制文件名(cindy-updater.exe)。 */
@@ -636,11 +637,11 @@ function signPackagedExes(buildPath: string): void {
  * ⚠️ 绝不能改 CFBundleName:Electron 启动时用主 app 的 CFBundleName 拼
  * `Frameworks/<CFBundleName> Helper.app` 查找 Helper(electron_main_delegate_mac.mm,
  * 唯一 fallback 是 'Electron Helper.app'),而 Helper 目录名跟随 packager name
- * (区域派生:cn 'Cindy' / global 'CindyGlobal' / dev 'CindyDev')。把
- * CFBundleName 改成 Cindy 会让 global/dev 包启动即 FATAL
- * "Unable to find helper app"(SIGTRAP;2026-07-21 dev region smoke 实踩)。
- * 代价:菜单栏粗体标题取自 CFBundleName 且运行时改不了,global/dev 构建上
- * 显示区域 exe 名而非 Cindy——cn(packager 已写 Cindy)不受影响,可接受。
+ * (区域派生:cn/global 'Cindy' / dev 'CindyDev')。把 CFBundleName 改成
+ * 与 Helper 目录不一致的值会让包启动即 FATAL "Unable to find helper app"
+ * (SIGTRAP;2026-07-21 dev region smoke 实踩)。
+ * 代价:菜单栏粗体标题取自 CFBundleName 且运行时改不了,dev 构建上显示
+ * CindyDev 而非 Cindy——cn/global(packager 已写 Cindy)不受影响,可接受。
  *
  * 为什么在 postPackage 改而不是 packagerConfig:electron-packager 在
  * updatePlistFiles 里先合并 extendInfo、后用 appName/executableName 覆写
@@ -650,11 +651,11 @@ function signPackagedExes(buildPath: string): void {
  * 历史沿革:本步骤诞生于身份翻转前(当时 .app/CFBundleExecutable/bundle id/
  * userData 均为 xdt-maker 系,这里是唯一的显示名来源)。2026-07-17 身份翻转后
  * cn 构建的 packager 本身就会把 CFBundleName/CFBundleDisplayName 写成 Cindy,
- * 对 cn 是冗余兜底;2026-07-18 双装支持后 global 构建的 packager name 是
- * 'CindyGlobal'(.app 目录名 / 标识符层),本步骤把 Dock 名、Cmd+Tab、
- * 系统通知的**显示层**统一拉回 Cindy(BRAND_NAME 各区共用)——对
- * global/dev 不再冗余,是显示名的唯一来源。正式签名/公证(外部发布流程)
- * 发生在 postPackage 之后,本改动会被签名一起封印,不存在破坏签名问题。
+ * 对 cn 是冗余兜底;2026-07-26 global exe 名与 cn 统一为 'Cindy' 后 global
+ * 同样只是冗余兜底;dev 构建的 packager name 仍是 'CindyDev',本步骤把
+ * Dock 名、Cmd+Tab、系统通知的**显示层**拉回 Cindy(BRAND_NAME 各区共用),
+ * 对 dev 是显示名的唯一来源。正式签名/公证(外部发布流程)发生在
+ * postPackage 之后,本改动会被签名一起封印,不存在破坏签名问题。
  */
 function applyMacPackagedDisplayName(buildPath: string, platform: string): void {
   if (platform !== 'darwin') return;
@@ -1003,7 +1004,7 @@ const makers: ForgeConfig['makers'] = [
       // 双 scheme:cindy 主 + xdt-maker 兼容(老分享链接不死)。
       mimeType: allDeepLinkSchemes().map((s) => `x-scheme-handler/${s}`),
       maintainer: 'Lizi <feedback@cindy.app>',
-      // deb 包名规范要求小写;跟随区域 exe 名(cn cindy / global cindyglobal)。
+      // deb 包名规范要求小写;跟随区域 exe 名(cn/global cindy / dev cindydev)。
       name: CINDY_EXE.toLowerCase(),
       bin: CINDY_EXE,
       productName: CINDY_EXE,
@@ -1043,9 +1044,10 @@ if (isWin) {
         // 才会接收 toast；否则原生 Notification 被静默丢弃。
         // 值按构建区域派生(shared/brandRegion 运行时同源),见文件头身份块。
         appId: CINDY_APP_ID,
-        // 安装目录名跟随区域(默认装到 …\Programs\<productName>):cn 'Cindy' /
-        // global 'CindyGlobal'。不设的话 app-builder 回落 package.json 的
-        // productName('Cindy'),两个区域会装进同一目录互相覆盖(双装红线)。
+        // 安装目录名跟随区域 exe 名(默认装到 …\Programs\<productName>):
+        // cn/global 'Cindy'(2026-07-26 显示名统一,双装同目录互抢已被 owner
+        // 接受)/ dev 'CindyDev'(仍与正式包隔离)。显式设值防 app-builder
+        // 回落 package.json productName 造成 dev 与正式包同目录。
         productName: CINDY_EXE,
         nsis: {
           oneClick: false,
@@ -1054,10 +1056,11 @@ if (isWin) {
           uninstallerIcon: 'resources/icon.ico',
           createDesktopShortcut: 'always',
           createStartMenuShortcut: true,
-          // 快捷方式显示名,跟随区域 exe 名(cn 'Cindy' / global 'CindyGlobal',
-          // 同名 .lnk 双装互抢)。installer.nsh 只清理/重建自家 .lnk——同机可能
-          // 并存老 XDMaker 安装,它的 xdt-maker.lnk / XDMaker.lnk 属于老 app,
-          // 绝不能删(共存红线,见 installer.nsh customInit 注释)。
+          // 快捷方式显示名,跟随区域 exe 名(cn/global 'Cindy'——同名 .lnk
+          // 双装互抢已被 owner 接受 / dev 'CindyDev')。installer.nsh 只清理/
+          // 重建自家 .lnk——同机可能并存老 XDMaker 安装,它的 xdt-maker.lnk /
+          // XDMaker.lnk 属于老 app,绝不能删(共存红线,见 installer.nsh
+          // customInit 注释)。
           shortcutName: CINDY_EXE,
           runAfterFinish: true,
           include: 'resources/installer.nsh',
@@ -1088,11 +1091,12 @@ const config: ForgeConfig = {
     // 所以这里显式覆盖 loudness / node-pty 整个目录。
     asar: { unpack: '**/{@img/{sharp-libvips-*,sharp-win32-*},loudness,native/sqlite-vec,node-pty}/**' },
     // 打包名(out 目录 / mac .app 包名 / Helper 目录名 / 主 plist CFBundleName)
-    // 按区域派生:不设的话 packager 回落 package.json productName('Cindy'),
-    // global 的 .app 会与 cn 撞名(双装时拖进 /Applications 直接覆盖)。mac 的
-    // Dock/Cmd+Tab/通知**显示名**由 postPackage 的 applyMacPackagedDisplayName
-    // 经 CFBundleDisplayName 统一拉回 Cindy(显示层共用 BRAND_NAME,标识符层
-    // 分区域;CFBundleName 不可动,Electron 靠它找 Helper,见该函数注释)。
+    // 按区域派生:cn/global 'Cindy'(2026-07-26 显示名统一,.app 撞名双装
+    // 互覆已被 owner 接受)/ dev 'CindyDev'(显式设值防 packager 回落
+    // package.json productName 让 dev 与正式包撞名)。mac 的 Dock/Cmd+Tab/
+    // 通知**显示名**由 postPackage 的 applyMacPackagedDisplayName 经
+    // CFBundleDisplayName 统一拉回 Cindy(对 dev 是唯一显示名来源;
+    // CFBundleName 不可动,Electron 靠它找 Helper,见该函数注释)。
     name: CINDY_EXE,
     executableName: CINDY_EXE,
     // mac bundle id(与 Windows AUMID 同值,按区域派生;cn/global 是两个可并存

--- a/apps/desktop/resources/installer.nsh
+++ b/apps/desktop/resources/installer.nsh
@@ -1,11 +1,12 @@
-; 区域身份参数化(2026-07-18 同机双装):本文件不再硬编码 Cindy 字面量,
+; 区域身份参数化:本文件不再硬编码 Cindy 字面量,
 ; 一律走 electron-builder 在 common.nsh 里注入的宏——
-;   ${APP_EXECUTABLE_FILENAME} = <productName>.exe(cn Cindy.exe / global CindyGlobal.exe)
-;   ${PRODUCT_FILENAME}        = productName(cn Cindy / global CindyGlobal)
+;   ${APP_EXECUTABLE_FILENAME} = <productName>.exe(cn/global Cindy.exe / dev CindyDev.exe)
+;   ${PRODUCT_FILENAME}        = productName(cn/global Cindy / dev CindyDev)
 ;   ${SHORTCUT_NAME}           = forge.config nsis.shortcutName(与 exe 基名同源)
-; 这样 cn 安装器只杀/只删自己区域的进程与快捷方式,绝不误伤同机并存的另一
-; 区域安装(双装红线)。注册表键名 Windows 大小写不敏感,cn 的 shell 键
-; "Cindy" 与历史写入的 "cindy" 是同一个键,行为零变化。
+; 2026-07-26 起 cn/global exe 名同值(显示名统一,双装文件层互抢已被 owner
+; 接受);dev 仍独立名,dev 安装器绝不误伤同机并存的正式安装。注册表键名
+; Windows 大小写不敏感,shell 键 "Cindy" 与历史写入的 "cindy" 是同一个键,
+; 行为零变化。
 !macro customInit
   ; Check if the app is already running
   check_running:
@@ -43,9 +44,9 @@
   ; 用 HKCU 不用 HKLM:不需要管理员权限, 多用户机器上每个用户启动 app 时自注册。
   ; %V 在 Directory\shell / Directory\Background\shell 两种上下文里都解析为
   ; "用户右键所在的目录" 路径, argv 直传不做 URL 编解码 (deep link 走 cindy:// 另一套)。
-  ; 键名用 ${PRODUCT_FILENAME}(区域身份):cn 'Cindy' 与历史 'cindy' 键大小写
-  ; 不敏感同键;global 'CindyGlobal' 独立键——双装时两条菜单项并存互不覆盖,
-  ; 也与老 XDMaker 安装的 xdt-maker 键并存。
+  ; 键名用 ${PRODUCT_FILENAME}(区域身份):cn/global 'Cindy' 与历史 'cindy'
+  ; 键大小写不敏感同键(2026-07-26 起两区同键,双装互写已被 owner 接受);
+  ; dev 'CindyDev' 独立键;都与老 XDMaker 安装的 xdt-maker 键并存。
   WriteRegStr HKCU "Software\Classes\Directory\shell\${PRODUCT_FILENAME}" "" "通过 ${PRODUCT_FILENAME} 打开"
   WriteRegStr HKCU "Software\Classes\Directory\shell\${PRODUCT_FILENAME}" "Icon" "$INSTDIR\${APP_EXECUTABLE_FILENAME},0"
   WriteRegStr HKCU "Software\Classes\Directory\shell\${PRODUCT_FILENAME}\command" "" '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" --open-folder "%V"'

--- a/apps/desktop/scripts/ci/lib.mjs
+++ b/apps/desktop/scripts/ci/lib.mjs
@@ -70,15 +70,15 @@ export const RELEASE_DIR = path.join(DESKTOP_ROOT, 'release');
 export const PACKAGED_APP_NAME = 'Cindy';
 
 /**
- * 按区域取打包产物基名(2026-07-18 同机双装:cn 'Cindy' / global 'CindyGlobal',
- * exe / .app / 安装目录 / 快捷方式全部跟随)。镜像
- * brandIdentity.ts 的 executableNameByRegion,一致性同样由
+ * 按区域取打包产物基名(exe / .app / 安装目录 / 快捷方式全部跟随)。
+ * cn/global 同值 'Cindy'(2026-07-26 显示名统一决策,放弃文件层双装隔离),
+ * dev 独立。镜像 brandIdentity.ts 的 executableNameByRegion,一致性由
  * scripts/__tests__/brand-identity-sync.test.mjs 断言兜底。
  * PACKAGED_APP_NAME 保留为 cn 基线值,供未传 region 的 legacy 脚本使用。
  */
 export const PACKAGED_APP_NAME_BY_REGION = Object.freeze({
   cn: 'Cindy',
-  global: 'CindyGlobal',
+  global: 'Cindy',
   dev: 'CindyDev',
 });
 
@@ -745,7 +745,7 @@ export function createMacDMG(appPath, dmgPath, volumeName, identity) {
     throw new Error(`DMG background missing: ${backgroundPath}`);
   }
 
-  const appName = path.basename(appPath); // Cindy.app / CindyGlobal.app(global 线)
+  const appName = path.basename(appPath); // Cindy.app(cn/global)/ CindyDev.app(dev 线)
   // JSON.stringify 产出合法 Python 字符串字面量(转义引号/反斜杠语义一致)
   const py = (s) => JSON.stringify(s);
   const settings = [
@@ -790,7 +790,7 @@ export function runSmokeTest(platform, arch, region = 'cn') {
       'scripts/smoke-packaged.mjs',
       `--platform=${platform}`,
       `--arch=${arch}`,
-      // 产物基名按区域派生(global 的 out 目录 / exe / .app 是 CindyGlobal)。
+      // 产物基名按区域派生(cn/global 'Cindy' / dev 'CindyDev')。
       `--app-name=${packagedAppName(region)}`,
     ],
     { stdio: 'inherit', cwd: DESKTOP_ROOT, shell: false },

--- a/apps/desktop/scripts/package-desktop.mjs
+++ b/apps/desktop/scripts/package-desktop.mjs
@@ -354,8 +354,8 @@ async function finishDarwin({ artifactDir, baseName, appName, arch, versionless,
 
     const dmgPath = path.join(artifactDir, `${baseName}-${arch}.dmg`);
     console.log('==> Creating DMG...');
-    // DMG 卷名 = 安装窗口标题,走 '<appName> Installer'(cn 'Cindy Installer',
-    // global 'CindyGlobal Installer',双装机器仍可区分挂载卷);版本号不进卷名,
+    // DMG 卷名 = 安装窗口标题,走 '<appName> Installer'(cn/global
+    // 'Cindy Installer' / dev 'CindyDev Installer');版本号不进卷名,
     // 安装包文件名里已有。
     createMacDMG(appPath, dmgPath, `${appName} Installer`, identity);
     files.push(fileEntry('installer', dmgPath));
@@ -448,7 +448,7 @@ async function main() {
   // 版本号临时写入 package.json(asar 内 app.getVersion() 的来源),退出自动恢复。
   writePackageVersion(version);
 
-  // 产物基名按区域派生(cn 'Cindy' / global 'CindyGlobal',out 目录 / exe /
+  // 产物基名按区域派生(cn/global 'Cindy' / dev 'CindyDev',out 目录 / exe /
   // .app 同名;forge.config 的 packagerConfig.name 同源)。
   const appName = packagedAppName(region);
   const baseName = artifactBaseName({ version, versionless });

--- a/apps/desktop/scripts/smoke-packaged.mjs
+++ b/apps/desktop/scripts/smoke-packaged.mjs
@@ -39,7 +39,7 @@ const DESKTOP_ROOT = path.resolve(__dirname, '..');
  * BRAND_IDENTITY.executableName 及 ci/lib.mjs 的 PACKAGED_APP_NAME 一致
  * (本脚本刻意零外部依赖,不 import lib.mjs;一致性由
  * scripts/__tests__/brand-identity-sync.test.mjs 断言兜底)。
- * 区域化(同机双装):global 产物基名是 CindyGlobal,由调用方
+ * 区域化:产物基名按区域派生(cn/global 'Cindy' / dev 'CindyDev'),由调用方
  * (ci/lib.mjs runSmokeTest)经 --app-name= 传入覆盖,本默认值只服务 cn / 手跑。
  */
 const PACKAGED_APP_NAME = 'Cindy';

--- a/apps/desktop/src/main/__tests__/regionUserData.test.ts
+++ b/apps/desktop/src/main/__tests__/regionUserData.test.ts
@@ -36,7 +36,7 @@ describe('resolveRegionUserDataDirName', () => {
       resolveRegionUserDataDirName({
         isPackaged: true,
         region: 'global',
-        argv: ['CindyGlobal.exe', '--smoke-test', '--user-data-dir=C:\\tmp\\xdt-smoke-x'],
+        argv: ['Cindy.exe', '--smoke-test', '--user-data-dir=C:\\tmp\\xdt-smoke-x'],
       }),
     ).toBeNull();
     // 空格分隔形态同样尊重。
@@ -44,7 +44,7 @@ describe('resolveRegionUserDataDirName', () => {
       resolveRegionUserDataDirName({
         isPackaged: true,
         region: 'global',
-        argv: ['CindyGlobal.exe', '--user-data-dir', 'C:\\tmp\\xdt-smoke-x'],
+        argv: ['Cindy.exe', '--user-data-dir', 'C:\\tmp\\xdt-smoke-x'],
       }),
     ).toBeNull();
   });

--- a/apps/desktop/src/main/cindy-brain/fileAssociation.ts
+++ b/apps/desktop/src/main/cindy-brain/fileAssociation.ts
@@ -32,13 +32,12 @@ const REG_TIMEOUT_MS = 5_000;
 
 /**
  * 新身份 ProgId(2026-07-17 品牌翻转:XDMaker.CindyGhost → Cindy.CindyGhost;
- * 2026-07-18 双装区域化:按区域 exe 基名派生,cn 'Cindy.CindyGhost' 不变 /
- * global 'CindyGlobal.CindyGhost')。与并存的老 XDMaker 安装写的
- * `XDMaker.CindyGhost` ProgId、以及另一区域的 ProgId 各自独立,互不覆盖
- * (共用 ProgId 会让两个区域实例每次启动都把 open command 改写回自己,
- * 幂等检查永远不命中,反复写注册表);`.cindy` 扩展名的默认 handler 归
- * 后启动的那个 app(它把 KEY_EXT 默认值改写成自己的 ProgId),可接受——
- * 各 app 双击 .cindy 的行为语义一致。
+ * 按区域 exe 基名派生,cn/global 'Cindy.CindyGhost'——2026-07-26 显示名统一
+ * 后两区同 ProgId,双装时后启动方改写 open command 已被 owner 接受 / dev
+ * 'CindyDev.CindyGhost' 仍独立)。与并存的老 XDMaker 安装写的
+ * `XDMaker.CindyGhost` ProgId 各自独立,互不覆盖;`.cindy` 扩展名的默认
+ * handler 归后启动的那个 app(它把 KEY_EXT 默认值改写成自己的 ProgId),
+ * 可接受——各 app 双击 .cindy 的行为语义一致。
  */
 const PROG_ID = `${brandExecutableName(CURRENT_CINDY_REGION)}.CindyGhost`;
 const KEY_EXT = 'HKCU\\Software\\Classes\\.cindy';

--- a/apps/desktop/src/main/folderContextMenu.ts
+++ b/apps/desktop/src/main/folderContextMenu.ts
@@ -55,20 +55,19 @@ const log = createLogger('folderContextMenu');
  *
  * 文案故意全中文 / 不做 i18n:Windows 注册表 MUIVerb 多语言切换需要 .mui 资源
  * 文件,成本高。绝大多数用户是中文环境,英文用户能看懂品牌名即可。
- * 名字用区域 exe 基名(cn 'Cindy' / global 'CindyGlobal'):同机双装时两条
- * 菜单项文案可区分;与 installer.nsh customInstall 写入的文案保持一致,
+ * 名字用区域 exe 基名(cn/global 'Cindy' / dev 'CindyDev'):dev 包菜单项
+ * 文案与正式包可区分;与 installer.nsh customInstall 写入的文案保持一致,
  * 否则启动自愈会误判"值漂移"反复重写。
  */
 const MENU_LABEL = `通过 ${brandExecutableName(CURRENT_CINDY_REGION)} 打开`;
 
 /**
- * shell 子键名(2026-07-17 品牌翻转:xdt-maker → cindy;2026-07-18 双装
- * 区域化:按区域 exe 基名派生,cn 'Cindy' / global 'CindyGlobal')。
- * 必须与老 XDMaker 安装的 `...\shell\xdt-maker` 键、以及另一区域的键
- * **并存而不复用**:两个 app 若抢同一个键,后启动方会把 command 改回指向
- * 自己的 exe,互相覆盖没完。Windows 注册表键名大小写不敏感,cn 的 'Cindy'
- * 与历史写入的 'cindy' 是同一个键,存量用户行为零变化;与 installer.nsh
- * 的 ${PRODUCT_FILENAME} 键名同源。
+ * shell 子键名(2026-07-17 品牌翻转:xdt-maker → cindy;按区域 exe 基名
+ * 派生,cn/global 'Cindy'——2026-07-26 显示名统一后两区同键,双装互写已被
+ * owner 接受 / dev 'CindyDev' 仍独立)。必须与老 XDMaker 安装的
+ * `...\shell\xdt-maker` 键**并存而不复用**。Windows 注册表键名大小写不敏感,
+ * 'Cindy' 与历史写入的 'cindy' 是同一个键,存量用户行为零变化;与
+ * installer.nsh 的 ${PRODUCT_FILENAME} 键名同源。
  */
 const SHELL_KEY_NAME = brandExecutableName(CURRENT_CINDY_REGION);
 

--- a/apps/desktop/src/main/windowsShortcutSelfHeal.ts
+++ b/apps/desktop/src/main/windowsShortcutSelfHeal.ts
@@ -39,10 +39,10 @@ const log = createLogger('shortcutSelfHeal');
 const LEGACY_SHORTCUT_BASENAMES = ['xdt-maker', 'XDMaker'] as const;
 
 /**
- * 重建目标快捷方式名 = 本区域 NSIS shortcutName(cn 'Cindy' / global
- * 'CindyGlobal',与 forge.config 同源)。不能用共享的 BRAND_NAME:同机双装时
- * global 实例若写出 Cindy.lnk 会与 cn 安装的快捷方式互抢(实际上 legacy lnk
- * 的 target 只可能是 cn 系老安装,global 侧本函数天然 no-op,这里是防御性对齐)。
+ * 重建目标快捷方式名 = 本区域 NSIS shortcutName(cn/global 'Cindy' /
+ * dev 'CindyDev',与 forge.config 同源;2026-07-26 起 cn/global 同名,
+ * 双装 .lnk 互抢已被 owner 接受)。仍从 brandExecutableName 派生而不用共享的
+ * BRAND_NAME:dev 包必须写自己的 CindyDev.lnk,不能抢正式包的 Cindy.lnk。
  */
 const SHORTCUT_BASENAME = brandExecutableName(CURRENT_CINDY_REGION);
 

--- a/packages/maker-shared/src/__tests__/brandIdentity.test.ts
+++ b/packages/maker-shared/src/__tests__/brandIdentity.test.ts
@@ -51,12 +51,14 @@ describe('BRAND_IDENTITY invariants', () => {
     }
   });
 
-  it('双装身份区域字段两区互不相同(同机并存的硬前提)', () => {
-    // exe / userData 目录 / appId 任何一组撞名,同机双装都会互相覆盖
-    // (安装目录、数据库、系统身份)。cdnPrefix 两区共用是 owner 决策:
+  it('系统身份与数据目录两区互不相同;exe 名两区同值(显示名统一决策)', () => {
+    // userData 目录 / appId 撞名会让两区共库、共系统身份,必须保持分离。
+    // exe 名(安装目录 / .app / 快捷方式)2026-07-26 起 cn/global 同值
+    // 'Cindy':owner 决策显示名统一,放弃文件层双装隔离(见
+    // executableNameByRegion doc)。cdnPrefix 两区共用是 owner 决策:
     // 发布渠道靠不同 OSS bucket 区分,不靠路径前缀。
     expect(BRAND_IDENTITY.executableNameByRegion.cn)
-      .not.toBe(BRAND_IDENTITY.executableNameByRegion.global);
+      .toBe(BRAND_IDENTITY.executableNameByRegion.global);
     expect(BRAND_IDENTITY.userDataDirNameByRegion.cn)
       .not.toBe(BRAND_IDENTITY.userDataDirNameByRegion.global);
   });
@@ -130,7 +132,9 @@ describe('区域解析与派生', () => {
 
   it('brandExecutableName / brandUserDataDirName 按区域取值,默认 cn', () => {
     expect(brandExecutableName()).toBe('Cindy');
-    expect(brandExecutableName('global')).toBe('CindyGlobal');
+    // global 与 cn 同值(2026-07-26 显示名统一决策);dev 仍独立。
+    expect(brandExecutableName('global')).toBe('Cindy');
+    expect(brandExecutableName('dev')).toBe('CindyDev');
     expect(brandUserDataDirName()).toBe('Cindy');
     expect(brandUserDataDirName('global')).toBe('CindyGlobal');
   });

--- a/packages/maker-shared/src/brandIdentity.ts
+++ b/packages/maker-shared/src/brandIdentity.ts
@@ -12,9 +12,10 @@
  *
  * ⚠️ 语义边界:
  *  - 这是**构建期单点,不是运行时开关**。区域(cn/global)是唯一的构建期维度,
- *    经打包命令的 CINDY_AUTH_REGION 选择,默认 cn。appId / exe 名 / userData
- *    目录名按区域派生(cn 与 global 是两个可同机并存的系统身份,appId 与
- *    mobile 的 com.xd.cindycn / com.xd.cindy 同一套)。
+ *    经打包命令的 CINDY_AUTH_REGION 选择,默认 cn。appId / userData 目录名
+ *    按区域派生(cn 与 global 是两个可并存的系统身份,appId 与 mobile 的
+ *    com.xd.cindycn / com.xd.cindy 同一套);exe 名 cn/global 同值 'Cindy'
+ *    (2026-07-26 显示名统一决策,文件层双装隔离随之放弃,dev 仍独立)。
  *  - 历史兼容锚点(旧 scheme 解析、旧 userData / DB 文件识别)由
  *    `legacySchemes` / `legacyUserDataDirNames` / `legacyDbFilePrefixes`
  *    承载,只增不减:老用户机器上的存量注册与文件可能永远带着旧值。
@@ -74,10 +75,14 @@ export interface BrandIdentity {
    */
   readonly executableName: string;
   /**
-   * 按区域派生的可执行文件基名(同机双装:cn 与 global 的安装目录 / exe /
-   * mac .app 包名 / NSIS 快捷方式必须互不相同,否则第二个安装会覆盖第一个,
-   * 更新器按 exe 名杀进程也会误伤另一区域)。区域名不含空格(部分系统对
-   * 带空格路径的兼容性差,owner 决策)。
+   * 按区域派生的可执行文件基名(exe / mac .app 包名 / 安装目录 / NSIS
+   * 快捷方式全部跟随)。2026-07-26 owner 决策:cn 与 global 同值 'Cindy',
+   * 让 global 包在 Dock / Finder / 菜单栏 / Windows 快捷方式等全部位置显示
+   * Cindy——代价是 cn/global 同机双装时安装目录 / .app / .lnk 同名互抢
+   * (第二个安装覆盖第一个的文件与快捷方式,更新器按 exe 名杀进程会波及另一
+   * 区域),该场景明确放弃支持;appId 与 userData 目录仍按区域分离,系统身份
+   * 与数据互不影响。dev 保持独立名(CindyDev,可与正式包并存)。区域名不含
+   * 空格(部分系统对带空格路径的兼容性差,owner 决策)。
    */
   readonly executableNameByRegion: Readonly<Record<CindyRegion, string>>;
   /**
@@ -121,18 +126,22 @@ export interface BrandIdentity {
  * 当前生效的身份档案(Cindy,2026-07-17 翻转)。
  * 旧 xdt-maker 值全部下沉 legacy 数组。
  *
- * 区域差异字段(2026-07-18 起支持 cn / global 同机双装):appId、
- * executableName、userDataDirName 三组按区域派生;深链 scheme、展示名
- * BRAND_NAME、cdnPrefix、dbFilePrefix、updaterName 两区共用(scheme 共用是
- * owner 决策:双装时后注册者赢,单装用户无感;cdnPrefix 共用因发布渠道靠
- * 不同 OSS bucket 区分;db 前缀因 userData 已分目录无需再区分)。
+ * 区域差异字段:appId、userDataDirName 按区域派生(cn/global 是两个可并存
+ * 的系统身份,数据分库);executableName 自 2026-07-26 起 cn/global 同值
+ * (显示统一为 Cindy,放弃文件层双装隔离,见 executableNameByRegion doc),
+ * 仅 dev 保持独立名;深链 scheme、展示名 BRAND_NAME、cdnPrefix、dbFilePrefix、
+ * updaterName 两区共用(scheme 共用是 owner 决策:双装时后注册者赢,单装用户
+ * 无感;cdnPrefix 共用因发布渠道靠不同 OSS bucket 区分;db 前缀因 userData
+ * 已分目录无需再区分)。
  */
 export const BRAND_IDENTITY: BrandIdentity = Object.freeze({
   displayName: BRAND_NAME,
   executableName: 'Cindy',
   executableNameByRegion: Object.freeze({
     cn: 'Cindy',
-    global: 'CindyGlobal',
+    // 2026-07-26 与 cn 同值(见字段 doc):global 包全部可见位置显示 Cindy,
+    // 放弃 cn/global 同机双装的文件层隔离;appId / userData 仍分区。
+    global: 'Cindy',
     dev: 'CindyDev',
   }),
   appIdByRegion: Object.freeze({

--- a/scripts/__tests__/brand-identity-sync.test.mjs
+++ b/scripts/__tests__/brand-identity-sync.test.mjs
@@ -39,6 +39,37 @@ const USER_DATA_DIR_NAME = extractLiteral(
   /userDataDirName:\s*'([^']+)'/,
   'brandIdentity.ts userDataDirName',
 );
+/**
+ * 从源码里抽取形如 `<mapName>: Object.freeze({ cn: '...', ... })` 的区域映射。
+ * 锚定到 `Object.freeze({` 赋值处:字段名可能还出现在 interface 声明里。
+ */
+function extractRegionMap(source, mapName, label) {
+  const blockRe = new RegExp(`${mapName}\\s*[:=]\\s*Object\\.freeze\\(\\{([\\s\\S]*?)\\}\\)`);
+  const block = blockRe.exec(source);
+  assert.ok(block, `pattern not found: ${label} (${blockRe})`);
+  const map = {};
+  for (const [, key, value] of block[1].matchAll(/(cn|global|dev):\s*'([^']+)'/g)) {
+    map[key] = value;
+  }
+  assert.deepEqual(Object.keys(map).sort(), ['cn', 'dev', 'global'], `${label} 缺区域键`);
+  return map;
+}
+
+test('ci/lib.mjs PACKAGED_APP_NAME_BY_REGION mirrors brandIdentity.executableNameByRegion', () => {
+  const expected = extractRegionMap(
+    brandIdentitySource,
+    'executableNameByRegion',
+    'brandIdentity.ts executableNameByRegion',
+  );
+  const libSource = readSource('apps/desktop/scripts/ci/lib.mjs');
+  const actual = extractRegionMap(
+    libSource,
+    'PACKAGED_APP_NAME_BY_REGION',
+    'ci/lib.mjs PACKAGED_APP_NAME_BY_REGION',
+  );
+  assert.deepEqual(actual, expected);
+});
+
 test('smoke-packaged.mjs PACKAGED_APP_NAME mirrors brandIdentity.executableName', () => {
   const smokeSource = readSource('apps/desktop/scripts/smoke-packaged.mjs');
   const value = extractLiteral(


### PR DESCRIPTION
## 这次改了什么

### 摘要

海外(global)桌面包此前在 Windows 桌面/开始菜单快捷方式、安装目录、mac `.app` 名与菜单栏标题显示 **CindyGlobal**。本 PR 把标识符层单点 `brandIdentity.ts` 的 `executableNameByRegion.global` 由 `'CindyGlobal'` 改为 `'Cindy'`,exe / mac .app 包名(含 CFBundleName,菜单栏标题随之修正)/ 安装目录 / NSIS 快捷方式 / 右键菜单 / ProgId 全部随单点自动切换——global 包所有用户可见位置统一显示 Cindy,与国内包一致。

**决策代价(owner 已确认接受)**:cn/global 同机双装的文件层隔离(安装目录 / .app / .lnk 互不同名)随之放弃,双装时后装者覆盖先装者的文件与快捷方式、更新器按 exe 名杀进程会波及另一区域——该场景明确不再支持。appId(`com.xd.cindy`)与 userData 目录(`CindyGlobal`)保持按区域分离,系统身份、Windows toast 通知(AUMID)与数据分库不受影响;dev 区域保持 CindyDev,可继续与正式包并存。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:global 桌面包图标显示名应为 Cindy(owner 口头需求)
- 本 PR 包含:brandIdentity 单点改值;ci/lib.mjs 镜像表同步;brand-identity-sync 测试补上按区域映射表的一致性断言(此前 lib.mjs 注释声称有此兜底但测试实际未覆盖);brandIdentity.test.ts 双装不变量断言更新为新决策;forge.config.ts / installer.nsh / windowsShortcutSelfHeal / folderContextMenu / fileAssociation / package-desktop / smoke-packaged 中陈述旧值与旧双装决策的注释更新;regionUserData.test.ts fixture 中 argv[0] 更新为新 exe 名(仅示例值,不影响断言语义)
- 明确不包含:存量 global 用户的升级迁移(mac 自动更新按现有脚本可正常完成但磁盘 .app 名保持 CindyGlobal.app;Windows 存量用户老更新器按旧 exe 名启动校验会失败回滚,需手动重装新包——owner 决策不做迁移处理);cindy-build-scripts 仓(已确认无 CindyGlobal 硬编码,零改动);mobile(不消费 executableNameByRegion,不受影响)
- 用户可见变化:global 新包在 mac(Dock / Finder / 菜单栏 / .app 名)与 Windows(桌面及开始菜单快捷方式、安装目录、右键菜单文案)全部显示 Cindy
- 是否存在 breaking change:有,说明:cn/global 同机双装不再受支持(文件层互抢);Windows 存量 global 用户无法经自动更新升级到本版本(见上)

### UI 变化

不涉及:改动仅为 OS 层安装/显示名称(快捷方式、bundle 名),无应用内界面、交互或文案变化。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:25 PASS / 6 SKIP / 0 FAIL,exit 0

pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/maker-shared run --if-present typecheck
结果:均通过

node --test scripts/__tests__/brand-identity-sync.test.mjs
结果:4 pass / 0 fail;并做了负向验证——临时把 lib.mjs 镜像表 global 改错后该断言即红,恢复后全绿(新断言确实能抓两边漂移)
```

### 手工验证

不涉及:本机未执行 global 区域完整打包。改动为单点字面量 + 注释,打包链路消费点(forge.config `CINDY_EXE`、NSIS productName/shortcutName、mac packager name)均直接派生自该单点,已逐一走读确认;mac postPackage 的 CFBundleDisplayName 兜底与 Helper 查找(CFBundleName 与 Helper 目录名同源变化)与 cn 包现行同构。

### 未执行的验证

未执行 global 区域的 mac / Windows 实机打包与安装冒烟(需发布环境签名凭证);建议合入后首次 global 打包时按 release 流程跑 smoke(ci/lib.mjs runSmokeTest 已随镜像表自动使用新产物名),并实机确认 Dock / Finder / 快捷方式显示名。

## 风险

### 风险分类

- [x] 其他:安装身份 / 打包产物命名(exe、.app、安装目录、快捷方式)

### 影响与回滚

- 影响范围:仅 global 区域桌面包的打包产物命名与 OS 注册显示层;cn 与 dev 包字节不变;mobile、服务端、发布产物文件名(cindy-global-* 前缀)、OSS key、深链、userData、appId 均不受影响
- 回滚 / 降级方式:revert 本 PR 即回到 CindyGlobal 命名,单点 + 镜像表 + 测试一起回退,无数据迁移、无协议变化,可安全回滚

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(决策记录写入 brandIdentity.ts 单点注释)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)