### PR TITLE
fix(desktop): use full row for plugin install location

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
@@ -629,6 +629,7 @@ export function DetailsSection({
     value: string;
     monospace?: boolean;
     action?: ReactNode;
+    fullWidth?: boolean;
   }> = [
     {
       key: 'version',
@@ -682,6 +683,7 @@ export function DetailsSection({
             key: 'location',
             label: t('settings.ghosts.detail.infoLocation'),
             value: detail.installDir,
+            fullWidth: true,
             action: (
               <div className="flex shrink-0 items-center gap-0.5">
                 <button
@@ -727,7 +729,7 @@ export function DetailsSection({
       <DetailSectionHeader id="ghost-details-title" title={t('settings.ghosts.detail.infoTitle')} />
       <div className={cn(DETAIL_SECTION_CONTENT_CLASS, 'grid grid-cols-3 gap-x-10 gap-y-7')}>
         {facts.map((fact) => (
-          <div key={fact.key} className="min-w-0">
+          <div key={fact.key} className={cn('min-w-0', fact.fullWidth && 'col-span-full')}>
             <p className="truncate text-13 leading-5 text-[var(--text-secondary)]">{fact.label}</p>
             <ExpandableDetailValue
               label={fact.label}

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
@@ -386,7 +386,7 @@ describe('Ghost plugin detail sections', () => {
     );
   });
 
-  it('renders every detail fact in a three-column flat grid and copies the install location', async () => {
+  it('lets the install location use the full details row and preserves its actions', async () => {
     vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(100);
     vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockReturnValue(300);
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -409,6 +409,7 @@ describe('Ghost plugin detail sections', () => {
     expect(screen.getByText('Panel')).toBeTruthy();
     expect(screen.getByText('Install Location')).toBeTruthy();
     const installLocation = screen.getByText('/tmp/cindy-brain/builtin.example');
+    expect(installLocation.parentElement?.parentElement?.className).toContain('col-span-full');
     expect(installLocation.className).toContain('truncate');
     expect(installLocation.className).toContain('whitespace-nowrap');
     expect(screen.queryByRole('button', { name: 'See All' })).toBeNull();

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
@@ -409,7 +409,7 @@ describe('Ghost plugin detail sections', () => {
     expect(screen.getByText('Panel')).toBeTruthy();
     expect(screen.getByText('Install Location')).toBeTruthy();
     const installLocation = screen.getByText('/tmp/cindy-brain/builtin.example');
-    expect(installLocation.parentElement?.parentElement?.className).toContain('col-span-full');
+    expect(installLocation.closest('.col-span-full')).toBeTruthy();
     expect(installLocation.className).toContain('truncate');
     expect(installLocation.className).toContain('whitespace-nowrap');
     expect(screen.queryByRole('button', { name: 'See All' })).toBeNull();


### PR DESCRIPTION
## 这次改了什么

### 摘要

插件详情页的“安装位置”原本被限制在三列详情网格的单列中，即使最后一行还有大量空间，也会过早显示省略号。本 PR 让安装位置独占并跨满整行，同时保留空间确实不足时的截断、展开、复制和打开目录操作。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：插件详情页安装路径过早截断
- 本 PR 包含：Desktop 插件详情信息布局修复及回归测试
- 明确不包含：插件包内容、插件协议、安装逻辑
- 用户可见变化：安装路径可使用详情区域整行宽度，仅在整行仍放不下时显示省略号和展开按钮
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Layout Principles（让内容使用所属区域的有效空间，保持详情结构简洁）；§10 Theme System & Token Reference / Light-Dark delivery gate（未新增颜色或模式分支，继续复用现有主题 token，两种模式共享同一布局）

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
结果：12 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全部 required unit workspaces 通过
```

### 手工验证

未执行；等待在 Desktop PR 分支中使用已有插件详情页做实际视觉确认。

### 未执行的验证

未在运行中的 Electron 窗口里分别目测 Light / Dark；本次只调整网格跨度，不改变主题颜色或文案。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 插件详情页“安装位置”一项的网格跨度
- 回滚 / 降级方式：回退本提交即可恢复原单列布局；无数据或协议影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
