### PR TITLE
fix(desktop): preserve auto approval on transient failures

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -102,9 +102,10 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
     setClaudeAutoClassifierUnavailableListener(listener);
     const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1');
 
+    expect(observer(ctx({ status: 408 }))).toBeUndefined();
     expect(observer(ctx({ status: 429 }))).toBeUndefined();
-    expect(observer(ctx({ status: 529 }))).toBeUndefined();
     expect(observer(ctx({ status: 503 }))).toBeUndefined();
+    expect(observer(ctx({ status: 529 }))).toBeUndefined();
 
     expect(listener).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -97,33 +97,37 @@ describe('Claude Auto classifier request detection', () => {
 });
 
 describe('createClaudeAutoClassifierFailureObserver', () => {
-  it('reports classifier failures across 4xx and 5xx with the resolved business session id', () => {
-    // 任何错误响应都意味着分类器没给 verdict、CLI 会 fail-closed——4xx(模型/参数/鉴权
-    // 不可用)与 5xx(限流/服务故障)都必须触发降级,不再限于 429/5xx。
+  it('keeps Auto for transient classifier failures', () => {
+    const listener = vi.fn();
+    setClaudeAutoClassifierUnavailableListener(listener);
+    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1');
+
+    expect(observer(ctx({ status: 429 }))).toBeUndefined();
+    expect(observer(ctx({ status: 529 }))).toBeUndefined();
+    expect(observer(ctx({ status: 503 }))).toBeUndefined();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('reports non-transient classifier failures with the resolved business session id', () => {
     const signals: unknown[] = [];
     setClaudeAutoClassifierUnavailableListener((signal) => signals.push(signal));
     const observer = createClaudeAutoClassifierFailureObserver((sdkId) =>
       sdkId === 'sdk-1' ? 'session-1' : null,
     );
 
-    expect(observer(ctx({ status: 429 }))).toBeUndefined();
     expect(observer(ctx({ status: 400 }))).toBeUndefined();
     expect(observer(ctx({ status: 401 }))).toBeUndefined();
+    expect(observer(ctx({ status: 403 }))).toBeUndefined();
     expect(observer(ctx({ status: 404 }))).toBeUndefined();
-    expect(
-      observer(
-        ctx({
-          status: 503,
-          requestBody: requestBody({ system: `${CLASSIFIER_PREFIX}\nRules` }),
-        }),
-      ),
-    ).toBeUndefined();
+    expect(observer(ctx({ status: 422 }))).toBeUndefined();
+
     expect(signals).toEqual([
-      { sessionId: 'session-1', agentKind: 'claude-code', status: 429 },
       { sessionId: 'session-1', agentKind: 'claude-code', status: 400 },
       { sessionId: 'session-1', agentKind: 'claude-code', status: 401 },
+      { sessionId: 'session-1', agentKind: 'claude-code', status: 403 },
       { sessionId: 'session-1', agentKind: 'claude-code', status: 404 },
-      { sessionId: 'session-1', agentKind: 'claude-code', status: 503 },
+      { sessionId: 'session-1', agentKind: 'claude-code', status: 422 },
     ]);
   });
 

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -124,13 +124,11 @@ export function createClaudeAutoClassifierFailureObserver(
   resolveSessionId: (sdkSessionId: string) => string | null,
 ): ResponseObserver {
   return (ctx: ResponseObserverCtx) => {
-    // 分类器请求的任何错误响应都意味着这一轮没拿到 verdict、CLI 会 fail-closed 把工具拦下,
-    // 一律当作「分类器不可用」触发降级——不再限于 429/5xx:
-    //   - 429 限流 / 5xx 服务故障(过载、宕机);
-    //   - 4xx 模型/参数层不可用(404 模型不存在、400 参数被拒、401/403 鉴权失效)。
-    // 降级到 ask 是安全方向(把 auto 收紧成人工授权,绝不放宽),瞬时 4xx 造成的单向降级
-    // 用户随时可手动切回 auto;coordinator 侧仍会复核持久态为 auto 并按 session 去重。
-    if (ctx.status < 400) return undefined;
+    // 分类器错误本身仍由 Claude Code fail-closed 为人工审批。这里只决定是否需要把用户的
+    // Auto 偏好持久改成 ask：限流/过载/上游故障等瞬时错误不能永久改写用户选择。
+    if (ctx.status < 400 || ctx.status === 429 || ctx.status === 529 || ctx.status >= 500) {
+      return undefined;
+    }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
     if (!sdkSessionId) return undefined;
     const sessionId = resolveSessionId(sdkSessionId);

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -126,7 +126,7 @@ export function createClaudeAutoClassifierFailureObserver(
   return (ctx: ResponseObserverCtx) => {
     // 分类器错误本身仍由 Claude Code fail-closed 为人工审批。这里只决定是否触发降级协调器：
     // 限流/过载/上游故障等瞬时错误直接短路，不切 runtime、不持久化 ask、也不广播降级。
-    if (ctx.status < 400 || ctx.status === 429 || ctx.status === 529 || ctx.status >= 500) {
+    if (ctx.status < 400 || ctx.status === 408 || ctx.status === 429 || ctx.status >= 500) {
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -124,8 +124,8 @@ export function createClaudeAutoClassifierFailureObserver(
   resolveSessionId: (sdkSessionId: string) => string | null,
 ): ResponseObserver {
   return (ctx: ResponseObserverCtx) => {
-    // 分类器错误本身仍由 Claude Code fail-closed 为人工审批。这里只决定是否需要把用户的
-    // Auto 偏好持久改成 ask：限流/过载/上游故障等瞬时错误不能永久改写用户选择。
+    // 分类器错误本身仍由 Claude Code fail-closed 为人工审批。这里只决定是否触发降级协调器：
+    // 限流/过载/上游故障等瞬时错误直接短路，不切 runtime、不持久化 ask、也不广播降级。
     if (ctx.status < 400 || ctx.status === 429 || ctx.status === 529 || ctx.status >= 500) {
       return undefined;
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude 自动审批的安全分类器遇到 429、529 或 5xx 临时故障时，保留用户选择的“自动审批”，不再把整个会话持久降级为默认权限。

当次分类失败仍由 Claude Code 保守地要求人工审批，不会自动放行工具调用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈自动审批在分类器 429 后变回默认权限
- 本 PR 包含：区分瞬时分类器故障与非瞬时 4xx，并补充回归测试
- 明确不包含：新增分类器重试机制
- 用户可见变化：短暂限流或上游故障后，刷新会话仍保持自动审批
- 是否存在 breaking change：无

### UI 变化

不涉及：未修改 UI、交互或文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
npx --yes pnpm@10.17.1 --dir . exec vitest run apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
结果：1 个测试文件通过，14 个测试通过

git diff --check
结果：通过
```

### 手工验证

根据两台 macOS 设备的 Cindy 日志确认原问题链路：Claude 自动审批分类请求返回 HTTP 429 后，`maker-ipc` 将 session 从 `auto` 持久降级为 `ask`。本 PR 覆盖该状态分支。

### 未执行的验证

完整 Desktop TypeScript 检查未通过。现有工作区缺少 `@cindy/slack-hook-protocol`、`@cindy/plugin-protocol` 和 `@cindy/device-link-protocol` 等模块，报错集中在与本次修改无关的 hook-control、plugin-market 和 device-link 文件。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Claude Code 自动审批分类器的错误响应观察逻辑
- 回滚 / 降级方式：回滚本提交即可恢复原有“所有错误均降级为 ask”的行为

安全边界不变：分类器无法给出 verdict 时，当次工具调用仍 fail-closed 并要求人工审批；本 PR 仅避免临时服务故障永久改写用户的 session 权限偏好。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
