### PR TITLE
fix(desktop): 修复设备会话加载终态

### DIFF
--- a/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 afterEach(() => {
@@ -8,21 +8,32 @@ afterEach(() => {
 });
 
 describe('useDeviceLinkDeviceList initial request', () => {
-  it('marks a rejected initial device-list request as settled without fabricating an empty list', async () => {
-    const listDevices = vi.fn().mockRejectedValue(new Error('relay unavailable'));
+  it('re-enters loading when online retries a rejected request with no device snapshot', async () => {
+    let resolveRetry: ((value: { devices: DeviceLinkDeviceView[] }) => void) | undefined;
+    const retry = new Promise<{ devices: DeviceLinkDeviceView[] }>((resolve) => {
+      resolveRetry = resolve;
+    });
+    let statusChanged:
+      ((payload: { status: 'stopped' | 'connecting' | 'online' }) => void) | undefined;
+    const listDevices = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('relay unavailable'))
+      .mockReturnValueOnce(retry);
     vi.stubGlobal('electronAPI', {
       deviceLink: {
         listDevices,
         onPresenceChanged: vi.fn(),
-        onStatusChanged: vi.fn(),
+        onStatusChanged: vi.fn(
+          (callback: (payload: { status: 'stopped' | 'connecting' | 'online' }) => void) => {
+            statusChanged = callback;
+          },
+        ),
         onControlTargetChanged: vi.fn(),
       },
     });
 
-    const {
-      useDeviceLinkDeviceList,
-      useDeviceLinkDeviceListSettled,
-    } = await import('@/features/device-link/useDeviceLinkDeviceList');
+    const { useDeviceLinkDeviceList, useDeviceLinkDeviceListSettled } =
+      await import('@/features/device-link/useDeviceLinkDeviceList');
     const { result } = renderHook(() => ({
       devices: useDeviceLinkDeviceList(),
       settled: useDeviceLinkDeviceListSettled(),
@@ -32,5 +43,12 @@ describe('useDeviceLinkDeviceList initial request', () => {
     await waitFor(() => expect(result.current.settled).toBe(true));
     expect(result.current.devices).toBeNull();
     expect(listDevices).toHaveBeenCalledTimes(1);
+
+    act(() => statusChanged?.({ status: 'online' }));
+    expect(listDevices).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ devices: null, settled: false });
+
+    await act(async () => resolveRetry?.({ devices: [] }));
+    await waitFor(() => expect(result.current).toEqual({ devices: [], settled: true }));
   });
 });

--- a/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
@@ -514,12 +514,15 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
 });
 
 describe('shouldShowSelectedMachineConnectingPlaceholder', () => {
+  const noBootstrapFailures = new Set<string>();
+
   it('在线可控但尚未同步会话 → 显示连接中占位', () => {
     expect(
       shouldShowSelectedMachineConnectingPlaceholder({
         rawSelection: ['dev-a'],
         devices: [{ deviceId: 'dev-a', name: 'Mac A', status: 'connecting' }],
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(true);
   });
@@ -532,6 +535,7 @@ describe('shouldShowSelectedMachineConnectingPlaceholder', () => {
         syncedDevices: [
           { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 2, connected: false },
         ],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
   });
@@ -544,8 +548,20 @@ describe('shouldShowSelectedMachineConnectingPlaceholder', () => {
         syncedDevices: [
           { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 0, connected: false },
         ],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(true);
+  });
+
+  it('选中设备的 bootstrap 已终态失败 → 停止连接中占位并进入真实空态', () => {
+    expect(
+      shouldShowSelectedMachineConnectingPlaceholder({
+        rawSelection: ['dev-a'],
+        devices: [{ deviceId: 'dev-a', name: 'Mac A', status: 'connecting' }],
+        syncedDevices: [],
+        bootstrapFailedDeviceIds: new Set(['dev-a']),
+      }),
+    ).toBe(false);
   });
 
   it('多选:全是连接中且无缓存 → 占位;混入本机或已连接设备 → 不占位', () => {
@@ -558,6 +574,7 @@ describe('shouldShowSelectedMachineConnectingPlaceholder', () => {
         rawSelection: ['dev-a'],
         devices,
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(true);
     expect(
@@ -565,6 +582,7 @@ describe('shouldShowSelectedMachineConnectingPlaceholder', () => {
         rawSelection: ['dev-a', 'dev-b'],
         devices,
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
     expect(
@@ -572,6 +590,7 @@ describe('shouldShowSelectedMachineConnectingPlaceholder', () => {
         rawSelection: ['local', 'dev-a'],
         devices,
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
   });

--- a/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
@@ -385,6 +385,7 @@ describe('normalizeSelectedMachineId 配合可选中集(连接中可保留,被�
 
 describe('shouldWaitForRemoteSessionBootstrap', () => {
   const connecting = [{ deviceId: 'dev-a', name: 'Mac A', status: 'connecting' as const }];
+  const noBootstrapFailures = new Set<string>();
 
   it('所有机器:设备清单或在线远端首快照未落地 → 保持加载态', () => {
     expect(
@@ -393,6 +394,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         deviceListSettled: false,
         devices: [],
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(true);
     expect(
@@ -401,6 +403,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         deviceListSettled: true,
         devices: connecting,
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(true);
   });
@@ -414,6 +417,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         syncedDevices: [
           { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 0, connected: false },
         ],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
   });
@@ -425,6 +429,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         deviceListSettled: true,
         devices: [],
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
   });
@@ -436,6 +441,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         deviceListSettled: false,
         devices: [],
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
     expect(
@@ -444,6 +450,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         deviceListSettled: true,
         devices: connecting,
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
     expect(
@@ -452,6 +459,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         deviceListSettled: true,
         devices: connecting,
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(true);
   });
@@ -463,6 +471,7 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         deviceListSettled: true,
         devices: [{ deviceId: 'dev-a', name: 'Mac A', status: 'rejected' }],
         syncedDevices: [],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
     expect(
@@ -473,8 +482,34 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
         syncedDevices: [
           { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 2, connected: false },
         ],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
       }),
     ).toBe(false);
+  });
+
+  it('bootstrap 终态失败的连接中设备不再无限 loading；其它未结算设备仍继续等待', () => {
+    const devices = [
+      { deviceId: 'dev-a', name: 'Mac A', status: 'connecting' as const },
+      { deviceId: 'dev-b', name: 'Mac B', status: 'connecting' as const },
+    ];
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: ['dev-a'],
+        deviceListSettled: true,
+        devices,
+        syncedDevices: [],
+        bootstrapFailedDeviceIds: new Set(['dev-a']),
+      }),
+    ).toBe(false);
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: MACHINE_ALL,
+        deviceListSettled: true,
+        devices,
+        syncedDevices: [],
+        bootstrapFailedDeviceIds: new Set(['dev-a']),
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
@@ -422,6 +422,20 @@ describe('shouldWaitForRemoteSessionBootstrap', () => {
     ).toBe(false);
   });
 
+  it('明确选择已有权威 shard 的设备时，不等待独立的设备清单重试', () => {
+    expect(
+      shouldWaitForRemoteSessionBootstrap({
+        selectedMachineId: ['dev-a'],
+        deviceListSettled: false,
+        devices: connecting,
+        syncedDevices: [
+          { deviceId: 'dev-a', deviceName: 'Mac A', sessionCount: 0, connected: false },
+        ],
+        bootstrapFailedDeviceIds: noBootstrapFailures,
+      }),
+    ).toBe(false);
+  });
+
   it('设备清单请求失败但已结算 → 不把未知设备列表当成永久加载', () => {
     expect(
       shouldWaitForRemoteSessionBootstrap({

--- a/apps/desktop/src/renderer/__tests__/refreshRemoteSessionsRetry.test.ts
+++ b/apps/desktop/src/renderer/__tests__/refreshRemoteSessionsRetry.test.ts
@@ -129,6 +129,19 @@ describe('refreshRemoteDeviceSessions retry', () => {
     expect(remoteProjectsStore.getMergedRemoteSessions().map((s) => s.id)).toContain('only');
   });
 
+  it('断连使在途快照失效 → 返回 superseded，不冒充终态请求失败', async () => {
+    const d = did();
+    const snapshot = deferred<Session[]>();
+    invoke.mockReturnValueOnce(snapshot.promise);
+
+    const refresh = refreshRemoteDeviceSessions(d, 'Mac B', { sleep: noSleep });
+    remoteProjectsStore.markAllDisconnected();
+    snapshot.resolve([session('stale')]);
+
+    await expect(refresh).resolves.toBe('superseded');
+    expect(remoteProjectsStore.getMergedRemoteSessions()).toHaveLength(0);
+  });
+
   it('首拉 active 列表时要求被控端补齐置顶,避免旧置顶被 200 条窗口截掉', async () => {
     const d = did();
     invoke.mockResolvedValueOnce([

--- a/apps/desktop/src/renderer/__tests__/remoteProjectsStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remoteProjectsStore.test.ts
@@ -214,6 +214,31 @@ describe('remoteProjectsStore', () => {
     ]);
   });
 
+  it('tracks terminal bootstrap failures with stable snapshots and clears them after a successful snapshot', () => {
+    const before = remoteProjectsStore.getBootstrapFailedDeviceIds();
+    remoteProjectsStore.markBootstrapFailed('dev-B');
+    const failed = remoteProjectsStore.getBootstrapFailedDeviceIds();
+    expect(failed).not.toBe(before);
+    expect([...failed]).toEqual(['dev-B']);
+
+    remoteProjectsStore.markBootstrapFailed('dev-B');
+    expect(remoteProjectsStore.getBootstrapFailedDeviceIds()).toBe(failed);
+
+    remoteProjectsStore.setDeviceSessions('dev-B', 'B', []);
+    expect(remoteProjectsStore.getBootstrapFailedDeviceIds().size).toBe(0);
+  });
+
+  it('removeDevice and clear discard bootstrap failure state even before a shard exists', () => {
+    remoteProjectsStore.markBootstrapFailed('dev-A');
+    remoteProjectsStore.removeDevice('dev-A');
+    expect(remoteProjectsStore.getBootstrapFailedDeviceIds().size).toBe(0);
+
+    remoteProjectsStore.markBootstrapFailed('dev-A');
+    remoteProjectsStore.markBootstrapFailed('dev-B');
+    remoteProjectsStore.clear();
+    expect(remoteProjectsStore.getBootstrapFailedDeviceIds().size).toBe(0);
+  });
+
   it('clear resets everything', () => {
     remoteProjectsStore.setDeviceSessions('dev-B', 'B', [mk('s1'), mk('s2')]);
     remoteProjectsStore.clear();

--- a/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
+++ b/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
@@ -85,9 +85,10 @@ export interface RefreshOptions {
  * 重拉结果:
  *  - `ok`:成功落地最新快照(或本次被更新一次取代而让位,语义上无需调用方善后);
  *  - `revoked`:被控端在 bootstrap 期间撤销了访问权限 → 调用方应 handleRevoked;
+ *  - `superseded`:断连 / 清理等外部状态变化使本次快照失效 → 不是请求失败,等待后续重连;
  *  - `gave-up`:瞬态重试耗尽 / 永久非撤销错误 → 调用方照常收尾(push / reconnect 会兜底补上)。
  */
-export type RefreshResult = 'ok' | 'revoked' | 'gave-up';
+export type RefreshResult = 'ok' | 'revoked' | 'superseded' | 'gave-up';
 
 interface RefreshTask {
   promise: Promise<RefreshResult>;
@@ -256,7 +257,7 @@ async function runRefreshRemoteDeviceSessions(
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     // 被一次更新的重拉取代(期间又发起了新的 refresh)→ 停手,交给那一次(也避免无谓重试)。
-    if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch)) return 'gave-up';
+    if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch)) return 'superseded';
     try {
       const list = await window.electronAPI.deviceLink.invoke(deviceId, 'local-db:sessions:list', [
         LIST_LIMIT,
@@ -264,7 +265,7 @@ async function runRefreshRemoteDeviceSessions(
         { includePinned: true },
       ]);
       // 乱序保护:本次拉取已不是最新一次 → 丢弃,别覆盖更新的结果。
-      if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch)) return 'gave-up';
+      if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch)) return 'superseded';
       if (Array.isArray(list)) {
         if ((opts.snapshotMode ?? 'merge') === 'merge') {
           const sessions = list as Session[];
@@ -291,7 +292,7 @@ async function runRefreshRemoteDeviceSessions(
       }
       return 'ok'; // 成功
     } catch (err) {
-      if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch)) return 'gave-up';
+      if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch)) return 'superseded';
       const message = err instanceof Error ? err.message : String(err);
       // 访问被撤销:语义性终态,不重试、也不静默 give-up —— 让调用方 handleRevoked(见 ACCESS_REVOKED_MARKER)。
       if (message.includes(ACCESS_REVOKED_MARKER)) {

--- a/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
+++ b/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
@@ -83,7 +83,7 @@ export interface RefreshOptions {
 
 /**
  * 重拉结果:
- *  - `ok`:成功落地最新快照(或本次被更新一次取代而让位,语义上无需调用方善后);
+ *  - `ok`:成功落地最新快照;
  *  - `revoked`:被控端在 bootstrap 期间撤销了访问权限 → 调用方应 handleRevoked;
  *  - `superseded`:断连 / 清理等外部状态变化使本次快照失效 → 不是请求失败,等待后续重连;
  *  - `gave-up`:瞬态重试耗尽 / 永久非撤销错误 → 调用方照常收尾(push / reconnect 会兜底补上)。

--- a/apps/desktop/src/renderer/features/device-link/remoteProjectsStore.ts
+++ b/apps/desktop/src/renderer/features/device-link/remoteProjectsStore.ts
@@ -38,6 +38,14 @@ interface DeviceShard {
 const shards = new Map<string, DeviceShard>();
 const subs = new Set<() => void>();
 /**
+ * 已完成一次 bootstrap、但以永久错误或重试耗尽告终且尚无权威 sessions shard 的设备。
+ * 这不是「权威空列表」：仅用于让侧边栏结束无限 loading；下一次 reconnect/bootstrap
+ * 开始时会清掉，成功 snapshot 也会清掉。
+ *
+ * 用不可变 Set 快照，保证 useSyncExternalStore 在内容不变时引用稳定。
+ */
+let bootstrapFailedDeviceIds: ReadonlySet<string> = new Set();
+/**
  * 设备改名通知订阅(deviceId → 新名)。设备名走 REST PATCH(Device.name,不进 sessions 表),
  * 服务端不广播 presence;listing tier 把设备名缓存在自己的 eligible 表,改名时同步通知接入器
  * 对齐缓存名,避免下一轮拉取用旧名回填。这与「会话真相」无关,是设备元数据的即时性补丁。
@@ -134,6 +142,17 @@ function recompute(): void {
   subs.forEach((fn) => fn());
 }
 
+/** 更新 bootstrap 失败快照但不通知；调用方与其它 mutation 合并成一次通知。 */
+function setBootstrapFailed(deviceId: string, failed: boolean): boolean {
+  const has = bootstrapFailedDeviceIds.has(deviceId);
+  if (has === failed) return false;
+  const next = new Set(bootstrapFailedDeviceIds);
+  if (failed) next.add(deviceId);
+  else next.delete(deviceId);
+  bootstrapFailedDeviceIds = next;
+  return true;
+}
+
 /** 给一条远端会话打上 device-link origin 标记(供 groupSessions + 传输层识别)。 */
 function stamp(
   session: Session,
@@ -160,16 +179,30 @@ const actions = {
     const connectionStatus: DeviceLinkConnectionStatus = 'connected';
     const stamped = rawSessions.map((s) => stamp(s, deviceId, deviceName, connectionStatus));
     const existing = shards.get(deviceId);
+    const failureCleared = setBootstrapFailed(deviceId, false);
     if (
       existing &&
       existing.connectionStatus === connectionStatus &&
       JSON.stringify(existing.sessions) === JSON.stringify(stamped)
     ) {
       // 内容不变但设备名可能变了(改名走 renameDevice,不经这里);保持引用不动。
+      if (failureCleared) subs.forEach((fn) => fn());
       return;
     }
     shards.set(deviceId, { deviceId, deviceName, connectionStatus, sessions: stamped });
     recompute();
+  },
+
+  /** bootstrap 永久失败 / 重试耗尽且没有 sessions shard：记录终态，避免侧边栏无限 loading。 */
+  markBootstrapFailed(deviceId: string): void {
+    if (!setBootstrapFailed(deviceId, true)) return;
+    subs.forEach((fn) => fn());
+  },
+
+  /** 新一轮 bootstrap 开始或 snapshot 成功：重新进入等待 / 已同步状态。 */
+  clearBootstrapFailure(deviceId: string): void {
+    if (!setBootstrapFailed(deviceId, false)) return;
+    subs.forEach((fn) => fn());
   },
 
   /**
@@ -286,8 +319,10 @@ const actions = {
     // 的 epoch 立即失效,且下次 bootstrap 拿到更高 epoch,不会与断连前在途的 epoch 撞值。即使尚未建
     // shard(首拉未完成就被移除)也要 bump,否则在途首拉 await 回来仍能通过 isLatestSnapshotEpoch 加回。
     snapshotEpoch.set(deviceId, (snapshotEpoch.get(deviceId) ?? 0) + 1);
-    if (!shards.delete(deviceId)) return;
-    recompute();
+    const shardDeleted = shards.delete(deviceId);
+    const failureCleared = setBootstrapFailed(deviceId, false);
+    if (shardDeleted) recompute();
+    else if (failureCleared) subs.forEach((fn) => fn());
   },
 
   /** 清空所有远端项目(登出 / device-link stopped / 卸载)。 */
@@ -295,7 +330,12 @@ const actions = {
     // 所有设备 epoch 无条件**自增**(不 clear-to-0,见 snapshotEpoch 注释的 ABA):清空时在途
     // 首拉立即失效;下一轮 bootstrap 拿到更高 epoch,不会与清空前的 epoch 撞值把陈旧 snapshot 盖回。
     for (const [k, v] of snapshotEpoch) snapshotEpoch.set(k, v + 1);
-    if (shards.size === 0) return;
+    const failureChanged = bootstrapFailedDeviceIds.size > 0;
+    if (failureChanged) bootstrapFailedDeviceIds = new Set();
+    if (shards.size === 0) {
+      if (failureChanged) subs.forEach((fn) => fn());
+      return;
+    }
     shards.clear();
     recompute();
   },
@@ -338,6 +378,11 @@ const actions = {
   /** 机器切换栏用:当前已同步或保留断线缓存的被控设备摘要列表(引用稳定 + 稳定排序)。 */
   getDeviceList(): RemoteDeviceSummary[] {
     return deviceListSnapshot;
+  },
+
+  /** 机器切换栏 loading 判定用：已终态失败且尚无权威 sessions shard 的设备 id。 */
+  getBootstrapFailedDeviceIds(): ReadonlySet<string> {
+    return bootstrapFailedDeviceIds;
   },
 
   /** snapshot 乱序保护:发起一次全量拉取前取新 epoch。 */
@@ -391,6 +436,11 @@ export function useRemoteProjectSessions(): Session[] {
 /** 组件内订阅:返回当前已连接的被控设备摘要列表(机器切换栏 chips)。 */
 export function useRemoteDevices(): RemoteDeviceSummary[] {
   return useSyncExternalStore(subscribe, actions.getDeviceList);
+}
+
+/** 组件内订阅：bootstrap 已终态失败、下一次重试尚未开始的设备集合。 */
+export function useRemoteBootstrapFailedDeviceIds(): ReadonlySet<string> {
+  return useSyncExternalStore(subscribe, actions.getBootstrapFailedDeviceIds);
 }
 
 /** 非组件上下文(presence 订阅器 / 传输层)读写入口。 */

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
@@ -119,6 +119,13 @@ function ensureStarted(): void {
   if (started) return;
   started = true;
   const refresh = (): void => {
+    // 上一轮在尚无设备快照时失败只代表「该次请求已结算」。online / push 触发了新的
+    // 有意义重试后要重新进入 loading，直到这次请求成功或失败；否则失败后重连期间会
+    // 把 devices=null + settled=true 误当成权威空列表。
+    if (devices === null && initialRequestSettled) {
+      initialRequestSettled = false;
+      subs.forEach((fn) => fn());
+    }
     loadGeneration += 1; // 本次为最新一次拉取,作废所有更早的在途响应(见 loadGeneration 注释)。
     const gen = loadGeneration;
     window.electronAPI.deviceLink

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
@@ -158,6 +158,7 @@ export function useDeviceLinkRemoteProjects(): void {
       if (result === 'gave-up' && !remoteProjectsStore.hasDevice(deviceId)) {
         // 永久错误（如旧被控端 CHANNEL_NOT_ALLOWED）或瞬态重试耗尽：不是权威空列表，
         // 但本轮 bootstrap 已有终态，不能让「所有」侧边栏永久停在 loading。
+        // superseded 表示断连 / 清理使请求失效，必须等重连，不能误记成终态失败。
         remoteProjectsStore.markBootstrapFailed(deviceId);
       }
       // 预取被控端能力(model/effort/fast/permission/fork/rewind),使首次打开远程会话时

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
@@ -141,6 +141,8 @@ export function useDeviceLinkRemoteProjects(): void {
      * 任一步返回 ACCESS_REVOKED → 标记已撤销并移除该设备;全程无撤销 → 清掉残留标记(恢复收尾)。
      */
     const runSubscribeAndBootstrap = async (deviceId: string, name: string): Promise<void> => {
+      // 新一轮 bootstrap 是有意义的重试：恢复 loading，直到本轮落下 snapshot 或再次终态失败。
+      remoteProjectsStore.clearBootstrapFailure(deviceId);
       try {
         await window.electronAPI.deviceLink.subscribe(deviceId, ['sessions']);
       } catch (err) {
@@ -152,13 +154,18 @@ export function useDeviceLinkRemoteProjects(): void {
       // (而非静默 give-up)→ 这里 handleRevoked,而不是继续预取能力 / 清撤销标记无视拒绝。
       const result = await refreshRemoteDeviceSessions(deviceId, name);
       if (result === 'revoked') return void handleRevoked(deviceId);
-      if (disposed) return;
+      if (disposed || !eligible.has(deviceId)) return;
+      if (result === 'gave-up' && !remoteProjectsStore.hasDevice(deviceId)) {
+        // 永久错误（如旧被控端 CHANNEL_NOT_ALLOWED）或瞬态重试耗尽：不是权威空列表，
+        // 但本轮 bootstrap 已有终态，不能让「所有」侧边栏永久停在 loading。
+        remoteProjectsStore.markBootstrapFailed(deviceId);
+      }
       // 预取被控端能力(model/effort/fast/permission/fork/rewind),使首次打开远程会话时
       // 模型下拉等不为空、modelDefinitions 同步层已热。fire-and-forget,失败不阻断。
       void prefetchDeviceCapabilities(deviceId);
       void prefetchDeviceProviders(deviceId);
       void prefetchDeviceGitSafetySettings(deviceId);
-      // 未被撤销(ok 或瞬态 give-up):清掉可能残留的「已撤销」标记(被控端恢复 → 自动接回的收尾)。
+      // 未被撤销(ok 或普通失败):清掉可能残留的「已撤销」标记(被控端恢复 → 自动接回的收尾)。
       revokedDevicesStore.clearRevoked(deviceId);
     };
 

--- a/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
+++ b/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
@@ -22,7 +22,11 @@
  */
 
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
-import { useRemoteDevices, type RemoteDeviceSummary } from './remoteProjectsStore';
+import {
+  useRemoteBootstrapFailedDeviceIds,
+  useRemoteDevices,
+  type RemoteDeviceSummary,
+} from './remoteProjectsStore';
 import { revokedDevicesStore } from './revokedDevicesStore';
 import {
   useDeviceLinkDeviceList,
@@ -50,6 +54,7 @@ export interface RemoteSessionBootstrapLoadingInput {
   deviceListSettled: boolean;
   devices: readonly SwitcherDevice[];
   syncedDevices: readonly RemoteDeviceSummary[];
+  bootstrapFailedDeviceIds: ReadonlySet<string>;
 }
 
 /**
@@ -62,6 +67,7 @@ export function shouldWaitForRemoteSessionBootstrap({
   deviceListSettled,
   devices,
   syncedDevices,
+  bootstrapFailedDeviceIds,
 }: RemoteSessionBootstrapLoadingInput): boolean {
   const selectedRemoteIds =
     selectedMachineId === MACHINE_ALL
@@ -75,6 +81,7 @@ export function shouldWaitForRemoteSessionBootstrap({
     (device) =>
       device.status === 'connecting' &&
       !syncedIds.has(device.deviceId) &&
+      !bootstrapFailedDeviceIds.has(device.deviceId) &&
       (selectedRemoteIds === null || selectedRemoteIds.has(device.deviceId)),
   );
 }
@@ -159,6 +166,7 @@ export function useRemoteSessionBootstrapLoading(
   const deviceListSettled = useDeviceLinkDeviceListSettled();
   const devices = useSwitcherDevices();
   const synced = useRemoteDevices();
+  const bootstrapFailedDeviceIds = useRemoteBootstrapFailedDeviceIds();
   return useMemo(
     () =>
       shouldWaitForRemoteSessionBootstrap({
@@ -166,8 +174,9 @@ export function useRemoteSessionBootstrapLoading(
         deviceListSettled,
         devices,
         syncedDevices: synced,
+        bootstrapFailedDeviceIds,
       }),
-    [selectedMachineId, deviceListSettled, devices, synced],
+    [selectedMachineId, deviceListSettled, devices, synced, bootstrapFailedDeviceIds],
   );
 }
 

--- a/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
+++ b/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
@@ -75,9 +75,18 @@ export function shouldWaitForRemoteSessionBootstrap({
       ? null
       : new Set(selectedMachineId.filter((id) => id !== MACHINE_LOCAL));
   if (selectedRemoteIds?.size === 0) return false;
-  if (!deviceListSettled) return true;
 
   const syncedIds = new Set(syncedDevices.map((device) => device.deviceId));
+  // 明确选择的远端设备若都已有权威 shard（包括 0 会话），设备目录的独立重试不应
+  // 把已知作用域重新挡回 loading；「所有」仍必须等目录结算，才能知道完整远端集合。
+  if (
+    selectedRemoteIds !== null &&
+    [...selectedRemoteIds].every((deviceId) => syncedIds.has(deviceId))
+  ) {
+    return false;
+  }
+  if (!deviceListSettled) return true;
+
   return devices.some(
     (device) =>
       device.status === 'connecting' &&

--- a/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
+++ b/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
@@ -47,6 +47,7 @@ export interface SelectedMachineConnectingInput {
   rawSelection: MachineSelection;
   devices: readonly SwitcherDevice[];
   syncedDevices: readonly RemoteDeviceSummary[];
+  bootstrapFailedDeviceIds: ReadonlySet<string>;
 }
 
 export interface RemoteSessionBootstrapLoadingInput {
@@ -96,12 +97,14 @@ export function shouldShowSelectedMachineConnectingPlaceholder({
   rawSelection,
   devices,
   syncedDevices,
+  bootstrapFailedDeviceIds,
 }: SelectedMachineConnectingInput): boolean {
   const effective = normalizeSelectedMachineId(rawSelection, selectableDeviceIds(devices));
   if (effective === MACHINE_ALL || effective.includes(MACHINE_LOCAL)) return false;
   for (const deviceId of effective) {
     const selectedDevice = devices.find((d) => d.deviceId === deviceId);
     if (selectedDevice?.status !== 'connecting') return false;
+    if (bootstrapFailedDeviceIds.has(deviceId)) return false;
     const cachedSessionCount =
       syncedDevices.find((d) => d.deviceId === deviceId)?.sessionCount ?? 0;
     if (cachedSessionCount > 0) return false;
@@ -148,10 +151,12 @@ export function useSelectedMachineConnecting(): boolean {
   const raw = useSelectedMachineId();
   const devices = useSwitcherDevices();
   const synced = useRemoteDevices();
+  const bootstrapFailedDeviceIds = useRemoteBootstrapFailedDeviceIds();
   return shouldShowSelectedMachineConnectingPlaceholder({
     rawSelection: raw,
     devices,
     syncedDevices: synced,
+    bootstrapFailedDeviceIds,
   });
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

这是 #468 合并后的技术 follow-up，处理设备会话 loading 终态的连续 review 反馈：

- 首次设备清单请求失败后，后续 `online` 重试会重新进入 loading，避免把仍在请求的未知状态误当成权威空列表。
- 远端 sessions bootstrap 遇到永久错误或重试耗尽且尚无权威快照时，记录本轮终态，避免「所有」或仅选中该远端设备时侧边栏永久 loading；下一次有效重试开始或快照成功时自动清除该终态。
- 断连或清理取消在途 bootstrap 时返回独立的 `superseded` 结果，不再把取消误记成终态失败；明确选择已有权威 shard 的设备时，也不再被独立的设备目录重试挡回 loading。
- 补充重试、终态失败、成功恢复及状态清理的回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#468 合并后的 review follow-up
- 本 PR 包含：Desktop Renderer 的 Device Link 设备清单与远端会话 bootstrap loading 状态收口，以及对应单元测试。
- 明确不包含：视觉样式、UI 文案、IPC / wire protocol、服务端、Mobile 原生配置或 runtime fingerprint 变更。
- 用户可见变化：设备清单重试期间继续显示加载态；旧版本被控端不支持 sessions channel 等终态失败不再让「所有」侧边栏无限加载。
- 是否存在 breaking change：无。

### UI 变化

不涉及视觉、布局或文案变化：仅修正 #468 已有 loading / empty 状态组件的状态机时序，沿用现有 Light / Dark 双模式实现。设计约束参考 `docs/design-rules/DESIGN.md` §10 的主题与双模式交付规则，本 PR 未新增或修改任何视觉 token。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 主题与双模式交付规则；本 PR 不涉及视觉、布局或文案变化，仅修正既有 loading / empty 状态机时序。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过。Desktop 1202 个文件 / 12915 项测试通过（2 项既有 skip）；Mobile 251 个文件 / 2361 项测试通过；其余必需 workspace 全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec eslint <本 PR 修改的 9 个文件>
结果：通过。

pnpm --filter desktop exec vitest run src/renderer/__tests__/refreshRemoteSessionsRetry.test.ts src/renderer/__tests__/machineSwitcher.test.ts src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx src/renderer/__tests__/remoteProjectsStore.test.ts src/renderer/__tests__/deviceLinkRemoteProjects.test.ts
结果：5 个文件、102 项测试全部通过。

pnpm check:dco
结果：通过，4 个 commit 已签署 DCO。
```

### 手工验证

不涉及：本次为纯状态机收口，失败 / 重试 / 恢复路径已用可控 Promise 与 store 单测覆盖。

### 未执行的验证

- 未启动 Desktop 做人工视觉走查：没有视觉、布局或文案变化。
- 未执行 Mobile 真机验证：没有修改 Mobile 代码、原生配置或跨端协议。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Device Link 远端会话 loading 状态收口

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的 Device Link 设备清单与远端 sessions bootstrap loading 判定。
- 回滚 / 降级方式：回滚本 PR commit 即恢复原行为；不涉及数据迁移、协议或持久化格式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因
