### PR TITLE
fix(settings): limit Slack conversation model list to six rows

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -350,10 +350,21 @@ import {
   ModelSelector,
   ModelSelectorContent,
   modelEffortLabel,
+  modelListMaxHeightForRows,
 } from '@/components/new-chat/ModelSelector';
 import { makerChatStore } from '@/lib/makerChatStore';
 
 describe('ModelSelector trigger variants', () => {
+  it('keeps row-count caps finite and within the shared 300px ceiling', () => {
+    expect(modelListMaxHeightForRows()).toBeUndefined();
+    expect(modelListMaxHeightForRows(Number.NaN)).toBeUndefined();
+    expect(modelListMaxHeightForRows(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(modelListMaxHeightForRows(0)).toBe(44);
+    expect(modelListMaxHeightForRows(6)).toBe(274);
+    expect(modelListMaxHeightForRows(7)).toBe(300);
+    expect(modelListMaxHeightForRows(100)).toBe(300);
+  });
+
   it('shows the intent model and its default source after registering an agent switch', () => {
     const sessionId = 'model-selector-agent-switch-intent';
     providersRef.providers = [
@@ -1088,11 +1099,14 @@ describe('ModelSelector trigger variants', () => {
           vendorKey: 'cc',
           currentProviderId: 'xd',
           onProviderChange: vi.fn(),
+          maxVisibleModelRows: 6,
         }),
       );
 
       // 行内折后价在上、标准价划线在下,折价徽标挂在模型名一侧的 tags 区。
       const row = screen.getByRole('option', { name: /Qwen 3\.7/ });
+      expect(row.className).toContain('min-h-11');
+      expect(screen.getByRole('listbox', { name: 'Model list' }).style.maxHeight).toBe('274px');
       expect(row.textContent).toContain('¥6 / ¥18');
       expect(row.textContent).toContain('¥12 / ¥36');
       const rowBadge = within(row).getByText('立省 50%');

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -89,6 +89,19 @@ const PROVIDER_TITLE_KEY: Record<string, string> = {
 
 // 配置面板锚在主菜单内缩 8px 的模型行上；补偿这段内缩，让两块面板贴边但不重叠。
 const MODEL_OPTIONS_SIDE_OFFSET = 8;
+const MODEL_LIST_DEFAULT_MAX_HEIGHT_PX = 300;
+// 折扣模型的价格会叠成两行：27.5px 价格栈 + 16px 纵向 padding，向上取整为 44px。
+const MODEL_LIST_CONSTRAINED_ROW_HEIGHT_PX = 44;
+const MODEL_LIST_ROW_GAP_PX = 2;
+
+export function modelListMaxHeightForRows(maxVisibleRows?: number): number | undefined {
+  if (maxVisibleRows === undefined || !Number.isFinite(maxVisibleRows)) return undefined;
+  const rows = Math.max(1, Math.floor(maxVisibleRows));
+  return Math.min(
+    MODEL_LIST_DEFAULT_MAX_HEIGHT_PX,
+    rows * MODEL_LIST_CONSTRAINED_ROW_HEIGHT_PX + Math.max(0, rows - 1) * MODEL_LIST_ROW_GAP_PX,
+  );
+}
 
 function providerDisplayName(p: ProviderView, t: (key: string) => string): string {
   const key = PROVIDER_TITLE_KEY[p.id];
@@ -453,6 +466,7 @@ function ModelSelectorContentView({
   pricing,
 }: ModelSelectorContentProps & { pricing: ModelPricingCatalog | null }) {
   const { t } = useTranslation();
+  const constrainedListMaxHeight = modelListMaxHeightForRows(maxVisibleModelRows);
   // session-agent-switch:两步式引擎切换的浏览态。browseVendor 初始 = 会话当前引擎;
   // 切到另一家 tab 只是「浏览目标引擎的模型」,选中模型行才真正触发切换事务。
   const [browseVendor, setBrowseVendor] = useState<'cc' | 'codex'>(
@@ -1221,6 +1235,7 @@ function ModelSelectorContentView({
             }}
             className={cn(
               'flex w-full cursor-pointer items-center justify-between rounded-[8px] px-3 py-2',
+              constrainedListMaxHeight !== undefined && 'min-h-11',
               'transition-colors duration-100 hover:bg-[var(--model-item-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
               isSelected && 'bg-[var(--model-item-hover)]',
               isEditingThis &&
@@ -1453,12 +1468,9 @@ function ModelSelectorContentView({
         // 行宽与有滚动时一致(否则行会比搜索框宽 8px);细滚动条见 globals.css
         className="morph-panel-list-scroll -mr-2 flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
         style={
-          maxVisibleModelRows === undefined
+          constrainedListMaxHeight === undefined
             ? undefined
-            : {
-                // 标准模型行 = 20px 字高 + 上下各 8px padding；行间 gap 为 2px。
-                maxHeight: `${Math.max(1, Math.floor(maxVisibleModelRows)) * 36 + Math.max(0, Math.floor(maxVisibleModelRows) - 1) * 2}px`,
-              }
+            : { maxHeight: `${constrainedListMaxHeight}px` }
         }
         role="listbox"
         aria-label="Model list"

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -314,6 +314,11 @@ interface ModelSelectorProps {
   useMorphPopover?: boolean;
   /** Popover 弹出方向,默认 "top"（底部工具栏向上弹），dialog 内嵌场景传 "bottom"。 */
   popoverSide?: 'top' | 'bottom';
+  /**
+   * 模型列表最多露出的标准行数；超出后列表自身滚动。
+   * 不传时沿用通用面板的 300px 上限，供 Settings 等紧凑场景按行数收窄。
+   */
+  maxVisibleModelRows?: number;
   /** 关闭模型的 effort / Fast 编辑入口；只选择模型 id 的设置项使用。 */
   configurationEnabled?: boolean;
   /** 可选的列表首行兜底值，例如“不指定（使用原逻辑）”。 */
@@ -371,6 +376,8 @@ interface ModelSelectorContentProps {
   excludeChatBridgedCodex?: boolean;
   /** 选中后是否自动关闭。Popover 场景传入,内嵌场景不传。 */
   onDismiss?: () => void;
+  /** 语义同 ModelSelectorProps.maxVisibleModelRows。 */
+  maxVisibleModelRows?: number;
   /** 模型信息 / 选项浮层的额外样式。供嵌套在高层级 overlay 中的调用方覆盖默认 z-index。 */
   overlayContentClassName?: string;
   currentProviderId?: string | null;
@@ -432,6 +439,7 @@ function ModelSelectorContentView({
   excludeSubscriptionDirect,
   excludeChatBridgedCodex,
   onDismiss,
+  maxVisibleModelRows,
   overlayContentClassName,
   currentProviderId,
   onProviderChange,
@@ -1444,6 +1452,14 @@ function ModelSelectorContentView({
         // -mr-2 把滚动条挪进面板右侧 8px 留白;scrollbar-gutter:stable 让无滚动时
         // 行宽与有滚动时一致(否则行会比搜索框宽 8px);细滚动条见 globals.css
         className="morph-panel-list-scroll -mr-2 flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
+        style={
+          maxVisibleModelRows === undefined
+            ? undefined
+            : {
+                // 标准模型行 = 20px 字高 + 上下各 8px padding；行间 gap 为 2px。
+                maxHeight: `${Math.max(1, Math.floor(maxVisibleModelRows)) * 36 + Math.max(0, Math.floor(maxVisibleModelRows) - 1) * 2}px`,
+              }
+        }
         role="listbox"
         aria-label="Model list"
         onScroll={() => {
@@ -1513,6 +1529,7 @@ export function ModelSelector({
   visualVariant = 'default',
   useMorphPopover = false,
   popoverSide = 'top',
+  maxVisibleModelRows,
   configurationEnabled = true,
   fallbackOption,
   reselectEmitsChange = false,
@@ -1946,6 +1963,7 @@ export function ModelSelector({
       excludeSubscriptionDirect={excludeSubscriptionDirect}
       excludeChatBridgedCodex={excludeChatBridgedCodex}
       onDismiss={() => setOpen(false)}
+      maxVisibleModelRows={maxVisibleModelRows}
       currentProviderId={currentProviderId}
       onProviderChange={onProviderChange}
       onNavigateToProviders={onNavigateToProviders}

--- a/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
@@ -665,7 +665,10 @@ export function HookConnectionsSection() {
    * 渠道切换 chip。用普通函数而非内联子组件渲染: 内联组件每次渲染都会
    * 重建类型导致子树 remount, 别名输入框会在输入中途失焦。
    */
-  const renderWorkdirSection = (prefsState: ReturnType<typeof useHookWorkspacePrefs>) => (
+  const renderWorkdirSection = (
+    prefsState: ReturnType<typeof useHookWorkspacePrefs>,
+    chatMaxVisibleModelRows?: number,
+  ) => (
     <>
       <div className="h-px w-full bg-[var(--border-default)]" />
       <div className="flex flex-col gap-1.5">
@@ -733,7 +736,11 @@ export function HookConnectionsSection() {
               {t('settings.tina.chat.description')}
             </span>
           </div>
-          <WorkspacePrefsEditor alias={HOOK_CHAT_WORKSPACE_ALIAS} state={prefsState} />
+          <WorkspacePrefsEditor
+            alias={HOOK_CHAT_WORKSPACE_ALIAS}
+            state={prefsState}
+            maxVisibleModelRows={chatMaxVisibleModelRows}
+          />
         </div>
         {rows.map((row, i) => (
           <div
@@ -1075,7 +1082,7 @@ export function HookConnectionsSection() {
           ) : null}
 
           {/* 工作目录映射(清单共享, 偏好取 Slack 那份) */}
-          {hook.enabled ? renderWorkdirSection(slackPrefsState) : null}
+          {hook.enabled ? renderWorkdirSection(slackPrefsState, 6) : null}
         </div>
       </ImChannelSettingsCard>
 

--- a/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookWorkspacePrefsEditor.tsx
@@ -496,9 +496,11 @@ function toAgentKind(vendor: MakerVendor): KnownAgent {
 export function WorkspacePrefsEditor({
   alias,
   state,
+  maxVisibleModelRows,
 }: {
   alias: string;
   state: HookWorkspacePrefsState;
+  maxVisibleModelRows?: number;
 }) {
   const { t } = useTranslation();
   const claudeCaps = useAgentCapabilities('claude-code');
@@ -574,6 +576,7 @@ export function WorkspacePrefsEditor({
           vendorKey={vendorKey}
           triggerVariant="field"
           popoverSide="bottom"
+          maxVisibleModelRows={maxVisibleModelRows}
           dense
           // 可及名上下文与 agent 分段同规则(字段名 · 行别名),多卡片同屏读屏可区分。
           ariaContext={`${t('settings.tina.prefs.modelLabel')} · ${alias}`}

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
@@ -18,6 +18,7 @@ const ipc = vi.hoisted(() => ({
   openExternal: vi.fn(),
 }));
 const dialog = vi.hoisted(() => ({ confirm: vi.fn() }));
+const workspacePrefsEditor = vi.hoisted(() => ({ render: vi.fn() }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -66,7 +67,10 @@ vi.mock('../HookWorkspacePrefsEditor', () => ({
     selectTeam: vi.fn(),
     showTeamChip: false,
   }),
-  WorkspacePrefsEditor: () => null,
+  WorkspacePrefsEditor: (props: { alias: string; maxVisibleModelRows?: number }) => {
+    workspacePrefsEditor.render(props);
+    return null;
+  },
 }));
 
 import { deriveAlias, HookConnectionsSection, workspaceRowsToMap } from '../HookConnectionsSection';
@@ -149,6 +153,31 @@ describe('HookConnectionsSection Telegram binding actions', () => {
     expect(workspaceRowsToMap([{ alias: ' repo ', dir: ' /tmp/repo ' }])).toEqual({
       repo: '/tmp/repo',
     });
+  });
+
+  it('limits only the Slack built-in chat model list to six visible rows', async () => {
+    ipc.get.mockResolvedValue({
+      hook: {
+        ...BASE_HOOK,
+        enabled: true,
+        status: 'connected',
+      },
+    });
+
+    render(<HookConnectionsSection />);
+    await expandChannelCard(SLACK_CARD);
+    await waitFor(() =>
+      expect(workspacePrefsEditor.render).toHaveBeenCalledWith(
+        expect.objectContaining({ alias: 'chat', maxVisibleModelRows: 6 }),
+      ),
+    );
+
+    workspacePrefsEditor.render.mockClear();
+    await expandChannelCard(TELEGRAM_CARD);
+    await waitFor(() => expect(workspacePrefsEditor.render).toHaveBeenCalled());
+    expect(workspacePrefsEditor.render).toHaveBeenCalledWith(
+      expect.objectContaining({ alias: 'chat', maxVisibleModelRows: undefined }),
+    );
   });
 
   it('offers an explicit link action when Telegram is enabled but unbound', async () => {

--- a/apps/desktop/src/renderer/components/settings/__tests__/WorkspacePrefsEditorRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/WorkspacePrefsEditorRendering.test.tsx
@@ -44,6 +44,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
     effort: string;
     vendorKey: string;
     triggerVariant?: string;
+    maxVisibleModelRows?: number;
     disabled?: boolean;
     onProviderChange?: (providerId: string | null, modelId?: string) => void;
     onModelChange: (modelId: string) => void;
@@ -57,6 +58,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
       data-effort={props.effort}
       data-vendor={props.vendorKey}
       data-trigger-variant={props.triggerVariant}
+      data-max-visible-model-rows={props.maxVisibleModelRows}
       data-disabled={String(props.disabled)}
       data-aria-context={props.ariaContext ?? ''}
       // onProviderChange 是「供应商分段模式」的开关(ModelSelector 内部
@@ -126,7 +128,7 @@ afterEach(() => {
 
 describe('WorkspacePrefsEditor 复用标准选择器', () => {
   it('三个字段分别落在标准组件上,且都用 field 形态', () => {
-    render(<WorkspacePrefsEditor alias="cindy" state={stateWith()} />);
+    render(<WorkspacePrefsEditor alias="cindy" state={stateWith()} maxVisibleModelRows={6} />);
 
     // agent: VendorSegmentedSwitcher 的品牌分段(真实渲染),不再是露原始 id 的下拉
     const tablist = screen.getByRole('tablist', { name: 'settings.tina.prefs.agentLabel · cindy' });
@@ -138,6 +140,7 @@ describe('WorkspacePrefsEditor 复用标准选择器', () => {
     expect(model.getAttribute('data-model')).toBe('claude-opus-4-8');
     expect(model.getAttribute('data-vendor')).toBe('cc');
     expect(model.getAttribute('data-trigger-variant')).toBe('field');
+    expect(model.getAttribute('data-max-visible-model-rows')).toBe('6');
 
     const permission = screen.getByTestId('permission-selector');
     expect(permission.getAttribute('data-mode')).toBe('bypassPermissions');


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop「设置 → IM 机器人 → 官方 → Slack → 对话」中的模型选择器高度失控问题。

当模型目录较长时，该下拉此前会一次露出过多模型行，遮挡 Slack 设置和同一张卡片里的其他偏好字段。本 PR 为通用 `ModelSelector` 增加可选的“最大可见模型行数”能力，并只在 Slack 的内置 `chat` 对话行传入 6：前 6 行直接可见，后续模型在原列表容器内纵向滚动。

实现继续复用现有模型选择器、搜索、来源、推理强度、Fast 配置和滚动条样式，没有另造一套设置页下拉。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #578
- 本 PR 包含：
  - 为 `ModelSelector` / `ModelSelectorContentView` 增加可选的 `maxVisibleModelRows` 展示参数。
  - 受限场景统一使用可容纳双行折扣价格的 44px 最小行高，并按 2px 行间距计算列表高度；6 行为 274px，且始终不突破既有 300px 上限。
  - 仅在 Slack 工作目录区域的内置「对话（chat）」行传入 6。
  - 增加装配层回归断言，锁定 Slack 内置对话传递 6 行限制，并确认 Telegram 内置对话不受影响。
  - 增加非有限值、零值、超大行数、300px 封顶及双行折扣价格的边界测试。
- 明确不包含：不修改 Telegram、真实工作目录行、聊天输入框、调度任务等其他模型选择器的既有高度；不改模型目录、来源路由、IM 协议或偏好持久化。
- 用户可见变化：Slack「对话」模型列表最多同时露出 6 行，更多模型通过列表内部滚动访问。
- 是否存在 breaking change：无。

### UI 变化

- Desktop / macOS：模型弹层的结构、宽度、颜色、圆角和交互保持不变，仅收窄 Slack「对话」场景的模型列表可视高度。
- 未附新增截图：本次没有新增视觉元素，问题表现和目标范围见 #578；手工实机目检列在“未执行的验证”。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4「Component Stylings」→「Select & Dropdown」：继续复用标准选择器与绑定 trigger 宽度的面板结构，只调整列表内部可滚动区域。
  - `docs/design-rules/DESIGN.md` §5「Layout Principles」→「Whitespace Philosophy」：限制长列表对设置页内容的遮挡，保持紧凑设置卡片的可读上下文。
  - `docs/design-rules/DESIGN.md` §10「Theme System & Token Reference」→「Light / Dark Dual-Mode Delivery Gate」：未引入颜色或主题条件分支，继续使用既有语义 token 与 themed 滚动条，Light / Dark 行为一致。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：通过。

pnpm build
结果：通过；Electron Forge 成功生成 darwin/arm64 zip 产物。

GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false pnpm test:unit
结果：通过；全部 required unit workspace 通过。
说明：首次直接运行继承了本机 tag.gpgSign 配置，Desktop git-review 的 5 个临时 tag 用例因无交互 EDITOR 失败；用进程级配置隔离该本机偏好后完整重跑通过，未修改仓库配置或测试代码。

git diff --check
结果：通过。

pnpm check:dco
结果：通过；2 个提交的 Signed-off-by 与 author 一致。
```

### 手工验证

不涉及自动数据迁移或后台行为；未在运行中的 Desktop 实例做额外点击验证。

### 未执行的验证

- 未做 Light / Dark 实机目检：改动复用现有 themed 面板与滚动条，没有新增颜色或主题分支。
- 未做 Windows / Linux 实机验证：改动仅为 Renderer DOM 高度与 overflow 行为，不涉及平台 API。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Slack 内置「对话」行的模型列表最大高度。模型选中、搜索、配置与持久化路径不变。
- 回滚 / 降级方式：移除 Slack 装配层的 `maxVisibleModelRows={6}` 即恢复原高度；通用可选参数未传时仍沿用原有 300px 上限。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果并说明未执行项

