### PR TITLE
fix(mobile): 修复语音听写的换行错位与「刚开始就被掐断」

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -251,6 +251,7 @@ import {
   MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
   MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
   MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
+  MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   MOBILE_COMPOSER_TOOL_GAP,
   MobileComposerInputRow,
   VoiceMicWaveCaret,
@@ -483,20 +484,6 @@ const SESSION_ACTION_TEST_IDS = {
 } satisfies Record<SessionActionStripActionId, string>;
 const COMPOSER_CONTROL_HIT_SLOP = { bottom: 8, left: 8, right: 8, top: 8 };
 const COMPOSER_INPUT_SINGLE_LINE_CONTENT_HEIGHT = MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT;
-/**
- * 听写草稿覆盖层(「点输入区停止听写」的命中层)把热区补到 44pt 触控目标。
- *
- * 它 absoluteFill 在 inputFrame 上,单行听写时只有 MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT
- * (28pt)高,不满足 mobile-design-guide「主操作命中区 ≥ 44×44」;差额在上下均分补齐。
- * 只补竖直方向:水平方向输入区本就撑满整行。溢出的热区落在 composer 卡片自身的内边距里,
- * 不会吃掉相邻控件——grabber(zIndex 3)与语音按钮(zIndex 2)都在本层之上,命中优先。
- */
-const COMPOSER_VOICE_DRAFT_HIT_SLOP = (() => {
-  const deficit = Math.max(0, 44 - MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT);
-  // 奇数差额时上多下少,两侧之和恒等于 deficit(两侧都取 ceil 会补过头)。
-  const top = Math.ceil(deficit / 2);
-  return { bottom: deficit - top, left: 0, right: 0, top };
-})();
 const COMPOSER_INPUT_MULTILINE_CONTENT_THRESHOLD = 34;
 const COMPOSER_INPUT_LINE_HEIGHT = MOBILE_COMPOSER_INPUT_LINE_HEIGHT;
 const COMPOSER_INPUT_VERTICAL_PADDING = MOBILE_COMPOSER_INPUT_VERTICAL_PADDING;
@@ -1840,7 +1827,6 @@ export default function SessionScreen() {
     <Pressable
       accessibilityLabel={t('session.common.voiceStopRecording')}
       accessibilityRole="button"
-      hitSlop={COMPOSER_VOICE_DRAFT_HIT_SLOP}
       // onPressIn 给手指「触摸即停」的即时手感;onPress 是无障碍激活(VoiceOver /
       // TalkBack 的 activate 只走 onPress,不会派发 onPressIn)的唯一入口,两者都要挂。
       // handler 幂等:finishVoiceRecording 有 voiceStopInFlight 门,重复调用是 no-op。
@@ -7129,6 +7115,9 @@ export default function SessionScreen() {
                     floatingVoiceButtonStyle={composerFloatingVoiceButtonStyle}
                     cursorColor={colors.inputCaret}
                     inputFrameHeight={composerResize.frameHeight}
+                    // 听写期间把输入区撑到 44pt 触控目标:命中层盖在 inputFrame 上,
+                    // hitSlop 越不过父边界(见常量注释)。
+                    inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}
                     inputElement={(
                       <ComposerRichInput
                         ref={composerInputRef}

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -246,6 +246,7 @@ import {
   ComposerToolbarSpacer,
   ComposerToolbarVoiceSlot,
   MOBILE_COMPOSER_CONTROL_SIZE,
+  MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
   MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
   MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
@@ -301,6 +302,7 @@ import {
   resolveComposerVoiceHoldActive,
   shouldArmComposerVoiceHold,
 } from '@/session/composerVoiceHold';
+import { COMPOSER_TEXT_HORIZONTAL_PADDING } from '@/session/composerTextMetrics';
 import {
   isMobileRealtimeAudioAvailable,
   prewarmMobileRealtimeAudio,
@@ -1817,52 +1819,64 @@ export default function SessionScreen() {
     </>
   );
   const renderComposerInputOverlay = () => voiceIsListening ? (
-    <ScrollView
-      ref={voiceDraftScrollRef}
-      contentContainerStyle={styles.voiceDraftOverlayContent}
-      onContentSizeChange={() => {
-        requestAnimationFrame(() => {
-          voiceDraftScrollRef.current?.scrollToEnd({ animated: false });
-        });
-      }}
-      onLayout={() => {
-        requestAnimationFrame(() => {
-          voiceDraftScrollRef.current?.scrollToEnd({ animated: false });
-        });
-      }}
-      pointerEvents="none"
-      scrollEnabled={composerInputScrollEnabled}
-      showsVerticalScrollIndicator={false}
+    // 「点输入区 = 想打字 → 停止听写」由这层 RN 覆盖层承接。听写期间真正盖在输入区上的
+    // 就是它;底下的富文本 WebView 此刻是 hidden(opacity 0),iOS hitTest 会跳过 alpha≈0
+    // 的 view,它根本收不到触摸——把停听写挂在 WebView 的 focus / touch 上都不成立
+    // (focus 还会被 WKWebView 自己恢复焦点误触发,掐断刚开始的听写)。
+    <Pressable
+      accessibilityLabel={t('session.common.voiceStopRecording')}
+      accessibilityRole="button"
+      onPressIn={handleComposerInputPressIn}
       style={styles.voiceDraftOverlay}
+      testID="session.voiceDraftOverlay"
     >
-      {voiceDraftShowsListeningPrompt ? (
-        <View style={styles.voiceDraftListeningPrompt}>
-          <VoiceMicWaveCaret color={colors.statusReady} testID="session.voiceMicCaret" />
-          <Text style={styles.voiceDraftListeningText}>{composerLayout.input.placeholder}</Text>
-        </View>
-      ) : (
-        <View style={styles.voiceDraftMeasuredBlock}>
-          <Text
-            onTextLayout={handleVoiceDraftTextLayout}
-            style={styles.voiceDraftText}
-          >
-            {draft}
-          </Text>
-          <View
-            pointerEvents="none"
-            style={[
-              styles.voiceDraftCaretOverlay,
-              {
-                left: voiceDraftCaretFrame.left,
-                top: voiceDraftCaretFrame.top,
-              },
-            ]}
-          >
+      <ScrollView
+        ref={voiceDraftScrollRef}
+        contentContainerStyle={styles.voiceDraftOverlayContent}
+        onContentSizeChange={() => {
+          requestAnimationFrame(() => {
+            voiceDraftScrollRef.current?.scrollToEnd({ animated: false });
+          });
+        }}
+        onLayout={() => {
+          requestAnimationFrame(() => {
+            voiceDraftScrollRef.current?.scrollToEnd({ animated: false });
+          });
+        }}
+        pointerEvents="none"
+        scrollEnabled={composerInputScrollEnabled}
+        showsVerticalScrollIndicator={false}
+        style={styles.voiceDraftScroll}
+      >
+        {voiceDraftShowsListeningPrompt ? (
+          <View style={styles.voiceDraftListeningPrompt}>
             <VoiceMicWaveCaret color={colors.statusReady} testID="session.voiceMicCaret" />
+            <Text style={styles.voiceDraftListeningText}>{composerLayout.input.placeholder}</Text>
           </View>
-        </View>
-      )}
-    </ScrollView>
+        ) : (
+          <View style={styles.voiceDraftMeasuredBlock}>
+            <Text
+              onTextLayout={handleVoiceDraftTextLayout}
+              style={styles.voiceDraftText}
+            >
+              {draft}
+            </Text>
+            <View
+              pointerEvents="none"
+              style={[
+                styles.voiceDraftCaretOverlay,
+                {
+                  left: voiceDraftCaretFrame.left,
+                  top: voiceDraftCaretFrame.top,
+                },
+              ]}
+            >
+              <VoiceMicWaveCaret color={colors.statusReady} testID="session.voiceMicCaret" />
+            </View>
+          </View>
+        )}
+      </ScrollView>
+    </Pressable>
   ) : null;
   const measureSendButtonTarget = useCallback(() => {
     sendButtonRef.current?.measureInWindow((x, y, width, height) => {
@@ -7111,10 +7125,7 @@ export default function SessionScreen() {
                           setComposerVoiceHoldArmed(false);
                         }}
                         onChangeDocument={applyRichComposerChange}
-                        onFocus={() => {
-                          setComposerFocused(true);
-                          handleComposerInputPressIn();
-                        }}
+                        onFocus={() => setComposerFocused(true)}
                         onHeightChange={handleComposerRichInputHeight}
                         onPasteImages={(uris) => void addPastedImageAttachments(uris)}
                         onPasteImagesLoading={beginPastePlaceholders}
@@ -7134,7 +7145,7 @@ export default function SessionScreen() {
                       />
                     )}
                     inputOverlay={renderComposerInputOverlay()}
-                    inputStyle={[styles.sessionComposerInput, voiceIsListening && styles.inputVoiceHidden]}
+                    inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
                     inputTestID="session.composerInput"
                     leading={renderComposerCollapsedAttachmentBadge()}
                     maxHeight={composerResize.inputMaxHeight}
@@ -8319,16 +8330,17 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     backgroundColor: colors.surfaceChip,
     borderColor: colors.borderStrong,
   },
-  sessionComposerInput: {
-    fontSize: typeScale.listBody,
-    lineHeight: lineHeight.listBody,
-  },
   voiceDraftOverlay: {
     ...StyleSheet.absoluteFill,
     overflow: 'hidden',
   },
+  // 草稿滚动层填满外层触摸区(外层负责「点输入区停听写」,自身 pointerEvents 关闭)。
+  voiceDraftScroll: {
+    flex: 1,
+  },
+  // 内边距与真实输入框同源:差一点就会让听写文字与非听写文字左右错位、换行位置不同。
   voiceDraftOverlayContent: {
-    paddingHorizontal: spacing.xs,
+    paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
     paddingVertical: COMPOSER_INPUT_VERTICAL_PADDING,
   },
   voiceDraftMeasuredBlock: {
@@ -8338,10 +8350,11 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   voiceDraftCaretOverlay: {
     position: 'absolute',
   },
+  // 草稿层的文本档必须与真实 TextInput 完全一致,否则换行位置错开、超出的行被裁在
+  // 框外(见 MOBILE_COMPOSER_DRAFT_TEXT_STYLE)。
   voiceDraftText: {
     color: colors.textPrimary,
-    fontSize: typeScale.body,
-    lineHeight: COMPOSER_INPUT_LINE_HEIGHT,
+    ...MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   },
   voiceDraftListeningPrompt: {
     alignItems: 'center',
@@ -8350,8 +8363,7 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   voiceDraftListeningText: {
     color: colors.statusReady,
-    fontSize: typeScale.body,
-    lineHeight: COMPOSER_INPUT_LINE_HEIGHT,
+    ...MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   },
   palettePanel: {
     backgroundColor: colors.surfaceElevated,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -483,6 +483,19 @@ const SESSION_ACTION_TEST_IDS = {
 } satisfies Record<SessionActionStripActionId, string>;
 const COMPOSER_CONTROL_HIT_SLOP = { bottom: 8, left: 8, right: 8, top: 8 };
 const COMPOSER_INPUT_SINGLE_LINE_CONTENT_HEIGHT = MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT;
+/**
+ * 听写草稿覆盖层(「点输入区停止听写」的命中层)把热区补到 44pt 触控目标。
+ *
+ * 它 absoluteFill 在 inputFrame 上,单行听写时只有 MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT
+ * (28pt)高,不满足 mobile-design-guide「主操作命中区 ≥ 44×44」;差额在上下均分补齐。
+ * 只补竖直方向:水平方向输入区本就撑满整行。溢出的热区落在 composer 卡片自身的内边距里,
+ * 不会吃掉相邻控件——grabber(zIndex 3)与语音按钮(zIndex 2)都在本层之上,命中优先。
+ */
+const COMPOSER_VOICE_DRAFT_HIT_SLOP = (() => {
+  const deficit = Math.max(0, 44 - MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT);
+  const vertical = Math.ceil(deficit / 2);
+  return { bottom: vertical, left: 0, right: 0, top: vertical };
+})();
 const COMPOSER_INPUT_MULTILINE_CONTENT_THRESHOLD = 34;
 const COMPOSER_INPUT_LINE_HEIGHT = MOBILE_COMPOSER_INPUT_LINE_HEIGHT;
 const COMPOSER_INPUT_VERTICAL_PADDING = MOBILE_COMPOSER_INPUT_VERTICAL_PADDING;
@@ -1826,6 +1839,11 @@ export default function SessionScreen() {
     <Pressable
       accessibilityLabel={t('session.common.voiceStopRecording')}
       accessibilityRole="button"
+      hitSlop={COMPOSER_VOICE_DRAFT_HIT_SLOP}
+      // onPressIn 给手指「触摸即停」的即时手感;onPress 是无障碍激活(VoiceOver /
+      // TalkBack 的 activate 只走 onPress,不会派发 onPressIn)的唯一入口,两者都要挂。
+      // handler 幂等:finishVoiceRecording 有 voiceStopInFlight 门,重复调用是 no-op。
+      onPress={handleComposerInputPressIn}
       onPressIn={handleComposerInputPressIn}
       style={styles.voiceDraftOverlay}
       testID="session.voiceDraftOverlay"

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -493,8 +493,9 @@ const COMPOSER_INPUT_SINGLE_LINE_CONTENT_HEIGHT = MOBILE_COMPOSER_INPUT_SINGLE_L
  */
 const COMPOSER_VOICE_DRAFT_HIT_SLOP = (() => {
   const deficit = Math.max(0, 44 - MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT);
-  const vertical = Math.ceil(deficit / 2);
-  return { bottom: vertical, left: 0, right: 0, top: vertical };
+  // 奇数差额时上多下少,两侧之和恒等于 deficit(两侧都取 ceil 会补过头)。
+  const top = Math.ceil(deficit / 2);
+  return { bottom: deficit - top, left: 0, right: 0, top };
 })();
 const COMPOSER_INPUT_MULTILINE_CONTENT_THRESHOLD = 34;
 const COMPOSER_INPUT_LINE_HEIGHT = MOBILE_COMPOSER_INPUT_LINE_HEIGHT;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -174,6 +174,7 @@ import {
   ComposerToolbarSpacer,
   ComposerToolbarVoiceSlot,
   MOBILE_COMPOSER_CONTROL_SIZE,
+  MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
   MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
   MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
@@ -195,6 +196,7 @@ import {
   resolveComposerVoiceHoldActive,
   shouldArmComposerVoiceHold,
 } from '@/session/composerVoiceHold';
+import { COMPOSER_TEXT_HORIZONTAL_PADDING } from '@/session/composerTextMetrics';
 import {
   isMobileRealtimeAudioAvailable,
   prewarmMobileRealtimeAudio,
@@ -2805,7 +2807,7 @@ export default function NewRemoteSessionScreen() {
                   leading={renderComposerCollapsedAttachmentBadge()}
                   inputFrameHeight={composerResize.frameHeight}
                   inputOverlay={renderComposerInputOverlay()}
-                  inputStyle={[styles.sessionComposerInput, voiceIsListening && styles.inputVoiceHidden]}
+                  inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
                   inputTestID="newSession.firstMessageInput"
                   maxHeight={composerResize.inputMaxHeight}
                   multilineShape={!composerCardActive && composerInputIsMultiline}
@@ -3533,8 +3535,9 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     ...StyleSheet.absoluteFill,
     overflow: 'hidden',
   },
+  // 内边距与真实输入框同源:差一点就会让听写文字与非听写文字左右错位、换行位置不同。
   voiceDraftOverlayContent: {
-    paddingHorizontal: spacing.xs,
+    paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
     paddingVertical: MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
   },
   voiceDraftMeasuredBlock: {
@@ -3544,10 +3547,11 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   voiceDraftCaretOverlay: {
     position: 'absolute',
   },
+  // 草稿层的文本档必须与真实 TextInput 完全一致,否则换行位置错开、超出的行被裁在
+  // 框外(见 MOBILE_COMPOSER_DRAFT_TEXT_STYLE)。
   voiceDraftText: {
     color: colors.textPrimary,
-    fontSize: typeScale.body,
-    lineHeight: MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
+    ...MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   },
   voiceDraftListeningPrompt: {
     alignItems: 'center',
@@ -3556,8 +3560,7 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   voiceDraftListeningText: {
     color: colors.statusReady,
-    fontSize: typeScale.body,
-    lineHeight: MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
+    ...MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   },
   composerToolbarWrap: {
     position: 'relative',
@@ -3586,10 +3589,6 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     fontWeight: fontWeight.semibold,
     lineHeight: lineHeight.caption,
     minWidth: 0,
-  },
-  sessionComposerInput: {
-    fontSize: typeScale.listBody,
-    lineHeight: lineHeight.listBody,
   },
   inputVoiceHidden: {
     color: 'transparent',

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -179,6 +179,7 @@ import {
   MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
   MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
   MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
+  MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   MobileComposerInputRow,
   VoiceMicWaveCaret,
   resolveMobileComposerVoiceButtonPlacement,
@@ -2806,6 +2807,9 @@ export default function NewRemoteSessionScreen() {
                   inputRef={firstMessageInputRef}
                   leading={renderComposerCollapsedAttachmentBadge()}
                   inputFrameHeight={composerResize.frameHeight}
+                  // 听写期间把输入区撑到 44pt 触控目标:此时「点输入区停止听写」的命中层
+                  // 是这层输入区自身(TextInput 的 onPressIn),单行时只有 28pt。
+                  inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}
                   inputOverlay={renderComposerInputOverlay()}
                   inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
                   inputTestID="newSession.firstMessageInput"

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -113,6 +113,13 @@ describe('mobile composer rich input HTML', () => {
     );
 
     expect(overlaySource).toContain('onPressIn={handleComposerInputPressIn}');
+    // 无障碍激活(VoiceOver / TalkBack)只走 onPress,不会派发 onPressIn:两者都必须挂,
+    // 否则读屏用户按下这个「停止录音」按钮不会有任何反应。
+    expect(overlaySource).toContain('onPress={handleComposerInputPressIn}');
+    // 单行听写时覆盖层只有 28pt 高,热区要补到 44pt(mobile-design-guide 触控目标)。
+    expect(overlaySource).toContain('hitSlop={COMPOSER_VOICE_DRAFT_HIT_SLOP}');
+    expect(screenSource).toContain('const COMPOSER_VOICE_DRAFT_HIT_SLOP = (() => {');
+    expect(screenSource).toContain('Math.max(0, 44 - MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT)');
     expect(overlaySource).toContain('testID="session.voiceDraftOverlay"');
     // 草稿滚动层本身不吃触摸,交给外层覆盖层。
     expect(overlaySource).toContain('pointerEvents="none"');

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -116,12 +116,10 @@ describe('mobile composer rich input HTML', () => {
     // 无障碍激活(VoiceOver / TalkBack)只走 onPress,不会派发 onPressIn:两者都必须挂,
     // 否则读屏用户按下这个「停止录音」按钮不会有任何反应。
     expect(overlaySource).toContain('onPress={handleComposerInputPressIn}');
-    // 单行听写时覆盖层只有 28pt 高,热区要补到 44pt(mobile-design-guide 触控目标)。
-    expect(overlaySource).toContain('hitSlop={COMPOSER_VOICE_DRAFT_HIT_SLOP}');
-    expect(screenSource).toContain('const COMPOSER_VOICE_DRAFT_HIT_SLOP = (() => {');
-    expect(screenSource).toContain('Math.max(0, 44 - MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT)');
-    // 两侧之和恒等于差额:奇数时不能两边都取 ceil，否则热区补过头。
-    expect(screenSource).toContain('return { bottom: deficit - top, left: 0, right: 0, top };');
+    // 单行听写时 inputFrame 只有 28pt,命中层必须靠父容器撑到 44pt 触控目标——
+    // hitSlop 无效(RN 的命中区不会越过父视图边界),所以不许再用它顶替。
+    expect(overlaySource).not.toContain('hitSlop');
+    expect(screenSource).toContain('inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
     expect(overlaySource).toContain('testID="session.voiceDraftOverlay"');
     // 草稿滚动层本身不吃触摸,交给外层覆盖层。
     expect(overlaySource).toContain('pointerEvents="none"');

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -120,6 +120,15 @@ describe('mobile composer rich input HTML', () => {
     // hitSlop 无效(RN 的命中区不会越过父视图边界),所以不许再用它顶替。
     expect(overlaySource).not.toContain('hitSlop');
     expect(screenSource).toContain('inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
+
+    // hidden 的富文本编辑器必须同时从两端的无障碍树里摘掉:opacity: 0 不隐藏读屏焦点,
+    // 而它的 focus 已不再停听写,焦点留在那里会让读屏用户卡在「按了没反应」的输入框上。
+    const inputSource = readFileSync(
+      resolve(process.cwd(), 'src/session/ComposerRichInput.tsx'),
+      'utf8',
+    ).replace(/\r\n/g, '\n');
+    expect(inputSource).toContain('accessibilityElementsHidden={hidden}');
+    expect(inputSource).toContain("importantForAccessibility={hidden ? 'no-hide-descendants' : 'auto'}");
     expect(overlaySource).toContain('testID="session.voiceDraftOverlay"');
     // 草稿滚动层本身不吃触摸,交给外层覆盖层。
     expect(overlaySource).toContain('pointerEvents="none"');

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -120,6 +120,8 @@ describe('mobile composer rich input HTML', () => {
     expect(overlaySource).toContain('hitSlop={COMPOSER_VOICE_DRAFT_HIT_SLOP}');
     expect(screenSource).toContain('const COMPOSER_VOICE_DRAFT_HIT_SLOP = (() => {');
     expect(screenSource).toContain('Math.max(0, 44 - MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT)');
+    // 两侧之和恒等于差额:奇数时不能两边都取 ceil，否则热区补过头。
+    expect(screenSource).toContain('return { bottom: deficit - top, left: 0, right: 0, top };');
     expect(overlaySource).toContain('testID="session.voiceDraftOverlay"');
     // 草稿滚动层本身不吃触摸,交给外层覆盖层。
     expect(overlaySource).toContain('pointerEvents="none"');

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -93,6 +93,32 @@ describe('mobile composer rich input HTML', () => {
     expect(selectSource).not.toContain('composerInputRef.current?.focus();');
   });
 
+  /**
+   * 「点输入区 = 想打字 → 停止听写」必须由听写期间盖在输入区上的 RN 覆盖层承接:
+   * - 挂 WebView 的 focus 不行:WKWebView 在输入区展开、拿到 native 焦点后会自己恢复
+   *   DOM 焦点并派发 focus,收起态点语音、输入框展开的那一拍就把刚开始的听写掐断;
+   * - 挂 WebView 内的触摸也不行:听写期间富文本编辑器是 hidden(opacity 0),iOS hitTest
+   *   跳过 alpha≈0 的 view,它根本收不到触摸。
+   * 两条都由 2026-07 的实机日志确认。
+   */
+  it('stops dictation from the RN draft overlay instead of WebView focus', () => {
+    const screenSource = readFileSync(
+      resolve(process.cwd(), 'app/sessions/[sessionId].tsx'),
+      'utf8',
+    ).replace(/\r\n/g, '\n');
+    const overlayStart = screenSource.indexOf('const renderComposerInputOverlay = ');
+    const overlaySource = screenSource.slice(
+      overlayStart,
+      screenSource.indexOf('const measureSendButtonTarget', overlayStart),
+    );
+
+    expect(overlaySource).toContain('onPressIn={handleComposerInputPressIn}');
+    expect(overlaySource).toContain('testID="session.voiceDraftOverlay"');
+    // 草稿滚动层本身不吃触摸,交给外层覆盖层。
+    expect(overlaySource).toContain('pointerEvents="none"');
+    expect(screenSource).toContain('onFocus={() => setComposerFocused(true)}');
+  });
+
   it('rejects malformed image messages at the WebView boundary', () => {
     expect(parseComposerWebMessage(JSON.stringify({ type: 'paste-images-start', count: '2' }))).toBeNull();
     expect(parseComposerWebMessage(JSON.stringify({

--- a/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
@@ -85,6 +85,19 @@ describe('composer voice draft text metrics', () => {
     }
   });
 
+  /**
+   * 听写期间「点输入区停止听写」的命中层盖在 inputFrame 上,单行时只有 28pt;
+   * 触控目标要 ≥44pt(mobile-design-guide),且只能靠父容器撑起——RN 的 hitSlop
+   * 不会越过父视图边界。两个页面都要撑,否则各自的听写停止都点不准。
+   */
+  it('raises the input frame to the touch target while dictating', () => {
+    expect(read(COMPOSER_ROW)).toContain('export const MOBILE_COMPOSER_MIN_TOUCH_TARGET = 44;');
+    for (const rel of COMPOSER_PAGES) {
+      expect(read(rel), `${rel} 听写期间必须把输入区撑到触控目标`)
+        .toContain('inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
+    }
+  });
+
   it('forbids page-level font overrides on the composer input', () => {
     for (const rel of COMPOSER_PAGES) {
       expect(read(rel), `${rel} 不得再用页面样式覆盖输入框字号 / 行高`)

--- a/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
@@ -24,7 +24,8 @@ const COMPOSER_PAGES = ['app/sessions/new.tsx', 'app/sessions/[sessionId].tsx'];
 const DRAFT_TEXT_STYLES = ['voiceDraftText', 'voiceDraftListeningText'];
 
 function read(rel: string): string {
-  return readFileSync(join(ROOT, rel), 'utf8');
+  // 归一化换行:Windows checkout 是 CRLF,styleBlock 的 `\n  <name>:` 锚点会全部失配。
+  return readFileSync(join(ROOT, rel), 'utf8').replace(/\r\n/g, '\n');
 }
 
 /**
@@ -91,7 +92,12 @@ describe('composer voice draft text metrics', () => {
    * 不会越过父视图边界。两个页面都要撑,否则各自的听写停止都点不准。
    */
   it('raises the input frame to the touch target while dictating', () => {
-    expect(read(COMPOSER_ROW)).toContain('export const MOBILE_COMPOSER_MIN_TOUCH_TARGET = 44;');
+    const row = read(COMPOSER_ROW);
+    expect(row).toContain('export const MOBILE_COMPOSER_MIN_TOUCH_TARGET = 44;');
+    // 显式 height 会压过 minHeight(manual 定高时 frameHeight 可能小于触控目标),
+    // 数值高度必须先 clamp,否则命中区又被压回 28pt。
+    expect(row).toContain('Math.max(inputFrameHeight, inputFrameMinHeight)');
+    expect(row).toContain('resolvedInputFrameHeight != null && { height: resolvedInputFrameHeight }');
     for (const rel of COMPOSER_PAGES) {
       expect(read(rel), `${rel} 听写期间必须把输入区撑到触控目标`)
         .toContain('inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');

--- a/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Composer 三个文本渲染器的度量一致性守护。
+ *
+ * 同一段草稿文字可能由三处画出来:新建会话页的原生 TextInput、会话页的 WebView 富文本
+ * 编辑器、语音听写期间盖在上面的草稿覆盖层。前两者撑起输入区高度,第三者只是展示层。
+ *
+ * 背景(2026-07 修复):三处曾各写一份档位——原生 14/20(页面覆盖)、WebView CSS 字面
+ * 15/22 且无水平内边距、听写层 16/22。后果是听写层提前一行换行,新起的那行落在框外被
+ * overflow hidden 裁掉(说到第二行看不到新内容,要等输入框也换行才补出来),听写文字与
+ * 非听写文字的字号、左右起点也明显不同。
+ *
+ * 因此字号 / 行高 / 内边距只许来自 composerTextMetrics 一个正本。
+ */
+
+const ROOT = process.cwd();
+const METRICS = 'src/session/composerTextMetrics.ts';
+const COMPOSER_ROW = 'src/session/MobileComposerInputRow.tsx';
+const RICH_INPUT_HTML = 'src/session/composerRichInputHtml.ts';
+const COMPOSER_PAGES = ['app/sessions/new.tsx', 'app/sessions/[sessionId].tsx'];
+const DRAFT_TEXT_STYLES = ['voiceDraftText', 'voiceDraftListeningText'];
+
+function read(rel: string): string {
+  return readFileSync(join(ROOT, rel), 'utf8');
+}
+
+/**
+ * 取 StyleSheet 里某个样式键的对象字面量内容（这些块内部没有嵌套对象）。
+ * 锚定「行首两空格缩进」以命中样式表条目，不误吃同名的函数参数对象。
+ */
+function styleBlock(source: string, name: string): string {
+  const match = new RegExp(`\\n {2}${name}:\\s*\\{([^}]*)\\}`).exec(source);
+  expect(match, `未找到样式 ${name}`).not.toBeNull();
+  return match![1];
+}
+
+describe('composer voice draft text metrics', () => {
+  it('derives the shared composer metrics from the design tokens', () => {
+    const source = read(METRICS);
+    expect(source).toContain('export const COMPOSER_TEXT_FONT_SIZE = typeScale.code;');
+    expect(source).toContain('export const COMPOSER_TEXT_LINE_HEIGHT = lineHeight.body;');
+    expect(source).toContain('export const COMPOSER_TEXT_HORIZONTAL_PADDING = spacing.xs;');
+    // WebView HTML 生成器与 node 单测都要 import 本文件,不能把 react-native 拖进来。
+    expect(source).not.toMatch(/from 'react-native'/);
+  });
+
+  it('exposes the shared metrics as the composer row draft text style', () => {
+    const source = read(COMPOSER_ROW);
+    expect(source).toContain('export const MOBILE_COMPOSER_DRAFT_TEXT_STYLE = COMPOSER_TEXT_STYLE;');
+    // 单行盒高与文本行高同源:「单行」必须正好装一行文字。
+    expect(source).toContain('export const MOBILE_COMPOSER_INPUT_LINE_HEIGHT = COMPOSER_TEXT_LINE_HEIGHT;');
+  });
+
+  it('renders the real composer TextInput with the shared metrics', () => {
+    const block = styleBlock(read(COMPOSER_ROW), 'input');
+    expect(block).toContain('...COMPOSER_TEXT_STYLE');
+    expect(block).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
+  });
+
+  it('renders the WebView rich composer with the shared metrics instead of CSS literals', () => {
+    const source = read(RICH_INPUT_HTML);
+    expect(source).toContain('font-size: ${COMPOSER_TEXT_FONT_SIZE}px');
+    expect(source).toContain('line-height: ${COMPOSER_TEXT_LINE_HEIGHT}px');
+    expect(source).toContain('padding: ${COMPOSER_TEXT_VERTICAL_PADDING}px ${COMPOSER_TEXT_HORIZONTAL_PADDING}px');
+    // #editor 的排版不得回退成字面量(CSS 不在 typographyTokenDiscipline 的扫描面内)。
+    const editorBlock = /#editor \{([^}]*)\}/.exec(source)?.[1] ?? '';
+    expect(editorBlock).not.toMatch(/font-size:\s*\d/);
+    expect(editorBlock).not.toMatch(/line-height:\s*\d/);
+  });
+
+  it('keeps every voice draft overlay text on the shared draft text style', () => {
+    for (const rel of COMPOSER_PAGES) {
+      const source = read(rel);
+      for (const name of DRAFT_TEXT_STYLES) {
+        const block = styleBlock(source, name);
+        expect(block, `${rel} ${name} 必须复用输入框档位`).toContain('...MOBILE_COMPOSER_DRAFT_TEXT_STYLE');
+        expect(block, `${rel} ${name} 不得自带字号 / 行高`).not.toMatch(/fontSize|lineHeight/);
+      }
+      const overlayContent = styleBlock(source, 'voiceDraftOverlayContent');
+      expect(overlayContent, `${rel} 覆盖层水平内边距必须与输入框同源`)
+        .toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
+    }
+  });
+
+  it('forbids page-level font overrides on the composer input', () => {
+    for (const rel of COMPOSER_PAGES) {
+      expect(read(rel), `${rel} 不得再用页面样式覆盖输入框字号 / 行高`)
+        .not.toContain('sessionComposerInput');
+    }
+  });
+});

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -758,11 +758,11 @@ describe('new session composer surface', () => {
     const modelPillEnd = newSource.indexOf('modelPillText:', modelPillStart);
     const modelPillStyle = newSource.slice(modelPillStart, modelPillEnd);
     const modelPillTextStart = newSource.indexOf('modelPillText: {');
-    const modelPillTextEnd = newSource.indexOf('sessionComposerInput:', modelPillTextStart);
+    const modelPillTextEnd = newSource.indexOf('inputVoiceHidden:', modelPillTextStart);
     const modelPillTextStyle = newSource.slice(modelPillTextStart, modelPillTextEnd);
-    const sessionComposerInputStart = newSource.indexOf('sessionComposerInput: {');
-    const sessionComposerInputEnd = newSource.indexOf('inputVoiceHidden:', sessionComposerInputStart);
-    const sessionComposerInputStyle = newSource.slice(sessionComposerInputStart, sessionComposerInputEnd);
+    const voiceDraftTextStart = newSource.indexOf('voiceDraftText: {');
+    const voiceDraftTextEnd = newSource.indexOf('voiceDraftListeningPrompt:', voiceDraftTextStart);
+    const voiceDraftTextStyle = newSource.slice(voiceDraftTextStart, voiceDraftTextEnd);
     const sendButtonStart = newSource.indexOf('sendButton: {');
     const sendButtonEnd = newSource.indexOf('sendButtonDisabled:', sendButtonStart);
     const sendButtonStyle = newSource.slice(sendButtonStart, sendButtonEnd);
@@ -811,7 +811,7 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('selectionColor={colors.inputCaret}');
     expect(newComposerSource).toContain('inputRef={firstMessageInputRef}');
     expect(newComposerSource).toContain('inputOverlay={renderComposerInputOverlay()}');
-    expect(newComposerSource).toContain('inputStyle={[styles.sessionComposerInput, voiceIsListening && styles.inputVoiceHidden]}');
+    expect(newComposerSource).toContain('inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}');
     expect(newComposerSource).toContain('onChangeText={setFirstMessageDraft}');
     expect(newComposerSource).toContain('onContentSizeChange={handleFirstMessageInputContentSizeChange}');
     expect(newComposerSource).toContain("placeholder={voiceIsListening ? '' : composerPlaceholder}");
@@ -841,8 +841,11 @@ describe('new session composer surface', () => {
     expect(modelPillTextStyle).toContain('color: colors.textPrimary');
     expect(modelPillTextStyle).toContain('fontSize: typeScale.caption');
     expect(modelPillTextStyle).toContain('fontWeight: fontWeight.semibold');
-    expect(sessionComposerInputStyle).toContain('fontSize: typeScale.listBody');
-    expect(sessionComposerInputStyle).toContain('lineHeight: lineHeight.listBody');
+    // 输入框字号档由 MobileComposerInputRow 统一持有(MOBILE_COMPOSER_DRAFT_TEXT_STYLE),
+    // 页面不再覆盖;语音草稿覆盖层必须引用同一档,否则换行位置与输入框错开(见
+    // composerVoiceDraftMetrics.test.ts)。
+    expect(newSource).not.toContain('sessionComposerInput');
+    expect(voiceDraftTextStyle).toContain('...MOBILE_COMPOSER_DRAFT_TEXT_STYLE');
     expect(sendButtonStyle).toContain('backgroundColor: colors.cta');
     expect(sendButtonStyle).toContain('borderColor: colors.cta');
     expect(sendButtonStyle).toContain('borderWidth: StyleSheet.hairlineWidth');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -182,10 +182,12 @@ describe('mobile session composer desktop-first surface', () => {
     expect(inputStyle).toContain('borderWidth: 0');
     expect(inputStyle).not.toContain('borderColor: colors.border');
     expect(inputStyle).not.toContain('borderRadius: radius.pill');
-    expect(inputStyle).toContain('lineHeight: MOBILE_COMPOSER_INPUT_LINE_HEIGHT');
+    // 字号 / 行高 / 水平内边距走 composerTextMetrics:WebView 富文本编辑器与语音听写
+    // 覆盖层共用同一份度量,三边换行位置必须逐字一致(见 composerVoiceDraftMetrics.test.ts)。
+    expect(inputStyle).toContain('...COMPOSER_TEXT_STYLE');
     expect(inputStyle).toContain('maxHeight: MOBILE_COMPOSER_INPUT_MAX_HEIGHT');
     expect(inputStyle).toContain('minHeight: MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT');
-    expect(inputStyle).toContain('paddingHorizontal: spacing.xs');
+    expect(inputStyle).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
     expect(inputStyle).toContain('paddingVertical: MOBILE_COMPOSER_INPUT_VERTICAL_PADDING');
     expect(inputStyle).toContain("textAlignVertical: 'top'");
     // Composer input is a single stable, always-multiline, always-inline instance (no compact↔expanded
@@ -321,13 +323,13 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('onPressIn={handleComposerInputPressIn}');
     expect(source).toContain("placeholder={voiceIsListening ? '' : composerLayout.input.placeholder}");
     expect(source).toContain('placeholderTextColor={colors.textTertiary}');
-    expect(source).toContain('voiceIsListening && styles.inputVoiceHidden');
+    expect(source).toContain('inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}');
     expect(source).toContain('styles.voiceDraftOverlay');
     expect(voiceDraftOverlayStyle).toContain('...StyleSheet.absoluteFill');
     expect(voiceDraftOverlayStyle).toContain("overflow: 'hidden'");
     expect(voiceDraftOverlayContentStyle).not.toContain('minHeight: COMPOSER_INPUT_SINGLE_LINE_CONTENT_HEIGHT');
     expect(voiceDraftOverlayContentStyle).not.toContain("alignItems: 'flex-start'");
-    expect(voiceDraftOverlayContentStyle).toContain('paddingHorizontal: spacing.xs');
+    expect(voiceDraftOverlayContentStyle).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
     expect(voiceDraftOverlayContentStyle).toContain('paddingVertical: COMPOSER_INPUT_VERTICAL_PADDING');
     expect(voiceDraftOverlayContentStyle).not.toContain("width: '100%'");
     expect(voiceDraftMeasuredBlockStyle).not.toContain("alignSelf: 'flex-start'");

--- a/apps/mobile/src/session/ComposerRichInput.tsx
+++ b/apps/mobile/src/session/ComposerRichInput.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/session/composerDocument';
 import { composerNodesForBoundedPlainTextPaste } from '@/session/composerPaste';
 import { buildComposerRichInputHtml, type ComposerRichInputTheme } from '@/session/composerRichInputHtml';
+import { COMPOSER_SINGLE_LINE_HEIGHT } from '@/session/composerTextMetrics';
 import {
   parseComposerWebMessage,
   type ComposerWebMessage,
@@ -326,7 +327,9 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
         return;
       }
       if (message.type === 'height') {
-        if (Number.isFinite(message.height)) onHeightChange?.(Math.max(28, Math.min(maxHeight, message.height)));
+        if (Number.isFinite(message.height)) {
+          onHeightChange?.(Math.max(COMPOSER_SINGLE_LINE_HEIGHT, Math.min(maxHeight, message.height)));
+        }
         return;
       }
       if (message.type === 'focus') return onFocus?.();
@@ -406,6 +409,6 @@ const styles = StyleSheet.create({
     // react-native-webview defaults the native child to flex: 1. Override it
     // because this composer drives the child with an explicit measured height.
     flex: 0,
-    minHeight: 28,
+    minHeight: COMPOSER_SINGLE_LINE_HEIGHT,
   },
 });

--- a/apps/mobile/src/session/ComposerRichInput.tsx
+++ b/apps/mobile/src/session/ComposerRichInput.tsx
@@ -364,6 +364,13 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
         ref={webViewRef}
         accessibilityHint={accessibilityHint}
         accessibilityLabel={accessibilityLabel}
+        // hidden 期间(语音听写)把整棵子树从无障碍树里摘掉。opacity: 0 只影响视觉与
+        // hitTest,读屏焦点仍能落到这个不可见的 textbox 上;而它的 focus 已不再停止听写
+        // (停听写只认覆盖层的真实触摸),读屏用户会卡在一个「按了没反应」的输入框里。
+        // iOS 用 accessibilityElementsHidden,Android 用 importantForAccessibility,
+        // 两端都要给,少一个就会在该平台留下幽灵焦点。
+        accessibilityElementsHidden={hidden}
+        importantForAccessibility={hidden ? 'no-hide-descendants' : 'auto'}
         allowFileAccess={false}
         // iOS 给 WKWebView 里的可编辑区域挂一条系统表单导航条(上一项 / 下一项 /
         // 完成),iOS 26 起画成键盘上方的独立浮动胶囊。composer 只有这一个字段,

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -17,11 +17,26 @@ import { Mic } from 'lucide-react-native';
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { iconSize, iconStroke, useThemedStyles, type ThemeColors } from '@/theme';
-import { radius, spacing, typeScale } from '@/theme/tokens';
+import { radius, spacing } from '@/theme/tokens';
+import {
+  COMPOSER_SINGLE_LINE_HEIGHT,
+  COMPOSER_TEXT_HORIZONTAL_PADDING,
+  COMPOSER_TEXT_LINE_HEIGHT,
+  COMPOSER_TEXT_STYLE,
+  COMPOSER_TEXT_VERTICAL_PADDING,
+} from '@/session/composerTextMetrics';
 
-export const MOBILE_COMPOSER_INPUT_LINE_HEIGHT = 22;
-export const MOBILE_COMPOSER_INPUT_VERTICAL_PADDING = 3;
-export const MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT = 28;
+/**
+ * Composer 草稿文本的排版档。正本在 `composerTextMetrics`——原生输入框、WebView 富文本
+ * 编辑器与语音听写覆盖层共用同一档,任一处漂移都会让听写文字与真实输入框换行位置错开
+ * (详见该文件注释)。此处只做转出,页面按既有名字引用。
+ */
+export const MOBILE_COMPOSER_DRAFT_TEXT_STYLE = COMPOSER_TEXT_STYLE;
+
+/** 单行内容盒高 = 文本行高(两者同源,保证「单行 = 一行文字」)。 */
+export const MOBILE_COMPOSER_INPUT_LINE_HEIGHT = COMPOSER_TEXT_LINE_HEIGHT;
+export const MOBILE_COMPOSER_INPUT_VERTICAL_PADDING = COMPOSER_TEXT_VERTICAL_PADDING;
+export const MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT = COMPOSER_SINGLE_LINE_HEIGHT;
 export const MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES = 12;
 export const MOBILE_COMPOSER_INPUT_MAX_HEIGHT = (MOBILE_COMPOSER_INPUT_LINE_HEIGHT * MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES)
   + (MOBILE_COMPOSER_INPUT_VERTICAL_PADDING * 2);
@@ -518,16 +533,17 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     height: MOBILE_COMPOSER_CONTROL_SIZE,
     width: MOBILE_COMPOSER_CONTROL_SIZE,
   },
+  // 字号 / 行高 / 水平内边距全部走 composerTextMetrics:WebView 富文本编辑器与语音
+  // 听写覆盖层用同一份度量,三边换行位置必须逐字一致(见该文件注释)。
   input: {
     backgroundColor: 'transparent',
     borderWidth: 0,
     color: colors.textPrimary,
     flex: 1,
-    fontSize: typeScale.body,
-    lineHeight: MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
+    ...COMPOSER_TEXT_STYLE,
     maxHeight: MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
     minHeight: MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
-    paddingHorizontal: spacing.xs,
+    paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
     paddingVertical: MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
     textAlignVertical: 'top',
   },

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -33,7 +33,10 @@ import {
  */
 export const MOBILE_COMPOSER_DRAFT_TEXT_STYLE = COMPOSER_TEXT_STYLE;
 
-/** 单行内容盒高 = 文本行高(两者同源,保证「单行 = 一行文字」)。 */
+/**
+ * 输入区的单行**内容高度**(不含上下内边距) = 单行文字行高:两者同源,保证「单行」
+ * 正好装一行文字。含内边距的单行可视高度是 MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT。
+ */
 export const MOBILE_COMPOSER_INPUT_LINE_HEIGHT = COMPOSER_TEXT_LINE_HEIGHT;
 export const MOBILE_COMPOSER_INPUT_VERTICAL_PADDING = COMPOSER_TEXT_VERTICAL_PADDING;
 export const MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT = COMPOSER_SINGLE_LINE_HEIGHT;

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -219,6 +219,13 @@ export function MobileComposerInputRow({
 }: MobileComposerInputRowProps) {
   const styles = useThemedStyles(makeMobileComposerInputRowStyles);
   const cardLayout = cardActive === true;
+  // RN 里显式 height 压过 minHeight:manual 定高(用户拖过高度)时 frameHeight 可能小于
+  // inputFrameMinHeight,直接铺开会把听写停止命中区又压回不足 44pt。数值高度在这里
+  // 先 clamp;拖拽中的 Animated 值无法在 JS 侧 clamp(会打断跟手),那一瞬保持动画值,
+  // 松手结算成数值后重新受本 clamp 约束。
+  const resolvedInputFrameHeight = typeof inputFrameHeight === 'number' && inputFrameMinHeight != null
+    ? Math.max(inputFrameHeight, inputFrameMinHeight)
+    : inputFrameHeight;
   // useCallback 稳定引用,避免每次 render 都向原生 TextInputWrapper diff 新函数 prop。
   // images-loading:原生刚检测到图片粘贴意图(数据还在后台读),先画占位;
   // images:原生侧已阻止默认粘贴,上抛进附件链路(占位在此兑现);
@@ -286,7 +293,7 @@ export function MobileComposerInputRow({
           style={[
             styles.inputFrame,
             inputFrameMinHeight != null && { minHeight: inputFrameMinHeight },
-            inputFrameHeight != null && { height: inputFrameHeight },
+            resolvedInputFrameHeight != null && { height: resolvedInputFrameHeight },
           ]}
         >
           {inputElement ?? (onPasteImages && !isExpoGo ? (

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -45,6 +45,11 @@ export const MOBILE_COMPOSER_INPUT_MAX_HEIGHT = (MOBILE_COMPOSER_INPUT_LINE_HEIG
   + (MOBILE_COMPOSER_INPUT_VERTICAL_PADDING * 2);
 export const MOBILE_COMPOSER_CONTROL_SIZE = 34;
 export const MOBILE_COMPOSER_TOOL_GAP = 6;
+/**
+ * 触控目标下限(mobile-design-guide「主操作命中区 ≥ 44×44」,iOS HIG 同值)。
+ * 语音听写期间「点输入区停止听写」的命中层用它撑起 inputFrame(见 inputFrameMinHeight)。
+ */
+export const MOBILE_COMPOSER_MIN_TOUCH_TARGET = 44;
 const isExpoGo =
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
 /** 语音按钮 absolute 锚点距 composer 内容区右缘的距离(voiceButtonAnchor.right);
@@ -103,6 +108,12 @@ export interface MobileComposerInputRowProps {
    * null / undefined 走内容自动增长（现状行为）。
    */
   inputFrameHeight?: number | Animated.Value | null;
+  /**
+   * 输入区（inputFrame）的最小高度。给语音听写用：听写期间「点输入区停止听写」的命中层
+   * 盖在 inputFrame 上，而单行听写时 inputFrame 只有 28pt，不满足触控目标 44pt；
+   * hitSlop 解决不了——RN 的命中区不会越过父视图边界，必须让父容器本身够高。
+   */
+  inputFrameMinHeight?: number;
   /** Rich composer replacement for the plain TextInput. */
   inputElement?: ReactNode;
   inputOverlay?: ReactNode;
@@ -176,6 +187,7 @@ export function MobileComposerInputRow({
   floatingVoiceButton,
   floatingVoiceButtonStyle,
   inputFrameHeight,
+  inputFrameMinHeight,
   inputElement,
   inputOverlay,
   inputRef,
@@ -273,6 +285,7 @@ export function MobileComposerInputRow({
         <Animated.View
           style={[
             styles.inputFrame,
+            inputFrameMinHeight != null && { minHeight: inputFrameMinHeight },
             inputFrameHeight != null && { height: inputFrameHeight },
           ]}
         >

--- a/apps/mobile/src/session/composerRichInputHtml.ts
+++ b/apps/mobile/src/session/composerRichInputHtml.ts
@@ -6,6 +6,13 @@ import {
   MAX_PASTED_IMAGE_NAME_CHARS,
   SUPPORTED_PASTED_IMAGE_MIME_TYPES,
 } from '@/session/composerRichInputProtocol';
+import {
+  COMPOSER_SINGLE_LINE_HEIGHT,
+  COMPOSER_TEXT_FONT_SIZE,
+  COMPOSER_TEXT_HORIZONTAL_PADDING,
+  COMPOSER_TEXT_LINE_HEIGHT,
+  COMPOSER_TEXT_VERTICAL_PADDING,
+} from '@/session/composerTextMetrics';
 
 export interface ComposerRichInputTheme {
   background: string;
@@ -40,10 +47,15 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; background: transparent; overflow: hidden; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  /* 字号 / 行高 / 内边距来自 composerTextMetrics(与原生输入框、语音听写覆盖层同源):
+     任一处漂移都会让同一段文字在两个渲染器里换行位置不同,听写时新起的行被裁在框外。 */
   #editor {
-    color: var(--text); caret-color: var(--focus); font-size: 15px; line-height: 22px;
-    min-height: 28px; max-height: var(--max-height); overflow-y: auto; outline: none;
-    padding: 3px 0; white-space: pre-wrap; overflow-wrap: anywhere; -webkit-user-select: text;
+    color: var(--text); caret-color: var(--focus);
+    font-size: ${COMPOSER_TEXT_FONT_SIZE}px; line-height: ${COMPOSER_TEXT_LINE_HEIGHT}px;
+    min-height: ${COMPOSER_SINGLE_LINE_HEIGHT}px; max-height: var(--max-height);
+    overflow-y: auto; outline: none;
+    padding: ${COMPOSER_TEXT_VERTICAL_PADDING}px ${COMPOSER_TEXT_HORIZONTAL_PADDING}px;
+    white-space: pre-wrap; overflow-wrap: anywhere; -webkit-user-select: text;
   }
   #editor:empty::before { content: attr(data-placeholder); color: var(--placeholder); pointer-events: none; }
   .atom {
@@ -190,7 +202,7 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
     walk(root, nodes);
     return { version: 1, nodes };
   };
-  const reportHeight = () => post({ type: 'height', height: Math.min(config.maxHeight, Math.max(28, root.scrollHeight)) });
+  const reportHeight = () => post({ type: 'height', height: Math.min(config.maxHeight, Math.max(${COMPOSER_SINGLE_LINE_HEIGHT}, root.scrollHeight)) });
   const notify = () => {
     if (applying || composing) return;
     const value = readDocument();

--- a/apps/mobile/src/session/composerRichInputProtocol.ts
+++ b/apps/mobile/src/session/composerRichInputProtocol.ts
@@ -1,4 +1,10 @@
 export type ComposerWebMessage =
+  /**
+   * focus 只代表「编辑器现在有 DOM 焦点」,**不代表用户点了输入框**:WKWebView 在输入区
+   * 展开、拿到 native 焦点后会自己恢复 DOM 焦点并派发它。用户意图类动作(如「点输入框
+   * → 停止语音听写」)不能挂在这里,否则收起态点语音、输入框展开的瞬间就会误触发,把刚
+   * 开始的听写掐断(2026-07 实机日志确认)。
+   */
   | { type: 'ready' | 'focus' | 'blur' }
   | { type: 'height'; height: number }
   | { type: 'change'; document: unknown }

--- a/apps/mobile/src/session/composerTextMetrics.ts
+++ b/apps/mobile/src/session/composerTextMetrics.ts
@@ -1,0 +1,37 @@
+/**
+ * Composer 文本度量 —— 输入框本体与语音听写覆盖层的**唯一**来源。
+ *
+ * 为什么必须集中:一段草稿文字在同一个 composer 里可能由三个渲染器画出来——
+ * 1. 新建会话页的原生 `TextInput`;
+ * 2. 会话页的 WebView 富文本编辑器(`composerRichInputHtml` 的 CSS);
+ * 3. 语音听写期间盖在上面的草稿覆盖层(`Text` + absoluteFill)。
+ *
+ * 输入区可视高度由 1/2 的内容高度撑起,3 只是展示层(overflow hidden)。字号、行高或
+ * 水平内边距任一处不同,同一段文字的换行位置就不同:覆盖层先换行时新起的那行落在框外
+ * 被裁掉(表现为「说到第二行看不到新内容,要等输入框也换行才补出来」),反向则露出空行;
+ * 内边距不同还会让听写与非听写的文字左右错位。
+ *
+ * 2026-07 收敛前这三处分别是 14/20、15/22(CSS 字面量)、16/22,且 WebView 无水平内边距。
+ * 新增消费方一律引用本文件,不要各自写档位;本文件刻意不依赖 react-native,便于 WebView
+ * HTML 生成器与 node 环境单测直接 import。
+ */
+import { lineHeight, spacing, typeScale } from '@/theme/tokens';
+
+/** 输入文本字号(排版阶梯 typeScale.code)。 */
+export const COMPOSER_TEXT_FONT_SIZE = typeScale.code;
+/** 输入文本行高(排版阶梯 lineHeight.body);同时等于单行内容盒高。 */
+export const COMPOSER_TEXT_LINE_HEIGHT = lineHeight.body;
+/** 输入文本左右内边距:三个渲染器必须一致,否则听写与非听写的文字左右错位。 */
+export const COMPOSER_TEXT_HORIZONTAL_PADDING = spacing.xs;
+/** 输入文本上下内边距(内容盒高之外的呼吸)。 */
+export const COMPOSER_TEXT_VERTICAL_PADDING = 3;
+
+/** 单行输入区的可视高度(一行文字 + 上下内边距);原生输入框与 WebView 编辑器同源。 */
+export const COMPOSER_SINGLE_LINE_HEIGHT =
+  COMPOSER_TEXT_LINE_HEIGHT + (COMPOSER_TEXT_VERTICAL_PADDING * 2);
+
+/** RN 样式片段:`...COMPOSER_TEXT_STYLE` 一次展开字号 + 行高,不给漂移留缝。 */
+export const COMPOSER_TEXT_STYLE = {
+  fontSize: COMPOSER_TEXT_FONT_SIZE,
+  lineHeight: COMPOSER_TEXT_LINE_HEIGHT,
+};

--- a/apps/mobile/src/session/composerTextMetrics.ts
+++ b/apps/mobile/src/session/composerTextMetrics.ts
@@ -19,14 +19,17 @@ import { lineHeight, spacing, typeScale } from '@/theme/tokens';
 
 /** 输入文本字号(排版阶梯 typeScale.code)。 */
 export const COMPOSER_TEXT_FONT_SIZE = typeScale.code;
-/** 输入文本行高(排版阶梯 lineHeight.body);同时等于单行内容盒高。 */
+/**
+ * 单行文字的行高(排版阶梯 lineHeight.body),**不含内边距**;
+ * 也是 COMPOSER_SINGLE_LINE_HEIGHT 的基数(见下)。
+ */
 export const COMPOSER_TEXT_LINE_HEIGHT = lineHeight.body;
 /** 输入文本左右内边距:三个渲染器必须一致,否则听写与非听写的文字左右错位。 */
 export const COMPOSER_TEXT_HORIZONTAL_PADDING = spacing.xs;
-/** 输入文本上下内边距(内容盒高之外的呼吸)。 */
+/** 输入文本上下内边距(单行行高之外的呼吸)。 */
 export const COMPOSER_TEXT_VERTICAL_PADDING = 3;
 
-/** 单行输入区的可视高度(一行文字 + 上下内边距);原生输入框与 WebView 编辑器同源。 */
+/** 单行输入区的可视高度 = 单行行高 + 上下内边距;原生输入框与 WebView 编辑器同源。 */
 export const COMPOSER_SINGLE_LINE_HEIGHT =
   COMPOSER_TEXT_LINE_HEIGHT + (COMPOSER_TEXT_VERTICAL_PADDING * 2);
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修手机端语音听写的两个缺陷，都发生在 composer 输入区。

**一、听写文字与真实输入框换行位置错开，超出的行被裁在框外**

用户现象：说话超过一行后，新说的内容看不到；要等内容再多出一行，上一行才补出来，永远滞后一行。

原因是同一个 composer 里有**三套文本度量各写一份**：

| 渲染器 | 改前 | 改后 |
|---|---|---|
| 会话页真实输入（WebView 富文本，`composerRichInputHtml` 的 CSS） | 15/22，水平内边距 **0** | 15/22，水平内边距 4 |
| 新建会话页真实输入（原生 `TextInput`） | 14/20 | 15/22 |
| 语音听写草稿覆盖层（两页共用） | 16/22 | 15/22 |

输入区可视高度由前两者的内容高度撑起（auto 模式不给 inputFrame 定高），覆盖层只是 `absoluteFill` + `overflow: hidden` 的展示层。字号、行高或水平内边距任一处不同，同一段文字的换行位置就不同：覆盖层先换行时新起的那行落在框外被裁掉，反向则露出空行；内边距不同还会让听写与非听写的文字左右起点错位（实测差约 4pt，与截图一致）。

WebView 那条链此前没人管，是因为排版守护测试 `typographyTokenDiscipline` 只扫 RN 样式属性，CSS 字面量天然不命中。

**二、在输入框收起态点语音，输入框展开的那一拍听写立刻停止**

「点输入框 = 想打字 → 停止听写」原本挂在 WebView 的 `focus` 上，而 WKWebView 在输入区展开、拿到 native 焦点后**会自己恢复 DOM 焦点并派发 focus**（实机日志 + 调用栈确认，栈顶为 `onFocus`）。也就是说改动前这个交互一直靠该副作用工作：同一个不可靠信号既被当成用户点击、又会被系统自己触发，所以它既能停听写、也会掐断刚开始的听写。只在收起态复现，是因为展开那一拍 WebView 此前没有焦点，`focus` 才真的会派发。

现在 `onFocus` 回归只表示「编辑器有焦点」，停听写由听写期间真正盖在输入区上的 RN 覆盖层承接（`voiceDraftOverlay` 由裸 `ScrollView` 改为 `Pressable` 包住它，滚动层保持 `pointerEvents="none"`）。不能改挂 WebView 内的 `touchstart`：听写期间富文本编辑器是 `hidden`（`opacity: 0`），iOS `hitTest` 会跳过 `alpha ≈ 0` 的 view，它收不到任何触摸（这条也是实测排除的）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实机反馈）
- 本 PR 包含：
  - 新增 `apps/mobile/src/session/composerTextMetrics.ts` 作为 composer 文本度量唯一正本（字号 / 行高 / 水平与垂直内边距 / 单行高度），刻意不依赖 react-native，便于 WebView 的 HTML 生成器与 node 单测直接 import
  - 原生 `TextInput`、WebView 富文本 CSS、听写覆盖层三处统一引用该正本，档位统一为 15/22（`typeScale.code` + `lineHeight.body`）
  - 顺带收敛单行高度魔数：`28` 此前散在 4 处（组件常量、CSS `min-height`、WebView 上报高度下限、WebView 容器 `minHeight`），现在都由 `COMPOSER_SINGLE_LINE_HEIGHT = 行高 + 上下 padding` 推出；`MOBILE_COMPOSER_INPUT_LINE_HEIGHT`（拖拽调高步进、12 行上限的基数）此前是 22 而实际文本行高 20，现在与文本行高同源，「单行」正好装一行字
  - 会话页停听写改由 RN 覆盖层的真实触摸承接，`onFocus` 不再触发用户意图动作
  - 新增守护测试 `composerVoiceDraftMetrics.test.ts`；`composerRichInputHtml.test.ts` 增锁「停听写来自覆盖层 `onPressIn`、不来自 focus」，注释写清两条已被实测排除的失败路径
- 明确不包含：
  - 新建会话页的听写覆盖层触摸层未改（那页真实输入是原生 `TextInput`，听写时只是文字透明、仍可接触摸，既有 `onPressIn` 语义正确）
  - `pnpm lint` 在 `packages/project-context/src/toc.ts` 的 2 个 `no-useless-escape` 错误未修：在干净 `origin/main` 上同样复现，属基线问题、与本 PR 无关
- 用户可见变化：
  - 听写时显示的文字与停止听写后完全一致（字号、行高、左右起点），换行不再滞后
  - **新建会话页输入框字号从 14/20 变为 15/22**（与会话页对齐；这是两页统一的预期结果，已与需求方确认选择该档）
  - 收起态点语音不再被展开动作打断；听写中点输入区仍然正常停止录音
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §排版：字号 / 行高只许取自 `typeScale` / `lineHeight` 阶梯，不得在组件里写字面量。本次把 WebView CSS 里的 `15px` / `22px` / `padding` 字面量改为由 token 推导的常量插值，并让三个渲染器共用同一档（`typeScale.code` 15 + `lineHeight.body` 22），满足该约束
  - `docs/design-rules/DESIGN.md` §双模式交付门槛：本次不新增颜色，全部沿用既有语义 token（`colors.textPrimary` / `colors.statusReady` 等），Light / Dark 两种模式共用同一套实现，无单模式硬编码或条件补丁
- 视觉变化：新建会话页 composer 输入文字字号 +1 档（14→15）、行高 20→22；会话页 WebView 输入文字整体右移 4pt（补齐与原生输入框一致的水平内边距）。听写覆盖层跟随统一。
- 截图：未附。改动是字号 / 行高 / 内边距的逐字对齐，静态截图不足以体现「听写过程中换行是否跟手」，实机验证记录见下方「手工验证」。

## 怎么验证的

### 自动验证

```text
# 仓库根全量单测门禁（提交前硬门禁）
pnpm test:unit
结果：GATE_EXIT=0，25 个 workspace 全部通过，无失败项

# 本 PR 涉及的 package
pnpm --filter mobile run typecheck
结果：通过（tsc --noEmit 无输出）

pnpm --filter mobile exec vitest run
结果：Test Files 252 passed (252)，Tests 2399 passed (2399)

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

### 手工验证

iOS 模拟器（iPhone 17 Pro / iOS 27.0）+ cn dev client `com.xd.cindycn`，Light 模式：

- 归属验证：`pnpm mobile:sim:whoami -- --region=cn` → `✓ PASS`
  - booted dev client：iPhone 17 Pro（iOS 27.0），`com.xd.cindycn`
  - Metro `:8081` 归属 worktree `cindy-voice-draft-overlay-metrics`
  - 源码指纹 `dash/voice-draft-overlay-metrics@3538232b1+605c65ba0a`（rebase 前基线）
  - Metro 打印 `iOS Bundled apps/mobile/index.js (4131 modules)`，每次改动后重载 app 取新 bundle（WebView 的 HTML 在挂载时生成一次，不能只靠 Fast Refresh）
- 会话页 + 新建会话页各听写一段超过一行的话：新内容即时可见、输入框同步长高；听写文字与停止后文字的字号、行距、左右起点一致
- 收起态点语音：听写不再被展开动作打断
- 听写中点输入区：正常停止录音（确认第二处修复没有把这个交互改坏）

诊断过程中曾在会话页加临时 `[voice-debug]` 日志定位调用栈（正是它确认了 `onFocus` 是元凶、且 `programmatic` 判定拦不住 WKWebView 自发的 focus），提交前已全部删除，删除后重跑 typecheck 与 mobile 全量单测仍全绿。

### 未执行的验证

- **Dark 模式未做实机目检**：本次不新增颜色、全部沿用既有语义 token，但按仓库双模式门槛不把「复用 token」当成「已验证」，如实记录未目检。
- Android 未验证：改动为 JS/TS 层的排版度量与触摸层，无平台分支代码；iOS 侧的两条关键结论（WKWebView 自发 focus、`alpha ≈ 0` 不接触摸）只影响「为什么不能挂 focus / WebView 触摸」的推理，改后的实现（RN 覆盖层触摸）在两端语义一致。
- 未跑 `pnpm test:all`：改动限于 `apps/mobile` 的 composer 排版与触摸层，未触及协议、数据库、原生配置；根 `test:unit` 全量已通过，其余交 CI 门禁。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

补充说明：

- **不触发 mobile runtime fingerprint 变化**（不冷更）：只改 `apps/mobile` 的 TS/TSX 源码，未动 `app.json` / `app.config.js` / `eas.json` / `apps/mobile/package.json` 的依赖与 scripts / `plugins/` / `modules/`，也未引入新依赖。
- WebView 协议（`composerRichInputProtocol`）本次**无实质变更**：中途试过给 `focus` 加 `programmatic` 字段、以及新增 `user-tap` 消息，两条方案都被实测证伪后整套回退，最终协议与 `origin/main` 一致，不存在 native 与页面版本错配问题。

### 影响与回滚

- 影响范围：`apps/mobile` 会话页与新建会话页的 composer 输入区（文本排版、语音听写覆盖层、听写期间的点击停止）。不影响消息流、发送链路、附件与协议。
- 回滚 / 降级方式：单 commit，`git revert` 即可完整回到改动前行为；无数据迁移、无持久化状态、无 OTA 边界影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（度量正本的约束写在 `composerTextMetrics.ts` 的模块注释与两处守护测试里；未新增 docs 规则文件）
- [x] 已确认测试结果或说明未执行原因
