### PR TITLE
fix(desktop): align permission selector focus behavior

### DIFF
--- a/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
@@ -118,12 +118,20 @@ describe('PermissionSelector (MorphPopover pilot)', () => {
 
     fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     expect(document.activeElement).toBe(defaultOption);
+    expect(defaultOption.tabIndex).toBe(0);
+    expect(bypassOption.tabIndex).toBe(-1);
     fireEvent.keyDown(listbox, { key: 'ArrowUp' });
     expect(document.activeElement).toBe(bypassOption);
+    expect(bypassOption.tabIndex).toBe(0);
+    expect(defaultOption.tabIndex).toBe(-1);
     fireEvent.keyDown(listbox, { key: 'Home' });
     expect(document.activeElement).toBe(defaultOption);
+    expect(defaultOption.tabIndex).toBe(0);
+    expect(bypassOption.tabIndex).toBe(-1);
     fireEvent.keyDown(listbox, { key: 'End' });
     expect(document.activeElement).toBe(bypassOption);
+    expect(bypassOption.tabIndex).toBe(0);
+    expect(defaultOption.tabIndex).toBe(-1);
   });
 
   it('点击选项回调 onPermissionModeChange 并收合卸载', async () => {

--- a/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/permissionSelectorMorph.test.tsx
@@ -26,14 +26,16 @@ const PERMISSION_MODES = [
   { id: 'auto', displayName: '自动审批', description: 'auto desc' },
   { id: 'bypassPermissions', displayName: '完全访问', description: 'bypass desc' },
 ];
+let mockPermissionModes = PERMISSION_MODES;
 
 vi.mock('@/hooks/useAgentCapabilities', () => ({
-  useAgentCapabilities: () => ({ capabilities: { permissionModes: PERMISSION_MODES } }),
+  useAgentCapabilities: () => ({ capabilities: { permissionModes: mockPermissionModes } }),
 }));
 
 import { PermissionSelector } from '../components/new-chat/PermissionSelector';
 
 afterEach(() => {
+  mockPermissionModes = PERMISSION_MODES;
   cleanup();
   vi.restoreAllMocks();
 });
@@ -63,11 +65,65 @@ describe('PermissionSelector (MorphPopover pilot)', () => {
     expect(listbox).toBeTruthy();
     expect(screen.getAllByRole('option')).toHaveLength(4);
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
-    // 选中档正确标记(焦点策略 2026-07-23 改回落首个可交互项,恢复键盘可达性,见 codex review)
+    // 选中档正确标记
     const selected = screen
       .getAllByRole('option')
       .find((o) => o.getAttribute('aria-selected') === 'true');
     expect(selected).toBeTruthy();
+  });
+
+  it('打开时聚焦当前选中权限，避免 focus tooltip 错指向首个选项', async () => {
+    renderSelector({ permissionMode: 'bypassPermissions' });
+    fireEvent.click(getTrigger());
+
+    const selectedOption = await screen.findByRole('option', { name: '完全访问' });
+    await waitFor(() => expect(document.activeElement).toBe(selectedOption));
+  });
+
+  it.each([
+    ['chip', undefined],
+    ['field', 'field' as const],
+  ])('%s 形态在 capability 异步返回后聚焦当前选中权限', async (_name, triggerVariant) => {
+    mockPermissionModes = [];
+    const { onChange, rerender } = renderSelector({
+      permissionMode: 'bypassPermissions',
+      triggerVariant,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /bypassPermissions/ }));
+    await screen.findByRole('listbox');
+
+    mockPermissionModes = PERMISSION_MODES;
+    rerender(
+      <PermissionSelector
+        permissionMode="bypassPermissions"
+        onPermissionModeChange={onChange}
+        triggerVariant={triggerVariant}
+      />,
+    );
+
+    const selectedOption = await screen.findByRole('option', { name: '完全访问' });
+    await waitFor(() => expect(document.activeElement).toBe(selectedOption));
+  });
+
+  it('从当前权限支持方向键、Home、End 访问全部选项', async () => {
+    renderSelector({ permissionMode: 'bypassPermissions' });
+    fireEvent.click(getTrigger());
+
+    const listbox = await screen.findByRole('listbox');
+    const defaultOption = screen.getByRole('option', { name: '默认权限' });
+    const bypassOption = screen.getByRole('option', { name: '完全访问' });
+    await waitFor(() => expect(document.activeElement).toBe(bypassOption));
+    expect(bypassOption.tabIndex).toBe(0);
+    expect(defaultOption.tabIndex).toBe(-1);
+
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(defaultOption);
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(bypassOption);
+    fireEvent.keyDown(listbox, { key: 'Home' });
+    expect(document.activeElement).toBe(defaultOption);
+    fireEvent.keyDown(listbox, { key: 'End' });
+    expect(document.activeElement).toBe(bypassOption);
   });
 
   it('点击选项回调 onPermissionModeChange 并收合卸载', async () => {
@@ -185,6 +241,14 @@ describe('PermissionSelector triggerVariant', () => {
 
     fireEvent.click(screen.getByText('完全访问'));
     expect(onChange).toHaveBeenCalledWith('bypassPermissions');
+  });
+
+  it('field 形态打开时同样聚焦当前选中权限', async () => {
+    renderSelector({ triggerVariant: 'field', permissionMode: 'bypassPermissions' });
+    fireEvent.click(getTrigger());
+
+    const selectedOption = await screen.findByRole('option', { name: '完全访问' });
+    await waitFor(() => expect(document.activeElement).toBe(selectedOption));
   });
 
   it('ariaContext 前置到 trigger 可及名(多实例同屏读屏区分,不传则原样)', () => {

--- a/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
@@ -156,7 +156,7 @@ export function PermissionSelector({
       selectedOptionRef.current?.focus({ preventScroll: true });
     });
     return () => cancelAnimationFrame(frame);
-  }, [open, options.length]);
+  }, [open, options.length, effectiveMode]);
 
   /** chip 内容行(icon + label + chevron) */
   const triggerContent = (
@@ -372,7 +372,7 @@ export function PermissionSelector({
             // 使 focus tooltip 的介绍与 field trigger 当前值一致。
             if (selectedOptionRef.current) {
               event.preventDefault();
-              selectedOptionRef.current.focus();
+              selectedOptionRef.current.focus({ preventScroll: true });
             }
           }}
           className={cn(

--- a/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
@@ -106,6 +106,7 @@ export function PermissionSelector({
 }: PermissionSelectorProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [focusedOptionId, setFocusedOptionId] = useState<string | null>(null);
   const selectedOptionRef = useRef<HTMLButtonElement>(null);
   const agentKind = vendorKeyToAgentKind(vendorKey);
   // device-link:deviceId 非空 → 权限档从被控端读(本地会话 undefined,行为不变)。
@@ -138,12 +139,19 @@ export function PermissionSelector({
   const isIconOnly = iconOnly && isCreateAgentVariant;
 
   useEffect(() => {
+    if (!open) {
+      setFocusedOptionId(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
     const previousLength = previousOptionsLengthRef.current;
     previousOptionsLengthRef.current = options.length;
     if (!open || previousLength !== 0 || options.length === 0) return;
 
     // capability cache miss 时，选项可能晚于弹层首次 autofocus 才返回。仅在菜单仍打开且
     // 选项从空变为可用时补聚焦一次，使 chip / field 的当前权限 tooltip 都与选择一致。
+    setFocusedOptionId(effectiveMode);
     const frame = requestAnimationFrame(() => {
       selectedOptionRef.current?.focus({ preventScroll: true });
     });
@@ -270,7 +278,10 @@ export function PermissionSelector({
                 ? enabledOptions.length - 1
                 : (activeIndex - 1 + enabledOptions.length) % enabledOptions.length;
           }
-          enabledOptions[nextIndex]?.focus({ preventScroll: true });
+          const nextOption = enabledOptions[nextIndex];
+          if (!nextOption) return;
+          setFocusedOptionId(nextOption.dataset.permissionMode ?? null);
+          nextOption.focus({ preventScroll: true });
         }}
       >
         {options.map((option) => {
@@ -298,7 +309,8 @@ export function PermissionSelector({
                 }}
                 role="option"
                 aria-selected={isSelected}
-                tabIndex={isSelected ? 0 : -1}
+                data-permission-mode={option.id}
+                tabIndex={(focusedOptionId ?? effectiveMode) === option.id ? 0 : -1}
                 className={cn(
                   'flex w-full items-center gap-3 rounded-[8px] px-3 py-2',
                   'transition-colors',

--- a/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Hand,
   CodeXml,
@@ -106,6 +106,7 @@ export function PermissionSelector({
 }: PermissionSelectorProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const selectedOptionRef = useRef<HTMLButtonElement>(null);
   const agentKind = vendorKeyToAgentKind(vendorKey);
   // device-link:deviceId 非空 → 权限档从被控端读(本地会话 undefined,行为不变)。
   const { capabilities } = useAgentCapabilities(agentKind, deviceId);
@@ -132,8 +133,22 @@ export function PermissionSelector({
   const triggerDescription = descriptionOf(current, effectiveMode);
   const isCreateAgentVariant = visualVariant === 'create-agent';
   const isFieldTrigger = triggerVariant === 'field';
+  const previousOptionsLengthRef = useRef(options.length);
   // 窄态工具条(#562):新建对话框空间不足时权限入口图标化,防与语音/发送重叠。
   const isIconOnly = iconOnly && isCreateAgentVariant;
+
+  useEffect(() => {
+    const previousLength = previousOptionsLengthRef.current;
+    previousOptionsLengthRef.current = options.length;
+    if (!open || previousLength !== 0 || options.length === 0) return;
+
+    // capability cache miss 时，选项可能晚于弹层首次 autofocus 才返回。仅在菜单仍打开且
+    // 选项从空变为可用时补聚焦一次，使 chip / field 的当前权限 tooltip 都与选择一致。
+    const frame = requestAnimationFrame(() => {
+      selectedOptionRef.current?.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [open, options.length]);
 
   /** chip 内容行(icon + label + chevron) */
   const triggerContent = (
@@ -219,7 +234,45 @@ export function PermissionSelector({
   );
 
   const optionsList = (
-      <div role="listbox" aria-label={t('newChat.permissionSelector.listAria')}>
+      <div
+        role="listbox"
+        aria-label={t('newChat.permissionSelector.listAria')}
+        className="flex flex-col gap-0.5"
+        onKeyDown={(event) => {
+          if (
+            event.key !== 'ArrowDown' &&
+            event.key !== 'ArrowUp' &&
+            event.key !== 'Home' &&
+            event.key !== 'End'
+          ) {
+            return;
+          }
+
+          const enabledOptions = Array.from(
+            event.currentTarget.querySelectorAll<HTMLButtonElement>(
+              '[role="option"]:not([disabled])',
+            ),
+          );
+          if (enabledOptions.length === 0) return;
+
+          event.preventDefault();
+          const activeIndex = enabledOptions.indexOf(document.activeElement as HTMLButtonElement);
+          let nextIndex: number;
+          if (event.key === 'Home') {
+            nextIndex = 0;
+          } else if (event.key === 'End') {
+            nextIndex = enabledOptions.length - 1;
+          } else if (event.key === 'ArrowDown') {
+            nextIndex = activeIndex < 0 ? 0 : (activeIndex + 1) % enabledOptions.length;
+          } else {
+            nextIndex =
+              activeIndex < 0
+                ? enabledOptions.length - 1
+                : (activeIndex - 1 + enabledOptions.length) % enabledOptions.length;
+          }
+          enabledOptions[nextIndex]?.focus({ preventScroll: true });
+        }}
+      >
         {options.map((option) => {
           const Icon = PERMISSION_ICONS[option.id] ?? Hand;
           const isSelected = effectiveMode === option.id;
@@ -234,12 +287,18 @@ export function PermissionSelector({
               contentClassName="max-w-[280px] whitespace-normal break-words text-left"
             >
               <button
+                type="button"
+                ref={isSelected ? selectedOptionRef : undefined}
+                // MorphPopover 打开后优先聚焦当前选中项；否则会聚焦列表首项，
+                // 触发“默认权限”的 focus tooltip，造成介绍与当前权限不一致。
+                data-morph-autofocus={isSelected ? '' : undefined}
                 onClick={() => {
                   onPermissionModeChange(option.id);
                   setOpen(false);
                 }}
                 role="option"
                 aria-selected={isSelected}
+                tabIndex={isSelected ? 0 : -1}
                 className={cn(
                   'flex w-full items-center gap-3 rounded-[8px] px-3 py-2',
                   'transition-colors',
@@ -296,6 +355,14 @@ export function PermissionSelector({
           align="end"
           sideOffset={4}
           collisionPadding={8}
+          onOpenAutoFocus={(event) => {
+            // Radix 默认聚焦首个可交互项；与 MorphPopover 保持一致，聚焦当前选中权限，
+            // 使 focus tooltip 的介绍与 field trigger 当前值一致。
+            if (selectedOptionRef.current) {
+              event.preventDefault();
+              selectedOptionRef.current.focus();
+            }
+          }}
           className={cn(
             // 面板宽度绑定 trigger 宽度(DESIGN.md §Select & Dropdown: 不许比触发它的
             // 控件更宽或更窄;Radix 语义即 --radix-popover-trigger-width)。行内容自带


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 权限选择器展开后焦点与当前权限不一致的问题。同步与异步 capability 场景下，chip 和 field 两种形态都会聚焦当前选中权限并显示对应 tooltip；同时补齐 listbox 键盘导航，并统一选项间距。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：权限选择器 tooltip 与当前选择不一致
- 本 PR 包含：同步打开聚焦当前权限；capability 从空变为可用时补聚焦；field 空 ref 时保留 Radix 默认聚焦；ArrowUp/ArrowDown/Home/End 导航；2px 行间距；`type="button"`；回归测试
- 明确不包含：权限模型、权限文案或服务端能力变更
- 用户可见变化：展开菜单后显示当前权限的 tooltip；异步加载后焦点自动对齐；可用方向键遍历所有权限；hover 背景之间保留 2px 间隙
- 是否存在 breaking change：无

### UI 变化

- 平台：Desktop（macOS）
- 界面效果：收起态 tooltip 保留；展开态显示当前选中权限的 tooltip；每行 hover 显示自身说明；选项行之间为 2px 间距
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 “Select & Dropdown” Composer dropdown rows 统一约束；保留 `px-3`、`rounded-[8px]`、`--model-item-hover`，间距与相邻模型菜单统一为 `gap-0.5`。Light/Dark 均继续使用现有语义 token。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/permissionSelectorMorph.test.tsx --maxWorkers=1
结果：通过，17 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false pnpm test:unit
结果：通过，所有 required unit workspaces 通过（Desktop、Mobile 及共享 packages）

pnpm check:dco
结果：通过，3 commits signed off
```

### 手工验证

Desktop / macOS：验证收起态 tooltip、同步展开焦点、异步 capability 返回后的焦点、逐行 hover tooltip、2px 间距及方向键/Home/End 导航。

### 未执行的验证

未执行 Mobile 手工验证（本次仅修改 Desktop Renderer）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 新建对话权限选择器的焦点、键盘交互、tooltip 和选项间距
- 回滚 / 降级方式：回滚本 PR 的 commits；无数据、协议或配置迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因