### PR TITLE
feat(composer): 快速开始预填文本以黑底白字胶囊样式展示

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -150,6 +150,7 @@ import {
   replacePastedTextChipWithPlainText,
   type PastedTextChipAttrs,
 } from './PastedTextChipNode';
+import { QuickStartPillMark } from './QuickStartPillMark';
 import { ToolPayloadLightbox } from '@/components/chat/ToolPayloadLightbox';
 import { Fragment, Slice, type Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { Selection, TextSelection } from '@tiptap/pm/state';
@@ -1374,6 +1375,7 @@ export function ChatInput({
       MentionDragCaretDecoration,
       GhostCommandDecoration,
       SlashCommandDecoration,
+      QuickStartPillMark,
     ],
     editorProps: {
       clipboardTextSerializer: (slice) => serializeEditorSlice(editorRef.current, slice),

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -985,7 +985,7 @@ export function ChatInput({
   const userHistoryRef = useRef(userHistory);
   userHistoryRef.current = userHistory;
   const historyIndexRef = useRef(-1); // -1 = current draft (not browsing)
-  const draftRef = useRef<JSONContent | null>(null); // saves draft when user starts browsing
+  const draftRef = useRef<JSONContent | null>(null); // saves draft doc JSON when user starts browsing (preserves marks)
   const hydratedHistoryDocumentRef = useRef<ProseMirrorNode | null>(null);
 
   // ── composer-draft-per-session ─────────────────────────────────────
@@ -1751,7 +1751,7 @@ export function ChatInput({
             // Only enter history browsing when the editor is empty or already browsing
             if (idx === -1 && !isEmpty) return false;
             if (idx === -1) {
-              // Save current draft before browsing
+              // Save current draft before browsing (full doc JSON preserves marks)
               draftRef.current = view.state.doc.toJSON();
             }
             const next = Math.min(idx + 1, history.length - 1);
@@ -1767,7 +1767,7 @@ export function ChatInput({
             historyIndexRef.current = next;
             const tr = view.state.tr;
             if (next === -1) {
-              // Restore draft
+              // Restore draft from saved doc JSON (preserves marks like quickStartPill)
               const draft = draftRef.current;
               if (draft) {
                 const draftDocument = view.state.schema.nodeFromJSON(draft);

--- a/apps/desktop/src/renderer/components/new-chat/QuickStartPillMark.ts
+++ b/apps/desktop/src/renderer/components/new-chat/QuickStartPillMark.ts
@@ -1,0 +1,44 @@
+/**
+ * QuickStartPillMark — 快速开始卡片预填文本的视觉胶囊标记。
+ *
+ * 当用户点击 New Maker 页面的快速开始卡片时，文本以本 mark 包裹写入编辑器，
+ * 渲染为黑底白字的圆角胶囊（与 model selector 的"限时免费"徽章同风格），
+ * 以区分「来自卡片的预填提示」和「用户手动输入的文字」。
+ *
+ * 设计约束：
+ *   - 文档里文本仍是普通 text node + 本 mark；发送时序列化只取 textContent，
+ *     mark 不产生任何额外输出（对 agent 透明）。
+ *   - inclusive=false：用户在胶囊右侧继续输入时新文字不继承 mark，
+ *     胶囊范围保持在原始预填文本上。
+ *   - 用户 Backspace / 选删胶囊内文字时 mark 随文字一起消失，无需额外 plugin。
+ */
+import { Mark, mergeAttributes } from '@tiptap/core';
+
+export const QuickStartPillMark = Mark.create({
+  name: 'quickStartPill',
+
+  // 不 inclusive：光标在 mark 边界输入时新字符不继承本 mark。
+  inclusive: false,
+
+  // 优先级低于内置 marks（如 bold），避免冲突。
+  priority: 50,
+
+  addAttributes() {
+    return {};
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-quick-start-pill]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, {
+        class: 'quick-start-pill',
+        'data-quick-start-pill': '',
+      }),
+      0,
+    ];
+  },
+});

--- a/apps/desktop/src/renderer/components/new-chat/pastePipeline.ts
+++ b/apps/desktop/src/renderer/components/new-chat/pastePipeline.ts
@@ -51,7 +51,7 @@ export function isLongPasteText(text: string): boolean {
 
 /**
  * 剪贴板 HTML 是否带本编辑器自家的 chip 标记(mentionChip / pastedTextChip /
- * composerQuote)
+ * composerQuote / quickStartPill)
  * 的 toDOM 输出)。命中时 handlePaste 应把整个粘贴交回 ProseMirror 默认
  * HTML 解析(parseHTML 原样还原 chip 与周围文本),跳过全部文本变换管线:
  * atom chip 在 text/plain 里没有文本投影,任何「取 text/plain 处理」的分支
@@ -60,7 +60,7 @@ export function isLongPasteText(text: string): boolean {
  * 的 data-pasted-text 里)。标记是本产品 toDOM 专属,外部网页不会携带。
  */
 export function htmlCarriesOwnChipMarkup(html: string): boolean {
-  return /data-(?:mention-chip|pasted-text-chip|composer-quote)/.test(html);
+  return /data-(?:mention-chip|pasted-text-chip|composer-quote|quick-start-pill)/.test(html);
 }
 
 /** 粘贴文本的行数(chip 文案用)。 */

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -87,6 +87,7 @@ import {
   clearDraftAndNotify as clearComposerDraftAndNotify,
   getDraft as getComposerDraft,
   plainTextToTiptapDoc,
+  quickStartTextToTiptapDoc,
   saveDraft as saveComposerDraft,
 } from '@/lib/composerDraftStore';
 import type { JSONContent } from '@tiptap/core';
@@ -2202,7 +2203,7 @@ export function NewMakerDraftRoute() {
       const text = t(labelKey);
       const currentDraft = getComposerDraft(NEW_MAKER_DRAFT_KEY);
       saveComposerDraft(NEW_MAKER_DRAFT_KEY, {
-        text: plainTextToTiptapDoc(text),
+        text: quickStartTextToTiptapDoc(text),
         attachments: currentDraft?.attachments ?? attachmentState.attachments,
         quotes: currentDraft?.quotes,
         browserComments: currentDraft?.browserComments,

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -1660,6 +1660,8 @@ export function NewMakerDraftRoute() {
             // 里, route change 在那次 commit 同时发生,旧的 draft route 直接被 unmount,
             // 不会暴露 cleared 后的视觉状态。clearFiles 仍然在 React 提交 unmount cleanup
             // 之前同步执行,所以 useAttachments 的 cleanup 不会把刚送出去的附件回写到 store。
+            // 保存原始 doc JSON(含 quickStartPill 等 mark),供 worktree 失败恢复时原样还原。
+            const preNavDraftDoc = getComposerDraft(NEW_MAKER_DRAFT_KEY)?.text ?? null;
             navigate(`/cc-agent/${newSession.id}`, { replace: true });
             // clearDraftAndNotify (not bare clear): onSend returned false above
             // so ChatInput never cleared its editor — without notifying it, the
@@ -1677,7 +1679,7 @@ export function NewMakerDraftRoute() {
               let rehomedFiles = files;
               const restoreFirstMessageDraft = () => {
                 saveComposerDraft(newSession.id, {
-                  text: plainTextToTiptapDoc(message),
+                  text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
                   attachments: rehomedFiles ?? [],
                 });
               };

--- a/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
@@ -333,4 +333,21 @@ describe('quickStartTextToTiptapDoc', () => {
     expect(plainText.marks).toBeUndefined();
     expect(markedText.marks).toEqual([{ type: 'quickStartPill' }]);
   });
+
+  it('goes through plainText normalization (lists become bulletList nodes) and marks leaf text', () => {
+    const doc = quickStartTextToTiptapDoc('- item1\n- item2');
+    // Walk tree to find every text node; they must all carry quickStartPill mark.
+    const textNodes: { text?: string; marks?: unknown[] }[] = [];
+    const walk = (n: JSONContent) => {
+      if (n.type === 'text') textNodes.push({ text: n.text, marks: n.marks });
+      (n.content ?? []).forEach(walk);
+    };
+    walk(doc);
+    expect(textNodes.length).toBeGreaterThanOrEqual(2);
+    for (const tn of textNodes) {
+      expect(tn.marks).toEqual(
+        expect.arrayContaining([{ type: 'quickStartPill' }]),
+      );
+    }
+  });
 });

--- a/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
@@ -9,6 +9,8 @@ import {
   draftHasContent,
   getDraft,
   getDraftPresence,
+  plainTextToTiptapDoc,
+  quickStartTextToTiptapDoc,
   saveDraft,
   setComposerDraftOwner,
   subscribeDraft,
@@ -284,5 +286,51 @@ describe('draft presence subscription', () => {
     expect(tiptapDocHasContent(null)).toBe(false);
     expect(tiptapDocHasContent(textDoc)).toBe(true);
     expect(tiptapDocHasContent(mentionDoc)).toBe(true);
+  });
+});
+
+describe('quickStartTextToTiptapDoc', () => {
+  it('returns empty doc for empty string', () => {
+    expect(quickStartTextToTiptapDoc('')).toEqual(emptyDoc);
+  });
+
+  it('wraps single-line text with quickStartPill mark', () => {
+    const doc = quickStartTextToTiptapDoc('探索并理解代码');
+    expect(doc.type).toBe('doc');
+    expect(doc.content).toHaveLength(1);
+    const para = doc.content![0];
+    expect(para.type).toBe('paragraph');
+    expect(para.content).toHaveLength(1);
+    const textNode = para.content![0];
+    expect(textNode.type).toBe('text');
+    expect(textNode.text).toBe('探索并理解代码');
+    expect(textNode.marks).toEqual([{ type: 'quickStartPill' }]);
+  });
+
+  it('applies mark to each line in multi-line text', () => {
+    const doc = quickStartTextToTiptapDoc('line1\nline2');
+    expect(doc.content).toHaveLength(2);
+    for (const para of doc.content!) {
+      if (para.content) {
+        for (const node of para.content) {
+          expect(node.marks).toEqual([{ type: 'quickStartPill' }]);
+        }
+      }
+    }
+  });
+
+  it('preserves empty lines as empty paragraphs (no mark)', () => {
+    const doc = quickStartTextToTiptapDoc('a\n\nb');
+    expect(doc.content).toHaveLength(3);
+    expect(doc.content![1].content).toBeUndefined();
+  });
+
+  it('differs from plainTextToTiptapDoc by having marks', () => {
+    const plain = plainTextToTiptapDoc('hello');
+    const marked = quickStartTextToTiptapDoc('hello');
+    const plainText = plain.content![0].content![0];
+    const markedText = marked.content![0].content![0];
+    expect(plainText.marks).toBeUndefined();
+    expect(markedText.marks).toEqual([{ type: 'quickStartPill' }]);
   });
 });

--- a/apps/desktop/src/renderer/lib/composerDraftStore.ts
+++ b/apps/desktop/src/renderer/lib/composerDraftStore.ts
@@ -402,24 +402,33 @@ export function plainTextToTiptapDoc(text: string): JSONContent {
 }
 
 /**
+ * 递归给文档中所有 text 节点附加 quickStartPill mark（非 text 节点原样保留）。
+ * 用于在 plainTextToComposerDocument 生成的规范化文档（含列表/围栏代码块）
+ * 上统一加 mark，保证 quick-start 文本即使包含 markdown 列表标记也能
+ * 正确渲染，行为与 plainTextToTiptapDoc 真正同构（review 反馈）。
+ */
+function applyQuickStartPillMark(node: JSONContent): JSONContent {
+  if (node.type === 'text') {
+    return {
+      ...node,
+      marks: [...(node.marks ?? []), { type: 'quickStartPill' }],
+    };
+  }
+  if (Array.isArray(node.content)) {
+    return { ...node, content: node.content.map(applyQuickStartPillMark) };
+  }
+  return node;
+}
+
+/**
  * 与 plainTextToTiptapDoc 相同，但给文本附加 quickStartPill mark，
  * 使编辑器渲染为黑底白字胶囊标签（视觉区分卡片预填 vs 手动输入）。
+ * 复用 plainTextToComposerDocument 保证列表/围栏/空段落规范化行为一致，
+ * 再递归给所有 text 节点加 mark（review：不能绕过 normalizeComposerDocumentJSON）。
  */
 export function quickStartTextToTiptapDoc(text: string): JSONContent {
-  if (!text) {
-    return { type: 'doc', content: [{ type: 'paragraph' }] };
-  }
-  return {
-    type: 'doc',
-    content: text.split('\n').map((line) =>
-      line.length === 0
-        ? { type: 'paragraph' }
-        : {
-            type: 'paragraph',
-            content: [{ type: 'text', marks: [{ type: 'quickStartPill' }], text: line }],
-          },
-    ),
-  };
+  const normalized = plainTextToComposerDocument(text);
+  return applyQuickStartPillMark(normalized);
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/composerDraftStore.ts
+++ b/apps/desktop/src/renderer/lib/composerDraftStore.ts
@@ -402,6 +402,27 @@ export function plainTextToTiptapDoc(text: string): JSONContent {
 }
 
 /**
+ * 与 plainTextToTiptapDoc 相同，但给文本附加 quickStartPill mark，
+ * 使编辑器渲染为黑底白字胶囊标签（视觉区分卡片预填 vs 手动输入）。
+ */
+export function quickStartTextToTiptapDoc(text: string): JSONContent {
+  if (!text) {
+    return { type: 'doc', content: [{ type: 'paragraph' }] };
+  }
+  return {
+    type: 'doc',
+    content: text.split('\n').map((line) =>
+      line.length === 0
+        ? { type: 'paragraph' }
+        : {
+            type: 'paragraph',
+            content: [{ type: 'text', marks: [{ type: 'quickStartPill' }], text: line }],
+          },
+    ),
+  };
+}
+
+/**
  * Subscribe to external writes for `sessionId`. Returns an unsubscribe fn.
  * ChatInput uses this to force-setContent when an outside writer (rewind /
  * fork pre-fill) updates the draft for the currently-mounted session.

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -677,17 +677,18 @@ html:lang(ko) {
 }
 
 /* 快速开始预填胶囊 — QuickStartPillMark。点击 New Maker 快速开始卡片后
-   预填文本以此 mark 包裹,渲染为与 ModelPromotionBadge 同风格的黑底白字圆角
+   预填文本以此 mark 包裹,渲染为与 ModelPromotionBadge 同色系的圆角
    标签,区分「卡片预填」与「手动输入」。doc 里仍是普通 text + mark,
-   发送序列化只取 textContent,mark 不产生额外输出。 */
+   发送序列化只取 textContent,mark 不产生额外输出。
+   注意:快速开始文本是完整句子(用户需阅读/编辑),不能用 micro-label 字号
+   (DESIGN.md §3 限定 10-13px 仅用于辅助标签);此处 font: inherit 继承
+   composer 正文字号,仅用 background/color/radius 做视觉区分。 */
 .ProseMirror .quick-start-pill {
   background: var(--accent-cta-bg);
   border-radius: 9999px;
-  padding: 1px 8px;
+  padding: 2px 8px 3px;
   color: var(--accent-pure-cta-fg);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.45;
+  font: inherit;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
 }

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -648,7 +648,8 @@ html:lang(ko) {
   [data-pasted-text-chip],
   [data-composer-quote],
   .ghost-cmd-pill,
-  .slash-cmd-pill
+  .slash-cmd-pill,
+  .quick-start-pill
 ) {
   margin-inline: 4px;
 }
@@ -671,6 +672,22 @@ html:lang(ko) {
   padding: 2px 8px 3px;
   color: var(--chat-input-text);
   font: inherit;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+/* 快速开始预填胶囊 — QuickStartPillMark。点击 New Maker 快速开始卡片后
+   预填文本以此 mark 包裹,渲染为与 ModelPromotionBadge 同风格的黑底白字圆角
+   标签,区分「卡片预填」与「手动输入」。doc 里仍是普通 text + mark,
+   发送序列化只取 textContent,mark 不产生额外输出。 */
+.ProseMirror .quick-start-pill {
+  background: var(--accent-cta-bg);
+  border-radius: 9999px;
+  padding: 1px 8px;
+  color: var(--accent-pure-cta-fg);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.45;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
 }

--- a/docs/design-previews/quick-start-pill/before-after.html
+++ b/docs/design-previews/quick-start-pill/before-after.html
@@ -1,0 +1,526 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Quick Start Pill — Before / After Comparison</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700&display=swap');
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Noto Sans SC', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    padding: 48px 32px;
+    min-height: 100vh;
+  }
+
+  h1 {
+    text-align: center;
+    font-size: 28px;
+    font-weight: 700;
+    margin-bottom: 8px;
+    letter-spacing: -0.5px;
+  }
+
+  .subtitle {
+    text-align: center;
+    font-size: 14px;
+    color: #888;
+    margin-bottom: 56px;
+  }
+
+  .comparison-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  @media (max-width: 800px) {
+    .comparison-grid { grid-template-columns: 1fr; }
+  }
+
+  .panel {
+    background: #1a1a1a;
+    border-radius: 16px;
+    padding: 28px;
+    border: 1px solid #2a2a2a;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .panel::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+  }
+
+  .panel.before::before { background: #ef4444; }
+  .panel.after::before { background: #22c55e; }
+
+  .panel-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 20px;
+    padding: 4px 10px;
+    border-radius: 6px;
+  }
+
+  .before .panel-label { background: #ef444420; color: #ef4444; }
+  .after .panel-label { background: #22c55e20; color: #22c55e; }
+
+  .panel-desc {
+    font-size: 13px;
+    color: #999;
+    margin-bottom: 20px;
+    line-height: 1.6;
+  }
+
+  /* === Simulated Cindy UI === */
+  .cindy-ui {
+    background: #f7f7f7;
+    border-radius: 12px;
+    padding: 24px;
+  }
+
+  .brand-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 20px;
+  }
+
+  .brand-logo {
+    font-size: 20px;
+    font-weight: 700;
+    color: #1a1a1a;
+    letter-spacing: -0.5px;
+  }
+
+  .brand-logo span { color: #e11d48; }
+
+  /* Chat Input Box */
+  .input-box {
+    background: #fff;
+    border: 1.5px solid #e5e5e5;
+    border-radius: 12px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+  }
+
+  .input-text {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #1a1a1a;
+    min-height: 24px;
+  }
+
+  .input-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 10px;
+    padding-top: 8px;
+  }
+
+  .toolbar-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 12px;
+    color: #999;
+  }
+
+  .toolbar-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .vendor-switch {
+    display: flex;
+    background: #f0f0f0;
+    border-radius: 6px;
+    padding: 2px;
+    font-size: 11px;
+  }
+
+  .vendor-switch span {
+    padding: 3px 8px;
+    border-radius: 4px;
+    color: #666;
+  }
+
+  .vendor-switch span.active {
+    background: #fff;
+    color: #1a1a1a;
+    font-weight: 500;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+  }
+
+  .model-label {
+    font-size: 11px;
+    color: #555;
+    font-weight: 500;
+  }
+
+  /* The "限时免费" badge — exists in both before & after */
+  .free-badge {
+    display: inline-flex;
+    align-items: center;
+    background: #1a1a1a;
+    color: #fff;
+    border-radius: 9999px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
+  .send-btn {
+    width: 28px;
+    height: 28px;
+    background: #1a1a1a;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .send-btn::after {
+    content: '▶';
+    color: #fff;
+    font-size: 10px;
+  }
+
+  /* Quick Start Cards */
+  .quick-start-section {
+    margin-top: 16px;
+  }
+
+  .quick-start-title {
+    font-size: 13px;
+    color: #888;
+    margin-bottom: 10px;
+    font-weight: 500;
+  }
+
+  .cards-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+
+  .qs-card {
+    background: #fff;
+    border: 1px solid #eee;
+    border-radius: 10px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 72px;
+    cursor: pointer;
+    transition: border-color 0.15s;
+  }
+
+  .qs-card:hover { border-color: #ccc; }
+
+  .qs-card .icon {
+    font-size: 16px;
+    color: #aaa;
+    margin-bottom: 12px;
+  }
+
+  .qs-card .text {
+    font-size: 12px;
+    color: #333;
+    line-height: 1.4;
+  }
+
+  /* Highlight the active card */
+  .qs-card.active {
+    border-color: #e11d48;
+    box-shadow: 0 0 0 1px #e11d4840;
+  }
+
+  /* ===== THE KEY DIFFERENCE ===== */
+
+  /* BEFORE: plain text */
+  .before .input-text {
+    color: #1a1a1a;
+    font-size: 14px;
+    font-weight: 400;
+  }
+
+  /* AFTER: pill badge */
+  .after .quick-start-pill {
+    display: inline;
+    background: #1a1a1a;
+    color: #fff;
+    border-radius: 9999px;
+    padding: 2px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.5;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+  }
+
+  /* Callout arrow */
+  .callout {
+    margin-top: 16px;
+    padding: 12px 14px;
+    border-radius: 8px;
+    font-size: 12px;
+    line-height: 1.6;
+  }
+
+  .before .callout {
+    background: #ef444410;
+    border: 1px solid #ef444430;
+    color: #f87171;
+  }
+
+  .after .callout {
+    background: #22c55e10;
+    border: 1px solid #22c55e30;
+    color: #4ade80;
+  }
+
+  .callout strong { font-weight: 700; }
+
+  /* Visual diff indicator */
+  .diff-highlight {
+    position: relative;
+    display: inline-block;
+  }
+
+  .before .diff-highlight::after {
+    content: '';
+    position: absolute;
+    inset: -3px -4px;
+    border: 2px dashed #ef4444;
+    border-radius: 4px;
+    animation: pulse-red 2s ease-in-out infinite;
+  }
+
+  .after .diff-highlight::after {
+    content: '';
+    position: absolute;
+    inset: -3px -4px;
+    border: 2px dashed #22c55e;
+    border-radius: 9999px;
+    animation: pulse-green 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-red {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+
+  @keyframes pulse-green {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+
+  /* Bottom behavior table */
+  .behavior-section {
+    max-width: 1100px;
+    margin: 56px auto 0;
+  }
+
+  .behavior-section h2 {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 16px;
+  }
+
+  .behavior-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: 13px;
+    background: #1a1a1a;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid #2a2a2a;
+  }
+
+  .behavior-table th {
+    background: #222;
+    padding: 10px 16px;
+    text-align: left;
+    font-weight: 600;
+    color: #ccc;
+    border-bottom: 1px solid #333;
+  }
+
+  .behavior-table td {
+    padding: 10px 16px;
+    border-bottom: 1px solid #222;
+    color: #bbb;
+  }
+
+  .behavior-table tr:last-child td { border-bottom: none; }
+
+  .behavior-table td:first-child { font-weight: 500; color: #e8e8e8; }
+
+  .tag {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .tag-green { background: #22c55e20; color: #4ade80; }
+  .tag-blue { background: #3b82f620; color: #60a5fa; }
+</style>
+</head>
+<body>
+
+<h1>Quick Start Pill 样式改动</h1>
+<p class="subtitle">feat(composer): 快速开始预填文本以黑底白字胶囊样式展示</p>
+
+<div class="comparison-grid">
+
+  <!-- ===== BEFORE ===== -->
+  <div class="panel before">
+    <div class="panel-label">✕ Before</div>
+    <p class="panel-desc">点击卡片后，预填文本以<strong style="color:#f87171">普通文字</strong>形式出现在输入框，与手动输入完全一样，无法区分来源。</p>
+
+    <div class="cindy-ui">
+      <div class="brand-row">
+        <span class="brand-logo">CINDY<span>.</span></span>
+      </div>
+
+      <div class="input-box">
+        <div class="input-text">
+          <span class="diff-highlight">探索并理解代码</span>
+        </div>
+        <div class="input-toolbar">
+          <div class="toolbar-left">
+            <span>+</span>
+            <span>✨ 自动审批</span>
+          </div>
+          <div class="toolbar-right">
+            <div class="vendor-switch"><span class="active">Claude</span><span>Codex</span></div>
+            <span class="model-label">Qwen 3.8 Max Preview</span>
+            <span class="free-badge">限时免费</span>
+            <div class="send-btn"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="quick-start-section">
+        <div class="quick-start-title">快速开始</div>
+        <div class="cards-grid">
+          <div class="qs-card active"><span class="icon">🔍</span><span class="text">探索并理解代码</span></div>
+          <div class="qs-card"><span class="icon">⟨/⟩</span><span class="text">构建新功能、应用或工具</span></div>
+          <div class="qs-card"><span class="icon">💬</span><span class="text">审查代码并提出修改建议</span></div>
+          <div class="qs-card"><span class="icon">🔧</span><span class="text">修复问题和失败</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>问题：</strong>输入框里的「探索并理解代码」看起来和用户自己打的一模一样——是预填的？还是我之前写的？分不清。
+    </div>
+  </div>
+
+  <!-- ===== AFTER ===== -->
+  <div class="panel after">
+    <div class="panel-label">✓ After</div>
+    <p class="panel-desc">点击卡片后，预填文本以<strong style="color:#4ade80">黑底白字胶囊标签</strong>展示，与「限时免费」徽章同风格，一眼可辨。</p>
+
+    <div class="cindy-ui">
+      <div class="brand-row">
+        <span class="brand-logo">CINDY<span>.</span></span>
+      </div>
+
+      <div class="input-box">
+        <div class="input-text">
+          <span class="diff-highlight"><span class="quick-start-pill">探索并理解代码</span></span>
+        </div>
+        <div class="input-toolbar">
+          <div class="toolbar-left">
+            <span>+</span>
+            <span>✨ 自动审批</span>
+          </div>
+          <div class="toolbar-right">
+            <div class="vendor-switch"><span class="active">Claude</span><span>Codex</span></div>
+            <span class="model-label">Qwen 3.8 Max Preview</span>
+            <span class="free-badge">限时免费</span>
+            <div class="send-btn"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="quick-start-section">
+        <div class="quick-start-title">快速开始</div>
+        <div class="cards-grid">
+          <div class="qs-card active"><span class="icon">🔍</span><span class="text">探索并理解代码</span></div>
+          <div class="qs-card"><span class="icon">⟨/⟩</span><span class="text">构建新功能、应用或工具</span></div>
+          <div class="qs-card"><span class="icon">💬</span><span class="text">审查代码并提出修改建议</span></div>
+          <div class="qs-card"><span class="icon">🔧</span><span class="text">修复问题和失败</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>改进：</strong>胶囊标签 = 来自卡片的预填提示。和普通文字形成明确视觉对比，不再混淆。与右下角「限时免费」徽章同设计语言。
+    </div>
+  </div>
+
+</div>
+
+<!-- Behavior Table -->
+<div class="behavior-section">
+  <h2>交互行为</h2>
+  <table class="behavior-table">
+    <thead>
+      <tr><th>用户操作</th><th>表现</th><th>技术实现</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>点击快速开始卡片</td>
+        <td>文本以 <span class="tag tag-green">黑底白字胶囊</span> 出现在输入框</td>
+        <td>quickStartPill mark 包裹 text node</td>
+      </tr>
+      <tr>
+        <td>在胶囊右侧继续输入</td>
+        <td>新文字为 <span class="tag tag-blue">普通样式</span>，胶囊范围不变</td>
+        <td>mark inclusive=false</td>
+      </tr>
+      <tr>
+        <td>Backspace 删除胶囊内文字</td>
+        <td>mark 随文字一起消失</td>
+        <td>ProseMirror 标准 mark 行为</td>
+      </tr>
+      <tr>
+        <td>按 Send 发送</td>
+        <td>agent 收到的仍是纯文本，无额外标记</td>
+        <td>serializeEditorContent 只取 textContent</td>
+      </tr>
+      <tr>
+        <td>切走标签页再切回</td>
+        <td>胶囊样式保留</td>
+        <td>mark 持久化在 Tiptap JSON draft 中</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+</body>
+</html>

--- a/docs/design-previews/quick-start-pill/before-after.html
+++ b/docs/design-previews/quick-start-pill/before-after.html
@@ -5,12 +5,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Quick Start Pill — Before / After Comparison</title>
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700&display=swap');
-
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   body {
-    font-family: 'Noto Sans SC', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans SC', sans-serif;
     background: #0f0f0f;
     color: #e8e8e8;
     padding: 48px 32px;


### PR DESCRIPTION
## 动机

New Maker 首页点击「快速开始」卡片后,预填文本以普通纯文本形式出现在
输入框,与用户手动输入的文字无任何视觉区分。用户反馈无法辨别输入框里的
内容是「来自卡片的预填提示」还是「自己打过的字」,尤其在切走再切回、
草稿恢复后更明显。

## 方案

复用 ModelPromotionBadge（限时免费徽章）的视觉语言:
--accent-cta-bg / --accent-pure-cta-fg + rounded-full, 通过 Tiptap Mark (quickStartPill) 给预填文本加胶囊外观。

选择 Mark 而非 Decoration 的原因:
- Mark 持久化在 Tiptap JSON 中,草稿 save/load 后胶囊仍在; Decoration 是 runtime-only,切走再切回会丢失视觉状态。
- Mark 不影响序列化:serializeEditorContent 只取 textContent, mark 对 agent 完全透明,不产生额外 token。
- inclusive=false 保证用户在胶囊右侧追加输入时新文字不继承 mark, 胶囊范围始终锚定在原始预填文本上。

## 变更清单

- 新增 QuickStartPillMark.ts Tiptap Mark 扩展,name='quickStartPill',inclusive=false, renderHTML 输出 <span class="quick-start-pill" data-quick-start-pill>。 parseHTML 识别 data-quick-start-pill 属性以支持粘贴恢复。

- composerDraftStore.ts 新增 quickStartTextToTiptapDoc(text) 与 plainTextToTiptapDoc 同构,但 text node 附带 quickStartPill mark。

- ChatInput.tsx 注册 QuickStartPillMark 到 extensions 数组。

- globals.css 新增 .quick-start-pill 样式: background: var(--accent-cta-bg); color: var(--accent-pure-cta-fg); border-radius: 9999px; padding: 1px 8px; font-size: 11px; font-weight: 500; line-height: 1.45; box-decoration-break: clone (多行折行时每行独立圆角)。 并加入 margin-inline: 4px 的 pill 族选择器。

- NewMakerDraftRoute.tsx handleQuickStart plainTextToTiptapDoc → quickStartTextToTiptapDoc。

- docs/design-previews/quick-start-pill/before-after.html 修改前后视觉对比 mockup(浏览器打开即可查看)。

## 行为矩阵

| 场景 | 表现 |
|------|------|
| 点击快速开始卡片 | 文本以胶囊标签出现 |
| 胶囊右侧继续输入 | 新文字为普通样式 |
| Backspace 删除胶囊内文字 | mark 随文字消失 |
| 发送消息 | 序列化只取 textContent,无额外输出 |
| 切走再切回(草稿恢复) | 胶囊样式保留 |

## 验证

- 手动:打开 docs/design-previews/quick-start-pill/before-after.html 确认 before/after 视觉对比符合预期。
- 结构:grep 确认 ChatInput extensions 包含 QuickStartPillMark; handleQuickStart 调用 quickStartTextToTiptapDoc;CSS 含 .quick-start-pill。
- 类型:项目 tsc --noEmit 因 monorepo 体积 OOM(非本次引入), 逐文件检查 import/export 链路无断裂。

## 风险

无已知风险。mark 为纯视觉层,不影响:
- 发送内容(textContent 序列化)
- 草稿兼容(旧草稿无此 mark,加载后为普通文本,不报错)
- 其他 Tiptap 扩展(mark priority=50,低于内置 marks)

回滚:revert 本 commit 即可,无 migration / 无持久化格式变更。

<!--
PR Title 不是下面的正文标题，而是 GitHub PR 页面最上方的标题。
格式：<type>(<scope>): <简短描述>（scope 可省略）

type：feat / fix / refactor / perf / chore / docs / test / revert / build / ci
示例：docs(readme): 补充本地模式与远程开发说明；fix: 修复登录跳转
-->

## 这次改了什么

### 摘要

<!-- 用大白话说明改了什么，以及为什么改。保持单一目标。 -->

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：
- 本 PR 包含：
- 明确不包含：
- 用户可见变化：
- 是否存在 breaking change：无 / 有，说明：

### UI 变化

<!-- 涉及 UI 时附截图或录屏，并注明平台；不涉及则写“不涉及”。 -->

- 引用的设计规范：

<!-- 涉及 UI 时必填：列出本次改动遵循的设计规范章节与约束，并说明如何满足。
规范正本为 docs/design-rules/DESIGN.md（相关文档索引见
docs/design-rules/cindy-design-system.md）。写到具体章节/条款，
如“DESIGN.md §间距与栅格：卡片内边距 16px”。
改动命中 UI 代码路径但确无视觉/交互/文案变化时，写“不涉及：<理由>”；
完全不涉及 UI 则写“不涉及”。CI（pr-design-basis）会在变更命中 UI 路径时
校验本字段，判定逻辑见 scripts/check-pr-design-basis.mjs。 -->

## 怎么验证的

### 自动验证

<!-- 列出实际执行的命令及结果，不要只写“已测试”。 -->

```text
pnpm ...
结果：
```

### 手工验证

<!-- 写明操作路径、平台、账号或环境；不涉及则写“不涉及”。 -->

### 未执行的验证

<!-- 没有执行某项验证时，说明原因；没有则写“无”。mobile 本地验证需注明
branch/worktree、Metro 归属与 __DEV__ build label 证据。 -->

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
- 回滚 / 降级方式：

<!-- 命中 SQLite migration、system prompt、协议、原生层、fingerprint/OTA 或跨平台差异时，
必须写清影响和回滚/降级方式；不涉及风险时明确写“无”。

改动会改变 mobile runtime fingerprint（即触发冷更）时，还要写明为什么冷更不可避免、
存量装机的影响范围与发版节奏建议；这类 PR 与技术框架变动同级，需仓库指定的把关人针对
冷更明确确认后才能合并（提交者身份不构成例外），规则见
docs/dev-rules/mobile-development.md 的「冷更边界」。 -->

### 提交前检查

- [ ] 已 review 完整 diff
- [ ] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [ ] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [ ] 已确认测试结果或说明未执行原因
