### PR TITLE
fix(licenses): collectClosure 强制显式目标平台,取代可绕过的源码守卫

### DIFF
--- a/docs/legal/notices/README.md
+++ b/docs/legal/notices/README.md
@@ -23,8 +23,8 @@
 每个产物闭包都按显式目标平台收集，产物内容不受生成机器上装了哪些平台可选包影响。
 生成器判断可选依赖是否存在靠 `node_modules` 里有没有对应目录，而 pnpm 并不保证只
 安装 `pnpm.supportedArchitectures` 声明的架构，因此省掉目标平台参数会让声明内容随
-生成机器漂移。覆盖全部支持架构的闭包由 `SUPPORTED_TARGETS` 按该字段叉乘得出；新增
-闭包时不要省掉目标平台参数。
+生成机器漂移。覆盖全部支持架构的闭包由 `SUPPORTED_TARGETS` 按该字段叉乘得出。目标平台
+是必填的：省掉它会让生成直接失败，而不是静默产出与本机相关的声明。
 
 移动端使用 Expo managed workflow，完整 Pod/Gradle 图只在原生构建阶段产生。因此移动端
 静态声明会明确标注范围，不能替代发布构建所产生的 `Podfile.lock` 或 Gradle dependency

--- a/scripts/__tests__/third-party-notices.test.mjs
+++ b/scripts/__tests__/third-party-notices.test.mjs
@@ -98,16 +98,30 @@ test("mobile notices exclude build-time platform binaries but keep their JS pack
   }
 });
 
-// 闭包必须按显式目标平台收集：collectClosure() 判断可选依赖是否存在只看
-// node_modules 里有没有目录，省掉 target 会让产物随生成机器的安装集合漂移。
-test("every dependency closure is collected against an explicit target", () => {
+// 闭包必须按显式目标平台收集：collectClosure() 判断可选依赖是否存在只看 node_modules
+// 里有没有目录，省掉 target 就会让产物随生成机器的安装集合漂移。
+//
+// 这里守的是那一处强制校验本身，而不是去枚举调用点。枚举的写法（无论正则还是括号扫描）
+// 都能被换一种调用形式绕过，且在本文件上会实打实误报——生成器的错误消息与注释里都出现
+// 了 `collectClosure(`，而源码含带引号的正则字面量，使得零依赖的字符串跳过无法可靠实现。
+// 强制校验则覆盖全部调用形式：`licenses:generate` 是产物的唯一生成途径，缺 target 的调用
+// 必然在生成时抛错，产物不可能带着机器相关的内容进仓库。
+test("collectClosure() refuses to run without an explicit target", () => {
   const source = read("scripts/generate-third-party-notices.mjs");
-  const untargeted = [...source.matchAll(/collectClosure\(\s*\[[^\]]*\]\s*\)/g)];
-  assert.deepEqual(
-    untargeted.map((match) => match[0]),
-    [],
-    "collectClosure() 调用缺少目标平台参数，产物会随本机安装的平台可选包漂移",
+  const signature = source.match(/function collectClosure\(([^)]*)\)/)?.[1];
+  assert.ok(signature, "找不到 collectClosure 定义，守卫已失效");
+  assert.doesNotMatch(
+    signature,
+    /=/,
+    "target 不得有默认值：默认值会让缺 target 的调用静默恢复成机器相关行为",
   );
+  assert.match(source, /requires an explicit target/);
+  // matchesTarget() 不得再有「target 为空则一律放行」的分支，那是漂移的根源。
+  const matchesTarget = source.match(
+    /function matchesTarget\([^)]*\)\s*\{[\s\S]*?\n\}/,
+  )?.[0];
+  assert.ok(matchesTarget, "找不到 matchesTarget 定义，守卫已失效");
+  assert.doesNotMatch(matchesTarget, /return true/);
 });
 
 test("commercial distributions do not resolve forbidden Sustainable Use dependencies", () => {

--- a/scripts/__tests__/third-party-notices.test.mjs
+++ b/scripts/__tests__/third-party-notices.test.mjs
@@ -116,6 +116,13 @@ test("collectClosure() refuses to run without an explicit target", () => {
     "target 不得有默认值：默认值会让缺 target 的调用静默恢复成机器相关行为",
   );
   assert.match(source, /requires an explicit target/);
+  // linux 目标必须连 libc 一起强制：只有 linux 分 glibc / musl，缺了这一轴
+  // matchesPackageConstraint() 会把两种变体同时放行，产物又随本机装了哪个变体漂移。
+  assert.match(
+    source,
+    /os === "linux"\s*\?\s*\["os", "cpu", "libc"\]/,
+    "linux 目标未强制 libc：glibc 与 musl 变体会同时进闭包",
+  );
   // matchesTarget() 不得再有「target 为空则一律放行」的分支，那是漂移的根源。
   const matchesTarget = source.match(
     /function matchesTarget\([^)]*\)\s*\{[\s\S]*?\n\}/,

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -260,7 +260,12 @@ function matchesTarget(pkgJson, target) {
  * 行为的路径。
  */
 function collectClosure(entryDirs, target) {
-  for (const axis of ["os", "cpu"]) {
+  // 只有 linux 分 glibc / musl，所以 libc 只在 linux 目标上必填：缺了它
+  // matchesPackageConstraint() 会因为「未声明约束一律放行」把 glibc 与 musl 变体同时收进
+  // 闭包，产物重新随本机装了哪个变体漂移——正是本函数要挡掉的那种机器相关行为。
+  const requiredAxes =
+    target?.os === "linux" ? ["os", "cpu", "libc"] : ["os", "cpu"];
+  for (const axis of requiredAxes) {
     if (typeof target?.[axis] !== "string" || target[axis].length === 0) {
       throw new Error(
         `collectClosure() requires an explicit target.${axis}: license notices would otherwise depend on the generating machine`,

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -245,8 +245,11 @@ function matchesTarget(pkgJson, target) {
   return (
     matchesPackageConstraint(pkgJson.os, target.os) &&
     matchesPackageConstraint(pkgJson.cpu, target.cpu) &&
-    // libc 只对 linux 有意义，其余平台的 target 不带该轴，交给 matchesPackageConstraint
-    // 按「未声明约束一律放行」处理。
+    // libc 只对 linux 有意义，非 linux 目标可以省略这一轴（desktop-win / desktop-macos
+    // 与移动端的 target 就没带），省略时由 matchesPackageConstraint() 按「未声明约束一律
+    // 放行」处理；SUPPORTED_TARGETS 叉乘出来的 target 则各轴齐全，os 不是 linux 时也带
+    // libc，那种情况下这一轴只会挡掉声明了 libc 约束的包，而声明该约束的包都把 os 限定
+    // 在 linux，早已被上面的 os 轴挡掉。
     matchesPackageConstraint(pkgJson.libc, target.libc)
   );
 }

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -242,16 +242,31 @@ function matchesPackageConstraint(values, actual) {
 }
 
 function matchesTarget(pkgJson, target) {
-  if (!target) return true;
   return (
     matchesPackageConstraint(pkgJson.os, target.os) &&
     matchesPackageConstraint(pkgJson.cpu, target.cpu) &&
+    // libc 只对 linux 有意义，其余平台的 target 不带该轴，交给 matchesPackageConstraint
+    // 按「未声明约束一律放行」处理。
     matchesPackageConstraint(pkgJson.libc, target.libc)
   );
 }
 
-/** BFS 遍历给定入口的生产依赖闭包。workspace 内部包穿透但不收录。 */
-function collectClosure(entryDirs, target = null) {
+/**
+ * BFS 遍历给定入口的生产依赖闭包。workspace 内部包穿透但不收录。
+ *
+ * `target` 必填且强制校验：本函数判断一个平台可选依赖是否存在，只看 `node_modules` 里
+ * 有没有对应目录，所以缺了 target 就等于把「本机恰好装了哪些架构」写进产物。这里刻意
+ * 不提供「不过滤」的默认值——宁可让调用点直接报错，也不给出一条能静默恢复机器相关
+ * 行为的路径。
+ */
+function collectClosure(entryDirs, target) {
+  for (const axis of ["os", "cpu"]) {
+    if (typeof target?.[axis] !== "string" || target[axis].length === 0) {
+      throw new Error(
+        `collectClosure() requires an explicit target.${axis}: license notices would otherwise depend on the generating machine`,
+      );
+    }
+  }
   const collected = new Map(); // key: name@version
   const visitedDirs = new Set();
   const missing = new Set();
@@ -389,11 +404,11 @@ function mergeClosures(...closures) {
 /**
  * 由根 package.json 的 `pnpm.supportedArchitectures` 叉乘出的目标平台集合。
  *
- * 覆盖「本仓声明支持的全部架构」而非单一发行产物的闭包必须逐个 target 收集再合并，
- * 不能省掉 target 让 matchesTarget() 一律放行：collectClosure() 判断一个平台可选依赖
- * 是否存在只看 `node_modules` 里有没有对应目录，而实际装出来的集合可能超出
- * supportedArchitectures 的声明（例如 libc 只声明 glibc 时仍装进 musl 变体），产物
- * 内容就会随生成机器漂移。这里不假设包管理器只安装声明过的架构。
+ * 覆盖「本仓声明支持的全部架构」而非单一发行产物的闭包必须逐个 target 收集再合并：
+ * collectClosure() 判断一个平台可选依赖是否存在只看 `node_modules` 里有没有对应目录，
+ * 而实际装出来的集合可能超出 supportedArchitectures 的声明（例如 libc 只声明 glibc 时
+ * 仍装进 musl 变体），产物内容就会随生成机器漂移。这里不假设包管理器只安装声明过的
+ * 架构。
  */
 function readSupportedTargets() {
   const declared = readJson(path.join(REPO_ROOT, "package.json")).pnpm


### PR DESCRIPTION
## 这次改了什么

### 摘要

跟进 #499 上 Greptile 与 Copilot 指出的同一处问题：该 PR 引入的「每个闭包都必须按显式目标
平台收集」这条不变量，是靠一条源码正则守卫的，而那条正则只匹配「首参是字面量数组、右方括号
后直接收尾」的调用形式。`collectClosure(entryDirs)`、`collectClosure(getDirs())` 或带尾逗号
的无 target 调用都会漏检，守卫只要换一种写法就静默失效。

本 PR 把防线从「检查源码长什么样」换成「运行时强制」：

- `collectClosure(entryDirs, target)` 去掉 `= null` 默认值，进函数先校验 `target.os` 与
  `target.cpu`，缺任一就抛
  `collectClosure() requires an explicit target.<axis>: license notices would otherwise depend on the generating machine`。
- 删掉 `matchesTarget()` 里的 `if (!target) return true`。那条放行分支正是声明产物随生成机器
  漂移的根源，而该函数只被 `collectClosure()` 调用，删掉后不再存在「不过滤」的代码路径。
- 测试改为守卫这一处不变量本身（签名不得带默认值、错误消息在位、`matchesTarget()` 不得再有
  放行分支），不再枚举调用点。

这样比源码守卫更强：`licenses:generate` 是这些产物的唯一生成途径且线性执行，任何缺 target 的
调用必然让生成整体失败，产物不可能带着与本机相关的内容进仓库。

**为什么没按建议去解析调用表达式 / 放宽正则**：这条路我先实现了一版（括号扫描、跳过字符串与
注释、排除函数声明本身，可覆盖变量实参、嵌套调用与尾逗号），但它在这个文件上**实测误报**——
生成器自己的错误消息模板串和一处 doc 注释里都含 `collectClosure(`，被报成 `0 个实参`。要排除
它们就得可靠区分字符串与注释，而本文件含带引号的正则字面量（`/VERSION:"([\d.]+)"/`、
`/:type\s*=>\s*['\"]Apache-2\.0['\"]/s`），线性状态扫描必定在那里错位；写对就得连正则字面量
一起 tokenize。走 AST 则要把只是传递依赖的 `acorn` 提成直接依赖并改动 lockfile，代价高于这个
守卫本身的价值。运行时校验对调用形式完全不敏感，不存在这类边界。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：跟进 #499 的 code review 意见；#485 仍保持开启（CI 一致性门禁与移动端
  声明范围的更大范围讨论都不在本 PR）。
- 本 PR 包含：`collectClosure()` 强制显式目标平台、移除 `matchesTarget()` 的放行分支、测试改为
  守卫该不变量、README 措辞同步。
- 明确不包含：`licenses:generate` + `git diff --exit-code` 的 CI 门禁（阻塞前置见 #499 描述）；
  任何产物内容改动。
- 用户可见变化：无。
- 是否存在 breaking change：无。

**本 PR 不含任何产物改动**：现有调用点本来就全部传了 target，新旧逻辑对它们完全等价，所以
`licenses:generate` 的输出零 diff——这同时也是改动没有副作用的证据。

### UI 变化

不涉及

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部 PASS，退出码 0（无 FAIL 项）

node --test scripts/__tests__/third-party-notices.test.mjs
结果：8 pass / 0 fail

pnpm licenses:generate
结果：退出码 0，产物内容零 diff（git diff --stat 对 docs/legal/notices/ 与
      apps/desktop/resources/ 无输出）
```

反向验证（确认两道防线都不是空过）：

```text
把签名改回 collectClosure(entryDirs, target = null)
→ 测试 fail 1：「target 不得有默认值：默认值会让缺 target 的调用静默恢复成机器相关行为」

把 mobileIosNpm 的调用改成 collectClosure([MOBILE_DIR])
→ 生成器退出码 1，抛 collectClosure() requires an explicit target.os，且未写出任何产物
```

顺带在合并前的分支上实测过一次「缺 target 且无校验」的效果：`mobile-ios` 产物立刻退回到带
`lightningcss-*` 平台二进制的状态，即把 #485 那次漂移原地重现了一遍。

### 手工验证

不涉及（无 UI、无用户可见行为变化）。

### 未执行的验证

- 跨平台生成一致性：本地只在 Windows 上验证。本 PR 不改变闭包的目标平台集合，产物零 diff，
  因此不引入新的跨平台差异；#499 遗留的 macOS/Linux 生成一致性核对仍待补。
- `pnpm test:all`：未跑，改动只涉及 `scripts/` 与 `docs/`，不触碰任何 workspace package 的
  运行时代码。

另需说明一个与本 PR 无关的既有环境问题：在 Windows 上跑 `pnpm test:unit`，
`GLOSSARY.md 与 glossary.json 同步` 会因该测试对行尾敏感、而仓库在 Windows 检出为 CRLF 而
失败（重新生成该文件产生零 git diff）。本次为通过门禁把该文件临时转成 LF，跑完已恢复，未进入
任何 commit。这个假失败还会短路掉后续的 workspace 测试（`test:unit` =
`test:runner && test-workspaces`），值得单独开 issue 修。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

不改运行时代码与原生输入，不影响 mobile runtime fingerprint。产物零 diff，合规声明内容不变。
新增的失败模式只有一种：将来有人新增缺目标平台的 `collectClosure()` 调用时，`licenses:generate`
会直接报错而不是静默产出机器相关声明——这正是本 PR 想要的行为。

### 影响与回滚

- 影响范围：仅 `pnpm licenses:generate` 在参数缺失时的失败行为，以及对应测试。
- 回滚 / 降级方式：revert 本 PR 即可，无数据迁移、无状态残留、无产物需要重新生成。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
