### PR TITLE
feat(settings): add legal links to desktop about page

### DIFF
--- a/apps/desktop/src/renderer/components/settings/AboutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AboutSection.tsx
@@ -195,7 +195,7 @@ function LegalLinkRow({ label, url }: { label: string; url: string }) {
       <button
         aria-label={t('settings.about.legal.viewDocument', { document: label })}
         className={cn(
-          '-mr-1 flex select-none items-center gap-1.5 rounded-full px-3 py-1.5',
+          '-mr-1 flex select-none items-center gap-1.5 rounded-full px-6 py-2.5',
           'text-12 font-medium text-[var(--settings-section-title)]',
           'border border-[var(--settings-theme-card-border)]',
           'transition-colors hover:bg-[var(--surface-hover)] active:scale-[0.98]',
@@ -205,7 +205,7 @@ function LegalLinkRow({ label, url }: { label: string; url: string }) {
         title={url}
         type="button"
       >
-        {t('settings.about.legal.view')}
+        {t('settings.about.legal.viewDocument', { document: label })}
         <ExternalLink aria-hidden size={13} strokeWidth={1.7} />
       </button>
     </div>

--- a/apps/desktop/src/renderer/components/settings/AboutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AboutSection.tsx
@@ -22,6 +22,7 @@ import { useAnalyticsSettings } from '@/hooks/useAnalyticsSettings';
 import { DefaultOverrideControls } from './DefaultOverrideControls';
 import { StorageManagementCard } from './StorageManagementCard';
 import { CURRENT_CINDY_REGION } from '../../../shared/brandRegion';
+import { LEGAL_LINKS } from '../../../shared/legalLinks';
 
 interface AgentVersionState {
   loading: boolean;
@@ -141,6 +142,8 @@ export function AboutSection() {
         <DebugLogToggleRow />
         <Divider />
         <OpenLogsRow />
+        <Divider />
+        <LegalLinksRows />
       </div>
 
       {/* 存储空间(媒体总仓占用 / 清理 / 体检) */}
@@ -150,6 +153,61 @@ export function AboutSection() {
       <StorageManagementCard />
 
       <SocialLinksPanel />
+    </div>
+  );
+}
+
+export function LegalLinksRows() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <LegalLinkRow
+        label={t('settings.about.legal.termsOfServiceLabel')}
+        url={LEGAL_LINKS.termsOfService}
+      />
+      <Divider />
+      <LegalLinkRow
+        label={t('settings.about.legal.privacyPolicyLabel')}
+        url={LEGAL_LINKS.privacyPolicy}
+      />
+    </>
+  );
+}
+
+function LegalLinkRow({ label, url }: { label: string; url: string }) {
+  const { t } = useTranslation();
+
+  const handleOpen = async () => {
+    try {
+      const result = await window.electronAPI.openExternal(url);
+      if (!result.success) {
+        toast.error(t('settings.about.legal.openFailed'));
+      }
+    } catch {
+      toast.error(t('settings.about.legal.openFailed'));
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3 px-[18px] py-4">
+      <span className="select-none text-13 text-[var(--settings-section-sublabel)]">{label}</span>
+      <button
+        aria-label={t('settings.about.legal.viewDocument', { document: label })}
+        className={cn(
+          '-mr-1 flex select-none items-center gap-1.5 rounded-full px-3 py-1.5',
+          'text-12 font-medium text-[var(--settings-section-title)]',
+          'border border-[var(--settings-theme-card-border)]',
+          'transition-colors hover:bg-[var(--surface-hover)] active:scale-[0.98]',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--focus-ring-soft)]',
+        )}
+        onClick={() => void handleOpen()}
+        title={url}
+        type="button"
+      >
+        {t('settings.about.legal.view')}
+        <ExternalLink aria-hidden size={13} strokeWidth={1.7} />
+      </button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/settings/__tests__/AboutSection.legalLinks.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/AboutSection.legalLinks.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LEGAL_LINKS } from '../../../../shared/legalLinks';
+
+const toast = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { document?: string }) =>
+      options?.document ? `${key}:${options.document}` : key,
+  }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast,
+}));
+
+import { LegalLinksRows } from '../AboutSection';
+
+const openExternal = vi.fn();
+
+describe('AboutSection legal links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openExternal.mockResolvedValue({ success: true });
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      openExternal,
+    };
+  });
+
+  afterEach(() => cleanup());
+
+  it('renders both legal documents and opens the region-selected URLs externally', async () => {
+    render(<LegalLinksRows />);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'settings.about.legal.viewDocument:settings.about.legal.termsOfServiceLabel',
+      }),
+    );
+    await waitFor(() => expect(openExternal).toHaveBeenCalledWith(LEGAL_LINKS.termsOfService));
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'settings.about.legal.viewDocument:settings.about.legal.privacyPolicyLabel',
+      }),
+    );
+    await waitFor(() => expect(openExternal).toHaveBeenCalledWith(LEGAL_LINKS.privacyPolicy));
+  });
+
+  it('shows the localized failure message when the system browser cannot open a document', async () => {
+    openExternal.mockResolvedValueOnce({ success: false });
+    render(<LegalLinksRows />);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'settings.about.legal.viewDocument:settings.about.legal.privacyPolicyLabel',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('settings.about.legal.openFailed'),
+    );
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/__tests__/AboutSection.legalLinks.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/AboutSection.legalLinks.test.tsx
@@ -38,18 +38,26 @@ describe('AboutSection legal links', () => {
   it('renders both legal documents and opens the region-selected URLs externally', async () => {
     render(<LegalLinksRows />);
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'settings.about.legal.viewDocument:settings.about.legal.termsOfServiceLabel',
-      }),
+    const termsButton = screen.getByRole('button', {
+      name: 'settings.about.legal.viewDocument:settings.about.legal.termsOfServiceLabel',
+    });
+    expect(termsButton.textContent).toContain(
+      'settings.about.legal.viewDocument:settings.about.legal.termsOfServiceLabel',
     );
+    expect(termsButton.className).toContain('px-6');
+    expect(termsButton.className).toContain('py-2.5');
+
+    fireEvent.click(termsButton);
     await waitFor(() => expect(openExternal).toHaveBeenCalledWith(LEGAL_LINKS.termsOfService));
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'settings.about.legal.viewDocument:settings.about.legal.privacyPolicyLabel',
-      }),
+    const privacyButton = screen.getByRole('button', {
+      name: 'settings.about.legal.viewDocument:settings.about.legal.privacyPolicyLabel',
+    });
+    expect(privacyButton.textContent).toContain(
+      'settings.about.legal.viewDocument:settings.about.legal.privacyPolicyLabel',
     );
+
+    fireEvent.click(privacyButton);
     await waitFor(() => expect(openExternal).toHaveBeenCalledWith(LEGAL_LINKS.privacyPolicy));
   });
 

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -656,7 +656,6 @@
       "legal": {
         "termsOfServiceLabel": "Terms of Service",
         "privacyPolicyLabel": "Privacy Policy",
-        "view": "View",
         "viewDocument": "View {{document}}",
         "openFailed": "Unable to open the document. Check your system browser settings."
       },

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -653,6 +653,13 @@
       "analyticsSaveFailed": "Failed to save usage statistics settings",
       "debugLogLabel": "Debug logs",
       "debugLogDescription": "When enabled, emits verbose debug logs: main/maker logger raised to debug level; new Claude Code sessions also log API request URL/status/latency, Node-level DNS/TCP/TLS handshake timing, and SDK internals. Output is large — turn off after troubleshooting. Always on in dev mode.",
+      "legal": {
+        "termsOfServiceLabel": "Terms of Service",
+        "privacyPolicyLabel": "Privacy Policy",
+        "view": "View",
+        "viewDocument": "View {{document}}",
+        "openFailed": "Unable to open the document. Check your system browser settings."
+      },
       "social": {
         "title": "Connect with Cindy",
         "discordLabel": "Discord",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -653,6 +653,13 @@
       "analyticsSaveFailed": "利用統計の設定を保存できませんでした",
       "debugLogLabel": "デバッグログ",
       "debugLogDescription": "有効にすると詳細なデバッグログを出力します:main/maker logger が debug レベルになり、新しい Claude Code セッションは API リクエスト URL/ステータス/レイテンシ、Node レベルの DNS/TCP/TLS ハンドシェイクのタイミング、SDK 内部情報も出力します。ログ量が大きいため、調査が終わったらオフにしてください。dev モードでは常に有効です。",
+      "legal": {
+        "termsOfServiceLabel": "利用規約",
+        "privacyPolicyLabel": "プライバシーポリシー",
+        "view": "表示",
+        "viewDocument": "{{document}}を表示",
+        "openFailed": "文書を開けませんでした。システムのブラウザー設定を確認してください"
+      },
       "social": {
         "title": "Cindy とつながる",
         "discordLabel": "Discord",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -656,7 +656,6 @@
       "legal": {
         "termsOfServiceLabel": "利用規約",
         "privacyPolicyLabel": "プライバシーポリシー",
-        "view": "表示",
         "viewDocument": "{{document}}を表示",
         "openFailed": "文書を開けませんでした。システムのブラウザー設定を確認してください"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -653,6 +653,13 @@
       "analyticsSaveFailed": "사용 통계 설정을 저장하지 못했습니다",
       "debugLogLabel": "디버그 로그",
       "debugLogDescription": "활성화하면 전체 디버그 로그를 출력합니다: main/maker logger가 debug 레벨로 올라가며, 새 Claude Code 세션은 API 요청 URL/상태/지연 시간, Node 레벨 DNS/TCP/TLS 핸드셰이크 타이밍 및 SDK 내부 정보도 출력합니다. 로그 양이 많으므로 문제 해결 후에는 꺼주세요. dev 모드에서는 항상 켜져 있습니다.",
+      "legal": {
+        "termsOfServiceLabel": "서비스 이용약관",
+        "privacyPolicyLabel": "개인정보 처리방침",
+        "view": "보기",
+        "viewDocument": "{{document}} 보기",
+        "openFailed": "문서를 열 수 없습니다. 시스템 브라우저 설정을 확인해 주세요"
+      },
       "social": {
         "title": "Cindy와 연결하기",
         "discordLabel": "Discord",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -656,7 +656,6 @@
       "legal": {
         "termsOfServiceLabel": "서비스 이용약관",
         "privacyPolicyLabel": "개인정보 처리방침",
-        "view": "보기",
         "viewDocument": "{{document}} 보기",
         "openFailed": "문서를 열 수 없습니다. 시스템 브라우저 설정을 확인해 주세요"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -653,6 +653,13 @@
       "analyticsSaveFailed": "保存使用统计设置失败",
       "debugLogLabel": "Debug 日志",
       "debugLogDescription": "开启后输出全量调试日志：main/maker logger 抬到 debug 级，新建的 Claude Code 会话额外输出 API 请求 URL/状态/耗时、Node 层 DNS/TCP/TLS 握手时序，以及 SDK 内部信息。日志量较大，定位问题后请关闭。dev 模式下始终开启。",
+      "legal": {
+        "termsOfServiceLabel": "用户协议",
+        "privacyPolicyLabel": "隐私政策",
+        "view": "查看",
+        "viewDocument": "查看{{document}}",
+        "openFailed": "无法打开协议，请检查系统浏览器设置"
+      },
       "social": {
         "title": "和 Cindy 联系",
         "discordLabel": "Discord",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -658,7 +658,7 @@
         "privacyPolicyLabel": "隐私政策",
         "view": "查看",
         "viewDocument": "查看{{document}}",
-        "openFailed": "无法打开协议，请检查系统浏览器设置"
+        "openFailed": "无法打开文档，请检查系统浏览器设置"
       },
       "social": {
         "title": "和 Cindy 联系",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -654,9 +654,8 @@
       "debugLogLabel": "Debug 日志",
       "debugLogDescription": "开启后输出全量调试日志：main/maker logger 抬到 debug 级，新建的 Claude Code 会话额外输出 API 请求 URL/状态/耗时、Node 层 DNS/TCP/TLS 握手时序，以及 SDK 内部信息。日志量较大，定位问题后请关闭。dev 模式下始终开启。",
       "legal": {
-        "termsOfServiceLabel": "用户协议",
-        "privacyPolicyLabel": "隐私政策",
-        "view": "查看",
+        "termsOfServiceLabel": "服务条款",
+        "privacyPolicyLabel": "隐私协议",
         "viewDocument": "查看{{document}}",
         "openFailed": "无法打开文档，请检查系统浏览器设置"
       },


### PR DESCRIPTION
## 这次改了什么

### 摘要

在 Desktop 现有“设置 → 关于”信息卡片中补充“用户协议”和“隐私政策”两个持续查看入口，满足用户登录后可便捷再次查阅协议的需求。入口复用现有地区链接配置，并通过系统默认浏览器打开，不新增设置页、WebView 或 IPC。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #567
- 本 PR 包含：Desktop“关于”页两条协议入口；复用 `LEGAL_LINKS` 的国内/全球构建分流；系统浏览器打开及失败提示；zh-CN / en / ja / ko 文案；入口与打开行为测试。
- 明确不包含：登录页协议同意流程、Mobile 改动、协议正文或 URL 调整、协议版本/同意历史、独立隐私中心、内嵌 WebView。
- 用户可见变化：Desktop 用户可在“设置 → 关于”中查看适用的用户协议和隐私政策。
- 是否存在 breaking change：无。

### UI 变化

- 平台与路径：Windows Desktop，“设置 → 关于”，在日志目录入口之后增加两条链接行。
- 截图：当前自动化环境未完成 Electron 实机截图；Draft 阶段仍需在 Windows Light / Dark 下做一次界面走查。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Buttons（交互元素使用 pill 几何）、§5 Layout Principles（复用现有 About 卡片的行间距与分隔结构）、§10 Theme System & Token Reference（仅使用现有主题 token，无硬编码颜色）、§14.1/§14.2（控件文字 `select-none`，提供 `focus-visible` 与完整可访问名称）。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/components/settings/__tests__/AboutSection.legalLinks.test.tsx
结果：2/2 通过。

NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm --filter desktop typecheck
结果：通过。

corepack pnpm check:i18n
结果：四语 key 一致；仅保留仓库既有非阻塞警告。

corepack pnpm check:i18n-glossary
结果：通过，无新增违规。

corepack pnpm --filter desktop exec eslint src/renderer/components/settings/AboutSection.tsx src/renderer/components/settings/__tests__/AboutSection.legalLinks.test.tsx
结果：通过。

node scripts/hardcoded-color-audit.mjs --base-ref main
结果：unexpected=0，通过。

corepack pnpm check:dco
结果：1 个提交已签署，通过。

corepack pnpm --dir cindy-protocol -r test
结果：4 个协议包、154 项测试全部通过。
```

全量 unit workspace sweep 结果：1,217 个 Desktop 测试文件通过、13,290 项 Desktop 测试通过；其余可运行 workspace 均通过。Desktop 有 3 项与本 PR 无关的基线失败：`markdownTargetRendererContract.test.ts` 1 项，以及 `skillhub/installService.test.ts` 2 项。

### 手工验证

- 已 review 完整 diff，并确认国内/全球 URL 均来自现有 `LEGAL_LINKS`，组件内未写死协议地址。
- 尚未启动 Electron 做 Windows Light / Dark 实机点击与截图验收。

### 未执行的验证

- 全仓 Desktop lint：仓库当前存在 88 个与本 PR 无关的既有错误；本次改动的两个 TS/TSX 文件已单独 lint 通过。
- Windows Electron Light / Dark 实机走查：当前自动化环境未启动 GUI，留待 Draft reviewer 验收。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop renderer 的“关于”页展示与外链打开；不改变登录、同意记录、协议内容、Mobile、数据库或原生层。
- 回滚 / 降级方式：回滚本提交即可恢复原“关于”页；协议链接配置本身未修改。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；本需求无需新增独立文档
- [x] 已确认测试结果或说明未执行原因
