### PR TITLE
fix(desktop): 插件更新确认框长列表限高可滚动

### DIFF
--- a/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
@@ -136,7 +136,14 @@ export function ConfirmDialog({
             // 富内容 / 长正文可能超过视口高度:包一层限高滚动区,让标题与底部按钮
             // 固定、中间内容纵向滚动,避免整个弹窗被撑出屏幕后无法滚动到被裁掉的内容
             // (典型:插件更新确认框的权限变更清单)。
-            <div className="mt-2 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+            <div
+              className={cn(
+                'min-h-0 flex-1 overflow-y-auto overscroll-contain',
+                // 保持旧间距:有 description 时紧跟标题 mt-2;仅富内容(无正文)
+                // 时沿用原 content 的 mt-3,避免 content-only 弹窗间距变化。
+                description ? 'mt-2' : 'mt-3',
+              )}
+            >
               {description && (
                 <AlertDialog.Description
                   className={cn('text-base text-[var(--confirm-desc)]', textClassName)}

--- a/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
@@ -105,6 +105,7 @@ export function ConfirmDialog({
         <AlertDialog.Content
           className={cn(
             'fixed left-1/2 top-1/2 z-[10000] -translate-x-1/2 -translate-y-1/2',
+            'flex max-h-[85vh] flex-col',
             'w-full select-none rounded-xl p-4',
             'bg-[var(--confirm-bg)] shadow-[var(--confirm-shadow)]',
             'data-[state=open]:animate-confirm-content-in',
@@ -127,22 +128,29 @@ export function ConfirmDialog({
           }
         >
           <AlertDialog.Title
-            className={cn('text-lg font-medium text-[var(--confirm-title)]', textClassName)}
+            className={cn('shrink-0 text-lg font-medium text-[var(--confirm-title)]', textClassName)}
           >
             {title}
           </AlertDialog.Title>
-          {description && (
-            <AlertDialog.Description
-              className={cn('mt-2 text-base text-[var(--confirm-desc)]', textClassName)}
-            >
-              {description}
-            </AlertDialog.Description>
+          {(description || content) && (
+            // 富内容 / 长正文可能超过视口高度:包一层限高滚动区,让标题与底部按钮
+            // 固定、中间内容纵向滚动,避免整个弹窗被撑出屏幕后无法滚动到被裁掉的内容
+            // (典型:插件更新确认框的权限变更清单)。
+            <div className="mt-2 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+              {description && (
+                <AlertDialog.Description
+                  className={cn('text-base text-[var(--confirm-desc)]', textClassName)}
+                >
+                  {description}
+                </AlertDialog.Description>
+              )}
+              {content && <div className={cn(description && 'mt-3')}>{content}</div>}
+            </div>
           )}
-          {content && <div className="mt-3">{content}</div>}
           {dontShowAgainLabel && (
             <label
               className={cn(
-                'mt-4 flex cursor-pointer select-none items-center gap-2 text-13',
+                'mt-4 flex shrink-0 cursor-pointer select-none items-center gap-2 text-13',
                 'text-[var(--confirm-desc)]',
               )}
             >
@@ -155,7 +163,7 @@ export function ConfirmDialog({
               {dontShowAgainLabel}
             </label>
           )}
-          <div className="mt-6 flex justify-end gap-2.5">
+          <div className="mt-6 flex shrink-0 justify-end gap-2.5">
             <AlertDialog.Action asChild>
               <button
                 ref={confirmBtnRef}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复插件(Ghost)详情页点「更新」后弹出的确认框:当权限变更清单较长、超过视口高度时,列表溢出屏幕上下两端且无法滚动(Radix 打开弹窗时锁背景滚动,页面也滚不动),用户看不到被裁掉的内容也点不到底部按钮。

根因是共享 `ConfirmDialog`(`apps/desktop/src/renderer/components/ui/confirm-dialog.tsx`)的 `AlertDialog.Content` 既没有 `max-height` 也没有滚动区,垂直居中布局下长 `content` 直接把弹窗撑出屏幕。安装确认走的 `GhostInstallReview` 自带限高滚动,更新确认走的 `GhostPermissionDiffView` 没有,导致两条路径不对称。

在共享层兜底修复:任何 caller 传入的长 `content`/`description` 都不再撑出屏幕。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(dogfooding 发现)
- 本 PR 包含:`ConfirmDialog` 加 `max-h-[85vh]` + flex 布局,正文/富内容包进限高滚动区,标题/复选框/按钮固定
- 明确不包含:不改各调用方(`installFlow` / `GhostPermissionDiffView` 等)——共享层兜底后无需逐处改
- 用户可见变化:更新/安装等确认框内容超高时可纵向滚动,不再溢出屏幕
- 是否存在 breaking change:无

### UI 变化

行为变化(交互):长内容确认框现在限高并在内部滚动;短内容弹窗视觉不变(内容不超高时不出现滚动条、高度自适应如旧)。macOS 上验证。

- 引用的设计规范:`docs/design-rules/DESIGN.md` §4 Dialog & Modal —— 该节以 `confirm-dialog.tsx` 为参考实现。本次保持其容器规范不变(12px 圆角 `rounded-xl`、`--confirm-bg`、`--confirm-shadow`、16px 内边距 `p-4`、居中),仅新增高度上限 + 溢出时内部滚动,标题与主/次按钮按该节要求保持可见、焦点行为不变。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果:通过(tsc --noEmit,exit 0)

pnpm check:dco
结果:通过(1 commit signed off)
```

### 手工验证

macOS:插件详情页 → 点「更新」→ 权限变更确认框内容超高时可上下滚动,标题与按钮始终可见;短内容确认框(如卸载确认)高度与外观无变化。

### 未执行的验证

未跑完整 `pnpm test:unit`:本改动为单文件共享 UI 组件的布局调整,无对应单测;已用 typecheck 覆盖类型层。Windows 未实机验证——纯 flex/overflow CSS,跨平台一致,标注待验证。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:所有使用共享 `ConfirmDialog` 的确认框(仅在内容超过 85vh 时行为改变:改为内部滚动;否则无变化)
- 回滚 / 降级方式:`git revert` 本 commit 即可,单文件、无数据/协议/迁移影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(无需)
- [x] 已确认测试结果或说明未执行原因
