### PR TITLE
fix(desktop): 加固 IM 模型菜单滚动边界

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -465,6 +465,70 @@ describe('ModelSelector trigger variants', () => {
     expect(trigger.querySelector('[data-model-promotion-badge]')).toBeNull();
   });
 
+  it('keeps a long subscription-backed field menu bounded and wheel-scrollable', () => {
+    const models: VisibleModelFixture[] = Array.from({ length: 40 }, (_, index) => ({
+      id: `subscription-model-${index + 1}`,
+      displayName: `Subscription Model ${index + 1}`,
+      contextWindow: 200000,
+      efforts: ['high'],
+      defaultEffort: 'high',
+    }));
+    const originalCapabilities = agentCapabilitiesRef.capabilities;
+    visibleModelsRef.models = models;
+    agentCapabilitiesRef.capabilities = {
+      availableModels: models,
+      effortLevels: [{ id: 'high', displayName: 'High' }],
+      hasFastMode: false,
+    };
+    providersRef.providers = [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'oauth' },
+        routing: { 'claude-code': {} },
+        connected: true,
+        models: {
+          'claude-code': models.map((model) => ({
+            ...model,
+            name: model.displayName,
+          })),
+        },
+      },
+    ];
+
+    try {
+      render(
+        React.createElement(ModelSelector, {
+          modelId: models[0].id,
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          triggerVariant: 'field',
+          currentProviderId: 'anthropic',
+          onProviderChange: vi.fn(),
+        }),
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Current: Subscription Model 1/ }));
+      const list = screen.getByRole('listbox', { name: 'Model list' });
+
+      expect(list.className).toContain('max-h-[300px]');
+      expect(list.className).toContain('overflow-y-auto');
+      expect(list.className).toContain('overscroll-contain');
+      const options = within(list).getAllByRole('option');
+      expect(options).toHaveLength(40);
+      expect(options[0].textContent).toContain('Subscription Model 1');
+      expect(options[39].textContent).toContain('Subscription Model 40');
+    } finally {
+      visibleModelsRef.models = null;
+      agentCapabilitiesRef.capabilities = originalCapabilities;
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
   it('reuses the parent pricing snapshot when the model content opens', () => {
     pricingRef.renderCalls = 0;
     render(

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1443,7 +1443,7 @@ function ModelSelectorContentView({
         ref={listRef}
         // -mr-2 把滚动条挪进面板右侧 8px 留白;scrollbar-gutter:stable 让无滚动时
         // 行宽与有滚动时一致(否则行会比搜索框宽 8px);细滚动条见 globals.css
-        className="morph-panel-list-scroll -mr-2 flex max-h-[300px] flex-col gap-0.5 overflow-y-auto [scrollbar-gutter:stable]"
+        className="morph-panel-list-scroll -mr-2 flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
         role="listbox"
         aria-label="Model list"
         onScroll={() => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

加固标准模型选择面板的内部滚动边界：模型列表保留 300px 高度上限与纵向滚动，并增加 `overscroll-contain`，避免触控板或滚轮滚到列表边界后继续带动外层设置页。

用户现场反馈旧版「设置 → IM 机器人 → Telegram → 工作目录模型」下拉无法滚动，列表顶部的订阅模型也因此不可见。新仓 `main` 已由 #509 将该入口切换为支持订阅来源的标准 `ModelSelector`；本 PR 在此基础上补齐滚动隔离，并增加 40 个订阅来源模型的回归测试，锁定首尾选项、列表高度上限和内部滚动契约。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：2026-07-26 用户反馈 Mac mini 上 IM 模型菜单无法滚动且看不到订阅模型
- 本 PR 包含：标准 `ModelSelector` 模型列表的 overscroll 隔离；长订阅模型列表回归测试
- 明确不包含：不改模型目录、订阅识别、来源持久化或 IM 派发逻辑；这些能力已由 #509 落地
- 用户可见变化：模型列表滚到顶部或底部时，滚轮/触控板不会继续带动外层设置页
- 是否存在 breaking change：无
- SSH 远程工作区：不涉及 workdir 文件、Agent 进程或会话数据，仅修改 Desktop Renderer 的菜单滚动样式
- 设备互联 / 远程控制：不新增或修改 IPC channel、推送事件或 allowlist
- 手机版：不涉及；手机版没有复用此 Desktop Settings 菜单

### UI 变化

不改变颜色、尺寸、排版或菜单结构，仅增加滚动边界隔离。未上传用户现场截图：截图含账号、本地路径与模型信息；本 PR 通过组件回归测试覆盖相关交互契约。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Select & Dropdown（下拉列表应在面板内滚动）与 §10 Light / Dark 双模式交付门槛。本改动不引入颜色或模式分支，继续复用既有双模式标准模型面板。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：25 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全部 unit workspace 通过，退出码 0

node scripts/check-dco.mjs --base cindy-upstream/main --head HEAD
结果：1 commit signed off，校验通过

git diff --check
结果：通过
```

### 手工验证

未启动新的 Desktop dev 实例；当前正式版实例不会加载该 worktree 的 Renderer 代码。

### 未执行的验证

- 未在 Windows 实机验证滚轮；改动是 Chromium 标准 CSS `overscroll-behavior`，macOS 与 Windows 共用同一 Renderer 路径
- 未做 Light / Dark 实机目检；本次没有颜色、token 或视觉结构变化

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：所有复用标准 `ModelSelector` 的 Desktop 模型列表，主要是会话输入框与 Settings 的 IM / 子代理模型入口
- 回滚 / 降级方式：revert 本 PR 即可；无数据迁移、配置变更或持久化副作用

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：行为由测试与代码注释完整表达，无需用户文档）
- [x] 已确认测试结果或说明未执行原因
