### PR TITLE
fix(codex): 避免恢复长会话时返回完整历史

### DIFF
--- a/packages/maker-core/src/agents/codex/app-server/protocol.ts
+++ b/packages/maker-core/src/agents/codex/app-server/protocol.ts
@@ -395,6 +395,18 @@ export interface ThreadResumeParams {
    * 用于重启后恢复 host 产品级 prompt。
    */
   developerInstructions?: string;
+  /**
+   * 只恢复 thread 元数据与 live state，不把完整历史塞进单条 NDJSON response。
+   * 历史展示由 Cindy 自己的会话数据负责；需要检查近期 Codex 状态时配合
+   * initialTurnsPage 获取有界摘要。
+   */
+  excludeTurns?: boolean;
+  /** 在 resume response 中附带一页有界的近期 turns。 */
+  initialTurnsPage?: {
+    limit?: number | null;
+    sortDirection?: 'asc' | 'desc' | null;
+    itemsView?: 'notLoaded' | 'summary' | 'full' | null;
+  } | null;
   [k: string]: unknown;
 }
 
@@ -408,6 +420,12 @@ export interface ThreadResumeResponse {
   approvalPolicy: AskForApproval;
   sandbox: SandboxPolicy;
   serviceTier?: ServiceTier | null;
+  /** 仅在请求 initialTurnsPage 时返回。 */
+  initialTurnsPage?: {
+    data: Array<{ id: string; items?: unknown[]; [k: string]: unknown }>;
+    nextCursor: string | null;
+    backwardsCursor: string | null;
+  } | null;
   [k: string]: unknown;
 }
 

--- a/packages/maker-core/src/agents/codex/app-server/protocol.ts
+++ b/packages/maker-core/src/agents/codex/app-server/protocol.ts
@@ -397,16 +397,9 @@ export interface ThreadResumeParams {
   developerInstructions?: string;
   /**
    * 只恢复 thread 元数据与 live state，不把完整历史塞进单条 NDJSON response。
-   * 历史展示由 Cindy 自己的会话数据负责；需要检查近期 Codex 状态时配合
-   * initialTurnsPage 获取有界摘要。
+   * 历史展示由 Cindy 自己的会话数据负责。
    */
   excludeTurns?: boolean;
-  /** 在 resume response 中附带一页有界的近期 turns。 */
-  initialTurnsPage?: {
-    limit?: number | null;
-    sortDirection?: 'asc' | 'desc' | null;
-    itemsView?: 'notLoaded' | 'summary' | 'full' | null;
-  } | null;
   [k: string]: unknown;
 }
 
@@ -420,12 +413,6 @@ export interface ThreadResumeResponse {
   approvalPolicy: AskForApproval;
   sandbox: SandboxPolicy;
   serviceTier?: ServiceTier | null;
-  /** 仅在请求 initialTurnsPage 时返回。 */
-  initialTurnsPage?: {
-    data: Array<{ id: string; items?: unknown[]; [k: string]: unknown }>;
-    nextCursor: string | null;
-    backwardsCursor: string | null;
-  } | null;
   [k: string]: unknown;
 }
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6858,6 +6858,59 @@ describe('CodexAgent plan mode', () => {
     await handle.close();
   });
 
+  it('uses the resolved resume model when a default turn retries after a daemon restart', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnStartCount = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ThreadStart) {
+        return {
+          thread: { id: 'start-thread-id' },
+          model: 'gpt-5',
+          modelProvider: 'openai',
+          cwd: '/repo',
+        };
+      }
+      if (method === Method.TurnStart) {
+        turnStartCount += 1;
+        if (turnStartCount === 1) return { turn: { id: 'turn-1' } };
+        if (turnStartCount === 2) throw new Error('thread not found');
+        return { turn: { id: `turn-${turnStartCount}` } };
+      }
+      if (method === Method.ThreadResume) {
+        return {
+          thread: { id: 'start-thread-id' },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          cwd: '/repo',
+        };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-plan-exit-retry-default-model',
+      model: 'gpt-5',
+      workingDir: '/repo',
+      planMode: true,
+    });
+    handle.setInteractionResolver(async () => ({ kind: 'plan_review', behavior: 'allow' }));
+
+    await handle.send({ type: 'user', content: 'make a plan' });
+    runPlanTurn(host, 'turn-1', '1. do X\n2. do Y');
+
+    await vi.waitFor(() => {
+      expect(turnStartCalls(host)).toHaveLength(3);
+    });
+    const [, retryParams] = turnStartCalls(host)[2] as [string, {
+      collaborationMode?: { mode: string; settings: { model: string; reasoning_effort: string } };
+    }];
+    expect(retryParams.collaborationMode?.settings).toMatchObject({
+      model: 'gpt-5.4',
+      reasoning_effort: 'high',
+    });
+    expect(handle.model).toBe('gpt-5.4');
+    await handle.close();
+  });
+
   it('emits a terminal event when the approved plan implementation turn cannot start', async () => {
     const agent = new CodexAgent(createDeps());
     let turnSeq = 0;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -887,11 +887,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     };
     expect(params.modelProvider).toBe('cindy_openai');
     expect(params.excludeTurns).toBe(true);
-    expect(params.initialTurnsPage).toEqual({
-      limit: 100,
-      sortDirection: 'desc',
-      itemsView: 'summary',
-    });
+    expect(params.initialTurnsPage).toBeUndefined();
     await handle.close();
   });
 
@@ -6537,7 +6533,7 @@ describe('CodexAgent plan mode', () => {
     await normalHandle.close();
   });
 
-  it('does not request a default marker for resumed native plan items without a collaboration marker', async () => {
+  it('conservatively requests a default marker for resumed native plan items', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {
       if (method === Method.ThreadResume) {
@@ -6570,7 +6566,7 @@ describe('CodexAgent plan mode', () => {
     const [, params] = turnStartCalls(host)[0] as [string, Record<string, unknown>];
     expect(params.collaborationMode).toEqual({
       mode: 'default',
-      settings: { ...PLAN_SETTINGS, developer_instructions: '' },
+      settings: PLAN_SETTINGS,
     });
     await handle.close();
   });
@@ -6613,7 +6609,7 @@ describe('CodexAgent plan mode', () => {
     await handle.close();
   });
 
-  it('does not request another default marker when resumed history already ended in Default Mode', async () => {
+  it('conservatively requests a default marker when legacy resumed history ended in Default Mode', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {
       if (method === Method.ThreadResume) {
@@ -6653,60 +6649,16 @@ describe('CodexAgent plan mode', () => {
     const [, params] = turnStartCalls(host)[0] as [string, Record<string, unknown>];
     expect(params.collaborationMode).toEqual({
       mode: 'default',
-      settings: { ...PLAN_SETTINGS, developer_instructions: '' },
+      settings: PLAN_SETTINGS,
     });
     await handle.close();
   });
 
-  it('reads the latest collaboration marker from the bounded descending resume page', async () => {
-    const agent = new CodexAgent(createDeps());
-    const host = installFakeHost(agent, (method) => {
-      if (method === Method.ThreadResume) {
-        return {
-          thread: { id: 'resume-thread-id', turns: [] },
-          initialTurnsPage: {
-            data: [
-              {
-                id: 'turn-default',
-                items: [collaborationModeItem('Default')],
-              },
-              {
-                id: 'turn-plan',
-                items: [collaborationModeItem('Plan')],
-              },
-            ],
-            nextCursor: null,
-            backwardsCursor: null,
-          },
-          model: 'gpt-5.4',
-          modelProvider: 'openai',
-          cwd: '/repo',
-        };
-      }
-      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
-      return undefined;
-    });
-    const handle = await agent.startSession({
-      sessionId: 'session-paged-plan-history',
-      model: 'gpt-5.4',
-      workingDir: '/repo',
-      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
-    });
-
-    await handle.send({ type: 'user', content: 'continue normally' });
-    const [, params] = turnStartCalls(host)[0] as [string, Record<string, unknown>];
-    expect(params.collaborationMode).toEqual({
-      mode: 'default',
-      settings: { ...PLAN_SETTINGS, developer_instructions: '' },
-    });
-    await handle.close();
-  });
-
-  it('does not request a default marker for resumed threads without plan history', async () => {
+  it('conservatively resets sticky collaboration mode after metadata-only resume', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installTurnHost(agent);
     const handle = await agent.startSession({
-      sessionId: 'session-normal-resume-reset',
+      sessionId: 'session-metadata-only-resume-reset',
       model: 'gpt-5.4',
       workingDir: '/repo',
       resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
@@ -6717,7 +6669,7 @@ describe('CodexAgent plan mode', () => {
     const [, params] = turnStartCalls(host)[0] as [string, Record<string, unknown>];
     expect(params.collaborationMode).toEqual({
       mode: 'default',
-      settings: { ...PLAN_SETTINGS, developer_instructions: '' },
+      settings: PLAN_SETTINGS,
     });
     await handle.close();
   });
@@ -6779,15 +6731,7 @@ describe('CodexAgent plan mode', () => {
       }
       if (method === Method.ThreadResume) {
         return {
-          thread: {
-            id: 'start-thread-id',
-            turns: [
-              {
-                id: 'turn-1',
-                items: [collaborationModeItem('Plan')],
-              },
-            ],
-          },
+          thread: { id: 'start-thread-id' },
           model: 'gpt-5.4',
           modelProvider: 'openai',
           cwd: '/repo',
@@ -6804,6 +6748,11 @@ describe('CodexAgent plan mode', () => {
     await vi.waitFor(() => {
       expect(turnStartCalls(host)).toHaveLength(3);
     });
+    const [, resumeParams] = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadResume,
+    ) as [string, { excludeTurns?: boolean; initialTurnsPage?: unknown }];
+    expect(resumeParams.excludeTurns).toBe(true);
+    expect(resumeParams.initialTurnsPage).toBeUndefined();
     const [, failedImplParams] = turnStartCalls(host)[1] as [string, {
       collaborationMode?: { mode: string; settings: { developer_instructions: string | null } };
     }];

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -891,6 +891,24 @@ describe('CodexAgent.startSession developerInstructions', () => {
     await handle.close();
   });
 
+  it('omits metadata-only resume for remote Codex versions older than 0.125.0', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, undefined, { userAgent: 'mock-codex/0.124.0' });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-legacy-remote-resume',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      remoteHostId: 'legacy-remote',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+    const params = host.request.mock.calls.find(([method]) => method === Method.ThreadResume)?.[1] as {
+      excludeTurns?: boolean;
+    };
+    expect(params.excludeTurns).toBeUndefined();
+    await handle.close();
+  });
+
   it('omits thread/start developerInstructions and registers prompt when codex proxy is active', async () => {
     const runtimeConfig = { systemPrompt: 'HOST PRODUCT PROMPT' };
     const userPrompt = [
@@ -6671,6 +6689,26 @@ describe('CodexAgent plan mode', () => {
       mode: 'default',
       settings: PLAN_SETTINGS,
     });
+    await handle.close();
+  });
+
+  it('uses the resolved resume model for the default collaboration marker', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installTurnHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-default-model-resume',
+      model: 'gpt-5',
+      workingDir: '/repo',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    await handle.send({ type: 'user', content: 'continue normally' });
+
+    const [, params] = turnStartCalls(host)[0] as [string, {
+      collaborationMode?: { mode: string; settings: { model: string } };
+    }];
+    expect(params.collaborationMode?.settings.model).toBe('gpt-5.4');
+    expect(handle.model).toBe('gpt-5.4');
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -882,8 +882,16 @@ describe('CodexAgent.startSession developerInstructions', () => {
     });
     const params = host.request.mock.calls.find(([method]) => method === Method.ThreadResume)?.[1] as {
       modelProvider?: string;
+      excludeTurns?: boolean;
+      initialTurnsPage?: unknown;
     };
     expect(params.modelProvider).toBe('cindy_openai');
+    expect(params.excludeTurns).toBe(true);
+    expect(params.initialTurnsPage).toEqual({
+      limit: 100,
+      sortDirection: 'desc',
+      itemsView: 'summary',
+    });
     await handle.close();
   });
 
@@ -6636,6 +6644,50 @@ describe('CodexAgent plan mode', () => {
     });
     const handle = await agent.startSession({
       sessionId: 'session-plan-default-marker-resume',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    await handle.send({ type: 'user', content: 'continue normally' });
+    const [, params] = turnStartCalls(host)[0] as [string, Record<string, unknown>];
+    expect(params.collaborationMode).toEqual({
+      mode: 'default',
+      settings: { ...PLAN_SETTINGS, developer_instructions: '' },
+    });
+    await handle.close();
+  });
+
+  it('reads the latest collaboration marker from the bounded descending resume page', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ThreadResume) {
+        return {
+          thread: { id: 'resume-thread-id', turns: [] },
+          initialTurnsPage: {
+            data: [
+              {
+                id: 'turn-default',
+                items: [collaborationModeItem('Default')],
+              },
+              {
+                id: 'turn-plan',
+                items: [collaborationModeItem('Plan')],
+              },
+            ],
+            nextCursor: null,
+            backwardsCursor: null,
+          },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          cwd: '/repo',
+        };
+      }
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-paged-plan-history',
       model: 'gpt-5.4',
       workingDir: '/repo',
       resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -309,21 +309,27 @@ function mapPermissionToCodex(
   }
 }
 
+function codexUserAgentAtLeast(
+  userAgent: string | undefined,
+  minimum: readonly [number, number, number],
+): boolean {
+  const match = /\/(\d+)\.(\d+)\.(\d+)(?:[-+ )]|$)/.exec(userAgent ?? '');
+  if (!match) return false;
+  const version = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
+  for (let i = 0; i < minimum.length; i += 1) {
+    if (version[i]! > minimum[i]!) return true;
+    if (version[i]! < minimum[i]!) return false;
+  }
+  return true;
+}
+
 /**
  * `approvalsReviewer` is verified against the app-server bundled with Codex 0.144.6.
  * Remote hosts may keep an older standalone binary across desktop upgrades, so parse the
  * initialize userAgent and conservatively omit the field unless that verified floor is met.
  */
 function supportsCodexApprovalsReviewer(userAgent: string | undefined): boolean {
-  const match = /\/(\d+)\.(\d+)\.(\d+)(?:[-+ )]|$)/.exec(userAgent ?? '');
-  if (!match) return false;
-  const version = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
-  const minimum = [0, 144, 6] as const;
-  for (let i = 0; i < minimum.length; i += 1) {
-    if (version[i]! > minimum[i]!) return true;
-    if (version[i]! < minimum[i]!) return false;
-  }
-  return true;
+  return codexUserAgentAtLeast(userAgent, [0, 144, 6]);
 }
 
 /**
@@ -334,6 +340,15 @@ function supportsCodexApprovalsReviewer(userAgent: string | undefined): boolean 
  */
 function supportsCodexReadonlyReferenceDirs(userAgent: string | undefined): boolean {
   return supportsCodexApprovalsReviewer(userAgent);
+}
+
+/**
+ * `excludeTurns` was introduced in Codex 0.125.0 and later marked experimental.
+ * Older remote daemons can outlive desktop upgrades, so omit the unknown field
+ * and preserve their legacy full-history resume behavior.
+ */
+function supportsCodexResumeExcludeTurns(userAgent: string | undefined): boolean {
+  return codexUserAgentAtLeast(userAgent, [0, 125, 0]);
 }
 
 const READONLY_REFERENCES_PERMISSION_PROFILE = 'cindy-readonly-references';
@@ -2076,6 +2091,7 @@ export class CodexAgent extends BaseAgent {
     if (initResp.codexHome) this.codexHome = initResp.codexHome;
     const approvalsReviewerSupported = supportsCodexApprovalsReviewer(initResp.userAgent);
     const readonlyReferenceDirsSupported = supportsCodexReadonlyReferenceDirs(initResp.userAgent);
+    const resumeExcludeTurnsSupported = supportsCodexResumeExcludeTurns(initResp.userAgent);
     if (mutableExtraDirs.length > 0 && !readonlyReferenceDirsSupported) {
       releaseHostBindingLeaseIfNeeded();
       throw new Error(
@@ -2410,7 +2426,7 @@ export class CodexAgent extends BaseAgent {
       const useProxyChannel = isCodexProxyChannelReady();
       const params: ThreadResumeParams = {
         threadId: opts.resumeSessionId,
-        excludeTurns: true,
+        ...(resumeExcludeTurnsSupported ? { excludeTurns: true } : {}),
         cwd: opts.workingDir,
         ...currentThreadWorkspaceConfig(),
         ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
@@ -2427,6 +2443,9 @@ export class CodexAgent extends BaseAgent {
         assertCurrentHost('thread/resume');
         if (Object.hasOwn(resp, 'serviceTier')) {
           mutableServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
+        }
+        if (mutableModel === 'gpt-5' && resp.model) {
+          mutableModel = resp.model;
         }
         threadId = resp.thread.id;
         if (useProxyChannel) {
@@ -4115,7 +4134,7 @@ export class CodexAgent extends BaseAgent {
               host.subscribeThread(threadId, handlers);
               const resumeParams: ThreadResumeParams = {
                 threadId,
-                excludeTurns: true,
+                ...(resumeExcludeTurnsSupported ? { excludeTurns: true } : {}),
                 cwd: opts.workingDir,
                 ...currentThreadWorkspaceConfig(),
                 ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -154,12 +154,6 @@ const CODEX_MINIMAL_EFFORT_MODELS = new Set([
   'z-ai/glm-5.2',
 ]);
 
-const CODEX_RESUME_HISTORY_PAGE = {
-  limit: 100,
-  sortDirection: 'desc',
-  itemsView: 'summary',
-} as const;
-
 /**
  * item.type → chip status 文案 (对齐 claude-code 6 类). null = 该 item 不触发 chip 切换
  * (imageView/plan/userMessage/hookPrompt 等是 completed-only 或 UI 不暴露的 item)。
@@ -2355,60 +2349,6 @@ export class CodexAgent extends BaseAgent {
     let threadId: string;
     let codexProductPromptDelivery: AgentSessionHandle['codexProductPromptDelivery'];
 
-    const collaborationModeFromText = (text: string): 'plan' | 'default' | null => {
-      const match = /<collaboration_mode>\s*#\s*(Plan|Default)\s+Mode/i.exec(text);
-      if (!match) return null;
-      return match[1]?.toLowerCase() === 'plan' ? 'plan' : 'default';
-    };
-
-    const textFromResponsesItem = (value: unknown): string[] => {
-      if (!value || typeof value !== 'object') return [];
-      if (Array.isArray(value)) return value.flatMap(textFromResponsesItem);
-      const record = value as Record<string, unknown>;
-      const texts: string[] = [];
-      if (typeof record.text === 'string') texts.push(record.text);
-      if (Array.isArray(record.content)) texts.push(...record.content.flatMap(textFromResponsesItem));
-      return texts;
-    };
-
-    const latestCollaborationModeFromTurns = (
-      turns: unknown,
-    ): 'plan' | 'default' | null => {
-      if (!Array.isArray(turns)) return null;
-      // Codex 0.142.5 thread/resume includes turns[].items. Only collaboration
-      // markers are authoritative here: ordinary non-Plan-Mode Codex turns can
-      // also persist native `type:'plan'` items.
-      let latestCollaborationMode: 'plan' | 'default' | null = null;
-      for (const turn of turns) {
-        if (!turn || typeof turn !== 'object') continue;
-        const items = (turn as { items?: unknown }).items;
-        if (!Array.isArray(items)) continue;
-        for (const item of items) {
-          if (!item || typeof item !== 'object') continue;
-          for (const text of textFromResponsesItem(item)) {
-            latestCollaborationMode = collaborationModeFromText(text) ?? latestCollaborationMode;
-          }
-        }
-      }
-      return latestCollaborationMode;
-    };
-
-    const resumeNeedsDefaultModeMarker = (response: ThreadResumeResponse): boolean => {
-      const page = response.initialTurnsPage;
-      if (page && Array.isArray(page.data)) {
-        // 请求方向是 desc；反转后再复用按时间正序扫描的 marker 判定。
-        const latestMode = latestCollaborationModeFromTurns([...page.data].reverse());
-        // 页面之外仍有更早历史且当前页没 marker 时，无法证明 server 的 sticky
-        // collaborationMode 已复位；保守发一次 default marker。
-        return latestMode === 'plan' || (latestMode === null && page.nextCursor !== null);
-      }
-      // 兼容旧 fake host / 不支持分页字段的 app-server response。
-      const turns = response.thread && typeof response.thread === 'object'
-        ? (response.thread as { turns?: unknown }).turns
-        : undefined;
-      return latestCollaborationModeFromTurns(turns) === 'plan';
-    };
-
     /**
      * 会话中途把单个设置 (serviceTier / model / effort) 立即推给 app-server,
      * 写入后续 turn 的 sticky context — 不必等下一个 turn/start 携带 (与官方
@@ -2471,7 +2411,6 @@ export class CodexAgent extends BaseAgent {
       const params: ThreadResumeParams = {
         threadId: opts.resumeSessionId,
         excludeTurns: true,
-        initialTurnsPage: CODEX_RESUME_HISTORY_PAGE,
         cwd: opts.workingDir,
         ...currentThreadWorkspaceConfig(),
         ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
@@ -2502,7 +2441,10 @@ export class CodexAgent extends BaseAgent {
         // that sticky state lives server-side, conservatively send mode:'default'
         // on future normal turns after any successful resume.
         threadTouchedPlanMode = true;
-        planModeDefaultMarkerNeeded = resumeNeedsDefaultModeMarker(resp);
+        // excludeTurns intentionally loads no history, so we cannot prove whether
+        // the persisted thread last used Plan Mode. Inject the official Default
+        // marker once; markCollaborationModeAccepted() suppresses repeats.
+        planModeDefaultMarkerNeeded = true;
         log.info('thread/resume ok', { threadId, model: resp.model, serviceTier: mutableServiceTier ?? null });
       } catch (e) {
         releaseHostBindingLeaseIfNeeded();
@@ -4174,17 +4116,16 @@ export class CodexAgent extends BaseAgent {
               const resumeParams: ThreadResumeParams = {
                 threadId,
                 excludeTurns: true,
-                initialTurnsPage: CODEX_RESUME_HISTORY_PAGE,
                 cwd: opts.workingDir,
                 ...currentThreadWorkspaceConfig(),
                 ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
                 ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
               };
-              const resumeResp = await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams);
+              await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams);
               if (collaborationMode?.mode === 'default') {
-                planModeDefaultMarkerNeeded = resumeNeedsDefaultModeMarker(resumeResp);
+                planModeDefaultMarkerNeeded = true;
                 if (turnParams.collaborationMode?.mode === 'default') {
-                  turnParams.collaborationMode.settings.developer_instructions = planModeDefaultMarkerNeeded ? null : '';
+                  turnParams.collaborationMode.settings.developer_instructions = null;
                 }
               }
               log.info('thread/resume after stale daemon ok, retrying turn/start', { threadId });

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4159,7 +4159,16 @@ export class CodexAgent extends BaseAgent {
                 ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
                 ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
               };
-              await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams);
+              const resumeResp = await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams);
+              if (mutableModel === 'gpt-5' && resumeResp.model) {
+                mutableModel = resumeResp.model;
+                turnParams.effort = clampEffortForCodex(mutableModel, mutableEffort);
+                if (turnParams.collaborationMode) {
+                  turnParams.collaborationMode.settings.model = mutableModel;
+                  turnParams.collaborationMode.settings.reasoning_effort =
+                    clampEffortForCodex(mutableModel, mutableEffort);
+                }
+              }
               if (collaborationMode?.mode === 'default') {
                 planModeDefaultMarkerNeeded = true;
                 if (turnParams.collaborationMode?.mode === 'default') {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -154,6 +154,12 @@ const CODEX_MINIMAL_EFFORT_MODELS = new Set([
   'z-ai/glm-5.2',
 ]);
 
+const CODEX_RESUME_HISTORY_PAGE = {
+  limit: 100,
+  sortDirection: 'desc',
+  itemsView: 'summary',
+} as const;
+
 /**
  * item.type → chip status 文案 (对齐 claude-code 6 类). null = 该 item 不触发 chip 切换
  * (imageView/plan/userMessage/hookPrompt 等是 completed-only 或 UI 不暴露的 item)。
@@ -2365,10 +2371,10 @@ export class CodexAgent extends BaseAgent {
       return texts;
     };
 
-    const threadHistoryNeedsDefaultModeMarker = (thread: unknown): boolean => {
-      if (!thread || typeof thread !== 'object') return false;
-      const turns = (thread as { turns?: unknown }).turns;
-      if (!Array.isArray(turns)) return false;
+    const latestCollaborationModeFromTurns = (
+      turns: unknown,
+    ): 'plan' | 'default' | null => {
+      if (!Array.isArray(turns)) return null;
       // Codex 0.142.5 thread/resume includes turns[].items. Only collaboration
       // markers are authoritative here: ordinary non-Plan-Mode Codex turns can
       // also persist native `type:'plan'` items.
@@ -2384,7 +2390,23 @@ export class CodexAgent extends BaseAgent {
           }
         }
       }
-      return latestCollaborationMode === 'plan';
+      return latestCollaborationMode;
+    };
+
+    const resumeNeedsDefaultModeMarker = (response: ThreadResumeResponse): boolean => {
+      const page = response.initialTurnsPage;
+      if (page && Array.isArray(page.data)) {
+        // 请求方向是 desc；反转后再复用按时间正序扫描的 marker 判定。
+        const latestMode = latestCollaborationModeFromTurns([...page.data].reverse());
+        // 页面之外仍有更早历史且当前页没 marker 时，无法证明 server 的 sticky
+        // collaborationMode 已复位；保守发一次 default marker。
+        return latestMode === 'plan' || (latestMode === null && page.nextCursor !== null);
+      }
+      // 兼容旧 fake host / 不支持分页字段的 app-server response。
+      const turns = response.thread && typeof response.thread === 'object'
+        ? (response.thread as { turns?: unknown }).turns
+        : undefined;
+      return latestCollaborationModeFromTurns(turns) === 'plan';
     };
 
     /**
@@ -2448,6 +2470,8 @@ export class CodexAgent extends BaseAgent {
       const useProxyChannel = isCodexProxyChannelReady();
       const params: ThreadResumeParams = {
         threadId: opts.resumeSessionId,
+        excludeTurns: true,
+        initialTurnsPage: CODEX_RESUME_HISTORY_PAGE,
         cwd: opts.workingDir,
         ...currentThreadWorkspaceConfig(),
         ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
@@ -2478,7 +2502,7 @@ export class CodexAgent extends BaseAgent {
         // that sticky state lives server-side, conservatively send mode:'default'
         // on future normal turns after any successful resume.
         threadTouchedPlanMode = true;
-        planModeDefaultMarkerNeeded = threadHistoryNeedsDefaultModeMarker(resp.thread);
+        planModeDefaultMarkerNeeded = resumeNeedsDefaultModeMarker(resp);
         log.info('thread/resume ok', { threadId, model: resp.model, serviceTier: mutableServiceTier ?? null });
       } catch (e) {
         releaseHostBindingLeaseIfNeeded();
@@ -4149,6 +4173,8 @@ export class CodexAgent extends BaseAgent {
               host.subscribeThread(threadId, handlers);
               const resumeParams: ThreadResumeParams = {
                 threadId,
+                excludeTurns: true,
+                initialTurnsPage: CODEX_RESUME_HISTORY_PAGE,
                 cwd: opts.workingDir,
                 ...currentThreadWorkspaceConfig(),
                 ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
@@ -4156,7 +4182,7 @@ export class CodexAgent extends BaseAgent {
               };
               const resumeResp = await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams);
               if (collaborationMode?.mode === 'default') {
-                planModeDefaultMarkerNeeded = threadHistoryNeedsDefaultModeMarker(resumeResp.thread);
+                planModeDefaultMarkerNeeded = resumeNeedsDefaultModeMarker(resumeResp);
                 if (turnParams.collaborationMode?.mode === 'default') {
                   turnParams.collaborationMode.settings.developer_instructions = planModeDefaultMarkerNeeded ? null : '';
                 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex 长会话在重启后无法恢复的问题。此前 `thread/resume` 会把完整 turns（包括内嵌 Base64 图片和长文本）放进单条 NDJSON 响应；当该行超过 16 MiB 时，Cindy 的 app-server transport 会直接关闭。

恢复时现在：

- 使用 `excludeTurns: true`，只恢复 thread 元数据与 live state；
- 不请求 turns 分页，避免 `summary` 仍携带大段文本；
- 因为不再读取历史，恢复后的首个普通回合保守注入一次官方 Default Mode marker，随后自动停止重复注入；
- 首次恢复与 stale daemon 重试两条路径行为一致。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #183
- 本 PR 包含：Codex `thread/resume` 请求类型、两条恢复路径、协作模式保守复位及单测
- 明确不包含：调整全局 NDJSON 16 MiB 上限、修改本地会话数据、迁移或删除历史 rollout
- 用户可见变化：含大量图片或长文本的长会话在重启后可继续恢复
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
GIT_CONFIG_GLOBAL=/dev/null pnpm test:unit
结果：通过；root 297 passed / 1 skipped，desktop、mobile、maker-core 等全部 workspace 通过

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts
结果：184 passed

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过，2 commits signed off
```

### 手工验证

在 macOS 上复制实际超限的 Codex rollout 到隔离的 `CODEX_HOME`，使用 Cindy 当前固定的 Codex app-server 0.145.0 实测：

- 原始 `thread/resume` 单行响应：17,524,173 bytes，超过 16 MiB；
- 仅加入 `excludeTurns: true` 后：1,938 bytes；
- 返回 thread 元数据，`turns: []`、`initialTurnsPage: null`，原始 rollout 文件未修改。

### 未执行的验证

未启动完整 Electron UI 手工回归；本次不涉及 UI，且为避免干扰正在运行的 Cindy 会话，采用隔离 app-server 协议复现与全仓单测。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Codex 会话恢复；桌面本地与远程 host 共用同一请求参数，Windows/macOS 行为一致。Cindy 自己的会话展示数据不依赖 app-server 返回的完整 turns。
- 兼容性：当前固定的 Codex app-server 支持 `excludeTurns`；恢复后首次普通回合额外注入一次 Default Mode marker，以覆盖可能残留的 sticky Plan Mode。
- 回滚 / 降级方式：revert 本 PR 的提交即可恢复原来的完整历史响应行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增用户文档）
- [x] 已确认测试结果或说明未执行原因
