### PR TITLE
fix(desktop): 聊天消息 chip 复制到外部富文本时不再丢内容

### DIFF
--- a/apps/desktop/src/renderer/__tests__/inlineReferenceChip.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/inlineReferenceChip.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { File } from 'lucide-react';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -31,5 +32,49 @@ describe('InlineReferenceChip', () => {
     expect(screen.queryByRole('button')).toBeNull();
     expect(chip?.getAttribute('draggable')).toBeNull();
     expect(chip?.getAttribute('title')).toBeNull();
+  });
+
+  // 剪贴板契约。复制一段聊天消息时 Chromium 会把选区原样序列化进 text/html:
+  //   - `<button>` 不在外部富文本编辑器(Slack / 飞书 / Notion)的粘贴白名单里,
+  //     整个节点连同文字会被丢弃,只留下一个断行;
+  //   - `user-select: none` 让文字连 text/plain 都进不了剪贴板。
+  // 两条都会让用户复制出来的消息**缺内容**,所以固化成回归测试。
+  it('stays a <span> even when interactive, so pasted HTML keeps the label', () => {
+    const { container } = render(
+      <InlineReferenceChip label="endpoint.json" onClick={() => {}} />,
+    );
+    const chip = container.querySelector('[data-inline-reference-chip]');
+    expect(chip?.tagName).toBe('SPAN');
+    expect(container.querySelector('button')).toBeNull();
+    // 交互语义靠 role/tabIndex 补齐,不靠原生按钮元素。
+    expect(chip?.getAttribute('role')).toBe('button');
+    expect(chip?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('keeps chip text selectable by default, and only opts out for composer atoms', () => {
+    const { container: sent } = render(<InlineReferenceChip label="sent.ts" />);
+    expect(sent.querySelector('[data-inline-reference-chip]')?.className).not.toContain(
+      'select-none',
+    );
+
+    const { container: composer } = render(
+      <InlineReferenceChip label="composer.ts" textSelectable={false} />,
+    );
+    expect(composer.querySelector('[data-inline-reference-chip]')?.className).toContain(
+      'select-none',
+    );
+  });
+
+  it('activates on Enter and Space like the native button it replaced', async () => {
+    const user = userEvent.setup();
+    let clicks = 0;
+    const { container } = render(
+      <InlineReferenceChip label="endpoint.json" onClick={() => { clicks += 1; }} />,
+    );
+    const chip = container.querySelector('[data-inline-reference-chip]') as HTMLElement;
+    chip.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    expect(clicks).toBe(2);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
@@ -56,6 +56,24 @@ describe('Markdown target rendering contract', () => {
     expect(markdownRenderer).not.toContain('function FilePathChip');
   });
 
+  it('renders the path chip as <code>, so copied messages survive an external paste', () => {
+    // 复制一段聊天消息时 Chromium 把选区原样序列化进 text/html。`<button>` 是交互
+    // 控件,不属于富文本内容模型:Slack / 飞书 / Notion / Word 按标签白名单解析
+    // 粘贴内容,会把整个节点连同路径文字丢掉,只在原位留下一个断行——用户看到的
+    // 就是"文件名凭空消失"。`<code>` 既是语义正解(这个 chip 本来就是行内代码
+    // 升级来的),粘出去还会落成对方的行内代码。
+    const chipBody = markdownRenderer.match(/function FileTargetChip\([\s\S]*?\n}\n/)?.[0];
+    expect(chipBody).toBeDefined();
+    expect(chipBody).toContain('<code');
+    expect(chipBody).not.toContain('<button');
+    // 原生按钮语义靠 role/tabIndex/onKeyDown 补齐,不要退回 <button>。
+    expect(chipBody).toContain('role="button"');
+    expect(chipBody).toContain('tabIndex={0}');
+    expect(chipBody).toContain('onKeyDown');
+    // 同理:chip 文字必须能进剪贴板,不得 select-none。
+    expect(chipBody).not.toContain('select-none');
+  });
+
   it('resolves targets through the renderer cache so session switches do not re-flash', () => {
     // Eager render-time resolution (chip only when unique) re-fires the IPC and
     // re-flashes plain-text → chip on every session switch unless results are

--- a/apps/desktop/src/renderer/__tests__/quoteChip.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/quoteChip.test.tsx
@@ -14,6 +14,9 @@ describe('QuoteChip', () => {
     const chip = container.querySelector<HTMLElement>('[aria-label]');
     expect(chip?.getAttribute('aria-label')).toBe('first line\n\nsecond line');
     expect(chip?.textContent).toBe('first line second line');
+    // 引用 chip 是消息内 chip 里唯一保留 select-none 的:它展示的是折叠成单行的
+    // 摘要而非原文,不该跟着复制出去(其余 chip 默认可选中,见 inlineReferenceChip
+    // 的剪贴板契约测试)。
     expect(chip?.className).toContain('select-none');
   });
 

--- a/apps/desktop/src/renderer/components/chat/InlineReferenceChip.tsx
+++ b/apps/desktop/src/renderer/components/chat/InlineReferenceChip.tsx
@@ -5,8 +5,17 @@
  * Callers keep semantic behaviour such as navigation, file preview and
  * ProseMirror drag handling. Atomic chips intentionally have no close button;
  * composer nodes remain removable through normal node selection + Delete.
+ *
+ * 剪贴板契约(为什么这里是 `<span role="button">` 而不是 `<button>`):
+ *   聊天消息被选中复制时,Chromium 会把选区**原样**序列化进 `text/html`。
+ *   `<button>` 是交互控件,不属于任何富文本内容模型,外部编辑器(Slack /
+ *   飞书 / Notion / Word)解析粘贴的 HTML 时按标签白名单走,会把整个节点
+ *   连同内部文字一起丢弃,并在原位留下一个断行——用户看到的就是"文件名
+ *   凭空消失"。`<span>` 在所有这些白名单里,文字能完整落地。
+ *   同理 `user-select: none` 会让文字连 `text/plain` 都进不了剪贴板,所以
+ *   它只对 composer 的 ProseMirror atomic node 开启,见 `textSelectable`。
  */
-import type { MouseEventHandler, ReactNode, Ref } from 'react';
+import type { KeyboardEventHandler, MouseEventHandler, ReactNode, Ref } from 'react';
 
 import { Tip } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
@@ -18,12 +27,18 @@ export interface InlineReferenceChipProps {
   tooltipMono?: boolean;
   tooltipContentClassName?: string;
   selected?: boolean;
-  onClick?: MouseEventHandler<HTMLButtonElement>;
-  onContextMenu?: MouseEventHandler<HTMLButtonElement>;
-  buttonRef?: Ref<HTMLButtonElement>;
+  onClick?: MouseEventHandler<HTMLSpanElement>;
+  onContextMenu?: MouseEventHandler<HTMLSpanElement>;
+  chipRef?: Ref<HTMLSpanElement>;
   ariaLabel?: string;
   className?: string;
   labelClassName?: string;
+  /**
+   * chip 文字能否被 selection 选中并进入剪贴板。默认 `true`——已发送消息里的
+   * chip 必须能跟着正文一起复制出去。composer 里的 ProseMirror atomic node 传
+   * `false`:那里 chip 是一个整体被选中 / 删除的原子节点,内部文字不参与 selection。
+   */
+  textSelectable?: boolean;
 }
 
 /** Theme-aware 12px reference pill with a formal full-content tooltip. */
@@ -36,14 +51,16 @@ export function InlineReferenceChip({
   selected = false,
   onClick,
   onContextMenu,
-  buttonRef,
+  chipRef,
   ariaLabel,
   className,
   labelClassName,
+  textSelectable = true,
 }: InlineReferenceChipProps) {
   const interactive = Boolean(onClick || onContextMenu);
   const sharedClassName = cn(
-    'inline-flex min-w-0 max-w-full select-none items-center',
+    'inline-flex min-w-0 max-w-full items-center',
+    !textSelectable && 'select-none',
     'gap-1.5 rounded-full border px-2 py-0.5 text-[12px] font-normal leading-5',
     'bg-[var(--surface-chip)] text-[var(--text-primary)]',
     interactive && 'cursor-pointer transition-colors hover:bg-[var(--surface-hover)]',
@@ -65,22 +82,23 @@ export function InlineReferenceChip({
       <span className={cn('min-w-0 truncate', labelClassName)}>{label}</span>
     </>
   );
-  const trigger = interactive ? (
-    <button
-      ref={buttonRef}
-      type="button"
+  // `<span role="button">` 换掉原生 `<button>` 后要自己补键盘激活:走 native
+  // click(),让 onClick 收到一个正常的合成鼠标事件,调用方无需区分入口。
+  const handleKeyDown: KeyboardEventHandler<HTMLSpanElement> = (e) => {
+    if (!onClick) return;
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.preventDefault();
+    e.currentTarget.click();
+  };
+  const trigger = (
+    <span
+      ref={chipRef}
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
       aria-label={ariaLabel}
       onClick={onClick}
       onContextMenu={onContextMenu}
-      className={sharedClassName}
-      style={style}
-      data-inline-reference-chip=""
-    >
-      {contents}
-    </button>
-  ) : (
-    <span
-      aria-label={ariaLabel}
+      onKeyDown={interactive ? handleKeyDown : undefined}
       className={sharedClassName}
       style={style}
       data-inline-reference-chip=""

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -825,6 +825,12 @@ function localKindFromAbsPath(absPath: string, fallback: MarkdownLocalKind): Mar
  * unresolved / ambiguous / unsupported scheme — renders as plain text by the
  * call sites, not as a chip. So this component is always interactive: click
  * to open, hover to highlight, right-click for the file menu.
+ *
+ * 标签是 `<code role="button">` 而不是 `<button>`,这条不能回退:这个 chip 是
+ * 行内代码升级来的,复制消息时 Chromium 会把选区原样序列化进 `text/html`,而
+ * `<button>` 不在外部富文本编辑器(Slack / 飞书 / Notion / Word)的粘贴白名单
+ * 里——整个节点连同路径文字会被丢弃,只在原位留下一个断行。`<code>` 既是语义
+ * 正解,粘出去还会落成对方的行内代码。详见 InlineReferenceChip 的同款说明。
  */
 function FileTargetChip({
   resolvedAbsPath,
@@ -882,11 +888,18 @@ function FileTargetChip({
 
   return (
     <>
-      <button
-        type="button"
+      <code
+        role="button"
+        tabIndex={0}
         title={title}
         onClick={activate}
         onContextMenu={ctxMenu.onContextMenu}
+        onKeyDown={(e) => {
+          // 换掉原生按钮元素后,键盘激活要自己补回来。
+          if (e.key !== 'Enter' && e.key !== ' ') return;
+          e.preventDefault();
+          activate();
+        }}
         className={cn(
           'inline rounded-[6px] border-0 px-1 py-0.5',
           'font-mono text-14 align-baseline',
@@ -898,7 +911,7 @@ function FileTargetChip({
         )}
       >
         {children}
-      </button>
+      </code>
       {ctxMenu.menu}
     </>
   );

--- a/apps/desktop/src/renderer/components/chat/QuoteChip.tsx
+++ b/apps/desktop/src/renderer/components/chat/QuoteChip.tsx
@@ -47,6 +47,10 @@ export function QuoteChip({
       tooltipContentClassName="max-h-64 w-80 max-w-[70vw] overflow-y-auto whitespace-normal"
       ariaLabel={quote.text}
       selected={selected}
+      // 刻意的例外:chip 上是把换行折叠成单行的**摘要**,不是引用原文。让它进
+      // 剪贴板等于把压扁过的文本混进复制结果,原文本身就在被引用的那条消息里。
+      // 其余消息内 chip(文件名、会话、项目)展示的是完整实体名,默认可复制。
+      textSelectable={false}
     />
   );
 }

--- a/apps/desktop/src/renderer/components/new-chat/MentionChipNode.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/MentionChipNode.tsx
@@ -101,6 +101,9 @@ function MentionChipNodeView({ node, selected }: NodeViewProps) {
         tooltip={tooltip}
         ariaLabel={displayLabel(attrs)}
         selected={selected}
+        // ProseMirror atomic node:chip 整体被选中 / 删除,内部文字不参与
+        // selection(外层 wrapper 也已 userSelect: none,这里显式声明意图)。
+        textSelectable={false}
         className={attrs.kind === 'slash' ? 'text-[var(--chat-input-text)]' : undefined}
       />
     </NodeViewWrapper>

--- a/apps/desktop/src/renderer/components/new-chat/PastedTextChipNode.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PastedTextChipNode.tsx
@@ -99,6 +99,8 @@ function PastedTextChipNodeView({ node, selected }: NodeViewProps) {
         tooltipContentClassName="max-h-64 w-80 max-w-[70vw] overflow-y-auto whitespace-pre-wrap [overflow-wrap:anywhere]"
         ariaLabel={attrs.display}
         selected={selected}
+        // 同 MentionChipNode:composer 的原子节点不参与文字级 selection。
+        textSelectable={false}
         className="cursor-pointer"
       />
     </NodeViewWrapper>


### PR DESCRIPTION
## 这次改了什么

### 摘要

选中聊天消息复制、粘到 Slack（飞书 / Notion / Word 同理）时，消息里的文件名会**凭空消失**，原位只留下一个断行。

原因是剪贴板的 `text/html` 那条路：Chromium 复制时把选区**原样**序列化，而消息里的 chip 此前用 `<button>` 承载。`<button>` 是交互控件，不属于任何富文本内容模型，外部编辑器按标签白名单解析粘贴内容，会把整个节点连同内部文字一并丢弃。同一句话里的普通 `` `authDesktopCallbackUrl` `` 是 `<code>`，在白名单内、安然无恙——一句话里两个「代码块」一个丢一个不丢，就是这个原因。

共享 chip 外壳（`InlineReferenceChip`）还写死了 `select-none`，那条路径更彻底：文字连 `text/plain` 都进不了剪贴板，复制出来是空的。

实测 Chromium 序列化产物（改动前）：

```html
…才往<span> </span><button class="chip" type="button"
  title="/Users/…/config/endpoint.json">config/endpoint.json</button>
(及 global 版)填<code>authDesktopCallbackUrl</code>。…
```

改动后：

```html
…才往<span> </span><code role="button"
  title="/Users/…/config/endpoint.json">config/endpoint.json</code>
(及 global 版)填<code>authDesktopCallbackUrl</code>。…
```

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实际使用中发现：从 Cindy 复制一段回复粘到 Slack，文件名丢失）
- 本 PR 包含：
  - `FileTargetChip`（行内代码里被解析成真实文件的路径 chip）：`<button>` → `<code role="button">`，补 Enter/Space 键盘激活。这个 chip 本就是行内代码升级来的，`<code>` 既是语义正解，粘出去还会落成对方的行内代码。
  - `InlineReferenceChip`（@文件 / 会话 / 项目 chip 的共享外壳）：交互态 `<button>` → `<span role="button">`；`select-none` 由写死改为 `textSelectable` prop，默认 `true`。顺带把不再准确的 `buttonRef` 改名 `chipRef`（全仓无外部使用者）。
  - composer 的两个 ProseMirror 原子节点（`MentionChipNode` / `PastedTextChipNode`）显式传 `textSelectable={false}`——它们本就靠外层 wrapper 的 `userSelect: none`，现在把意图写在调用处。
  - `QuoteChip` 保留不可选中并显式声明：它展示的是把换行折叠成单行的**摘要**而非引用原文，让这段压扁的文本进剪贴板是负收益，原文本身就在被引用的那条消息里。
- 明确不包含：
  - 代码块的复制按钮、`AgentActionRow` 的工具调用行仍是 `<button>`——它们是纯 UI 控件，粘贴时被丢弃是正确行为。
  - 消息里的图片仍被 zoom 用的 `<button>` 包着。`xdt-image://` 是本地协议，外部应用拿不到字节，改了也只能得到一个坏掉的 img 引用，无实际收益。
  - 没有接管 `copy` 事件去重写 `clipboardData`——换标签已从根上解决，再叠一层序列化逻辑是多余的维护负担。
- 用户可见变化：从 Cindy 复制的消息粘到外部富文本编辑器时，文件名 / 会话名 / 项目名不再丢失。Cindy 内部显示与交互无变化。
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：不涉及。本次只把承载 chip 的 HTML 标签从 `<button>` 换成 `<code>` / `<span role="button">`，样式 class 与颜色 token 逐字未动（`--msg-code-inline-bg`、`--surface-chip`、`--text-primary`、`--border-default` 等全部原样保留），因此没有视觉、交互或文案变化。键盘可达性按等价方式补齐：`role="button"` + `tabIndex={0}` + Enter/Space 激活，焦点环仍走 DESIGN.md 中 `--focus-ring`（Focus Blue `#417CDD`）这套既有 token，未引入新的视觉元素。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（仓库根全量，GATE_EXIT=0）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range 9a8886f1..8739e9ba
```

新增回归覆盖：

- `inlineReferenceChip.test.tsx`：交互态仍是 `<span>` 且无 `<button>`、默认可选中而 composer 才 opt-out、Enter/Space 能激活。
- `markdownTargetRendererContract.test.ts`：把「路径 chip 必须是 `<code>`、不得 `<button>`、不得 `select-none`」钉成契约。

另外用 Electron 起了一次真实的 selection copy 探针，直接 dump 剪贴板，确认改动前后 `text/html` 的差异（见摘要中的两段 HTML），以及 composer 原子节点仍不参与复制。

### 手工验证

macOS，从本 worktree 起隔离沙箱大陆版实机验证：

```text
pnpm dev:desktop:remote --region=cn --isolated=chipclip
```

1. 会话 workdir 指向本 worktree，让 agent 回一句带 `` `config/endpoint.json` `` 的话，选中整段复制 → 粘到 Slack：文件名完整保留，无多余断行。
2. 输入框 `@` 一个文件发出去，选中该条已发出的用户消息复制 → 粘到 Slack：chip 上的文件名正常跟出（改动前这条路径连纯文本都是空的）。

### 未执行的验证

- Light / Dark 双模式实机目检未做。本次改动不含任何颜色 token 或样式 class 变化（只换 HTML 标签），两种模式的呈现均由既有 themed 样式决定，不存在只适配一种模式的风险。
- 未逐一覆盖飞书 / Notion / Word 等其它外部编辑器，仅验证了 Slack。三者的粘贴处理同为标签白名单模型，`<code>` / `<span>` 均在白名单内。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop renderer 的聊天消息与输入框 chip 渲染。无 main 进程、无持久化、无协议、无原生层改动。
- 回滚 / 降级方式：整个 PR revert 即可，无数据或状态残留。

### 已知残留（权衡后未处理）

`InlineReferenceChip` 是 `display: inline-flex`（icon + label 对齐需要），Chromium 生成 **text/plain** 时会把它当块级、前后各插一个换行。`text/html` 那条路（也就是外部富文本编辑器）不受影响，因为对方只看标签。为少一个纯文本换行去改 `inline-flex`，会连带破坏 `truncate` 与 `max-w` 的截断行为，不划算；相比改动前「文字彻底消失」这已是明确改进。

## 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动理由以「剪贴板契约」注释固化在 `InlineReferenceChip` 与 `FileTargetChip` 上方，避免被无意回退）
- [x] 已确认测试结果或说明未执行原因
