### PR TITLE
fix(mobile): compact title-only session rows

### DIFF
--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -145,6 +145,7 @@ const DEVICE_LIST_TIMEOUT_MS = 12_000;
 // 项目组与自动化组展开后的子列表共用同一个预览限量(设备详情页也 import 复用,避免两处漂移)。
 export const PROJECT_PREVIEW_LIMIT = 5;
 const HOME_SESSION_ROW_HEIGHT = 78;
+const HOME_SESSION_SINGLE_LINE_ROW_HEIGHT = 60;
 const CINDY_LIST_GUTTER = 20;
 const CINDY_LIST_ROW_HEIGHT = 60;
 const CINDY_LIST_ROW_GAP = 10;
@@ -2192,6 +2193,9 @@ function HomeSessionRowInner({
   const preview = group
     ? automationGroupPreview(item, group.sessionCount, t)
     : buildRemoteSessionCardPreview(item, { running });
+  // 零消息会话没有摘要。此时不要保留双行列表的空白第二行；但定时任务与置顶
+  // 标记仍占用右下状态槽，因此继续使用双行布局。
+  const showPreviewLine = !!preview?.trim() || showSchedule || showPinned;
   // 组行点击语义对齐桌面版侧边栏:收起且有需关注内容(未读运行 / 待处理)时,点行直接打开
   // 该看的那条会话(共享层 primary:运行中 > 有未读 > 最新);想展开点行首箭头(独立热区)。
   // 无需关注内容或已展开时,点行仍是展开 / 收起。
@@ -2224,6 +2228,7 @@ function HomeSessionRowInner({
         style={({ pressed }) => [
           styles.sessionListRow,
           cindyList && styles.sessionListRowCindy,
+          !showPreviewLine && styles.sessionListRowSingleLine,
           cindyList && inOutlinedGroup && styles.sessionListRowOutlinedGroup,
           cindyList && inOutlinedGroup && groupEnd && styles.sessionListRowOutlinedGroupEnd,
           standaloneCindyCard && styles.sessionListRowCindyCard,
@@ -2258,7 +2263,11 @@ function HomeSessionRowInner({
             )}
           </Pressable>
         ) : null}
-        <View style={[styles.sessionIconCell, cindyList && styles.sessionIconCellCindy]}>
+        <View style={[
+          styles.sessionIconCell,
+          cindyList && styles.sessionIconCellCindy,
+          !showPreviewLine && styles.sessionIconCellSingleLine,
+        ]}>
           <SessionStatusMark
             active={running || attention}
             item={item}
@@ -2310,30 +2319,32 @@ function HomeSessionRowInner({
               </View>
             )}
           </View>
-          <View style={[styles.sessionPreviewRow, cindyList && styles.sessionPreviewRowCindy]}>
-            <Text
-              ellipsizeMode="tail"
-              numberOfLines={1}
-              style={[styles.sessionPreview, cindyList && styles.sessionPreviewCindy]}
-              testID={`home.sessionRowPreview.${item.session.id}`}
-            >
-              {preview}
-            </Text>
-            {showSchedule || showPinned ? (
-              // 组行与单次自动化会话行同款标记:Timer 放右下(时间下方的尾部图标位),
-              // 行首保留正常的会话状态图标(primary 运行的 vendor / 运行态)。
-              <View style={[styles.sessionTrailingIcons, cindyList && styles.sessionTrailingIconsCindy]}>
-                {showSchedule ? (
-                  <AutomationTimerIcon
-                    paused={scheduleStopped}
-                    size={cindyList ? iconSize.xs : iconSize.lg}
-                    testID={`home.sessionAutomationTimer.${item.session.id}`}
-                  />
-                ) : null}
-                {showPinned ? <Pin color={colors.textTertiary} size={cindyList ? iconSize.xs : iconSize.lg} strokeWidth={iconStroke.thin} /> : null}
-              </View>
-            ) : null}
-          </View>
+          {showPreviewLine ? (
+            <View style={[styles.sessionPreviewRow, cindyList && styles.sessionPreviewRowCindy]}>
+              <Text
+                ellipsizeMode="tail"
+                numberOfLines={1}
+                style={[styles.sessionPreview, cindyList && styles.sessionPreviewCindy]}
+                testID={`home.sessionRowPreview.${item.session.id}`}
+              >
+                {preview}
+              </Text>
+              {showSchedule || showPinned ? (
+                // 组行与单次自动化会话行同款标记:Timer 放右下(时间下方的尾部图标位),
+                // 行首保留正常的会话状态图标(primary 运行的 vendor / 运行态)。
+                <View style={[styles.sessionTrailingIcons, cindyList && styles.sessionTrailingIconsCindy]}>
+                  {showSchedule ? (
+                    <AutomationTimerIcon
+                      paused={scheduleStopped}
+                      size={cindyList ? iconSize.xs : iconSize.lg}
+                      testID={`home.sessionAutomationTimer.${item.session.id}`}
+                    />
+                  ) : null}
+                  {showPinned ? <Pin color={colors.textTertiary} size={cindyList ? iconSize.xs : iconSize.lg} strokeWidth={iconStroke.thin} /> : null}
+                </View>
+              ) : null}
+            </View>
+          ) : null}
         </View>
       </Pressable>
       {group && groupExpanded ? (
@@ -3023,6 +3034,9 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     height: CINDY_LIST_ROW_HEIGHT,
     paddingLeft: 18,
   },
+  sessionListRowSingleLine: {
+    height: HOME_SESSION_SINGLE_LINE_ROW_HEIGHT,
+  },
   sessionListRowCindyCard: {
     borderColor: colors.border,
     borderRadius: radius.container,
@@ -3122,6 +3136,10 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   sessionIconCellCindy: {
     paddingTop: 14,
     width: iconSize.md,
+  },
+  sessionIconCellSingleLine: {
+    justifyContent: 'center',
+    paddingTop: 0,
   },
   sessionGroupChevronCell: {
     // 自动化组行行首的展开箭头列:与项目组行首 chevron 对齐(尺寸 22、次级色),

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -284,6 +284,10 @@ describe('mobile home desktop-first surface', () => {
     expect(sessionRowSource).toContain('numberOfLines={1}');
     expect(sessionRowSource).toContain('buildRemoteSessionCardPreview(item, { running })');
     expect(sessionRowSource).toContain('testID={`home.sessionRowPreview.${item.session.id}`}');
+    expect(sessionRowSource).toContain('const showPreviewLine = !!preview?.trim() || showSchedule || showPinned;');
+    expect(sessionRowSource).toContain('!showPreviewLine && styles.sessionListRowSingleLine');
+    expect(sessionRowSource).toContain('!showPreviewLine && styles.sessionIconCellSingleLine');
+    expect(sessionRowSource).toContain('{showPreviewLine ? (');
     expect(sessionRowSource).not.toContain('numberOfLines={2}');
     // 相对时间下沉到独家订阅分钟心跳的叶子组件(行主体 memo 化后由它单独保鲜,风暴修复)
     expect(sessionRowSource).toContain('<SessionRelativeTime lastActivityAt={item.lastActivityAt}');
@@ -305,12 +309,14 @@ describe('mobile home desktop-first surface', () => {
     expect(automationTimerSource).toContain('borderColor: colors.border');
     expect(sessionRowSource).not.toContain('SessionBadge');
     expect(source).toContain('const HOME_SESSION_ROW_HEIGHT = 78;');
+    expect(source).toContain('const HOME_SESSION_SINGLE_LINE_ROW_HEIGHT = 60;');
     expect(source).toContain('const CINDY_LIST_ROW_HEIGHT = 60;');
     // 用户改稿 2026-07-21:列表首页回退 XD-MAKER 通栏样式(legacy 变体),色彩体系沿用 07-20 定稿。
     expect(source).toContain('variant="legacy"');
     expect(source).not.toContain('variant="cindyList"');
     expect(source).toContain("type HomeSessionRowVariant = 'legacy' | 'cindyList';");
     expect(stylesSource).toContain('height: HOME_SESSION_ROW_HEIGHT');
+    expect(stylesSource).toContain('height: HOME_SESSION_SINGLE_LINE_ROW_HEIGHT');
     expect(stylesSource).toContain('height: CINDY_LIST_ROW_HEIGHT');
     expect(stylesSource).toContain('height: lineHeight.micro');
     // 通栏回退:项目子行回 surface 全宽底(用户改稿 2026-07-21)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 iOS 会话列表中仅有标题、没有摘要时仍保留空白第二行的问题。标题-only 行改为 60pt 并垂直居中；有摘要、定时任务或置顶标记的行继续保持原 78pt 双行布局。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：iOS 会话列表仅标题 item 布局优化
- 本 PR 包含：会话行的单行布局判定、60pt 单行高度、图标垂直居中及对应回归测试
- 明确不包含：Desktop、插件、服务端、原生配置或其他 Mobile 功能改动
- 用户可见变化：仅标题会话不再显示空白摘要行，列表更紧凑
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Layout Principles（保持最小、清晰的布局层级）；`apps/mobile/docs/mobile-design-guide.md` §1 视觉哲学中的“手机只做减法”，以及 §5 触控目标 ≥ 44×44。单行行高为 60pt，仍满足触控目标；颜色继续复用现有主题 token，因此 Light/Dark 行为不变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/homeDesktopFirst.test.ts
结果：12 tests passed

pnpm check:dco
结果：通过，1 commit signed off

git diff --check
结果：通过
```

### 手工验证

不涉及：本隔离 worktree 未启动 iOS 模拟器。

### 未执行的验证

未执行 iOS/Android 实机视觉验证；需要在 CI 构建或开发环境中确认列表观感。由于该行组件为 React Native 共享实现，Android 会同步获得相同的紧凑布局，但本 PR 聚焦用户报告的 iOS 问题。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 会话列表的标题-only 行；共享实现会同时作用于 iOS 与 Android。不修改原生配置，不改变 runtime fingerprint。
- 回滚 / 降级方式：回退本提交即可恢复固定 78pt 双行布局。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不需要额外文档；已补回归测试）
- [x] 已确认测试结果或说明未执行原因