### PR TITLE
fix(scheduler): resume() 的 interval 任务按冷启动从 now 起算,不再沿用旧节奏

### DIFF
--- a/packages/maker-scheduler/src/__tests__/scheduler.test.ts
+++ b/packages/maker-scheduler/src/__tests__/scheduler.test.ts
@@ -737,6 +737,40 @@ describe('Scheduler', () => {
     expect(after?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 5, 10, 0));
   });
 
+  it('resume() with intervalMs cold-starts from now even when the last run is recent', async () => {
+    // Regression: resume is documented as a cold start ("起新一轮 N 倒计时"), matching
+    // update()'s `now + intervalMs`. A schedule that finished 17:22:25 with a 1h
+    // interval, resumed at 17:40:00 (well within that hour), must re-arm at
+    // now + 1h = 18:40:00 — NOT lastFinishedAt + 1h = 18:22:25. The latter is
+    // start()/restart's "respect the original cadence" semantics, which must not
+    // leak into a user-initiated resume.
+    h.storage.schedules.set('hourly', {
+      id: 'hourly',
+      name: 'every hour',
+      prompt: 'p',
+      kind: 'cron',
+      cronExpr: '0 * * * *',
+      intervalMs: 60 * 60_000,
+      timezone: 'UTC',
+      recurring: true,
+      manual: false,
+      agentKind: 'claude-code',
+      workspaceKind: 'project',
+      useWorktree: false,
+      notify: { desktop: false, feishu: false },
+      status: 'paused',
+      createdAt: Date.UTC(2026, 0, 1, 16, 0, 0),
+      updatedAt: 0,
+      lastFiredAt: Date.UTC(2026, 0, 1, 17, 22, 18),
+      lastFinishedAt: Date.UTC(2026, 0, 1, 17, 22, 25),
+      nextFireAt: Date.UTC(2026, 0, 1, 18, 22, 25),
+    });
+    h.clock.setTo(Date.UTC(2026, 0, 1, 17, 40, 0));
+    await h.scheduler.resume('hourly');
+    const after = await h.storage.get('hourly');
+    expect(after?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 18, 40, 0));
+  });
+
   // ── update() 在用户编辑时是否立刻取消 pending fire ──
   // 用户体感："Next 13:50" 还有 9 分钟到，我把 Every 10min 改成 Every 5min，
   // 应该看到 nextFireAt 立刻刷成 now+5min（取消旧的 13:50）。

--- a/packages/maker-scheduler/src/engine/scheduler.ts
+++ b/packages/maker-scheduler/src/engine/scheduler.ts
@@ -1111,10 +1111,12 @@ export class Scheduler extends EventEmitter {
     const existing = await this.storage.get(id);
     if (!existing) throw new Error(`Schedule not found: ${id}`);
     const now = this.clock.now();
-    // resume 视作冷启动：interval 模式起新一轮 N 倒计时；cron 模式找下一个壁钟槽位。
+    // resume 视作冷启动：interval 模式起新一轮 N 倒计时（从 now 起算，与 update() 一致）；
+    // cron 模式找下一个壁钟槽位。不要复用 nextIntervalFire —— 它按 lastFinishedAt+N 尊重原
+    // 节奏（restart 语义），会让「上次完成不到一个 N 就 resume」比冷启动更早触发。
     const next =
       existing.intervalMs !== undefined
-        ? nextIntervalFire(existing.lastFinishedAt ?? existing.createdAt, existing.intervalMs, now)
+        ? now + existing.intervalMs
         : nextCronOrMonthlyFire(existing.cronExpr, now, existing.timezone);
     const updated = await this.storage.update(id, {
       status: 'active',


### PR DESCRIPTION
## 这次改了什么

### 摘要

`Scheduler.resume()`（`packages/maker-scheduler/src/engine/scheduler.ts` 的 `resumeUnlocked`）对 interval 任务的下次触发时间算错。它的注释与测试名都把 resume 定义为「冷启动：interval 模式起新一轮 N 倒计时」，同类的 `update()` 也用 `now + intervalMs`；但 resume 实际调用的是 `nextIntervalFire(lastFinishedAt ?? createdAt, intervalMs, now)`——该 helper 的语义是「`base + intervalMs` 若仍在未来就沿用」，这是 `start()`/restart「尊重原节奏、重启不重置」的语义。

于是当用户在「距上次完成不到一个 N」的窗口内暂停后再 resume 时，下次触发会落在 `lastFinishedAt + N` 而不是 `now + N`——比冷启动更早触发。改为直接 `now + intervalMs`，与 `update()` 及注释/测试名对齐。`nextIntervalFire` 仍由 `start()`/restart 使用，语义不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`resumeUnlocked` 的 interval 分支改为 `now + intervalMs`；补一条回归测试
- 明确不包含：不改 `start()`/restart 的 `nextIntervalFire` 语义，不改 cron 分支，不动其它文件
- 用户可见变化：对按间隔运行的定时任务，暂停后 resume 现在从「当下」起重新倒计时一个完整间隔（与 UI/文档承诺一致）
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
# 修复前跑新增回归测试（TDD 红）：
pnpm --filter @cindy/maker-scheduler exec vitest run src/__tests__/scheduler.test.ts -t "cold-starts from now even when the last run is recent"
结果：1 failed —— 期望 18:40:00(now+1h)，实际 18:22:25(lastFinishedAt+1h)

# 修复后：
pnpm --filter @cindy/maker-scheduler test
结果：Test Files 5 passed (5) | Tests 152 passed (152)

pnpm --filter @cindy/maker-scheduler run build   # tsc --noEmit
结果：通过，无类型错误

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

### 手工验证

不涉及（纯时间计算，已由回归测试锁定；场景：1h 间隔任务，17:22:25 完成、暂停，17:40:00 resume → 重排到 18:40:00 而非 18:22:25）。

### 未执行的验证

未跑仓库根的全量 `pnpm test:unit`：本机环境下 `electron` 二进制下载被网络拦截（`connect ETIMEDOUT`），desktop 相关用例无法在本地启动，与本改动无关。本 PR 仅触及 `@cindy/maker-scheduler` 单个包，已对该包跑完整单测 + typecheck，并跑通 `check:dco`；其余交由 CI 门禁。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 `Scheduler.resume()` 对 interval 任务重算 `nextFireAt` 的取值。修正方向是「更晚而非更早」触发（回到文档承诺的冷启动语义），不会造成漏跑或提前越权。cron / monthly 任务、`start()`/restart、`update()` 均不受影响。
- 回滚 / 降级方式：单 commit，`git revert` 即可完全还原。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`resumeUnlocked` 注释已说明为何不复用 `nextIntervalFire`）
- [x] 已确认测试结果或说明未执行原因
