### PR TITLE
feat(rail): 折叠面板补齐新建入口(对话/项目内定向新建)

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -20,7 +20,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, use
 import type { ReactNode } from 'react';
 import type { SchedulerEvent } from '@cindy/maker-scheduler';
 import { createPortal } from 'react-dom';
-import { Archive, ChevronRight, CirclePlus, Folder, Plug, Timer, Trash2, X } from 'lucide-react';
+import { Archive, ChevronRight, CirclePlus, Folder, Plug, SquarePen, Timer, Trash2, X } from 'lucide-react';
 import { useNavigate, useMatch } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -2383,6 +2383,8 @@ function ExpandedView({
         onMoveSession={handleMoveSession}
         projectOptions={projectPickerOptions}
         onScheduleAction={handleScheduleAction}
+        onCreateDialogue={handleCreateDialogue}
+        onCreateInProject={handleCreateInProject}
       />
       {deleteScheduleDialog}
     </>
@@ -2634,6 +2636,11 @@ interface RailPanelsProps {
   onMoveSession: Parameters<typeof SessionEntryList>[0]['onMoveSession'];
   projectOptions: Parameters<typeof SessionEntryList>[0]['projectOptions'];
   onScheduleAction: Parameters<typeof SessionEntryList>[0]['onScheduleAction'];
+  /** 新建对话(对话面板头部 SquarePen)——展开态 DialogueSection 段头同源 handler。 */
+  onCreateDialogue: () => void;
+  /** 在此项目内新建(项目行右键菜单 + 三级面板头部)——展开态 ProjectNode
+   *  的 newInDirectory 主操作同源 handler(内置远程写保护)。 */
+  onCreateInProject: (project: ProjectNode) => void;
 }
 
 /**
@@ -2663,9 +2670,18 @@ function RailPanels({
   onMoveSession,
   projectOptions,
   onScheduleAction,
+  onCreateDialogue,
+  onCreateInProject,
 }: RailPanelsProps) {
   const { t } = useTranslation();
   const panelState = useSyncExternalStore(railPanelStore.subscribe, railPanelStore.getSnapshot);
+  // 项目行右键菜单(「在此项目内新建」)——controlled DropdownMenu + 不可见
+  // trigger 跟坐标(Automations 菜单同款模式)。
+  const [projectMenu, setProjectMenu] = useState<{
+    x: number;
+    y: number;
+    projectKey: string;
+  } | null>(null);
   const attentionKinds = useSessionAttentionKinds();
   const urgentSet = useSessionAttentionUrgencySet();
   // 项目列表「显示全部」:面板关闭后复位(与 ProjectsSection 的段收起复位同语义)。
@@ -2853,13 +2869,34 @@ function RailPanels({
     onScheduleAction,
   } as const;
 
-  const panelHead = (title: string, count: number) => (
+  const panelHead = (title: string, count: number, action?: ReactNode) => (
     <div className="flex items-baseline gap-1.5 px-2.5 pb-1 pt-1.5">
       <span className="min-w-0 flex-1 truncate text-[12.5px] font-extrabold text-foreground">{title}</span>
       <span className="shrink-0 text-[10px] text-[var(--text-tertiary)]">
         {t('ccAgent.sidebar.railNavCount', { count })}
       </span>
+      {action}
     </div>
+  );
+
+  /** 面板头部的新建按钮(展开态段头 SquarePen 同款配色);创建动作导航去
+   *  新建页,面板随之收起。 */
+  const panelHeadCreateButton = (label: string, onCreate: () => void) => (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={() => {
+        railPanelStore.closeAll();
+        onCreate();
+      }}
+      className={cn(
+        'flex h-6 w-6 shrink-0 items-center justify-center self-center rounded-md -my-1',
+        'text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-secondary)]',
+      )}
+    >
+      <SquarePen size={14} strokeWidth={2} />
+    </button>
   );
 
   if (!panelState.openSection || !panelState.anchor) return null;
@@ -2880,7 +2917,11 @@ function RailPanels({
       >
         {panelState.openSection === 'dialogues' && (
           <>
-            {panelHead(t('ccAgent.sidebar.railNav.dialogues'), dialogues.length)}
+            {panelHead(
+              t('ccAgent.sidebar.railNav.dialogues'),
+              dialogues.length,
+              panelHeadCreateButton(t('ccAgent.sidebar.newDialogue'), onCreateDialogue),
+            )}
             <div className="max-h-[420px] overflow-y-auto [scrollbar-width:thin]">
               <SessionEntryList
                 sessions={dialogues}
@@ -2924,6 +2965,10 @@ function RailPanels({
                     onClick={(e) => {
                       const rect = e.currentTarget.getBoundingClientRect();
                       railPanelStore.openProject(p.projectKey, { right: rect.right, top: rect.top });
+                    }}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setProjectMenu({ x: e.clientX, y: e.clientY, projectKey: p.projectKey });
                     }}
                     onMouseLeave={() => railPanelStore.scheduleProjectClose()}
                     className={cn(
@@ -2992,7 +3037,14 @@ function RailPanels({
             railPanelStore.scheduleClose();
           }}
         >
-          {panelHead(projectDisplayLabelWithMachine(openProject), openProject.sessions.length)}
+          {panelHead(
+            projectDisplayLabelWithMachine(openProject),
+            openProject.sessions.length,
+            panelHeadCreateButton(
+              t('ccAgent.sidebar.projectAction.newInDirectory'),
+              () => onCreateInProject(openProject),
+            ),
+          )}
           <div className="max-h-[420px] overflow-y-auto [scrollbar-width:thin]">
             {/* key 按项目:hover 直切另一项目时列表组件被复用,内部「显示全部」
                 状态会泄漏给下一个项目、绕过折叠上限(codex review)——换 key 强制
@@ -3007,6 +3059,54 @@ function RailPanels({
           </div>
         </RailPanelShell>
       )}
+
+      {/* 项目行右键菜单 —— Automations 菜单同款「controlled + 坐标 trigger」;
+          Radix 浮层在保活白名单内,阻断性浮层守卫保证面板不被 hover 宽限收掉。 */}
+      <DropdownMenu
+        open={projectMenu !== null}
+        onOpenChange={(open) => {
+          if (!open) setProjectMenu(null);
+        }}
+      >
+        <DropdownMenuTrigger asChild>
+          <span
+            aria-hidden
+            style={{
+              position: 'fixed',
+              left: projectMenu?.x ?? 0,
+              top: projectMenu?.y ?? 0,
+              width: 0,
+              height: 0,
+              pointerEvents: 'none',
+            }}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          sideOffset={2}
+          className={cn(
+            'min-w-[180px] rounded-xl p-1 overflow-hidden',
+            'bg-[var(--cmd-palette-bg)]',
+            'border border-[var(--cmd-palette-border)]',
+            'shadow-[var(--shadow-menu)]',
+          )}
+        >
+          <DropdownMenuItem
+            onSelect={() => {
+              const target = projectMenu
+                ? projects.find((x) => x.projectKey === projectMenu.projectKey)
+                : null;
+              setProjectMenu(null);
+              if (!target) return;
+              railPanelStore.closeAll();
+              onCreateInProject(target);
+            }}
+            className="cursor-pointer text-sm text-[var(--msg-assistant-text)] hover:bg-[var(--cmd-palette-item-hover)]"
+          >
+            {t('ccAgent.sidebar.projectAction.newInDirectory')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </>
   );
 }

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -132,7 +132,11 @@ import {
   SIDEBAR_RAIL_ICON_BUTTON_CLASS,
 } from '@/components/sidebar/SidebarIconButton';
 import { RailNav, remoteLampOf } from './sidebar/RailNav';
-import { panelHasEditingFocus, railPanelStore } from './sidebar/railPanelStore';
+import {
+  panelHasBlockingOverlay,
+  panelHasEditingFocus,
+  railPanelStore,
+} from './sidebar/railPanelStore';
 import { SessionEntryList } from './sidebar/SessionEntryList';
 import { AttentionDot } from '@/components/sidebar/AttentionDot';
 import {
@@ -2764,11 +2768,18 @@ function RailPanels({
       if (e.key !== 'Escape') return;
       // 行内重命名编辑中:Esc 归编辑器(取消编辑),不整面板收掉。
       if (panelHasEditingFocus()) return;
-      // 有 Radix 浮层(行菜单/右键菜单/子菜单)挂载时:这一记 Esc 归浮层
-      // (Radix 自己会 dismiss),不能同帧把面板也收掉——否则触发行被卸载,
-      // 还焦逻辑失效、焦点掉到 document(codex review)。浮层的 React 卸载
-      // 发生在本事件处理之后,此刻 querySelector 仍能命中。
-      if (document.querySelector('[data-radix-popper-content-wrapper]')) return;
+      // 有浮层挂载时:这一记 Esc 归浮层(Radix 自己会 dismiss),不能同帧把
+      // 面板也收掉——否则触发行被卸载,还焦逻辑失效、焦点掉到 document
+      // (codex review)。两路判定:菜单/子菜单看 popper 存在性(React 卸载
+      // 发生在本事件处理之后,此刻必命中);ConfirmDialog 等弹窗看模态信号
+      // (panelHasBlockingOverlay,copilot review)——不能按 role 全量匹配,
+      // 否则 FindInPageBar 的常驻非模态 role="dialog" 会让 Esc 永远收不掉
+      // 面板(#505 同款教训)。
+      if (
+        document.querySelector('[data-radix-popper-content-wrapper]') ||
+        panelHasBlockingOverlay()
+      )
+        return;
       railPanelStore.closeAll();
     };
     const onDown = (e: MouseEvent) => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2729,6 +2729,28 @@ function RailPanels({
     });
   }, [projects, unclassified, dialogues]);
 
+  // 键盘打开(popover 焦点契约,DESIGN.md §14.2):焦点移入一级面板的首个
+  // 可聚焦元素(对话面板=头部新建钮/项目面板=首行),Tab 不再穿越 portal 间隔
+  // 的无关控件(codex review);关闭时还焦到触发瓷砖,键盘导航可继续。
+  const keyboardFocusReturnRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!panelState.openedViaKeyboard || !panelState.openSection) return;
+    keyboardFocusReturnRef.current = panelState.anchorEl;
+    const raf = requestAnimationFrame(() => {
+      const shell = document.querySelector('[data-rail-panel-level="1"]');
+      shell
+        ?.querySelector<HTMLElement>('button, [role="menuitem"], [tabindex]:not([tabindex="-1"])')
+        ?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [panelState.openedViaKeyboard, panelState.openSection]);
+  useEffect(() => {
+    if (panelState.openSection !== null) return;
+    const returnTo = keyboardFocusReturnRef.current;
+    keyboardFocusReturnRef.current = null;
+    if (returnTo?.isConnected) returnTo.focus();
+  }, [panelState.openSection]);
+
   // 触发瓷砖可见性监测:⌘B 完全隐藏(aside w-0)、rail 滚出等任何"触发器
   // 消失"路径,即刻收面板——不依赖指针再动(review P1「键盘隐藏仍会残留」)。
   useEffect(() => {
@@ -2907,12 +2929,14 @@ function RailPanels({
   );
 
   /** 面板头部的新建按钮(展开态段头 SquarePen 同款配色);创建动作导航去
-   *  新建页,面板随之收起。 */
-  const panelHeadCreateButton = (label: string, onCreate: () => void) => (
+   *  新建页,面板随之收起。disabled = 远程写保护(与展开态 ProjectAction
+   *  同语义置灰,不收面板不丢上下文,codex review)。 */
+  const panelHeadCreateButton = (label: string, onCreate: () => void, disabled = false) => (
     <button
       type="button"
       aria-label={label}
       title={label}
+      disabled={disabled}
       onClick={() => {
         railPanelStore.closeAll();
         onCreate();
@@ -2923,6 +2947,7 @@ function RailPanels({
         // globals.css 移除了 Chromium 默认 outline,键盘可达按钮必须自带
         // token 化 focus 环(DESIGN.md §10;codex review)。
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+        'disabled:opacity-40 disabled:hover:text-[var(--text-tertiary)]',
       )}
     >
       <SquarePen size={14} strokeWidth={2} />
@@ -3080,8 +3105,11 @@ function RailPanels({
             projectDisplayLabelWithMachine(openProject),
             openProject.sessions.length,
             panelHeadCreateButton(
-              t('ccAgent.sidebar.projectAction.newInDirectory'),
+              isDeviceLinkWriteBlocked(openProject)
+                ? t('ccAgent.remoteSession.actionsUnavailable')
+                : t('ccAgent.sidebar.projectAction.newInDirectory'),
               () => onCreateInProject(openProject),
+              isDeviceLinkWriteBlocked(openProject),
             ),
           )}
           <div className="max-h-[420px] overflow-y-auto [scrollbar-width:thin]">
@@ -3137,20 +3165,30 @@ function RailPanels({
             'shadow-[var(--shadow-menu)]',
           )}
         >
-          <DropdownMenuItem
-            onSelect={() => {
-              const target = projectMenu
-                ? projects.find((x) => x.projectKey === projectMenu.projectKey)
-                : null;
-              setProjectMenu(null);
-              if (!target) return;
-              railPanelStore.closeAll();
-              onCreateInProject(target);
-            }}
-            className="cursor-pointer text-sm text-[var(--msg-assistant-text)] hover:bg-[var(--cmd-palette-item-hover)]"
-          >
-            {t('ccAgent.sidebar.projectAction.newInDirectory')}
-          </DropdownMenuItem>
+          {(() => {
+            // 远程写保护项目:菜单项与展开态同语义禁用(codex review),不触发
+            // closeAll 丢上下文。
+            const menuTarget = projectMenu
+              ? projects.find((x) => x.projectKey === projectMenu.projectKey) ?? null
+              : null;
+            const menuTargetBlocked = menuTarget != null && isDeviceLinkWriteBlocked(menuTarget);
+            return (
+              <DropdownMenuItem
+                disabled={menuTarget == null || menuTargetBlocked}
+                onSelect={() => {
+                  setProjectMenu(null);
+                  if (!menuTarget || menuTargetBlocked) return;
+                  railPanelStore.closeAll();
+                  onCreateInProject(menuTarget);
+                }}
+                className="cursor-pointer text-sm text-[var(--msg-assistant-text)] hover:bg-[var(--cmd-palette-item-hover)]"
+              >
+                {menuTargetBlocked
+                  ? t('ccAgent.remoteSession.actionsUnavailable')
+                  : t('ccAgent.sidebar.projectAction.newInDirectory')}
+              </DropdownMenuItem>
+            );
+          })()}
         </DropdownMenuContent>
       </DropdownMenu>
     </>

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2682,12 +2682,19 @@ function RailPanels({
     y: number;
     projectKey: string;
   } | null>(null);
+  // 面板经 closeAll 路径(⌘B 隐藏/侧栏展开/触发器消失)关闭时不会走菜单的
+  // onOpenChange —— openSection 离开 projects 就同步清掉菜单状态,否则组件常驻
+  // (只是 return null),下次打开面板旧菜单会按旧坐标复现并引用旧项目(review)。
+  // 与下方 showAllProjects 的复位同构。
   const attentionKinds = useSessionAttentionKinds();
   const urgentSet = useSessionAttentionUrgencySet();
   // 项目列表「显示全部」:面板关闭后复位(与 ProjectsSection 的段收起复位同语义)。
   const [showAllProjects, setShowAllProjects] = useState(false);
   useEffect(() => {
-    if (panelState.openSection !== 'projects') setShowAllProjects(false);
+    if (panelState.openSection !== 'projects') {
+      setShowAllProjects(false);
+      setProjectMenu(null);
+    }
   }, [panelState.openSection]);
 
   // 生命周期清理(review P1「Portal 面板跨视图残留」):

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2764,6 +2764,11 @@ function RailPanels({
       if (e.key !== 'Escape') return;
       // 行内重命名编辑中:Esc 归编辑器(取消编辑),不整面板收掉。
       if (panelHasEditingFocus()) return;
+      // 有 Radix 浮层(行菜单/右键菜单/子菜单)挂载时:这一记 Esc 归浮层
+      // (Radix 自己会 dismiss),不能同帧把面板也收掉——否则触发行被卸载,
+      // 还焦逻辑失效、焦点掉到 document(codex review)。浮层的 React 卸载
+      // 发生在本事件处理之后,此刻 querySelector 仍能命中。
+      if (document.querySelector('[data-radix-popper-content-wrapper]')) return;
       railPanelStore.closeAll();
     };
     const onDown = (e: MouseEvent) => {
@@ -2983,7 +2988,15 @@ function RailPanels({
                     onContextMenu={(e) => {
                       e.preventDefault();
                       projectMenuAnchorRef.current = e.currentTarget;
-                      setProjectMenu({ x: e.clientX, y: e.clientY, projectKey: p.projectKey });
+                      // 键盘唤起(Shift+F10/Menu 键)时浏览器报 clientX/Y=0,
+                      // 菜单会飘到视口左上角——退回行矩形定位(codex review)。
+                      const keyboardInvoked = e.clientX === 0 && e.clientY === 0;
+                      const rect = e.currentTarget.getBoundingClientRect();
+                      setProjectMenu({
+                        x: keyboardInvoked ? rect.left + 12 : e.clientX,
+                        y: keyboardInvoked ? rect.bottom - 2 : e.clientY,
+                        projectKey: p.projectKey,
+                      });
                     }}
                     onMouseLeave={() => railPanelStore.scheduleProjectClose()}
                     className={cn(

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2732,24 +2732,56 @@ function RailPanels({
   // 键盘打开(popover 焦点契约,DESIGN.md §14.2):焦点移入一级面板的首个
   // 可聚焦元素(对话面板=头部新建钮/项目面板=首行),Tab 不再穿越 portal 间隔
   // 的无关控件(codex review);关闭时还焦到触发瓷砖,键盘导航可继续。
+  // 还焦前必须查**可见性**而非仅 isConnected:折叠/展开两视图常驻挂载,
+  // 侧栏展开或 ⌘B 隐藏后 rail 瓷砖仍 connected 但 opacity-0 + pointer-events
+  // -none,把焦点还给不可见元素会让键盘用户失联(codex review)。
+  const focusIfVisible = (el: HTMLElement | null): void => {
+    if (!el?.isConnected) return;
+    if (
+      typeof el.checkVisibility === 'function' &&
+      !el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true })
+    )
+      return;
+    el.focus();
+  };
+  const focusFirstIn = (selector: string): void => {
+    document
+      .querySelector(selector)
+      ?.querySelector<HTMLElement>('button, [role="menuitem"], [tabindex]:not([tabindex="-1"])')
+      ?.focus();
+  };
   const keyboardFocusReturnRef = useRef<HTMLElement | null>(null);
   useEffect(() => {
     if (!panelState.openedViaKeyboard || !panelState.openSection) return;
     keyboardFocusReturnRef.current = panelState.anchorEl;
-    const raf = requestAnimationFrame(() => {
-      const shell = document.querySelector('[data-rail-panel-level="1"]');
-      shell
-        ?.querySelector<HTMLElement>('button, [role="menuitem"], [tabindex]:not([tabindex="-1"])')
-        ?.focus();
-    });
+    const raf = requestAnimationFrame(() => focusFirstIn('[data-rail-panel-level="1"]'));
     return () => cancelAnimationFrame(raf);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelState.openedViaKeyboard, panelState.openSection]);
   useEffect(() => {
     if (panelState.openSection !== null) return;
     const returnTo = keyboardFocusReturnRef.current;
     keyboardFocusReturnRef.current = null;
-    if (returnTo?.isConnected) returnTo.focus();
+    focusIfVisible(returnTo);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelState.openSection]);
+  // 项目三级面板的同款契约(codex review:一级 effect 只观察 openSection,
+  // 覆盖不到 openProjectKey):键盘展开 → 焦点入三级首个可聚焦;收起 → 还焦
+  // 到展开它的项目行。
+  const keyboardProjectReturnRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!panelState.projectOpenedViaKeyboard || !panelState.openProjectKey) return;
+    const raf = requestAnimationFrame(() => focusFirstIn('[data-rail-panel-level="2"]'));
+    return () => cancelAnimationFrame(raf);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelState.projectOpenedViaKeyboard, panelState.openProjectKey]);
+  useEffect(() => {
+    if (panelState.openProjectKey !== null) return;
+    const returnTo = keyboardProjectReturnRef.current;
+    keyboardProjectReturnRef.current = null;
+    focusIfVisible(returnTo);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelState.openProjectKey]);
 
   // 触发瓷砖可见性监测:⌘B 完全隐藏(aside w-0)、rail 滚出等任何"触发器
   // 消失"路径,即刻收面板——不依赖指针再动(review P1「键盘隐藏仍会残留」)。
@@ -3019,7 +3051,14 @@ function RailPanels({
                     // 同一条 openProject 路径,否则三级面板只有鼠标能打开(codex review)。
                     onClick={(e) => {
                       const rect = e.currentTarget.getBoundingClientRect();
-                      railPanelStore.openProject(p.projectKey, { right: rect.right, top: rect.top });
+                      // 键盘激活(detail===0)按 popover 契约展开三级并记录还焦行。
+                      const viaKeyboard = e.detail === 0;
+                      if (viaKeyboard) keyboardProjectReturnRef.current = e.currentTarget;
+                      railPanelStore.openProject(
+                        p.projectKey,
+                        { right: rect.right, top: rect.top },
+                        viaKeyboard,
+                      );
                     }}
                     onContextMenu={(e) => {
                       e.preventDefault();

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2682,6 +2682,10 @@ function RailPanels({
     y: number;
     projectKey: string;
   } | null>(null);
+  // 菜单关闭后把焦点还给唤起它的项目行:Radix 默认还焦到 trigger,但这里的
+  // trigger 是零尺寸 aria-hidden span,不接管会让焦点掉到 document、打断
+  // Shift+F10 之后的键盘导航(DESIGN.md §14.2 焦点回归契约;codex review)。
+  const projectMenuAnchorRef = useRef<HTMLElement | null>(null);
   // 面板经 closeAll 路径(⌘B 隐藏/侧栏展开/触发器消失)关闭时不会走菜单的
   // onOpenChange —— openSection 离开 projects 就同步清掉菜单状态,否则组件常驻
   // (只是 return null),下次打开面板旧菜单会按旧坐标复现并引用旧项目(review)。
@@ -2900,6 +2904,9 @@ function RailPanels({
       className={cn(
         'flex h-6 w-6 shrink-0 items-center justify-center self-center rounded-md -my-1',
         'text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-secondary)]',
+        // globals.css 移除了 Chromium 默认 outline,键盘可达按钮必须自带
+        // token 化 focus 环(DESIGN.md §10;codex review)。
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
       )}
     >
       <SquarePen size={14} strokeWidth={2} />
@@ -2975,6 +2982,7 @@ function RailPanels({
                     }}
                     onContextMenu={(e) => {
                       e.preventDefault();
+                      projectMenuAnchorRef.current = e.currentTarget;
                       setProjectMenu({ x: e.clientX, y: e.clientY, projectKey: p.projectKey });
                     }}
                     onMouseLeave={() => railPanelStore.scheduleProjectClose()}
@@ -3091,6 +3099,13 @@ function RailPanels({
         <DropdownMenuContent
           align="start"
           sideOffset={2}
+          onCloseAutoFocus={(e) => {
+            // 还焦到唤起菜单的项目行(而非零尺寸 trigger span)。行已被卸载
+            // (面板关闭)时不抢焦点。
+            e.preventDefault();
+            const anchor = projectMenuAnchorRef.current;
+            if (anchor?.isConnected) anchor.focus();
+          }}
           className={cn(
             'min-w-[180px] rounded-xl p-1 overflow-hidden',
             'bg-[var(--cmd-palette-bg)]',

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/RailNav.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/RailNav.tsx
@@ -291,11 +291,14 @@ export function RailNav({
     [activeSessionId, navigate, sessions],
   );
 
-  const openSectionAt = useCallback((section: RailPanelSection, el: HTMLElement) => {
-    setPreview(null);
-    const rect = el.getBoundingClientRect();
-    railPanelStore.openSection(section, { right: rect.right, top: rect.top }, el);
-  }, []);
+  const openSectionAt = useCallback(
+    (section: RailPanelSection, el: HTMLElement, viaKeyboard = false) => {
+      setPreview(null);
+      const rect = el.getBoundingClientRect();
+      railPanelStore.openSection(section, { right: rect.right, top: rect.top }, el, viaKeyboard);
+    },
+    [],
+  );
 
   return (
     <>
@@ -400,7 +403,9 @@ export function RailNav({
           aria-expanded={panelState.openSection === key}
           onMouseEnter={(e) => openSectionAt(key, e.currentTarget)}
           onMouseLeave={() => railPanelStore.scheduleClose()}
-          onClick={(e) => openSectionAt(key, e.currentTarget)}
+          // 键盘激活(Enter/Space 的合成 click,detail===0):按 popover 焦点契约
+          // 打开——焦点移入面板、hover 收回让位、显式关闭(codex review)。
+          onClick={(e) => openSectionAt(key, e.currentTarget, e.detail === 0)}
           className={cn(
             'relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors duration-150',
             panelState.openSection === key

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/RailNav.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/RailNav.tsx
@@ -405,7 +405,13 @@ export function RailNav({
           // (openedViaKeyboard)覆写成 false、并清掉已展开的项目三级,破坏
           // popover 显式关闭契约(copilot review);锚点不变,重开本无意义。
           onMouseEnter={(e) => {
-            if (panelState.openSection !== key) openSectionAt(key, e.currentTarget);
+            if (panelState.openSection !== key) {
+              openSectionAt(key, e.currentTarget);
+            } else {
+              // 不重开,但要取消可能在途的收回计时(离开瓷砖 120ms 内折返;
+              // copilot review)——全局 pointermove 保活通常已覆盖,这里兜底。
+              railPanelStore.cancelClose();
+            }
           }}
           onMouseLeave={() => railPanelStore.scheduleClose()}
           // 键盘激活(Enter/Space 的合成 click,detail===0):按 popover 焦点契约

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/RailNav.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/RailNav.tsx
@@ -401,7 +401,12 @@ export function RailNav({
           title={t(`ccAgent.sidebar.railNav.${key}`)}
           aria-haspopup="menu"
           aria-expanded={panelState.openSection === key}
-          onMouseEnter={(e) => openSectionAt(key, e.currentTarget)}
+          // 同 section 已打开时 hover 不重复 open:重复调用会把键盘打开态
+          // (openedViaKeyboard)覆写成 false、并清掉已展开的项目三级,破坏
+          // popover 显式关闭契约(copilot review);锚点不变,重开本无意义。
+          onMouseEnter={(e) => {
+            if (panelState.openSection !== key) openSectionAt(key, e.currentTarget);
+          }}
           onMouseLeave={() => railPanelStore.scheduleClose()}
           // 键盘激活(Enter/Space 的合成 click,detail===0):按 popover 焦点契约
           // 打开——焦点移入面板、hover 收回让位、显式关闭(codex review)。

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
@@ -93,7 +93,9 @@ export function panelHasEditingFocus(): boolean {
  *  - 纯 inline style 读取,热路径(全局 pointermove)零选择器解析开销,
  *    也没有 :has 的引擎兼容面。 */
 function panelHasBlockingOverlay(): boolean {
-  return typeof document !== 'undefined' && document.body.style.pointerEvents === 'none';
+  // body 可空(极早初始化 / 非浏览器测试环境),空时按无浮层处理。
+  const body = typeof document !== 'undefined' ? document.body : null;
+  return body != null && body.style.pointerEvents === 'none';
 }
 
 function suppressAutoClose(): boolean {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
@@ -29,6 +29,8 @@ export interface RailPanelState {
    *  hover 宽限收回让位,只经 Esc/面板外点击/执行动作显式关闭。 */
   openedViaKeyboard: boolean;
   openProjectKey: string | null;
+  /** 项目三级面板由键盘打开(Enter/Space 于项目行):同 popover 契约。 */
+  projectOpenedViaKeyboard: boolean;
   projectAnchor: RailPanelAnchor | null;
   /** 灯语取样范围(会话 id):由 RailPanels(ExpandedView)发布,与面板实际
    *  展示的过滤后集合一致(vendor/项目筛选/未分类都算);null = 尚未发布,
@@ -50,6 +52,7 @@ const CLOSED_FIELDS = {
   anchorEl: null,
   openedViaKeyboard: false,
   openProjectKey: null,
+  projectOpenedViaKeyboard: false,
   projectAnchor: null,
 } as const;
 
@@ -132,6 +135,7 @@ export const railPanelStore = {
       openedViaKeyboard: viaKeyboard,
       openProjectKey: null,
       projectAnchor: null,
+      projectOpenedViaKeyboard: false,
     });
   },
 
@@ -150,11 +154,16 @@ export const railPanelStore = {
     emit({ ...state, lampScope: scope });
   },
   /** 项目一级面板内 hover 具体项目 → 打开二级。 */
-  openProject(projectKey: string, anchor: RailPanelAnchor): void {
+  openProject(projectKey: string, anchor: RailPanelAnchor, viaKeyboard = false): void {
     clearCloseTimer();
     clearProjectCloseTimer();
     if (state.openSection !== 'projects') return;
-    emit({ ...state, openProjectKey: projectKey, projectAnchor: anchor });
+    emit({
+      ...state,
+      openProjectKey: projectKey,
+      projectAnchor: anchor,
+      projectOpenedViaKeyboard: viaKeyboard,
+    });
   },
 
   cancelClose(): void {
@@ -177,13 +186,14 @@ export const railPanelStore = {
     clearProjectCloseTimer();
   },
   scheduleProjectClose(): void {
-    if (state.openedViaKeyboard) return;
+    if (state.openedViaKeyboard || state.projectOpenedViaKeyboard) return;
     if (suppressAutoClose()) return;
     clearProjectCloseTimer();
     projectCloseTimer = setTimeout(() => {
       projectCloseTimer = null;
       if (suppressAutoClose()) return;
-      if (state.openProjectKey) emit({ ...state, openProjectKey: null, projectAnchor: null });
+      if (state.openProjectKey)
+        emit({ ...state, openProjectKey: null, projectAnchor: null, projectOpenedViaKeyboard: false });
     }, RAIL_PANEL_CLOSE_GRACE_MS);
   },
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
@@ -25,6 +25,9 @@ export interface RailPanelState {
   /** 触发瓷砖元素——RailPanels 用 IntersectionObserver 监测其可见性,
    *  触发器消失(⌘B 完全隐藏 / rail 滚出)即收面板,不依赖指针再动。 */
   anchorEl: HTMLElement | null;
+  /** 本次面板由键盘激活打开(Enter/Space):按 popover 焦点契约,焦点移入面板、
+   *  hover 宽限收回让位,只经 Esc/面板外点击/执行动作显式关闭。 */
+  openedViaKeyboard: boolean;
   openProjectKey: string | null;
   projectAnchor: RailPanelAnchor | null;
   /** 灯语取样范围(会话 id):由 RailPanels(ExpandedView)发布,与面板实际
@@ -45,6 +48,7 @@ const CLOSED_FIELDS = {
   openSection: null,
   anchor: null,
   anchorEl: null,
+  openedViaKeyboard: false,
   openProjectKey: null,
   projectAnchor: null,
 } as const;
@@ -112,10 +116,23 @@ export const railPanelStore = {
   },
 
   /** 打开(或切换)一级面板;同时收起可能开着的项目二级。 */
-  openSection(section: RailPanelSection, anchor: RailPanelAnchor, anchorEl: HTMLElement): void {
+  openSection(
+    section: RailPanelSection,
+    anchor: RailPanelAnchor,
+    anchorEl: HTMLElement,
+    viaKeyboard = false,
+  ): void {
     clearCloseTimer();
     clearProjectCloseTimer();
-    emit({ ...state, openSection: section, anchor, anchorEl, openProjectKey: null, projectAnchor: null });
+    emit({
+      ...state,
+      openSection: section,
+      anchor,
+      anchorEl,
+      openedViaKeyboard: viaKeyboard,
+      openProjectKey: null,
+      projectAnchor: null,
+    });
   },
 
   /** 由 RailPanels 发布与面板展示一致的灯语取样范围(浅比较去抖,防循环)。 */
@@ -144,6 +161,8 @@ export const railPanelStore = {
     clearCloseTimer();
   },
   scheduleClose(): void {
+    // 键盘打开的面板不做 hover 宽限收回(popover 契约:显式关闭)。
+    if (state.openedViaKeyboard) return;
     if (suppressAutoClose()) return;
     clearCloseTimer();
     closeTimer = setTimeout(() => {
@@ -158,6 +177,7 @@ export const railPanelStore = {
     clearProjectCloseTimer();
   },
   scheduleProjectClose(): void {
+    if (state.openedViaKeyboard) return;
     if (suppressAutoClose()) return;
     clearProjectCloseTimer();
     projectCloseTimer = setTimeout(() => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/railPanelStore.ts
@@ -92,7 +92,7 @@ export function panelHasEditingFocus(): boolean {
  *    关闭后由下一次 pointermove 收回,是可达的最优行为;
  *  - 纯 inline style 读取,热路径(全局 pointermove)零选择器解析开销,
  *    也没有 :has 的引擎兼容面。 */
-function panelHasBlockingOverlay(): boolean {
+export function panelHasBlockingOverlay(): boolean {
   // body 可空(极早初始化 / 非浏览器测试环境),空时按无浮层处理。
   const body = typeof document !== 'undefined' ? document.body : null;
   return body != null && body.style.pointerEvents === 'none';


### PR DESCRIPTION
> **依赖声明(已完成)**:#505 已于 2026-07-26 合入 main,本 PR 已按约定 rebase 到最新 main,现仅含 4 个 feature commit,无依赖残留。

## 这次改了什么

### 摘要

折叠 rail 的悬浮面板此前只有全局「新建」入口(rail 顶部 + 号),展开态的三个定向新建入口都不可达。本 PR 把它们补进面板,handler 与展开态零复制共享(面板由 ExpandedView 渲染,直连 `handleCreateDialogue` / `handleCreateInProject`):

1. **对话面板头部**新增 SquarePen「新对话」按钮(与展开态 DialogueSection 段头同款);
2. **项目三级面板头部**新增 SquarePen「在此目录新建会话」按钮(与展开态 ProjectNode 行的 newInDirectory 主操作同源,内置 device-link 远程写保护);
3. **项目一级面板行**新增右键菜单,含「在此目录新建会话」(复用 Automations 菜单的 controlled + 坐标 trigger 模式)。

创建动作导航至新建页并收起面板;`panelHead` 增加可选动作槽承载头部按钮。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:无(用户提出并逐项验收)
- 本 PR 包含:折叠 rail 面板的三个定向新建入口
- 明确不包含:新建流程本身的任何改动;项目行右键菜单的其它条目(归档全部/重命名等仍属展开态)
- 用户可见变化:折叠模式下可直接在对话面板、具体项目内发起新建,不再必须先展开侧栏
- 是否存在 breaking change:无

### UI 变化

平台:macOS(源码版)。新增元素全部复用展开态既有组件的视觉与文案,无新视觉语言、无新 i18n key:段头按钮 = DialogueSection 段头动作钮同款(SquarePen 14px,`--text-tertiary` → hover `--text-secondary`);右键菜单 = Automations 菜单同款(`--cmd-palette-bg/-border/-item-hover` + `--shadow-menu`)。

### 界面效果(HTML 静态示意)

三个入口的布局/配色/禁用态/焦点环示意(演示数据;示意中的色值即 Default Light 主题对应 token 的取值,实现内全部经 `var(--*)` 消费):

```html
<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8"><title>PR #513 折叠面板新建入口 · 界面示意</title>
<style>
  /* 静态示意:值取 Default Light 主题 token(实现内全部经 var(--*) 消费,无硬编码) */
  body{margin:0;padding:28px;background:#f8f8f6;font:13px/1.5 Inter,-apple-system,"PingFang SC",sans-serif;color:#262626;display:flex;gap:28px;align-items:flex-start;flex-wrap:wrap}
  .panel{width:264px;background:#fff;border:1px solid #d7d7d4;border-radius:12px;padding:6px;box-shadow:0 8px 24px rgba(0,0,0,.08)}
  .head{display:flex;align-items:baseline;gap:6px;padding:6px 10px 4px}
  .head b{flex:1;font-size:12.5px;font-weight:800;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
  .head small{font-size:10px;color:#a3a3a3}
  .newbtn{width:24px;height:24px;margin:-4px 0;border:0;background:none;border-radius:6px;display:flex;align-items:center;justify-content:center;color:#a3a3a3;cursor:pointer;align-self:center}
  .newbtn:hover{color:#737373}
  .newbtn:focus-visible{outline:none;box-shadow:0 0 0 2px #417CDD}
  .newbtn[disabled]{opacity:.4;cursor:default}
  .row{display:flex;align-items:center;gap:8px;height:32px;padding:0 6px 0 10px;border-radius:8px;font-weight:500}
  .row:hover{background:#f0f0ee}
  .row .t{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
  .row .n{font-size:10px;color:#a3a3a3;font-variant-numeric:tabular-nums}
  .row .c{color:#a3a3a3;font-size:11px}
  .menu{width:180px;background:#fff;border:1px solid #d7d7d4;border-radius:12px;padding:4px;box-shadow:0 8px 24px rgba(0,0,0,.12)}
  .mi{padding:6px 10px;border-radius:8px;font-size:13px}
  .mi:hover{background:#f0f0ee}
  .cap{font-size:11px;color:#737373;margin:8px 0 0;max-width:264px}
  .anno{position:relative}
  .anno::after{content:attr(data-tip);position:absolute;left:0;top:100%;margin-top:6px;font-size:10px;color:#417CDD}
  svg{display:block}
</style></head><body>

<!-- ① 对话面板:头部新增 SquarePen「新对话」 -->
<div>
  <div class="panel">
    <div class="head"><b>对话</b><small>59 个会话</small>
      <button class="newbtn anno" aria-label="新对话" data-tip="① 新对话(段头同款)">
        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
      </button>
    </div>
    <div class="row"><span class="t">新版功能配置</span><span class="n">17 分钟</span></div>
    <div class="row"><span class="t">客服费用查询</span><span class="n">2 天</span></div>
  </div>
  <p class="cap">① 对话面板头部 SquarePen(与展开态 DialogueSection 段头同款图标/配色/文案),Tab 聚焦显示 --focus-ring 焦点环。</p>
</div>

<!-- ② 项目三级面板:头部「在此目录新建会话」;远程写保护时置灰 -->
<div>
  <div class="panel">
    <div class="head"><b>cindy-rail-live</b><small>16 个会话</small>
      <button class="newbtn anno" aria-label="在此目录新建会话" data-tip="② 在此目录新建会话">
        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
      </button>
    </div>
    <div class="row"><span class="t">rail 重设计</span><span class="n">1 小时</span></div>
    <div class="row"><span class="t">面板行为对齐</span><span class="n">3 天</span></div>
  </div>
  <div class="panel" style="margin-top:12px">
    <div class="head"><b>macmini(远程·断连)</b><small>8 个会话</small>
      <button class="newbtn" disabled aria-label="操作不可用" title="操作不可用">
        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
      </button>
    </div>
  </div>
  <p class="cap">② 项目三级面板头部同款按钮;device-link 断连的远程项目与展开态同语义置灰(opacity .4 + 「操作不可用」)。</p>
</div>

<!-- ③ 项目行右键菜单 -->
<div>
  <div class="panel">
    <div class="head"><b>项目</b><small>7 个会话</small></div>
    <div class="row" style="background:#f0f0ee"><span class="t">📁 cindy-rail-live</span><span class="n">16</span><span class="c">›</span></div>
    <div class="row"><span class="t">📁 session-backup</span><span class="n">4</span><span class="c">›</span></div>
  </div>
  <div class="menu" style="margin:6px 0 0 96px">
    <div class="mi">在此目录新建会话</div>
  </div>
  <p class="cap">③ 项目行右键(或 Shift+F10,键盘时按行矩形定位)弹出菜单;菜单容器与 Automations 菜单同款 token(cmd-palette 系 + shadow-menu)。</p>
</div>

</body></html>
```

- 引用的设计规范:`docs/design-rules/DESIGN.md` §10(Theme System:组件不写 hex,全部经 token 消费——本 PR 仅复用上述既有 token,无新增色值);交互沿用展开态同名入口的既有行为契约,未引入新交互模式。

## 怎么验证的

### 自动验证

```text
cd apps/desktop && npx tsc --noEmit -p tsconfig.json
结果:0 错误
cd apps/desktop && npx vitest run src/renderer/features/cc-agent
结果:Test Files 24 passed (24) / Tests 177 passed (177)
```

### 手工验证

macOS 源码版(`pnpm restart:desktop:remote`,真实账号数据),由提出需求的用户逐项验收通过:对话面板头部新建 → 进入新建页(对话模式);项目三级面板头部新建 → 带该项目 workingDir 进入新建页;项目行右键菜单弹出稳定、点击「在此目录新建会话」行为同上;面板均随创建动作收起。

### 未执行的验证

无自动化 UI 交互测试覆盖(依赖真实 DOM / 路由导航,jsdom 不适用),以上述手工验收为准。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅折叠 rail 面板新增入口,不触碰新建流程与展开态
- 已知限制:无(远程写保护项目的面板入口已与展开态同语义禁用,commit 1ed67c763)
- 回滚 / 降级方式:revert 本 feature commit 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因



