### PR TITLE
fix(analytics): dev 构建不再上报 TapDB,避免凭空造出「新增设备」

### DIFF
--- a/apps/desktop/src/main/__tests__/analyticsSettingsStore.test.ts
+++ b/apps/desktop/src/main/__tests__/analyticsSettingsStore.test.ts
@@ -5,6 +5,7 @@
  *  - 默认必须是「未同意」,即 allowed=false(fail closed)
  *  - 同意后才允许上报,且开关能独立关掉
  *  - 存量迁移只在本机毫无记录时生效,绝不覆盖用户已有选择
+ *  - dev 构建一律不上报(构建闸),且不因此篡改用户的同意与开关
  *
  * 用真实 tmpdir 当 userData(mkdtemp),覆盖到落盘与回读,而不是只测 normalize。
  */
@@ -16,9 +17,17 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let userDataDir = '';
+/** 除「构建闸」那一组之外,所有用例测的都是正式构建下的同意语义。 */
+let isPackaged = true;
 
 vi.mock('electron', () => ({
-  app: { getPath: (name: string) => (name === 'userData' ? userDataDir : userDataDir) },
+  app: {
+    getPath: (name: string) => (name === 'userData' ? userDataDir : userDataDir),
+    // getter:构建 flavor 要能在用例内切换,不能在 mock 工厂调用那一刻定死。
+    get isPackaged() {
+      return isPackaged;
+    },
+  },
 }));
 vi.mock('../maker-host/logger-adapter.js', () => ({
   desktopMakerLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
@@ -33,12 +42,18 @@ function settingsFile(): string {
   return path.join(userDataDir, 'analytics-settings.json');
 }
 
+const originalDevReportingEnv = process.env.XDT_TAPDB_DEV;
+
 beforeEach(() => {
   userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-analytics-'));
+  isPackaged = true;
+  delete process.env.XDT_TAPDB_DEV;
 });
 
 afterEach(() => {
   fs.rmSync(userDataDir, { recursive: true, force: true });
+  if (originalDevReportingEnv === undefined) delete process.env.XDT_TAPDB_DEV;
+  else process.env.XDT_TAPDB_DEV = originalDevReportingEnv;
 });
 
 describe('analytics settings store', () => {
@@ -210,6 +225,76 @@ describe('analytics settings store', () => {
     const store = await importStore();
 
     expect(store.migrateExistingLoginAsConsented(true)).toBe(false);
+    expect(store.isAnalyticsAllowed()).toBe(false);
+  });
+});
+
+/**
+ * 构建闸 —— dev 构建绝不上报。
+ *
+ * dev 的 renderer 从 http://localhost:<vite 端口> 加载、每条 --isolated 沙箱各有独立
+ * userData,TapDB 的 device_id 存在 localStorage 里因而每次都是新的,会凭空造出大量
+ * 「新增设备」污染线上口径(2026-07-26 复盘)。这一组守的就是那道闸。
+ */
+describe('analytics build gate', () => {
+  it('refuses to report from a dev build even after consent', async () => {
+    isPackaged = false;
+    const store = await importStore();
+
+    store.acceptPrivacyConsent();
+
+    expect(store.isAnalyticsAllowed()).toBe(false);
+    // 闸只挡上报,不得篡改用户的持久真相 —— dev 与正式版常共享同一份 userData。
+    expect(store.readAnalyticsSettings()).toEqual({
+      privacyConsentAccepted: true,
+      analyticsEnabled: true,
+    });
+    expect(JSON.parse(fs.readFileSync(settingsFile(), 'utf-8'))).toMatchObject({
+      privacyConsentAccepted: true,
+    });
+  });
+
+  it('still reports from a packaged build with the same on-disk record', async () => {
+    isPackaged = false;
+    const devStore = await importStore();
+    devStore.acceptPrivacyConsent();
+    expect(devStore.isAnalyticsAllowed()).toBe(false);
+
+    // 同一份盘上记录,换成正式构建立刻放行 —— 证明差异只来自构建 flavor。
+    isPackaged = true;
+    const packagedStore = await importStore();
+    expect(packagedStore.isAnalyticsAllowed()).toBe(true);
+  });
+
+  it('lets XDT_TAPDB_DEV=1 opt a dev build back in (link verification escape hatch)', async () => {
+    isPackaged = false;
+    process.env.XDT_TAPDB_DEV = '1';
+    const store = await importStore();
+
+    store.acceptPrivacyConsent();
+
+    expect(store.isAnalyticsAllowed()).toBe(true);
+  });
+
+  it('treats any value other than "1" as opted out — no boolean guessing', async () => {
+    isPackaged = false;
+    for (const raw of ['0', 'true', 'yes', '', ' 1']) {
+      process.env.XDT_TAPDB_DEV = raw;
+      const store = await importStore();
+      store.acceptPrivacyConsent();
+
+      expect(store.isAnalyticsAllowed()).toBe(false);
+      expect(store.__testing.isReportingBuild()).toBe(false);
+    }
+  });
+
+  it('fails closed when the host cannot tell whether the build is packaged', async () => {
+    // 非 Electron 宿主 / 不完整 mock:isPackaged 不是严格 true 就按 dev 处理。
+    isPackaged = undefined as unknown as boolean;
+    const store = await importStore();
+
+    store.acceptPrivacyConsent();
+
     expect(store.isAnalyticsAllowed()).toBe(false);
   });
 });

--- a/apps/desktop/src/main/analytics-settings-store.ts
+++ b/apps/desktop/src/main/analytics-settings-store.ts
@@ -125,7 +125,7 @@ const DEV_REPORTING_ENV = 'XDT_TAPDB_DEV';
 let buildGateLogged = false;
 
 /**
- * 构建 flavor 闸:只有 packaged 构建才允许上报。
+ * 构建 flavor 闸:默认只有 packaged 构建允许上报,dev 可通过 XDT_TAPDB_DEV=1 手动放行。
  *
  * 为什么必须有这道闸:TapDB Web SDK 的设备身份(device_id)写在 renderer 的
  * localStorage 里,而 localStorage 按 **origin + userData 目录** 分家 ——

--- a/apps/desktop/src/main/analytics-settings-store.ts
+++ b/apps/desktop/src/main/analytics-settings-store.ts
@@ -9,7 +9,8 @@
  *    国内《APP违法违规收集使用个人信息行为认定方法》也把「未经同意收集」列为违规。
  *  - analyticsEnabled：同意之后的 opt-out 开关,默认开启,用户可随时在设置里关闭。
  *
- * 有效上报条件 = privacyConsentAccepted && analyticsEnabled(见 isAnalyticsAllowed)。
+ * 有效上报条件 = 正式构建 && privacyConsentAccepted && analyticsEnabled
+ * (见 isAnalyticsAllowed;构建闸的理由见 isReportingBuild)。
  *
  * 关于「恢复默认」:consent 是事实记录而非配置,不提供 UI 级 reset。resetAnalyticsSettings
  * 只用于测试与显式的账号数据清理,调用后用户会重新落回「未同意」。
@@ -113,9 +114,54 @@ export function readAnalyticsSettingsState(): OverrideSettingsState<AnalyticsSet
   return store.readState();
 }
 
-/** 有效上报条件:同意在先,开关在后。任一为 false 都不得上报。 */
+/**
+ * dev 逃生口:严格 `XDT_TAPDB_DEV=1` 才让非 packaged 构建上报,其它任何值
+ * ('0' / 'true' / 空串)都视为关——与 devCliFlags 的 XDT_ISOLATED 同款约定,不做
+ * 布尔猜测。只在需要验证上报链路本身时手动打开,打开即污染线上口径。
+ */
+const DEV_REPORTING_ENV = 'XDT_TAPDB_DEV';
+
+/** 构建闸的结论只在第一次求值时记一条日志,避免每次广播都刷屏。 */
+let buildGateLogged = false;
+
+/**
+ * 构建 flavor 闸:只有 packaged 构建才允许上报。
+ *
+ * 为什么必须有这道闸:TapDB Web SDK 的设备身份(device_id)写在 renderer 的
+ * localStorage 里,而 localStorage 按 **origin + userData 目录** 分家 ——
+ *   - dev 的 renderer 从 `http://localhost:<vite 端口>` 加载(packaged 走 file://),
+ *     并行多开时端口自增(5173 / 5174 / …),每个端口一份全新 localStorage;
+ *   - `--isolated[=<名字>]` / `XDT_USER_DATA_DIR` 每条沙箱一份独立 localStorage,
+ *     沙箱删掉重建又是一份。
+ * 而 SDK init 时的 `isInitDeviceLogin` 会发 device_login,正是 TapDB 后台认定
+ * 「新增设备」的事件。于是一个开发者每天能凭空造出几十台"新增设备",把线上
+ * 新增设备 / 转化率 / 次日留存全部带偏(2026-07-26 复盘:某地区单人一天 78 台设备、
+ * 新增账号 1、次日留存 2.6%)。dev 与 release 目前共用同一个 TapDB appId,只能在
+ * 闸上区分;将来 dev 拿到独立 appId 后这道闸仍应保留(默认不上报)。
+ *
+ * 严格判 `=== true`:非 Electron 宿主或测试 mock 拿不到 isPackaged 时按 dev 处理
+ * (fail closed,宁可少报不可乱报)。
+ */
+function isReportingBuild(): boolean {
+  if (app.isPackaged === true) return true;
+  const devOptIn = process.env[DEV_REPORTING_ENV] === '1';
+  if (!buildGateLogged) {
+    buildGateLogged = true;
+    log.info('analytics build gate evaluated', { packaged: false, devOptIn });
+  }
+  return devOptIn;
+}
+
+/**
+ * 有效上报条件:构建闸在最前,然后同意在先、开关在后。任一为 false 都不得上报。
+ *
+ * 构建闸不写盘、不改 privacyConsentAccepted / analyticsEnabled —— 那两个字段是用户
+ * 的持久真相(dev 与正式版共享同一份 userData 时必须保持一致),设置页照常显示真实
+ * 开关状态,dev 下只是没有任何字节发出去。
+ */
 export function isAnalyticsAllowed(): boolean {
   probeRecordOnce();
+  if (!isReportingBuild()) return false;
   const value = store.read();
   return value.privacyConsentAccepted && value.analyticsEnabled;
 }
@@ -198,6 +244,8 @@ export function resetAnalyticsSettings(): AnalyticsSettings {
 export const __testing = {
   normalize,
   DEFAULTS,
+  isReportingBuild,
+  DEV_REPORTING_ENV,
   resetProbe(): void {
     recordProbe = null;
   },

--- a/apps/desktop/src/renderer/analytics/tapdbClient.ts
+++ b/apps/desktop/src/renderer/analytics/tapdbClient.ts
@@ -8,7 +8,13 @@
  *   在 PIPL 与 GDPR 下都属于个人信息;TapTap 自己的合规文档也要求
  *   `if (用户同意隐私协议) { init(...) }`。真相由 main 持有,本模块只消费
  *   `electronAPI.getAnalyticsSettings().allowed` 这个结论:
- *     allowed = 已同意隐私政策 && 使用统计开关开启
+ *     allowed = 正式构建 && 已同意隐私政策 && 使用统计开关开启
+ *
+ * ⚠️ 构建闸(2026-07-26):dev 构建恒 allowed=false,SDK 一律不初始化。dev 的
+ *   renderer 从 `http://localhost:<vite 端口>` 加载、沙箱各有独立 userData,
+ *   localStorage 里的 device_id 每次都是新的,会凭空造出大量"新增设备"污染线上
+ *   口径。理由与逃生口(XDT_TAPDB_DEV=1)见
+ *   main/analytics-settings-store.ts 的 isReportingBuild。
  *
  * 为什么放在 renderer:
  *   TapDB SDK 依赖 `localStorage` / `document` / `window` / `XMLHttpRequest` /

--- a/apps/desktop/src/renderer/analytics/tapdbClient.ts
+++ b/apps/desktop/src/renderer/analytics/tapdbClient.ts
@@ -8,9 +8,10 @@
  *   在 PIPL 与 GDPR 下都属于个人信息;TapTap 自己的合规文档也要求
  *   `if (用户同意隐私协议) { init(...) }`。真相由 main 持有,本模块只消费
  *   `electronAPI.getAnalyticsSettings().allowed` 这个结论:
- *     allowed = 正式构建 && 已同意隐私政策 && 使用统计开关开启
+ *     allowed = isReportingBuild() && 已同意隐私政策 && 使用统计开关开启
+ *   (isReportingBuild = packaged 构建,或 dev 下显式 XDT_TAPDB_DEV=1)
  *
- * ⚠️ 构建闸(2026-07-26):dev 构建恒 allowed=false,SDK 一律不初始化。dev 的
+ * ⚠️ 构建闸(2026-07-26):dev 构建默认 allowed=false,SDK 不初始化。dev 的
  *   renderer 从 `http://localhost:<vite 端口>` 加载、沙箱各有独立 userData,
  *   localStorage 里的 device_id 每次都是新的,会凭空造出大量"新增设备"污染线上
  *   口径。理由与逃生口(XDT_TAPDB_DEV=1)见

--- a/apps/desktop/src/renderer/hooks/useAnalyticsSettings.ts
+++ b/apps/desktop/src/renderer/hooks/useAnalyticsSettings.ts
@@ -5,7 +5,7 @@ export interface AnalyticsSettingsState {
   analyticsEnabled: boolean;
   /** 用户是否显式设置过开关;false = 跟随当前默认值。 */
   analyticsEnabledCustomized: boolean;
-  /** allowed = 正式构建 && 已同意隐私政策 && 统计开关开启(dev 构建恒 false)。 */
+  /** allowed = isReportingBuild && 已同意隐私政策 && 统计开关开启(dev 默认 false,XDT_TAPDB_DEV=1 可放行)。 */
   allowed: boolean;
   loading: boolean;
 }

--- a/apps/desktop/src/renderer/hooks/useAnalyticsSettings.ts
+++ b/apps/desktop/src/renderer/hooks/useAnalyticsSettings.ts
@@ -5,7 +5,7 @@ export interface AnalyticsSettingsState {
   analyticsEnabled: boolean;
   /** 用户是否显式设置过开关;false = 跟随当前默认值。 */
   analyticsEnabledCustomized: boolean;
-  /** allowed = 已同意隐私政策 && 统计开关开启。 */
+  /** allowed = 正式构建 && 已同意隐私政策 && 统计开关开启(dev 构建恒 false)。 */
   allowed: boolean;
   loading: boolean;
 }

--- a/apps/desktop/src/shared/analyticsSettings.ts
+++ b/apps/desktop/src/shared/analyticsSettings.ts
@@ -14,8 +14,9 @@ export interface AnalyticsSettingsPayload {
   analyticsEnabledCustomized: boolean;
   /**
    * 是否允许初始化 TapDB / 继续上报
-   * = 正式构建 && privacyConsentAccepted && analyticsEnabled。
-   * 构建闸的理由见 main/analytics-settings-store.ts 的 isReportingBuild。
+   * = isReportingBuild() && privacyConsentAccepted && analyticsEnabled。
+   * isReportingBuild = packaged 构建,或 dev 下显式 XDT_TAPDB_DEV=1。
+   * 构建闸的理由见 main/analytics-settings-store.ts。
    */
   allowed: boolean;
 }

--- a/apps/desktop/src/shared/analyticsSettings.ts
+++ b/apps/desktop/src/shared/analyticsSettings.ts
@@ -12,7 +12,11 @@ export interface AnalyticsSettingsPayload {
   analyticsEnabled: boolean;
   /** 用户是否显式设置过开关(盘上有 override)。false = 跟随当前默认值。 */
   analyticsEnabledCustomized: boolean;
-  /** 是否允许初始化 TapDB / 继续上报 = privacyConsentAccepted && analyticsEnabled。 */
+  /**
+   * 是否允许初始化 TapDB / 继续上报
+   * = 正式构建 && privacyConsentAccepted && analyticsEnabled。
+   * 构建闸的理由见 main/analytics-settings-store.ts 的 isReportingBuild。
+   */
   allowed: boolean;
 }
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -65,9 +65,9 @@ Agent 自身仍只走 restart 命令，不直接调 human-only 的 `dev:desktop*
 
 ### 使用统计（TapDB）在 dev 下不上报
 
-dev 构建**一律不初始化 TapDB**，与用户是否同意《隐私政策》、统计开关是否打开无关。闸在
+dev 构建**默认不初始化 TapDB**，与用户是否同意《隐私政策》、统计开关是否打开无关。闸在
 main 侧 `analytics-settings-store.ts` 的 `isReportingBuild()`（`app.isPackaged !== true`
-即关），renderer 只消费 `allowed` 这个结论。
+默认关），renderer 只消费 `allowed` 这个结论。
 
 原因：TapDB Web SDK 的设备身份（`device_id`）写在 renderer 的 localStorage 里，而
 localStorage 按 **origin + userData 目录** 分家——dev 的 renderer 从

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -63,6 +63,22 @@ restart 无法同时多开**。真要并行多个 dev 实例，走下面三条�
 Agent 自身仍只走 restart 命令，不直接调 human-only 的 `dev:desktop*`。共享同一 userData
 多开时，非 primary 实例用 `--passive` 让出定时任务调度（见上）。
 
+### 使用统计（TapDB）在 dev 下不上报
+
+dev 构建**一律不初始化 TapDB**，与用户是否同意《隐私政策》、统计开关是否打开无关。闸在
+main 侧 `analytics-settings-store.ts` 的 `isReportingBuild()`（`app.isPackaged !== true`
+即关），renderer 只消费 `allowed` 这个结论。
+
+原因：TapDB Web SDK 的设备身份（`device_id`）写在 renderer 的 localStorage 里，而
+localStorage 按 **origin + userData 目录** 分家——dev 的 renderer 从
+`http://localhost:<vite 端口>` 加载（并行多开时端口自增），`--isolated[=<名字>]` 与
+`XDT_USER_DATA_DIR` 每条沙箱又各有一份。于是一个开发者一天能凭空造出几十台「新增设备」，
+把线上新增设备／转化率／次日留存全部带偏（2026-07-26 复盘：某地区单人一天 78 台设备、
+新增账号 1、次日留存 2.6%）。dev 与 release 目前共用同一个 TapDB appId，只能在闸上区分。
+
+要验证上报链路本身时，手动设 `XDT_TAPDB_DEV=1` 放行（严格等于 `1`，其它值一律视为关）。
+**这会把 dev 数据打进线上 app，用完即撤，不要写进任何脚本或 `.env`。**
+
 ## 何时需要重启
 
 - 修改 main、preload、MCP、原生依赖或 package 运行时代码后需要重启。

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -457,6 +457,7 @@ export function devEnvPrefix(env = process.env, platform = process.platform) {
     ['XDT_SCHEDULER_PASSIVE', env.XDT_SCHEDULER_PASSIVE],
     ['XDT_ISOLATED', env.XDT_ISOLATED],
     ['XDT_ISOLATED_NAME', env.XDT_ISOLATED_NAME],
+    ['XDT_TAPDB_DEV', env.XDT_TAPDB_DEV],
     // 端点清单来源覆写:--endpoints-cdn(dev 走线上 CDN)/ local 模式的
     // endpoint.local.json 文件路径,均由主进程 clientEndpointsService 消费。
     ['XDT_ENDPOINTS_CDN', env.XDT_ENDPOINTS_CDN],


### PR DESCRIPTION
## 这次改了什么

### 摘要

dev 构建不再向 TapDB 上报任何数据。

TapDB Web SDK 的设备身份(`device_id`)写在 renderer 的 localStorage 里,而 localStorage 按 **origin + userData 目录** 分家:

- dev 的 renderer 从 `http://localhost:<vite 端口>` 加载(packaged 走 `file://`),并行多开时端口自增(5173 / 5174 / …),**每个端口一份全新 localStorage**;
- `--isolated[=<名字>]` / `XDT_USER_DATA_DIR` 每条沙箱一份独立 localStorage,沙箱删掉重建又是一份。

而 SDK init 时的 `isInitDeviceLogin` 会发 `device_login`,正是 TapDB 后台认定「新增设备」的事件。于是**一个开发者一天能凭空造出几十台「新增设备」**。

2026-07-26 复盘:某地区实际只有 1 个人在用 dev,一天记了 **78 台新增设备、转化设备 72、新增账号 1、次日留存 2.6%** —— 线上新增设备 / 转化率 / 留存口径全部被带偏(设备一次性、启动即 `setUser` 同一个老账号 → 转化率虚高、新增账号只有 1、第二天旧 ID 再不出现)。

改法:main 侧 `isAnalyticsAllowed()` 最前面加构建闸 `isReportingBuild()`,`app.isPackaged !== true` 一律返回 `false`,renderer 拿到 `allowed=false` 就完全不初始化 SDK。

```
allowed = 正式构建 && privacyConsentAccepted && analyticsEnabled
```

几个刻意的选择:

- **收口在 store 而不是 `analyticsSettingsPayload()`**:`allowed` 目前只有一个生产者,但闸放在 store 里,将来任何新增消费者都自动继承,不会绕过。
- **严格判 `=== true`**:非 Electron 宿主 / 不完整 mock 拿不到 `isPackaged` 时按 dev 处理(fail closed,宁可少报不可乱报)。
- **不写盘、不改 `privacyConsentAccepted` / `analyticsEnabled`**:这两个字段是用户的持久真相,而 dev 与正式版常共享同一份 `Cindy` userData,篡改会串味。设置页在 dev 下照常显示真实开关状态,只是没有任何字节发出去。
- **逃生口 `XDT_TAPDB_DEV=1`**:严格等于 `1`,`'0'` / `'true'` / 空串一律视为关(沿用 `devCliFlags` 的 `XDT_ISOLATED` 约定,不做布尔猜测)。第一次求值时打一条 `analytics build gate evaluated` 日志,免得以后有人查「dev 为什么不上报」查半天。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(线上数据异常排查)
- 本 PR 包含:
  - `analytics-settings-store.ts` 新增构建闸 `isReportingBuild()`,插在 `isAnalyticsAllowed()` 最前
  - 三处描述 `allowed` 语义的注释对齐(`shared/analyticsSettings.ts`、`hooks/useAnalyticsSettings.ts`、`renderer/analytics/tapdbClient.ts` 头注)——它们此前都写着 `allowed = 同意 && 开关`
  - `docs/dev-rules/desktop-development.md` 新增「使用统计(TapDB)在 dev 下不上报」小节
  - store 测试:electron mock 的 `isPackaged` 改成 getter(用例内可切),新增 `analytics build gate` 5 个用例
- 明确不包含:
  - **dev 专用 appId**:线上另行申请,拿到后这道闸仍应保留、只把默认值从「dev 不报」改成「dev 报到 dev app」
  - **mobile 侧**(`apps/mobile/src/analytics/mobileTapdb.ts`)同样没有 dev 判定,但它走原生 SDK,device_id 跟安装绑定、不会每次换身份,不是本次 78 台设备的成因,量级完全不同 —— 单独评估
  - **历史脏数据清洗**:后台按 `#app_version = 1.0.0` 可圈出 dev 设备(dev 读 `apps/desktop/package.json` 的 `1.0.0`,release 是 `0.1.x`),属运营侧动作
- 用户可见变化:无。正式版行为完全不变(`app.isPackaged === true` 直接放行);只有开发机上的 dev 实例不再上报
- 是否存在 breaking change:无

### UI 变化

不涉及:命中的两个 renderer 文件只改了注释(`tapdbClient.ts` 头注、`useAnalyticsSettings.ts` 的字段说明),无任何视觉、交互或文案变化。设置页的统计开关渲染的仍是 `analyticsEnabled`(真实持久状态),不消费本次收紧的 `allowed`,dev 下显示与改前完全一致。

- 引用的设计规范:不涉及:本次改动无 UI 渲染变化,命中 UI 路径的两处均为注释修改,不新增或修改任何界面、组件、布局、样式、动效与 UI 文案。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:PASS(exit 0)。全量输出被 tail 截断,故单独复跑了本次改动所在的 workspace:

node scripts/test-workspaces.mjs --tier unit --workspace desktop
结果:PASS apps/desktop unit

pnpm --filter desktop typecheck
结果:通过(tsc --noEmit 无输出)

pnpm --filter desktop exec vitest run \
  src/main/__tests__/analyticsSettingsStore.test.ts \
  src/main/__tests__/analyticsSettingsService.test.ts \
  src/renderer/__tests__/tapdbConsentGate.test.ts
结果:3 files / 42 tests passed

pnpm check:dco
结果:DCO check passed: 1 commit signed off
```

新增用例覆盖:dev 下同意也不放行且盘上记录不变 / 同一份盘上记录换成 packaged 立刻放行(证明差异只来自构建 flavor)/ `XDT_TAPDB_DEV=1` 放行 / 非 `'1'` 的值一律不放行 / `isPackaged` 拿不到时 fail closed。

### 手工验证

不涉及 —— 「dev 不上报」这条断言在 dev 环境里本身就是「什么都不发生」,靠单测覆盖比人眼看更可靠;正式构建路径(`isPackaged === true`)由「同一份记录换 packaged 立刻放行」的用例守住。

### 未执行的验证

- 未打包正式版实测上报仍然正常。改动对 packaged 分支是 `if (app.isPackaged === true) return true` 的早返回,行为与改前逐字等价,风险极低;真要复核,可用 `XDT_TAPDB_DEV=1` 在 dev 下验证整条上报链路。
- mobile 侧未验证(本 PR 不含 mobile 改动,无 fingerprint 输入变更)。

## 风险

### 风险分类

- [x] 其他:埋点口径(只会少报,不会多报或错报)

### 影响与回滚

- 影响范围:仅 desktop dev 构建的 TapDB 上报。正式版零变化。合规方向是**更保守**(采集减少),不放宽任何采集条件。
- 副作用:合并后线上「新增设备 / 转化设备 / 次日留存」会出现一次台阶式变化 —— 那是虚高数据被摘掉,不是掉量,建议同步给看数据的人。
- 回滚 / 降级方式:`git revert` 单个 commit 即可;不落盘、不改数据格式,无迁移、无状态残留。临时放行单台开发机设 `XDT_TAPDB_DEV=1` 即可,不必回滚代码。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI,跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(`docs/dev-rules/desktop-development.md`)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
