### PR TITLE
fix(desktop): 修复模型选择列表订阅类模型名称显示不全的问题

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1282,11 +1282,16 @@ function ModelSelectorContentView({
                         <Tip text={t('settings.providers.models.subscription')}>
                           <span
                             data-model-subscription-badge="pill"
-                            aria-label={t('settings.providers.models.subscription')}
-                            className="inline-flex h-[20px] shrink-0 items-center gap-1.5 rounded-full bg-black/[0.04] px-2 py-0.5 text-11 transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:hover:bg-white/[0.14]"
+                            className="inline-flex h-[20px] shrink-0 items-center gap-1.5 rounded-full bg-[var(--surface-chip)] px-2 py-0.5 text-11 transition-colors hover:bg-[var(--surface-hover)]"
                           >
-                            <BrandArrow size={12} className="shrink-0 text-[#FF3B30] dark:text-[#FF453A]" />
-                            <span className="sr-only">{t('settings.providers.models.subscription')}</span>
+                            <BrandArrow
+                              size={12}
+                              className="shrink-0 text-[var(--login-brand-accent)]"
+                            />
+                            {/* sr-only: 订阅语义进 option 可访问名;Tip 仅指针可见 */}
+                            <span className="sr-only">
+                              {t('settings.providers.models.subscription')}
+                            </span>
                             <span
                               data-model-price-stack={rowPrice.original ? 'true' : undefined}
                               className={cn(
@@ -1309,11 +1314,15 @@ function ModelSelectorContentView({
                         <Tip text={t('settings.providers.models.subscription')}>
                           <span
                             data-model-subscription-badge="compact"
-                            aria-label={t('settings.providers.models.subscription')}
-                            className="inline-flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded-full bg-black/[0.04] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:hover:bg-white/[0.14]"
+                            className="inline-flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded-full bg-[var(--surface-chip)] transition-colors hover:bg-[var(--surface-hover)]"
                           >
-                            <BrandArrow size={12} className="text-[#FF3B30] dark:text-[#FF453A]" />
-                            <span className="sr-only">{t('settings.providers.models.subscription')}</span>
+                            <BrandArrow
+                              size={12}
+                              className="text-[var(--login-brand-accent)]"
+                            />
+                            <span className="sr-only">
+                              {t('settings.providers.models.subscription')}
+                            </span>
                           </span>
                         </Tip>
                       ))}
@@ -1501,8 +1510,9 @@ function ModelSelectorContentView({
       {/* 模型列表 —— 单栏;分段(供应商)或 flat。 */}
       <div
         ref={listRef}
-        // pr-1 保持内缩边距,使滚动条与左右内边距对称内嵌(避免贴死面板卡片外框);细滚动条见 globals.css
-        className="morph-panel-list-scroll flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain pr-1"
+        // -mr-2 把滚动条挪进面板右侧 8px 留白;scrollbar-gutter:stable 让无滚动时
+        // 行宽与有滚动时一致(否则行会比搜索框宽 8px);细滚动条见 globals.css
+        className="morph-panel-list-scroll -mr-2 flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
         style={
           constrainedListMaxHeight === undefined
             ? undefined

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1510,9 +1510,10 @@ function ModelSelectorContentView({
       {/* 模型列表 —— 单栏;分段(供应商)或 flat。 */}
       <div
         ref={listRef}
-        // -mr-2 把滚动条挪进面板右侧 8px 留白;scrollbar-gutter:stable 让无滚动时
-        // 行宽与有滚动时一致(否则行会比搜索框宽 8px);细滚动条见 globals.css
-        className="morph-panel-list-scroll -mr-2 flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
+        // 不使用 -mr-2 / scrollbar-gutter:stable:
+        // 列表落在 pane 的 p-2 内,左右与搜索框同宽对齐,滚动条内嵌不贴浮层外框;
+        // pr-1 给滚动条与行内容之间留一点气口。细滚动条见 globals.css。
+        className="morph-panel-list-scroll flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain pr-1"
         style={
           constrainedListMaxHeight === undefined
             ? undefined

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -15,9 +15,11 @@ import { flashScrollbar } from '@/lib/scrollbarAutoHide';
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { MorphPopover } from '@/components/ui/morph-popover';
 import { AnthropicMark } from '@/components/icons/AnthropicMark';
+import { BrandArrow } from '@/components/icons/BrandArrow';
 import { OpenAIMark } from '@/components/icons/OpenAIMark';
 import { XDIncMark } from '@/components/icons/XDIncMark';
 import { hasProviderLogo, ProviderLogoMark } from '@/components/icons/ProviderLogoMark';
+import { Tip } from '@/components/ui/tooltip';
 import { FastModeToggle } from './FastModeToggle';
 import { VendorSegmentedSwitcher } from './VendorSegmentedSwitcher';
 import { useAgentCapabilities, type AgentKind } from '@/hooks/useAgentCapabilities';
@@ -252,7 +254,7 @@ function ModelPromotionBadge({ children }: { children: ReactNode }) {
   return (
     <span
       data-model-promotion-badge
-      className="inline-flex shrink-0 items-center rounded-full bg-[var(--accent-cta-bg)] px-2 py-[1px] text-11 font-medium leading-[1.45] text-[var(--accent-pure-cta-fg)]"
+      className="inline-flex min-w-0 max-w-[140px] shrink items-center truncate rounded-full bg-[var(--accent-cta-bg)] px-2 py-[1px] text-11 font-medium leading-[1.45] text-[var(--accent-pure-cta-fg)]"
     >
       {children}
     </span>
@@ -1274,14 +1276,49 @@ function ModelSelectorContentView({
                   )}
                 </span>
                 {(isSubscriptionModel || isBudgetModel || rowPromotionLabel) && (
-                  <span data-model-tags className="ml-auto flex shrink-0 items-center gap-1.5">
-                    {isSubscriptionModel && (
-                      <span className="inline-flex shrink-0 items-center rounded-full bg-[var(--surface-chip)] px-2 py-[1px] text-[11px] font-medium text-[var(--text-secondary)]">
-                        {t('settings.providers.models.subscription')}
-                      </span>
-                    )}
+                  <span data-model-tags className="ml-auto flex min-w-0 shrink items-center gap-1.5">
+                    {isSubscriptionModel &&
+                      (rowPrice?.kind === 'priced' ? (
+                        <Tip text={t('settings.providers.models.subscription')}>
+                          <span
+                            data-model-subscription-badge="pill"
+                            aria-label={t('settings.providers.models.subscription')}
+                            className="inline-flex h-[20px] shrink-0 items-center gap-1.5 rounded-full bg-black/[0.04] px-2 py-0.5 text-11 transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:hover:bg-white/[0.14]"
+                          >
+                            <BrandArrow size={12} className="shrink-0 text-[#FF3B30] dark:text-[#FF453A]" />
+                            <span className="sr-only">{t('settings.providers.models.subscription')}</span>
+                            <span
+                              data-model-price-stack={rowPrice.original ? 'true' : undefined}
+                              className={cn(
+                                'flex tabular-nums text-11 font-normal leading-[1.25]',
+                                rowPrice.original ? 'flex-col items-end' : 'items-center',
+                              )}
+                            >
+                              <span className="text-[var(--text-secondary)]">
+                                {formatModelPricePair(rowPrice.current)}
+                              </span>
+                              {rowPrice.original && (
+                                <span className="text-[var(--text-tertiary)] line-through">
+                                  {formatModelPricePair(rowPrice.original)}
+                                </span>
+                              )}
+                            </span>
+                          </span>
+                        </Tip>
+                      ) : (
+                        <Tip text={t('settings.providers.models.subscription')}>
+                          <span
+                            data-model-subscription-badge="compact"
+                            aria-label={t('settings.providers.models.subscription')}
+                            className="inline-flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded-full bg-black/[0.04] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:hover:bg-white/[0.14]"
+                          >
+                            <BrandArrow size={12} className="text-[#FF3B30] dark:text-[#FF453A]" />
+                            <span className="sr-only">{t('settings.providers.models.subscription')}</span>
+                          </span>
+                        </Tip>
+                      ))}
                     {isBudgetModel && (
-                      <span className="inline-flex shrink-0 items-center rounded-full bg-[var(--model-budget-badge-bg)] px-2 py-[1px] text-[11px] font-medium text-[var(--model-budget-badge-text)]">
+                      <span className="inline-flex min-w-0 max-w-[120px] shrink items-center truncate rounded-full bg-[var(--model-budget-badge-bg)] px-2 py-[1px] text-[11px] font-medium text-[var(--model-budget-badge-text)]">
                         {t('newChat.modelSelector.meta.budgetDiscount')}
                       </span>
                     )}
@@ -1292,9 +1329,9 @@ function ModelSelectorContentView({
                 )}
               </span>
             </span>
-            {(rowPrice?.kind === 'priced' || isSelected) && (
+            {((rowPrice?.kind === 'priced' && !isSubscriptionModel) || isSelected) && (
               <span className="ml-2 flex shrink-0 items-center gap-1.5">
-                {rowPrice?.kind === 'priced' && (
+                {rowPrice?.kind === 'priced' && !isSubscriptionModel && (
                   <span
                     data-model-price-stack={rowPrice.original ? 'true' : undefined}
                     className={cn(
@@ -1464,9 +1501,8 @@ function ModelSelectorContentView({
       {/* 模型列表 —— 单栏;分段(供应商)或 flat。 */}
       <div
         ref={listRef}
-        // -mr-2 把滚动条挪进面板右侧 8px 留白;scrollbar-gutter:stable 让无滚动时
-        // 行宽与有滚动时一致(否则行会比搜索框宽 8px);细滚动条见 globals.css
-        className="morph-panel-list-scroll -mr-2 flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
+        // pr-1 保持内缩边距,使滚动条与左右内边距对称内嵌(避免贴死面板卡片外框);细滚动条见 globals.css
+        className="morph-panel-list-scroll flex max-h-[300px] flex-col gap-0.5 overflow-y-auto overscroll-contain pr-1"
         style={
           constrainedListMaxHeight === undefined
             ? undefined
@@ -2004,6 +2040,7 @@ export function ModelSelector({
         onOpenChange={(next) => setOpen(disabled ? false : next)}
         side={popoverSide}
         align="end"
+        panelWidth={isFieldTrigger ? undefined : 320}
         wrapperClassName="min-w-0 max-w-full shrink"
         panelClassName="p-0"
         panelAriaLabel={ariaLabel}

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1236,7 +1236,9 @@ function ModelSelectorContentView({
               handleRowSelect(providerId, model.id);
             }}
             className={cn(
-              'flex w-full cursor-pointer items-center justify-between rounded-[8px] px-3 py-2',
+              // 单行三槽:icon | 名称(可截断) | 右侧 meta(徽章/价/对勾) shrink-0 贴右,
+              // 避免徽章嵌在名称 flex-1 里导致「限时免费 + 对勾」停在行中、右侧空一截。
+              'flex w-full cursor-pointer items-center gap-2.5 rounded-[8px] px-3 py-2',
               constrainedListMaxHeight !== undefined && 'min-h-11',
               'transition-colors duration-100 hover:bg-[var(--model-item-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
               isSelected && 'bg-[var(--model-item-hover)]',
@@ -1245,38 +1247,42 @@ function ModelSelectorContentView({
               disabled && 'cursor-not-allowed opacity-50 hover:bg-transparent',
             )}
           >
-            <span className="flex min-w-0 flex-1 items-center gap-2.5">
-              {provider && (
-                <ModelIconMark
-                  icon={model.icon}
-                  providerId={provider.id}
-                  name={provider.name}
-                  routing={provider.routing}
-                  colorClass="text-[var(--text-secondary)]"
-                  withMargin={false}
-                  dense
+            {provider && (
+              <ModelIconMark
+                icon={model.icon}
+                providerId={provider.id}
+                name={provider.name}
+                routing={provider.routing}
+                colorClass="text-[var(--text-secondary)]"
+                withMargin={false}
+                dense
+              />
+            )}
+            <span className="flex min-w-0 flex-1 items-center gap-1.5">
+              <span className="truncate text-14 font-medium text-[var(--model-item-text)]">
+                {model.displayName}
+              </span>
+              {rowEffort && (
+                <span className="shrink-0 text-13 font-normal text-[var(--text-tertiary)]">
+                  {effortLabelFor(model, rowEffort)}
+                </span>
+              )}
+              {rowFastOn && (
+                <Zap
+                  size={13}
+                  className="shrink-0 text-[var(--text-tertiary)]"
+                  aria-label={t('newChat.modelSelector.meta.fastBadge')}
                 />
               )}
-              <span className="flex min-w-0 flex-1 items-center gap-1.5">
-                <span className="flex min-w-0 flex-1 items-center gap-1.5">
-                  <span className="truncate text-14 font-medium text-[var(--model-item-text)]">
-                    {model.displayName}
-                  </span>
-                  {rowEffort && (
-                    <span className="shrink-0 text-13 font-normal text-[var(--text-tertiary)]">
-                      {effortLabelFor(model, rowEffort)}
-                    </span>
-                  )}
-                  {rowFastOn && (
-                    <Zap
-                      size={13}
-                      className="shrink-0 text-[var(--text-tertiary)]"
-                      aria-label={t('newChat.modelSelector.meta.fastBadge')}
-                    />
-                  )}
-                </span>
+            </span>
+            {(isSubscriptionModel ||
+              isBudgetModel ||
+              rowPromotionLabel ||
+              (rowPrice?.kind === 'priced' && !isSubscriptionModel) ||
+              isSelected) && (
+              <span className="flex shrink-0 items-center gap-1.5">
                 {(isSubscriptionModel || isBudgetModel || rowPromotionLabel) && (
-                  <span data-model-tags className="ml-auto flex min-w-0 shrink items-center gap-1.5">
+                  <span data-model-tags className="flex shrink-0 items-center gap-1.5">
                     {isSubscriptionModel &&
                       (rowPrice?.kind === 'priced' ? (
                         <Tip text={t('settings.providers.models.subscription')}>
@@ -1336,10 +1342,6 @@ function ModelSelectorContentView({
                     )}
                   </span>
                 )}
-              </span>
-            </span>
-            {((rowPrice?.kind === 'priced' && !isSubscriptionModel) || isSelected) && (
-              <span className="ml-2 flex shrink-0 items-center gap-1.5">
                 {rowPrice?.kind === 'priced' && !isSubscriptionModel && (
                   <span
                     data-model-price-stack={rowPrice.original ? 'true' : undefined}


### PR DESCRIPTION
<!--
PR Title 不是下面的正文标题，而是 GitHub PR 页面最上方的标题。
格式：<type>(<scope>): <简短描述>（scope 可省略）

type：feat / fix / refactor / perf / chore / docs / test / revert / build / ci
示例：docs(readme): 补充本地模式与远程开发说明；fix: 修复登录跳转
-->

## 这次改了什么

### 摘要

<!-- 用大白话说明改了什么，以及为什么改。保持单一目标。 -->

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：无
- 明确不包含：无
- 用户可见变化：模型选择列表中订阅的模型
- 是否存在 breaking change：无

### UI 变化

原英文版 UI 对模型名称显示不全：
<img width="314" height="461" alt="Screenshot 2026-07-27 at 13 11 57" src="https://github.com/user-attachments/assets/daadb07d-ad17-44c5-ae5f-0e0f85a33dd3" />

修复后，订阅以 tooltip 形式展示：
<img width="383" height="466" alt="Screenshot 2026-07-27 at 14 11 45" src="https://github.com/user-attachments/assets/796b5ea3-c52a-46db-b7a7-0e4a44bb5d37" />

- 引用的设计规范：

  - **`DESIGN.md §4 Select & Dropdown`**：维持模型选择器弹层面板 `320px` 标准宽度，内层 `pane` 采用 `w-full min-w-0` 充满容器；列表设置 `pr-1` 确保滚动条与左右内边距对称（9px），避免贴死外框。
  - **`DESIGN.md §5 Border Radius Scale`**：符合 Pill（`9999px / rounded-full`）胶囊形态规范。将订阅类模型的 Brand Arrow 品牌标识与价格统一组合在半透明 `rounded-full` 胶囊微型气泡内，高为 `20px`，Icon 尺寸为 `12px`。
  - **`DESIGN.md §2 Color Roles`**：遵循双模式适配规则，背景使用 `bg-black/[0.04] dark:bg-white/[0.08]` 双模式 Token，交互浮层与图标自动响应 Light/Dark 模式。
  - **`DESIGN.md §3 Typography`**：价格与微标签统一采用 `text-11` 微型字号并开启 `tabular-nums` 保持等宽对齐。

## 怎么验证的

### 自动验证

```text
1. 单元测试（模型选择器触发与渲染测试）：
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：
✓ src/renderer/__tests__/modelSelectorTriggerVariant.test.ts (26 tests)
Test Files  1 passed (1)
     Tests  26 passed (26)
2. 类型检查：
pnpm --filter desktop typecheck
结果：
> desktop@0.0.0 typecheck
> tsc --noEmit -p tsconfig.json
通过（0 errors）。
3. DCO 签名校验：
pnpm check:dco
结果：
DCO check passed: 1 commit signed off — range 7da0a53c..67d816bc (base origin/main).
```

### 手工验证

手动点开模型列表并滚动到订阅项目。

### 未执行的验证

无

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
- 回滚 / 降级方式：

<!-- 命中 SQLite migration、system prompt、协议、原生层、fingerprint/OTA 或跨平台差异时，
必须写清影响和回滚/降级方式；不涉及风险时明确写“无”。

改动会改变 mobile runtime fingerprint（即触发冷更）时，还要写明为什么冷更不可避免、
存量装机的影响范围与发版节奏建议；这类 PR 与技术框架变动同级，需仓库指定的把关人针对
冷更明确确认后才能合并（提交者身份不构成例外），规则见
docs/dev-rules/mobile-development.md 的「冷更边界」。 -->

### 提交前检查

- [x] 已 review 完整 diff
- [ ] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
