### PR TITLE
fix(desktop): device-link OSS 上传网络层失败改走系统网络栈重试

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
@@ -322,6 +322,24 @@ describe('putBytesToOss — 传输栈回退', () => {
     );
   });
 
+  it('写入记忆时顺手清掉过期条目,长跑进程不会攒下一堆一次性 host', async () => {
+    // 清理原本只在"再次命中同一 host"时发生,多 region / 多 bucket 场景下这张
+    // 表会在 main 进程整个生命周期里只增不减。
+    __testing.electronNetPreferredHosts.set(
+      'stale-1.example',
+      Date.now() - __testing.TRANSPORT_PREFERENCE_TTL_MS - 1,
+    );
+    __testing.electronNetPreferredHosts.set('fresh.example', Date.now());
+    undiciFetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+
+    await uploadLocalFile('/tmp/a.png');
+
+    expect(__testing.electronNetPreferredHosts.has('stale-1.example')).toBe(false);
+    expect(__testing.electronNetPreferredHosts.has('fresh.example')).toBe(true);
+    expect(__testing.electronNetPreferredHosts.has('oss.example')).toBe(true);
+  });
+
   it('记忆过期后回到 undici 主路径', async () => {
     undiciFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
     __testing.electronNetPreferredHosts.set(

--- a/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
@@ -295,6 +295,33 @@ describe('putBytesToOss — 传输栈回退', () => {
     expect(__testing.electronNetPreferredHosts.get('oss.example')).toBe(firstStamp);
   });
 
+  it('记忆命中的 Electron 跳被 HTTP 拒绝 → 仍回落 undici,并清掉这条记忆', async () => {
+    // 记忆只是顺序优化,不该让结果比默认顺序更糟:Electron 是"对自定义 header
+    // 不可靠"的那条,它的 403 不能当最终结论,否则环境一变就卡到 TTL 到期。
+    __testing.electronNetPreferredHosts.set('oss.example', Date.now());
+    netFetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => '<Error/>' });
+    undiciFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+
+    const r = await uploadLocalFile('/tmp/a.png');
+
+    expect(r.key).toBe(KEY);
+    expect(netFetchMock).toHaveBeenCalledTimes(1);
+    expect(undiciFetchMock).toHaveBeenCalledTimes(1);
+    expect(__testing.electronNetPreferredHosts.has('oss.example')).toBe(false);
+  });
+
+  it('两跳都被 HTTP 拒绝 → 抛默认栈的状态码结论', async () => {
+    __testing.electronNetPreferredHosts.set('oss.example', Date.now());
+    netFetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => '' });
+    undiciFetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => '' });
+
+    await expect(uploadLocalFile('/tmp/a.png')).rejects.toThrow(/OSS PUT 失败 \(403\)/);
+    expect(apiFetch).toHaveBeenCalledWith(
+      DEL_PATH,
+      expect.objectContaining({ method: 'DELETE', body: { key: KEY } }),
+    );
+  });
+
   it('记忆过期后回到 undici 主路径', async () => {
     undiciFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
     __testing.electronNetPreferredHosts.set(

--- a/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
@@ -319,6 +319,24 @@ describe('putBytesToOss — 传输栈回退', () => {
     expect(__testing.electronNetPreferredHosts.has('oss.example')).toBe(false);
   });
 
+  it('记忆命中跳被拒 + 默认栈网络失败 → 可见串只留 errno,不混入中间态的 HTTP 码', async () => {
+    // 那一跳的 403 是"已判定不可信、已换栈"的中间态;混进可见串会把人往权限
+    // 方向带,而真正卡住的是后面这跳的网络故障。
+    __testing.electronNetPreferredHosts.set('oss.example', Date.now());
+    netFetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => '' });
+    const undiciErr = new TypeError('fetch failed');
+    undiciErr.cause = Object.assign(new Error('connect ETIMEDOUT 10.0.0.1:443'), {
+      code: 'ETIMEDOUT',
+    });
+    undiciFetchMock.mockRejectedValue(undiciErr);
+
+    const message = await uploadLocalFile('/tmp/a.png').catch((err: Error) => err.message);
+
+    expect(message).toContain('ETIMEDOUT');
+    expect(message).not.toContain('403');
+    expect(message).not.toContain('HTTP_');
+  });
+
   it('两跳都被 HTTP 拒绝 → 抛默认栈的状态码结论', async () => {
     __testing.electronNetPreferredHosts.set('oss.example', Date.now());
     netFetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => '' });

--- a/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
@@ -251,6 +251,24 @@ describe('putBytesToOss — 传输栈回退', () => {
     expect(message).not.toContain('AK-TEST');
   });
 
+  it('happy-eyeballs 的 AggregateError → 可见串仍给出地址族的真实 errno', async () => {
+    // undici 开着 autoSelectFamily 时,每个地址族的 errno 只存在于聚合分支里,
+    // 只沿 cause 链找会退化成一句没信息量的 NETWORK_ERROR。
+    const undiciErr = new TypeError('fetch failed');
+    undiciErr.cause = new AggregateError([
+      Object.assign(new Error('connect ECONNREFUSED 10.0.0.1:443'), { code: 'ECONNREFUSED' }),
+      Object.assign(new Error('connect ETIMEDOUT [::1]:443'), { code: 'ETIMEDOUT' }),
+    ]);
+    undiciFetchMock.mockRejectedValue(undiciErr);
+    netFetchMock.mockRejectedValue(new TypeError('net::ERR_PROXY_CONNECTION_FAILED'));
+
+    const message = await uploadLocalFile('/tmp/a.png').catch((err: Error) => err.message);
+
+    expect(message).toContain('ECONNREFUSED');
+    expect(message).not.toContain('NETWORK_ERROR');
+    expect(message).not.toContain('10.0.0.1');
+  });
+
   it('换栈成功后按 host 记住,下一次直接走 Electron net,不再白等 undici 超时', async () => {
     undiciFetchMock.mockRejectedValue(new TypeError('fetch failed'));
     netFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });

--- a/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
@@ -1,22 +1,27 @@
 /**
  * mediaTransfer.test.ts — device-link OSS 中转 client 的传输编排契约。
  * ---------------------------------------------------------------------------
- * mock electron net.fetch + serverApiClient.serverApiFetch + fs,只验编排:
+ * mock electron net.fetch + globalThis.fetch + serverApiClient.serverApiFetch + fs,只验编排:
  *   - 上传:小文件整体 PUT(ArrayBuffer body,带 Content-Length)/ 大文件流式 PUT(ReadableStream + duplex half)
- *   - presign 走 serverApiFetch、OSS PUT/GET 走裸 net.fetch(绝对 URL)
+ *   - presign 走 serverApiFetch、OSS PUT 走 undici(globalThis.fetch)、OSS GET 走 net.fetch(绝对 URL)
+ *   - OSS PUT 的传输栈回退:undici 网络层失败 → Electron net.fetch 重试一次
  *   - 下载整文件 / range 流式(206 不当错误,透传原始 Response)
  *   - delete 失败被吞(best-effort 清理,不阻断主流程)
  *   - ext / mime 推断
+ *
+ * 两个 fetch 分开 mock:PUT 与 GET 走的是不同网络栈(undici 不吃系统代理,
+ * Electron net 吃),把它们混成一个 mock 就测不出回退是否真的换了栈。
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createHash } from 'node:crypto';
 import { PassThrough, Readable } from 'node:stream';
 
-const fetchMock = vi.hoisted(() => vi.fn());
-// 早期(electron net.fetch 时代)mock 的是 electron.net.fetch;现在 OSS PUT/GET 走 globalThis.fetch
-// (Node undici,不受 Chromium net 栈限制),mock 改为覆盖全局 fetch。其它 GET/range 流式同此。
-vi.mock('electron', () => ({ net: { fetch: fetchMock } }));
-vi.stubGlobal('fetch', fetchMock);
+/** Electron net.fetch(Chromium 网络栈):OSS GET / range,以及 PUT 的回退跳。 */
+const netFetchMock = vi.hoisted(() => vi.fn());
+/** globalThis.fetch(Node undici):OSS PUT 主路径。 */
+const undiciFetchMock = vi.hoisted(() => vi.fn());
+vi.mock('electron', () => ({ net: { fetch: netFetchMock } }));
+vi.stubGlobal('fetch', undiciFetchMock);
 
 const apiFetch = vi.hoisted(() => vi.fn());
 vi.mock('../../serverApiClient.js', () => ({
@@ -79,11 +84,13 @@ function wirePresign() {
 }
 
 function okPut() {
-  fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+  undiciFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // 传输栈记忆跨用例泄漏会让"先走哪条栈"的断言互相污染。
+  __testing.electronNetPreferredHosts.clear();
   wirePresign();
   renameMock.mockResolvedValue(undefined);
   rmMock.mockResolvedValue(undefined);
@@ -108,7 +115,7 @@ describe('uploadLocalFile — 小文件整体 PUT', () => {
         baseUrl: 'http://relay.test:3335',
       }),
     );
-    const [url, init] = fetchMock.mock.calls[0];
+    const [url, init] = undiciFetchMock.mock.calls[0];
     expect(url).toBe('https://oss.example/put');
     expect(init.method).toBe('PUT');
     expect(init.body).toBeInstanceOf(ArrayBuffer);
@@ -136,9 +143,10 @@ describe('uploadLocalFile — 小文件整体 PUT', () => {
     );
   });
 
-  it('OSS PUT 非 2xx → 抛错', async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => '<Error/>' });
-    await expect(uploadLocalFile('/tmp/a.png')).rejects.toThrow(/OSS PUT/);
+  it('OSS PUT 非 2xx → 抛错,且不换传输栈重试(应用层拒绝,换栈没用)', async () => {
+    undiciFetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => '<Error/>' });
+    await expect(uploadLocalFile('/tmp/a.png')).rejects.toThrow(/OSS PUT 失败 \(403\)/);
+    expect(netFetchMock).not.toHaveBeenCalled();
   });
 
   it('路径不是文件 → 抛错', async () => {
@@ -150,7 +158,8 @@ describe('uploadLocalFile — 小文件整体 PUT', () => {
     statMock.mockResolvedValue({ isFile: () => true, size: __testing.MAX_MEDIA_BYTES + 1 });
     await expect(uploadLocalFile('/tmp/huge.mp4')).rejects.toThrow(/超过上限/);
     expect(apiFetch).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(undiciFetchMock).not.toHaveBeenCalled();
+    expect(netFetchMock).not.toHaveBeenCalled();
   });
 });
 
@@ -169,23 +178,137 @@ describe('uploadLocalFile — 大文件流式 PUT', () => {
         })(),
       ),
     );
-    fetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
-      if (init.body instanceof ReadableStream) {
-        const reader = init.body.getReader();
-        while (!(await reader.read()).done) {
-          /* drain like undici */
-        }
-      }
-      return { ok: true, status: 200, text: async () => '' };
-    });
+    undiciFetchMock.mockImplementation(drainingPut);
     const result = await uploadLocalFile('/tmp/big.mp4');
     expect(readFileMock).not.toHaveBeenCalled(); // 流式不读全文件
-    const [, init] = fetchMock.mock.calls[0];
+    const [, init] = undiciFetchMock.mock.calls[0];
     expect(init.body).toBeInstanceOf(ReadableStream);
     expect(init.duplex).toBe('half');
     expect(init.headers['Content-Type']).toBe('video/mp4');
     expect(result.size).toBe(size);
     expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+/**
+ * 回归:被控端在代理 / 分流网络里,undici 直连 OSS 全挂而 Electron net 能通,
+ * 导致手机端所有 OSS 中转预览(PDF / 图片原图 / 视频 / 导出分享)只回一句裸
+ * 'TypeError: fetch failed'。PUT 因此必须能换栈重试,并把 cause 展开出来。
+ */
+describe('putBytesToOss — 传输栈回退', () => {
+  /** 带签名 query 的 presign URL:用于确认错误串不外泄可复用的上传凭证。 */
+  const SIGNED_PUT_URL =
+    'https://oss-cn-hangzhou.example/bucket/obj.png?OSSAccessKeyId=AK-TEST&Signature=SECRET-SIG';
+
+  function wireSignedPresign() {
+    apiFetch.mockImplementation(async (path: string) => {
+      if (path === PUT_PATH) return { putUrl: SIGNED_PUT_URL, key: KEY, expiresAt: 'x' };
+      if (path === DEL_PATH) return { deleted: true };
+      throw new Error(`unexpected path ${path}`);
+    });
+  }
+
+  beforeEach(() => {
+    statMock.mockResolvedValue({ isFile: () => true, size: 100 });
+    readFileMock.mockResolvedValue(Buffer.alloc(100, 7));
+  });
+
+  it('undici 网络层失败 → 改走 Electron net 重试成功,PUT 契约不变', async () => {
+    undiciFetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+
+    const r = await uploadLocalFile('/tmp/a.png');
+
+    expect(r.key).toBe(KEY);
+    expect(netFetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = netFetchMock.mock.calls[0];
+    expect(url).toBe('https://oss.example/put');
+    expect(init.method).toBe('PUT');
+    // ACL header 与签名绑定:回退跳必须照带,否则 OSS 只会 403,不会静默降级成公开对象。
+    expect(init.headers['x-oss-object-acl']).toBe('private');
+    expect(init.body).toBeInstanceOf(ArrayBuffer);
+    // 上传最终成功,不该顺手把对象删掉。
+    expect(apiFetch).not.toHaveBeenCalledWith(DEL_PATH, expect.anything());
+  });
+
+  it('两跳都失败 → 错误串带 host 与展开后的 cause,且不含 presign 签名', async () => {
+    wireSignedPresign();
+    const undiciErr = new TypeError('fetch failed');
+    undiciErr.cause = Object.assign(new Error('connect ETIMEDOUT 10.0.0.1:443'), {
+      code: 'ETIMEDOUT',
+    });
+    undiciFetchMock.mockRejectedValue(undiciErr);
+    netFetchMock.mockRejectedValue(new Error('net::ERR_PROXY_CONNECTION_FAILED'));
+
+    await expect(uploadLocalFile('/tmp/a.png')).rejects.toThrow(
+      /oss-cn-hangzhou\.example.*ETIMEDOUT.*ERR_PROXY_CONNECTION_FAILED/s,
+    );
+    const message = await uploadLocalFile('/tmp/a.png').catch((err: Error) => err.message);
+    expect(message).not.toContain('SECRET-SIG');
+    expect(message).not.toContain('AK-TEST');
+  });
+
+  it('换栈成功后按 host 记住,下一次直接走 Electron net,不再白等 undici 超时', async () => {
+    undiciFetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+
+    await uploadLocalFile('/tmp/a.png');
+    expect(undiciFetchMock).toHaveBeenCalledTimes(1);
+
+    await uploadLocalFile('/tmp/b.png');
+    expect(undiciFetchMock).toHaveBeenCalledTimes(1); // 第二次没再碰 undici
+    expect(netFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('记忆过期后回到 undici 主路径', async () => {
+    undiciFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+    __testing.electronNetPreferredHosts.set(
+      'oss.example',
+      Date.now() - __testing.TRANSPORT_PREFERENCE_TTL_MS - 1,
+    );
+
+    await uploadLocalFile('/tmp/a.png');
+
+    expect(undiciFetchMock).toHaveBeenCalledTimes(1);
+    expect(netFetchMock).not.toHaveBeenCalled();
+    expect(__testing.electronNetPreferredHosts.has('oss.example')).toBe(false);
+  });
+
+  it('undici 恢复可用后清掉记忆', async () => {
+    __testing.electronNetPreferredHosts.set('oss.example', Date.now());
+    netFetchMock.mockRejectedValue(new TypeError('net::ERR_FAILED'));
+    undiciFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+
+    await uploadLocalFile('/tmp/a.png');
+
+    expect(netFetchMock).toHaveBeenCalledTimes(1); // 记忆让它先试 Electron net
+    expect(undiciFetchMock).toHaveBeenCalledTimes(1);
+    expect(__testing.electronNetPreferredHosts.has('oss.example')).toBe(false);
+  });
+
+  it('流式 body 换栈时重新开流,摘要按重传的字节算', async () => {
+    const size = __testing.STREAM_THRESHOLD + 1;
+    statMock.mockResolvedValue({ isFile: () => true, size });
+    const chunk = Buffer.alloc(1024 * 1024, 0x62);
+    const makeSource = () =>
+      Readable.from(
+        (function* chunks() {
+          for (let offset = 0; offset < __testing.STREAM_THRESHOLD; offset += chunk.length) {
+            yield chunk;
+          }
+          yield Buffer.from([0x21]);
+        })(),
+      );
+    createReadStreamMock.mockImplementation(makeSource);
+    undiciFetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    netFetchMock.mockImplementation(drainingPut);
+
+    const r = await uploadLocalFile('/tmp/big.mp4');
+
+    // 两跳各开一次流:流只能消费一次,回退不重开就会传 0 字节还算出错误摘要。
+    expect(createReadStreamMock).toHaveBeenCalledTimes(2);
+    expect(r.size).toBe(size);
+    expect(r.sha256).toMatch(/^[0-9a-f]{64}$/);
   });
 });
 
@@ -200,7 +323,7 @@ describe('uploadBuffer — 内存字节(base64 附件)', () => {
       PUT_PATH,
       expect.objectContaining({ body: { size: 5, ext: 'png', contentType: 'image/png' } }),
     );
-    const [url, init] = fetchMock.mock.calls[0];
+    const [url, init] = undiciFetchMock.mock.calls[0];
     expect(url).toBe('https://oss.example/put');
     expect(init.body).toBeInstanceOf(ArrayBuffer);
     expect(init.headers['Content-Length']).toBeUndefined();
@@ -223,7 +346,7 @@ describe('uploadBuffer — 内存字节(base64 附件)', () => {
 describe('downloadToFile — 原子完整性校验', () => {
   it('大小和 SHA-256 都匹配后才发布目标文件', async () => {
     const bytes = Uint8Array.from([1, 2, 3]);
-    fetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(bytes) });
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(bytes) });
     const expected = {
       size: bytes.byteLength,
       sha256: createHash('sha256').update(bytes).digest('hex'),
@@ -238,7 +361,7 @@ describe('downloadToFile — 原子完整性校验', () => {
 
   it('截断时删除 part 文件且不发布', async () => {
     const bytes = Uint8Array.from([1, 2, 3]);
-    fetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(bytes) });
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(bytes) });
 
     await expect(
       downloadToFile(KEY, '/tmp/final.bin', {
@@ -254,7 +377,7 @@ describe('downloadToFile — 原子完整性校验', () => {
   it('同长度内容损坏时由 SHA-256 发现并清理', async () => {
     const expectedBytes = Uint8Array.from([1, 2, 3]);
     const actualBytes = Uint8Array.from([1, 2, 4]);
-    fetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(actualBytes) });
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(actualBytes) });
 
     await expect(
       downloadToFile(KEY, '/tmp/final.bin', {
@@ -271,7 +394,7 @@ describe('downloadToFile — 原子完整性校验', () => {
 describe('downloadToBuffer', () => {
   it('presign-get + GET 整文件 → Buffer + contentType', async () => {
     const ab = new Uint8Array([1, 2, 3]).buffer;
-    fetchMock.mockResolvedValue({
+    netFetchMock.mockResolvedValue({
       ok: true,
       status: 200,
       arrayBuffer: async () => ab,
@@ -282,13 +405,13 @@ describe('downloadToBuffer', () => {
       GET_PATH,
       expect.objectContaining({ body: { key: KEY } }),
     );
-    expect(fetchMock.mock.calls[0][0]).toBe('https://oss.example/get');
+    expect(netFetchMock.mock.calls[0][0]).toBe('https://oss.example/get');
     expect([...r.bytes]).toEqual([1, 2, 3]);
     expect(r.contentType).toBe('image/png');
   });
 
   it('GET 失败 → 抛错', async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 404, text: async () => '' });
+    netFetchMock.mockResolvedValue({ ok: false, status: 404, text: async () => '' });
     await expect(downloadToBuffer(KEY)).rejects.toThrow(/OSS GET/);
   });
 });
@@ -296,23 +419,23 @@ describe('downloadToBuffer', () => {
 describe('openMediaStream — range 流式', () => {
   it('带 Range → 转发 Range 头,返回原始 206 Response(不 buffer)', async () => {
     const resp = { ok: true, status: 206, headers: { get: () => null } };
-    fetchMock.mockResolvedValue(resp);
+    netFetchMock.mockResolvedValue(resp);
     const out = await openMediaStream(KEY, 'bytes=0-1023');
-    const [url, init] = fetchMock.mock.calls[0];
+    const [url, init] = netFetchMock.mock.calls[0];
     expect(url).toBe('https://oss.example/get');
     expect(init.headers['Range']).toBe('bytes=0-1023');
     expect(out).toBe(resp); // 原样透传
   });
 
   it('无 Range → 整文件 GET,不带 Range 头', async () => {
-    fetchMock.mockResolvedValue({ ok: true, status: 200, headers: { get: () => null } });
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, headers: { get: () => null } });
     await openMediaStream(KEY);
-    const [, init] = fetchMock.mock.calls[0];
+    const [, init] = netFetchMock.mock.calls[0];
     expect(init.headers['Range']).toBeUndefined();
   });
 
   it('非 2xx/206 → 抛错', async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 500, headers: { get: () => null } });
+    netFetchMock.mockResolvedValue({ ok: false, status: 500, headers: { get: () => null } });
     await expect(openMediaStream(KEY, 'bytes=0-1')).rejects.toThrow(/OSS GET/);
   });
 });
@@ -360,15 +483,7 @@ describe('integrity regression coverage', () => {
         })(),
       ),
     );
-    fetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
-      if (init.body instanceof ReadableStream) {
-        const reader = init.body.getReader();
-        while (!(await reader.read()).done) {
-          // drain like undici
-        }
-      }
-      return { ok: true, status: 200, text: async () => '' };
-    });
+    undiciFetchMock.mockImplementation(drainingPut);
 
     await expect(uploadLocalFile('/tmp/changed.mp4')).rejects.toThrow();
     expect(apiFetch).toHaveBeenCalledWith(
@@ -377,11 +492,12 @@ describe('integrity regression coverage', () => {
     );
   });
 
-  it('deletes the OSS object when a streamed PUT fails mid-transfer', async () => {
+  it('deletes the OSS object when a streamed PUT fails on both transports', async () => {
     const size = __testing.STREAM_THRESHOLD + 1;
     statMock.mockResolvedValue({ isFile: () => true, size });
     createReadStreamMock.mockImplementation(() => Readable.from([Buffer.alloc(1024, 0x62)]));
-    fetchMock.mockRejectedValue(new Error('socket reset'));
+    undiciFetchMock.mockRejectedValue(new Error('socket reset'));
+    netFetchMock.mockRejectedValue(new Error('socket reset'));
 
     await expect(uploadLocalFile('/tmp/interrupted.mp4')).rejects.toThrow('socket reset');
     expect(apiFetch).toHaveBeenCalledWith(
@@ -398,6 +514,8 @@ describe('integrity regression coverage', () => {
     });
 
     await expect(uploadLocalFile('/tmp/source-error.mp4')).rejects.toThrow('source read failed');
+    // 源流打不开是本机故障,换传输栈重试没有意义。
+    expect(netFetchMock).not.toHaveBeenCalled();
     expect(apiFetch).toHaveBeenCalledWith(
       DEL_PATH,
       expect.objectContaining({ method: 'DELETE', body: { key: KEY } }),
@@ -406,7 +524,7 @@ describe('integrity regression coverage', () => {
 
   it('reports progress while bytes are written to the random part file', async () => {
     const bytes = Uint8Array.from([1, 2, 3]);
-    fetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(bytes) });
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, body: webBody(bytes) });
     const onProgress = vi.fn();
 
     await downloadToFile(KEY, '/tmp/final.bin', undefined, onProgress);
@@ -414,6 +532,17 @@ describe('integrity regression coverage', () => {
     expect(onProgress).toHaveBeenCalledWith(bytes.byteLength);
   });
 });
+
+/** 像 undici / Chromium 那样把流式 body 抽干后回 200(不抽干 counter 不会 flush)。 */
+async function drainingPut(_url: string, init: RequestInit) {
+  if (init.body instanceof ReadableStream) {
+    const reader = init.body.getReader();
+    while (!(await reader.read()).done) {
+      /* drain */
+    }
+  }
+  return { ok: true, status: 200, text: async () => '' };
+}
 
 function webBody(bytes: Uint8Array): ReadableStream<Uint8Array> {
   return new ReadableStream({

--- a/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
@@ -231,19 +231,22 @@ describe('putBytesToOss — 传输栈回退', () => {
     expect(apiFetch).not.toHaveBeenCalledWith(DEL_PATH, expect.anything());
   });
 
-  it('两跳都失败 → 错误串带 host 与展开后的 cause,且不含 presign 签名', async () => {
+  it('两跳都失败 → 用户可见串只留可判因的 errno,host / 完整链路 / presign 签名都不外泄', async () => {
     wireSignedPresign();
     const undiciErr = new TypeError('fetch failed');
     undiciErr.cause = Object.assign(new Error('connect ETIMEDOUT 10.0.0.1:443'), {
       code: 'ETIMEDOUT',
     });
     undiciFetchMock.mockRejectedValue(undiciErr);
-    netFetchMock.mockRejectedValue(new Error('net::ERR_PROXY_CONNECTION_FAILED'));
+    netFetchMock.mockRejectedValue(new TypeError('net::ERR_PROXY_CONNECTION_FAILED'));
 
-    await expect(uploadLocalFile('/tmp/a.png')).rejects.toThrow(
-      /oss-cn-hangzhou\.example.*ETIMEDOUT.*ERR_PROXY_CONNECTION_FAILED/s,
-    );
     const message = await uploadLocalFile('/tmp/a.png').catch((err: Error) => err.message);
+
+    expect(message).toContain('ETIMEDOUT');
+    expect(message).toContain('net::ERR_PROXY_CONNECTION_FAILED');
+    // 这条会原样显示在手机预览页:host、地址族与完整 cause 链只进主进程日志。
+    expect(message).not.toContain('oss-cn-hangzhou.example');
+    expect(message).not.toContain('10.0.0.1');
     expect(message).not.toContain('SECRET-SIG');
     expect(message).not.toContain('AK-TEST');
   });
@@ -258,6 +261,20 @@ describe('putBytesToOss — 传输栈回退', () => {
     await uploadLocalFile('/tmp/b.png');
     expect(undiciFetchMock).toHaveBeenCalledTimes(1); // 第二次没再碰 undici
     expect(netFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('命中记忆的成功不续期,TTL 到点仍会重新探测 undici', async () => {
+    undiciFetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    netFetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+    await uploadLocalFile('/tmp/a.png');
+    const firstStamp = __testing.electronNetPreferredHosts.get('oss.example');
+    expect(firstStamp).toBeTypeOf('number');
+
+    // 记忆有效期内再传若干次,时间戳必须保持首次回退那一刻。
+    await uploadLocalFile('/tmp/b.png');
+    await uploadLocalFile('/tmp/c.png');
+
+    expect(__testing.electronNetPreferredHosts.get('oss.example')).toBe(firstStamp);
   });
 
   it('记忆过期后回到 undici 主路径', async () => {
@@ -286,12 +303,13 @@ describe('putBytesToOss — 传输栈回退', () => {
     expect(__testing.electronNetPreferredHosts.has('oss.example')).toBe(false);
   });
 
-  it('流式 body 换栈时重新开流,摘要按重传的字节算', async () => {
+  it('流式 body 换栈时重新开流并关掉被放弃的那条,摘要按重传的字节算', async () => {
     const size = __testing.STREAM_THRESHOLD + 1;
     statMock.mockResolvedValue({ isFile: () => true, size });
     const chunk = Buffer.alloc(1024 * 1024, 0x62);
-    const makeSource = () =>
-      Readable.from(
+    const opened: Readable[] = [];
+    createReadStreamMock.mockImplementation(() => {
+      const source = Readable.from(
         (function* chunks() {
           for (let offset = 0; offset < __testing.STREAM_THRESHOLD; offset += chunk.length) {
             yield chunk;
@@ -299,7 +317,9 @@ describe('putBytesToOss — 传输栈回退', () => {
           yield Buffer.from([0x21]);
         })(),
       );
-    createReadStreamMock.mockImplementation(makeSource);
+      opened.push(source);
+      return source;
+    });
     undiciFetchMock.mockRejectedValue(new TypeError('fetch failed'));
     netFetchMock.mockImplementation(drainingPut);
 
@@ -307,8 +327,35 @@ describe('putBytesToOss — 传输栈回退', () => {
 
     // 两跳各开一次流:流只能消费一次,回退不重开就会传 0 字节还算出错误摘要。
     expect(createReadStreamMock).toHaveBeenCalledTimes(2);
+    // 被放弃的那条必须关掉,否则每次换栈上传都漏一个 fd。
+    expect(opened[0].destroyed).toBe(true);
     expect(r.size).toBe(size);
     expect(r.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('源流异步读盘失败 → 不换栈重试,原样抛源错误(不埋进两栈汇总里)', async () => {
+    const size = __testing.STREAM_THRESHOLD + 1;
+    statMock.mockResolvedValue({ isFile: () => true, size });
+    // 真实的 createReadStream 失败是异步 'error' 事件,不在调用点 throw。
+    createReadStreamMock.mockImplementation(
+      () =>
+        new Readable({
+          read() {
+            this.destroy(Object.assign(new Error('EIO: read failed'), { code: 'EIO' }));
+          },
+        }),
+    );
+    undiciFetchMock.mockImplementation(drainingPut);
+
+    await expect(uploadLocalFile('/tmp/broken.mp4')).rejects.toThrow('EIO: read failed');
+
+    expect(netFetchMock).not.toHaveBeenCalled();
+    expect(createReadStreamMock).toHaveBeenCalledTimes(1);
+    // 本地故障也要清掉已 presign 的对象。
+    expect(apiFetch).toHaveBeenCalledWith(
+      DEL_PATH,
+      expect.objectContaining({ method: 'DELETE', body: { key: KEY } }),
+    );
   });
 });
 
@@ -496,10 +543,12 @@ describe('integrity regression coverage', () => {
     const size = __testing.STREAM_THRESHOLD + 1;
     statMock.mockResolvedValue({ isFile: () => true, size });
     createReadStreamMock.mockImplementation(() => Readable.from([Buffer.alloc(1024, 0x62)]));
-    undiciFetchMock.mockRejectedValue(new Error('socket reset'));
-    netFetchMock.mockRejectedValue(new Error('socket reset'));
+    undiciFetchMock.mockRejectedValue(Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }));
+    netFetchMock.mockRejectedValue(new TypeError('net::ERR_CONNECTION_RESET'));
 
-    await expect(uploadLocalFile('/tmp/interrupted.mp4')).rejects.toThrow('socket reset');
+    await expect(uploadLocalFile('/tmp/interrupted.mp4')).rejects.toThrow(
+      /ECONNRESET.*net::ERR_CONNECTION_RESET/,
+    );
     expect(apiFetch).toHaveBeenCalledWith(
       DEL_PATH,
       expect.objectContaining({ method: 'DELETE', body: { key: KEY } }),

--- a/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mediaTransfer.test.ts
@@ -133,6 +133,15 @@ describe('uploadLocalFile — 小文件整体 PUT', () => {
     });
   });
 
+  it('PUT 成功后取消响应体,及时归还底层连接', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    undiciFetchMock.mockResolvedValue({ ok: true, status: 200, body: { cancel }, text: async () => '' });
+
+    await uploadLocalFile('/tmp/a.png');
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
   it('contentType 可显式覆盖', async () => {
     await uploadLocalFile('/tmp/a.bin', { contentType: 'application/x-custom' });
     expect(apiFetch).toHaveBeenCalledWith(

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -200,7 +200,11 @@ function failureHint(err: unknown): string {
  * (签名/权限/配额)。携带最终要抛给调用方的错误。
  */
 class NonRetriableOssPutError extends Error {
-  constructor(readonly inner: unknown) {
+  constructor(
+    readonly inner: unknown,
+    /** HTTP 应用层拒绝时的状态码;body 构造失败等本地故障没有。 */
+    readonly httpStatus?: number,
+  ) {
     super('non-retriable OSS PUT failure');
     this.name = 'NonRetriableOssPutError';
   }
@@ -283,19 +287,35 @@ async function putBytesToOss(
     if (!resp.ok) {
       const txt = await resp.text().catch(() => '');
       log.warn(`OSS PUT rejected status=${resp.status} host=${host} body=${txt.slice(0, 200)}`);
-      throw new NonRetriableOssPutError(new Error(`OSS PUT 失败 (${resp.status})`));
+      throw new NonRetriableOssPutError(new Error(`OSS PUT 失败 (${resp.status})`), resp.status);
     }
   };
 
+  const order = transportOrderFor(host);
+  // 记忆把 Electron 跳提到了首位——而它正是"对自定义 header 不可靠"的那条。
+  // 这种顺序下它的 HTTP 拒绝不能当最终结论,否则环境一变就要卡到 TTL 到期;
+  // 只有默认顺序(undici 先)的拒绝才权威。
+  const cachedFallbackFirst = order[0]?.name === 'electron-net';
   const failures: string[] = [];
   const hints: string[] = [];
-  for (const transport of transportOrderFor(host)) {
+  for (const transport of order) {
     try {
       await attempt(transport.impl);
     } catch (err) {
       if (err instanceof NonRetriableOssPutError) {
+        const retriableCacheArtifact =
+          cachedFallbackFirst && transport.name === 'electron-net' && err.httpStatus !== undefined;
+        if (!retriableCacheArtifact) {
+          bodySource.dispose?.();
+          throw err.inner;
+        }
+        // 这条记忆已经不值得信:清掉,让本次与后续都回到 undici 优先。
+        electronNetPreferredHosts.delete(host);
         bodySource.dispose?.();
-        throw err.inner;
+        failures.push(`${transport.name}:HTTP ${err.httpStatus}`);
+        hints.push(`HTTP_${err.httpStatus}`);
+        log.warn(`OSS PUT cached fallback rejected host=${host} status=${err.httpStatus}; retrying via undici`);
+        continue;
       }
       // 源文件读盘失败在 fetch 消费 body 时才浮出来,形态与网络失败一样;
       // 不甄别就会白读一遍磁盘,还把真实原因埋进"两条栈都失败"的汇总里。

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -331,8 +331,10 @@ async function putBytesToOss(
         // 这条记忆已经不值得信:清掉,让本次与后续都回到 undici 优先。
         electronNetPreferredHosts.delete(host);
         bodySource.dispose?.();
+        // 只进 failures(日志),不进 hints:这一跳是"已判定不可信、已换栈"的中间
+        // 态,把它的 HTTP 码混进用户可见串会把人往权限方向带,而真正卡住的是后面
+        // 那跳。默认栈自己被拒时是 non-retriable,状态码照样会原样抛出。
         failures.push(`${transport.name}:HTTP ${err.httpStatus}`);
-        hints.push(`HTTP_${err.httpStatus}`);
         log.warn(`OSS PUT cached fallback rejected host=${host} status=${err.httpStatus}; retrying via undici`);
         continue;
       }
@@ -363,7 +365,8 @@ async function putBytesToOss(
   // 用户可见串只留 errno;host 与完整 cause 链已进日志(见上面的 warn)。
   // 括号而非冒号:控制端模板本身是「取回 PDF 失败：{{detail}}」,再来一个冒号
   // 会串成两级冒号。中文标点按 i18n/GLOSSARY.md 的 zh-CN 规则用全角。
-  throw new Error(`OSS 上传失败（${[...new Set(hints)].join(' / ')}）`);
+  const visibleHints = [...new Set(hints)].join(' / ');
+  throw new Error(visibleHints ? `OSS 上传失败（${visibleHints}）` : 'OSS 上传失败');
 }
 
 /**

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -163,19 +163,34 @@ function hostOf(url: string): string {
 }
 
 /**
- * 用户可见错误只带最必要的判因线索:cause 链上第一个 errno(ETIMEDOUT /
- * ECONNREFUSED / 证书类),够反馈截图判因,又不把 host、地址族、完整链路
- * 抖到控制端界面上——那些只进主进程日志。
+ * 用户可见错误只带最必要的判因线索:第一个 errno(ETIMEDOUT / ECONNREFUSED /
+ * 证书类),够反馈截图判因,又不把 host、地址族、完整链路抖到控制端界面上
+ * ——那些只进主进程日志。
+ *
+ * 必须同时下探 `AggregateError.errors`:undici 开着 happy-eyeballs,每个地址族
+ * 的真实 errno 恰恰只存在于聚合分支里,只走 cause 链会在最典型的场景下什么码
+ * 都拿不到。
  */
 function failureHint(err: unknown): string {
-  for (let cur: unknown = err, depth = 0; cur instanceof Error && depth <= 4; depth += 1) {
+  const seen = new Set<unknown>();
+  const visit = (cur: unknown, depth: number): string | null => {
+    if (!(cur instanceof Error) || depth > 4 || seen.has(cur)) return null;
+    seen.add(cur);
     const code = (cur as NodeJS.ErrnoException).code;
     if (typeof code === 'string' && code) return code;
     // Chromium 侧不带 errno,可判因的码在 message 里(net::ERR_PROXY_CONNECTION_FAILED 等)。
     const chromiumCode = /net::ERR_[A-Z0-9_]+/.exec(cur.message);
     if (chromiumCode) return chromiumCode[0];
-    cur = cur.cause;
-  }
+    if (cur instanceof AggregateError) {
+      for (const inner of cur.errors) {
+        const hit = visit(inner, depth + 1);
+        if (hit) return hit;
+      }
+    }
+    return visit(cur.cause, depth + 1);
+  };
+  const hit = visit(err, 0);
+  if (hit) return hit;
   if (err instanceof Error) return err.name === 'TypeError' ? 'NETWORK_ERROR' : err.name;
   return 'UNKNOWN';
 }

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -354,7 +354,9 @@ async function putBytesToOss(
     return;
   }
   // 用户可见串只留 errno;host 与完整 cause 链已进日志(见上面的 warn)。
-  throw new Error(`OSS 上传失败:${[...new Set(hints)].join(' / ')}`);
+  // 括号而非冒号:控制端模板本身是「取回 PDF 失败：{{detail}}」,再来一个冒号
+  // 会串成两级冒号。中文标点按 i18n/GLOSSARY.md 的 zh-CN 规则用全角。
+  throw new Error(`OSS 上传失败（${[...new Set(hints)].join(' / ')}）`);
 }
 
 /**
@@ -458,10 +460,10 @@ export async function uploadLocalFile(
       if (!uploadedAttempt || uploadedAttempt.sent !== size) {
         // Cleanup is centralized below so transport and source-stream errors use the same path.
         throw new Error(
-          `文件在上传期间发生变化:预期 ${size} 字节,实际 ${uploadedAttempt?.sent ?? 0} 字节`,
+          `文件在上传期间发生变化：预期 ${size} 字节，实际 ${uploadedAttempt?.sent ?? 0} 字节`,
         );
       }
-      if (!uploadedAttempt.sha256) throw new Error('上传流未读完,无法确认字节摘要');
+      if (!uploadedAttempt.sha256) throw new Error('上传流未读完，无法确认字节摘要');
       sha256 = uploadedAttempt.sha256;
     }
   } catch (error) {

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -232,6 +232,18 @@ const ELECTRON_NET_TRANSPORT: OssPutTransport = {
   impl: (url, init) => net.fetch(url, init),
 };
 
+/**
+ * 记住某 host 要走 Electron 优先。顺手清掉已过期的条目:清理原本只发生在
+ * "再次命中同一 host"时,多 region / 多 bucket 场景下这张表会在 main 进程的
+ * 整个生命周期里只增不减。
+ */
+function rememberElectronNetPreference(host: string, now: number): void {
+  for (const [known, at] of electronNetPreferredHosts) {
+    if (now - at >= TRANSPORT_PREFERENCE_TTL_MS) electronNetPreferredHosts.delete(known);
+  }
+  electronNetPreferredHosts.set(host, now);
+}
+
 function transportOrderFor(host: string): OssPutTransport[] {
   const preferredAt = electronNetPreferredHosts.get(host);
   if (preferredAt !== undefined && Date.now() - preferredAt < TRANSPORT_PREFERENCE_TTL_MS) {
@@ -332,7 +344,7 @@ async function putBytesToOss(
       // 只在"确实是从 undici 失败里救回来"时记时间戳。命中记忆直接成功的不刷新,
       // 否则只要每 30 分钟内传一次文件,TTL 就永远到不了期,undici 再也不被探测。
       if (failures.length > 0) {
-        electronNetPreferredHosts.set(host, Date.now());
+        rememberElectronNetPreference(host, Date.now());
         log.info(`OSS PUT recovered via Electron net host=${host} (undici unusable: ${failures.join('; ')})`);
       }
     } else {

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -35,6 +35,7 @@ import type { AttachmentIntegrity } from '@cindy/device-link';
 import { serverApiFetch } from '../serverApiClient.js';
 import { requireAppCapability } from '../appCapabilities.js';
 import { deviceLinkApiBase } from './index.js';
+import { describeErrorChain } from '../utils/errorChain.js';
 import { createLogger } from '../logger.js';
 
 const log = createLogger('device-link:mediaTransfer');
@@ -133,29 +134,137 @@ async function presignGet(key: string): Promise<PresignGetResponse> {
   });
 }
 
-/** 裸 PUT 字节到 OSS 预签名 URL(绝对 URL,不经 serverApiFetch)。失败抛错。 */
+type OssPutBody = ArrayBuffer | ReadableStream;
+type FetchLike = (url: string, init: RequestInit) => Promise<Response>;
+
+/**
+ * presign URL 的 query 里带着可直接复用的上传签名,日志与回传给控制端的错误
+ * 只能出现 host。
+ */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return '<invalid-url>';
+  }
+}
+
+/**
+ * 换传输栈重试也没用的失败:body 构造失败(源文件读不了)与 HTTP 应用层拒绝
+ * (签名/权限/配额)。携带最终要抛给调用方的错误。
+ */
+class NonRetriableOssPutError extends Error {
+  constructor(readonly inner: unknown) {
+    super('non-retriable OSS PUT failure');
+    this.name = 'NonRetriableOssPutError';
+  }
+}
+
+/**
+ * 上次靠 Electron net 才传成功的 host → 记忆时间。ETIMEDOUT 类失败一次要等
+ * 几十秒,不记住的话用户每预览一个文件都先白等一轮 undici 超时。
+ * 带 TTL 是为了让网络环境恢复(关掉代理/换网)后自动回到主路径。
+ */
+const electronNetPreferredHosts = new Map<string, number>();
+const TRANSPORT_PREFERENCE_TTL_MS = 30 * 60 * 1000;
+
+interface OssPutTransport {
+  name: 'undici' | 'electron-net';
+  impl: FetchLike;
+}
+
+const UNDICI_TRANSPORT: OssPutTransport = {
+  name: 'undici',
+  impl: (url, init) => globalThis.fetch(url, init),
+};
+const ELECTRON_NET_TRANSPORT: OssPutTransport = {
+  name: 'electron-net',
+  impl: (url, init) => net.fetch(url, init),
+};
+
+function transportOrderFor(host: string): OssPutTransport[] {
+  const preferredAt = electronNetPreferredHosts.get(host);
+  if (preferredAt !== undefined && Date.now() - preferredAt < TRANSPORT_PREFERENCE_TTL_MS) {
+    return [ELECTRON_NET_TRANSPORT, UNDICI_TRANSPORT];
+  }
+  if (preferredAt !== undefined) electronNetPreferredHosts.delete(host);
+  return [UNDICI_TRANSPORT, ELECTRON_NET_TRANSPORT];
+}
+
+/**
+ * 裸 PUT 字节到 OSS 预签名 URL(绝对 URL,不经 serverApiFetch)。失败抛错。
+ *
+ * 传输栈两跳:默认先 undici(`globalThis.fetch`),**网络层**失败再换 Electron
+ * `net.fetch` 试一次。两者差别是致命的——undici 不吃系统代理,而本进程其它请求
+ * (presign / OSS GET)全走 `net.fetch`(Chromium 网络栈,吃系统代理、PAC 与系统
+ * 证书)。代理或分流环境下于是出现"登录、聊天、文本预览都正常,凡是要 OSS 中转
+ * 的图片 / PDF / 视频 / 导出分享全打不开"的怪象,且 undici 只回一个裸
+ * `fetch failed`,日志里看不出因。换栈成功后按 host 记住顺序,免得之后每传一个
+ * 文件都先白等一轮 undici 超时。
+ *
+ * 默认主路径仍是 undici:`x-oss-object-acl` 是 canonical header,与 server 侧
+ * signPutUrl 的签名绑定,历史上 Chromium net 栈对自定义 header 的处理让这条路
+ * 不可靠。换栈因此是安全的——若 `net.fetch` 剥掉该 header,签名不再匹配,OSS
+ * 只会返回 403,绝不会静默把对象降级成 bucket 默认的公开可读。
+ *
+ * @param createBody 每次尝试重新构造 body:流式 body 只能消费一次,换栈重试
+ *   必须重新开流(调用方据此重置进度与摘要)。
+ */
 async function putBytesToOss(
   putUrl: string,
-  body: ArrayBuffer | ReadableStream,
+  createBody: () => OssPutBody,
   contentType: string,
 ): Promise<void> {
+  const host = hostOf(putUrl);
   const headers: Record<string, string> = {
     'Content-Type': contentType,
     // device-link 媒体一律私有:对象 ACL 设 private(覆盖 public-read bucket 默认),
     // 仅 presign-get 可下载。OSS V1 签名规范要求 ACL 走 canonical header(sub-resource 白名单
     // 不含 x-oss-object-acl,放 query 会签名不匹配)。
-    // 这里走 globalThis.fetch(Node undici),不走 Electron net.fetch,不受其 header 限制。
     'x-oss-object-acl': 'private',
   };
-  const init: RequestInit & { duplex?: 'half' } = { method: 'PUT', headers, body };
-  // 流式 body 必须带 duplex:'half'(标准 fetch 要求),Buffer body 无需。
-  if (body instanceof ReadableStream) init.duplex = 'half';
-  const resp = await globalThis.fetch(putUrl, init as RequestInit);
-  if (!resp.ok) {
-    const txt = await resp.text().catch(() => '');
-    log.warn(`OSS PUT failed status=${resp.status} body=${txt.slice(0, 200)}`);
-    throw new Error(`OSS PUT 失败 (${resp.status})`);
+  const attempt = async (impl: FetchLike): Promise<void> => {
+    let body: OssPutBody;
+    try {
+      body = createBody();
+    } catch (err) {
+      throw new NonRetriableOssPutError(err);
+    }
+    const init: RequestInit & { duplex?: 'half' } = { method: 'PUT', headers, body };
+    // 流式 body 必须带 duplex:'half'(标准 fetch 要求),Buffer body 无需。
+    if (body instanceof ReadableStream) init.duplex = 'half';
+    const resp = await impl(putUrl, init as RequestInit);
+    if (!resp.ok) {
+      const txt = await resp.text().catch(() => '');
+      log.warn(`OSS PUT rejected status=${resp.status} host=${host} body=${txt.slice(0, 200)}`);
+      throw new NonRetriableOssPutError(new Error(`OSS PUT 失败 (${resp.status})`));
+    }
+  };
+
+  const failures: string[] = [];
+  for (const transport of transportOrderFor(host)) {
+    try {
+      await attempt(transport.impl);
+    } catch (err) {
+      // 应用层拒绝与源文件读不了:换栈无益,原样抛给调用方(上层据此清理 OSS 对象)。
+      if (err instanceof NonRetriableOssPutError) throw err.inner;
+      const detail = describeErrorChain(err);
+      failures.push(`${transport.name}:${detail}`);
+      log.warn(`OSS PUT transport failed host=${host} via=${transport.name}: ${detail}`);
+      continue;
+    }
+    if (transport.name === 'electron-net') {
+      electronNetPreferredHosts.set(host, Date.now());
+      if (failures.length > 0) {
+        log.info(`OSS PUT recovered via Electron net host=${host} (undici unusable: ${failures.join('; ')})`);
+      }
+    } else {
+      // undici 又通了:清掉记忆,回到默认顺序。
+      electronNetPreferredHosts.delete(host);
+    }
+    return;
   }
+  throw new Error(`OSS 上传失败(${host}):${failures.join(';')}`);
 }
 
 /**
@@ -196,29 +305,50 @@ export async function uploadLocalFile(
         throw new Error(`文件在上传前发生变化:预期 ${size} 字节,实际 ${buf.byteLength} 字节`);
       }
       sha256 = createHash('sha256').update(buf).digest('hex');
-      await putBytesToOss(putUrl, exactArrayBuffer(buf), contentType);
+      // Buffer body 可重放:回退重试直接复用同一份字节(fetch 不 transfer ArrayBuffer)。
+      await putBytesToOss(putUrl, () => exactArrayBuffer(buf), contentType);
       opts.onProgress?.(size);
     } else {
       // 大媒体:磁盘流式 PUT,避免整文件进内存;经计数 Transform 上报进度。
-      let sent = 0;
-      const hasher = createHash('sha256');
-      const counter = new Transform({
-        transform(chunk: Buffer, _enc, cb) {
-          sent += chunk.length;
-          hasher.update(chunk);
-          opts.onProgress?.(sent);
-          cb(null, chunk);
-        },
-      });
-      const webStream = Readable.toWeb(
-        createReadStream(localPath).pipe(counter),
-      ) as unknown as ReadableStream;
-      await putBytesToOss(putUrl, webStream, contentType);
-      if (sent !== size) {
-        // Cleanup is centralized below so transport and source-stream errors use the same path.
-        throw new Error(`文件在上传期间发生变化:预期 ${size} 字节,实际 ${sent} 字节`);
+      // 流只能消费一次,换传输栈重试必须重新开流。每次尝试各记各的字节数与摘要:
+      // 被放弃的那条流在 backpressure 停住前还会再推几个 chunk,共享计数会被它
+      // 串扰成"实际字节多于文件大小",于是好端端的重传被判成"文件上传期间变了"。
+      interface StreamAttempt {
+        sent: number;
+        sha256: string;
       }
-      sha256 = hasher.digest('hex');
+      const attempts: StreamAttempt[] = [];
+      const createBody = (): ReadableStream => {
+        const current: StreamAttempt = { sent: 0, sha256: '' };
+        attempts.push(current);
+        const hasher = createHash('sha256');
+        const counter = new Transform({
+          transform(chunk: Buffer, _enc, cb) {
+            current.sent += chunk.length;
+            hasher.update(chunk);
+            // 只有当前这跳有资格上报进度(控制端看到的已传字节因此可能回退一次)。
+            if (attempts.at(-1) === current) opts.onProgress?.(current.sent);
+            cb(null, chunk);
+          },
+          flush(cb) {
+            current.sha256 = hasher.digest('hex');
+            cb();
+          },
+        });
+        return Readable.toWeb(
+          createReadStream(localPath).pipe(counter),
+        ) as unknown as ReadableStream;
+      };
+      await putBytesToOss(putUrl, createBody, contentType);
+      const uploadedAttempt = attempts.at(-1);
+      if (!uploadedAttempt || uploadedAttempt.sent !== size) {
+        // Cleanup is centralized below so transport and source-stream errors use the same path.
+        throw new Error(
+          `文件在上传期间发生变化:预期 ${size} 字节,实际 ${uploadedAttempt?.sent ?? 0} 字节`,
+        );
+      }
+      if (!uploadedAttempt.sha256) throw new Error('上传流未读完,无法确认字节摘要');
+      sha256 = uploadedAttempt.sha256;
     }
   } catch (error) {
     // Cleanup is best-effort after every post-presign transfer failure.
@@ -250,7 +380,7 @@ export async function uploadBuffer(
     bytes.byteOffset + bytes.byteLength,
   ) as ArrayBuffer;
   const sha256 = createHash('sha256').update(bytes).digest('hex');
-  await putBytesToOss(putUrl, ab, contentType);
+  await putBytesToOss(putUrl, () => ab, contentType);
   log.debug(`uploaded(buffer) key=${key} size=${size} ct=${contentType} integrity=sha256`);
   return { key, size, contentType, sha256 };
 }
@@ -378,4 +508,13 @@ export async function removeRemote(key: string): Promise<void> {
   }
 }
 
-export const __testing = { extOf, mimeOf, MIME_BY_EXT, STREAM_THRESHOLD, MAX_MEDIA_BYTES };
+export const __testing = {
+  extOf,
+  mimeOf,
+  MIME_BY_EXT,
+  STREAM_THRESHOLD,
+  MAX_MEDIA_BYTES,
+  /** 传输栈记忆是模块级状态,单测之间必须清干净。 */
+  electronNetPreferredHosts,
+  TRANSPORT_PREFERENCE_TTL_MS,
+};

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -138,6 +138,19 @@ type OssPutBody = ArrayBuffer | ReadableStream;
 type FetchLike = (url: string, init: RequestInit) => Promise<Response>;
 
 /**
+ * 可重放的 PUT body 供给者。换传输栈重试必须重新构造 body(流只能消费一次),
+ * 同时要能分辨"这一跳失败是网络问题还是本地读盘问题",并释放上一跳的资源。
+ */
+interface OssPutBodySource {
+  /** 构造本跳的 body。抛错视为不可重试(源打不开,换栈无益)。 */
+  create(): OssPutBody;
+  /** 本跳是否因**本地源**出错而失败;返回原错误则不换栈重试。 */
+  localFailure?(): unknown;
+  /** 放弃本跳:关掉底层文件流,别让被丢弃的 body 攥着 fd 与缓冲。 */
+  dispose?(): void;
+}
+
+/**
  * presign URL 的 query 里带着可直接复用的上传签名,日志与回传给控制端的错误
  * 只能出现 host。
  */
@@ -147,6 +160,24 @@ function hostOf(url: string): string {
   } catch {
     return '<invalid-url>';
   }
+}
+
+/**
+ * 用户可见错误只带最必要的判因线索:cause 链上第一个 errno(ETIMEDOUT /
+ * ECONNREFUSED / 证书类),够反馈截图判因,又不把 host、地址族、完整链路
+ * 抖到控制端界面上——那些只进主进程日志。
+ */
+function failureHint(err: unknown): string {
+  for (let cur: unknown = err, depth = 0; cur instanceof Error && depth <= 4; depth += 1) {
+    const code = (cur as NodeJS.ErrnoException).code;
+    if (typeof code === 'string' && code) return code;
+    // Chromium 侧不带 errno,可判因的码在 message 里(net::ERR_PROXY_CONNECTION_FAILED 等)。
+    const chromiumCode = /net::ERR_[A-Z0-9_]+/.exec(cur.message);
+    if (chromiumCode) return chromiumCode[0];
+    cur = cur.cause;
+  }
+  if (err instanceof Error) return err.name === 'TypeError' ? 'NETWORK_ERROR' : err.name;
+  return 'UNKNOWN';
 }
 
 /**
@@ -207,12 +238,12 @@ function transportOrderFor(host: string): OssPutTransport[] {
  * 不可靠。换栈因此是安全的——若 `net.fetch` 剥掉该 header,签名不再匹配,OSS
  * 只会返回 403,绝不会静默把对象降级成 bucket 默认的公开可读。
  *
- * @param createBody 每次尝试重新构造 body:流式 body 只能消费一次,换栈重试
- *   必须重新开流(调用方据此重置进度与摘要)。
+ * 只有**网络层**失败才换栈:HTTP 应用层拒绝(签名/权限/配额)与本地源读盘失败
+ * 换栈都无益,原样抛给调用方,免得白传一遍还把原因掩盖成"两条栈都失败"。
  */
 async function putBytesToOss(
   putUrl: string,
-  createBody: () => OssPutBody,
+  bodySource: OssPutBodySource,
   contentType: string,
 ): Promise<void> {
   const host = hostOf(putUrl);
@@ -226,7 +257,7 @@ async function putBytesToOss(
   const attempt = async (impl: FetchLike): Promise<void> => {
     let body: OssPutBody;
     try {
-      body = createBody();
+      body = bodySource.create();
     } catch (err) {
       throw new NonRetriableOssPutError(err);
     }
@@ -242,20 +273,31 @@ async function putBytesToOss(
   };
 
   const failures: string[] = [];
+  const hints: string[] = [];
   for (const transport of transportOrderFor(host)) {
     try {
       await attempt(transport.impl);
     } catch (err) {
-      // 应用层拒绝与源文件读不了:换栈无益,原样抛给调用方(上层据此清理 OSS 对象)。
-      if (err instanceof NonRetriableOssPutError) throw err.inner;
+      if (err instanceof NonRetriableOssPutError) {
+        bodySource.dispose?.();
+        throw err.inner;
+      }
+      // 源文件读盘失败在 fetch 消费 body 时才浮出来,形态与网络失败一样;
+      // 不甄别就会白读一遍磁盘,还把真实原因埋进"两条栈都失败"的汇总里。
+      const localFailure = bodySource.localFailure?.();
+      bodySource.dispose?.();
+      if (localFailure !== undefined && localFailure !== null) throw localFailure;
       const detail = describeErrorChain(err);
       failures.push(`${transport.name}:${detail}`);
+      hints.push(failureHint(err));
       log.warn(`OSS PUT transport failed host=${host} via=${transport.name}: ${detail}`);
       continue;
     }
     if (transport.name === 'electron-net') {
-      electronNetPreferredHosts.set(host, Date.now());
+      // 只在"确实是从 undici 失败里救回来"时记时间戳。命中记忆直接成功的不刷新,
+      // 否则只要每 30 分钟内传一次文件,TTL 就永远到不了期,undici 再也不被探测。
       if (failures.length > 0) {
+        electronNetPreferredHosts.set(host, Date.now());
         log.info(`OSS PUT recovered via Electron net host=${host} (undici unusable: ${failures.join('; ')})`);
       }
     } else {
@@ -264,7 +306,8 @@ async function putBytesToOss(
     }
     return;
   }
-  throw new Error(`OSS 上传失败(${host}):${failures.join(';')}`);
+  // 用户可见串只留 errno;host 与完整 cause 链已进日志(见上面的 warn)。
+  throw new Error(`OSS 上传失败:${[...new Set(hints)].join(' / ')}`);
 }
 
 /**
@@ -305,8 +348,9 @@ export async function uploadLocalFile(
         throw new Error(`文件在上传前发生变化:预期 ${size} 字节,实际 ${buf.byteLength} 字节`);
       }
       sha256 = createHash('sha256').update(buf).digest('hex');
-      // Buffer body 可重放:回退重试直接复用同一份字节(fetch 不 transfer ArrayBuffer)。
-      await putBytesToOss(putUrl, () => exactArrayBuffer(buf), contentType);
+      // Buffer body 可重放:换栈重试直接复用同一份字节(fetch 不 transfer ArrayBuffer),
+      // 也没有需要释放的底层资源。
+      await putBytesToOss(putUrl, { create: () => exactArrayBuffer(buf) }, contentType);
       opts.onProgress?.(size);
     } else {
       // 大媒体:磁盘流式 PUT,避免整文件进内存;经计数 Transform 上报进度。
@@ -316,30 +360,53 @@ export async function uploadLocalFile(
       interface StreamAttempt {
         sent: number;
         sha256: string;
+        sourceError: unknown;
+        dispose(): void;
       }
       const attempts: StreamAttempt[] = [];
-      const createBody = (): ReadableStream => {
-        const current: StreamAttempt = { sent: 0, sha256: '' };
-        attempts.push(current);
-        const hasher = createHash('sha256');
-        const counter = new Transform({
-          transform(chunk: Buffer, _enc, cb) {
-            current.sent += chunk.length;
-            hasher.update(chunk);
-            // 只有当前这跳有资格上报进度(控制端看到的已传字节因此可能回退一次)。
-            if (attempts.at(-1) === current) opts.onProgress?.(current.sent);
-            cb(null, chunk);
-          },
-          flush(cb) {
-            current.sha256 = hasher.digest('hex');
-            cb();
-          },
-        });
-        return Readable.toWeb(
-          createReadStream(localPath).pipe(counter),
-        ) as unknown as ReadableStream;
+      const bodySource: OssPutBodySource = {
+        create(): ReadableStream {
+          const source = createReadStream(localPath);
+          const hasher = createHash('sha256');
+          const current: StreamAttempt = {
+            sent: 0,
+            sha256: '',
+            sourceError: null,
+            dispose() {
+              source.destroy();
+              counter.destroy();
+            },
+          };
+          const counter = new Transform({
+            transform(chunk: Buffer, _enc, cb) {
+              current.sent += chunk.length;
+              hasher.update(chunk);
+              // 只有当前这跳有资格上报进度(控制端看到的已传字节因此可能回退一次)。
+              if (attempts.at(-1) === current) opts.onProgress?.(current.sent);
+              cb(null, chunk);
+            },
+            flush(cb) {
+              current.sha256 = hasher.digest('hex');
+              cb();
+            },
+          });
+          // 读盘失败多半是异步 'error' 事件,到 putBytesToOss 手里只是一个
+          // "fetch 消费 body 时挂了",与网络失败长得一模一样——记下来供其甄别。
+          // 必须同时把错误推给下游:`pipe` 不转发 error,只记不推的话 counter
+          // 既不 end 也不 error,web body 就此挂住,PUT 会一直干等到超时。
+          source.on('error', (err) => {
+            current.sourceError = err;
+            counter.destroy(err);
+          });
+          attempts.push(current);
+          return Readable.toWeb(source.pipe(counter)) as unknown as ReadableStream;
+        },
+        localFailure: () => attempts.at(-1)?.sourceError ?? null,
+        // 被放弃的 body 不主动关掉的话,底层 createReadStream 会一直攥着 fd 与
+        // 已缓冲的数据,每次换栈上传都漏一个。
+        dispose: () => attempts.at(-1)?.dispose(),
       };
-      await putBytesToOss(putUrl, createBody, contentType);
+      await putBytesToOss(putUrl, bodySource, contentType);
       const uploadedAttempt = attempts.at(-1);
       if (!uploadedAttempt || uploadedAttempt.sent !== size) {
         // Cleanup is centralized below so transport and source-stream errors use the same path.
@@ -380,7 +447,7 @@ export async function uploadBuffer(
     bytes.byteOffset + bytes.byteLength,
   ) as ArrayBuffer;
   const sha256 = createHash('sha256').update(bytes).digest('hex');
-  await putBytesToOss(putUrl, () => ab, contentType);
+  await putBytesToOss(putUrl, { create: () => ab }, contentType);
   log.debug(`uploaded(buffer) key=${key} size=${size} ct=${contentType} integrity=sha256`);
   return { key, size, contentType, sha256 };
 }

--- a/apps/desktop/src/main/device-link/mediaTransfer.ts
+++ b/apps/desktop/src/main/device-link/mediaTransfer.ts
@@ -301,6 +301,13 @@ async function putBytesToOss(
       log.warn(`OSS PUT rejected status=${resp.status} host=${host} body=${txt.slice(0, 200)}`);
       throw new NonRetriableOssPutError(new Error(`OSS PUT 失败 (${resp.status})`), resp.status);
     }
+    // PUT 的成功响应体用不上,但不消费/取消的话底层连接不会及时归还
+    // (与 provider-diagnostics 的非流式探测同一处理)。
+    try {
+      await resp.body?.cancel();
+    } catch {
+      /* no-op */
+    }
   };
 
   const order = transportOrderFor(host);

--- a/apps/desktop/src/main/file-browser/device-op.ts
+++ b/apps/desktop/src/main/file-browser/device-op.ts
@@ -576,8 +576,11 @@ async function handleRemoteOp(args: RemoteOpArgs): Promise<unknown> {
             setExportJobTerminal(transferId, { state: 'done', key: up.key, size: up.size, uploaded: up.size });
           })
           .catch((err) => {
-            log.warn('exportFile upload failed', { transferId, error: String(err) });
-            setExportJobTerminal(transferId, { state: 'error', message: String(err), size: st.size, uploaded: 0 });
+            // message 而非 String(err):这条会原样显示在控制端(手机预览页)的失败
+            // 占位上,'Error: ' / 'TypeError: ' 前缀对用户没有意义。
+            const message = err instanceof Error ? err.message : String(err);
+            log.warn('exportFile upload failed', { transferId, error: message });
+            setExportJobTerminal(transferId, { state: 'error', message, size: st.size, uploaded: 0 });
           });
         return { ok: true as const, transferId, size: st.size, mtimeMs: st.mtimeMs };
       } catch (err) {

--- a/apps/desktop/src/main/file-browser/device-op.ts
+++ b/apps/desktop/src/main/file-browser/device-op.ts
@@ -577,8 +577,9 @@ async function handleRemoteOp(args: RemoteOpArgs): Promise<unknown> {
           })
           .catch((err) => {
             // message 而非 String(err):这条会原样显示在控制端(手机预览页)的失败
-            // 占位上,'Error: ' / 'TypeError: ' 前缀对用户没有意义。
-            const message = err instanceof Error ? err.message : String(err);
+            // 占位上,'Error: ' / 'TypeError: ' 前缀对用户没有意义。message 为空时
+            // 回落到错误名,别让控制端收到空串。
+            const message = err instanceof Error ? err.message || err.name : String(err);
             log.warn('exportFile upload failed', { transferId, error: message });
             setExportJobTerminal(transferId, { state: 'error', message, size: st.size, uploaded: 0 });
           });

--- a/apps/desktop/src/main/file-browser/device-op.ts
+++ b/apps/desktop/src/main/file-browser/device-op.ts
@@ -576,11 +576,12 @@ async function handleRemoteOp(args: RemoteOpArgs): Promise<unknown> {
             setExportJobTerminal(transferId, { state: 'done', key: up.key, size: up.size, uploaded: up.size });
           })
           .catch((err) => {
-            // message 而非 String(err):这条会原样显示在控制端(手机预览页)的失败
-            // 占位上,'Error: ' / 'TypeError: ' 前缀对用户没有意义。message 为空时
-            // 回落到错误名,别让控制端收到空串。
+            // 回包用 message 而非 String(err):这条会原样显示在控制端(手机预览页)
+            // 的失败占位上,'Error: ' / 'TypeError: ' 前缀对用户没有意义。message
+            // 为空时回落到错误名,别让控制端收到空串。
             const message = err instanceof Error ? err.message || err.name : String(err);
-            log.warn('exportFile upload failed', { transferId, error: message });
+            // 日志单独带原始 error(stack 与 cause 链都要留着排障),不跟着回包降级成字符串。
+            log.warn('exportFile upload failed', { transferId }, err);
             setExportJobTerminal(transferId, { state: 'error', message, size: st.size, uploaded: 0 });
           });
         return { ok: true as const, transferId, size: st.size, mtimeMs: st.mtimeMs };

--- a/apps/desktop/src/main/maker-host/__tests__/claudeOauthLoginErrorChain.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeOauthLoginErrorChain.test.ts
@@ -64,6 +64,16 @@ describe('describeErrorChain', () => {
     expect(describeErrorChain(noMsg)).toBe('ETIMEDOUT');
   });
 
+  it('AggregateError 分支同样补 code / 回退空 message,不在聚合段留空洞', () => {
+    const bareCode = Object.assign(new Error(''), { code: 'ECONNREFUSED' });
+    const needsAnnotation = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    const aggregate = new AggregateError([bareCode, needsAnnotation], '');
+    const top = new TypeError('fetch failed', { cause: aggregate });
+
+    const out = describeErrorChain(top);
+    expect(out).toContain('[ECONNREFUSED; socket hang up (ECONNRESET)]');
+  });
+
   it('cause 链深度有界:超过上限截断,不无限展开', () => {
     let leaf: Error = new Error('depth-7');
     for (let i = 6; i >= 1; i -= 1) {

--- a/apps/desktop/src/main/maker-host/claude-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/claude-oauth-login.ts
@@ -25,6 +25,7 @@ import {
   renderOAuthResultPage,
   type OAuthResultPageLang,
 } from '../oauthResultPage.js';
+import { describeErrorChain } from '../utils/errorChain.js';
 import { desktopMakerLogger } from './logger-adapter.js';
 import { writeClaudeAiOAuth } from './claude-credentials-store.js';
 import { bindNativeProviderAuth } from './nativeProviderAuthBinding.js';
@@ -69,27 +70,9 @@ function parseScopes(scopeString?: string): string[] {
   return scopeString?.split(' ').filter(Boolean) ?? [];
 }
 
-const MAX_CAUSE_DEPTH = 4;
-
-// undici 把网络层失败包成裸 'fetch failed' TypeError,可行动的细节(每个地址族的
-// connect ETIMEDOUT / ECONNREFUSED)藏在 cause 链和 AggregateError.errors 里 ——
-// 只记 message 的话日志里永远只剩 'fetch failed',区分不了"端点挂了"和"本机网络路径断了"。
-export function describeErrorChain(err: unknown): string {
-  if (!(err instanceof Error)) return String(err);
-  const parts: string[] = [];
-  let current: unknown = err;
-  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && current instanceof Error; depth += 1) {
-    const code = (current as NodeJS.ErrnoException).code;
-    let part = current.message || (code ? String(code) : current.name);
-    if (code && current.message && !current.message.includes(String(code))) part += ` (${code})`;
-    if (current instanceof AggregateError && current.errors.length > 0) {
-      part += ` [${current.errors.map((e) => (e instanceof Error ? e.message : String(e))).join('; ')}]`;
-    }
-    parts.push(part);
-    current = current.cause;
-  }
-  return parts.filter(Boolean).join(' <- ');
-}
+// 实现搬到 main/utils/errorChain.ts(device-link OSS 上传也要展开 undici 的
+// 裸 'fetch failed');这里保留导出,原有调用方与单测的 import 路径不变。
+export { describeErrorChain };
 
 function buildAuthUrl(opts: { codeChallenge: string; state: string; port: number }): string {
   const url = new URL(CLAUDE_AI_AUTHORIZE_URL);

--- a/apps/desktop/src/main/utils/errorChain.ts
+++ b/apps/desktop/src/main/utils/errorChain.ts
@@ -1,0 +1,29 @@
+/**
+ * errorChain.ts — 网络/IO 错误链展开(main 侧通用)。
+ *
+ * undici 把一切网络层失败包成裸 `TypeError: fetch failed`,可行动的细节
+ * (connect ETIMEDOUT / ECONNREFUSED / 证书错误,以及 happy-eyeballs 下每个
+ * 地址族各自的失败)全藏在 `cause` 链与 `AggregateError.errors` 里。只记
+ * `err.message` 的日志永远只剩 'fetch failed',区分不了"端点挂了"和"本机
+ * 网络路径断了",线上反馈拿回来也没法判因。
+ */
+
+const MAX_CAUSE_DEPTH = 4;
+
+/** 把 Error 的 cause 链(含 AggregateError 分支)拍平成单行可读诊断串。 */
+export function describeErrorChain(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const parts: string[] = [];
+  let current: unknown = err;
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && current instanceof Error; depth += 1) {
+    const code = (current as NodeJS.ErrnoException).code;
+    let part = current.message || (code ? String(code) : current.name);
+    if (code && current.message && !current.message.includes(String(code))) part += ` (${code})`;
+    if (current instanceof AggregateError && current.errors.length > 0) {
+      part += ` [${current.errors.map((e) => (e instanceof Error ? e.message : String(e))).join('; ')}]`;
+    }
+    parts.push(part);
+    current = current.cause;
+  }
+  return parts.filter(Boolean).join(' <- ');
+}

--- a/apps/desktop/src/main/utils/errorChain.ts
+++ b/apps/desktop/src/main/utils/errorChain.ts
@@ -10,17 +10,30 @@
 
 const MAX_CAUSE_DEPTH = 4;
 
+/**
+ * 单个 Error → 可读片段:message 为空时回退 errno / name,message 不含 errno
+ * 时补注。空 message + 带 code 的形态在 undici 里真实存在,直接取 message 会
+ * 在诊断串里留下空段。
+ */
+function describeSingle(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const code = (err as NodeJS.ErrnoException).code;
+  let part = err.message || (code ? String(code) : err.name);
+  if (code && err.message && !err.message.includes(String(code))) part += ` (${code})`;
+  return part;
+}
+
 /** 把 Error 的 cause 链(含 AggregateError 分支)拍平成单行可读诊断串。 */
 export function describeErrorChain(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
   const parts: string[] = [];
   let current: unknown = err;
   for (let depth = 0; depth <= MAX_CAUSE_DEPTH && current instanceof Error; depth += 1) {
-    const code = (current as NodeJS.ErrnoException).code;
-    let part = current.message || (code ? String(code) : current.name);
-    if (code && current.message && !current.message.includes(String(code))) part += ` (${code})`;
+    let part = describeSingle(current);
     if (current instanceof AggregateError && current.errors.length > 0) {
-      part += ` [${current.errors.map((e) => (e instanceof Error ? e.message : String(e))).join('; ')}]`;
+      // 聚合分支同样走 describeSingle:happy-eyeballs 的地址族错误正是最需要
+      // errno 的地方,只取 message 会丢码、空 message 还会留下空段。
+      part += ` [${current.errors.map(describeSingle).filter(Boolean).join('; ')}]`;
     }
     parts.push(part);
     current = current.cause;


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户反馈手机端文件"基本打不开"，预览页统一报 `取回 PDF 失败：TypeError: fetch failed`。

顺链路定位：手机看到的 `{{detail}}` 是被控桌面端原样回传的字符串，`fetch failed` 是 Node undici 的特征文案（RN 侧的网络失败是 `Network request failed`）。链路是 `exportRemoteFileToUrl` → 被控端 `exportFileStart` → `uploadLocalFile` → `presignPut`（走 `net.fetch`，成功）→ `putBytesToOss` 的 `globalThis.fetch`（失败）。presign 走 `serverApiFetch`，它把任何网络失败都吞成 `请求失败 (0)`，不可能吐出 `TypeError: fetch failed`，所以卡点唯一。

而 `putBytesToOss` 是整条媒体链路里**唯一**走 undici 的一跳：presign、`downloadToBuffer`、`openMediaStream`、`downloadToFile` 全部走 Electron `net.fetch`。两者的差别是致命的——undici 不吃系统代理，`net.fetch` 走 Chromium 网络栈（吃系统代理、PAC、系统证书）。代理 / 分流环境下于是恰好呈现"登录、聊天、文本预览都正常，凡是要 OSS 中转的图片 / PDF / 视频 / 导出分享全打不开"，而 undici 只回一个裸 `fetch failed`，日志里连 errno 都没有。

本 PR 做两件事：让 PUT 在网络层失败后换到系统网络栈重试（真是代理问题就直接自愈），并把 undici 的 `cause` 链展开出来（不是代理问题时，下一份反馈能带回可判因的 errno，而不是再一句 `fetch failed`）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户反馈截图）
- 本 PR 包含：
  - `putBytesToOss` 改为两跳传输：默认 undici，**网络层**失败换 Electron `net.fetch` 重试一次。HTTP 非 2xx（403 等）与 body 构造失败（源文件读不了）不换栈——换了也没用，原样抛给调用方走既有的 OSS 对象清理路径。
  - 一个不变量：**传输栈记忆只是顺序优化，不允许让结果比默认顺序更糟**。所以记忆命中时被提到首位的 Electron 跳若收到 HTTP 拒绝，会清掉记忆并继续试 undici——只有默认顺序（undici 先）的拒绝才权威（review 指出）。
  - 换栈成功后按 host 记 30 分钟。`ETIMEDOUT` 型故障一次要等几十秒，不记住的话用户每预览一个文件都先白等一轮 undici 超时；undici 恢复或记忆过期自动回到默认顺序。时间戳只在"确实从一次 undici 失败里救回来"时写——命中记忆的成功也刷新的话，只要每 30 分钟内传一次文件 TTL 就永不到期（review 指出）。
  - 只有**网络层**失败换栈。HTTP 应用层拒绝与本地源读盘失败都原样抛出：源流的读盘失败多是异步 `error` 事件，在 fetch 消费 body 时才浮出来，形态与网络失败一样，不甄别就会白读一遍磁盘、还把真实原因埋进"两条栈都失败"的汇总里（review 指出）。
  - 源流出错时同步 `destroy` 下游 counter。`pipe` 不转发 error，只记不推的话 counter 既不 end 也不 error，web body 会一直挂住让 PUT 干等到超时——这是顺带修掉的既有缺陷。
  - 换栈或放弃时显式 `dispose` 上一跳的 body，否则 `createReadStream` 会一直攥着 fd 与已缓冲数据，每次换栈上传漏一个（review 指出）。
  - 失败诊断展开 undici 的 `cause` 链与 `AggregateError.errors`，写进主进程日志；**用户可见串只留与语言无关的 errno**（`ETIMEDOUT` / `net::ERR_*`），host、地址族、完整链路都不外泄到控制端界面。errno 提取同样下探 `AggregateError.errors`——undici 开着 happy-eyeballs 时，每个地址族的真实 errno 只存在于聚合分支里（review 指出）。
  - 流式 body 每跳重新开流，且每跳各记各的字节数与摘要。被放弃的那条流在 backpressure 停住前还会再推几个 chunk，共享计数会被串扰成"实际字节多于文件大小"，把正常重传误判成"文件在上传期间变了"——这是新增测试实际抓到的，不是预防性设计。
  - `describeErrorChain` 从 `maker-host/claude-oauth-login.ts` 抽到 `main/utils/errorChain.ts` 共用，原文件保留 re-export（既有调用方与单测 import 路径不变）。
  - `exportFile` 失败回包改用 `err.message`（为空时回落 `err.name`）：这条会原样显示在手机预览页的失败占位上，`TypeError: ` / `Error: ` 前缀对用户没有意义。
- 明确不包含：
  - 不改主路径的传输栈选择（undici 仍是默认）。`x-oss-object-acl` 是 canonical header、与服务端 `signPutUrl` 的签名绑定，当初绕开 Chromium net 栈是有原因的，本 PR 不推翻这个取舍，只在它失效时兜底。
  - 不动服务端 presign 签名方式（跨仓）。
  - 不改被控端错误 detail 的 i18n 形态（见下方"已知限制"）。
- 用户可见变化：手机端文件预览 / 导出分享在代理环境下能打开；失败时看到的不再是 `TypeError: fetch failed`，而是 `取回 PDF 失败：OSS 上传失败（ETIMEDOUT）` 这类带 errno 的可判因描述。
- 是否存在 breaking change：无。

### UI 变化

不涉及：只改 main 进程传输实现与错误字符串，没有界面、组件、布局、样式或 UI 文案改动。手机端展示的失败文案模板（`files.preview.fetchPdfFailed` 等）未改，只是插值内容变得可读。

- 引用的设计规范：不涉及

### 远程连接与手机版适配（`docs/dev-rules/remote-and-mobile-adaptation.md` 三问）

1. **SSH 远程工作区**：本改动在 `uploadLocalFile` 的 OSS 传输层，位于 SSH 物化之后（`materializeSshRemoteMedia` 已把远端字节落到本地缓存路径再交给上传）。SSH 通道本身不受影响，且同样受益于这次的换栈重试。
2. **IPC / 推送白名单**：未新增或修改任何 IPC channel、推送事件或 device-link 白名单条目，走的是既有的 `exportFileStart` / `exportFileStatus` / `device-link:media:fetch`。
3. **手机版入口 / UI**：无需新增。本 PR 修的正是手机版既有入口（文件浏览、预览、导出分享）在代理环境下的失效，手机侧代码零改动。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/device-link/__tests__/mediaTransfer.test.ts
结果：40 passed

pnpm --filter desktop exec vitest run src/main/device-link src/main/file-browser \
  src/main/maker-host/__tests__/claudeOauthLoginErrorChain.test.ts
结果：23 files / 327 passed（device-link + file-browser + errorChain）

pnpm --filter desktop typecheck
结果：通过

npx eslint src/main/device-link/mediaTransfer.ts src/main/utils/errorChain.ts \
  src/main/file-browser/device-op.ts src/main/maker-host/claude-oauth-login.ts \
  src/main/device-link/__tests__/mediaTransfer.test.ts
结果：通过（exit 0）

pnpm check:i18n-glossary
结果：通过（术语表 27 条已裁决，四语无新增违规）

pnpm test:unit（仓库根全量门禁，经 run-unit-gate.sh 清污染变量后跑）
结果：GATE_EXIT=0
```

测试侧把 `electron.net.fetch` 与 `globalThis.fetch` 拆成两个独立 mock——原来两者混成同一个 mock，测不出回退是否真的换了栈。新增覆盖：

- undici 网络层失败 → 换 `net.fetch` 成功，且回退跳照带 `x-oss-object-acl`
- HTTP 403 → 不换栈重试
- 源流打不开 → 不换栈重试
- 源流**异步** `destroy(error)` → 不换栈重试、原样抛源错误、仍清理已 presign 的对象
- happy-eyeballs 的 `AggregateError`（`[ECONNREFUSED, ETIMEDOUT]`）→ 可见串给出真实 errno 而非 `NETWORK_ERROR`
- 记忆命中的 Electron 跳 403 + undici 200 → 上传成功且记忆被清除；两跳都 403 → 抛 `OSS PUT 失败 (403)` 并清理对象；记忆命中跳 403 + undici `ETIMEDOUT` → 可见串只留 `ETIMEDOUT`（换栈中间态的 HTTP 码不外泄）
- PUT 成功后 `cancel()` 响应体（及时归还连接）
- 写入记忆时清掉过期条目（长跑进程不攒一次性 host）
- `describeErrorChain` 的聚合分支：空 message + 带 code 的 inner error 不留空段、不丢 errno
- host 记忆：命中后第二次直接走 `net.fetch`；命中记忆的成功不续期（时间戳保持首次那一刻）；TTL 过期回到 undici；undici 恢复后清掉记忆
- 流式 body 换栈时重新开流（`createReadStream` 被调用两次），被放弃的那条 `destroyed === true`，摘要按重传字节算
- 两跳都失败时可见串含 errno、不含 host / IP / presign 签名

### 手工验证

未做真机验证（与提交者确认后跳过）。本机复现不了原故障：日志里没有 `exportFile upload failed` / `OSS PUT failed` 记录，说明本机 undici 直连 OSS 是通的，真机跑一遍只能验证"没有回归"，验不出"修好了"。

### 未执行的验证

- 代理 / 分流网络下的端到端真机验证：手上没有能复现的网络环境。
- **根因未实证**：`fetch failed` 卡在 `putBytesToOss` 是确定的（见摘要的排除推理），但"因为 undici 不吃系统代理"是最强嫌疑而非实测结论。这也是本 PR 同时补诊断的原因——若换栈没解决，下一份用户截图会带回 errno（`ECONNREFUSED` / `ETIMEDOUT` / 证书 / DNS），主进程日志里还有 host 与完整 cause 链，足以判因。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：device-link 全部出/入方向的 OSS 上传（手机预览取件、导出分享、控制端发附件）。成功路径的行为与之前完全一致——undici 通的时候一次就成，不会多发请求。

- **安全面（两处，都已按"失败而非降级"处理）**：
  1. **ACL 不会被静默降级**。`x-oss-object-acl: private` 是 canonical header，与服务端 `signPutUrl` 的签名绑定。若回退跳的 `net.fetch` 剥掉该 header，签名不再匹配，OSS 只会返回 403（这也是当初绕开 Chromium net 栈的原因），绝不会变成 bucket 默认的 public-read。测试断言了回退跳照带该 header。
  2. **presign 签名不外泄**。putUrl 的 query 里是可直接复用的上传凭证：日志只取 `new URL(putUrl).host`，回传控制端的错误串连 host 都不带、只留 errno。测试断言错误消息不含 host / IP / `Signature` / `OSSAccessKeyId`。

- 失败语义未变：两跳都失败仍抛错，仍走 `removeRemote(key)` 清掉已 presign 的对象；上层的 `exportJobs` 终态、`media:fetch` 错误码保持不变。

- 回滚 / 降级方式：改动集中在 `putBytesToOss` 与其两个调用点，`git revert` 单个 commit 即可回到"只走 undici"的旧行为，无数据迁移、无持久化状态（host 记忆是进程内 Map，重启即清）。

### 已知限制 / 待跟踪（不在本 PR 范围）

**被控端错误 detail 未做跨端错误码化。** `exportFileStatus` 回包的 `message` 是既有协议字段，被控端塞进去的一整类中文串（`OSS PUT 失败 (403)`、`文件超过上限 2GB`、`媒体文件不存在或不可读`、`该路径位于敏感目录，已阻止远程取件`…）都会原样进手机端 `files.preview.*` 的 `{{detail}}` 插值，不随控制端语言变化。

彻底修需要扩回包结构（跨端 wire protocol）+ mobile 四语文案 + 把上述既有串一起码化，牵动本 PR 之外的功能线，因此拆出去单独做。本 PR 只做了两件不扩协议的事：把新增的可见串收敛成语言无关的 errno，把 host 与完整 cause 链留在主进程日志里。

（review 中 codex 提过这一点，已在对应 thread 说明取舍。）

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
