### PR TITLE
feat(desktop): 协同 Worker 创建开满标准模型选择面板,来源全链显式下发

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
@@ -1308,6 +1308,118 @@ describe('buildNoProviderMessage', () => {
     });
   });
 
+  it('normalizes effort against the explicit provider catalog entry, not the flattened union', async () => {
+    // gpt-5.5 的拍平首见条目只有 medium 档,而显式来源 openai 的同 id 条目支持
+    // low/medium/high:explicit effort=high 必须按 openai 自己的元数据放行,不被
+    // 拍平条目在 resolveWorkerConfig 内 error 早退误拒(codex review)。
+    const { service } = createDeps({
+      getAvailableModels: vi.fn((agent: AgentKind) => (
+        agent === 'codex'
+          ? [{ id: 'gpt-5.5', efforts: ['medium'], defaultEffort: 'medium', supportsFastMode: false }]
+          : []
+      )),
+      getProviderRoutingContext: vi.fn(async () => providerRoutingContext({
+        'claude-code': [],
+        codex: [
+          { id: 'xd', name: 'XD Gateway', models: ['gpt-5.5'] },
+          {
+            id: 'openai',
+            name: 'OpenAI',
+            models: ['gpt-5.5'],
+            effortMetaByModel: {
+              'gpt-5.5': { efforts: ['low', 'medium', 'high'], defaultEffort: 'high' },
+            },
+          },
+        ],
+      })),
+    });
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      effort: 'high',
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { providerId: 'openai', effort: 'high' },
+    });
+  });
+
+  it('rejects efforts the explicit no-effort provider copy does not support and defaults to null', async () => {
+    // 自定义来源的 gpt-5.5 副本无 effort 档(efforts:[]):explicit effort 必须按该
+    // 来源条目拒绝,不能沿用拍平首见条目的档位表放行;非显式输入则落该来源的
+    // defaultEffort(null),不带着拍平归一出的档位派发(codex review)。
+    const routing = () => providerRoutingContext({
+      'claude-code': [],
+      codex: [
+        { id: 'xd', name: 'XD Gateway', models: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'codex/budget'] },
+        {
+          id: 'custom',
+          name: 'Custom Gateway',
+          models: ['gpt-5.5'],
+          effortMetaByModel: { 'gpt-5.5': { efforts: [], defaultEffort: null } },
+        },
+      ],
+    });
+
+    const rejected = createDeps({ getProviderRoutingContext: vi.fn(async () => routing()) });
+    await expect(rejected.service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: 'custom',
+      effort: 'high',
+    })).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'INVALID_PARAMS',
+    });
+
+    const defaulted = createDeps({ getProviderRoutingContext: vi.fn(async () => routing()) });
+    await expect(defaulted.service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: 'custom',
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { providerId: 'custom', effort: null },
+    });
+  });
+
+  it('renormalizes effort against the default route provider when no explicit source is set', async () => {
+    // 未显式选来源时实际路由来源是 lead/defaults 解析出的 xd:其 gpt-5.5 条目只有
+    // low 档,lead effort=medium 按拍平条目(四档)归一原样通过,必须再按路由来源
+    // 条目重归一落到该来源的 defaultEffort(codex review;与 Fast 的路由来源口径一致)。
+    const { service } = createDeps({
+      getProviderRoutingContext: vi.fn(async () => providerRoutingContext({
+        'claude-code': [],
+        codex: [{
+          id: 'xd',
+          name: 'XD Gateway',
+          models: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'codex/budget'],
+          effortMetaByModel: { 'gpt-5.5': { efforts: ['low'], defaultEffort: 'low' } },
+        }],
+      })),
+    });
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { model: 'gpt-5.5', effort: 'low' },
+    });
+  });
+
   it('rejects an explicit provider that does not offer the requested model', async () => {
     const { deps, service } = createDeps({
       getProviderRoutingContext: vi.fn(async () => providerRoutingContext({

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
@@ -1255,6 +1255,59 @@ describe('buildNoProviderMessage', () => {
     });
   });
 
+  it('resolves Fast from the explicit provider catalog entry, not the flattened union', async () => {
+    // gpt-5.5 在 xd(拍平清单首来源,不支持 Fast)与 openai(支持)都有:显式选 openai
+    // 时 Fast 必须按 openai 自己的条目放行,不被拍平首来源误杀;反向显式选 xd 时压掉。
+    const routing = () => providerRoutingContext({
+      'claude-code': [],
+      codex: [
+        { id: 'xd', name: 'XD Gateway', models: ['gpt-5.5'], fastModels: [] },
+        { id: 'openai', name: 'OpenAI', models: ['gpt-5.5'], fastModels: ['gpt-5.5'] },
+      ],
+    });
+    const supportsFastByUnion = (supported: boolean) => vi.fn((agent: AgentKind) => (
+      agent === 'codex'
+        ? [{ id: 'gpt-5.5', efforts: ['high'], defaultEffort: 'high', supportsFastMode: supported }]
+        : []
+    ));
+
+    const enabled = createDeps({
+      getProviderRoutingContext: vi.fn(async () => routing()),
+      // 拍平清单说不支持(首来源 xd wins)——显式 openai 仍应放行。
+      getAvailableModels: supportsFastByUnion(false),
+    });
+    await expect(enabled.service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      fast: true,
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { providerId: 'openai', fastMode: true },
+    });
+
+    const suppressed = createDeps({
+      getProviderRoutingContext: vi.fn(async () => routing()),
+      // 拍平清单说支持(假设首来源换位)——显式 xd 不支持,必须压掉。
+      getAvailableModels: supportsFastByUnion(true),
+    });
+    await expect(suppressed.service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: 'xd',
+      fast: true,
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { providerId: 'xd', fastMode: false },
+    });
+  });
+
   it('rejects an explicit provider that does not offer the requested model', async () => {
     const { deps, service } = createDeps({
       getProviderRoutingContext: vi.fn(async () => providerRoutingContext({

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
@@ -1206,4 +1206,82 @@ describe('buildNoProviderMessage', () => {
     expect(msg).toContain('设置 → 模型供应商');
     expect(msg).not.toContain('改用');
   });
+
+  it('honors an explicit panel-selected provider over the forced default route', async () => {
+    const { deps, service } = createDeps({
+      getProviderRoutingContext: vi.fn(async () => providerRoutingContext({
+        'claude-code': [],
+        codex: [
+          { id: 'xd', name: 'XD Gateway', models: ['gpt-5.5'] },
+          { id: 'openai', name: 'OpenAI', models: ['gpt-5.5'] },
+        ],
+      })),
+    });
+
+    // 显式 model 且未显式来源时既有语义是强制默认路由(providerId=null);
+    // 标准面板显式选定来源后必须原样生效,不再被强制回落。
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: 'openai',
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { providerId: 'openai', model: 'gpt-5.5' },
+    });
+
+    expect(deps.buildCreateOptsWithStderr).toHaveBeenCalledWith(expect.objectContaining({
+      providerId: 'openai',
+      model: 'gpt-5.5',
+    }));
+  });
+
+  it('rejects an explicit provider that does not offer the requested model', async () => {
+    const { deps, service } = createDeps({
+      getProviderRoutingContext: vi.fn(async () => providerRoutingContext({
+        'claude-code': [],
+        codex: [
+          { id: 'xd', name: 'XD Gateway', models: ['gpt-5.5'] },
+          { id: 'openai', name: 'OpenAI', models: ['gpt-5.4'] },
+        ],
+      })),
+    });
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: 'openai',
+    })).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'PROVIDER_ROUTE_UNAVAILABLE',
+    });
+    expect(deps.bootstrapSession).not.toHaveBeenCalled();
+  });
+
+  it('does not demand the gateway API key for a budget model on an explicit non-gateway route', async () => {
+    const { service } = createDeps({
+      getProviderRoutingContext: vi.fn(async () => providerRoutingContext({
+        'claude-code': [],
+        codex: [{ id: 'custom-codex', name: 'Custom Codex', models: ['codex/budget'] }],
+      })),
+      readClaudeApiKey: vi.fn((): string | null => null),
+    });
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'codex/budget',
+      providerId: 'custom-codex',
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { providerId: 'custom-codex', model: 'codex/budget' },
+    });
+  });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
@@ -1238,6 +1238,23 @@ describe('buildNoProviderMessage', () => {
     }));
   });
 
+  it('treats an empty-string providerId as not-explicit and keeps the forced default route', async () => {
+    const { service } = createDeps();
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      providerId: '',
+    })).resolves.toMatchObject({
+      ok: true,
+      // 与「显式 model 未显式来源」同语义:providerId 强制默认路由,不进显式 preflight。
+      resolved: { providerId: null, model: 'gpt-5.5' },
+    });
+  });
+
   it('rejects an explicit provider that does not offer the requested model', async () => {
     const { deps, service } = createDeps({
       getProviderRoutingContext: vi.fn(async () => providerRoutingContext({

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
@@ -1393,6 +1393,60 @@ describe('buildNoProviderMessage', () => {
     });
   });
 
+  it('allows an explicit effort the flattened descriptor lacks when the route provider supports it', async () => {
+    // 拍平首见条目(可能来自已断开来源,不含连接态)缺 xhigh,而实际路由来源
+    // (未显式时的生效默认来源)支持:explicit effort 不得在首次归一处 error 早退,
+    // 暂存后由路由来源档位表裁决放行(codex review)。
+    const { service } = createDeps({
+      getAvailableModels: vi.fn((agent: AgentKind) => (
+        agent === 'codex'
+          ? [{ id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false }]
+          : []
+      )),
+      getProviderRoutingContext: vi.fn(async () => providerRoutingContext({
+        'claude-code': [],
+        codex: [{
+          id: 'xd',
+          name: 'XD Gateway',
+          models: ['gpt-5.5'],
+          effortMetaByModel: {
+            'gpt-5.5': { efforts: ['low', 'medium', 'high', 'xhigh'], defaultEffort: 'high' },
+          },
+        }],
+      })),
+    });
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      effort: 'xhigh',
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { model: 'gpt-5.5', effort: 'xhigh' },
+    });
+  });
+
+  it('surfaces the flattened rejection when the route provider carries no effort metadata', async () => {
+    // 路由来源无 effort 元数据(旧组装方)时没有更权威的档位表:explicit 无效输入
+    // 的暂存拒绝按拍平条目落地,不静默吞掉派发 null(行为与重构前一致)。
+    const { service } = createDeps();
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'reviewer',
+      agent: 'codex',
+      label: 'reviewer',
+      model: 'gpt-5.5',
+      effort: 'ultra',
+    })).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'INVALID_PARAMS',
+    });
+  });
+
   it('renormalizes effort against the default route provider when no explicit source is set', async () => {
     // 未显式选来源时实际路由来源是 lead/defaults 解析出的 xd:其 gpt-5.5 条目只有
     // low 档,lead effort=medium 按拍平条目(四档)归一原样通过,必须再按路由来源

--- a/apps/desktop/src/main/maker-ipc/orcaLifecycleService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaLifecycleService.ts
@@ -21,6 +21,8 @@ export interface OrcaEnableTeamParams {
   model?: string;
   effort?: OrcaWorkerEffort;
   fast?: boolean;
+  /** 显式选定的模型来源;语义见 OrcaWorkerCreateParams.providerId。 */
+  providerId?: string | null;
   delegateTask?: string;
 }
 
@@ -123,6 +125,7 @@ function normalizeEnableParams(params: OrcaEnableTeamParams): OrcaWorkerCreatePa
     model: params.model?.trim() || undefined,
     effort: params.effort,
     fast: params.fast,
+    providerId: params.providerId,
     initialTask: delegateTask,
   };
 }

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -271,6 +271,14 @@ type ResolveWorkerConfigResult =
       effort: string | null;
       fastMode: boolean;
       providerId: string | null;
+      /**
+       * 显式 effort 被拍平首见条目拒绝的**暂存**错误:拍平清单(首来源 wins,不含
+       * 连接态)不是档位权威 —— 实际路由来源(显式/缓存/默认解析)的条目可能支持
+       * 该档(如首见来源已断开且缺 xhigh,而生效默认来源提供,codex review)。由
+       * 调用方在解析出路由来源后裁决:有该来源元数据则按它重归一定论;没有(旧
+       * 组装方)才按本错误落地。
+       */
+      pendingEffortError?: string;
     }
   | {
       ok: false;
@@ -319,17 +327,8 @@ function resolveWorkerConfig(params: {
   lead: OrcaLeadSessionSnapshot;
   defaults: OrcaWorkerDefaultsSnapshot;
   availableModels: OrcaWorkerModelCapabilities[];
-  /**
-   * 显式来源对某 model 的 effort 元数据;返回 undefined(未显式选来源 / 来源无该
-   * 元数据)时按拍平清单条目归一。effort 档位是 per-(provider, model) 的,显式来源
-   * 的归一必须用它自己的条目,否则拍平首见条目会误拒该来源支持的档位(explicit
-   * 时归一直接 error 早退)或误放行它不支持的档位(codex review)。
-   */
-  explicitEffortMeta?: (
-    model: string,
-  ) => { efforts: readonly string[]; defaultEffort: string | null } | undefined;
 }): ResolveWorkerConfigResult {
-  const { input, lead, defaults, availableModels, explicitEffortMeta } = params;
+  const { input, lead, defaults, availableModels } = params;
   const model = input.model
     ?? defaults.model
     ?? (input.agent === lead.agentKind ? lead.model : input.agent === 'codex' ? 'gpt-5.5' : 'claude-sonnet-4-6');
@@ -340,23 +339,18 @@ function resolveWorkerConfig(params: {
       message: `model "${model}" not available for ${input.agent}. valid: ${availableModels.map((candidate) => candidate.id).join(', ')}`,
     };
   }
-  const sourceEffortMeta = explicitEffortMeta?.(model);
   const normalizedEffort = normalizeResolvedEffort({
-    model: sourceEffortMeta
-      ? {
-          id: model,
-          efforts: sourceEffortMeta.efforts,
-          defaultEffort: sourceEffortMeta.defaultEffort,
-        }
-      : modelCapabilities,
+    model: modelCapabilities,
     effort: input.effort ?? defaults.effort ?? lead.effort,
     explicit: input.effort !== undefined,
   });
-  if (!normalizedEffort.ok) return normalizedEffort;
   return {
     ok: true,
     model,
-    effort: normalizedEffort.effort,
+    // 归一 !ok 只发生在 explicit 输入:此处不 error 早退,暂存给调用方按实际路由
+    // 来源的档位表裁决(见 pendingEffortError 注);其余字段照常解析。
+    effort: normalizedEffort.ok ? normalizedEffort.effort : null,
+    ...(normalizedEffort.ok ? {} : { pendingEffortError: normalizedEffort.message }),
     providerId: defaults.providerId !== undefined
       ? defaults.providerId
       : (input.agent === lead.agentKind ? lead.providerId : null),
@@ -505,18 +499,7 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
       typeof params.providerId === 'string' && params.providerId.trim().length > 0
         ? params.providerId.trim()
         : null;
-    const explicitSourceProvider = explicitSourceId === null
-      ? undefined
-      : agentProviders.find((provider) => provider.id === explicitSourceId);
-    const resolvedConfig = resolveWorkerConfig({
-      input: params,
-      lead,
-      defaults,
-      availableModels,
-      // 显式来源的 effort 归一必须按该来源自己的条目(codex review):explicit effort
-      // 被拍平首见条目误拒发生在归一内部的 error 早退,后面按路由来源的重归一救不了。
-      explicitEffortMeta: (model) => explicitSourceProvider?.effortMetaByModel?.[model],
-    });
+    const resolvedConfig = resolveWorkerConfig({ input: params, lead, defaults, availableModels });
     if (!resolvedConfig.ok) {
       return { ok: false, errorCode: 'INVALID_PARAMS', message: resolvedConfig.message };
     }
@@ -575,11 +558,14 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
         : (defaults.fastMode ?? !!lead.fastMode);
       resolved.fastMode = providerSupportsFast && requestedFast === true;
     }
-    // effort 按路由来源自己的条目**重归一**:resolveWorkerConfig 已按拍平首见条目
-    // 归一过,但自定义来源的同 id 模型 efforts/defaultEffort 可分叉 —— 面板行按
-    // 该来源元数据显示可选档位,创建却按首见条目得出 effort:null,或反向拒绝该行
-    // 支持的档位(codex review)。重归一用与 resolveWorkerConfig 相同的**原始输入**,
-    // 不能拿已归一的 resolved.effort 二次级联;无元数据(旧组装方)保留拍平归一结果。
+    // effort 按路由来源自己的条目**重归一定论**:resolveWorkerConfig 按拍平首见
+    // 条目归一只是初值(该条目不含连接态、同 id 模型档位表跨来源可分叉),显式
+    // 来源、defaults 缓存来源与默认解析来源统一在这里按权威档位表收口 —— 误放行
+    // (无档副本携带拍平档位)与误拒(路由来源支持而拍平缺档,explicit 输入已被
+    // 暂存为 pendingEffortError,不在归一处 error 早退)两个方向都在此裁决
+    // (codex review 两轮)。重归一用与 resolveWorkerConfig 相同的**原始输入**,
+    // 不拿已归一值二次级联;路由来源无元数据(旧组装方)时没有更权威的档位表,
+    // 按拍平结果落地 —— 含暂存的拒绝。
     const routeEffortMeta = routeProvider?.effortMetaByModel?.[resolved.model];
     if (routeEffortMeta) {
       const renormalized = normalizeResolvedEffort({
@@ -595,6 +581,8 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
         return { ok: false, errorCode: 'INVALID_PARAMS', message: renormalized.message };
       }
       resolved.effort = renormalized.effort;
+    } else if (resolvedConfig.pendingEffortError) {
+      return { ok: false, errorCode: 'INVALID_PARAMS', message: resolvedConfig.pendingEffortError };
     }
     const budgetRouteProviderId = explicitSourceId !== null
       ? explicitSourceId

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -501,8 +501,8 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
     // 共用内核自防调用方漏归一),维持既有解析,包括「显式 model 不等于显式来源」的
     // 强制默认路由与 requiresExplicitRoute 唯一来源救援。
     const explicitSourceId =
-      typeof params.providerId === 'string' && params.providerId.length > 0
-        ? params.providerId
+      typeof params.providerId === 'string' && params.providerId.trim().length > 0
+        ? params.providerId.trim()
         : null;
     const resolved = {
       ...resolvedConfig,

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -48,6 +48,15 @@ export interface OrcaWorkerProviderSnapshot {
    * 回落拍平清单解析(兼容旧组装方,不整体压灭 Fast)。
    */
   fastModels?: readonly string[];
+  /**
+   * 该来源下各模型的 effort 元数据。effort 档位同样是 per-(provider, model) 的:
+   * 自定义来源追加同 id 模型时不经过基础目录的跨来源一致性校验,efforts /
+   * defaultEffort 可与拍平清单的首见条目分叉;缺省 = 该快照来源未提供 effort
+   * 元数据,effort 归一保留拍平清单解析(兼容旧组装方)。
+   */
+  effortMetaByModel?: Readonly<
+    Record<string, { efforts: readonly string[]; defaultEffort: string | null }>
+  >;
   /** true 表示该来源必须写入 session provider store 才能注入自己的 API key/OAuth token。 */
   requiresExplicitRoute?: boolean;
 }
@@ -310,8 +319,17 @@ function resolveWorkerConfig(params: {
   lead: OrcaLeadSessionSnapshot;
   defaults: OrcaWorkerDefaultsSnapshot;
   availableModels: OrcaWorkerModelCapabilities[];
+  /**
+   * 显式来源对某 model 的 effort 元数据;返回 undefined(未显式选来源 / 来源无该
+   * 元数据)时按拍平清单条目归一。effort 档位是 per-(provider, model) 的,显式来源
+   * 的归一必须用它自己的条目,否则拍平首见条目会误拒该来源支持的档位(explicit
+   * 时归一直接 error 早退)或误放行它不支持的档位(codex review)。
+   */
+  explicitEffortMeta?: (
+    model: string,
+  ) => { efforts: readonly string[]; defaultEffort: string | null } | undefined;
 }): ResolveWorkerConfigResult {
-  const { input, lead, defaults, availableModels } = params;
+  const { input, lead, defaults, availableModels, explicitEffortMeta } = params;
   const model = input.model
     ?? defaults.model
     ?? (input.agent === lead.agentKind ? lead.model : input.agent === 'codex' ? 'gpt-5.5' : 'claude-sonnet-4-6');
@@ -322,8 +340,15 @@ function resolveWorkerConfig(params: {
       message: `model "${model}" not available for ${input.agent}. valid: ${availableModels.map((candidate) => candidate.id).join(', ')}`,
     };
   }
+  const sourceEffortMeta = explicitEffortMeta?.(model);
   const normalizedEffort = normalizeResolvedEffort({
-    model: modelCapabilities,
+    model: sourceEffortMeta
+      ? {
+          id: model,
+          efforts: sourceEffortMeta.efforts,
+          defaultEffort: sourceEffortMeta.defaultEffort,
+        }
+      : modelCapabilities,
     effort: input.effort ?? defaults.effort ?? lead.effort,
     explicit: input.effort !== undefined,
   });
@@ -472,7 +497,26 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
     }
 
     const defaults = deps.getWorkerDefaults(params.agent);
-    const resolvedConfig = resolveWorkerConfig({ input: params, lead, defaults, availableModels });
+    // 标准面板显式选定的来源(非空 string)直接生效,由下方精确 preflight 把关「已连接且
+    // 提供该模型」;空串/null/undefined 一律按未显式处理(与 IPC 边界同口径,service 作为
+    // 共用内核自防调用方漏归一),维持既有解析,包括「显式 model 不等于显式来源」的
+    // 强制默认路由与 requiresExplicitRoute 唯一来源救援。
+    const explicitSourceId =
+      typeof params.providerId === 'string' && params.providerId.trim().length > 0
+        ? params.providerId.trim()
+        : null;
+    const explicitSourceProvider = explicitSourceId === null
+      ? undefined
+      : agentProviders.find((provider) => provider.id === explicitSourceId);
+    const resolvedConfig = resolveWorkerConfig({
+      input: params,
+      lead,
+      defaults,
+      availableModels,
+      // 显式来源的 effort 归一必须按该来源自己的条目(codex review):explicit effort
+      // 被拍平首见条目误拒发生在归一内部的 error 早退,后面按路由来源的重归一救不了。
+      explicitEffortMeta: (model) => explicitSourceProvider?.effortMetaByModel?.[model],
+    });
     if (!resolvedConfig.ok) {
       return { ok: false, errorCode: 'INVALID_PARAMS', message: resolvedConfig.message };
     }
@@ -497,14 +541,6 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
     const cachedProviderFallback = cachedProviderFallbackId === null
       ? undefined
       : agentProviders.find((provider) => provider.id === cachedProviderFallbackId);
-    // 标准面板显式选定的来源(非空 string)直接生效,由下方精确 preflight 把关「已连接且
-    // 提供该模型」;空串/null/undefined 一律按未显式处理(与 IPC 边界同口径,service 作为
-    // 共用内核自防调用方漏归一),维持既有解析,包括「显式 model 不等于显式来源」的
-    // 强制默认路由与 requiresExplicitRoute 唯一来源救援。
-    const explicitSourceId =
-      typeof params.providerId === 'string' && params.providerId.trim().length > 0
-        ? params.providerId.trim()
-        : null;
     const resolved = {
       ...resolvedConfig,
       // 仅显式指定 model 不等于显式选择来源：providerId=null 必须保留 spawn-aware 默认路由。
@@ -521,23 +557,44 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
               ? (cachedProviderFallback?.requiresExplicitRoute ? cachedProviderFallback.id : null)
               : resolvedConfig.providerId,
     };
-    // Fast 按**实际路由来源**自己的模型条目判定(显式来源、defaults 缓存来源、
-    // spawn 默认来源统一)—— getAvailableModels 是跨来源拍平清单(首来源 wins,且不含
-    // 连接态),同 id 模型的 supportsFastMode 在不同来源可分叉:首来源不支持会误杀
-    // 真实路由来源的 Fast,反向则把 Fast 放到不支持的来源上(codex review 两轮)。
-    const fastRouteProviderId = explicitSourceId
+    // Fast 与 effort 都按**实际路由来源**自己的模型条目判定(显式来源、defaults 缓存
+    // 来源、spawn 默认来源统一)—— getAvailableModels 是跨来源拍平清单(首来源 wins,
+    // 且不含连接态),同 id 模型的 supportsFastMode / efforts 在不同来源可分叉:首来源
+    // 的元数据会误杀或误放行真实路由来源的能力(codex review 三轮)。
+    const routeProviderId = explicitSourceId
       ?? resolved.providerId
       ?? providerRouting.resolveDefaultProviderIdForModel(params.agent, resolved.model);
-    const fastRouteProvider = fastRouteProviderId === null
+    const routeProvider = routeProviderId === null
       ? undefined
-      : agentProviders.find((provider) => provider.id === fastRouteProviderId);
+      : agentProviders.find((provider) => provider.id === routeProviderId);
     // 只有该来源确实带了 Fast 元数据才覆盖;无元数据(旧组装方)保留拍平解析。
-    if (fastRouteProvider?.fastModels) {
-      const providerSupportsFast = fastRouteProvider.fastModels.includes(resolved.model);
+    if (routeProvider?.fastModels) {
+      const providerSupportsFast = routeProvider.fastModels.includes(resolved.model);
       const requestedFast = params.agent === 'codex' && params.fast !== undefined
         ? params.fast
         : (defaults.fastMode ?? !!lead.fastMode);
       resolved.fastMode = providerSupportsFast && requestedFast === true;
+    }
+    // effort 按路由来源自己的条目**重归一**:resolveWorkerConfig 已按拍平首见条目
+    // 归一过,但自定义来源的同 id 模型 efforts/defaultEffort 可分叉 —— 面板行按
+    // 该来源元数据显示可选档位,创建却按首见条目得出 effort:null,或反向拒绝该行
+    // 支持的档位(codex review)。重归一用与 resolveWorkerConfig 相同的**原始输入**,
+    // 不能拿已归一的 resolved.effort 二次级联;无元数据(旧组装方)保留拍平归一结果。
+    const routeEffortMeta = routeProvider?.effortMetaByModel?.[resolved.model];
+    if (routeEffortMeta) {
+      const renormalized = normalizeResolvedEffort({
+        model: {
+          id: resolved.model,
+          efforts: routeEffortMeta.efforts,
+          defaultEffort: routeEffortMeta.defaultEffort,
+        },
+        effort: params.effort ?? defaults.effort ?? lead.effort,
+        explicit: params.effort !== undefined,
+      });
+      if (!renormalized.ok) {
+        return { ok: false, errorCode: 'INVALID_PARAMS', message: renormalized.message };
+      }
+      resolved.effort = renormalized.effort;
     }
     const budgetRouteProviderId = explicitSourceId !== null
       ? explicitSourceId

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -44,7 +44,8 @@ export interface OrcaWorkerProviderSnapshot {
   models: readonly string[];
   /**
    * 该来源下 supportsFastMode 的模型 id 集合。Fast 能力是 per-(provider, model) 的,
-   * 同 id 模型在不同来源可分叉;缺省 = 该快照来源无 Fast 元数据,按不支持处理。
+   * 同 id 模型在不同来源可分叉;缺省 = 该快照来源未提供 Fast 元数据,Fast 判定
+   * 回落拍平清单解析(兼容旧组装方,不整体压灭 Fast)。
    */
   fastModels?: readonly string[];
   /** true 表示该来源必须写入 session provider store 才能注入自己的 API key/OAuth token。 */
@@ -520,15 +521,19 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
               ? (cachedProviderFallback?.requiresExplicitRoute ? cachedProviderFallback.id : null)
               : resolvedConfig.providerId,
     };
-    // 显式来源下 Fast 按该来源自己的模型条目判定 —— getAvailableModels 是跨来源拍平
-    // 清单(首来源 wins),同 id 模型的 supportsFastMode 在不同来源可分叉:首来源不支持
-    // 会误杀显式来源真正支持的 Fast,反向则可能把 Fast 放到不支持的来源上(codex review)。
-    if (explicitSourceId !== null) {
-      const explicitRouteProvider = agentProviders.find(
-        (provider) => provider.id === explicitSourceId,
-      );
-      const providerSupportsFast =
-        explicitRouteProvider?.fastModels?.includes(resolved.model) === true;
+    // Fast 按**实际路由来源**自己的模型条目判定(显式来源、defaults 缓存来源、
+    // spawn 默认来源统一)—— getAvailableModels 是跨来源拍平清单(首来源 wins,且不含
+    // 连接态),同 id 模型的 supportsFastMode 在不同来源可分叉:首来源不支持会误杀
+    // 真实路由来源的 Fast,反向则把 Fast 放到不支持的来源上(codex review 两轮)。
+    const fastRouteProviderId = explicitSourceId
+      ?? resolved.providerId
+      ?? providerRouting.resolveDefaultProviderIdForModel(params.agent, resolved.model);
+    const fastRouteProvider = fastRouteProviderId === null
+      ? undefined
+      : agentProviders.find((provider) => provider.id === fastRouteProviderId);
+    // 只有该来源确实带了 Fast 元数据才覆盖;无元数据(旧组装方)保留拍平解析。
+    if (fastRouteProvider?.fastModels) {
+      const providerSupportsFast = fastRouteProvider.fastModels.includes(resolved.model);
       const requestedFast = params.agent === 'codex' && params.fast !== undefined
         ? params.fast
         : (defaults.fastMode ?? !!lead.fastMode);

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -130,6 +130,13 @@ export interface OrcaWorkerCreateParams {
   model?: string;
   effort?: OrcaWorkerEffort;
   fast?: boolean;
+  /**
+   * 显式选定的模型来源(标准模型选择面板的 per-worker 选择)。string = 显式来源,
+   * 走下方精确 preflight 校验「已连接且提供该模型」,不满足即失败,不静默换路由;
+   * undefined / null = 未显式选择,沿用 defaults 缓存 / Lead 继承 / spawn-aware
+   * 默认路由的既有解析(含 requiresExplicitRoute 唯一来源救援与 stale 回落)。
+   */
+  providerId?: string | null;
   initialTask?: string;
 }
 
@@ -484,23 +491,31 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
     const cachedProviderFallback = cachedProviderFallbackId === null
       ? undefined
       : agentProviders.find((provider) => provider.id === cachedProviderFallbackId);
+    // 标准面板显式选定的来源(string)直接生效,由下方精确 preflight 把关「已连接且
+    // 提供该模型」;null/undefined 维持既有解析,包括「显式 model 不等于显式来源」的
+    // 强制默认路由与 requiresExplicitRoute 唯一来源救援。
+    const explicitSourceId = typeof params.providerId === 'string' ? params.providerId : null;
     const resolved = {
       ...resolvedConfig,
       // 仅显式指定 model 不等于显式选择来源：providerId=null 必须保留 spawn-aware 默认路由。
       // 例外是该模型只有一个来源且它必须依赖 session provider store 注入自己的凭证。
-      providerId: params.model !== undefined
-        && explicitModelProviders.length === 1
-        && explicitModelProvider?.requiresExplicitRoute
-        ? explicitModelProvider.id
+      providerId: explicitSourceId !== null
+        ? explicitSourceId
         : params.model !== undefined
-          ? null
-          : cachedProviderRouteIsStale
-            ? (cachedProviderFallback?.requiresExplicitRoute ? cachedProviderFallback.id : null)
-            : resolvedConfig.providerId,
+          && explicitModelProviders.length === 1
+          && explicitModelProvider?.requiresExplicitRoute
+          ? explicitModelProvider.id
+          : params.model !== undefined
+            ? null
+            : cachedProviderRouteIsStale
+              ? (cachedProviderFallback?.requiresExplicitRoute ? cachedProviderFallback.id : null)
+              : resolvedConfig.providerId,
     };
-    const budgetRouteProviderId = params.model !== undefined
-      ? explicitModelDefaultProviderId
-      : (cachedProviderRouteIsStale ? cachedProviderFallbackId : resolved.providerId);
+    const budgetRouteProviderId = explicitSourceId !== null
+      ? explicitSourceId
+      : params.model !== undefined
+        ? explicitModelDefaultProviderId
+        : (cachedProviderRouteIsStale ? cachedProviderFallbackId : resolved.providerId);
 
     // codex/ 预算模型依赖 Cindy AI API key；XD/default 路由即使因 provider 缺失，
     // 也要先返回这条可操作的凭证错误，避免被下方通用的精确路由失败遮蔽。

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -491,10 +491,14 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
     const cachedProviderFallback = cachedProviderFallbackId === null
       ? undefined
       : agentProviders.find((provider) => provider.id === cachedProviderFallbackId);
-    // 标准面板显式选定的来源(string)直接生效,由下方精确 preflight 把关「已连接且
-    // 提供该模型」;null/undefined 维持既有解析,包括「显式 model 不等于显式来源」的
+    // 标准面板显式选定的来源(非空 string)直接生效,由下方精确 preflight 把关「已连接且
+    // 提供该模型」;空串/null/undefined 一律按未显式处理(与 IPC 边界同口径,service 作为
+    // 共用内核自防调用方漏归一),维持既有解析,包括「显式 model 不等于显式来源」的
     // 强制默认路由与 requiresExplicitRoute 唯一来源救援。
-    const explicitSourceId = typeof params.providerId === 'string' ? params.providerId : null;
+    const explicitSourceId =
+      typeof params.providerId === 'string' && params.providerId.length > 0
+        ? params.providerId
+        : null;
     const resolved = {
       ...resolvedConfig,
       // 仅显式指定 model 不等于显式选择来源：providerId=null 必须保留 spawn-aware 默认路由。

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -42,6 +42,11 @@ export interface OrcaWorkerProviderSnapshot {
   id: string;
   name: string;
   models: readonly string[];
+  /**
+   * 该来源下 supportsFastMode 的模型 id 集合。Fast 能力是 per-(provider, model) 的,
+   * 同 id 模型在不同来源可分叉;缺省 = 该快照来源无 Fast 元数据,按不支持处理。
+   */
+  fastModels?: readonly string[];
   /** true 表示该来源必须写入 session provider store 才能注入自己的 API key/OAuth token。 */
   requiresExplicitRoute?: boolean;
 }
@@ -515,6 +520,20 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
               ? (cachedProviderFallback?.requiresExplicitRoute ? cachedProviderFallback.id : null)
               : resolvedConfig.providerId,
     };
+    // 显式来源下 Fast 按该来源自己的模型条目判定 —— getAvailableModels 是跨来源拍平
+    // 清单(首来源 wins),同 id 模型的 supportsFastMode 在不同来源可分叉:首来源不支持
+    // 会误杀显式来源真正支持的 Fast,反向则可能把 Fast 放到不支持的来源上(codex review)。
+    if (explicitSourceId !== null) {
+      const explicitRouteProvider = agentProviders.find(
+        (provider) => provider.id === explicitSourceId,
+      );
+      const providerSupportsFast =
+        explicitRouteProvider?.fastModels?.includes(resolved.model) === true;
+      const requestedFast = params.agent === 'codex' && params.fast !== undefined
+        ? params.fast
+        : (defaults.fastMode ?? !!lead.fastMode);
+      resolved.fastMode = providerSupportsFast && requestedFast === true;
+    }
     const budgetRouteProviderId = explicitSourceId !== null
       ? explicitSourceId
       : params.model !== undefined

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -5534,6 +5534,13 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
             fastModels: (provider.models['claude-code'] ?? [])
               .filter((model) => model.supportsFastMode)
               .map((model) => model.id),
+            // effort 档位同样 per-(provider, model):供 service 按实际路由来源重归一。
+            effortMetaByModel: Object.fromEntries(
+              (provider.models['claude-code'] ?? []).map((model) => [
+                model.id,
+                { efforts: model.efforts, defaultEffort: model.defaultEffort },
+              ]),
+            ),
             requiresExplicitRoute: provider.routing['claude-code']?.authStrategy === 'api-key-header'
               || provider.routing['claude-code']?.authStrategy === 'oauth-token',
           })),
@@ -5544,6 +5551,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
             fastModels: (provider.models.codex ?? [])
               .filter((model) => model.supportsFastMode)
               .map((model) => model.id),
+            effortMetaByModel: Object.fromEntries(
+              (provider.models.codex ?? []).map((model) => [
+                model.id,
+                { efforts: model.efforts, defaultEffort: model.defaultEffort },
+              ]),
+            ),
             requiresExplicitRoute: provider.routing.codex?.authStrategy === 'api-key-header'
               || provider.routing.codex?.authStrategy === 'oauth-token',
           })),

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -923,6 +923,8 @@ interface EnableOrcaOptions {
   model?: string;
   effort?: OrcaWorkerEffort;
   fast?: boolean;
+  /** 显式选定的模型来源;语义见 OrcaWorkerCreateParams.providerId。 */
+  providerId?: string | null;
 }
 
 let orcaCollabServiceHolder: OrcaCollabService | null = null;
@@ -4259,6 +4261,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       model: opts.model,
       effort: opts.effort,
       fast: opts.fast,
+      providerId: opts.providerId,
       delegateTask: opts.delegateTask,
     });
     if (!result.ok) throwOrcaServiceFailure(result);
@@ -5153,6 +5156,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       model?: unknown;
       effort?: unknown;
       fast?: unknown;
+      providerId?: unknown;
     };
     const workerAgent: AgentKind = body.workerAgent === 'codex' ? 'codex' : 'claude-code';
     const delegateTask = typeof body.delegateTask === 'string' ? body.delegateTask : undefined;
@@ -5164,6 +5168,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       model: typeof body.model === 'string' ? body.model : undefined,
       effort: typeof body.effort === 'string' ? body.effort as OrcaWorkerEffort : undefined,
       fast: typeof body.fast === 'boolean' ? body.fast : undefined,
+      // 只认非空 string 为显式来源;其余(null/缺省/异型)一律按「未显式」处理。
+      providerId: typeof body.providerId === 'string' && body.providerId.length > 0
+        ? body.providerId
+        : undefined,
     });
   });
 
@@ -5304,6 +5312,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       model,
       effort: typeof b.effort === 'string' ? b.effort as OrcaWorkerEffort : undefined,
       fast: typeof b.fast === 'boolean' ? b.fast : undefined,
+      // 只认非空 string 为显式来源;其余(null/缺省/异型)一律按「未显式」处理。
+      providerId: typeof b.providerId === 'string' && b.providerId.length > 0
+        ? b.providerId
+        : undefined,
       label: label.value,
       initialTask: typeof b.initialTask === 'string' && b.initialTask.length > 0 ? b.initialTask : undefined,
     });

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -5530,6 +5530,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
             id: provider.id,
             name: provider.name,
             models: (provider.models['claude-code'] ?? []).map((model) => model.id),
+            // Fast 能力 per-(provider, model):显式来源的 Fast 判定按该来源自己的条目。
+            fastModels: (provider.models['claude-code'] ?? [])
+              .filter((model) => model.supportsFastMode)
+              .map((model) => model.id),
             requiresExplicitRoute: provider.routing['claude-code']?.authStrategy === 'api-key-header'
               || provider.routing['claude-code']?.authStrategy === 'oauth-token',
           })),
@@ -5537,6 +5541,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
             id: provider.id,
             name: provider.name,
             models: (provider.models.codex ?? []).map((model) => model.id),
+            fastModels: (provider.models.codex ?? [])
+              .filter((model) => model.supportsFastMode)
+              .map((model) => model.id),
             requiresExplicitRoute: provider.routing.codex?.authStrategy === 'api-key-header'
               || provider.routing.codex?.authStrategy === 'oauth-token',
           })),

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -5168,9 +5168,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       model: typeof body.model === 'string' ? body.model : undefined,
       effort: typeof body.effort === 'string' ? body.effort as OrcaWorkerEffort : undefined,
       fast: typeof body.fast === 'boolean' ? body.fast : undefined,
-      // 只认非空 string 为显式来源;其余(null/缺省/异型)一律按「未显式」处理。
-      providerId: typeof body.providerId === 'string' && body.providerId.length > 0
-        ? body.providerId
+      // 只认非空(trim 后)string 为显式来源;其余(null/空白/缺省/异型)一律按「未显式」处理。
+      providerId: typeof body.providerId === 'string' && body.providerId.trim().length > 0
+        ? body.providerId.trim()
         : undefined,
     });
   });
@@ -5312,9 +5312,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       model,
       effort: typeof b.effort === 'string' ? b.effort as OrcaWorkerEffort : undefined,
       fast: typeof b.fast === 'boolean' ? b.fast : undefined,
-      // 只认非空 string 为显式来源;其余(null/缺省/异型)一律按「未显式」处理。
-      providerId: typeof b.providerId === 'string' && b.providerId.length > 0
-        ? b.providerId
+      // 只认非空(trim 后)string 为显式来源;其余(null/空白/缺省/异型)一律按「未显式」处理。
+      providerId: typeof b.providerId === 'string' && b.providerId.trim().length > 0
+        ? b.providerId.trim()
         : undefined,
       label: label.value,
       initialTask: typeof b.initialTask === 'string' && b.initialTask.length > 0 ? b.initialTask : undefined,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3864,6 +3864,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
         label?: string;
         model?: string;
         effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+        fast?: boolean;
+        /** 显式选定的模型来源(标准面板 per-worker 选择);缺省 = 跟随默认路由解析。 */
+        providerId?: string | null;
       },
     ): Promise<{ workflowId: string; workerSessionId: string; workerId: string }> =>
       ipcRenderer.invoke('maker:session:enable-orca', leadSessionId, opts),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3868,7 +3868,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         /** 显式选定的模型来源(标准面板 per-worker 选择);缺省 = 跟随默认路由解析。 */
         providerId?: string | null;
       },
-    ): Promise<{ workflowId: string; workerSessionId: string; workerId: string }> =>
+      // main handler 实际返回 teamId(见 enableOrcaInternal);此前类型写成 workflowId 是漂移。
+    ): Promise<{ teamId: string; workerSessionId: string; workerId: string }> =>
       ipcRenderer.invoke('maker:session:enable-orca', leadSessionId, opts),
 
     /**

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1809,6 +1809,8 @@ export function CCAgentSessionView({
           effort: form.effort as
             'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra' | undefined,
           fast: form.fast,
+          // null(未显式选来源)不传字段:IPC 侧只认非空 string 为显式来源。
+          providerId: form.providerId ?? undefined,
           delegateTask: form.initialTask || undefined,
         });
         void sessionsStore.forceRefresh('active');

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -307,12 +307,16 @@ export function CreateWorkerPopover({
     (providerId: string | null, modelId?: string, reconciledEffort?: Effort) => {
       const nextModel = modelId ?? model;
       const narrowed = narrowProviderSource(providerId, nextModel);
+      // 「钉/重选当前生效来源」与「切到恰好提供同一模型的另一来源」必须区分
+      // (codex review):前者保留表单 live 值(仅把生效来源钉成显式);后者是真实
+      // 来源切换,要恢复目标行显示的预设。判据 = 目标来源是否就是切换前的生效来源
+      // (显式值,未显式时为解析出的默认来源),不能只看模型是否相同。
+      const effectiveBefore = deviceId
+        ? null
+        : providerSource ?? effectiveSourceIdForModel(providers, null, model, agent);
       setProviderSource(narrowed);
-      // 钉来源(reselect 当前模型行 / 未回传模型)不是换模型:保留表单当前
-      // effort/Fast,不按全局预设重载 —— 否则仅仅钉个来源就静默改配置
-      // (codex review)。来源导致的 Fast 能力收窄由 currentModelSupportsFast
-      // 联动 effect 兜底。
-      if (!modelId || modelId === model) return;
+      if (!modelId) return;
+      if (modelId === model && narrowed !== null && narrowed === effectiveBefore) return;
       setModel(modelId);
       const available = activeModels.find((m) => m.id === modelId);
       if (!available) return;
@@ -335,7 +339,17 @@ export function CreateWorkerPopover({
         setFast(rememberedFast === true);
       }
     },
-    [activeModels, agent, effort, model, narrowProviderSource, providerFastSupported],
+    [
+      activeModels,
+      agent,
+      deviceId,
+      effort,
+      model,
+      narrowProviderSource,
+      providerFastSupported,
+      providerSource,
+      providers,
+    ],
   );
 
   // 活跃行的 effort/Fast 编辑走 onEffortChange/onFastModeChange 而非 modelMemory

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -287,13 +287,15 @@ export function CreateWorkerPopover({
       if (available && available.efforts.length > 0 && !available.efforts.includes(effort)) {
         setEffort(available.defaultEffort ?? available.efforts[available.efforts.length - 1]);
       }
-      if (!available?.supportsFastMode) {
+      // 仅换模型:当前显式来源不提供新模型时收窄,避免形成不可能组合;
+      // Fast 与选行路径同判据(providerFastSupported,per-provider),不用拍平并集值。
+      const narrowed = narrowProviderSource(providerSource, nextModel);
+      setProviderSource(narrowed);
+      if (!providerFastSupported(narrowed, nextModel)) {
         setFast(false);
       }
-      // 仅换模型:当前显式来源不提供新模型时收窄,避免形成不可能组合。
-      setProviderSource((prev) => narrowProviderSource(prev, nextModel));
     },
-    [activeModels, effort, narrowProviderSource],
+    [activeModels, effort, narrowProviderSource, providerFastSupported, providerSource],
   );
 
   // 分段行原子选择 (来源, 模型):与 composer 的 handleProviderChange 同语义。
@@ -320,10 +322,12 @@ export function CreateWorkerPopover({
       if (!providerFastSupported(narrowed, modelId)) {
         setFast(false);
       } else {
+        // 面板行的 Fast 闪电按全局预设显示,无预设 = 关:选行后必须对齐显示,
+        // 不能沿用上一个模型的 true(codex review)。
         const rememberedFast = providerId
           ? getProviderModelFast(agent, providerId, modelId)
           : undefined;
-        if (rememberedFast !== undefined) setFast(rememberedFast);
+        setFast(rememberedFast === true);
       }
     },
     [activeModels, agent, effort, model, narrowProviderSource, providerFastSupported],

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { X } from 'lucide-react';
-import { connectedProvidersForAgent, providerOffersModel } from '@cindy/model-providers';
+import {
+  connectedProvidersForAgent,
+  modelSupportsFastMode,
+  providerOffersModel,
+} from '@cindy/model-providers';
 
 import { FastModeToggle } from '@/components/new-chat/FastModeToggle';
 import { ModelSelector } from '@/components/new-chat/ModelSelector';
@@ -159,8 +163,24 @@ export function CreateWorkerPopover({
   ]);
   const currentModel = activeModels.find((m) => m.id === model);
   const modelCatalogLoading = activeCapabilitiesState.loading || providersLoading;
+
+  // per-provider Fast 能力:同一 model id 在不同来源下 supportsFastMode 可不同(见
+  // CatalogModel),显式选了来源就按该来源自己的条目查;未显式(默认路由)/device-link
+  // 回落拍平并集值(与既有行为一致)。
+  const providerFastSupported = useCallback(
+    (candidate: string | null, modelId: string): boolean => {
+      if (!deviceId && candidate) {
+        const provider = connectedProvidersForAgent(providers, agent).find(
+          (p) => p.id === candidate,
+        );
+        return modelSupportsFastMode(provider, modelId, agent);
+      }
+      return !!activeModels.find((m) => m.id === modelId)?.supportsFastMode;
+    },
+    [activeModels, agent, deviceId, providers],
+  );
   const currentModelSupportsFast = Boolean(
-    agent === 'codex' && activeCaps?.hasFastMode && currentModel?.supportsFastMode,
+    agent === 'codex' && activeCaps?.hasFastMode && providerFastSupported(providerSource, model),
   );
   const noAvailableLocalModels =
     prefsRestored &&
@@ -268,26 +288,37 @@ export function CreateWorkerPopover({
     [activeModels, effort, narrowProviderSource],
   );
 
-  // 分段行原子选择 (来源, 模型, effort):与 composer 的 handleProviderChange 同语义。
-  // 面板回传的 reconciledEffort 已按模型级全局预设解析,模型不支持时仍按 efforts 校准。
+  // 分段行原子选择 (来源, 模型):与 composer 的 handleProviderChange 同语义。
+  // 面板选行只回传 (providerId, modelId) 两参,目标模型记忆的 effort/Fast 要在这里
+  // 主动从模型级全局预设恢复(codex review:否则用户在非选中行 hover 配置的
+  // effort/Fast 在选中该行后被丢弃);Fast 还要叠加该来源条目的 per-provider 能力。
   const handleProviderChange = useCallback(
     (providerId: string | null, modelId?: string, reconciledEffort?: Effort) => {
       const nextModel = modelId ?? model;
-      setProviderSource(narrowProviderSource(providerId, nextModel));
+      const narrowed = narrowProviderSource(providerId, nextModel);
+      setProviderSource(narrowed);
       if (!modelId) return;
       setModel(modelId);
       const available = activeModels.find((m) => m.id === modelId);
       if (!available) return;
-      if (reconciledEffort && available.efforts.includes(reconciledEffort)) {
-        setEffort(reconciledEffort);
+      const remembered =
+        reconciledEffort ??
+        (providerId ? getProviderModelEffort(agent, providerId, modelId) : undefined);
+      if (remembered && available.efforts.includes(remembered)) {
+        setEffort(remembered);
       } else if (available.efforts.length > 0 && !available.efforts.includes(effort)) {
         setEffort(available.defaultEffort ?? available.efforts[available.efforts.length - 1]);
       }
-      if (!available.supportsFastMode) {
+      if (!providerFastSupported(narrowed, modelId)) {
         setFast(false);
+      } else {
+        const rememberedFast = providerId
+          ? getProviderModelFast(agent, providerId, modelId)
+          : undefined;
+        if (rememberedFast !== undefined) setFast(rememberedFast);
       }
     },
-    [activeModels, effort, model, narrowProviderSource],
+    [activeModels, agent, effort, model, narrowProviderSource, providerFastSupported],
   );
 
   const updateEffort = setEffort;
@@ -472,6 +503,10 @@ export function CreateWorkerPopover({
               popoverSide="bottom"
               currentProviderId={deviceId ? undefined : providerSource}
               onProviderChange={deviceId ? undefined : handleProviderChange}
+              // providerSource=null 时面板高亮的是**解析出来的生效默认来源**,点它的
+              // 语义是「把默认来源钉成显式偏好」,必须照常回调(codex review)——否则
+              // 用户点了没反应,之后默认路由一变创建就静默换来源。显式同值幂等无害。
+              reselectEmitsChange
               onNavigateToProviders={
                 deviceId
                   ? undefined
@@ -481,8 +516,13 @@ export function CreateWorkerPopover({
                     }
               }
               modelMemory={modelMemory}
-              fastMode={deviceId ? undefined : fast}
-              onFastModeChange={deviceId ? undefined : (enabled) => setFast(enabled)}
+              // worker 创建链的显式 Fast 派发目前仅 Codex(resolveWorkerConfig 只对
+              // codex 消费 input.fast):cc 不接线,面板就不显示 Fast 开关,避免
+              // 「开关能开、提交被丢」的名不副实(codex review)。
+              fastMode={deviceId || agent !== 'codex' ? undefined : fast}
+              onFastModeChange={
+                deviceId || agent !== 'codex' ? undefined : (enabled) => setFast(enabled)
+              }
             />
           </div>
           {noAvailableLocalModels ? (

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -383,10 +383,14 @@ export function CreateWorkerPopover({
   // 活跃行的 effort/Fast 编辑走 onEffortChange/onFastModeChange 而非 modelMemory
   // (ModelSelector 有意区分两条通道),必须同步写回模型级全局预设 —— 否则切走再
   // 切回时 handleProviderChange 按旧全局值恢复,刚做的编辑被静默丢弃(codex review)。
-  // 记忆槽位取显式来源,未显式时取该模型的生效默认来源(全局预设本就是跨来源共享)。
+  // 记忆槽位对显式来源先收窄(与 Fast 判定同口径):恢复读的是全局预设槽不受 key
+  // 影响,但来源槽兼容副本按实际生效来源落 key,不在收敛 effect 前的窗口里写给已
+  // 失效来源(copilot review;ChatInput 的 effectiveSourceId 同语义);收窄空则回落
+  // 该模型的生效默认来源(全局预设本就是跨来源共享)。
   const activeMemorySourceId = deviceId
     ? null
-    : providerSource ?? effectiveSourceIdForModel(providers, null, model, agent);
+    : narrowProviderSource(providerSource, model)
+      ?? effectiveSourceIdForModel(providers, null, model, agent);
   const updateEffort = useCallback(
     (next: Effort) => {
       setEffort(next);

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -277,14 +277,31 @@ export function CreateWorkerPopover({
   const vendorKey = agent === 'codex' ? 'codex' : 'cc';
   const updateAgent = useCallback(
     (nextAgent: 'claude-code' | 'codex') => {
+      if (nextAgent === agent) return;
+      // 切走前把当前 agent 的 live 编辑(模型/effort/Fast/来源)快照进内存 prefs:
+      // 恢复读的是 prefs,不快照会把「改了还没提交就切了个 tab」的编辑静默回滚到
+      // 打开弹窗时的旧值(codex review)。只更新内存态,localStorage 仍只在提交时
+      // 写 —— 关闭弹窗不持久化未提交编辑,语义不变。
+      const snapshot: WorkerPrefs = {
+        ...prefs,
+        [agent]: {
+          model,
+          effort,
+          fast,
+          // device-link 面板无来源维度(providerSource 恒 null),保留本地记忆原值,
+          // 与提交路径同规则。
+          providerId: deviceId ? prefs[agent].providerId : providerSource,
+        },
+      };
+      setPrefs(snapshot);
       setAgent(nextAgent);
-      const remembered = prefs[nextAgent];
+      const remembered = snapshot[nextAgent];
       setModel(remembered.model);
       setEffort(remembered.effort);
       setFast(remembered.fast);
       setProviderSource(deviceId ? null : remembered.providerId);
     },
-    [deviceId, prefs],
+    [agent, deviceId, effort, fast, model, prefs, providerSource],
   );
 
   const updateModel = useCallback(
@@ -331,7 +348,13 @@ export function CreateWorkerPopover({
         (providerId ? getProviderModelEffort(agent, providerId, modelId) : undefined);
       if (remembered && available.efforts.includes(remembered)) {
         setEffort(remembered);
-      } else if (available.efforts.length > 0 && !available.efforts.includes(effort)) {
+      } else if (available.efforts.length > 0) {
+        // 该模型无共享预设(如 workerCreationPrefs 早于预设 store 的老数据)时,对齐
+        // 目标行显示的 defaultEffort(非活跃行的 effort 徽标 = 预设 ?? defaultEffort,
+        // 见 ModelSelector 行级 effort 派生):旧 live 值恰好也被目标支持时保留它,
+        // 会让创建参数与行上显示的档位不一致(codex review);与下方 Fast 的
+        // 「无预设 = 对齐显示」同规则。钉/重选当前生效来源已在上方早退,live 值
+        // 不受本分支影响。
         setEffort(available.defaultEffort ?? available.efforts[available.efforts.length - 1]);
       }
       if (!providerFastSupported(narrowed, modelId)) {
@@ -349,7 +372,6 @@ export function CreateWorkerPopover({
       activeModels,
       agent,
       deviceId,
-      effort,
       model,
       narrowProviderSource,
       providerFastSupported,

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -216,6 +216,26 @@ export function CreateWorkerPopover({
       activeCaps?.hasFastMode &&
       providerFastSupported(narrowProviderSource(providerSource, model), model),
   );
+  // 实际路由来源的 effort 档位表:**显示收敛与提交共用同一口径**,保证面板显示的
+  // effort 就是派发的 effort —— 只在提交口改写会出现「显示 high、创建 low」的静默
+  // 不一致(codex review,device-link 与本地恢复路径同病)。显式来源(收窄后)优先,
+  // 否则生效默认来源(local/remote 快照同规则);来源条目缺失或无档位元数据回落
+  // 拍平条目(旧 peer 无快照),main 侧重归一兜底。
+  const routeEffortMetaFor = useCallback(
+    (modelId: string): { efforts: readonly string[]; defaultEffort: string | null } | undefined => {
+      const flat = activeModels.find((m) => m.id === modelId);
+      const sourceId = deviceId
+        ? effectiveSourceIdForModel(providers, null, modelId, agent)
+        : narrowProviderSource(providerSource, modelId)
+          ?? effectiveSourceIdForModel(providers, null, modelId, agent);
+      const provider = sourceId
+        ? connectedProvidersForAgent(providers, agent).find((p) => p.id === sourceId)
+        : undefined;
+      const entry = provider ? getModel(provider, modelId, agent) : undefined;
+      return entry?.efforts ? entry : flat;
+    },
+    [activeModels, agent, deviceId, narrowProviderSource, providerSource, providers],
+  );
   const noAvailableLocalModels =
     prefsRestored &&
     !deviceId &&
@@ -253,8 +273,13 @@ export function CreateWorkerPopover({
       selected = models[0];
       setModel(selected.id);
     }
-    if (selected.efforts.length > 0 && !selected.efforts.includes(effort)) {
-      setEffort(selected.defaultEffort ?? selected.efforts[selected.efforts.length - 1]);
+    // effort 收敛按**实际路由来源档位表**(routeEffortMetaFor,与提交同口径):
+    // 按拍平条目收敛会留下「显示 high、提交时被对账成 low」的静默不一致
+    // (codex review)。
+    const effortMeta = routeEffortMetaFor(selected.id) ?? selected;
+    const metaEfforts: readonly string[] = effortMeta.efforts;
+    if (metaEfforts.length > 0 && !metaEfforts.includes(effort)) {
+      setEffort(effortMeta.defaultEffort ?? metaEfforts[metaEfforts.length - 1]);
     }
     // 恢复出来的显式来源可能已断开或不提供收敛后的模型 —— 目录就绪后同步收窄。
     if (providerSource !== null) {
@@ -271,6 +296,7 @@ export function CreateWorkerPopover({
     open,
     prefsRestored,
     providerSource,
+    routeEffortMetaFor,
   ]);
 
   useEffect(() => {
@@ -312,9 +338,12 @@ export function CreateWorkerPopover({
   const updateModel = useCallback(
     (nextModel: string) => {
       setModel(nextModel);
-      const available = activeModels.find((m) => m.id === nextModel);
-      if (available && available.efforts.length > 0 && !available.efforts.includes(effort)) {
-        setEffort(available.defaultEffort ?? available.efforts[available.efforts.length - 1]);
+      // flat 面板换模型(device-link 退化路径):effort 同样按路由来源档位表收敛,
+      // 与收敛 effect / 提交同口径,不留显示与派发不一致的窗口。
+      const effortMeta = routeEffortMetaFor(nextModel);
+      const metaEfforts: readonly string[] = effortMeta?.efforts ?? [];
+      if (effortMeta && metaEfforts.length > 0 && !metaEfforts.includes(effort)) {
+        setEffort(effortMeta.defaultEffort ?? metaEfforts[metaEfforts.length - 1]);
       }
       // 仅换模型:当前显式来源不提供新模型时收窄,避免形成不可能组合;
       // Fast 与选行路径同判据(providerFastSupported,per-provider),不用拍平并集值。
@@ -324,7 +353,7 @@ export function CreateWorkerPopover({
         setFast(false);
       }
     },
-    [activeModels, effort, narrowProviderSource, providerFastSupported, providerSource],
+    [effort, narrowProviderSource, providerFastSupported, providerSource, routeEffortMetaFor],
   );
 
   // 分段行原子选择 (来源, 模型):与 composer 的 handleProviderChange 同语义。
@@ -502,22 +531,13 @@ export function CreateWorkerPopover({
     };
     setPrefs(nextPrefs);
     writeWorkerPrefs(nextPrefs);
-    // 提交 effort 按**实际路由来源条目**对账(codex/copilot review):恢复路径的
+    // 提交 effort 按**实际路由来源档位表**对账(codex/copilot review):恢复路径的
     // stale effort、以及路由来源条目无档而拍平条目有档的组合,直接把 live 值
     // explicit 下发会被 main 侧路由来源校验拒掉(INVALID_PARAMS 阻断创建)。条目
     // 无档 → 省略(main 按该来源 defaultEffort=null 落);live 值不在其档位表 →
-    // 落其 defaultEffort(与面板行显示口径一致);拿不到来源条目(旧 peer 无
-    // provider 快照)回落拍平条目,main 侧重归一兜底。
-    const submitSourceId = deviceId
-      ? effectiveSourceIdForModel(providers, null, model, agent)
-      : submitProviderId ?? effectiveSourceIdForModel(providers, null, model, agent);
-    const submitSourceProvider = submitSourceId
-      ? connectedProvidersForAgent(providers, agent).find((p) => p.id === submitSourceId)
-      : undefined;
-    const submitEntry = submitSourceProvider
-      ? getModel(submitSourceProvider, model, agent)
-      : undefined;
-    const submitEffortMeta = submitEntry?.efforts ? submitEntry : currentModel;
+    // 落其 defaultEffort。收敛 effect 与本对账共用 routeEffortMetaFor,显示与派发
+    // 同口径,这里只是提交瞬间的兜底(收敛后目录仍可能变化)。
+    const submitEffortMeta = routeEffortMetaFor(model) ?? currentModel;
     const submitEfforts: readonly string[] = submitEffortMeta?.efforts ?? [];
     const submitEffort = submitEfforts.length === 0
       ? undefined
@@ -553,7 +573,7 @@ export function CreateWorkerPopover({
     currentModelSupportsFast,
     initialTask,
     onCreate,
-    providers,
+    routeEffortMetaFor,
   ]);
 
   if (!open) return null;

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -62,8 +62,9 @@ function readWorkerPrefs(): WorkerPrefs {
         ...DEFAULT_PREFS[agent],
         ...(p ?? {}),
         fast: p?.fast === true,
-        // 老版本 prefs 无此字段 → null(未显式);非法类型同样回落。
-        providerId: typeof p?.providerId === 'string' && p.providerId ? p.providerId : null,
+        // 老版本 prefs 无此字段 → null(未显式);非法类型/空白串同样回落(与 IPC 同口径 trim)。
+        providerId:
+          typeof p?.providerId === 'string' && p.providerId.trim() ? p.providerId.trim() : null,
       };
     };
     return {
@@ -307,7 +308,11 @@ export function CreateWorkerPopover({
       const nextModel = modelId ?? model;
       const narrowed = narrowProviderSource(providerId, nextModel);
       setProviderSource(narrowed);
-      if (!modelId) return;
+      // 钉来源(reselect 当前模型行 / 未回传模型)不是换模型:保留表单当前
+      // effort/Fast,不按全局预设重载 —— 否则仅仅钉个来源就静默改配置
+      // (codex review)。来源导致的 Fast 能力收窄由 currentModelSupportsFast
+      // 联动 effect 兜底。
+      if (!modelId || modelId === model) return;
       setModel(modelId);
       const available = activeModels.find((m) => m.id === modelId);
       if (!available) return;

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import { X } from 'lucide-react';
 import {
   connectedProvidersForAgent,
+  effectiveSourceIdForModel,
+  getModel,
   modelSupportsFastMode,
   providerOffersModel,
 } from '@cindy/model-providers';
@@ -165,17 +167,20 @@ export function CreateWorkerPopover({
   const modelCatalogLoading = activeCapabilitiesState.loading || providersLoading;
 
   // per-provider Fast 能力:同一 model id 在不同来源下 supportsFastMode 可不同(见
-  // CatalogModel),显式选了来源就按该来源自己的条目查;未显式(默认路由)/device-link
-  // 回落拍平并集值(与既有行为一致)。
+  // CatalogModel)。显式选了来源按该来源条目查;未显式(null)也要先解析**生效默认
+  // 来源**再查它自己的条目(codex review:拍平并集是首来源 wins,默认来源不支持时
+  // 会把 stale true 一路带到提交)。device-link 无本地目录,回落并集值(既有行为)。
   const providerFastSupported = useCallback(
     (candidate: string | null, modelId: string): boolean => {
-      if (!deviceId && candidate) {
-        const provider = connectedProvidersForAgent(providers, agent).find(
-          (p) => p.id === candidate,
-        );
-        return modelSupportsFastMode(provider, modelId, agent);
+      if (deviceId) {
+        return !!activeModels.find((m) => m.id === modelId)?.supportsFastMode;
       }
-      return !!activeModels.find((m) => m.id === modelId)?.supportsFastMode;
+      const sourceId = candidate ?? effectiveSourceIdForModel(providers, null, modelId, agent);
+      if (!sourceId) return false;
+      const provider = connectedProvidersForAgent(providers, agent).find(
+        (p) => p.id === sourceId,
+      );
+      return modelSupportsFastMode(provider, modelId, agent);
     },
     [activeModels, agent, deviceId, providers],
   );
@@ -189,16 +194,19 @@ export function CreateWorkerPopover({
     (activeCaps !== null || activeCapabilitiesState.error !== null) &&
     activeModels.length === 0;
 
-  // 显式来源仅在「已连接且确实提供该模型」时有效;其余(断开/下架/换了模型)收窄为
-  // null 交回默认路由解析。与 SubagentModelSection / ImDefaultSettingsSection 同规则,
-  // 防止提交「选 A 落 B」的不可能组合。device-link 无本地来源维度,恒 null。
+  // 显式来源仅在「已连接、确实提供该模型、且该 (来源, 模型) 未被可见性开关隐藏」时
+  // 有效;其余(断开/下架/被隐藏/换了模型)收窄为 null 交回默认路由解析。可见性判据
+  // 与 activeModels 的 isVisible 同源(codex review:同模型多来源时,用户隐藏了记忆
+  // 来源的那份条目后,面板已不显示该行,不能仍显式路由过去)。device-link 恒 null。
   const narrowProviderSource = useCallback(
     (candidate: string | null, modelId: string): string | null => {
       if (!candidate || deviceId) return null;
       const provider = connectedProvidersForAgent(providers, agent).find(
         (p) => p.id === candidate,
       );
-      return provider && providerOffersModel(provider, modelId, agent) ? candidate : null;
+      if (!provider || !providerOffersModel(provider, modelId, agent)) return null;
+      const catalogModel = getModel(provider, modelId, agent);
+      return catalogModel && isModelEnabled(agent, candidate, catalogModel) ? candidate : null;
     },
     [agent, deviceId, providers],
   );
@@ -321,7 +329,31 @@ export function CreateWorkerPopover({
     [activeModels, agent, effort, model, narrowProviderSource, providerFastSupported],
   );
 
-  const updateEffort = setEffort;
+  // 活跃行的 effort/Fast 编辑走 onEffortChange/onFastModeChange 而非 modelMemory
+  // (ModelSelector 有意区分两条通道),必须同步写回模型级全局预设 —— 否则切走再
+  // 切回时 handleProviderChange 按旧全局值恢复,刚做的编辑被静默丢弃(codex review)。
+  // 记忆槽位取显式来源,未显式时取该模型的生效默认来源(全局预设本就是跨来源共享)。
+  const activeMemorySourceId = deviceId
+    ? null
+    : providerSource ?? effectiveSourceIdForModel(providers, null, model, agent);
+  const updateEffort = useCallback(
+    (next: Effort) => {
+      setEffort(next);
+      if (activeMemorySourceId && model) {
+        setProviderModelEffort(agent, activeMemorySourceId, model, next);
+      }
+    },
+    [activeMemorySourceId, agent, model],
+  );
+  const updateFast = useCallback(
+    (enabled: boolean) => {
+      setFast(enabled);
+      if (activeMemorySourceId && model) {
+        setProviderModelFast(agent, activeMemorySourceId, model, enabled);
+      }
+    },
+    [activeMemorySourceId, agent, model],
+  );
 
   // 非选中行 hover 配置(推理强度/Fast)与 composer 共用同一份模型级全局预设。
   // device-link 远程创建不传:被控端记忆需镜像通道,宁可无记忆也不掺控制端本机。
@@ -520,9 +552,7 @@ export function CreateWorkerPopover({
               // codex 消费 input.fast):cc 不接线,面板就不显示 Fast 开关,避免
               // 「开关能开、提交被丢」的名不副实(codex review)。
               fastMode={deviceId || agent !== 'codex' ? undefined : fast}
-              onFastModeChange={
-                deviceId || agent !== 'codex' ? undefined : (enabled) => setFast(enabled)
-              }
+              onFastModeChange={deviceId || agent !== 'codex' ? undefined : updateFast}
             />
           </div>
           {noAvailableLocalModels ? (

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -343,19 +343,45 @@ export function CreateWorkerPopover({
       setModel(modelId);
       const available = activeModels.find((m) => m.id === modelId);
       if (!available) return;
+      // 档位表按选中来源自己的目录条目:activeModels 是首来源 wins 的拍平清单,
+      // 同 id 模型的 efforts/defaultEffort 跨来源可分叉,按拍平条目校验会保留/赋予
+      // 选中来源不支持的档位,提交后被 main 侧路由来源校验拒掉(codex review)。
+      // 未收窄出显式来源时取生效默认来源的条目;来源条目缺失或无档位元数据时
+      // 回落拍平条目(device-link 无本地目录,handleProviderChange 本就不接线)。
+      const effortSourceId =
+        narrowed ?? effectiveSourceIdForModel(providers, null, modelId, agent);
+      const effortSourceProvider = effortSourceId
+        ? connectedProvidersForAgent(providers, agent).find((p) => p.id === effortSourceId)
+        : undefined;
+      const sourceEntry = effortSourceProvider
+        ? getModel(effortSourceProvider, modelId, agent)
+        : undefined;
+      const effortMeta = sourceEntry?.efforts ? sourceEntry : available;
+      // 宽化为 string 数组做 includes:目录条目的 efforts 是 model-providers 包的
+      // 字面量联合,与本组件的 Effort(string)不同源,语义同为档位 id。
+      const validEfforts: readonly string[] = effortMeta.efforts;
       const remembered =
         reconciledEffort ??
         (providerId ? getProviderModelEffort(agent, providerId, modelId) : undefined);
-      if (remembered && available.efforts.includes(remembered)) {
-        setEffort(remembered);
-      } else if (available.efforts.length > 0) {
+      let nextEffort: Effort | null = null;
+      if (remembered && validEfforts.includes(remembered)) {
+        nextEffort = remembered;
+      } else if (validEfforts.length > 0) {
         // 该模型无共享预设(如 workerCreationPrefs 早于预设 store 的老数据)时,对齐
         // 目标行显示的 defaultEffort(非活跃行的 effort 徽标 = 预设 ?? defaultEffort,
         // 见 ModelSelector 行级 effort 派生):旧 live 值恰好也被目标支持时保留它,
         // 会让创建参数与行上显示的档位不一致(codex review);与下方 Fast 的
         // 「无预设 = 对齐显示」同规则。钉/重选当前生效来源已在上方早退,live 值
         // 不受本分支影响。
-        setEffort(available.defaultEffort ?? available.efforts[available.efforts.length - 1]);
+        nextEffort = effortMeta.defaultEffort ?? effortMeta.efforts[effortMeta.efforts.length - 1];
+      }
+      if (nextEffort) setEffort(nextEffort);
+      // 真实选定 (来源, 模型) 要写 choice:更新该来源槽的 lastModel(composer 与
+      // 其它标准选择器的 resolveSourceSwitch 用它做切来源落点),否则本面板的显式
+      // 选择不进全局记忆,别处切到该来源仍恢复旧模型(codex review)。无档模型
+      // 跳过 —— store 的 lastModel 依附 effort 记录。
+      if (effortSourceId && nextEffort) {
+        setProviderModelChoice(agent, effortSourceId, modelId, nextEffort);
       }
       if (!providerFastSupported(narrowed, modelId)) {
         setFast(false);

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -16,6 +16,7 @@ import { VendorSegmentedSwitcher } from '@/components/new-chat/VendorSegmentedSw
 import { useAgentCapabilities } from '@/hooks/useAgentCapabilities';
 import { useDeviceProviders } from '@/hooks/useDeviceProviders';
 import { useProviders } from '@/hooks/useProviders';
+import { isSidebarWindow } from '@/lib/sidebarWindow';
 import { cn } from '@/lib/utils';
 import { isModelEnabled, useModelVisibilityVersion } from '@/state/modelVisibilityPrefs';
 import {
@@ -187,14 +188,18 @@ export function CreateWorkerPopover({
   // per-provider Fast 能力:同一 model id 在不同来源下 supportsFastMode 可不同(见
   // CatalogModel)。显式选了来源按该来源条目查;未显式(null)也要先解析**生效默认
   // 来源**再查它自己的条目(codex review:拍平并集是首来源 wins,默认来源不支持时
-  // 会把 stale true 一路带到提交)。device-link 无本地目录,回落并集值(既有行为)。
+  // 会把 stale true 一路带到提交)。device-link 同规则按被控端 provider 快照的生效
+  // 默认来源判定(与被控端 main 的 fastModels re-gate 同口径);仅快照不可用(旧
+  // peer 无 provider 镜像,解析不出来源)才回落拍平并集(codex review)。
   const providerFastSupported = useCallback(
     (candidate: string | null, modelId: string): boolean => {
-      if (deviceId) {
-        return !!activeModels.find((m) => m.id === modelId)?.supportsFastMode;
-      }
+      // device-link 面板无来源维度,candidate 恒 null,走默认来源解析。
       const sourceId = candidate ?? effectiveSourceIdForModel(providers, null, modelId, agent);
-      if (!sourceId) return false;
+      if (!sourceId) {
+        return deviceId
+          ? !!activeModels.find((m) => m.id === modelId)?.supportsFastMode
+          : false;
+      }
       const provider = connectedProvidersForAgent(providers, agent).find(
         (p) => p.id === sourceId,
       );
@@ -339,7 +344,16 @@ export function CreateWorkerPopover({
         : providerSource ?? effectiveSourceIdForModel(providers, null, model, agent);
       setProviderSource(narrowed);
       if (!modelId) return;
-      if (modelId === model && narrowed !== null && narrowed === effectiveBefore) return;
+      if (modelId === model && narrowed !== null && narrowed === effectiveBefore) {
+        // 钉当前生效来源也是一次真实选定:live effort/Fast 保留,但 (来源, 模型)
+        // 要记入全局 choice —— 该来源槽的 lastModel 可能还指着别的模型,不记会让
+        // 其它标准选择器切到该来源时恢复 stale 模型(codex review)。无档模型跳过,
+        // 与下方真实切换路径同规则。
+        if (currentModel && currentModel.efforts.length > 0) {
+          setProviderModelChoice(agent, narrowed, modelId, effort);
+        }
+        return;
+      }
       setModel(modelId);
       const available = activeModels.find((m) => m.id === modelId);
       if (!available) return;
@@ -397,7 +411,9 @@ export function CreateWorkerPopover({
     [
       activeModels,
       agent,
+      currentModel,
       deviceId,
+      effort,
       model,
       narrowProviderSource,
       providerFastSupported,
@@ -486,12 +502,34 @@ export function CreateWorkerPopover({
     };
     setPrefs(nextPrefs);
     writeWorkerPrefs(nextPrefs);
+    // 提交 effort 按**实际路由来源条目**对账(codex/copilot review):恢复路径的
+    // stale effort、以及路由来源条目无档而拍平条目有档的组合,直接把 live 值
+    // explicit 下发会被 main 侧路由来源校验拒掉(INVALID_PARAMS 阻断创建)。条目
+    // 无档 → 省略(main 按该来源 defaultEffort=null 落);live 值不在其档位表 →
+    // 落其 defaultEffort(与面板行显示口径一致);拿不到来源条目(旧 peer 无
+    // provider 快照)回落拍平条目,main 侧重归一兜底。
+    const submitSourceId = deviceId
+      ? effectiveSourceIdForModel(providers, null, model, agent)
+      : submitProviderId ?? effectiveSourceIdForModel(providers, null, model, agent);
+    const submitSourceProvider = submitSourceId
+      ? connectedProvidersForAgent(providers, agent).find((p) => p.id === submitSourceId)
+      : undefined;
+    const submitEntry = submitSourceProvider
+      ? getModel(submitSourceProvider, model, agent)
+      : undefined;
+    const submitEffortMeta = submitEntry?.efforts ? submitEntry : currentModel;
+    const submitEfforts: readonly string[] = submitEffortMeta?.efforts ?? [];
+    const submitEffort = submitEfforts.length === 0
+      ? undefined
+      : submitEfforts.includes(effort)
+        ? effort
+        : (submitEffortMeta?.defaultEffort ?? undefined);
     try {
       await onCreate({
         role: activeRole,
         agent,
         model,
-        effort: currentModel && currentModel.efforts.length > 0 ? effort : undefined,
+        effort: submitEffort,
         fast: currentModelSupportsFast ? fast : undefined,
         providerId: submitProviderId,
         initialTask,
@@ -515,6 +553,7 @@ export function CreateWorkerPopover({
     currentModelSupportsFast,
     initialTask,
     onCreate,
+    providers,
   ]);
 
   if (!open) return null;
@@ -620,8 +659,11 @@ export function CreateWorkerPopover({
               // 语义是「把默认来源钉成显式偏好」,必须照常回调(codex review)——否则
               // 用户点了没反应,之后默认路由一变创建就静默换来源。显式同值幂等无害。
               reselectEmitsChange
+              // 分离侧栏窗口固定在 /sidebar-window 壳路由,本地 navigate 会把辅助
+              // 窗口整壳替换成主设置路由(codex review)——与 OrcaWorkerPanel 的
+              // settingsEnabled={!isSidebarWindow()} 同禁用口径,不接线跳转。
               onNavigateToProviders={
-                deviceId
+                deviceId || isSidebarWindow()
                   ? undefined
                   : () => {
                       onClose();

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -167,6 +167,23 @@ export function CreateWorkerPopover({
   const currentModel = activeModels.find((m) => m.id === model);
   const modelCatalogLoading = activeCapabilitiesState.loading || providersLoading;
 
+  // 显式来源仅在「已连接、确实提供该模型、且该 (来源, 模型) 未被可见性开关隐藏」时
+  // 有效;其余(断开/下架/被隐藏/换了模型)收窄为 null 交回默认路由解析。可见性判据
+  // 与 activeModels 的 isVisible 同源(codex review:同模型多来源时,用户隐藏了记忆
+  // 来源的那份条目后,面板已不显示该行,不能仍显式路由过去)。device-link 恒 null。
+  const narrowProviderSource = useCallback(
+    (candidate: string | null, modelId: string): string | null => {
+      if (!candidate || deviceId) return null;
+      const provider = connectedProvidersForAgent(providers, agent).find(
+        (p) => p.id === candidate,
+      );
+      if (!provider || !providerOffersModel(provider, modelId, agent)) return null;
+      const catalogModel = getModel(provider, modelId, agent);
+      return catalogModel && isModelEnabled(agent, candidate, catalogModel) ? candidate : null;
+    },
+    [agent, deviceId, providers],
+  );
+
   // per-provider Fast 能力:同一 model id 在不同来源下 supportsFastMode 可不同(见
   // CatalogModel)。显式选了来源按该来源条目查;未显式(null)也要先解析**生效默认
   // 来源**再查它自己的条目(codex review:拍平并集是首来源 wins,默认来源不支持时
@@ -185,8 +202,14 @@ export function CreateWorkerPopover({
     },
     [activeModels, agent, deviceId, providers],
   );
+  // Fast 判定先对 providerSource 收窄:记忆来源刚失效(断开/掉模型/被隐藏)而收敛
+  // effect 尚未把 state 置 null 的同一渲染里,直接用旧值会得到 false 并把记忆的
+  // fast=true 清掉,回退默认来源支持 Fast 也不会恢复(codex review)。收窄后按
+  // 「实际会生效的来源」口径判定,不经历 false 窗口。
   const currentModelSupportsFast = Boolean(
-    agent === 'codex' && activeCaps?.hasFastMode && providerFastSupported(providerSource, model),
+    agent === 'codex' &&
+      activeCaps?.hasFastMode &&
+      providerFastSupported(narrowProviderSource(providerSource, model), model),
   );
   const noAvailableLocalModels =
     prefsRestored &&
@@ -194,23 +217,6 @@ export function CreateWorkerPopover({
     !modelCatalogLoading &&
     (activeCaps !== null || activeCapabilitiesState.error !== null) &&
     activeModels.length === 0;
-
-  // 显式来源仅在「已连接、确实提供该模型、且该 (来源, 模型) 未被可见性开关隐藏」时
-  // 有效;其余(断开/下架/被隐藏/换了模型)收窄为 null 交回默认路由解析。可见性判据
-  // 与 activeModels 的 isVisible 同源(codex review:同模型多来源时,用户隐藏了记忆
-  // 来源的那份条目后,面板已不显示该行,不能仍显式路由过去)。device-link 恒 null。
-  const narrowProviderSource = useCallback(
-    (candidate: string | null, modelId: string): string | null => {
-      if (!candidate || deviceId) return null;
-      const provider = connectedProvidersForAgent(providers, agent).find(
-        (p) => p.id === candidate,
-      );
-      if (!provider || !providerOffersModel(provider, modelId, agent)) return null;
-      const catalogModel = getModel(provider, modelId, agent);
-      return catalogModel && isModelEnabled(agent, candidate, catalogModel) ? candidate : null;
-    },
-    [agent, deviceId, providers],
-  );
 
   // 打开弹窗时恢复上次选择；initial task 不记忆，避免把旧任务误带到下一次创建。
   useEffect(() => {

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -1,14 +1,24 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { X } from 'lucide-react';
+import { connectedProvidersForAgent, providerOffersModel } from '@cindy/model-providers';
 
 import { FastModeToggle } from '@/components/new-chat/FastModeToggle';
 import { ModelSelector } from '@/components/new-chat/ModelSelector';
+import { VendorSegmentedSwitcher } from '@/components/new-chat/VendorSegmentedSwitcher';
 import { useAgentCapabilities } from '@/hooks/useAgentCapabilities';
 import { useDeviceProviders } from '@/hooks/useDeviceProviders';
 import { useProviders } from '@/hooks/useProviders';
 import { cn } from '@/lib/utils';
 import { isModelEnabled, useModelVisibilityVersion } from '@/state/modelVisibilityPrefs';
+import {
+  getProviderModelEffort,
+  getProviderModelFast,
+  setProviderModelChoice,
+  setProviderModelEffort,
+  setProviderModelFast,
+} from '@/state/providerModelMemory';
 import type { Effort } from '@/lib/userPreferences.types';
 import { selectWorkerModels } from './workerModelAvailability';
 
@@ -19,6 +29,8 @@ interface WorkerAgentPrefs {
   model: string;
   effort: Effort;
   fast: boolean;
+  /** 上次显式选定的模型来源;null = 未显式选择(跟随默认路由解析)。 */
+  providerId: string | null;
 }
 
 interface WorkerPrefs {
@@ -29,8 +41,8 @@ interface WorkerPrefs {
 
 const DEFAULT_PREFS: WorkerPrefs = {
   lastAgent: 'codex',
-  codex: { model: 'codex/gpt-5.5', effort: 'high', fast: false },
-  'claude-code': { model: 'claude-opus-4-7', effort: 'high', fast: false },
+  codex: { model: 'codex/gpt-5.5', effort: 'high', fast: false, providerId: null },
+  'claude-code': { model: 'claude-opus-4-7', effort: 'high', fast: false, providerId: null },
 };
 
 function readWorkerPrefs(): WorkerPrefs {
@@ -38,18 +50,20 @@ function readWorkerPrefs(): WorkerPrefs {
     const raw = window.localStorage.getItem(PREFS_KEY);
     if (!raw) return DEFAULT_PREFS;
     const parsed = JSON.parse(raw) as Partial<WorkerPrefs>;
+    const agentPrefs = (agent: 'codex' | 'claude-code'): WorkerAgentPrefs => {
+      const p = parsed[agent];
+      return {
+        ...DEFAULT_PREFS[agent],
+        ...(p ?? {}),
+        fast: p?.fast === true,
+        // 老版本 prefs 无此字段 → null(未显式);非法类型同样回落。
+        providerId: typeof p?.providerId === 'string' && p.providerId ? p.providerId : null,
+      };
+    };
     return {
       lastAgent: parsed.lastAgent === 'claude-code' ? 'claude-code' : 'codex',
-      codex: {
-        ...DEFAULT_PREFS.codex,
-        ...(parsed.codex ?? {}),
-        fast: parsed.codex?.fast === true,
-      },
-      'claude-code': {
-        ...DEFAULT_PREFS['claude-code'],
-        ...(parsed['claude-code'] ?? {}),
-        fast: parsed['claude-code']?.fast === true,
-      },
+      codex: agentPrefs('codex'),
+      'claude-code': agentPrefs('claude-code'),
     };
   } catch {
     return DEFAULT_PREFS;
@@ -70,6 +84,8 @@ export interface CreateWorkerForm {
   model: string;
   effort?: Effort;
   fast?: boolean;
+  /** 显式选定的模型来源;null = 未显式,由 main 侧按默认路由解析。 */
+  providerId: string | null;
   initialTask: string;
 }
 
@@ -94,12 +110,16 @@ export function CreateWorkerPopover({
   deviceId,
 }: CreateWorkerPopoverProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [role, setRole] = useState('developer');
   const [customRole, setCustomRole] = useState('');
   const [agent, setAgent] = useState<'claude-code' | 'codex'>('codex');
   const [model, setModel] = useState(DEFAULT_PREFS.codex.model);
   const [effort, setEffort] = useState<Effort>(DEFAULT_PREFS.codex.effort);
   const [fast, setFast] = useState(DEFAULT_PREFS.codex.fast);
+  // 显式选定的模型来源(标准面板供应商分段);null = 未显式。device-link 远程创建
+  // 面板退化为被控端纯列表(无来源维度),恒为 null。
+  const [providerSource, setProviderSource] = useState<string | null>(null);
   const [initialTask, setInitialTask] = useState('');
   const [prefs, setPrefs] = useState<WorkerPrefs>(DEFAULT_PREFS);
   const [prefsRestored, setPrefsRestored] = useState(false);
@@ -149,6 +169,20 @@ export function CreateWorkerPopover({
     (activeCaps !== null || activeCapabilitiesState.error !== null) &&
     activeModels.length === 0;
 
+  // 显式来源仅在「已连接且确实提供该模型」时有效;其余(断开/下架/换了模型)收窄为
+  // null 交回默认路由解析。与 SubagentModelSection / ImDefaultSettingsSection 同规则,
+  // 防止提交「选 A 落 B」的不可能组合。device-link 无本地来源维度,恒 null。
+  const narrowProviderSource = useCallback(
+    (candidate: string | null, modelId: string): string | null => {
+      if (!candidate || deviceId) return null;
+      const provider = connectedProvidersForAgent(providers, agent).find(
+        (p) => p.id === candidate,
+      );
+      return provider && providerOffersModel(provider, modelId, agent) ? candidate : null;
+    },
+    [agent, deviceId, providers],
+  );
+
   // 打开弹窗时恢复上次选择；initial task 不记忆，避免把旧任务误带到下一次创建。
   useEffect(() => {
     if (!open) {
@@ -162,9 +196,10 @@ export function CreateWorkerPopover({
     setModel(agentPrefs.model);
     setEffort(agentPrefs.effort);
     setFast(agentPrefs.fast);
+    setProviderSource(deviceId ? null : agentPrefs.providerId);
     setInitialTask('');
     setPrefsRestored(true);
-  }, [open]);
+  }, [deviceId, open]);
 
   // capabilities 可能尚未加载或模型被移除；加载后把当前选择收敛到可用模型和 effort。
   useEffect(() => {
@@ -181,7 +216,22 @@ export function CreateWorkerPopover({
     if (selected.efforts.length > 0 && !selected.efforts.includes(effort)) {
       setEffort(selected.defaultEffort ?? selected.efforts[selected.efforts.length - 1]);
     }
-  }, [activeModels, agent, effort, model, open, prefsRestored, modelCatalogLoading]);
+    // 恢复出来的显式来源可能已断开或不提供收敛后的模型 —— 目录就绪后同步收窄。
+    if (providerSource !== null) {
+      const narrowed = narrowProviderSource(providerSource, selected.id);
+      if (narrowed !== providerSource) setProviderSource(narrowed);
+    }
+  }, [
+    activeModels,
+    agent,
+    effort,
+    model,
+    modelCatalogLoading,
+    narrowProviderSource,
+    open,
+    prefsRestored,
+    providerSource,
+  ]);
 
   useEffect(() => {
     if (currentModel && !currentModelSupportsFast && fast) {
@@ -197,8 +247,9 @@ export function CreateWorkerPopover({
       setModel(remembered.model);
       setEffort(remembered.effort);
       setFast(remembered.fast);
+      setProviderSource(deviceId ? null : remembered.providerId);
     },
-    [prefs],
+    [deviceId, prefs],
   );
 
   const updateModel = useCallback(
@@ -211,11 +262,51 @@ export function CreateWorkerPopover({
       if (!available?.supportsFastMode) {
         setFast(false);
       }
+      // 仅换模型:当前显式来源不提供新模型时收窄,避免形成不可能组合。
+      setProviderSource((prev) => narrowProviderSource(prev, nextModel));
     },
-    [activeModels, effort],
+    [activeModels, effort, narrowProviderSource],
+  );
+
+  // 分段行原子选择 (来源, 模型, effort):与 composer 的 handleProviderChange 同语义。
+  // 面板回传的 reconciledEffort 已按模型级全局预设解析,模型不支持时仍按 efforts 校准。
+  const handleProviderChange = useCallback(
+    (providerId: string | null, modelId?: string, reconciledEffort?: Effort) => {
+      const nextModel = modelId ?? model;
+      setProviderSource(narrowProviderSource(providerId, nextModel));
+      if (!modelId) return;
+      setModel(modelId);
+      const available = activeModels.find((m) => m.id === modelId);
+      if (!available) return;
+      if (reconciledEffort && available.efforts.includes(reconciledEffort)) {
+        setEffort(reconciledEffort);
+      } else if (available.efforts.length > 0 && !available.efforts.includes(effort)) {
+        setEffort(available.defaultEffort ?? available.efforts[available.efforts.length - 1]);
+      }
+      if (!available.supportsFastMode) {
+        setFast(false);
+      }
+    },
+    [activeModels, effort, model, narrowProviderSource],
   );
 
   const updateEffort = setEffort;
+
+  // 非选中行 hover 配置(推理强度/Fast)与 composer 共用同一份模型级全局预设。
+  // device-link 远程创建不传:被控端记忆需镜像通道,宁可无记忆也不掺控制端本机。
+  const modelMemory = useMemo(
+    () =>
+      deviceId
+        ? undefined
+        : {
+            getEffort: getProviderModelEffort,
+            setEffort: setProviderModelEffort,
+            setChoice: setProviderModelChoice,
+            getFast: getProviderModelFast,
+            setFast: setProviderModelFast,
+          },
+    [deviceId],
+  );
 
   const activeRole = customRole || role;
   const customRoleError =
@@ -236,10 +327,18 @@ export function CreateWorkerPopover({
     if (!canCreate || submittingRef.current) return;
     submittingRef.current = true;
     setIsSubmitting(true);
+    // 提交前对 (来源, 模型) 再收窄一次:收敛 effect 与提交之间目录可能已变化。
+    const submitProviderId = narrowProviderSource(providerSource, model);
     const nextPrefs: WorkerPrefs = {
       ...prefs,
       lastAgent: agent,
-      [agent]: { model, effort, fast },
+      [agent]: {
+        model,
+        effort,
+        fast,
+        // device-link 创建不覆盖本地来源记忆(远程面板没有来源维度)。
+        providerId: deviceId ? prefs[agent].providerId : submitProviderId,
+      },
     };
     setPrefs(nextPrefs);
     writeWorkerPrefs(nextPrefs);
@@ -250,6 +349,7 @@ export function CreateWorkerPopover({
         model,
         effort: currentModel && currentModel.efforts.length > 0 ? effort : undefined,
         fast: currentModelSupportsFast ? fast : undefined,
+        providerId: submitProviderId,
         initialTask,
       });
     } finally {
@@ -261,9 +361,12 @@ export function CreateWorkerPopover({
     prefs,
     activeRole,
     agent,
+    deviceId,
     model,
     effort,
     fast,
+    providerSource,
+    narrowProviderSource,
     currentModel,
     currentModelSupportsFast,
     initialTask,
@@ -335,31 +438,28 @@ export function CreateWorkerPopover({
           <div className="mb-2 text-12 font-medium uppercase tracking-[0.5px] text-[var(--text-tertiary)]">
             {t('orca.createWorker.agentLabel')}
           </div>
-          <div className="inline-flex rounded-lg bg-[var(--surface-elevated)] border border-[var(--border-default)] p-1">
-            {(['codex', 'claude-code'] as const).map((a) => (
-              <button
-                key={a}
-                type="button"
-                className={cn(
-                  'rounded-md px-4 py-1.5 text-13 leading-none border transition-colors',
-                  agent === a
-                    ? 'bg-[var(--surface-chip)] border-[var(--text-secondary)] text-[var(--text-primary)] font-medium'
-                    : 'border-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]',
-                )}
-                onClick={() => updateAgent(a)}
-              >
-                {a === 'codex' ? 'Codex' : 'Claude Code'}
-              </button>
-            ))}
-          </div>
+          {/* 应用标准 Agent 分段控件(替换此前手写的按钮组;与 New Maker / IM 目录偏好同款,
+              「不自建选择 UI」的组件复用原则)。 */}
+          <VendorSegmentedSwitcher
+            value={vendorKey}
+            width={220}
+            ariaLabel={t('orca.createWorker.agentLabel')}
+            onChange={(next) => updateAgent(next === 'codex' ? 'codex' : 'claude-code')}
+          />
         </div>
 
         <div className="mb-4">
           <div className="mb-2 text-12 font-medium uppercase tracking-[0.5px] text-[var(--text-tertiary)]">
             {t('orca.createWorker.modelLabel')}
           </div>
+          {/* composer 同款全功能标准面板(2026-07 用户定稿基准:全软件一个模型选择面板,
+              处处同行为):供应商分段、订阅来源、推理强度、Fast(行级配置列,替代此前的
+              外置开关)全开;选定来源随创建参数显式下发,由 OrcaWorkerCreationService
+              精确 preflight。device-link 远程创建维持既有退化:被控端纯列表、无来源维度,
+              且面板行级 Fast 依赖来源分段(fastEditable 走 connected 目录),故远程仍用
+              外置 FastModeToggle,不能删。 */}
           <div className="flex items-center gap-2">
-            {currentModelSupportsFast && (
+            {deviceId && currentModelSupportsFast && (
               <FastModeToggle enabled={fast} onToggle={() => setFast((v) => !v)} />
             )}
             <ModelSelector
@@ -370,6 +470,19 @@ export function CreateWorkerPopover({
               vendorKey={vendorKey}
               deviceId={deviceId}
               popoverSide="bottom"
+              currentProviderId={deviceId ? undefined : providerSource}
+              onProviderChange={deviceId ? undefined : handleProviderChange}
+              onNavigateToProviders={
+                deviceId
+                  ? undefined
+                  : () => {
+                      onClose();
+                      navigate('/settings?tab=providers');
+                    }
+              }
+              modelMemory={modelMemory}
+              fastMode={deviceId ? undefined : fast}
+              onFastModeChange={deviceId ? undefined : (enabled) => setFast(enabled)}
             />
           </div>
           {noAvailableLocalModels ? (

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -217,6 +217,8 @@ function draftEnableOrcaOptions(collab: CollabDraft) {
     model: cfg.model,
     effort: cfg.effort as 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined,
     fast: cfg.fast,
+    // null(未显式选来源)不传字段:IPC 侧只认非空 string 为显式来源。
+    providerId: cfg.providerId ?? undefined,
     delegateTask: cfg.initialTask || undefined,
   };
 }
@@ -2468,6 +2470,7 @@ export function NewMakerDraftRoute() {
                 model: form.model,
                 effort: form.effort,
                 fast: form.fast,
+                providerId: form.providerId,
                 initialTask: form.initialTask || undefined,
               },
             });

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -138,6 +138,7 @@ import {
   type AgentCapabilities,
 } from '@/hooks/useAgentCapabilities';
 import { useProviders } from '@/hooks/useProviders';
+import { isModelEnabled } from '@/state/modelVisibilityPrefs';
 import {
   useDeviceProviders,
   evictDeviceProviders,
@@ -149,7 +150,7 @@ import {
   useProjectPickerOptions,
 } from '@/hooks/useProjectPickerOptions';
 import { resolveFastSupported, deriveModelsFromProviders } from '@/lib/providerModels';
-import { effectiveSourceIdForModel, getModel, sessionModelSupportsFastMode, connectedProvidersForAgent } from '@cindy/model-providers';
+import { effectiveSourceIdForModel, getModel, providerOffersModel, sessionModelSupportsFastMode, connectedProvidersForAgent, type ProviderView } from '@cindy/model-providers';
 import { isSubscriptionDirectModel } from '../../../shared/subscriptionModels';
 import {
   resolveDeviceLinkDraftDefaults,
@@ -206,10 +207,25 @@ const DRAFT_IMAGE_URL_PREFIX = `xdt-image://${NEW_MAKER_DRAFT_KEY}/`;
  * 由 draft.collab 拼出 createSession 后 enableOrca 的入参:与会话内 requestEnableCollab 同口径。
  * 有 workerConfig(用户在「开启协同」弹窗配过 role/model/…)则透传全量;否则只带 workerAgent 回退默认。
  */
-function draftEnableOrcaOptions(collab: CollabDraft) {
+function draftEnableOrcaOptions(collab: CollabDraft, providers: ProviderView[]) {
   const workerAgent: 'claude-code' | 'codex' = collab.worker === 'codex' ? 'codex' : 'claude-code';
   const cfg = collab.workerConfig;
   if (!cfg) return { workerAgent };
+  // 草稿里持久化的来源在发送时按 live 目录重新收窄(已连接 + 提供该模型 + 未被可见性
+  // 隐藏,与 CreateWorkerPopover.narrowProviderSource 同规则):草稿可跨重启存活,来源
+  // 可能已断开/掉模型 —— 直接透传会撞 main 的 PROVIDER_ROUTE_UNAVAILABLE 精确 preflight,
+  // 让协同静默退化成单会话(codex review)。收窄为 undefined = 交回默认路由解析。
+  const providerId = (() => {
+    if (!cfg.providerId) return undefined;
+    const provider = connectedProvidersForAgent(providers, workerAgent).find(
+      (p) => p.id === cfg.providerId,
+    );
+    if (!provider || !providerOffersModel(provider, cfg.model, workerAgent)) return undefined;
+    const catalogModel = getModel(provider, cfg.model, workerAgent);
+    return catalogModel && isModelEnabled(workerAgent, cfg.providerId, catalogModel)
+      ? cfg.providerId
+      : undefined;
+  })();
   return {
     workerAgent,
     role: cfg.role,
@@ -217,8 +233,7 @@ function draftEnableOrcaOptions(collab: CollabDraft) {
     model: cfg.model,
     effort: cfg.effort as 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined,
     fast: cfg.fast,
-    // null(未显式选来源)不传字段:IPC 侧只认非空 string 为显式来源。
-    providerId: cfg.providerId ?? undefined,
+    providerId,
     delegateTask: cfg.initialTask || undefined,
   };
 }
@@ -1561,7 +1576,7 @@ export function NewMakerDraftRoute() {
                   try {
                     const result = await window.electronAPI.maker.enableOrca(
                       newSession.id,
-                      draftEnableOrcaOptions(effectiveCollab),
+                      draftEnableOrcaOptions(effectiveCollab, localProviders),
                     );
                     // worktree 创建在后台完成,组件可能已经切走;这里读取当前 URL,
                     // 避免用 render 时捕获的旧路由误判。
@@ -1675,7 +1690,7 @@ export function NewMakerDraftRoute() {
             try {
               const result = await window.electronAPI.maker.enableOrca(
                 newSession.id,
-                draftEnableOrcaOptions(effectiveCollab),
+                draftEnableOrcaOptions(effectiveCollab, localProviders),
               );
               orcaNavTarget = `/cc-agent/${newSession.id}`;
               orcaWorkersRevealState = { focusWorkerSessionId: result.workerSessionId };
@@ -1958,7 +1973,7 @@ export function NewMakerDraftRoute() {
         try {
           const result = await window.electronAPI.maker.enableOrca(
             newSession.id,
-            draftEnableOrcaOptions(effectiveCollab),
+            draftEnableOrcaOptions(effectiveCollab, localProviders),
           );
           orcaWorkersRevealState = { focusWorkerSessionId: result.workerSessionId };
         } catch (err) {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -207,16 +207,23 @@ const DRAFT_IMAGE_URL_PREFIX = `xdt-image://${NEW_MAKER_DRAFT_KEY}/`;
  * 由 draft.collab 拼出 createSession 后 enableOrca 的入参:与会话内 requestEnableCollab 同口径。
  * 有 workerConfig(用户在「开启协同」弹窗配过 role/model/…)则透传全量;否则只带 workerAgent 回退默认。
  */
-function draftEnableOrcaOptions(collab: CollabDraft, providers: ProviderView[]) {
+function draftEnableOrcaOptions(
+  collab: CollabDraft,
+  providers: ProviderView[],
+  providersReady: boolean,
+) {
   const workerAgent: 'claude-code' | 'codex' = collab.worker === 'codex' ? 'codex' : 'claude-code';
   const cfg = collab.workerConfig;
   if (!cfg) return { workerAgent };
   // 草稿里持久化的来源在发送时按 live 目录重新收窄(已连接 + 提供该模型 + 未被可见性
   // 隐藏,与 CreateWorkerPopover.narrowProviderSource 同规则):草稿可跨重启存活,来源
   // 可能已断开/掉模型 —— 直接透传会撞 main 的 PROVIDER_ROUTE_UNAVAILABLE 精确 preflight,
-  // 让协同静默退化成单会话(codex review)。收窄为 undefined = 交回默认路由解析。
+  // 让协同退化成单会话(codex review)。收窄为 undefined = 交回默认路由解析。
+  // 仅在目录快照就绪时收窄:loading 中把空/滞后快照当权威会误清有效来源(静默降级,
+  // 用户无感);未就绪透传原值,真失效由 main 精确 preflight 报可操作错误(codex review)。
   const providerId = (() => {
     if (!cfg.providerId) return undefined;
+    if (!providersReady) return cfg.providerId;
     const provider = connectedProvidersForAgent(providers, workerAgent).find(
       (p) => p.id === cfg.providerId,
     );
@@ -517,7 +524,7 @@ export function NewMakerDraftRoute() {
   const { capabilities, loading: capabilitiesLoading } = useAgentCapabilities(capabilityAgentKind, effectiveDeviceLinkDeviceId);
   // device-link「以被控端为准」:远程草稿用被控端经隧道带来的 providers(per-provider,含 fast 能力);
   // 本地草稿用本机 providers。fast 判定统一交给 resolveFastSupported(不在控制端另写远程逻辑)。
-  const { providers: localProviders } = useProviders();
+  const { providers: localProviders, loading: localProvidersLoading } = useProviders();
   const { providers: deviceProviders, loading: deviceProvidersLoading } = useDeviceProviders(effectiveDeviceLinkDeviceId);
   const providers = effectiveDeviceLinkDeviceId ? deviceProviders : localProviders;
 
@@ -1576,7 +1583,7 @@ export function NewMakerDraftRoute() {
                   try {
                     const result = await window.electronAPI.maker.enableOrca(
                       newSession.id,
-                      draftEnableOrcaOptions(effectiveCollab, localProviders),
+                      draftEnableOrcaOptions(effectiveCollab, localProviders, !localProvidersLoading),
                     );
                     // worktree 创建在后台完成,组件可能已经切走;这里读取当前 URL,
                     // 避免用 render 时捕获的旧路由误判。
@@ -1690,7 +1697,7 @@ export function NewMakerDraftRoute() {
             try {
               const result = await window.electronAPI.maker.enableOrca(
                 newSession.id,
-                draftEnableOrcaOptions(effectiveCollab, localProviders),
+                draftEnableOrcaOptions(effectiveCollab, localProviders, !localProvidersLoading),
               );
               orcaNavTarget = `/cc-agent/${newSession.id}`;
               orcaWorkersRevealState = { focusWorkerSessionId: result.workerSessionId };
@@ -1776,6 +1783,10 @@ export function NewMakerDraftRoute() {
       // workerConfig 也要进依赖:只改角色/模型/effort/初始任务(worker 类型不变)时,
       // 少了它 handleSend 会闭包吃旧的 effectiveCollab,起 Worker 用错配置(codex P2)。
       effectiveCollab.workerConfig,
+      // draftEnableOrcaOptions 现按 live 目录收窄草稿来源:快照与 loading 都要进
+      // 依赖,否则闭包吃旧快照,来源连/断后仍按陈旧目录收窄(codex review)。
+      localProviders,
+      localProvidersLoading,
       vendorAuthGate,
       createSession,
       navigate,
@@ -1973,7 +1984,7 @@ export function NewMakerDraftRoute() {
         try {
           const result = await window.electronAPI.maker.enableOrca(
             newSession.id,
-            draftEnableOrcaOptions(effectiveCollab, localProviders),
+            draftEnableOrcaOptions(effectiveCollab, localProviders, !localProvidersLoading),
           );
           orcaWorkersRevealState = { focusWorkerSessionId: result.workerSessionId };
         } catch (err) {
@@ -2019,6 +2030,9 @@ export function NewMakerDraftRoute() {
       collabPolicy.refresh,
       collabPolicy.unavailable,
       collabPolicy.enabled,
+      // 同 handleSend:草稿来源收窄依赖 live 目录快照。
+      localProviders,
+      localProvidersLoading,
       patchCollab,
       navigate,
       t,

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -4,7 +4,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { renderToString } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { setProviderModelChoice, setProviderModelFast } from '@/state/providerModelMemory';
+import {
+  getProviderModelEffort,
+  setProviderModelChoice,
+  setProviderModelFast,
+} from '@/state/providerModelMemory';
 import { CreateWorkerPopover } from '../CreateWorkerPopover';
 
 const mocks = vi.hoisted(() => ({
@@ -28,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   },
   capabilitiesLoading: false,
   providersLoading: false,
+  // 「(providerId, modelId)」被可见性开关隐藏的组合(isModelEnabled mock 消费)。
+  hiddenModels: [] as string[],
   // 本地已连接来源目录(narrowProviderSource 走真函数,消费这份最小 ProviderView 形状)。
   localProviders: [] as Array<{
     id: string;
@@ -62,7 +68,9 @@ vi.mock('@/hooks/useDeviceProviders', () => ({
   useDeviceProviders: () => ({ providers: [], loading: mocks.providersLoading, error: null }),
 }));
 
-vi.mock('react-router-dom', () => ({
+// 只覆写 useNavigate,保留真实导出:全量 mock 会连带打断任何间接依赖(copilot review)。
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
   useNavigate: () => vi.fn(),
 }));
 
@@ -71,6 +79,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
     modelId: string;
     currentProviderId?: string | null;
     onProviderChange?: (providerId: string | null, modelId?: string, effort?: string) => void;
+    onEffortChange: (effort: string) => void;
     reselectEmitsChange?: boolean;
     fastMode?: boolean;
     onFastModeChange?: (enabled: boolean) => void;
@@ -98,12 +107,18 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
         data-testid="pick-openai-row-bare"
         onClick={() => props.onProviderChange?.('openai', 'gpt-5.5')}
       />
+      <button
+        type="button"
+        data-testid="edit-active-effort"
+        onClick={() => props.onEffortChange('low')}
+      />
     </div>
   ),
 }));
 
 vi.mock('@/state/modelVisibilityPrefs', () => ({
-  isModelEnabled: () => true,
+  isModelEnabled: (_agent: string, providerId: string, m: { id: string }) =>
+    !mocks.hiddenModels.includes(`${providerId}:${m.id}`),
   useModelVisibilityVersion: () => 0,
 }));
 
@@ -123,6 +138,7 @@ describe('CreateWorkerPopover', () => {
     mocks.capabilitiesLoading = false;
     mocks.providersLoading = false;
     mocks.localProviders = [];
+    mocks.hiddenModels = [];
   });
 
   afterEach(() => {
@@ -498,6 +514,98 @@ describe('CreateWorkerPopover', () => {
       expect(onCreate).toHaveBeenCalledWith(
         expect.objectContaining({ model: 'gpt-5.5', providerId: 'openai', fast: undefined }),
       ),
+    );
+  });
+
+  it('narrows a remembered provider whose model entry is hidden by visibility prefs', async () => {
+    // 同模型多来源:用户隐藏了记忆来源那份条目后,面板已不显示该行,
+    // 不能仍显式路由过去(codex review)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'openai' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.hiddenModels = ['openai:gpt-5.5'];
+    mocks.modelsByAgent.codex = [model('gpt-5.5')];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe(''),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ providerId: null })),
+    );
+  });
+
+  it('resolves Fast against the effective default provider when no explicit source is set', async () => {
+    // 未显式来源时 Fast 能力按生效默认来源自己的条目查,不用拍平并集的首来源值
+    // (codex review:默认来源不支持时不能把 stale true 带到提交)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: true, providerId: null },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        // 该来源的条目不带 supportsFastMode → 默认来源不支持 Fast。
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [model('gpt-5.5')]; // 并集条目 supportsFastMode: true
+    mocks.capabilitiesByAgent.codex = {
+      availableModels: [{ id: 'gpt-5.5' }],
+      hasFastMode: true,
+    } as never;
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'orca.createWorker.submit' }),
+    );
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ fast: undefined })),
+    );
+  });
+
+  it('persists active-row effort edits into the shared model memory', async () => {
+    // 活跃行编辑走 onEffortChange 而非 modelMemory,必须写回全局预设 ——
+    // 否则切走再切回按旧值恢复,编辑被静默丢弃(codex review)。
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'codex/gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [model('codex/gpt-5.5', ['low', 'high'], 'high')];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'codex/gpt-5.5' }] };
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={vi.fn()} />);
+    fireEvent.click(await screen.findByTestId('edit-active-effort'));
+    await waitFor(() =>
+      expect(getProviderModelEffort('codex', 'openai', 'codex/gpt-5.5')).toBe('low'),
     );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -34,7 +34,7 @@ const mocks = vi.hoisted(() => ({
     name: string;
     connected: boolean;
     agents: string[];
-    models: Record<string, Array<{ id: string }>>;
+    models: Record<string, Array<{ id: string; supportsFastMode?: boolean }>>;
   }>,
 }));
 

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -52,6 +52,15 @@ const mocks = vi.hoisted(() => ({
       }>
     >;
   }>,
+  // 被控端 provider 快照(device-link 创建;providerFastSupported 的远程口径消费)。
+  remoteProviders: [] as Array<{
+    id: string;
+    name: string;
+    connected: boolean;
+    agents: string[];
+    models: Record<string, Array<{ id: string; supportsFastMode?: boolean }>>;
+  }>,
+  sidebarWindow: false,
 }));
 
 function model(id: string, efforts = ['high'], defaultEffort = 'high') {
@@ -75,7 +84,15 @@ vi.mock('@/hooks/useProviders', () => ({
 }));
 
 vi.mock('@/hooks/useDeviceProviders', () => ({
-  useDeviceProviders: () => ({ providers: [], loading: mocks.providersLoading, error: null }),
+  useDeviceProviders: () => ({
+    providers: mocks.remoteProviders,
+    loading: mocks.providersLoading,
+    error: null,
+  }),
+}));
+
+vi.mock('@/lib/sidebarWindow', () => ({
+  isSidebarWindow: () => mocks.sidebarWindow,
 }));
 
 // 只覆写 useNavigate,保留真实导出:全量 mock 会连带打断任何间接依赖(copilot review)。
@@ -93,6 +110,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
     reselectEmitsChange?: boolean;
     fastMode?: boolean;
     onFastModeChange?: (enabled: boolean) => void;
+    onNavigateToProviders?: () => void;
     modelMemory?: unknown;
   }) => (
     <div
@@ -104,6 +122,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
       data-reselect-emits={String(props.reselectEmitsChange === true)}
       data-fast-wired={String(props.onFastModeChange !== undefined)}
       data-memory-wired={String(props.modelMemory !== undefined)}
+      data-navigate-wired={String(props.onNavigateToProviders !== undefined)}
     >
       {props.modelId}
       <button
@@ -155,7 +174,9 @@ describe('CreateWorkerPopover', () => {
     mocks.capabilitiesLoading = false;
     mocks.providersLoading = false;
     mocks.localProviders = [];
+    mocks.remoteProviders = [];
     mocks.hiddenModels = [];
+    mocks.sidebarWindow = false;
   });
 
   afterEach(() => {
@@ -402,6 +423,7 @@ describe('CreateWorkerPopover', () => {
     expect(selector.dataset.fastWired).toBe('true');
     expect(selector.dataset.memoryWired).toBe('true');
     expect(selector.dataset.reselectEmits).toBe('true');
+    expect(selector.dataset.navigateWired).toBe('true');
   });
 
   it('keeps the degraded flat panel for device-link remote creation', async () => {
@@ -948,5 +970,176 @@ describe('CreateWorkerPopover', () => {
     fireEvent.click(screen.getByTestId('pick-xd-row-bare'));
 
     expect(getProviderModelChoice('codex', 'xd')).toEqual({ model: 'gpt-5.5', effort: 'high' });
+  });
+
+  it('reconciles a restored stale effort against the saved provider entry on submit', async () => {
+    // 恢复路径:prefs 存的 effort=high 来自旧目录,而显式来源 xd 的条目只有 low 档;
+    // 收敛 effect 按拍平条目(三档)不会清 high,直接 explicit 下发会被 main 侧路由
+    // 来源校验拒掉阻断创建(codex review)。提交前按来源条目对账,落其 defaultEffort。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'xd' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: {
+          codex: [{ id: 'gpt-5.5', efforts: ['low'], defaultEffort: 'low' }],
+          'claude-code': [],
+        },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('xd'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'xd', effort: 'low' }),
+      ),
+    );
+  });
+
+  it('omits effort when the route provider entry has no effort switching', async () => {
+    // 来源条目无档(efforts:[])而拍平条目有档:带 effort 下发会被 main 按该来源
+    // 档位表 explicit 拒绝 —— 该来源本可创建(effort 省略),不能让 UI 主动触发
+    // INVALID_PARAMS 阻断(copilot review)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'xd' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: {
+          codex: [{ id: 'gpt-5.5', efforts: [], defaultEffort: null }],
+          'claude-code': [],
+        },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('xd'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'xd', effort: undefined }),
+      ),
+    );
+  });
+
+  it('records the model choice when re-pinning the current effective source row', async () => {
+    // 钉/重选当前生效来源的早退分支保留 live 值,但 (来源, 模型) 仍是一次真实选定:
+    // 该来源槽 lastModel 指着别的模型时必须更新,否则其它标准选择器切到该来源会
+    // 恢复 stale 模型(codex review)。
+    setProviderModelChoice('codex', 'openai', 'gpt-other', 'low');
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'openai' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={vi.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('openai'),
+    );
+    fireEvent.click(screen.getByTestId('pick-openai-row-bare'));
+
+    expect(getProviderModelChoice('codex', 'openai')).toEqual({ model: 'gpt-5.5', effort: 'high' });
+  });
+
+  it('resolves remote Fast against the effective device provider, not the flattened union', async () => {
+    // 被控端快照可用时,Fast 按其生效默认来源自己的条目判定(与被控端 main 的
+    // fastModels re-gate 同口径);拍平条目说支持而默认来源 xd 不支持 → 不提供
+    // Fast,提交 fast=undefined(codex review)。快照缺失(旧 peer)仍回落拍平。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: true },
+      }),
+    );
+    mocks.remoteProviders = [
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5', supportsFastMode: false }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [model('gpt-5.5')];
+    mocks.capabilitiesByAgent.codex = {
+      availableModels: [{ id: 'gpt-5.5' }],
+      hasFastMode: true,
+    } as never;
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open deviceId="device-a" onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').textContent).toContain('gpt-5.5'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', fast: undefined }),
+      ),
+    );
+  });
+
+  it('does not wire provider navigation inside the detached sidebar window', async () => {
+    // 分离侧栏窗口固定 /sidebar-window 壳路由:本地 navigate 会把辅助窗口整壳替换
+    // 成主设置路由,与 OrcaWorkerPanel 的 settingsEnabled={!isSidebarWindow()} 同
+    // 禁用口径(codex review)。
+    mocks.sidebarWindow = true;
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={vi.fn()} />);
+    const selector = await screen.findByTestId('model-selector');
+    expect(selector.dataset.navigateWired).toBe('false');
+    // 供应商分段本身不受影响,只禁跳转。
+    expect(selector.dataset.sourcesEnabled).toBe('true');
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   __resetForTest as resetProviderModelMemoryForTest,
+  getProviderModelChoice,
   getProviderModelEffort,
   setProviderModelChoice,
   setProviderModelFast,
@@ -41,7 +42,15 @@ const mocks = vi.hoisted(() => ({
     name: string;
     connected: boolean;
     agents: string[];
-    models: Record<string, Array<{ id: string; supportsFastMode?: boolean }>>;
+    models: Record<
+      string,
+      Array<{
+        id: string;
+        supportsFastMode?: boolean;
+        efforts?: string[];
+        defaultEffort?: string | null;
+      }>
+    >;
   }>,
 }));
 
@@ -845,5 +854,99 @@ describe('CreateWorkerPopover', () => {
     const raw = JSON.parse(window.localStorage.getItem('xdt:providerModelMemory:v2') ?? '{}');
     expect(Object.keys(raw)).toContain('codex:openai');
     expect(Object.keys(raw)).not.toContain('codex:ghost-provider');
+  });
+
+  it('resolves effort from the selected provider catalog row, not the flattened union', async () => {
+    // gpt-5.5 的拍平条目(首来源 openai wins)默认 high,而 xd 自己的目录条目只有
+    // low 档:选 xd 行(无共享预设)必须落 xd 条目的 defaultEffort,不能按拍平条目
+    // 保留/赋予 xd 不支持的档位 —— 提交后会被 main 侧路由来源校验拒掉(codex review)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'openai' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: {
+          codex: [{ id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high' }],
+          'claude-code': [],
+        },
+      },
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: {
+          codex: [{ id: 'gpt-5.5', efforts: ['low'], defaultEffort: 'low' }],
+          'claude-code': [],
+        },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('openai'),
+    );
+    fireEvent.click(screen.getByTestId('pick-xd-row-bare'));
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'xd', effort: 'low' }),
+      ),
+    );
+  });
+
+  it('persists the picked (source, model) into the provider choice slot', async () => {
+    // 选行是一次真实选定:必须写该来源槽的 lastModel(composer/其它标准选择器的
+    // resolveSourceSwitch 用它做切来源落点),否则本面板的显式选择不进全局记忆,
+    // 别处切到该来源仍恢复旧模型(codex review)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'openai' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={vi.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('openai'),
+    );
+    fireEvent.click(screen.getByTestId('pick-xd-row-bare'));
+
+    expect(getProviderModelChoice('codex', 'xd')).toEqual({ model: 'gpt-5.5', effort: 'high' });
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { renderToString } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { setProviderModelChoice, setProviderModelFast } from '@/state/providerModelMemory';
 import { CreateWorkerPopover } from '../CreateWorkerPopover';
 
 const mocks = vi.hoisted(() => ({
@@ -70,6 +71,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
     modelId: string;
     currentProviderId?: string | null;
     onProviderChange?: (providerId: string | null, modelId?: string, effort?: string) => void;
+    reselectEmitsChange?: boolean;
     fastMode?: boolean;
     onFastModeChange?: (enabled: boolean) => void;
     modelMemory?: unknown;
@@ -80,6 +82,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
       // fastMode/onFastModeChange 是行级配置列的 Fast 开关(替代外置 FastModeToggle)。
       data-sources-enabled={String(props.onProviderChange !== undefined)}
       data-current-provider={props.currentProviderId ?? ''}
+      data-reselect-emits={String(props.reselectEmitsChange === true)}
       data-fast-wired={String(props.onFastModeChange !== undefined)}
       data-memory-wired={String(props.modelMemory !== undefined)}
     >
@@ -88,6 +91,12 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
         type="button"
         data-testid="pick-openai-row"
         onClick={() => props.onProviderChange?.('openai', 'gpt-5.5', 'medium')}
+      />
+      {/* 真组件选行只回传两参(见 ModelSelector.handleRowSelect),记忆恢复走全局预设。 */}
+      <button
+        type="button"
+        data-testid="pick-openai-row-bare"
+        onClick={() => props.onProviderChange?.('openai', 'gpt-5.5')}
       />
     </div>
   ),
@@ -354,9 +363,11 @@ describe('CreateWorkerPopover', () => {
     render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={vi.fn()} />);
     const selector = await screen.findByTestId('model-selector');
     expect(selector.dataset.sourcesEnabled).toBe('true');
-    // Fast 收进面板行级配置列(外置开关已移除),模型级记忆与 composer 共用。
+    // Fast 收进面板行级配置列(本地 + codex),模型级记忆与 composer 共用;
+    // 点「解析出的生效默认来源」行必须能钉成显式偏好。
     expect(selector.dataset.fastWired).toBe('true');
     expect(selector.dataset.memoryWired).toBe('true');
+    expect(selector.dataset.reselectEmits).toBe('true');
   });
 
   it('keeps the degraded flat panel for device-link remote creation', async () => {
@@ -414,6 +425,79 @@ describe('CreateWorkerPopover', () => {
 
     await waitFor(() =>
       expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ providerId: null })),
+    );
+  });
+
+  it('restores remembered effort and Fast for the picked row when the panel omits them', async () => {
+    // 真组件选行只回传 (providerId, modelId);目标模型 hover 配置过的 effort/Fast
+    // 存在模型级全局预设里,选中后必须恢复,不能沿用上一个模型的值。
+    setProviderModelChoice('codex', 'openai', 'gpt-5.5', 'low');
+    setProviderModelFast('codex', 'openai', 'gpt-5.5', true);
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5', supportsFastMode: true }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      model('codex/gpt-5.5'),
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: true },
+    ];
+    mocks.capabilitiesByAgent.codex = {
+      availableModels: [{ id: 'codex/gpt-5.5' }, { id: 'gpt-5.5' }],
+      hasFastMode: true,
+    } as never;
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    fireEvent.click(await screen.findByTestId('pick-openai-row-bare'));
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-5.5',
+          providerId: 'openai',
+          effort: 'low',
+          fast: true,
+        }),
+      ),
+    );
+  });
+
+  it('drops Fast when the picked provider does not support it for the model', async () => {
+    // per-provider Fast 能力:同一 model id 在选中来源的条目上不支持 Fast 时,
+    // 不能沿用拍平并集的首来源能力继续提交 fast=true。
+    setProviderModelFast('codex', 'openai', 'gpt-5.5', true);
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['medium'], defaultEffort: 'medium', supportsFastMode: true },
+    ];
+    mocks.capabilitiesByAgent.codex = {
+      availableModels: [{ id: 'gpt-5.5' }],
+      hasFastMode: true,
+    } as never;
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    fireEvent.click(await screen.findByTestId('pick-openai-row-bare'));
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'openai', fast: undefined }),
+      ),
     );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -27,6 +27,14 @@ const mocks = vi.hoisted(() => ({
   },
   capabilitiesLoading: false,
   providersLoading: false,
+  // 本地已连接来源目录(narrowProviderSource 走真函数,消费这份最小 ProviderView 形状)。
+  localProviders: [] as Array<{
+    id: string;
+    name: string;
+    connected: boolean;
+    agents: string[];
+    models: Record<string, Array<{ id: string }>>;
+  }>,
 }));
 
 function model(id: string, efforts = ['high'], defaultEffort = 'high') {
@@ -46,20 +54,42 @@ vi.mock('@/hooks/useAgentCapabilities', () => ({
 }));
 
 vi.mock('@/hooks/useProviders', () => ({
-  useProviders: () => ({ providers: [], loading: mocks.providersLoading }),
+  useProviders: () => ({ providers: mocks.localProviders, loading: mocks.providersLoading }),
 }));
 
 vi.mock('@/hooks/useDeviceProviders', () => ({
   useDeviceProviders: () => ({ providers: [], loading: mocks.providersLoading, error: null }),
 }));
 
-vi.mock('@/components/new-chat/FastModeToggle', () => ({
-  FastModeToggle: () => null,
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
 }));
 
 vi.mock('@/components/new-chat/ModelSelector', () => ({
-  ModelSelector: ({ modelId }: { modelId: string }) => (
-    <div data-testid="model-selector">{modelId}</div>
+  ModelSelector: (props: {
+    modelId: string;
+    currentProviderId?: string | null;
+    onProviderChange?: (providerId: string | null, modelId?: string, effort?: string) => void;
+    fastMode?: boolean;
+    onFastModeChange?: (enabled: boolean) => void;
+    modelMemory?: unknown;
+  }) => (
+    <div
+      data-testid="model-selector"
+      // onProviderChange 是「供应商分段模式」的开关(面板内部 sourcesEnabled 判据),
+      // fastMode/onFastModeChange 是行级配置列的 Fast 开关(替代外置 FastModeToggle)。
+      data-sources-enabled={String(props.onProviderChange !== undefined)}
+      data-current-provider={props.currentProviderId ?? ''}
+      data-fast-wired={String(props.onFastModeChange !== undefined)}
+      data-memory-wired={String(props.modelMemory !== undefined)}
+    >
+      {props.modelId}
+      <button
+        type="button"
+        data-testid="pick-openai-row"
+        onClick={() => props.onProviderChange?.('openai', 'gpt-5.5', 'medium')}
+      />
+    </div>
   ),
 }));
 
@@ -83,6 +113,7 @@ describe('CreateWorkerPopover', () => {
     };
     mocks.capabilitiesLoading = false;
     mocks.providersLoading = false;
+    mocks.localProviders = [];
   });
 
   afterEach(() => {
@@ -293,7 +324,7 @@ describe('CreateWorkerPopover', () => {
     await waitFor(() =>
       expect(screen.getByTestId('model-selector').textContent).toBe('codex/gpt-5.5'),
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Claude Code' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Claude' }));
 
     await waitFor(() =>
       expect(screen.getByTestId('model-selector').textContent).toBe('claude-sonnet-4-6'),
@@ -317,5 +348,72 @@ describe('CreateWorkerPopover', () => {
       (screen.getByRole('button', { name: 'orca.createWorker.submit' }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+  });
+
+  it('mounts the standard panel with provider sections for local creation', async () => {
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={vi.fn()} />);
+    const selector = await screen.findByTestId('model-selector');
+    expect(selector.dataset.sourcesEnabled).toBe('true');
+    // Fast 收进面板行级配置列(外置开关已移除),模型级记忆与 composer 共用。
+    expect(selector.dataset.fastWired).toBe('true');
+    expect(selector.dataset.memoryWired).toBe('true');
+  });
+
+  it('keeps the degraded flat panel for device-link remote creation', async () => {
+    render(<CreateWorkerPopover open deviceId="device-a" onClose={vi.fn()} onCreate={vi.fn()} />);
+    const selector = await screen.findByTestId('model-selector');
+    expect(selector.dataset.sourcesEnabled).toBe('false');
+    expect(selector.dataset.memoryWired).toBe('false');
+  });
+
+  it('submits the provider picked from a source section row', async () => {
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [model('gpt-5.5', ['medium'], 'medium')];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    fireEvent.click(await screen.findByTestId('pick-openai-row'));
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('openai'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'openai', effort: 'medium' }),
+      ),
+    );
+  });
+
+  it('narrows a restored provider that no longer offers the model to null', async () => {
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'ghost-provider' },
+      }),
+    );
+    mocks.modelsByAgent.codex = [model('gpt-5.5')];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe(''),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ providerId: null })),
+    );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -113,6 +113,11 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
         data-testid="edit-active-effort"
         onClick={() => props.onEffortChange('low')}
       />
+      <button
+        type="button"
+        data-testid="pick-xd-row-bare"
+        onClick={() => props.onProviderChange?.('xd', 'gpt-5.5')}
+      />
     </div>
   ),
 }));
@@ -610,6 +615,53 @@ describe('CreateWorkerPopover', () => {
     fireEvent.click(await screen.findByTestId('edit-active-effort'));
     await waitFor(() =>
       expect(getProviderModelEffort('codex', 'openai', 'codex/gpt-5.5')).toBe('low'),
+    );
+  });
+
+  it('restores the target row preset when switching sources that share the same model', async () => {
+    // 同一模型在 openai(当前生效)与 xd 都有:点 xd 行是真实来源切换,必须恢复
+    // xd 行显示的预设,不能因「模型相同」被当成钉当前来源而保留 live 值(codex review)。
+    setProviderModelChoice('codex', 'xd', 'gpt-5.5', 'low');
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'openai' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('openai'),
+    );
+    fireEvent.click(screen.getByTestId('pick-xd-row-bare'));
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'xd', effort: 'low' }),
+      ),
     );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -808,4 +808,42 @@ describe('CreateWorkerPopover', () => {
       ),
     );
   });
+
+  it('keys memory compatibility copies to the effective source while an explicit source is stale', async () => {
+    // 目录仍在加载(收敛 effect 未跑)、恢复出的显式来源已失效:活跃行编辑的记忆
+    // 写入按收窄后口径落 key —— 全局预设槽不受影响,但来源槽兼容副本不得写给
+    // 已失效来源(copilot review;ChatInput 的 effectiveSourceId 同语义)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'ghost-provider' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    mocks.providersLoading = true;
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={vi.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('ghost-provider'),
+    );
+    fireEvent.click(screen.getByTestId('edit-active-effort'));
+
+    expect(getProviderModelEffort('codex', 'openai', 'gpt-5.5')).toBe('low');
+    const raw = JSON.parse(window.localStorage.getItem('xdt:providerModelMemory:v2') ?? '{}');
+    expect(Object.keys(raw)).toContain('codex:openai');
+    expect(Object.keys(raw)).not.toContain('codex:ghost-provider');
+  });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -5,6 +5,7 @@ import { renderToString } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  __resetForTest as resetProviderModelMemoryForTest,
   getProviderModelEffort,
   setProviderModelChoice,
   setProviderModelFast,
@@ -129,6 +130,8 @@ vi.mock('../workerModelAvailability', () => ({
 describe('CreateWorkerPopover', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    // providerModelMemory 有进程内 cache,只清 localStorage 会把记忆泄漏到后续用例。
+    resetProviderModelMemoryForTest();
     mocks.modelsByAgent.codex = [model('codex/gpt-5.5')];
     mocks.modelsByAgent['claude-code'] = [model('claude-opus-4-7')];
     mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'codex/gpt-5.5' }] };
@@ -144,6 +147,7 @@ describe('CreateWorkerPopover', () => {
   afterEach(() => {
     cleanup();
     window.localStorage.clear();
+    resetProviderModelMemoryForTest();
   });
 
   it('disables immediately and collapses repeated click events into one request', async () => {

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -703,4 +703,109 @@ describe('CreateWorkerPopover', () => {
       ),
     );
   });
+
+  it('keeps live source and effort edits across agent tab switches', async () => {
+    // 切 tab 的恢复读的是 prefs:切走前必须把当前 agent 的 live 编辑快照进内存
+    // prefs,否则「选好来源/改好 effort 还没提交就切了个 tab」会被静默回滚到打开
+    // 弹窗时的旧值(codex review)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false, providerId: 'openai' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('openai'),
+    );
+    fireEvent.click(screen.getByTestId('pick-xd-row-bare'));
+    fireEvent.click(screen.getByTestId('edit-active-effort'));
+    fireEvent.click(screen.getByRole('tab', { name: 'Claude' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').textContent).toContain('claude-opus-4-7'),
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('xd'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'xd', effort: 'low' }),
+      ),
+    );
+  });
+
+  it('falls back to the target row default effort when switching sources without a preset', async () => {
+    // 模型预设槽为空、live effort 来自更早的 workerCreationPrefs(预设 store 之前的
+    // 老数据):此时面板非活跃行显示的是 defaultEffort,切过去必须用它,不能因旧
+    // live 值恰好也被支持而保留 —— 行上显示 high、创建却用 low 是显示与派发不一致
+    // (codex review);与 Fast 的「无预设 = 对齐显示」同规则。(若用户编辑过 effort,
+    // 预设写在 `${agent}:*` 全局槽跨来源共享,remembered 分支已保证与行显示一致。)
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'low', fast: false, providerId: 'openai' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5' }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe('openai'),
+    );
+    fireEvent.click(screen.getByTestId('pick-xd-row-bare'));
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', providerId: 'xd', effort: 'high' }),
+      ),
+    );
+  });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -58,7 +58,15 @@ const mocks = vi.hoisted(() => ({
     name: string;
     connected: boolean;
     agents: string[];
-    models: Record<string, Array<{ id: string; supportsFastMode?: boolean }>>;
+    models: Record<
+      string,
+      Array<{
+        id: string;
+        supportsFastMode?: boolean;
+        efforts?: string[];
+        defaultEffort?: string | null;
+      }>
+    >;
   }>,
   sidebarWindow: false,
 }));
@@ -104,6 +112,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 vi.mock('@/components/new-chat/ModelSelector', () => ({
   ModelSelector: (props: {
     modelId: string;
+    effort?: string;
     currentProviderId?: string | null;
     onProviderChange?: (providerId: string | null, modelId?: string, effort?: string) => void;
     onEffortChange: (effort: string) => void;
@@ -123,6 +132,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
       data-fast-wired={String(props.onFastModeChange !== undefined)}
       data-memory-wired={String(props.modelMemory !== undefined)}
       data-navigate-wired={String(props.onNavigateToProviders !== undefined)}
+      data-effort={props.effort ?? ''}
     >
       {props.modelId}
       <button
@@ -1141,5 +1151,47 @@ describe('CreateWorkerPopover', () => {
     expect(selector.dataset.navigateWired).toBe('false');
     // 供应商分段本身不受影响,只禁跳转。
     expect(selector.dataset.sourcesEnabled).toBe('true');
+  });
+
+  it('reconciles remote effort against the effective device provider before showing it', async () => {
+    // device-link 退化面板的显示收敛与提交共用路由来源档位表:被控端生效默认来源
+    // xd 只有 low 档而拍平条目默认 high 时,面板显示的 effort 必须先收敛到 low,
+    // 不能显示 high、提交时才被静默改写成 low(codex review)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: false },
+      }),
+    );
+    mocks.remoteProviders = [
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: {
+          codex: [{ id: 'gpt-5.5', efforts: ['low'], defaultEffort: 'low' }],
+          'claude-code': [],
+        },
+      },
+    ];
+    mocks.modelsByAgent.codex = [
+      { id: 'gpt-5.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high', supportsFastMode: false },
+    ];
+    mocks.capabilitiesByAgent.codex = { availableModels: [{ id: 'gpt-5.5' }] };
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open deviceId="device-a" onClose={vi.fn()} onCreate={onCreate} />);
+    // 显示先收敛:面板拿到的 effort 已是路由来源支持的档位。
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.effort).toBe('low'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-5.5', effort: 'low' }),
+      ),
+    );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/CreateWorkerPopover.test.tsx
@@ -664,4 +664,43 @@ describe('CreateWorkerPopover', () => {
       ),
     );
   });
+
+  it('keeps remembered Fast when a stale source narrows to a Fast-capable default', async () => {
+    // 记忆来源已失效(不在目录)但模型仍有支持 Fast 的默认来源:Fast 判定必须按
+    // 收窄后的来源口径,不得在收敛 effect 前的渲染窗口里用旧失效来源清掉 fast=true
+    // (codex review)。
+    window.localStorage.setItem(
+      'workerCreationPrefs',
+      JSON.stringify({
+        lastAgent: 'codex',
+        codex: { model: 'gpt-5.5', effort: 'high', fast: true, providerId: 'ghost-provider' },
+      }),
+    );
+    mocks.localProviders = [
+      {
+        id: 'xd',
+        name: 'XD Gateway',
+        connected: true,
+        agents: ['codex'],
+        models: { codex: [{ id: 'gpt-5.5', supportsFastMode: true }], 'claude-code': [] },
+      },
+    ];
+    mocks.modelsByAgent.codex = [model('gpt-5.5')];
+    mocks.capabilitiesByAgent.codex = {
+      availableModels: [{ id: 'gpt-5.5' }],
+      hasFastMode: true,
+    } as never;
+    const onCreate = vi.fn();
+
+    render(<CreateWorkerPopover open onClose={vi.fn()} onCreate={onCreate} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('model-selector').dataset.currentProvider).toBe(''),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'orca.createWorker.submit' }));
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: null, fast: true }),
+      ),
+    );
+  });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
@@ -356,6 +356,7 @@ describe('useOrcaWorkerSelection', () => {
         role: 'tester',
         agent: 'codex',
         model: 'gpt-5.4',
+        providerId: null,
         initialTask: '',
       });
     });
@@ -381,6 +382,7 @@ describe('useOrcaWorkerSelection', () => {
         role: 'tester',
         agent: 'codex',
         model: 'gpt-5.4',
+        providerId: null,
         initialTask: 'run once',
       });
     });

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
@@ -309,6 +309,8 @@ export function useOrcaWorkerSelection({
             model: form.model,
             effort: form.effort,
             fast: form.fast,
+            // null(未显式选来源)不传字段:IPC 侧只认非空 string 为显式来源。
+            providerId: form.providerId ?? undefined,
             label,
             initialTask: form.initialTask || undefined,
           });

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -73,6 +73,8 @@ export interface CollabWorkerConfig {
   model: string;
   effort?: Effort;
   fast?: boolean;
+  /** 显式选定的模型来源;null/缺省 = 未显式(main 侧按默认路由解析)。 */
+  providerId?: string | null;
   /** 首条派工任务。一次性,故意不跨重启持久化(sanitize 加载时丢弃,见下方解析)。 */
   initialTask?: string;
 }
@@ -261,9 +263,11 @@ function sanitize(raw: unknown): NewMakerDraft {
       model,
       effort: typeof wc.effort === 'string' ? (wc.effort as Effort) : undefined,
       fast: typeof wc.fast === 'boolean' ? wc.fast : undefined,
+      // 来源与模型是同一次选择的两个维度,随 model 一起耐久保留;非法类型回落未显式。
+      providerId: typeof wc.providerId === 'string' && wc.providerId ? wc.providerId : undefined,
       // initialTask 是一次性任务,**故意不跨重启持久化**(同 deviceLinkDeviceId 先例):
       // 重启后 Send/New Goal 会静默把过期任务当 delegateTask 发出去,而收起态 pill
-      // 无从看见/编辑(codex P2)。耐久保留的只有 role/model/effort/fast。
+      // 无从看见/编辑(codex P2)。耐久保留的只有 role/model/effort/fast/providerId。
     };
   })();
   const collab: CollabDraft = { enabled: collabEnabled, worker: collabWorker, workerConfig };

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -263,8 +263,13 @@ function sanitize(raw: unknown): NewMakerDraft {
       model,
       effort: typeof wc.effort === 'string' ? (wc.effort as Effort) : undefined,
       fast: typeof wc.fast === 'boolean' ? wc.fast : undefined,
-      // 来源与模型是同一次选择的两个维度,随 model 一起耐久保留;非法类型回落未显式。
-      providerId: typeof wc.providerId === 'string' && wc.providerId ? wc.providerId : undefined,
+      // 来源与模型是同一次选择的两个维度,随 model 一起耐久保留;与 role 同样 trim,
+      // 空白串回落未显式 —— IPC 侧把非空 string 当显式来源,漏 trim 会把无效 id
+      // 一路带到 PROVIDER_ROUTE_UNAVAILABLE(copilot review)。
+      providerId:
+        typeof wc.providerId === 'string' && wc.providerId.trim()
+          ? wc.providerId.trim()
+          : undefined,
       // initialTask 是一次性任务,**故意不跨重启持久化**(同 deviceLinkDeviceId 先例):
       // 重启后 Send/New Goal 会静默把过期任务当 delegateTask 发出去,而收起态 pill
       // 无从看见/编辑(codex P2)。耐久保留的只有 role/model/effort/fast/providerId。

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3691,6 +3691,8 @@ interface ElectronAPI {
         model?: string;
         effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
         fast?: boolean;
+        /** 显式选定的模型来源(标准面板 per-worker 选择);缺省 = 跟随默认路由解析。 */
+        providerId?: string | null;
       },
     ) => Promise<{ teamId: string; workerSessionId: string; workerId: string }>;
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

协同 Worker 创建弹窗(CreateWorkerPopover,含会话内开协同、右侧栏协同 tab、New Maker 草稿「开启协同」共 4 个挂载点)的模型选择器,从「provider 三件套不传」的阉割装配(单栏 flat 列表、来源无处存、Fast 外置开关、手写 agent 分段按钮)升级为与会话输入框完全一致的标准模型选择面板:供应商分段、订阅来源、模型级 effort/Fast 全局记忆全开;agent 分段替换为应用标准 `VendorSegmentedSwitcher`。

选定来源 (providerId) 全链显式下发:弹窗 → `enableOrca` / `maker:worker:create` IPC → `OrcaLifecycleService` → `OrcaWorkerCreationService`。main 侧对显式来源做精确 preflight(已连接且提供该模型,不满足返回 `PROVIDER_ROUTE_UNAVAILABLE`),显式来源不再被「显式 model 强制默认路由」的既有逻辑回落——此前 UI 即使能选来源也传不进来,worker 永远落 spawn 默认路由。未显式选择时,defaults 缓存 / Lead 继承 / `requiresExplicitRoute` 唯一来源救援 / stale 回落等既有解析逐字段保留(测试锁定)。

设计基准(维护者定稿,同 #509/#517):全软件一个模型选择面板,任何入口行为一致。本 PR 是该基准在协同 Worker 入口的落地,与 #517(子代理入口)相互独立、可各自合并。

偏好与草稿:localStorage `workerCreationPrefs` 与 New Maker 草稿 `collab.workerConfig` 均加 providerId 维度;恢复时按「已连接且提供该模型」收窄(与 ImDefaultSettingsSection/#517 同规则),不提交「选 A 落 B」的不可能组合。

功能特殊化说明:device-link 远程创建维持既有退化形态——被控端纯列表、无来源维度、外置 Fast 开关保留(面板行级 Fast 依赖来源分段的 connected 目录,远程不开分段时行级开关不可编辑,删外置会丢 Fast 能力)。远程来源选择需要被控端目录/路由镜像通道,属独立特性。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:模型选择统一新基准(同 #509、#517 的逐入口对齐推进)
- 本 PR 包含:CreateWorkerPopover 标准面板装配 + `OrcaWorkerCreateParams`/`OrcaEnableTeamParams` 加 providerId + 两条 IPC 解析 + 显式来源解析语义 + 偏好/草稿 providerId 维度 + 行为锁测试
- 明确不包含:不动 MCP `cindy_orca` 工具面(`create_worker`/`create_workers` schema 不变,agent 侧继续走 defaults 解析);不动 device-link 远程来源选择;不动 worker 运行中的模型语义(model 不可中途换的不变量不受影响)
- 用户可见变化:创建 Worker 弹窗的模型下拉变为供应商分段全功能面板(含订阅来源与行级 effort/Fast);agent 分段控件视觉与 New Maker 一致;本地创建的外置 Fast 开关移入面板
- 是否存在 breaking change:无(IPC payload 加 additive 可选字段,老端忽略;localStorage/draft 旧数据缺字段回落未显式,行为与现状一致)

### UI 变化

- 引用的设计规范:docs/design-rules/cindy-design-system.md 组件复用原则——三控件(agent 分段/模型/Fast)均复用应用标准选择器(`VendorSegmentedSwitcher` / `ModelSelector`),不自建选择 UI,本 PR 零新增样式;DESIGN.md §Select & Dropdown(弹层为既有 ModelSelector 组件自身实现)

远程/手机三问(remote-and-mobile-adaptation):device-link 远程创建路径已显式处理——`maker:worker:create` 为既有白名单 channel,payload 新增 additive 可选字段 `providerId`,老被控端忽略之(行为与现状一致);远程创建 UI 维持既有退化并保留外置 Fast 开关(理由见上),控制端不会向被控端下发来源。SSH 远程与 mobile 无本弹窗入口,不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit                        → 全部通过(EXIT=0)
pnpm --filter desktop typecheck       → 通过
新增行为锁:
- CreateWorkerPopover 4 例(本地必须开供应商分段+Fast/记忆接线/远程维持退化/
  分段行选择提交 providerId/恢复失效来源收窄为 null),既有 9 例全部保留通过
- orcaWorkerCreationService 3 例(显式来源覆盖强制默认路由/显式来源不提供该模型报
  PROVIDER_ROUTE_UNAVAILABLE 且无副作用/budget 模型显式非网关路由不误报需要 API key),
  既有 41 例(defaults/stale/救援语义)全部保留通过
- newMakerDraft 28 例通过(workerConfig providerId 解析为 additive)
```

### 手工验证

未执行(见下)。

### 未执行的验证

dev 实例实机走查(Light/Dark、真实创建 worker 走订阅来源)未执行:本次为 worktree 会话,无法重启宿主 dev 实例。面板/分段控件均为既有组件零样式改动,装配与 composer/#509 同构;建议维护者在 dev 实例:会话内开协同 → 创建 Worker 弹窗选订阅来源模型 → 确认 worker session 的 providerId 落库与路由。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:desktop 协同 Worker 创建弹窗 UI 与创建链路的来源解析;显式来源仅在新 UI 主动传入时生效,MCP/旧调用方路径逐字段不变(测试锁定)
- 回滚 / 降级方式:revert 本 PR 即可;localStorage/draft 多出的 providerId 字段被旧版本解析忽略,无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
