### PR TITLE
fix(desktop): 目录币种裁决只统计计价条目,无价条目不再拖垮 CNY 价格目录

### DIFF
--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -143,7 +143,15 @@ function applyGatewayModels(models: ModelAccessGatewayModel[]): void {
   // 同一次 /models 响应先建立 provider-scoped 价格投影，再做仅影响展示元数据的
   // dev overlay。空成功响应会同时清空模型和价格；请求失败不会调用本函数，
   // 因而保留上一份完整成功快照。
-  replaceGatewayModelPricing(models);
+  const pricing = replaceGatewayModelPricing(models);
+  const quoteCount = Object.keys(pricing.xd ?? {}).length;
+  if (models.length > 0 && quoteCount < models.length) {
+    // 报价覆盖不足此前是静默的(目录币种冲突或缺价字段都会整条丢弃),
+    // #587 只能从空缓存反推;这里留一行日志让现场可判。
+    log.warn(
+      `xd gateway pricing quotes cover ${quoteCount}/${models.length} models`,
+    );
+  }
   // dev:本地目录文件(catalog/providers.json)的 cindyModelMeta 段覆盖服务端下发的
   // 元数据,改本地 json + 重启即可自测,无需发 OSS / 等服务端热加载;只覆盖同 id,
   // 清单成员资格仍以网关为准。packaged 不走此分支(语义见 devMetaOverlay.ts)。

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -18,6 +18,7 @@ import {
   replaceGatewayModelPricing,
   trackGatewayModelPricingSync,
 } from '../usage/modelPricing.js';
+import { isPricedGatewayModel } from '../../shared/modelPriceQuote.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
 import {
   MODEL_ACCESS_STATUS_CHANNEL,
@@ -144,12 +145,14 @@ function applyGatewayModels(models: ModelAccessGatewayModel[]): void {
   // dev overlay。空成功响应会同时清空模型和价格；请求失败不会调用本函数，
   // 因而保留上一份完整成功快照。
   const pricing = replaceGatewayModelPricing(models);
+  // 分母只算会产生报价的条目:免费/无价条目按设计不出报价,不该把健康目录
+  // 也报成覆盖不足。此时覆盖缺口只剩一种成因——币种声明与目录冲突被丢弃,
+  // 这在 #587 之前是全程静默的,这行日志让现场可判。
+  const pricedCount = models.filter(isPricedGatewayModel).length;
   const quoteCount = Object.keys(pricing.xd ?? {}).length;
-  if (models.length > 0 && quoteCount < models.length) {
-    // 报价覆盖不足此前是静默的(目录币种冲突或缺价字段都会整条丢弃),
-    // #587 只能从空缓存反推;这里留一行日志让现场可判。
+  if (quoteCount < pricedCount) {
     log.warn(
-      `xd gateway pricing quotes cover ${quoteCount}/${models.length} models`,
+      `xd gateway pricing quotes cover ${quoteCount}/${pricedCount} priced models (${models.length} total)`,
     );
   }
   // dev:本地目录文件(catalog/providers.json)的 cindyModelMeta 段覆盖服务端下发的

--- a/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
+++ b/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
@@ -58,6 +58,40 @@ describe('resolveGatewayCatalogCurrency', () => {
       ]),
     ).toBe('USD');
   });
+
+  it('excludes price-less entries from the vote — a metadata-only sibling cannot pin CNY catalogs to USD', () => {
+    expect(
+      resolveGatewayCatalogCurrency([
+        model('a', { currency: 'CNY' }),
+        model('doc', {
+          inputCostPerToken: undefined,
+          outputCostPerToken: undefined,
+        }),
+      ]),
+    ).toBe('CNY');
+  });
+
+  it('excludes zero-priced (free) entries from the vote', () => {
+    expect(
+      resolveGatewayCatalogCurrency([
+        model('a', { currency: 'CNY' }),
+        model('free', { inputCostPerToken: 0, outputCostPerToken: 0 }),
+      ]),
+    ).toBe('CNY');
+  });
+
+  it('still keeps the catalog USD when a priced entry lacks the declaration', () => {
+    expect(
+      resolveGatewayCatalogCurrency([
+        model('a', { currency: 'CNY' }),
+        model('b'),
+        model('doc', {
+          inputCostPerToken: undefined,
+          outputCostPerToken: undefined,
+        }),
+      ]),
+    ).toBe('USD');
+  });
 });
 
 describe('gatewayPricingCatalog currency', () => {
@@ -92,5 +126,22 @@ describe('gatewayPricingCatalog currency', () => {
     ]);
     expect(Object.keys(catalog.xd)).toEqual(['b']);
     expect(catalog.xd.b.currency).toBe('USD');
+  });
+
+  it('keeps every CNY quote when the only undeclared sibling is price-less (#587 regression)', () => {
+    const catalog = gatewayPricingCatalog([
+      model('a', { currency: 'CNY' }),
+      model('b', { currency: 'CNY' }),
+      model('doc', {
+        inputCostPerToken: undefined,
+        outputCostPerToken: undefined,
+      }),
+      model('free', { inputCostPerToken: 0, outputCostPerToken: 0 }),
+    ]);
+    expect(Object.keys(catalog.xd)).toEqual(['a', 'b']);
+    expect(Object.values(catalog.xd).map((quote) => quote.currency)).toEqual([
+      'CNY',
+      'CNY',
+    ]);
   });
 });

--- a/apps/desktop/src/shared/modelAccess.ts
+++ b/apps/desktop/src/shared/modelAccess.ts
@@ -156,9 +156,10 @@ export interface ModelAccessGatewayModel extends ModelGroupPricing {
   /**
    * 本条目价格字段的计费币种声明(透传 Gateway)。缺省表示 Gateway 原生口径
    * USD;客户端不得按构建区域改标或折算——单位永远跟随下发数据。
-   * 注意:本地记账账本是单币种的,只有**每个**条目都显式声明同一非 USD 币种
-   * 时目录才整体切换;与目录币种冲突的声明条目不出报价(费用退回 SDK 实报
-   * USD 兜底),见 modelPriceQuote.resolveGatewayCatalogCurrency。
+   * 注意:本地记账账本是单币种的,只有**每个会产生报价**的条目都显式声明同一
+   * 非 USD 币种时目录才整体切换(免费/无价条目不参与裁决);与目录币种冲突的
+   * 声明条目不出报价(费用退回 SDK 实报 USD 兜底),见
+   * modelPriceQuote.resolveGatewayCatalogCurrency。
    */
   currency?: 'USD' | 'CNY';
   /** 进哪些 runtime tab;缺省 = 仅 claude-code(网关 /v1/messages 翻译覆盖面最广)。 */

--- a/apps/desktop/src/shared/modelPriceQuote.ts
+++ b/apps/desktop/src/shared/modelPriceQuote.ts
@@ -68,12 +68,15 @@ function declaredCurrency(
  *   - 与目录币种冲突的声明条目由 gatewayPricingCatalog 丢弃报价(退回 SDK
  *     实报 USD 兜底),而不是改标币种——错标单位正是本模块要杜绝的事。
  */
+/** 该条目是否会产生报价(与币种无关;目录币种裁决与覆盖率统计共用此判定)。 */
+export function isPricedGatewayModel(model: ModelAccessGatewayModel): boolean {
+  return gatewayModelPriceQuote(model) !== undefined;
+}
+
 export function resolveGatewayCatalogCurrency(
   models: readonly ModelAccessGatewayModel[],
 ): MoneyCurrency {
-  const priced = models.filter(
-    (model) => gatewayModelPriceQuote(model) !== undefined,
-  );
+  const priced = models.filter(isPricedGatewayModel);
   if (priced.length === 0) return GATEWAY_NATIVE_CURRENCY;
   const first = declaredCurrency(priced[0]);
   if (!first || first === GATEWAY_NATIVE_CURRENCY) return GATEWAY_NATIVE_CURRENCY;

--- a/apps/desktop/src/shared/modelPriceQuote.ts
+++ b/apps/desktop/src/shared/modelPriceQuote.ts
@@ -60,18 +60,24 @@ function declaredCurrency(
 /**
  * 目录级币种:本地记账账本(daily / session / schedule)都是单币种,逐条目
  * 混用币种会造成同端多币种金额被聚合层丢弃。规则:
- *   - 未声明条目恒为 Gateway 原生 USD(契约缺省),绝不被其它条目的声明改标;
- *   - 只有当**每个**条目都显式声明同一非 USD 币种时,目录才整体切换;
+ *   - 只有**会产生报价**的条目参与裁决:免费/无价条目本就不出报价,它们缺失
+ *     currency 声明不能把整个目录钉回 USD、连带丢弃全部已声明的报价
+ *     (对外 CNY 目录曾因此全军覆没,#587);
+ *   - 未声明的计价条目恒为 Gateway 原生 USD(契约缺省),绝不被其它条目的声明改标;
+ *   - 只有当每个计价条目都显式声明同一非 USD 币种时,目录才整体切换;
  *   - 与目录币种冲突的声明条目由 gatewayPricingCatalog 丢弃报价(退回 SDK
  *     实报 USD 兜底),而不是改标币种——错标单位正是本模块要杜绝的事。
  */
 export function resolveGatewayCatalogCurrency(
   models: readonly ModelAccessGatewayModel[],
 ): MoneyCurrency {
-  if (models.length === 0) return GATEWAY_NATIVE_CURRENCY;
-  const first = declaredCurrency(models[0]);
+  const priced = models.filter(
+    (model) => gatewayModelPriceQuote(model) !== undefined,
+  );
+  if (priced.length === 0) return GATEWAY_NATIVE_CURRENCY;
+  const first = declaredCurrency(priced[0]);
   if (!first || first === GATEWAY_NATIVE_CURRENCY) return GATEWAY_NATIVE_CURRENCY;
-  return models.every((model) => declaredCurrency(model) === first)
+  return priced.every((model) => declaredCurrency(model) === first)
     ? first
     : GATEWAY_NATIVE_CURRENCY;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #587:更新到含 #488 的版本后,对外(CNY 计费)用户的模型选择下拉框里价格与「是否免费」标识全部消失。

根因:#488 引入的目录级币种裁决 `resolveGatewayCatalogCurrency` 要求 `/models` 下发的**每一个**条目都显式声明同一非 USD 币种,目录才切换到该币种;否则目录按 USD 处理,并把所有声明了 CNY 的条目的报价整条丢弃。参与裁决的包括**根本不会产生报价的条目**(免费模型、无价格字段的条目)——只要清单里有一个这样的条目没带 `currency` 声明,整个 CNY 目录的报价就会全军覆没,而且丢弃是静默的,一行日志都没有。

实机复现(macOS,0.1.15,CN 区):日志显示 `xd gateway models synced: 67`,同一毫秒写入的 `cache/model-pricing.json`(v4)价格目录为空——67 个模型 0 条报价。

修复:

- 币种裁决只统计**会产生报价**的条目(与 `gatewayPricingCatalog` 出报价的判定同一口径),免费/无价条目不再参与投票;
- 计价条目之间的既有语义完全不变:未声明恒 USD、必须全体一致才切换、冲突条目丢弃报价不改标——#488 杜绝「单位错标」的方向原样保留;
- 补一行覆盖率日志:同步成功但报价覆盖不足时输出 `xd gateway pricing quotes cover N/M models`,这类丢弃不再静默,现场可判。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求:#587(现象),#488(引入语义)
- 本 PR 包含:`resolveGatewayCatalogCurrency` 裁决口径修正、相关注释同步(`modelAccess.ts`)、报价覆盖率日志、5 个新增单测
- 明确不包含:服务端 `/models` 下发内容的任何假设修正;计价条目声明不一致时的丢弃语义(维持 #488 设计)
- 用户可见变化:CNY 目录在存在免费/无价条目时恢复显示价格与免费标识
- 是否存在 breaking change:无

### UI 变化

不涉及:纯数据层修复,UI 代码零改动;价格展示恢复为 #488 之前的既有样式。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:通过(全仓单元测试,含本 PR 新增 5 例)

pnpm --filter desktop run --if-present typecheck
结果:通过
```

### 手工验证

不涉及运行时 UI 目检(无 UI 改动)。根因链在实机(macOS 0.1.15,CN 区外部账号)上确认:模型同步 67 条、价格投影为空、选择器无价格,与 #587 报告一致。

### 未执行的验证

未对真实 CN 网关 `/models` 响应做端到端回归(需要重新打包客户端);新增单测覆盖了「CNY 声明 + 无价条目缺声明」的最小复现。若线上清单中存在**计价**条目缺 `currency` 声明,本修复不掩盖该问题——覆盖率日志会显性暴露,需服务端补声明。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:`apps/desktop` 价格投影(模型选择器展示价、单轮费用记账的报价来源);USD 目录(全部条目未声明)行为零变化
- 回滚 / 降级方式:revert 本 PR 即回到 #488 语义;价格磁盘缓存版本未变,无需迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
