### PR TITLE
fix(mobile): 手机端项目分组折叠 worktree 到主仓

### DIFF
--- a/apps/desktop/src/shared/managedWorktreePaths.ts
+++ b/apps/desktop/src/shared/managedWorktreePaths.ts
@@ -1,37 +1,22 @@
-/** Cindy 新建托管 worktree 使用的目录名。 */
-export const MANAGED_WORKTREE_DIR_NAME = '.cindy-worktrees';
+/**
+ * Cindy 托管 worktree 的目录名与 base repo 解析。
+ *
+ * 事实源在 `@cindy/maker-shared/worktree-paths` —— 手机端的项目分组要用同一套折叠口径,
+ * 词表分叉会让两端对「这是哪个项目」给出不同答案。本文件只保留桌面侧的历史导出名。
+ */
+import { managedWorktreeBaseRepo } from '@cindy/maker-shared/worktree-paths';
 
-/** 品牌迁移前使用的目录名；只用于识别和恢复既有 worktree。 */
-export const LEGACY_MANAGED_WORKTREE_DIR_NAME = '.xdt-worktrees';
-
-/** 所有受 Cindy 生命周期管理的 worktree 目录名，新目录必须排在第一位。 */
-export const MANAGED_WORKTREE_DIR_NAMES = [
-  MANAGED_WORKTREE_DIR_NAME,
+export {
+  isManagedWorktreeDirectoryName,
   LEGACY_MANAGED_WORKTREE_DIR_NAME,
-] as const;
-
-/** 判断一个目录 basename 是否属于 Cindy 托管的 worktree 根目录。 */
-export function isManagedWorktreeDirectoryName(name: string): boolean {
-  return MANAGED_WORKTREE_DIR_NAMES.some((candidate) => candidate === name);
-}
+  MANAGED_WORKTREE_DIR_NAME,
+  MANAGED_WORKTREE_DIR_NAMES,
+} from '@cindy/maker-shared/worktree-paths';
 
 /**
  * 从已经过 storage normalization 的路径中解析 Cindy 托管 worktree 的 base repo。
  * 找不到完整的 `<root>/<managed-dir>/<name>` 形态时返回 null。
  */
 export function getManagedWorktreeBasePath(normalizedPath: string): string | null {
-  for (const directoryName of MANAGED_WORKTREE_DIR_NAMES) {
-    const marker = `/${directoryName}/`;
-    const markerIndex = normalizedPath.indexOf(marker);
-    if (markerIndex < 0) continue;
-
-    const worktreeRelativePath = normalizedPath.slice(markerIndex + marker.length);
-    if (!worktreeRelativePath || worktreeRelativePath.startsWith('/')) continue;
-
-    const baseRepo = normalizedPath.slice(0, markerIndex);
-    if (baseRepo === '') return '/';
-    if (/^[A-Za-z]:$/.test(baseRepo)) return `${baseRepo}/`;
-    return baseRepo;
-  }
-  return null;
+  return managedWorktreeBaseRepo(normalizedPath);
 }

--- a/apps/desktop/src/shared/workingDir.ts
+++ b/apps/desktop/src/shared/workingDir.ts
@@ -1,3 +1,5 @@
+import { collapseWorktreeDirForGrouping } from '@cindy/maker-shared/worktree-paths';
+
 import { getManagedWorktreeBasePath } from './managedWorktreePaths';
 
 /**
@@ -58,9 +60,7 @@ export function normalizeWorkingDirForGrouping(raw: string | null | undefined): 
   const out = normalizeWorkingDirForProjectSettings(raw);
   if (out == null) return null;
 
-  return out
-    .replace(/\/\.worktrees\/[^/]+(?:\/.*)?$/, '')
-    .replace(/\/\.claude\/worktrees\/[^/]+(?:\/.*)?$/, '');
+  return collapseWorktreeDirForGrouping(out);
 }
 
 function stripWindowsLongPathPrefix(p: string): string {

--- a/packages/maker-shared/package.json
+++ b/packages/maker-shared/package.json
@@ -56,6 +56,7 @@
     "./thinking-text": "./src/thinkingText.ts",
     "./tool-use-descriptor": "./src/toolUseDescriptor.ts",
     "./work-activity-projection": "./src/workActivityProjection.ts",
+    "./worktree-paths": "./src/worktreePaths.ts",
     "./codex-usage-buckets": "./src/codexUsageBuckets.ts"
   },
   "scripts": {

--- a/packages/maker-shared/src/__tests__/mobileHome.test.ts
+++ b/packages/maker-shared/src/__tests__/mobileHome.test.ts
@@ -93,6 +93,48 @@ describe('mobileHome', () => {
     ]);
   });
 
+  it('groups worktree sessions into the base repo project instead of a random worktree card', () => {
+    // Slack / 定时任务这类自动建 worktree 的会话,workingDir 是 `<主仓>/.cindy-worktrees/<随机名>`。
+    // 不折叠的话首页会多出「serene-lovelace」这种随机名项目卡(与桌面侧栏口径不一致)。
+    const home = buildMobileHomePresentation({
+      devices: [{ canOpen: true, deviceId: 'mac-a', name: 'Mac A' }],
+      sessions: [
+        session('main-repo', { deviceLinkDeviceId: 'mac-a', updatedAt: '2026-01-01T00:03:00.000Z' }),
+        session('managed-worktree', {
+          deviceLinkDeviceId: 'mac-a',
+          workingDir: '/repo/app/.cindy-worktrees/serene-lovelace',
+          worktreePath: '/repo/app/.cindy-worktrees/serene-lovelace',
+          updatedAt: '2026-01-01T00:04:00.000Z',
+        }),
+        session('legacy-worktree', {
+          deviceLinkDeviceId: 'mac-a',
+          workingDir: '/repo/app/.xdt-worktrees/pensive-pasteur/src',
+          worktreePath: '/repo/app/.xdt-worktrees/pensive-pasteur',
+          updatedAt: '2026-01-01T00:05:00.000Z',
+        }),
+        session('conventional-worktree', {
+          deviceLinkDeviceId: 'mac-a',
+          workingDir: '/repo/app/.claude/worktrees/manual',
+          updatedAt: '2026-01-01T00:06:00.000Z',
+        }),
+      ],
+    });
+
+    expect(home.projects.map((project) => ({
+      key: project.key,
+      sessionIds: project.sessions.map((item) => item.session.id),
+      title: project.title,
+      workingDir: project.workingDir,
+    }))).toEqual([
+      {
+        key: 'device:mac-a:/repo/app',
+        sessionIds: ['conventional-worktree', 'legacy-worktree', 'managed-worktree', 'main-repo'],
+        title: 'app',
+        workingDir: '/repo/app',
+      },
+    ]);
+  });
+
   it('keeps the Windows drive-root separator so C:\\ and c:/ merge into one card', () => {
     // 盘符根特例:去尾分隔符不能把 C:\ / c:/ 削成 drive-relative 的 C: —— 否则丢掉 Windows 路径特征、
     // 盘符大小写无法归一,两条盘符根会话又会拆成两张卡。

--- a/packages/maker-shared/src/__tests__/sessionList.test.ts
+++ b/packages/maker-shared/src/__tests__/sessionList.test.ts
@@ -543,6 +543,21 @@ describe('sessionList', () => {
     expect(remoteSessionOverviewCopy(overview)).toBe('1 个置顶 · 3 个项目 · 1 个自动化执行中');
   });
 
+  it('counts a worktree session under its base repo so the overview matches the project sections', () => {
+    const sessions = [
+      session('main-repo', { workingDir: '/repo/app' }),
+      session('worktree', {
+        workingDir: '/repo/app/.cindy-worktrees/serene-lovelace',
+        worktreePath: '/repo/app/.cindy-worktrees/serene-lovelace',
+      }),
+    ];
+    const overview = summarizeRemoteSessionOverview(sessions, new Map(), new Map());
+    const sections = buildRemoteSessionSections(sessions, new Date('2026-01-01T00:10:00.000Z').getTime());
+
+    expect(overview.projectCount).toBe(1);
+    expect(sections.filter((section) => section.key.startsWith('project:'))).toHaveLength(1);
+  });
+
   it('builds mobile list context for search and grouped automation rows', () => {
     const now = new Date('2026-01-01T00:10:00.000Z').getTime();
     const activeSessions = [

--- a/packages/maker-shared/src/__tests__/sessionList.test.ts
+++ b/packages/maker-shared/src/__tests__/sessionList.test.ts
@@ -91,6 +91,23 @@ describe('sessionList', () => {
     ]);
   });
 
+  it('groups worktree sessions under their base repo instead of the random worktree name', () => {
+    const sections = buildRemoteSessionSections([
+      session('main-repo', { updatedAt: '2026-01-01T00:01:00.000Z' }),
+      session('worktree', {
+        updatedAt: '2026-01-01T00:02:00.000Z',
+        workingDir: '/repo/app/.cindy-worktrees/serene-lovelace',
+        worktreePath: '/repo/app/.cindy-worktrees/serene-lovelace',
+      }),
+    ], new Date('2026-01-01T00:10:00.000Z').getTime());
+
+    expect(sections.map((section) => [section.key, section.title, section.data.map((item) => item.session.id)])).toEqual([
+      ['project:/repo/app', 'app', ['worktree', 'main-repo']],
+    ]);
+    // worktree 身份不丢:仍由会话行副标题标出。
+    expect(sections[0].data[0].worktreeLabel).toBe('Worktree serene-lovelace');
+  });
+
   it('builds compact display metadata for a session row', () => {
     const item = toRemoteSessionListItem(session('s1', {
       title: '',

--- a/packages/maker-shared/src/__tests__/worktreePaths.test.ts
+++ b/packages/maker-shared/src/__tests__/worktreePaths.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collapseWorktreeDirForGrouping,
+  groupingWorktreeBaseRepo,
+  isManagedWorktreeDirectoryName,
+  managedWorktreeBaseRepo,
+} from '../worktreePaths.js';
+
+describe('worktreePaths', () => {
+  it('collapses Cindy-managed worktrees (current and legacy dir name) to their base repo', () => {
+    expect(managedWorktreeBaseRepo('/repo/.cindy-worktrees/serene-lovelace')).toBe('/repo');
+    expect(managedWorktreeBaseRepo('/repo/.cindy-worktrees/serene-lovelace/src/main')).toBe('/repo');
+    expect(managedWorktreeBaseRepo('/repo/.xdt-worktrees/pensive-pasteur')).toBe('/repo');
+  });
+
+  it('collapses conventional worktree layouts only for grouping', () => {
+    expect(managedWorktreeBaseRepo('/repo/.worktrees/feature')).toBeNull();
+    expect(managedWorktreeBaseRepo('/repo/.claude/worktrees/feature')).toBeNull();
+    expect(groupingWorktreeBaseRepo('/repo/.worktrees/feature')).toBe('/repo');
+    expect(groupingWorktreeBaseRepo('/repo/.claude/worktrees/feature/src')).toBe('/repo');
+  });
+
+  it('returns null when the path is not a worktree path', () => {
+    expect(groupingWorktreeBaseRepo('/repo')).toBeNull();
+    expect(groupingWorktreeBaseRepo('/repo/src/.cindy-worktreesish/name')).toBeNull();
+    // 容器目录本身(后面没有 worktree 名)不是 worktree 路径。
+    expect(groupingWorktreeBaseRepo('/repo/.cindy-worktrees')).toBeNull();
+    expect(groupingWorktreeBaseRepo('/repo/.cindy-worktrees/')).toBeNull();
+    // 相对路径直接以容器目录开头时定不出 base repo。
+    expect(groupingWorktreeBaseRepo('.cindy-worktrees/serene-lovelace')).toBeNull();
+  });
+
+  it('keeps filesystem roots addressable', () => {
+    expect(groupingWorktreeBaseRepo('/.cindy-worktrees/name')).toBe('/');
+    expect(groupingWorktreeBaseRepo('C:/.cindy-worktrees/name')).toBe('C:/');
+    expect(groupingWorktreeBaseRepo(String.raw`C:\.cindy-worktrees\name`)).toBe('C:\\');
+    // 重复分隔符不该跟着漏进盘符根。
+    expect(groupingWorktreeBaseRepo('C://.cindy-worktrees/name')).toBe('C:/');
+  });
+
+  it('preserves the incoming separator style', () => {
+    expect(groupingWorktreeBaseRepo(String.raw`C:\Repo\App\.cindy-worktrees\calm-feynman`))
+      .toBe(String.raw`C:\Repo\App`);
+    expect(groupingWorktreeBaseRepo(String.raw`\\Server\Share\App\.worktrees\feature`))
+      .toBe(String.raw`\\Server\Share\App`);
+    expect(groupingWorktreeBaseRepo('//Server/Share/App/.worktrees/feature'))
+      .toBe('//Server/Share/App');
+  });
+
+  it('does not treat literal backslashes in POSIX directory names as separators', () => {
+    // POSIX 下反斜杠是合法文件名字符:`weird\.worktrees` 是一个目录名,不是容器目录。
+    expect(groupingWorktreeBaseRepo(String.raw`/repo/weird\.worktrees/name`)).toBeNull();
+    expect(groupingWorktreeBaseRepo(String.raw`/Users/me/a\b/.xdt-worktrees/auto/src`))
+      .toBe(String.raw`/Users/me/a\b`);
+  });
+
+  it('collapses at the outermost worktree container when nested', () => {
+    expect(groupingWorktreeBaseRepo('/repo/.cindy-worktrees/outer/.worktrees/inner'))
+      .toBe('/repo');
+  });
+
+  it('collapseWorktreeDirForGrouping falls back to the input path', () => {
+    expect(collapseWorktreeDirForGrouping('/repo/app')).toBe('/repo/app');
+    expect(collapseWorktreeDirForGrouping('/repo/.cindy-worktrees/serene-lovelace')).toBe('/repo');
+  });
+
+  it('recognizes managed worktree container directory names', () => {
+    expect(isManagedWorktreeDirectoryName('.cindy-worktrees')).toBe(true);
+    expect(isManagedWorktreeDirectoryName('.xdt-worktrees')).toBe(true);
+    expect(isManagedWorktreeDirectoryName('.worktrees')).toBe(false);
+  });
+});

--- a/packages/maker-shared/src/index.ts
+++ b/packages/maker-shared/src/index.ts
@@ -44,3 +44,4 @@ export * from './systemCard.js';
 export * from './toolUseDescriptor.js';
 export * from './thinkingText.js';
 export * from './workActivityProjection.js';
+export * from './worktreePaths.js';

--- a/packages/maker-shared/src/mobileHome.ts
+++ b/packages/maker-shared/src/mobileHome.ts
@@ -9,6 +9,7 @@ import {
   type RemoteSessionStatusFilter,
 } from './sessionList.js';
 import { stripTrailingPathSeparators } from './pathText.js';
+import { collapseWorktreeDirForGrouping } from './worktreePaths.js';
 
 export const MOBILE_HOME_ALL_DEVICES = 'all';
 
@@ -583,7 +584,12 @@ function normalizeProjectWorkingDir(value: string | null | undefined): string {
   // 此时把紧跟 "X:" 的第一个分隔符保留下来。
   if (end === 2 && trimmed.length > 2 && trimmed[1] === ':' && isAsciiLetter(trimmed[0])) end = 3;
   // 全是斜杠时(end === 0)保留 trim 后原值,与旧 `replace(...) || value` 语义一致。
-  return end > 0 ? trimmed.slice(0, end) : trimmed;
+  const withoutTrailingSeparators = end > 0 ? trimmed.slice(0, end) : trimmed;
+  // worktree 会话折叠到 base repo(与桌面侧栏 normalizeWorkingDirForGrouping 同一口径):
+  // 不折叠的话每个 worktree 都会变成一个独立「项目」,标题是随机 worktree 名(serene-lovelace
+  // 之类),Slack / 定时任务这类自动建 worktree 的会话尤其明显。worktree 身份仍由会话行与
+  // 会话菜单的 worktreePath 单独展示,信息不丢。
+  return collapseWorktreeDirForGrouping(withoutTrailingSeparators);
 }
 
 function isAsciiLetter(ch: string): boolean {

--- a/packages/maker-shared/src/sessionList.ts
+++ b/packages/maker-shared/src/sessionList.ts
@@ -221,7 +221,9 @@ export function summarizeRemoteSessionOverview(
     if (session.status === 'active') active += 1;
     if (session.status === 'archived') archived += 1;
     if (session.pinnedAt) pinned += 1;
-    if (session.workingDir) projects.add(session.workingDir);
+    // 与 buildProjectSections 同一把折叠口径:worktree 会话算进它所属主仓,
+    // 否则概览里的项目数会比列表里的项目分区多出来。
+    if (session.workingDir) projects.add(collapseWorktreeDirForGrouping(session.workingDir));
     if ((pendingInteractionIndex.get(session.id) ?? 0) > 0) waiting += 1;
     if (isAutomationSession(session, scheduleIndex)) automation += 1;
   }

--- a/packages/maker-shared/src/sessionList.ts
+++ b/packages/maker-shared/src/sessionList.ts
@@ -5,6 +5,7 @@ import type { RemoteSchedule, RemoteScheduleRun, RemoteScheduleRunStatus } from 
 import { toMillis } from './scheduleModel.js';
 import { sessionCollaborationLabel, sessionWorktreeLabel } from './sessionIdentity.js';
 import { getSessionListCollapseView } from './sessionListCollapse.js';
+import { collapseWorktreeDirForGrouping } from './worktreePaths.js';
 
 export interface RemoteSessionListSessionLike {
   _count?: { messages?: number } | null;
@@ -375,7 +376,9 @@ function buildProjectSections(
   const projectGroups = new Map<string, RemoteSessionListItem[]>();
   for (const item of items) {
     if (isDialogueSession(item.session)) continue;
-    const key = item.session.workingDir ?? 'unknown';
+    // worktree 会话按 base repo 归组(与首页 projectGroupKey、桌面侧栏同一口径),
+    // 否则每个 worktree 会单独成一个随机名分区。
+    const key = item.session.workingDir ? collapseWorktreeDirForGrouping(item.session.workingDir) : 'unknown';
     const list = projectGroups.get(key) ?? [];
     list.push(item);
     projectGroups.set(key, list);

--- a/packages/maker-shared/src/worktreePaths.ts
+++ b/packages/maker-shared/src/worktreePaths.ts
@@ -4,8 +4,11 @@
  * 会话跑在 worktree 里时,它的 workingDir 是 `<base repo>/<容器目录>/<worktree 名>`。
  * worktree 名是随机生成的(见 desktop `worktree/nameGenerator.ts`,docker 风格
  * `形容词-名人`),所以**按 workingDir 原值分组会把每个 worktree 变成一个独立「项目」,
- * 标题显示成 `serene-lovelace` 这类随机名**。项目分组、项目归属判断与项目设置读写都
- * 必须先折叠到 base repo;需要真正读写文件的路径仍用会话 workingDir 原值。
+ * 标题显示成 `serene-lovelace` 这类随机名**。项目分组与项目归属判断必须先折叠到 base
+ * repo(`groupingWorktreeBaseRepo`,认全部四种容器目录);项目设置读写只对 Cindy 托管
+ * worktree 折叠(`managedWorktreeBaseRepo`)——用户自建的 `.worktrees` /
+ * `.claude/worktrees` 可能刻意带独立的 `.claude/settings.json`,继承 base repo 会覆盖
+ * 掉它的意图。需要真正读写文件的路径一律用会话 workingDir 原值。
  *
  * 本模块只做纯字符串折叠(不碰文件系统),同时接受 `/` 与 `\` 分隔符,并保留输入的
  * 分隔符风格 —— 手机端的项目标题 / 副标题直接展示折叠结果,不能被改写成另一种风格。

--- a/packages/maker-shared/src/worktreePaths.ts
+++ b/packages/maker-shared/src/worktreePaths.ts
@@ -1,0 +1,155 @@
+/**
+ * worktree 路径 → base repo 折叠:桌面与手机共享的唯一事实源。
+ *
+ * 会话跑在 worktree 里时,它的 workingDir 是 `<base repo>/<容器目录>/<worktree 名>`。
+ * worktree 名是随机生成的(见 desktop `worktree/nameGenerator.ts`,docker 风格
+ * `形容词-名人`),所以**按 workingDir 原值分组会把每个 worktree 变成一个独立「项目」,
+ * 标题显示成 `serene-lovelace` 这类随机名**。项目分组、项目归属判断与项目设置读写都
+ * 必须先折叠到 base repo;需要真正读写文件的路径仍用会话 workingDir 原值。
+ *
+ * 本模块只做纯字符串折叠(不碰文件系统),同时接受 `/` 与 `\` 分隔符,并保留输入的
+ * 分隔符风格 —— 手机端的项目标题 / 副标题直接展示折叠结果,不能被改写成另一种风格。
+ */
+
+/** Cindy 新建托管 worktree 使用的目录名。 */
+export const MANAGED_WORKTREE_DIR_NAME = '.cindy-worktrees';
+
+/** 品牌迁移前使用的目录名;只用于识别和恢复既有 worktree。 */
+export const LEGACY_MANAGED_WORKTREE_DIR_NAME = '.xdt-worktrees';
+
+/** 所有受 Cindy 生命周期管理的 worktree 目录名,新目录必须排在第一位。 */
+export const MANAGED_WORKTREE_DIR_NAMES = [
+  MANAGED_WORKTREE_DIR_NAME,
+  LEGACY_MANAGED_WORKTREE_DIR_NAME,
+] as const;
+
+/** 判断一个目录 basename 是否属于 Cindy 托管的 worktree 根目录。 */
+export function isManagedWorktreeDirectoryName(name: string): boolean {
+  return MANAGED_WORKTREE_DIR_NAMES.some((candidate) => candidate === name);
+}
+
+/** Cindy 托管的 worktree 容器目录(生命周期由 Cindy 管理,项目设置继承 base repo)。 */
+const MANAGED_WORKTREE_CONTAINERS: readonly (readonly string[])[] = MANAGED_WORKTREE_DIR_NAMES.map(
+  (name) => [name] as const,
+);
+
+/**
+ * 用户 / 其它工具自己建的 worktree 约定目录。它们可能刻意带独立的
+ * `.claude/settings.json`,所以只用于**分组**,不参与项目设置继承。
+ */
+const CONVENTIONAL_WORKTREE_CONTAINERS: readonly (readonly string[])[] = [
+  ['.worktrees'],
+  ['.claude', 'worktrees'],
+];
+
+const GROUPING_WORKTREE_CONTAINERS: readonly (readonly string[])[] = [
+  ...MANAGED_WORKTREE_CONTAINERS,
+  ...CONVENTIONAL_WORKTREE_CONTAINERS,
+];
+
+interface PathSegment {
+  readonly start: number;
+  readonly text: string;
+}
+
+/**
+ * 反斜杠是否算分隔符 —— 只有盘符路径(`C:\`)与反斜杠 UNC(`\\server\share`)才算。
+ * POSIX 路径里的反斜杠是**文件名的合法字符**(桌面侧 storage 归一化刻意保留它),
+ * 把它当分隔符会让 `/repo/weird\.worktrees/name` 被误折叠成 `/repo/weird`。
+ */
+function usesBackslashSeparator(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\');
+}
+
+/** 拆出非空路径段并记录每段在原串中的起始下标(折叠时按下标切片,保留原分隔符风格)。 */
+function splitPathSegments(value: string, allowBackslash: boolean): PathSegment[] {
+  const segments: PathSegment[] = [];
+  let start = -1;
+  for (let i = 0; i <= value.length; i += 1) {
+    if (i < value.length) {
+      const code = value.charCodeAt(i);
+      const isSeparator = code === 47 /* / */ || (allowBackslash && code === 92 /* \ */);
+      if (!isSeparator) {
+        if (start < 0) start = i;
+        continue;
+      }
+    }
+    if (start >= 0) {
+      segments.push({ start, text: value.slice(start, i) });
+      start = -1;
+    }
+  }
+  return segments;
+}
+
+function isDriveRoot(value: string): boolean {
+  return value.length === 2 && value[1] === ':' && /^[A-Za-z]$/.test(value[0]);
+}
+
+/**
+ * 去掉 base 末尾的分隔符。只去当前路径风格认可的分隔符 —— POSIX 下目录名可以以反斜杠
+ * 结尾(`/repo/weird\`),不能顺手削掉。
+ */
+function stripTrailingSeparators(value: string, allowBackslash: boolean): string {
+  let end = value.length;
+  while (end > 0) {
+    const code = value.charCodeAt(end - 1);
+    if (code !== 47 /* / */ && !(allowBackslash && code === 92 /* \ */)) break;
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
+function resolveWorktreeBase(
+  value: string,
+  containers: readonly (readonly string[])[],
+): string | null {
+  const allowBackslash = usesBackslashSeparator(value);
+  const segments = splitPathSegments(value, allowBackslash);
+  for (let i = 0; i < segments.length; i += 1) {
+    for (const container of containers) {
+      // 容器目录后面必须还有一段 worktree 名,否则这只是容器目录本身(或它的父级)。
+      if (i + container.length >= segments.length) continue;
+      let matched = true;
+      for (let k = 0; k < container.length; k += 1) {
+        if (segments[i + k].text !== container[k]) {
+          matched = false;
+          break;
+        }
+      }
+      if (!matched) continue;
+
+      const markerStart = segments[i].start;
+      // 路径以容器目录开头(相对路径)时定不出 base repo,按不折叠处理。
+      if (markerStart === 0) continue;
+      const base = stripTrailingSeparators(value.slice(0, markerStart), allowBackslash);
+      // base 只剩分隔符 → POSIX 根;盘符根(`C:`)要补回一个分隔符,否则 `C:` 会退化成
+      // drive-relative 语义。分隔符字符都取自原串,不改写风格。
+      if (base === '') return value.slice(0, 1);
+      if (isDriveRoot(base)) return `${base}${value[markerStart - 1]}`;
+      return base;
+    }
+  }
+  return null;
+}
+
+/**
+ * 解析 Cindy 托管 worktree 的 base repo(只认 `.cindy-worktrees` / `.xdt-worktrees`)。
+ * 不是托管 worktree 路径时返回 null。
+ */
+export function managedWorktreeBaseRepo(value: string): string | null {
+  return resolveWorktreeBase(value, MANAGED_WORKTREE_CONTAINERS);
+}
+
+/**
+ * 解析用于**项目分组**的 base repo:托管 worktree 加上 `.worktrees/<name>` 与
+ * `.claude/worktrees/<name>` 这两种社区约定形态。不是 worktree 路径时返回 null。
+ */
+export function groupingWorktreeBaseRepo(value: string): string | null {
+  return resolveWorktreeBase(value, GROUPING_WORKTREE_CONTAINERS);
+}
+
+/** 项目分组用:是 worktree 路径就折叠到 base repo,否则原样返回。 */
+export function collapseWorktreeDirForGrouping(value: string): string {
+  return groupingWorktreeBaseRepo(value) ?? value;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端首页会把跑在 worktree 里的会话错误地归成一个独立「项目」，卡片标题是随机的
worktree 名（`serene-lovelace`、`pensive-pasteur` 之类）。Slack bot 任务最容易撞上：
hook-control 的 `use_worktree` 路径会先 `prepareHandoffWorktree` 预建托管 worktree，
新会话的 `workingDir` 就是 `<主仓>/.cindy-worktrees/<随机名>`，而随机名来自
`apps/desktop/src/main/worktree/nameGenerator.ts` 的 docker 风格词库。

桌面侧栏分组走 `normalizeWorkingDirForGrouping`，早就把 worktree 路径折叠回主仓，所以
桌面看不出问题；手机端首页 `projectGroupKey`（`mobileHome.ts`）和设备详情页项目分区
（`sessionList.ts`）都直接用 `workingDir` 原值，两端口径不一致。

本 PR 把「worktree → base repo」折叠下沉到 `maker-shared` 作为唯一事实源，手机端分组与
桌面端共用同一实现。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户反馈：Slack 机器人的任务在手机版上被归类到一个奇怪的项目下）
- 本 PR 包含：
  - 新增 `packages/maker-shared/src/worktreePaths.ts`：worktree 路径折叠到 base repo 的
    唯一事实源，覆盖 `.cindy-worktrees`、历史 `.xdt-worktrees`、`.worktrees`、
    `.claude/worktrees` 四种形态；纯字符串线性扫描（不碰文件系统、不用可回溯正则），
    同时支持 `/` 与 `\` 并保留输入的分隔符风格（手机端项目标题／副标题直接展示折叠结果）。
  - `mobileHome.ts`：`normalizeProjectWorkingDir` 折叠到 base repo，于是首页项目卡的
    分组键、标题、副标题以及 `sessionMatchesProjectDir` 的项目归属判断口径一起对齐。
  - `sessionList.ts`：设备详情页的项目分区同样折叠。
  - 桌面侧 `shared/managedWorktreePaths.ts` / `shared/workingDir.ts` 改为委托 maker-shared
    的同一实现（导出名与行为不变），避免两端词表分叉。
- 明确不包含：不改 worktree 的创建／回收逻辑，不改 hook-control 会话创建路径，不改
  `session.workingDir` 本身（读写文件仍用 cwd 原值）。
- 用户可见变化：手机端首页与设备详情页不再出现随机 worktree 名的项目卡；worktree 会话
  合并进它所属的主仓项目，worktree 身份仍由会话行副标题与会话菜单的
  `Worktree <name>` 展示。
- 是否存在 breaking change：无。

### UI 变化

不涉及：只改会话分组的路径归一化逻辑，没有新增或修改任何组件、布局、样式、动效或 UI
文案；项目卡的标题文本内容由折叠后的路径决定，渲染方式不变。

- 引用的设计规范：不涉及（无视觉／交互／文案变化）

## 怎么验证的

### 自动验证

```text
pnpm test:unit（仓库门禁，全量）
结果：通过（GATE_EXIT=0）

pnpm --filter @cindy/maker-shared exec vitest run
结果：49 files / 683 tests 全部通过（含新增 worktreePaths.test.ts 9 例、
      mobileHome 与 sessionList 新增用例）

pnpm --filter desktop exec vitest run src/shared/__tests__/workingDir.test.ts \
  src/renderer/__tests__/projectGrouping.test.ts src/main/localDb/__tests__ src/main/im/__tests__
结果：全部通过（32 files / 238 tests + 8 files / 95 tests）

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter mobile run typecheck
结果：通过

pnpm --filter @cindy/maker-shared run lint
结果：通过

pnpm --filter @cindy/maker-shared run build（tsc --noEmit）
结果：5 条报错，与 origin/main 基线逐条一致（region 表与 composerPalette 测试的
      既有类型问题），本 PR 未新增类型错误

pnpm check:dco
结果：通过（1 commit signed off）
```

新增测试覆盖的边界：四种 worktree 容器目录、worktree 子目录、缺 worktree 名的容器目录
本身、以容器目录开头的相对路径、POSIX 下含字面反斜杠的目录名（不得误判为分隔符）、
盘符根与 UNC（正／反斜杠两种写法）、重复分隔符、嵌套 worktree；以及首页把托管／legacy／
`.claude/worktrees` 三种 worktree 会话与主仓会话合并成同一张项目卡。

### 手工验证

不涉及：改动为共享层纯逻辑，行为差异已由上述单测覆盖到分组键、标题与项目归属判断。

### 未执行的验证

- 未做手机端实机目检（未在真机上确认首页项目卡）。原因：改动不触碰 UI 组件与样式，
  分组结果由共享层纯函数决定并已被单测锁定。
- 未跑 `pnpm test:all`。原因：改动限于 `maker-shared` 展示层与 desktop 的两个 shared
  helper（委托改写、行为不变），已用仓库门禁全量单测 + 两端 typecheck 覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：手机端首页项目分组、设备详情页项目分区，以及桌面端 `workingDir` 分组归一化
  （委托改写，行为与既有测试口径一致）。不涉及原生层与 mobile runtime fingerprint，
  不触发冷更；不涉及数据库、协议与持久化格式（首页列表缓存只存会话，项目分组每次重算）。
- 回滚 / 降级方式：单 commit，直接 revert 即可恢复原有分组口径，无数据迁移或兼容包袱。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（新模块的口径与边界写在源码文档注释里，未新增规则文档）
- [x] 已确认测试结果或说明未执行原因
