### PR TITLE
fix(desktop): 收口 xAI 订阅 OAuth 被上游作废的 401/403

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -406,6 +406,7 @@ import {
   logoutGrok,
   hasGrokOAuthLogin,
 } from './maker-host/grok-oauth-login.js';
+import { setXaiAuthInvalidatedHandler } from './maker-host/xai-auth-invalidation-host.js';
 import {
   readSilentEncryptedRetrySettingsState,
   resetSilentEncryptedRetrySettings,
@@ -2759,6 +2760,13 @@ const registerIpcHandlers = () => {
   ipcMain.handle(MAKER_IPC_INVOKE.CLAUDE_OAUTH_CANCEL, async () => {
     cancelClaudeOAuthLogin();
     return { authorized: hasClaudeAiOAuth() };
+  });
+
+  // 上游作废 xAI 凭证、收口自动登出后,走和手动登出完全一致的 UI 收尾(广播 + 清账号级
+  // 限流快照),否则用户会停在「显示已连接、请求连环 403」的假状态。
+  setXaiAuthInvalidatedHandler(() => {
+    clearXaiRateLimitSnapshot();
+    broadcastXaiAuthStateChanged();
   });
 
   // xAI(SuperGrok 订阅)OAuth —— 与 claude-oauth 同形态。登录成功后 bridge 的 xai provider 立即可用

--- a/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
@@ -214,6 +214,27 @@ describe('recoverGrokAuthAfterRejection', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('superseded 没有真的刷新,不占用冷却窗口', async () => {
+    seedCredentials();
+    const fetchMock = vi.fn(async () =>
+      tokenResponse(200, { access_token: 'fresh-access-token', expires_in: 3600 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // 在刷新任务进入串行链之前登出:锁内重读拿到 null,直接 superseded,不发请求。
+    const pending = recoverGrokAuthAfterRejection();
+    logoutGrok();
+    await expect(pending).resolves.toBe('superseded');
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // 冷却必须还没被占用 —— 否则紧接着被拒的新 token 最多 60s 内无法自愈。
+    bound = true;
+    seedCredentials({ access_token: 'second-access-token', refresh_token: 'refresh-token-v2' });
+    resetGrokOAuthMemoryCache();
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('refreshed');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('未登录 / 未绑定当前数据归属时不碰凭证', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
@@ -51,12 +51,14 @@ import {
 } from '../grok-oauth-login.js';
 
 const SECRET_ID = 'xai';
+/** 上游拒掉的那把 access_token —— 收口必须绑定到它。 */
+const REJECTED_TOKEN = 'rejected-access-token';
 
 function seedCredentials(overrides: Record<string, unknown> = {}): void {
   store.set(
     SECRET_ID,
     JSON.stringify({
-      access_token: 'rejected-access-token',
+      access_token: REJECTED_TOKEN,
       refresh_token: 'refresh-token-v1',
       // 故意设成远未到期:被服务端提前作废的 token 本地看就是"没过期",
       // 常规刷新永远不触发,只有强制路径能动它。
@@ -105,7 +107,7 @@ describe('recoverGrokAuthAfterRejection', () => {
       ),
     );
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('refreshed');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('refreshed');
     expect(readStored()?.access_token).toBe('fresh-access-token');
   });
 
@@ -113,7 +115,31 @@ describe('recoverGrokAuthAfterRejection', () => {
     seedCredentials();
     vi.stubGlobal('fetch', vi.fn(async () => tokenResponse(400, { error: 'invalid_grant' })));
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('logged_out');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('logged_out');
+    expect(readStored()).toBeNull();
+  });
+
+  it('收口开始时凭证已换成别的账号 —— 不拿新凭证承担旧 token 的失败', async () => {
+    // invalidator 的等值检查到 recover 开始之间还有一次 await 边界,期间可能完成新登录或
+    // 切换数据归属。收口必须重新绑定被拒的那把 token,否则会对新账号强制刷新,
+    // 一个 invalid_grant 就把新账号登出了。
+    seedCredentials({ access_token: 'another-account-token', refresh_token: 'another-refresh' });
+    const fetchMock = vi.fn(async () => tokenResponse(400, { error: 'invalid_grant' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('superseded');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(readStored()?.access_token).toBe('another-account-token');
+  });
+
+  it('本地没有 refresh_token 时无从自愈,登出但不消耗冷却', async () => {
+    // unrecoverable ≠ rejected:前者请求都没发出去,冷却要还回去。
+    seedCredentials({ refresh_token: undefined });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('logged_out');
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(readStored()).toBeNull();
   });
 
@@ -138,7 +164,7 @@ describe('recoverGrokAuthAfterRejection', () => {
       }),
     );
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('superseded');
     // 新登录态必须原封不动。
     expect(readStored()?.access_token).toBe('relogin-access-token');
     expect(readStored()?.refresh_token).toBe('refresh-token-from-relogin');
@@ -155,7 +181,7 @@ describe('recoverGrokAuthAfterRejection', () => {
       }),
     );
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('superseded');
     expect(readStored()).toBeNull();
   });
 
@@ -171,7 +197,7 @@ describe('recoverGrokAuthAfterRejection', () => {
       ),
     );
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('unchanged');
     expect(readStored()?.access_token).toBe('rejected-access-token');
   });
 
@@ -179,14 +205,14 @@ describe('recoverGrokAuthAfterRejection', () => {
     seedCredentials();
     vi.stubGlobal('fetch', vi.fn(async () => tokenResponse(400, '<html>invalid_grant</html>')));
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('unchanged');
     expect(readStored()?.access_token).toBe('rejected-access-token');
   });
 
   it('5xx 与网络异常不误杀凭证', async () => {
     seedCredentials();
     vi.stubGlobal('fetch', vi.fn(async () => tokenResponse(503, { error: 'invalid_grant' })));
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('unchanged');
     expect(readStored()?.access_token).toBe('rejected-access-token');
 
     resetGrokOAuthMemoryCache();
@@ -196,7 +222,7 @@ describe('recoverGrokAuthAfterRejection', () => {
         throw new Error('network down');
       }),
     );
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('unchanged');
     expect(readStored()?.access_token).toBe('rejected-access-token');
   });
 
@@ -207,10 +233,10 @@ describe('recoverGrokAuthAfterRejection', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('refreshed');
-    // 403 若实为订阅/权限问题,刷新会一直"成功"却修不好;冷却挡住第二次,
-    // 否则每个请求都会消耗一次 refresh_token 轮换。
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('refreshed');
+    // 403 若实为订阅/权限问题,刷新会一直"成功"却修不好:换出来的新 token 一样被拒。
+    // 冷却必须挡住这一次,否则每个请求都会消耗一次 refresh_token 轮换。
+    await expect(recoverGrokAuthAfterRejection('fresh-access-token')).resolves.toBe('unchanged');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -240,7 +266,7 @@ describe('recoverGrokAuthAfterRejection', () => {
       ),
     );
 
-    const pending = recoverGrokAuthAfterRejection();
+    const pending = recoverGrokAuthAfterRejection(REJECTED_TOKEN);
     await inText;
     releaseText();
     // 推进两拍:`await res.text().catch(...)` 的 catch 派生一层 promise,所以 refreshBlob
@@ -270,7 +296,7 @@ describe('recoverGrokAuthAfterRejection', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     // 在刷新任务进入串行链之前登出:锁内重读拿到 null,直接 superseded,不发请求。
-    const pending = recoverGrokAuthAfterRejection();
+    const pending = recoverGrokAuthAfterRejection(REJECTED_TOKEN);
     logoutGrok();
     await expect(pending).resolves.toBe('superseded');
     expect(fetchMock).not.toHaveBeenCalled();
@@ -279,7 +305,7 @@ describe('recoverGrokAuthAfterRejection', () => {
     bound = true;
     seedCredentials({ access_token: 'second-access-token', refresh_token: 'refresh-token-v2' });
     resetGrokOAuthMemoryCache();
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('refreshed');
+    await expect(recoverGrokAuthAfterRejection('second-access-token')).resolves.toBe('refreshed');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -287,11 +313,11 @@ describe('recoverGrokAuthAfterRejection', () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('superseded');
 
     seedCredentials();
     bound = false;
-    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+    await expect(recoverGrokAuthAfterRejection(REJECTED_TOKEN)).resolves.toBe('superseded');
     expect(readStored()?.access_token).toBe('rejected-access-token');
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
@@ -214,6 +214,54 @@ describe('recoverGrokAuthAfterRejection', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('复核之后、登出之前完成的新登录不被误删', async () => {
+    // refreshBlob 内部那道复核到 logoutGrok() 之间隔着两次 await 恢复,进行中的 OAuth
+    // 登录足以插进来。这里用手工控制的 text() resolve 时机精确落在那个窗口里。
+    seedCredentials();
+    let enteredText!: () => void;
+    const inText = new Promise<void>((resolve) => {
+      enteredText = resolve;
+    });
+    let releaseText!: () => void;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 400,
+            text: () =>
+              new Promise<string>((resolve) => {
+                releaseText = () => resolve(JSON.stringify({ error: 'invalid_grant' }));
+                enteredText();
+              }),
+            json: async () => ({}),
+          }) as unknown as Response,
+      ),
+    );
+
+    const pending = recoverGrokAuthAfterRejection();
+    await inText;
+    releaseText();
+    // 推进两拍:`await res.text().catch(...)` 的 catch 派生一层 promise,所以 refreshBlob
+    // 内那道复核要到第二个 microtask 才跑完(此刻它看到的仍是旧凭证)。停在这里时
+    // recoverGrokAuthAfterRejection 尚未恢复到 switch —— 正是要覆盖的窗口。
+    await Promise.resolve();
+    await Promise.resolve();
+    store.set(
+      SECRET_ID,
+      JSON.stringify({
+        access_token: 'relogin-access-token',
+        refresh_token: 'refresh-token-from-relogin',
+        expires_at: Date.now() + 3600_000,
+      }),
+    );
+    resetGrokOAuthMemoryCache();
+
+    await expect(pending).resolves.toBe('superseded');
+    expect(readStored()?.access_token).toBe('relogin-access-token');
+  });
+
   it('superseded 没有真的刷新,不占用冷却窗口', async () => {
     seedCredentials();
     const fetchMock = vi.fn(async () =>

--- a/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
@@ -1,0 +1,229 @@
+/**
+ * recoverGrokAuthAfterRejection 回归单测 —— 上游拒绝 xAI access_token 后的凭证收口。
+ *
+ * 覆盖(内存 store + 注入 fetch,不联网、不触电 Electron):
+ *   - invalid_grant → 清凭证登出;
+ *   - **刷新在途时用户重新登录**:旧 refresh_token 的作废结论不得删掉新写入的凭证;
+ *   - 拒绝判定只认结构化 OAuth error 码,error_description 里的同名字样不触发登出;
+ *   - 网络/5xx 等临时失败保留登录态;
+ *   - 强制刷新冷却窗口,防 403 实为权限问题时每请求刷一次。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  shell: { openExternal: vi.fn() },
+  app: {
+    getPath: vi.fn(() => '/tmp/cindy-grok-recovery-test'),
+    getAppPath: vi.fn(() => '/tmp/cindy-grok-recovery-test/app'),
+    isPackaged: false,
+  },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false) },
+}));
+
+/** 内存凭证库替身 —— 绝不碰真实 safeStorage / userData。 */
+const store = new Map<string, string>();
+vi.mock('../../secrets/providerSecretStore.js', () => ({
+  getProviderSecretStore: () => ({
+    get: (id: string) => store.get(id) ?? null,
+    set: (id: string, value: string) => {
+      store.set(id, value);
+    },
+    remove: (id: string) => {
+      store.delete(id);
+    },
+  }),
+}));
+
+let bound = true;
+vi.mock('../nativeProviderAuthBinding.js', () => ({
+  isNativeProviderAuthBound: () => bound,
+  bindNativeProviderAuth: vi.fn(),
+  unbindNativeProviderAuth: vi.fn(() => {
+    bound = false;
+  }),
+}));
+
+import {
+  logoutGrok,
+  recoverGrokAuthAfterRejection,
+  resetGrokOAuthMemoryCache,
+} from '../grok-oauth-login.js';
+
+const SECRET_ID = 'xai';
+
+function seedCredentials(overrides: Record<string, unknown> = {}): void {
+  store.set(
+    SECRET_ID,
+    JSON.stringify({
+      access_token: 'rejected-access-token',
+      refresh_token: 'refresh-token-v1',
+      // 故意设成远未到期:被服务端提前作废的 token 本地看就是"没过期",
+      // 常规刷新永远不触发,只有强制路径能动它。
+      expires_at: Date.now() + 3600_000,
+      ...overrides,
+    }),
+  );
+}
+
+function readStored(): { access_token?: string; refresh_token?: string } | null {
+  const raw = store.get(SECRET_ID);
+  return raw ? (JSON.parse(raw) as { access_token?: string; refresh_token?: string }) : null;
+}
+
+function tokenResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  store.clear();
+  bound = true;
+  resetGrokOAuthMemoryCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('recoverGrokAuthAfterRejection', () => {
+  it('刷新成功即自愈,凭证换成新 token 且不登出', async () => {
+    seedCredentials();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        tokenResponse(200, {
+          access_token: 'fresh-access-token',
+          refresh_token: 'refresh-token-v2',
+          expires_in: 3600,
+        }),
+      ),
+    );
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('refreshed');
+    expect(readStored()?.access_token).toBe('fresh-access-token');
+  });
+
+  it('refresh_token 被服务端作废时清空凭证', async () => {
+    seedCredentials();
+    vi.stubGlobal('fetch', vi.fn(async () => tokenResponse(400, { error: 'invalid_grant' })));
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('logged_out');
+    expect(readStored()).toBeNull();
+  });
+
+  it('刷新在途时用户重新登录 —— 旧 invalid_grant 不得删掉新凭证', async () => {
+    seedCredentials();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        // 模拟这次刷新往返期间用户走完了一遍全新的 OAuth 登录:凭证库里已经是另一枚
+        // refresh_token。此时旧 token 的作废结论只对它自己成立。
+        // (真实登录路径经 writeBlob 落盘并刷新内存缓存,这里用 reset 等价模拟。)
+        store.set(
+          SECRET_ID,
+          JSON.stringify({
+            access_token: 'relogin-access-token',
+            refresh_token: 'refresh-token-from-relogin',
+            expires_at: Date.now() + 3600_000,
+          }),
+        );
+        resetGrokOAuthMemoryCache();
+        return tokenResponse(400, { error: 'invalid_grant' });
+      }),
+    );
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+    // 新登录态必须原封不动。
+    expect(readStored()?.access_token).toBe('relogin-access-token');
+    expect(readStored()?.refresh_token).toBe('refresh-token-from-relogin');
+  });
+
+  it('刷新在途时用户登出 —— 不得把凭证写回去', async () => {
+    seedCredentials();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        // 走真实登出路径:清凭证库 + 内存缓存 + 解绑,与用户点「登出」等价。
+        logoutGrok();
+        return tokenResponse(200, { access_token: 'late-access-token', expires_in: 3600 });
+      }),
+    );
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+    expect(readStored()).toBeNull();
+  });
+
+  it('只认结构化 OAuth error 码:error_description 里的同名字样不触发登出', async () => {
+    seedCredentials();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        tokenResponse(400, {
+          error: 'server_error',
+          error_description: 'upstream said invalid_grant while proxying',
+        }),
+      ),
+    );
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    expect(readStored()?.access_token).toBe('rejected-access-token');
+  });
+
+  it('非 JSON 错误体按临时失败处理,保留登录态', async () => {
+    seedCredentials();
+    vi.stubGlobal('fetch', vi.fn(async () => tokenResponse(400, '<html>invalid_grant</html>')));
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    expect(readStored()?.access_token).toBe('rejected-access-token');
+  });
+
+  it('5xx 与网络异常不误杀凭证', async () => {
+    seedCredentials();
+    vi.stubGlobal('fetch', vi.fn(async () => tokenResponse(503, { error: 'invalid_grant' })));
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    expect(readStored()?.access_token).toBe('rejected-access-token');
+
+    resetGrokOAuthMemoryCache();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    );
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    expect(readStored()?.access_token).toBe('rejected-access-token');
+  });
+
+  it('冷却窗口内不重复强制刷新', async () => {
+    seedCredentials();
+    const fetchMock = vi.fn(async () =>
+      tokenResponse(200, { access_token: 'fresh-access-token', expires_in: 3600 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('refreshed');
+    // 403 若实为订阅/权限问题,刷新会一直"成功"却修不好;冷却挡住第二次,
+    // 否则每个请求都会消耗一次 refresh_token 轮换。
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('unchanged');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('未登录 / 未绑定当前数据归属时不碰凭证', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+
+    seedCredentials();
+    bound = false;
+    await expect(recoverGrokAuthAfterRejection()).resolves.toBe('superseded');
+    expect(readStored()?.access_token).toBe('rejected-access-token');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/xaiBridgeAuthInvalidation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xaiBridgeAuthInvalidation.test.ts
@@ -70,7 +70,9 @@ describe('xAI bridge auth invalidation', () => {
       handleFailure({ status: 403, body: REJECTED_BODY, failedAccessToken: 'token-a' }),
     ).resolves.toBe('refreshed');
     expect(recover).toHaveBeenCalledOnce();
-    expect(recover).toHaveBeenCalledWith('access_token_rejected');
+    // 必须把被拒的 token 一并交给收口:等值检查到 recover 之间还有一次 await 边界,
+    // 收口要用它重新绑定,否则会拿期间新登录的凭证承担旧 token 的失败。
+    expect(recover).toHaveBeenCalledWith('access_token_rejected', 'token-a');
   });
 
   it('把 refresh_token 也被作废的结果原样回传', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/xaiBridgeAuthInvalidation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xaiBridgeAuthInvalidation.test.ts
@@ -1,0 +1,213 @@
+import { gzipSync } from 'node:zlib';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ResponseObserverCtx } from '@cindy/anthropic-compat-proxy';
+
+import {
+  createXaiAuthInvalidationObserver,
+  createXaiBridgeAuthInvalidator,
+  detectXaiBridgeAuthInvalidationReason,
+} from '../xai-bridge-auth-invalidation.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+/** api.x.ai 实测拒绝 OAuth 凭证时的真实响应体(2026-07)。 */
+const REJECTED_BODY =
+  '{"code":"unauthenticated:bad-credentials","error":"The OAuth2 access token could not be validated."}';
+
+describe('xAI bridge auth invalidation', () => {
+  it('只把认证状态码里的明确凭证作废信号分类为收口原因', () => {
+    expect(detectXaiBridgeAuthInvalidationReason(403, REJECTED_BODY)).toBe('access_token_rejected');
+    expect(detectXaiBridgeAuthInvalidationReason(401, REJECTED_BODY)).toBe('access_token_rejected');
+    expect(
+      detectXaiBridgeAuthInvalidationReason(403, 'The OAuth2 access token could not be validated.'),
+    ).toBe('access_token_rejected');
+  });
+
+  it('不把普通 4xx 当成凭证失效', () => {
+    // 不成形的 token 走 api.x.ai 另一条分支(400 invalid-argument),不是登录态问题。
+    expect(
+      detectXaiBridgeAuthInvalidationReason(
+        400,
+        '{"code":"invalid-argument","error":"Incorrect API key provided."}',
+      ),
+    ).toBeNull();
+    // 配额 / 地域 / 模型未授权类 403 不带凭证作废标记,不能据此删用户凭证。
+    expect(
+      detectXaiBridgeAuthInvalidationReason(403, '{"code":"permission-denied","error":"no access"}'),
+    ).toBeNull();
+    expect(detectXaiBridgeAuthInvalidationReason(429, REJECTED_BODY)).toBeNull();
+  });
+
+  it('非作废信号直接放行,不触碰凭证', async () => {
+    const recover = vi.fn(async () => 'refreshed' as const);
+    const getCurrentAccessToken = vi.fn(async () => 'token-a');
+    const handleFailure = createXaiBridgeAuthInvalidator({ getCurrentAccessToken, recover });
+
+    await expect(
+      handleFailure({ status: 429, body: REJECTED_BODY, failedAccessToken: 'token-a' }),
+    ).resolves.toBe('ignored');
+    expect(getCurrentAccessToken).not.toHaveBeenCalled();
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('当前凭证仍是失败 token 时执行收口', async () => {
+    const recover = vi.fn(async () => 'refreshed' as const);
+    const handleFailure = createXaiBridgeAuthInvalidator({
+      getCurrentAccessToken: async () => 'token-a',
+      recover,
+    });
+
+    await expect(
+      handleFailure({ status: 403, body: REJECTED_BODY, failedAccessToken: 'token-a' }),
+    ).resolves.toBe('refreshed');
+    expect(recover).toHaveBeenCalledOnce();
+    expect(recover).toHaveBeenCalledWith('access_token_rejected');
+  });
+
+  it('把 refresh_token 也被作废的结果原样回传', async () => {
+    const handleFailure = createXaiBridgeAuthInvalidator({
+      getCurrentAccessToken: async () => 'token-a',
+      recover: async () => 'logged_out',
+    });
+
+    await expect(
+      handleFailure({ status: 403, body: REJECTED_BODY, failedAccessToken: 'token-a' }),
+    ).resolves.toBe('logged_out');
+  });
+
+  it('忽略新登录后迟到的旧 token 失败', async () => {
+    const recover = vi.fn(async () => 'logged_out' as const);
+    const handleFailure = createXaiBridgeAuthInvalidator({
+      getCurrentAccessToken: async () => 'token-new',
+      recover,
+    });
+
+    await expect(
+      handleFailure({ status: 403, body: REJECTED_BODY, failedAccessToken: 'token-old' }),
+    ).resolves.toBe('superseded');
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('未登录(当前无凭证)时不执行收口', async () => {
+    const recover = vi.fn(async () => 'logged_out' as const);
+    const handleFailure = createXaiBridgeAuthInvalidator({
+      getCurrentAccessToken: async () => null,
+      recover,
+    });
+
+    await expect(
+      handleFailure({ status: 403, body: REJECTED_BODY, failedAccessToken: 'token-a' }),
+    ).resolves.toBe('superseded');
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('合并同一失败 token 的并发收口', async () => {
+    const currentToken = deferred<string | null>();
+    const recover = vi.fn(async () => 'refreshed' as const);
+    const getCurrentAccessToken = vi.fn(() => currentToken.promise);
+    const handleFailure = createXaiBridgeAuthInvalidator({ getCurrentAccessToken, recover });
+    const failure = {
+      status: 403,
+      body: REJECTED_BODY,
+      failedAccessToken: 'token-a',
+    };
+
+    const first = handleFailure(failure);
+    const second = handleFailure(failure);
+    currentToken.resolve('token-a');
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['refreshed', 'refreshed']);
+    expect(getCurrentAccessToken).toHaveBeenCalledOnce();
+    expect(recover).toHaveBeenCalledOnce();
+  });
+
+  it('收口结束后释放合并槽位,后续失败重新收口', async () => {
+    const recover = vi.fn(async () => 'unchanged' as const);
+    const handleFailure = createXaiBridgeAuthInvalidator({
+      getCurrentAccessToken: async () => 'token-a',
+      recover,
+    });
+    const failure = { status: 403, body: REJECTED_BODY, failedAccessToken: 'token-a' };
+
+    await handleFailure(failure);
+    await handleFailure(failure);
+
+    expect(recover).toHaveBeenCalledTimes(2);
+  });
+});
+
+function observerCtx(overrides: Partial<ResponseObserverCtx> = {}): ResponseObserverCtx {
+  return {
+    reqId: 1,
+    method: 'POST',
+    url: '/v1/responses',
+    upstreamBase: 'https://api.x.ai/v1',
+    status: 403,
+    requestHeaders: { authorization: 'Bearer token-a' },
+    responseHeaders: {},
+    requestBody: Buffer.alloc(0),
+    ...overrides,
+  };
+}
+
+describe('xAI codex-proxy auth invalidation observer', () => {
+  it('成功响应与非认证状态码零开销跳过', () => {
+    const handleFailure = vi.fn(async () => undefined);
+    const observe = createXaiAuthInvalidationObserver(handleFailure);
+
+    expect(observe(observerCtx({ status: 200 }))).toBeNull();
+    expect(observe(observerCtx({ status: 500 }))).toBeNull();
+    expect(handleFailure).not.toHaveBeenCalled();
+  });
+
+  it('非 xAI 上游不观察(避免误伤其它供应商凭证)', () => {
+    const observe = createXaiAuthInvalidationObserver(async () => undefined);
+
+    expect(observe(observerCtx({ upstreamBase: 'https://api.openai.com/v1' }))).toBeNull();
+    expect(observe(observerCtx({ upstreamBase: 'not-a-url' }))).toBeNull();
+  });
+
+  it('请求没有 Bearer 时不观察(无从关联失败凭证)', () => {
+    const observe = createXaiAuthInvalidationObserver(async () => undefined);
+
+    expect(observe(observerCtx({ requestHeaders: {} }))).toBeNull();
+    expect(observe(observerCtx({ requestHeaders: { authorization: 'Basic abc' } }))).toBeNull();
+  });
+
+  it('401/403 命中 xAI 上游时把响应体与失败凭证交给收口', () => {
+    const handleFailure = vi.fn(async () => undefined);
+    const observe = createXaiAuthInvalidationObserver(handleFailure);
+
+    const sink = observe(observerCtx());
+    expect(sink).not.toBeNull();
+    sink!.onData?.(Buffer.from(REJECTED_BODY, 'utf-8'));
+    sink!.onEnd?.();
+
+    expect(handleFailure).toHaveBeenCalledWith({
+      status: 403,
+      body: REJECTED_BODY,
+      failedAccessToken: 'token-a',
+    });
+  });
+
+  it('按 content-encoding 解压后再判定', () => {
+    const handleFailure = vi.fn(async () => undefined);
+    const observe = createXaiAuthInvalidationObserver(handleFailure);
+
+    const sink = observe(observerCtx({ responseHeaders: { 'content-encoding': 'gzip' } }));
+    sink!.onData?.(gzipSync(Buffer.from(REJECTED_BODY, 'utf-8')));
+    sink!.onEnd?.();
+
+    expect(handleFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ body: REJECTED_BODY }),
+    );
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/xaiBridgeAuthInvalidation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xaiBridgeAuthInvalidation.test.ts
@@ -8,6 +8,7 @@ import {
   createXaiAuthInvalidationObserver,
   createXaiBridgeAuthInvalidator,
   detectXaiBridgeAuthInvalidationReason,
+  type XaiBridgeAuthFailure,
 } from '../xai-bridge-auth-invalidation.js';
 
 function deferred<T>() {
@@ -151,7 +152,10 @@ function observerCtx(overrides: Partial<ResponseObserverCtx> = {}): ResponseObse
     url: '/v1/responses',
     upstreamBase: 'https://api.x.ai/v1',
     status: 403,
-    requestHeaders: { authorization: 'Bearer token-a' },
+    // 客户端(codex 子进程)自带的 bearer 与实际路由注入的 xAI token 刻意不同 ——
+    // 收口必须关联后者,读错就永远 superseded。
+    requestHeaders: { authorization: 'Bearer codex-subprocess-token' },
+    outboundHeaders: { authorization: 'Bearer token-a' },
     responseHeaders: {},
     requestBody: Buffer.alloc(0),
     ...overrides,
@@ -178,8 +182,39 @@ describe('xAI codex-proxy auth invalidation observer', () => {
   it('请求没有 Bearer 时不观察(无从关联失败凭证)', () => {
     const observe = createXaiAuthInvalidationObserver(async () => undefined);
 
-    expect(observe(observerCtx({ requestHeaders: {} }))).toBeNull();
-    expect(observe(observerCtx({ requestHeaders: { authorization: 'Basic abc' } }))).toBeNull();
+    expect(observe(observerCtx({ outboundHeaders: {} }))).toBeNull();
+    expect(observe(observerCtx({ outboundHeaders: { authorization: 'Basic abc' } }))).toBeNull();
+  });
+
+  it('关联的是路由注入后的凭证,不是子进程自带的 bearer', () => {
+    // 回归:xAI token 由 provider-route 经 headerOverride 注入,只有 outboundHeaders 里才有。
+    // 早期版本读 requestHeaders,拿到 codex 自带 bearer → 等值比对永远不成立 → 收口静默失效。
+    const handleFailure = vi.fn(async () => undefined);
+    const observe = createXaiAuthInvalidationObserver(handleFailure);
+
+    const sink = observe(observerCtx());
+    sink!.onData?.(Buffer.from(REJECTED_BODY, 'utf-8'));
+    sink!.onEnd?.();
+
+    expect(handleFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAccessToken: 'token-a' }),
+    );
+  });
+
+  it('超大 chunk 按剩余空间裁剪,不整段驻留', () => {
+    const seen: XaiBridgeAuthFailure[] = [];
+    const observe = createXaiAuthInvalidationObserver(async (failure) => {
+      seen.push(failure);
+    });
+
+    const sink = observe(observerCtx());
+    // 首个 chunk 就远超上限:必须只留下上限内的部分。
+    sink!.onData?.(Buffer.alloc(64 * 1024, 0x61));
+    sink!.onData?.(Buffer.alloc(8 * 1024, 0x62));
+    sink!.onEnd?.();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].body).toBe('a'.repeat(8 * 1024));
   });
 
   it('401/403 命中 xAI 上游时把响应体与失败凭证交给收口', () => {

--- a/apps/desktop/src/main/maker-host/anthropic-responses-bridge-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-responses-bridge-host.ts
@@ -26,6 +26,7 @@ import { createResponsesHandler, type BridgeProviderConfig, type ResponsesBridge
 
 import { createMakerLogger } from './logger-adapter.js';
 import { getGrokAccessToken } from './grok-oauth-login.js';
+import { invalidateXaiBridgeAuth } from './xai-auth-invalidation-host.js';
 import { chatgptAccountIdFromIdToken, desktopCodexAuthAdapter } from './auth-adapters.js';
 import {
   bearerAccessTokenFromHeaders,
@@ -285,6 +286,14 @@ function xaiProviderConfig(): BridgeProviderConfig {
     // api.x.ai 无 ChatGPT 那种订阅窗口端点;尽力抓响应头 x-ratelimit-* 给底部 chip 展示,
     // 拿不到(上游不返头)则 renderer 诚实降级为仅价值估算。
     onRateLimit: (info) => recordXaiRateLimitSnapshot(info),
+    // 上游判定 OAuth 凭证失效时收口本地登录态。缺这一步的话:token 被服务端提前作废后
+    // 本地 expires_at 仍未到期 → 永不刷新 → 每次请求都 403,而「设置 → 模型供应商」还
+    // 一直显示已连接,用户没有任何线索该去重连。
+    onUpstreamError: async ({ status, body, requestHeaders }) => {
+      const failedAccessToken = bearerAccessTokenFromHeaders(requestHeaders);
+      if (!failedAccessToken) return;
+      await invalidateXaiBridgeAuth({ status, body, failedAccessToken });
+    },
   };
 }
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -59,6 +59,7 @@ import {
 import { getSessionProvider } from './session-provider-store.js';
 import { composeResponseObservers } from './claude-rate-limit-headers-observer.js';
 import { createProviderUpstreamErrorObserver, reportProviderUpstreamError } from './provider-upstream-error-observer.js';
+import { createXaiProxyAuthInvalidationObserver } from './xai-auth-invalidation-host.js';
 import { encryptedStripController, imageGenerationStripController } from './thread-strip-controllers.js';
 import { createMakerLogger } from './logger-adapter.js';
 import { resolveDesktopOutboundProxy } from './outbound-proxy-resolver.js';
@@ -1411,8 +1412,9 @@ export async function ensureCodexProxyReady(): Promise<void> {
         upstream: () => buildCodexGatewayBaseUrl(),
         transformRequest: createTransformRequestChain(),
         routingTransform: createModelRoutingTransform(),
-        // 组合两个只读观察器:service-tier 抽取 + 自定义供应商上游错误分类广播
-        // (后者仅 status≥400 且会话路由到 user 供应商时才 tee,成功路径零开销)。
+        // 组合三个只读观察器:service-tier 抽取 + 自定义供应商上游错误分类广播 + xAI 凭证
+        // 失效收口(后两者分别仅在 status≥400 路由到 user 供应商、401/403 且上游为 api.x.ai
+        // 时才 tee,成功路径零开销)。
         responseObserver: composeResponseObservers(
           createCodexResponseObserver(),
           createProviderUpstreamErrorObserver({
@@ -1425,6 +1427,9 @@ export async function ensureCodexProxyReady(): Promise<void> {
             resolveUserProviderName: (providerId) =>
               getActiveCatalog().providers.find((provider) => provider.id === providerId)?.name ?? null,
           }),
+          // xai 是 builtin 来源,上面那个 observer 的 user-only 语义覆盖不到它;订阅 OAuth
+          // 被上游作废后必须有人收口,否则 codex agent 下会连环 403 而 UI 仍显示已连接。
+          createXaiProxyAuthInvalidationObserver(),
         ),
         maxRequestBodyBytes: CODEX_PROXY_MAX_REQUEST_BODY_BYTES,
         // 请求体 dump 默认关(dev trace 级别 + agent 高并发会刷爆 main event loop

--- a/apps/desktop/src/main/maker-host/grok-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/grok-oauth-login.ts
@@ -764,7 +764,7 @@ export async function recoverGrokAuthAfterRejection(): Promise<XaiBridgeAuthReco
   // 先占位再刷:并发进来的其它 token 不该同时发起强制刷新。
   const previousForcedRefreshAt = _lastForcedRefreshAt;
   _lastForcedRefreshAt = now;
-  const { outcome } = await refreshBlob(blob, true);
+  const { blob: attempted, outcome } = await refreshBlob(blob, true);
   switch (outcome) {
     case 'refreshed':
       log.info('xai access_token 被上游拒绝,已强制刷新恢复');
@@ -775,10 +775,19 @@ export async function recoverGrokAuthAfterRejection(): Promise<XaiBridgeAuthReco
       // 仅在占位仍是自己写的时候回滚,避免覆盖期间另一次真实刷新的时间戳。
       if (_lastForcedRefreshAt === now) _lastForcedRefreshAt = previousForcedRefreshAt;
       return 'superseded';
-    case 'rejected':
+    case 'rejected': {
+      // refreshBlob 内部那道复核到这里还隔着两次 await 恢复(锁链 await + 本函数 await),
+      // 足够让一次进行中的 OAuth 登录把新凭证写进来。删凭证是不可逆动作,登出前再复核一次:
+      // 不是同一枚 refresh_token 就说明作废结论已经过期,按 superseded 放过。
+      // 冷却不回滚 —— 这一路确实发出了刷新请求,轮换已经消耗掉了。
+      const currentBlob = readBlob();
+      if (currentBlob === null || currentBlob.refresh_token !== attempted.refresh_token) {
+        return 'superseded';
+      }
       log.warn('xai refresh_token 已被服务端作废,清空本机凭证并回落未登录');
       logoutGrok();
       return 'logged_out';
+    }
     default:
       // failed / skipped:刷新没成功但也没有作废证据,保留凭证等下次。
       return 'unchanged';

--- a/apps/desktop/src/main/maker-host/grok-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/grok-oauth-login.ts
@@ -586,14 +586,34 @@ function isExpired(b: GrokTokenBlob): boolean {
 }
 
 /**
- * 一次刷新尝试的结局。`rejected` 专指服务端明确作废 refresh_token(OAuth `invalid_grant`
- * 家族),是唯一允许据此清空本机凭证的信号;网络抖动、5xx、超时一律 `failed`,保留凭证。
+ * 一次刷新尝试的结局。
+ *
+ * - `rejected` **专指**服务端以 OAuth `invalid_grant` 家族明确作废了 refresh_token;
+ * - `unrecoverable` 是本地根本没有 refresh_token(请求都没发出去)—— 与 `rejected` 后果
+ *   相同(只能重新登录),但成因完全不同,不能混成一个值,否则调用方会把「本地缺凭证」
+ *   读成「服务端作废凭证」;
+ * - 网络抖动、5xx、超时一律 `failed`,保留凭证。
  */
-type GrokRefreshOutcome = 'refreshed' | 'skipped' | 'superseded' | 'rejected' | 'failed';
+type GrokRefreshOutcome =
+  | 'refreshed'
+  | 'skipped'
+  | 'superseded'
+  | 'rejected'
+  | 'unrecoverable'
+  | 'failed';
 
 interface GrokRefreshResult {
   blob: GrokTokenBlob;
   outcome: GrokRefreshOutcome;
+}
+
+/** 凭证库里的当前值是否仍是本次收口开始时那一份(access + refresh 都没被换过)。 */
+function isSameCredential(current: GrokTokenBlob | null, attempted: GrokTokenBlob): boolean {
+  return (
+    current !== null
+    && current.access_token === attempted.access_token
+    && current.refresh_token === attempted.refresh_token
+  );
 }
 
 /**
@@ -627,8 +647,8 @@ function isRefreshRejection(status: number, body: string): boolean {
 async function refreshBlob(current: GrokTokenBlob, force: boolean): Promise<GrokRefreshResult> {
   if (!force && !isExpired(current)) return { blob: current, outcome: 'skipped' };
   if (!current.refresh_token) {
-    // 强制路径下没有 refresh_token = 无从自愈,交给调用方按「已作废」登出。
-    return { blob: current, outcome: force ? 'rejected' : 'skipped' };
+    // 强制路径下没有 refresh_token = 无从自愈(请求都没发出去),交给调用方处理。
+    return { blob: current, outcome: force ? 'unrecoverable' : 'skipped' };
   }
   // 下面的 catch 吞掉异常(超时 / 网络)时保留这个初值:强制路径当临时失败,不误杀凭证。
   let result: GrokRefreshResult = { blob: current, outcome: force ? 'failed' : 'skipped' };
@@ -650,7 +670,7 @@ async function refreshBlob(current: GrokTokenBlob, force: boolean): Promise<Grok
     }
     const refreshToken = fresh.refresh_token;
     if (!refreshToken) {
-      result = { blob: fresh, outcome: force ? 'rejected' : 'skipped' };
+      result = { blob: fresh, outcome: force ? 'unrecoverable' : 'skipped' };
       return;
     }
     // 刷新路径只需 token endpoint，直接用常量，避免 OIDC discovery fetch 挂起整条 _refreshChain。
@@ -750,12 +770,20 @@ export function peekGrokAccessToken(): string | null {
  * expires_at 上仍"没到期",常规刷新永远不会触发。所以这里强制刷一次:刷得动就自愈,
  * refresh_token 也被作废才登出。网络或临时失败保留登录态 —— 宁可下次再撞一次 403,
  * 也不要因为一次抖动把用户踢下线。
+ *
+ * @param rejectedAccessToken 上游拒掉的那把 access_token。**必须传**:invalidator 那边
+ *   的等值检查到这里还隔着一次 await 边界,期间可能完成新登录或切换数据归属;不重新绑定
+ *   就会拿新账号的凭证去承担旧 token 的失败,一个 invalid_grant 就能把新账号登出。
  */
-export async function recoverGrokAuthAfterRejection(): Promise<XaiBridgeAuthRecoveryOutcome> {
+export async function recoverGrokAuthAfterRejection(
+  rejectedAccessToken: string,
+): Promise<XaiBridgeAuthRecoveryOutcome> {
   // 与 getGrokAccessToken 同一道 owner 门:未绑定当前数据归属时不碰凭证。
   if (!isNativeProviderAuthBound('xai')) return 'superseded';
   const blob = readBlob();
   if (!blob) return 'superseded';
+  // 重新绑定到被拒的那把 token(见 @param):不是同一把就说明这次失败已经与当前登录态无关。
+  if (blob.access_token !== rejectedAccessToken) return 'superseded';
   // 冷却:同样是 401/403,也可能是订阅缺失、地域或模型未授权 —— 那种情况 token 本身有效,
   // 刷新永远"成功"却永远修不好,不设窗口就会每个请求刷一次,空耗 refresh_token 轮换,
   // 甚至撞上服务端的刷新复用检测。一个窗口只允许自愈一次,不行就让错误如实暴露给用户。
@@ -775,16 +803,24 @@ export async function recoverGrokAuthAfterRejection(): Promise<XaiBridgeAuthReco
       // 仅在占位仍是自己写的时候回滚,避免覆盖期间另一次真实刷新的时间戳。
       if (_lastForcedRefreshAt === now) _lastForcedRefreshAt = previousForcedRefreshAt;
       return 'superseded';
-    case 'rejected': {
+    case 'rejected':
+    case 'unrecoverable': {
+      // 两者后果相同(只能重新登录),成因不同:rejected = 服务端作废 refresh_token;
+      // unrecoverable = 本地压根没有 refresh_token,连请求都没发。
+      //
       // refreshBlob 内部那道复核到这里还隔着两次 await 恢复(锁链 await + 本函数 await),
       // 足够让一次进行中的 OAuth 登录把新凭证写进来。删凭证是不可逆动作,登出前再复核一次:
-      // 不是同一枚 refresh_token 就说明作废结论已经过期,按 superseded 放过。
-      // 冷却不回滚 —— 这一路确实发出了刷新请求,轮换已经消耗掉了。
+      // 凭证已被换过就说明这个结论已经过期,按 superseded 放过。
       const currentBlob = readBlob();
-      if (currentBlob === null || currentBlob.refresh_token !== attempted.refresh_token) {
-        return 'superseded';
+      if (!isSameCredential(currentBlob, attempted)) return 'superseded';
+      if (outcome === 'unrecoverable') {
+        // 没发出请求,冷却还回去 —— 否则用户重登前的每次失败都白等一个窗口。
+        if (_lastForcedRefreshAt === now) _lastForcedRefreshAt = previousForcedRefreshAt;
+        log.warn('xai 凭证缺少 refresh_token,无从自愈,清空本机凭证并回落未登录');
+      } else {
+        // 冷却不回滚 —— 这一路确实发出了刷新请求,轮换已经消耗掉了。
+        log.warn('xai refresh_token 已被服务端作废,清空本机凭证并回落未登录');
       }
-      log.warn('xai refresh_token 已被服务端作废,清空本机凭证并回落未登录');
       logoutGrok();
       return 'logged_out';
     }

--- a/apps/desktop/src/main/maker-host/grok-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/grok-oauth-login.ts
@@ -32,6 +32,7 @@ import {
 import { desktopMakerLogger } from './logger-adapter.js';
 import { getProviderSecretStore } from '../secrets/providerSecretStore.js';
 import { bindNativeProviderAuth, isNativeProviderAuthBound, unbindNativeProviderAuth } from './nativeProviderAuthBinding.js';
+import type { XaiBridgeAuthRecoveryOutcome } from './xai-bridge-auth-invalidation.js';
 
 const log = desktopMakerLogger.child('grok-oauth-login');
 
@@ -86,6 +87,7 @@ let _blobCache: GrokTokenBlob | null | undefined;
 export function resetGrokOAuthMemoryCache(): void {
   _blobCache = undefined;
   _refreshChain = Promise.resolve();
+  _lastForcedRefreshAt = 0;
 }
 
 function readBlob(): GrokTokenBlob | null {
@@ -124,6 +126,8 @@ export function hasGrokOAuthLoginUnbound(): boolean {
 export function logoutGrok(): void {
   getProviderSecretStore().remove(SECRET_ID);
   _blobCache = null;
+  // 冷却窗口跟着登录态走:重新登录后第一次被拒仍应立刻尝试自愈。
+  _lastForcedRefreshAt = 0;
   unbindNativeProviderAuth('xai');
 }
 
@@ -571,28 +575,73 @@ export function cancelGrokOAuthLogin(): void {
 // ── token 刷新(bridge 每请求经 getGrokAccessToken 取用)────────────────────────
 let _refreshChain: Promise<void> = Promise.resolve();
 
+/** 被上游拒绝后强制刷新的冷却窗口(见 recoverGrokAuthAfterRejection 的说明)。 */
+const FORCED_REFRESH_COOLDOWN_MS = 60_000;
+let _lastForcedRefreshAt = 0;
+
 function isExpired(b: GrokTokenBlob): boolean {
-  if (!b.expires_at) return false; // 无 expiry 信息 → 不主动刷,靠 401 暴露
+  // 无 expiry 信息 → 不主动刷;真失效时由上游 401/403 经 recoverGrokAuthAfterRejection 收口。
+  if (!b.expires_at) return false;
   return Date.now() >= b.expires_at - REFRESH_MARGIN_SEC * 1000;
 }
 
-async function refreshIfNeeded(current: GrokTokenBlob): Promise<GrokTokenBlob> {
-  if (!isExpired(current) || !current.refresh_token) return current;
-  let result = current;
+/**
+ * 一次刷新尝试的结局。`rejected` 专指服务端明确作废 refresh_token(OAuth `invalid_grant`
+ * 家族),是唯一允许据此清空本机凭证的信号;网络抖动、5xx、超时一律 `failed`,保留凭证。
+ */
+type GrokRefreshOutcome = 'refreshed' | 'skipped' | 'superseded' | 'rejected' | 'failed';
+
+interface GrokRefreshResult {
+  blob: GrokTokenBlob;
+  outcome: GrokRefreshOutcome;
+}
+
+/**
+ * 服务端明确作废**用户凭证**的信号:再刷也不会好,只能重新登录。
+ *
+ * 只认 invalid_grant 家族(RFC 6749 里 refresh_token 失效/被撤销/被复用的标准回答)。
+ * 刻意不认 invalid_client / unauthorized_client —— 那是 client 注册侧的问题,把它当作废
+ * 会在 xAI 调整 client 配置时把所有人一起登出,而重新登录同样失败,只会更糟。
+ */
+function isRefreshRejection(status: number, body: string): boolean {
+  if (status < 400 || status >= 500) return false;
+  return /invalid_grant|invalid_token/i.test(body);
+}
+
+/**
+ * 刷新 access_token。
+ *
+ * @param force 忽略本地 expires_at 直接刷。上游已经拒了当前 token 时必须强制:被服务端
+ *   提前作废的 token 在本地看仍"没到期",不强制就永远刷不动 —— 这正是 403 长期无人
+ *   收口时用户卡在「UI 显示已连接、请求连环失败」的根因。
+ */
+async function refreshBlob(current: GrokTokenBlob, force: boolean): Promise<GrokRefreshResult> {
+  if (!force && !isExpired(current)) return { blob: current, outcome: 'skipped' };
+  if (!current.refresh_token) {
+    // 强制路径下没有 refresh_token = 无从自愈,交给调用方按「已作废」登出。
+    return { blob: current, outcome: force ? 'rejected' : 'skipped' };
+  }
+  // 下面的 catch 吞掉异常(超时 / 网络)时保留这个初值:强制路径当临时失败,不误杀凭证。
+  let result: GrokRefreshResult = { blob: current, outcome: force ? 'failed' : 'skipped' };
   const run = _refreshChain.then(async () => {
     const fresh = readBlob();
     if (fresh === null) {
       // 刷新期间用户已登出(blob 被清空)——不写回,让本次请求用旧 token 自然失败。
-      result = current;
+      result = { blob: current, outcome: 'superseded' };
       return;
     }
-    if (!isExpired(fresh)) {
-      result = fresh;
+    // 强制路径:其它请求或重新登录已经换过 token,本次失败关联的是旧凭证,不再消耗一次轮换。
+    if (force && fresh.access_token !== current.access_token) {
+      result = { blob: fresh, outcome: 'superseded' };
+      return;
+    }
+    if (!force && !isExpired(fresh)) {
+      result = { blob: fresh, outcome: 'skipped' };
       return;
     }
     const refreshToken = fresh.refresh_token;
     if (!refreshToken) {
-      result = fresh;
+      result = { blob: fresh, outcome: force ? 'rejected' : 'skipped' };
       return;
     }
     // 刷新路径只需 token endpoint，直接用常量，避免 OIDC discovery fetch 挂起整条 _refreshChain。
@@ -609,13 +658,16 @@ async function refreshIfNeeded(current: GrokTokenBlob): Promise<GrokTokenBlob> {
       signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
-      log.warn('xai token 刷新失败', { status: res.status });
-      result = fresh;
+      // body 只用于判定作废信号,不入日志 —— 错误响应可能回显授权材料。
+      const body = await res.text().catch(() => '');
+      const rejected = isRefreshRejection(res.status, body);
+      log.warn('xai token 刷新失败', { status: res.status, rejected });
+      result = { blob: fresh, outcome: rejected ? 'rejected' : 'failed' };
       return;
     }
     const tok = (await res.json()) as TokenResponse;
     if (!tok.access_token) {
-      result = fresh;
+      result = { blob: fresh, outcome: 'failed' };
       return;
     }
     const next = blobFromTokenResponse(tok, fresh);
@@ -624,21 +676,26 @@ async function refreshIfNeeded(current: GrokTokenBlob): Promise<GrokTokenBlob> {
     // 丢弃本次刷新结果。
     const beforeWrite = readBlob();
     if (beforeWrite === null) {
-      result = fresh;
+      result = { blob: fresh, outcome: 'superseded' };
       return;
     }
     if (beforeWrite.refresh_token !== refreshToken) {
-      result = beforeWrite;
+      result = { blob: beforeWrite, outcome: 'superseded' };
       return;
     }
     writeBlob(next);
-    result = next;
+    result = { blob: next, outcome: 'refreshed' };
   });
   _refreshChain = run.catch(() => undefined);
   await run.catch((err) =>
     log.warn('xai token 刷新异常', { err: err instanceof Error ? err.message : String(err) }),
   );
   return result;
+}
+
+/** 到期才刷的常规路径(getGrokAccessToken 用);强制刷新走 refreshBlob(blob, true)。 */
+async function refreshIfNeeded(current: GrokTokenBlob): Promise<GrokTokenBlob> {
+  return (await refreshBlob(current, false)).blob;
 }
 
 /**
@@ -654,4 +711,51 @@ export async function getGrokAccessToken(): Promise<string> {
   const fresh = await refreshIfNeeded(blob);
   if (!fresh.access_token) throw new Error('xAI access_token 不可用,请重新登录');
   return fresh.access_token;
+}
+
+/**
+ * 只读当前 access_token:不刷新、不抛错、未登录返回 null。
+ *
+ * 失效收口用它把上游失败与「当时确实发出去的那把凭证」做等值关联 —— 换成
+ * getGrokAccessToken 会顺带触发刷新,反而改变了要比对的状态。
+ */
+export function peekGrokAccessToken(): string | null {
+  if (!isNativeProviderAuthBound('xai')) return null;
+  return readBlob()?.access_token ?? null;
+}
+
+/**
+ * 上游(api.x.ai)明确拒绝当前 access_token 后的凭证收口。
+ *
+ * xAI 没有子进程替我们维护凭证(见文件头注),而被服务端提前作废的 token 在本地
+ * expires_at 上仍"没到期",常规刷新永远不会触发。所以这里强制刷一次:刷得动就自愈,
+ * refresh_token 也被作废才登出。网络或临时失败保留登录态 —— 宁可下次再撞一次 403,
+ * 也不要因为一次抖动把用户踢下线。
+ */
+export async function recoverGrokAuthAfterRejection(): Promise<XaiBridgeAuthRecoveryOutcome> {
+  // 与 getGrokAccessToken 同一道 owner 门:未绑定当前数据归属时不碰凭证。
+  if (!isNativeProviderAuthBound('xai')) return 'superseded';
+  const blob = readBlob();
+  if (!blob) return 'superseded';
+  // 冷却:同样是 401/403,也可能是订阅缺失、地域或模型未授权 —— 那种情况 token 本身有效,
+  // 刷新永远"成功"却永远修不好,不设窗口就会每个请求刷一次,空耗 refresh_token 轮换,
+  // 甚至撞上服务端的刷新复用检测。一个窗口只允许自愈一次,不行就让错误如实暴露给用户。
+  const now = Date.now();
+  if (now - _lastForcedRefreshAt < FORCED_REFRESH_COOLDOWN_MS) return 'unchanged';
+  _lastForcedRefreshAt = now;
+  const { outcome } = await refreshBlob(blob, true);
+  switch (outcome) {
+    case 'refreshed':
+      log.info('xai access_token 被上游拒绝,已强制刷新恢复');
+      return 'refreshed';
+    case 'superseded':
+      return 'superseded';
+    case 'rejected':
+      log.warn('xai refresh_token 已被服务端作废,清空本机凭证并回落未登录');
+      logoutGrok();
+      return 'logged_out';
+    default:
+      // failed / skipped:刷新没成功但也没有作废证据,保留凭证等下次。
+      return 'unchanged';
+  }
 }

--- a/apps/desktop/src/main/maker-host/grok-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/grok-oauth-login.ts
@@ -761,6 +761,8 @@ export async function recoverGrokAuthAfterRejection(): Promise<XaiBridgeAuthReco
   // 甚至撞上服务端的刷新复用检测。一个窗口只允许自愈一次,不行就让错误如实暴露给用户。
   const now = Date.now();
   if (now - _lastForcedRefreshAt < FORCED_REFRESH_COOLDOWN_MS) return 'unchanged';
+  // 先占位再刷:并发进来的其它 token 不该同时发起强制刷新。
+  const previousForcedRefreshAt = _lastForcedRefreshAt;
   _lastForcedRefreshAt = now;
   const { outcome } = await refreshBlob(blob, true);
   switch (outcome) {
@@ -768,6 +770,10 @@ export async function recoverGrokAuthAfterRejection(): Promise<XaiBridgeAuthReco
       log.info('xai access_token 被上游拒绝,已强制刷新恢复');
       return 'refreshed';
     case 'superseded':
+      // superseded = 排队期间凭证已被换掉或清空,这次**根本没发起刷新**,占位要还回去:
+      // 不还的话,紧接着被拒的那枚新 token 会被冷却挡住,最多 60s 无法自愈。
+      // 仅在占位仍是自己写的时候回滚,避免覆盖期间另一次真实刷新的时间戳。
+      if (_lastForcedRefreshAt === now) _lastForcedRefreshAt = previousForcedRefreshAt;
       return 'superseded';
     case 'rejected':
       log.warn('xai refresh_token 已被服务端作废,清空本机凭证并回落未登录');

--- a/apps/desktop/src/main/maker-host/grok-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/grok-oauth-login.ts
@@ -599,13 +599,22 @@ interface GrokRefreshResult {
 /**
  * 服务端明确作废**用户凭证**的信号:再刷也不会好,只能重新登录。
  *
- * 只认 invalid_grant 家族(RFC 6749 里 refresh_token 失效/被撤销/被复用的标准回答)。
- * 刻意不认 invalid_client / unauthorized_client —— 那是 client 注册侧的问题,把它当作废
- * 会在 xAI 调整 client 配置时把所有人一起登出,而重新登录同样失败,只会更糟。
+ * 只认 RFC 6749 §5.2 的结构化 `error` 码,不对整个响应体做子串匹配 —— `error_description`
+ * 之类的自由文本里出现同样字样并不代表 refresh_token 被作废,上游改一句文案就把用户登出
+ * 是不可接受的。非 JSON 或读不出 error 码时一律按临时失败处理(保留凭证)。
+ *
+ * 只认 invalid_grant 家族。刻意不认 invalid_client / unauthorized_client —— 那是 client
+ * 注册侧的问题,把它当作废会在 xAI 调整 client 配置时把所有人一起登出,而重新登录同样失败。
  */
 function isRefreshRejection(status: number, body: string): boolean {
   if (status < 400 || status >= 500) return false;
-  return /invalid_grant|invalid_token/i.test(body);
+  let code: unknown;
+  try {
+    code = (JSON.parse(body) as { error?: unknown }).error;
+  } catch {
+    return false;
+  }
+  return code === 'invalid_grant' || code === 'invalid_token';
 }
 
 /**
@@ -662,6 +671,16 @@ async function refreshBlob(current: GrokTokenBlob, force: boolean): Promise<Grok
       const body = await res.text().catch(() => '');
       const rejected = isRefreshRejection(res.status, body);
       log.warn('xai token 刷新失败', { status: res.status, rejected });
+      if (rejected) {
+        // 与成功路径同一道复核(见下方 beforeWrite):作废结论只对**发起本次刷新的那枚**
+        // refresh_token 成立。fetch 期间用户可能已登出或重新登录 —— 此时凭证库里是另一枚
+        // 全新的 refresh_token,拿旧的 invalid_grant 去 logoutGrok 会当场删掉刚建立的登录态。
+        const currentBlob = readBlob();
+        if (currentBlob === null || currentBlob.refresh_token !== refreshToken) {
+          result = { blob: currentBlob ?? fresh, outcome: 'superseded' };
+          return;
+        }
+      }
       result = { blob: fresh, outcome: rejected ? 'rejected' : 'failed' };
       return;
     }

--- a/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
+++ b/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
@@ -91,8 +91,11 @@ export function reportProviderUpstreamError(params: {
   });
 }
 
-/** 按 content-encoding 解压错误体（与 proxy 包 debug dump 的解压语义一致；失败回退原文）。 */
-function decodeBody(buf: Buffer, encoding: string | undefined): string {
+/**
+ * 按 content-encoding 解压错误体（与 proxy 包 debug dump 的解压语义一致；失败回退原文）。
+ * 导出供其它 responseObserver 复用（如 xai 凭证收口），解压语义单点维护。
+ */
+export function decodeUpstreamErrorBody(buf: Buffer, encoding: string | undefined): string {
   try {
     if (encoding === 'gzip') return gunzipSync(buf).toString('utf-8');
     if (encoding === 'br') return brotliDecompressSync(buf).toString('utf-8');
@@ -146,7 +149,7 @@ export function createProviderUpstreamErrorObserver(
       },
       onEnd: () => {
         const encoding = ctx.responseHeaders['content-encoding'];
-        const bodyText = decodeBody(
+        const bodyText = decodeUpstreamErrorBody(
           Buffer.concat(chunks, Math.min(size, MAX_ERROR_BODY_BYTES)),
           typeof encoding === 'string' ? encoding : undefined,
         );

--- a/apps/desktop/src/main/maker-host/xai-auth-invalidation-host.ts
+++ b/apps/desktop/src/main/maker-host/xai-auth-invalidation-host.ts
@@ -1,0 +1,50 @@
+/**
+ * xai-auth-invalidation-host —— xAI 凭证失效收口的 host 接线(单例)。
+ *
+ * claude-code(anthropic-responses-bridge 的 onUpstreamError)与 codex(codex-proxy 的
+ * responseObserver)两条链路必须共用同一个 invalidator 实例:并发合并是按 failed token
+ * 做的,各建一个实例就会各刷各的,把 refresh_token 的轮换互相作废。
+ */
+
+import { peekGrokAccessToken, recoverGrokAuthAfterRejection } from './grok-oauth-login.js';
+import {
+  createXaiAuthInvalidationObserver,
+  createXaiBridgeAuthInvalidator,
+} from './xai-bridge-auth-invalidation.js';
+
+/**
+ * 凭证被作废并清空后的 UI 收尾(bootstrap 注入)。
+ *
+ * 用注入而不是直接 import maker-host/index 的 broadcast:那条路会在
+ * index → proxy host → 本模块 之间成环。与 claude adapter 的
+ * setOnInvalidatedBroadcast / setClaudeOAuthInvalidGrantHandler 同一模式。
+ */
+let _onLoggedOut: () => void = () => {};
+export function setXaiAuthInvalidatedHandler(cb: () => void): void {
+  _onLoggedOut = cb;
+}
+
+/** 全局唯一的 xAI 凭证收口入口(两条 agent 链路共用)。 */
+export const invalidateXaiBridgeAuth = createXaiBridgeAuthInvalidator({
+  getCurrentAccessToken: async () => peekGrokAccessToken(),
+  recover: async () => {
+    const outcome = await recoverGrokAuthAfterRejection();
+    // 自动登出必须和手动登出一样即时反映到 UI,否则用户仍停在「显示已连接」的假状态 ——
+    // 那正是本模块要消灭的东西。广播失败不影响凭证收口结论。
+    if (outcome === 'logged_out') {
+      try {
+        _onLoggedOut();
+      } catch {
+        /* 广播是尽力而为:UI 最迟在下次 listProviders 现读时纠正 */
+      }
+    }
+    return outcome;
+  },
+});
+
+/** codex proxy 的 responseObserver 接线(与上面同一个 invalidator)。 */
+export function createXaiProxyAuthInvalidationObserver(): ReturnType<
+  typeof createXaiAuthInvalidationObserver
+> {
+  return createXaiAuthInvalidationObserver(invalidateXaiBridgeAuth);
+}

--- a/apps/desktop/src/main/maker-host/xai-auth-invalidation-host.ts
+++ b/apps/desktop/src/main/maker-host/xai-auth-invalidation-host.ts
@@ -27,8 +27,8 @@ export function setXaiAuthInvalidatedHandler(cb: () => void): void {
 /** 全局唯一的 xAI 凭证收口入口(两条 agent 链路共用)。 */
 export const invalidateXaiBridgeAuth = createXaiBridgeAuthInvalidator({
   getCurrentAccessToken: async () => peekGrokAccessToken(),
-  recover: async () => {
-    const outcome = await recoverGrokAuthAfterRejection();
+  recover: async (_reason, failedAccessToken) => {
+    const outcome = await recoverGrokAuthAfterRejection(failedAccessToken);
     // 自动登出必须和手动登出一样即时反映到 UI,否则用户仍停在「显示已连接」的假状态 ——
     // 那正是本模块要消灭的东西。广播失败不影响凭证收口结论。
     if (outcome === 'logged_out') {

--- a/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
+++ b/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
@@ -144,9 +144,12 @@ export function createXaiAuthInvalidationObserver(
       onData: (chunk: Buffer) => {
         // 按剩余空间裁剪后再缓存:上游可能一个 chunk 就远超上限,整段留到 onEnd 会把
         // 大 Buffer 一直挂住(判定只需要开头的 code/error 字段)。
+        // 超限时必须 Buffer.from 拷贝而不是只取 subarray —— 后者是共享底层内存的视图,
+        // 留着它等于留着整段原始 chunk,起不到限量的作用。
         const remaining = MAX_ERROR_BODY_BYTES - size;
         if (remaining <= 0) return;
-        const slice = chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+        const slice =
+          chunk.length > remaining ? Buffer.from(chunk.subarray(0, remaining)) : chunk;
         chunks.push(slice);
         size += slice.length;
       },

--- a/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
+++ b/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
@@ -1,0 +1,159 @@
+/**
+ * xai-bridge-auth-invalidation —— api.x.ai 拒绝订阅 OAuth 凭证后的失效收口(纯逻辑)。
+ *
+ * 与 chatgpt-bridge-auth-invalidation 同构:只认上游明确声明的凭证作废信号,并把同一
+ * token 的并发失败合并成一次收口。差异在恢复动作 —— ChatGPT 侧凭证由 codex CLI /
+ * app-server 一起持有,判失效即断开;xAI 侧没有任何子进程替我们刷新(见 grok-oauth-login
+ * 头注),所以先强制刷新自愈,刷不动才登出。因此这里回传 outcome 而不是 boolean。
+ *
+ * Electron-free:只做判定、并发合并与响应观察,凭证读写留在 grok-oauth-login。
+ */
+
+import type { ResponseObserver, ResponseObserverCtx } from '@cindy/anthropic-compat-proxy';
+
+import { bearerAccessTokenFromHeaders } from './chatgpt-bridge-auth-invalidation.js';
+import { decodeUpstreamErrorBody } from './provider-upstream-error-observer.js';
+
+/** 错误体累积上限(判定只看开头的 code/error 字段)。 */
+const MAX_ERROR_BODY_BYTES = 8 * 1024;
+
+/** xAI bridge 上游认证失效原因。 */
+export type XaiBridgeAuthInvalidationReason = 'access_token_rejected';
+
+/** 单次 bridge 上游失败与实际请求凭证的关联信息。 */
+export interface XaiBridgeAuthFailure {
+  status: number;
+  body: string;
+  failedAccessToken: string;
+}
+
+/**
+ * 收口结果。
+ *
+ * - `refreshed`:强制刷新拿到新 token,凭证已自愈(本次请求仍失败,下次即恢复);
+ * - `logged_out`:refresh_token 也被服务端拒绝,已清空本机凭证,UI 回落未登录;
+ * - `superseded`:期间用户重登或其它请求已换过 token,本次失败关联的是旧凭证,不动;
+ * - `unchanged`:刷新遇到网络或临时错误,保留凭证等下次重试(不因抖动误杀登录态)。
+ */
+export type XaiBridgeAuthRecoveryOutcome =
+  | 'refreshed'
+  | 'logged_out'
+  | 'superseded'
+  | 'unchanged';
+
+/** 收口入口的返回值;`ignored` = 不是凭证作废信号,未触碰凭证。 */
+export type XaiBridgeAuthInvalidationResult = XaiBridgeAuthRecoveryOutcome | 'ignored';
+
+/** bridge 认证失效协调器所需的 host 能力。 */
+export interface XaiBridgeAuthInvalidatorDependencies {
+  getCurrentAccessToken: () => Promise<string | null>;
+  recover: (reason: XaiBridgeAuthInvalidationReason) => Promise<XaiBridgeAuthRecoveryOutcome>;
+}
+
+/**
+ * 只接受 api.x.ai 明确声明「OAuth2 凭证没通过校验」的信号。
+ *
+ * 实测口径(2026-07):形态合法但验不过的 OAuth token 返 403 +
+ * `{"code":"unauthenticated:bad-credentials","error":"The OAuth2 access token could not be
+ * validated."}`;完全不成形的 token 走的是另一条 400 `invalid-argument` /
+ * "Incorrect API key provided" 分支,不在此列。普通 401/403(配额、地域、模型未授权)
+ * 不带这两个标记 —— 据此删用户凭证会把「有登录但没权限」误判成「登录失效」。
+ */
+export function detectXaiBridgeAuthInvalidationReason(
+  status: number,
+  body: string,
+): XaiBridgeAuthInvalidationReason | null {
+  if (status !== 401 && status !== 403) return null;
+  if (/unauthenticated:\s*bad-credentials/i.test(body)) return 'access_token_rejected';
+  if (/OAuth2 access token could not be validated/i.test(body)) return 'access_token_rejected';
+  return null;
+}
+
+/**
+ * 创建请求级失效协调器。
+ *
+ * 同一 token 的并发失败合并为一次收口(一轮对话可能有多个请求同时撞上同一坏 token,
+ * 各自刷新会互相作废 refresh_token 的轮换);执行前再读一次当前凭证,确保旧请求迟到时
+ * 不会把用户刚完成重连的新凭证一并注销。
+ */
+export function createXaiBridgeAuthInvalidator(
+  dependencies: XaiBridgeAuthInvalidatorDependencies,
+): (failure: XaiBridgeAuthFailure) => Promise<XaiBridgeAuthInvalidationResult> {
+  const inFlightByToken = new Map<string, Promise<XaiBridgeAuthInvalidationResult>>();
+
+  return async (failure) => {
+    const reason = detectXaiBridgeAuthInvalidationReason(failure.status, failure.body);
+    if (!reason) return 'ignored';
+
+    const existing = inFlightByToken.get(failure.failedAccessToken);
+    if (existing) return await existing;
+
+    const run = (async (): Promise<XaiBridgeAuthInvalidationResult> => {
+      const currentAccessToken = await dependencies.getCurrentAccessToken();
+      if (currentAccessToken !== failure.failedAccessToken) return 'superseded';
+      return await dependencies.recover(reason);
+    })();
+    inFlightByToken.set(failure.failedAccessToken, run);
+    try {
+      return await run;
+    } finally {
+      if (inFlightByToken.get(failure.failedAccessToken) === run) {
+        inFlightByToken.delete(failure.failedAccessToken);
+      }
+    }
+  };
+}
+
+/** 该请求是否发往 xAI 推理上游(codex 链路按 upstreamBase 判归属)。 */
+function isXaiUpstream(upstreamBase: string): boolean {
+  try {
+    return new URL(upstreamBase).hostname === 'api.x.ai';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * codex 链路的凭证收口观察器。
+ *
+ * claude-code 侧的 xai/ 请求由 anthropic-responses-bridge 接管,收口挂在它的
+ * onUpstreamError;codex 原生就是 Responses 协议,proxy 只注入 header 后原样转发,
+ * 只有 responseObserver 能看到上游状态码 —— 缺这一条,同一把坏 token 在 codex agent
+ * 下依旧无人收口。
+ *
+ * proxy 热路径契约(规则 10):非认证状态码与非 xAI 上游直接返回 null,零 tee 零开销;
+ * 只读观察,不改写、不阻塞响应 pipe。
+ */
+export function createXaiAuthInvalidationObserver(
+  handleFailure: (failure: XaiBridgeAuthFailure) => Promise<unknown>,
+): ResponseObserver {
+  return (ctx: ResponseObserverCtx) => {
+    if (ctx.status !== 401 && ctx.status !== 403) return null;
+    if (!isXaiUpstream(ctx.upstreamBase)) return null;
+    const failedAccessToken = bearerAccessTokenFromHeaders(ctx.requestHeaders);
+    if (!failedAccessToken) return null;
+
+    const chunks: Buffer[] = [];
+    let size = 0;
+    return {
+      onData: (chunk: Buffer) => {
+        if (size >= MAX_ERROR_BODY_BYTES) return;
+        chunks.push(chunk);
+        size += chunk.length;
+      },
+      onEnd: () => {
+        const encoding = ctx.responseHeaders['content-encoding'];
+        const body = decodeUpstreamErrorBody(
+          Buffer.concat(chunks, Math.min(size, MAX_ERROR_BODY_BYTES)),
+          typeof encoding === 'string' ? encoding : undefined,
+        );
+        // observer 契约是同步只读:收口只能 fire-and-forget,且必须自己吃掉异常 ——
+        // 未捕获的 rejection 会冒成进程级 unhandledRejection,而上游原始错误必须原样
+        // 到达调用方,不能被收口失败改写。
+        void handleFailure({ status: ctx.status, body, failedAccessToken }).catch(() => {});
+      },
+      // 上游流错误:本次观察放弃即可(连接层问题由 proxy 主路径处理与记日志)。
+      onError: () => {},
+    };
+  };
+}

--- a/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
+++ b/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
@@ -130,21 +130,31 @@ export function createXaiAuthInvalidationObserver(
   return (ctx: ResponseObserverCtx) => {
     if (ctx.status !== 401 && ctx.status !== 403) return null;
     if (!isXaiUpstream(ctx.upstreamBase)) return null;
-    const failedAccessToken = bearerAccessTokenFromHeaders(ctx.requestHeaders);
+    // 必须读 outboundHeaders:xAI token 是路由期经 headerOverride 注入的,requestHeaders
+    // 里的 authorization 还是 codex 子进程自带的那把,拿它做等值关联会永远 superseded,
+    // 等于这条链路的收口完全不生效。省略时回落 requestHeaders(无路由改写 = 两者相同)。
+    const failedAccessToken = bearerAccessTokenFromHeaders(
+      ctx.outboundHeaders ?? ctx.requestHeaders,
+    );
     if (!failedAccessToken) return null;
 
     const chunks: Buffer[] = [];
     let size = 0;
     return {
       onData: (chunk: Buffer) => {
-        if (size >= MAX_ERROR_BODY_BYTES) return;
-        chunks.push(chunk);
-        size += chunk.length;
+        // 按剩余空间裁剪后再缓存:上游可能一个 chunk 就远超上限,整段留到 onEnd 会把
+        // 大 Buffer 一直挂住(判定只需要开头的 code/error 字段)。
+        const remaining = MAX_ERROR_BODY_BYTES - size;
+        if (remaining <= 0) return;
+        const slice = chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+        chunks.push(slice);
+        size += slice.length;
       },
       onEnd: () => {
         const encoding = ctx.responseHeaders['content-encoding'];
+        // size 在 onData 已按上限裁过,这里直接用即可。
         const body = decodeUpstreamErrorBody(
-          Buffer.concat(chunks, Math.min(size, MAX_ERROR_BODY_BYTES)),
+          Buffer.concat(chunks, size),
           typeof encoding === 'string' ? encoding : undefined,
         );
         // observer 契约是同步只读:收口只能 fire-and-forget,且必须自己吃掉异常 ——

--- a/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
+++ b/apps/desktop/src/main/maker-host/xai-bridge-auth-invalidation.ts
@@ -47,7 +47,15 @@ export type XaiBridgeAuthInvalidationResult = XaiBridgeAuthRecoveryOutcome | 'ig
 /** bridge 认证失效协调器所需的 host 能力。 */
 export interface XaiBridgeAuthInvalidatorDependencies {
   getCurrentAccessToken: () => Promise<string | null>;
-  recover: (reason: XaiBridgeAuthInvalidationReason) => Promise<XaiBridgeAuthRecoveryOutcome>;
+  /**
+   * 执行收口。**必须接住 failedAccessToken 并在开始时重新校验** —— 下面的等值检查到这里
+   * 还隔着一次 await 边界,期间可能完成新登录或切换数据归属;只凭 reason 恢复会拿新账号的
+   * 凭证去承担旧 token 的失败。
+   */
+  recover: (
+    reason: XaiBridgeAuthInvalidationReason,
+    failedAccessToken: string,
+  ) => Promise<XaiBridgeAuthRecoveryOutcome>;
 }
 
 /**
@@ -91,7 +99,8 @@ export function createXaiBridgeAuthInvalidator(
     const run = (async (): Promise<XaiBridgeAuthInvalidationResult> => {
       const currentAccessToken = await dependencies.getCurrentAccessToken();
       if (currentAccessToken !== failure.failedAccessToken) return 'superseded';
-      return await dependencies.recover(reason);
+      // 这一步之后还有 await 边界,recover 必须自己再绑一次被拒的 token(见依赖注释)。
+      return await dependencies.recover(reason, failure.failedAccessToken);
     })();
     inFlightByToken.set(failure.failedAccessToken, run);
     try {

--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -1086,6 +1086,52 @@ describe('anthropic-compat-proxy routingTransform', () => {
     expect(chunks.join('')).toBe(errBody);
     expect(observedEnd).toBe(true);
   });
+
+  it('exposes the final routed headers to the observer, not the client-sent ones', async () => {
+    // 回归:供应商 OAuth 是路由期经 headerOverride 注入的。观察器若只拿得到 requestHeaders,
+    // 就只能看到 agent 子进程自带的那把 bearer —— 任何「这次请求用了哪把凭证」的判断
+    // (如 xAI 凭证失效收口的等值关联)都会永远对不上,整条链路的收口静默失效。
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(403, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ code: 'unauthenticated:bad-credentials' }));
+    });
+    upstreamClose = upstream.close;
+    let observedRequestAuth: string | undefined;
+    let observedOutboundAuth: string | undefined;
+    let observedOutboundBeta: string | undefined;
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [],
+      routingTransform: () => ({
+        headerOverride: { authorization: 'Bearer routed-xai-token' },
+        headerDelete: ['anthropic-beta'],
+      }),
+      responseObserver: (ctx) => {
+        observedRequestAuth = ctx.requestHeaders.authorization;
+        observedOutboundAuth = ctx.outboundHeaders?.authorization;
+        observedOutboundBeta = ctx.outboundHeaders?.['anthropic-beta'];
+        return null;
+      },
+    });
+
+    const r = await fetch(`${proxy.url}/v1/responses`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'thread-id': 'thread-a',
+        authorization: 'Bearer client-subprocess-token',
+        'anthropic-beta': 'oauth-2025-04-20',
+      },
+      body: JSON.stringify({ model: 'gpt-5.5', input: [] }),
+    });
+
+    expect(r.status).toBe(403);
+    // 客户端原始头保持原样(反解 thread-id 等会话归属仍靠它)。
+    expect(observedRequestAuth).toBe('Bearer client-subprocess-token');
+    // 实际发往上游的是路由注入后的凭证,且 headerDelete 已生效。
+    expect(observedOutboundAuth).toBe('Bearer routed-xai-token');
+    expect(observedOutboundBeta).toBeUndefined();
+  });
 });
 
 const THINKING_ERROR_BODY = JSON.stringify({

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -802,6 +802,7 @@ function forward(
               upstreamBase: formatUpstreamBase(actualTarget),
               status,
               requestHeaders: headers,
+              outboundHeaders: actualHeaders,
               responseHeaders: flattenResponseHeaders(upstreamRes.headers),
               requestBody: body,
             }) ?? null;
@@ -851,6 +852,7 @@ function forward(
           upstreamBase: formatUpstreamBase(actualTarget),
           status,
           requestHeaders: headers,
+          outboundHeaders: actualHeaders,
           responseHeaders: flattenResponseHeaders(upstreamRes.headers),
           requestBody: body,
         }) ?? null;

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -116,7 +116,20 @@ export interface ResponseObserverCtx {
   readonly url: string;
   readonly upstreamBase: string;
   readonly status: number;
+  /**
+   * 客户端(agent 子进程)发来的原始请求头,**未**经路由改写。
+   * 反解会话归属(thread-id 等 agent 自带 header)用这个。
+   */
   readonly requestHeaders: Readonly<Record<string, string>>;
+  /**
+   * 实际发往上游的请求头 —— 已应用 RoutingDecision 的 headerOverride 与 headerDelete。
+   *
+   * 凡是要判断「这次请求究竟用了哪把凭证」的观察器必须读它:供应商 OAuth 是路由期注入的,
+   * requestHeaders 里的 authorization 仍是子进程自带的那把,拿它做等值关联必然对不上。
+   *
+   * 省略时按 requestHeaders 理解(没有路由改写 = 发出去的就是收到的)。
+   */
+  readonly outboundHeaders?: Readonly<Record<string, string>>;
   readonly responseHeaders: Readonly<Record<string, string>>;
   readonly requestBody: Buffer;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

用 Grok 时撞到 `403 {"code":"unauthenticated:bad-credentials","error":"The OAuth2 access token could not be validated."}`。查下来发现 **xAI 订阅 OAuth 在两条 agent 链路上都没有任何认证失效收口**：

- **claude-code**(`anthropic-responses-bridge`)的 `xaiProviderConfig` 没接 `onUpstreamError`——chatgpt 那条接了；
- **codex**(`codex-proxy`)的 `createProviderUpstreamErrorObserver` 只覆盖 `source='user'` 供应商，`xai` 是 builtin，落在覆盖面之外。

而被服务端提前作废的 token 在本地 `expires_at` 上仍"没到期"，常规刷新永远不触发（`grok-oauth-login` 原注释写的"靠 401 暴露"也对不上——上游返的是 **403**）。结果是每个请求都 403，而「设置 → 模型供应商」一直显示已连接，用户没有任何线索该去重连。

对齐 `chatgpt-bridge-auth-invalidation` 的 invalidator 模式补上收口，两条链路都接。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（使用中实测发现）
- 本 PR 包含：
  - 新增 `xai-bridge-auth-invalidation.ts`——判定 + 并发合并 + codex proxy 用的 `responseObserver`；
  - `grok-oauth-login.ts`：`refreshIfNeeded` 重构为 `refreshBlob(blob, force)`，新增 `peekGrokAccessToken()` 与 `recoverGrokAuthAfterRejection()`；
  - `xai-auth-invalidation-host.ts`：两条链路共用同一 invalidator 实例 + 自动登出的 UI 收尾接线；
  - `anthropic-responses-bridge-host.ts` 接 `onUpstreamError`、`codex-proxy-host.ts` 接 observer；
  - `provider-upstream-error-observer.ts` 把 `decodeBody` 导出为 `decodeUpstreamErrorBody`，解压语义单点维护。
- 明确不包含：
  - `generic-oauth.ts:186` 有一模一样的注释与缺口（自定义 provider 的 OAuth）。没一并修是因为它是 `source: 'user'`，`provider-upstream-error-observer` 会给它弹 `providerError.*` toast，用户至少看得到；xai 是 builtin，连 toast 都没有，才是真盲区。
  - `utility-model/oneShotCandidates.ts` 的 xai 分支拿 token 直发 HTTP，403 不收口。影响面小（工具模型），且与主链路共享同一份凭证，主链路修好后顺带治愈。
- 用户可见变化：xAI 凭证被上游作废时，会自动尝试刷新恢复；确认作废则清凭证并即时把「模型供应商」刷回未登录，而不是继续显示已连接。
- 是否存在 breaking change：无

**这个 PR 不改变 Grok 本身的可用性。** 它消灭的是「token 已失效但 UI 显示已连接、请求连环 403」这类假状态；如果 403 的根因是账号没有 SuperGrok 订阅（token 本身有效），错误仍会如实暴露——那属于账号侧。

### 收口语义

xAI 没有任何子进程替它维护凭证（不同于 Claude / codex 各有 CLI），所以不照搬 ChatGPT 的"判失效即断开"，而是**先自愈、后登出**：

| 情况 | 动作 |
|---|---|
| 强制刷新成功 | 凭证自愈，下次请求即恢复 |
| refresh 被拒（`invalid_grant` 家族） | 清凭证 + 广播，UI 回落未登录 |
| 网络 / 5xx / 超时 | 保留登录态，不因一次抖动把人踢下线 |
| 期间已重登或别处刷过 | 不动 |

几个刻意的保守取舍：

- **只认明确信号**：仅 401/403 且 body 命中 `unauthenticated:bad-credentials` / `OAuth2 access token could not be validated`。普通 403（配额、地域、模型未授权）和 400 `invalid-argument` 一律放行，不能拿它们删用户凭证。
- **不认 `invalid_client` / `unauthorized_client`**：那是 client 注册侧问题，把它当作废会在 xAI 调整 client 配置时把所有人一起登出，而重新登录同样失败。
- **60s 强制刷新冷却**：若 403 实为订阅/权限问题，token 有效、刷新永远"成功"却修不好，无冷却会每请求刷一次，空耗 refresh_token 轮换并可能撞上服务端刷新复用检测。
- **两条链路共用一个 invalidator 实例**：并发合并按 failed token 做，各建一个会各刷各的、互相作废轮换。
- **非强制刷新路径逐分支保持原行为**，只是返回值从 blob 变成 `{blob, outcome}`。

### UI 变化

不涉及：改动全在 main 侧（`maker-host` / `bootstrap-electron`），没有新增或修改任何界面、组件、样式与文案。自动登出复用手动登出既有的 `broadcastXaiAuthStateChanged()` 通道，渲染结果与用户手动点登出完全一致。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
# 全量门禁（改动完成后跑过一轮）
pnpm test:unit
结果：50 workspace PASS / 0 FAIL

# 门禁后又做了 4 处自审修正（见下），补跑受影响 workspace：
pnpm --filter desktop run typecheck
结果：通过

cd apps/desktop && npx vitest run --maxWorkers=1
结果：1288 文件 / 13940 passed | 2 skipped

# rebase 到最新 origin/main 后再补跑：
pnpm --filter desktop run typecheck        结果：通过
npx vitest run src/main/maker-host/__tests__/   结果：60 文件 / 700 passed

pnpm check:dco
结果：DCO check passed
```

新增 14 个用例覆盖：判定口径（含 400 `invalid-argument` 与普通 403 不误判）、并发合并、迟到旧 token、未登录、observer 热路径短路（非 401/403、非 xAI 上游、无 Bearer）、gzip 解压。

**门禁后的自审修正**（因此补跑而非复用绿灯结果）：

1. `isRefreshRejection` 收窄，去掉 `invalid_client` / `unauthorized_client`；
2. observer 里 `void handleFailure(...)` 会漏 unhandled rejection，补 `.catch()`；
3. 加 60s 强制刷新冷却，防刷新风暴；
4. 自动登出补 UI 收尾广播，否则仍停在「显示已连接」的假状态。

### 手工验证

不涉及。

### 未执行的验证

- **没有实机验证 xAI 403 真实场景**：需要一把真实失效的 xAI OAuth token，本地无法构造。自动化覆盖的是判定逻辑与 observer 契约，接线正确性靠 typecheck + 现有 `codexProxyHost` / `maker-host` 回归用例兜底。
- 判定口径来自对 `api.x.ai` 的实测：无效 OAuth token 返 403 + `unauthenticated:bad-credentials`；不成形 token 返 400 + `invalid-argument` / "Incorrect API key provided"。两条分支不同，测试固定了这个区别。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响 xAI(SuperGrok 订阅)provider 的凭证生命周期。最坏情况是误判导致用户被登出一次，需重新走 OAuth——判定条件已收窄到上游明确声明的作废信号，且刷新失败默认保留凭证（只有 `invalid_grant` 家族才登出）。不触碰其它 provider 的凭证。
- 凭证处理：新增代码不落盘新文件、不改存储位置，仍走 `providerSecretStore`(safeStorage)；刷新失败响应体只用于判定，不入日志（`log.warn` 只记 `status` 与布尔 `rejected`）。
- 回滚 / 降级方式：整体 revert 即可，无数据迁移、无持久化格式变化。回滚后行为退回当前的"静默连环 403"。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动的约束与原因写在代码注释里；无需新增规则文档）
- [x] 已确认测试结果或说明未执行原因
