### PR TITLE
feat(desktop): 更新公告支持主题式 v2 格式

### DIFF
--- a/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
+++ b/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
@@ -76,7 +76,7 @@ describe('releaseNotesService', () => {
     response.emit('end');
 
     const notes = await promise;
-    const item = notes?.sections[0]?.items[0]?.list[0];
+    const item = notes?.sections?.[0]?.items[0]?.list[0];
     expect(item).toContain('断线恢复');
     expect(item).not.toContain('�');
   });

--- a/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
+++ b/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
@@ -107,4 +107,33 @@ describe('releaseNotesService', () => {
     // 两次都真正发起了请求——坏 payload 没有进程级缓存,CDN 修正后可生效。
     expect(requestMock).toHaveBeenCalledTimes(2);
   });
+
+  it('sections 非空但全部畸形(无任何有效 bullet)同样按失败处理不缓存', async () => {
+    const { fetchReleaseNotes } = await import('../releaseNotesService');
+
+    const payload = JSON.stringify({
+      version: '0.1.21',
+      date: '2026-07-31',
+      contributors: ['A'],
+      sections: [
+        { title: 'Bug Fixes', items: [{ name: 'X' }, { name: 'Y', list: [42] }] },
+        { items: [{ name: 'Z', list: ['有内容但缺 title'] }] },
+      ],
+    });
+
+    const fetchOnce = async () => {
+      const request = new MockRequest();
+      const response = new MockResponse();
+      requestMock.mockReturnValueOnce(request);
+      const promise = fetchReleaseNotes('0.1.21');
+      request.emit('response', response);
+      response.emit('data', Buffer.from(payload, 'utf8'));
+      response.emit('end');
+      return promise;
+    };
+
+    expect(await fetchOnce()).toBeNull();
+    expect(await fetchOnce()).toBeNull();
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
+++ b/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
@@ -80,4 +80,31 @@ describe('releaseNotesService', () => {
     expect(item).toContain('断线恢复');
     expect(item).not.toContain('�');
   });
+
+  it('无可渲染内容的 200 payload 按失败处理且不写缓存(重试会重新请求 CDN)', async () => {
+    const { fetchReleaseNotes } = await import('../releaseNotesService');
+
+    const emptyPayload = JSON.stringify({
+      version: '0.1.20',
+      date: '2026-07-30',
+      contributors: [],
+      topics: [{ title: '   ', text: '' }],
+    });
+
+    const fetchOnce = async () => {
+      const request = new MockRequest();
+      const response = new MockResponse();
+      requestMock.mockReturnValueOnce(request);
+      const promise = fetchReleaseNotes('0.1.20');
+      request.emit('response', response);
+      response.emit('data', Buffer.from(emptyPayload, 'utf8'));
+      response.emit('end');
+      return promise;
+    };
+
+    expect(await fetchOnce()).toBeNull();
+    expect(await fetchOnce()).toBeNull();
+    // 两次都真正发起了请求——坏 payload 没有进程级缓存,CDN 修正后可生效。
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/main/releaseNotesService.ts
+++ b/apps/desktop/src/main/releaseNotesService.ts
@@ -48,6 +48,14 @@ export interface RawSection {
   items: RawItem[];
 }
 
+/** Topic-format (v2) block: one user-facing theme with a short narrative. */
+export interface RawTopic {
+  emoji?: string;
+  title: string;
+  text: string;
+  contributors?: string[];
+}
+
 export interface RawReleaseNotes {
   version: string;
   date: string;
@@ -60,7 +68,12 @@ export interface RawReleaseNotes {
   githash?: string;
   /** Flat contributor list — collective hall-of-fame on top of per-item `by`. */
   contributors: string[];
-  sections: RawSection[];
+  /** Legacy author-grouped sections. Absent on topic-format payloads. */
+  sections?: RawSection[];
+  /** Topic-format blocks. Non-empty ⇒ renderer uses the topic layout. */
+  topics?: RawTopic[];
+  /** Optional one-line lead above the topics (e.g. PR/commit counts). */
+  intro?: string;
 }
 
 // ── Constants ──────────────────────────────────────────────────────────────

--- a/apps/desktop/src/main/releaseNotesService.ts
+++ b/apps/desktop/src/main/releaseNotesService.ts
@@ -29,6 +29,8 @@ import { StringDecoder } from 'node:string_decoder';
 
 import { net } from 'electron';
 
+import { hasRenderableContent } from '../shared/releaseNotesContent';
+
 import { getBaseUrl, getPlatformKey } from './manifestService';
 
 import { createLogger } from './logger';
@@ -66,8 +68,11 @@ export interface RawReleaseNotes {
    * Optional because older notice files predate the field.
    */
   githash?: string;
-  /** Flat contributor list — collective hall-of-fame on top of per-item `by`. */
-  contributors: string[];
+  /**
+   * Flat contributor list — collective hall-of-fame on top of per-item `by`.
+   * Optional: older notice files predate the field (renderer defaults to []).
+   */
+  contributors?: string[];
   /** Legacy author-grouped sections. Absent on topic-format payloads. */
   sections?: RawSection[];
   /** Topic-format blocks. Non-empty ⇒ renderer uses the topic layout. */
@@ -181,6 +186,14 @@ export async function fetchReleaseNotes(version: string): Promise<RawReleaseNote
   const url = `${getBaseUrl()}/notice/${platform}/${version}.json?t=${Date.now()}`;
   const json = await fetchCdnJson<RawReleaseNotes>(url);
   if (!json) return null;
+  // A 200 payload with nothing renderable (e.g. a v2 document whose topics
+  // are all malformed) is treated as a failed fetch and NOT cached — the
+  // process-lifetime cache would otherwise keep serving the bad document
+  // even after the CDN is corrected, and the renderer would reject it anyway.
+  if (!hasRenderableContent(json)) {
+    log.warn('Payload has no renderable content, treating as failure: version=%s', version);
+    return null;
+  }
   cache.set(version, json);
   log.info('Fetched OK: version=%s, sections=%d', json.version, json.sections?.length ?? 0);
   return json;

--- a/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
+++ b/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
@@ -4,10 +4,14 @@
  * v2 payload 的 topics/intro 透传、缺 sections 不炸;畸形 topic 条目被丢弃
  * 而不是让弹窗崩溃。模块级缓存:每个用例 vi.resetModules() + 动态 import。
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 beforeEach(() => {
   vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 function stubFetch(payload: unknown) {

--- a/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
+++ b/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
@@ -1,0 +1,88 @@
+/**
+ * release-notes 归一化单测(更新公告 topic 格式 v2)。
+ * 守住:legacy 作者分组 payload 展开为 flat items 且 topics 为空数组;
+ * v2 payload 的 topics/intro 透传、缺 sections 不炸;畸形 topic 条目被丢弃
+ * 而不是让弹窗崩溃。模块级缓存:每个用例 vi.resetModules() + 动态 import。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+function stubFetch(payload: unknown) {
+  const fetchReleaseNotes = vi.fn(async () => payload);
+  vi.stubGlobal('window', { electronAPI: { fetchReleaseNotes } });
+  return fetchReleaseNotes;
+}
+
+describe('release-notes normalization', () => {
+  it('legacy payload:sections 按作者组展开,topics 归一为空数组', async () => {
+    stubFetch({
+      version: '0.1.17',
+      date: '2026-07-27',
+      contributors: ['Lizi'],
+      sections: [
+        {
+          title: 'Bug Fixes',
+          items: [{ name: 'Lizi', list: ['修复 A', '修复 B'] }],
+        },
+      ],
+    });
+    const mod = await import('@/release-notes');
+    const notes = await mod.fetchReleaseNotes('0.1.17');
+    expect(notes?.sections[0]?.items).toEqual([
+      { text: '修复 A', by: 'Lizi' },
+      { text: '修复 B', by: 'Lizi' },
+    ]);
+    expect(notes?.topics).toEqual([]);
+    expect(notes?.intro).toBeUndefined();
+  });
+
+  it('v2 payload:topics/intro 透传,缺 sections 归一为空数组', async () => {
+    stubFetch({
+      version: '0.1.18',
+      date: '2026-07-28',
+      contributors: ['Lizi', 'Kmny'],
+      intro: '本次合并 64 个 PR。',
+      topics: [
+        {
+          emoji: '🎙️',
+          title: '语音输入更稳',
+          text: '麦克风保活逻辑重写,后台麦克风不再意外残留。',
+          contributors: ['Lizi'],
+        },
+      ],
+    });
+    const mod = await import('@/release-notes');
+    const notes = await mod.fetchReleaseNotes('0.1.18');
+    expect(notes?.sections).toEqual([]);
+    expect(notes?.intro).toBe('本次合并 64 个 PR。');
+    expect(notes?.topics).toEqual([
+      {
+        emoji: '🎙️',
+        title: '语音输入更稳',
+        text: '麦克风保活逻辑重写,后台麦克风不再意外残留。',
+        contributors: ['Lizi'],
+      },
+    ]);
+  });
+
+  it('畸形 topic 条目被丢弃,合法条目补默认值', async () => {
+    stubFetch({
+      version: '0.1.19',
+      date: '2026-07-29',
+      contributors: [],
+      topics: [
+        { title: '只有标题没有正文' },
+        { emoji: 42, title: '正常主题', text: '正文。', contributors: ['A', 7, 'B'] },
+        'not-an-object',
+      ],
+    });
+    const mod = await import('@/release-notes');
+    const notes = await mod.fetchReleaseNotes('0.1.19');
+    expect(notes?.topics).toEqual([
+      { emoji: undefined, title: '正常主题', text: '正文。', contributors: ['A', 'B'] },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
+++ b/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
@@ -92,6 +92,32 @@ describe('release-notes normalization', () => {
     ]);
   });
 
+  it('legacy payload 的畸形 section/作者组/条目被丢弃而不是抛异常', async () => {
+    stubFetch({
+      version: '0.1.21',
+      date: '2026-07-31',
+      contributors: ['A', 42, null],
+      sections: [
+        { title: 'Bug Fixes' }, // 缺 items
+        { items: [{ name: 'X', list: ['x'] }] }, // 缺 title
+        {
+          title: 'New Features',
+          items: [
+            { name: 'A', list: ['正常条目', 7, null] },
+            { name: 'B' }, // 缺 list
+            'not-a-group',
+          ],
+        },
+      ],
+    });
+    const mod = await import('@/release-notes');
+    const notes = await mod.fetchReleaseNotes('0.1.21');
+    expect(notes?.contributors).toEqual(['A']);
+    expect(notes?.sections).toEqual([
+      { title: 'New Features', items: [{ text: '正常条目', by: 'A' }] },
+    ]);
+  });
+
   it('无任何可渲染内容(全部 topic 畸形且无 sections)按拉取失败处理', async () => {
     const fetchReleaseNotes = stubFetch({
       version: '0.1.20',

--- a/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
+++ b/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
@@ -89,4 +89,18 @@ describe('release-notes normalization', () => {
       { emoji: undefined, title: '正常主题', text: '正文。', contributors: ['A', 'B'] },
     ]);
   });
+
+  it('无任何可渲染内容(全部 topic 畸形且无 sections)按拉取失败处理', async () => {
+    const fetchReleaseNotes = stubFetch({
+      version: '0.1.20',
+      date: '2026-07-30',
+      contributors: ['A'],
+      topics: [{ title: '只有标题', body: '字段名写错了' }],
+    });
+    const mod = await import('@/release-notes');
+    expect(await mod.fetchReleaseNotes('0.1.20')).toBeNull();
+    // 不缓存失败结果:同版本再次调用要重新发起请求,修复后的 CDN payload 可以生效。
+    expect(await mod.fetchReleaseNotes('0.1.20')).toBeNull();
+    expect(fetchReleaseNotes).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
+++ b/apps/desktop/src/renderer/__tests__/releaseNotesNormalize.test.ts
@@ -79,6 +79,8 @@ describe('release-notes normalization', () => {
       contributors: [],
       topics: [
         { title: '只有标题没有正文' },
+        { title: '   ', text: '标题是纯空白' },
+        { title: '正文是纯空白', text: '' },
         { emoji: 42, title: '正常主题', text: '正文。', contributors: ['A', 7, 'B'] },
         'not-an-object',
       ],

--- a/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
@@ -229,29 +229,32 @@ function TopicList({ intro, topics }: { intro?: string; topics: ReleaseNoteTopic
   return (
     <div className="flex flex-col items-center px-7">
       {intro && (
-        <div className="w-full max-w-[760px] pb-3 text-13 text-[var(--cmd-palette-item-meta)]">
+        <div className="w-full max-w-[760px] pb-3 text-13 break-words text-[var(--cmd-palette-item-meta)]">
           {intro}
         </div>
       )}
       {topics.map((topic, i) => (
         <div key={`${i}-${topic.title}`} className="w-full max-w-[760px] py-3">
-          <div className="mb-1.5 flex items-baseline gap-2">
+          {/* flex-wrap + min-w-0: long titles shrink/wrap and an overlong
+              contributor list drops to its own right-aligned line instead of
+              overflowing the dialog at narrow widths. */}
+          <div className="mb-1.5 flex flex-wrap items-baseline gap-x-2 gap-y-1">
             {topic.emoji && <span className="text-15 leading-none">{topic.emoji}</span>}
             <span
               className={cn(
-                'text-15 font-semibold leading-none tracking-tight',
+                'min-w-0 break-words text-15 font-semibold leading-tight tracking-tight',
                 'text-[var(--msg-assistant-text)]',
               )}
             >
               {topic.title}
             </span>
             {topic.contributors.length > 0 && (
-              <span className="ml-auto whitespace-nowrap text-12 text-[var(--cmd-palette-item-meta)]">
+              <span className="ml-auto max-w-full break-words text-right text-12 text-[var(--cmd-palette-item-meta)]">
                 {topic.contributors.join(' · ')}
               </span>
             )}
           </div>
-          <div className="text-sm leading-[1.7] text-[var(--msg-assistant-text)]">
+          <div className="text-sm leading-[1.7] break-words text-[var(--msg-assistant-text)]">
             {topic.text}
           </div>
         </div>

--- a/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
@@ -229,7 +229,7 @@ function TopicList({ intro, topics }: { intro?: string; topics: ReleaseNoteTopic
   return (
     <div className="flex flex-col items-center px-7">
       {intro && (
-        <div className="w-full max-w-[760px] pb-3 text-13 break-words text-[var(--cmd-palette-item-meta)]">
+        <div className="w-full max-w-[760px] pb-3 text-sm leading-[1.7] break-words text-[var(--cmd-palette-item-meta)]">
           {intro}
         </div>
       )}

--- a/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
@@ -242,7 +242,7 @@ function TopicList({ intro, topics }: { intro?: string; topics: ReleaseNoteTopic
             {topic.emoji && <span className="text-15 leading-none">{topic.emoji}</span>}
             <span
               className={cn(
-                'min-w-0 break-words text-15 font-semibold leading-tight tracking-tight',
+                'min-w-0 break-words text-15 font-medium leading-tight tracking-tight',
                 'text-[var(--msg-assistant-text)]',
               )}
             >

--- a/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
@@ -1,6 +1,6 @@
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Flame, Zap, Wrench, Swords, ChevronDown } from 'lucide-react';
+import { Flame, Zap, Wrench, Flower, ChevronDown } from 'lucide-react';
 import {
   useCallback,
   useEffect,
@@ -10,7 +10,12 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { ReleaseNoteItem, ReleaseNoteSection, ReleaseNotes } from '@/release-notes';
+import type {
+  ReleaseNoteItem,
+  ReleaseNoteSection,
+  ReleaseNoteTopic,
+  ReleaseNotes,
+} from '@/release-notes';
 import type { UpdateNoticeMode } from '@/hooks/useUpdateNotice';
 import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
@@ -201,12 +206,12 @@ function ContributorsLine({ contributors }: { contributors: string[] }) {
       )}
     >
       <span className="flex h-[12px] items-center">
-        <Swords
+        <Flower
           className="h-3.5 w-3.5 text-[var(--status-bar-accent)] -translate-y-[2px]"
           strokeWidth={2.25}
         />
       </span>
-      <span className="text-[var(--cmd-palette-item-meta)]">{t('update.notice.craftedBy')}</span>
+      <span className="text-[var(--cmd-palette-item-meta)]">{t('update.notice.thanksTo')}</span>
       <span className="font-semibold text-[var(--msg-assistant-text)]">
         {contributors.join(' · ')}
       </span>
@@ -214,13 +219,56 @@ function ContributorsLine({ contributors }: { contributors: string[] }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Topic-format (v2) body: single centered column of theme blocks. Replaces
+// the two-column author-grouped layout for payloads that carry `topics` —
+// notably fixes the half-empty dialog on bugfix-only releases.
+// ---------------------------------------------------------------------------
+
+function TopicList({ intro, topics }: { intro?: string; topics: ReleaseNoteTopic[] }) {
+  return (
+    <div className="flex flex-col items-center px-7">
+      {intro && (
+        <div className="w-full max-w-[760px] pb-3 text-13 text-[var(--cmd-palette-item-meta)]">
+          {intro}
+        </div>
+      )}
+      {topics.map((topic, i) => (
+        <div key={`${i}-${topic.title}`} className="w-full max-w-[760px] py-3">
+          <div className="mb-1.5 flex items-baseline gap-2">
+            {topic.emoji && <span className="text-15 leading-none">{topic.emoji}</span>}
+            <span
+              className={cn(
+                'text-15 font-semibold leading-none tracking-tight',
+                'text-[var(--msg-assistant-text)]',
+              )}
+            >
+              {topic.title}
+            </span>
+            {topic.contributors.length > 0 && (
+              <span className="ml-auto whitespace-nowrap text-12 text-[var(--cmd-palette-item-meta)]">
+                {topic.contributors.join(' · ')}
+              </span>
+            )}
+          </div>
+          <div className="text-sm leading-[1.7] text-[var(--msg-assistant-text)]">
+            {topic.text}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /**
  * A loaded version's block — subheader (version badge + date + contributors)
- * on top, two-column features/bugfixes below. Same layout auto and manual
- * modes share; the outer container owns scrolling in both cases.
+ * on top, body below: topic list for v2 payloads, two-column
+ * features/bugfixes for legacy ones. Same layout auto and manual modes
+ * share; the outer container owns scrolling in both cases.
  */
 function VersionBlock({ notes, locale }: { notes: ReleaseNotes; locale: string }) {
   const { t } = useTranslation();
+  const isTopicFormat = notes.topics.length > 0;
   const { leftSections, rightSections } = splitSections(notes.sections);
   const formattedDate = formatDate(notes.date, locale);
   return (
@@ -236,21 +284,27 @@ function VersionBlock({ notes, locale }: { notes: ReleaseNotes; locale: string }
           </span>
         )}
       </div>
-      <div className="flex py-3">
-        <SectionColumn
-          icon="zap"
-          title={t('update.notice.newFeatures')}
-          sections={leftSections}
-          scroll={false}
-        />
-        <div className="w-px self-stretch bg-[var(--cmd-palette-border)]" />
-        <SectionColumn
-          icon="wrench"
-          title={t('update.notice.bugFixes')}
-          sections={rightSections}
-          scroll={false}
-        />
-      </div>
+      {isTopicFormat ? (
+        <div className="py-3">
+          <TopicList intro={notes.intro} topics={notes.topics} />
+        </div>
+      ) : (
+        <div className="flex py-3">
+          <SectionColumn
+            icon="zap"
+            title={t('update.notice.newFeatures')}
+            sections={leftSections}
+            scroll={false}
+          />
+          <div className="w-px self-stretch bg-[var(--cmd-palette-border)]" />
+          <SectionColumn
+            icon="wrench"
+            title={t('update.notice.bugFixes')}
+            sections={rightSections}
+            scroll={false}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -853,24 +907,30 @@ export function UpdateNoticeDialog({
               onNotesLoaded={handleNotesLoaded}
             />
           ) : mode === 'auto' && releaseNotes.length === 1 ? (
-            (() => {
-              const { leftSections, rightSections } = splitSections(newest.sections);
-              return (
-                <div className="flex flex-1 min-h-0 py-4 select-text">
-                  <SectionColumn
-                    icon="zap"
-                    title={t('update.notice.newFeatures')}
-                    sections={leftSections}
-                  />
-                  <div className="w-px self-stretch bg-[var(--cmd-palette-border)]" />
-                  <SectionColumn
-                    icon="wrench"
-                    title={t('update.notice.bugFixes')}
-                    sections={rightSections}
-                  />
-                </div>
-              );
-            })()
+            newest.topics.length > 0 ? (
+              <div className="flex flex-1 min-h-0 flex-col overflow-y-auto py-4 select-text">
+                <TopicList intro={newest.intro} topics={newest.topics} />
+              </div>
+            ) : (
+              (() => {
+                const { leftSections, rightSections } = splitSections(newest.sections);
+                return (
+                  <div className="flex flex-1 min-h-0 py-4 select-text">
+                    <SectionColumn
+                      icon="zap"
+                      title={t('update.notice.newFeatures')}
+                      sections={leftSections}
+                    />
+                    <div className="w-px self-stretch bg-[var(--cmd-palette-border)]" />
+                    <SectionColumn
+                      icon="wrench"
+                      title={t('update.notice.bugFixes')}
+                      sections={rightSections}
+                    />
+                  </div>
+                );
+              })()
+            )
           ) : (
             <AutoBody releaseNotes={releaseNotes} locale={i18n.language} />
           )}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3658,7 +3658,7 @@
       "title": "What's New",
       "newFeatures": "New Features",
       "bugFixes": "Bug Fixes",
-      "craftedBy": "Crafted by",
+      "thanksTo": "Thanks to",
       "gotIt": "Got it",
       "ariaDescription": "Release notes for version {{version}}",
       "ariaDescriptionSpan": "Release notes for {{count}} versions since v{{from}}",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3657,7 +3657,7 @@
       "title": "更新情報",
       "newFeatures": "新機能",
       "bugFixes": "不具合修正",
-      "craftedBy": "制作",
+      "thanksTo": "感謝",
       "gotIt": "了解しました",
       "ariaDescription": "バージョン {{version}} のリリースノート",
       "ariaDescriptionSpan": "v{{from}} 以降 {{count}} バージョン分のリリースノート",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3657,7 +3657,7 @@
       "title": "업데이트 소식",
       "newFeatures": "새로운 기능",
       "bugFixes": "버그 수정",
-      "craftedBy": "제작",
+      "thanksTo": "감사",
       "gotIt": "확인",
       "ariaDescription": "버전 {{version}} 릴리스 노트",
       "ariaDescriptionSpan": "v{{from}} 이후 {{count}}개 버전의 릴리스 노트",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3657,7 +3657,7 @@
       "title": "更新公告",
       "newFeatures": "新功能",
       "bugFixes": "问题修复",
-      "craftedBy": "出品",
+      "thanksTo": "感谢",
       "gotIt": "我知道了",
       "ariaDescription": "版本 {{version}} 的更新说明",
       "ariaDescriptionSpan": "自 v{{from}} 起累计 {{count}} 个版本的更新说明",

--- a/apps/desktop/src/renderer/release-notes/index.ts
+++ b/apps/desktop/src/renderer/release-notes/index.ts
@@ -149,11 +149,14 @@ export async function fetchReleaseNotes(
       })),
     intro: typeof raw.intro === 'string' ? raw.intro : undefined,
   };
-  // A notice with no renderable content (e.g. a v2 payload whose topics were
-  // all malformed and dropped) must count as a failed fetch: caching it would
-  // open an empty dialog and, worse, advance lastReadVersion on dismiss so a
-  // corrected CDN payload would never be shown again.
-  if (notes.sections.length === 0 && notes.topics.length === 0) return null;
+  // A notice with no renderable content (e.g. a payload whose topics or
+  // section bullets were all malformed and dropped) must count as a failed
+  // fetch: caching it would open an empty dialog and, worse, advance
+  // lastReadVersion on dismiss so a corrected CDN payload would never be
+  // shown again. Bullet-level truth, mirroring shared hasRenderableContent.
+  const hasContent =
+    notes.topics.length > 0 || notes.sections.some((s) => s.items.length > 0);
+  if (!hasContent) return null;
   cache.set(version, notes);
   return notes;
 }

--- a/apps/desktop/src/renderer/release-notes/index.ts
+++ b/apps/desktop/src/renderer/release-notes/index.ts
@@ -99,8 +99,9 @@ export async function fetchReleaseNotesIndex(): Promise<string[] | null> {
  * Returns null when the CDN has no entry for this version on the current
  * platform, or when the network/parse fails.
  *
- * The CDN payload uses the same shape as `ReleaseNotes`, so no normalisation
- * is needed — we just memoise and return.
+ * The CDN payload is normalised defensively before caching: missing
+ * `contributors` / `sections` / `topics` become empty arrays, malformed topic
+ * entries are dropped, and legacy author-grouped items are flattened.
  */
 export async function fetchReleaseNotes(
   version: string,

--- a/apps/desktop/src/renderer/release-notes/index.ts
+++ b/apps/desktop/src/renderer/release-notes/index.ts
@@ -9,10 +9,18 @@
  * Successful results are memoised per version so that dismissing and
  * re-opening the dialog from the sidebar does not trigger another fetch.
  *
- * Schema: each section's `items` is an array of author groups
+ * Two payload generations coexist on the CDN:
+ *
+ * Legacy (author-grouped): each section's `items` is an array of author groups
  *   { "name": "Lizi", "list": ["...", "..."] }
  * The dialog flattens these into one bullet per `list` entry under the
  * matching author sub-head.
+ *
+ * Topic format (v2): the payload carries `topics` instead of `sections` —
+ * user-facing theme blocks, each a short narrative paragraph:
+ *   { "emoji": "🎙️", "title": "语音输入更稳", "text": "…", "contributors": ["Lizi"] }
+ * plus an optional top-level `intro` one-liner. Presence of a non-empty
+ * `topics` array is the discriminator; old payloads never have it.
  */
 
 /** Per-item shape after flattening: one bullet with its author tag. */
@@ -33,12 +41,28 @@ export interface ReleaseNoteSection {
   items: ReleaseNoteItem[];
 }
 
+/** Topic-format (v2) block: one user-facing theme with a short narrative. */
+export interface ReleaseNoteTopic {
+  /** Leading emoji for the topic title. Optional — renderer tolerates absence. */
+  emoji?: string;
+  title: string;
+  /** 1–2 sentence user-facing narrative for this topic. */
+  text: string;
+  /** Contributors credited on this topic (small text next to the title). */
+  contributors: string[];
+}
+
 export interface ReleaseNotes {
   version: string;
   date: string;
-  /** Flat contributor list — rendered as a single "Contributors" line. */
+  /** Flat contributor list — rendered as a single thanks line. */
   contributors: string[];
+  /** Legacy author-grouped sections. Empty when the payload is topic-format. */
   sections: ReleaseNoteSection[];
+  /** Topic-format blocks. Non-empty ⇒ dialog renders the topic layout. */
+  topics: ReleaseNoteTopic[];
+  /** Optional one-line lead above the topics (e.g. PR/commit counts). */
+  intro?: string;
 }
 
 /** Fan out one author group into N flat items, one per `list` entry. */
@@ -87,16 +111,29 @@ export async function fetchReleaseNotes(
   const raw = await window.electronAPI.fetchReleaseNotes(version);
   if (!raw) return null;
 
-  // Defensive default: tolerate older payloads missing `contributors`, and
-  // normalise legacy string items into the object form.
+  // Defensive defaults: tolerate older payloads missing `contributors`,
+  // topic-format payloads missing `sections`, and legacy payloads missing
+  // `topics`. Malformed topic entries are dropped rather than crashing.
+  const rawTopics = Array.isArray(raw.topics) ? raw.topics : [];
   const notes: ReleaseNotes = {
     version: raw.version,
     date: raw.date,
     contributors: raw.contributors ?? [],
-    sections: raw.sections.map((s) => ({
+    sections: (raw.sections ?? []).map((s) => ({
       title: s.title,
       items: (s.items as RawReleaseNoteItem[]).flatMap(expandRawItem),
     })),
+    topics: rawTopics
+      .filter((t) => typeof t?.title === 'string' && typeof t?.text === 'string')
+      .map((t) => ({
+        emoji: typeof t.emoji === 'string' ? t.emoji : undefined,
+        title: t.title,
+        text: t.text,
+        contributors: Array.isArray(t.contributors)
+          ? t.contributors.filter((c): c is string => typeof c === 'string')
+          : [],
+      })),
+    intro: typeof raw.intro === 'string' ? raw.intro : undefined,
   };
   cache.set(version, notes);
   return notes;

--- a/apps/desktop/src/renderer/release-notes/index.ts
+++ b/apps/desktop/src/renderer/release-notes/index.ts
@@ -116,16 +116,27 @@ export async function fetchReleaseNotes(
 
   // Defensive defaults: tolerate older payloads missing `contributors`,
   // topic-format payloads missing `sections`, and legacy payloads missing
-  // `topics`. Malformed topic entries are dropped rather than crashing.
+  // `topics`. Malformed entries (topics, sections, author groups, bullets)
+  // are dropped rather than crashing the dialog on a bad CDN document.
   const rawTopics = Array.isArray(raw.topics) ? raw.topics : [];
+  const rawSections = Array.isArray(raw.sections) ? raw.sections : [];
   const notes: ReleaseNotes = {
     version: raw.version,
     date: raw.date,
-    contributors: raw.contributors ?? [],
-    sections: (raw.sections ?? []).map((s) => ({
-      title: s.title,
-      items: (s.items as RawReleaseNoteItem[]).flatMap(expandRawItem),
-    })),
+    contributors: Array.isArray(raw.contributors)
+      ? raw.contributors.filter((c): c is string => typeof c === 'string')
+      : [],
+    sections: rawSections
+      .filter((s) => typeof s?.title === 'string' && Array.isArray(s?.items))
+      .map((s) => ({
+        title: s.title,
+        items: (s.items as RawReleaseNoteItem[])
+          .filter((g) => typeof g?.name === 'string' && Array.isArray(g?.list))
+          .flatMap((g) => expandRawItem({
+            name: g.name,
+            list: g.list.filter((text): text is string => typeof text === 'string'),
+          })),
+      })),
     topics: rawTopics
       .filter((t) => isRenderableTopic(t))
       .map((t) => ({

--- a/apps/desktop/src/renderer/release-notes/index.ts
+++ b/apps/desktop/src/renderer/release-notes/index.ts
@@ -136,6 +136,11 @@ export async function fetchReleaseNotes(
       })),
     intro: typeof raw.intro === 'string' ? raw.intro : undefined,
   };
+  // A notice with no renderable content (e.g. a v2 payload whose topics were
+  // all malformed and dropped) must count as a failed fetch: caching it would
+  // open an empty dialog and, worse, advance lastReadVersion on dismiss so a
+  // corrected CDN payload would never be shown again.
+  if (notes.sections.length === 0 && notes.topics.length === 0) return null;
   cache.set(version, notes);
   return notes;
 }

--- a/apps/desktop/src/renderer/release-notes/index.ts
+++ b/apps/desktop/src/renderer/release-notes/index.ts
@@ -23,6 +23,8 @@
  * `topics` array is the discriminator; old payloads never have it.
  */
 
+import { isRenderableTopic } from '../../shared/releaseNotesContent';
+
 /** Per-item shape after flattening: one bullet with its author tag. */
 export interface ReleaseNoteItem {
   text: string;
@@ -125,7 +127,7 @@ export async function fetchReleaseNotes(
       items: (s.items as RawReleaseNoteItem[]).flatMap(expandRawItem),
     })),
     topics: rawTopics
-      .filter((t) => typeof t?.title === 'string' && typeof t?.text === 'string')
+      .filter((t) => isRenderableTopic(t))
       .map((t) => ({
         emoji: typeof t.emoji === 'string' ? t.emoji : undefined,
         title: t.title,

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -4503,8 +4503,11 @@ interface RawReleaseNotesTopic {
 interface RawReleaseNotesPayload {
   version: string;
   date: string;
-  /** Flat contributor list — collective hall-of-fame on top of per-item `by`. */
-  contributors: string[];
+  /**
+   * Flat contributor list — collective hall-of-fame on top of per-item `by`.
+   * Optional: older notice files predate the field (renderer defaults to []).
+   */
+  contributors?: string[];
   /** Legacy author-grouped sections. Absent on topic-format payloads. */
   sections?: RawReleaseNotesSection[];
   /** Topic-format blocks. Non-empty ⇒ renderer uses the topic layout. */

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -4492,12 +4492,25 @@ interface RawReleaseNotesSection {
   items: RawReleaseNotesItem[];
 }
 
+/** Topic-format (v2) block: one user-facing theme with a short narrative. */
+interface RawReleaseNotesTopic {
+  emoji?: string;
+  title: string;
+  text: string;
+  contributors?: string[];
+}
+
 interface RawReleaseNotesPayload {
   version: string;
   date: string;
   /** Flat contributor list — collective hall-of-fame on top of per-item `by`. */
   contributors: string[];
-  sections: RawReleaseNotesSection[];
+  /** Legacy author-grouped sections. Absent on topic-format payloads. */
+  sections?: RawReleaseNotesSection[];
+  /** Topic-format blocks. Non-empty ⇒ renderer uses the topic layout. */
+  topics?: RawReleaseNotesTopic[];
+  /** Optional one-line lead above the topics (e.g. PR/commit counts). */
+  intro?: string;
 }
 
 /* ── SkillHub Registry types (v0.6) ──

--- a/apps/desktop/src/shared/releaseNotesContent.ts
+++ b/apps/desktop/src/shared/releaseNotesContent.ts
@@ -1,0 +1,40 @@
+/**
+ * releaseNotesContent.ts
+ * ---------------------------------------------------------------------------
+ * Shared (main + renderer) content-validity predicates for update-notice
+ * payloads. Both sides must agree on what counts as renderable: main uses
+ * them to avoid caching a payload the renderer would reject (a poisoned
+ * process-lifetime cache would keep serving the bad document even after the
+ * CDN is corrected), and the renderer uses them to filter topic entries.
+ */
+
+/** Minimal structural shape both processes can check without full typing. */
+interface TopicLike {
+  title?: unknown;
+  text?: unknown;
+}
+
+/**
+ * A topic renders iff both title and text are non-blank strings. Blank
+ * strings would produce an empty block, so they count as malformed.
+ */
+export function isRenderableTopic(topic: TopicLike | null | undefined): boolean {
+  return (
+    typeof topic?.title === 'string' &&
+    topic.title.trim() !== '' &&
+    typeof topic?.text === 'string' &&
+    topic.text.trim() !== ''
+  );
+}
+
+/**
+ * Whether a raw CDN payload carries anything the dialog can render: a
+ * non-empty legacy `sections` array, or at least one valid v2 topic.
+ */
+export function hasRenderableContent(raw: {
+  sections?: unknown;
+  topics?: unknown;
+}): boolean {
+  if (Array.isArray(raw.sections) && raw.sections.length > 0) return true;
+  return Array.isArray(raw.topics) && raw.topics.some((t) => isRenderableTopic(t as TopicLike));
+}

--- a/apps/desktop/src/shared/releaseNotesContent.ts
+++ b/apps/desktop/src/shared/releaseNotesContent.ts
@@ -8,10 +8,20 @@
  * CDN is corrected), and the renderer uses them to filter topic entries.
  */
 
-/** Minimal structural shape both processes can check without full typing. */
+/** Minimal structural shapes both processes can check without full typing. */
 interface TopicLike {
   title?: unknown;
   text?: unknown;
+}
+
+interface SectionLike {
+  title?: unknown;
+  items?: unknown;
+}
+
+interface AuthorGroupLike {
+  name?: unknown;
+  list?: unknown;
 }
 
 /**
@@ -28,13 +38,30 @@ export function isRenderableTopic(topic: TopicLike | null | undefined): boolean 
 }
 
 /**
- * Whether a raw CDN payload carries anything the dialog can render: a
- * non-empty legacy `sections` array, or at least one valid v2 topic.
+ * A legacy section renders iff it yields at least one actual bullet: string
+ * title, array items, and some author group with a string name and at least
+ * one string bullet. Mirrors the renderer's per-entry normalization filters —
+ * the two sides must agree, or main would cache a document the renderer
+ * rejects (process-lifetime cache poisoning).
+ */
+export function isRenderableSection(section: SectionLike | null | undefined): boolean {
+  if (typeof section?.title !== 'string' || !Array.isArray(section?.items)) return false;
+  return section.items.some((group: AuthorGroupLike | null | undefined) => {
+    if (typeof group?.name !== 'string' || !Array.isArray(group?.list)) return false;
+    return group.list.some((text) => typeof text === 'string');
+  });
+}
+
+/**
+ * Whether a raw CDN payload carries anything the dialog can render: at least
+ * one legacy section with a real bullet, or at least one valid v2 topic.
  */
 export function hasRenderableContent(raw: {
   sections?: unknown;
   topics?: unknown;
 }): boolean {
-  if (Array.isArray(raw.sections) && raw.sections.length > 0) return true;
+  if (Array.isArray(raw.sections) && raw.sections.some((s) => isRenderableSection(s as SectionLike))) {
+    return true;
+  }
   return Array.isArray(raw.topics) && raw.topics.some((t) => isRenderableTopic(t as TopicLike));
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

更新公告弹窗的可读性改版。现在的公告按「作者 → 条目」两栏(新功能 / 问题修复)排版,读者要先扫一遍贡献者 ID 才能看到内容;纯修复版本(如 v0.1.17)左栏整个空白,占掉一半宽度。本 PR 引入主题式 topic 格式(v2):公告按用户视角的主题聚合(如 🎙️ 语音输入 / 🧩 插件生态 / 💳 计费),每题一段一两句的叙述,单栏居中排版;作者署名保留为主题标题右侧的小字,头部致谢行照旧。legacy 格式完全兼容,CDN 上的存量历史版本渲染不变。

同时把头部致谢行的「出品」改为「感谢」(4 语言),图标由小刀(Swords)换成鲜花(Flower)。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求：无(维护者发起的公告可读性改进)
- 本 PR 包含：
  - `release-notes/index.ts`:`ReleaseNotes` 新增 `topics` / `intro` 字段与防御性归一化(畸形 topic 条目丢弃、缺 `sections` 不炸)
  - `UpdateNoticeDialog.tsx`:新增 `TopicList` 单栏渲染,`topics` 非空时替换两栏布局(auto 单版本 / auto 多版本 / manual 懒加载三条路径都覆盖);`craftedBy`→`thanksTo`;Swords→Flower
  - `releaseNotesService.ts` / `vite-env.d.ts`:Raw payload 类型同步(`sections` 可选、新增 `topics` / `intro`)
  - i18n 4 语言:`update.notice.craftedBy` 改名 `update.notice.thanksTo`,译文「感谢 / Thanks to / 感謝 / 감사」
  - 新增单测 `releaseNotesNormalize.test.ts`(legacy 展开 / v2 透传 / 畸形条目丢弃)
- 明确不包含：公告 JSON 的生成流程(由仓外发布工具产出 v2 JSON;未产出前线上仍是 legacy 格式,渲染走旧路径,行为不变)
- 用户可见变化：收到 v2 格式公告时,弹窗正文为单栏主题块;致谢行文案与图标变化对所有用户可见
- 是否存在 breaking change：无。`topics` 缺失时走原两栏渲染;旧客户端只拉取 `≤ 自身版本` 的公告 JSON(`versionsForManual` / `versionsToFetch` 都以 appVersion 截断),不会碰到 v2 文件

### UI 变化

弹窗正文(v2 时)改为单栏主题块:emoji + 主题标题 + 右侧贡献者小字,下接一两句正文,内容列宽 760px 居中;头部致谢行「🌼 感谢 xxx · xxx」。截图:维护者已在静态 harness 页面(复刻组件规格与真实 token 值)目检明暗两种模式;实机截图待 review 时可补。

- 引用的设计规范：DESIGN.md §10 Theme System——全部颜色走既有语义 token(`--cmd-palette-item-meta` / `--msg-assistant-text` / `--status-bar-accent` 等),无新增硬编码色值,Light/Dark 自动跟随;§2 色彩角色——accent 仅用于致谢行图标,沿用原 `--status-bar-accent` 用法;§7 Don'ts——无新增阴影/渐变/圆角值,复用组件内既有字号刻度(text-12/13/15/sm)

## 怎么验证的

### 自动验证

```text
pnpm test:unit                             结果:全部 PASS(apps/desktop unit 118.6s,含新增 releaseNotesNormalize.test.ts 3 例)
pnpm --filter desktop run typecheck        结果:通过
pnpm check:i18n                            结果:4 语言 5586 key 全部一致
pnpm check:i18n-glossary                   结果:无新增违规
pnpm check:dco                             结果:1 commit signed off
```

### 手工验证

以静态 harness 页面(按组件真实 class 规格与 colors.ts 真实 token 值复刻)目检了 v2 主题布局的 Light / Dark 两种模式、纯修复小版本与多主题大版本两种内容形态、固定高度内部滚动行为。

### 未执行的验证

未在实机 dev 实例触发真实弹窗目检(公告 JSON 由 CDN 下发,本地触发需要 mock 数据源);类型/单测/静态 harness 已覆盖渲染分支,实机双模式目检未做,如实说明。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅更新公告弹窗渲染与致谢行文案/图标。数据格式为纯 additive(新增可选字段),legacy 渲染路径未删改;发布侧未产出 v2 JSON 之前线上行为完全不变。
- 回滚 / 降级方式：revert 本 commit 即可;或发布侧继续产出 legacy 格式 JSON,客户端自动走旧渲染。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
