### PR TITLE
fix(desktop): 避免误报跨 Agent 工作区迁移提示

### DIFF
--- a/apps/desktop/src/main/cross-agent-convert/__tests__/detector.test.ts
+++ b/apps/desktop/src/main/cross-agent-convert/__tests__/detector.test.ts
@@ -132,6 +132,30 @@ describe('detect — agents', () => {
     expect(agents!.subItems).toHaveLength(1);
     expect(agents!.subItems![0].targetPath).toMatch(/\.codex[\\/]agents[\\/]foo\.toml$/);
   });
+
+  it('to-codex: 普通 Markdown 不应被误报为可迁移 agent', async () => {
+    await fs.mkdir(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, '.claude', 'agents', 'codebase-explorer.md'),
+      '# 代码库探索代理',
+    );
+
+    const r = await detect({ workingDir: tmpDir, agentKind: 'codex' });
+
+    expect(r.items.find((i) => i.kind === 'agents')).toBeUndefined();
+  });
+
+  it('to-codex: 缺少 name 元数据的 Claude agent 不应被误报', async () => {
+    await fs.mkdir(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, '.claude', 'agents', 'without-name.md'),
+      '---\ndescription: only description\n---\nbody',
+    );
+
+    const r = await detect({ workingDir: tmpDir, agentKind: 'codex' });
+
+    expect(r.items.find((i) => i.kind === 'agents')).toBeUndefined();
+  });
 });
 
 describe('detect — mcp', () => {

--- a/apps/desktop/src/main/cross-agent-convert/__tests__/detector.test.ts
+++ b/apps/desktop/src/main/cross-agent-convert/__tests__/detector.test.ts
@@ -168,6 +168,30 @@ describe('detect — agents', () => {
 
     expect(r.items.find((i) => i.kind === 'agents')).toBeUndefined();
   });
+
+  it('to-codex: name 只有空白的 Claude agent 不应被误报', async () => {
+    await fs.mkdir(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, '.claude', 'agents', 'blank-name.md'),
+      '---\nname: "   "\n---\nbody',
+    );
+
+    const r = await detect({ workingDir: tmpDir, agentKind: 'codex' });
+
+    expect(r.items.find((i) => i.kind === 'agents')).toBeUndefined();
+  });
+
+  it('to-codex: frontmatter YAML 无法解析的 Claude agent 不应被误报', async () => {
+    await fs.mkdir(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, '.claude', 'agents', 'invalid-frontmatter.md'),
+      '---\nname: [unterminated\n---\nbody',
+    );
+
+    const r = await detect({ workingDir: tmpDir, agentKind: 'codex' });
+
+    expect(r.items.find((i) => i.kind === 'agents')).toBeUndefined();
+  });
 });
 
 describe('detect — mcp', () => {

--- a/apps/desktop/src/main/cross-agent-convert/__tests__/detector.test.ts
+++ b/apps/desktop/src/main/cross-agent-convert/__tests__/detector.test.ts
@@ -156,6 +156,18 @@ describe('detect — agents', () => {
 
     expect(r.items.find((i) => i.kind === 'agents')).toBeUndefined();
   });
+
+  it('to-codex: name 不是字符串的 Claude agent 不应被误报', async () => {
+    await fs.mkdir(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, '.claude', 'agents', 'numeric-name.md'),
+      '---\nname: 1\n---\nbody',
+    );
+
+    const r = await detect({ workingDir: tmpDir, agentKind: 'codex' });
+
+    expect(r.items.find((i) => i.kind === 'agents')).toBeUndefined();
+  });
 });
 
 describe('detect — mcp', () => {

--- a/apps/desktop/src/main/cross-agent-convert/detector.ts
+++ b/apps/desktop/src/main/cross-agent-convert/detector.ts
@@ -12,6 +12,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import yaml from 'js-yaml';
 
 import type {
   AgentKind,
@@ -66,6 +67,27 @@ async function listFilesByExt(p: string, ext: string): Promise<string[]> {
     return ents.filter((e) => e.isFile() && e.name.toLowerCase().endsWith(ext)).map((e) => e.name);
   } catch {
     return [];
+  }
+}
+
+/**
+ * Claude agent 文件必须包含可解析且非空的 `name` 元数据，转换器才会生成
+ * Codex 的 TOML 文件。检测阶段使用同一条约束，避免把普通 Markdown
+ * 误报为可迁移代理。
+ */
+async function isConvertibleClaudeAgentFile(p: string): Promise<boolean> {
+  try {
+    const raw = await fs.readFile(p, 'utf8');
+    const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+    if (!match) return false;
+    const parsed = yaml.load(match[1]);
+    const name =
+      parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as { name?: unknown }).name
+        : undefined;
+    return typeof name === 'string' && name.trim().length > 0;
+  } catch {
+    return false;
   }
 }
 
@@ -150,8 +172,17 @@ async function detectAgents(wd: string, direction: MigrationDirection, items: Mi
     if (!(await isDir(claudeAgents))) return;
     const sourceFiles = await listFilesByExt(claudeAgents, '.md');
     if (sourceFiles.length === 0) return;
-    const targetExisting = new Set((await listFilesByExt(codexAgents, '.toml')).map((n) => n.replace(/\.toml$/i, '')));
-    const baseNames = sourceFiles.map((f) => f.replace(/\.md$/i, ''));
+    const convertibleSourceFiles: string[] = [];
+    for (const file of sourceFiles) {
+      if (await isConvertibleClaudeAgentFile(path.join(claudeAgents, file))) {
+        convertibleSourceFiles.push(file);
+      }
+    }
+    if (convertibleSourceFiles.length === 0) return;
+    const targetExisting = new Set(
+      (await listFilesByExt(codexAgents, '.toml')).map((n) => n.replace(/\.toml$/i, '')),
+    );
+    const baseNames = convertibleSourceFiles.map((f) => f.replace(/\.md$/i, ''));
     const missing = baseNames.filter((n) => !targetExisting.has(n));
     if (missing.length === 0) return;
     items.push({

--- a/apps/desktop/src/main/cross-agent-convert/detector.ts
+++ b/apps/desktop/src/main/cross-agent-convert/detector.ts
@@ -71,9 +71,9 @@ async function listFilesByExt(p: string, ext: string): Promise<string[]> {
 }
 
 /**
- * Claude agent 文件必须包含可解析且非空的 `name` 元数据，转换器才会生成
- * Codex 的 TOML 文件。检测阶段使用同一条约束，避免把普通 Markdown
- * 误报为可迁移代理。
+ * 检测阶段要求 Claude agent 文件包含可解析 YAML 中的非空字符串 `name`，
+ * 避免把普通 Markdown 误报为可迁移代理。转换器对缺少或假值 `name` 的源文件
+ * 会跳过，但不在这里重复执行转换。
  */
 async function isConvertibleClaudeAgentFile(p: string): Promise<boolean> {
   try {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Cindy 在 Codex 工作区中把普通 `.claude/agents/*.md` 文件误报为可迁移配置，导致用户点击迁移后又看到“所有项已存在，无需迁移”。检测阶段现在会先验证 Claude agent 文件是否包含可解析且非空的 `name` 元数据，再列入迁移项。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Codex 会话反复提示工作区配置可转换，但迁移后显示无需迁移
- 本 PR 包含：跨 Agent 检测器的 Claude agent 元数据校验；普通 Markdown、缺少 `name`、`name` 非字符串的回归测试
- 明确不包含：迁移格式、转换器输出、弹窗文案和其他工作区配置类型
- 用户可见变化：不可转换的普通 Markdown 不再触发迁移提示
- 是否存在 breaking change：无

## UI 变化

不涉及：只修改 main 侧检测逻辑和测试，没有改变界面结构、样式或文案。

## 怎么验证的

### 自动验证

```text
定向测试：
apps/desktop/src/main/cross-agent-convert/__tests__/detector.test.ts
apps/desktop/src/main/cross-agent-convert/__tests__/agents.test.ts
结果：全部通过

类型检查：
使用 Node 22.21.1 运行 pnpm --filter desktop run --if-present typecheck
结果：通过

提交前全量门禁：
使用 Node 22.21.1 和 Python 3.11 运行仓库根 pnpm test:unit
结果：全部工作区通过

DCO：
pnpm check:dco
结果：通过，所有本 PR 提交均带有匹配 author 的 Signed-off-by
```

### 手工验证

不涉及：检测逻辑由自动化回归测试覆盖；未启动桌面应用进行手工 UI 验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：跨 Agent 工作区配置检测

### 远程与多端结论

- SSH 远程工作区：不涉及。本检测只在 Desktop 本地草稿发送路径执行；远程工作区会跳过本地文件检测。
- 设备互联：不涉及。本 PR 没有新增 IPC 或推送事件，也没有接入 device-link。
- 手机版：不涉及。本功能只存在于 Desktop 新建对话流程，手机版没有对应入口。

### 影响与回滚

- 影响范围：仅影响 Claude → Codex 方向的 `.claude/agents/*.md` 检测；带有效 `name` 元数据的合法 agent 仍会照常提示和迁移。
- 回滚 / 降级方式：回滚本 PR 即可恢复原检测逻辑。