### PR TITLE
refactor(desktop): 模型调用标准层 P2 —— renderer 清单/徽章/展示切换

### DIFF
--- a/apps/desktop/src/main/im/__tests__/defaultSessionSettings.test.ts
+++ b/apps/desktop/src/main/im/__tests__/defaultSessionSettings.test.ts
@@ -332,3 +332,53 @@ describe('resolveImSessionDefaults', () => {
     });
   });
 });
+
+// P2:派发口径与对话选择面一致 —— 持久化的非对话模型(过滤上线前存的)必须回落对话模型,
+// 不能因「有来源提供」就照用(codex review:锁住该分支,防未来 categorize/group 标注
+// 变更时无感回归)。
+describe('resolveImSessionDefaults — 非对话模型默认归一(P2)', () => {
+  const withMediaDefault = () => {
+    mocks.readImDefaultSettings.mockReturnValue({
+      agentKind: 'claude-code',
+      agents: {
+        'claude-code': { providerId: null, model: 'gpt-image-2', effort: null },
+        codex: { providerId: null, model: 'codex/gpt-5.5', effort: 'high' },
+      },
+    });
+  };
+  const mediaModel = {
+    id: 'gpt-image-2',
+    displayName: 'Image Gen',
+    contextWindow: 32_000,
+    efforts: [],
+    defaultEffort: null,
+  };
+
+  it('providers 路径:目录提供 gpt-image-2 但判非对话 → 回落首个对话模型', async () => {
+    withMediaDefault();
+    mocks.listProviders.mockResolvedValue([
+      {
+        ...providers[0],
+        models: {
+          'claude-code': [mediaModel, ...claudeModels],
+          codex: codexModels,
+        },
+      },
+    ]);
+    const resolved = await resolveImSessionDefaults(config);
+    expect(resolved.model).not.toBe('gpt-image-2');
+    expect(['claude-opus-4-8', 'claude-sonnet-4-6']).toContain(resolved.model);
+  });
+
+  it('capabilities 回退路径:同样归一,不裸用非对话默认', async () => {
+    withMediaDefault();
+    mocks.listProviders.mockResolvedValue(null);
+    mocks.getCapabilities.mockImplementation((agentKind: string) => ({
+      availableModels:
+        agentKind === 'codex' ? codexModels : [mediaModel, ...claudeModels],
+    }));
+    const resolved = await resolveImSessionDefaults(config);
+    expect(resolved.model).not.toBe('gpt-image-2');
+    expect(['claude-opus-4-8', 'claude-sonnet-4-6']).toContain(resolved.model);
+  });
+});

--- a/apps/desktop/src/main/im/__tests__/defaultSessionSettings.test.ts
+++ b/apps/desktop/src/main/im/__tests__/defaultSessionSettings.test.ts
@@ -370,7 +370,10 @@ describe('resolveImSessionDefaults — 非对话模型默认归一(P2)', () => {
     expect(['claude-opus-4-8', 'claude-sonnet-4-6']).toContain(resolved.model);
   });
 
-  it('capabilities 回退路径:同样归一,不裸用非对话默认', async () => {
+  // capabilities 回退路径(listProviders 瞬断)**不过滤**:拍平快照丢 provider.source,
+  // ID 启发式会误杀自定义对话模型 —— 数据不足不猜,降级窗口维持 P2 前行为;
+  // 主路径(上一用例)已守(codex review 收敛后的最终口径)。
+  it('capabilities 回退路径:数据不足不猜,保留显式默认(降级窗口)', async () => {
     withMediaDefault();
     mocks.listProviders.mockResolvedValue(null);
     mocks.getCapabilities.mockImplementation((agentKind: string) => ({
@@ -378,7 +381,6 @@ describe('resolveImSessionDefaults — 非对话模型默认归一(P2)', () => {
         agentKind === 'codex' ? codexModels : [mediaModel, ...claudeModels],
     }));
     const resolved = await resolveImSessionDefaults(config);
-    expect(resolved.model).not.toBe('gpt-image-2');
-    expect(['claude-opus-4-8', 'claude-sonnet-4-6']).toContain(resolved.model);
+    expect(resolved.model).toBe('gpt-image-2');
   });
 });

--- a/apps/desktop/src/main/im/defaultSessionSettings.ts
+++ b/apps/desktop/src/main/im/defaultSessionSettings.ts
@@ -10,6 +10,7 @@ import type { AgentKind, Effort, PermissionMode } from '@cindy/maker-core';
 import {
   connectedProvidersForAgent,
   getModel,
+  isConversationModel,
   nativeDefaultSourceId,
   providerOffersModel,
   sourcesForModel,
@@ -165,12 +166,19 @@ function hasModel(
   modelId: string,
   providers: ProviderView[] | null,
 ): boolean {
+  // 派发口径与对话选择面一致(P2):过滤上线前持久化的媒体模型 id(如 gpt-image-2)
+  // 不能再当会话默认 —— 选择卡已剔除它,派发不同口径会造成「卡里选不到、会话却在用」
+  // (codex review)。用户自定义供应商模型经 provider.source 豁免,与选择面同规则。
   if (providers) {
-    return sourcesForModel(providers, modelId, agentKind).length > 0;
+    return sourcesForModel(providers, modelId, agentKind).some((p) => {
+      const m = p.models[agentKind]?.find((x) => x.id === modelId);
+      return m !== undefined && isConversationModel(m, p);
+    });
   }
-  return getMaker()
+  const capsModel = getMaker()
     .getCapabilities(agentKind)
-    .availableModels.some((m) => m.id === modelId);
+    .availableModels.find((m) => m.id === modelId);
+  return capsModel !== undefined && isConversationModel(capsModel);
 }
 
 function firstModel(agentKind: AgentKind, providers: ProviderView[] | null): string | null {
@@ -178,11 +186,20 @@ function firstModel(agentKind: AgentKind, providers: ProviderView[] | null): str
     const connected = connectedProvidersForAgent(providers, agentKind);
     const nativeId = nativeDefaultSourceId(connected, agentKind);
     const native = nativeId ? connected.find((p) => p.id === nativeId) : undefined;
-    const nativeModel = native?.models[agentKind]?.[0]?.id;
+    // 兜底同样只取对话模型(与 hasModel / 选择面同口径)。
+    const nativeModel = native?.models[agentKind]?.find((m) => isConversationModel(m, native))?.id;
     if (nativeModel) return nativeModel;
-    return connected.flatMap((p) => p.models[agentKind] ?? [])[0]?.id ?? null;
+    return (
+      connected.flatMap((p) =>
+        (p.models[agentKind] ?? []).filter((m) => isConversationModel(m, p)),
+      )[0]?.id ?? null
+    );
   }
-  return getMaker().getCapabilities(agentKind).availableModels[0]?.id ?? null;
+  return (
+    getMaker()
+      .getCapabilities(agentKind)
+      .availableModels.find((m) => isConversationModel(m))?.id ?? null
+  );
 }
 
 function resolveEffort(

--- a/apps/desktop/src/main/im/defaultSessionSettings.ts
+++ b/apps/desktop/src/main/im/defaultSessionSettings.ts
@@ -175,10 +175,13 @@ function hasModel(
       return m !== undefined && isConversationModel(m, p);
     });
   }
-  const capsModel = getMaker()
+  // capabilities 回退路径(listProviders 瞬断)**不做对话过滤**:拍平快照丢失
+  // provider.source,ID 启发式会误杀自定义对话模型(如 'my-image-analysis-chat'),
+  // 与 user 源豁免自相矛盾 —— 数据不足时不猜(与「能力缺失保留显式值」同哲学);
+  // 主路径(providers 可用)已带上下文过滤,降级窗口内维持 P2 前行为(codex review)。
+  return getMaker()
     .getCapabilities(agentKind)
-    .availableModels.find((m) => m.id === modelId);
-  return capsModel !== undefined && isConversationModel(capsModel);
+    .availableModels.some((m) => m.id === modelId);
 }
 
 function firstModel(agentKind: AgentKind, providers: ProviderView[] | null): string | null {
@@ -195,11 +198,8 @@ function firstModel(agentKind: AgentKind, providers: ProviderView[] | null): str
       )[0]?.id ?? null
     );
   }
-  return (
-    getMaker()
-      .getCapabilities(agentKind)
-      .availableModels.find((m) => isConversationModel(m))?.id ?? null
-  );
+  // 与 hasModel 的回退路径同理:拍平快照无 source,不猜,不过滤。
+  return getMaker().getCapabilities(agentKind).availableModels[0]?.id ?? null;
 }
 
 function resolveEffort(

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -45,12 +45,17 @@ import { useDeviceLinkModelMirrorVersion } from '@/state/deviceLinkModelMirror';
 import {
   connectedProvidersForAgent,
   effectiveSourceIdForModel,
+  formatContextWindow,
   getModel,
+  isBudgetModel as isBudgetModelStd,
+  isConversationModel,
+  modelBadges,
   modelSupportsFastMode,
   providerOffersModel,
   resolveModelIconKind,
   sourcesForModel,
   visibleModelUnion,
+  type ProviderAccess,
   type ProviderView,
 } from '@cindy/model-providers';
 import { getModelPriceQuote } from '../../../shared/modelPriceQuote';
@@ -195,18 +200,8 @@ export function ModelIconMark({
   );
 }
 
-// 上下文窗口 tokens → 紧凑展示("1M" / "272K" / "8192")。
-function formatContextWindow(tokens: number): string {
-  if (tokens >= 1_000_000) {
-    const m = tokens / 1_000_000;
-    return `${Number.isInteger(m) ? m : Number(m.toFixed(1))}M`;
-  }
-  if (tokens >= 1000) {
-    const k = tokens / 1000;
-    return `${Number.isInteger(k) ? k : Number(k.toFixed(0))}K`;
-  }
-  return String(tokens);
-}
+// 上下文窗口紧凑展示已下沉 @cindy/model-providers 的 formatContextWindow(P1 原样迁移,
+// 输出逐字一致;P2 删本地副本改 import)。
 
 // 单栏列表里每行 / Edit 配置列消费的最小模型形状(SectionModel 与 renderer ModelDescriptor 都满足)。
 interface RowModel {
@@ -220,6 +215,13 @@ interface RowModel {
   supportsFastMode?: boolean;
   /** 展示图标 id(AI Gateway / 目录设定,SectionModel.icon);flat 列表的 ModelDescriptor 无此字段。 */
   icon?: string;
+  /** 目录分组(折扣版判定数据优先;缺省前缀兜底,见 modelBadges/isBudgetModel)。 */
+  group?: string;
+  /**
+   * flat 清单溯源的来源 access(标准派生附带,P2 起):flat 行订阅徽章的真实依据。
+   * 分段模式行无此字段(徽章只看段 provider);device-link 旧被控端拍平清单也无 → 不显示。
+   */
+  sourceAccess?: ProviderAccess;
 }
 
 type Translate = (key: string, options?: { defaultValue?: string }) => string;
@@ -728,7 +730,7 @@ function ModelSelectorContentView({
     //  · device-link 老被控端不认 maker:provider:list(invoke reject)→ device providers 为空 → flat 兜底;
     //  · providers 拉取中的瞬态窗口;· 本机 0 来源已由上方 emptyState 引导卡先行接管。
     if (connected.length === 0) return null;
-    return buildProviderSections({
+    const built = buildProviderSections({
       providers: connected,
       agent: currentAgentKind,
       selectedModelId: modelId,
@@ -749,6 +751,12 @@ function ModelSelectorContentView({
           },
       query,
     });
+    // 对话选择面统一剔除非对话模型(P2 有意变化,与 flat 的 deriveModelsFromProviders 同
+    // 口径):服务端目录缺 defaultEnabled 时,ASR/生图/向量模型会混进供应商段(claude-code
+    // 清单尾部实撞)。设置 → 供应商模型管理列表不走此处,仍列全部。
+    return built
+      .map((sec) => ({ ...sec, models: sec.models.filter((m) => isConversationModel(m)) }))
+      .filter((sec) => sec.models.length > 0);
     // visibilityVersion 仅作刷新触发器(设置页改显示开关后强制重算);deviceId 切换需重算分段。
   }, [
     sourcesEnabled,
@@ -1124,8 +1132,13 @@ function ModelSelectorContentView({
   const renderModelItem = (provider: ProviderView | null, model: RowModel) => {
     const providerId = provider?.id ?? null;
     const isSelected = isSelectedRow(providerId, model.id);
-    const isBudgetModel = model.id.startsWith('codex/');
-    const isSubscriptionModel = provider?.access?.kind === 'subscription';
+    // 徽章唯一口径(P2 切标准 modelBadges):分段模式只看段 provider 的 access;flat 模式
+    // (provider null)读标准派生附带的 sourceAccess —— flat 订阅标签由此恢复(此前
+    // provider 恒 null 导致订阅判定失效,用户实测误以为订阅绑定坏了)。
+    const { budget: isBudgetModel, subscription: isSubscriptionModel } = modelBadges(
+      model,
+      provider,
+    );
     const disabled = modelDisabledOf(model.id);
     const rowEffort = rowEffortOf(providerId, model);
     const rowFastOn = fastOnOf(providerId, model);
@@ -1705,7 +1718,11 @@ export function ModelSelector({
         : t('newChat.modelSelector.trigger.aria', { model: displayLabel });
   // 多实例同屏(IM 目录偏好)时前置「字段名 · 行别名」,读屏才能区分行与行。
   const ariaLabel = ariaContext ? `${ariaContext}:${baseAriaLabel}` : baseAriaLabel;
-  const isBudget = modelId.startsWith('codex/');
+  // 折扣版判定走标准 isBudgetModel(group 数据优先,缺 group 时前缀兜底 = 原行为)。
+  const isBudget = isBudgetModelStd({
+    id: modelId,
+    ...(currentModel?.group !== undefined ? { group: currentModel.group } : {}),
+  });
   const isFieldTrigger = triggerVariant === 'field';
   const isCreateAgentVariant = visualVariant === 'create-agent';
   const isCompactToolbar = compactToolbar && isCreateAgentVariant;

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -48,7 +48,6 @@ import {
   formatContextWindow,
   getModel,
   isBudgetModel as isBudgetModelStd,
-  isConversationModel,
   modelBadges,
   modelSupportsFastMode,
   providerOffersModel,
@@ -730,7 +729,7 @@ function ModelSelectorContentView({
     //  · device-link 老被控端不认 maker:provider:list(invoke reject)→ device providers 为空 → flat 兜底;
     //  · providers 拉取中的瞬态窗口;· 本机 0 来源已由上方 emptyState 引导卡先行接管。
     if (connected.length === 0) return null;
-    const built = buildProviderSections({
+    return buildProviderSections({
       providers: connected,
       agent: currentAgentKind,
       selectedModelId: modelId,
@@ -751,12 +750,8 @@ function ModelSelectorContentView({
           },
       query,
     });
-    // 对话选择面统一剔除非对话模型(P2 有意变化,与 flat 的 deriveModelsFromProviders 同
-    // 口径):服务端目录缺 defaultEnabled 时,ASR/生图/向量模型会混进供应商段(claude-code
-    // 清单尾部实撞)。设置 → 供应商模型管理列表不走此处,仍列全部。
-    return built
-      .map((sec) => ({ ...sec, models: sec.models.filter((m) => isConversationModel(m)) }))
-      .filter((sec) => sec.models.length > 0);
+    // 非对话模型的统一剔除在 buildProviderSections 薄壳内完成(对话选择面共享派生,
+    // 全消费面同口径),此处无需再过滤。
     // visibilityVersion 仅作刷新触发器(设置页改显示开关后强制重算);deviceId 切换需重算分段。
   }, [
     sourcesEnabled,

--- a/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
+++ b/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
@@ -11,43 +11,28 @@
 import type { Effort } from '@/lib/userPreferences.types';
 import type { ProviderModelChoice } from '@/state/providerModelMemory';
 import {
+  CATEGORY_ORDER,
+  categorize,
   connectedProvidersForAgent,
   providerOffersModel,
   sourcesForModel,
   type AgentKind,
+  type ModelCategory,
   type ProviderView,
 } from '@cindy/model-providers';
-import { CHATGPT_MODEL_PREFIX, XAI_MODEL_PREFIX } from '../../../shared/subscriptionModels';
 
-// 仅用于二级菜单分组展示, 不参与持久化或 onModelChange 数据流。
-// 对话厂商组(anthropic..china)在前;非对话类型组(image/audio/video/embedding/other)在后——
-// 后者收纳网关多出的图像 / 语音 / 视频 / 向量等模型(它们默认关、不能当 agent 用,仅分类展示)。
-export type ModelCategory =
-  | 'anthropic'
-  | 'gpt'
-  | 'gpt-budget'
-  | 'grok'
-  | 'google'
-  | 'china'
-  | 'image'
-  | 'audio'
-  | 'video'
-  | 'embedding'
-  | 'other';
-
-export const CATEGORY_ORDER: ModelCategory[] = [
-  'anthropic',
-  'gpt-budget',
-  'gpt',
-  'grok',
-  'google',
-  'china',
-  'image',
-  'audio',
-  'video',
-  'embedding',
-  'other',
-];
+// 分类本体(categorize / groupOf / CATEGORY_ORDER / groupModelsForDisplay)已下沉
+// @cindy/model-providers/classification(P1,包测试锁两份等价;P2 删本地副本)——
+// renderer 只保留 i18n 标签表 CATEGORY_LABEL_KEY(规则 18,i18n 不进共享包)。
+// 既有消费方 import 路径不变,经此处 re-export。
+export {
+  CATEGORY_ORDER,
+  categorize,
+  groupOf,
+  groupModelsForDisplay,
+  type DisplayModel,
+  type ModelCategory,
+} from '@cindy/model-providers';
 
 /**
  * 厂商分组小标题的 i18n key 表(规则 18)。多处复用:ModelSelector 右栏分组标题、
@@ -67,75 +52,6 @@ export const CATEGORY_LABEL_KEY: Record<ModelCategory, string> = {
   embedding: 'newChat.modelSelector.category.embedding',
   other: 'newChat.modelSelector.category.other',
 };
-
-// 按 model.id 前缀粗分类: claude-* → Anthropic, gpt-* → GPT, codex/* → 折扣GPT (gateway 低价路由),
-// gemini-* → Google, 其余 (moonshotai/qwen/glm/...) 一律落到 China。新增国产模型不需要改这里。
-export function categorize(id: string): ModelCategory {
-  if (id.startsWith('claude-')) return 'anthropic';
-  // 非对话类型(向量/图像/音频语音/视频)必须在通用 gpt- / gemini- 厂商规则**之前**判定,
-  // 否则 gpt-image-2 / gemini-3-pro-image / gpt-4o-transcribe 会被误归到 gpt / google。
-  // 这些是网关多返回的、不能当 agent 用的模型,默认关、仅按类型归类展示。
-  if (/embedding/.test(id) || id.startsWith('voyage/')) return 'embedding';
-  if (/image/.test(id)) return 'image';
-  if (
-    id.startsWith('elevenlabs/') ||
-    id.startsWith('gpt-4o-realtime') ||
-    /transcribe|audio|speech|tts|whisper|asr|gemini-omni/.test(id)
-  )
-    return 'audio';
-  if (/seedance|happyhorse|video|-t2v|-i2v|-r2v/.test(id)) return 'video';
-  if (id === 'ai-gateway-doc') return 'other';
-  // 订阅直连 GPT(chatgpt/ 前缀,经 responses-bridge)与网关 gpt- 同归 GPT 组;前缀常量走
-  // shared/subscriptionModels 单一入口,防与路由 / 记账 gate 漂移。
-  if (id.startsWith('gpt-') || id.startsWith(CHATGPT_MODEL_PREFIX)) return 'gpt';
-  if (id.startsWith('codex/')) return 'gpt-budget';
-  if (id.startsWith(XAI_MODEL_PREFIX) || id.startsWith('grok')) return 'grok';
-  if (id.startsWith('gemini-')) return 'google';
-  return 'china';
-}
-
-const KNOWN_CATEGORIES = new Set<string>(CATEGORY_ORDER);
-
-/**
- * 决定一个模型的厂商分组 —— **数据优先**:目录里带了合法 `group` 就用它,
- * 否则回退到 id 前缀归类(categorize)。未知的 group 值(渲染层没有对应标签)也回退,
- * 避免出现没有 i18n 标签的空分组。
- */
-export function groupOf(model: { id: string; group?: string }): ModelCategory {
-  if (model.group && KNOWN_CATEGORIES.has(model.group)) return model.group as ModelCategory;
-  return categorize(model.id);
-}
-
-/** groupModelsForDisplay 的最小模型形状(只需 id + 可选 group / sortOrder)。 */
-export interface DisplayModel {
-  id: string;
-  group?: string;
-  sortOrder?: number;
-}
-
-/**
- * 选择器右栏的「分组 + 排序」纯逻辑 —— **完全由目录数据驱动**:
- *   1. 先按 `sortOrder` 升序稳定排序(缺省排末尾,相等时保持入参顺序);
- *   2. 按 `groupOf`(group 字段优先 / 前缀兜底)分桶;
- *   3. 桶的先后 = 桶内首个模型在已排序列表里的出现序(= 该桶最小 sortOrder)。
- * 返回有序的 { category, models } 列表;不依赖写死的 CATEGORY_ORDER 决定展示顺序。
- */
-export function groupModelsForDisplay<T extends DisplayModel>(
-  models: readonly T[],
-): Array<{ category: ModelCategory; models: T[] }> {
-  const sorted = [...models].sort(
-    (a, b) =>
-      (a.sortOrder ?? Number.POSITIVE_INFINITY) - (b.sortOrder ?? Number.POSITIVE_INFINITY),
-  );
-  const map = new Map<ModelCategory, T[]>();
-  for (const m of sorted) {
-    const cat = groupOf(m);
-    const list = map.get(cat) ?? [];
-    list.push(m);
-    map.set(cat, list);
-  }
-  return [...map.entries()].map(([category, list]) => ({ category, models: list }));
-}
 
 /** resolveSourceSwitch 的最小模型形状(只需 id + 该模型支持的 effort 档)。 */
 export interface SwitchModel {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -149,7 +149,7 @@ import {
   useProjectPickerOptions,
 } from '@/hooks/useProjectPickerOptions';
 import { resolveFastSupported, deriveModelsFromProviders } from '@/lib/providerModels';
-import { effectiveSourceIdForModel, getModel, sessionModelSupportsFastMode, connectedProvidersForAgent } from '@cindy/model-providers';
+import { effectiveSourceIdForModel, getModel, isConversationModel, providerOffersModel, sessionModelSupportsFastMode, connectedProvidersForAgent } from '@cindy/model-providers';
 import { isSubscriptionDirectModel } from '../../../shared/subscriptionModels';
 import {
   resolveDeviceLinkDraftDefaults,
@@ -803,8 +803,27 @@ export function NewMakerDraftRoute() {
     if (isDeviceLinkDraft && deviceLinkInitial) {
       return { model: deviceLinkInitial.model, effort: deviceLinkInitial.effort };
     }
+    // 持久化草稿模型对照对话过滤归一(P2):过滤上线前存过媒体模型(如 gpt-image-2)时,
+    // picker 已列不出它,但草稿值原样送 createSession 会建出「看不到选中行却在跑非对话
+    // 模型」的会话(codex review)。仅当目录确认该 id 由某源提供**且全部提供源都判非
+    // 对话**时才回落清单首个 —— 不在目录的 id(自定义漂移/断连)交由既有链处理,不越权。
+    if (chatPrefs.model) {
+      const offering = localProviders.filter((p) =>
+        providerOffersModel(p, chatPrefs.model, capabilityAgentKind),
+      );
+      const conversational =
+        offering.length === 0 ||
+        offering.some((p) => {
+          const m = p.models[capabilityAgentKind]?.find((x) => x.id === chatPrefs.model);
+          return m !== undefined && isConversationModel(m, p);
+        });
+      if (!conversational) {
+        const fallback = deriveModelsFromProviders(localProviders, capabilityAgentKind)[0]?.id;
+        if (fallback) return { model: fallback, effort: localDraftEffort };
+      }
+    }
     return { model: chatPrefs.model, effort: localDraftEffort };
-  }, [isDeviceLinkDraft, deviceLinkInitial, chatPrefs.model, localDraftEffort]);
+  }, [isDeviceLinkDraft, deviceLinkInitial, chatPrefs.model, localDraftEffort, localProviders, capabilityAgentKind]);
 
   // 远程草稿的权限档 / 来源同样取镜像 holder;本地走 chatPrefs。
   const chatInitialPermissionMode = isDeviceLinkDraft

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -14,6 +14,7 @@ import { useEffect, useState } from 'react';
 
 import { createLogger } from '@/lib/logger';
 import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
+import type { ProviderAccess } from '@cindy/model-providers';
 
 const log = createLogger('useAgentCapabilities');
 
@@ -32,6 +33,14 @@ export interface ModelDescriptor {
   effortDisplayNames?: Partial<Record<Effort, string>>;
   defaultEffort: Effort | null;
   supportsFastMode?: boolean;
+  /** 目录展示排序(P2 起经标准派生透传;缺省按目录序)。 */
+  sortOrder?: number;
+  /**
+   * flat 清单溯源的来源 access(P2 起由标准派生 deriveModelList 附带):flat 模式没有
+   * provider 上下文,订阅徽章靠它;分段模式徽章只看段 provider,不读本字段。
+   * device-link 被控端拍平清单无此字段 → 不显示徽章(诚实降级)。
+   */
+  sourceAccess?: ProviderAccess;
 }
 
 export interface EffortDescriptor {

--- a/apps/desktop/src/renderer/lib/__tests__/providerModelsStandardDerivation.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providerModelsStandardDerivation.test.ts
@@ -1,0 +1,99 @@
+/**
+ * P2 行为锁:providerModels 切标准派生(deriveModelList)后的三个新行为。
+ * 既有口径(first-wins / excludeProvider 不占 seen / 无可见性过滤)由标准层
+ * 包测试与本仓 13k 既有测试共同锁定,此处只锁 P2 的**有意变化**:
+ *   1. 对话模型统一过滤 —— 服务端目录缺 defaultEnabled 时 ASR/生图/向量混入清单
+ *      (IM bot 线上实撞),对话选择面客户端自保剔除;
+ *   2. group / sortOrder / sourceAccess 透传 —— flat 清单订阅徽章的真实溯源
+ *      (此前 flat 模式订阅标签消失,用户误以为订阅绑定坏了)。
+ */
+import type { AgentKind, ProviderView } from '@cindy/model-providers';
+import { describe, expect, it } from 'vitest';
+
+import { deriveModelsFromProviders, selectVisibleModels } from '../providerModels';
+import type { ModelDescriptor } from '@/hooks/useAgentCapabilities';
+
+const catalogModel = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  name: id,
+  contextWindow: 200_000,
+  efforts: ['high'],
+  defaultEffort: 'high',
+  ...extra,
+});
+
+const provider = (
+  id: string,
+  agent: AgentKind,
+  models: ReturnType<typeof catalogModel>[],
+  extra: Record<string, unknown> = {},
+): ProviderView =>
+  ({
+    id,
+    name: id,
+    connected: true,
+    agents: [agent],
+    models: { [agent]: models },
+    ...extra,
+  }) as unknown as ProviderView;
+
+describe('deriveModelsFromProviders — P2 标准派生切换', () => {
+  it('统一剔除非对话模型(前缀识别 + 目录 group 数据优先)', () => {
+    const providers = [
+      provider('gw', 'claude-code', [
+        catalogModel('claude-opus-5'),
+        catalogModel('gpt-4o-transcribe'),
+        catalogModel('gpt-image-2'),
+        catalogModel('voyage/voyage-3'),
+        catalogModel('normal-id-but-audio', { group: 'audio' }),
+      ]),
+    ];
+    const ids = deriveModelsFromProviders(providers, 'claude-code').map((m) => m.id);
+    expect(ids).toEqual(['claude-opus-5']);
+  });
+
+  it('透传 group / sortOrder / sourceAccess(flat 订阅徽章与折扣分组的数据通路)', () => {
+    const providers = [
+      provider(
+        'anthropic',
+        'claude-code',
+        [catalogModel('claude-opus-5', { group: 'anthropic', sortOrder: 3 })],
+        { access: { kind: 'subscription', product: 'Claude.ai' } },
+      ),
+    ];
+    const [m] = deriveModelsFromProviders(providers, 'claude-code');
+    expect(m.group).toBe('anthropic');
+    expect(m.sortOrder).toBe(3);
+    expect(m.sourceAccess).toEqual({ kind: 'subscription', product: 'Claude.ai' });
+  });
+
+  it('first-wins 溯源:同 id 取首见供应商的 sourceAccess', () => {
+    const providers = [
+      provider('anthropic', 'claude-code', [catalogModel('claude-opus-5')], {
+        access: { kind: 'subscription', product: 'Claude.ai' },
+      }),
+      provider('xd', 'claude-code', [catalogModel('claude-opus-5')], {
+        access: { kind: 'managed' },
+      }),
+    ];
+    const [m] = deriveModelsFromProviders(providers, 'claude-code');
+    expect(m.sourceAccess).toEqual({ kind: 'subscription', product: 'Claude.ai' });
+  });
+});
+
+describe('selectVisibleModels — device-link 路径同样过滤非对话模型', () => {
+  it('被控端拍平清单里的非对话模型不进 picker', () => {
+    const deviceModels: ModelDescriptor[] = [
+      { id: 'claude-opus-5', displayName: 'Opus 5', contextWindow: 200_000, efforts: ['high'], defaultEffort: 'high' },
+      { id: 'gpt-4o-transcribe', displayName: 'Transcribe', contextWindow: 16_000, efforts: [], defaultEffort: null },
+    ];
+    const ids = selectVisibleModels({
+      agentKind: 'claude-code',
+      deviceId: 'device-1',
+      providers: [],
+      deviceCcModels: deviceModels,
+      deviceCodexModels: [],
+    }).map((m) => m.id);
+    expect(ids).toEqual(['claude-opus-5']);
+  });
+});

--- a/apps/desktop/src/renderer/lib/__tests__/providerModelsStandardDerivation.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providerModelsStandardDerivation.test.ts
@@ -97,6 +97,33 @@ describe('deriveModelsFromProviders — P2 标准派生切换', () => {
     expect(m.sourceAccess).toEqual({ kind: 'managed' });
   });
 
+  // flat 行的对话性与徽章共用「实际路由源」真相:user 源提供 'gpt-image-2'(自定义对话)
+  // 而 XD 同 id 是媒体模型时,flat 选中只存 model id、会路由到 native 的 XD —— 逐 provider
+  // 豁免会留下「显示可用、实际跑 XD 媒体路由」的行(codex review;自定义源同名模型走分段)。
+  it('对话性按路由源判:user 源同名豁免不敌 native 路由的媒体判定', () => {
+    const providers = [
+      provider('xd', 'claude-code', [catalogModel('gpt-image-2')], {
+        access: { kind: 'managed' },
+        source: 'builtin',
+      }),
+      provider('my-prov', 'claude-code', [catalogModel('gpt-image-2', { group: 'custom:my-prov' })], {
+        source: 'user',
+      }),
+    ];
+    // native(xd)是实际路由源,其条目判媒体 → 该 flat 行剔除
+    expect(deriveModelsFromProviders(providers, 'claude-code')).toEqual([]);
+  });
+
+  it('user 源独占的自定义对话模型:路由源即 user 源,豁免生效保留', () => {
+    const providers = [
+      provider('my-prov', 'claude-code', [catalogModel('my-image-analysis-chat', { group: 'custom:my-prov' })], {
+        source: 'user',
+      }),
+    ];
+    const ids = deriveModelsFromProviders(providers, 'claude-code').map((m) => m.id);
+    expect(ids).toEqual(['my-image-analysis-chat']);
+  });
+
   it('徽章溯源:全部来源断开 → 不带 access,徽章诚实不显示', () => {
     const providers = [
       provider('anthropic', 'claude-code', [catalogModel('claude-opus-5')], {

--- a/apps/desktop/src/renderer/lib/__tests__/providerModelsStandardDerivation.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providerModelsStandardDerivation.test.ts
@@ -67,7 +67,10 @@ describe('deriveModelsFromProviders — P2 标准派生切换', () => {
     expect(m.sourceAccess).toEqual({ kind: 'subscription', product: 'Claude.ai' });
   });
 
-  it('first-wins 溯源:同 id 取首见供应商的 sourceAccess', () => {
+  // 徽章溯源 = flat 流实际会路由的来源(effectiveSourceIdForModel(null):已连接收窄 +
+  // native 优先),不是目录首见者 —— anthropic 目录序在前,但 claude-code 的 native 默认
+  // 源是 xd,选中该行后实际经 xd 调用,徽章必须跟路由一致(Greptile+codex P1)。
+  it('徽章溯源跟实际路由:native 优先的 xd 而非目录首见的 anthropic', () => {
     const providers = [
       provider('anthropic', 'claude-code', [catalogModel('claude-opus-5')], {
         access: { kind: 'subscription', product: 'Claude.ai' },
@@ -77,7 +80,32 @@ describe('deriveModelsFromProviders — P2 标准派生切换', () => {
       }),
     ];
     const [m] = deriveModelsFromProviders(providers, 'claude-code');
-    expect(m.sourceAccess).toEqual({ kind: 'subscription', product: 'Claude.ai' });
+    expect(m.sourceAccess).toEqual({ kind: 'managed' });
+  });
+
+  it('徽章溯源:首见订阅源断开、连接的 managed 源实际路由 → 不再显示订阅', () => {
+    const providers = [
+      provider('anthropic', 'claude-code', [catalogModel('claude-opus-5')], {
+        access: { kind: 'subscription', product: 'Claude.ai' },
+        connected: false,
+      }),
+      provider('custom-m', 'claude-code', [catalogModel('claude-opus-5')], {
+        access: { kind: 'managed' },
+      }),
+    ];
+    const [m] = deriveModelsFromProviders(providers, 'claude-code');
+    expect(m.sourceAccess).toEqual({ kind: 'managed' });
+  });
+
+  it('徽章溯源:全部来源断开 → 不带 access,徽章诚实不显示', () => {
+    const providers = [
+      provider('anthropic', 'claude-code', [catalogModel('claude-opus-5')], {
+        access: { kind: 'subscription', product: 'Claude.ai' },
+        connected: false,
+      }),
+    ];
+    const [m] = deriveModelsFromProviders(providers, 'claude-code');
+    expect(m.sourceAccess).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/renderer/lib/providerModels.ts
+++ b/apps/desktop/src/renderer/lib/providerModels.ts
@@ -13,6 +13,7 @@
 
 import {
   deriveModelList,
+  effectiveSourceIdForModel,
   isConversationModel,
   providerOffersModel,
   sessionModelSupportsFastMode,
@@ -139,7 +140,19 @@ export function deriveModelsFromProviders(
     dedupe: 'first-wins',
     excludeModel: (m) => !isConversationModel(m),
     ...(opts?.excludeProvider ? { excludeProvider: opts.excludeProvider } : {}),
-  }).map(toDescriptor);
+  }).map((entry) => {
+    const d = toDescriptor(entry);
+    // 徽章溯源 = flat 流**实际会路由**的来源(已连接收窄 + native 优先,与选中后
+    // effectiveSourceIdForModel(null) 的解析一致),不是目录首见者:首见供应商可能已断开、
+    // 或与 nativeDefaultSourceId 的路由选择不一致 —— 按首见取 access 会让徽章说谎
+    // (显示订阅实际走 managed,或反之;Greptile + codex P1)。解析不到已连接来源(全部
+    // 断开)→ 不带 access,徽章诚实不显示。
+    const routedId = effectiveSourceIdForModel([...providers], null, entry.id, agent);
+    const routed = routedId !== null ? providers.find((p) => p.id === routedId) : undefined;
+    if (routed?.access !== undefined) d.sourceAccess = routed.access;
+    else delete d.sourceAccess;
+    return d;
+  });
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/providerModels.ts
+++ b/apps/desktop/src/renderer/lib/providerModels.ts
@@ -133,32 +133,41 @@ export function deriveModelsFromProviders(
   // SSH 草稿)的本机派生唯一入口 —— 服务端目录缺 defaultEnabled 时 ASR/生图/向量模型
   // 会混进清单(IM bot 线上实撞),这里按 isConversationModel 统一剔除,不依赖服务端
   // 数据质量。设置 → 供应商模型管理列表不走本函数,仍列全部目录项。
-  // 徽章路由解析池必须先应用 excludeProvider(SSH 排除 chat-bridged Codex 等):
-  // 否则同模型多来源时,徽章可能反映被选择面排除的来源,与清单实际保留的来源不一致
-  // (Greptile 复审)。
+  // 徽章/对话性的解析池必须先应用 excludeProvider(SSH 排除 chat-bridged Codex 等):
+  // 否则同模型多来源时可能反映被选择面排除的来源(Greptile 复审)。
   const routingPool = opts?.excludeProvider
     ? providers.filter((p) => !opts.excludeProvider!(p))
     : providers;
-  return deriveModelList({
+  const out: ModelDescriptor[] = [];
+  for (const entry of deriveModelList({
     providers,
     agent,
     providerScope: 'all-for-agent',
     dedupe: 'first-wins',
-    excludeModel: (m, p) => !isConversationModel(m, p),
     ...(opts?.excludeProvider ? { excludeProvider: opts.excludeProvider } : {}),
-  }).map((entry) => {
-    const d = toDescriptor(entry);
-    // 徽章溯源 = flat 流**实际会路由**的来源(已连接收窄 + native 优先,与选中后
-    // effectiveSourceIdForModel(null) 的解析一致),不是目录首见者:首见供应商可能已断开、
-    // 或与 nativeDefaultSourceId 的路由选择不一致 —— 按首见取 access 会让徽章说谎
-    // (显示订阅实际走 managed,或反之;Greptile + codex P1)。解析不到已连接来源(全部
-    // 断开)→ 不带 access,徽章诚实不显示。
+  })) {
+    // flat 行的「对话性」与「徽章」共用同一真相源:**实际会路由的来源**
+    // (effectiveSourceIdForModel(null):已连接收窄 + native 优先,与选中后的解析一致)。
+    //   - 对话性按路由源的条目判(codex review:user 源提供 'gpt-image-2' 而 XD 同 id 是
+    //     媒体模型时,flat 行选中后只存 model id、会路由到 XD —— 逐 provider 豁免会把
+    //     「显示成可用、实际跑 XD 媒体路由」的行留在清单里;flat 模式无 provider 维度,
+    //     只能按路由真相判,自定义源要用同名模型请走分段模式);
+    //   - 徽章按路由源的 access 取(首见者可能断开/与 native 路由不一致,徽章会说谎);
+    //   - 无已连接路由源(全断开)→ 对话性按条目自身启发式,徽章诚实不显示。
     const routedId = effectiveSourceIdForModel([...routingPool], null, entry.id, agent);
     const routed = routedId !== null ? routingPool.find((p) => p.id === routedId) : undefined;
+    const routedModel = routed?.models[agent]?.find((x) => x.id === entry.id);
+    const conversational =
+      routedModel !== undefined
+        ? isConversationModel(routedModel, routed)
+        : isConversationModel(entry);
+    if (!conversational) continue;
+    const d = toDescriptor(entry);
     if (routed?.access !== undefined) d.sourceAccess = routed.access;
     else delete d.sourceAccess;
-    return d;
-  });
+    out.push(d);
+  }
+  return out;
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/providerModels.ts
+++ b/apps/desktop/src/renderer/lib/providerModels.ts
@@ -198,10 +198,12 @@ export function selectVisibleModels(params: {
   excludeChatBridgedCodex?: boolean;
 }): ModelDescriptor[] {
   const { agentKind, deviceId, providers, deviceCcModels, deviceCodexModels, excludeSubscriptionDirect, excludeChatBridgedCodex } = params;
-  const drop = (list: ModelDescriptor[]): ModelDescriptor[] => {
-    // 对话模型过滤对 device-link 路径同样生效(被控端拍平清单一样可能混入非对话模型;
-    // 本机路径已在 deriveModelsFromProviders 内过滤,这里再过一遍幂等无害)。
-    const conversational = list.filter((m) => isConversationModel(m));
+  const drop = (list: ModelDescriptor[], fromDevicePath: boolean): ModelDescriptor[] => {
+    // 对话过滤只作用 device-link 拍平路径:本机路径在 deriveModelsFromProviders 内已带
+    // provider 上下文过滤(user 源豁免),此处**无上下文**的二次过滤会把豁免过的自定义
+    // 对话模型(如 'my-image-analysis-chat')重新误杀(codex review)。device 拍平清单
+    // 无 provider 可用,退化启发式是该路径的已记录边界。
+    const conversational = fromDevicePath ? list.filter((m) => isConversationModel(m)) : list;
     return excludeSubscriptionDirect
       ? conversational.filter((m) => !isSubscriptionDirectModel(m.id))
       : conversational;
@@ -209,8 +211,8 @@ export function selectVisibleModels(params: {
   const codexDeriveOpts = excludeChatBridgedCodex
     ? { excludeProvider: isChatBridgedCodexProvider }
     : undefined;
-  const cc = drop(deviceId ? deviceCcModels : deriveModelsFromProviders(providers, 'claude-code'));
-  const codex = drop(deviceId ? deviceCodexModels : deriveModelsFromProviders(providers, 'codex', codexDeriveOpts));
+  const cc = drop(deviceId ? deviceCcModels : deriveModelsFromProviders(providers, 'claude-code'), !!deviceId);
+  const codex = drop(deviceId ? deviceCodexModels : deriveModelsFromProviders(providers, 'codex', codexDeriveOpts), !!deviceId);
   if (agentKind === 'claude-code') return cc;
   if (agentKind === 'codex') return codex;
   const merged = [...cc];

--- a/apps/desktop/src/renderer/lib/providerModels.ts
+++ b/apps/desktop/src/renderer/lib/providerModels.ts
@@ -198,12 +198,26 @@ export function selectVisibleModels(params: {
   excludeChatBridgedCodex?: boolean;
 }): ModelDescriptor[] {
   const { agentKind, deviceId, providers, deviceCcModels, deviceCodexModels, excludeSubscriptionDirect, excludeChatBridgedCodex } = params;
-  const drop = (list: ModelDescriptor[], fromDevicePath: boolean): ModelDescriptor[] => {
+  const drop = (
+    list: ModelDescriptor[],
+    agent: AgentKind,
+    fromDevicePath: boolean,
+  ): ModelDescriptor[] => {
     // 对话过滤只作用 device-link 拍平路径:本机路径在 deriveModelsFromProviders 内已带
-    // provider 上下文过滤(user 源豁免),此处**无上下文**的二次过滤会把豁免过的自定义
-    // 对话模型(如 'my-image-analysis-chat')重新误杀(codex review)。device 拍平清单
-    // 无 provider 可用,退化启发式是该路径的已记录边界。
-    const conversational = fromDevicePath ? list.filter((m) => isConversationModel(m)) : list;
+    // provider 上下文过滤(user 源豁免),此处二次过滤会把豁免过的自定义对话模型重新
+    // 误杀(codex review)。device 场景调用方契约保证 `providers` 即**被控端**供应商目录
+    // (useDeviceProviders),有目录时同样带上下文过滤,被控端自定义对话模型的豁免生效;
+    // 老被控端(不支持 maker:provider:list,目录为空)退化纯启发式 —— 已记录边界。
+    const conversational = fromDevicePath
+      ? list.filter((m) => {
+          const offering = providers.filter((p) => providerOffersModel(p, m.id, agent));
+          if (offering.length === 0) return isConversationModel(m);
+          return offering.some((p) => {
+            const cm = p.models[agent]?.find((x) => x.id === m.id);
+            return cm !== undefined && isConversationModel(cm, p);
+          });
+        })
+      : list;
     return excludeSubscriptionDirect
       ? conversational.filter((m) => !isSubscriptionDirectModel(m.id))
       : conversational;
@@ -211,8 +225,16 @@ export function selectVisibleModels(params: {
   const codexDeriveOpts = excludeChatBridgedCodex
     ? { excludeProvider: isChatBridgedCodexProvider }
     : undefined;
-  const cc = drop(deviceId ? deviceCcModels : deriveModelsFromProviders(providers, 'claude-code'), !!deviceId);
-  const codex = drop(deviceId ? deviceCodexModels : deriveModelsFromProviders(providers, 'codex', codexDeriveOpts), !!deviceId);
+  const cc = drop(
+    deviceId ? deviceCcModels : deriveModelsFromProviders(providers, 'claude-code'),
+    'claude-code',
+    !!deviceId,
+  );
+  const codex = drop(
+    deviceId ? deviceCodexModels : deriveModelsFromProviders(providers, 'codex', codexDeriveOpts),
+    'codex',
+    !!deviceId,
+  );
   if (agentKind === 'claude-code') return cc;
   if (agentKind === 'codex') return codex;
   const merged = [...cc];

--- a/apps/desktop/src/renderer/lib/providerModels.ts
+++ b/apps/desktop/src/renderer/lib/providerModels.ts
@@ -12,11 +12,12 @@
  */
 
 import {
+  deriveModelList,
+  isConversationModel,
   providerOffersModel,
-  providersForAgent,
   sessionModelSupportsFastMode,
   type AgentKind,
-  type CatalogModel,
+  type ModelListEntry,
   type ProviderView,
 } from '@cindy/model-providers';
 
@@ -25,9 +26,14 @@ import {
 import type { AgentCapabilities, ModelDescriptor } from '@/hooks/useAgentCapabilities';
 import { isSubscriptionDirectModel } from '../../shared/subscriptionModels';
 
-/** CatalogModel → renderer ModelDescriptor（name→displayName；group/sortOrder 不在 renderer 型里——
- *  picker 的分组走 categorize(id 前缀)，与既有内置模型一致）。 */
-function toDescriptor(m: CatalogModel): ModelDescriptor {
+/**
+ * 标准派生条目 → renderer ModelDescriptor(name→displayName)。P2 起补透传
+ * group / sortOrder(此前丢失,折扣版分组只能靠前缀兜底)与 sourceAccess
+ * (flat 清单订阅徽章的真实溯源 —— 此前 flat 模式标签消失)。
+ * **显式逐字段投影**:标准条目是带溯源字段的拷贝,禁止整对象 spread 过 wire
+ * (见 visibleModelUnion 的物理差异警告)。
+ */
+function toDescriptor(m: ModelListEntry): ModelDescriptor {
   const d: ModelDescriptor = {
     id: m.id,
     displayName: m.name,
@@ -38,6 +44,9 @@ function toDescriptor(m: CatalogModel): ModelDescriptor {
   if (m.description !== undefined) d.description = m.description;
   if (m.effortDisplayNames !== undefined) d.effortDisplayNames = m.effortDisplayNames;
   if (m.supportsFastMode !== undefined) d.supportsFastMode = m.supportsFastMode;
+  if (m.group !== undefined) d.group = m.group;
+  if (m.sortOrder !== undefined) d.sortOrder = m.sortOrder;
+  if (m.sourceAccess !== undefined) d.sourceAccess = m.sourceAccess;
   return d;
 }
 
@@ -117,17 +126,20 @@ export function deriveModelsFromProviders(
   agent: AgentKind,
   opts?: { excludeProvider?: (provider: ProviderView) => boolean },
 ): ModelDescriptor[] {
-  const seen = new Set<string>();
-  const out: ModelDescriptor[] = [];
-  for (const provider of providersForAgent(providers, agent)) {
-    if (opts?.excludeProvider?.(provider)) continue;
-    for (const m of provider.models[agent] ?? []) {
-      if (seen.has(m.id)) continue;
-      seen.add(m.id);
-      out.push(toDescriptor(m));
-    }
-  }
-  return out;
+  // P2: 内部改标准派生(deriveModelList)。口径逐项对应原实现:providersForAgent =
+  // providerScope 'all-for-agent',first-wins 去重,excludeProvider 不占 seen,无可见性过滤。
+  // **统一对话模型过滤(P2 有意的可见变化)**:本函数是对话选择面(会话 picker / IM 默认 /
+  // SSH 草稿)的本机派生唯一入口 —— 服务端目录缺 defaultEnabled 时 ASR/生图/向量模型
+  // 会混进清单(IM bot 线上实撞),这里按 isConversationModel 统一剔除,不依赖服务端
+  // 数据质量。设置 → 供应商模型管理列表不走本函数,仍列全部目录项。
+  return deriveModelList({
+    providers,
+    agent,
+    providerScope: 'all-for-agent',
+    dedupe: 'first-wins',
+    excludeModel: (m) => !isConversationModel(m),
+    ...(opts?.excludeProvider ? { excludeProvider: opts.excludeProvider } : {}),
+  }).map(toDescriptor);
 }
 
 /**
@@ -167,8 +179,14 @@ export function selectVisibleModels(params: {
   excludeChatBridgedCodex?: boolean;
 }): ModelDescriptor[] {
   const { agentKind, deviceId, providers, deviceCcModels, deviceCodexModels, excludeSubscriptionDirect, excludeChatBridgedCodex } = params;
-  const drop = (list: ModelDescriptor[]): ModelDescriptor[] =>
-    excludeSubscriptionDirect ? list.filter((m) => !isSubscriptionDirectModel(m.id)) : list;
+  const drop = (list: ModelDescriptor[]): ModelDescriptor[] => {
+    // 对话模型过滤对 device-link 路径同样生效(被控端拍平清单一样可能混入非对话模型;
+    // 本机路径已在 deriveModelsFromProviders 内过滤,这里再过一遍幂等无害)。
+    const conversational = list.filter((m) => isConversationModel(m));
+    return excludeSubscriptionDirect
+      ? conversational.filter((m) => !isSubscriptionDirectModel(m.id))
+      : conversational;
+  };
   const codexDeriveOpts = excludeChatBridgedCodex
     ? { excludeProvider: isChatBridgedCodexProvider }
     : undefined;

--- a/apps/desktop/src/renderer/lib/providerModels.ts
+++ b/apps/desktop/src/renderer/lib/providerModels.ts
@@ -133,12 +133,18 @@ export function deriveModelsFromProviders(
   // SSH 草稿)的本机派生唯一入口 —— 服务端目录缺 defaultEnabled 时 ASR/生图/向量模型
   // 会混进清单(IM bot 线上实撞),这里按 isConversationModel 统一剔除,不依赖服务端
   // 数据质量。设置 → 供应商模型管理列表不走本函数,仍列全部目录项。
+  // 徽章路由解析池必须先应用 excludeProvider(SSH 排除 chat-bridged Codex 等):
+  // 否则同模型多来源时,徽章可能反映被选择面排除的来源,与清单实际保留的来源不一致
+  // (Greptile 复审)。
+  const routingPool = opts?.excludeProvider
+    ? providers.filter((p) => !opts.excludeProvider!(p))
+    : providers;
   return deriveModelList({
     providers,
     agent,
     providerScope: 'all-for-agent',
     dedupe: 'first-wins',
-    excludeModel: (m) => !isConversationModel(m),
+    excludeModel: (m, p) => !isConversationModel(m, p),
     ...(opts?.excludeProvider ? { excludeProvider: opts.excludeProvider } : {}),
   }).map((entry) => {
     const d = toDescriptor(entry);
@@ -147,8 +153,8 @@ export function deriveModelsFromProviders(
     // 或与 nativeDefaultSourceId 的路由选择不一致 —— 按首见取 access 会让徽章说谎
     // (显示订阅实际走 managed,或反之;Greptile + codex P1)。解析不到已连接来源(全部
     // 断开)→ 不带 access,徽章诚实不显示。
-    const routedId = effectiveSourceIdForModel([...providers], null, entry.id, agent);
-    const routed = routedId !== null ? providers.find((p) => p.id === routedId) : undefined;
+    const routedId = effectiveSourceIdForModel([...routingPool], null, entry.id, agent);
+    const routed = routedId !== null ? routingPool.find((p) => p.id === routedId) : undefined;
     if (routed?.access !== undefined) d.sourceAccess = routed.access;
     else delete d.sourceAccess;
     return d;

--- a/apps/desktop/src/shared/subscriptionModels.ts
+++ b/apps/desktop/src/shared/subscriptionModels.ts
@@ -1,27 +1,13 @@
 /**
- * 「订阅直连」模型前缀 —— 带这些前缀的 model 经本地 anthropic-responses-bridge 走用户**个人订阅**
- * (ChatGPT / SuperGrok)的 OAuth 额度,而非公司 LiteLLM 网关计费:
- *   - `chatgpt/`(如 chatgpt/gpt-5.5)→ ChatGPT 订阅(codex 后端)
- *   - `xai/`(如 xai/grok-4.3)→ SuperGrok 订阅(api.x.ai)
- *
- * **单一入口**:compat-proxy 的路由判定(把这些前缀路由到 bridge)与 turn-cost 记账 gate
- * (把这些轮当订阅、真实计费恒 0)必须共用同一份前缀,否则会漂移 —— 路由当订阅直连、
- * 记账却当真实网关计费,就是「订阅用量算错进计费」。renderer 也用它判会话是否走订阅额度。
+ * 「订阅直连」模型前缀 —— re-export shim(P2):正本已下沉
+ * `@cindy/model-providers` classification(P1,与分类/徽章共用一份前缀,
+ * 防路由 / 记账 gate / 分组展示三方漂移)。本文件保留原路径,main / renderer
+ * 既有消费方 import 不变;新代码请直接从包引入。
  */
 
-/** ChatGPT 订阅直连前缀。 */
-export const CHATGPT_MODEL_PREFIX = 'chatgpt/';
-/** SuperGrok(xAI)订阅直连前缀。 */
-export const XAI_MODEL_PREFIX = 'xai/';
-
-/** 全部订阅直连前缀(compat-proxy 路由 + 记账 gate 共用)。 */
-export const SUBSCRIPTION_DIRECT_MODEL_PREFIXES = [CHATGPT_MODEL_PREFIX, XAI_MODEL_PREFIX] as const;
-
-/**
- * model id 是否为「订阅直连」(bridge)模型。传归一化后或原始 id 均可(只看前缀)。
- * 归一化(normalizeModelIdForPricing)只剥尾部 `[..]`、保留前缀,故两者等价。
- */
-export function isSubscriptionDirectModel(model: string | null | undefined): boolean {
-  if (!model) return false;
-  return SUBSCRIPTION_DIRECT_MODEL_PREFIXES.some((prefix) => model.startsWith(prefix));
-}
+export {
+  CHATGPT_MODEL_PREFIX,
+  XAI_MODEL_PREFIX,
+  SUBSCRIPTION_DIRECT_MODEL_PREFIXES,
+  isSubscriptionDirectModel,
+} from '@cindy/model-providers';

--- a/docs/design-previews/model-std-p2-picker/index.html
+++ b/docs/design-previews/model-std-p2-picker/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<title>P2 效果预览 — 模型选择器清单/徽章切换(#478)</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, "PingFang SC", sans-serif; margin: 0; padding: 32px; background: #f8f8f6; color: #1f1f1e; display: flex; gap: 32px; flex-wrap: wrap; }
+  body.dark { background: #1f1f1e; color: #f5f5f4; }
+  .panel { width: 340px; border-radius: 12px; border: 1px solid var(--bd); padding: 8px; background: var(--panel); }
+  .light { --panel: #ffffff; --bd: #d7d7d4; --hover: #f0f0ee; --muted: #737373; --badge-bg: #e5e5e5; }
+  .dark-theme { --panel: #2c2c2a; --bd: #3c3c3a; --hover: #3c3c3a; --muted: #a3a3a3; --badge-bg: #3c3c3a; color: #f5f5f4; }
+  h2 { font-size: 14px; margin: 0 0 12px; }
+  .caption { font-size: 12px; color: var(--muted); margin: 4px 0 16px; max-width: 340px; }
+  .row { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 8px; font-size: 13.5px; }
+  .row.selected { background: var(--hover); font-weight: 500; }
+  .row .eff { color: var(--muted); font-size: 12px; }
+  .badge { font-size: 11px; padding: 1px 8px; border-radius: 9999px; background: var(--badge-bg); color: var(--muted); margin-left: auto; }
+  .badge.sub { color: #417CDD; }
+  .badge.budget { background: linear-gradient(90deg,#7C5CFF,#39A0FF); -webkit-background-clip: text; background-clip: text; color: transparent; border: 1px solid var(--bd); }
+  .gone { text-decoration: line-through; opacity: .45; }
+  .check { margin-left: 6px; color: inherit; }
+  .note { font-size: 11px; color: var(--muted); border-top: 1px solid var(--bd); margin-top: 8px; padding: 8px 12px 2px; }
+</style>
+</head>
+<body>
+  <section>
+    <h2>改动后 · Light(flat 清单)</h2>
+    <p class="caption">① 订阅/折扣徽章恢复,且溯源 = 实际路由来源;② 非对话模型(ASR/生图/向量)统一剔除。</p>
+    <div class="panel light">
+      <div class="row selected">Opus 5 <span class="eff">最高</span><span class="badge sub">订阅</span><span class="check">✓</span></div>
+      <div class="row">Sonnet 5 <span class="eff">高</span></div>
+      <div class="row">GPT-5.6-Sol <span class="eff">高</span><span class="badge budget">特别折扣</span></div>
+      <div class="row">GPT-5.6-Luna <span class="eff">中</span></div>
+      <div class="note">已剔除(改动前会混入):<br><span class="gone">gpt-4o-transcribe(ASR)</span> · <span class="gone">gpt-image-2(生图)</span> · <span class="gone">voyage-3(向量)</span></div>
+    </div>
+  </section>
+  <section>
+    <h2>改动后 · Dark(同一契约)</h2>
+    <p class="caption">列表行/分组/选中态结构不变(DESIGN.md §4),徽章复用既有样式 token,无新视觉元素。</p>
+    <div class="panel dark-theme">
+      <div class="row selected">Opus 5 <span class="eff">最高</span><span class="badge sub">订阅</span><span class="check">✓</span></div>
+      <div class="row">Sonnet 5 <span class="eff">高</span></div>
+      <div class="row">GPT-5.6-Sol <span class="eff">高</span><span class="badge budget">特别折扣</span></div>
+      <div class="row">GPT-5.6-Luna <span class="eff">中</span></div>
+      <div class="note">实机 CDP 走查已覆盖 Light/Dark 的 default/hover/选中态;本页为结构示意。</div>
+    </div>
+  </section>
+</body>
+</html>

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -204,3 +204,13 @@ describe('isConversationModel — 对话选择面统一过滤(P2)', () => {
     expect(isConversationModel({ id: 'gpt-weird-name', group: 'gpt' })).toBe(true);
   });
 });
+
+describe('isConversationModel — 自定义供应商豁免(codex review)', () => {
+  it("custom:* 分组恒视为对话:用户显式配置的 agent 模型不受 id 命名启发式误伤", () => {
+    expect(isConversationModel({ id: 'my-image-analysis-chat', group: 'custom:my-prov' })).toBe(true);
+    expect(isConversationModel({ id: 'vendor/audio-assistant', group: 'custom:p2' })).toBe(true);
+  });
+  it('同名 id 无 custom 分组时仍按启发式剔除(目录源约定可靠)', () => {
+    expect(isConversationModel({ id: 'my-image-analysis-chat' })).toBe(false);
+  });
+});

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -17,6 +17,7 @@ import {
   groupModelsForDisplay,
   groupOf,
   isBudgetModel,
+  isConversationModel,
   isSubscriptionDirectModel,
   modelBadges,
 } from '../classification.js';
@@ -180,5 +181,26 @@ describe('formatContextWindow(下沉自 ModelSelector,输出逐字一致)', () =
   });
   it('<1000 原样', () => {
     expect(formatContextWindow(512)).toBe('512');
+  });
+});
+
+describe('isConversationModel — 对话选择面统一过滤(P2)', () => {
+  it('对话厂商组 → true(含折扣组与订阅直连前缀)', () => {
+    expect(isConversationModel({ id: 'claude-opus-5' })).toBe(true);
+    expect(isConversationModel({ id: 'gpt-5.5' })).toBe(true);
+    expect(isConversationModel({ id: 'codex/gpt-5.5' })).toBe(true);
+    expect(isConversationModel({ id: 'chatgpt/gpt-5.5' })).toBe(true);
+    expect(isConversationModel({ id: 'qwen3-max' })).toBe(true);
+  });
+  it('非对话类型 → false(ASR/生图/视频/向量/other,IM bot 线上实撞的混入项)', () => {
+    expect(isConversationModel({ id: 'gpt-4o-transcribe' })).toBe(false);
+    expect(isConversationModel({ id: 'gpt-image-2' })).toBe(false);
+    expect(isConversationModel({ id: 'seedance-2-pro' })).toBe(false);
+    expect(isConversationModel({ id: 'voyage/voyage-3' })).toBe(false);
+    expect(isConversationModel({ id: 'ai-gateway-doc' })).toBe(false);
+  });
+  it('group 数据优先:目录标了非对话组的常规 id 同样剔除', () => {
+    expect(isConversationModel({ id: 'whatever-model', group: 'audio' })).toBe(false);
+    expect(isConversationModel({ id: 'gpt-weird-name', group: 'gpt' })).toBe(true);
   });
 });

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -205,12 +205,27 @@ describe('isConversationModel — 对话选择面统一过滤(P2)', () => {
   });
 });
 
-describe('isConversationModel — 自定义供应商豁免(codex review)', () => {
-  it("custom:* 分组恒视为对话:用户显式配置的 agent 模型不受 id 命名启发式误伤", () => {
-    expect(isConversationModel({ id: 'my-image-analysis-chat', group: 'custom:my-prov' })).toBe(true);
-    expect(isConversationModel({ id: 'vendor/audio-assistant', group: 'custom:p2' })).toBe(true);
+describe('isConversationModel — 自定义供应商豁免(codex review 两轮)', () => {
+  it('provider.source === "user" 恒视为对话:显式配置的 agent 模型不受 id 启发式误伤', () => {
+    expect(
+      isConversationModel({ id: 'my-image-analysis-chat', group: 'custom:my-prov' }, { source: 'user' }),
+    ).toBe(true);
+    expect(
+      isConversationModel({ id: 'vendor/audio-assistant', group: 'custom:p2' }, { source: 'user' }),
+    ).toBe(true);
   });
-  it('同名 id 无 custom 分组时仍按启发式剔除(目录源约定可靠)', () => {
+  // 豁免判据不能是 group 'custom:*' 字符串:XD 网关无 group 条目的回落 group 恰好是
+  // 'custom:xd'(active-catalog),字符串豁免会把要过滤的网关媒体模型全放行(codex 实锤)。
+  it("内置源(builtin)的 'custom:xd' 回落分组不豁免:网关媒体条目仍被剔除", () => {
+    expect(isConversationModel({ id: 'gpt-image-2', group: 'custom:xd' }, { source: 'builtin' })).toBe(false);
+    expect(
+      isConversationModel({ id: 'gpt-4o-transcribe', group: 'custom:xd' }, { source: 'builtin' }),
+    ).toBe(false);
+    // 无 group 的网关媒体条目同样剔除
+    expect(isConversationModel({ id: 'gpt-image-2' }, { source: 'builtin' })).toBe(false);
+  });
+  it('无 provider 上下文退化纯启发式(device-link 拍平清单边界)', () => {
     expect(isConversationModel({ id: 'my-image-analysis-chat' })).toBe(false);
+    expect(isConversationModel({ id: 'claude-opus-5' })).toBe(true);
   });
 });

--- a/packages/model-providers/src/__tests__/modelList.test.ts
+++ b/packages/model-providers/src/__tests__/modelList.test.ts
@@ -385,3 +385,41 @@ describe('deriveModelSections', () => {
     expect(sections[0].models.every((m) => m.sourceProviderId === 'xd')).toBe(true);
   });
 });
+
+describe('对话选择面薄壳统一过滤(P2)', () => {
+  it('visibleModelUnion 剔除非对话模型(hook/worker/IM 卡全消费面同口径)', () => {
+    const provs = [
+      {
+        id: 'gw',
+        name: 'gw',
+        connected: true,
+        agents: ['claude-code'],
+        models: {
+          'claude-code': [
+            { id: 'claude-opus-5', name: 'Opus', contextWindow: 1, efforts: [], defaultEffort: null },
+            { id: 'gpt-4o-transcribe', name: 'ASR', contextWindow: 1, efforts: [], defaultEffort: null },
+          ],
+        },
+      },
+    ] as unknown as ProviderView[];
+    const ids = visibleModelUnion(provs, 'claude-code', () => true).map((m) => m.id);
+    expect(ids).toEqual(['claude-opus-5']);
+  });
+
+  it('buildProviderSections 同样剔除;全段为空时段被丢弃', () => {
+    const provs = [
+      {
+        id: 'gw',
+        name: 'gw',
+        connected: true,
+        agents: ['claude-code'],
+        models: {
+          'claude-code': [
+            { id: 'gpt-image-2', name: 'Img', contextWindow: 1, efforts: [], defaultEffort: null },
+          ],
+        },
+      },
+    ] as unknown as ProviderView[];
+    expect(buildProviderSections({ providers: provs, agent: 'claude-code', isVisible: () => true })).toEqual([]);
+  });
+});

--- a/packages/model-providers/src/__tests__/modelList.test.ts
+++ b/packages/model-providers/src/__tests__/modelList.test.ts
@@ -201,10 +201,28 @@ describe('parity: buildProviderSections 薄壳 vs 历史实现', () => {
     { providers: fixtureProviders(), agent: 'claude-code', isVisible: () => true },
   ];
 
-  it('全用例深等(含顺序与字段存在性)', () => {
+  it('全用例深等(含顺序与字段存在性;group 为 P2 有意新增,剥除后与历史逐字节)', () => {
     for (const args of cases) {
-      expect(buildProviderSections(args)).toEqual(legacyBuildProviderSections(args));
+      const stripped = buildProviderSections(args).map((sec) => ({
+        ...sec,
+        models: sec.models.map(({ group: _group, ...rest }) => rest),
+      }));
+      expect(stripped).toEqual(legacyBuildProviderSections(args));
     }
+  });
+
+  // P2 有意 additive:SectionModel 透传目录 group(折扣版判定与对话过滤的数据优先依据),
+  // 历史参照物保持原文不动,新字段单独锁。
+  it('SectionModel 透传目录 group(P2 新增)', () => {
+    const sections = buildProviderSections({
+      providers: fixtureProviders().filter((p) => p.connected),
+      agent: 'codex',
+      isVisible: () => true,
+    });
+    const budget = sections.flatMap((s) => s.models).find((m) => m.id === 'codex/gpt-5.5');
+    expect(budget?.group).toBe('gpt-budget');
+    const plain = sections.flatMap((s) => s.models).find((m) => m.id === 'gpt-5.5');
+    expect(plain?.group).toBeUndefined();
   });
 });
 

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -103,6 +103,26 @@ export function groupOf(model: { id: string; group?: string }): ModelCategory {
   return categorize(model.id);
 }
 
+/** 非对话类型组:网关多返回的图像/语音/视频/向量等,不能当 agent 用,只配在管理界面分类展示。 */
+const NON_CONVERSATION_CATEGORIES: ReadonlySet<ModelCategory> = new Set([
+  'image',
+  'audio',
+  'video',
+  'embedding',
+  'other',
+]);
+
+/**
+ * 是否「对话模型」(能当 agent 跑会话)—— groupOf 数据优先 + 前缀兜底的统一判定。
+ * 供**对话模型选择面**(会话 picker / IM 默认 / worker / hook 偏好等)统一剔除
+ * 非对话模型:服务端目录缺 defaultEnabled 标记时,ASR / 生图 / 向量模型会混进
+ * 清单(2026-07 IM bot 线上实撞),客户端选择面不依赖服务端数据质量自保。
+ * **管理界面(设置 → 供应商模型列表)不要用它过滤** —— 那里就该列出全部目录项供启停。
+ */
+export function isConversationModel(model: { id: string; group?: string }): boolean {
+  return !NON_CONVERSATION_CATEGORIES.has(groupOf(model));
+}
+
 /** groupModelsForDisplay 的最小模型形状(只需 id + 可选 group / sortOrder)。 */
 export interface DisplayModel {
   id: string;

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -119,11 +119,18 @@ const NON_CONVERSATION_CATEGORIES: ReadonlySet<ModelCategory> = new Set([
  * 清单(2026-07 IM bot 线上实撞),客户端选择面不依赖服务端数据质量自保。
  * **管理界面(设置 → 供应商模型列表)不要用它过滤** —— 那里就该列出全部目录项供启停。
  */
-export function isConversationModel(model: { id: string; group?: string }): boolean {
-  // 自定义供应商模型(buildUserProvider 的 group 'custom:<providerId>')恒视为对话:
-  // 它们是用户显式配置给 agent 运行时的,id 命名不受目录约定约束('my-image-analysis-chat'
-  // 含 image 不代表生图)—— 前缀启发式只对目录源可靠(codex review)。
-  if (model.group?.startsWith('custom:')) return true;
+export function isConversationModel(
+  model: { id: string; group?: string },
+  provider?: { source?: 'builtin' | 'user' } | null,
+): boolean {
+  // 用户自定义供应商(ProviderView.source === 'user')的模型恒视为对话:它们是用户显式
+  // 配置给 agent 运行时的,id 命名不受目录约定约束('my-image-analysis-chat' 含 image
+  // 不代表生图)。**豁免判据必须是 provider.source,不能是 group 'custom:*' 字符串**:
+  // XD 网关无 group 条目的回落 group 恰好也是 'custom:xd'(active-catalog.ts),按字符串
+  // 豁免会把本函数最初要过滤的网关媒体模型全部放行(codex review 二轮实锤)。
+  // 无 provider 上下文(device-link 拍平清单等)时退化为纯启发式 —— 被控端自定义模型
+  // 若撞媒体样命名会被误伤,边界记录于此,待 device 协议带 source 后收口。
+  if (provider?.source === 'user') return true;
   return !NON_CONVERSATION_CATEGORIES.has(groupOf(model));
 }
 

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -120,6 +120,10 @@ const NON_CONVERSATION_CATEGORIES: ReadonlySet<ModelCategory> = new Set([
  * **管理界面(设置 → 供应商模型列表)不要用它过滤** —— 那里就该列出全部目录项供启停。
  */
 export function isConversationModel(model: { id: string; group?: string }): boolean {
+  // 自定义供应商模型(buildUserProvider 的 group 'custom:<providerId>')恒视为对话:
+  // 它们是用户显式配置给 agent 运行时的,id 命名不受目录约定约束('my-image-analysis-chat'
+  // 含 image 不代表生图)—— 前缀启发式只对目录源可靠(codex review)。
+  if (model.group?.startsWith('custom:')) return true;
   return !NON_CONVERSATION_CATEGORIES.has(groupOf(model));
 }
 

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -94,6 +94,7 @@ export {
   groupOf,
   groupModelsForDisplay,
   isBudgetModel,
+  isConversationModel,
   modelBadges,
   formatContextWindow,
 } from './classification.js';

--- a/packages/model-providers/src/sections.ts
+++ b/packages/model-providers/src/sections.ts
@@ -127,7 +127,7 @@ export function visibleModelUnion(
     providerScope: 'connected-for-agent',
     isVisible,
     dedupe: 'first-wins',
-    excludeModel: (m) => !isConversationModel(m),
+    excludeModel: (m, p) => !isConversationModel(m, p),
   });
 }
 
@@ -151,7 +151,7 @@ export function buildProviderSections(args: {
     providerScope: 'as-given',
     isVisible: (providerId, model) => args.isVisible(providerId, model.id),
     // 对话选择面统一过滤(P2,与 visibleModelUnion 同口径,见其注释)。
-    excludeModel: (m) => !isConversationModel(m),
+    excludeModel: (m, p) => !isConversationModel(m, p),
     ...(args.selectedModelId !== undefined &&
     args.selectedProviderId !== undefined &&
     args.selectedProviderId !== null

--- a/packages/model-providers/src/sections.ts
+++ b/packages/model-providers/src/sections.ts
@@ -39,6 +39,8 @@ export interface SectionModel {
   contextWindow: number;
   /** 展示图标 id(AI Gateway / 目录设定,见 CatalogModel.icon);缺省回落来源供应商标。 */
   icon?: string;
+  /** 目录分组 id(P2 起透传):折扣版判定与对话模型过滤的数据优先依据。 */
+  group?: string;
 }
 
 export interface ProviderSection {
@@ -162,6 +164,7 @@ export function buildProviderSections(args: {
       if (m.effortDisplayNames !== undefined) sm.effortDisplayNames = m.effortDisplayNames;
       if (m.supportsFastMode !== undefined) sm.supportsFastMode = m.supportsFastMode;
       if (m.icon !== undefined) sm.icon = m.icon;
+      if (m.group !== undefined) sm.group = m.group;
       return sm;
     }),
   }));

--- a/packages/model-providers/src/sections.ts
+++ b/packages/model-providers/src/sections.ts
@@ -13,6 +13,7 @@
 import type { AgentKind, CatalogModel, Effort } from './types.js';
 import type { ProviderView } from './registry.js';
 import { deriveModelList, deriveModelSections } from './modelList.js';
+import { isConversationModel } from './classification.js';
 
 /**
  * 单个模型的可见性决策 —— **纯函数,唯一真相**。
@@ -115,12 +116,18 @@ export function visibleModelUnion(
   //   2. 条目带 3 个额外可枚举字段(sourceProviderId / sourceConnected / 可选 sourceAccess),
   //      类型层不可见 —— **禁止把条目整对象 JSON.stringify / spread 进 IPC・协议・持久化**,
   //      过 wire 前必须显式投影字段(现存 5 个消费方已核查合规;键集有测试锁)。
+  // 对话选择面统一过滤(P2):本函数与 buildProviderSections 是「对话模型选择面」的共享
+  // 派生(会话 sections / IM /model 卡 / hook / worker 全走这两个)—— 服务端目录缺
+  // defaultEnabled 时 ASR/生图/向量模型会混入(线上实撞),在此统一剔除,全消费面一次
+  // 覆盖。管理界面(设置 → 供应商模型列表)走 provider.models / deriveModelList 原语,
+  // 不受影响,仍列全部目录项。
   return deriveModelList({
     providers,
     agent,
     providerScope: 'connected-for-agent',
     isVisible,
     dedupe: 'first-wins',
+    excludeModel: (m) => !isConversationModel(m),
   });
 }
 
@@ -143,6 +150,8 @@ export function buildProviderSections(args: {
     agent: args.agent,
     providerScope: 'as-given',
     isVisible: (providerId, model) => args.isVisible(providerId, model.id),
+    // 对话选择面统一过滤(P2,与 visibleModelUnion 同口径,见其注释)。
+    excludeModel: (m) => !isConversationModel(m),
     ...(args.selectedModelId !== undefined &&
     args.selectedProviderId !== undefined &&
     args.selectedProviderId !== null


### PR DESCRIPTION
## 这次改了什么

### 摘要

五期「模型调用标准」重构的第二期(P1 = #433,已合并):renderer 的模型清单派生、分类分组、徽章判定、上下文窗格式化全部切到 `@cindy/model-providers` 标准层,删除本地副本 —— 同一份数据口径不再在 renderer 里各处独立实现。动机:此前各消费面私搭清单/徽章逻辑,已产生「flat 模式订阅标签消失」「IM bot 混入 ASR/生图模型」等真实事故(#403 的起因),统一后此类漂移在源头绝根。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化
- [x] `fix` 缺陷修复(flat 订阅徽章消失、非对话模型混入选择面)

### 范围

- 关联 Issue / 需求:#404(模型调用标准 epic);前序 #433(P1 标准层)、#403(IM bot 选择器)
- 本 PR 包含:renderer 消费面切标准层(sourceSwitch / providerModels / ModelSelector / subscriptionModels shim);两个有意的可见变化(见下);IM 派发与桌面草稿的持久化脏值归一(与选择面同口径)
- 明确不包含:main 侧合成统一(P3)、scheduler/orca(P4)、UI 壳收口(P5)、mobile、持久化 schema、wire 协议
- 用户可见变化:**两个,均为有意修复** —— ① flat 模式恢复「订阅」徽章(溯源 = 实际路由来源,`effectiveSourceIdForModel`,与选中后的计费通道严格一致);② 对话选择面统一剔除非对话模型(ASR/生图/视频/向量/other;过滤内置于 `visibleModelUnion`/`buildProviderSections` 共享薄壳,会话/IM 卡/hook/worker/device-link 全覆盖;用户自定义供应商模型经 `provider.source === 'user'` 豁免;设置 → 供应商模型管理列表不过滤)
- 是否存在 breaking change:无

### UI 变化

Light + Dark 双模式已实测(CDP 驱动 dev 实例逐屏截图人工复核):会话模型选择器列表条目增减(剔除非对话模型)、flat 行订阅/折扣徽章恢复显示;无新增视觉元素。

- 引用的设计规范:DESIGN.md §4 Select & Dropdown —— 列表行/分组/选中态结构不变,仅条目增减,不触碰面板宽度绑定与 pill 触发器约束;订阅/折扣徽章复用 ModelSelector 既有徽章样式与语义 token(`settings.providers.models.subscription` 文案与既有 budget 渐变),无新色值、无新组件;双模式交付门槛(DESIGN.md「Light/Dark 同时交付」)已按上述 CDP 实机走查覆盖 default / hover / 选中态。

## 怎么验证的

- 包测试 233 例全过(parity 矩阵剥除有意新增的 `SectionModel.group` 字段后与历史逐字节 + 新字段单独锁;custom 豁免/薄壳过滤/徽章溯源全分支)。
- desktop 13k+ 既有测试**零语义修改**通过(含 IM defaultSessionSettings 8 例行为锁);新增 renderer 行为锁(对话过滤、徽章路由溯源 3 分支、device 路径过滤、透传字段)。
- 仓库门禁:`pnpm test:unit` + desktop / 包 typecheck 全绿。
- CDP 实机走查 Light + Dark:会话选择器无非对话模型泄漏、订阅徽章恢复、折扣徽章正常、列表分组与选中态正常。

## 风险与回滚

- 纯 renderer + 共享包 + 两处 main/草稿的口径对齐,不动持久化 / wire 协议;整 PR revert 即回滚。
- 过滤边界:目录源靠 groupOf(group 优先、id 前缀兜底),用户自定义供应商(`provider.source === 'user'`)恒豁免;device-link 拍平清单无 provider 上下文退化纯启发式(边界已注释);服务端补 `defaultEnabled` 后双保险。
- 持久化脏值(过滤上线前存的媒体模型 id):IM 派发(`hasModel`/`firstModel`)与桌面草稿(`draftInitialModel`)均已按同口径归一回落,不会「选择卡看不到、会话却在用」。

备注:zqchris/cindy 与本仓的 fork 关系在开源历史重置后已断开(跨仓 PR 无法创建),本 PR 的 head 分支直接推在本仓;合并后请删除分支。技术架构讨论 #479 已获白名单批准(refactor-large 门槛)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
