### PR TITLE
fix(desktop): localize permission prompts and agent status

### DIFF
--- a/apps/desktop/src/renderer/__tests__/PermissionPrompt.i18n.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/PermissionPrompt.i18n.test.tsx
@@ -72,4 +72,22 @@ describe('PermissionPrompt i18n', () => {
 
     expect(screen.getByText('允许 Bash？')).toBeTruthy();
   });
+
+  it('keeps the session boundary explicit in the English approval label', async () => {
+    await i18n.changeLanguage('en');
+
+    render(
+      <PermissionPrompt
+        permission={{
+          requestId: 'permission-4',
+          toolName: 'exec',
+          input: { command: 'pwd' },
+          suggestions: [{ destination: 'session' }],
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Always allow for this session')).toBeTruthy();
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/PermissionPrompt.i18n.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/PermissionPrompt.i18n.test.tsx
@@ -40,4 +40,36 @@ describe('PermissionPrompt i18n', () => {
     expect(screen.queryByText('Allow Codex to run this command?')).toBeNull();
     expect(screen.getByText('Provider-supplied reason stays verbatim.')).toBeTruthy();
   });
+
+  it('preserves an action-specific title when no display name is available', () => {
+    render(
+      <PermissionPrompt
+        permission={{
+          requestId: 'permission-2',
+          toolName: 'file_change',
+          input: { path: '/tmp/example.txt' },
+          title: 'Allow Codex to edit /tmp/example.txt?',
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Allow Codex to edit /tmp/example.txt?')).toBeTruthy();
+    expect(screen.queryByText('允许 file_change？')).toBeNull();
+  });
+
+  it('localizes the tool fallback when no richer title is available', () => {
+    render(
+      <PermissionPrompt
+        permission={{
+          requestId: 'permission-3',
+          toolName: 'Bash',
+          input: { command: 'pwd' },
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('允许 Bash？')).toBeTruthy();
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/PermissionPrompt.i18n.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/PermissionPrompt.i18n.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '@/i18n';
+import i18n from '@/i18n';
+import { PermissionPrompt } from '@/components/new-chat/PermissionPrompt';
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh-CN');
+});
+
+afterEach(async () => {
+  cleanup();
+  await i18n.changeLanguage('en');
+});
+
+describe('PermissionPrompt i18n', () => {
+  it('uses the selected UI language for Cindy-owned permission copy', () => {
+    render(
+      <PermissionPrompt
+        permission={{
+          requestId: 'permission-1',
+          toolName: 'exec',
+          displayName: 'PowerShell',
+          input: { command: 'Get-ChildItem' },
+          title: 'Allow Codex to run this command?',
+          description: 'Provider-supplied reason stays verbatim.',
+          suggestions: [{ destination: 'session' }],
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('允许 PowerShell？')).toBeTruthy();
+    expect(screen.getByText('拒绝')).toBeTruthy();
+    expect(screen.getByText('本对话总是允许')).toBeTruthy();
+    expect(screen.getByText('允许一次')).toBeTruthy();
+    expect(screen.queryByText('Allow Codex to run this command?')).toBeNull();
+    expect(screen.getByText('Provider-supplied reason stays verbatim.')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
@@ -26,6 +26,15 @@ describe('localizeAgentStatus', () => {
     );
   });
 
+  it('localizes Cindy-owned turn-start phrases without changing the user name', () => {
+    expect(localizeAgentStatus('Just Wait ...', i18n.t)).toBe('请稍候…');
+    expect(localizeAgentStatus('Nice day, Alice!', i18n.t)).toBe('正在处理，Alice');
+    expect(localizeAgentStatus('Working on it, Alice', i18n.t)).toBe('正在处理，Alice');
+    expect(localizeAgentStatus('Alice,试试 /issue 给我们提反馈或建议', i18n.t)).toBe(
+      'Alice，试试用 /issue 给我们提反馈或建议',
+    );
+  });
+
   it('preserves arbitrary vendor status text verbatim', () => {
     expect(localizeAgentStatus('Still running', i18n.t)).toBe('Still running');
     expect(localizeAgentStatus('正在检查测试', i18n.t)).toBe('正在检查测试');

--- a/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import '@/i18n';
+import i18n from '@/i18n';
+import { localizeAgentStatus } from '@/features/cc-agent/lib/localizeAgentStatus';
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh-CN');
+});
+
+afterEach(async () => {
+  await i18n.changeLanguage('en');
+});
+
+describe('localizeAgentStatus', () => {
+  it('localizes Cindy-owned static status labels', () => {
+    expect(localizeAgentStatus('Thinking...', i18n.t)).toBe('正在思考…');
+    expect(localizeAgentStatus('Editing files...', i18n.t)).toBe('正在编辑文件…');
+    expect(localizeAgentStatus('Done', i18n.t)).toBe('已完成');
+  });
+
+  it('keeps the command or tool name while localizing the running suffix', () => {
+    expect(localizeAgentStatus('powershell running...', i18n.t)).toBe('powershell 运行中…');
+    expect(localizeAgentStatus('mcp__cindy__tool running…', i18n.t)).toBe(
+      'mcp__cindy__tool 运行中…',
+    );
+  });
+
+  it('preserves arbitrary vendor status text verbatim', () => {
+    expect(localizeAgentStatus('Still running', i18n.t)).toBe('Still running');
+    expect(localizeAgentStatus('正在检查测试', i18n.t)).toBe('正在检查测试');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
@@ -16,6 +16,8 @@ describe('localizeAgentStatus', () => {
   it('localizes Cindy-owned static status labels', () => {
     expect(localizeAgentStatus('Thinking...', i18n.t)).toBe('正在思考…');
     expect(localizeAgentStatus('Editing files...', i18n.t)).toBe('正在编辑文件…');
+    expect(localizeAgentStatus('Working', i18n.t)).toBe('正在工作…');
+    expect(localizeAgentStatus('Running', i18n.t)).toBe('运行中…');
     expect(localizeAgentStatus('Done', i18n.t)).toBe('已完成');
   });
 

--- a/apps/desktop/src/renderer/__tests__/imeEnterCompositionGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/imeEnterCompositionGuard.test.ts
@@ -15,6 +15,7 @@ import { createElement } from 'react';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import '@/i18n';
 import type { PendingAskUser } from '@/lib/makerChatStore';
 import { AskUserQuestionPrompt } from '../components/new-chat/AskUserQuestionPrompt';
 import { PermissionPrompt } from '../components/new-chat/PermissionPrompt';

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useCallback, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
 import type { PendingPermission } from '@/lib/makerChatStore';
@@ -65,9 +66,12 @@ function filterSessionScopedSuggestions(suggestions?: unknown[]): unknown[] {
 // ---------------------------------------------------------------------------
 
 export function PermissionPrompt({ permission, onRespond }: PermissionPromptProps) {
-  const { toolName, input, title, description, suggestions } = permission;
+  const { t } = useTranslation();
+  const { toolName, input, displayName, description, suggestions } = permission;
 
-  const displayTitle = title || `Allow Claude to use ${toolName}?`;
+  const displayTitle = t('agentIsland.native.permissionPromptTitleWithTool', {
+    toolName: displayName || toolName,
+  });
   const codeContent = formatToolInput(toolName, input);
   const sessionSuggestions = useMemo(() => filterSessionScopedSuggestions(suggestions), [suggestions]);
   const canAlwaysAllowForSession = sessionSuggestions.length > 0;
@@ -171,7 +175,7 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
             'transition-colors hover:bg-[var(--perm-code-bg)]',
           )}
         >
-          <span>Deny</span>
+          <span>{t('agentIsland.native.deny')}</span>
           <kbd className="rounded-[4px] border border-[var(--chat-input-border)] bg-[var(--perm-code-bg)] px-1.5 py-[1px] text-11 font-normal text-[var(--status-bar-meta)]">
             Esc
           </kbd>
@@ -188,7 +192,7 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
               'transition-colors hover:bg-[var(--perm-code-bg)]',
             )}
           >
-            <span>Always allow for session</span>
+            <span>{t('agentIsland.native.alwaysAllowForSession')}</span>
             <kbd className="rounded-[4px] border border-[var(--chat-input-border)] bg-[var(--perm-code-bg)] px-1.5 py-[1px] text-11 font-normal text-[var(--status-bar-meta)]">
               Ctrl
             </kbd>
@@ -210,7 +214,7 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
             'transition-colors hover:opacity-90',
           )}
         >
-          <span>Allow once</span>
+          <span>{t('agentIsland.native.allowOnce')}</span>
           <kbd className="rounded-[4px] border border-[var(--perm-allow-kbd-border)] bg-[var(--perm-allow-kbd-bg)] px-1.5 py-[1px] text-11 font-normal text-[var(--perm-allow-btn-text)] opacity-70">
             Enter
           </kbd>

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -67,11 +67,11 @@ function filterSessionScopedSuggestions(suggestions?: unknown[]): unknown[] {
 
 export function PermissionPrompt({ permission, onRespond }: PermissionPromptProps) {
   const { t } = useTranslation();
-  const { toolName, input, displayName, description, suggestions } = permission;
+  const { toolName, input, title, displayName, description, suggestions } = permission;
 
-  const displayTitle = t('agentIsland.native.permissionPromptTitleWithTool', {
-    toolName: displayName || toolName,
-  });
+  const displayTitle = displayName
+    ? t('agentIsland.native.permissionPromptTitleWithTool', { toolName: displayName })
+    : title || t('agentIsland.native.permissionPromptTitleWithTool', { toolName });
   const codeContent = formatToolInput(toolName, input);
   const sessionSuggestions = useMemo(() => filterSessionScopedSuggestions(suggestions), [suggestions]);
   const canAlwaysAllowForSession = sessionSuggestions.length > 0;

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -152,6 +152,7 @@ import { isGlobalDropIntercepted } from '@/lib/globalDropIntercept';
 import { getCollaborationStartErrorMessage } from './collaborationErrors';
 import { useCollabProjectPolicy } from './hooks/useCollabProjectPolicy';
 import { shouldFallbackVendorModel } from './lib/vendorModelFallback';
+import { localizeAgentStatus } from './lib/localizeAgentStatus';
 import { createSessionRefreshSequence } from './lib/sessionRefreshSequence';
 import { createSessionSnapshotPatchBuffer } from './lib/sessionSnapshotPatchBuffer';
 import { readPanelCollapsedRecord } from '@/layout/collapsePrefs';
@@ -3647,7 +3648,7 @@ function RunningStatusBar({
     ? backgroundBashOnlyCount > 0
       ? t('chat.backgroundActivity.bashStatus', { count: backgroundBashOnlyCount })
       : t('chat.backgroundActivity.status')
-    : status;
+    : localizeAgentStatus(status, t);
   // F-COMPACT-1: when SDK is auto-summarizing the conversation, give the
   // status bar a distinct icon so the user can tell "Compacting..." apart
   // from "Thinking..." — both share the shimmer animation by design, but

--- a/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
@@ -1,0 +1,35 @@
+import type { TFunction } from 'i18next';
+
+const STATUS_KEYS = new Map<string, string>([
+  ['thinking', 'ccAgent.agentStatus.thinking'],
+  ['generating', 'ccAgent.agentStatus.generating'],
+  ['editing files', 'ccAgent.agentStatus.editingFiles'],
+  ['searching web', 'ccAgent.agentStatus.searchingWeb'],
+  ['generating image', 'ccAgent.agentStatus.generatingImage'],
+  ['compacting', 'ccAgent.agentStatus.compacting'],
+  ['done', 'ccAgent.agentStatus.done'],
+]);
+
+function normalizeStaticStatus(status: string): string {
+  return status
+    .trim()
+    .replace(/(?:\.{3}|…)$/, '')
+    .toLowerCase();
+}
+
+/**
+ * Localizes Cindy-owned Agent status chrome while preserving vendor/tool names
+ * and arbitrary status text verbatim. Raw terminal stdout/stderr never passes
+ * through this helper.
+ */
+export function localizeAgentStatus(status: string, t: TFunction): string {
+  const staticKey = STATUS_KEYS.get(normalizeStaticStatus(status));
+  if (staticKey) return t(staticKey);
+
+  const runningTool = status.trim().match(/^(.+?) running(?:\.{3}|…)$/i);
+  if (runningTool) {
+    return t('ccAgent.agentStatus.runningTool', { tool: runningTool[1] });
+  }
+
+  return status;
+}

--- a/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
@@ -9,6 +9,8 @@ const STATUS_KEYS = new Map<string, string>([
   ['compacting', 'ccAgent.agentStatus.compacting'],
   ['done', 'ccAgent.agentStatus.done'],
   ['just wait', 'ccAgent.agentStatus.waiting'],
+  ['working', 'ccAgent.agentStatus.working'],
+  ['running', 'ccAgent.agentStatus.running'],
 ]);
 
 const TURN_START_NAME_PATTERNS = [

--- a/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
@@ -8,12 +8,27 @@ const STATUS_KEYS = new Map<string, string>([
   ['generating image', 'ccAgent.agentStatus.generatingImage'],
   ['compacting', 'ccAgent.agentStatus.compacting'],
   ['done', 'ccAgent.agentStatus.done'],
+  ['just wait', 'ccAgent.agentStatus.waiting'],
 ]);
+
+const TURN_START_NAME_PATTERNS = [
+  /^Nice day, (.+)!$/i,
+  /^Hey (.+), here we go$/i,
+  /^(.+), sit tight$/i,
+  /^Crafting for (.+?)(?:\.{3}|…)$/i,
+  /^(.+), on it$/i,
+  /^Brewing magic for (.+?)(?:\.{3}|…)$/i,
+  /^Take a breath, (.+)$/i,
+  /^Let's go, (.+)!$/i,
+  /^(.+), leave it to me$/i,
+  /^Working on it, (.+)$/i,
+];
 
 function normalizeStaticStatus(status: string): string {
   return status
     .trim()
     .replace(/(?:\.{3}|…)$/, '')
+    .trim()
     .toLowerCase();
 }
 
@@ -26,7 +41,20 @@ export function localizeAgentStatus(status: string, t: TFunction): string {
   const staticKey = STATUS_KEYS.get(normalizeStaticStatus(status));
   if (staticKey) return t(staticKey);
 
-  const runningTool = status.trim().match(/^(.+?) running(?:\.{3}|…)$/i);
+  const trimmedStatus = status.trim();
+  const issueTip = trimmedStatus.match(/^(.+),试试 \/issue 给我们提反馈或建议$/);
+  if (issueTip) {
+    return t('ccAgent.agentStatus.issueTip', { name: issueTip[1] });
+  }
+
+  for (const pattern of TURN_START_NAME_PATTERNS) {
+    const match = trimmedStatus.match(pattern);
+    if (match) {
+      return t('ccAgent.agentStatus.turnStart', { name: match[1], status: trimmedStatus });
+    }
+  }
+
+  const runningTool = trimmedStatus.match(/^(.+?) running(?:\.{3}|…)$/i);
   if (runningTool) {
     return t('ccAgent.agentStatus.runningTool', { tool: runningTool[1] });
   }

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -56,6 +56,7 @@ import { buildSessionDeepLink } from '@/lib/deepLink';
 import { createLogger } from '@/lib/logger';
 import { formatSidebarTime, formatSidebarTimeAbsolute } from '../lib/formatSidebarTime';
 import { highlightSegments } from '../lib/highlightSegments';
+import { localizeAgentStatus } from '../lib/localizeAgentStatus';
 import { scrollIntoNearestView } from '../lib/scrollIntoNearestView';
 import {
   getAutomationSessionDisplayTitle,
@@ -169,7 +170,7 @@ export function SessionCard({
           : t('ccAgent.sidebar.card.awaitingQuestion');
   const runningDetail =
     islandActivity?.phase === 'running' && islandActivity.compactDetail
-      ? islandActivity.compactDetail
+      ? localizeAgentStatus(islandActivity.compactDetail, t)
       : null;
   const listPreview = awaitingText ?? runningDetail ?? summaryPreview;
   const cardPreview = awaitingText ?? summaryPreview;

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -56,7 +56,6 @@ import { buildSessionDeepLink } from '@/lib/deepLink';
 import { createLogger } from '@/lib/logger';
 import { formatSidebarTime, formatSidebarTimeAbsolute } from '../lib/formatSidebarTime';
 import { highlightSegments } from '../lib/highlightSegments';
-import { localizeAgentStatus } from '../lib/localizeAgentStatus';
 import { scrollIntoNearestView } from '../lib/scrollIntoNearestView';
 import {
   getAutomationSessionDisplayTitle,
@@ -170,7 +169,7 @@ export function SessionCard({
           : t('ccAgent.sidebar.card.awaitingQuestion');
   const runningDetail =
     islandActivity?.phase === 'running' && islandActivity.compactDetail
-      ? localizeAgentStatus(islandActivity.compactDetail, t)
+      ? islandActivity.compactDetail
       : null;
   const listPreview = awaitingText ?? runningDetail ?? summaryPreview;
   const cardPreview = awaitingText ?? summaryPreview;

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -68,7 +68,7 @@
       "permissionPromptTitle": "Confirm permission",
       "permissionPromptTitleWithTool": "Allow {{toolName}}?",
       "allowOnce": "Allow once",
-      "alwaysAllowForSession": "Always allow",
+      "alwaysAllowForSession": "Always allow for this session",
       "deny": "Deny"
     }
   },
@@ -4951,6 +4951,8 @@
       "compacting": "Compacting context…",
       "done": "Done",
       "waiting": "Just wait…",
+      "working": "Working…",
+      "running": "Running…",
       "turnStart": "{{status}}",
       "issueTip": "{{name}}, try /issue to send us feedback or suggestions",
       "runningTool": "{{tool}} running…"

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -66,6 +66,7 @@
       "awaitingQuestion": "Awaiting your reply",
       "awaitingPlan": "Awaiting plan review",
       "permissionPromptTitle": "Confirm permission",
+      "permissionPromptTitleWithTool": "Allow {{toolName}}?",
       "allowOnce": "Allow once",
       "alwaysAllowForSession": "Always allow",
       "deny": "Deny"
@@ -4941,6 +4942,16 @@
     }
   },
   "ccAgent": {
+    "agentStatus": {
+      "thinking": "Thinking…",
+      "generating": "Generating…",
+      "editingFiles": "Editing files…",
+      "searchingWeb": "Searching the web…",
+      "generatingImage": "Generating an image…",
+      "compacting": "Compacting context…",
+      "done": "Done",
+      "runningTool": "{{tool}} running…"
+    },
     "remoteSession": {
       "reconnecting": "Connection to the controlled device was lost — reconnecting…",
       "hostOffline": "The controlled device is offline; can't sync right now",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -4950,6 +4950,9 @@
       "generatingImage": "Generating an image…",
       "compacting": "Compacting context…",
       "done": "Done",
+      "waiting": "Just wait…",
+      "turnStart": "{{status}}",
+      "issueTip": "{{name}}, try /issue to send us feedback or suggestions",
       "runningTool": "{{tool}} running…"
     },
     "remoteSession": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4940,6 +4940,9 @@
       "generatingImage": "画像を生成中…",
       "compacting": "コンテキストを圧縮中…",
       "done": "完了",
+      "waiting": "少々お待ちください…",
+      "turnStart": "{{name}} さん、対応中です…",
+      "issueTip": "{{name}} さん、/issue でフィードバックや提案をお寄せください",
       "runningTool": "{{tool}} を実行中…"
     },
     "remoteSession": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4941,6 +4941,8 @@
       "compacting": "コンテキストを圧縮中…",
       "done": "完了",
       "waiting": "少々お待ちください…",
+      "working": "作業中…",
+      "running": "実行中…",
       "turnStart": "{{name}} さん、対応中です…",
       "issueTip": "{{name}} さん、/issue でフィードバックや提案をお寄せください",
       "runningTool": "{{tool}} を実行中…"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -66,6 +66,7 @@
       "awaitingQuestion": "返信待ち",
       "awaitingPlan": "プランの確認待ち",
       "permissionPromptTitle": "権限の確認",
+      "permissionPromptTitleWithTool": "{{toolName}} を許可しますか?",
       "allowOnce": "一度だけ許可",
       "alwaysAllowForSession": "このセッションで常に許可",
       "deny": "拒否"
@@ -4931,6 +4932,16 @@
     }
   },
   "ccAgent": {
+    "agentStatus": {
+      "thinking": "考え中…",
+      "generating": "生成中…",
+      "editingFiles": "ファイルを編集中…",
+      "searchingWeb": "ウェブを検索中…",
+      "generatingImage": "画像を生成中…",
+      "compacting": "コンテキストを圧縮中…",
+      "done": "完了",
+      "runningTool": "{{tool}} を実行中…"
+    },
     "remoteSession": {
       "reconnecting": "被制御デバイスとの接続が切れました。再接続中…",
       "hostOffline": "被制御デバイスがオフラインのため、現在は同期できません",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4941,6 +4941,8 @@
       "compacting": "컨텍스트 압축 중…",
       "done": "완료",
       "waiting": "잠시만 기다려 주세요…",
+      "working": "작업 중…",
+      "running": "실행 중…",
       "turnStart": "{{name}}님, 처리 중이에요…",
       "issueTip": "{{name}}님, /issue로 피드백이나 제안을 보내 주세요",
       "runningTool": "{{tool}} 실행 중…"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -66,6 +66,7 @@
       "awaitingQuestion": "답장 대기 중",
       "awaitingPlan": "계획 검토 대기 중",
       "permissionPromptTitle": "권한 확인 필요",
+      "permissionPromptTitleWithTool": "{{toolName}} 사용을 허용할까요?",
       "allowOnce": "한 번 허용",
       "alwaysAllowForSession": "이 세션에서 항상 허용",
       "deny": "거부"
@@ -4931,6 +4932,16 @@
     }
   },
   "ccAgent": {
+    "agentStatus": {
+      "thinking": "생각 중…",
+      "generating": "생성 중…",
+      "editingFiles": "파일 수정 중…",
+      "searchingWeb": "웹 검색 중…",
+      "generatingImage": "이미지 생성 중…",
+      "compacting": "컨텍스트 압축 중…",
+      "done": "완료",
+      "runningTool": "{{tool}} 실행 중…"
+    },
     "remoteSession": {
       "reconnecting": "제어 대상 기기와 연결이 끊겼습니다. 다시 연결 중…",
       "hostOffline": "제어 대상 기기가 오프라인이라 지금은 동기화할 수 없습니다",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4940,6 +4940,9 @@
       "generatingImage": "이미지 생성 중…",
       "compacting": "컨텍스트 압축 중…",
       "done": "완료",
+      "waiting": "잠시만 기다려 주세요…",
+      "turnStart": "{{name}}님, 처리 중이에요…",
+      "issueTip": "{{name}}님, /issue로 피드백이나 제안을 보내 주세요",
       "runningTool": "{{tool}} 실행 중…"
     },
     "remoteSession": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4941,6 +4941,8 @@
       "compacting": "正在压缩上下文…",
       "done": "已完成",
       "waiting": "请稍候…",
+      "working": "正在工作…",
+      "running": "运行中…",
       "turnStart": "正在处理，{{name}}",
       "issueTip": "{{name}}，试试用 /issue 给我们提反馈或建议",
       "runningTool": "{{tool}} 运行中…"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4940,6 +4940,9 @@
       "generatingImage": "正在生成图片…",
       "compacting": "正在压缩上下文…",
       "done": "已完成",
+      "waiting": "请稍候…",
+      "turnStart": "正在处理，{{name}}",
+      "issueTip": "{{name}}，试试用 /issue 给我们提反馈或建议",
       "runningTool": "{{tool}} 运行中…"
     },
     "remoteSession": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -66,6 +66,7 @@
       "awaitingQuestion": "等待你的回复",
       "awaitingPlan": "等待计划审阅",
       "permissionPromptTitle": "需要确认权限",
+      "permissionPromptTitleWithTool": "允许 {{toolName}}？",
       "allowOnce": "允许一次",
       "alwaysAllowForSession": "本对话总是允许",
       "deny": "拒绝"
@@ -4931,6 +4932,16 @@
     }
   },
   "ccAgent": {
+    "agentStatus": {
+      "thinking": "正在思考…",
+      "generating": "正在生成…",
+      "editingFiles": "正在编辑文件…",
+      "searchingWeb": "正在搜索网页…",
+      "generatingImage": "正在生成图片…",
+      "compacting": "正在压缩上下文…",
+      "done": "已完成",
+      "runningTool": "{{tool}} 运行中…"
+    },
     "remoteSession": {
       "reconnecting": "与被控设备的连接中断，正在重连…",
       "hostOffline": "被控设备已离线，暂时无法同步",


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复切换 Cindy 界面语言后，权限确认卡和 Agent 运行状态仍显示英文的问题。Cindy 自有状态文案现在由 Renderer 按当前语言展示，工具或命令名称保持原样；终端原始 stdout/stderr 不做翻译，避免改变诊断信息。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Refs #586（本 PR 仅处理权限卡与 Cindy 自有状态文案；#586 保持开放，终端原始 stdout/stderr 的产品边界另行确认）
- 本 PR 包含：权限卡标题与操作按钮 i18n、Agent/命令运行状态 i18n、四种现有语言资源及回归测试。
- 明确不包含：终端原始 stdout/stderr、Agent 或第三方 Provider 提供的自由文本翻译。
- 用户可见变化：切换 `zh-CN`、`en`、`ja` 或 `ko` 后，权限卡与 Cindy 自有运行状态会使用对应语言；工具和命令名称不变。
- 是否存在 breaking change：无。

### UI 变化

本次只替换现有组件中的文案，不改变布局、颜色、间距或交互。Light 与 Dark 模式继续共用既有主题变量和组件样式。以下 HTML 使用当前 i18n 资源中的实际文案，展示权限卡及运行状态栏的改动后效果；对应组件行为由 `PermissionPrompt.i18n.test.tsx` 与 `agentStatusI18n.test.ts` 覆盖。

```html
<!-- zh-CN：权限卡 + 恢复会话运行状态 -->
<section lang="zh-CN" aria-label="权限确认">
  <h3>允许 PowerShell？</h3>
  <p>Provider 提供的原因保持原文</p>
  <button type="button">拒绝</button>
  <button type="button">本对话总是允许</button>
  <button type="button">允许一次</button>
</section>
<div lang="zh-CN" role="status">运行中…</div>

<!-- en：会话级授权边界保持明确 -->
<section lang="en" aria-label="Permission confirmation">
  <h3>Allow PowerShell?</h3>
  <button type="button">Deny</button>
  <button type="button">Always allow for this session</button>
  <button type="button">Allow once</button>
</section>
<div lang="en" role="status">Working…</div>
```

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light / Dark 双模式交付门槛（沿用同一套主题化组件与变量）；§11 Voice & Content（界面文案跟随用户所选语言，保留工具名和原始诊断文本）。
- 证据边界：以上为结构化界面效果证据，不代表已完成 Light / Dark 或 Windows 实机截图验证；未验证项仍在下文如实列出。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（Desktop、Mobile、packages 与 protocol workspace 全部通过）

pnpm --filter desktop run --if-present typecheck
结果：通过

Desktop 相关回归测试（17 个测试文件、189 个测试）
结果：通过
```

### 手工验证

不涉及：本 PR 使用当前工作区分支，改动可由 Desktop HMR 加载；提交前未进行人工截图验证。

### 未执行的验证

未单独执行 Windows 平台及 Light / Dark 人工截图验证；本次未改动样式，双模式沿用同一组件和现有主题变量。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 展示层；不改变权限决策、协议数据、状态存储或终端输出。
- 回滚 / 降级方式：回滚本 PR 的单个提交即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
