### PR TITLE
fix(desktop): 右栏「+」菜单 portal 到 body,修复窄面板下被裁剪

### DIFF
--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -88,6 +88,15 @@ import {
 const SIDEBAR_RAIL_KEY = 'sidebar-rail';
 
 /**
+ * RSB 交互领地:aside 本体(data-panel-drag-root="right-tabs")+ portal 到 body 的
+ * RSB 浮层(data-rsb-territory,如 TabStrip「+」菜单)。浮层 DOM 挂在 body 尾,
+ * 但交互语义仍属右栏 —— ⌘W 归属的两层判定(activeElement / 最近 pointer 交互)
+ * 都用本 selector。浮层不能复用 data-panel-drag-root:PanelDragController 会把
+ * 该标记内的长按识别成拖面板手势。
+ */
+const RSB_TERRITORY_SELECTOR = '[data-panel-drag-root="right-tabs"], [data-rsb-territory]';
+
+/**
  * 右栏折叠态:per-session 记忆(切 A → B 不串扰,新 session 默认 collapsed=true
  * 不主动占地)。B2a 起读写统一走 collapsePrefs(按注册表 collapseMemory 声明分发),
  * 存储位置与键不变,这两个包装只固化 right-tabs 的默认值与空 sessionId 短路。
@@ -1011,7 +1020,8 @@ export function MainLayout() {
   // (有意为之: 焦点在 composer 等输入框里时 ⌘W 关窗符合 mac 惯例, 不被面板的
   // 历史交互抢走); 右侧栏里大量区域不可聚焦 (review diff 正文 / 面板空白处),
   // 点击后焦点被 blur 回 body, 此时回落到最近一次 pointerdown / wheel 交互是否
-  // 落在 aside (data-panel-drag-root="right-tabs") 内 —— 否则用户明明在面板里
+  // 落在 RSB 领地 (RSB_TERRITORY_SELECTOR: aside 本体或 RSB 的 body portal 浮层)
+  // 内 —— 否则用户明明在面板里
   // 操作, ⌘W 却把整个窗口收起来 (Codex review P2, wheel 补充同轮 P2)。副作用上
   // 这也让"连续 ⌘W 逐个关 tab"可用: 关 tab 后焦点落回 body, 交互标记仍在面板内。
   // detached / 折叠态下两层判定都不可能命中内嵌 aside, 直接走窗口分支;
@@ -1021,9 +1031,7 @@ export function MainLayout() {
   useEffect(() => {
     const handler = (e: Event) => {
       const target = e.target instanceof Element ? e.target : null;
-      lastInteractionInRsbRef.current = Boolean(
-        target?.closest('[data-panel-drag-root="right-tabs"]'),
-      );
+      lastInteractionInRsbRef.current = Boolean(target?.closest(RSB_TERRITORY_SELECTOR));
     };
     window.addEventListener('pointerdown', handler, true);
     // wheel 必须 passive —— 只记录区域, 不 preventDefault, 不能拖累滚动性能。
@@ -1041,7 +1049,7 @@ export function MainLayout() {
     const activeEl = document.activeElement;
     const userInRsb =
       activeEl && activeEl !== document.body
-        ? Boolean(activeEl.closest('[data-panel-drag-root="right-tabs"]'))
+        ? Boolean(activeEl.closest(RSB_TERRITORY_SELECTOR))
         : lastInteractionInRsbRef.current;
     if (sessionId && !rsbDetached && !isRightSidebarCollapsed && userInRsb) {
       const bucket = getBucket(sessionId);

--- a/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
@@ -96,10 +96,20 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
 
   useLayoutEffect(() => {
     let raf = 0;
+    // 主窗口内嵌形态的宿主 aside:收起时不 unmount 而是 w-0 + overflow-hidden
+    // 保挂载(见 RightSidebar.tsx 规则 7 注释),此时 anchor 自身 rect 并不归零
+    // (「+」wrapper shrink-0 仍有宽度),要靠 aside 的 data-pane-collapsed 状态
+    // 判定。detached 子窗口没有这层 aside(closest 为 null),跳过该检测。
+    const hostPane = anchorRef.current?.closest('[data-panel-drag-root="right-tabs"]');
     const track = () => {
       const anchor = anchorRef.current;
       const rect = anchor?.getBoundingClientRect();
-      if (!anchor || !rect || (rect.width === 0 && rect.height === 0)) {
+      if (
+        !anchor ||
+        !rect ||
+        (rect.width === 0 && rect.height === 0) ||
+        hostPane?.hasAttribute('data-pane-collapsed')
+      ) {
         onClose();
         return;
       }
@@ -118,17 +128,21 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
   // 焦点:portal 在 body 末尾,原生 tab 序从「+」按钮出发够不到菜单,打开时把焦点
   // 落到第一个可用 menuitem 上(DESIGN.md 焦点规范:浮层打开焦点落主控件 —— 键盘
   // Enter/Space 打开后直接可再按 Enter 选中;鼠标打开时首项走 focus-visible,不会
-  // 无端高亮)。卸载时若焦点仍困在菜单里(DOM 摘除后落回 body)则还给「+」按钮:
-  // ⌘W 关 tab 的归属按 activeElement 判定,焦点丢在 body 会让下一次 ⌘W 误关整个
-  // 窗口;焦点已被用户主动移去别处时不抢。
-  useEffect(() => {
+  // 无端高亮)。
+  //
+  // 卸载时仅当焦点仍在菜单里时才还给「+」按钮(Escape / 选中菜单项的路径):⌘W
+  // 归属按 activeElement 判定,焦点随菜单 DOM 摘除丢到 body 会让下一次 ⌘W 误关
+  // 整个窗口。必须用 useLayoutEffect —— cleanup 在 DOM 摘除前运行,此时还能读到
+  // "焦点是否在菜单内";点击菜单外时浏览器已先把焦点移走(不可聚焦区 → body),
+  // 该场景下不 restore,⌘W 归属正确地跟随用户点击的区域(而不是被拽回右栏)。
+  useLayoutEffect(() => {
     const menuEl = ref.current;
     const anchor = anchorRef.current;
     const firstItem = menuEl?.querySelector<HTMLButtonElement>('[role="menuitem"]:not([disabled])');
     (firstItem ?? menuEl)?.focus();
     return () => {
       const active = document.activeElement;
-      if (active === document.body || (menuEl && menuEl.contains(active))) {
+      if (menuEl && menuEl.contains(active)) {
         anchor?.querySelector('button')?.focus();
       }
     };
@@ -173,7 +187,12 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
       data-rsb-territory=""
       onBlur={(e) => {
         const next = e.relatedTarget as Node | null;
-        if (next && ref.current && !ref.current.contains(next)) onClose();
+        if (!next || !ref.current || ref.current.contains(next)) return;
+        // 焦点移向「+」按钮不算离开:菜单打开时首项持有焦点,点「+」的 mousedown
+        // 会先把焦点转移到按钮触发本 blur —— 这里关闭会让随后的 click toggle 把
+        // 菜单重新打开("点 + 关不上"以 blur 路径回归)。关闭交给按钮 onClick。
+        if (anchorRef.current?.contains(next)) return;
+        onClose();
       }}
       className="fixed z-50 w-[220px] rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] p-1 outline-none"
       style={{

--- a/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
@@ -142,9 +142,12 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
     (firstItem ?? menuEl)?.focus();
     return () => {
       const active = document.activeElement;
-      if (menuEl && menuEl.contains(active)) {
-        anchor?.querySelector('button')?.focus();
-      }
+      if (!menuEl || !menuEl.contains(active)) return;
+      // 面板收起触发的关闭(如 ⌘W 关掉最后一个 tab):「+」已随宿主 aside 缩进
+      // w-0 不可见,焦点还给它会落在不可见控件上 —— 跳过,让焦点自然回落。
+      const pane = anchor?.closest('[data-panel-drag-root="right-tabs"]');
+      if (pane?.hasAttribute('data-pane-collapsed')) return;
+      anchor?.querySelector('button')?.focus();
     };
   }, [anchorRef]);
 

--- a/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
@@ -115,15 +115,17 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
     return () => cancelAnimationFrame(raf);
   }, [anchorRef, onClose]);
 
-  // 焦点:portal 在 body 末尾,原生 tab 序从「+」按钮出发够不到菜单,打开时必须
-  // 显式把焦点移进容器(focus 容器而非首项 —— 鼠标打开时首项不该无端高亮,键盘
-  // 用户按 Tab 即进入第一个 menuitem)。卸载时若焦点仍困在菜单里(DOM 摘除后落回
-  // body)则还给「+」按钮:⌘W 关 tab 的归属按 activeElement 判定,焦点丢在 body
-  // 会让下一次 ⌘W 误关整个窗口;焦点已被用户主动移去别处时不抢。
+  // 焦点:portal 在 body 末尾,原生 tab 序从「+」按钮出发够不到菜单,打开时把焦点
+  // 落到第一个可用 menuitem 上(DESIGN.md 焦点规范:浮层打开焦点落主控件 —— 键盘
+  // Enter/Space 打开后直接可再按 Enter 选中;鼠标打开时首项走 focus-visible,不会
+  // 无端高亮)。卸载时若焦点仍困在菜单里(DOM 摘除后落回 body)则还给「+」按钮:
+  // ⌘W 关 tab 的归属按 activeElement 判定,焦点丢在 body 会让下一次 ⌘W 误关整个
+  // 窗口;焦点已被用户主动移去别处时不抢。
   useEffect(() => {
     const menuEl = ref.current;
     const anchor = anchorRef.current;
-    menuEl?.focus();
+    const firstItem = menuEl?.querySelector<HTMLButtonElement>('[role="menuitem"]:not([disabled])');
+    (firstItem ?? menuEl)?.focus();
     return () => {
       const active = document.activeElement;
       if (active === document.body || (menuEl && menuEl.contains(active))) {
@@ -268,7 +270,9 @@ function DropdownItem({
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-[13px] leading-snug text-[var(--text-primary)] transition-colors',
+        // focus-visible 与 hover 同款背景:键盘打开时首项自动聚焦要有可见落点,
+        // 鼠标交互不触发 focus-visible,无视觉噪音。
+        'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-[13px] leading-snug text-[var(--text-primary)] transition-colors focus:outline-none focus-visible:bg-[var(--surface-hover)]',
         disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-[var(--surface-hover)]',
       )}
     >

--- a/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { FileDiff, FolderTree, Globe, Terminal } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -21,10 +22,14 @@ import { listGhostTabMenuMetas, useTabKindRegistryVersion } from './registry';
 import type { TabKindId, TabKindMenuMeta } from './types';
 
 const DROPDOWN_WIDTH = 220;
-/** 视口右边给 dropdown 留的呼吸空间;<8 就翻成 right-0 向左展开。 */
+/** 视口两侧给 dropdown 留的呼吸空间。 */
 const VIEWPORT_PADDING = 8;
+/** anchor 底边到 dropdown 顶边的间距(原 mt-1)。 */
+const ANCHOR_GAP = 4;
 
 interface AddTabDropdownProps {
+  /** 定位锚点:「+」按钮 wrapper。dropdown portal 到 body 后按它的 rect 摆位。 */
+  anchorRef: React.RefObject<HTMLElement | null>;
   /** 点 outside / Escape 关闭。 */
   onClose: () => void;
   /** 选 kind。调用方负责真创建 tab + 关闭 dropdown。单例 kind 已存在时
@@ -70,26 +75,37 @@ const MENU_ITEMS: TabKindMenuMeta[] = [
   },
 ];
 
-export function AddTabDropdown({ onClose, onSelect, existingKinds }: AddTabDropdownProps) {
+export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: AddTabDropdownProps) {
   const { t } = useTranslation();
   const ref = useRef<HTMLDivElement | null>(null);
-  // 视口边缘检测:默认 left-0 从 + 按钮往右展开;若右边空间不够 220 + 8,翻成
-  // right-0 向左展开。RSB 贴窗口右边时 + 按钮天然靠右,默认配置必然右溢出,所
-  // 以这里实测翻转,而不是预设一种方向。
+  // 定位:portal 到 body + fixed,按 anchor rect 摆位。原实现是「+」wrapper 内的
+  // absolute 元素,RSB 面板窄于 220px 时向左展开的部分会被 Shell 根容器的
+  // overflow-hidden 直接裁掉(左圆角/边框消失)。portal 出去后 dropdown 浮在面板
+  // 之上,只受视口约束 —— 与 radix DropdownMenuContent portal 到 body 的做法一致。
   //
-  // 用 useLayoutEffect 在 paint 之前同步切换,避免 1 帧"先冒出再缩回去"的闪烁。
-  const [alignRight, setAlignRight] = useState(false);
+  // 摆位规则:默认从 anchor 左边往右展开;右边装不下翻成右对齐(贴 anchor 右边
+  // 向左展开);最后整体 clamp 进视口(两侧留 VIEWPORT_PADDING)。
+  //
+  // 用 useLayoutEffect 在 paint 之前同步定位,避免 1 帧"先冒出再挪位"的闪烁。
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 
   useLayoutEffect(() => {
-    const anchor = ref.current?.parentElement;
-    if (!anchor) return;
-    const rect = anchor.getBoundingClientRect();
-    // rect.left = + 按钮 wrapper 左边 X;若从这里往右 220px 装不下(伸出窗口右
-    // 边),翻向左展开。判据用 left 而不是 right,因为我们看的是 dropdown 左对齐
-    // 时的展开起点是否够。
-    const rightSpace = window.innerWidth - rect.left;
-    setAlignRight(rightSpace < DROPDOWN_WIDTH + VIEWPORT_PADDING);
-  }, []);
+    const measure = () => {
+      const anchor = anchorRef.current;
+      if (!anchor) return;
+      const rect = anchor.getBoundingClientRect();
+      const alignRight = window.innerWidth - rect.left < DROPDOWN_WIDTH + VIEWPORT_PADDING;
+      const raw = alignRight ? rect.right - DROPDOWN_WIDTH : rect.left;
+      const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_PADDING;
+      const left = Math.max(VIEWPORT_PADDING, Math.min(raw, maxLeft));
+      setPos({ top: rect.bottom + ANCHOR_GAP, left });
+    };
+    measure();
+    // 打开期间窗口 resize(如键盘触发缩放)时跟随重排;面板拖宽窄走 mousedown,
+    // 会先命中 outside-close,不需要额外监听。
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [anchorRef]);
 
   // 点 outside / Escape 关闭(模式参考 RolePillDropdown 的 click-outside 实现)
   useEffect(() => {
@@ -113,15 +129,18 @@ export function AddTabDropdown({ onClose, onSelect, existingKinds }: AddTabDropd
   useTabKindRegistryVersion();
   const ghostItems = listGhostTabMenuMetas();
 
-  return (
+  return createPortal(
     <div
       ref={ref}
       role="menu"
-      className={cn(
-        'absolute top-full z-50 mt-1 w-[220px] rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] p-1',
-        alignRight ? 'right-0' : 'left-0',
-      )}
-      style={{ boxShadow: 'var(--shadow-menu)' }}
+      className="fixed z-50 w-[220px] rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] p-1"
+      style={{
+        boxShadow: 'var(--shadow-menu)',
+        top: pos?.top ?? 0,
+        left: pos?.left ?? 0,
+        // 首帧 pos 未测出前不可见,layoutEffect 同步定位后展示(paint 前,无闪烁)。
+        visibility: pos ? 'visible' : 'hidden',
+      }}
     >
       <GroupHeader label={t('rightSidebar.tabs.menu.addLabel')} />
       {enabled.map((m) => {
@@ -176,7 +195,8 @@ export function AddTabDropdown({ onClose, onSelect, existingKinds }: AddTabDropd
           ))}
         </>
       )}
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/AddTabDropdown.tsx
@@ -86,31 +86,61 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
   // 摆位规则:默认从 anchor 左边往右展开;右边装不下翻成右对齐(贴 anchor 右边
   // 向左展开);最后整体 clamp 进视口(两侧留 VIEWPORT_PADDING)。
   //
-  // 用 useLayoutEffect 在 paint 之前同步定位,避免 1 帧"先冒出再挪位"的闪烁。
+  // 跟随:portal 后菜单不再随面板布局流动,打开期间用 rAF 轮询 anchor rect ——
+  // 位置变了(键盘触发的布局变化 / 面板换位 / 拖宽侧栏)同步重摆;anchor 从布局
+  // 中消失(关掉最后一个 tab 面板收起)直接关闭,避免菜单悬空残留在旧坐标。
+  // 每帧一次 getBoundingClientRect 只发生在菜单打开的短窗口内,成本可忽略。
+  //
+  // 用 useLayoutEffect 在 paint 之前完成首次定位,避免 1 帧"先冒出再挪位"的闪烁。
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 
   useLayoutEffect(() => {
-    const measure = () => {
+    let raf = 0;
+    const track = () => {
       const anchor = anchorRef.current;
-      if (!anchor) return;
-      const rect = anchor.getBoundingClientRect();
+      const rect = anchor?.getBoundingClientRect();
+      if (!anchor || !rect || (rect.width === 0 && rect.height === 0)) {
+        onClose();
+        return;
+      }
       const alignRight = window.innerWidth - rect.left < DROPDOWN_WIDTH + VIEWPORT_PADDING;
       const raw = alignRight ? rect.right - DROPDOWN_WIDTH : rect.left;
       const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_PADDING;
       const left = Math.max(VIEWPORT_PADDING, Math.min(raw, maxLeft));
-      setPos({ top: rect.bottom + ANCHOR_GAP, left });
+      const top = rect.bottom + ANCHOR_GAP;
+      setPos((prev) => (prev && prev.top === top && prev.left === left ? prev : { top, left }));
+      raf = requestAnimationFrame(track);
     };
-    measure();
-    // 打开期间窗口 resize(如键盘触发缩放)时跟随重排;面板拖宽窄走 mousedown,
-    // 会先命中 outside-close,不需要额外监听。
-    window.addEventListener('resize', measure);
-    return () => window.removeEventListener('resize', measure);
+    track();
+    return () => cancelAnimationFrame(raf);
+  }, [anchorRef, onClose]);
+
+  // 焦点:portal 在 body 末尾,原生 tab 序从「+」按钮出发够不到菜单,打开时必须
+  // 显式把焦点移进容器(focus 容器而非首项 —— 鼠标打开时首项不该无端高亮,键盘
+  // 用户按 Tab 即进入第一个 menuitem)。卸载时若焦点仍困在菜单里(DOM 摘除后落回
+  // body)则还给「+」按钮:⌘W 关 tab 的归属按 activeElement 判定,焦点丢在 body
+  // 会让下一次 ⌘W 误关整个窗口;焦点已被用户主动移去别处时不抢。
+  useEffect(() => {
+    const menuEl = ref.current;
+    const anchor = anchorRef.current;
+    menuEl?.focus();
+    return () => {
+      const active = document.activeElement;
+      if (active === document.body || (menuEl && menuEl.contains(active))) {
+        anchor?.querySelector('button')?.focus();
+      }
+    };
   }, [anchorRef]);
 
   // 点 outside / Escape 关闭(模式参考 RolePillDropdown 的 click-outside 实现)
   useEffect(() => {
     const onMouseDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      const target = e.target as Node;
+      if (!ref.current || ref.current.contains(target)) return;
+      // 「+」按钮自身不算 outside:mousedown 先 onClose、click 再 toggle 会把菜单
+      // 重新打开,导致点「+」永远关不上;关闭交给按钮自己的 onClick toggle。
+      if (anchorRef.current?.contains(target)) return;
+      onClose();
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -121,7 +151,7 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
       document.removeEventListener('mousedown', onMouseDown);
       document.removeEventListener('keydown', onKey);
     };
-  }, [onClose]);
+  }, [anchorRef, onClose]);
 
   const enabled = MENU_ITEMS.filter((m) => m.enabled).sort((a, b) => a.order - b.order);
   const coming = MENU_ITEMS.filter((m) => !m.enabled).sort((a, b) => a.order - b.order);
@@ -133,7 +163,17 @@ export function AddTabDropdown({ anchorRef, onClose, onSelect, existingKinds }: 
     <div
       ref={ref}
       role="menu"
-      className="fixed z-50 w-[220px] rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] p-1"
+      // 编程式容器焦点(见上方焦点 effect),不渲染 focus ring;Tab 离开菜单时关闭
+      // (relatedTarget 为 null 的失焦交给 mousedown-outside / Escape 处理)。
+      tabIndex={-1}
+      // RSB 交互领地标记:MainLayout 的 ⌘W 归属判定(RSB_TERRITORY_SELECTOR)靠它
+      // 识别 portal 到 body 的右栏浮层 —— 菜单打开期间 ⌘W 仍应关右栏 tab 而非窗口。
+      data-rsb-territory=""
+      onBlur={(e) => {
+        const next = e.relatedTarget as Node | null;
+        if (next && ref.current && !ref.current.contains(next)) onClose();
+      }}
+      className="fixed z-50 w-[220px] rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] p-1 outline-none"
       style={{
         boxShadow: 'var(--shadow-menu)',
         top: pos?.top ?? 0,

--- a/apps/desktop/src/renderer/features/right-sidebar/TabBar.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/TabBar.tsx
@@ -277,6 +277,7 @@ export function TabStrip({
   const reducedMotion = useReducedMotion();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const tabsScrollRef = useRef<HTMLDivElement | null>(null);
+  const addButtonWrapperRef = useRef<HTMLDivElement | null>(null);
   const existingKinds = useMemo(() => new Set<TabKindId>(tabs.map((t) => t.kind)), [tabs]);
   // 右键菜单状态:虚拟 trigger 在 rect 位置弹 DropdownMenu(跟 FileTreeView 同款做法,
   // 同时间只可能一个右键菜单打开,统一在 TabStrip 顶层管理避免每 pill 一份实例)。
@@ -394,9 +395,10 @@ export function TabStrip({
           )}
         />
       </div>
-      {/* 「+」按钮 wrapper:scroll 容器外、shrink-0 永远可见。relative 给 dropdown
-          absolute 定位用;dropdown 现在不被 mask / overflow 切。 */}
+      {/* 「+」按钮 wrapper:scroll 容器外、shrink-0 永远可见。dropdown portal 到
+          body(fixed 定位,以本 wrapper 为 anchor),不被面板 overflow-hidden 切。 */}
       <div
+        ref={addButtonWrapperRef}
         className={cn('relative flex shrink-0 items-center', addButtonWrapperClassName)}
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
@@ -418,6 +420,7 @@ export function TabStrip({
         </button>
         {dropdownOpen && (
           <AddTabDropdown
+            anchorRef={addButtonWrapperRef}
             onClose={() => setDropdownOpen(false)}
             onSelect={(kind) => {
               onAdd(kind);


### PR DESCRIPTION
## 这次改了什么

### 摘要

右侧栏「+」添加页签菜单原来是「+」按钮 wrapper 内的 `absolute` 定位元素(固定 220px 宽),而 `RightSidebarShell` 根容器带 `overflow-hidden`:右栏贴窗口右侧时菜单向左展开,一旦面板本身宽度不足,超出面板左缘的部分会被直接裁掉(左侧圆角与边框消失,菜单被"拦"在面板内)。

改为 `createPortal` 到 `document.body` + `fixed` 定位:以「+」wrapper 的 rect 为锚,默认向右展开,右侧装不下翻成右对齐,最后整体 clamp 进视口(两侧留 8px)。`useLayoutEffect` 在 paint 前同步定位避免闪烁,打开期间监听 `window resize` 跟随重排。与 `components/ui/dropdown-menu.tsx`(radix Content/SubContent portal 到 body 根治 overflow 裁剪)的仓内既定做法一致。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(实测发现)
- 本 PR 包含:`AddTabDropdown` 挂载/定位方式重构(portal + fixed + 视口 clamp);`TabBar` 为「+」wrapper 增加 anchor ref
- 明确不包含:菜单视觉样式、菜单项内容、其他弹层组件、dev 脚本
- 用户可见变化:右栏较窄时「+」菜单完整浮出(可越过面板左缘悬浮于聊天区上方),不再被裁剪
- 是否存在 breaking change:无

### UI 变化

修复前:菜单左缘被面板边界裁剪,左侧圆角/边框消失(macOS 实测截图见会话记录)。修复后:菜单完整浮出。平台:macOS dev 实测。

- 引用的设计规范:`DESIGN.md` §4 Select & Dropdown(面板 12px 圆角、Card bg `--surface-elevated`、1px Board border)——本次**零视觉样式变化**,容器 class(`rounded-xl` / `border-default` / `surface-elevated` / `shadow-menu` / `p-1`)与交互(click-outside / Escape)原样保留,仅改挂载点与定位方式;portal 到 body 对齐 `components/ui/dropdown-menu.tsx` 的既有先例注释。Light/Dark:未引入任何新颜色,全部复用既有语义 token。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果:通过
pnpm --dir apps/desktop exec vitest run src/renderer/features/right-sidebar
结果:32 test files / 369 tests 全部通过
pnpm test:unit
结果:通过
```

### 手工验证

macOS dev 实例(remote 模式):右栏拖窄后点「+」,菜单完整显示、不再被面板左缘裁剪;宽面板下展开方向与原行为一致。

### 未执行的验证

- Light/Dark 双模式未逐一实机目检:本次零视觉样式变化,全部复用既有 themed class(如实说明,非"已验证")。
- Windows 端未实测:改动为纯 renderer 定位逻辑,无平台分支。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅右侧栏「+」添加页签菜单弹层的挂载与定位
- 回滚 / 降级方式:revert 本 commit 即可,无数据 / 协议 / 持久化影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(改动自带注释说明,无需独立文档)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
