### PR TITLE
fix(desktop): clarify Claude usage window labels

### DIFF
--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.behavior.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.behavior.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTranslation } from 'react-i18next';
+
+import enCommon from '../i18n/locales/en/common.json';
+import koCommon from '../i18n/locales/ko/common.json';
+import type { ClaudeSubscriptionUsageSnapshot } from '../hooks/useClaudeSubscriptionUsage';
+
+const mocks = vi.hoisted(() => ({
+  useClaudeSubscriptionUsage: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: vi.fn(),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ text, children }: { text: React.ReactNode; children: React.ReactElement }) => (
+    <>
+      {children}
+      <div data-testid="usage-tooltip">{text}</div>
+    </>
+  ),
+}));
+
+vi.mock('@/hooks/useApiKey', () => ({
+  useApiKey: () => ({ hasSavedKey: false, isReconciling: false }),
+}));
+vi.mock('@/hooks/useClaudeOAuthConnected', () => ({
+  useClaudeOAuthConnected: () => true,
+}));
+vi.mock('@/hooks/useClaudeSessionRoute', () => ({
+  useClaudeSessionRoute: () => null,
+}));
+vi.mock('@/hooks/useSessionSpend', () => ({
+  useSessionSpend: () => null,
+}));
+vi.mock('@/hooks/useSessionEstimatedValue', () => ({
+  useSessionEstimatedValue: () => null,
+}));
+vi.mock('@/hooks/useSessionTokens', () => ({
+  useSessionTokens: () => null,
+}));
+vi.mock('@/components/chat/ChatDisplaySnapshotContext', () => ({
+  useChatDisplaySnapshot: () => null,
+}));
+vi.mock('@/hooks/useAccountUsage', () => ({
+  requestCodexAccountRefresh: vi.fn(),
+  useAccountUsage: () => null,
+}));
+vi.mock('@/hooks/useClaudeAccountUsage', () => ({
+  useClaudeAccountUsage: () => null,
+}));
+vi.mock('@/hooks/useClaudeSubscriptionUsage', () => ({
+  requestClaudeSubscriptionRefresh: vi.fn(),
+  useClaudeSubscriptionUsage: mocks.useClaudeSubscriptionUsage,
+}));
+vi.mock('@/hooks/useCodexRuntimeRoute', () => ({
+  useCodexRuntimeRoute: () => ({ authInjection: null }),
+}));
+vi.mock('@/hooks/useXaiRateLimit', () => ({
+  useXaiRateLimit: () => null,
+}));
+vi.mock('@/lib/makerChatStore', () => ({
+  makerChatStore: {
+    getSnapshot: () => ({ messages: [] }),
+    subscribe: () => () => {},
+  },
+}));
+vi.mock('../components/status/quotaResetRollup', () => ({
+  RESET_PENDING_MAX_MS: 10 * 60_000,
+  computeCountdownTickDelayMs: () => 60_000,
+  useQuotaResetRollup: (
+    slot: { remainingPercent: number } | null,
+  ) => slot ? { percent: slot.remainingPercent, celebrating: false } : null,
+}));
+vi.mock('../components/status/QuotaResetConfetti', () => ({
+  QuotaResetConfetti: () => null,
+}));
+
+import { TodaySpendChip } from '../components/status/TodaySpendChip';
+
+type LocaleCatalog = Record<string, unknown>;
+
+function readCatalogValue(catalog: LocaleCatalog, key: string): string {
+  const value = key.split('.').reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, catalog);
+  if (typeof value !== 'string') throw new Error(`Missing test translation: ${key}`);
+  return value;
+}
+
+function makeTranslator(catalog: LocaleCatalog) {
+  return (key: string, values?: Record<string, unknown>): string =>
+    readCatalogValue(catalog, key).replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+      String(values?.[name] ?? ''),
+    );
+}
+
+// 选择 UTC / Asia-Shanghai 下都不会跨天的时刻,让 resetAt 稳定走“当天只显时分”分支。
+const NOW_MS = Date.parse('2026-07-25T08:00:00.000Z');
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const RESET_AT_SECONDS = Math.floor((NOW_MS + FIVE_HOURS_MS) / 1000);
+
+function usageSnapshot(): ClaudeSubscriptionUsageSnapshot {
+  return {
+    subscriptionType: 'pro',
+    fiveHour: { utilization: 5, resetsAt: RESET_AT_SECONDS },
+    sevenDay: { utilization: 25, resetsAt: RESET_AT_SECONDS },
+    scoped: [{
+      modelDisplayName: 'Fable',
+      utilization: 25,
+      resetsAt: RESET_AT_SECONDS,
+    }],
+  };
+}
+
+function renderClaudeUsage(catalog: LocaleCatalog) {
+  vi.mocked(useTranslation).mockReturnValue({
+    t: makeTranslator(catalog),
+  } as never);
+  mocks.useClaudeSubscriptionUsage.mockReturnValue(usageSnapshot());
+  render(
+    <TodaySpendChip
+      vendorKey="cc"
+      providerId="anthropic"
+      modelId="claude-fable"
+    />,
+  );
+}
+
+describe('TodaySpendChip Claude subscription presentation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('keeps stable chip identities and renders complete reset details in the tooltip', () => {
+    renderClaudeUsage(enCommon);
+
+    expect(screen.getByText('5h 95% left')).toBeTruthy();
+    expect(screen.getByText('Fable weekly 75% left')).toBeTruthy();
+
+    const resetAt = new Date(RESET_AT_SECONDS * 1000).toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    const tooltipText = screen.getByTestId('usage-tooltip').textContent;
+    expect(tooltipText).toContain(
+      `Weekly 75% left (25% used) · resets in 5h (${resetAt})`,
+    );
+    expect(tooltipText).toContain(
+      `Fable weekly 75% left (25% used) · resets in 5h (${resetAt})`,
+    );
+  });
+
+  it('keeps a space before the Korean reset-time parenthesis', () => {
+    renderClaudeUsage(koCommon);
+
+    const resetAt = new Date(RESET_AT_SECONDS * 1000).toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    expect(screen.getByTestId('usage-tooltip').textContent).toContain(
+      `재설정 (${resetAt})`,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -139,7 +139,7 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain('getCodexWindowUsages(snapshot, t, nowMs)');
     expect(source).toContain('todaySpend.codex.planCreditsLine');
     expect(source).toContain('todaySpend.codex.windowLine');
-    // chip 主体 label 统一为距 reset 的剩余时长倒计时 (Claude / Codex 同一函数),
+    // Codex chip 主体 label 为距 reset 的剩余时长倒计时,
     // tooltip 保留窗口名 + 精确 reset 时间点
     expect(source).toContain('function formatCompactTimeUntilReset(');
     expect(source).toContain('function toCodexChipWindow(');
@@ -189,8 +189,13 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain('todaySpend.claude.weeklyLabel');
     expect(source).toContain('todaySpend.claude.windowLine');
     expect(source).toContain('todaySpend.claude.resetAt');
-    // chip 周限段: scoped 命中时倒计时前带模型名标注口径 (「Fable 7天 剩余 78%」)
-    expect(source).toContain('weekly.modelDisplayName ? `${weekly.modelDisplayName} ${countdown}` : countdown');
+    expect(source).toContain('todaySpend.claude.resetInAt');
+    // Claude chip 保留稳定窗口身份,reset 时间只放 tooltip。周限即使恰好剩 5h
+    // 也必须显示 Weekly / Fable weekly,不能与 5h 窗口同名。
+    expect(source).toContain("label: '5h',");
+    expect(source).toContain('label: weekly.label,');
+    expect(source).toContain('resetIn: formatCompactTimeUntilReset(window.resetsAt, nowMs, t)');
+    expect(source).not.toContain('weekly.modelDisplayName ? `${weekly.modelDisplayName} ${countdown}` : countdown');
     expect(source).toContain('todaySpend.claude.sessionValueLabel');
     expect(source).toContain('todaySpend.claude.planLine');
     // 告警判定是纯数据判定, 统一收在 shared/claudeSubscriptionUsage.ts (有直接单测:

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -190,12 +190,8 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain('todaySpend.claude.windowLine');
     expect(source).toContain('todaySpend.claude.resetAt');
     expect(source).toContain('todaySpend.claude.resetInAt');
-    // Claude chip 保留稳定窗口身份,reset 时间只放 tooltip。周限即使恰好剩 5h
-    // 也必须显示 Weekly / Fable weekly,不能与 5h 窗口同名。
-    expect(source).toContain("label: '5h',");
-    expect(source).toContain('label: weekly.label,');
-    expect(source).toContain('resetIn: formatCompactTimeUntilReset(window.resetsAt, nowMs, t)');
-    expect(source).not.toContain('weekly.modelDisplayName ? `${weekly.modelDisplayName} ${countdown}` : countdown');
+    // 稳定窗口身份与完整 reset tooltip 的最终输出由 todaySpendChip.behavior.test.tsx
+    // 直接渲染组件验证；这里仅保留形态路由契约。
     expect(source).toContain('todaySpend.claude.sessionValueLabel');
     expect(source).toContain('todaySpend.claude.planLine');
     // 告警判定是纯数据判定, 统一收在 shared/claudeSubscriptionUsage.ts (有直接单测:

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -236,8 +236,8 @@ function formatResetAt(epochSeconds: number | null | undefined): string | null {
 
 /**
  * chip 主体用的紧凑剩余时长(距 reset 还有多久): 单级精度 + 向上取整 ——
- * 「7天」/「3小时」/「45分钟」/「41秒」。Codex 与 Claude 订阅两种形态统一用它当窗口
- * label(所有限额窗口都算给用户);无数据 / 已过期 → null, 调用方回退窗口名。
+ * 「7天」/「3小时」/「45分钟」/「41秒」。Codex 订阅用它当窗口 label,
+ * Claude 订阅只在 tooltip 展示;主 chip 保留稳定窗口名。无数据 / 已过期 → null。
  * 天级向上取整与 Codex 既有 getDaysUntilReset 口径一致(剩 6天10小时 → 7天)。
  * 最后一分钟降到秒级, 配合秒级 tick(computeCountdownTickDelayMs)逐秒走动。
  */
@@ -272,7 +272,7 @@ function toEpochMs(epochSeconds: number | null | undefined): number | null {
 }
 
 /**
- * chip 上一个限额窗口段的素材: 倒计时 label + 数值化剩余百分比 + 窗口身份/reset
+ * chip 上一个限额窗口段的素材: 展示 label + 数值化剩余百分比 + 窗口身份/reset
  * 时点(useQuotaResetRollup 检测重置并驱动 0% → 100% 滚动动画的输入)。
  * Codex 订阅与 Claude 订阅两种形态共用, 成品字符串在组件里统一格式化。
  */
@@ -535,6 +535,8 @@ interface ClaudeWindowUsage {
   label: string;
   used: string;
   remaining: string;
+  /** tooltip 用的相对 reset 倒计时;无数据 / 已过期 → null。 */
+  resetIn: string | null;
   /** tooltip 用的精确 reset 时间点;无数据 → null。 */
   resetAt: string | null;
 }
@@ -542,6 +544,8 @@ interface ClaudeWindowUsage {
 function toClaudeWindowUsage(
   label: string,
   window: ClaudeUsageWindow | null | undefined,
+  nowMs: number,
+  t: TFunction,
 ): ClaudeWindowUsage | null {
   if (!window || typeof window.utilization !== 'number' || !Number.isFinite(window.utilization)) {
     return null;
@@ -551,6 +555,7 @@ function toClaudeWindowUsage(
     label,
     used: formatPercent(usedPercent),
     remaining: formatPercent(100 - usedPercent),
+    resetIn: formatCompactTimeUntilReset(window.resetsAt, nowMs, t),
     resetAt: formatResetAt(window.resetsAt),
   };
 }
@@ -558,7 +563,7 @@ function toClaudeWindowUsage(
 /**
  * 当前会话生效的周限窗口: 命中当前模型的 weekly_scoped 条目优先 (label 带模型名,
  * 如 "Fable 周限"), 否则回退总周限 —— 两种 label 口径可区分, 绝不臆造数字。
- * modelDisplayName 仅 scoped 命中时有, chip 倒计时 label 用它拼「Fable 7天」。
+ * modelDisplayName 仅 scoped 命中时有, 用于区分窗口身份。
  */
 function resolveClaudeWeeklyWindow(
   snapshot: ClaudeSubscriptionUsageSnapshot,
@@ -580,9 +585,9 @@ function resolveClaudeWeeklyWindow(
 }
 
 /**
- * chip 段素材 (方案 B + 倒计时 label): 窗口 label 直接用距 reset 的剩余时长 ——
- * 「3小时 剩余 45% · Fable 7天 剩余 78%」;scoped 命中时时长前带模型名标注口径。
- * 无 reset 数据回退窗口名 (5h / Fable 周限 / 周限), 绝不显示算不出的时间。
+ * chip 段素材 (方案 B): 保留稳定窗口身份 ——
+ * 「5h 剩余 45% · Fable 周限 剩余 78%」;reset 时间只放 tooltip,避免周限恰好
+ * 剩 5 小时时与 5h 窗口显示成两个同名「5h」。
  * 剩余百分比留数值形态, 由组件经 useQuotaResetRollup(重置滚动动画)后再格式化。
  */
 function getClaudeChipWindows(
@@ -595,11 +600,10 @@ function getClaudeChipWindows(
   const windows: ChipWindowSegment[] = [];
   const fiveHour = snapshot.fiveHour;
   if (fiveHour && typeof fiveHour.utilization === 'number' && Number.isFinite(fiveHour.utilization)) {
-    const countdown = formatCompactTimeUntilReset(fiveHour.resetsAt, nowMs, t);
     const resetsAtMs = toEpochMs(fiveHour.resetsAt);
     windows.push({
       key: 'claude-5h',
-      label: countdown ?? '5h',
+      label: '5h',
       remainingPercent: 100 - clampPercent(fiveHour.utilization),
       resetsAtMs,
       resetPending: isResetPending(resetsAtMs, nowMs),
@@ -611,15 +615,11 @@ function getClaudeChipWindows(
     && typeof weekly.window.utilization === 'number'
     && Number.isFinite(weekly.window.utilization)
   ) {
-    const countdown = formatCompactTimeUntilReset(weekly.window.resetsAt, nowMs, t);
-    const label = countdown
-      ? (weekly.modelDisplayName ? `${weekly.modelDisplayName} ${countdown}` : countdown)
-      : weekly.label;
     const resetsAtMs = toEpochMs(weekly.window.resetsAt);
     windows.push({
       // 身份 key 区分总周限与各 scoped 周限: 切模型导致窗口切换时只重置动画基线。
       key: weekly.modelDisplayName ? `claude-weekly:${weekly.modelDisplayName}` : 'claude-weekly:total',
-      label,
+      label: weekly.label,
       remainingPercent: 100 - clampPercent(weekly.window.utilization),
       resetsAtMs,
       resetPending: isResetPending(resetsAtMs, nowMs),
@@ -639,6 +639,7 @@ function buildClaudeSubscriptionTooltipNode(
   modelId: string | null | undefined,
   sessionValueMoney: RegionalMoney | null,
   t: TFunction,
+  nowMs: number,
   usageDashboardLabel: string | null,
   latestTurnUsage: LatestTurnUsageSummary | null,
 ): React.ReactNode {
@@ -661,16 +662,23 @@ function buildClaudeSubscriptionTooltipNode(
   }
 
   // 窗口明细: 5h → 总周限 → 全部分模型周限 (含非当前模型, 用户能看到谁先见底)。
-  // tooltip 保留精确 reset 时间点 (chip 上是倒计时, 两层信息互补)。
+  // chip 保留稳定窗口名;tooltip 同时给相对倒计时和精确 reset 时间点。
   const windows: ClaudeWindowUsage[] = [];
-  const fiveHour = toClaudeWindowUsage('5h', snapshot.fiveHour);
+  const fiveHour = toClaudeWindowUsage('5h', snapshot.fiveHour, nowMs, t);
   if (fiveHour) windows.push(fiveHour);
-  const sevenDay = toClaudeWindowUsage(t('todaySpend.claude.weeklyLabel'), snapshot.sevenDay);
+  const sevenDay = toClaudeWindowUsage(
+    t('todaySpend.claude.weeklyLabel'),
+    snapshot.sevenDay,
+    nowMs,
+    t,
+  );
   if (sevenDay) windows.push(sevenDay);
   for (const scoped of snapshot.scoped ?? []) {
     const usage = toClaudeWindowUsage(
       t('todaySpend.claude.modelWeeklyLabel', { model: scoped.modelDisplayName }),
       scoped,
+      nowMs,
+      t,
     );
     if (usage) windows.push(usage);
   }
@@ -680,10 +688,16 @@ function buildClaudeSubscriptionTooltipNode(
       remaining: window.remaining,
       used: window.used,
     });
-    lines.push(window.resetAt
-      ? `${base} · ${t('todaySpend.claude.resetAt', { at: window.resetAt })}`
-      : base,
-    );
+    let resetLabel: string | null = null;
+    if (window.resetAt && window.resetIn) {
+      resetLabel = t('todaySpend.claude.resetInAt', {
+        countdown: window.resetIn,
+        at: window.resetAt,
+      });
+    } else if (window.resetAt) {
+      resetLabel = t('todaySpend.claude.resetAt', { at: window.resetAt });
+    }
+    lines.push(resetLabel ? `${base} · ${resetLabel}` : base);
   }
 
   // tooltip 比 chip 宽一档: allowed_warning (服务端综合全部窗口的模糊信号) 也提示 ——
@@ -1184,9 +1198,9 @@ export function TodaySpendChip({
   );
 
   React.useEffect(() => {
-    // 订阅形态 (codex-oauth / cc+chatgpt bridge / claude 订阅) 的 reset 倒计时文案
-    // 需要随时间走动: 常态分钟级 tick 足够; 任一窗口进入最后一分钟切秒级 tick,
-    // 让「59秒 → 1秒」逐秒跳动。setTimeout 链每次 tick 后按最新窗口重估下一次延迟。
+    // Codex 订阅的 reset 倒计时文案与全部订阅窗口的 resetPending 判定需要随时间走动:
+    // 常态分钟级 tick 足够;任一窗口进入最后一分钟切秒级 tick,让倒计时准确归零,
+    // Claude 稳定窗口名也能及时切到「重置中」。setTimeout 链每次 tick 后重估延迟。
     if (!usesCodexQuotaForm && !isClaudeSubscription) return undefined;
     const delay = computeCountdownTickDelayMs(chipResetsAtMsList, Date.now());
     const timer = window.setTimeout(() => {
@@ -1289,8 +1303,8 @@ export function TodaySpendChip({
       latestTurnUsage,
     );
   } else if (isClaudeSubscription) {
-    // Claude 订阅形态 (方案 B): chip 显示「剩余时长 剩余%」倒计时段 + 本会话价值,
-    // 倒计时由 windowLabelNowMs 驱动 (常态 60s tick, 最后一分钟逐秒); tooltip 保留精确时间。
+    // Claude 订阅形态 (方案 B): chip 显示稳定窗口名 + 剩余% + 本会话价值;
+    // tooltip 保留相对倒计时和精确 reset 时间。
     const chipSegments = [...windowSegments];
     if (sessionEstimatedValueMoney) {
       chipSegments.push(t('todaySpend.claude.sessionValueLabel', {
@@ -1305,6 +1319,7 @@ export function TodaySpendChip({
       modelId,
       sessionEstimatedValueMoney,
       t,
+      windowLabelNowMs,
       usageDashboardLabel,
       latestTurnUsage,
     );

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3028,6 +3028,7 @@
       "modelWeeklyLabel": "{{model}} weekly",
       "windowSegment": "{{label}} {{remaining}} left",
       "resetAt": "resets {{at}}",
+      "resetInAt": "resets in {{countdown}} ({{at}})",
       "windowLine": "{{label}} {{remaining}} left ({{used}} used)",
       "sessionValueLabel": "Session value {{cost}}",
       "planLine": "Plan {{plan}}",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3027,6 +3027,7 @@
       "modelWeeklyLabel": "{{model}} 週間",
       "windowSegment": "{{label}} 残り {{remaining}}",
       "resetAt": "{{at}} にリセット",
+      "resetInAt": "{{countdown}}後にリセット（{{at}}）",
       "windowLine": "{{label}} 残り {{remaining}} (使用済み {{used}})",
       "sessionValueLabel": "このセッションの価値 {{cost}}",
       "planLine": "プラン {{plan}}",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3027,7 +3027,7 @@
       "modelWeeklyLabel": "{{model}} 주간",
       "windowSegment": "{{label}} {{remaining}} 남음",
       "resetAt": "{{at}} 재설정",
-      "resetInAt": "{{countdown}} 후 재설정({{at}})",
+      "resetInAt": "{{countdown}} 후 재설정 ({{at}})",
       "windowLine": "{{label}} 남음 {{remaining}} (사용 {{used}})",
       "sessionValueLabel": "세션 가치 {{cost}}",
       "planLine": "플랜 {{plan}}",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3027,6 +3027,7 @@
       "modelWeeklyLabel": "{{model}} 주간",
       "windowSegment": "{{label}} {{remaining}} 남음",
       "resetAt": "{{at}} 재설정",
+      "resetInAt": "{{countdown}} 후 재설정({{at}})",
       "windowLine": "{{label}} 남음 {{remaining}} (사용 {{used}})",
       "sessionValueLabel": "세션 가치 {{cost}}",
       "planLine": "플랜 {{plan}}",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3027,6 +3027,7 @@
       "modelWeeklyLabel": "{{model}} 周限",
       "windowSegment": "{{label}} 剩余 {{remaining}}",
       "resetAt": "{{at}} 重置",
+      "resetInAt": "{{countdown}}后重置（{{at}}）",
       "windowLine": "{{label}} 剩余 {{remaining}}(已用 {{used}})",
       "sessionValueLabel": "本会话价值 {{cost}}",
       "planLine": "套餐 {{plan}}",


### PR DESCRIPTION
> [!NOTE]
> 本 PR 替代 #438。原 head 仓库在重新 fork 后已脱离 fork network，导致 #438 的 head SHA 冻结、无法继续接收提交。原 review 与讨论仍保留在 #438；产品讨论见 #443。

## 这次改了什么

### 摘要

修正 Claude 订阅用量底栏的窗口标识：底栏稳定显示 `5h 95% left | Weekly 75% left`，不再用重置倒计时替换窗口名；tooltip 则完整显示用量与重置时间，例如 `Weekly 75% left (25% used) · resets in 5h (9:00 PM)`。

根因是原实现把窗口的稳定身份替换成了“距离重置还剩多久”。当周限窗口恰好还剩 5 小时时，Weekly 也会显示成 `5h`，与真正的 5h 窗口无法区分。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Claude 订阅用量窗口标识不准确
- 本 PR 包含：Desktop Renderer 的 Claude 用量 chip / tooltip 文案逻辑、对应单测、zh-CN / en / ja / ko 四语文案
- 明确不包含：订阅后台、用量数据获取、刷新逻辑、Codex 用量展示、布局与视觉样式
- 用户可见变化：底栏保留稳定窗口身份；相对倒计时与绝对重置时刻放入完整 tooltip 行
- 是否存在 breaking change：无

### UI 变化

- 无截图：本次只调整既有底栏与 tooltip 的信息组织及文案，没有改布局、颜色、字号或动效
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §3 Typography Rules / Hierarchy：沿用既有 Small / Micro Label 排版与 `tabular-nums` 样式，不引入新的视觉层级
  - `docs/design-rules/DESIGN.md` §11 Voice & Content：窗口名保持直接、稳定且可区分；四语数字与单位遵循 §11.2
  - `docs/design-rules/DESIGN.md` §10.1 Light / Dark Dual-Mode Delivery Gate：未新增或修改颜色、token 与样式，两种模式继续共用现有实现

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，全部适用 workspace 的单元测试均通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:i18n
结果：通过（仅既有 warning）

相关定向测试
结果：39/39 通过
```

### 手工验证

未执行。

### 未执行的验证

未启动带真实 Anthropic 订阅账号的 Desktop 运行时做截图或视觉走查；当前环境未建立对应在线账号会话。本次已由单测覆盖窗口标签、完整 tooltip 文案与 i18n key。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的 Claude 订阅用量展示与四语文案
- 回滚 / 降级方式：回退本 PR 的功能提交即可恢复原显示逻辑；不涉及数据迁移或持久化格式

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外产品文档）
- [x] 已确认测试结果或说明未执行原因
