### PR TITLE
fix(licenses): 声明闭包按显式目标平台收集,移动端不再声明构建期原生包

### DIFF
--- a/docs/legal/notices/README.md
+++ b/docs/legal/notices/README.md
@@ -7,6 +7,8 @@
 - `desktop-macos.txt`：macOS x64/arm64 桌面安装包。
 - `desktop-linux.txt`：Linux x64 glibc 桌面安装包。
 - `mobile-ios.txt` / `mobile-android.txt`：移动端 JS 生产依赖与仓库显式声明的原生 SDK。
+  按 app 实际分发到的设备过滤，不含只在开发机构建期使用的平台可选原生包（这些包的
+  JS 主包本身仍在声明内，只是其 `darwin`/`linux`/`win32` 预编译二进制不随 app 分发）。
 - `*-restricted.txt`：与各产物对应的专有、source-available 或许可待确认组件；不计入开源包数量。
 - `THIRD-PARTY-RESTRICTED.txt`：上述受限组件的全工程聚合审计表。
 - `THIRD-PARTY-NOTICES.txt`：上述开源组件的全工程保守聚合声明。
@@ -17,6 +19,12 @@
 `res/raw`。生成器会
 阻断 UNKNOWN/UNLICENSED、非法 SPDX 表达式、单一强 copyleft、未锁定 Rust 依赖和
 未登记的二进制资产。
+
+每个产物闭包都按显式目标平台收集，产物内容不受生成机器上装了哪些平台可选包影响。
+生成器判断可选依赖是否存在靠 `node_modules` 里有没有对应目录，而 pnpm 并不保证只
+安装 `pnpm.supportedArchitectures` 声明的架构，因此省掉目标平台参数会让声明内容随
+生成机器漂移。覆盖全部支持架构的闭包由 `SUPPORTED_TARGETS` 按该字段叉乘得出；新增
+闭包时不要省掉目标平台参数。
 
 移动端使用 Expo managed workflow，完整 Pod/Gradle 图只在原生构建阶段产生。因此移动端
 静态声明会明确标注范围，不能替代发布构建所产生的 `Podfile.lock` 或 Gradle dependency

--- a/docs/legal/notices/THIRD-PARTY-NOTICES.txt
+++ b/docs/legal/notices/THIRD-PARTY-NOTICES.txt
@@ -4684,7 +4684,7 @@ SECTION 2: npm packages (1310 packages)
 - bplist-parser@0.3.1 — MIT — https://github.com/nearinfinity/node-bplist-parser
 - bplist-parser@0.3.2 — MIT — https://github.com/nearinfinity/node-bplist-parser
 - brace-expansion@2.1.2 — MIT — https://github.com/juliangruber/brace-expansion
-- brace-expansion@5.0.7 — MIT — https://github.com/juliangruber/brace-expansion
+- brace-expansion@5.0.8 — MIT — https://github.com/juliangruber/brace-expansion
 - braces@3.0.3 — MIT — https://github.com/micromatch/braces
 - browserslist@4.28.6 — MIT — https://github.com/browserslist/browserslist
 - bser@2.1.1 — Apache-2.0 — https://github.com/facebook/watchman
@@ -30937,7 +30937,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:brace-expansion@5.0.7
+[230] Applies to: npm:brace-expansion@5.0.8
 ------------------------------------------------------------------------------
 MIT License
 

--- a/docs/legal/notices/mobile-android.txt
+++ b/docs/legal/notices/mobile-android.txt
@@ -14,6 +14,7 @@ We are grateful to all open source authors and maintainers.
 ------------------------------------------------------------------------------
 SCOPE NOTES:
   - Expo managed 工程的完整 Gradle 闭包在构建时生成;本文件不声称替代具体 APK/AAB 的依赖报告。
+  - 不含只在开发机构建期使用、不随 app 分发的平台可选原生包(其 JS 包自身仍已声明)。
 
 受限或专有第三方组件不列入开源包数量,另见配套的 THIRD-PARTY-RESTRICTED.txt。
 Restricted or proprietary components are disclosed in the companion file.
@@ -329,7 +330,7 @@ Apache License
    limitations under the License.
 
 ==============================================================================
-SECTION 2: npm packages (607 packages)
+SECTION 2: npm packages (601 packages)
 ==============================================================================
 
 - @adobe/css-tools@4.5.0 — MIT — https://github.com/adobe/css-tools
@@ -716,12 +717,6 @@ SECTION 2: npm packages (607 packages)
 - leven@3.1.0 — MIT — https://github.com/sindresorhus/leven
 - lighthouse-logger@1.4.2 — Apache-2.0
 - lightningcss@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-darwin-arm64@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-darwin-x64@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-linux-arm64-gnu@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-linux-x64-gnu@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-win32-arm64-msvc@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-win32-x64-msvc@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
 - lodash.debounce@4.0.8 — MIT — https://github.com/lodash/lodash
 - lodash.throttle@4.1.1 — MIT — https://github.com/lodash/lodash
 - log-symbols@2.2.0 — MIT — https://github.com/sindresorhus/log-symbols
@@ -5614,7 +5609,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:lightningcss@1.32.0, npm:lightningcss-darwin-arm64@1.32.0, npm:lightningcss-darwin-x64@1.32.0, npm:lightningcss-linux-arm64-gnu@1.32.0, npm:lightningcss-linux-x64-gnu@1.32.0, npm:lightningcss-win32-arm64-msvc@1.32.0, npm:lightningcss-win32-x64-msvc@1.32.0
+[134] Applies to: npm:lightningcss@1.32.0
 ------------------------------------------------------------------------------
 Mozilla Public License Version 2.0
 ==================================

--- a/docs/legal/notices/mobile-android.txt
+++ b/docs/legal/notices/mobile-android.txt
@@ -539,7 +539,7 @@ SECTION 2: npm packages (601 packages)
 - bplist-creator@0.1.0 — MIT — https://github.com/nearinfinity/node-bplist-creator
 - bplist-parser@0.3.1 — MIT — https://github.com/nearinfinity/node-bplist-parser
 - bplist-parser@0.3.2 — MIT — https://github.com/nearinfinity/node-bplist-parser
-- brace-expansion@5.0.7 — MIT — https://github.com/juliangruber/brace-expansion
+- brace-expansion@5.0.8 — MIT — https://github.com/juliangruber/brace-expansion
 - braces@3.0.3 — MIT — https://github.com/micromatch/braces
 - browserslist@4.28.6 — MIT — https://github.com/browserslist/browserslist
 - bser@2.1.1 — Apache-2.0 — https://github.com/facebook/watchman
@@ -2703,7 +2703,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[50] Applies to: npm:brace-expansion@5.0.7
+[50] Applies to: npm:brace-expansion@5.0.8
 ------------------------------------------------------------------------------
 MIT License
 

--- a/docs/legal/notices/mobile-ios.txt
+++ b/docs/legal/notices/mobile-ios.txt
@@ -357,7 +357,7 @@ SECTION 2: npm packages (601 packages)
 - bplist-creator@0.1.0 — MIT — https://github.com/nearinfinity/node-bplist-creator
 - bplist-parser@0.3.1 — MIT — https://github.com/nearinfinity/node-bplist-parser
 - bplist-parser@0.3.2 — MIT — https://github.com/nearinfinity/node-bplist-parser
-- brace-expansion@5.0.7 — MIT — https://github.com/juliangruber/brace-expansion
+- brace-expansion@5.0.8 — MIT — https://github.com/juliangruber/brace-expansion
 - braces@3.0.3 — MIT — https://github.com/micromatch/braces
 - browserslist@4.28.6 — MIT — https://github.com/browserslist/browserslist
 - bser@2.1.1 — Apache-2.0 — https://github.com/facebook/watchman
@@ -2521,7 +2521,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[50] Applies to: npm:brace-expansion@5.0.7
+[50] Applies to: npm:brace-expansion@5.0.8
 ------------------------------------------------------------------------------
 MIT License
 

--- a/docs/legal/notices/mobile-ios.txt
+++ b/docs/legal/notices/mobile-ios.txt
@@ -14,6 +14,7 @@ We are grateful to all open source authors and maintainers.
 ------------------------------------------------------------------------------
 SCOPE NOTES:
   - Expo managed 工程的完整 Pod 闭包在构建时生成;本文件不声称替代具体构建产物的 Podfile.lock 审计。
+  - 不含只在开发机构建期使用、不随 app 分发的平台可选原生包(其 JS 包自身仍已声明)。
 
 受限或专有第三方组件不列入开源包数量,另见配套的 THIRD-PARTY-RESTRICTED.txt。
 Restricted or proprietary components are disclosed in the companion file.
@@ -147,7 +148,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (607 packages)
+SECTION 2: npm packages (601 packages)
 ==============================================================================
 
 - @adobe/css-tools@4.5.0 — MIT — https://github.com/adobe/css-tools
@@ -534,12 +535,6 @@ SECTION 2: npm packages (607 packages)
 - leven@3.1.0 — MIT — https://github.com/sindresorhus/leven
 - lighthouse-logger@1.4.2 — Apache-2.0
 - lightningcss@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-darwin-arm64@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-darwin-x64@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-linux-arm64-gnu@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-linux-x64-gnu@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-win32-arm64-msvc@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
-- lightningcss-win32-x64-msvc@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
 - lodash.debounce@4.0.8 — MIT — https://github.com/lodash/lodash
 - lodash.throttle@4.1.1 — MIT — https://github.com/lodash/lodash
 - log-symbols@2.2.0 — MIT — https://github.com/sindresorhus/log-symbols
@@ -5432,7 +5427,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:lightningcss@1.32.0, npm:lightningcss-darwin-arm64@1.32.0, npm:lightningcss-darwin-x64@1.32.0, npm:lightningcss-linux-arm64-gnu@1.32.0, npm:lightningcss-linux-x64-gnu@1.32.0, npm:lightningcss-win32-arm64-msvc@1.32.0, npm:lightningcss-win32-x64-msvc@1.32.0
+[134] Applies to: npm:lightningcss@1.32.0
 ------------------------------------------------------------------------------
 Mozilla Public License Version 2.0
 ==================================

--- a/docs/legal/notices/sbom/desktop-linux.spdx.json
+++ b/docs/legal/notices/sbom/desktop-linux.spdx.json
@@ -5,7 +5,7 @@
   "name": "cindy-desktop-linux",
   "documentNamespace": "https://cindy.app/spdx/desktop-linux/71ca5d23b32ae6e9265183d63607f7fc4dc7376308cfffc4cf746d2dc7918531",
   "creationInfo": {
-    "created": "2026-07-25T09:00:18Z",
+    "created": "2026-07-26T02:38:39Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]

--- a/docs/legal/notices/sbom/desktop-macos.spdx.json
+++ b/docs/legal/notices/sbom/desktop-macos.spdx.json
@@ -5,7 +5,7 @@
   "name": "cindy-desktop-macos",
   "documentNamespace": "https://cindy.app/spdx/desktop-macos/3b3da6083be54d1a02f211b384e996fe863f75def512829c90ecda5ee685e5dc",
   "creationInfo": {
-    "created": "2026-07-25T09:00:18Z",
+    "created": "2026-07-26T02:38:39Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]

--- a/docs/legal/notices/sbom/desktop-win.spdx.json
+++ b/docs/legal/notices/sbom/desktop-win.spdx.json
@@ -5,7 +5,7 @@
   "name": "cindy-desktop-win",
   "documentNamespace": "https://cindy.app/spdx/desktop-win/a4ceee438b8b55f4ba8a27d4ec3b154cbe5badce74aeaeda93193b7a3499b1e7",
   "creationInfo": {
-    "created": "2026-07-25T09:00:18Z",
+    "created": "2026-07-26T02:38:39Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]

--- a/docs/legal/notices/sbom/mobile-android.spdx.json
+++ b/docs/legal/notices/sbom/mobile-android.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-mobile-android",
-  "documentNamespace": "https://cindy.app/spdx/mobile-android/86e68102518a578d9ed29b1aff09ce263e307222c8cf54356267607f265c8bb9",
+  "documentNamespace": "https://cindy.app/spdx/mobile-android/7073bd26a8bec4bc519dddb64ad4dec5f8e3314eeb49284f203d4779b32decd0",
   "creationInfo": {
-    "created": "2026-07-25T09:00:18Z",
+    "created": "2026-07-26T02:38:39Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -3535,8 +3535,8 @@
     },
     {
       "name": "brace-expansion",
-      "SPDXID": "SPDXRef-Package-7beda3a9b7db41eb",
-      "versionInfo": "5.0.7",
+      "SPDXID": "SPDXRef-Package-0f66532ca9b9986b",
+      "versionInfo": "5.0.8",
       "downloadLocation": "https://github.com/juliangruber/brace-expansion",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -3546,7 +3546,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/brace-expansion@5.0.7"
+          "referenceLocator": "pkg:npm/brace-expansion@5.0.8"
         }
       ]
     },
@@ -11293,7 +11293,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-7beda3a9b7db41eb"
+      "relatedSpdxElement": "SPDXRef-Package-0f66532ca9b9986b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/mobile-android.spdx.json
+++ b/docs/legal/notices/sbom/mobile-android.spdx.json
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-mobile-android",
-  "documentNamespace": "https://cindy.app/spdx/mobile-android/9f845f2d234656d48bca8d491b1ea3a5bd15a79c4fa744be623e71f447ec805e",
+  "documentNamespace": "https://cindy.app/spdx/mobile-android/86e68102518a578d9ed29b1aff09ce263e307222c8cf54356267607f265c8bb9",
   "creationInfo": {
     "created": "2026-07-25T09:00:18Z",
     "creators": [
@@ -6560,108 +6560,6 @@
       ]
     },
     {
-      "name": "lightningcss-darwin-arm64",
-      "SPDXID": "SPDXRef-Package-0f68197d2c532d19",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-darwin-arm64@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-darwin-x64",
-      "SPDXID": "SPDXRef-Package-654a9c60e340e499",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-darwin-x64@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-linux-arm64-gnu",
-      "SPDXID": "SPDXRef-Package-e53a5cf23dfe9fe6",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-linux-arm64-gnu@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-linux-x64-gnu",
-      "SPDXID": "SPDXRef-Package-3514c4270c99770a",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-linux-x64-gnu@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-win32-arm64-msvc",
-      "SPDXID": "SPDXRef-Package-0491f1c7a23201bb",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-win32-arm64-msvc@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-win32-x64-msvc",
-      "SPDXID": "SPDXRef-Package-c9aa92c5ae5869f4",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-win32-x64-msvc@1.32.0"
-        }
-      ]
-    },
-    {
       "name": "lodash.debounce",
       "SPDXID": "SPDXRef-Package-34b2f2c81ad9bbd3",
       "versionInfo": "4.0.8",
@@ -12281,36 +12179,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4ae3a8c2073b4202"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-0f68197d2c532d19"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-654a9c60e340e499"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e53a5cf23dfe9fe6"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-3514c4270c99770a"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-0491f1c7a23201bb"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c9aa92c5ae5869f4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/mobile-ios.spdx.json
+++ b/docs/legal/notices/sbom/mobile-ios.spdx.json
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-mobile-ios",
-  "documentNamespace": "https://cindy.app/spdx/mobile-ios/e0ee8e6b570715d064e035b74053200f76167559cc5e539a2a80c25b6d5a7ef0",
+  "documentNamespace": "https://cindy.app/spdx/mobile-ios/206246ae771fcc78ae8cfb6b1e5d6310d2ab83ee8c5ca58a541eba4b091ec6c1",
   "creationInfo": {
     "created": "2026-07-25T09:00:18Z",
     "creators": [
@@ -6560,108 +6560,6 @@
       ]
     },
     {
-      "name": "lightningcss-darwin-arm64",
-      "SPDXID": "SPDXRef-Package-0f68197d2c532d19",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-darwin-arm64@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-darwin-x64",
-      "SPDXID": "SPDXRef-Package-654a9c60e340e499",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-darwin-x64@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-linux-arm64-gnu",
-      "SPDXID": "SPDXRef-Package-e53a5cf23dfe9fe6",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-linux-arm64-gnu@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-linux-x64-gnu",
-      "SPDXID": "SPDXRef-Package-3514c4270c99770a",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-linux-x64-gnu@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-win32-arm64-msvc",
-      "SPDXID": "SPDXRef-Package-0491f1c7a23201bb",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-win32-arm64-msvc@1.32.0"
-        }
-      ]
-    },
-    {
-      "name": "lightningcss-win32-x64-msvc",
-      "SPDXID": "SPDXRef-Package-c9aa92c5ae5869f4",
-      "versionInfo": "1.32.0",
-      "downloadLocation": "https://github.com/parcel-bundler/lightningcss",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MPL-2.0",
-      "licenseDeclared": "MPL-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/lightningcss-win32-x64-msvc@1.32.0"
-        }
-      ]
-    },
-    {
       "name": "lodash.debounce",
       "SPDXID": "SPDXRef-Package-34b2f2c81ad9bbd3",
       "versionInfo": "4.0.8",
@@ -12281,36 +12179,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4ae3a8c2073b4202"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-0f68197d2c532d19"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-654a9c60e340e499"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e53a5cf23dfe9fe6"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-3514c4270c99770a"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-0491f1c7a23201bb"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c9aa92c5ae5869f4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/mobile-ios.spdx.json
+++ b/docs/legal/notices/sbom/mobile-ios.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-mobile-ios",
-  "documentNamespace": "https://cindy.app/spdx/mobile-ios/206246ae771fcc78ae8cfb6b1e5d6310d2ab83ee8c5ca58a541eba4b091ec6c1",
+  "documentNamespace": "https://cindy.app/spdx/mobile-ios/bcbee371f2714b4c4f18b156d42dd7bfd99ed8e2fd7e7a89d3dd3873c39324cf",
   "creationInfo": {
-    "created": "2026-07-25T09:00:18Z",
+    "created": "2026-07-26T02:38:39Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -3535,8 +3535,8 @@
     },
     {
       "name": "brace-expansion",
-      "SPDXID": "SPDXRef-Package-7beda3a9b7db41eb",
-      "versionInfo": "5.0.7",
+      "SPDXID": "SPDXRef-Package-0f66532ca9b9986b",
+      "versionInfo": "5.0.8",
       "downloadLocation": "https://github.com/juliangruber/brace-expansion",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -3546,7 +3546,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/brace-expansion@5.0.7"
+          "referenceLocator": "pkg:npm/brace-expansion@5.0.8"
         }
       ]
     },
@@ -11293,7 +11293,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-7beda3a9b7db41eb"
+      "relatedSpdxElement": "SPDXRef-Package-0f66532ca9b9986b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/scripts/__tests__/third-party-notices.test.mjs
+++ b/scripts/__tests__/third-party-notices.test.mjs
@@ -84,6 +84,32 @@ test("multi-arch desktop notices describe every architecture they ship with", ()
   assert.match(linux, /for use with sharp on Linux \(glibc\) 64-bit ARM\./);
 });
 
+// 移动端安装包不分发构建期工具链的预编译二进制，但这些包的许可义务由其 JS 主包
+// 承载，主包必须留在声明里。
+test("mobile notices exclude build-time platform binaries but keep their JS packages", () => {
+  for (const artifact of ["mobile-ios", "mobile-android"]) {
+    const notices = read(`docs/legal/notices/${artifact}.txt`);
+    // 覆盖 name-darwin-arm64 与 @scope/darwin-arm64 两种命名形式。
+    assert.doesNotMatch(
+      notices,
+      /^- \S*(?:darwin|linux|win32|musl|freebsd)\S*@/im,
+    );
+    assert.match(notices, /^- lightningcss@/m);
+  }
+});
+
+// 闭包必须按显式目标平台收集：collectClosure() 判断可选依赖是否存在只看
+// node_modules 里有没有目录，省掉 target 会让产物随生成机器的安装集合漂移。
+test("every dependency closure is collected against an explicit target", () => {
+  const source = read("scripts/generate-third-party-notices.mjs");
+  const untargeted = [...source.matchAll(/collectClosure\(\s*\[[^\]]*\]\s*\)/g)];
+  assert.deepEqual(
+    untargeted.map((match) => match[0]),
+    [],
+    "collectClosure() 调用缺少目标平台参数，产物会随本机安装的平台可选包漂移",
+  );
+});
+
 test("commercial distributions do not resolve forbidden Sustainable Use dependencies", () => {
   const lockfile = read("pnpm-lock.yaml");
   assert.doesNotMatch(lockfile, /@codesandbox\/nodebox/);

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -386,6 +386,50 @@ function mergeClosures(...closures) {
   };
 }
 
+/**
+ * 由根 package.json 的 `pnpm.supportedArchitectures` 叉乘出的目标平台集合。
+ *
+ * 覆盖「本仓声明支持的全部架构」而非单一发行产物的闭包必须逐个 target 收集再合并，
+ * 不能省掉 target 让 matchesTarget() 一律放行：collectClosure() 判断一个平台可选依赖
+ * 是否存在只看 `node_modules` 里有没有对应目录，而实际装出来的集合可能超出
+ * supportedArchitectures 的声明（例如 libc 只声明 glibc 时仍装进 musl 变体），产物
+ * 内容就会随生成机器漂移。这里不假设包管理器只安装声明过的架构。
+ */
+function readSupportedTargets() {
+  const declared = readJson(path.join(REPO_ROOT, "package.json")).pnpm
+    ?.supportedArchitectures;
+  for (const axis of ["os", "cpu", "libc"]) {
+    const values = declared?.[axis];
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error(
+        `pnpm.supportedArchitectures.${axis} must list explicit values in the root package.json`,
+      );
+    }
+    // pnpm 支持 "current" 表示生成机器自身的架构，那会把机器差异重新带回产物。
+    if (values.includes("current")) {
+      throw new Error(
+        `pnpm.supportedArchitectures.${axis} must not use "current": license notices would depend on the generating machine`,
+      );
+    }
+  }
+  const targets = [];
+  for (const os of declared.os) {
+    for (const cpu of declared.cpu) {
+      for (const libc of declared.libc) targets.push({ os, cpu, libc });
+    }
+  }
+  return targets;
+}
+
+const SUPPORTED_TARGETS = readSupportedTargets();
+
+/** 在全部支持架构上收集闭包并合并，结果与生成机器的安装集合无关。 */
+function collectClosureForSupportedTargets(entryDirs) {
+  return mergeClosures(
+    ...SUPPORTED_TARGETS.map((target) => collectClosure(entryDirs, target)),
+  );
+}
+
 function cargoExecutable() {
   const candidate = process.env.USERPROFILE
     ? path.join(process.env.USERPROFILE, ".cargo", "bin", "cargo.exe")
@@ -1239,7 +1283,12 @@ if (!fs.existsSync(path.join(path.dirname(CARGO_MANIFEST), "Cargo.lock"))) {
   );
 }
 
-const projectNpm = collectClosure([REPO_ROOT, ...discoverWorkspaceDirs()]);
+const projectNpm = collectClosureForSupportedTargets([
+  REPO_ROOT,
+  ...discoverWorkspaceDirs(),
+]);
+// 桌面三份产物的 target 是各自的实际发行矩阵（如 Windows 只发 x64），刻意不等于
+// SUPPORTED_TARGETS——后者是仓库声明支持的全部架构，用于覆盖面更宽的聚合声明。
 const desktopWinNpm = collectClosure([DESKTOP_DIR], {
   os: "win32",
   cpu: "x64",
@@ -1252,7 +1301,16 @@ const desktopLinuxNpm = mergeClosures(
   collectClosure([DESKTOP_DIR], { os: "linux", cpu: "x64", libc: "glibc" }),
   collectClosure([DESKTOP_DIR], { os: "linux", cpu: "arm64", libc: "glibc" }),
 );
-const mobileNpm = collectClosure([MOBILE_DIR]);
+// 移动端产物的 target 是「app 实际分发到的设备」，不是仓库支持的构建架构：
+// 移动端 JS 依赖里的平台可选包（lightningcss / @parcel/watcher / @rollup 等预编译
+// 二进制）属于开发机上的构建期工具链，不进 iOS bundle 或 APK/AAB。npm 生态里纯 JS
+// 包不声明 os/cpu，matchesPackageConstraint() 对未声明的约束一律放行，所以按设备
+// target 过滤只会摘掉这些原生变体，包自身（含其许可义务）仍然照常声明。
+const mobileIosNpm = collectClosure([MOBILE_DIR], { os: "ios", cpu: "arm64" });
+const mobileAndroidNpm = collectClosure([MOBILE_DIR], {
+  os: "android",
+  cpu: "arm64",
+});
 const cargoClosure = collectCargoClosure();
 
 const apacheText =
@@ -1306,21 +1364,23 @@ const artifactDefinitions = {
     ],
   },
   "mobile-ios": {
-    closure: mobileNpm,
+    closure: mobileIosNpm,
     manual: buildMobileEntries(apacheText, "ios"),
     productName: "Cindy mobile application — iOS",
     description: ["iOS JS 生产依赖及仓库显式声明的原生 SDK/字体组件。"],
     notes: [
       "Expo managed 工程的完整 Pod 闭包在构建时生成;本文件不声称替代具体构建产物的 Podfile.lock 审计。",
+      "不含只在开发机构建期使用、不随 app 分发的平台可选原生包(其 JS 包自身仍已声明)。",
     ],
   },
   "mobile-android": {
-    closure: mobileNpm,
+    closure: mobileAndroidNpm,
     manual: buildMobileEntries(apacheText, "android"),
     productName: "Cindy mobile application — Android",
     description: ["Android JS 生产依赖及仓库显式声明的原生 SDK/字体组件。"],
     notes: [
       "Expo managed 工程的完整 Gradle 闭包在构建时生成;本文件不声称替代具体 APK/AAB 的依赖报告。",
+      "不含只在开发机构建期使用、不随 app 分发的平台可选原生包(其 JS 包自身仍已声明)。",
     ],
   },
 };


### PR DESCRIPTION
## 这次改了什么

### 摘要

`pnpm licenses:generate` 生成的第三方声明产物会随「生成机器上装了哪些平台可选包」漂移。
根因是 `scripts/generate-third-party-notices.mjs` 的 `collectClosure()` 判断一个平台可选
依赖是否存在，靠的是 `node_modules` 里有没有对应目录；而 `projectNpm` / `mobileNpm` 两处
闭包收集时没有传目标平台，`matchesTarget()` 遇到空 target 一律放行。于是在装了 musl 变体的
机器上生成，产物就会多出 `@rollup/rollup-linux-*-musl`、`lightningcss-linux-*-musl` 等只在
另一类机器上存在的包（issue #485 列出的 5 个文件）。

本 PR 让每个闭包都按显式目标平台收集：

1. **确定性**：新增 `SUPPORTED_TARGETS`，由根 `package.json` 的
   `pnpm.supportedArchitectures` 按 os × cpu × libc 叉乘得出，`projectNpm` 改为在全部支持
   架构上逐个收集再合并。刻意不省掉 target 让 `matchesTarget()` 放行——因为包管理器并不保证
   只安装声明过的架构，省掉 target 等于把机器差异重新引回产物。同时校验该字段必须显式列值、
   且不得使用 `current`（`current` 表示生成机器自身架构，会直接破坏确定性）。
2. **声明范围与分发物一致**：`mobile-ios` / `mobile-android` 改为按「app 实际分发到的设备」
   （`ios`/`android` + `arm64`）收集，而不是仓库支持的构建架构。移动端 JS 依赖里的平台可选包
   （`lightningcss` / `@parcel/watcher` / `@rollup` 的预编译二进制）属于开发机上的构建期
   工具链，不进 iOS bundle 也不进 APK/AAB，此前被算进了移动端声明。npm 生态里纯 JS 包不声明
   `os`/`cpu`，`matchesPackageConstraint()` 对未声明的约束一律放行，所以按设备 target 过滤
   只摘掉原生变体，包自身（含其许可义务）仍照常声明——例如 MPL-2.0 的 `lightningcss` 主包
   保留，只去掉它的 6 个平台二进制。移动端 npm 包数 607 → 601。

产物改动分两个 commit：`bd37788f` 是逻辑改动及其直接导致的移动端产物变化；`21bf2a4b` 是按
当前 lockfile 刷新（SBOM `created` 时间戳 + `brace-expansion@5.0.7 → 5.0.8`），属于本 PR
之前就已存在的产物滞后，在干净的 `main` 上重新生成同样会漂移，与本次逻辑改动无关。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#485（**请勿直接关闭**，见下）
- 本 PR 包含：
  - 生成器按显式目标平台收集闭包（`SUPPORTED_TARGETS` + `collectClosureForSupportedTargets()`）
  - `supportedArchitectures` 字段校验（必须显式列值、禁用 `current`）
  - 移动端闭包按分发设备过滤
  - 2 个回归测试：移动端不含构建期平台二进制但保留其 JS 主包；源码里不允许出现缺 target 的
    `collectClosure()` 调用
  - `docs/legal/notices/README.md` 说明范围与不变量
  - 重新生成的产物
- 明确不包含：
  - **`licenses:generate` + `git diff --exit-code` 的 CI 一致性门禁**（issue 里的建议 3）。
    issue 的评论已指出正确顺序是「先让闭包与本机安装集合解耦，再加门禁，反过来会得到一道
    flaky 门禁」，本 PR 是第 1 步。门禁本身还有独立前置问题需要单独解决：SBOM 的 `created`
    取自 `pnpm-lock.yaml` / `Cargo.toml` 的 git committer date，squash-merge 会重写该时间戳，
    门禁在 PR 上校验的产物与合并后应有的产物必然不同；此外还需要 `fetch-depth: 0`、checkout
    `pull_request.head.sha` 而非 merge commit、Rust toolchain 与 `~/.cargo` 缓存
    （`cargo metadata` 需要 crate 源码解包才能读 LICENSE 文件）。
  - 移动端是否该更严格地排除平台可选包（例如连纯 JS 构建工具链一起排除）这个更大范围的讨论。
- 用户可见变化：无（仅合规声明文本与 SBOM 内容）
- 是否存在 breaking change：无

因此 **#485 建议保持开启**，剩下 CI 门禁与移动端范围讨论两项。

### UI 变化

不涉及

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部 PASS（含新增 2 个回归测试），退出码 0

pnpm licenses:generate（连续两次）
结果：第二次零 diff，产物自洽

sha256 不变性验证（把本机 14 个 musl 变体目录移出 node_modules 后重新生成，逐文件比对）
结果：全部 19 个产物 sha256 完全一致

node scripts/check-dco.mjs --base main
结果：DCO check passed: 2 commits signed off
```

反向验证：临时去掉源码守卫测试里断言的 target 后，该测试按预期失败并给出预期消息，确认测试
不是空过。

范围改动的量化：移动端 npm 包 607 → 601，去掉的恰好是 6 个 `lightningcss-*` 平台变体，
`lightningcss` 主包及其 MPL-2.0 义务保留，桌面三份产物的包集合零变化（`lightningcss` 本来
就不在桌面闭包里）。

### 手工验证

Windows 上人工核对 `mobile-ios.txt` / `mobile-android.txt` 与两份 SBOM 的 diff，确认删除项
全部是平台专用二进制、无其他包被误删。

### 未执行的验证

- **macOS / Linux 上的生成一致性**：本地只在 Windows 上验证。跨平台一致性正是本 PR 要解决的
  问题，需要在另一类机器上跑 `pnpm licenses:generate` 并确认零 diff 才算完整闭环。
- CI 一致性门禁：本 PR 刻意不含，见上。
- `pnpm test:all`：未跑，本次改动只涉及 `scripts/` 与 `docs/`，不触碰任何 workspace package
  的运行时代码。

另需说明一个与本 PR 无关的环境问题：在 Windows 上跑 `pnpm test:unit`，
`GLOSSARY.md 与 glossary.json 同步` 会失败，因为该测试对行尾敏感而仓库在 Windows 检出为
CRLF。重新生成该文件产生零 git diff，`git diff HEAD -- i18n/` 也是干净的，可确认与本 PR 无关。
本次为通过门禁把该文件临时转成 LF 跑测试，跑完已 `git checkout` 恢复，未进入任何 commit。
这个假失败还会短路掉后续的 workspace 测试（`test:unit` = `test:runner && test-workspaces`），
值得单独开 issue 修。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

不改任何运行时代码与原生输入，不影响 mobile runtime fingerprint。合规层面本 PR 收窄的只有
「不随 app 分发的预编译二进制」，承载许可义务的 JS 主包全部保留。

### 影响与回滚

- 影响范围：仅 `pnpm licenses:generate` 的输出内容与 `docs/legal/notices/` 下的产物。
- 回滚 / 降级方式：revert 本 PR 即可，无数据迁移、无状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
