### PR TITLE
feat(desktop): 为内置 Provider 增加手动刷新

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -538,6 +538,7 @@ import {
   initModelAccess,
   noteManualXdKeySaved,
   noteManualXdKeyRemoved,
+  refreshXdGatewayModels,
 } from './model-access/index.js';
 import { effectiveXdGatewayBaseUrl } from './model-access/effectiveEndpoint.js';
 import { isLocalDbOwnerCurrent } from './appSessionPolicy.js';
@@ -3550,6 +3551,7 @@ const registerIpcHandlers = () => {
           setMainWindowBackgroundThrottlingForActiveTurn(isRunning);
           notifyUpdateAutoRelaunchBusyStateChanged();
         },
+        refreshXdGatewayModels,
       });
       registerMakerTitleIpc();
       registerMakerHelpIpc(ipcMaker);

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogRevision.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogRevision.test.ts
@@ -9,6 +9,7 @@ import {
   setActiveCatalogChangedListener,
   setAnthropicDiscoveredModels,
   setDiscoveredCodexModels,
+  setProviderModelsFromCatalog,
 } from '../active-catalog.js';
 
 describe('active catalog revision', () => {
@@ -63,5 +64,50 @@ describe('active catalog revision', () => {
     expect(listener).toHaveBeenCalledOnce();
     expect(listener.mock.results[0]?.value).toMatchObject({ revision: start + 1 });
     expect(listener.mock.results[0]?.value.ids).toContain('claude-opus-next');
+  });
+
+  it('refreshes one provider model snapshot without replacing live routing or other providers', () => {
+    const current = structuredClone(BUNDLED_CATALOG);
+    const incoming = structuredClone(BUNDLED_CATALOG);
+    const currentXai = current.providers.find((provider) => provider.id === 'xai');
+    const incomingXai = incoming.providers.find((provider) => provider.id === 'xai');
+    const currentOpenAi = current.providers.find((provider) => provider.id === 'openai');
+    const incomingOpenAi = incoming.providers.find((provider) => provider.id === 'openai');
+    if (!currentXai || !incomingXai || !currentOpenAi || !incomingOpenAi) {
+      throw new Error('expected bundled xai/openai providers');
+    }
+    currentXai.routing.codex = {
+      ...currentXai.routing.codex!,
+      upstream: 'https://current-routing.example.com/v1',
+    };
+    incomingXai.routing.codex = {
+      ...incomingXai.routing.codex!,
+      upstream: 'https://incoming-routing.example.com/v1',
+    };
+    incomingXai.models.codex = [{
+      id: 'xai/new-model',
+      name: 'New xAI Model',
+      contextWindow: 256_000,
+      efforts: ['high'],
+      defaultEffort: 'high',
+    }];
+    incomingOpenAi.models.codex = [{
+      id: 'should-not-replace-openai',
+      name: 'Should Not Replace OpenAI',
+      contextWindow: 1,
+      efforts: [],
+      defaultEffort: null,
+    }];
+
+    setActiveCatalog(current);
+    setProviderModelsFromCatalog('xai', incoming);
+
+    const active = getActiveCatalog();
+    expect(active.providers.find((provider) => provider.id === 'xai')?.models.codex)
+      .toEqual(incomingXai.models.codex);
+    expect(active.providers.find((provider) => provider.id === 'xai')?.routing.codex)
+      .toEqual(currentXai.routing.codex);
+    expect(active.providers.find((provider) => provider.id === 'openai')?.models.codex)
+      .toEqual(currentOpenAi.models.codex);
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -460,6 +460,46 @@ describe('noteAnthropicSdkSupportedModels(登录态门控 + 合并纪律)', () =
     await expect(fsp.access(cache)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('HTTP 刷新落盘期间换号时返回未应用,不向设置页误报成功', async () => {
+    oauthRefreshMock.getValidClaudeAiOAuth.mockResolvedValue({ accessToken: 'test-token' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'claude-opus-4-8', display_name: 'Account A Opus', type: 'model' }],
+          has_more: false,
+        }),
+      })),
+    );
+
+    const originalWriteFile = fsp.writeFile.bind(fsp);
+    let releaseWrite!: () => void;
+    let signalWriteStarted!: () => void;
+    const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    const writeStarted = new Promise<void>((resolve) => { signalWriteStarted = resolve; });
+    const writeSpy = vi.spyOn(fsp, 'writeFile').mockImplementationOnce(async (...args) => {
+      signalWriteStarted();
+      await writeGate;
+      return originalWriteFile(...args);
+    });
+
+    try {
+      const refreshPromise = refreshAnthropicModelsFromHttp();
+      await writeStarted;
+      authState.loggedIn = false;
+      const clearPromise = clearAnthropicDiscoveredModels();
+      releaseWrite();
+
+      await expect(refreshPromise).resolves.toBe(false);
+      await clearPromise;
+      expect(anthropicIds()).toEqual([]);
+    } finally {
+      releaseWrite();
+      writeSpy.mockRestore();
+    }
+  });
+
   it('登出删除排在旧 SDK 在途持久化之后,缓存不会死灰复燃(review P1 回归)', async () => {
     const originalWriteFile = fsp.writeFile.bind(fsp);
     let releaseWrite!: () => void;

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -367,6 +367,20 @@ describe('createModelRoutingTransform —— session-less 控制面请求(桶③
       .toEqual({ upstreamOverride: CHATGPT });
   });
 
+  it('冻结 control-plane auth 形态后不受 session host 的全局模式改写', async () => {
+    const host = await import('../codex-proxy-host.js');
+    host.setCodexProxyAuthInjection('provider-oauth');
+    const transform = host.createModelRoutingTransform('oauth-bearer');
+
+    host.setCodexProxyAuthInjection('provider-oauth');
+    expect(transform(undefined, {
+      reqId: 1,
+      method: 'GET',
+      url: '/models',
+      headers: {},
+    })).toEqual({ upstreamOverride: CHATGPT });
+  });
+
   it('env-key + 无 session + 无 model(GET /models)→ null(留默认网关, sk- key 本就有效)', async () => {
     const host = await import('../codex-proxy-host.js');
     host.setCodexProxyAuthInjection('env-key');

--- a/apps/desktop/src/main/maker-host/__tests__/providerModelRefresh.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerModelRefresh.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  refreshBuiltinProviderModels,
+  type BuiltinProviderModelRefreshDeps,
+} from '../provider-model-refresh.js';
+
+function deps(
+  overrides: Partial<BuiltinProviderModelRefreshDeps> = {},
+): BuiltinProviderModelRefreshDeps {
+  return {
+    refreshXd: vi.fn(async () => {}),
+    refreshAnthropic: vi.fn(async () => true),
+    refreshOpenAi: vi.fn(async () => true),
+    refreshXaiCatalog: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('refreshBuiltinProviderModels', () => {
+  it.each([
+    ['xd', 'refreshXd'],
+    ['anthropic', 'refreshAnthropic'],
+    ['openai', 'refreshOpenAi'],
+    ['xai', 'refreshXaiCatalog'],
+  ] as const)('dispatches %s to its existing refresh source', async (providerId, method) => {
+    const d = deps();
+    await refreshBuiltinProviderModels(providerId, d);
+    expect(d[method]).toHaveBeenCalledOnce();
+  });
+
+  it('rejects stale or unapplied dynamic snapshots', async () => {
+    await expect(
+      refreshBuiltinProviderModels('anthropic', deps({ refreshAnthropic: async () => false })),
+    ).rejects.toThrow(/Anthropic model discovery/);
+    await expect(
+      refreshBuiltinProviderModels('openai', deps({ refreshOpenAi: async () => false })),
+    ).rejects.toThrow(/OpenAI model discovery/);
+  });
+});

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -575,6 +575,29 @@ export function setActiveCatalog(catalog: Catalog): void {
 }
 
 /**
+ * 只把一次新目录里的模型快照投影到当前基础目录，保留当前 provider 的 routing/auth
+ * 与其它 provider。手动模型刷新可因此即时更新列表，而不会在活跃 turn 中途替换
+ * 上游、鉴权策略、modelPrefixes 或 rewrite 等运行时路由字段。
+ */
+export function setProviderModelsFromCatalog(providerId: string, catalog: Catalog): void {
+  const incoming = catalog.providers.find((provider) => provider.id === providerId);
+  if (!incoming) {
+    throw new Error(`catalog does not contain provider '${providerId}'`);
+  }
+  const current = base ?? BUNDLED_CATALOG;
+  if (!current.providers.some((provider) => provider.id === providerId)) {
+    throw new Error(`active catalog does not contain provider '${providerId}'`);
+  }
+  base = {
+    ...current,
+    providers: current.providers.map((provider) =>
+      provider.id === providerId ? { ...provider, models: incoming.models } : provider,
+    ),
+  };
+  markChanged();
+}
+
+/**
  * 注入 / 刷新用户自定义供应商(CRUD 后、或换账号 DB 重开后调用)。
  * 传入的是已 `buildUserProvider` 展开的标准 `Provider[]`(**不含 API key**)。
  */

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -75,6 +75,8 @@ const threadToSession = new Map<string, string>();
 
 let _handle: ProxyHandle | null = null;
 let _startPromise: Promise<void> | null = null;
+const _controlPlaneHandles = new Map<CodexProxyAuthInjection, ProxyHandle>();
+const _controlPlaneStartPromises = new Map<CodexProxyAuthInjection, Promise<void>>();
 let _disposeGeneration = 0;
 let dumpSeq = 0;
 
@@ -1284,13 +1286,15 @@ export function decideCodexRoute(opts: {
   return { upstreamOverride: CODEX_OAUTH_UPSTREAM };
 }
 
-export function createModelRoutingTransform(): RoutingTransform {
+export function createModelRoutingTransform(
+  frozenAuthInjection?: CodexProxyAuthInjection,
+): RoutingTransform {
   return (body, ctx) => {
     // body 可能为 undefined —— 无 body 的 GET(典型: codex models-manager 的 `GET /models` 轮询,
     // 引擎现在也会对它跑路由)。不再因 body 非对象就短路;会话解析只依赖 headers,model 字段可选。
     const model = isPlainObject(body) && typeof body.model === 'string' ? body.model : '';
     const gatewayKey = _readGatewayKey();
-    const authInjection = getCodexProxyAuthInjection();
+    const authInjection = frozenAuthInjection ?? getCodexProxyAuthInjection();
     const threadId = selectedThreadIdFromHeaders(ctx.headers);
     const sessionId = threadId ? threadToSession.get(threadId) : undefined;
 
@@ -1392,6 +1396,45 @@ function createTransformRequestChain(): RequestTransform[] {
   return transforms;
 }
 
+function createCodexProxyHandle(
+  frozenAuthInjection?: CodexProxyAuthInjection,
+): Promise<ProxyHandle> {
+  return createAnthropicCompatProxy({
+    // 默认上游 = gateway(含 /v1)；普通模型 + oauth 由 routingTransform 覆盖到 ChatGPT。
+    upstream: () => buildCodexGatewayBaseUrl(),
+    transformRequest: createTransformRequestChain(),
+    // 常规 session proxy 继续读取当前全局 spawn 形态；control-plane proxy 在创建时
+    // 冻结自己的形态，两个 app-server 并行时不会互相改写路由。
+    routingTransform: createModelRoutingTransform(frozenAuthInjection),
+    responseObserver: composeResponseObservers(
+      createCodexResponseObserver(),
+      createProviderUpstreamErrorObserver({
+        agent: 'codex',
+        resolveUserProviderId: (requestHeaders) => {
+          const threadId = selectedThreadIdFromHeaders(requestHeaders);
+          const sessionId = threadId ? threadToSession.get(threadId) : undefined;
+          return sessionId ? getUserProviderIdForSession(sessionId) : null;
+        },
+        resolveUserProviderName: (providerId) =>
+          getActiveCatalog().providers.find((provider) => provider.id === providerId)?.name ?? null,
+      }),
+    ),
+    maxRequestBodyBytes: CODEX_PROXY_MAX_REQUEST_BODY_BYTES,
+    debugDumpRequestBody: process.env.XDT_PROXY_DUMP_REQUEST_BODY === '1',
+    recoveryRules: [
+      createEncryptedContentRecoveryRule({
+        enabled: () => readSilentEncryptedRetrySettings().enabled,
+        onRetry: (threadId, model) => encryptedStripController.markActive(threadId, model),
+      }),
+      createImageGenerationIdRecoveryRule({
+        onRetry: (threadId, model) => imageGenerationStripController.markActive(threadId, model),
+      }),
+    ],
+    logger: log,
+    resolveOutboundProxy: resolveDesktopOutboundProxy,
+  });
+}
+
 /**
  * 启动本地 Codex prompt proxy。幂等 —— 重复调用直接返回已缓存状态。
  *
@@ -1405,47 +1448,7 @@ export async function ensureCodexProxyReady(): Promise<void> {
   const generation = _disposeGeneration;
   _startPromise = (async () => {
     try {
-      const handle = await createAnthropicCompatProxy({
-        // 默认上游 = gateway(含 /v1); 「普通模型 + oauth」由 routingTransform override 到 ChatGPT。
-        // 函数形态:model-access 下发切换网关 endpoint 后,常驻 proxy 每请求现取(按值 memoize)。
-        upstream: () => buildCodexGatewayBaseUrl(),
-        transformRequest: createTransformRequestChain(),
-        routingTransform: createModelRoutingTransform(),
-        // 组合两个只读观察器:service-tier 抽取 + 自定义供应商上游错误分类广播
-        // (后者仅 status≥400 且会话路由到 user 供应商时才 tee,成功路径零开销)。
-        responseObserver: composeResponseObservers(
-          createCodexResponseObserver(),
-          createProviderUpstreamErrorObserver({
-            agent: 'codex',
-            resolveUserProviderId: (requestHeaders) => {
-              const threadId = selectedThreadIdFromHeaders(requestHeaders);
-              const sessionId = threadId ? threadToSession.get(threadId) : undefined;
-              return sessionId ? getUserProviderIdForSession(sessionId) : null;
-            },
-            resolveUserProviderName: (providerId) =>
-              getActiveCatalog().providers.find((provider) => provider.id === providerId)?.name ?? null,
-          }),
-        ),
-        maxRequestBodyBytes: CODEX_PROXY_MAX_REQUEST_BODY_BYTES,
-        // 请求体 dump 默认关(dev trace 级别 + agent 高并发会刷爆 main event loop
-        // 与日志盘);诊断请求体时设 XDT_PROXY_DUMP_REQUEST_BODY=1 显式开启。
-        debugDumpRequestBody: process.env.XDT_PROXY_DUMP_REQUEST_BODY === '1',
-        // Codex 走 OpenAI Responses API, 从不打 Anthropic Messages API, 不会出现空 thinking 块 400
-        // → 挂 Responses 专属恢复规则, 不挂 thinking 规则。
-        recoveryRules: [
-          createEncryptedContentRecoveryRule({
-            enabled: () => readSilentEncryptedRetrySettings().enabled,
-            onRetry: (threadId, model) => encryptedStripController.markActive(threadId, model),
-          }),
-          createImageGenerationIdRecoveryRule({
-            onRetry: (threadId, model) => imageGenerationStripController.markActive(threadId, model),
-          }),
-        ],
-        logger: log,
-        // 上游连接跟随代理环境变量 / 系统代理(非 TUN 的代理软件场景);无代理配置时直连,
-        // 行为与之前字节级一致。见 outbound-proxy-resolver.ts。
-        resolveOutboundProxy: resolveDesktopOutboundProxy,
-      });
+      const handle = await createCodexProxyHandle();
       if (generation !== _disposeGeneration) {
         await handle.dispose().catch((err) => {
           log.warn('codex proxy start raced with dispose; disposing fresh handle failed', {
@@ -1467,6 +1470,72 @@ export async function ensureCodexProxyReady(): Promise<void> {
     }
   })();
   return _startPromise;
+}
+
+/**
+ * 为一次独立 control-plane app-server 提供冻结鉴权形态的专用 proxy。
+ * 它不读取也不改写 session host 的全局 auth injection；同形态可安全复用同一端口。
+ */
+export async function ensureCodexControlPlaneProxyReady(
+  authInjection: CodexProxyAuthInjection,
+): Promise<void> {
+  if (_controlPlaneHandles.has(authInjection)) return;
+  const existing = _controlPlaneStartPromises.get(authInjection);
+  if (existing) return existing;
+
+  const generation = _disposeGeneration;
+  let start!: Promise<void>;
+  start = (async () => {
+    try {
+      const handle = await createCodexProxyHandle(authInjection);
+      if (generation !== _disposeGeneration) {
+        await handle.dispose().catch((err) => {
+          log.warn('codex control-plane proxy start raced with dispose', {
+            authInjection,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        });
+        return;
+      }
+      _controlPlaneHandles.set(authInjection, handle);
+      log.info('codex control-plane proxy ready', {
+        authInjection,
+        url: handle.url,
+        upstream: buildCodexGatewayBaseUrl(),
+      });
+    } catch (err) {
+      _controlPlaneHandles.delete(authInjection);
+      log.error('codex control-plane proxy failed to start', {
+        authInjection,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      if (_controlPlaneStartPromises.get(authInjection) === start) {
+        _controlPlaneStartPromises.delete(authInjection);
+      }
+    }
+  })();
+  _controlPlaneStartPromises.set(authInjection, start);
+  return start;
+}
+
+export function isCodexControlPlaneProxyHandleReady(
+  authInjection: CodexProxyAuthInjection,
+): boolean {
+  return _controlPlaneHandles.has(authInjection);
+}
+
+export function getCodexControlPlaneProxyEndpoint(
+  authInjection: CodexProxyAuthInjection,
+): string {
+  const handle = _controlPlaneHandles.get(authInjection);
+  if (handle) return handle.url;
+  const fallbackEndpoint = buildCodexGatewayBaseUrl();
+  log.warn('codex control-plane proxy not ready, falling back to direct gateway', {
+    authInjection,
+    fallbackEndpoint,
+  });
+  return fallbackEndpoint;
 }
 
 /**
@@ -1555,13 +1624,30 @@ export async function disposeCodexProxy(): Promise<void> {
     await _startPromise.catch(() => undefined);
   }
 
-  if (!_handle) return;
-
   const h = _handle;
   _handle = null;
-  try {
-    await h.dispose();
-  } catch (err) {
-    log.warn('codex proxy dispose failed', { err: err instanceof Error ? err.message : String(err) });
+
+  if (_controlPlaneStartPromises.size > 0) {
+    await Promise.allSettled(_controlPlaneStartPromises.values());
+    _controlPlaneStartPromises.clear();
   }
+  const controlPlaneHandles = Array.from(_controlPlaneHandles.values());
+  _controlPlaneHandles.clear();
+
+  if (h) {
+    try {
+      await h.dispose();
+    } catch (err) {
+      log.warn('codex proxy dispose failed', { err: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  await Promise.all(controlPlaneHandles.map(async (handle) => {
+    try {
+      await handle.dispose();
+    } catch (err) {
+      log.warn('codex control-plane proxy dispose failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }));
 }

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -173,6 +173,7 @@ async function cleanupLegacyCatalogCache(): Promise<void> {
 
 let activeLoaded = false;
 let activeInflight: Promise<Catalog> | null = null;
+let catalogRefreshInflight: Promise<Catalog> | null = null;
 
 /**
  * 启动期（splash）await 一次：加载远端目录写入 active-catalog。幂等 + 并发去重。
@@ -235,6 +236,25 @@ export function ensureActiveCatalogLoaded(): Promise<Catalog> {
       });
   }
   return activeInflight;
+}
+
+/**
+ * 手动重载远端/本地目录。先确保启动期动态发现已完成，再复用同一 `loadCatalog`
+ * 源选择与 bundled fallback；active-catalog 的动态模型、自定义供应商状态保持不变。
+ */
+export async function refreshActiveCatalogFromSource(): Promise<Catalog> {
+  await ensureActiveCatalogLoaded();
+  if (catalogRefreshInflight) return catalogRefreshInflight;
+  const flight = loadCatalog(buildSource(), io)
+    .then((catalog) => {
+      setActiveCatalog(catalog);
+      return catalog;
+    })
+    .finally(() => {
+      if (catalogRefreshInflight === flight) catalogRefreshInflight = null;
+    });
+  catalogRefreshInflight = flight;
+  return flight;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -23,6 +23,7 @@ import {
   buildUserProvider,
   DEFAULT_REMOTE_CATALOG_BUDGET_MS,
   loadCatalog,
+  loadCatalogWithSource,
   type Catalog,
   type CatalogIO,
   type CatalogSourceConfig,
@@ -245,8 +246,11 @@ export function ensureActiveCatalogLoaded(): Promise<Catalog> {
 export async function refreshActiveCatalogFromSource(): Promise<Catalog> {
   await ensureActiveCatalogLoaded();
   if (catalogRefreshInflight) return catalogRefreshInflight;
-  const flight = loadCatalog(buildSource(), io)
-    .then((catalog) => {
+  const flight = loadCatalogWithSource(buildSource(), io)
+    .then(({ catalog, source }) => {
+      if (source === 'bundled') {
+        throw new Error('catalog refresh exhausted configured sources; keeping current snapshot');
+      }
       setActiveCatalog(catalog);
       return catalog;
     })

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -32,7 +32,13 @@ import {
 import { createLogger } from '../logger.js';
 import { getBaseUrl, isDev } from '../manifestService.js';
 import { getClientEndpoint } from '../clientEndpointsService.js';
-import { getActiveCatalog, setActiveCatalog, setCustomProviders, setDiscoveredCodexModels } from './active-catalog.js';
+import {
+  getActiveCatalog,
+  setActiveCatalog,
+  setCustomProviders,
+  setDiscoveredCodexModels,
+  setProviderModelsFromCatalog,
+} from './active-catalog.js';
 import {
   readCodexDiscoveredModels,
   readCodexDiscoveredModelsForAuthRefresh,
@@ -240,8 +246,9 @@ export function ensureActiveCatalogLoaded(): Promise<Catalog> {
 }
 
 /**
- * 手动重载远端/本地目录。先确保启动期动态发现已完成，再复用同一 `loadCatalog`
- * 源选择与 bundled fallback；active-catalog 的动态模型、自定义供应商状态保持不变。
+ * 手动重载 xAI 模型目录。先确保启动期动态发现已完成，再复用同一 `loadCatalog`
+ * 源选择与 bundled fallback；只投影 xAI 的静态模型列表，当前 routing/auth 以及其它
+ * provider 全部保持不变，避免活跃 turn 中途被整份远端目录切换路由。
  */
 export async function refreshActiveCatalogFromSource(): Promise<Catalog> {
   await ensureActiveCatalogLoaded();
@@ -251,8 +258,8 @@ export async function refreshActiveCatalogFromSource(): Promise<Catalog> {
       if (source === 'bundled') {
         throw new Error('catalog refresh exhausted configured sources; keeping current snapshot');
       }
-      setActiveCatalog(catalog);
-      return catalog;
+      setProviderModelsFromCatalog('xai', catalog);
+      return getActiveCatalog();
     })
     .finally(() => {
       if (catalogRefreshInflight === flight) catalogRefreshInflight = null;

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -80,9 +80,12 @@ import { notifyAutoPermissionClassifierUnavailable } from './claude-auto-permiss
 import { hasClaudeAiOAuth } from './claude-credentials-store.js';
 import {
   clearCodexProxyAuthInjection,
+  ensureCodexControlPlaneProxyReady,
   ensureCodexProxyReady,
+  getCodexControlPlaneProxyEndpoint,
   getCodexProxyAuthInjectionState,
   getCodexProxyEndpoint,
+  isCodexControlPlaneProxyHandleReady,
   isCodexProxyHandleReady,
   setCodexProxyAuthInjection,
   setCodexProxyGatewayKeyReader,
@@ -484,14 +487,23 @@ export function getMaker(): Maker {
               ? 'provider-oauth'
               : 'env-key';
         const useOAuthBearer = authInjection === 'oauth-bearer';
-        setCodexProxyAuthInjection(authInjection);
-        await broadcastCodexRuntimeRoute();
+        const isControlPlane = ctx.hostPurpose === 'control-plane';
+        if (!isControlPlane) {
+          setCodexProxyAuthInjection(authInjection);
+          await broadcastCodexRuntimeRoute();
+        }
         setCodexProxyGatewayKeyReader(readClaudeApiKey);
 
         // 这个点在 CodexAgent.createHost() 内。返回的 codexProxyActive 会被冻到 AppServerHost 实例上,
         // 后续 startSession 只读 host 自己的事实,不再 live 读全局 flag。
-        await ensureCodexProxyReady();
-        const ready = isCodexProxyHandleReady();
+        if (isControlPlane) {
+          await ensureCodexControlPlaneProxyReady(authInjection);
+        } else {
+          await ensureCodexProxyReady();
+        }
+        const ready = isControlPlane
+          ? isCodexControlPlaneProxyHandleReady(authInjection)
+          : isCodexProxyHandleReady();
         if ((useOAuthBearer || authInjection === 'provider-oauth') && !ready) {
           const error = new Error(
             authInjection === 'provider-oauth'
@@ -503,7 +515,9 @@ export function getMaker(): Maker {
           throw error;
         }
         // gateway-key 模式下 proxy 挂了仍可 fallback 到 gateway base_url(codex 直连 gateway, 不裸奔)。
-        const endpoint = getCodexProxyEndpoint();
+        const endpoint = isControlPlane
+          ? getCodexControlPlaneProxyEndpoint(authInjection)
+          : getCodexProxyEndpoint();
         return {
           extraArgs: [...mcpExtraArgs, ...buildCodexProxySpawnArgs(endpoint, authInjection)],
           extraEnv: mcpExtraEnv,

--- a/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
@@ -76,7 +76,7 @@ const explicitFastModeModelIds = new Set<string>();
 const explicitWindows = new Map<string, number>();
 /** 授权边界(登出 / 换号)自增:在途发现若世代已变,结果作废不写回。 */
 let authGeneration = 0;
-let httpRefreshInflight: Promise<void> | null = null;
+let httpRefreshInflight: Promise<boolean> | null = null;
 /** 在途拉取所属的世代;世代已变时新调用不复用旧 promise(换号补拉不被吞)。 */
 let httpRefreshInflightGen = -1;
 /** 缓存写入 / 删除严格串行,保证授权边界后的删除一定排在旧世代写入之后。 */
@@ -438,8 +438,8 @@ async function applyModels(
   generation = authGeneration,
   nextExplicitEffortIds: ReadonlySet<string> = explicitEffortModelIds,
   nextExplicitFastModeIds: ReadonlySet<string> = explicitFastModeModelIds,
-): Promise<void> {
-  if (!generationCanApply(generation, models)) return;
+): Promise<boolean> {
+  if (!generationCanApply(generation, models)) return false;
   const modelIds = new Set(models.map((model) => model.id));
   const normalizedExplicitEffortIds = new Set(
     [...nextExplicitEffortIds].filter((id) => modelIds.has(id)),
@@ -453,7 +453,7 @@ async function applyModels(
     [...normalizedExplicitEffortIds].some((id) => !explicitEffortModelIds.has(id)) ||
     normalizedExplicitFastModeIds.size !== explicitFastModeModelIds.size ||
     [...normalizedExplicitFastModeIds].some((id) => !explicitFastModeModelIds.has(id));
-  if (!modelsChanged && !capabilityProvenanceChanged) return;
+  if (!modelsChanged && !capabilityProvenanceChanged) return true;
   lastApplied = models;
   explicitEffortModelIds.clear();
   for (const id of normalizedExplicitEffortIds) explicitEffortModelIds.add(id);
@@ -496,6 +496,7 @@ async function applyModels(
       }
     });
   }
+  return generationCanApply(generation, models);
 }
 
 /**
@@ -669,15 +670,15 @@ export function noteAnthropicSdkSupportedModels(raw: unknown): void {
  * HTTP `/v1/models` 拉取(登录成功 / 启动时)。single-flight;失败只记日志、
  * 保留现值(缓存是上次成功的真数据);成功按合并纪律生效并持久化。
  */
-export function refreshAnthropicModelsFromHttp(): Promise<void> {
+export function refreshAnthropicModelsFromHttp(): Promise<boolean> {
   // 只复用**同世代**的在途拉取:登出后世代已变,旧 promise 的结果注定作废,
   // 复用会吞掉换号后新账号的补拉。
   if (httpRefreshInflight && httpRefreshInflightGen === authGeneration) return httpRefreshInflight;
   const gen = authGeneration;
   const flight = (async () => {
     const oauth = await getValidClaudeAiOAuth();
-    if (!oauth?.accessToken) return;
-    if (gen !== authGeneration || !hasClaudeAiOAuth()) return;
+    if (!oauth?.accessToken) return false;
+    if (gen !== authGeneration || !hasClaudeAiOAuth()) return false;
     const provider = getActiveCatalog().providers.find((p) => p.id === 'anthropic');
     const upstream = provider?.routing['claude-code']?.upstream ?? 'https://api.anthropic.com';
     const entries: unknown[] = [];
@@ -703,17 +704,17 @@ export function refreshAnthropicModelsFromHttp(): Promise<void> {
     } catch (err) {
       // 失败不清列表:现值(含磁盘缓存)是上次成功的真数据;SDK 通道随后仍会精化。
       log.warn('anthropic /v1/models fetch failed; keeping current list', { error: String(err) });
-      return;
+      return false;
     }
     // 在途期间登出 / 换号:结果作废,不写回、不重建缓存(review P1 竞态豁口)。
     if (gen !== authGeneration || !hasClaudeAiOAuth()) {
       log.info('anthropic /v1/models result discarded: auth changed mid-flight');
-      return;
+      return false;
     }
     const mapped = mapAnthropicHttpModels(entries);
     if (mapped.length === 0) {
       log.warn('anthropic /v1/models returned no usable models; keeping current list');
-      return;
+      return false;
     }
     // 退化判定必须先于任何状态写入:被拒快照连 explicitWindows 也不许污染,
     // 否则后续 SDK 捕获会把退化响应带来的窗口值用作精确记账(review P2)。
@@ -722,7 +723,7 @@ export function refreshAnthropicModelsFromHttp(): Promise<void> {
       log.warn(
         `anthropic /v1/models response looks degenerate (${lastApplied.length} -> ${mapped.length}); keeping current list (streak ${httpShrinkStreak}/${CONFIRMED_SHRINK_STREAK})`,
       );
-      return;
+      return false;
     }
     for (const { model, explicitContextWindow } of mapped) {
       if (explicitContextWindow != null) explicitWindows.set(model.id, explicitContextWindow);
@@ -731,7 +732,7 @@ export function refreshAnthropicModelsFromHttp(): Promise<void> {
     const { models, explicitEffortIds, explicitFastModeIds } =
       mergeCapabilitiesWithPrevious(mapped);
     log.info(`anthropic models refreshed via HTTP: ${models.length}`);
-    await applyModels(models, true, gen, explicitEffortIds, explicitFastModeIds);
+    return applyModels(models, true, gen, explicitEffortIds, explicitFastModeIds);
   })().finally(() => {
     // 只清自己的登记:世代变化后可能已有新 flight 顶替,不能误清。
     if (httpRefreshInflight === flight) httpRefreshInflight = null;

--- a/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
@@ -453,7 +453,9 @@ async function applyModels(
     [...normalizedExplicitEffortIds].some((id) => !explicitEffortModelIds.has(id)) ||
     normalizedExplicitFastModeIds.size !== explicitFastModeModelIds.size ||
     [...normalizedExplicitFastModeIds].some((id) => !explicitFastModeModelIds.has(id));
-  if (!modelsChanged && !capabilityProvenanceChanged) return true;
+  if (!modelsChanged && !capabilityProvenanceChanged) {
+    return generationCanApply(generation, models);
+  }
   lastApplied = models;
   explicitEffortModelIds.clear();
   for (const id of normalizedExplicitEffortIds) explicitEffortModelIds.add(id);

--- a/apps/desktop/src/main/maker-host/provider-model-refresh.ts
+++ b/apps/desktop/src/main/maker-host/provider-model-refresh.ts
@@ -1,0 +1,38 @@
+/**
+ * Built-in provider model-list refresh dispatcher.
+ *
+ * Each provider keeps its existing source-specific discovery implementation; this
+ * module only gives the Settings IPC one deterministic, testable entry point.
+ */
+
+import type { BuiltinRefreshableProviderId } from '../../shared/providerModelRefresh.js';
+
+export interface BuiltinProviderModelRefreshDeps {
+  refreshXd(): Promise<void>;
+  refreshAnthropic(): Promise<boolean>;
+  refreshOpenAi(): Promise<boolean>;
+  refreshXaiCatalog(): Promise<void>;
+}
+
+export async function refreshBuiltinProviderModels(
+  providerId: BuiltinRefreshableProviderId,
+  deps: BuiltinProviderModelRefreshDeps,
+): Promise<void> {
+  switch (providerId) {
+    case 'xd':
+      await deps.refreshXd();
+      return;
+    case 'anthropic':
+      if (!(await deps.refreshAnthropic())) {
+        throw new Error('Anthropic model discovery did not produce a current snapshot');
+      }
+      return;
+    case 'openai':
+      if (!(await deps.refreshOpenAi())) {
+        throw new Error('OpenAI model discovery did not apply to the current runtime');
+      }
+      return;
+    case 'xai':
+      await deps.refreshXaiCatalog();
+  }
+}

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -64,6 +64,8 @@ function makeDeps(over: Partial<ProviderHandlerDeps> = {}): ProviderHandlerDeps 
     listPresets: () => [],
     testConnection: vi.fn(async () => ({ ok: true, latencyMs: 1 })),
     fetchModels: vi.fn(async () => ({ ok: true, models: [{ id: 'm1', name: 'M1' }] })),
+    refreshBuiltinModels: vi.fn(async () => {}),
+    assertTrustedSender: vi.fn(() => {}),
     oauthLogin: vi.fn(async () => ({ ok: true })),
     oauthLogout: vi.fn(async () => {}),
     oauthCancel: vi.fn(() => {}),
@@ -107,6 +109,70 @@ describe('provider:list IPC handler', () => {
       }),
     );
     await expect(harness.invoke(MAKER_INVOKE.PROVIDER_LIST)).rejects.toThrow('boom');
+  });
+});
+
+describe('provider:models-refresh handler', () => {
+  it('guards the sender, validates the built-in id, and forwards the refresh', async () => {
+    const harness = new IpcHarness();
+    const assertTrustedSender = vi.fn();
+    const refreshBuiltinModels = vi.fn(async () => {});
+    registerProviderHandlers(
+      harness,
+      makeDeps({ assertTrustedSender, refreshBuiltinModels }),
+    );
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_REFRESH, 'anthropic'),
+    ).resolves.toEqual({ ok: true, providerId: 'anthropic' });
+    expect(assertTrustedSender).toHaveBeenCalledOnce();
+    expect(refreshBuiltinModels).toHaveBeenCalledWith('anthropic');
+  });
+
+  it('rejects unsupported ids before refreshing', async () => {
+    const harness = new IpcHarness();
+    const deps = makeDeps();
+    registerProviderHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_REFRESH, 'custom-provider'),
+    ).rejects.toThrow(/INVALID_PARAMS/);
+    expect(deps.refreshBuiltinModels).not.toHaveBeenCalled();
+  });
+
+  it('does not run the refresh when the sender guard rejects', async () => {
+    const harness = new IpcHarness();
+    const refreshBuiltinModels = vi.fn(async () => {});
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        assertTrustedSender: () => {
+          throw new Error('[PERMISSION_DENIED] untrusted sender');
+        },
+        refreshBuiltinModels,
+      }),
+    );
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_REFRESH, 'openai'),
+    ).rejects.toThrow(/PERMISSION_DENIED/);
+    expect(refreshBuiltinModels).not.toHaveBeenCalled();
+  });
+
+  it('maps source refresh failures to a generic IPC error', async () => {
+    const harness = new IpcHarness();
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        refreshBuiltinModels: async () => {
+          throw new Error('/secret/path should stay in main logs');
+        },
+      }),
+    );
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_REFRESH, 'xai'),
+    ).rejects.toThrow("[INTERNAL] model list refresh failed for 'xai'");
   });
 });
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 
 import type { CustomProviderConfig, ProviderView } from '@cindy/model-providers';
 
+import { BUILTIN_REFRESHABLE_PROVIDER_IDS } from '../../../shared/providerModelRefresh.js';
 import type { DbClient } from '../../localDb/client/DbClient.js';
 import { clearCurrentDbClient, setCurrentDbClient } from '../../localDb/client/current.js';
 import * as schema from '../../localDb/schema.js';
@@ -137,7 +138,9 @@ describe('provider:models-refresh handler', () => {
 
     await expect(
       harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_REFRESH, 'custom-provider'),
-    ).rejects.toThrow(/INVALID_PARAMS/);
+    ).rejects.toThrow(
+      `[INVALID_PARAMS] providerId must be one of: ${BUILTIN_REFRESHABLE_PROVIDER_IDS.join(', ')}`,
+    );
     expect(deps.refreshBuiltinModels).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -8,6 +8,7 @@ import type { DbClient } from '../../localDb/client/DbClient.js';
 import { clearCurrentDbClient, setCurrentDbClient } from '../../localDb/client/current.js';
 import * as schema from '../../localDb/schema.js';
 import { listCustomProviders } from '../../maker-host/custom-provider-store.js';
+import { throwIpcError } from '../../utils/ipcValidate.js';
 import { MAKER_INVOKE } from '../channels.js';
 import { registerProviderHandlers, type ProviderHandlerDeps } from '../providerHandlers.js';
 import { IpcHarness } from './helpers/ipcHarness.js';
@@ -173,6 +174,25 @@ describe('provider:models-refresh handler', () => {
     await expect(
       harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_REFRESH, 'xai'),
     ).rejects.toThrow("[INTERNAL] model list refresh failed for 'xai'");
+  });
+
+  it('preserves structured IPC errors from provider-specific refreshers', async () => {
+    const harness = new IpcHarness();
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        refreshBuiltinModels: async () => {
+          throwIpcError('MODEL_ACCESS_FAILED', 'Cindy AI model list refresh failed.');
+        },
+      }),
+    );
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_REFRESH, 'xd'),
+    ).rejects.toMatchObject({
+      code: 'MODEL_ACCESS_FAILED',
+      message: '[MODEL_ACCESS_FAILED] Cindy AI model list refresh failed.',
+    });
   });
 });
 

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -380,6 +380,12 @@ export const MAKER_INVOKE = {
    */
   PROVIDER_LIST: 'maker:provider:list',
   /**
+   * 内置四家模型清单手动刷新。入参仅允许 xd / anthropic / openai / xai；
+   * Main 按各家既有真源分派，不接收 URL、凭证或任意执行参数。
+   * 属被控端全局账号/目录操作，不进 device-link allowlist。
+   */
+  PROVIDER_MODELS_REFRESH: 'maker:provider:models-refresh',
+  /**
    * 自定义模型供应商 CRUD（配置入 localDb，密钥另走通用 safe-storage IPC）。
    * create/update 入参 = CustomProviderConfig；delete 入参 = providerId。
    * 成功后 main 重算 active-catalog 并广播 PROVIDER_CHANGED（见 MAKER_PUSH）。

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -25,6 +25,7 @@ import {
 import type { LocalCliDetection } from '../../shared/localCliDetect.js';
 import { isIpcError } from '../../shared/ipc-errors.js';
 import {
+  BUILTIN_REFRESHABLE_PROVIDER_IDS,
   isBuiltinRefreshableProviderId,
   type BuiltinRefreshableProviderId,
   type ProviderModelRefreshResult,
@@ -192,7 +193,10 @@ export function registerProviderHandlers(
     async (event, providerId: unknown): Promise<ProviderModelRefreshResult> => {
       deps.assertTrustedSender(event);
       if (!isBuiltinRefreshableProviderId(providerId)) {
-        throwIpcError('INVALID_PARAMS', 'providerId must be xd|anthropic|openai|xai');
+        throwIpcError(
+          'INVALID_PARAMS',
+          `providerId must be one of: ${BUILTIN_REFRESHABLE_PROVIDER_IDS.join(', ')}`,
+        );
       }
       try {
         await deps.refreshBuiltinModels(providerId);

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -23,6 +23,7 @@ import {
 } from '@cindy/model-providers';
 
 import type { LocalCliDetection } from '../../shared/localCliDetect.js';
+import { isIpcError } from '../../shared/ipc-errors.js';
 import {
   isBuiltinRefreshableProviderId,
   type BuiltinRefreshableProviderId,
@@ -196,6 +197,7 @@ export function registerProviderHandlers(
       try {
         await deps.refreshBuiltinModels(providerId);
       } catch (err) {
+        if (isIpcError(err)) throw err;
         log.warn('built-in provider model refresh failed', {
           providerId,
           error: err instanceof Error ? err.message : String(err),

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -23,8 +23,14 @@ import {
 } from '@cindy/model-providers';
 
 import type { LocalCliDetection } from '../../shared/localCliDetect.js';
+import {
+  isBuiltinRefreshableProviderId,
+  type BuiltinRefreshableProviderId,
+  type ProviderModelRefreshResult,
+} from '../../shared/providerModelRefresh.js';
 
 import { throwIpcError } from '../utils/ipcValidate.js';
+import { createLogger } from '../logger.js';
 import {
   createCustomProvider,
   customProviderExists,
@@ -41,6 +47,7 @@ import { MAKER_INVOKE } from './channels.js';
 import type { IpcHandlerRegistry } from './ipcHandlerRegistry.js';
 
 const VALID_AGENTS: readonly string[] = ['claude-code', 'codex'];
+const log = createLogger('maker-ipc:providerHandlers');
 
 export interface ProviderHandlerDeps {
   /** 当前供应商视图（含实时连接状态）；见 createDesktopProviderService。 */
@@ -61,6 +68,10 @@ export interface ProviderHandlerDeps {
   testConnection(input: ProviderTestInput): Promise<ProviderTestResult>;
   /** 获取模型列表（生产 = fetchProviderModels；单测注入 stub 不联网）。 */
   fetchModels(spec: ProviderModelsFetchSpec): Promise<ProviderModelsFetchResult>;
+  /** 内置四家的模型真源刷新；生产按 providerId 分派到既有 discovery 机制。 */
+  refreshBuiltinModels(providerId: BuiltinRefreshableProviderId): Promise<void>;
+  /** 新增的特权刷新入口只接受 Cindy 自有顶层 Renderer。 */
+  assertTrustedSender(event: unknown): void;
   /**
    * 通用 OAuth 登录 / 登出 / 取消（生产接 generic-oauth Runner + 目录描述符解析；
    * login 成功后由生产 deps 负责模型发现与 PROVIDER_CHANGED 广播）。
@@ -172,6 +183,26 @@ export function registerProviderHandlers(
     }> => {
       const providers = await deps.listProviders();
       return { providers, modelVisibilityOverrides: deps.getModelVisibilityOverrides() };
+    },
+  );
+
+  registry.handle(
+    MAKER_INVOKE.PROVIDER_MODELS_REFRESH,
+    async (event, providerId: unknown): Promise<ProviderModelRefreshResult> => {
+      deps.assertTrustedSender(event);
+      if (!isBuiltinRefreshableProviderId(providerId)) {
+        throwIpcError('INVALID_PARAMS', 'providerId must be xd|anthropic|openai|xai');
+      }
+      try {
+        await deps.refreshBuiltinModels(providerId);
+      } catch (err) {
+        log.warn('built-in provider model refresh failed', {
+          providerId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throwIpcError('INTERNAL', `model list refresh failed for '${providerId}'`);
+      }
+      return { ok: true, providerId };
     },
   );
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3430,7 +3430,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       refreshBuiltinProviderModels(providerId, {
         refreshXd: options.refreshXdGatewayModels,
         refreshAnthropic: refreshAnthropicModelsFromHttp,
-        refreshOpenAi: () => maker.refreshAgentLocalModels('codex'),
+        refreshOpenAi: () => maker.refreshAgentLocalModels(
+          'codex',
+          { credentialMode: 'oauth-bearer' },
+        ),
         refreshXaiCatalog: async () => {
           await refreshActiveCatalogFromSource();
         },

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -32,7 +32,7 @@ import { redactSensitiveText } from '@cindy/maker-shared/error-redaction';
 import { permissionModeOrAsk } from '@cindy/maker-shared/permission-mode';
 import { DL_SESSION_REFERENCE_CAPABILITY_CHANNEL } from '@cindy/device-link';
 import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
-import { BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, ipcMain, type IpcMainInvokeEvent } from 'electron';
 import type { AgentMeta } from '../../renderer/lib/ccAgent.types';
 import {
   deriveAutoTitleSeed,
@@ -384,6 +384,7 @@ import {
 } from '../mcp-integrations/custom-mcp-registry.js';
 import {
   getDesktopProviderService,
+  refreshActiveCatalogFromSource,
   refreshCustomProvidersIntoCatalog,
 } from '../maker-host/createDesktopProviderService.js';
 import { connectedProvidersForAgent, effectiveSourceIdForModel } from '@cindy/model-providers';
@@ -391,6 +392,8 @@ import { hydrateSessionProvider, getSessionProvider } from '../maker-host/sessio
 import { getActiveCatalog, setDiscoveredProviderModels } from '../maker-host/active-catalog.js';
 import { testProviderConnection } from '../maker-host/provider-diagnostics.js';
 import { fetchProviderModels } from '../maker-host/provider-model-fetch.js';
+import { refreshBuiltinProviderModels } from '../maker-host/provider-model-refresh.js';
+import { refreshAnthropicModelsFromHttp } from '../maker-host/model-discovery/anthropic.js';
 import { setProviderUpstreamErrorBroadcaster } from '../maker-host/provider-upstream-error-observer.js';
 import {
   createClaudeAutoPermissionFallbackCoordinator,
@@ -3127,9 +3130,11 @@ export const wireSessionToIpcExternal = wireSessionToIpc;
 
 export interface RegisterMakerIpcOptions {
   onAnySessionTurnKeepaliveChange?: (isRunning: boolean) => void;
+  /** 由 bootstrap 注入，避免 maker-ipc → model-access → maker-host 的循环依赖。 */
+  refreshXdGatewayModels(): Promise<void>;
 }
 
-export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions = {}): void {
+export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions): void {
   log.info('registering maker:* IPC handlers');
   getAgentIslandService()?.setPermissionResolver(resolvePendingPermissionFromAgentIsland);
   sessionTurnActivityTracker.setTurnKeepaliveChangeListener(options.onAnySessionTurnKeepaliveChange ?? null);
@@ -3421,6 +3426,17 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     listPresets: () => getActiveCatalog().presets ?? [],
     testConnection: (input) => testProviderConnection(input),
     fetchModels: (spec) => fetchProviderModels(spec),
+    refreshBuiltinModels: (providerId) =>
+      refreshBuiltinProviderModels(providerId, {
+        refreshXd: options.refreshXdGatewayModels,
+        refreshAnthropic: refreshAnthropicModelsFromHttp,
+        refreshOpenAi: () => maker.refreshAgentLocalModels('codex'),
+        refreshXaiCatalog: async () => {
+          await refreshActiveCatalogFromSource();
+        },
+      }),
+    assertTrustedSender: (event) =>
+      assertTrustedAppRendererEvent(event as IpcMainInvokeEvent),
     scanLocalCli: () => scanLocalCliAuth(createLocalCliScanDeps()),
     // 通用 OAuth（目录 auth.oauth 描述符驱动）：login 成功后 best-effort 拉动态模型发现
     // (additions-only merge 进 active-catalog) 并广播 PROVIDER_CHANGED 让 UI 刷新连接态。

--- a/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
@@ -1,12 +1,26 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  buildModelsSyncRequest,
   ensureCredentialsReadyForModelsRefresh,
   waitForModelsSyncRefresh,
+  XD_MODELS_SYNC_TIMEOUT_MS,
   type ModelsSyncFlightSnapshot,
 } from '../modelsSyncRefresh.js';
 
 describe('waitForModelsSyncRefresh', () => {
+  it('gives the shared XD model-list request a finite deadline', () => {
+    expect(buildModelsSyncRequest('https://model-access.example.com')).toEqual({
+      path: '/api/model-access/models',
+      options: {
+        baseUrl: 'https://model-access.example.com',
+        timeoutMs: 20_000,
+      },
+    });
+    expect(Number.isFinite(XD_MODELS_SYNC_TIMEOUT_MS)).toBe(true);
+    expect(XD_MODELS_SYNC_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
   it('reuses ready credentials and preserves the prior snapshot when the model request fails', async () => {
     const existingModels = ['last-known-model'];
     const retry = vi.fn(async () => {

--- a/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildModelsSyncRequest,
   ensureCredentialsReadyForModelsRefresh,
+  withModelsSyncOverallDeadline,
   waitForModelsSyncRefresh,
   XD_MODELS_SYNC_TIMEOUT_MS,
   type ModelsSyncFlightSnapshot,
@@ -19,6 +20,30 @@ describe('waitForModelsSyncRefresh', () => {
     });
     expect(Number.isFinite(XD_MODELS_SYNC_TIMEOUT_MS)).toBe(true);
     expect(XD_MODELS_SYNC_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  it('bounds the complete fetch lifecycle without cancelling the underlying auth refresh', async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveOperation!: (value: string) => void;
+      const operation = new Promise<string>((resolve) => {
+        resolveOperation = resolve;
+      });
+      const bounded = withModelsSyncOverallDeadline(operation, 25);
+      const rejection = expect(bounded).rejects.toThrow(
+        'Cindy AI model list refresh timed out after 25ms',
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      await rejection;
+
+      // Token rotation is deliberately non-abortable; it may settle safely after the
+      // model single-flight has already been released for a later retry.
+      resolveOperation('late-safe-result');
+      await expect(operation).resolves.toBe('late-safe-result');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('reuses ready credentials and preserves the prior snapshot when the model request fails', async () => {

--- a/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
@@ -1,11 +1,61 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  ensureCredentialsReadyForModelsRefresh,
   waitForModelsSyncRefresh,
   type ModelsSyncFlightSnapshot,
 } from '../modelsSyncRefresh.js';
 
 describe('waitForModelsSyncRefresh', () => {
+  it('reuses ready credentials and preserves the prior snapshot when the model request fails', async () => {
+    const existingModels = ['last-known-model'];
+    const retry = vi.fn(async () => {
+      existingModels.length = 0;
+      return {
+        state: 'failed' as const,
+        source: null,
+        endpoint: null,
+      };
+    });
+    const status = await ensureCredentialsReadyForModelsRefresh({
+      getStatus: () => ({
+        state: 'ok',
+        source: 'server',
+        endpoint: 'https://gateway.example.com',
+      }),
+      retry,
+    });
+
+    expect(status.state).toBe('ok');
+    expect(retry).not.toHaveBeenCalled();
+    await expect(
+      waitForModelsSyncRefresh({
+        expectedGeneration: 3,
+        schedule: vi.fn(),
+        snapshot: () => ({ flight: Promise.resolve(), generation: 3, attempt: 9 }),
+        currentGeneration: () => 3,
+        lastSuccessfulAttempt: () => 8,
+      }),
+    ).resolves.toBe('failed');
+    expect(existingModels).toEqual(['last-known-model']);
+  });
+
+  it('retries credential acquisition when credentials are not ready', async () => {
+    const retry = vi.fn(async () => ({
+      state: 'ok' as const,
+      source: 'server' as const,
+      endpoint: 'https://gateway.example.com',
+    }));
+
+    await expect(
+      ensureCredentialsReadyForModelsRefresh({
+        getStatus: () => ({ state: 'failed', source: null, endpoint: null }),
+        retry,
+      }),
+    ).resolves.toMatchObject({ state: 'ok' });
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
   it('waits through an old-account flight and accepts the current successful attempt', async () => {
     const oldFlight = Promise.resolve();
     const currentFlight = Promise.resolve();

--- a/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  waitForModelsSyncRefresh,
+  type ModelsSyncFlightSnapshot,
+} from '../modelsSyncRefresh.js';
+
+describe('waitForModelsSyncRefresh', () => {
+  it('waits through an old-account flight and accepts the current successful attempt', async () => {
+    const oldFlight = Promise.resolve();
+    const currentFlight = Promise.resolve();
+    const snapshots: ModelsSyncFlightSnapshot[] = [
+      { flight: oldFlight, generation: 1, attempt: 4 },
+      { flight: currentFlight, generation: 2, attempt: 5 },
+    ];
+    let index = 0;
+    let scheduleCalls = 0;
+
+    await expect(
+      waitForModelsSyncRefresh({
+        expectedGeneration: 2,
+        schedule: () => {
+          if (scheduleCalls > 0) index = 1;
+          scheduleCalls += 1;
+        },
+        snapshot: () => snapshots[index],
+        currentGeneration: () => 2,
+        lastSuccessfulAttempt: () => 5,
+      }),
+    ).resolves.toBe('succeeded');
+  });
+
+  it('stops instead of following a new account when auth changes in flight', async () => {
+    let resolveFlight!: () => void;
+    const flight = new Promise<void>((resolve) => { resolveFlight = resolve; });
+    let generation = 7;
+    const outcome = waitForModelsSyncRefresh({
+      expectedGeneration: 7,
+      schedule: vi.fn(),
+      snapshot: () => ({ flight, generation: 7, attempt: 3 }),
+      currentGeneration: () => generation,
+      lastSuccessfulAttempt: () => 3,
+    });
+
+    generation = 8;
+    resolveFlight();
+    await expect(outcome).resolves.toBe('account-changed');
+  });
+
+  it('does not mistake an older successful attempt for the current failed request', async () => {
+    await expect(
+      waitForModelsSyncRefresh({
+        expectedGeneration: 3,
+        schedule: vi.fn(),
+        snapshot: () => ({ flight: Promise.resolve(), generation: 3, attempt: 9 }),
+        currentGeneration: () => 3,
+        lastSuccessfulAttempt: () => 8,
+      }),
+    ).resolves.toBe('failed');
+  });
+});

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -34,6 +34,7 @@ import {
 import {
   buildModelsSyncRequest,
   ensureCredentialsReadyForModelsRefresh,
+  withModelsSyncOverallDeadline,
   waitForModelsSyncRefresh,
 } from './modelsSyncRefresh.js';
 import { getGhostSetupChangeBus } from '../cindy-brain/ghostSetupChangeBus.js';
@@ -166,9 +167,11 @@ async function runModelsSync(myGen: number, myAttempt: number): Promise<void> {
   let payload: { models: ModelAccessGatewayModel[] };
   try {
     const request = buildModelsSyncRequest(getClientEndpoint('modelAccessApiBaseUrl'));
-    payload = await serverApiFetch<{ models: ModelAccessGatewayModel[] }>(
-      request.path,
-      request.options,
+    payload = await withModelsSyncOverallDeadline(
+      serverApiFetch<{ models: ModelAccessGatewayModel[] }>(
+        request.path,
+        request.options,
+      ),
     );
   } catch (err) {
     log.warn('xd gateway models fetch failed (keeping last valid list)', {

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -31,6 +31,7 @@ import {
   type CredentialsPayload,
   type CredentialsSync,
 } from './credentialsSync.js';
+import { waitForModelsSyncRefresh } from './modelsSyncRefresh.js';
 import { getGhostSetupChangeBus } from '../cindy-brain/ghostSetupChangeBus.js';
 export { isModelAccessReady } from './readiness.js';
 
@@ -127,6 +128,9 @@ function broadcastStatus(status: ModelAccessStatus): void {
 // setXdGatewayModels)。拉取失败保留最后一次完整成功快照；成功空列表同时清空模型和价格。
 
 let modelsSyncInflight: Promise<void> | null = null;
+/** 模型请求的单调尝试号与最近成功号，供手动刷新区分“旧成功 + 本次失败”。 */
+let modelsSyncAttempt = 0;
+let lastModelsSyncSucceededAttempt = 0;
 /** 在途目录请求所属的认证世代。 */
 let modelsSyncGen = -1;
 /** 旧世代请求在途时新账号的补发标记。 */
@@ -155,7 +159,7 @@ function applyGatewayModels(models: ModelAccessGatewayModel[]): void {
   setXdGatewayModels(effective);
 }
 
-async function runModelsSync(myGen: number): Promise<void> {
+async function runModelsSync(myGen: number, myAttempt: number): Promise<void> {
   let payload: { models: ModelAccessGatewayModel[] };
   try {
     payload = await serverApiFetch<{ models: ModelAccessGatewayModel[] }>(MODELS_PATH, {
@@ -172,10 +176,12 @@ async function runModelsSync(myGen: number): Promise<void> {
   if (models.length === 0) {
     log.warn('xd gateway models fetch returned empty list; clearing current list');
     applyGatewayModels([]);
+    lastModelsSyncSucceededAttempt = myAttempt;
     return;
   }
   log.info(`xd gateway models synced: ${models.length}`);
   applyGatewayModels(models);
+  lastModelsSyncSucceededAttempt = myAttempt;
 }
 
 /** 触发一次模型目录同步(同世代 single-flight;旧世代在途时为新账号排队补发)。 */
@@ -194,7 +200,8 @@ function scheduleModelsSync(): void {
     return;
   }
   modelsSyncGen = gen;
-  modelsSyncInflight = runModelsSync(gen)
+  const attempt = ++modelsSyncAttempt;
+  modelsSyncInflight = runModelsSync(gen, attempt)
     .catch((err) => {
       log.warn('xd gateway models sync threw', {
         error: err instanceof Error ? err.message : String(err),
@@ -238,6 +245,44 @@ function getSync(): CredentialsSync {
 /** 当前同步状态(renderer 首帧经 IPC 拉;main 内部也可直接读)。 */
 export function getModelAccessStatus(): ModelAccessStatus {
   return getSync().getStatus();
+}
+
+/**
+ * 设置页手动刷新：复用凭据 retry 状态机，并等待它触发的同源 `/models` single-flight
+ * 真正结束。凭据或模型请求任一失败都 reject，Renderer 才不会误报“已刷新”。
+ */
+export async function refreshXdGatewayModels(): Promise<void> {
+  if (!getAppCapabilities().canUseCindyGateway) {
+    throwIpcError('PERMISSION_DENIED', 'Cindy AI requires a Cindy account.');
+  }
+  const status = await getSync().retry();
+  if (status.state !== 'ok') {
+    throwIpcError('MODEL_ACCESS_FAILED', 'Cindy AI credentials are not ready.');
+  }
+  const gen = authGeneration;
+  // onStatusChange(ok) 已经 schedule；重复调用会复用同世代在途请求。若此时仍有
+  // 旧账号 flight，先等它作废，再显式补发当前世代并等待当前尝试号的真实结果。
+  const outcome = await waitForModelsSyncRefresh({
+    expectedGeneration: gen,
+    schedule: scheduleModelsSync,
+    snapshot: () => ({
+      flight: modelsSyncInflight,
+      generation: modelsSyncGen,
+      attempt: modelsSyncAttempt,
+    }),
+    currentGeneration: () => authGeneration,
+    lastSuccessfulAttempt: () => lastModelsSyncSucceededAttempt,
+  });
+  switch (outcome) {
+    case 'succeeded':
+      return;
+    case 'not-started':
+      throwIpcError('MODEL_ACCESS_FAILED', 'Cindy AI model list refresh did not start.');
+    case 'account-changed':
+      throwIpcError('MODEL_ACCESS_FAILED', 'Cindy AI account changed during model list refresh.');
+    case 'failed':
+      throwIpcError('MODEL_ACCESS_FAILED', 'Cindy AI model list refresh failed.');
+  }
 }
 
 /** 存量手填 key 场景的写入通知(safe-storage IPC 层保留的兼容钩子):来源标记翻 manual。 */
@@ -317,6 +362,8 @@ export function resetModelAccessForTest(): void {
   modelsSyncInflight = null;
   modelsSyncGen = -1;
   modelsSyncRerunQueued = false;
+  modelsSyncAttempt = 0;
+  lastModelsSyncSucceededAttempt = 0;
   authGeneration = 0;
   lastAuthUserId = null;
   applyGatewayModels([]);

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -31,7 +31,10 @@ import {
   type CredentialsPayload,
   type CredentialsSync,
 } from './credentialsSync.js';
-import { waitForModelsSyncRefresh } from './modelsSyncRefresh.js';
+import {
+  ensureCredentialsReadyForModelsRefresh,
+  waitForModelsSyncRefresh,
+} from './modelsSyncRefresh.js';
 import { getGhostSetupChangeBus } from '../cindy-brain/ghostSetupChangeBus.js';
 export { isModelAccessReady } from './readiness.js';
 
@@ -248,14 +251,15 @@ export function getModelAccessStatus(): ModelAccessStatus {
 }
 
 /**
- * 设置页手动刷新：复用凭据 retry 状态机，并等待它触发的同源 `/models` single-flight
- * 真正结束。凭据或模型请求任一失败都 reject，Renderer 才不会误报“已刷新”。
+ * 设置页手动刷新：已有 ready 凭据时直接刷新 `/models`；只有凭据不可用时才复用
+ * retry 状态机。随后等待同源 `/models` single-flight 真正结束。凭据或模型请求
+ * 任一失败都 reject，Renderer 才不会误报“已刷新”。
  */
 export async function refreshXdGatewayModels(): Promise<void> {
   if (!getAppCapabilities().canUseCindyGateway) {
     throwIpcError('PERMISSION_DENIED', 'Cindy AI requires a Cindy account.');
   }
-  const status = await getSync().retry();
+  const status = await ensureCredentialsReadyForModelsRefresh(getSync());
   if (status.state !== 'ok') {
     throwIpcError('MODEL_ACCESS_FAILED', 'Cindy AI credentials are not ready.');
   }

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -32,6 +32,7 @@ import {
   type CredentialsSync,
 } from './credentialsSync.js';
 import {
+  buildModelsSyncRequest,
   ensureCredentialsReadyForModelsRefresh,
   waitForModelsSyncRefresh,
 } from './modelsSyncRefresh.js';
@@ -57,7 +58,6 @@ const log = createLogger('modelAccess');
  */
 
 const CREDENTIALS_PATH = '/api/model-access/credentials';
-const MODELS_PATH = '/api/model-access/models';
 
 function notifyXdProviderKeyChanged(): void {
   getGhostSetupChangeBus().emitAll({
@@ -165,9 +165,11 @@ function applyGatewayModels(models: ModelAccessGatewayModel[]): void {
 async function runModelsSync(myGen: number, myAttempt: number): Promise<void> {
   let payload: { models: ModelAccessGatewayModel[] };
   try {
-    payload = await serverApiFetch<{ models: ModelAccessGatewayModel[] }>(MODELS_PATH, {
-      baseUrl: getClientEndpoint('modelAccessApiBaseUrl'),
-    });
+    const request = buildModelsSyncRequest(getClientEndpoint('modelAccessApiBaseUrl'));
+    payload = await serverApiFetch<{ models: ModelAccessGatewayModel[] }>(
+      request.path,
+      request.options,
+    );
   } catch (err) {
     log.warn('xd gateway models fetch failed (keeping last valid list)', {
       error: err instanceof Error ? err.message : String(err),

--- a/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
+++ b/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
@@ -1,0 +1,37 @@
+/**
+ * Wait for the model-list request that belongs to one Cindy account generation.
+ *
+ * The credential retry may initially encounter an older account's in-flight request;
+ * callers provide the existing scheduler/snapshot so this helper can wait through
+ * that boundary without ever following a later account indefinitely.
+ */
+
+export interface ModelsSyncFlightSnapshot {
+  flight: Promise<void> | null;
+  generation: number;
+  attempt: number;
+}
+
+export type ModelsSyncRefreshOutcome =
+  | 'succeeded'
+  | 'failed'
+  | 'not-started'
+  | 'account-changed';
+
+export async function waitForModelsSyncRefresh(input: {
+  expectedGeneration: number;
+  schedule(): void;
+  snapshot(): ModelsSyncFlightSnapshot;
+  currentGeneration(): number;
+  lastSuccessfulAttempt(): number;
+}): Promise<ModelsSyncRefreshOutcome> {
+  for (;;) {
+    input.schedule();
+    const { flight, generation, attempt } = input.snapshot();
+    if (!flight) return 'not-started';
+    await flight;
+    if (input.currentGeneration() !== input.expectedGeneration) return 'account-changed';
+    if (generation !== input.expectedGeneration) continue;
+    return input.lastSuccessfulAttempt() === attempt ? 'succeeded' : 'failed';
+  }
+}

--- a/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
+++ b/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
@@ -4,6 +4,29 @@ import type { CredentialsSync } from './credentialsSync.js';
 /** Bound the shared single-flight so a black-hole connection cannot block later refreshes. */
 export const XD_MODELS_SYNC_TIMEOUT_MS = 20_000;
 
+/**
+ * Bound the whole serverApiFetch lifecycle, including its non-abortable token-rotation refresh.
+ * The input promise is intentionally not cancelled: aborting `/api/auth/refresh` after the server
+ * rotates a token can invalidate the session. Promise.race still observes its eventual settlement,
+ * while the model single-flight is released at the advertised deadline.
+ */
+export function withModelsSyncOverallDeadline<T>(
+  operation: Promise<T>,
+  timeoutMs = XD_MODELS_SYNC_TIMEOUT_MS,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(`Cindy AI model list refresh timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    timeout.unref?.();
+  });
+  return Promise.race([operation, deadline]).finally(() => {
+    if (timeout !== null) clearTimeout(timeout);
+  });
+}
+
 export function buildModelsSyncRequest(baseUrl: string): {
   path: '/api/model-access/models';
   options: { baseUrl: string; timeoutMs: number };

--- a/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
+++ b/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
@@ -1,6 +1,22 @@
 import type { ModelAccessStatus } from '../../shared/modelAccess.js';
 import type { CredentialsSync } from './credentialsSync.js';
 
+/** Bound the shared single-flight so a black-hole connection cannot block later refreshes. */
+export const XD_MODELS_SYNC_TIMEOUT_MS = 20_000;
+
+export function buildModelsSyncRequest(baseUrl: string): {
+  path: '/api/model-access/models';
+  options: { baseUrl: string; timeoutMs: number };
+} {
+  return {
+    path: '/api/model-access/models',
+    options: {
+      baseUrl,
+      timeoutMs: XD_MODELS_SYNC_TIMEOUT_MS,
+    },
+  };
+}
+
 /**
  * Wait for the model-list request that belongs to one Cindy account generation.
  *

--- a/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
+++ b/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
@@ -1,3 +1,6 @@
+import type { ModelAccessStatus } from '../../shared/modelAccess.js';
+import type { CredentialsSync } from './credentialsSync.js';
+
 /**
  * Wait for the model-list request that belongs to one Cindy account generation.
  *
@@ -17,6 +20,19 @@ export type ModelsSyncRefreshOutcome =
   | 'failed'
   | 'not-started'
   | 'account-changed';
+
+/**
+ * A model-only refresh must not reacquire credentials when the current credentials
+ * are already ready. Reacquisition can transition the shared status to `failed`
+ * during a transient endpoint outage, which would invalidate an otherwise usable
+ * model snapshot before the `/models` request even starts.
+ */
+export async function ensureCredentialsReadyForModelsRefresh(
+  sync: Pick<CredentialsSync, 'getStatus' | 'retry'>,
+): Promise<ModelAccessStatus> {
+  const status = sync.getStatus();
+  return status.state === 'ok' ? status : sync.retry();
+}
 
 export async function waitForModelsSyncRefresh(input: {
   expectedGeneration: number;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3605,6 +3605,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // 模型供应商目录（只读）—— 内置目录元数据 + 各供应商实时连接状态。
     listProviders: (): Promise<{ providers: import('@cindy/model-providers').ProviderView[] }> =>
       ipcRenderer.invoke('maker:provider:list'),
+    /** Refresh one built-in provider through its existing main-process discovery source. */
+    refreshBuiltinProviderModels: (
+      providerId: import('../shared/providerModelRefresh').BuiltinRefreshableProviderId,
+    ): Promise<import('../shared/providerModelRefresh').ProviderModelRefreshResult> =>
+      ipcRenderer.invoke('maker:provider:models-refresh', providerId),
 
     // 自定义供应商配置 CRUD（密钥另走通用 safeStorage IPC，不经这里）。
     createCustomProvider: (

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -2,19 +2,22 @@
 
 /**
  * ProvidersSection(双栏重构)关键不变量:
- *   1. Cindy AI(xd)固定置顶且默认选中;实时模型清单为空时详情给空态提示。
+ *   1. Cindy AI(xd)固定置顶且默认选中;实时模型清单为空时仍保留手动刷新入口。
  *   2. 未连接的内置渠道不再常驻占行(入口在向导目录 + 检测建议)。
  *   3. 本机 CLI 检测命中且渠道未连接时,左栏出现建议行,点击直达向导授权步。
  */
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ProviderView } from '@cindy/model-providers';
 
-const { wizardSpy } = vi.hoisted(() => ({ wizardSpy: vi.fn() }));
+const { refreshBuiltinModelsSpy, wizardSpy } = vi.hoisted(() => ({
+  refreshBuiltinModelsSpy: vi.fn(async () => ({ ok: true, providerId: 'xd' as const })),
+  wizardSpy: vi.fn(),
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'zh-CN' } }),
@@ -132,6 +135,7 @@ beforeEach(() => {
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     maker: {
       scanLocalCli: vi.fn(async () => scanResult),
+      refreshBuiltinProviderModels: refreshBuiltinModelsSpy,
     },
   };
 });
@@ -142,7 +146,7 @@ afterEach(() => {
 });
 
 describe('ProvidersSection — 双栏管理', () => {
-  it('Cindy AI 置顶默认选中;未连接内置渠道不占行;零模型详情给空态提示', async () => {
+  it('Cindy AI 置顶默认选中;未连接内置渠道不占行;零模型仍可手动刷新', async () => {
     // ProvidersSection 内部消费 useSearchParams(深链定位),测试需要 Router 上下文。
     render(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
 
@@ -152,9 +156,15 @@ describe('ProvidersSection — 双栏管理', () => {
     ).toBeGreaterThanOrEqual(2);
     // 未连接的 Anthropic 不出现在左栏(无检测建议时整页不出现)。
     expect(screen.queryByText('Anthropic')).toBeNull();
-    // xd 实时模型为空 → 详情空态提示(不渲染模型开关面板)。
+    // xd 实时模型为空 → 详情仍渲染模型工具行与刷新入口，避免用户无从恢复。
     expect(screen.getByText('settings.providers.detail.emptyModels')).not.toBeNull();
-    expect(screen.queryByText('settings.providers.models.available')).toBeNull();
+    expect(screen.getByText('settings.providers.models.available')).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'settings.providers.models.refreshAria' }),
+      );
+    });
+    expect(refreshBuiltinModelsSpy).toHaveBeenCalledWith('xd');
   });
 
   it('检测到本机 CLI 且渠道未连接 → 建议行出现,点击直达向导授权步', async () => {

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -184,6 +184,11 @@ describe('ProvidersSection — 双栏管理', () => {
       await Promise.resolve();
     });
     expect(refreshBuiltinModelsSpy).toHaveBeenCalledTimes(1);
+    const refreshingButton = screen.getByRole('button', {
+      name: 'settings.providers.models.refreshingAria',
+    });
+    expect(refreshingButton.getAttribute('title'))
+      .toBe('settings.providers.models.refreshingAria');
 
     await act(async () => {
       resolveRefresh({ ok: true, providerId: 'xd' });

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -161,7 +161,7 @@ describe('ProvidersSection — 双栏管理', () => {
     expect(screen.getByText('settings.providers.models.available')).not.toBeNull();
     await act(async () => {
       fireEvent.click(
-        screen.getByRole('button', { name: 'settings.providers.models.refreshAria' }),
+        screen.getByRole('button', { name: 'settings.providers.models.refreshBuiltinAria' }),
       );
     });
     expect(refreshBuiltinModelsSpy).toHaveBeenCalledWith('xd');
@@ -176,7 +176,7 @@ describe('ProvidersSection — 双栏管理', () => {
     render(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
 
     const button = await screen.findByRole('button', {
-      name: 'settings.providers.models.refreshAria',
+      name: 'settings.providers.models.refreshBuiltinAria',
     });
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -167,6 +167,30 @@ describe('ProvidersSection — 双栏管理', () => {
     expect(refreshBuiltinModelsSpy).toHaveBeenCalledWith('xd');
   });
 
+  it('同一事件循环内连续点击刷新只启动一个请求', async () => {
+    let resolveRefresh!: (value: { ok: true; providerId: 'xd' }) => void;
+    const pendingRefresh = new Promise<{ ok: true; providerId: 'xd' }>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    refreshBuiltinModelsSpy.mockReturnValueOnce(pendingRefresh);
+    render(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+
+    const button = await screen.findByRole('button', {
+      name: 'settings.providers.models.refreshAria',
+    });
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(refreshBuiltinModelsSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRefresh({ ok: true, providerId: 'xd' });
+      await pendingRefresh;
+    });
+  });
+
   it('检测到本机 CLI 且渠道未连接 → 建议行出现,点击直达向导授权步', async () => {
     scanResult = {
       detections: [

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1123,6 +1123,20 @@ export function ProvidersSection() {
   >(null);
   const [detections, setDetections] = useState<LocalCliDetection[]>([]);
   const [refreshingProviderId, setRefreshingProviderId] = useState<string | null>(null);
+  // React state 负责渲染反馈；ref 才是同一事件循环内立即生效的互斥锁，防止双击在
+  // disabled 状态提交到 DOM 前启动两条刷新。
+  const refreshingProviderIdRef = useRef<string | null>(null);
+  const beginProviderRefresh = useCallback((providerId: string): boolean => {
+    if (refreshingProviderIdRef.current !== null) return false;
+    refreshingProviderIdRef.current = providerId;
+    setRefreshingProviderId(providerId);
+    return true;
+  }, []);
+  const finishProviderRefresh = useCallback((providerId: string): void => {
+    if (refreshingProviderIdRef.current !== providerId) return;
+    refreshingProviderIdRef.current = null;
+    setRefreshingProviderId(null);
+  }, []);
 
   // 本机 CLI 扫描:挂载时一次(失败静默空数组;检测建议是增强,不是依赖)。
   useEffect(() => {
@@ -1258,8 +1272,7 @@ export function ProvidersSection() {
    */
   const handleRefreshModels = useCallback(
     async (p: ProviderView) => {
-      if (refreshingProviderId !== null) return;
-      setRefreshingProviderId(p.id);
+      if (!beginProviderRefresh(p.id)) return;
       try {
         const config = providerViewToCustomProviderConfig(p);
         let added = 0;
@@ -1295,17 +1308,16 @@ export function ProvidersSection() {
       } catch {
         toast.error(t('settings.providers.models.refreshFailed'));
       } finally {
-        setRefreshingProviderId(null);
+        finishProviderRefresh(p.id);
       }
     },
-    [refetch, refreshingProviderId, t],
+    [beginProviderRefresh, finishProviderRefresh, refetch, t],
   );
 
   /** 内置四家复用 main 已有的 provider-specific 真源刷新，不在 Renderer 复制网络逻辑。 */
   const handleRefreshBuiltinModels = useCallback(
     async (p: ProviderView) => {
-      if (!isBuiltinRefreshableProviderId(p.id) || refreshingProviderId !== null) return;
-      setRefreshingProviderId(p.id);
+      if (!isBuiltinRefreshableProviderId(p.id) || !beginProviderRefresh(p.id)) return;
       try {
         await window.electronAPI.maker.refreshBuiltinProviderModels(p.id);
         toast.success(t('settings.providers.models.refreshDone'));
@@ -1313,10 +1325,10 @@ export function ProvidersSection() {
       } catch {
         toast.error(t('settings.providers.models.refreshFailed'));
       } finally {
-        setRefreshingProviderId(null);
+        finishProviderRefresh(p.id);
       }
     },
-    [refetch, refreshingProviderId, t],
+    [beginProviderRefresh, finishProviderRefresh, refetch, t],
   );
 
   // 详情头部按供应商类型分派(鉴权逻辑与重构前一致)。

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1493,6 +1493,7 @@ export function ProvidersSection() {
                             onRefresh: () => void handleRefreshBuiltinModels(effectiveSelected),
                             refreshing: refreshingProviderId === effectiveSelected.id,
                             refreshDisabled: refreshingProviderId !== null,
+                            refreshIdleLabel: t('settings.providers.models.refreshBuiltinAria'),
                           }
                         : effectiveSelected.source === 'user' &&
                             effectiveSelected.auth.method !== 'oauth'

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -53,6 +53,7 @@ import { XDIncMark } from '@/components/icons/XDIncMark';
 import { hasProviderLogo, ProviderLogoMark } from '@/components/icons/ProviderLogoMark';
 
 import type { LocalCliDetection } from '../../../shared/localCliDetect';
+import { isBuiltinRefreshableProviderId } from '../../../shared/providerModelRefresh';
 import type { CustomProviderConfig, ProviderView } from '@cindy/model-providers';
 
 // ---------------------------------------------------------------------------
@@ -1121,7 +1122,7 @@ export function ProvidersSection() {
     null | { mode: 'create' } | { mode: 'edit'; config: CustomProviderConfig }
   >(null);
   const [detections, setDetections] = useState<LocalCliDetection[]>([]);
-  const [refreshingModels, setRefreshingModels] = useState(false);
+  const [refreshingProviderId, setRefreshingProviderId] = useState<string | null>(null);
 
   // 本机 CLI 扫描:挂载时一次(失败静默空数组;检测建议是增强,不是依赖)。
   useEffect(() => {
@@ -1257,7 +1258,8 @@ export function ProvidersSection() {
    */
   const handleRefreshModels = useCallback(
     async (p: ProviderView) => {
-      setRefreshingModels(true);
+      if (refreshingProviderId !== null) return;
+      setRefreshingProviderId(p.id);
       try {
         const config = providerViewToCustomProviderConfig(p);
         let added = 0;
@@ -1293,10 +1295,28 @@ export function ProvidersSection() {
       } catch {
         toast.error(t('settings.providers.models.refreshFailed'));
       } finally {
-        setRefreshingModels(false);
+        setRefreshingProviderId(null);
       }
     },
-    [refetch, t],
+    [refetch, refreshingProviderId, t],
+  );
+
+  /** 内置四家复用 main 已有的 provider-specific 真源刷新，不在 Renderer 复制网络逻辑。 */
+  const handleRefreshBuiltinModels = useCallback(
+    async (p: ProviderView) => {
+      if (!isBuiltinRefreshableProviderId(p.id) || refreshingProviderId !== null) return;
+      setRefreshingProviderId(p.id);
+      try {
+        await window.electronAPI.maker.refreshBuiltinProviderModels(p.id);
+        toast.success(t('settings.providers.models.refreshDone'));
+        refetch();
+      } catch {
+        toast.error(t('settings.providers.models.refreshFailed'));
+      } finally {
+        setRefreshingProviderId(null);
+      }
+    },
+    [refetch, refreshingProviderId, t],
   );
 
   // 详情头部按供应商类型分派(鉴权逻辑与重构前一致)。
@@ -1442,7 +1462,8 @@ export function ProvidersSection() {
             ) : effectiveSelected ? (
               <>
                 {renderDetailHeader(effectiveSelected)}
-                {providerHasModels(effectiveSelected) && (
+                {(providerHasModels(effectiveSelected) ||
+                  isBuiltinRefreshableProviderId(effectiveSelected.id)) && (
                   <>
                     <div
                       className="border-t"
@@ -1450,30 +1471,43 @@ export function ProvidersSection() {
                     />
                     <UnifiedModelList
                       provider={effectiveSelected}
-                      {...(effectiveSelected.source === 'user' &&
-                      effectiveSelected.auth.method !== 'oauth'
+                      emptyMessage={t(
+                        effectiveSelected.connected
+                          ? 'settings.providers.detail.emptyModelsConnected'
+                          : 'settings.providers.detail.emptyModels',
+                      )}
+                      {...(isBuiltinRefreshableProviderId(effectiveSelected.id)
                         ? {
-                            onRefresh: () => void handleRefreshModels(effectiveSelected),
-                            refreshing: refreshingModels,
+                            onRefresh: () => void handleRefreshBuiltinModels(effectiveSelected),
+                            refreshing: refreshingProviderId === effectiveSelected.id,
+                            refreshDisabled: refreshingProviderId !== null,
                           }
-                        : {})}
+                        : effectiveSelected.source === 'user' &&
+                            effectiveSelected.auth.method !== 'oauth'
+                          ? {
+                              onRefresh: () => void handleRefreshModels(effectiveSelected),
+                              refreshing: refreshingProviderId === effectiveSelected.id,
+                              refreshDisabled: refreshingProviderId !== null,
+                            }
+                          : {})}
                     />
                   </>
                 )}
-                {!providerHasModels(effectiveSelected) && (
-                  <div
-                    className="flex flex-1 items-center justify-center px-8 text-center text-13"
-                    style={{ color: 'var(--text-tertiary)' }}
-                  >
-                    {/* 已连接却无模型(如 Codex 刚登录、models_cache 未生成;或网关清单拉取失败)
+                {!providerHasModels(effectiveSelected) &&
+                  !isBuiltinRefreshableProviderId(effectiveSelected.id) && (
+                    <div
+                      className="flex flex-1 items-center justify-center px-8 text-center text-13"
+                      style={{ color: 'var(--text-tertiary)' }}
+                    >
+                      {/* 已连接却无模型(如 Codex 刚登录、models_cache 未生成;或网关清单拉取失败)
                         不能沿用未连接的「授权后…」文案——那对已连接供应商自相矛盾。 */}
-                    {t(
-                      effectiveSelected.connected
-                        ? 'settings.providers.detail.emptyModelsConnected'
-                        : 'settings.providers.detail.emptyModels',
-                    )}
-                  </div>
-                )}
+                      {t(
+                        effectiveSelected.connected
+                          ? 'settings.providers.detail.emptyModelsConnected'
+                          : 'settings.providers.detail.emptyModels',
+                      )}
+                    </div>
+                  )}
               </>
             ) : (
               <div

--- a/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
+++ b/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
@@ -165,6 +165,7 @@ export function UnifiedModelList({
   onRefresh,
   refreshing,
   refreshDisabled,
+  refreshIdleLabel,
   emptyMessage,
 }: {
   provider: ProviderView;
@@ -173,6 +174,8 @@ export function UnifiedModelList({
   refreshing?: boolean;
   /** 其它供应商正在刷新时禁用，避免并发刷新造成反馈归属不清。 */
   refreshDisabled?: boolean;
+  /** 内置供应商可传中性文案；自定义供应商默认保留 additions-only 的承诺。 */
+  refreshIdleLabel?: string;
   /** 模型真源当前为空时的说明；搜索无结果仍使用 noResults。 */
   emptyMessage?: string;
 }) {
@@ -240,11 +243,9 @@ export function UnifiedModelList({
   const agentCounts = useMemo(() => countModelsByAgent(provider), [provider, visibilityVersion]);
   const totalModelsAcrossAgents = agentCounts.reduce((sum, count) => sum + count.total, 0);
   const allOn = totalModelsAcrossAgents > 0 && agentCounts.every((count) => count.on === count.total);
-  const refreshLabel = t(
-    refreshing
-      ? 'settings.providers.models.refreshingAria'
-      : 'settings.providers.models.refreshAria',
-  );
+  const refreshLabel = refreshing
+    ? t('settings.providers.models.refreshingAria')
+    : (refreshIdleLabel ?? t('settings.providers.models.refreshAria'));
 
   /** 单开关:一次写该行全部可用 agent(分歧行拨动即归一)。写入用各 agent 的**真实模型 id**
    *  (桥接投影行两端 id 不同:chatgpt/gpt-5.5 vs gpt-5.5),不能用规范化后的 row.id。 */

--- a/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
+++ b/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
@@ -23,6 +23,7 @@ import { ChevronDown, RefreshCw, Search } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
+import { Spinner } from '@/components/ui/spinner';
 import {
   groupModelsForDisplay,
   CATEGORY_LABEL_KEY,
@@ -163,11 +164,17 @@ export function UnifiedModelList({
   provider,
   onRefresh,
   refreshing,
+  refreshDisabled,
+  emptyMessage,
 }: {
   provider: ProviderView;
-  /** 「刷新模型」(仅自定义供应商传入;增量发现,additions-only)。 */
+  /** 「刷新模型」；内置供应商走各自真源，自定义供应商走 additions-only 发现。 */
   onRefresh?: () => void;
   refreshing?: boolean;
+  /** 其它供应商正在刷新时禁用，避免并发刷新造成反馈归属不清。 */
+  refreshDisabled?: boolean;
+  /** 模型真源当前为空时的说明；搜索无结果仍使用 noResults。 */
+  emptyMessage?: string;
 }) {
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
@@ -292,26 +299,24 @@ export function UnifiedModelList({
           <button
             type="button"
             onClick={onRefresh}
-            disabled={refreshing}
-            aria-label={t('settings.providers.models.refreshAria')}
+            disabled={refreshing || refreshDisabled}
+            aria-busy={refreshing}
+            aria-label={t(
+              refreshing
+                ? 'settings.providers.models.refreshingAria'
+                : 'settings.providers.models.refreshAria',
+            )}
             title={t('settings.providers.models.refreshAria')}
             className={cn(
-              'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-[var(--surface-hover)]',
-              refreshing && 'cursor-not-allowed opacity-60',
+              'flex h-7 w-7 shrink-0 select-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]',
+              (refreshing || refreshDisabled) && 'cursor-not-allowed opacity-60',
             )}
             style={{ color: 'var(--text-secondary)' }}
           >
-            {/* 常驻动画只在 refreshing(有状态含义)时挂载,且挂在 wrapper 上(规则 7)。 */}
-            {refreshing ? (
-              <span className="inline-flex animate-spin motion-reduce:animate-none">
-                <RefreshCw size={14} />
-              </span>
-            ) : (
-              <RefreshCw size={14} />
-            )}
+            <Spinner icon={RefreshCw} size={14} spinning={refreshing} />
           </button>
         )}
-        {multiAgent && (
+        {unionRows.length > 0 && multiAgent && (
           <button
             type="button"
             onClick={() => setSplitMode((v) => !v)}
@@ -321,14 +326,16 @@ export function UnifiedModelList({
             {t(splitMode ? 'settings.providers.models.splitDone' : 'settings.providers.models.splitAdjust')}
           </button>
         )}
-        <button
-          type="button"
-          onClick={handleBulk}
-          className="shrink-0 text-12 font-medium transition-opacity hover:opacity-80"
-          style={{ color: 'var(--text-secondary)' }}
-        >
-          {t(allOn ? 'settings.providers.models.disableAll' : 'settings.providers.models.enableAll')}
-        </button>
+        {unionRows.length > 0 && (
+          <button
+            type="button"
+            onClick={handleBulk}
+            className="shrink-0 text-12 font-medium transition-opacity hover:opacity-80"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {t(allOn ? 'settings.providers.models.disableAll' : 'settings.providers.models.enableAll')}
+          </button>
+        )}
       </div>
 
       {/* 分别模式列头(与行内双列同宽对齐)。 */}
@@ -352,7 +359,9 @@ export function UnifiedModelList({
       <div className="flex flex-col gap-4 px-5 pb-4 pt-0.5">
         {groups.length === 0 ? (
           <div className="py-4 text-center text-13" style={{ color: 'var(--text-tertiary)' }}>
-            {t('settings.providers.models.noResults')}
+            {query.trim()
+              ? t('settings.providers.models.noResults')
+              : (emptyMessage ?? t('settings.providers.models.noResults'))}
           </div>
         ) : (
           groups.map((g) => {

--- a/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
+++ b/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
@@ -240,6 +240,11 @@ export function UnifiedModelList({
   const agentCounts = useMemo(() => countModelsByAgent(provider), [provider, visibilityVersion]);
   const totalModelsAcrossAgents = agentCounts.reduce((sum, count) => sum + count.total, 0);
   const allOn = totalModelsAcrossAgents > 0 && agentCounts.every((count) => count.on === count.total);
+  const refreshLabel = t(
+    refreshing
+      ? 'settings.providers.models.refreshingAria'
+      : 'settings.providers.models.refreshAria',
+  );
 
   /** 单开关:一次写该行全部可用 agent(分歧行拨动即归一)。写入用各 agent 的**真实模型 id**
    *  (桥接投影行两端 id 不同:chatgpt/gpt-5.5 vs gpt-5.5),不能用规范化后的 row.id。 */
@@ -301,12 +306,8 @@ export function UnifiedModelList({
             onClick={onRefresh}
             disabled={refreshing || refreshDisabled}
             aria-busy={refreshing}
-            aria-label={t(
-              refreshing
-                ? 'settings.providers.models.refreshingAria'
-                : 'settings.providers.models.refreshAria',
-            )}
-            title={t('settings.providers.models.refreshAria')}
+            aria-label={refreshLabel}
+            title={refreshLabel}
             className={cn(
               'flex h-7 w-7 shrink-0 select-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]',
               (refreshing || refreshDisabled) && 'cursor-not-allowed opacity-60',

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1307,10 +1307,12 @@
         "splitDone": "Done",
         "capabilityNote": "Not available in {{agent}}",
         "divergedChip": "Hidden in {{agent}}",
-        "refreshAria": "Refresh model list (additions only)",
+        "refreshAria": "Refresh Model List",
+        "refreshingAria": "Refreshing model list…",
+        "refreshDone": "Model list refreshed",
         "refreshAdded": "Found {{count}} new models",
         "refreshNoNew": "Model list is up to date — nothing new",
-        "refreshFailed": "Failed to refresh the model list. Please try again later"
+        "refreshFailed": "Model list couldn’t be refreshed — try again later"
       },
       "genericOAuth": {
         "subtitle": "Subscription sign-in (OAuth)",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1308,6 +1308,7 @@
         "capabilityNote": "Not available in {{agent}}",
         "divergedChip": "Hidden in {{agent}}",
         "refreshAria": "Refresh Model List",
+        "refreshBuiltinAria": "Refresh Model List",
         "refreshingAria": "Refreshing model list…",
         "refreshDone": "Model list refreshed",
         "refreshAdded": "Found {{count}} new models",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1306,10 +1306,12 @@
         "splitDone": "完了",
         "capabilityNote": "{{agent}} では利用不可",
         "divergedChip": "{{agent}} で非表示",
-        "refreshAria": "モデル一覧を更新(追加のみ)",
+        "refreshAria": "モデル一覧を更新",
+        "refreshingAria": "モデル一覧を更新中…",
+        "refreshDone": "モデル一覧を再読み込みしました",
         "refreshAdded": "新しいモデルを {{count}} 件検出しました",
         "refreshNoNew": "モデル一覧は最新です。新規はありません",
-        "refreshFailed": "モデル一覧の更新に失敗しました。しばらくしてからもう一度お試しください"
+        "refreshFailed": "モデル一覧を更新できませんでした。しばらくしてから再試行してください"
       },
       "genericOAuth": {
         "subtitle": "サブスクリプション認証（OAuth）",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1307,6 +1307,7 @@
         "capabilityNote": "{{agent}} では利用不可",
         "divergedChip": "{{agent}} で非表示",
         "refreshAria": "モデル一覧を更新",
+        "refreshBuiltinAria": "モデル一覧を更新",
         "refreshingAria": "モデル一覧を更新中…",
         "refreshDone": "モデル一覧を再読み込みしました",
         "refreshAdded": "新しいモデルを {{count}} 件検出しました",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1307,6 +1307,7 @@
         "capabilityNote": "{{agent}}에서는 사용 불가",
         "divergedChip": "{{agent}}에서 숨김",
         "refreshAria": "모델 목록 새로고침",
+        "refreshBuiltinAria": "모델 목록 새로고침",
         "refreshingAria": "모델 목록 새로고침 중…",
         "refreshDone": "모델 목록을 새로고침했습니다",
         "refreshAdded": "새 모델 {{count}}개를 발견했습니다",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1306,10 +1306,12 @@
         "splitDone": "완료",
         "capabilityNote": "{{agent}}에서는 사용 불가",
         "divergedChip": "{{agent}}에서 숨김",
-        "refreshAria": "모델 목록 새로고침(추가만)",
+        "refreshAria": "모델 목록 새로고침",
+        "refreshingAria": "모델 목록 새로고침 중…",
+        "refreshDone": "모델 목록을 새로고침했습니다",
         "refreshAdded": "새 모델 {{count}}개를 발견했습니다",
         "refreshNoNew": "모델 목록이 최신 상태입니다. 새 항목이 없습니다",
-        "refreshFailed": "모델 목록 새로고침에 실패했습니다. 잠시 후 다시 시도해 주세요"
+        "refreshFailed": "모델 목록을 새로고침하지 못했습니다. 잠시 후 다시 시도해 주세요"
       },
       "genericOAuth": {
         "subtitle": "구독 인증 로그인 (OAuth)",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1307,6 +1307,8 @@
         "capabilityNote": "不支持 {{agent}}",
         "divergedChip": "已在 {{agent}} 隐藏",
         "refreshAria": "刷新模型列表(仅新增，不改动现有)",
+        "refreshingAria": "正在刷新模型列表…",
+        "refreshDone": "模型列表已刷新",
         "refreshAdded": "已发现 {{count}} 个新模型",
         "refreshNoNew": "模型列表已是最新，无新增",
         "refreshFailed": "模型列表刷新失败，请稍后再试"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1307,6 +1307,7 @@
         "capabilityNote": "不支持 {{agent}}",
         "divergedChip": "已在 {{agent}} 隐藏",
         "refreshAria": "刷新模型列表(仅新增，不改动现有)",
+        "refreshBuiltinAria": "刷新模型列表",
         "refreshingAria": "正在刷新模型列表…",
         "refreshDone": "模型列表已刷新",
         "refreshAdded": "已发现 {{count}} 个新模型",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3466,6 +3466,10 @@ interface ElectronAPI {
 
     // 模型供应商目录（只读）—— 内置目录元数据 + 各供应商实时连接状态。
     listProviders: () => Promise<{ providers: import('@cindy/model-providers').ProviderView[] }>;
+    /** 复用各内置供应商既有真源刷新模型清单。 */
+    refreshBuiltinProviderModels: (
+      providerId: import('../shared/providerModelRefresh').BuiltinRefreshableProviderId,
+    ) => Promise<import('../shared/providerModelRefresh').ProviderModelRefreshResult>;
 
     // 自定义供应商配置 CRUD（密钥另走通用 safeStorage IPC，不经这里）。
     createCustomProvider: (

--- a/apps/desktop/src/shared/providerModelRefresh.ts
+++ b/apps/desktop/src/shared/providerModelRefresh.ts
@@ -1,0 +1,22 @@
+/**
+ * Built-in provider model-list refresh protocol shared by main, preload, and renderer.
+ *
+ * Custom providers keep their existing endpoint-driven additions-only refresh flow.
+ */
+export const BUILTIN_REFRESHABLE_PROVIDER_IDS = ['xd', 'anthropic', 'openai', 'xai'] as const;
+
+export type BuiltinRefreshableProviderId = (typeof BUILTIN_REFRESHABLE_PROVIDER_IDS)[number];
+
+export function isBuiltinRefreshableProviderId(
+  value: unknown,
+): value is BuiltinRefreshableProviderId {
+  return (
+    typeof value === 'string' &&
+    (BUILTIN_REFRESHABLE_PROVIDER_IDS as readonly string[]).includes(value)
+  );
+}
+
+export interface ProviderModelRefreshResult {
+  ok: true;
+  providerId: BuiltinRefreshableProviderId;
+}

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -122,7 +122,11 @@ export interface CodexLocalCredentialModeSwitchContext {
 }
 
 export interface RefreshLocalModelsOptions {
-  /** Bind control-plane model discovery to a specific local credential route. */
+  /**
+   * Bind model discovery to a specific local credential route.
+   * Codex serves explicit routes from an isolated control-plane host so live
+   * session hosts never need a credential-mode switch.
+   */
   credentialMode?: AgentCredentialMode;
 }
 

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -202,6 +202,8 @@ export interface AgentDeps {
     ctx: {
       remoteHostId?: string;
       credentialMode?: AgentCredentialMode;
+      /** Marks one-off app-server work (e.g. model/list) that must not alter session routing. */
+      hostPurpose?: 'control-plane';
     },
   ) => Promise<CodexExtraSpawnConfig>;
 

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -121,6 +121,11 @@ export interface CodexLocalCredentialModeSwitchContext {
   activeSubscriptions: number;
 }
 
+export interface RefreshLocalModelsOptions {
+  /** Bind control-plane model discovery to a specific local credential route. */
+  credentialMode?: AgentCredentialMode;
+}
+
 export interface ClaudeSubagentTaskRegistration {
   taskId: string;
   parentToolUseId: string;
@@ -1008,7 +1013,7 @@ export abstract class BaseAgent {
    * 默认无运行时发现能力，返回 false；Codex 覆盖后通过 app-server `model/list`
    * 拉完整分页快照。返回值表示快照是否仍属于当前 host 且已由宿主成功应用。
    */
-  async refreshLocalModels(): Promise<boolean> {
+  async refreshLocalModels(_options?: RefreshLocalModelsOptions): Promise<boolean> {
     return false;
   }
 

--- a/packages/maker-core/src/agents/codex/app-server/client.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.ts
@@ -40,6 +40,17 @@ import type { Transport } from './transport.js';
  */
 const DEFAULT_MAX_LINE_BYTES = 16 * 1024 * 1024;
 const MAX_STDERR_LOG_CHARS = 2_000;
+
+export class AppServerRequestTimeoutError extends Error {
+  constructor(
+    public readonly method: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`codex app-server ${method} timed out after ${timeoutMs}ms`);
+    this.name = 'AppServerRequestTimeoutError';
+  }
+}
+
 /**
  * Keep a small bounded correlation window for writes that rejected after the
  * transport may already have handed bytes to the OS / websocket buffer.
@@ -315,7 +326,7 @@ export class AppServerClient {
         pending.timeoutId = setTimeout(() => {
           if (this.pending.get(id) !== pending) return;
           this.pending.delete(id);
-          reject(new Error(`codex app-server ${method} timed out after ${timeoutMs}ms`));
+          reject(new AppServerRequestTimeoutError(method, timeoutMs));
         }, timeoutMs);
         pending.timeoutId.unref?.();
       }

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -485,10 +485,14 @@ export class AppServerHost {
    * 透传 JSON-RPC request 到底层 client (会先 ensureStarted)。
    * thread/start / turn/start / turn/interrupt / thread/resume / thread/fork 都走这里。
    */
-  async request<R = unknown>(method: string, params?: unknown): Promise<R> {
+  async request<R = unknown>(
+    method: string,
+    params?: unknown,
+    opts?: { timeoutMs?: number },
+  ): Promise<R> {
     await this.ensureStarted();
     if (!this.client) throw new Error('AppServerHost: client missing after ensureStarted (unreachable)');
-    return this.client.request<R>(method, params);
+    return this.client.request<R>(method, params, opts);
   }
 
   /** Release one thread's live runtime without archiving or deleting its history. */

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -20,6 +20,7 @@ const { MockCodexTransport, createdTransports } = vi.hoisted(() => {
     static threadSeq = 1;
     static failThreadStart = false;
     static dropThreadUnsubscribe = false;
+    static dropModelList = false;
     static beforeThreadStartResponse: ((transport: MockCodexTransport) => Promise<void> | void) | null = null;
     static onCreate: ((transport: MockCodexTransport) => void) | null = null;
 
@@ -134,6 +135,7 @@ const { MockCodexTransport, createdTransports } = vi.hoisted(() => {
         return;
       }
       if (req.method === 'model/list') {
+        if (MockCodexTransport.dropModelList) return;
         this.emitLine({ id: req.id, result: { data: [], nextCursor: null } });
         return;
       }
@@ -228,6 +230,7 @@ beforeEach(() => {
   MockCodexTransport.threadSeq = 1;
   MockCodexTransport.failThreadStart = false;
   MockCodexTransport.dropThreadUnsubscribe = false;
+  MockCodexTransport.dropModelList = false;
   MockCodexTransport.beforeThreadStartResponse = null;
   MockCodexTransport.onCreate = null;
 });
@@ -672,6 +675,7 @@ describe('CodexAgent.refreshLocalModels', () => {
     expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(2, [], {
       remoteHostId: undefined,
       credentialMode: 'oauth-bearer',
+      hostPurpose: 'control-plane',
     });
     expect(onCodexLocalModelsListed).toHaveBeenCalledOnce();
     expect(Array.from(
@@ -708,8 +712,16 @@ describe('CodexAgent.refreshLocalModels', () => {
 
     await expect(agent.refreshLocalModels()).resolves.toBe(true);
     expect(host.request.mock.calls.filter(([method]) => method === Method.ModelList)).toEqual([
-      [Method.ModelList, { cursor: null, limit: 100, includeHidden: false }],
-      [Method.ModelList, { cursor: 'page-2', limit: 100, includeHidden: false }],
+      [
+        Method.ModelList,
+        { cursor: null, limit: 100, includeHidden: false },
+        { timeoutMs: 20_000 },
+      ],
+      [
+        Method.ModelList,
+        { cursor: 'page-2', limit: 100, includeHidden: false },
+        { timeoutMs: 20_000 },
+      ],
     ]);
     expect(onCodexLocalModelsListed).toHaveBeenCalledOnce();
     expect(onCodexLocalModelsListed.mock.calls[0][0].map((model: { id: string }) => model.id))
@@ -744,6 +756,30 @@ describe('CodexAgent.refreshLocalModels', () => {
 
     await expect(agent.refreshLocalModels()).resolves.toBe(false);
     expect(onCodexLocalModelsListed).not.toHaveBeenCalled();
+  });
+
+  it('retires a wedged control-plane host after the model/list deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      MockCodexTransport.dropModelList = true;
+      const agent = new CodexAgent(createDeps());
+      const refresh = agent.refreshLocalModels({ credentialMode: 'oauth-bearer' });
+      const refreshExpectation = expect(refresh).rejects.toThrow(
+        'codex app-server model/list timed out after 20000ms',
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      await refreshExpectation;
+      expect(createdTransports).toHaveLength(1);
+      expect(createdTransports[0].closed).toBe(true);
+      expect(Array.from(
+        (agent as unknown as { hosts: Map<string, unknown> }).hosts.keys(),
+      )).not.toContain('local-control:oauth-bearer');
+      await agent.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -632,8 +632,9 @@ describe('CodexAgent.listCustomizations', () => {
 });
 
 describe('CodexAgent.refreshLocalModels', () => {
-  it('replaces a provider-oauth utility host with an OpenAI-bound host for explicit refreshes', async () => {
+  it('uses an isolated OpenAI control-plane host without closing provider-oauth sessions', async () => {
     const onCodexLocalModelsListed = vi.fn().mockResolvedValue(undefined);
+    const prepareCodexLocalCredentialModeSwitch = vi.fn(async () => {});
     const prepareCodexExtraSpawnConfig = vi.fn(async (_providers, ctx) => ({
       extraArgs: [],
       extraEnv: {},
@@ -641,6 +642,7 @@ describe('CodexAgent.refreshLocalModels', () => {
     }));
     const agent = new CodexAgent(createDeps({}, {
       onCodexLocalModelsListed,
+      prepareCodexLocalCredentialModeSwitch,
       prepareCodexExtraSpawnConfig,
     }));
     const xaiHandle = await agent.startSession({
@@ -649,14 +651,14 @@ describe('CodexAgent.refreshLocalModels', () => {
       model: 'xai/grok-4.3',
       workingDir: '/repo-xai',
     });
-    await xaiHandle.close();
 
     await expect(
       agent.refreshLocalModels({ credentialMode: 'oauth-bearer' }),
     ).resolves.toBe(true);
 
     expect(createdTransports).toHaveLength(2);
-    expect(createdTransports[0].closed).toBe(true);
+    expect(createdTransports[0].closed).toBe(false);
+    expect(prepareCodexLocalCredentialModeSwitch).not.toHaveBeenCalled();
     expect(createdTransports[0].lines.some((line) => (
       (JSON.parse(line) as { method?: string }).method === Method.ModelList
     ))).toBe(false);
@@ -672,6 +674,15 @@ describe('CodexAgent.refreshLocalModels', () => {
       credentialMode: 'oauth-bearer',
     });
     expect(onCodexLocalModelsListed).toHaveBeenCalledOnce();
+    expect(Array.from(
+      (agent as unknown as { hosts: Map<string, unknown> }).hosts.keys(),
+    )).toEqual(['local', 'local-control:oauth-bearer']);
+    await xaiHandle.close();
+    await agent.forceDisposeLocalHostForAuthChange('test account boundary');
+    expect(createdTransports.every((transport) => transport.closed)).toBe(true);
+    expect(
+      (agent as unknown as { hosts: Map<string, unknown> }).hosts.size,
+    ).toBe(0);
     await agent.dispose();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -632,6 +632,49 @@ describe('CodexAgent.listCustomizations', () => {
 });
 
 describe('CodexAgent.refreshLocalModels', () => {
+  it('replaces a provider-oauth utility host with an OpenAI-bound host for explicit refreshes', async () => {
+    const onCodexLocalModelsListed = vi.fn().mockResolvedValue(undefined);
+    const prepareCodexExtraSpawnConfig = vi.fn(async (_providers, ctx) => ({
+      extraArgs: [],
+      extraEnv: {},
+      codexProxyActive: ctx.credentialMode === 'provider-oauth',
+    }));
+    const agent = new CodexAgent(createDeps({}, {
+      onCodexLocalModelsListed,
+      prepareCodexExtraSpawnConfig,
+    }));
+    const xaiHandle = await agent.startSession({
+      sessionId: 'session-provider-oauth-before-openai-refresh',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai',
+    });
+    await xaiHandle.close();
+
+    await expect(
+      agent.refreshLocalModels({ credentialMode: 'oauth-bearer' }),
+    ).resolves.toBe(true);
+
+    expect(createdTransports).toHaveLength(2);
+    expect(createdTransports[0].closed).toBe(true);
+    expect(createdTransports[0].lines.some((line) => (
+      (JSON.parse(line) as { method?: string }).method === Method.ModelList
+    ))).toBe(false);
+    expect(createdTransports[1].lines.some((line) => (
+      (JSON.parse(line) as { method?: string }).method === Method.ModelList
+    ))).toBe(true);
+    expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(1, [], {
+      remoteHostId: undefined,
+      credentialMode: 'provider-oauth',
+    });
+    expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(2, [], {
+      remoteHostId: undefined,
+      credentialMode: 'oauth-bearer',
+    });
+    expect(onCodexLocalModelsListed).toHaveBeenCalledOnce();
+    await agent.dispose();
+  });
+
   it('reads every model/list page and publishes one complete snapshot', async () => {
     const onCodexLocalModelsListed = vi.fn().mockResolvedValue(undefined);
     const agent = new CodexAgent(createDeps({}, { onCodexLocalModelsListed }));

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -32,6 +32,7 @@ import {
   type AgentDeps,
   type StartSessionOptions,
   type OneShotOptions,
+  type RefreshLocalModelsOptions,
   type SendOptions,
 } from '../base-agent.js';
 import type { AgentCredentialMode } from '../../interfaces/auth-adapter.js';
@@ -1507,8 +1508,11 @@ export class CodexAgent extends BaseAgent {
    * 成功时未必已经触发模型注册表刷新。`model/list` 是官方 app-server 的权威读取面，
    * 同时也是 cache ready barrier；分页全部读完后才一次性交给宿主，避免 UI 看到半份目录。
    */
-  override async refreshLocalModels(): Promise<boolean> {
-    const { key, host } = await this.getUtilityHost();
+  override async refreshLocalModels(options?: RefreshLocalModelsOptions): Promise<boolean> {
+    const key = hostKey();
+    const host = options?.credentialMode
+      ? await this.getHost(undefined, options.credentialMode)
+      : (await this.getUtilityHost()).host;
     const init = await host.ensureStarted();
     if (init.codexHome) this.codexHome = init.codexHome;
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -276,6 +276,16 @@ export function hostKey(remoteHostId?: string | null): string {
   return remoteHostId ? `remote:${remoteHostId}` : 'local';
 }
 
+const LOCAL_CONTROL_PLANE_HOST_PREFIX = 'local-control:';
+
+function localControlPlaneHostKey(credentialMode: AgentCredentialMode): string {
+  return `${LOCAL_CONTROL_PLANE_HOST_PREFIX}${credentialMode}`;
+}
+
+function isLocalControlPlaneHostKey(key: string): boolean {
+  return key.startsWith(LOCAL_CONTROL_PLANE_HOST_PREFIX);
+}
+
 /**
  * maker permissionMode → app-server { approvalPolicy, approvalsReviewer, sandbox }。
  *
@@ -1334,9 +1344,9 @@ export class CodexAgent extends BaseAgent {
   private async getHost(
     remoteHostId?: string,
     credentialMode?: AgentCredentialMode,
-    opts: { ignoreBindingLeases?: number } = {},
+    opts: { ignoreBindingLeases?: number; keyOverride?: string } = {},
   ): Promise<AppServerHost> {
-    const key = hostKey(remoteHostId);
+    const key = opts.keyOverride ?? hostKey(remoteHostId);
     // spawnMode = 调用方原始诉求(undefined 保持 adapter fallback,spawn 行为不变)。
     // 复用判定分两级(review P2:归一化解析走 getState、含 reconcile/fs,不允许进
     // 无条件路径):
@@ -1509,9 +1519,14 @@ export class CodexAgent extends BaseAgent {
    * 同时也是 cache ready barrier；分页全部读完后才一次性交给宿主，避免 UI 看到半份目录。
    */
   override async refreshLocalModels(options?: RefreshLocalModelsOptions): Promise<boolean> {
-    const key = hostKey();
-    const host = options?.credentialMode
-      ? await this.getHost(undefined, options.credentialMode)
+    const credentialMode = options?.credentialMode;
+    // 显式 provider 刷新使用独立 control-plane app-server。不能为了发一次 model/list
+    // 切换共享 local host 的凭证形态：切换协调器会关闭空闲会话，忙碌会话则直接拒绝。
+    const key = credentialMode
+      ? localControlPlaneHostKey(credentialMode)
+      : hostKey();
+    const host = credentialMode
+      ? await this.getHost(undefined, credentialMode, { keyOverride: key })
       : (await this.getUtilityHost()).host;
     const init = await host.ensureStarted();
     if (init.codexHome) this.codexHome = init.codexHome;
@@ -1732,14 +1747,15 @@ export class CodexAgent extends BaseAgent {
       // 持续撞鉴权失败; auth.invalidate 会触发 logout + 通知 UI 重登。延后到 microtask
       // 防止在 JSON-RPC response 分发回调里同步收割自己。远端也走同一结构化协议路径。
       onAuthInvalidated: (reason) => {
+        const usesLocalAuth = !remoteHostId;
         this.deps.logger.warn('codex auth invalidated', {
           reason,
           key,
-          localAuthWillInvalidate: key === hostKey(),
+          localAuthWillInvalidate: usesLocalAuth,
         });
         Promise.resolve()
           .then(async () => {
-            if (key === hostKey()) {
+            if (usesLocalAuth) {
               try {
                 await this.deps.auth.invalidate?.(reason);
               } catch (e) {
@@ -4780,16 +4796,24 @@ export class CodexAgent extends BaseAgent {
   }
 
   /**
-   * 本地 Codex OAuth/logout 失效时强制收掉 local host。
+   * 本地 Codex OAuth/logout 失效时强制收掉共享 local host 与独立 control-plane hosts。
    *
-   * 这条路径说明当前 local host 持有的凭证已经不可用，不能因为仍有订阅就继续保留；
-   * 但仍然只处理 local key，不能扩散到 remote host。
+   * 这些 host 都持有本机凭证，账号边界变化后不能继续复用；remote hosts 使用远端
+   * 用户配置，不在本次清理范围内。
    */
   async forceDisposeLocalHostForAuthChange(reason = 'CodexAgent local auth changed'): Promise<void> {
-    await this.retireHostKey(hostKey(), reason, {
-      failIfActive: false,
-      logPrefix: 'codex local auth restart',
-    });
+    const keys = new Set<string>([hostKey()]);
+    for (const key of this.hosts.keys()) {
+      if (isLocalControlPlaneHostKey(key)) keys.add(key);
+    }
+    for (const key of this.hostPromises.keys()) {
+      if (isLocalControlPlaneHostKey(key)) keys.add(key);
+    }
+    await Promise.all(Array.from(keys, (key) =>
+      this.retireHostKey(key, reason, {
+        failIfActive: false,
+        logPrefix: 'codex local auth restart',
+      })));
   }
 
   private async disposeLocalHostForCredentialChangeUnlocked(key: string, reason: string): Promise<void> {
@@ -4909,13 +4933,16 @@ export class CodexAgent extends BaseAgent {
     this.memoryOverride = enabled;
     // 立即 push, 让所有 live thread 通过 server 端 reload_user_config 拿到新值
     try {
-      if (this.hosts.size === 0) {
+      const localSessionHosts = Array.from(this.hosts.entries()).filter(
+        ([key]) => !key.startsWith('remote:') && !isLocalControlPlaneHostKey(key),
+      );
+      if (localSessionHosts.length === 0) {
         log.info('setMemory ◀ no live app-server, will apply on next session');
         return { effective: 'next-session' };
       }
-      await Promise.all(Array.from(this.hosts.entries()).filter(([key]) => !key.startsWith('remote:')).map(async ([key, host]) => {
-        // Remote hosts do not receive Maker Memory, so their native setting is
-        // owned by the target rather than this local manager.
+      await Promise.all(localSessionHosts.map(async ([key, host]) => {
+        // Only thread-serving local hosts receive Maker Memory. Remote hosts own
+        // their native setting; model-list control-plane hosts have no live threads.
         await host.request(Method.ExperimentalFeatureEnablementSet, {
           enablement: { memories: enabled },
         });

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -90,6 +90,7 @@ import {
   type CodexRuntimeState,
 } from './translator.js';
 import { AppServerHost, type ThreadEventHandlers, type ThreadSubscription } from './app-server/host.js';
+import { AppServerRequestTimeoutError } from './app-server/client.js';
 import { createStdioTransport } from './app-server/stdioTransport.js';
 import { CodexInteractionBroker } from './interaction-broker.js';
 import { SYSTEM_PROMPT_APPEND as MAKER_CODEX_SYSTEM_PROMPT_APPEND } from './system-prompt-append.js';
@@ -277,6 +278,7 @@ export function hostKey(remoteHostId?: string | null): string {
 }
 
 const LOCAL_CONTROL_PLANE_HOST_PREFIX = 'local-control:';
+const CODEX_MODEL_LIST_RPC_TIMEOUT_MS = 20_000;
 
 function localControlPlaneHostKey(credentialMode: AgentCredentialMode): string {
   return `${LOCAL_CONTROL_PLANE_HOST_PREFIX}${credentialMode}`;
@@ -1344,7 +1346,11 @@ export class CodexAgent extends BaseAgent {
   private async getHost(
     remoteHostId?: string,
     credentialMode?: AgentCredentialMode,
-    opts: { ignoreBindingLeases?: number; keyOverride?: string } = {},
+    opts: {
+      ignoreBindingLeases?: number;
+      keyOverride?: string;
+      hostPurpose?: 'control-plane';
+    } = {},
   ): Promise<AppServerHost> {
     const key = opts.keyOverride ?? hostKey(remoteHostId);
     // spawnMode = 调用方原始诉求(undefined 保持 adapter fallback,spawn 行为不变)。
@@ -1471,12 +1477,19 @@ export class CodexAgent extends BaseAgent {
         credentialModeResolved: boolean;
         generation: number;
       } | null = null;
-      const promise = this.createHost(remoteHostId, key, spawnMode, generation, (resolvedMode) => {
-        if (inflightEntry) {
-          inflightEntry.credentialMode = resolvedMode;
-          inflightEntry.credentialModeResolved = true;
-        }
-      }).finally(() => {
+      const promise = this.createHost(
+        remoteHostId,
+        key,
+        spawnMode,
+        generation,
+        (resolvedMode) => {
+          if (inflightEntry) {
+            inflightEntry.credentialMode = resolvedMode;
+            inflightEntry.credentialModeResolved = true;
+          }
+        },
+        opts.hostPurpose,
+      ).finally(() => {
         // 成功: this.hosts 已赋值, 后续走快路径; 失败: 清掉 promise 让下次调用能重试
         const current = this.hostPromises.get(key);
         if (current?.promise === promise) this.hostPromises.delete(key);
@@ -1526,7 +1539,10 @@ export class CodexAgent extends BaseAgent {
       ? localControlPlaneHostKey(credentialMode)
       : hostKey();
     const host = credentialMode
-      ? await this.getHost(undefined, credentialMode, { keyOverride: key })
+      ? await this.getHost(undefined, credentialMode, {
+        keyOverride: key,
+        hostPurpose: 'control-plane',
+      })
       : (await this.getUtilityHost()).host;
     const init = await host.ensureStarted();
     if (init.codexHome) this.codexHome = init.codexHome;
@@ -1534,22 +1550,36 @@ export class CodexAgent extends BaseAgent {
     const models: CodexModelListResponse['data'] = [];
     const seenCursors = new Set<string>();
     let cursor: string | null = null;
-    do {
-      const page: CodexModelListResponse = await host.request<CodexModelListResponse>(Method.ModelList, {
-        cursor,
-        limit: 100,
-        includeHidden: false,
-      });
-      models.push(...(Array.isArray(page.data) ? page.data : []));
-      const next: string | null = typeof page.nextCursor === 'string' && page.nextCursor.length > 0
-        ? page.nextCursor
-        : null;
-      if (next && seenCursors.has(next)) {
-        throw new Error(`Codex app-server model/list repeated cursor: ${next}`);
+    try {
+      do {
+        const page: CodexModelListResponse = await host.request<CodexModelListResponse>(
+          Method.ModelList,
+          {
+            cursor,
+            limit: 100,
+            includeHidden: false,
+          },
+          { timeoutMs: CODEX_MODEL_LIST_RPC_TIMEOUT_MS },
+        );
+        models.push(...(Array.isArray(page.data) ? page.data : []));
+        const next: string | null = typeof page.nextCursor === 'string' && page.nextCursor.length > 0
+          ? page.nextCursor
+          : null;
+        if (next && seenCursors.has(next)) {
+          throw new Error(`Codex app-server model/list repeated cursor: ${next}`);
+        }
+        if (next) seenCursors.add(next);
+        cursor = next;
+      } while (cursor !== null);
+    } catch (error) {
+      if (credentialMode && error instanceof AppServerRequestTimeoutError) {
+        await this.retireHostKey(key, 'Codex control-plane model/list timed out', {
+          failIfActive: false,
+          logPrefix: 'codex model list refresh',
+        });
       }
-      if (next) seenCursors.add(next);
-      cursor = next;
-    } while (cursor !== null);
+      throw error;
+    }
 
     // Auth 切换 / logout 可能在分页请求期间 retire 旧 host。旧账号的迟到响应绝不能
     // 覆盖新账号目录；只有仍登记为当前 local host 的结果才允许交给宿主。
@@ -1584,6 +1614,7 @@ export class CodexAgent extends BaseAgent {
     credentialMode: AgentCredentialMode | undefined,
     generation: number,
     onSpawnCredentialModeResolved?: (mode: AgentCredentialMode | undefined) => void,
+    hostPurpose?: 'control-plane',
   ): Promise<AppServerHost> {
     const seq = (this.createHostSeqByKey.get(key) ?? 0) + 1;
     this.createHostSeqByKey.set(key, seq);
@@ -1664,7 +1695,11 @@ export class CodexAgent extends BaseAgent {
         try {
           const cfg = await this.deps.prepareCodexExtraSpawnConfig(
             this.deps.mcpProviders ?? [],
-            { remoteHostId, credentialMode: spawnCredentialMode },
+            {
+              remoteHostId,
+              credentialMode: spawnCredentialMode,
+              ...(hostPurpose ? { hostPurpose } : {}),
+            },
           );
           assertCurrentGeneration('spawn config');
           Object.assign(env, cfg.extraEnv);

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -30,7 +30,12 @@ import type {
   ListCustomizationsResult,
 } from './types/customizations.js';
 import { Session, generateSessionId } from './session.js';
-import type { BaseAgent, StartSessionOptions, OneShotOptions } from './agents/base-agent.js';
+import type {
+  BaseAgent,
+  StartSessionOptions,
+  OneShotOptions,
+  RefreshLocalModelsOptions,
+} from './agents/base-agent.js';
 import type { MemoryStatus, MemorySetResult, MemoryResetResult } from './types/memory.js';
 import type { ConsumeAccountRateLimitResetCreditParams } from './types/account-rate-limits.js';
 import type { SessionStorage, SessionMeta } from './interfaces/session-storage.js';
@@ -666,8 +671,11 @@ export class Maker {
   }
 
   /** 刷新指定 agent 的本机运行时模型清单；不支持或结果已过期时返回 false。 */
-  async refreshAgentLocalModels(agentKind: AgentKind): Promise<boolean> {
-    return this.requireAgent(agentKind).refreshLocalModels();
+  async refreshAgentLocalModels(
+    agentKind: AgentKind,
+    options?: RefreshLocalModelsOptions,
+  ): Promise<boolean> {
+    return this.requireAgent(agentKind).refreshLocalModels(options);
   }
 
   /** Read account quota and banked reset credits through the selected agent runtime. */

--- a/packages/model-providers/src/__tests__/source-registry.test.ts
+++ b/packages/model-providers/src/__tests__/source-registry.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { BUNDLED_CATALOG } from '../catalog.js';
 import {
   loadCatalog,
+  loadCatalogWithSource,
   resolveCatalogUrl,
   resolveFallbackCatalogUrl,
   mergeWithBundled,
@@ -176,6 +177,25 @@ describe('mergeWithBundled', () => {
 });
 
 describe('loadCatalog', () => {
+  it('reports whether local, remote, or bundled supplied the snapshot', async () => {
+    const local = await loadCatalogWithSource(
+      { localPath: '/repo/providers.json' },
+      { readFile: vi.fn(async () => JSON.stringify(MINIMAL)) },
+    );
+    const remote = await loadCatalogWithSource(
+      { url: 'https://catalog.example.test/providers.json' },
+      { fetchText: vi.fn(async () => JSON.stringify(MINIMAL)) },
+    );
+    const bundled = await loadCatalogWithSource(
+      { url: 'https://catalog.example.test/providers.json' },
+      { fetchText: vi.fn(async () => { throw new Error('network down'); }) },
+    );
+
+    expect(local).toMatchObject({ source: 'local', catalog: { version: 'test' } });
+    expect(remote).toMatchObject({ source: 'remote', catalog: { version: 'test' } });
+    expect(bundled).toEqual({ source: 'bundled', catalog: BUNDLED_CATALOG });
+  });
+
   it('dev: reads local path, skips network', async () => {
     const fetchText = vi.fn();
     const io: CatalogIO = { readFile: vi.fn(async () => JSON.stringify(MINIMAL)), fetchText };

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -44,8 +44,14 @@ export {
   resolveFallbackCatalogUrl,
   mergeWithBundled,
   loadCatalog,
+  loadCatalogWithSource,
 } from './source.js';
-export type { CatalogSourceConfig, CatalogIO } from './source.js';
+export type {
+  CatalogSourceConfig,
+  CatalogIO,
+  CatalogLoadResult,
+  CatalogLoadSource,
+} from './source.js';
 
 export {
   buildRegistry,

--- a/packages/model-providers/src/source.ts
+++ b/packages/model-providers/src/source.ts
@@ -50,6 +50,13 @@ export interface CatalogIO {
   log?: (level: 'info' | 'warn' | 'error', msg: string, meta?: Record<string, unknown>) => void;
 }
 
+export type CatalogLoadSource = 'local' | 'remote' | 'bundled';
+
+export interface CatalogLoadResult {
+  catalog: Catalog;
+  source: CatalogLoadSource;
+}
+
 // 去尾部斜杠。不用 /\/+$/ 正则——超长 '/' 串上会 O(n²) 回溯(CodeQL js/polynomial-redos)。
 function trimTrailingSlashes(s: string): string {
   let end = s.length;
@@ -132,14 +139,19 @@ function log(io: CatalogIO, level: 'info' | 'warn' | 'error', msg: string, meta?
 }
 
 /**
- * 加载目录。返回值永远是一个合法 Catalog（最差也回退内置 bundled），不抛错。
+ * 加载目录并返回实际命中的来源。返回值永远包含一个合法 Catalog（最差也回退内置
+ * bundled），不抛错。来源标记让手动刷新可以把 bundled fallback 视为失败并保留上次
+ * 有效快照；启动加载仍可通过 loadCatalog 接受 bundled 兜底。
  *
  * 顺序：
  *  1. dev：cfg.localPath + io.readFile → 读本地、合并 bundled、直接返回（不联网）。
  *  2. 远端依次尝试公共 API、迁移期旧 OSS（除非 disableFetch / 无 URL / 无 fetchText）。
  *  3. 任意上述来源均不可用 → 内置 bundled。
  */
-export async function loadCatalog(cfg: CatalogSourceConfig, io: CatalogIO): Promise<Catalog> {
+export async function loadCatalogWithSource(
+  cfg: CatalogSourceConfig,
+  io: CatalogIO,
+): Promise<CatalogLoadResult> {
   // 1) dev 本地文件优先（命中即用，不联网）。
   if (cfg.localPath && io.readFile) {
     try {
@@ -147,7 +159,7 @@ export async function loadCatalog(cfg: CatalogSourceConfig, io: CatalogIO): Prom
       if (text != null) {
         const parsed = parseCatalog(text);
         log(io, 'info', 'loaded catalog from local path', { path: cfg.localPath });
-        return mergeWithBundled(parsed);
+        return { catalog: mergeWithBundled(parsed), source: 'local' };
       }
     } catch (err) {
       log(io, 'warn', 'local catalog read/parse failed, falling back', { err: String(err) });
@@ -175,7 +187,7 @@ export async function loadCatalog(cfg: CatalogSourceConfig, io: CatalogIO): Prom
         const text = await io.fetchText(remoteUrl, remainingMs);
         const parsed = parseCatalog(text);
         log(io, 'info', 'loaded catalog from remote', { url: remoteUrl });
-        return mergeWithBundled(parsed);
+        return { catalog: mergeWithBundled(parsed), source: 'remote' };
       } catch (err) {
         log(io, 'warn', 'remote catalog read/parse failed, trying fallback', {
           url: remoteUrl,
@@ -187,5 +199,10 @@ export async function loadCatalog(cfg: CatalogSourceConfig, io: CatalogIO): Prom
 
   // 3) 兜底：内置 bundled。
   log(io, 'info', 'using bundled catalog');
-  return BUNDLED_CATALOG;
+  return { catalog: BUNDLED_CATALOG, source: 'bundled' };
+}
+
+/** 启动期兼容入口：接受最终 bundled fallback，只返回目录快照。 */
+export async function loadCatalog(cfg: CatalogSourceConfig, io: CatalogIO): Promise<Catalog> {
+  return (await loadCatalogWithSource(cfg, io)).catalog;
 }


### PR DESCRIPTION
## 迁移说明

本 PR 替代已关闭的 #431。原 head 仓库在 upstream 公开迁移后实际为独立私有镜像，GitHub 无法继续读取新增提交；现已从重新建立的真实 fork 提交。本 PR 包含 #431 已完成的全部 review 修复，以及 commit `e81c1774` 增加的 XD 模型刷新请求 timeout 回归修复。

## 这次改了什么

### 摘要

为 Cindy AI、Anthropic、OpenAI 和 xAI 四个内置模型供应商补充统一的手动刷新入口。Renderer 只负责统一的 loading、禁用态和 Toast 反馈，Main 进程继续按各供应商既有的模型发现真源执行刷新，避免复制网络与凭据逻辑。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：设置页内置 Provider 缺少统一的手动模型刷新入口
- 本 PR 包含：四个内置 Provider 刷新分派、受信 Renderer IPC、统一按钮状态与四语文案、账号切换竞态处理和回归测试
- 明确不包含：自定义 Provider 刷新语义调整、device-link 远程刷新、服务端改动
- 用户可见变化：设置 → 模型供应商的模型列表标题栏新增刷新按钮；空模型状态仍可刷新；刷新中显示 Spinner，并提供成功或失败 Toast
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Color Palette & Roles、§4 Component Stylings / Buttons、§10 Light / Dark Dual-Mode Delivery Gate、§11 Voice & Content、§14 Interaction Conventions
- 实现说明：按钮沿用现有灰阶主题 token 与 pill 形态，使用 `--focus-ring-soft` 提供键盘焦点；Light / Dark 共用语义 token；loading、disabled、empty 和 error 状态均有明确反馈；处理中使用进行时文案，结果 Toast 直接说明刷新结果。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；所有 required workspace 均 PASS

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:i18n
结果：通过；zh-CN / en / ja / ko 共 5485 个 key 对齐（仅仓库既有非阻塞 warning）

git diff --check
结果：通过
```

### 手工验证

- macOS 隔离开发实例 `provider-refresh`：用户完成登录后走查设置 → 模型供应商刷新交互，反馈未发现问题。
- 验证刷新按钮、Spinner、禁用态、空模型入口及成功/失败反馈的实际显示与交互。

### 未执行的验证

- 未在 Windows 实机验证；本次 UI 使用跨平台 Renderer 组件与主题 token，未涉及原生平台代码。
- 未附截图或录屏。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：新增的特权 IPC 仅接受 `xd | anthropic | openai | xai`，不接收 URL、凭据或任意执行参数；Main 校验 Cindy 顶层 Renderer，且未加入 device-link allowlist。Cindy AI 刷新额外等待账号世代对应的 single-flight，Anthropic 在授权边界变化时不会误报成功。
- 回滚 / 降级方式：回滚本提交即可移除刷新按钮和 IPC；各 Provider 原有启动、登录及会话内自动发现机制不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；无需额外产品文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)


