### PR TITLE
feat(desktop): 输入框附件改为带缩略图的文件卡

### DIFF
--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
   __clearFileThumbnailCacheForTest();
   isPathAllowedAgainst.mockReturnValue(true);
   realpath.mockImplementation(async (p: string) => p);
-  stat.mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 10 });
+  stat.mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 10, ino: 1, dev: 1 });
   createThumbnailFromPath.mockResolvedValue(okImage());
 });
 
@@ -96,7 +96,7 @@ describe('readFileThumbnail — 授权边界', () => {
   });
 
   it('目录与不存在的文件不出图', async () => {
-    stat.mockResolvedValueOnce({ isFile: () => false, mtimeMs: 1, size: 0 });
+    stat.mockResolvedValueOnce({ isFile: () => false, mtimeMs: 1, size: 0, ino: 1, dev: 1 });
     await expect(readFileThumbnail({ path: '/tmp/dir', size: 80 })).resolves.toBeNull();
     stat.mockRejectedValueOnce(new Error('ENOENT'));
     await expect(readFileThumbnail({ path: '/tmp/missing.pdf', size: 80 })).resolves.toBeNull();
@@ -122,7 +122,7 @@ describe('readFileThumbnail — 兜底与缓存', () => {
   });
 
   it('回传复核那一刻的当前字节数(卡片据此刷新「类型 · 大小」)', async () => {
-    stat.mockResolvedValue({ isFile: () => true, mtimeMs: 7, size: 4242 });
+    stat.mockResolvedValue({ isFile: () => true, mtimeMs: 7, size: 4242, ino: 1, dev: 1 });
     await expect(readFileThumbnail({ path: '/tmp/a.pdf', size: 80 })).resolves.toEqual({
       dataUrl: 'data:image/png;base64,AAA',
       byteSize: 4242,
@@ -142,6 +142,15 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     expect((await readFileThumbnail({ path: '/tmp/a.zzz', size: 80 }))?.dataUrl).toBeNull();
     expect((await readFileThumbnail({ path: '/tmp/a.zzz', size: 80 }))?.dataUrl).toBeNull();
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('取图后目标被掉包(dev/ino/mtime 变了)则丢弃结果,不交给 renderer', async () => {
+    // createThumbnailFromPath 只吃路径、拿不到 fd,校验用的 stat 和它内部那次 open
+    // 绑不到同一文件对象;结果出锅后复验一次身份,变了就不返回也不入缓存。
+    stat
+      .mockResolvedValueOnce({ isFile: () => true, mtimeMs: 1, size: 10, ino: 1, dev: 1 })
+      .mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 10, ino: 999, dev: 1 });
+    expect((await readFileThumbnail({ path: '/tmp/swap.pdf', size: 80 }))?.dataUrl).toBeNull();
   });
 
   it('系统 API 同步抛(Linux 没有这个 API)时释放名额,不把闸门占死', async () => {
@@ -347,7 +356,7 @@ describe('readFileThumbnail — 兜底与缓存', () => {
 
   it('文件被改写(mtime/size 变化)后重新出图,不吃旧缓存', async () => {
     await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 });
-    stat.mockResolvedValue({ isFile: () => true, mtimeMs: 999, size: 20 });
+    stat.mockResolvedValue({ isFile: () => true, mtimeMs: 999, size: 20, ino: 1, dev: 1 });
     createThumbnailFromPath.mockResolvedValue(okImage('data:image/png;base64,BBB'));
     expect((await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 }))?.dataUrl).toBe(
       'data:image/png;base64,BBB',

--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -144,6 +144,49 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
+  it('负结果只短期缓存,瞬时失败之后还能重试', async () => {
+    // QuickLook / Shell 偶发失败不该把预览永久钉死:超过负结果 TTL 后要重新尝试。
+    createThumbnailFromPath.mockRejectedValueOnce(new Error('transient'));
+    expect((await readFileThumbnail({ path: '/tmp/t.pdf', size: 80 }))?.dataUrl).toBeNull();
+    expect((await readFileThumbnail({ path: '/tmp/t.pdf', size: 80 }))?.dataUrl).toBeNull();
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+    // 把时间推过负结果 TTL(60s)。
+    const realNow = Date.now;
+    try {
+      const t0 = realNow();
+      Date.now = () => t0 + 61_000;
+      createThumbnailFromPath.mockResolvedValue(okImage());
+      expect((await readFileThumbnail({ path: '/tmp/t.pdf', size: 80 }))?.dataUrl).toBe(
+        'data:image/png;base64,AAA',
+      );
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('正结果也有软过期(粗时间戳文件系统上同尺寸改写撞 key 时能自愈)', async () => {
+    expect((await readFileThumbnail({ path: '/tmp/p.pdf', size: 80 }))?.dataUrl).toBe(
+      'data:image/png;base64,AAA',
+    );
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+    const realNow = Date.now;
+    try {
+      const t0 = realNow();
+      Date.now = () => t0 + 11 * 60_000;
+      await readFileThumbnail({ path: '/tmp/p.pdf', size: 80 });
+      expect(createThumbnailFromPath).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('缓存 key 含 dev/ino:同路径换成另一个 inode 不会吃旧图', async () => {
+    await readFileThumbnail({ path: '/tmp/id.pdf', size: 80 });
+    stat.mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 10, ino: 2, dev: 1 });
+    await readFileThumbnail({ path: '/tmp/id.pdf', size: 80 });
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(2);
+  });
+
   it('取图后目标被掉包(dev/ino/mtime 变了)则丢弃结果,不交给 renderer', async () => {
     // createThumbnailFromPath 只吃路径、拿不到 fd,校验用的 stat 和它内部那次 open
     // 绑不到同一文件对象;结果出锅后复验一次身份,变了就不返回也不入缓存。

--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -1,0 +1,108 @@
+/**
+ * fileThumbnail.test.ts
+ * ---------------------------------------------------------------------------
+ * 附件卡缩略图入口(file:thumbnail 背后的 readFileThumbnail)的授权边界与兜底。
+ *
+ * 这是一条新开的「renderer 递绝对路径 → main 读本地文件」通道,所以这里钉住
+ * 的是 fail-closed 行为(docs/dev-rules/electron-security-and-process-boundaries.md
+ * §5):敏感目录、相对路径、越界尺寸、目录、不存在的文件一律拿不到图,且任何
+ * 失败都回 null 而不是抛异常/漏路径。系统缩略图服务本身用 stub 替身。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const createThumbnailFromPath = vi.fn();
+
+vi.mock('electron', () => ({
+  nativeImage: {
+    createThumbnailFromPath: (...args: unknown[]) => createThumbnailFromPath(...args),
+  },
+}));
+
+const stat = vi.fn();
+vi.mock('node:fs/promises', () => ({
+  stat: (...args: unknown[]) => stat(...args),
+}));
+
+const isPathAllowedAgainst = vi.fn();
+vi.mock('../filePathPolicy', () => ({
+  isPathAllowedAgainst: (...args: unknown[]) => isPathAllowedAgainst(...args),
+  getSensitiveMediaBlocklist: () => ['/Users/x/Library/Keychains'],
+}));
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { readFileThumbnail, __clearFileThumbnailCacheForTest } from '../fileThumbnail';
+
+function okImage(dataUrl = 'data:image/png;base64,AAA') {
+  return { isEmpty: () => false, toDataURL: () => dataUrl };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __clearFileThumbnailCacheForTest();
+  isPathAllowedAgainst.mockReturnValue(true);
+  stat.mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 10 });
+  createThumbnailFromPath.mockResolvedValue(okImage());
+});
+
+describe('readFileThumbnail — 授权边界', () => {
+  it('命中敏感目录 blocklist 时不出图,也不去碰系统服务', async () => {
+    isPathAllowedAgainst.mockReturnValue(false);
+    await expect(readFileThumbnail({ path: '/Users/x/Library/Keychains/a.pdf', size: 80 })).resolves.toBeNull();
+    expect(createThumbnailFromPath).not.toHaveBeenCalled();
+  });
+
+  it('相对路径 / 空路径直接拒绝', async () => {
+    await expect(readFileThumbnail({ path: 'a.pdf', size: 80 })).resolves.toBeNull();
+    await expect(readFileThumbnail({ path: '', size: 80 })).resolves.toBeNull();
+    expect(createThumbnailFromPath).not.toHaveBeenCalled();
+  });
+
+  it('尺寸越界或非数字一律拒绝(不让 renderer 用尺寸放大资源占用)', async () => {
+    for (const size of [0, 8, 4096, Number.NaN, Number.POSITIVE_INFINITY]) {
+      await expect(readFileThumbnail({ path: '/tmp/a.pdf', size })).resolves.toBeNull();
+    }
+    expect(createThumbnailFromPath).not.toHaveBeenCalled();
+  });
+
+  it('目录与不存在的文件不出图', async () => {
+    stat.mockResolvedValueOnce({ isFile: () => false, mtimeMs: 1, size: 0 });
+    await expect(readFileThumbnail({ path: '/tmp/dir', size: 80 })).resolves.toBeNull();
+    stat.mockRejectedValueOnce(new Error('ENOENT'));
+    await expect(readFileThumbnail({ path: '/tmp/missing.pdf', size: 80 })).resolves.toBeNull();
+    expect(createThumbnailFromPath).not.toHaveBeenCalled();
+  });
+});
+
+describe('readFileThumbnail — 兜底与缓存', () => {
+  it('系统服务抛错时回 null,不把异常抛给 renderer', async () => {
+    createThumbnailFromPath.mockRejectedValue(new Error('unsupported'));
+    await expect(readFileThumbnail({ path: '/tmp/a.zzz', size: 80 })).resolves.toBeNull();
+  });
+
+  it('空图当作拿不到', async () => {
+    createThumbnailFromPath.mockResolvedValue({ isEmpty: () => true, toDataURL: () => '' });
+    await expect(readFileThumbnail({ path: '/tmp/a.pdf', size: 80 })).resolves.toBeNull();
+  });
+
+  it('同一文件重复请求只问一次系统服务', async () => {
+    const first = await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 });
+    const second = await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 });
+    expect(first).toBe('data:image/png;base64,AAA');
+    expect(second).toBe(first);
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('文件被改写(mtime/size 变化)后重新出图,不吃旧缓存', async () => {
+    await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 });
+    stat.mockResolvedValue({ isFile: () => true, mtimeMs: 999, size: 20 });
+    createThumbnailFromPath.mockResolvedValue(okImage('data:image/png;base64,BBB'));
+    await expect(readFileThumbnail({ path: '/tmp/a.pdf', size: 80 })).resolves.toBe(
+      'data:image/png;base64,BBB',
+    );
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -105,28 +105,42 @@ describe('readFileThumbnail — 授权边界', () => {
 });
 
 describe('readFileThumbnail — 兜底与缓存', () => {
-  it('系统服务抛错时回 null,不把异常抛给 renderer', async () => {
+  it('系统服务抛错时 dataUrl 为 null,不把异常抛给 renderer', async () => {
     createThumbnailFromPath.mockRejectedValue(new Error('unsupported'));
-    await expect(readFileThumbnail({ path: '/tmp/a.zzz', size: 80 })).resolves.toBeNull();
+    await expect(readFileThumbnail({ path: '/tmp/a.zzz', size: 80 })).resolves.toEqual({
+      dataUrl: null,
+      byteSize: 10,
+    });
   });
 
   it('空图当作拿不到', async () => {
     createThumbnailFromPath.mockResolvedValue({ isEmpty: () => true, toDataURL: () => '' });
-    await expect(readFileThumbnail({ path: '/tmp/a.pdf', size: 80 })).resolves.toBeNull();
+    await expect(readFileThumbnail({ path: '/tmp/a.pdf', size: 80 })).resolves.toEqual({
+      dataUrl: null,
+      byteSize: 10,
+    });
+  });
+
+  it('回传复核那一刻的当前字节数(卡片据此刷新「类型 · 大小」)', async () => {
+    stat.mockResolvedValue({ isFile: () => true, mtimeMs: 7, size: 4242 });
+    await expect(readFileThumbnail({ path: '/tmp/a.pdf', size: 80 })).resolves.toEqual({
+      dataUrl: 'data:image/png;base64,AAA',
+      byteSize: 4242,
+    });
   });
 
   it('同一文件重复请求只问一次系统服务', async () => {
     const first = await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 });
     const second = await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 });
-    expect(first).toBe('data:image/png;base64,AAA');
-    expect(second).toBe(first);
+    expect(first?.dataUrl).toBe('data:image/png;base64,AAA');
+    expect(second?.dataUrl).toBe(first?.dataUrl);
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
   it('出不了图的文件进负缓存,不必每次重挂载都再撞一次昂贵的原生调用', async () => {
     createThumbnailFromPath.mockResolvedValue({ isEmpty: () => true, toDataURL: () => '' });
-    await expect(readFileThumbnail({ path: '/tmp/a.zzz', size: 80 })).resolves.toBeNull();
-    await expect(readFileThumbnail({ path: '/tmp/a.zzz', size: 80 })).resolves.toBeNull();
+    expect((await readFileThumbnail({ path: '/tmp/a.zzz', size: 80 }))?.dataUrl).toBeNull();
+    expect((await readFileThumbnail({ path: '/tmp/a.zzz', size: 80 }))?.dataUrl).toBeNull();
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
@@ -157,19 +171,48 @@ describe('readFileThumbnail — 兜底与缓存', () => {
       expect(peak).toBe(4);
       // 让前 4 个全部超时:IPC 各自回 null,但原生任务仍挂着。
       await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
-      expect(await Promise.all(calls.slice(0, 4))).toEqual([null, null, null, null]);
-      // 关键断言:名额没被超时释放,排队的第 5 个仍进不来。
+      expect((await Promise.all(calls.slice(0, 4))).map((r) => r?.dataUrl)).toEqual([
+        null, null, null, null,
+      ]);
+      // 关键断言:名额没被超时释放,排队的第 5 个自始至终没能点火。
       expect(peak).toBe(4);
       expect(createThumbnailFromPath).toHaveBeenCalledTimes(4);
-      // 放掉一个原生任务,排队者才拿到名额。
-      gates.shift()?.();
-      await vi.advanceTimersByTimeAsync(0);
-      expect(createThumbnailFromPath).toHaveBeenCalledTimes(5);
+      // 而它也不会永远挂着——排队这一段同样受超时约束,直接回落。
+      expect((await calls[4])?.dataUrl).toBeNull();
+      expect(createThumbnailFromPath).toHaveBeenCalledTimes(4);
       while (gates.length) {
         gates.shift()?.();
         await vi.advanceTimersByTimeAsync(0);
       }
       await Promise.all(calls);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('名额被挂死任务占满时,排队请求超时回落而不是无限挂起', async () => {
+    const gates: (() => void)[] = [];
+    createThumbnailFromPath.mockImplementation(
+      () => new Promise((resolve) => gates.push(() => resolve(okImage()))),
+    );
+    vi.useFakeTimers();
+    try {
+      // 先用 4 个挂死任务占满名额。
+      const hung = Array.from({ length: 4 }, (_, i) =>
+        readFileThumbnail({ path: `/tmp/block${i}.pdf`, size: 80 }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(createThumbnailFromPath).toHaveBeenCalledTimes(4);
+      // 第 5 个只能排队:它必须在超时后自己回落,而不是等到天荒地老。
+      const queued = readFileThumbnail({ path: '/tmp/queued.pdf', size: 80 });
+      await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+      expect((await queued)?.dataUrl).toBeNull();
+      expect(createThumbnailFromPath).toHaveBeenCalledTimes(4);
+      while (gates.length) {
+        gates.shift()?.();
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      await Promise.all(hung);
     } finally {
       vi.useRealTimers();
     }
@@ -183,11 +226,11 @@ describe('readFileThumbnail — 兜底与缓存', () => {
       }),
     );
     vi.useFakeTimers();
-    let first: Promise<string | null>;
+    let first: ReturnType<typeof readFileThumbnail>;
     try {
       first = readFileThumbnail({ path: '/tmp/late.pdf', size: 80 });
       await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
-      expect(await first).toBeNull();
+      expect((await first)?.dataUrl).toBeNull();
     } finally {
       vi.useRealTimers();
     }
@@ -195,7 +238,7 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     resolveNative?.(okImage());
     await Promise.resolve();
     await Promise.resolve();
-    await expect(readFileThumbnail({ path: '/tmp/late.pdf', size: 80 })).resolves.toBe(
+    expect((await readFileThumbnail({ path: '/tmp/late.pdf', size: 80 }))?.dataUrl).toBe(
       'data:image/png;base64,AAA',
     );
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
@@ -209,14 +252,14 @@ describe('readFileThumbnail — 兜底与缓存', () => {
       }),
     );
     vi.useFakeTimers();
-    let first: Promise<string | null>;
+    let first: ReturnType<typeof readFileThumbnail>;
     try {
       first = readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 });
       await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
-      expect(await first).toBeNull();
+      expect((await first)?.dataUrl).toBeNull();
       // 超时只让 IPC 早返回;原生任务还挂着时,同一文件的重挂载请求复用它,
       // 不会再点一把新火(否则系统卡住时会越积越多)。
-      await expect(readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 })).resolves.toBeNull();
+      expect((await readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 }))?.dataUrl).toBeNull();
       expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
@@ -225,7 +268,7 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     rejectNative?.(new Error('unsupported'));
     await Promise.resolve();
     await Promise.resolve();
-    await expect(readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 })).resolves.toBeNull();
+    expect((await readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 }))?.dataUrl).toBeNull();
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
@@ -244,7 +287,7 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     await Promise.resolve();
     resolveImage?.(okImage());
     const results = await all;
-    expect(results).toEqual(Array(3).fill('data:image/png;base64,AAA'));
+    expect(results.map((r) => r?.dataUrl)).toEqual(Array(3).fill('data:image/png;base64,AAA'));
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
@@ -284,7 +327,7 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 });
     stat.mockResolvedValue({ isFile: () => true, mtimeMs: 999, size: 20 });
     createThumbnailFromPath.mockResolvedValue(okImage('data:image/png;base64,BBB'));
-    await expect(readFileThumbnail({ path: '/tmp/a.pdf', size: 80 })).resolves.toBe(
+    expect((await readFileThumbnail({ path: '/tmp/a.pdf', size: 80 }))?.dataUrl).toBe(
       'data:image/png;base64,BBB',
     );
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(2);

--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -38,6 +38,9 @@ vi.mock('../logger', () => ({
 
 import { readFileThumbnail, __clearFileThumbnailCacheForTest } from '../fileThumbnail';
 
+/** 与 fileThumbnail.ts 的 TIMEOUT_MS 对齐(那里是模块私有常量)。 */
+const TIMEOUT_MS = 4000;
+
 function okImage(dataUrl = 'data:image/png;base64,AAA') {
   return { isEmpty: () => false, toDataURL: () => dataUrl };
 }
@@ -127,20 +130,103 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
-  it('超时不入负缓存(是暂时性的,下次可能成功)', async () => {
+  it('超时后名额不放行,直到原生任务真正 settle(否则闸门形同虚设)', async () => {
+    // 超时只让 IPC 早返回,QuickLook/Shell 那边取消不了 —— 若此刻就放名额,
+    // 系统卡住时每过一个超时周期就会再放一批新任务进去。
+    const gates: (() => void)[] = [];
+    let active = 0;
+    let peak = 0;
+    createThumbnailFromPath.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          active += 1;
+          peak = Math.max(peak, active);
+          gates.push(() => {
+            active -= 1;
+            resolve(okImage());
+          });
+        }),
+    );
     vi.useFakeTimers();
     try {
-      createThumbnailFromPath.mockReturnValue(new Promise(() => {}));
-      const first = readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 });
-      await vi.advanceTimersByTimeAsync(5000);
-      await expect(first).resolves.toBeNull();
+      // 5 个不同文件:前 4 个占满名额,第 5 个排队。
+      const calls = Array.from({ length: 5 }, (_, i) =>
+        readFileThumbnail({ path: `/tmp/hang${i}.pdf`, size: 80 }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(peak).toBe(4);
+      // 让前 4 个全部超时:IPC 各自回 null,但原生任务仍挂着。
+      await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+      expect(await Promise.all(calls.slice(0, 4))).toEqual([null, null, null, null]);
+      // 关键断言:名额没被超时释放,排队的第 5 个仍进不来。
+      expect(peak).toBe(4);
+      expect(createThumbnailFromPath).toHaveBeenCalledTimes(4);
+      // 放掉一个原生任务,排队者才拿到名额。
+      gates.shift()?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(createThumbnailFromPath).toHaveBeenCalledTimes(5);
+      while (gates.length) {
+        gates.shift()?.();
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      await Promise.all(calls);
     } finally {
       vi.useRealTimers();
     }
-    createThumbnailFromPath.mockResolvedValue(okImage());
-    await expect(readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 })).resolves.toBe(
+  });
+
+  it('超时后迟到的原生结果仍写进缓存,下次挂载直接命中', async () => {
+    let resolveNative: ((v: unknown) => void) | undefined;
+    createThumbnailFromPath.mockReturnValue(
+      new Promise((resolve) => {
+        resolveNative = resolve;
+      }),
+    );
+    vi.useFakeTimers();
+    let first: Promise<string | null>;
+    try {
+      first = readFileThumbnail({ path: '/tmp/late.pdf', size: 80 });
+      await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+      expect(await first).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+    // 原生任务姗姗来迟：结果不该被丢掉。
+    resolveNative?.(okImage());
+    await Promise.resolve();
+    await Promise.resolve();
+    await expect(readFileThumbnail({ path: '/tmp/late.pdf', size: 80 })).resolves.toBe(
       'data:image/png;base64,AAA',
     );
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('原生任务卡住期间不重复点火;它真失败后才落负缓存', async () => {
+    let rejectNative: ((e: unknown) => void) | undefined;
+    createThumbnailFromPath.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectNative = reject;
+      }),
+    );
+    vi.useFakeTimers();
+    let first: Promise<string | null>;
+    try {
+      first = readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 });
+      await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+      expect(await first).toBeNull();
+      // 超时只让 IPC 早返回;原生任务还挂着时,同一文件的重挂载请求复用它,
+      // 不会再点一把新火(否则系统卡住时会越积越多)。
+      await expect(readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 })).resolves.toBeNull();
+      expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+    // 原生任务最终失败 → 落负缓存,后续请求直接命中,仍不重复调用。
+    rejectNative?.(new Error('unsupported'));
+    await Promise.resolve();
+    await Promise.resolve();
+    await expect(readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 })).resolves.toBeNull();
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
   it('同一文件的并发请求合并成一次原生调用', async () => {

--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -144,6 +144,28 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
   });
 
+  it('系统 API 同步抛(Linux 没有这个 API)时释放名额,不把闸门占死', async () => {
+    // 本仓有 deb 打包目标,而 createThumbnailFromPath 只在 macOS / Windows 实现:
+    // 同步异常若发生在 native.finally 装上之前,名额和 inFlight 会永久泄漏。
+    createThumbnailFromPath.mockImplementation(() => {
+      throw new TypeError('createThumbnailFromPath is not a function');
+    });
+    for (let i = 0; i < 6; i++) {
+      expect((await readFileThumbnail({ path: `/tmp/lin${i}.pdf`, size: 80 }))?.dataUrl).toBeNull();
+    }
+    // 6 次全部真正跑到了系统调用,说明前 4 次没把名额占死。
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(6);
+  });
+
+  it('一张图只编码一次 dataURL(race 与迟到回调共用结果)', async () => {
+    const toDataURL = vi.fn(() => 'data:image/png;base64,AAA');
+    createThumbnailFromPath.mockResolvedValue({ isEmpty: () => false, toDataURL });
+    await readFileThumbnail({ path: '/tmp/once.pdf', size: 80 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(toDataURL).toHaveBeenCalledTimes(1);
+  });
+
   it('超时后名额不放行,直到原生任务真正 settle(否则闸门形同虚设)', async () => {
     // 超时只让 IPC 早返回,QuickLook/Shell 那边取消不了 —— 若此刻就放名额,
     // 系统卡住时每过一个超时周期就会再放一批新任务进去。

--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -68,7 +68,7 @@ describe('readFileThumbnail — 授权边界', () => {
   });
 
   it('尺寸越界或非数字一律拒绝(不让 renderer 用尺寸放大资源占用)', async () => {
-    for (const size of [0, 8, 4096, Number.NaN, Number.POSITIVE_INFINITY]) {
+    for (const size of [0, 8, 129, 512, 4096, Number.NaN, Number.POSITIVE_INFINITY]) {
       await expect(readFileThumbnail({ path: '/tmp/a.pdf', size })).resolves.toBeNull();
     }
     expect(createThumbnailFromPath).not.toHaveBeenCalled();
@@ -187,13 +187,53 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(2);
   });
 
-  it('取图后目标被掉包(dev/ino/mtime 变了)则丢弃结果,不交给 renderer', async () => {
+  it('revalidate 跳过正缓存重新生成,但仍尊重负缓存', async () => {
+    // 粗时间戳文件系统上「改完切回来就发送」算不出新 key,靠 TTL 要等十分钟。
+    await readFileThumbnail({ path: '/tmp/rv.pdf', size: 80 });
+    await readFileThumbnail({ path: '/tmp/rv.pdf', size: 80 });
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+    await readFileThumbnail({ path: '/tmp/rv.pdf', size: 80, revalidate: true });
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(2);
+
+    // 负缓存不跳过:否则每次焦点复核都要再撞一次同一堵墙。
+    __clearFileThumbnailCacheForTest();
+    vi.clearAllMocks();
+    createThumbnailFromPath.mockResolvedValue({ isEmpty: () => true, toDataURL: () => '' });
+    await readFileThumbnail({ path: '/tmp/neg.zzz', size: 80 });
+    await readFileThumbnail({ path: '/tmp/neg.zzz', size: 80, revalidate: true });
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('缓存按字节预算限界,不只按条数(尺寸进 key,同路径换 size 就是新条目)', async () => {
+    // 单条约 4MB 的 dataURL:条数远没到 512,字节预算(24MB)先到顶。
+    const big = 'data:image/png;base64,' + 'A'.repeat(4 * 1024 * 1024);
+    createThumbnailFromPath.mockResolvedValue({ isEmpty: () => false, toDataURL: () => big });
+    for (let px = 16; px <= 26; px++) {
+      await readFileThumbnail({ path: '/tmp/big.pdf', size: px });
+    }
+    // 11 次请求 × 4MB = 44MB,若不按字节淘汰就会全留下。
+    vi.clearAllMocks();
+    createThumbnailFromPath.mockResolvedValue(okImage());
+    // 最早那几档已被淘汰 → 会重新生成。
+    await readFileThumbnail({ path: '/tmp/big.pdf', size: 16 });
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('取图后目标被掉包(dev/ino/mtime/size 变了)则丢弃结果,不交给 renderer', async () => {
     // createThumbnailFromPath 只吃路径、拿不到 fd,校验用的 stat 和它内部那次 open
     // 绑不到同一文件对象;结果出锅后复验一次身份,变了就不返回也不入缓存。
     stat
       .mockResolvedValueOnce({ isFile: () => true, mtimeMs: 1, size: 10, ino: 1, dev: 1 })
       .mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 10, ino: 999, dev: 1 });
     expect((await readFileThumbnail({ path: '/tmp/swap.pdf', size: 80 }))?.dataUrl).toBeNull();
+  });
+
+  it('复验也比 size:mtime 没动但尺寸变了同样算被掉包', async () => {
+    __clearFileThumbnailCacheForTest();
+    stat
+      .mockResolvedValueOnce({ isFile: () => true, mtimeMs: 1, size: 10, ino: 1, dev: 1 })
+      .mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 4242, ino: 1, dev: 1 });
+    expect((await readFileThumbnail({ path: '/tmp/resize.pdf', size: 80 }))?.dataUrl).toBeNull();
   });
 
   it('系统 API 同步抛(Linux 没有这个 API)时释放名额,不把闸门占死', async () => {

--- a/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
+++ b/apps/desktop/src/main/__tests__/fileThumbnail.test.ts
@@ -20,8 +20,10 @@ vi.mock('electron', () => ({
 }));
 
 const stat = vi.fn();
+const realpath = vi.fn();
 vi.mock('node:fs/promises', () => ({
   stat: (...args: unknown[]) => stat(...args),
+  realpath: (...args: unknown[]) => realpath(...args),
 }));
 
 const isPathAllowedAgainst = vi.fn();
@@ -44,6 +46,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   __clearFileThumbnailCacheForTest();
   isPathAllowedAgainst.mockReturnValue(true);
+  realpath.mockImplementation(async (p: string) => p);
   stat.mockResolvedValue({ isFile: () => true, mtimeMs: 1, size: 10 });
   createThumbnailFromPath.mockResolvedValue(okImage());
 });
@@ -66,6 +69,27 @@ describe('readFileThumbnail — 授权边界', () => {
       await expect(readFileThumbnail({ path: '/tmp/a.pdf', size })).resolves.toBeNull();
     }
     expect(createThumbnailFromPath).not.toHaveBeenCalled();
+  });
+
+  it('软链指向敏感目录时,按真实目标拒绝(词法路径看着无害也不放行)', async () => {
+    // 允许目录里的一条软链完全可以指向 ~/Library/Keychains:只看词法路径会放行。
+    realpath.mockResolvedValue('/Users/x/Library/Keychains/login.keychain');
+    isPathAllowedAgainst.mockImplementation((p: string) => !p.includes('Keychains'));
+    await expect(readFileThumbnail({ path: '/tmp/harmless-link.pdf', size: 80 })).resolves.toBeNull();
+    expect(createThumbnailFromPath).not.toHaveBeenCalled();
+  });
+
+  it('realpath 失败(断链 / 软链环 / EACCES)时不出图', async () => {
+    realpath.mockRejectedValue(new Error('ELOOP'));
+    await expect(readFileThumbnail({ path: '/tmp/loop.pdf', size: 80 })).resolves.toBeNull();
+    expect(createThumbnailFromPath).not.toHaveBeenCalled();
+  });
+
+  it('stat 与取图都用 realpath 后的真实路径(关掉 check→open 的 TOCTOU 窗口)', async () => {
+    realpath.mockResolvedValue('/tmp/real-target.pdf');
+    await readFileThumbnail({ path: '/tmp/link.pdf', size: 80 });
+    expect(stat).toHaveBeenCalledWith('/tmp/real-target.pdf');
+    expect(createThumbnailFromPath).toHaveBeenCalledWith('/tmp/real-target.pdf', expect.anything());
   });
 
   it('目录与不存在的文件不出图', async () => {
@@ -94,6 +118,80 @@ describe('readFileThumbnail — 兜底与缓存', () => {
     expect(first).toBe('data:image/png;base64,AAA');
     expect(second).toBe(first);
     expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('出不了图的文件进负缓存,不必每次重挂载都再撞一次昂贵的原生调用', async () => {
+    createThumbnailFromPath.mockResolvedValue({ isEmpty: () => true, toDataURL: () => '' });
+    await expect(readFileThumbnail({ path: '/tmp/a.zzz', size: 80 })).resolves.toBeNull();
+    await expect(readFileThumbnail({ path: '/tmp/a.zzz', size: 80 })).resolves.toBeNull();
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('超时不入负缓存(是暂时性的,下次可能成功)', async () => {
+    vi.useFakeTimers();
+    try {
+      createThumbnailFromPath.mockReturnValue(new Promise(() => {}));
+      const first = readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 });
+      await vi.advanceTimersByTimeAsync(5000);
+      await expect(first).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+    createThumbnailFromPath.mockResolvedValue(okImage());
+    await expect(readFileThumbnail({ path: '/tmp/slow.pdf', size: 80 })).resolves.toBe(
+      'data:image/png;base64,AAA',
+    );
+  });
+
+  it('同一文件的并发请求合并成一次原生调用', async () => {
+    let resolveImage: ((v: unknown) => void) | undefined;
+    createThumbnailFromPath.mockReturnValue(
+      new Promise((resolve) => {
+        resolveImage = resolve;
+      }),
+    );
+    const all = Promise.all([
+      readFileThumbnail({ path: '/tmp/same.pdf', size: 80 }),
+      readFileThumbnail({ path: '/tmp/same.pdf', size: 80 }),
+      readFileThumbnail({ path: '/tmp/same.pdf', size: 80 }),
+    ]);
+    await Promise.resolve();
+    resolveImage?.(okImage());
+    const results = await all;
+    expect(results).toEqual(Array(3).fill('data:image/png;base64,AAA'));
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('并发闸限制同时在飞的原生任务数(超时取消不了底层任务,只能限流)', async () => {
+    let peak = 0;
+    let active = 0;
+    const gates: (() => void)[] = [];
+    createThumbnailFromPath.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          active += 1;
+          peak = Math.max(peak, active);
+          gates.push(() => {
+            active -= 1;
+            resolve(okImage());
+          });
+        }),
+    );
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+    // 每个路径都不同 → 不会被 in-flight 去重合并,只受并发闸约束。
+    const all = Promise.all(
+      Array.from({ length: 10 }, (_, i) => readFileThumbnail({ path: `/tmp/f${i}.pdf`, size: 80 })),
+    );
+    await tick();
+    expect(peak).toBeLessThanOrEqual(4);
+    // 逐个放行:每释放一个,排队中的下一个才会启动并注册新 gate。
+    for (let i = 0; i < 10; i++) {
+      await tick();
+      gates.shift()?.();
+    }
+    await all;
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(createThumbnailFromPath).toHaveBeenCalledTimes(10);
   });
 
   it('文件被改写(mtime/size 变化)后重新出图,不吃旧缓存', async () => {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -4896,7 +4896,10 @@ const registerIpcHandlers = () => {
   // 任何失败都回 null,由 renderer 回落到自绘文件图标。
   ipcMain.handle(
     'file:thumbnail',
-    async (event: Electron.IpcMainInvokeEvent, params: { path: string; size: number }) => {
+    async (
+      event: Electron.IpcMainInvokeEvent,
+      params: { path: string; size: number; revalidate?: boolean },
+    ) => {
       assertTrustedAppRendererEvent(event);
       return readFileThumbnail(params);
     },

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -213,6 +213,7 @@ import {
 import { localFileSchemePrivilege, registerLocalFileProtocolHandler } from './localFileProtocol';
 import { audioFileSchemePrivilege, registerAudioFileProtocolHandler } from './audioFileProtocol';
 import { buildSystemPathBlocklist, isPathAllowedAgainst } from './filePathPolicy';
+import { readFileThumbnail } from './fileThumbnail';
 import { resolveShellOpenPathTarget } from './shellOpenPath';
 import { cindyGhostSchemePrivilege } from './cindy-brain/runtime/electronSandboxAdapter';
 import { fetchReleaseNotes, fetchReleaseNotesIndex } from './releaseNotesService';
@@ -4889,6 +4890,17 @@ const registerIpcHandlers = () => {
       lightboxMedia.readImageBytes(params),
     );
   }
+
+  // 附件卡缩略图:系统缩略图服务(macOS QuickLook / Windows Shell)按路径出小预览。
+  // 高权限入口——先过 sender 闸,再由 readFileThumbnail 做路径策略与 payload 校验;
+  // 任何失败都回 null,由 renderer 回落到自绘文件图标。
+  ipcMain.handle(
+    'file:thumbnail',
+    async (event: Electron.IpcMainInvokeEvent, params: { path: string; size: number }) => {
+      assertTrustedAppRendererEvent(event);
+      return readFileThumbnail(params);
+    },
+  );
 
   // ── CC Agent SDK IPC handlers (Stage 2 C1 大批退役) ──
   // 老 cc-agent:* handler 全部退役 —— renderer 已切到 maker.* (A4/A5/B/B'/B''/C1/C2)。

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -1,0 +1,114 @@
+/**
+ * fileThumbnail — 用系统缩略图服务给本地文件生成小预览图。
+ *
+ * 为什么走系统而不是自己渲染:`nativeImage.createThumbnailFromPath` 在 macOS 背后
+ * 是 QuickLook、Windows 是 Shell IShellItemImageFactory —— 一个调用就覆盖 PDF /
+ * Office / 文本 / 代码 / 图片 / 视频,拿到的是**文件真实内容**的缩略图(实测本机
+ * PDF 48ms、Markdown 165ms、JSON 22ms),renderer 不必背 pdfjs,也不用为每种格式
+ * 各自接一个解析器。
+ *
+ * 边界(见 docs/dev-rules/electron-security-and-process-boundaries.md §5):
+ *   - 调用方身份由 assertTrustedAppRendererEvent 在 handler 侧闸住,这里只做
+ *     路径与 payload 校验,不信任 renderer 传来的任何归属结论。
+ *   - 路径策略复用 xdt-file:// 协议那条同款敏感目录 blocklist(filePathPolicy),
+ *     不给 renderer 开出第二条读取面。
+ *   - 一切失败都返回 null(fail closed),不把 errno、堆栈或内部绝对路径回传。
+ */
+
+import { nativeImage } from 'electron';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { getSensitiveMediaBlocklist, isPathAllowedAgainst } from './filePathPolicy';
+import { createLogger } from './logger';
+
+const log = createLogger('fileThumbnail');
+
+/** 允许的请求边长(CSS px 的整数倍),避免 renderer 传任意值放大资源占用。 */
+const MIN_PX = 16;
+const MAX_PX = 512;
+
+/**
+ * 系统缩略图偶发卡住(实测同进程连续调 app.getFileIcon 会挂死),这里给硬超时:
+ * 附件托盘宁可回落图标,也不能把一次 IPC 永远挂在那儿。
+ */
+const TIMEOUT_MS = 4000;
+
+/** 缓存条数上限;value 是 40~80px 的 PNG dataURL,单条只有几 KB。 */
+const CACHE_LIMIT = 128;
+
+const cache = new Map<string, string>();
+
+function cacheGet(key: string): string | undefined {
+  const hit = cache.get(key);
+  if (hit === undefined) return undefined;
+  // 简易 LRU:命中即挪到队尾。
+  cache.delete(key);
+  cache.set(key, hit);
+  return hit;
+}
+
+function cacheSet(key: string, value: string): void {
+  if (cache.size >= CACHE_LIMIT) {
+    const oldest = cache.keys().next();
+    if (!oldest.done) cache.delete(oldest.value);
+  }
+  cache.set(key, value);
+}
+
+/** 仅供测试:清空缓存,避免用例之间互相污染。 */
+export function __clearFileThumbnailCacheForTest(): void {
+  cache.clear();
+}
+
+export interface FileThumbnailParams {
+  /** 本机绝对路径。 */
+  path: string;
+  /** 期望边长(px)。 */
+  size: number;
+}
+
+/**
+ * 返回 PNG dataURL;拿不到缩略图(路径越界 / 文件不存在 / 系统不支持该类型 /
+ * 超时)一律返回 null,由调用方回落到自绘图标。
+ */
+export async function readFileThumbnail(params: FileThumbnailParams): Promise<string | null> {
+  const absPath = typeof params?.path === 'string' ? params.path : '';
+  const size = Number(params?.size);
+  if (!absPath || !path.isAbsolute(absPath)) return null;
+  if (!Number.isFinite(size) || size < MIN_PX || size > MAX_PX) return null;
+  if (!isPathAllowedAgainst(absPath, getSensitiveMediaBlocklist())) return null;
+
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(absPath);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile()) return null;
+
+  // mtime + size 进 key:文件被改写后不会拿到旧缩略图。
+  const key = `${absPath}::${stat.mtimeMs}::${stat.size}::${Math.round(size)}`;
+  const cached = cacheGet(key);
+  if (cached) return cached;
+
+  try {
+    const image = await Promise.race([
+      nativeImage.createThumbnailFromPath(absPath, {
+        width: Math.round(size),
+        height: Math.round(size),
+      }),
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS),
+      ),
+    ]);
+    if (!image || image.isEmpty()) return null;
+    const dataUrl = image.toDataURL();
+    cacheSet(key, dataUrl);
+    return dataUrl;
+  } catch (err) {
+    // 系统不支持该类型是常态(冷门扩展名),按 debug 记,不刷 warn。
+    log.debug('thumbnail unavailable', { ext: path.extname(absPath), error: String(err) });
+    return null;
+  }
+}

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -187,6 +187,24 @@ export async function readFileThumbnail(
   const pending = inFlight.get(key);
   if (pending) return pending;
 
+  /**
+   * 取图后复验目标身份。`createThumbnailFromPath` 只吃路径、拿不到 fd,校验用的
+   * stat 与它内部那次 open 天然绑不到同一个文件对象;允许目录里的目录项若在这中间
+   * 被换成指向敏感文件的软链,拿回来的就会是别人的内容。这里在结果出锅后按
+   * dev/ino/mtime 复验一次:关不掉底层竞争窗口,但能拦住「已经被换掉的目标」的
+   * 缩略图交到 renderer 手里。(既有 xdt-file:// 协议是同构写法,同一量级的窗口。)
+   */
+  const sameTarget = async (): Promise<boolean> => {
+    try {
+      const after = await fs.stat(realPath);
+      return (
+        after.ino === stat.ino && after.dev === stat.dev && after.mtimeMs === stat.mtimeMs
+      );
+    } catch {
+      return false;
+    }
+  };
+
   const task = (async (): Promise<FileThumbnailResult> => {
     // 排队这一段也算进超时:四个挂死的原生任务会一直占着名额,排不上就直接回落。
     const gotSlot = await acquireSlot(TIMEOUT_MS);
@@ -225,8 +243,13 @@ export async function readFileThumbnail(
     // 若在超时那一刻就放名额、删 inFlight,系统卡住时每过 4s 就会再放 4 个新任务
     // 进去,闸门等于没有——真实在飞数必须由原生任务的生命周期决定。
     void native
-      .then((image) => {
+      .then(async (image) => {
         // 迟到的结果照样有用:写进缓存,下次挂载直接命中,不用再跑一遍。
+        // 但先复验目标没被掉包,否则连缓存都不该留。
+        if (!(await sameTarget())) {
+          log.debug('thumbnail target changed under us', { ext: path.extname(realPath) });
+          return;
+        }
         cacheSet(key, encodeOnce(image));
       })
       .catch((err) => {
@@ -248,6 +271,7 @@ export async function readFileThumbnail(
           timer = setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS);
         }),
       ]);
+      if (!(await sameTarget())) return { dataUrl: null, byteSize };
       return { dataUrl: encodeOnce(image), byteSize };
     } catch {
       // 超时或原生失败:本次 IPC 回 null 让卡片先回落图标。task 会带着 null 停在

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -195,10 +195,30 @@ export async function readFileThumbnail(
       log.debug('thumbnail slot wait timed out', { ext: path.extname(realPath) });
       return { dataUrl: null, byteSize };
     }
-    const native = nativeImage.createThumbnailFromPath(realPath, {
-      width: Math.round(size),
-      height: Math.round(size),
-    });
+    let native: Promise<Electron.NativeImage>;
+    try {
+      native = nativeImage.createThumbnailFromPath(realPath, {
+        width: Math.round(size),
+        height: Math.round(size),
+      });
+    } catch (err) {
+      // 同步抛:Linux 上根本没有这个 API(Electron 只在 macOS / Windows 实现,而本仓
+      // 有 deb 打包目标),异常会在下面的 finally 装上之前就掀桌 —— 那样名额和
+      // inFlight 会永久泄漏,前四个附件就把闸门占死。这里补齐清理再回落。
+      releaseSlot();
+      inFlight.delete(key);
+      cacheSet(key, null);
+      log.debug('thumbnail api unavailable', { error: String(err) });
+      return { dataUrl: null, byteSize };
+    }
+
+    // 一张 NativeImage 只编码一次:成功路径上 race 与 native.then 都要拿 dataURL,
+    // 各编一次等于白白多做一遍 PNG 编码 + 字符串分配(一次拖入多个附件时会放大)。
+    let encoded: string | null | undefined;
+    const encodeOnce = (image: Electron.NativeImage | null | undefined): string | null => {
+      if (encoded === undefined) encoded = !image || image.isEmpty() ? null : image.toDataURL();
+      return encoded;
+    };
 
     // 名额与 in-flight 都跟着**原生 promise**走,不跟着下面那个 race:超时只能让
     // IPC 早点返回,取消不了已经交给 QuickLook / Shell 的任务(Electron 无此 API)。
@@ -207,7 +227,7 @@ export async function readFileThumbnail(
     void native
       .then((image) => {
         // 迟到的结果照样有用:写进缓存,下次挂载直接命中,不用再跑一遍。
-        cacheSet(key, !image || image.isEmpty() ? null : image.toDataURL());
+        cacheSet(key, encodeOnce(image));
       })
       .catch((err) => {
         // 系统不支持该类型是常态(冷门扩展名),按 debug 记,不刷 warn。
@@ -228,7 +248,7 @@ export async function readFileThumbnail(
           timer = setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS);
         }),
       ]);
-      return { dataUrl: !image || image.isEmpty() ? null : image.toDataURL(), byteSize };
+      return { dataUrl: encodeOnce(image), byteSize };
     } catch {
       // 超时或原生失败:本次 IPC 回 null 让卡片先回落图标。task 会带着 null 停在
       // inFlight 里直到原生 settle —— 期间同一文件的重挂载请求复用它,不会再点火。

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -47,25 +47,53 @@ const MAX_CONCURRENT = 4;
 /** null = 已知这份文件出不了图(损坏 / 系统不支持),负缓存同样按内容版本失效。 */
 const cache = new Map<string, string | null>();
 /** 同 key 在飞的请求:多张卡指向同一文件时只做一次原生调用。 */
-const inFlight = new Map<string, Promise<string | null>>();
+const inFlight = new Map<string, Promise<FileThumbnailResult | null>>();
 
-let running = 0;
-const waiters: (() => void)[] = [];
-
-/** 并发闸:超过 MAX_CONCURRENT 时排队,拿到名额再往下走。 */
-async function acquireSlot(): Promise<void> {
-  if (running < MAX_CONCURRENT) {
-    running += 1;
-    return;
-  }
-  await new Promise<void>((resolve) => waiters.push(resolve));
-  running += 1;
+interface Waiter {
+  grant: () => void;
 }
 
+let running = 0;
+const waiters: Waiter[] = [];
+
+/**
+ * 并发闸:拿到名额返回 true;在 `timeoutMs` 内排不上就放弃(返回 false)并把自己
+ * 从队列摘掉 —— 计时必须覆盖**排队**这一段:四个挂死的原生任务会一直占着名额,
+ * 若只在拿到名额之后才起计时,排队者就永远等不到超时,IPC 会无限挂起。
+ */
+async function acquireSlot(timeoutMs: number): Promise<boolean> {
+  if (running < MAX_CONCURRENT) {
+    running += 1;
+    return true;
+  }
+  return new Promise<boolean>((resolve) => {
+    const waiter: Waiter = { grant: () => undefined };
+    const timer = setTimeout(() => {
+      const idx = waiters.indexOf(waiter);
+      if (idx >= 0) waiters.splice(idx, 1);
+      resolve(false);
+    }, timeoutMs);
+    waiter.grant = () => {
+      clearTimeout(timer);
+      // 名额由 releaseSlot 直接移交,running 不动(见下面的原子移交)。
+      resolve(true);
+    };
+    waiters.push(waiter);
+  });
+}
+
+/**
+ * 有人排队时把名额**原子移交**给它:先 `running -= 1` 再唤醒的话,两者之间隔着一个
+ * 微任务,这期间新来的请求会看到空位直接启动,加上随后恢复的排队者就超过
+ * MAX_CONCURRENT 了。只有队列真的空了才把计数减回去。
+ */
 function releaseSlot(): void {
-  running -= 1;
   const next = waiters.shift();
-  if (next) next();
+  if (next) {
+    next.grant();
+    return;
+  }
+  running -= 1;
 }
 
 function cacheGet(key: string): string | null | undefined {
@@ -78,17 +106,23 @@ function cacheGet(key: string): string | null | undefined {
 }
 
 function cacheSet(key: string, value: string | null): void {
-  if (cache.size >= CACHE_LIMIT) {
+  // 覆盖已有 key 不会让 size 增长,此时淘汰最旧条目纯属误伤;delete + set 同时把
+  // 这条刷成"最近使用"。
+  const existed = cache.delete(key);
+  if (!existed && cache.size >= CACHE_LIMIT) {
     const oldest = cache.keys().next();
     if (!oldest.done) cache.delete(oldest.value);
   }
   cache.set(key, value);
 }
 
-/** 仅供测试:清空缓存与在飞表,避免用例之间互相污染。 */
+/** 仅供测试:清空缓存、在飞表与并发闸,避免用例之间互相污染。 */
 export function __clearFileThumbnailCacheForTest(): void {
   cache.clear();
   inFlight.clear();
+  // 上个用例可能留下未 settle 的原生任务,不清零会让后续用例被错误限流甚至死等。
+  running = 0;
+  waiters.length = 0;
 }
 
 export interface FileThumbnailParams {
@@ -98,11 +132,23 @@ export interface FileThumbnailParams {
   size: number;
 }
 
+export interface FileThumbnailResult {
+  /** PNG dataURL;这份文件出不了图(损坏 / 系统不支持 / 超时)时为 null。 */
+  dataUrl: string | null;
+  /**
+   * 复核那一刻的**当前**字节数。附件卡上的「类型 · 大小」原本是拖入时的快照,
+   * 文件在托盘期间被改写后就会跟实际发送的内容对不上;这里顺路把新值带回去。
+   */
+  byteSize: number;
+}
+
 /**
- * 返回 PNG dataURL;拿不到缩略图(路径越界 / 文件不存在 / 系统不支持该类型 /
- * 超时)一律返回 null,由调用方回落到自绘图标。
+ * 取系统缩略图。路径越界 / 不是文件 / 取不到 stat 时返回 null(整体不可用);
+ * 文件在、但出不了图时返回 `{ dataUrl: null, byteSize }`,由调用方回落自绘图标。
  */
-export async function readFileThumbnail(params: FileThumbnailParams): Promise<string | null> {
+export async function readFileThumbnail(
+  params: FileThumbnailParams,
+): Promise<FileThumbnailResult | null> {
   const absPath = typeof params?.path === 'string' ? params.path : '';
   const size = Number(params?.size);
   if (!absPath || !path.isAbsolute(absPath)) return null;
@@ -133,15 +179,22 @@ export async function readFileThumbnail(params: FileThumbnailParams): Promise<st
   // mtime + size 进 key:文件被改写后不会拿到旧缩略图。key 用 realPath,不同软链
   // 指向同一份文件时天然共享一条缓存。
   const key = `${realPath}::${stat.mtimeMs}::${stat.size}::${Math.round(size)}`;
+  const byteSize = stat.size;
   const cached = cacheGet(key);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return { dataUrl: cached, byteSize };
 
   // 同一份文件被多张卡同时请求(拖入一批 / 会话切回重挂载)时只做一次原生调用。
   const pending = inFlight.get(key);
   if (pending) return pending;
 
-  const task = (async () => {
-    await acquireSlot();
+  const task = (async (): Promise<FileThumbnailResult> => {
+    // 排队这一段也算进超时:四个挂死的原生任务会一直占着名额,排不上就直接回落。
+    const gotSlot = await acquireSlot(TIMEOUT_MS);
+    if (!gotSlot) {
+      inFlight.delete(key);
+      log.debug('thumbnail slot wait timed out', { ext: path.extname(realPath) });
+      return { dataUrl: null, byteSize };
+    }
     const native = nativeImage.createThumbnailFromPath(realPath, {
       width: Math.round(size),
       height: Math.round(size),
@@ -175,11 +228,11 @@ export async function readFileThumbnail(params: FileThumbnailParams): Promise<st
           timer = setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS);
         }),
       ]);
-      return !image || image.isEmpty() ? null : image.toDataURL();
+      return { dataUrl: !image || image.isEmpty() ? null : image.toDataURL(), byteSize };
     } catch {
-      // 超时或原生失败:本次 IPC 回 null 让卡片先回落图标。task 会以 null 停在
+      // 超时或原生失败:本次 IPC 回 null 让卡片先回落图标。task 会带着 null 停在
       // inFlight 里直到原生 settle —— 期间同一文件的重挂载请求复用它,不会再点火。
-      return null;
+      return { dataUrl: null, byteSize };
     } finally {
       if (timer) clearTimeout(timer);
     }

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -37,18 +37,47 @@ const TIMEOUT_MS = 4000;
 /** 缓存条数上限;value 是 40~80px 的 PNG dataURL,单条只有几 KB。 */
 const CACHE_LIMIT = 128;
 
-const cache = new Map<string, string>();
+/**
+ * 同时在飞的系统缩略图请求数上限。`Promise.race` 的超时只让 IPC 早返回,**取消不了**
+ * 已经交给 QuickLook / Shell 的原生任务(Electron 没有这个 API);一次拖进几十个
+ * 附件时若不设闸,超时后仍有几十个昂贵任务在后台堆着,主进程会持续被拖住。
+ */
+const MAX_CONCURRENT = 4;
 
-function cacheGet(key: string): string | undefined {
-  const hit = cache.get(key);
-  if (hit === undefined) return undefined;
+/** null = 已知这份文件出不了图(损坏 / 系统不支持),负缓存同样按内容版本失效。 */
+const cache = new Map<string, string | null>();
+/** 同 key 在飞的请求:多张卡指向同一文件时只做一次原生调用。 */
+const inFlight = new Map<string, Promise<string | null>>();
+
+let running = 0;
+const waiters: (() => void)[] = [];
+
+/** 并发闸:超过 MAX_CONCURRENT 时排队,拿到名额再往下走。 */
+async function acquireSlot(): Promise<void> {
+  if (running < MAX_CONCURRENT) {
+    running += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => waiters.push(resolve));
+  running += 1;
+}
+
+function releaseSlot(): void {
+  running -= 1;
+  const next = waiters.shift();
+  if (next) next();
+}
+
+function cacheGet(key: string): string | null | undefined {
+  if (!cache.has(key)) return undefined;
+  const hit = cache.get(key) ?? null;
   // 简易 LRU:命中即挪到队尾。
   cache.delete(key);
   cache.set(key, hit);
   return hit;
 }
 
-function cacheSet(key: string, value: string): void {
+function cacheSet(key: string, value: string | null): void {
   if (cache.size >= CACHE_LIMIT) {
     const oldest = cache.keys().next();
     if (!oldest.done) cache.delete(oldest.value);
@@ -56,9 +85,10 @@ function cacheSet(key: string, value: string): void {
   cache.set(key, value);
 }
 
-/** 仅供测试:清空缓存,避免用例之间互相污染。 */
+/** 仅供测试:清空缓存与在飞表,避免用例之间互相污染。 */
 export function __clearFileThumbnailCacheForTest(): void {
   cache.clear();
+  inFlight.clear();
 }
 
 export interface FileThumbnailParams {
@@ -77,38 +107,67 @@ export async function readFileThumbnail(params: FileThumbnailParams): Promise<st
   const size = Number(params?.size);
   if (!absPath || !path.isAbsolute(absPath)) return null;
   if (!Number.isFinite(size) || size < MIN_PX || size > MAX_PX) return null;
+  // 词法 blocklist 先行(与 localFileProtocol 同序):即使随后 realpath 因 EACCES
+  // 失败,一个明确指向敏感目录的请求也要被确定性拒绝。
   if (!isPathAllowedAgainst(absPath, getSensitiveMediaBlocklist())) return null;
+
+  // 再解析符号链接并**对真实目标**重跑一次策略:允许目录里的一条软链完全可以指向
+  // ~/.ssh、Keychains 之类;之后 stat 与取缩略图都用 realPath,把 check→open 的
+  // TOCTOU 窗口一并关掉(localFileProtocol.ts:202-235 是同一套顺序)。
+  let realPath: string;
+  try {
+    realPath = await fs.realpath(absPath);
+  } catch {
+    return null;
+  }
+  if (!isPathAllowedAgainst(realPath, getSensitiveMediaBlocklist())) return null;
 
   let stat: Awaited<ReturnType<typeof fs.stat>>;
   try {
-    stat = await fs.stat(absPath);
+    stat = await fs.stat(realPath);
   } catch {
     return null;
   }
   if (!stat.isFile()) return null;
 
-  // mtime + size 进 key:文件被改写后不会拿到旧缩略图。
-  const key = `${absPath}::${stat.mtimeMs}::${stat.size}::${Math.round(size)}`;
+  // mtime + size 进 key:文件被改写后不会拿到旧缩略图。key 用 realPath,不同软链
+  // 指向同一份文件时天然共享一条缓存。
+  const key = `${realPath}::${stat.mtimeMs}::${stat.size}::${Math.round(size)}`;
   const cached = cacheGet(key);
-  if (cached) return cached;
+  if (cached !== undefined) return cached;
 
-  try {
-    const image = await Promise.race([
-      nativeImage.createThumbnailFromPath(absPath, {
-        width: Math.round(size),
-        height: Math.round(size),
-      }),
-      new Promise<never>((_resolve, reject) =>
-        setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS),
-      ),
-    ]);
-    if (!image || image.isEmpty()) return null;
-    const dataUrl = image.toDataURL();
-    cacheSet(key, dataUrl);
-    return dataUrl;
-  } catch (err) {
-    // 系统不支持该类型是常态(冷门扩展名),按 debug 记,不刷 warn。
-    log.debug('thumbnail unavailable', { ext: path.extname(absPath), error: String(err) });
-    return null;
-  }
+  // 同一份文件被多张卡同时请求(拖入一批 / 会话切回重挂载)时只做一次原生调用。
+  const pending = inFlight.get(key);
+  if (pending) return pending;
+
+  const task = (async () => {
+    await acquireSlot();
+    try {
+      const image = await Promise.race([
+        nativeImage.createThumbnailFromPath(realPath, {
+          width: Math.round(size),
+          height: Math.round(size),
+        }),
+        new Promise<never>((_resolve, reject) =>
+          setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS),
+        ),
+      ]);
+      const dataUrl = !image || image.isEmpty() ? null : image.toDataURL();
+      cacheSet(key, dataUrl);
+      return dataUrl;
+    } catch (err) {
+      // 系统不支持该类型是常态(冷门扩展名),按 debug 记,不刷 warn。
+      // 负结果同样入缓存:否则每次重挂载都要再花一次昂贵的原生调用去撞同一堵墙。
+      // 超时不入缓存——那是暂时性的,下次可能成功。
+      const timedOut = err instanceof Error && err.message === 'thumbnail timeout';
+      if (!timedOut) cacheSet(key, null);
+      log.debug('thumbnail unavailable', { ext: path.extname(realPath), error: String(err) });
+      return null;
+    } finally {
+      releaseSlot();
+      inFlight.delete(key);
+    }
+  })();
+  inFlight.set(key, task);
+  return task;
 }

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -24,7 +24,10 @@ import { createLogger } from './logger';
 
 const log = createLogger('fileThumbnail');
 
-/** 允许的请求边长(CSS px 的整数倍),避免 renderer 传任意值放大资源占用。 */
+/**
+ * 允许的请求边长(px)。只卡区间不要求整数——非整数会在下面统一 Math.round 后再
+ * 进 key 与原生调用;这里的作用是不让 renderer 用一个夸张的尺寸放大资源占用。
+ */
 const MIN_PX = 16;
 const MAX_PX = 512;
 
@@ -34,8 +37,25 @@ const MAX_PX = 512;
  */
 const TIMEOUT_MS = 4000;
 
-/** 缓存条数上限;value 是 40~80px 的 PNG dataURL,单条只有几 KB。 */
-const CACHE_LIMIT = 128;
+/**
+ * 缓存条数上限;value 是 40~80px 的 PNG dataURL,单条只有几 KB,512 条也就几 MB。
+ * 给得宽是为了别让大托盘反复触发驱逐——驱逐后每次焦点复核都要重新跑一遍原生调用。
+ */
+const CACHE_LIMIT = 512;
+
+/**
+ * 缓存条目的软过期。key 里的 mtimeMs 在粗时间戳文件系统(FAT 之类,量化到 2s)上
+ * 分辨不出"同尺寸、同一时间片内的改写",保时间戳的替换工具也一样;正结果给个上限
+ * 让它最终能自愈。
+ */
+const POSITIVE_TTL_MS = 10 * 60_000;
+
+/**
+ * 负结果的过期要短得多:QuickLook / Shell 偶发的瞬时失败不该把预览永久钉死——
+ * 之前那样存成普通 LRU 条目的话,除非文件变化或重启,后续所有挂载与复核都会拿到
+ * null,连原先已经显示出来的预览都会被抹掉。
+ */
+const NEGATIVE_TTL_MS = 60_000;
 
 /**
  * 同时在飞的系统缩略图请求数上限。`Promise.race` 的超时只让 IPC 早返回,**取消不了**
@@ -44,8 +64,14 @@ const CACHE_LIMIT = 128;
  */
 const MAX_CONCURRENT = 4;
 
-/** null = 已知这份文件出不了图(损坏 / 系统不支持),负缓存同样按内容版本失效。 */
-const cache = new Map<string, string | null>();
+interface CacheEntry {
+  /** null = 这份文件出不了图(损坏 / 系统不支持 / 那一次原生调用失败)。 */
+  dataUrl: string | null;
+  /** 写入时刻,配合分级 TTL 判软过期。 */
+  at: number;
+}
+
+const cache = new Map<string, CacheEntry>();
 /** 同 key 在飞的请求:多张卡指向同一文件时只做一次原生调用。 */
 const inFlight = new Map<string, Promise<FileThumbnailResult | null>>();
 
@@ -97,12 +123,17 @@ function releaseSlot(): void {
 }
 
 function cacheGet(key: string): string | null | undefined {
-  if (!cache.has(key)) return undefined;
-  const hit = cache.get(key) ?? null;
+  const hit = cache.get(key);
+  if (!hit) return undefined;
+  const ttl = hit.dataUrl === null ? NEGATIVE_TTL_MS : POSITIVE_TTL_MS;
+  if (Date.now() - hit.at > ttl) {
+    cache.delete(key);
+    return undefined;
+  }
   // 简易 LRU:命中即挪到队尾。
   cache.delete(key);
   cache.set(key, hit);
-  return hit;
+  return hit.dataUrl;
 }
 
 function cacheSet(key: string, value: string | null): void {
@@ -113,7 +144,7 @@ function cacheSet(key: string, value: string | null): void {
     const oldest = cache.keys().next();
     if (!oldest.done) cache.delete(oldest.value);
   }
-  cache.set(key, value);
+  cache.set(key, { dataUrl: value, at: Date.now() });
 }
 
 /** 仅供测试:清空缓存、在飞表与并发闸,避免用例之间互相污染。 */
@@ -176,9 +207,11 @@ export async function readFileThumbnail(
   }
   if (!stat.isFile()) return null;
 
-  // mtime + size 进 key:文件被改写后不会拿到旧缩略图。key 用 realPath,不同软链
-  // 指向同一份文件时天然共享一条缓存。
-  const key = `${realPath}::${stat.mtimeMs}::${stat.size}::${Math.round(size)}`;
+  // 身份(dev/ino) + 版本(mtime/size) 一起进 key:文件被改写或换成另一个 inode 都
+  // 拿不到旧缩略图。key 用 realPath,不同软链指向同一份文件时天然共享一条缓存。
+  // 粗时间戳文件系统(FAT 量化到 2s)上同尺寸改写仍可能撞 key,那一层由
+  // POSITIVE_TTL_MS 的软过期兜底。
+  const key = `${realPath}::${stat.dev}::${stat.ino}::${stat.mtimeMs}::${stat.size}::${Math.round(size)}`;
   const byteSize = stat.size;
   const cached = cacheGet(key);
   if (cached !== undefined) return { dataUrl: cached, byteSize };

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -26,10 +26,12 @@ const log = createLogger('fileThumbnail');
 
 /**
  * 允许的请求边长(px)。只卡区间不要求整数——非整数会在下面统一 Math.round 后再
- * 进 key 与原生调用;这里的作用是不让 renderer 用一个夸张的尺寸放大资源占用。
+ * 进 key 与原生调用。上限按 UI 实际需要给(缩略区 40px @2x = 80,留一档余量到
+ * 128):尺寸进了缓存 key,放到 512 的话被攻陷的 renderer 只要变换 size 就能对同
+ * 一个路径囤出几百张大图,单张 512×512 未压缩可达 MB 级。
  */
 const MIN_PX = 16;
-const MAX_PX = 512;
+const MAX_PX = 128;
 
 /**
  * 系统缩略图偶发卡住(实测同进程连续调 app.getFileIcon 会挂死),这里给硬超时:
@@ -38,10 +40,17 @@ const MAX_PX = 512;
 const TIMEOUT_MS = 4000;
 
 /**
- * 缓存条数上限;value 是 40~80px 的 PNG dataURL,单条只有几 KB,512 条也就几 MB。
- * 给得宽是为了别让大托盘反复触发驱逐——驱逐后每次焦点复核都要重新跑一遍原生调用。
+ * 缓存条数上限;给得宽是为了别让大托盘反复触发驱逐——驱逐后每次焦点复核都要重新
+ * 跑一遍原生调用。
  */
 const CACHE_LIMIT = 512;
+
+/**
+ * 缓存的字节预算。只按条数限界挡不住内存:尺寸是 key 的一部分,同一路径换 size 就
+ * 是一条新条目。这里按 dataURL 的实际长度累计,超预算就从最旧的开始淘汰,让保有量
+ * 有一个与条数无关的硬顶。
+ */
+const CACHE_BYTES_BUDGET = 24 * 1024 * 1024;
 
 /**
  * 缓存条目的软过期。key 里的 mtimeMs 在粗时间戳文件系统(FAT 之类,量化到 2s)上
@@ -72,6 +81,8 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
+/** 当前缓存里 dataURL 的字节合计(与 cache 同步维护)。 */
+let cacheBytes = 0;
 /** 同 key 在飞的请求:多张卡指向同一文件时只做一次原生调用。 */
 const inFlight = new Map<string, Promise<FileThumbnailResult | null>>();
 
@@ -122,12 +133,25 @@ function releaseSlot(): void {
   running -= 1;
 }
 
+function dropEntry(key: string): boolean {
+  const entry = cache.get(key);
+  if (!entry) return false;
+  cacheBytes -= entry.dataUrl?.length ?? 0;
+  cache.delete(key);
+  return true;
+}
+
+function evictOldest(): void {
+  const oldest = cache.keys().next();
+  if (!oldest.done) dropEntry(oldest.value);
+}
+
 function cacheGet(key: string): string | null | undefined {
   const hit = cache.get(key);
   if (!hit) return undefined;
   const ttl = hit.dataUrl === null ? NEGATIVE_TTL_MS : POSITIVE_TTL_MS;
   if (Date.now() - hit.at > ttl) {
-    cache.delete(key);
+    dropEntry(key);
     return undefined;
   }
   // 简易 LRU:命中即挪到队尾。
@@ -139,17 +163,18 @@ function cacheGet(key: string): string | null | undefined {
 function cacheSet(key: string, value: string | null): void {
   // 覆盖已有 key 不会让 size 增长,此时淘汰最旧条目纯属误伤;delete + set 同时把
   // 这条刷成"最近使用"。
-  const existed = cache.delete(key);
-  if (!existed && cache.size >= CACHE_LIMIT) {
-    const oldest = cache.keys().next();
-    if (!oldest.done) cache.delete(oldest.value);
-  }
+  const existed = dropEntry(key);
+  if (!existed && cache.size >= CACHE_LIMIT) evictOldest();
   cache.set(key, { dataUrl: value, at: Date.now() });
+  cacheBytes += value?.length ?? 0;
+  // 字节预算兜底:条数没超但保有量超了同样要淘汰(尺寸不同的同一路径会各占一条)。
+  while (cacheBytes > CACHE_BYTES_BUDGET && cache.size > 1) evictOldest();
 }
 
 /** 仅供测试:清空缓存、在飞表与并发闸,避免用例之间互相污染。 */
 export function __clearFileThumbnailCacheForTest(): void {
   cache.clear();
+  cacheBytes = 0;
   inFlight.clear();
   // 上个用例可能留下未 settle 的原生任务,不清零会让后续用例被错误限流甚至死等。
   running = 0;
@@ -161,6 +186,12 @@ export interface FileThumbnailParams {
   path: string;
   /** 期望边长(px)。 */
   size: number;
+  /**
+   * 显式复核:跳过**正**缓存直接重新生成。粗时间戳文件系统(FAT 量化到 2s)上
+   * "同尺寸、同一时间片内改写"算不出新的版本 key,靠 TTL 要等十分钟才自愈,而
+   * 「改完切回来就发送」是常规动线。负缓存仍然尊重——那是防反复撞墙用的。
+   */
+  revalidate?: boolean;
 }
 
 export interface FileThumbnailResult {
@@ -214,7 +245,10 @@ export async function readFileThumbnail(
   const key = `${realPath}::${stat.dev}::${stat.ino}::${stat.mtimeMs}::${stat.size}::${Math.round(size)}`;
   const byteSize = stat.size;
   const cached = cacheGet(key);
-  if (cached !== undefined) return { dataUrl: cached, byteSize };
+  // revalidate 只跳过正缓存;负缓存照旧命中,否则每次焦点复核都要再撞一次同一堵墙。
+  if (cached !== undefined && !(params?.revalidate && cached !== null)) {
+    return { dataUrl: cached, byteSize };
+  }
 
   // 同一份文件被多张卡同时请求(拖入一批 / 会话切回重挂载)时只做一次原生调用。
   const pending = inFlight.get(key);
@@ -230,8 +264,13 @@ export async function readFileThumbnail(
   const sameTarget = async (): Promise<boolean> => {
     try {
       const after = await fs.stat(realPath);
+      // size 也要比:key 的"版本"语义里本来就含 size,粗时间戳文件系统上
+      // mtime 可能没动而内容尺寸变了,只比 mtime 会误判成同一目标。
       return (
-        after.ino === stat.ino && after.dev === stat.dev && after.mtimeMs === stat.mtimeMs
+        after.ino === stat.ino &&
+        after.dev === stat.dev &&
+        after.mtimeMs === stat.mtimeMs &&
+        after.size === stat.size
       );
     } catch {
       return false;

--- a/apps/desktop/src/main/fileThumbnail.ts
+++ b/apps/desktop/src/main/fileThumbnail.ts
@@ -142,30 +142,46 @@ export async function readFileThumbnail(params: FileThumbnailParams): Promise<st
 
   const task = (async () => {
     await acquireSlot();
+    const native = nativeImage.createThumbnailFromPath(realPath, {
+      width: Math.round(size),
+      height: Math.round(size),
+    });
+
+    // 名额与 in-flight 都跟着**原生 promise**走,不跟着下面那个 race:超时只能让
+    // IPC 早点返回,取消不了已经交给 QuickLook / Shell 的任务(Electron 无此 API)。
+    // 若在超时那一刻就放名额、删 inFlight,系统卡住时每过 4s 就会再放 4 个新任务
+    // 进去,闸门等于没有——真实在飞数必须由原生任务的生命周期决定。
+    void native
+      .then((image) => {
+        // 迟到的结果照样有用:写进缓存,下次挂载直接命中,不用再跑一遍。
+        cacheSet(key, !image || image.isEmpty() ? null : image.toDataURL());
+      })
+      .catch((err) => {
+        // 系统不支持该类型是常态(冷门扩展名),按 debug 记,不刷 warn。
+        // 负结果入缓存:否则每次重挂载都要再花一次昂贵的原生调用去撞同一堵墙。
+        cacheSet(key, null);
+        log.debug('thumbnail unavailable', { ext: path.extname(realPath), error: String(err) });
+      })
+      .finally(() => {
+        releaseSlot();
+        inFlight.delete(key);
+      });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const image = await Promise.race([
-        nativeImage.createThumbnailFromPath(realPath, {
-          width: Math.round(size),
-          height: Math.round(size),
+        native,
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS);
         }),
-        new Promise<never>((_resolve, reject) =>
-          setTimeout(() => reject(new Error('thumbnail timeout')), TIMEOUT_MS),
-        ),
       ]);
-      const dataUrl = !image || image.isEmpty() ? null : image.toDataURL();
-      cacheSet(key, dataUrl);
-      return dataUrl;
-    } catch (err) {
-      // 系统不支持该类型是常态(冷门扩展名),按 debug 记,不刷 warn。
-      // 负结果同样入缓存:否则每次重挂载都要再花一次昂贵的原生调用去撞同一堵墙。
-      // 超时不入缓存——那是暂时性的,下次可能成功。
-      const timedOut = err instanceof Error && err.message === 'thumbnail timeout';
-      if (!timedOut) cacheSet(key, null);
-      log.debug('thumbnail unavailable', { ext: path.extname(realPath), error: String(err) });
+      return !image || image.isEmpty() ? null : image.toDataURL();
+    } catch {
+      // 超时或原生失败:本次 IPC 回 null 让卡片先回落图标。task 会以 null 停在
+      // inFlight 里直到原生 settle —— 期间同一文件的重挂载请求复用它,不会再点火。
       return null;
     } finally {
-      releaseSlot();
-      inFlight.delete(key);
+      if (timer) clearTimeout(timer);
     }
   })();
   inFlight.set(key, task);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -2502,8 +2502,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('media:read-image-bytes', params),
 
   // 附件卡缩略图:本机文件交给系统缩略图服务(macOS QuickLook / Windows Shell)
-  // 出一张小预览,拿不到时回 null(调用方回落自绘文件图标)。
-  getFileThumbnail: (params: { path: string; size: number }): Promise<string | null> =>
+  // 出一张小预览,顺带回传复核那一刻的当前字节数。整体不可用(路径越界 / 文件不在)
+  // 回 null;文件在但出不了图时 dataUrl 为 null,调用方回落自绘文件图标。
+  getFileThumbnail: (params: {
+    path: string;
+    size: number;
+  }): Promise<{ dataUrl: string | null; byteSize: number } | null> =>
     ipcRenderer.invoke('file:thumbnail', params),
 
   // markdown-monorepo-resolve: smart relative-path resolver.

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -2501,6 +2501,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   }): Promise<{ base64: string; mimeType: string }> =>
     ipcRenderer.invoke('media:read-image-bytes', params),
 
+  // 附件卡缩略图:本机文件交给系统缩略图服务(macOS QuickLook / Windows Shell)
+  // 出一张小预览,拿不到时回 null(调用方回落自绘文件图标)。
+  getFileThumbnail: (params: { path: string; size: number }): Promise<string | null> =>
+    ipcRenderer.invoke('file:thumbnail', params),
+
   // markdown-monorepo-resolve: smart relative-path resolver.
   // Tries `cwd/href` first, then BFS the workspace for files whose absolute
   // path ends with `/<href>` so monorepo sub-package refs (`src/App.tsx`

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -2507,6 +2507,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getFileThumbnail: (params: {
     path: string;
     size: number;
+    revalidate?: boolean;
   }): Promise<{ dataUrl: string | null; byteSize: number } | null> =>
     ipcRenderer.invoke('file:thumbnail', params),
 

--- a/apps/desktop/src/renderer/__tests__/attachmentFileCard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentFileCard.test.ts
@@ -55,7 +55,9 @@ describe('Attachment thumbnail — non-image file card (attachment-file-card)', 
     expect(block).toContain('{metaLine}');
     // metaLine 由扩展名 + formatBytes(当前大小)组成,size 缺失时只留类型。
     expect(block).toMatch(/const metaLine = \[[\s\S]*formatBytes\(shownSize\)[\s\S]*\]/);
-    expect(block).toMatch(/shownSize > 0 \? formatBytes\(shownSize\) : null/);
+    expect(block).toMatch(/hasSize \? formatBytes\(shownSize\) : null/);
+    // 复核回来的 0 是真实的当前大小(文件被清空),要照实显示 0 B。
+    expect(block).toMatch(/liveByteSize !== null \? shownSize >= 0 : shownSize > 0/);
     // 显示的大小优先用复核回来的当前值,file.size 只是拖入那一刻的快照。
     expect(block).toMatch(/const shownSize = liveByteSize \?\? file\.size/);
     // formatBytes 走 TextLightbox 的具名导出,不要在这里重造一份。

--- a/apps/desktop/src/renderer/__tests__/attachmentFileCard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentFileCard.test.ts
@@ -44,7 +44,7 @@ describe('Attachment thumbnail — non-image file card (attachment-file-card)', 
     const card = fileCardBlock();
     expect(card).toContain('{file.name}');
     // 缩略区交给 AttachmentTypeThumb(PDF 首页预览 / 类型图标),不再是扩展名方块。
-    expect(card).toContain('<AttachmentTypeThumb file={file} />');
+    expect(card).toContain('<AttachmentTypeThumb file={file} onByteSize={setLiveByteSize} />');
     expect(chatInput).toMatch(
       /import\s+\{\s*AttachmentTypeThumb\s*\}\s+from\s+'\.\/AttachmentTypeThumb'/,
     );
@@ -53,9 +53,11 @@ describe('Attachment thumbnail — non-image file card (attachment-file-card)', 
   it('副行给出「类型 · 大小」,大小复用 TextLightbox 的 formatBytes', () => {
     const block = thumbnailItemBlock();
     expect(block).toContain('{metaLine}');
-    // metaLine 由扩展名 + formatBytes(file.size) 组成,size 缺失时只留类型。
-    expect(block).toMatch(/const metaLine = \[[\s\S]*formatBytes\(file\.size\)[\s\S]*\]/);
-    expect(block).toMatch(/file\.size > 0 \? formatBytes\(file\.size\) : null/);
+    // metaLine 由扩展名 + formatBytes(当前大小)组成,size 缺失时只留类型。
+    expect(block).toMatch(/const metaLine = \[[\s\S]*formatBytes\(shownSize\)[\s\S]*\]/);
+    expect(block).toMatch(/shownSize > 0 \? formatBytes\(shownSize\) : null/);
+    // 显示的大小优先用复核回来的当前值,file.size 只是拖入那一刻的快照。
+    expect(block).toMatch(/const shownSize = liveByteSize \?\? file\.size/);
     // formatBytes 走 TextLightbox 的具名导出,不要在这里重造一份。
     expect(chatInput).toMatch(
       /import\s+\{\s*formatBytes,\s*TextLightbox\s*\}\s+from\s+'@\/components\/chat\/TextLightbox'/,

--- a/apps/desktop/src/renderer/__tests__/attachmentFileCard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentFileCard.test.ts
@@ -1,0 +1,91 @@
+/**
+ * attachmentFileCard.test.ts
+ * ---------------------------------------------------------------------------
+ * Regression test for: attachment file card (2026-07-27)
+ *
+ * 输入框托盘里的非图片附件(PDF / Office / 文本)此前渲染成一个 56×56 方块,
+ * 正中只印大写扩展名 —— 并排两份 PDF 完全认不出谁是谁,文件名只在 hover
+ * tooltip 里出现。现在改成横向文件卡:图标块 + 文件名 + 「类型 · 大小」。
+ *
+ * 与同目录 thumbnailClickPreview.test.ts 同族,走源码断言:ThumbnailItem 依赖
+ * ChatInput 的大量本地状态,单独挂载成本远高于收益,这里把关键契约钉在源码层,
+ * 防止后续重构悄悄退回「只有扩展名」的形态。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// 归一化 CRLF → LF：Windows autocrlf=true 检出下工作树是 CRLF。
+const chatInput = readFileSync(
+  resolve(__dirname, '..', 'components', 'new-chat', 'ChatInput.tsx'),
+  'utf8',
+).replace(/\r\n/g, '\n');
+
+function thumbnailItemBlock(): string {
+  const startIdx = chatInput.indexOf('function ThumbnailItem');
+  expect(startIdx).toBeGreaterThan(-1);
+  // ThumbnailItem 是文件里最后一个组件,切到 EOF。
+  return chatInput.slice(startIdx);
+}
+
+/** 文件卡分支(非图片)的 JSX 片段:卡片容器 → Remove 按钮注释之前。 */
+function fileCardBlock(): string {
+  const block = thumbnailItemBlock();
+  const cardStart = block.indexOf('items-center gap-2 rounded-xl px-2');
+  expect(cardStart).toBeGreaterThan(-1);
+  const cardEnd = block.indexOf('{/* Remove button', cardStart);
+  expect(cardEnd).toBeGreaterThan(cardStart);
+  return block.slice(cardStart, cardEnd);
+}
+
+describe('Attachment thumbnail — non-image file card (attachment-file-card)', () => {
+  it('文件卡直接渲染文件名,不再只印扩展名', () => {
+    const card = fileCardBlock();
+    expect(card).toContain('{file.name}');
+    // 缩略区交给 AttachmentTypeThumb(PDF 首页预览 / 类型图标),不再是扩展名方块。
+    expect(card).toContain('<AttachmentTypeThumb file={file} />');
+    expect(chatInput).toMatch(
+      /import\s+\{\s*AttachmentTypeThumb\s*\}\s+from\s+'\.\/AttachmentTypeThumb'/,
+    );
+  });
+
+  it('副行给出「类型 · 大小」,大小复用 TextLightbox 的 formatBytes', () => {
+    const block = thumbnailItemBlock();
+    expect(block).toContain('{metaLine}');
+    // metaLine 由扩展名 + formatBytes(file.size) 组成,size 缺失时只留类型。
+    expect(block).toMatch(/const metaLine = \[[\s\S]*formatBytes\(file\.size\)[\s\S]*\]/);
+    expect(block).toMatch(/file\.size > 0 \? formatBytes\(file\.size\) : null/);
+    // formatBytes 走 TextLightbox 的具名导出,不要在这里重造一份。
+    expect(chatInput).toMatch(
+      /import\s+\{\s*formatBytes,\s*TextLightbox\s*\}\s+from\s+'@\/components\/chat\/TextLightbox'/,
+    );
+  });
+
+  it('文件卡颜色全部走语义 token,不含硬编码色值', () => {
+    const card = fileCardBlock();
+    // 旧实现是 `text-white` 压 --file-chip-bg,Light 模式下几乎读不出来。
+    expect(card).not.toContain('text-white');
+    // 硬编码色值:style 值里的 '#xxx' 与 Tailwind 任意值 bg-[#xxx]。
+    // (注释里引用具体 hex 说明取色理由是允许的,所以不能整块 grep '#'。)
+    expect(card).not.toMatch(/:\s*'#[0-9a-fA-F]{3,8}'/);
+    expect(card).not.toMatch(/-\[#[0-9a-fA-F]{3,8}\]/);
+    expect(card).toContain("backgroundColor: 'var(--surface-chip)'");
+    // 缩略区再抬一层,否则 Light 下与卡片底色只差一档灰、看不出块。
+    expect(card).toContain("backgroundColor: 'var(--surface-elevated)'");
+    expect(card).toContain("color: 'var(--text-primary)'");
+    expect(card).toContain("color: 'var(--text-secondary)'");
+  });
+
+  it('图片附件仍是 56×56 方块,文件卡按内容自适应且不超过 220px', () => {
+    const block = thumbnailItemBlock();
+    expect(block).toMatch(
+      /style=\{isImageThumb \? \{ width: 56, height: 56 \} : \{ height: 56, maxWidth: 220 \}\}/,
+    );
+    // isImageThumb 必须与渲染分支同条件:缓存写失败的图片(无 url / base64)
+    // 会落到文件卡分支,宽度也得跟着走文件卡的规则。
+    expect(block).toMatch(
+      /const isImageThumb = file\.category === 'image' && Boolean\(file\.url \|\| file\.base64\)/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -134,7 +134,13 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
     // dmg / zip 这类系统只给类型图标:图标四周本来就是透明的,再套一圈边框
     // 等于在图标外面画个空方框(2026-07-27 Dash 指出)。
     expect(src).toMatch(/objectFit: thumb\.isIcon \? 'contain' : 'cover'/);
-    expect(src).toMatch(/boxShadow: thumb\.isIcon \? undefined :/);
+    expect(src).toMatch(/outline: thumb\.isIcon \? undefined : '1px solid var\(--border-default\)'/);
+    // DESIGN.md §6:in-page 元素只能用 1px Board 边框区分,阴影只留给 token 化的浮层。
+    expect(src).not.toMatch(/boxShadow/);
+  });
+
+  it('焦点复核请求跳过正缓存(挂载首取仍走缓存消闪烁)', () => {
+    expect(src).toMatch(/revalidate: revalidateTick > 0/);
   });
 
   it('图标型判定采样四边中点与四角,解码失败按内容图处理', () => {

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -87,9 +87,19 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
 
   it('窗口重新获得焦点时复核(附件挂在托盘期间文件可能被改写)', () => {
     // 只在挂载时问一次的话,「切出去改完文件再切回来发送」这个场景拿到的还是旧内容。
-    expect(src).toMatch(/window\.addEventListener\('focus', onFocus\)/);
-    expect(src).toMatch(/window\.removeEventListener\('focus', onFocus\)/);
+    expect(src).toMatch(/window\.addEventListener\('focus'/);
     expect(src).toMatch(/\}, \[filePath, revalidateTick\]\)/);
+  });
+
+  it('焦点复核走模块级单例 + 节流,不是每张卡各挂一个监听', () => {
+    // 托盘附件数没有上限;每卡一个 focus 监听 + 各自发 IPC,一次切窗口就能打出
+    // 成百上千次 realpath/stat。
+    expect(src).toMatch(/const revalidateSubscribers = new Set<\(\) => void>\(\)/);
+    expect(src).toMatch(/if \(focusListenerBound \|\| typeof window === 'undefined'\) return/);
+    expect(src).toMatch(/const REVALIDATE_MIN_INTERVAL_MS = [\d_]+/);
+    expect(src).toMatch(/now - lastRevalidateAt < REVALIDATE_MIN_INTERVAL_MS/);
+    // 卸载要退订,否则订阅集合会随会话切换无限增长。
+    expect(src).toMatch(/revalidateSubscribers\.delete\(notify\)/);
   });
 
   it('角标标签渲染尺寸不低于 10px(DESIGN.md §3 Micro Label 下限)', () => {

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -85,6 +85,13 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
     expect(src).toMatch(/const onByteSizeRef = useRef\(onByteSize\)/);
   });
 
+  it('窗口重新获得焦点时复核(附件挂在托盘期间文件可能被改写)', () => {
+    // 只在挂载时问一次的话,「切出去改完文件再切回来发送」这个场景拿到的还是旧内容。
+    expect(src).toMatch(/window\.addEventListener\('focus', onFocus\)/);
+    expect(src).toMatch(/window\.removeEventListener\('focus', onFocus\)/);
+    expect(src).toMatch(/\}, \[filePath, revalidateTick\]\)/);
+  });
+
   it('角标标签渲染尺寸不低于 10px(DESIGN.md §3 Micro Label 下限)', () => {
     // viewBox 32 + width 32 → 1:1,fontSize 10 即屏幕 10px。
     expect(src).toMatch(/<svg width="32" height="32" viewBox="0 0 32 32"/);

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -49,9 +49,22 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
     expect(src).toMatch(/size: THUMB_PX \* 2/);
   });
 
-  it('取不到缩略图记进 miss 集合,不每次重挂载都重问 main', () => {
-    expect(src).toMatch(/thumbMisses\.add\(filePath\)/);
-    expect(src).toMatch(/if \(thumbMisses\.has\(filePath\)\) return/);
+  it('缓存只用于消闪烁,每次挂载仍向 main 复核(文件被覆盖时不会一直显示旧图)', () => {
+    // 缓存按路径存,而同一路径的文件可能被覆盖 —— main 侧才按 mtime+size 判失效,
+    // 所以这里必须无条件 revalidate,不能命中缓存就 return。
+    const effect = src.slice(src.indexOf('useEffect(() => {'), src.indexOf('if (thumb) {'));
+    expect(effect).toMatch(/const cached = thumbCache\.get\(filePath\) \?\? null;\s*\n\s*setThumb\(cached\)/);
+    expect(effect).not.toMatch(/if \(cached\)[\s\S]{0,80}return;/);
+    expect(effect).toMatch(/getFileThumbnail/);
+    // 复核结果为空时清掉可能过期的缓存,回落图标。
+    expect(effect).toMatch(/thumbCache\.delete\(filePath\)/);
+  });
+
+  it('renderer 缓存有上限(长会话里拖入的文件数没有上限)', () => {
+    expect(src).toMatch(/const THUMB_CACHE_LIMIT = \d+/);
+    expect(src).toMatch(/function rememberThumb[\s\S]*thumbCache\.delete\(oldest\.value\)/);
+    // 不再维护会无限增长、且永久记住失败的 miss 集合。
+    expect(src).not.toMatch(/thumbMisses/);
   });
 
   it('粘贴产生的 clipboard:// 伪路径不去问系统缩略图', () => {

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -1,0 +1,96 @@
+/**
+ * attachmentTypeThumb.test.ts
+ * ---------------------------------------------------------------------------
+ * 附件卡缩略区(AttachmentTypeThumb)。
+ *
+ * 「文件需要根据文件类型有图片或者预览」(2026-07-27):优先要系统缩略图(真实
+ * 内容),拿不到才回落自绘的类型图标。这里钉住图标分派(纯函数)与回落契约;
+ * 缩略图那半依赖 Electron 系统服务,由 main 侧 fileThumbnail 测试 + 实机覆盖。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { pickIconKind } from '../components/new-chat/AttachmentTypeThumb';
+
+const src = readFileSync(
+  resolve(__dirname, '..', 'components', 'new-chat', 'AttachmentTypeThumb.tsx'),
+  'utf8',
+).replace(/\r\n/g, '\n');
+
+describe('AttachmentTypeThumb — 自绘图标的类型分派', () => {
+  it('表格 / 幻灯片 / 文档 / 代码 / PDF 各归各的类型', () => {
+    expect(pickIconKind('.xlsx', 'office')).toBe('sheet');
+    expect(pickIconKind('.pptx', 'office')).toBe('slide');
+    expect(pickIconKind('.docx', 'office')).toBe('doc');
+    expect(pickIconKind('.ts', 'text')).toBe('code');
+    expect(pickIconKind('.pdf', 'pdf')).toBe('pdf');
+  });
+
+  it('大写扩展名同样命中(拖进来的文件名可能是 .PDF / .XLSX)', () => {
+    expect(pickIconKind('.XLSX', 'office')).toBe('sheet');
+    expect(pickIconKind('.PDF', 'pdf')).toBe('pdf');
+  });
+
+  it('无扩展名 / 未知类型回落中性纸张,不崩', () => {
+    expect(pickIconKind('', 'file')).toBe('plain');
+    expect(pickIconKind('.zzz', 'file')).toBe('plain');
+    expect(pickIconKind('', 'text')).toBe('text');
+  });
+
+  it('category 为 pdf 但扩展名缺失时仍算 PDF', () => {
+    expect(pickIconKind('', 'pdf')).toBe('pdf');
+  });
+});
+
+describe('AttachmentTypeThumb — 缩略图取用契约', () => {
+  it('按 2x 边长要图,retina 下不糊', () => {
+    expect(src).toMatch(/size: THUMB_PX \* 2/);
+  });
+
+  it('取不到缩略图记进 miss 集合,不每次重挂载都重问 main', () => {
+    expect(src).toMatch(/thumbMisses\.add\(filePath\)/);
+    expect(src).toMatch(/if \(thumbMisses\.has\(filePath\)\) return/);
+  });
+
+  it('粘贴产生的 clipboard:// 伪路径不去问系统缩略图', () => {
+    expect(src).toMatch(/startsWith\('clipboard:\/\/'\)/);
+  });
+
+  it('缩略图失败静默回落图标,不弹错', () => {
+    expect(src).toMatch(/catch \(err\)[\s\S]*log\.debug\('file thumbnail unavailable'/);
+    // 卸载后不得再 setState(附件可能在取图途中被移除)。
+    expect(src).toMatch(/cancelled = true/);
+    expect(src).toMatch(/if \(!cancelled\) setThumb\(next\)/);
+  });
+
+  it('图标型缩略图不裁切也不描边,内容型才裁切填满并描边', () => {
+    // dmg / zip 这类系统只给类型图标:图标四周本来就是透明的,再套一圈边框
+    // 等于在图标外面画个空方框(2026-07-27 Dash 指出)。
+    expect(src).toMatch(/objectFit: thumb\.isIcon \? 'contain' : 'cover'/);
+    expect(src).toMatch(/boxShadow: thumb\.isIcon \? undefined :/);
+  });
+
+  it('图标型判定采样四边中点与四角,解码失败按内容图处理', () => {
+    const fn = src.slice(src.indexOf('async function looksLikeIconBitmap'), src.indexOf('// ── 自绘文件图标'));
+    // 8 个采样点:四边中点 + 四角。少采会把「上白下花」的内容图误判成图标。
+    expect((fn.match(/\[[^\]]*\],/g) ?? []).length).toBeGreaterThanOrEqual(4);
+    expect(fn).toMatch(/samples\.every\(\(\[x, y\]\) => alphaAt\(x, y\) < 8\)/);
+    // 兜底方向:读不到像素时回 false(当内容图),多一圈边框好过给内容图裁错。
+    expect(fn).toMatch(/catch \{\s*return false;\s*\}/);
+  });
+
+  it('自绘图标的纸面走 token,只有类型角标带内容语义色', () => {
+    // 纸张本体 / 描边 / 正文线必须是 token,否则 Dark 模式会失配。
+    expect(src).toMatch(/fill="var\(--surface-elevated\)"/);
+    expect(src).toMatch(/stroke="var\(--text-placeholder\)"/);
+    // 角标色是 theme-invariant 的内容语义色,集中在 KIND_ACCENT 一张表里。
+    const accentBlock = src.slice(src.indexOf('const KIND_ACCENT'), src.indexOf('const KIND_LABEL'));
+    expect(accentBlock).toMatch(/pdf: '#D9553F'/);
+    // 表以外不得再散落硬编码色值(角标文字的纯白除外)。
+    const withoutAccent = src.replace(accentBlock, '');
+    const strays = withoutAccent.match(/#[0-9A-Fa-f]{6}/g) ?? [];
+    expect(strays).toEqual(['#FFFFFF']);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -94,16 +94,23 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
     expect(fn).toMatch(/catch \{\s*return false;\s*\}/);
   });
 
-  it('自绘图标的纸面走 token,只有类型角标带内容语义色', () => {
+  it('自绘图标的颜色全部走注册 token,组件里不写死任何 hex', () => {
     // 纸张本体 / 描边 / 正文线必须是 token,否则 Dark 模式会失配。
     expect(src).toMatch(/fill="var\(--surface-elevated\)"/);
     expect(src).toMatch(/stroke="var\(--text-placeholder\)"/);
-    // 角标色是 theme-invariant 的内容语义色,集中在 KIND_ACCENT 一张表里。
-    const accentBlock = src.slice(src.indexOf('const KIND_ACCENT'), src.indexOf('const KIND_LABEL'));
-    expect(accentBlock).toMatch(/pdf: '#D9553F'/);
-    // 表以外不得再散落硬编码色值(角标文字的纯白除外)。
-    const withoutAccent = src.replace(accentBlock, '');
-    const strays = withoutAccent.match(/#[0-9A-Fa-f]{6}/g) ?? [];
-    expect(strays).toEqual(['#FFFFFF']);
+    // 角标色是 theme-invariant 例外族,但同样得走注册 token —— DESIGN.md §10:
+    // 「Never freestyle these semantic colors as hardcoded hex」。
+    const accentBlock = src.slice(src.indexOf('const KIND_ACCENT'), src.indexOf('/** 角标里的短标签'));
+    expect(accentBlock).toMatch(/pdf: 'var\(--file-badge-pdf\)'/);
+    expect(accentBlock).toMatch(/code: 'var\(--file-badge-code\)'/);
+    expect(src).toMatch(/fill="var\(--file-badge-fg\)"/);
+    // 整个组件不得出现硬编码色值(注释里引用取值说明不算,这里只查代码字面量)。
+    const literals = src.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(literals.match(/#[0-9A-Fa-f]{3,8}\b/g) ?? []).toEqual([]);
+  });
+
+  it('角标字重不超过 500(DESIGN.md §3 Weight restraint:No bold)', () => {
+    expect(src).toMatch(/fontWeight="500"/);
+    expect(src).not.toMatch(/fontWeight="[6-9]\d\d"/);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -78,6 +78,19 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
     expect(src).toMatch(/if \(!cancelled\) setThumb\(next\)/);
   });
 
+  it('复核时把当前字节数回传给卡片(file.size 只是拖入那一刻的快照)', () => {
+    expect(src).toMatch(/onByteSize\?: \(bytes: number\) => void/);
+    expect(src).toMatch(/if \(result\) onByteSizeRef\.current\?\.\(result\.byteSize\)/);
+    // 回调走 ref:换引用不该触发重新取图。
+    expect(src).toMatch(/const onByteSizeRef = useRef\(onByteSize\)/);
+  });
+
+  it('角标标签渲染尺寸不低于 10px(DESIGN.md §3 Micro Label 下限)', () => {
+    // viewBox 32 + width 32 → 1:1,fontSize 10 即屏幕 10px。
+    expect(src).toMatch(/<svg width="32" height="32" viewBox="0 0 32 32"/);
+    expect(src).toMatch(/fontSize="10"/);
+  });
+
   it('图标型缩略图不裁切也不描边,内容型才裁切填满并描边', () => {
     // dmg / zip 这类系统只给类型图标:图标四周本来就是透明的,再套一圈边框
     // 等于在图标外面画个空方框(2026-07-27 Dash 指出)。

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -97,9 +97,20 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
     expect(src).toMatch(/const revalidateSubscribers = new Set<\(\) => void>\(\)/);
     expect(src).toMatch(/if \(focusListenerBound \|\| typeof window === 'undefined'\) return/);
     expect(src).toMatch(/const REVALIDATE_MIN_INTERVAL_MS = [\d_]+/);
-    expect(src).toMatch(/now - lastRevalidateAt < REVALIDATE_MIN_INTERVAL_MS/);
+    expect(src).toMatch(/window\.addEventListener\('focus', requestRevalidate\)/);
     // 卸载要退订,否则订阅集合会随会话切换无限增长。
     expect(src).toMatch(/revalidateSubscribers\.delete\(notify\)/);
+  });
+
+  it('节流带 trailing 补播,不吞掉窗口内的最新一次改动', () => {
+    // 只做 leading 的话:「改一次 → 切回来 → 再改 → 30s 内切回来」第二次改动会被
+    // 整个丢掉,而发送用的是当前内容,卡片就一直描述旧版本。
+    const fn = src.slice(src.indexOf('function requestRevalidate'), src.indexOf('function ensureFocusListener'));
+    expect(fn).toMatch(/if \(trailingTimer\) return;/);
+    expect(fn).toMatch(/trailingTimer = setTimeout\([\s\S]*broadcastRevalidate\(\)/);
+    expect(fn).toMatch(/REVALIDATE_MIN_INTERVAL_MS - elapsed/);
+    // leading 命中时要清掉已排的补播,避免紧接着再播一次。
+    expect(fn).toMatch(/clearTimeout\(trailingTimer\)/);
   });
 
   it('角标标签渲染尺寸不低于 10px(DESIGN.md §3 Micro Label 下限)', () => {

--- a/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
+++ b/apps/desktop/src/renderer/__tests__/attachmentTypeThumb.test.ts
@@ -102,6 +102,17 @@ describe('AttachmentTypeThumb — 缩略图取用契约', () => {
     expect(src).toMatch(/revalidateSubscribers\.delete\(notify\)/);
   });
 
+  it('广播分批铺开,不一次性唤醒全部卡片', () => {
+    // 节流压住的是频率,压不住扇出:托盘附件数没有上限,一次性唤醒所有订阅者仍会
+    // 瞬间打出 N 次 IPC(每次都带 realpath + stat)。
+    const fn = src.slice(src.indexOf('function broadcastRevalidate'), src.indexOf('function requestRevalidate'));
+    expect(src).toMatch(/const REVALIDATE_BATCH_SIZE = \d+/);
+    expect(fn).toMatch(/queue\.splice\(0, REVALIDATE_BATCH_SIZE\)/);
+    expect(fn).toMatch(/setTimeout\(pump, REVALIDATE_BATCH_GAP_MS\)/);
+    // 分批期间卡片可能卸载,叫号前要确认还在订阅集合里。
+    expect(fn).toMatch(/revalidateSubscribers\.has\(notify\)/);
+  });
+
   it('节流带 trailing 补播,不吞掉窗口内的最新一次改动', () => {
     // 只做 leading 的话:「改一次 → 切回来 → 再改 → 30s 内切回来」第二次改动会被
     // 整个丢掉,而发送用的是当前内容,卡片就一直描述旧版本。

--- a/apps/desktop/src/renderer/__tests__/thumbnailClickPreview.test.ts
+++ b/apps/desktop/src/renderer/__tests__/thumbnailClickPreview.test.ts
@@ -36,8 +36,10 @@ describe('Attachment thumbnail — click opens lightbox (attachment-thumb-click)
     expect(chatInput).toMatch(
       /import\s+\{\s*ImageLightbox\s*\}\s+from\s+'@\/components\/chat\/ImageLightbox'/,
     );
+    // 该模块还导出 formatBytes(文件卡的大小副行复用它),所以这里只钉
+    // TextLightbox 在具名导入列表里,不锁死整条 import 的成员组成。
     expect(chatInput).toMatch(
-      /import\s+\{\s*TextLightbox\s*\}\s+from\s+'@\/components\/chat\/TextLightbox'/,
+      /import\s+\{[^}]*\bTextLightbox\b[^}]*\}\s+from\s+'@\/components\/chat\/TextLightbox'/,
     );
   });
 

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -44,6 +44,30 @@ interface Thumb {
 const THUMB_CACHE_LIMIT = 64;
 const thumbCache = new Map<string, Thumb>();
 
+/**
+ * 焦点复核的**单例**广播:托盘里的附件数量没有上限,每张卡各挂一个 focus 监听、
+ * 各自发一次 IPC 的话,一次切窗口就能打出成百上千次 realpath/stat。这里收敛成
+ * 一个监听器 + 节流窗口,订阅者共享同一次广播。
+ *
+ * 真正昂贵的原生缩略图那一层另有防线(main 的 4 名额闸门 + mtime/size 缓存),
+ * 这里挡住的是「切一次窗口就全量重问」的放大效应。
+ */
+const REVALIDATE_MIN_INTERVAL_MS = 30_000;
+const revalidateSubscribers = new Set<() => void>();
+let lastRevalidateAt = 0;
+let focusListenerBound = false;
+
+function ensureFocusListener(): void {
+  if (focusListenerBound || typeof window === 'undefined') return;
+  focusListenerBound = true;
+  window.addEventListener('focus', () => {
+    const now = Date.now();
+    if (now - lastRevalidateAt < REVALIDATE_MIN_INTERVAL_MS) return;
+    lastRevalidateAt = now;
+    for (const notify of revalidateSubscribers) notify();
+  });
+}
+
 function rememberThumb(key: string, value: Thumb): void {
   if (thumbCache.size >= THUMB_CACHE_LIMIT && !thumbCache.has(key)) {
     const oldest = thumbCache.keys().next();
@@ -223,14 +247,18 @@ export function AttachmentTypeThumb({
 
   // 附件挂在托盘上的这段时间里,用户完全可能切出去把文件改了再切回来发送 —— 只在
   // 挂载时复核一次的话,预览和大小描述的还是旧内容。窗口重新获得焦点就是这个场景
-  // 的自然触发点(切到编辑器改完再切回来),比轮询或 fs.watch 都便宜;main 侧按
-  // mtime+size 命中缓存,没改动的文件这一趟几乎不花钱。
+  // 的自然触发点(切到编辑器改完再切回来),比轮询或 fs.watch 都便宜。监听与节流
+  // 都在模块级单例里,见 ensureFocusListener。
   const [revalidateTick, setRevalidateTick] = useState(0);
   useEffect(() => {
-    const onFocus = () => setRevalidateTick((n) => n + 1);
-    window.addEventListener('focus', onFocus);
-    return () => window.removeEventListener('focus', onFocus);
-  }, []);
+    if (!filePath) return;
+    ensureFocusListener();
+    const notify = () => setRevalidateTick((n) => n + 1);
+    revalidateSubscribers.add(notify);
+    return () => {
+      revalidateSubscribers.delete(notify);
+    };
+  }, [filePath]);
 
   useEffect(() => {
     if (!filePath) {

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -14,7 +14,7 @@
  * 失败、既无 url 也无 base64 的图片才会落到这个组件。
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { AttachedFile, FileCategory } from '@/lib/fileTypes';
 import { createLogger } from '@/lib/logger';
@@ -152,42 +152,44 @@ export function pickIconKind(ext: string, category: FileCategory): IconKind {
 function FileGlyph({ kind }: { kind: IconKind }) {
   const accent = KIND_ACCENT[kind];
   const label = KIND_LABEL[kind];
+  // viewBox 32 渲染成 32px(1:1),角标文字 10 个单位即屏幕 10px —— DESIGN.md §3
+  // 的下限(Micro Label 10–13px)。此前 26px 渲染 + 7.5 单位只有约 6px,越界了。
   return (
-    <svg width="26" height="26" viewBox="0 0 32 32" fill="none" aria-hidden focusable="false">
+    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden focusable="false">
       {/* 纸张本体 + 折角 */}
       <path
-        d="M7 3.5h11.2L26 11.3V28a1.5 1.5 0 0 1-1.5 1.5h-17A1.5 1.5 0 0 1 6 28V5a1.5 1.5 0 0 1 1-1.5Z"
+        d="M6.5 2.5h11.2L25.5 10.3V27a1.5 1.5 0 0 1-1.5 1.5H6.5A1.5 1.5 0 0 1 5 27V4a1.5 1.5 0 0 1 1.5-1.5Z"
         fill="var(--surface-elevated)"
         stroke="var(--text-placeholder)"
         strokeWidth="1.4"
         strokeLinejoin="round"
       />
       <path
-        d="M18 3.6V10a1.5 1.5 0 0 0 1.5 1.5h6.2"
+        d="M17.5 2.6V9a1.5 1.5 0 0 0 1.5 1.5h6.2"
         stroke="var(--text-placeholder)"
         strokeWidth="1.4"
         strokeLinejoin="round"
       />
       {/* 正文示意线:没有角标的中性类型靠它表达「这是文档」 */}
       <path
-        d="M10.5 15.5h11M10.5 19h11M10.5 22.5h6.5"
+        d="M9 14h13M9 17.5h13M9 21h7.5"
         stroke="var(--text-placeholder)"
         strokeWidth="1.4"
         strokeLinecap="round"
-        opacity={accent ? 0.45 : 0.9}
+        opacity={accent ? 0.35 : 0.9}
       />
-      {/* 类型角标 */}
+      {/* 类型角标:容纳 10px 标签,所以铺到底边整条 */}
       {accent && label ? (
         <>
-          <rect x="9" y="18.5" width="19" height="11" rx="2.5" fill={accent} />
+          <rect x="3" y="18.5" width="26" height="13.5" rx="3" fill={accent} />
           {/* 字重 500 封顶:DESIGN.md §3「Weight restraint — 只有 400 与 500,No bold」。 */}
           <text
-            x="18.5"
-            y="26.4"
+            x="16"
+            y="28.6"
             textAnchor="middle"
-            fontSize="7.5"
+            fontSize="10"
             fontWeight="500"
-            letterSpacing="0.2"
+            letterSpacing="0.3"
             fill="var(--file-badge-fg)"
           >
             {label}
@@ -200,11 +202,24 @@ function FileGlyph({ kind }: { kind: IconKind }) {
 
 // ── 组件 ─────────────────────────────────────────────────────────────────
 
-export function AttachmentTypeThumb({ file }: { file: AttachedFile }) {
+export function AttachmentTypeThumb({
+  file,
+  onByteSize,
+}: {
+  file: AttachedFile;
+  /**
+   * 复核缩略图时顺带带回的**当前**字节数。`file.size` 是拖入那一刻的快照,文件在
+   * 托盘期间被改写后就会跟真正发出去的内容对不上,卡片的「类型 · 大小」用这个刷新。
+   */
+  onByteSize?: (bytes: number) => void;
+}) {
   const filePath = file.path && !file.path.startsWith('clipboard://') ? file.path : null;
   const [thumb, setThumb] = useState<Thumb | null>(() =>
     filePath ? (thumbCache.get(filePath) ?? null) : null,
   );
+  // 走 ref:回调换引用不该触发重新取图(effect 只认 filePath)。
+  const onByteSizeRef = useRef(onByteSize);
+  onByteSizeRef.current = onByteSize;
 
   useEffect(() => {
     if (!filePath) {
@@ -218,18 +233,22 @@ export function AttachmentTypeThumb({ file }: { file: AttachedFile }) {
     let cancelled = false;
     void (async () => {
       try {
-        const dataUrl = await window.electronAPI.getFileThumbnail({
+        const result = await window.electronAPI.getFileThumbnail({
           path: filePath,
           size: THUMB_PX * 2,
         });
         if (cancelled) return;
-        if (!dataUrl) {
+        if (result) onByteSizeRef.current?.(result.byteSize);
+        if (!result?.dataUrl) {
           // 现在拿不到图:清掉可能过期的缓存,回落自绘图标。
           thumbCache.delete(filePath);
           setThumb(null);
           return;
         }
-        const next: Thumb = { url: dataUrl, isIcon: await looksLikeIconBitmap(dataUrl) };
+        const next: Thumb = {
+          url: result.dataUrl,
+          isIcon: await looksLikeIconBitmap(result.dataUrl),
+        };
         rememberThumb(filePath, next);
         if (!cancelled) setThumb(next);
       } catch (err) {

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -94,13 +94,17 @@ async function looksLikeIconBitmap(dataUrl: string): Promise<boolean> {
 
 type IconKind = 'pdf' | 'doc' | 'sheet' | 'slide' | 'code' | 'text' | 'image' | 'plain';
 
-/** 角标色:同族低饱和,避免在灰调界面里跳出来。 */
+/**
+ * 角标色:走 themes/colors.ts 注册的 file-badge-* token(§10 theme-invariant
+ * 例外族),不在组件里写死 hex —— 否则自定义主题改不动它。取值都按白字 ≥4.5:1
+ * 选过,前景恒用 --file-badge-fg。
+ */
 const KIND_ACCENT: Record<IconKind, string | null> = {
-  pdf: '#D9553F',
-  doc: '#3B72C4',
-  sheet: '#3F9A5C',
-  slide: '#D08A32',
-  code: '#7A63C9',
+  pdf: 'var(--file-badge-pdf)',
+  doc: 'var(--file-badge-doc)',
+  sheet: 'var(--file-badge-sheet)',
+  slide: 'var(--file-badge-slide)',
+  code: 'var(--file-badge-code)',
   text: null,
   image: null,
   plain: null,
@@ -176,14 +180,15 @@ function FileGlyph({ kind }: { kind: IconKind }) {
       {accent && label ? (
         <>
           <rect x="9" y="18.5" width="19" height="11" rx="2.5" fill={accent} />
+          {/* 字重 500 封顶:DESIGN.md §3「Weight restraint — 只有 400 与 500,No bold」。 */}
           <text
             x="18.5"
             y="26.4"
             textAnchor="middle"
             fontSize="7.5"
-            fontWeight="700"
+            fontWeight="500"
             letterSpacing="0.2"
-            fill="#FFFFFF"
+            fill="var(--file-badge-fg)"
           >
             {label}
           </text>

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -58,9 +58,27 @@ let lastRevalidateAt = 0;
 let trailingTimer: ReturnType<typeof setTimeout> | null = null;
 let focusListenerBound = false;
 
+/** 一批唤醒多少张卡,以及批与批之间的间隔。 */
+const REVALIDATE_BATCH_SIZE = 6;
+const REVALIDATE_BATCH_GAP_MS = 120;
+
+/**
+ * 分批广播:节流只压住了**频率**,压不住**扇出** —— 托盘附件数没有上限,一次性
+ * 唤醒全部订阅者仍会瞬间打出 N 次 IPC(每次都要 realpath + stat)。按 6 张一批、
+ * 隔 120ms 铺开,峰值压到个位数,总时长对用户无感(60 个附件也就 1.2s 内铺完)。
+ */
 function broadcastRevalidate(): void {
   lastRevalidateAt = Date.now();
-  for (const notify of revalidateSubscribers) notify();
+  const queue = [...revalidateSubscribers];
+  const pump = () => {
+    const batch = queue.splice(0, REVALIDATE_BATCH_SIZE);
+    for (const notify of batch) {
+      // 期间可能有卡片卸载:退订过的就别叫了。
+      if (revalidateSubscribers.has(notify)) notify();
+    }
+    if (queue.length > 0) setTimeout(pump, REVALIDATE_BATCH_GAP_MS);
+  };
+  pump();
 }
 
 /**

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -316,6 +316,9 @@ export function AttachmentTypeThumb({
         const result = await window.electronAPI.getFileThumbnail({
           path: filePath,
           size: THUMB_PX * 2,
+          // 首次挂载走缓存(消闪烁);焦点复核是"用户可能刚改过这个文件"的信号,
+          // 跳过正缓存重新生成,否则粗时间戳文件系统上的同尺寸改写要等 TTL 才自愈。
+          revalidate: revalidateTick > 0,
         });
         if (cancelled) return;
         if (result) onByteSizeRef.current?.(result.byteSize);
@@ -355,10 +358,14 @@ export function AttachmentTypeThumb({
         style={{
           width: '100%',
           height: '100%',
-          // 写成内联而不是 Tailwind 类:这两个值要跟 isIcon 一起切,内联最直白。
+          // 写成内联而不是 Tailwind 类:这几个值要跟 isIcon 一起切,内联最直白。
           objectFit: thumb.isIcon ? 'contain' : 'cover',
           objectPosition: 'top center',
-          boxShadow: thumb.isIcon ? undefined : 'inset 0 0 0 1px var(--border-default)',
+          // 用 1px Board 描边而不是 inset 阴影:DESIGN.md §6 只允许 token 化的浮层
+          // 阴影,in-page 元素一律靠边框区分。outline + 负 offset 画在元素内沿,
+          // 不占布局也不撑大缩略区。
+          outline: thumb.isIcon ? undefined : '1px solid var(--border-default)',
+          outlineOffset: thumb.isIcon ? undefined : '-1px',
         }}
         draggable={false}
       />

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -217,9 +217,20 @@ export function AttachmentTypeThumb({
   const [thumb, setThumb] = useState<Thumb | null>(() =>
     filePath ? (thumbCache.get(filePath) ?? null) : null,
   );
-  // 走 ref:回调换引用不该触发重新取图(effect 只认 filePath)。
+  // 走 ref:回调换引用不该触发重新取图(effect 只认 filePath / revalidateTick)。
   const onByteSizeRef = useRef(onByteSize);
   onByteSizeRef.current = onByteSize;
+
+  // 附件挂在托盘上的这段时间里,用户完全可能切出去把文件改了再切回来发送 —— 只在
+  // 挂载时复核一次的话,预览和大小描述的还是旧内容。窗口重新获得焦点就是这个场景
+  // 的自然触发点(切到编辑器改完再切回来),比轮询或 fs.watch 都便宜;main 侧按
+  // mtime+size 命中缓存,没改动的文件这一趟几乎不花钱。
+  const [revalidateTick, setRevalidateTick] = useState(0);
+  useEffect(() => {
+    const onFocus = () => setRevalidateTick((n) => n + 1);
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, []);
 
   useEffect(() => {
     if (!filePath) {
@@ -259,7 +270,7 @@ export function AttachmentTypeThumb({
     return () => {
       cancelled = true;
     };
-  }, [filePath]);
+  }, [filePath, revalidateTick]);
 
   if (thumb) {
     // 图标型(dmg / zip 这类系统只给类型图标的):按原样居中显示,不裁切也不描边

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -55,17 +55,40 @@ const thumbCache = new Map<string, Thumb>();
 const REVALIDATE_MIN_INTERVAL_MS = 30_000;
 const revalidateSubscribers = new Set<() => void>();
 let lastRevalidateAt = 0;
+let trailingTimer: ReturnType<typeof setTimeout> | null = null;
 let focusListenerBound = false;
+
+function broadcastRevalidate(): void {
+  lastRevalidateAt = Date.now();
+  for (const notify of revalidateSubscribers) notify();
+}
+
+/**
+ * 节流是 leading + **trailing**:光掐掉窗口内的事件会把最新一次改动整个吞掉
+ * (改一次 → 切回来 → 再改 → 30s 内切回来,第二次改动就看不见了,而发送用的是
+ * 当前内容)。窗口内的多次 focus 合并成一次尾部补播,既不丢最新状态也不放大 IPC。
+ */
+function requestRevalidate(): void {
+  const elapsed = Date.now() - lastRevalidateAt;
+  if (elapsed >= REVALIDATE_MIN_INTERVAL_MS) {
+    if (trailingTimer) {
+      clearTimeout(trailingTimer);
+      trailingTimer = null;
+    }
+    broadcastRevalidate();
+    return;
+  }
+  if (trailingTimer) return; // 已经排好补播,后续 focus 合并进去
+  trailingTimer = setTimeout(() => {
+    trailingTimer = null;
+    broadcastRevalidate();
+  }, REVALIDATE_MIN_INTERVAL_MS - elapsed);
+}
 
 function ensureFocusListener(): void {
   if (focusListenerBound || typeof window === 'undefined') return;
   focusListenerBound = true;
-  window.addEventListener('focus', () => {
-    const now = Date.now();
-    if (now - lastRevalidateAt < REVALIDATE_MIN_INTERVAL_MS) return;
-    lastRevalidateAt = now;
-    for (const notify of revalidateSubscribers) notify();
-  });
+  window.addEventListener('focus', requestRevalidate);
 }
 
 function rememberThumb(key: string, value: Thumb): void {

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -1,0 +1,251 @@
+/**
+ * AttachmentTypeThumb — 输入框附件卡左侧的 40×40 缩略区。
+ *
+ * 「文件需要根据文件类型有图片或者预览」(2026-07-27):
+ *   1. 先要系统缩略图(main 的 file:thumbnail → macOS QuickLook / Windows Shell)。
+ *      它给的是**文件真实内容**:PDF 首页、docx/pptx 版面、Markdown / 代码的排版
+ *      预览、图片视频的画面 —— 一个入口覆盖所有格式,且比在 renderer 里塞 pdfjs
+ *      更快更轻(实测 PDF 48ms / Markdown 165ms)。
+ *   2. 拿不到时(remote 会话的远端路径、系统不认的冷门扩展名、超时)回落到自绘的
+ *      文件图标:纸张 + 折角 + 类型色角标,矢量绘制,40px / 80px 都锐利,双模式跟
+ *      着 token 走。
+ *
+ * 图片附件本身在 ChatInput 里直接走 56×56 缩略图,不会走到这里 —— 只有缓存写
+ * 失败、既无 url 也无 base64 的图片才会落到这个组件。
+ */
+
+import { useEffect, useState } from 'react';
+
+import type { AttachedFile, FileCategory } from '@/lib/fileTypes';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('AttachmentTypeThumb');
+
+/** 缩略区边长(CSS px)。按 2x 要图,retina 下不糊。 */
+const THUMB_PX = 40;
+
+interface Thumb {
+  url: string;
+  /**
+   * 系统给的是「类型图标」而不是文件内容缩略图(dmg / zip / 冷门扩展名走这条)。
+   * 图标型位图四周是透明的,展示规则跟内容图完全不同,见渲染处。
+   */
+  isIcon: boolean;
+}
+
+/** 已取回的缩略图(key = 路径)。托盘会随会话切换 / HMR / 草稿恢复反复重挂载。 */
+const thumbCache = new Map<string, Thumb>();
+/** 已知拿不到缩略图的路径:避免每次重挂载都再问一次 main。 */
+const thumbMisses = new Set<string>();
+
+/**
+ * 判断系统返回的是类型图标还是内容缩略图:图标画在透明画布中央,四边都是空的;
+ * PDF 首页 / 视频首帧这类内容图则铺满画布。采样四边中点与四角,全透明即图标。
+ * 读不到像素(解码失败等)时按内容图处理 —— 多一圈边框远好过给内容图裁错。
+ */
+async function looksLikeIconBitmap(dataUrl: string): Promise<boolean> {
+  try {
+    const img = new Image();
+    img.src = dataUrl;
+    await img.decode();
+    const w = img.naturalWidth;
+    const h = img.naturalHeight;
+    if (!w || !h) return false;
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d', { willReadFrequently: false });
+    if (!ctx) return false;
+    ctx.drawImage(img, 0, 0);
+    const { data } = ctx.getImageData(0, 0, w, h);
+    const alphaAt = (x: number, y: number) => data[(y * w + x) * 4 + 3];
+    const midX = w >> 1;
+    const midY = h >> 1;
+    const samples: [number, number][] = [
+      [0, midY], [w - 1, midY], [midX, 0], [midX, h - 1],
+      [0, 0], [w - 1, 0], [0, h - 1], [w - 1, h - 1],
+    ];
+    return samples.every(([x, y]) => alphaAt(x, y) < 8);
+  } catch {
+    return false;
+  }
+}
+
+// ── 自绘文件图标 ──────────────────────────────────────────────────────────
+//
+// 类型色是内容语义色(和「这份文件是什么」绑定),不随主题翻转,属于
+// docs/design-rules/DESIGN.md §10 的 theme-invariant 例外;纸张本体仍走语义
+// token,所以 Light / Dark 下纸面与卡片的关系保持一致。
+
+type IconKind = 'pdf' | 'doc' | 'sheet' | 'slide' | 'code' | 'text' | 'image' | 'plain';
+
+/** 角标色:同族低饱和,避免在灰调界面里跳出来。 */
+const KIND_ACCENT: Record<IconKind, string | null> = {
+  pdf: '#D9553F',
+  doc: '#3B72C4',
+  sheet: '#3F9A5C',
+  slide: '#D08A32',
+  code: '#7A63C9',
+  text: null,
+  image: null,
+  plain: null,
+};
+
+/** 角标里的短标签(≤4 字符);没有角标色的类型不画角标。 */
+const KIND_LABEL: Record<IconKind, string | null> = {
+  pdf: 'PDF',
+  doc: 'DOC',
+  sheet: 'XLS',
+  slide: 'PPT',
+  code: '<>',
+  text: null,
+  image: null,
+  plain: null,
+};
+
+const SHEET_EXTS = new Set(['.xls', '.xlsx', '.csv', '.tsv', '.numbers']);
+const SLIDE_EXTS = new Set(['.ppt', '.pptx', '.key']);
+const DOC_EXTS = new Set(['.doc', '.docx', '.rtf', '.odt', '.pages']);
+const CODE_EXTS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs', '.java',
+  '.c', '.cc', '.cpp', '.h', '.hpp', '.cs', '.rb', '.php', '.swift', '.kt',
+  '.sh', '.bash', '.zsh', '.sql', '.json', '.yaml', '.yml', '.toml', '.xml',
+  '.css', '.scss', '.html', '.vue', '.svelte', '.lua',
+]);
+
+/** 按扩展名 + category 定图标类型;拿不准回落中性纸张。 */
+export function pickIconKind(ext: string, category: FileCategory): IconKind {
+  const e = ext.toLowerCase();
+  if (e === '.pdf' || category === 'pdf') return 'pdf';
+  if (SHEET_EXTS.has(e)) return 'sheet';
+  if (SLIDE_EXTS.has(e)) return 'slide';
+  if (DOC_EXTS.has(e)) return 'doc';
+  if (CODE_EXTS.has(e)) return 'code';
+  if (category === 'image') return 'image';
+  if (category === 'text') return 'text';
+  return 'plain';
+}
+
+/**
+ * 自绘文件图标:一张带折角的纸,右下角压一枚类型色角标。
+ * 纸面 / 描边走 token,只有角标带类型色。
+ */
+function FileGlyph({ kind }: { kind: IconKind }) {
+  const accent = KIND_ACCENT[kind];
+  const label = KIND_LABEL[kind];
+  return (
+    <svg width="26" height="26" viewBox="0 0 32 32" fill="none" aria-hidden focusable="false">
+      {/* 纸张本体 + 折角 */}
+      <path
+        d="M7 3.5h11.2L26 11.3V28a1.5 1.5 0 0 1-1.5 1.5h-17A1.5 1.5 0 0 1 6 28V5a1.5 1.5 0 0 1 1-1.5Z"
+        fill="var(--surface-elevated)"
+        stroke="var(--text-placeholder)"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 3.6V10a1.5 1.5 0 0 0 1.5 1.5h6.2"
+        stroke="var(--text-placeholder)"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      {/* 正文示意线:没有角标的中性类型靠它表达「这是文档」 */}
+      <path
+        d="M10.5 15.5h11M10.5 19h11M10.5 22.5h6.5"
+        stroke="var(--text-placeholder)"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        opacity={accent ? 0.45 : 0.9}
+      />
+      {/* 类型角标 */}
+      {accent && label ? (
+        <>
+          <rect x="9" y="18.5" width="19" height="11" rx="2.5" fill={accent} />
+          <text
+            x="18.5"
+            y="26.4"
+            textAnchor="middle"
+            fontSize="7.5"
+            fontWeight="700"
+            letterSpacing="0.2"
+            fill="#FFFFFF"
+          >
+            {label}
+          </text>
+        </>
+      ) : null}
+    </svg>
+  );
+}
+
+// ── 组件 ─────────────────────────────────────────────────────────────────
+
+export function AttachmentTypeThumb({ file }: { file: AttachedFile }) {
+  const filePath = file.path && !file.path.startsWith('clipboard://') ? file.path : null;
+  const [thumb, setThumb] = useState<Thumb | null>(() =>
+    filePath ? (thumbCache.get(filePath) ?? null) : null,
+  );
+
+  useEffect(() => {
+    if (!filePath) {
+      setThumb(null);
+      return;
+    }
+    const cached = thumbCache.get(filePath);
+    if (cached) {
+      setThumb(cached);
+      return;
+    }
+    setThumb(null);
+    if (thumbMisses.has(filePath)) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const dataUrl = await window.electronAPI.getFileThumbnail({
+          path: filePath,
+          size: THUMB_PX * 2,
+        });
+        if (!dataUrl) {
+          thumbMisses.add(filePath);
+          return;
+        }
+        const next: Thumb = { url: dataUrl, isIcon: await looksLikeIconBitmap(dataUrl) };
+        thumbCache.set(filePath, next);
+        if (!cancelled) setThumb(next);
+      } catch (err) {
+        // 取不到缩略图是常态(远端路径 / 冷门格式),回落图标即可,不打扰用户。
+        thumbMisses.add(filePath);
+        log.debug('file thumbnail unavailable', { error: String(err) });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [filePath]);
+
+  if (thumb) {
+    // 图标型(dmg / zip 这类系统只给类型图标的):按原样居中显示,不裁切也不描边
+    // —— 图标四周本来就是透明的,套一圈边框等于在图标外面画个空方框。
+    // 内容型(PDF 首页、视频首帧这类铺满画面的):裁切填满,并给一圈 Board,
+    // 否则白纸压在同样浅的底上会糊成一片(Dark 下同样区分纸白与卡片)。
+    return (
+      <img
+        src={thumb.url}
+        alt=""
+        aria-hidden
+        className="rounded-lg"
+        style={{
+          width: '100%',
+          height: '100%',
+          // 写成内联而不是 Tailwind 类:这两个值要跟 isIcon 一起切,内联最直白。
+          objectFit: thumb.isIcon ? 'contain' : 'cover',
+          objectPosition: 'top center',
+          boxShadow: thumb.isIcon ? undefined : 'inset 0 0 0 1px var(--border-default)',
+        }}
+        draggable={false}
+      />
+    );
+  }
+
+  return <FileGlyph kind={pickIconKind(file.ext, file.category)} />;
+}

--- a/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AttachmentTypeThumb.tsx
@@ -33,10 +33,25 @@ interface Thumb {
   isIcon: boolean;
 }
 
-/** 已取回的缩略图(key = 路径)。托盘会随会话切换 / HMR / 草稿恢复反复重挂载。 */
+/**
+ * 已取回的缩略图(key = 路径),只用来消掉重挂载时的闪烁 —— 托盘会随会话切换 /
+ * HMR / 草稿恢复反复重挂载,没有它每次都要空一帧再补图。
+ *
+ * 它**不是**事实源:每次挂载仍会向 main 复核一次(stale-while-revalidate),因为
+ * 这里按路径存,而同一路径的文件可能被覆盖(main 侧按 mtime+size 判失效)。
+ * 长会话里拖入的文件数没有上限,所以这里也必须有上限,不能无限长。
+ */
+const THUMB_CACHE_LIMIT = 64;
 const thumbCache = new Map<string, Thumb>();
-/** 已知拿不到缩略图的路径:避免每次重挂载都再问一次 main。 */
-const thumbMisses = new Set<string>();
+
+function rememberThumb(key: string, value: Thumb): void {
+  if (thumbCache.size >= THUMB_CACHE_LIMIT && !thumbCache.has(key)) {
+    const oldest = thumbCache.keys().next();
+    if (!oldest.done) thumbCache.delete(oldest.value);
+  }
+  thumbCache.delete(key);
+  thumbCache.set(key, value);
+}
 
 /**
  * 判断系统返回的是类型图标还是内容缩略图:图标画在透明画布中央,四边都是空的;
@@ -191,13 +206,10 @@ export function AttachmentTypeThumb({ file }: { file: AttachedFile }) {
       setThumb(null);
       return;
     }
-    const cached = thumbCache.get(filePath);
-    if (cached) {
-      setThumb(cached);
-      return;
-    }
-    setThumb(null);
-    if (thumbMisses.has(filePath)) return;
+    // 先用缓存顶上(可能是旧内容),再无条件向 main 复核一次:main 按 mtime+size
+    // 判失效,文件被覆盖时会给回新图;之前出不了图的文件后来变得可读也能补上。
+    const cached = thumbCache.get(filePath) ?? null;
+    setThumb(cached);
     let cancelled = false;
     void (async () => {
       try {
@@ -205,16 +217,18 @@ export function AttachmentTypeThumb({ file }: { file: AttachedFile }) {
           path: filePath,
           size: THUMB_PX * 2,
         });
+        if (cancelled) return;
         if (!dataUrl) {
-          thumbMisses.add(filePath);
+          // 现在拿不到图:清掉可能过期的缓存,回落自绘图标。
+          thumbCache.delete(filePath);
+          setThumb(null);
           return;
         }
         const next: Thumb = { url: dataUrl, isIcon: await looksLikeIconBitmap(dataUrl) };
-        thumbCache.set(filePath, next);
+        rememberThumb(filePath, next);
         if (!cancelled) setThumb(next);
       } catch (err) {
-        // 取不到缩略图是常态(远端路径 / 冷门格式),回落图标即可,不打扰用户。
-        thumbMisses.add(filePath);
+        // 取不到缩略图是常态(冷门格式 / 文件已被移走),回落图标即可,不打扰用户。
         log.debug('file thumbnail unavailable', { error: String(err) });
       }
     })();

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -17,7 +17,8 @@ import { useTranslation } from 'react-i18next';
 import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
 import { requiresFullAccessConfirmation } from '@cindy/maker-shared/permission-mode';
 import { ImageLightbox } from '@/components/chat/ImageLightbox';
-import { TextLightbox } from '@/components/chat/TextLightbox';
+import { formatBytes, TextLightbox } from '@/components/chat/TextLightbox';
+import { AttachmentTypeThumb } from './AttachmentTypeThumb';
 import { useEditor, EditorContent } from '@tiptap/react';
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
@@ -6034,11 +6035,24 @@ function ThumbnailItem({
     setTextLightboxOpen(true);
   }, [file]);
 
+  // 图片缩略图恒为 56×56 方块;其余附件走横向文件卡,宽度随文件名自适应
+  // (上限 220px)。判定条件必须与下面渲染分支一致——缓存写失败、既无 url 也无
+  // base64 的图片同样落到文件卡分支。
+  const isImageThumb = file.category === 'image' && Boolean(file.url || file.base64);
+  // 副行是「类型 · 大小」;无扩展名(Makefile 之类)或 size 缺失时按存在的部分给。
+  const extLabel = file.ext.replace('.', '').toUpperCase();
+  const metaLine = [
+    extLabel || null,
+    Number.isFinite(file.size) && file.size > 0 ? formatBytes(file.size) : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
   return (
     <div
       ref={thumbRef}
       className="group relative shrink-0"
-      style={{ width: 56, height: 56 }}
+      style={isImageThumb ? { width: 56, height: 56 } : { height: 56, maxWidth: 220 }}
       onPointerEnter={() => setIsHovered(true)}
       onPointerLeave={() => setIsHovered(false)}
     >
@@ -6069,12 +6083,31 @@ function ThumbnailItem({
             ) : null}
           </span>
         ) : (
+          // 文件卡(2026-07-27):图标块 + 文件名 + 「类型 · 大小」。此前是一个只印
+          // 扩展名的 56×56 方块,并排两份 PDF 根本认不出谁是谁——文件名必须直接
+          // 可见,不能只挂在 hover tooltip 上。
           <div
-            className="flex h-full w-full items-center justify-center rounded-lg"
-            style={{ backgroundColor: 'var(--file-chip-bg)' }}
+            className="flex h-full w-full items-center gap-2 rounded-xl px-2"
+            style={{ backgroundColor: 'var(--surface-chip)' }}
           >
-            <span className="text-sm font-medium uppercase text-white">
-              {file.ext.replace('.', '')}
+            <span
+              // 缩略区比卡片底再抬一层:--file-chip-bg 与 --surface-chip 在 Light
+              // 下只差一档灰(#D8D9DB / #e5e5e5),实机上根本看不出块。内容由
+              // AttachmentTypeThumb 决定:优先系统缩略图,拿不到回落自绘类型图标。
+              className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg"
+              style={{ backgroundColor: 'var(--surface-elevated)' }}
+            >
+              <AttachmentTypeThumb file={file} />
+            </span>
+            <span className="flex min-w-0 flex-col gap-0.5">
+              <span className="truncate text-xs" style={{ color: 'var(--text-primary)' }}>
+                {file.name}
+              </span>
+              {metaLine ? (
+                <span className="truncate text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+                  {metaLine}
+                </span>
+              ) : null}
             </span>
           </div>
         )}

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -6040,10 +6040,14 @@ function ThumbnailItem({
   // base64 的图片同样落到文件卡分支。
   const isImageThumb = file.category === 'image' && Boolean(file.url || file.base64);
   // 副行是「类型 · 大小」;无扩展名(Makefile 之类)或 size 缺失时按存在的部分给。
+  // file.size 是拖入那一刻的快照:文件在托盘期间被改写后,发出去的是新内容,卡片
+  // 却还报旧字节数。缩略图复核时 main 会把当前 stat 大小一并带回,这里优先用它。
   const extLabel = file.ext.replace('.', '').toUpperCase();
+  const [liveByteSize, setLiveByteSize] = useState<number | null>(null);
+  const shownSize = liveByteSize ?? file.size;
   const metaLine = [
     extLabel || null,
-    Number.isFinite(file.size) && file.size > 0 ? formatBytes(file.size) : null,
+    Number.isFinite(shownSize) && shownSize > 0 ? formatBytes(shownSize) : null,
   ]
     .filter(Boolean)
     .join(' · ');
@@ -6097,7 +6101,7 @@ function ThumbnailItem({
               className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg"
               style={{ backgroundColor: 'var(--surface-elevated)' }}
             >
-              <AttachmentTypeThumb file={file} />
+              <AttachmentTypeThumb file={file} onByteSize={setLiveByteSize} />
             </span>
             <span className="flex min-w-0 flex-col gap-0.5">
               <span className="truncate text-xs" style={{ color: 'var(--text-primary)' }}>

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -6045,10 +6045,11 @@ function ThumbnailItem({
   const extLabel = file.ext.replace('.', '').toUpperCase();
   const [liveByteSize, setLiveByteSize] = useState<number | null>(null);
   const shownSize = liveByteSize ?? file.size;
-  const metaLine = [
-    extLabel || null,
-    Number.isFinite(shownSize) && shownSize > 0 ? formatBytes(shownSize) : null,
-  ]
+  // 复核回来的 0 是**真实的当前大小**(文件被清空了),要照实显示 0 B;只有拿不到
+  // 复核值、且快照本身就是 0/缺失时才省掉大小段。
+  const hasSize =
+    Number.isFinite(shownSize) && (liveByteSize !== null ? shownSize >= 0 : shownSize > 0);
+  const metaLine = [extLabel || null, hasSize ? formatBytes(shownSize) : null]
     .filter(Boolean)
     .join(' · ');
 

--- a/apps/desktop/src/renderer/themes/colors.ts
+++ b/apps/desktop/src/renderer/themes/colors.ts
@@ -798,6 +798,33 @@ registerColor('file-remove-bg', {
   light: '#525252',
   dark: '#737373',
 }, 'Mid Gray');
+// 附件卡自绘文件图标的类型角标(§10 theme-invariant 例外族):颜色跟「这份文件是
+// 什么」绑定,不随明暗翻转,两模式同值。取值都按白字 ≥4.5:1 选过(pdf 5.96 /
+// doc 6.56 / sheet 5.05 / slide 5.24 / code 7.09),角标文字恒用 file-badge-fg。
+registerColor('file-badge-pdf', {
+  light: '#B23A26',
+  dark: '#B23A26',
+}, '文件类型角标 — PDF(theme-invariant;× file-badge-fg = 5.96:1)');
+registerColor('file-badge-doc', {
+  light: '#2C5CA8',
+  dark: '#2C5CA8',
+}, '文件类型角标 — 文档(theme-invariant;× file-badge-fg = 6.56:1)');
+registerColor('file-badge-sheet', {
+  light: '#2E7D4F',
+  dark: '#2E7D4F',
+}, '文件类型角标 — 表格(theme-invariant;× file-badge-fg = 5.05:1)');
+registerColor('file-badge-slide', {
+  light: '#A25A12',
+  dark: '#A25A12',
+}, '文件类型角标 — 幻灯片(theme-invariant;× file-badge-fg = 5.24:1)');
+registerColor('file-badge-code', {
+  light: '#5B49A8',
+  dark: '#5B49A8',
+}, '文件类型角标 — 代码(theme-invariant;× file-badge-fg = 7.09:1)');
+registerColor('file-badge-fg', {
+  light: '#FFFFFF',
+  dark: '#FFFFFF',
+}, '文件类型角标前景 — 恒白(不能借 accent-pure-cta-fg:那个会在 Dark 翻成黑)');
 registerColor('chat-input-chip-bg', {
   light: 'var(--surface-chip)',
   dark: 'var(--surface-chip)',

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2098,6 +2098,8 @@ interface ElectronAPI {
   getFileThumbnail: (params: {
     path: string;
     size: number;
+    /** 显式复核:跳过正缓存重新生成(负缓存仍尊重)。焦点复核时传 true。 */
+    revalidate?: boolean;
   }) => Promise<{ dataUrl: string | null; byteSize: number } | null>;
 
   /**

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2090,11 +2090,15 @@ interface ElectronAPI {
   }) => Promise<{ base64: string; mimeType: string }>;
 
   /**
-   * 附件卡缩略图:本机文件走系统缩略图服务(macOS QuickLook / Windows Shell),
-   * 返回 PNG dataURL。路径越界、文件不存在、系统不支持该类型或超时都回 null,
-   * 调用方需回落到自绘文件图标。
+   * 附件卡缩略图:本机文件走系统缩略图服务(macOS QuickLook / Windows Shell)。
+   * 路径越界 / 不是文件 / stat 失败 → 整体回 null;文件在但出不了图(系统不支持、
+   * 超时、排不上并发名额)→ `dataUrl` 为 null,调用方回落自绘文件图标。
+   * `byteSize` 是复核那一刻的当前大小,用来刷新卡片上「类型 · 大小」的快照值。
    */
-  getFileThumbnail: (params: { path: string; size: number }) => Promise<string | null>;
+  getFileThumbnail: (params: {
+    path: string;
+    size: number;
+  }) => Promise<{ dataUrl: string | null; byteSize: number } | null>;
 
   /**
    * markdown-monorepo-resolve: smart relative-path resolver. Tries direct

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2090,6 +2090,13 @@ interface ElectronAPI {
   }) => Promise<{ base64: string; mimeType: string }>;
 
   /**
+   * 附件卡缩略图:本机文件走系统缩略图服务(macOS QuickLook / Windows Shell),
+   * 返回 PNG dataURL。路径越界、文件不存在、系统不支持该类型或超时都回 null,
+   * 调用方需回落到自绘文件图标。
+   */
+  getFileThumbnail: (params: { path: string; size: number }) => Promise<string | null>;
+
+  /**
    * markdown-monorepo-resolve: smart relative-path resolver. Tries direct
    * `cwd/href` first, then BFS the workspace for files whose absolute path
    * ends with `/<href>`. Returns 'none' on bad input or no matches so the

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -415,6 +415,7 @@ Theme switching: `useTheme.ts` provides `theme` (System / Light / Dark mode) plu
 | `--overlay-modal` / `--overlay-lightbox` | rgba | rgba (deeper) | Modal / lightbox backdrop |
 | `--perm-auto-selected-text` | `#417CDD` | `#417CDD` | Auto Approval accent, finalized 2026-07-17 (same value both modes; replaces #000050/#00D9C5) |
 | Toast `#417CDD / #2AAE5B / #F3A115 / #D91F37` | (hardcoded in Toast.tsx, VARIANT_MAP exported) | same | Finalized 2026-07-17 (Toast exemption lifted, merged into the status-color family) |
+| `--file-badge-pdf/-doc/-sheet/-slide/-code` + `--file-badge-fg` | `#B23A26` / `#2C5CA8` / `#2E7D4F` / `#A25A12` / `#5B49A8`, fg `#FFFFFF` | same | File-type badges on the self-drawn attachment icon (2026-07-27). Bound to *what the file is*, not to the theme, so both modes share one value. Each accent is picked for ≥4.5:1 against `--file-badge-fg` (5.96 / 6.56 / 5.05 / 5.24 / 7.09) — the badge label is 7.5px, so AA small-text applies. `--file-badge-fg` is a standalone white: `--accent-pure-cta-fg` flips to black in Dark and cannot be borrowed. |
 
 Never freestyle these semantic colors as hardcoded hex — always go through the corresponding token.
 

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -415,7 +415,7 @@ Theme switching: `useTheme.ts` provides `theme` (System / Light / Dark mode) plu
 | `--overlay-modal` / `--overlay-lightbox` | rgba | rgba (deeper) | Modal / lightbox backdrop |
 | `--perm-auto-selected-text` | `#417CDD` | `#417CDD` | Auto Approval accent, finalized 2026-07-17 (same value both modes; replaces #000050/#00D9C5) |
 | Toast `#417CDD / #2AAE5B / #F3A115 / #D91F37` | (hardcoded in Toast.tsx, VARIANT_MAP exported) | same | Finalized 2026-07-17 (Toast exemption lifted, merged into the status-color family) |
-| `--file-badge-pdf/-doc/-sheet/-slide/-code` + `--file-badge-fg` | `#B23A26` / `#2C5CA8` / `#2E7D4F` / `#A25A12` / `#5B49A8`, fg `#FFFFFF` | same | File-type badges on the self-drawn attachment icon (2026-07-27). Bound to *what the file is*, not to the theme, so both modes share one value. Each accent is picked for ≥4.5:1 against `--file-badge-fg` (5.96 / 6.56 / 5.05 / 5.24 / 7.09) — the badge label is 7.5px, so AA small-text applies. `--file-badge-fg` is a standalone white: `--accent-pure-cta-fg` flips to black in Dark and cannot be borrowed. |
+| `--file-badge-pdf/-doc/-sheet/-slide/-code` + `--file-badge-fg` | `#B23A26` / `#2C5CA8` / `#2E7D4F` / `#A25A12` / `#5B49A8`, fg `#FFFFFF` | same | File-type badges on the self-drawn attachment icon (2026-07-27). Bound to *what the file is*, not to the theme, so both modes share one value. Each accent is picked for ≥4.5:1 against `--file-badge-fg` (5.96 / 6.56 / 5.05 / 5.24 / 7.09) — the badge label renders at 10px (Micro Label floor, §3), so AA small-text applies. `--file-badge-fg` is a standalone white: `--accent-pure-cta-fg` flips to black in Dark and cannot be borrowed. |
 
 Never freestyle these semantic colors as hardcoded hex — always go through the corresponding token.
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

输入框里的非图片附件此前渲染成一个 56×56 方块、正中只印一个大写扩展名（`PDF`），
文件名只有 hover 时才在 tooltip 里出现——并排两份 PDF 根本认不出谁是谁。移动端
（`ComposerAttachmentTray`）早就是文件名 chip 形态，桌面端是这条链路上唯一落后的一端。

现在改成横向文件卡：**缩略区 + 文件名 + 「类型 · 大小」**。

缩略区优先要系统缩略图（新增 `file:thumbnail` IPC → `nativeImage.createThumbnailFromPath`，
macOS 走 QuickLook、Windows 走 Shell IShellItemImageFactory），拿到的是文件**真实内容**：
PDF 首页、视频首帧、Office 版面、Markdown 与代码的排版预览。一个入口覆盖所有格式，
renderer 不必为每种格式各接一个解析器，也不用背 pdfjs。

三层降级：

1. **内容缩略图**（PDF / 视频 / Office / 文本 / 代码 / 图片）→ `cover` 填满，带一圈 Board 边界
2. **系统只给类型图标**（dmg / zip 这类）→ `contain` 居中，不裁切也不描边（图标四周本就透明，
   套边框等于在图标外画个空方框）
3. **系统完全给不出图**（remote 会话的远端路径、冷门扩展名、超时）→ 自绘 SVG：纸张 + 折角 +
   类型色角标

两类的区分不是靠扩展名猜的：采样位图四边中点与四角的 alpha，全透明即判定为图标型。
实测 zip / dmg 判为图标，PDF / Markdown / JSON / 图片判为内容图。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（使用中提出）
- 本 PR 包含：桌面端输入框附件托盘的非图片附件卡；`file:thumbnail` IPC（main + preload +
  类型声明）；自绘文件图标；配套单测
- 明确不包含：移动端（早已是文件名 chip）；消息流里已发送附件的展示（走 `@file` chip，本身有
  文件名）；图片附件（仍是 56×56 缩略图，未动）
- 用户可见变化：输入框附件从「扩展名方块」变成「缩略图 + 文件名 + 类型·大小」的横向卡片
- 是否存在 breaking change：无

### UI 变化

未附截图：改动只影响本机输入框附件托盘，实机效果已由维护者在 dev 版逐项确认（见「手工验证」）。

- 引用的设计规范：
  - **DESIGN.md §5 Border Radius Scale**：文件卡按容器层用 12px（`rounded-xl`），内嵌的 40×40
    缩略区用内控件层 8px（`rounded-lg`）——内层小于容器，符合嵌套规则。
  - **DESIGN.md §2 Chip & Button Neutrals**：卡片底走 `--surface-chip`（chip 是前景元素，不属于
    背景层系统）；缩略区再抬一层到 `--surface-elevated`，否则 Light 下 `--file-chip-bg`（#D8D9DB）
    与 `--surface-chip`（#e5e5e5）只差一档灰，实机上看不出块。
  - **DESIGN.md §10 Token Selection Rules**：颜色全部走语义 token。顺带修掉旧实现的硬编码
    `text-white` 压 `--file-chip-bg`——Light 下对比度只有约 1.3:1，基本读不出来。
  - **DESIGN.md §10 Semantic Exemption Colors**：自绘图标的类型角标色（PDF 红 / DOC 蓝 /
    XLS 绿 / PPT 橙 / 代码紫）是与「这份文件是什么」绑定的内容语义色，不随主题翻转，作为
    theme-invariant 例外集中在 `KIND_ACCENT` 一张表里；纸张本体、描边、正文线仍走 token，
    并有单测守住「该表以外不得再出现硬编码色值」。
  - **DESIGN.md §10 双模式交付门槛**：两种模式都已实现（无单模式硬编码或条件补丁）。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：exit 0（全量单元测试）

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/main/__tests__/fileThumbnail.test.ts \
  src/renderer/__tests__/attachmentTypeThumb.test.ts \
  src/renderer/__tests__/attachmentFileCard.test.ts \
  src/renderer/__tests__/thumbnailClickPreview.test.ts
结果：4 files / 28 tests passed

# 安全规则要求的最小验证入口
pnpm --filter desktop exec vitest run \
  src/main/__tests__/webview-security.test.ts \
  src/main/security/__tests__/csp.test.ts \
  src/main/security/__tests__/trustedAppRenderer.test.ts
结果：3 files / 45 tests passed

pnpm --filter desktop exec eslint <本次改动文件>
结果：无告警（ChatInput.tsx 既有的 visualVariant 未使用告警在基线上同样存在，非本 PR 引入）

pnpm check:i18n-glossary
结果：通过（本 PR 不新增 UI 文案）
```

新增测试覆盖：`file:thumbnail` 的 fail-closed 行为（敏感目录 blocklist、相对路径、尺寸越界、
目录与不存在文件、系统服务抛错、空图、缓存命中与 mtime 失效），以及 renderer 侧的类型分派、
图标型/内容型展示差异、卸载后不 setState、颜色 token 约束。

### 手工验证

macOS 26 / Apple Silicon，dev 版（`pnpm restart:desktop:remote -- --preserve-running`，
`desktop:whoami` 确认 MATCH），Dark 模式逐项确认：

- PDF（1.3 MB）→ 首页封面缩略图；MP4（2.1 GB）→ 视频首帧缩略图
- DMG（471 MB）/ ZIP（3.1 GB）→ 系统类型图标，`contain` 居中且外层无多余边框
- 卡片显示文件名与「类型 · 大小」，长文件名截断
- 原有交互不变：hover 出删除按钮与完整路径 tooltip，点击仍开 TextLightbox / 系统应用

排障过程中还用真 Electron 探针核对了两处事实：`nativeImage.createThumbnailFromPath`
在本机的耗时（PDF 48ms / Markdown 165ms / JSON 22ms）与返回位图保持原始宽高比；以及
`app.getFileIcon` 只给 32×32 且同进程连续调用会挂起（因此没选它）。

### 未执行的验证

- **Windows 未实测**：`createThumbnailFromPath` 在 Windows 走 Shell IShellItemImageFactory，
  本 PR 只在 macOS 实机验证过。该路径失败时会走同一条 fail-closed 分支回落自绘图标，
  不影响可用性，但缩略图观感未在 Windows 核对。
- **Light 模式未逐项目检**：实机确认在 Dark 模式下完成。颜色全部走语义 token、无单模式
  条件分支，但按双模式交付门槛，这里如实标注 Light 未做实机目检。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

**权限 / 安全**：新增 `file:thumbnail` 是一条「renderer 递绝对路径 → main 读本地文件」的通道，
按 `docs/dev-rules/electron-security-and-process-boundaries.md` §5 收口：

- sender 走 `assertTrustedAppRendererEvent`（只允许 Cindy 自有顶层 frame，Ghost / WebView 拒绝）
- 路径策略复用 `xdt-file://` 协议同一条敏感目录 blocklist（`isPathAllowedAgainst` +
  `getSensitiveMediaBlocklist`），**不新开读取面**——renderer 本来就能通过该协议读同一批文件
- payload 运行时校验：必须绝对路径、必须是文件、尺寸限定在 16–512px
- 4s 硬超时（系统缩略图服务实测会挂）、mtime+size 为 key 的 LRU 缓存（上限 128 条）
- 一切失败回 `null`，不把 errno、堆栈或内部绝对路径回传 renderer
- 返回物是缩略位图，不含文件正文

**跨平台差异**：macOS 与 Windows 由系统各自的缩略图服务出图，同一份文件在两端观感可能不同；
拿不到时两端都回落到同一套自绘 SVG 图标。

**影响范围**：仅桌面端输入框附件托盘的渲染与一条新增只读 IPC，不改附件数据结构、不改发送链路、
不碰数据库与协议。

**回滚方式**：整 PR revert 即可，无数据迁移、无持久化状态；缩略图缓存是进程内存，重启即清。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动内联注释已写明取舍；无需新增规则文档）
- [x] 已确认测试结果或说明未执行原因
