### PR TITLE
fix(desktop): 插件 Node 进程意外退出时带上 stderr 诊断行

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -468,6 +468,67 @@ describe('nodeRuntimeBroker · 启动瞬时失败重试(2026-07-24)', () => {
   });
 });
 
+describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
+  it('就绪后崩溃:在途请求与 crashed 状态都带临死前的 stderr 诊断行,且不泄露绝对路径', async () => {
+    const ghost = fakeGhost();
+    const child = new FakeNodeProcess(); // 不回 response,保持在途
+    const pushes: Array<Record<string, unknown>> = [];
+    const warn = vi.fn();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      sendToGhost: (_id, payload) => pushes.push(payload as unknown as Record<string, unknown>),
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+      log: { info: vi.fn(), warn },
+    });
+
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.waitFor(() => expect(child.received).toHaveLength(1));
+    // 引导层先发 ready、后 require 插件入口,所以这类崩溃发生在启动期之后。
+    child.stderr.write(
+      "C:\\Users\\dev\\AppData\\Roaming\\cindy\\plugins\\demo\\node\\worker.cjs:74\n" +
+        "Object.defineProperty(process, 'stdin', {\n       ^\n\n" +
+        'TypeError: Cannot redefine property: stdin\n    at Object.<anonymous>\n',
+    );
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith('ghost node stderr', expect.anything()),
+    );
+    child.emit('exit', 1, null);
+
+    const result = await pending;
+    expect(result).toMatchObject({ ok: false, errorCode: 'PROCESS_EXITED' });
+    const message = (result as { message?: string }).message ?? '';
+    expect(message).toContain('code=1');
+    expect(message).toContain('Cannot redefine property: stdin');
+    expect(message).not.toContain('C:\\Users');
+    expect(message).not.toContain('AppData');
+    const crashed = pushes.find((p) => p.state === 'crashed') as { message?: string };
+    expect(crashed.message).toContain('Cannot redefine property: stdin');
+    expect(crashed.message).not.toContain('C:\\Users');
+  });
+
+  it('陈旧 stderr 不当死因:超过回看窗口只报退出码', async () => {
+    vi.useFakeTimers();
+    const ghost = fakeGhost();
+    const child = new FakeNodeProcess();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+    });
+
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.advanceTimersByTimeAsync(10);
+    child.stderr.write('compiling scene 1...\n');
+    await vi.advanceTimersByTimeAsync(6_000);
+    child.emit('exit', 1, null);
+
+    const result = await pending;
+    expect(result).toMatchObject({ ok: false, errorCode: 'PROCESS_EXITED' });
+    const message = (result as { message?: string }).message ?? '';
+    expect(message).toContain('code=1');
+    expect(message).not.toContain('compiling scene 1');
+  });
+});
+
 describe('nodeRuntimeBroker · 权限与协议', () => {
   it('没声明 node 槽时拒绝且不启动进程', async () => {
     const ghost = fakeGhost();

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -520,7 +520,8 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     child.stderr.write('compiling scene 1...\n');
     await vi.advanceTimersByTimeAsync(6_000);
     child.emit('exit', 1, null);
-    await vi.advanceTimersByTimeAsync(20);
+    child.stderr.end();
+    await vi.advanceTimersByTimeAsync(10);
 
     const result = await pending;
     expect(result).toMatchObject({ ok: false, errorCode: 'PROCESS_EXITED' });
@@ -543,7 +544,8 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     child.emit('exit', 1, null);
     // stderr 晚于 exit 到达(管道中的最后一段)
     child.stderr.write('Error: EACCES permission denied\n');
-    await vi.advanceTimersByTimeAsync(20);
+    child.stderr.end();
+    await vi.advanceTimersByTimeAsync(10);
 
     const result = await pending;
     const message = (result as { message?: string }).message ?? '';
@@ -619,7 +621,8 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     child.stderr.write('heartbeat ok\n');
     await vi.advanceTimersByTimeAsync(100);
     child.emit('exit', 1, null);
-    await vi.advanceTimersByTimeAsync(20);
+    child.stderr.end();
+    await vi.advanceTimersByTimeAsync(10);
 
     const result = await pending;
     const message = (result as { message?: string }).message ?? '';

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -606,6 +606,32 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     expect(message).not.toContain('/Users/jane');
   });
 
+  it('含撇号的 unquoted 路径被完整收敛为文件名', async () => {
+    const ghost = fakeGhost();
+    const child = new FakeNodeProcess();
+    const warn = vi.fn();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+      log: { info: vi.fn(), warn },
+    });
+
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.waitFor(() => expect(child.received).toHaveLength(1));
+    child.stderr.write(
+      "Error: ENOENT\n    at C:\\Users\\O'Brien\\AppData\\Roaming\\cindy\\worker.js:12\n",
+    );
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    child.emit('exit', 1, null);
+    child.stderr.end();
+
+    const result = await pending;
+    const message = (result as { message?: string }).message ?? '';
+    expect(message).toContain('ENOENT');
+    expect(message).not.toContain("O'Brien");
+    expect(message).not.toContain('AppData');
+  });
+
   it('陈旧段不被后续良性 chunk 携带进回看窗口', async () => {
     vi.useFakeTimers();
     const ghost = fakeGhost();

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -576,6 +576,31 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     expect(message).not.toContain('AppData');
   });
 
+  it('含空格的 POSIX 路径被完整收敛为文件名', async () => {
+    const ghost = fakeGhost();
+    const child = new FakeNodeProcess();
+    const warn = vi.fn();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+      log: { info: vi.fn(), warn },
+    });
+
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.waitFor(() => expect(child.received).toHaveLength(1));
+    child.stderr.write(
+      'Error: ENOENT /Users/jane/Library/Application Support/Cindy/plugins/demo/worker.cjs\n',
+    );
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    child.emit('exit', 1, null);
+
+    const result = await pending;
+    const message = (result as { message?: string }).message ?? '';
+    expect(message).toContain('ENOENT');
+    expect(message).not.toContain('Application Support');
+    expect(message).not.toContain('/Users/jane');
+  });
+
   it('陈旧段不被后续良性 chunk 携带进回看窗口', async () => {
     vi.useFakeTimers();
     const ghost = fakeGhost();

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -520,12 +520,115 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     child.stderr.write('compiling scene 1...\n');
     await vi.advanceTimersByTimeAsync(6_000);
     child.emit('exit', 1, null);
+    await vi.advanceTimersByTimeAsync(20);
 
     const result = await pending;
     expect(result).toMatchObject({ ok: false, errorCode: 'PROCESS_EXITED' });
     const message = (result as { message?: string }).message ?? '';
     expect(message).toContain('code=1');
     expect(message).not.toContain('compiling scene 1');
+  });
+
+  it('exit 前的 drain 窗口:stderr 在 exit 后到达仍可截获', async () => {
+    vi.useFakeTimers();
+    const ghost = fakeGhost();
+    const child = new FakeNodeProcess();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+    });
+
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.advanceTimersByTimeAsync(10);
+    child.emit('exit', 1, null);
+    // stderr 晚于 exit 到达(管道中的最后一段)
+    child.stderr.write('Error: EACCES permission denied\n');
+    await vi.advanceTimersByTimeAsync(20);
+
+    const result = await pending;
+    const message = (result as { message?: string }).message ?? '';
+    expect(message).toContain('EACCES permission denied');
+  });
+
+  it('含空格的 Windows 路径被完整收敛为文件名', async () => {
+    const ghost = fakeGhost();
+    const child = new FakeNodeProcess();
+    const warn = vi.fn();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+      log: { info: vi.fn(), warn },
+    });
+
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.waitFor(() => expect(child.received).toHaveLength(1));
+    child.stderr.write(
+      'Error: Cannot find module\n' +
+        '    at C:\\Users\\Jane Doe\\AppData\\Roaming\\cindy\\plugins\\demo\\worker.cjs:12\n',
+    );
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    child.emit('exit', 1, null);
+
+    const result = await pending;
+    const message = (result as { message?: string }).message ?? '';
+    expect(message).toContain('Cannot find module');
+    expect(message).not.toContain('Jane Doe');
+    expect(message).not.toContain('AppData');
+  });
+
+  it('陈旧段不被后续良性 chunk 携带进回看窗口', async () => {
+    vi.useFakeTimers();
+    const ghost = fakeGhost();
+    const child = new FakeNodeProcess();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+    });
+
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.advanceTimersByTimeAsync(10);
+    // 10 秒前写入一条错误日志
+    child.stderr.write('Error: old failure from initialization\n');
+    await vi.advanceTimersByTimeAsync(10_000);
+    // 紧邻退出前写入一条良性日志
+    child.stderr.write('heartbeat ok\n');
+    await vi.advanceTimersByTimeAsync(100);
+    child.emit('exit', 1, null);
+    await vi.advanceTimersByTimeAsync(20);
+
+    const result = await pending;
+    const message = (result as { message?: string }).message ?? '';
+    // 只有"heartbeat ok"在窗口内,选取的诊断行不应含旧错误
+    expect(message).not.toContain('old failure from initialization');
+  });
+
+  it('凭证值出现在 stderr 诊断行中时被脱敏', async () => {
+    const ghost = fakeGhost();
+    // secretBindings 绑定到所有方法(包括 slow)
+    ghost.manifest.node!.secretBindings = [
+      { key: 'api_key', label: 'API Key', methods: ['slow'] },
+    ];
+    const child = new FakeNodeProcess();
+    const readSecret = vi.fn(() => 'sk-secret-token-12345');
+    const warn = vi.fn();
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      readSecret,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+      log: { info: vi.fn(), warn },
+    });
+
+    // 发一个带凭证的请求并保持 pending(不回复)
+    const pending = broker.handleRequest('node-ghost', rpcRequest('slow'));
+    await vi.waitFor(() => expect(child.received).toHaveLength(1));
+    child.stderr.write('Error: auth failed with token sk-secret-token-12345\n');
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    child.emit('exit', 1, null);
+
+    const result = await pending;
+    const message = (result as { message?: string }).message ?? '';
+    expect(message).toContain('[REDACTED]');
+    expect(message).not.toContain('sk-secret-token-12345');
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -493,6 +493,7 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
       expect(warn).toHaveBeenCalledWith('ghost node stderr', expect.anything()),
     );
     child.emit('exit', 1, null);
+    child.stderr.end();
 
     const result = await pending;
     expect(result).toMatchObject({ ok: false, errorCode: 'PROCESS_EXITED' });
@@ -570,6 +571,7 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     );
     await vi.waitFor(() => expect(warn).toHaveBeenCalled());
     child.emit('exit', 1, null);
+    child.stderr.end();
 
     const result = await pending;
     const message = (result as { message?: string }).message ?? '';
@@ -595,6 +597,7 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     );
     await vi.waitFor(() => expect(warn).toHaveBeenCalled());
     child.emit('exit', 1, null);
+    child.stderr.end();
 
     const result = await pending;
     const message = (result as { message?: string }).message ?? '';
@@ -652,6 +655,7 @@ describe('nodeRuntimeBroker · 意外死亡诊断(2026-07-26)', () => {
     child.stderr.write('Error: auth failed with token sk-secret-token-12345\n');
     await vi.waitFor(() => expect(warn).toHaveBeenCalled());
     child.emit('exit', 1, null);
+    child.stderr.end();
 
     const result = await pending;
     const message = (result as { message?: string }).message ?? '';

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -52,6 +52,17 @@ const WORKER_START_ATTEMPTS = 3;
 const WORKER_START_RETRY_DELAYS_MS = [250, 750] as const;
 /** 启动期 stderr 只留头部这么多字符,够提取一行诊断,不给日志灌洪。 */
 const STARTUP_STDERR_CAP = 4_096;
+/**
+ * 意外死亡诊断(2026-07-26):引导层先发 ready、后 require 插件入口,所以"插件
+ * 模块加载期抛错"这类崩溃落在启动期之后——startupStderr 那条路截不到,在途
+ * 请求只会收到干巴巴的"已退出(code=1)"。真实案例:某插件在 Windows 上
+ * defineProperty(process, 'stdin') 抛 TypeError,主进程日志里有完整栈,插件与
+ * Agent 侧却一无所知,只能翻日志才知道为什么。这里另留 stderr **尾部**——崩溃
+ * 摘要出现在最后,与启动期的头部截存互补。
+ */
+const EXIT_STDERR_CAP = 4_096;
+/** 尾部 stderr 只在紧邻退出时可信;更早的日志与本次死亡无关,拼进错误只会误导。 */
+const EXIT_STDERR_LOOKBACK_MS = 5_000;
 const MAX_REQUEST_TIMEOUT_MS = 120_000;
 const MAX_PENDING_REQUESTS = 32;
 const MAX_REQUEST_BYTES = 256 * 1024;
@@ -141,6 +152,10 @@ interface WorkerEntry {
   startupPhase: boolean;
   /** 启动期 stderr 头部截存,失败时提取一行诊断拼进错误消息(如杀软拦截的 EPERM)。 */
   startupStderr: string;
+  /** stderr 尾部滚动截存,进程意外死亡时提取一行诊断拼进错误消息(如加载期抛错)。 */
+  recentStderr: string;
+  /** 尾部截存最后一次进账的时刻(this.now() 口径);0 = 从未收到 stderr。 */
+  recentStderrAt: number;
   /** stdout 的 UTF-8 字节可能把一个汉字切在两个 chunk 之间，必须流式解码。 */
   stdoutDecoder: StringDecoder;
   stdoutBuffer: string;
@@ -178,8 +193,8 @@ class WorkerStartError extends Error {
   }
 }
 
-/** 从启动期 stderr 里挑最有诊断价值的一行(优先含 error 的行),截短拼进失败消息。 */
-function startupStderrHint(text: string): string | null {
+/** 从 stderr 里挑最有诊断价值的一行(优先含 error 的行),截短拼进失败消息。 */
+function stderrHint(text: string): string | null {
   const lines = text
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -935,6 +950,8 @@ export class GhostNodeRuntimeBroker {
       child,
       startupPhase: true,
       startupStderr: '',
+      recentStderr: '',
+      recentStderrAt: 0,
       stdoutDecoder: new StringDecoder('utf8'),
       stdoutBuffer: '',
       nextId: 1,
@@ -958,6 +975,9 @@ export class GhostNodeRuntimeBroker {
       if (entry.startupPhase && entry.startupStderr.length < STARTUP_STDERR_CAP) {
         entry.startupStderr = (entry.startupStderr + String(chunk)).slice(0, STARTUP_STDERR_CAP);
       }
+      // 启动诊断在最前面、死因诊断在最后面,所以两份截存方向相反,不能共用。
+      entry.recentStderr = (entry.recentStderr + String(chunk)).slice(-EXIT_STDERR_CAP);
+      entry.recentStderrAt = this.now();
       const text = String(chunk).trim().slice(0, 4_096);
       if (text) this.deps.log?.warn('ghost node stderr', { ghostId: ghost.manifest.id, text });
       // stderr 是手册钦定的日志口——构建刷日志就是活着的证据,给续命请求重置沉默窗口。
@@ -993,7 +1013,7 @@ export class GhostNodeRuntimeBroker {
               if (entry.stopping) {
                 reject(new WorkerStartError('Node 工作进程启动已取消', false, true));
               } else {
-                const hint = startupStderrHint(entry.startupStderr);
+                const hint = stderrHint(entry.startupStderr);
                 reject(
                   new WorkerStartError(
                     `Node 工作进程启动前退出(code=${code}, signal=${signal ?? 'none'})${hint ? `:${hint}` : ''}`,
@@ -1258,7 +1278,10 @@ export class GhostNodeRuntimeBroker {
     this.clearIdleTimer(entry);
     // worker 意外死亡:孩子级联收掉,不留孤儿(silent——收件人已经不在了)。
     for (const child of [...entry.children.values()]) this.stopChild(entry, child, true);
-    const detail = error?.message ?? `code=${code}, signal=${signal ?? 'none'}`;
+    const exitHint = this.exitStderrHint(entry);
+    const detail = `${error?.message ?? `code=${code}, signal=${signal ?? 'none'}`}${
+      exitHint ? `:${exitHint}` : ''
+    }`;
     for (const pending of entry.pending.values()) {
       this.clearTimer(pending.timer);
       pending.reject(new NodeRpcError('exit', `Node 工作进程已退出(${detail})`));
@@ -1270,6 +1293,18 @@ export class GhostNodeRuntimeBroker {
       this.deps.log?.warn('ghost node process exited', { ghostId, entry: entry.entryRel, detail });
       this.sendStatus(entry.ghost, 'crashed', detail, entry.entryRel);
     }
+  }
+
+  /**
+   * 意外死亡时的 stderr 诊断行:补上 startupStderr 那条路截不到的"就绪之后才崩"
+   * (插件模块加载期抛错最典型)。绝对路径已由 stderrHint 收敛为文件名。
+   * 主动 stop 不参与——那是预期内的收摊,拼诊断只会把无关日志说成死因;陈旧
+   * 尾部同理,只认紧邻退出的那一段。
+   */
+  private exitStderrHint(entry: WorkerEntry): string | null {
+    if (entry.stopping || !entry.recentStderr) return null;
+    if (this.now() - entry.recentStderrAt > EXIT_STDERR_LOOKBACK_MS) return null;
+    return stderrHint(entry.recentStderr);
   }
 
   private scheduleIdleStop(entry: WorkerEntry): void {

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -212,9 +212,10 @@ function stderrHint(text: string, preferLast = false): string | null {
     .filter(Boolean);
   if (lines.length === 0) return null;
   const fallback = preferLast ? lines[lines.length - 1] : lines[0];
+  const isDiagnostic = (s: string) => /error|fatal|exception|panic|abort/i.test(s);
   const errorLine = preferLast
-    ? lines.findLast((candidate) => /error/i.test(candidate))
-    : lines.find((candidate) => /error/i.test(candidate));
+    ? lines.findLast(isDiagnostic)
+    : lines.find(isDiagnostic);
   const line = errorLine ?? fallback;
   return sanitizePathsInHint(line).slice(0, 240);
 }
@@ -222,13 +223,16 @@ function stderrHint(text: string, preferLast = false): string | null {
 function sanitizePathsInHint(hint: string): string {
   const basename = (p: string) => p.split(/[/\\]/).pop() ?? p;
   return hint
-    .replace(/(['"])((?:[A-Za-z]:[/\\]|\\\\[^'"]+|\/)[^'"]+)\1/g, (_, q, p) => `${q}${basename(p)}${q}`)
+    // 双引号包裹(内部允许 ')
+    .replace(/"((?:[A-Za-z]:[/\\]|\\\\[^"]+|\/)[^"]+)"/g, (_, p) => `"${basename(p)}"`)
+    // 单引号包裹(内部允许 ")
+    .replace(/'((?:[A-Za-z]:[/\\]|\\\\[^']+|\/)[^']+)'/g, (_, p) => `'${basename(p)}'`)
     .replace(/[A-Za-z]:[/\\][^'")\]\n]*/g, basename)
     .replace(/\\\\[^'")\]\n]*/g, basename)
-    // 多段 POSIX 路径(含空格);(?<!:) 排除 URL scheme 后的路径
-    .replace(/(?<!:)\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename)
+    // 多段 POSIX 路径;(?<![:/]) 排除 URL scheme 和连续斜杠
+    .replace(/(?<![:/])\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename)
     // 单段 POSIX 绝对路径(/.ssh、/_private、/123mount 等)
-    .replace(/(?<!:|\/)\/[^\s/'")\]\n:,][^\s'")\]\n:,]*(?=[\s'")\]\n:,]|$)/g, basename);
+    .replace(/(?<![:/])\/[^\s/'")\]\n:,][^\s'")\]\n:,]*(?=[\s'")\]\n:,]|$)/g, basename);
 }
 
 type UtilityFork = typeof utilityProcess.fork;
@@ -850,6 +854,7 @@ export class GhostNodeRuntimeBroker {
   private stopWorker(key: string, entry: WorkerEntry): void {
     entry.stopping = true;
     this.workers.delete(key);
+    this.exitGen.set(key, (this.exitGen.get(key) ?? 0) + 1);
     this.clearIdleTimer(entry);
     // 级联:先收孩子再收本体,不留孤儿进程。
     for (const child of [...entry.children.values()]) this.stopChild(entry, child, true);

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -155,6 +155,8 @@ interface WorkerEntry {
   startupStderr: string;
   /** stderr 尾部按段带时间戳截存,退出时只取回看窗口内的段拼接诊断。 */
   stderrSegments: Array<{ text: string; at: number }>;
+  /** segments 总字符数(增量维护,避免每次 reduce)。 */
+  stderrTotalChars: number;
   /** stderr 也可能把多字节字符切在两个 Buffer 之间,与 stdout 同理需流式解码。 */
   stderrDecoder: StringDecoder;
   /** stdout 的 UTF-8 字节可能把一个汉字切在两个 chunk 之间，必须流式解码。 */
@@ -962,6 +964,7 @@ export class GhostNodeRuntimeBroker {
       startupPhase: true,
       startupStderr: '',
       stderrSegments: [],
+      stderrTotalChars: 0,
       stderrDecoder: new StringDecoder('utf8'),
       stdoutDecoder: new StringDecoder('utf8'),
       stdoutBuffer: '',
@@ -991,15 +994,16 @@ export class GhostNodeRuntimeBroker {
       }
       // 按段带时间戳截存,退出时只取回看窗口内的段,不让老日志被新 chunk 携带。
       entry.stderrSegments.push({ text: decoded, at: this.now() });
-      // 总量控制:保留尾部 EXIT_STDERR_CAP 字符。先丢弃最老整段,若仍超限则
-      // 裁剪最老段的头部(保留其尾部),确保总量严格不超。
-      let total = entry.stderrSegments.reduce((sum, s) => sum + s.text.length, 0);
-      while (total > EXIT_STDERR_CAP && entry.stderrSegments.length > 1) {
-        total -= entry.stderrSegments.shift()!.text.length;
+      entry.stderrTotalChars += decoded.length;
+      // 总量控制:保留尾部 EXIT_STDERR_CAP 字符。
+      while (entry.stderrTotalChars > EXIT_STDERR_CAP && entry.stderrSegments.length > 1) {
+        entry.stderrTotalChars -= entry.stderrSegments.shift()!.text.length;
       }
-      if (total > EXIT_STDERR_CAP && entry.stderrSegments.length === 1) {
+      if (entry.stderrTotalChars > EXIT_STDERR_CAP && entry.stderrSegments.length === 1) {
         const seg = entry.stderrSegments[0];
-        seg.text = seg.text.slice(seg.text.length - EXIT_STDERR_CAP);
+        const trimmed = seg.text.length - EXIT_STDERR_CAP;
+        seg.text = seg.text.slice(trimmed);
+        entry.stderrTotalChars = EXIT_STDERR_CAP;
       }
       const text = decoded.trim().slice(0, 4_096);
       if (text) this.deps.log?.warn('ghost node stderr', { ghostId: ghost.manifest.id, text });
@@ -1344,7 +1348,11 @@ export class GhostNodeRuntimeBroker {
     // 重试成功时插件不该看到一次假 crash)。
     if (!entry.stopping && !entry.startupPhase) {
       this.deps.log?.warn('ghost node process exited', { ghostId, entry: entry.entryRel, detail });
-      this.sendStatus(entry.ghost, 'crashed', detail, entry.entryRel);
+      // 如果 drain 期间已有替代 worker 启动,不发 crashed——消费方会误以为新 worker 崩溃。
+      const key = GhostNodeRuntimeBroker.keyOf(ghostId, entry.entryRel);
+      if (!this.workers.has(key)) {
+        this.sendStatus(entry.ghost, 'crashed', detail, entry.entryRel);
+      }
     }
   }
 

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -1003,16 +1003,11 @@ export class GhostNodeRuntimeBroker {
       }
       const text = decoded.trim().slice(0, 4_096);
       if (text) this.deps.log?.warn('ghost node stderr', { ghostId: ghost.manifest.id, text });
-      // 进程已退出、正在 drain 时,每收到新 chunk 就重置 drain 定时器(debounce),
-      // 确保管道完全排空后再提取诊断。
-      if (entry.exitDrain) {
-        this.clearTimer(entry.exitDrain.timer);
-        const d = entry.exitDrain;
-        d.timer = this.setTimer(() => this.settleExit(entry, d.code, d.signal, d.error), 10);
-        d.timer.unref?.();
+      // 进程已退出后不再续命——定时器已冻结,由 settleExit 统一结算。
+      if (!entry.exitDrain) {
+        // stderr 是手册钦定的日志口——构建刷日志就是活着的证据,给续命请求重置沉默窗口。
+        this.renewPendingOnActivity(entry);
       }
-      // stderr 是手册钦定的日志口——构建刷日志就是活着的证据,给续命请求重置沉默窗口。
-      this.renewPendingOnActivity(entry);
     });
     child.on('exit', (code, signal) => this.handleExit(entry, code, signal, null));
     child.on('error', (error) => this.handleExit(entry, null, null, error));
@@ -1311,10 +1306,10 @@ export class GhostNodeRuntimeBroker {
     for (const child of [...entry.children.values()]) this.stopChild(entry, child, true);
     // 立即冻结所有 pending 请求的超时定时器,防止在 drain 窗口内误报 TIMEOUT。
     for (const pending of entry.pending.values()) this.clearTimer(pending.timer);
-    // stderr 管道字节可能晚于 exit 事件到达——同时监听 stderr stream end(权威
-    // 排空信号)和 debounce 兜底定时器(stream 不发 end 时的安全网)。
+    // stderr stream 'end' 是权威排空信号——所有管道字节已到达。
+    // 定时器仅作为"end 永远不来"的兜底安全网(500ms),不做 debounce。
     const settle = () => this.settleExit(entry, code, signal, error);
-    const timer = this.setTimer(settle, 50);
+    const timer = this.setTimer(settle, 500);
     timer.unref?.();
     entry.exitDrain = { code, signal, error, timer };
     entry.child.stderr.once?.('end', settle);

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -216,7 +216,7 @@ function stderrHint(text: string, preferLast = false): string | null {
     ? lines.findLast((candidate) => /error/i.test(candidate))
     : lines.find((candidate) => /error/i.test(candidate));
   const line = errorLine ?? fallback;
-  return sanitizePathsInHint(line.slice(0, 240));
+  return sanitizePathsInHint(line).slice(0, 240);
 }
 
 function sanitizePathsInHint(hint: string): string {

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -152,10 +152,10 @@ interface WorkerEntry {
   startupPhase: boolean;
   /** 启动期 stderr 头部截存,失败时提取一行诊断拼进错误消息(如杀软拦截的 EPERM)。 */
   startupStderr: string;
-  /** stderr 尾部滚动截存,进程意外死亡时提取一行诊断拼进错误消息(如加载期抛错)。 */
-  recentStderr: string;
-  /** 尾部截存最后一次进账的时刻(this.now() 口径);0 = 从未收到 stderr。 */
-  recentStderrAt: number;
+  /** stderr 尾部按段带时间戳截存,退出时只取回看窗口内的段拼接诊断。 */
+  stderrSegments: Array<{ text: string; at: number }>;
+  /** stderr 也可能把多字节字符切在两个 Buffer 之间,与 stdout 同理需流式解码。 */
+  stderrDecoder: StringDecoder;
   /** stdout 的 UTF-8 字节可能把一个汉字切在两个 chunk 之间，必须流式解码。 */
   stdoutDecoder: StringDecoder;
   stdoutBuffer: string;
@@ -167,6 +167,8 @@ interface WorkerEntry {
   hardKillTimer: NodeJS.Timeout | null;
   mcpInitPromise: Promise<void> | null;
   stopping: boolean;
+  /** 曾发给本 worker 的凭证值(用于退出诊断脱敏);set 保证 O(1) 去重。 */
+  exposedSecretValues: Set<string>;
 }
 
 class NodeRpcError extends Error {
@@ -208,7 +210,9 @@ function sanitizePathsInHint(hint: string): string {
   const basename = (p: string) => p.split(/[/\\]/).pop() ?? p;
   return hint
     .replace(/(['"])((?:[A-Z]:[/\\]|\/)[^'"]+)\1/g, (_, q, p) => `${q}${basename(p)}${q}`)
-    .replace(/[A-Z]:[/\\][^\s'")\]]*/g, basename)
+    // Windows 路径可含空格(如 C:\Users\Jane Doe\AppData\...),所以不把 \s 加
+    // 入排除集;用 newline、引号、括号、方括号做终止符。
+    .replace(/[A-Z]:[/\\][^'")\]\n]*/g, basename)
     .replace(/\/(?:[^\s/'")\]]+\/)+[^\s'")\]]*/g, basename);
 }
 
@@ -548,6 +552,11 @@ export class GhostNodeRuntimeBroker {
         await this.ensureMcpInitialized(entry);
         if (entry.pending.size >= MAX_PENDING_REQUESTS) {
           return errorResult('RATE_LIMITED', '这个插件同时等待的 Node 请求太多');
+        }
+      }
+      if (hostSecrets) {
+        for (const v of Object.values(hostSecrets)) {
+          if (v.length >= 6) entry.exposedSecretValues.add(v);
         }
       }
       const pendingResult = this.sendRpc(
@@ -950,8 +959,8 @@ export class GhostNodeRuntimeBroker {
       child,
       startupPhase: true,
       startupStderr: '',
-      recentStderr: '',
-      recentStderrAt: 0,
+      stderrSegments: [],
+      stderrDecoder: new StringDecoder('utf8'),
       stdoutDecoder: new StringDecoder('utf8'),
       stdoutBuffer: '',
       nextId: 1,
@@ -961,6 +970,7 @@ export class GhostNodeRuntimeBroker {
       hardKillTimer: null,
       mcpInitPromise: null,
       stopping: false,
+      exposedSecretValues: new Set(),
     };
     this.workers.set(key, entry);
     if (this.destroyed || this.stoppedGhosts.has(ghost.manifest.id)) {
@@ -972,13 +982,18 @@ export class GhostNodeRuntimeBroker {
     child.onControl?.((message) => this.handleWorkerControl(entry, message));
     child.stdout.on('data', (chunk) => this.handleStdout(entry, chunk));
     child.stderr.on('data', (chunk) => {
+      const decoded = entry.stderrDecoder.write(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
       if (entry.startupPhase && entry.startupStderr.length < STARTUP_STDERR_CAP) {
-        entry.startupStderr = (entry.startupStderr + String(chunk)).slice(0, STARTUP_STDERR_CAP);
+        entry.startupStderr = (entry.startupStderr + decoded).slice(0, STARTUP_STDERR_CAP);
       }
-      // 启动诊断在最前面、死因诊断在最后面,所以两份截存方向相反,不能共用。
-      entry.recentStderr = (entry.recentStderr + String(chunk)).slice(-EXIT_STDERR_CAP);
-      entry.recentStderrAt = this.now();
-      const text = String(chunk).trim().slice(0, 4_096);
+      // 按段带时间戳截存,退出时只取回看窗口内的段,不让老日志被新 chunk 携带。
+      entry.stderrSegments.push({ text: decoded, at: this.now() });
+      // 总量控制:丢弃最老的段直到总字节 <= EXIT_STDERR_CAP。
+      let total = entry.stderrSegments.reduce((sum, s) => sum + s.text.length, 0);
+      while (total > EXIT_STDERR_CAP && entry.stderrSegments.length > 1) {
+        total -= entry.stderrSegments.shift()!.text.length;
+      }
+      const text = decoded.trim().slice(0, 4_096);
       if (text) this.deps.log?.warn('ghost node stderr', { ghostId: ghost.manifest.id, text });
       // stderr 是手册钦定的日志口——构建刷日志就是活着的证据,给续命请求重置沉默窗口。
       this.renewPendingOnActivity(entry);
@@ -1278,6 +1293,19 @@ export class GhostNodeRuntimeBroker {
     this.clearIdleTimer(entry);
     // worker 意外死亡:孩子级联收掉,不留孤儿(silent——收件人已经不在了)。
     for (const child of [...entry.children.values()]) this.stopChild(entry, child, true);
+    // stderr 管道字节可能晚于 exit 事件到达:给在途 chunk 一个极短的落地窗口,
+    // 与启动期退出路径(line ~1011)保持一致。
+    const drainTimer = this.setTimer(() => this.settleExit(entry, code, signal, error), 10);
+    drainTimer.unref?.();
+  }
+
+  private settleExit(
+    entry: WorkerEntry,
+    code: number | null,
+    signal: string | null,
+    error: Error | null,
+  ): void {
+    const ghostId = entry.ghost.manifest.id;
     const exitHint = this.exitStderrHint(entry);
     const detail = `${error?.message ?? `code=${code}, signal=${signal ?? 'none'}`}${
       exitHint ? `:${exitHint}` : ''
@@ -1299,12 +1327,24 @@ export class GhostNodeRuntimeBroker {
    * 意外死亡时的 stderr 诊断行:补上 startupStderr 那条路截不到的"就绪之后才崩"
    * (插件模块加载期抛错最典型)。绝对路径已由 stderrHint 收敛为文件名。
    * 主动 stop 不参与——那是预期内的收摊,拼诊断只会把无关日志说成死因;陈旧
-   * 尾部同理,只认紧邻退出的那一段。
+   * 段同理,只认回看窗口内的段。
    */
   private exitStderrHint(entry: WorkerEntry): string | null {
-    if (entry.stopping || !entry.recentStderr) return null;
-    if (this.now() - entry.recentStderrAt > EXIT_STDERR_LOOKBACK_MS) return null;
-    return stderrHint(entry.recentStderr);
+    if (entry.stopping) return null;
+    const now = this.now();
+    const recent = entry.stderrSegments
+      .filter((seg) => now - seg.at <= EXIT_STDERR_LOOKBACK_MS)
+      .map((seg) => seg.text)
+      .join('');
+    if (!recent) return null;
+    return stderrHint(this.redactSecrets(entry, recent));
+  }
+
+  private redactSecrets(entry: WorkerEntry, text: string): string {
+    for (const secret of entry.exposedSecretValues) {
+      if (text.includes(secret)) text = text.replaceAll(secret, '[REDACTED]');
+    }
+    return text;
   }
 
   private scheduleIdleStop(entry: WorkerEntry): void {

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -200,14 +200,18 @@ class WorkerStartError extends Error {
   }
 }
 
-/** 从 stderr 里挑最有诊断价值的一行(优先含 error 的行),截短拼进失败消息。 */
-function stderrHint(text: string): string | null {
+/**
+ * 从 stderr 里挑最有诊断价值的一行(优先含 error 的行),截短拼进失败消息。
+ * preferLast: 无 error 关键词时回退到末行(退出诊断)还是首行(启动诊断)。
+ */
+function stderrHint(text: string, preferLast = false): string | null {
   const lines = text
     .split(/\r?\n|\r/)
     .map((line) => line.trim())
     .filter(Boolean);
   if (lines.length === 0) return null;
-  const line = lines.find((candidate) => /error/i.test(candidate)) ?? lines[lines.length - 1];
+  const fallback = preferLast ? lines[lines.length - 1] : lines[0];
+  const line = lines.find((candidate) => /error/i.test(candidate)) ?? fallback;
   return sanitizePathsInHint(line.slice(0, 240));
 }
 
@@ -217,7 +221,10 @@ function sanitizePathsInHint(hint: string): string {
     .replace(/(['"])((?:[A-Za-z]:[/\\]|\\\\[^'"]+|\/)[^'"]+)\1/g, (_, q, p) => `${q}${basename(p)}${q}`)
     .replace(/[A-Za-z]:[/\\][^'")\]\n]*/g, basename)
     .replace(/\\\\[^'")\]\n]*/g, basename)
-    .replace(/\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename);
+    // 多段 POSIX 路径(含空格)
+    .replace(/\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename)
+    // 单段 POSIX 绝对路径(如 /private、/AcmeSecretMount)
+    .replace(/\/[A-Za-z][A-Za-z0-9._-]*(?=[\s'")\]\n:,]|$)/g, basename);
 }
 
 type UtilityFork = typeof utilityProcess.fork;
@@ -1356,9 +1363,10 @@ export class GhostNodeRuntimeBroker {
     // 重试成功时插件不该看到一次假 crash)。
     if (!entry.stopping && !entry.startupPhase) {
       this.deps.log?.warn('ghost node process exited', { ghostId, entry: entry.entryRel, detail });
-      // 如果 drain 期间已有替代 worker 启动,不发 crashed——消费方会误以为新 worker 崩溃。
+      // 抑制 crashed 广播:替代 worker 已启动(key 被占);或 drain 期间插件被
+      // 主动停止/禁用(ghostId 加入 stoppedGhosts)。
       const key = GhostNodeRuntimeBroker.keyOf(ghostId, entry.entryRel);
-      if (!this.workers.has(key)) {
+      if (!this.workers.has(key) && !this.stoppedGhosts.has(ghostId)) {
         this.sendStatus(entry.ghost, 'crashed', detail, entry.entryRel);
       }
     }
@@ -1379,7 +1387,7 @@ export class GhostNodeRuntimeBroker {
       .map((seg) => seg.text)
       .join('');
     if (!recent) return null;
-    return stderrHint(this.redactSecrets(entry, recent));
+    return stderrHint(this.redactSecrets(entry, recent), true);
   }
 
   private redactSecrets(entry: WorkerEntry, text: string): string {

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -227,12 +227,12 @@ function sanitizePathsInHint(hint: string): string {
     .replace(/"((?:[A-Za-z]:[/\\]|\\\\[^"]+|\/)[^"]+)"/g, (_, p) => `"${basename(p)}"`)
     // 单引号包裹(内部允许 ")
     .replace(/'((?:[A-Za-z]:[/\\]|\\\\[^']+|\/)[^']+)'/g, (_, p) => `'${basename(p)}'`)
-    .replace(/[A-Za-z]:[/\\][^'")\]\n]*/g, basename)
-    .replace(/\\\\[^'")\]\n]*/g, basename)
+    .replace(/[A-Za-z]:[/\\][^")\]\n]*/g, basename)
+    .replace(/\\\\[^")\]\n]*/g, basename)
     // 多段 POSIX 路径;(?<![:/]) 排除 URL scheme 和连续斜杠
-    .replace(/(?<![:/])\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename)
+    .replace(/(?<![:/])\/(?:[^/")\]\n]+\/)+[^")\]\n]*/g, basename)
     // 单段 POSIX 绝对路径(/.ssh、/_private、/123mount 等)
-    .replace(/(?<![:/])\/[^\s/'")\]\n:,][^\s'")\]\n:,]*(?=[\s'")\]\n:,]|$)/g, basename);
+    .replace(/(?<![:/])\/[^\s/")\]\n:,][^\s")\]\n:,]*(?=[\s")\]\n:,]|$)/g, basename);
 }
 
 type UtilityFork = typeof utilityProcess.fork;

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -71,6 +71,7 @@ const MCP_PROTOCOL_VERSION = '2025-06-18';
 
 interface NodeWorkerReadable {
   on(event: 'data', listener: (chunk: Buffer | string) => void): this;
+  once?(event: 'end', listener: () => void): this;
 }
 
 interface NodeWorkerWritable {
@@ -167,8 +168,8 @@ interface WorkerEntry {
   hardKillTimer: NodeJS.Timeout | null;
   mcpInitPromise: Promise<void> | null;
   stopping: boolean;
-  /** 曾发给本 worker 的凭证 key(退出诊断时按 key 临时读取并脱敏)。 */
-  exposedSecretKeys: Set<string>;
+  /** 曾发给本 worker 的凭证明文(退出诊断脱敏用;settleExit 后立即清空)。 */
+  exposedSecretValues: Set<string>;
   /** exit 后 stderr drain 用:非 null 表示进程已退出、正在等待管道排空。 */
   exitDrain: { code: number | null; signal: string | null; error: Error | null; timer: NodeJS.Timeout } | null;
 }
@@ -211,11 +212,9 @@ function stderrHint(text: string): string | null {
 function sanitizePathsInHint(hint: string): string {
   const basename = (p: string) => p.split(/[/\\]/).pop() ?? p;
   return hint
-    .replace(/(['"])((?:[A-Z]:[/\\]|\/)[^'"]+)\1/g, (_, q, p) => `${q}${basename(p)}${q}`)
-    // Windows/POSIX 路径都可含空格(如 C:\Users\Jane Doe\... 或
-    // /Users/jane/Library/Application Support/...),不把 \s 加入排除集;
-    // 用 newline、引号、括号、方括号做终止符。
-    .replace(/[A-Z]:[/\\][^'")\]\n]*/g, basename)
+    .replace(/(['"])((?:[A-Za-z]:[/\\]|\\\\[^'"]+|\/)[^'"]+)\1/g, (_, q, p) => `${q}${basename(p)}${q}`)
+    .replace(/[A-Za-z]:[/\\][^'")\]\n]*/g, basename)
+    .replace(/\\\\[^'")\]\n]*/g, basename)
     .replace(/\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename);
 }
 
@@ -558,7 +557,9 @@ export class GhostNodeRuntimeBroker {
         }
       }
       if (hostSecrets) {
-        for (const k of Object.keys(hostSecrets)) entry.exposedSecretKeys.add(k);
+        for (const v of Object.values(hostSecrets)) {
+          if (v) entry.exposedSecretValues.add(v);
+        }
       }
       const pendingResult = this.sendRpc(
         entry,
@@ -971,7 +972,7 @@ export class GhostNodeRuntimeBroker {
       hardKillTimer: null,
       mcpInitPromise: null,
       stopping: false,
-      exposedSecretKeys: new Set(),
+      exposedSecretValues: new Set(),
       exitDrain: null,
     };
     this.workers.set(key, entry);
@@ -1310,11 +1311,13 @@ export class GhostNodeRuntimeBroker {
     for (const child of [...entry.children.values()]) this.stopChild(entry, child, true);
     // 立即冻结所有 pending 请求的超时定时器,防止在 drain 窗口内误报 TIMEOUT。
     for (const pending of entry.pending.values()) this.clearTimer(pending.timer);
-    // stderr 管道字节可能晚于 exit 事件到达:用 debounce 模式等管道排空——
-    // 每次新 chunk 到达都重置定时器,管道静默 10ms 后 settle。
-    const timer = this.setTimer(() => this.settleExit(entry, code, signal, error), 10);
+    // stderr 管道字节可能晚于 exit 事件到达——同时监听 stderr stream end(权威
+    // 排空信号)和 debounce 兜底定时器(stream 不发 end 时的安全网)。
+    const settle = () => this.settleExit(entry, code, signal, error);
+    const timer = this.setTimer(settle, 50);
     timer.unref?.();
     entry.exitDrain = { code, signal, error, timer };
+    entry.child.stderr.once?.('end', settle);
   }
 
   private settleExit(
@@ -1323,6 +1326,14 @@ export class GhostNodeRuntimeBroker {
     signal: string | null,
     error: Error | null,
   ): void {
+    if (!entry.exitDrain) return;
+    this.clearTimer(entry.exitDrain.timer);
+    entry.exitDrain = null;
+    // flush stderrDecoder 残留字节(多字节字符被切在最后一个 chunk 边界时)
+    const tail = entry.stderrDecoder.end();
+    if (tail) {
+      entry.stderrSegments.push({ text: tail, at: this.now() });
+    }
     const ghostId = entry.ghost.manifest.id;
     const exitHint = this.exitStderrHint(entry);
     const detail = `${error?.message ?? `code=${code}, signal=${signal ?? 'none'}`}${
@@ -1333,6 +1344,7 @@ export class GhostNodeRuntimeBroker {
       pending.reject(new NodeRpcError('exit', `Node 工作进程已退出(${detail})`));
     }
     entry.pending.clear();
+    entry.exposedSecretValues.clear();
     // 启动期退出不在这里报 crashed:ensureWorker 统一收口(可能还要重试,
     // 重试成功时插件不该看到一次假 crash)。
     if (!entry.stopping && !entry.startupPhase) {
@@ -1359,13 +1371,8 @@ export class GhostNodeRuntimeBroker {
   }
 
   private redactSecrets(entry: WorkerEntry, text: string): string {
-    if (!entry.exposedSecretKeys.size || !this.deps.readSecret) return text;
-    const ghostId = entry.ghost.manifest.id;
-    for (const key of entry.exposedSecretKeys) {
-      try {
-        const value = this.deps.readSecret(ghostId, key);
-        if (value && text.includes(value)) text = text.replaceAll(value, '[REDACTED]');
-      } catch { /* readSecret 不可用时跳过该 key */ }
+    for (const secret of entry.exposedSecretValues) {
+      if (text.includes(secret)) text = text.replaceAll(secret, '[REDACTED]');
     }
     return text;
   }

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -173,7 +173,7 @@ interface WorkerEntry {
   /** 曾发给本 worker 的凭证明文(退出诊断脱敏用;settleExit 后立即清空)。 */
   exposedSecretValues: Set<string>;
   /** exit 后 stderr drain 用:非 null 表示进程已退出、正在等待管道排空。 */
-  exitDrain: { code: number | null; signal: string | null; error: Error | null; timer: NodeJS.Timeout } | null;
+  exitDrain: { code: number | null; signal: string | null; error: Error | null; timer: NodeJS.Timeout; exitedAt: number } | null;
 }
 
 class NodeRpcError extends Error {
@@ -203,11 +203,11 @@ class WorkerStartError extends Error {
 /** 从 stderr 里挑最有诊断价值的一行(优先含 error 的行),截短拼进失败消息。 */
 function stderrHint(text: string): string | null {
   const lines = text
-    .split(/\r?\n/)
+    .split(/\r?\n|\r/)
     .map((line) => line.trim())
     .filter(Boolean);
   if (lines.length === 0) return null;
-  const line = lines.find((candidate) => /error/i.test(candidate)) ?? lines[0];
+  const line = lines.find((candidate) => /error/i.test(candidate)) ?? lines[lines.length - 1];
   return sanitizePathsInHint(line.slice(0, 240));
 }
 
@@ -847,6 +847,7 @@ export class GhostNodeRuntimeBroker {
       pending.reject(new NodeRpcError('exit', 'Node 工作进程已停止'));
     }
     entry.pending.clear();
+    entry.exposedSecretValues.clear();
     try {
       entry.child.kill('SIGTERM');
       entry.hardKillTimer = this.setTimer(() => {
@@ -995,14 +996,19 @@ export class GhostNodeRuntimeBroker {
       // 按段带时间戳截存,退出时只取回看窗口内的段,不让老日志被新 chunk 携带。
       entry.stderrSegments.push({ text: decoded, at: this.now() });
       entry.stderrTotalChars += decoded.length;
-      // 总量控制:保留尾部 EXIT_STDERR_CAP 字符。
-      while (entry.stderrTotalChars > EXIT_STDERR_CAP && entry.stderrSegments.length > 1) {
-        entry.stderrTotalChars -= entry.stderrSegments.shift()!.text.length;
-      }
-      if (entry.stderrTotalChars > EXIT_STDERR_CAP && entry.stderrSegments.length === 1) {
-        const seg = entry.stderrSegments[0];
-        const trimmed = seg.text.length - EXIT_STDERR_CAP;
-        seg.text = seg.text.slice(trimmed);
+      // 总量控制:保留尾部 EXIT_STDERR_CAP 字符——部分裁剪最老段的头部。
+      if (entry.stderrTotalChars > EXIT_STDERR_CAP) {
+        let excess = entry.stderrTotalChars - EXIT_STDERR_CAP;
+        while (excess > 0 && entry.stderrSegments.length > 0) {
+          const oldest = entry.stderrSegments[0];
+          if (excess >= oldest.text.length) {
+            entry.stderrSegments.shift();
+            excess -= oldest.text.length;
+          } else {
+            oldest.text = oldest.text.slice(excess);
+            excess = 0;
+          }
+        }
         entry.stderrTotalChars = EXIT_STDERR_CAP;
       }
       const text = decoded.trim().slice(0, 4_096);
@@ -1315,7 +1321,7 @@ export class GhostNodeRuntimeBroker {
     const settle = () => this.settleExit(entry, code, signal, error);
     const timer = this.setTimer(settle, 500);
     timer.unref?.();
-    entry.exitDrain = { code, signal, error, timer };
+    entry.exitDrain = { code, signal, error, timer, exitedAt: this.now() };
     entry.child.stderr.once?.('end', settle);
   }
 
@@ -1326,15 +1332,17 @@ export class GhostNodeRuntimeBroker {
     error: Error | null,
   ): void {
     if (!entry.exitDrain) return;
+    const exitedAt = entry.exitDrain.exitedAt;
     this.clearTimer(entry.exitDrain.timer);
     entry.exitDrain = null;
     // flush stderrDecoder 残留字节(多字节字符被切在最后一个 chunk 边界时)
     const tail = entry.stderrDecoder.end();
     if (tail) {
       entry.stderrSegments.push({ text: tail, at: this.now() });
+      entry.stderrTotalChars += tail.length;
     }
     const ghostId = entry.ghost.manifest.id;
-    const exitHint = this.exitStderrHint(entry);
+    const exitHint = this.exitStderrHint(entry, exitedAt);
     const detail = `${error?.message ?? `code=${code}, signal=${signal ?? 'none'}`}${
       exitHint ? `:${exitHint}` : ''
     }`;
@@ -1362,11 +1370,12 @@ export class GhostNodeRuntimeBroker {
    * 主动 stop 不参与——那是预期内的收摊,拼诊断只会把无关日志说成死因;陈旧
    * 段同理,只认回看窗口内的段。
    */
-  private exitStderrHint(entry: WorkerEntry): string | null {
+  private exitStderrHint(entry: WorkerEntry, exitedAt: number): string | null {
     if (entry.stopping) return null;
-    const now = this.now();
+    // 以退出时刻为锚点(而非结算时刻),避免兜底定时器延迟导致回看窗口偏移。
+    // drain 期间到达的 chunk 时间戳 >= exitedAt,自然在窗口内。
     const recent = entry.stderrSegments
-      .filter((seg) => now - seg.at <= EXIT_STDERR_LOOKBACK_MS)
+      .filter((seg) => exitedAt - seg.at <= EXIT_STDERR_LOOKBACK_MS)
       .map((seg) => seg.text)
       .join('');
     if (!recent) return null;
@@ -1374,7 +1383,9 @@ export class GhostNodeRuntimeBroker {
   }
 
   private redactSecrets(entry: WorkerEntry, text: string): string {
-    for (const secret of entry.exposedSecretValues) {
+    if (!entry.exposedSecretValues.size) return text;
+    const sorted = [...entry.exposedSecretValues].sort((a, b) => b.length - a.length);
+    for (const secret of sorted) {
       if (text.includes(secret)) text = text.replaceAll(secret, '[REDACTED]');
     }
     return text;

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -167,8 +167,10 @@ interface WorkerEntry {
   hardKillTimer: NodeJS.Timeout | null;
   mcpInitPromise: Promise<void> | null;
   stopping: boolean;
-  /** 曾发给本 worker 的凭证值(用于退出诊断脱敏);set 保证 O(1) 去重。 */
-  exposedSecretValues: Set<string>;
+  /** 曾发给本 worker 的凭证 key(退出诊断时按 key 临时读取并脱敏)。 */
+  exposedSecretKeys: Set<string>;
+  /** exit 后 stderr drain 用:非 null 表示进程已退出、正在等待管道排空。 */
+  exitDrain: { code: number | null; signal: string | null; error: Error | null; timer: NodeJS.Timeout } | null;
 }
 
 class NodeRpcError extends Error {
@@ -210,10 +212,11 @@ function sanitizePathsInHint(hint: string): string {
   const basename = (p: string) => p.split(/[/\\]/).pop() ?? p;
   return hint
     .replace(/(['"])((?:[A-Z]:[/\\]|\/)[^'"]+)\1/g, (_, q, p) => `${q}${basename(p)}${q}`)
-    // Windows 路径可含空格(如 C:\Users\Jane Doe\AppData\...),所以不把 \s 加
-    // 入排除集;用 newline、引号、括号、方括号做终止符。
+    // Windows/POSIX 路径都可含空格(如 C:\Users\Jane Doe\... 或
+    // /Users/jane/Library/Application Support/...),不把 \s 加入排除集;
+    // 用 newline、引号、括号、方括号做终止符。
     .replace(/[A-Z]:[/\\][^'")\]\n]*/g, basename)
-    .replace(/\/(?:[^\s/'")\]]+\/)+[^\s'")\]]*/g, basename);
+    .replace(/\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename);
 }
 
 type UtilityFork = typeof utilityProcess.fork;
@@ -555,9 +558,7 @@ export class GhostNodeRuntimeBroker {
         }
       }
       if (hostSecrets) {
-        for (const v of Object.values(hostSecrets)) {
-          if (v.length >= 6) entry.exposedSecretValues.add(v);
-        }
+        for (const k of Object.keys(hostSecrets)) entry.exposedSecretKeys.add(k);
       }
       const pendingResult = this.sendRpc(
         entry,
@@ -970,7 +971,8 @@ export class GhostNodeRuntimeBroker {
       hardKillTimer: null,
       mcpInitPromise: null,
       stopping: false,
-      exposedSecretValues: new Set(),
+      exposedSecretKeys: new Set(),
+      exitDrain: null,
     };
     this.workers.set(key, entry);
     if (this.destroyed || this.stoppedGhosts.has(ghost.manifest.id)) {
@@ -988,13 +990,26 @@ export class GhostNodeRuntimeBroker {
       }
       // 按段带时间戳截存,退出时只取回看窗口内的段,不让老日志被新 chunk 携带。
       entry.stderrSegments.push({ text: decoded, at: this.now() });
-      // 总量控制:丢弃最老的段直到总字节 <= EXIT_STDERR_CAP。
+      // 总量控制:保留尾部 EXIT_STDERR_CAP 字符。先丢弃最老整段,若仍超限则
+      // 裁剪最老段的头部(保留其尾部),确保总量严格不超。
       let total = entry.stderrSegments.reduce((sum, s) => sum + s.text.length, 0);
       while (total > EXIT_STDERR_CAP && entry.stderrSegments.length > 1) {
         total -= entry.stderrSegments.shift()!.text.length;
       }
+      if (total > EXIT_STDERR_CAP && entry.stderrSegments.length === 1) {
+        const seg = entry.stderrSegments[0];
+        seg.text = seg.text.slice(seg.text.length - EXIT_STDERR_CAP);
+      }
       const text = decoded.trim().slice(0, 4_096);
       if (text) this.deps.log?.warn('ghost node stderr', { ghostId: ghost.manifest.id, text });
+      // 进程已退出、正在 drain 时,每收到新 chunk 就重置 drain 定时器(debounce),
+      // 确保管道完全排空后再提取诊断。
+      if (entry.exitDrain) {
+        this.clearTimer(entry.exitDrain.timer);
+        const d = entry.exitDrain;
+        d.timer = this.setTimer(() => this.settleExit(entry, d.code, d.signal, d.error), 10);
+        d.timer.unref?.();
+      }
       // stderr 是手册钦定的日志口——构建刷日志就是活着的证据,给续命请求重置沉默窗口。
       this.renewPendingOnActivity(entry);
     });
@@ -1293,10 +1308,13 @@ export class GhostNodeRuntimeBroker {
     this.clearIdleTimer(entry);
     // worker 意外死亡:孩子级联收掉,不留孤儿(silent——收件人已经不在了)。
     for (const child of [...entry.children.values()]) this.stopChild(entry, child, true);
-    // stderr 管道字节可能晚于 exit 事件到达:给在途 chunk 一个极短的落地窗口,
-    // 与启动期退出路径(line ~1011)保持一致。
-    const drainTimer = this.setTimer(() => this.settleExit(entry, code, signal, error), 10);
-    drainTimer.unref?.();
+    // 立即冻结所有 pending 请求的超时定时器,防止在 drain 窗口内误报 TIMEOUT。
+    for (const pending of entry.pending.values()) this.clearTimer(pending.timer);
+    // stderr 管道字节可能晚于 exit 事件到达:用 debounce 模式等管道排空——
+    // 每次新 chunk 到达都重置定时器,管道静默 10ms 后 settle。
+    const timer = this.setTimer(() => this.settleExit(entry, code, signal, error), 10);
+    timer.unref?.();
+    entry.exitDrain = { code, signal, error, timer };
   }
 
   private settleExit(
@@ -1341,8 +1359,13 @@ export class GhostNodeRuntimeBroker {
   }
 
   private redactSecrets(entry: WorkerEntry, text: string): string {
-    for (const secret of entry.exposedSecretValues) {
-      if (text.includes(secret)) text = text.replaceAll(secret, '[REDACTED]');
+    if (!entry.exposedSecretKeys.size || !this.deps.readSecret) return text;
+    const ghostId = entry.ghost.manifest.id;
+    for (const key of entry.exposedSecretKeys) {
+      try {
+        const value = this.deps.readSecret(ghostId, key);
+        if (value && text.includes(value)) text = text.replaceAll(value, '[REDACTED]');
+      } catch { /* readSecret 不可用时跳过该 key */ }
     }
     return text;
   }

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -173,7 +173,7 @@ interface WorkerEntry {
   /** 曾发给本 worker 的凭证明文(退出诊断脱敏用;settleExit 后立即清空)。 */
   exposedSecretValues: Set<string>;
   /** exit 后 stderr drain 用:非 null 表示进程已退出、正在等待管道排空。 */
-  exitDrain: { code: number | null; signal: string | null; error: Error | null; timer: NodeJS.Timeout; exitedAt: number } | null;
+  exitDrain: { code: number | null; signal: string | null; error: Error | null; timer: NodeJS.Timeout; exitedAt: number; gen: number } | null;
 }
 
 class NodeRpcError extends Error {
@@ -202,7 +202,8 @@ class WorkerStartError extends Error {
 
 /**
  * 从 stderr 里挑最有诊断价值的一行(优先含 error 的行),截短拼进失败消息。
- * preferLast: 无 error 关键词时回退到末行(退出诊断)还是首行(启动诊断)。
+ * preferLast: true 时从末尾向前搜索(退出诊断,最后的 error 行更可能是死因);
+ *             false 时从头向后搜索(启动诊断,首条 error 最相关)。
  */
 function stderrHint(text: string, preferLast = false): string | null {
   const lines = text
@@ -211,7 +212,10 @@ function stderrHint(text: string, preferLast = false): string | null {
     .filter(Boolean);
   if (lines.length === 0) return null;
   const fallback = preferLast ? lines[lines.length - 1] : lines[0];
-  const line = lines.find((candidate) => /error/i.test(candidate)) ?? fallback;
+  const errorLine = preferLast
+    ? lines.findLast((candidate) => /error/i.test(candidate))
+    : lines.find((candidate) => /error/i.test(candidate));
+  const line = errorLine ?? fallback;
   return sanitizePathsInHint(line.slice(0, 240));
 }
 
@@ -884,6 +888,9 @@ export class GhostNodeRuntimeBroker {
   /** stop(ghostId) 置入:在途重试检测到后立即中止,不继续拉新进程。 */
   private readonly stoppedGhosts = new Set<string>();
 
+  /** 每次 handleExit 递增,settleExit 仅在世代未推进时发布 crashed。 */
+  private readonly exitGen = new Map<string, number>();
+
   /** destroyAll(主机退出)后置真:退避中的重试不得再拉新进程。 */
   private destroyed = false;
 
@@ -1325,10 +1332,12 @@ export class GhostNodeRuntimeBroker {
     for (const pending of entry.pending.values()) this.clearTimer(pending.timer);
     // stderr stream 'end' 是权威排空信号——所有管道字节已到达。
     // 定时器仅作为"end 永远不来"的兜底安全网(500ms),不做 debounce。
+    const gen = (this.exitGen.get(key) ?? 0) + 1;
+    this.exitGen.set(key, gen);
     const settle = () => this.settleExit(entry, code, signal, error);
     const timer = this.setTimer(settle, 500);
     timer.unref?.();
-    entry.exitDrain = { code, signal, error, timer, exitedAt: this.now() };
+    entry.exitDrain = { code, signal, error, timer, exitedAt: this.now(), gen };
     entry.child.stderr.once?.('end', settle);
   }
 
@@ -1339,7 +1348,7 @@ export class GhostNodeRuntimeBroker {
     error: Error | null,
   ): void {
     if (!entry.exitDrain) return;
-    const exitedAt = entry.exitDrain.exitedAt;
+    const { exitedAt, gen } = entry.exitDrain;
     this.clearTimer(entry.exitDrain.timer);
     entry.exitDrain = null;
     // flush stderrDecoder 残留字节(多字节字符被切在最后一个 chunk 边界时)
@@ -1363,10 +1372,11 @@ export class GhostNodeRuntimeBroker {
     // 重试成功时插件不该看到一次假 crash)。
     if (!entry.stopping && !entry.startupPhase) {
       this.deps.log?.warn('ghost node process exited', { ghostId, entry: entry.entryRel, detail });
-      // 抑制 crashed 广播:替代 worker 已启动(key 被占);或 drain 期间插件被
-      // 主动停止/禁用(ghostId 加入 stoppedGhosts)。
+      // 抑制 crashed 广播:替代 worker 已启动(key 被占);drain 期间插件被
+      // 主动停止/禁用;或同 key 有更新世代退出(本次已过时)。
       const key = GhostNodeRuntimeBroker.keyOf(ghostId, entry.entryRel);
-      if (!this.workers.has(key) && !this.stoppedGhosts.has(ghostId)) {
+      const isLatest = this.exitGen.get(key) === gen;
+      if (!this.workers.has(key) && !this.stoppedGhosts.has(ghostId) && isLatest) {
         this.sendStatus(entry.ghost, 'crashed', detail, entry.entryRel);
       }
     }

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -225,10 +225,10 @@ function sanitizePathsInHint(hint: string): string {
     .replace(/(['"])((?:[A-Za-z]:[/\\]|\\\\[^'"]+|\/)[^'"]+)\1/g, (_, q, p) => `${q}${basename(p)}${q}`)
     .replace(/[A-Za-z]:[/\\][^'")\]\n]*/g, basename)
     .replace(/\\\\[^'")\]\n]*/g, basename)
-    // 多段 POSIX 路径(含空格)
-    .replace(/\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename)
-    // 单段 POSIX 绝对路径(如 /private、/AcmeSecretMount)
-    .replace(/\/[A-Za-z][A-Za-z0-9._-]*(?=[\s'")\]\n:,]|$)/g, basename);
+    // 多段 POSIX 路径(含空格);(?<!:) 排除 URL scheme 后的路径
+    .replace(/(?<!:)\/(?:[^/'")\]\n]+\/)+[^'")\]\n]*/g, basename)
+    // 单段 POSIX 绝对路径(/.ssh、/_private、/123mount 等)
+    .replace(/(?<!:|\/)\/[^\s/'")\]\n:,][^\s'")\]\n:,]*(?=[\s'")\]\n:,]|$)/g, basename);
 }
 
 type UtilityFork = typeof utilityProcess.fork;


### PR DESCRIPTION
## 这次改了什么

### 摘要

插件的 Node 工作进程**意外死亡**时，把它临死前 stderr 里的一行诊断拼进错误消息，让插件与 Agent 直接看到原因，而不是只拿到一句 `Node 工作进程已退出(code=1, signal=none)`、真实原因只留在 main 日志里。

为什么现有机制截不到：引导层 `nodeRuntimeWorkerProcess.ts` **先发 `ready`、再 `require` 插件入口**，所以「插件模块加载期抛错」这类崩溃发生在启动期之后，`startupStderr` 那条诊断路径（`startWorkerOnce` 里的 `child.once('exit')`）根本走不到。

实测案例：TapTap Maker 2.1.3 在 Windows 上无条件执行 `Object.defineProperty(process, 'stdin', …)`，而 Electron 在 win32 把 `process.stdin` 钉成 `configurable: false` 的 getter（这正是 `nodeRuntimeVirtualStdin.ts` 头注释描述的行为），于是主入口每次加载即抛 `TypeError: Cannot redefine property: stdin`、进程 `code=1` 退出。插件侧与 Agent 侧完全看不到原因，只能人工翻 `main-*.log` 才能定位。本 PR 后这类崩溃在对话里就能看到 `TypeError: Cannot redefine property: stdin`。

做法：
- 在既有的 stderr **头部**截存（启动诊断，诊断行在最前面）之外，再留一份**尾部**滚动截存（死因诊断，崩溃摘要在最后）。两者方向相反，不能共用。
- `handleExit` 里提取一行拼进 `PROCESS_EXITED` 消息与 `crashed` 状态事件。
- 复用既有 `stderrHint`（原 `startupStderrHint`，因两条路径共用而改名），**绝对路径照旧收敛为文件名**，不把宿主路径暴露给沙箱。
- 只认紧邻退出 5 秒内的 stderr，避免把十分钟前的构建日志说成死因；主动 `stop` 不参与（预期收摊不报死因）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实际排查 TapTap Maker 插件在 Windows 上崩溃时暴露）
- 本 PR 包含：`nodeRuntimeBroker.ts` 的退出诊断 + 7 个回归测试
- 明确不包含：**不修插件自身的 Windows 兼容 bug**（那是第三方 `.cindy` 包，源码不在本仓，已在本机热补并需插件作者发版根治）；不改启动期诊断的既有行为；不改任何 slot / 管子 / 身份卡 / 打包契约
- 用户可见变化：插件 Node 进程意外崩溃时，插件与 Agent 收到的错误消息末尾多一段 `:<诊断行>`；插件详情页的 `crashed` 状态消息同样带上
- 是否存在 breaking change：无（错误消息是追加，`errorCode` 与结构不变）

### UI 变化

不涉及

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
结果：36 passed（含本 PR 新增 2 个）

pnpm --filter desktop typecheck
结果：通过（tsc --noEmit 无输出）

pnpm test:unit
结果：全绿，exit=0（apps/desktop、apps/mobile 及全部 packages PASS）

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range a477aade..2b95b438
```

新增测试（本 PR describe 区块共 7 个新增用例）：
- 就绪后崩溃：PROCESS_EXITED 消息与 crashed 状态都带上诊断行，且不含宿主路径
- exit 后 drain 窗口：stderr 在 exit 后到达仍可截获
- 含空格的 Windows 路径被完整收敛为文件名
- 含空格的 POSIX 路径被完整收敛为文件名
- 陈旧段不被后续良性 chunk 携带进回看窗口
- 凭证值出现在 stderr 诊断行中时被脱敏

### 手工验证

在 Windows 11 上用真实的 TapTap Maker 2.1.3 复现了原始崩溃（`maker_status` 稳定返回 `INTERNAL: Node 工作进程已退出(code=1, signal=none)`，真实 `TypeError` 只出现在 `main-2026-07-26.log`），确认了本 PR 要解决的信息断层。

### 未执行的验证

- 本 PR 的代码改动**未在打包后的客户端里手工验证**：它编译进 main 进程，需重新构建/发版才生效；行为已由上述单测覆盖（假进程注入 stderr + exit）。
- **macOS 未实测**：改动与平台无关（stderr 截存 + 字符串处理，`sanitizePathsInHint` 对 `C:\` 与 POSIX 两种分隔符都已覆盖），无平台分支。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

补充说明（虽勾选「无已知风险」，仍列出安全侧考量）：诊断行会流向插件沙箱与 Agent，因此**沿用既有的 `sanitizePathsInHint`** 把绝对路径收敛成文件名——这与 `PROCESS_START_FAILED` 早已存在的行为一致，未新增暴露面。内存占用上界为每个 worker 4 KiB 尾部截存。

### 影响与回滚

- 影响范围：仅 `GhostNodeRuntimeBroker` 的退出路径。正常请求、启动重试、续命、childSpawn 均不受影响
- 回滚 / 降级方式：`git revert` 单个 commit 即可，无数据、无 migration、无协议变更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需同步 `FORGE_GUIDE`：未命中身份卡 / 管子 / 模型 slot / 面板供片 / 打包等作者可见契约）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)