### PR TITLE
fix(desktop,maker-core): Claude 与 Codex 共用同一份 MCP 审批策略

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/custom-mcp-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-mcp-store.test.ts
@@ -123,6 +123,13 @@ describe('validateCustomMcpConfig', () => {
   it('skips the reserved-id check when no reserved list is supplied', () => {
     expect(validateCustomMcpConfig({ ...valid, id: 'cindy_browser' })).toEqual({ ok: true });
   });
+
+  // slug 正则允许下划线，`__proto__` 因此是合法 id，而 server 名会被当作对象 key 用。
+  it('rejects ids that are unsafe as object keys', () => {
+    for (const id of ['__proto__', 'constructor', 'prototype']) {
+      expect(validateCustomMcpConfig({ ...valid, id }).ok, `${id} should be rejected`).toBe(false);
+    }
+  });
 });
 
 describe('custom-mcp-store CRUD', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/custom-mcp-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-mcp-store.test.ts
@@ -102,6 +102,27 @@ describe('validateCustomMcpConfig', () => {
   it('rejects non-string headers', () => {
     expect(validateCustomMcpConfig({ ...valid, headers: { X: 1 } }).ok).toBe(false);
   });
+
+  // 撞名的自定义 MCP 会在装配层顶替同名内置 server，并继承 MCP 审批策略里对该
+  // server 名的信任（策略只看 serverName），所以 id 必须在 CRUD 阶段就拒收。
+  it('rejects ids reserved by builtin MCP servers', () => {
+    const result = validateCustomMcpConfig({ ...valid, id: 'cindy_browser' }, [
+      'cindy_browser',
+      'cindy_helper',
+    ]);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.message).toContain('reserved');
+  });
+
+  it('keeps accepting ids that only resemble a builtin name', () => {
+    expect(validateCustomMcpConfig({ ...valid, id: 'cindy_browser_x' }, ['cindy_browser'])).toEqual({
+      ok: true,
+    });
+  });
+
+  it('skips the reserved-id check when no reserved list is supplied', () => {
+    expect(validateCustomMcpConfig({ ...valid, id: 'cindy_browser' })).toEqual({ ok: true });
+  });
 });
 
 describe('custom-mcp-store CRUD', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
@@ -33,6 +33,26 @@ describe('desktop Claude read-only allowlist', () => {
     expect(tools.every((tool) => !tool.endsWith('__call_tool'))).toBe(true);
   });
 
+  // allowedTools 进 SDK options，属于请求前缀的一部分（maker-core-and-agent-behavior.md
+  // §3.1 缓存率）。内容或顺序变化都会打断 prompt cache，所以这里锁死精确顺序，而不是
+  // 只做 arrayContaining 的包含性检查。
+  it('keeps the exact tool list and order stable for prompt-cache prefix', () => {
+    expect(getDesktopClaudeReadOnlyAllowedTools()).toEqual([
+      'mcp__cindy__ghost_list',
+      'mcp__cindy__ghost_forge_guide',
+      'mcp__cindy_browser__list_tools',
+      'mcp__cindy_android__list_tools',
+      'mcp__cindy_computer__list_tools',
+      'mcp__cindy_feishu_bot__list_tools',
+      'mcp__cindy_scheduler__list_tools',
+      'mcp__cindy_ssh__list_tools',
+      'mcp__cindy_helper__list_tools',
+      'mcp__cindy_memory__list_tools',
+      'mcp__cindy_contacts__list_tools',
+      'mcp__cindy_slack__slack_status',
+    ]);
+  });
+
   it('returns an isolated copy', () => {
     const first = getDesktopClaudeReadOnlyAllowedTools();
     first.push('Bash');

--- a/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
@@ -38,6 +38,18 @@ describe('desktop Claude read-only allowlist', () => {
     first.push('Bash');
     expect(getDesktopClaudeReadOnlyAllowedTools()).not.toContain('Bash');
   });
+
+  // allowedTools 只是同一份只读声明在 CLI 层的提前短路(省掉 auto 模式的远程分类器)。
+  // 两个出口必须来自同一张表, 否则会出现"静态白名单放行、动态策略却弹窗"的自相矛盾。
+  it('stays consistent with the shared approval policy', () => {
+    for (const tool of getDesktopClaudeReadOnlyAllowedTools()) {
+      const [serverName, ...rest] = tool.slice('mcp__'.length).split('__');
+      expect(
+        getDesktopMcpToolApprovalPolicy({ serverName, toolName: rest.join('__') }),
+        `${tool} should also be auto-approved by the shared policy`,
+      ).toBe('auto-approve');
+    }
+  });
 });
 
 describe('desktop MCP approval policy', () => {
@@ -84,5 +96,35 @@ describe('desktop MCP approval policy', () => {
     expect(getDesktopMcpToolApprovalPolicy({ serverName: 'cindy_ssh' })).toBe('prompt');
     expect(getDesktopMcpToolApprovalPolicy({ serverName: 'cindy_future_tool' })).toBe('prompt');
     expect(getDesktopMcpToolApprovalPolicy({ serverName: 'third_party' })).toBe('prompt');
+  });
+
+  it('auto-approves read-only discovery entries even on untrusted servers', () => {
+    // server 整体不可信, 但列工具清单 / 查连接状态没有副作用。
+    expect(
+      getDesktopMcpToolApprovalPolicy({ serverName: 'cindy_ssh', toolName: 'list_tools' }),
+    ).toBe('auto-approve');
+    expect(
+      getDesktopMcpToolApprovalPolicy({ serverName: 'cindy', toolName: 'ghost_list' }),
+    ).toBe('auto-approve');
+
+    // 同一个 server 的执行入口不跟着沾光。
+    expect(
+      getDesktopMcpToolApprovalPolicy({ serverName: 'cindy_ssh', toolName: 'call_tool' }),
+    ).toBe('prompt');
+    expect(
+      getDesktopMcpToolApprovalPolicy({ serverName: 'cindy', toolName: 'ghost_call' }),
+    ).toBe('prompt');
+  });
+
+  it('auto-approves the browser call_tool entry that Claude used to prompt for every time', () => {
+    // 回归锚点: cindy_browser 的真实动作全部走 call_tool。Claude 侧过去只静态放行
+    // list_tools, 于是每次 navigate / snapshot / click 都弹一次窗。
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy_browser',
+        toolName: 'call_tool',
+        toolParams: { name: 'browser', args: { action: 'navigate', url: 'https://example.com' } },
+      }),
+    ).toBe('auto-approve');
   });
 });

--- a/apps/desktop/src/main/maker-host/custom-mcp-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-mcp-store.ts
@@ -39,14 +39,26 @@ function invalid(message: string): ValidationResult {
   return { ok: false, code: 'INVALID_PARAMS', message };
 }
 
-/** 纯函数：校验一份自定义 MCP 配置的结构合法性。 */
-export function validateCustomMcpConfig(config: unknown): ValidationResult {
+/**
+ * 纯函数：校验一份自定义 MCP 配置的结构合法性。
+ *
+ * `reservedIds` 传内置 MCP server 名（生产由 getBuiltinMcpServerNames() 派生）。撞名的
+ * 自定义 MCP 会在装配层按 key 顶替内置 server，还顺带继承审批策略里对该 server 名的
+ * 信任，所以这里直接拒收；装配层另有一道纵深防御会跳过它。
+ */
+export function validateCustomMcpConfig(
+  config: unknown,
+  reservedIds: readonly string[] = [],
+): ValidationResult {
   if (!config || typeof config !== 'object') return invalid('config must be an object');
   const c = config as Record<string, unknown>;
 
   if (typeof c.id !== 'string' || c.id.length === 0) return invalid('id required');
   if (c.id.length > MAX_ID_LEN) return invalid(`id too long (max ${MAX_ID_LEN})`);
   if (!CUSTOM_MCP_ID_RE.test(c.id)) return invalid('id must match /^[a-z0-9_-]+$/');
+  if (reservedIds.includes(c.id)) {
+    return invalid(`id '${c.id}' is reserved by a builtin MCP server; pick another id`);
+  }
 
   if (typeof c.name !== 'string' || c.name.trim().length === 0) return invalid('name required');
   if (c.name.length > MAX_NAME_LEN) return invalid(`name too long (max ${MAX_NAME_LEN})`);

--- a/apps/desktop/src/main/maker-host/custom-mcp-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-mcp-store.ts
@@ -34,6 +34,16 @@ export const CUSTOM_MCP_ID_RE = /^[a-z0-9_-]+$/;
  * 兜底，这里从源头再拒一次，避免这种 id 流进任何按 key 建表的下游。
  */
 const UNSAFE_OBJECT_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * 该 id 是否不适合当对象 key。
+ *
+ * 校验是**新加的**，旧版本存下来的行不会被重新校验：启动刷新直接读库建 provider。
+ * 装配层因此要能自己识别并隔离这类历史行，共用这一个判定，避免两处名单漂移。
+ */
+export function isUnsafeMcpServerId(id: string): boolean {
+  return UNSAFE_OBJECT_KEYS.has(id);
+}
 const MAX_ID_LEN = 40;
 const MAX_NAME_LEN = 60;
 

--- a/apps/desktop/src/main/maker-host/custom-mcp-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-mcp-store.ts
@@ -27,6 +27,13 @@ export type { CustomMcpConfig, McpTransport };
 
 /** MCP id slug 规则（与 safeStorage key 名 `mcp_token_<id>` 合法字符对齐）。 */
 export const CUSTOM_MCP_ID_RE = /^[a-z0-9_-]+$/;
+
+/**
+ * slug 正则允许下划线，于是 `__proto__` / `constructor` 这类名字是合法 id，而 server 名
+ * 会被当作普通对象的 key 使用（agent 侧的 mcpServers map）。装配层已改用 null-prototype
+ * 兜底，这里从源头再拒一次，避免这种 id 流进任何按 key 建表的下游。
+ */
+const UNSAFE_OBJECT_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype']);
 const MAX_ID_LEN = 40;
 const MAX_NAME_LEN = 60;
 
@@ -56,6 +63,9 @@ export function validateCustomMcpConfig(
   if (typeof c.id !== 'string' || c.id.length === 0) return invalid('id required');
   if (c.id.length > MAX_ID_LEN) return invalid(`id too long (max ${MAX_ID_LEN})`);
   if (!CUSTOM_MCP_ID_RE.test(c.id)) return invalid('id must match /^[a-z0-9_-]+$/');
+  if (UNSAFE_OBJECT_KEYS.has(c.id)) {
+    return invalid(`id '${c.id}' is not allowed`);
+  }
   if (reservedIds.includes(c.id)) {
     return invalid(`id '${c.id}' is reserved by a builtin MCP server; pick another id`);
   }

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -339,6 +339,10 @@ export function getMaker(): Maker {
       // 第一方只读工具走 SDK allowedTools, 避免 auto 模式为 discovery/read-only
       // 操作额外调用远程安全分类器; 列表按精确工具名维护, 不放行动态 call_tool。
       claudeAllowedTools: getDesktopClaudeReadOnlyAllowedTools(),
+      // MCP 工具审批与 Codex 共用同一份策略(mcp-tool-approval-policy.ts)。没有这一
+      // 行时, Claude 只剩上面那份静态只读白名单, 可信第一方 server 的 call_tool
+      // (浏览器自动化等高频入口)会逐次弹窗, 与 Codex 侧的静默执行行为分叉。
+      getMcpToolApprovalPolicy: getDesktopMcpToolApprovalPolicy,
       // 模型清单 SSoT = 目录（providers.json，OSS 运行时真源 / bundled 兜底）。maker-core 的
       // CLAUDE_MODELS 已删、availableModels 起始为空；host 从账号可选目录派生 cc 列表注入
       // （含 claude 订阅模型 + XD 网关路由的 gpt / 国产 / gemini 等）。active catalog 已在 splash 期
@@ -533,7 +537,8 @@ export function getMaker(): Maker {
       // host 自家、用户已通过 OAuth/账号授权过且完成权限 review 的 MCP server,
       // 按精确 server name 自动通过 Codex MCP elicitation，避免每次可信写操作都弹
       // PermissionPrompt。`cindy_` 只是 namespace，不构成信任边界；新 provider
-      // 默认仍弹审批，必须显式加入 allowlist。
+      // 默认仍弹审批，必须显式加入 allowlist。同一份策略也注入 Claude Code
+      // (见上方 claudeAgent 构造)，两端对同一个 MCP 工具必须给出同一个答案。
       // 例外:`cindy_ssh` 显式排除——它的 ssh_exec 在远端机器上执行任意命令,
       // 属于跨机器写操作,必须保留 Codex MCP elicitation 审批(PR #874 review)。
       // cindy_contacts 是渐进式 list_tools/call_tool server：不能按 serverName

--- a/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
+++ b/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
@@ -23,11 +23,15 @@ import { canAutoApproveContactsMcpTool } from '@cindy/mcps';
 /**
  * 精确到工具的只读放行表，键为 `<server>::<tool>`。
  *
- * 只收录工具整体都无写副作用、且不外发数据的发现 / 状态入口，禁止 wildcard / 前缀
- * 匹配：progressive `call_tool`、`ghost_call` 等聚合入口的风险取决于内层 action，不能
- * 因 server 属于第一方就粗粒度放行。`WebSearch` / `WebFetch` 虽只读但会把搜索词 / URL
- * 发往外部服务（exfiltration 面），与 maker-core `READ_ONLY_CLAUDE_TOOLS` 的既有边界
- * 保持一致，不列入免审批。新增工具默认继续走原权限链，必须 review 后显式加入。
+ * 只收录工具整体都无写副作用、且不把调用方提供的自由文本 / URL / 文件内容外发的
+ * 发现与状态入口，禁止 wildcard / 前缀匹配：progressive `call_tool`、`ghost_call` 等
+ * 聚合入口的风险取决于内层 action，不能因 server 属于第一方就粗粒度放行。
+ *
+ * 判据是「有没有携带内容出境」，不是「有没有网络往返」：`cindy_slack::slack_status`
+ * 会经 bridge 向 slack-hook-server 查一次绑定状态，参数为空、返回的是本机已有的授权
+ * 信息，因此仍算只读；`WebSearch` / `WebFetch` 则把搜索词 / URL 送到外部服务
+ * （exfiltration 面），与 maker-core `READ_ONLY_CLAUDE_TOOLS` 的既有边界一致，不列入
+ * 免审批。新增工具默认继续走原权限链，必须 review 后显式加入。
  *
  * 这张表同时是 Claude `options.allowedTools` 的真源（见
  * getDesktopClaudeReadOnlyAllowedTools）：allowedTools 在 CLI 层就免询问，比

--- a/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
+++ b/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
@@ -1,39 +1,63 @@
-/** Desktop 端的 Claude 只读工具白名单与 Codex MCP 审批策略。 */
+/**
+ * Desktop 端 MCP 工具审批策略 —— Claude Code 与 Codex 共用的唯一真源。
+ *
+ * 一个第一方 MCP 在两个 agent 下必须给出同一个答案。历史上这里只有 Codex 用的
+ * server allowlist，Claude 侧另有一份静态 `allowedTools` 白名单且不查策略，结果
+ * `cindy_browser` 这种高频 server 的 `call_tool` 在 Codex 侧静默执行、在 Claude 侧
+ * 每调用一次弹一次窗——一次浏览器调研就能攒出上百个权限请求。
+ *
+ * 现在两端都查 `getDesktopMcpToolApprovalPolicy`：
+ *   - Codex：`mcpServerElicitation` handler（maker-core codex/index.ts）
+ *   - Claude：`canUseTool` 对 `mcp__<server>__<tool>` 形态的工具（maker-core claude-code/index.ts）
+ *
+ * 判定顺序（从最窄到最宽）：
+ *   1. READ_ONLY_MCP_TOOLS —— 精确到工具的只读发现入口，server 未整体可信也放行
+ *   2. cindy_contacts     —— 按内层 action 细粒度判定（见 contacts/approval.ts）
+ *   3. TRUSTED_MCP_SERVERS —— 已 review 的第一方 server，整体静默
+ *   4. 其余                —— 逐次弹窗（第三方 server、cindy_ssh、插件 ghost_call…）
+ */
 
 import type { McpToolApprovalContext, McpToolApprovalPolicy } from '@cindy/maker-core';
 import { canAutoApproveContactsMcpTool } from '@cindy/mcps';
 
 /**
- * Claude Code `options.allowedTools` 的第一方只读白名单。
+ * 精确到工具的只读放行表，键为 `<server>::<tool>`。
  *
- * 这里只收录工具整体都无写副作用、且不外发数据的精确名称，禁止 wildcard / 前缀匹配：
- * progressive `call_tool`、`ghost_call` 等聚合入口的风险取决于内层 action，不能
+ * 只收录工具整体都无写副作用、且不外发数据的发现 / 状态入口，禁止 wildcard / 前缀
+ * 匹配：progressive `call_tool`、`ghost_call` 等聚合入口的风险取决于内层 action，不能
  * 因 server 属于第一方就粗粒度放行。`WebSearch` / `WebFetch` 虽只读但会把搜索词 / URL
  * 发往外部服务（exfiltration 面），与 maker-core `READ_ONLY_CLAUDE_TOOLS` 的既有边界
  * 保持一致，不列入免审批。新增工具默认继续走原权限链，必须 review 后显式加入。
+ *
+ * 这张表同时是 Claude `options.allowedTools` 的真源（见
+ * getDesktopClaudeReadOnlyAllowedTools）：allowedTools 在 CLI 层就免询问，比
+ * canUseTool 更早短路，能让 auto 模式省掉一次远程安全分类器调用。两个出口共用一份
+ * 声明，避免"静态白名单放行、动态策略却要弹窗"这类自相矛盾。
  */
-const DESKTOP_CLAUDE_READ_ONLY_ALLOWED_TOOLS = [
-  'mcp__cindy__ghost_list',
-  'mcp__cindy__ghost_forge_guide',
-  'mcp__cindy_browser__list_tools',
-  'mcp__cindy_android__list_tools',
-  'mcp__cindy_computer__list_tools',
-  'mcp__cindy_feishu_bot__list_tools',
-  'mcp__cindy_scheduler__list_tools',
-  'mcp__cindy_ssh__list_tools',
-  'mcp__cindy_helper__list_tools',
-  'mcp__cindy_memory__list_tools',
-  'mcp__cindy_contacts__list_tools',
-  'mcp__cindy_slack__slack_status',
-] as const;
+const READ_ONLY_MCP_TOOLS: ReadonlySet<string> = new Set([
+  'cindy::ghost_list',
+  'cindy::ghost_forge_guide',
+  'cindy_browser::list_tools',
+  'cindy_android::list_tools',
+  'cindy_computer::list_tools',
+  'cindy_feishu_bot::list_tools',
+  'cindy_scheduler::list_tools',
+  'cindy_ssh::list_tools',
+  'cindy_helper::list_tools',
+  'cindy_memory::list_tools',
+  'cindy_contacts::list_tools',
+  'cindy_slack::slack_status',
+]);
 
 /**
- * Codex MCP elicitation 的精确 server allowlist。
+ * 整体静默执行的第一方 server。
  *
  * 这里不能按 `cindy_` 前缀放行：namespace 只表示品牌归属，不代表新 provider
- * 已完成权限 review。SSH 与 Contacts 分别走显式拒绝和 inner-tool 细粒度策略。
+ * 已完成权限 review。SSH（在已配置主机上跑任意命令）、插件宿主 `cindy`
+ * （`ghost_call` 转发到第三方插件沙箱）与第三方 server 都不在表内，继续逐次确认；
+ * Contacts 走 inner-tool 细粒度策略。
  */
-const DESKTOP_CODEX_AUTO_APPROVED_MCP_SERVERS: ReadonlySet<string> = new Set([
+const TRUSTED_MCP_SERVERS: ReadonlySet<string> = new Set([
   'cindy_android',
   'cindy_browser',
   'cindy_computer',
@@ -46,9 +70,17 @@ const DESKTOP_CODEX_AUTO_APPROVED_MCP_SERVERS: ReadonlySet<string> = new Set([
   'cindy_lsp',
 ]);
 
-/** 返回副本，避免 SDK / 调用方原地改写 host 的白名单真源。 */
+/** Claude SDK 工具名格式固定为 `mcp__<server>__<tool>`。 */
+function toClaudeToolName(key: string): string {
+  const [serverName, toolName] = key.split('::');
+  return `mcp__${serverName}__${toolName}`;
+}
+
+/**
+ * Claude `options.allowedTools`：由只读表派生，返回新数组避免调用方原地改写真源。
+ */
 export function getDesktopClaudeReadOnlyAllowedTools(): string[] {
-  return [...DESKTOP_CLAUDE_READ_ONLY_ALLOWED_TOOLS];
+  return [...READ_ONLY_MCP_TOOLS].map(toClaudeToolName);
 }
 
 /**
@@ -58,12 +90,17 @@ export function getDesktopMcpToolApprovalPolicy(
   context: McpToolApprovalContext,
 ): McpToolApprovalPolicy {
   const { serverName, toolName, toolParams } = context;
+  // Codex 的 elicitation 不总是带 toolName（0.142.5 / 0.144.1 会省略），拿不到工具名
+  // 时这条精确规则自然不命中，回落到下面的 server 级判定，与改动前行为一致。
+  if (toolName && READ_ONLY_MCP_TOOLS.has(`${serverName}::${toolName}`)) {
+    return 'auto-approve';
+  }
   if (serverName === 'cindy_contacts') {
     return canAutoApproveContactsMcpTool({ toolName, toolParams })
       ? 'auto-approve'
       : 'prompt-each-time';
   }
-  if (DESKTOP_CODEX_AUTO_APPROVED_MCP_SERVERS.has(serverName)) {
+  if (TRUSTED_MCP_SERVERS.has(serverName)) {
     return 'auto-approve';
   }
   return 'prompt';

--- a/apps/desktop/src/main/maker-ipc/mcpHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/mcpHandlers.ts
@@ -39,6 +39,12 @@ export interface McpHandlerDeps {
    * 只告警不阻塞 CRUD）。测试可省略。
    */
   invalidateCodex?(): Promise<void>;
+  /**
+   * 内置 MCP server 名（生产 = getBuiltinMcpServerNames）。自定义 MCP 撞上这些名字时
+   * 会在装配层顶替内置 server 并继承其审批信任，因此创建 / 更新阶段直接拒收。
+   * 省略时不做保留名校验（测试便利）。
+   */
+  getReservedMcpIds?(): string[];
 }
 
 export function registerMcpHandlers(registry: IpcHandlerRegistry, deps: McpHandlerDeps): void {
@@ -61,7 +67,7 @@ export function registerMcpHandlers(registry: IpcHandlerRegistry, deps: McpHandl
   }
 
   registry.handle(MAKER_INVOKE.MCP_CUSTOM_CREATE, async (_event, input: unknown) => {
-    const v = validateCustomMcpConfig(input);
+    const v = validateCustomMcpConfig(input, deps.getReservedMcpIds?.() ?? []);
     if (!v.ok) throwIpcError(v.code, v.message);
     const config = input as CustomMcpConfig;
     if (await customMcpServerExists(config.id)) {
@@ -73,7 +79,7 @@ export function registerMcpHandlers(registry: IpcHandlerRegistry, deps: McpHandl
   });
 
   registry.handle(MAKER_INVOKE.MCP_CUSTOM_UPDATE, async (_event, input: unknown) => {
-    const v = validateCustomMcpConfig(input);
+    const v = validateCustomMcpConfig(input, deps.getReservedMcpIds?.() ?? []);
     if (!v.ok) throwIpcError(v.code, v.message);
     const config = input as CustomMcpConfig;
     const updated = await updateCustomMcpServer(config.id, config);

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -374,7 +374,10 @@ import { registerStopSessionBackgroundTasksHandler } from './stopSessionBackgrou
 import { registerProviderHandlers } from './providerHandlers.js';
 import { createLocalCliScanDeps, scanLocalCliAuth } from './localCliDetect.js';
 import { registerMcpHandlers } from './mcpHandlers.js';
-import { refreshCustomMcpProviders } from '../mcp-integrations/custom-mcp-registry.js';
+import {
+  getBuiltinMcpServerNames,
+  refreshCustomMcpProviders,
+} from '../mcp-integrations/custom-mcp-registry.js';
 import {
   getDesktopProviderService,
   refreshCustomProvidersIntoCatalog,
@@ -3472,6 +3475,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
   registerMcpHandlers(createElectronIpcHandlerRegistry(), {
     refreshProviders: () => refreshCustomMcpProviders(),
     broadcastChanged: () => broadcastToAllWindows(MAKER_PUSH.MCP_CHANGED, {}),
+    // 内置 server 名对自定义 MCP 是保留名：撞名会在装配层顶替内置 server 并继承
+    // 它在 MCP 审批策略里的信任，所以 CRUD 阶段就拒收。
+    getReservedMcpIds: () => getBuiltinMcpServerNames(),
     // Codex 的 MCP flags 冻在 codexEnvironment 的 cached spawn 配置里,清缓存 + dispose app-server,
     // 让下个 codex 会话按新 MCP 配置重 spawn(与 slack 变更同款 best-effort;busy 会话软重启失败只告警)。
     // 顺序：先 dispose app-server（含 busy 检查），成功后再关 bridge/cache。

--- a/apps/desktop/src/main/mcp-integrations/__tests__/codexEnvironment.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/codexEnvironment.test.ts
@@ -48,6 +48,14 @@ function slackProvider(isBound: () => boolean): McpProvider {
   };
 }
 
+/** server 名是不安全对象 key 的远程 provider（自定义 MCP id 正则允许 `__proto__`）。 */
+function unsafeKeyRemoteProvider(): McpProvider {
+  return {
+    name: '__proto__',
+    toCodexMcpConfig: () => ({ type: 'http', url: 'https://evil.example/mcp' }),
+  };
+}
+
 /** 远程 HTTP MCP provider(无 in-process SDK server),带自定义 header。 */
 function remoteHttpProvider(): McpProvider {
   return {
@@ -163,5 +171,20 @@ describe('codexEnvironment', () => {
     });
     // 密钥明文绝不出现在 spawn 参数里。
     expect(cfg.extraArgs.some((a) => a.includes('sk-123'))).toBe(false);
+  });
+
+  // server 名可能来自用户可控来源（自定义 MCP id、插件身份卡）。普通 `{}` 上
+  // `map['__proto__'] = cfg` 命中的是原型 setter：该 server 不出现在 Object.entries 里，
+  // 于是在 Codex 侧静默消失，同一份配置却在 Claude 侧正常工作。
+  it('keeps an unsafe object-key server name visible instead of hitting the prototype setter', async () => {
+    const cfg = await getCodexExtraSpawnConfig({
+      mcpProviders: [unsafeKeyRemoteProvider(), remoteHttpProvider()],
+      logger: noopLogger(),
+    });
+
+    expect(cfg.extraArgs).toContain('mcp_servers.__proto__.url="https://evil.example/mcp"');
+    // 同批次的正常 provider 不受影响，原型也没有被污染。
+    expect(cfg.extraArgs).toContain('mcp_servers.themis.url="https://themis.example/mcp"');
+    expect(Object.getPrototypeOf({} as Record<string, unknown>)).toBe(Object.prototype);
   });
 });

--- a/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
@@ -1,0 +1,116 @@
+/**
+ * custom-mcp-registry —— 自定义 MCP 注入内置 provider 数组时的撞名防御。
+ *
+ * 背景: host 把用户自定义 MCP **追加**在内置 provider 之后, 而两个装配点
+ * (claude buildMcpServers / codex codexEnvironment) 都按 `name` 建 key。若允许撞名,
+ * 一个 id 取作 `cindy_browser` 的自定义远程端点会顶替内置 server, 并继承 MCP 审批
+ * 策略里对该 server 名的信任(策略只看 serverName) —— 第三方端点的所有工具被静默放行。
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { McpProvider } from '@cindy/maker-core';
+import type { CustomMcpConfig } from '../../../shared/customMcp.js';
+
+const storeMock = vi.hoisted(() => ({ listCustomMcpServers: vi.fn() }));
+
+vi.mock('../../maker-host/custom-mcp-store.js', () => ({
+  listCustomMcpServers: storeMock.listCustomMcpServers,
+}));
+
+vi.mock('../../secrets/providerSecretStore.js', () => ({
+  readCustomMcpToken: () => null,
+}));
+
+import {
+  getBuiltinMcpServerNames,
+  refreshCustomMcpProviders,
+  registerCustomMcpArrays,
+  resetCustomMcpRegistry,
+} from '../custom-mcp-registry.js';
+
+function config(id: string): CustomMcpConfig {
+  return {
+    id,
+    name: `custom ${id}`,
+    transport: 'http',
+    url: 'https://example.com/mcp',
+    headers: {},
+  };
+}
+
+function builtin(name: string): McpProvider {
+  return { name, toClaudeSdkConfig: () => ({ type: 'sdk' }) };
+}
+
+beforeEach(() => {
+  resetCustomMcpRegistry();
+  storeMock.listCustomMcpServers.mockReset();
+});
+
+describe('refreshCustomMcpProviders', () => {
+  it('appends custom providers that do not collide', async () => {
+    const arr: McpProvider[] = [builtin('cindy_browser')];
+    registerCustomMcpArrays(arr);
+    storeMock.listCustomMcpServers.mockResolvedValue([config('mytools')]);
+
+    await refreshCustomMcpProviders();
+
+    expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'mytools']);
+  });
+
+  it('skips a custom MCP whose id collides with a builtin server name', async () => {
+    const arr: McpProvider[] = [builtin('cindy_browser'), builtin('cindy_helper')];
+    registerCustomMcpArrays(arr);
+    storeMock.listCustomMcpServers.mockResolvedValue([
+      config('cindy_browser'),
+      config('safe_one'),
+    ]);
+
+    await refreshCustomMcpProviders();
+
+    // 撞名那个整个不装；不撞名的照常注入。
+    expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'cindy_helper', 'safe_one']);
+    expect(arr[0]?.toClaudeSdkConfig?.({ agentKind: 'claude-code', workingDir: '/tmp' })).toEqual({
+      type: 'sdk',
+    });
+  });
+
+  it('still allows ids that merely resemble a builtin name', async () => {
+    const arr: McpProvider[] = [builtin('cindy_browser')];
+    registerCustomMcpArrays(arr);
+    storeMock.listCustomMcpServers.mockResolvedValue([config('cindy_browser_x')]);
+
+    await refreshCustomMcpProviders();
+
+    expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'cindy_browser_x']);
+  });
+
+  it('re-evaluates collisions on every refresh instead of leaking old custom providers', async () => {
+    const arr: McpProvider[] = [builtin('cindy_browser')];
+    registerCustomMcpArrays(arr);
+
+    storeMock.listCustomMcpServers.mockResolvedValue([config('mytools')]);
+    await refreshCustomMcpProviders();
+    expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'mytools']);
+
+    storeMock.listCustomMcpServers.mockResolvedValue([config('cindy_browser')]);
+    await refreshCustomMcpProviders();
+    expect(arr.map((p) => p.name)).toEqual(['cindy_browser']);
+  });
+});
+
+describe('getBuiltinMcpServerNames', () => {
+  it('reports builtin names only, so reserved ids track provider changes automatically', async () => {
+    const arr: McpProvider[] = [builtin('cindy_browser'), builtin('cindy_ssh')];
+    registerCustomMcpArrays(arr);
+    storeMock.listCustomMcpServers.mockResolvedValue([config('mytools')]);
+    await refreshCustomMcpProviders();
+
+    expect(getBuiltinMcpServerNames().sort()).toEqual(['cindy_browser', 'cindy_ssh']);
+  });
+
+  it('returns nothing when no provider array is registered', () => {
+    expect(getBuiltinMcpServerNames()).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
@@ -16,6 +16,8 @@ const storeMock = vi.hoisted(() => ({ listCustomMcpServers: vi.fn() }));
 
 vi.mock('../../maker-host/custom-mcp-store.js', () => ({
   listCustomMcpServers: storeMock.listCustomMcpServers,
+  // 只把读库这一步换成 mock；判定逻辑用真实实现，避免名单在测试里漂移。
+  isUnsafeMcpServerId: (id: string) => ['__proto__', 'constructor', 'prototype'].includes(id),
 }));
 
 vi.mock('../../secrets/providerSecretStore.js', () => ({
@@ -74,6 +76,26 @@ describe('refreshCustomMcpProviders', () => {
     expect(arr[0]?.toClaudeSdkConfig?.({ agentKind: 'claude-code', workingDir: '/tmp' })).toEqual({
       type: 'sdk',
     });
+  });
+
+  // 保留名 / 不安全 key 的校验是后加的，旧版本存下来的行不会被重新校验（refresh 直接
+  // 读库建 provider）。这类 id 当对象 key 用会踩原型 setter，在按 `{}` 建表的装配点静默
+  // 消失，造成「Claude 里能用、Codex 里不见」的分叉，所以两端一律不装。
+  it('quarantines persisted ids that are unsafe as object keys', async () => {
+    const arr: McpProvider[] = [builtin('cindy_browser')];
+    registerCustomMcpArrays(arr);
+    storeMock.listCustomMcpServers.mockResolvedValue([
+      config('__proto__'),
+      config('constructor'),
+      config('prototype'),
+      config('safe_one'),
+    ]);
+
+    await refreshCustomMcpProviders();
+
+    expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'safe_one']);
+    // 没有污染原型：普通对象仍然干净。
+    expect(Object.getPrototypeOf({} as Record<string, unknown>)).toBe(Object.prototype);
   });
 
   it('still allows ids that merely resemble a builtin name', async () => {

--- a/apps/desktop/src/main/mcp-integrations/codexEnvironment.ts
+++ b/apps/desktop/src/main/mcp-integrations/codexEnvironment.ts
@@ -138,12 +138,17 @@ async function doStart(
       };
     },
   };
-  const serverFactories: Record<string, () => McpServer> = {};
-  const pluginIdByServerName: Record<string, string> = {};
+  // null-prototype：server 名可能来自用户可控来源（自定义 MCP id、插件身份卡），而
+  // `__proto__` 这类名字在普通 `{}` 上命中的是原型 setter —— 该 server 不会出现在
+  // Object.keys / Object.entries 里，于是在 Codex 侧静默消失，同一份配置却在 Claude 侧
+  // 正常工作。registry 已从源头隔离这类 id，这里是对称的纵深防御（Claude 侧的
+  // buildMcpServers 同样用 null-prototype）。
+  const serverFactories: Record<string, () => McpServer> = Object.create(null);
+  const pluginIdByServerName: Record<string, string> = Object.create(null);
   const remoteHttpServers: Record<
     string,
     { url: string; bearerTokenEnvVar?: string; envHttpHeaders?: Record<string, string> }
-  > = {};
+  > = Object.create(null);
   const extraEnv: Record<string, string> = {};
   for (const provider of opts.mcpProviders) {
     if (provider.isEnabled && !provider.isEnabled(ctx)) continue;

--- a/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
+++ b/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
@@ -40,6 +40,23 @@ export function resetCustomMcpRegistry(): void {
   registeredArrays.length = 0;
 }
 
+/**
+ * 当前内置（非用户自定义）MCP server 名 —— 自定义 MCP 的保留名清单。
+ *
+ * 从已注册数组里实际存在的 provider 派生，而不是硬编码一份名单：内置 provider 增删
+ * 时这里自动跟上，不会漏掉新 server 而让保留名校验形同虚设。
+ */
+export function getBuiltinMcpServerNames(): string[] {
+  const names = new Set<string>();
+  for (const arr of registeredArrays) {
+    for (const provider of arr) {
+      if (provider instanceof CustomMcpProvider) continue;
+      names.add(provider.name);
+    }
+  }
+  return [...names];
+}
+
 /** @deprecated 测试别名，直接用 resetCustomMcpRegistry。 */
 export const __resetCustomMcpRegistryForTest = resetCustomMcpRegistry;
 
@@ -58,15 +75,34 @@ export async function refreshCustomMcpProviders(): Promise<void> {
     });
     return;
   }
+  // 按名字去重统计：同一个撞名配置会在每个已注册数组各命中一次，累加会虚报。
+  const skippedNames = new Set<string>();
   for (const arr of registeredArrays) {
     // 原地移除旧的 custom provider,再追加新的一批(不换数组引用)。
     for (let i = arr.length - 1; i >= 0; i--) {
       if (arr[i] instanceof CustomMcpProvider) arr.splice(i, 1);
     }
-    arr.push(...providers);
+    // 此刻数组里只剩内置 provider —— 用它们的名字当保留名。自定义 MCP 一旦与内置
+    // 撞名，装配层(claude buildMcpServers / codex codexEnvironment)会按 key 覆盖，
+    // 于是一个第三方远程端点顶替内置 server，还顺带继承审批策略里对该 server 名的
+    // 信任(策略只看 serverName)。这里直接不装它，撞名的自定义 MCP 视为无效配置。
+    const builtinNames = new Set(arr.map((p) => p.name));
+    for (const provider of providers) {
+      if (builtinNames.has(provider.name)) {
+        if (!skippedNames.has(provider.name)) {
+          log.warn('skipping custom MCP that collides with a builtin server name', {
+            serverName: provider.name,
+          });
+        }
+        skippedNames.add(provider.name);
+        continue;
+      }
+      arr.push(provider);
+    }
   }
   log.info('custom mcp providers refreshed', {
     count: providers.length,
+    skipped: skippedNames.size,
     arrays: registeredArrays.length,
   });
 }

--- a/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
+++ b/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
@@ -16,7 +16,7 @@
 import { createLogger } from '../logger.js';
 import type { McpProvider } from '@cindy/maker-core';
 
-import { listCustomMcpServers } from '../maker-host/custom-mcp-store.js';
+import { isUnsafeMcpServerId, listCustomMcpServers } from '../maker-host/custom-mcp-store.js';
 import { readCustomMcpToken } from '../secrets/providerSecretStore.js';
 import { CustomMcpProvider } from './custom-mcp-provider.js';
 
@@ -88,6 +88,20 @@ export async function refreshCustomMcpProviders(): Promise<void> {
     // 信任(策略只看 serverName)。这里直接不装它，撞名的自定义 MCP 视为无效配置。
     const builtinNames = new Set(arr.map((p) => p.name));
     for (const provider of providers) {
+      // 历史行隔离：保留名 / 不安全 key 的校验是后加的，旧版本存下来的行不会被重新
+      // 校验（这里直接读库建 provider）。这类 id 当对象 key 用会踩原型 setter，在
+      // 按 `{}` 建表的装配点（codex 的 remoteHttpServers 等）静默消失，造成「Claude 里
+      // 能用、Codex 里不见」的分叉。两端一律不装，用户删掉重建即可（delete 按 id 走，
+      // 不受新校验影响）。
+      if (isUnsafeMcpServerId(provider.name)) {
+        if (!skippedNames.has(provider.name)) {
+          log.warn('skipping custom MCP whose id is unsafe as an object key; delete and recreate it', {
+            serverName: provider.name,
+          });
+        }
+        skippedNames.add(provider.name);
+        continue;
+      }
       if (builtinNames.has(provider.name)) {
         if (!skippedNames.has(provider.name)) {
           log.warn('skipping custom MCP that collides with a builtin server name', {

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -75,7 +75,13 @@ export interface CodexMcpThreadContextArgs {
   vendorOptions: Record<string, unknown>;
 }
 
-/** Metadata Codex attaches to an MCP tool approval elicitation. */
+/**
+ * Metadata for an MCP tool approval decision.
+ *
+ * Codex fills it from the elicitation `_meta`; Claude fills it by splitting the
+ * SDK tool name (`mcp__<server>__<tool>`) and passing the tool input verbatim.
+ * Both therefore hand the host the same shape, so one policy answers for both.
+ */
 export interface McpToolApprovalContext {
   serverName: string;
   /** Top-level MCP tool name, for example `list_tools` or `call_tool`. */
@@ -258,10 +264,10 @@ export interface AgentDeps {
   makerMemory?: MakerMemoryManager;
 
   /**
-   * Host-side Codex MCP approval policy. `auto-approve` skips PermissionPrompt;
-   * `prompt` preserves Codex's normal approval UI and optional session grant;
-   * `prompt-each-time` always asks and never persists a server/tool grant.
-   * Claude SDK does not consume this hook.
+   * Host-side MCP approval policy, shared by **both** agents. `auto-approve`
+   * skips the permission prompt; `prompt` preserves the normal approval UI and
+   * its optional session grant; `prompt-each-time` always asks and never
+   * persists a server/tool grant.
    *
    * 背景:
    *  - Codex CLI 对 raw `mcp_servers.*` 的 write 类 tool call 弹 user approval 是 known
@@ -270,9 +276,14 @@ export interface AgentDeps {
    *  - host 自家可信的 MCP server (e.g. lizi_*) 每次写都弹严重影响 UX, 这里给一个
    *    宿主策略短路。渐进式 server 还可利用 toolName/toolParams 区分 inner action,
    *    让查询保持无打扰而删除/外部写入逐次确认。
+   *  - 同一个第一方 MCP 在两个 agent 下必须给出同一个答案。历史上 Claude 只有一份
+   *    静态 allowedTools 白名单、不查这个 hook, 结果 `cindy_browser` 之类高频 server
+   *    的 `call_tool` 在 Codex 侧静默执行、在 Claude 侧每调用一次弹一次窗。
    *
-   * 实现位置: codex/index.ts mcpServerElicitation handler 在 dispatchInteraction 之前
-   * 查这里；auto-approve 直接 accept，prompt-each-time 禁掉 session persistence。
+   * 实现位置:
+   *  - codex/index.ts mcpServerElicitation handler 在 dispatchInteraction 之前查这里;
+   *  - claude-code/index.ts canUseTool 对 `mcp__<server>__<tool>` 形态的工具查这里。
+   * 两侧同义: auto-approve 直接放行, prompt-each-time 禁掉 session persistence。
    *
    * 缺省 / undefined → 走原 dispatchInteraction (弹 UI), 行为与改动前一致。
    */

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -463,6 +463,38 @@ describe('a custom server cannot take over a builtin name', () => {
     expect(configs).toEqual([{ name: 'cindy_browser', marker: 'builtin' }]);
     await handle.close();
   });
+
+  it('treats an unsafe object-key server name as an ordinary key', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+    sdkMock.query.mockReturnValue(createFakeQuery());
+
+    const deps = createDeps(() => 'prompt');
+    // 自定义 MCP 的 id 正则允许下划线，`__proto__` 是合法 id。普通 `{}` 作 map 时这个键
+    // 会打到原型访问器上：server 注册不进去、去重看不见它，map 的原型还被换成 config。
+    deps.mcpProviders = [
+      { name: '__proto__', toClaudeSdkConfig: () => ({ type: 'http', marker: 'evil' }) },
+      { name: 'cindy_browser', toClaudeSdkConfig: () => ({ type: 'sdk', marker: 'builtin' }) },
+    ] as McpProvider[];
+
+    const agent = new ClaudeCodeAgent(deps);
+    const handle = await agent.startSession({
+      sessionId: 'session-proto-mcp',
+      model: 'claude-opus-4-6',
+      workingDir,
+      permissionMode: 'default',
+    });
+
+    const mcpServers = sdkMock.query.mock.calls.at(-1)?.[0]?.options?.mcpServers as
+      | Record<string, unknown>
+      | undefined;
+    // 作为普通自有键存在，且没有污染原型。
+    expect(Object.keys(mcpServers ?? {}).sort()).toEqual(['__proto__', 'cindy_browser']);
+    expect(Object.getPrototypeOf({} as Record<string, unknown>)).toBe(Object.prototype);
+    expect(({} as { marker?: string }).marker).toBeUndefined();
+    await handle.close();
+  });
 });
 
 describe('fail-closed still precedes the MCP policy', () => {
@@ -473,6 +505,111 @@ describe('fail-closed still precedes the MCP policy', () => {
 
     // host 策略说的是"值不值得打扰用户"，不代表"没有用户在场也能跑"。
     expect(result.behavior).toBe('deny');
+    await handle.close();
+  });
+});
+
+describe('remote sessions share the same permission semantics', () => {
+  /** 起一个远端会话并拿到 daemon 侧的 approval 回调。 */
+  async function startRemoteSession(
+    policy: (context: McpToolApprovalContext) => McpToolApprovalPolicy,
+    options?: { attachResolver?: (req: InteractionRequest) => InteractionDecision },
+  ) {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+
+    let onApprovalRequest: ((raw: unknown) => Promise<{ behavior?: string }>) | undefined;
+    const deps = createDeps(policy);
+    // 远端只装得到 stdio / sse / http 类 server —— in-process 的会被 filter 掉。
+    deps.mcpProviders = [
+      { name: 'cindy_browser', toClaudeSdkConfig: () => ({ type: 'http', url: 'https://x/mcp' }) },
+      { name: 'cindy_contacts', toClaudeSdkConfig: () => ({ type: 'http', url: 'https://y/mcp' }) },
+    ] as McpProvider[];
+    deps.remoteCcQueryFactory = (async (args: {
+      onApprovalRequest: (raw: unknown) => Promise<{ behavior?: string }>;
+    }) => {
+      onApprovalRequest = args.onApprovalRequest;
+      return createFakeQuery() as never;
+    }) as NonNullable<AgentDeps['remoteCcQueryFactory']>;
+
+    const agent = new ClaudeCodeAgent(deps);
+    const handle = await agent.startSession({
+      sessionId: 'session-remote-mcp-policy',
+      model: 'claude-opus-4-6',
+      workingDir,
+      remoteHostId: 'remote-1',
+      permissionMode: 'default',
+    });
+    const seen: InteractionRequest[] = [];
+    if (options?.attachResolver) {
+      handle.setInteractionResolver(async (req): Promise<InteractionDecision> => {
+        seen.push(req);
+        return options.attachResolver!(req);
+      });
+    }
+    if (!onApprovalRequest) throw new Error('expected remote onApprovalRequest');
+    return { handle, onApprovalRequest, seen };
+  }
+
+  it('auto-approves trusted MCP tools without prompting', async () => {
+    const { handle, onApprovalRequest, seen } = await startRemoteSession(() => 'auto-approve', {
+      attachResolver: () => ({ kind: 'permission', behavior: 'allow' }),
+    });
+
+    const result = await onApprovalRequest({
+      requestId: 'r-1',
+      kind: 'permission',
+      toolName: 'mcp__cindy_browser__call_tool',
+      input: { name: 'browser', args: { action: 'snapshot' } },
+    });
+
+    expect(result.behavior).toBe('allow');
+    expect(seen).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('drops session grants for prompt-each-time tools', async () => {
+    const { handle, onApprovalRequest } = await startRemoteSession(() => 'prompt-each-time', {
+      attachResolver: () => ({
+        kind: 'permission',
+        behavior: 'allow',
+        permissionUpdates: [{ type: 'addRules', destination: 'session', behavior: 'allow' }],
+      }),
+    });
+
+    const result = (await onApprovalRequest({
+      requestId: 'r-2',
+      kind: 'permission',
+      toolName: 'mcp__cindy_contacts__call_tool',
+      input: { name: 'contacts_delete' },
+    })) as { behavior?: string; permissionUpdates?: unknown[] };
+
+    expect(result.behavior).toBe('allow');
+    expect(result.permissionUpdates).toBeUndefined();
+    await handle.close();
+  });
+
+  it('fails closed instead of allowing when no resolver is attached', async () => {
+    const { handle, onApprovalRequest } = await startRemoteSession(() => 'prompt');
+
+    // 改动前这里 return allow —— 裸远端会话可以在无人在场时跑破坏性工具。
+    const denied = await onApprovalRequest({
+      requestId: 'r-3',
+      kind: 'permission',
+      toolName: 'Bash',
+      input: { command: 'rm -rf /' },
+    });
+    expect(denied.behavior).toBe('deny');
+
+    // 只读工具仍然放行，与本地 canUseTool 的白名单语义一致。
+    const allowed = await onApprovalRequest({
+      requestId: 'r-4',
+      kind: 'permission',
+      toolName: 'Read',
+      input: { file_path: '/tmp/x' },
+    });
+    expect(allowed.behavior).toBe('allow');
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -112,11 +112,17 @@ function createFakeQuery() {
   };
 }
 
+/** 与真实 canUseTool 契约对齐 —— 含 allow 分支可能带回的 updatedPermissions。 */
 type CanUseToolFn = (
   toolName: string,
   input: Record<string, unknown>,
   options: { toolUseID: string; suggestions?: unknown[] },
-) => Promise<{ behavior: 'allow' | 'deny'; updatedInput?: Record<string, unknown>; message?: string }>;
+) => Promise<{
+  behavior: 'allow' | 'deny';
+  updatedInput?: Record<string, unknown>;
+  updatedPermissions?: unknown[];
+  message?: string;
+}>;
 
 async function makeTempDir(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'maker-core-claude-mcp-policy-'));
@@ -417,6 +423,44 @@ describe('prompt-each-time never turns into a persisted grant', () => {
     await handle.setPermissionMode('bypassPermissions');
 
     expect((await pending).behavior).toBe('allow');
+    await handle.close();
+  });
+});
+
+describe('a custom server cannot take over a builtin name', () => {
+  it('keeps the first registration when two providers share a name', async () => {
+    const configs: Array<{ name: string; marker: string }> = [];
+    const contexts: McpToolApprovalContext[] = [];
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+    sdkMock.query.mockReturnValue(createFakeQuery());
+
+    const deps = createDeps((context) => {
+      contexts.push(context);
+      return 'auto-approve';
+    });
+    // host 把用户自定义 MCP 追加在内置之后；同名时后写覆盖会让第三方端点顶替内置
+    // server 并继承它的信任。这里两个 provider 同名，断言内置（先注册的）胜出。
+    deps.mcpProviders = [
+      { name: 'cindy_browser', toClaudeSdkConfig: () => ({ type: 'sdk', marker: 'builtin' }) },
+      { name: 'cindy_browser', toClaudeSdkConfig: () => ({ type: 'http', marker: 'custom' }) },
+    ] as McpProvider[];
+
+    const agent = new ClaudeCodeAgent(deps);
+    const handle = await agent.startSession({
+      sessionId: 'session-dup-mcp',
+      model: 'claude-opus-4-6',
+      workingDir,
+      permissionMode: 'default',
+    });
+
+    const mcpServers = sdkMock.query.mock.calls.at(-1)?.[0]?.options?.mcpServers as
+      | Record<string, { marker?: string }>
+      | undefined;
+    configs.push({ name: 'cindy_browser', marker: mcpServers?.cindy_browser?.marker ?? 'missing' });
+
+    expect(configs).toEqual([{ name: 'cindy_browser', marker: 'builtin' }]);
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -22,6 +22,7 @@ import type { AgentDeps, McpToolApprovalContext, McpToolApprovalPolicy } from '.
 import type { AuthAdapter } from '../../../interfaces/auth-adapter.js';
 import type { InteractionDecision, InteractionRequest } from '../../../types/events.js';
 import type { Logger } from '../../../interfaces/logger.js';
+import type { McpProvider } from '../../../interfaces/mcp-provider.js';
 
 const sdkMock = vi.hoisted(() => ({
   forkSession: vi.fn(),
@@ -53,8 +54,25 @@ function createNoopLogger(): Logger {
   return logger;
 }
 
+/** 本 session 注册的 MCP server —— canUseTool 只认这批名字做归属判定。 */
+const REGISTERED_MCP_SERVERS = [
+  'cindy_browser',
+  'cindy_contacts',
+  'cindy_ssh',
+  // 自定义 MCP 的 id 正则允许下划线, 所以可以叫出这种冒充第一方前缀的名字。
+  'cindy_browser__evil',
+];
+
+function createMcpProviders(names: readonly string[]): McpProvider[] {
+  return names.map((name) => ({
+    name,
+    toClaudeSdkConfig: () => ({ type: 'stdio', command: 'true' }),
+  }));
+}
+
 function createDeps(
   getMcpToolApprovalPolicy?: (context: McpToolApprovalContext) => McpToolApprovalPolicy,
+  mcpServerNames: readonly string[] = REGISTERED_MCP_SERVERS,
 ): AgentDeps {
   const auth: AuthAdapter = {
     async getState() {
@@ -74,6 +92,7 @@ function createDeps(
     runtimeConfig: {},
     binaryPath: process.execPath,
     logger: createNoopLogger(),
+    mcpProviders: createMcpProviders(mcpServerNames),
     ...(getMcpToolApprovalPolicy ? { getMcpToolApprovalPolicy } : {}),
   };
 }
@@ -108,6 +127,13 @@ async function makeTempDir(): Promise<string> {
 /** 起一个 session 并暴露 SDK query 的 canUseTool + 收到的 interaction 请求。 */
 async function startSession(
   policy?: (context: McpToolApprovalContext) => McpToolApprovalPolicy,
+  options?: {
+    mcpServerNames?: readonly string[];
+    /** 覆盖 resolver 的决策；默认简单 allow。返回 undefined 表示挂起不决策。 */
+    decide?: (req: InteractionRequest) => InteractionDecision | undefined;
+    /** true 时不注入 resolver，用于验证 fail-closed 分支。 */
+    bare?: boolean;
+  },
 ) {
   const configDir = await makeTempDir();
   process.env.CLAUDE_CONFIG_DIR = configDir;
@@ -116,7 +142,7 @@ async function startSession(
   const fakeQuery = createFakeQuery();
   sdkMock.query.mockReturnValue(fakeQuery);
 
-  const agent = new ClaudeCodeAgent(createDeps(policy));
+  const agent = new ClaudeCodeAgent(createDeps(policy, options?.mcpServerNames));
   const handle = await agent.startSession({
     sessionId: 'session-mcp-policy',
     model: 'claude-opus-4-6',
@@ -129,10 +155,16 @@ async function startSession(
   if (!queryOptions?.canUseTool) throw new Error('expected sdk query canUseTool');
 
   const seen: InteractionRequest[] = [];
-  handle.setInteractionResolver(async (req): Promise<InteractionDecision> => {
-    seen.push(req);
-    return { kind: 'permission', behavior: 'allow' };
-  });
+  if (!options?.bare) {
+    handle.setInteractionResolver(async (req): Promise<InteractionDecision> => {
+      seen.push(req);
+      const decided = options?.decide?.(req);
+      if (decided) return decided;
+      // undefined = 请求保持挂起，交给 dismissAllPending 结算。
+      if (options?.decide) return new Promise<InteractionDecision>(() => {});
+      return { kind: 'permission', behavior: 'allow' };
+    });
+  }
 
   return { agent, handle, canUseTool: queryOptions.canUseTool, seen };
 }
@@ -270,6 +302,133 @@ describe('ClaudeCodeAgent canUseTool honors the host MCP approval policy', () =>
     await canUseTool('mcp__cindy_browser__call_tool', {}, { toolUseID: 't-nopolicy' });
 
     expect(permissionRequests(seen)).toHaveLength(1);
+    await handle.close();
+  });
+});
+
+describe('MCP server attribution cannot be spoofed by tool-name prefixes', () => {
+  it('attributes a custom server whose id embeds a trusted prefix to itself', async () => {
+    const contexts: McpToolApprovalContext[] = [];
+    const { handle, canUseTool } = await startSession((context) => {
+      contexts.push(context);
+      // 只有真正的第一方 cindy_browser 才可信。
+      return context.serverName === 'cindy_browser' ? 'auto-approve' : 'prompt';
+    });
+
+    // 自定义 MCP 的 id 允许下划线，`cindy_browser__evil` 是合法 id。按 `__` 盲切会
+    // 把它算成 cindy_browser，从而继承第一方信任——这里锁死最长匹配的正确归属。
+    const result = await canUseTool('mcp__cindy_browser__evil__call_tool', {}, {
+      toolUseID: 't-spoof',
+    });
+
+    expect(contexts).toEqual([
+      { serverName: 'cindy_browser__evil', toolName: 'call_tool', toolParams: {} },
+    ]);
+    // 走了权限链而不是静默放行。
+    expect(result.behavior).toBe('allow');
+    await handle.close();
+  });
+
+  it('does not consult the policy for servers this session never registered', async () => {
+    const contexts: McpToolApprovalContext[] = [];
+    const { handle, canUseTool, seen } = await startSession(
+      (context) => {
+        contexts.push(context);
+        return 'auto-approve';
+      },
+      { mcpServerNames: ['cindy_browser'] },
+    );
+
+    await canUseTool('mcp__cindy_slack__slack_call_tool', {}, { toolUseID: 't-unregistered' });
+
+    expect(contexts).toHaveLength(0);
+    expect(permissionRequests(seen)).toHaveLength(1);
+    await handle.close();
+  });
+});
+
+describe('prompt-each-time never turns into a persisted grant', () => {
+  it('drops permission updates that a surface attaches on its own', async () => {
+    const { handle, canUseTool } = await startSession(() => 'prompt-each-time', {
+      // 模拟 hook-control / IM 卡片流：不看 request.suggestions，自行拼 session 规则。
+      decide: () => ({
+        kind: 'permission',
+        behavior: 'allow',
+        permissionUpdates: [{ type: 'addRules', destination: 'session', behavior: 'allow' }],
+      }),
+    });
+
+    const result = await canUseTool('mcp__cindy_contacts__call_tool', { name: 'contacts_delete' }, {
+      toolUseID: 't-grant',
+    });
+
+    expect(result.behavior).toBe('allow');
+    // 本次放行，但不给 SDK 落任何会话规则——否则后续调用全部跳过 canUseTool。
+    expect(result.updatedPermissions).toBeUndefined();
+    await handle.close();
+  });
+
+  it('still forwards permission updates for ordinary prompt policy', async () => {
+    const { handle, canUseTool } = await startSession(() => 'prompt', {
+      decide: () => ({
+        kind: 'permission',
+        behavior: 'allow',
+        permissionUpdates: [{ type: 'addRules', destination: 'session', behavior: 'allow' }],
+      }),
+    });
+
+    const result = await canUseTool('mcp__cindy_ssh__call_tool', { name: 'ssh_exec' }, {
+      toolUseID: 't-grant-ok',
+    });
+
+    expect(result.updatedPermissions).toHaveLength(1);
+    await handle.close();
+  });
+
+  it('denies a pending forced prompt when the session switches to a laxer mode', async () => {
+    const { handle, canUseTool } = await startSession(() => 'prompt-each-time', {
+      // 决策永不返回：请求挂起，等模式切换来结算。
+      decide: () => undefined,
+    });
+
+    const pending = canUseTool('mcp__cindy_contacts__call_tool', { name: 'contacts_merge' }, {
+      toolUseID: 't-pending',
+    });
+    // 让 canUseTool 跑到 dispatchInteraction 并登记 pending。
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await handle.setPermissionMode('bypassPermissions');
+
+    // 切到 Full access 也不能替用户批准这一次高风险调用。
+    expect((await pending).behavior).toBe('deny');
+    await handle.close();
+  });
+
+  it('still auto-allows ordinary pending prompts on a laxer mode switch', async () => {
+    const { handle, canUseTool } = await startSession(() => 'prompt', {
+      decide: () => undefined,
+    });
+
+    const pending = canUseTool('mcp__cindy_ssh__call_tool', { name: 'ssh_exec' }, {
+      toolUseID: 't-pending-ok',
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await handle.setPermissionMode('bypassPermissions');
+
+    expect((await pending).behavior).toBe('allow');
+    await handle.close();
+  });
+});
+
+describe('fail-closed still precedes the MCP policy', () => {
+  it('denies trusted MCP tools when no interaction resolver is attached', async () => {
+    const { handle, canUseTool } = await startSession(() => 'auto-approve', { bare: true });
+
+    const result = await canUseTool('mcp__cindy_browser__call_tool', {}, { toolUseID: 't-bare' });
+
+    // host 策略说的是"值不值得打扰用户"，不代表"没有用户在场也能跑"。
+    expect(result.behavior).toBe('deny');
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Claude canUseTool 消费 host MCP 审批策略(deps.getMcpToolApprovalPolicy)的单测。
+ *
+ * 背景: 这个 hook 原本只有 Codex 的 mcpServerElicitation 在查, Claude 侧另有一份
+ * 静态 allowedTools 白名单。同一个第一方 MCP 因此两端行为分叉 —— `cindy_browser`
+ * 的 call_tool 在 Codex 侧静默执行, 在 Claude 侧每调用一次弹一次窗。
+ *
+ * 覆盖:
+ *  - auto-approve  → 静默放行, 完全不惊动 interactionResolver
+ *  - prompt        → 照常弹窗, 会话级 suggestion 保留("总是允许"可用)
+ *  - prompt-each-time → 照常弹窗, 但 suggestion 被剥掉(不许持久化授权)
+ *  - 策略抛错 / 返回非法值 → 按最保守的 prompt-each-time 处理, 绝不 fail-open
+ *  - 非 MCP 内置工具不查策略; MCP 工具名按 `mcp__<server>__<tool>` 正确拆分
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentDeps, McpToolApprovalContext, McpToolApprovalPolicy } from '../../base-agent.js';
+import type { AuthAdapter } from '../../../interfaces/auth-adapter.js';
+import type { InteractionDecision, InteractionRequest } from '../../../types/events.js';
+import type { Logger } from '../../../interfaces/logger.js';
+
+const sdkMock = vi.hoisted(() => ({
+  forkSession: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  forkSession: sdkMock.forkSession,
+  query: sdkMock.query,
+}));
+
+import { ClaudeCodeAgent } from '../index.js';
+
+const tempDirs: string[] = [];
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+function createNoopLogger(): Logger {
+  const logger: Logger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    fatal() {},
+    child() {
+      return logger;
+    },
+  };
+  return logger;
+}
+
+function createDeps(
+  getMcpToolApprovalPolicy?: (context: McpToolApprovalContext) => McpToolApprovalPolicy,
+): AgentDeps {
+  const auth: AuthAdapter = {
+    async getState() {
+      return { authenticated: true };
+    },
+    async triggerLogin() {
+      return { authenticated: true };
+    },
+    async logout() {},
+    async getAuthEnv() {
+      return {};
+    },
+  };
+
+  return {
+    auth,
+    runtimeConfig: {},
+    binaryPath: process.execPath,
+    logger: createNoopLogger(),
+    ...(getMcpToolApprovalPolicy ? { getMcpToolApprovalPolicy } : {}),
+  };
+}
+
+/** 最小可用的 SDK Query 假实现: 消息流永远挂起, 控制方法全部记录调用。 */
+function createFakeQuery() {
+  return {
+    [Symbol.asyncIterator]() {
+      return { next: () => new Promise<IteratorResult<unknown>>(() => {}) };
+    },
+    setPermissionMode: vi.fn(async () => {}),
+    setModel: vi.fn(async () => {}),
+    applyFlagSettings: vi.fn(async () => {}),
+    interrupt: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    rewindFiles: vi.fn(async () => ({ canRewind: false })),
+  };
+}
+
+type CanUseToolFn = (
+  toolName: string,
+  input: Record<string, unknown>,
+  options: { toolUseID: string; suggestions?: unknown[] },
+) => Promise<{ behavior: 'allow' | 'deny'; updatedInput?: Record<string, unknown>; message?: string }>;
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'maker-core-claude-mcp-policy-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** 起一个 session 并暴露 SDK query 的 canUseTool + 收到的 interaction 请求。 */
+async function startSession(
+  policy?: (context: McpToolApprovalContext) => McpToolApprovalPolicy,
+) {
+  const configDir = await makeTempDir();
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  const workingDir = await makeTempDir();
+
+  const fakeQuery = createFakeQuery();
+  sdkMock.query.mockReturnValue(fakeQuery);
+
+  const agent = new ClaudeCodeAgent(createDeps(policy));
+  const handle = await agent.startSession({
+    sessionId: 'session-mcp-policy',
+    model: 'claude-opus-4-6',
+    workingDir,
+    permissionMode: 'default',
+  });
+  const queryOptions = sdkMock.query.mock.calls.at(-1)?.[0]?.options as
+    | { canUseTool?: CanUseToolFn }
+    | undefined;
+  if (!queryOptions?.canUseTool) throw new Error('expected sdk query canUseTool');
+
+  const seen: InteractionRequest[] = [];
+  handle.setInteractionResolver(async (req): Promise<InteractionDecision> => {
+    seen.push(req);
+    return { kind: 'permission', behavior: 'allow' };
+  });
+
+  return { agent, handle, canUseTool: queryOptions.canUseTool, seen };
+}
+
+/** 取出 resolver 收到的 permission 请求(测试只会产生这一类)。 */
+function permissionRequests(seen: InteractionRequest[]) {
+  return seen.flatMap((req) => (req.kind === 'permission' ? [req] : []));
+}
+
+const SESSION_SUGGESTION = [{ type: 'addRules', destination: 'session', behavior: 'allow' }];
+
+afterEach(async () => {
+  sdkMock.forkSession.mockReset();
+  sdkMock.query.mockReset();
+  if (originalClaudeConfigDir === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR;
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('ClaudeCodeAgent canUseTool honors the host MCP approval policy', () => {
+  it('auto-approves trusted MCP tools without prompting the user', async () => {
+    const { handle, canUseTool, seen } = await startSession(() => 'auto-approve');
+
+    const input = { name: 'browser', args: { action: 'navigate', url: 'https://example.com' } };
+    const result = await canUseTool('mcp__cindy_browser__call_tool', input, {
+      toolUseID: 't-browser',
+    });
+
+    expect(result.behavior).toBe('allow');
+    expect(result.updatedInput).toEqual(input);
+    // 关键: 没有产生任何权限交互 —— 一次浏览器调研不该攒出上百个弹窗。
+    expect(seen).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('passes the parsed server / tool name and the raw input to the policy', async () => {
+    const contexts: McpToolApprovalContext[] = [];
+    const { handle, canUseTool } = await startSession((context) => {
+      contexts.push(context);
+      return 'auto-approve';
+    });
+
+    const input = { name: 'contacts_search', args: { query: 'Carol' } };
+    await canUseTool('mcp__cindy_contacts__call_tool', input, { toolUseID: 't-contacts' });
+
+    // server 段自身含下划线, 分隔符是双下划线 —— 拆分不能被 `cindy_contacts` 误伤。
+    expect(contexts).toEqual([
+      { serverName: 'cindy_contacts', toolName: 'call_tool', toolParams: input },
+    ]);
+    await handle.close();
+  });
+
+  it('keeps prompting (with session suggestions) for policy "prompt"', async () => {
+    const { handle, canUseTool, seen } = await startSession(() => 'prompt');
+
+    const result = await canUseTool('mcp__cindy_ssh__call_tool', { name: 'ssh_exec' }, {
+      toolUseID: 't-ssh',
+      suggestions: SESSION_SUGGESTION,
+    });
+
+    expect(result.behavior).toBe('allow');
+    expect(permissionRequests(seen)).toHaveLength(1);
+    expect(permissionRequests(seen)[0]?.suggestions).toHaveLength(1);
+    await handle.close();
+  });
+
+  it('strips session suggestions for policy "prompt-each-time"', async () => {
+    const { handle, canUseTool, seen } = await startSession(() => 'prompt-each-time');
+
+    await canUseTool('mcp__cindy_contacts__call_tool', { name: 'contacts_delete' }, {
+      toolUseID: 't-delete',
+      suggestions: SESSION_SUGGESTION,
+    });
+
+    const requests = permissionRequests(seen);
+    expect(requests).toHaveLength(1);
+    // 逐次确认的语义就是不许一次点选永久放行。
+    expect(requests[0]?.suggestions).toBeUndefined();
+    await handle.close();
+  });
+
+  it('falls back to prompt-each-time when the policy throws or returns garbage', async () => {
+    const thrower = await startSession(() => {
+      throw new Error('policy exploded');
+    });
+    await thrower.canUseTool('mcp__cindy_browser__call_tool', {}, {
+      toolUseID: 't-throw',
+      suggestions: SESSION_SUGGESTION,
+    });
+    const thrownRequests = permissionRequests(thrower.seen);
+    expect(thrownRequests).toHaveLength(1);
+    expect(thrownRequests[0]?.suggestions).toBeUndefined();
+    await thrower.handle.close();
+
+    const garbage = await startSession(() => 'definitely-not-a-policy' as McpToolApprovalPolicy);
+    await garbage.canUseTool('mcp__cindy_browser__call_tool', {}, {
+      toolUseID: 't-garbage',
+      suggestions: SESSION_SUGGESTION,
+    });
+    const garbageRequests = permissionRequests(garbage.seen);
+    expect(garbageRequests).toHaveLength(1);
+    expect(garbageRequests[0]?.suggestions).toBeUndefined();
+    await garbage.handle.close();
+  });
+
+  it('never routes built-in tools through the MCP policy', async () => {
+    const calls: McpToolApprovalContext[] = [];
+    const { handle, canUseTool, seen } = await startSession((context) => {
+      calls.push(context);
+      return 'auto-approve';
+    });
+
+    for (const tool of ['Bash', 'Write', 'Read', 'WebFetch', 'mcp__notaserver']) {
+      await canUseTool(tool, {}, { toolUseID: `t-${tool}` });
+    }
+
+    expect(calls).toHaveLength(0);
+    // 全部照常走权限链, 不因 MCP 策略被静默放行。
+    expect(permissionRequests(seen).map((req) => req.toolName)).toEqual([
+      'Bash',
+      'Write',
+      'Read',
+      'WebFetch',
+      'mcp__notaserver',
+    ]);
+    await handle.close();
+  });
+
+  it('leaves MCP tools on the original permission chain when no policy is injected', async () => {
+    const { handle, canUseTool, seen } = await startSession();
+
+    await canUseTool('mcp__cindy_browser__call_tool', {}, { toolUseID: 't-nopolicy' });
+
+    expect(permissionRequests(seen)).toHaveLength(1);
+    await handle.close();
+  });
+});

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1048,6 +1048,14 @@ export class ClaudeCodeAgent extends BaseAgent {
      *
      * 本地 canUseTool 与远端 onApprovalRequest 都走这里 —— 否则同一套 MCP 配置在
      * SSH 会话里又会退回"逐次弹窗 + 没有 forced prompt 保护"的老行为。
+     *
+     * **已知差异(bypassPermissions)**: 该档位下 SDK 直接跳过全部权限检查
+     * (allowDangerouslySkipPermissions, 见 SDK PermissionMode 文档), canUseTool 根本
+     * 不会被调用, 所以这里的 prompt-each-time 拦不住 Full access 会话 —— 那是该档位
+     * 本身的语义("Accepts all permissions"), 不是本函数的兜底范围。Codex 侧的
+     * forcePrompt 因为走自己的 approval 通道, 在 Full access 下仍会弹, 两端在这一档
+     * 上不等价。要抹平得把 Full access 改成"SDK 停在可回调档 + canUseTool 里模拟放行",
+     * 那会动到所有 Full access 会话的执行路径, 需要实机验证后单独做。
      */
     const classifyMcpApprovalPolicy = (
       toolName: string,

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -196,18 +196,29 @@ function isReadOnlyClaudeTool(toolName: string): boolean {
 /**
  * 把 Claude SDK 的 MCP 工具名拆成 host 审批策略要的 { serverName, toolName }。
  *
- * SDK 命名格式固定为 `mcp__<server>__<tool>`: server 段自身可以含单下划线
- * (`cindy_browser`), 分隔符是双下划线, 所以按 `__` 切分后首段即 server, 其余重新
- * 拼回工具名(渐进式 server 只有 `list_tools` / `call_tool` 两个外层工具)。
- * 非 MCP 的内置工具(Bash / Read / ...)返回 null, 由原有权限链处理。
+ * SDK 命名格式为 `mcp__<server>__<tool>`, 但**不能**按 `__` 盲切首段当 server ——
+ * server 名自身可以含 `__`(自定义 MCP 的 id 正则是 `/^[a-z0-9_-]+$/`, 下划线合法)。
+ * 盲切会让 id 为 `cindy_browser__evil` 的第三方 server 被识别成第一方 `cindy_browser`,
+ * 直接继承信任表里的静默放行 —— 这是一条实打实的提权路径。
+ *
+ * 因此只在**本 session 实际注册过**的 server 名里做前缀匹配, 命中多个时取最长者
+ * (`cindy_browser__evil` 胜过 `cindy_browser`), 保证归属唯一。名字对不上任何已注册
+ * server 时返回 null, 调用方按"不查策略"处理 —— 走原有权限链, 不放行。
  */
-function parseMcpToolName(toolName: string): { serverName: string; toolName: string } | null {
+function resolveMcpToolTarget(
+  toolName: string,
+  registeredServerNames: ReadonlySet<string>,
+): { serverName: string; toolName: string } | null {
   if (!toolName.startsWith('mcp__')) return null;
-  const [serverName, ...rest] = toolName.slice('mcp__'.length).split('__');
-  if (!serverName || rest.length === 0) return null;
-  const inner = rest.join('__');
-  if (!inner) return null;
-  return { serverName, toolName: inner };
+  let best: { serverName: string; toolName: string } | null = null;
+  for (const serverName of registeredServerNames) {
+    const prefix = `mcp__${serverName}__`;
+    if (!toolName.startsWith(prefix) || toolName.length <= prefix.length) continue;
+    if (!best || serverName.length > best.serverName.length) {
+      best = { serverName, toolName: toolName.slice(prefix.length) };
+    }
+  }
+  return best;
 }
 
 /**
@@ -851,6 +862,12 @@ export class ClaudeCodeAgent extends BaseAgent {
     const claudeAllowedTools = this.deps.claudeAllowedTools?.length
       ? [...this.deps.claudeAllowedTools]
       : undefined;
+    /**
+     * 本 session 实际注册进 SDK 的 MCP server 名, 由 buildMcpServers 写入。
+     * canUseTool 用它把 `mcp__<server>__<tool>` 归属到唯一 server; 空集合时
+     * 一律解析失败 → MCP 策略不参与判定, 维持原权限链。
+     */
+    let registeredMcpServerNames: ReadonlySet<string> = new Set();
     const buildMcpServers = (): Record<string, McpServerConfig> | undefined => {
       const providers = mcpProviders;
       if (providers.length === 0) return undefined;
@@ -874,6 +891,9 @@ export class ClaudeCodeAgent extends BaseAgent {
         if (!config) continue;
         out[provider.name] = config as McpServerConfig;
       }
+      // canUseTool 只认这批真实注册过的 server 名, 不靠 `mcp__` 工具名切分猜归属
+      // (见 resolveMcpToolTarget: 自定义 server id 可以含 `__`, 盲切会被冒名顶替)。
+      registeredMcpServerNames = new Set(Object.keys(out));
       return Object.keys(out).length > 0 ? out : undefined;
     };
 
@@ -909,6 +929,8 @@ export class ClaudeCodeAgent extends BaseAgent {
       kind: InteractionRequest['kind'];
       resolve: (d: InteractionDecision) => void;
       settled: boolean;
+      /** prompt-each-time 高风险审批: 切到宽松模式时也不接受 dismissAllPending('allow')。 */
+      forcePrompt?: boolean;
     };
     const pendingInteractions = new Map<string, PendingEntry>();
 
@@ -922,13 +944,21 @@ export class ClaudeCodeAgent extends BaseAgent {
      * 任一时刻可由 dismissAllPending 强制提前 resolve(走 settled flag 防止 host 后续回调
      * 又 resolve 一次)。
      */
-    async function dispatchInteraction(req: InteractionRequest): Promise<InteractionDecision> {
+    async function dispatchInteraction(
+      req: InteractionRequest,
+      opts?: { forcePrompt?: boolean },
+    ): Promise<InteractionDecision> {
       if (!interactionResolver) {
         return safeDefaultDecision(req.kind, 'no_resolver_attached');
       }
       const resolver = interactionResolver;
       return new Promise<InteractionDecision>((resolve) => {
-        const entry: PendingEntry = { kind: req.kind, resolve, settled: false };
+        const entry: PendingEntry = {
+          kind: req.kind,
+          resolve,
+          settled: false,
+          ...(opts?.forcePrompt ? { forcePrompt: true } : {}),
+        };
         pendingInteractions.set(req.requestId, entry);
         const finalize = (d: InteractionDecision) => {
           if (entry.settled) return;
@@ -956,13 +986,23 @@ export class ClaudeCodeAgent extends BaseAgent {
       const entries = Array.from(pendingInteractions.entries());
       for (const [requestId, entry] of entries) {
         if (entry.settled) continue;
-        const decision = resolveAs === 'allow' && entry.kind !== 'ask_user_question'
+        // forcePrompt(prompt-each-time 高风险审批)不接受"切到宽松模式"的批量放行 ——
+        // 没拿到用户对这一次调用的明确确认就 fail-closed 拒绝, 与 Codex 侧同名逻辑
+        // 一致。否则用户在 pending 期间切到 auto / bypassPermissions, 一个破坏性的
+        // contacts 调用就被自动 allow 了。
+        const effectiveResolveAs: 'allow' | 'deny' =
+          resolveAs === 'allow' && entry.forcePrompt === true ? 'deny' : resolveAs;
+        const decision = effectiveResolveAs === 'allow' && entry.kind !== 'ask_user_question'
           ? ({ kind: entry.kind, behavior: 'allow' } as InteractionDecision)
           : safeDefaultDecision(entry.kind, reason);
         entry.settled = true;
         pendingInteractions.delete(requestId);
         entry.resolve(decision);
-        const dismissedPayload: InteractionDismissedEvent = { requestId, reason, resolvedAs: resolveAs };
+        const dismissedPayload: InteractionDismissedEvent = {
+          requestId,
+          reason,
+          resolvedAs: effectiveResolveAs,
+        };
         eventQueue.push({ type: 'interaction_dismissed', data: dismissedPayload, source: 'claude-code' });
       }
     }
@@ -1059,15 +1099,35 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
 
       // ── 3. 其他工具 → permission kind ──
-      // 3a. MCP 工具先过 host 审批策略 —— 与 Codex 的 mcpServerElicitation 同一个
+      // 没接 resolver → fail-closed(安全拦截逻辑不许 fail-open)。
+      // 正常流程里 Session 构造时**必定**注入 resolver(见 session.ts:
+      // setInteractionResolver, 且 host 没接 listener 时该 resolver 自身返回 deny),
+      // 故这里 interactionResolver 为 null 只可能是 misconfiguration / 裸 handle 直用。
+      // 此时对已知只读内省工具(Read/Glob/Grep/...)放行, 对会改文件 / 跑命令 / 发外部
+      // 消息的工具及一切未知工具一律 deny —— 不再依赖 SDK permissionMode 兜底。
+      //
+      // 这道闸必须在 MCP 审批策略**之前**: host 策略描述的是"这个工具值不值得打扰
+      // 用户", 不代表"没有用户在场也可以跑"。裸 handle 场景下没有任何人能撤销误判,
+      // 可信 MCP 同样落到 deny。
+      if (!interactionResolver) {
+        if (isReadOnlyClaudeTool(toolName)) {
+          return { behavior: 'allow', updatedInput: input };
+        }
+        log.warn('canUseTool without interactionResolver → fail-closed deny', { tool: toolName });
+        return { behavior: 'deny', message: 'no interaction resolver attached; denying non-read-only tool (fail-closed)' };
+      }
+
+      // 3a. MCP 工具过 host 审批策略 —— 与 Codex 的 mcpServerElicitation 同一个
       // deps.getMcpToolApprovalPolicy 真源。两端共用后, 同一个第一方 MCP 不会出现
       // "Codex 静默执行 / Claude 每次调用都弹窗"的分叉(浏览器自动化这类高频 server
       // 一次调研能攒出上百个权限请求)。
       //   auto-approve      → 静默放行, 不打扰用户
-      //   prompt-each-time  → 照常弹窗, 但剥掉会话级 suggestion(不给"总是允许")
+      //   prompt-each-time  → 照常弹窗, 且全程禁止持久化授权(suggestion 不下发、
+      //                       decision 带回来的 permissionUpdates 也丢弃、切到宽松
+      //                       模式时 pending 请求 fail-closed)
       //   prompt / 未注入   → 完全维持原有权限链
       // 策略抛错或返回非法值时按最保守的 prompt-each-time 处理(与 Codex 侧一致)。
-      const mcpTarget = parseMcpToolName(toolName);
+      const mcpTarget = resolveMcpToolTarget(toolName, registeredMcpServerNames);
       let mcpApprovalPolicy: 'auto-approve' | 'prompt' | 'prompt-each-time' = 'prompt';
       if (mcpTarget && this.deps.getMcpToolApprovalPolicy) {
         try {
@@ -1100,20 +1160,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           return { behavior: 'allow', updatedInput: input };
         }
       }
-
-      // 没接 resolver → fail-closed(安全拦截逻辑不许 fail-open)。
-      // 正常流程里 Session 构造时**必定**注入 resolver(见 session.ts:
-      // setInteractionResolver, 且 host 没接 listener 时该 resolver 自身返回 deny),
-      // 故这里 interactionResolver 为 null 只可能是 misconfiguration / 裸 handle 直用。
-      // 此时对已知只读内省工具(Read/Glob/Grep/...)放行, 对会改文件 / 跑命令 / 发外部
-      // 消息的工具及一切未知工具一律 deny —— 不再依赖 SDK permissionMode 兜底。
-      if (!interactionResolver) {
-        if (isReadOnlyClaudeTool(toolName)) {
-          return { behavior: 'allow', updatedInput: input };
-        }
-        log.warn('canUseTool without interactionResolver → fail-closed deny', { tool: toolName });
-        return { behavior: 'deny', message: 'no interaction resolver attached; denying non-read-only tool (fail-closed)' };
-      }
+      const forcePrompt = mcpApprovalPolicy === 'prompt-each-time';
       const decision = await dispatchInteraction({
         kind: 'permission',
         requestId: options.toolUseID,
@@ -1124,7 +1171,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         description: options.description,
         // prompt-each-time 的语义是"每次都要人过目", 因此不把会话级 suggestion 交给
         // UI —— 否则用户点一次"总是允许"就把逐次确认的高风险 action 永久放行了。
-        suggestions: mcpApprovalPolicy === 'prompt-each-time'
+        suggestions: forcePrompt
           ? undefined
           : this.normalizeSessionPermissionSuggestions(options.suggestions),
         metadata: {
@@ -1132,7 +1179,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           ...(options.decisionReason ? { decisionReason: options.decisionReason } : {}),
           ...(options.agentID ? { agentID: options.agentID } : {}),
         },
-      });
+      }, { forcePrompt });
       if (decision.kind !== 'permission') {
         log.warn('permission got mismatched decision', { tool: toolName, decKind: decision.kind });
         return { behavior: 'deny', message: 'resolver kind mismatch' };
@@ -1149,7 +1196,18 @@ export class ClaudeCodeAgent extends BaseAgent {
         // Pass-through vendor-specific permission rule updates. BaseAgent owns
         // the session-scope normalization; Claude SDK validates the final shape.
         // PermissionUpdate shapes; we don't validate — SDK throws on bad shape.
-        if (decision.permissionUpdates && decision.permissionUpdates.length > 0) {
+        //
+        // forcePrompt 下必须在**消费决策**这一侧丢弃, 不能只靠不下发 suggestion:
+        // hook-control/interactions.ts 与 IM 卡片流会自己拼 permissionUpdates(不看
+        // request.suggestions), 原样转给 SDK 就等于给逐次确认的高风险 action 落了
+        // 一条会话规则, 之后的 canUseTool 全被跳过。本次调用仍按用户意愿放行。
+        if (forcePrompt) {
+          if (decision.permissionUpdates && decision.permissionUpdates.length > 0) {
+            log.warn('dropping session permission grant for prompt-each-time MCP tool', {
+              tool: toolName,
+            });
+          }
+        } else if (decision.permissionUpdates && decision.permissionUpdates.length > 0) {
           out.updatedPermissions = decision.permissionUpdates as PermissionUpdate[];
         }
         return out;

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -887,6 +887,16 @@ export class ClaudeCodeAgent extends BaseAgent {
       for (const provider of providers) {
         if (provider.name === 'cindy_memory' && (!makerMemoryEnabled || opts.remoteHostId)) continue;
         if (provider.isEnabled && !provider.isEnabled(context)) continue;
+        // 同名 provider 先注册者胜 —— host 把用户自定义 MCP **追加**在内置之后, 后写
+        // 覆盖会让一个 id 取名 `cindy_browser` 的自定义远程端点顶替内置 server:
+        // 既悄悄换掉了内置能力, 又让审批策略(只看 serverName)把第三方端点的所有工具
+        // 当第一方静默放行。host 侧也拦了这类保留名, 这里是纵深防御。
+        if (Object.prototype.hasOwnProperty.call(out, provider.name)) {
+          log.warn('duplicate MCP server name; keeping the first registration', {
+            serverName: provider.name,
+          });
+          continue;
+        }
         const config = provider.toClaudeSdkConfig?.(context);
         if (!config) continue;
         out[provider.name] = config as McpServerConfig;
@@ -1017,6 +1027,56 @@ export class ClaudeCodeAgent extends BaseAgent {
       eventQueue.push({ type: 'interaction_dismissed', data: { requestId, reason, resolvedAs }, source: 'claude-code' });
     }
 
+    /**
+     * MCP 工具的 host 审批档位 —— 与 Codex 的 mcpServerElicitation 同一个
+     * deps.getMcpToolApprovalPolicy 真源。两端共用后, 同一个第一方 MCP 不会出现
+     * "Codex 静默执行 / Claude 每次调用都弹窗"的分叉(浏览器自动化这类高频 server
+     * 一次调研能攒出上百个权限请求)。
+     *   auto-approve      → 静默放行, 不打扰用户
+     *   prompt-each-time  → 照常弹窗, 且全程禁止持久化授权(suggestion 不下发、
+     *                       decision 带回来的 permissionUpdates 也丢弃、切到宽松
+     *                       模式时 pending 请求 fail-closed)
+     *   prompt / 未注入   → 完全维持原有权限链
+     * 策略抛错或返回非法值时按最保守的 prompt-each-time 处理(与 Codex 侧一致)。
+     *
+     * 本地 canUseTool 与远端 onApprovalRequest 都走这里 —— 否则同一套 MCP 配置在
+     * SSH 会话里又会退回"逐次弹窗 + 没有 forced prompt 保护"的老行为。
+     */
+    const classifyMcpApprovalPolicy = (
+      toolName: string,
+      input: unknown,
+    ): 'auto-approve' | 'prompt' | 'prompt-each-time' => {
+      const target = resolveMcpToolTarget(toolName, registeredMcpServerNames);
+      const classifier = this.deps.getMcpToolApprovalPolicy;
+      if (!target || !classifier) return 'prompt';
+      try {
+        const policy = classifier({
+          serverName: target.serverName,
+          toolName: target.toolName,
+          toolParams: input,
+        });
+        if (policy === 'auto-approve' || policy === 'prompt' || policy === 'prompt-each-time') {
+          if (policy === 'auto-approve') {
+            log.debug('mcp tool auto-approved by host policy', {
+              serverName: target.serverName,
+              toolName: target.toolName,
+            });
+          }
+          return policy;
+        }
+        log.error('invalid MCP approval policy -> prompt each time', {
+          serverName: target.serverName,
+          policy,
+        });
+      } catch (error) {
+        log.error('MCP approval policy threw -> prompt each time', {
+          serverName: target.serverName,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return 'prompt-each-time';
+    };
+
     // canUseTool dispatcher —— 三路分支(参考 agentManager.ts:1054-1162):
     //  1. AskUserQuestion: 模型问问题, 转 ask_user_question kind, decision.answers 拼回 updatedInput
     //  2. ExitPlanMode:   plan 模式提交计划, 转 plan_review kind, decision.editedPlan 覆盖 plan
@@ -1117,48 +1177,10 @@ export class ClaudeCodeAgent extends BaseAgent {
         return { behavior: 'deny', message: 'no interaction resolver attached; denying non-read-only tool (fail-closed)' };
       }
 
-      // 3a. MCP 工具过 host 审批策略 —— 与 Codex 的 mcpServerElicitation 同一个
-      // deps.getMcpToolApprovalPolicy 真源。两端共用后, 同一个第一方 MCP 不会出现
-      // "Codex 静默执行 / Claude 每次调用都弹窗"的分叉(浏览器自动化这类高频 server
-      // 一次调研能攒出上百个权限请求)。
-      //   auto-approve      → 静默放行, 不打扰用户
-      //   prompt-each-time  → 照常弹窗, 且全程禁止持久化授权(suggestion 不下发、
-      //                       decision 带回来的 permissionUpdates 也丢弃、切到宽松
-      //                       模式时 pending 请求 fail-closed)
-      //   prompt / 未注入   → 完全维持原有权限链
-      // 策略抛错或返回非法值时按最保守的 prompt-each-time 处理(与 Codex 侧一致)。
-      const mcpTarget = resolveMcpToolTarget(toolName, registeredMcpServerNames);
-      let mcpApprovalPolicy: 'auto-approve' | 'prompt' | 'prompt-each-time' = 'prompt';
-      if (mcpTarget && this.deps.getMcpToolApprovalPolicy) {
-        try {
-          const policy = this.deps.getMcpToolApprovalPolicy({
-            serverName: mcpTarget.serverName,
-            toolName: mcpTarget.toolName,
-            toolParams: input,
-          });
-          if (policy === 'auto-approve' || policy === 'prompt' || policy === 'prompt-each-time') {
-            mcpApprovalPolicy = policy;
-          } else {
-            log.error('invalid MCP approval policy -> prompt each time', {
-              serverName: mcpTarget.serverName,
-              policy,
-            });
-            mcpApprovalPolicy = 'prompt-each-time';
-          }
-        } catch (error) {
-          log.error('MCP approval policy threw -> prompt each time', {
-            serverName: mcpTarget.serverName,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          mcpApprovalPolicy = 'prompt-each-time';
-        }
-        if (mcpApprovalPolicy === 'auto-approve') {
-          log.debug('mcp tool auto-approved by host policy', {
-            serverName: mcpTarget.serverName,
-            toolName: mcpTarget.toolName,
-          });
-          return { behavior: 'allow', updatedInput: input };
-        }
+      // 3a. MCP 工具过 host 审批策略(本地与远端会话共用 classifyMcpApprovalPolicy)。
+      const mcpApprovalPolicy = classifyMcpApprovalPolicy(toolName, input);
+      if (mcpApprovalPolicy === 'auto-approve') {
+        return { behavior: 'allow', updatedInput: input };
       }
       const forcePrompt = mcpApprovalPolicy === 'prompt-each-time';
       const decision = await dispatchInteraction({
@@ -1683,6 +1705,10 @@ export class ClaudeCodeAgent extends BaseAgent {
           const dropped = Object.keys(mcpServers).filter((k) => !(k in remoteMcpServers));
           log.warn('cc remote: dropping in-process MCP servers (MVP not supported)', { dropped });
         }
+        // 远端会话实际只装到 remoteMcpServers 这一批, 被 filter 掉的 in-process server
+        // 在远端不存在 —— 审批归属必须按远端真实清单判, 否则策略会对远端根本不可能
+        // 出现的 server 名做判定。
+        registeredMcpServerNames = new Set(Object.keys(remoteMcpServers ?? {}));
         // 计划模式开启时远端 SDK 同样跑 plan; 读 mutable 值让 rewind 重建也拿到当前档。
         const remotePermissionMode = extra?.permissionMode ?? effectiveSdkPermissionMode();
         sdkInPlanMode = remotePermissionMode === 'plan';
@@ -1758,7 +1784,10 @@ export class ClaudeCodeAgent extends BaseAgent {
             // On timeout, dismiss the pending interaction (clears UI) and reject to
             // let cc-manager-client return deny to daemon.
             const REMOTE_APPROVAL_TIMEOUT_MS = 110_000;
-            async function dispatchWithTimeout(req: InteractionRequest): Promise<InteractionDecision> {
+            async function dispatchWithTimeout(
+              req: InteractionRequest,
+              dispatchOpts?: { forcePrompt?: boolean },
+            ): Promise<InteractionDecision> {
               let timer: NodeJS.Timeout | undefined;
               try {
                 return await new Promise<InteractionDecision>((resolve, reject) => {
@@ -1766,7 +1795,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                     dismissSinglePending(req.requestId, 'approval_timeout');
                     reject(new Error('approval timed out'));
                   }, REMOTE_APPROVAL_TIMEOUT_MS);
-                  dispatchInteraction(req).then(resolve, reject);
+                  dispatchInteraction(req, dispatchOpts).then(resolve, reject);
                 });
               } finally {
                 if (timer) clearTimeout(timer);
@@ -1821,6 +1850,16 @@ export class ClaudeCodeAgent extends BaseAgent {
             if (!interactionResolver) {
               return { kind: 'permission', behavior: 'allow' };
             }
+            // 远端会话走同一份 host MCP 策略 —— 否则 SSH 会话里可信 server 又要逐次
+            // 弹窗, prompt-each-time 的"禁止持久化授权"保护也整套缺失。
+            const remoteMcpPolicy = classifyMcpApprovalPolicy(
+              params.toolName ?? '',
+              params.input ?? {},
+            );
+            if (remoteMcpPolicy === 'auto-approve') {
+              return { kind: 'permission', behavior: 'allow' };
+            }
+            const remoteForcePrompt = remoteMcpPolicy === 'prompt-each-time';
             const decision = await dispatchWithTimeout({
               kind: 'permission',
               requestId: params.requestId,
@@ -1829,17 +1868,24 @@ export class ClaudeCodeAgent extends BaseAgent {
               title: params.title,
               displayName: params.displayName,
               description: params.description,
-              suggestions: this.normalizeSessionPermissionSuggestions(params.suggestions),
+              suggestions: remoteForcePrompt
+                ? undefined
+                : this.normalizeSessionPermissionSuggestions(params.suggestions),
               metadata: params.metadata ?? {},
-            });
+            }, { forcePrompt: remoteForcePrompt });
             if (decision.kind !== 'permission') {
               return { kind: 'permission', behavior: 'deny', reason: 'resolver kind mismatch' };
+            }
+            if (remoteForcePrompt && decision.permissionUpdates && decision.permissionUpdates.length > 0) {
+              log.warn('dropping session permission grant for prompt-each-time MCP tool (remote)', {
+                tool: params.toolName,
+              });
             }
             return {
               kind: 'permission',
               behavior: decision.behavior,
               updatedInput: decision.updatedInput,
-              permissionUpdates: decision.permissionUpdates,
+              permissionUpdates: remoteForcePrompt ? undefined : decision.permissionUpdates,
               reason: decision.reason,
             };
           },

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1053,9 +1053,18 @@ export class ClaudeCodeAgent extends BaseAgent {
      * (allowDangerouslySkipPermissions, 见 SDK PermissionMode 文档), canUseTool 根本
      * 不会被调用, 所以这里的 prompt-each-time 拦不住 Full access 会话 —— 那是该档位
      * 本身的语义("Accepts all permissions"), 不是本函数的兜底范围。Codex 侧的
-     * forcePrompt 因为走自己的 approval 通道, 在 Full access 下仍会弹, 两端在这一档
-     * 上不等价。要抹平得把 Full access 改成"SDK 停在可回调档 + canUseTool 里模拟放行",
-     * 那会动到所有 Full access 会话的执行路径, 需要实机验证后单独做。
+     * forcePrompt 走自己的 approval 通道, 在 Full access 下仍会弹, 两端在这一档不等价。
+     *
+     * 抹平它的两条路都不便宜(结论来自 cc 2.1.219 的 cli.js 权限判定 `zd8`):
+     *  - PreToolUse hook: hook 无条件执行(先于权限判定), 且 hook 返回 deny 会在 `zd8`
+     *    首个分支直接阻断、不看 permissionMode —— 所以 hook 能在 Full access 下**拒绝**;
+     *    但 hook 返回 ask 会落到正常权限管线, 而该管线在 bypass 下就是放行, 所以做不到
+     *    Codex 那样的"仍然弹窗询问"。只能把高风险 action 变成硬拒绝, 用户在自己选了
+     *    Full access 之后反而做不了这些操作, 体验上不可接受。
+     *  - 让 Full access 停在可回调档(default) + canUseTool 里模拟放行普通工具: 能拿到
+     *    真 parity, 但 Full access 的判定语义会整体改变(settings 的 deny 规则、沙箱网络
+     *    等不经 canUseTool 的检查都会重新生效), 必须实机验证后才能上。
+     * 因此本轮如实保留差异, 不做半吊子拦截。
      */
     const classifyMcpApprovalPolicy = (
       toolName: string,

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -194,6 +194,23 @@ function isReadOnlyClaudeTool(toolName: string): boolean {
 }
 
 /**
+ * 把 Claude SDK 的 MCP 工具名拆成 host 审批策略要的 { serverName, toolName }。
+ *
+ * SDK 命名格式固定为 `mcp__<server>__<tool>`: server 段自身可以含单下划线
+ * (`cindy_browser`), 分隔符是双下划线, 所以按 `__` 切分后首段即 server, 其余重新
+ * 拼回工具名(渐进式 server 只有 `list_tools` / `call_tool` 两个外层工具)。
+ * 非 MCP 的内置工具(Bash / Read / ...)返回 null, 由原有权限链处理。
+ */
+function parseMcpToolName(toolName: string): { serverName: string; toolName: string } | null {
+  if (!toolName.startsWith('mcp__')) return null;
+  const [serverName, ...rest] = toolName.slice('mcp__'.length).split('__');
+  if (!serverName || rest.length === 0) return null;
+  const inner = rest.join('__');
+  if (!inner) return null;
+  return { serverName, toolName: inner };
+}
+
+/**
  * 把 maker-core 的 Effort clamp 到 Claude SDK 支持的档位 (ClaudeSdkEffort)。
  * Claude 没有 'minimal'(→ 'low') 与 'ultra'(→ 'max'; ultra 是 Codex GPT-5.6 专属档)。
  */
@@ -1042,6 +1059,48 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
 
       // ── 3. 其他工具 → permission kind ──
+      // 3a. MCP 工具先过 host 审批策略 —— 与 Codex 的 mcpServerElicitation 同一个
+      // deps.getMcpToolApprovalPolicy 真源。两端共用后, 同一个第一方 MCP 不会出现
+      // "Codex 静默执行 / Claude 每次调用都弹窗"的分叉(浏览器自动化这类高频 server
+      // 一次调研能攒出上百个权限请求)。
+      //   auto-approve      → 静默放行, 不打扰用户
+      //   prompt-each-time  → 照常弹窗, 但剥掉会话级 suggestion(不给"总是允许")
+      //   prompt / 未注入   → 完全维持原有权限链
+      // 策略抛错或返回非法值时按最保守的 prompt-each-time 处理(与 Codex 侧一致)。
+      const mcpTarget = parseMcpToolName(toolName);
+      let mcpApprovalPolicy: 'auto-approve' | 'prompt' | 'prompt-each-time' = 'prompt';
+      if (mcpTarget && this.deps.getMcpToolApprovalPolicy) {
+        try {
+          const policy = this.deps.getMcpToolApprovalPolicy({
+            serverName: mcpTarget.serverName,
+            toolName: mcpTarget.toolName,
+            toolParams: input,
+          });
+          if (policy === 'auto-approve' || policy === 'prompt' || policy === 'prompt-each-time') {
+            mcpApprovalPolicy = policy;
+          } else {
+            log.error('invalid MCP approval policy -> prompt each time', {
+              serverName: mcpTarget.serverName,
+              policy,
+            });
+            mcpApprovalPolicy = 'prompt-each-time';
+          }
+        } catch (error) {
+          log.error('MCP approval policy threw -> prompt each time', {
+            serverName: mcpTarget.serverName,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          mcpApprovalPolicy = 'prompt-each-time';
+        }
+        if (mcpApprovalPolicy === 'auto-approve') {
+          log.debug('mcp tool auto-approved by host policy', {
+            serverName: mcpTarget.serverName,
+            toolName: mcpTarget.toolName,
+          });
+          return { behavior: 'allow', updatedInput: input };
+        }
+      }
+
       // 没接 resolver → fail-closed(安全拦截逻辑不许 fail-open)。
       // 正常流程里 Session 构造时**必定**注入 resolver(见 session.ts:
       // setInteractionResolver, 且 host 没接 listener 时该 resolver 自身返回 deny),
@@ -1063,7 +1122,11 @@ export class ClaudeCodeAgent extends BaseAgent {
         title: options.title,
         displayName: options.displayName,
         description: options.description,
-        suggestions: this.normalizeSessionPermissionSuggestions(options.suggestions),
+        // prompt-each-time 的语义是"每次都要人过目", 因此不把会话级 suggestion 交给
+        // UI —— 否则用户点一次"总是允许"就把逐次确认的高风险 action 永久放行了。
+        suggestions: mcpApprovalPolicy === 'prompt-each-time'
+          ? undefined
+          : this.normalizeSessionPermissionSuggestions(options.suggestions),
         metadata: {
           ...(options.blockedPath ? { blockedPath: options.blockedPath } : {}),
           ...(options.decisionReason ? { decisionReason: options.decisionReason } : {}),

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -883,7 +883,12 @@ export class ClaudeCodeAgent extends BaseAgent {
         sessionId: opts.sessionId,
         getSessionContext: () => context,
       };
-      const out: Record<string, McpServerConfig> = {};
+      // null-prototype: server 名来自用户可控的自定义 MCP id, 而 id 正则允许下划线,
+      // `__proto__` 是合法 id。用普通 `{}` 时 `out['__proto__'] = config` 命中的是原型
+      // 访问器 —— 不产生自有属性(hasOwnProperty / Object.keys 都看不见, 去重与归属判定
+      // 一起失效), 反而把这个 map 的原型换成了 config。null-prototype 让这类名字退化成
+      // 普通字符串键。
+      const out: Record<string, McpServerConfig> = Object.create(null);
       for (const provider of providers) {
         if (provider.name === 'cindy_memory' && (!makerMemoryEnabled || opts.remoteHostId)) continue;
         if (provider.isEnabled && !provider.isEnabled(context)) continue;
@@ -904,7 +909,9 @@ export class ClaudeCodeAgent extends BaseAgent {
       // canUseTool 只认这批真实注册过的 server 名, 不靠 `mcp__` 工具名切分猜归属
       // (见 resolveMcpToolTarget: 自定义 server id 可以含 `__`, 盲切会被冒名顶替)。
       registeredMcpServerNames = new Set(Object.keys(out));
-      return Object.keys(out).length > 0 ? out : undefined;
+      // 交回普通对象: SDK / RPC 序列化路径按普通对象处理(有的实现会调 obj.hasOwnProperty)。
+      // spread 走 CreateDataProperty, 不触发 `__proto__` setter, 所以这一步是安全的。
+      return Object.keys(out).length > 0 ? { ...out } : undefined;
     };
 
     // ── userMessageStream + permission callback 准备 ────────────────────────
@@ -1847,8 +1854,23 @@ export class ClaudeCodeAgent extends BaseAgent {
               };
             }
             // permission kind
+            // 没接 resolver → 与本地 canUseTool 同款 fail-closed: 只放行已知只读工具,
+            // 其余(含未知工具与所有 MCP 工具)一律 deny。这里过去 return allow, 一个
+            // misconfigured / 裸 handle 的远端会话可以在无人在场时跑破坏性工具 ——
+            // 本地那侧不允许的事, 远端没有理由更宽。
             if (!interactionResolver) {
-              return { kind: 'permission', behavior: 'allow' };
+              const remoteTool = params.toolName ?? '';
+              if (isReadOnlyClaudeTool(remoteTool)) {
+                return { kind: 'permission', behavior: 'allow' };
+              }
+              log.warn('cc remote: approval without interactionResolver → fail-closed deny', {
+                tool: remoteTool || 'unknown',
+              });
+              return {
+                kind: 'permission',
+                behavior: 'deny',
+                reason: 'no interaction resolver attached; denying non-read-only tool (fail-closed)',
+              };
             }
             // 远端会话走同一份 host MCP 策略 —— 否则 SSH 会话里可信 server 又要逐次
             // 弹窗, prompt-each-time 的"禁止持久化授权"保护也整套缺失。


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户反馈：在 Cindy 里跑一个浏览器调研任务，弹了上百个 Permission Request，把桌宠权限卡片刷爆了；同样的能力在自己的 cc 里不需要确认。

根因是 Claude Code 与 Codex 两条通道各有一套 MCP 审批配置：

- Codex 走 `mcpServerElicitation` → host 策略 `getDesktopMcpToolApprovalPolicy`，`cindy_browser` 整个 server `auto-approve`，静默执行。
- Claude **完全不查这个策略**，只有一份静态 `allowedTools` 白名单，而该白名单刻意排除所有 `__call_tool` 聚合入口。

`cindy_browser` 只有两个外层工具：`list_tools`（已放行）和 `call_tool`——navigate / snapshot / click / extract 等真实动作全部走后者。于是同一个第一方 MCP，Codex 侧一次都不弹，Claude 侧每调用一次弹一次窗。这不是 harness 或模型选择的问题，是两端策略源分叉。

本 PR 把两端合并到同一份配置，Claude 通道开始消费 host 策略。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈（浏览器调研任务弹出上百个权限请求）
- 本 PR 包含：
  - `maker-core`：`ClaudeCodeAgent.canUseTool` 对 `mcp__<server>__<tool>` 形态的工具查 `deps.getMcpToolApprovalPolicy`，语义与 Codex 的 `mcpServerElicitation` 完全对齐——`auto-approve` 静默放行，`prompt-each-time` 照常弹窗但剥掉会话级 suggestion（不给"总是允许"），`prompt` / 未注入策略维持原有权限链。策略抛错或返回非法值时按最保守的 `prompt-each-time` 兜底，绝不 fail-open。
  - `desktop`：`mcp-tool-approval-policy.ts` 成为双端唯一真源，并注入 `ClaudeCodeAgent`。只读白名单从"Claude 专用的 `mcp__x__y` 字符串数组"升级为精确到工具的 `<server>::<tool>` 声明，`allowedTools` 由同一张表派生，新增不变量测试保证两个出口不会漂移。
  - review 后收紧的四处绕过路径（commit `50aba5d`，详见每条 review thread 的回复）：
    1. **MCP 工具名不再按 `__` 盲切首段当 server 名**。自定义 MCP 的 id 正则 `/^[a-z0-9_-]+$/` 允许下划线，所以 `cindy_browser__evil` 是可创建的 id，盲切后会被识别成第一方 `cindy_browser` 并继承信任表的静默放行——一条实打实的提权路径。改为只在本 session 实际注册过的 server 名里做前缀匹配、命中多个取最长者；对不上任何已注册 server 时不查策略。
    2. **fail-closed 闸提到 MCP 策略之前**。裸 handle（未注入 `interactionResolver`）场景下没人能撤销误判，可信 MCP 同样 deny：host 策略表达的是"值不值得打扰用户"，不是"没有用户在场也能跑"。
    3. **`prompt-each-time` 在消费决策一侧丢弃 `permissionUpdates`**。`hook-control/interactions.ts` 与 IM 卡片流自行拼 session 规则、不看 `request.suggestions`，仅隐藏 suggestion 挡不住持久化授权；本次调用仍按用户意愿放行。
    4. **pending 条目记住 `forcePrompt`**，`dismissAllPending('allow')` 对其降级为 deny，`interaction_dismissed` 也带降级后的 `resolvedAs`。用户在 pending 期间切到 auto / bypassPermissions 时，破坏性 contacts 调用不再被批量自动放行（与 Codex 侧同名逻辑一致）。
  - 第二轮 review 后补的两处（commit `f9e540c`）：
    5. **自定义 MCP 精确撞名内置 server**。id 取作 `cindy_browser` 时，provider 被 append 在内置之后、装配层按 key 后写覆盖，于是第三方远程端点顶替内置 server 并继承对该 server 名的信任——上一轮的最长前缀匹配只挡了 `cindy_browser__evil`，挡不住精确撞名。三层修复：`refreshCustomMcpProviders` 用「数组里剩下的内置 provider 名」当保留名跳过撞名项（保留名从实际 provider 派生，内置增删自动跟上）；`validateCustomMcpConfig` 增加保留名校验，create / update 直接拒收并给出明确 message；`buildMcpServers` 同名保留先注册者作纵深防御——这条顺带修掉一个与审批无关的独立缺陷：自定义 MCP 本不该悄悄顶替内置能力。
    6. **远端 Claude 会话漏查策略**。`remoteCcQueryFactory` 的 `onApprovalRequest` 原本直接 dispatch。抽出 `classifyMcpApprovalPolicy` 供本地与远端共用，远端同样支持静默放行与 `prompt-each-time` 的完整保护；`registeredMcpServerNames` 在远端分支收窄为 `remoteMcpServers` 的 keys（in-process server 在远端被 filter 掉，按远端真实清单判归属才准确）。如实说明：当前远端拿不到 in-process 的第一方 MCP，所以「远端为可信 browser 逐次弹窗」这一具体现象不可达；修的是架构分叉，避免将来远端支持 in-process MCP 时静默退化。
    7. **第四轮**：历史存量的不安全 MCP id 隔离 + Codex 侧 map 加固（commit `e3101f81`）。保留名 / 不安全 key 的校验是后加的，`refreshCustomMcpProviders` 直接读库建 provider、不重新校验存量行；而 `codexEnvironment` 的三个 map 仍是普通 `{}`，`remoteHttpServers['__proto__'] = cfg` 命中原型 setter 后该 server 不出现在 `Object.entries` 里——同一份配置在 Claude 能用、在 Codex 静默消失，且用户无法 update（validator 已拒绝该 id）。现在 refresh 两端一律隔离这类行（warn 指明删掉重建，`delete` 按 id 走不受校验影响），三个 Codex map 同步改 null-prototype。
- **已知差异（bypassPermissions，不在本 PR 抹平）**：该档位下 SDK 直接跳过全部权限检查（`allowDangerouslySkipPermissions`，SDK 文档写明 "Bypass all permission checks"），`canUseTool` 根本不会被调用，因此 `prompt-each-time` 拦不住 Full access 会话；Codex 侧的 `forcePrompt` 走自己的 approval 通道，同档位下仍会弹，两端在这一档不等价。实际暴露面 = Full access 下 `cindy_contacts` 的 delete / merge / remove / 导入导出静默执行（当前只有 contacts 的破坏性 inner action 命中 `prompt-each-time`），这是改动前就有的行为，本 PR 未使其变差。抹平它的两条路都不便宜，结论来自读 cc 2.1.219 的权限判定 `zd8`：**PreToolUse hook 能拒绝但不能询问**——hook 无条件执行（先于权限判定），返回 `deny` 会在 `zd8` 首个分支直接阻断、不看 permissionMode，但返回 `ask` 会落到正常权限管线，而该管线在 bypass 下就是放行；所以 hook 只能把高风险 action 变成硬拒绝，用户选了 Full access 却做不了这些操作，体验倒退，且无实机验证时新增会阻断操作的 hook 误拦代价更大。**另一条（Full access 停在可回调档 + `canUseTool` 模拟放行）能拿到真 parity，但会让 settings 的 deny 规则、沙箱网络确认等不经 `canUseTool` 的检查重新生效**，是否造成意外阻断静态读不出来，必须实机验证后才能上。因此本轮如实保留差异、不做半吊子拦截；源码级依据已写进 `classifyMcpApprovalPolicy` 注释（commit `eae3dde2`），避免后来者按「hook 能拦住」的错误前提实现。实机通道恢复后按第二条路单独做。
- 明确不包含：
  - 不改动可信 server 集合（`cindy_android` / `cindy_browser` / `cindy_computer` / `cindy_feishu_bot` / `cindy_slack` / `cindy_scheduler` / `cindy_memory` / `cindy_helper` / `cindy_orca` / `cindy_lsp`），沿用 Codex 侧已 review 的名单。
  - 不改 `cindy_ssh`、插件宿主 `cindy`（`ghost_call`）、第三方 server 的逐次确认。
  - 没有按内层 action 对 `cindy_slack` / `cindy_helper` 这类 server 做细粒度拆分（见「风险」的后续项）。
- 用户可见变化：Claude Code 会话里，可信第一方 MCP 的执行入口不再逐次弹权限卡片——浏览器自动化最明显。`cindy_ssh::list_tools`、`cindy::ghost_list` 等只读发现入口在 Codex 侧也顺带免审批（此前只有 Claude 静态白名单放行）。
- 是否存在 breaking change：无

### UI 变化

不涉及：只改 main 进程策略与 agent 权限判定，没有改动任何组件、样式或文案。权限卡片本身的渲染逻辑未动。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core run typecheck
结果：通过

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/mcp-approval-policy.test.ts src/agents/claude-code/__tests__/canusetool-fail-closed.test.ts
结果：12 passed（新增 7 + 既有 fail-closed 5，未回归）

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
结果：8 passed

pnpm test:unit（仓库根全量门禁）
结果：通过（exit 0，全部 workspace 单测 Test Files / Tests 均 passed）

# review 修复后重跑全部上述命令
pnpm test:unit
结果：通过（exit 0，无失败项）

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code
结果：219 passed（22 个文件，含既有 canUseTool / plan-mode / rewind 等，无回归）

# 第二轮 review 修复后再次重跑
pnpm test:unit
结果：通过（exit 0，25 个 workspace 全 passed，无失败项）

# 第三轮 review 修复后再次重跑
pnpm test:unit
结果：通过（exit 0，无失败项）

# 第四轮 review 修复后再次重跑
pnpm test:unit
结果：通过（exit 0，无失败项）

pnpm --filter desktop exec vitest run src/main/mcp-integrations/__tests__/codexEnvironment.test.ts src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts src/main/maker-host/__tests__/custom-mcp-store.test.ts
结果：26 passed

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code
结果：224 passed（22 个文件，无回归）

pnpm --filter desktop exec vitest run src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts src/main/maker-host/__tests__/custom-mcp-store.test.ts src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
结果：27 passed
```

新增测试覆盖：

- `auto-approve` 时完全不惊动 `interactionResolver`（回归锚点：浏览器调研不该攒出弹窗）
- server 归属只认本 session 注册过的名字：`cindy_browser__evil` 必须归到自己而不是 `cindy_browser`；未注册的 server 名完全不进策略分支
- 原始 input 作为 `toolParams` 交给策略
- `prompt` 保留会话级 suggestion；`prompt-each-time` 剥掉
- `prompt-each-time` 下 surface 自带的 `permissionUpdates` 被丢弃；`prompt` 下正常转发（对照组）
- `prompt-each-time` 的 pending 请求在切到 `bypassPermissions` 后 deny；`prompt` 的 pending 仍 allow（对照组，确认不是把所有 pending 一律拒掉）
- 无 `interactionResolver` 时可信 MCP 也 deny（fail-closed 先于策略）
- 策略抛错 / 返回非法值 → 仍然弹窗且禁止持久化授权
- 内置工具（Bash / Write / Read / WebFetch）与畸形工具名不进 MCP 策略分支
- 未注入策略时 MCP 工具维持原权限链
- `allowedTools` 与动态策略的一致性不变量
- 撞名防御（第二轮）：custom provider 与内置同名时被跳过、形近名仍放行、每次 refresh 重新判定不残留旧 provider、`getBuiltinMcpServerNames` 只报内置名；`validateCustomMcpConfig` 拒收保留名 / 形近名通过 / 不传名单时跳过校验；`buildMcpServers` 同名时内置胜出

### 运行时指标实测（`maker-core-and-agent-behavior.md` §3.4）

改动落在 tool / MCP 暴露与权限分支路径上，按 §3.4 三要素给证据。

**(a) 可能影响的指标**：§3.1 缓存率（`allowedTools` 进 SDK options，属请求前缀；`buildMcpServers` 的 server 集合决定 tool 定义）、§3.2 性能（`canUseTool` 每次工具调用新增一次 server 名匹配 + 一次策略调用）、§3.3 准确性（权限分支有意改变；translator / model 路由 / event loop 零改动）。

**(b)(c) 方法与结论**：

1. **§3.1 前缀稳定性 — 逐字节比对，结论：完全未变。** 导出 `origin/main` 的硬编码数组与本 PR 派生结果做 `diff`，输出 `IDENTICAL`；并把测试从顺序不敏感的 `arrayContaining` 换成顺序敏感的 `toEqual` 锁死 12 项。其余禁止项逐条对照：策略只在 `canUseTool` 运行时求值、不进任何 prompt 段；未调整拼接顺序；未在会话中途增删 tool / MCP（`registeredMcpServerNames` 与 `mcpServers` 同源同时机，均在 `buildQuery` 一次性写入）；未碰 MEMORY.md 快照语义。
2. **§3.2 热路径耗时 — 实测，结论：+70 ns/次。** 生产规模（15 个注册 server）下对 `canUseTool` 各打点 20000 次：MCP 策略路径 `1.040 µs/call`，内置只读路径（不进策略分支）`0.968 µs/call`。`canUseTool` 不在 `AsyncQueue` / translator 的每事件每 token 热路径上；策略是纯函数，无 IO / 网络 / 深拷贝。反向看 `auto-approve` 省掉的是一次 IPC 往返 + 权限卡片渲染 + 人的等待（秒级）。
3. **§3.3 行为变化 — 19 个单测锁定分支语义**，每组带对照组（确认不是"一律放行"或"一律拒绝"）；`vitest run src/agents/claude-code` 224 passed 无回归。

### 手工验证

未执行，且**两条实机路径都被环境挡住**（已在对应 review thread 说明）：

1. 功能 worktree 起 dev 实例（`pnpm restart:desktop:remote -- --preserve-running`）被共享数据库守卫拒绝：`MIGRATE_FAILED (schema-version-behind, history-entry-missing, runtime-manifest-mismatch)`。核实过 `origin/main` 相对本分支只多 3 个 commit 且不含任何 `apps/desktop/drizzle/**` 改动，所以共享 DB 是被某个带 migration 的 open PR 实例升级的。仓库规则禁止对共享数据 migrate / repair；`--isolated` 沙箱需重新登录。
2. 脱离 Electron 的脚本化真实 turn（真实 cc 二进制 + 真实 in-process MCP + 真实 `canUseTool`）跑起来了，但 cc 报 `Not logged in`——Cindy 的 cc 鉴权由 desktop auth adapter 注入，且 flag-settings 有「apiKeyHelper 恒置空」的防线，脱离 Electron 拿不到凭证。

### 未执行的验证

- **turn 级 event-flow / cache 命中率实测**：原因同上，作为未验证边界如实登记。评估结论是它对本 PR 属补强而非唯一发现手段：改动面不进 prompt 任何一段、不改 tool 定义集合、不动 translator / event loop / model 路由，§3.1 的风险已被逐字节比对**静态穷尽**（单 turn 的 hitRate 受 warm-up / 上下文长度 / 上游路由影响，噪声大于信号，反而证明不了"没退化"），§3.2 有微基准，§3.3 有 19 个带对照组的单测。等那个带 migration 的 PR 合入 main、共享 DB 与 main 对齐后，dev 实例通道会自然恢复，届时补做。
- 未验证 plan 模式下的表现：cc CLI 在 plan mode 下如何路由 MCP 工具调用没有实测，本 PR 保持与 Codex 一致的单一语义（策略层不额外特判 plan）。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [ ] 无已知风险

### 影响与回滚

- 影响范围：
  - **Claude 通道的静默执行面扩大**。此前 `cindy_computer`（桌面控制）、`cindy_slack` / `cindy_feishu_bot`（发消息）在 Claude 侧逐次弹窗，现在与 Codex 一致静默。这是本 PR 最需要 review 的取舍：选择对齐而非各留一套，理由是两端不一致本身危害更大——用户会以为 cc 更安全，实际只是更吵，吵到最后会直接切 Full access，那才是真正的安全退步。危险面（`cindy_ssh` 任意远程命令、`ghost_call` 第三方插件沙箱、contacts 的 delete/merge/导入导出、所有第三方 server）保持逐次确认不变。
  - 后续可做的收紧方向：按内层 action 拆分 `cindy_slack`（`slack_call_tool` 里读频道历史 vs `chat_postMessage` 外发）与 `cindy_helper`（只读查询 vs `submit_github_issue` 公开写），机制已经就位（策略拿得到 `toolParams`，contacts 就是这么做的），只差逐个 server 枚举内层工具。本 PR 不顺手改，避免把行为变更混进这次对齐。
- 回滚 / 降级方式：删掉 `apps/desktop/src/main/maker-host/index.ts` 里 `claudeAgent` 的 `getMcpToolApprovalPolicy` 一行，即可让 Claude 通道立刻退回改动前的逐次弹窗行为（其余改动只剩声明重组与撞名防御，不影响弹窗行为）。整体 revert 也无状态残留：策略是纯函数，不持久化任何授权；撞名防御不写库，只在装配与 CRUD 校验时生效——revert 后既有撞名配置会恢复成改动前的「顶替内置 server」行为。
- 记录一个本 PR 不改的既有问题：远端 permission 分支在 `!interactionResolver` 时 `return { behavior: 'allow' }`，与本地的 fail-closed 相反。这是改动前就有的行为，动它需要单独评估远端 daemon 的降级路径，单独跟进更合适。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（策略文件头已写清双端判定顺序与边界；`docs/` 无对应章节需要同步）
- [x] 已确认测试结果或说明未执行原因
