### PR TITLE
fix(desktop): 修复最近工作目录 LRU 驱逐静默失效

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
@@ -48,15 +48,19 @@ import { upsertRecentWorkdir } from '../recentWorkdirs';
 
 /**
  * 假 transport:按 worker/dispatcher.ts 的 op 语义把 SQL 转发给真实 in-memory SQLite。
- * query → stmt.all / queryOne → stmt.get / run|exec → stmt.run,与真实 worker 一致。
+ * 逐条对齐 worker/opHandlers:query → stmt.all / queryOne → stmt.get /
+ * run|exec → stmt.run / rawAll → stmt.raw().all / rawGet → stmt.raw().get
+ * (raw* 返回数组而非对象,见 opHandlers/rawAll.ts、rawGet.ts)。
  */
 function createTransport(): DbTransport {
   return {
     send: async (op: string, args?: unknown) => {
       const { sql: text, params = [] } = (args ?? {}) as { sql: string; params?: unknown[] };
       const stmt = h.sqlite!.prepare(text);
-      if (op === 'query' || op === 'rawAll') return stmt.all(...(params as never[]));
-      if (op === 'queryOne' || op === 'rawGet') return stmt.get(...(params as never[]));
+      if (op === 'query') return stmt.all(...(params as never[]));
+      if (op === 'queryOne') return stmt.get(...(params as never[]));
+      if (op === 'rawAll') return stmt.raw().all(...(params as never[]));
+      if (op === 'rawGet') return stmt.raw().get(...(params as never[]));
       if (op === 'run' || op === 'exec') return stmt.run(...(params as never[]));
       throw new Error(`unexpected op: ${op}`);
     },

--- a/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
@@ -23,6 +23,8 @@ const h = vi.hoisted(() => ({
   sqlite: null as InstanceType<typeof import('better-sqlite3')> | null,
   client: null as { drizzle: unknown; exec: unknown } | null,
   warns: [] as unknown[],
+  /** 本次 upsert 实际发给 backend 的 SQL,用于断言驱逐没退化成 SELECT + DELETE 两步。 */
+  statements: [] as string[],
 }));
 
 vi.mock('electron', () => ({
@@ -56,6 +58,7 @@ function createTransport(): DbTransport {
   return {
     send: async (op: string, args?: unknown) => {
       const { sql: text, params = [] } = (args ?? {}) as { sql: string; params?: unknown[] };
+      h.statements.push(text.replace(/\s+/g, ' ').trim());
       const stmt = h.sqlite!.prepare(text);
       if (op === 'query') return stmt.all(...(params as never[]));
       if (op === 'queryOne') return stmt.get(...(params as never[]));
@@ -88,6 +91,7 @@ beforeEach(() => {
   `);
   h.sqlite = sqlite;
   h.warns = [];
+  h.statements = [];
 
   const transport = createTransport();
   h.client = {
@@ -132,10 +136,27 @@ describe('upsertRecentWorkdir LRU 驱逐', () => {
 
     await upsertRecentWorkdir('/Users/dash/Code/fresh', 1_700_000_000_000);
 
-    // `LIMIT -1 OFFSET n` 删的是第 n+1 行起的全部行 → 一次到位。
+    // 子查询里的 `LIMIT -1 OFFSET n` 选中第 n+1 行起的全部行 → 一条 DELETE 一次到位。
     const kept = rows();
     expect(kept).toHaveLength(MAX_RECENT_WORKDIRS);
     expect(kept[0]?.path).toBe('/Users/dash/Code/fresh');
+    expect(h.warns).toEqual([]);
+  });
+
+  it('驱逐是单条 DELETE(子查询挑待删行),不退化成 SELECT 快照 + DELETE 两步', async () => {
+    // 分两步时,fire-and-forget 的并发 upsert 会在 SELECT 与 DELETE 之间刷新被选中的行,
+    // 前一个调用仍按旧快照把「刚用过的目录」删掉。单语句由 SQLite 原子求值,没有这个窗口。
+    for (let i = 0; i < MAX_RECENT_WORKDIRS + 2; i++) {
+      await upsertRecentWorkdir(`/Users/dash/Code/proj-${i}`, 1_700_000_000_000 + i * 1_000);
+    }
+
+    const sent = h.statements.map((s) => s.toLowerCase());
+    // 驱逐不得单独发 SELECT 去取快照。
+    expect(sent.filter((s) => s.startsWith('select'))).toEqual([]);
+    const deletes = sent.filter((s) => s.startsWith('delete'));
+    expect(deletes.length).toBeGreaterThan(0);
+    // 每条 DELETE 都必须自带子查询,而不是 `in (?, ?, …)` 这种按快照展开的形式。
+    for (const stmt of deletes) expect(stmt).toMatch(/in \(select /);
     expect(h.warns).toEqual([]);
   });
 

--- a/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
@@ -109,6 +109,24 @@ describe('upsertRecentWorkdir LRU 驱逐', () => {
     expect(h.warns).toEqual([]);
   });
 
+  it('存量已远超上限时,一次 upsert 就收敛到上限(不是每次只删 1 行)', async () => {
+    // 模拟修复前留下的脏数据:驱逐长期静默失败,表涨到 18 行(线上实测值)。
+    for (let i = 0; i < 18; i++) {
+      h.sqlite!
+        .prepare('INSERT INTO recent_workdirs (path, last_used_at) VALUES (?, ?)')
+        .run(`/Users/dash/Code/stale-${i}`, 1_600_000_000_000 + i * 1_000);
+    }
+    expect(rows()).toHaveLength(18);
+
+    await upsertRecentWorkdir('/Users/dash/Code/fresh', 1_700_000_000_000);
+
+    // `LIMIT -1 OFFSET n` 删的是第 n+1 行起的全部行 → 一次到位。
+    const kept = rows();
+    expect(kept).toHaveLength(MAX_RECENT_WORKDIRS);
+    expect(kept[0]?.path).toBe('/Users/dash/Code/fresh');
+    expect(h.warns).toEqual([]);
+  });
+
   it('未超上限时不删任何行', async () => {
     for (let i = 0; i < 3; i++) {
       await upsertRecentWorkdir(`/Users/dash/Code/proj-${i}`, 1_700_000_000_000 + i * 1_000);

--- a/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
@@ -1,0 +1,151 @@
+/**
+ * recentWorkdirsLru.test.ts — upsertRecentWorkdir 的 LRU 驱逐回归。
+ *
+ * 背景:驱逐原先写成 `getDbClient().drizzle.run(sql`...`)`。main 侧拿到的 drizzle 是
+ * createDrizzleProxy 的代理,只把 **query builder** 的终结方法转发给 worker RPC;直接在
+ * db 对象上跑 raw SQL 不经过 builder,会落进代理内部只会抛错的 fakeSqliteClient.prepare(),
+ * 再被 drizzle 包成 "Failed to run the query '...'",最后被 fire-and-forget 的 catch 吞成
+ * 一条 warn —— 驱逐 100% 静默失败,表一直涨过上限(线上实测 18 行 > 上限 10)。
+ *
+ * 所以 harness 必须用**代理**建,不能用真实 `drizzle(sqlite)`:同样的用例在真实 drizzle 上
+ * 会假绿,这正是 bug 当初溜过去的原因(见 recentWorkdirsDelete.test.ts 的 harness)。
+ */
+import Database from 'better-sqlite3';
+import { sql } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DbTransport } from '../../client/DbTransport.js';
+
+/** 与 recentWorkdirs.ts 的模块私有常量对齐(未 export,这里跟随其语义硬编码)。 */
+const MAX_RECENT_WORKDIRS = 10;
+
+const h = vi.hoisted(() => ({
+  sqlite: null as InstanceType<typeof import('better-sqlite3')> | null,
+  client: null as { drizzle: unknown; exec: unknown } | null,
+  warns: [] as unknown[],
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('../../../logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: (...args: unknown[]) => {
+      h.warns.push(args);
+    },
+    error: vi.fn(),
+  }),
+}));
+vi.mock('../../client/current', () => ({
+  getDbClient: () => h.client,
+}));
+
+import { createDrizzleProxy } from '../../client/drizzleProxy';
+import { upsertRecentWorkdir } from '../recentWorkdirs';
+
+/**
+ * 假 transport:按 worker/dispatcher.ts 的 op 语义把 SQL 转发给真实 in-memory SQLite。
+ * query → stmt.all / queryOne → stmt.get / run|exec → stmt.run,与真实 worker 一致。
+ */
+function createTransport(): DbTransport {
+  return {
+    send: async (op: string, args?: unknown) => {
+      const { sql: text, params = [] } = (args ?? {}) as { sql: string; params?: unknown[] };
+      const stmt = h.sqlite!.prepare(text);
+      if (op === 'query' || op === 'rawAll') return stmt.all(...(params as never[]));
+      if (op === 'queryOne' || op === 'rawGet') return stmt.get(...(params as never[]));
+      if (op === 'run' || op === 'exec') return stmt.run(...(params as never[]));
+      throw new Error(`unexpected op: ${op}`);
+    },
+    on: () => {},
+    onTerminated: () => {},
+    close: async () => {},
+  } as unknown as DbTransport;
+}
+
+function rows(): Array<{ path: string; last_used_at: number }> {
+  return h.sqlite!
+    .prepare('SELECT path, last_used_at FROM recent_workdirs ORDER BY last_used_at DESC')
+    .all() as Array<{ path: string; last_used_at: number }>;
+}
+
+beforeEach(() => {
+  h.sqlite?.close();
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE recent_workdirs (
+      path TEXT PRIMARY KEY NOT NULL,
+      last_used_at INTEGER NOT NULL
+    );
+    CREATE INDEX idx_recent_workdirs_last_used_at ON recent_workdirs(last_used_at);
+  `);
+  h.sqlite = sqlite;
+  h.warns = [];
+
+  const transport = createTransport();
+  h.client = {
+    drizzle: createDrizzleProxy(() => transport),
+    exec: (text: string, params?: unknown[]) => transport.send('exec', { sql: text, params }),
+  };
+});
+
+describe('upsertRecentWorkdir LRU 驱逐', () => {
+  it('超过上限时删掉最旧的,只保留 MAX_RECENT_WORKDIRS 条', async () => {
+    const total = MAX_RECENT_WORKDIRS + 4;
+    for (let i = 0; i < total; i++) {
+      await upsertRecentWorkdir(`/Users/dash/Code/proj-${i}`, 1_700_000_000_000 + i * 1_000);
+    }
+
+    const kept = rows();
+    expect(kept).toHaveLength(MAX_RECENT_WORKDIRS);
+    // 保留的必须是 lastUsedAt 最新的那批,最旧的 4 条被驱逐。
+    expect(kept.map((r) => r.path)).toEqual(
+      Array.from({ length: MAX_RECENT_WORKDIRS }, (_, k) => `/Users/dash/Code/proj-${total - 1 - k}`),
+    );
+    // 驱逐路径不得再走 fire-and-forget 的 catch —— 一条 warn 都不该有。
+    expect(h.warns).toEqual([]);
+  });
+
+  it('未超上限时不删任何行', async () => {
+    for (let i = 0; i < 3; i++) {
+      await upsertRecentWorkdir(`/Users/dash/Code/proj-${i}`, 1_700_000_000_000 + i * 1_000);
+    }
+    expect(rows()).toHaveLength(3);
+    expect(h.warns).toEqual([]);
+  });
+
+  it('重复 upsert 同一目录只刷新时间戳,不新增行也不触发驱逐', async () => {
+    await upsertRecentWorkdir('/Users/dash/Code/proj-a', 1_700_000_000_000);
+    await upsertRecentWorkdir('/Users/dash/Code/proj-a', 1_700_000_009_000);
+
+    const kept = rows();
+    expect(kept).toHaveLength(1);
+    expect(kept[0]).toMatchObject({ path: '/Users/dash/Code/proj-a', last_used_at: 1_700_000_009_000 });
+    expect(h.warns).toEqual([]);
+  });
+});
+
+describe('drizzleProxy 契约', () => {
+  it('db 级 raw SQL(db.run(sql`...`))不被代理支持 —— 驱逐不能依赖这条路径', () => {
+    const proxy = h.client!.drizzle as { run: (q: unknown) => unknown };
+    // 这就是修复前的写法。注意它是**同步** throw(drizzle better-sqlite3 的 db.run 是
+    // 同步 API),不是 rejected promise —— 所以原代码 `await db.run(...)` 的错误是靠外层
+    // try/catch 兜住的。哪天代理开始支持 db 级 raw SQL,这条会变红,提醒回头更新
+    // recentWorkdirs.ts 里那段注释。
+    let caught: unknown;
+    try {
+      proxy.run(sql`DELETE FROM recent_workdirs WHERE path = 'nope'`);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as Error | undefined)?.message).toMatch(/Failed to run the query/);
+    // 根因只在 cause 里 —— upsertRecentWorkdir 的 warn 因此必须带上 cause,否则日志
+    // 只剩一条无因果的 SQL。
+    expect((caught as Error).cause).toMatchObject({
+      message: expect.stringContaining('worker RPC'),
+    });
+  });
+});

--- a/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts
@@ -92,7 +92,15 @@ beforeEach(() => {
   const transport = createTransport();
   h.client = {
     drizzle: createDrizzleProxy(() => transport),
-    exec: (text: string, params?: unknown[]) => transport.send('exec', { sql: text, params }),
+    // upsert 与驱逐必须全程留在上面这个**已捕获**的 drizzle handle 上。走 client.exec
+    // 会在 in-proc fallback 下于调用时再解析一次模块全局 getRawDb() —— insert 之后若发生
+    // 账号切换,驱逐就会打到新账号的库。这里故意让 exec 抛错:实现一旦回退去用它,
+    // 下面的用例立刻变红。
+    exec: () => {
+      throw new Error(
+        'client.exec must not be used: eviction has to stay on the pinned drizzle handle',
+      );
+    },
   };
 });
 

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -20,7 +20,7 @@
 import { stat } from 'node:fs/promises';
 
 import { BrowserWindow, ipcMain } from 'electron';
-import { desc, eq, sql } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 
 import { getDbClient } from '../client/current';
 import { recentWorkdirs } from '../schema';
@@ -94,18 +94,29 @@ export async function upsertRecentWorkdir(
     // LRU 驱逐:超过 MAX_RECENT_WORKDIRS 时,删掉 lastUsedAt 最旧的多出来的行。
     // SQLite 不支持直接 DELETE ... ORDER BY LIMIT,用子查询 OFFSET 拿出待删 path。
     // 单条 INSERT 最多新增 1 条 → 单条最多删 1 条;query 廉价。
-    await db.run(sql`
-      DELETE FROM ${recentWorkdirs}
-      WHERE ${recentWorkdirs.path} IN (
-        SELECT ${recentWorkdirs.path} FROM ${recentWorkdirs}
-        ORDER BY ${recentWorkdirs.lastUsedAt} DESC
-        LIMIT -1 OFFSET ${MAX_RECENT_WORKDIRS}
-      )
-    `);
+    //
+    // 必须走 DbClient.exec,不能用 drizzle 的 db.run(sql`...`):main 侧拿到的
+    // drizzle 是 createDrizzleProxy 的代理,只把 **query builder** 的终结方法
+    // (all / get / run / values)转发给 worker RPC。直接在 db 对象上跑 raw SQL 不
+    // 经过 builder,会落进代理内部那个只会抛错的 fakeSqliteClient.prepare(),再被
+    // drizzle 包成 "Failed to run the query '...'" —— 驱逐 100% 静默失败(fire-and-
+    // forget 的 catch 只留一条 warn),表会一直涨过上限。回归见 __tests__/recentWorkdirsLru。
+    await getDbClient().exec(
+      `DELETE FROM recent_workdirs
+       WHERE path IN (
+         SELECT path FROM recent_workdirs
+         ORDER BY last_used_at DESC
+         LIMIT -1 OFFSET ?
+       )`,
+      [MAX_RECENT_WORKDIRS],
+    );
   } catch (err) {
     log.warn('[localDb] upsertRecentWorkdir failed', {
       path: normalized,
       error: err instanceof Error ? err.message : String(err),
+      // drizzle 把底层错误包一层后 message 只剩 "Failed to run the query '<sql>'",
+      // 根因全在 cause 里。不带上就只能对着一条无因果的 SQL 反向猜。
+      cause: err instanceof Error && err.cause instanceof Error ? err.cause.message : undefined,
     });
   }
 }

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -83,7 +83,11 @@ export async function upsertRecentWorkdir(
   const normalized = normalizeRecentWorkdirPath(path);
   if (!normalized) return;
   try {
-    const db = getDbClient().drizzle;
+    // 一次拿 client 后复用:getDbClient() 读的是模块级可变 current(账号切换 / client
+    // 重新初始化会 set 或 clear 它),分两次取有可能让 insert 与下面的驱逐落在不同
+    // DbClient 上,或第二次直接抛 "DbClient not ready"。
+    const client = getDbClient();
+    const db = client.drizzle;
     await db
       .insert(recentWorkdirs)
       .values({ path: normalized, lastUsedAt: atMs })
@@ -104,7 +108,7 @@ export async function upsertRecentWorkdir(
     // 经过 builder,会落进代理内部那个只会抛错的 fakeSqliteClient.prepare(),再被
     // drizzle 包成 "Failed to run the query '...'" —— 驱逐 100% 静默失败(fire-and-
     // forget 的 catch 只留一条 warn),表会一直涨过上限。回归见 __tests__/recentWorkdirsLru。
-    await getDbClient().exec(
+    await client.exec(
       `DELETE FROM recent_workdirs
        WHERE path IN (
          SELECT path FROM recent_workdirs

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -20,7 +20,7 @@
 import { stat } from 'node:fs/promises';
 
 import { BrowserWindow, ipcMain } from 'electron';
-import { desc, eq } from 'drizzle-orm';
+import { desc, eq, inArray } from 'drizzle-orm';
 
 import { getDbClient } from '../client/current';
 import { recentWorkdirs } from '../schema';
@@ -83,11 +83,13 @@ export async function upsertRecentWorkdir(
   const normalized = normalizeRecentWorkdirPath(path);
   if (!normalized) return;
   try {
-    // 一次拿 client 后复用:getDbClient() 读的是模块级可变 current(账号切换 / client
-    // 重新初始化会 set 或 clear 它),分两次取有可能让 insert 与下面的驱逐落在不同
-    // DbClient 上,或第二次直接抛 "DbClient not ready"。
-    const client = getDbClient();
-    const db = client.drizzle;
+    // 只取一次 drizzle handle,upsert 与驱逐全程复用它 —— 两端必须 pin 在同一个
+    // backend 上。getDbClient() 读的是模块级可变 current(账号切换 / client 重新初始化
+    // 会 set 或 clear 它);而 in-proc fallback client(worker 起不来时装的那个)的
+    // drizzle 是 getter、exec 则在调用时才解析模块全局 getRawDb()。混用「已捕获的
+    // drizzle」和「晚绑定的 exec」时,只要 insert 之后这个 fire-and-forget helper 被挂起
+    // 期间发生账号切换,驱逐就会打到新账号的库上:旧库该裁的没裁,新库反而被裁一行。
+    const db = getDbClient().drizzle;
     await db
       .insert(recentWorkdirs)
       .values({ path: normalized, lastUsedAt: atMs })
@@ -95,28 +97,31 @@ export async function upsertRecentWorkdir(
         target: recentWorkdirs.path,
         set: { lastUsedAt: atMs },
       });
-    // LRU 驱逐:超过 MAX_RECENT_WORKDIRS 时,删掉 lastUsedAt 最旧的多出来的行。
-    // SQLite 不支持直接 DELETE ... ORDER BY LIMIT,用子查询 OFFSET 拿出待删 path。
-    // `LIMIT -1 OFFSET n` 选中第 n+1 行起的**全部**行 —— 一次收敛到上限,不是每次删 1 行:
-    // 稳态下单条 INSERT 最多新增 1 条,自然也只删 1 条;而历史脏数据(驱逐曾长期静默失败,
-    // 用户库涨到 18 行)在下一次 upsert 就一次清到 MAX_RECENT_WORKDIRS,不用等多轮。
-    // 表最多十几行,一次删几行无性能顾虑。
+    // LRU 驱逐:超过 MAX_RECENT_WORKDIRS 的行按 lastUsedAt 从旧到新淘汰。
     //
-    // 必须走 DbClient.exec,不能用 drizzle 的 db.run(sql`...`):main 侧拿到的
-    // drizzle 是 createDrizzleProxy 的代理,只把 **query builder** 的终结方法
-    // (all / get / run / values)转发给 worker RPC。直接在 db 对象上跑 raw SQL 不
-    // 经过 builder,会落进代理内部那个只会抛错的 fakeSqliteClient.prepare(),再被
-    // drizzle 包成 "Failed to run the query '...'" —— 驱逐 100% 静默失败(fire-and-
-    // forget 的 catch 只留一条 warn),表会一直涨过上限。回归见 __tests__/recentWorkdirsLru。
-    await client.exec(
-      `DELETE FROM recent_workdirs
-       WHERE path IN (
-         SELECT path FROM recent_workdirs
-         ORDER BY last_used_at DESC
-         LIMIT -1 OFFSET ?
-       )`,
-      [MAX_RECENT_WORKDIRS],
-    );
+    // 全部用 query builder 表达,不走 raw SQL —— 两个原因:
+    //  1. pin(见上):builder 走的是已捕获的 db,不会二次解析 DbClient。
+    //  2. main 侧的 drizzle 是 createDrizzleProxy 的代理,只把 **query builder** 的终结
+    //     方法(all / get / run / values)转发给 worker RPC。在 db 对象上直接跑 raw SQL
+    //     (db.run(sql`...`))不经过 builder,会落进代理内部那个只会抛错的
+    //     fakeSqliteClient.prepare(),被 drizzle 包成 "Failed to run the query '...'",再被
+    //     下面 fire-and-forget 的 catch 吞成一条 warn —— 驱逐 100% 静默失败,表一直涨过
+    //     上限(本 PR 修的就是这个,回归见 __tests__/recentWorkdirsLru)。
+    //
+    // 不用 `LIMIT -1 OFFSET n` 子查询挑待删行:drizzle 会丢掉 limit(-1) 只留 offset,
+    // SQLite 报 `near "offset": syntax error`。这张表上限十几行,整表取回在 JS 里切更
+    // 直白,也顺带避开了拼 SQL。
+    const ordered = await db
+      .select({ path: recentWorkdirs.path })
+      .from(recentWorkdirs)
+      .orderBy(desc(recentWorkdirs.lastUsedAt));
+    const stale = ordered.slice(MAX_RECENT_WORKDIRS).map((row) => row.path);
+    if (stale.length > 0) {
+      // 一次删掉所有超出上限的行,不是每次删 1 行:稳态下单条 INSERT 最多新增 1 条,
+      // 自然也只删 1 条;而驱逐曾长期静默失败留下的脏数据(本机库涨到 18 行)在下一次
+      // upsert 就一次清到上限,不用等多轮。
+      await db.delete(recentWorkdirs).where(inArray(recentWorkdirs.path, stale));
+    }
   } catch (err) {
     log.warn('[localDb] upsertRecentWorkdir failed', {
       path: normalized,

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -99,29 +99,37 @@ export async function upsertRecentWorkdir(
       });
     // LRU 驱逐:超过 MAX_RECENT_WORKDIRS 的行按 lastUsedAt 从旧到新淘汰。
     //
-    // 全部用 query builder 表达,不走 raw SQL —— 两个原因:
-    //  1. pin(见上):builder 走的是已捕获的 db,不会二次解析 DbClient。
-    //  2. main 侧的 drizzle 是 createDrizzleProxy 的代理,只把 **query builder** 的终结
-    //     方法(all / get / run / values)转发给 worker RPC。在 db 对象上直接跑 raw SQL
-    //     (db.run(sql`...`))不经过 builder,会落进代理内部那个只会抛错的
-    //     fakeSqliteClient.prepare(),被 drizzle 包成 "Failed to run the query '...'",再被
-    //     下面 fire-and-forget 的 catch 吞成一条 warn —— 驱逐 100% 静默失败,表一直涨过
-    //     上限(本 PR 修的就是这个,回归见 __tests__/recentWorkdirsLru)。
+    // 必须是**一条** DELETE,待删集合由子查询在同一条语句里求值 —— 不能先 SELECT 出
+    // 快照再按快照 DELETE。session 创建路径以 void 调用本 helper(fire-and-forget),两个
+    // upsert 会交错:若分两步,A 选中最旧的 X 之后 B 刷新了 X,A 仍按旧快照删掉 X ——
+    // 用户刚用过的目录反而从「最近」里消失,交错还会让列表少于上限。单语句在 SQLite 里
+    // 原子求值,最坏只是驱逐重复执行(幂等,结果一致)。
     //
-    // 不用 `LIMIT -1 OFFSET n` 子查询挑待删行:drizzle 会丢掉 limit(-1) 只留 offset,
-    // SQLite 报 `near "offset": syntax error`。这张表上限十几行,整表取回在 JS 里切更
-    // 直白,也顺带避开了拼 SQL。
-    const ordered = await db
+    // 用 query builder 而不是 client.exec 拼 raw SQL,两个原因:
+    //  1. pin(见上):builder 走的是已捕获的 db handle,不会二次解析 DbClient。
+    //  2. main 侧的 drizzle 是 createDrizzleProxy 的代理,只把 **query builder** 的终结方法
+    //     (all / get / run / values)转发给 worker RPC。在 db 对象上直接跑 raw SQL
+    //     (db.run(sql`...`))不经过 builder,会落进代理内部那个只会抛错的
+    //     fakeSqliteClient.prepare(),被 fire-and-forget 的 catch 吞成一条 warn —— 驱逐
+    //     100% 静默失败(本 PR 修的就是这个)。子查询的 limit / offset 是 builder 内部的
+    //     SQL 构造,不是 db 级 raw SQL,照样走代理。
+    //
+    // SQLite 的 OFFSET 必须跟着 LIMIT,而这里要的是"从第 n+1 行起全部":
+    //  - 不能传 -1(SQLite 表示无上限的写法):drizzle 会把数字 -1 丢掉只留 offset,生成
+    //    `... offset ?`,SQLite 直接报 `near "offset": syntax error`;
+    //  - 也不能传 sql`-1` 绕过:limit() 的类型只收 number | Placeholder,typecheck 不过。
+    // 所以用 MAX_SAFE_INTEGER 表达"无上限"(表上限十几行,永远取不满)。
+    //
+    // 一次删掉所有超出上限的行,不是每次删 1 行:稳态下单条 INSERT 最多新增 1 条,自然
+    // 也只删 1 条;而驱逐曾长期静默失败留下的脏数据(本机库涨到 18 行)在下一次 upsert
+    // 就一次清到上限,不用等多轮。
+    const doomed = db
       .select({ path: recentWorkdirs.path })
       .from(recentWorkdirs)
-      .orderBy(desc(recentWorkdirs.lastUsedAt));
-    const stale = ordered.slice(MAX_RECENT_WORKDIRS).map((row) => row.path);
-    if (stale.length > 0) {
-      // 一次删掉所有超出上限的行,不是每次删 1 行:稳态下单条 INSERT 最多新增 1 条,
-      // 自然也只删 1 条;而驱逐曾长期静默失败留下的脏数据(本机库涨到 18 行)在下一次
-      // upsert 就一次清到上限,不用等多轮。
-      await db.delete(recentWorkdirs).where(inArray(recentWorkdirs.path, stale));
-    }
+      .orderBy(desc(recentWorkdirs.lastUsedAt))
+      .limit(Number.MAX_SAFE_INTEGER)
+      .offset(MAX_RECENT_WORKDIRS);
+    await db.delete(recentWorkdirs).where(inArray(recentWorkdirs.path, doomed));
   } catch (err) {
     log.warn('[localDb] upsertRecentWorkdir failed', {
       path: normalized,

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -93,7 +93,10 @@ export async function upsertRecentWorkdir(
       });
     // LRU 驱逐:超过 MAX_RECENT_WORKDIRS 时,删掉 lastUsedAt 最旧的多出来的行。
     // SQLite 不支持直接 DELETE ... ORDER BY LIMIT,用子查询 OFFSET 拿出待删 path。
-    // 单条 INSERT 最多新增 1 条 → 单条最多删 1 条;query 廉价。
+    // `LIMIT -1 OFFSET n` 选中第 n+1 行起的**全部**行 —— 一次收敛到上限,不是每次删 1 行:
+    // 稳态下单条 INSERT 最多新增 1 条,自然也只删 1 条;而历史脏数据(驱逐曾长期静默失败,
+    // 用户库涨到 18 行)在下一次 upsert 就一次清到 MAX_RECENT_WORKDIRS,不用等多轮。
+    // 表最多十几行,一次删几行无性能顾虑。
     //
     // 必须走 DbClient.exec,不能用 drizzle 的 db.run(sql`...`):main 侧拿到的
     // drizzle 是 createDrizzleProxy 的代理,只把 **query builder** 的终结方法

--- a/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
+++ b/apps/desktop/src/main/localDb/ipc/recentWorkdirs.ts
@@ -108,7 +108,8 @@ export async function upsertRecentWorkdir(
     // 用 query builder 而不是 client.exec 拼 raw SQL,两个原因:
     //  1. pin(见上):builder 走的是已捕获的 db handle,不会二次解析 DbClient。
     //  2. main 侧的 drizzle 是 createDrizzleProxy 的代理,只把 **query builder** 的终结方法
-    //     (all / get / run / values)转发给 worker RPC。在 db 对象上直接跑 raw SQL
+    //     转发给 worker RPC(完整清单见 drizzleProxy.ts 的 terminalMethods:all / get / run /
+    //     values / execute,以及 then / catch / finally 触发的隐式执行)。在 db 对象上跑 raw SQL
     //     (db.run(sql`...`))不经过 builder,会落进代理内部那个只会抛错的
     //     fakeSqliteClient.prepare(),被 fire-and-forget 的 catch 吞成一条 warn —— 驱逐
     //     100% 静默失败(本 PR 修的就是这个)。子查询的 limit / offset 是 builder 内部的


### PR DESCRIPTION
## 这次改了什么

### 摘要

「最近工作目录」的 LRU 驱逐 100% 静默失败，`recent_workdirs` 表长期涨过 10 条上限（实测本机用户库 18 行）。

根因不在 SQL，而在 DB 访问方式。驱逐原先写成 ``db.run(sql`...`)``，但 main 侧拿到的 `drizzle` 是 `createDrizzleProxy` 的代理，它只把 **query builder** 的终结方法（`all` / `get` / `run` / `values`）转发给 worker RPC。直接在 db 对象上跑 raw SQL 不经过 builder，会落进代理内部那个只会抛错的 `fakeSqliteClient.prepare()`（`client/drizzleProxy.ts:26-30`），被 drizzle 包成 `Failed to run the query '...'`，最后被 `upsertRecentWorkdir` fire-and-forget 的 `catch` 吞成一条 warn。

修复方式是把驱逐写成**一条** `DELETE`，待删集合由子查询在同一语句内求值，并且整条语句用 **query builder** 表达（`db.delete(...).where(inArray(path, 子查询))`），复用 upsert 那一次取到的 drizzle handle。三个约束同时满足：

- **代理支持**：builder 的终结方法会被 `createDrizzleProxy` 转发给 worker RPC，绕开上面那个陷阱（子查询里的 `limit`/`offset` 只是 builder 内部的 SQL 构造，不是 db 级 raw SQL）。
- **pin 在同一 backend**：`getDbClient()` 读的是模块级可变 `current`，而 in-proc fallback client（worker 起不来时装的）的 `drizzle` 是 getter、`exec` 在调用时才解析模块全局 `getRawDb()`。混用「已捕获的 drizzle」和「晚绑定的 exec」，只要 insert 之后这个 fire-and-forget helper 被挂起期间发生账号切换，驱逐就会打到新账号的库上。
- **原子**：session 创建路径以 `void` 调用本 helper，两个 upsert 会交错。若先 `SELECT` 出快照再按快照 `DELETE`，A 选中最旧的 X 之后 B 刷新了 X，A 仍会删掉 X —— 用户刚用过的目录反而从「最近」里消失，交错还会让列表少于上限。单语句由 SQLite 原子求值，最坏只是驱逐重复执行（幂等）。

一处实现细节记在注释里：SQLite 的 `OFFSET` 必须跟 `LIMIT`，而这里要「从第 n+1 行起全部」——传数字 `-1` 会被 drizzle 丢掉只留 `offset`（SQLite 报 `near "offset": syntax error`），改用 `sql\`-1\`` 又过不了 `limit()` 的类型（只收 `number | Placeholder`），所以用 `Number.MAX_SAFE_INTEGER` 表达「无上限」。三种写法都实测过。

同时给那条 warn 补上 `err.cause`：drizzle 包装后 `message` 只剩那条 SQL，根因全在 `cause` 里，不带上就只能对着一条无因果的 SQL 反向猜（本次定位就卡在这里）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（dogfood 时从日志里发现：`[recentWorkdirs] upsertRecentWorkdir failed` 单日 14 次）
- 本 PR 包含：`upsertRecentWorkdir` 驱逐路径改走 `DbClient.exec`；warn 补 `err.cause`；新增走真实 `drizzleProxy` 的回归测试
- 明确不包含：不动 schema / migration；不改 `drizzleProxy` 本身（不给代理补 db 级 raw SQL 支持）；不写一次性数据清理脚本（不需要，见下条）
- 用户可见变化：几乎无感。修复后「最近工作目录」下拉恢复按 LRU 收敛到 10 条。存量超限行**不需要额外迁移**：驱逐一次删掉所有超出上限的行，所以历史脏数据（本机库 18 行）在下一次 upsert 就一次清到上限；稳态下每次 INSERT 只多 1 条、自然也只删 1 条
- 是否存在 breaking change：无

### UI 变化

不涉及。改动只在 `apps/desktop/src/main/localDb/`（main 进程 DB 访问路径），不命中 UI 代码路径，无视觉/交互/文案变化。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
bash <git-skill>/scripts/run-unit-gate.sh <worktree>    # 仓库根 pnpm test:unit 全量
结果：GATE_EXIT=0，PASS apps/desktop unit (71.5s)、PASS apps/mobile unit，# fail 0

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm --filter desktop exec vitest run \
  src/main/localDb/ipc/__tests__/recentWorkdirsLru.test.ts \
  src/main/localDb/ipc/__tests__/recentWorkdirsDelete.test.ts
结果：2 files / 10 tests passed

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

**反向验证（确认测试真能抓住这个 bug）**：临时把实现退回 ``db.run(sql`...`)`` 老写法后重跑，3 个 LRU 用例全红，表里留下 14 行 —— 与线上现象（18 行 > 上限 10）一致，且每次 upsert 都产生一条 warn。确认后已恢复修复。

**Review follow-up**（三轮，全部核实成立后修复）：

1. Copilot：`LIMIT -1 OFFSET ?` 会一次删掉所有超出行，与原注释「单条最多删 1 条」不符。核实确认行为描述正确（seed 18 行，一次 DELETE 后剩 10 行），而一次性收敛正是期望语义 —— 保留行为，改掉那句沿用自旧代码的错误注释，并补用例锚定（seed 18 行 → 单次 upsert 收敛到 10）。
2. Copilot：同一 try 块里两次 `getDbClient()`，账号切换时两步可能落在不同 client。核实 `client/current.ts` 的 `current` 确为模块级可变状态 —— 改为只取一次。
3. Codex（P1）：即使只取一次 client，in-proc fallback 的 `drizzle`（getter，访问即捕获）与 `exec`（调用时才解析 `getRawDb()`）仍会分裂到不同库。核实成立 —— 驱逐改用 builder，复用同一个已捕获的 handle。测试里把 `client.exec` 换成会抛错的哨兵，实现若回退去用它，用例立刻变红。
4. Copilot：测试 harness 把 `rawAll`/`rawGet` 并到了 `stmt.all`/`stmt.get`，而 `worker/opHandlers` 用的是 `.raw().all()`/`.raw().get()`（返回数组），与注释「与真实 worker 一致」不符。核实成立 —— 5 条 op 逐条对齐。
5. Greptile（P1）与 Codex（P1）分别指出：第 3 轮改成的「`SELECT` 快照 + `DELETE`」两步，在 fire-and-forget 并发交错时会按过期快照删掉刚被刷新的目录。核实成立，且危害比我先前判断的更重 —— 不是「多删/少删一行、下次自愈」，而是**用户刚用过的项目从「最近」里消失**。据此把驱逐压成上文那条单语句 `DELETE`。同时 Copilot 指出测试里一条注释还在描述旧的 OFFSET 行为、与当轮实现不符，也一并更正。
6. 承接第 5 条：Codex 给的是「one SQL statement **or** a worker transaction」，这里取前者。仓库规则（`docs/dev-rules/database-and-migrations.md:99`）要求「多步骤写操作需要原子性时使用已有命名事务／worker transaction」——把驱逐压成单条语句后它不再是多步骤写操作，因此没有引入命名事务：`DbTxName` 的 handler 在 `worker/opHandlers/tx.ts` 与 `client/WorkerThreadTransport.ts` 各有一份、必须手工保持一致（前者文件头明写这条约束），为一个 fire-and-forget 的体验增强数据增加一对需同步维护的 handler，长期成本高于收益。`insert` 与驱逐仍是两条语句，但驱逐每次按执行那一刻的表状态实时求值、不依赖快照，交错最多重复执行一次（幂等）。

新增测试的 harness 特意用 `createDrizzleProxy` + 假 transport（按 `worker/dispatcher.ts` 的 op 语义把 SQL 转发到真实 in-memory SQLite），**不是**真实 `drizzle(sqlite)`：既有 `recentWorkdirsDelete.test.ts` mock 的是真实 drizzle，同样的用例在它上面会假绿 —— 这正是这个 bug 当初溜过去的原因。另有一条 `drizzleProxy` 契约测试锚定「db 级 raw SQL 不被代理支持」，将来代理若开始支持会变红，提醒回头更新实现里的注释。

### 手工验证

未执行。改动位于 main 侧 DB 写路径，无 UI 表现；行为由上述单测 + 反向验证覆盖。

### 未执行的验证

- 全量 `pnpm test:unit` 跑在「去掉注释里一处多余转义符」之前；该改动为纯注释，之后按规则补跑了 desktop 定向测试（10 passed），未重跑全量。
- 未启动 desktop 实测存量超限行的收敛过程（每次 upsert 删 1 行的渐进行为），仅由单测覆盖驱逐语义。
- 附带说明：本次新建 worktree 的 `cindy-protocol` submodule 原本未初始化，导致首轮门禁与 typecheck 因找不到 protocol 包而失败；按 `docs/dev-rules/environment-setup.md` 执行 `git submodule sync` + `update --init` + `pnpm install` 后才得到上面结果。与本 PR 改动无关。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

勾选 SQLite 是因为改动落在 SQLite 写路径（一条 DELETE）上，值得 reviewer 过一眼；**无 schema 变更、无新增或修改 migration**。

### 影响与回滚

- 影响范围：仅 `recent_workdirs` 表的 LRU 驱逐。写入的 DELETE 语义与原先意图完全一致（按 `last_used_at DESC` 保留前 `MAX_RECENT_WORKDIRS=10` 条），区别只是这次真的执行得到。失败仍是 fire-and-forget，不会挡住 session 创建主流程。
- 回滚 / 降级方式：单 commit revert 即可，无数据迁移、无状态残留。revert 后行为回到「驱逐静默失败、表继续涨」，不会损坏数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已注明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档：根因写在实现处注释与本 PR）
- [x] 已确认测试结果或说明未执行原因
