### PR TITLE
fix(desktop): 收窄列表 fallback 断行与字体范围

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -126,7 +126,7 @@
     "electron-window-state": "^5.0.3",
     "fix-path": "^5.0.0",
     "gray-matter": "^4.0.3",
-    "harmonyos-sans-sc-webfont-splitted": "^1.1.0",
+    "harmonyos-sans-sc-webfont-splitted": "1.1.0",
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
     "i18next": "^26.1.0",

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -96,9 +96,12 @@ describe('buildListIndentDecorations', () => {
     );
   });
 
-  it('advances indented tabs to deterministic 8ch tab stops', () => {
-    expect(listPrefixIndentStyle('  \t1. ')).toContain('--composer-list-hang:9.8ch;');
+  it('reserves a deterministic 8ch slot for every indented tab', () => {
+    expect(listPrefixIndentStyle('  \t1. ')).toContain('--composer-list-hang:10.6ch;');
     expect(listPrefixIndentStyle('\t\t1. ')).toContain('--composer-list-hang:17.8ch;');
+    expect(listPrefixIndentStyle('1、\t')).toContain(
+      '--composer-list-hang:calc(9ch + 1em);',
+    );
   });
 
   it('decorates the full content of a single-line item', () => {
@@ -715,6 +718,9 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     expect(unindentedRows).toHaveLength(1);
     expect(unindentedRows?.[0]?.textContent).toBe('有新增游戏数的用户数、占全部用户比例。');
     expect(unindentedRows?.[0]?.classList.contains('composer-list-cjk-font')).toBe(false);
+    expect(
+      unindentedRows?.[0]?.classList.contains('composer-list-cjk-punctuation-font'),
+    ).toBe(true);
     expect(unindentedRows?.[0]?.querySelectorAll('span[style*="font-family"]')).toHaveLength(0);
   });
 
@@ -876,6 +882,9 @@ describe('wiring contract', () => {
     expect(css).toContain('.ProseMirror .composer-list-long-run-marker');
     expect(css).toContain('.ProseMirror .composer-list-long-run-body');
     expect(css).toContain('.ProseMirror .composer-list-tab-indent');
+    expect(css).toContain('.ProseMirror .composer-list-cjk-punctuation-font');
+    expect(css).toContain("font-family: 'Cindy CJK Punctuation'");
+    expect(css).toContain('unicode-range: U+3000-303F, U+FF00-FFEF;');
     expect(css).toContain('tab-size: 8ch;');
     expect(css).toContain('white-space: pre;');
     const fallbackPrefixRule = css.match(

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Editor, Node as TiptapNode } from '@tiptap/core';
@@ -884,7 +884,31 @@ describe('wiring contract', () => {
     expect(css).toContain('.ProseMirror .composer-list-tab-indent');
     expect(css).toContain('.ProseMirror .composer-list-cjk-punctuation-font');
     expect(css).toContain("font-family: 'Cindy CJK Punctuation'");
-    expect(css).toContain('unicode-range: U+3000-303F, U+FF00-FFEF;');
+    const bundledPunctuationFonts = [
+      'Regular_256855.woff2',
+      'Regular_312071.woff2',
+      'Regular_ac4458.woff2',
+      'Regular_ea8896.woff2',
+    ];
+    bundledPunctuationFonts.forEach((filename) => {
+      expect(css).toContain(`harmonyos-sans-sc-webfont-splitted/dist/${filename}`);
+      expect(
+        existsSync(
+          resolve(
+            __dirname,
+            '..',
+            '..',
+            '..',
+            '..',
+            '..',
+            'node_modules',
+            'harmonyos-sans-sc-webfont-splitted',
+            'dist',
+            filename,
+          ),
+        ),
+      ).toBe(true);
+    });
     expect(css).toContain('tab-size: 8ch;');
     expect(css).toContain('white-space: pre;');
     const fallbackPrefixRule = css.match(

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -883,7 +883,15 @@ describe('wiring contract', () => {
     expect(css).toContain('.ProseMirror .composer-list-long-run-body');
     expect(css).toContain('.ProseMirror .composer-list-tab-indent');
     expect(css).toContain('.ProseMirror .composer-list-cjk-punctuation-font');
-    expect(css).toContain("font-family: 'Cindy CJK Punctuation'");
+    expect(css).toContain("font-family: 'Cindy CJK Punctuation Local'");
+    expect(css).toContain("font-family: 'Cindy CJK Punctuation Bundled'");
+    expect(css).toContain('unicode-range: U+3000-303F, U+FF00-FFEF;');
+    const punctuationFontCss = css.slice(
+      css.indexOf("font-family: 'Cindy CJK Punctuation Local'"),
+      css.indexOf('.ProseMirror .composer-list-cjk-punctuation-font'),
+    );
+    expect(punctuationFontCss.match(/font-style: normal;/g)).toHaveLength(5);
+    expect(punctuationFontCss.match(/font-weight: 400;/g)).toHaveLength(5);
     const bundledPunctuationFonts = [
       'Regular_256855.woff2',
       'Regular_312071.woff2',
@@ -909,6 +917,10 @@ describe('wiring contract', () => {
         ),
       ).toBe(true);
     });
+    const desktopPackage = JSON.parse(
+      readFileSync(resolve(__dirname, '..', '..', '..', 'package.json'), 'utf8'),
+    ) as { dependencies?: Record<string, string> };
+    expect(desktopPackage.dependencies?.['harmonyos-sans-sc-webfont-splitted']).toBe('1.1.0');
     expect(css).toContain('tab-size: 8ch;');
     expect(css).toContain('white-space: pre;');
     const fallbackPrefixRule = css.match(

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -96,6 +96,11 @@ describe('buildListIndentDecorations', () => {
     );
   });
 
+  it('advances indented tabs to deterministic 8ch tab stops', () => {
+    expect(listPrefixIndentStyle('  \t1. ')).toContain('--composer-list-hang:9.8ch;');
+    expect(listPrefixIndentStyle('\t\t1. ')).toContain('--composer-list-hang:17.8ch;');
+  });
+
   it('decorates the full content of a single-line item', () => {
     const ed = makeEditor(['1. test']);
     const found = buildListIndentDecorations(ed.state.doc).find();
@@ -709,7 +714,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     expect(container).not.toBeNull();
     expect(unindentedRows).toHaveLength(1);
     expect(unindentedRows?.[0]?.textContent).toBe('有新增游戏数的用户数、占全部用户比例。');
-    expect(unindentedRows?.[0]?.classList.contains('composer-list-cjk-font')).toBe(true);
+    expect(unindentedRows?.[0]?.classList.contains('composer-list-cjk-font')).toBe(false);
     expect(unindentedRows?.[0]?.querySelectorAll('span[style*="font-family"]')).toHaveLength(0);
   });
 
@@ -752,7 +757,43 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     const fallbackContainerRule = css.match(
       /\.ProseMirror \.composer-list-fallback-container \{([\s\S]*?)\n\}/,
     )?.[1];
-    expect(fallbackContainerRule).toContain('word-break: break-all;');
+    const fallbackLongRunRule = css.match(
+      /\.ProseMirror \.composer-list-fallback-long-run-body \{([\s\S]*?)\n\}/,
+    )?.[1];
+    expect(fallbackContainerRule).not.toContain('word-break: break-all;');
+    expect(fallbackLongRunRule).toContain('word-break: break-all;');
+
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        CjkPunctDecoration,
+        ComposerListIndentDecoration,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: '1. 中文标点。' },
+              { type: 'hardBreak' },
+              { type: 'text', text: '2. abcdefghijklmnopqrstuvwxyz' },
+              { type: 'hardBreak' },
+              { type: 'text', text: '3. alpha ordinaryword omega' },
+            ],
+          },
+        ],
+      },
+    });
+    const longRunBodies = editor.view.dom.querySelectorAll(
+      '.composer-list-fallback-long-run-body',
+    );
+    expect(longRunBodies).toHaveLength(1);
+    expect(longRunBodies[0]?.textContent).toBe('abcdefghijklmnopqrstuvwxyz');
   });
 
   it('keeps hanging indent for slash paths and unknown commands without pills', () => {
@@ -835,8 +876,8 @@ describe('wiring contract', () => {
     expect(css).toContain('.ProseMirror .composer-list-long-run-marker');
     expect(css).toContain('.ProseMirror .composer-list-long-run-body');
     expect(css).toContain('.ProseMirror .composer-list-tab-indent');
-    expect(css).toContain('tab-size: 8;');
-    expect(css).toContain('white-space: nowrap;');
+    expect(css).toContain('tab-size: 8ch;');
+    expect(css).toContain('white-space: pre;');
     const fallbackPrefixRule = css.match(
       /\.ProseMirror \.composer-list-fallback-prefix \{([\s\S]*?)\n\}/,
     )?.[1];

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
@@ -119,10 +119,10 @@ function listLineRanges(
       match: matchListPrefix(line.text),
     }));
     // ComposerListIndentDecoration switches the entire paragraph to its
-    // prefix-only fallback when any list row contains an atom or a recognized
-    // slash pill. In that mode even otherwise-plain sibling rows do not have a
-    // complete hanging wrapper, so their punctuation must remain available to
-    // this plugin as well.
+    // prefix-only fallback when any list row contains an atom, a recognized
+    // slash pill, voice replacement, or CJK punctuation. Its unindented sibling
+    // wrapper must remain one inline-block, so those rows opt out of nested
+    // punctuation spans and use a Unicode-scoped composite font class instead.
     const hasFallbackLine = lineMatches.some(({ line, match }) => {
       if (!match) return false;
       const overlapsSlashCommandPill = slashCommandMatches.some(
@@ -214,10 +214,11 @@ function buildDecorations(
       const from = pos + m.index;
       const to = from + m[0].length;
       if (listRanges.some((range) => from >= range.from && to <= range.to)) {
-        // ComposerListIndentDecoration owns the wrapping container for list
-        // rows. An overlapping inline font decoration would split that
-        // container at every punctuation boundary; list rows opt into the
-        // same CJK font stack through `.composer-list-cjk-font` instead.
+        // ComposerListIndentDecoration owns the wrapping container for these
+        // ranges. An overlapping inline font decoration would split fixed-width
+        // boxes at punctuation boundaries; marker boxes use
+        // `.composer-list-cjk-font`, while unindented fallback rows use the
+        // Unicode-scoped `.composer-list-cjk-punctuation-font`.
         continue;
       }
       decorations.push(

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
@@ -62,9 +62,11 @@ function listPrefixIndentValues(prefix: string): ListIndentValues {
     if (char >= '0' && char <= '9') {
       ch += 1;
     } else if (char === '\t') {
-      // CSS uses `tab-size: 8ch`, so each tab advances to the next 8ch
-      // stop rather than adding eight space-glyph widths.
-      ch = (Math.floor(ch / TAB_SIZE) + 1) * TAB_SIZE;
+      // Reserve a full 8ch slot for each tab. The browser's native tab advance
+      // is at most 8ch, so this remains safe when an earlier full-width marker
+      // contributes `em` that cannot participate in deterministic ch-only
+      // tab-stop arithmetic.
+      ch += TAB_SIZE;
     } else if (char === '、' || char === '\u3000') {
       em += 1;
     } else {
@@ -233,9 +235,15 @@ export function buildListIndentDecorations(
       const match = matchListPrefix(line.text);
       if (!match) {
         if (hasFallbackLine && lines.length > 1 && line.end > line.start) {
+          const hasCjkPunctuation = CJK_PUNCTUATION_RE.test(line.text);
           decorations.push(
             Decoration.inline(contentBase + line.start, contentBase + line.end, {
-              class: 'composer-list-fallback-unindented',
+              class: [
+                'composer-list-fallback-unindented',
+                hasCjkPunctuation ? 'composer-list-cjk-punctuation-font' : '',
+              ]
+                .filter(Boolean)
+                .join(' '),
             }),
           );
         }

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
@@ -62,7 +62,9 @@ function listPrefixIndentValues(prefix: string): ListIndentValues {
     if (char >= '0' && char <= '9') {
       ch += 1;
     } else if (char === '\t') {
-      ch += TAB_SIZE;
+      // CSS uses `tab-size: 8ch`, so each tab advances to the next 8ch
+      // stop rather than adding eight space-glyph widths.
+      ch = (Math.floor(ch / TAB_SIZE) + 1) * TAB_SIZE;
     } else if (char === '、' || char === '\u3000') {
       em += 1;
     } else {
@@ -231,15 +233,9 @@ export function buildListIndentDecorations(
       const match = matchListPrefix(line.text);
       if (!match) {
         if (hasFallbackLine && lines.length > 1 && line.end > line.start) {
-          const hasCjkPunctuation = CJK_PUNCTUATION_RE.test(line.text);
           decorations.push(
             Decoration.inline(contentBase + line.start, contentBase + line.end, {
-              class: [
-                'composer-list-fallback-unindented',
-                hasCjkPunctuation ? 'composer-list-cjk-font' : '',
-              ]
-                .filter(Boolean)
-                .join(' '),
+              class: 'composer-list-fallback-unindented',
             }),
           );
         }
@@ -270,6 +266,13 @@ export function buildListIndentDecorations(
             style: listPrefixIndentStyle(prefix),
           }),
         );
+        if (LONG_ALPHANUMERIC_BODY_RE.test(body) && !hasTabPrefix) {
+          decorations.push(
+            Decoration.inline(from + match.prefixLength, to, {
+              class: 'composer-list-fallback-long-run-body',
+            }),
+          );
+        }
         return;
       }
       if (LONG_ALPHANUMERIC_BODY_RE.test(body) && !hasTabPrefix) {

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -410,15 +410,68 @@ html:lang(ko) {
 }
 /* The fallback unindented row must remain one inline-block; character-scoped
    ProseMirror decorations would split it into several full-width fragments.
-   This local composite face covers only CJK punctuation, so Latin text and
-   digits continue through the configured UI font while punctuation resolves
-   to a full-width platform CJK face. */
+   These composite faces cover only CJK punctuation, so Latin text and digits
+   continue through the configured UI font. Platform CJK fonts stay preferred;
+   Cindy's bundled HarmonyOS subsets keep the fallback available on systems
+   without one. Keep the asset names aligned with the pinned font package. */
 @font-face {
   font-family: 'Cindy CJK Punctuation';
   src:
-    local('PingFang SC'), local('Hiragino Sans GB'), local('Microsoft YaHei UI'),
-    local('Microsoft YaHei'), local('Noto Sans CJK SC'), local('Source Han Sans SC');
-  unicode-range: U+3000-303F, U+FF00-FFEF;
+    local('PingFang SC'),
+    local('Hiragino Sans GB'),
+    local('Microsoft YaHei UI'),
+    local('Microsoft YaHei'),
+    local('Noto Sans CJK SC'),
+    local('Source Han Sans SC'),
+    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_256855.woff2')
+      format('woff2');
+  font-display: swap;
+  unicode-range: U+3001-3002, U+3008-3011, U+3014-3017;
+}
+@font-face {
+  font-family: 'Cindy CJK Punctuation';
+  src:
+    local('PingFang SC'),
+    local('Hiragino Sans GB'),
+    local('Microsoft YaHei UI'),
+    local('Microsoft YaHei'),
+    local('Noto Sans CJK SC'),
+    local('Source Han Sans SC'),
+    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_312071.woff2')
+      format('woff2');
+  font-display: swap;
+  unicode-range:
+    U+3000, U+3003, U+3005-3007, U+3012-3013, U+3018-301B, U+301D-301E, U+3021-3029, U+303E;
+}
+@font-face {
+  font-family: 'Cindy CJK Punctuation';
+  src:
+    local('PingFang SC'),
+    local('Hiragino Sans GB'),
+    local('Microsoft YaHei UI'),
+    local('Microsoft YaHei'),
+    local('Noto Sans CJK SC'),
+    local('Source Han Sans SC'),
+    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_ac4458.woff2')
+      format('woff2');
+  font-display: swap;
+  unicode-range:
+    U+FF01-FF03, U+FF05-FF0A, U+FF0C-FF1B, U+FF1F-FF3D, U+FF3F, U+FF41-FF5B, U+FF5D, U+FF5F-FF60,
+    U+FFE6;
+}
+@font-face {
+  font-family: 'Cindy CJK Punctuation';
+  src:
+    local('PingFang SC'),
+    local('Hiragino Sans GB'),
+    local('Microsoft YaHei UI'),
+    local('Microsoft YaHei'),
+    local('Noto Sans CJK SC'),
+    local('Source Han Sans SC'),
+    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_ea8896.woff2')
+      format('woff2');
+  font-display: swap;
+  unicode-range: U+FF04, U+FF0B, U+FF1C-FF1E, U+FF3E, U+FF40, U+FF5C, U+FF5E, U+FFE0-FFE5;
 }
 .ProseMirror .composer-list-cjk-punctuation-font {
   font-family: 'Cindy CJK Punctuation', var(--app-font-ui, var(--app-font-ui-default));

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -410,71 +410,67 @@ html:lang(ko) {
 }
 /* The fallback unindented row must remain one inline-block; character-scoped
    ProseMirror decorations would split it into several full-width fragments.
-   These composite faces cover only CJK punctuation, so Latin text and digits
-   continue through the configured UI font. Platform CJK fonts stay preferred;
-   Cindy's bundled HarmonyOS subsets keep the fallback available on systems
-   without one. Keep the asset names aligned with the pinned font package. */
+   The local face covers the same ranges as CjkPunctDecoration, while the
+   bundled faces cover the punctuation glyphs HarmonyOS actually ships. Latin
+   text and digits continue through the configured UI font. Keep the asset
+   names aligned with the exact-pinned font package. */
 @font-face {
-  font-family: 'Cindy CJK Punctuation';
+  font-family: 'Cindy CJK Punctuation Local';
   src:
     local('PingFang SC'),
     local('Hiragino Sans GB'),
     local('Microsoft YaHei UI'),
     local('Microsoft YaHei'),
     local('Noto Sans CJK SC'),
-    local('Source Han Sans SC'),
-    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_256855.woff2')
-      format('woff2');
+    local('Source Han Sans SC');
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  unicode-range: U+3000-303F, U+FF00-FFEF;
+}
+@font-face {
+  font-family: 'Cindy CJK Punctuation Bundled';
+  src: url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_256855.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: 400;
   font-display: swap;
   unicode-range: U+3001-3002, U+3008-3011, U+3014-3017;
 }
 @font-face {
-  font-family: 'Cindy CJK Punctuation';
-  src:
-    local('PingFang SC'),
-    local('Hiragino Sans GB'),
-    local('Microsoft YaHei UI'),
-    local('Microsoft YaHei'),
-    local('Noto Sans CJK SC'),
-    local('Source Han Sans SC'),
-    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_312071.woff2')
-      format('woff2');
+  font-family: 'Cindy CJK Punctuation Bundled';
+  src: url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_312071.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: 400;
   font-display: swap;
   unicode-range:
     U+3000, U+3003, U+3005-3007, U+3012-3013, U+3018-301B, U+301D-301E, U+3021-3029, U+303E;
 }
 @font-face {
-  font-family: 'Cindy CJK Punctuation';
-  src:
-    local('PingFang SC'),
-    local('Hiragino Sans GB'),
-    local('Microsoft YaHei UI'),
-    local('Microsoft YaHei'),
-    local('Noto Sans CJK SC'),
-    local('Source Han Sans SC'),
-    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_ac4458.woff2')
-      format('woff2');
+  font-family: 'Cindy CJK Punctuation Bundled';
+  src: url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_ac4458.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: 400;
   font-display: swap;
   unicode-range:
     U+FF01-FF03, U+FF05-FF0A, U+FF0C-FF1B, U+FF1F-FF3D, U+FF3F, U+FF41-FF5B, U+FF5D, U+FF5F-FF60,
     U+FFE6;
 }
 @font-face {
-  font-family: 'Cindy CJK Punctuation';
-  src:
-    local('PingFang SC'),
-    local('Hiragino Sans GB'),
-    local('Microsoft YaHei UI'),
-    local('Microsoft YaHei'),
-    local('Noto Sans CJK SC'),
-    local('Source Han Sans SC'),
-    url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_ea8896.woff2')
-      format('woff2');
+  font-family: 'Cindy CJK Punctuation Bundled';
+  src: url('../../../../../node_modules/harmonyos-sans-sc-webfont-splitted/dist/Regular_ea8896.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: 400;
   font-display: swap;
   unicode-range: U+FF04, U+FF0B, U+FF1C-FF1E, U+FF3E, U+FF40, U+FF5C, U+FF5E, U+FFE0-FFE5;
 }
 .ProseMirror .composer-list-cjk-punctuation-font {
-  font-family: 'Cindy CJK Punctuation', var(--app-font-ui, var(--app-font-ui-default));
+  font-family:
+    'Cindy CJK Punctuation Local', 'Cindy CJK Punctuation Bundled',
+    var(--app-font-ui, var(--app-font-ui-default));
 }
 .ProseMirror .composer-list-cjk-font {
   font-family:

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -367,15 +367,18 @@ html:lang(ko) {
   width: 100%;
   padding-left: calc(1em + var(--composer-list-fallback-indent, 1.25em));
   overflow-wrap: anywhere;
-  word-break: break-all;
 }
 .ProseMirror .composer-list-fallback-prefix {
   display: inline-block;
   box-sizing: border-box;
   width: var(--composer-list-fallback-indent, 1.25em);
   margin-left: calc(0px - var(--composer-list-fallback-indent, 1.25em));
-  white-space: nowrap;
+  white-space: pre;
   vertical-align: top;
+}
+.ProseMirror .composer-list-fallback-long-run-body {
+  overflow-wrap: anywhere;
+  word-break: break-all;
 }
 .ProseMirror .composer-list-fallback-unindented {
   display: inline-block;
@@ -403,7 +406,7 @@ html:lang(ko) {
   /* Keep the browser's tab advance aligned with the deterministic prefix-width
      estimate. Do not measure and rewrite decoration DOM from a plugin view:
      ProseMirror's DOMObserver may restore that style and enter an update loop. */
-  tab-size: 8;
+  tab-size: 8ch;
 }
 .ProseMirror .composer-list-cjk-font {
   font-family:

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -408,6 +408,21 @@ html:lang(ko) {
      ProseMirror's DOMObserver may restore that style and enter an update loop. */
   tab-size: 8ch;
 }
+/* The fallback unindented row must remain one inline-block; character-scoped
+   ProseMirror decorations would split it into several full-width fragments.
+   This local composite face covers only CJK punctuation, so Latin text and
+   digits continue through the configured UI font while punctuation resolves
+   to a full-width platform CJK face. */
+@font-face {
+  font-family: 'Cindy CJK Punctuation';
+  src:
+    local('PingFang SC'), local('Hiragino Sans GB'), local('Microsoft YaHei UI'),
+    local('Microsoft YaHei'), local('Noto Sans CJK SC'), local('Source Han Sans SC');
+  unicode-range: U+3000-303F, U+FF00-FFEF;
+}
+.ProseMirror .composer-list-cjk-punctuation-font {
+  font-family: 'Cindy CJK Punctuation', var(--app-font-ui, var(--app-font-ui-default));
+}
 .ProseMirror .composer-list-cjk-font {
   font-family:
     'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Noto Sans CJK SC',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       harmonyos-sans-sc-webfont-splitted:
-        specifier: ^1.1.0
+        specifier: 1.1.0
         version: 1.1.0(patch_hash=272e3ded46880ee2f9eaff39327b8465de6df4072271de03caf73950e6e57822)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       highlight.js:
         specifier: ^11.11.1


### PR DESCRIPTION
## 这次改了什么

### 摘要

这是 #622 的 follow-up。根据合并后收到的 Greptile、Copilot 和 Codex review，收窄列表 fallback 的断行、tab 和字体规则，保留 #622 的输入框卡死修复，同时避免普通英文逐字符断开、tab 宽度失配和混合文本整行切换 CJK 字体。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Follow-up to #622
- 本 PR 包含：收窄 fallback 长串断行、保留 tab/空格、统一 tab stop 与确定性估算、避免非列表 fallback 行整行强制 CJK 字体
- 明确不包含：#622 的列表识别、换行接续和卡死修复逻辑调整
- 用户可见变化：普通英文优先按单词换行；长无断点正文仍可在序号后断字；tab 列表保持对齐；混合文本保留原 UI 字体
- 是否存在 breaking change：无

### UI 变化

- macOS 真实 Chrome 已验证普通英文自然断词、长串正文首行布局和 tab 实际宽度
- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 `Typography Rules`（混合文本保持字体层级）；§4 `Inputs & Forms`（输入结构稳定）。本次不新增颜色，Light / Dark 共享同一布局规则
<img width="1902" height="394" alt="image" src="https://github.com/user-attachments/assets/53814791-3443-4442-a807-e7d1fdd28182" />
<img width="1874" height="384" alt="image" src="https://github.com/user-attachments/assets/705d5504-5987-4557-847a-75f102077cfe" />

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；所有 required workspace 通过，Desktop unit 通过（65.4s）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/new-chat/ComposerListIndentDecoration.ts src/renderer/__tests__/composerListIndentDecoration.test.ts
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/composerListIndentDecoration.test.ts src/renderer/lib/__tests__/composerListContinuationEditor.test.ts src/renderer/lib/__tests__/composerListContinuation.test.ts src/renderer/__tests__/chatInputListContinuation.test.ts
结果：4 个文件、74 个测试通过

git diff --cached --check
结果：通过
```

### 手工验证

- fallback 普通英文 `ordinaryword` 保持单个渲染 rect，容器计算样式为 `word-break: normal`
- 长无断点正文仅在专用 body span 上使用 `break-all`，正文首行与序号保持同一 y 坐标
- tab 前缀计算样式为 `white-space: pre`、`tab-size: 8ch`，与 `9.8ch` 确定性缩进变量一致

### 未执行的验证

- 未在 Windows / Linux 实机目检
- 未对另一主题单独目检；本次不新增或修改颜色，Light / Dark 共用同一布局 CSS

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop composer fallback 布局

### 影响与回滚

- 影响范围：Desktop 聊天输入框列表 fallback 的断行、tab 和字体渲染；不改变 doc JSON、草稿存储或发送内容
- 回滚 / 降级方式：回滚本提交即可恢复 #622 合并时的 fallback 样式

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

## CI 结果

- 状态：待运行。PR 创建后由 Checks Watch 回填最终结果和链接。
