### PR TITLE
fix(desktop): avoid PowerShell during Windows startup orphan reap

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -155,6 +155,12 @@ const NATIVE_RUNTIME_DEPS = [
   'undici',
 ];
 
+// Windows 启动期 Claude orphan 扫描:直接走 Win32 Tool Help snapshot,
+// 不再 spawn PowerShell(360 等安全软件会把启动期脚本子进程判成攻击)。
+// main 进程按架构规则使用顶层静态 import，所以各平台都携带平台中立的 JS
+// 入口；只有 win32 目标携带并从锁定补丁后的源码重建 N-API binary。
+const WINDOWS_PROCESS_TREE_RUNTIME_DEP = '@vscode/windows-process-tree';
+
 /**
  * @parcel/watcher 的 prebuilt 二进制按 platform-arch (在 linux 上还分 glibc/musl)
  * 拆进独立子包, 主包运行时按 process.platform/arch 动态 require。打包时只带
@@ -312,6 +318,37 @@ function copySqliteVecBinary(buildPath: string, targetPlatform: string, targetAr
   console.log(`[forge:afterCopy] sqlite-vec ${platformDir}/${ext} -> ${dst}`);
 }
 
+function copyWindowsProcessTreeRuntime(
+  src: string,
+  dst: string,
+  targetPlatform: string,
+): void {
+  fs.mkdirSync(dst, { recursive: true });
+  fs.cpSync(path.join(src, 'lib'), path.join(dst, 'lib'), {
+    recursive: true,
+    dereference: true,
+  });
+  for (const fileName of ['package.json', 'LICENSE']) {
+    fs.copyFileSync(path.join(src, fileName), path.join(dst, fileName));
+  }
+
+  if (targetPlatform !== 'win32') return;
+
+  const runtimeBinary = path.join(src, 'build', 'Release', 'windows_process_tree.node');
+  if (!fs.existsSync(runtimeBinary)) {
+    throw new Error(
+      `[forge:afterCopy] @vscode/windows-process-tree runtime missing: ${runtimeBinary}`,
+    );
+  }
+  fs.copyFileSync(path.join(src, 'binding.gyp'), path.join(dst, 'binding.gyp'));
+  fs.cpSync(path.join(src, 'src'), path.join(dst, 'src'), {
+    recursive: true,
+    dereference: true,
+  });
+  fs.mkdirSync(path.join(dst, 'build', 'Release'), { recursive: true });
+  fs.copyFileSync(runtimeBinary, path.join(dst, 'build', 'Release', 'windows_process_tree.node'));
+}
+
 function bundleNativeDeps(buildPath: string, targetPlatform: string, targetArch: string): void {
   const destModules = path.join(buildPath, 'node_modules');
   fs.mkdirSync(destModules, { recursive: true });
@@ -322,6 +359,7 @@ function bundleNativeDeps(buildPath: string, targetPlatform: string, targetArch:
     ...NATIVE_RUNTIME_DEPS,
     parcelWatcherPlatformPkg(targetPlatform, targetArch),
     ...sharpPlatformPkgs(targetPlatform, targetArch),
+    WINDOWS_PROCESS_TREE_RUNTIME_DEP,
     // loudness 只在 Windows 用 (录音时静音)。它的 Win 后端是个捆绑的 .exe,
     // 必须运行时按 __dirname 找 — 所以走 NATIVE_RUNTIME_DEPS 这条路, 不让 vite
     // bundle。Mac/Linux 完全不带, 避免拖入 execa 这条无用依赖链。
@@ -339,7 +377,11 @@ function bundleNativeDeps(buildPath: string, targetPlatform: string, targetArch:
     // dir created before cpSync — cpSync only mkdir's the leaf.
     fs.mkdirSync(path.dirname(dst), { recursive: true });
     fs.rmSync(dst, { recursive: true, force: true });
-    fs.cpSync(src, dst, { recursive: true, dereference: true });
+    if (dep === WINDOWS_PROCESS_TREE_RUNTIME_DEP) {
+      copyWindowsProcessTreeRuntime(src, dst, targetPlatform);
+    } else {
+      fs.cpSync(src, dst, { recursive: true, dereference: true });
+    }
     console.log(`[forge:afterCopy] bundled native dep: ${dep} <- ${src}`);
   }
   copyDiscordRuntimeDeps(destModules);
@@ -353,16 +395,22 @@ async function rebuildNativeDepsInPackage(
   buildPath: string,
   electronVersion: string,
   arch: string,
+  targetPlatform: string,
 ): Promise<void> {
+  const rebuildModules = [
+    'better-sqlite3',
+    'node-pty',
+    ...(targetPlatform === 'win32' ? [WINDOWS_PROCESS_TREE_RUNTIME_DEP] : []),
+  ];
   console.log(
-    `[forge:afterCopy] rebuilding native modules (better-sqlite3, node-pty) for Electron ${electronVersion} (${arch})...`,
+    `[forge:afterCopy] rebuilding native modules (${rebuildModules.join(', ')}) for Electron ${electronVersion} (${arch})...`,
   );
   await electronRebuild({
     buildPath,
     electronVersion,
     arch,
     force: true,
-    onlyModules: ['better-sqlite3', 'node-pty'],
+    onlyModules: rebuildModules,
   });
   const sqliteNative = path.join(
     buildPath,
@@ -393,6 +441,43 @@ async function rebuildNativeDepsInPackage(
     );
   }
 
+  let processTreeNative: string | undefined;
+  if (targetPlatform === 'win32') {
+    processTreeNative = path.join(
+      buildPath,
+      'node_modules',
+      WINDOWS_PROCESS_TREE_RUNTIME_DEP,
+      'build',
+      'Release',
+      'windows_process_tree.node',
+    );
+    if (!fs.existsSync(processTreeNative)) {
+      throw new Error(
+        `[forge:afterCopy] rebuild reported success but ${processTreeNative} is missing`,
+      );
+    }
+
+    // electron-rebuild leaves C++ sources, vcxproj files, .obj/.pdb outputs and
+    // a second ABI-cache copy behind. Runtime only needs lib/ + this N-API
+    // binary, so collapse build/ back to the same minimal shape we ship from
+    // the upstream package.
+    const processTreeDir = path.join(
+      buildPath,
+      'node_modules',
+      WINDOWS_PROCESS_TREE_RUNTIME_DEP,
+    );
+    const rebuiltNative = fs.readFileSync(processTreeNative);
+    for (const relativePath of ['bin', 'build', 'src', 'binding.gyp']) {
+      fs.rmSync(path.join(processTreeDir, relativePath), {
+        recursive: true,
+        force: true,
+      });
+    }
+    fs.mkdirSync(path.dirname(processTreeNative), { recursive: true });
+    fs.writeFileSync(processTreeNative, rebuiltNative);
+    console.log(`[forge:afterCopy] pruned windows-process-tree build intermediates`);
+  }
+
   // node-pty 被整目录纳入 asar.unpack（为放出 spawn-helper / winpty 等运行时二进制），
   // 但 node-gyp 重编会在 build/Release/obj.target/ 留下 .o 编译中间产物（也是 Mach-O）。
   // 若随目录一起解包进 app.asar.unpacked，macOS 发版/公证签名脚本（release-macos.mjs /
@@ -413,7 +498,11 @@ async function rebuildNativeDepsInPackage(
     console.log(`[forge:afterCopy] pruned node-gyp intermediates: ${ptyObjTarget}`);
   }
 
-  console.log(`[forge:afterCopy] rebuild ok: ${sqliteNative}, ${ptyNative}`);
+  console.log(
+    `[forge:afterCopy] rebuild ok: ${[sqliteNative, ptyNative, processTreeNative]
+      .filter(Boolean)
+      .join(', ')}`,
+  );
 }
 
 const isDev = process.env.NODE_ENV !== 'production' && !process.argv.includes('make') && !process.argv.includes('package');
@@ -1252,7 +1341,7 @@ const config: ForgeConfig = {
         (async () => {
           try {
             bundleNativeDeps(buildPath, platform, arch);
-            await rebuildNativeDepsInPackage(buildPath, electronVersion, arch);
+            await rebuildNativeDepsInPackage(buildPath, electronVersion, arch, platform);
             copySqliteVecBinary(buildPath, platform, arch);
             callback();
           } catch (err) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -90,6 +90,7 @@
     "@cindy/model-providers": "workspace:*",
     "@cindy/remote-file-service": "workspace:*",
     "@cindy/voice-input-core": "workspace:*",
+    "@vscode/windows-process-tree": "0.8.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@paralleldrive/cuid2": "^2.3.1",
     "@parcel/watcher": "^2.5.6",

--- a/apps/desktop/src/main/__tests__/claudeOrphanReaper.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeOrphanReaper.test.ts
@@ -1,8 +1,8 @@
 /**
  * claudeOrphanReaper.test.ts
  * ---------------------------------------------------------------------------
- * 单测只覆盖同步 reaper 的识别 / 容错语义。真实 taskkill / pgrep / kill 由
- * 平台集成验证兜底，避免测试环境误碰本机进程树。
+ * 单测覆盖异步 reaper 的识别 / 容错语义。真实 taskkill / Win32 snapshot /
+ * ps / kill 由平台集成验证兜底，避免测试环境误碰本机进程树。
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -16,8 +16,17 @@ const logger = {
   fatal: vi.fn(),
 };
 
+interface WindowsProcessRow {
+  name: string;
+  pid: number;
+  ppid: number;
+  commandLine?: string;
+  creationTime?: number;
+}
+
 type ExecFileSyncMock = ReturnType<typeof vi.fn>;
 type SpawnSyncMock = ReturnType<typeof vi.fn>;
+type GetAllProcessesMock = ReturnType<typeof vi.fn>;
 
 const originalPlatform = process.platform;
 
@@ -37,6 +46,8 @@ function restorePlatform(): void {
 
 async function importReaper(options: {
   platform: NodeJS.Platform;
+  windowsProcesses?: WindowsProcessRow[];
+  getAllProcesses?: GetAllProcessesMock;
   execFileSync?: ExecFileSyncMock;
   spawnSync?: SpawnSyncMock;
 }) {
@@ -45,6 +56,14 @@ async function importReaper(options: {
   vi.doMock('../logger', () => ({
     createLogger: () => logger,
   }));
+  vi.doMock('@vscode/windows-process-tree', () => ({
+    ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+    getAllProcesses:
+      options.getAllProcesses ??
+      vi.fn((callback: (processes: WindowsProcessRow[]) => void) => {
+        callback(options.windowsProcesses ?? []);
+      }),
+  }));
   vi.doMock('node:child_process', () => ({
     execFileSync: options.execFileSync ?? vi.fn(),
     spawnSync: options.spawnSync ?? vi.fn(),
@@ -52,10 +71,12 @@ async function importReaper(options: {
   return import('../claude-orphan-reaper');
 }
 
-describe('reapClaudeOrphansSync', () => {
+describe('reapClaudeOrphans', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.doUnmock('../logger');
+    vi.doUnmock('@vscode/windows-process-tree');
     vi.doUnmock('node:child_process');
     restorePlatform();
     logger.debug.mockReset();
@@ -63,20 +84,12 @@ describe('reapClaudeOrphansSync', () => {
     logger.warn.mockReset();
   });
 
-  it('kills current main-process children and historical xdt-maker orphans', async () => {
+  it('kills current main-process children and historical Cindy orphans', async () => {
     const selfChildPid = 111;
     const historicalPid = 222;
     const livePeerPid = 333;
     const externalPid = 444;
-    const execFileSync = vi.fn((file: string) => {
-      if (file === 'taskkill') return '';
-      return [
-        `${selfChildPid}|${process.pid}|C:\\tools\\claude.exe`,
-        `${historicalPid}|99999|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-        `${livePeerPid}|88888|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-        `${externalPid}|77777|C:\\Users\\me\\.local\\bin\\claude.exe`,
-      ].join('\n');
-    });
+    const execFileSync = vi.fn();
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
       if (pid === 99999 || pid === 77777) {
         const err = new Error('missing') as NodeJS.ErrnoException;
@@ -85,9 +98,44 @@ describe('reapClaudeOrphansSync', () => {
       }
       return true;
     }) as typeof process.kill);
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      execFileSync,
+      windowsProcesses: [
+        {
+          name: 'claude.exe',
+          pid: selfChildPid,
+          ppid: process.pid,
+          commandLine: 'C:\\tools\\claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: historicalPid,
+          ppid: 99999,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+        {
+          name: 'CLAUDE.EXE',
+          pid: livePeerPid,
+          ppid: 88888,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: externalPid,
+          ppid: 77777,
+          commandLine: 'C:\\Users\\me\\.local\\bin\\claude.exe',
+        },
+        {
+          name: 'notepad.exe',
+          pid: 555,
+          ppid: process.pid,
+          commandLine: 'C:\\Windows\\notepad.exe',
+        },
+      ],
+    });
 
-    const result = reapClaudeOrphansSync();
+    const result = await reapClaudeOrphans();
 
     expect(result.scannedTotal).toBe(4);
     expect(result.killedSelfSpawned).toBe(1);
@@ -119,36 +167,63 @@ describe('reapClaudeOrphansSync', () => {
   it('treats PPID <= 4 as dead and PPID === process.pid as alive without probing', async () => {
     const systemOrphanPid = 555;
     const selfChildPid = 666;
-    const execFileSync = vi.fn((file: string) => {
-      if (file === 'taskkill') return '';
-      return [
-        `${systemOrphanPid}|4|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-        `${selfChildPid}|${process.pid}|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-      ].join('\n');
+    const killSpy = vi
+      .spyOn(process, 'kill')
+      .mockImplementation((() => true) as typeof process.kill);
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      windowsProcesses: [
+        {
+          name: 'claude.exe',
+          pid: systemOrphanPid,
+          ppid: 4,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: selfChildPid,
+          ppid: process.pid,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+      ],
     });
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
 
-    const result = reapClaudeOrphansSync();
+    const result = await reapClaudeOrphans();
 
     expect(result.killedHistoricalOrphans).toBe(1);
     expect(result.killedSelfSpawned).toBe(1);
     expect(killSpy).not.toHaveBeenCalled();
   });
 
-  it('matches all xdt-maker Claude binary path markers', async () => {
+  it('matches all Cindy Claude binary path markers', async () => {
     const pids = [701, 702, 703];
-    const execFileSync = vi.fn((file: string) => {
-      if (file === 'taskkill') return '';
-      return [
-        `${pids[0]}|4|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-        `${pids[1]}|4|C:/Users/me/AppData/Roaming/xdt-maker/claude-code/claude.exe`,
-        `${pids[2]}|4|/Users/me/Library/Application Support/xdt-maker/claude-code/claude`,
-      ].join('\n');
+    const execFileSync = vi.fn();
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      execFileSync,
+      windowsProcesses: [
+        {
+          name: 'claude.exe',
+          pid: pids[0],
+          ppid: 4,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: pids[1],
+          ppid: 4,
+          commandLine: 'C:/Users/me/AppData/Roaming/xdt-maker/claude-code/claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: pids[2],
+          ppid: 4,
+          commandLine: '/Users/me/Library/Application Support/xdt-maker/claude-code/claude',
+        },
+      ],
     });
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
 
-    const result = reapClaudeOrphansSync();
+    const result = await reapClaudeOrphans();
 
     expect(result.killedHistoricalOrphans).toBe(3);
     for (const pid of pids) {
@@ -160,33 +235,188 @@ describe('reapClaudeOrphansSync', () => {
     }
   });
 
-  it('does not throw when scanning fails', async () => {
-    const execFileSync = vi.fn(() => {
+  it('does not throw when the native Windows scan fails', async () => {
+    const getAllProcesses = vi.fn(() => {
       throw new Error('scan failed');
     });
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      getAllProcesses,
+    });
 
-    expect(() => reapClaudeOrphansSync()).not.toThrow();
-    expect(reapClaudeOrphansSync().scannedTotal).toBe(0);
+    await expect(reapClaudeOrphans()).resolves.toEqual(
+      expect.objectContaining({ scannedTotal: 0 }),
+    );
     expect(logger.debug).toHaveBeenCalled();
   });
 
-  it('does not throw when killing fails', async () => {
-    const execFileSync = vi.fn((file: string) => {
-      if (file === 'taskkill') throw new Error('already gone');
-      return `${process.pid + 10}|${process.pid}|C:\\tools\\claude.exe`;
+  it('does not invoke the native Windows snapshot on POSIX', async () => {
+    const getAllProcesses = vi.fn(() => {
+      throw new Error('Windows native snapshot must not run on POSIX');
     });
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
+    const spawnSync = vi.fn(() => ({ stdout: '', status: 0 }));
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'linux',
+      getAllProcesses,
+      spawnSync,
+    });
 
-    let result: ReturnType<typeof reapClaudeOrphansSync> | undefined;
-    expect(() => { result = reapClaudeOrphansSync(); }).not.toThrow();
-    expect(result?.killedSelfSpawned).toBe(0);
+    await expect(reapClaudeOrphans()).resolves.toEqual(
+      expect.objectContaining({ scannedTotal: 0 }),
+    );
+    expect(getAllProcesses).not.toHaveBeenCalled();
+    expect(spawnSync).toHaveBeenCalledWith(
+      'ps',
+      ['-A', '-o', 'pid=,ppid=,etime=,command='],
+      expect.anything(),
+    );
+  });
+
+  it('bounds a native Windows scan that never invokes its callback', async () => {
+    vi.useFakeTimers();
+    let nativeCallback: ((processes: WindowsProcessRow[]) => void) | undefined;
+    let markNativeScanStarted!: () => void;
+    const nativeScanStarted = new Promise<void>((resolve) => {
+      markNativeScanStarted = resolve;
+    });
+    const getAllProcesses = vi.fn((callback: (processes: WindowsProcessRow[]) => void) => {
+      nativeCallback = callback;
+      markNativeScanStarted();
+    });
+    const execFileSync = vi.fn();
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      getAllProcesses,
+      execFileSync,
+    });
+
+    const resultPromise = reapClaudeOrphans();
+    await nativeScanStarted;
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(resultPromise).resolves.toEqual(expect.objectContaining({ scannedTotal: 0 }));
+    expect(logger.debug).toHaveBeenCalledWith('windows process snapshot timed out', {
+      timeoutMs: 1000,
+    });
+
+    nativeCallback?.([
+      {
+        name: 'claude.exe',
+        pid: process.pid + 10,
+        ppid: process.pid,
+        commandLine: 'C:\\tools\\claude.exe',
+      },
+    ]);
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('startup pass skips current-session children but still reaps historical orphans', async () => {
+    const selfChildPid = 111;
+    const historicalPid = 222;
+    const execFileSync = vi.fn();
+    vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+      if (pid === 99999) {
+        const err = new Error('missing') as NodeJS.ErrnoException;
+        err.code = 'ESRCH';
+        throw err;
+      }
+      return true;
+    }) as typeof process.kill);
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      execFileSync,
+      windowsProcesses: [
+        {
+          name: 'claude.exe',
+          pid: selfChildPid,
+          ppid: process.pid,
+          commandLine: 'C:\\tools\\claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: historicalPid,
+          ppid: 99999,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+      ],
+    });
+
+    const result = await reapClaudeOrphans({ reapCurrentSession: false });
+
+    expect(result.killedSelfSpawned).toBe(0);
+    expect(result.killedHistoricalOrphans).toBe(1);
+    expect(execFileSync).not.toHaveBeenCalledWith(
+      'taskkill',
+      ['/T', '/F', '/PID', String(selfChildPid)],
+      expect.anything(),
+    );
+    expect(execFileSync).toHaveBeenCalledWith(
+      'taskkill',
+      ['/T', '/F', '/PID', String(historicalPid)],
+      expect.objectContaining({ stdio: 'ignore' }),
+    );
+  });
+
+  it('serializes native snapshots so a timed-out scan cannot poison the next', async () => {
+    vi.useFakeTimers();
+    const callbacks: Array<(processes: WindowsProcessRow[]) => void> = [];
+    const getAllProcesses = vi.fn((cb: (processes: WindowsProcessRow[]) => void) => {
+      callbacks.push(cb);
+    });
+    const flush = async () => {
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    };
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      getAllProcesses,
+    });
+
+    // Startup scan issues one native call whose callback stays pending past 1s.
+    const startup = reapClaudeOrphans({ reapCurrentSession: false });
+    await flush();
+    expect(getAllProcesses).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(startup).resolves.toEqual(expect.objectContaining({ scannedTotal: 0 }));
+
+    // Quit scan begins while the first native call is STILL pending: it must not
+    // issue a second call yet (no coalescing onto the stale in-flight request).
+    const quit = reapClaudeOrphans({ reapCurrentSession: true });
+    await flush();
+    expect(getAllProcesses).toHaveBeenCalledTimes(1);
+
+    // Only after the first native call drains may the quit scan enumerate afresh.
+    callbacks[0]([]);
+    await flush();
+    expect(getAllProcesses).toHaveBeenCalledTimes(2);
+
+    callbacks[1]([]);
+    await expect(quit).resolves.toEqual(expect.objectContaining({ scannedTotal: 0 }));
+  });
+
+  it('does not throw when killing fails', async () => {
+    const execFileSync = vi.fn(() => {
+      throw new Error('already gone');
+    });
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      execFileSync,
+      windowsProcesses: [
+        {
+          name: 'claude.exe',
+          pid: process.pid + 10,
+          ppid: process.pid,
+          commandLine: 'C:\\tools\\claude.exe',
+        },
+      ],
+    });
+
+    const result = await reapClaudeOrphans();
+
+    expect(result.killedSelfSpawned).toBe(0);
     expect(logger.debug).toHaveBeenCalled();
   });
 
   it('buildClaudePathMarkers 为每个 userData 目录名(含历史值)生成三种路径形态', async () => {
-    // 品牌改名迁移窗口期,老安装 spawn 的 claude 命令行里仍是旧目录名——
-    // 标记表必须同时覆盖 brand-identity 的当前值与 legacyUserDataDirNames。
     const { buildClaudePathMarkers } = await importReaper({ platform: 'win32' });
     const markers = buildClaudePathMarkers(['Cindy', 'xdt-maker']);
     expect(markers).toEqual([
@@ -199,74 +429,64 @@ describe('reapClaudeOrphansSync', () => {
     ]);
   });
 
-  it('pipes Get-CimInstance into ForEach-Object in the Windows scan script', async () => {
-    // 回归锚(2026-07-14):管道符缺失时两条语句独立执行,ForEach-Object 拿不到
-    // 输入,扫描永远 0 行且不报错——收割器在 Windows 上静默失明。
-    // 带参数签名的 mock:零参 vi.fn 会把 mock.calls 推成空元组,下标访问过不了 typecheck。
-    const execFileSync = vi.fn((_file: string, _args?: string[], _opts?: unknown) => '');
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
-
-    reapClaudeOrphansSync();
-
-    const psCall = execFileSync.mock.calls.find(([file]) => file === 'powershell.exe');
-    expect(psCall).toBeDefined();
-    const script = (psCall![1] as string[])[3];
-    expect(script).toMatch(/\|\s*ForEach-Object/);
-    expect(psCall![2]).toEqual(expect.objectContaining({ timeout: 5000 }));
-  });
-
-  it('warns when scan output is non-empty but unparseable (format drift self-check)', async () => {
-    // 无管道符时 PowerShell 输出的就是这种格式化表格:有行、无 | 分隔。
-    const execFileSync = vi.fn((file: string) => {
-      if (file === 'taskkill') return '';
-      return [
-        'ProcessId Name       HandleCount',
-        '--------- ----       -----------',
-        '47140     claude.exe 1219',
-      ].join('\n');
+  it('uses a native command-line snapshot without launching PowerShell', async () => {
+    const getAllProcesses = vi.fn((callback: (processes: WindowsProcessRow[]) => void) => {
+      callback([]);
     });
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
+    const execFileSync = vi.fn();
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      getAllProcesses,
+      execFileSync,
+    });
 
-    const result = reapClaudeOrphansSync();
+    await reapClaudeOrphans();
 
-    expect(result.scannedTotal).toBe(0);
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('unparseable'),
-      expect.objectContaining({ lineCount: 3 }),
-    );
-  });
-
-  it('does not warn when scan output is genuinely empty', async () => {
-    const execFileSync = vi.fn(() => '');
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
-
-    expect(reapClaudeOrphansSync().scannedTotal).toBe(0);
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(getAllProcesses).toHaveBeenCalledWith(expect.any(Function), 2);
+    expect(execFileSync.mock.calls.some(([file]) => file === 'powershell.exe')).toBe(false);
   });
 
   it('reaps dev-checkout orphans launched from apps/claude-code-bin', async () => {
     const devOrphanPid = 901;
     const worktreeOrphanPid = 902;
     const liveDevPeerPid = 903;
-    const execFileSync = vi.fn((file: string) => {
-      if (file === 'taskkill') return '';
-      return [
-        `${devOrphanPid}|99999|E:\\AIWork\\Lizi\\apps\\claude-code-bin\\win32-x64\\claude.exe --output-format stream-json`,
-        `${worktreeOrphanPid}|99999|E:/AIWork/Lizi/.xdt-worktrees/foo/apps/claude-code-bin/win32-x64/claude.exe`,
-        `${liveDevPeerPid}|88888|E:\\Other\\Lizi\\apps\\claude-code-bin\\win32-x64\\claude.exe`,
-      ].join('\n');
-    });
+    const execFileSync = vi.fn();
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
       if (pid === 99999) {
         const err = new Error('missing') as NodeJS.ErrnoException;
         err.code = 'ESRCH';
         throw err;
       }
-      return true; // 88888 alive → 另一个活着的 checkout 实例,必须放过
+      return true;
     }) as typeof process.kill);
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      execFileSync,
+      windowsProcesses: [
+        {
+          name: 'claude.exe',
+          pid: devOrphanPid,
+          ppid: 99999,
+          commandLine:
+            'E:\\AIWork\\Lizi\\apps\\claude-code-bin\\win32-x64\\claude.exe --output-format stream-json',
+        },
+        {
+          name: 'claude.exe',
+          pid: worktreeOrphanPid,
+          ppid: 99999,
+          commandLine:
+            'E:/AIWork/Lizi/.xdt-worktrees/foo/apps/claude-code-bin/win32-x64/claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: liveDevPeerPid,
+          ppid: 88888,
+          commandLine: 'E:\\Other\\Lizi\\apps\\claude-code-bin\\win32-x64\\claude.exe',
+        },
+      ],
+    });
 
-    const result = reapClaudeOrphansSync();
+    const result = await reapClaudeOrphans();
 
     expect(result.killedHistoricalOrphans).toBe(2);
     expect(killSpy).toHaveBeenCalledWith(88888, 0);
@@ -278,18 +498,23 @@ describe('reapClaudeOrphansSync', () => {
   });
 
   it('matches Windows path markers case-insensitively', async () => {
-    const lowercasePid = 801;
-    const execFileSync = vi.fn((file: string) => {
-      if (file === 'taskkill') return '';
-      return `${lowercasePid}|4|C:\\users\\me\\appdata\\roaming\\xdt-maker\\claude-code\\claude.exe`;
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      windowsProcesses: [
+        {
+          name: 'claude.exe',
+          pid: 801,
+          ppid: 4,
+          commandLine: 'C:\\users\\me\\appdata\\roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+      ],
     });
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
 
-    const result = reapClaudeOrphansSync();
+    const result = await reapClaudeOrphans();
     expect(result.killedHistoricalOrphans).toBe(1);
   });
 
-  it('scans POSIX, walks the in-memory ppid map, and skips external claude installs', async () => {
+  it('scans POSIX, walks the in-memory ppid map, and skips external Claude installs', async () => {
     const claudePid = process.pid + 20;
     const childPid = process.pid + 21;
     const grandchildPid = process.pid + 22;
@@ -299,42 +524,131 @@ describe('reapClaudeOrphansSync', () => {
       if (file === 'ps') {
         return {
           status: 0,
-          stdout: [
-            // Class A: current-process child via xdt-maker bundled claude
-            `${claudePid} ${process.pid} /Users/me/Library/Application Support/xdt-maker/claude-code/claude`,
-            // Descendants of claudePid (cmd/npx-like)
-            `${childPid} ${claudePid} /bin/sh -c lark-mcp`,
-            `${grandchildPid} ${childPid} node lark-mcp`,
-            // External claude install — must NOT be killed
-            `${externalClaudePid} 1 /usr/local/bin/claude --help`,
-          ].join('\n') + '\n',
+          stdout:
+            [
+              `${claudePid} ${process.pid} 00:10 /Users/me/Library/Application Support/xdt-maker/claude-code/claude`,
+              `${childPid} ${claudePid} 00:09 /bin/sh -c lark-mcp`,
+              `${grandchildPid} ${childPid} 00:08 node lark-mcp`,
+              `${externalClaudePid} 1 05:00 /usr/local/bin/claude --help`,
+            ].join('\n') + '\n',
         };
       }
       return { status: 0, stdout: '' };
     });
-    const { reapClaudeOrphansSync } = await importReaper({ platform: 'darwin', spawnSync });
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'darwin',
+      spawnSync,
+    });
 
-    const result = reapClaudeOrphansSync();
+    const result = await reapClaudeOrphans();
 
     expect(result.killedSelfSpawned).toBe(1);
     expect(result.killedHistoricalOrphans).toBe(0);
     expect(spawnSync).toHaveBeenCalledWith(
       'ps',
-      ['-A', '-o', 'pid=,ppid=,command='],
+      ['-A', '-o', 'pid=,ppid=,etime=,command='],
       expect.objectContaining({ encoding: 'utf8' }),
     );
-    // Tree-walk produced root + child + grandchild from the in-memory map, no pgrep involved.
     expect(spawnSync).toHaveBeenCalledWith(
       'kill',
       ['-9', String(claudePid), String(childPid), String(grandchildPid)],
       expect.objectContaining({ timeout: 1000 }),
     );
-    // External claude must not be in any kill invocation.
     const killCalls = spawnSync.mock.calls.filter(([file]) => file === 'kill');
     for (const [, args] of killCalls) {
       expect(args).not.toContain(String(externalClaudePid));
     }
-    // pgrep is no longer used — the old recursive walk is gone.
     expect(spawnSync).not.toHaveBeenCalledWith('pgrep', expect.anything(), expect.anything());
+  });
+
+  it('parses POSIX etime across its formats and rejects junk', async () => {
+    const { parsePosixEtimeSeconds } = await importReaper({ platform: 'linux' });
+    expect(parsePosixEtimeSeconds('05:30')).toBe(330);
+    expect(parsePosixEtimeSeconds('01:02:03')).toBe(3723);
+    expect(parsePosixEtimeSeconds('2-03:04:05')).toBe(2 * 86400 + 3 * 3600 + 4 * 60 + 5);
+    expect(parsePosixEtimeSeconds('  00:00 ')).toBe(0);
+    expect(parsePosixEtimeSeconds('garbage')).toBeNull();
+    expect(parsePosixEtimeSeconds('')).toBeNull();
+  });
+
+  it('startup pass reaps a ppid===self orphan that provably predates this process', async () => {
+    // A previous instance crashed and this process reused its PID, so an orphan
+    // it left carries our PID as ppid. Creation time proves the orphan is older
+    // than us — it cannot be a child we spawned — so it is reaped even though the
+    // startup pass would normally skip ppid===self. A genuinely newer child is
+    // left untouched.
+    const selfCreated = 1_000_000;
+    const orphanPid = 111;
+    const liveChildPid = 222;
+    const execFileSync = vi.fn();
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      execFileSync,
+      windowsProcesses: [
+        { name: 'electron.exe', pid: process.pid, ppid: 1, creationTime: selfCreated },
+        {
+          name: 'claude.exe',
+          pid: orphanPid,
+          ppid: process.pid,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+          creationTime: selfCreated - 60_000,
+        },
+        {
+          name: 'claude.exe',
+          pid: liveChildPid,
+          ppid: process.pid,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+          creationTime: selfCreated + 60_000,
+        },
+      ],
+    });
+
+    const result = await reapClaudeOrphans({ reapCurrentSession: false });
+
+    expect(result.killedHistoricalOrphans).toBe(1);
+    expect(result.killedSelfSpawned).toBe(0);
+    expect(execFileSync).toHaveBeenCalledWith(
+      'taskkill',
+      ['/T', '/F', '/PID', String(orphanPid)],
+      expect.objectContaining({ stdio: 'ignore' }),
+    );
+    expect(execFileSync).not.toHaveBeenCalledWith(
+      'taskkill',
+      ['/T', '/F', '/PID', String(liveChildPid)],
+      expect.anything(),
+    );
+  });
+
+  it('startup pass leaves ppid===self processes alone when age or ownership is unproven', async () => {
+    const selfCreated = 1_000_000;
+    const unknownAgePid = 111; // older than us in reality, but no creation time reported
+    const foreignOlderPid = 222; // older than us, but no Cindy marker → not ours to reap
+    const execFileSync = vi.fn();
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      execFileSync,
+      windowsProcesses: [
+        { name: 'electron.exe', pid: process.pid, ppid: 1, creationTime: selfCreated },
+        {
+          name: 'claude.exe',
+          pid: unknownAgePid,
+          ppid: process.pid,
+          commandLine: 'C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe',
+        },
+        {
+          name: 'claude.exe',
+          pid: foreignOlderPid,
+          ppid: process.pid,
+          commandLine: 'C:\\tools\\claude.exe',
+          creationTime: selfCreated - 60_000,
+        },
+      ],
+    });
+
+    const result = await reapClaudeOrphans({ reapCurrentSession: false });
+
+    expect(result.killedHistoricalOrphans).toBe(0);
+    expect(result.killedSelfSpawned).toBe(0);
+    expect(execFileSync).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/claudeOrphanReaper.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeOrphanReaper.test.ts
@@ -393,6 +393,32 @@ describe('reapClaudeOrphans', () => {
     await expect(quit).resolves.toEqual(expect.objectContaining({ scannedTotal: 0 }));
   });
 
+  it('claims the native snapshot slot before same-tick callers can overlap it', async () => {
+    const callbacks: Array<(processes: WindowsProcessRow[]) => void> = [];
+    const getAllProcesses = vi.fn((cb: (processes: WindowsProcessRow[]) => void) => {
+      callbacks.push(cb);
+    });
+    const flush = async () => {
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    };
+    const { reapClaudeOrphans } = await importReaper({
+      platform: 'win32',
+      getAllProcesses,
+    });
+
+    const first = reapClaudeOrphans();
+    const second = reapClaudeOrphans();
+    await flush();
+    expect(getAllProcesses).toHaveBeenCalledTimes(1);
+
+    callbacks[0]([]);
+    await flush();
+    expect(getAllProcesses).toHaveBeenCalledTimes(2);
+
+    callbacks[1]([]);
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  });
+
   it('does not throw when killing fails', async () => {
     const execFileSync = vi.fn(() => {
       throw new Error('already gone');

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -1,8 +1,9 @@
 /**
  * lifecycle.test.ts
  * ---------------------------------------------------------------------------
- * 单测覆盖 runQuitDisposers 的三阶段编排语义:
+ * 单测覆盖 runQuitDisposers 的四阶段编排语义:
  *   - sync 串行, 抛错不影响后续
+ *   - pre-async 串行 await, 必须早于所有 async teardown
  *   - async 并发, 整体超时兜底
  *   - post-async 串行, 必须晚于 async (用于 db close 这种依赖 async 产物的清理)
  *
@@ -84,23 +85,27 @@ describe('runQuitDisposers', () => {
     vi.useRealTimers();
   });
 
-  it('runs sync → async → post-async in order', async () => {
+  it('runs sync → pre-async → async → post-async in order', async () => {
     const { onQuit, runQuitDisposers } = await freshLifecycle();
     const log: string[] = [];
 
     onQuit('a-sync', () => { log.push('a-sync'); }, 'sync');
-    onQuit('b-async', async () => {
+    onQuit('b-pre-async', async () => {
       await new Promise((r) => setTimeout(r, 10));
-      log.push('b-async');
+      log.push('b-pre-async');
+    }, 'pre-async');
+    onQuit('c-async', async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      log.push('c-async');
     }, 'async');
-    onQuit('c-post', async () => {
+    onQuit('d-post', async () => {
       await new Promise((r) => setTimeout(r, 5));
-      log.push('c-post');
+      log.push('d-post');
     }, 'post-async');
 
     await runQuitDisposers(1000);
 
-    expect(log).toEqual(['a-sync', 'b-async', 'c-post']);
+    expect(log).toEqual(['a-sync', 'b-pre-async', 'c-async', 'd-post']);
   });
 
   it('sync disposer that throws does not block subsequent disposers', async () => {
@@ -143,6 +148,24 @@ describe('runQuitDisposers', () => {
     expect(postRan).toBe(true);
     // 超时 50ms, 实际不应远超 (无其它阻塞)
     expect(elapsed).toBeLessThan(200);
+  });
+
+  it('pre-async phase honors per-disposer timeout — later phases still run', async () => {
+    const { onQuit, runQuitDisposers } = await freshLifecycle();
+    const log: string[] = [];
+
+    // 永不 resolve 的 pre-async disposer 不能无限阻塞整条 shutdown。
+    onQuit('hang-pre', () => new Promise(() => { /* never */ }), 'pre-async');
+    onQuit('after-pre', () => { log.push('after-pre'); }, 'pre-async');
+    onQuit('post', () => { log.push('post'); }, 'post-async');
+
+    const start = Date.now();
+    await runQuitDisposers(50);
+    const elapsed = Date.now() - start;
+
+    // 卡住的 disposer 超时后, 后续 pre-async 与 post-async 仍然执行。
+    expect(log).toEqual(['after-pre', 'post']);
+    expect(elapsed).toBeLessThan(400);
   });
 
   it('rejected async disposer does not break the chain', async () => {

--- a/apps/desktop/src/main/__tests__/windowsLegacyDevShortcutCleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/windowsLegacyDevShortcutCleanup.test.ts
@@ -1,0 +1,473 @@
+import path from 'node:path';
+import os from 'node:os';
+import { promises as realFs } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => {
+      throw new Error('not used in tests');
+    },
+  },
+}));
+vi.mock('../logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import {
+  cleanupLegacyDevShortcuts,
+  parseWindowsShortcut,
+  readBoundedShortcut,
+  MAX_SHORTCUT_BYTES,
+  type LegacyDevShortcutCleanupDeps,
+  type LegacyShortcutDetails,
+} from '../windowsLegacyDevShortcutCleanup';
+
+const APP_DATA = 'C:\\Users\\u\\AppData\\Roaming';
+const START_MENU = path.join(APP_DATA, 'Microsoft', 'Windows', 'Start Menu', 'Programs');
+
+function dirEntry(name: string, kind: 'directory' | 'file') {
+  return {
+    name,
+    isDirectory: () => kind === 'directory',
+    isFile: () => kind === 'file',
+  };
+}
+
+function makeHarness(options?: {
+  files?: Record<string, { target: string; args?: string }>;
+  dirs?: Record<string, Array<ReturnType<typeof dirEntry>>>;
+}) {
+  const files = new Map<string, { target: string; args?: string }>(
+    Object.entries(options?.files ?? {}),
+  );
+  const dirs = new Map(Object.entries(options?.dirs ?? {}));
+  const removed: string[] = [];
+  const logger = { info: vi.fn(), warn: vi.fn() };
+  const deps: LegacyDevShortcutCleanupDeps = {
+    platform: 'win32',
+    appDataDir: () => APP_DATA,
+    exists: async (filePath) => files.has(filePath),
+    readdir: async (dirPath) => dirs.get(dirPath) ?? [],
+    unlink: async (filePath) => {
+      if (!files.delete(filePath)) throw new Error(`ENOENT ${filePath}`);
+      removed.push(filePath);
+    },
+    readShortcut: async (filePath) => {
+      const details = files.get(filePath);
+      if (!details) throw new Error(`ENOENT ${filePath}`);
+      return { target: details.target, args: details.args ?? '' };
+    },
+    logger,
+  };
+  return { deps, dirs, files, logger, removed };
+}
+
+describe('cleanupLegacyDevShortcuts', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  it('removes the known SnoreToast shortcut by exact legacy name', async () => {
+    const knownShortcut = path.join(START_MENU, 'XdtMakerDev.lnk');
+    const { deps, files, removed } = makeHarness({
+      files: {
+        [knownShortcut]: {
+          target: 'C:\\somewhere\\legacy.exe',
+          args: '--legacy',
+        },
+      },
+    });
+
+    await cleanupLegacyDevShortcuts(deps);
+
+    expect(files.has(knownShortcut)).toBe(false);
+    expect(removed).toEqual([knownShortcut]);
+  });
+
+  it('recursively removes only argumentless dev Electron shortcuts', async () => {
+    const nestedDir = path.join(START_MENU, 'Nested');
+    const rootDevShortcut = path.join(START_MENU, 'Electron.lnk');
+    const nestedDevShortcut = path.join(nestedDir, 'OldElectron.lnk');
+    const shortcutWithArgs = path.join(START_MENU, 'KeepArgs.lnk');
+    const unrelatedShortcut = path.join(START_MENU, 'Other.lnk');
+    const { deps, files, removed } = makeHarness({
+      dirs: {
+        [START_MENU]: [
+          dirEntry('Nested', 'directory'),
+          dirEntry('Electron.lnk', 'file'),
+          dirEntry('KeepArgs.lnk', 'file'),
+          dirEntry('Other.lnk', 'file'),
+          dirEntry('README.txt', 'file'),
+        ],
+        [nestedDir]: [dirEntry('OldElectron.lnk', 'file')],
+      },
+      files: {
+        [rootDevShortcut]: {
+          target: 'C:/repo/node_modules/electron/dist/electron.exe',
+        },
+        [nestedDevShortcut]: {
+          target: 'D:\\code\\node_modules\\electron\\dist\\electron.exe',
+          args: '',
+        },
+        [shortcutWithArgs]: {
+          target: 'C:\\repo\\node_modules\\electron\\dist\\electron.exe',
+          args: 'C:\\repo',
+        },
+        [unrelatedShortcut]: {
+          target: 'C:\\Program Files\\Electron\\electron.exe',
+        },
+      },
+    });
+
+    await cleanupLegacyDevShortcuts(deps);
+
+    expect(removed).toEqual(expect.arrayContaining([rootDevShortcut, nestedDevShortcut]));
+    expect(files.has(shortcutWithArgs)).toBe(true);
+    expect(files.has(unrelatedShortcut)).toBe(true);
+  });
+
+  it('treats whitespace-only arguments as argumentless and still removes the link', async () => {
+    const whitespaceArgsShortcut = path.join(START_MENU, 'Electron.lnk');
+    const { deps, files, removed } = makeHarness({
+      dirs: { [START_MENU]: [dirEntry('Electron.lnk', 'file')] },
+      files: {
+        [whitespaceArgsShortcut]: {
+          target: 'C:\\repo\\node_modules\\electron\\dist\\electron.exe',
+          args: '   ',
+        },
+      },
+    });
+
+    await cleanupLegacyDevShortcuts(deps);
+
+    expect(files.has(whitespaceArgsShortcut)).toBe(false);
+    expect(removed).toEqual([whitespaceArgsShortcut]);
+  });
+
+  it('skips non-Windows platforms before touching the filesystem', async () => {
+    const { deps } = makeHarness();
+    deps.platform = 'darwin';
+    const appDataDir = vi.fn(() => APP_DATA);
+    deps.appDataDir = appDataDir;
+
+    await cleanupLegacyDevShortcuts(deps);
+
+    expect(appDataDir).not.toHaveBeenCalled();
+  });
+
+  it('swallows read, traversal, and unlink failures so startup continues', async () => {
+    const knownShortcut = path.join(START_MENU, 'XdtMakerDev.lnk');
+    const scannedShortcut = path.join(START_MENU, 'Electron.lnk');
+    const { deps, logger } = makeHarness({
+      dirs: {
+        [START_MENU]: [
+          dirEntry('Protected', 'directory'),
+          dirEntry('Electron.lnk', 'file'),
+        ],
+      },
+      files: {
+        [knownShortcut]: { target: 'C:\\legacy.exe' },
+        [scannedShortcut]: {
+          target: 'C:\\repo\\node_modules\\electron\\dist\\electron.exe',
+        },
+      },
+    });
+    deps.unlink = async () => {
+      throw new Error('access denied');
+    };
+    deps.readShortcut = async () => {
+      throw new Error('corrupt link');
+    };
+    const originalReaddir = deps.readdir;
+    deps.readdir = async (dirPath) => {
+      if (dirPath.endsWith('Protected')) throw new Error('access denied');
+      return originalReaddir(dirPath);
+    };
+
+    await expect(cleanupLegacyDevShortcuts(deps)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('stops the pending Start Menu scan from resuming work after timeout', async () => {
+    vi.useFakeTimers();
+    const { deps, logger, removed } = makeHarness();
+    let finishReaddir: ((entries: ReturnType<typeof dirEntry>[]) => void) | undefined;
+    deps.readdir = () =>
+      new Promise((resolve) => {
+        finishReaddir = resolve;
+      });
+    const readShortcut = vi.fn(async (): Promise<LegacyShortcutDetails> => ({
+      target: 'C:\\repo\\node_modules\\electron\\dist\\electron.exe',
+      args: '',
+    }));
+    deps.readShortcut = readShortcut;
+
+    const cleanup = cleanupLegacyDevShortcuts(deps);
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    await expect(cleanup).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'legacy dev shortcut cleanup timed out; continuing startup',
+      { timeoutMs: 8_000 },
+    );
+
+    finishReaddir?.([dirEntry('Electron.lnk', 'file')]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readShortcut).not.toHaveBeenCalled();
+    expect(removed).toEqual([]);
+  });
+
+  it('lets the deadline win when a single shortcut resolution never completes', async () => {
+    // Resolution is now async, so one hanging read cannot hold the main thread
+    // past the deadline the way a synchronous shell.readShortcutLink call could.
+    vi.useFakeTimers();
+    const shortcut = path.join(START_MENU, 'Electron.lnk');
+    const { deps, logger, removed } = makeHarness({
+      dirs: { [START_MENU]: [dirEntry('Electron.lnk', 'file')] },
+    });
+    deps.readShortcut = () => new Promise<LegacyShortcutDetails>(() => {});
+
+    const cleanup = cleanupLegacyDevShortcuts(deps);
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    await expect(cleanup).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'legacy dev shortcut cleanup timed out; continuing startup',
+      { timeoutMs: 8_000 },
+    );
+    expect(removed).toEqual([]);
+    expect(shortcut).toContain('Electron.lnk');
+  });
+});
+
+describe('parseWindowsShortcut', () => {
+  const SHELL_LINK_CLSID = Buffer.from([
+    0x01, 0x14, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+  ]);
+
+  function buildLnk(opts: { target: string; args?: string }): Buffer {
+    const header = Buffer.alloc(0x4c);
+    header.writeUInt32LE(0x4c, 0);
+    SHELL_LINK_CLSID.copy(header, 4);
+    let flags = 0x0000_0002; // HasLinkInfo
+    const hasArgs = opts.args !== undefined;
+    if (hasArgs) flags |= 0x0000_0020; // HasArguments
+    header.writeUInt32LE(flags, 20);
+
+    const linkInfoHeaderSize = 0x1c;
+    const baseBytes = Buffer.from(opts.target, 'latin1');
+    const localBasePathOffset = linkInfoHeaderSize;
+    const suffixOffset = localBasePathOffset + baseBytes.length + 1;
+    const linkInfoSize = suffixOffset + 1;
+    const linkInfo = Buffer.alloc(linkInfoSize);
+    linkInfo.writeUInt32LE(linkInfoSize, 0);
+    linkInfo.writeUInt32LE(linkInfoHeaderSize, 4);
+    linkInfo.writeUInt32LE(0x1, 8); // VolumeIDAndLocalBasePath
+    linkInfo.writeUInt32LE(linkInfoHeaderSize, 12); // VolumeIDOffset (unused here)
+    linkInfo.writeUInt32LE(localBasePathOffset, 16);
+    linkInfo.writeUInt32LE(0, 20); // CommonNetworkRelativeLinkOffset
+    linkInfo.writeUInt32LE(suffixOffset, 24);
+    baseBytes.copy(linkInfo, localBasePathOffset);
+
+    const parts = [header, linkInfo];
+    if (hasArgs) {
+      const argBytes = Buffer.from(opts.args!, 'latin1');
+      const stringData = Buffer.alloc(2 + argBytes.length);
+      stringData.writeUInt16LE(argBytes.length, 0);
+      argBytes.copy(stringData, 2);
+      parts.push(stringData);
+    }
+    return Buffer.concat(parts);
+  }
+
+  it('decodes an argumentless dev Electron target from raw .lnk bytes', () => {
+    const target = 'C:\\repo\\node_modules\\electron\\dist\\electron.exe';
+    expect(parseWindowsShortcut(buildLnk({ target }))).toEqual({ target, args: '' });
+  });
+
+  it('decodes command-line arguments when present', () => {
+    const target = 'C:\\repo\\node_modules\\electron\\dist\\electron.exe';
+    expect(parseWindowsShortcut(buildLnk({ target, args: 'C:\\repo' }))).toEqual({
+      target,
+      args: 'C:\\repo',
+    });
+  });
+
+  it('returns null for buffers that are not shell links', () => {
+    expect(parseWindowsShortcut(Buffer.from('not a shortcut'))).toBeNull();
+    expect(parseWindowsShortcut(Buffer.alloc(0x4c))).toBeNull();
+  });
+
+  it('does not alias bytes outside LinkInfo when a path offset points past it', () => {
+    // A corrupt LinkInfo whose LocalBasePathOffset points at the trailing bytes
+    // (past linkInfoSize but still inside the file) must NOT decode those bytes
+    // as the target — otherwise a crafted `.lnk` could impersonate a dev Electron
+    // link and get deleted. Expect a safe null instead.
+    const header = Buffer.alloc(0x4c);
+    header.writeUInt32LE(0x4c, 0);
+    SHELL_LINK_CLSID.copy(header, 4);
+    header.writeUInt32LE(0x0000_0002, 20); // HasLinkInfo only
+
+    const linkInfoHeaderSize = 0x1c;
+    const linkInfoSize = linkInfoHeaderSize; // no in-struct path data
+    const linkInfo = Buffer.alloc(linkInfoSize);
+    linkInfo.writeUInt32LE(linkInfoSize, 0);
+    linkInfo.writeUInt32LE(linkInfoHeaderSize, 4);
+    linkInfo.writeUInt32LE(0x1, 8); // VolumeIDAndLocalBasePath
+    linkInfo.writeUInt32LE(0, 12);
+    linkInfo.writeUInt32LE(linkInfoSize, 16); // LocalBasePathOffset == end (out of struct)
+    linkInfo.writeUInt32LE(0, 20);
+    linkInfo.writeUInt32LE(0, 24);
+
+    const trailing = Buffer.from(
+      'C:\\x\\node_modules\\electron\\dist\\electron.exe\0',
+      'latin1',
+    );
+    const malformed = Buffer.concat([header, linkInfo, trailing]);
+
+    expect(parseWindowsShortcut(malformed)).toBeNull();
+  });
+
+  it('does not treat an unterminated LocalBasePath as a valid target', () => {
+    // The LocalBasePath runs to the end of LinkInfo with no NUL terminator and
+    // its bytes end in a dev Electron suffix. Without requiring a terminator the
+    // parser would hand back that content and the link would be deleted.
+    const header = Buffer.alloc(0x4c);
+    header.writeUInt32LE(0x4c, 0);
+    SHELL_LINK_CLSID.copy(header, 4);
+    header.writeUInt32LE(0x0000_0002, 20); // HasLinkInfo only
+
+    const linkInfoHeaderSize = 0x1c;
+    const baseBytes = Buffer.from(
+      'C:\\x\\node_modules\\electron\\dist\\electron.exe',
+      'latin1',
+    );
+    const localBasePathOffset = linkInfoHeaderSize;
+    const linkInfoSize = localBasePathOffset + baseBytes.length; // no NUL, no suffix
+    const linkInfo = Buffer.alloc(linkInfoSize);
+    linkInfo.writeUInt32LE(linkInfoSize, 0);
+    linkInfo.writeUInt32LE(linkInfoHeaderSize, 4);
+    linkInfo.writeUInt32LE(0x1, 8); // VolumeIDAndLocalBasePath
+    linkInfo.writeUInt32LE(0, 12);
+    linkInfo.writeUInt32LE(localBasePathOffset, 16);
+    linkInfo.writeUInt32LE(0, 20);
+    linkInfo.writeUInt32LE(0, 24); // no suffix
+    baseBytes.copy(linkInfo, localBasePathOffset);
+
+    expect(parseWindowsShortcut(Buffer.concat([header, linkInfo]))).toBeNull();
+  });
+
+  // A network-share target (CommonNetworkRelativeLinkAndPathSuffix, flag 0x2):
+  // the resolved path is the share name plus the CommonPathSuffix.
+  function buildNetworkLnk(opts: { netName: string; suffix: string; args?: string }): Buffer {
+    const header = Buffer.alloc(0x4c);
+    header.writeUInt32LE(0x4c, 0);
+    SHELL_LINK_CLSID.copy(header, 4);
+    let flags = 0x0000_0002; // HasLinkInfo
+    const hasArgs = opts.args !== undefined;
+    if (hasArgs) flags |= 0x0000_0020; // HasArguments
+    header.writeUInt32LE(flags, 20);
+
+    const linkInfoHeaderSize = 0x1c;
+    const netNameBytes = Buffer.from(`${opts.netName}\0`, 'latin1');
+    const cnrlHeaderSize = 0x14;
+    const cnrlSize = cnrlHeaderSize + netNameBytes.length;
+    const cnrl = Buffer.alloc(cnrlSize);
+    cnrl.writeUInt32LE(cnrlSize, 0);
+    cnrl.writeUInt32LE(0x2, 4); // ValidNetType
+    cnrl.writeUInt32LE(cnrlHeaderSize, 8); // NetNameOffset
+    cnrl.writeUInt32LE(0, 12); // DeviceNameOffset
+    cnrl.writeUInt32LE(0, 16); // NetworkProviderType
+    netNameBytes.copy(cnrl, cnrlHeaderSize);
+
+    const suffixBytes = Buffer.from(`${opts.suffix}\0`, 'latin1');
+    const cnrlOffset = linkInfoHeaderSize;
+    const suffixOffset = cnrlOffset + cnrl.length;
+    const linkInfoSize = suffixOffset + suffixBytes.length;
+    const linkInfo = Buffer.alloc(linkInfoSize);
+    linkInfo.writeUInt32LE(linkInfoSize, 0);
+    linkInfo.writeUInt32LE(linkInfoHeaderSize, 4);
+    linkInfo.writeUInt32LE(0x2, 8); // CommonNetworkRelativeLinkAndPathSuffix
+    linkInfo.writeUInt32LE(0, 12); // VolumeIDOffset (unused)
+    linkInfo.writeUInt32LE(0, 16); // LocalBasePathOffset (unused)
+    linkInfo.writeUInt32LE(cnrlOffset, 20); // CommonNetworkRelativeLinkOffset
+    linkInfo.writeUInt32LE(suffixOffset, 24); // CommonPathSuffixOffset
+    cnrl.copy(linkInfo, cnrlOffset);
+    suffixBytes.copy(linkInfo, suffixOffset);
+
+    const parts = [header, linkInfo];
+    if (hasArgs) {
+      const argBytes = Buffer.from(opts.args!, 'latin1');
+      const stringData = Buffer.alloc(2 + argBytes.length);
+      stringData.writeUInt16LE(argBytes.length, 0);
+      argBytes.copy(stringData, 2);
+      parts.push(stringData);
+    }
+    return Buffer.concat(parts);
+  }
+
+  it('decodes a network-share dev Electron target (UNC checkout)', () => {
+    const netName = '\\\\build-server\\dev';
+    const suffix = '\\repo\\node_modules\\electron\\dist\\electron.exe';
+    expect(parseWindowsShortcut(buildNetworkLnk({ netName, suffix }))).toEqual({
+      target: netName + suffix,
+      args: '',
+    });
+  });
+
+  it('does not forge a target from a surviving field when the other is unterminated', () => {
+    // A valid LocalBasePath ending in the dev Electron suffix, but an unterminated
+    // CommonPathSuffix. The old behavior collapsed the corrupt suffix to "" and
+    // handed back the base alone — which passes the dev-link check and gets the
+    // shortcut deleted. A present-but-corrupt field must void the whole target.
+    const header = Buffer.alloc(0x4c);
+    header.writeUInt32LE(0x4c, 0);
+    SHELL_LINK_CLSID.copy(header, 4);
+    header.writeUInt32LE(0x0000_0002, 20); // HasLinkInfo only
+
+    const linkInfoHeaderSize = 0x1c;
+    const baseBytes = Buffer.from(
+      'C:\\x\\node_modules\\electron\\dist\\electron.exe\0',
+      'latin1',
+    );
+    const localBasePathOffset = linkInfoHeaderSize;
+    const suffixOffset = localBasePathOffset + baseBytes.length;
+    const suffixBytes = Buffer.from('\\trailing-with-no-terminator', 'latin1'); // no NUL
+    const linkInfoSize = suffixOffset + suffixBytes.length;
+    const linkInfo = Buffer.alloc(linkInfoSize);
+    linkInfo.writeUInt32LE(linkInfoSize, 0);
+    linkInfo.writeUInt32LE(linkInfoHeaderSize, 4);
+    linkInfo.writeUInt32LE(0x1, 8); // VolumeIDAndLocalBasePath
+    linkInfo.writeUInt32LE(0, 12);
+    linkInfo.writeUInt32LE(localBasePathOffset, 16);
+    linkInfo.writeUInt32LE(0, 20);
+    linkInfo.writeUInt32LE(suffixOffset, 24); // CommonPathSuffixOffset → unterminated run
+    baseBytes.copy(linkInfo, localBasePathOffset);
+    suffixBytes.copy(linkInfo, suffixOffset);
+
+    expect(parseWindowsShortcut(Buffer.concat([header, linkInfo]))).toBeNull();
+  });
+
+  it('reads a normal shortcut but refuses oversized files', async () => {
+    const dir = await realFs.mkdtemp(path.join(os.tmpdir(), 'lnk-bounded-'));
+    try {
+      const target = 'C:\\repo\\node_modules\\electron\\dist\\electron.exe';
+      const okPath = path.join(dir, 'ok.lnk');
+      const bigPath = path.join(dir, 'big.lnk');
+      await realFs.writeFile(okPath, buildLnk({ target }));
+      await realFs.writeFile(bigPath, Buffer.alloc(MAX_SHORTCUT_BYTES + 1));
+
+      expect(await readBoundedShortcut(okPath)).toEqual({ target, args: '' });
+      expect(await readBoundedShortcut(bigPath)).toBeNull();
+    } finally {
+      await realFs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/windowsLegacyDevShortcutCleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/windowsLegacyDevShortcutCleanup.test.ts
@@ -89,33 +89,36 @@ describe('cleanupLegacyDevShortcuts', () => {
     expect(removed).toEqual([knownShortcut]);
   });
 
-  it('recursively removes only argumentless dev Electron shortcuts', async () => {
+  it('recursively removes only argumentless Electron links owned by Cindy checkouts', async () => {
     const nestedDir = path.join(START_MENU, 'Nested');
+    const argsDir = path.join(START_MENU, 'Args');
     const rootDevShortcut = path.join(START_MENU, 'Electron.lnk');
-    const nestedDevShortcut = path.join(nestedDir, 'OldElectron.lnk');
-    const shortcutWithArgs = path.join(START_MENU, 'KeepArgs.lnk');
+    const nestedDevShortcut = path.join(nestedDir, 'Electron.lnk');
+    const shortcutWithArgs = path.join(argsDir, 'Electron.lnk');
     const unrelatedShortcut = path.join(START_MENU, 'Other.lnk');
     const { deps, files, removed } = makeHarness({
       dirs: {
         [START_MENU]: [
           dirEntry('Nested', 'directory'),
+          dirEntry('Args', 'directory'),
           dirEntry('Electron.lnk', 'file'),
-          dirEntry('KeepArgs.lnk', 'file'),
           dirEntry('Other.lnk', 'file'),
           dirEntry('README.txt', 'file'),
         ],
-        [nestedDir]: [dirEntry('OldElectron.lnk', 'file')],
+        [nestedDir]: [dirEntry('Electron.lnk', 'file')],
+        [argsDir]: [dirEntry('Electron.lnk', 'file')],
       },
       files: {
         [rootDevShortcut]: {
-          target: 'C:/repo/node_modules/electron/dist/electron.exe',
+          target: 'C:/repo/xdt-maker/node_modules/electron/dist/electron.exe',
         },
         [nestedDevShortcut]: {
-          target: 'D:\\code\\node_modules\\electron\\dist\\electron.exe',
+          target:
+            'D:\\code\\cindy\\.cindy-worktrees\\old-session\\node_modules\\electron\\dist\\electron.exe',
           args: '',
         },
         [shortcutWithArgs]: {
-          target: 'C:\\repo\\node_modules\\electron\\dist\\electron.exe',
+          target: 'C:\\repo\\cindy\\node_modules\\electron\\dist\\electron.exe',
           args: 'C:\\repo',
         },
         [unrelatedShortcut]: {
@@ -131,13 +134,42 @@ describe('cleanupLegacyDevShortcuts', () => {
     expect(files.has(unrelatedShortcut)).toBe(true);
   });
 
+  it('keeps other Electron projects and non-legacy shortcut names', async () => {
+    const otherDir = path.join(START_MENU, 'OtherProject');
+    const otherElectron = path.join(otherDir, 'Electron.lnk');
+    const renamedCindyLink = path.join(START_MENU, 'CindyPreview.lnk');
+    const { deps, files, removed } = makeHarness({
+      dirs: {
+        [START_MENU]: [
+          dirEntry('OtherProject', 'directory'),
+          dirEntry('CindyPreview.lnk', 'file'),
+        ],
+        [otherDir]: [dirEntry('Electron.lnk', 'file')],
+      },
+      files: {
+        [otherElectron]: {
+          target: 'C:\\repos\\other-app\\node_modules\\electron\\dist\\electron.exe',
+        },
+        [renamedCindyLink]: {
+          target: 'C:\\repos\\cindy\\node_modules\\electron\\dist\\electron.exe',
+        },
+      },
+    });
+
+    await cleanupLegacyDevShortcuts(deps);
+
+    expect(files.has(otherElectron)).toBe(true);
+    expect(files.has(renamedCindyLink)).toBe(true);
+    expect(removed).toEqual([]);
+  });
+
   it('treats whitespace-only arguments as argumentless and still removes the link', async () => {
     const whitespaceArgsShortcut = path.join(START_MENU, 'Electron.lnk');
     const { deps, files, removed } = makeHarness({
       dirs: { [START_MENU]: [dirEntry('Electron.lnk', 'file')] },
       files: {
         [whitespaceArgsShortcut]: {
-          target: 'C:\\repo\\node_modules\\electron\\dist\\electron.exe',
+          target: 'C:\\repo\\cindy\\node_modules\\electron\\dist\\electron.exe',
           args: '   ',
         },
       },

--- a/apps/desktop/src/main/__tests__/windowsStartupPowerShellCompatibility.test.ts
+++ b/apps/desktop/src/main/__tests__/windowsStartupPowerShellCompatibility.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const MAIN_ROOT = resolve(__dirname, '..');
+const DESKTOP_ROOT = resolve(MAIN_ROOT, '..', '..');
+const REPO_ROOT = resolve(DESKTOP_ROOT, '..', '..');
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(DESKTOP_ROOT, relativePath), 'utf8').replace(/\r\n?/g, '\n');
+}
+
+function readRepo(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8').replace(/\r\n?/g, '\n');
+}
+
+describe('Windows startup PowerShell compatibility', () => {
+  it('keeps both startup maintenance paths free of PowerShell', () => {
+    const reaper = read('src/main/claude-orphan-reaper.ts');
+    const shortcuts = read('src/main/windowsLegacyDevShortcutCleanup.ts');
+
+    expect(reaper.toLowerCase()).not.toContain('powershell.exe');
+    expect(reaper).toContain('@vscode/windows-process-tree');
+    expect(reaper).not.toContain("await import('@vscode/windows-process-tree')");
+    expect(shortcuts.toLowerCase()).not.toContain('powershell.exe');
+    expect(shortcuts).not.toContain('node:child_process');
+    // Resolution must not use the synchronous Electron main-thread API: a single
+    // slow/redirected shell.readShortcutLink call cannot be interrupted by the
+    // cleanup deadline and would freeze startup. Parse the raw bytes with async fs.
+    expect(shortcuts).not.toContain('shell.readShortcutLink');
+    expect(shortcuts).toContain("import fs from 'node:fs/promises'");
+    // Reads must stay bounded: a size ceiling checked before loading the file,
+    // via an async file handle rather than an unbounded fs.readFile that the 8s
+    // deadline cannot cancel.
+    expect(shortcuts).toContain('MAX_SHORTCUT_BYTES');
+    expect(shortcuts).toContain('handle.read(');
+    expect(shortcuts).not.toContain('await fs.readFile');
+  });
+
+  it('awaits orphan ownership scanning before any concurrent teardown', () => {
+    const bootstrap = read('src/main/bootstrap-electron.ts');
+    // Match the disposer name literal rather than the whole onQuit(...) call so
+    // the assertion survives prettier wrapping the registration across lines.
+    const reaperRegistration = bootstrap.indexOf("'reap-claude-orphans'");
+    const makerRegistration = bootstrap.indexOf("onQuit('shutdown-maker'");
+
+    expect(reaperRegistration).toBeGreaterThan(-1);
+    expect(bootstrap.slice(reaperRegistration, makerRegistration)).toContain("'pre-async'");
+    expect(reaperRegistration).toBeLessThan(makerRegistration);
+    expect(read('src/main/lifecycle.ts')).toContain(
+      "registry.filter((x) => x.phase === 'pre-async')",
+    );
+    expect(bootstrap).not.toContain('function cleanupLegacyDevShortcut(');
+  });
+
+  it('does not block ready initialization on best-effort shortcut cleanup', () => {
+    const bootstrap = read('src/main/bootstrap-electron.ts');
+
+    expect(bootstrap).toContain('void cleanupLegacyDevShortcuts().catch');
+    expect(bootstrap).not.toContain('await cleanupLegacyDevShortcuts()');
+  });
+
+  it('ships the native snapshot runtime as an externalized packaged dependency', () => {
+    const viteConfig = read('vite.main.config.ts');
+    const forgeConfig = read('forge.config.ts');
+
+    expect(viteConfig).toContain("'@vscode/windows-process-tree'");
+    expect(forgeConfig).toContain('copyWindowsProcessTreeRuntime(src, dst, targetPlatform)');
+    expect(forgeConfig).toContain("if (targetPlatform !== 'win32') return;");
+    expect(forgeConfig).toContain(
+      "targetPlatform === 'win32' ? [WINDOWS_PROCESS_TREE_RUNTIME_DEP] : []",
+    );
+    expect(forgeConfig).toContain("'windows_process_tree.node'");
+  });
+
+  it('patches and rebuilds the Windows snapshot without the upstream 1024-process cap', () => {
+    const dependencyPatch = readRepo(
+      'dependency-patches/@vscode__windows-process-tree@0.8.0.patch',
+    );
+    const forgeConfig = read('forge.config.ts');
+
+    expect(dependencyPatch).toContain(
+      '-    } while (process_count < 1024 && Process32Next(snapshot_handle, &process_entry));',
+    );
+    expect(dependencyPatch).toContain(
+      '+    } while (Process32Next(snapshot_handle, &process_entry));',
+    );
+    expect(forgeConfig).toContain('onlyModules: rebuildModules');
+    expect(forgeConfig).toContain('pruned windows-process-tree build intermediates');
+  });
+
+  it('rebuilds the patched snapshot module for the dev runtime, not just packaging', () => {
+    // The source patch only takes effect when the module is compiled from source.
+    // Packaging does this in Forge's afterCopy; the dev runtime (electron-forge
+    // start) relies on pnpm building it, which only happens when the module is in
+    // the root onlyBuiltDependencies allowlist. Without it, dev loads the capped
+    // upstream prebuilt.
+    const rootPackageJson = JSON.parse(readRepo('package.json'));
+    expect(rootPackageJson.pnpm.onlyBuiltDependencies).toContain(
+      '@vscode/windows-process-tree',
+    );
+  });
+
+  it('exposes process creation time from the patched snapshot for PID-reuse safety', () => {
+    // The reaper distinguishes a previous instance's orphan (inherited via PID
+    // reuse) from a live current-session child by process creation time. The
+    // patched native must supply it.
+    const dependencyPatch = readRepo(
+      'dependency-patches/@vscode__windows-process-tree@0.8.0.patch',
+    );
+    const reaper = read('src/main/claude-orphan-reaper.ts');
+
+    expect(dependencyPatch).toContain('GetProcessCreationTime');
+    expect(dependencyPatch).toContain('creationTime');
+    expect(reaper).toContain('creationTime');
+    expect(reaper).toContain('startedBefore');
+  });
+});

--- a/apps/desktop/src/main/__tests__/windowsStartupPowerShellCompatibility.test.ts
+++ b/apps/desktop/src/main/__tests__/windowsStartupPowerShellCompatibility.test.ts
@@ -41,9 +41,13 @@ describe('Windows startup PowerShell compatibility', () => {
     const bootstrap = read('src/main/bootstrap-electron.ts');
     // Match the disposer name literal rather than the whole onQuit(...) call so
     // the assertion survives prettier wrapping the registration across lines.
+    const quiesceRegistration = bootstrap.indexOf("'quiesce-maker-session-starts'");
     const reaperRegistration = bootstrap.indexOf("'reap-claude-orphans'");
     const makerRegistration = bootstrap.indexOf("onQuit('shutdown-maker'");
 
+    expect(quiesceRegistration).toBeGreaterThan(-1);
+    expect(bootstrap.slice(quiesceRegistration, reaperRegistration)).toContain("'pre-async'");
+    expect(quiesceRegistration).toBeLessThan(reaperRegistration);
     expect(reaperRegistration).toBeGreaterThan(-1);
     expect(bootstrap.slice(reaperRegistration, makerRegistration)).toContain("'pre-async'");
     expect(reaperRegistration).toBeLessThan(makerRegistration);
@@ -63,8 +67,17 @@ describe('Windows startup PowerShell compatibility', () => {
   it('ships the native snapshot runtime as an externalized packaged dependency', () => {
     const viteConfig = read('vite.main.config.ts');
     const forgeConfig = read('forge.config.ts');
+    const processTreeEntry = readRepo(
+      'node_modules/@vscode/windows-process-tree/lib/index.js',
+    );
 
     expect(viteConfig).toContain("'@vscode/windows-process-tree'");
+    // The package's JS entry is safe to import on POSIX: only win32 evaluates
+    // the native require. Non-Windows packages intentionally ship lib/ without
+    // windows_process_tree.node.
+    expect(processTreeEntry).toContain(
+      "process.platform === 'win32' ? require('../build/Release/windows_process_tree.node') : undefined",
+    );
     expect(forgeConfig).toContain('copyWindowsProcessTreeRuntime(src, dst, targetPlatform)');
     expect(forgeConfig).toContain("if (targetPlatform !== 'win32') return;");
     expect(forgeConfig).toContain(

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -23,7 +23,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { pipeline } from 'node:stream/promises';
-import { execFile, execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { machineIdSync } from 'node-machine-id';
 import windowStateKeeper from 'electron-window-state';
 import { BRAND_NAME } from '@cindy/maker-shared/branding';
@@ -252,7 +252,7 @@ import {
   broadcastVoiceInputPowerState,
   installVoiceInputPowerRelease,
 } from './voice-input/powerReleaseNotifier';
-import { reapClaudeOrphansSync } from './claude-orphan-reaper';
+import { reapClaudeOrphans } from './claude-orphan-reaper';
 import { initAppBadgeService, clearAllSessionAttention } from './appBadgeService';
 import { initNotificationService } from './notificationService';
 import { getAgentIslandService, initAgentIslandService } from './agent-island/service.js';
@@ -483,6 +483,7 @@ import {
 } from './deepLink.js';
 import { registerFolderContextMenu } from './folderContextMenu.js';
 import { healWindowsShortcuts } from './windowsShortcutSelfHeal.js';
+import { cleanupLegacyDevShortcuts } from './windowsLegacyDevShortcutCleanup.js';
 import { CURRENT_APP_ID } from '../shared/brandRegion.js';
 import {
   readWindowBehaviorSettings,
@@ -942,14 +943,17 @@ authManager.setAccountSwitchTeardown(async () => {
 });
 authManager.setAuthSessionTeardown(teardownAuthAccountBoundary);
 
-try {
-  reapClaudeOrphansSync();
-} catch (err) {
-  // Defensive: reapClaudeOrphansSync already catches its own scan/kill errors
-  // and logs to debug. This only fires on truly unexpected throws (e.g. module
-  // load failure) and must never abort bootstrap.
+// Fire-and-forget startup cleanup: Windows enumeration is an async native
+// snapshot, so it neither blocks the first frame nor launches PowerShell.
+// reapCurrentSession:false — this pass runs concurrently with bootstrap, so it
+// must only reap historical orphans (dead parent) and never a claude.exe whose
+// parent is us: that would be a session launched moments after cold start, not
+// an orphan. Quit-time cleanup is the one that reaps live current-session trees.
+void reapClaudeOrphans({ reapCurrentSession: false }).catch((err) => {
+  // Defensive: reapClaudeOrphans already catches its own scan/kill errors.
+  // This only fires on truly unexpected failures and must never abort bootstrap.
   createLogger('claude-orphan-reaper').warn('initial reap threw', { error: String(err) });
-}
+});
 
 // ── 启动诊断 (issue #758) ────────────────────────────────────────────────
 // 上次异常退出尸检 (run marker) + Crashpad 本地 minidump + crash dump 扫描。
@@ -5099,80 +5103,6 @@ async function runSmokeTest(userId: string): Promise<void> {
 // (cn=com.xd.cindycn / global=com.xd.cindy；未注入 region 时默认 global)。
 const WINDOWS_APP_USER_MODEL_ID = CURRENT_APP_ID;
 
-/**
- * 清理 Start Menu 里指向 dev `node_modules\electron\dist\electron.exe` 的残留 .lnk。
- *
- * 背景：这类 .lnk 的 target 是裸 dev electron.exe、Arguments 为空，被 Windows 注册
- * 成 AUMID 后（如 `XdtMaker.Dev`、`electron.app.xdt-maker`），一旦 toast 点击触发
- * AUMID 激活机制，就会启动一个没有 app 参数的 electron.exe，弹出 Electron 默认
- * 欢迎页 —— 用户视角看就是"通知点了之后跳到一个空白 Electron 页"。
- *
- * 已知来源：
- *   - 老版本 SnoreToast `-install` 留下的 `XdtMakerDev.lnk`（AUMID `XdtMaker.Dev`）
- *   - Electron 自身按 productName 自动注册的 `Electron.lnk`（AUMID `electron.app.xdt-maker`），
- *     dev 第一次启动后偶现
- *
- * 策略：
- *   1. 快路径：按已知文件名（XdtMakerDev.lnk）直删
- *   2. 防御扫描：枚举 Start Menu Programs 下所有 .lnk，凡是 target 指向
- *      `node_modules\electron\dist\electron.exe` 且 Arguments 为空的一律删除
- *
- * 静默 try/catch：用户手动删过 / 没装过 / 权限问题 / PowerShell 异常都不影响主流程。
- */
-function cleanupLegacyDevShortcut(): Promise<void> {
-  if (process.platform !== 'win32') return Promise.resolve();
-  const appData = process.env.APPDATA;
-  if (!appData) return Promise.resolve();
-  const startMenuDir = path.join(appData, 'Microsoft\\Windows\\Start Menu\\Programs');
-
-  // 快路径
-  const knownLnk = path.join(startMenuDir, 'XdtMakerDev.lnk');
-  try {
-    if (fs.existsSync(knownLnk)) {
-      fs.unlinkSync(knownLnk);
-      console.log('[AUMID] cleaned up legacy dev shortcut: %s', knownLnk);
-    }
-  } catch (err) {
-    console.warn('[AUMID] failed to remove legacy dev shortcut: %s', err);
-  }
-
-  // 防御扫描：解析 .lnk target 必须走 WScript.Shell COM，所以走 PowerShell。
-  // 单引号包路径并把内部 `'` 转成 `''`（PS 单引号字符串转义）。
-  const psRoot = startMenuDir.replace(/'/g, "''");
-  const ps =
-    `$sh = New-Object -ComObject WScript.Shell; ` +
-    `$root = '${psRoot}'; ` +
-    `if (Test-Path $root) { ` +
-    `Get-ChildItem -Path $root -Recurse -Filter *.lnk -ErrorAction SilentlyContinue | ForEach-Object { ` +
-    `try { ` +
-    `$lnk = $sh.CreateShortcut($_.FullName); ` +
-    `if ($lnk.TargetPath -match '(?i)node_modules\\\\electron\\\\dist\\\\electron\\.exe$' -and -not $lnk.Arguments) { ` +
-    `Remove-Item -LiteralPath $_.FullName -Force; ` +
-    `Write-Output ('removed: ' + $_.FullName) ` +
-    `} ` +
-    `} catch {} ` +
-    `} ` +
-    `}`;
-
-  return new Promise((resolve) => {
-    execFile(
-      'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', ps],
-      { timeout: 8000, windowsHide: true },
-      (err, stdout) => {
-        if (err) {
-          console.warn('[AUMID] dev shortcut scan failed: %s', err.message);
-        } else if (stdout.trim()) {
-          for (const line of stdout.trim().split(/\r?\n/)) {
-            console.log('[AUMID] %s', line);
-          }
-        }
-        resolve();
-      },
-    );
-  });
-}
-
 app.on('ready', async () => {
   // Smoke-test flag short-circuit: skip all normal init paths.
   const smoke = parseSmokeArgs();
@@ -5255,7 +5185,13 @@ app.on('ready', async () => {
   //
   // 必须在创建任何 Notification 之前调用。macOS / Linux 不需要。
   if (process.platform === 'win32') {
-    await cleanupLegacyDevShortcut();
+    // 旧开发快捷方式清理是 best-effort 后台维护；即使 Start Menu 位于慢速
+    // 或重定向存储，也不能阻塞 AUMID 与其余 ready 初始化。
+    void cleanupLegacyDevShortcuts().catch((err) => {
+      createLogger('legacyDevShortcutCleanup').warn('startup cleanup threw', {
+        error: String(err),
+      });
+    });
     app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID);
     console.log('[AUMID] runtime=%s', WINDOWS_APP_USER_MODEL_ID);
   }
@@ -5604,15 +5540,14 @@ app.on('ready', async () => {
 //   - process.on('uncaughtException')—— main 进程未捕获异常
 //   - app.on('render-process-gone')  —— renderer 崩 (main 还活)
 //
-// 三个阶段串成 sync → async(并发+6s 超时, 见下方 installQuitHandler) → post-async,
+// 四个阶段串成 sync → pre-async(串行 await) → async(并发+6s 超时,
+// 见下方 installQuitHandler) → post-async,
 // 然后 app.exit(<code>)。
 // 散落的 fire-and-forget 已经收掉, 进程不会在 disposer 跑完之前死。
 // 真硬崩 (segfault / kill -9) JS 层无能为力, 子进程靠 stdin EOF 自死。
 // ---------------------------------------------------------------------------
 
 // Sync 阶段: 同步触发, 不等结果。只放真正同步的清理 (释放本地句柄 / 取消定时器)。
-//   - reap-claude-children: 必须在 shutdown-maker 之前同步完成；SDK abort 掐掉
-//     claude.exe 后 Windows 上子进程会被 reparent 到 System, PPID 链断了就无法安全识别。
 //   - authManager / google auth: 同步释放定时器+回调引用。
 //     注意 token.dispose() 只清内存状态, 不删盘上的 refresh token (那是 logout 干的)。
 // interrupted-turn-resume:退出编排一启动就冻结「turn 在飞」标记的写入 —— 否则
@@ -5623,13 +5558,6 @@ onQuit(
   'session-active-turn-freeze',
   () => {
     freezeSessionActiveTurnMarkers();
-  },
-  'sync',
-);
-onQuit(
-  'reap-claude-children',
-  () => {
-    reapClaudeOrphansSync();
   },
   'sync',
 );
@@ -5653,6 +5581,15 @@ onQuit(
     disposeProviderAccessAuthListener = null;
   },
   'sync',
+);
+
+// Pre-async 阶段: 串行 await。Claude ownership snapshot + tree reap 必须在任何
+// 并发 teardown 之前完成；否则 proxy / maker 先关会让直接 Claude 进程退出并丢失
+// 可证明归属的 PPID 链。
+onQuit(
+  'reap-claude-orphans',
+  () => reapClaudeOrphans({ reapCurrentSession: true }).then(() => undefined),
+  'pre-async',
 );
 
 // Async 阶段: 并发跑, 6s 超时兜底。

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -5583,9 +5583,14 @@ onQuit(
   'sync',
 );
 
-// Pre-async 阶段: 串行 await。Claude ownership snapshot + tree reap 必须在任何
-// 并发 teardown 之前完成；否则 proxy / maker 先关会让直接 Claude 进程退出并丢失
-// 可证明归属的 PPID 链。
+// Pre-async 阶段: 串行 await。先封住新的 session startup 并排空已在途 startup，
+// 再做 Claude ownership snapshot + tree reap；否则 snapshot 期间新拉起的 Claude
+// 不在清理集合里，而并发 teardown 又会让直接进程退出并丢失可证明归属的 PPID 链。
+onQuit(
+  'quiesce-maker-session-starts',
+  () => getMakerIfReady()?.quiesceSessionStarts(),
+  'pre-async',
+);
 onQuit(
   'reap-claude-orphans',
   () => reapClaudeOrphans({ reapCurrentSession: true }).then(() => undefined),

--- a/apps/desktop/src/main/claude-orphan-reaper.ts
+++ b/apps/desktop/src/main/claude-orphan-reaper.ts
@@ -6,27 +6,42 @@
  *   abort path only terminates the direct `claude` child. On Windows that kill
  *   is a Win32 TerminateProcess call: it does not propagate to grandchildren,
  *   so stdio MCP servers started below `claude.exe` can survive as orphaned
- *   `node` processes after xdt-maker quits, restarts, or crashes.
+ *   `node` processes after Cindy quits, restarts, or crashes.
  *
  * Timing trap:
  *   On a normal quit, this must run before maker-core asks the SDK to abort the
  *   Claude session. Once the direct `claude` process is dead, its child tree is
  *   reparented to System/init and the PPID chain that proves ownership is gone.
- *   That is why bootstrap-electron registers this reaper in lifecycle's sync
- *   phase before the async `shutdown-maker` disposer.
+ *   That is why bootstrap-electron registers this reaper in lifecycle's
+ *   awaited `pre-async` phase, before any concurrent teardown can stop the
+ *   active sessions or their transports.
  *
  * Safety guarantees:
  *   - Current-session cleanup only targets `claude` processes whose parent is
- *     the current Electron main process.
- *   - Historical cleanup requires both an xdt-maker bundled Claude binary path
- *     marker and a dead parent, so an active second xdt-maker instance is left
- *     alone.
+ *     the current Electron main process, and only at quit time — the startup
+ *     pass (`reapCurrentSession: false`) leaves them alone, so a session launched
+ *     moments after a cold start is not misread as an orphan. The one exception
+ *     is a ppid===self process that provably started before this one: it cannot
+ *     be a child we spawned, so it is a previous instance's orphan whose PID we
+ *     inherited via reuse, and it is reaped like any other historical orphan.
+ *   - Historical cleanup requires both a Cindy-bundled Claude binary path marker
+ *     (matching every current + historical userData dir name, plus dev-checkout
+ *     `apps/claude-code-bin/` binaries) and a dead parent, so an active second
+ *     Cindy instance is left alone.
  *   - External Claude installs (for example `/usr/local/bin/claude`) do not
- *     contain the xdt-maker marker and are not historical-orphan candidates.
+ *     contain the Cindy marker and are not historical-orphan candidates.
  *   - Scan / kill failures are best-effort and never block app startup or quit.
+ *   - Windows enumeration uses the Win32 Tool Help snapshot API through a
+ *     native N-API module. It must not launch PowerShell during app startup:
+ *     security products classify that child-process pattern as script attack.
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  getAllProcesses,
+  ProcessDataFlag,
+  type IProcessInfo,
+} from '@vscode/windows-process-tree';
 import { allUserDataDirNames } from '@cindy/maker-shared/brand-identity';
 import { CURRENT_CINDY_REGION } from '../shared/brandRegion.js';
 import { createLogger } from './logger';
@@ -57,7 +72,7 @@ export function buildClaudePathMarkers(dirNames: readonly string[]): string[] {
   });
 }
 
-const XDT_CLAUDE_PATH_MARKERS = [
+const CINDY_CLAUDE_PATH_MARKERS = [
   // 只认领本区域(+ 历史)userData 下的进程:同机双装时另一区域实例的
   // Claude 子进程属于对方,跨区域匹配会把人家活着的 agent 树误杀。
   ...buildClaudePathMarkers(allUserDataDirNames(CURRENT_CINDY_REGION)),
@@ -71,7 +86,32 @@ const XDT_CLAUDE_PATH_MARKERS = [
 
 const POSIX_CLAUDE_CMD_RE = /(^|[\s/"'])claude(\.exe)?($|[\s"'])/;
 const POSIX_CLAUDE_CODE_CMD_RE = /(^|[\s/"'])claude-code($|[\s"'])/;
-const POSIX_PS_ROW_RE = /^(\d+)\s+(\d+)\s+(.+)$/;
+// pid ppid etime command — `etime` is a whitespace-free [[dd-]hh:]mm:ss token, so
+// the command (which may contain spaces) is the greedy tail.
+const POSIX_PS_ROW_RE = /^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/;
+
+// A ppid===self claude must be OLDER than this process by more than this margin
+// before we treat it as a PID-reuse orphan. Our own children are always spawned
+// after us (younger), so the margin only guards against clock/rounding skew
+// between `ps etime`'s 1-second resolution and process.uptime(); it never lets a
+// real current-session child be misread as an orphan and killed.
+const PID_REUSE_SKEW_MS = 5_000;
+
+/**
+ * Parses a POSIX `ps -o etime=` value ([[dd-]hh:]mm:ss elapsed time) into
+ * seconds. Returns null for anything that does not match, so an unexpected
+ * column layout degrades to "creation time unknown" rather than a bogus age.
+ */
+export function parsePosixEtimeSeconds(value: string): number | null {
+  const match = value.trim().match(/^(?:(\d+)-)?(?:(\d+):)?(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+  const days = match[1] ? Number.parseInt(match[1], 10) : 0;
+  const hours = match[2] ? Number.parseInt(match[2], 10) : 0;
+  const minutes = Number.parseInt(match[3], 10);
+  const seconds = Number.parseInt(match[4], 10);
+  if (![days, hours, minutes, seconds].every(Number.isFinite)) return null;
+  return days * 86_400 + hours * 3_600 + minutes * 60 + seconds;
+}
 
 export interface ReaperResult {
   scannedTotal: number;
@@ -84,59 +124,127 @@ interface ProcessRow {
   pid: number;
   ppid: number;
   cmdLine: string;
+  // Epoch milliseconds when the process started, or undefined when the platform
+  // could not supply it (older-than-us classification then stays conservative).
+  createdAtMs?: number;
 }
 
-function parseProcessLine(line: string): ProcessRow | null {
-  const parts = line.split('|');
-  if (parts.length < 3) return null;
+const WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS = 1000;
 
-  const pid = Number.parseInt(parts[0]?.trim() ?? '', 10);
-  const ppid = Number.parseInt(parts[1]?.trim() ?? '', 10);
-  if (!Number.isFinite(pid) || !Number.isFinite(ppid)) return null;
+// Serializes native enumerations. @vscode/windows-process-tree keeps a single
+// module-level in-progress request: issuing getAllProcesses while a prior call is
+// still running coalesces our callback onto that in-flight result. If a startup
+// scan hits WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS and returns [] while its native
+// call is still pending, a later quit-time scan could otherwise receive that
+// stale snapshot — missing a claude.exe spawned after startup, right before
+// `shutdown-maker` tears down transport. Chaining guarantees a fresh native
+// enumeration is issued only after the previous one has actually drained.
+let nativeSnapshotChain: Promise<unknown> = Promise.resolve();
 
-  return {
-    pid,
-    ppid,
-    cmdLine: parts.slice(2).join('|').trim(),
-  };
+function runNativeProcessSnapshot(): Promise<IProcessInfo[]> {
+  return new Promise<IProcessInfo[]>((resolve, reject) => {
+    try {
+      getAllProcesses(resolve, ProcessDataFlag.CommandLine);
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
 }
 
-function scanWindowsClaudeProcesses(): ProcessRow[] {
-  // 注意行尾的管道符:没有它,Get-CimInstance 与 ForEach-Object 会被 PowerShell
-  // 当成两条独立语句执行——前者输出格式化表格、后者拿不到管道输入,parse 永远
-  // 得到 0 行,收割器在 Windows 上整体失明(2026-07-14 实锤修复,曾静默失效)。
-  const script = [
-    'Get-CimInstance Win32_Process -Filter "Name=\'claude.exe\'" |',
-    'ForEach-Object {',
-    '  $cmd = ([string]$_.CommandLine) -replace "`r|`n", " "',
-    '  Write-Output ("{0}|{1}|{2}" -f $_.ProcessId, $_.ParentProcessId, $cmd)',
-    '}',
-  ].join('\n');
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-  // 冷启动的 powershell.exe 经常超过 1.5s,超时会被上层吞成"扫到 0 个",
-  // 与真实空结果不可区分——放宽到 5s,宁可启动多等一拍也不要静默漏收割。
-  const stdout = execFileSync(
-    'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-Command', script],
-    { encoding: 'utf8', timeout: 5000, windowsHide: true },
+async function getWindowsProcessSnapshot(): Promise<IProcessInfo[]> {
+  // Phase 1 — wait for any in-flight native enumeration to drain before issuing
+  // ours. The package hands every callback queued during one enumeration the
+  // SAME snapshot and only clears `requestInProgress` after that callback drains,
+  // so a call issued while a prior one is running would receive its (stale) list.
+  // We cap the wait and, on expiry, return [] WITHOUT calling getAllProcesses —
+  // enqueuing then would coalesce onto the stale in-flight scan.
+  const previous = nativeSnapshotChain;
+  const drained = await Promise.race([
+    previous.then(
+      () => true,
+      () => true,
+    ),
+    delay(WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS).then(() => false),
+  ]);
+  if (!drained) {
+    log.debug('windows process snapshot timed out waiting for prior scan', {
+      timeoutMs: WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS,
+    });
+    return [];
+  }
+
+  // Phase 2 — the prior enumeration has drained (`requestInProgress` is false),
+  // so this issues a FRESH native scan. Its deadline is armed only now, so time
+  // spent waiting in phase 1 does not eat into this scan's budget (otherwise a
+  // slow prior scan could make quit resolve [] before its fresh scan even runs,
+  // missing the live Claude tree right before transport teardown).
+  const nativeCall = runNativeProcessSnapshot();
+  nativeSnapshotChain = nativeCall.then(
+    () => undefined,
+    () => undefined,
   );
 
-  const lines = stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const rows = lines
-    .map(parseProcessLine)
-    .filter((row): row is ProcessRow => row !== null);
-  // 自检:有输出但一行都解析不出来 = 输出格式漂移(正是管道符缺失的症状形态)。
-  // 这类失效不会抛错、结果与"机器上没有 claude 进程"同形,只能靠这条 warn 暴露。
-  if (lines.length > 0 && rows.length === 0) {
-    log.warn('windows claude scan output unparseable; scan is likely broken', {
-      lineCount: lines.length,
-      firstLine: lines[0]?.slice(0, 120),
-    });
+  return new Promise<IProcessInfo[]>((resolve) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      log.debug('windows process snapshot timed out', {
+        timeoutMs: WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS,
+      });
+      resolve([]);
+    }, WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS);
+
+    nativeCall.then(
+      (processes) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve(processes);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        log.debug('windows process snapshot failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        resolve([]);
+      },
+    );
+  });
+}
+
+// The patched @vscode/windows-process-tree fills `creationTime` (epoch ms) via
+// GetProcessTimes; upstream/unpatched builds and inaccessible processes omit it.
+function readWindowsCreationTime(proc: IProcessInfo): number | undefined {
+  const raw = (proc as { creationTime?: number }).creationTime;
+  return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : undefined;
+}
+
+async function scanWindowsClaudeProcesses(): Promise<{
+  rows: ProcessRow[];
+  selfCreatedAtMs?: number;
+}> {
+  const processes = await getWindowsProcessSnapshot();
+  const rows: ProcessRow[] = [];
+  let selfCreatedAtMs: number | undefined;
+  for (const proc of processes) {
+    const createdAtMs = readWindowsCreationTime(proc);
+    // Our own creation time comes from the same native clock as every candidate,
+    // so PID-reuse orphans (from a previous instance) sort strictly before us.
+    if (proc.pid === process.pid && createdAtMs !== undefined) {
+      selfCreatedAtMs = createdAtMs;
+    }
+    if (proc.name.toLowerCase() === 'claude.exe') {
+      rows.push({ pid: proc.pid, ppid: proc.ppid, cmdLine: proc.commandLine ?? '', createdAtMs });
+    }
   }
-  return rows;
+  return { rows, selfCreatedAtMs };
 }
 
 function isClaudeCommandLine(cmdLine: string): boolean {
@@ -156,12 +264,16 @@ function isClaudeCommandLine(cmdLine: string): boolean {
 interface ScanResult {
   rows: ProcessRow[];
   childrenByParent: Map<number, number[]>;
+  // Epoch milliseconds when THIS process started, used to tell PID-reuse orphans
+  // (older than us) apart from children we spawned (younger). Undefined leaves
+  // the classification conservative.
+  selfCreatedAtMs?: number;
 }
 
 function scanPosixAllProcesses(): ScanResult {
   const result = spawnSync(
     'ps',
-    ['-A', '-o', 'pid=,ppid=,command='],
+    ['-A', '-o', 'pid=,ppid=,etime=,command='],
     { encoding: 'utf8', timeout: 1500 },
   );
   if (result.error) throw result.error;
@@ -171,6 +283,8 @@ function scanPosixAllProcesses(): ScanResult {
 
   const rows: ProcessRow[] = [];
   const childrenByParent = new Map<number, number[]>();
+  const nowMs = Date.now();
+  let selfCreatedAtMs: number | undefined;
 
   for (const raw of (result.stdout ?? '').split(/\r?\n/)) {
     const line = raw.trim();
@@ -179,31 +293,42 @@ function scanPosixAllProcesses(): ScanResult {
     if (!match) continue;
     const pid = Number.parseInt(match[1], 10);
     const ppid = Number.parseInt(match[2], 10);
-    const cmdLine = match[3];
+    const etimeSeconds = parsePosixEtimeSeconds(match[3]);
+    const cmdLine = match[4];
     if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+
+    const createdAtMs = etimeSeconds !== null ? nowMs - etimeSeconds * 1000 : undefined;
+    if (pid === process.pid && createdAtMs !== undefined) selfCreatedAtMs = createdAtMs;
 
     const siblings = childrenByParent.get(ppid);
     if (siblings) siblings.push(pid);
     else childrenByParent.set(ppid, [pid]);
 
     if (isClaudeCommandLine(cmdLine)) {
-      rows.push({ pid, ppid, cmdLine });
+      rows.push({ pid, ppid, cmdLine, createdAtMs });
     }
   }
 
-  return { rows, childrenByParent };
+  // Fall back to our own reported uptime if `ps` did not list our row (or gave an
+  // unparseable etime), keeping the comparison on the same "seconds ago" scale.
+  if (selfCreatedAtMs === undefined && Number.isFinite(process.uptime())) {
+    selfCreatedAtMs = nowMs - Math.round(process.uptime() * 1000);
+  }
+
+  return { rows, childrenByParent, selfCreatedAtMs };
 }
 
-function scanClaudeProcesses(): ScanResult {
+async function scanClaudeProcesses(): Promise<ScanResult> {
   if (process.platform === 'win32') {
-    return { rows: scanWindowsClaudeProcesses(), childrenByParent: new Map() };
+    const { rows, selfCreatedAtMs } = await scanWindowsClaudeProcesses();
+    return { rows, childrenByParent: new Map(), selfCreatedAtMs };
   }
   return scanPosixAllProcesses();
 }
 
-function hasXdtClaudeMarker(cmdLine: string): boolean {
+function hasCindyClaudeMarker(cmdLine: string): boolean {
   const haystack = cmdLine.toLowerCase();
-  return XDT_CLAUDE_PATH_MARKERS.some((marker) => haystack.includes(marker));
+  return CINDY_CLAUDE_PATH_MARKERS.some((marker) => haystack.includes(marker));
 }
 
 function isParentAlive(ppid: number): boolean {
@@ -220,6 +345,15 @@ function isParentAlive(ppid: number): boolean {
     // orphans whose parent is just opaque to us.
     return (err as NodeJS.ErrnoException).code !== 'ESRCH';
   }
+}
+
+/**
+ * True only when `childMs` is known to precede `selfMs` by more than the skew
+ * margin — i.e. the process started before this one did. Undefined inputs (no
+ * creation-time source) return false so the caller stays conservative.
+ */
+function startedBefore(childMs: number | undefined, selfMs: number | undefined): boolean {
+  return childMs !== undefined && selfMs !== undefined && childMs < selfMs - PID_REUSE_SKEW_MS;
 }
 
 function killWindowsProcessTree(pid: number): void {
@@ -275,16 +409,34 @@ function killProcessTree(pid: number, childrenByParent: Map<number, number[]>): 
   }
 }
 
+export interface ReapOptions {
+  /**
+   * Kill Claude trees whose parent is the current Electron process.
+   *
+   * Quit-time cleanup sets this true. The startup pass must leave it false: it
+   * runs fire-and-forget while bootstrap continues, so its async snapshot can
+   * complete after a session was launched (interrupted-turn resume, scheduler,
+   * a fast user action). Such a fresh `claude.exe` has `ppid === process.pid`
+   * and would be misread as a self-spawned orphan and killed even though it is a
+   * legitimate, live current session. Historical orphans (dead parent) are still
+   * reaped at startup regardless of this flag; so is a ppid===self process that
+   * provably predates this one (a previous instance's orphan we inherited via PID
+   * reuse), which creation-time comparison distinguishes from a live child.
+   */
+  reapCurrentSession?: boolean;
+}
+
 /**
- * Synchronously reaps Claude Code process trees owned by this app instance, plus
- * historical xdt-maker bundled Claude processes whose parent has already died.
+ * Reaps Claude Code process trees owned by this app instance, plus historical
+ * Cindy-bundled Claude processes whose parent has already died.
  */
-export function reapClaudeOrphansSync(): ReaperResult {
+export async function reapClaudeOrphans(options: ReapOptions = {}): Promise<ReaperResult> {
+  const reapCurrentSession = options.reapCurrentSession ?? true;
   const start = Date.now();
   let scan: ScanResult = { rows: [], childrenByParent: new Map() };
 
   try {
-    scan = scanClaudeProcesses();
+    scan = await scanClaudeProcesses();
   } catch (err) {
     log.debug('failed to scan claude processes', {
       error: err instanceof Error ? err.message : String(err),
@@ -298,11 +450,26 @@ export function reapClaudeOrphansSync(): ReaperResult {
     if (proc.pid === process.pid) continue;
 
     if (proc.ppid === process.pid) {
-      if (killProcessTree(proc.pid, scan.childrenByParent)) killedSelfSpawned += 1;
+      if (reapCurrentSession) {
+        // Quit-time cleanup reaps live current-session children.
+        if (killProcessTree(proc.pid, scan.childrenByParent)) killedSelfSpawned += 1;
+        continue;
+      }
+      // Startup pass. Normally we must NOT touch ppid===self processes: one may be
+      // a session launched moments after cold start (see ReapOptions). But a claude
+      // that provably started BEFORE this process cannot be a child we spawned —
+      // our children are always younger. It is a previous instance's orphan whose
+      // dead parent's PID this process happened to reuse after a crash + relaunch;
+      // ppid alone can no longer prove ownership. Reap it under the same Cindy
+      // marker guard as the dead-parent historical path. When creation time is
+      // unknown the comparison stays false, so we fall back to the safe skip.
+      if (startedBefore(proc.createdAtMs, scan.selfCreatedAtMs) && hasCindyClaudeMarker(proc.cmdLine)) {
+        if (killProcessTree(proc.pid, scan.childrenByParent)) killedHistoricalOrphans += 1;
+      }
       continue;
     }
 
-    if (hasXdtClaudeMarker(proc.cmdLine) && !isParentAlive(proc.ppid)) {
+    if (hasCindyClaudeMarker(proc.cmdLine) && !isParentAlive(proc.ppid)) {
       if (killProcessTree(proc.pid, scan.childrenByParent)) killedHistoricalOrphans += 1;
     }
   }

--- a/apps/desktop/src/main/claude-orphan-reaper.ts
+++ b/apps/desktop/src/main/claude-orphan-reaper.ts
@@ -156,6 +156,11 @@ function delay(ms: number): Promise<void> {
 }
 
 async function getWindowsProcessSnapshot(): Promise<IProcessInfo[]> {
+  // Claim this queue slot synchronously. If two callers enter in the same tick,
+  // the second must observe this slot rather than the same already-resolved
+  // `previous` promise, otherwise both can start a native enumeration after their
+  // first await. Keep the slot chained behind `previous`: if our wait budget
+  // expires, later callers still cannot bypass the native scan ahead of us.
   // Phase 1 — wait for any in-flight native enumeration to drain before issuing
   // ours. The package hands every callback queued during one enumeration the
   // SAME snapshot and only clears `requestInProgress` after that callback drains,
@@ -163,6 +168,14 @@ async function getWindowsProcessSnapshot(): Promise<IProcessInfo[]> {
   // We cap the wait and, on expiry, return [] WITHOUT calling getAllProcesses —
   // enqueuing then would coalesce onto the stale in-flight scan.
   const previous = nativeSnapshotChain;
+  let releaseSlot!: () => void;
+  const slot = new Promise<void>((resolve) => {
+    releaseSlot = resolve;
+  });
+  nativeSnapshotChain = previous.then(
+    () => slot,
+    () => slot,
+  );
   const drained = await Promise.race([
     previous.then(
       () => true,
@@ -171,6 +184,7 @@ async function getWindowsProcessSnapshot(): Promise<IProcessInfo[]> {
     delay(WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS).then(() => false),
   ]);
   if (!drained) {
+    releaseSlot();
     log.debug('windows process snapshot timed out waiting for prior scan', {
       timeoutMs: WINDOWS_PROCESS_SNAPSHOT_TIMEOUT_MS,
     });
@@ -183,10 +197,7 @@ async function getWindowsProcessSnapshot(): Promise<IProcessInfo[]> {
   // slow prior scan could make quit resolve [] before its fresh scan even runs,
   // missing the live Claude tree right before transport teardown).
   const nativeCall = runNativeProcessSnapshot();
-  nativeSnapshotChain = nativeCall.then(
-    () => undefined,
-    () => undefined,
-  );
+  void nativeCall.then(releaseSlot, releaseSlot);
 
   return new Promise<IProcessInfo[]>((resolve) => {
     let settled = false;

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -11,8 +11,9 @@
  * 执行顺序:
  *   1. sync       —— 串行跑, 吞个体异常不影响后续。允许返回 Promise 但不会被 await
  *                    (出现时只 warn, 鼓励标成 async)
- *   2. async      —— 并发跑, 整体不超过 timeoutMs (默认 2000ms), 超时谁没完就被腰斩
- *   3. post-async —— 串行跑, 确保依赖 async 阶段产物的清理 (例如关 sqlite 必须晚于
+ *   2. pre-async  —— 串行 await, 用于必须先于所有并发 teardown 完成的短任务
+ *   3. async      —— 并发跑, 整体不超过 timeoutMs (默认 2000ms), 超时谁没完就被腰斩
+ *   4. post-async —— 串行跑, 确保依赖 async 阶段产物的清理 (例如关 sqlite 必须晚于
  *                    db.backup, 关 IM WS 必须晚于 announce offline)
  *
  * 然后 `app.exit(<code>)` 强制退出。`will-quit` / `quit` 事件不会触发——任何
@@ -81,7 +82,7 @@ function broadcastTransientNetworkErrorTip(err: NodeJS.ErrnoException): void {
 const log = createLogger('lifecycle');
 let brokenStdioWarningLogged = false;
 
-export type DisposerPhase = 'sync' | 'async' | 'post-async';
+export type DisposerPhase = 'sync' | 'pre-async' | 'async' | 'post-async';
 
 interface Disposer {
   name: string;
@@ -112,7 +113,40 @@ export async function runQuitDisposers(timeoutMs = 2000): Promise<void> {
     }
   }
 
-  // ── Phase 2: async (concurrent, bounded by timeout) ──────────────────────
+  // ── Phase 2: pre-async (serial, awaited before concurrent teardown) ─────
+  // 每个 disposer 单独设超时: pre-async 是串行 await, 某个 disposer 卡死
+  // (返回永不 settle 的 Promise) 会无限阻塞整条 shutdown, app.exit() 永远
+  // 到不了。超时就 log 并继续 —— 与 async 阶段同样 "log + proceed" 语义,
+  // 保证退出始终可推进; 个体任务的取消/降级由 disposer 自己负责。
+  for (const d of registry.filter((x) => x.phase === 'pre-async')) {
+    let timer: NodeJS.Timeout | undefined;
+    // Settle the disposer to 'done' whether it resolves or rejects, and catch
+    // here — the timeout may win the race below while the disposer is still
+    // pending, and a late rejection would otherwise surface as an
+    // unhandledRejection (process warning / possible crash).
+    const disposer = Promise.resolve()
+      .then(() => d.fn())
+      .then(
+        () => 'done' as const,
+        (err) => {
+          log.error(`pre-async disposer "${d.name}" threw`, err);
+          return 'done' as const;
+        },
+      );
+    try {
+      const timedOut = new Promise<'timeout'>((resolve) => {
+        timer = setTimeout(() => resolve('timeout'), timeoutMs);
+      });
+      const outcome = await Promise.race([disposer, timedOut]);
+      if (outcome === 'timeout') {
+        log.warn(`pre-async disposer "${d.name}" timed out after ${timeoutMs}ms — proceeding`);
+      }
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  // ── Phase 3: async (concurrent, bounded by timeout) ──────────────────────
   const asyncs = registry.filter((x) => x.phase === 'async');
   if (asyncs.length > 0) {
     const settled = Promise.allSettled(
@@ -140,7 +174,7 @@ export async function runQuitDisposers(timeoutMs = 2000): Promise<void> {
     }
   }
 
-  // ── Phase 3: post-async ──────────────────────────────────────────────────
+  // ── Phase 4: post-async ──────────────────────────────────────────────────
   for (const d of registry.filter((x) => x.phase === 'post-async')) {
     try {
       const ret = d.fn();

--- a/apps/desktop/src/main/windowsLegacyDevShortcutCleanup.ts
+++ b/apps/desktop/src/main/windowsLegacyDevShortcutCleanup.ts
@@ -344,14 +344,37 @@ async function collectShortcutFiles(
   return shortcuts;
 }
 
-function isArgumentlessDevElectronShortcut(details: LegacyShortcutDetails): boolean {
+const DEV_ELECTRON_TARGET_SUFFIX = '\\node_modules\\electron\\dist\\electron.exe';
+
+function isCindyDevCheckoutTarget(target: string): boolean {
+  if (!target.endsWith(DEV_ELECTRON_TARGET_SUFFIX)) return false;
+  const checkoutDir = target.slice(0, -DEV_ELECTRON_TARGET_SUFFIX.length);
+  return (
+    /(?:^|\\)(?:cindy|xdt-maker)$/.test(checkoutDir) ||
+    /(?:^|\\)(?:cindy|xdt-maker)\\\.(?:cindy|xdt)-worktrees\\[^\\]+$/.test(checkoutDir)
+  );
+}
+
+function isOwnedArgumentlessDevElectronShortcut(
+  shortcutPath: string,
+  details: LegacyShortcutDetails,
+): boolean {
   if (typeof details.target !== 'string' || details.target.length === 0) return false;
   const target = details.target.replace(/\//g, '\\').toLowerCase();
   // Whitespace-only arguments are equivalent to no arguments — a `.lnk` may store
   // a trailing space or empty COMMAND_LINE_ARGUMENTS, and the legacy dev links we
   // target carry none. Trim before deciding so those are still recognized.
   const hasArgs = (details.args ?? '').trim().length > 0;
-  return target.endsWith('\\node_modules\\electron\\dist\\electron.exe') && !hasArgs;
+  // Electron.lnk is the one generic filename historically registered for Cindy
+  // dev, but other Electron apps can create the same link. Require both that name
+  // and a Cindy/xdt-maker checkout-shaped target before deleting anything found
+  // by the recursive scan. The product-specific XdtMakerDev.lnk is handled by the
+  // exact-name fast path above.
+  return (
+    path.basename(shortcutPath).toLowerCase() === 'electron.lnk' &&
+    isCindyDevCheckoutTarget(target) &&
+    !hasArgs
+  );
 }
 
 async function runCleanup(
@@ -392,7 +415,7 @@ async function runCleanup(
       continue;
     }
     if (shouldStop()) return;
-    if (!details || !isArgumentlessDevElectronShortcut(details)) continue;
+    if (!details || !isOwnedArgumentlessDevElectronShortcut(shortcutPath, details)) continue;
     try {
       await deps.unlink(shortcutPath);
       if (shouldStop()) return;
@@ -412,9 +435,10 @@ async function runCleanup(
 
 /**
  * Best-effort cleanup entrypoint. The known SnoreToast shortcut is removed by
- * name; the recursive fallback only removes argumentless links whose resolved
- * target is a development Electron binary. Slow or redirected Start Menu
- * storage must not delay the rest of application startup.
+ * name; the recursive fallback only removes the known Electron.lnk shape when
+ * its resolved target proves it belongs to a Cindy/xdt-maker development
+ * checkout. Slow or redirected Start Menu storage must not delay the rest of
+ * application startup.
  */
 export async function cleanupLegacyDevShortcuts(
   overrides?: Partial<LegacyDevShortcutCleanupDeps>,

--- a/apps/desktop/src/main/windowsLegacyDevShortcutCleanup.ts
+++ b/apps/desktop/src/main/windowsLegacyDevShortcutCleanup.ts
@@ -1,0 +1,454 @@
+/**
+ * Removes legacy development shortcuts that launch Electron without app args.
+ *
+ * This runs during Windows startup before notifications are initialized. Keep
+ * it free of script hosts: spawning PowerShell here is both unnecessary
+ * (a `.lnk` is a documented binary format) and prone to security-product alerts.
+ *
+ * Shortcut resolution also stays off Electron's synchronous shell shortcut
+ * reader: that API resolves links synchronously on the main thread and may touch
+ * the (possibly redirected or high-latency) target volume, so a single slow call
+ * cannot be interrupted by the cleanup deadline and would freeze startup. Instead
+ * we read the raw bytes with async fs and decode only the stored target/arguments,
+ * so the main thread performs at most a microsecond-scale in-memory parse.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { app } from 'electron';
+import { createLogger } from './logger';
+
+const log = createLogger('legacyDevShortcutCleanup');
+const CLEANUP_TIMEOUT_MS = 8_000;
+// A real `.lnk` is a few KB. Cap how much of a shortcut we ever load so a corrupt
+// or hostile oversized file (another installer's broken Start Menu entry) cannot
+// make this startup-path maintenance allocate its whole length into memory. The
+// 8s cleanup deadline does not cancel an in-flight `fs.readFile`, so an unbounded
+// read could keep allocating after cleanup already returned.
+export const MAX_SHORTCUT_BYTES = 1_048_576;
+
+interface ShortcutDirEntry {
+  name: string;
+  isDirectory(): boolean;
+  isFile(): boolean;
+}
+
+export interface LegacyShortcutDetails {
+  target: string;
+  args: string;
+}
+
+export interface LegacyDevShortcutCleanupDeps {
+  platform: NodeJS.Platform;
+  appDataDir: () => string | null;
+  exists: (filePath: string) => Promise<boolean>;
+  readdir: (dirPath: string) => Promise<ShortcutDirEntry[]>;
+  unlink: (filePath: string) => Promise<void>;
+  readShortcut: (filePath: string) => Promise<LegacyShortcutDetails | null>;
+  logger?: Pick<ReturnType<typeof createLogger>, 'info' | 'warn'>;
+}
+
+// [MS-SHLLINK] ShellLinkHeader is a fixed 0x4C-byte prefix whose LinkCLSID is the
+// packed GUID {00021401-0000-0000-C000-000000000046}.
+const SHELL_LINK_HEADER_SIZE = 0x4c;
+const SHELL_LINK_CLSID = Buffer.from([
+  0x01, 0x14, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+]);
+
+// [MS-SHLLINK] LinkFlags bits used here.
+const FLAG_HAS_LINK_TARGET_ID_LIST = 0x0000_0001;
+const FLAG_HAS_LINK_INFO = 0x0000_0002;
+const FLAG_HAS_NAME = 0x0000_0004;
+const FLAG_HAS_RELATIVE_PATH = 0x0000_0008;
+const FLAG_HAS_WORKING_DIR = 0x0000_0010;
+const FLAG_HAS_ARGUMENTS = 0x0000_0020;
+const FLAG_IS_UNICODE = 0x0000_0080;
+
+// Returns the decoded string, or `null` when a NUL terminator is not found
+// within bounds. Callers pass an offset already known to be inside the containing
+// structure, so `null` specifically means "field present but unterminated"
+// (malformed/hostile) — distinct from a field that is simply absent. That
+// distinction is load-bearing: silently collapsing a corrupt field to "" and
+// building the target from a surviving field can let one field alone forge a
+// "...\electron.exe" path and get an unrelated shortcut deleted.
+function decodeNullTerminated(
+  buffer: Buffer,
+  start: number,
+  unicode: boolean,
+  limit: number,
+): string | null {
+  // Never read past `limit` (the end of the containing structure). A corrupt
+  // `.lnk` can point a path offset past its own structure but still inside the
+  // file; without this bound we would decode unrelated bytes as the path.
+  const stop = Math.min(limit, buffer.length);
+  if (start < 0 || start >= stop) return null;
+  if (unicode) {
+    for (let end = start; end + 1 < stop; end += 2) {
+      if (buffer[end] === 0 && buffer[end + 1] === 0) {
+        return buffer.toString('utf16le', start, end);
+      }
+    }
+    return null;
+  }
+  for (let end = start; end < stop; end += 1) {
+    if (buffer[end] === 0) return buffer.toString('latin1', start, end);
+  }
+  return null;
+}
+
+/**
+ * Decodes the stored target path and command-line arguments from raw `.lnk`
+ * bytes. Best-effort and defensive: any structural anomaly yields `null` (or an
+ * empty field) rather than throwing, so a malformed shortcut is simply skipped.
+ * We only need enough of [MS-SHLLINK] to recognize an argumentless dev Electron
+ * link, not a faithful round-trip of every field.
+ */
+export function parseWindowsShortcut(buffer: Buffer): LegacyShortcutDetails | null {
+  if (buffer.length < SHELL_LINK_HEADER_SIZE) return null;
+  if (buffer.readUInt32LE(0) !== SHELL_LINK_HEADER_SIZE) return null;
+  if (!buffer.subarray(4, 20).equals(SHELL_LINK_CLSID)) return null;
+
+  const flags = buffer.readUInt32LE(20);
+  const unicode = (flags & FLAG_IS_UNICODE) !== 0;
+  let offset = SHELL_LINK_HEADER_SIZE;
+
+  // LinkTargetIDList: a 2-byte size prefix + IDList. We only need to skip it.
+  if (flags & FLAG_HAS_LINK_TARGET_ID_LIST) {
+    if (offset + 2 > buffer.length) return null;
+    const idListSize = buffer.readUInt16LE(offset);
+    offset += 2 + idListSize;
+    if (offset > buffer.length) return null;
+  }
+
+  let target = '';
+
+  // LinkInfo: the resolved target for a local file is LocalBasePath (+ optional
+  // CommonPathSuffix); for a file on a network share it is the share name from the
+  // CommonNetworkRelativeLink (+ the same CommonPathSuffix). Either avoids touching
+  // the target volume the way shell resolution does.
+  if (flags & FLAG_HAS_LINK_INFO) {
+    const linkInfoStart = offset;
+    if (linkInfoStart + 4 > buffer.length) return null;
+    const linkInfoSize = buffer.readUInt32LE(linkInfoStart);
+    if (linkInfoSize < 0x1c || linkInfoStart + linkInfoSize > buffer.length) return null;
+    const linkInfoEnd = linkInfoStart + linkInfoSize;
+    const headerSize = buffer.readUInt32LE(linkInfoStart + 4);
+    const linkInfoFlags = buffer.readUInt32LE(linkInfoStart + 8);
+    // The optional unicode offset fields live at bytes [28,36) of the LinkInfo
+    // header; only read them when the header (and thus the LinkInfo block, whose
+    // size was already validated) actually extends that far. Guarding on
+    // linkInfoEnd — not the whole buffer — keeps a bogus headerSize from making us
+    // read the following StringData section as offset fields.
+    const hasUnicodeOffsets = headerSize >= 0x24 && linkInfoStart + 36 <= linkInfoEnd;
+    // A path offset is relative to the LinkInfo start and MUST land inside this
+    // structure's data region (after its header, before its end). Anything else
+    // is a corrupt/hostile `.lnk`; return an absolute offset only when in range,
+    // otherwise -1 so the field is skipped rather than aliasing later bytes.
+    const inStructAbs = (rawOffset: number): number =>
+      rawOffset >= headerSize && rawOffset < linkInfoSize ? linkInfoStart + rawOffset : -1;
+
+    // Any path field that is present (offset in range) but unterminated makes the
+    // whole target untrustworthy — we must skip the shortcut rather than assemble
+    // a partial, misleading path (see decodeNullTerminated). `corrupt` latches
+    // that condition across every field we touch here.
+    let corrupt = false;
+    // Reads the path field whose unicode-preferred / ansi offsets sit at the given
+    // LinkInfo header positions. Returns '' for a genuinely absent field, and
+    // latches `corrupt` (returning '') for a present-but-unterminated one. A
+    // corrupt unicode field is NOT retried as ansi: falling back would resurrect
+    // exactly the forged-path risk this guards against.
+    const readPathField = (unicodeOffsetPos: number, ansiOffsetPos: number): string => {
+      if (hasUnicodeOffsets) {
+        const abs = inStructAbs(buffer.readUInt32LE(unicodeOffsetPos));
+        if (abs >= 0) {
+          const decoded = decodeNullTerminated(buffer, abs, true, linkInfoEnd);
+          if (decoded === null) corrupt = true;
+          return decoded ?? '';
+        }
+      }
+      const abs = inStructAbs(buffer.readUInt32LE(ansiOffsetPos));
+      if (abs >= 0) {
+        const decoded = decodeNullTerminated(buffer, abs, false, linkInfoEnd);
+        if (decoded === null) corrupt = true;
+        return decoded ?? '';
+      }
+      return '';
+    };
+
+    // CommonNetworkRelativeLink.NetName — the `\\server\share` target root for a
+    // link whose file lives on a network share. Its offsets are relative to the
+    // CommonNetworkRelativeLink block, not the LinkInfo header. A flag that
+    // promises this block but points nowhere valid latches `corrupt`.
+    const readNetworkShareName = (): string => {
+      const cnrlAbs = inStructAbs(buffer.readUInt32LE(linkInfoStart + 20));
+      if (cnrlAbs < 0 || cnrlAbs + 0x14 > linkInfoEnd) {
+        corrupt = true;
+        return '';
+      }
+      const cnrlSize = buffer.readUInt32LE(cnrlAbs);
+      const cnrlEnd = cnrlAbs + cnrlSize;
+      if (cnrlSize < 0x14 || cnrlEnd > linkInfoEnd) {
+        corrupt = true;
+        return '';
+      }
+      const inCnrl = (rawOffset: number): number =>
+        rawOffset >= 0x14 && rawOffset < cnrlSize ? cnrlAbs + rawOffset : -1;
+      const netNameOffset = buffer.readUInt32LE(cnrlAbs + 8);
+      // A NetNameOffset > 0x14 signals an optional unicode NetName at +20.
+      if (netNameOffset > 0x14 && cnrlAbs + 24 <= cnrlEnd) {
+        const unicodeAbs = inCnrl(buffer.readUInt32LE(cnrlAbs + 20));
+        if (unicodeAbs >= 0) {
+          const decoded = decodeNullTerminated(buffer, unicodeAbs, true, cnrlEnd);
+          if (decoded === null) corrupt = true;
+          return decoded ?? '';
+        }
+      }
+      const ansiAbs = inCnrl(netNameOffset);
+      if (ansiAbs < 0) {
+        corrupt = true;
+        return '';
+      }
+      const decoded = decodeNullTerminated(buffer, ansiAbs, false, cnrlEnd);
+      if (decoded === null) corrupt = true;
+      return decoded ?? '';
+    };
+
+    let base = '';
+    if (linkInfoFlags & 0x1) {
+      // VolumeIDAndLocalBasePath: LocalBasePath (unicode @ +28 / ansi @ +16).
+      base = readPathField(linkInfoStart + 28, linkInfoStart + 16);
+    } else if (linkInfoFlags & 0x2) {
+      // CommonNetworkRelativeLinkAndPathSuffix: target root is the share name.
+      base = readNetworkShareName();
+    }
+
+    if (!corrupt && base) {
+      // CommonPathSuffix (unicode @ +32 / ansi @ +24) appends to either root.
+      const suffix = readPathField(linkInfoStart + 32, linkInfoStart + 24);
+      if (!corrupt) target = base + suffix;
+    }
+
+    if (corrupt) return null;
+    offset = linkInfoEnd;
+  }
+
+  // StringData: NAME, RELATIVE_PATH, WORKING_DIR, COMMAND_LINE_ARGUMENTS,
+  // ICON_LOCATION — each a 2-byte character count followed by the string.
+  const readStringData = (): string | null => {
+    if (offset + 2 > buffer.length) return null;
+    const count = buffer.readUInt16LE(offset);
+    offset += 2;
+    const byteLength = unicode ? count * 2 : count;
+    if (offset + byteLength > buffer.length) return null;
+    const value = buffer.toString(unicode ? 'utf16le' : 'latin1', offset, offset + byteLength);
+    offset += byteLength;
+    return value;
+  };
+
+  let relativePath = '';
+  let args = '';
+  if (flags & FLAG_HAS_NAME && readStringData() === null) return null;
+  if (flags & FLAG_HAS_RELATIVE_PATH) {
+    const value = readStringData();
+    if (value === null) return null;
+    relativePath = value;
+  }
+  if (flags & FLAG_HAS_WORKING_DIR && readStringData() === null) return null;
+  if (flags & FLAG_HAS_ARGUMENTS) {
+    const value = readStringData();
+    if (value === null) return null;
+    args = value;
+  }
+
+  // A relative path preserves the trailing "...\electron.exe" segment, which is
+  // all the classifier needs, so it is an adequate fallback when LinkInfo is absent.
+  if (!target && relativePath) target = relativePath;
+  if (!target) return null;
+  return { target, args };
+}
+
+/**
+ * Reads a shortcut's raw bytes with a hard size ceiling before parsing. Stats the
+ * file first and refuses anything larger than {@link MAX_SHORTCUT_BYTES}, then
+ * reads only that many bytes — so the allocation is bounded even if the file grew
+ * after the stat. Returns null (skip) for oversized files.
+ */
+export async function readBoundedShortcut(filePath: string): Promise<LegacyShortcutDetails | null> {
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(filePath, 'r');
+    const { size } = await handle.stat();
+    if (size > MAX_SHORTCUT_BYTES) return null;
+    const buffer = Buffer.alloc(size);
+    const { bytesRead } = await handle.read(buffer, 0, size, 0);
+    return parseWindowsShortcut(bytesRead === size ? buffer : buffer.subarray(0, bytesRead));
+  } finally {
+    await handle?.close();
+  }
+}
+
+function defaultDeps(): LegacyDevShortcutCleanupDeps {
+  return {
+    platform: process.platform,
+    appDataDir: () => {
+      try {
+        return app.getPath('appData');
+      } catch {
+        return null;
+      }
+    },
+    exists: async (filePath) => {
+      try {
+        await fs.access(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    readdir: (dirPath) => fs.readdir(dirPath, { withFileTypes: true }),
+    unlink: (filePath) => fs.unlink(filePath),
+    readShortcut: readBoundedShortcut,
+    logger: log,
+  };
+}
+
+async function collectShortcutFiles(
+  deps: LegacyDevShortcutCleanupDeps,
+  rootDir: string,
+  shouldStop: () => boolean,
+): Promise<string[]> {
+  const shortcuts: string[] = [];
+  const pending = [rootDir];
+
+  while (pending.length > 0 && !shouldStop()) {
+    const dirPath = pending.pop()!;
+    let entries: ShortcutDirEntry[];
+    try {
+      entries = await deps.readdir(dirPath);
+    } catch {
+      // Start Menu may contain protected or concurrently removed directories.
+      continue;
+    }
+    if (shouldStop()) break;
+    for (const entry of entries) {
+      if (shouldStop()) break;
+      const entryPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (entry.isFile() && path.extname(entry.name).toLowerCase() === '.lnk') {
+        shortcuts.push(entryPath);
+      }
+    }
+  }
+
+  return shortcuts;
+}
+
+function isArgumentlessDevElectronShortcut(details: LegacyShortcutDetails): boolean {
+  if (typeof details.target !== 'string' || details.target.length === 0) return false;
+  const target = details.target.replace(/\//g, '\\').toLowerCase();
+  // Whitespace-only arguments are equivalent to no arguments — a `.lnk` may store
+  // a trailing space or empty COMMAND_LINE_ARGUMENTS, and the legacy dev links we
+  // target carry none. Trim before deciding so those are still recognized.
+  const hasArgs = (details.args ?? '').trim().length > 0;
+  return target.endsWith('\\node_modules\\electron\\dist\\electron.exe') && !hasArgs;
+}
+
+async function runCleanup(
+  deps: LegacyDevShortcutCleanupDeps,
+  appData: string,
+  shouldStop: () => boolean,
+): Promise<void> {
+  const startMenuDir = path.join(appData, 'Microsoft', 'Windows', 'Start Menu', 'Programs');
+  let removed = 0;
+
+  if (shouldStop()) return;
+  const knownShortcut = path.join(startMenuDir, 'XdtMakerDev.lnk');
+  try {
+    const exists = await deps.exists(knownShortcut);
+    if (shouldStop()) return;
+    if (exists) {
+      await deps.unlink(knownShortcut);
+      if (shouldStop()) return;
+      removed += 1;
+    }
+  } catch (err) {
+    deps.logger?.warn('failed to remove known legacy dev shortcut', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  if (shouldStop()) return;
+  const shortcutFiles = await collectShortcutFiles(deps, startMenuDir, shouldStop);
+  if (shouldStop()) return;
+  for (const shortcutPath of shortcutFiles) {
+    if (shouldStop()) return;
+    let details: LegacyShortcutDetails | null;
+    try {
+      // Async byte read + in-memory parse; unlike the synchronous shell reader
+      // this yields to the deadline instead of blocking the main thread.
+      details = await deps.readShortcut(shortcutPath);
+    } catch {
+      continue;
+    }
+    if (shouldStop()) return;
+    if (!details || !isArgumentlessDevElectronShortcut(details)) continue;
+    try {
+      await deps.unlink(shortcutPath);
+      if (shouldStop()) return;
+      removed += 1;
+    } catch (err) {
+      deps.logger?.warn('failed to remove scanned legacy dev shortcut', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (shouldStop()) return;
+  if (removed > 0) {
+    deps.logger?.info('legacy dev shortcut cleanup applied', { removed });
+  }
+}
+
+/**
+ * Best-effort cleanup entrypoint. The known SnoreToast shortcut is removed by
+ * name; the recursive fallback only removes argumentless links whose resolved
+ * target is a development Electron binary. Slow or redirected Start Menu
+ * storage must not delay the rest of application startup.
+ */
+export async function cleanupLegacyDevShortcuts(
+  overrides?: Partial<LegacyDevShortcutCleanupDeps>,
+): Promise<void> {
+  const deps: LegacyDevShortcutCleanupDeps = { ...defaultDeps(), ...overrides };
+  if (deps.platform !== 'win32') return;
+
+  const appData = deps.appDataDir();
+  if (!appData) return;
+
+  const deadlineAt = Date.now() + CLEANUP_TIMEOUT_MS;
+  let expired = false;
+  const expire = (): void => {
+    if (expired) return;
+    expired = true;
+    deps.logger?.warn('legacy dev shortcut cleanup timed out; continuing startup', {
+      timeoutMs: CLEANUP_TIMEOUT_MS,
+    });
+  };
+  const shouldStop = (): boolean => {
+    if (!expired && Date.now() >= deadlineAt) expire();
+    return expired;
+  };
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      expire();
+      resolve();
+    }, CLEANUP_TIMEOUT_MS);
+  });
+
+  try {
+    await Promise.race([runCleanup(deps, appData, shouldStop), timeout]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -168,6 +168,10 @@ export default defineConfig(({ mode }) => {
           // node_modules; packaged app 由 forge.config 的 NATIVE_RUNTIME_DEPS + rebuild
           // 流程把它放到 app.asar.unpacked/node_modules/node-pty/build/Release/pty.node。
           'node-pty',
+          // Win32 Tool Help snapshot N-API binding。claude-orphan-reaper 在
+          // Windows 启动/退出时用它枚举 PID、PPID 与命令行，替代 PowerShell。
+          // forge.config 各平台携带 runtime JS，只有 Windows 携带并重建 .node。
+          '@vscode/windows-process-tree',
         ],
         // gray-matter 的 JS frontmatter 引擎用了 eval,我们只走 YAML 引擎,
         // 这条警告纯噪音。只屏蔽这一处,保留对其他新增 eval 的告警能力。

--- a/dependency-patches/@vscode__windows-process-tree@0.8.0.patch
+++ b/dependency-patches/@vscode__windows-process-tree@0.8.0.patch
@@ -1,0 +1,93 @@
+diff --git a/src/process.cc b/src/process.cc
+index ad63727..942962a 100644
+--- a/src/process.cc
++++ b/src/process.cc
+@@ -24,6 +24,8 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
+         ProcessInfo pinfo;
+         pinfo.pid = process_entry.th32ProcessID;
+         pinfo.ppid = process_entry.th32ParentProcessID;
++        pinfo.creationTime = 0;
++        GetProcessCreationTime(pinfo);
+ 
+         if (MEMORY & process_data_flags) {
+           GetProcessMemoryUsage(pinfo);
+@@ -37,7 +39,7 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
+         process_info.push_back(std::move(pinfo));
+         process_count++;
+       }
+-    } while (process_count < 1024 && Process32Next(snapshot_handle, &process_entry));
++    } while (Process32Next(snapshot_handle, &process_entry));
+   }
+ 
+   CloseHandle(snapshot_handle);
+@@ -62,6 +64,31 @@ void GetProcessMemoryUsage(ProcessInfo& process_info) {
+   CloseHandle(hProcess);
+ }
+ 
++// Populates the process creation time as Unix epoch milliseconds (left at 0 when
++// the process cannot be opened or queried). Lets the caller tell a process that
++// predates it from one it spawned - a distinction PID alone loses after reuse.
++void GetProcessCreationTime(ProcessInfo& process_info) {
++  HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_info.pid);
++  if (hProcess == NULL) {
++    return;
++  }
++
++  FILETIME creationTime, exitTime, kernelTime, userTime;
++  if (GetProcessTimes(hProcess, &creationTime, &exitTime, &kernelTime, &userTime)) {
++    ULARGE_INTEGER ct;
++    ct.LowPart = creationTime.dwLowDateTime;
++    ct.HighPart = creationTime.dwHighDateTime;
++    // FILETIME counts 100ns intervals since 1601-01-01; 116444736000000000 of
++    // them elapse before the Unix epoch. Convert the remainder to milliseconds.
++    const ULONGLONG EPOCH_DIFF_100NS = 116444736000000000ULL;
++    if (ct.QuadPart > EPOCH_DIFF_100NS) {
++      process_info.creationTime = (ct.QuadPart - EPOCH_DIFF_100NS) / 10000ULL;
++    }
++  }
++
++  CloseHandle(hProcess);
++}
++
+ // Per documentation, it is not recommended to add or subtract values from the FILETIME
+ // structure, or to cast it to ULARGE_INTEGER as this can cause alignment faults on 64-bit Windows.
+ // Copy the high and low part to a ULARGE_INTEGER and peform arithmetic on that instead.
+diff --git a/src/process.h b/src/process.h
+index 3c9b852..7f544e2 100644
+--- a/src/process.h
++++ b/src/process.h
+@@ -21,6 +21,7 @@ struct ProcessInfo {
+   DWORD pid;
+   DWORD ppid;
+   DWORD memory; // Reported in bytes
++  unsigned long long creationTime; // Unix epoch ms of process start; 0 if unavailable
+   std::string commandLine;
+ };
+ 
+@@ -34,6 +35,8 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info, DWORD flags);
+ 
+ void GetProcessMemoryUsage(ProcessInfo& process_info);
+ 
++void GetProcessCreationTime(ProcessInfo& process_info);
++
+ void GetCpuUsage(Cpu& cpu_info, bool first_run);
+ 
+ #endif  // SRC_PROCESS_H_
+diff --git a/src/process_worker.cc b/src/process_worker.cc
+index f59559d..891734b 100644
+--- a/src/process_worker.cc
++++ b/src/process_worker.cc
+@@ -43,6 +43,13 @@ void GetProcessesWorker::OnOK() {
+           Napi::String::New(env, pinfo.commandLine));
+     }
+ 
++    // Left undefined when the creation time could not be queried, so callers can
++    // distinguish "unknown" from a real timestamp instead of seeing a bogus 0.
++    if (pinfo.creationTime != 0) {
++      object.Set("creationTime",
++                 Napi::Number::New(env, static_cast<double>(pinfo.creationTime)));
++    }
++
+     result.Set(i, object);
+   }
+ 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",
+      "@vscode/windows-process-tree",
       "better-sqlite3",
       "electron",
       "electron-winstaller",
@@ -57,6 +58,7 @@
       "@esbuild-kit/core-utils>esbuild": "^0.25.0"
     },
     "patchedDependencies": {
+      "@vscode/windows-process-tree@0.8.0": "dependency-patches/@vscode__windows-process-tree@0.8.0.patch",
       "harmonyos-sans-sc-webfont-splitted": "dependency-patches/harmonyos-sans-sc-webfont-splitted.patch",
       "react-native@0.85.3": "dependency-patches/react-native@0.85.3.patch",
       "react-native-uitextview@2.2.0": "dependency-patches/react-native-uitextview@2.2.0.patch",

--- a/packages/maker-core/src/maker.shutdown.test.ts
+++ b/packages/maker-core/src/maker.shutdown.test.ts
@@ -71,7 +71,10 @@ function createHandle(overrides: Partial<AgentSessionHandle>): AgentSessionHandl
   };
 }
 
-function createAgent(handle: AgentSessionHandle): BaseAgent {
+function createAgent(
+  handle: AgentSessionHandle,
+  startSession = vi.fn(async () => handle),
+): BaseAgent {
   return {
     capabilities: {
       switchModel: { supported: false, reason: 'not-implemented' },
@@ -81,12 +84,51 @@ function createAgent(handle: AgentSessionHandle): BaseAgent {
       rewind: { supported: false, reason: 'not-implemented' },
       memory: { supported: false, reason: 'not-implemented' },
     } as never,
-    startSession: vi.fn(async () => handle),
+    startSession,
     dispose: vi.fn(async () => undefined),
   } as unknown as BaseAgent;
 }
 
 describe('Maker.shutdown', () => {
+  it('quiesces new session starts and waits for an in-flight start without closing it', async () => {
+    let resolveStart!: (handle: AgentSessionHandle) => void;
+    const handle = createHandle({});
+    const startPending = new Promise<AgentSessionHandle>((resolve) => {
+      resolveStart = resolve;
+    });
+    const startSession = vi.fn(() => startPending);
+    const maker = new Maker({
+      agents: { 'claude-code': createAgent(handle, startSession) },
+      storage: createStorage(),
+      logger,
+    });
+    const options = {
+      agentKind: 'claude-code' as const,
+      workingDir: '/w',
+      model: 'm',
+    };
+
+    const creation = maker.createSession({ ...options, id: 'in-flight' });
+    for (let i = 0; i < 4; i += 1) await Promise.resolve();
+    expect(startSession).toHaveBeenCalledTimes(1);
+
+    let quiesced = false;
+    const drain = maker.quiesceSessionStarts().then(() => {
+      quiesced = true;
+    });
+    await Promise.resolve();
+    expect(quiesced).toBe(false);
+    await expect(
+      maker.createSession({ ...options, id: 'late-start' }),
+    ).rejects.toThrow('new session starts are not accepted');
+
+    resolveStart(handle);
+    await expect(creation).resolves.toBeDefined();
+    await drain;
+    expect(quiesced).toBe(true);
+    expect(startSession).toHaveBeenCalledTimes(1);
+  });
+
   it('detaches remote-capable sessions instead of full-closing them', async () => {
     const close = vi.fn(async () => undefined);
     const detach = vi.fn(async () => undefined);

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -149,6 +149,12 @@ export class Maker {
     { promise: Promise<Session> }
   >();
   /**
+   * 退出期先停止接收新的 session startup，再等待已经进入 createSession 的调用
+   * 完成。这样宿主可以在不 teardown 现有 session 的前提下取得稳定的进程快照。
+   */
+  private sessionStartsQuiesced = false;
+  private readonly pendingSessionStarts = new Set<Promise<Session>>();
+  /**
    * 同一 business session 的 vendor id 写入必须串行。invalid-resume CAS 只有排在
    * 已在途的 session_id update 之后执行，才能保证旧写入不会在清空后反向覆盖。
    */
@@ -182,6 +188,23 @@ export class Maker {
    * 继续聊"以及多个后台入口同时恢复同一会话的场景。
    */
   async createSession(opts: CreateSessionOptions): Promise<Session> {
+    if (this.sessionStartsQuiesced) {
+      throw new Error('Maker is shutting down; new session starts are not accepted');
+    }
+
+    // 注册 pending 不得跨 await：quiesceSessionStarts() 与 createSession() 在同一
+    // event loop tick 交错时，必须要么看到这次 startup，要么让它命中上面的拒绝。
+    const pending = this.createSessionTracked(opts);
+    this.pendingSessionStarts.add(pending);
+    try {
+      return await pending;
+    } finally {
+      this.pendingSessionStarts.delete(pending);
+    }
+  }
+
+  /** createSession 的既有 singleflight 实现；外围统一负责退出期 startup drain。 */
+  private async createSessionTracked(opts: CreateSessionOptions): Promise<Session> {
     if (!opts.id) {
       return this.createSessionOnce(opts);
     }
@@ -202,6 +225,17 @@ export class Maker {
       if (this.inFlightSessionCreations.get(opts.id) === creation) {
         this.inFlightSessionCreations.delete(opts.id);
       }
+    }
+  }
+
+  /**
+   * 永久停止本 Maker 接受新的 session startup，并等待所有已进入 createSession()
+   * 的调用完成。幂等；只冻结 launch，不关闭或 detach 已有 session。
+   */
+  async quiesceSessionStarts(): Promise<void> {
+    this.sessionStartsQuiesced = true;
+    while (this.pendingSessionStarts.size > 0) {
+      await Promise.allSettled(Array.from(this.pendingSessionStarts));
     }
   }
 
@@ -505,6 +539,10 @@ export class Maker {
    * 失败一律 swallow + 聚合日志, 不抛 (before-quit 阶段不能阻断退出流程)。
    */
   async shutdown(): Promise<void> {
+    // 直接调用 shutdown() 的宿主也必须先封住 launch；Desktop 会在更早的
+    // pre-async 阶段显式调用，以便在 teardown 前取得稳定的进程快照。
+    await this.quiesceSessionStarts();
+
     // snapshot 必须先做 (status listener 在 close 完成后会从 activeSessions 删条目,
     // 不 snapshot 则迭代到一半 Map mutate)。
     const sessSnapshot = Array.from(this.activeSessions.values());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ overrides:
   '@esbuild-kit/core-utils>esbuild': ^0.25.0
 
 patchedDependencies:
+  '@vscode/windows-process-tree@0.8.0':
+    hash: 9e0b2bb050e788937f534f4c44339a8d53a8abff907e18fecc006df1d43f7c6b
+    path: dependency-patches/@vscode__windows-process-tree@0.8.0.patch
   expo-paste-input@0.2.2:
     hash: 53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8
     path: dependency-patches/expo-paste-input@0.2.2.patch
@@ -254,6 +257,9 @@ importers:
       '@tiptap/react':
         specifier: ^3.22.3
         version: 3.28.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@vscode/windows-process-tree':
+        specifier: 0.8.0
+        version: 0.8.0(patch_hash=9e0b2bb050e788937f534f4c44339a8d53a8abff907e18fecc006df1d43f7c6b)
       '@xterm/addon-clipboard':
         specifier: ^0.1.0
         version: 0.1.0(@xterm/xterm@5.5.0)
@@ -4657,6 +4663,9 @@ packages:
   '@vscode/sudo-prompt@9.3.2':
     resolution: {integrity: sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==}
 
+  '@vscode/windows-process-tree@0.8.0':
+    resolution: {integrity: sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -8244,6 +8253,10 @@ packages:
 
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+
+  node-addon-api@7.1.0:
+    resolution: {integrity: sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==}
+    engines: {node: ^16 || ^18 || >= 20}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -14453,6 +14466,10 @@ snapshots:
 
   '@vscode/sudo-prompt@9.3.2': {}
 
+  '@vscode/windows-process-tree@0.8.0(patch_hash=9e0b2bb050e788937f534f4c44339a8d53a8abff907e18fecc006df1d43f7c6b)':
+    dependencies:
+      node-addon-api: 7.1.0
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -18744,6 +18761,8 @@ snapshots:
 
   node-addon-api@1.7.2:
     optional: true
+
+  node-addon-api@7.1.0: {}
 
   node-addon-api@7.1.1: {}
 


### PR DESCRIPTION
> 承接原 PR #291(被误关闭、无法 reopen),已 rebase 到最新 main 并压成单提交重开。

## 这次改了什么

### 摘要

Windows 启动/退出期清理 Claude 孤儿进程时不再 spawn PowerShell(360 等安全软件会把启动期脚本子进程判成攻击,issue #215),改用 Win32 Tool Help snapshot 原生 N-API 模块;并顺带清理遗留 dev 快捷方式。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue:#215
- 本 PR 包含:
  - `claude-orphan-reaper`:PowerShell 同步版 → 异步 `@vscode/windows-process-tree` 原生快照(`reapClaudeOrphans`)。退出期注册在 lifecycle 新增的 `pre-async` 阶段,先于并发 teardown 完成、PPID 链仍可证明归属。
  - `windows-process-tree` 补丁:去掉上游 1024 进程上限;新增 `GetProcessCreationTime` 暴露进程创建时间(Unix epoch ms)。加入根 `onlyBuiltDependencies`,使 dev(electron-forge start)也从补丁源码重建,而非加载带上限的上游预编译产物;forge 打包侧 electron-rebuild + copy + prune,vite externalize。
  - PID 复用安全:按进程创建时间区分"早于本进程的孤儿"与"本进程拉起的子进程"。Windows 崩溃后 PID 复用时,启动期只回收 `ppid===self` 且确证更早、且带 Cindy 标记的孤儿;创建时间未知则保守跳过,绝不误杀活跃会话。POSIX 走 `ps etime`。
  - `windowsLegacyDevShortcutCleanup`:异步解析 `.lnk` 原始字节(不走同步 shell API),读取前设 1MiB 上限;解析本地卷与网络共享(UNC)目标;字段存在但未终止即判损坏,拒绝用幸存字段伪造 electron.exe 路径而误删;8s 截止兜底。
- 明确不包含:`scheduler-host/proc-util.ts` 仍有的后台 `Get-CimInstance` PowerShell 枚举(main 既有代码,同类模式的后续项,不在本 PR 范围)。
- 用户可见变化:无(后台维护逻辑)。
- 是否存在 breaking change:无。

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck                     → 通过
pnpm --dir apps/desktop exec vitest run \
  claudeOrphanReaper / windowsLegacyDevShortcutCleanup / \
  windowsStartupPowerShellCompatibility / lifecycle     → 48 passed
pnpm install(win32)                                     → @vscode/windows-process-tree 从补丁源码重建
                                                          (不再进入 Ignored build scripts);
                                                          运行期 getProcessList 的 creationTime 可读
```

### 手工验证

不涉及(worktree 会话内无法重启宿主 app;运行期行为由平台集成兜底)。

### 未执行的验证

仓库根 `pnpm test:unit` 全量在本机有 3 处**与本改动无关的环境失败**:`scriptRunnerPythonProtocol`(本机 Python 过旧,`future feature annotations`)、`anthropic-compat-proxy`(Windows loopback 端口 EACCES)、`apps/mobile` 的 `chatQuoteCrossDevice`(mobile 既有测试漂移)。本 PR 只改 `apps/desktop`,desktop 侧除该 Python 环境用例外 11636 项通过。最终以 CI 为准。

## 风险

### 风险分类

- [x] 原生层 / fingerprint / OTA(`@vscode/windows-process-tree` 源码补丁 + 重建)
- [x] 跨平台差异(Windows 原生快照 / POSIX `ps`)
- [x] 权限 / 安全 / 用户数据(杀进程路径;创建时间比较确保不误杀活跃会话)

### 影响与回滚

- 影响范围:仅 Windows/桌面端启动与退出期的孤儿进程清理及遗留快捷方式清理。
- 回滚 / 降级方式:revert 本提交即可恢复到 main 的 PowerShell 同步版;patch 与依赖随之移除。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明(不涉及)
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)