### PR TITLE
fix(mobile): restore Android microphone permission

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -125,7 +125,7 @@
         {
           "photosPermission": "Cindy needs photo library access to attach images to remote sessions.",
           "cameraPermission": "Cindy needs camera access to attach photos to remote sessions.",
-          "microphonePermission": false
+          "microphonePermission": "Cindy needs microphone access for voice input in remote sessions."
         }
       ],
       [

--- a/apps/mobile/src/__tests__/nativeAppConfig.test.ts
+++ b/apps/mobile/src/__tests__/nativeAppConfig.test.ts
@@ -401,6 +401,10 @@ describe('mobile native app config', () => {
     const audioPlugin = appJson.expo.plugins.find(
       (plugin: unknown) => Array.isArray(plugin) && plugin[0] === 'expo-audio',
     );
+    const imagePickerPlugin = appJson.expo.plugins.find(
+      (plugin: unknown) =>
+        Array.isArray(plugin) && plugin[0] === 'expo-image-picker',
+    );
 
     expect(audioPlugin).toEqual([
       'expo-audio',
@@ -410,6 +414,13 @@ describe('mobile native app config', () => {
         enableBackgroundPlayback: false,
         enableBackgroundRecording: false,
       },
+    ]);
+    expect(imagePickerPlugin).toEqual([
+      'expo-image-picker',
+      expect.objectContaining({
+        microphonePermission:
+          'Cindy needs microphone access for voice input in remote sessions.',
+      }),
     ]);
     const foregroundOnlyPluginIndex = appJson.expo.plugins.indexOf(
       './plugins/with-foreground-only-audio',


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Android 安装包缺少麦克风权限的问题。`expo-audio` 已声明
`RECORD_AUDIO`，但后执行的 `expo-image-picker` 配置又将该权限显式屏蔽，
导致最终 Manifest 删除录音权限。本 PR 统一两处插件的麦克风权限配置，并增加
原生配置契约测试，防止后续再次被覆盖。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #602
- 本 PR 包含：修正 `expo-image-picker` 的麦克风权限配置；补充配置回归测试。
- 明确不包含：语音输入业务流程或 UI 改动。
- 用户可见变化：Android 首次使用语音输入时可以正常请求系统麦克风权限，不再因应用未声明权限而只能跳转设置页。
- 是否存在 breaking change：无。

### UI 变化

- 不涉及。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，全部 required workspace 单元测试通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm --filter mobile exec vitest run src/__tests__/nativeAppConfig.test.ts
结果：通过，14/14。

node apps/mobile/scripts/ci-fingerprint.mjs compare ...
结果：iOS 与 Android fingerprint 均发生变化，符合本次原生配置修复预期。
```

完整单测首轮有一个与本 PR 无关的 Desktop Git 用例在高负载下达到 30 秒超时；
该文件单独复跑 19/19 通过，随后完整 `pnpm test:unit` 重跑全绿。

### 手工验证

- Worktree：`/Users/kmny/XDProject/cindy-moved`
- Branch：`codex/fix-android-microphone-permission`
- Metro：端口 8081，进程工作目录为本 worktree 的 `apps/mobile`，
  通过 `expo start --dev-client` 启动。
- Build 证据：`expo run:android --no-bundler` 完成 `assembleDebug`，
  `BUILD SUCCESSFUL`，安装的是 `__DEV__` 调试包。
- 设备：Android 真机 Samsung SM-F9360。
- 验证结果：生成后的 Manifest 包含 `android.permission.RECORD_AUDIO`；
  覆盖安装保留本地数据后，麦克风授权与语音输入由报告者手工验证通过。

### 未执行的验证

- 未在 Issue 报告设备 Xiaomi 14 / HyperOS 上复测；问题根因是安装包 Manifest
  配置冲突，与厂商权限页面实现无关，已在另一台 Android 真机验证。
- 未执行商店签名 release 构建；本地 debug 原生构建及生成 Manifest 已验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 原生配置。Android 新安装包会声明并在使用语音输入时请求
  `RECORD_AUDIO`；iOS 权限文案保持与 `expo-audio` 相同，但 iOS 与 Android 的
  runtime fingerprint 都会变化。
- 冷更不可避免的原因：Android 权限必须写入安装包 Manifest，OTA 无法为已安装应用
  新增系统权限声明。
- 存量装机影响：现有安装包继续缺少该权限，无法仅靠 OTA 获得修复；用户需要安装包含
  本 PR 的新原生版本。
- 发版节奏建议：将本改动纳入下一次 iOS / Android 原生冷更版本，不要作为 OTA-only
  更新发布；按现有发布流程更新平台构建号并重新出包。
- 合并要求：本 PR 会改变 Mobile runtime fingerprint，需要仓库指定把关人明确确认冷更
  后再转为 Ready / 合并。
- 回滚 / 降级方式：恢复 `expo-image-picker.microphonePermission: false` 可回滚原生配置，
  但会重新引入 Android 语音输入不可用问题。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
