### PR TITLE
fix(desktop): 修复侧边栏会话行 memo 被整表打穿

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
@@ -110,8 +110,11 @@ describe('Project 行内 + 也对标统一 New(delayed-create)', () => {
 
 describe('inline archive dirty-worktree warning', () => {
   it('preflights archive-now and opens the warning dialog before archiving a dirty worktree', () => {
+    // 钉的是预检顺序,不是排版:末段用 [\s\S]*? 容忍换行。activeSessionId 取
+    // viewedSessionIdRef.current(而非 viewedSessionId)是为了让 handleActionClick
+    // 的 useCallback deps 保持稳定,见 sessionRowRenderIsolation 的行渲染隔离不变量。
     expect(sidebarSource).toMatch(
-      /if \(action === 'archive-now'\) \{[\s\S]*?fetchDirtyWorktreeForRemoval\([\s\S]*?if \(dirtyWorktree\) \{[\s\S]*?setConfirm\(\{ open: true, sessionId, action: 'archive', dirtyWorktree: true \}\);[\s\S]*?return;[\s\S]*?await runSessionAction\(sessionId, 'archive', \{ activeSessionId: viewedSessionId \}\);/,
+      /if \(action === 'archive-now'\) \{[\s\S]*?fetchDirtyWorktreeForRemoval\([\s\S]*?if \(dirtyWorktree\) \{[\s\S]*?setConfirm\(\{ open: true, sessionId, action: 'archive', dirtyWorktree: true \}\);[\s\S]*?return;[\s\S]*?await runSessionAction\(sessionId, 'archive', \{[\s\S]*?activeSessionId: viewedSessionIdRef\.current,[\s\S]*?\}\);/,
     );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -1257,6 +1257,9 @@ function ExpandedView({
   // 经 ref 读还顺带避开闭包陈旧:拿到的是最新值而非渲染时快照。
   const activeSessionIdRef = useRef(activeSessionId);
   activeSessionIdRef.current = activeSessionId;
+  // viewedSessionId 同理:handleActionClick 只在触发归档那一刻用它算重定向目标。
+  const viewedSessionIdRef = useRef(viewedSessionId);
+  viewedSessionIdRef.current = viewedSessionId;
   const selectedSessionIdsRef = useRef(selectedSessionIds);
   selectedSessionIdsRef.current = selectedSessionIds;
   const selectionAnchorSessionIdRef = useRef(selectionAnchorSessionId);
@@ -1651,7 +1654,9 @@ function ExpandedView({
         patchLocal(sessionId, { pinnedAt: oldPinnedAt });
       }
     },
-    [filter, patchLocal, t],
+    // 只依赖 filter.promotePin(useCallback 稳定),不要整个 filter ——
+    // useSidebarFilter 每次调用都返回新对象字面量,带上它等于每渲染换引用。
+    [filter.promotePin, patchLocal, t],
   );
 
   const handleToggleProjectPin = useCallback(
@@ -1749,7 +1754,16 @@ function ExpandedView({
         );
       }
     },
-    [collapse, effectiveRunningSessionIds, patchLocal, t],
+    // 同理只依赖用到的三个成员,不要整个 collapse —— useCollapsedProjects 也返回
+    // 新对象字面量。collapsed 是 Set,仅用户手动折叠/展开时换引用,频率可忽略。
+    [
+      collapse.collapsed,
+      collapse.expand,
+      collapse.setCollapsed,
+      effectiveRunningSessionIds,
+      patchLocal,
+      t,
+    ],
   );
 
   /* ---- Delete / Archive / Unarchive action handlers ----
@@ -1805,8 +1819,11 @@ function ExpandedView({
           return;
         }
         // 重定向判定用 viewedSessionId:files 路由下归档「正在浏览的会话」也要
-        // 跳离失效的文件视图(codex review;正常路由下两者恒等)。
-        await runSessionAction(sessionId, 'archive', { activeSessionId: viewedSessionId });
+        // 跳离失效的文件视图(codex review;正常路由下两者恒等)。经 ref 读:它随
+        // 路由切换而变,留在 deps 里会让本 handler 每次切换都重建、打穿整表 memo。
+        await runSessionAction(sessionId, 'archive', {
+          activeSessionId: viewedSessionIdRef.current,
+        });
         return;
       }
       if (action !== 'unarchive') {
@@ -1821,7 +1838,6 @@ function ExpandedView({
       await unarchiveSession(sessionId);
     },
     [
-      viewedSessionId,
       runningSessionIds,
       runSessionAction,
       unarchiveSession,

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -1251,6 +1251,16 @@ function ExpandedView({
 
   const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(() => new Set());
   const [selectionAnchorSessionId, setSelectionAnchorSessionId] = useState<string | null>(null);
+  // 这三个值 handleSessionClick 只在「点击那一刻」读一次。留在它的 deps 里会让
+  // 每次点击(:setSelectionAnchorSessionId 必触发)和每次切换都重建 handler,
+  // 行的 onClick 跟着换引用 → 整表 memo 失效重画一遍(SessionItem.tsx 不变量 #3)。
+  // 经 ref 读还顺带避开闭包陈旧:拿到的是最新值而非渲染时快照。
+  const activeSessionIdRef = useRef(activeSessionId);
+  activeSessionIdRef.current = activeSessionId;
+  const selectedSessionIdsRef = useRef(selectedSessionIds);
+  selectedSessionIdsRef.current = selectedSessionIds;
+  const selectionAnchorSessionIdRef = useRef(selectionAnchorSessionId);
+  selectionAnchorSessionIdRef.current = selectionAnchorSessionId;
   const [bulkActionPending, setBulkActionPending] = useState<BulkSessionAction | null>(null);
   const sidebarScrollRef = useRef<HTMLDivElement>(null);
   // 含远程会话:device-link 远程行也渲染在可选行里,bulk 选择/归档/删除必须能解析到它们
@@ -1385,10 +1395,9 @@ function ExpandedView({
         if (modifiers?.shiftKey) {
           const visibleIds = getVisibleSidebarSessionIds(sidebarScrollRef.current);
           const visibleIdSet = new Set(visibleIds);
+          const anchorSessionId = selectionAnchorSessionIdRef.current;
           const anchor =
-            selectionAnchorSessionId && visibleIds.includes(selectionAnchorSessionId)
-              ? selectionAnchorSessionId
-              : id;
+            anchorSessionId && visibleIds.includes(anchorSessionId) ? anchorSessionId : id;
           const anchorIndex = visibleIds.indexOf(anchor);
           const targetIndex = visibleIds.indexOf(id);
           const rangeIds =
@@ -1422,7 +1431,7 @@ function ExpandedView({
         return;
       }
 
-      if (selectedSessionIds.size > 0) {
+      if (selectedSessionIdsRef.current.size > 0) {
         setSelectedSessionIds(new Set());
       }
       setSelectionAnchorSessionId(id);
@@ -1430,19 +1439,15 @@ function ExpandedView({
       clearNotification(id);
       markAutomationSessionRunsRead(id);
       clearSystemSessionAttention(id);
-      if (id === activeSessionId) return; // No duplicate navigate.
+      if (id === activeSessionIdRef.current) return; // No duplicate navigate.
       if (import.meta.env.DEV) perfLog.debug(`sidebar:click sid=${id}`); // 纯诊断,生产剔除
       const target = sessionsRef.current.find((s) => s.id === id);
       navigate(await resolveSessionRoute(id, target));
     },
-    [
-      activeSessionId,
-      navigate,
-      clearNotification,
-      markAutomationSessionRunsRead,
-      selectedSessionIds.size,
-      selectionAnchorSessionId,
-    ],
+    // deps 只剩三个天然稳定的引用:navigate(router)、clearNotification(空 deps
+    // useCallback)、markAutomationSessionRunsRead(随 scheduleSessionIndex,仅
+    // schedule 真变时换)。至此 onClick 在运行期与切换时都不再换引用。
+    [navigate, clearNotification, markAutomationSessionRunsRead],
   );
 
   /* ---- Project 行内的 + 按钮：对标顶部 "+ New"——预填该 project 的 workingDir 后进 draft 路由 ----

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -1259,6 +1259,10 @@ function ExpandedView({
     () => new Map([...sessions, ...remoteProjectSessions].map((session) => [session.id, session])),
     [sessions, remoteProjectSessions],
   );
+  // 与 sessionsRef 同理:行级 handler 只在「点击那一刻」查表,不该因为表换了引用就
+  // 重建自身 —— 否则 SessionItem 的 memo 会被整表打穿(SessionItem.tsx 不变量第 3 条)。
+  const sessionsByIdRef = useRef(sessionsById);
+  sessionsByIdRef.current = sessionsById;
   const selectedSessions = useMemo(
     () =>
       [...selectedSessionIds]
@@ -1428,7 +1432,7 @@ function ExpandedView({
       clearSystemSessionAttention(id);
       if (id === activeSessionId) return; // No duplicate navigate.
       if (import.meta.env.DEV) perfLog.debug(`sidebar:click sid=${id}`); // 纯诊断,生产剔除
-      const target = sessions.find((s) => s.id === id);
+      const target = sessionsRef.current.find((s) => s.id === id);
       navigate(await resolveSessionRoute(id, target));
     },
     [
@@ -1436,7 +1440,6 @@ function ExpandedView({
       navigate,
       clearNotification,
       markAutomationSessionRunsRead,
-      sessions,
       selectedSessionIds.size,
       selectionAnchorSessionId,
     ],
@@ -1584,13 +1587,15 @@ function ExpandedView({
   /* ---- Rename handler ---- */
   const handleRename = useCallback(
     async (sessionId: string, newTitle: string) => {
-      const session = sessionsById.get(sessionId);
+      const session = sessionsByIdRef.current.get(sessionId);
       if (isRemoteSessionWriteBlocked(session)) {
         toast.warning(t('ccAgent.remoteSession.actionsUnavailable'));
         return;
       }
       // 取旧值用于失败回滚，乐观先 patch（不刷整列表，列表顺序保持稳定）
-      const oldTitle = sessions.find((s) => s.id === sessionId)?.title;
+      // 保持读 sessions(而非 sessionsById):后者含 remoteProjectSessions,换源会连带
+      // 改变远程会话的回滚行为,不在本次修复范围内。
+      const oldTitle = sessionsRef.current.find((s) => s.id === sessionId)?.title;
       patchLocal(sessionId, { title: newTitle });
       try {
         // 远程会话:patch-meta 经隧道写被控端 → 广播 sessions:patched → applyPatch 更新远程分片(纯镜像)。
@@ -1601,7 +1606,7 @@ function ExpandedView({
         if (oldTitle !== undefined) patchLocal(sessionId, { title: oldTitle });
       }
     },
-    [sessions, sessionsById, patchLocal, t],
+    [patchLocal, t],
   );
 
   const handleProjectAliasChange = useCallback(
@@ -1620,12 +1625,13 @@ function ExpandedView({
   /* ---- Pin / Unpin handler ---- */
   const handleTogglePin = useCallback(
     async (sessionId: string, currentlyPinned: boolean) => {
-      const session = sessionsById.get(sessionId);
+      const session = sessionsByIdRef.current.get(sessionId);
       if (isRemoteSessionWriteBlocked(session)) {
         toast.warning(t('ccAgent.remoteSession.actionsUnavailable'));
         return;
       }
-      const oldPinnedAt = sessions.find((s) => s.id === sessionId)?.pinnedAt ?? null;
+      // 同 handleRename:回滚值刻意仍读 sessions,不换成 sessionsById。
+      const oldPinnedAt = sessionsRef.current.find((s) => s.id === sessionId)?.pinnedAt ?? null;
       const newPinnedAt = currentlyPinned ? null : new Date().toISOString();
       patchLocal(sessionId, { pinnedAt: newPinnedAt });
       // pin / re-pin 时把它顶到 manualPinnedOrder 首位，否则带着老 rank 会卡回原位。
@@ -1640,7 +1646,7 @@ function ExpandedView({
         patchLocal(sessionId, { pinnedAt: oldPinnedAt });
       }
     },
-    [filter, patchLocal, sessions, sessionsById, t],
+    [filter, patchLocal, t],
   );
 
   const handleToggleProjectPin = useCallback(
@@ -1658,7 +1664,7 @@ function ExpandedView({
 
   const handleMoveSession = useCallback(
     async (sessionId: string, target: SessionMoveTarget) => {
-      const session = sessionsById.get(sessionId);
+      const session = sessionsByIdRef.current.get(sessionId);
       if (!session) return;
       if (session.remoteHostId || session.deviceLinkDeviceId) {
         toast.warning(t('ccAgent.sidebar.sessionMenu.moveToProjectRemoteUnsupported'));
@@ -1738,7 +1744,7 @@ function ExpandedView({
         );
       }
     },
-    [collapse, effectiveRunningSessionIds, patchLocal, sessionsById, t],
+    [collapse, effectiveRunningSessionIds, patchLocal, t],
   );
 
   /* ---- Delete / Archive / Unarchive action handlers ----
@@ -1759,7 +1765,7 @@ function ExpandedView({
 
   const handleActionClick = useCallback(
     async (sessionId: string, action: 'delete' | 'archive' | 'archive-now' | 'unarchive') => {
-      const session = sessionsById.get(sessionId);
+      const session = sessionsByIdRef.current.get(sessionId);
       if (isRemoteSessionWriteBlocked(session)) {
         toast.warning(t('ccAgent.remoteSession.actionsUnavailable'));
         return;
@@ -1813,7 +1819,6 @@ function ExpandedView({
       viewedSessionId,
       runningSessionIds,
       runSessionAction,
-      sessionsById,
       unarchiveSession,
       t,
     ],

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -292,6 +292,34 @@ describe('父层 — 行级 handler 的引用稳定性', () => {
     }
   });
 
+  it('deps 里不得出现每渲染重建的 hook 返回对象(filter / collapse)', () => {
+    // useSidebarFilter / useCollapsedProjects 都返回裸对象字面量,每次调用换引用。
+    // 必须依赖到具体成员(filter.promotePin、collapse.expand …),故用 (?!\.) 放行
+    // 成员访问、只拦整个对象。
+    const source = readFileSync(
+      resolve(__dirname, '..', '..', 'CCAgentSidebarUpper.tsx'),
+      'utf8',
+    );
+    for (const name of ROW_HANDLERS) {
+      const deps = useCallbackDeps(source, name);
+      expect(deps, `${name} 的 deps 不得含整个 filter`).not.toMatch(/\bfilter\b(?!\.)/);
+      expect(deps, `${name} 的 deps 不得含整个 collapse`).not.toMatch(/\bcollapse\b(?!\.)/);
+    }
+  });
+
+  it('deps 里不得出现随路由切换而变的 viewedSessionId', () => {
+    const source = readFileSync(
+      resolve(__dirname, '..', '..', 'CCAgentSidebarUpper.tsx'),
+      'utf8',
+    );
+    for (const name of ROW_HANDLERS) {
+      const deps = useCallbackDeps(source, name);
+      expect(deps, `${name} 的 deps 不得含 viewedSessionId`).not.toMatch(
+        /\bviewedSessionId\b/,
+      );
+    }
+  });
+
   it('handleSessionClick 的 deps 不得含每次点击/切换都变的选择态', () => {
     // 这三个只在点击那一刻读,却会被 setSelectionAnchorSessionId(每次点击必调)
     // 和路由切换带着变 —— 留在 deps 里等于每切换一次就整表重画一遍。

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -235,3 +235,70 @@ describe('SessionItem — 父层与 urgency 隔离', () => {
     expect(renderCounts.get('session-b')).toBe(baselineB);
   });
 });
+
+// ── 不变量 4:父层传给行的 props 必须运行期引用稳定 ──────────────────────────
+//
+// 上面三条都在「隔离环境 + 稳定 noop props」下成立,抓不到真正的历史 bug:
+// 真实父组件(CCAgentSidebarUpper)把每渲染换引用的东西放进 handler 的 useCallback
+// deps,memo 在生产里从未生效。渲染真实父组件需要 mock 掉 router + 十几个 store,
+// 成本远超收益,故这里退一步做源码级断言 —— 脆,但能钉住确切的回归点。
+//
+// 历史:2026-07 单击切换卡顿排查发现两处
+//   a) useSessionRunningStatus 的 runningSessionIds 裸调 deriveRunningSet,每渲染 new Set;
+//   b) 5 个行级 handler 的 deps 里带着 sessions / sessionsById(它们随每条消息换引用)。
+// 两者都会让 onAction / onMoveSession / onClick 等 prop 每渲染换引用,打穿整表 memo。
+
+/** 取 `const <name> = useCallback(...)` 的 deps 数组文本(括号配平扫描)。 */
+function useCallbackDeps(source: string, name: string): string {
+  const start = source.indexOf(`const ${name} = useCallback(`);
+  if (start < 0) throw new Error(`未找到 handler: ${name}`);
+  let depth = 0;
+  let i = source.indexOf('(', start);
+  const open = i;
+  for (; i < source.length; i += 1) {
+    if (source[i] === '(') depth += 1;
+    else if (source[i] === ')') {
+      depth -= 1;
+      if (depth === 0) break;
+    }
+  }
+  const body = source.slice(open, i);
+  const depsStart = body.lastIndexOf('[');
+  const depsEnd = body.lastIndexOf(']');
+  if (depsStart < 0 || depsEnd < depsStart) throw new Error(`${name} 没有 deps 数组`);
+  return body.slice(depsStart, depsEnd + 1);
+}
+
+describe('父层 — 行级 handler 的引用稳定性', () => {
+  /** 这 5 个是 SessionItem 的直接 props(onClick/onAction/onRename/onTogglePin/onMoveSession)。 */
+  const ROW_HANDLERS = [
+    'handleSessionClick',
+    'handleRename',
+    'handleTogglePin',
+    'handleMoveSession',
+    'handleActionClick',
+  ];
+
+  it('deps 里不得出现每条消息都换引用的 sessions / sessionsById', () => {
+    const source = readFileSync(
+      resolve(__dirname, '..', '..', 'CCAgentSidebarUpper.tsx'),
+      'utf8',
+    );
+    for (const name of ROW_HANDLERS) {
+      const deps = useCallbackDeps(source, name);
+      // 词边界保证 sessionsRef / sessionsByIdRef 不误伤。
+      expect(deps, `${name} 的 deps 不得含裸 sessions`).not.toMatch(/\bsessions\b/);
+      expect(deps, `${name} 的 deps 不得含裸 sessionsById`).not.toMatch(/\bsessionsById\b/);
+    }
+  });
+
+  it('runningSessionIds 必须 memo 化(否则每渲染 new Set 打穿整表)', () => {
+    const source = readFileSync(
+      resolve(__dirname, '..', '..', '..', '..', 'hooks', 'useSessionRunningStatus.ts'),
+      'utf8',
+    );
+    expect(source).toMatch(
+      /const runningSessionIds = useMemo\(\s*\(\)\s*=>\s*deriveRunningSet\(statusMap\),\s*\[statusMap\]\s*\)/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -292,6 +292,19 @@ describe('父层 — 行级 handler 的引用稳定性', () => {
     }
   });
 
+  it('handleSessionClick 的 deps 不得含每次点击/切换都变的选择态', () => {
+    // 这三个只在点击那一刻读,却会被 setSelectionAnchorSessionId(每次点击必调)
+    // 和路由切换带着变 —— 留在 deps 里等于每切换一次就整表重画一遍。
+    const source = readFileSync(
+      resolve(__dirname, '..', '..', 'CCAgentSidebarUpper.tsx'),
+      'utf8',
+    );
+    const deps = useCallbackDeps(source, 'handleSessionClick');
+    expect(deps).not.toMatch(/\bactiveSessionId\b/);
+    expect(deps).not.toMatch(/\bselectedSessionIds\b/);
+    expect(deps).not.toMatch(/\bselectionAnchorSessionId\b/);
+  });
+
   it('runningSessionIds 必须 memo 化(否则每渲染 new Set 打穿整表)', () => {
     const source = readFileSync(
       resolve(__dirname, '..', '..', '..', '..', 'hooks', 'useSessionRunningStatus.ts'),

--- a/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
@@ -37,7 +37,7 @@
  * 静默完成不走去抖(见下方分支)。
  */
 
-import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import { makerChatStore } from '@/lib/makerChatStore';
 import type { SessionStatusInfo } from '@/lib/makerChatStore';
 import {
@@ -329,7 +329,11 @@ export function useSessionRunningStatus(
   );
 
   // Derive running set for the return value (outside effect, for rendering).
-  const runningSessionIds = deriveRunningSet(statusMap);
+  // 必须 memo:裸调用每渲染都 new Set,会顺着 effectiveRunningSessionIds →
+  // handleActionClick / handleMoveSession 一路换引用,把 SessionItem 的 memo
+  // 全表打穿(见 sidebar/SessionItem.tsx 的性能不变量第 3 条)。statusMap 来自
+  // useSyncExternalStore,只在真实状态变化时换引用,故这里的缓存是安全的。
+  const runningSessionIds = useMemo(() => deriveRunningSet(statusMap), [statusMap]);
 
   return {
     /** Set of session IDs currently running. */


### PR DESCRIPTION
## 这次改了什么

### 摘要

`SessionItem` 有一条写在源码里的性能不变量（`sidebar/SessionItem.tsx`）：上游传给行的
props 必须引用稳定，否则 `memo` 失效、整栏重画（该注释记录的实测值是单次 80-96ms、
每次切换连跑 3 遍）。排查侧边栏卡顿时发现三处违反它，其中一处让这条保护在部分路径上
**从未真正生效过**：

1. `useSessionRunningStatus.ts:332` 的 `runningSessionIds` 裸调 `deriveRunningSet`，
   每次渲染都 `new Set()`。它直接进入 `handleActionClick` 的 deps、并顺着
   `effectiveRunningSessionIds` 进入 `handleMoveSession` 的 deps，使 `onAction` /
   `onMoveSession` 每渲染换引用 —— 这条路径上的 memo 一直是破的，与是否有任务在跑无关。
2. `handleSessionClick` / `handleRename` / `handleTogglePin` 的 deps 里带着
   `sessions` 或 `sessionsById`，而运行期每条消息、每次 spend 推送都让 `sessions` 换引用
   → **运行期连续重画**。
3. `handleSessionClick` 的 deps 里还有 `activeSessionId`、`selectionAnchorSessionId`、
   `selectedSessionIds.size`。普通点击分支每次都调 `setSelectionAnchorSessionId(id)`，
   路由切换也会改 `activeSessionId` → **每切换一次整表重画一遍**，任务空闲时同样存在。

修法沿用同文件既有写法（`sessionsRef` 已存在，见 `:667` / `:747` / `:987`）：把
`runningSessionIds` memo 化，补 `sessionsByIdRef` 与三个选择态 ref，让行级 handler 统一
经 ref 读值。这些值本来就只在「点击那一刻」读一次。

**两个 commit 刻意分开**，便于分别做 A/B 归因：
- `e314299` → 运行期连续重画（缺陷 1、2）
- `239d227` → 每切换一次性重画（缺陷 3）

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（源于「任务执行时侧边栏单击切不动」的用户反馈排查，见风险栏）
- 本 PR 包含：`runningSessionIds` memo 化；`sessionsByIdRef` + 5 个行级 handler 经 ref 读表；
  `handleSessionClick` 的三个选择态经 ref 读取；三条源码级回归断言
- 明确不包含：
  - **不包含对上述用户反馈的修复承诺**（因果未证实，见「风险」）
  - 不改回滚值的取数来源：`handleRename` / `handleTogglePin` 的失败回滚刻意仍读
    `sessions` 而非 `sessionsById` —— 后者含 `remoteProjectSessions`，换源会连带改变
    远程会话的回滚行为，属于另一个问题
  - 不动 `resolveSessionRemovalRedirect` / `handleConfirm`（同样带 `sessionsById`，
    但不是 `SessionItem` 的直接 props，不影响行渲染隔离）
  - 未采用「把 `onClick` 改成从 `data-session-id` 取 id 的稳定分发器」方案：需要改
    `SessionClickHandler` 签名并波及所有调用点，ref 方案等价且改动面小得多
- 用户可见变化：无新增 UI；预期收益是侧边栏行不再被无关状态变化整表重画
- 是否存在 breaking change：无

### UI 变化

不涉及

- 引用的设计规范：不涉及：本 PR 只调整 React hook 的依赖与引用缓存（`useMemo` /
  `useRef`），不改动任何布局、样式、动效、组件结构或 UI 文案，渲染结果与改动前逐像素
  一致，因此没有可引用的设计规范章节。命中 UI 路径仅因为文件位于
  `apps/desktop/src/renderer/` 下。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全绿，exit 0（25 个 workspace PASS / 0 FAIL）

pnpm --filter desktop typecheck
结果：通过，无输出

pnpm check:dco
结果：DCO check passed: 2 commits signed off

cd apps/desktop && pnpm exec vitest run \
  src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
结果：9 passed（原 6 条 + 本次新增 3 条）
```

**三条新断言都做过有效性验证**：逐一临时回退对应修复后立刻变红且报错精确
（指名 `handleRename` 的 deps 含裸 `sessions`、`runningSessionIds` 未 memo 化、
`handleSessionClick` 的 deps 含 `activeSessionId`），恢复后复绿。

同一组回退实验还实证了一件事：**现有 `sessionRowRenderIsolation` 的三条不变量在
回退后依然全绿**。它在隔离环境渲染 `SessionItem` 并喂稳定 `noop` 当 handler、从不
渲染真实父组件，结构上就抓不到「真实父组件传不稳定 props」这类问题 —— 这正是本次
三个缺陷能长期存在而测试保持绿色的原因。新增断言是为了补上这个盲区。

### 手工验证

未执行（见下）。

### 未执行的验证

- **未做运行时 profile 对比**。收益需要在可复现环境里用仓库内建探针量化：
  `perf/interaction` 的 longtask 与 `inputDelay`，对齐 `perf/session-switch` 的
  `stream:profile actual=`（对齐方法见 `CCAgentSessionView.tsx` 的探针注释）。
  探针与 `sidebar:click` 均有 `import.meta.env.DEV` 守卫，需 dev 构建。
  **建议合入前先在 main 上取一次 baseline**，否则对照窗口关闭。我这边不具备复现环境。
- 未新增渲染行为测试：验证「父组件 notify 时行不重渲染」需要挂载真实 `ExpandedView`
  并 mock router 与十余个 store，成本远超收益，故退一步用源码级断言。该断言是脆的
  （改变量名即失效），测试注释里已写明这个取舍。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：`useSessionRunningStatus` 被多处消费，但本次只是把每渲染新建的 Set 换成
  按 `statusMap` 缓存 —— `statusMap` 来自 `useSyncExternalStore`，只在真实状态变化时
  换引用，集合内容语义完全不变，仅引用变稳。handler 改经 ref 读值语义同样等价：
  它们本就只在「点击那一刻」读，ref 拿到的是最新值而非渲染时快照，不存在读旧值的
  风险，反而修掉了原先闭包捕获快照可能带来的陈旧判断。
- 回滚 / 降级方式：两个独立 commit，可整体或单独 `git revert`，无数据或协议残留。

### 需要 reviewer 特别留意的一点

**这是独立的性能修复，不要把它当成「侧边栏单击切不动」那个反馈的 fix。**
两者的因果尚未证实，尤其因为缺陷 1 与 3 都属于「与运行状态无关」的失效 —— 仅凭它们
解释不了「只有任务执行时才卡」，真正的变量更可能是运行期的重渲染频率。该反馈的定位
仍需按上面「未执行的验证」里的探针协议在可复现环境裁决。两个 commit 的 message 里也
写明了这一点，避免后续查 git log 时误判问题已解决。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
