### PR TITLE
test(desktop): 修复 Markdown 契约测试的 CRLF 兼容性

### DIFF
--- a/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
@@ -62,7 +62,9 @@ describe('Markdown target rendering contract', () => {
     // 粘贴内容,会把整个节点连同路径文字丢掉,只在原位留下一个断行——用户看到的
     // 就是"文件名凭空消失"。`<code>` 既是语义正解(这个 chip 本来就是行内代码
     // 升级来的),粘出去还会落成对方的行内代码。
-    const chipBody = markdownRenderer.match(/function FileTargetChip\([\s\S]*?\n}\n/)?.[0];
+    const chipBody = markdownRenderer.match(
+      /function FileTargetChip\([\s\S]*?\r?\n}\r?\n/,
+    )?.[0];
     expect(chipBody).toBeDefined();
     expect(chipBody).toContain('<code');
     expect(chipBody).not.toContain('<button');


### PR DESCRIPTION
## 这次改了什么

### 摘要

`markdownTargetRendererContract` 截取 `FileTargetChip` 函数体时把换行写死为 LF，导致 Windows CRLF checkout 下组件明明满足 `<code role="button">` 契约，测试仍误报 `chipBody` 未定义。

本 PR 让函数体正则同时兼容 LF 与 CRLF，不改变 renderer 实现或用户界面。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；#646 的 Codex 修复由 #670 处理，本 PR 是排查期间发现的独立跨平台测试问题
- 本 PR 包含：Markdown renderer 源码契约测试的 LF/CRLF 兼容
- 明确不包含：renderer 行为、UI、Codex 权限逻辑
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及：只调整读取源码的测试正则，无视觉、交互或文案变化。

- 引用的设计规范：不涉及：纯测试逻辑调整，无视觉、交互或文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/markdownTargetRendererContract.test.ts
结果：8/8 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全部必跑 workspace 通过

pnpm check:dco
结果：1 个提交通过 DCO 检查
```

### 手工验证

确认 Windows checkout 中 `MarkdownRenderer.tsx` 为 CRLF；修改前该测试稳定失败，修改后稳定通过。

### 未执行的验证

未启动 Desktop 做 UI 目检：本次没有 UI 实现变化。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅一条读取源码文本的 Desktop 契约测试
- 回滚 / 降级方式：回退本提交

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
