### PR TITLE
fix(desktop): 关于页 Discord 入口换成永久邀请链接

### DIFF
--- a/apps/desktop/src/renderer/__tests__/aboutSocialLinks.test.ts
+++ b/apps/desktop/src/renderer/__tests__/aboutSocialLinks.test.ts
@@ -19,7 +19,7 @@ const expectedXiaohongshuDescriptions: Record<string, string> = {
 
 describe('Settings About social links', () => {
   it('uses the official destinations and prioritizes the Discord community', () => {
-    const discordIndex = aboutSource.indexOf('https://discord.gg/UxHPUGXdd');
+    const discordIndex = aboutSource.indexOf('https://discord.gg/V4yKguac7K');
     const xIndex = aboutSource.indexOf('https://x.com/making_cindy');
     const xiaohongshuIndex = aboutSource.indexOf('https://xhslink.com/m/XmfveHjLlL');
 

--- a/apps/desktop/src/renderer/components/settings/AboutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AboutSection.tsx
@@ -36,7 +36,7 @@ const DESKTOP_SOCIAL_LINKS = [
     id: 'discord',
     labelKey: 'settings.about.social.discordLabel',
     descriptionKey: 'settings.about.social.discordDescription',
-    url: 'https://discord.gg/UxHPUGXdd',
+    url: 'https://discord.gg/V4yKguac7K',
   },
   {
     id: 'x',


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置 → 关于 → 社区卡片里的 Discord 链接是一个**带有效期的临时邀请**，用户点「接受邀请」会被 Discord 拒绝（#498）。换成社区管理账号签发的**永久邀请**。

用 Discord 公开 invite API 对比两个邀请码：

| | 旧 `UxHPUGXdd` | 新 `V4yKguac7K` |
|---|---|---|
| guild | `1524291334654132335` · Cindy App | 同一个 |
| `expires_at` | `2026-08-20T00:25:04Z`（临时） | `null`（永久） |
| 签发者 | `nanaco623` / XW（个人号） | `cindy.ops` / Cindy Community Owner |

两个码指向同一个服务器，替换后落地位置不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #498
- 本 PR 包含：替换 `AboutSection.tsx` 里的 Discord 邀请 URL，同步更新硬编码断言该 URL 的测试
- 明确不包含：Discord 服务器侧的运营配置（见下方「遗留风险」）
- 用户可见变化：设置 → 关于 → Discord 卡片跳转到新的永久邀请链接
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：本次仅替换 `DESKTOP_SOCIAL_LINKS` 常量中一个 URL 字符串，社区卡片的布局、间距、样式、图标与文案均未变动，Light 与 Dark 两种模式下的渲染结果与改动前完全一致，因此没有需要引用的设计规范章节。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部 PASS（exit 0），含 apps/desktop 的 aboutSocialLinks 用例

pnpm --filter desktop run --if-present typecheck
结果：tsc --noEmit 通过，无输出

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

### 手工验证

用 Discord 公开 invite API 核对两个邀请码的 `guild.id`、`expires_at` 与签发者，确认新码指向同一服务器且为永久邀请（数据见上表）。

### 未执行的验证

- 未真实点击「接受邀请」复现报错：这需要登录 Discord 账号操作，不在本次改动的验证范围内。因此「临时邀请次数耗尽」是基于 `expires_at` 非空的推断，而非直接观测。
- 未启动 Electron 应用手工点击该卡片：改动仅为常量字符串替换，渲染与跳转逻辑（`window.electronAPI.openExternal`）未触及，已由既有单测覆盖。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop 设置页「关于」的 Discord 跳转目标。
- 回滚 / 降级方式：还原这两行即可，无状态、无迁移、无缓存。

### 遗留风险（已由社区侧确认关闭）

本 PR 只换链接，不改 Discord 服务器配置。原本的担心是：如果新邀请仍带使用次数上限，
同样的问题会复发。**社区侧已确认 `V4yKguac7K` 设置为永久有效、无使用次数上限**，
该风险已关闭。

仍建议后续把对外入口收敛到自有短链，这样再换邀请码就不必发客户端版本——但这属于
独立改进，不阻塞本 PR。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（本次无视觉变化，已说明理由）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
