### PR TITLE
fix(desktop): 支持 Kimi K3 Chat 图片桥接

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -24,6 +24,7 @@ const mockState = vi.hoisted(() => {
       error: vi.fn(),
     },
     createAnthropicCompatProxy: vi.fn(),
+    createResponsesChatHandler: vi.fn(() => ({ handle: vi.fn(async () => undefined) })),
     injectionTransform: vi.fn<(body: unknown, ctx: unknown) => unknown | null>(() => null),
     stripNonAnthropicFields: vi.fn<(body: unknown, ctx: unknown) => unknown | null>(() => null),
     recordXaiRateLimitSnapshot: vi.fn(),
@@ -99,9 +100,14 @@ vi.mock('@cindy/anthropic-compat-proxy', () => ({
   },
 }));
 
+vi.mock('@cindy/responses-chat-bridge', () => ({
+  createResponsesChatHandler: mockState.createResponsesChatHandler,
+}));
+
 async function freshCodexProxyHost() {
   vi.resetModules();
   mockState.createAnthropicCompatProxy.mockReset();
+  mockState.createResponsesChatHandler.mockClear();
   mockState.createInstructionsInjectionTransform.mockClear();
   mockState.injectionTransform.mockReset();
   mockState.injectionTransform.mockReturnValue(null);
@@ -264,6 +270,82 @@ describe('decideCodexRoute', () => {
   it('空 model → null', async () => {
     const { decideCodexRoute } = await import('../codex-proxy-host.js');
     expect(decideCodexRoute({ model: '', authInjection: 'oauth-bearer', gatewayKey: 'gw' })).toBeNull();
+  });
+});
+
+describe('chatBridgeCapabilitiesForRoute', () => {
+  it.each([
+    'https://api.moonshot.cn/v1',
+    'https://api.moonshot.ai/v1/',
+  ])('enables image_url only for Kimi K3 on official Moonshot host: %s', async (upstream) => {
+    const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
+    expect(chatBridgeCapabilitiesForRoute(upstream, 'kimi-k3').imageInput).toBe('image_url');
+  });
+
+  it.each([
+    ['https://api.moonshot.cn/v1', 'kimi-k2.6'],
+    ['https://api.deepseek.com/v1', 'kimi-k3'],
+    ['https://api.moonshot.cn.evil.example/v1', 'kimi-k3'],
+    ['http://api.moonshot.cn/v1', 'kimi-k3'],
+    ['not-a-url', 'kimi-k3'],
+  ])('keeps image input disabled for non-matching route %s / %s', async (upstream, model) => {
+    const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
+    expect(chatBridgeCapabilitiesForRoute(upstream, model).imageInput).toBeUndefined();
+  });
+
+  it('passes image support into the handler for a preset-derived custom Kimi route', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'kimi-moonshot',
+        name: 'Kimi (Moonshot 中国大陆)',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://api.moonshot.cn/v1',
+            wireProtocol: 'openai-chat',
+            models: [{ id: 'kimi-k3', name: 'Kimi K3' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'moonshot-key');
+    host.registerComposed('session-kimi-image', 'thread-kimi-image', 'PRODUCT_PROMPT');
+    setSessionProvider('session-kimi-image', 'kimi-moonshot');
+    host.setCodexProxyAuthInjection('env-key');
+
+    const decision = await Promise.resolve(host.createModelRoutingTransform()(
+      {
+        model: 'kimi-k3',
+        input: [{
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_image', image_url: 'data:image/png;base64,eA==' }],
+        }],
+      },
+      {
+        reqId: 1,
+        method: 'POST',
+        url: '/responses',
+        headers: { 'thread-id': 'thread-kimi-image' },
+      },
+    ));
+
+    expect(decision).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+    expect(mockState.createResponsesChatHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        upstreamBase: 'https://api.moonshot.cn/v1',
+        capabilities: expect.objectContaining({ imageInput: 'image_url' }),
+      }),
+      expect.anything(),
+    );
+
+    clearSessionProvider('session-kimi-image');
+    setCustomProviderKeyReader(() => null);
+    setCustomProviders([]);
   });
 });
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -209,6 +209,39 @@ function isGoogleGeminiChatUpstream(upstream: string): boolean {
   }
 }
 
+const MOONSHOT_CHAT_HOSTS = new Set(['api.moonshot.cn', 'api.moonshot.ai']);
+
+function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined): string {
+  return stripPrefix && model.startsWith(stripPrefix)
+    ? model.slice(stripPrefix.length)
+    : model;
+}
+
+/**
+ * 图片桥接必须按已验证的上游能力显式开启。这里认官方 Moonshot DNS 边界 + Kimi K3
+ * 上游 model，不认 provider id（预设创建后会生成用户自定义 id），也不对所有
+ * openai-chat 供应商放开。未命中继续沿用 fail-closed 默认。
+ */
+export function chatBridgeCapabilitiesForRoute(
+  upstream: string,
+  realModel: string,
+  fallback: ChatBridgeCapabilities = CHAT_BRIDGE_DEFAULT_CAPABILITIES,
+): ChatBridgeCapabilities {
+  if (realModel !== 'kimi-k3') return fallback;
+  try {
+    const url = new URL(upstream);
+    if (url.protocol !== 'https:' || !MOONSHOT_CHAT_HOSTS.has(url.hostname.toLowerCase())) {
+      return fallback;
+    }
+  } catch {
+    return fallback;
+  }
+  return {
+    ...fallback,
+    imageInput: 'image_url',
+  };
+}
+
 /**
  * Chat bridge 上游只收 host 明确构造的 header。绝不把 Codex/ChatGPT 请求 header
  * 原样透传，防止账号 id、OpenAI OAuth bearer 或内部 session 元数据泄漏给第三方。
@@ -216,17 +249,19 @@ function isGoogleGeminiChatUpstream(upstream: string): boolean {
 function createChatBridgeDecision(
   route: Awaited<ReturnType<typeof resolveSessionRoute>>,
   instructions: string | undefined,
+  wireModel: string,
 ): RoutingDecision | null {
   if (!route || route.routing.wireProtocol !== 'openai-chat') return null;
   const { headers } = buildLocalHandlerHeaders(route, 'codex');
   const stripPrefix = route.routing.modelIdRewrite?.stripPrefix;
+  const realModel = rewriteChatBridgeModel(wireModel, stripPrefix);
   // localHandler 绕过 proxy 的 responseObserver,自定义(user)供应商的上游错误不会被
   // createProviderUpstreamErrorObserver 看到。这里显式把非 2xx 上游错误喂回同一广播通道,
   // 让 Chat 桥接会话与透明自定义供应商一样弹结构化 providerError.* 提示。内置来源不广播
   // (与 observer 的 user-only 语义一致)。
   const providerId = route.providerId;
   const providerName = getActiveCatalog().providers.find((p) => p.id === providerId)?.name ?? providerId;
-  const capabilities: ChatBridgeCapabilities = isGoogleGeminiChatUpstream(
+  const baseCapabilities: ChatBridgeCapabilities = isGoogleGeminiChatUpstream(
     route.routing.upstream,
   )
     ? {
@@ -239,6 +274,11 @@ function createChatBridgeDecision(
         googleThoughtSignaturePlaceholder: true,
       }
     : CHAT_BRIDGE_DEFAULT_CAPABILITIES;
+  const capabilities = chatBridgeCapabilitiesForRoute(
+    route.routing.upstream,
+    realModel,
+    baseCapabilities,
+  );
   const onUpstreamError = route.providerSource === 'user'
     ? ({ status, body }: { status: number; body: string }): void => {
         reportProviderUpstreamError({ agent: 'codex', providerId, providerName, status, bodyText: body });
@@ -248,9 +288,7 @@ function createChatBridgeDecision(
     upstreamBase: route.routing.upstream,
     ...(route.routing.requestPath ? { chatCompletionsPath: route.routing.requestPath } : {}),
     buildHeaders: async () => headers,
-    rewriteModel: (model: string) => stripPrefix && model.startsWith(stripPrefix)
-      ? model.slice(stripPrefix.length)
-      : model,
+    rewriteModel: (model: string) => rewriteChatBridgeModel(model, stripPrefix),
     capabilities,
     ...(onUpstreamError ? { onUpstreamError } : {}),
   }, { logger: log });
@@ -1269,7 +1307,11 @@ export function createModelRoutingTransform(): RoutingTransform {
       const selectedRouting = getSessionRoutingDescriptor(sessionId, 'codex', model || undefined);
       if (selectedRouting?.wireProtocol === 'openai-chat' && ctx.method === 'POST' && model) {
         return resolveSessionRoute(sessionId, 'codex', model).then((localRoute) =>
-          createChatBridgeDecision(localRoute, threadId ? registry.get(threadId) : undefined));
+          createChatBridgeDecision(
+            localRoute,
+            threadId ? registry.get(threadId) : undefined,
+            model,
+          ));
       }
       // model 传给 scope 门(空串 = 控制面 GET,不受范围限制);声明了 modelPrefixes 的
       // 供应商(如 xai)只捕获自家命名空间的请求,其余回落默认路由。

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -118,6 +118,62 @@ describe('createResponsesChatHandler', () => {
     expect(buildHeaders).not.toHaveBeenCalled();
   });
 
+  it('posts capability-gated image_url content without logging image data', async () => {
+    const imageUrl = 'data:image/png;base64,SECRET_IMAGE_DATA';
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        model: 'kimi-k3',
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: 'describe' },
+            { type: 'image_url', image_url: { url: imageUrl } },
+          ],
+        }],
+      });
+      return streamResponse([
+        { id: 'chat_image', model: 'kimi-k3', choices: [{ delta: { content: 'done' }, finish_reason: 'stop' }] },
+      ]);
+    }) as typeof fetch;
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://api.moonshot.cn/v1',
+      buildHeaders: async () => ({ authorization: 'Bearer secret' }),
+      capabilities: { imageInput: 'image_url' },
+    }, { fetchImpl, logger });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'kimi-k3',
+        input: [{
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'describe' },
+            { type: 'input_image', image_url: imageUrl },
+          ],
+        }],
+      },
+      res: res as never,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+    const logCalls = [
+      ...logger.debug.mock.calls,
+      ...logger.info.mock.calls,
+      ...logger.warn.mock.calls,
+      ...logger.error.mock.calls,
+    ];
+    expect(JSON.stringify(logCalls)).not.toContain('SECRET_IMAGE_DATA');
+  });
+
   it('accepts a final SSE data event without a trailing newline', async () => {
     const fetchImpl = vi.fn(async () => new Response(
       'data: {"id":"chat_tail","choices":[{"delta":{"content":"tail"},"finish_reason":"stop"}]}',
@@ -214,6 +270,33 @@ describe('createResponsesChatHandler', () => {
     expect(res.status).toBe(400);
     expect(res.chunks.join('')).toContain('unsupported_feature');
     expect(buildHeaders).not.toHaveBeenCalled();
+  });
+
+  it('keeps image input disabled by default and rejects it before credentials or network', async () => {
+    const buildHeaders = vi.fn(async () => ({ authorization: 'Bearer secret' }));
+    const fetchImpl = vi.fn<typeof fetch>();
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders,
+    }, { fetchImpl });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'm',
+        input: [{
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_image', image_url: 'data:image/png;base64,eA==' }],
+        }],
+      },
+      res: res as never,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.chunks.join('')).toContain('unsupported_feature');
+    expect(buildHeaders).not.toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it('runs the provider error callback before returning the original status', async () => {

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -299,6 +299,73 @@ describe('translateResponsesRequest', () => {
     }))).toThrowError(UnsupportedResponsesFeatureError);
   });
 
+  it('translates capability-gated Kimi user images and preserves replayed history order', () => {
+    const imageUrl = 'data:image/png;base64,aW1hZ2U=';
+    const out = translateResponsesRequest(base({
+      input: [
+        {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'before' },
+            { type: 'input_image', image_url: imageUrl },
+            { type: 'input_text', text: 'after' },
+          ],
+        },
+        { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'seen' }] },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'continue' }] },
+      ],
+    }), { capabilities: { imageInput: 'image_url' } });
+
+    expect(out.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'before' },
+          { type: 'image_url', image_url: { url: imageUrl } },
+          { type: 'text', text: 'after' },
+        ],
+      },
+      { role: 'assistant', content: 'seen' },
+      { role: 'user', content: 'continue' },
+    ]);
+  });
+
+  it('keeps pure-text JSON shape unchanged when image capability is enabled', () => {
+    const out = translateResponsesRequest(base({
+      input: [{
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'hello' },
+          { type: 'input_text', text: ' world' },
+        ],
+      }],
+    }), { capabilities: { imageInput: 'image_url' } });
+
+    expect(out.messages).toEqual([{ role: 'user', content: 'hello world' }]);
+  });
+
+  it('keeps invalid or non-user image inputs fail-closed even with image capability', () => {
+    const capabilities = { imageInput: 'image_url' as const };
+    expect(() => translateResponsesRequest(base({
+      input: [{ type: 'message', role: 'user', content: [{ type: 'input_image', file_id: 'file_1' }] }],
+    }), { capabilities })).toThrow("input content part 'input_image'");
+    expect(() => translateResponsesRequest(base({
+      input: [{ type: 'message', role: 'user', content: [{ type: 'input_image' }] }],
+    }), { capabilities })).toThrow("input content part 'input_image'");
+    expect(() => translateResponsesRequest(base({
+      input: [{
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'input_image', image_url: 'data:image/png;base64,eA==' }],
+      }],
+    }), { capabilities })).toThrow("input content part 'input_image'");
+    expect(() => translateResponsesRequest(base({
+      input: [{ type: 'message', role: 'user', content: [{ type: 'input_audio', audio_url: 'x' }] }],
+    }), { capabilities })).toThrow("input content part 'input_audio'");
+  });
+
   it('drops Codex built-in tools (namespace/web_search) but keeps standard function tools', () => {
     const dropped: Array<[string, number]> = [];
     const out = translateResponsesRequest(base({

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -366,6 +366,22 @@ describe('translateResponsesRequest', () => {
     }), { capabilities })).toThrow("input content part 'input_audio'");
   });
 
+  it('allows normalized user-like roles such as latest_reminder to carry images', () => {
+    const imageUrl = 'data:image/png;base64,eA==';
+    const out = translateResponsesRequest(base({
+      input: [{
+        type: 'message',
+        role: 'latest_reminder',
+        content: [{ type: 'input_image', image_url: imageUrl }],
+      }],
+    }), { capabilities: { imageInput: 'image_url' } });
+
+    expect(out.messages).toEqual([{
+      role: 'user',
+      content: [{ type: 'image_url', image_url: { url: imageUrl } }],
+    }]);
+  });
+
   it('drops Codex built-in tools (namespace/web_search) but keeps standard function tools', () => {
     const dropped: Array<[string, number]> = [];
     const out = translateResponsesRequest(base({

--- a/packages/responses-chat-bridge/src/index.ts
+++ b/packages/responses-chat-bridge/src/index.ts
@@ -9,6 +9,11 @@ export {
   type ChatBridgeProviderConfig,
   type ChatBridgeUpstreamErrorInfo,
   type ChatCompletionsRequest,
+  type ChatImageInput,
+  type ChatImageUrlContentPart,
+  type ChatTextContentPart,
+  type ChatUserContentPart,
+  type ChatUserMessage,
   type ResponsesChatBridgeHandler,
   type ResponsesRequest,
 } from './types.js';

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -4,8 +4,10 @@ import {
   type ChatBridgeCapabilities,
   type ChatDeveloperRole,
   type ChatCompletionsRequest,
+  type ChatImageInput,
   type ChatMessage,
   type ChatToolCallExtraContent,
+  type ChatUserContentPart,
   type ResponsesContentPart,
   type ResponsesFunctionTool,
   type ResponsesInputItem,
@@ -62,9 +64,20 @@ function customToolArguments(input: unknown): string {
   }
 }
 
-function textFromParts(parts: ResponsesContentPart[], itemIndex: number): string {
+function messageContent(
+  item: Extract<ResponsesInputItem, { role: string }>,
+  itemIndex: number,
+  imageInput: ChatImageInput | undefined,
+): string | ChatUserContentPart[] {
+  if (typeof item.content === 'string') return item.content;
+  if (!Array.isArray(item.content)) {
+    throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
+  }
+
   let text = '';
-  for (const part of parts) {
+  let hasImage = false;
+  const multimodal: ChatUserContentPart[] = [];
+  for (const part of item.content) {
     if (!isPlainObject(part) || typeof part.type !== 'string') {
       throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
     }
@@ -73,23 +86,36 @@ function textFromParts(parts: ResponsesContentPart[], itemIndex: number): string
         throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content.${part.type}`);
       }
       text += part.text;
+      multimodal.push({ type: 'text', text: part.text });
+      continue;
+    }
+    if (part.type === 'input_image') {
+      if (
+        item.role !== 'user'
+        || imageInput !== 'image_url'
+        || part.file_id !== undefined
+        || typeof part.image_url !== 'string'
+        || part.image_url.length === 0
+      ) {
+        throw new UnsupportedResponsesFeatureError(`input content part '${part.type}'`);
+      }
+      hasImage = true;
+      multimodal.push({
+        type: 'image_url',
+        image_url: { url: part.image_url },
+      });
       continue;
     }
     throw new UnsupportedResponsesFeatureError(`input content part '${part.type}'`);
   }
-  return text;
-}
-
-function messageContent(item: Extract<ResponsesInputItem, { role: string }>, itemIndex: number): string {
-  if (typeof item.content === 'string') return item.content;
-  if (!Array.isArray(item.content)) {
-    throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
-  }
-  return textFromParts(item.content, itemIndex);
+  // 无图片时维持历史 JSON 形态(string)，不让 capability 改变纯文本供应商请求。
+  return hasImage ? multimodal : text;
 }
 
 interface TranslateInputOptions {
   developerRole: ChatDeveloperRole;
+  /** 仅明确支持视觉的 Chat 上游开启；未声明时 input_image 继续 fail closed。 */
+  imageInput?: ChatImageInput;
   /** thinking 模型:为带 tool_calls 但缺 reasoning_content 的 assistant 消息注入占位。 */
   toolCallReasoningPlaceholder: boolean;
   /** Gemini 3 OpenAI 兼容层:为每步首个回放 tool call 注入官方允许的签名跳过值。 */
@@ -155,14 +181,30 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
     if (!isPlainObject(item)) throw new UnsupportedResponsesFeatureError(`input[${index}]`);
 
     if ('role' in item && typeof item.role === 'string') {
-      const content = messageContent(item as Extract<ResponsesInputItem, { role: string }>, index);
+      const content = messageContent(
+        item as Extract<ResponsesInputItem, { role: string }>,
+        index,
+        opts.imageInput,
+      );
       if (item.role === 'assistant') {
+        // messageContent 只会为 user 图片返回数组；这里再守一次类型边界，避免未来扩展误放行。
+        if (typeof content !== 'string') {
+          throw new UnsupportedResponsesFeatureError(`input[${index}].content`);
+        }
         if (!assistant) assistant = { role: 'assistant', content };
         else if (assistant.content == null) assistant.content = content;
         else if (content) assistant.content += content;
       } else {
         assistant = flushAssistant(messages, assistant, opts);
-        messages.push({ role: normalizeRole(item.role, opts.developerRole), content });
+        const role = normalizeRole(item.role, opts.developerRole);
+        if (role === 'user') {
+          messages.push({ role, content });
+        } else {
+          if (typeof content !== 'string') {
+            throw new UnsupportedResponsesFeatureError(`input[${index}].content`);
+          }
+          messages.push({ role, content });
+        }
       }
       continue;
     }
@@ -304,6 +346,7 @@ export function translateResponsesRequest(
   const developerRole = capabilities.developerRole ?? 'system';
   const messages = translateInput(input.input, {
     developerRole,
+    imageInput: capabilities.imageInput,
     toolCallReasoningPlaceholder: capabilities.toolCallReasoningPlaceholder === true,
     googleThoughtSignaturePlaceholder: capabilities.googleThoughtSignaturePlaceholder === true,
   });

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -8,7 +8,6 @@ import {
   type ChatMessage,
   type ChatToolCallExtraContent,
   type ChatUserContentPart,
-  type ResponsesContentPart,
   type ResponsesFunctionTool,
   type ResponsesInputItem,
   type ResponsesRequest,
@@ -67,6 +66,7 @@ function customToolArguments(input: unknown): string {
 function messageContent(
   item: Extract<ResponsesInputItem, { role: string }>,
   itemIndex: number,
+  developerRole: ChatDeveloperRole,
   imageInput: ChatImageInput | undefined,
 ): string | ChatUserContentPart[] {
   if (typeof item.content === 'string') return item.content;
@@ -90,8 +90,11 @@ function messageContent(
       continue;
     }
     if (part.type === 'input_image') {
+      const normalizedRole = item.role === 'assistant'
+        ? 'assistant'
+        : normalizeRole(item.role, developerRole);
       if (
-        item.role !== 'user'
+        normalizedRole !== 'user'
         || imageInput !== 'image_url'
         || part.file_id !== undefined
         || typeof part.image_url !== 'string'
@@ -184,6 +187,7 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
       const content = messageContent(
         item as Extract<ResponsesInputItem, { role: string }>,
         index,
+        opts.developerRole,
         opts.imageInput,
       );
       if (item.role === 'assistant') {

--- a/packages/responses-chat-bridge/src/types.ts
+++ b/packages/responses-chat-bridge/src/types.ts
@@ -80,9 +80,28 @@ export interface ResponsesRequest {
   [key: string]: unknown;
 }
 
+export interface ChatTextContentPart {
+  type: 'text';
+  text: string;
+}
+
+export interface ChatImageUrlContentPart {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  };
+}
+
+export type ChatUserContentPart = ChatTextContentPart | ChatImageUrlContentPart;
+
 export interface ChatTextMessage {
-  role: 'system' | 'developer' | 'user';
+  role: 'system' | 'developer';
   content: string;
+}
+
+export interface ChatUserMessage {
+  role: 'user';
+  content: string | ChatUserContentPart[];
 }
 
 export interface ChatAssistantMessage {
@@ -105,7 +124,7 @@ export interface ChatToolMessage {
   content: string;
 }
 
-export type ChatMessage = ChatTextMessage | ChatAssistantMessage | ChatToolMessage;
+export type ChatMessage = ChatTextMessage | ChatUserMessage | ChatAssistantMessage | ChatToolMessage;
 
 export interface ChatCompletionsRequest {
   model: string;
@@ -131,6 +150,7 @@ export interface ChatCompletionsRequest {
 export type ChatDeveloperRole = 'developer' | 'system';
 export type ChatMaxTokensField = 'max_tokens' | 'max_completion_tokens' | 'omit';
 export type ChatReasoningField = 'reasoning_effort' | 'none';
+export type ChatImageInput = 'image_url';
 
 /** 同协议族内的上游差异，全部由数据表达（对齐 cc-switch / opencodex 的 per-provider 处理）。 */
 export interface ChatBridgeCapabilities {
@@ -139,6 +159,11 @@ export interface ChatBridgeCapabilities {
   maxTokensField?: ChatMaxTokensField;
   reasoningField?: ChatReasoningField;
   streamUsage?: boolean;
+  /**
+   * Responses `input_image` 的上游等价形态。默认未声明 = fail closed；只有已确认支持
+   * Chat Completions 视觉输入的运行时才开启，避免把图片静默丢掉或误发给纯文本上游。
+   */
+  imageInput?: ChatImageInput;
   /**
    * thinking 模型(DeepSeek/Kimi/Moonshot)要求每个带 tool_calls 的 assistant 消息携带非空
    * reasoning_content,否则上游报 `reasoning_content is missing in assistant tool call message`。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Kimi K3 通过 `openai-chat` 路由使用时，第二轮或后续对话因历史消息包含 Responses `input_image` 而被本地 Chat Completions bridge 拒绝的问题。

根因是 provider 的 `wireProtocol: openai-chat` 配置正确，但本地 Responses → Chat bridge 只转换文本，没有把 Responses 图片 part 映射成 Chat Completions 的 `image_url` content part。

本 PR 为 bridge 增加默认关闭的图片能力，并仅在 HTTPS、官方 Moonshot hostname（`api.moonshot.cn` / `api.moonshot.ai`）且实际模型精确为 `kimi-k3` 时开启。历史图片同样转换，因此发图后的后续纯文本轮次可继续。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Kimi K3 第二轮带历史图片时出现 `Responses feature is not supported by the Chat Completions bridge: input content part 'input_image'`
- 本 PR 包含：Responses `input_image` → Chat `image_url` 映射；Kimi K3 官方 Moonshot 路由能力判断；主路径、历史回放、默认关闭及错误边界回归测试
- 明确不包含：不修改 provider 的 `wireProtocol`；不对所有 `openai-chat` provider 放开图片；不支持 `file_id`、assistant 图片或未知 content part
- 用户可见变化：Kimi K3 对话发送图片后，后续消息不再因历史图片被 bridge 拒绝
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
PATH="$PWD/.tmp-python-bin:$PATH" pnpm test:unit
结果：通过（临时 wrapper 仅用于让本机 `python` 使用 Python 3，未提交）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：62 tests 通过

pnpm --filter @cindy/responses-chat-bridge test
结果：38 tests 通过

git diff --check
结果：通过
```

### 手工验证

不涉及：当前 worktree 未连接运行中的 Desktop 实例；行为由路由与 bridge 回归测试覆盖。

### 未执行的验证

未进行 Kimi 真实 API 调用，避免在测试和日志中使用用户凭证；已使用与上游 Chat Completions 图片格式一致的请求形态做 handler 测试。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 本地 Responses → Chat bridge。图片能力默认关闭；只对 HTTPS + 精确官方 Moonshot hostname + 实际模型 `kimi-k3` 开启。纯文本请求继续保持原字符串 content 形态，其他 Chat provider 继续 fail-closed。
- 回滚 / 降级方式：回滚本 PR 后恢复为所有 Chat bridge 路由拒绝 `input_image`；纯文本行为不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
