### PR TITLE
fix(desktop): 修复工作中插话快捷键竞态

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -23,11 +23,20 @@ describe('ChatInput steer shortcut contract', () => {
       '// Plain Enter keeps the existing queue semantics.',
       'return true;\n        }\n        return false;',
     );
+    const windowComposerSteerBlock = extractBetween(
+      windowKeydownBlock,
+      'if (\n        showStopButtonRef.current &&',
+      "if (\n        currentState === 'listening'",
+    );
+    const editorSteerChoice = extractBetween(
+      editorEnterBlock,
+      'const wantsSteer =',
+      "void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');",
+    );
 
     expect(chatInputSource).toContain('const composerCanSubmitRef = useRef(false);');
     expect(chatInputSource).toContain('composerCanSubmitRef.current = !sendButtonDisabled;');
     expect(windowKeydownBlock).toContain('showStopButtonRef.current');
-    expect(windowKeydownBlock).toContain('composerCanSubmitRef.current');
     expect(windowKeydownBlock).toContain('isComposerEnterTarget(event.target)');
     expect(windowKeydownBlock).toContain("event.key === 'Enter'");
     expect(windowKeydownBlock).toContain('event.metaKey || event.ctrlKey');
@@ -39,11 +48,15 @@ describe('ChatInput steer shortcut contract', () => {
     expect(chatInputSource).toContain('turnRunning={showStopButton}');
     expect(chatInputSource).toContain('onSteer={onQueueSteer ? handleQueueSteer : undefined}');
     expect(editorEnterBlock).toContain("event.key === 'Enter' && !event.shiftKey && !event.altKey");
-    expect(editorEnterBlock).toContain('composerCanSubmitRef.current');
     expect(editorEnterBlock).toContain("voiceInputStateRef.current !== 'listening'");
     expect(editorEnterBlock).toContain(
       "void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');",
     );
+    // Tiptap's document is current before React's send-button effect updates
+    // composerCanSubmitRef. The shortcut must not use that lagging UI mirror
+    // to choose between steer and normal queue delivery.
+    expect(windowComposerSteerBlock).not.toContain('composerCanSubmitRef.current');
+    expect(editorSteerChoice).not.toContain('composerCanSubmitRef.current');
   });
 
   it('steers without an interrupt confirmation gate (same-turn injection)', () => {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1974,10 +1974,14 @@ export function ChatInput({
             void voiceInputStopAndSendRef.current(deliveryMode);
             return true;
           }
+          // Do not gate the delivery choice on composerCanSubmitRef here.
+          // Tiptap updates its document synchronously, while that ref mirrors
+          // sendButtonDisabled from a later React effect. A quick Cmd/Ctrl+Enter
+          // after typing could otherwise observe the previous empty state and
+          // incorrectly enqueue instead of steering the running turn.
           const wantsSteer =
             (event.metaKey || event.ctrlKey) &&
             showStopButtonRef.current &&
-            composerCanSubmitRef.current &&
             voiceInputStateRef.current !== 'listening';
           void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');
           return true;
@@ -2347,7 +2351,6 @@ export function ChatInput({
 
       if (
         showStopButtonRef.current &&
-        composerCanSubmitRef.current &&
         isComposerEnterTarget(event.target) &&
         event.key === 'Enter' &&
         (event.metaKey || event.ctrlKey) &&


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 会话正在工作时，用户刚输入文本便立即按 Cmd/Ctrl+Enter，快捷键偶发读取到上一帧“不可发送”状态并把文本错误排入输入框上方队列的问题。快捷键现在只根据组合键和当前 turn 是否运行来选择插话语义，实际发送校验仍由既有发送链路负责。

同时补充回归断言，防止快捷键重新依赖由 React effect 延迟同步的 composerCanSubmitRef。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户反馈 Desktop 工作状态下 Cmd+Enter 偶发排队且再次按键无响应
- 本 PR 包含：输入框 Cmd/Ctrl+Enter 分流修复；对应回归测试
- 明确不包含：队列 UI、发送按钮样式、普通 Enter 排队语义、语音输入流程
- 用户可见变化：工作中快速输入后按 Cmd/Ctrl+Enter 会稳定执行插话，不再偶发挂到输入框上方
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.3 Keyboard & IME；不涉及视觉、布局、文案或主题样式，仅修复既有快捷键行为与提示不一致的问题

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/chatInputSteerShortcut.test.ts src/renderer/__tests__/pendingQueueSteerShortcut.test.ts src/renderer/__tests__/voiceInputEnterToSend.test.ts
结果：3 files / 15 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit -- --workspace-concurrency=1
结果：全部 workspace 通过

pnpm check:dco
结果：1 commit signed off
```

首次完整单测中 `src/main/git-review/__tests__/stageOps.test.ts` 有一项在 30 秒处偶发超时；该文件单独重跑 19 项全部通过，随后完整门禁串行 workspace 重跑全部通过，测试范围未减少。

### 手工验证

未在独立 PR worktree 内启动 Desktop；原 checkout 的 Renderer 已通过 HMR 加载同一逻辑修复。

### 未执行的验证

未做亮色/暗色视觉走查：本次没有视觉或样式变化。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop 会话运行中、焦点位于 composer 或发送按钮时的 Cmd/Ctrl+Enter 分流
- 回滚 / 降级方式：回滚本提交即可恢复原行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因