### PR TITLE
fix(desktop): 修正启动时侧栏对话加载空态

### DIFF
--- a/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useDeviceLinkDeviceList initial request', () => {
+  it('marks a rejected initial device-list request as settled without fabricating an empty list', async () => {
+    const listDevices = vi.fn().mockRejectedValue(new Error('relay unavailable'));
+    vi.stubGlobal('electronAPI', {
+      deviceLink: {
+        listDevices,
+        onPresenceChanged: vi.fn(),
+        onStatusChanged: vi.fn(),
+        onControlTargetChanged: vi.fn(),
+      },
+    });
+
+    const {
+      useDeviceLinkDeviceList,
+      useDeviceLinkDeviceListSettled,
+    } = await import('@/features/device-link/useDeviceLinkDeviceList');
+    const { result } = renderHook(() => ({
+      devices: useDeviceLinkDeviceList(),
+      settled: useDeviceLinkDeviceListSettled(),
+    }));
+
+    expect(result.current).toEqual({ devices: null, settled: false });
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.devices).toBeNull();
+    expect(listDevices).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -60,7 +60,13 @@ describe('Dialogue sidebar section', () => {
   });
 
   it('shows loading instead of the empty state until the initial session fetch settles', () => {
-    expect(sidebarSource.match(/isLoading=\{isLoadingSessions\}/g)).toHaveLength(2);
+    expect(sidebarSource.match(/isLoading=\{isLoadingSidebarSessions\}/g)).toHaveLength(2);
+    expect(sidebarSource).toContain(
+      'useRemoteSessionBootstrapLoading(selectedMachineId)',
+    );
+    expect(sidebarSource).toContain(
+      'sessionsHook.isLoading || remoteSessionBootstrapLoading',
+    );
     expect(dialogueSectionSource).toContain('isLoading: boolean');
     expect(dialogueSectionSource).toContain("'ccAgent.sidebar.loadingDialogues'");
     expect(dialogueSectionSource).toMatch(

--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -22,6 +22,19 @@ const dialogueSectionSource = readFileSync(
   'utf8',
 );
 
+const dateGroupedSectionSource = readFileSync(
+  resolve(
+    __dirname,
+    '..',
+    'features',
+    'cc-agent',
+    'sidebar',
+    'sections',
+    'DateGroupedSessionsSection.tsx',
+  ),
+  'utf8',
+);
+
 const newMakerDraftRouteSource = readFileSync(
   resolve(__dirname, '..', 'features', 'cc-agent', 'NewMakerDraftRoute.tsx'),
   'utf8',
@@ -47,11 +60,16 @@ describe('Dialogue sidebar section', () => {
   });
 
   it('shows loading instead of the empty state until the initial session fetch settles', () => {
-    expect(sidebarSource).toContain('isLoading={isLoadingSessions}');
+    expect(sidebarSource.match(/isLoading=\{isLoadingSessions\}/g)).toHaveLength(2);
     expect(dialogueSectionSource).toContain('isLoading: boolean');
     expect(dialogueSectionSource).toContain("'ccAgent.sidebar.loadingDialogues'");
     expect(dialogueSectionSource).toMatch(
       /isLoading\s*\?\s*'ccAgent\.sidebar\.loadingDialogues'\s*:\s*'ccAgent\.sidebar\.noDialogues'/,
+    );
+    expect(dateGroupedSectionSource).toContain('isLoading: boolean');
+    expect(dateGroupedSectionSource).toContain('!isLoading');
+    expect(dateGroupedSectionSource).toMatch(
+      /isLoading\s*\?\s*'ccAgent\.sidebar\.loadingDialogues'\s*:\s*'ccAgent\.sidebar\.dateGroup\.empty'/,
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -43,7 +43,16 @@ describe('Dialogue sidebar section', () => {
 
   it('keeps the Dialogue section visible when it has no sessions', () => {
     expect(dialogueSectionSource).not.toMatch(/sessions\.length\s*===\s*0\)\s*return\s+null/);
-    expect(dialogueSectionSource).toContain("t('ccAgent.sidebar.noDialogues')");
+    expect(dialogueSectionSource).toContain("'ccAgent.sidebar.noDialogues'");
+  });
+
+  it('shows loading instead of the empty state until the initial session fetch settles', () => {
+    expect(sidebarSource).toContain('isLoading={isLoadingSessions}');
+    expect(dialogueSectionSource).toContain('isLoading: boolean');
+    expect(dialogueSectionSource).toContain("'ccAgent.sidebar.loadingDialogues'");
+    expect(dialogueSectionSource).toMatch(
+      /isLoading\s*\?\s*'ccAgent\.sidebar\.loadingDialogues'\s*:\s*'ccAgent\.sidebar\.noDialogues'/,
+    );
   });
 
   it('has a Dialogue-owned runtime sort setting instead of using project manual order or renderer storage', () => {

--- a/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
@@ -390,7 +390,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: MACHINE_ALL,
-        devicesLoaded: false,
+        deviceListSettled: false,
         devices: [],
         syncedDevices: [],
       }),
@@ -398,7 +398,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: MACHINE_ALL,
-        devicesLoaded: true,
+        deviceListSettled: true,
         devices: connecting,
         syncedDevices: [],
       }),
@@ -409,7 +409,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: MACHINE_ALL,
-        devicesLoaded: true,
+        deviceListSettled: true,
         devices: connecting,
         syncedDevices: [
           { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 0, connected: false },
@@ -418,11 +418,22 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     ).toBe(false);
   });
 
+  it('设备清单请求失败但已结算 → 不把未知设备列表当成永久加载', () => {
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: MACHINE_ALL,
+        deviceListSettled: true,
+        devices: [],
+        syncedDevices: [],
+      }),
+    ).toBe(false);
+  });
+
   it('仅本机不等待远端；混合选择只等待作用域内尚未同步的远端设备', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: [MACHINE_LOCAL],
-        devicesLoaded: false,
+        deviceListSettled: false,
         devices: [],
         syncedDevices: [],
       }),
@@ -430,7 +441,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: [MACHINE_LOCAL, 'dev-b'],
-        devicesLoaded: true,
+        deviceListSettled: true,
         devices: connecting,
         syncedDevices: [],
       }),
@@ -438,7 +449,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: [MACHINE_LOCAL, 'dev-a'],
-        devicesLoaded: true,
+        deviceListSettled: true,
         devices: connecting,
         syncedDevices: [],
       }),
@@ -449,7 +460,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: MACHINE_ALL,
-        devicesLoaded: true,
+        deviceListSettled: true,
         devices: [{ deviceId: 'dev-a', name: 'Mac A', status: 'rejected' }],
         syncedDevices: [],
       }),
@@ -457,7 +468,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId: MACHINE_ALL,
-        devicesLoaded: true,
+        deviceListSettled: true,
         devices: connecting,
         syncedDevices: [
           { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 2, connected: false },

--- a/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
@@ -13,7 +13,10 @@ import {
   toggleMachineSelection,
 } from '@/features/device-link/selectedMachineStore';
 import { remoteProjectsStore } from '@/features/device-link/remoteProjectsStore';
-import { shouldShowSelectedMachineConnectingPlaceholder } from '@/features/device-link/useMachineSwitcher';
+import {
+  shouldShowSelectedMachineConnectingPlaceholder,
+  shouldWaitForRemoteSessionBootstrap,
+} from '@/features/device-link/useMachineSwitcher';
 import { buildSwitcherDevices, selectableDeviceIds } from '@/features/device-link/switcherDevices';
 import { compareDevicesByName } from '@/features/device-link/deviceSort';
 import { applyDeviceRename } from '@/features/device-link/useDeviceLinkDeviceList';
@@ -377,6 +380,90 @@ describe('normalizeSelectedMachineId 配合可选中集(连接中可保留,被�
     expect(normalizeSelectedMachineId(['connecting-1', 'rejected-1'], selectable)).toEqual([
       'connecting-1',
     ]);
+  });
+});
+
+describe('shouldWaitForRemoteSessionBootstrap', () => {
+  const connecting = [{ deviceId: 'dev-a', name: 'Mac A', status: 'connecting' as const }];
+
+  it('所有机器:设备清单或在线远端首快照未落地 → 保持加载态', () => {
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: MACHINE_ALL,
+        devicesLoaded: false,
+        devices: [],
+        syncedDevices: [],
+      }),
+    ).toBe(true);
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: MACHINE_ALL,
+        devicesLoaded: true,
+        devices: connecting,
+        syncedDevices: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('权威空快照已落地也算 bootstrap 完成，不把 0 会话误判成仍加载', () => {
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: MACHINE_ALL,
+        devicesLoaded: true,
+        devices: connecting,
+        syncedDevices: [
+          { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 0, connected: false },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('仅本机不等待远端；混合选择只等待作用域内尚未同步的远端设备', () => {
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: [MACHINE_LOCAL],
+        devicesLoaded: false,
+        devices: [],
+        syncedDevices: [],
+      }),
+    ).toBe(false);
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: [MACHINE_LOCAL, 'dev-b'],
+        devicesLoaded: true,
+        devices: connecting,
+        syncedDevices: [],
+      }),
+    ).toBe(false);
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: [MACHINE_LOCAL, 'dev-a'],
+        devicesLoaded: true,
+        devices: connecting,
+        syncedDevices: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('被拒或已有断线缓存的设备不算等待中的首次 bootstrap', () => {
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: MACHINE_ALL,
+        devicesLoaded: true,
+        devices: [{ deviceId: 'dev-a', name: 'Mac A', status: 'rejected' }],
+        syncedDevices: [],
+      }),
+    ).toBe(false);
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: MACHINE_ALL,
+        devicesLoaded: true,
+        devices: connecting,
+        syncedDevices: [
+          { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 2, connected: false },
+        ],
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
@@ -72,12 +72,13 @@ describe('远程机器切换入口并入 SidebarTopNav(置顶段上方,固定不
   });
 
   it('日期分组视图:选中 0 会话的远程机器时仍渲染空态段头(空列表可感知)', () => {
-    // groups 为空且 filter 未激活时,若还选中了非「所有」的远程机器,machineFilterActive
-    // 让组件继续渲染空态段头(「空」标签),让用户看得出是机器过滤导致的空列表而非白屏。
+    // groups 为空且 filter 未激活、初始加载已结束时,若还选中了非「所有」的远程机器,
+    // machineFilterActive 让组件继续渲染空态段头(「空」标签),让用户看得出是机器
+    // 过滤导致的空列表而非白屏。
     expect(dateSectionSource).toContain('machineFilterActive');
     expect(dateSectionSource).toMatch(/selectedDeviceId\s*!==\s*MACHINE_ALL/);
     expect(dateSectionSource).toContain(
-      'if (groups.length === 0 && !filter.isFilterActive && !machineFilterActive) return null;',
+      'if (groups.length === 0 && !isLoading && !filter.isFilterActive && !machineFilterActive) return null;',
     );
   });
 

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -162,6 +162,7 @@ import {
 } from './lib/remoteSessionWriteGuard';
 import {
   useEffectiveSelectedMachineId,
+  useRemoteSessionBootstrapLoading,
   useSelectedMachineConnecting,
 } from '@/features/device-link/useMachineSwitcher';
 import {
@@ -867,6 +868,12 @@ function ExpandedView({
   // 机器切换栏选中机器后整体过滤:本机 → 只本地会话;远程 → 只该机器会话。
   // 过滤在源头做,下游 grouping / pinned / projects / dialogues / date-grouped / search 自动继承。
   const selectedMachineId = useEffectiveSelectedMachineId();
+  // 「所有」或含远程设备的作用域还要等 device-link 首次 sessions snapshot；
+  // 否则本地 sessions 先完成时会把尚未知的远程空数组误报成真实空态。
+  const remoteSessionBootstrapLoading =
+    useRemoteSessionBootstrapLoading(selectedMachineId);
+  const isLoadingSidebarSessions =
+    sessionsHook.isLoading || remoteSessionBootstrapLoading;
   // 选中的远程机器尚在连接中(会话未同步)→ 用「连接中」占位替换空列表的「暂无对话」。
   const selectedMachineConnecting = useSelectedMachineConnecting();
   // orca worker + status 过滤(**不含**机器过滤)—— 抽出给「机器过滤后渲染」与「全量项目宇宙」共用。
@@ -2224,7 +2231,7 @@ function ExpandedView({
         {filter.groupBy === 'date' ? (
           <DateGroupedSessionsSection
             sessions={visibleDateSessions}
-            isLoading={isLoadingSessions}
+            isLoading={isLoadingSidebarSessions}
             allKnownProjects={projectUniverse.projects}
             filter={filter}
             activeSessionId={activeSessionId}
@@ -2278,7 +2285,7 @@ function ExpandedView({
             />
             <DialogueSection
               sessions={visibleDialogues}
-              isLoading={isLoadingSessions}
+              isLoading={isLoadingSidebarSessions}
               activeSessionId={activeSessionId}
               runningSessionIds={displayRunningSessionIds}
               attachedSessionIds={attachedSessionIds}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2277,6 +2277,7 @@ function ExpandedView({
             />
             <DialogueSection
               sessions={visibleDialogues}
+              isLoading={isLoadingSessions}
               activeSessionId={activeSessionId}
               runningSessionIds={displayRunningSessionIds}
               attachedSessionIds={attachedSessionIds}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2224,6 +2224,7 @@ function ExpandedView({
         {filter.groupBy === 'date' ? (
           <DateGroupedSessionsSection
             sessions={visibleDateSessions}
+            isLoading={isLoadingSessions}
             allKnownProjects={projectUniverse.projects}
             filter={filter}
             activeSessionId={activeSessionId}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/DateGroupedSessionsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/DateGroupedSessionsSection.tsx
@@ -34,6 +34,8 @@ const HEADER_HOVER_ACTION_CLASS =
 
 export interface DateGroupedSessionsSectionProps {
   sessions: Session[];
+  /** 首次载入会话列表时避免把暂时的空数组误报成真正空态。 */
+  isLoading: boolean;
   allKnownProjects: ProjectNodeData[];
   filter: UseSidebarFilterReturn;
   activeSessionId?: string;
@@ -64,6 +66,7 @@ function formatDateGroupLabel(
 
 export function DateGroupedSessionsSection({
   sessions,
+  isLoading,
   allKnownProjects,
   filter,
   activeSessionId,
@@ -102,14 +105,18 @@ export function DateGroupedSessionsSection({
     [i18n.language],
   );
 
-  if (groups.length === 0 && !filter.isFilterActive && !machineFilterActive) return null;
+  if (groups.length === 0 && !isLoading && !filter.isFilterActive && !machineFilterActive) return null;
 
   return (
     <div className="flex w-full flex-col gap-2">
       {groups.length === 0 ? (
         <div className="group/sidebar-header flex h-6 select-none items-center justify-between pr-0 pl-6">
           <span className="text-sm font-semibold text-[var(--cmd-palette-item-meta)]">
-            {t('ccAgent.sidebar.dateGroup.empty')}
+            {t(
+              isLoading
+                ? 'ccAgent.sidebar.loadingDialogues'
+                : 'ccAgent.sidebar.dateGroup.empty',
+            )}
           </span>
           <div className="-mt-px flex items-center gap-0.5">
             <div className={HEADER_HOVER_ACTION_CLASS}>

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/DialogueSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/DialogueSection.tsx
@@ -67,6 +67,8 @@ const HEADER_ACTIONS_CLASS = cn('flex items-center gap-0.5 -mt-px', HEADER_HOVER
 
 export interface DialogueSectionProps {
   sessions: Session[];
+  /** 首次载入会话列表时避免把暂时的空数组误报成真正空态。 */
+  isLoading: boolean;
   activeSessionId?: string;
   runningSessionIds: ReadonlySet<string>;
   attachedSessionIds: ReadonlySet<string>;
@@ -113,6 +115,7 @@ export function compareDialogueSessions(a: Session, b: Session, sortBy: Dialogue
 
 export function DialogueSection({
   sessions,
+  isLoading,
   activeSessionId,
   runningSessionIds,
   attachedSessionIds,
@@ -277,7 +280,7 @@ export function DialogueSection({
           />
           {sortedSessions.length === 0 && (
             <div className="flex h-7 items-center rounded-full px-3 text-xs text-sidebar-muted">
-              {t('ccAgent.sidebar.noDialogues')}
+              {t(isLoading ? 'ccAgent.sidebar.loadingDialogues' : 'ccAgent.sidebar.noDialogues')}
             </div>
           )}
         </div>

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
@@ -19,6 +19,8 @@ import { useSyncExternalStore } from 'react';
 let devices: DeviceLinkDeviceView[] | null = null;
 const subs = new Set<() => void>();
 let started = false;
+/** 当前账号 / relay 生命周期内，至少一次最新的 listDevices 请求已经 resolve 或 reject。 */
+let initialRequestSettled = false;
 /**
  * 加载代次:**每次 refresh 发起**与**每次清空(登出 / relay stop)**都自增,作废所有更早的在途
  * listDevices 响应 —— 只有"最新一次操作"的响应能落地(同 remoteProjectsStore 的 snapshotEpoch 思路)。
@@ -74,16 +76,27 @@ export function applyDeviceRename(
 function setDevices(next: DeviceLinkDeviceView[]): void {
   // 按 deviceId 稳定排序,避免服务端返回顺序抖动触发无谓重渲染。
   const sorted = [...next].sort((a, b) => a.deviceId.localeCompare(b.deviceId));
-  if (relevantEqual(devices, sorted)) return;
+  const devicesChanged = !relevantEqual(devices, sorted);
+  const settledChanged = !initialRequestSettled;
+  if (!devicesChanged && !settledChanged) return;
   devices = sorted;
+  initialRequestSettled = true;
   subs.forEach((fn) => fn());
 }
 
 /** 清空缓存设备,回到「未加载」态(null → 切换栏隐藏)。登出 / relay 停止时调用。 */
 function clearDevices(): void {
   loadGeneration += 1; // 作废所有在途 listDevices 响应(见 loadGeneration 注释)。
-  if (devices === null) return;
+  const changed = devices !== null || initialRequestSettled;
+  if (!changed) return;
   devices = null;
+  initialRequestSettled = false;
+  subs.forEach((fn) => fn());
+}
+
+function markInitialRequestSettled(): void {
+  if (initialRequestSettled) return;
+  initialRequestSettled = true;
   subs.forEach((fn) => fn());
 }
 
@@ -116,8 +129,12 @@ function ensureStarted(): void {
         setDevices(list);
       })
       .catch(() => {
+        // 只有最新请求的失败才算本轮首拉已经结算；更晚的 refresh 仍在途时继续等待它。
+        if (gen !== loadGeneration) return;
+        markInitialRequestSettled();
         // 瞬态拉取失败(relay 重连中等)保持当前快照;登出 / relay 停止由下面的 'stopped'
-        // 状态事件显式清空,不靠这里的失败兜底(避免一次网络抖动就清掉、闪烁)。
+        // 状态事件显式清空,不靠这里的失败兜底(避免一次网络抖动就清掉、闪烁)。但把请求
+        // 标成已结算，避免远端 sidebar bootstrap 因 devices 仍为 null 永久显示加载态。
       });
   };
   refresh();
@@ -154,4 +171,13 @@ function getSnapshot(): DeviceLinkDeviceView[] | null {
 /** 订阅全量设备列表(共享单例);null = 尚未加载。 */
 export function useDeviceLinkDeviceList(): DeviceLinkDeviceView[] | null {
   return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+function getInitialRequestSettledSnapshot(): boolean {
+  return initialRequestSettled;
+}
+
+/** 首次设备清单请求是否已结算；失败也算结算，后续 push / online 事件仍会继续 refresh。 */
+export function useDeviceLinkDeviceListSettled(): boolean {
+  return useSyncExternalStore(subscribe, getInitialRequestSettledSnapshot);
 }

--- a/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
+++ b/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
@@ -24,7 +24,10 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import { useRemoteDevices, type RemoteDeviceSummary } from './remoteProjectsStore';
 import { revokedDevicesStore } from './revokedDevicesStore';
-import { useDeviceLinkDeviceList } from './useDeviceLinkDeviceList';
+import {
+  useDeviceLinkDeviceList,
+  useDeviceLinkDeviceListSettled,
+} from './useDeviceLinkDeviceList';
 import { buildSwitcherDevices, selectableDeviceIds, type SwitcherDevice } from './switcherDevices';
 import {
   MACHINE_ALL,
@@ -44,7 +47,7 @@ export interface SelectedMachineConnectingInput {
 
 export interface RemoteSessionBootstrapLoadingInput {
   selectedMachineId: MachineSelection;
-  devicesLoaded: boolean;
+  deviceListSettled: boolean;
   devices: readonly SwitcherDevice[];
   syncedDevices: readonly RemoteDeviceSummary[];
 }
@@ -56,7 +59,7 @@ export interface RemoteSessionBootstrapLoadingInput {
  */
 export function shouldWaitForRemoteSessionBootstrap({
   selectedMachineId,
-  devicesLoaded,
+  deviceListSettled,
   devices,
   syncedDevices,
 }: RemoteSessionBootstrapLoadingInput): boolean {
@@ -65,7 +68,7 @@ export function shouldWaitForRemoteSessionBootstrap({
       ? null
       : new Set(selectedMachineId.filter((id) => id !== MACHINE_LOCAL));
   if (selectedRemoteIds?.size === 0) return false;
-  if (!devicesLoaded) return true;
+  if (!deviceListSettled) return true;
 
   const syncedIds = new Set(syncedDevices.map((device) => device.deviceId));
   return devices.some(
@@ -153,18 +156,18 @@ export function useSelectedMachineConnecting(): boolean {
 export function useRemoteSessionBootstrapLoading(
   selectedMachineId: MachineSelection,
 ): boolean {
-  const fullList = useDeviceLinkDeviceList();
+  const deviceListSettled = useDeviceLinkDeviceListSettled();
   const devices = useSwitcherDevices();
   const synced = useRemoteDevices();
   return useMemo(
     () =>
       shouldWaitForRemoteSessionBootstrap({
         selectedMachineId,
-        devicesLoaded: fullList !== null,
+        deviceListSettled,
         devices,
         syncedDevices: synced,
       }),
-    [selectedMachineId, fullList, devices, synced],
+    [selectedMachineId, deviceListSettled, devices, synced],
   );
 }
 

--- a/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
+++ b/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
@@ -42,6 +42,40 @@ export interface SelectedMachineConnectingInput {
   syncedDevices: readonly RemoteDeviceSummary[];
 }
 
+export interface RemoteSessionBootstrapLoadingInput {
+  selectedMachineId: MachineSelection;
+  devicesLoaded: boolean;
+  devices: readonly SwitcherDevice[];
+  syncedDevices: readonly RemoteDeviceSummary[];
+}
+
+/**
+ * 当前机器作用域是否仍包含尚未完成首次 sessions snapshot 的远程设备。
+ * syncedDevices 即使 sessionCount=0 也代表 bootstrap 已落过权威空快照；
+ * connecting 且没有对应分片才是冷启动中的未知状态。
+ */
+export function shouldWaitForRemoteSessionBootstrap({
+  selectedMachineId,
+  devicesLoaded,
+  devices,
+  syncedDevices,
+}: RemoteSessionBootstrapLoadingInput): boolean {
+  const selectedRemoteIds =
+    selectedMachineId === MACHINE_ALL
+      ? null
+      : new Set(selectedMachineId.filter((id) => id !== MACHINE_LOCAL));
+  if (selectedRemoteIds?.size === 0) return false;
+  if (!devicesLoaded) return true;
+
+  const syncedIds = new Set(syncedDevices.map((device) => device.deviceId));
+  return devices.some(
+    (device) =>
+      device.status === 'connecting' &&
+      !syncedIds.has(device.deviceId) &&
+      (selectedRemoteIds === null || selectedRemoteIds.has(device.deviceId)),
+  );
+}
+
 /**
  * 只有「勾选集里全是连接中设备(不含本机)且没有任何缓存会话可显示」时才显示连接中占位。
  * 离线但已有 cached sessions 的设备仍会被 buildSwitcherDevices 标成 connecting
@@ -109,6 +143,29 @@ export function useSelectedMachineConnecting(): boolean {
     devices,
     syncedDevices: synced,
   });
+}
+
+/**
+ * 当前可见列表是否还在等待 device-link 远程会话的首次 bootstrap。
+ * 「所有」作用域包含本机与全部远程源，因此远端设备清单或任一相关首快照未落地时，
+ * 侧栏继续显示加载态，避免本地 sessions 先完成后短暂误报真实空态。
+ */
+export function useRemoteSessionBootstrapLoading(
+  selectedMachineId: MachineSelection,
+): boolean {
+  const fullList = useDeviceLinkDeviceList();
+  const devices = useSwitcherDevices();
+  const synced = useRemoteDevices();
+  return useMemo(
+    () =>
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId,
+        devicesLoaded: fullList !== null,
+        devices,
+        syncedDevices: synced,
+      }),
+    [selectedMachineId, fullList, devices, synced],
+  );
 }
 
 export interface MachineSwitcherState {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5030,6 +5030,7 @@
       "newDialogue": "New dialogue",
       "dialoguesToggleExpand": "Expand dialogues",
       "dialoguesToggleCollapse": "Collapse dialogues",
+      "loadingDialogues": "Loading…",
       "noDialogues": "No dialogues",
       "dialogueSettings": "Organize dialogues",
       "dialogueSettingsAria": "Organize dialogues (Sort by: {{sortBy}})",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5020,6 +5020,7 @@
       "newDialogue": "新規会話",
       "dialoguesToggleExpand": "会話を展開",
       "dialoguesToggleCollapse": "会話を折りたたむ",
+      "loadingDialogues": "読み込み中…",
       "noDialogues": "会話はありません",
       "dialogueSettings": "会話を整理",
       "dialogueSettingsAria": "会話を整理（並び替え：{{sortBy}}）",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5020,6 +5020,7 @@
       "newDialogue": "새 대화",
       "dialoguesToggleExpand": "대화 펼치기",
       "dialoguesToggleCollapse": "대화 접기",
+      "loadingDialogues": "불러오는 중…",
       "noDialogues": "대화 없음",
       "dialogueSettings": "대화 정리",
       "dialogueSettingsAria": "대화 정리(정렬: {{sortBy}})",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5020,6 +5020,7 @@
       "newDialogue": "新对话",
       "dialoguesToggleExpand": "展开对话",
       "dialoguesToggleCollapse": "收起对话",
+      "loadingDialogues": "加载中…",
       "noDialogues": "暂无对话",
       "dialogueSettings": "整理对话",
       "dialogueSettingsAria": "整理对话（排序：{{sortBy}}）",


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 冷启动时左侧会话列表短暂显示真实空态的问题。

会话列表首次加载完成前，项目分组的「对话」分区和日期分组现在都会显示「加载中…」；只有加载完成且确实没有会话时，才显示对应空态。Desktop 本地作用域复用 `useCCSessions().isLoading`，All / 含远程设备作用域还会等待 Device Link 首次 sessions 快照；设备清单请求失败也会结束等待，不会永久停在加载态。同步补齐中、英、日、韩四语文案与回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：软件启动加载期间，左侧对话列表应显示加载态，而不是空态
- 本 PR 包含：Desktop 项目分组与日期分组的会话加载态、Device Link 远程 sessions 首快照加载态、四语 i18n、回归测试
- 明确不包含：IPC / relay / protocol payload、远程机器连接态语义、侧栏布局与样式调整
- 用户可见变化：冷启动首次加载会话时显示「加载中…」，加载完成后才可能显示「暂无对话」或日期分组空态
- 是否存在 breaking change：无

### UI 变化

- 未附截图：这是冷启动时序中的单行状态文案变化，不改变布局或样式
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §10 Light / Dark 双模式交付门槛：继续复用现有侧栏 muted token，不新增颜色或主题分叉；已在两种模式验证
  - `docs/design-rules/DESIGN.md` §11.1 Voice & Content：加载态使用进行时语义与省略号

### 远程与移动端适配

- SSH 远程 workspace：已覆盖。加载态来自 Desktop 共用的 `useCCSessions` 会话列表，不依赖本地文件路径、进程或 workdir，因此本地与 SSH 会话使用同一渲染逻辑。
- Device Link / IPC：已适配。All / 含远程设备作用域会把在线可控设备的 sessions 首快照纳入侧栏加载态；权威空快照落地后结束等待。首次设备清单请求失败时只标记请求已结算，保留未知列表与后续事件重试能力，避免永久 loading。未新增或修改 IPC channel、推送事件、relay、协议 payload；远程机器仍在既有 `selectedMachineConnecting` 守卫下显示「连接中…」。
- Mobile：不涉及。Mobile 使用 `apps/mobile` 的独立界面，不渲染本 PR 修改的 Desktop 侧栏组件，也没有 runtime fingerprint 变化。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-sidebar-loading-state
结果：通过（仓库根 pnpm test:unit 全量门禁）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx src/renderer/__tests__/machineSwitcher.test.ts src/renderer/__tests__/dialogueSidebarSection.test.ts
结果：通过，62/62

pnpm check:i18n
结果：通过，zh-CN / en / ja / ko 共 5531 个 key 一致

pnpm check:i18n-glossary
结果：通过

pnpm check:dco
结果：通过，PR 的 4 个 commit 均有匹配 author 的 Signed-off-by

git diff --check
结果：通过
```

### 手工验证

- macOS / Desktop remote / 功能 worktree：通过 `desktop:whoami` 确认运行来源为 `/Users/dash/Code/Cindy/cindy-sidebar-loading-state`
- 在功能 worktree 中临时注入空会话列表与 `isLoading`（未提交该 fixture），分别验证项目分组和日期分组
- Light 与 Dark 下均显示可读的「加载中…」，未出现布局跳动；验证后恢复原 Light 主题并撤销临时注入

### 未执行的验证

- 未录制或上传冷启动截图/视频；已在实际 Desktop 组件中完成双主题手工验证

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 左侧会话列表首次加载为空时的占位文案，以及 All / 含远程设备作用域等待首次远程 sessions 快照与设备清单失败回退的时序
- 回滚 / 降级方式：回退本 PR 的四笔 commit 即可恢复原有空态逻辑；不涉及数据、协议或持久化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
