### PR TITLE
fix(maker-core): 恢复 Codex steer Turn ID 失配后的普通派发

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4822,16 +4822,17 @@ describe('CodexAgent steer', () => {
 
   it('normalizes a server-side active-turn-id mismatch for the normal-send fallback', async () => {
     const agent = new CodexAgent(createDeps());
+    const serverError = Object.assign(
+      new Error(
+        'codex app-server turn/steer error -32600: expected active turn id '
+        + '`019fa22b-2461-7842-b852-082c0f82676a` but found '
+        + '`dda88981-5aca-4b99-90c7-68488deaccc8`',
+      ),
+      { code: -32600 },
+    );
     const host = installFakeHost(agent, (method) => {
       if (method === Method.TurnSteer) {
-        throw Object.assign(
-          new Error(
-            'codex app-server turn/steer error -32600: expected active turn id '
-            + '`019fa22b-2461-7842-b852-082c0f82676a` but found '
-            + '`dda88981-5aca-4b99-90c7-68488deaccc8`',
-          ),
-          { code: -32600 },
-        );
+        throw serverError;
       }
       return undefined;
     });
@@ -4850,9 +4851,11 @@ describe('CodexAgent steer', () => {
       turn: { id: '019fa22b-2461-7842-b852-082c0f82676a' },
     });
 
-    await expect(handle.steer({ type: 'user', content: 'steer message' })).rejects.toThrow(
-      /No active Codex turn to steer/,
-    );
+    await expect(handle.steer({ type: 'user', content: 'steer message' })).rejects.toMatchObject({
+      message: 'No active Codex turn to steer',
+      cause: serverError,
+    });
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnSteer)).toHaveLength(1);
     expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(0);
     await handle.close();
   });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4820,6 +4820,43 @@ describe('CodexAgent steer', () => {
     await handle.close();
   });
 
+  it('normalizes a server-side active-turn-id mismatch for the normal-send fallback', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnSteer) {
+        throw Object.assign(
+          new Error(
+            'codex app-server turn/steer error -32600: expected active turn id '
+            + '`019fa22b-2461-7842-b852-082c0f82676a` but found '
+            + '`dda88981-5aca-4b99-90c7-68488deaccc8`',
+          ),
+          { code: -32600 },
+        );
+      }
+      return undefined;
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-steer-server-active-turn-mismatch',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      userPrompt: 'USER PROMPT',
+    });
+    const handlers = host.getThreadHandlers();
+    expect(handlers).not.toBeNull();
+    if (!handlers) throw new Error('expected thread handlers');
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: '019fa22b-2461-7842-b852-082c0f82676a' },
+    });
+
+    await expect(handle.steer({ type: 'user', content: 'steer message' })).rejects.toThrow(
+      /No active Codex turn to steer/,
+    );
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(0);
+    await handle.close();
+  });
+
   it('resolves as delivered when the turn ends before the steer acknowledgement arrives', async () => {
     // review #939 第二轮 P1: ack 与 turn 终态乱序——server 已确认接受注入,消息
     // 已进 rollout,必须按**已投递**成功返回;抛 NO_ACTIVE_TURN 会让 coordinator

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -607,6 +607,11 @@ function parseLeadingSlashToken(text: string): { name: string; rest: string } | 
   return { name: match[1], rest: match[2] ?? '' };
 }
 
+function isExpectedTurnIdMismatchError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /expected active turn id\b.*\bbut found\b/i.test(message);
+}
+
 // 插话 (steer) 时 turn/steer RPC 的 ack 有界等待上限。AppServerClient.request
 // 本身没有超时, app-server 卡死时裸 await 会永久挂起 → coordinator steering marker
 // 永久残留 → 后续插话点击被静默吞掉。正常情况下 ack 是毫秒级, 10s 足够宽裕。
@@ -4265,9 +4270,10 @@ export class CodexAgent extends BaseAgent {
         // 没有被打断,它们仍然有效。
         // (历史:2026-06 曾以「模型继续旧工具计划」为由改成 interrupt+follow-up,
         // 那正是注入语义的预期行为,现按统一产品决策回归注入。)
-        // expectedTurnId 是 stale-client 防线:server 端 turn 已结束时报
-        // "no active turn to steer" 而不是伪装成功,coordinator 按 NO_ACTIVE_TURN
-        // fallback 成普通派发,消息不丢。
+        // expectedTurnId 是 stale-client 防线:server 端 turn 已结束时会报
+        // "no active turn to steer",或在当前已有另一 turn 时报告 expected/found
+        // id 不匹配。后者同样是明确的 pre-accept 拒绝,需归一化为 no-active-turn,
+        // 让 coordinator fallback 成普通派发,消息不丢。
         log.debug('steer ▶ inject into active turn', {
           threadId,
           turnId: steeredTurnId,
@@ -4332,6 +4338,14 @@ export class CodexAgent extends BaseAgent {
             );
           });
           ackSettled = true;
+        } catch (error) {
+          if (isExpectedTurnIdMismatchError(error)) {
+            // app-server 已明确拒绝该 stale expectedTurnId,消息没有注入其它 turn。
+            // 标记 RPC 已 settle,避免把这类确定性拒绝误当成 timeout/abort 在飞请求。
+            ackSettled = true;
+            throw new Error('No active Codex turn to steer');
+          }
+          throw error;
         } finally {
           if (!ackSettled) {
             // 超时 / abort 后请求仍在飞:迟到成功说明消息已注入但上层已按失败

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -608,8 +608,12 @@ function parseLeadingSlashToken(text: string): { name: string; rest: string } | 
 }
 
 function isExpectedTurnIdMismatchError(error: unknown): boolean {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? (error as { code?: unknown }).code
+      : undefined;
   const message = error instanceof Error ? error.message : String(error);
-  return /expected active turn id\b.*\bbut found\b/i.test(message);
+  return code === -32600 && /expected active turn id\b[\s\S]*\bbut found\b/i.test(message);
 }
 
 // 插话 (steer) 时 turn/steer RPC 的 ack 有界等待上限。AppServerClient.request
@@ -4343,7 +4347,7 @@ export class CodexAgent extends BaseAgent {
             // app-server 已明确拒绝该 stale expectedTurnId,消息没有注入其它 turn。
             // 标记 RPC 已 settle,避免把这类确定性拒绝误当成 timeout/abort 在飞请求。
             ackSettled = true;
-            throw new Error('No active Codex turn to steer');
+            throw new Error('No active Codex turn to steer', { cause: error });
           }
           throw error;
         } finally {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex app-server 在客户端的 `expectedTurnId` 已过期、服务端已有另一 active turn 时，会返回 `-32600: expected active turn id ... but found ...`。此前该错误没有归一化为 `NO_ACTIVE_TURN`，Desktop main 会把它显示为 `INTERNAL`，插话队列也无法按既有普通派发兜底恢复。

本 PR 仅调整 Codex steer 的确定性拒绝路径：

- 识别 expected/found active turn ID mismatch；
- 归一化为既有 `No active Codex turn to steer`，让 main 映射到 `NO_ACTIVE_TURN`，再由 coordinator 按普通 turn 派发；
- 将 RPC 标记为已 settle，避免误套 timeout/abort 的“投递结果不确定”处理；
- 补充使用现场原始错误形态的回归测试。

### 变更类型

- [ ] `feat` 新能力
- [x] `fix` 缺陷修复
- [ ] `refactor` 重构（行为不变）
- [ ] `perf` 性能优化
- [ ] `test` 测试
- [ ] `docs` 文档
- [ ] `build` / `chore` 工程或维护

### 范围

- 关联 Issue / 需求：现场复现；提交前已检索官方公开 Issue/PR，未发现同类修复
- 本 PR 包含：maker-core Codex steer 错误归一化与回归测试
- 明确不包含：队列状态机、renderer、Codex app-server 协议变更
- 用户可见变化：状态竞态导致 Turn ID 失配时，输入不再报 `INTERNAL`，而会按普通新 turn 继续派发
- breaking change：无

### UI 变化

- 引用的设计规范：不涉及 UI

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts
结果：1 file passed，186 tests passed

GIT_CONFIG_GLOBAL=/dev/null pnpm test:unit
结果：全部必需 unit workspaces 通过；脚本测试 297 passed / 0 failed / 1 skipped

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：命令成功；该包未定义 typecheck script

GIT_CONFIG_GLOBAL=/dev/null pnpm check:dco
结果：1 commit signed off
```

### 手工验证

- 未启动 Desktop 做交互复现；现场错误形态已由 fake app-server 回归测试精确覆盖。

### 未执行的验证

- 额外尝试 `pnpm --filter @cindy/maker-core build`，被 upstream 未修改的 Claude 测试类型错误阻断：`mcp-approval-policy.test.ts` 第 406、423 行 `TS2722`。本 PR 要求的全量单测与 DCO 门禁均已通过。

## 风险与影响

- 影响范围：仅 Codex `turn/steer` RPC 被服务端以 expected/found Turn ID mismatch 明确拒绝的错误路径
- 核心指标评估：不修改 system prompt、tools/MCP、translator、事件循环热路径、模型或 usage；happy path 的缓存命中、响应速度、内容准确率和 token 使用不变
- 回滚方式：回滚本 PR 单一提交

## Checklist

- [x] 变更保持最小范围，没有顺手重构
- [x] 已补充对应回归测试
- [x] 已运行仓库要求的单元测试
- [x] Commit 已包含 DCO Signed-off-by
- [x] 已检查不存在重复 Issue/PR
