### PR TITLE
fix(desktop): align gateway quota with declared pricing currency

### DIFF
--- a/apps/desktop/src/renderer/__tests__/homeUsageDashboardSource.test.ts
+++ b/apps/desktop/src/renderer/__tests__/homeUsageDashboardSource.test.ts
@@ -19,7 +19,11 @@ const heatmapSource = readFileSync(
 describe('HomeUsageDashboard source contract', () => {
   it('uses the Claude account daily spend for the visible today amount when available', () => {
     expect(source).toMatch(
-      /const accountTodayMoney =\s+typeof claudeQuota\?\.todaySpend === 'number'\s+\? gatewayMoney\(claudeQuota\.todaySpend\)\s+: null;/,
+      /const accountTodayMoney =\s+typeof claudeQuota\?\.todaySpend === 'number'\s+\? gatewayMoney\(claudeQuota\.todaySpend, 'actual-cost', gatewayCurrency\)\s+: null;/,
+    );
+    expect(source).toContain('const pricing = useModelPricing();');
+    expect(source).toContain(
+      'const gatewayCurrency = resolveGatewayPricingCurrency(pricing);',
     );
     expect(source).toContain('const hasAccountTodaySpend = accountTodayMoney !== null;');
     expect(source).toContain('const layoutHistory = history ?? emptyLayoutHistory;');
@@ -40,6 +44,15 @@ describe('HomeUsageDashboard source contract', () => {
       /hasSpendValue \?\s+formatMoney\(displayTodaySpend\)\s+:\s+UNKNOWN_VALUE/,
     );
     expect(source).toContain('warning={showLocalSpendAnomaly}');
+    expect(source).toContain(
+      "gatewayMoney(softDailyLimit, 'actual-cost', gatewayCurrency)",
+    );
+    expect(source).toContain(
+      "gatewayMoney(claudeQuota.spend, 'actual-cost', gatewayCurrency)",
+    );
+    expect(source).toContain(
+      "gatewayMoney(claudeQuota.maxBudget, 'actual-cost', gatewayCurrency)",
+    );
   });
 
   it('keeps a fixed empty layout while usage history is still loading or empty', () => {

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -151,11 +151,18 @@ describe('TodaySpendChip dashboard routing', () => {
   });
 
   it('formats gateway quota amounts with the gateway-native currency', () => {
+    expect(source).toContain('const pricing = useModelPricing();');
     expect(source).toContain(
-      'formatCompactMoney(gatewayMoney(claudeQuota.spend))',
+      'const gatewayCurrency = resolveGatewayPricingCurrency(pricing);',
     );
     expect(source).toContain(
-      'formatCompactMoney(gatewayMoney(claudeQuota.maxBudget))',
+      "formatCompactMoney(gatewayMoney(claudeQuota.spend, 'actual-cost', gatewayCurrency))",
+    );
+    expect(source).toContain(
+      "formatCompactMoney(gatewayMoney(claudeQuota.maxBudget, 'actual-cost', gatewayCurrency))",
+    );
+    expect(source).toContain(
+      'const slots = computeMetricSlots(claudeQuota, sessionMoney, t, gatewayCurrency);',
     );
     expect(source).not.toContain('formatCompactUsd(claudeQuota.');
   });

--- a/apps/desktop/src/renderer/components/new-chat/HomeUsageDashboard.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/HomeUsageDashboard.tsx
@@ -29,6 +29,7 @@ import {
   formatMoney,
 } from '@/lib/usageFormat';
 import { useClaudeAccountUsage } from '@/hooks/useClaudeAccountUsage';
+import { useModelPricing } from '@/hooks/useModelPricing';
 import { useUsageHistory, type UsageHistoryPayload } from '@/hooks/useUsageHistory';
 import { useAuth } from '@/contexts/AuthContext';
 import { UsageDailyBars } from './UsageDailyBars';
@@ -39,6 +40,7 @@ import {
   type RegionalMoney,
   zeroUsageMoney,
 } from '../../../shared/regionalMoney';
+import { resolveGatewayPricingCurrency } from '../../../shared/modelPriceQuote';
 
 const COLLAPSED_STORAGE_KEY = 'homeUsageDashboard.collapsed';
 /** 与 useUsageHistory 的拉取窗口一致 (20 周)。 */
@@ -175,6 +177,8 @@ export function HomeUsageDashboard(): React.JSX.Element {
   const hasHistoryData = history !== null;
   // 月度预算与右下角 chip 同源 (XD gateway key 的 LiteLLM spend, 与 vendor 无关)
   const claudeQuota = useClaudeAccountUsage(true);
+  const pricing = useModelPricing();
+  const gatewayCurrency = resolveGatewayPricingCurrency(pricing);
 
   const hasMonthly = !!claudeQuota && claudeQuota.maxBudget > 0;
 
@@ -188,7 +192,7 @@ export function HomeUsageDashboard(): React.JSX.Element {
 
   const accountTodayMoney =
     typeof claudeQuota?.todaySpend === 'number'
-      ? gatewayMoney(claudeQuota.todaySpend)
+      ? gatewayMoney(claudeQuota.todaySpend, 'actual-cost', gatewayCurrency)
       : null;
   const hasAccountTodaySpend = accountTodayMoney !== null;
 
@@ -201,7 +205,7 @@ export function HomeUsageDashboard(): React.JSX.Element {
   const softDailyLimitMoney =
     softDailyLimit === null
       ? null
-      : gatewayMoney(softDailyLimit);
+      : gatewayMoney(softDailyLimit, 'actual-cost', gatewayCurrency);
   const todayValue = !hasSpendValue
     ? UNKNOWN_VALUE
     : softDailyLimitMoney
@@ -352,7 +356,7 @@ export function HomeUsageDashboard(): React.JSX.Element {
           <StatCell
             value={
               hasMonthly
-                ? `${formatCompactMoney(gatewayMoney(claudeQuota.spend))} / ${formatCompactMoney(gatewayMoney(claudeQuota.maxBudget))}`
+                ? `${formatCompactMoney(gatewayMoney(claudeQuota.spend, 'actual-cost', gatewayCurrency))} / ${formatCompactMoney(gatewayMoney(claudeQuota.maxBudget, 'actual-cost', gatewayCurrency))}`
                 : `${UNKNOWN_VALUE} / ${UNKNOWN_VALUE}`
             }
             label={t('usageDashboard.monthly')}

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -50,6 +50,7 @@ import { useClaudeSessionRoute } from '@/hooks/useClaudeSessionRoute';
 import { useSessionSpend } from '@/hooks/useSessionSpend';
 import { useSessionEstimatedValue } from '@/hooks/useSessionEstimatedValue';
 import { useSessionTokens } from '@/hooks/useSessionTokens';
+import { useModelPricing } from '@/hooks/useModelPricing';
 import { useChatDisplaySnapshot } from '@/components/chat/ChatDisplaySnapshotContext';
 import {
   requestCodexAccountRefresh,
@@ -76,7 +77,12 @@ import { useXaiRateLimit, type XaiRateLimitSnapshot } from '@/hooks/useXaiRateLi
 import { makerChatStore, type ChatMessage } from '@/lib/makerChatStore';
 import { buildTurnUsageTooltipLines } from '@/lib/turnUsageTooltip';
 import type { TurnUsageDetails } from '../../../shared/turnUsageDetails';
-import { gatewayMoney, type RegionalMoney } from '../../../shared/regionalMoney';
+import {
+  gatewayMoney,
+  type MoneyCurrency,
+  type RegionalMoney,
+} from '../../../shared/regionalMoney';
+import { resolveGatewayPricingCurrency } from '../../../shared/modelPriceQuote';
 import { CHATGPT_MODEL_PREFIX, XAI_MODEL_PREFIX } from '../../../shared/subscriptionModels';
 import {
   RESET_PENDING_MAX_MS,
@@ -140,6 +146,7 @@ function computeMetricSlots(
   claudeQuota: ClaudeAccountUsageSnapshot | null,
   sessionMoney: RegionalMoney | null,
   t: TFunction,
+  gatewayCurrency: MoneyCurrency,
 ): Record<MetricKey, MetricSlot> {
   const slots: Record<MetricKey, MetricSlot> = {
     daily: { label: t('todaySpend.dailyLimitLabel', { spend: '$—', limit: '$—' }), available: false },
@@ -151,8 +158,8 @@ function computeMetricSlots(
     // monthly 永远跟 cycle 一起拿到; daily 走单独 endpoint 可能拉不到 (todaySpend=null) → 隐藏
     slots.monthly = {
       label: t('todaySpend.monthlyLimitLabel', {
-        spend: formatCompactMoney(gatewayMoney(claudeQuota.spend)),
-        limit: formatCompactMoney(gatewayMoney(claudeQuota.maxBudget)),
+        spend: formatCompactMoney(gatewayMoney(claudeQuota.spend, 'actual-cost', gatewayCurrency)),
+        limit: formatCompactMoney(gatewayMoney(claudeQuota.maxBudget, 'actual-cost', gatewayCurrency)),
       }),
       available: true,
     };
@@ -161,9 +168,9 @@ function computeMetricSlots(
       slots.daily = {
         label: t('todaySpend.dailyLimitLabel', {
           spend: formatCompactMoney(
-            gatewayMoney(claudeQuota.todaySpend),
+            gatewayMoney(claudeQuota.todaySpend, 'actual-cost', gatewayCurrency),
           ),
-          limit: formatCompactMoney(gatewayMoney(softLimit)),
+          limit: formatCompactMoney(gatewayMoney(softLimit, 'actual-cost', gatewayCurrency)),
         }),
         available: true,
       };
@@ -1066,6 +1073,8 @@ export function TodaySpendChip({
     (((vendorKey === 'cc' && !isClaudeSubscription && !isSubscriptionBridge && !ccBillingFormPending) || isCodexApi)
       && !isDeviceLinkRemote),
   );
+  const pricing = useModelPricing();
+  const gatewayCurrency = resolveGatewayPricingCurrency(pricing);
   // Claude 订阅账号余量 (5h/周/分模型窗口, 端点 + proxy 旁路 headers 双源)。bridge 模型形态
   // 优先(不消耗 Claude 订阅额度),此时不读。
   const claudeSubscriptionUsage = useClaudeSubscriptionUsage(
@@ -1308,7 +1317,7 @@ export function TodaySpendChip({
       latestTurnUsage,
     );
   } else {
-    const slots = computeMetricSlots(claudeQuota, sessionMoney, t);
+    const slots = computeMetricSlots(claudeQuota, sessionMoney, t, gatewayCurrency);
     const chipSegments = getGatewayChipSegments(slots);
     const codexApiHasTokenFallback = isCodexApi
       && !slots.session.available

--- a/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
+++ b/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
@@ -4,6 +4,7 @@ import type { ModelAccessGatewayModel } from '../modelAccess.js';
 import {
   gatewayPricingCatalog,
   resolveGatewayCatalogCurrency,
+  resolveGatewayPricingCurrency,
 } from '../modelPriceQuote.js';
 
 function model(
@@ -143,5 +144,72 @@ describe('gatewayPricingCatalog currency', () => {
       'CNY',
       'CNY',
     ]);
+  });
+});
+
+describe('resolveGatewayPricingCurrency', () => {
+  it('reuses the declared currency from the projected XD catalog', () => {
+    expect(
+      resolveGatewayPricingCurrency({
+        xd: {
+          a: {
+            providerId: 'xd',
+            modelId: 'a',
+            currency: 'CNY',
+            source: 'gateway',
+            approximate: false,
+            inputPerMtok: 1,
+            outputPerMtok: 2,
+          },
+        },
+      }),
+    ).toBe('CNY');
+  });
+
+  it('falls back to USD for empty or mixed projected catalogs', () => {
+    expect(resolveGatewayPricingCurrency(null)).toBe('USD');
+    expect(resolveGatewayPricingCurrency({})).toBe('USD');
+    expect(
+      resolveGatewayPricingCurrency({
+        xd: {
+          cny: {
+            providerId: 'xd',
+            modelId: 'cny',
+            currency: 'CNY',
+            source: 'gateway',
+            approximate: false,
+            inputPerMtok: 1,
+            outputPerMtok: 2,
+          },
+          usd: {
+            providerId: 'xd',
+            modelId: 'usd',
+            currency: 'USD',
+            source: 'gateway',
+            approximate: false,
+            inputPerMtok: 1,
+            outputPerMtok: 2,
+          },
+        },
+      }),
+    ).toBe('USD');
+  });
+
+  it('falls back to USD for invalid persisted currency values', () => {
+    expect(
+      resolveGatewayPricingCurrency({
+        xd: {
+          invalid: {
+            providerId: 'xd',
+            modelId: 'invalid',
+            currency: 'EUR' as unknown as 'USD',
+            source: 'gateway',
+            approximate: false,
+            inputPerMtok: 1,
+            outputPerMtok: 2,
+          },
+        },
+      }),
+    ).toBe('USD');
   });
 });

--- a/apps/desktop/src/shared/modelPriceQuote.ts
+++ b/apps/desktop/src/shared/modelPriceQuote.ts
@@ -137,6 +137,28 @@ export function gatewayPricingCatalog(
   return Object.keys(xd).length > 0 ? { xd } : {};
 }
 
+/**
+ * Resolve the currency of the already-projected XD pricing catalog.
+ *
+ * Account quota endpoints return bare numbers without a currency field. Reuse
+ * the currency from the same server-declared model pricing snapshot so quota
+ * and per-turn amounts cannot disagree. Invalid/mixed/empty snapshots retain
+ * the Gateway-native USD fallback instead of guessing from the build region.
+ */
+export function resolveGatewayPricingCurrency(
+  pricing: ModelPricingCatalog | null | undefined,
+): MoneyCurrency {
+  const quotes = Object.values(pricing?.xd ?? {});
+  if (quotes.length === 0) return GATEWAY_NATIVE_CURRENCY;
+  const currency = quotes[0].currency;
+  if (currency !== 'USD' && currency !== 'CNY') {
+    return GATEWAY_NATIVE_CURRENCY;
+  }
+  return quotes.every((quote) => quote.currency === currency)
+    ? currency
+    : GATEWAY_NATIVE_CURRENCY;
+}
+
 function subscriptionQuote(
   providerId: string,
   modelId: string,


### PR DESCRIPTION
Fixes #634

## What changed
- Reuse the server-declared XD model pricing snapshot to resolve the gateway quota currency.
- Render TodaySpendChip and HomeUsageDashboard quota amounts with that currency, including CNY for the domestic catalog.
- Fall back safely to USD for empty, invalid, or mixed-currency snapshots.

## Why
Quota endpoints return bare numeric amounts. The UI previously passed those amounts through the Gateway-native USD default, so domestic CNY usage was displayed with dollar formatting.

The server-side pricing catalog already carries the authoritative currency declaration (including the CNY catalog from #600). This change keeps quota and per-turn pricing aligned without guessing from build region or applying an exchange rate.

## Validation
- Targeted Vitest: 45 tests passed across model pricing, TodaySpendChip, and HomeUsageDashboard source contracts.
- `git diff --check` passed.
- Full desktop typecheck is currently blocked by missing workspace packages in this checkout (for example `@cindy/auth-client` and `@cindy/device-link`), with no errors reported from the changed files before the dependency cascade.
- Workspace unit runner is blocked by the uninitialized `cindy-protocol` submodule; repository test runner also has unrelated existing worktree/glossary failures.

## Risk and rollback
Low risk: only the currency metadata passed to quota display formatting changes; historical stored amounts are not migrated or relabeled. Revert commit `776c7366c7b36b82346bdbc8004255653eebdde4` to roll back.