### PR TITLE
docs(dev-rules): 测试门禁从 commit 级改为 push 批次级

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,13 +111,15 @@
   瞬时 commit（不存在于本仓库、GitHub 上查不到该 SHA）；对这类合成 SHA 跑
   `check:dco` 的失败结果不构成缺签证据，不要据此报告 DCO 问题。判定 DCO 是否通过，
   一律以 PR 上的 DCO App check 与真实提交范围（`origin/main..PR head`）的结果为准。
-- **提交前测试门禁（硬性要求）**：无论是提 PR 还是直接 commit，提交前都必须在本地
-  跑完仓库根 `pnpm test:unit`（全部单元测试），并对本次改动涉及的每个 package 跑
+- **推送前测试门禁（硬性要求）**：每次 push（含提 PR）前，都必须对本批全部改动在
+  本地跑完仓库根 `pnpm test:unit`（全部单元测试），并对本批改动涉及的每个 package 跑
   `pnpm --filter <包名> run --if-present typecheck`（`<包名>` 用该 package 在
   `package.json` 里的 `name`，如 `desktop`、`@cindy/maker-core`；没有 `typecheck`
-  script 的 package 该步自动跳过），全部通过后才允许提交；任何一项失败都不得提交，
-  必须先修复。细则与唯一例外（防丢数据的兜底保存）见
-  `docs/dev-rules/development-workflow.md`。
+  script 的 package 该步自动跳过），全部通过后才允许 push；任何一项失败都不得 push，
+  必须先修复。同一批次内的中间 commit 用定向验证（相关 package 的 typecheck、精确
+  vitest 文件）即可，不要求每个 commit 重复全量套件——配合「一轮 review 修复合批成
+  一次 push」，全量验证按 push 批次恰好执行一次。细则与唯一例外（防丢数据的兜底
+  保存）见 `docs/dev-rules/development-workflow.md`。
 - 在上述门禁之上按风险追加验证：跨模块、高风险或基础设施改动追加更广泛验证（如
   `pnpm test:all`），最终以 CI 门禁为准。不得通过跳过、删除或弱化测试制造通过。
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -87,8 +87,8 @@ localStorage 按 **origin + userData 目录** 分家——dev 的 renderer 从
 
 ## 分层验证
 
-本节指导**开发过程中的增量验证**；提交（commit／PR）前的强制门禁以
-`development-workflow.md` 的「提交前测试门禁」为准（仓库根 `pnpm test:unit` 与相关
+本节指导**开发过程中的增量验证**；push／提 PR 前的强制门禁以
+`development-workflow.md` 的「推送前测试门禁」为准（仓库根 `pnpm test:unit` 与相关
 package 的 typecheck 全部通过）。开发过程中根据实际改动选择最小但充分的检查：
 
 ```bash

--- a/docs/dev-rules/development-workflow.md
+++ b/docs/dev-rules/development-workflow.md
@@ -19,8 +19,8 @@ worktree 会话契约、直推 `main` 的额外门禁与 review 严重度口径�
   命令超时）。
 - **你的编辑对运行中的 app 无效**：Vite HMR 只 watch 启动 dev 实例的那个 checkout，
   worktree 下的改动既不热更也不随重启生效。「改了没反应」不是 bug。开发过程中的增量验证在本
-  worktree 内跑 `pnpm --filter desktop typecheck` / 定向 `vitest run`；**提交前仍须通过
-  第 2 节的提交前测试门禁**。需要运行时验证时 commit + push 后交用户（你无法重启宿主）。
+  worktree 内跑 `pnpm --filter desktop typecheck` / 定向 `vitest run`；**push 前仍须通过
+  第 2 节的推送前测试门禁**。需要运行时验证时 commit + push 后交用户（你无法重启宿主）。
 - **宿主 app 日志不在你的 cwd 下**：dev 日志在启动 checkout（通常是 baseRepo）的
   `apps/desktop/logs/`，读日志时拼 baseRepo 的绝对路径。
 - **结束前必须 commit**：会话被删除或归档时脏 worktree 会先存内容快照再删目录。**PR
@@ -57,15 +57,19 @@ worktree 会话契约、直推 `main` 的额外门禁与 review 严重度口径�
     改这个脚本时不要放宽 name／邮箱比对，否则会出现「本地绿、PR 红」。
   - 漏签不要重新造一份提交：用 `git commit --amend -s --no-edit` 或
     `git rebase --signoff <base>` 补签后 `git push --force-with-lease`。
-- **提交前测试门禁（硬性要求）**：无论是提 PR 还是直接 commit，提交前都必须在本地跑完
-  仓库根 `pnpm test:unit`（全部单元测试），并对本次改动涉及的每个 package 跑
+- **推送前测试门禁（硬性要求）**：每次 push 或提 PR 前，都必须对本批全部改动在本地跑完
+  仓库根 `pnpm test:unit`（全部单元测试），并对本批改动涉及的每个 package 跑
   `pnpm --filter <包名> run --if-present typecheck`（`<包名>` 用该 package 在
   `package.json` 里的 `name`，如 `desktop`、`@cindy/maker-core`；没有 `typecheck`
-  script 的 package 该步自动跳过），全部通过后才允许提交；任何一项失败都不得提交，
-  必须先修复。worktree 会话内的 commit 同样适用。唯一例外是**防丢数据的兜底保存**：
-  宿主删除／归档会话时自动存的内容快照（见第 1 节），以及会话必须收尾、测试却来不及
-  修好时的收尾 commit——后者 commit message 必须标注 `WIP`，且在门禁通过前不得
-  push、不得提 PR。
+  script 的 package 该步自动跳过），全部通过后才允许 push；任何一项失败都不得 push，
+  必须先修复。worktree 会话内同样适用。**批次内的中间 commit** 用定向验证（相关
+  package 的 typecheck、精确 `vitest run` 文件）即可，不要求每个 commit 重复全量套件
+  ——门禁按 push 批次执行，配合「一轮 review 修复合批成一次 push」，全量验证与推送
+  一一对应（2026-07 实测：commit 级全量门禁在多轮 review 修复下两头失守——要么被
+  跳过「34 个 commit 只配 9 次全量」，要么空转「单会话 90 次全量重跑」）。唯一例外是
+  **防丢数据的兜底保存**：宿主删除／归档会话时自动存的内容快照（见第 1 节），以及
+  会话必须收尾、测试却来不及修好时的收尾 commit——后者 commit message 必须标注
+  `WIP`，且在门禁通过前不得 push、不得提 PR。
   - **完整单测的外层超时**：`pnpm test:unit` 是全仓完整门禁，正常执行可能超过数分钟。
     调用它的 agent／自动化工具不得使用 120 秒或更短的绝对超时；未知当前耗时时，外层
     兜底超时至少设为 15 分钟。工具支持后台运行或 yielded process handle 时优先使用该


### PR DESCRIPTION
## 这次改了什么

### 摘要

把「提交前测试门禁」调整为「推送前测试门禁」：全量 `pnpm test:unit` + 相关 package typecheck 的执行时点从**每个 commit 前**改为**每次 push（批次）前**；批次内的中间 commit 改用定向验证（相关 package typecheck、精确 vitest 文件）。验证强度不变——推送出去的每个批次仍被全量把关——只是让门禁粒度与「一轮 review 修复合批成一次 push」的纪律对齐。

为什么改：commit 级全量门禁与合批 push 纪律在多轮 review 修复场景下互相冲突，实测两头失守——要么中间 commit 事实上跳过全量（一个会话 34 个 commit 只配了 9 次全量），要么反复空转重跑（另一会话 90 次全量单测、约 2.8 小时纯等待）。push 级批次门禁让全量验证与推送一一对应，两种失败模式同时消除。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无（工程流程审计结论）
- 本 PR 包含：AGENTS.md 门禁条款、development-workflow.md 第 2 节细则、desktop-development.md 分层验证一节的引用措辞，三处同步更新
- 明确不包含：任何代码/CI 配置改动；`pnpm test:all` 追加验证条款、WIP 例外条款均保持原语义
- 用户可见变化：无（仅 agent/贡献者工作流规则）
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
纯 Markdown 文档改动，无代码路径影响；未运行测试套件。
grep 复核：全仓不再有「提交前测试门禁」残留引用（除本 PR 改动的三处外无其它出现点）。
```

### 手工验证

通读三处改动上下文，确认与 DCO 条款、WIP 例外、`pnpm test:all` 追加验证条款的衔接语义一致。

### 未执行的验证

`pnpm test:unit`：文档-only 改动，不触及任何被测代码路径。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅贡献者/agent 工作流文档；CI 门禁（以 CI 为准的条款）未变
- 回滚 / 降级方式：revert 本 commit 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
