### PR TITLE
fix(desktop): preserve versionless exemption for direct builds

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Cindy",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Cindy desktop client (真实版本号在 release 时由脚本通过 APP_VERSION 注入,见 forge.config.ts)",
   "main": ".vite/build/index.js",
   "private": true,

--- a/apps/desktop/scripts/ci/lib.mjs
+++ b/apps/desktop/scripts/ci/lib.mjs
@@ -178,7 +178,8 @@ export function exec(cmd, opts = {}) {
 // ── package.json 版本号写入 (退出时自动恢复) ────────────────────────────────
 //
 // electron-packager 会把 package.json 拷到 asar 内部，运行时 app.getVersion()
-// 优先读那里。占位符 0.0.0-dev 不改的话热更新版本比较全部失真。
+// 优先读那里。源码里的 0.0.0 是版本无关构建哨兵；正式打包必须在 forge
+// 运行前临时写入真实版本，否则发布包会被 updateService 当成本地包而跳过更新。
 // 任何 exit / SIGINT / SIGTERM 都恢复，保证 git 工作区干净。
 
 const PACKAGE_JSON_PATH = path.join(DESKTOP_ROOT, 'package.json');

--- a/scripts/__tests__/package-args.test.mjs
+++ b/scripts/__tests__/package-args.test.mjs
@@ -1,16 +1,26 @@
 // 桌面打包参数解析与产物架构命名的单测（apps/desktop/scripts/ci/package-lib.mjs）。
 //
 // 这层是「在哪台机器上能打出哪个包、包叫什么名字」的唯一判定点，错了会直接
-// 顶着错误的架构后缀发出安装包。用 node 内置 test runner，不依赖 vitest：
-// 被测模块是纯函数、零 IO，可直接 `node --test scripts/__tests__/`。
+// 顶着错误的架构后缀发出安装包。用 node 内置 test runner，不依赖 vitest。
+// 被测逻辑以纯函数为主，版本占位契约包含少量仓库内文件 IO。
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 
 import {
   PLATFORM_ARCHS,
+  VERSIONLESS_VERSION,
   debianArch,
   parsePackageArgs,
 } from '../../apps/desktop/scripts/ci/package-lib.mjs';
+
+test('Desktop 默认版本与 versionless 打包哨兵一致', () => {
+  const desktopPackageJson = JSON.parse(fs.readFileSync(
+    new URL('../../apps/desktop/package.json', import.meta.url),
+    'utf8',
+  ));
+  assert.equal(desktopPackageJson.version, VERSIONLESS_VERSION);
+});
 
 test('PLATFORM_ARCHS: linux 支持 x64 与 arm64', () => {
   assert.deepEqual([...PLATFORM_ARCHS.linux].sort(), ['arm64', 'x64']);


### PR DESCRIPTION
## 这次改了什么

### 摘要

让直接执行 `pnpm build` / `electron-forge make` 生成的 Desktop 包继续使用 `0.0.0` versionless 哨兵，从而正确跳过正式更新流程。此前 `release:package` 会临时写入哨兵，但直接 Forge 构建沿用了 `package.json` 中的 `1.0.0`，导致 macOS / Windows 本地包被误认为正式版本。

同时补充契约测试，锁定 Desktop 默认版本与 `VERSIONLESS_VERSION` 必须一致，并更新正式发布临时写入版本的注释。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #508
- 本 PR 包含：
  - 将 Desktop 源码默认版本从 `1.0.0` 改为 versionless 哨兵 `0.0.0`
  - 修正 `writePackageVersion` 附近过期的 `0.0.0-dev` 注释
  - 增加默认版本与共享哨兵一致的回归测试
- 明确不包含：不扩大 `isVersionlessAppVersion` 的豁免范围；`1.0.0` 仍被视为真实版本
- 用户可见变化：直接构建的本地 Desktop 包报告版本 `0.0.0`，且不再进入正式自动更新流程
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及 UI、视觉、交互或文案变化

## 怎么验证的

### 自动验证

```text
node --test scripts/__tests__/package-args.test.mjs
结果：10 tests passed

pnpm --filter desktop exec vitest run src/main/__tests__/updateService.test.ts
结果：16 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：完整仓库单元测试门禁通过

pnpm --filter desktop build
结果：macOS arm64 electron-forge make 成功
```

### 手工验证

- macOS arm64：检查直接构建产物 `Cindy.app/Contents/Info.plist`，`CFBundleShortVersionString` 为 `0.0.0`
- macOS arm64：解包直接构建产物的 `app.asar/package.json`，`version` 为 `0.0.0`

### 未执行的验证

- 未在 Windows / Linux 主机上实际打包；默认 `package.json` 版本与跨平台共享的 `VERSIONLESS_VERSION` 由同一契约测试覆盖

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：Desktop 自动更新版本识别

### 影响与回滚

- 更新器改动已与 owner 确认。
- 影响范围：macOS / Windows / Linux 直接 Forge 构建的包使用 `0.0.0`；正式 `release:package` 仍会在 Forge 执行前临时写入真实发布版本，因此正式更新链路不变。
- 回滚 / 降级方式：回滚本 PR 即可恢复旧的默认版本；不涉及数据库、协议或用户数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
