### PR TITLE
fix(voice-input): 按地区设置默认识别语言

### DIFF
--- a/apps/desktop/src/renderer/voice-input/__tests__/voiceInputData.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/voiceInputData.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createVoiceInputShortcutFromMacNativeKeys,
+  getDefaultVoiceInputSettings,
   isVoiceInputMacNativeKeyboardShortcutPressed,
   isVoiceInputMacNativeKeyboardShortcutTargetDown,
   isVoiceInputModifierShortcut,
+  normalizeVoiceInputSettings,
   normalizeVoiceInputShortcut,
   voiceInputShortcutNeedsMacNativeListener,
 } from '../../../shared/voiceInputData';
@@ -13,6 +15,20 @@ import {
   createVoiceInputShortcutFromEvent,
   getVoiceInputBareModifierCodeFromEvent,
 } from '../shortcut';
+
+describe('voice input language defaults', () => {
+  it('defaults Global to auto and Mainland China to Simplified Chinese', () => {
+    expect(getDefaultVoiceInputSettings('darwin', 'global').language).toBe('auto');
+    expect(getDefaultVoiceInputSettings('darwin', 'cn').language).toBe('zh-CN');
+    expect(getDefaultVoiceInputSettings('darwin', 'dev').language).toBe('auto');
+  });
+
+  it('keeps an explicit language instead of replacing it with the region default', () => {
+    expect(normalizeVoiceInputSettings({ language: 'en' }, 'darwin', 'cn').language).toBe('en');
+    expect(normalizeVoiceInputSettings({ language: 'auto' }, 'darwin', 'cn').language).toBe('auto');
+    expect(normalizeVoiceInputSettings({}, 'darwin', 'cn').language).toBe('zh-CN');
+  });
+});
 
 describe('voice input shortcut normalization', () => {
   it('keeps legacy keyboard shortcuts compatible', () => {

--- a/apps/desktop/src/shared/voiceInputData.ts
+++ b/apps/desktop/src/shared/voiceInputData.ts
@@ -5,7 +5,9 @@ import type {
   DictationDictionaryLearningEntryState,
   DictationRefinementContext,
 } from '@cindy/voice-input-core';
+import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
+import { CURRENT_CINDY_REGION } from './brandRegion';
 import { SUPPORTED_LOCALES, type SupportedLocale } from './locale';
 import type { IpcErrorCode } from './ipc-errors';
 
@@ -387,9 +389,15 @@ export function isVoiceInputMacNativeKeyboardShortcutTargetDown(
   return typeof expectedKeyCode === 'number' && keys.includes(`KeyCode:${expectedKeyCode}`);
 }
 
-export function getDefaultVoiceInputSettings(platform?: string): VoiceInputSettings {
+export function getDefaultVoiceInputSettings(
+  platform?: string,
+  region: CindyRegion = CURRENT_CINDY_REGION,
+): VoiceInputSettings {
   return {
-    language: 'auto',
+    // Global cannot assume a spoken language; the Mainland China build uses
+    // Chinese as its product default. A persisted user choice still wins in
+    // normalizeVoiceInputSettings below.
+    language: region === 'cn' ? 'zh-CN' : 'auto',
     microphoneDeviceId: null,
     muteSystemAudio: true,
     playInteractionSound: true,
@@ -407,8 +415,9 @@ export function getDefaultVoiceInputSettings(platform?: string): VoiceInputSetti
 export function normalizeVoiceInputSettings(
   raw: unknown,
   platform?: string,
+  region: CindyRegion = CURRENT_CINDY_REGION,
 ): VoiceInputSettings {
-  const defaults = getDefaultVoiceInputSettings(platform);
+  const defaults = getDefaultVoiceInputSettings(platform, region);
   if (!raw || typeof raw !== 'object') return defaults;
   const candidate = raw as Partial<VoiceInputSettings>;
   const legacyPlayStartSound = (candidate as { playStartSound?: unknown }).playStartSound;

--- a/apps/mobile/src/__tests__/mobileCindyVoiceSession.test.ts
+++ b/apps/mobile/src/__tests__/mobileCindyVoiceSession.test.ts
@@ -7,6 +7,7 @@ vi.mock('expo-constants', () => ({
   },
 }));
 vi.mock('@/config/env', () => ({
+  AUTH_REGION: 'global',
   VOICE_API_BASE_URL: 'https://voice.example.com/',
 }));
 vi.mock('@/auth/secureStorage', () => ({
@@ -243,6 +244,14 @@ describe('createMobileCindyVoiceCredential', () => {
       refinementEnabled: true,
       playInteractionSound: true,
     });
+  });
+
+  it.each([
+    ['cn', 'zh-CN'],
+    ['global', 'auto'],
+    ['dev', 'auto'],
+  ] as const)('uses the %s build voice language default', (region, language) => {
+    expect(createMobileCindyVoiceCredential('device-1', region).settings?.language).toBe(language);
   });
 
   it('rejects an empty host device id', () => {

--- a/apps/mobile/src/session/mobileCindyVoiceSession.ts
+++ b/apps/mobile/src/session/mobileCindyVoiceSession.ts
@@ -1,7 +1,11 @@
 import Constants from 'expo-constants';
 
 import { ApiError, type ApiFetchOptions } from '@/api/client';
-import { VOICE_API_BASE_URL } from '@/config/env';
+import {
+  AUTH_REGION,
+  VOICE_API_BASE_URL,
+  type CindyAuthRegion,
+} from '@/config/env';
 import { i18n } from '@/i18n';
 import type {
   MobileVoiceCredentialSyncAsr,
@@ -231,7 +235,10 @@ const CINDY_MANAGED_REFINER_CHAIN = [
 ] as const satisfies readonly MobileVoiceCredentialSyncRefiner[];
 
 /** Builds the provider-neutral profile graph without persisting any inference key. */
-export function createMobileCindyVoiceCredential(hostDeviceId: string): StoredMobileVoiceCredential {
+export function createMobileCindyVoiceCredential(
+  hostDeviceId: string,
+  region: CindyAuthRegion = AUTH_REGION,
+): StoredMobileVoiceCredential {
   const normalizedHostDeviceId = hostDeviceId.trim();
   if (!normalizedHostDeviceId) throw new Error('host device id is required');
   const baseUrl = requireVoiceBaseUrl();
@@ -247,7 +254,9 @@ export function createMobileCindyVoiceCredential(hostDeviceId: string): StoredMo
     refiner: { ...CINDY_MANAGED_REFINER_CHAIN[0] },
     refinerProviderChain: CINDY_MANAGED_REFINER_CHAIN.map((item) => ({ ...item })),
     settings: {
-      language: 'auto',
+      // Global and dev builds let ASR detect the spoken language. The Mainland
+      // China build keeps Chinese as its product default.
+      language: region === 'cn' ? 'zh-CN' : 'auto',
       refinementEnabled: true,
       playInteractionSound: true,
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Desktop 与 Mobile 的语音识别默认语言跟随发行地区：

- Global 与 dev 构建默认 `auto`，由 ASR 自动识别用户实际说的语言。
- 中国大陆版默认 `zh-CN`，优先保证中文识别稳定性。
- Desktop 已持久化的显式语言设置（包括用户主动选择的 `auto`）继续优先，不会被地区默认值覆盖；恢复默认或缺少语言字段时重新跟随当前构建地区。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Global 默认自动识别语言，中国大陆版默认中文
- 本 PR 包含：Desktop 默认设置、Mobile 托管语音凭据、地区默认值与 override 回归测试
- 明确不包含：语音设置 UI、ASR provider 链、voice-server、原生录音层
- 用户可见变化：中国大陆版新用户或未设置用户默认按简体中文识别；Global 继续自动识别
- 是否存在 breaking change：无

### UI 变化

不涉及：只调整语音识别语言默认值与测试，没有视觉、交互流程或 UI 文案变化。

- 引用的设计规范：不涉及：纯默认值逻辑与测试变更，无视觉、交互或文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/voice-input/__tests__/voiceInputData.test.ts src/main/voice-input/__tests__/VoiceInputDataStore.test.ts
结果：通过，2 个文件 / 16 个测试

pnpm --filter mobile exec vitest run src/__tests__/mobileCindyVoiceSession.test.ts
结果：通过，1 个文件 / 13 个测试

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：通过（仓库根 pnpm test:unit 门禁）

node apps/mobile/scripts/ci-fingerprint.mjs compute --output <file>
结果：分支与 main 的 iOS / Android fingerprint 完全一致

pnpm check:dco
结果：通过
```

### 手工验证

不涉及：本次没有 UI 或原生录音层变化，地区分支和 override 行为由单元测试覆盖。

### 未执行的验证

未执行真机或模拟器语音听写。改动为纯 TypeScript 默认值选择，未改变 Mobile runtime fingerprint。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：语音识别语言提示策略

### 影响与回滚

- 影响范围：Desktop 缺省/恢复默认设置，以及 Mobile 每次生成的临时托管语音凭据；用户显式设置不受影响。
- 回滚 / 降级方式：回退本提交即可恢复所有地区默认 `auto`。不涉及数据迁移、协议或原生包。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不需要新增用户文档）
- [x] 已确认测试结果或说明未执行原因
