### PR TITLE
fix(desktop): 避免列表输入时 IME 卡死

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -71,6 +71,7 @@ function indentSpans(ed: Editor): string[] {
 afterEach(() => {
   editor?.destroy();
   editor = null;
+  vi.useRealTimers();
 });
 
 describe('buildListIndentDecorations', () => {
@@ -350,6 +351,53 @@ describe('ComposerListIndentDecoration in a real editor', () => {
         Reflect.deleteProperty(Range.prototype, 'getBoundingClientRect');
       }
     }
+  });
+
+  it('suspends list and CJK decorations for the full IME composition', () => {
+    vi.useFakeTimers();
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        CjkPunctDecoration,
+        ComposerListIndentDecoration,
+      ],
+      content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: '1. 《旧》' }] }],
+      },
+    });
+
+    expect(editor.view.dom.querySelector('.composer-list-block-indent')).not.toBeNull();
+    expect(editor.view.dom.querySelectorAll('span[style*="font-family"]').length).toBeGreaterThan(
+      0,
+    );
+
+    editor.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    expect(editor.view.composing).toBe(true);
+    expect(editor.view.dom.querySelector('.composer-list-block-indent')).toBeNull();
+    expect(editor.view.dom.querySelector('span[style*="font-family"]')).toBeNull();
+
+    editor.view.dispatch(
+      editor.state.tr.insertText('中', editor.state.doc.content.size - 1).setMeta('composition', 1),
+    );
+    expect(editor.getText()).toBe('1. 《旧》中');
+    expect(editor.view.dom.querySelector('.composer-list-block-indent')).toBeNull();
+    expect(editor.view.dom.querySelector('span[style*="font-family"]')).toBeNull();
+
+    editor.view.dom.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+    expect(editor.view.composing).toBe(false);
+    vi.runOnlyPendingTimers();
+
+    expect(editor.view.dom.querySelector('.composer-list-block-indent')?.textContent).toBe(
+      '1. 《旧》中',
+    );
+    expect(editor.view.dom.querySelectorAll('span[style*="font-family"]').length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('renders the indent span into the DOM for list lines', () => {

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
@@ -21,9 +21,8 @@
  *
  * 边界处理
  * --------
- * - IME 组合期 (用户打 pinyin 还没选字): view.update() 跳过布局测量,
- *   避免同步 layout 读写干扰输入法候选框; decoration state 仍由 transaction
- *   驱动,在 doc/meta 变化时按正常路径重算。
+ * - IME 组合期 (用户打 pinyin 还没选字): compositionstart 前临时移除
+ *   decoration,compositionend 后再按当前 doc 补算,避免改写输入法维护的 DOM。
  * - 性能: chat input 文本量很小,doc 变化、slash roster 或 voice replacement
  *   range 变化时采用全量重扫;不使用 DecorationSet.map 增量映射,以保持边界逻辑简单。
  * - 不污染源数据: decoration 只是渲染层,doc JSON 里没有 span,copy/paste/save
@@ -52,7 +51,14 @@ import {
   type VoiceInputReplacementRange,
 } from './VoiceInputDraftDecoration';
 
-const PLUGIN_KEY = new PluginKey<DecorationSet>('cjkPunctDecoration');
+type CjkDecorationPluginState = {
+  decorations: DecorationSet;
+  suspendedForComposition: boolean;
+};
+
+type CompositionMeta = 'suspend' | 'resume';
+
+const PLUGIN_KEY = new PluginKey<CjkDecorationPluginState>('cjkPunctDecoration');
 
 /**
  * CJK 标点字符集合。覆盖最常用的几个区段,够 chat input 场景用:
@@ -236,20 +242,41 @@ export const CjkPunctDecoration = Extension.create({
   name: 'cjkPunctDecoration',
 
   addProseMirrorPlugins() {
+    let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+
     return [
-      new Plugin<DecorationSet>({
+      new Plugin<CjkDecorationPluginState>({
         key: PLUGIN_KEY,
         state: {
           init(_config, state: EditorState) {
             const roster = getSlashCommandRoster(state);
-            return buildDecorations(state.doc, findSlashCommandMatches(state.doc, roster));
+            return {
+              decorations: buildDecorations(state.doc, findSlashCommandMatches(state.doc, roster)),
+              suspendedForComposition: false,
+            };
           },
-          apply(tr: Transaction, old: DecorationSet, oldState: EditorState) {
+          apply(tr: Transaction, old: CjkDecorationPluginState, oldState: EditorState) {
+            const compositionMeta = tr.getMeta(PLUGIN_KEY) as CompositionMeta | undefined;
+            if (compositionMeta === 'suspend') {
+              return {
+                decorations: DecorationSet.empty,
+                suspendedForComposition: true,
+              };
+            }
+
             const rosterUpdate = getSlashCommandRosterUpdate(tr);
             const voiceReplacement = resolveVoiceInputReplacementRange(tr, oldState);
+            if (old.suspendedForComposition && compositionMeta !== 'resume') {
+              return old;
+            }
             // doc、命令 roster 和 voice replacement 都没变 → decoration 位置不变,
             // 直接复用;任一输入变化都需要重新扫描。
-            if (!tr.docChanged && rosterUpdate === undefined && !voiceReplacement.changed) {
+            if (
+              compositionMeta !== 'resume' &&
+              !tr.docChanged &&
+              rosterUpdate === undefined &&
+              !voiceReplacement.changed
+            ) {
               return old;
             }
             // doc、命令 roster 或 voice replacement 变化 → 全量重算。
@@ -257,28 +284,56 @@ export const CjkPunctDecoration = Extension.create({
             // 文本量很小 (< 1KB 常见), 全量重扫成本可忽略, 而增量映射要额外
             // 处理"变化范围内新增/删除的 CJK 标点", 代码复杂度上升不划算。
             const roster = rosterUpdate ?? getSlashCommandRoster(oldState);
-            return buildDecorations(
-              tr.doc,
-              findSlashCommandMatches(tr.doc, roster),
-              voiceReplacement.range,
-            );
+            return {
+              decorations: buildDecorations(
+                tr.doc,
+                findSlashCommandMatches(tr.doc, roster),
+                voiceReplacement.range,
+              ),
+              suspendedForComposition: false,
+            };
           },
         },
         props: {
           decorations(state) {
-            return this.getState(state) ?? DecorationSet.empty;
+            return this.getState(state)?.decorations ?? DecorationSet.empty;
+          },
+          handleDOMEvents: {
+            compositionstart(view) {
+              if (resumeTimer !== null) {
+                clearTimeout(resumeTimer);
+                resumeTimer = null;
+              }
+              if (!PLUGIN_KEY.getState(view.state)?.suspendedForComposition) {
+                view.dispatch(
+                  view.state.tr
+                    .setMeta(PLUGIN_KEY, 'suspend' satisfies CompositionMeta)
+                    .setMeta('addToHistory', false),
+                );
+              }
+              return false;
+            },
+            compositionend(view) {
+              if (resumeTimer !== null) clearTimeout(resumeTimer);
+              resumeTimer = setTimeout(() => {
+                resumeTimer = null;
+                if (view.isDestroyed || view.composing) return;
+                if (!PLUGIN_KEY.getState(view.state)?.suspendedForComposition) return;
+                view.dispatch(
+                  view.state.tr
+                    .setMeta(PLUGIN_KEY, 'resume' satisfies CompositionMeta)
+                    .setMeta('addToHistory', false),
+                );
+              }, 0);
+              return false;
+            },
           },
         },
         view() {
           return {
-            update(view, prevState) {
-              // IME 组合期 (用户打 pinyin 还没回车选字) 不重新计算 decoration,
-              // 避免 DOM 抖动把输入法候选框踢掉。组合结束后 ProseMirror 会发
-              // 一个常规 transaction, apply() 会把 decoration 补上。
-              if (view.composing) return;
-              // composing 期间 doc 也会变, 但 apply() 已经在每次 docChanged
-              // 时重算了, 这里 view.update 是后置 hook, 不需要额外动作。
-              void prevState;
+            destroy() {
+              if (resumeTimer !== null) clearTimeout(resumeTimer);
+              resumeTimer = null;
             },
           };
         },

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
@@ -19,7 +19,8 @@
  * - decoration 只是渲染层,doc JSON / 草稿存储 / 发送内容里没有任何痕迹;
  * - doc 没变直接复用 DecorationSet,变了全量重扫(chat input 文本量小,
  *   全量成本可忽略,不值得做增量映射);
- * - 只在 doc 发生变化时重算,view.update 不参与 decoration 计算;
+ * - IME composition 开始前临时移除 decoration,结束后的下一轮 task 再按
+ *   当前 doc 补算,避免微软拼音输入时改写 composition DOM;
  * - 这是纯文本编辑器的视觉缩进,不改变 doc JSON / 发送文本。
  */
 import { Extension } from '@tiptap/core';
@@ -39,8 +40,18 @@ import {
   type VoiceInputReplacementRange,
 } from './VoiceInputDraftDecoration';
 
-const PLUGIN_KEY = new PluginKey<DecorationSet>('composerListIndentDecoration');
 const TAB_SIZE = 8;
+
+type ListDecorationPluginState = {
+  decorations: DecorationSet;
+  suspendedForComposition: boolean;
+};
+
+type CompositionMeta = 'suspend' | 'resume';
+
+const PLUGIN_STATE_KEY = new PluginKey<ListDecorationPluginState>(
+  'composerListIndentDecorationState',
+);
 
 /** 行内一个非文本 inline 节点(mention chip 等)的占位符,与 applyListContinuation 一致。 */
 const ATOM_PLACEHOLDER = '\uFFFC';
@@ -380,40 +391,102 @@ export const ComposerListIndentDecoration = Extension.create({
   name: 'composerListIndentDecoration',
 
   addProseMirrorPlugins() {
+    let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+
     return [
-      new Plugin<DecorationSet>({
-        key: PLUGIN_KEY,
+      new Plugin<ListDecorationPluginState>({
+        key: PLUGIN_STATE_KEY,
         state: {
           init(_config, state: EditorState) {
             const roster = getSlashCommandRoster(state);
-            return buildListIndentDecorations(
-              state.doc,
-              findSlashCommandMatches(state.doc, roster),
-            );
+            return {
+              decorations: buildListIndentDecorations(
+                state.doc,
+                findSlashCommandMatches(state.doc, roster),
+              ),
+              suspendedForComposition: false,
+            };
           },
-          apply(tr: Transaction, old: DecorationSet, oldState: EditorState) {
+          apply(tr: Transaction, old: ListDecorationPluginState, oldState: EditorState) {
+            const compositionMeta = tr.getMeta(PLUGIN_STATE_KEY) as CompositionMeta | undefined;
+            if (compositionMeta === 'suspend') {
+              return {
+                decorations: DecorationSet.empty,
+                suspendedForComposition: true,
+              };
+            }
+
             const rosterUpdate = getSlashCommandRosterUpdate(tr);
             const voiceReplacement = resolveVoiceInputReplacementRange(tr, oldState);
-            if (!tr.docChanged && rosterUpdate === undefined && !voiceReplacement.changed) {
+            if (old.suspendedForComposition && compositionMeta !== 'resume') {
+              return old;
+            }
+            if (
+              compositionMeta !== 'resume' &&
+              !tr.docChanged &&
+              rosterUpdate === undefined &&
+              !voiceReplacement.changed
+            ) {
               return old;
             }
             const roster = rosterUpdate ?? getSlashCommandRoster(oldState);
-            return buildListIndentDecorations(
-              tr.doc,
-              findSlashCommandMatches(tr.doc, roster),
-              voiceReplacement.range,
-            );
+            return {
+              decorations: buildListIndentDecorations(
+                tr.doc,
+                findSlashCommandMatches(tr.doc, roster),
+                voiceReplacement.range,
+              ),
+              suspendedForComposition: false,
+            };
           },
         },
         props: {
           decorations(state) {
-            return this.getState(state) ?? DecorationSet.empty;
+            return this.getState(state)?.decorations ?? DecorationSet.empty;
+          },
+          handleDOMEvents: {
+            compositionstart(view) {
+              if (resumeTimer !== null) {
+                clearTimeout(resumeTimer);
+                resumeTimer = null;
+              }
+              if (!PLUGIN_STATE_KEY.getState(view.state)?.suspendedForComposition) {
+                view.dispatch(
+                  view.state.tr
+                    .setMeta(PLUGIN_STATE_KEY, 'suspend' satisfies CompositionMeta)
+                    .setMeta('addToHistory', false),
+                );
+              }
+              return false;
+            },
+            compositionend(view) {
+              if (resumeTimer !== null) clearTimeout(resumeTimer);
+              // ProseMirror's own compositionend handler runs after custom
+              // handlers and flushes pending DOM records in a microtask.
+              // A timer restores decorations after that flush, never while
+              // EditorView.composing still owns the native IME DOM.
+              resumeTimer = setTimeout(() => {
+                resumeTimer = null;
+                if (view.isDestroyed || view.composing) return;
+                if (!PLUGIN_STATE_KEY.getState(view.state)?.suspendedForComposition) return;
+                view.dispatch(
+                  view.state.tr
+                    .setMeta(PLUGIN_STATE_KEY, 'resume' satisfies CompositionMeta)
+                    .setMeta('addToHistory', false),
+                );
+              }, 0);
+              return false;
+            },
           },
         },
-        // 注:曾有一个 view().update 里 `if (view.composing) return` 的"IME 保护",
-        // 但重算发生在上面的 state.apply(只看 tr.docChanged),view.update 在视图更新
-        // 之后才跑、DecorationSet 早已算好,该钩子等价 no-op(greptile P2)——已删除。
-        // 真要在 IME 期跳过重算,应在 apply 里按 composition 事务标记判断,而非此处。
+        view() {
+          return {
+            destroy() {
+              if (resumeTimer !== null) clearTimeout(resumeTimer);
+              resumeTimer = null;
+            },
+          };
+        },
       }),
     ];
   },


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复在 Markdown 有序列表后使用微软拼音继续输入中文时，列表缩进与 CJK 标点 decoration 在原生 IME composition 期间重建 DOM，概率性导致整窗卡死的问题。

composition 开始前会临时清空两类 decoration，期间只更新文档状态；composition 结束且 ProseMirror 完成待处理 DOM records 后，再依据最新文档恢复 decoration。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#614
- 本 PR 包含：Composer 列表缩进与 CJK 标点 decoration 的 IME composition 暂停/恢复逻辑，以及真实 Tiptap 编辑器事务序列回归测试
- 明确不包含：编辑器文档 JSON、草稿或发送文本格式变更；颜色、文案、数据库或协议变更
- 用户可见变化：中文输入法组词期间列表缩进和 CJK 标点字体 decoration 会暂时消失，选字完成后立即按最新文本恢复
- 是否存在 breaking change：无

### UI 变化

- 受影响组件：Desktop 新会话 Composer
- 交互变化：IME composition 期间临时关闭列表/CJK decoration，结束后的下一轮 task 恢复；普通输入与发送内容不变
- Light / Dark：两种模式共用同一逻辑，未增加颜色、样式或主题分支
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark Dual-Mode Delivery Gate」；本改动不新增视觉 token，双模式行为一致
- 截图 / 录屏：未附；问题依赖微软拼音且概率触发，本地未能稳定复现

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/composerListIndentDecoration.test.ts
结果：通过，26 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过；Desktop 约 13,329 tests 全部通过，其余 workspace 测试通过，root runner 290 passed / 8 skipped
```

### 手工验证

通过真实 Tiptap 编辑器测试覆盖完整事务序列：初始 decoration 存在，`compositionstart` 后清空，带 composition ID 的文本事务期间保持暂停，`compositionend` 后按最新文本恢复。

### 未执行的验证

- 未在 Windows 微软拼音下稳定复现原始概率性卡死，也未进行 Light / Dark 双模式实机目检
- 原因：该问题依赖特定输入法时序；修复通过真实编辑器的 composition 事务序列自动测试验证，且未改动主题样式

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：composition 期间 decoration 会短暂隐藏

### 影响与回滚

- 影响范围：仅 Desktop 新会话 Composer 的列表缩进和 CJK 标点渲染 decoration
- 剩余风险：微软拼音卡死具有概率性，尚未完成输入法实机稳定复现；composition 期间会有短暂的视觉回退
- 回滚 / 降级方式：回滚本 PR，即恢复 composition 期间持续计算 decoration 的旧行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认无需补充额外文档
- [x] 已确认测试结果并说明未执行项