### PR TITLE
fix(mobile): 补送 #540 的 review 修复(合并竞态漏掉)

### DIFF
--- a/apps/mobile/src/__tests__/interactionModel.test.ts
+++ b/apps/mobile/src/__tests__/interactionModel.test.ts
@@ -217,11 +217,18 @@ describe('interactionModel', () => {
     // 取消出口:没有出口 + 卡接管输入框 = 会话锁死(线上已复现)。
     expect(interactionPanelSource).toContain("if (kind === 'plugin_setup')");
     expect(interactionPanelSource).toContain('buildPluginSetupCancelDecision(item.request)');
-    expect(interactionPanelSource).toContain('interaction.unsupported.cancelButton');
-    // 未知 kind 仍回退到 UnsupportedCard 的合并摘要:每行各自 numberOfLines 会把
-    // 总高度放大成 6 × 行数。
-    expect(interactionPanelSource).toContain("const summaryText = (summaryLines ?? [contentToPreview(request)])");
+    // testID 与 UnsupportedCard 区分开,UI 测试才能精确定位这张卡的取消按钮(#540 review)。
+    expect(interactionPanelSource).toContain('interaction.pluginSetup.cancelButton');
+    expect(interactionPanelSource).not.toContain('interaction.unsupported.cancelButton');
+    // 未知 kind 仍回退到 UnsupportedCard 的 request 预览,整段一次限行:每行各自
+    // numberOfLines 会把总高度放大成 6 × 行数。
+    expect(interactionPanelSource).toContain('const summaryText = contentToPreview(request);');
     expect(interactionPanelSource).not.toContain('lines.map((line, index)');
+    // plugin_setup 移出 UnsupportedCard 后,当初为它加的形参不能留成没人走的分支。
+    // 钉形参声明与 JSX 传参本身,不做全文匹配——注释里可以照常说明这段历史。
+    for (const dead of ['summaryLines?:', 'summaryLines={', 'kindLabel?:', 'kindLabel={']) {
+      expect(interactionPanelSource, dead).not.toContain(dead);
+    }
     // 取消由被控端按 expectedRevision 裁决,不能乐观撤卡(撤了可能其实没取消);
     // 但仍要按该 revision 封顶抑制,否则取消前发出的慢快照会把卡写回来。
     expect(interactionPanelSource).toContain('optimisticDismiss: false');
@@ -288,6 +295,8 @@ describe('interactionModel', () => {
           'interaction.pluginSetup.desktopActionHint',
           'interaction.pluginSetup.inlineFormAction',
           'interaction.pluginSetup.inlineFormActionGeneric',
+          // 读屏聚合分隔符:硬编码「，」会让非中文 locale 念出中文标点(#540 review)
+          'interaction.pluginSetup.a11ySeparator',
         ]) {
           expect(i18n.t(key), `${locale} ${key}`).not.toBe(key);
         }

--- a/apps/mobile/src/i18n/locales/en/interaction.json
+++ b/apps/mobile/src/i18n/locales/en/interaction.json
@@ -182,9 +182,9 @@
   "pluginSetup": {
     "completeOnDesktop": "Complete this setup on the controlled desktop. This card will update automatically.",
     "chooseOne": "Choose one setup method",
-    "stepsHeading": "Setup steps",
     "progress": "{{satisfied}}/{{total}} completed",
     "desktopActionHint": "On your computer: {{action}}",
+    "a11ySeparator": ", ",
     "phase": {
       "pending": "Pending",
       "action_running": "In progress…",

--- a/apps/mobile/src/i18n/locales/ja/interaction.json
+++ b/apps/mobile/src/i18n/locales/ja/interaction.json
@@ -182,9 +182,9 @@
   "pluginSetup": {
     "completeOnDesktop": "操作対象のデスクトップで設定を完了してください。このカードは自動的に更新されます。",
     "chooseOne": "設定方法を1つ選択してください",
-    "stepsHeading": "設定手順",
     "progress": "{{satisfied}}/{{total}} 完了",
     "desktopActionHint": "パソコンで{{action}}",
+    "a11ySeparator": "、",
     "phase": {
       "pending": "設定待ち",
       "action_running": "処理中…",

--- a/apps/mobile/src/i18n/locales/ko/interaction.json
+++ b/apps/mobile/src/i18n/locales/ko/interaction.json
@@ -182,9 +182,9 @@
   "pluginSetup": {
     "completeOnDesktop": "제어 중인 데스크톱에서 설정을 완료하세요. 이 카드는 자동으로 업데이트됩니다.",
     "chooseOne": "설정 방법을 하나 선택하세요",
-    "stepsHeading": "설정 단계",
     "progress": "{{satisfied}}/{{total}} 완료",
     "desktopActionHint": "컴퓨터에서 {{action}}",
+    "a11ySeparator": ", ",
     "phase": {
       "pending": "설정 대기",
       "action_running": "진행 중…",

--- a/apps/mobile/src/i18n/locales/zh-CN/interaction.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/interaction.json
@@ -182,9 +182,9 @@
   "pluginSetup": {
     "completeOnDesktop": "请在被控桌面完成设置，本卡片会自动更新状态。",
     "chooseOne": "选择一种配置方式",
-    "stepsHeading": "配置步骤",
     "progress": "{{satisfied}}/{{total}} 已完成",
     "desktopActionHint": "在电脑端{{action}}",
+    "a11ySeparator": "，",
     "phase": {
       "pending": "待设置",
       "action_running": "进行中…",

--- a/apps/mobile/src/session/InteractionPanel.tsx
+++ b/apps/mobile/src/session/InteractionPanel.tsx
@@ -407,7 +407,6 @@ function InteractionItem({
   if (!requestId) {
     return (
       <UnsupportedCard
-        kind={kind}
         message={t('interaction.panel.missingRequestId')}
         request={item.request}
         touchLayout={touchLayout}
@@ -450,7 +449,6 @@ function InteractionItem({
   if (kind === 'issue_confirm') {
     return (
       <UnsupportedCard
-        kind={kind}
         message={t('interaction.panel.issueConfirmUnsupported')}
         request={item.request}
         touchLayout={touchLayout}
@@ -488,7 +486,6 @@ function InteractionItem({
   }
   return (
     <UnsupportedCard
-      kind={kind}
       message={t('interaction.panel.unsupportedType')}
       request={item.request}
       touchLayout={touchLayout}
@@ -1417,7 +1414,7 @@ function PluginSetupCard({
             onPress={cancel.onPress}
             requestId={requestId}
             touchStyle={resolveButtonLayoutStyle(touchLayout, 'secondary')}
-            testID="interaction.unsupported.cancelButton"
+            testID="interaction.pluginSetup.cancelButton"
             variant="secondary"
           />
         </View>
@@ -1458,10 +1455,11 @@ function PluginSetupStepRow({ step }: { step: RemotePluginSetupStep }) {
   return (
     <View
       // 聚合成一个读屏单元:标题 / 状态 / 待办 / 错误分开念会把一步拆成四条碎片。
+      // 分隔符走文案目录:硬编码「，」会让 en / ja / ko 的读屏念出中文标点。
       accessible
       accessibilityLabel={[step.title, phaseText, step.description, visibleActionHint, errorText]
         .filter((part): part is string => !!part)
-        .join('，')}
+        .join(t('interaction.pluginSetup.a11ySeparator'))}
       style={styles.pluginSetupStep}
       testID="interaction.pluginSetup.step"
     >
@@ -1486,60 +1484,31 @@ function PluginSetupStepRow({ step }: { step: RemotePluginSetupStep }) {
   );
 }
 
+/**
+ * 本端既处理不了、也没有可用出口的卡:缺 requestId 的残卡、issue_confirm,以及
+ * 任何未知 kind。纯展示——`plugin_setup` 自 PluginSetupCard 起不再走这里,当时
+ * 为它加的 cancel / busy / kindLabel / summaryLines 形参已随之失去调用方,一并
+ * 移除,避免留下没人走的分支。
+ */
 function UnsupportedCard({
-  busy = false,
-  cancel = null,
-  kind,
-  kindLabel,
   message,
   request,
-  requestId = null,
-  summaryLines,
   touchLayout,
 }: {
-  busy?: boolean;
-  /** 本端唯一能做的动作(目前只有 plugin_setup 的取消);null = 纯展示卡。 */
-  cancel?: { accessibilityLabel: string; label: string; onPress(): void } | null;
-  kind: string;
-  /** eyebrow 覆写;缺省是「暂不支持」。 */
-  kindLabel?: string;
   message: string;
   request: PendingInteraction['request'];
-  requestId?: string | null;
-  /**
-   * 可读摘要。**未提供**时才回退成 request 预览(未知类型只能这样交底);提供了
-   * 空数组表示「这类卡本来就该只显示标题」,不能再掉回 raw JSON —— 那正是本次要
-   * 消灭的展示(#530 review)。
-   */
-  summaryLines?: string[];
   touchLayout: InteractionTouchLayout;
 }) {
   const styles = useThemedStyles(makeStyles);
   const { t } = useTranslation();
-  // 合并成一段带换行的文本再限行:每行各自 numberOfLines={6} 会把总可见行数放大成
-  // 6 × 行数,步骤多时把卡撑得很高(#530 review)。
-  const summaryText = (summaryLines ?? [contentToPreview(request)])
-    .filter((line) => line.length > 0)
-    .join('\n');
+  // 未知类型只能靠 request 预览交底;整段一次限行,不按行各自限行(每行各自
+  // numberOfLines={6} 会把总可见行数放大成 6 × 行数,#530 review)。
+  const summaryText = contentToPreview(request);
   return (
     <View style={cardStyle(styles, touchLayout)} testID="interaction.unsupported.card">
-      <Text style={styles.kind}>{kindLabel ?? t('interaction.panel.unsupportedKind')}</Text>
+      <Text style={styles.kind}>{t('interaction.panel.unsupportedKind')}</Text>
       <Text style={styles.cardTitle}>{message}</Text>
       {summaryText ? <Text style={styles.body} numberOfLines={6}>{summaryText}</Text> : null}
-      {cancel ? (
-        <View style={actionsStyle(styles, touchLayout)}>
-          <ResolveButton
-            accessibilityLabel={cancel.accessibilityLabel}
-            busy={busy}
-            label={cancel.label}
-            onPress={cancel.onPress}
-            requestId={requestId}
-            touchStyle={resolveButtonLayoutStyle(touchLayout, 'secondary')}
-            testID="interaction.unsupported.cancelButton"
-            variant="secondary"
-          />
-        </View>
-      ) : null}
     </View>
   );
 }

--- a/packages/maker-shared/src/__tests__/interaction.test.ts
+++ b/packages/maker-shared/src/__tests__/interaction.test.ts
@@ -695,7 +695,7 @@ describe('interaction shared model', () => {
     expect(presentation.terminal).toBe(true);
     expect(presentation.stepCount).toBe(1);
     expect(presentation.groups).toEqual([{
-      id: 'a-group',
+      id: 'a-group-0',
       anyOf: false,
       steps: [{
         id: 'a',
@@ -714,6 +714,19 @@ describe('interaction shared model', () => {
       requestId: 's1',
       ghost: { id: 'g', name: 'G', iconDataUrl: 'https://example.com/icon.png' },
     }).iconDataUrl).toBeNull();
+
+    // 远端重复用同一个 step id 且都缺 groupId 时,仍必须各自成组——只按 step.id 造
+    // fallback key 会把它们并回一组,与「缺 groupId 各自成组」的语义矛盾(#540 review)。
+    const duplicated = buildRemotePluginSetupPresentation({
+      kind: 'plugin_setup',
+      requestId: 's1',
+      steps: [
+        { id: 'same', title: '第一步' },
+        { id: 'same', title: '第二步' },
+      ],
+    });
+    expect(duplicated.groups.map((g) => g.id)).toEqual(['same-group-0', 'same-group-1']);
+    expect(duplicated.groups.map((g) => g.steps.length)).toEqual([1, 1]);
 
     // 换个 kind 传进来必须返回空投影,而不是从任意 request 上刮字段让误用「看起来正常」。
     expect(buildRemotePluginSetupPresentation({

--- a/packages/maker-shared/src/__tests__/interaction.test.ts
+++ b/packages/maker-shared/src/__tests__/interaction.test.ts
@@ -695,7 +695,7 @@ describe('interaction shared model', () => {
     expect(presentation.terminal).toBe(true);
     expect(presentation.stepCount).toBe(1);
     expect(presentation.groups).toEqual([{
-      id: 'a-group-0',
+      id: 'ungrouped-0',
       anyOf: false,
       steps: [{
         id: 'a',
@@ -725,8 +725,24 @@ describe('interaction shared model', () => {
         { id: 'same', title: '第二步' },
       ],
     });
-    expect(duplicated.groups.map((g) => g.id)).toEqual(['same-group-0', 'same-group-1']);
+    expect(duplicated.groups.map((g) => g.id)).toEqual(['ungrouped-0', 'ungrouped-1']);
     expect(duplicated.groups.map((g) => g.steps.length)).toEqual([1, 1]);
+
+    // 合成身份与被控端真实 groupId 共用命名空间:撞名时绝不能并组,否则两批互不
+    // 相关的要求会被当成「二选一」,用户漏做另一半(#657 review)。
+    const collided = buildRemotePluginSetupPresentation({
+      kind: 'plugin_setup',
+      requestId: 's1',
+      steps: [
+        { id: 'a', title: '无组步骤' },
+        { id: 'b', title: '真实组步骤', groupId: 'ungrouped-0', groupMode: 'any_of' },
+      ],
+    });
+    expect(collided.groups.map((g) => g.steps.map((s) => s.title))).toEqual([['无组步骤'], ['真实组步骤']]);
+    // 展示 id 仍去重,渲染层拿它当 list key。
+    expect(collided.groups.map((g) => g.id)).toEqual(['ungrouped-0', 'ungrouped-0-2']);
+    // 撞名的真实组只有 1 步 → any_of 收敛为 false,不会误显示「任选其一」。
+    expect(collided.groups.map((g) => g.anyOf)).toEqual([false, false]);
 
     // 换个 kind 传进来必须返回空投影,而不是从任意 request 上刮字段让误用「看起来正常」。
     expect(buildRemotePluginSetupPresentation({

--- a/packages/maker-shared/src/interaction.ts
+++ b/packages/maker-shared/src/interaction.ts
@@ -597,7 +597,10 @@ export function buildRemotePluginSetupPresentation(
     if (phase === 'satisfied') satisfiedCount += 1;
 
     // 分组按首次出现顺序保留;groupId 缺失的步骤各自成组,不并进同一个「空组」。
-    const groupId = trimmedOrNull(rawStep.groupId) ?? `${step.id}-group`;
+    // fallback 必须带 index:远端 payload 若重复用同一个 step id(甚至全都缺 id、
+    // 一起落到 `step-${index}` 之外的同名值),只按 step.id 造的 key 会把它们又并
+    // 回一组,与上面这句注释自相矛盾(#540 review)。
+    const groupId = trimmedOrNull(rawStep.groupId) ?? `${step.id}-group-${index}`;
     const existing = groupsById.get(groupId);
     if (existing) {
       existing.steps.push(step);

--- a/packages/maker-shared/src/interaction.ts
+++ b/packages/maker-shared/src/interaction.ts
@@ -596,23 +596,28 @@ export function buildRemotePluginSetupPresentation(
     stepCount += 1;
     if (phase === 'satisfied') satisfiedCount += 1;
 
-    // 分组按首次出现顺序保留;groupId 缺失的步骤各自成组,不并进同一个「空组」。
-    // fallback 必须带 index:远端 payload 若重复用同一个 step id(甚至全都缺 id、
-    // 一起落到 `step-${index}` 之外的同名值),只按 step.id 造的 key 会把它们又并
-    // 回一组,与上面这句注释自相矛盾(#540 review)。
-    const groupId = trimmedOrNull(rawStep.groupId) ?? `${step.id}-group-${index}`;
-    const existing = groupsById.get(groupId);
+    // 分组按首次出现顺序保留。
+    const rawGroupId = trimmedOrNull(rawStep.groupId);
+    if (rawGroupId === null) {
+      // 缺 groupId 的步骤各自成组,并且**不进 groupsById**:合成的 id 与被控端真实
+      // groupId 共用一个命名空间,一旦撞名(远端某组恰好就叫合成出来的那个名字),
+      // 两批互不相关的配置要求会被并成一组、还套上 any_of 语义,让用户以为「二选
+      // 一」而漏做另一半(#657 review)。生成身份只用于本地展示,不参与查表。
+      groups.push({ id: `ungrouped-${index}`, anyOf: false, steps: [step] });
+      return;
+    }
+    const existing = groupsById.get(rawGroupId);
     if (existing) {
       existing.steps.push(step);
       if (rawStep.groupMode === 'any_of') existing.anyOf = true;
       return;
     }
     const group: RemotePluginSetupGroup = {
-      id: groupId,
+      id: rawGroupId,
       anyOf: rawStep.groupMode === 'any_of',
       steps: [step],
     };
-    groupsById.set(groupId, group);
+    groupsById.set(rawGroupId, group);
     groups.push(group);
   });
 
@@ -621,11 +626,30 @@ export function buildRemotePluginSetupPresentation(
     iconDataUrl: inlineImageDataUrl(ghost?.iconDataUrl),
     intro: trimmedOrNull(request.intro),
     // 单项组没有「任选其一」的语义,提示只会让用户困惑。
-    groups: groups.map((group) => ({ ...group, anyOf: group.anyOf && group.steps.length > 1 })),
+    groups: dedupeGroupIds(groups).map((group) => ({
+      ...group,
+      anyOf: group.anyOf && group.steps.length > 1,
+    })),
     satisfiedCount,
     stepCount,
     terminal: request.terminal === true,
   };
+}
+
+/**
+ * 保证组 id 在本次投影内唯一(渲染层拿它当 list key)。
+ *
+ * 合成的 `ungrouped-*` 已经不参与合并,但仍可能与被控端某个真实 groupId 撞名;
+ * 那只是展示身份重复,不该退化成重复 key。id 不回传被控端,改写是安全的。
+ */
+function dedupeGroupIds(groups: RemotePluginSetupGroup[]): RemotePluginSetupGroup[] {
+  const used = new Set<string>();
+  return groups.map((group) => {
+    let id = group.id;
+    for (let suffix = 2; used.has(id); suffix += 1) id = `${group.id}-${suffix}`;
+    used.add(id);
+    return id === group.id ? group : { ...group, id };
+  });
 }
 
 function trimmedOrNull(value: unknown): string | null {


### PR DESCRIPTION
## 这次改了什么

### 摘要

补送 #540 的 4 条 review 修复——它们因为一次合并竞态没能进入 `main`。

时间线：#540 的 review 反馈修复 commit 提交于 `2026-07-26T16:12:49Z`，push 稍晚几秒；PR 于 `16:12:52Z` 被合并，合并的是当时的 head `09352c6b`。结果 merge commit `8bb72510` 里不含这批修复，而对应的 4 条 review thread 已在合并后被回复并 resolve——记录看起来闭环，代码其实没跟上。本 PR 把它们原样补上（已 rebase 到最新 `main`，重跑完整门禁）。

reviewer 提的 4 条：

| # | 问题 | 本 PR 的修法 |
|---|---|---|
| 1 | `groupId` 缺失时 fallback 只按 `step.id` 造 key，远端若重复用同一个 step id 会把它们并回一组，与紧邻注释「缺 groupId 各自成组」自相矛盾 | fallback 补 index：`` `${step.id}-group-${index}` `` |
| 2 | 步骤行读屏聚合 label 硬编码中文逗号拼接，en / ja / ko 的屏幕阅读器会念出中文标点 | 分隔符走文案目录 `interaction.pluginSetup.a11ySeparator`（zh-CN 「，」/ en `", "` / ja 「、」/ ko `", "`） |
| 3 | `stepsHeading` 四语言都加了却没有任何渲染处 | 删除，不留死文案 |
| 4 | 取消按钮沿用 `UnsupportedCard` 的 testID，UI 测试无法精确定位 | 改为 `interaction.pluginSetup.cancelButton` |

外加一处 #540 自身造成的死代码清理：`plugin_setup` 移出 `UnsupportedCard` 后，当初为它加的 `cancel` / `busy` / `requestId` / `kindLabel` / `summaryLines` 形参已全部失去调用方（三个剩余调用点只传 `message` / `request` / `touchLayout`），连同合并成单段文本后不再使用的 `kind` 一并移除，`UnsupportedCard` 回归纯展示卡。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#540 的 review follow-up（4 条 thread 已在该 PR 上回复并 resolve，但修复未随之合入）
- 本 PR 包含：上表 4 条修复 + `UnsupportedCard` 死代码清理 + 对应测试断言更新
- 明确不包含：任何新功能或行为扩展。`plugin_setup` 卡的展示结构、安全边界与文案措辞与 `main` 现状一致，只修上述缺陷
- 用户可见变化：
  - en / ja / ko 用户用屏幕阅读器听插件配置步骤时，不再夹杂中文逗号
  - 其余三条对最终用户无可见变化（内部一致性、死文案、测试可定位性）
- 是否存在 breaking change：无

### UI 变化

无视觉、交互或用户可见文案变化。唯一涉及呈现的是屏幕阅读器聚合 label 的**分隔符**，属无障碍朗读文本，界面上不显示；`stepsHeading` 从未被渲染过；testID 与形参清理不影响任何渲染结果。

- 引用的设计规范：不涉及：本 PR 命中 UI 路径（`apps/mobile/src/session/`、`apps/mobile/src/i18n/`）但无视觉／交互／文案变化——不新增或修改任何颜色、字号、间距、圆角与布局，`plugin_setup` 卡的呈现结构与 `main` 现状一致。相关约束在 #540 已落地且本 PR 未触碰：`docs/design-rules/DESIGN.md` §Light / Dark Dual-Mode Delivery Gate 第 3 条（颜色必须经语义 token 消费，本 PR 零新增 hex）、`apps/mobile/docs/mobile-design-guide.md` §1（灰度环境 + `statusReady` / `statusAccent` 两个语义色）与 §4（`makeStyles` 模块级常量）。唯一涉及呈现的改动是屏幕阅读器聚合 label 的分隔符，属无障碍朗读文本、界面不显示，对应的是 `mobile-design-guide.md` §5 的触控与可访问性要求而非视觉规范。

## 怎么验证的

### 自动验证

```text
pnpm test:unit                                  # 仓库根全量门禁（rebase 到 488e9b9e 后重跑）
结果：通过（exit 0）

pnpm --filter mobile typecheck
结果：通过

pnpm --filter desktop typecheck
结果：通过（本 PR 动了 packages/maker-shared，desktop 依赖它）

pnpm --filter @cindy/maker-shared run --if-present typecheck
结果：该 package 无 typecheck script，按规则自动跳过

pnpm check:i18n-glossary
结果：通过（en / zh-CN / ja / ko 无新增违规）

pnpm --filter mobile test:scope
结果：通过（mobile-scope-guard passed）

pnpm check:dco
结果：通过（1 commit signed off，488e9b9e..7a12907d）
```

测试断言更新：

- `packages/maker-shared/src/__tests__/interaction.test.ts` — 新增「两个 `id: "same"` 且都缺 `groupId` 的 step 必须产出 `["same-group-0", "same-group-1"]` 两个各含 1 步的组」；原 `a-group` 断言相应改为 `a-group-0`。
- `apps/mobile/src/__tests__/interactionModel.test.ts` — testID 断言改为 `interaction.pluginSetup.cancelButton` 并加 `not.toContain('interaction.unsupported.cancelButton')` 防回退；`a11ySeparator` 并入四语言 × 全枚举的文案完整性断言；死代码断言钉形参声明与 JSX 传参（`summaryLines?:` / `summaryLines={` / `kindLabel?:` / `kindLabel={`）而非全文匹配关键词——否则注释里说明这段历史都会误伤。

### 手工验证

不涉及。

### 未执行的验证

- 模拟器 Light / Dark 目检未执行。按 `docs/design-rules/DESIGN.md` §Light / Dark Dual-Mode Delivery Gate，目检是 best-effort、不阻塞合并，据实声明：**两种模式都没有实机目检过**。本 PR 无视觉变化（唯一呈现相关改动是读屏分隔符），因此该项与 #540 相比未新增风险；但此处不主张「无视觉变化 ⇒ 双模式已验证」。
- 未跑 `pnpm test:all`：改动集中在手机端交互面板与其共享 model，不触及原生层、DB、协议 wire format。
- 不改变 mobile runtime fingerprint（不触发冷更）：只动 `apps/mobile/src` 与 `packages/maker-shared`，未碰 `app.json` / `app.config.js` / `eas.json` / `apps/mobile/package.json` / `plugins/` / `modules/`，未增删依赖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

安全边界未变动：手机端仍然只能对 `plugin_setup` 发 `cancel`，`run_action` 与 Secret `submitInline` 的限制原样保留（`plugin-security-and-authoring.md` §4）。本 PR 未新增任何回传通道，也未改动 `phase` / `errorCode` / `actionKind` 的白名单收敛逻辑。

### 影响与回滚

- 影响范围：手机端 `plugin_setup` 卡的分组兜底、读屏 label 分隔符、取消按钮 testID，以及 `UnsupportedCard` 的形参表。
- 回滚 / 降级方式：单 commit，`git revert` 即可完整回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（本 PR 不涉及）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及规则或作者可见契约）
- [x] 已确认测试结果或说明未执行原因
