### PR TITLE
fix(desktop): 修复成本提示换行显示

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
@@ -51,7 +51,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { toast } from '@/lib/toast';
 import { formatAbsolute, useRelativeTime } from '@/hooks/useRelativeTime';
-import { formatTurnCostMoney, formatTurnCostUsd } from '@/lib/usageFormat';
+import { formatTurnCostMoney } from '@/lib/usageFormat';
 import { buildTurnUsageTooltipLines } from '@/lib/turnUsageTooltip';
 import type { TurnUsageDetails } from '../../../shared/turnUsageDetails';
 import { CURRENT_CINDY_REGION } from '../../../shared/brandRegion';
@@ -327,11 +327,10 @@ export function MessageActionBar({
   const turnCostTooltipNode =
     displayedMoney && displayedMoney.amount > 0 && turnUsageDetails ? (
       <span className="whitespace-pre-line">
-        {isUserTurnTotal && (
-          <>{t('chat.messageActionBar.userTurnCostTotalLine', {
+        {isUserTurnTotal &&
+          `${t('chat.messageActionBar.userTurnCostTotalLine', {
             cost: formatTurnCostMoney(displayedMoney),
-          })}\n</>
-        )}
+          })}\n`}
         {buildTurnUsageTooltipLines({
           details: turnUsageDetails,
           t,

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@/lib/toast', () => ({
 
 import { MessageActionBar } from '../MessageActionBar';
 
-describe('MessageActionBar more menu', () => {
+describe('MessageActionBar', () => {
   const writeText = vi.fn(async () => undefined);
 
   beforeEach(() => {
@@ -176,5 +176,50 @@ describe('MessageActionBar more menu', () => {
     fireEvent.keyDown(item, { key: 'Escape' });
 
     await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it('renders the user-turn total and SDK segment details on separate lines', () => {
+    render(
+      <MessageActionBar
+        copyText="message body"
+        align="left"
+        hovered
+        userTurnMoney={{
+          amount: 2,
+          currency: 'CNY',
+          approximate: false,
+          kind: 'actual-cost',
+        }}
+        turnMoney={{
+          amount: 1,
+          currency: 'CNY',
+          approximate: false,
+          kind: 'actual-cost',
+        }}
+        turnUsageDetails={{
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          totalTokens: 15,
+          cacheHitRate: 0,
+        }}
+      />,
+    );
+
+    const tooltip = screen.getByText(
+      (_, element) =>
+        element?.classList.contains('whitespace-pre-line') === true &&
+        element.textContent?.includes('chat.messageActionBar.userTurnCostTotalLine') === true,
+    );
+    expect(tooltip.textContent).toBe(
+      [
+        'chat.messageActionBar.userTurnCostTotalLine',
+        'chat.messageActionBar.userTurnCostDetailsTitle',
+        'usageDetails.costLine',
+        'usageDetails.tokenLine',
+        'usageDetails.cacheLine',
+      ].join('\n'),
+    );
   });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复聊天消息末尾成本悬浮提示把 `\n` 显示成字面字符的问题。React JSX 原先把反斜杠和 `n` 当作普通文本渲染；现在改为插入真实换行，并补充组件回归测试锁定完整 Tooltip 文本结构。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：聊天末尾成本悬浮提示显示字面量 `\n`
- 本 PR 包含：成本 Tooltip 的换行修复；覆盖用户轮累计与最后 SDK 分段之间分隔符的回归测试
- 明确不包含：成本计算、Token 统计、Tooltip 视觉样式调整
- 用户可见变化：成本悬浮提示恢复正常分行，不再显示 `\n`
- 是否存在 breaking change：无

### UI 变化

- 截图 / 录屏：未新增；本次仅修正已有 Tooltip 的文本换行，未调整布局、颜色或交互
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light / Dark 双模式交付门槛。本次复用既有 Tooltip 样式和 token，仅修正模式无关的文本节点；Light / Dark 共用同一渲染路径。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-cost-tooltip-newline
结果：通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
结果：通过（4 tests）

pnpm --filter desktop exec eslint src/renderer/components/chat/MessageActionBar.tsx src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
结果：通过

git diff --check
结果：通过
```

### 手工验证

未执行。回归测试直接断言 Tooltip 的 `textContent` 使用真实换行，且不涉及主题样式分支。

### 未执行的验证

- 未启动 Desktop 做界面走查：改动仅替换文本分隔符，已有组件回归测试覆盖实际 React 渲染结果。
- Desktop 全量 lint 未作为门禁：仓库当前存在多处与本 PR 无关的既有 lint 错误；本次修改的两个文件已定向 lint 通过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Renderer 的消息成本 Tooltip 文本展示
- 回滚 / 降级方式：回滚本提交即可恢复原行为；不涉及数据或协议

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
