### PR TITLE
fix(mobile): 切换语言时刷新更新检查提示

### DIFF
--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -65,7 +65,11 @@ import {
 } from '@/notifications/pushNotifications';
 import { buildMobileUpdateInfoRows, currentMobileOtaVersion } from '@/settings/updateInfo';
 import { shouldCheckBundleUpdate } from '@/update/bundleUpdate';
-import { runManualUpdateCheck } from '@/update/manualUpdateCheck';
+import {
+  manualUpdateCheckMessage,
+  runManualUpdateCheck,
+  type ManualUpdateCheckOutcome,
+} from '@/update/manualUpdateCheck';
 import { useBundleUpdatePrompt } from '@/update/useBundleUpdatePrompt';
 import { useCanaryChannelGate } from '@/update/useCanaryChannelGate';
 import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
@@ -94,7 +98,7 @@ export default function SettingsScreen() {
     useState(false);
   const [debugExpanded, setDebugExpanded] = useState(false);
   const [updatePhase, setUpdatePhase] = useState<UpdatePhase>('idle');
-  const [updateMessage, setUpdateMessage] = useState<string | null>(null);
+  const [updateOutcome, setUpdateOutcome] = useState<ManualUpdateCheckOutcome | null>(null);
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
   const [pushMessage, setPushMessage] = useState<string | null>(null);
@@ -159,6 +163,14 @@ export default function SettingsScreen() {
     isTestFlightBuild: IS_TESTFLIGHT_BUILD,
   });
   const updateCheckEnabled = bundleCheckEnabled || updatesEnabled;
+  // 保存未翻译的结果，语言切换触发重渲染时用当前 t() 重新生成提示。
+  const updateMessage = useMemo(
+    () => updateOutcome && manualUpdateCheckMessage(updateOutcome, {
+      isTestFlightBuild: IS_TESTFLIGHT_BUILD,
+      t,
+    }),
+    [t, updateOutcome],
+  );
 
   const aboutSection = overview.sections.find((section) => section.id === 'about');
   const debugSection = overview.sections.find((section) => section.id === 'debug');
@@ -228,7 +240,7 @@ export default function SettingsScreen() {
     // 审核模式:入口按钮已隐藏,这里再挡一层(状态由代码保证,不依赖 UI 层记得隐藏)。
     if (REVIEW_MODE || !updateCheckEnabled || updateCheckInFlightRef.current) return;
     updateCheckInFlightRef.current = true;
-    setUpdateMessage(null);
+    setUpdateOutcome(null);
     try {
       const outcome = await runManualUpdateCheck({
         checkBundleUpdate: bundleCheckEnabled ? checkBundleUpdate : undefined,
@@ -238,31 +250,19 @@ export default function SettingsScreen() {
         reload: () => Updates.reloadAsync(),
         onPhase: (phase) => setUpdatePhase(phase),
       });
+      setUpdateOutcome(outcome);
       if (outcome.kind === 'bundle-update-available') {
         setUpdatePhase('idle');
-        setUpdateMessage(t('settings.version.bundleUpdateFound'));
       } else if (outcome.kind === 'up-to-date') {
         setUpdatePhase('uptodate');
-        setUpdateMessage(t(
-          IS_TESTFLIGHT_BUILD
-            ? 'settings.version.testFlightNoContentUpdate'
-            : 'settings.version.upToDate',
-        ));
       } else if (outcome.kind === 'ota-unavailable') {
         setUpdatePhase('uptodate');
-        setUpdateMessage(t(
-          IS_TESTFLIGHT_BUILD
-            ? 'settings.version.testFlightContentUpdateUnavailable'
-            : 'settings.version.bundleUpToDateNoOta',
-        ));
       } else if (outcome.kind === 'reloading') {
         setUpdatePhase('downloading');
-        setUpdateMessage(t('settings.version.downloadedRestarting'));
       } else if (outcome.kind === 'busy') {
         setUpdatePhase('idle');
       } else {
         setUpdatePhase('error');
-        setUpdateMessage(outcome.message);
       }
     } finally {
       updateCheckInFlightRef.current = false;

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -211,10 +211,13 @@ describe('mobile settings overview', () => {
     expect(source).toContain('isTestFlightBuild: IS_TESTFLIGHT_BUILD');
     expect(source).toContain('const updateCheckEnabled = bundleCheckEnabled || updatesEnabled');
     expect(source).toContain('checkBundleUpdate: bundleCheckEnabled ? checkBundleUpdate : undefined');
+    expect(source).toContain('const [updateOutcome, setUpdateOutcome] = useState<ManualUpdateCheckOutcome | null>(null);');
+    expect(source).toContain('manualUpdateCheckMessage(updateOutcome, {');
+    expect(source).toContain('setUpdateOutcome(outcome);');
+    expect(source).not.toContain('const [updateMessage, setUpdateMessage]');
+    expect(source).not.toContain('setUpdateMessage(');
     expect(source).toContain("'settings.version.testFlightCheckAction'");
     expect(source).toContain("'settings.version.testFlightCheckingAccessibility'");
-    expect(source).toContain("'settings.version.testFlightNoContentUpdate'");
-    expect(source).toContain("'settings.version.testFlightContentUpdateUnavailable'");
     expect(source).toContain("testID=\"settings.testFlightUpdateHint\"");
     expect(source).toContain("{t('settings.version.testFlightUpdateManaged')}");
     expect(source).toContain("{t('settings.version.bundleVersion', { version: appVersion })}");

--- a/apps/mobile/src/update/manualUpdateCheck.test.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { i18n } from '@/i18n';
 import {
+  manualUpdateCheckMessage,
   runManualUpdateCheck,
   type BundleUpdateCheckOutcome,
   type ManualUpdateCheckDeps,
@@ -66,7 +67,7 @@ describe('runManualUpdateCheck', () => {
     const input = deps({ checkBundleUpdate: bundleCheck('error') });
     await expect(runManualUpdateCheck(input)).resolves.toEqual({
       kind: 'error',
-      message: '无法检查整包更新，请稍后重试',
+      reason: 'bundle-check',
     });
     expect(input.checkOtaUpdate).not.toHaveBeenCalled();
   });
@@ -84,5 +85,33 @@ describe('runManualUpdateCheck', () => {
     });
     await expect(runManualUpdateCheck(input)).resolves.toEqual({ kind: 'ota-unavailable' });
     expect(input.checkOtaUpdate).not.toHaveBeenCalled();
+  });
+
+  it('keeps OTA failure details unlocalized until the settings page renders them', async () => {
+    const input = deps({
+      checkOtaUpdate: vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    });
+
+    await expect(runManualUpdateCheck(input)).resolves.toEqual({
+      kind: 'error',
+      reason: 'ota-check',
+      detail: 'offline',
+    });
+  });
+});
+
+describe('manualUpdateCheckMessage', () => {
+  it('uses the current language for an already completed TestFlight check', async () => {
+    const outcome = { kind: 'up-to-date' } as const;
+
+    await i18n.changeLanguage('zh-CN');
+    expect(manualUpdateCheckMessage(outcome, { isTestFlightBuild: true, t: i18n.t }))
+      .toBe('当前没有可用的内容更新。新测试版本请在 TestFlight 中查看。');
+
+    await i18n.changeLanguage('en');
+    expect(manualUpdateCheckMessage(outcome, { isTestFlightBuild: true, t: i18n.t }))
+      .toBe('No content updates are available. Check TestFlight for new test builds.');
   });
 });

--- a/apps/mobile/src/update/manualUpdateCheck.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.ts
@@ -1,4 +1,4 @@
-import { i18n } from '@/i18n';
+import type { TFunction } from 'i18next';
 
 /** 手动整包检查结果,供统一流程决定是否继续检查 JS 热更新。 */
 export type BundleUpdateCheckOutcome =
@@ -18,7 +18,7 @@ export type ManualUpdateCheckOutcome =
   | { kind: 'ota-unavailable' }
   | { kind: 'reloading' }
   | { kind: 'busy' }
-  | { kind: 'error'; message: string };
+  | { kind: 'error'; reason: 'bundle-check' | 'ota-check'; detail?: string };
 
 /** 统一更新检查所需的外部能力,由设置页注入真实 Expo / 整包更新实现。 */
 export interface ManualUpdateCheckDeps {
@@ -50,10 +50,10 @@ export async function runManualUpdateCheck({
     try {
       bundleOutcome = await checkBundleUpdate();
     } catch {
-      return { kind: 'error', message: i18n.t('settings.version.bundleCheckFailed') };
+      return { kind: 'error', reason: 'bundle-check' };
     }
     if (bundleOutcome === 'update-available') return { kind: 'bundle-update-available' };
-    if (bundleOutcome === 'error') return { kind: 'error', message: i18n.t('settings.version.bundleCheckFailed') };
+    if (bundleOutcome === 'error') return { kind: 'error', reason: 'bundle-check' };
     if (bundleOutcome === 'busy') return { kind: 'busy' };
   }
 
@@ -70,9 +70,39 @@ export async function runManualUpdateCheck({
     const detail = error instanceof Error ? error.message.trim() : String(error).trim();
     return {
       kind: 'error',
-      message: detail
-        ? i18n.t('settings.version.checkFailedDetail', { detail })
-        : i18n.t('settings.version.checkFailed'),
+      reason: 'ota-check',
+      ...(detail ? { detail } : {}),
     };
+  }
+}
+
+/**
+ * 在设置页渲染更新检查结果。结果本身只保存语义和动态详情，避免语言切换后保留旧语言的字符串。
+ */
+export function manualUpdateCheckMessage(
+  outcome: ManualUpdateCheckOutcome,
+  options: { isTestFlightBuild: boolean; t: TFunction },
+): string | null {
+  const { isTestFlightBuild, t } = options;
+  switch (outcome.kind) {
+    case 'bundle-update-available':
+      return t('settings.version.bundleUpdateFound');
+    case 'up-to-date':
+      return t(isTestFlightBuild
+        ? 'settings.version.testFlightNoContentUpdate'
+        : 'settings.version.upToDate');
+    case 'ota-unavailable':
+      return t(isTestFlightBuild
+        ? 'settings.version.testFlightContentUpdateUnavailable'
+        : 'settings.version.bundleUpToDateNoOta');
+    case 'reloading':
+      return t('settings.version.downloadedRestarting');
+    case 'error':
+      if (outcome.reason === 'bundle-check') return t('settings.version.bundleCheckFailed');
+      return outcome.detail
+        ? t('settings.version.checkFailedDetail', { detail: outcome.detail })
+        : t('settings.version.checkFailed');
+    case 'busy':
+      return null;
   }
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

更新检查完成后，设置页不再缓存已经翻译的提示字符串，而是保存检查结果及错误详情，在渲染时使用当前语言生成提示。切换语言后无需重新检查更新，TestFlight 内容更新结果及同一路径的错误提示会立即刷新。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #624
- 本 PR 包含：将手动更新检查结果改为语义化 outcome；在设置页按当前 i18n 语言渲染结果；补充语言切换回归测试。
- 明确不包含：OTA 检查策略、TestFlight 分发逻辑、原生配置或翻译文案调整。
- 用户可见变化：已显示的更新检查结果会随应用语言切换立即更新。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：未新增或修改 UI 文案、布局、样式或动效；仅修正既有动态提示在语言切换后的重新计算。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/update/manualUpdateCheck.test.ts
结果：通过，覆盖同一 TestFlight 检查结果在 zh-CN 与 en 下的渲染。

pnpm --filter mobile typecheck
结果：通过。

pnpm --filter mobile test
结果：通过，252 个测试文件、2409 个用例。

pnpm check:i18n
pnpm check:i18n-glossary
结果：通过。

pnpm test:unit
结果：通过，Desktop、Mobile 和所有必测 workspace 均通过。

pnpm check:dco
结果：通过，1 个提交已签署 DCO。
```

### 手工验证

不涉及：未运行真实 iOS TestFlight 设备；回归测试验证已完成检查的结果在语言切换后按当前 i18n 语言重新生成。

### 未执行的验证

真实 iOS TestFlight 安装包手工验证未执行：当前环境没有对应 TestFlight 设备与分发构建。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：移动端设置页的手动更新检查结果展示；不改变更新检查请求、下载或重启行为。
- 回滚 / 降级方式：revert 本 PR 的单个提交即可恢复原展示逻辑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
