### PR TITLE
fix(plugins): follow server order in plugin catalog

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -68,6 +68,7 @@ import { GhostPluginIcon } from './GhostPluginIcon';
 import { MarketPluginDetailView } from './MarketPluginDetailView';
 import { PluginScopePicker, usePluginRecentWorkdirs } from './PluginScopePicker';
 import {
+  orderPluginCatalogItems,
   pluginPresentationOrigin,
   type PluginPresentationOrigin,
 } from './lib/pluginMarketPresentation';
@@ -361,6 +362,10 @@ export function GhostPluginPage() {
             (item) => pluginPresentationOrigin(item) === effectiveOriginFilter,
           ),
     [effectiveOriginFilter, searchedAvailableMarketItems],
+  );
+  const catalogItems = useMemo(
+    () => orderPluginCatalogItems(marketItems, items, availableMarketItems),
+    [availableMarketItems, items, marketItems],
   );
   const originCounts = useMemo(() => {
     const counts: Record<PluginPresentationOrigin, number> = {
@@ -917,34 +922,40 @@ export function GhostPluginPage() {
               />
             ) : null}
 
-            {items.length > 0 || availableMarketItems.length > 0 ? (
+            {catalogItems.length > 0 ? (
               <div className={cn('plugin-motion-stagger', PLUGIN_MANAGEMENT_CARD_GRID_CLASS)}>
-                {items.map((item) => (
-                  <GhostPluginCard
-                    key={item.id}
-                    item={item}
-                    sourceLabel={t(`settings.ghosts.page.origin.${item.origin}`)}
-                    onSelect={() => setSelectedId(item.id)}
-                    onAction={() => void handleUseGhost(item.id)}
-                    updateVersion={item.marketUpdate?.version}
-                    updateBusy={item.marketUpdate !== null && marketBusyId !== null}
-                    onUpdate={
-                      item.marketUpdate ? () => void handleMarketUpdate(item.id) : undefined
-                    }
-                    effectiveEnabled={effectiveEnabled(item.id, item.enabled)}
-                    toggleDisabled={scopeDir !== null && !item.enabled}
-                    onToggle={(enabled) => void handleToggle(item.id, enabled)}
-                  />
-                ))}
-                {availableMarketItems.map((item) => (
-                  <MarketPluginCard
-                    key={item.pluginId}
-                    item={item}
-                    busy={marketBusyId !== null}
-                    onSelect={() => void handleSelectMarket(item.pluginId)}
-                    onIconLoadError={handleMarketIconLoadError}
-                  />
-                ))}
+                {catalogItems.map((catalogItem) =>
+                  catalogItem.kind === 'installed' ? (
+                    <GhostPluginCard
+                      key={`installed:${catalogItem.item.id}`}
+                      item={catalogItem.item}
+                      sourceLabel={t(`settings.ghosts.page.origin.${catalogItem.item.origin}`)}
+                      onSelect={() => setSelectedId(catalogItem.item.id)}
+                      onAction={() => void handleUseGhost(catalogItem.item.id)}
+                      updateVersion={catalogItem.item.marketUpdate?.version}
+                      updateBusy={catalogItem.item.marketUpdate !== null && marketBusyId !== null}
+                      onUpdate={
+                        catalogItem.item.marketUpdate
+                          ? () => void handleMarketUpdate(catalogItem.item.id)
+                          : undefined
+                      }
+                      effectiveEnabled={effectiveEnabled(
+                        catalogItem.item.id,
+                        catalogItem.item.enabled,
+                      )}
+                      toggleDisabled={scopeDir !== null && !catalogItem.item.enabled}
+                      onToggle={(enabled) => void handleToggle(catalogItem.item.id, enabled)}
+                    />
+                  ) : (
+                    <MarketPluginCard
+                      key={`market:${catalogItem.item.pluginId}`}
+                      item={catalogItem.item}
+                      busy={marketBusyId !== null}
+                      onSelect={() => void handleSelectMarket(catalogItem.item.pluginId)}
+                      onIconLoadError={handleMarketIconLoadError}
+                    />
+                  ),
+                )}
               </div>
             ) : !legacyRecoveryStatus ? (
               <div className="rounded-xl border-[0.5px] border-[var(--border-default)] px-5 py-10 text-center">

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
@@ -74,6 +74,22 @@ describe('orderPluginCatalogItems', () => {
     ).toEqual(['market:market', 'installed:local-z', 'installed:local-a']);
   });
 
+  it('keeps a conflicting market card and its local install at the server position', () => {
+    const first = marketItem('plugin-first', 'first', 'not-installed');
+    const conflict = marketItem('plugin-conflict', 'collision', 'conflict');
+    const third = marketItem('plugin-third', 'third', 'not-installed');
+
+    const ordered = orderPluginCatalogItems(
+      [first, conflict, third],
+      [{ id: 'collision' }],
+      [first, conflict, third],
+    );
+
+    expect(
+      ordered.map(({ kind, item }) => `${kind}:${kind === 'installed' ? item.id : item.ghostId}`),
+    ).toEqual(['market:first', 'market:collision', 'installed:collision', 'market:third']);
+  });
+
   it('preserves server order after search or origin filters remove entries', () => {
     const first = marketItem('plugin-first', 'first', 'not-installed');
     const hidden = marketItem('plugin-hidden', 'hidden', 'not-installed');

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { pluginPresentationOrigin } from '../pluginMarketPresentation';
+import type { PluginMarketItem } from '../../../../../shared/pluginMarket';
+import { orderPluginCatalogItems, pluginPresentationOrigin } from '../pluginMarketPresentation';
+
+function marketItem(
+  pluginId: string,
+  ghostId: string,
+  installState: PluginMarketItem['installState'],
+): PluginMarketItem {
+  return {
+    pluginId,
+    ghostId,
+    name: ghostId,
+    description: null,
+    author: null,
+    scope: 'public',
+    organizationId: null,
+    defaultInstall: false,
+    releaseId: `release-${pluginId}`,
+    version: '1.0.0',
+    publishedAt: '2026-07-27T00:00:00.000Z',
+    icon: null,
+    installState,
+    enabled: installState === 'not-installed' ? null : true,
+  };
+}
 
 describe('pluginPresentationOrigin', () => {
   it('maps public plugins independently of their default-install policy', () => {
@@ -16,5 +40,49 @@ describe('pluginPresentationOrigin', () => {
 
   it.each([null, undefined])('keeps unmatched installed plugins local', (item) => {
     expect(pluginPresentationOrigin(item)).toBe('local');
+  });
+});
+
+describe('orderPluginCatalogItems', () => {
+  it('renders installed and available cards in the server response order', () => {
+    const first = marketItem('plugin-first', 'first', 'not-installed');
+    const second = marketItem('plugin-second', 'second', 'installed');
+    const third = marketItem('plugin-third', 'third', 'not-installed');
+
+    const ordered = orderPluginCatalogItems(
+      [first, second, third],
+      [{ id: 'second' }],
+      [first, third],
+    );
+
+    expect(
+      ordered.map(({ kind, item }) => `${kind}:${kind === 'installed' ? item.id : item.ghostId}`),
+    ).toEqual(['market:first', 'installed:second', 'market:third']);
+  });
+
+  it('keeps local-only installed plugins after the server-ordered catalog', () => {
+    const market = marketItem('plugin-market', 'market', 'not-installed');
+
+    const ordered = orderPluginCatalogItems(
+      [market],
+      [{ id: 'local-z' }, { id: 'local-a' }],
+      [market],
+    );
+
+    expect(
+      ordered.map(({ kind, item }) => `${kind}:${kind === 'installed' ? item.id : item.ghostId}`),
+    ).toEqual(['market:market', 'installed:local-z', 'installed:local-a']);
+  });
+
+  it('preserves server order after search or origin filters remove entries', () => {
+    const first = marketItem('plugin-first', 'first', 'not-installed');
+    const hidden = marketItem('plugin-hidden', 'hidden', 'not-installed');
+    const third = marketItem('plugin-third', 'third', 'update-available');
+
+    const ordered = orderPluginCatalogItems([first, hidden, third], [{ id: 'third' }], [first]);
+
+    expect(
+      ordered.map(({ kind, item }) => `${kind}:${kind === 'installed' ? item.id : item.ghostId}`),
+    ).toEqual(['market:first', 'installed:third']);
   });
 });

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
@@ -90,6 +90,21 @@ describe('orderPluginCatalogItems', () => {
     ).toEqual(['market:first', 'market:collision', 'installed:collision', 'market:third']);
   });
 
+  it('does not duplicate installed records passed through the available-item input', () => {
+    const installed = marketItem('plugin-installed', 'installed', 'installed');
+    const update = marketItem('plugin-update', 'update', 'update-available');
+
+    const ordered = orderPluginCatalogItems(
+      [installed, update],
+      [{ id: 'installed' }, { id: 'update' }],
+      [installed, update],
+    );
+
+    expect(
+      ordered.map(({ kind, item }) => `${kind}:${kind === 'installed' ? item.id : item.ghostId}`),
+    ).toEqual(['installed:installed', 'installed:update']);
+  });
+
   it('preserves server order after search or origin filters remove entries', () => {
     const first = marketItem('plugin-first', 'first', 'not-installed');
     const hidden = marketItem('plugin-hidden', 'hidden', 'not-installed');

--- a/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
@@ -45,9 +45,12 @@ export function orderPluginCatalogItems<TInstalled extends { id: string }>(
     const availableItem = availableByPluginId.get(marketItem.pluginId);
     if (availableItem) {
       ordered.push({ kind: 'market', item: availableItem });
-      continue;
     }
-    if (marketItem.installState !== 'installed' && marketItem.installState !== 'update-available') {
+    if (
+      marketItem.installState !== 'installed' &&
+      marketItem.installState !== 'update-available' &&
+      marketItem.installState !== 'conflict'
+    ) {
       continue;
     }
     const installedItem = installedByGhostId.get(marketItem.ghostId);

--- a/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
@@ -12,6 +12,9 @@ export type PluginPresentationOrigin =
   | 'organization'
   | 'local';
 
+export type PluginCatalogPresentationItem<TInstalled> =
+  { kind: 'installed'; item: TInstalled } | { kind: 'market'; item: PluginMarketItem };
+
 export function pluginPresentationOrigin(
   item: Pick<PluginMarketItem, 'scope'> | null | undefined,
 ): PluginPresentationOrigin {
@@ -21,4 +24,41 @@ export function pluginPresentationOrigin(
   // Personal market publishing is intentionally not exposed by the client.
   // Keep the renderer taxonomy closed even if an older/newer server returns it.
   return 'local';
+}
+
+/**
+ * Keeps the complete catalog in server order while rendering an installed card
+ * for market records already owned by this client. Local-only installs have no
+ * server position, so they remain visible after the ordered market catalog.
+ */
+export function orderPluginCatalogItems<TInstalled extends { id: string }>(
+  marketItems: readonly PluginMarketItem[],
+  installedItems: readonly TInstalled[],
+  availableMarketItems: readonly PluginMarketItem[],
+): PluginCatalogPresentationItem<TInstalled>[] {
+  const installedByGhostId = new Map(installedItems.map((item) => [item.id, item]));
+  const availableByPluginId = new Map(availableMarketItems.map((item) => [item.pluginId, item]));
+  const emittedInstalledIds = new Set<string>();
+  const ordered: PluginCatalogPresentationItem<TInstalled>[] = [];
+
+  for (const marketItem of marketItems) {
+    const availableItem = availableByPluginId.get(marketItem.pluginId);
+    if (availableItem) {
+      ordered.push({ kind: 'market', item: availableItem });
+      continue;
+    }
+    if (marketItem.installState !== 'installed' && marketItem.installState !== 'update-available') {
+      continue;
+    }
+    const installedItem = installedByGhostId.get(marketItem.ghostId);
+    if (!installedItem || emittedInstalledIds.has(installedItem.id)) continue;
+    emittedInstalledIds.add(installedItem.id);
+    ordered.push({ kind: 'installed', item: installedItem });
+  }
+
+  for (const installedItem of installedItems) {
+    if (emittedInstalledIds.has(installedItem.id)) continue;
+    ordered.push({ kind: 'installed', item: installedItem });
+  }
+  return ordered;
 }

--- a/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
@@ -43,7 +43,10 @@ export function orderPluginCatalogItems<TInstalled extends { id: string }>(
 
   for (const marketItem of marketItems) {
     const availableItem = availableByPluginId.get(marketItem.pluginId);
-    if (availableItem) {
+    if (
+      availableItem &&
+      (marketItem.installState === 'not-installed' || marketItem.installState === 'conflict')
+    ) {
       ordered.push({ kind: 'market', item: availableItem });
     }
     if (


### PR DESCRIPTION
## 这次改了什么

### 摘要

全部插件列表现在严格遵循服务端返回顺序。已安装插件如果在服务端目录中有对应记录，会在该记录的位置继续渲染已安装卡片；仅本地安装、服务端没有对应记录的插件追加到列表末尾。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：全部插件列表的服务端顺序映射和回归测试
- 明确不包含：顶部“已安装”分区的排序、行为或交互变化
- 用户可见变化：全部插件列表不再按已安装状态置顶，改为服务端返回顺序
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及视觉变化；仅调整既有插件卡片的渲染顺序，顶部“已安装”分区行为不变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；根测试 297 项（296 passed, 1 skipped），Desktop 1219 个测试文件 / 13317 个测试通过（2 skipped），其余 workspace 全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec vitest run src/renderer/features/plugin --reporter=dot
结果：通过；9 个测试文件、65 个测试通过。

git diff --check
结果：通过。
```

### 手工验证

未执行；本 PR 通过定向回归测试覆盖顺序映射。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop 插件目录列表的卡片排列顺序。
- 回滚 / 降级方式：回滚本 PR commit 即可恢复原有排列逻辑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及视觉变化）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
