### PR TITLE
fix(billing): 修复临时结算与套餐变更展示

### DIFF
--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -78,18 +78,15 @@ const SUPPORTED_SUBSCRIPTION_CAPABILITIES = new Set<BillingPurchaseOption['capab
   'PROVIDER_MANAGED_SUBSCRIPTION',
 ]);
 
-// 新服务端的“当前订阅”只包含真实生命周期状态，未完成首购不再下发也不阻断重选；
-// INCOMPLETE 仅作为旧服务端兼容防御保留（旧服务端仍会拒绝重复首购）。
+// 未完成首购只属于当前 checkout 会话，不能展示为当前套餐或阻断重新购买。
 const SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES: BillingSubscription['status'][] = [
-  'INCOMPLETE',
   'TRIALING',
   'ACTIVE',
   'PAST_DUE',
   'UNPAID',
   'PAUSED',
 ];
-const SUBSCRIPTION_CANCELLABLE_STATUSES: BillingSubscription['status'][] =
-  SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES.filter((status) => status !== 'INCOMPLETE');
+const SUBSCRIPTION_CANCELLABLE_STATUSES = SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES;
 
 const PLAN_CHANGE_ENTRY_STATUSES: BillingSubscription['status'][] = ['ACTIVE'];
 
@@ -299,7 +296,12 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     setLoadingSubscription(true);
     setSubscriptionError(false);
     try {
-      setCurrentSubscription((await billingApi.getCurrentSubscription()).subscription);
+      const subscription = (await billingApi.getCurrentSubscription()).subscription;
+      setCurrentSubscription(
+        subscription && SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES.includes(subscription.status)
+          ? subscription
+          : null,
+      );
     } catch {
       setCurrentSubscription(null);
       setSubscriptionError(true);
@@ -329,7 +331,10 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
   }, [loadBillingState]);
 
   useEffect(() => {
-    if (checkout.state.subscription) {
+    if (
+      checkout.state.subscription &&
+      SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES.includes(checkout.state.subscription.status)
+    ) {
       setCurrentSubscription(checkout.state.subscription);
       setSubscriptionError(false);
     }

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -330,16 +330,6 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     void loadBillingState();
   }, [loadBillingState]);
 
-  useEffect(() => {
-    if (
-      checkout.state.subscription &&
-      SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES.includes(checkout.state.subscription.status)
-    ) {
-      setCurrentSubscription(checkout.state.subscription);
-      setSubscriptionError(false);
-    }
-  }, [checkout.state.subscription]);
-
   const closeCheckout = useCallback(() => {
     const abandonedIncomplete = checkout.state.subscription?.status === 'INCOMPLETE';
     checkout.close();
@@ -354,8 +344,9 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     previousCheckoutPhaseRef.current = checkout.state.phase;
     if (previousPhase !== 'COMPLETED' && checkout.state.phase === 'COMPLETED') {
       void loadBalance();
+      if (checkout.state.kind === 'SUBSCRIPTION') void loadSubscription();
     }
-  }, [checkout.state.phase, loadBalance]);
+  }, [checkout.state.kind, checkout.state.phase, loadBalance, loadSubscription]);
 
   const handlePlanChangeSettled = useCallback(
     (kind: PlanChangeSettledKind) => {
@@ -489,6 +480,17 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     SUPPORTED_BILLING_PROVIDERS.has(currentSubscription.provider as SupportedBillingProvider)
       ? (currentSubscription.provider as SupportedBillingProvider)
       : null;
+  const currentPlanCandidate = useMemo<PlanChangeCandidate | null>(() => {
+    if (!currentPlan) return null;
+    const entry = subscriptionOffers.find(({ offer }) => offer.code === currentPlan.offer.code);
+    if (!entry) return null;
+    return {
+      product: entry.product,
+      offer: entry.offer,
+      providers: currentProvider ? [currentProvider] : [],
+      direction: null,
+    };
+  }, [currentPlan, currentProvider, subscriptionOffers]);
   const showPlanChangeEntry =
     currentPlan !== null &&
     currentSubscription !== null &&
@@ -832,6 +834,7 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
 
       <PlanChangeTargetDialog
         open={planChangeTargetOpen}
+        currentPlan={currentPlanCandidate}
         candidates={planChangeCandidates}
         onClose={() => setPlanChangeTargetOpen(false)}
         onSelect={selectPlanChangeTarget}

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -292,7 +292,7 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     }
   }, []);
 
-  const loadSubscription = useCallback(async () => {
+  const loadSubscription = useCallback(async (fallback: BillingSubscription | null = null) => {
     setLoadingSubscription(true);
     setSubscriptionError(false);
     try {
@@ -303,8 +303,12 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
           : null,
       );
     } catch {
-      setCurrentSubscription(null);
-      setSubscriptionError(true);
+      const completedFallback =
+        fallback && SUBSCRIPTION_PURCHASE_BLOCKING_STATUSES.includes(fallback.status)
+          ? fallback
+          : null;
+      setCurrentSubscription(completedFallback);
+      setSubscriptionError(completedFallback === null);
     } finally {
       setLoadingSubscription(false);
     }
@@ -344,9 +348,17 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     previousCheckoutPhaseRef.current = checkout.state.phase;
     if (previousPhase !== 'COMPLETED' && checkout.state.phase === 'COMPLETED') {
       void loadBalance();
-      if (checkout.state.kind === 'SUBSCRIPTION') void loadSubscription();
+      if (checkout.state.kind === 'SUBSCRIPTION') {
+        void loadSubscription(checkout.state.subscription);
+      }
     }
-  }, [checkout.state.kind, checkout.state.phase, loadBalance, loadSubscription]);
+  }, [
+    checkout.state.kind,
+    checkout.state.phase,
+    checkout.state.subscription,
+    loadBalance,
+    loadSubscription,
+  ]);
 
   const handlePlanChangeSettled = useCallback(
     (kind: PlanChangeSettledKind) => {
@@ -482,15 +494,33 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
       : null;
   const currentPlanCandidate = useMemo<PlanChangeCandidate | null>(() => {
     if (!currentPlan) return null;
-    const entry = subscriptionOffers.find(({ offer }) => offer.code === currentPlan.offer.code);
-    if (!entry) return null;
+    const catalogProduct = catalog?.products.find(
+      (product) => product.code === currentPlan.product.code,
+    );
     return {
-      product: entry.product,
-      offer: entry.offer,
+      product: {
+        code: currentPlan.product.code,
+        name: catalogProduct?.name ?? currentPlan.product.code,
+        kind: 'SUBSCRIPTION',
+        level: currentPlan.product.level,
+        sortOrder: catalogProduct?.sortOrder ?? 0,
+        offers: [],
+      },
+      offer: {
+        code: currentPlan.offer.code,
+        interval: currentPlan.offer.interval,
+        currency: currentPlan.terms.currency,
+        amount: currentPlan.terms.amount,
+        minAmount: null,
+        maxAmount: null,
+        creditAmount: currentPlan.terms.creditAmount,
+        rolloverCap: currentPlan.terms.rolloverCap,
+        purchaseOptions: [],
+      },
       providers: currentProvider ? [currentProvider] : [],
       direction: null,
     };
-  }, [currentPlan, currentProvider, subscriptionOffers]);
+  }, [catalog, currentPlan, currentProvider]);
   const showPlanChangeEntry =
     currentPlan !== null &&
     currentSubscription !== null &&

--- a/apps/desktop/src/renderer/features/billing/PlanChangeDialog.tsx
+++ b/apps/desktop/src/renderer/features/billing/PlanChangeDialog.tsx
@@ -54,17 +54,23 @@ function formatEffectiveDate(iso: string, locale: string): string {
 
 export function PlanChangeTargetDialog({
   open,
+  currentPlan,
   candidates,
   onClose,
   onSelect,
 }: {
   open: boolean;
+  currentPlan: PlanChangeCandidate | null;
   candidates: PlanChangeCandidate[];
   onClose: () => void;
   onSelect: (candidate: PlanChangeCandidate) => void;
 }) {
   const { t, i18n } = useTranslation();
   const billingLocale = i18n.resolvedLanguage ?? i18n.language;
+  const displayedPlans = [
+    ...(currentPlan ? [{ candidate: currentPlan, current: true }] : []),
+    ...candidates.map((candidate) => ({ candidate, current: false })),
+  ];
   return (
     <Dialog.Root open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
       <Dialog.Portal>
@@ -94,19 +100,9 @@ export function PlanChangeTargetDialog({
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto border-t border-[var(--border-default)] px-6 py-4 [scrollbar-gutter:stable]">
-            {candidates.length === 0 ? (
-              <div className="flex min-h-[184px] flex-col items-center justify-center rounded-xl border border-[var(--border-default)] px-6 text-center">
-                <div className="grid size-11 place-items-center rounded-full bg-[var(--surface-chip)]">
-                  <PackageOpen size={22} />
-                </div>
-                <p className="mt-4 text-sm font-medium">{t('billing.planChange.emptyTitle')}</p>
-                <p className="mt-1 text-12 text-[var(--text-secondary)]">
-                  {t('billing.planChange.emptyDescription')}
-                </p>
-              </div>
-            ) : (
+            {displayedPlans.length > 0 && (
               <div className="divide-y divide-[var(--border-default)] overflow-hidden rounded-xl border border-[var(--border-default)]">
-                {candidates.map((candidate) => {
+                {displayedPlans.map(({ candidate, current }) => {
                   const DirectionIcon =
                     candidate.direction === 'UPGRADE'
                       ? ArrowUpRight
@@ -114,13 +110,15 @@ export function PlanChangeTargetDialog({
                         ? ArrowDownRight
                         : null;
                   const directionLabel =
-                    candidate.direction === 'UPGRADE'
-                      ? t('billing.planChange.upgradeBadge')
-                      : candidate.direction === 'DOWNGRADE'
-                        ? t('billing.planChange.downgradeBadge')
-                        : candidate.direction === 'SAME_LEVEL'
-                          ? t('billing.planChange.sameLevelBadge')
-                          : null;
+                    current
+                      ? t('billing.catalog.currentPlan')
+                      : candidate.direction === 'UPGRADE'
+                        ? t('billing.planChange.upgradeBadge')
+                        : candidate.direction === 'DOWNGRADE'
+                          ? t('billing.planChange.downgradeBadge')
+                          : candidate.direction === 'SAME_LEVEL'
+                            ? t('billing.planChange.sameLevelBadge')
+                            : null;
                   const providerLabel = candidate.providers
                     .map((provider) => t(`billing.providers.${provider}`))
                     .join(', ');
@@ -128,10 +126,14 @@ export function PlanChangeTargetDialog({
                     <button
                       key={candidate.offer.code}
                       type="button"
-                      onClick={() => onSelect(candidate)}
+                      disabled={current}
+                      aria-current={current ? 'true' : undefined}
+                      onClick={() => {
+                        if (!current) onSelect(candidate);
+                      }}
                       className={cn(
                         'flex w-full items-center justify-between gap-4 px-4 py-3 text-left',
-                        'transition-colors hover:bg-[var(--surface-hover-soft)]',
+                        !current && 'transition-colors hover:bg-[var(--surface-hover-soft)]',
                         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset',
                         'focus-visible:ring-[var(--text-primary)]',
                       )}
@@ -173,6 +175,23 @@ export function PlanChangeTargetDialog({
                     </button>
                   );
                 })}
+              </div>
+            )}
+            {candidates.length === 0 && (
+              <div
+                className={cn(
+                  'flex min-h-[184px] flex-col items-center justify-center rounded-xl border',
+                  'border-[var(--border-default)] px-6 text-center',
+                  displayedPlans.length > 0 && 'mt-4',
+                )}
+              >
+                <div className="grid size-11 place-items-center rounded-full bg-[var(--surface-chip)]">
+                  <PackageOpen size={22} />
+                </div>
+                <p className="mt-4 text-sm font-medium">{t('billing.planChange.emptyTitle')}</p>
+                <p className="mt-1 text-12 text-[var(--text-secondary)]">
+                  {t('billing.planChange.emptyDescription')}
+                </p>
               </div>
             )}
           </div>

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -1367,6 +1367,35 @@ describe('BillingPage plan change', () => {
     expect(screen.queryByText('Max plan')).toBeNull();
   });
 
+  it('keeps the completed checkout subscription when the canonical reload temporarily fails', async () => {
+    const billing = billingMocks();
+    billing.getCurrentSubscription
+      .mockResolvedValueOnce({ subscription: null })
+      .mockRejectedValueOnce(new Error('temporarily unavailable'));
+    install(billing);
+    const completed = { ...activeSubscription(), provider: 'alipay' };
+    Object.assign(checkout.state, {
+      open: true,
+      kind: 'SUBSCRIPTION',
+      phase: 'AWAITING_PAYMENT',
+      subscription: { ...completed, status: 'INCOMPLETE' },
+    });
+
+    const view = render(<BillingPage />);
+    await waitFor(() => expect(billing.getCurrentSubscription).toHaveBeenCalledTimes(1));
+
+    Object.assign(checkout.state, {
+      phase: 'COMPLETED',
+      subscription: completed,
+    });
+    view.rerender(<BillingPage />);
+
+    await waitFor(() => expect(billing.getCurrentSubscription).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('billing.subscriptionStatus.ACTIVE')).toBeTruthy();
+    expect(screen.queryByText('billing.settings.subscriptionCard.unavailable')).toBeNull();
+    expect(screen.getByText('billing.settings.subscriptionCard.changeAction')).toBeTruthy();
+  });
+
   it('locks cancellation before confirmation resolves', async () => {
     const billing = install(billingMocks());
     let resolveConfirm!: (confirmed: boolean) => void;
@@ -1541,6 +1570,36 @@ describe('BillingPage plan change', () => {
     // APPLIED refreshes subscription, catalog, and balance exactly once more.
     await waitFor(() => expect(billing.getBalance).toHaveBeenCalledTimes(2));
     expect(billing.getCurrentSubscription).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders a grandfathered current plan from the captured subscription terms', async () => {
+    const billing = billingMocks();
+    const grandfathered = activeSubscription();
+    grandfathered.effectivePlan = {
+      ...grandfathered.effectivePlan!,
+      offer: { code: 'plus_legacy', interval: 'MONTH' },
+      terms: {
+        amount: '7',
+        currency: 'usd',
+        creditAmount: '80',
+        rolloverCap: '0',
+      },
+    };
+    billing.getCurrentSubscription = vi.fn(async () => ({ subscription: grandfathered }));
+    install(billing);
+
+    render(<BillingPage />);
+    fireEvent.click(await screen.findByText('billing.settings.subscriptionCard.changeAction'));
+
+    const dialog = await screen.findByRole('dialog');
+    const currentButton = within(dialog)
+      .getByText('billing.catalog.currentPlan')
+      .closest('button')!;
+    expect(within(currentButton).getByText('Plus plan')).toBeTruthy();
+    expect(within(currentButton).getByText('$7.00')).toBeTruthy();
+    expect(
+      within(currentButton).getByText('billing.credits:{"amount":"80"}'),
+    ).toBeTruthy();
   });
 
   it('does not expose plan change for yearly subscriptions while server v1 is monthly-only', async () => {

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -838,8 +838,8 @@ describe('BillingPage remote catalog rendering', () => {
     expect(checkout.startSubscription).not.toHaveBeenCalled();
   });
 
-  it.each(['CANCELED', 'INCOMPLETE_EXPIRED'] as const)(
-    'routes a %s terminal subscription to repurchase',
+  it.each(['INCOMPLETE', 'CANCELED', 'INCOMPLETE_EXPIRED'] as const)(
+    'does not treat a %s response as the current subscription',
     async (status) => {
       window.electronAPI.billing.getCurrentSubscription = vi.fn(async () => ({
         subscription: {
@@ -856,6 +856,10 @@ describe('BillingPage remote catalog rendering', () => {
       }));
 
       render(<BillingPage />);
+      expect(
+        await screen.findByText('billing.settings.subscriptionCard.emptyTitle'),
+      ).toBeTruthy();
+      expect(screen.queryByText(`billing.subscriptionStatus.${status}`)).toBeNull();
       fireEvent.click(await screen.findByText('billing.settings.subscriptionCard.action'));
 
       fireEvent.click((await screen.findByText('Configured subscription')).closest('button')!);
@@ -1314,7 +1318,7 @@ describe('BillingPage plan change', () => {
   });
 
   it.each(['INCOMPLETE', 'CANCELED', 'INCOMPLETE_EXPIRED'] as const)(
-    'does not offer renewal cancellation for a %s subscription',
+    'ignores a non-current %s subscription response',
     async (status) => {
       const billing = billingMocks();
       billing.getCurrentSubscription = vi.fn(async () => ({
@@ -1324,7 +1328,8 @@ describe('BillingPage plan change', () => {
 
       render(<BillingPage />);
 
-      await screen.findByText(`billing.subscriptionStatus.${status}`);
+      await screen.findByText('billing.settings.subscriptionCard.emptyTitle');
+      expect(screen.queryByText(`billing.subscriptionStatus.${status}`)).toBeNull();
       expect(screen.queryByText('billing.settings.subscriptionCard.cancelAction')).toBeNull();
       expect(billing.cancelCurrentSubscription).not.toHaveBeenCalled();
     },
@@ -1608,6 +1613,10 @@ describe('BillingPage plan change', () => {
     });
 
     render(<BillingPage />);
+    await waitFor(() => {
+      expect(screen.getByText('billing.settings.subscriptionCard.emptyTitle')).toBeTruthy();
+      expect(screen.queryByText('billing.subscriptionStatus.INCOMPLETE')).toBeNull();
+    });
     fireEvent.click(await screen.findByLabelText('billing.actions.close'));
 
     expect(checkout.close).toHaveBeenCalled();

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -1256,7 +1256,11 @@ describe('BillingPage plan change', () => {
       observedAt: '2026-07-23T12:00:00.000Z',
     })),
     getCatalog: vi.fn(async () => subscriptionCatalog),
-    getCurrentSubscription: vi.fn(async () => ({ subscription: activeSubscription() })),
+    getCurrentSubscription: vi.fn(
+      async (): Promise<{ subscription: BillingSubscription | null }> => ({
+        subscription: activeSubscription(),
+      }),
+    ),
     cancelCurrentSubscription: vi.fn(),
     quotePlanChange: vi.fn(),
     confirmPlanChange: vi.fn(),
@@ -1334,6 +1338,34 @@ describe('BillingPage plan change', () => {
       expect(billing.cancelCurrentSubscription).not.toHaveBeenCalled();
     },
   );
+
+  it('reloads the canonical subscription after checkout instead of keeping a provider-less response', async () => {
+    const billing = billingMocks();
+    const canonical = { ...activeSubscription(), provider: 'alipay' };
+    billing.getCurrentSubscription
+      .mockResolvedValueOnce({ subscription: null })
+      .mockResolvedValueOnce({ subscription: canonical });
+    install(billing);
+    const checkoutSubscription: BillingSubscription = { ...canonical };
+    delete checkoutSubscription.provider;
+    Object.assign(checkout.state, {
+      open: true,
+      kind: 'SUBSCRIPTION',
+      phase: 'AWAITING_PAYMENT',
+      subscription: checkoutSubscription,
+    });
+
+    const view = render(<BillingPage />);
+    await waitFor(() => expect(billing.getCurrentSubscription).toHaveBeenCalledTimes(1));
+
+    Object.assign(checkout.state, { phase: 'COMPLETED' });
+    view.rerender(<BillingPage />);
+
+    await waitFor(() => expect(billing.getCurrentSubscription).toHaveBeenCalledTimes(2));
+    fireEvent.click(await screen.findByText('billing.settings.subscriptionCard.changeAction'));
+    expect(await screen.findByText('Alipay-only Max')).toBeTruthy();
+    expect(screen.queryByText('Max plan')).toBeNull();
+  });
 
   it('locks cancellation before confirmation resolves', async () => {
     const billing = install(billingMocks());
@@ -1462,6 +1494,8 @@ describe('BillingPage plan change', () => {
     fireEvent.click(await screen.findByText('billing.settings.subscriptionCard.changeAction'));
 
     await screen.findByText('billing.planChange.targetTitle');
+    const dialog = screen.getByRole('dialog');
+    const currentPlanButton = within(dialog).getByText('Plus plan').closest('button')!;
     const maxButton = screen.getByText('Max plan').closest('button')!;
     const sameLevelButton = screen.getByText('Same-level plan').closest('button')!;
     const starterButton = screen.getByText('Starter plan').closest('button')!;
@@ -1472,6 +1506,9 @@ describe('BillingPage plan change', () => {
       sameLevelButton.compareDocumentPosition(starterButton) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(within(maxButton).getByText('billing.planChange.upgradeBadge')).toBeTruthy();
+    expect(currentPlanButton.hasAttribute('disabled')).toBe(true);
+    expect(currentPlanButton.getAttribute('aria-current')).toBe('true');
+    expect(within(currentPlanButton).getByText('billing.catalog.currentPlan')).toBeTruthy();
     expect(within(maxButton).getByText('stripe')).toBeTruthy();
     expect(within(sameLevelButton).getByText('billing.planChange.sameLevelBadge')).toBeTruthy();
     expect(within(starterButton).getByText('billing.planChange.downgradeBadge')).toBeTruthy();


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复订阅首购与套餐变更的两个用户可见问题：

- 未完成支付只属于当前结算会话，关闭后不再作为“当前套餐”或跨启动恢复项展示；用户可重新选择套餐和渠道发起新的支付。
- 支付成功后重新读取服务端 canonical 订阅，避免缺少 `provider` 的临时响应导致套餐变更列表被错误筛空。
- 套餐变更弹窗置顶展示并禁用当前套餐，其他候选仍严格按当前支付渠道筛选。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：订阅临时支付动作不跨会话恢复；修复套餐变更空列表和当前套餐标识
- 本 PR 包含：客户端临时结算会话、canonical 订阅读取、套餐变更当前套餐展示
- 明确不包含：服务端支付宝旧支付动作替换；Stripe 服务端替换能力
- 用户可见变化：关闭二维码后可重新购买；支付完成后可看到同渠道可切换套餐；当前套餐有明确标识且不可重复选择
- 是否存在 breaking change：无

### UI 变化

- 未附截图：复用现有套餐变更对话框结构，只增加当前套餐行和既有“当前套餐”标识；没有新增视觉资产或文案。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10（组件状态与语义 token）；当前套餐使用原生 disabled/`aria-current` 语义，颜色和边框继续使用现有主题 token，兼容浅色与深色主题。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，全部 workspace unit tests 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec vitest run \
  src/renderer/features/billing/__tests__/BillingPage.test.tsx \
  src/renderer/features/billing/__tests__/PlanChangeDialog.test.tsx
结果：2 files / 47 tests passed。

pnpm check:dco
结果：2 commits signed off。
```

### 手工验证

- 既有 dev 隔离环境复现确认：旧 `INCOMPLETE` 会造成当前套餐状态和套餐变更空列表。
- 最新提交未再做独立桌面截图验证；交互路径由真实组件测试覆盖。

### 未执行的验证

- 未做 Stripe 服务端替换验证：不在本 PR 范围，客户端保持渠道无感。

## 风险

### 风险分类

- [x] 协议兼容

### 影响与回滚

- 影响范围：桌面端 Billing 页面和套餐变更弹窗。
- 回滚 / 降级方式：回滚本 PR；服务端字段保持可选，旧客户端不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档：未新增公共客户端契约）
- [x] 已确认测试结果或说明未执行原因
