### PR TITLE
fix(maker-core): 修复 Codex 引用目录权限配置

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -357,7 +357,7 @@ function installFakeHost(
     threadHandlers = handlers;
     return { release: vi.fn() };
   });
-  const unsubscribeThread = vi.fn(async (_threadId: string) => {});
+  const unsubscribeThread = vi.fn(async () => {});
   const isCodexProxyActive = vi.fn(() => opts.codexProxyActive === true);
   const getRemoteCompactionProviderId = vi.fn(() => opts.remoteCompactionProviderId ?? null);
   const host = {
@@ -404,7 +404,7 @@ describe('CodexAgent permissions', () => {
 describe('CodexAgent reference directories', () => {
   const profileName = 'cindy-readonly-references';
 
-  it('keeps reference roots read-only on thread/start and every turn', async () => {
+  it('keeps the thread-level reference profile active without repeating it on turn/start', async () => {
     const agent = new CodexAgent(createDeps());
     let turnSeq = 0;
     const host = installFakeHost(
@@ -458,7 +458,7 @@ describe('CodexAgent reference directories', () => {
     );
     const [, firstTurn] = turnCalls()[0] as [string, Record<string, unknown>];
     expect(firstTurn.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-a']);
-    expect(firstTurn.permissions).toBe(profileName);
+    expect('permissions' in firstTurn).toBe(false);
     expect('sandboxPolicy' in firstTurn).toBe(false);
 
     const handlers = host.getThreadHandlers();
@@ -472,7 +472,8 @@ describe('CodexAgent reference directories', () => {
     await handle.send({ type: 'user', content: 'use the replacement reference' });
     const [, secondTurn] = turnCalls()[1] as [string, Record<string, unknown>];
     expect(secondTurn.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-b']);
-    expect(secondTurn.permissions).toBe(profileName);
+    expect('permissions' in secondTurn).toBe(false);
+    expect('sandboxPolicy' in secondTurn).toBe(false);
     handlers.turnCompleted?.({
       threadId: 'start-thread-id',
       turn: { id: 'turn-2', status: 'completed' },
@@ -499,6 +500,615 @@ describe('CodexAgent reference directories', () => {
       type: 'workspaceWrite',
       writableRoots: ['/tmp/mock-codex-home/memories'],
     });
+    await handle.close();
+  });
+
+  it('replaces an unused thread instead of resuming before its first rollout exists', async () => {
+    const agent = new CodexAgent(createDeps());
+    let threadStartSeq = 0;
+    const host = installFakeHost(
+      agent,
+      (method) => {
+        if (method === Method.ThreadStart) {
+          return {
+            thread: { id: `start-thread-${++threadStartSeq}` },
+            model: 'gpt-5.4',
+            modelProvider: 'openai',
+            cwd: '/repo',
+          };
+        }
+        if (method === Method.ThreadResume) {
+          throw new Error('no rollout found for thread id');
+        }
+        if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+        return undefined;
+      },
+      { codexHome: '/tmp/mock-codex-home' },
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-add-extra-dirs-before-first-turn',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      userPrompt: 'STABLE USER PROMPT',
+    });
+
+    await handle.setExtraDirs?.(['/shared-before-first-turn']);
+    await handle.send(
+      { type: 'user', content: 'use the reference on the first turn' },
+      { throwOnStartFailure: true },
+    );
+
+    const startCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.ThreadStart,
+    );
+    expect(startCalls).toHaveLength(2);
+    const [, initialStart] = startCalls[0] as [string, Record<string, unknown>];
+    const [, replacementStart] = startCalls[1] as [string, Record<string, unknown>];
+    expect(replacementStart.runtimeWorkspaceRoots).toEqual([
+      '/repo',
+      '/shared-before-first-turn',
+    ]);
+    expect(replacementStart.permissions).toBe(profileName);
+    expect(replacementStart.config).toHaveProperty(`permissions.${profileName}`);
+    expect(replacementStart.developerInstructions).toBe(initialStart.developerInstructions);
+    expect(replacementStart.dynamicTools).toEqual(initialStart.dynamicTools);
+    expect(host.request.mock.calls.filter(([method]) => method === Method.ThreadResume)).toHaveLength(0);
+    expect(handle.id).toBe('start-thread-2');
+    expect(host.subscribeThread).toHaveBeenLastCalledWith('start-thread-2', expect.any(Object));
+
+    const [, turnParams] = host.request.mock.calls.find(
+      ([method]) => method === Method.TurnStart,
+    ) as [string, Record<string, unknown>];
+    expect(turnParams.threadId).toBe('start-thread-2');
+    expect('permissions' in turnParams).toBe(false);
+    expect('sandboxPolicy' in turnParams).toBe(false);
+    await handle.close();
+  });
+
+  it('preserves a Fast mode toggle made while replacing an unused thread', async () => {
+    const agent = new CodexAgent(createDeps());
+    let threadStartCount = 0;
+    const replacementGate = deferred<{
+      thread: { id: string };
+      model: string;
+      modelProvider: string;
+      cwd: string;
+      serviceTier: null;
+    }>();
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ThreadStart) {
+        threadStartCount += 1;
+        if (threadStartCount === 2) return replacementGate.promise;
+      }
+      if (method === Method.ThreadSettingsUpdate) return {};
+      if (method === Method.TurnStart) return { turn: { id: 'turn-fast-replacement' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-fast-during-replacement',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+
+    await handle.setExtraDirs?.(['/shared-fast-replacement']);
+    const sendPromise = handle.send({ type: 'user', content: 'use fast mode' });
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.ThreadStart,
+      )).toHaveLength(2);
+    });
+    const bindingLeases = (
+      agent as unknown as { hostSessionBindingLeases: Map<string, number> }
+    ).hostSessionBindingLeases;
+    expect(bindingLeases.get('local')).toBe(1);
+
+    await handle.setFastMode?.(true);
+    replacementGate.resolve({
+      thread: { id: 'start-thread-2' },
+      model: 'gpt-5.4',
+      modelProvider: 'openai',
+      cwd: '/repo',
+      serviceTier: null,
+    });
+    await sendPromise;
+
+    expect(handle.getFastMode?.()).toBe(true);
+    const settingsCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.ThreadSettingsUpdate,
+    );
+    expect(settingsCalls.map(([, params]) => params)).toEqual([
+      { threadId: 'start-thread-id', serviceTier: 'fast' },
+      { threadId: 'start-thread-2', serviceTier: 'fast' },
+    ]);
+    const turnCall = host.request.mock.calls.find(
+      ([method]) => method === Method.TurnStart,
+    );
+    expect(turnCall?.[1]).toMatchObject({
+      threadId: 'start-thread-2',
+      serviceTier: 'fast',
+    });
+    expect(bindingLeases.has('local')).toBe(false);
+    await handle.close();
+  });
+
+  it('cancels a pending unused-thread replacement before turn/start', async () => {
+    const agent = new CodexAgent(createDeps());
+    let threadStartCount = 0;
+    const replacementGate = deferred<{
+      thread: { id: string };
+      model: string;
+      modelProvider: string;
+      cwd: string;
+    }>();
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ThreadStart) {
+        threadStartCount += 1;
+        if (threadStartCount === 2) return replacementGate.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-cancel-unused-replacement',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+
+    await handle.setExtraDirs?.(['/shared-cancel-replacement']);
+    const controller = new AbortController();
+    const sendPromise = handle.send(
+      { type: 'user', content: 'cancel unused replacement' },
+      { signal: controller.signal, throwOnStartFailure: true },
+    );
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.ThreadStart,
+      )).toHaveLength(2);
+    });
+    controller.abort();
+
+    await expect(sendPromise).rejects.toThrow(/send cancelled before acceptance/i);
+    replacementGate.resolve({
+      thread: { id: 'start-thread-2' },
+      model: 'gpt-5.4',
+      modelProvider: 'openai',
+      cwd: '/repo',
+    });
+    await waitForExpectation(() => {
+      expect(host.unsubscribeThread).toHaveBeenCalledWith('start-thread-2');
+    });
+    expect(host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    )).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('times out an unused-thread replacement before turn/start', async () => {
+    const agent = new CodexAgent(createDeps());
+    let threadStartCount = 0;
+    const replacementGate = deferred<{
+      thread: { id: string };
+      model: string;
+      modelProvider: string;
+      cwd: string;
+    }>();
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ThreadStart) {
+        threadStartCount += 1;
+        if (threadStartCount === 2) return replacementGate.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-timeout-unused-replacement',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    await handle.setExtraDirs?.(['/shared-timeout-replacement']);
+
+    vi.useFakeTimers();
+    try {
+      const sendPromise = handle.send(
+        { type: 'user', content: 'time out unused replacement' },
+        { throwOnStartFailure: true },
+      );
+      const failure = expect(sendPromise).rejects.toThrow(
+        /profile replacement did not acknowledge within 10000ms/i,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.ThreadStart,
+      )).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await failure;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    replacementGate.resolve({
+      thread: { id: 'start-thread-2' },
+      model: 'gpt-5.4',
+      modelProvider: 'openai',
+      cwd: '/repo',
+    });
+    await waitForExpectation(() => {
+      expect(host.unsubscribeThread).toHaveBeenCalledWith('start-thread-2');
+    });
+    expect(host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    )).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('discards an unused replacement when close races with subscription release', async () => {
+    const agent = new CodexAgent(createDeps());
+    let threadStartSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ThreadStart) {
+        return {
+          thread: { id: `start-thread-${++threadStartSeq}` },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          cwd: '/repo',
+        };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-unused-replacement-close-race',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+
+    let resolveRelease: (() => void) | undefined;
+    const releaseGate = new Promise<void>((resolve) => {
+      resolveRelease = resolve;
+    });
+    const initialSubscription = host.subscribeThread.mock.results[0]?.value;
+    const release = initialSubscription?.release;
+    if (!release) throw new Error('expected initial subscription');
+    release.mockImplementation(() => releaseGate);
+
+    await handle.setExtraDirs?.(['/shared-before-first-turn']);
+    const sendPromise = handle.send(
+      { type: 'user', content: 'use the reference on the first turn' },
+      { throwOnStartFailure: true },
+    );
+    await waitForExpectation(() => expect(release).toHaveBeenCalledTimes(1));
+    const closePromise = handle.close();
+    await waitForExpectation(() => expect(release).toHaveBeenCalledTimes(2));
+    resolveRelease?.();
+
+    await expect(sendPromise).rejects.toThrow(
+      /closed during read-only reference profile replacement/i,
+    );
+    await closePromise;
+    expect(host.subscribeThread).toHaveBeenCalledTimes(1);
+    expect(host.unsubscribeThread).toHaveBeenCalledWith('start-thread-2');
+  });
+
+  it('restores the thread-level profile before using references added after an earlier turn', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(
+      agent,
+      (method) => {
+        if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
+        return undefined;
+      },
+      { codexHome: '/tmp/mock-codex-home' },
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-add-extra-dirs',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+
+    await handle.send({ type: 'user', content: 'start without references' });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+
+    await handle.setExtraDirs?.(['/shared-added']);
+    await handle.send({ type: 'user', content: 'use the new reference' });
+
+    const resumeCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.ThreadResume,
+    );
+    expect(resumeCalls).toHaveLength(1);
+    const [, resumeParams] = resumeCalls[0] as [string, Record<string, unknown>];
+    expect(resumeParams.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-added']);
+    expect(resumeParams.permissions).toBe(profileName);
+    expect(resumeParams.config).toHaveProperty(`permissions.${profileName}`);
+
+    const turnCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    );
+    const [, turnParams] = turnCalls[1] as [string, Record<string, unknown>];
+    expect(turnParams.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-added']);
+    expect('permissions' in turnParams).toBe(false);
+    expect('sandboxPolicy' in turnParams).toBe(false);
+    await handle.close();
+  });
+
+  it('restores the thread-level profile after Full access before the next reference turn', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(
+      agent,
+      (method) => {
+        if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
+        return undefined;
+      },
+      {
+        codexHome: '/tmp/mock-codex-home',
+        remoteCompactionProviderId: 'cindy_openai',
+      },
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-restore-after-bypass',
+      model: 'gpt-5.4',
+      providerId: 'openai',
+      fastMode: true,
+      workingDir: '/repo',
+      extraDirs: ['/shared-a'],
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+
+    await handle.setPermissionMode?.('bypassPermissions');
+    await handle.send({ type: 'user', content: 'run with full access' });
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+
+    await handle.setPermissionMode?.('ask');
+    await handle.send({ type: 'user', content: 'return to read-only references' });
+
+    const resumeCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.ThreadResume,
+    );
+    expect(resumeCalls).toHaveLength(1);
+    const [, resumeParams] = resumeCalls[0] as [string, Record<string, unknown>];
+    expect(resumeParams.permissions).toBe(profileName);
+    expect(resumeParams.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-a']);
+    expect(resumeParams.modelProvider).toBe('cindy_openai');
+    expect(resumeParams.model).toBe('gpt-5.4');
+    expect(resumeParams.serviceTier).toBe('fast');
+
+    const turnCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    );
+    const [, askTurn] = turnCalls[1] as [string, Record<string, unknown>];
+    expect('permissions' in askTurn).toBe(false);
+    expect('sandboxPolicy' in askTurn).toBe(false);
+    await handle.close();
+  });
+
+  it('preserves a Fast mode toggle made while profile resume is pending', async () => {
+    const agent = new CodexAgent(createDeps());
+    const profileResumeGate = deferred<{
+      thread: { id: string };
+      model: string;
+      modelProvider: string;
+      cwd: string;
+      serviceTier: null;
+    }>();
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
+      if (method === Method.ThreadResume) return profileResumeGate.promise;
+      if (method === Method.ThreadSettingsUpdate) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-fast-during-profile-resume',
+      model: 'gpt-5.4',
+      fastMode: false,
+      workingDir: '/repo',
+      extraDirs: ['/shared-profile-resume'],
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+
+    await handle.setPermissionMode?.('bypassPermissions');
+    await handle.send({ type: 'user', content: 'run with full access' });
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+
+    await handle.setPermissionMode?.('ask');
+    const sendPromise = handle.send({ type: 'user', content: 'restore with fast mode' });
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.ThreadResume,
+      )).toHaveLength(1);
+    });
+    await handle.setFastMode?.(true);
+    profileResumeGate.resolve({
+      thread: { id: 'start-thread-id' },
+      model: 'gpt-5.4',
+      modelProvider: 'openai',
+      cwd: '/repo',
+      serviceTier: null,
+    });
+    await sendPromise;
+
+    expect(handle.getFastMode?.()).toBe(true);
+    const settingsCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.ThreadSettingsUpdate,
+    );
+    expect(settingsCalls.map(([, params]) => params)).toEqual([
+      { threadId: 'start-thread-id', serviceTier: 'fast' },
+      { threadId: 'start-thread-id', serviceTier: 'fast' },
+    ]);
+    const turnCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    );
+    expect(turnCalls[1]?.[1]).toMatchObject({
+      threadId: 'start-thread-id',
+      serviceTier: 'fast',
+    });
+    await handle.close();
+  });
+
+  it('cancels a pending profile refresh before turn/start', async () => {
+    const agent = new CodexAgent(createDeps());
+    const profileResumeGate = deferred<{
+      thread: { id: string };
+      model: string;
+      modelProvider: string;
+      cwd: string;
+    }>();
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
+      if (method === Method.ThreadResume) return profileResumeGate.promise;
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-cancel-profile-resume',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      extraDirs: ['/shared-cancel-resume'],
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+
+    await handle.setPermissionMode?.('bypassPermissions');
+    await handle.send({ type: 'user', content: 'run with full access' });
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+
+    await handle.setPermissionMode?.('ask');
+    const controller = new AbortController();
+    const sendPromise = handle.send(
+      { type: 'user', content: 'cancel profile refresh' },
+      { signal: controller.signal, throwOnStartFailure: true },
+    );
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.ThreadResume,
+      )).toHaveLength(1);
+    });
+    controller.abort();
+
+    await expect(sendPromise).rejects.toThrow(/send cancelled before acceptance/i);
+    expect(host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    )).toHaveLength(1);
+    profileResumeGate.resolve({
+      thread: { id: 'start-thread-id' },
+      model: 'gpt-5.4',
+      modelProvider: 'openai',
+      cwd: '/repo',
+    });
+    await handle.close();
+  });
+
+  it('times out a profile refresh before turn/start', async () => {
+    const agent = new CodexAgent(createDeps());
+    const profileResumeGate = deferred<never>();
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
+      if (method === Method.ThreadResume) return profileResumeGate.promise;
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-timeout-profile-resume',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      extraDirs: ['/shared-timeout-resume'],
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+
+    await handle.setPermissionMode?.('bypassPermissions');
+    await handle.send({ type: 'user', content: 'run with full access' });
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await handle.setPermissionMode?.('ask');
+
+    vi.useFakeTimers();
+    try {
+      const sendPromise = handle.send(
+        { type: 'user', content: 'time out profile refresh' },
+        { throwOnStartFailure: true },
+      );
+      const failure = expect(sendPromise).rejects.toThrow(
+        /profile refresh did not acknowledge within 10000ms/i,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.ThreadResume,
+      )).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await failure;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    )).toHaveLength(1);
+    await handle.close();
+  });
+
+  it('refreshes the profile after thread/rollback replaces the active thread', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(
+      agent,
+      (method) => {
+        if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
+        return undefined;
+      },
+      { codexHome: '/tmp/mock-codex-home' },
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-reference-dirs-rollback',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      extraDirs: ['/shared-rollback'],
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+
+    await handle.send({ type: 'user', content: 'create a persisted rollout' });
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    const commitRewindFiles = handle.commitRewindFiles;
+    if (!commitRewindFiles) throw new Error('expected commitRewindFiles');
+    await commitRewindFiles('', '', { tailTurnsToDrop: 1 });
+
+    await handle.send({ type: 'user', content: 'continue after rollback' });
+
+    const resumeCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.ThreadResume,
+    );
+    expect(resumeCalls).toHaveLength(1);
+    const [, resumeParams] = resumeCalls[0] as [string, Record<string, unknown>];
+    expect(resumeParams.threadId).toBe('rollback-thread-id');
+    expect(resumeParams.permissions).toBe(profileName);
+    expect(resumeParams.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-rollback']);
+
+    const turnCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    );
+    const [, turnParams] = turnCalls[1] as [string, Record<string, unknown>];
+    expect(turnParams.threadId).toBe('rollback-thread-id');
+    expect('permissions' in turnParams).toBe(false);
     await handle.close();
   });
 
@@ -558,9 +1168,77 @@ describe('CodexAgent reference directories', () => {
     expect(turnCalls).toHaveLength(2);
     for (const [, params] of turnCalls as Array<[string, Record<string, unknown>]>) {
       expect(params.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-retry']);
-      expect(params.permissions).toBe(profileName);
+      expect('permissions' in params).toBe(false);
       expect('sandboxPolicy' in params).toBe(false);
     }
+    await handle.close();
+  });
+
+  it('retries a stale reference turn with its frozen permission profile', async () => {
+    const agent = new CodexAgent(createDeps());
+    const firstTurnGate = deferred<never>();
+    let turnStartCount = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnStartCount += 1;
+        if (turnStartCount === 1) return firstTurnGate.promise;
+        return { turn: { id: 'turn-frozen-reference-retry' } };
+      }
+      if (method === Method.ThreadResume) {
+        return {
+          thread: { id: 'start-thread-id' },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          cwd: '/repo',
+        };
+      }
+      if (method === Method.ThreadSettingsUpdate) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-frozen-reference-retry',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      extraDirs: ['/shared-frozen-turn'],
+    });
+
+    const sendPromise = handle.send({ type: 'user', content: 'retry safely' });
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.TurnStart,
+      )).toHaveLength(1);
+    });
+    await handle.setExtraDirs?.([]);
+    await handle.setModel?.('gpt-5.5');
+    await handle.setFastMode?.(true);
+    firstTurnGate.reject(new Error('thread not found'));
+    await sendPromise;
+
+    const [, resumeParams] = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadResume,
+    ) as [string, Record<string, unknown>];
+    expect(resumeParams).toMatchObject({
+      threadId: 'start-thread-id',
+      runtimeWorkspaceRoots: ['/repo', '/shared-frozen-turn'],
+      permissions: profileName,
+      approvalPolicy: 'on-request',
+      model: 'gpt-5.5',
+      serviceTier: 'fast',
+    });
+    expect('sandbox' in resumeParams).toBe(false);
+
+    const turnCalls = host.request.mock.calls.filter(
+      ([method]) => method === Method.TurnStart,
+    );
+    expect(turnCalls).toHaveLength(2);
+    for (const [, params] of turnCalls as Array<[string, Record<string, unknown>]>) {
+      expect(params.runtimeWorkspaceRoots).toEqual(['/repo', '/shared-frozen-turn']);
+      expect('sandboxPolicy' in params).toBe(false);
+    }
+    expect(turnCalls[1]?.[1]).toMatchObject({
+      model: 'gpt-5.5',
+      serviceTier: 'fast',
+    });
     await handle.close();
   });
 
@@ -7044,39 +7722,59 @@ describe('CodexAgent plan mode', () => {
     await handle.close();
   });
 
-  it('emits a terminal event and ends the plan cycle when the revision turn cannot start', async () => {
+  it('emits a terminal event and ends the plan cycle when revision profile restoration fails', async () => {
     const agent = new CodexAgent(createDeps());
     let turnSeq = 0;
+    let resumeSeq = 0;
     const host = installFakeHost(agent, (method) => {
       if (method === Method.TurnStart) {
         turnSeq += 1;
-        if (turnSeq === 2) {
-          throw new Error('Codex send cannot be accepted: stale host before turn/start');
-        }
         return { turn: { id: `turn-${turnSeq}` } };
+      }
+      if (method === Method.ThreadResume) {
+        resumeSeq += 1;
+        if (resumeSeq === 1) throw new Error('profile refresh failed');
+        return {
+          thread: { id: 'start-thread-id' },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          cwd: '/repo',
+        };
       }
       return undefined;
     });
-    const handle = await startPlanSession(agent, host, 'session-plan-revision-start-fails');
+    const handle = await agent.startSession({
+      sessionId: 'session-plan-revision-profile-refresh-fails',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      extraDirs: ['/shared-plan-refresh'],
+      planMode: true,
+    });
     const iterator = handle.events()[Symbol.asyncIterator]();
-    handle.setInteractionResolver(async () => ({
-      kind: 'plan_review',
-      behavior: 'deny',
-      reason: '先补测试',
-    }));
+    handle.setInteractionResolver(async () => {
+      await handle.setPermissionMode?.('ask');
+      return {
+        kind: 'plan_review',
+        behavior: 'deny',
+        reason: '先补测试',
+      };
+    });
 
+    await handle.setPermissionMode?.('bypassPermissions');
     await handle.send({ type: 'user', content: 'make a plan' });
     runPlanTurn(host, 'turn-1', '1. do X');
 
     await vi.waitFor(() => {
-      expect(turnStartCalls(host)).toHaveLength(2);
+      expect(host.request.mock.calls.filter(
+        ([method]) => method === Method.ThreadResume,
+      )).toHaveLength(1);
     });
     let sawTerminalError = false;
     for (let i = 0; i < 30 && !sawTerminalError; i++) {
       const ev = await nextEvent(iterator);
       if (ev.type === 'error') {
         expect(ev.data).toMatchObject({
-          message: expect.stringContaining('plan revision turn failed to start'),
+          message: expect.stringContaining('Failed to restore Codex read-only reference permissions'),
           isTerminal: true,
         });
         sawTerminalError = true;
@@ -7089,7 +7787,7 @@ describe('CodexAgent plan mode', () => {
     });
 
     await handle.send({ type: 'user', content: 'continue normally' });
-    const [, nextParams] = turnStartCalls(host)[2] as [string, Record<string, unknown>];
+    const [, nextParams] = turnStartCalls(host)[1] as [string, Record<string, unknown>];
     expect((nextParams.collaborationMode as { mode?: string } | undefined)?.mode).not.toBe('plan');
     await handle.close();
   });

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -641,6 +641,12 @@ const STEER_ACK_TIMEOUT_MS = 10_000;
 // 免审 turn 将无声继续跑 (review #969 第六轮 Greptile P1)。取值与 steer 同款 10s。
 const TIGHTEN_INTERRUPT_ACK_TIMEOUT_MS = 10_000;
 
+// Permission profile refresh / replacement runs before turn/start and therefore
+// sits on the message acceptance path. Keep its app-server acknowledgement
+// bounded so a live-but-unresponsive daemon cannot freeze the queued message or
+// ignore Stop.
+const PROFILE_LIFECYCLE_ACK_TIMEOUT_MS = 10_000;
+
 // 计划批准后自动发起实施 turn 的固定输入 — 与官方 TUI 逐字一致
 // (codex-rs/tui/src/chatwidget/plan_implementation.rs 的
 // PLAN_IMPLEMENTATION_CODING_MESSAGE), 模型对这句有训练分布上的既有理解。
@@ -2011,6 +2017,15 @@ export class CodexAgent extends BaseAgent {
     let mutableEffort: Effort = opts.effort ?? 'high';
     let mutablePermissionMode: PermissionMode = opts.permissionMode ?? 'ask';
     let mutableExtraDirs = [...(opts.extraDirs ?? [])];
+    // Named profiles defined through thread/start.config are thread-local. Codex
+    // 0.145.0 cannot resolve that thread-local definition when the selector is
+    // repeated on turn/start, so remember whether the thread is already using it.
+    let readonlyReferencesProfileActive = false;
+    // A fresh thread/start has no rollout yet, so thread/resume fails until a
+    // turn/start may have crossed the server acceptance boundary. Once a turn
+    // was attempted, prefer resume before replacing the thread; "no rollout"
+    // is the only safe proof that the thread is still unused.
+    let threadMayHaveRollout = false;
     // 计划模式(与 permissionMode 正交, **一次性选择**): mutablePlanMode 是 UI 勾选的
     // "武装"态 —— send 消耗它并立即 emit plan_mode_changed(false) 让勾选熄灭;
     // 本轮「计划 → 审阅 → 修订/批准」循环由 planCycleActive 承载:
@@ -2025,11 +2040,22 @@ export class CodexAgent extends BaseAgent {
     let planModeDefaultMarkerNeeded = false;
     // 当前 plan turn 流出的 proposed plan 文本 (plan item / <proposed_plan> 块)。
     let proposedPlanText: string | null = null;
+    const endPlanCycleAfterPreStartFailure = (reason: string): void => {
+      if (!planCycleActive) return;
+      planCycleActive = false;
+      proposedPlanText = null;
+      currentTurnPlanModeActive = false;
+      pendingTurnStartPlanMode = null;
+      log.debug(`${reason} during plan cycle — plan cycle ends`);
+    };
     // plan_review requestId 去重序号 (同一 turn 理论上只有一个 plan item, 防御性加序号)。
     let planReviewSeq = 0;
     // Undefined = 不覆盖 app-server/config 默认; null = explicit standard; 'fast' = Fast mode.
     let mutableServiceTier: ServiceTier | null | undefined =
       opts.fastMode === undefined ? undefined : opts.fastMode ? 'fast' : null;
+    // Older async thread start/resume responses must not overwrite a newer
+    // Fast mode choice made while the request was in flight.
+    let serviceTierMutationGeneration = 0;
     const vo: Record<string, unknown> = { ...(opts.vendorOptions ?? {}) };
     const credentialMode = opts.remoteHostId
       ? undefined
@@ -2216,6 +2242,14 @@ export class CodexAgent extends BaseAgent {
       return mapPermissionToCodex(mutablePermissionMode, approvalsReviewerSupported);
     }
 
+    function shouldUseReadonlyReferencesProfile(): boolean {
+      return (
+        readonlyReferenceDirsSupported &&
+        mutableExtraDirs.length > 0 &&
+        mutablePermissionMode !== 'bypassPermissions'
+      );
+    }
+
     function currentThreadWorkspaceConfig(): Pick<
       ThreadStartParams,
       | 'approvalPolicy'
@@ -2236,11 +2270,7 @@ export class CodexAgent extends BaseAgent {
             }
           : {}),
       };
-      if (
-        readonlyReferenceDirsSupported &&
-        mutableExtraDirs.length > 0 &&
-        mutablePermissionMode !== 'bypassPermissions'
-      ) {
+      if (shouldUseReadonlyReferencesProfile()) {
         return {
           ...shared,
           permissions: READONLY_REFERENCES_PERMISSION_PROFILE,
@@ -2254,7 +2284,6 @@ export class CodexAgent extends BaseAgent {
       | 'approvalPolicy'
       | 'approvalsReviewer'
       | 'sandboxPolicy'
-      | 'permissions'
       | 'runtimeWorkspaceRoots'
     > {
       const { approvalPolicy, approvalsReviewer, sandbox } = currentApprovalConfig();
@@ -2265,15 +2294,17 @@ export class CodexAgent extends BaseAgent {
           ? { runtimeWorkspaceRoots: runtimeWorkspaceRoots() }
           : {}),
       };
-      if (
-        readonlyReferenceDirsSupported &&
-        mutableExtraDirs.length > 0 &&
-        mutablePermissionMode !== 'bypassPermissions'
-      ) {
-        return {
-          ...shared,
-          permissions: READONLY_REFERENCES_PERMISSION_PROFILE,
-        };
+      if (shouldUseReadonlyReferencesProfile()) {
+        // The profile was selected on thread/start or thread/resume. Repeating
+        // the selector here makes Codex 0.145.0 reload its base config (which
+        // does not contain our per-thread definition) and reject turn/start
+        // with "default_permissions requires a `[permissions]` table".
+        if (!readonlyReferencesProfileActive) {
+          throw new Error(
+            'Codex read-only reference profile is not active for this thread; restore it with thread/resume before turn/start',
+          );
+        }
+        return shared;
       }
       return {
         ...shared,
@@ -2389,6 +2420,13 @@ export class CodexAgent extends BaseAgent {
         resumeSessionId: opts.resumeSessionId,
       });
     }
+    const developerInstructions = buildCodexDeveloperInstructions({
+      makerMemoryRules,
+      runtimeSystemPrompt: this.deps.runtimeConfig.systemPrompt,
+      makerMemoryIndex,
+      userPrompt: opts.userPrompt,
+    });
+    const useProxyChannel = isCodexProxyChannelReady();
     let threadId: string;
     let codexProductPromptDelivery: AgentSessionHandle['codexProductPromptDelivery'];
 
@@ -2444,13 +2482,6 @@ export class CodexAgent extends BaseAgent {
           });
         }
       }
-      const developerInstructions = buildCodexDeveloperInstructions({
-        makerMemoryRules,
-        runtimeSystemPrompt: this.deps.runtimeConfig.systemPrompt,
-        makerMemoryIndex,
-        userPrompt: opts.userPrompt,
-      });
-      const useProxyChannel = isCodexProxyChannelReady();
       const params: ThreadResumeParams = {
         threadId: opts.resumeSessionId,
         ...(resumeExcludeTurnsSupported ? { excludeTurns: true } : {}),
@@ -2482,6 +2513,8 @@ export class CodexAgent extends BaseAgent {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: true };
         }
         sdkSessionId = threadId;
+        readonlyReferencesProfileActive = shouldUseReadonlyReferencesProfile();
+        threadMayHaveRollout = true;
         // Resumed app-server threads may have sticky collaborationMode='plan' from
         // a previous handle whose plan cycle ended without a follow-up turn. Since
         // that sticky state lives server-side, conservatively send mode:'default'
@@ -2515,13 +2548,6 @@ export class CodexAgent extends BaseAgent {
       //                                          每次 startSession 透传, 优先级最高)
       // 跟 claude-code 六段语义对齐。空段被 .filter 跳过,
       // 内容为空时不发送 developerInstructions 字段。
-      const developerInstructions = buildCodexDeveloperInstructions({
-        makerMemoryRules,
-        runtimeSystemPrompt: this.deps.runtimeConfig.systemPrompt,
-        makerMemoryIndex,
-        userPrompt: opts.userPrompt,
-      });
-      const useProxyChannel = isCodexProxyChannelReady();
       const params: ThreadStartParams = {
         cwd: opts.workingDir,
         ...currentThreadWorkspaceConfig(),
@@ -2547,6 +2573,8 @@ export class CodexAgent extends BaseAgent {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: true };
         }
         sdkSessionId = threadId;
+        readonlyReferencesProfileActive = shouldUseReadonlyReferencesProfile();
+        threadMayHaveRollout = false;
         log.info('thread/start ok', { threadId, model: resp.model, serviceTier: mutableServiceTier ?? null });
       } catch (e) {
         releaseHostBindingLeaseIfNeeded();
@@ -2561,6 +2589,241 @@ export class CodexAgent extends BaseAgent {
         throw new Error(message);
       }
     }
+
+    const requestProfileLifecycle = <Response>({
+      action,
+      signal,
+      request,
+      onLateResolve,
+    }: {
+      action: 'refresh' | 'replacement';
+      signal?: AbortSignal;
+      request: () => Promise<Response>;
+      onLateResolve?: (response: Response) => Promise<void> | void;
+    }): Promise<Response> =>
+      new Promise<Response>((resolve, reject) => {
+        let settled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        const cleanup = () => {
+          if (timer) clearTimeout(timer);
+          signal?.removeEventListener('abort', onAbort);
+        };
+        const resolveOnce = (value: Response) => {
+          if (settled) {
+            if (onLateResolve) {
+              void Promise.resolve(onLateResolve(value)).catch((error) => {
+                log.warn(`late read-only reference profile ${action} cleanup threw`, {
+                  error: String(error),
+                  threadId,
+                });
+              });
+            }
+            return;
+          }
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+        const rejectOnce = (error: Error) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          reject(error);
+        };
+        const onAbort = () => {
+          rejectOnce(new Error('Codex send cancelled before acceptance'));
+        };
+        signal?.addEventListener('abort', onAbort, { once: true });
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        timer = setTimeout(() => {
+          rejectOnce(
+            new Error(
+              `Codex read-only reference profile ${action} did not acknowledge within ${PROFILE_LIFECYCLE_ACK_TIMEOUT_MS}ms`,
+            ),
+          );
+        }, PROFILE_LIFECYCLE_ACK_TIMEOUT_MS);
+        timer.unref?.();
+        try {
+          request().then(
+            resolveOnce,
+            (error) => rejectOnce(
+              error instanceof Error ? error : new Error(String(error)),
+            ),
+          );
+        } catch (error) {
+          rejectOnce(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+
+    /**
+     * A thread that has not accepted a turn has no rollout and cannot be
+     * resumed. Recreate that unused thread with the current profile instead,
+     * then move the live subscription and thread-scoped registrations.
+     */
+    const replaceUnusedThreadWithCurrentProfile = async (
+      signal?: AbortSignal,
+    ): Promise<void> => {
+      const previousThreadId = threadId;
+      const replacementServiceTierGeneration = serviceTierMutationGeneration;
+      const inheritedHostBindingLease = releaseHostBindingLease !== null;
+      acquireHostBindingLeaseIfNeeded();
+      try {
+        assertCurrentHost('read-only reference profile replacement');
+        const resp = await requestProfileLifecycle<ThreadStartResponse>({
+          action: 'replacement',
+          signal,
+          request: () => host.request<ThreadStartResponse>(Method.ThreadStart, {
+            cwd: opts.workingDir,
+            ...currentThreadWorkspaceConfig(),
+            ...(shouldRegisterAskUserDynamicTool(opts) ? { dynamicTools: [ASK_USER_DYNAMIC_TOOL] } : {}),
+            ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
+            ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
+            ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
+            ...(developerInstructions && !useProxyChannel ? { developerInstructions } : {}),
+          }),
+          onLateResolve: async (lateResp) => {
+            const lateThreadId = lateResp.thread.id;
+            if (lateThreadId === previousThreadId) return;
+            await host.unsubscribeThread(lateThreadId);
+            log.debug('discarded late unused profile replacement', {
+              previousThreadId,
+              threadId: lateThreadId,
+            });
+          },
+        });
+        assertCurrentHost('read-only reference profile replacement');
+        const nextThreadId = resp.thread.id;
+        if (closed) {
+          try {
+            await host.unsubscribeThread(nextThreadId);
+          } catch (e) {
+            log.warn('unused profile replacement cleanup threw after close', {
+              error: String(e),
+              threadId: nextThreadId,
+            });
+          }
+          throw new Error('Codex session closed during read-only reference profile replacement');
+        }
+        if (
+          Object.hasOwn(resp, 'serviceTier') &&
+          replacementServiceTierGeneration === serviceTierMutationGeneration
+        ) {
+          mutableServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
+        }
+        if (nextThreadId !== previousThreadId) {
+          try {
+            await subscription?.release();
+          } catch (e) {
+            log.warn('unused profile replacement release threw', {
+              error: String(e),
+              threadId: previousThreadId,
+            });
+          }
+          unregisterCodexMcpContext(previousThreadId);
+          if (closed) {
+            try {
+              await host.unsubscribeThread(nextThreadId);
+            } catch (e) {
+              log.warn('unused profile replacement cleanup threw after concurrent close', {
+                error: String(e),
+                threadId: nextThreadId,
+              });
+            }
+            throw new Error('Codex session closed during read-only reference profile replacement');
+          }
+          threadId = nextThreadId;
+          sdkSessionId = nextThreadId;
+          subscription = host.subscribeThread(threadId, handlers);
+          registerCodexMcpContext(threadId);
+          eventQueue.push({ type: 'session_id', data: sdkSessionId, source: 'codex' });
+          if (replacementServiceTierGeneration !== serviceTierMutationGeneration) {
+            // setFastMode() updated the old thread while thread/start was
+            // pending. turn/start still carries the current value; reapply the
+            // sticky thread setting without blocking dispatch.
+            void pushThreadSettings({ serviceTier: mutableServiceTier ?? null });
+          }
+        }
+        if (useProxyChannel) {
+          registerCodexDeveloperInstructions(threadId, developerInstructions);
+          codexProductPromptDelivery = { threadId, historyHasProductPrompt: false };
+        } else {
+          codexProductPromptDelivery = developerInstructions
+            ? { threadId, historyHasProductPrompt: true }
+            : undefined;
+        }
+        readonlyReferencesProfileActive = shouldUseReadonlyReferencesProfile();
+        threadMayHaveRollout = false;
+        log.debug('unused thread replaced with read-only reference profile', {
+          previousThreadId,
+          threadId,
+          referenceRoots: mutableExtraDirs.length,
+        });
+      } finally {
+        if (!inheritedHostBindingLease) releaseHostBindingLeaseIfNeeded();
+      }
+    };
+
+    /**
+     * turn/start cannot select a profile that only exists in this thread's
+     * per-request config. Most turns simply inherit the profile selected by
+     * thread/start. A live thread only needs a refresh after it previously used
+     * a sandboxPolicy (for example Full access), or when references are added
+     * to a thread that started without them.
+     */
+    const ensureReadonlyReferencesProfileForNextTurn = (
+      signal?: AbortSignal,
+    ): Promise<void> | null => {
+      if (!shouldUseReadonlyReferencesProfile() || readonlyReferencesProfileActive) return null;
+      return (async () => {
+        if (!threadMayHaveRollout) {
+          await replaceUnusedThreadWithCurrentProfile(signal);
+          return;
+        }
+        const resumeThreadWorkspaceConfig = currentThreadWorkspaceConfig();
+        const resumeServiceTierGeneration = serviceTierMutationGeneration;
+        assertCurrentHost('read-only reference profile refresh');
+        let resp: ThreadResumeResponse;
+        try {
+          resp = await requestProfileLifecycle<ThreadResumeResponse>({
+            action: 'refresh',
+            signal,
+            request: () => host.request<ThreadResumeResponse>(Method.ThreadResume, {
+              threadId,
+              ...(resumeExcludeTurnsSupported ? { excludeTurns: true } : {}),
+              cwd: opts.workingDir,
+              ...resumeThreadWorkspaceConfig,
+              ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
+              ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
+              ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
+            }),
+          });
+        } catch (e) {
+          if (!/no rollout found/i.test(String(e))) throw e;
+          if (signal?.aborted) throw new Error('Codex send cancelled before acceptance');
+          threadMayHaveRollout = false;
+          await replaceUnusedThreadWithCurrentProfile(signal);
+          return;
+        }
+        assertCurrentHost('read-only reference profile refresh');
+        if (
+          Object.hasOwn(resp, 'serviceTier') &&
+          resumeServiceTierGeneration === serviceTierMutationGeneration
+        ) {
+          mutableServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
+        } else if (resumeServiceTierGeneration !== serviceTierMutationGeneration) {
+          void pushThreadSettings({ serviceTier: mutableServiceTier ?? null });
+        }
+        readonlyReferencesProfileActive = 'permissions' in resumeThreadWorkspaceConfig;
+        threadMayHaveRollout = true;
+        log.debug('read-only reference profile restored before turn/start', {
+          threadId,
+          referenceRoots: mutableExtraDirs.length,
+        });
+      })();
+    };
 
     // ── dispatchInteraction + pendingApprovals (Claude 同款 dismissAllPending 模式) ──
     //
@@ -3751,6 +4014,7 @@ export class CodexAgent extends BaseAgent {
         if (shouldIgnoreStaleTurnEvent(params.turn.id)) return;
         // 终态已先到的 turn (墓碑) 不得被乱序晚到的 started 重新置活。
         if (turnsCompletedBeforeStartResp.has(params.turn.id)) return;
+        threadMayHaveRollout = true;
         const wasSameTurn = currentTurnId === params.turn.id;
         currentTurnId = params.turn.id;
         isTurnInFlight = true;
@@ -4025,16 +4289,48 @@ export class CodexAgent extends BaseAgent {
         });
 
         // Phase 3: 把 mutable 配置每 turn 透传 — server 接受 per-turn 覆盖。
-        // **关键**: 无引用目录时用 sandboxPolicy: SandboxPolicy；有引用目录时改用
-        // named permissions profile，两者不能同时发送。turn/start 的 legacy 字段也不是
-        // thread/start 的 sandbox: SandboxMode，写错 server 会直接忽略。
+        // **关键**: 无引用目录时用 sandboxPolicy: SandboxPolicy；有引用目录时继承
+        // thread/start / thread/resume 已激活的 named permissions profile。profile
+        // selector 不能在 turn/start 重复发送，见 ensureReadonlyReferencesProfileForNextTurn。
         // effort 同理: 协议层只能在 turn/start 透传 (v2.rs:5800), thread/start 不接;
         // 用户在 session 创建时选的 effort 也是靠 first turn/start 这里传过去才生效。
-        const turnWorkspaceConfig = currentTurnWorkspaceConfig();
+        let turnWorkspaceConfig: ReturnType<typeof currentTurnWorkspaceConfig>;
+        let turnThreadWorkspaceConfig: ReturnType<typeof currentThreadWorkspaceConfig>;
+        try {
+          const profileRefresh = ensureReadonlyReferencesProfileForNextTurn(sendOpts?.signal);
+          if (profileRefresh) await profileRefresh;
+          turnWorkspaceConfig = currentTurnWorkspaceConfig();
+          // A stale-daemon retry must hydrate the exact thread-level profile
+          // that matches this turn, not mutable settings changed while the
+          // original turn/start RPC was pending.
+          turnThreadWorkspaceConfig = currentThreadWorkspaceConfig();
+        } catch (e) {
+          isTurnStartPending = false;
+          endPlanCycleAfterPreStartFailure('read-only reference profile refresh failed');
+          flushDeferredTerminalTurnCompletionsIfIdle();
+          rejectIfCancelled(sendOpts, 'send');
+          const message = `Failed to restore Codex read-only reference permissions: ${String(e)}`;
+          log.error('read-only reference profile refresh failed', { error: String(e), threadId });
+          eventQueue.push({
+            type: 'error',
+            data: { message, isTerminal: true },
+            source: 'codex',
+          });
+          eventQueue.push({
+            type: 'status',
+            data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+            source: 'codex',
+          });
+          if (sendOpts?.throwOnStartFailure) throw new Error(message);
+          return;
+        }
         const { approvalPolicy } = turnWorkspaceConfig;
         // 记录本 turn 是否由无人值守策略发射。Auto 即使因路由能力降级为
         // untrusted,切回 Ask 时也必须中断当前 turn,避免旧策略继续执行 trusted 操作。
         turnLaunchedUnattended = mutablePermissionMode === 'auto' || approvalPolicy === 'never';
+        if (!turnLaunchedUnattended) {
+          pendingTightenInterrupt = false;
+        }
         let turnInput: TurnStartParams['input'];
         try {
           turnInput = await toTurnInput(message.content);
@@ -4080,7 +4376,8 @@ export class CodexAgent extends BaseAgent {
           ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
           ...(collaborationMode ? { collaborationMode } : {}),
         };
-        const markCollaborationModeAccepted = (): void => {
+        const markTurnConfigAccepted = (): void => {
+          threadMayHaveRollout = true;
           if (turnParams.collaborationMode?.mode === 'plan') {
             threadTouchedPlanMode = true;
             planModeDefaultMarkerNeeded = true;
@@ -4093,6 +4390,15 @@ export class CodexAgent extends BaseAgent {
             }
           }
         };
+        // A sandboxPolicy overrides the thread-local profile. Invalidate before
+        // the request crosses the acceptance boundary: the peer can accept the
+        // turn even if the local transport loses the response.
+        if ('sandboxPolicy' in turnWorkspaceConfig) {
+          readonlyReferencesProfileActive = false;
+        }
+        // After turn/start is attempted, resume before ever replacing this
+        // thread. Only an explicit "no rollout found" proves it stayed unused.
+        threadMayHaveRollout = true;
         pendingTurnStartPlanMode = turnStartsInPlanMode;
         // turn/start 失败若是 "thread not found" — 通常 daemon 重启 (sync auth /
         // OOM / 服务器 reboot / 我们主动 pkill) 导致 in-memory thread state 丢失,
@@ -4135,7 +4441,7 @@ export class CodexAgent extends BaseAgent {
         let finalErr: unknown = null;
         try {
           const resp = await host.request<TurnStartResponse>(Method.TurnStart, turnParams);
-          markCollaborationModeAccepted();
+          markTurnConfigAccepted();
           if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start')) {
             return;
           }
@@ -4160,24 +4466,47 @@ export class CodexAgent extends BaseAgent {
               // 无需在这里管理新返回的 subscription 句柄。
               assertCurrentHost('thread/resume retry subscribe');
               host.subscribeThread(threadId, handlers);
+              const resumeModel = mutableModel;
+              const resumeServiceTierGeneration = serviceTierMutationGeneration;
               const resumeParams: ThreadResumeParams = {
                 threadId,
                 ...(resumeExcludeTurnsSupported ? { excludeTurns: true } : {}),
                 cwd: opts.workingDir,
-                ...currentThreadWorkspaceConfig(),
-                ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
+                ...turnThreadWorkspaceConfig,
+                ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
+                ...(resumeModel && resumeModel !== 'gpt-5' ? { model: resumeModel } : {}),
                 ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
               };
               const resumeResp = await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams);
-              if (mutableModel === 'gpt-5' && resumeResp.model) {
+              if (mutableModel === resumeModel && resumeModel === 'gpt-5' && resumeResp.model) {
                 mutableModel = resumeResp.model;
-                turnParams.effort = clampEffortForCodex(mutableModel, mutableEffort);
-                if (turnParams.collaborationMode) {
-                  turnParams.collaborationMode.settings.model = mutableModel;
-                  turnParams.collaborationMode.settings.reasoning_effort =
-                    clampEffortForCodex(mutableModel, mutableEffort);
-                }
               }
+              if (
+                Object.hasOwn(resumeResp, 'serviceTier') &&
+                resumeServiceTierGeneration === serviceTierMutationGeneration
+              ) {
+                mutableServiceTier = normalizeServiceTier(resumeResp.serviceTier) ?? null;
+              } else if (resumeServiceTierGeneration !== serviceTierMutationGeneration) {
+                void pushThreadSettings({ serviceTier: mutableServiceTier ?? null });
+              }
+              turnParams.effort = clampEffortForCodex(mutableModel, mutableEffort);
+              if (mutableModel && mutableModel !== 'gpt-5') {
+                turnParams.model = mutableModel;
+              } else {
+                delete turnParams.model;
+              }
+              if (mutableServiceTier !== undefined) {
+                turnParams.serviceTier = mutableServiceTier ?? null;
+              } else {
+                delete turnParams.serviceTier;
+              }
+              if (turnParams.collaborationMode) {
+                turnParams.collaborationMode.settings.model = mutableModel;
+                turnParams.collaborationMode.settings.reasoning_effort =
+                  clampEffortForCodex(mutableModel, mutableEffort);
+              }
+              readonlyReferencesProfileActive = 'permissions' in turnThreadWorkspaceConfig;
+              threadMayHaveRollout = true;
               if (collaborationMode?.mode === 'default') {
                 planModeDefaultMarkerNeeded = true;
                 if (turnParams.collaborationMode?.mode === 'default') {
@@ -4186,7 +4515,7 @@ export class CodexAgent extends BaseAgent {
               }
               log.info('thread/resume after stale daemon ok, retrying turn/start', { threadId });
               const resp = await host.request<TurnStartResponse>(Method.TurnStart, turnParams);
-              markCollaborationModeAccepted();
+              markTurnConfigAccepted();
               if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start retry')) {
                 return;
               }
@@ -4211,12 +4540,7 @@ export class CodexAgent extends BaseAgent {
           // 计划模式: turn 从未启动就终失败 → 结束半开循环(与 turnCompleted 的
           // failed 分支同语义), 否则 planCycleActive 泄漏, 下一条常规消息仍会
           // 携带 collaborationMode plan(勾选与 chip 早已熄灭, 行为与 UI 脱节)。
-          if (planCycleActive) {
-            planCycleActive = false;
-            proposedPlanText = null;
-            currentTurnPlanModeActive = false;
-            log.debug('turn/start failed during plan cycle — plan cycle ends');
-          }
+          endPlanCycleAfterPreStartFailure('turn/start failed');
           log.error('turn/start failed', { error: String(finalErr) });
           eventQueue.push({
             type: 'error',
@@ -4450,7 +4774,7 @@ export class CodexAgent extends BaseAgent {
           (newMode === 'ask' && wasOpen) ||
           (newMode === 'auto' && wasBypass);
         mutablePermissionMode = newMode;
-        // 下一 turn 通过 approvalPolicy + permissions profile / sandboxPolicy 透传。
+        // 下一 turn 通过 approvalPolicy + 已激活的 profile / sandboxPolicy 透传。
         //
         // 收紧兜底 (auto/bypass → ask): 见 interruptTurnForPermissionTighten 顶注。
         // turn id 已知 → 立即中断; turn/start 在飞 (id 未回) → 置标记, 由
@@ -4497,6 +4821,7 @@ export class CodexAgent extends BaseAgent {
         if (isFastServiceTier(mutableServiceTier) === enabled) return;
         const next: ServiceTier | null = enabled ? 'fast' : null;
         log.debug('setFastMode', { from: mutableServiceTier ?? null, to: next });
+        serviceTierMutationGeneration += 1;
         mutableServiceTier = next;
         // thread 已启动 → 立即经 thread/settings/update 生效 (serviceTier 双 Option:
         // 'fast'=开 / null=清空 standard); 未启动则由首个 thread/start 携带。server 端
@@ -4573,12 +4898,15 @@ export class CodexAgent extends BaseAgent {
           }
           threadId = nextThreadId;
           sdkSessionId = nextThreadId;
+          readonlyReferencesProfileActive = false;
+          threadMayHaveRollout = true;
           subscription = host.subscribeThread(threadId, handlers);
           registerCodexMcpContext(threadId);
           registerCodexDeveloperInstructions(threadId, registeredDeveloperInstructions);
           eventQueue.push({ type: 'session_id', data: sdkSessionId, source: 'codex' });
         } else {
           sdkSessionId = threadId;
+          threadMayHaveRollout = true;
         }
         currentTurnId = null;
         isTurnInFlight = false;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex 添加引用目录后，`turn/start` 重复选择线程级 permissions profile，导致
`default_permissions requires a '[permissions]' table` 的问题。

`cindy-readonly-references` 现在只在 `thread/start` / `thread/resume` 激活，
`turn/start` 直接继承。引用目录或权限模式变化时，仅维护该 profile 的线程生命周期：

- 首轮前新增引用目录：按当前 profile 替换尚未使用的线程。
- 已有 turn 后新增引用目录，或 Full access 切回 Ask / Auto：先 `thread/resume`
  恢复 profile，再开始下一轮。
- rollback 或 daemon 重连：用与当前 turn 匹配的冻结配置恢复 profile。
- 替换 / resume 并发期间：保留 sticky model、provider、Fast mode、订阅与 host binding。

本次将原先扩大的实现收敛为一个提交、两个 `maker-core` 文件。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #646
- 本 PR 包含：
  - Codex 引用目录 permissions profile 的线程级生命周期
  - 首轮、多轮、动态引用目录、权限回切、rollback、daemon 重连及并发回归测试
- 明确不包含：
  - 模糊 turn 投递恢复、重放或 steer
  - Desktop / Orca 改动
  - usage / origin 语义
  - 远程 rollout 文件读取或恢复
- 用户可见变化：添加引用目录的 Codex 会话可正常启动，引用目录仍保持只读
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts
结果：201/201 通过

pnpm --filter @cindy/maker-core exec eslint src/agents/codex/index.ts src/agents/codex/index.test.ts
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（该 package 当前无独立 typecheck script，自动跳过）

pnpm test:unit
结果：通过（Desktop、Mobile、maker-core 及全部可运行 unit workspace）

pnpm check:dco
结果：通过（1 个提交已签名）
```

### 手工验证

- macOS arm64，Codex app-server `0.145.0`
- 原始 RPC 可复现：在 `turn/start` 重复传入线程级 profile selector 时，返回
  `default_permissions requires a '[permissions]' table`
- 修复后，profile 继承、`thread/resume` 恢复和首轮前线程替换三条路径均可接受 turn

### maker-core 核心指标评估

- Cache rate：未修改 prompt、tool、MCP 或 developer instructions 内容；线程替换回归测试
  校验 `developerInstructions` 与 `dynamicTools` 保持一致
- Latency：正常 turn 不增加 RPC；真实 Codex `0.145.0` 测得继承 `turn/start`
  约 `5.33 ms`，动态 profile 的 `thread/resume` 约 `4.77 ms`，首轮前一次性线程替换
  约 `50.60 ms`
- Response accuracy / event stream：真实协议三条路径均成功接受 turn；未修改 translator
  与事件映射，201 条 Codex agent 测试通过
- Token / usage：`thread/start` / `thread/resume` 不触发模型调用或 usage 事件；
  本 PR 不修改 usage tracker 或 token 统计

### 未执行的验证

- 未执行登录态 UI 端到端验收；本 PR 不涉及 UI，故障路径已由真实 RPC 与自动化覆盖

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Codex 会话存在 `extraDirs`，或引用目录 / 权限模式在会话中变化的路径；
  旧 daemon 继续沿用既有 fail-closed 版本检查
- 回滚 / 降级方式：回退本 PR 的单个提交；回滚后 #646 的配置加载错误会恢复

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次行为由代码与回归测试约束，无用户文档变化）
- [x] 已确认测试结果或说明未执行原因


