### PR TITLE
fix(desktop): IM 移动授权改由 Main 登记（#653 review follow-up 补送）

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -51,7 +51,7 @@ describe('hook binding store', () => {
     store.set('conn-b', 'k2', 'sess-1', { workingDir: '/repos/demo', authority: 'workspace' });
     store.set('conn-b', 'k3', 'other', { workingDir: '/repos/demo', authority: 'workspace' });
 
-    expect(store.noteSessionMoved('sess-1', '/repos/moved')).toBe(2);
+    expect(store.noteSessionMoved('sess-1', '/repos/moved', 'local-move')).toBe(2);
 
     // 重启(新实例)后仍认这份授权, 否则跟随会退回撤权
     const reopened = makeStore();
@@ -69,7 +69,7 @@ describe('hook binding store', () => {
     // 别的会话的绑定不受影响
     expect(reopened.getEntry('conn-b', 'k3')?.authority).toBe('workspace');
     // 没有匹配绑定时是廉价 no-op
-    expect(reopened.noteSessionMoved('nobody', '/repos/moved')).toBe(0);
+    expect(reopened.noteSessionMoved('nobody', '/repos/moved', 'local-move')).toBe(0);
   });
 
   it('未传 meta 时不写这些字段', () => {

--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -36,7 +36,7 @@ describe('hook binding store', () => {
     });
 
     expect(store.get('conn-1', 'slack:C1:1.1')).toBe('sess-1');
-    expect(store.getEntry('conn-1', 'slack:C1:1.1')).toEqual({
+    expect(store.getEntry('conn-1', 'slack:C1:1.1')).toMatchObject({
       sessionId: 'sess-1',
       workingDir: '/repos/demo',
       authority: 'workspace',
@@ -59,7 +59,7 @@ describe('hook binding store', () => {
       ['conn-a', 'k1'],
       ['conn-b', 'k2'],
     ] as const) {
-      expect(reopened.getEntry(ns, key)).toEqual({
+      expect(reopened.getEntry(ns, key)).toMatchObject({
         sessionId: 'sess-1',
         workingDir: '/repos/moved',
         authority: 'local-move',
@@ -81,7 +81,7 @@ describe('hook binding store', () => {
 
     expect(row['conn-1']['k']).not.toHaveProperty('workingDir');
     expect(row['conn-1']['k']).not.toHaveProperty('authority');
-    expect(makeStore().getEntry('conn-1', 'k')).toEqual({
+    expect(makeStore().getEntry('conn-1', 'k')).toMatchObject({
       sessionId: 'sess-2',
       workingDir: null,
       authority: null,
@@ -98,7 +98,7 @@ describe('hook binding store', () => {
     const store = makeStore();
 
     expect(store.get('conn-1', 'slack:C1:1.1')).toBe('legacy');
-    expect(store.getEntry('conn-1', 'slack:C1:1.1')).toEqual({
+    expect(store.getEntry('conn-1', 'slack:C1:1.1')).toMatchObject({
       sessionId: 'legacy',
       workingDir: null,
       authority: null,

--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -51,7 +51,9 @@ describe('hook binding store', () => {
     store.set('conn-b', 'k2', 'sess-1', { workingDir: '/repos/demo', authority: 'workspace' });
     store.set('conn-b', 'k3', 'other', { workingDir: '/repos/demo', authority: 'workspace' });
 
-    expect(store.noteSessionMoved('sess-1', '/repos/moved', 'local-move')).toBe(2);
+    expect(
+      store.noteSessionMoved('sess-1', { from: '/repos/demo', to: '/repos/moved' }, 'local-move'),
+    ).toBe(2);
 
     // 重启(新实例)后仍认这份授权, 否则跟随会退回撤权
     const reopened = makeStore();
@@ -69,7 +71,9 @@ describe('hook binding store', () => {
     // 别的会话的绑定不受影响
     expect(reopened.getEntry('conn-b', 'k3')?.authority).toBe('workspace');
     // 没有匹配绑定时是廉价 no-op
-    expect(reopened.noteSessionMoved('nobody', '/repos/moved', 'local-move')).toBe(0);
+    expect(
+      reopened.noteSessionMoved('nobody', { from: null, to: '/repos/moved' }, 'local-move'),
+    ).toBe(0);
   });
 
   it('未传 meta 时不写这些字段', () => {

--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -52,7 +52,8 @@ describe('hook binding store', () => {
     store.set('conn-b', 'k3', 'other', { workingDir: '/repos/demo', authority: 'workspace' });
 
     expect(
-      store.noteSessionMoved('sess-1', { from: '/repos/demo', to: '/repos/moved' }, 'local-move'),
+      store.noteSessionMoved('sess-1', { from: '/repos/demo', to: '/repos/moved' }, 'local-move')
+        .updated,
     ).toBe(2);
 
     // 重启(新实例)后仍认这份授权, 否则跟随会退回撤权
@@ -72,7 +73,7 @@ describe('hook binding store', () => {
     expect(reopened.getEntry('conn-b', 'k3')?.authority).toBe('workspace');
     // 没有匹配绑定时是廉价 no-op
     expect(
-      reopened.noteSessionMoved('nobody', { from: null, to: '/repos/moved' }, 'local-move'),
+      reopened.noteSessionMoved('nobody', { from: null, to: '/repos/moved' }, 'local-move').updated,
     ).toBe(0);
   });
 

--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -30,28 +30,49 @@ const makeStore = () => createHookBindingStore({ filePath: filePath(), log: noop
 describe('hook binding store', () => {
   it('落绑定时记下工作目录快照与授权来源, get / getEntry 都能读回', () => {
     const store = makeStore();
-    store.set('conn-1', 'slack:C1:1.1', 'sess-1', '/repos/demo', 'workspace');
+    store.set('conn-1', 'slack:C1:1.1', 'sess-1', {
+      workingDir: '/repos/demo',
+      authority: 'workspace',
+    });
 
     expect(store.get('conn-1', 'slack:C1:1.1')).toBe('sess-1');
     expect(store.getEntry('conn-1', 'slack:C1:1.1')).toEqual({
       sessionId: 'sess-1',
       workingDir: '/repos/demo',
       authority: 'workspace',
+      noticePending: false,
     });
     expect(store.getEntry('conn-1', 'missing')).toBeNull();
   });
 
-  it('local-move 授权跨实例持久化(重启后跟随不能退回撤权)', () => {
-    makeStore().set('conn-1', 'k', 'sess-1', '/repos/moved', 'local-move');
+  it('noteSessionMoved 登记授权, 跨命名空间反查且跨实例持久化', () => {
+    const store = makeStore();
+    store.set('conn-a', 'k1', 'sess-1', { workingDir: '/repos/demo', authority: 'workspace' });
+    store.set('conn-b', 'k2', 'sess-1', { workingDir: '/repos/demo', authority: 'workspace' });
+    store.set('conn-b', 'k3', 'other', { workingDir: '/repos/demo', authority: 'workspace' });
 
-    expect(makeStore().getEntry('conn-1', 'k')).toEqual({
-      sessionId: 'sess-1',
-      workingDir: '/repos/moved',
-      authority: 'local-move',
-    });
+    expect(store.noteSessionMoved('sess-1', '/repos/moved')).toBe(2);
+
+    // 重启(新实例)后仍认这份授权, 否则跟随会退回撤权
+    const reopened = makeStore();
+    for (const [ns, key] of [
+      ['conn-a', 'k1'],
+      ['conn-b', 'k2'],
+    ] as const) {
+      expect(reopened.getEntry(ns, key)).toEqual({
+        sessionId: 'sess-1',
+        workingDir: '/repos/moved',
+        authority: 'local-move',
+        noticePending: true,
+      });
+    }
+    // 别的会话的绑定不受影响
+    expect(reopened.getEntry('conn-b', 'k3')?.authority).toBe('workspace');
+    // 没有匹配绑定时是廉价 no-op
+    expect(reopened.noteSessionMoved('nobody', '/repos/moved')).toBe(0);
   });
 
-  it('未传目录 / 授权时不写这两个字段', () => {
+  it('未传 meta 时不写这些字段', () => {
     makeStore().set('conn-1', 'k', 'sess-2');
     const row = JSON.parse(fs.readFileSync(filePath(), 'utf-8')) as Record<
       string,
@@ -64,6 +85,7 @@ describe('hook binding store', () => {
       sessionId: 'sess-2',
       workingDir: null,
       authority: null,
+      noticePending: false,
     });
   });
 
@@ -80,6 +102,7 @@ describe('hook binding store', () => {
       sessionId: 'legacy',
       workingDir: null,
       authority: null,
+      noticePending: false,
     });
   });
 
@@ -104,7 +127,7 @@ describe('hook binding store', () => {
 
   it('remove 清掉整条绑定(含快照与授权)', () => {
     const store = makeStore();
-    store.set('conn-1', 'k', 'sess-1', '/repos/demo', 'local-move');
+    store.set('conn-1', 'k', 'sess-1', { workingDir: '/repos/demo', authority: 'local-move' });
     store.remove('conn-1', 'k');
 
     expect(store.getEntry('conn-1', 'k')).toBeNull();

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -54,11 +54,16 @@ function memoryBindings(): HookBindingStore {
         authority: meta?.authority ?? null,
         noticePending: meta?.noticePending === true,
       }),
-    noteSessionMoved: (sessionId, workingDir) => {
+    noteSessionMoved: (sessionId, workingDir, authority) => {
       let updated = 0;
       for (const [key, row] of map) {
         if (row.sessionId !== sessionId) continue;
-        map.set(key, { sessionId, workingDir, authority: 'local-move', noticePending: true });
+        map.set(key, {
+          sessionId,
+          workingDir,
+          authority,
+          noticePending: authority === 'local-move',
+        });
         updated += 1;
       }
       return updated;
@@ -455,7 +460,7 @@ describe('dispatcher 核心语义', () => {
     // 用户在桌面端把这条会话「移动到项目」: Main 侧登记授权 + 会话目录变更
     const MOVED_DIR = path.resolve('/repos/another-project');
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
-    expect(bindings.noteSessionMoved(first, MOVED_DIR)).toBe(1);
+    expect(bindings.noteSessionMoved(first, MOVED_DIR, 'local-move')).toBe(1);
 
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
@@ -519,7 +524,7 @@ describe('dispatcher 核心语义', () => {
 
     // 移动后连发两条: 第二条时目录已等于登记值, 只有持久化的授权能保住复用
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
-    bindings.noteSessionMoved(first, MOVED_DIR);
+    bindings.noteSessionMoved(first, MOVED_DIR, 'local-move');
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
     fr.finish({ finalText: '第一次' });
@@ -549,7 +554,7 @@ describe('dispatcher 核心语义', () => {
     await tick();
     const first = c.last('task.ack')!.payload.sessionId!;
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
-    bindings.noteSessionMoved(first, MOVED_DIR);
+    bindings.noteSessionMoved(first, MOVED_DIR, 'local-move');
     fr.finish();
     await tick();
 
@@ -559,7 +564,8 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
     await tick();
     sessions[first] = { workingDir: WS_DIR, usable: true };
-    bindings.noteSessionMoved(first, WS_DIR);
+    // 移回映射内: 登记方按当前映射记 workspace, 不留 local-move 例外
+    bindings.noteSessionMoved(first, WS_DIR, 'workspace');
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
     await tick();
     expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -77,9 +77,11 @@ function memoryBindings(): HookBindingStore {
       return updated;
     },
     noteSessionMoved: (sessionId, move, authority) => {
+      const before: Array<[string, HookBindingEntry]> = [];
       let updated = 0;
       for (const [key, row] of map) {
         if (row.sessionId !== sessionId) continue;
+        before.push([key, { ...row }]);
         map.set(key, {
           sessionId,
           workingDir: move.to,
@@ -90,7 +92,15 @@ function memoryBindings(): HookBindingStore {
         });
         updated += 1;
       }
-      return updated;
+      return {
+        updated,
+        rollback: () => {
+          for (const [key, row] of before) {
+            const live = map.get(key);
+            map.set(key, { ...row, rev: (live?.rev ?? row.rev) + 1 });
+          }
+        },
+      };
     },
     remove: (c, e) => void map.delete(k(c, e)),
   };
@@ -484,7 +494,9 @@ describe('dispatcher 核心语义', () => {
     // 用户在桌面端把这条会话「移动到项目」: Main 侧登记授权 + 会话目录变更
     const MOVED_DIR = path.resolve('/repos/another-project');
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
-    expect(bindings.noteSessionMoved(first, { from: WS_DIR, to: MOVED_DIR }, 'local-move')).toBe(1);
+    expect(
+      bindings.noteSessionMoved(first, { from: WS_DIR, to: MOVED_DIR }, 'local-move').updated,
+    ).toBe(1);
 
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -668,6 +668,38 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
   });
 
+  it('inspect 期间完成的移动不被当成撤权(撤权前重读绑定)', async () => {
+    const bindings = memoryBindings();
+    const OUTSIDE = path.resolve('/repos/outside');
+    let inspected = 0;
+    const runner: HookSessionRunner = {
+      isBusy: () => false,
+      inspect: async () => {
+        inspected += 1;
+        // 第一次 inspect 的"期间", 移动完成: 绑定被登记并清掉在途标记,
+        // 会话已在新目录 —— 旧快照三条判定全落空
+        bindings.noteSessionMoved('sess-1', { from: WS_DIR, to: OUTSIDE }, 'local-move');
+        bindings.completeSessionMove('sess-1', OUTSIDE);
+        return { workingDir: OUTSIDE, usable: true };
+      },
+      run: async () => ({ status: 'ok', finalText: 'done', errorMessage: null, durationMs: 1 }),
+    };
+    const { d } = makeDispatcher({ runner, bindings });
+    const c = collector();
+    bindings.set('conn-1', 'team-slack:C1:1.1', 'sess-1', {
+      workingDir: WS_DIR,
+      authority: 'workspace',
+    });
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+
+    expect(inspected).toBe(1);
+    // 重读后认出新授权 -> 继续复用原会话, 而不是删绑定重开
+    expect(c.last('task.ack')!.payload.sessionId).toBe('sess-1');
+    expect(bindings.get('conn-1', 'team-slack:C1:1.1')).toBe('sess-1');
+  });
+
   it('过期的在途标记不再放行(清理失败也不会变成长期通行证)', async () => {
     const bindings = memoryBindings();
     const OUTSIDE = path.resolve('/repos/outside');

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -65,6 +65,17 @@ function memoryBindings(): HookBindingStore {
       });
       return true;
     },
+    completeSessionMove: (sessionId, workingDir) => {
+      let updated = 0;
+      for (const [key, row] of map) {
+        if (row.sessionId !== sessionId) continue;
+        if (row.workingDir !== workingDir) continue;
+        if (row.previousWorkingDir === null) continue;
+        map.set(key, { ...row, previousWorkingDir: null, rev: row.rev + 1 });
+        updated += 1;
+      }
+      return updated;
+    },
     noteSessionMoved: (sessionId, move, authority) => {
       let updated = 0;
       for (const [key, row] of map) {

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -40,6 +40,8 @@ const CONFIG: HookConnectionConfig = {
 /** 内存 binding(含目录快照与授权状态, 与文件实现同语义)。 */
 function memoryBindings(): HookBindingStore {
   const map = new Map<string, HookBindingEntry>();
+  // 单调递增版本号,模拟文件实现的 updatedAt(乐观并发控制用)
+  let version = 1;
   const k = (c: string, e: string): string => `${c}|${e}`;
   return {
     get: (c, e) => map.get(k(c, e))?.sessionId ?? null,
@@ -47,13 +49,24 @@ function memoryBindings(): HookBindingStore {
       const row = map.get(k(c, e));
       return row ? { ...row } : null;
     },
-    set: (c, e, s, meta) =>
-      void map.set(k(c, e), {
+    set: (c, e, s, meta) => {
+      const current = map.get(k(c, e));
+      if (
+        meta?.expectedUpdatedAt !== undefined &&
+        current !== undefined &&
+        current.updatedAt !== meta.expectedUpdatedAt
+      ) {
+        return false;
+      }
+      map.set(k(c, e), {
         sessionId: s,
         workingDir: meta?.workingDir ?? null,
         authority: meta?.authority ?? null,
         noticePending: meta?.noticePending === true,
-      }),
+        updatedAt: version++,
+      });
+      return true;
+    },
     noteSessionMoved: (sessionId, workingDir, authority) => {
       let updated = 0;
       for (const [key, row] of map) {
@@ -63,6 +76,7 @@ function memoryBindings(): HookBindingStore {
           workingDir,
           authority,
           noticePending: authority === 'local-move',
+          updatedAt: version++,
         });
         updated += 1;
       }
@@ -467,7 +481,7 @@ describe('dispatcher 核心语义', () => {
     expect(c.last('task.ack')!.payload).toMatchObject({ result: 'accepted', sessionId: first });
     expect(fr.calls[1]).toMatchObject({ isNew: false, sessionId: first, workingDir: MOVED_DIR });
     // 说明已发出, pending 清掉, 授权留下
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
       sessionId: first,
       workingDir: MOVED_DIR,
       authority: 'local-move',
@@ -541,6 +555,77 @@ describe('dispatcher 核心语义', () => {
     expect(c.last('turn.end')!.payload.finalText).toBe('第二次');
   });
 
+  it('移动登记已落、会话目录还没落库: 这一轮照常跑旧目录, 但不抹掉登记', async () => {
+    const bindings = memoryBindings();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const { d } = makeDispatcher({ runner: fr.runner, bindings });
+    const c = collector();
+    const MOVED_DIR = path.resolve('/repos/another-project');
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const first = c.last('task.ack')!.payload.sessionId!;
+    sessions[first] = { workingDir: WS_DIR, usable: true };
+    fr.finish();
+    await tick();
+
+    // 移动的两步之间: 授权已登记(新目录), session 行还停在旧目录
+    bindings.noteSessionMoved(first, MOVED_DIR, 'local-move');
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    // 这一轮按 session 的真实目录(仍在映射内)复用
+    expect(fr.calls[1]).toMatchObject({ isNew: false, sessionId: first, workingDir: WS_DIR });
+    // 关键: 登记没有被收敛回 workspace + 旧目录
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
+      workingDir: MOVED_DIR,
+      authority: 'local-move',
+      noticePending: true,
+    });
+    fr.finish();
+    await tick();
+
+    // 移动写库完成后, 下一条消息跟随到新目录并说明一次
+    sessions[first] = { workingDir: MOVED_DIR, usable: true };
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
+    await tick();
+    expect(c.last('task.ack')!.payload.sessionId).toBe(first);
+    fr.finish({ finalText: '跟过来了' });
+    await tick();
+    expect(c.last('turn.end')!.payload.finalText).toContain('已被移动到新的工作目录');
+  });
+
+  it('回填期间落下的登记不被覆盖(乐观并发控制)', async () => {
+    const bindings = memoryBindings();
+    const MOVED_DIR = path.resolve('/repos/another-project');
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {
+      'sess-1': { workingDir: WS_DIR, usable: true },
+    };
+    // inspect 是异步的: 在它 await 期间模拟一次移动登记落盘
+    const runner: HookSessionRunner = {
+      isBusy: () => false,
+      inspect: async (id) => {
+        bindings.noteSessionMoved('sess-1', MOVED_DIR, 'local-move');
+        return sessions[id] ? { ...sessions[id] } : null;
+      },
+      run: async () => ({ status: 'ok', finalText: 'ok', errorMessage: null, durationMs: 1 }),
+    };
+    const { d } = makeDispatcher({ runner, bindings });
+    const c = collector();
+    // 老形态绑定(无快照): 正常复用路径本会回填 workspace + 当前目录
+    bindings.set('conn-1', 'team-slack:C1:1.1', 'sess-1');
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+
+    expect(c.last('task.ack')!.payload.sessionId).toBe('sess-1');
+    // 回填必须让位给 inspect 期间落下的登记
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
+      workingDir: MOVED_DIR,
+      authority: 'local-move',
+    });
+  });
+
   it('对话移回工作目录映射内: 授权来源复位, 此后映射被改仍按撤权重建', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
@@ -568,7 +653,7 @@ describe('dispatcher 核心语义', () => {
     bindings.noteSessionMoved(first, WS_DIR, 'workspace');
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
     await tick();
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
       sessionId: first,
       workingDir: WS_DIR,
       authority: 'workspace',
@@ -636,7 +721,7 @@ describe('dispatcher 核心语义', () => {
     const sessionId = c.last('task.ack')!.payload.sessionId!;
     expect(sessionId).not.toBe('legacy-session');
     expect(fr.calls[0]).toMatchObject({ isNew: true, workingDir: WS_DIR });
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
       sessionId,
       workingDir: WS_DIR,
       authority: 'workspace',
@@ -656,7 +741,7 @@ describe('dispatcher 核心语义', () => {
     await tick();
 
     expect(c.last('task.ack')!.payload.sessionId).toBe('legacy-session');
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
       sessionId: 'legacy-session',
       workingDir: WS_DIR,
       authority: 'workspace',

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -59,6 +59,7 @@ function memoryBindings(): HookBindingStore {
         sessionId: s,
         workingDir: meta?.workingDir ?? null,
         previousWorkingDir: meta?.previousWorkingDir ?? null,
+        movePendingUntil: meta?.movePendingUntil ?? 0,
         authority: meta?.authority ?? null,
         noticePending: meta?.noticePending === true,
         rev: (current?.rev ?? 0) + 1,
@@ -71,7 +72,7 @@ function memoryBindings(): HookBindingStore {
         if (row.sessionId !== sessionId) continue;
         if (row.workingDir !== workingDir) continue;
         if (row.previousWorkingDir === null) continue;
-        map.set(key, { ...row, previousWorkingDir: null, rev: row.rev + 1 });
+        map.set(key, { ...row, previousWorkingDir: null, movePendingUntil: 0, rev: row.rev + 1 });
         updated += 1;
       }
       return updated;
@@ -86,6 +87,8 @@ function memoryBindings(): HookBindingStore {
           sessionId,
           workingDir: move.to,
           previousWorkingDir: move.from,
+          // 与文件实现同规: 有 from 才算在途, TTL 给足(测试不模拟过期)
+          movePendingUntil: move.from ? Date.now() + 60_000 : 0,
           authority,
           noticePending: authority === 'local-move',
           rev: row.rev + 1,
@@ -183,6 +186,7 @@ function makeDispatcher(overrides?: {
   dialogue?: HookDispatcherDeps['dialogue'];
   abortSession?: HookDispatcherDeps['abortSession'];
   accountInitiallyActive?: boolean;
+  now?: HookDispatcherDeps['now'];
 }) {
   const bindings = overrides?.bindings ?? memoryBindings();
   const fr = fakeRunner();
@@ -195,6 +199,7 @@ function makeDispatcher(overrides?: {
     dialogue: overrides?.dialogue,
     abortSession: overrides?.abortSession,
     accountInitiallyActive: overrides?.accountInitiallyActive,
+    ...(overrides?.now ? { now: overrides.now } : {}),
     log: noopLog,
   });
   return { d, bindings, fr };
@@ -660,6 +665,29 @@ describe('dispatcher 核心语义', () => {
       previousWorkingDir: null,
       authority: 'local-move',
     });
+    fr.finish();
+  });
+
+  it('过期的在途标记不再放行(清理失败也不会变成长期通行证)', async () => {
+    const bindings = memoryBindings();
+    const OUTSIDE = path.resolve('/repos/outside');
+    const fr = fakeRunner({ sessions: { 'sess-1': { workingDir: OUTSIDE, usable: true } } });
+    // now 停在"标记已过期"之后
+    const { d } = makeDispatcher({ runner: fr.runner, bindings, now: () => 10_000_000 });
+    const c = collector();
+    // 残留的在途标记: 指向当前目录, 但截止时刻早已过去
+    bindings.set('conn-1', 'team-slack:C1:1.1', 'sess-1', {
+      workingDir: path.resolve('/repos/elsewhere'),
+      previousWorkingDir: OUTSIDE,
+      movePendingUntil: 9_000_000,
+      authority: 'local-move',
+    });
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+
+    // 过期标记不再充当放行凭据 -> 按撤权重建
+    expect(c.last('task.ack')!.payload.sessionId).not.toBe('sess-1');
     fr.finish();
   });
 

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -37,7 +37,7 @@ const CONFIG: HookConnectionConfig = {
   createdAt: 0,
 };
 
-/** 内存 binding(含工作目录快照与授权来源, 与文件实现同语义)。 */
+/** 内存 binding(含目录快照与授权状态, 与文件实现同语义)。 */
 function memoryBindings(): HookBindingStore {
   const map = new Map<string, HookBindingEntry>();
   const k = (c: string, e: string): string => `${c}|${e}`;
@@ -47,12 +47,22 @@ function memoryBindings(): HookBindingStore {
       const row = map.get(k(c, e));
       return row ? { ...row } : null;
     },
-    set: (c, e, s, workingDir, authority) =>
+    set: (c, e, s, meta) =>
       void map.set(k(c, e), {
         sessionId: s,
-        workingDir: workingDir ?? null,
-        authority: authority ?? null,
+        workingDir: meta?.workingDir ?? null,
+        authority: meta?.authority ?? null,
+        noticePending: meta?.noticePending === true,
       }),
+    noteSessionMoved: (sessionId, workingDir) => {
+      let updated = 0;
+      for (const [key, row] of map) {
+        if (row.sessionId !== sessionId) continue;
+        map.set(key, { sessionId, workingDir, authority: 'local-move', noticePending: true });
+        updated += 1;
+      }
+      return updated;
+    },
     remove: (c, e) => void map.delete(k(c, e)),
   };
 }
@@ -428,7 +438,7 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
   });
 
-  it('会话被移出工作目录映射: 目录变过 -> 跟随复用并说明, 不重开新会话', async () => {
+  it('会话被移出工作目录映射(移动已登记) -> 跟随复用并说明, 不重开新会话', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
     const fr = fakeRunner({ sessions });
@@ -442,19 +452,21 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
     await tick();
 
-    // 用户在桌面端把这条会话「移动到项目」, 目标目录不在工作目录映射里
+    // 用户在桌面端把这条会话「移动到项目」: Main 侧登记授权 + 会话目录变更
     const MOVED_DIR = path.resolve('/repos/another-project');
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
+    expect(bindings.noteSessionMoved(first, MOVED_DIR)).toBe(1);
 
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
     expect(c.last('task.ack')!.payload).toMatchObject({ result: 'accepted', sessionId: first });
     expect(fr.calls[1]).toMatchObject({ isNew: false, sessionId: first, workingDir: MOVED_DIR });
-    // 快照跟随移动, 并记下"这份授权来自本地移动"
+    // 说明已发出, pending 清掉, 授权留下
     expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
       sessionId: first,
       workingDir: MOVED_DIR,
       authority: 'local-move',
+      noticePending: false,
     });
 
     fr.finish({ finalText: '在新目录里跑完了' });
@@ -462,6 +474,32 @@ describe('dispatcher 核心语义', () => {
     const finalText = c.last('turn.end')!.payload.finalText;
     expect(finalText).toContain('已被移动到新的工作目录');
     expect(finalText).toContain('在新目录里跑完了');
+  });
+
+  it('目录被改到映射外但没有登记过移动 -> 不跟随(不可信元数据不能当授权)', async () => {
+    const bindings = memoryBindings();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const { d } = makeDispatcher({ runner: fr.runner, bindings });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const first = c.last('task.ack')!.payload.sessionId!;
+    sessions[first] = { workingDir: WS_DIR, usable: true };
+    fr.finish();
+    await tick();
+
+    // 模拟 workingDir 被通用 patch 路径改到映射外(未经移动登记, 如被攻陷的
+    // renderer 调 local-db:sessions:update): 绝不能据此放行
+    sessions[first] = { workingDir: path.resolve('/private/keys'), usable: true };
+
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    const second = c.last('task.ack')!.payload.sessionId!;
+    expect(second).not.toBe(first);
+    expect(fr.calls[1]).toMatchObject({ isNew: true, workingDir: WS_DIR });
+    fr.finish();
   });
 
   it('移动后的后续消息持续复用同一 session, 且不再重复提示(跟随不能只生效一次)', async () => {
@@ -479,8 +517,9 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
     await tick();
 
-    // 移动后连发两条: 第二条时快照已等于新目录, 只有持久化的授权来源能保住复用
+    // 移动后连发两条: 第二条时目录已等于登记值, 只有持久化的授权能保住复用
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
+    bindings.noteSessionMoved(first, MOVED_DIR);
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
     fr.finish({ finalText: '第一次' });
@@ -510,6 +549,7 @@ describe('dispatcher 核心语义', () => {
     await tick();
     const first = c.last('task.ack')!.payload.sessionId!;
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
+    bindings.noteSessionMoved(first, MOVED_DIR);
     fr.finish();
     await tick();
 
@@ -519,12 +559,14 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
     await tick();
     sessions[first] = { workingDir: WS_DIR, usable: true };
+    bindings.noteSessionMoved(first, WS_DIR);
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
     await tick();
     expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
       sessionId: first,
       workingDir: WS_DIR,
       authority: 'workspace',
+      noticePending: false,
     });
     fr.finish();
     await tick();
@@ -592,6 +634,7 @@ describe('dispatcher 核心语义', () => {
       sessionId,
       workingDir: WS_DIR,
       authority: 'workspace',
+      noticePending: false,
     });
     fr.finish();
   });
@@ -611,6 +654,7 @@ describe('dispatcher 核心语义', () => {
       sessionId: 'legacy-session',
       workingDir: WS_DIR,
       authority: 'workspace',
+      noticePending: false,
     });
     fr.finish({ finalText: '继续' });
     await tick();
@@ -623,7 +667,10 @@ describe('dispatcher 核心语义', () => {
     const fr = fakeRunner({ sessions: { 'gone-session': { workingDir: WS_DIR, usable: false } } });
     const { d } = makeDispatcher({ runner: fr.runner, bindings });
     const c = collector();
-    bindings.set('conn-1', 'team-slack:C1:1.1', 'gone-session', WS_DIR, 'workspace');
+    bindings.set('conn-1', 'team-slack:C1:1.1', 'gone-session', {
+      workingDir: WS_DIR,
+      authority: 'workspace',
+    });
 
     d.handleDispatch('conn-1', dispatch(), c.send);
     await tick();

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -40,8 +40,6 @@ const CONFIG: HookConnectionConfig = {
 /** 内存 binding(含目录快照与授权状态, 与文件实现同语义)。 */
 function memoryBindings(): HookBindingStore {
   const map = new Map<string, HookBindingEntry>();
-  // 单调递增版本号,模拟文件实现的 updatedAt(乐观并发控制用)
-  let version = 1;
   const k = (c: string, e: string): string => `${c}|${e}`;
   return {
     get: (c, e) => map.get(k(c, e))?.sessionId ?? null,
@@ -52,31 +50,32 @@ function memoryBindings(): HookBindingStore {
     set: (c, e, s, meta) => {
       const current = map.get(k(c, e));
       if (
-        meta?.expectedUpdatedAt !== undefined &&
-        current !== undefined &&
-        current.updatedAt !== meta.expectedUpdatedAt
+        meta?.expectedRev !== undefined &&
+        (current === undefined || current.rev !== meta.expectedRev)
       ) {
         return false;
       }
       map.set(k(c, e), {
         sessionId: s,
         workingDir: meta?.workingDir ?? null,
+        previousWorkingDir: meta?.previousWorkingDir ?? null,
         authority: meta?.authority ?? null,
         noticePending: meta?.noticePending === true,
-        updatedAt: version++,
+        rev: (current?.rev ?? 0) + 1,
       });
       return true;
     },
-    noteSessionMoved: (sessionId, workingDir, authority) => {
+    noteSessionMoved: (sessionId, move, authority) => {
       let updated = 0;
       for (const [key, row] of map) {
         if (row.sessionId !== sessionId) continue;
         map.set(key, {
           sessionId,
-          workingDir,
+          workingDir: move.to,
+          previousWorkingDir: move.from,
           authority,
           noticePending: authority === 'local-move',
-          updatedAt: version++,
+          rev: row.rev + 1,
         });
         updated += 1;
       }
@@ -474,7 +473,7 @@ describe('dispatcher 核心语义', () => {
     // 用户在桌面端把这条会话「移动到项目」: Main 侧登记授权 + 会话目录变更
     const MOVED_DIR = path.resolve('/repos/another-project');
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
-    expect(bindings.noteSessionMoved(first, MOVED_DIR, 'local-move')).toBe(1);
+    expect(bindings.noteSessionMoved(first, { from: WS_DIR, to: MOVED_DIR }, 'local-move')).toBe(1);
 
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
@@ -538,7 +537,7 @@ describe('dispatcher 核心语义', () => {
 
     // 移动后连发两条: 第二条时目录已等于登记值, 只有持久化的授权能保住复用
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
-    bindings.noteSessionMoved(first, MOVED_DIR, 'local-move');
+    bindings.noteSessionMoved(first, { from: WS_DIR, to: MOVED_DIR }, 'local-move');
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
     fr.finish({ finalText: '第一次' });
@@ -571,7 +570,7 @@ describe('dispatcher 核心语义', () => {
     await tick();
 
     // 移动的两步之间: 授权已登记(新目录), session 行还停在旧目录
-    bindings.noteSessionMoved(first, MOVED_DIR, 'local-move');
+    bindings.noteSessionMoved(first, { from: WS_DIR, to: MOVED_DIR }, 'local-move');
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
     // 这一轮按 session 的真实目录(仍在映射内)复用
@@ -595,6 +594,52 @@ describe('dispatcher 核心语义', () => {
     expect(c.last('turn.end')!.payload.finalText).toContain('已被移动到新的工作目录');
   });
 
+  it('已在映射外的会话再次移动: 两步之间照常跑旧目录, 不丢绑定', async () => {
+    const bindings = memoryBindings();
+    const OUT_A = path.resolve('/repos/outside-a');
+    const OUT_B = path.resolve('/repos/outside-b');
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {
+      'sess-1': { workingDir: OUT_A, usable: true },
+    };
+    const fr = fakeRunner({ sessions });
+    const { d } = makeDispatcher({ runner: fr.runner, bindings });
+    const c = collector();
+    // 现状: 会话已在映射外 A, 且有 A 的 local-move 授权
+    bindings.set('conn-1', 'team-slack:C1:1.1', 'sess-1', {
+      workingDir: OUT_A,
+      authority: 'local-move',
+    });
+
+    // 再移动一次 A -> B: 登记已落, session 行还停在 A
+    bindings.noteSessionMoved('sess-1', { from: OUT_A, to: OUT_B }, 'local-move');
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+
+    // 绑定必须留着(旧版本在这里会直接判撤权、重开新对话)
+    expect(c.last('task.ack')!.payload.sessionId).toBe('sess-1');
+    expect(fr.calls[0]).toMatchObject({ isNew: false, sessionId: 'sess-1', workingDir: OUT_A });
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
+      workingDir: OUT_B,
+      previousWorkingDir: OUT_A,
+      authority: 'local-move',
+    });
+    fr.finish();
+    await tick();
+
+    // 写库完成后跟随到 B
+    sessions['sess-1'] = { workingDir: OUT_B, usable: true };
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    expect(fr.calls[1]).toMatchObject({ isNew: false, sessionId: 'sess-1', workingDir: OUT_B });
+    // 收敛后清掉在途标记
+    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({
+      workingDir: OUT_B,
+      previousWorkingDir: null,
+      authority: 'local-move',
+    });
+    fr.finish();
+  });
+
   it('回填期间落下的登记不被覆盖(乐观并发控制)', async () => {
     const bindings = memoryBindings();
     const MOVED_DIR = path.resolve('/repos/another-project');
@@ -605,7 +650,7 @@ describe('dispatcher 核心语义', () => {
     const runner: HookSessionRunner = {
       isBusy: () => false,
       inspect: async (id) => {
-        bindings.noteSessionMoved('sess-1', MOVED_DIR, 'local-move');
+        bindings.noteSessionMoved('sess-1', { from: WS_DIR, to: MOVED_DIR }, 'local-move');
         return sessions[id] ? { ...sessions[id] } : null;
       },
       run: async () => ({ status: 'ok', finalText: 'ok', errorMessage: null, durationMs: 1 }),
@@ -639,7 +684,7 @@ describe('dispatcher 核心语义', () => {
     await tick();
     const first = c.last('task.ack')!.payload.sessionId!;
     sessions[first] = { workingDir: MOVED_DIR, usable: true };
-    bindings.noteSessionMoved(first, MOVED_DIR, 'local-move');
+    bindings.noteSessionMoved(first, { from: WS_DIR, to: MOVED_DIR }, 'local-move');
     fr.finish();
     await tick();
 
@@ -650,7 +695,7 @@ describe('dispatcher 核心语义', () => {
     await tick();
     sessions[first] = { workingDir: WS_DIR, usable: true };
     // 移回映射内: 登记方按当前映射记 workspace, 不留 local-move 例外
-    bindings.noteSessionMoved(first, WS_DIR, 'workspace');
+    bindings.noteSessionMoved(first, { from: MOVED_DIR, to: WS_DIR }, 'workspace');
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
     await tick();
     expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toMatchObject({

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -104,6 +104,13 @@ export interface HookBindingStore {
     move: { from: string | null; to: string },
     authority: HookBindingAuthority,
   ): number;
+  /**
+   * 移动写库成功后收尾: 清掉 previousWorkingDir(在途标记), 让它严格只存在于
+   * 「登记已落、库还没落」那一小段。不清的话这个标记会一直有效, 之后有人把
+   * 会话目录改回旧值就能靠它绕过撤权(PR #669 review 指出)。
+   * 只对仍指向本次目标目录的绑定生效; 返回更新条数。
+   */
+  completeSessionMove(sessionId: string, workingDir: string): number;
   /** 删除单条绑定(session 失效重建前清理)。 */
   remove(connectionId: string, externalKey: string): void;
 }
@@ -225,6 +232,23 @@ export function createHookBindingStore(deps: {
             rev: revOf(row) + 1,
             updatedAt: Date.now(),
           };
+          updated += 1;
+        }
+      }
+      if (updated > 0) writeAll(data);
+      return updated;
+    },
+    completeSessionMove(sessionId, workingDir) {
+      if (!sessionId || !workingDir) return 0;
+      const data = readAll();
+      let updated = 0;
+      for (const rows of Object.values(data)) {
+        for (const [externalKey, row] of Object.entries(rows)) {
+          if (row?.sessionId !== sessionId) continue;
+          if (row.workingDir !== workingDir) continue;
+          if (row.previousWorkingDir == null) continue;
+          const { previousWorkingDir: _dropped, ...rest } = row;
+          rows[externalKey] = { ...rest, rev: revOf(row) + 1, updatedAt: Date.now() };
           updated += 1;
         }
       }

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -78,6 +78,16 @@ export interface HookBindingMeta {
   expectedRev?: number;
 }
 
+/**
+ * 一次移动登记的结果。rollback 把被覆盖的行原样写回 —— 移动写库失败时必须回滚,
+ * 否则 previousWorkingDir 会永久残留成一张"在途通行证"(PR #669 review 指出)。
+ */
+export interface HookMoveRegistration {
+  /** 实际改写的绑定条数(0 = 该会话没有 IM 绑定)。 */
+  updated: number;
+  rollback(): void;
+}
+
 export interface HookBindingStore {
   get(connectionId: string, externalKey: string): string | null;
   /** 含目录快照与授权状态的绑定视图; 不存在时 null。 */
@@ -103,7 +113,7 @@ export interface HookBindingStore {
     sessionId: string,
     move: { from: string | null; to: string },
     authority: HookBindingAuthority,
-  ): number;
+  ): HookMoveRegistration;
   /**
    * 移动写库成功后收尾: 清掉 previousWorkingDir(在途标记), 让它严格只存在于
    * 「登记已落、库还没落」那一小段。不清的话这个标记会一直有效, 之后有人把
@@ -138,12 +148,24 @@ export function createHookBindingStore(deps: {
 }): HookBindingStore {
   const { filePath, log } = deps;
 
+  /**
+   * 严格读取: 文件不存在 = 真的没有绑定(返回空表), 读不动 / 解析不了则**抛出**。
+   * 读侧的常规调用容忍失败(见 readAll), 但移动登记必须把失败当失败 —— 把一次
+   * 读故障当成"空表"会让登记静默变成 no-op, 移动照常提交, 等文件恢复可读后
+   * 下一条 IM 消息就把绑定当撤权删掉(PR #669 review 指出)。
+   */
+  function readAllStrict(): BindingFile {
+    if (!fs.existsSync(filePath)) return {};
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new Error('hook-bindings.json is not an object');
+    }
+    return raw as BindingFile;
+  }
+
   function readAll(): BindingFile {
     try {
-      if (!fs.existsSync(filePath)) return {};
-      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
-      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
-      return raw as BindingFile;
+      return readAllStrict();
     } catch (err) {
       log.warn(`read hook-bindings failed: ${err instanceof Error ? err.message : String(err)}`);
       return {};
@@ -215,12 +237,16 @@ export function createHookBindingStore(deps: {
       return true;
     },
     noteSessionMoved(sessionId, move, authority) {
-      if (!sessionId || !move.to) return 0;
-      const data = readAll();
+      const noop: HookMoveRegistration = { updated: 0, rollback: () => {} };
+      if (!sessionId || !move.to) return noop;
+      // 严格读: 读故障不能被当成"没有绑定"(见 readAllStrict)
+      const data = readAllStrict();
+      const before: Array<{ namespace: string; externalKey: string; row: BindingRow }> = [];
       let updated = 0;
-      for (const rows of Object.values(data)) {
+      for (const [namespace, rows] of Object.entries(data)) {
         for (const [externalKey, row] of Object.entries(rows)) {
           if (row?.sessionId !== sessionId) continue;
+          before.push({ namespace, externalKey, row: { ...row } });
           rows[externalKey] = {
             sessionId,
             workingDir: move.to,
@@ -235,8 +261,21 @@ export function createHookBindingStore(deps: {
           updated += 1;
         }
       }
-      if (updated > 0) writeAll(data);
-      return updated;
+      if (updated === 0) return noop;
+      writeAll(data);
+      return {
+        updated,
+        rollback: () => {
+          const current = readAll();
+          for (const { namespace, externalKey, row } of before) {
+            const live = current[namespace]?.[externalKey];
+            // 回滚期间又被别人写过(新的移动登记)就别覆盖它
+            if (!live || live.sessionId !== sessionId) continue;
+            (current[namespace] ??= {})[externalKey] = { ...row, rev: revOf(live) + 1 };
+          }
+          writeAll(current);
+        },
+      };
     },
     completeSessionMove(sessionId, workingDir) {
       if (!sessionId || !workingDir) return 0;

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -51,6 +51,8 @@ export interface HookBindingEntry {
   authority: HookBindingAuthority | null;
   /** 已登记的移动尚未在渠道里说明过。 */
   noticePending: boolean;
+  /** 该行最后一次写入时刻; set 的 expectedUpdatedAt 用它做乐观并发控制。 */
+  updatedAt: number;
 }
 
 /** set 的可选元信息(整行覆盖写, 省略即清空对应字段)。 */
@@ -58,14 +60,28 @@ export interface HookBindingMeta {
   workingDir?: string | null;
   authority?: HookBindingAuthority | null;
   noticePending?: boolean;
+  /**
+   * 乐观并发控制: 只有当前行的 updatedAt 仍等于该值时才写。dispatcher 的回填
+   * 用它避免抹掉「读取之后、回填之前」落下的移动登记(PR #669 review 指出的
+   * 反向竞态)。省略 = 无条件覆盖。
+   */
+  expectedUpdatedAt?: number;
 }
 
 export interface HookBindingStore {
   get(connectionId: string, externalKey: string): string | null;
   /** 含目录快照与授权状态的绑定视图; 不存在时 null。 */
   getEntry(connectionId: string, externalKey: string): HookBindingEntry | null;
-  /** 整行覆盖写: meta 里省略的字段等于清空, 调用方应显式传当前状态。 */
-  set(connectionId: string, externalKey: string, sessionId: string, meta?: HookBindingMeta): void;
+  /**
+   * 整行覆盖写: meta 里省略的字段等于清空, 调用方应显式传当前状态。
+   * 返回是否真的写入(带 expectedUpdatedAt 且版本已变时返回 false)。
+   */
+  set(
+    connectionId: string,
+    externalKey: string,
+    sessionId: string,
+    meta?: HookBindingMeta,
+  ): boolean;
   /**
    * 登记一次「用户在桌面端把这个会话移到了 workingDir」—— 由窄口径的
    * `local-db:sessions:move` 经 sessionMoves.ts 调用, 是 local-move 授权的唯一
@@ -144,12 +160,20 @@ export function createHookBindingStore(deps: {
         authority:
           row.authority === 'workspace' || row.authority === 'local-move' ? row.authority : null,
         noticePending: row.noticePending === true,
+        updatedAt: typeof row.updatedAt === 'number' ? row.updatedAt : 0,
       };
     },
     set(connectionId, externalKey, sessionId, meta) {
       const data = readAll();
+      if (meta?.expectedUpdatedAt !== undefined) {
+        const current = data[connectionId]?.[externalKey];
+        const currentVersion = typeof current?.updatedAt === 'number' ? current.updatedAt : 0;
+        // 期间被别人写过(典型: 一次移动登记)——放弃本次覆盖, 保住更新的那条
+        if (current !== undefined && currentVersion !== meta.expectedUpdatedAt) return false;
+      }
       (data[connectionId] ??= {})[externalKey] = toRow(sessionId, meta);
       writeAll(data);
+      return true;
     },
     noteSessionMoved(sessionId, workingDir, authority) {
       if (!sessionId || !workingDir) return 0;

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -26,10 +26,12 @@
  *   映射被改/删且目录没动时即失效(撤权语义不变)。
  * - `authority: 'local-move'` + `workingDir` —— 用户把对话移到了这个目录,
  *   此后目录只要没再变就继续复用; 移回映射内会复位成 'workspace'。
- * - `previousWorkingDir` —— 移动登记时会话**还在**的那个目录。移动是"先登记、
- *   再写库"两步, 其间到达的消息看到的 session 仍是旧目录; 靠这个字段识别出
- *   "登记已落、库还没落"的中间态, 照常在旧目录跑而不误判成撤权。落库后的第一次
- *   收敛就清掉它。
+ * - `previousWorkingDir` + `movePendingUntil` —— 移动登记时会话**还在**的那个
+ *   目录, 以及这份"在途"容忍的截止时刻。移动是"先登记、再写库"两步, 其间到达
+ *   的消息看到的 session 仍是旧目录; 靠这两个字段识别出"登记已落、库还没落"的
+ *   中间态, 照常在旧目录跑而不误判成撤权。写库成功会立刻清掉它们, 万一清理
+ *   本身失败(磁盘/权限), 截止时刻到了也自动失效 —— 残留的标记不能变成一张
+ *   长期有效的"在途通行证"(PR #669 review 指出)。
  * - `noticePending` —— 该次移动还没在渠道里说明过, dispatcher 说明一次后清掉。
  * - `rev` —— 单调递增的行版本, 供 set 的 expectedRev 做乐观并发控制。用计数而
  *   不是时间戳: 毫秒精度下同一毫秒的两次写会撞版本, CAS 就形同虚设。
@@ -55,6 +57,8 @@ export interface HookBindingEntry {
   workingDir: string | null;
   /** 见文件头: 移动登记时会话还在的目录; null = 没有在途的移动。 */
   previousWorkingDir: string | null;
+  /** 见文件头: 在途容忍的截止时刻(epoch ms); 0 = 没有在途的移动。 */
+  movePendingUntil: number;
   /** 上次放行的依据; null = 老数据未记录。 */
   authority: HookBindingAuthority | null;
   /** 已登记的移动尚未在渠道里说明过。 */
@@ -67,6 +71,7 @@ export interface HookBindingEntry {
 export interface HookBindingMeta {
   workingDir?: string | null;
   previousWorkingDir?: string | null;
+  movePendingUntil?: number;
   authority?: HookBindingAuthority | null;
   noticePending?: boolean;
   /**
@@ -131,6 +136,8 @@ interface BindingRow {
   workingDir?: string | null;
   /** 见文件头: 移动登记时会话还在的目录; 缺省 = 没有在途移动。 */
   previousWorkingDir?: string | null;
+  /** 见文件头: 在途容忍的截止时刻(epoch ms); 缺省 = 没有在途移动。 */
+  movePendingUntil?: number;
   /** 见文件头: 上次放行的依据; 缺省 = 老数据。 */
   authority?: HookBindingAuthority | null;
   /** 见文件头: 已登记的移动还没说明过。 */
@@ -141,6 +148,13 @@ interface BindingRow {
 }
 
 type BindingFile = Record<string, Record<string, BindingRow>>;
+
+/**
+ * "登记已落、库还没落"的容忍时长。正常只有一次 DB 写入 + 转录迁移(百毫秒级),
+ * 给到一分钟足够宽松; 上限的意义是: 万一写库后清理标记本身失败(磁盘/权限),
+ * 残留的在途标记也会自动失效, 不至于长期充当映射外的放行凭据。
+ */
+const MOVE_PENDING_TTL_MS = 60_000;
 
 export function createHookBindingStore(deps: {
   filePath: string;
@@ -192,6 +206,9 @@ export function createHookBindingStore(deps: {
       ...(typeof meta?.previousWorkingDir === 'string' && meta.previousWorkingDir.length > 0
         ? { previousWorkingDir: meta.previousWorkingDir }
         : {}),
+      ...(typeof meta?.movePendingUntil === 'number' && meta.movePendingUntil > 0
+        ? { movePendingUntil: meta.movePendingUntil }
+        : {}),
       ...(meta?.authority === 'workspace' || meta?.authority === 'local-move'
         ? { authority: meta.authority }
         : {}),
@@ -218,6 +235,7 @@ export function createHookBindingStore(deps: {
         workingDir: typeof row.workingDir === 'string' ? row.workingDir : null,
         previousWorkingDir:
           typeof row.previousWorkingDir === 'string' ? row.previousWorkingDir : null,
+        movePendingUntil: typeof row.movePendingUntil === 'number' ? row.movePendingUntil : 0,
         // 未知字面量(手改文件 / 更早的实验值)按"没有授权记录"处理, fail closed
         authority:
           row.authority === 'workspace' || row.authority === 'local-move' ? row.authority : null,
@@ -250,8 +268,14 @@ export function createHookBindingStore(deps: {
           rows[externalKey] = {
             sessionId,
             workingDir: move.to,
-            // 记下移动前的目录: 登记与写库之间到达的消息看到的还是它
-            ...(move.from ? { previousWorkingDir: move.from } : {}),
+            // 记下移动前的目录与容忍截止时刻: 登记与写库之间到达的消息看到的
+            // 还是旧目录; 截止后标记自动失效, 不会变成长期通行证
+            ...(move.from
+              ? {
+                  previousWorkingDir: move.from,
+                  movePendingUntil: Date.now() + MOVE_PENDING_TTL_MS,
+                }
+              : {}),
             authority,
             // 只有映射外的跟随才需要在渠道里解释一句
             ...(authority === 'local-move' ? { noticePending: true } : {}),
@@ -285,8 +309,8 @@ export function createHookBindingStore(deps: {
         for (const [externalKey, row] of Object.entries(rows)) {
           if (row?.sessionId !== sessionId) continue;
           if (row.workingDir !== workingDir) continue;
-          if (row.previousWorkingDir == null) continue;
-          const { previousWorkingDir: _dropped, ...rest } = row;
+          if (row.previousWorkingDir == null && row.movePendingUntil == null) continue;
+          const { previousWorkingDir: _dropped, movePendingUntil: _alsoDropped, ...rest } = row;
           rows[externalKey] = { ...rest, rev: revOf(row) + 1, updatedAt: Date.now() };
           updated += 1;
         }

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -67,11 +67,12 @@ export interface HookBindingStore {
   /** 整行覆盖写: meta 里省略的字段等于清空, 调用方应显式传当前状态。 */
   set(connectionId: string, externalKey: string, sessionId: string, meta?: HookBindingMeta): void;
   /**
-   * 登记一次「用户在桌面端把这个会话移到了 workingDir」—— 由 Main 侧真实的
-   * 移动写入调用(见 localDb/ipc/sessions.ts), 是 local-move 授权的唯一来源。
-   * 跨全部 connection 命名空间反查该 sessionId; 返回更新的绑定条数。
+   * 登记一次「用户在桌面端把这个会话移到了 workingDir」—— 由窄口径的
+   * `local-db:sessions:move` 经 sessionMoves.ts 调用, 是 local-move 授权的唯一
+   * 来源。authority 由调用方按当前工作目录映射判定(移进映射内的目录记
+   * 'workspace', 不留例外)。跨全部 connection 命名空间反查; 返回更新条数。
    */
-  noteSessionMoved(sessionId: string, workingDir: string): number;
+  noteSessionMoved(sessionId: string, workingDir: string, authority: HookBindingAuthority): number;
   /** 删除单条绑定(session 失效重建前清理)。 */
   remove(connectionId: string, externalKey: string): void;
 }
@@ -150,7 +151,7 @@ export function createHookBindingStore(deps: {
       (data[connectionId] ??= {})[externalKey] = toRow(sessionId, meta);
       writeAll(data);
     },
-    noteSessionMoved(sessionId, workingDir) {
+    noteSessionMoved(sessionId, workingDir, authority) {
       if (!sessionId || !workingDir) return 0;
       const data = readAll();
       let updated = 0;
@@ -160,8 +161,9 @@ export function createHookBindingStore(deps: {
           rows[externalKey] = {
             sessionId,
             workingDir,
-            authority: 'local-move',
-            noticePending: true,
+            authority,
+            // 只有映射外的跟随才需要在渠道里解释一句
+            ...(authority === 'local-move' ? { noticePending: true } : {}),
             updatedAt: Date.now(),
           };
           updated += 1;

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -26,7 +26,13 @@
  *   映射被改/删且目录没动时即失效(撤权语义不变)。
  * - `authority: 'local-move'` + `workingDir` —— 用户把对话移到了这个目录,
  *   此后目录只要没再变就继续复用; 移回映射内会复位成 'workspace'。
+ * - `previousWorkingDir` —— 移动登记时会话**还在**的那个目录。移动是"先登记、
+ *   再写库"两步, 其间到达的消息看到的 session 仍是旧目录; 靠这个字段识别出
+ *   "登记已落、库还没落"的中间态, 照常在旧目录跑而不误判成撤权。落库后的第一次
+ *   收敛就清掉它。
  * - `noticePending` —— 该次移动还没在渠道里说明过, dispatcher 说明一次后清掉。
+ * - `rev` —— 单调递增的行版本, 供 set 的 expectedRev 做乐观并发控制。用计数而
+ *   不是时间戳: 毫秒精度下同一毫秒的两次写会撞版本, CAS 就形同虚设。
  *
  * 老文件没有这些字段 = null/false, 判定按保守侧(见 dispatcher.resolveTarget)。
  */
@@ -47,25 +53,29 @@ export interface HookBindingEntry {
   sessionId: string;
   /** 上次确认/登记时会话的工作目录; null = 老数据未记录。 */
   workingDir: string | null;
+  /** 见文件头: 移动登记时会话还在的目录; null = 没有在途的移动。 */
+  previousWorkingDir: string | null;
   /** 上次放行的依据; null = 老数据未记录。 */
   authority: HookBindingAuthority | null;
   /** 已登记的移动尚未在渠道里说明过。 */
   noticePending: boolean;
-  /** 该行最后一次写入时刻; set 的 expectedUpdatedAt 用它做乐观并发控制。 */
-  updatedAt: number;
+  /** 单调递增的行版本; set 的 expectedRev 用它做乐观并发控制。 */
+  rev: number;
 }
 
 /** set 的可选元信息(整行覆盖写, 省略即清空对应字段)。 */
 export interface HookBindingMeta {
   workingDir?: string | null;
+  previousWorkingDir?: string | null;
   authority?: HookBindingAuthority | null;
   noticePending?: boolean;
   /**
-   * 乐观并发控制: 只有当前行的 updatedAt 仍等于该值时才写。dispatcher 的回填
-   * 用它避免抹掉「读取之后、回填之前」落下的移动登记(PR #669 review 指出的
-   * 反向竞态)。省略 = 无条件覆盖。
+   * 乐观并发控制: 只有当前行存在且 rev 仍等于该值时才写。dispatcher 的回填用它
+   * 避免抹掉「读取之后、回填之前」落下的移动登记(PR #669 review 指出的反向
+   * 竞态)。行在此期间被删掉时同样拒绝写入 —— 那说明状态已经不是读到的那份。
+   * 省略 = 无条件覆盖。
    */
-  expectedUpdatedAt?: number;
+  expectedRev?: number;
 }
 
 export interface HookBindingStore {
@@ -74,7 +84,7 @@ export interface HookBindingStore {
   getEntry(connectionId: string, externalKey: string): HookBindingEntry | null;
   /**
    * 整行覆盖写: meta 里省略的字段等于清空, 调用方应显式传当前状态。
-   * 返回是否真的写入(带 expectedUpdatedAt 且版本已变时返回 false)。
+   * 返回是否真的写入(带 expectedRev 且行版本已变/行已被删时返回 false)。
    */
   set(
     connectionId: string,
@@ -83,12 +93,17 @@ export interface HookBindingStore {
     meta?: HookBindingMeta,
   ): boolean;
   /**
-   * 登记一次「用户在桌面端把这个会话移到了 workingDir」—— 由窄口径的
+   * 登记一次「用户在桌面端把这个会话从 move.from 移到了 move.to」—— 由窄口径的
    * `local-db:sessions:move` 经 sessionMoves.ts 调用, 是 local-move 授权的唯一
    * 来源。authority 由调用方按当前工作目录映射判定(移进映射内的目录记
-   * 'workspace', 不留例外)。跨全部 connection 命名空间反查; 返回更新条数。
+   * 'workspace', 不留例外); move.from 落进 previousWorkingDir, 让 dispatcher
+   * 认得出"登记已落、库还没落"的中间态。跨全部命名空间反查; 返回更新条数。
    */
-  noteSessionMoved(sessionId: string, workingDir: string, authority: HookBindingAuthority): number;
+  noteSessionMoved(
+    sessionId: string,
+    move: { from: string | null; to: string },
+    authority: HookBindingAuthority,
+  ): number;
   /** 删除单条绑定(session 失效重建前清理)。 */
   remove(connectionId: string, externalKey: string): void;
 }
@@ -97,10 +112,14 @@ interface BindingRow {
   sessionId: string;
   /** 见文件头: 上次确认/登记时的工作目录; 缺省 = 老数据。 */
   workingDir?: string | null;
+  /** 见文件头: 移动登记时会话还在的目录; 缺省 = 没有在途移动。 */
+  previousWorkingDir?: string | null;
   /** 见文件头: 上次放行的依据; 缺省 = 老数据。 */
   authority?: HookBindingAuthority | null;
   /** 见文件头: 已登记的移动还没说明过。 */
   noticePending?: boolean;
+  /** 见文件头: 单调递增的行版本(缺省 = 老数据, 按 0 起算)。 */
+  rev?: number;
   updatedAt: number;
 }
 
@@ -131,18 +150,30 @@ export function createHookBindingStore(deps: {
     fs.renameSync(tmp, filePath);
   }
 
-  function toRow(sessionId: string, meta: HookBindingMeta | undefined): BindingRow {
+  function toRow(
+    sessionId: string,
+    meta: HookBindingMeta | undefined,
+    previousRev: number,
+  ): BindingRow {
     return {
       sessionId,
       ...(typeof meta?.workingDir === 'string' && meta.workingDir.length > 0
         ? { workingDir: meta.workingDir }
         : {}),
+      ...(typeof meta?.previousWorkingDir === 'string' && meta.previousWorkingDir.length > 0
+        ? { previousWorkingDir: meta.previousWorkingDir }
+        : {}),
       ...(meta?.authority === 'workspace' || meta?.authority === 'local-move'
         ? { authority: meta.authority }
         : {}),
       ...(meta?.noticePending === true ? { noticePending: true } : {}),
+      rev: previousRev + 1,
       updatedAt: Date.now(),
     };
+  }
+
+  function revOf(row: BindingRow | undefined): number {
+    return typeof row?.rev === 'number' ? row.rev : 0;
   }
 
   return {
@@ -156,27 +187,28 @@ export function createHookBindingStore(deps: {
       return {
         sessionId: row.sessionId,
         workingDir: typeof row.workingDir === 'string' ? row.workingDir : null,
+        previousWorkingDir:
+          typeof row.previousWorkingDir === 'string' ? row.previousWorkingDir : null,
         // 未知字面量(手改文件 / 更早的实验值)按"没有授权记录"处理, fail closed
         authority:
           row.authority === 'workspace' || row.authority === 'local-move' ? row.authority : null,
         noticePending: row.noticePending === true,
-        updatedAt: typeof row.updatedAt === 'number' ? row.updatedAt : 0,
+        rev: revOf(row),
       };
     },
     set(connectionId, externalKey, sessionId, meta) {
       const data = readAll();
-      if (meta?.expectedUpdatedAt !== undefined) {
-        const current = data[connectionId]?.[externalKey];
-        const currentVersion = typeof current?.updatedAt === 'number' ? current.updatedAt : 0;
-        // 期间被别人写过(典型: 一次移动登记)——放弃本次覆盖, 保住更新的那条
-        if (current !== undefined && currentVersion !== meta.expectedUpdatedAt) return false;
+      const current = data[connectionId]?.[externalKey];
+      if (meta?.expectedRev !== undefined) {
+        // 期间被别人写过(典型: 一次移动登记)或整行被删 —— 放弃本次覆盖
+        if (current === undefined || revOf(current) !== meta.expectedRev) return false;
       }
-      (data[connectionId] ??= {})[externalKey] = toRow(sessionId, meta);
+      (data[connectionId] ??= {})[externalKey] = toRow(sessionId, meta, revOf(current));
       writeAll(data);
       return true;
     },
-    noteSessionMoved(sessionId, workingDir, authority) {
-      if (!sessionId || !workingDir) return 0;
+    noteSessionMoved(sessionId, move, authority) {
+      if (!sessionId || !move.to) return 0;
       const data = readAll();
       let updated = 0;
       for (const rows of Object.values(data)) {
@@ -184,10 +216,13 @@ export function createHookBindingStore(deps: {
           if (row?.sessionId !== sessionId) continue;
           rows[externalKey] = {
             sessionId,
-            workingDir,
+            workingDir: move.to,
+            // 记下移动前的目录: 登记与写库之间到达的消息看到的还是它
+            ...(move.from ? { previousWorkingDir: move.from } : {}),
             authority,
             // 只有映射外的跟随才需要在渠道里解释一句
             ...(authority === 'local-move' ? { noticePending: true } : {}),
+            rev: revOf(row) + 1,
             updatedAt: Date.now(),
           };
           updated += 1;

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -4,19 +4,31 @@
  * externalKey -> sessionId 映射存储(协议铁律「同 key 同 session」的落地)。
  *
  * 结构:
- * { [connectionId]: { [externalKey]: { sessionId, workingDir, authority, updatedAt } } }
+ * { [connectionId]: { [externalKey]: { sessionId, workingDir, authority, … } } }
  * —— 以 connectionId 为命名空间隔离, 两个 hook server 的同名 key 不会串台。
  * 持久化为 <userData>/hook-bindings.json(原子写), 跨 app 重启保持会话连续性。
  * 体量: 每 thread/issue 一条, 实际规模远小于消息量, JSON 文件足够;
  * 若未来需要清理策略再升级 localDb 表。
  *
- * workingDir + authority 记录**上次确认这条绑定可用时**的工作目录, 以及那次
- * 是凭什么放行的。dispatcher 靠这两个字段区分三件本来看起来一样的事:
- * 「用户在桌面端把对话移出了工作目录映射」(目录相对快照变了 -> 跟随, 并把
- * authority 记为 local-move)、「上一条消息已按本地移动放行过」(目录没再变且
- * authority=local-move -> 继续跟随, 否则跟随只生效一次)、「用户改动了工作
- * 目录映射」(目录没变且 authority=workspace -> 撤权, 丢绑定重建)。
- * 老文件没有这两个字段 = null/undefined, 判定按保守侧(见 resolveTarget)。
+ * ## 为什么绑定要记「授权来源」
+ *
+ * 会话的工作目录必须落在该连接的工作目录映射内, IM 侧才驱动得动它 —— 这是
+ * 「远端能碰哪些本地目录」的边界。唯一的例外是用户自己在桌面端把对话移到了
+ * 映射外的项目: 那时应当跟随, 否则同一个 thread 每条消息都会重开新对话。
+ *
+ * 判断"是不是用户移的"**不能**靠比对 session 元数据 —— `sessions` 行的
+ * workingDir 经通用 patch IPC 就能改(见 localDb/ipc/sessions.ts 的
+ * `local-db:sessions:update`), 而 Renderer 按 electron-security 规则属不可信
+ * 环境; 目录写法归一化之类的无关写入也会让"目录变了"成立。因此授权由**移动
+ * 动作本身**在 Main 侧登记(`noteSessionMoved`), dispatcher 只认已登记的结论:
+ *
+ * - `authority: 'workspace'` —— 上次放行是因为目录在映射(或内置对话根)内;
+ *   映射被改/删且目录没动时即失效(撤权语义不变)。
+ * - `authority: 'local-move'` + `workingDir` —— 用户把对话移到了这个目录,
+ *   此后目录只要没再变就继续复用; 移回映射内会复位成 'workspace'。
+ * - `noticePending` —— 该次移动还没在渠道里说明过, dispatcher 说明一次后清掉。
+ *
+ * 老文件没有这些字段 = null/false, 判定按保守侧(见 dispatcher.resolveTarget)。
  */
 
 import fs from 'node:fs';
@@ -24,44 +36,54 @@ import path from 'node:path';
 
 /**
  * 上次放行这条绑定的依据:
- * - 'workspace': 目录当时落在工作目录映射(或内置对话根)内, 授权随映射走 ——
- *   映射被改/删且目录没动时即失效(撤权)。
- * - 'local-move': 用户在桌面端把对话移出了映射, 由这次**本地**移动授权 ——
- *   目录不在映射内也继续复用, 直到它再被移动(重新判定)或移回映射内。
+ * - 'workspace': 目录当时落在工作目录映射(或内置对话根)内, 授权随映射走。
+ * - 'local-move': 由 Main 侧登记的一次真实「移动对话」动作授权, 目录不在映射
+ *   内也继续复用, 直到它再被移动(重新登记)或移回映射内。
  */
 export type HookBindingAuthority = 'workspace' | 'local-move';
 
-/** 一条绑定的完整视图(get 只要 sessionId 时用 get, 需要目录快照时用 getEntry)。 */
+/** 一条绑定的完整视图(只要 sessionId 时用 get, 需要授权状态时用 getEntry)。 */
 export interface HookBindingEntry {
   sessionId: string;
-  /** 上次确认时会话的工作目录; null = 老数据未记录快照。 */
+  /** 上次确认/登记时会话的工作目录; null = 老数据未记录。 */
   workingDir: string | null;
   /** 上次放行的依据; null = 老数据未记录。 */
   authority: HookBindingAuthority | null;
+  /** 已登记的移动尚未在渠道里说明过。 */
+  noticePending: boolean;
+}
+
+/** set 的可选元信息(整行覆盖写, 省略即清空对应字段)。 */
+export interface HookBindingMeta {
+  workingDir?: string | null;
+  authority?: HookBindingAuthority | null;
+  noticePending?: boolean;
 }
 
 export interface HookBindingStore {
   get(connectionId: string, externalKey: string): string | null;
-  /** 含工作目录快照与授权来源的绑定视图; 不存在时 null。 */
+  /** 含目录快照与授权状态的绑定视图; 不存在时 null。 */
   getEntry(connectionId: string, externalKey: string): HookBindingEntry | null;
-  /** 整行覆盖写: 省略 workingDir / authority 等于把它们清空, 调用方应显式传。 */
-  set(
-    connectionId: string,
-    externalKey: string,
-    sessionId: string,
-    workingDir?: string | null,
-    authority?: HookBindingAuthority | null,
-  ): void;
+  /** 整行覆盖写: meta 里省略的字段等于清空, 调用方应显式传当前状态。 */
+  set(connectionId: string, externalKey: string, sessionId: string, meta?: HookBindingMeta): void;
+  /**
+   * 登记一次「用户在桌面端把这个会话移到了 workingDir」—— 由 Main 侧真实的
+   * 移动写入调用(见 localDb/ipc/sessions.ts), 是 local-move 授权的唯一来源。
+   * 跨全部 connection 命名空间反查该 sessionId; 返回更新的绑定条数。
+   */
+  noteSessionMoved(sessionId: string, workingDir: string): number;
   /** 删除单条绑定(session 失效重建前清理)。 */
   remove(connectionId: string, externalKey: string): void;
 }
 
 interface BindingRow {
   sessionId: string;
-  /** 见文件头: 上次确认时的工作目录快照; 缺省 = 老数据。 */
+  /** 见文件头: 上次确认/登记时的工作目录; 缺省 = 老数据。 */
   workingDir?: string | null;
   /** 见文件头: 上次放行的依据; 缺省 = 老数据。 */
   authority?: HookBindingAuthority | null;
+  /** 见文件头: 已登记的移动还没说明过。 */
+  noticePending?: boolean;
   updatedAt: number;
 }
 
@@ -92,6 +114,20 @@ export function createHookBindingStore(deps: {
     fs.renameSync(tmp, filePath);
   }
 
+  function toRow(sessionId: string, meta: HookBindingMeta | undefined): BindingRow {
+    return {
+      sessionId,
+      ...(typeof meta?.workingDir === 'string' && meta.workingDir.length > 0
+        ? { workingDir: meta.workingDir }
+        : {}),
+      ...(meta?.authority === 'workspace' || meta?.authority === 'local-move'
+        ? { authority: meta.authority }
+        : {}),
+      ...(meta?.noticePending === true ? { noticePending: true } : {}),
+      updatedAt: Date.now(),
+    };
+  }
+
   return {
     get(connectionId, externalKey) {
       const row = readAll()[connectionId]?.[externalKey];
@@ -106,17 +142,33 @@ export function createHookBindingStore(deps: {
         // 未知字面量(手改文件 / 更早的实验值)按"没有授权记录"处理, fail closed
         authority:
           row.authority === 'workspace' || row.authority === 'local-move' ? row.authority : null,
+        noticePending: row.noticePending === true,
       };
     },
-    set(connectionId, externalKey, sessionId, workingDir, authority) {
+    set(connectionId, externalKey, sessionId, meta) {
       const data = readAll();
-      (data[connectionId] ??= {})[externalKey] = {
-        sessionId,
-        ...(typeof workingDir === 'string' && workingDir.length > 0 ? { workingDir } : {}),
-        ...(authority === 'workspace' || authority === 'local-move' ? { authority } : {}),
-        updatedAt: Date.now(),
-      };
+      (data[connectionId] ??= {})[externalKey] = toRow(sessionId, meta);
       writeAll(data);
+    },
+    noteSessionMoved(sessionId, workingDir) {
+      if (!sessionId || !workingDir) return 0;
+      const data = readAll();
+      let updated = 0;
+      for (const rows of Object.values(data)) {
+        for (const [externalKey, row] of Object.entries(rows)) {
+          if (row?.sessionId !== sessionId) continue;
+          rows[externalKey] = {
+            sessionId,
+            workingDir,
+            authority: 'local-move',
+            noticePending: true,
+            updatedAt: Date.now(),
+          };
+          updated += 1;
+        }
+      }
+      if (updated > 0) writeAll(data);
+      return updated;
     },
     remove(connectionId, externalKey) {
       const data = readAll();

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -151,10 +151,11 @@ type BindingFile = Record<string, Record<string, BindingRow>>;
 
 /**
  * "登记已落、库还没落"的容忍时长。正常只有一次 DB 写入 + 转录迁移(百毫秒级),
- * 给到一分钟足够宽松; 上限的意义是: 万一写库后清理标记本身失败(磁盘/权限),
- * 残留的在途标记也会自动失效, 不至于长期充当映射外的放行凭据。
+ * 十几秒已经很宽松; 上限的意义是: 万一写库后清理标记本身失败(磁盘/权限),
+ * 残留的在途标记也会自动失效, 不至于充当映射外的放行凭据 —— 窗口越短, 那段
+ * 时间里"把会话目录改回旧值来蹭这张票"的机会越小(PR #669 review 指出)。
  */
-const MOVE_PENDING_TTL_MS = 60_000;
+const MOVE_PENDING_TTL_MS = 15_000;
 
 export function createHookBindingStore(deps: {
   filePath: string;
@@ -290,20 +291,26 @@ export function createHookBindingStore(deps: {
       return {
         updated,
         rollback: () => {
-          const current = readAll();
+          // 严格读: readAll 的兜底会把一次读故障变成空表, 然后 writeAll 就把整个
+          // 绑定文件覆写成 {} —— 一次失败的移动会清光所有 thread 绑定
+          // (PR #669 review 指出)。读不动就直接放弃回滚, 不写。
+          const current = readAllStrict();
+          let restored = 0;
           for (const { namespace, externalKey, row } of before) {
             const live = current[namespace]?.[externalKey];
             // 回滚期间又被别人写过(新的移动登记)就别覆盖它
             if (!live || live.sessionId !== sessionId) continue;
             (current[namespace] ??= {})[externalKey] = { ...row, rev: revOf(live) + 1 };
+            restored += 1;
           }
-          writeAll(current);
+          if (restored > 0) writeAll(current);
         },
       };
     },
     completeSessionMove(sessionId, workingDir) {
       if (!sessionId || !workingDir) return 0;
-      const data = readAll();
+      // 同 rollback: 读故障不能被兜底成空表后整file覆写
+      const data = readAllStrict();
       let updated = 0;
       for (const rows of Object.values(data)) {
         for (const [externalKey, row] of Object.entries(rows)) {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -640,6 +640,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       authority: HookBindingAuthority | null,
     ): void => {
       if (!legacyBound || !legacyNamespace) return;
+      // inspect 期间 legacy 行可能刚收到一次移动登记 —— 用初读的快照迁移会把
+      // 旧目录写进新命名空间并把带登记的 legacy 行删掉(PR #669 review 指出)。
+      // 迁移前重读一次, 版本变了就这轮不迁, 下条消息再走正常路径。
+      const fresh = bindings.getEntry(legacyNamespace, payload.externalKey);
+      if (!fresh || fresh.sessionId !== legacyBound || fresh.rev !== legacyEntry?.rev) return;
       bindings.set(connectionId, payload.externalKey, legacyBound, {
         workingDir,
         authority,
@@ -707,11 +712,15 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
        *
        * 少了这条, 从映射外再移动一次会直接丢绑定: 新授权指向新目录、session 还
        * 在旧的映射外目录, 两个条件都不满足就落到撤权分支(PR #669 review 指出)。
+       *
+       * **不限定 authority**: 从映射外移回映射内时登记的是 'workspace', 只认
+       * local-move 的话这条路径照样丢绑定。previousWorkingDir 只由可信的 move
+       * 入口写入、写库成功即清, 它本身就是"有一次已登记的移动在途"的证据; 放行
+       * 的又是移动前那个已授权目录, 不放宽任何边界。
        */
       const pendingMoveRegistration =
         usable &&
-        boundEntry?.authority === 'local-move' &&
-        boundEntry.previousWorkingDir != null &&
+        boundEntry?.previousWorkingDir != null &&
         isSamePath(boundEntry.previousWorkingDir, info!.workingDir!);
       // 三者都不满足 = 映射被改/删的撤权语义(或目录被别的路径改过), 仍丢绑定
       // 重建。老绑定无授权记录时同样走保守侧。

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -11,11 +11,10 @@
  *      - 带 sessionId(接管): session 必须存在且其工作目录落在本连接注册的
  *        别名路径内(白名单不因接管放松), 通过后把 externalKey 重绑到它;
  *      - 不带(默认): 别名解析(映射即白名单)-> binding 查 externalKey ->
- *        复用(且重校验白名单)或新建并落绑定; 白名单重校验失败时看绑定上的
- *        目录快照与授权来源: 目录相对快照变过 = 用户在桌面端把对话移出了
- *        映射(目录是本地用户亲手选的, 不是远端指定的)-> 跟随并记 local-move;
- *        目录没再变但已记过 local-move -> 继续认这份授权(否则跟随只生效一
- *        次); 两者都不满足 = 映射被改/删的撤权语义 -> 丢绑定重建;
+ *        复用(且重校验白名单)或新建并落绑定; 白名单重校验失败时只认绑定上
+ *        **已登记**的本地移动授权(authority=local-move 且目录仍是登记时那个,
+ *        登记入口 hook-control/sessionMoves.ts)-> 跟随, 并在渠道里说明一次;
+ *        没有该授权 = 映射被改/删的撤权语义 -> 丢绑定重建;
  *   3. 排队: 目标 session 正在跑 turn 时 FIFO 排队, ack 回 queued + 位置;
  *      turn 收口后自动 drain;
  *   4. 回推: turn.end 经当前连接发送; 连接不在线时缓存, 重连(onConnected)
@@ -592,13 +591,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }
       // 接管路径刚校验过白名单, 授权来源恒为 workspace(远端不能凭接管把会话
       // 带出映射 —— 越界的 sessionId 在上面就被 workspace_not_allowed 打回)
-      bindings.set(
-        connectionId,
-        payload.externalKey,
-        payload.sessionId,
-        info.workingDir,
-        'workspace',
-      );
+      bindings.set(connectionId, payload.externalKey, payload.sessionId, {
+        workingDir: info.workingDir,
+        authority: 'workspace',
+      });
       return {
         run: {
           sessionId: payload.sessionId,
@@ -644,7 +640,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       authority: HookBindingAuthority | null,
     ): void => {
       if (!legacyBound || !legacyNamespace) return;
-      bindings.set(connectionId, payload.externalKey, legacyBound, workingDir, authority);
+      bindings.set(connectionId, payload.externalKey, legacyBound, {
+        workingDir,
+        authority,
+        noticePending: false,
+      });
       bindings.remove(legacyNamespace, payload.externalKey);
     };
     if (bound) {
@@ -683,42 +683,47 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       const inAllowedRoot =
         info !== null && (isChat ? inDialogueRoot(info.workingDir) : inWhitelist(info.workingDir));
       const usable = info?.usable === true && info.workingDir !== null;
-      /** 会话目录与绑定快照一致 = 自上次确认以来它没被动过。 */
-      const sameAsSnapshot =
+      /**
+       * 映射外唯一的放行依据: 绑定上有 Main 侧登记的「本地移动授权」, 且会话
+       * 目录仍是登记时那个 —— 用户在桌面端把对话移到了映射外的项目, 跟随即可,
+       * 否则同一个 thread 每条消息都会重开新对话。
+       *
+       * 授权**不从 session 元数据反推**(不比对"目录跟上次不一样"就放行):
+       * sessions 行的 workingDir 经通用 patch IPC 就能改, 而 Renderer 按
+       * electron-security 规则属不可信环境 —— 那样等于给了一条绕过工作目录
+       * 映射的路子; 目录归一化之类的无关写入也会被误判成移动。登记入口见
+       * hook-control/sessionMoves.ts。
+       */
+      const locallyAuthorized =
+        !inAllowedRoot &&
         usable &&
-        boundEntry?.workingDir != null &&
+        boundEntry?.authority === 'local-move' &&
+        boundEntry.workingDir != null &&
         isSamePath(boundEntry.workingDir, info!.workingDir!);
-      /**
-       * 白名单外但**目录相对快照变过** = 用户在桌面端把这条会话「移动到项目」了。
-       * 目录是本地用户亲手选的(不是远端指定的 —— 远端只能在接管路径里选白名单
-       * 内的会话), 属本地授权, 跟随即可; 否则同一个 thread 每条消息都会重开新
-       * 会话, 破坏「同 key 同 session」。
-       */
-      const movedNow =
-        !inAllowedRoot && usable && boundEntry?.workingDir != null && !sameAsSnapshot;
-      /**
-       * 上一条消息已按本地移动放行过, 且此后目录没再变 —— 必须继续认这份授权。
-       * 少了这一条, 跟随只在移动后的第一条消息生效: 那次会把快照更新成新目录,
-       * 下一条消息 movedNow 就变回 false, 绑定又被丢掉(PR #653 review 实测)。
-       */
-      const stillLocallyAuthorized =
-        !inAllowedRoot && usable && boundEntry?.authority === 'local-move' && sameAsSnapshot;
-      // 目录没变、也没有本地移动授权而校验失败, 才是「工作目录映射被改/删」的
-      // 撤权语义, 仍丢绑定重建。老绑定没有快照时同样走保守侧(正常复用会回填)。
-      if (usable && (inAllowedRoot || movedNow || stillLocallyAuthorized)) {
+      // 既不在映射内、也没有登记过的移动授权 = 映射被改/删的撤权语义(或目录被
+      // 别的路径改过), 仍丢绑定重建。老绑定无授权记录时同样走保守侧。
+      if (usable && (inAllowedRoot || locallyAuthorized)) {
         const workingDir = info!.workingDir!;
         const authority: HookBindingAuthority = inAllowedRoot ? 'workspace' : 'local-move';
+        // 登记过的移动要在渠道里说明一次(说明完就清掉 pending)
+        const announceMove = locallyAuthorized && boundEntry?.noticePending === true;
         migrateLegacyBinding(workingDir, authority);
-        // 快照回填 / 跟随: 只在目录或授权来源变化时落盘, 常规复用不产生写。
+        // 快照回填 / 授权收敛: 只在目录、来源或待说明状态变化时落盘,
+        // 常规复用不产生写。
         if (
           namespacedEntry !== null &&
           (namespacedEntry.workingDir === null ||
             !isSamePath(namespacedEntry.workingDir, workingDir) ||
-            namespacedEntry.authority !== authority)
+            namespacedEntry.authority !== authority ||
+            namespacedEntry.noticePending)
         ) {
-          bindings.set(connectionId, payload.externalKey, bound, workingDir, authority);
+          bindings.set(connectionId, payload.externalKey, bound, {
+            workingDir,
+            authority,
+            noticePending: false,
+          });
         }
-        if (movedNow) {
+        if (announceMove) {
           log.info(
             `hook session ${bound} followed a desktop-side move to ${workingDir} (outside the workspace map)`,
           );
@@ -737,8 +742,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             attachments: payload.attachments,
             origin,
           },
-          // 只在"这次刚发现被移动"时说明一次; 之后的消息静默沿用该授权
-          ...(movedNow ? { notice: NOTICE_SESSION_MOVED } : {}),
+          // 每次登记的移动只说明一次; 之后的消息静默沿用该授权
+          ...(announceMove ? { notice: NOTICE_SESSION_MOVED } : {}),
         };
       }
       bindings.remove(connectionId, payload.externalKey);
@@ -791,7 +796,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }
     }
     // 新建会话跑在别名目录(或对话根)里, 授权随映射走
-    bindings.set(connectionId, payload.externalKey, sessionId, runDir, 'workspace');
+    bindings.set(connectionId, payload.externalKey, sessionId, {
+      workingDir: runDir,
+      authority: 'workspace',
+    });
     // 标题带 provider 名: externalKey 约定为 `<providerId>:<渠道内标识>`,
     // 取前缀作 provider 名(如 team-slack), 比连接名(desktop 侧命名)更能
     // 说明"这条会话是谁驱动的"; 无前缀(非常规 key)时回退连接名

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -700,32 +700,37 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         boundEntry?.authority === 'local-move' &&
         boundEntry.workingDir != null &&
         isSamePath(boundEntry.workingDir, info!.workingDir!);
-      // 既不在映射内、也没有登记过的移动授权 = 映射被改/删的撤权语义(或目录被
-      // 别的路径改过), 仍丢绑定重建。老绑定无授权记录时同样走保守侧。
-      if (usable && (inAllowedRoot || locallyAuthorized)) {
+      /**
+       * 移动是"先登记授权、再写库"两步。中间这一小段里绑定已指向新目录, 而
+       * session 行还停在移动前的目录 —— 靠登记时记下的 previousWorkingDir 认出
+       * 这个中间态: 这一轮照常在旧目录跑(那本就是已授权的目录), 且不动绑定。
+       *
+       * 少了这条, 从映射外再移动一次会直接丢绑定: 新授权指向新目录、session 还
+       * 在旧的映射外目录, 两个条件都不满足就落到撤权分支(PR #669 review 指出)。
+       */
+      const pendingMoveRegistration =
+        usable &&
+        boundEntry?.authority === 'local-move' &&
+        boundEntry.previousWorkingDir != null &&
+        isSamePath(boundEntry.previousWorkingDir, info!.workingDir!);
+      // 三者都不满足 = 映射被改/删的撤权语义(或目录被别的路径改过), 仍丢绑定
+      // 重建。老绑定无授权记录时同样走保守侧。
+      if (usable && (inAllowedRoot || locallyAuthorized || pendingMoveRegistration)) {
         const workingDir = info!.workingDir!;
         const authority: HookBindingAuthority = inAllowedRoot ? 'workspace' : 'local-move';
         // 登记过的移动要在渠道里说明一次(说明完就清掉 pending)
         const announceMove = locallyAuthorized && boundEntry?.noticePending === true;
         migrateLegacyBinding(workingDir, authority);
-        /**
-         * 已登记但尚未落库的移动: 绑定记着 local-move + 新目录, 而 session 行
-         * 还停在旧目录(移动的两步之间)。这一轮照常在旧目录跑, 但**不能**把绑定
-         * 收敛回 workspace + 旧目录 —— 那会抹掉刚落下的授权, 等移动写库完成后
-         * 下一条消息就把绑定当撤权删掉(PR #669 review 指出的反向竞态)。
-         */
-        const pendingMoveRegistration =
-          namespacedEntry?.authority === 'local-move' &&
-          namespacedEntry.workingDir != null &&
-          !isSamePath(namespacedEntry.workingDir, workingDir);
-        // 快照回填 / 授权收敛: 只在目录、来源或待说明状态变化时落盘,
-        // 常规复用不产生写。
+        // 快照回填 / 授权收敛: 只在目录、来源或待说明状态变化时落盘, 常规复用
+        // 不产生写。在途移动(pendingMoveRegistration)一律不回填 —— 那会把刚落
+        // 下的授权收敛回旧目录, 移动写库后下一条消息就当撤权把绑定删了。
         if (
           namespacedEntry !== null &&
           !pendingMoveRegistration &&
           (namespacedEntry.workingDir === null ||
             !isSamePath(namespacedEntry.workingDir, workingDir) ||
             namespacedEntry.authority !== authority ||
+            namespacedEntry.previousWorkingDir !== null ||
             namespacedEntry.noticePending)
         ) {
           bindings.set(connectionId, payload.externalKey, bound, {
@@ -733,8 +738,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             authority,
             noticePending: false,
             // 另一半窗口: 本次 inspect 期间才落下的登记同样不能被覆盖,
-            // 用读到的版本做乐观并发控制(不匹配就放弃这次回填)。
-            expectedUpdatedAt: namespacedEntry.updatedAt,
+            // 用读到的行版本做乐观并发控制(不匹配就放弃这次回填)。
+            expectedRev: namespacedEntry.rev,
           });
         }
         if (announceMove) {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -720,7 +720,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         const authority: HookBindingAuthority = inAllowedRoot ? 'workspace' : 'local-move';
         // 登记过的移动要在渠道里说明一次(说明完就清掉 pending)
         const announceMove = locallyAuthorized && boundEntry?.noticePending === true;
-        migrateLegacyBinding(workingDir, authority);
+        // 在途移动时不迁移 legacy 行: 迁移会把 inspect 到的旧目录写进新命名空间
+        // 并丢掉 previousWorkingDir / noticePending, 等于抹掉刚落下的登记
+        // (PR #669 review 指出)。等移动落库后的下一条消息再迁, 语义不变。
+        if (!pendingMoveRegistration) migrateLegacyBinding(workingDir, authority);
         // 快照回填 / 授权收敛: 只在目录、来源或待说明状态变化时落盘, 常规复用
         // 不产生写。在途移动(pendingMoveRegistration)一律不回填 —— 那会把刚落
         // 下的授权收敛回旧目录, 移动写库后下一条消息就当撤权把绑定删了。

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -708,10 +708,21 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         // 登记过的移动要在渠道里说明一次(说明完就清掉 pending)
         const announceMove = locallyAuthorized && boundEntry?.noticePending === true;
         migrateLegacyBinding(workingDir, authority);
+        /**
+         * 已登记但尚未落库的移动: 绑定记着 local-move + 新目录, 而 session 行
+         * 还停在旧目录(移动的两步之间)。这一轮照常在旧目录跑, 但**不能**把绑定
+         * 收敛回 workspace + 旧目录 —— 那会抹掉刚落下的授权, 等移动写库完成后
+         * 下一条消息就把绑定当撤权删掉(PR #669 review 指出的反向竞态)。
+         */
+        const pendingMoveRegistration =
+          namespacedEntry?.authority === 'local-move' &&
+          namespacedEntry.workingDir != null &&
+          !isSamePath(namespacedEntry.workingDir, workingDir);
         // 快照回填 / 授权收敛: 只在目录、来源或待说明状态变化时落盘,
         // 常规复用不产生写。
         if (
           namespacedEntry !== null &&
+          !pendingMoveRegistration &&
           (namespacedEntry.workingDir === null ||
             !isSamePath(namespacedEntry.workingDir, workingDir) ||
             namespacedEntry.authority !== authority ||
@@ -721,6 +732,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             workingDir,
             authority,
             noticePending: false,
+            // 另一半窗口: 本次 inspect 期间才落下的登记同样不能被覆盖,
+            // 用读到的版本做乐观并发控制(不匹配就放弃这次回填)。
+            expectedUpdatedAt: namespacedEntry.updatedAt,
           });
         }
         if (announceMove) {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -174,6 +174,8 @@ export interface HookDispatcherDeps {
    * eager behavior unless they opt out explicitly.
    */
   accountInitiallyActive?: boolean;
+  /** 当前时刻(epoch ms)。注入只为让「在途标记过期」这类时效判定可测。 */
+  now?: () => number;
   log: { info(msg: string): void; warn(msg: string): void };
 }
 
@@ -348,6 +350,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     archiveSessionRow,
     resolveInteraction,
     accountInitiallyActive,
+    now = () => Date.now(),
     log,
   } = deps;
 
@@ -721,6 +724,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       const pendingMoveRegistration =
         usable &&
         boundEntry?.previousWorkingDir != null &&
+        // 过期的在途标记不算数: 写库后清理标记万一失败(磁盘/权限), 残留的它
+        // 不能长期充当映射外的放行凭据(PR #669 review 指出)
+        boundEntry.movePendingUntil > now() &&
         isSamePath(boundEntry.previousWorkingDir, info!.workingDir!);
       // 三者都不满足 = 映射被改/删的撤权语义(或目录被别的路径改过), 仍丢绑定
       // 重建。老绑定无授权记录时同样走保守侧。

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -702,12 +702,43 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
        * 映射的路子; 目录归一化之类的无关写入也会被误判成移动。登记入口见
        * hook-control/sessionMoves.ts。
        */
-      const locallyAuthorized =
-        !inAllowedRoot &&
+      const authorizedBy = (
+        entry: typeof boundEntry,
+      ): { locallyAuthorized: boolean; pendingMoveRegistration: boolean } => ({
+        locallyAuthorized:
+          !inAllowedRoot &&
+          usable &&
+          entry?.authority === 'local-move' &&
+          entry.workingDir != null &&
+          isSamePath(entry.workingDir, info!.workingDir!),
+        pendingMoveRegistration:
+          usable &&
+          entry?.previousWorkingDir != null &&
+          // 过期的在途标记不算数: 写库后清理标记万一失败(磁盘/权限), 残留的它
+          // 不能长期充当映射外的放行凭据(PR #669 review 指出)
+          entry.movePendingUntil > now() &&
+          isSamePath(entry.previousWorkingDir, info!.workingDir!),
+      });
+      let effectiveEntry = boundEntry;
+      let verdict = authorizedBy(effectiveEntry);
+      /**
+       * inspect 是个 await —— 期间可能刚好完成一次移动(登记 + 写库 + 清标记),
+       * 那时 info 已是新目录而 boundEntry 还是移动前的快照, 三条判定全落空,
+       * 绑定就被当撤权删掉(PR #669 review 指出)。撤权前用最新的绑定重判一次。
+       */
+      if (
         usable &&
-        boundEntry?.authority === 'local-move' &&
-        boundEntry.workingDir != null &&
-        isSamePath(boundEntry.workingDir, info!.workingDir!);
+        !inAllowedRoot &&
+        !verdict.locallyAuthorized &&
+        !verdict.pendingMoveRegistration
+      ) {
+        const latest = bindings.getEntry(connectionId, payload.externalKey);
+        if (latest && latest.sessionId === bound && latest.rev !== namespacedEntry?.rev) {
+          effectiveEntry = latest;
+          verdict = authorizedBy(latest);
+        }
+      }
+      const locallyAuthorized = verdict.locallyAuthorized;
       /**
        * 移动是"先登记授权、再写库"两步。中间这一小段里绑定已指向新目录, 而
        * session 行还停在移动前的目录 —— 靠登记时记下的 previousWorkingDir 认出
@@ -721,20 +752,14 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
        * 入口写入、写库成功即清, 它本身就是"有一次已登记的移动在途"的证据; 放行
        * 的又是移动前那个已授权目录, 不放宽任何边界。
        */
-      const pendingMoveRegistration =
-        usable &&
-        boundEntry?.previousWorkingDir != null &&
-        // 过期的在途标记不算数: 写库后清理标记万一失败(磁盘/权限), 残留的它
-        // 不能长期充当映射外的放行凭据(PR #669 review 指出)
-        boundEntry.movePendingUntil > now() &&
-        isSamePath(boundEntry.previousWorkingDir, info!.workingDir!);
+      const pendingMoveRegistration = verdict.pendingMoveRegistration;
       // 三者都不满足 = 映射被改/删的撤权语义(或目录被别的路径改过), 仍丢绑定
       // 重建。老绑定无授权记录时同样走保守侧。
       if (usable && (inAllowedRoot || locallyAuthorized || pendingMoveRegistration)) {
         const workingDir = info!.workingDir!;
         const authority: HookBindingAuthority = inAllowedRoot ? 'workspace' : 'local-move';
         // 登记过的移动要在渠道里说明一次(说明完就清掉 pending)
-        const announceMove = locallyAuthorized && boundEntry?.noticePending === true;
+        const announceMove = locallyAuthorized && effectiveEntry?.noticePending === true;
         // 在途移动时不迁移 legacy 行: 迁移会把 inspect 到的旧目录写进新命名空间
         // 并丢掉 previousWorkingDir / noticePending, 等于抹掉刚落下的登记
         // (PR #669 review 指出)。等移动落库后的下一条消息再迁, 语义不变。
@@ -742,14 +767,16 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         // 快照回填 / 授权收敛: 只在目录、来源或待说明状态变化时落盘, 常规复用
         // 不产生写。在途移动(pendingMoveRegistration)一律不回填 —— 那会把刚落
         // 下的授权收敛回旧目录, 移动写库后下一条消息就当撤权把绑定删了。
+        // 重判时读到的最新行(若有)才是回填基准, 否则会拿陈旧 rev 去 CAS
+        const backfillBase = namespacedEntry === null ? null : (effectiveEntry ?? namespacedEntry);
         if (
-          namespacedEntry !== null &&
+          backfillBase !== null &&
           !pendingMoveRegistration &&
-          (namespacedEntry.workingDir === null ||
-            !isSamePath(namespacedEntry.workingDir, workingDir) ||
-            namespacedEntry.authority !== authority ||
-            namespacedEntry.previousWorkingDir !== null ||
-            namespacedEntry.noticePending)
+          (backfillBase.workingDir === null ||
+            !isSamePath(backfillBase.workingDir, workingDir) ||
+            backfillBase.authority !== authority ||
+            backfillBase.previousWorkingDir !== null ||
+            backfillBase.noticePending)
         ) {
           bindings.set(connectionId, payload.externalKey, bound, {
             workingDir,
@@ -757,7 +784,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             noticePending: false,
             // 另一半窗口: 本次 inspect 期间才落下的登记同样不能被覆盖,
             // 用读到的行版本做乐观并发控制(不匹配就放弃这次回填)。
-            expectedRev: namespacedEntry.rev,
+            expectedRev: backfillBase.rev,
           });
         }
         if (announceMove) {

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -3,36 +3,77 @@
  * ---------------------------------------------------------------------------
  * 「用户在桌面端把对话移到了别的目录」的**授权登记入口**。
  *
- * 为什么单独一个模块: 授权必须由 Main 侧真实的移动写入登记, 不能由 dispatcher
- * 事后从 session 元数据反推(Renderer 不可信, 通用 patch IPC 能改 workingDir;
- * 见 bindings.ts 文件头)。localDb 的 session 更新链路在确认目录真的变了之后
- * 调这里, 与 hook 连接是否在线、provider 开没开都无关 —— 绑定文件本就独立于
- * 连接存在, 因此这里直接按当前 data owner 的绑定文件写, 不依赖 manager 生命
- * 周期(hook 关着时移动、之后再开也照样跟随)。
+ * 为什么单独一个模块: 授权必须由 Main 侧真实的移动动作登记, 不能由 dispatcher
+ * 事后从 session 元数据反推(Renderer 不可信; 见 bindings.ts 文件头)。唯一的
+ * 调用方是窄口径的 `local-db:sessions:move` —— 它带 sender 闸与目的地校验;
+ * 通用的 `sessions:update` 能改 workingDir, 但**不**铸造授权。
+ *
+ * 与 hook 连接是否在线、provider 开没开无关: 绑定文件本就独立于连接存在, 因此
+ * 这里直接按当前 data owner 的绑定文件写(hook 关着时移动、之后再开也照样跟随)。
  */
 
 import { ownerScopedUserDataPath } from '../appSessionState.js';
 import { createLogger } from '../logger.js';
-import { createHookBindingStore } from './bindings.js';
+import { getClientEndpoint } from '../clientEndpointsService.js';
+import { createHookBindingStore, type HookBindingAuthority } from './bindings.js';
+import { createSlackHookStore } from './store.js';
 
 const log = createLogger('hookSessionMoves');
 
+/** 与 store / dispatcher 同口径的「目录是否落在 base 内」(含相等)。 */
+function within(base: string, target: string): boolean {
+  const norm = (p: string): string => {
+    const s = p.replace(/\\/g, '/').replace(/\/+$/, '');
+    return process.platform === 'win32' ? s.toLowerCase() : s;
+  };
+  const b = norm(base);
+  const t = norm(target);
+  return t === b || t.startsWith(`${b}/`);
+}
+
 /**
- * 登记一次会话移动: 把所有指向该 session 的 IM 绑定标成「由本地移动授权」。
- * 没有绑定(绝大多数会话)时是廉价 no-op。best-effort —— 登记失败只记日志,
- * 不影响移动本身; 失败的后果只是该 thread 下一条消息会按撤权重开新对话。
+ * 目标目录是否仍落在某个工作目录映射内。移进映射内的目录**不该**留下
+ * local-move 例外 —— 否则用户随后把该目录从映射里删掉(撤权)时, 这条过期的
+ * 例外会让 IM 继续驱动它(PR #669 review 指出)。
  */
-export function noteHookSessionMoved(sessionId: string, workingDir: string): void {
+function authorityForDir(workingDir: string): HookBindingAuthority {
+  try {
+    const store = createSlackHookStore({
+      filePath: ownerScopedUserDataPath('slack-hook.json'),
+      defaultUrl: () => getClientEndpoint('slackHookWsUrl'),
+      log: { info: () => {}, warn: (msg: string) => log.warn(msg) },
+    });
+    const roots = Object.values(store.get().workspaces);
+    return roots.some((root) => within(root, workingDir)) ? 'workspace' : 'local-move';
+  } catch (err) {
+    // 读不到配置时按 local-move 记(移动确实发生过); dispatcher 每次仍按当前
+    // 映射重判, 目录在映射内时会把它收敛回 workspace。
+    log.warn(`authorityForDir failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 'local-move';
+  }
+}
+
+/**
+ * 登记一次会话移动: 把所有指向该 session 的 IM 绑定改写成移动后的目录与授权。
+ * 没有绑定(绝大多数会话)时是廉价 no-op。
+ *
+ * 必须在**写库之前**同步 await 完 —— 「目录已变、授权还没落」的窗口里, 一条
+ * 到达的 IM 消息会把绑定当成撤权删掉, 那条 thread 就永久换了新对话
+ * (PR #669 review 指出)。best-effort: 登记失败只记日志, 不拖累移动本身。
+ */
+export async function noteHookSessionMoved(sessionId: string, workingDir: string): Promise<void> {
   try {
     const store = createHookBindingStore({
       filePath: ownerScopedUserDataPath('hook-bindings.json'),
       log: { warn: (msg: string) => log.warn(msg) },
     });
-    const updated = store.noteSessionMoved(sessionId, workingDir);
+    const authority = authorityForDir(workingDir);
+    const updated = store.noteSessionMoved(sessionId, workingDir, authority);
     if (updated > 0) {
-      log.info('recorded local-move authorization for hook bindings', {
+      log.info('recorded move authorization for hook bindings', {
         sessionId,
         bindings: updated,
+        authority,
       });
     }
   } catch (err) {

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -39,10 +39,11 @@ function authorityForDir(workingDir: string): HookBindingAuthority {
     const roots = Object.values(store.get().workspaces);
     return roots.some((root) => isPathWithin(root, workingDir)) ? 'workspace' : 'local-move';
   } catch (err) {
-    // 读不到配置时按 local-move 记(移动确实发生过); dispatcher 每次仍按当前
-    // 映射重判, 目录在映射内时会把它收敛回 workspace。
+    // fail closed: 读不到映射时按 'workspace' 记(不发放映射外例外)。反过来默认
+    // local-move 是 fail-open —— 用户随后撤销该目录的映射时, 这条凭空来的例外
+    // 还会放行(PR #669 review 指出)。判错的代价只是 thread 重开一次。
     log.warn(`authorityForDir failed: ${err instanceof Error ? err.message : String(err)}`);
-    return 'local-move';
+    return 'workspace';
   }
 }
 
@@ -54,36 +55,45 @@ function authorityForDir(workingDir: string): HookBindingAuthority {
  * 到达的 IM 消息会把绑定当成撤权删掉, 那条 thread 就永久换了新对话
  * (PR #669 review 指出)。
  *
- * 返回是否登记成功。**失败必须让整个移动失败**: 吞掉错误照常写库的话, 目录变了
- * 而授权没落, 下一条 IM 消息就把绑定当撤权删掉、thread 静默丢上下文; 移动是用户
- * 主动动作, 报错让他重试比静默降级好(PR #669 review 指出)。没有绑定的会话读到
- * 空表同样算成功, 不受影响。
+ * 成功时返回 rollback(写库失败必须调它, 否则 previousWorkingDir 会永久残留成
+ * 一张"在途通行证"); 失败返回 null, 调用方**必须中止移动** —— 吞掉错误照常写库
+ * 的话, 目录变了而授权没落, 下一条 IM 消息就把绑定当撤权删掉、thread 静默丢上
+ * 下文(PR #669 review 指出)。文件不存在(没有任何绑定)算成功。
  */
 export async function noteHookSessionMoved(
   sessionId: string,
   move: { from: string | null; to: string },
-): Promise<boolean> {
+): Promise<(() => void) | null> {
   try {
     const store = createHookBindingStore({
       filePath: ownerScopedUserDataPath('hook-bindings.json'),
       log: { warn: (msg: string) => log.warn(msg) },
     });
     const authority = authorityForDir(move.to);
-    const updated = store.noteSessionMoved(sessionId, move, authority);
-    if (updated > 0) {
+    const registration = store.noteSessionMoved(sessionId, move, authority);
+    if (registration.updated > 0) {
       log.info('recorded move authorization for hook bindings', {
         sessionId,
-        bindings: updated,
+        bindings: registration.updated,
         authority,
       });
     }
-    return true;
+    return () => {
+      try {
+        registration.rollback();
+      } catch (err) {
+        log.warn('rollback of move authorization failed', {
+          sessionId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
   } catch (err) {
     log.warn('noteHookSessionMoved failed', {
       sessionId,
       err: err instanceof Error ? err.message : String(err),
     });
-    return false;
+    return null;
   }
 }
 

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -52,12 +52,17 @@ function authorityForDir(workingDir: string): HookBindingAuthority {
  *
  * 必须在**写库之前**同步 await 完 —— 「目录已变、授权还没落」的窗口里, 一条
  * 到达的 IM 消息会把绑定当成撤权删掉, 那条 thread 就永久换了新对话
- * (PR #669 review 指出)。best-effort: 登记失败只记日志, 不拖累移动本身。
+ * (PR #669 review 指出)。
+ *
+ * 返回是否登记成功。**失败必须让整个移动失败**: 吞掉错误照常写库的话, 目录变了
+ * 而授权没落, 下一条 IM 消息就把绑定当撤权删掉、thread 静默丢上下文; 移动是用户
+ * 主动动作, 报错让他重试比静默降级好(PR #669 review 指出)。没有绑定的会话读到
+ * 空表同样算成功, 不受影响。
  */
 export async function noteHookSessionMoved(
   sessionId: string,
   move: { from: string | null; to: string },
-): Promise<void> {
+): Promise<boolean> {
   try {
     const store = createHookBindingStore({
       filePath: ownerScopedUserDataPath('hook-bindings.json'),
@@ -72,11 +77,13 @@ export async function noteHookSessionMoved(
         authority,
       });
     }
+    return true;
   } catch (err) {
     log.warn('noteHookSessionMoved failed', {
       sessionId,
       err: err instanceof Error ? err.message : String(err),
     });
+    return false;
   }
 }
 

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -12,6 +12,8 @@
  * 这里直接按当前 data owner 的绑定文件写(hook 关着时移动、之后再开也照样跟随)。
  */
 
+import fs from 'node:fs';
+
 import { ownerScopedUserDataPath } from '../appSessionState.js';
 import { createLogger } from '../logger.js';
 import { createHookBindingStore, type HookBindingAuthority } from './bindings.js';
@@ -29,6 +31,17 @@ const log = createLogger('hookSessionMoves');
  */
 function authorityForDir(workingDir: string): HookBindingAuthority {
   try {
+    // store.get() 自己会把读失败兜底成空配置 —— 那样 roots 为空, 结论就成了
+    // local-move(凭空发放映射外例外)。安全判定不能吃这个兜底: 先严格读一次,
+    // 文件存在但读不动/解析不了就抛, 由 catch 落到 fail-closed 的 workspace
+    // (PR #669 review 指出)。
+    const configPath = ownerScopedUserDataPath('slack-hook.json');
+    if (fs.existsSync(configPath)) {
+      const raw: unknown = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        throw new Error('slack-hook.json is not an object');
+      }
+    }
     const store = createSlackHookStore({
       filePath: ownerScopedUserDataPath('slack-hook.json'),
       // 这里只读 workspaces 映射, 不碰服务器地址 —— 给个空默认值即可,
@@ -102,17 +115,24 @@ export async function noteHookSessionMoved(
  * 让「登记已落、库还没落」的容忍窗口严格限定在移动的两步之间 —— 标记留着不清,
  * 之后把会话目录改回旧值就能靠它绕过撤权(PR #669 review 指出)。
  */
-export function completeHookSessionMove(sessionId: string, workingDir: string): void {
-  try {
-    const store = createHookBindingStore({
-      filePath: ownerScopedUserDataPath('hook-bindings.json'),
-      log: { warn: (msg: string) => log.warn(msg) },
-    });
-    store.completeSessionMove(sessionId, workingDir);
-  } catch (err) {
-    log.warn('completeHookSessionMove failed', {
-      sessionId,
-      err: err instanceof Error ? err.message : String(err),
-    });
-  }
+export function completeHookSessionMove(sessionId: string, workingDir: string): boolean {
+  const attempt = (): boolean => {
+    try {
+      const store = createHookBindingStore({
+        filePath: ownerScopedUserDataPath('hook-bindings.json'),
+        log: { warn: (msg: string) => log.warn(msg) },
+      });
+      store.completeSessionMove(sessionId, workingDir);
+      return true;
+    } catch (err) {
+      log.warn('completeHookSessionMove failed', {
+        sessionId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+  };
+  // 重试一次: 瞬时的文件系统抖动不该让标记多留一个 TTL 窗口。两次都失败也不
+  // 让移动失败(那时移动已经真的完成了, 报错会误导), 靠 movePendingUntil 兜底。
+  return attempt() || attempt();
 }

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -1,0 +1,44 @@
+/**
+ * hook-control/sessionMoves.ts
+ * ---------------------------------------------------------------------------
+ * 「用户在桌面端把对话移到了别的目录」的**授权登记入口**。
+ *
+ * 为什么单独一个模块: 授权必须由 Main 侧真实的移动写入登记, 不能由 dispatcher
+ * 事后从 session 元数据反推(Renderer 不可信, 通用 patch IPC 能改 workingDir;
+ * 见 bindings.ts 文件头)。localDb 的 session 更新链路在确认目录真的变了之后
+ * 调这里, 与 hook 连接是否在线、provider 开没开都无关 —— 绑定文件本就独立于
+ * 连接存在, 因此这里直接按当前 data owner 的绑定文件写, 不依赖 manager 生命
+ * 周期(hook 关着时移动、之后再开也照样跟随)。
+ */
+
+import { ownerScopedUserDataPath } from '../appSessionState.js';
+import { createLogger } from '../logger.js';
+import { createHookBindingStore } from './bindings.js';
+
+const log = createLogger('hookSessionMoves');
+
+/**
+ * 登记一次会话移动: 把所有指向该 session 的 IM 绑定标成「由本地移动授权」。
+ * 没有绑定(绝大多数会话)时是廉价 no-op。best-effort —— 登记失败只记日志,
+ * 不影响移动本身; 失败的后果只是该 thread 下一条消息会按撤权重开新对话。
+ */
+export function noteHookSessionMoved(sessionId: string, workingDir: string): void {
+  try {
+    const store = createHookBindingStore({
+      filePath: ownerScopedUserDataPath('hook-bindings.json'),
+      log: { warn: (msg: string) => log.warn(msg) },
+    });
+    const updated = store.noteSessionMoved(sessionId, workingDir);
+    if (updated > 0) {
+      log.info('recorded local-move authorization for hook bindings', {
+        sessionId,
+        bindings: updated,
+      });
+    }
+  } catch (err) {
+    log.warn('noteHookSessionMoved failed', {
+      sessionId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -54,14 +54,17 @@ function authorityForDir(workingDir: string): HookBindingAuthority {
  * 到达的 IM 消息会把绑定当成撤权删掉, 那条 thread 就永久换了新对话
  * (PR #669 review 指出)。best-effort: 登记失败只记日志, 不拖累移动本身。
  */
-export async function noteHookSessionMoved(sessionId: string, workingDir: string): Promise<void> {
+export async function noteHookSessionMoved(
+  sessionId: string,
+  move: { from: string | null; to: string },
+): Promise<void> {
   try {
     const store = createHookBindingStore({
       filePath: ownerScopedUserDataPath('hook-bindings.json'),
       log: { warn: (msg: string) => log.warn(msg) },
     });
-    const authority = authorityForDir(workingDir);
-    const updated = store.noteSessionMoved(sessionId, workingDir, authority);
+    const authority = authorityForDir(move.to);
+    const updated = store.noteSessionMoved(sessionId, move, authority);
     if (updated > 0) {
       log.info('recorded move authorization for hook bindings', {
         sessionId,

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -79,3 +79,23 @@ export async function noteHookSessionMoved(
     });
   }
 }
+
+/**
+ * 移动写库成功后调用: 清掉绑定上的在途标记(previousWorkingDir)。
+ * 让「登记已落、库还没落」的容忍窗口严格限定在移动的两步之间 —— 标记留着不清,
+ * 之后把会话目录改回旧值就能靠它绕过撤权(PR #669 review 指出)。
+ */
+export function completeHookSessionMove(sessionId: string, workingDir: string): void {
+  try {
+    const store = createHookBindingStore({
+      filePath: ownerScopedUserDataPath('hook-bindings.json'),
+      log: { warn: (msg: string) => log.warn(msg) },
+    });
+    store.completeSessionMove(sessionId, workingDir);
+  } catch (err) {
+    log.warn('completeHookSessionMove failed', {
+      sessionId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -16,20 +16,12 @@ import { ownerScopedUserDataPath } from '../appSessionState.js';
 import { createLogger } from '../logger.js';
 import { getClientEndpoint } from '../clientEndpointsService.js';
 import { createHookBindingStore, type HookBindingAuthority } from './bindings.js';
+// 复用 dispatcher 的路径口径: 判定必须与它放行时用的同一套规则, 否则会把该记
+// workspace 的移动记成 local-move(反之亦然)——PR #669 review 指出。
+import { isPathWithin } from './dispatcher.js';
 import { createSlackHookStore } from './store.js';
 
 const log = createLogger('hookSessionMoves');
-
-/** 与 store / dispatcher 同口径的「目录是否落在 base 内」(含相等)。 */
-function within(base: string, target: string): boolean {
-  const norm = (p: string): string => {
-    const s = p.replace(/\\/g, '/').replace(/\/+$/, '');
-    return process.platform === 'win32' ? s.toLowerCase() : s;
-  };
-  const b = norm(base);
-  const t = norm(target);
-  return t === b || t.startsWith(`${b}/`);
-}
 
 /**
  * 目标目录是否仍落在某个工作目录映射内。移进映射内的目录**不该**留下
@@ -44,7 +36,7 @@ function authorityForDir(workingDir: string): HookBindingAuthority {
       log: { info: () => {}, warn: (msg: string) => log.warn(msg) },
     });
     const roots = Object.values(store.get().workspaces);
-    return roots.some((root) => within(root, workingDir)) ? 'workspace' : 'local-move';
+    return roots.some((root) => isPathWithin(root, workingDir)) ? 'workspace' : 'local-move';
   } catch (err) {
     // 读不到配置时按 local-move 记(移动确实发生过); dispatcher 每次仍按当前
     // 映射重判, 目录在映射内时会把它收敛回 workspace。

--- a/apps/desktop/src/main/hook-control/sessionMoves.ts
+++ b/apps/desktop/src/main/hook-control/sessionMoves.ts
@@ -14,7 +14,6 @@
 
 import { ownerScopedUserDataPath } from '../appSessionState.js';
 import { createLogger } from '../logger.js';
-import { getClientEndpoint } from '../clientEndpointsService.js';
 import { createHookBindingStore, type HookBindingAuthority } from './bindings.js';
 // 复用 dispatcher 的路径口径: 判定必须与它放行时用的同一套规则, 否则会把该记
 // workspace 的移动记成 local-move(反之亦然)——PR #669 review 指出。
@@ -32,7 +31,9 @@ function authorityForDir(workingDir: string): HookBindingAuthority {
   try {
     const store = createSlackHookStore({
       filePath: ownerScopedUserDataPath('slack-hook.json'),
-      defaultUrl: () => getClientEndpoint('slackHookWsUrl'),
+      // 这里只读 workspaces 映射, 不碰服务器地址 —— 给个空默认值即可,
+      // 免得为一次判定把端点清单模块也拖进 localDb 的静态依赖图。
+      defaultUrl: () => '',
       log: { info: () => {}, warn: (msg: string) => log.warn(msg) },
     });
     const roots = Object.values(store.get().workspaces);

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -25,6 +25,7 @@ const h = vi.hoisted(() => ({
     persistedSdkSessionId: null,
   })),
   noteHookSessionMoved: vi.fn(async () => undefined),
+  completeHookSessionMove: vi.fn(),
   isKnownRecentWorkdir: vi.fn(async () => true),
   assertTrustedAppRendererEvent: vi.fn(),
   moveOrder: [] as string[],
@@ -68,6 +69,7 @@ vi.mock('../../../maker-host/claude-transcript-relocation.js', () => ({
 }));
 vi.mock('../../../hook-control/sessionMoves.js', () => ({
   noteHookSessionMoved: h.noteHookSessionMoved,
+  completeHookSessionMove: h.completeHookSessionMove,
 }));
 
 import { registerSessionIpc } from '../sessions';
@@ -343,6 +345,32 @@ describe('local-db:sessions:move handler wiring', () => {
 
   it('rejects an unknown target kind', async () => {
     await expect(invokeMove('codex-local', { kind: 'nowhere' })).rejects.toThrow(/INVALID_PARAMS/);
+  });
+
+  it('clears the in-flight marker once the move commits', async () => {
+    await invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' });
+
+    expect(h.noteHookSessionMoved).toHaveBeenCalledWith('codex-local', {
+      from: '/old/dir',
+      to: '/new/dir',
+    });
+    // 收尾必须发生在写库之后:标记留着不清就能被拿来绕过撤权
+    expect(h.completeHookSessionMove).toHaveBeenCalledWith('codex-local', '/new/dir');
+    const persisted = h
+      .sqlite!.prepare('SELECT working_dir FROM sessions WHERE id = ?')
+      .get('codex-local') as { working_dir: string };
+    expect(persisted.working_dir).toBe('/new/dir');
+  });
+
+  it('rejects a project target that contains path traversal segments', async () => {
+    // 校验解析后的路径、存原串, 两者不一致就能绕过目的地校验
+    await expect(
+      invokeMove('codex-local', {
+        kind: 'project',
+        workingDir: '/known/repo/.cindy-worktrees/x/../../../etc',
+      }),
+    ).rejects.toThrow(/INVALID_PARAMS/);
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
   });
 
   it('rejects a project target whose path normalizes to nothing', async () => {

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -343,4 +343,12 @@ describe('local-db:sessions:move handler wiring', () => {
   it('rejects an unknown target kind', async () => {
     await expect(invokeMove('codex-local', { kind: 'nowhere' })).rejects.toThrow(/INVALID_PARAMS/);
   });
+
+  it('rejects a project target whose path normalizes to nothing', async () => {
+    // 放过去会写成 workspaceKind='project' 且 workingDir=null 的不一致状态
+    await expect(invokeMove('codex-local', { kind: 'project', workingDir: '   ' })).rejects.toThrow(
+      /INVALID_PARAMS/,
+    );
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -24,7 +24,8 @@ const h = vi.hoisted(() => ({
   relocate: vi.fn(async (): Promise<{ persistedSdkSessionId: string | null }> => ({
     persistedSdkSessionId: null,
   })),
-  noteHookSessionMoved: vi.fn(async () => true),
+  noteHookSessionMoved: vi.fn(async () => () => {}),
+  rollbacks: 0,
   completeHookSessionMove: vi.fn(),
   isKnownRecentWorkdir: vi.fn(async () => true),
   assertTrustedAppRendererEvent: vi.fn(),
@@ -163,7 +164,10 @@ beforeEach(() => {
   h.moveOrder = [];
   h.isKnownRecentWorkdir.mockImplementation(async () => true);
   h.assertTrustedAppRendererEvent.mockImplementation(() => undefined);
-  h.noteHookSessionMoved.mockImplementation(async () => true);
+  h.rollbacks = 0;
+  h.noteHookSessionMoved.mockImplementation(async () => () => {
+    h.rollbacks += 1;
+  });
   h.relocate.mockImplementation(async () => ({ persistedSdkSessionId: null }));
   h.handlers.clear();
   createDb();
@@ -298,7 +302,9 @@ describe('local-db:sessions:move handler wiring', () => {
         .sqlite!.prepare('SELECT working_dir FROM sessions WHERE id = ?')
         .get('codex-local') as { working_dir: string | null };
       h.moveOrder.push(`db-at-note:${row.working_dir}`);
-      return true;
+      return () => {
+        h.rollbacks += 1;
+      };
     });
 
     await invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' });
@@ -365,7 +371,7 @@ describe('local-db:sessions:move handler wiring', () => {
 
   it('aborts the move when the binding registration fails', async () => {
     // 吞掉登记失败照常写库的话, 下一条 IM 消息会把绑定当撤权删掉、静默丢上下文
-    h.noteHookSessionMoved.mockImplementation(async () => false);
+    h.noteHookSessionMoved.mockImplementation(async () => null);
 
     await expect(
       invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' }),
@@ -375,6 +381,36 @@ describe('local-db:sessions:move handler wiring', () => {
       .get('codex-local') as { working_dir: string };
     expect(persisted.working_dir).toBe('/old/dir');
     expect(h.completeHookSessionMove).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the registration when the database write fails', async () => {
+    // 不回滚的话 previousWorkingDir 永久残留, 成了绕过撤权的"在途通行证"
+    h.relocate.mockImplementation(async () => {
+      throw new Error('transcript relocation exploded');
+    });
+
+    await expect(
+      invokeMove('cc-local', { kind: 'project', workingDir: '/new/dir' }),
+    ).rejects.toThrow(/transcript relocation exploded/);
+    expect(h.rollbacks).toBe(1);
+    expect(h.completeHookSessionMove).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent moves for the same session', async () => {
+    // 并发移动各自读到同一个 fromDir 时, 先落库的那次会与绑定记录对不上
+    const seen: Array<string | null> = [];
+    h.noteHookSessionMoved.mockImplementation(async (...args: unknown[]) => {
+      seen.push((args[1] as { from: string | null }).from);
+      return () => {};
+    });
+
+    await Promise.all([
+      invokeMove('codex-local', { kind: 'project', workingDir: '/dir-b' }),
+      invokeMove('codex-local', { kind: 'project', workingDir: '/dir-c' }),
+    ]);
+
+    // 第二次必须看到第一次落库后的目录, 而不是同一个旧值
+    expect(seen).toEqual(['/old/dir', '/dir-b']);
   });
 
   it('rejects a relative project target', async () => {

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -384,8 +384,9 @@ describe('local-db:sessions:move handler wiring', () => {
     expect(h.completeHookSessionMove).not.toHaveBeenCalled();
   });
 
-  it('rolls back the registration when the database write fails', async () => {
-    // 不回滚的话 previousWorkingDir 永久残留, 成了绕过撤权的"在途通行证"
+  it('finalizes instead of rolling back when the directory already committed', async () => {
+    // 目录写入在前、转录迁移等副作用在后: 这时回滚绑定会造成"库在新目录、绑定
+    // 记旧目录"的分叉, 下一条消息照样丢绑定
     h.relocate.mockImplementation(async () => {
       throw new Error('transcript relocation exploded');
     });
@@ -393,6 +394,23 @@ describe('local-db:sessions:move handler wiring', () => {
     await expect(
       invokeMove('cc-local', { kind: 'project', workingDir: '/new/dir' }),
     ).rejects.toThrow(/transcript relocation exploded/);
+    expect(h.rollbacks).toBe(0);
+    expect(h.completeHookSessionMove).toHaveBeenCalledWith('cc-local', '/new/dir');
+  });
+
+  it('rolls back the registration when the directory never lands', async () => {
+    // 登记之后、写库之前会话没了: 移动没成立, 必须回滚, 否则 previousWorkingDir
+    // 残留成绕过撤权的"在途通行证"
+    h.noteHookSessionMoved.mockImplementation(async () => {
+      h.sqlite!.prepare('DELETE FROM sessions WHERE id = ?').run('codex-local');
+      return () => {
+        h.rollbacks += 1;
+      };
+    });
+
+    await expect(
+      invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' }),
+    ).rejects.toThrow(/NOT_FOUND/);
     expect(h.rollbacks).toBe(1);
     expect(h.completeHookSessionMove).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -24,7 +24,7 @@ const h = vi.hoisted(() => ({
   relocate: vi.fn(async (): Promise<{ persistedSdkSessionId: string | null }> => ({
     persistedSdkSessionId: null,
   })),
-  noteHookSessionMoved: vi.fn(async () => undefined),
+  noteHookSessionMoved: vi.fn(async () => true),
   completeHookSessionMove: vi.fn(),
   isKnownRecentWorkdir: vi.fn(async () => true),
   assertTrustedAppRendererEvent: vi.fn(),
@@ -163,7 +163,7 @@ beforeEach(() => {
   h.moveOrder = [];
   h.isKnownRecentWorkdir.mockImplementation(async () => true);
   h.assertTrustedAppRendererEvent.mockImplementation(() => undefined);
-  h.noteHookSessionMoved.mockImplementation(async () => undefined);
+  h.noteHookSessionMoved.mockImplementation(async () => true);
   h.relocate.mockImplementation(async () => ({ persistedSdkSessionId: null }));
   h.handlers.clear();
   createDb();
@@ -298,6 +298,7 @@ describe('local-db:sessions:move handler wiring', () => {
         .sqlite!.prepare('SELECT working_dir FROM sessions WHERE id = ?')
         .get('codex-local') as { working_dir: string | null };
       h.moveOrder.push(`db-at-note:${row.working_dir}`);
+      return true;
     });
 
     await invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' });
@@ -360,6 +361,28 @@ describe('local-db:sessions:move handler wiring', () => {
       .sqlite!.prepare('SELECT working_dir FROM sessions WHERE id = ?')
       .get('codex-local') as { working_dir: string };
     expect(persisted.working_dir).toBe('/new/dir');
+  });
+
+  it('aborts the move when the binding registration fails', async () => {
+    // 吞掉登记失败照常写库的话, 下一条 IM 消息会把绑定当撤权删掉、静默丢上下文
+    h.noteHookSessionMoved.mockImplementation(async () => false);
+
+    await expect(
+      invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' }),
+    ).rejects.toThrow(/INTERNAL/);
+    const persisted = h
+      .sqlite!.prepare('SELECT working_dir FROM sessions WHERE id = ?')
+      .get('codex-local') as { working_dir: string };
+    expect(persisted.working_dir).toBe('/old/dir');
+    expect(h.completeHookSessionMove).not.toHaveBeenCalled();
+  });
+
+  it('rejects a relative project target', async () => {
+    // 相对路径会按主进程 CWD 解释, 落到意料外的目录
+    await expect(invokeMove('codex-local', { kind: 'project', workingDir: 'foo' })).rejects.toThrow(
+      /INVALID_PARAMS/,
+    );
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
   });
 
   it('rejects a project target that contains path traversal segments', async () => {

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -161,9 +161,7 @@ beforeEach(() => {
   h.moveOrder = [];
   h.isKnownRecentWorkdir.mockImplementation(async () => true);
   h.assertTrustedAppRendererEvent.mockImplementation(() => undefined);
-  h.noteHookSessionMoved.mockImplementation(async (...args: unknown[]) => {
-    h.moveOrder.push(`note:${String(args[1])}`);
-  });
+  h.noteHookSessionMoved.mockImplementation(async () => undefined);
   h.relocate.mockImplementation(async () => ({ persistedSdkSessionId: null }));
   h.handlers.clear();
   createDb();
@@ -282,7 +280,10 @@ describe('local-db:sessions:move handler wiring', () => {
       workingDir: '/new/dir',
     })) as { workingDir: string; workspaceKind: string };
 
-    expect(h.noteHookSessionMoved).toHaveBeenCalledWith('codex-local', '/new/dir');
+    expect(h.noteHookSessionMoved).toHaveBeenCalledWith('codex-local', {
+      from: '/old/dir',
+      to: '/new/dir',
+    });
     expect(updated.workingDir).toBe('/new/dir');
     expect(updated.workspaceKind).toBe('project');
   });

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -24,7 +24,8 @@ const h = vi.hoisted(() => ({
   relocate: vi.fn(async (): Promise<{ persistedSdkSessionId: string | null }> => ({
     persistedSdkSessionId: null,
   })),
-  noteHookSessionMoved: vi.fn(async () => () => {}),
+  // 返回类型显式放宽: 生产签名是 rollback 句柄或 null(登记失败), 用例两种都要 mock
+  noteHookSessionMoved: vi.fn(async (): Promise<(() => void) | null> => () => {}),
   rollbacks: 0,
   completeHookSessionMove: vi.fn(),
   isKnownRecentWorkdir: vi.fn(async () => true),

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -6,6 +6,9 @@
  * relocateClaudeTranscriptsForSessionMove(旧值 → 新值)，并把迁移中持久化的最新
  * sdkSessionId 并入返回行与广播 patch；其它会话或未实际移动时不得调用。
  *
+ * 另覆盖 IM 绑定的「本地移动授权」登记:目录真的变了才登记(hook 侧据此在工作
+ * 目录映射外继续复用该会话,见 hook-control/bindings.ts),归一化写法差异不算。
+ *
  * 通过 mock electron ipcMain 捕获真实 handler + 内存 sqlite 全列 sessions 表做集成断言。
  */
 import Database from 'better-sqlite3';
@@ -21,6 +24,7 @@ const h = vi.hoisted(() => ({
   relocate: vi.fn(async (): Promise<{ persistedSdkSessionId: string | null }> => ({
     persistedSdkSessionId: null,
   })),
+  noteHookSessionMoved: vi.fn(),
   tapWindowBroadcast: vi.fn(),
 }));
 
@@ -52,6 +56,9 @@ vi.mock('../../../messagePersistBroadcaster', () => ({ noteSessionClearBoundary:
 vi.mock('../../../sessionIds', () => ({ resolveBusinessSessionId: (id: string) => id }));
 vi.mock('../../../maker-host/claude-transcript-relocation.js', () => ({
   relocateClaudeTranscriptsForSessionMove: h.relocate,
+}));
+vi.mock('../../../hook-control/sessionMoves.js', () => ({
+  noteHookSessionMoved: h.noteHookSessionMoved,
 }));
 
 import { registerSessionIpc } from '../sessions';
@@ -234,5 +241,35 @@ describe('local-db:sessions:update handler wiring', () => {
   it('does nothing for remote sessions', async () => {
     await invokeUpdate('cc-remote', { workingDir: '/new/dir' });
     expect(h.relocate).not.toHaveBeenCalled();
+  });
+
+  it('registers the local-move authorization for IM bindings when the dir really changes', async () => {
+    // codex 会话也要登记:授权与 agent 种类无关,只与"目录被用户移动了"有关
+    await invokeUpdate('codex-local', { workingDir: '/new/dir', workspaceKind: 'project' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.noteHookSessionMoved).toHaveBeenCalledWith('codex-local', '/new/dir');
+  });
+
+  it('does not register a move when the workingDir only changes spelling', async () => {
+    h.sqlite!.prepare('UPDATE sessions SET working_dir = ? WHERE id = ?').run(
+      'D:\\repo\\project',
+      'cc-local',
+    );
+
+    await invokeUpdate('cc-local', { workingDir: 'D:/repo/project' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
+  });
+
+  it('does not register a move for patches without workingDir', async () => {
+    await invokeUpdate('cc-local', { workspaceKind: 'dialogue', title: '换个名字' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -24,7 +24,10 @@ const h = vi.hoisted(() => ({
   relocate: vi.fn(async (): Promise<{ persistedSdkSessionId: string | null }> => ({
     persistedSdkSessionId: null,
   })),
-  noteHookSessionMoved: vi.fn(),
+  noteHookSessionMoved: vi.fn(async () => undefined),
+  isKnownRecentWorkdir: vi.fn(async () => true),
+  assertTrustedAppRendererEvent: vi.fn(),
+  moveOrder: [] as string[],
   tapWindowBroadcast: vi.fn(),
 }));
 
@@ -47,7 +50,13 @@ vi.mock('../../../git-context/prRefsStore', () => ({
   recomputePrRefsForSession: vi.fn(async () => undefined),
 }));
 vi.mock('../../../imageCacheStore', () => ({ removeSession: vi.fn(async () => undefined) }));
-vi.mock('../recentWorkdirs', () => ({ upsertRecentWorkdir: vi.fn(async () => undefined) }));
+vi.mock('../recentWorkdirs', () => ({
+  upsertRecentWorkdir: vi.fn(async () => undefined),
+  isKnownRecentWorkdir: h.isKnownRecentWorkdir,
+}));
+vi.mock('../../../security/trustedAppRenderer.js', () => ({
+  assertTrustedAppRendererEvent: h.assertTrustedAppRendererEvent,
+}));
 vi.mock('../../../device-link/broadcast-tap.js', () => ({
   tapWindowBroadcast: h.tapWindowBroadcast,
 }));
@@ -141,8 +150,20 @@ async function invokeUpdate(id: string, patch: Record<string, unknown>): Promise
   return handler({}, id, patch);
 }
 
+async function invokeMove(id: string, target: Record<string, unknown>): Promise<unknown> {
+  const handler = h.handlers.get('local-db:sessions:move');
+  if (!handler) throw new Error('move handler not registered');
+  return handler({}, id, target);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  h.moveOrder = [];
+  h.isKnownRecentWorkdir.mockImplementation(async () => true);
+  h.assertTrustedAppRendererEvent.mockImplementation(() => undefined);
+  h.noteHookSessionMoved.mockImplementation(async (...args: unknown[]) => {
+    h.moveOrder.push(`note:${String(args[1])}`);
+  });
   h.relocate.mockImplementation(async () => ({ persistedSdkSessionId: null }));
   h.handlers.clear();
   createDb();
@@ -243,33 +264,83 @@ describe('local-db:sessions:update handler wiring', () => {
     expect(h.relocate).not.toHaveBeenCalled();
   });
 
-  it('registers the local-move authorization for IM bindings when the dir really changes', async () => {
-    // codex 会话也要登记:授权与 agent 种类无关,只与"目录被用户移动了"有关
+  it('never mints move authority from the generic update IPC', async () => {
+    // 通用 patch 通道是不可信 Renderer 也能调的(preload 直接暴露),
+    // 它改 workingDir 只写库,绝不铸造 IM 绑定授权 —— 这正是 #669 要堵的洞。
     await invokeUpdate('codex-local', { workingDir: '/new/dir', workspaceKind: 'project' });
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
+  });
+});
+
+describe('local-db:sessions:move handler wiring', () => {
+  it('mints the move authority and persists the new workspace target', async () => {
+    const updated = (await invokeMove('codex-local', {
+      kind: 'project',
+      workingDir: '/new/dir',
+    })) as { workingDir: string; workspaceKind: string };
+
     expect(h.noteHookSessionMoved).toHaveBeenCalledWith('codex-local', '/new/dir');
+    expect(updated.workingDir).toBe('/new/dir');
+    expect(updated.workspaceKind).toBe('project');
   });
 
-  it('does not register a move when the workingDir only changes spelling', async () => {
-    h.sqlite!.prepare('UPDATE sessions SET working_dir = ? WHERE id = ?').run(
-      'D:\\repo\\project',
-      'cc-local',
-    );
+  it('registers the authority before the directory lands in the database', async () => {
+    // 顺序反了就有一个"目录已变、授权还没落"的窗口,那期间到达的 IM 消息会把
+    // 绑定当撤权删掉(#669 review)。用登记回调里读库来锁死这个顺序。
+    h.noteHookSessionMoved.mockImplementation(async () => {
+      const row = h
+        .sqlite!.prepare('SELECT working_dir FROM sessions WHERE id = ?')
+        .get('codex-local') as { working_dir: string | null };
+      h.moveOrder.push(`db-at-note:${row.working_dir}`);
+    });
 
-    await invokeUpdate('cc-local', { workingDir: 'D:/repo/project' });
-    await Promise.resolve();
-    await Promise.resolve();
+    await invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' });
+
+    expect(h.moveOrder).toEqual(['db-at-note:/old/dir']);
+  });
+
+  it('rejects callers that are not the trusted Cindy renderer', async () => {
+    h.assertTrustedAppRendererEvent.mockImplementation(() => {
+      throw new Error('[PERMISSION_DENIED] 此操作只能从 Cindy 主页面发起');
+    });
+
+    await expect(
+      invokeMove('codex-local', { kind: 'project', workingDir: '/new/dir' }),
+    ).rejects.toThrow(/PERMISSION_DENIED/);
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
+  });
+
+  it('still moves but mints no authority when the destination is not a known project', async () => {
+    h.isKnownRecentWorkdir.mockImplementation(async () => false);
+
+    const updated = (await invokeMove('codex-local', {
+      kind: 'project',
+      workingDir: '/private/keys',
+    })) as { workingDir: string };
+
+    expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
+    expect(updated.workingDir).toBe('/private/keys');
+  });
+
+  it('does not mint authority when the move keeps the same directory', async () => {
+    await invokeMove('codex-local', { kind: 'project', workingDir: '/old/dir' });
 
     expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
   });
 
-  it('does not register a move for patches without workingDir', async () => {
-    await invokeUpdate('cc-local', { workspaceKind: 'dialogue', title: '换个名字' });
-    await Promise.resolve();
-    await Promise.resolve();
+  it('moves back to dialogue without touching bindings', async () => {
+    const updated = (await invokeMove('codex-local', { kind: 'dialogue' })) as {
+      workspaceKind: string;
+    };
 
+    expect(updated.workspaceKind).toBe('dialogue');
     expect(h.noteHookSessionMoved).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown target kind', async () => {
+    await expect(invokeMove('codex-local', { kind: 'nowhere' })).rejects.toThrow(/INVALID_PARAMS/);
   });
 });

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -17,7 +17,7 @@
  *  - upsert 失败仅日志,不抛 —— 这是"用户体验增强"数据,不该挡住 session 创建主流程。
  */
 
-import { stat } from 'node:fs/promises';
+import { realpath, stat } from 'node:fs/promises';
 
 import { BrowserWindow, ipcMain } from 'electron';
 import { desc, eq, sql } from 'drizzle-orm';
@@ -124,8 +124,21 @@ async function dirExists(path: string): Promise<boolean> {
 }
 
 /**
+ * 解析到真实路径再比较, 否则「已知项目内的一个软链」能指到项目外任意目录,
+ * 词法前缀比会把它当成子目录放行(PR #669 review 指出)。解析失败(路径不存在 /
+ * 无权限)时回退原值 —— 这条链路只用于收紧判定, 回退不会放宽已有边界。
+ */
+async function resolveRealPath(p: string): Promise<string> {
+  try {
+    return (await realpath(p)).replace(/\\/g, '/');
+  } catch {
+    return p;
+  }
+}
+
+/**
  * 该目录是否是「用户已经用 Cindy 打开过的项目」—— 即 recent_workdirs 里某条
- * 记录本身或它的子目录(worktree 落在项目内, 同样算已知)。
+ * 记录本身或它的子目录(worktree 落在项目内, 同样算已知), 按 **realpath** 比较。
  *
  * 用途是给 sessions:move 判断「目标是不是用户授权过的目的地」: 只有已知项目
  * 才铸造 IM 绑定的本地移动授权, 攻击者因此拿不到"把 IM 引向任意路径"的能力。
@@ -137,12 +150,14 @@ export async function isKnownRecentWorkdir(candidate: string | null | undefined)
   try {
     const db = getDbClient().drizzle;
     const rows = await db.select({ path: recentWorkdirs.path }).from(recentWorkdirs);
-    return rows.some((row) => {
-      // 表内与入参都已过 normalizeRecentWorkdirPath(posix 形态、无尾斜杠),
-      // 直接按段前缀比即可; Windows 盘符大小写不敏感, 统一小写再比。
-      const base = process.platform === 'win32' ? row.path.toLowerCase() : row.path;
-      const target = process.platform === 'win32' ? normalized.toLowerCase() : normalized;
-      return target === base || target.startsWith(base.endsWith('/') ? base : `${base}/`);
+    if (rows.length === 0) return false;
+    const lower = (v: string): string => (process.platform === 'win32' ? v.toLowerCase() : v);
+    const target = lower(await resolveRealPath(normalized));
+    const bases = await Promise.all(rows.map((row) => resolveRealPath(row.path)));
+    return bases.some((raw) => {
+      // 两侧都已归一(posix 形态、无尾斜杠); Windows 盘符大小写不敏感。
+      const base = lower(raw).replace(/\/+$/, '');
+      return target === base || target.startsWith(`${base}/`);
     });
   } catch (err) {
     log.warn('[localDb] isKnownRecentWorkdir failed', {

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -124,15 +124,17 @@ async function dirExists(path: string): Promise<boolean> {
 }
 
 /**
- * 解析到真实路径再比较, 否则「已知项目内的一个软链」能指到项目外任意目录,
- * 词法前缀比会把它当成子目录放行(PR #669 review 指出)。解析失败(路径不存在 /
- * 无权限)时回退原值 —— 这条链路只用于收紧判定, 回退不会放宽已有边界。
+ * 解析到真实路径, 否则「已知项目内的一个软链」能指到项目外任意目录, 词法前缀比
+ * 会把它当成子目录放行(PR #669 review 指出)。
+ *
+ * 解析失败(不存在 / 断链 / 无权限)返回 null, **不**回退词法路径 —— 回退等于把
+ * 断链软链当成普通子目录, 授权判定必须 fail closed。
  */
-async function resolveRealPath(p: string): Promise<string> {
+async function resolveRealPath(p: string): Promise<string | null> {
   try {
     return (await realpath(p)).replace(/\\/g, '/');
   } catch {
-    return p;
+    return null;
   }
 }
 
@@ -152,9 +154,14 @@ export async function isKnownRecentWorkdir(candidate: string | null | undefined)
     const rows = await db.select({ path: recentWorkdirs.path }).from(recentWorkdirs);
     if (rows.length === 0) return false;
     const lower = (v: string): string => (process.platform === 'win32' ? v.toLowerCase() : v);
-    const target = lower(await resolveRealPath(normalized));
+    const resolvedTarget = await resolveRealPath(normalized);
+    // 目标解析不了 = 不存在 / 断链 / 无权限 -> 不认它是已知项目(fail closed)
+    if (resolvedTarget === null) return false;
+    const target = lower(resolvedTarget);
     const bases = await Promise.all(rows.map((row) => resolveRealPath(row.path)));
     return bases.some((raw) => {
+      // 解析不了的项目条目(目录已被删/移走)不参与判定
+      if (raw === null) return false;
       // 两侧都已归一(posix 形态、无尾斜杠); Windows 盘符大小写不敏感。
       const base = lower(raw).replace(/\/+$/, '');
       return target === base || target.startsWith(`${base}/`);

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -155,11 +155,6 @@ async function resolveRealPath(p: string): Promise<string | null> {
 export async function isKnownRecentWorkdir(candidate: string | null | undefined): Promise<boolean> {
   const shaped = normalizePathShape(candidate);
   if (!shaped) return false;
-  // 受管 worktree 解析回它的 base 项目再判定 —— 这里**不能**复用
-  // normalizeRecentWorkdirPath 的 worktree 排除(那是"别进最近列表"的语义):
-  // hook 自己新建的会话就跑在 worktree 里, 把会话移到 worktree 是正常操作,
-  // 直接判 false 会让移动后的 thread 白白重开(PR #669 review 指出)。
-  const normalized = getManagedWorktreeBasePath(shaped) ?? shaped;
   try {
     const db = getDbClient().drizzle;
     // 与 list IPC 同样加 LIMIT: 万一驱逐路径被绕过, 也不至于让每次移动都变成
@@ -171,10 +166,17 @@ export async function isKnownRecentWorkdir(candidate: string | null | undefined)
       .limit(MAX_RECENT_WORKDIRS);
     if (rows.length === 0) return false;
     const lower = (v: string): string => (process.platform === 'win32' ? v.toLowerCase() : v);
-    const resolvedTarget = await resolveRealPath(normalized);
+    // **先解析成 canonical 路径再谈 worktree**: 反过来的话
+    // `/known/repo/.cindy-worktrees/x/../../../etc` 会被 marker 切成
+    // `/known/repo` 而通过校验, 真正生效的却是 /etc(PR #669 review 指出)。
+    const resolvedTarget = await resolveRealPath(shaped);
     // 目标解析不了 = 不存在 / 断链 / 无权限 -> 不认它是已知项目(fail closed)
     if (resolvedTarget === null) return false;
-    const target = lower(resolvedTarget);
+    // 受管 worktree 解析回它的 base 项目再判定 —— 这里**不能**复用
+    // normalizeRecentWorkdirPath 的 worktree 排除(那是"别进最近列表"的语义):
+    // hook 自己新建的会话就跑在 worktree 里, 把会话移到 worktree 是正常操作,
+    // 直接判 false 会让移动后的 thread 白白重开。
+    const target = lower(getManagedWorktreeBasePath(resolvedTarget) ?? resolvedTarget);
     const bases = await Promise.all(rows.map((row) => resolveRealPath(row.path)));
     return bases.some((raw) => {
       // 解析不了的项目条目(目录已被删/移走)不参与判定

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -138,7 +138,11 @@ async function dirExists(path: string): Promise<boolean> {
  */
 async function resolveRealPath(p: string): Promise<string | null> {
   try {
-    return (await realpath(p)).replace(/\\/g, '/');
+    const resolved = (await realpath(p)).replace(/\\/g, '/');
+    // Windows 的 realpath 可能带扩展长度 / 设备命名空间前缀(`\\?\C:\...`、
+    // `\\.\C:\...`), 替换斜杠后成了 `//?/C:/...` —— 不剥掉就永远比不上表里的
+    // `C:/...`, 授权判定会系统性 false negative(PR #669 review 指出)。
+    return resolved.replace(/^\/\/[?.]\/(?:UNC\/)?/, (m) => (m.includes('UNC') ? '//' : ''));
   } catch {
     return null;
   }
@@ -172,6 +176,9 @@ export async function isKnownRecentWorkdir(candidate: string | null | undefined)
     const resolvedTarget = await resolveRealPath(shaped);
     // 目标解析不了 = 不存在 / 断链 / 无权限 -> 不认它是已知项目(fail closed)
     if (resolvedTarget === null) return false;
+    // 必须是目录: 已知项目里的一个普通文件(如 /repo/package.json)也能通过前缀
+    // 比较, 存成 workingDir 后 agent 每轮都会拿它当 cwd 失败(PR #669 review)。
+    if (!(await dirExists(resolvedTarget))) return false;
     // 受管 worktree 解析回它的 base 项目再判定 —— 这里**不能**复用
     // normalizeRecentWorkdirPath 的 worktree 排除(那是"别进最近列表"的语义):
     // hook 自己新建的会话就跑在 worktree 里, 把会话移到 worktree 是正常操作,

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -55,9 +55,7 @@ const MAX_RECENT_WORKDIRS = 10;
  *
  * 空 / 非字符串 / worktree 路径 → 返回 null,调用方应据此跳过 upsert。
  */
-export function normalizeRecentWorkdirPath(
-  raw: string | null | undefined,
-): string | null {
+export function normalizeRecentWorkdirPath(raw: string | null | undefined): string | null {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
@@ -121,6 +119,35 @@ async function dirExists(path: string): Promise<boolean> {
   try {
     return (await stat(path)).isDirectory();
   } catch {
+    return false;
+  }
+}
+
+/**
+ * 该目录是否是「用户已经用 Cindy 打开过的项目」—— 即 recent_workdirs 里某条
+ * 记录本身或它的子目录(worktree 落在项目内, 同样算已知)。
+ *
+ * 用途是给 sessions:move 判断「目标是不是用户授权过的目的地」: 只有已知项目
+ * 才铸造 IM 绑定的本地移动授权, 攻击者因此拿不到"把 IM 引向任意路径"的能力。
+ * 任何异常按 false 处理(fail closed)。
+ */
+export async function isKnownRecentWorkdir(candidate: string | null | undefined): Promise<boolean> {
+  const normalized = normalizeRecentWorkdirPath(candidate);
+  if (!normalized) return false;
+  try {
+    const db = getDbClient().drizzle;
+    const rows = await db.select({ path: recentWorkdirs.path }).from(recentWorkdirs);
+    return rows.some((row) => {
+      // 表内与入参都已过 normalizeRecentWorkdirPath(posix 形态、无尾斜杠),
+      // 直接按段前缀比即可; Windows 盘符大小写不敏感, 统一小写再比。
+      const base = process.platform === 'win32' ? row.path.toLowerCase() : row.path;
+      const target = process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+      return target === base || target.startsWith(base.endsWith('/') ? base : `${base}/`);
+    });
+  } catch (err) {
+    log.warn('[localDb] isKnownRecentWorkdir failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return false;
   }
 }

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -55,7 +55,7 @@ const MAX_RECENT_WORKDIRS = 10;
  *
  * 空 / 非字符串 / worktree 路径 → 返回 null,调用方应据此跳过 upsert。
  */
-export function normalizeRecentWorkdirPath(raw: string | null | undefined): string | null {
+function normalizePathShape(raw: string | null | undefined): string | null {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
@@ -64,6 +64,12 @@ export function normalizeRecentWorkdirPath(raw: string | null | undefined): stri
     if (/^[A-Za-z]:\/$/.test(s)) break; // 盘符根 `D:/`
     s = s.slice(0, -1);
   }
+  return s;
+}
+
+export function normalizeRecentWorkdirPath(raw: string | null | undefined): string | null {
+  const s = normalizePathShape(raw);
+  if (s === null) return null;
   if (getManagedWorktreeBasePath(s) != null) return null;
   return s;
 }
@@ -147,11 +153,22 @@ async function resolveRealPath(p: string): Promise<string | null> {
  * 任何异常按 false 处理(fail closed)。
  */
 export async function isKnownRecentWorkdir(candidate: string | null | undefined): Promise<boolean> {
-  const normalized = normalizeRecentWorkdirPath(candidate);
-  if (!normalized) return false;
+  const shaped = normalizePathShape(candidate);
+  if (!shaped) return false;
+  // 受管 worktree 解析回它的 base 项目再判定 —— 这里**不能**复用
+  // normalizeRecentWorkdirPath 的 worktree 排除(那是"别进最近列表"的语义):
+  // hook 自己新建的会话就跑在 worktree 里, 把会话移到 worktree 是正常操作,
+  // 直接判 false 会让移动后的 thread 白白重开(PR #669 review 指出)。
+  const normalized = getManagedWorktreeBasePath(shaped) ?? shaped;
   try {
     const db = getDbClient().drizzle;
-    const rows = await db.select({ path: recentWorkdirs.path }).from(recentWorkdirs);
+    // 与 list IPC 同样加 LIMIT: 万一驱逐路径被绕过, 也不至于让每次移动都变成
+    // 无界的 realpath 扫描。
+    const rows = await db
+      .select({ path: recentWorkdirs.path })
+      .from(recentWorkdirs)
+      .orderBy(desc(recentWorkdirs.lastUsedAt))
+      .limit(MAX_RECENT_WORKDIRS);
     if (rows.length === 0) return false;
     const lower = (v: string): string => (process.platform === 'win32' ? v.toLowerCase() : v);
     const resolvedTarget = await resolveRealPath(normalized);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -955,6 +955,22 @@ export function registerSessionIpc(): void {
       broadcastSessionPatched(sid, { summary: null });
       void recomputePrRefsForSession(sid).catch(() => undefined);
     }
+    // 会话被移到别的目录时给 IM 绑定登记一次「本地移动授权」:这是 hook 侧
+    // local-move 授权的唯一来源(dispatcher 不从 session 元数据反推是不是用户
+    // 移的,见 hook-control/bindings.ts 文件头)。只在目录真的变了时登记,归一化
+    // 写法差异不算移动。fire-and-forget:登记失败只影响该 thread 下一条消息会
+    // 重开新对话,不该拖累移动本身。
+    if (
+      beforeMove &&
+      typeof p.workingDir === 'string' &&
+      p.workingDir &&
+      normalizeWorkingDirForStorage(beforeMove.workingDir) !== p.workingDir
+    ) {
+      const movedTo = p.workingDir;
+      void import('../../hook-control/sessionMoves.js')
+        .then((m) => m.noteHookSessionMoved(sid, movedTo))
+        .catch(() => undefined);
+    }
     // workingDir 实际变化的本机 cc 会话:迁移 CLI 转录后再查询返回行/广播,保证
     // renderer 拿到更新结果时转录已就位(用户可立即续聊),且迁移中持久化的最新
     // sdkSessionId 能进返回行与广播 patch——否则 renderer 留着旧 resume id,下一次

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -15,6 +15,7 @@ import { getDbClient } from '../client/current';
 import type { DbClient } from '../client/DbClient';
 import { sessions, messages } from '../schema';
 import { throwIpcError, requireString, requireObject } from '../../utils/ipcValidate';
+import { assertTrustedAppRendererEvent } from '../../security/trustedAppRenderer.js';
 import { resolveBusinessSessionId } from '../../sessionIds';
 import {
   sessionToCamel,
@@ -28,7 +29,7 @@ import { ensureProjectGitInitialized } from '../../git-snapshot/projectGitBootst
 import { readGitSafetySettings } from '../../maker-host/git-safety-settings-store';
 import * as imageCacheStore from '../../imageCacheStore';
 import { removeSessionRefs as removeSessionMediaRefs } from '../../cindy-media/ledger';
-import { upsertRecentWorkdir } from './recentWorkdirs';
+import { isKnownRecentWorkdir, upsertRecentWorkdir } from './recentWorkdirs';
 import { createLogger } from '../../logger';
 import { DESKTOP_VISIBLE_SESSION_SOURCES } from '../../../shared/sessionSource.js';
 import { normalizeWorkingDirForStorage } from '../../../shared/workingDir.js';
@@ -875,7 +876,12 @@ export function registerSessionIpc(): void {
     },
   );
 
-  ipcMain.handle('local-db:sessions:update', async (_e, id: unknown, patch: unknown) => {
+  /**
+   * update handler 的实现体。抽成具名函数供窄口径的 sessions:move 复用 ——
+   * 移动必须复用同一条写入编排(转录迁移、recent_workdirs、广播、agent island
+   * 通知), 否则两条路径会漂移。
+   */
+  async function applySessionUpdate(id: unknown, patch: unknown): Promise<unknown> {
     const sid = requireString(id, 'id');
     const p = requireObject(patch, 'patch');
     const db = getDbClient().drizzle;
@@ -955,22 +961,6 @@ export function registerSessionIpc(): void {
       broadcastSessionPatched(sid, { summary: null });
       void recomputePrRefsForSession(sid).catch(() => undefined);
     }
-    // 会话被移到别的目录时给 IM 绑定登记一次「本地移动授权」:这是 hook 侧
-    // local-move 授权的唯一来源(dispatcher 不从 session 元数据反推是不是用户
-    // 移的,见 hook-control/bindings.ts 文件头)。只在目录真的变了时登记,归一化
-    // 写法差异不算移动。fire-and-forget:登记失败只影响该 thread 下一条消息会
-    // 重开新对话,不该拖累移动本身。
-    if (
-      beforeMove &&
-      typeof p.workingDir === 'string' &&
-      p.workingDir &&
-      normalizeWorkingDirForStorage(beforeMove.workingDir) !== p.workingDir
-    ) {
-      const movedTo = p.workingDir;
-      void import('../../hook-control/sessionMoves.js')
-        .then((m) => m.noteHookSessionMoved(sid, movedTo))
-        .catch(() => undefined);
-    }
     // workingDir 实际变化的本机 cc 会话:迁移 CLI 转录后再查询返回行/广播,保证
     // renderer 拿到更新结果时转录已就位(用户可立即续聊),且迁移中持久化的最新
     // sdkSessionId 能进返回行与广播 patch——否则 renderer 留着旧 resume id,下一次
@@ -1030,6 +1020,56 @@ export function registerSessionIpc(): void {
     notifyGhostSessionStatusChange(sid, p.status, updated.workingDir);
     removeHookAttachmentDir(sid, p.status);
     return updated;
+  }
+
+  ipcMain.handle('local-db:sessions:update', async (_e, id: unknown, patch: unknown) =>
+    applySessionUpdate(id, patch),
+  );
+
+  /**
+   * 窄口径「移动对话到项目 / 对话」。与通用 sessions:update 的区别只有一个:
+   * **只有它能铸造 IM 绑定的本地移动授权**(hook 侧据此在工作目录映射外继续
+   * 复用该会话, 见 hook-control/bindings.ts 文件头)。因此这里比 update 多三道闸:
+   *
+   *  1. sender 必须是 Cindy 主页面(assertTrustedAppRendererEvent) —— WebView、
+   *     Ghost 面板、子 frame 一律拒绝;
+   *  2. 目标目录必须是**用户已经用 Cindy 打开过的项目**(recent_workdirs 内),
+   *     否则照常移动但**不铸造授权** —— 攻击者拿不到"把 IM 引向任意路径"的能力,
+   *     用户自己浏览新目录移动时也不会被阻断(代价只是该 thread 换新对话并收到说明);
+   *  3. 授权在写库**之前**同步登记 —— 否则存在"目录已变、授权还没落"的窗口,
+   *     那期间到达的 IM 消息会把绑定当成撤权删掉(PR #669 review 指出)。
+   */
+  ipcMain.handle('local-db:sessions:move', async (event, id: unknown, target: unknown) => {
+    assertTrustedAppRendererEvent(event);
+    const sid = requireString(id, 'id');
+    const t = requireObject(target, 'target');
+    if (t.kind !== 'project' && t.kind !== 'dialogue') {
+      throwIpcError('INVALID_PARAMS', `invalid target.kind: ${String(t.kind)}`);
+    }
+    const patch: Record<string, unknown> =
+      t.kind === 'dialogue'
+        ? { workspaceKind: 'dialogue' }
+        : {
+            workspaceKind: 'project',
+            workingDir: normalizeWorkingDirForStorage(requireString(t.workingDir, 'workingDir')),
+          };
+
+    const nextDir = typeof patch.workingDir === 'string' ? patch.workingDir : null;
+    if (nextDir !== null) {
+      const db = getDbClient().drizzle;
+      const [before] = await db
+        .select({ workingDir: sessions.workingDir })
+        .from(sessions)
+        .where(eq(sessions.id, sid));
+      const dirActuallyChanges =
+        !before || normalizeWorkingDirForStorage(before.workingDir) !== nextDir;
+      // 目标不在用户已知项目里就不铸造授权(移动本身照常进行)
+      if (dirActuallyChanges && (await isKnownRecentWorkdir(nextDir))) {
+        const m = await import('../../hook-control/sessionMoves.js');
+        await m.noteHookSessionMoved(sid, nextDir);
+      }
+    }
+    return applySessionUpdate(sid, patch);
   });
 
   // 窄口径会话元数据编辑(status / title / pinnedAt)。专为 device-link 控制端**远程**

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1046,13 +1046,16 @@ export function registerSessionIpc(): void {
     if (t.kind !== 'project' && t.kind !== 'dialogue') {
       throwIpcError('INVALID_PARAMS', `invalid target.kind: ${String(t.kind)}`);
     }
-    const patch: Record<string, unknown> =
-      t.kind === 'dialogue'
-        ? { workspaceKind: 'dialogue' }
-        : {
-            workspaceKind: 'project',
-            workingDir: normalizeWorkingDirForStorage(requireString(t.workingDir, 'workingDir')),
-          };
+    let patch: Record<string, unknown>;
+    if (t.kind === 'dialogue') {
+      patch = { workspaceKind: 'dialogue' };
+    } else {
+      // 归一化可能返回 null(纯空白等) —— 放过去会写成 project + workingDir=null
+      // 的不一致状态, 这里直接拒绝(PR #669 review 指出)。
+      const normalized = normalizeWorkingDirForStorage(requireString(t.workingDir, 'workingDir'));
+      if (!normalized) throwIpcError('INVALID_PARAMS', 'workingDir must be a usable path');
+      patch = { workspaceKind: 'project', workingDir: normalized };
+    }
 
     const nextDir = typeof patch.workingDir === 'string' ? patch.workingDir : null;
     if (nextDir !== null) {

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -16,6 +16,7 @@ import type { DbClient } from '../client/DbClient';
 import { sessions, messages } from '../schema';
 import { throwIpcError, requireString, requireObject } from '../../utils/ipcValidate';
 import { assertTrustedAppRendererEvent } from '../../security/trustedAppRenderer.js';
+import { noteHookSessionMoved } from '../../hook-control/sessionMoves.js';
 import { resolveBusinessSessionId } from '../../sessionIds';
 import {
   sessionToCamel,
@@ -1068,8 +1069,7 @@ export function registerSessionIpc(): void {
         !before || normalizeWorkingDirForStorage(before.workingDir) !== nextDir;
       // 目标不在用户已知项目里就不铸造授权(移动本身照常进行)
       if (dirActuallyChanges && (await isKnownRecentWorkdir(nextDir))) {
-        const m = await import('../../hook-control/sessionMoves.js');
-        await m.noteHookSessionMoved(sid, nextDir);
+        await noteHookSessionMoved(sid, nextDir);
       }
     }
     return applySessionUpdate(sid, patch);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1061,6 +1061,11 @@ export function registerSessionIpc(): void {
       if (normalized.split('/').includes('..')) {
         throwIpcError('INVALID_PARAMS', 'workingDir must not contain path traversal segments');
       }
+      // 相对路径会在后续 path.resolve / fs 操作里按主进程 CWD 解释, 落到意料外
+      // 的目录(PR #669 review 指出)。移动目标必须是绝对路径。
+      if (!path.isAbsolute(normalized) && !/^[A-Za-z]:\//.test(normalized)) {
+        throwIpcError('INVALID_PARAMS', 'workingDir must be an absolute path');
+      }
       patch = { workspaceKind: 'project', workingDir: normalized };
     }
 
@@ -1077,7 +1082,11 @@ export function registerSessionIpc(): void {
       const fromDir = normalizeWorkingDirForStorage(before.workingDir);
       // 目标不在用户已知项目里就不铸造授权(移动本身照常进行)
       if (fromDir !== nextDir && (await isKnownRecentWorkdir(nextDir))) {
-        await noteHookSessionMoved(sid, { from: fromDir, to: nextDir });
+        // 登记失败就别提交移动: 目录变了而授权没落的话, 下一条 IM 消息会把绑定
+        // 当撤权删掉, 用户莫名丢上下文。报错让他重试(PR #669 review 指出)。
+        if (!(await noteHookSessionMoved(sid, { from: fromDir, to: nextDir }))) {
+          throwIpcError('INTERNAL', '移动失败:无法更新 IM 绑定,请重试');
+        }
         const updated = await applySessionUpdate(sid, patch);
         // 写库成功 = 移动的两步都完成, 立刻收掉在途标记(见 bindings 文件头)
         completeHookSessionMove(sid, nextDir);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -16,7 +16,7 @@ import type { DbClient } from '../client/DbClient';
 import { sessions, messages } from '../schema';
 import { throwIpcError, requireString, requireObject } from '../../utils/ipcValidate';
 import { assertTrustedAppRendererEvent } from '../../security/trustedAppRenderer.js';
-import { noteHookSessionMoved } from '../../hook-control/sessionMoves.js';
+import { completeHookSessionMove, noteHookSessionMoved } from '../../hook-control/sessionMoves.js';
 import { resolveBusinessSessionId } from '../../sessionIds';
 import {
   sessionToCamel,
@@ -1055,6 +1055,12 @@ export function registerSessionIpc(): void {
       // 的不一致状态, 这里直接拒绝(PR #669 review 指出)。
       const normalized = normalizeWorkingDirForStorage(requireString(t.workingDir, 'workingDir'));
       if (!normalized) throwIpcError('INVALID_PARAMS', 'workingDir must be a usable path');
+      // 拒绝含 `..` 段的路径: 校验用的是解析后的路径、存下来的却是原串, 两者
+      // 不一致就会被拿来绕过目的地校验(PR #669 review 指出)。正常入口(原生
+      // 目录框 / 项目列表)给的都是规范绝对路径。
+      if (normalized.split('/').includes('..')) {
+        throwIpcError('INVALID_PARAMS', 'workingDir must not contain path traversal segments');
+      }
       patch = { workspaceKind: 'project', workingDir: normalized };
     }
 
@@ -1072,6 +1078,10 @@ export function registerSessionIpc(): void {
       // 目标不在用户已知项目里就不铸造授权(移动本身照常进行)
       if (fromDir !== nextDir && (await isKnownRecentWorkdir(nextDir))) {
         await noteHookSessionMoved(sid, { from: fromDir, to: nextDir });
+        const updated = await applySessionUpdate(sid, patch);
+        // 写库成功 = 移动的两步都完成, 立刻收掉在途标记(见 bindings 文件头)
+        completeHookSessionMove(sid, nextDir);
+        return updated;
       }
     }
     return applySessionUpdate(sid, patch);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1065,11 +1065,13 @@ export function registerSessionIpc(): void {
         .select({ workingDir: sessions.workingDir })
         .from(sessions)
         .where(eq(sessions.id, sid));
-      const dirActuallyChanges =
-        !before || normalizeWorkingDirForStorage(before.workingDir) !== nextDir;
+      // 会话不存在时提前收口: 否则会先铸造一次"根本没发生的移动"的授权,
+      // 再由 applySessionUpdate 抛 NOT_FOUND(PR #669 review 指出)。
+      if (!before) throwIpcError('NOT_FOUND', 'Session 不存在');
+      const fromDir = normalizeWorkingDirForStorage(before.workingDir);
       // 目标不在用户已知项目里就不铸造授权(移动本身照常进行)
-      if (dirActuallyChanges && (await isKnownRecentWorkdir(nextDir))) {
-        await noteHookSessionMoved(sid, nextDir);
+      if (fromDir !== nextDir && (await isKnownRecentWorkdir(nextDir))) {
+        await noteHookSessionMoved(sid, { from: fromDir, to: nextDir });
       }
     }
     return applySessionUpdate(sid, patch);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1040,6 +1040,25 @@ export function registerSessionIpc(): void {
    *  3. 授权在写库**之前**同步登记 —— 否则存在"目录已变、授权还没落"的窗口,
    *     那期间到达的 IM 消息会把绑定当成撤权删掉(PR #669 review 指出)。
    */
+  /**
+   * 同一 session 的移动必须串行: 两次并发移动会各自读到同一个 fromDir、各自登记,
+   * 先落库的那次与绑定记录对不上, 到达的 IM 消息就把绑定删了(PR #669 review)。
+   */
+  const moveChains = new Map<string, Promise<unknown>>();
+  function serializeMove<T>(sessionId: string, run: () => Promise<T>): Promise<T> {
+    const prev = moveChains.get(sessionId) ?? Promise.resolve();
+    const next = prev.then(run, run);
+    const settled = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    moveChains.set(sessionId, settled);
+    void settled.finally(() => {
+      if (moveChains.get(sessionId) === settled) moveChains.delete(sessionId);
+    });
+    return next;
+  }
+
   ipcMain.handle('local-db:sessions:move', async (event, id: unknown, target: unknown) => {
     assertTrustedAppRendererEvent(event);
     const sid = requireString(id, 'id');
@@ -1070,7 +1089,8 @@ export function registerSessionIpc(): void {
     }
 
     const nextDir = typeof patch.workingDir === 'string' ? patch.workingDir : null;
-    if (nextDir !== null) {
+    return serializeMove(sid, async () => {
+      if (nextDir === null) return applySessionUpdate(sid, patch);
       const db = getDbClient().drizzle;
       const [before] = await db
         .select({ workingDir: sessions.workingDir })
@@ -1081,19 +1101,25 @@ export function registerSessionIpc(): void {
       if (!before) throwIpcError('NOT_FOUND', 'Session 不存在');
       const fromDir = normalizeWorkingDirForStorage(before.workingDir);
       // 目标不在用户已知项目里就不铸造授权(移动本身照常进行)
-      if (fromDir !== nextDir && (await isKnownRecentWorkdir(nextDir))) {
-        // 登记失败就别提交移动: 目录变了而授权没落的话, 下一条 IM 消息会把绑定
-        // 当撤权删掉, 用户莫名丢上下文。报错让他重试(PR #669 review 指出)。
-        if (!(await noteHookSessionMoved(sid, { from: fromDir, to: nextDir }))) {
-          throwIpcError('INTERNAL', '移动失败:无法更新 IM 绑定,请重试');
-        }
+      if (fromDir === nextDir || !(await isKnownRecentWorkdir(nextDir))) {
+        return applySessionUpdate(sid, patch);
+      }
+      // 登记失败就别提交移动: 目录变了而授权没落的话, 下一条 IM 消息会把绑定
+      // 当撤权删掉, 用户莫名丢上下文。报错让他重试(PR #669 review 指出)。
+      const rollback = await noteHookSessionMoved(sid, { from: fromDir, to: nextDir });
+      if (!rollback) throwIpcError('INTERNAL', '移动失败:无法更新 IM 绑定,请重试');
+      try {
         const updated = await applySessionUpdate(sid, patch);
         // 写库成功 = 移动的两步都完成, 立刻收掉在途标记(见 bindings 文件头)
         completeHookSessionMove(sid, nextDir);
         return updated;
+      } catch (err) {
+        // 写库失败必须回滚登记 —— 否则 previousWorkingDir 永久残留, 之后会话
+        // 目录再等于旧值时会被当成"在途移动"放行, 绕过撤权(PR #669 review)。
+        rollback();
+        throw err;
       }
-    }
-    return applySessionUpdate(sid, patch);
+    });
   });
 
   // 窄口径会话元数据编辑(status / title / pinnedAt)。专为 device-link 控制端**远程**

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1119,7 +1119,7 @@ export function registerSessionIpc(): void {
         // 一条消息照样丢绑定(PR #669 review 指出)。按库里的真实状态补偿:
         //   - 目录已经是新的 -> 移动其实成立, 收掉在途标记、保留新授权;
         //   - 目录还是旧的   -> 移动没成立, 回滚登记。
-        let committed = false;
+        let committed: boolean | null = null;
         try {
           const [after] = await db
             .select({ workingDir: sessions.workingDir })
@@ -1127,10 +1127,13 @@ export function registerSessionIpc(): void {
             .where(eq(sessions.id, sid));
           committed = !!after && normalizeWorkingDirForStorage(after.workingDir) === nextDir;
         } catch {
-          // 连状态都查不到时按"没提交"处理: 回滚是保守侧(最多一次 thread 重开)
+          // 连状态都查不到 -> 什么都不动。硬判成"没提交"去回滚, 万一其实提交了
+          // 就制造出"库在新目录、绑定记旧目录"的分叉(PR #669 review 指出);
+          // 保留在途标记则两种情况都能自愈: 真提交了下一条消息按新目录复用,
+          // 没提交则标记过期(movePendingUntil)后按撤权处理。
         }
-        if (committed) completeHookSessionMove(sid, nextDir);
-        else rollback();
+        if (committed === true) completeHookSessionMove(sid, nextDir);
+        else if (committed === false) rollback();
         throw err;
       }
     });

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1114,9 +1114,23 @@ export function registerSessionIpc(): void {
         completeHookSessionMove(sid, nextDir);
         return updated;
       } catch (err) {
-        // 写库失败必须回滚登记 —— 否则 previousWorkingDir 永久残留, 之后会话
-        // 目录再等于旧值时会被当成"在途移动"放行, 绕过撤权(PR #669 review)。
-        rollback();
+        // applySessionUpdate 里 DB 写入在前、转录迁移等副作用在后: 目录可能已经
+        // 提交了才抛错。这时回滚绑定会造成"库在新目录、绑定记旧目录"的分叉, 下
+        // 一条消息照样丢绑定(PR #669 review 指出)。按库里的真实状态补偿:
+        //   - 目录已经是新的 -> 移动其实成立, 收掉在途标记、保留新授权;
+        //   - 目录还是旧的   -> 移动没成立, 回滚登记。
+        let committed = false;
+        try {
+          const [after] = await db
+            .select({ workingDir: sessions.workingDir })
+            .from(sessions)
+            .where(eq(sessions.id, sid));
+          committed = !!after && normalizeWorkingDirForStorage(after.workingDir) === nextDir;
+        } catch {
+          // 连状态都查不到时按"没提交"处理: 回滚是保守侧(最多一次 thread 重开)
+        }
+        if (committed) completeHookSessionMove(sid, nextDir);
+        else rollback();
         throw err;
       }
     });

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3307,6 +3307,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('local-db:sessions:restore-if-archived', id, expected),
       update: (id: string, patch: unknown): Promise<unknown> =>
         ipcRenderer.invoke('local-db:sessions:update', id, patch),
+      /**
+       * 窄口径「移动对话到项目 / 对话」。与 update 的区别是它是 IM 绑定本地移动
+       * 授权的唯一铸造入口(main 侧带 sender 闸与目的地校验),移动 UI 必须走它。
+       */
+      move: (id: string, target: unknown): Promise<unknown> =>
+        ipcRenderer.invoke('local-db:sessions:move', id, target),
       touchUserSend: (id: string, atMs?: number): Promise<void> =>
         ipcRenderer.invoke('local-db:sessions:touchUserSend', id, atMs),
       /** interrupted-turn-resume:「疑似中断」(startedAt > endedAt)的 active 会话 id(启动红点)。 */

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -4777,7 +4777,13 @@ export function ChatInput({
       addRecentFolder(folderPath);
       try {
         if (sessionId) {
-          await sessionService.update(sessionId, { workingDir: folderPath });
+          // 用户主动给这个对话换工作目录 = 一次移动: 走窄口径 move, 它是 IM 绑定
+          // 「本地移动授权」的唯一铸造入口(通用 update 不铸造), 绑了 Slack /
+          // Telegram 的对话才能在换目录后继续复用原对话。
+          await sessionService.moveToWorkspace(sessionId, {
+            kind: 'project',
+            workingDir: folderPath,
+          });
         }
         // Server succeeded → update UI
         setWorkingDir(folderPath);

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -1728,7 +1728,14 @@ function ExpandedView({
         }
       }
       try {
-        await sessionService.update(sessionId, nextPatch);
+        // 走窄口径 move(不是通用 update):它是 IM 绑定「本地移动授权」的唯一
+        // 铸造入口,绑了 Slack / Telegram 的对话靠它在移动后继续复用原对话。
+        await sessionService.moveToWorkspace(
+          sessionId,
+          target.kind === 'dialogue'
+            ? { kind: 'dialogue' }
+            : { kind: 'project', workingDir: targetWorkingDir! },
+        );
         if (target.kind !== 'dialogue') {
           void recentWorkdirsStore.forceRefresh().catch(() => undefined);
         }

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -331,7 +331,14 @@ export function SessionContentHeader({
           : { workingDir: targetWorkingDir, workspaceKind: 'project' as const };
       patchLocal(session.id, nextPatch);
       try {
-        await sessionService.update(session.id, nextPatch);
+        // 走窄口径 move(不是通用 update):它是 IM 绑定「本地移动授权」的唯一
+        // 铸造入口,绑了 Slack / Telegram 的对话靠它在移动后继续复用原对话。
+        await sessionService.moveToWorkspace(
+          session.id,
+          target.kind === 'dialogue'
+            ? { kind: 'dialogue' }
+            : { kind: 'project', workingDir: targetWorkingDir! },
+        );
         if (target.kind !== 'dialogue') {
           void recentWorkdirsStore.forceRefresh().catch(() => undefined);
         }

--- a/apps/desktop/src/renderer/lib/sessionService.ts
+++ b/apps/desktop/src/renderer/lib/sessionService.ts
@@ -134,6 +134,18 @@ export async function update(
 }
 
 /**
+ * 移动对话到项目 / 内置「对话」。走 main 的窄口径 `sessions:move` 而不是通用
+ * update —— 它是 IM 绑定「本地移动授权」的唯一铸造入口(main 侧校验 sender 与
+ * 目的地),绑定了 Slack / Telegram 的对话靠它在移动后继续复用原对话。
+ */
+export async function moveToWorkspace(
+  id: string,
+  target: { kind: 'project'; workingDir: string } | { kind: 'dialogue' },
+): Promise<Session> {
+  return wrap(window.electronAPI.localDb.sessions.move(id, target));
+}
+
+/**
  * 窄口径会话元数据编辑(status / title / pinnedAt = 删/归档/恢复/重命名/置顶)。按来源路由:
  *   - device-link 远程会话 → 隧道到被控端的 local-db:sessions:patch-meta(allowlist 内的窄口径写)
  *   - 本机会话 → 保持原 update 路径(零行为变更)

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3116,6 +3116,14 @@ interface ElectronAPI {
         },
       ) => Promise<import('@/lib/ccAgent.types').Session>;
       /**
+       * 窄口径「移动对话到项目 / 对话」。IM 绑定本地移动授权的唯一铸造入口
+       * （main 侧校验 sender 与目的地），移动 UI 必须走它而不是通用 update。
+       */
+      move: (
+        id: string,
+        target: { kind: 'project'; workingDir: string } | { kind: 'dialogue' },
+      ) => Promise<import('@/lib/ccAgent.types').Session>;
+      /**
        * 单字段 bump：把 user_send_at 设为 atMs（默认当前时间）。
        * fire-and-forget；renderer 应在 emitPatch userSendAt 之后调用，作为持久化兜底。
        */


### PR DESCRIPTION
## 这次改了什么

### 摘要

#653 的 review follow-up 补送——那条修复因合并竞态没进 `main`。

时间线：#653 于 `2026-07-27T10:33:38Z` 合并，合并的 head 是 `dd720e38`；针对 codex review 最后一条 P1（[#653 discussion_r3656402759](https://github.com/makecindy/cindy/pull/653#discussion_r3656402759)）的修复 `afb5b626` 在门禁跑完后才 push，晚了十几分钟，因此没有进入合并。现在 `main` 上的 hook 绑定仍是「从 session 元数据推断本地移动授权」的版本。本 PR 先把那个 commit cherry-pick 到最新 `main`，再按本 PR 上三家 reviewer 的一致意见把授权模型重做了一轮（见下）。

**要修的问题**：#653 合入的版本把「会话当前 workingDir 与绑定快照不一样」当作「用户在桌面端移动了对话」的证据，据此允许该绑定在 IM 工作目录映射之外继续复用。这个推断不成立——`sessions` 行的 `workingDir` 经通用 patch IPC（`local-db:sessions:update`）就能改，而 Renderer 按 [`electron-security-and-process-boundaries.md`](../docs/dev-rules/electron-security-and-process-boundaries.md) §1 属不可信环境；被攻陷的 renderer（或任何别的通用调用方）把一个 hook 绑定的会话改到未映射目录后，下一条外部消息就会把它固化成 `local-move` 授权，让 IM 继续驱动那个目录，绕过工作目录映射这道边界。此外，目录写法归一化之类的无关写入也会被误判成「移动」。

**改法**：授权只由一个受信任的窄入口铸造，dispatcher 只读结论、不做推断。

- 新增窄口径 IPC `local-db:sessions:move`（「移动到项目 / 对话」的唯一通道），它比通用 update 多三道闸：
  1. `assertTrustedAppRendererEvent(event)`——只接受 Cindy 主页面，WebView、Ghost 面板、子 frame 一律拒绝；
  2. 目标目录必须是**用户已经用 Cindy 打开过的项目**（`recent_workdirs` 内，含其子目录）；不是的话照常移动但**不铸造授权**——攻击者拿不到「把 IM 引向任意路径」的能力，用户浏览新目录移动也不会被阻断（代价只是该 thread 换新对话并收到说明）；
  3. 授权在写库**之前**同步 `await` 登记（按 `sessionId` 串行，登记失败或写库抛错都中止并回滚），并把移动前的目录一并记进 `previousWorkingDir`；dispatcher 据此认出「登记已落、库还没落」的中间态（照常在旧目录跑、不动绑定、也不迁移 legacy 行），写库成功后立刻清掉该标记（窗口严格限定在两步之间），回填再带单调递增的 `expectedRev` 做乐观并发控制——移动两步之间到达的 IM 消息既不会把绑定当撤权删掉，也不会抹掉刚落下的授权，映射外的二次移动同样不丢绑定。
- 通用 `local-db:sessions:update` **不再**铸造任何授权（它的实现体抽成 `applySessionUpdate()`，被 move 复用，两条路径的写入编排不会漂移）。
- `hook-control/sessionMoves.ts` 的 `noteHookSessionMoved()` 按**当前工作目录映射**判定要记哪种授权：移进映射内的目录记 `workspace`（不留过期例外），映射外才记 `local-move` + `noticePending`。
- `dispatcher.ts` 映射外的唯一放行条件是「绑定上有已登记的 `local-move` 且会话目录仍是登记时那个」；未经登记的目录变化一律按撤权丢绑定重建。移动说明由 `noticePending` 驱动，每次登记只说明一次。
- renderer 的用户主动移动入口（侧栏卡片菜单、会话头部菜单、ChatInput 的「换工作目录」）统一改走 `sessionService.moveToWorkspace()`；草稿发送时指向新 worktree 的内部流程仍走 `update`（不该铸造授权）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#653（本 PR 是它的 review follow-up 补送）
- 本 PR 包含：`hook-control/sessionMoves.ts`（新增登记入口 + 按映射判定授权种类）、`hook-control/bindings.ts` 的 `noticePending` 与 `noteSessionMoved()`、`hook-control/dispatcher.ts` 的放行判定、`localDb/ipc/sessions.ts` 的窄口径 `sessions:move` handler（sender 闸 + 目的地校验 + 有序登记）、`localDb/ipc/recentWorkdirs.ts` 的 `isKnownRecentWorkdir()`、preload / `sessionService` / 两处移动 UI 的调用切换，及对应单测。
- 明确不包含：#653 已合入的其余部分（目录快照、`authority` 字段、渠道侧说明文案）不再重复改动。
- 用户可见变化：无新增可见行为。#653 的「对话被移动后仍复用原对话」照常工作，只是授权来源换成了 Main 侧登记；未经移动动作而被改到映射外的会话不再被 IM 驱动。
- 是否存在 breaking change：无。`hook-bindings.json` 只增 `noticePending` 字段，老文件读到缺省值按 `false` 处理。#653 合入版本写下的 `local-move` 授权在本版本下仍然有效（目录对得上就继续跟随）。

### 远程与手机版适配结论

按 [`remote-and-mobile-adaptation.md`](../docs/dev-rules/remote-and-mobile-adaptation.md) 的 PR 门禁，逐项给结论（与 #653 一致）：

1. **SSH 远程工作区**：不涉及。IM hook 派发本就排除远程会话（`session-runner.inspect()` 判定 `usable` 时要求 `remoteHostId == null`，`listRecentHookSessions()` 同样 `isNull(sessions.remoteHostId)`）。本 PR 只读已有的 workingDir 值并写本机 JSON，没有新增 workdir 文件访问，不需要走 remote-file-service / cc-manager。
2. **设备互联远程控制**：已确认无需适配。新增的 `local-db:sessions:move` **刻意不进** `packages/device-link/src/allowlist.ts`——与通用 `sessions:update` 同理（allowlist 里本来就没有它，远程控制端不能改 workingDir），且移动 UI 自身对 `remoteHostId` / `deviceLinkDeviceId` 会话已有守卫（`moveToProjectRemoteUnsupported`），远程会话本就不允许移动。没有新增推送事件与 topic 路由。
3. **手机版**：不涉及。手机端是纯控制端，不参与 IM hook 的会话定位，没有新增入口、UI 或交互。

### UI 变化

不涉及：有 Renderer 改动，但只是把两处「移动到项目 / 对话」菜单项的落地调用从 `sessionService.update()` 换成 `sessionService.moveToWorkspace()`，界面、组件、布局、样式、动效与文案零改动，用户看到的交互完全一致。

- 引用的设计规范：不涉及：无视觉／交互／文案变化（改动是同一菜单动作的 IPC 通道切换）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：通过

apps/desktop $ npx vitest run src/main/hook-control/ src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
结果：306 tests 全部通过

pnpm test:unit（仓库根全量门禁，经 skill 统一脚本执行）
结果：GATE_EXIT=0，全部 workspace PASS

npx prettier --check <本次改动的文件>
结果：通过
```

关键测试：

- `dispatcher.test.ts`「目录被改到映射外但没有登记过移动 -> 不跟随(不可信元数据不能当授权)」——直接锁住本 PR 要修的边界。
- `dispatcher.test.ts`「移动后的后续消息持续复用同一 session, 且不再重复提示」「对话移回工作目录映射内: 授权来源复位, 此后映射被改仍按撤权重建」。
- `bindings.test.ts`「`noteSessionMoved()` 跨命名空间反查 + 跨实例持久化」。
- `dispatcher.test.ts` 竞态回归：「移动登记已落、会话目录还没落库 → 这一轮跑旧目录且不抹登记，写库后跟随并说明一次」「已在映射外的会话再次移动 → 两步之间照常跑旧目录、不丢绑定，写库后跟随并清掉在途标记」「回填期间落下的登记不被覆盖（乐观并发控制）」。
- `sessionsUpdate.test.ts`：通用 update **绝不**铸造授权；写库后清掉在途标记、写库失败回滚登记、同会话并发移动串行、含 `..` 与相对路径的目标被拒收、登记失败中止移动；move handler 的其余边界——铸造并落库、**授权先于写库**（登记回调里读库断言仍是旧目录）、非可信 sender 直接拒绝且不铸造、目的地不是已知项目时照常移动但不铸造、同目录不铸造、移回「对话」不碰绑定、非法 target.kind 拒绝。

### 手工验证

不涉及：复现需要真实 Slack workspace 绑定 + 在桌面端移动会话，本地没有可用的联调环境，行为覆盖靠上述单测。

### 未执行的验证

- 未做 Slack / Telegram 真机端到端验证（原因同上）。
- `pnpm lint` 全仓当前是红的（`packages/project-context/src/toc.ts` 的 `no-useless-escape` 等既有问题），属基线问题，未在本 PR 内修；本次改动的文件零 lint 报错。
- 未在 Windows 上实测。路径比较沿用既有口径：dispatcher 侧 `normalizePathForCompare`（`path.resolve` + win32 小写），`isKnownRecentWorkdir` / `authorityForDir` 按 `recent_workdirs` 已归一的 posix 形态比较并在 win32 下统一小写。
- 移动 UI 的改动没有实机点测（同上，功能 worktree 未启动实例）；两处调用点的类型与参数由 typecheck 与既有 renderer 单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：IM hook 的会话定位（Slack / Telegram 的 `task.dispatch` 复用路径）、`<userData>/hook-bindings.json` 的行结构、新增的 `local-db:sessions:move` IPC，以及两处移动 UI 的调用通道。

  本 PR 是**收紧**边界：合入后，工作目录映射之外的复用只认由窄口径 `sessions:move` 铸造的授权，而铸造要同时满足「来自 Cindy 主页面」与「目的地是用户已知项目」；通用 `sessions:update` 改 workingDir 不再产生任何授权，未经登记的目录变化一律按撤权处理。远端唯一能指定目录的接管路径（`payload.sessionId`）仍严格校验白名单。

  **残余面 1（需要维护者决定，见 [讨论](https://github.com/makecindy/cindy/pull/669#discussion_r3656738361)）**：目的地校验的信任根 `recent_workdirs` 本身可被通用 IPC 间接写入——`sessions:create` / `sessions:update` 会把 renderer 传来的 `workingDir` 经 `upsertRecentWorkdir()` 入表（sessions.ts:723 / 993）。因此被攻陷的主页面可以「先把任意目录喂进表，再调 move」而通过校验。这道闸是纵深防御（抬高成本、挡住直接指向 `~/.ssh` 这类路径，且已收紧到 realpath 比较），不是不可伪造的边界。

  彻底消除需要二选一，代价都超出本补送 PR 且不是纯工程取舍：(1) 移动时加 Main 原生确认框——真正不可伪造，但每次移动 IM 绑定的对话都多一次弹窗，属用户可见行为变更；(2) 给 `recent_workdirs` 加来源列、move 只认经 Main 原生目录框进表的行——需要 migration，且存量行无从判定来源（标 user-picked 等于保留今天的污染面，标 session 则让存量用户的跟随功能直接退化）。

  **残余面 2（已知取舍）**：目的地校验在移动那一刻做 `realpath`，但存储的是用户选的路径写法。若某个已知项目内的目录 symlink 在授权之后被改指到项目外，dispatcher 仍会按原字符串放行。彻底修需要 dispatcher 每次放行前做文件系统解析（会破坏它「纯逻辑模块、单测不碰 fs」的边界）或改存 canonical 路径（改变用户可见的工作目录写法）。攻击前提是能改用户项目内的 symlink——那已意味着能写该项目，而 agent 本来就在其中执行，故判定为可接受。

  在维护者拍板前，本 PR 相对 `main` 仍是**净收紧**：`main` 上当前是「任何 workingDir 变化都能推断出授权」，本 PR 收敛为「只有主页面发起的窄口径 move + realpath 校验过的已知项目目的地才铸造」。

  用户数据方面只是给 `hook-bindings.json` 每行增加 `noticePending` 字段（不含凭证），老文件原样可读。

- 回滚 / 降级方式：revert 本 PR 即可，无数据迁移；回滚后会退回 #653 合入版本的推断式判定（即本 PR 要修的边界问题）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`bindings.ts` 文件头写清了「为什么授权要由 Main 登记、不能从元数据反推」，`dispatcher.ts` 职责链注释与 `sessionMoves.ts` 文件头同步）
- [x] 已确认测试结果或说明未执行原因

