### PR TITLE
docs(agents): 说明 review 沙箱合成 SHA 不构成 DCO 缺签证据

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,10 @@
   `.github/dco.yml`）会拦下漏签的 commit。`git commit` 没有自动签名的配置项，一次配好
   可跑 `pnpm dco:install-hook` 装 `.githooks/prepare-commit-msg`；提交前自查用
   `pnpm check:dco`。DCO 全文见根目录 `DCO`，贡献者说明见 `CONTRIBUTING.md`。
+  对自动 code review 环境的说明：review 沙箱 checkout 出的 HEAD 可能是平台合成的
+  瞬时 commit（不存在于本仓库、GitHub 上查不到该 SHA）；对这类合成 SHA 跑
+  `check:dco` 的失败结果不构成缺签证据，不要据此报告 DCO 问题。判定 DCO 是否通过，
+  一律以 PR 上的 DCO App check 与真实提交范围（`origin/main..PR head`）的结果为准。
 - **提交前测试门禁（硬性要求）**：无论是提 PR 还是直接 commit，提交前都必须在本地
   跑完仓库根 `pnpm test:unit`（全部单元测试），并对本次改动涉及的每个 package 跑
   `pnpm --filter <包名> run --if-present typecheck`（`<包名>` 用该 package 在


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex review bot 在多个 PR 上反复报 DCO 缺签 P1 误报:它的云端沙箱会把 PR 内容物化成一个平台合成的瞬时 commit(该 SHA 不存在于本仓库,GitHub commits API 返回 422),再对这个合成 commit 跑 `check:dco`,必然失败。bot 每次引用的依据正是 AGENTS.md 的「DCO 签名(硬性要求)」段落。本 PR 在该段落末尾补充 4 行说明:review 沙箱合成 SHA 上的 `check:dco` 失败不构成缺签证据,DCO 判定一律以 PR 上的 DCO App check 与真实提交范围(`origin/main..PR head`)为准,从源头消除这类误报。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求:无(起因是近期 PR 上 chatgpt-codex-connector 的重复 DCO 误报,如引用瞬时 SHA `d429daa` / `fbc03222` 的两轮 P1)
- 本 PR 包含:仅 `AGENTS.md` DCO 段落新增 4 行说明
- 明确不包含:不改 `scripts/check-dco.mjs`(合成 commit 离线无不可伪造的识别特征,任何豁免都会成为可钻的空子,脚本注释已明确拒绝该方向);不改 `.github/dco.yml`
- 用户可见变化:无
- 是否存在 breaking change:无

### UI 变化

不涉及

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:通过,0 失败(scripts runner 250 例 + workspace unit tier 全绿)
pnpm check:dco
结果:DCO check passed: 1 commit signed off — range a4269a41..e99c4ff4
```

误报事实核验:`git cat-file -t d429daa` → Not a valid object name(fetch origin 后);对真实范围 `node scripts/check-dco.mjs --base 7e717c5 --head 1d1ada9` → 5 commits signed off,exit 0。

### 手工验证

不涉及(纯文档改动)

### 未执行的验证

无。备注:本地首轮 `pnpm test:unit` 曾失败于「GLOSSARY.md 与 glossary.json 同步」,经 stash 验证为 main 上即存在的 Windows 环境问题(`core.autocrlf=true` 把 `i18n/GLOSSARY.md` 检出成 CRLF,与生成器 LF 输出逐字节比对失败),与本改动无关;以 LF 重新检出该文件后全量通过。建议后续单独修复(如 `.gitattributes` 固定该文件 eol=lf 或测试侧归一化行尾)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 agent 指令文档;不改变任何门禁的实际判定(DCO App check 与 `check:dco` 行为均不变),只是让自动 review 环境不再把沙箱合成 commit 当缺签证据
- 回滚 / 降级方式:revert 本 commit 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)