### PR TITLE
fix(desktop): expand Claude usage reset tooltip

### DIFF
--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.behavior.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.behavior.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTranslation } from 'react-i18next';
+
+import enCommon from '../i18n/locales/en/common.json';
+import koCommon from '../i18n/locales/ko/common.json';
+import type { ClaudeSubscriptionUsageSnapshot } from '../hooks/useClaudeSubscriptionUsage';
+
+const mocks = vi.hoisted(() => ({
+  useClaudeSubscriptionUsage: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: vi.fn(),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ text, children }: { text: React.ReactNode; children: React.ReactElement }) => (
+    <>
+      {children}
+      <div data-testid="usage-tooltip">{text}</div>
+    </>
+  ),
+}));
+
+vi.mock('@/hooks/useApiKey', () => ({
+  useApiKey: () => ({ hasSavedKey: false, isReconciling: false }),
+}));
+vi.mock('@/hooks/useClaudeOAuthConnected', () => ({
+  useClaudeOAuthConnected: () => true,
+}));
+vi.mock('@/hooks/useClaudeSessionRoute', () => ({
+  useClaudeSessionRoute: () => null,
+}));
+vi.mock('@/hooks/useSessionSpend', () => ({
+  useSessionSpend: () => null,
+}));
+vi.mock('@/hooks/useSessionEstimatedValue', () => ({
+  useSessionEstimatedValue: () => null,
+}));
+vi.mock('@/hooks/useSessionTokens', () => ({
+  useSessionTokens: () => null,
+}));
+vi.mock('@/components/chat/ChatDisplaySnapshotContext', () => ({
+  useChatDisplaySnapshot: () => null,
+}));
+vi.mock('@/hooks/useAccountUsage', () => ({
+  requestCodexAccountRefresh: vi.fn(),
+  useAccountUsage: () => null,
+}));
+vi.mock('@/hooks/useClaudeAccountUsage', () => ({
+  useClaudeAccountUsage: () => null,
+}));
+vi.mock('@/hooks/useClaudeSubscriptionUsage', () => ({
+  requestClaudeSubscriptionRefresh: vi.fn(),
+  useClaudeSubscriptionUsage: mocks.useClaudeSubscriptionUsage,
+}));
+vi.mock('@/hooks/useCodexRuntimeRoute', () => ({
+  useCodexRuntimeRoute: () => ({ authInjection: null }),
+}));
+vi.mock('@/hooks/useXaiRateLimit', () => ({
+  useXaiRateLimit: () => null,
+}));
+vi.mock('@/lib/makerChatStore', () => ({
+  makerChatStore: {
+    getSnapshot: () => ({ messages: [] }),
+    subscribe: () => () => {},
+  },
+}));
+vi.mock('../components/status/quotaResetRollup', () => ({
+  RESET_PENDING_MAX_MS: 10 * 60_000,
+  computeCountdownTickDelayMs: () => 60_000,
+  useQuotaResetRollup: (
+    slot: { remainingPercent: number } | null,
+  ) => slot ? { percent: slot.remainingPercent, celebrating: false } : null,
+}));
+vi.mock('../components/status/QuotaResetConfetti', () => ({
+  QuotaResetConfetti: () => null,
+}));
+
+import { TodaySpendChip } from '../components/status/TodaySpendChip';
+
+type LocaleCatalog = Record<string, unknown>;
+
+function readCatalogValue(catalog: LocaleCatalog, key: string): string {
+  const value = key.split('.').reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, catalog);
+  if (typeof value !== 'string') throw new Error(`Missing test translation: ${key}`);
+  return value;
+}
+
+function makeTranslator(catalog: LocaleCatalog) {
+  return (key: string, values?: Record<string, unknown>): string =>
+    readCatalogValue(catalog, key).replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+      String(values?.[name] ?? ''),
+    );
+}
+
+// 选择 UTC / Asia-Shanghai 下都不会跨天的时刻,让 resetAt 稳定走“当天只显时分”分支。
+const NOW_MS = Date.parse('2026-07-25T08:00:00.000Z');
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const RESET_AT_SECONDS = Math.floor((NOW_MS + FIVE_HOURS_MS) / 1000);
+
+function formatResetAtForTest(epochSeconds: number): string {
+  const date = new Date(epochSeconds * 1000);
+  const sameDay = date.toDateString() === new Date().toDateString();
+  return new Intl.DateTimeFormat(
+    undefined,
+    sameDay
+      ? { hour: 'numeric', minute: '2-digit' }
+      : { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' },
+  ).format(date);
+}
+
+function usageSnapshot(): ClaudeSubscriptionUsageSnapshot {
+  return {
+    subscriptionType: 'pro',
+    fiveHour: { utilization: 5, resetsAt: RESET_AT_SECONDS },
+    sevenDay: { utilization: 25, resetsAt: RESET_AT_SECONDS },
+    scoped: [{
+      modelDisplayName: 'Fable',
+      utilization: 25,
+      resetsAt: RESET_AT_SECONDS,
+    }],
+  };
+}
+
+function renderClaudeUsage(catalog: LocaleCatalog) {
+  vi.mocked(useTranslation).mockReturnValue({
+    t: makeTranslator(catalog),
+  } as never);
+  mocks.useClaudeSubscriptionUsage.mockReturnValue(usageSnapshot());
+  render(
+    <TodaySpendChip
+      vendorKey="cc"
+      providerId="anthropic"
+      modelId="claude-fable"
+    />,
+  );
+}
+
+describe('TodaySpendChip Claude subscription presentation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('keeps reset countdowns in the chip and renders complete reset details in the tooltip', () => {
+    renderClaudeUsage(enCommon);
+
+    expect(screen.getByText('5h 95% left')).toBeTruthy();
+    expect(screen.getByText('Fable 5h 75% left')).toBeTruthy();
+
+    const resetAt = formatResetAtForTest(RESET_AT_SECONDS);
+    const tooltipText = screen.getByTestId('usage-tooltip').textContent;
+    expect(tooltipText).toContain(
+      `Weekly 75% left (25% used) · resets in 5h (${resetAt})`,
+    );
+    expect(tooltipText).toContain(
+      `Fable weekly 75% left (25% used) · resets in 5h (${resetAt})`,
+    );
+  });
+
+  it('keeps a space before the Korean reset-time parenthesis', () => {
+    renderClaudeUsage(koCommon);
+
+    const resetAt = formatResetAtForTest(RESET_AT_SECONDS);
+    expect(screen.getByTestId('usage-tooltip').textContent).toContain(
+      `재설정 (${resetAt})`,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -189,6 +189,7 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain('todaySpend.claude.weeklyLabel');
     expect(source).toContain('todaySpend.claude.windowLine');
     expect(source).toContain('todaySpend.claude.resetAt');
+    expect(source).toContain('todaySpend.claude.resetInAt');
     // chip 周限段: scoped 命中时倒计时前带模型名标注口径 (「Fable 7天 剩余 78%」)
     expect(source).toContain('weekly.modelDisplayName ? `${weekly.modelDisplayName} ${countdown}` : countdown');
     expect(source).toContain('todaySpend.claude.sessionValueLabel');

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -534,6 +534,8 @@ interface ClaudeWindowUsage {
   label: string;
   used: string;
   remaining: string;
+  /** tooltip 用的相对 reset 倒计时;无数据 / 已过期 → null。 */
+  resetIn: string | null;
   /** tooltip 用的精确 reset 时间点;无数据 → null。 */
   resetAt: string | null;
 }
@@ -541,6 +543,8 @@ interface ClaudeWindowUsage {
 function toClaudeWindowUsage(
   label: string,
   window: ClaudeUsageWindow | null | undefined,
+  nowMs: number,
+  t: TFunction,
 ): ClaudeWindowUsage | null {
   if (!window || typeof window.utilization !== 'number' || !Number.isFinite(window.utilization)) {
     return null;
@@ -550,6 +554,7 @@ function toClaudeWindowUsage(
     label,
     used: formatPercent(usedPercent),
     remaining: formatPercent(100 - usedPercent),
+    resetIn: formatCompactTimeUntilReset(window.resetsAt, nowMs, t),
     resetAt: formatResetAt(window.resetsAt),
   };
 }
@@ -638,6 +643,7 @@ function buildClaudeSubscriptionTooltipNode(
   modelId: string | null | undefined,
   sessionValueMoney: RegionalMoney | null,
   t: TFunction,
+  nowMs: number,
   usageDashboardLabel: string | null,
   latestTurnUsage: LatestTurnUsageSummary | null,
 ): React.ReactNode {
@@ -660,16 +666,23 @@ function buildClaudeSubscriptionTooltipNode(
   }
 
   // 窗口明细: 5h → 总周限 → 全部分模型周限 (含非当前模型, 用户能看到谁先见底)。
-  // tooltip 保留精确 reset 时间点 (chip 上是倒计时, 两层信息互补)。
+  // chip 显示 reset 倒计时;tooltip 额外保留窗口身份、相对倒计时和精确 reset 时间点。
   const windows: ClaudeWindowUsage[] = [];
-  const fiveHour = toClaudeWindowUsage('5h', snapshot.fiveHour);
+  const fiveHour = toClaudeWindowUsage('5h', snapshot.fiveHour, nowMs, t);
   if (fiveHour) windows.push(fiveHour);
-  const sevenDay = toClaudeWindowUsage(t('todaySpend.claude.weeklyLabel'), snapshot.sevenDay);
+  const sevenDay = toClaudeWindowUsage(
+    t('todaySpend.claude.weeklyLabel'),
+    snapshot.sevenDay,
+    nowMs,
+    t,
+  );
   if (sevenDay) windows.push(sevenDay);
   for (const scoped of snapshot.scoped ?? []) {
     const usage = toClaudeWindowUsage(
       t('todaySpend.claude.modelWeeklyLabel', { model: scoped.modelDisplayName }),
       scoped,
+      nowMs,
+      t,
     );
     if (usage) windows.push(usage);
   }
@@ -679,10 +692,16 @@ function buildClaudeSubscriptionTooltipNode(
       remaining: window.remaining,
       used: window.used,
     });
-    lines.push(window.resetAt
-      ? `${base} · ${t('todaySpend.claude.resetAt', { at: window.resetAt })}`
-      : base,
-    );
+    let resetLabel: string | null = null;
+    if (window.resetAt && window.resetIn) {
+      resetLabel = t('todaySpend.claude.resetInAt', {
+        countdown: window.resetIn,
+        at: window.resetAt,
+      });
+    } else if (window.resetAt) {
+      resetLabel = t('todaySpend.claude.resetAt', { at: window.resetAt });
+    }
+    lines.push(resetLabel ? `${base} · ${resetLabel}` : base);
   }
 
   // tooltip 比 chip 宽一档: allowed_warning (服务端综合全部窗口的模糊信号) 也提示 ——
@@ -1289,7 +1308,7 @@ export function TodaySpendChip({
     );
   } else if (isClaudeSubscription) {
     // Claude 订阅形态 (方案 B): chip 显示「剩余时长 剩余%」倒计时段 + 本会话价值,
-    // 倒计时由 windowLabelNowMs 驱动 (常态 60s tick, 最后一分钟逐秒); tooltip 保留精确时间。
+    // 倒计时由 windowLabelNowMs 驱动;tooltip 保留窗口身份、相对倒计时与精确时间。
     const chipSegments = [...windowSegments];
     if (sessionEstimatedValueMoney) {
       chipSegments.push(t('todaySpend.claude.sessionValueLabel', {
@@ -1304,6 +1323,7 @@ export function TodaySpendChip({
       modelId,
       sessionEstimatedValueMoney,
       t,
+      windowLabelNowMs,
       usageDashboardLabel,
       latestTurnUsage,
     );

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3109,6 +3109,7 @@
       "modelWeeklyLabel": "{{model}} weekly",
       "windowSegment": "{{label}} {{remaining}} left",
       "resetAt": "resets {{at}}",
+      "resetInAt": "resets in {{countdown}} ({{at}})",
       "windowLine": "{{label}} {{remaining}} left ({{used}} used)",
       "sessionValueLabel": "Session value {{cost}}",
       "planLine": "Plan {{plan}}",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3108,6 +3108,7 @@
       "modelWeeklyLabel": "{{model}} 週間",
       "windowSegment": "{{label}} 残り {{remaining}}",
       "resetAt": "{{at}} にリセット",
+      "resetInAt": "{{countdown}}後にリセット（{{at}}）",
       "windowLine": "{{label}} 残り {{remaining}} (使用済み {{used}})",
       "sessionValueLabel": "このセッションの価値 {{cost}}",
       "planLine": "プラン {{plan}}",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3108,6 +3108,7 @@
       "modelWeeklyLabel": "{{model}} 주간",
       "windowSegment": "{{label}} {{remaining}} 남음",
       "resetAt": "{{at}} 재설정",
+      "resetInAt": "{{countdown}} 후 재설정 ({{at}})",
       "windowLine": "{{label}} 남음 {{remaining}} (사용 {{used}})",
       "sessionValueLabel": "세션 가치 {{cost}}",
       "planLine": "플랜 {{plan}}",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3108,6 +3108,7 @@
       "modelWeeklyLabel": "{{model}} 周限",
       "windowSegment": "{{label}} 剩余 {{remaining}}",
       "resetAt": "{{at}} 重置",
+      "resetInAt": "{{countdown}}后重置（{{at}}）",
       "windowLine": "{{label}} 剩余 {{remaining}}(已用 {{used}})",
       "sessionValueLabel": "本对话价值 {{cost}}",
       "planLine": "套餐 {{plan}}",


### PR DESCRIPTION
> [!NOTE]
> Follow-up to #568 and its revert `36a2c406`. This keeps the developer-designed countdown labels in the bottom bar while restoring only the richer tooltip details.

## 这次改了什么

### 摘要

保留 Claude 订阅用量底栏原有的 reset 倒计时设计，例如 `5h 95% left | Fable 5h 75% left`；tooltip 则完整展示窗口身份、剩余/已用比例、相对倒计时和绝对重置时刻，例如 `Weekly 75% left (25% used) · resets in 5h (9:00 PM)`。

本 PR 从最新 `upstream/main` 创建，只重新引入 tooltip 增强，不改变底栏窗口 label 逻辑。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：开发者反馈底栏倒计时是特意设计的逻辑；保留 #568 中 tooltip 的完整信息
- 本 PR 包含：Desktop Renderer 的 Claude 用量 tooltip 组合逻辑、四语 reset 文案、组件行为测试
- 明确不包含：底栏倒计时逻辑、订阅后台、用量数据获取与刷新、布局和视觉样式、Codex 用量展示
- 用户可见变化：底栏保持现状；悬停后可同时看到窗口身份、用量、相对倒计时和绝对时间
- 是否存在 breaking change：无

### UI 变化

- 无截图：未修改布局、颜色、字号或动效，仅补全既有 tooltip 的信息层级
- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 Typography Rules / Hierarchy 与 §11 Voice & Content；底栏继续使用原有紧凑倒计时，tooltip 作为渐进披露承载完整信息。未新增样式，Light / Dark 继续共用既有语义 token

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，全部适用 workspace 单元测试通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/todaySpendChip.test.ts src/renderer/__tests__/todaySpendChip.behavior.test.tsx
结果：通过，19/19

pnpm check:i18n
结果：通过，四语 key 一致；仅报告仓库既有非阻塞 warning

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

未执行。

### 未执行的验证

未使用真实 Anthropic 订阅账号启动 Desktop 做视觉走查；当前环境没有对应在线账号会话。用量窗口、底栏倒计时、完整 tooltip 及本地时区格式由组件行为测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的 Claude 订阅用量 tooltip
- 回滚 / 降级方式：回退本 PR 的单个提交；不涉及数据迁移或持久化格式

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外产品文档）
- [x] 已确认测试结果或说明未执行原因
