### PR TITLE
fix(desktop): 修复窄会话 composer 底栏控件重叠

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const rendererRoot = join(import.meta.dirname, '..');
+const read = (relativePath: string) =>
+  readFileSync(join(rendererRoot, 'components/new-chat', relativePath), 'utf8');
+
+const chatInputSource = read('ChatInput.tsx');
+const modelSelectorSource = read('ModelSelector.tsx');
+const permissionSelectorSource = read('PermissionSelector.tsx');
+
+describe('composer narrow toolbar contract', () => {
+  it('uses measured card width for both default-session and create-agent composers', () => {
+    expect(chatInputSource).toContain(
+      'const useNarrowToolbar = narrowToolbar || (toolbarWidth != null && toolbarWidth < 600);',
+    );
+    expect(chatInputSource).not.toContain(
+      'isCreateAgentVariant &&\n    (narrowToolbar || (toolbarWidth != null && toolbarWidth < 600))',
+    );
+    expect(chatInputSource).toContain('compactToolbar={useNarrowToolbar}');
+    expect(chatInputSource).toContain('ultraCompactToolbar={useUltraCompactToolbar}');
+    expect(chatInputSource).toContain('iconOnly={useUltraCompactToolbar}');
+  });
+
+  it('reserves fixed action space and makes permission/model chrome compact by container state', () => {
+    expect(chatInputSource).toContain("'flex shrink-0 items-center gap-1'");
+    expect(modelSelectorSource).toContain(
+      'const isCompactToolbar = compactToolbar && !isFieldTrigger;',
+    );
+    expect(modelSelectorSource).toContain("'w-[148px] min-w-[72px]'");
+    expect(modelSelectorSource).toContain("'w-[64px] min-w-[64px]'");
+    expect(modelSelectorSource).toContain('triggerPromotionLabel && !isCompactToolbar');
+    expect(modelSelectorSource).toContain('effortLabel && !isCompactToolbar');
+    expect(permissionSelectorSource).toContain(
+      'const isIconOnly = iconOnly && !isFieldTrigger;',
+    );
+    expect(permissionSelectorSource).toContain(
+      "'h-[30px] w-[34px] min-w-[34px] justify-center px-0'",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-const rendererRoot = join(import.meta.dirname, '..');
+const rendererRoot = join(__dirname, '..');
 const read = (relativePath: string) =>
   readFileSync(join(rendererRoot, 'components/new-chat', relativePath), 'utf8');
 

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -29,6 +29,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'settings.providers.anthropic.title': 'Anthropic',
         'newChat.modelSelector.trigger.placeholder': '选择模型',
         'newChat.modelSelector.pricing.free': '限时免费',
+        'newChat.modelSelector.source.disconnected': '已断开',
       };
       if (key === 'newChat.modelSelector.priceTip') {
         return `Input ${options?.input} · Output ${options?.output} per 1M tokens`;
@@ -399,6 +400,28 @@ describe('ModelSelector trigger variants', () => {
     // 可及名仍保留完整模型 + effort，视觉仅收起文字，不丢选择能力。
     expect(trigger.getAttribute('aria-label')).toContain('Opus 4.8');
     expect(trigger.getAttribute('aria-label')).toContain('超高');
+  });
+
+  it('keeps the disconnected status in the compact trigger title', () => {
+    render(
+      React.createElement(ModelSelector, {
+        modelId: 'claude-opus-4-8',
+        effort: 'xhigh' as Effort,
+        onModelChange: vi.fn(),
+        onEffortChange: vi.fn(),
+        vendorKey: 'cc',
+        compactToolbar: true,
+        currentProviderId: 'anthropic',
+        sourceDisconnected: true,
+      }),
+    );
+
+    const trigger = screen.getByRole('button', {
+      name: /已断开: Opus 4\.8/,
+    });
+    expect(trigger.getAttribute('title')).toBe('已断开: Opus 4.8');
+    // compact 隐藏冗余状态文案，但 Unplug 错误图标与悬停 title 仍保留。
+    expect(trigger.textContent).not.toContain('已断开');
   });
 
   it('shows the intent model and its default source after registering an agent switch', () => {

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -365,6 +365,42 @@ describe('ModelSelector trigger variants', () => {
     expect(modelListMaxHeightForRows(100)).toBe(300);
   });
 
+  it('bounds the default-session trigger in narrow and ultra-narrow composers', () => {
+    const props = {
+      modelId: 'claude-opus-4-8',
+      effort: 'xhigh' as Effort,
+      onModelChange: vi.fn(),
+      onEffortChange: vi.fn(),
+      vendorKey: 'cc' as const,
+      compactToolbar: true,
+    };
+    const view = render(React.createElement(ModelSelector, props));
+
+    let trigger = screen.getByRole('button', {
+      name: /Current: Opus 4\.8, effort: 超高/,
+    });
+    expect(trigger.className).toContain('w-[148px]');
+    expect(trigger.className).toContain('min-w-[72px]');
+    expect(within(trigger).getByText('Opus 4.8').className).toContain('truncate');
+    expect(trigger.textContent).not.toContain('超高');
+
+    view.rerender(
+      React.createElement(ModelSelector, {
+        ...props,
+        ultraCompactToolbar: true,
+      }),
+    );
+    trigger = screen.getByRole('button', {
+      name: /Current: Opus 4\.8, effort: 超高/,
+    });
+    expect(trigger.className).toContain('w-[64px]');
+    expect(trigger.className).toContain('min-w-[64px]');
+    expect(within(trigger).getByText('Opus 4.8').className).toContain('hidden');
+    // 可及名仍保留完整模型 + effort，视觉仅收起文字，不丢选择能力。
+    expect(trigger.getAttribute('aria-label')).toContain('Opus 4.8');
+    expect(trigger.getAttribute('aria-label')).toContain('超高');
+  });
+
   it('shows the intent model and its default source after registering an agent switch', () => {
     const sessionId = 'model-selector-agent-switch-intent';
     providersRef.providers = [

--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -209,7 +209,9 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(permissionSelectorSource).toContain("'truncate'");
     expect(modelSelectorSource).not.toContain('border-[var(--create-agent-control-border)]');
     expect(modelSelectorSource).toContain('border border-transparent bg-transparent');
-    expect(modelSelectorSource).toContain('min-w-[72px] max-w-full shrink overflow-hidden');
+    expect(modelSelectorSource).toContain("'h-[30px] max-w-full shrink overflow-hidden px-2.5'");
+    expect(modelSelectorSource).toContain("? 'w-[64px] min-w-[64px]'");
+    expect(modelSelectorSource).toContain("? 'w-[148px] min-w-[72px]'");
     expect(modelSelectorSource).not.toContain('w-[206px] min-w-[160px] max-w-[206px] shrink');
     expect(modelSelectorSource).not.toContain('max-w-[180px] truncate');
 
@@ -259,7 +261,7 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(sendButtonSource).toContain(
       "'flex shrink-0 items-center justify-center rounded-full transition-[color,background-color,transform]'",
     );
-    expect(modelSelectorSource).toContain("'h-[30px] min-w-[72px] max-w-full shrink overflow-hidden");
+    expect(modelSelectorSource).toContain("'h-[30px] max-w-full shrink overflow-hidden px-2.5'");
     expect(modelSelectorSource).not.toContain("'h-[30px] min-w-max shrink-0");
     expect(modelSelectorSource).not.toContain("'h-[30px] w-[206px] min-w-[160px] max-w-[206px]");
     expect(modelSelectorSource).toContain("? 'truncate'");

--- a/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
@@ -195,6 +195,18 @@ describe('PermissionSelector triggerVariant', () => {
     expect(cls).not.toContain('settings-input-bg');
   });
 
+  it('普通会话的超窄态也收成图标，field 形态不受影响', () => {
+    const { unmount } = renderSelector({ iconOnly: true });
+    const compactTrigger = getTrigger();
+    expect(compactTrigger.className).toContain('w-[34px]');
+    expect(compactTrigger.textContent).toBe('');
+    expect(compactTrigger.getAttribute('aria-label')).toContain('默认权限');
+
+    unmount();
+    renderSelector({ iconOnly: true, triggerVariant: 'field' });
+    expect(getTrigger().textContent).toContain('默认权限');
+  });
+
   it('field 形态:输入面样式,与 ModelSelector 的 field trigger 同规格(pill,§4 Select 触发器)', () => {
     renderSelector({ triggerVariant: 'field' });
     const cls = getTrigger().className;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -518,7 +518,7 @@ interface ChatInputProps {
   onRememberedEffortChange?: (modelId: string, effort: Effort) => void;
   /** Enables wrapping for narrow split-pane layouts such as Orca. Defaults to false. */
   compactToolbar?: boolean;
-  /** 窄态新建对话时使用紧凑单行工具栏，保留所有操作入口。 */
+  /** 强制使用紧凑单行工具栏；容器测宽也会自动进入同一状态。 */
   narrowToolbar?: boolean;
   /**
    * 工具行采用更紧凑的视觉密度 (字号 -1px, 协同 toggle 只剩 logo)。
@@ -4748,9 +4748,10 @@ export function ChatInput({
   const showTopSlot = !!topSlot;
   const showFusedWrapper = showQueuePanel || showTopSlot;
   const isCreateAgentVariant = visualVariant === 'create-agent';
-  const useNarrowToolbar =
-    isCreateAgentVariant &&
-    (narrowToolbar || (toolbarWidth != null && toolbarWidth < 600));
+  // split-pane 同时打开侧栏 / 会话 / 浏览器时，普通会话 composer 也会落到窄容器。
+  // 这里必须按 card 实际宽度统一切 compact，而不是只照顾 create-agent；否则普通
+  // 会话仍走两组 max-content flex，长模型名会把权限入口挤进语音 / 发送固定动作区。
+  const useNarrowToolbar = narrowToolbar || (toolbarWidth != null && toolbarWidth < 600);
   const useCompactMiddleToolbar =
     isCreateAgentVariant && (toolbarWidth == null ? narrowToolbar : toolbarWidth < 600);
   const useUltraCompactToolbar =

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -323,9 +323,9 @@ interface ModelSelectorProps {
   disabled?: boolean;
   /** 窄容器下把 trigger 字号/高度各压一档,默认 false。 */
   dense?: boolean;
-  /** 窄态工具栏的简略触发器:隐藏 effort / Fast 次要信息并限制模型名宽度。 */
+  /** 窄 composer 的简略触发器:隐藏 effort / Fast 次要信息并限制模型名宽度。 */
   compactToolbar?: boolean;
-  /** 极窄工具栏进一步隐藏模型文字，只保留模型图标和下拉箭头。 */
+  /** 极窄 composer 进一步隐藏模型文字，只保留模型图标和下拉箭头。 */
   ultraCompactToolbar?: boolean;
   /** Trigger presentation: toolbar keeps the compact chat pill; field renders a settings input-like control. */
   triggerVariant?: 'toolbar' | 'field';
@@ -1774,7 +1774,9 @@ export function ModelSelector({
   const isBudget = modelId.startsWith('codex/');
   const isFieldTrigger = triggerVariant === 'field';
   const isCreateAgentVariant = visualVariant === 'create-agent';
-  const isCompactToolbar = compactToolbar && isCreateAgentVariant;
+  // compact 是 composer 容器宽度状态，不是 create-agent 的视觉私有状态。
+  // 正常会话在侧栏 + 浏览器 split-pane 下也必须让长模型名承担收缩。
+  const isCompactToolbar = compactToolbar && !isFieldTrigger;
   const isUltraCompactToolbar = ultraCompactToolbar && isCompactToolbar;
   // 保留 useMorphPopover 作用域开关(仅 composer 工具条 opt-in;settings/CreateWorker 用 Radix 回退),
   // 但去掉 !isCreateAgentVariant —— 新建对话框工具条也走脱身上浮 morph,与会话内统一(2026-07-22)。
@@ -1809,9 +1811,13 @@ export function ModelSelector({
               'rounded-full',
               // 裸态工具条(2026-07-22 用户定稿):默认无框,hover 才浮现胶囊外框。
               // create-agent(新建对话框)与会话内共用同一套裸态,不再分叉 —— 静息/hover 逐字一致。
-              'h-[30px] min-w-[72px] max-w-full shrink overflow-hidden px-2.5',
-              // 窄态工具条(#562):新建对话框空间不足时钳制触发器宽度,防与语音/发送重叠。
-              isUltraCompactToolbar ? 'w-[64px]' : isCompactToolbar ? 'w-[148px]' : undefined,
+              'h-[30px] max-w-full shrink overflow-hidden px-2.5',
+              // 窄态工具条:钳制唯一可收缩的模型入口，给语音 / 发送固定动作留足空间。
+              isUltraCompactToolbar
+                ? 'w-[64px] min-w-[64px]'
+                : isCompactToolbar
+                  ? 'w-[148px] min-w-[72px]'
+                  : 'min-w-[72px]',
               'border border-transparent bg-transparent',
               'hover:border-[var(--border-default)] hover:bg-[var(--composer-pill-bg,#FCFCFC)] dark:hover:bg-[var(--composer-pill-bg,#393838)]',
             ),
@@ -1837,13 +1843,13 @@ export function ModelSelector({
               isCreateAgentVariant
                 ? 'text-[var(--create-agent-control-text)]'
                 : 'text-[var(--text-primary)]',
-              isCreateAgentVariant
-                ? isUltraCompactToolbar
-                  ? 'hidden'
-                  : isCompactToolbar
-                    ? 'max-w-[108px] truncate'
-                    : 'truncate'
-                : cn('truncate', isFieldTrigger ? 'max-w-[260px]' : ''),
+              isUltraCompactToolbar
+                ? 'hidden'
+                : isCompactToolbar
+                  ? 'max-w-[108px] truncate'
+                  : isCreateAgentVariant
+                    ? 'truncate'
+                    : cn('truncate', isFieldTrigger ? 'max-w-[260px]' : ''),
               isCreateAgentVariant ? 'text-[12px]' : dense ? 'text-[12.5px]' : 'text-[13px]',
             )}
           >
@@ -1866,15 +1872,15 @@ export function ModelSelector({
           <span
             className={cn(
               'min-w-0 font-normal text-[var(--text-primary)]',
-              isCreateAgentVariant
-                ? isUltraCompactToolbar
-                  ? 'hidden'
-                  : isCompactToolbar
-                    ? 'max-w-[108px] truncate'
-                    : 'truncate'
-                : isFieldTrigger
-                  ? 'max-w-[260px] truncate'
-                  : 'truncate',
+              isUltraCompactToolbar
+                ? 'hidden'
+                : isCompactToolbar
+                  ? 'max-w-[108px] truncate'
+                  : isCreateAgentVariant
+                    ? 'truncate'
+                    : isFieldTrigger
+                      ? 'max-w-[260px] truncate'
+                      : 'truncate',
               isCreateAgentVariant ? 'text-[12px]' : dense ? 'text-[12.5px]' : 'text-[13px]',
             )}
           >
@@ -1887,14 +1893,16 @@ export function ModelSelector({
             className="ml-0.5 shrink-0 text-[var(--error-fg)]"
             aria-hidden
           />
-          <span
-            className={cn(
-              'shrink-0 font-medium text-[var(--error-fg)]',
-              dense ? 'text-[11.5px]' : 'text-[12px]',
-            )}
-          >
-            {t('newChat.modelSelector.source.disconnected')}
-          </span>
+          {!isCompactToolbar && (
+            <span
+              className={cn(
+                'shrink-0 font-medium text-[var(--error-fg)]',
+                dense ? 'text-[11.5px]' : 'text-[12px]',
+              )}
+            >
+              {t('newChat.modelSelector.source.disconnected')}
+            </span>
+          )}
         </>
       ) : (
         <>
@@ -1915,15 +1923,15 @@ export function ModelSelector({
           <span
             className={cn(
               'min-w-0 font-normal',
-              isCreateAgentVariant
-                ? isUltraCompactToolbar
-                  ? 'hidden'
-                  : isCompactToolbar
-                    ? 'max-w-[108px] truncate'
-                    : 'truncate'
-                : isFieldTrigger
-                  ? 'max-w-[260px] truncate'
-                  : 'truncate',
+              isUltraCompactToolbar
+                ? 'hidden'
+                : isCompactToolbar
+                  ? 'max-w-[108px] truncate'
+                  : isCreateAgentVariant
+                    ? 'truncate'
+                    : isFieldTrigger
+                      ? 'max-w-[260px] truncate'
+                      : 'truncate',
               !isBudget &&
                 (isCreateAgentVariant
                   ? 'text-[var(--create-agent-control-text)]'

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1769,6 +1769,9 @@ export function ModelSelector({
             effort: effortLabel,
           })
         : t('newChat.modelSelector.trigger.aria', { model: displayLabel });
+  // compact 会隐藏断连状态文字；原生 title 仍需保留同一状态，避免鼠标用户悬停
+  // 错误图标时只看到模型名、无法判断发送为何被阻断。
+  const triggerTitle = showSourceDisconnected ? baseAriaLabel : displayLabel;
   // 多实例同屏(IM 目录偏好)时前置「字段名 · 行别名」,读屏才能区分行与行。
   const ariaLabel = ariaContext ? `${ariaContext}:${baseAriaLabel}` : baseAriaLabel;
   const isBudget = modelId.startsWith('codex/');
@@ -1797,7 +1800,7 @@ export function ModelSelector({
       onClick={morphEnabled ? () => setOpen((prev) => (disabled ? false : !prev)) : undefined}
       aria-expanded={open && !disabled}
       aria-haspopup="listbox"
-      title={displayLabel}
+      title={triggerTitle}
       className={cn(
         'flex min-w-0 max-w-full items-center gap-1 transition-colors',
         isFieldTrigger

--- a/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
@@ -135,8 +135,9 @@ export function PermissionSelector({
   const isCreateAgentVariant = visualVariant === 'create-agent';
   const isFieldTrigger = triggerVariant === 'field';
   const previousOptionsLengthRef = useRef(options.length);
-  // 窄态工具条(#562):新建对话框空间不足时权限入口图标化,防与语音/发送重叠。
-  const isIconOnly = iconOnly && isCreateAgentVariant;
+  // 窄态工具条:权限语义由 tooltip + aria-label 保留，视觉收成固定宽图标。
+  // 普通会话在侧栏 + 浏览器 split-pane 下同样会变窄，不能只处理 create-agent。
+  const isIconOnly = iconOnly && !isFieldTrigger;
 
   useEffect(() => {
     if (!open) {

--- a/docs/design-previews/narrow-composer-toolbar/index.html
+++ b/docs/design-previews/narrow-composer-toolbar/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
+  <title>窄 composer 工具栏溢出修复预览</title>
+  <style>
+    * { box-sizing: border-box; }
+    :root {
+      color-scheme: light;
+      --page: #f4f4f2; --frame: #fff; --card: #fff; --border: #d7d7d4;
+      --text: #3c3f43; --muted: #8c8e94; --pill: #f5f5f3; --send: #3c3f43;
+    }
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --page: #181817; --frame: #222220; --card: #2c2c2a; --border: #484846;
+      --text: #d4d4d4; --muted: #6f6f6f; --pill: #393838; --send: #eee;
+    }
+    body { margin: 0; padding: 28px; background: var(--page); color: var(--text);
+      font: 13px/1.5 -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif; }
+    h1 { margin: 0 0 6px; font-size: 18px; }
+    .intro { margin: 0 0 18px; max-width: 780px; color: var(--muted); }
+    .switch { display: flex; gap: 8px; margin-bottom: 20px; }
+    button { font: inherit; }
+    .theme { border: 1px solid var(--border); border-radius: 999px; padding: 6px 14px;
+      color: var(--text); background: var(--frame); cursor: pointer; }
+    .theme.active { background: var(--send); color: var(--card); }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(380px, 1fr)); gap: 18px; }
+    .case { min-width: 0; }
+    .label { margin: 0 0 7px; font-size: 12px; font-weight: 600; }
+    .label.before { color: #c35b67; } .label.after { color: #41935c; }
+    .frame { min-width: 0; padding: 14px; border: 1px solid var(--border); border-radius: 14px;
+      background: var(--frame); }
+    .composer { width: 380px; max-width: 100%; min-height: 142px; padding: 14px 12px 10px;
+      border: 1px solid var(--border); border-radius: 16px; background: var(--card);
+      display: flex; flex-direction: column; justify-content: space-between; }
+    .draft { min-height: 74px; color: var(--muted); }
+    .toolbar { display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .toolbar.before { overflow: visible; }
+    .toolbar.after { gap: 8px; overflow: hidden; }
+    .left, .right { display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .left.before { flex-shrink: 0; } .right.before { flex-shrink: 0; margin-left: auto; }
+    .left.after { flex-shrink: 0; gap: 4px; } .right.after { flex-shrink: 0; gap: 4px; margin-left: auto; }
+    .plus { width: 26px; text-align: center; font-size: 22px; line-height: 30px; }
+    .permission, .model { display: inline-flex; align-items: center; gap: 5px; min-width: 0;
+      height: 30px; padding: 0 10px; border-radius: 999px; white-space: nowrap; }
+    .permission { color: #c76519; }
+    .before .permission { min-width: 142px; }
+    .model { color: var(--text); }
+    .before .model { min-width: 218px; }
+    .after .permission { width: 34px; min-width: 34px; justify-content: center; padding: 0; }
+    .after .model { width: 64px; min-width: 64px; justify-content: flex-start; padding: 0 10px; }
+    .model-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .after .model-name { display: none; }
+    .meta { color: var(--muted); flex-shrink: 0; }
+    .action { width: 30px; height: 30px; display: inline-flex; align-items: center; justify-content: center;
+      flex: 0 0 30px; border: 1px solid var(--border); border-radius: 50%; color: var(--text); }
+    .send { border: 0; background: var(--send); color: var(--card); }
+    .note { margin: 8px 0 0; color: var(--muted); font-size: 12px; }
+    @media (max-width: 480px) { body { padding: 18px; } .grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body data-theme="light">
+  <h1>窄 composer 工具栏：长模型名不再挤压固定动作</h1>
+  <p class="intro">复现尺寸为 380px CSS 宽度，对应侧栏 + 会话 + 浏览器 split-pane。修复后权限入口保留为图标，
+    模型入口固定 64px 并隐藏次要 effort/Fast 信息，语音、Stop、发送始终占固定动作位。</p>
+  <div class="switch">
+    <button class="theme active" data-theme-choice="light">Light</button>
+    <button class="theme" data-theme-choice="dark">Dark</button>
+  </div>
+  <div class="grid">
+    <section class="case">
+      <p class="label before">修复前 · max-content flex 相互争抢</p>
+      <div class="frame">
+        <div class="composer">
+          <div class="draft">输入任务……</div>
+          <div class="toolbar before">
+            <div class="left before"><span class="plus">＋</span><span class="permission">⚠ 完全访问</span></div>
+            <div class="right before"><span class="model">⚙ <span class="model-name">GPT-5.6-Solution-Long-Context</span> · High</span>
+              <span class="action">♩</span><span class="action send">■</span></div>
+          </div>
+        </div>
+      </div>
+      <p class="note">左侧权限与右侧模型均按内容占宽，窄容器下会侵入语音 / 发送动作区。</p>
+    </section>
+    <section class="case">
+      <p class="label after">修复后 · compact / ultra-compact</p>
+      <div class="frame">
+        <div class="composer">
+          <div class="draft">输入任务……</div>
+          <div class="toolbar after">
+            <div class="left after"><span class="plus">＋</span><span class="permission">⚠</span></div>
+            <div class="right after"><span class="model">⚙ <span class="model-name">GPT-5.6-Solution-Long-Context</span></span>
+              <span class="action">♩</span><span class="action send">■</span></div>
+          </div>
+        </div>
+      </div>
+      <p class="note">权限 / 模型共享窄态策略，模型文字可截断或隐藏；固定动作区不收缩、不换行。</p>
+    </section>
+  </div>
+  <script>
+    document.querySelectorAll('[data-theme-choice]').forEach((button) => {
+      button.addEventListener('click', () => {
+        document.body.dataset.theme = button.dataset.themeChoice;
+        document.querySelectorAll('[data-theme-choice]').forEach((item) =>
+          item.classList.toggle('active', item === button));
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 在同时打开侧边栏、会话与右侧浏览器时，窄会话 composer 底栏的权限、长模型名、语音与发送按钮相互重叠的问题。

根因是 ChatInput 已经通过 ResizeObserver 测量输入卡宽度，也已有 compact / ultra-compact 工具栏样式，但 useNarrowToolbar、ModelSelector.compactToolbar 与 PermissionSelector.iconOnly 都被 create-agent 变体门控。正常会话即使缩到约 380 CSS px，仍保留按内容占宽的权限和模型触发器，长模型名会侵入 shrink-0 的语音 / Stop / 发送动作区。

本 PR 将同一套容器宽度状态应用到正常会话和新建对话框，并让模型入口承担可控收缩；固定动作仍保留完整尺寸和点击目标。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Desktop 侧栏 + 会话 + 浏览器 split-pane 下，长模型名导致 composer 底栏控件重叠
- 本 PR 包含：
  - card 宽度 < 600px 时，default-session 与 create-agent 统一进入 compact 单行工具栏
  - < 420px 时，权限入口图标化、模型入口收至真实 64px，并隐藏 effort / Fast /促销等次要视觉信息
  - 语音、Stop、发送动作组继续 `shrink-0`
  - 模型完整名称、effort 与权限名称继续通过 title / tooltip / aria-label 提供
  - disconnected 模型在 compact 态隐藏冗余状态文字，保留错误图标与完整可及名
  - 回归测试与 Light / Dark 可交互 HTML 预览
- 明确不包含：模型选择语义、权限模式语义、Popover 行为、Mobile UI
- 用户可见变化：窄会话下底栏不再重叠；普通宽度布局保持不变
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - `DESIGN.md §8 Window & Adaptive Behavior`：composer 按窗口 / 容器宽度流式重排，固定动作目标不缩小
  - `DESIGN.md §10 Light / Dark Dual-Mode Delivery Gate`：组件不增加硬编码主题色，继续消费现有语义 token；Light / Dark 均已目检
  - `DESIGN.md §14.4 Composer toolbar`：permission / model 属于 morphing-dropdown tier，voice / send 属于 persistent-tool tier；会话内与 create dialog 共用同一套 chrome

可交互 HTML 预览（380px CSS 容器，修复前 / 修复后，Light / Dark）：

- [docs/design-previews/narrow-composer-toolbar/index.html](https://github.com/justinbao19/cindy-public/blob/codex/fix-narrow-composer-overlap/docs/design-previews/narrow-composer-toolbar/index.html)

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run   src/renderer/__tests__/composerNarrowToolbarContract.test.ts   src/renderer/__tests__/modelSelectorTriggerVariant.test.ts   src/renderer/__tests__/permissionSelectorMorph.test.tsx   src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
结果：通过，4 files / 56 tests（rebase 到最新 upstream/main 后复跑）

pnpm --filter desktop run --if-present typecheck
结果：通过（rebase 后复跑）

pnpm test:unit
结果：通过；Desktop、Mobile 与全部 required workspace PASS
说明：完整门禁完成后 upstream/main 前进 2 个无关提交；已 rebase，随后复跑上述定向测试与 Desktop typecheck

pnpm check:dco --range upstream/main..HEAD
结果：通过

git diff --check upstream/main..HEAD
结果：通过
```

### 手工验证

- macOS / Chromium：用 Playwright 以 1280×720 viewport 渲染预览
- 在 380px CSS composer 宽度检查修复前溢出与修复后 ultra-compact 状态
- Light 与 Dark 两种模式均已实际切换并目检
- 确认修复后权限 / 模型入口与语音 / 发送固定动作无重叠、无换行

### 未执行的验证

- 未重启真实 Desktop dev 实例；本次为纯 Renderer 布局改动，已用组件测试、typecheck 与 Chromium 预览覆盖
- 未在 Windows 实机目检

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop ChatInput 的窄容器展示约束；宽度 ≥ 600px 的普通布局、模型 / 权限业务逻辑与弹层交互不变
- 回滚 / 降级方式：回滚本提交即可恢复原布局；无数据迁移或持久化变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
