### PR TITLE
refactor(desktop): UserMessage 文件 chip 的元素类型对齐到 HTMLElement

### DIFF
--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -220,7 +220,9 @@ function UserFileChip({
   refText: string;
   fileName: string;
   workingDir: string;
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  // chip 由 InlineReferenceChip 渲染成 `<span role="button">`(见其剪贴板契约),
+  // 不再是原生 `<button>`;这里标 HTMLElement 与实际 currentTarget 对齐。
+  onClick: (e: React.MouseEvent<HTMLElement>) => void | Promise<void>;
 }) {
   // remote 会话:fs:resolve-path 打的是本机 fs,对远程 workdir 恒 none——
   // 按 workdir 风格直接 join(与 useResolvedMarkdownTarget 的 remote 分支同策)。
@@ -377,21 +379,23 @@ function looksLikeCommand(word: string): boolean {
  * Plain text segments are further scanned for URLs, which are rendered as
  * clickable links that open in the system default browser.
  *
- * F2: file chips are rendered as `<button>` (not `<span>`) so they can open
- * TextLightbox on click. The dir/agent/slash chips remain `<span>` — they
- * have no click target in this iteration.
+ * F2: file chips are clickable (they open TextLightbox); dir/agent/slash chips
+ * are inert — no click target in this iteration. Both render through
+ * InlineReferenceChip, whose interactive shell is a `<span role="button">`
+ * rather than a native `<button>` so copied messages survive an external
+ * paste (see the clipboard contract on InlineReferenceChip).
  *
  * @param content       The user message content to parse.
  * @param workingDir    Session cwd; used to resolve relative refs.
  * @param onFileChipClick  Called when a file chip is clicked. Receives the
  *                          resolved abs path, the displayed file name, and
- *                          the clicked button element (for focus restoration
+ *                          the clicked chip element (for focus restoration
  *                          when the lightbox closes — F6).
  */
 function renderContentWithoutPastedText(
   content: string,
   workingDir: string,
-  onFileChipClick: (abs: string, name: string, btn: HTMLButtonElement) => void | Promise<void>,
+  onFileChipClick: (abs: string, name: string, chip: HTMLElement) => void | Promise<void>,
   onImageClick: (xdtFileUrl: string) => void,
   t: TFunction,
   sessionId?: string,
@@ -597,7 +601,7 @@ export function projectSentRanges<T extends { start: number; end: number }>(
 function renderContent(
   content: string,
   workingDir: string,
-  onFileChipClick: (abs: string, name: string, btn: HTMLButtonElement) => void | Promise<void>,
+  onFileChipClick: (abs: string, name: string, chip: HTMLElement) => void | Promise<void>,
   onImageClick: (xdtFileUrl: string) => void,
   t: TFunction,
   sessionId?: string,
@@ -719,7 +723,7 @@ export function UserMessage({
   const [longMessageExpanded, setLongMessageExpanded] = useState(false);
   // text-lightbox F6: ref to the chip currently driving the lightbox so
   // close can return focus to it (only one lightbox at a time per message).
-  const activeFileChipRef = useRef<HTMLButtonElement | null>(null);
+  const activeFileChipRef = useRef<HTMLElement | null>(null);
 
   // text-lightbox F1 replaces the old `@path` inline prepend. Files are now
   // rendered as a dedicated Chip-Row above the text bubble (per cc-agent-view

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -373,7 +373,7 @@ function looksLikeCommand(word: string): boolean {
  * Chip patterns:
  *   @.claude/agents/name.md  → agent chip (sparkles + name)
  *   @path/to/dir/            → dir chip (folder + dirname/)
- *   @path/to/file.ext        → file chip (file + basename) — clickable button
+ *   @path/to/file.ext        → file chip (file + basename) — clickable
  *   /command (at line start) → slash chip (no icon, /command)
  *
  * Plain text segments are further scanned for URLs, which are rendered as
@@ -490,11 +490,11 @@ function renderContentWithoutPastedText(
               onClick={async (e) => {
                 // Capture currentTarget before await — React pools events and
                 // by the time the IPC resolves, currentTarget is null.
-                const btn = e.currentTarget;
+                const chip = e.currentTarget;
                 if (remoteJoin) {
                   // remote:本机 BFS 无意义,join 出远端绝对路径,存在性由
                   // 点击后的远程取回链路兜底。
-                  await onFileChipClick(resolveLocalPath(ref, workingDir), fileName, btn);
+                  await onFileChipClick(resolveLocalPath(ref, workingDir), fileName, chip);
                   return;
                 }
                 // markdown-monorepo-resolve: smart resolve so a chip like
@@ -508,7 +508,7 @@ function renderContentWithoutPastedText(
                   return;
                 }
                 const abs = result.status === 'unique' ? result.absPath : result.fallbackAbsPath;
-                await onFileChipClick(abs, fileName, btn);
+                await onFileChipClick(abs, fileName, chip);
               }}
             />,
           );
@@ -1054,9 +1054,9 @@ export function UserMessage({
                   await saveChatAttachmentWithToasts(sessionFileCtx, f);
                   return;
                 }
-                const btn = e.currentTarget;
+                const chip = e.currentTarget;
                 if (!(await shouldOpenTextLightboxForOrigin(sessionFileCtx, f.path))) return;
-                activeFileChipRef.current = btn;
+                activeFileChipRef.current = chip;
                 setTextLightboxFile({ path: f.path, name: f.name });
               }}
               className={cn(
@@ -1282,7 +1282,7 @@ export function UserMessage({
                                 : renderContent(
                                     segment.text,
                                     workingDir,
-                                    async (abs, name, btn) => {
+                                    async (abs, name, chip) => {
                                       if (
                                         !(await shouldOpenTextLightboxForOrigin(
                                           sessionFileCtx,
@@ -1290,7 +1290,7 @@ export function UserMessage({
                                         ))
                                       )
                                         return;
-                                      activeFileChipRef.current = btn;
+                                      activeFileChipRef.current = chip;
                                       setTextLightboxFile({ path: abs, name });
                                     },
                                     (xdtFileUrl) => setLightboxSrc(xdtFileUrl),
@@ -1336,13 +1336,13 @@ export function UserMessage({
                           : renderContent(
                               bubbleBody,
                               workingDir,
-                              async (abs, name, btn) => {
+                              async (abs, name, chip) => {
                                 if (!(await shouldOpenTextLightboxForOrigin(sessionFileCtx, abs)))
                                   return;
-                                // F2 / F6: stash the clicked button so the lightbox can
+                                // F2 / F6: stash the clicked chip so the lightbox can
                                 // return focus on close. State + ref are shared with the
                                 // Chip-Row above ("most recent trigger wins" semantics).
-                                activeFileChipRef.current = btn;
+                                activeFileChipRef.current = chip;
                                 setTextLightboxFile({ path: abs, name });
                               },
                               (xdtFileUrl) => setLightboxSrc(xdtFileUrl),
@@ -1406,10 +1406,10 @@ export function UserMessage({
                         ? renderContent(
                             ghostCardPromptBody,
                             workingDir,
-                            async (abs, name, btn) => {
+                            async (abs, name, chip) => {
                               if (!(await shouldOpenTextLightboxForOrigin(sessionFileCtx, abs)))
                                 return;
-                              activeFileChipRef.current = btn;
+                              activeFileChipRef.current = chip;
                               setTextLightboxFile({ path: abs, name });
                             },
                             (xdtFileUrl) => setLightboxSrc(xdtFileUrl),

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -488,8 +488,11 @@ function renderContentWithoutPastedText(
               fileName={fileName}
               workingDir={workingDir}
               onClick={async (e) => {
-                // Capture currentTarget before await — React pools events and
-                // by the time the IPC resolves, currentTarget is null.
+                // Capture currentTarget before the await: `currentTarget` is only
+                // set while the DOM event is being dispatched, so it reads back as
+                // null once the IPC resolves. (Not React event pooling — that was
+                // removed in React 17; this is plain DOM Event semantics.) The
+                // element is needed later to restore focus when the lightbox closes.
                 const chip = e.currentTarget;
                 if (remoteJoin) {
                   // remote:本机 BFS 无意义,join 出远端绝对路径,存在性由


### PR DESCRIPTION
## 这次改了什么

### 摘要

#552 的 follow-up，处理 review 里提的 P2（non-blocking）。

#552 把 `InlineReferenceChip` 的交互外壳从 `<button>` 换成了 `<span role="button">`（剪贴板契约：`<button>` 会被 Slack / 飞书 / Notion / Word 的粘贴白名单整个丢弃），但 `UserMessage.tsx` 这边的调用方类型标注没跟着改：

- `UserFileChip.onClick` 仍标 `React.MouseEvent<HTMLButtonElement>`
- `onFileChipClick` 的第三个参数仍标 `HTMLButtonElement`（两处）
- `activeFileChipRef` 仍是 `useRef<HTMLButtonElement | null>`

因为方法参数的 bivariance，加上下游实际只把它当 `HTMLElement` 用，编译与运行都不受影响——纯粹是类型标注滞后于实现。本 PR 把它们对齐到 `HTMLElement`。

对齐到 `HTMLElement` 而不是 `HTMLSpanElement`，是为了跟这条链路上已有的类型保持一致：`TextLightbox` / `ToolPayloadLightbox` 的 `triggerRef` 本来就是 `React.RefObject<HTMLElement | null>`，`AgentActionRow` 里同款 ref 也是 `useRef<HTMLElement | null>`。

顺带修正了同一段里两处过时注释（还写着 file chip 渲染成 `<button>`），并把参数名 `btn` 改成 `chip`，与实际元素一致。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#552 的 review follow-up（reviewer 标注为 P2、不阻断）
- 本 PR 包含：`UserMessage.tsx` 中 4 处 `HTMLButtonElement` → `HTMLElement`，2 处过时注释修正，参数名 `btn` → `chip`
- 明确不包含：无其它逻辑或样式改动
- 用户可见变化：无
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：不涉及。本 PR 只改 TypeScript 类型标注、参数名与注释，没有触碰任何 JSX 结构、样式 class、颜色 token 或文案，渲染产物逐字节不变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（仓库根全量，GATE_EXIT=0）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range 8d2e8ed7..f12fee36
```

另外确认改动后 `UserMessage.tsx` 已无 `HTMLButtonElement` 残留，其余 chip 调用方（`SessionLinkChip` / `ProjectLinkChip` / `QuoteChip` / `MentionChipNode` / `PastedTextChipNode`）本就没有该标注。

### 手工验证

不涉及：纯类型标注与注释改动，无运行时行为变化，渲染产物不变。#552 的实机复制粘贴验证（macOS，`--region=cn --isolated=chipclip` 沙箱 → Slack）已在该 PR 完成。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `apps/desktop/src/renderer/components/chat/UserMessage.tsx` 的类型标注与注释。编译产物行为不变。
- 回滚 / 降级方式：直接 revert，无任何状态或数据残留。

## 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（过时注释已随本 PR 修正）
- [x] 已确认测试结果或说明未执行原因
