### PR TITLE
fix(maker-core): Codex Auto 在不支持的路由降级

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3520,7 +3520,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
-  it('falls back to untrusted approvals on the XD gateway instead of routing the hidden reviewer model', async () => {
+  it('falls back to untrusted approvals on XD and interrupts the active turn when tightened to Ask', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {
       if (method === Method.TurnStart) {
@@ -3558,6 +3558,12 @@ describe('CodexAgent MCP thread context hooks', () => {
       sandboxPolicy: { type: 'workspaceWrite' },
     });
     expect(turnParams).not.toHaveProperty('approvalsReviewer');
+    if (!handle.setPermissionMode) throw new Error('expected setPermissionMode');
+    await handle.setPermissionMode('ask');
+    expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+      threadId: 'start-thread-id',
+      turnId: 'turn-xd-auto-fallback',
+    });
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3489,6 +3489,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-auto-approval-policy',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3519,6 +3520,47 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('falls back to untrusted approvals on the XD gateway instead of routing the hidden reviewer model', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        return { turn: { id: 'turn-xd-auto-fallback' } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-xd-auto-fallback',
+      model: 'gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+    });
+
+    const startParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+      sandbox?: string;
+    };
+    expect(startParams).toMatchObject({
+      approvalPolicy: 'untrusted',
+      sandbox: 'workspace-write',
+    });
+    expect(startParams).not.toHaveProperty('approvalsReviewer');
+
+    await handle.send({ type: 'user', content: 'hello' });
+    const turnParams = host.request.mock.calls.find(([method]) => method === Method.TurnStart)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+      sandboxPolicy?: { type?: string };
+    };
+    expect(turnParams).toMatchObject({
+      approvalPolicy: 'untrusted',
+      sandboxPolicy: { type: 'workspaceWrite' },
+    });
+    expect(turnParams).not.toHaveProperty('approvalsReviewer');
+    await handle.close();
+  });
+
   it('falls back to untrusted approvals without reviewer fields on an older app-server', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {
@@ -3530,6 +3572,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-legacy-auto',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3557,6 +3600,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-auto-command-fallback',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3585,6 +3629,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-guardian-denial-fail-closed',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3630,6 +3675,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-guardian-timeout',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3677,6 +3723,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-guardian-timeout-runtime',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3722,6 +3769,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-guardian-reviewer-failure',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3772,6 +3820,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-guardian-stale-timeout',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });
@@ -3812,6 +3861,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const handle = await agent.startSession({
       sessionId: 'session-auto-review-tighten',
       model: 'gpt-5.5',
+      providerId: 'openai',
       workingDir: '/repo',
       permissionMode: 'auto',
     });

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2835,8 +2835,9 @@ export class CodexAgent extends BaseAgent {
     let pendingTightenInterrupt = false;
     /**
      * 最近一次 send 的 turn 是否以无人值守策略发射 (覆盖在飞与运行中两个阶段)。
-     * auto_review / never 发射的 turn 在收紧时需要中断; user reviewer 发射的 turn
-     * 审批请求照常流经本地、收紧即时生效,即使期间 UI 短暂切过宽松档也不得误杀。
+     * Auto (auto_review 或 untrusted 降级) / never 发射的 turn 在收紧时需要中断;
+     * user reviewer 发射的 turn 审批请求照常流经本地、收紧即时生效,即使期间 UI
+     * 短暂切过宽松档也不得误杀。
      */
     let turnLaunchedUnattended = false;
     /**
@@ -4036,10 +4037,10 @@ export class CodexAgent extends BaseAgent {
         // effort 同理: 协议层只能在 turn/start 透传 (v2.rs:5800), thread/start 不接;
         // 用户在 session 创建时选的 effort 也是靠 first turn/start 这里传过去才生效。
         const turnWorkspaceConfig = currentTurnWorkspaceConfig();
-        const { approvalPolicy, approvalsReviewer } = turnWorkspaceConfig;
-        // 记录本 turn 是否由无人值守策略发射。Auto-review 也需要在切回 Ask
-        // 时中断当前 turn,避免 reviewer 继续替用户批准新的越界操作。
-        turnLaunchedUnattended = approvalPolicy === 'never' || approvalsReviewer === 'auto_review';
+        const { approvalPolicy } = turnWorkspaceConfig;
+        // 记录本 turn 是否由无人值守策略发射。Auto 即使因路由能力降级为
+        // untrusted,切回 Ask 时也必须中断当前 turn,避免旧策略继续执行 trusted 操作。
+        turnLaunchedUnattended = mutablePermissionMode === 'auto' || approvalPolicy === 'never';
         let turnInput: TurnStartParams['input'];
         try {
           turnInput = await toTurnInput(message.content);
@@ -4445,8 +4446,8 @@ export class CodexAgent extends BaseAgent {
         if (!tightensCurrentTurn) {
           pendingTightenInterrupt = false;
         } else if (!closed && turnLaunchedUnattended) {
-          // 只中断 auto_review / never 发射的 turn; user reviewer 发射的 turn 审批请求
-          // 照常流经本地、收紧即时生效,期间 UI 短暂切过宽松档不构成中断理由。
+          // 只中断 Auto (含 untrusted 降级) / never 发射的 turn; user reviewer 发射的
+          // turn 审批请求照常流经本地、收紧即时生效,期间 UI 短暂切过宽松档不构成中断理由。
           if (currentTurnId !== null) {
             await interruptTurnForPermissionTighten(currentTurnId);
           } else if (isTurnStartPending) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -296,8 +296,9 @@ function mapPermissionToCodex(
       return { approvalPolicy: 'never', sandbox: 'danger-full-access' };
     case 'auto':
       if (!approvalsReviewerSupported) {
-        // 旧 app-server 没有 approvalsReviewer 字段时回退到原生 untrusted:
-        // 可信命令自动执行,其余请求交给用户。不能发送未知字段让整次 RPC 失败。
+        // 旧 app-server 或未验证 reviewer 模型路由时回退到原生 untrusted:
+        // 可信命令自动执行,其余请求交给用户。既不能发送未知字段,也不能让
+        // 首个越界动作撞上 provider 不支持的隐藏审核模型。
         return { approvalPolicy: 'untrusted', sandbox: 'workspace-write' };
       }
       // Codex app-server 原生 auto_review 与 Claude Auto 的分工一致:
@@ -314,7 +315,7 @@ function mapPermissionToCodex(
  * Remote hosts may keep an older standalone binary across desktop upgrades, so parse the
  * initialize userAgent and conservatively omit the field unless that verified floor is met.
  */
-function supportsCodexApprovalsReviewer(userAgent: string | undefined): boolean {
+function supportsCodexApprovalsReviewerProtocol(userAgent: string | undefined): boolean {
   const match = /\/(\d+)\.(\d+)\.(\d+)(?:[-+ )]|$)/.exec(userAgent ?? '');
   if (!match) return false;
   const version = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
@@ -333,7 +334,7 @@ function supportsCodexApprovalsReviewer(userAgent: string | undefined): boolean 
  * runtime root writable.
  */
 function supportsCodexReadonlyReferenceDirs(userAgent: string | undefined): boolean {
-  return supportsCodexApprovalsReviewer(userAgent);
+  return supportsCodexApprovalsReviewerProtocol(userAgent);
 }
 
 const READONLY_REFERENCES_PERMISSION_PROFILE = 'cindy-readonly-references';
@@ -2074,7 +2075,20 @@ export class CodexAgent extends BaseAgent {
       throw error;
     }
     if (initResp.codexHome) this.codexHome = initResp.codexHome;
-    const approvalsReviewerSupported = supportsCodexApprovalsReviewer(initResp.userAgent);
+    const sessionCredentialMode = opts.remoteHostId
+      ? undefined
+      : credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
+    const approvalsReviewerProtocolSupported =
+      supportsCodexApprovalsReviewerProtocol(initResp.userAgent);
+    // Codex's built-in reviewer currently selects the hidden `codex-auto-review`
+    // model through the session's model provider. Cindy's gateway, third-party
+    // providers, and remote daemons do not have a verified route for that model.
+    // Keep Auto usable on those routes by falling back to Codex's native
+    // `untrusted` policy instead of letting the first write fail in the reviewer.
+    const approvalsReviewerRouteSupported =
+      !opts.remoteHostId && sessionCredentialMode === 'oauth-bearer';
+    const approvalsReviewerSupported =
+      approvalsReviewerProtocolSupported && approvalsReviewerRouteSupported;
     const readonlyReferenceDirsSupported = supportsCodexReadonlyReferenceDirs(initResp.userAgent);
     if (mutableExtraDirs.length > 0 && !readonlyReferenceDirsSupported) {
       releaseHostBindingLeaseIfNeeded();
@@ -2083,8 +2097,12 @@ export class CodexAgent extends BaseAgent {
       );
     }
     if (mutablePermissionMode === 'auto' && !approvalsReviewerSupported) {
-      log.warn('Codex Auto falling back to untrusted approvals: app-server lacks verified auto-review support', {
+      log.warn('Codex Auto falling back to untrusted approvals: automatic reviewer is unavailable on this route', {
         userAgent: initResp.userAgent,
+        providerId: opts.providerId ?? null,
+        credentialMode: sessionCredentialMode ?? 'unknown',
+        remote: Boolean(opts.remoteHostId),
+        protocolSupported: approvalsReviewerProtocolSupported,
       });
     }
     // 闭包 capture 一次, 整个 session 复用 — codexHome 是 server 进程级常量, host 不变就不变。
@@ -2702,9 +2720,9 @@ export class CodexAgent extends BaseAgent {
       req: InteractionRequest,
       opts?: { forcePrompt?: boolean },
     ): Promise<ApprovalDecision> {
-      // Full access 的普通审批不应打断用户。Auto 的越界审批由 app-server
-      // auto_review 负责；如果某个请求仍回到客户端，走 UI 是安全的 fail-to-prompt
-      // 兜底，不能绕过 reviewer 直接放行。forcePrompt 高风险 MCP inner tool
+      // Full access 的普通审批不应打断用户。Auto 在已验证路由上由 app-server
+      // auto_review 负责；降级路由则由 untrusted 把越界请求发回客户端。两条路径
+      // 只要收到请求都走 UI，不能绕过 reviewer / 降级审批直接放行。forcePrompt 高风险 MCP inner tool
       // (如 contacts delete/merge/系统回写)在任何模式下都必须拿到用户的逐次确认。
       if (
         !opts?.forcePrompt &&
@@ -4407,7 +4425,8 @@ export class CodexAgent extends BaseAgent {
       async setPermissionMode(newMode: PermissionMode) {
         log.debug('setPermissionMode', { from: mutablePermissionMode, to: newMode });
         // Full access 才能批量放行挂起的 ask。切到 Auto 时，已有请求不能绕过
-        // app-server reviewer，先 fail-closed 关闭；后续重试会按 auto_review 路由。
+        // reviewer / untrusted 降级审批，先 fail-closed 关闭；后续重试按当前路由能力
+        // 选择 auto_review 或 untrusted。
         const allowPending = newMode === 'bypassPermissions';
         dismissAllPending(`permission_mode_changed_to_${newMode}`, allowPending ? 'allow' : 'deny');
         const wasAuto = mutablePermissionMode === 'auto';


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex `Auto` 目前会在所有新版 app-server 上启用内置 `auto_review`，但该 reviewer 会请求隐藏模型 `codex-auto-review`。XD Gateway、第三方 provider 和远端 daemon 没有经过验证的模型路由，首个越界写入会因此失败。

本 PR 将原生 reviewer 限定为本地 OpenAI OAuth 路由；其它路由在会话开始时直接降级到 Codex 原生 `untrusted`：可信操作继续自动执行，其余操作回到用户审批，不再先触发一次隐藏模型错误。旧版 app-server 的既有降级保持不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack 用户反馈 Codex Auto 写入被 `Invalid model name passed in model=codex-auto-review` 阻断
- 本 PR 包含：maker-core 按 app-server 协议版本和会话凭证路由决定是否启用 `auto_review`；XD Gateway 回归测试
- 明确不包含：服务端增加 `codex-auto-review` 别名、provider catalog 新增 reviewer capability、UI 配置变化
- 用户可见变化：XD Gateway、第三方 provider 和远端 Codex 会话使用 Auto 时不再因隐藏 reviewer 模型阻断；需要额外审批的操作会询问用户
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：通过

pnpm --filter @cindy/maker-core test -- src/agents/codex/index.test.ts
结果：46 个测试文件、660 个用例通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（该 package 当前没有 typecheck script，按仓库门禁约定跳过）

pnpm --dir packages/maker-core exec eslint src/agents/codex/index.ts
结果：通过

git diff --check
结果：通过
```

### 手工验证

不涉及：本次是 maker-core 协议参数选择，已通过 thread/start 与 turn/start 参数回归测试覆盖。

### 未执行的验证

- 未运行真实 XD Gateway 会话；本 PR 不改网络路由，回归测试验证 XD 来源不会再发送 `approvalsReviewer: auto_review`。
- `@cindy/maker-core` 全包 `build` / `lint` 当前分别被主分支已有的 Claude 测试类型错误和 8 个既有 lint 错误阻塞；已在干净 `main` 复现，未混入无关修复。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Codex `Auto` 的审批策略选择。非 OpenAI OAuth 路由从不可用的自动 reviewer 保守降级为 `untrusted`；沙箱仍为 `workspace-write`，不会扩大权限。OpenAI OAuth 路径保持原生 reviewer，已有 Guardian 失败后切 Ask 的兜底仍保留。
- 回滚 / 降级方式：revert 本 PR 即恢复所有支持协议字段的 app-server 都启用 `auto_review`；未来 provider 明确支持 reviewer 模型后，可将路由判断替换为正式 capability。
- maker-core 核心指标：未改 system prompt、tool/MCP、translator 或 usage 计量，缓存率与返回内容不受影响；新增判断只在 session 启动时读取已有内存状态，不增加网络请求或热路径开销；thread/turn 参数由回归测试覆盖。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
