### PR TITLE
feat(desktop): IM 工作目录偏好接入标准模型选择面板,订阅来源可选(纯客户端)

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/workspaceProviderSourceStore.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspaceProviderSourceStore.test.ts
@@ -1,0 +1,60 @@
+/**
+ * 目录模型来源偏好(纯本地)的行为锁:键语义(channel + teamId + workspace)、
+ * teamId 的 null 兜底(与 prefsFor 的 multi-team 宽松语义一致)、null 写清除、
+ * 损坏文件宽容为空表。
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tmp = vi.hoisted(() => ({ dir: '' }));
+
+vi.mock('electron', () => ({
+  app: { getPath: () => tmp.dir },
+}));
+
+import {
+  getWorkspaceProviderSource,
+  listWorkspaceProviderSources,
+  setWorkspaceProviderSource,
+} from '../workspaceProviderSourceStore';
+
+describe('workspaceProviderSourceStore', () => {
+  beforeEach(() => {
+    tmp.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wps-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp.dir, { recursive: true, force: true });
+  });
+
+  it('写读一条来源偏好;不同渠道/目录互不串', () => {
+    setWorkspaceProviderSource('telegram', null, 'chat', 'anthropic');
+    setWorkspaceProviderSource('slack', null, 'chat', 'openai');
+    expect(getWorkspaceProviderSource('telegram', null, 'chat')).toBe('anthropic');
+    expect(getWorkspaceProviderSource('slack', null, 'chat')).toBe('openai');
+    expect(getWorkspaceProviderSource('telegram', null, 'repo')).toBeNull();
+  });
+
+  it('teamId 精确匹配优先, null 行兜底(multi-team 宽松语义)', () => {
+    setWorkspaceProviderSource('slack', null, 'repo', 'anthropic');
+    setWorkspaceProviderSource('slack', 'T1', 'repo', 'openai');
+    expect(getWorkspaceProviderSource('slack', 'T1', 'repo')).toBe('openai');
+    expect(getWorkspaceProviderSource('slack', 'T2', 'repo')).toBe('anthropic');
+  });
+
+  it('providerId=null 清除条目', () => {
+    setWorkspaceProviderSource('telegram', null, 'chat', 'anthropic');
+    setWorkspaceProviderSource('telegram', null, 'chat', null);
+    expect(getWorkspaceProviderSource('telegram', null, 'chat')).toBeNull();
+    expect(listWorkspaceProviderSources()).toEqual([]);
+  });
+
+  it('损坏文件宽容为空表, 下次写入覆盖', () => {
+    fs.writeFileSync(path.join(tmp.dir, 'hook-workspace-provider-source.json'), '{broken');
+    expect(listWorkspaceProviderSources()).toEqual([]);
+    setWorkspaceProviderSource('telegram', null, 'chat', 'anthropic');
+    expect(getWorkspaceProviderSource('telegram', null, 'chat')).toBe('anthropic');
+  });
+});

--- a/apps/desktop/src/main/hook-control/__tests__/workspaceProviderSourceStore.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspaceProviderSourceStore.test.ts
@@ -58,4 +58,20 @@ describe('workspaceProviderSourceStore', () => {
     setWorkspaceProviderSource('telegram', null, 'chat', 'anthropic');
     expect(getWorkspaceProviderSource('telegram', null, 'chat')).toBe('anthropic');
   });
+
+  it('读侧与 IPC 同规过滤不合规条目(外部写入异常值不透传)', () => {
+    fs.writeFileSync(
+      path.join(tmp.dir, 'hook-workspace-provider-source.json'),
+      JSON.stringify({
+        entries: [
+          { channel: 'telegram', teamId: null, workspace: 'chat', providerId: 'anthropic' },
+          { channel: 'telegram', teamId: null, workspace: 'bad alias!', providerId: 'x' },
+          { channel: 'telegram', teamId: null, workspace: 'ok', providerId: 'p'.repeat(200) },
+        ],
+      }),
+    );
+    expect(listWorkspaceProviderSources()).toEqual([
+      { channel: 'telegram', teamId: null, workspace: 'chat', providerId: 'anthropic' },
+    ]);
+  });
 });

--- a/apps/desktop/src/main/hook-control/__tests__/workspaceProviderSourceStore.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspaceProviderSourceStore.test.ts
@@ -11,8 +11,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const tmp = vi.hoisted(() => ({ dir: '' }));
 
-vi.mock('electron', () => ({
-  app: { getPath: () => tmp.dir },
+// owner-scoped 路径打桩到临时目录(真实实现依赖 electron app 与登录态)。
+vi.mock('../../im/ownerScopedStorage.js', () => ({
+  ownerScopedImUserDataPath: (...parts: string[]) => path.join(tmp.dir, ...parts),
 }));
 
 import {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -82,6 +82,11 @@ export interface HookRunRequest {
    * 落侧边栏「对话」分组而非按目录聚成项目。仅 isNew 时有意义。
    */
   workspaceKind?: 'dialogue';
+  /**
+   * 本次派发的目录别名(内置「对话」= chat)—— runner 据此查本地的目录模型
+   * 来源偏好(workspaceProviderSourceStore)。缺省 = 老 server 未带 workspace。
+   */
+  workspaceAlias?: string;
   title: string | null;
   prompt: string;
   /** 本次派发携带的入站附件(base64); 无则省略。runner 解码落盘后喂给 agent。 */
@@ -699,6 +704,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         effort,
         permissionMode,
         ...(isChat ? { workspaceKind: 'dialogue' as const } : {}),
+        ...(payload.workspace ? { workspaceAlias: payload.workspace } : {}),
         title: buildHookSessionTitle(
           providerName,
           payload.prompt,

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -46,6 +46,7 @@ import {
   HOOK_CONTROL_EVENT,
   HOOK_CONTROL_INVOKE,
   HOOK_WORKSPACE_ALIAS_RE,
+  HOOK_WORKSPACE_PROVIDER_SOURCE_MAX_ENTRIES,
   type HookPrefsPatch,
   type HookPrefsView,
   type ProviderPrefsView,
@@ -731,9 +732,28 @@ export function registerHookControlIpc(): void {
       if (providerId !== null && providerId.length > 128) {
         throwIpcError('INVALID_PARAMS', 'providerId too long');
       }
-      return {
-        entries: setWorkspaceProviderSource(channel, teamId, workspace, providerId),
-      };
+      // 条目总量上限(codex review): 键合法性校验挡不住海量唯一 teamId 的无限
+      // 追加 —— 新增(非替换/删除)且已达上限时拒绝。按精确键判新增(不能用
+      // getWorkspaceProviderSource, 它的 teamId null 兜底会把新 team 误判为已存在)。
+      const existing = listWorkspaceProviderSources();
+      const isReplace = existing.some(
+        (e) => e.channel === channel && e.teamId === teamId && e.workspace === workspace,
+      );
+      if (
+        providerId !== null &&
+        !isReplace &&
+        existing.length >= HOOK_WORKSPACE_PROVIDER_SOURCE_MAX_ENTRIES
+      ) {
+        throwIpcError('INVALID_PARAMS', 'too many workspace provider source entries');
+      }
+      const entries = setWorkspaceProviderSource(channel, teamId, workspace, providerId);
+      // 多窗口同步(codex review): 会话副窗也能开设置页, 写后全窗口广播全量条目。
+      for (const w of BrowserWindow.getAllWindows()) {
+        if (!w.isDestroyed() && isAppContentWindow(w)) {
+          w.webContents.send(HOOK_CONTROL_EVENT.WORKSPACE_PROVIDER_SOURCE_CHANGED, entries);
+        }
+      }
+      return { entries };
     },
   );
 

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -28,6 +28,10 @@ import { getModelVisibilityOverride } from '../maker-host/model-visibility-mirro
 import { WorktreeManager } from '../worktree/index.js';
 import { prepareHandoffWorktree } from '../maker-ipc/handoffWorktree.js';
 import { throwIpcError, requireObject, requireString } from '../utils/ipcValidate.js';
+import {
+  listWorkspaceProviderSources,
+  setWorkspaceProviderSource,
+} from './workspaceProviderSourceStore.js';
 import { patchSessionMetaInDb } from '../localDb/ipc/sessions.js';
 import {
   dialogueWorkspaceRootDir,
@@ -693,6 +697,33 @@ export function registerHookControlIpc(): void {
       throwHookPrefsError(err);
     }
   });
+
+  // 工作目录模型来源偏好: 纯本地文件, 不经 WS(来源是纯客户端维度, server 零感知)。
+  registerTrustedHookControlHandler(
+    HOOK_CONTROL_INVOKE.WORKSPACE_PROVIDER_SOURCE_GET,
+    async () => ({ entries: listWorkspaceProviderSources() }),
+  );
+
+  registerTrustedHookControlHandler(
+    HOOK_CONTROL_INVOKE.WORKSPACE_PROVIDER_SOURCE_SET,
+    async (_e, payload) => {
+      const p = requireObject(payload);
+      const channel = requireString(p.channel, 'channel');
+      if (channel !== 'slack' && channel !== 'telegram') {
+        throwIpcError('INVALID_PARAMS', 'channel must be slack or telegram');
+      }
+      const workspace = requireString(p.workspace, 'workspace');
+      const teamId =
+        p.teamId === undefined || p.teamId === null ? null : requireString(p.teamId, 'teamId');
+      const providerId =
+        p.providerId === undefined || p.providerId === null
+          ? null
+          : requireString(p.providerId, 'providerId');
+      return {
+        entries: setWorkspaceProviderSource(channel, teamId, workspace, providerId),
+      };
+    },
+  );
 
   // Account teardown is orchestrated before its DB closes. This listener is a
   // fail-closed backstop for signed-out/local sessions; activation waits for

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -746,7 +746,18 @@ export function registerHookControlIpc(): void {
       ) {
         throwIpcError('INVALID_PARAMS', 'too many workspace provider source entries');
       }
-      const entries = setWorkspaceProviderSource(channel, teamId, workspace, providerId);
+      // fs 异常在 IPC 边界翻译(codex review): 只读盘/满盘/rename 失败的原始
+      // 异常含 owner-scoped 绝对路径, 不得未脱敏穿透给 renderer;统一走
+      // throwIpcError 协议给稳定错误码, 细节留 main 日志。
+      let entries: ReturnType<typeof setWorkspaceProviderSource>;
+      try {
+        entries = setWorkspaceProviderSource(channel, teamId, workspace, providerId);
+      } catch (err) {
+        log.warn(
+          `workspace provider source write failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        throwIpcError('INTERNAL', 'failed to persist workspace provider source');
+      }
       // 多窗口同步(codex review): 会话副窗也能开设置页, 写后全窗口广播全量条目。
       for (const w of BrowserWindow.getAllWindows()) {
         if (!w.isDestroyed() && isAppContentWindow(w)) {

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -45,6 +45,7 @@ import { ownerScopedUserDataPath } from '../appSessionState.js';
 import {
   HOOK_CONTROL_EVENT,
   HOOK_CONTROL_INVOKE,
+  HOOK_WORKSPACE_ALIAS_RE,
   type HookPrefsPatch,
   type HookPrefsView,
   type ProviderPrefsView,
@@ -712,13 +713,24 @@ export function registerHookControlIpc(): void {
       if (channel !== 'slack' && channel !== 'telegram') {
         throwIpcError('INVALID_PARAMS', 'channel must be slack or telegram');
       }
+      // 输入设界(codex review): 即使 renderer 被攻破, 也不允许任意长度/格式的键
+      // 无限追加条目撑爆本地文件 —— workspace 按别名正则(与 prefs 同规), 其余限长。
       const workspace = requireString(p.workspace, 'workspace');
+      if (!HOOK_WORKSPACE_ALIAS_RE.test(workspace)) {
+        throwIpcError('INVALID_PARAMS', 'workspace must match the alias format');
+      }
       const teamId =
         p.teamId === undefined || p.teamId === null ? null : requireString(p.teamId, 'teamId');
+      if (teamId !== null && teamId.length > 64) {
+        throwIpcError('INVALID_PARAMS', 'teamId too long');
+      }
       const providerId =
         p.providerId === undefined || p.providerId === null
           ? null
           : requireString(p.providerId, 'providerId');
+      if (providerId !== null && providerId.length > 128) {
+        throwIpcError('INVALID_PARAMS', 'providerId too long');
+      }
       return {
         entries: setWorkspaceProviderSource(channel, teamId, workspace, providerId),
       };

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -157,10 +157,12 @@ async function resolveNewSessionConfig(
   const preferredProviderId = workdirProviderId ?? resolved.providerId;
 
   // 目录可用时始终把最终模型收敛到一个真实已连接、且确实提供它的来源。
-  // 目录读取失败才保留旧行为(草稿来源原样透传),避免临时目录故障阻断 hook。
+  // 目录读取失败才保留旧行为(**只**透传草稿来源, 不透传目录级来源 —— 后者未经
+  // 收窄校验, 降级窗口直接钉给会话会绕过连接态/供给校验; 数据不足不猜, 维持
+  // 加目录来源之前的降级语义, codex review)。
   const providerId = providers
     ? effectiveSourceIdForModel(providers, preferredProviderId, resolved.model, resolved.agentKind)
-    : preferredProviderId;
+    : resolved.providerId;
   return { ...resolved, providerId };
 }
 

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -77,6 +77,7 @@ import { resolveSafe as resolveCindyMediaUrl } from '../cindy-media/blobStore.js
 import { ingestMedia, supportedMime as isCindyMediaMime } from '../cindy-media/ingest.js';
 import { worktreeStore, WorktreeManager } from '../worktree/index.js';
 import { readImDefaultSettings } from '../im/defaultSettingsStore.js';
+import { getWorkspaceProviderSource } from './workspaceProviderSourceStore.js';
 import { getDesktopProviderService } from '../maker-host/createDesktopProviderService.js';
 import { getModelVisibilityOverride } from '../maker-host/model-visibility-mirror.js';
 import {
@@ -114,6 +115,7 @@ async function resolveNewSessionConfig(
   },
   log: { warn(msg: string): void },
   sourceIm?: string | null,
+  workspaceCtx?: { alias: string | undefined; teamId: string | null },
 ): Promise<ResolvedHookSessionConfig> {
   let providers: ProviderView[] | null = null;
   try {
@@ -145,11 +147,20 @@ async function resolveNewSessionConfig(
     overrides,
   );
 
+  // 目录级来源偏好(纯本地, 用户在工作目录映射行显式选的来源)优先于草稿默认来源。
+  const channel =
+    sourceIm === 'telegram' ? ('telegram' as const) : sourceIm === 'slack' ? ('slack' as const) : null;
+  const workdirProviderId =
+    channel !== null && workspaceCtx?.alias
+      ? getWorkspaceProviderSource(channel, workspaceCtx.teamId, workspaceCtx.alias)
+      : null;
+  const preferredProviderId = workdirProviderId ?? resolved.providerId;
+
   // 目录可用时始终把最终模型收敛到一个真实已连接、且确实提供它的来源。
   // 目录读取失败才保留旧行为(草稿来源原样透传),避免临时目录故障阻断 hook。
   const providerId = providers
-    ? effectiveSourceIdForModel(providers, resolved.providerId, resolved.model, resolved.agentKind)
-    : resolved.providerId;
+    ? effectiveSourceIdForModel(providers, preferredProviderId, resolved.model, resolved.agentKind)
+    : preferredProviderId;
   return { ...resolved, providerId };
 }
 
@@ -350,6 +361,7 @@ export function createMakerHookSessionRunner(deps: {
             },
             log,
             req.source?.im,
+            { alias: req.workspaceAlias, teamId: req.source?.teamId ?? null },
           )
         : null;
       let workingDir = req.workingDir;

--- a/apps/desktop/src/main/hook-control/workspaceProviderSourceStore.ts
+++ b/apps/desktop/src/main/hook-control/workspaceProviderSourceStore.ts
@@ -17,7 +17,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { HookWorkspaceProviderSourceEntry } from '../../shared/hookControlIpc.js';
+import {
+  HOOK_WORKSPACE_ALIAS_RE,
+  type HookWorkspaceProviderSourceEntry,
+} from '../../shared/hookControlIpc.js';
 import { ownerScopedImUserDataPath } from '../im/ownerScopedStorage.js';
 
 export type HookProviderChannel = HookWorkspaceProviderSourceEntry['channel'];
@@ -37,16 +40,19 @@ function filePath(): string {
   return ownerScopedImUserDataPath(FILE_NAME);
 }
 
+// 读侧与 IPC 写侧同规收紧(Copilot review):文件被手工改坏/外部写入异常值时,
+// 不合规条目在读取即被过滤,不透传 renderer、不参与派发查找。
 function isEntry(raw: unknown): raw is WorkspaceProviderSourceEntry {
   if (!raw || typeof raw !== 'object') return false;
   const r = raw as Record<string, unknown>;
   return (
     (r.channel === 'slack' || r.channel === 'telegram') &&
-    (r.teamId === null || typeof r.teamId === 'string') &&
+    (r.teamId === null || (typeof r.teamId === 'string' && r.teamId.length > 0 && r.teamId.length <= 64)) &&
     typeof r.workspace === 'string' &&
-    r.workspace.length > 0 &&
+    HOOK_WORKSPACE_ALIAS_RE.test(r.workspace) &&
     typeof r.providerId === 'string' &&
-    r.providerId.length > 0
+    r.providerId.length > 0 &&
+    r.providerId.length <= 128
   );
 }
 

--- a/apps/desktop/src/main/hook-control/workspaceProviderSourceStore.ts
+++ b/apps/desktop/src/main/hook-control/workspaceProviderSourceStore.ts
@@ -1,0 +1,115 @@
+/**
+ * hook-control/workspaceProviderSourceStore.ts
+ * ---------------------------------------------------------------------------
+ * IM hook 工作目录(含内置「对话」)的**模型来源(providerId)偏好** —— 纯客户端数据。
+ *
+ * 为什么单独存本地而不进 server prefs 表:来源是纯客户端维度(供应商凭证、
+ * 连接态、目录、派发全在客户端,server 对它零感知,Slack /model 卡也不需要
+ * 编辑它)。server prefs 继续只存 model/effort/agentKind/permissionMode 四字段
+ * 服务卡片展示;本表按 (channel, teamId, workspace) 记来源,派发合成时与
+ * server 显式 model 组合,再经 effectiveSourceIdForModel 收窄到真实已连接来源
+ * (来源断开/不提供该模型时自动回落,不会拼出不可能路由)。
+ *
+ * 持久化 <userData>/hook-workspace-provider-source.json —— 属配置而非业务数据,
+ * 与 slack-hook.json 同级同模式(原子写防半截文件);不含任何凭证。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+
+export type HookProviderChannel = 'slack' | 'telegram';
+
+export interface WorkspaceProviderSourceEntry {
+  channel: HookProviderChannel;
+  /** Slack multi-team 的归属 team;Telegram / 单绑定为 null。 */
+  teamId: string | null;
+  /** 目录别名(内置「对话」= chat)。 */
+  workspace: string;
+  providerId: string;
+}
+
+interface StoreFile {
+  entries: WorkspaceProviderSourceEntry[];
+}
+
+const FILE_NAME = 'hook-workspace-provider-source.json';
+
+function filePath(): string {
+  return path.join(app.getPath('userData'), FILE_NAME);
+}
+
+function isEntry(raw: unknown): raw is WorkspaceProviderSourceEntry {
+  if (!raw || typeof raw !== 'object') return false;
+  const r = raw as Record<string, unknown>;
+  return (
+    (r.channel === 'slack' || r.channel === 'telegram') &&
+    (r.teamId === null || typeof r.teamId === 'string') &&
+    typeof r.workspace === 'string' &&
+    r.workspace.length > 0 &&
+    typeof r.providerId === 'string' &&
+    r.providerId.length > 0
+  );
+}
+
+function readFileEntries(fp: string): WorkspaceProviderSourceEntry[] {
+  try {
+    const raw: unknown = JSON.parse(fs.readFileSync(fp, 'utf-8'));
+    const entries = (raw as StoreFile | null)?.entries;
+    if (!Array.isArray(entries)) return [];
+    return entries.filter(isEntry);
+  } catch {
+    // 文件不存在 / 损坏 → 空表(损坏文件在下次写入时被完整覆盖)
+    return [];
+  }
+}
+
+function writeFileEntries(fp: string, entries: WorkspaceProviderSourceEntry[]): void {
+  const tmp = `${fp}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify({ entries } satisfies StoreFile, null, 2), 'utf-8');
+  fs.renameSync(tmp, fp);
+}
+
+const sameKey = (
+  e: WorkspaceProviderSourceEntry,
+  channel: HookProviderChannel,
+  teamId: string | null,
+  workspace: string,
+): boolean => e.channel === channel && e.teamId === teamId && e.workspace === workspace;
+
+/** 全量条目(设置页一次拉取)。 */
+export function listWorkspaceProviderSources(): WorkspaceProviderSourceEntry[] {
+  return readFileEntries(filePath());
+}
+
+/**
+ * 某 (channel, teamId, workspace) 的来源偏好。
+ * teamId 精确匹配优先,null 行兜底 —— 与 prefsFor 的 multi-team 宽松语义一致。
+ */
+export function getWorkspaceProviderSource(
+  channel: HookProviderChannel,
+  teamId: string | null,
+  workspace: string,
+): string | null {
+  const entries = readFileEntries(filePath());
+  return (
+    entries.find((e) => sameKey(e, channel, teamId, workspace))?.providerId ??
+    entries.find((e) => sameKey(e, channel, null, workspace))?.providerId ??
+    null
+  );
+}
+
+/** 写/清一条来源偏好(providerId = null 删除条目);返回更新后的全量条目。 */
+export function setWorkspaceProviderSource(
+  channel: HookProviderChannel,
+  teamId: string | null,
+  workspace: string,
+  providerId: string | null,
+): WorkspaceProviderSourceEntry[] {
+  const fp = filePath();
+  const rest = readFileEntries(fp).filter((e) => !sameKey(e, channel, teamId, workspace));
+  const next =
+    providerId === null ? rest : [...rest, { channel, teamId, workspace, providerId }];
+  writeFileEntries(fp, next);
+  return next;
+}

--- a/apps/desktop/src/main/hook-control/workspaceProviderSourceStore.ts
+++ b/apps/desktop/src/main/hook-control/workspaceProviderSourceStore.ts
@@ -16,18 +16,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { app } from 'electron';
 
-export type HookProviderChannel = 'slack' | 'telegram';
+import type { HookWorkspaceProviderSourceEntry } from '../../shared/hookControlIpc.js';
+import { ownerScopedImUserDataPath } from '../im/ownerScopedStorage.js';
 
-export interface WorkspaceProviderSourceEntry {
-  channel: HookProviderChannel;
-  /** Slack multi-team 的归属 team;Telegram / 单绑定为 null。 */
-  teamId: string | null;
-  /** 目录别名(内置「对话」= chat)。 */
-  workspace: string;
-  providerId: string;
-}
+export type HookProviderChannel = HookWorkspaceProviderSourceEntry['channel'];
+/** 持久化条目形状 = IPC 契约形状(shared 单一来源, 防 main/renderer 漂移)。 */
+export type WorkspaceProviderSourceEntry = HookWorkspaceProviderSourceEntry;
 
 interface StoreFile {
   entries: WorkspaceProviderSourceEntry[];
@@ -35,8 +30,11 @@ interface StoreFile {
 
 const FILE_NAME = 'hook-workspace-provider-source.json';
 
+// owner-scoped(owners/<hash>/…):来源偏好属账号数据 —— 放 userData 根会让
+// 同机第二个账号消费第一个账号留下的订阅来源(Greptile/codex review 同点)。
+// 新文件无 legacy 迁移负担,直接落 scoped 路径。
 function filePath(): string {
-  return path.join(app.getPath('userData'), FILE_NAME);
+  return ownerScopedImUserDataPath(FILE_NAME);
 }
 
 function isEntry(raw: unknown): raw is WorkspaceProviderSourceEntry {
@@ -65,6 +63,7 @@ function readFileEntries(fp: string): WorkspaceProviderSourceEntry[] {
 }
 
 function writeFileEntries(fp: string, entries: WorkspaceProviderSourceEntry[]): void {
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
   const tmp = `${fp}.tmp`;
   fs.writeFileSync(tmp, JSON.stringify({ entries } satisfies StoreFile, null, 2), 'utf-8');
   fs.renameSync(tmp, fp);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3120,6 +3120,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
       patch: Record<string, string | null>,
     ): Promise<{ prefs: unknown }> =>
       ipcRenderer.invoke('maker:hook-control:provider-prefs-set', { workspace, patch }),
+    // 工作目录模型来源偏好(纯本地, 不经 WS; providerId=null 清除条目)
+    getWorkspaceProviderSources: (): Promise<{ entries: unknown }> =>
+      ipcRenderer.invoke('maker:hook-control:workspace-provider-source-get'),
+    setWorkspaceProviderSource: (payload: {
+      channel: 'slack' | 'telegram';
+      teamId: string | null;
+      workspace: string;
+      providerId: string | null;
+    }): Promise<{ entries: unknown }> =>
+      ipcRenderer.invoke('maker:hook-control:workspace-provider-source-set', payload),
     onPrefsChanged: fanOutHookControlPrefs,
     onProviderPrefsChanged: fanOutHookControlProviderPrefs,
     onStatusChanged: fanOutHookControlStatus,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -405,6 +405,10 @@ const fanOutHookControlPrefs = createIpcFanOut('maker:hook-control:prefs-changed
 const fanOutHookControlProviderPrefs = createIpcFanOut(
   'maker:hook-control:provider-prefs-changed',
 );
+// 目录模型来源偏好全量推送(本地写入后广播, 多窗口设置页同步)。
+const fanOutHookControlWorkspaceProviderSource = createIpcFanOut(
+  'maker:hook-control:workspace-provider-source-changed',
+);
 
 // ─── Maker Core 一阶段重构（新链路）── 与 cc-agent:* / codex:* 双轨并行 ─────
 const fanOutMakerEvent = createIpcFanOut('maker:event');
@@ -3132,6 +3136,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('maker:hook-control:workspace-provider-source-set', payload),
     onPrefsChanged: fanOutHookControlPrefs,
     onProviderPrefsChanged: fanOutHookControlProviderPrefs,
+    onWorkspaceProviderSourcesChanged: fanOutHookControlWorkspaceProviderSource,
     onStatusChanged: fanOutHookControlStatus,
   },
 

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -251,10 +251,15 @@ export function useHookWorkspacePrefs(
         if (active) setImDefaults({ agentKind: state.agentKind, agents: state.agents });
       })
       .catch(() => {});
+    // 初次拉取同样受 latest-wins 守卫(Copilot review): 回复未归时若已收到其它
+    // 窗口的写入广播(revision 已前进), 旧快照不得回滚新状态。
+    const initialSourcesRevision = providerSourceRevisionRef.current;
     void window.electronAPI.hookControl
       .getWorkspaceProviderSources()
       .then((res) => {
-        if (active) setProviderSources(res.entries);
+        if (active && providerSourceRevisionRef.current === initialSourcesRevision) {
+          setProviderSources(res.entries);
+        }
       })
       .catch(() => {});
     // 多窗口同步(codex review): 会话副窗也能开设置页, 其它窗口写入时以广播的

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -389,6 +389,13 @@ export function useHookWorkspacePrefs(
             );
       void request
         .then((res) => {
+          // 来源落地在快照守卫**之前**(codex review): invoke 成功 = 远端已确认
+          // 本次 (model, effort) 写入 —— 这一事实不因「更新的快照先到」而失效;
+          // 守卫只管下方 UI 快照是否回填,若来源也被守卫跳过(prefs 回执经广播
+          // 先到的正常时序), 会留下「新模型 + 旧来源」的持久分裂。
+          if (alsoProviderSource !== undefined) {
+            applyProviderSource(workspace, alsoProviderSource);
+          }
           if (revision !== fetchRevisionRef.current) return;
           const nextPrefs: HookPrefsView | ProviderPrefsView = res.prefs;
           if (
@@ -403,9 +410,6 @@ export function useHookWorkspacePrefs(
           fetchRevisionRef.current += 1;
           setPrefsView(nextPrefs);
           setLoadError(null);
-          if (alsoProviderSource !== undefined) {
-            applyProviderSource(workspace, alsoProviderSource);
-          }
         })
         .catch((err: unknown) => {
           if (revision !== fetchRevisionRef.current) return;

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -110,7 +110,12 @@ export interface HookWorkspacePrefsState {
   retry: (() => void) | null;
   /** 桌面新会话默认设置(解析「当前生效默认值」的数据源; 未就绪为 null)。 */
   imDefaults: ImDefaultsLike | null;
-  applyPatch: (workspace: string, patch: HookPrefsPatch) => void;
+  /** alsoProviderSource: 远端写成功后串联落本地来源(undefined = 不动来源)。 */
+  applyPatch: (
+    workspace: string,
+    patch: HookPrefsPatch,
+    alsoProviderSource?: string | null,
+  ) => void;
   /** (multi-team)可用绑定清单(未 displaced); 单绑定/老 server 时 ≤1 条。 */
   teams: Array<{ teamId: string; teamName: string | null }>;
   /** 当前偏好归属 team(teams 非空时必有值; 选中项失效自动回落首个)。 */
@@ -325,13 +330,19 @@ export function useHookWorkspacePrefs(
     [providerSources, provider, multiTeam, selectedTeamId],
   );
 
+  // latest-wins 守卫(Copilot review): 快速连选时, 较慢的旧回复不得覆盖较新的选择。
+  const providerSourceRevisionRef = useRef(0);
   const applyProviderSource = useCallback(
     (alias: string, providerId: string | null) => {
       const teamId = multiTeam ? selectedTeamId : null;
+      const revision = ++providerSourceRevisionRef.current;
       void window.electronAPI.hookControl
         .setWorkspaceProviderSource({ channel: provider, teamId, workspace: alias, providerId })
-        .then((res) => setProviderSources(res.entries))
+        .then((res) => {
+          if (revision === providerSourceRevisionRef.current) setProviderSources(res.entries);
+        })
         .catch((err: unknown) => {
+          if (revision !== providerSourceRevisionRef.current) return;
           toast.error(
             extractIpcError(err)?.message ?? t('settings.tina.prefs.toast.saveFailed'),
           );
@@ -341,7 +352,12 @@ export function useHookWorkspacePrefs(
   );
 
   const applyPatch = useCallback(
-    (workspace: string, patch: HookPrefsPatch) => {
+    // alsoProviderSource(可选): 远端 model/effort 写**成功后**再落本地来源 ——
+    // 两个持久面串联而非并行(Greptile/codex review: 并行 fire-and-forget 会在
+    // 一半失败时留下「新来源配旧模型」的分裂态)。顺序选「先远端后本地」:远端
+    // 失败 → 整体失败, 来源不动, 状态与操作前一致;本地失败(概率远小)→ 旧来源
+    // 配新模型, 派发端 effectiveSourceIdForModel 收窄兜底, 行为等于改前语义。
+    (workspace: string, patch: HookPrefsPatch, alsoProviderSource?: string | null) => {
       // A server push, binding change, retry, or newer mutation must win over
       // this response. Otherwise a delayed set reply can roll the UI back to
       // an older provider snapshot and clear another mutation's pending state.
@@ -372,6 +388,9 @@ export function useHookWorkspacePrefs(
           fetchRevisionRef.current += 1;
           setPrefsView(nextPrefs);
           setLoadError(null);
+          if (alsoProviderSource !== undefined) {
+            applyProviderSource(workspace, alsoProviderSource);
+          }
         })
         .catch((err: unknown) => {
           if (revision !== fetchRevisionRef.current) return;
@@ -384,7 +403,7 @@ export function useHookWorkspacePrefs(
           if (mutationRevision === mutationRevisionRef.current) setPendingWs(null);
         });
     },
-    [fetchPrefs, t, multiTeam, provider, selectedTeamId],
+    [fetchPrefs, t, multiTeam, provider, selectedTeamId, applyProviderSource],
   );
 
   const bound = providerBindingConfirmed && activePrefsView?.bound === true;
@@ -560,9 +579,24 @@ export function WorkspacePrefsEditor({
             setFast: setProviderModelFast,
           }}
           currentProviderId={state.providerSourceFor(alias)}
-          onProviderChange={(providerId, modelId) => {
-            state.applyProviderSource(alias, providerId);
-            if (modelId) applyModel(modelId);
+          // 分段行原子选择:model/effort 走远端 prefs, 成功后来源落本地(串联,
+          // 见 applyPatch 的 alsoProviderSource 注释)。effort 用行上解析值(含
+          // hover 改过的全局预设记忆, codex review), 不足时 patch 已按模型校准。
+          onProviderChange={(providerId, modelId, rowEffort) => {
+            if (eff.agentKind.id === null) return;
+            const caps = toPrefsCaps(effAgentCaps);
+            if (modelId) {
+              const patch = patchForModelChange(eff.agentKind.id, modelId, prefs, caps);
+              if (
+                rowEffort &&
+                caps?.models.find((m) => m.id === modelId)?.efforts.includes(rowEffort)
+              ) {
+                patch.effort = rowEffort;
+              }
+              state.applyPatch(alias, patch, providerId);
+            } else {
+              state.applyProviderSource(alias, providerId);
+            }
           }}
           onModelChange={applyModel}
           onEffortChange={(next) => {

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -8,9 +8,10 @@
  * 定稿: 这里曾私搭一套裸下拉, 露出 'claude-code' 原始 id、自己拼一遍可选模型
  * 清单、effort 直接显示未经 i18n 的 low/medium/high):
  *   - agent   -> VendorSegmentedSwitcher(品牌分段 pill, 与首页新建对话同一个)
- *   - 模型    -> ModelSelector 的 field trigger(单栏 flat, 不开供应商分段 —— 偏好表
- *                没有 providerId 字段, 分段会造成「选 A 落 B」, 详见组件内注释);
- *                可选清单、骨折版区分、effort 档位与显示名全部由它内部给出
+ *   - 模型    -> ModelSelector 的 field trigger, **composer 同款全功能形态**(供应商
+ *                分段/订阅来源/推理强度全开; 2026-07 用户定稿基准: 全软件一个模型
+ *                选择面板, 处处同行为, 差异只有样式)。来源落本地
+ *                workspaceProviderSourceStore, model/effort 照旧走 server prefs
  *   - 权限    -> PermissionSelector 的 field trigger
  * 思考强度不再是独立控件 —— 它并进模型 trigger 显示成「模型名 · 档位」, 与
  * 隔壁 ImDefaultSettingsSection(IM 新会话默认)和会话输入框成一套。
@@ -48,10 +49,18 @@ import { ModelSelector } from '@/components/new-chat/ModelSelector';
 import { PermissionSelector } from '@/components/new-chat/PermissionSelector';
 import { VendorSegmentedSwitcher } from '@/components/new-chat/VendorSegmentedSwitcher';
 import type { MakerVendor } from '@/lib/ccAgent.types';
+import {
+  getProviderModelEffort,
+  setProviderModelChoice,
+  setProviderModelEffort,
+  getProviderModelFast,
+  setProviderModelFast,
+} from '@/state/providerModelMemory';
 import type {
   HookPrefsPatch,
   HookPrefsView,
   HookWorkspacePrefs,
+  HookWorkspaceProviderSourceEntry,
   ProviderPrefsView,
   SlackHookView,
 } from '../../../shared/hookControlIpc';
@@ -87,6 +96,10 @@ function toPrefsCaps(caps: AgentCapabilities | null): PrefsAgentCaps | null {
 export interface HookWorkspacePrefsState {
   /** 按别名查该目录偏好(无行返回全 null 缺省; multi-team 下按选中 team 过滤)。 */
   prefsFor: (alias: string) => HookWorkspacePrefs;
+  /** 该目录的模型来源偏好(纯本地; null = 未设置, 跟随默认路由)。 */
+  providerSourceFor: (alias: string) => string | null;
+  /** 写/清该目录的模型来源偏好(providerId = null 清除)。 */
+  applyProviderSource: (alias: string, providerId: string | null) => void;
   /** 是否可编辑(已连接 + 已绑定 + 快照可用)。 */
   editable: boolean;
   /** 写入在途的目录别名(该卡片下拉禁用)。 */
@@ -127,6 +140,8 @@ export function useHookWorkspacePrefs(
   const [loadError, setLoadError] = useState<'unavailable' | null>(null);
   const [pendingWs, setPendingWs] = useState<string | null>(null);
   const [imDefaults, setImDefaults] = useState<ImDefaultsLike | null>(null);
+  // 目录模型来源偏好(纯本地文件, 不经 WS): 全量条目一次拉取, 写后用返回值刷新。
+  const [providerSources, setProviderSources] = useState<HookWorkspaceProviderSourceEntry[]>([]);
   const telegramBindingId =
     provider === 'telegram' && hook?.telegram.binding?.state === 'confirmed'
       ? hook.telegram.binding.bindingId
@@ -228,6 +243,12 @@ export function useHookWorkspacePrefs(
         if (active) setImDefaults({ agentKind: state.agentKind, agents: state.agents });
       })
       .catch(() => {});
+    void window.electronAPI.hookControl
+      .getWorkspaceProviderSources()
+      .then((res) => {
+        if (active) setProviderSources(res.entries);
+      })
+      .catch(() => {});
     return () => {
       active = false;
       fetchRevisionRef.current += 1;
@@ -289,6 +310,34 @@ export function useHookWorkspacePrefs(
       return entries.find((e) => e.workspace === alias) ?? emptyPrefs(alias);
     },
     [activePrefsView, multiTeam, selectedTeamId],
+  );
+
+  // 目录来源偏好: teamId 精确匹配优先、null 行兜底 —— 与 prefsFor 同语义。
+  const providerSourceFor = useCallback(
+    (alias: string): string | null => {
+      const teamId = multiTeam ? selectedTeamId : null;
+      const match = (want: string | null) =>
+        providerSources.find(
+          (e) => e.channel === provider && e.teamId === want && e.workspace === alias,
+        )?.providerId ?? null;
+      return match(teamId) ?? (teamId !== null ? match(null) : null);
+    },
+    [providerSources, provider, multiTeam, selectedTeamId],
+  );
+
+  const applyProviderSource = useCallback(
+    (alias: string, providerId: string | null) => {
+      const teamId = multiTeam ? selectedTeamId : null;
+      void window.electronAPI.hookControl
+        .setWorkspaceProviderSource({ channel: provider, teamId, workspace: alias, providerId })
+        .then((res) => setProviderSources(res.entries))
+        .catch((err: unknown) => {
+          toast.error(
+            extractIpcError(err)?.message ?? t('settings.tina.prefs.toast.saveFailed'),
+          );
+        });
+    },
+    [provider, multiTeam, selectedTeamId, t],
   );
 
   const applyPatch = useCallback(
@@ -354,6 +403,8 @@ export function useHookWorkspacePrefs(
 
   return {
     prefsFor,
+    providerSourceFor,
+    applyProviderSource,
     editable: connected && bound && loadError === null,
     pendingWs,
     hint,
@@ -471,23 +522,13 @@ export function WorkspacePrefsEditor({
           }}
         />
       </PrefsField>
-      {/* 模型 + 思考强度同一个控件: trigger 显示「模型名 · 档位」, 展开后行内改档。
-
-          **刻意不开供应商分段**(不传 currentProviderId / onProviderChange), 即单栏
-          flat 列表 —— 这是不做「兑现不了的承诺」, 不是偷懒:
-          IM hook 的偏好表(server 侧)只有 model id 字段, **没有 providerId**。开分段
-          会按 (供应商, 模型) 列出多行, 但选完只能落一个 model id, 来源仍由派发侧按
-          nativeDefaultSourceId 解析 —— claude-code 一律优先 'xd'(见
-          model-providers/registry.ts:84)。结果就是用户点「订阅版 Opus 5」, 当场被
-          重映射成「Cindy AI 的 Opus 5」, 订阅额度根本用不上却以为选中了
-          (2026-07 用户实测: 选 A 落 B)。列多行让人以为能选、选完静默改掉, 比列表短
-          恶劣得多。
-          等偏好表支持 providerId 后再开分段, 届时同步去掉本段说明。
-
-          同理不传 modelMemory: flat 行没有 providerId 上下文, ModelSelector 的
-          canConfigure 对非选中行要求 editingProviderId 非空, 传了也是死代码。
-          非选中行看不到档位菜单 —— 先点中模型再 hover 改档, 与改造前「改当前生效
-          模型的档位」功能等价。 */}
+      {/* 模型 + 思考强度同一个控件, **composer 同款全功能标准面板**(2026-07 用户
+          定稿基准: 全软件一个模型选择面板, 处处同行为, 差异只有样式):供应商分段、
+          订阅来源、推理强度全开。来源(providerId)是纯客户端维度, 落本地
+          workspaceProviderSourceStore; model/effort 照旧走 server prefs 通道
+          (Slack /model 卡展示不受影响)。派发侧按 (来源, 模型) 经
+          effectiveSourceIdForModel 收窄, 来源断开/不提供该模型时自动回落,
+          不会拼出不可能路由 —— 「选 A 落 B」的根因(选了来源没地方存)已消除。 */}
       <PrefsField label={t('settings.tina.prefs.modelLabel')} className="flex-1 basis-[220px]">
         <ModelSelector
           modelId={eff.model.id ?? ''}
@@ -510,6 +551,19 @@ export function WorkspacePrefsEditor({
           // 既看不到自己存的是什么、也无从判断为何 bot 用的不是它。与本组件接管前
           // (PrefsSelect 的 modelLabel 回落裸 id)行为一致; 派发侧另有回落并记日志。
           unknownModelLabel={(id) => id}
+          // 非选中行 hover 配置(推理强度/Fast)与 composer 共用同一份模型级全局预设。
+          modelMemory={{
+            getEffort: getProviderModelEffort,
+            setEffort: setProviderModelEffort,
+            setChoice: setProviderModelChoice,
+            getFast: getProviderModelFast,
+            setFast: setProviderModelFast,
+          }}
+          currentProviderId={state.providerSourceFor(alias)}
+          onProviderChange={(providerId, modelId) => {
+            state.applyProviderSource(alias, providerId);
+            if (modelId) applyModel(modelId);
+          }}
           onModelChange={applyModel}
           onEffortChange={(next) => {
             if (next !== prefs.effort) state.applyPatch(alias, { effort: next });

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -68,6 +68,7 @@ import type { ImDefaultSettingsState } from '../../../shared/imDefaultSettings';
 import {
   AGENT_KINDS,
   HOOK_DEFAULT_PERMISSION_MODE,
+  isKnownAgent,
   patchForAgentChange,
   patchForModelChange,
   resolveEffectiveRow,
@@ -147,6 +148,8 @@ export function useHookWorkspacePrefs(
   const [imDefaults, setImDefaults] = useState<ImDefaultsLike | null>(null);
   // 目录模型来源偏好(纯本地文件, 不经 WS): 全量条目一次拉取, 写后用返回值刷新。
   const [providerSources, setProviderSources] = useState<HookWorkspaceProviderSourceEntry[]>([]);
+  // latest-wins 守卫(Copilot review): 快速连选/跨窗口广播时, 较慢的旧回复不得覆盖新状态。
+  const providerSourceRevisionRef = useRef(0);
   const telegramBindingId =
     provider === 'telegram' && hook?.telegram.binding?.state === 'confirmed'
       ? hook.telegram.binding.bindingId
@@ -254,11 +257,20 @@ export function useHookWorkspacePrefs(
         if (active) setProviderSources(res.entries);
       })
       .catch(() => {});
+    // 多窗口同步(codex review): 会话副窗也能开设置页, 其它窗口写入时以广播的
+    // 全量条目为准刷新(与 prefs.state 的 latest-wins 快照语义一致)。
+    const offProviderSources = window.electronAPI.hookControl.onWorkspaceProviderSourcesChanged(
+      (entries) => {
+        providerSourceRevisionRef.current += 1;
+        setProviderSources(entries);
+      },
+    );
     return () => {
       active = false;
       fetchRevisionRef.current += 1;
       mutationRevisionRef.current += 1;
       offPrefs();
+      offProviderSources();
     };
   }, [fetchPrefs, provider]);
 
@@ -330,8 +342,6 @@ export function useHookWorkspacePrefs(
     [providerSources, provider, multiTeam, selectedTeamId],
   );
 
-  // latest-wins 守卫(Copilot review): 快速连选时, 较慢的旧回复不得覆盖较新的选择。
-  const providerSourceRevisionRef = useRef(0);
   const applyProviderSource = useCallback(
     (alias: string, providerId: string | null) => {
       const teamId = multiTeam ? selectedTeamId : null;
@@ -580,18 +590,24 @@ export function WorkspacePrefsEditor({
           }}
           currentProviderId={state.providerSourceFor(alias)}
           // 分段行原子选择:model/effort 走远端 prefs, 成功后来源落本地(串联,
-          // 见 applyPatch 的 alsoProviderSource 注释)。effort 用行上解析值(含
-          // hover 改过的全局预设记忆, codex review), 不足时 patch 已按模型校准。
-          onProviderChange={(providerId, modelId, rowEffort) => {
+          // 见 applyPatch 的 alsoProviderSource 注释)。effort 取该 (来源, 模型) 的
+          // 全局预设记忆(用户 hover 非选中行改过的档位, codex review;ModelSelector
+          // 的 onProviderChange 只回传 provider+model 两参, 记忆值需自取), 该模型
+          // 支持时进 patch, 否则维持 patchForModelChange 的模型默认校准。
+          onProviderChange={(providerId, modelId) => {
             if (eff.agentKind.id === null) return;
             const caps = toPrefsCaps(effAgentCaps);
             if (modelId) {
               const patch = patchForModelChange(eff.agentKind.id, modelId, prefs, caps);
+              const remembered =
+                providerId && isKnownAgent(eff.agentKind.id)
+                  ? getProviderModelEffort(eff.agentKind.id, providerId, modelId)
+                  : undefined;
               if (
-                rowEffort &&
-                caps?.models.find((m) => m.id === modelId)?.efforts.includes(rowEffort)
+                remembered &&
+                caps?.models.find((m) => m.id === modelId)?.efforts.includes(remembered)
               ) {
-                patch.effort = rowEffort;
+                patch.effort = remembered;
               }
               state.applyPatch(alias, patch, providerId);
             } else {

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
@@ -53,6 +53,8 @@ vi.mock('@/components/ui/switch', () => ({
 vi.mock('../HookWorkspacePrefsEditor', () => ({
   useHookWorkspacePrefs: () => ({
     prefsFor: vi.fn(),
+    providerSourceFor: vi.fn(() => null),
+    applyProviderSource: vi.fn(),
     editable: false,
     pendingWs: null,
     hint: null,

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
@@ -99,6 +99,7 @@ describe('useHookWorkspacePrefs provider isolation', () => {
         setWorkspacePrefs: vi.fn(),
         getWorkspaceProviderSources: vi.fn(async () => ({ entries: [] })),
         setWorkspaceProviderSource: vi.fn(async () => ({ entries: [] })),
+        onWorkspaceProviderSourcesChanged: vi.fn(() => () => {}),
       },
       maker: {
         imDefaultSettingsGet: vi.fn(async () => ({ agentKind: 'codex', agents: {} })),

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
@@ -97,6 +97,8 @@ describe('useHookWorkspacePrefs provider isolation', () => {
         onPrefsChanged: vi.fn(() => () => {}),
         setProviderWorkspacePrefs: vi.fn(),
         setWorkspacePrefs: vi.fn(),
+        getWorkspaceProviderSources: vi.fn(async () => ({ entries: [] })),
+        setWorkspaceProviderSource: vi.fn(async () => ({ entries: [] })),
       },
       maker: {
         imDefaultSettingsGet: vi.fn(async () => ({ agentKind: 'codex', agents: {} })),

--- a/apps/desktop/src/renderer/components/settings/__tests__/WorkspacePrefsEditorRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/WorkspacePrefsEditorRendering.test.tsx
@@ -9,7 +9,7 @@
  * PermissionSelector 上;effort 没有独立控件(并进模型 trigger);禁用态整行同步。
  */
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { WorkspacePrefsEditor, type HookWorkspacePrefsState } from '../HookWorkspacePrefsEditor';
@@ -66,6 +66,8 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
       // 未知模型的 trigger 文案由调用方给出;这里回放它对一个不存在的 id 的结果。
       data-unknown-label={props.unknownModelLabel?.('ghost-model-1') ?? ''}
       onClick={() => props.onModelChange('gpt-5.5')}
+      // 分段行点击(供应商, 模型)原子选择 —— 回放 onProviderChange 的行为锁触发器。
+      onKeyDown={() => props.onProviderChange?.('anthropic', 'claude-opus-5')}
     />
   ),
 }));
@@ -100,6 +102,8 @@ function stateWith(overrides: Partial<HookWorkspacePrefsState> = {}): HookWorksp
       agentKind: 'claude-code',
       permissionMode: 'bypassPermissions',
     }),
+    providerSourceFor: () => null,
+    applyProviderSource: vi.fn(),
     editable: true,
     pendingWs: null,
     hint: null,
@@ -141,14 +145,25 @@ describe('WorkspacePrefsEditor 复用标准选择器', () => {
     expect(permission.getAttribute('data-trigger-variant')).toBe('field');
   });
 
-  it('模型选择器不开供应商分段(偏好表无 providerId,分段会造成选 A 落 B)', () => {
+  // 2026-07 用户定稿基准反转:全软件一个模型选择面板,处处同行为 —— 供应商分段
+  // **必须开**。旧的「选 A 落 B」根因(选了来源没地方存)已由本地
+  // workspaceProviderSourceStore 消除:来源落本地,model 照旧走 server prefs。
+  it('模型选择器开供应商分段(composer 同款全功能形态)', () => {
     render(<WorkspacePrefsEditor alias="cindy" state={stateWith()} />);
+    expect(screen.getByTestId('model-selector').getAttribute('data-sources-enabled')).toBe('true');
+  });
 
-    // 开分段会按 (供应商, 模型) 列多行,但只能落一个 model id,来源仍由派发侧按
-    // nativeDefaultSourceId 解析(claude-code 一律优先 'xd')—— 用户点「订阅版
-    // Opus 5」当场被重映射成「Cindy AI 的 Opus 5」(2026-07 用户实测)。
-    // 等偏好表支持 providerId 再开;在那之前这个断言必须是 false。
-    expect(screen.getByTestId('model-selector').getAttribute('data-sources-enabled')).toBe('false');
+  it('分段行选择:(来源, 模型)分别落 applyProviderSource 与 model patch', () => {
+    const applyProviderSource = vi.fn();
+    render(
+      <WorkspacePrefsEditor alias="cindy" state={stateWith({ applyProviderSource })} />,
+    );
+    fireEvent.keyDown(screen.getByTestId('model-selector'));
+    expect(applyProviderSource).toHaveBeenCalledWith('cindy', 'anthropic');
+    expect(applyPatch).toHaveBeenCalledWith(
+      'cindy',
+      expect.objectContaining({ model: 'claude-opus-5', agentKind: 'claude-code' }),
+    );
   });
 
   it('选中模型落 model id,并随手写入 agent 配对', () => {

--- a/apps/desktop/src/renderer/components/settings/__tests__/WorkspacePrefsEditorRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/WorkspacePrefsEditorRendering.test.tsx
@@ -153,17 +153,20 @@ describe('WorkspacePrefsEditor 复用标准选择器', () => {
     expect(screen.getByTestId('model-selector').getAttribute('data-sources-enabled')).toBe('true');
   });
 
-  it('分段行选择:(来源, 模型)分别落 applyProviderSource 与 model patch', () => {
+  // 双写串联(Greptile/codex review):model/effort 走远端 prefs patch,来源作为
+  // applyPatch 第三参在远端成功后落本地 —— 不再各自 fire-and-forget(分裂态风险)。
+  it('分段行选择:(模型, 来源)经 applyPatch 串联落库,不直接调 applyProviderSource', () => {
     const applyProviderSource = vi.fn();
     render(
       <WorkspacePrefsEditor alias="cindy" state={stateWith({ applyProviderSource })} />,
     );
     fireEvent.keyDown(screen.getByTestId('model-selector'));
-    expect(applyProviderSource).toHaveBeenCalledWith('cindy', 'anthropic');
     expect(applyPatch).toHaveBeenCalledWith(
       'cindy',
       expect.objectContaining({ model: 'claude-opus-5', agentKind: 'claude-code' }),
+      'anthropic',
     );
+    expect(applyProviderSource).not.toHaveBeenCalled();
   });
 
   it('选中模型落 model id,并随手写入 agent 配对', () => {

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2890,6 +2890,17 @@ interface ElectronAPI {
       workspace: string,
       patch: import('../shared/hookControlIpc').HookPrefsPatch,
     ) => Promise<{ prefs: import('../shared/hookControlIpc').ProviderPrefsView }>;
+    getWorkspaceProviderSources: () => Promise<{
+      entries: import('../shared/hookControlIpc').HookWorkspaceProviderSourceEntry[];
+    }>;
+    setWorkspaceProviderSource: (payload: {
+      channel: 'slack' | 'telegram';
+      teamId: string | null;
+      workspace: string;
+      providerId: string | null;
+    }) => Promise<{
+      entries: import('../shared/hookControlIpc').HookWorkspaceProviderSourceEntry[];
+    }>;
     onPrefsChanged: (
       cb: (view: import('../shared/hookControlIpc').HookPrefsView) => void,
     ) => () => void;

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2901,6 +2901,11 @@ interface ElectronAPI {
     }) => Promise<{
       entries: import('../shared/hookControlIpc').HookWorkspaceProviderSourceEntry[];
     }>;
+    onWorkspaceProviderSourcesChanged: (
+      listener: (
+        entries: import('../shared/hookControlIpc').HookWorkspaceProviderSourceEntry[],
+      ) => void,
+    ) => () => void;
     onPrefsChanged: (
       cb: (view: import('../shared/hookControlIpc').HookPrefsView) => void,
     ) => () => void;

--- a/apps/desktop/src/shared/hookControlIpc.ts
+++ b/apps/desktop/src/shared/hookControlIpc.ts
@@ -61,6 +61,10 @@ export const HOOK_CONTROL_INVOKE = {
   PROVIDER_PREFS_GET: 'maker:hook-control:provider-prefs-get',
   /** 更新 Telegram provider 独立的 workspace 偏好。 */
   PROVIDER_PREFS_SET: 'maker:hook-control:provider-prefs-set',
+  /** 读取工作目录模型来源偏好(纯本地, 不经 WS; 见 workspaceProviderSourceStore)。 */
+  WORKSPACE_PROVIDER_SOURCE_GET: 'maker:hook-control:workspace-provider-source-get',
+  /** 写/清一条工作目录模型来源偏好(纯本地)。 */
+  WORKSPACE_PROVIDER_SOURCE_SET: 'maker:hook-control:workspace-provider-source-set',
 } as const;
 
 export const HOOK_CONTROL_EVENT = {
@@ -274,6 +278,20 @@ export const HOOK_CHAT_WORKSPACE_ALIAS = 'chat';
  * 引协议包)。null = 未设置, 跟随桌面端草稿默认(权限默认完全访问)。
  * 数据正本在 slack-hook-server 的 user_prefs 表, 与 Slack /model 卡同源。
  */
+/**
+ * 工作目录的模型来源偏好条目(纯客户端, 不进 server prefs 表)。
+ * server prefs 继续只存 model/effort/agentKind/permissionMode 服务 /model 卡展示;
+ * 来源是纯客户端维度(凭证/连接态/目录/派发全在客户端), 按本表与 server 显式
+ * model 组合后经 effectiveSourceIdForModel 收窄派发。
+ */
+export interface HookWorkspaceProviderSourceEntry {
+  channel: 'slack' | 'telegram';
+  /** Slack multi-team 归属; Telegram / 单绑定为 null。 */
+  teamId: string | null;
+  workspace: string;
+  providerId: string;
+}
+
 export interface HookWorkspacePrefs {
   workspace: string;
   model: string | null;

--- a/apps/desktop/src/shared/hookControlIpc.ts
+++ b/apps/desktop/src/shared/hookControlIpc.ts
@@ -74,7 +74,13 @@ export const HOOK_CONTROL_EVENT = {
   PREFS_CHANGED: 'maker:hook-control:prefs-changed',
   /** provider-neutral 偏好快照推送（本版由 Telegram 消费）。 */
   PROVIDER_PREFS_CHANGED: 'maker:hook-control:provider-prefs-changed',
+  /** 目录模型来源偏好全量推送(本地写入后广播全窗口, 多窗口设置页同步)。 */
+  WORKSPACE_PROVIDER_SOURCE_CHANGED: 'maker:hook-control:workspace-provider-source-changed',
 } as const;
+
+/** 目录来源偏好条目总量上限(渠道×目录×team 现实规模远小于此;防被攻破的
+ * renderer 用海量唯一 teamId 无限追加撑爆本地文件)。 */
+export const HOOK_WORKSPACE_PROVIDER_SOURCE_MAX_ENTRIES = 256;
 
 /** Cindy relay 当前支持的客户端 provider。 */
 export type HookProvider = 'slack' | 'telegram';


### PR DESCRIPTION
## 这次改了什么

### 摘要

IM 机器人的工作目录映射(含内置「对话」行)的模型选择器,替换为与会话输入框完全一致的标准模型选择面板:供应商分段、订阅来源、推理强度全部可选。选中的来源(providerId)按「渠道 + 目录」落**纯客户端本地文件**,派发合成时经 `effectiveSourceIdForModel` 收窄到真实已连接来源——官方 Telegram/Slack bot 的会话从此可以真正使用用户的 Claude/ChatGPT 订阅额度(此前永远落 native 网关路由)。

设计基准(维护者定稿):全软件一个模型选择面板,任何入口行为一致,差异只允许样式微调;此前该入口因「偏好表无 providerId、开分段会选 A 落 B」被刻意剥掉供应商分段——本 PR 消除该根因(来源有地方存了),而不是继续阉割 UI。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:#404(工作目录偏好缺来源维度)
- 本 PR 包含:本地来源偏好存储(`workspaceProviderSourceStore`)+ 读写 IPC + 偏好行选择器开满标准面板 + hook 派发合成消费目录级来源
- 明确不包含:**不动 hook server / wire 协议**(server prefs 继续只存 model/effort/agentKind/permissionMode 四字段,Slack /model 卡展示不受影响);不动 IM 渠道全局默认;与 #478(renderer 派生切换)相互独立
- 用户可见变化:工作目录映射各行的模型选择器从单栏 flat 变为供应商分段全功能面板;选中订阅来源后 trigger 显示真实来源图标
- 是否存在 breaking change:无
- 远程/手机适配结论(新增 2 个 IPC + 1 个推送事件):**均为桌面设置页专用,按 `packages/device-link/src/allowlist.ts` 准入判据评估后不登记** invoke/push 白名单——来源偏好的编辑入口只存在于桌面设置页;手机/远程控制场景不消费该 IPC(被控端派发在 main 内直接读本地文件,不经 IPC);SSH 工作目录不经 hook workspace 偏好表。mobile 不涉及(无此设置面)。

### UI 变化

实机走查(CN 区 dev,Light + Dark):「对话」行弹层供应商分段完整(Anthropic/OpenAI/xAI 订阅段带订阅徽章与价格 + Cindy AI 段);选订阅版 Opus 5 后本地落 `{channel: telegram, workspace: chat, providerId: anthropic}`,trigger 显示 Anthropic 字标 + Opus 5 · 超高。无新增自定义样式——完全复用既有 ModelSelector(双模式已交付),仅传参装配变化。

- 引用的设计规范:DESIGN.md §Select & Dropdown(选择菜单行规约,弹层为既有 ModelSelector 组件自身实现,本 PR 零样式改动);docs/design-rules/cindy-design-system.md 组件复用原则——三控件(agent 分段/模型/权限)均复用应用标准选择器,不自建选择 UI(沿袭该文件既有约定并去除其功能阉割)

## 怎么验证的

### 自动验证

```text
pnpm test:unit            → 全绿(12.9k tests, EXIT=0)
pnpm --filter desktop run typecheck → 绿
新增行为锁:workspaceProviderSourceStore 4 例(键语义/teamId 兜底/null 清除/损坏宽容);
WorkspacePrefsEditorRendering「必须开供应商分段」+「(来源,模型)分别落库」(旧「不开分段」锁反转)
```

### 手工验证

CN 区 dev 沙箱(`--region=cn --isolated=modelstd`,真实账号供应商数据),macOS:设置 → IM 机器人 → Telegram → 「对话」行:弹层分段/徽章/价格正常(Light+Dark);选订阅版 Opus 5 → 本地文件落 providerId=anthropic;trigger 显示真实来源。

### 未执行的验证

Telegram 实发 `/new` 的端到端派发(合成链路由既有 defaults/session-runner 测试与 `effectiveSourceIdForModel` 包测试覆盖;实发验证待维护者在 dev 实例自测)。mobile 不涉及。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:desktop IM hook 偏好编辑与新会话来源合成;来源偏好为纯本地新文件,老版本忽略之(行为与现状一致)
- 回滚:revert 本 PR 即可,无数据迁移;本地偏好文件残留无害

🤖 Generated with [Claude Code](https://claude.com/claude-code)

