### PR TITLE
fix(desktop): superseded by #622

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
@@ -6,43 +6,56 @@ const chatInputSource = readFileSync(
   resolve(__dirname, '..', 'components', 'new-chat', 'ChatInput.tsx'),
   'utf8',
 ).replace(/\r\n?/g, '\n');
+const hardBreakSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'new-chat', 'ComposerHardBreak.ts'),
+  'utf8',
+).replace(/\r\n?/g, '\n');
 
-/**
- * ChatInput 列表接续接线契约:
- * - Shift/Alt+Enter 换行前先尝试列表接续;
- * - 普通 Enter 一律保持"发送"语义,绝不被列表接续拦截(2026-07 产品定案:
- *   Enter=发送的肌肉记忆优先,不做 Claude 式"列表内 Enter 继续列表");
- * - 守住 IME composition 边界。
- * 接续行为本身的用例见 lib/__tests__/composerListContinuation*.test.ts
- * (纯前缀匹配 + 真实编辑器)。
- */
 describe('ChatInput list continuation wiring contract', () => {
-  it('imports the shared helper from lib/composerListContinuation', () => {
+  it('imports the composer extension and only the direct Backspace helper', () => {
     expect(chatInputSource).toContain(
-      "import { applyListBackspace, applyListContinuation } from '@/lib/composerListContinuation';",
+      "import { applyComposerHardBreak, ComposerHardBreak } from './ComposerHardBreak';",
     );
+    expect(chatInputSource).toContain(
+      "import { applyListBackspace } from '@/lib/composerListContinuation';",
+    );
+    expect(chatInputSource).toContain('applyComposerHardBreak(editorRef.current)');
+    expect(chatInputSource).not.toContain('applyListContinuation(view)');
   });
 
-  it('tries list continuation on Shift/Alt+Enter before the default hard break', () => {
+  it('keeps Shift/Alt+Enter semantics inside ComposerHardBreak', () => {
+    expect(hardBreakSource).toContain('export function applyComposerHardBreak(editor: Editor)');
+    expect(hardBreakSource).toContain('applyListContinuation(editor.view)');
+    expect(hardBreakSource).toContain('editor.commands.setHardBreak()');
+    expect(hardBreakSource).not.toContain('replaceSelectionWith');
+  });
+
+  it('routes first modified Enter through the ComposerHardBreak command', () => {
     const block = extractBetween(
       chatInputSource,
-      '// Shift/Alt+Enter — markdown 列表接续',
+      '// Shift/Alt+Enter belongs to ComposerHardBreak',
       '// Plain Enter keeps the existing queue semantics.',
     );
-    expect(block).toContain('(event.shiftKey || event.altKey) &&');
+    expect(block).toContain("event.key === 'Enter'");
+    expect(block).toContain('event.shiftKey || event.altKey');
     expect(block).toContain('!event.metaKey');
     expect(block).toContain('!event.ctrlKey');
-    expect(block).toContain('!event.isComposing');
-    expect(block).toContain('if (applyListContinuation(view)) {');
-    // 非列表行必须放行给 ComposerHardBreak 默认换行
-    expect(block).toContain('return false;');
+    expect(block).toContain('applyComposerHardBreak(editorRef.current)');
+  });
+
+  it('consumes repeated Enter before the palette bridge', () => {
+    const handler = extractBetween(chatInputSource, 'handleKeyDown(view, event) {', '      },\n    },');
+    const repeatGuard = handler.indexOf("event.key === 'Enter' && event.repeat");
+    const panelBridge = handler.indexOf('const bridge = panelBridgeRef.current;');
+    expect(repeatGuard).toBeGreaterThanOrEqual(0);
+    expect(panelBridge).toBeGreaterThan(repeatGuard);
   });
 
   it('intercepts bare Backspace for empty-item deletion, leaving modified backspace alone', () => {
     const block = extractBetween(
       chatInputSource,
       '// Backspace — 空列表项整体回删',
-      '// Shift/Alt+Enter — markdown 列表接续',
+      '// Shift/Alt+Enter belongs to ComposerHardBreak',
     );
     expect(block).toContain("event.key === 'Backspace'");
     expect(block).toContain('!event.metaKey');
@@ -53,13 +66,27 @@ describe('ChatInput list continuation wiring contract', () => {
     expect(block).toContain('applyListBackspace(view)');
   });
 
-  it('never intercepts plain Enter — send semantics stay untouched', () => {
+  it('lets modified and composing Enter bypass an open command palette', () => {
+    const block = extractBetween(
+      chatInputSource,
+      'captureKey: (e) => {',
+      'switch (e.key) {',
+    );
+    expect(block).toContain("e.key === 'Enter'");
+    expect(block).toContain('e.shiftKey || e.altKey || e.metaKey || e.ctrlKey || e.isComposing');
+    expect(block).toContain('return false;');
+  });
+
+  it('never intercepts first plain Enter for list continuation', () => {
     const plainEnterBlock = extractBetween(
       chatInputSource,
       '// Plain Enter keeps the existing queue semantics.',
       "void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');",
     );
     expect(plainEnterBlock).not.toContain('applyListContinuation');
+    expect(plainEnterBlock).toContain(
+      "event.key === 'Enter' && !event.shiftKey && !event.altKey && !event.repeat",
+    );
   });
 
   it('keeps tabular-nums on the editor so multi-line list prefixes align', () => {

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -43,7 +43,9 @@ describe('ChatInput steer shortcut contract', () => {
     expect(windowKeydownBlock).toContain('!event.altKey');
     expect(windowKeydownBlock).toContain("currentState !== 'listening'");
     expect(windowKeydownBlock).toContain("void dispatchSendRef.current('steer');");
-    expect(chatInputSource).toContain("'Alt-Enter': () => this.editor.commands.setHardBreak()");
+    expect(chatInputSource).toContain(
+      "import { applyComposerHardBreak, ComposerHardBreak } from './ComposerHardBreak';",
+    );
     expect(chatInputSource).toContain('ComposerHardBreak');
     expect(chatInputSource).toContain('turnRunning={showStopButton}');
     expect(chatInputSource).toContain('onSteer={onQueueSteer ? handleQueueSteer : undefined}');

--- a/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
@@ -66,7 +66,7 @@ describe('ChatInput voice input Enter-to-send contract', () => {
     );
     const enterBlock = extractBetween(
       tiptapKeydownBlock,
-      "if (event.key === 'Enter' && !event.shiftKey && !event.altKey) {",
+      "if (event.key === 'Enter' && !event.shiftKey && !event.altKey && !event.repeat) {",
       'const wantsSteer =',
     );
 

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -24,8 +24,8 @@ import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import History from '@tiptap/extension-history';
 import Placeholder from '@tiptap/extension-placeholder';
-import HardBreak from '@tiptap/extension-hard-break';
 import type { Editor } from '@tiptap/core';
+import { applyComposerHardBreak, ComposerHardBreak } from './ComposerHardBreak';
 import { CjkPunctDecoration } from './CjkPunctDecoration';
 import { ComposerListIndentDecoration } from './ComposerListIndentDecoration';
 import { WindowsSelectionReplacement } from './WindowsSelectionReplacement';
@@ -152,7 +152,7 @@ import { Selection } from '@tiptap/pm/state';
 import * as sessionService from '@/lib/sessionService';
 import { getModelById } from '@/lib/modelDefinitions';
 import { loadAllCommands, filterSlashCommands, type UnifiedCommand } from '@/lib/slashCommands';
-import { applyListBackspace, applyListContinuation } from '@/lib/composerListContinuation';
+import { applyListBackspace } from '@/lib/composerListContinuation';
 import { scanAtResources, filterAtResources, type AtResourceItem } from '@/lib/atResourceService';
 import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
 import { getAppShortcutCombos } from '@/lib/appShortcutStore';
@@ -213,14 +213,6 @@ const perfLog = createLogger('perf/session-switch');
 
 const VOICE_INPUT_LONG_PRESS_MS = 450;
 const VOICE_INPUT_SHORTCUT_DEDUPE_MS = 250;
-const ComposerHardBreak = HardBreak.extend({
-  addKeyboardShortcuts() {
-    return {
-      ...this.parent?.(),
-      'Alt-Enter': () => this.editor.commands.setHardBreak(),
-    };
-  },
-});
 
 // 工具行宽度自适应阈值（input card 像素宽）。低于阈值时自动收紧工具行，避免窄宽
 // 下换行 / 文字溢出，与 doc rail / orca 的显式 compactToolbar / denseToolbar 取 OR。
@@ -1800,6 +1792,14 @@ export function ChatInput({
         return true;
       },
       handleKeyDown(view, event) {
+        // Repeated Enter must be consumed before any palette bridge. Otherwise
+        // holding Enter while slash/@ results are open can confirm the same
+        // item repeatedly before the composer repeat guard runs.
+        if (event.key === 'Enter' && event.repeat) {
+          event.preventDefault();
+          return true;
+        }
+
         // Delegate panel navigation keys (↑ ↓ Enter Esc Tab) when a
         // palette is open. We can't read React state from here directly,
         // but we expose a ref-based escape hatch via `panelBridgeRef`.
@@ -1931,28 +1931,25 @@ export function ChatInput({
           return true;
         }
 
-        // Shift/Alt+Enter — markdown 列表接续(纯文本):当前行以列表 / 待办 /
-        // 引用前缀开头时,换行后自动补下一个前缀(序号 +1);前缀后无内容时改为
-        // 清掉前缀退出列表。其余情况 return false 走 ComposerHardBreak 默认换行。
+        // Shift/Alt+Enter belongs to ComposerHardBreak, which owns list
+        // continuation and the ordinary hard-break fallback. Invoke its command
+        // here so the full extension stack cannot consume the key first.
         if (
           event.key === 'Enter' &&
           (event.shiftKey || event.altKey) &&
           !event.metaKey &&
           !event.ctrlKey &&
-          !event.isComposing
+          !event.repeat
         ) {
-          if (applyListContinuation(view)) {
-            event.preventDefault();
-            return true;
-          }
-          return false;
+          event.preventDefault();
+          return editorRef.current ? applyComposerHardBreak(editorRef.current) : false;
         }
 
         // Plain Enter keeps the existing queue semantics. Cmd/Ctrl+Enter is
         // only treated as 插话 while a turn is actually running; otherwise it
         // falls back to the normal send path so the shortcut never becomes a
         // "no active turn" footgun on an idle composer.
-        if (event.key === 'Enter' && !event.shiftKey && !event.altKey) {
+        if (event.key === 'Enter' && !event.shiftKey && !event.altKey && !event.repeat) {
           event.preventDefault();
           const isEditorEnterTarget = event.target instanceof Node && view.dom.contains(event.target);
           if (
@@ -3233,6 +3230,15 @@ export function ChatInput({
     panelBridgeRef.current = {
       captureKey: (e) => {
         if (!slashOpen && !atOpen) return false;
+        // Modified Enter belongs to the composer (Shift/Alt = newline,
+        // Cmd/Ctrl = send/steer), and composition Enter belongs to the IME.
+        // Only bare Enter may confirm a palette item.
+        if (
+          e.key === 'Enter' &&
+          (e.shiftKey || e.altKey || e.metaKey || e.ctrlKey || e.isComposing)
+        ) {
+          return false;
+        }
         switch (e.key) {
           case 'ArrowDown':
             if (slashOpen && filteredCommands.length > 0) {

--- a/apps/desktop/src/renderer/components/new-chat/ComposerHardBreak.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerHardBreak.ts
@@ -1,0 +1,43 @@
+import HardBreak from '@tiptap/extension-hard-break';
+import { Plugin } from '@tiptap/pm/state';
+import type { Editor } from '@tiptap/core';
+import { applyListContinuation } from '@/lib/composerListContinuation';
+
+/**
+ * Apply the composer's modified-Enter behavior. Kept beside the extension so
+ * ChatInput owns only the stable keyboard boundary, not document semantics.
+ */
+export function applyComposerHardBreak(editor: Editor): boolean {
+  if (applyListContinuation(editor.view)) return true;
+  return editor.commands.setHardBreak();
+}
+
+/**
+ * Composer-owned hard-break schema and IME boundary.
+ */
+export const ComposerHardBreak = HardBreak.extend({
+  // HardBreak owns only the schema/command here. ChatInput invokes the helper
+  // above from its stable key boundary so extension ordering cannot decide
+  // whether modified Enter reaches the composer behavior.
+  addKeyboardShortcuts() {
+    return {};
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handleDOMEvents: {
+            // ProseMirror already skips handleKeyDown while `view.composing`,
+            // but an IME keydown may still report `isComposing` after the view
+            // has ended its composition. Stop that Enter before any composer
+            // handler can mutate the document. Do not preventDefault: the IME
+            // still owns candidate confirmation.
+            keydown: (view, event) =>
+              event.key === 'Enter' && (event.isComposing || view.composing),
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/ComposerHardBreak.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/ComposerHardBreak.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { applyComposerHardBreak, ComposerHardBreak } from '../ComposerHardBreak';
+import { CjkPunctDecoration } from '../CjkPunctDecoration';
+import { ComposerListIndentDecoration } from '../ComposerListIndentDecoration';
+
+let editor: Editor | null = null;
+
+function makeEditor(lines: string[]): Editor {
+  const content: Array<Record<string, unknown>> = [];
+  lines.forEach((line, i) => {
+    if (i > 0) content.push({ type: 'hardBreak' });
+    if (line.length > 0) content.push({ type: 'text', text: line });
+  });
+  editor = new Editor({
+    element: document.createElement('div'),
+    extensions: [Document, Paragraph, Text, ComposerHardBreak],
+    content: { type: 'doc', content: [{ type: 'paragraph', content }] },
+    editorProps: {
+      handleKeyDown: (_view, event) => {
+        if (
+          event.key !== 'Enter' ||
+          event.repeat ||
+          event.isComposing ||
+          event.metaKey ||
+          event.ctrlKey ||
+          (!event.shiftKey && !event.altKey)
+        ) {
+          return false;
+        }
+        return editor ? applyComposerHardBreak(editor) : false;
+      },
+    },
+  });
+  editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+  return editor;
+}
+
+function docText(ed: Editor): string {
+  return ed.state.doc.textBetween(0, ed.state.doc.content.size, '\n', '\n');
+}
+
+function dispatchEnter(
+  ed: Editor,
+  options: KeyboardEventInit & { keyCode?: number } = {},
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    code: 'Enter',
+    keyCode: 13,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  });
+  ed.view.dom.dispatchEvent(event);
+  return event;
+}
+
+function compositionCycle(ed: Editor): void {
+  ed.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+  expect(ed.view.composing).toBe(true);
+  ed.view.dom.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+  expect(ed.view.composing).toBe(false);
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe('ComposerHardBreak DOM keydown integration', () => {
+  it.each([
+    ['Shift+Enter', { shiftKey: true }],
+    ['Alt+Enter', { altKey: true }],
+  ] as const)('inserts a standard hard break for plain text on %s', (_, options) => {
+    const ed = makeEditor(['shirt']);
+    dispatchEnter(ed, options);
+
+    expect(docText(ed)).toBe('shirt\n');
+    expect(ed.state.doc.child(0).child(1).type.name).toBe('hardBreak');
+  });
+
+  it.each([
+    ['Shift+Enter', { shiftKey: true }],
+    ['Alt+Enter', { altKey: true }],
+  ] as const)('continues a list through the real %s keydown path', (_, options) => {
+    const ed = makeEditor(['1. item']);
+    dispatchEnter(ed, options);
+
+    expect(docText(ed)).toBe('1. item\n2. ');
+  });
+
+  it('exits an empty list item through the stable Shift+Enter boundary', () => {
+    const ed = makeEditor(['1. item', '2. ']);
+
+    dispatchEnter(ed, { shiftKey: true });
+
+    expect(docText(ed)).toBe('1. item\n');
+  });
+
+  it('continues a CJK ordered list without switching the paragraph to fallback layout', () => {
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        ComposerHardBreak,
+        CjkPunctDecoration,
+        ComposerListIndentDecoration,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: '1、你' }],
+          },
+        ],
+      },
+      editorProps: {
+        handleKeyDown: (_view, event) => {
+          if (
+            event.key !== 'Enter' ||
+            event.repeat ||
+            event.isComposing ||
+            event.metaKey ||
+            event.ctrlKey ||
+            (!event.shiftKey && !event.altKey)
+          ) {
+            return false;
+          }
+          return editor ? applyComposerHardBreak(editor) : false;
+        },
+      },
+    });
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    dispatchEnter(editor, { shiftKey: true });
+
+    expect(docText(editor)).toBe('1、你\n2、');
+  });
+
+  it('exits an empty CJK item after mixed ordered-list rows without fragmenting the DOM', () => {
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        ComposerHardBreak,
+        CjkPunctDecoration,
+        ComposerListIndentDecoration,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: '1. asdasd' },
+              { type: 'hardBreak' },
+              { type: 'text', text: '2. 阿萨德噶结算单' },
+              { type: 'hardBreak' },
+              { type: 'text', text: '1、' },
+            ],
+          },
+        ],
+      },
+      editorProps: {
+        handleKeyDown: (_view, event) => {
+          if (
+            event.key !== 'Enter' ||
+            event.repeat ||
+            event.isComposing ||
+            event.metaKey ||
+            event.ctrlKey ||
+            (!event.shiftKey && !event.altKey)
+          ) {
+            return false;
+          }
+          return editor ? applyComposerHardBreak(editor) : false;
+        },
+      },
+    });
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    dispatchEnter(editor, { shiftKey: true });
+
+    expect(docText(editor)).toBe('1. asdasd\n2. 阿萨德噶结算单\n');
+  });
+
+  it('leaves active composition Enter to ProseMirror without mutating the document', () => {
+    const ed = makeEditor(['你好']);
+    const before = ed.state.doc.toJSON();
+    ed.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+
+    const event = dispatchEnter(ed, { shiftKey: true, isComposing: true });
+
+    expect(ed.view.composing).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(ed.state.doc.toJSON()).toEqual(before);
+  });
+
+  it.each([
+    ['bare Enter', {}],
+    ['Shift+Enter', { shiftKey: true }],
+    ['Alt+Enter', { altKey: true }],
+    ['Ctrl+Enter', { ctrlKey: true }],
+    ['Meta+Enter', { metaKey: true }],
+  ] as const)(
+    'does not mutate the document when %s still belongs to the IME after view composition ended',
+    (_, options) => {
+      const ed = makeEditor(['1. item']);
+      const before = ed.state.doc.toJSON();
+      compositionCycle(ed);
+
+      const event = dispatchEnter(ed, { ...options, isComposing: true });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(ed.state.doc.toJSON()).toEqual(before);
+      expect(ed.state.doc.childCount).toBe(1);
+    },
+  );
+
+  it('restores modified Enter after the IME and upstream post-composition guard finish', () => {
+    const ed = makeEditor(['shirt']);
+    compositionCycle(ed);
+
+    const imeEvent = dispatchEnter(ed, { shiftKey: true, isComposing: true });
+    expect(imeEvent.defaultPrevented).toBe(false);
+    expect(docText(ed)).toBe('shirt');
+
+    // ProseMirror deliberately ignores one near-composition Enter on Safari.
+    // A subsequent non-composing keydown must still reach our shortcut.
+    dispatchEnter(ed, { shiftKey: true });
+    if (docText(ed) === 'shirt') dispatchEnter(ed, { shiftKey: true });
+    expect(docText(ed)).toBe('shirt\n');
+  });
+
+  it.each([
+    ['Ctrl+Enter', { ctrlKey: true }],
+    ['Meta+Enter', { metaKey: true }],
+  ] as const)('does not inherit HardBreak Mod-Enter for %s', (_, options) => {
+    const ed = makeEditor(['shirt']);
+    dispatchEnter(ed, options);
+
+    expect(docText(ed)).toBe('shirt');
+  });
+});


### PR DESCRIPTION
## 关闭说明

该问题已由 #622 `fix(desktop): 修复输入框列表缩进与卡死` 修复。

#622 已处理 Desktop 输入框列表相关的 renderer 卡死、缩进、换行和字体显示问题。为避免重复修改同一功能及继续扩大变更范围，本 PR 不再继续，现已关闭且不会合并。

请以 #622 的实现为准。