### PR TITLE
fix(rail): 折叠 rail 面板的行菜单弹出即被自动收回

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
@@ -78,20 +78,22 @@ export function panelHasEditingFocus(): boolean {
   return ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable;
 }
 
-/** 有阻断性浮层(Radix 菜单/子菜单/选择器/确认弹窗)打开时抑制 hover 宽限收回:
- *  Radix modal 浮层会给 body 挂 pointer-events:none,面板上的指针判定全部失灵——
- *  mouseleave(relatedTarget 不匹配保活白名单)与全局 pointermove(target 退化成
- *  `<html>`)都会误判「指针已离开」,把面板连同刚弹出的菜单一起收掉(实测:行 ⋮
- *  菜单弹出即自动关闭;右键菜单因光标恰好落在菜单内容上而幸免)。浮层关闭后
- *  body 恢复,下一次 pointermove 重新接管收回。tooltip 也挂 popper wrapper,
- *  用 :has 限定菜单/列表内容,不让悬浮提示误阻收回。 */
+/** 有模态浮层打开时抑制 hover 宽限收回。判定直接读模态浮层的标志性副作用——
+ *  body 上的 pointer-events:none(Radix DismissableLayer 在 modal 时挂上):
+ *  这正是面板指针保活失灵的唯一根源——mouseleave 的 relatedTarget 不再匹配
+ *  保活白名单、全局 pointermove 的 target 退化成 `<html>`,都会误判「指针已
+ *  离开」把面板连同刚弹出的菜单一起收掉(实测:行 ⋮ 菜单弹出即自动关闭;
+ *  右键菜单因光标恰好落在菜单内容上而幸免)。该状态存在时任何「指针已离开」
+ *  信号都不可信,抑制收回是唯一安全解;状态解除后下一次 pointermove 立即恢复
+ *  正常收回语义。对比全局扫描浮层 DOM 的方案(review 三连):
+ *  - 非模态 dialog(如全局 FindInPageBar 的常驻 role="dialog")不改 body,
+ *    指针语义完好,不会被误判抑制;
+ *  - 与面板无关的模态浮层打开期间,指针信号本身已不可信,抑制悬留、浮层
+ *    关闭后由下一次 pointermove 收回,是可达的最优行为;
+ *  - 纯 inline style 读取,热路径(全局 pointermove)零选择器解析开销,
+ *    也没有 :has 的引擎兼容面。 */
 function panelHasBlockingOverlay(): boolean {
-  if (typeof document === 'undefined') return false;
-  return (
-    document.querySelector(
-      '[data-radix-popper-content-wrapper]:has([role="menu"],[role="listbox"]),[role="dialog"],[role="alertdialog"]',
-    ) != null
-  );
+  return typeof document !== 'undefined' && document.body.style.pointerEvents === 'none';
 }
 
 function suppressAutoClose(): boolean {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
@@ -78,6 +78,26 @@ export function panelHasEditingFocus(): boolean {
   return ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable;
 }
 
+/** 有阻断性浮层(Radix 菜单/子菜单/选择器/确认弹窗)打开时抑制 hover 宽限收回:
+ *  Radix modal 浮层会给 body 挂 pointer-events:none,面板上的指针判定全部失灵——
+ *  mouseleave(relatedTarget 不匹配保活白名单)与全局 pointermove(target 退化成
+ *  `<html>`)都会误判「指针已离开」,把面板连同刚弹出的菜单一起收掉(实测:行 ⋮
+ *  菜单弹出即自动关闭;右键菜单因光标恰好落在菜单内容上而幸免)。浮层关闭后
+ *  body 恢复,下一次 pointermove 重新接管收回。tooltip 也挂 popper wrapper,
+ *  用 :has 限定菜单/列表内容,不让悬浮提示误阻收回。 */
+function panelHasBlockingOverlay(): boolean {
+  if (typeof document === 'undefined') return false;
+  return (
+    document.querySelector(
+      '[data-radix-popper-content-wrapper]:has([role="menu"],[role="listbox"]),[role="dialog"],[role="alertdialog"]',
+    ) != null
+  );
+}
+
+function suppressAutoClose(): boolean {
+  return panelHasEditingFocus() || panelHasBlockingOverlay();
+}
+
 export const railPanelStore = {
   subscribe(listener: () => void): () => void {
     listeners.add(listener);
@@ -120,18 +140,25 @@ export const railPanelStore = {
     clearCloseTimer();
   },
   scheduleClose(): void {
-    if (panelHasEditingFocus()) return;
+    if (suppressAutoClose()) return;
     clearCloseTimer();
-    closeTimer = setTimeout(() => { closeTimer = null; railPanelStore.closeAll(); }, RAIL_PANEL_CLOSE_GRACE_MS);
+    closeTimer = setTimeout(() => {
+      closeTimer = null;
+      // 触发时再验一次:浮层可能在计时器排下之后、走完之前才挂载
+      // (点击 ⋮ → mouseleave 先到、菜单内容后 mount 的竞态)。
+      if (suppressAutoClose()) return;
+      railPanelStore.closeAll();
+    }, RAIL_PANEL_CLOSE_GRACE_MS);
   },
   cancelProjectClose(): void {
     clearProjectCloseTimer();
   },
   scheduleProjectClose(): void {
-    if (panelHasEditingFocus()) return;
+    if (suppressAutoClose()) return;
     clearProjectCloseTimer();
     projectCloseTimer = setTimeout(() => {
       projectCloseTimer = null;
+      if (suppressAutoClose()) return;
       if (state.openProjectKey) emit({ ...state, openProjectKey: null, projectAnchor: null });
     }, RAIL_PANEL_CLOSE_GRACE_MS);
   },


### PR DESCRIPTION
## 这次改了什么

### 摘要

折叠 rail 的项目/对话面板中,点击会话行的 ⋮ 更多菜单后,菜单会连同面板立即自动关闭(必现;右键菜单因光标恰好落在菜单内容上而偶然幸免)。

根因:Radix 模态浮层打开时给 `body` 挂 `pointer-events: none`,面板的两条指针保活判定同时失灵——面板 `mouseleave` 的 `relatedTarget` 不再匹配保活白名单、全局 `pointermove` 的 `event.target` 退化成 `<html>`——被误判为「指针已离开」,120ms 宽限后面板收回,菜单随 trigger 行卸载而关闭。

修复:`railPanelStore` 的两级收回排期(`scheduleClose` / `scheduleProjectClose`)在排期与计时器触发两个时点检测 `body` 的 `pointer-events: none`(模态浮层的标志性副作用,也正是指针信号不可信的充要条件),该状态存在时抑制自动收回;浮层关闭后由下一次 `pointermove` 恢复正常收回语义。非模态浮层(如 FindInPageBar 的常驻 `role="dialog"`)不改 `body`,不受影响。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(用户实测报告)
- 本 PR 包含:`railPanelStore` 自动收回排期的模态浮层守卫(与既有行内重命名编辑焦点守卫共用抑制入口)
- 明确不包含:面板其它交互语义、菜单自身行为
- 用户可见变化:折叠面板中行 ⋮ 菜单/右键菜单/确认弹窗可正常停留操作,不再闪关
- 是否存在 breaking change:无

### UI 变化

无视觉/布局/文案变化,仅修复收回计时的误触发,恢复既有交互设计的收回时序。

- 引用的设计规范:不涉及:命中 UI 代码路径但无视觉/交互样式/文案变化;面板 hover 宽限收回语义遵循既有实现(与 useSidebarPeek 同款 120ms 宽限),本 PR 只修正其在模态浮层期间的误触发。

## 怎么验证的

### 自动验证

```text
cd apps/desktop && npx tsc --noEmit -p tsconfig.json
结果:0 错误
cd apps/desktop && npx vitest run src/renderer/features/cc-agent
结果:Test Files 24 passed (24) / Tests 177 passed (177)
```

### 手工验证

源码版隔离沙箱(macOS,`pnpm restart:desktop:remote -- --isolated`)行为回归进行中,由报告该缺陷的用户复核:折叠 rail → hover 项目/对话面板 → 行 ⋮ 菜单弹出后稳定停留、菜单项可正常执行;FindInPageBar 打开时面板照常自动收回。

### 未执行的验证

无自动化 UI 交互测试覆盖此路径:浮层与指针事件的交互依赖真实 DOM / Radix 行为(body pointer-events、boundary events),jsdom 无法复现,以上述手工回归为准。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅折叠 rail 面板的自动收回时序;`body` 无 `pointer-events: none` 时行为与修复前逐字节一致
- 回滚 / 降级方式:revert 本 PR 即可,无数据/协议/迁移影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
