### PR TITLE
fix(i18n): 补齐 settings.tina.prefs.effortLabel 的 zh-CN/ja/ko 词条(修 main 基线 check-i18n 红)

### DIFF
--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2097,6 +2097,7 @@
       "prefs": {
         "agentLabel": "Agent",
         "modelLabel": "モデル",
+        "effortLabel": "推論強度",
         "permissionLabel": "権限モード",
         "providerSlack": "Slack",
         "providerTelegram": "Telegram",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2097,6 +2097,7 @@
       "prefs": {
         "agentLabel": "Agent",
         "modelLabel": "모델",
+        "effortLabel": "추론 강도",
         "permissionLabel": "권한 모드",
         "providerSlack": "Slack",
         "providerTelegram": "Telegram",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2097,6 +2097,7 @@
       "prefs": {
         "agentLabel": "Agent",
         "modelLabel": "模型",
+        "effortLabel": "推理强度",
         "permissionLabel": "权限模式",
         "providerSlack": "Slack",
         "providerTelegram": "Telegram",


### PR DESCRIPTION
## 这次改了什么

### 摘要

补齐 `settings.tina.prefs.effortLabel` 的 zh-CN / ja / ko 词条。#509 合并时该 key 只加了 en,四语言 `common.json` key 一致性检查(`check-i18n`)在 main 基线上红了,当前所有 open PR 的 verify(merge-ref)都被殃及(实测 #517/#519 的 verify 因此 FAILURE,失败日志明确指向该 key)。

译法与仓内既有 effortLabel 词条一致:推理强度 / 推論強度 / 추론 강도;插入位置与 en 同序(modelLabel 与 permissionLabel 之间)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#509 合并后的 i18n 基线回归
- 本 PR 包含:3 个 locale 文件各 1 行
- 明确不包含:其它 439 处既有软告警(不阻断)不动
- 用户可见变化:IM 工作目录偏好行的推理强度字段标签在中/日/韩语言下显示本地化文案(此前回退英文)
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及(纯 i18n 词条补齐,无样式/交互变化)

远程/手机三问:不涉及(纯 desktop 词条文件,无 IPC/workdir/mobile 面)。

## 怎么验证的

### 自动验证

```text
node scripts/check-i18n.mjs → ✅ zh-CN / en / ja / ko 共 5571 个 key 全部一致
node scripts/check-i18n-glossary.mjs → ✅ 无新增违规
```

### 手工验证

不涉及(词条与既有翻译逐字对齐)。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:3 个 locale 文件各 1 行;解锁所有 open PR 的 verify 基线
- 回滚 / 降级方式:revert 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
