### PR TITLE
fix(desktop): passive 共享实例不再删除全机 auth 凭证

### DIFF
--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -130,14 +130,16 @@ describe('passive shared-userData instance auth isolation', () => {
 
   it('relogin marker:passive 不消费整机一份的 marker,也不删 primary 的 token', () => {
     const start = authSource.indexOf('const reloginFlag = readReloginFlag();');
-    const end = authSource.indexOf('clearReloginFlag();', start);
+    const end = authSource.indexOf('// Old Feishu-auth refresh tokens', start);
     const body = authSource.slice(start, end);
 
     // marker 一次性且整机一份：passive 消费掉，primary 就永远看不到这次
-    // requireRelogin；顺带删掉的又正是 primary 的 token。
-    expect(body).toContain('!isPassiveSharedUserDataInstance()');
-    const guardIdx = body.indexOf('!isPassiveSharedUserDataInstance()');
-    expect(body.indexOf('removeSafe(REFRESH_TOKEN_KEY);')).toBeGreaterThan(guardIdx);
+    // requireRelogin；顺带删掉的又正是 primary 的 token。清理与消费必须整体落在
+    // 非 passive 分支里。
+    const passiveIdx = body.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    expect(passiveIdx).toBeGreaterThan(-1);
+    expect(body.indexOf('removeSafe(REFRESH_TOKEN_KEY);')).toBeGreaterThan(passiveIdx);
+    expect(body.indexOf('clearReloginFlag();')).toBeGreaterThan(passiveIdx);
   });
 
   it('其余整机一份的账号派生状态:canary flag 与账号删除 receipt 都不被 passive 清掉', () => {
@@ -175,11 +177,35 @@ describe('passive shared-userData instance auth isolation', () => {
     expect(body).toContain('removeSafeIfUnchanged(REFRESH_TOKEN_KEY, storedToken)');
     expect(body).not.toContain('removeSafe(REFRESH_TOKEN_KEY);');
 
-    // compare-and-delete 读不出磁盘内容时不得删（宁留失效 token 也不误删有效凭证）。
+    // compare-and-delete 读不出磁盘内容时不得删（宁留失效 token 也不误删有效凭证），
+    // 并且要在内容比对前后各校验一次文件身份，收紧 read→unlink 之间的 TOCTOU。
     const helper = sliceBody(
       'function removeSafeIfUnchanged(key: string, expected: string): boolean {',
       '\n}\n',
     );
     expect(helper).toContain('if (readSafe(key) !== expected) return false;');
+    expect(helper).toContain('const before = identity();');
+    expect(helper).toContain('if (before === null) return false;');
+    expect(helper).toContain('if (identity() !== before) return false;');
+    expect(helper.indexOf('if (identity() !== before) return false;')).toBeLessThan(
+      helper.indexOf('removeSafe(key);'),
+    );
+  });
+
+  it('relogin marker:passive 不消费 marker,但同样保持登出(不得拿旧 token 登进去)', () => {
+    const start = authSource.indexOf('const reloginFlag = readReloginFlag();');
+    const end = authSource.indexOf('// Old Feishu-auth refresh tokens', start);
+    const body = authSource.slice(start, end);
+
+    // marker 命中 = 这个版本要求重新登录。passive 跑的是同一个版本，不消费 marker
+    // 不等于可以拿旧 token 冷启动登进去——那正是 marker 想避免的。
+    const passiveIdx = body.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    expect(passiveIdx).toBeGreaterThan(-1);
+    const passiveBranch = body.slice(passiveIdx, body.indexOf('lastAcceptedRefreshToken = null;'));
+    expect(passiveBranch).toContain('passiveLocalSignOut = true;');
+    expect(passiveBranch).toContain('return snapshotLoggedOutAuthState();');
+    // 但这条分支里不得出现任何删除或 marker 消费。
+    expect(passiveBranch).not.toContain('removeSafe(');
+    expect(passiveBranch).not.toContain('clearReloginFlag();');
   });
 });

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -98,4 +98,61 @@ describe('passive shared-userData instance auth isolation', () => {
     expect(body).toContain("await expireRuntimeAuth(previousUserId, 'credential-lost', {");
     expect(body).toContain('preservePersistedRefreshToken: true');
   });
+
+  it('唤醒续期有意不加闸门:passive 让出的是周期轮换,不是按需自愈', () => {
+    const body = sliceBody('export function handleResume(): void {', '\n}\n');
+
+    // 拦掉 resume 会让 passive 的 access token 过期后再无替换：primary 的续期只更新
+    // 磁盘 refresh token，不更新本进程内存里的 access token，而直接走 apiFetch 的
+    // 路径（getAccountDeletionAvailability / updateServerProfile）拿不到 401 重试。
+    // 这条断言把取舍钉住，避免后续 review 来回改。
+    expect(body).not.toContain('isPassiveSharedUserDataInstance');
+    expect(body).toContain('refresh();');
+  });
+
+  it('登出墓碑:passive 本地登出后 initialize 不得用 primary 的 token 登回来', () => {
+    const clearBody = sliceBody('function clearAuth(', 'commitActiveAppSession');
+    const passiveIdx = clearBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    // 墓碑必须和「保留磁盘 token」在同一分支里立起来。
+    expect(clearBody.indexOf('passiveLocalSignOut = true;')).toBeGreaterThan(passiveIdx);
+
+    const initBody = sliceBody(
+      'export async function initialize(options: AuthInitializeOptions = {}): Promise<AuthState> {',
+      'const reloginFlag = readReloginFlag();',
+    );
+    expect(initBody).toContain('if (passiveLocalSignOut) {');
+    // 早退必须发生在读持久化 token 之前。
+    expect(initBody).toContain('return snapshotLoggedOutAuthState();');
+
+    // 显式登录解除墓碑，否则 passive 上登出后就再也登不回来。
+    expect(authSource).toContain('passiveLocalSignOut = false;');
+  });
+
+  it('relogin marker:passive 不消费整机一份的 marker,也不删 primary 的 token', () => {
+    const start = authSource.indexOf('const reloginFlag = readReloginFlag();');
+    const end = authSource.indexOf('clearReloginFlag();', start);
+    const body = authSource.slice(start, end);
+
+    // marker 一次性且整机一份：passive 消费掉，primary 就永远看不到这次
+    // requireRelogin；顺带删掉的又正是 primary 的 token。
+    expect(body).toContain('!isPassiveSharedUserDataInstance()');
+    const guardIdx = body.indexOf('!isPassiveSharedUserDataInstance()');
+    expect(body.indexOf('removeSafe(REFRESH_TOKEN_KEY);')).toBeGreaterThan(guardIdx);
+  });
+
+  it('其余整机一份的账号派生状态:canary flag 与账号删除 receipt 都不被 passive 清掉', () => {
+    const clearBody = sliceBody('function clearAuth(', 'clearPerAccountIntegrationsInBackground');
+    // canary-flag.json 被清 → packaged primary 下次更新轮询按 stable 拉 manifest。
+    expect(clearBody).toContain('if (!isPassiveSharedUserDataInstance()) {');
+    const canaryGuardIdx = clearBody.indexOf('if (!isPassiveSharedUserDataInstance()) {');
+    expect(clearBody.indexOf('canaryFlagStore.clear();')).toBeGreaterThan(canaryGuardIdx);
+
+    // receipt 被清 → primary 的 confirmAccountDeletion() 拿 RECEIPT_MISSING。
+    const receiptBody = sliceBody('export function clearAccountDeletionReceipt(): void {', '\n}\n');
+    const receiptGuardIdx = receiptBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    expect(receiptGuardIdx).toBeGreaterThan(-1);
+    expect(receiptBody.indexOf('removeSafe(ACCOUNT_DELETION_RECEIPT_KEY);')).toBeGreaterThan(
+      receiptGuardIdx,
+    );
+  });
 });

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -176,20 +176,30 @@ describe('passive shared-userData instance auth isolation', () => {
     // 非 passive 也不能无条件删：判定与删除之间另一个实例可能写入了替换凭证。
     expect(body).toContain('removeSafeIfUnchanged(REFRESH_TOKEN_KEY, storedToken)');
     expect(body).not.toContain('removeSafe(REFRESH_TOKEN_KEY);');
+    // 三种结果各自如实记日志，尤其 'failed' 不得报成已清理。
+    expect(body).toContain("case 'deleted':");
+    expect(body).toContain("case 'changed':");
+    expect(body).toContain("case 'failed':");
 
     // compare-and-delete 读不出磁盘内容时不得删（宁留失效 token 也不误删有效凭证），
     // 并且要在内容比对前后各校验一次文件身份，收紧 read→unlink 之间的 TOCTOU。
     const helper = sliceBody(
-      'function removeSafeIfUnchanged(key: string, expected: string): boolean {',
+      'function removeSafeIfUnchanged(key: string, expected: string): RemoveIfUnchangedResult {',
       '\n}\n',
     );
-    expect(helper).toContain('if (readSafe(key) !== expected) return false;');
+    expect(helper).toContain("if (readSafe(key) !== expected) return 'changed';");
     expect(helper).toContain('const before = identity();');
-    expect(helper).toContain('if (before === null) return false;');
-    expect(helper).toContain('if (identity() !== before) return false;');
-    expect(helper.indexOf('if (identity() !== before) return false;')).toBeLessThan(
-      helper.indexOf('removeSafe(key);'),
+    expect(helper).toContain("if (before === null) return 'changed';");
+    expect(helper).toContain("if (identity() !== before) return 'changed';");
+    expect(helper.indexOf("if (identity() !== before) return 'changed';")).toBeLessThan(
+      helper.indexOf('fs.unlinkSync(filepath);'),
     );
+
+    // 删除失败必须如实回报：removeSafe() 吞掉所有 unlink 错误，用它会让调用方把
+    // 「没删成」当成「已清理」并据此打日志。ENOENT 例外——目标状态已达成。
+    expect(helper).not.toContain('removeSafe(key);');
+    expect(helper).toContain("if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return 'deleted';");
+    expect(helper).toContain("return 'failed';");
   });
 
   it('relogin marker:passive 不消费 marker,但同样保持登出(不得拿旧 token 登进去)', () => {

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -148,11 +148,38 @@ describe('passive shared-userData instance auth isolation', () => {
     expect(clearBody.indexOf('canaryFlagStore.clear();')).toBeGreaterThan(canaryGuardIdx);
 
     // receipt 被清 → primary 的 confirmAccountDeletion() 拿 RECEIPT_MISSING。
-    const receiptBody = sliceBody('export function clearAccountDeletionReceipt(): void {', '\n}\n');
-    const receiptGuardIdx = receiptBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    // 闸门必须加在 logout 这条隐式路径上，而不是函数体里。
+    const logoutBody = sliceBody('export async function logout(): Promise<void> {', '\n}\n');
+    const receiptGuardIdx = logoutBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
     expect(receiptGuardIdx).toBeGreaterThan(-1);
-    expect(receiptBody.indexOf('removeSafe(ACCOUNT_DELETION_RECEIPT_KEY);')).toBeGreaterThan(
-      receiptGuardIdx,
+    expect(logoutBody.indexOf('clearAccountDeletionReceipt();')).toBeGreaterThan(receiptGuardIdx);
+  });
+
+  it('receipt 的显式清理不被闸门波及:renderer 主动 dismiss 在 passive 上必须照常生效', () => {
+    // clearAccountDeletionReceipt() 经 auth:account-deletion:clear-receipt 暴露给
+    // renderer（登录页处理无效/已取消挑战、dismiss 已完成状态）。把整个函数禁掉会让
+    // receipt 永远留在盘上，snapshotAuthState() 每次启动又报出来，dismiss 不掉。
+    const body = sliceBody('export function clearAccountDeletionReceipt(): void {', '\n}\n');
+    expect(body).not.toContain('isPassiveSharedUserDataInstance');
+    expect(body).toContain('removeSafe(ACCOUNT_DELETION_RECEIPT_KEY);');
+  });
+
+  it('冷启动确定性失效:passive 不删盘,非 passive 也只做 compare-and-delete', () => {
+    const start = authSource.indexOf("if (action.kind === 'definitive-failure') {");
+    const end = authSource.indexOf("} else if (action.kind === 'replacement-retry') {", start);
+    const body = authSource.slice(start, end);
+
+    // passive 冷启动拿到 INVALID_REFRESH_TOKEN，最常见的原因就是 primary 刚轮换过它。
+    expect(body).toContain('if (isPassiveSharedUserDataInstance()) {');
+    // 非 passive 也不能无条件删：判定与删除之间另一个实例可能写入了替换凭证。
+    expect(body).toContain('removeSafeIfUnchanged(REFRESH_TOKEN_KEY, storedToken)');
+    expect(body).not.toContain('removeSafe(REFRESH_TOKEN_KEY);');
+
+    // compare-and-delete 读不出磁盘内容时不得删（宁留失效 token 也不误删有效凭证）。
+    const helper = sliceBody(
+      'function removeSafeIfUnchanged(key: string, expected: string): boolean {',
+      '\n}\n',
     );
+    expect(helper).toContain('if (readSafe(key) !== expected) return false;');
   });
 });

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 共享 userData 的 passive dev 实例对 auth 凭证保持只读的回归守卫(authManager 依赖
+ * Electron,node 测试环境无法直接 import,沿用 authSessionExpiredDetection.test.ts 的
+ * 源码守卫模式)。
+ *
+ * 守护的契约:passive 共享实例可以**用**登录态,但不能**改**它。三个共享物——磁盘
+ * refresh token 文件、服务端按 (user, device) 一对一存的 refresh token、由前者派生的
+ * 续期节奏——一个都不能动。
+ *
+ * 2026-07-27 事故:两个 MIGRATE_FAILED 的 passive 实例(05:30 与 07:51)在 LocalDbGate
+ * fatal 界面点「返回登录」,logout 删掉整机 refresh token;正在使用的 primary 分别在
+ * 19 / 46 分钟后的 refresh 周期被判 credential-lost 强制重登,当场还中断了在跑的
+ * scheduler run、IM 连接与 device-link 持有权。同源事故 2026-07-23 已发生过一次,当时
+ * 只把静默半死改成明确弹重登(正确的报警),没有堵住 passive 的写入权。
+ */
+describe('passive shared-userData instance auth isolation', () => {
+  const authSource = readFileSync(resolve(process.cwd(), 'src/main/authManager.ts'), 'utf8').replace(
+    /\r\n/g,
+    '\n',
+  );
+
+  const sliceBody = (startAnchor: string, endAnchor: string): string => {
+    const start = authSource.indexOf(startAnchor);
+    expect(start, `anchor not found: ${startAnchor}`).toBeGreaterThan(-1);
+    const end = authSource.indexOf(endAnchor, start);
+    expect(end, `end anchor not found: ${endAnchor}`).toBeGreaterThan(start);
+    return authSource.slice(start, end);
+  };
+
+  it('判定复用启动期已落地的 XDT_PASSIVE_SHARED_USER_DATA,且 packaged 无条件排除', () => {
+    const body = sliceBody('function isPassiveSharedUserDataInstance(): boolean {', '\n}\n');
+
+    // packaged 恒不设置该 env,但仍保留 isPackaged 双保险,防 ambient env 污染线上语义。
+    expect(body).toContain('!app.isPackaged');
+    expect(body).toContain("process.env.XDT_PASSIVE_SHARED_USER_DATA === '1'");
+    // 不新增判定通道:isolated 沙箱有独立 userData 与 deviceId,不该出现在这条判定里。
+    expect(body).not.toContain('XDT_ISOLATED');
+  });
+
+  it('clearAuth:passive 共享实例不删磁盘 refresh token', () => {
+    const body = sliceBody('function clearAuth(', 'commitActiveAppSession');
+
+    const guardIdx = body.indexOf('if (!opts.preservePersistedRefreshToken) {');
+    const passiveIdx = body.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    expect(guardIdx).toBeGreaterThan(-1);
+    // passive 判定必须落在 opts 守卫之内、三个 removeSafe 之前——即显式 preserve 与
+    // passive 身份是两道独立的闸,任一命中都不得删盘。
+    expect(passiveIdx).toBeGreaterThan(guardIdx);
+    expect(body.indexOf('removeSafe(REFRESH_TOKEN_KEY);')).toBeGreaterThan(passiveIdx);
+    expect(body.indexOf('removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);')).toBeGreaterThan(passiveIdx);
+    expect(body.indexOf('removeSafe(LEGACY_REFRESH_TOKEN_KEY);')).toBeGreaterThan(passiveIdx);
+  });
+
+  it('logout:passive 共享实例不调服务端登出(会连坐作废 primary 的 device token)', () => {
+    const body = sliceBody('export async function logout(): Promise<void> {', '\n}\n');
+
+    // refresh token 服务端按 (user, device) 一对一存,passive 与 primary 共用 deviceId:
+    // 只留本地文件不够,这一发也必须拦,否则 primary 下次续期拿确定性失败被踢。
+    expect(body).toContain('!isPassiveSharedUserDataInstance()');
+    const guardIdx = body.indexOf('!isPassiveSharedUserDataInstance()');
+    expect(body.indexOf("apiFetch('/api/auth/logout'")).toBeGreaterThan(guardIdx);
+  });
+
+  it('续期节奏:passive 共享实例既不排定时 refresh,也不排瞬时失败重试', () => {
+    const scheduleBody = sliceBody('function scheduleRefresh(token: string): void {', '\n}\n');
+    const passiveIdx = scheduleBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    expect(passiveIdx).toBeGreaterThan(-1);
+    // 早退必须发生在排 timer 之前。
+    expect(scheduleBody.indexOf('setTimeout(')).toBeGreaterThan(passiveIdx);
+    expect(scheduleBody.slice(passiveIdx)).toContain('return;');
+
+    const retryBody = sliceBody(
+      'function scheduleRefreshRetryAfterTransientFailure(): void {',
+      '\n}\n',
+    );
+    const retryPassiveIdx = retryBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    expect(retryPassiveIdx).toBeGreaterThan(-1);
+    expect(retryBody.indexOf('refreshTimer = setTimeout(')).toBeGreaterThan(retryPassiveIdx);
+    // 早退前必须把已清掉的 timer 置 null,不留悬空引用。
+    expect(retryBody.slice(0, retryPassiveIdx)).toContain('refreshTimer = null;');
+  });
+
+  it('refresh 本身不被 passive 拦:冷启动仍能换 access token,凭证缺席仍走过期出口', () => {
+    const body = sliceBody(
+      'export async function refresh(): Promise<boolean> {',
+      'const diskTokenChangedBeforeRefresh',
+    );
+
+    // passive 需要冷启动那一次 refresh 才有可用会话;拦掉 refresh() 本身会让它拿不到
+    // access token。闸门只加在「排 timer」和「删凭证」上,不加在 refresh 入口。
+    expect(body).not.toContain('isPassiveSharedUserDataInstance');
+    // 且 passive 被 primary 换掉 token 时仍明确过期(只影响本进程、不删盘),
+    // 不得退回 2026-07-23 那种静默半死。
+    expect(body).toContain("await expireRuntimeAuth(previousUserId, 'credential-lost', {");
+    expect(body).toContain('preservePersistedRefreshToken: true');
+  });
+});

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -7,10 +7,13 @@ import { describe, expect, it } from 'vitest';
  * Electron,node 测试环境无法直接 import,沿用 authSessionExpiredDetection.test.ts 的
  * 源码守卫模式)。
  *
- * 守护的契约:passive 共享实例可以**用**登录态,但不能**写/删**整机共享的 auth 持久
- * 状态——refresh token 文件、服务端 device token(登出会连坐作废)、relogin marker、
- * canary flag、账号删除 receipt。「谁负责续期」是正交问题,不在本契约内:passive
- * 照常续期,否则它的 access token 过期后没有任何自愈路径。
+ * 守护的契约:passive 共享实例可以**用**登录态,但不得**删除 / 作废 / 消费**整机共享
+ * 的 auth 持久状态——refresh token 文件、服务端 device token(登出会连坐作废)、
+ * relogin marker(一次性,被消费掉 primary 就看不到)、canary flag、账号删除 receipt。
+ *
+ * 约束的是破坏性动作,不是写入本身:passive 照常续期并写回轮换后的新 token(写入的
+ * 是有效凭证,primary 侧由 replacement-retry 消化);停掉续期反而会让它的 access
+ * token 过期后没有任何自愈路径。
  *
  * 2026-07-27 事故:两个 MIGRATE_FAILED 的 passive 实例(05:30 与 07:51)在 LocalDbGate
  * fatal 界面点「返回登录」,logout 删掉整机 refresh token;正在使用的 primary 分别在

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -7,9 +7,10 @@ import { describe, expect, it } from 'vitest';
  * Electron,node 测试环境无法直接 import,沿用 authSessionExpiredDetection.test.ts 的
  * 源码守卫模式)。
  *
- * 守护的契约:passive 共享实例可以**用**登录态,但不能**改**它。三个共享物——磁盘
- * refresh token 文件、服务端按 (user, device) 一对一存的 refresh token、由前者派生的
- * 续期节奏——一个都不能动。
+ * 守护的契约:passive 共享实例可以**用**登录态,但不能**写/删**整机共享的 auth 持久
+ * 状态——refresh token 文件、服务端 device token(登出会连坐作废)、relogin marker、
+ * canary flag、账号删除 receipt。「谁负责续期」是正交问题,不在本契约内:passive
+ * 照常续期,否则它的 access token 过期后没有任何自愈路径。
  *
  * 2026-07-27 事故:两个 MIGRATE_FAILED 的 passive 实例(05:30 与 07:51)在 LocalDbGate
  * fatal 界面点「返回登录」,logout 删掉整机 refresh token;正在使用的 primary 分别在
@@ -65,23 +66,23 @@ describe('passive shared-userData instance auth isolation', () => {
     expect(body.indexOf("apiFetch('/api/auth/logout'")).toBeGreaterThan(guardIdx);
   });
 
-  it('续期节奏:passive 共享实例既不排定时 refresh,也不排瞬时失败重试', () => {
+  it('续期节奏不设闸门:passive 照常排 timer,否则 access token 过期后无自愈路径', () => {
+    // 本 PR 的契约是「不写/不删共享的 auth 持久状态」;「谁负责续期」是正交问题。
+    // 曾经让 passive 停止续期，被两个 reviewer 从相反方向指出问题：停掉之后
+    // access token 过期就再无替换途径（primary 的续期只更新磁盘 token，不更新本
+    // 进程内存态），而 updateServerProfile 等直接走 apiFetch 的路径没有 401
+    // refresh/retry，会一直失败到进程重启——resume 也救不了，系统不休眠就不触发。
+    // 轮换本身不会踢人（primary 侧 replacement-retry 兜底），踢人的是删除凭证。
     const scheduleBody = sliceBody('function scheduleRefresh(token: string): void {', '\n}\n');
-    const passiveIdx = scheduleBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
-    expect(passiveIdx).toBeGreaterThan(-1);
-    // 早退必须发生在排 timer 之前。
-    expect(scheduleBody.indexOf('setTimeout(')).toBeGreaterThan(passiveIdx);
-    expect(scheduleBody.slice(passiveIdx)).toContain('return;');
+    expect(scheduleBody).not.toContain('if (isPassiveSharedUserDataInstance()) {');
+    expect(scheduleBody).toContain('refreshTimer = setTimeout(');
 
     const retryBody = sliceBody(
       'function scheduleRefreshRetryAfterTransientFailure(): void {',
       '\n}\n',
     );
-    const retryPassiveIdx = retryBody.indexOf('if (isPassiveSharedUserDataInstance()) {');
-    expect(retryPassiveIdx).toBeGreaterThan(-1);
-    expect(retryBody.indexOf('refreshTimer = setTimeout(')).toBeGreaterThan(retryPassiveIdx);
-    // 早退前必须把已清掉的 timer 置 null,不留悬空引用。
-    expect(retryBody.slice(0, retryPassiveIdx)).toContain('refreshTimer = null;');
+    expect(retryBody).not.toContain('isPassiveSharedUserDataInstance');
+    expect(retryBody).toContain('refreshTimer = setTimeout(');
   });
 
   it('refresh 本身不被 passive 拦:冷启动仍能换 access token,凭证缺席仍走过期出口', () => {
@@ -91,7 +92,7 @@ describe('passive shared-userData instance auth isolation', () => {
     );
 
     // passive 需要冷启动那一次 refresh 才有可用会话;拦掉 refresh() 本身会让它拿不到
-    // access token。闸门只加在「排 timer」和「删凭证」上,不加在 refresh 入口。
+    // access token。闸门只加在「写/删共享持久状态」上,不加在 refresh 入口。
     expect(body).not.toContain('isPassiveSharedUserDataInstance');
     // 且 passive 被 primary 换掉 token 时仍明确过期(只影响本进程、不删盘),
     // 不得退回 2026-07-23 那种静默半死。
@@ -99,13 +100,8 @@ describe('passive shared-userData instance auth isolation', () => {
     expect(body).toContain('preservePersistedRefreshToken: true');
   });
 
-  it('唤醒续期有意不加闸门:passive 让出的是周期轮换,不是按需自愈', () => {
+  it('唤醒续期同样不设闸门', () => {
     const body = sliceBody('export function handleResume(): void {', '\n}\n');
-
-    // 拦掉 resume 会让 passive 的 access token 过期后再无替换：primary 的续期只更新
-    // 磁盘 refresh token，不更新本进程内存里的 access token，而直接走 apiFetch 的
-    // 路径（getAccountDeletionAvailability / updateServerProfile）拿不到 401 重试。
-    // 这条断言把取舍钉住，避免后续 review 来回改。
     expect(body).not.toContain('isPassiveSharedUserDataInstance');
     expect(body).toContain('refresh();');
   });

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -142,6 +142,19 @@ describe('passive shared-userData instance auth isolation', () => {
     expect(body.indexOf('clearReloginFlag();')).toBeGreaterThan(passiveIdx);
   });
 
+  it('legacy 凭证清理:passive 启动不得删掉老构建 primary 可能还在用的文件', () => {
+    const start = authSource.indexOf('// Old Feishu-auth refresh tokens');
+    const end = authSource.indexOf('const storedToken = readSafe(REFRESH_TOKEN_KEY);', start);
+    const body = authSource.slice(start, end);
+
+    // dev + packaged 共库双开是受支持的场景（--preserve-running）：老构建的 primary
+    // 可能仍在消费这两个 legacy 文件，passive 只是启动一下就把它们删了。
+    expect(body).toContain('if (!isPassiveSharedUserDataInstance()) {');
+    const guardIdx = body.indexOf('if (!isPassiveSharedUserDataInstance()) {');
+    expect(body.indexOf('removeSafe(LEGACY_REFRESH_TOKEN_KEY);')).toBeGreaterThan(guardIdx);
+    expect(body.indexOf('removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);')).toBeGreaterThan(guardIdx);
+  });
+
   it('其余整机一份的账号派生状态:canary flag 与账号删除 receipt 都不被 passive 清掉', () => {
     const clearBody = sliceBody('function clearAuth(', 'clearPerAccountIntegrationsInBackground');
     // canary-flag.json 被清 → packaged primary 下次更新轮询按 stable 拉 manifest。
@@ -189,9 +202,14 @@ describe('passive shared-userData instance auth isolation', () => {
     );
     expect(helper).toContain("if (readSafe(key) !== expected) return 'changed';");
     expect(helper).toContain('const before = identity();');
-    expect(helper).toContain("if (before === null) return 'changed';");
-    expect(helper).toContain("if (identity() !== before) return 'changed';");
-    expect(helper.indexOf("if (identity() !== before) return 'changed';")).toBeLessThan(
+    // stat 失败要分开归类：ENOENT = 目标状态已达成（deleted），其它错误 = 不敢动（failed）。
+    // 都折叠成 'changed' 会让调用点打出「token changed meanwhile」这种不实日志。
+    expect(helper).toContain("if (before.kind === 'absent') return 'deleted';");
+    expect(helper).toContain("if (before.kind === 'error') return 'failed';");
+    expect(helper).toContain("if (after.kind === 'absent') return 'deleted';");
+    expect(helper).toContain("if (after.kind === 'error') return 'failed';");
+    expect(helper).toContain("if (after.id !== before.id) return 'changed';");
+    expect(helper.indexOf("if (after.id !== before.id) return 'changed';")).toBeLessThan(
       helper.indexOf('fs.unlinkSync(filepath);'),
     );
 

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -268,6 +268,34 @@ function createAuthClient(): CindyAuthClient {
   });
 }
 
+// ── passive 共享实例闸门 ────────────────────────────────────────────────────
+
+/**
+ * 共享 userData 的 passive dev 实例(`--preserve-running` / `--passive` 非 isolated)。
+ *
+ * 这类实例复用 primary 的登录态,但对共享状态保持只读——与 owner-namespace 迁移
+ * (ownerNamespaceMigration.ts)、localDb schema(localDb/index.ts)同一条契约。auth
+ * 侧的共享物有三个,passive 一个都不能改:
+ *   1. 磁盘 refresh token 文件(整机一份,删了 primary 下次续期就被踢);
+ *   2. 服务端 refresh token(按 (user, device) 一对一存,passive 与 primary 共用
+ *      同一 deviceId,调登出会把 primary 的那份一起作废);
+ *   3. 由前者派生的续期节奏(定时 refresh 会轮换共享 token,让 primary 反复走
+ *      replacement-retry)。
+ *
+ * 2026-07-27 事故:两个 MIGRATE_FAILED 的 passive 实例在 LocalDbGate fatal 界面点
+ * 「返回登录」,logout 删掉整机 refresh token,正在使用的 primary 在下一个 refresh
+ * 周期(隔了 19 / 46 分钟)被判定 credential-lost 强制重登。同源事故 2026-07-23 已
+ * 发生过一次,当时只把静默半死改成明确弹重登(见 authSessionExpiredDetection.test.ts),
+ * 没有堵住 passive 的写入权。
+ *
+ * packaged 恒不设置该 env(index.ts 启动时对 packaged / isolated 显式 delete 兜底,
+ * 防 ambient env 污染),线上零影响;`--isolated` 沙箱有独立 userData 与 deviceId,
+ * 本来就不共享,不受此闸门约束。
+ */
+function isPassiveSharedUserDataInstance(): boolean {
+  return !app.isPackaged && process.env.XDT_PASSIVE_SHARED_USER_DATA === '1';
+}
+
 // ── safeStorage helpers ─────────────────────────────────────────────────────
 
 const SAFE_STORAGE_DIR = () => path.join(app.getPath('userData'), 'safe-storage');
@@ -680,6 +708,14 @@ function scheduleRefresh(token: string): void {
     clearTimeout(refreshTimer);
     refreshTimer = null;
   }
+  if (isPassiveSharedUserDataInstance()) {
+    // passive 共享实例不主动续期:定时 refresh 会轮换整机共用的 refresh token,让
+    // primary 每轮都走 replacement-retry(2026-07-27 两边日志每 55 分钟互刷一次
+    // 「refresh token changed on disk」就是这么来的)。冷启动那一次 refresh 仍保留
+    // ——passive 需要它换取 access token;之后的续期节奏交给 primary。
+    log.info('passive shared-userData instance skips scheduled refresh (primary owns renewal)');
+    return;
+  }
   try {
     const payload = JSON.parse(
       Buffer.from(token.split('.')[1], 'base64').toString('utf-8'),
@@ -796,6 +832,13 @@ let coldStartAuthInFlight: Promise<AuthState> | null = null;
 function scheduleRefreshRetryAfterTransientFailure(): void {
   if (refreshTimer !== null) {
     clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+  if (isPassiveSharedUserDataInstance()) {
+    // 同 scheduleRefresh:passive 不接管续期,瞬时失败也不排重试,免得把整机共用的
+    // refresh token 又轮换一次。
+    log.info('passive shared-userData instance skips refresh retry (primary owns renewal)');
+    return;
   }
   refreshTimer = setTimeout(() => void refresh(), RUNTIME_REFRESH_RETRY_MS);
 }
@@ -1085,9 +1128,17 @@ function clearAuth(
     refreshTimer = null;
   }
   if (!opts.preservePersistedRefreshToken) {
-    removeSafe(REFRESH_TOKEN_KEY);
-    removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);
-    removeSafe(LEGACY_REFRESH_TOKEN_KEY);
+    if (isPassiveSharedUserDataInstance()) {
+      // passive 共享实例无权删整机凭证:它的登出只清本进程内存态,磁盘 token 留给
+      // primary(见 isPassiveSharedUserDataInstance 的事故记录)。
+      log.info(
+        'passive shared-userData instance keeps the persisted refresh token (local sign-out only)',
+      );
+    } else {
+      removeSafe(REFRESH_TOKEN_KEY);
+      removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);
+      removeSafe(LEGACY_REFRESH_TOKEN_KEY);
+    }
   }
   // 未登录时固定使用 stable；同步中的旧请求会被 authStateEpoch 守卫丢弃。
   canaryFlagStore.clear();
@@ -2355,7 +2406,10 @@ export async function logout(): Promise<void> {
   clearAccountDeletionReceipt();
   clearAuth();
 
-  if (currentAccessToken) {
+  // passive 共享实例跳过服务端登出:refresh token 按 (user, device) 一对一存,而它与
+  // primary 共用同一 deviceId——调这一发会把 primary 的那份一起作废,即使本地文件留着,
+  // primary 下次续期照样拿到确定性失败被踢。
+  if (currentAccessToken && !isPassiveSharedUserDataInstance()) {
     apiFetch('/api/auth/logout', {
       method: 'POST',
       body: { deviceId },

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -387,7 +387,15 @@ function removeSafe(key: string): void {
  * 范围内。当前收益是把窗口从数秒级压到一次 syscall,且真正高频的那条路径
  * (passive)已经完全不删。
  */
-function removeSafeIfUnchanged(key: string, expected: string): boolean {
+type RemoveIfUnchangedResult =
+  /** 确实删掉了(或删除时文件已不在,目标状态达成)。 */
+  | 'deleted'
+  /** 磁盘上的已经不是本次判定的那一枚,按约定不删。 */
+  | 'changed'
+  /** 删除真的失败了(权限 / IO):凭证还在盘上,调用方不得当成已清理。 */
+  | 'failed';
+
+function removeSafeIfUnchanged(key: string, expected: string): RemoveIfUnchangedResult {
   const filepath = path.join(SAFE_STORAGE_DIR(), `${key}.enc`);
   const identity = (): string | null => {
     try {
@@ -398,12 +406,22 @@ function removeSafeIfUnchanged(key: string, expected: string): boolean {
     }
   };
   const before = identity();
-  if (before === null) return false;
-  if (readSafe(key) !== expected) return false;
+  if (before === null) return 'changed';
+  if (readSafe(key) !== expected) return 'changed';
   // 读内容期间文件被换掉(另一个实例写入了替换凭证)→ 那枚不在本次判定范围内。
-  if (identity() !== before) return false;
-  removeSafe(key);
-  return true;
+  if (identity() !== before) return 'changed';
+  try {
+    // 不走 removeSafe():它吞掉所有 unlink 错误,会让调用方把「没删成」当成
+    // 「已清理」并据此打日志。这里必须如实区分。
+    fs.unlinkSync(filepath);
+    return 'deleted';
+  } catch (err) {
+    // 这一瞬别人已经删掉了 → 目标状态达成,算成功。
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return 'deleted';
+    // EPERM / EACCES / EBUSY 等:凭证仍在盘上。
+    log.warn(`failed to delete persisted secret ${key}: ${(err as Error).message}`);
+    return 'failed';
+  }
 }
 
 // ── PKCE (Node.js native crypto) ────────────────────────────────────────────
@@ -1784,16 +1802,27 @@ async function runColdStartRefreshFlow(storedToken: string): Promise<AuthState> 
           log.warn(
             'cold-start refresh: definitive credential failure — passive shared-userData instance starts logged out and keeps the persisted refresh token',
           );
-        } else if (removeSafeIfUnchanged(REFRESH_TOKEN_KEY, storedToken)) {
-          log.warn(
-            'cold-start refresh: definitive credential failure — clearing persisted refresh token',
-          );
         } else {
-          // 判定失败后磁盘 token 已被换掉(另一个实例写入了替换凭证):那枚不在本次
-          // 判定范围内,不能删。
-          log.warn(
-            'cold-start refresh: definitive credential failure, but the persisted refresh token changed meanwhile — keeping the replacement',
-          );
+          switch (removeSafeIfUnchanged(REFRESH_TOKEN_KEY, storedToken)) {
+            case 'deleted':
+              log.warn(
+                'cold-start refresh: definitive credential failure — cleared persisted refresh token',
+              );
+              break;
+            case 'changed':
+              // 判定失败后磁盘 token 已被换掉(另一个实例写入了替换凭证):那枚不在
+              // 本次判定范围内,不能删。
+              log.warn(
+                'cold-start refresh: definitive credential failure, but the persisted refresh token changed meanwhile — keeping the replacement',
+              );
+              break;
+            case 'failed':
+              // 删除真的失败了:凭证仍在盘上,下次启动会再判一次。不能报成已清理。
+              log.error(
+                'cold-start refresh: definitive credential failure, but deleting the persisted refresh token failed — it is still on disk',
+              );
+              break;
+          }
         }
       } else if (action.kind === 'replacement-retry') {
         log.warn(

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -296,6 +296,16 @@ function isPassiveSharedUserDataInstance(): boolean {
   return !app.isPackaged && process.env.XDT_PASSIVE_SHARED_USER_DATA === '1';
 }
 
+/**
+ * passive 实例「本进程已登出」的墓碑(进程内,不落盘)。
+ *
+ * passive 登出保留磁盘 token(那是 primary 的),于是登出后任何 initialize() ——
+ * 副窗 mount、右侧栏子窗口、renderer reload —— 都会读到仍在的 token 把本进程
+ * 冷启动登回去,还顺手轮换一次共享 token。有了墓碑,「只登出本进程」才是稳定的:
+ * 直到用户在本进程显式登录或重启进程为止。
+ */
+let passiveLocalSignOut = false;
+
 // ── safeStorage helpers ─────────────────────────────────────────────────────
 
 const SAFE_STORAGE_DIR = () => path.join(app.getPath('userData'), 'safe-storage');
@@ -1130,7 +1140,9 @@ function clearAuth(
   if (!opts.preservePersistedRefreshToken) {
     if (isPassiveSharedUserDataInstance()) {
       // passive 共享实例无权删整机凭证:它的登出只清本进程内存态,磁盘 token 留给
-      // primary(见 isPassiveSharedUserDataInstance 的事故记录)。
+      // primary(见 isPassiveSharedUserDataInstance 的事故记录)。同时立墓碑,否则
+      // 下一次 initialize() 会拿 primary 的 token 把本进程登回去。
+      passiveLocalSignOut = true;
       log.info(
         'passive shared-userData instance keeps the persisted refresh token (local sign-out only)',
       );
@@ -1141,7 +1153,12 @@ function clearAuth(
     }
   }
   // 未登录时固定使用 stable；同步中的旧请求会被 authStateEpoch 守卫丢弃。
-  canaryFlagStore.clear();
+  // canary-flag.json 同样是整机一份的账号派生状态:passive 清掉它,packaged primary
+  // 下次更新轮询就会把自己当 stable 用户,拉到错误的 manifest(见 manifestService
+  // fetchManifest)。passive 只登出本进程,不改这个共享文件。
+  if (!isPassiveSharedUserDataInstance()) {
+    canaryFlagStore.clear();
+  }
   // provider key(XD / Mivo)是绑定账号的本机密钥,**不在登出时清** —— 同账号重新登录 /
   // 会话过期重登需保留,避免每次都重填(本地 only 后服务器已无副本可拉回)。换账号导致的
   // 串号边界改由 login / 冷启动时 providerSecretStore.reconcileOwner 处理:owner 变了才清。
@@ -1445,6 +1462,15 @@ export async function getAccountDeletionStatus(): Promise<AccountDeletionStatus 
 }
 
 export function clearAccountDeletionReceipt(): void {
+  // 唯一调用方是 logout()。receipt 同样是整机一份:primary 发起账号删除挑战后,
+  // passive 一次本地登出就会删掉它,primary 随后 confirmAccountDeletion() 直接
+  // ACCOUNT_DELETION_RECEIPT_MISSING。passive 不碰。
+  // (账号删除确认成功后的清理走另外两处 removeSafe(ACCOUNT_DELETION_RECEIPT_KEY),
+  //  那是账号级终态,不受本闸门约束。)
+  if (isPassiveSharedUserDataInstance()) {
+    log.info('passive shared-userData instance keeps the account-deletion receipt');
+    return;
+  }
   removeSafe(ACCOUNT_DELETION_RECEIPT_KEY);
 }
 
@@ -1573,13 +1599,29 @@ export async function initialize(options: AuthInitializeOptions = {}): Promise<A
     return snapshotAuthState();
   }
 
+  // passive 实例在本进程登出过:磁盘上的 token 是 primary 的,不能拿它把自己登回去
+  // （副窗 mount / renderer reload 都会走到这里）。直到显式登录或进程重启为止。
+  if (passiveLocalSignOut) {
+    log.info('passive shared-userData instance stays signed out locally (tombstone)');
+    commitActiveAppSession('signed-out');
+    return snapshotLoggedOutAuthState();
+  }
+
   // release-relogin-on-update: if the auto-updater dropped a relogin marker
   // for *this* version, wipe persisted auth and force the user back to the
   // OAuth flow. The flag is one-shot: once consumed, subsequent launches
   // see no marker and no refresh_token, so the user stays logged out
   // naturally until they sign in (rather than getting kicked every launch).
+  //
+  // marker 是一次性的、整机一份:passive 若消费它,primary 就再也看不到这次
+  // requireRelogin 更新的标记,而 passive 顺带删掉的又正是 primary 的 token ——
+  // 本 PR 要防的失败被原样重现。passive 一律不碰 marker,交给 primary 处理。
   const reloginFlag = readReloginFlag();
-  if (reloginFlag && reloginFlag.version === app.getVersion()) {
+  if (
+    reloginFlag &&
+    reloginFlag.version === app.getVersion() &&
+    !isPassiveSharedUserDataInstance()
+  ) {
     log.info(
       'relogin marker hit for v%s — clearing persisted auth',
       reloginFlag.version,
@@ -1867,6 +1909,8 @@ async function completeLogin(
     removeSafe(ACCOUNT_DELETION_RECEIPT_KEY);
     accountDeletionRestoredNoticePending = deletionWasRestored;
     clearReloginFlag();
+    // 显式登录解除 passive 本地登出墓碑(见 passiveLocalSignOut)。
+    passiveLocalSignOut = false;
     currentUser = nextUser;
     commitActiveAppSession('cloud', currentUser.id);
   } finally {
@@ -2421,6 +2465,16 @@ export async function logout(): Promise<void> {
 /**
  * Called on system resume (powerMonitor 'resume' event).
  * If the app JWT is expired or expiring within 5 minutes, trigger a refresh.
+ *
+ * 唤醒续期对 passive 实例**有意不加闸门**（与 scheduleRefresh 的处理不同）。
+ *
+ * passive 让出的是「周期性主动轮换」——那是每 55 分钟一次、与 primary 规律对撞的
+ * 噪音源。但它不能连按需续期一起让出:access token 过期后,primary 的续期只更新
+ * 磁盘上的 refresh token,不会更新本进程内存里的 access token,而
+ * getAccountDeletionAvailability() / updateServerProfile() 这类直接走 apiFetch 的
+ * 路径拿不到 401 重试,会一直失败到进程重启。resume 是低频事件,让它作为按需自愈
+ * 入口，代价（一次轮换）由 primary 侧既有的 replacement-retry 消化——轮换本身不会
+ * 踢人，把 primary 踢下线的是删除凭证，那条已由 clearAuth 的闸门堵住。
  */
 export function handleResume(): void {
   if (accessToken === null) return;

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -367,6 +367,23 @@ function removeSafe(key: string): void {
   }
 }
 
+/**
+ * 只在磁盘内容仍等于 `expected` 时删除(compare-and-delete)。
+ *
+ * 共享 userData 下,「判定这枚 token 已失效」与「执行删除」之间存在窗口:另一个
+ * 实例可能刚好在这中间写入了有效的替换 token。无条件删就会把别人刚写的有效凭证
+ * 删掉——正是本 PR 要防的失败模式。冷启动路径尤其危险:它带 transient 重试与
+ * replacement recheck,从判定到删除可能隔了数秒。
+ *
+ * 读不出来(加密不可用 / IO 抖动 / 解密失败)时一律不删:宁可留一枚已失效的
+ * token(下次 refresh 自然会再判一次),也不能误删有效凭证。
+ */
+function removeSafeIfUnchanged(key: string, expected: string): boolean {
+  if (readSafe(key) !== expected) return false;
+  removeSafe(key);
+  return true;
+}
+
 // ── PKCE (Node.js native crypto) ────────────────────────────────────────────
 
 function generatePKCE(): { codeVerifier: string; codeChallenge: string } {
@@ -1461,16 +1478,19 @@ export async function getAccountDeletionStatus(): Promise<AccountDeletionStatus 
   return createAuthClient().getAccountDeletionStatus(receiptToken);
 }
 
+/**
+ * 显式清除账号删除 receipt。
+ *
+ * 注意这不只是 logout 的内部步骤:它经 `auth:account-deletion:clear-receipt`
+ * (bootstrap-electron.ts)暴露给 renderer,用户在登录页处理无效/已取消的挑战、
+ * 或 dismiss 已完成的删除状态时会直接调到。这类显式清理在 passive 实例上必须
+ * 照常生效 —— 否则 receipt 永远留在盘上,`snapshotAuthState()` 每次启动又把它
+ * 报出来,dismiss 不掉。
+ *
+ * 需要保护的只有「passive 登出顺带清掉 primary 的 receipt」那条隐式路径,闸门
+ * 因此加在 logout() 的调用点上,不在这里。
+ */
 export function clearAccountDeletionReceipt(): void {
-  // 唯一调用方是 logout()。receipt 同样是整机一份:primary 发起账号删除挑战后,
-  // passive 一次本地登出就会删掉它,primary 随后 confirmAccountDeletion() 直接
-  // ACCOUNT_DELETION_RECEIPT_MISSING。passive 不碰。
-  // (账号删除确认成功后的清理走另外两处 removeSafe(ACCOUNT_DELETION_RECEIPT_KEY),
-  //  那是账号级终态,不受本闸门约束。)
-  if (isPassiveSharedUserDataInstance()) {
-    log.info('passive shared-userData instance keeps the account-deletion receipt');
-    return;
-  }
   removeSafe(ACCOUNT_DELETION_RECEIPT_KEY);
 }
 
@@ -1724,11 +1744,25 @@ async function runColdStartRefreshFlow(storedToken: string): Promise<AuthState> 
       // 与运行时 refresh() 的清除条件保持一致(共用 authRefreshFailure)。
       const action: RefreshFailureAction = failureAction ?? { kind: 'transient-failure' };
       if (action.kind === 'definitive-failure') {
-        log.warn(
-          'cold-start refresh: definitive credential failure — clearing persisted refresh token',
-        );
         lastAcceptedRefreshToken = null;
-        removeSafe(REFRESH_TOKEN_KEY);
+        if (isPassiveSharedUserDataInstance()) {
+          // passive 只对本进程判定失效:磁盘 token 是整机共用的,而 passive 冷启动拿到
+          // INVALID_REFRESH_TOKEN 最常见的原因恰恰是 primary 刚轮换过它。删掉就是把
+          // primary 踢下线。
+          log.warn(
+            'cold-start refresh: definitive credential failure — passive shared-userData instance starts logged out and keeps the persisted refresh token',
+          );
+        } else if (removeSafeIfUnchanged(REFRESH_TOKEN_KEY, storedToken)) {
+          log.warn(
+            'cold-start refresh: definitive credential failure — clearing persisted refresh token',
+          );
+        } else {
+          // 判定失败后磁盘 token 已被换掉(另一个实例写入了替换凭证):那枚不在本次
+          // 判定范围内,不能删。
+          log.warn(
+            'cold-start refresh: definitive credential failure, but the persisted refresh token changed meanwhile — keeping the replacement',
+          );
+        }
       } else if (action.kind === 'replacement-retry') {
         log.warn(
           `cold-start refresh failed for a stale token after ${attempts} attempt(s) — keeping latest refresh token, starting logged out`,
@@ -2447,7 +2481,16 @@ export async function logout(): Promise<void> {
   }
   // Ordinary logout abandons an unconfirmed challenge. Confirmed deletion uses
   // clearLocalSessionAfterAccountDeletion() and intentionally preserves receipt.
-  clearAccountDeletionReceipt();
+  //
+  // receipt 也是整机一份:primary 发起账号删除挑战后,passive 一次本地登出就会删掉
+  // 它,primary 随后 confirmAccountDeletion() 直接 ACCOUNT_DELETION_RECEIPT_MISSING。
+  // 闸门只加在这条隐式路径上——renderer 主动调的显式清理仍照常生效(见
+  // clearAccountDeletionReceipt 的注释)。
+  if (isPassiveSharedUserDataInstance()) {
+    log.info('passive shared-userData instance keeps the account-deletion receipt on logout');
+  } else {
+    clearAccountDeletionReceipt();
+  }
   clearAuth();
 
   // passive 共享实例跳过服务端登出:refresh token 按 (user, device) 一对一存,而它与

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -377,9 +377,31 @@ function removeSafe(key: string): void {
  *
  * 读不出来(加密不可用 / IO 抖动 / 解密失败)时一律不删:宁可留一枚已失效的
  * token(下次 refresh 自然会再判一次),也不能误删有效凭证。
+ *
+ * 内容比对之外再校验一次文件身份(inode / mtime / size),把「读到的是旧值、删掉的
+ * 却是刚写入的新文件」这段 TOCTOU 收紧到两次 stat 之间。
+ *
+ * **这不是真正原子的 compare-and-delete**:POSIX 没有按路径的 CAS unlink,而本模块
+ * 的写入侧(writeSafe 直接 writeFileSync 覆盖)同样不原子。要彻底消除竞态,得把整个
+ * safeStorage 层改成「临时文件 + rename 写入 + 跨进程锁」,那是独立重构,不在本次
+ * 范围内。当前收益是把窗口从数秒级压到一次 syscall,且真正高频的那条路径
+ * (passive)已经完全不删。
  */
 function removeSafeIfUnchanged(key: string, expected: string): boolean {
+  const filepath = path.join(SAFE_STORAGE_DIR(), `${key}.enc`);
+  const identity = (): string | null => {
+    try {
+      const s = fs.statSync(filepath);
+      return `${s.ino}:${s.mtimeMs}:${s.size}`;
+    } catch {
+      return null;
+    }
+  };
+  const before = identity();
+  if (before === null) return false;
   if (readSafe(key) !== expected) return false;
+  // 读内容期间文件被换掉(另一个实例写入了替换凭证)→ 那枚不在本次判定范围内。
+  if (identity() !== before) return false;
   removeSafe(key);
   return true;
 }
@@ -1635,13 +1657,23 @@ export async function initialize(options: AuthInitializeOptions = {}): Promise<A
   //
   // marker 是一次性的、整机一份:passive 若消费它,primary 就再也看不到这次
   // requireRelogin 更新的标记,而 passive 顺带删掉的又正是 primary 的 token ——
-  // 本 PR 要防的失败被原样重现。passive 一律不碰 marker,交给 primary 处理。
+  // 本 PR 要防的失败被原样重现。
+  //
+  // 但「不消费」不等于「可以无视」:marker 命中说明这个版本要求重新登录,passive
+  // 跑的是同一个版本,拿旧 token 冷启动登录正是 marker 想避免的事。所以 passive
+  // 照样保持登出(复用 passiveLocalSignOut 墓碑,避免副窗 initialize() 又绕回来),
+  // 只是不动磁盘 token、不消费 marker —— 那两件事留给 primary。
   const reloginFlag = readReloginFlag();
-  if (
-    reloginFlag &&
-    reloginFlag.version === app.getVersion() &&
-    !isPassiveSharedUserDataInstance()
-  ) {
+  if (reloginFlag && reloginFlag.version === app.getVersion()) {
+    if (isPassiveSharedUserDataInstance()) {
+      log.info(
+        'relogin marker hit for v%s — passive shared-userData instance stays signed out, leaving the marker and token to the primary',
+        reloginFlag.version,
+      );
+      passiveLocalSignOut = true;
+      commitActiveAppSession('signed-out');
+      return snapshotLoggedOutAuthState();
+    }
     log.info(
       'relogin marker hit for v%s — clearing persisted auth',
       reloginFlag.version,

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -784,14 +784,13 @@ function scheduleRefresh(token: string): void {
     clearTimeout(refreshTimer);
     refreshTimer = null;
   }
-  if (isPassiveSharedUserDataInstance()) {
-    // passive 共享实例不主动续期:定时 refresh 会轮换整机共用的 refresh token,让
-    // primary 每轮都走 replacement-retry(2026-07-27 两边日志每 55 分钟互刷一次
-    // 「refresh token changed on disk」就是这么来的)。冷启动那一次 refresh 仍保留
-    // ——passive 需要它换取 access token;之后的续期节奏交给 primary。
-    log.info('passive shared-userData instance skips scheduled refresh (primary owns renewal)');
-    return;
-  }
+  // 续期节奏对 passive 实例不设闸门。本 PR 的契约是「passive 不写/不删共享的
+  // auth 持久状态」;「谁负责续期」是正交问题,不在这里解决。让 passive 停止续期
+  // 会让它的 access token 过期后再无替换途径(primary 的续期只更新磁盘 token,
+  // 不更新本进程内存态),而 updateServerProfile 等直接走 apiFetch 的路径没有
+  // 401 refresh/retry,会一直失败到进程重启——resume 也救不了,系统不休眠就不触发。
+  // 轮换本身不会踢人:2026-07-27 两个实例每 55 分钟互刷一次,primary 每次都靠
+  // replacement-retry 恢复,一次没掉线;把 primary 踢下线的是删除凭证。
   try {
     const payload = JSON.parse(
       Buffer.from(token.split('.')[1], 'base64').toString('utf-8'),
@@ -909,12 +908,6 @@ function scheduleRefreshRetryAfterTransientFailure(): void {
   if (refreshTimer !== null) {
     clearTimeout(refreshTimer);
     refreshTimer = null;
-  }
-  if (isPassiveSharedUserDataInstance()) {
-    // 同 scheduleRefresh:passive 不接管续期,瞬时失败也不排重试,免得把整机共用的
-    // refresh token 又轮换一次。
-    log.info('passive shared-userData instance skips refresh retry (primary owns renewal)');
-    return;
   }
   refreshTimer = setTimeout(() => void refresh(), RUNTIME_REFRESH_RETRY_MS);
 }
@@ -2585,16 +2578,6 @@ export async function logout(): Promise<void> {
 /**
  * Called on system resume (powerMonitor 'resume' event).
  * If the app JWT is expired or expiring within 5 minutes, trigger a refresh.
- *
- * 唤醒续期对 passive 实例**有意不加闸门**（与 scheduleRefresh 的处理不同）。
- *
- * passive 让出的是「周期性主动轮换」——那是每 55 分钟一次、与 primary 规律对撞的
- * 噪音源。但它不能连按需续期一起让出:access token 过期后,primary 的续期只更新
- * 磁盘上的 refresh token,不会更新本进程内存里的 access token,而
- * getAccountDeletionAvailability() / updateServerProfile() 这类直接走 apiFetch 的
- * 路径拿不到 401 重试,会一直失败到进程重启。resume 是低频事件,让它作为按需自愈
- * 入口，代价（一次轮换）由 primary 侧既有的 replacement-retry 消化——轮换本身不会
- * 踢人，把 primary 踢下线的是删除凭证，那条已由 clearAuth 的闸门堵住。
  */
 export function handleResume(): void {
   if (accessToken === null) return;

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -273,20 +273,25 @@ function createAuthClient(): CindyAuthClient {
 /**
  * 共享 userData 的 passive dev 实例(`--preserve-running` / `--passive` 非 isolated)。
  *
- * 这类实例复用 primary 的登录态,但对共享状态保持只读——与 owner-namespace 迁移
- * (ownerNamespaceMigration.ts)、localDb schema(localDb/index.ts)同一条契约。auth
- * 侧的共享物有三个,passive 一个都不能改:
+ * 这类实例复用 primary 的登录态,但**不得销毁整机共享的 auth 持久状态**——与
+ * owner-namespace 迁移(ownerNamespaceMigration.ts)、localDb schema
+ * (localDb/index.ts)同一条契约。受约束的是「删除 / 作废 / 消费」这类破坏性动作:
  *   1. 磁盘 refresh token 文件(整机一份,删了 primary 下次续期就被踢);
  *   2. 服务端 refresh token(按 (user, device) 一对一存,passive 与 primary 共用
  *      同一 deviceId,调登出会把 primary 的那份一起作废);
- *   3. 由前者派生的续期节奏(定时 refresh 会轮换共享 token,让 primary 反复走
- *      replacement-retry)。
+ *   3. relogin marker(一次性、整机一份,被 passive 消费掉 primary 就再也看不到);
+ *   4. canary flag 与账号删除 receipt(账号派生状态,删掉会让 primary 拉错 manifest
+ *      或丢掉进行中的删除挑战)。
+ *
+ * **续期不在约束内**:passive 照常排 refresh timer,轮换后正常 writeSafe 写回新
+ * token。轮换写入的是有效凭证,primary 侧由 replacement-retry 消化;停掉续期反而
+ * 会让 passive 的 access token 过期后无自愈路径(详见 scheduleRefresh 的注释)。
  *
  * 2026-07-27 事故:两个 MIGRATE_FAILED 的 passive 实例在 LocalDbGate fatal 界面点
  * 「返回登录」,logout 删掉整机 refresh token,正在使用的 primary 在下一个 refresh
  * 周期(隔了 19 / 46 分钟)被判定 credential-lost 强制重登。同源事故 2026-07-23 已
  * 发生过一次,当时只把静默半死改成明确弹重登(见 authSessionExpiredDetection.test.ts),
- * 没有堵住 passive 的写入权。
+ * 没有堵住 passive 的销毁权。
  *
  * packaged 恒不设置该 env(index.ts 启动时对 packaged / isolated 显式 delete 兜底,
  * 防 ambient env 污染),线上零影响;`--isolated` 沙箱有独立 userData 与 deviceId,

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -397,19 +397,28 @@ type RemoveIfUnchangedResult =
 
 function removeSafeIfUnchanged(key: string, expected: string): RemoveIfUnchangedResult {
   const filepath = path.join(SAFE_STORAGE_DIR(), `${key}.enc`);
-  const identity = (): string | null => {
+  // 三态:拿到身份 / 文件确定不在(ENOENT) / stat 本身失败。后两者必须分开——
+  // 「已经不在」是目标状态达成,「读不到状态」是我们不敢动它。
+  type Identity = { kind: 'ok'; id: string } | { kind: 'absent' } | { kind: 'error' };
+  const identity = (): Identity => {
     try {
       const s = fs.statSync(filepath);
-      return `${s.ino}:${s.mtimeMs}:${s.size}`;
-    } catch {
-      return null;
+      return { kind: 'ok', id: `${s.ino}:${s.mtimeMs}:${s.size}` };
+    } catch (err) {
+      return (err as NodeJS.ErrnoException)?.code === 'ENOENT'
+        ? { kind: 'absent' }
+        : { kind: 'error' };
     }
   };
   const before = identity();
-  if (before === null) return 'changed';
+  if (before.kind === 'absent') return 'deleted';
+  if (before.kind === 'error') return 'failed';
   if (readSafe(key) !== expected) return 'changed';
   // 读内容期间文件被换掉(另一个实例写入了替换凭证)→ 那枚不在本次判定范围内。
-  if (identity() !== before) return 'changed';
+  const after = identity();
+  if (after.kind === 'absent') return 'deleted';
+  if (after.kind === 'error') return 'failed';
+  if (after.id !== before.id) return 'changed';
   try {
     // 不走 removeSafe():它吞掉所有 unlink 错误,会让调用方把「没删成」当成
     // 「已清理」并据此打日志。这里必须如实区分。
@@ -1707,9 +1716,16 @@ export async function initialize(options: AuthInitializeOptions = {}): Promise<A
   }
 
   // Old Feishu-auth refresh tokens are intentionally not portable to auth-server.
-  removeSafe(LEGACY_REFRESH_TOKEN_KEY);
   // 早期测试版曾持久化 account refresh token；该会话现已收窄为登录期内存态。
-  removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);
+  //
+  // 这两个 legacy 文件同样是整机一份,而 dev + packaged 共库双开是受支持的场景
+  // (--preserve-running):老构建的 primary 可能还在消费它们,passive 只是启动一下
+  // 就把它们删掉,等于删了对方的活凭证。清理属于「搬家式迁移」,留给独占启动的
+  // 非 passive 实例做。
+  if (!isPassiveSharedUserDataInstance()) {
+    removeSafe(LEGACY_REFRESH_TOKEN_KEY);
+    removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);
+  }
   const storedToken = readSafe(REFRESH_TOKEN_KEY);
   if (!storedToken) {
     commitActiveAppSession('signed-out');

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -43,6 +43,13 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
   （dev 与 packaged 实例都登记——dev 与正式版共库双开受支持），发现其它存活实例
   共享同一 userData 时同样推迟——搬家式迁移必须独占 userData 才能执行，否则会打断
   还在运行的旧版本实例（2026-07-23 slack-hook.json／网关凭证被搬走事故）。
+  **auth 凭证同属这条只读契约**：passive 共享实例不删磁盘 refresh token、不调服务端
+  登出、不排定时续期，它的「退出登录」只清本进程内存态，磁盘与服务端凭证留给
+  primary（`authManager.ts` 的 `isPassiveSharedUserDataInstance`）。冷启动那一次
+  refresh 仍会发生——passive 需要它换取 access token，primary 侧由 replacement-retry
+  消化。代价是同机两个实例的登录态可能不一致，这是有意的：passive 无权代表整机登出
+  （2026-07-27 事故：MIGRATE_FAILED 的 passive 实例在 fatal 界面点「返回登录」，删掉
+  整机 refresh token，primary 在 19／46 分钟后的续期周期被强制重登）。
 - `--preserve-running`：并行 dev，不停止任何已有 Cindy dev 进程，每个新实例强制 passive
   并共享当前 userData／登录态；仅供能证明实例归属的上层编排，或用户明确「不要关当前
   实例／不要重新登录」时用。仅支持 remote，禁止与 `--isolated` 组合。

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -43,17 +43,18 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
   （dev 与 packaged 实例都登记——dev 与正式版共库双开受支持），发现其它存活实例
   共享同一 userData 时同样推迟——搬家式迁移必须独占 userData 才能执行，否则会打断
   还在运行的旧版本实例（2026-07-23 slack-hook.json／网关凭证被搬走事故）。
-  **auth 凭证同属这条只读契约**：passive 共享实例不得写或删整机共享的 auth 持久状态
-  ——磁盘 refresh token、服务端 device token（调登出会连坐作废 primary 的那份）、
-  relogin marker、canary flag、账号删除 receipt。它的「退出登录」只清本进程内存态
-  （`authManager.ts` 的 `isPassiveSharedUserDataInstance`）。代价是同机两个实例的登录
-  态可能不一致，这是有意的：passive 无权代表整机登出（2026-07-27 事故：MIGRATE_FAILED
-  的 passive 实例在 fatal 界面点「返回登录」，删掉整机 refresh token，primary 在
-  19／46 分钟后的续期周期被强制重登）。
-  **「谁负责续期」不在这条契约内**：passive 照常排续期 timer。让它停止续期会使自己的
-  access token 过期后再无替换途径（primary 的续期只更新磁盘 token，不更新 passive 进程
-  的内存态，而直接走 `apiFetch` 的路径没有 401 refresh/retry），而 token 轮换本身不会
-  踢人——primary 侧的 replacement-retry 会消化它。
+  **auth 凭证同属这条契约**：passive 共享实例不得**删除、作废或消费**整机共享的 auth
+  持久状态——磁盘 refresh token、服务端 device token（调登出会连坐作废 primary 的
+  那份）、relogin marker（一次性，被消费掉 primary 就再也看不到）、canary flag、账号
+  删除 receipt。它的「退出登录」只清本进程内存态（`authManager.ts` 的
+  `isPassiveSharedUserDataInstance`）。代价是同机两个实例的登录态可能不一致，这是有意
+  的：passive 无权代表整机登出（2026-07-27 事故：MIGRATE_FAILED 的 passive 实例在
+  fatal 界面点「返回登录」，删掉整机 refresh token，primary 在 19／46 分钟后的续期周期
+  被强制重登）。
+  约束的是破坏性动作，**不是写入本身**：passive 照常排续期 timer，轮换后正常写回新的
+  refresh token——那写入的是有效凭证，primary 侧由 replacement-retry 消化。反过来让
+  passive 停止续期，会使它的 access token 过期后再无替换途径（primary 的续期只更新磁盘
+  token，不更新 passive 进程的内存态，而直接走 `apiFetch` 的路径没有 401 refresh/retry）。
 - `--preserve-running`：并行 dev，不停止任何已有 Cindy dev 进程，每个新实例强制 passive
   并共享当前 userData／登录态；仅供能证明实例归属的上层编排，或用户明确「不要关当前
   实例／不要重新登录」时用。仅支持 remote，禁止与 `--isolated` 组合。

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -43,13 +43,17 @@ Desktop 连接的是你自己的 Cindy 云端账号（remote）。这与登录�
   （dev 与 packaged 实例都登记——dev 与正式版共库双开受支持），发现其它存活实例
   共享同一 userData 时同样推迟——搬家式迁移必须独占 userData 才能执行，否则会打断
   还在运行的旧版本实例（2026-07-23 slack-hook.json／网关凭证被搬走事故）。
-  **auth 凭证同属这条只读契约**：passive 共享实例不删磁盘 refresh token、不调服务端
-  登出、不排定时续期，它的「退出登录」只清本进程内存态，磁盘与服务端凭证留给
-  primary（`authManager.ts` 的 `isPassiveSharedUserDataInstance`）。冷启动那一次
-  refresh 仍会发生——passive 需要它换取 access token，primary 侧由 replacement-retry
-  消化。代价是同机两个实例的登录态可能不一致，这是有意的：passive 无权代表整机登出
-  （2026-07-27 事故：MIGRATE_FAILED 的 passive 实例在 fatal 界面点「返回登录」，删掉
-  整机 refresh token，primary 在 19／46 分钟后的续期周期被强制重登）。
+  **auth 凭证同属这条只读契约**：passive 共享实例不得写或删整机共享的 auth 持久状态
+  ——磁盘 refresh token、服务端 device token（调登出会连坐作废 primary 的那份）、
+  relogin marker、canary flag、账号删除 receipt。它的「退出登录」只清本进程内存态
+  （`authManager.ts` 的 `isPassiveSharedUserDataInstance`）。代价是同机两个实例的登录
+  态可能不一致，这是有意的：passive 无权代表整机登出（2026-07-27 事故：MIGRATE_FAILED
+  的 passive 实例在 fatal 界面点「返回登录」，删掉整机 refresh token，primary 在
+  19／46 分钟后的续期周期被强制重登）。
+  **「谁负责续期」不在这条契约内**：passive 照常排续期 timer。让它停止续期会使自己的
+  access token 过期后再无替换途径（primary 的续期只更新磁盘 token，不更新 passive 进程
+  的内存态，而直接走 `apiFetch` 的路径没有 401 refresh/retry），而 token 轮换本身不会
+  踢人——primary 侧的 replacement-retry 会消化它。
 - `--preserve-running`：并行 dev，不停止任何已有 Cindy dev 进程，每个新实例强制 passive
   并共享当前 userData／登录态；仅供能证明实例归属的上层编排，或用户明确「不要关当前
   实例／不要重新登录」时用。仅支持 remote，禁止与 `--isolated` 组合。


### PR DESCRIPTION
## 这次改了什么

### 摘要

共享 userData 的 passive dev 实例（`--preserve-running` / `--passive` 非 isolated）登出时，会删掉整机共用的 `<userData>/safe-storage/cindy_auth_refresh_token.enc`。正在使用的 primary 实例读不到凭证，在下一个 refresh 周期（最长 55 分钟后）按 `credential-lost` 强制重登——用户视角就是「什么都没做，突然让我重新登录」。

2026-07-27 当天复现两次：

| 时间 | 事件 |
|---|---|
| 05:30:04 | passive 实例 A（`MIGRATE_FAILED`）在 `LocalDbGate` fatal 界面点「返回登录」→ 删掉凭证 |
| 05:49:12 | primary 到 refresh 周期，`persisted refresh token missing` → 强制重登（隔 19 分钟） |
| 07:51:35 | passive 实例 B 同样操作 → 再次删掉凭证 |
| 08:37:31 | primary 再次被踢（隔 46 分钟） |

删除与掉线之间隔了 19／46 分钟，且删凭证的实例早已退出，所以现场看起来「当时没有别的实例在」，很难自查。每次掉线还会连带中止在跑的 scheduler run（PR 心跳）、IM 连接、embedding worker 与 device-link 持有权。

同源事故 2026-07-23 已发生过一次（见 `authSessionExpiredDetection.test.ts` 的注释），当时的修复是把「静默半死」改成「明确弹重登」——报警是对的，但没有堵住 passive 的写入权。

仓库其实已经确立了「共享 userData 的 passive 实例对共享状态保持只读」这条契约，并落地在两处：owner-namespace 迁移（`ownerNamespaceMigration.ts`）和 localDb schema（`localDb/index.ts`，reader lease + 拒绝迁移）。**auth 凭证是这条契约漏掉的一块**，本 PR 把它补上。

新增 `isPassiveSharedUserDataInstance()`，复用启动期已落地的 `XDT_PASSIVE_SHARED_USER_DATA`（`index.ts` 按 `shouldEnforcePassiveMigrationCompatibility` 设置，packaged 与 isolated 显式 `delete` 兜底），不新增判定通道。三处闸门：

- `clearAuth()`：不删磁盘 refresh token —— passive 的登出只清本进程内存态；
- `logout()`：不调服务端 `/api/auth/logout` —— refresh token 按 `(user, device)` 一对一存，passive 与 primary 共用同一 deviceId，只留本地文件不够，这一发也会连坐作废 primary 的那份；
- ~~`scheduleRefresh()` 与瞬时失败重试：不排 timer~~ —— **已在 `633d94ff` 撤回**，见下方说明。

review 后补齐了同一契约的另外四个出口（`e2b6984a`）——首版只堵住了 refresh token 文件：

- `initialize()` 的 relogin marker 分支仍会 `removeSafe(REFRESH_TOKEN_KEY)`，并消费整机一份的一次性 marker。passive 撞上带 `requireRelogin` 的更新时会原样重现本 PR 要防的失败，且 primary 永远看不到那次标记；
- `clearAuth()` 保留磁盘 token 后没有记录「本进程已登出」，任何副窗 mount / renderer reload 走 `initialize()` 都会拿 primary 的 token 把本进程登回去，顺带轮换一次共享 token——承诺的进程内登出并不稳定。新增进程内墓碑 `passiveLocalSignOut`（不落盘，显式登录时解除）；
- `clearAuth()` 继续无条件 `canaryFlagStore.clear()`，删掉整机一份的 `canary-flag.json`，packaged primary 下次更新轮询会按 stable 拉错 manifest；
- `logout()` 无条件 `clearAccountDeletionReceipt()`，删掉整机一份的 receipt，primary 随后 `confirmAccountDeletion()` 直接 `RECEIPT_MISSING`。

第三轮（`051b6472`）再收两条：把 receipt 闸门从 `clearAccountDeletionReceipt()` 函数体收窄到 `logout()` 调用点——它还经 `auth:account-deletion:clear-receipt` 暴露给 renderer，整体禁用会让用户永远 dismiss 不掉已完成的删除状态；以及给冷启动 `definitive-failure` 的 token 删除加上 passive 闸门与 **compare-and-delete**（新增 `removeSafeIfUnchanged()`，只在磁盘内容仍是本次判定那枚时才删，读不出来时不删）——判定与删除之间另一个实例可能已写入替换凭证。

第四轮（`bdd263df`）：passive 命中 relogin marker 时**也保持登出**——上一轮让它直接跳过整段逻辑，等于把「这个版本要求重新登录」的语义一起无视了（passive 跑的是同一个版本，却继续拿旧 token 登进去）；现在复用墓碑保持登出，只是仍不动磁盘 token、不消费 marker。同时给 `removeSafeIfUnchanged()` 加文件身份校验（`inode:mtimeMs:size`），把内容比对与 unlink 之间的 TOCTOU 收紧到两次 stat 之间——**这不是真正原子的 CAS**：写入侧（`writeSafe` 直接覆盖）本身也不原子，彻底消除需要把整个 safeStorage 层改成「临时文件 + rename 写入 + 跨进程锁」，属独立重构，已在函数注释里标注剩余窗口。

第五轮（`b9bc4d33`）：`removeSafeIfUnchanged()` 原先复用 `removeSafe()`，而后者吞掉所有 unlink 错误——EPERM / EACCES / EBUSY 时凭证仍在盘上，调用点却打出「已清理」。返回值改为三态（`deleted` / `changed` / `failed`），函数内直接 `unlinkSync`（`ENOENT` 映射为 `deleted`），冷启动调用点按三态如实记日志，`failed` 走 `log.error`。

第六轮（`bd255fd4`）：`initialize()` 对两个 legacy 凭证文件的清理仍是无条件的——dev + packaged 共库双开（`--preserve-running`）是受支持的场景，老构建的 primary 可能还在消费它们，passive 只是启动一下就删了对方的活凭证；清理属于搬家式迁移，收进非 passive 分支。同时 `removeSafeIfUnchanged()` 把所有 `statSync` 失败折叠成 `changed`，导致「文件已不在」与「权限/IO 故障」都打出不实日志，`identity()` 改为三态 `ok` / `absent` / `error`。

刻意保留两处：冷启动那一次 refresh（passive 需要它换取 access token，primary 侧由既有 replacement-retry + 磁盘 token 身份核对消化），以及 `credential-lost` 的过期出口（只影响本进程、已带 `preservePersistedRefreshToken: true` 不删盘，不退回 2026-07-23 那种静默半死）。

**续期节奏不在本契约内（`633d94ff` 撤回了原先的闸门）。** 首版让 passive 停止续期，先后被两个 reviewer 从相反方向质疑，最终确认这条闸门是错的：它依赖 `handleResume()` 作为按需自愈入口，而 resume 依赖系统休眠这个偶然事件——passive 一直开着不休眠就永远不触发，此时 access token 过期后再无替换途径（primary 的续期只更新磁盘 token，不更新 passive 进程内存态），`updateServerProfile` 等直接走 `apiFetch` 的路径没有 401 refresh/retry，会一直失败到进程重启。

更关键的是它与本次事故的根因无关：把 primary 踢下线的是删除凭证，不是 token 轮换（当天两实例每 55 分钟互刷一次，primary 每次都靠既有 replacement-retry 恢复，一次没掉线）。「谁负责续期」是需要独立设计的正交问题（真要解决应在 `apiFetch` 层补按需 refresh），不塞进本 PR。现在 passive 照常续期，契约收敛为单一句话：**不得删除、作废或消费整机共享的 auth 持久状态**（`fd080598` 把措辞从「不写」改正为此——passive 续期本来就会写回轮换后的新 token，受约束的一直是破坏性动作）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（本机事故排查）
- 本 PR 包含：`authManager.ts` 五处 passive 闸门（refresh token 文件、服务端登出、relogin marker、canary flag、账号删除 receipt）与配套的登出墓碑 / CAS 删除、源码守卫测试、`docs/dev-rules/desktop-development.md` 的 `--passive` 契约补充
- 明确不包含（其一）：**passive 上显式登录仍会写共享 refresh token**。这是基线既有行为（`42b61e4c` 的 `completeLogin()` 同一处），非本 PR 引入；但本 PR 建立契约后它成了剩余缺口——若 primary 登着账号 A、用户在 passive 上登账号 B，primary 下次 refresh 会接受替换并切到 B。没有在本 PR 内处理，是因为两种候选方案都需要先定语义：「阻止 passive 登录」会伤害 primary 未登录时的合理场景（此时 passive 是唯一实例，写共享凭证正是期望行为），而区分两种场景需要知道另一活实例登的是哪个账号——`.dev-instances` 没有这个信息，加进去等于把登录态写进另一份共享文件；「登录不落盘」则要给 passive 造一套独立的进程内凭证生命周期（登录写内存、冷启动仍读磁盘复用 primary 登录态、轮换后也不落盘），并连带处理 `clearReloginFlag()` 与 receipt。本 PR 已修的这几处都是「用户没要求、实例自己顺手做掉」的隐式副作用，删除它们不改变任何人的意图；登录是用户主动发起的动作，改变其落点等于重新定义「在 passive 上登录意味着什么」，属设计题，留待 follow-up。
- 明确不包含（其二）：passive 实例把 mode 切换写进共享 `app-session.json`（07:51:38 那个实例确实把 `activeMode` 改成了 `local`，属同一 bug 家族，牵动 `commitActiveAppSession` 多个调用点，单独处理）
- 用户可见变化：仅 dev。passive 实例上点「退出登录」只登出该实例，不再影响 primary；同机两个实例的登录态可能不一致，这是有意的——passive 无权代表整机登出
- 是否存在 breaking change：无。packaged 恒不设置该 env，线上零影响；`--isolated` 沙箱有独立 userData 与 deviceId，不受此闸门约束

### UI 变化

不涉及。

- 引用的设计规范：不涉及（改动只在 main 进程 auth 逻辑与开发规则文档，无视觉／交互／文案变化）

## 怎么验证的

### 自动验证

```text
pnpm test:unit（仓库根全量，经 run-unit-gate.sh 清污染变量）
结果：GATE_EXIT=0（六轮改动各跑一次；第三轮曾出现一次 flake——
      file-browser/deviceOp.test.ts 的 vi.waitFor 3s 超时 3010ms，与并行 typecheck
      抢 CPU 所致，单独重跑 35 项全过 1865ms；第四轮不并行跑 typecheck，该文件正常通过）。

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm --filter desktop exec vitest run \
  src/main/__tests__/authPassiveSharedInstance.test.ts \
  src/main/__tests__/authSessionExpiredDetection.test.ts \
  src/main/__tests__/authAccountDeletionLifecycle.test.ts \
  src/main/__tests__/authStartupGate.test.ts \
  src/main/__tests__/authRefreshFailure.test.ts
结果：5 files / 63 tests passed
      —— 新守卫 13 项，既有 auth 回归守卫 50 项未被打破
```

### 手工验证

平台 macOS 26.0 / darwin-arm64，remote 模式，共享 userData 与线上账号。

在本功能 worktree 起 passive 实例（`pnpm restart:desktop:remote -- --preserve-running`），与 primary（`cindy-personal-client`，pid 942）共享同一 userData：

1. **`XDT_PASSIVE_SHARED_USER_DATA` 判定在真实进程里生效**：passive 侧曾打出 `09:12:31 [INFO] [authManager] passive shared-userData instance skips scheduled refresh`（当时续期闸门尚未撤回）。该日志行已随 `633d94ff` 移除，但它证明了判定函数在真实 passive 进程中返回 `true`——现存五处闸门共用同一判定。
2. **冷启动 refresh 按设计保留**：passive 侧 `canary feature flag synced`，凭证文件被正常改写（设计内行为）。
3. **primary 未受影响**：09:10–09:29 primary 日志无 auth 异常、无 `session-expired`、无 `logout`，`.dev-instances` 记录仍为 `state: ready`。

### 未执行的验证

**`clearAuth` / `logout` 两处闸门的端到端手工验证未执行**：需要在 passive 实例窗口上真实点击「退出登录」，再断言凭证文件 mtime／hash 不变且 primary 不被踢。两个 Cindy 窗口位置几乎完全重叠（同名同坐标，仅宽度不同），误点会把 primary 真的登出，因此没有由 agent 代为操作，留给作者本机确认。

当前这两处的证据是：源码守卫测试锁定分支结构 + 上述第 1 条实证（同一判定函数在真实 passive 进程中返回 `true`）。补做端到端后会在 PR 里更新结论。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 dev 且仅共享 userData 的 passive 实例。判定含 `!app.isPackaged` 双保险，packaged 构建不受任何影响；`--isolated` 沙箱不共享 userData 与 deviceId，同样不受影响。非 passive 实例（含正式版、primary dev）的登出行为完全不变，仍会删除凭证并调服务端登出。
- 凭证侧的取舍：passive 登出后本地加密凭证与服务端 device token 都保留。这不构成凭证残留风险——账号若真的失效（删除／禁用／服务端作废），primary 一次 refresh 就会拿到确定性失败并按既有路径清理。
- 回滚 / 降级方式：六个 commit，`git revert` 即可完全回到旧行为，无数据结构或持久化格式变更（新增的 `passiveLocalSignOut` 是进程内变量，不落盘）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）——`pnpm check:dco` 通过
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已说明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`docs/dev-rules/desktop-development.md` 的 `--passive` 契约）
- [x] 已确认测试结果或说明未执行原因


