### PR TITLE
fix(desktop): avoid startup crash when resolving device id

### DIFF
--- a/apps/desktop/src/main/__tests__/deviceId.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceId.test.ts
@@ -7,7 +7,8 @@
  * 3. 首次取到的身份被冻结:硬件指纹成功持久化后,后续启动即使 machineIdSync 抛,
  *    也复用已持久化的硬件 ID,绝不改判成陌生 fallback(否则冷启动 refresh 可能登出);
  * 4. machineIdSync 抛(bare `ioreg` not found)时不上抛,回落到持久化 UUID,跨启动稳定;
- * 5. 磁盘已有身份时,直接复用,不被本次 machineIdSync 结果覆盖(并发首写的赢家值胜出);
+ * 5. reconcile 规则:硬件指纹可用时以其为准并回写旧的硬件 ID(修 userData 拷贝到新机),
+ *    但已确立的 fallback-* 身份予以保留、不被硬件 ID 覆盖(避免 DEVICE_MISMATCH 登出);
  * 6. userData 不可用(app 未 ready)时不崩溃,返回临时 fallback 且不因缺 whenReady 抛;
  * 7. ensureSystemBinPathForMachineId 在 darwin/linux 补齐 /usr/sbin:/sbin 且幂等。
  */

--- a/apps/desktop/src/main/__tests__/deviceId.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceId.test.ts
@@ -1,12 +1,15 @@
 /**
- * resolveDeviceId 单测 —— 取设备 ID 的启动崩溃护栏。
+ * resolveDeviceId 单测 —— 取设备 ID 的启动崩溃护栏 + 身份稳定性。
  *
  * 关注点:
- * 1. XDT_DEVICE_ID_OVERRIDE 优先,直接返回、不碰硬件指纹;
- * 2. machineIdSync 成功时透传其结果;
- * 3. machineIdSync 抛(bare `ioreg` not found)时不上抛,回落到 userData 持久化 UUID,
- *    且同一份 userData 跨调用稳定;
- * 4. ensureSystemBinPathForMachineId 在 darwin 补齐 /usr/sbin:/sbin 且幂等。
+ * 1. XDT_DEVICE_ID_OVERRIDE 优先,直接返回、不碰硬件指纹与磁盘;
+ * 2. machineIdSync 成功时透传其结果,并持久化;
+ * 3. 首次取到的身份被冻结:硬件指纹成功持久化后,后续启动即使 machineIdSync 抛,
+ *    也复用已持久化的硬件 ID,绝不改判成陌生 fallback(否则冷启动 refresh 可能登出);
+ * 4. machineIdSync 抛(bare `ioreg` not found)时不上抛,回落到持久化 UUID,跨启动稳定;
+ * 5. 磁盘已有身份时,直接复用,不被本次 machineIdSync 结果覆盖(并发首写的赢家值胜出);
+ * 6. userData 不可用(app 未 ready)时不崩溃,返回临时 fallback 且不因缺 whenReady 抛;
+ * 7. ensureSystemBinPathForMachineId 在 darwin/linux 补齐 /usr/sbin:/sbin 且幂等。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import os from 'node:os';
@@ -14,7 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const { appMock, machineIdSync } = vi.hoisted(() => ({
-  appMock: { getPath: vi.fn(() => '') },
+  appMock: { getPath: vi.fn((): string => '') },
   machineIdSync: vi.fn(() => 'hw-fingerprint'),
 }));
 
@@ -58,7 +61,20 @@ describe('resolveDeviceId', () => {
     expect(resolveDeviceId()).toBe('hw-fingerprint');
   });
 
-  it('machineIdSync 抛时不上抛,回落到持久化 UUID 且跨进程稳定', async () => {
+  it('指纹先成功落盘,后续启动指纹抛时复用它(transient 失败不改判、不登出)', async () => {
+    // 首启:硬件指纹成功 → 持久化。
+    const first = await loadFresh();
+    expect(first.resolveDeviceId()).toBe('hw-fingerprint');
+
+    // 次启:同一份 userData,指纹这次抛 —— 必须复用持久化的硬件 ID,而非造 fallback。
+    machineIdSync.mockImplementation(() => {
+      throw new Error('ioreg: command not found');
+    });
+    const second = await loadFresh();
+    expect(second.resolveDeviceId()).toBe('hw-fingerprint');
+  });
+
+  it('machineIdSync 抛时不上抛,回落到持久化 UUID 且跨启动稳定', async () => {
     machineIdSync.mockImplementation(() => {
       throw new Error('ioreg: command not found');
     });
@@ -67,9 +83,53 @@ describe('resolveDeviceId', () => {
     const id1 = first.resolveDeviceId();
     expect(id1).toMatch(/^fallback-/);
 
-    // 新进程(重置模块缓存)读同一份 userData,应拿到同一个持久化 id。
+    // 次启读同一份 userData,应拿到同一个持久化 id(不再 churn)。
     const second = await loadFresh();
     expect(second.resolveDeviceId()).toBe(id1);
+  });
+
+  it('硬件指纹可用时以其为准,并更新磁盘上的旧值(修复 userData 拷贝/恢复到新机)', async () => {
+    // 磁盘上是从别的机器带过来的旧 id;本机指纹可用 → 应以本机指纹为准并回写。
+    fs.writeFileSync(path.join(tmpDir, 'device-id'), 'old-machine-id', 'utf8');
+    machineIdSync.mockReturnValue('this-machine-hw');
+
+    const { resolveDeviceId } = await loadFresh();
+    expect(resolveDeviceId()).toBe('this-machine-hw');
+    expect(fs.readFileSync(path.join(tmpDir, 'device-id'), 'utf8')).toBe('this-machine-hw');
+  });
+
+  it('machineIdSync 返回空串时视作失败,不落盘空 ID,改用 fallback', async () => {
+    machineIdSync.mockReturnValue('   ');
+    const { resolveDeviceId } = await loadFresh();
+    const id = resolveDeviceId();
+    expect(id).toMatch(/^fallback-/);
+    // 磁盘持久化的是 fallback,不是空串。
+    expect(fs.readFileSync(path.join(tmpDir, 'device-id'), 'utf8').trim()).toBe(id);
+  });
+
+  it('落盘内容完整且等于返回值,且不残留 .tmp 文件', async () => {
+    machineIdSync.mockImplementation(() => {
+      throw new Error('ioreg: command not found');
+    });
+    const { resolveDeviceId } = await loadFresh();
+    const id = resolveDeviceId();
+
+    expect(fs.readFileSync(path.join(tmpDir, 'device-id'), 'utf8')).toBe(id);
+    const leftovers = fs.readdirSync(tmpDir).filter((f) => f.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('userData 不可用时不崩溃,返回临时 fallback', async () => {
+    appMock.getPath.mockImplementation(() => {
+      throw new Error('app is not ready');
+    });
+    machineIdSync.mockImplementation(() => {
+      throw new Error('ioreg: command not found');
+    });
+
+    const { resolveDeviceId } = await loadFresh();
+    // 不缺 whenReady 也不抛,拿到一个可用的临时 id。
+    expect(resolveDeviceId()).toMatch(/^fallback-/);
   });
 
   it('ensureSystemBinPathForMachineId 在 darwin/linux 补齐系统 bin 且幂等', async () => {

--- a/apps/desktop/src/main/__tests__/deviceId.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceId.test.ts
@@ -23,6 +23,10 @@ const { appMock, machineIdSync } = vi.hoisted(() => ({
 
 vi.mock('electron', () => ({ app: appMock }));
 vi.mock('node-machine-id', () => ({ machineIdSync }));
+// Isolate from the real main logger (touches electron app paths + fs at import).
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
 
 async function loadFresh() {
   vi.resetModules();
@@ -96,6 +100,17 @@ describe('resolveDeviceId', () => {
     const { resolveDeviceId } = await loadFresh();
     expect(resolveDeviceId()).toBe('this-machine-hw');
     expect(fs.readFileSync(path.join(tmpDir, 'device-id'), 'utf8')).toBe('this-machine-hw');
+  });
+
+  it('已确立的 fallback 身份在指纹恢复后被保留,不被硬件 ID 覆盖(避免 DEVICE_MISMATCH 登出)', async () => {
+    // 磁盘上是首启指纹失败时铸的 fallback(可能已在服务端注册);本次指纹恢复了。
+    fs.writeFileSync(path.join(tmpDir, 'device-id'), 'fallback-established-uuid', 'utf8');
+    machineIdSync.mockReturnValue('now-available-hw');
+
+    const { resolveDeviceId } = await loadFresh();
+    // 保留 fallback,不改判成硬件 ID。
+    expect(resolveDeviceId()).toBe('fallback-established-uuid');
+    expect(fs.readFileSync(path.join(tmpDir, 'device-id'), 'utf8')).toBe('fallback-established-uuid');
   });
 
   it('machineIdSync 返回空串时视作失败,不落盘空 ID,改用 fallback', async () => {

--- a/apps/desktop/src/main/__tests__/deviceId.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceId.test.ts
@@ -1,0 +1,89 @@
+/**
+ * resolveDeviceId 单测 —— 取设备 ID 的启动崩溃护栏。
+ *
+ * 关注点:
+ * 1. XDT_DEVICE_ID_OVERRIDE 优先,直接返回、不碰硬件指纹;
+ * 2. machineIdSync 成功时透传其结果;
+ * 3. machineIdSync 抛(bare `ioreg` not found)时不上抛,回落到 userData 持久化 UUID,
+ *    且同一份 userData 跨调用稳定;
+ * 4. ensureSystemBinPathForMachineId 在 darwin 补齐 /usr/sbin:/sbin 且幂等。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const { appMock, machineIdSync } = vi.hoisted(() => ({
+  appMock: { getPath: vi.fn(() => '') },
+  machineIdSync: vi.fn(() => 'hw-fingerprint'),
+}));
+
+vi.mock('electron', () => ({ app: appMock }));
+vi.mock('node-machine-id', () => ({ machineIdSync }));
+
+async function loadFresh() {
+  vi.resetModules();
+  return import('../deviceId');
+}
+
+describe('resolveDeviceId', () => {
+  const originalPath = process.env.PATH;
+  const originalOverride = process.env.XDT_DEVICE_ID_OVERRIDE;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-deviceid-'));
+    appMock.getPath.mockReturnValue(tmpDir);
+    machineIdSync.mockReset();
+    machineIdSync.mockReturnValue('hw-fingerprint');
+    delete process.env.XDT_DEVICE_ID_OVERRIDE;
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    if (originalOverride === undefined) delete process.env.XDT_DEVICE_ID_OVERRIDE;
+    else process.env.XDT_DEVICE_ID_OVERRIDE = originalOverride;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('override 优先,不调用硬件指纹', async () => {
+    process.env.XDT_DEVICE_ID_OVERRIDE = '  custom-device  ';
+    const { resolveDeviceId } = await loadFresh();
+    expect(resolveDeviceId()).toBe('custom-device');
+    expect(machineIdSync).not.toHaveBeenCalled();
+  });
+
+  it('machineIdSync 成功时透传结果', async () => {
+    const { resolveDeviceId } = await loadFresh();
+    expect(resolveDeviceId()).toBe('hw-fingerprint');
+  });
+
+  it('machineIdSync 抛时不上抛,回落到持久化 UUID 且跨进程稳定', async () => {
+    machineIdSync.mockImplementation(() => {
+      throw new Error('ioreg: command not found');
+    });
+
+    const first = await loadFresh();
+    const id1 = first.resolveDeviceId();
+    expect(id1).toMatch(/^fallback-/);
+
+    // 新进程(重置模块缓存)读同一份 userData,应拿到同一个持久化 id。
+    const second = await loadFresh();
+    expect(second.resolveDeviceId()).toBe(id1);
+  });
+
+  it('ensureSystemBinPathForMachineId 在 darwin/linux 补齐系统 bin 且幂等', async () => {
+    if (process.platform !== 'darwin' && process.platform !== 'linux') return;
+    process.env.PATH = '/usr/bin:/bin';
+    const { ensureSystemBinPathForMachineId } = await loadFresh();
+
+    ensureSystemBinPathForMachineId();
+    const dirs = (process.env.PATH ?? '').split(path.delimiter);
+    expect(dirs).toContain('/usr/sbin');
+    expect(dirs).toContain('/sbin');
+
+    const afterFirst = process.env.PATH;
+    ensureSystemBinPathForMachineId();
+    expect(process.env.PATH).toBe(afterFirst);
+  });
+});

--- a/apps/desktop/src/main/__tests__/deviceId.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceId.test.ts
@@ -48,7 +48,10 @@ describe('resolveDeviceId', () => {
   });
 
   afterEach(() => {
-    process.env.PATH = originalPath;
+    // Restore precisely: assigning `undefined` would coerce to the string
+    // "undefined" and pollute PATH for later tests.
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
     if (originalOverride === undefined) delete process.env.XDT_DEVICE_ID_OVERRIDE;
     else process.env.XDT_DEVICE_ID_OVERRIDE = originalOverride;
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -19,7 +19,7 @@ import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import path from 'node:path';
 import fs from 'node:fs';
-import { resolveDeviceId } from './deviceId';
+import { resolveDeviceId } from './deviceId.js';
 import {
   AuthApiError,
   CindyAuthClient,

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -1235,7 +1235,11 @@ export function getCurrentMembershipDisplayName(): string | undefined {
   return displayName || undefined;
 }
 
-/** SkillHub 跨设备识别：本机 deviceId（machineIdSync 结果），登录前后都可用 */
+/**
+ * SkillHub 跨设备识别：本机 deviceId,登录前后都可用。
+ * 通常是硬件指纹(machineIdSync),硬件取不到时是 userData 里持久化的 `fallback-*` UUID;
+ * 也可能是 dev 的 XDT_DEVICE_ID_OVERRIDE。取值逻辑见 resolveDeviceId()。
+ */
 export function getDeviceId(): string {
   return resolveDeviceId();
 }

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -230,9 +230,14 @@ let sessionInvalidationPromise: Promise<void> | null = null;
  *
  * resolveDeviceId() 内部对硬件指纹取值做了容错:补齐 PATH 里的 /usr/sbin:/sbin(Finder
  * 启动的 GUI 进程 PATH 极简,bare `ioreg` 找不到会抛),抛了则回落到 userData 里持久化的
- * UUID——绝不因取设备 ID 失败而让主进程在启动时崩溃。
+ * UUID——绝不因取设备 ID 失败而让主进程在启动时崩溃。结果在 resolveDeviceId 内部 memoize。
+ *
+ * 统一走 getDeviceId() 惰性解析,不在模块顶层调:resolveDeviceId 会读硬件指纹并写
+ * userData/device-id,属持久化副作用。authManager 是 bootstrap-electron 的静态依赖,模块
+ * 顶层求值会早于单实例锁(requestSingleInstanceLock),让一个马上会被判为副实例的进程也去
+ * 探测硬件、抢着落盘身份。改为在真正用到设备 ID 时(登录/续期/SkillHub,均在取得启动归属
+ * 之后)才解析。
  */
-const deviceId = resolveDeviceId();
 
 let loginFlowState: AuthFlowState | null = null;
 let providerConfig: ProviderConfig | null = null;
@@ -265,7 +270,7 @@ function createAuthClient(): CindyAuthClient {
   return new CindyAuthClient({
     baseUrl: authServerUrl(),
     region: AUTH_REGION,
-    deviceId,
+    deviceId: getDeviceId(),
     clientType: 'desktop',
     locale: getResolvedMainLocale(),
     fetch: scenarioFetch ?? (async (input, init) => net.fetch(input, init as RequestInit)),
@@ -402,7 +407,7 @@ function requestAuthRefresh(refreshToken: string): Promise<AuthRefreshResult> {
   // 客户端 abort,重试旧 token 会触发 INVALID_REFRESH_TOKEN。
   return apiFetch<RefreshResponse | AuthErrorResponse>('/api/auth/refresh', {
     method: 'POST',
-    body: { refreshToken, deviceId },
+    body: { refreshToken, deviceId: getDeviceId() },
     timeoutMs: 0,
   });
 }
@@ -926,7 +931,7 @@ function snapshotAuthState(): AuthState {
     canEnterApp: appSession.mode !== 'signed-out',
     isAuthenticated: isCloudAuthenticated,
     isCanary: currentUser !== null && canaryFlagStore.read(),
-    deviceId,
+    deviceId: getDeviceId(),
     hasAccountDeletionReceipt: readSafe(ACCOUNT_DELETION_RECEIPT_KEY) !== null,
     accountDeletionRestored: accountDeletionRestoredNoticePending,
   };
@@ -941,7 +946,7 @@ function snapshotLoggedOutAuthState(): AuthState {
     canEnterApp: false,
     isAuthenticated: false,
     isCanary: false,
-    deviceId,
+    deviceId: getDeviceId(),
     hasAccountDeletionReceipt: readSafe(ACCOUNT_DELETION_RECEIPT_KEY) !== null,
     accountDeletionRestored: false,
   };
@@ -1232,7 +1237,7 @@ export function getCurrentMembershipDisplayName(): string | undefined {
 
 /** SkillHub 跨设备识别：本机 deviceId（machineIdSync 结果），登录前后都可用 */
 export function getDeviceId(): string {
-  return deviceId;
+  return resolveDeviceId();
 }
 
 export function getAuthState(): AuthState {
@@ -2362,7 +2367,7 @@ export async function logout(): Promise<void> {
   if (currentAccessToken) {
     apiFetch('/api/auth/logout', {
       method: 'POST',
-      body: { deviceId },
+      body: { deviceId: getDeviceId() },
       token: currentAccessToken,
     }).catch(() => {});
   }

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -19,7 +19,7 @@ import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import path from 'node:path';
 import fs from 'node:fs';
-import { machineIdSync } from 'node-machine-id';
+import { resolveDeviceId } from './deviceId';
 import {
   AuthApiError,
   CindyAuthClient,
@@ -227,8 +227,12 @@ let sessionInvalidationPromise: Promise<void> | null = null;
  * dev-only 覆盖:设了 `XDT_DEVICE_ID_OVERRIDE` 则用它——用于在同一台机器上跑多个
  * desktop 实例模拟「多设备」(device-link 跨设备远程控制本地联调)。deviceId 只是
  * 同账号下区分设备的标识、非鉴权凭证(鉴权走 auth-server 签发的 JWT),覆盖无安全风险。
+ *
+ * resolveDeviceId() 内部对硬件指纹取值做了容错:补齐 PATH 里的 /usr/sbin:/sbin(Finder
+ * 启动的 GUI 进程 PATH 极简,bare `ioreg` 找不到会抛),抛了则回落到 userData 里持久化的
+ * UUID——绝不因取设备 ID 失败而让主进程在启动时崩溃。
  */
-const deviceId = process.env.XDT_DEVICE_ID_OVERRIDE?.trim() || machineIdSync();
+const deviceId = resolveDeviceId();
 
 let loginFlowState: AuthFlowState | null = null;
 let providerConfig: ProviderConfig | null = null;

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -24,7 +24,7 @@ import os from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { pipeline } from 'node:stream/promises';
 import { execFile, execFileSync, spawn } from 'node:child_process';
-import { resolveDeviceId } from './deviceId';
+import { resolveDeviceId } from './deviceId.js';
 import windowStateKeeper from 'electron-window-state';
 import { BRAND_NAME } from '@cindy/maker-shared/branding';
 import {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -24,7 +24,7 @@ import os from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { pipeline } from 'node:stream/promises';
 import { execFile, execFileSync, spawn } from 'node:child_process';
-import { machineIdSync } from 'node-machine-id';
+import { resolveDeviceId } from './deviceId';
 import windowStateKeeper from 'electron-window-state';
 import { BRAND_NAME } from '@cindy/maker-shared/branding';
 import {
@@ -2931,8 +2931,10 @@ const registerIpcHandlers = () => {
     },
   );
 
-  // Device ID (hardware-based, survives app reinstall)
-  const machineId = machineIdSync();
+  // Device ID (hardware-based, survives app reinstall). resolveDeviceId() is
+  // crash-safe: it patches PATH for bare `ioreg` and falls back to a persisted
+  // UUID rather than throwing (see deviceId.ts).
+  const machineId = resolveDeviceId();
   ipcMain.handle('get-device-id', () => machineId);
 
   // CC 网络调试开关 — renderer Settings → Experimental "CC 网络调试日志" 操作此值。

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -2931,9 +2931,10 @@ const registerIpcHandlers = () => {
     },
   );
 
-  // Device ID (hardware-based, survives app reinstall). resolveDeviceId() is
-  // crash-safe: it patches PATH for bare `ioreg` and falls back to a persisted
-  // UUID rather than throwing (see deviceId.ts).
+  // Device ID: prefers the hardware fingerprint, else a persisted UUID under
+  // userData (so it may not survive clearing userData / reinstall, and isn't
+  // necessarily hardware-derived). resolveDeviceId() is crash-safe: it patches
+  // PATH for bare `ioreg` and falls back rather than throwing (see deviceId.ts).
   const machineId = resolveDeviceId();
   ipcMain.handle('get-device-id', () => machineId);
 

--- a/apps/desktop/src/main/deviceId.ts
+++ b/apps/desktop/src/main/deviceId.ts
@@ -25,8 +25,13 @@
  *      id (which cold-start refresh would send with the existing token, risking
  *      a definitive rejection and logout). Probing first (rather than trusting
  *      the stored file blindly) also means a `userData` copied/restored onto a
- *      different machine re-derives that machine's own id rather than cloning the
- *      source's — two live installs must not share one server-side (user, device).
+ *      different machine re-derives that machine's own hardware id rather than
+ *      cloning the source's — two live installs must not share one server-side
+ *      (user, device). The one exception is a stored `fallback-*` id: once minted
+ *      it may already be registered with the server, so `reconcileHardwareId`
+ *      keeps it even when hardware later becomes identifiable (switching would
+ *      trip DEVICE_MISMATCH and log the user out); a copied userData that already
+ *      holds a fallback will therefore reuse it.
  *      Only when hardware can't be identified at all do we mint a persisted UUID,
  *      created exclusively so processes sharing one userData (device-link
  *      double-launch) converge on a single value instead of racing.

--- a/apps/desktop/src/main/deviceId.ts
+++ b/apps/desktop/src/main/deviceId.ts
@@ -1,0 +1,107 @@
+/**
+ * deviceId.ts
+ * ---------------------------------------------------------------------------
+ * Crash-safe resolution of the per-machine device identifier.
+ *
+ * `node-machine-id`'s `machineIdSync()` shells out to platform tools that live
+ * outside the default GUI PATH: on macOS it runs bare `ioreg`
+ * (`/usr/sbin/ioreg`), on Linux it reads `/var/lib/dbus/machine-id` but can fall
+ * back to tools in `/usr/sbin:/sbin`. An app launched from Finder/Dock (rather
+ * than a login shell) inherits a minimal PATH — typically just `/usr/bin:/bin` —
+ * so the bare command is not found and `machineIdSync()` throws
+ * `ioreg: command not found`.
+ *
+ * Historically this call sat at module top level, so the throw took the entire
+ * main process down before any window appeared — the "打开即闪退" (launch → instant
+ * crash) reported on packaged 0.1.14. This module hardens the call two ways:
+ *
+ *   1. Prepend the system bin dirs (`/usr/sbin:/sbin`) to PATH before probing,
+ *      so bare `ioreg` resolves regardless of how the app was launched.
+ *   2. Never let a fingerprint failure be fatal — fall back to a UUID persisted
+ *      under userData, so the id is stable across restarts (a fresh random id
+ *      each launch would churn the server-side (user, device) registration).
+ */
+
+import { app } from 'electron';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { machineIdSync } from 'node-machine-id';
+
+/**
+ * Ensure the system bin directories are on PATH so `node-machine-id`'s bare
+ * `ioreg` / `hostnamectl` invocations resolve. Idempotent; safe to call before
+ * `app` is ready. No-op on Windows (registry-based, no PATH dependency).
+ */
+export function ensureSystemBinPathForMachineId(): void {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') return;
+  const required = ['/usr/sbin', '/sbin'];
+  const current = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+  const missing = required.filter((dir) => !current.includes(dir));
+  if (missing.length === 0) return;
+  // Append (not prepend): we only want these as a fallback lookup location, not
+  // to shadow user-provided tool locations earlier on PATH.
+  process.env.PATH = [...current, ...missing].join(path.delimiter);
+}
+
+/**
+ * Stable per-install id used only when the hardware fingerprint is unavailable.
+ * Persisted under userData so it survives restarts. Falls back to an ephemeral
+ * id if userData is unwritable — keeping the app alive is the priority.
+ */
+function persistedFallbackDeviceId(): string {
+  const generate = () => `fallback-${crypto.randomUUID()}`;
+
+  let file: string;
+  try {
+    file = path.join(app.getPath('userData'), 'device-id-fallback');
+  } catch {
+    // userData path unavailable (e.g. app not ready): last-resort ephemeral id.
+    return generate();
+  }
+
+  try {
+    const existing = fs.readFileSync(file, 'utf8').trim();
+    if (existing) return existing;
+  } catch {
+    // Missing / unreadable — fall through to generate and persist a fresh one.
+  }
+
+  const generated = generate();
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, generated, 'utf8');
+  } catch {
+    // userData unwritable (rare): keep the ephemeral id so the app still launches.
+  }
+  return generated;
+}
+
+let cached: string | null = null;
+
+/**
+ * Resolve the device id, honouring the `XDT_DEVICE_ID_OVERRIDE` dev override,
+ * then the hardware fingerprint, then a persisted UUID fallback. Result is
+ * memoised so every call site in the process agrees on one id.
+ */
+export function resolveDeviceId(): string {
+  if (cached) return cached;
+
+  const override = process.env.XDT_DEVICE_ID_OVERRIDE?.trim();
+  if (override) {
+    cached = override;
+    return cached;
+  }
+
+  ensureSystemBinPathForMachineId();
+  try {
+    cached = machineIdSync();
+  } catch (err) {
+    process.stderr.write(
+      `[cindy] machineIdSync() failed (${(err as Error)?.message ?? err}); ` +
+        'falling back to persisted device id\n',
+    );
+    cached = persistedFallbackDeviceId();
+  }
+  return cached;
+}

--- a/apps/desktop/src/main/deviceId.ts
+++ b/apps/desktop/src/main/deviceId.ts
@@ -1,7 +1,7 @@
 /**
  * deviceId.ts
  * ---------------------------------------------------------------------------
- * Crash-safe resolution of the per-machine device identifier.
+ * Crash-safe, stable resolution of the per-machine device identifier.
  *
  * `node-machine-id`'s `machineIdSync()` shells out to platform tools that live
  * outside the default GUI PATH: on macOS it runs bare `ioreg`
@@ -15,11 +15,21 @@
  * main process down before any window appeared — the "打开即闪退" (launch → instant
  * crash) reported on packaged 0.1.14. This module hardens the call two ways:
  *
- *   1. Prepend the system bin dirs (`/usr/sbin:/sbin`) to PATH before probing,
+ *   1. Ensure the system bin dirs (`/usr/sbin:/sbin`) are on PATH before probing,
  *      so bare `ioreg` resolves regardless of how the app was launched.
- *   2. Never let a fingerprint failure be fatal — fall back to a UUID persisted
- *      under userData, so the id is stable across restarts (a fresh random id
- *      each launch would churn the server-side (user, device) registration).
+ *   2. Never let a fingerprint failure be fatal, and never let a *transient*
+ *      failure flip identity. The hardware id is authoritative when available:
+ *      we probe first, and cache the resolved id to `userData/device-id`. If a
+ *      later launch's probe fails, we reuse that stored id instead of minting a
+ *      brand-new one — so a transient failure can't hand the server an unrelated
+ *      id (which cold-start refresh would send with the existing token, risking
+ *      a definitive rejection and logout). Probing first (rather than trusting
+ *      the stored file blindly) also means a `userData` copied/restored onto a
+ *      different machine re-derives that machine's own id rather than cloning the
+ *      source's — two live installs must not share one server-side (user, device).
+ *      Only when hardware can't be identified at all do we mint a persisted UUID,
+ *      created exclusively so processes sharing one userData (device-link
+ *      double-launch) converge on a single value instead of racing.
  */
 
 import { app } from 'electron';
@@ -27,6 +37,8 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { machineIdSync } from 'node-machine-id';
+
+const DEVICE_ID_FILENAME = 'device-id';
 
 /**
  * Ensure the system bin directories are on PATH so `node-machine-id`'s bare
@@ -44,45 +56,143 @@ export function ensureSystemBinPathForMachineId(): void {
   process.env.PATH = [...current, ...missing].join(path.delimiter);
 }
 
-/**
- * Stable per-install id used only when the hardware fingerprint is unavailable.
- * Persisted under userData so it survives restarts. Falls back to an ephemeral
- * id if userData is unwritable — keeping the app alive is the priority.
- */
-function persistedFallbackDeviceId(): string {
-  const generate = () => `fallback-${crypto.randomUUID()}`;
-
-  let file: string;
+/** Absolute path of the persisted identity file, or null if userData is unavailable. */
+function deviceIdFilePath(): string | null {
   try {
-    file = path.join(app.getPath('userData'), 'device-id-fallback');
+    return path.join(app.getPath('userData'), DEVICE_ID_FILENAME);
   } catch {
-    // userData path unavailable (e.g. app not ready): last-resort ephemeral id.
-    return generate();
+    // userData not available yet (app not ready): caller handles the null.
+    return null;
   }
+}
 
+function readPersistedDeviceId(file: string): string | null {
   try {
-    const existing = fs.readFileSync(file, 'utf8').trim();
-    if (existing) return existing;
+    const value = fs.readFileSync(file, 'utf8').trim();
+    return value || null;
   } catch {
-    // Missing / unreadable — fall through to generate and persist a fresh one.
+    // Missing / unreadable.
+    return null;
   }
+}
 
-  const generated = generate();
+function safeUnlink(file: string): void {
+  try {
+    fs.unlinkSync(file);
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+/** Write `id` to a unique sibling temp file and return its path, or null on failure. */
+function writeTempDeviceId(file: string, id: string): string | null {
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, generated, 'utf8');
   } catch {
-    // userData unwritable (rare): keep the ephemeral id so the app still launches.
+    return null; // userData unwritable.
   }
-  return generated;
+  const tmp = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(tmp, id, 'utf8');
+    return tmp;
+  } catch {
+    safeUnlink(tmp);
+    return null;
+  }
+}
+
+/**
+ * Overwrite the stored identity with `id` atomically (temp file + rename). Used
+ * to keep the stored copy in sync with the current hardware id — including when
+ * userData was copied from another machine. Concurrent writers all write the
+ * same hardware id, so a last-writer-wins rename is harmless. Best-effort.
+ */
+function writeDeviceIdAtomic(file: string, id: string): void {
+  const tmp = writeTempDeviceId(file, id);
+  if (!tmp) return;
+  try {
+    fs.renameSync(tmp, file); // Atomic replace; consumes tmp.
+  } catch {
+    safeUnlink(tmp);
+  }
+}
+
+/**
+ * Create the stored identity only if none exists yet, atomically, so racing
+ * processes converge on one value.
+ *
+ * We write the full contents to a temp file first, then `link()` it into place.
+ * `link()` is atomic and fails with EEXIST if the target already exists, giving
+ * exclusive create — and because the temp is fully written before linking, the
+ * target is never observable half-written / empty. So a racer that loses
+ * (EEXIST) is guaranteed to read the winner's complete value rather than an
+ * empty string. (A plain `writeFileSync(…, 'wx')` creates the entry before
+ * writing bytes, leaving exactly that empty-read window.)
+ *
+ * Returns the id that is authoritative on disk after the call.
+ */
+function createDeviceIdExclusive(file: string, id: string): string {
+  const tmp = writeTempDeviceId(file, id);
+  if (!tmp) return id; // userData unwritable: keep the in-memory id.
+  try {
+    fs.linkSync(tmp, file);
+    return id; // We won the race (or were unopposed).
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'EEXIST') {
+      // Another process already published the identity. Because publishing is
+      // atomic, the file already holds a complete value — use it.
+      return readPersistedDeviceId(file) ?? id;
+    }
+    // Unexpected link failure: keep the in-memory id.
+    return id;
+  } finally {
+    safeUnlink(tmp);
+  }
+}
+
+/**
+ * Persist `id` once the app is ready. Used only when userData was unavailable at
+ * resolve time (extremely early startup): this run already committed to `id` in
+ * memory, but persisting now makes future launches stable. Best-effort.
+ */
+function deferPersistWhenReady(id: string): void {
+  const whenReady = (app as { whenReady?: () => Promise<void> }).whenReady;
+  if (typeof whenReady !== 'function') return;
+  whenReady
+    .call(app)
+    .then(() => {
+      const file = deviceIdFilePath();
+      if (file) createDeviceIdExclusive(file, id);
+    })
+    .catch(() => {
+      // Best-effort only; a failure here just means we retry next launch.
+    });
 }
 
 let cached: string | null = null;
 
+/** Probe the hardware id, returning a non-empty trimmed value or null on any failure. */
+function probeHardwareId(): string | null {
+  ensureSystemBinPathForMachineId();
+  try {
+    const probed = machineIdSync()?.trim();
+    // Treat an empty/whitespace result as a failure: persisting "" would hand
+    // out a blank device id and never stabilise (blank reads back as null).
+    return probed || null;
+  } catch (err) {
+    process.stderr.write(
+      `[cindy] machineIdSync() failed (${(err as Error)?.message ?? err})\n`,
+    );
+    return null;
+  }
+}
+
 /**
  * Resolve the device id, honouring the `XDT_DEVICE_ID_OVERRIDE` dev override,
- * then the hardware fingerprint, then a persisted UUID fallback. Result is
- * memoised so every call site in the process agrees on one id.
+ * then the live hardware probe (authoritative when available), then the last
+ * stored id (reused only when the probe fails), then a freshly minted UUID
+ * fallback. Result is memoised so every call site in the process agrees on one
+ * id, and so the persistent-storage side effect happens at most once per process.
  */
 export function resolveDeviceId(): string {
   if (cached) return cached;
@@ -93,15 +203,39 @@ export function resolveDeviceId(): string {
     return cached;
   }
 
-  ensureSystemBinPathForMachineId();
-  try {
-    cached = machineIdSync();
-  } catch (err) {
-    process.stderr.write(
-      `[cindy] machineIdSync() failed (${(err as Error)?.message ?? err}); ` +
-        'falling back to persisted device id\n',
-    );
-    cached = persistedFallbackDeviceId();
+  const file = deviceIdFilePath();
+  const hardwareId = probeHardwareId();
+
+  if (hardwareId) {
+    // Hardware id wins. Keep the stored copy in sync (so a later probe *failure*
+    // reuses this exact id, and so a userData copied here is re-pinned to this
+    // machine) — but only rewrite when it actually changed.
+    if (file && readPersistedDeviceId(file) !== hardwareId) {
+      writeDeviceIdAtomic(file, hardwareId);
+    }
+    cached = hardwareId;
+    return cached;
+  }
+
+  // Probe failed: prefer the last successfully stored id so a transient failure
+  // doesn't churn identity or log the user out.
+  if (file) {
+    const persisted = readPersistedDeviceId(file);
+    if (persisted) {
+      cached = persisted;
+      return cached;
+    }
+  }
+
+  // Hardware can't be identified and nothing is stored yet: mint a stable
+  // fallback, created exclusively so concurrent first launches converge.
+  const fallback = `fallback-${crypto.randomUUID()}`;
+  if (file) {
+    cached = createDeviceIdExclusive(file, fallback);
+  } else {
+    // userData wasn't available this early — commit now, persist when ready.
+    cached = fallback;
+    deferPersistWhenReady(fallback);
   }
   return cached;
 }

--- a/apps/desktop/src/main/deviceId.ts
+++ b/apps/desktop/src/main/deviceId.ts
@@ -37,8 +37,13 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { machineIdSync } from 'node-machine-id';
+import { createLogger } from './logger';
+
+const log = createLogger('deviceId');
 
 const DEVICE_ID_FILENAME = 'device-id';
+/** Prefix of ids minted when hardware can't be identified. Also used to detect them. */
+const FALLBACK_PREFIX = 'fallback-';
 
 /**
  * Ensure the system bin directories are on PATH so `node-machine-id`'s bare
@@ -180,19 +185,52 @@ function probeHardwareId(): string | null {
     // out a blank device id and never stabilise (blank reads back as null).
     return probed || null;
   } catch (err) {
-    process.stderr.write(
-      `[cindy] machineIdSync() failed (${(err as Error)?.message ?? err})\n`,
-    );
+    // Route through the rotating main logger, not process.stderr: on a packaged
+    // Finder launch (exactly the failure this module guards) stderr is invisible
+    // and would leave no trace in the documented diagnostic logs.
+    log.warn(`machineIdSync() failed: ${(err as Error)?.message ?? err}`);
     return null;
   }
 }
 
 /**
+ * Reconcile a successful hardware probe against whatever is already stored, and
+ * return the id to use (and persist). The rules keep every shared-userData
+ * process converging on one value while never silently invalidating an
+ * already-registered identity:
+ *
+ *   - nothing stored → publish the hardware id exclusively (racers adopt the
+ *     winner, whichever value that turns out to be);
+ *   - stored === hardware id → use it;
+ *   - stored is a `fallback-*` → KEEP it. It may already be registered with the
+ *     server (refresh token bound to it); replacing it with the hardware id would
+ *     trip DEVICE_MISMATCH and log the user out. Keeping it also makes a
+ *     probe-success process converge with a probe-failure process that already
+ *     published a fallback for this shared userData.
+ *   - stored is a *different* hardware id → userData was copied/restored from
+ *     another machine → re-pin to this machine's id.
+ */
+function reconcileHardwareId(file: string | null, hardwareId: string): string {
+  if (!file) {
+    // userData unavailable this early: use the hardware id now and persist when
+    // ready, so a later probe failure can reuse it.
+    deferPersistWhenReady(hardwareId);
+    return hardwareId;
+  }
+  const stored = readPersistedDeviceId(file);
+  if (!stored) return createDeviceIdExclusive(file, hardwareId);
+  if (stored === hardwareId) return stored;
+  if (stored.startsWith(FALLBACK_PREFIX)) return stored;
+  writeDeviceIdAtomic(file, hardwareId);
+  return hardwareId;
+}
+
+/**
  * Resolve the device id, honouring the `XDT_DEVICE_ID_OVERRIDE` dev override,
- * then the live hardware probe (authoritative when available), then the last
- * stored id (reused only when the probe fails), then a freshly minted UUID
- * fallback. Result is memoised so every call site in the process agrees on one
- * id, and so the persistent-storage side effect happens at most once per process.
+ * then the live hardware probe (reconciled against any stored id), then the last
+ * stored id (reused when the probe fails), then a freshly minted UUID fallback.
+ * Result is memoised so every call site in the process agrees on one id, and so
+ * the persistent-storage side effect happens at most once per process.
  */
 export function resolveDeviceId(): string {
   if (cached) return cached;
@@ -207,18 +245,12 @@ export function resolveDeviceId(): string {
   const hardwareId = probeHardwareId();
 
   if (hardwareId) {
-    // Hardware id wins. Keep the stored copy in sync (so a later probe *failure*
-    // reuses this exact id, and so a userData copied here is re-pinned to this
-    // machine) — but only rewrite when it actually changed.
-    if (file && readPersistedDeviceId(file) !== hardwareId) {
-      writeDeviceIdAtomic(file, hardwareId);
-    }
-    cached = hardwareId;
+    cached = reconcileHardwareId(file, hardwareId);
     return cached;
   }
 
-  // Probe failed: prefer the last successfully stored id so a transient failure
-  // doesn't churn identity or log the user out.
+  // Probe failed: prefer the last stored id so a transient failure doesn't churn
+  // identity or log the user out.
   if (file) {
     const persisted = readPersistedDeviceId(file);
     if (persisted) {
@@ -229,7 +261,7 @@ export function resolveDeviceId(): string {
 
   // Hardware can't be identified and nothing is stored yet: mint a stable
   // fallback, created exclusively so concurrent first launches converge.
-  const fallback = `fallback-${crypto.randomUUID()}`;
+  const fallback = `${FALLBACK_PREFIX}${crypto.randomUUID()}`;
   if (file) {
     cached = createDeviceIdExclusive(file, fallback);
   } else {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -71,6 +71,7 @@ installInvokeCapture();
 //   - --passive / XDT_SCHEDULER_PASSIVE:定时任务自动触发让位给同机另一实例。
 // 必须在 app 'ready' 前调用。仅 dev(非 packaged)生效,生产忽略,零线上影响。
 import { machineIdSync } from 'node-machine-id';
+import { ensureSystemBinPathForMachineId } from './deviceId.js';
 import {
   resolveDevCliFlags,
   shouldEnforcePassiveMigrationCompatibility,
@@ -135,6 +136,9 @@ if (devFlags.needsIsolatedDeviceId) {
   const nameSegment = devFlags.isolationName ? `${devFlags.isolationName}-` : '';
   let isolatedDeviceId: string;
   try {
+    // Finder-launched GUI PATH omits /usr/sbin, so bare `ioreg` would throw and
+    // drop us into the fixed-string fallback below; patch PATH first.
+    ensureSystemBinPathForMachineId();
     const hashBudget = 60 - nameSegment.length; // 'dev-'(4) + nameSegment + hash = 64
     isolatedDeviceId = `dev-${nameSegment}${machineIdSync().slice(0, hashBudget)}`;
   } catch {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -71,7 +71,7 @@ installInvokeCapture();
 //   - --passive / XDT_SCHEDULER_PASSIVE:定时任务自动触发让位给同机另一实例。
 // 必须在 app 'ready' 前调用。仅 dev(非 packaged)生效,生产忽略,零线上影响。
 import { machineIdSync } from 'node-machine-id';
-import { ensureSystemBinPathForMachineId } from './deviceId.js';
+import { ensureSystemBinPathForMachineId } from './deviceId';
 import {
   resolveDevCliFlags,
   shouldEnforcePassiveMigrationCompatibility,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -125,10 +125,11 @@ if (devFlags.invalidIsolationName !== null) {
   );
 }
 if (devFlags.needsIsolatedDeviceId) {
-  // 必须在 authManager 模块加载(bootstrap 动态 import)之前落到 env——它在模块
-  // 顶层读一次 XDT_DEVICE_ID_OVERRIDE ?? machineIdSync()。机器指纹极小概率取不到
-  // (machineIdSync 抛),兜底用固定串:跨机器同账号双沙箱会撞,但比静默回落物理机
-  // 指纹(必踢正式版)安全方向正确。
+  // 必须在首次 getDeviceId()(authManager 惰性调 resolveDeviceId())之前落到 env——
+  // 设备 ID 解析会优先 XDT_DEVICE_ID_OVERRIDE,否则探测机器指纹。这里在 bootstrap
+  // 动态 import 之前设好,时序上稳妥。机器指纹极小概率取不到(machineIdSync 抛),
+  // 兜底用固定串:跨机器同账号双沙箱会撞,但比静默回落物理机指纹(必踢正式版)
+  // 安全方向正确。
   // 长度硬预算 64:server 端 Slack 设备注册的 deviceId 白名单上限 64 字符
   // (apps/server/src/routes/slack.ts),超长会被静默降级成 legacy 伪设备。
   // 默认沙箱 'dev-' + 60 位指纹 = 64;命名沙箱 'dev-<名字>-' + 剩余预算的指纹

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -71,7 +71,7 @@ installInvokeCapture();
 //   - --passive / XDT_SCHEDULER_PASSIVE:定时任务自动触发让位给同机另一实例。
 // 必须在 app 'ready' 前调用。仅 dev(非 packaged)生效,生产忽略,零线上影响。
 import { machineIdSync } from 'node-machine-id';
-import { ensureSystemBinPathForMachineId } from './deviceId';
+import { ensureSystemBinPathForMachineId } from './deviceId.js';
 import {
   resolveDevCliFlags,
   shouldEnforcePassiveMigrationCompatibility,


### PR DESCRIPTION
Fixes a desktop startup crash when machineIdSync fails, for example when system paths such as /usr/sbin are missing from PATH. Adds a persisted fallback device id so app startup is not blocked by device id resolution.