### PR TITLE
fix(desktop/maker-core): 识别 Codex refresh token 被撤销的鉴权失效,重连替代无效重试

### DIFF
--- a/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
@@ -240,6 +240,25 @@ describe('ErrorBanner OpenAI connection recovery', () => {
     expect(screen.getByRole('button', { name: 'chat.errorBanner.retry' })).toBeTruthy();
   });
 
+  it('classifies the wrapped thread/resume refresh-token failure as reconnect, not retry', () => {
+    render(
+      <ErrorBanner
+        error="LAZY_CREATE_FAILED: Failed to resume Codex thread: Error: codex app-server thread/resume error -32600: failed to load configuration: Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again."
+        retryText="retry this turn"
+        onRetry={vi.fn()}
+        agentKind="codex"
+        modelId="gpt-5.4"
+        providerId="openai"
+      />,
+    );
+
+    expect(screen.getByText('chat.errorBanner.codexSessionExpired')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'chat.errorBanner.codexSessionExpiredLogin' }),
+    ).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'chat.errorBanner.retry' })).toBeNull();
+  });
+
   it('does not classify a non-OpenAI provider error as ChatGPT reconnect', () => {
     render(
       <ErrorBanner

--- a/apps/desktop/src/renderer/hooks/__tests__/codexAuthRecovery.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/codexAuthRecovery.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCodexOAuthReconnectRequired } from '../codexAuthRecovery';
+
+describe('isCodexOAuthReconnectRequired', () => {
+  it('matches invalidation reason tokens from auth adapters', () => {
+    for (const reason of [
+      'app_session_terminated',
+      'token_invalidated',
+      'token_revoked',
+      'refresh_token_reused',
+    ]) {
+      expect(isCodexOAuthReconnectRequired(reason)).toBe(true);
+    }
+  });
+
+  it('matches every codex-rs permanent refresh failure sentence variant', () => {
+    // codex-rs login/src/auth/manager.rs 的 REFRESH_TOKEN_*_MESSAGE 家族:
+    // 共享前缀 "access token could not be refreshed",全部为永久失败、需重登。
+    const variants = [
+      'Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.',
+      'Your access token could not be refreshed because your refresh token has expired. Please log out and sign in again.',
+      'Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.',
+      'Your access token could not be refreshed. Please log out and sign in again.',
+      'Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.',
+    ];
+    for (const variant of variants) {
+      expect(isCodexOAuthReconnectRequired(variant)).toBe(true);
+    }
+  });
+
+  it('matches the full wrapped thread/resume config-load failure end to end', () => {
+    expect(
+      isCodexOAuthReconnectRequired(
+        'LAZY_CREATE_FAILED: Failed to resume Codex thread: Error: codex app-server thread/resume error -32600: failed to load configuration: Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isCodexOAuthReconnectRequired(undefined)).toBe(false);
+    expect(isCodexOAuthReconnectRequired('')).toBe(false);
+    expect(isCodexOAuthReconnectRequired('fetch failed: ECONNREFUSED')).toBe(false);
+    expect(isCodexOAuthReconnectRequired('failed to load configuration: invalid TOML')).toBe(
+      false,
+    );
+    expect(isCodexOAuthReconnectRequired('401 Missing bearer token')).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/hooks/codexAuthRecovery.ts
+++ b/apps/desktop/src/renderer/hooks/codexAuthRecovery.ts
@@ -6,7 +6,10 @@
  */
 export function isCodexOAuthReconnectRequired(reason: string | undefined): boolean {
   if (!reason) return false;
-  return /app_session_terminated|token_invalidated|token_revoked|refresh_token_reused|Your session has ended|authentication token has been invalidated|authentication token has been revoked|refresh token was already used|refresh_token.*already used|bridge auth unavailable for chatgpt\//i.test(
+  // "access token could not be refreshed" 覆盖 codex-rs 永久刷新失败的整个文案家族
+  // (revoked / expired / already used / account mismatch / unknown)——这些句式只在
+  // refresh token 已不可用时产生，重试必然无效，只能重新连接。
+  return /app_session_terminated|token_invalidated|token_revoked|refresh_token_reused|Your session has ended|authentication token has been invalidated|authentication token has been revoked|refresh token was already used|refresh_token.*already used|access token could not be refreshed|refresh token (?:was|has been) revoked|bridge auth unavailable for chatgpt\//i.test(
     reason,
   );
 }

--- a/packages/maker-core/src/agents/codex/app-server/client.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.test.ts
@@ -100,6 +100,75 @@ describe('detectAuthInvalidationReason', () => {
     ).toBe('token_invalidated');
   });
 
+  it('maps structured cloudConfigBundle auth errors from config load failures', () => {
+    // codex-rs app-server config_errors.rs: thread/resume 等在配置加载阶段撞
+    // 鉴权失败时返回 -32600 + reason=cloudConfigBundle (detail 带 refresh 失败句)。
+    expect(
+      detectAuthInvalidationReason({
+        code: -32600,
+        message:
+          'failed to load configuration: Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.',
+        data: {
+          reason: 'cloudConfigBundle',
+          errorCode: 'Auth',
+          action: 'relogin',
+          statusCode: 401,
+          detail:
+            'Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.',
+        },
+      }),
+    ).toBe('token_revoked');
+    expect(
+      detectAuthInvalidationReason({
+        code: -32600,
+        message: 'failed to load configuration: request failed',
+        data: { reason: 'cloudConfigBundle', errorCode: 'Network' },
+      }),
+    ).toBeNull();
+  });
+
+  it('maps the text-only config-load token refresh failure without structured data', () => {
+    expect(
+      detectAuthInvalidationReason({
+        code: -32600,
+        message:
+          'failed to load configuration: Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.',
+      }),
+    ).toBe('token_revoked');
+    expect(
+      detectAuthInvalidationReason({
+        code: -32600,
+        message:
+          'failed to load configuration: Your access token could not be refreshed because your refresh token has expired. Please log out and sign in again.',
+      }),
+    ).toBe('token_invalidated');
+    expect(
+      detectAuthInvalidationReason({
+        code: -32600,
+        message:
+          'failed to load configuration: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.',
+      }),
+    ).toBe('refresh_token_reused');
+  });
+
+  it('rejects config-load errors and bare refresh sentences that lack the paired signal', () => {
+    // 非鉴权的配置加载失败: 不能清凭证。
+    expect(
+      detectAuthInvalidationReason({
+        code: -32600,
+        message: 'failed to load configuration: invalid TOML in config.toml',
+      }),
+    ).toBeNull();
+    // 孤立句子没有 config-load 包装也没有结构化 provenance: 保持窄门。
+    expect(
+      detectAuthInvalidationReason({
+        code: -32000,
+        message:
+          'Your access token could not be refreshed because your refresh token was revoked.',
+      }),
+    ).toBeNull();
+  });
+
   it('rejects keyword matches without the structured cloud auth provenance', () => {
     expect(
       detectAuthInvalidationReason({

--- a/packages/maker-core/src/agents/codex/app-server/client.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.ts
@@ -74,24 +74,39 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Detect a definitive Codex authentication failure from a correlated JSON-RPC
  * error response. Codex Desktop uses this same protocol boundary: stderr stays
- * diagnostic-only, while auth state changes require cloudRequirements plus an
- * explicit Auth/relogin action from app-server.
+ * diagnostic-only, while auth state changes require a structured Auth/relogin
+ * signal from app-server (cloudRequirements / cloudConfigBundle), or the
+ * narrowly-matched config-load wrapper around codex-rs' permanent token
+ * refresh failure.
  */
 export function detectAuthInvalidationReason(error: JsonRpcErrorObject): string | null {
   const data = isRecord(error.data) ? error.data : null;
-  if (
-    data?.reason !== 'cloudRequirements' ||
-    (data.errorCode !== 'Auth' && data.action !== 'relogin')
-  ) {
+  // 两种结构化 provenance 都是 app-server 主动声明的鉴权失效:
+  //  - cloudRequirements: turn 级 cloud 依赖检查失败 (Auth/relogin)。
+  //  - cloudConfigBundle: 配置加载阶段 cloud config bundle 拉取撞鉴权失败
+  //    (config_errors.rs 对 Auth code 附 action=relogin)。
+  const hasStructuredAuthSignal =
+    (data?.reason === 'cloudRequirements' || data?.reason === 'cloudConfigBundle') &&
+    (data.errorCode === 'Auth' || data.action === 'relogin');
+  // 文本兜底 (窄门): 非 cloud-config-bundle 的错误链不带结构化 data, 但 message 仍是
+  // app-server 生成的 "failed to load configuration: {err}" 包装; 其中 codex-rs 的
+  // "Your access token could not be refreshed ..." 句族只出自永久性 refresh 失败
+  // (revoked / expired / reused / account mismatch), 重试必然复现。两段都要求命中,
+  // 避免 correlated response error 里偶发回显的孤立关键词触发凭证清除。
+  const isTextualConfigLoadRefreshFailure =
+    !hasStructuredAuthSignal &&
+    /failed to load configuration:/i.test(error.message) &&
+    /access token could not be refreshed/i.test(error.message);
+  if (!hasStructuredAuthSignal && !isTextualConfigLoadRefreshFailure) {
     return null;
   }
 
-  const nestedError = isRecord(data.error) ? data.error : null;
+  const nestedError = isRecord(data?.error) ? data.error : null;
   const diagnostic = [
     error.message,
-    typeof data.message === 'string' ? data.message : '',
-    typeof data.detail === 'string' ? data.detail : '',
-    typeof data.code === 'string' ? data.code : '',
+    typeof data?.message === 'string' ? data.message : '',
+    typeof data?.detail === 'string' ? data.detail : '',
+    typeof data?.code === 'string' ? data.code : '',
     typeof nestedError?.message === 'string' ? nestedError.message : '',
     typeof nestedError?.code === 'string' ? nestedError.code : '',
   ].join('\n');
@@ -102,15 +117,20 @@ export function detectAuthInvalidationReason(error: JsonRpcErrorObject): string 
   if (/token_invalidated|authentication token has been invalidated/i.test(diagnostic)) {
     return 'token_invalidated';
   }
-  if (/token_revoked|authentication token has been revoked/i.test(diagnostic)) {
+  if (
+    /token_revoked|authentication token has been revoked|refresh token (?:was|has been) revoked/i.test(
+      diagnostic,
+    )
+  ) {
     return 'token_revoked';
   }
   if (/refresh token was already used|refresh_token.*already used/i.test(diagnostic)) {
     return 'refresh_token_reused';
   }
 
-  // The structured Auth/relogin signal is itself definitive even when the
-  // app-server does not expose the provider-specific token error code.
+  // Both gates above are definitive on their own (structured Auth/relogin, or the
+  // permanent refresh-failure sentence family — e.g. the "has expired" / account
+  // mismatch variants) even without a provider-specific token error code.
   return 'token_invalidated';
 }
 

--- a/packages/maker-core/src/agents/codex/app-server/client.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.ts
@@ -87,7 +87,7 @@ export function detectAuthInvalidationReason(error: JsonRpcErrorObject): string 
   //    (config_errors.rs 对 Auth code 附 action=relogin)。
   const hasStructuredAuthSignal =
     (data?.reason === 'cloudRequirements' || data?.reason === 'cloudConfigBundle') &&
-    (data.errorCode === 'Auth' || data.action === 'relogin');
+    (data?.errorCode === 'Auth' || data?.action === 'relogin');
   // 文本兜底 (窄门): 非 cloud-config-bundle 的错误链不带结构化 data, 但 message 仍是
   // app-server 生成的 "failed to load configuration: {err}" 包装; 其中 codex-rs 的
   // "Your access token could not be refreshed ..." 句族只出自永久性 refresh 失败


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户的 OpenAI refresh token 被服务端撤销后,Codex 会话报
`failed to load configuration: Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.`(`thread/resume` 等 RPC 的 `-32600` 错误)。此前 Cindy 两层都不识别这个文案家族:renderer 的 `isCodexOAuthReconnectRequired` 只认 `token_revoked`、`refresh token was already used` 等旧文案,错误横幅保留「重试」(必然无效)且不给「重新连接」入口;maker-core 的 `detectAuthInvalidationReason` 只接受 `reason=cloudRequirements` 的结构化信号,而配置加载阶段的鉴权失败带的是 `reason=cloudConfigBundle`(codex-rs app-server `config_errors.rs`),导致 `onAuthInvalidated` 不触发、旧凭证不清理。用户重试/重启/新开对话都无法恢复(源自 Slack 用户反馈)。

本 PR:

- `isCodexOAuthReconnectRequired` 增加 `access token could not be refreshed`(覆盖 codex-rs 永久刷新失败全部文案变体:revoked / expired / already used / account mismatch / unknown)与 `refresh token was|has been revoked`;
- `detectAuthInvalidationReason` 接受 `cloudConfigBundle` 结构化 provenance(同样要求 `errorCode=Auth` 或 `action=relogin`);另加窄门文本兜底:message 须**同时**命中 `failed to load configuration:` 包装与 `access token could not be refreshed` 句族才判定失效,防止孤立关键词误清凭证;`token_revoked` 分类补 revoked 句式变体。

效果:撞到该错误时 main 侧自动 invalidate 旧凭证并收割旧 host,错误横幅隐藏「重试」、显示「重新连接 ChatGPT」内联入口,设置页同步进入需重连状态。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:Slack 用户反馈(refresh token 被撤销后无限重试无法恢复)
- 本 PR 包含:renderer 错误文案识别扩展;maker-core app-server 鉴权失效检测扩展;对应单元测试
- 明确不包含:voice-input / ChatGPT bridge 的 HTTP 401 检测(消息族不同,不受影响);登录/重连流程本身无改动
- 用户可见变化:该错误从「原始英文报错 + 无效重试」变为「连接已过期提示 + 重新连接入口」
- 是否存在 breaking change:无

### UI 变化

不涉及:仅扩展错误原因识别逻辑,复用既有 `codexSessionExpired` 横幅分支(文案、样式、交互均为现有实现),无新增或修改的视觉/交互/UI 文案。

- 引用的设计规范:不涉及(无视觉/交互/文案变化)

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:通过(25 个 workspace PASS,含 maker-core 与 desktop unit)
pnpm --filter @cindy/maker-core run --if-present typecheck
结果:maker-core 无 typecheck script,自动跳过(其源码由 desktop typecheck 编译覆盖)
pnpm --filter desktop run --if-present typecheck
结果:通过
定向:packages/maker-core client.test.ts 12 passed;desktop codexAuthRecovery.test.ts / ErrorBannerCodexOAuth.test.tsx / errorBannerCodexXaiAuth.test.tsx / useCodexAuth.test.ts 共 37 passed
```

新增测试:maker-core `client.test.ts` +3 用例(结构化 `cloudConfigBundle`、文本兜底三变体映射、窄门拒绝非鉴权配置错误与孤立句子);desktop 新增 `codexAuthRecovery.test.ts`(上游 `manager.rs` 五种永久刷新失败文案 + 完整 `LAZY_CREATE_FAILED` 包装串 + 不误伤负例)与 `ErrorBannerCodexOAuth` 回归用例(真实全文错误 → 显示重连、隐藏重试)。

### 手工验证

未手工复现:refresh token 服务端撤销无法在本机随需触发。上游文案与结构化错误形态已对照 codex-rs(`login/src/auth/manager.rs` 的 `REFRESH_TOKEN_*_MESSAGE` 常量、`app-server/request_processors/config_errors.rs`,本仓捆绑的 rust-v0.145.0 与 main 一致)逐字核对并固化进测试。

### 未执行的验证

真实撤销场景端到端验证(原因同上);受影响用户侧的临时解法(断开重连 OpenAI)已在 Slack 给出且有效,与本修复引导的路径一致。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:检测面扩大意味着「自动清除本地 Codex OAuth 凭证 + 提示重登」的触发面扩大。误判风险已用双门限制:结构化路径仍要求 app-server 声明的 `Auth`/`relogin` 信号;文本兜底要求 config-load 包装与 codex-rs 永久刷新失败句族同时命中(该句族只出自真实 refresh 4xx 失败,且此时凭证本就不可用,清除是正确行为)。不触及凭证存储格式与登录流程。
- 回滚 / 降级方式:revert 本 commit 即可,无数据/schema 影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
