### PR TITLE
fix(desktop): 完善 Stripe 支付跳转

### DIFF
--- a/apps/desktop/src/main/billing/__tests__/index.test.ts
+++ b/apps/desktop/src/main/billing/__tests__/index.test.ts
@@ -472,9 +472,11 @@ describe('billing IPC', () => {
     });
   });
 
-  it('opens only public HTTPS Stripe Checkout URLs from the main top-level frame', async () => {
+  it.each([
+    'https://checkout.stripe.com/c/pay/session_fixture#fragment',
+    'https://invoice.stripe.com/i/acct_fixture/test_fixture',
+  ])('opens a public HTTPS Stripe payment URL from the main top-level frame: %s', async (url) => {
     const { call, openExternal } = harness();
-    const url = 'https://checkout.stripe.com/c/pay/session_fixture#fragment';
 
     await expect(call(BILLING_INVOKE.OPEN_PAYMENT_REDIRECT, { url })).resolves.toEqual({
       success: true,
@@ -488,7 +490,9 @@ describe('billing IPC', () => {
     'javascript:alert(1)',
     'stripe://checkout/session',
     'https://checkout.stripe.com.evil.example/c/pay/test',
+    'https://invoice.stripe.com.evil.example/i/test',
     'https://checkout.stripe.com@evil.example/c/pay/test',
+    'https://invoice.stripe.com@evil.example/i/test',
     'https://user:password@checkout.stripe.com/c/pay/test',
     'https://checkout.stripe.com:444/c/pay/test',
     `https://checkout.stripe.com/c/pay/${'x'.repeat(2_100)}`,

--- a/apps/desktop/src/main/billing/__tests__/projection.test.ts
+++ b/apps/desktop/src/main/billing/__tests__/projection.test.ts
@@ -772,6 +772,23 @@ describe('plan change projection', () => {
     });
   });
 
+  it('accepts a Stripe Hosted Invoice redirect for an awaiting upgrade', () => {
+    expect(projectBillingPlanChange(planChange({
+      quotedCurrency: 'usd',
+      paymentAction: {
+        type: 'REDIRECT',
+        url: 'https://invoice.stripe.com/i/acct_fixture/test_fixture',
+        expiresAt: now,
+      },
+    }))).toMatchObject({
+      status: 'AWAITING_PAYMENT',
+      paymentAction: {
+        type: 'REDIRECT',
+        url: 'https://invoice.stripe.com/i/acct_fixture/test_fixture',
+      },
+    });
+  });
+
   it.each([
     ['unknown status', { status: 'FUTURE_STATUS' }],
     ['unknown change type', { changeType: 'SIDEGRADE' }],

--- a/apps/desktop/src/main/billing/paymentRedirect.ts
+++ b/apps/desktop/src/main/billing/paymentRedirect.ts
@@ -2,7 +2,10 @@ const MAX_BILLING_REDIRECT_URL_LENGTH = 2_048;
 
 // Public provider-owned checkout hosts only. Merchant and Cindy-owned hosts do
 // not belong here; adding a host changes the desktop trust boundary.
-const ALLOWED_BILLING_REDIRECT_HOSTS = new Set(['checkout.stripe.com']);
+const ALLOWED_BILLING_REDIRECT_HOSTS = new Set([
+  'checkout.stripe.com',
+  'invoice.stripe.com',
+]);
 
 export function isAllowedBillingRedirectUrl(value: unknown): value is string {
   if (

--- a/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
@@ -30,6 +30,19 @@ export function BillingCheckoutDialog({
   const action = actionOf(state);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+  const openedRedirectKeyRef = useRef<string | null>(null);
+  const redirectUrl = action?.type === 'REDIRECT' ? action.url : null;
+  const redirectKey =
+    action?.type === 'REDIRECT'
+      ? [
+          state.kind,
+          state.order?.orderId ??
+            state.subscription?.purchaseAttemptId ??
+            state.subscription?.subscriptionId,
+          action.url,
+          action.expiresAt,
+        ].join(':')
+      : null;
 
   useEffect(() => {
     let active = true;
@@ -78,6 +91,16 @@ export function BillingCheckoutDialog({
   const openRedirect = () => {
     if (action?.type === 'REDIRECT') void billingApi.openPaymentRedirect(action.url);
   };
+
+  useEffect(() => {
+    if (!state.open || state.phase !== 'AWAITING_PAYMENT') {
+      openedRedirectKeyRef.current = null;
+      return;
+    }
+    if (!redirectKey || !redirectUrl || openedRedirectKeyRef.current === redirectKey) return;
+    openedRedirectKeyRef.current = redirectKey;
+    void billingApi.openPaymentRedirect(redirectUrl);
+  }, [redirectKey, redirectUrl, state.open, state.phase]);
 
   // 过期判定以服务端为权威：服务端只下发仍有效的动作，动作过期后轮询响应里
   // 会把它置空。因此“曾经有动作、现在没有了”才代表过期，本地时钟偏移不会

--- a/apps/desktop/src/renderer/features/billing/PlanChangeDialog.tsx
+++ b/apps/desktop/src/renderer/features/billing/PlanChangeDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as QRCode from 'qrcode';
 import {
@@ -240,6 +240,12 @@ export function PlanChangeStatusDialog({
   const change = state.planChange;
   const action: BillingPaymentAction | null = change?.paymentAction ?? null;
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const openedRedirectKeyRef = useRef<string | null>(null);
+  const redirectUrl = action?.type === 'REDIRECT' ? action.url : null;
+  const redirectKey =
+    action?.type === 'REDIRECT'
+      ? [change?.planChangeId, action.url, action.expiresAt].join(':')
+      : null;
   const actionSeconds = useCountdownSeconds(
     state.phase === 'AWAITING_PAYMENT' ? (action?.expiresAt ?? null) : null,
   );
@@ -263,6 +269,16 @@ export function PlanChangeStatusDialog({
       active = false;
     };
   }, [action]);
+
+  useEffect(() => {
+    if (!state.open || state.phase !== 'AWAITING_PAYMENT') {
+      openedRedirectKeyRef.current = null;
+      return;
+    }
+    if (!redirectKey || !redirectUrl || openedRedirectKeyRef.current === redirectKey) return;
+    openedRedirectKeyRef.current = redirectKey;
+    void billingApi.openPaymentRedirect(redirectUrl);
+  }, [redirectKey, redirectUrl, state.open, state.phase]);
 
   const busy = state.phase === 'QUOTING' || state.phase === 'CONFIRMING';
   const title = useMemo(() => {

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { BillingPaymentOrder, BillingSubscription } from '../../../../shared/billing';
+import type { BillingSubscription } from '../../../../shared/billing';
 
 const i18n = {
   language: 'en',
@@ -343,6 +343,7 @@ describe('BillingPage remote catalog rendering', () => {
             ],
           })),
           getCurrentSubscription: vi.fn(async () => ({ subscription: null })),
+          openPaymentRedirect: vi.fn(async () => ({ success: true })),
         },
         openExternal: vi.fn(),
       },
@@ -673,6 +674,42 @@ describe('BillingPage remote catalog rendering', () => {
     view.rerender(<BillingPage />);
     expect(await screen.findByText('billing.checkout.actionExpiredBody')).toBeTruthy();
     expect(screen.queryByAltText('billing.checkout.qrAlt')).toBeNull();
+  });
+
+  it('opens a Stripe Checkout redirect automatically once and keeps the manual fallback', async () => {
+    const url = 'https://checkout.stripe.com/c/pay/session_fixture';
+    const subscription = {
+      subscriptionId: 'subscription_incomplete',
+      status: 'INCOMPLETE' as const,
+      currentPeriodStartAt: null,
+      currentPeriodEndAt: null,
+      entitlementValidUntil: null,
+      cancelAtPeriodEnd: false,
+      effectivePlan: null,
+      purchaseAttemptId: 'attempt_redirect',
+      paymentAction: {
+        type: 'REDIRECT' as const,
+        url,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+    };
+    Object.assign(checkout.state, {
+      open: true,
+      kind: 'SUBSCRIPTION',
+      phase: 'AWAITING_PAYMENT',
+      subscription,
+    });
+    const openPaymentRedirect = vi.mocked(window.electronAPI.billing.openPaymentRedirect);
+
+    const view = render(<BillingPage />);
+    await waitFor(() => expect(openPaymentRedirect).toHaveBeenCalledWith({ url }));
+
+    Object.assign(checkout.state, { subscription: { ...subscription } });
+    view.rerender(<BillingPage />);
+    expect(openPaymentRedirect).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('billing.checkout.openPayment'));
+    expect(openPaymentRedirect).toHaveBeenCalledTimes(2);
   });
 
   it('does not show zero or block purchases when balance is not provisioned', async () => {
@@ -1270,6 +1307,7 @@ describe('BillingPage plan change', () => {
     confirmPlanChange: vi.fn(),
     refreshPlanChange: vi.fn(),
     cancelPlanChange: vi.fn(),
+    openPaymentRedirect: vi.fn(async () => ({ success: true })),
   });
 
   const install = (billing: ReturnType<typeof billingMocks>) => {
@@ -1574,6 +1612,46 @@ describe('BillingPage plan change', () => {
     // APPLIED refreshes subscription, catalog, and balance exactly once more.
     await waitFor(() => expect(billing.getBalance).toHaveBeenCalledTimes(2));
     expect(billing.getCurrentSubscription).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens a Stripe plan-change redirect automatically once and keeps the manual fallback', async () => {
+    const billing = install(billingMocks());
+    const url = 'https://checkout.stripe.com/c/pay/plan_change_fixture';
+    billing.quotePlanChange.mockResolvedValue({
+      planChangeId: 'plan_change_redirect',
+      changeType: 'UPGRADE',
+      status: 'QUOTED',
+      quotedAmountMinor: 1100,
+      quotedCurrency: 'usd',
+      quoteExpiresAt: '2099-01-01T00:00:00.000Z',
+      effectiveAt: '2026-07-24T00:00:00.000Z',
+      paymentAction: null,
+    });
+    billing.confirmPlanChange.mockResolvedValue({
+      planChangeId: 'plan_change_redirect',
+      changeType: 'UPGRADE',
+      status: 'AWAITING_PAYMENT',
+      quotedAmountMinor: 1100,
+      quotedCurrency: 'usd',
+      quoteExpiresAt: null,
+      effectiveAt: '2026-07-24T00:00:00.000Z',
+      paymentAction: {
+        type: 'REDIRECT',
+        url,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      },
+    });
+
+    render(<BillingPage />);
+    fireEvent.click(await screen.findByText('billing.settings.subscriptionCard.changeAction'));
+    fireEvent.click((await screen.findByText('Max plan')).closest('button')!);
+    fireEvent.click(await screen.findByText('billing.planChange.confirm'));
+
+    await waitFor(() => expect(billing.openPaymentRedirect).toHaveBeenCalledWith({ url }));
+    expect(billing.openPaymentRedirect).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('billing.checkout.openPayment'));
+    expect(billing.openPaymentRedirect).toHaveBeenCalledTimes(2);
   });
 
   it('renders a grandfathered current plan from the captured subscription terms', async () => {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7299,7 +7299,7 @@
     },
     "providers": {
       "alipay": "Alipay",
-      "stripe": "Card"
+      "stripe": "Stripe"
     },
     "currentSubscription": {
       "title": "Current subscription",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7288,7 +7288,7 @@
     },
     "providers": {
       "alipay": "Alipay",
-      "stripe": "カード"
+      "stripe": "Stripe"
     },
     "currentSubscription": {
       "title": "現在のサブスクリプション",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7288,7 +7288,7 @@
     },
     "providers": {
       "alipay": "Alipay",
-      "stripe": "카드"
+      "stripe": "Stripe"
     },
     "currentSubscription": {
       "title": "현재 구독",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7289,7 +7289,7 @@
     },
     "providers": {
       "alipay": "支付宝",
-      "stripe": "银行卡"
+      "stripe": "Stripe"
     },
     "currentSubscription": {
       "title": "当前订阅",


### PR DESCRIPTION
## 这次改了什么

### 摘要

完善 Desktop 的 Stripe 支付跳转：创建 Checkout、套餐变更返回受信任的 Stripe 地址时自动打开一次，同时保留手动打开兜底；支持 Stripe Hosted Invoice 域名，并将支付渠道名称统一显示为 `Stripe`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Stripe 全链路验证
- 本 PR 包含：Checkout 与套餐变更支付地址自动打开、严格 Stripe 域名白名单、四语渠道名称和回归测试
- 明确不包含：服务端支付状态投影、Webhook、MQ、Catalog 与本地启动脚本
- 用户可见变化：选择 Stripe 后无需再次点击即可进入支付页；仍可手动重新打开支付页
- 是否存在 breaking change：无

### UI 变化

- 无布局或视觉样式变化；仅调整支付跳转交互与渠道文案。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §11 Voice & Content（四语渠道名称保持产品名一致）与 §14 Interaction Conventions（支付跳转保持一次性自动动作，并保留明确的用户触发兜底）。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（Desktop、Mobile 与共享包测试均通过）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:i18n
结果：通过（5531 keys 四语 parity；437 条既有/专名 warning，无 error）

git diff --check origin/main...HEAD
结果：通过
```

### 手工验证

- macOS 隔离 Desktop 环境已走过 Stripe 新订阅、套餐升降级、取消与点数充值流程。

### 未执行的验证

- 未在 Windows/Linux 手工验证；本次只修改 Electron 通用跳转逻辑，相关行为由单元测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 外部支付页打开行为。新增地址仍限制为 HTTPS，且只允许 `checkout.stripe.com` 与 `invoice.stripe.com`，拒绝凭据、端口及其他主机。
- 回滚 / 降级方式：回滚本提交即可恢复为仅手动打开或原有 Checkout 域名范围；服务端支付状态不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
