### PR TITLE
fix(desktop): avoid wait cursor for plugin conflicts

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -1118,7 +1118,7 @@ export function MarketPluginCard({
         type="button"
         onClick={onSelect}
         disabled={busy || item.installState === 'conflict'}
-        className="flex min-w-0 flex-1 items-start gap-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:cursor-wait"
+        className="flex min-w-0 flex-1 items-start gap-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:cursor-not-allowed"
         aria-label={item.name}
       >
         <GhostPluginIcon

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -1118,7 +1118,12 @@ export function MarketPluginCard({
         type="button"
         onClick={onSelect}
         disabled={busy || item.installState === 'conflict'}
-        className="flex min-w-0 flex-1 items-start gap-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:cursor-not-allowed"
+        className={cn(
+          'flex min-w-0 flex-1 items-start gap-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+          item.installState === 'conflict'
+            ? 'disabled:cursor-not-allowed'
+            : 'disabled:cursor-wait',
+        )}
         aria-label={item.name}
       >
         <GhostPluginIcon

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -257,8 +257,8 @@ describe('GhostPluginCard', () => {
     expect(screen.getByText('Cindy').className).toContain('truncate');
   });
 
-  it('uses an unavailable cursor instead of a loading cursor for market id conflicts', () => {
-    render(
+  it('distinguishes unavailable conflicts from busy market operations', () => {
+    const { rerender } = render(
       <MarketPluginCard
         item={{ ...marketPlugin, installState: 'conflict' }}
         busy={false}
@@ -271,6 +271,20 @@ describe('GhostPluginCard', () => {
     expect((cardBody as HTMLButtonElement).disabled).toBe(true);
     expect(cardBody.className).toContain('disabled:cursor-not-allowed');
     expect(cardBody.className).not.toContain('disabled:cursor-wait');
+
+    rerender(
+      <MarketPluginCard
+        item={marketPlugin}
+        busy
+        onSelect={vi.fn()}
+        onIconLoadError={vi.fn()}
+      />,
+    );
+
+    const busyCardBody = screen.getByRole('button', { name: 'Google Calendar' });
+    expect((busyCardBody as HTMLButtonElement).disabled).toBe(true);
+    expect(busyCardBody.className).toContain('disabled:cursor-wait');
+    expect(busyCardBody.className).not.toContain('disabled:cursor-not-allowed');
   });
 });
 

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -256,6 +256,22 @@ describe('GhostPluginCard', () => {
     expect(screen.getByText('google-calendar').className).toContain('min-w-0');
     expect(screen.getByText('Cindy').className).toContain('truncate');
   });
+
+  it('uses an unavailable cursor instead of a loading cursor for market id conflicts', () => {
+    render(
+      <MarketPluginCard
+        item={{ ...marketPlugin, installState: 'conflict' }}
+        busy={false}
+        onSelect={vi.fn()}
+        onIconLoadError={vi.fn()}
+      />,
+    );
+
+    const cardBody = screen.getByRole('button', { name: 'Google Calendar' });
+    expect((cardBody as HTMLButtonElement).disabled).toBe(true);
+    expect(cardBody.className).toContain('disabled:cursor-not-allowed');
+    expect(cardBody.className).not.toContain('disabled:cursor-wait');
+  });
 });
 
 describe('LegacyGhostRecoveryNotice', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复插件市场卡片处于“插件标识冲突”状态时，鼠标悬浮卡片主体会错误显示 loading / wait 光标的问题。冲突代表该入口不可用，并非正在执行异步操作，因此统一改为与右侧冲突按钮一致的 unavailable / not-allowed 光标。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈的插件市场冲突态光标问题。
- 本 PR 包含：调整市场插件冲突态卡片主体的 disabled cursor，并增加回归测试。
- 明确不包含：插件冲突判断、安装流程、市场数据或插件运行时行为。
- 用户可见变化：悬浮“插件标识冲突”卡片时不再出现 loading 光标，改为不可用光标。
- 是否存在 breaking change：无。

### UI 变化

- 仅修正 disabled 状态的系统光标语义；布局、颜色、文案和动效均不变。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §10.1 Light / Dark Dual-Mode Delivery Gate：disabled 是本次实际触及状态；改动不依赖颜色，在 Light / Dark 下行为一致。
  - `docs/design-rules/DESIGN.md` §4 Component Stylings：保持既有插件卡片及按钮视觉，仅让禁用交互反馈与实际状态一致。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（Desktop、Mobile、共享 packages 全部通过）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --dir apps/desktop exec vitest run src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
结果：通过（15/15）

pnpm --dir apps/desktop exec eslint src/renderer/features/plugin/GhostPluginPage.tsx src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

- macOS Desktop 插件列表。
- 同一插件同时存在本地版本与市场版本，市场卡片显示“插件标识冲突”。
- 用户已确认悬浮冲突卡片时不再出现 loading 光标。

### 未执行的验证

- 未单独进行 Windows 手工验证；使用标准 CSS `cursor: not-allowed`，行为不依赖平台专属代码。
- 未分别截图走查 Light / Dark；本次不改变颜色、布局或主题 token。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的插件市场冲突态卡片。
- 回滚 / 降级方式：回滚本 PR 的单个提交即可。
- 不涉及插件作者契约、权限、IPC、协议、数据或安装逻辑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
