### PR TITLE
fix(desktop): preserve model pricing during startup

### DIFF
--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -140,11 +140,14 @@ let modelsSyncRerunQueued = false;
 let authGeneration = 0;
 let lastAuthUserId: string | null = null;
 
-function applyGatewayModels(models: ModelAccessGatewayModel[]): void {
+function applyGatewayModels(
+  models: ModelAccessGatewayModel[],
+  authenticatedUserId?: string,
+): void {
   // 同一次 /models 响应先建立 provider-scoped 价格投影，再做仅影响展示元数据的
   // dev overlay。空成功响应会同时清空模型和价格；请求失败不会调用本函数，
   // 因而保留上一份完整成功快照。
-  const pricing = replaceGatewayModelPricing(models);
+  const pricing = replaceGatewayModelPricing(models, authenticatedUserId);
   // 分母只算会产生报价的条目:免费/无价条目按设计不出报价,不该把健康目录
   // 也报成覆盖不足。此时覆盖缺口只剩一种成因——币种声明与目录冲突被丢弃,
   // 这在 #587 之前是全程静默的,这行日志让现场可判。
@@ -166,7 +169,10 @@ function applyGatewayModels(models: ModelAccessGatewayModel[]): void {
   setXdGatewayModels(effective);
 }
 
-async function runModelsSync(myGen: number): Promise<void> {
+async function runModelsSync(
+  myGen: number,
+  authenticatedUserId: string,
+): Promise<void> {
   let payload: { models: ModelAccessGatewayModel[] };
   try {
     payload = await serverApiFetch<{ models: ModelAccessGatewayModel[] }>(MODELS_PATH, {
@@ -182,16 +188,24 @@ async function runModelsSync(myGen: number): Promise<void> {
   const models = (payload.models ?? []).filter((m) => typeof m?.id === 'string' && m.id);
   if (models.length === 0) {
     log.warn('xd gateway models fetch returned empty list; clearing current list');
-    applyGatewayModels([]);
+    applyGatewayModels([], authenticatedUserId);
     return;
   }
   log.info(`xd gateway models synced: ${models.length}`);
-  applyGatewayModels(models);
+  applyGatewayModels(models, authenticatedUserId);
 }
 
 /** 触发一次模型目录同步(同世代 single-flight;旧世代在途时为新账号排队补发)。 */
 function scheduleModelsSync(): void {
   const gen = authGeneration;
+  // localDb takeover and /models run independently during startup. Capture the
+  // authenticated owner here instead of asking localDb who owns the cache only
+  // after the network response arrives.
+  const authenticatedUserId = lastAuthUserId;
+  if (!authenticatedUserId) {
+    log.warn('xd gateway models sync skipped: authenticated user id unavailable');
+    return;
+  }
   if (modelsSyncInflight) {
     if (modelsSyncGen === gen) return; // 同账号在途,复用
     if (!modelsSyncRerunQueued) {
@@ -205,7 +219,7 @@ function scheduleModelsSync(): void {
     return;
   }
   modelsSyncGen = gen;
-  modelsSyncInflight = runModelsSync(gen)
+  modelsSyncInflight = runModelsSync(gen, authenticatedUserId)
     .catch((err) => {
       log.warn('xd gateway models sync threw', {
         error: err instanceof Error ? err.message : String(err),

--- a/apps/desktop/src/main/usage/__tests__/modelPricing.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/modelPricing.test.ts
@@ -250,6 +250,31 @@ describe('pricing cache lifecycle', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('persists a startup snapshot under the authenticated user before localDb is ready', async () => {
+    mocks.getCurrentDbClientUserId.mockReturnValue(null);
+    const pricing = replaceGatewayModelPricing(
+      [
+        {
+          id: 'early-model',
+          inputCostPerToken: 0.000001,
+          outputCostPerToken: 0.000002,
+        },
+      ],
+      'user-a',
+    );
+
+    await vi.waitFor(async () => {
+      const raw = JSON.parse(await readFile(userDataPath('cache', 'model-pricing.json'), 'utf8'));
+      expect(raw).toMatchObject({
+        scope: expectedScope('user-a'),
+        pricing,
+      });
+    });
+
+    mocks.getCurrentDbClientUserId.mockReturnValue('user-a');
+    await expect(getModelPricing()).resolves.toEqual(pricing);
+  });
+
   it('does not hydrate another account pricing snapshot', async () => {
     await mkdir(userDataPath('cache'), { recursive: true });
     await writeFile(

--- a/apps/desktop/src/main/usage/modelPricing.ts
+++ b/apps/desktop/src/main/usage/modelPricing.ts
@@ -66,12 +66,12 @@ function currentKeyCacheIdentity(): string {
   }
 }
 
-function currentScope(): string {
+function currentScope(userId?: string): string {
   return [
     'v1',
     `region=${CURRENT_CINDY_REGION}`,
     `base=${getClientEndpoint('modelAccessApiBaseUrl').trim()}`,
-    `user=${getCurrentDbClientUserId() ?? 'anonymous'}`,
+    `user=${userId ?? getCurrentDbClientUserId() ?? 'anonymous'}`,
     currentKeyCacheIdentity(),
   ].join('|');
 }
@@ -222,8 +222,13 @@ function broadcastPricing(pricing: ModelPricingCatalog | null): void {
  */
 export function replaceGatewayModelPricing(
   models: readonly ModelAccessGatewayModel[],
+  authenticatedUserId?: string,
 ): ModelPricingCatalog {
-  const scope = currentScope();
+  // /models can finish a few milliseconds before localDb takeover has exposed
+  // its user through getCurrentDbClientUserId(). The model-access caller
+  // therefore passes the authenticated user captured when the request starts,
+  // so a valid startup snapshot is never persisted under `anonymous`.
+  const scope = currentScope(authenticatedUserId);
   const pricing = gatewayPricingCatalog(models);
   cache = pricing;
   cacheScope = scope;

--- a/apps/desktop/src/renderer/hooks/__tests__/useModelPricing.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useModelPricing.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ModelPricingCatalog } from '../../../shared/regionalMoney';
+
+type PricingListener = (pricing: ModelPricingCatalog | null) => void;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+let useModelPricing: typeof import('../useModelPricing').useModelPricing;
+
+describe('useModelPricing', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    ({ useModelPricing } = await import('../useModelPricing'));
+  });
+
+  it('does not let a stale initial IPC result overwrite a newer pricing push', async () => {
+    const initialRead = deferred<ModelPricingCatalog | null>();
+    const listeners = new Set<PricingListener>();
+    const usage = {
+      getModelPricing: vi.fn(() => initialRead.promise),
+      onModelPricingChanged: vi.fn((listener: PricingListener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      }),
+    };
+    (
+      window as unknown as {
+        electronAPI: { maker: { usage: typeof usage } };
+      }
+    ).electronAPI = { maker: { usage } };
+    const pricing: ModelPricingCatalog = {
+      xd: {
+        'early-model': {
+          providerId: 'xd',
+          modelId: 'early-model',
+          currency: 'CNY',
+          source: 'gateway',
+          approximate: false,
+          inputPerMtok: 1,
+          outputPerMtok: 2,
+        },
+      },
+    };
+
+    const hook = renderHook(() => useModelPricing());
+    await waitFor(() => expect(listeners.size).toBe(1));
+
+    act(() => {
+      for (const listener of listeners) listener(pricing);
+    });
+    expect(hook.result.current).toEqual(pricing);
+
+    await act(async () => {
+      initialRead.resolve(null);
+      await initialRead.promise;
+    });
+
+    expect(hook.result.current).toEqual(pricing);
+    expect(usage.getModelPricing).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useModelPricing.ts
+++ b/apps/desktop/src/renderer/hooks/useModelPricing.ts
@@ -10,6 +10,7 @@ import type {
 let cache: ModelPricingCatalog | null = null;
 let cacheLoaded = false;
 let inflight: Promise<ModelPricingCatalog | null> | null = null;
+let cacheRevision = 0;
 
 function isNonNegativeFinite(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0;
@@ -54,14 +55,20 @@ function isValidCatalog(v: unknown): v is ModelPricingCatalog {
 function load(): Promise<ModelPricingCatalog | null> {
   if (cacheLoaded) return Promise.resolve(cache);
   if (!inflight) {
+    const revisionAtStart = cacheRevision;
     inflight = window.electronAPI.maker.usage
       .getModelPricing()
       .then((res) => {
+        // A push received after this read started is newer than its snapshot.
+        // Keep the pushed value instead of letting a stale startup `null`
+        // remove prices until the next application restart.
+        if (cacheRevision !== revisionAtStart) return cache;
         cacheLoaded = true;
         cache = isValidCatalog(res) ? res : null;
         return cache;
       })
       .catch(() => {
+        if (cacheRevision !== revisionAtStart) return cache;
         cacheLoaded = true;
         cache = null;
         return null;
@@ -80,6 +87,7 @@ export function useModelPricing(): ModelPricingCatalog | null {
     let active = true;
     const unsubscribe =
       window.electronAPI.maker.usage.onModelPricingChanged((next) => {
+        cacheRevision += 1;
         cacheLoaded = true;
         cache = isValidCatalog(next) ? next : null;
         if (active) setPricing(cache);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 启动期间模型价格可能已经从 `/models` 获取成功、却在最终界面中消失的问题。

根因包含两个独立的启动竞态：

1. `/models` 可能先于 localDb ready，此时价格快照会按 `anonymous` scope 写入，真实用户随后无法复用该缓存。
2. Renderer 初始价格 IPC 读取可能晚于新价格广播返回；旧的 `null` 结果会覆盖刚收到的新报价。

本 PR 在请求发起时捕获认证用户并用于价格缓存 scope，同时为 Renderer 价格快照增加 revision，拒绝过期初始读取覆盖更新广播。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：个人账号启动后模型价格与货币符号偶发缺失
- 本 PR 包含：认证用户价格缓存作用域修复；Renderer 新旧价格快照竞态保护；对应 Main/Renderer 回归测试
- 明确不包含：服务端 `/models` 协议、价格计算规则、模型选择器视觉样式调整
- 用户可见变化：启动或热更新后，已经获取到的模型价格与币种不会再被旧空快照清除
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修正模型价格状态更新顺序与缓存作用域，没有新增或调整界面、组件、布局、样式、动效或文案。

- 引用的设计规范：不涉及视觉设计变更

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；runner 297 passed / 1 skipped，全部 required workspace 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/usage/__tests__/modelPricing.test.ts src/renderer/hooks/__tests__/useModelPricing.test.ts --maxWorkers=1
结果：2 files passed，14 tests passed

pnpm --filter desktop exec eslint src/main/model-access/index.ts src/main/usage/modelPricing.ts src/main/usage/__tests__/modelPricing.test.ts src/renderer/hooks/useModelPricing.ts src/renderer/hooks/__tests__/useModelPricing.test.ts
结果：通过

pnpm check:dco
结果：通过；1 commit signed off
```

### 手工验证

- macOS，CN 国内版隔离 Desktop，个人账号“用户0916”
- 在修复 worktree 上完成 1 次启动和 3 次热重启
- 每轮 `/models` 均同步 6 个模型，价格缓存均绑定真实用户而非 `anonymous`
- 模型选择器持续显示人民币报价：DeepSeek V4 Flash `¥1 / ¥2`、DeepSeek V4 Pro `¥3 / ¥6`、GLM-5.2 `¥8 / ¥28`、Kimi K3 `¥20 / ¥100`
- 限时免费和订阅美元价格保持原有语义

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop 启动并发时序与账号作用域缓存

### 影响与回滚

- 影响范围：Desktop Main 的 XD `/models` 价格缓存 scope，以及 Renderer 的价格初始读取/推送合并顺序
- 回滚 / 降级方式：回滚本提交即可恢复旧行为；不涉及 schema、migration 或 wire protocol

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
