### PR TITLE
fix(desktop): align permission tooltips with selection

### DIFF
--- a/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
@@ -63,11 +63,19 @@ describe('PermissionSelector (MorphPopover pilot)', () => {
     expect(listbox).toBeTruthy();
     expect(screen.getAllByRole('option')).toHaveLength(4);
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
-    // 选中档正确标记(焦点策略 2026-07-23 改回落首个可交互项,恢复键盘可达性,见 codex review)
+    // 选中档正确标记
     const selected = screen
       .getAllByRole('option')
       .find((o) => o.getAttribute('aria-selected') === 'true');
     expect(selected).toBeTruthy();
+  });
+
+  it('打开时聚焦当前选中权限，避免 focus tooltip 错指向首个选项', async () => {
+    renderSelector({ permissionMode: 'bypassPermissions' });
+    fireEvent.click(getTrigger());
+
+    const selectedOption = await screen.findByRole('option', { name: '完全访问' });
+    await waitFor(() => expect(document.activeElement).toBe(selectedOption));
   });
 
   it('点击选项回调 onPermissionModeChange 并收合卸载', async () => {
@@ -185,6 +193,14 @@ describe('PermissionSelector triggerVariant', () => {
 
     fireEvent.click(screen.getByText('完全访问'));
     expect(onChange).toHaveBeenCalledWith('bypassPermissions');
+  });
+
+  it('field 形态打开时同样聚焦当前选中权限', async () => {
+    renderSelector({ triggerVariant: 'field', permissionMode: 'bypassPermissions' });
+    fireEvent.click(getTrigger());
+
+    const selectedOption = await screen.findByRole('option', { name: '完全访问' });
+    await waitFor(() => expect(document.activeElement).toBe(selectedOption));
   });
 
   it('ariaContext 前置到 trigger 可及名(多实例同屏读屏区分,不传则原样)', () => {

--- a/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   Hand,
   CodeXml,
@@ -106,6 +106,7 @@ export function PermissionSelector({
 }: PermissionSelectorProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const selectedOptionRef = useRef<HTMLButtonElement>(null);
   const agentKind = vendorKeyToAgentKind(vendorKey);
   // device-link:deviceId 非空 → 权限档从被控端读(本地会话 undefined,行为不变)。
   const { capabilities } = useAgentCapabilities(agentKind, deviceId);
@@ -219,7 +220,11 @@ export function PermissionSelector({
   );
 
   const optionsList = (
-      <div role="listbox" aria-label={t('newChat.permissionSelector.listAria')}>
+      <div
+        role="listbox"
+        aria-label={t('newChat.permissionSelector.listAria')}
+        className="flex flex-col gap-0.5"
+      >
         {options.map((option) => {
           const Icon = PERMISSION_ICONS[option.id] ?? Hand;
           const isSelected = effectiveMode === option.id;
@@ -234,6 +239,11 @@ export function PermissionSelector({
               contentClassName="max-w-[280px] whitespace-normal break-words text-left"
             >
               <button
+                type="button"
+                ref={isSelected ? selectedOptionRef : undefined}
+                // MorphPopover 打开后优先聚焦当前选中项；否则会聚焦列表首项，
+                // 触发“默认权限”的 focus tooltip，造成介绍与当前权限不一致。
+                data-morph-autofocus={isSelected ? '' : undefined}
                 onClick={() => {
                   onPermissionModeChange(option.id);
                   setOpen(false);
@@ -296,6 +306,12 @@ export function PermissionSelector({
           align="end"
           sideOffset={4}
           collisionPadding={8}
+          onOpenAutoFocus={(event) => {
+            // Radix 默认聚焦首个可交互项；与 MorphPopover 保持一致，聚焦当前选中权限，
+            // 使 focus tooltip 的介绍与 field trigger 当前值一致。
+            event.preventDefault();
+            selectedOptionRef.current?.focus();
+          }}
           className={cn(
             // 面板宽度绑定 trigger 宽度(DESIGN.md §Select & Dropdown: 不许比触发它的
             // 控件更宽或更窄;Radix 语义即 --radix-popover-trigger-width)。行内容自带


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复权限选择器展开时始终聚焦首个“默认权限”选项，导致 tooltip 与当前已选权限不一致的问题。展开后会聚焦当前选中权限，收起状态仍显示当前权限的 tooltip；同时为菜单行增加 2px 间距，并补充回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：权限选择器 tooltip 与当前选择不一致
- 本 PR 包含：当前选中项自动聚焦、chip/field 两种触发器回归测试、选项间距统一为 2px、选项按钮显式声明 `type="button"`
- 明确不包含：异步能力加载后的重新聚焦、完整方向键/Home/End 导航
- 用户可见变化：展开权限菜单时显示当前已选权限的说明；各选项 hover 背景之间保留 2px 间隙
- 是否存在 breaking change：无

### UI 变化

- 平台：Desktop（macOS）
- 界面效果：权限菜单当前选中项获得焦点并显示对应 tooltip；选项行之间增加 2px 间距
- 截图/录屏：本次新分支未重新生成截图，界面效果已在本地交互验证
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 “Select & Dropdown” 中 Composer dropdown rows 统一约束；保留 `px-3`、`rounded-[8px]` 与 `--model-item-hover`，并使用与相邻模型菜单一致的 `gap-0.5`（2px）。颜色继续使用现有语义 token，Light/Dark 行为不变。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/permissionSelectorMorph.test.tsx --maxWorkers=1
结果：通过，14 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false pnpm test:unit
结果：通过，所有 required unit workspaces 通过（Desktop、Mobile 及共享 packages）

pnpm check:dco
结果：通过，1 commit signed off
```

### 手工验证

Desktop / macOS：验证收起状态 tooltip 保留；展开后当前选中权限显示对应 tooltip；hover 各行显示各自说明；选项背景之间存在间隙。

### 未执行的验证

未重新生成本 PR 分支的 UI 截图；未执行 Mobile 手工验证（本次仅修改 Desktop Renderer）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 新建对话权限选择器的弹层焦点、tooltip 与选项间距
- 回滚 / 降级方式：回滚本 PR 的单个 commit 即可；无数据、协议或配置迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因