### PR TITLE
fix(mobile): 语音输入默认自动识别语言

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -322,6 +322,10 @@ import {
   MobileCindyVoiceRunContext,
 } from '@/session/mobileCindyVoiceSession';
 import {
+  currentMobileVoiceUiLanguage,
+  resolveMobileVoiceRefinementSourceLanguage,
+} from '@/session/mobileVoiceLanguage';
+import {
   getMobileVoiceInputHistoryForHost,
   recordMobileVoiceInputHistoryForHost,
   updateMobileVoiceInputHistoryEntryForHost,
@@ -3460,10 +3464,14 @@ export default function SessionScreen() {
           recordHistory: (text) => recordMobileVoiceInputHistoryForHost(deviceId, text),
           updateHistoryEntry: (entryId, text) => updateMobileVoiceInputHistoryEntryForHost(deviceId, entryId, text),
           onRefinementApplied: (input) => {
+            const uiLanguage = currentMobileVoiceUiLanguage();
             voiceDictionaryLearningTrackerRef.current?.captureRefinedInsertion({
               ...input,
-              uiLanguage: 'zh-CN',
-              sourceLanguage: credential.settings?.language,
+              uiLanguage,
+              sourceLanguage: resolveMobileVoiceRefinementSourceLanguage(
+                credential.settings?.language,
+                uiLanguage,
+              ),
             });
           },
         });

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -217,6 +217,10 @@ import {
   MobileCindyVoiceRunContext,
 } from '@/session/mobileCindyVoiceSession';
 import {
+  currentMobileVoiceUiLanguage,
+  resolveMobileVoiceRefinementSourceLanguage,
+} from '@/session/mobileVoiceLanguage';
+import {
   getMobileVoiceInputHistoryForHost,
   recordMobileVoiceInputHistoryForHost,
   updateMobileVoiceInputHistoryEntryForHost,
@@ -1527,10 +1531,14 @@ export default function NewRemoteSessionScreen() {
         recordHistory: (text) => recordMobileVoiceInputHistoryForHost(selectedDeviceId, text),
         updateHistoryEntry: (entryId, text) => updateMobileVoiceInputHistoryEntryForHost(selectedDeviceId, entryId, text),
         onRefinementApplied: (input) => {
+          const uiLanguage = currentMobileVoiceUiLanguage();
           voiceDictionaryLearningTrackerRef.current?.captureRefinedInsertion({
             ...input,
-            uiLanguage: 'zh-CN',
-            sourceLanguage: credential.settings?.language,
+            uiLanguage,
+            sourceLanguage: resolveMobileVoiceRefinementSourceLanguage(
+              credential.settings?.language,
+              uiLanguage,
+            ),
           });
         },
       });

--- a/apps/mobile/src/__tests__/mobileCindyVoiceSession.test.ts
+++ b/apps/mobile/src/__tests__/mobileCindyVoiceSession.test.ts
@@ -22,6 +22,10 @@ import {
   createMobileCindyVoiceCredential,
   MobileCindyVoiceRunContext,
 } from '@/session/mobileCindyVoiceSession';
+import {
+  resolveMobileVoiceAsrLanguage,
+  resolveMobileVoiceRefinementSourceLanguage,
+} from '@/session/mobileVoiceLanguage';
 
 // 文案已 i18n 化;固定 zh-CN 让字面量断言与语言环境解耦(全局 mock 默认 en-US)。
 beforeAll(async () => {
@@ -80,6 +84,28 @@ describe('MobileCindyVoiceRunContext', () => {
       },
       timeoutMs: 10_000,
     });
+  });
+
+  it('keeps ASR auto-detection separate from the concrete refinement language', async () => {
+    const apiFetch = vi.fn(async (
+      _path: string,
+      _options: { body?: { language?: string } },
+    ) => sessionResponse());
+    const context = new MobileCindyVoiceRunContext(
+      vi.fn(async () => 'access-token'),
+      vi.fn(async () => 'fresh-access-token'),
+      apiFetch as ConstructorParameters<typeof MobileCindyVoiceRunContext>[2],
+      'auto',
+      CINDY_MANAGED_REFINER_PROVIDER,
+    );
+
+    await context.createAsrConnection('qwen-asr-flash-realtime');
+
+    expect(apiFetch.mock.calls[0][1].body?.language)
+      .toBeUndefined();
+    expect(resolveMobileVoiceAsrLanguage(' auto ')).toBeUndefined();
+    expect(resolveMobileVoiceRefinementSourceLanguage('auto', 'ja')).toBe('ja');
+    expect(resolveMobileVoiceRefinementSourceLanguage('ko', 'en')).toBe('ko');
   });
 
   it('retries once without the auto marker when a legacy voice-server rejects with 400, then fails refine fast', async () => {
@@ -213,7 +239,7 @@ describe('createMobileCindyVoiceCredential', () => {
     ]);
     expect(credential.asrProviderChain?.every((item) => item.pcmSampleRate === 16_000)).toBe(true);
     expect(credential.settings).toEqual({
-      language: 'zh-CN',
+      language: 'auto',
       refinementEnabled: true,
       playInteractionSound: true,
     });

--- a/apps/mobile/src/__tests__/mobileVoiceInput.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceInput.test.ts
@@ -121,6 +121,7 @@ describe('mobileVoiceInput', () => {
         voiceInputHistory: ['桌面较新的术语', '桌面较早的术语'],
       },
     }), {
+      uiLanguage: 'zh-CN',
       localVoiceInputHistory: ['手机最新术语', '手机较早术语'],
       refinementContext: {
         selectionBefore: '当前输入框前文',
@@ -148,6 +149,23 @@ describe('mobileVoiceInput', () => {
     expect(history.indexOf('- 桌面较早的术语')).toBeLessThan(history.indexOf('- 桌面较新的术语'));
     expect(history.indexOf('- 桌面较新的术语')).toBeLessThan(history.indexOf('- 手机较早术语'));
     expect(history.indexOf('- 手机较早术语')).toBeLessThan(history.indexOf('- 手机最新术语'));
+  });
+
+  it('uses the current UI language for refinement when ASR language is auto', () => {
+    const context = buildMobileVoiceRefinementContext(storedCredential({
+      settings: {
+        language: 'auto',
+        refinementEnabled: true,
+        playInteractionSound: true,
+      },
+    }), {
+      uiLanguage: 'ja',
+    });
+
+    expect(context).toMatchObject({
+      uiLanguage: 'ja',
+      sourceLanguage: 'ja',
+    });
   });
 
   it('normalizes the desktop transcribe result before inserting into the draft', () => {

--- a/apps/mobile/src/session/mobileCindyVoiceSession.ts
+++ b/apps/mobile/src/session/mobileCindyVoiceSession.ts
@@ -11,6 +11,7 @@ import {
   assertMobileVoiceCredentialShape,
   type StoredMobileVoiceCredential,
 } from '@/session/mobileVoiceCredentialStore';
+import { resolveMobileVoiceAsrLanguage } from '@/session/mobileVoiceLanguage';
 
 const VOICE_SESSION_REQUEST_TIMEOUT_MS = 10_000;
 const VOICE_REFINE_WARMUP_TIMEOUT_MS = 10_000;
@@ -43,6 +44,7 @@ type VoiceSessionResponse = {
 /** Per-dictation holder for one-shot ASR tickets and the owning refine session. */
 export class MobileCindyVoiceRunContext {
   private latestSessionId: string | null = null;
+  private readonly sourceLanguage: string | undefined;
   /**
    * 旧 voice-server 不认识 'auto' 标记时置位:会话分配已降级为无润色,后续
    * refine/warmup 直接快速失败(原始 ASR 文本保留),听写本身不受影响。
@@ -53,9 +55,11 @@ export class MobileCindyVoiceRunContext {
     private readonly getAccessToken: AccessTokenProvider,
     private readonly refreshAccessToken: AccessTokenProvider,
     private readonly apiFetch: AuthenticatedApiFetch,
-    private readonly sourceLanguage: string | undefined,
+    sourceLanguage: string | undefined,
     private readonly refinerProvider: string | undefined,
-  ) {}
+  ) {
+    this.sourceLanguage = resolveMobileVoiceAsrLanguage(sourceLanguage);
+  }
 
   async createAsrConnection(asrProvider: string): Promise<{
     websocketUrl: string;
@@ -243,7 +247,7 @@ export function createMobileCindyVoiceCredential(hostDeviceId: string): StoredMo
     refiner: { ...CINDY_MANAGED_REFINER_CHAIN[0] },
     refinerProviderChain: CINDY_MANAGED_REFINER_CHAIN.map((item) => ({ ...item })),
     settings: {
-      language: 'zh-CN',
+      language: 'auto',
       refinementEnabled: true,
       playInteractionSound: true,
     },

--- a/apps/mobile/src/session/mobileVoiceInput.ts
+++ b/apps/mobile/src/session/mobileVoiceInput.ts
@@ -2,6 +2,10 @@ import { apiFetchRaw } from '@/api/client';
 import { DEVICE_LINK_API_BASE_URL } from '@/config/env';
 import { i18n } from '@/i18n';
 import {
+  currentMobileVoiceUiLanguage,
+  resolveMobileVoiceRefinementSourceLanguage,
+} from '@/session/mobileVoiceLanguage';
+import {
   DictationRefiner,
   extractJsonStringFieldSnapshot,
   type DictationRefinementContext,
@@ -222,6 +226,7 @@ export async function uploadMobileVoiceRecording(
 export function buildMobileVoiceRefinementContext(
   credential: StoredMobileVoiceCredential,
   options: {
+    uiLanguage?: string;
     sourceLanguage?: string;
     refinementContext?: DictationRefinementContext;
     localVoiceInputHistory?: readonly string[];
@@ -230,9 +235,18 @@ export function buildMobileVoiceRefinementContext(
   const settings = credential.settings;
   const dictionaryEntries = settings?.dictionaryEntries ?? [];
   const history = mergeMobileVoiceHistories(settings?.voiceInputHistory, options.localVoiceInputHistory);
+  const uiLanguage = options.refinementContext?.uiLanguage?.trim()
+    || options.uiLanguage?.trim()
+    || currentMobileVoiceUiLanguage();
+  const sourceLanguage = resolveMobileVoiceRefinementSourceLanguage(
+    options.refinementContext?.sourceLanguage
+      ?? options.sourceLanguage
+      ?? settings?.language,
+    uiLanguage,
+  );
   const base: DictationRefinementContext = {
-    uiLanguage: 'zh-CN',
-    sourceLanguage: options.sourceLanguage ?? resolveSyncedSourceLanguage(settings?.language),
+    uiLanguage,
+    sourceLanguage,
     userRefinementInstructions: settings?.refinementInstructions?.trim() || undefined,
     userDictionary: formatMobileVoiceDictionary(dictionaryEntries) || undefined,
     dictionaryAliasHints: dictionaryEntries.map((entry) => ({
@@ -245,8 +259,8 @@ export function buildMobileVoiceRefinementContext(
   return {
     ...base,
     ...options.refinementContext,
-    uiLanguage: options.refinementContext?.uiLanguage ?? base.uiLanguage,
-    sourceLanguage: options.refinementContext?.sourceLanguage ?? base.sourceLanguage,
+    uiLanguage,
+    sourceLanguage,
   };
 }
 
@@ -618,12 +632,6 @@ function parseJsonObject(text: string): unknown {
 
 function hasReadableStreamBody(value: unknown): value is ReadableStream<Uint8Array> {
   return !!value && typeof (value as { getReader?: unknown }).getReader === 'function';
-}
-
-function resolveSyncedSourceLanguage(language: string | undefined): string | undefined {
-  const value = language?.trim();
-  if (!value || value.toLowerCase() === 'auto') return undefined;
-  return value;
 }
 
 function formatMobileVoiceDictionary(

--- a/apps/mobile/src/session/mobileVoiceLanguage.ts
+++ b/apps/mobile/src/session/mobileVoiceLanguage.ts
@@ -1,0 +1,37 @@
+import { i18n } from '@/i18n';
+
+function normalizedVoiceLanguage(language: string | null | undefined): string | undefined {
+  const value = language?.trim();
+  return value || undefined;
+}
+
+/**
+ * `auto` 对 ASR 的语义是让 provider 自行探测，不得把 App UI 语言强塞进识别提示。
+ * voice-server 与直连 provider 共用这条归一化，避免一边自动、一边仍锁死语言。
+ */
+export function resolveMobileVoiceAsrLanguage(
+  language: string | null | undefined,
+): string | undefined {
+  const value = normalizedVoiceLanguage(language);
+  return !value || value.toLowerCase() === 'auto' ? undefined : value;
+}
+
+/** 当前 Mobile UI 的实际生效语言；手动 override 已由 LocaleProvider 同步给 i18next。 */
+export function currentMobileVoiceUiLanguage(): string {
+  return normalizedVoiceLanguage(i18n.resolvedLanguage)
+    ?? normalizedVoiceLanguage(i18n.language)
+    ?? 'en';
+}
+
+/**
+ * 润色与词典学习需要一个具体语言作上下文；显式语音语言优先，`auto` 则回落 UI 语言。
+ * 这与 ASR 的自动探测刻意分离，避免中英混说被错误锁定。
+ */
+export function resolveMobileVoiceRefinementSourceLanguage(
+  language: string | null | undefined,
+  uiLanguage = currentMobileVoiceUiLanguage(),
+): string {
+  return resolveMobileVoiceAsrLanguage(language)
+    ?? normalizedVoiceLanguage(uiLanguage)
+    ?? 'en';
+}

--- a/apps/mobile/src/session/mobileVoiceLanguage.ts
+++ b/apps/mobile/src/session/mobileVoiceLanguage.ts
@@ -7,7 +7,7 @@ function normalizedVoiceLanguage(language: string | null | undefined): string | 
 
 /**
  * `auto` 对 ASR 的语义是让 provider 自行探测，不得把 App UI 语言强塞进识别提示。
- * voice-server 与直连 provider 共用这条归一化，避免一边自动、一边仍锁死语言。
+ * 托管 voice-server 请求在这里归一化；直连 provider 在各自协议边界省略 `auto` 提示。
  */
 export function resolveMobileVoiceAsrLanguage(
   language: string | null | undefined,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Mobile 语音输入的新凭据默认使用 `auto`，ASR 请求不再把中文作为固定语言提示，让 provider 自动识别用户实际说的语言。

`auto` 只影响 ASR：润色与词典学习仍需要具体语言上下文，因此显式语音语言优先；未显式指定时回落到当前 Mobile UI 语言。这样既支持中英日等语音识别，也避免润色和词典学习继续被写死为 `zh-CN`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Mobile 语音输入默认语言全球化
- 本 PR 包含：默认 `auto`、ASR 语言归一化、润色/词典学习语言回落、相关单测
- 明确不包含：Desktop 语音设置、voice-server、网站与地区命名
- 用户可见变化：首次使用 Mobile 语音输入时不再默认锁定中文识别
- 是否存在 breaking change：无

### UI 变化

不涉及：只调整语音会话参数与润色/词典学习上下文，没有视觉、交互流程或 UI 文案变化。

- 引用的设计规范：不涉及：纯逻辑改动，无视觉、交互流程或 UI 文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/mobileCindyVoiceSession.test.ts src/__tests__/mobileVoiceInput.test.ts
结果：通过，2 个文件 / 29 个测试

pnpm --filter mobile test:scope
结果：通过

pnpm --filter mobile test:smoke
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：通过（仓库根 pnpm test:unit 门禁）

node apps/mobile/scripts/ci-fingerprint.mjs compute --output <file>
结果：iOS / Android fingerprint 与 origin/main 一致

pnpm check:dco
结果：通过
```

### 手工验证

不涉及：本次没有启动真机麦克风；ASR payload 与润色上下文由定向单测覆盖。

### 未执行的验证

未执行真机语音听写。改动不触及原生录音层，且 Mobile runtime fingerprint 未变化。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：语音识别语言提示策略

### 影响与回滚

- 影响范围：新建或重新同步的 Mobile 托管语音凭据默认走自动语言识别；已有显式语言设置继续优先。
- 回滚 / 降级方式：回退本提交即可恢复固定 `zh-CN` 默认；服务端不支持语言字段缺省时仍沿用现有无语言提示兼容路径。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本 PR 不需要新增用户文档）
- [x] 已确认测试结果或说明未执行原因
