### PR TITLE
fix(models): correct gateway effort and fast capabilities

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -4,7 +4,7 @@
  *   - 空列表 = 不展示任何 XD 模型;清除后不回退任何静态数据;
  *   - 元数据只信服务端下发 + 确定性默认值(不再回落产品目录条目):
  *       efforts 缺失 → 合成 3 档(low/medium/high,默认 high);显式 [] → 不可调;
- *       supportsFastMode 缺失 → true;defaultEnabled 缺失 → 默认可见;
+ *       supportsFastMode 缺失 → false;defaultEnabled 缺失 → 默认可见;
  *   - perAgent 覆盖块按 tab 应用(gpt 系 cc/codex 的 Fast / 窗口分叉);
  *   - tab 归属:服务端 agents > 仅 claude-code;
  *   - 其它供应商永不受影响。
@@ -45,7 +45,7 @@ describe('XD 网关权威模型清单重建', () => {
     expect(xdModels('codex')).toEqual([]);
   });
 
-  it('未登记模型的确定性默认:3 档 effort + fast=true + 仅 cc tab + 200k 窗口', () => {
+  it('未登记模型的确定性默认:3 档 effort + fast=false + 仅 cc tab + 200k 窗口', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([{ id: 'brand-new-model' }]);
 
@@ -56,7 +56,7 @@ describe('XD 网关权威模型清单重建', () => {
       contextWindow: 200_000,
       efforts: ['low', 'medium', 'high'],
       defaultEffort: 'high',
-      supportsFastMode: true,
+      supportsFastMode: false,
     });
     expect(xdModels('codex')).toEqual([]);
   });

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -663,7 +663,7 @@ describe('codex proxy host', () => {
   });
 
   it.each([
-    'moonshot/kimi-k3',
+    'moonshotai/kimi-k3',
     'deepseek/deepseek-v4-pro',
     'deepseek/deepseek-v4-flash',
   ])('normalizes strict gateway history for model %s', async (model) => {
@@ -738,7 +738,7 @@ describe('codex proxy host', () => {
 
     const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
     let current: unknown = {
-      model: 'moonshot/kimi-k3',
+      model: 'moonshotai/kimi-k3',
       parallel_tool_calls: true,
       input: [
         { type: 'function_call', name: 'exec_command', call_id: 'call_1', arguments: '{"cmd":"pwd"}' },
@@ -760,7 +760,7 @@ describe('codex proxy host', () => {
     }
 
     expect(current).toEqual({
-      model: 'moonshot/kimi-k3',
+      model: 'moonshotai/kimi-k3',
       parallel_tool_calls: true,
       input: [
         { type: 'function_call', name: 'exec_command', call_id: 'call_1', arguments: '{"cmd":"pwd"}' },

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -78,7 +78,7 @@ export interface XdGatewayModelInfo {
   efforts?: string[];
   defaultEffort?: string | null;
   sortOrder?: number;
-  /** Fast 支持;缺省按 true(未登记模型的确定性默认:开了没效果无害)。 */
+  /** Fast 支持;缺省按 false(上游未声明时不猜测能力)。 */
   supportsFastMode?: boolean;
   /** 默认可见性;缺省按 true。 */
   defaultEnabled?: boolean;
@@ -490,7 +490,7 @@ function computeMerged(): Catalog {
   //   - perAgent 覆盖块按 tab 应用在基线字段之上;
   //   - efforts 字段缺失 = 未登记 → 合成 3 档(low/medium/high,默认 high);
   //     显式 [] = 登记为不可调 → 尊重为空;
-  //   - supportsFastMode 缺失 → true(开了没效果无害,但不能没有);
+  //   - supportsFastMode 缺失 → false(上游未声明就不能声称支持);
   //   - defaultEnabled 缺失 → 默认可见。
   // 放在所有 augment 之后:只影响 xd 供应商自己的模型列表,同 id 模型经其它供应商
   // (如 anthropic 订阅直连)仍照常可用。
@@ -532,7 +532,7 @@ function computeMerged(): Catalog {
           contextWindow: ov.contextWindow ?? gm.contextWindow ?? 200_000,
           efforts,
           defaultEffort,
-          supportsFastMode: ov.supportsFastMode ?? gm.supportsFastMode ?? true,
+          supportsFastMode: ov.supportsFastMode ?? gm.supportsFastMode ?? false,
           ...(gm.description !== undefined ? { description: gm.description } : {}),
           ...(gm.sortOrder !== undefined ? { sortOrder: gm.sortOrder } : {}),
           ...(defaultEnabled !== undefined ? { defaultEnabled } : {}),

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -642,7 +642,7 @@ function sanitizeByteDanceSeedTools(body: Record<string, unknown>): Record<strin
 }
 
 const STRICT_GATEWAY_TOOL_HISTORY_MODELS = new Set([
-  'moonshot/kimi-k3',
+  'moonshotai/kimi-k3',
   'deepseek/deepseek-v4-pro',
   'deepseek/deepseek-v4-flash',
 ]);

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -129,41 +129,43 @@ vi.mock('@/lib/scrollbarAutoHide', () => ({
   flashScrollbar: vi.fn(),
 }));
 
+const agentCapabilitiesRef = vi.hoisted(() => {
+  const DEFAULT_CAPABILITIES = {
+    availableModels: [
+      {
+        id: 'claude-opus-4-8',
+        displayName: 'Opus 4.8',
+        description: 'Most capable for ambitious work',
+        contextWindow: 200000,
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+        defaultEffort: 'high',
+        effortDisplayNames: {
+          xhigh: 'X-High',
+        },
+      },
+      {
+        id: 'claude-sonnet-4-6',
+        displayName: 'Sonnet 4.6',
+        contextWindow: 200000,
+        efforts: ['low', 'medium', 'high'],
+        defaultEffort: 'medium',
+      },
+      {
+        id: 'claude-haiku-4-5',
+        displayName: 'Haiku 4.5',
+        description: 'Fastest for quick answers',
+        contextWindow: 200000,
+        efforts: [],
+        defaultEffort: null,
+      },
+    ],
+    effortLevels: [{ id: 'xhigh', displayName: 'X-High' }],
+    hasFastMode: false,
+  };
+  return { DEFAULT_CAPABILITIES, capabilities: DEFAULT_CAPABILITIES as unknown };
+});
 vi.mock('@/hooks/useAgentCapabilities', () => ({
-  useAgentCapabilities: () => ({
-    capabilities: {
-      availableModels: [
-        {
-          id: 'claude-opus-4-8',
-          displayName: 'Opus 4.8',
-          description: 'Most capable for ambitious work',
-          contextWindow: 200000,
-          efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
-          defaultEffort: 'high',
-          effortDisplayNames: {
-            xhigh: 'X-High',
-          },
-        },
-        {
-          id: 'claude-sonnet-4-6',
-          displayName: 'Sonnet 4.6',
-          contextWindow: 200000,
-          efforts: ['low', 'medium', 'high'],
-          defaultEffort: 'medium',
-        },
-        {
-          id: 'claude-haiku-4-5',
-          displayName: 'Haiku 4.5',
-          description: 'Fastest for quick answers',
-          contextWindow: 200000,
-          efforts: [],
-          defaultEffort: null,
-        },
-      ],
-      effortLevels: [{ id: 'xhigh', displayName: 'X-High' }],
-      hasFastMode: false,
-    },
-  }),
+  useAgentCapabilities: () => ({ capabilities: agentCapabilitiesRef.capabilities }),
 }));
 
 vi.mock('@/hooks/useApiKey', () => ({
@@ -258,6 +260,20 @@ vi.mock('@/hooks/useDeviceProviders', () => ({
   useDeviceProviders: () => ({ providers: deviceProvidersRef.providers, loading: false }),
 }));
 
+interface VisibleModelFixture {
+  id: string;
+  displayName: string;
+  description?: string;
+  contextWindow: number;
+  efforts: string[];
+  defaultEffort: string | null;
+  effortDisplayNames?: Record<string, string>;
+  supportsFastMode?: boolean;
+}
+
+const visibleModelsRef = vi.hoisted(() => ({
+  models: null as VisibleModelFixture[] | null,
+}));
 vi.mock('@/lib/providerModels', () => ({
   providerMonogram: (name: string) => name.slice(0, 1).toUpperCase(),
   // #245 新增:ModelSelector 渲染路径直接调用;fixture providers 无 routing,按不过滤透传。
@@ -265,8 +281,9 @@ vi.mock('@/lib/providerModels', () => ({
   filterChatBridgedCodexProviders: (providers: unknown[]) => providers,
   resolveVisibleModelAgentKind: ({ agentKind }: { agentKind: 'claude-code' | 'codex' | null }) =>
     agentKind ?? 'claude-code',
-  selectVisibleModels: ({ agentKind }: { agentKind: 'claude-code' | 'codex' | null }) =>
-    [
+  selectVisibleModels: ({ agentKind }: { agentKind: 'claude-code' | 'codex' | null }) => {
+    if (visibleModelsRef.models) return visibleModelsRef.models;
+    return [
       {
         id: 'claude-opus-4-8',
         displayName: 'Opus 4.8',
@@ -304,7 +321,8 @@ vi.mock('@/lib/providerModels', () => ({
       if (agentKind === 'claude-code') return model.id.startsWith('claude-');
       if (agentKind === 'codex') return model.id.startsWith('gpt-');
       return true;
-    }),
+    });
+  },
 }));
 
 const modelVisibilityRef = vi.hoisted(
@@ -647,6 +665,164 @@ describe('ModelSelector trigger variants', () => {
       'Max',
     );
   });
+
+  it.each([
+    {
+      agentKind: 'claude-code' as const,
+      vendorKey: 'cc' as const,
+      currentModel: {
+        id: 'claude-opus-4-8',
+        displayName: 'Opus 4.8',
+        contextWindow: 200000,
+        efforts: ['high'],
+        defaultEffort: 'high',
+        supportsFastMode: false,
+      },
+      seedEfforts: ['low', 'medium', 'high'],
+      seedDefaultEffort: 'low',
+      seedLabel: 'Low',
+      glmEfforts: ['high', 'max'],
+    },
+    {
+      agentKind: 'codex' as const,
+      vendorKey: 'codex' as const,
+      currentModel: {
+        id: 'gpt-5.5',
+        displayName: 'GPT-5.5',
+        contextWindow: 400000,
+        efforts: ['high'],
+        defaultEffort: 'high',
+        supportsFastMode: false,
+      },
+      seedEfforts: ['minimal', 'low', 'medium', 'high'],
+      seedDefaultEffort: 'minimal',
+      seedLabel: 'Minimal',
+      glmEfforts: ['minimal', 'high', 'max'],
+    },
+  ])(
+    'renders the corrected XD effort defaults without Fast markers for $agentKind',
+    ({ agentKind, vendorKey, currentModel, seedEfforts, seedDefaultEffort, seedLabel, glmEfforts }) => {
+      const targetModels: VisibleModelFixture[] = [
+        {
+          id: 'bytedance-seed/seed-2.1-pro',
+          displayName: 'Seed 2.1 Pro',
+          contextWindow: 256000,
+          efforts: seedEfforts,
+          defaultEffort: seedDefaultEffort,
+          supportsFastMode: false,
+        },
+        {
+          id: 'moonshotai/kimi-k3',
+          displayName: 'Kimi K3',
+          contextWindow: 1000000,
+          efforts: ['low', 'high', 'max'],
+          defaultEffort: 'max',
+          supportsFastMode: false,
+        },
+        {
+          id: 'qwen/qwen3.8-max-preview',
+          displayName: 'Qwen 3.8 Max Preview',
+          contextWindow: 983616,
+          efforts: ['low', 'high', 'xhigh'],
+          defaultEffort: 'xhigh',
+          supportsFastMode: false,
+        },
+        {
+          id: 'z-ai/glm-5.2',
+          displayName: 'GLM-5.2',
+          contextWindow: 1000000,
+          efforts: glmEfforts,
+          defaultEffort: 'max',
+          supportsFastMode: false,
+        },
+        {
+          id: 'deepseek/deepseek-v4-pro',
+          displayName: 'DeepSeek V4 Pro',
+          contextWindow: 1048576,
+          efforts: ['high', 'max'],
+          defaultEffort: 'high',
+          supportsFastMode: false,
+        },
+        {
+          id: 'deepseek/deepseek-v4-flash',
+          displayName: 'DeepSeek V4 Flash',
+          contextWindow: 1048576,
+          efforts: ['high', 'max'],
+          defaultEffort: 'high',
+          supportsFastMode: false,
+        },
+      ];
+      const originalCapabilities = agentCapabilitiesRef.capabilities;
+      visibleModelsRef.models = [currentModel, ...targetModels];
+      agentCapabilitiesRef.capabilities = {
+        availableModels: visibleModelsRef.models,
+        effortLevels: [
+          { id: 'minimal', displayName: 'Minimal' },
+          { id: 'low', displayName: 'Low' },
+          { id: 'medium', displayName: 'Medium' },
+          { id: 'high', displayName: 'High' },
+          { id: 'xhigh', displayName: 'X-High' },
+          { id: 'max', displayName: 'Max' },
+        ],
+        hasFastMode: true,
+      };
+      providersRef.providers = [
+        {
+          id: 'xd',
+          name: 'Cindy',
+          connected: true,
+          agents: [agentKind],
+          routing: { [agentKind]: {} },
+          models: {
+            [agentKind]: visibleModelsRef.models.map((model) => ({
+              ...model,
+              name: model.displayName,
+            })),
+          },
+        },
+      ];
+      const modelMemory = {
+        getEffort: vi.fn(),
+        setEffort: vi.fn(),
+        // Even a stale persisted Fast=true must not render when the model capability is false.
+        getFast: vi.fn(() => true),
+        setFast: vi.fn(),
+      };
+
+      try {
+        render(
+          React.createElement(ModelSelectorContent, {
+            modelId: currentModel.id,
+            effort: 'high',
+            fastMode: false,
+            onModelChange: vi.fn(),
+            onEffortChange: vi.fn(),
+            onFastModeChange: vi.fn(),
+            vendorKey,
+            currentProviderId: 'xd',
+            onProviderChange: vi.fn(),
+            modelMemory,
+          }),
+        );
+
+        expect(screen.getByRole('option', { name: /Seed 2\.1 Pro/ }).textContent).toContain(
+          seedLabel,
+        );
+        expect(screen.getByRole('option', { name: /Kimi K3/ }).textContent).toContain('Max');
+        expect(screen.getByRole('option', { name: /Qwen 3\.8 Max Preview/ }).textContent).toContain(
+          '超高',
+        );
+        expect(screen.getByRole('option', { name: /GLM-5\.2/ }).textContent).toContain('Max');
+        expect(screen.getByRole('option', { name: /DeepSeek V4 Pro/ }).textContent).toContain('High');
+        expect(screen.getByRole('option', { name: /DeepSeek V4 Flash/ }).textContent).toContain('High');
+        expect(screen.queryByLabelText('newChat.modelSelector.meta.fastBadge')).toBeNull();
+      } finally {
+        visibleModelsRef.models = null;
+        agentCapabilitiesRef.capabilities = originalCapabilities;
+        providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+      }
+    },
+  );
 
   it('renders an active fallback option without model effort metadata', () => {
     render(

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2097,6 +2097,7 @@
       "prefs": {
         "agentLabel": "Agent",
         "modelLabel": "モデル",
+        "effortLabel": "推論強度",
         "permissionLabel": "権限モード",
         "providerSlack": "Slack",
         "providerTelegram": "Telegram",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2097,6 +2097,7 @@
       "prefs": {
         "agentLabel": "Agent",
         "modelLabel": "모델",
+        "effortLabel": "추론 강도",
         "permissionLabel": "권한 모드",
         "providerSlack": "Slack",
         "providerTelegram": "Telegram",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2097,6 +2097,7 @@
       "prefs": {
         "agentLabel": "Agent",
         "modelLabel": "模型",
+        "effortLabel": "推理强度",
         "permissionLabel": "权限模式",
         "providerSlack": "Slack",
         "providerTelegram": "Telegram",

--- a/apps/desktop/src/shared/modelAccess.ts
+++ b/apps/desktop/src/shared/modelAccess.ts
@@ -171,7 +171,7 @@ export interface ModelAccessGatewayModel extends ModelGroupPricing {
   efforts?: string[];
   defaultEffort?: string | null;
   sortOrder?: number;
-  /** Fast(加速档)支持;缺省按 true 处理(开了没效果无害,但不能没有)。 */
+  /** Fast(加速档)支持;缺省按 false 处理(上游未声明时不猜测能力)。 */
   supportsFastMode?: boolean;
   /** 是否默认出现在模型选择器;缺省按 true(默认可见)。 */
   defaultEnabled?: boolean;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -1470,6 +1470,30 @@ describe('CodexAgent send', () => {
     await handle.close();
   });
 
+  it.each(['bytedance-seed/seed-2.1-pro', 'z-ai/glm-5.2'])(
+    'passes minimal effort through to turn/start for %s',
+    async (model) => {
+      const agent = new CodexAgent(createDeps());
+      const host = installFakeHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-minimal-effort-supported-model',
+        model,
+        effort: 'minimal',
+        workingDir: '/repo',
+      });
+
+      await handle.send({ type: 'user', content: 'hello' });
+
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnStart,
+        expect.objectContaining({
+          effort: 'minimal',
+        }),
+      );
+      await handle.close();
+    },
+  );
+
   it('keeps medium effort before turn/start', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);
@@ -1555,6 +1579,36 @@ describe('CodexAgent send', () => {
     );
     await handle.close();
   });
+
+  it.each(['bytedance-seed/seed-2.1-pro', 'z-ai/glm-5.2'])(
+    'passes minimal effort through runtime settings and turn/start for %s',
+    async (model) => {
+      const agent = new CodexAgent(createDeps());
+      const host = installFakeHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-set-minimal-effort-supported-model',
+        model,
+        effort: 'medium',
+        workingDir: '/repo',
+      });
+
+      if (!handle.setEffort) throw new Error('Codex handle should support setEffort');
+      await handle.setEffort('minimal');
+      await handle.send({ type: 'user', content: 'hello' });
+
+      expect(host.request).toHaveBeenCalledWith(Method.ThreadSettingsUpdate, {
+        threadId: 'start-thread-id',
+        effort: 'minimal',
+      });
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnStart,
+        expect.objectContaining({
+          effort: 'minimal',
+        }),
+      );
+      await handle.close();
+    },
+  );
 
   it('rejects turn/start failures when the caller needs accepted-or-rejected semantics', async () => {
     const agent = new CodexAgent(createDeps());

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -147,7 +147,12 @@ import {
   type UserInput,
 } from './app-server/protocol.js';
 
-type CodexEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+type CodexEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+
+const CODEX_MINIMAL_EFFORT_MODELS = new Set([
+  'bytedance-seed/seed-2.1-pro',
+  'z-ai/glm-5.2',
+]);
 
 /**
  * item.type → chip status 文案 (对齐 claude-code 6 类). null = 该 item 不触发 chip 切换
@@ -178,14 +183,14 @@ function statusTextForItem(item: { type?: string; command?: string; tool?: strin
 }
 
 /**
- * maker Effort → Codex GPT 可透传档。
+ * maker Effort → Codex app-server 可透传档。
  *
- * 只把 'minimal' 收敛到 'low'(Codex 无 minimal 档); max / ultra 直接透传,
- * 不再静默降级为 xhigh(issue #352)。某模型是否真支持 max/ultra 由目录 efforts
- * 与 UI/reconcile 门控保证——只有声明支持的模型才会走到这里传 max/ultra。
+ * Seed 2.1 Pro 与 GLM-5.2 的官方档位包含 minimal，原样下发；其他模型继续
+ * 把 minimal 收敛到 low。max / ultra 直接透传，不再静默降级为 xhigh(issue #352)。
+ * 某模型是否真支持某档位由目录 efforts 与 UI/reconcile 门控保证。
  */
-function clampEffortForCodex(e: Effort): CodexEffort {
-  if (e === 'minimal') return 'low';
+function clampEffortForCodex(model: string, e: Effort): CodexEffort {
+  if (e === 'minimal' && !CODEX_MINIMAL_EFFORT_MODELS.has(model)) return 'low';
   return e;
 }
 
@@ -2256,7 +2261,7 @@ export class CodexAgent extends BaseAgent {
           mode: 'plan',
           settings: {
             model: mutableModel,
-            reasoning_effort: clampEffortForCodex(mutableEffort),
+            reasoning_effort: clampEffortForCodex(mutableModel, mutableEffort),
             developer_instructions: null,
           },
         };
@@ -2267,7 +2272,7 @@ export class CodexAgent extends BaseAgent {
           mode: 'default',
           settings: {
             model: mutableModel,
-            reasoning_effort: clampEffortForCodex(mutableEffort),
+            reasoning_effort: clampEffortForCodex(mutableModel, mutableEffort),
             developer_instructions: developerInstructions,
           },
         };
@@ -4053,7 +4058,7 @@ export class CodexAgent extends BaseAgent {
           threadId,
           input: turnInput,
           ...turnWorkspaceConfig,
-          effort: clampEffortForCodex(mutableEffort),
+          effort: clampEffortForCodex(mutableModel, mutableEffort),
           // 强制 reasoning summary='auto' — 不依赖用户 ~/.codex/config.toml 写没写
           // model_reasoning_summary, 让 thinking 文本在所有用户机器上一致流式出。
           // (v2.rs:5801-5803 turn/start 的 summary 会 override server config)
@@ -4391,7 +4396,7 @@ export class CodexAgent extends BaseAgent {
 
       async setEffort(newEffort: Effort) {
         if (newEffort === mutableEffort) return; // 去重: 值没变不重推
-        const clamped = clampEffortForCodex(newEffort);
+        const clamped = clampEffortForCodex(mutableModel, newEffort);
         log.debug('setEffort', { from: mutableEffort, to: newEffort, clamped });
         mutableEffort = newEffort;
         // thread 已启动 → 立即经 thread/settings/update 生效; 未启动由首个 turn/start

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -1085,12 +1085,23 @@
         "group": "china",
         "contextWindow": 256000,
         "efforts": [
+          "minimal",
           "low",
           "medium",
           "high"
         ],
-        "defaultEffort": "high",
-        "supportsFastMode": true
+        "defaultEffort": "minimal",
+        "supportsFastMode": false,
+        "perAgent": {
+          "claude-code": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "defaultEffort": "low"
+          }
+        }
       },
       "qwen/qwen3.8-max-preview": {
         "agents": [
@@ -1102,11 +1113,11 @@
         "contextWindow": 983616,
         "efforts": [
           "low",
-          "medium",
-          "high"
+          "high",
+          "xhigh"
         ],
-        "defaultEffort": "high",
-        "supportsFastMode": true
+        "defaultEffort": "xhigh",
+        "supportsFastMode": false
       },
       "qwen/qwen3.7-max": {
         "agents": [
@@ -1157,12 +1168,22 @@
         "description": "Zhipu GLM-5.2 agentic coding model; 1M context",
         "contextWindow": 1000000,
         "efforts": [
+          "minimal",
           "high",
           "max"
         ],
-        "defaultEffort": "high",
+        "defaultEffort": "max",
         "sortOrder": 43,
-        "supportsFastMode": false
+        "supportsFastMode": false,
+        "perAgent": {
+          "claude-code": {
+            "efforts": [
+              "high",
+              "max"
+            ],
+            "defaultEffort": "max"
+          }
+        }
       },
       "deepseek/deepseek-v4-pro": {
         "agents": [
@@ -1227,16 +1248,22 @@
         "sortOrder": 103,
         "defaultEnabled": false
       },
-      "moonshot/kimi-k3": {
+      "moonshotai/kimi-k3": {
         "agents": [
           "claude-code",
           "codex"
         ],
         "name": "Kimi K3",
         "group": "china",
-        "description": "Moonshot Kimi K3 agentic coding model; 1M context; thinking is provider-managed",
         "contextWindow": 1000000,
-        "sortOrder": 41
+        "efforts": [
+          "low",
+          "high",
+          "max"
+        ],
+        "defaultEffort": "max",
+        "sortOrder": 41,
+        "supportsFastMode": false
       },
       "qwen/qwen3.6-plus": {
         "agents": [

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -155,7 +155,7 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     expect(metadata.version).toBe(1);
     const expected = {
       'qwen/qwen3.7-max': 'Qwen 3.7 Max',
-      'moonshot/kimi-k3': 'Kimi K3',
+      'moonshotai/kimi-k3': 'Kimi K3',
       'z-ai/glm-5.2': 'GLM-5.2',
       'deepseek/deepseek-v4-pro': 'DeepSeek V4 Pro',
       'deepseek/deepseek-v4-flash': 'DeepSeek V4 Flash',
@@ -167,6 +167,53 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
         agents: ['claude-code', 'codex'],
         name,
       });
+    }
+
+    expect(metadata.models?.['bytedance-seed/seed-2.1-pro']).toMatchObject({
+      efforts: ['minimal', 'low', 'medium', 'high'],
+      defaultEffort: 'minimal',
+      supportsFastMode: false,
+      perAgent: {
+        'claude-code': {
+          efforts: ['low', 'medium', 'high'],
+          defaultEffort: 'low',
+        },
+      },
+    });
+    expect(metadata.models?.['moonshotai/kimi-k3']).toMatchObject({
+      efforts: ['low', 'high', 'max'],
+      defaultEffort: 'max',
+      supportsFastMode: false,
+    });
+    expect(metadata.models?.['qwen/qwen3.8-max-preview']).toMatchObject({
+      efforts: ['low', 'high', 'xhigh'],
+      defaultEffort: 'xhigh',
+      supportsFastMode: false,
+    });
+    expect(metadata.models?.['z-ai/glm-5.2']).toMatchObject({
+      efforts: ['minimal', 'high', 'max'],
+      defaultEffort: 'max',
+      supportsFastMode: false,
+      perAgent: {
+        'claude-code': {
+          efforts: ['high', 'max'],
+          defaultEffort: 'max',
+        },
+      },
+    });
+    for (const id of ['deepseek/deepseek-v4-pro', 'deepseek/deepseek-v4-flash']) {
+      expect(metadata.models?.[id], id).toMatchObject({
+        efforts: ['high', 'max'],
+        defaultEffort: 'high',
+        supportsFastMode: false,
+      });
+    }
+    for (const id of [
+      'bytedance-seed/seed-2.1-pro',
+      'moonshotai/kimi-k3',
+      'qwen/qwen3.8-max-preview',
+    ]) {
+      expect(metadata.models?.[id], id).not.toHaveProperty('description');
     }
   });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 XD Gateway 中 Seed 2.1 Pro、Kimi K3、Qwen 3.8 Max Preview 和 GLM-5.2 的 reasoning effort / 默认值，并核对 DeepSeek V4 Pro、DeepSeek V4 Flash 的现有配置。六款模型都没有 Cindy Fast acknowledgement，因此不展示 Fast 标记。

同时修正 Kimi K3 的网关 ID、严格工具历史匹配规则，以及未知 XD 模型对 Fast 能力的默认处理。Codex 现在只为官方支持 minimal 的 Seed 2.1 Pro 与 GLM-5.2 原样下发该档位，GPT 等其它模型仍保持 minimal -> low。新增目录、Claude/Codex ModelSelector 和请求 payload 回归测试。此外，最新 main 删除了已有 Reasoning effort 标签的中/日/韩 key，导致 GitHub merge ref 的 i18n 门禁失败；本 PR 以独立逻辑提交补回这 3 个翻译。本地诊断脚本及结果位于 ignored hack/*，不纳入本 PR。

### 变更类型

- [x] fix 缺陷修复
- [ ] feat 新功能
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：模型选择器错误展示 Seed Fast、错误 effort 默认值，以及 Kimi 原始模型 ID；补充核对 GLM-5.2 与 DeepSeek V4 系列。
- 本 PR 包含：六款模型的 capability metadata 审计、XD 未声明 Fast 时的 fail-closed 默认、Kimi ID 对齐、Codex model-aware effort 映射和回归测试。
- 明确不包含：服务端模型目录改动；主动重写既有会话的 model ID、effort 或 fastMode；订阅鉴权、计费、路由或模型可用性逻辑。
- 用户可见变化：Seed、Kimi、Qwen 不再显示 Fast 标记；GLM-5.2 默认显示 Max，并在 Codex 中提供 Minimal；其它表中列出的默认档位按官方资料对齐。
- 是否存在 breaking change：无。

### 模型功能与面板结果

| 模型 | Gateway ID | 官方有效推理档位 | Claude Code（默认） | Codex（默认） | Catalog context | Cindy Fast |
|---|---|---|---|---|---:|---|
| Seed 2.1 Pro | bytedance-seed/seed-2.1-pro | minimal / low / medium / high | low / medium / high（low） | minimal / low / medium / high（minimal） | 256,000 | 不支持 |
| Kimi K3 | moonshotai/kimi-k3 | low / high / max，始终推理 | low / high / max（max） | low / high / max（max） | 1,000,000 | 不支持 |
| Qwen 3.8 Max Preview | qwen/qwen3.8-max-preview | low / high / xhigh | low / high / xhigh（xhigh） | low / high / xhigh（xhigh） | 983,616 | 不支持 |
| GLM-5.2 | z-ai/glm-5.2 | minimal / high / max（去除等价 alias） | high / max（max） | minimal / high / max（max） | 1,000,000 | 不支持 |
| DeepSeek V4 Pro | deepseek/deepseek-v4-pro | high / max | high / max（high） | high / max（high） | 1,048,576 | 不支持 |
| DeepSeek V4 Flash | deepseek/deepseek-v4-flash | high / max | high / max（high） | high / max（high） | 1,048,576 | 不支持 |

Seed 与 GLM 的 Claude Code override 不暴露 minimal，因为当前 Claude Code CLI 的 effort 枚举不接受该值。GLM 官方将 low / medium 映射为 high、xhigh 映射为 max，所以 Cindy 只展示三个有区别的有效档位；Cindy 的 Effort 类型没有 none，以 minimal 表示关闭思考。DeepSeek 对兼容 alias 的静默接受不作为能力证据。

### 官方参考资料

| 模型 | 官方资料 | 本 PR 使用的事实 |
|---|---|---|
| Seed 2.1 Pro | [火山引擎文档](https://www.volcengine.com/docs/6492/2275546) | reasoning_effort 支持 minimal / low / medium / high，默认 minimal |
| Kimi K3 | [Kimi API: Reasoning Effort](https://platform.kimi.ai/docs/guide/use-reasoning-effort) | K3 始终推理，支持 low / high / max，默认 max |
| Qwen 3.8 Max Preview | [阿里云 Model Studio: Qwen Code](https://help.aliyun.com/zh/model-studio/qwen-code) | 支持 low / high / xhigh，默认 xhigh |
| GLM-5.2 | [GLM-5.2 指南](https://docs.z.ai/guides/llm/glm-5.2)、[Thinking 能力](https://docs.z.ai/guides/capabilities/thinking) | 默认/推荐 max；none / minimal 关闭思考；low / medium -> high，xhigh -> max |
| DeepSeek V4 Pro / Flash | [Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode)、[Chat Completion API](https://api-docs.deepseek.com/api/create-chat-completion) | 正式档位为 high / max，常规默认 high；兼容映射 low / medium -> high、xhigh -> max |

以上资料没有声明 Cindy 当前两套请求协议所需的 Fast acknowledgement；Fast 结论来自下面的 live gateway matrix，不把实验结果冒充为厂商声明。

### Live gateway 组合矩阵

测试维度为六款模型 × Fast 开/关 × effort {omitted, minimal, low, medium, high, xhigh, max, ultra}，分别通过 OpenAI Responses 和 Anthropic Messages 协议运行，共 192 个唯一组合。

| 协议 | 组合数 | Fast 请求形态 | Fast acknowledgement | 结果 |
|---|---:|---|---:|---|
| OpenAI Responses | 96 | service_tier: priority | 0 | Seed 的 Fast 请求返回 service_tier: default；其它五款未返回有效 Fast tier |
| Anthropic Messages | 96 | speed: fast + anthropic-beta: fast-mode-2026-02-01 | 0 | 所有 Fast 响应都没有返回 usage.speed: fast |

| 模型 | effort 实测行为 | 目录策略 |
|---|---|---|
| Seed 2.1 Pro | 明确拒绝 xhigh / max / ultra | 只展示官方集合 |
| Kimi K3 | 网关静默接受部分非官方值；Messages 拒绝 ultra | 只展示官方集合 |
| Qwen 3.8 Max Preview | 网关静默接受部分非官方值；Messages 拒绝 ultra | 只展示官方集合 |
| GLM-5.2 | Responses 接受全部值；Messages 明确拒绝 ultra 并返回官方枚举 | 只展示三个有区别的有效档位 |
| DeepSeek V4 Pro | 两协议静默接受额外值 | 只展示官方 high / max |
| DeepSeek V4 Flash | 两协议静默接受额外值 | 只展示官方 high / max |

四次完整运行均为 combinations=48 unique=48 expected=48 unresolved=0，合计 192 个唯一组合。本地诊断过程只在隔离 Electron profile 中解密现有 owner-scoped gateway credential，没有把脚本、凭证或响应结果提交到仓库。

### 订阅与 provider 影响

| 来源 / 套餐 | 是否改变 | 原因 |
|---|---|---|
| Cindy / XD managed models | 是，仅能力元数据与对应 Codex effort payload | 只影响 /models 已返回的同 ID 模型 |
| ChatGPT / Codex subscription（openai） | 否 | 未改 discovery、鉴权、路由、计费或 GPT effort 规则；GPT minimal -> low 回归测试保留 |
| Claude.ai subscription（anthropic） | 否 | 未改 Anthropic provider、OAuth、模型目录或请求路径 |
| 自定义 Kimi / OpenRouter 等 provider | 否 | 元数据键和 model-aware 白名单只匹配 XD gateway 的完整模型 ID |

STRICT_GATEWAY_TOOL_HISTORY_MODELS 只在 Codex 请求的 model ID 精确匹配 moonshotai/kimi-k3 时归一化工具历史，不修改 provider、套餐、计费或会话 model ID。

### 默认值与用户 override

- GLM-5.2 没有已记忆 effort 时，目录默认从 high 更新为官方推荐的 max。
- 已记忆且仍有效的用户选择继续保留；本 PR 不根据旧值猜测用户意图，也不写 migration。
- Seed、Qwen、Kimi 同样只在没有有效 active/remembered override 时采用修正后的目录默认。
- 现有恢复默认路径会清除 override，并重新跟随当前目录默认。

### UI 变化

| Agent 面板 | Seed | Kimi | Qwen | GLM | DeepSeek Pro / Flash | Fast 标记 |
|---|---|---|---|---|---|---|
| Claude Code | Low | Max | 超高 | Max | High | 六款均隐藏 |
| Codex | Minimal | Max | 超高 | Max | High | 六款均隐藏 |

- 引用的设计规范：docs/design-rules/DESIGN.md §4 Select & Dropdown、§10 Light / Dark Dual-Mode Delivery Gate。
- 不改组件布局、样式、动效或新增产品文案；移除了本 PR 原先新增的未本地化英文 model descriptions，并为最新 main 已有的 Reasoning effort 标签补齐 zh-CN / ja / ko 翻译。
- 现有 dropdown 与主题 token 路径保持不变；Claude/Codex 两个面板由真实 ModelSelector 渲染回归测试覆盖。

## 怎么验证的

### 自动验证

- pnpm test:unit
  - rebase 到最新 main 后，全部适用 workspace PASS（含 Desktop、Mobile、maker-core 和 model-providers）。
- pnpm --filter desktop run --if-present typecheck
- pnpm --filter @cindy/model-providers run --if-present typecheck
- pnpm --filter @cindy/maker-core run --if-present typecheck
  - 全部通过。
- pnpm --filter @cindy/model-providers exec vitest run src/__tests__/catalog.test.ts
  - 28 tests passed。
- pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts
  - 184 tests passed；覆盖 GPT clamp、Seed/GLM turn/start 与 runtime settings payload。
- pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
  - 24 tests passed；覆盖 Claude/Codex 默认 effort 和 stale Fast memory。
- pnpm check:i18n
- pnpm check:i18n-glossary
- Desktop / maker-core 相关生产文件定向 ESLint、JSON parse、git diff --check、pnpm check:dco
  - 全部通过。

### 手工 / live 验证

- macOS Electron 开发版：先前三款模型在 Claude Code 面板的 Light / Dark 下均确认没有 Fast 标记，Kimi/Qwen 显示修正后的默认档位。
- Live XD Gateway：Responses 96 组合、Messages 96 组合，均无 unresolved 结果。
- 新增 GLM/DeepSeek 行不改组件样式；两 Agent 的元数据消费结果由 ModelSelector 测试覆盖。

### 未执行的验证

- 未在现有活跃会话中实际切换到 Codex 面板，以避免触发 Agent 切换事务；Codex UI 与下发 payload 均由回归测试覆盖。
- 未运行 pnpm test:all；本次不涉及数据库、protocol migration、原生层或跨端 wire contract，仓库要求的完整 unit gate 与受影响 package typecheck 已通过。

## 风险

### maker-core 核心指标评估

| 指标 | 影响与验证 |
|---|---|
| Anthropic prompt cache | 无 system prompt、tool、MCP 或请求前缀变化；不经过 Anthropic prompt 组装路径，缓存率不变 |
| 返回速度 / streaming latency | 每次 turn/settings update 仅增加一次常量时间 Set.has，不在每 token/event 热路径，无网络往返；定向与全量单测通过 |
| 返回内容准确性 | 预期改进：Seed/GLM 的 minimal 不再被错误改写；精确 payload 单测同时确认 GPT 仍降级到 low |
| event / usage 计量 | 未改 translator、event loop 或 usage tracker；事件与计量路径不变 |

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：XD 模型在服务端未声明 Fast 能力时现在 fail closed；两个模型新增 model-aware minimal 透传。

### 影响与回滚

- 影响范围：XD Gateway 模型目录、Claude/Codex 模型选择器、Seed/GLM 的 Codex effort payload、Kimi K3 的严格工具历史归一化匹配，以及最新 main 已有 Tina effort 标签的三语 key 一致性。
- 服务端漏发 supportsFastMode 的模型会隐藏 Fast，直到服务端明确声明支持。
- 既有会话中持久化的 model ID、effort 与 fastMode 不会被主动重写；模型行能力和新选择路径按 capability gate 处理。
- 回滚 / 降级方式：revert 本提交即可恢复旧目录元数据、缺省行为和 Codex effort clamp。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌、授权文件或 hack/*
- [x] 已补充必要说明、功能表和官方参考资料
- [x] 已确认测试结果或说明未执行原因
