### PR TITLE
feat(desktop): add embedded browser automation capabilities

### DIFF
--- a/apps/desktop/src/main/__tests__/webview-security.test.ts
+++ b/apps/desktop/src/main/__tests__/webview-security.test.ts
@@ -65,6 +65,7 @@ describe('applyWebviewHardening', () => {
     expect(webPreferences.allowRunningInsecureContent).toBe(false);
     expect(webPreferences.webviewTag).toBe(false);
     expect(webPreferences.plugins).toBe(false);
+    expect(webPreferences.disableDialogs).toBe(true);
     expect(webPreferences.disablePopups).toBe(false);
     // 比 tY 多一步 preload 删除(未传 commentPreloadPath 的回落分支)
     expect('preload' in webPreferences).toBe(false);

--- a/apps/desktop/src/main/__tests__/webview-security.test.ts
+++ b/apps/desktop/src/main/__tests__/webview-security.test.ts
@@ -65,7 +65,7 @@ describe('applyWebviewHardening', () => {
     expect(webPreferences.allowRunningInsecureContent).toBe(false);
     expect(webPreferences.webviewTag).toBe(false);
     expect(webPreferences.plugins).toBe(false);
-    expect(webPreferences.disableDialogs).toBe(true);
+    expect(webPreferences.disableDialogs).toBe(false);
     expect(webPreferences.disablePopups).toBe(false);
     // 比 tY 多一步 preload 删除(未传 commentPreloadPath 的回落分支)
     expect('preload' in webPreferences).toBe(false);

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -354,6 +354,7 @@ import {
 import {
   disposeBrowserRuntime,
   registerBrowserBackendIpc,
+  setBrowserSessionUploadRootResolver,
   setMainWindowAccessorForBackend,
   setEnsureHostForBackend,
   setIsDetachedForBackend,
@@ -1091,6 +1092,15 @@ registerTabOpResultHandler({
 setMainWindowAccessorForBackend(() => rsbWindowController.getHostWebContents());
 setEnsureHostForBackend(() => rsbWindowController.ensureOpenForAutomation());
 setIsDetachedForBackend(() => readRsbWindowSettings().detached);
+setBrowserSessionUploadRootResolver(async (sessionId) => {
+  try {
+    const meta = await getMakerCore().getSessionMeta(sessionId);
+    if (!meta?.workDir || meta.remoteHostId) return [];
+    return [meta.workDir];
+  } catch {
+    return [];
+  }
+});
 registerBrowserBackendIpc();
 
 // ── 应用级快捷键 override 存储 IPC ──────────────────────────────────────

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
@@ -28,24 +28,36 @@ function artifactHarness() {
   return { wc, emitDownload };
 }
 
-function downloadItem(finalState: 'completed' | 'cancelled' | 'interrupted') {
+function downloadItem(
+  finalState: 'completed' | 'cancelled' | 'interrupted',
+  options: { totalBytes?: number; receivedBytes?: number } = {},
+) {
   let savePath = '';
   let doneListener: ((...args: unknown[]) => void) | undefined;
+  let updateListener: ((...args: unknown[]) => void) | undefined;
+  let receivedBytes = options.receivedBytes ?? options.totalBytes ?? 5;
   return {
     getFilename: () => '../unsafe?.txt',
     getURL: () => 'https://example.test/download',
     getMimeType: () => 'text/plain',
-    getTotalBytes: () => 5,
-    getReceivedBytes: () => 5,
+    getTotalBytes: () => options.totalBytes ?? 5,
+    getReceivedBytes: () => receivedBytes,
     setSavePath: vi.fn((value: string) => {
       savePath = value;
       fs.writeFileSync(value, 'hello');
     }),
     cancel: vi.fn(),
+    on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      if (event === 'updated') updateListener = listener;
+    }),
     once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
       if (event === 'done') doneListener = listener;
     }),
     finish: () => doneListener?.({}, finalState),
+    update: (value: number) => {
+      receivedBytes = value;
+      updateListener?.();
+    },
     savedPath: () => savePath,
   };
 }
@@ -116,5 +128,118 @@ describe('RsbWebviewArtifacts', () => {
     harness.emitDownload(item);
 
     expect(item.setSavePath).not.toHaveBeenCalled();
+  });
+
+  it('cancels a download that exceeds the per-file quota before saving', async () => {
+    const harness = artifactHarness();
+    const item = downloadItem('cancelled', { totalBytes: 32 * 1024 * 1024 + 1 });
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'quota-file', timeoutMs: 1000 },
+      async () => {
+        harness.emitDownload(item);
+        setTimeout(() => item.finish(), 0);
+      },
+    );
+
+    expect(item.cancel).toHaveBeenCalledTimes(1);
+    expect(item.setSavePath).not.toHaveBeenCalled();
+    expect(result.downloads[0]).toMatchObject({ state: 'cancelled' });
+  });
+
+  it('cancels a download that crosses the quota while streaming', async () => {
+    const harness = artifactHarness();
+    const item = downloadItem('cancelled', { totalBytes: 0, receivedBytes: 0 });
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'quota-stream', timeoutMs: 1000 },
+      async () => {
+        harness.emitDownload(item);
+        item.update(32 * 1024 * 1024 + 1);
+        setTimeout(() => item.finish(), 0);
+      },
+    );
+
+    expect(item.setSavePath).toHaveBeenCalledTimes(1);
+    expect(item.cancel).toHaveBeenCalledTimes(1);
+    expect(result.downloads[0]).toMatchObject({ state: 'cancelled' });
+    expect(fs.existsSync(item.savedPath())).toBe(false);
+  });
+
+  it('bounds both download count and total bytes for one action', async () => {
+    const harness = artifactHarness();
+    const items = Array.from({ length: 9 }, () => (
+      downloadItem('completed', { totalBytes: 20 * 1024 * 1024 })
+    ));
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'quota-capture', timeoutMs: 1000 },
+      async () => {
+        for (const item of items) harness.emitDownload(item);
+        setTimeout(() => {
+          for (const item of items) item.finish();
+        }, 0);
+      },
+    );
+
+    expect(result.downloads).toHaveLength(9);
+    expect(items.slice(0, 3).every((item) => item.setSavePath.mock.calls.length === 1)).toBe(true);
+    expect(items[3].cancel).toHaveBeenCalledTimes(1);
+    expect(items[8].cancel).toHaveBeenCalledTimes(1);
+    expect(result.downloads.slice(3).every((artifact) => artifact.state === 'cancelled')).toBe(true);
+  });
+
+  it('removes retained artifacts when the backend is disposed', async () => {
+    const harness = artifactHarness();
+    const item = downloadItem('completed');
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'dispose-cleanup', timeoutMs: 1000 },
+      async () => {
+        harness.emitDownload(item);
+        setTimeout(() => item.finish(), 0);
+      },
+    );
+    const artifactPath = result.downloads[0].path;
+
+    expect(artifactPath).toBeDefined();
+    await artifacts.dispose();
+    expect(fs.existsSync(artifactPath!)).toBe(false);
+  });
+
+  it('evicts the oldest files when retained bytes exceed the global budget', async () => {
+    const harness = artifactHarness();
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+    const savedPaths: string[] = [];
+
+    for (let captureIndex = 0; captureIndex < 5; captureIndex += 1) {
+      const items = [
+        downloadItem('completed', { totalBytes: 32 * 1024 * 1024 }),
+        downloadItem('completed', { totalBytes: 32 * 1024 * 1024 }),
+      ];
+      await artifacts.capture(
+        harness.wc,
+        { sessionId: 'quota-retained', timeoutMs: 1000 },
+        async () => {
+          for (const item of items) harness.emitDownload(item);
+          setTimeout(() => {
+            for (const item of items) item.finish();
+          }, 0);
+        },
+      );
+      savedPaths.push(...items.map((item) => item.savedPath()));
+    }
+
+    expect(fs.existsSync(savedPaths[0])).toBe(false);
+    expect(fs.existsSync(savedPaths[1])).toBe(false);
+    expect(fs.existsSync(savedPaths.at(-1)!)).toBe(true);
   });
 });

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WebContents } from 'electron';
+
+import { RsbWebviewArtifacts } from '../rsb-webview-artifacts.js';
+
+function artifactHarness() {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const session = {
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      const group = listeners.get(event) ?? new Set();
+      group.add(listener);
+      listeners.set(event, group);
+    },
+    removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(listener);
+    },
+  };
+  const wc = { session } as unknown as WebContents;
+  const emitDownload = (item: ReturnType<typeof downloadItem>) => {
+    for (const listener of listeners.get('will-download') ?? []) {
+      listener({}, item, wc);
+    }
+  };
+  return { wc, emitDownload };
+}
+
+function downloadItem(finalState: 'completed' | 'cancelled' | 'interrupted') {
+  let savePath = '';
+  let doneListener: ((...args: unknown[]) => void) | undefined;
+  return {
+    getFilename: () => '../unsafe?.txt',
+    getURL: () => 'https://example.test/download',
+    getMimeType: () => 'text/plain',
+    getTotalBytes: () => 5,
+    getReceivedBytes: () => 5,
+    setSavePath: vi.fn((value: string) => {
+      savePath = value;
+      fs.writeFileSync(value, 'hello');
+    }),
+    cancel: vi.fn(),
+    once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      if (event === 'done') doneListener = listener;
+    }),
+    finish: () => doneListener?.({}, finalState),
+    savedPath: () => savePath,
+  };
+}
+
+let root = '';
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-browser-artifact-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('RsbWebviewArtifacts', () => {
+  it('stores a completed download in an isolated directory with a safe name', async () => {
+    const harness = artifactHarness();
+    const item = downloadItem('completed');
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'session/one', timeoutMs: 1000 },
+      async () => {
+        harness.emitDownload(item);
+        setTimeout(() => item.finish(), 0);
+        return 'clicked';
+      },
+    );
+
+    expect(result.value).toBe('clicked');
+    expect(result.downloads).toEqual([
+      expect.objectContaining({
+        fileName: 'unsafe.txt',
+        state: 'completed',
+        bytes: 5,
+      }),
+    ]);
+    expect(result.downloads[0].path).toBe(item.savedPath());
+    expect(fs.readFileSync(item.savedPath(), 'utf8')).toBe('hello');
+  });
+
+  it('removes partial files after a cancelled download', async () => {
+    const harness = artifactHarness();
+    const item = downloadItem('cancelled');
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'session-two', timeoutMs: 1000 },
+      async () => {
+        harness.emitDownload(item);
+        setTimeout(() => item.finish(), 0);
+      },
+    );
+
+    expect(result.downloads[0]).toMatchObject({ state: 'cancelled' });
+    expect(result.downloads[0].path).toBeUndefined();
+    expect(fs.existsSync(item.savedPath())).toBe(false);
+  });
+
+  it('does not intercept downloads outside an active agent action', async () => {
+    const harness = artifactHarness();
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+    await artifacts.capture(harness.wc, { sessionId: 'session-three' }, async () => undefined);
+
+    const item = downloadItem('completed');
+    harness.emitDownload(item);
+
+    expect(item.setSavePath).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
@@ -73,6 +73,22 @@ afterEach(() => {
 });
 
 describe('RsbWebviewArtifacts', () => {
+  it('reclaims artifact roots left by a dead process before reuse', async () => {
+    const staleRoot = path.join(root, 'process-99999999');
+    await fs.promises.mkdir(staleRoot, { recursive: true });
+    await fs.promises.writeFile(path.join(staleRoot, 'stale.txt'), 'stale');
+    const harness = artifactHarness();
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() }, 0);
+
+    await artifacts.capture(
+      harness.wc,
+      { sessionId: 'startup-cleanup', timeoutMs: 1000 },
+      async () => undefined,
+    );
+
+    expect(fs.existsSync(staleRoot)).toBe(false);
+  });
+
   it('stores a completed download in an isolated directory with a safe name', async () => {
     const harness = artifactHarness();
     const item = downloadItem('completed');

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
@@ -230,11 +230,41 @@ describe('RsbWebviewArtifacts', () => {
       },
     );
 
-    expect(result.downloads).toHaveLength(9);
+    expect(result.downloads).toHaveLength(8);
     expect(items.slice(0, 3).every((item) => item.setSavePath.mock.calls.length === 1)).toBe(true);
     expect(items[3].cancel).toHaveBeenCalledTimes(1);
     expect(items[8].cancel).toHaveBeenCalledTimes(1);
     expect(result.downloads.slice(3).every((artifact) => artifact.state === 'cancelled')).toBe(true);
+  });
+
+  it('releases reserved bytes after a download is cancelled', async () => {
+    const harness = artifactHarness();
+    const cancelled = downloadItem('cancelled', { totalBytes: 32 * 1024 * 1024 });
+    const later = [
+      downloadItem('completed', { totalBytes: 32 * 1024 * 1024 }),
+      downloadItem('completed', { totalBytes: 32 * 1024 * 1024 }),
+    ];
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'quota-release', timeoutMs: 1000 },
+      async () => {
+        harness.emitDownload(cancelled);
+        cancelled.finish();
+        for (const item of later) harness.emitDownload(item);
+        setTimeout(() => {
+          for (const item of later) item.finish();
+        }, 0);
+      },
+    );
+
+    expect(later.every((item) => item.setSavePath.mock.calls.length === 1)).toBe(true);
+    expect(result.downloads.map((artifact) => artifact.state)).toEqual([
+      'cancelled',
+      'completed',
+      'completed',
+    ]);
   });
 
   it('removes retained artifacts when the backend is disposed', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
@@ -130,6 +130,48 @@ describe('RsbWebviewArtifacts', () => {
     expect(item.setSavePath).not.toHaveBeenCalled();
   });
 
+  it('captures a download that starts after the action returns', async () => {
+    const harness = artifactHarness();
+    const item = downloadItem('completed');
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'delayed-download', timeoutMs: 2_000 },
+      async () => {
+        setTimeout(() => {
+          harness.emitDownload(item);
+          setTimeout(() => item.finish(), 0);
+        }, 300);
+        return 'clicked';
+      },
+    );
+
+    expect(result.downloads).toHaveLength(1);
+    expect(result.downloads[0].state).toBe('completed');
+  });
+
+  it('limits artifact diagnostics to the requested session', async () => {
+    const harness = artifactHarness();
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    for (const sessionId of ['session-a', 'session-b']) {
+      const item = downloadItem('completed');
+      await artifacts.capture(
+        harness.wc,
+        { sessionId, timeoutMs: 1_000 },
+        async () => {
+          harness.emitDownload(item);
+          setTimeout(() => item.finish(), 0);
+        },
+      );
+    }
+
+    expect(artifacts.diagnostics('session-a').recentArtifacts).toHaveLength(1);
+    expect(artifacts.diagnostics('session-b').recentArtifacts).toHaveLength(1);
+    expect(artifacts.diagnostics('session-c').recentArtifacts).toHaveLength(0);
+  });
+
   it('cancels a download that exceeds the per-file quota before saving', async () => {
     const harness = artifactHarness();
     const item = downloadItem('cancelled', { totalBytes: 32 * 1024 * 1024 + 1 });

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
@@ -317,7 +317,7 @@ describe('RsbWebviewArtifacts', () => {
 
   it('evicts the oldest files when retained bytes exceed the global budget', async () => {
     const harness = artifactHarness();
-    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() }, 0);
     const savedPaths: string[] = [];
 
     for (let captureIndex = 0; captureIndex < 5; captureIndex += 1) {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-artifacts.test.ts
@@ -212,6 +212,34 @@ describe('RsbWebviewArtifacts', () => {
     expect(fs.existsSync(item.savedPath())).toBe(false);
   });
 
+  it('counts streaming bytes beyond a declared total toward the capture quota', async () => {
+    const harness = artifactHarness();
+    const items = Array.from({ length: 4 }, () => (
+      downloadItem('completed', { totalBytes: 16 * 1024 * 1024 })
+    ));
+    const artifacts = new RsbWebviewArtifacts(() => root, { warn: vi.fn() });
+
+    const result = await artifacts.capture(
+      harness.wc,
+      { sessionId: 'quota-known-total-overrun', timeoutMs: 1000 },
+      async () => {
+        for (const item of items) harness.emitDownload(item);
+        items[3].update(17 * 1024 * 1024);
+        setTimeout(() => {
+          for (const item of items) item.finish();
+        }, 0);
+      },
+    );
+
+    expect(items[3].cancel).toHaveBeenCalledTimes(1);
+    expect(result.downloads.map((artifact) => artifact.state)).toEqual([
+      'completed',
+      'completed',
+      'completed',
+      'cancelled',
+    ]);
+  });
+
   it('bounds both download count and total bytes for one action', async () => {
     const harness = artifactHarness();
     const items = Array.from({ length: 9 }, () => (

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -275,6 +275,49 @@ describe('RsbWebviewAutomation act', () => {
     expect(harness.sendCommand).toHaveBeenCalledWith('Emulation.clearDeviceMetricsOverride');
   });
 
+  it('sets validated files on a resolved file input', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'file-input' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 12 } };
+      if (method === 'Runtime.callFunctionOn') {
+        return { result: { value: { ok: true, multiple: true } } };
+      }
+      if (method === 'DOM.setFileInputFiles') return {};
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().setFiles('tab-1', harness.wc, {
+      paths: ['C:\\safe\\one.txt', 'C:\\safe\\two.txt'],
+      query: { label: 'Attachments' },
+    });
+
+    expect(result).toEqual({ tabId: 'tab-1', uploadedFiles: 2 });
+    expect(harness.sendCommand).toHaveBeenCalledWith('DOM.setFileInputFiles', {
+      files: ['C:\\safe\\one.txt', 'C:\\safe\\two.txt'],
+      objectId: 'file-input',
+    });
+  });
+
+  it('does not place multiple files into a single-file input', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'file-input' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 12 } };
+      if (method === 'Runtime.callFunctionOn') {
+        return { result: { value: { ok: true, multiple: false } } };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    await expect(automation().setFiles('tab-1', harness.wc, {
+      paths: ['C:\\safe\\one.txt', 'C:\\safe\\two.txt'],
+      element: 'input[type=file]',
+    })).rejects.toThrow('accepts only one file');
+    expect(harness.sendCommand).not.toHaveBeenCalledWith(
+      'DOM.setFileInputFiles',
+      expect.anything(),
+    );
+  });
+
   it('dispatches coordinate clicks without requiring a snapshot', async () => {
     const harness = debuggerHarness(async (method) => {
       throw new Error(`unexpected command: ${method}`);

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -120,6 +120,84 @@ describe('RsbWebviewAutomation snapshot', () => {
       { backendNodeId: 2, fetchRelatives: false },
     );
   });
+
+  it('returns a bounded resource list and authorizes only the latest snapshot URLs', async () => {
+    const instance = automation();
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Runtime.evaluate') {
+        expect(params?.expression).toContain('document.querySelectorAll');
+        return {
+          result: {
+            value: {
+              resources: [
+                {
+                  kind: 'image',
+                  url: 'https://cdn.example.test/image.png',
+                  label: 'Preview',
+                },
+              ],
+            },
+          },
+        };
+      }
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') return AX_TREE;
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await instance.snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      urls: true,
+    });
+
+    expect(result.resources).toEqual([
+      {
+        kind: 'image',
+        url: 'https://cdn.example.test/image.png',
+        label: 'Preview',
+      },
+    ]);
+    expect(() => instance.assertResource(
+      'tab-1',
+      'https://cdn.example.test/image.png',
+    )).not.toThrow();
+    expect(() => instance.assertResource(
+      'tab-1',
+      'https://other.example.test/file.zip',
+    )).toThrow('not present in the latest page resource list');
+  });
+
+  it('returns a structured verification barrier without creating action refs', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Runtime.evaluate') {
+        return {
+          result: {
+            value: {
+              resources: [],
+              barrier: {
+                kind: 'human-verification',
+                evidence: ['page contains a verification control'],
+              },
+            },
+          },
+        };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+    });
+
+    expect(result).toMatchObject({
+      barrier: {
+        kind: 'human-verification',
+        evidence: ['page contains a verification control'],
+      },
+      stats: { refs: 0, interactive: 0 },
+    });
+    expect(harness.sendCommand).not.toHaveBeenCalledWith('Accessibility.enable');
+  });
 });
 
 describe('RsbWebviewAutomation act', () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -230,6 +230,58 @@ describe('RsbWebviewAutomation act', () => {
     expect(harness.executeJavaScript.mock.calls[0][0]).toContain('"type":"validate"');
   });
 
+  it('scopes snapshots to the requested frame', async () => {
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'frame-object' } };
+      if (method === 'DOM.describeNode') {
+        expect(params).toMatchObject({ backendNodeId: 20, depth: 1 });
+        return {
+          node: {
+            frameId: 'frame-owner',
+            contentDocument: { frameId: 'frame-document', nodeId: 21 },
+          },
+        };
+      }
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') {
+        expect(params).toEqual({ frameId: 'frame-document' });
+        return AX_TREE;
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+    harness.sendCommand.mockImplementation(async (method, params) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'frame-object' } };
+      if (method === 'DOM.describeNode' && params?.objectId === 'frame-object') {
+        return { node: { backendNodeId: 20 } };
+      }
+      if (method === 'DOM.describeNode' && params?.backendNodeId === 20) {
+        return {
+          node: {
+            frameId: 'frame-owner',
+            contentDocument: { frameId: 'frame-document', nodeId: 21 },
+          },
+        };
+      }
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') {
+        expect(params).toEqual({ frameId: 'frame-document' });
+        return AX_TREE;
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      frame: 'iframe#widget',
+    });
+
+    expect(result).toMatchObject({ stats: { refs: 2 } });
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Accessibility.getFullAXTree',
+      { frameId: 'frame-document' },
+    );
+  });
+
   it('clicks a snapshot ref at the center of its DOM box', async () => {
     const instance = automation();
     let phase: 'snapshot' | 'click' = 'snapshot';
@@ -306,6 +358,51 @@ describe('RsbWebviewAutomation act', () => {
       expect.stringMatching(/^Input\./),
       expect.anything(),
     );
+  });
+
+  it('fills browser-native date inputs', async () => {
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'date-input' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 6 } };
+      if (method === 'Runtime.callFunctionOn') {
+        if (String(params?.functionDeclaration).includes('requireEditable')) {
+          expect(String(params?.functionDeclaration)).toContain('"date", "datetime-local"');
+        }
+        return { result: { value: { ok: true } } };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().act('tab-1', harness.wc, {
+      kind: 'fill',
+      selector: 'input[type=date]',
+      text: '2026-07-27',
+    });
+
+    expect(result).toMatchObject({ kind: 'fill', textLength: 10 });
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
+      '["date", "datetime-local", "month", "time", "week"]',
+    );
+  });
+
+  it('hovers without focusing the target', async () => {
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'hover-target' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 9 } };
+      if (method === 'Runtime.callFunctionOn') {
+        expect(String(params?.functionDeclaration)).not.toContain('this.focus()');
+        return { result: { value: { ok: true } } };
+      }
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [0, 0, 20, 0, 20, 10, 0, 10] } };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    await expect(automation().act('tab-1', harness.wc, {
+      kind: 'hover',
+      selector: '#hover-target',
+    })).resolves.toMatchObject({ kind: 'hover', x: 10, y: 5 });
   });
 
   it('resolves a semantic query and waits for an actionable target', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -6,9 +6,9 @@ import { RsbWebviewAutomation } from '../rsb-webview-automation.js';
 interface DebuggerHarness {
   wc: WebContents;
   sendCommand: ReturnType<typeof vi.fn>;
+  executeJavaScript: ReturnType<typeof vi.fn>;
   attach: ReturnType<typeof vi.fn>;
   detach: ReturnType<typeof vi.fn>;
-  focus: ReturnType<typeof vi.fn>;
 }
 
 function debuggerHarness(
@@ -22,11 +22,11 @@ function debuggerHarness(
   const detach = vi.fn(() => {
     attached = false;
   });
-  const focus = vi.fn();
   const sendCommand = vi.fn(handler);
+  const executeJavaScript = vi.fn(async () => ({ ok: true }));
   const wc = {
     getURL: () => 'https://example.test/form',
-    focus,
+    executeJavaScript,
     debugger: {
       isAttached: vi.fn(() => attached),
       attach,
@@ -34,7 +34,7 @@ function debuggerHarness(
       sendCommand,
     },
   } as unknown as WebContents;
-  return { wc, sendCommand, attach, detach, focus };
+  return { wc, sendCommand, executeJavaScript, attach, detach };
 }
 
 function automation(): RsbWebviewAutomation {
@@ -136,7 +136,6 @@ describe('RsbWebviewAutomation act', () => {
         if (method === 'DOM.getBoxModel') {
           return { model: { content: [10, 20, 30, 20, 30, 40, 10, 40] } };
         }
-        if (method === 'Input.dispatchMouseEvent') return {};
       }
       throw new Error(`unexpected command during ${phase}: ${method}`);
     });
@@ -153,14 +152,19 @@ describe('RsbWebviewAutomation act', () => {
     });
 
     expect(result).toMatchObject({ tabId: 'tab-1', kind: 'click', x: 20, y: 30 });
-    expect(harness.sendCommand).toHaveBeenCalledWith(
+    expect(harness.sendCommand).not.toHaveBeenCalledWith(
       'Input.dispatchMouseEvent',
-      expect.objectContaining({ type: 'mousePressed', x: 20, y: 30, button: 'left' }),
+      expect.anything(),
     );
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Input.dispatchMouseEvent',
-      expect.objectContaining({ type: 'mouseReleased', x: 20, y: 30, button: 'left' }),
+    expect(harness.executeJavaScript).toHaveBeenCalledTimes(2);
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
+      '"method":"Input.dispatchMouseEvent","params":{"type":"mousePressed"',
     );
+    expect(harness.executeJavaScript.mock.calls[0][1]).toBe(false);
+    expect(harness.executeJavaScript.mock.calls[1][0]).toContain(
+      '"method":"Input.dispatchMouseEvent","params":{"type":"mouseReleased"',
+    );
+    expect(harness.executeJavaScript.mock.calls[1][1]).toBe(true);
   });
 
   it('types into a selector and optionally submits', async () => {
@@ -168,7 +172,6 @@ describe('RsbWebviewAutomation act', () => {
       if (method === 'Runtime.evaluate') return { result: { objectId: 'input-object' } };
       if (method === 'DOM.describeNode') return { node: { backendNodeId: 5 } };
       if (method === 'Runtime.callFunctionOn') return { result: { value: { ok: true } } };
-      if (method === 'Input.insertText' || method === 'Input.dispatchKeyEvent') return {};
       throw new Error(`unexpected command: ${method}`);
     });
 
@@ -184,25 +187,21 @@ describe('RsbWebviewAutomation act', () => {
       kind: 'type',
       textLength: 18,
     });
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Input.insertText',
-      { text: 'hello@example.test' },
+    expect(harness.executeJavaScript).toHaveBeenCalledTimes(3);
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
+      '"method":"Input.insertText","params":{"text":"hello@example.test"}',
     );
-    expect(harness.focus).toHaveBeenCalledTimes(1);
-    expect(harness.focus.mock.invocationCallOrder[0]).toBeLessThan(
-      harness.sendCommand.mock.invocationCallOrder.find(
-        (_order, index) => harness.sendCommand.mock.calls[index]?.[0] === 'Input.insertText',
-      ) ?? Number.POSITIVE_INFINITY,
+    expect(harness.executeJavaScript.mock.calls[1][0]).toContain(
+      '"method":"Input.dispatchKeyEvent","params":{"type":"keyDown","key":"Enter"',
     );
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Input.dispatchKeyEvent',
-      expect.objectContaining({ type: 'keyDown', key: 'Enter' }),
+    expect(harness.sendCommand).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^Input\./),
+      expect.anything(),
     );
   });
 
   it('dispatches coordinate clicks without requiring a snapshot', async () => {
     const harness = debuggerHarness(async (method) => {
-      if (method === 'Input.dispatchMouseEvent') return {};
       throw new Error(`unexpected command: ${method}`);
     });
 
@@ -214,9 +213,11 @@ describe('RsbWebviewAutomation act', () => {
     });
 
     expect(result).toMatchObject({ kind: 'clickCoords', x: 12.5, y: 24 });
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Input.dispatchMouseEvent',
-      expect.objectContaining({ type: 'mousePressed', button: 'right' }),
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
+      '"method":"Input.dispatchMouseEvent","params":{"type":"mousePressed"',
+    );
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
+      '"button":"right"',
     );
   });
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -115,10 +115,13 @@ describe('RsbWebviewAutomation snapshot', () => {
 
     expect(result.format).toBe('aria');
     expect(result.nodes).toHaveLength(1);
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Accessibility.getPartialAXTree',
-      { backendNodeId: 2, fetchRelatives: true },
-    );
+    expect(harness.sendCommand).toHaveBeenCalledWith('Accessibility.getPartialAXTree', {
+      backendNodeId: 2,
+      fetchRelatives: true,
+    });
+    expect(harness.sendCommand).toHaveBeenCalledWith('Runtime.releaseObject', {
+      objectId: 'selector-object',
+    });
   });
 
   it('returns a bounded resource list and authorizes only the latest snapshot URLs', async () => {
@@ -157,14 +160,12 @@ describe('RsbWebviewAutomation snapshot', () => {
         label: 'Preview',
       },
     ]);
-    expect(() => instance.assertResource(
-      'tab-1',
-      'https://cdn.example.test/image.png',
-    )).not.toThrow();
-    expect(() => instance.assertResource(
-      'tab-1',
-      'https://other.example.test/file.zip',
-    )).toThrow('not present in the latest page resource list');
+    expect(() =>
+      instance.assertResource('tab-1', 'https://cdn.example.test/image.png'),
+    ).not.toThrow();
+    expect(() => instance.assertResource('tab-1', 'https://other.example.test/file.zip')).toThrow(
+      'not present in the latest page resource list',
+    );
   });
 
   it('returns a structured verification barrier without creating action refs', async () => {
@@ -206,10 +207,12 @@ describe('RsbWebviewAutomation act', () => {
       throw new Error('query should fail before debugger evaluation');
     });
 
-    await expect(automation().act('tab-1', harness.wc, {
-      kind: 'click',
-      query: { role: 'button', index: -1 },
-    })).rejects.toThrow('element query index must be a non-negative integer');
+    await expect(
+      automation().act('tab-1', harness.wc, {
+        kind: 'click',
+        query: { role: 'button', index: -1 },
+      }),
+    ).rejects.toThrow('element query index must be a non-negative integer');
     expect(harness.sendCommand).not.toHaveBeenCalled();
   });
 
@@ -220,14 +223,19 @@ describe('RsbWebviewAutomation act', () => {
     const sendInputEvent = vi.fn();
     Object.assign(harness.wc, { sendInputEvent });
 
-    await automation().act('tab-1', harness.wc, {
-      kind: 'press',
-      key: 'Ctrl+A',
-    }, {
-      nativeKeyDispatch: async (type, keyCode, modifiers) => {
-        sendInputEvent({ type, keyCode, modifiers });
+    await automation().act(
+      'tab-1',
+      harness.wc,
+      {
+        kind: 'press',
+        key: 'Ctrl+A',
       },
-    });
+      {
+        nativeKeyDispatch: async (type, keyCode, modifiers) => {
+          sendInputEvent({ type, keyCode, modifiers });
+        },
+      },
+    );
 
     expect(sendInputEvent).toHaveBeenNthCalledWith(1, {
       type: 'keyDown',
@@ -272,10 +280,12 @@ describe('RsbWebviewAutomation act', () => {
     expect(efficient.snapshot).toContain('[ref=e1]');
     expect(efficient.stats.lines).toBeGreaterThan(0);
 
-    await expect(automation().snapshot('tab-1', harness.wc, {
-      action: 'snapshot',
-      labels: true,
-    })).rejects.toThrow('snapshot labels are unavailable');
+    await expect(
+      automation().snapshot('tab-1', harness.wc, {
+        action: 'snapshot',
+        labels: true,
+      }),
+    ).rejects.toThrow('snapshot labels are unavailable');
   });
 
   it('scopes snapshots to the requested frame', async () => {
@@ -324,10 +334,9 @@ describe('RsbWebviewAutomation act', () => {
     });
 
     expect(result).toMatchObject({ stats: { refs: 2 } });
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Accessibility.getFullAXTree',
-      { frameId: 'frame-document' },
-    );
+    expect(harness.sendCommand).toHaveBeenCalledWith('Accessibility.getFullAXTree', {
+      frameId: 'frame-document',
+    });
   });
 
   it('clicks a snapshot ref at the center of its DOM box', async () => {
@@ -372,6 +381,10 @@ describe('RsbWebviewAutomation act', () => {
       '"method":"Input.dispatchMouseEvent","params":{"type":"mouseReleased"',
     );
     expect(harness.executeJavaScript.mock.calls[1][1]).toBe(true);
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Runtime.releaseObject',
+      { objectId: 'button-object' },
+    );
   });
 
   it('types into a selector and optionally submits', async () => {
@@ -383,8 +396,8 @@ describe('RsbWebviewAutomation act', () => {
         return {
           result: {
             value:
-              declaration.includes('options.editable')
-              || declaration.includes('function(requireEditable)')
+              declaration.includes('options.editable') ||
+              declaration.includes('function(requireEditable)')
                 ? { ok: true }
                 : false,
           },
@@ -407,9 +420,7 @@ describe('RsbWebviewAutomation act', () => {
     });
     expect(harness.executeJavaScript).toHaveBeenCalledTimes(3);
     const insertTextCall = harness.executeJavaScript.mock.calls.find(([script]) =>
-      String(script).includes(
-        '"method":"Input.insertText","params":{"text":"hello@example.test"}',
-      ),
+      String(script).includes('"method":"Input.insertText","params":{"text":"hello@example.test"}'),
     );
     expect(insertTextCall?.[0]).toContain('"targetTicket":"rsb-');
     const enterKeyDownCall = harness.executeJavaScript.mock.calls.find(([script]) =>
@@ -444,10 +455,12 @@ describe('RsbWebviewAutomation act', () => {
     });
 
     expect(result).toMatchObject({ kind: 'fill', textLength: 10 });
-    const fillCall = harness.sendCommand.mock.calls.find(([method, params]) =>
-      method === 'Runtime.callFunctionOn'
-      && String((params as { functionDeclaration?: unknown })?.functionDeclaration)
-        .includes('const type ='),
+    const fillCall = harness.sendCommand.mock.calls.find(
+      ([method, params]) =>
+        method === 'Runtime.callFunctionOn' &&
+        String((params as { functionDeclaration?: unknown })?.functionDeclaration).includes(
+          'const type =',
+        ),
     );
     expect(fillCall?.[1]).toMatchObject({
       arguments: [{ value: '2026-07-27' }, { value: undefined }],
@@ -483,6 +496,14 @@ describe('RsbWebviewAutomation act', () => {
     });
 
     expect(result).toMatchObject({ kind: 'fill', filled: 1 });
+    const fillCall = harness.sendCommand.mock.calls.find(
+      ([method, params]) =>
+        method === 'Runtime.callFunctionOn' &&
+        String((params as { functionDeclaration?: string })?.functionDeclaration).includes(
+          'HTMLInputElement.prototype',
+        ),
+    );
+    expect(fillCall).toBeDefined();
   });
 
   it('hovers without focusing the target', async () => {
@@ -499,10 +520,12 @@ describe('RsbWebviewAutomation act', () => {
       throw new Error(`unexpected command: ${method}`);
     });
 
-    await expect(automation().act('tab-1', harness.wc, {
-      kind: 'hover',
-      selector: '#hover-target',
-    })).resolves.toMatchObject({ kind: 'hover', x: 10, y: 5 });
+    await expect(
+      automation().act('tab-1', harness.wc, {
+        kind: 'hover',
+        selector: '#hover-target',
+      }),
+    ).resolves.toMatchObject({ kind: 'hover', x: 10, y: 5 });
   });
 
   it('resolves a semantic query and waits for an actionable target', async () => {
@@ -527,12 +550,14 @@ describe('RsbWebviewAutomation act', () => {
     });
 
     expect(result).toMatchObject({ kind: 'click', x: 10, y: 5 });
-    const pageCalls = harness.sendCommand.mock.calls.filter(([method]) =>
-      method === 'Runtime.callFunctionOn'
+    const pageCalls = harness.sendCommand.mock.calls.filter(
+      ([method]) => method === 'Runtime.callFunctionOn',
     );
-    expect(pageCalls.some(([, params]) =>
-      String(params?.functionDeclaration).includes('target is not visible')
-    )).toBe(true);
+    expect(
+      pageCalls.some(([, params]) =>
+        String(params?.functionDeclaration).includes('target is not visible'),
+      ),
+    ).toBe(true);
   });
 
   it('surfaces page-side query failures before attempting input', async () => {
@@ -548,10 +573,12 @@ describe('RsbWebviewAutomation act', () => {
       throw new Error(`unexpected command: ${method}`);
     });
 
-    await expect(automation().act('tab-1', harness.wc, {
-      kind: 'click',
-      query: { role: 'button', name: 'Continue' },
-    })).rejects.toThrow('element query matched 2 elements; provide index');
+    await expect(
+      automation().act('tab-1', harness.wc, {
+        kind: 'click',
+        query: { role: 'button', name: 'Continue' },
+      }),
+    ).rejects.toThrow('element query matched 2 elements; provide index');
     expect(harness.executeJavaScript).not.toHaveBeenCalled();
   });
 
@@ -560,10 +587,12 @@ describe('RsbWebviewAutomation act', () => {
       throw new Error(`unexpected command: ${method}`);
     });
 
-    await expect(automation().act('tab-1', harness.wc, {
-      kind: 'click',
-      query: { exact: true, index: 0 },
-    })).rejects.toThrow('element query requires at least one field');
+    await expect(
+      automation().act('tab-1', harness.wc, {
+        kind: 'click',
+        query: { exact: true, index: 0 },
+      }),
+    ).rejects.toThrow('element query requires at least one field');
     expect(harness.sendCommand).not.toHaveBeenCalled();
   });
 
@@ -612,10 +641,12 @@ describe('RsbWebviewAutomation act', () => {
       throw new Error(`unexpected command: ${method}`);
     });
 
-    await expect(automation().setFiles('tab-1', harness.wc, {
-      paths: ['C:\\safe\\one.txt', 'C:\\safe\\two.txt'],
-      element: 'input[type=file]',
-    })).rejects.toThrow('accepts only one file');
+    await expect(
+      automation().setFiles('tab-1', harness.wc, {
+        paths: ['C:\\safe\\one.txt', 'C:\\safe\\two.txt'],
+        element: 'input[type=file]',
+      }),
+    ).rejects.toThrow('accepts only one file');
     expect(harness.sendCommand).not.toHaveBeenCalledWith(
       'DOM.setFileInputFiles',
       expect.anything(),
@@ -638,9 +669,7 @@ describe('RsbWebviewAutomation act', () => {
     expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
       '"method":"Input.dispatchMouseEvent","params":{"type":"mousePressed"',
     );
-    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
-      '"button":"right"',
-    );
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain('"button":"right"');
   });
 
   it('waits for page conditions inside the guest and returns observed state', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -230,6 +230,22 @@ describe('RsbWebviewAutomation act', () => {
     expect(harness.executeJavaScript.mock.calls[0][0]).toContain('"type":"validate"');
   });
 
+  it('treats maxChars zero as unlimited', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') return AX_TREE;
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      maxChars: 0,
+    });
+
+    expect(result.snapshot).toContain('[ref=e1]');
+    expect(result.stats.lines).toBeGreaterThan(0);
+  });
+
   it('scopes snapshots to the requested frame', async () => {
     const harness = debuggerHarness(async (method, params) => {
       if (method === 'Runtime.evaluate') return { result: { objectId: 'frame-object' } };

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -380,9 +380,45 @@ describe('RsbWebviewAutomation act', () => {
     });
 
     expect(result).toMatchObject({ kind: 'fill', textLength: 10 });
-    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
-      '["date", "datetime-local", "month", "time", "week"]',
+    const fillCall = harness.sendCommand.mock.calls.find(([method, params]) =>
+      method === 'Runtime.callFunctionOn'
+      && String((params as { functionDeclaration?: unknown })?.functionDeclaration)
+        .includes('const type ='),
     );
+    expect(fillCall?.[1]).toMatchObject({
+      arguments: [{ value: '2026-07-27' }, { value: undefined }],
+    });
+    expect(fillCall).toBeDefined();
+  });
+
+  it('fills the shared multi-field form shape', async () => {
+    const instance = automation();
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'field-object' } };
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') return AX_TREE;
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 6 } };
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'field-object' } };
+      if (method === 'Runtime.callFunctionOn') {
+        if (String(params?.functionDeclaration).includes('const type =')) {
+          expect(params?.arguments).toEqual([{ value: 'Ada' }, { value: 'text' }]);
+          return { result: { value: undefined } };
+        }
+        return { result: { value: { ok: true } } };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    await instance.snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      interactive: true,
+    });
+    const result = await instance.act('tab-1', harness.wc, {
+      kind: 'fill',
+      fields: [{ ref: 'e2', type: 'text', value: 'Ada' }],
+    });
+
+    expect(result).toMatchObject({ kind: 'fill', filled: 1 });
   });
 
   it('hovers without focusing the target', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -8,6 +8,7 @@ interface DebuggerHarness {
   sendCommand: ReturnType<typeof vi.fn>;
   attach: ReturnType<typeof vi.fn>;
   detach: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
 }
 
 function debuggerHarness(
@@ -21,9 +22,11 @@ function debuggerHarness(
   const detach = vi.fn(() => {
     attached = false;
   });
+  const focus = vi.fn();
   const sendCommand = vi.fn(handler);
   const wc = {
     getURL: () => 'https://example.test/form',
+    focus,
     debugger: {
       isAttached: vi.fn(() => attached),
       attach,
@@ -31,7 +34,7 @@ function debuggerHarness(
       sendCommand,
     },
   } as unknown as WebContents;
-  return { wc, sendCommand, attach, detach };
+  return { wc, sendCommand, attach, detach, focus };
 }
 
 function automation(): RsbWebviewAutomation {
@@ -184,6 +187,12 @@ describe('RsbWebviewAutomation act', () => {
     expect(harness.sendCommand).toHaveBeenCalledWith(
       'Input.insertText',
       { text: 'hello@example.test' },
+    );
+    expect(harness.focus).toHaveBeenCalledTimes(1);
+    expect(harness.focus.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.sendCommand.mock.invocationCallOrder.find(
+        (_order, index) => harness.sendCommand.mock.calls[index]?.[0] === 'Input.insertText',
+      ) ?? Number.POSITIVE_INFINITY,
     );
     expect(harness.sendCommand).toHaveBeenCalledWith(
       'Input.dispatchKeyEvent',

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -191,6 +191,7 @@ describe('RsbWebviewAutomation act', () => {
     expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
       '"method":"Input.insertText","params":{"text":"hello@example.test"}',
     );
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain('"targetTicket":"rsb-');
     expect(harness.executeJavaScript.mock.calls[1][0]).toContain(
       '"method":"Input.dispatchKeyEvent","params":{"type":"keyDown","key":"Enter"',
     );
@@ -198,6 +199,80 @@ describe('RsbWebviewAutomation act', () => {
       expect.stringMatching(/^Input\./),
       expect.anything(),
     );
+  });
+
+  it('resolves a semantic query and waits for an actionable target', async () => {
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Runtime.evaluate') {
+        expect(params?.expression).toContain('"role":"button"');
+        expect(params?.expression).toContain('"name":"Continue"');
+        return { result: { objectId: 'button-object' } };
+      }
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 7 } };
+      if (method === 'Runtime.callFunctionOn') return { result: { value: { ok: true } } };
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [0, 0, 20, 0, 20, 10, 0, 10] } };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().act('tab-1', harness.wc, {
+      kind: 'click',
+      query: { role: 'button', name: 'Continue', exact: true },
+      timeoutMs: 750,
+    });
+
+    expect(result).toMatchObject({ kind: 'click', x: 10, y: 5 });
+    const pageCalls = harness.sendCommand.mock.calls.filter(([method]) =>
+      method === 'Runtime.callFunctionOn'
+    );
+    expect(pageCalls.some(([, params]) =>
+      String(params?.functionDeclaration).includes('target is not visible')
+    )).toBe(true);
+  });
+
+  it('surfaces page-side query failures before attempting input', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Runtime.evaluate') {
+        return {
+          result: { subtype: 'error' },
+          exceptionDetails: {
+            exception: { description: 'Error: element query matched 2 elements; provide index' },
+          },
+        };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    await expect(automation().act('tab-1', harness.wc, {
+      kind: 'click',
+      query: { role: 'button', name: 'Continue' },
+    })).rejects.toThrow('element query matched 2 elements; provide index');
+    expect(harness.executeJavaScript).not.toHaveBeenCalled();
+  });
+
+  it('rejects query options that do not identify an element', async () => {
+    const harness = debuggerHarness(async (method) => {
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    await expect(automation().act('tab-1', harness.wc, {
+      kind: 'click',
+      query: { exact: true, index: 0 },
+    })).rejects.toThrow('element query requires at least one field');
+    expect(harness.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('resets an overridden viewport when resize omits dimensions', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Emulation.clearDeviceMetricsOverride') return {};
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().act('tab-1', harness.wc, { kind: 'resize' });
+
+    expect(result).toMatchObject({ kind: 'resize', reset: true });
+    expect(harness.sendCommand).toHaveBeenCalledWith('Emulation.clearDeviceMetricsOverride');
   });
 
   it('dispatches coordinate clicks without requiring a snapshot', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -117,7 +117,7 @@ describe('RsbWebviewAutomation snapshot', () => {
     expect(result.nodes).toHaveLength(1);
     expect(harness.sendCommand).toHaveBeenCalledWith(
       'Accessibility.getPartialAXTree',
-      { backendNodeId: 2, fetchRelatives: false },
+      { backendNodeId: 2, fetchRelatives: true },
     );
   });
 
@@ -375,10 +375,21 @@ describe('RsbWebviewAutomation act', () => {
   });
 
   it('types into a selector and optionally submits', async () => {
-    const harness = debuggerHarness(async (method) => {
+    const harness = debuggerHarness(async (method, params) => {
       if (method === 'Runtime.evaluate') return { result: { objectId: 'input-object' } };
       if (method === 'DOM.describeNode') return { node: { backendNodeId: 5 } };
-      if (method === 'Runtime.callFunctionOn') return { result: { value: { ok: true } } };
+      if (method === 'Runtime.callFunctionOn') {
+        const declaration = String(params?.functionDeclaration ?? '');
+        return {
+          result: {
+            value:
+              declaration.includes('options.editable')
+              || declaration.includes('function(requireEditable)')
+                ? { ok: true }
+                : false,
+          },
+        };
+      }
       throw new Error(`unexpected command: ${method}`);
     });
 
@@ -395,13 +406,18 @@ describe('RsbWebviewAutomation act', () => {
       textLength: 18,
     });
     expect(harness.executeJavaScript).toHaveBeenCalledTimes(3);
-    expect(harness.executeJavaScript.mock.calls[0][0]).toContain(
-      '"method":"Input.insertText","params":{"text":"hello@example.test"}',
+    const insertTextCall = harness.executeJavaScript.mock.calls.find(([script]) =>
+      String(script).includes(
+        '"method":"Input.insertText","params":{"text":"hello@example.test"}',
+      ),
     );
-    expect(harness.executeJavaScript.mock.calls[0][0]).toContain('"targetTicket":"rsb-');
-    expect(harness.executeJavaScript.mock.calls[1][0]).toContain(
-      '"method":"Input.dispatchKeyEvent","params":{"type":"keyDown","key":"Enter"',
+    expect(insertTextCall?.[0]).toContain('"targetTicket":"rsb-');
+    const enterKeyDownCall = harness.executeJavaScript.mock.calls.find(([script]) =>
+      String(script).includes(
+        '"method":"Input.dispatchKeyEvent","params":{"type":"keyDown","key":"Enter"',
+      ),
     );
+    expect(enterKeyDownCall).toBeDefined();
     expect(harness.sendCommand).not.toHaveBeenCalledWith(
       expect.stringMatching(/^Input\./),
       expect.anything(),

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -201,6 +201,35 @@ describe('RsbWebviewAutomation snapshot', () => {
 });
 
 describe('RsbWebviewAutomation act', () => {
+  it('uses native keyboard input for browser-default navigation keys', async () => {
+    const harness = debuggerHarness(async () => {
+      throw new Error('unexpected debugger command');
+    });
+    const sendInputEvent = vi.fn();
+    Object.assign(harness.wc, { sendInputEvent });
+
+    await automation().act('tab-1', harness.wc, {
+      kind: 'press',
+      key: 'Ctrl+A',
+    }, {
+      nativeKeyDispatch: async (type, keyCode, modifiers) => {
+        sendInputEvent({ type, keyCode, modifiers });
+      },
+    });
+
+    expect(sendInputEvent).toHaveBeenNthCalledWith(1, {
+      type: 'keyDown',
+      keyCode: 'A',
+      modifiers: ['control'],
+    });
+    expect(sendInputEvent).toHaveBeenNthCalledWith(2, {
+      type: 'keyUp',
+      keyCode: 'A',
+      modifiers: ['control'],
+    });
+    expect(harness.executeJavaScript.mock.calls[0][0]).toContain('"type":"validate"');
+  });
+
   it('clicks a snapshot ref at the center of its DOM box', async () => {
     const instance = automation();
     let phase: 'snapshot' | 'click' = 'snapshot';

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -201,6 +201,18 @@ describe('RsbWebviewAutomation snapshot', () => {
 });
 
 describe('RsbWebviewAutomation act', () => {
+  it('rejects negative element query indexes before polling the page', async () => {
+    const harness = debuggerHarness(async () => {
+      throw new Error('query should fail before debugger evaluation');
+    });
+
+    await expect(automation().act('tab-1', harness.wc, {
+      kind: 'click',
+      query: { role: 'button', index: -1 },
+    })).rejects.toThrow('element query index must be a non-negative integer');
+    expect(harness.sendCommand).not.toHaveBeenCalled();
+  });
+
   it('uses native keyboard input for browser-default navigation keys', async () => {
     const harness = debuggerHarness(async () => {
       throw new Error('unexpected debugger command');
@@ -244,6 +256,26 @@ describe('RsbWebviewAutomation act', () => {
 
     expect(result.snapshot).toContain('[ref=e1]');
     expect(result.stats.lines).toBeGreaterThan(0);
+  });
+
+  it('applies efficient snapshot defaults and rejects unsupported labels', async () => {
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') return AX_TREE;
+      throw new Error(`unexpected command: ${method} ${JSON.stringify(params)}`);
+    });
+
+    const efficient = await automation().snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      mode: 'efficient',
+    });
+    expect(efficient.snapshot).toContain('[ref=e1]');
+    expect(efficient.stats.lines).toBeGreaterThan(0);
+
+    await expect(automation().snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      labels: true,
+    })).rejects.toThrow('snapshot labels are unavailable');
   });
 
   it('scopes snapshots to the requested frame', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-automation.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WebContents } from 'electron';
+
+import { RsbWebviewAutomation } from '../rsb-webview-automation.js';
+
+interface DebuggerHarness {
+  wc: WebContents;
+  sendCommand: ReturnType<typeof vi.fn>;
+  attach: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
+}
+
+function debuggerHarness(
+  handler: (method: string, params?: Record<string, unknown>) => unknown | Promise<unknown>,
+  alreadyAttached = false,
+): DebuggerHarness {
+  let attached = alreadyAttached;
+  const attach = vi.fn(() => {
+    attached = true;
+  });
+  const detach = vi.fn(() => {
+    attached = false;
+  });
+  const sendCommand = vi.fn(handler);
+  const wc = {
+    getURL: () => 'https://example.test/form',
+    debugger: {
+      isAttached: vi.fn(() => attached),
+      attach,
+      detach,
+      sendCommand,
+    },
+  } as unknown as WebContents;
+  return { wc, sendCommand, attach, detach };
+}
+
+function automation(): RsbWebviewAutomation {
+  return new RsbWebviewAutomation({ warn: vi.fn() });
+}
+
+const AX_TREE = {
+  nodes: [
+    {
+      nodeId: 'root',
+      role: { value: 'RootWebArea' },
+      name: { value: 'Example' },
+      backendDOMNodeId: 1,
+      childIds: ['button', 'textbox'],
+    },
+    {
+      nodeId: 'button',
+      role: { value: 'button' },
+      name: { value: 'Submit' },
+      backendDOMNodeId: 2,
+      childIds: [],
+    },
+    {
+      nodeId: 'textbox',
+      role: { value: 'textbox' },
+      name: { value: 'Email' },
+      value: { value: 'old@example.test' },
+      backendDOMNodeId: 3,
+      childIds: [],
+    },
+  ],
+};
+
+describe('RsbWebviewAutomation snapshot', () => {
+  it('builds an AI role snapshot with actionable refs and releases its debugger', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') return AX_TREE;
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      interactive: true,
+    });
+
+    expect(result).toMatchObject({
+      format: 'ai',
+      targetId: 'tab-1',
+      url: 'https://example.test/form',
+      refs: {
+        e1: { role: 'button', name: 'Submit', backendDOMNodeId: 2 },
+        e2: { role: 'textbox', name: 'Email', backendDOMNodeId: 3 },
+      },
+      stats: { refs: 2, interactive: 2 },
+    });
+    expect(result.snapshot).toContain('- button "Submit" [ref=e1]');
+    expect(result.snapshot).toContain('- textbox "Email" [ref=e2]');
+    expect(harness.attach).toHaveBeenCalledWith('1.3');
+    expect(harness.detach).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports aria output, selector scoping and limits', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'selector-object' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 2 } };
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getPartialAXTree') return AX_TREE;
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      snapshotFormat: 'aria',
+      selector: '#form',
+      limit: 1,
+    });
+
+    expect(result.format).toBe('aria');
+    expect(result.nodes).toHaveLength(1);
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Accessibility.getPartialAXTree',
+      { backendNodeId: 2, fetchRelatives: false },
+    );
+  });
+});
+
+describe('RsbWebviewAutomation act', () => {
+  it('clicks a snapshot ref at the center of its DOM box', async () => {
+    const instance = automation();
+    let phase: 'snapshot' | 'click' = 'snapshot';
+    const harness = debuggerHarness(async (method) => {
+      if (phase === 'snapshot') {
+        if (method === 'Accessibility.enable') return {};
+        if (method === 'Accessibility.getFullAXTree') return AX_TREE;
+      } else {
+        if (method === 'DOM.resolveNode') return { object: { objectId: 'button-object' } };
+        if (method === 'Runtime.callFunctionOn') return { result: { value: { ok: true } } };
+        if (method === 'DOM.getBoxModel') {
+          return { model: { content: [10, 20, 30, 20, 30, 40, 10, 40] } };
+        }
+        if (method === 'Input.dispatchMouseEvent') return {};
+      }
+      throw new Error(`unexpected command during ${phase}: ${method}`);
+    });
+    await instance.snapshot('tab-1', harness.wc, {
+      action: 'snapshot',
+      interactive: true,
+    });
+    phase = 'click';
+    harness.sendCommand.mockClear();
+
+    const result = await instance.act('tab-1', harness.wc, {
+      kind: 'click',
+      ref: 'e1',
+    });
+
+    expect(result).toMatchObject({ tabId: 'tab-1', kind: 'click', x: 20, y: 30 });
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mousePressed', x: 20, y: 30, button: 'left' }),
+    );
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mouseReleased', x: 20, y: 30, button: 'left' }),
+    );
+  });
+
+  it('types into a selector and optionally submits', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'input-object' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 5 } };
+      if (method === 'Runtime.callFunctionOn') return { result: { value: { ok: true } } };
+      if (method === 'Input.insertText' || method === 'Input.dispatchKeyEvent') return {};
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().act('tab-1', harness.wc, {
+      kind: 'type',
+      selector: 'input[type=email]',
+      text: 'hello@example.test',
+      submit: true,
+    });
+
+    expect(result).toMatchObject({
+      tabId: 'tab-1',
+      kind: 'type',
+      textLength: 18,
+    });
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Input.insertText',
+      { text: 'hello@example.test' },
+    );
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Input.dispatchKeyEvent',
+      expect.objectContaining({ type: 'keyDown', key: 'Enter' }),
+    );
+  });
+
+  it('dispatches coordinate clicks without requiring a snapshot', async () => {
+    const harness = debuggerHarness(async (method) => {
+      if (method === 'Input.dispatchMouseEvent') return {};
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().act('tab-1', harness.wc, {
+      kind: 'clickCoords',
+      x: 12.5,
+      y: 24,
+      button: 'right',
+    });
+
+    expect(result).toMatchObject({ kind: 'clickCoords', x: 12.5, y: 24 });
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mousePressed', button: 'right' }),
+    );
+  });
+
+  it('waits for page conditions inside the guest and returns observed state', async () => {
+    const harness = debuggerHarness(async (method, params) => {
+      if (method === 'Runtime.evaluate') {
+        expect(params?.expression).toContain('"selector":"#ready"');
+        return { result: { value: { url: 'https://example.test/form', readyState: 'complete' } } };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+
+    const result = await automation().act('tab-1', harness.wc, {
+      kind: 'wait',
+      selector: '#ready',
+      loadState: 'load',
+      timeoutMs: 500,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'wait',
+      state: { url: 'https://example.test/form', readyState: 'complete' },
+    });
+  });
+
+  it('rejects stale refs and still detaches the debugger', async () => {
+    const harness = debuggerHarness(async () => {
+      throw new Error('sendCommand should not run');
+    });
+
+    await expect(
+      automation().act('tab-1', harness.wc, { kind: 'click', ref: 'e999' }),
+    ).rejects.toThrow(/unknown or stale snapshot ref/);
+    expect(harness.detach).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -405,8 +405,9 @@ describe('RsbWebviewBackend — act:evaluate', () => {
     let attached = false;
     const sendCommand = vi.fn(async (
       method: string,
-      _params?: Record<string, unknown>,
+      params?: Record<string, unknown>,
     ): Promise<unknown> => {
+      void params;
       if (method === 'Runtime.evaluate' || method === 'Runtime.callFunctionOn') {
         return { result: { value: initialReturn } };
       }
@@ -445,7 +446,7 @@ describe('RsbWebviewBackend — act:evaluate', () => {
   }
 
   it('runs the fn in the guest and returns its result + as variable name', async () => {
-    const { backend, wc, sendCommand } = buildEvalEnv({ posts: [1, 2, 3] });
+    const { backend, sendCommand } = buildEvalEnv({ posts: [1, 2, 3] });
     const res = await backend.call({
       action: 'act',
       targetId: 't1',
@@ -1116,7 +1117,7 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
         listener({}, method, params);
       }
     };
-    return { backend, emit, sendCommand, downloadURL, wc, backendLogger };
+    return { backend, emit, sendCommand, downloadURL, wc, backendLogger, registry };
   }
 
   it('validates upload paths before assigning files to the page input', async () => {
@@ -1346,6 +1347,7 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
           dialog: { type: 'confirm', message: 'Continue?' },
         },
       });
+      expect(env.registry.pinHistory).toEqual([{ op: 'pin', tabId: 't1' }]);
       const dialogId = (blocked.data as {
         barrier: { dialog: { id: string } };
       }).barrier.dialog.id;
@@ -1360,6 +1362,15 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
         tabId: 't1',
         armed: true,
         retryRequired: true,
+      });
+      releaseAction();
+      await vi.waitFor(() => {
+        expect(env.registry.pinHistory).toEqual([
+          { op: 'pin', tabId: 't1' },
+          { op: 'pin', tabId: 't1' },
+          { op: 'unpin', tabId: 't1' },
+          { op: 'unpin', tabId: 't1' },
+        ]);
       });
     } finally {
       releaseAction();

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -762,6 +762,27 @@ describe('RsbWebviewBackend — per-action automation pin', () => {
     }
   });
 
+  it('rejects conflicting top-level and nested act targets', async () => {
+    const wc = fakeWc();
+    const { backend, registry } = buildBackend(wc);
+
+    const result = await backend.call({
+      action: 'act',
+      targetId: 't1',
+      request: {
+        kind: 'click',
+        targetId: 't2',
+        selector: '#submit',
+      },
+    } as never);
+
+    expect(result).toMatchObject({
+      ok: false,
+      message: expect.stringContaining('targetId mismatch'),
+    });
+    expect(registry.pinHistory).toEqual([]);
+  });
+
   it('non-tab-scoped actions (tabs / status / profiles / doctor) do not touch pin', async () => {
     const wc = fakeWc();
     const { backend, registry } = buildBackend(wc);
@@ -1557,9 +1578,16 @@ describe('RsbWebviewBackend — network actions', () => {
     });
   });
 
-  it('returns the body of a completed matching response', async () => {
+  it('returns the body of the next completed matching response', async () => {
     const env = buildNetworkEnv();
     await env.backend.call({ action: 'requests', targetId: 't1' } as never);
+    const pending = env.backend.call({
+      action: 'responseBody',
+      targetId: 't1',
+      url: '/api/items',
+      maxChars: 8,
+    } as never);
+    await new Promise((resolve) => setTimeout(resolve, 10));
     env.emitNetwork('Network.requestWillBeSent', {
       requestId: 'r2',
       type: 'XHR',
@@ -1575,12 +1603,7 @@ describe('RsbWebviewBackend — network actions', () => {
     });
     env.emitNetwork('Network.loadingFinished', { requestId: 'r2' });
 
-    const res = await env.backend.call({
-      action: 'responseBody',
-      targetId: 't1',
-      url: '/api/items',
-      maxChars: 8,
-    } as never);
+    const res = await pending;
 
     expect(res.ok).toBe(true);
     expect(res.data).toMatchObject({

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -3,7 +3,8 @@
 //  - tabs reads from TabRegistry + safeTabMeta on each WebContents
 //  - open / focus / close round-trip through dispatchTabOp (renderer bridge)
 //  - navigate / screenshot / pdf go straight to the guest WebContents
-//  - unsupported actions yield a structured error (no throw)
+//  - snapshot / non-evaluate act actions use the bounded CDP automation helper
+//  - advanced unsupported actions yield a structured error (no throw)
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WebContents } from 'electron';
@@ -464,15 +465,30 @@ describe('RsbWebviewBackend — act:evaluate', () => {
     expect(callArg.indexOf('window.__pwned')).toBeGreaterThan(callArg.indexOf(JSON.stringify(adversarial).slice(0, 10)));
   });
 
-  it('non-evaluate act kinds are rejected with a Phase 4 message', async () => {
-    const { backend } = buildEvalEnv(null);
+  it('non-evaluate act kinds route to the CDP automation helper', async () => {
+    const { backend, wc } = buildEvalEnv(null);
+    const sendCommand = vi.fn(async (method: string) => {
+      if (method === 'Input.dispatchMouseEvent') return {};
+      return {};
+    });
+    Object.assign(wc, {
+      debugger: {
+        isAttached: vi.fn(() => true),
+        attach: vi.fn(),
+        detach: vi.fn(),
+        sendCommand,
+      },
+    });
     const res = await backend.call({
       action: 'act',
       targetId: 't1',
-      request: { kind: 'click', ref: 'r-1' },
+      request: { kind: 'clickCoords', x: 10, y: 20 },
     } as never);
-    expect(res.ok).toBe(false);
-    expect(res.message).toMatch(/click not yet supported/);
+    expect(res.ok).toBe(true);
+    expect(sendCommand).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mousePressed', x: 10, y: 20 }),
+    );
   });
 
   it('executeJavaScript throw propagates as actionFailed', async () => {
@@ -487,6 +503,70 @@ describe('RsbWebviewBackend — act:evaluate', () => {
     } as never);
     expect(res.ok).toBe(false);
     expect(res.message).toBe('SyntaxError');
+  });
+});
+
+describe('RsbWebviewBackend — snapshot automation', () => {
+  it('returns refs from the active tab and pins for the complete CDP action', async () => {
+    const wc = fakeWc();
+    let attached = false;
+    Object.assign(wc, {
+      debugger: {
+        isAttached: vi.fn(() => attached),
+        attach: vi.fn(() => {
+          attached = true;
+        }),
+        detach: vi.fn(() => {
+          attached = false;
+        }),
+        sendCommand: vi.fn(async (method: string) => {
+          if (method === 'Accessibility.enable') return {};
+          if (method === 'Accessibility.getFullAXTree') {
+            return {
+              nodes: [
+                {
+                  nodeId: 'button',
+                  role: { value: 'button' },
+                  name: { value: 'Continue' },
+                  backendDOMNodeId: 7,
+                  childIds: [],
+                },
+              ],
+            };
+          }
+          throw new Error(`unexpected command: ${method}`);
+        }),
+      },
+    });
+    const registry = fakeRegistry(
+      [{ sessionId: 's1', tabId: 't1', webContentsId: 101 }],
+      new Map([['t1', wc]]),
+    );
+    const backend = new RsbWebviewBackend({
+      registry,
+      getActiveSessionId: () => 's1',
+      bridge: { getHostWebContents: () => null, logger: logger() },
+      logger: logger(),
+    });
+
+    const res = await backend.call({
+      action: 'snapshot',
+      targetId: 't1',
+      interactive: true,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({
+      targetId: 't1',
+      snapshot: '- button "Continue" [ref=e1]',
+      refs: {
+        e1: { role: 'button', name: 'Continue', backendDOMNodeId: 7 },
+      },
+    });
+    expect(registry.pinHistory).toEqual([
+      { op: 'pin', tabId: 't1' },
+      { op: 'unpin', tabId: 't1' },
+    ]);
   });
 });
 
@@ -790,6 +870,37 @@ describe('RsbWebviewBackend — MCP session id injection', () => {
     });
   });
 
+  it('targetless direct actions select a tab from the MCP-injected session', async () => {
+    const agentWc = fakeWc();
+    const uiWc = fakeWc();
+    const registry = fakeRegistry(
+      [
+        { sessionId: 'agent-A', tabId: 'agent-tab', webContentsId: 101 },
+        { sessionId: 'ui-focus-B', tabId: 'ui-tab', webContentsId: 102 },
+      ],
+      new Map([
+        ['agent-tab', agentWc],
+        ['ui-tab', uiWc],
+      ]),
+    );
+    const backend = new RsbWebviewBackend({
+      registry,
+      getActiveSessionId: () => 'ui-focus-B',
+      bridge: { getHostWebContents: () => null, logger: logger() },
+      logger: logger(),
+    });
+
+    const res = await backend.call({
+      action: 'navigate',
+      url: 'https://agent.example',
+      __mcpSessionId: 'agent-A',
+    } as never);
+
+    expect(res.ok).toBe(true);
+    expect(agentWc.loadURLMock).toHaveBeenCalledWith('https://agent.example');
+    expect(uiWc.loadURLMock).not.toHaveBeenCalled();
+  });
+
   it('empty / non-string __mcpSessionId falls back to getActiveSessionId', async () => {
     const wc = fakeWc();
     const registry = fakeRegistry(
@@ -824,14 +935,14 @@ describe('RsbWebviewBackend — MCP session id injection', () => {
 });
 
 describe('RsbWebviewBackend — unsupported actions', () => {
-  it('snapshot returns BROWSER_RUNTIME_ACTION_FAILED with explanation', async () => {
+  it('upload returns BROWSER_RUNTIME_ACTION_FAILED with explanation', async () => {
     const backend = new RsbWebviewBackend({
       registry: fakeRegistry([], new Map()),
       getActiveSessionId: () => 's1',
       bridge: { getHostWebContents: () => null, logger: logger() },
       logger: logger(),
     });
-    const res = await backend.call({ action: 'snapshot' } as never);
+    const res = await backend.call({ action: 'upload' } as never);
     expect(res.ok).toBe(false);
     expect(res.errorCode).toBe('BROWSER_RUNTIME_ACTION_FAILED');
     expect(res.message).toMatch(/not yet supported/);

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -7,6 +7,7 @@
 //  - advanced unsupported actions yield a structured error (no throw)
 
 import fs from 'node:fs/promises';
+import { writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -943,14 +944,25 @@ describe('RsbWebviewBackend — MCP session id injection', () => {
 });
 
 describe('RsbWebviewBackend — uploads and page dialogs', () => {
-  function buildPageEnv(options?: { uploadRoot?: string }) {
+  function buildPageEnv(options?: { uploadRoot?: string; resourceUrl?: string }) {
     let attached = false;
     const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    const sessionListeners = new Map<string, Set<(...args: unknown[]) => void>>();
     const sendCommand = vi.fn(async (method: string) => {
       if (method === 'Network.enable' || method === 'Page.enable') return {};
       if (method === 'Accessibility.enable') return {};
       if (method === 'Accessibility.getFullAXTree') return { nodes: [] };
-      if (method === 'Runtime.evaluate') return { result: { objectId: 'file-input' } };
+      if (method === 'Runtime.evaluate') {
+        return options?.resourceUrl
+          ? {
+              result: {
+                value: {
+                  resources: [{ kind: 'download', url: options.resourceUrl }],
+                },
+              },
+            }
+          : { result: { objectId: 'file-input' } };
+      }
       if (method === 'DOM.describeNode') return { node: { backendNodeId: 11 } };
       if (method === 'Runtime.callFunctionOn') {
         return { result: { value: { ok: true, multiple: true } } };
@@ -960,8 +972,39 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
       throw new Error(`unexpected command: ${method}`);
     });
     const wc = fakeWc();
+    const session = {
+      on: (event: string, listener: (...args: unknown[]) => void) => {
+        const group = sessionListeners.get(event) ?? new Set();
+        group.add(listener);
+        sessionListeners.set(event, group);
+      },
+      removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+        sessionListeners.get(event)?.delete(listener);
+      },
+    };
+    const downloadURL = vi.fn((url: string) => {
+      let doneListener: ((...args: unknown[]) => void) | undefined;
+      const item = {
+        getFilename: () => 'page-resource.bin',
+        getURL: () => url,
+        getMimeType: () => 'application/octet-stream',
+        getTotalBytes: () => 4,
+        getReceivedBytes: () => 4,
+        setSavePath: (filePath: string) => writeFileSync(filePath, 'data'),
+        cancel: vi.fn(),
+        once: (event: string, listener: (...args: unknown[]) => void) => {
+          if (event === 'done') doneListener = listener;
+        },
+      };
+      for (const listener of sessionListeners.get('will-download') ?? []) {
+        listener({}, item, wc);
+      }
+      setTimeout(() => doneListener?.({}, 'completed'), 0);
+    });
     Object.assign(wc, {
       once: vi.fn(),
+      session,
+      downloadURL,
       debugger: {
         isAttached: () => attached,
         attach: vi.fn(() => {
@@ -1000,7 +1043,7 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
         listener({}, method, params);
       }
     };
-    return { backend, emit, sendCommand };
+    return { backend, emit, sendCommand, downloadURL };
   }
 
   it('validates upload paths before assigning files to the page input', async () => {
@@ -1062,6 +1105,47 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
       { accept: false },
     );
     await env.backend.dispose();
+  });
+
+  it('saves only a resource listed by the latest page snapshot', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-browser-resource-'));
+    try {
+      const resourceUrl = 'https://cdn.example.test/archive.bin';
+      const env = buildPageEnv({ uploadRoot: root, resourceUrl });
+      const snapshot = await env.backend.call({
+        action: 'snapshot',
+        targetId: 't1',
+        urls: true,
+      });
+      expect(snapshot.data).toMatchObject({
+        resources: [{ kind: 'download', url: resourceUrl }],
+      });
+
+      const saved = await env.backend.call({
+        action: 'act',
+        targetId: 't1',
+        request: { kind: 'saveResource', url: resourceUrl, timeoutMs: 1000 },
+      });
+
+      expect(saved.ok).toBe(true);
+      expect(saved.data).toMatchObject({
+        kind: 'saveResource',
+        downloads: [
+          {
+            fileName: 'page-resource.bin',
+            state: 'completed',
+          },
+        ],
+      });
+      expect(env.downloadURL).toHaveBeenCalledWith(resourceUrl);
+      const artifactPath = (saved.data as {
+        downloads: Array<{ path: string }>;
+      }).downloads[0].path;
+      await expect(fs.readFile(artifactPath, 'utf8')).resolves.toBe('data');
+      await env.backend.dispose();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -1512,6 +1512,47 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it('captures downloads triggered by submit-enabled typing', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-browser-submit-download-'));
+    try {
+      const env = buildPageEnv({ uploadRoot: root });
+      const automation = (env.backend as unknown as {
+        automation: {
+          act: (
+            tabId: string,
+            wc: WebContents,
+            request: Record<string, unknown>,
+          ) => Promise<Record<string, unknown>>;
+        };
+      }).automation;
+      vi.spyOn(automation, 'act').mockImplementation(async () => {
+        env.downloadURL('https://example.test/submit-download');
+        return { tabId: 't1', kind: 'type', textLength: 1 };
+      });
+
+      const result = await env.backend.call({
+        action: 'act',
+        targetId: 't1',
+        request: {
+          kind: 'type',
+          targetId: 't1',
+          ref: 'input-1',
+          text: 'x',
+          submit: true,
+        },
+      } as never);
+
+      expect(result.ok).toBe(true);
+      expect(result.data).toMatchObject({
+        kind: 'type',
+        downloads: [{ state: 'completed' }],
+      });
+      await env.backend.dispose();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('RsbWebviewBackend — network actions', () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -938,6 +938,132 @@ describe('RsbWebviewBackend — MCP session id injection', () => {
   });
 });
 
+describe('RsbWebviewBackend — network actions', () => {
+  function buildNetworkEnv() {
+    let attached = false;
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    const sendCommand = vi.fn(async (method: string) => {
+      if (method === 'Network.enable') return {};
+      if (method === 'Network.getResponseBody') {
+        return { body: '{"items":[1,2,3]}', base64Encoded: false };
+      }
+      throw new Error(`unexpected command: ${method}`);
+    });
+    const wc = fakeWc();
+    Object.assign(wc, {
+      once: vi.fn(),
+      debugger: {
+        isAttached: () => attached,
+        attach: vi.fn(() => {
+          attached = true;
+        }),
+        detach: vi.fn(() => {
+          attached = false;
+        }),
+        sendCommand,
+        on: (event: string, listener: (...args: unknown[]) => void) => {
+          const group = listeners.get(event) ?? new Set();
+          group.add(listener);
+          listeners.set(event, group);
+        },
+        removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+          listeners.get(event)?.delete(listener);
+        },
+      },
+    });
+    const registry = fakeRegistry(
+      [{ sessionId: 's1', tabId: 't1', webContentsId: 101 }],
+      new Map([['t1', wc]]),
+    );
+    const backend = new RsbWebviewBackend({
+      registry,
+      getActiveSessionId: () => 's1',
+      bridge: { getHostWebContents: () => null, logger: logger() },
+      logger: logger(),
+    });
+    const emitNetwork = (method: string, params: Record<string, unknown>) => {
+      for (const listener of listeners.get('message') ?? []) {
+        listener({}, method, params);
+      }
+    };
+    return { backend, emitNetwork, sendCommand };
+  }
+
+  it('dispatches request history through the selected tab', async () => {
+    const env = buildNetworkEnv();
+    await env.backend.call({ action: 'requests', targetId: 't1' } as never);
+    env.emitNetwork('Network.requestWillBeSent', {
+      requestId: 'r1',
+      type: 'Fetch',
+      request: { method: 'GET', url: 'https://example.test/api/items' },
+    });
+    env.emitNetwork('Network.responseReceived', {
+      requestId: 'r1',
+      response: { url: 'https://example.test/api/items', status: 200 },
+    });
+    env.emitNetwork('Network.loadingFinished', { requestId: 'r1' });
+
+    const res = await env.backend.call({
+      action: 'requests',
+      targetId: 't1',
+      filter: '/api/',
+    } as never);
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({
+      tabId: 't1',
+      requests: [
+        {
+          id: 'r1',
+          method: 'GET',
+          url: 'https://example.test/api/items',
+          status: 200,
+          ok: true,
+        },
+      ],
+    });
+  });
+
+  it('returns the body of a completed matching response', async () => {
+    const env = buildNetworkEnv();
+    await env.backend.call({ action: 'requests', targetId: 't1' } as never);
+    env.emitNetwork('Network.requestWillBeSent', {
+      requestId: 'r2',
+      type: 'XHR',
+      request: { method: 'GET', url: 'https://example.test/api/items' },
+    });
+    env.emitNetwork('Network.responseReceived', {
+      requestId: 'r2',
+      response: {
+        url: 'https://example.test/api/items',
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    });
+    env.emitNetwork('Network.loadingFinished', { requestId: 'r2' });
+
+    const res = await env.backend.call({
+      action: 'responseBody',
+      targetId: 't1',
+      url: '/api/items',
+      maxChars: 8,
+    } as never);
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({
+      tabId: 't1',
+      response: {
+        url: 'https://example.test/api/items',
+        body: '{"items"',
+        truncated: true,
+      },
+    });
+    expect(env.sendCommand).toHaveBeenCalledWith('Network.getResponseBody', {
+      requestId: 'r2',
+    });
+  });
+});
+
 describe('RsbWebviewBackend — unsupported actions', () => {
   it('upload returns BROWSER_RUNTIME_ACTION_FAILED with explanation', async () => {
     const backend = new RsbWebviewBackend({

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -739,6 +739,51 @@ describe('RsbWebviewBackend — per-action automation pin', () => {
     ]);
   });
 
+  it.each([
+    { label: 'request timeout', timeoutMs: 25, elapsedMs: 25 },
+    { label: 'bounded default', timeoutMs: undefined, elapsedMs: 60_000 },
+  ])(
+    'navigate uses the $label, stops a stalled load, and lets dispose finish',
+    async ({ timeoutMs, elapsedMs }) => {
+      vi.useFakeTimers();
+      let finishLoad = () => {};
+      const wc = fakeWc();
+      wc.loadURLMock.mockImplementationOnce(
+        () => new Promise<void>((resolve) => {
+          finishLoad = resolve;
+        }),
+      );
+      const stop = vi.fn();
+      Object.assign(wc, { stop });
+      const { backend, registry } = buildBackend(wc);
+
+      try {
+        const navigating = backend.call({
+          action: 'navigate',
+          targetId: 't1',
+          url: 'https://stalled.test',
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        } as never);
+        const disposing = backend.dispose();
+
+        await vi.advanceTimersByTimeAsync(elapsedMs);
+        const result = await navigating;
+        await disposing;
+
+        expect(result.ok).toBe(false);
+        expect(result.message).toBe(`navigation timed out after ${elapsedMs}ms`);
+        expect(stop).toHaveBeenCalledTimes(1);
+        expect(registry.pinHistory).toEqual([
+          { op: 'pin', tabId: 't1' },
+          { op: 'unpin', tabId: 't1' },
+        ]);
+      } finally {
+        finishLoad();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it('unpins even when wc operation throws (action failure path)', async () => {
     const wc = {
       getURL: () => '',

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -950,12 +950,17 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
     uploadRoot?: string;
     resourceUrl?: string;
     onDialogHandled?: () => void;
+    pageEnableError?: Error;
   }) {
     let attached = false;
     const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
     const sessionListeners = new Map<string, Set<(...args: unknown[]) => void>>();
     const sendCommand = vi.fn(async (method: string) => {
-      if (method === 'Network.enable' || method === 'Page.enable') return {};
+      if (method === 'Network.enable') return {};
+      if (method === 'Page.enable') {
+        if (options?.pageEnableError) throw options.pageEnableError;
+        return {};
+      }
       if (method === 'Accessibility.enable') return {};
       if (method === 'Accessibility.getFullAXTree') return { nodes: [] };
       if (method === 'Runtime.evaluate') {
@@ -1038,6 +1043,7 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
       [{ sessionId: 's1', tabId: 't1', webContentsId: 101 }],
       new Map([['t1', wc]]),
     );
+    const backendLogger = logger();
     const backend = new RsbWebviewBackend({
       registry,
       getActiveSessionId: () => 's1',
@@ -1046,14 +1052,14 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
         ? async () => [options.uploadRoot!]
         : undefined,
       bridge: { getHostWebContents: () => null, logger: logger() },
-      logger: logger(),
+      logger: backendLogger,
     });
     const emit = (method: string, params: Record<string, unknown>) => {
       for (const listener of listeners.get('message') ?? []) {
         listener({}, method, params);
       }
     };
-    return { backend, emit, sendCommand, downloadURL, wc };
+    return { backend, emit, sendCommand, downloadURL, wc, backendLogger };
   }
 
   it('validates upload paths before assigning files to the page input', async () => {
@@ -1180,6 +1186,42 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
     } finally {
       await env.backend.dispose();
       await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('continues a page action when dialog observation is unavailable', async () => {
+    const env = buildPageEnv({
+      pageEnableError: new Error('another debugger client owns the page'),
+    });
+    const automation = (env.backend as unknown as {
+      automation: {
+        act: (
+          tabId: string,
+          wc: WebContents,
+          request: Record<string, unknown>,
+        ) => Promise<Record<string, unknown>>;
+      };
+    }).automation;
+    vi.spyOn(automation, 'act').mockResolvedValue({
+      tabId: 't1',
+      kind: 'click',
+    });
+
+    try {
+      const result = await env.backend.call({
+        action: 'act',
+        targetId: 't1',
+        request: { kind: 'click', targetId: 't1', ref: 'button-1' },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.data).toMatchObject({ tabId: 't1', kind: 'click' });
+      expect(env.backendLogger.warn).toHaveBeenCalledWith(
+        'RSB page dialog observation unavailable',
+        expect.objectContaining({ tabId: 't1' }),
+      );
+    } finally {
+      await env.backend.dispose();
     }
   });
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -1001,6 +1001,7 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
         getReceivedBytes: () => 4,
         setSavePath: (filePath: string) => writeFileSync(filePath, 'data'),
         cancel: vi.fn(),
+        on: vi.fn(),
         once: (event: string, listener: (...args: unknown[]) => void) => {
           if (event === 'done') doneListener = listener;
         },

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -949,6 +949,7 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
   function buildPageEnv(options?: {
     uploadRoot?: string;
     resourceUrl?: string;
+    humanVerification?: boolean;
     onDialogHandled?: () => void;
     pageEnableError?: Error;
   }) {
@@ -964,6 +965,19 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
       if (method === 'Accessibility.enable') return {};
       if (method === 'Accessibility.getFullAXTree') return { nodes: [] };
       if (method === 'Runtime.evaluate') {
+        if (options?.humanVerification) {
+          return {
+            result: {
+              value: {
+                resources: [],
+                barrier: {
+                  kind: 'human-verification',
+                  evidence: ['page contains a verification control'],
+                },
+              },
+            },
+          };
+        }
         return options?.resourceUrl
           ? {
               result: {
@@ -1187,6 +1201,28 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
       await env.backend.dispose();
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+
+  it('blocks direct actions after a human-verification snapshot barrier', async () => {
+    const env = buildPageEnv({ humanVerification: true });
+    const snapshot = await env.backend.call({ action: 'snapshot', targetId: 't1' });
+    expect(snapshot.data).toMatchObject({
+      barrier: { kind: 'human-verification' },
+    });
+
+    const action = await env.backend.call({
+      action: 'act',
+      targetId: 't1',
+      request: { kind: 'clickCoords', x: 10, y: 10 },
+    });
+    expect(action.data).toMatchObject({
+      barrier: { kind: 'human-verification' },
+    });
+    expect(env.sendCommand).not.toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.anything(),
+    );
+    await env.backend.dispose();
   });
 
   it('continues a page action when dialog observation is unavailable', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -402,13 +402,34 @@ describe('RsbWebviewBackend — direct WebContents actions', () => {
 
 describe('RsbWebviewBackend — act:evaluate', () => {
   function buildEvalEnv(initialReturn: unknown) {
+    let attached = false;
+    const sendCommand = vi.fn(async (
+      method: string,
+      _params?: Record<string, unknown>,
+    ): Promise<unknown> => {
+      if (method === 'Runtime.evaluate' || method === 'Runtime.callFunctionOn') {
+        return { result: { value: initialReturn } };
+      }
+      return {};
+    });
     const wc = {
       getURL: () => '',
       getTitle: () => '',
       isDestroyed: () => false,
       executeJavaScript: vi.fn(async () => initialReturn),
+      debugger: {
+        isAttached: vi.fn(() => attached),
+        attach: vi.fn(() => {
+          attached = true;
+        }),
+        detach: vi.fn(() => {
+          attached = false;
+        }),
+        sendCommand,
+      },
     } as unknown as Electron.WebContents & {
       executeJavaScript: ReturnType<typeof vi.fn>;
+      debugger: { sendCommand: ReturnType<typeof vi.fn> };
     };
     const registry = fakeRegistry(
       [{ sessionId: 's1', tabId: 't1', webContentsId: 101 }],
@@ -420,11 +441,11 @@ describe('RsbWebviewBackend — act:evaluate', () => {
       bridge: { getHostWebContents: () => null, logger: logger() },
       logger: logger(),
     });
-    return { backend, wc };
+    return { backend, wc, sendCommand };
   }
 
   it('runs the fn in the guest and returns its result + as variable name', async () => {
-    const { backend, wc } = buildEvalEnv({ posts: [1, 2, 3] });
+    const { backend, wc, sendCommand } = buildEvalEnv({ posts: [1, 2, 3] });
     const res = await backend.call({
       action: 'act',
       targetId: 't1',
@@ -437,11 +458,11 @@ describe('RsbWebviewBackend — act:evaluate', () => {
     // The wrapper mirrors the vendored runtime's evaluator: eval("(" + JSON.stringified-fn + ")")
     // → call it → wrap in Promise.resolve. The injected fn text is a JS string
     // LITERAL, so multi-statement payloads can't escape the IIFE.
-    expect(wc.executeJavaScript).toHaveBeenCalledTimes(1);
-    const callArg = (wc.executeJavaScript as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sendCommand).toHaveBeenCalledWith('Runtime.evaluate', expect.anything());
+    const callArg = sendCommand.mock.calls.find(([method]) => method === 'Runtime.evaluate')?.[1]
+      ?.expression as string;
     expect(callArg).toContain('eval("(" + "() => ({ posts: [1, 2, 3] })" + ")")');
-    expect(callArg).toContain('did not produce a function');
-    expect((wc.executeJavaScript as ReturnType<typeof vi.fn>).mock.calls[0][1]).toBe(false);
+    expect(callArg).toContain('evaluate source did not produce a function');
     expect(res.ok).toBe(true);
     expect(res.data).toMatchObject({
       tabId: 't1',
@@ -452,7 +473,7 @@ describe('RsbWebviewBackend — act:evaluate', () => {
   });
 
   it('escapes embedded quotes/backslashes in fn so multi-stmt payload cannot escape IIFE', async () => {
-    const { backend, wc } = buildEvalEnv(null);
+    const { backend, sendCommand } = buildEvalEnv(null);
     // Adversarial payload: try to close the string + run a second statement.
     const adversarial = '() => {}; window.__pwned = 1; (() => null';
     await backend.call({
@@ -460,7 +481,8 @@ describe('RsbWebviewBackend — act:evaluate', () => {
       targetId: 't1',
       request: { kind: 'evaluate', fn: adversarial },
     } as never);
-    const callArg = (wc.executeJavaScript as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const callArg = sendCommand.mock.calls.find(([method]) => method === 'Runtime.evaluate')?.[1]
+      ?.expression as string;
     // The whole payload is a JSON.stringified literal — `"` inside got escaped,
     // and the literal sits inside `eval("(" + LITERAL + ")")` so any "statement
     // separator" the attacker tries (a quote + `;`) stays inside the literal.
@@ -503,10 +525,10 @@ describe('RsbWebviewBackend — act:evaluate', () => {
   });
 
   it('executeJavaScript throw propagates as actionFailed', async () => {
-    const { backend, wc } = buildEvalEnv(null);
-    (wc.executeJavaScript as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new Error('SyntaxError'),
-    );
+    const { backend, sendCommand } = buildEvalEnv(null);
+    sendCommand.mockResolvedValueOnce({
+      exceptionDetails: { exception: { description: 'SyntaxError' } },
+    } as never);
     const res = await backend.call({
       action: 'act',
       targetId: 't1',

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -482,6 +482,8 @@ describe('RsbWebviewBackend — act:evaluate', () => {
         attach: vi.fn(),
         detach: vi.fn(),
         sendCommand,
+        on: vi.fn(),
+        removeListener: vi.fn(),
       },
     });
     const res = await backend.call({
@@ -944,7 +946,11 @@ describe('RsbWebviewBackend — MCP session id injection', () => {
 });
 
 describe('RsbWebviewBackend — uploads and page dialogs', () => {
-  function buildPageEnv(options?: { uploadRoot?: string; resourceUrl?: string }) {
+  function buildPageEnv(options?: {
+    uploadRoot?: string;
+    resourceUrl?: string;
+    onDialogHandled?: () => void;
+  }) {
     let attached = false;
     const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
     const sessionListeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -968,7 +974,10 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
         return { result: { value: { ok: true, multiple: true } } };
       }
       if (method === 'DOM.setFileInputFiles') return {};
-      if (method === 'Page.handleJavaScriptDialog') return {};
+      if (method === 'Page.handleJavaScriptDialog') {
+        options?.onDialogHandled?.();
+        return {};
+      }
       throw new Error(`unexpected command: ${method}`);
     });
     const wc = fakeWc();
@@ -1043,7 +1052,7 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
         listener({}, method, params);
       }
     };
-    return { backend, emit, sendCommand, downloadURL };
+    return { backend, emit, sendCommand, downloadURL, wc };
   }
 
   it('validates upload paths before assigning files to the page input', async () => {
@@ -1106,6 +1115,240 @@ describe('RsbWebviewBackend — uploads and page dialogs', () => {
     );
     await env.backend.dispose();
   });
+
+  it('returns a dialog barrier when a page action is blocked by the dialog', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-browser-dialog-action-'));
+    let finishAction = () => {};
+    const env = buildPageEnv({
+      uploadRoot: root,
+      onDialogHandled: () => finishAction(),
+    });
+    const automation = (env.backend as unknown as {
+      automation: {
+        act: (
+          tabId: string,
+          wc: WebContents,
+          request: Record<string, unknown>,
+        ) => Promise<Record<string, unknown>>;
+      };
+    }).automation;
+    const actionFinished = vi.fn();
+    const actSpy = vi.spyOn(automation, 'act').mockImplementation(
+      () => new Promise((resolve) => {
+        finishAction = () => {
+          actionFinished();
+          resolve({ tabId: 't1', kind: 'click' });
+        };
+      }),
+    );
+
+    try {
+      const action = env.backend.call({
+        action: 'act',
+        targetId: 't1',
+        request: { kind: 'click', targetId: 't1', ref: 'button-1' },
+      });
+      await vi.waitFor(() => expect(actSpy).toHaveBeenCalledTimes(1));
+      env.emit('Page.javascriptDialogOpening', {
+        type: 'confirm',
+        message: 'Continue?',
+      });
+
+      const blocked = await action;
+      expect(blocked.ok).toBe(true);
+      expect(blocked.data).toMatchObject({
+        tabId: 't1',
+        kind: 'click',
+        barrier: {
+          kind: 'page-dialog',
+          dialog: { type: 'confirm', message: 'Continue?' },
+        },
+      });
+      const dialogId = (blocked.data as {
+        barrier: { dialog: { id: string } };
+      }).barrier.dialog.id;
+
+      const handled = await env.backend.call({
+        action: 'dialog',
+        targetId: 't1',
+        dialogId,
+        accept: true,
+      });
+      expect(handled.ok).toBe(true);
+      await vi.waitFor(() => expect(actionFinished).toHaveBeenCalledTimes(1));
+    } finally {
+      await env.backend.dispose();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the host interactive after an auto-closed dialog and arms a retry', async () => {
+    const env = buildPageEnv();
+    const automation = (env.backend as unknown as {
+      automation: {
+        act: (
+          tabId: string,
+          wc: WebContents,
+          request: Record<string, unknown>,
+        ) => Promise<Record<string, unknown>>;
+      };
+    }).automation;
+    let releaseAction = () => {};
+    const actSpy = vi.spyOn(automation, 'act').mockImplementation(
+      () => {
+        env.emit('Page.javascriptDialogOpening', {
+          type: 'confirm',
+          message: 'Continue?',
+        });
+        env.emit('Page.javascriptDialogClosed', {
+          result: false,
+          userInput: '',
+        });
+        return new Promise((resolve) => {
+          releaseAction = () => resolve({ tabId: 't1', kind: 'click' });
+        });
+      },
+    );
+
+    try {
+      const action = env.backend.call({
+        action: 'act',
+        targetId: 't1',
+        request: { kind: 'click', targetId: 't1', ref: 'button-1' },
+      });
+      await vi.waitFor(() => expect(actSpy).toHaveBeenCalledTimes(1));
+      const blocked = await action;
+      expect(blocked.data).toMatchObject({
+        barrier: {
+          kind: 'page-dialog',
+          dialog: { type: 'confirm', message: 'Continue?' },
+        },
+      });
+      const dialogId = (blocked.data as {
+        barrier: { dialog: { id: string } };
+      }).barrier.dialog.id;
+
+      const armed = await env.backend.call({
+        action: 'dialog',
+        targetId: 't1',
+        dialogId,
+        accept: true,
+      });
+      expect(armed.data).toMatchObject({
+        tabId: 't1',
+        armed: true,
+        retryRequired: true,
+      });
+    } finally {
+      releaseAction();
+      await env.backend.dispose();
+    }
+  });
+
+  it('prepares the next confirmation when no previous dialog record remains', async () => {
+    const env = buildPageEnv();
+    await env.backend.call({ action: 'snapshot', targetId: 't1' });
+
+    const dialogs = (env.backend as unknown as {
+      dialogs: {
+        respond: (...args: unknown[]) => Promise<never>;
+      };
+    }).dialogs;
+    vi.spyOn(dialogs, 'respond').mockRejectedValueOnce(
+      new Error('no page dialog is pending'),
+    );
+
+    try {
+      const armed = await env.backend.call({
+        action: 'dialog',
+        targetId: 't1',
+        accept: true,
+      });
+      expect(armed.ok).toBe(true);
+      expect(armed.data).toMatchObject({
+        tabId: 't1',
+        armed: true,
+        retryRequired: true,
+      });
+
+      env.emit('Page.javascriptDialogOpening', {
+        type: 'confirm',
+        message: 'Continue?',
+      });
+      await vi.waitFor(() => {
+        expect(env.sendCommand).toHaveBeenCalledWith(
+          'Page.handleJavaScriptDialog',
+          { accept: true },
+        );
+      });
+    } finally {
+      await env.backend.dispose();
+    }
+  });
+
+  it.each([
+    {
+      dialogType: 'alert',
+      expected: {
+        dialogs: [{
+          type: 'alert',
+          message: 'Notice',
+          closedBy: 'auto',
+          handled: true,
+        }],
+      },
+    },
+    {
+      dialogType: 'confirm',
+      expected: {
+        barrier: {
+          kind: 'page-dialog',
+          dialog: {
+            type: 'confirm',
+            message: 'Notice',
+            closedBy: 'auto',
+          },
+        },
+      },
+    },
+  ])(
+    'classifies an auto-closed $dialogType even when the action finishes immediately',
+    async ({ dialogType, expected }) => {
+      const env = buildPageEnv();
+      const automation = (env.backend as unknown as {
+        automation: {
+          act: (
+            tabId: string,
+            wc: WebContents,
+            request: Record<string, unknown>,
+          ) => Promise<Record<string, unknown>>;
+        };
+      }).automation;
+      vi.spyOn(automation, 'act').mockImplementation(async () => {
+        env.emit('Page.javascriptDialogOpening', {
+          type: dialogType,
+          message: 'Notice',
+        });
+        env.emit('Page.javascriptDialogClosed', {
+          result: false,
+          userInput: '',
+        });
+        return { tabId: 't1', kind: 'click' };
+      });
+
+      try {
+        const result = await env.backend.call({
+          action: 'act',
+          targetId: 't1',
+          request: { kind: 'click', targetId: 't1', ref: 'button-1' },
+        });
+        expect(result.ok).toBe(true);
+        expect(result.data).toMatchObject(expected);
+      } finally {
+        await env.backend.dispose();
+      }
+    },
+  );
 
   it('saves only a resource listed by the latest page snapshot', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-browser-resource-'));

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -472,6 +472,7 @@ describe('RsbWebviewBackend — act:evaluate', () => {
       return {};
     });
     Object.assign(wc, {
+      focus: vi.fn(),
       debugger: {
         isAttached: vi.fn(() => true),
         attach: vi.fn(),

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -467,12 +467,11 @@ describe('RsbWebviewBackend — act:evaluate', () => {
 
   it('non-evaluate act kinds route to the CDP automation helper', async () => {
     const { backend, wc } = buildEvalEnv(null);
-    const sendCommand = vi.fn(async (method: string) => {
-      if (method === 'Input.dispatchMouseEvent') return {};
+    wc.executeJavaScript.mockResolvedValue({ ok: true });
+    const sendCommand = vi.fn(async () => {
       return {};
     });
     Object.assign(wc, {
-      focus: vi.fn(),
       debugger: {
         isAttached: vi.fn(() => true),
         attach: vi.fn(),
@@ -486,9 +485,13 @@ describe('RsbWebviewBackend — act:evaluate', () => {
       request: { kind: 'clickCoords', x: 10, y: 20 },
     } as never);
     expect(res.ok).toBe(true);
-    expect(sendCommand).toHaveBeenCalledWith(
+    expect(sendCommand).not.toHaveBeenCalledWith(
       'Input.dispatchMouseEvent',
-      expect.objectContaining({ type: 'mousePressed', x: 10, y: 20 }),
+      expect.anything(),
+    );
+    expect(wc.executeJavaScript).toHaveBeenCalledTimes(2);
+    expect(wc.executeJavaScript.mock.calls[0][0]).toContain(
+      '"method":"Input.dispatchMouseEvent","params":{"type":"mousePressed","x":10,"y":20',
     );
   });
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -6,6 +6,10 @@
 //  - snapshot / non-evaluate act actions use the bounded CDP automation helper
 //  - advanced unsupported actions yield a structured error (no throw)
 
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WebContents } from 'electron';
 
@@ -938,6 +942,129 @@ describe('RsbWebviewBackend — MCP session id injection', () => {
   });
 });
 
+describe('RsbWebviewBackend — uploads and page dialogs', () => {
+  function buildPageEnv(options?: { uploadRoot?: string }) {
+    let attached = false;
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    const sendCommand = vi.fn(async (method: string) => {
+      if (method === 'Network.enable' || method === 'Page.enable') return {};
+      if (method === 'Accessibility.enable') return {};
+      if (method === 'Accessibility.getFullAXTree') return { nodes: [] };
+      if (method === 'Runtime.evaluate') return { result: { objectId: 'file-input' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 11 } };
+      if (method === 'Runtime.callFunctionOn') {
+        return { result: { value: { ok: true, multiple: true } } };
+      }
+      if (method === 'DOM.setFileInputFiles') return {};
+      if (method === 'Page.handleJavaScriptDialog') return {};
+      throw new Error(`unexpected command: ${method}`);
+    });
+    const wc = fakeWc();
+    Object.assign(wc, {
+      once: vi.fn(),
+      debugger: {
+        isAttached: () => attached,
+        attach: vi.fn(() => {
+          attached = true;
+        }),
+        detach: vi.fn(() => {
+          attached = false;
+        }),
+        sendCommand,
+        on: (event: string, listener: (...args: unknown[]) => void) => {
+          const group = listeners.get(event) ?? new Set();
+          group.add(listener);
+          listeners.set(event, group);
+        },
+        removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+          listeners.get(event)?.delete(listener);
+        },
+      },
+    });
+    const registry = fakeRegistry(
+      [{ sessionId: 's1', tabId: 't1', webContentsId: 101 }],
+      new Map([['t1', wc]]),
+    );
+    const backend = new RsbWebviewBackend({
+      registry,
+      getActiveSessionId: () => 's1',
+      artifactRoot: options?.uploadRoot ? () => options.uploadRoot! : undefined,
+      resolveUploadRoots: options?.uploadRoot
+        ? async () => [options.uploadRoot!]
+        : undefined,
+      bridge: { getHostWebContents: () => null, logger: logger() },
+      logger: logger(),
+    });
+    const emit = (method: string, params: Record<string, unknown>) => {
+      for (const listener of listeners.get('message') ?? []) {
+        listener({}, method, params);
+      }
+    };
+    return { backend, emit, sendCommand };
+  }
+
+  it('validates upload paths before assigning files to the page input', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-browser-backend-upload-'));
+    try {
+      const file = path.join(root, 'notes.txt');
+      await fs.writeFile(file, 'notes');
+      const env = buildPageEnv({ uploadRoot: root });
+
+      const res = await env.backend.call({
+        action: 'upload',
+        targetId: 't1',
+        paths: [file],
+        query: { label: 'Attachments' },
+      });
+
+      expect(res.ok).toBe(true);
+      expect(res.data).toMatchObject({ tabId: 't1', uploadedFiles: 1 });
+      expect(env.sendCommand).toHaveBeenCalledWith('DOM.setFileInputFiles', {
+        files: [await fs.realpath(file)],
+        objectId: 'file-input',
+      });
+      await env.backend.dispose();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a dialog barrier from snapshot and handles the exact pending dialog', async () => {
+    const env = buildPageEnv();
+    await env.backend.call({ action: 'snapshot', targetId: 't1' });
+    env.emit('Page.javascriptDialogOpening', {
+      type: 'confirm',
+      message: 'Delete this item?',
+    });
+
+    const snapshot = await env.backend.call({ action: 'snapshot', targetId: 't1' });
+    expect(snapshot.ok).toBe(true);
+    expect(snapshot.data).toMatchObject({
+      targetId: 't1',
+      barrier: {
+        kind: 'page-dialog',
+        dialog: { type: 'confirm', message: 'Delete this item?' },
+      },
+    });
+    const dialogId = (snapshot.data as {
+      barrier: { dialog: { id: string } };
+    }).barrier.dialog.id;
+
+    const handled = await env.backend.call({
+      action: 'dialog',
+      targetId: 't1',
+      dialogId,
+      accept: false,
+    });
+    expect(handled.ok).toBe(true);
+    expect(env.sendCommand).toHaveBeenCalledWith(
+      'Page.handleJavaScriptDialog',
+      { accept: false },
+    );
+    await env.backend.dispose();
+  });
+});
+
 describe('RsbWebviewBackend — network actions', () => {
   function buildNetworkEnv() {
     let attached = false;
@@ -1065,14 +1192,14 @@ describe('RsbWebviewBackend — network actions', () => {
 });
 
 describe('RsbWebviewBackend — unsupported actions', () => {
-  it('upload returns BROWSER_RUNTIME_ACTION_FAILED with explanation', async () => {
+  it('unknown actions return BROWSER_RUNTIME_ACTION_FAILED with explanation', async () => {
     const backend = new RsbWebviewBackend({
       registry: fakeRegistry([], new Map()),
       getActiveSessionId: () => 's1',
       bridge: { getHostWebContents: () => null, logger: logger() },
       logger: logger(),
     });
-    const res = await backend.call({ action: 'upload' } as never);
+    const res = await backend.call({ action: 'trace' } as never);
     expect(res.ok).toBe(false);
     expect(res.errorCode).toBe('BROWSER_RUNTIME_ACTION_FAILED');
     expect(res.message).toMatch(/not yet supported/);

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
@@ -58,18 +58,20 @@ describe('RsbWebviewDialogs', () => {
       defaultValue: 'Cindy',
     });
 
-    await expect(dialogs.respond(harness.wc, {
-      dialogId: pending?.id,
-      accept: true,
-      promptText: 'New name',
-    })).resolves.toMatchObject({
+    await expect(
+      dialogs.respond(harness.wc, {
+        dialogId: pending?.id,
+        accept: true,
+        promptText: 'New name',
+      }),
+    ).resolves.toMatchObject({
       id: pending?.id,
       accepted: true,
     });
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Page.handleJavaScriptDialog',
-      { accept: true, promptText: 'New name' },
-    );
+    expect(harness.sendCommand).toHaveBeenCalledWith('Page.handleJavaScriptDialog', {
+      accept: true,
+      promptText: 'New name',
+    });
     harness.emit('Page.javascriptDialogClosed', {
       result: true,
       userInput: 'New name',
@@ -86,11 +88,13 @@ describe('RsbWebviewDialogs', () => {
       message: 'Continue?',
     });
 
-    await expect(dialogs.respond(harness.wc, {
-      dialogId: 'stale-dialog',
-      accept: false,
-      timeoutMs: 50,
-    })).rejects.toThrow('is no longer pending');
+    await expect(
+      dialogs.respond(harness.wc, {
+        dialogId: 'stale-dialog',
+        accept: false,
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow('is no longer pending');
     expect(harness.sendCommand).not.toHaveBeenCalledWith(
       'Page.handleJavaScriptDialog',
       expect.anything(),
@@ -156,10 +160,40 @@ describe('RsbWebviewDialogs', () => {
       message: 'Continue again?',
       closedBy: 'armed',
     });
-    expect(harness.sendCommand).toHaveBeenCalledWith(
-      'Page.handleJavaScriptDialog',
-      { accept: true },
-    );
+    expect(harness.sendCommand).toHaveBeenCalledWith('Page.handleJavaScriptDialog', {
+      accept: true,
+    });
+  });
+
+  it('does not let an undirected response consume a stale recent dialog', async () => {
+    const harness = dialogHarness();
+    const dialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+    await dialogs.observe(harness.wc);
+    harness.emit('Page.javascriptDialogOpening', {
+      type: 'confirm',
+      message: 'Old dialog',
+    });
+    harness.emit('Page.javascriptDialogClosed', {
+      result: false,
+      userInput: '',
+    });
+
+    await expect(
+      dialogs.respond(harness.wc, {
+        accept: true,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow('no page dialog is pending');
+
+    const armed = dialogs.armNext(harness.wc, { accept: true });
+    harness.emit('Page.javascriptDialogOpening', {
+      type: 'confirm',
+      message: 'Fresh dialog',
+    });
+    await expect(armed.response).resolves.toMatchObject({
+      message: 'Fresh dialog',
+      closedBy: 'armed',
+    });
   });
 
   it('keeps a prepared response active beyond the regular action timeout', async () => {
@@ -181,10 +215,9 @@ describe('RsbWebviewDialogs', () => {
         message: 'Continue later?',
         closedBy: 'armed',
       });
-      expect(harness.sendCommand).toHaveBeenCalledWith(
-        'Page.handleJavaScriptDialog',
-        { accept: true },
-      );
+      expect(harness.sendCommand).toHaveBeenCalledWith('Page.handleJavaScriptDialog', {
+        accept: true,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
@@ -70,6 +70,10 @@ describe('RsbWebviewDialogs', () => {
       'Page.handleJavaScriptDialog',
       { accept: true, promptText: 'New name' },
     );
+    harness.emit('Page.javascriptDialogClosed', {
+      result: true,
+      userInput: 'New name',
+    });
     expect(dialogs.pending(harness.wc)).toBeUndefined();
   });
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WebContents } from 'electron';
+
+import { RsbWebviewDialogs } from '../rsb-webview-dialogs.js';
+
+function dialogHarness() {
+  let attached = false;
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const sendCommand = vi.fn(async (method: string) => {
+    if (method === 'Page.enable' || method === 'Page.handleJavaScriptDialog') return {};
+    throw new Error(`unexpected command: ${method}`);
+  });
+  const electronDebugger = {
+    isAttached: () => attached,
+    attach: vi.fn(() => {
+      attached = true;
+    }),
+    detach: vi.fn(() => {
+      attached = false;
+    }),
+    sendCommand,
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      const group = listeners.get(event) ?? new Set();
+      group.add(listener);
+      listeners.set(event, group);
+    },
+    removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(listener);
+    },
+  };
+  const wc = {
+    debugger: electronDebugger,
+    once: vi.fn(),
+  } as unknown as WebContents;
+  const emit = (method: string, params: Record<string, unknown>) => {
+    for (const listener of listeners.get('message') ?? []) {
+      listener({}, method, params);
+    }
+  };
+  return { wc, emit, electronDebugger, sendCommand };
+}
+
+describe('RsbWebviewDialogs', () => {
+  it('reports and accepts a pending prompt', async () => {
+    const harness = dialogHarness();
+    const dialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+    await dialogs.observe(harness.wc);
+    harness.emit('Page.javascriptDialogOpening', {
+      type: 'prompt',
+      message: 'Enter a name',
+      defaultPrompt: 'Cindy',
+    });
+
+    const pending = dialogs.pending(harness.wc);
+    expect(pending).toMatchObject({
+      type: 'prompt',
+      message: 'Enter a name',
+      defaultValue: 'Cindy',
+    });
+
+    await expect(dialogs.respond(harness.wc, {
+      dialogId: pending?.id,
+      accept: true,
+      promptText: 'New name',
+    })).resolves.toMatchObject({
+      id: pending?.id,
+      accepted: true,
+    });
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Page.handleJavaScriptDialog',
+      { accept: true, promptText: 'New name' },
+    );
+    expect(dialogs.pending(harness.wc)).toBeUndefined();
+  });
+
+  it('rejects a stale id without responding to a different dialog', async () => {
+    const harness = dialogHarness();
+    const dialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+    await dialogs.observe(harness.wc);
+    harness.emit('Page.javascriptDialogOpening', {
+      type: 'confirm',
+      message: 'Continue?',
+    });
+
+    await expect(dialogs.respond(harness.wc, {
+      dialogId: 'stale-dialog',
+      accept: false,
+      timeoutMs: 50,
+    })).rejects.toThrow('is no longer pending');
+    expect(harness.sendCommand).not.toHaveBeenCalledWith(
+      'Page.handleJavaScriptDialog',
+      expect.anything(),
+    );
+  });
+
+  it('detaches only debugger sessions it owns', async () => {
+    const owned = dialogHarness();
+    const ownedDialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+    await ownedDialogs.observe(owned.wc);
+    ownedDialogs.dispose();
+    expect(owned.electronDebugger.detach).toHaveBeenCalledTimes(1);
+
+    const shared = dialogHarness();
+    shared.electronDebugger.attach();
+    const sharedDialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+    await sharedDialogs.observe(shared.wc);
+    sharedDialogs.dispose();
+    expect(shared.electronDebugger.detach).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-dialogs.test.ts
@@ -93,6 +93,99 @@ describe('RsbWebviewDialogs', () => {
     );
   });
 
+  it('resolves a one-shot opening watcher and allows cancellation', async () => {
+    const harness = dialogHarness();
+    const dialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+    await dialogs.observe(harness.wc);
+
+    const opening = dialogs.watchOpening(harness.wc);
+    harness.emit('Page.javascriptDialogOpening', {
+      type: 'alert',
+      message: 'Saved',
+    });
+    await expect(opening.opened).resolves.toMatchObject({
+      type: 'alert',
+      message: 'Saved',
+    });
+
+    const cancelled = dialogs.watchOpening(harness.wc);
+    cancelled.cancel();
+    harness.emit('Page.javascriptDialogClosed', {});
+    expect(dialogs.pending(harness.wc)).toBeUndefined();
+  });
+
+  it('records auto-closed dialogs and arms the next response', async () => {
+    const harness = dialogHarness();
+    const dialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+    await dialogs.observe(harness.wc);
+    harness.emit('Page.javascriptDialogOpening', {
+      type: 'confirm',
+      message: 'Continue?',
+    });
+    harness.emit('Page.javascriptDialogClosed', {
+      result: false,
+      userInput: '',
+    });
+    const first = dialogs.recent(harness.wc);
+    expect(first).toMatchObject({
+      type: 'confirm',
+      message: 'Continue?',
+      closedBy: 'auto',
+    });
+
+    const deferred = await dialogs.respond(harness.wc, {
+      dialogId: first?.id,
+      accept: true,
+    });
+    expect(deferred).toMatchObject({
+      id: first?.id,
+      deferred: true,
+    });
+
+    const armed = dialogs.armNext(harness.wc, { accept: true });
+    harness.emit('Page.javascriptDialogOpening', {
+      type: 'confirm',
+      message: 'Continue again?',
+    });
+    await expect(armed.response).resolves.toMatchObject({
+      type: 'confirm',
+      message: 'Continue again?',
+      closedBy: 'armed',
+    });
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Page.handleJavaScriptDialog',
+      { accept: true },
+    );
+  });
+
+  it('keeps a prepared response active beyond the regular action timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = dialogHarness();
+      const dialogs = new RsbWebviewDialogs({ warn: vi.fn() });
+      await dialogs.observe(harness.wc);
+
+      const armed = dialogs.armNext(harness.wc, { accept: true });
+      await vi.advanceTimersByTimeAsync(60_001);
+      harness.emit('Page.javascriptDialogOpening', {
+        type: 'confirm',
+        message: 'Continue later?',
+      });
+
+      await expect(armed.response).resolves.toMatchObject({
+        type: 'confirm',
+        message: 'Continue later?',
+        closedBy: 'armed',
+      });
+      expect(harness.sendCommand).toHaveBeenCalledWith(
+        'Page.handleJavaScriptDialog',
+        { accept: true },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('detaches only debugger sessions it owns', async () => {
     const owned = dialogHarness();
     const ownedDialogs = new RsbWebviewDialogs({ warn: vi.fn() });

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-network.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-network.test.ts
@@ -104,4 +104,20 @@ describe('RsbWebviewNetwork', () => {
     expect(network.readRequests(harness.wc)).toEqual([]);
     expect(JSON.stringify(network.diagnostics())).not.toContain('secret');
   });
+
+  it('waits for an actual quiet network window', async () => {
+    const harness = networkHarness();
+    const network = new RsbWebviewNetwork({ warn: vi.fn() });
+    await network.observe(harness.wc);
+
+    harness.emit('message', 'Network.requestWillBeSent', {
+      requestId: 'request-idle',
+      type: 'Fetch',
+      request: { method: 'GET', url: 'https://example.test/data' },
+    });
+    const pending = network.waitForIdle(harness.wc, { timeoutMs: 2_000, idleMs: 50 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    harness.emit('message', 'Network.loadingFinished', { requestId: 'request-idle' });
+    await expect(pending).resolves.toBeUndefined();
+  });
 });

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-network.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-network.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WebContents } from 'electron';
+
+import { RsbWebviewNetwork } from '../rsb-webview-network.js';
+
+function networkHarness() {
+  let attached = false;
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const sendCommand = vi.fn(async (method: string) => {
+    if (method === 'Network.enable') return {};
+    if (method === 'Network.getResponseBody') {
+      return { body: '{"ok":true}', base64Encoded: false };
+    }
+    throw new Error(`unexpected command: ${method}`);
+  });
+  const electronDebugger = {
+    isAttached: () => attached,
+    attach: vi.fn(() => {
+      attached = true;
+    }),
+    detach: vi.fn(() => {
+      attached = false;
+    }),
+    sendCommand,
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      const group = listeners.get(event) ?? new Set();
+      group.add(listener);
+      listeners.set(event, group);
+    },
+    removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(listener);
+    },
+  };
+  const wc = {
+    debugger: electronDebugger,
+    once: vi.fn(),
+  } as unknown as WebContents;
+  const emit = (event: string, ...args: unknown[]) => {
+    for (const listener of listeners.get(event) ?? []) listener({}, ...args);
+  };
+  return { wc, emit, electronDebugger, sendCommand };
+}
+
+describe('RsbWebviewNetwork', () => {
+  it('buffers request outcomes and returns a bounded response body', async () => {
+    const harness = networkHarness();
+    const network = new RsbWebviewNetwork({ warn: vi.fn() });
+    await network.observe(harness.wc);
+
+    harness.emit('message', 'Network.requestWillBeSent', {
+      requestId: 'request-1',
+      type: 'XHR',
+      request: { method: 'POST', url: 'https://example.test/api/items' },
+    });
+    harness.emit('message', 'Network.responseReceived', {
+      requestId: 'request-1',
+      response: {
+        url: 'https://example.test/api/items',
+        status: 201,
+        headers: {
+          'content-type': 'application/json',
+          'set-cookie': 'secret=hidden',
+        },
+      },
+    });
+    harness.emit('message', 'Network.loadingFinished', { requestId: 'request-1' });
+
+    expect(network.readRequests(harness.wc)).toEqual([
+      expect.objectContaining({
+        id: 'request-1',
+        method: 'POST',
+        resourceType: 'xhr',
+        status: 201,
+        ok: true,
+      }),
+    ]);
+    await expect(network.readResponseBody(harness.wc, {
+      url: '/api/items',
+      maxChars: 5,
+    })).resolves.toEqual({
+      url: 'https://example.test/api/items',
+      status: 201,
+      headers: { 'content-type': 'application/json' },
+      body: '{"ok"',
+      truncated: true,
+    });
+  });
+
+  it('clears buffered metadata without leaking sensitive request headers', async () => {
+    const harness = networkHarness();
+    const network = new RsbWebviewNetwork({ warn: vi.fn() });
+    await network.observe(harness.wc);
+    harness.emit('message', 'Network.requestWillBeSent', {
+      requestId: 'request-2',
+      type: 'Fetch',
+      request: {
+        method: 'GET',
+        url: 'https://example.test/private',
+        headers: { authorization: 'Bearer secret' },
+      },
+    });
+
+    expect(network.readRequests(harness.wc, { filter: '/private', clear: true })).toHaveLength(1);
+    expect(network.readRequests(harness.wc)).toEqual([]);
+    expect(JSON.stringify(network.diagnostics())).not.toContain('secret');
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-network.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-network.test.ts
@@ -47,6 +47,11 @@ describe('RsbWebviewNetwork', () => {
     const network = new RsbWebviewNetwork({ warn: vi.fn() });
     await network.observe(harness.wc);
 
+    const pendingBody = network.readResponseBody(harness.wc, {
+      url: '/api/items',
+      maxChars: 5,
+    });
+    await Promise.resolve();
     harness.emit('message', 'Network.requestWillBeSent', {
       requestId: 'request-1',
       type: 'XHR',
@@ -74,10 +79,7 @@ describe('RsbWebviewNetwork', () => {
         ok: true,
       }),
     ]);
-    await expect(network.readResponseBody(harness.wc, {
-      url: '/api/items',
-      maxChars: 5,
-    })).resolves.toEqual({
+    await expect(pendingBody).resolves.toEqual({
       url: 'https://example.test/api/items',
       status: 201,
       headers: { 'content-type': 'application/json' },
@@ -103,6 +105,83 @@ describe('RsbWebviewNetwork', () => {
     expect(network.readRequests(harness.wc, { filter: '/private', clear: true })).toHaveLength(1);
     expect(network.readRequests(harness.wc)).toEqual([]);
     expect(JSON.stringify(network.diagnostics())).not.toContain('secret');
+  });
+
+  it('waits for a new matching response instead of reusing response history', async () => {
+    const harness = networkHarness();
+    const network = new RsbWebviewNetwork({ warn: vi.fn() });
+    await network.observe(harness.wc);
+    harness.emit('message', 'Network.requestWillBeSent', {
+      requestId: 'request-old',
+      type: 'XHR',
+      request: { method: 'GET', url: 'https://example.test/api/state' },
+    });
+    harness.emit('message', 'Network.responseReceived', {
+      requestId: 'request-old',
+      response: { url: 'https://example.test/api/state', status: 200 },
+    });
+    harness.emit('message', 'Network.loadingFinished', { requestId: 'request-old' });
+
+    const pendingBody = network.readResponseBody(harness.wc, {
+      url: '/api/state',
+      timeoutMs: 1_000,
+    });
+    await Promise.resolve();
+    expect(harness.sendCommand).not.toHaveBeenCalledWith(
+      'Network.getResponseBody',
+      { requestId: 'request-old' },
+    );
+    harness.emit('message', 'Network.requestWillBeSent', {
+      requestId: 'request-new',
+      type: 'XHR',
+      request: { method: 'GET', url: 'https://example.test/api/state' },
+    });
+    harness.emit('message', 'Network.responseReceived', {
+      requestId: 'request-new',
+      response: { url: 'https://example.test/api/state', status: 200 },
+    });
+    harness.emit('message', 'Network.loadingFinished', { requestId: 'request-new' });
+
+    await expect(pendingBody).resolves.toMatchObject({
+      url: 'https://example.test/api/state',
+      body: '{"ok":true}',
+    });
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'Network.getResponseBody',
+      { requestId: 'request-new' },
+    );
+  });
+
+  it('removes URL credentials from request and response output', async () => {
+    const harness = networkHarness();
+    const network = new RsbWebviewNetwork({ warn: vi.fn() });
+    await network.observe(harness.wc);
+    const pendingBody = network.readResponseBody(harness.wc, {
+      url: '/private',
+      timeoutMs: 1_000,
+    });
+    await Promise.resolve();
+    harness.emit('message', 'Network.requestWillBeSent', {
+      requestId: 'request-secret',
+      type: 'XHR',
+      request: {
+        method: 'GET',
+        url: 'https://user:password@example.test/private',
+      },
+    });
+    harness.emit('message', 'Network.responseReceived', {
+      requestId: 'request-secret',
+      response: {
+        url: 'https://user:password@example.test/private',
+        status: 200,
+      },
+    });
+    harness.emit('message', 'Network.loadingFinished', { requestId: 'request-secret' });
+
+    expect(network.readRequests(harness.wc)[0].url).toBe('https://example.test/private');
+    await expect(pendingBody).resolves.toMatchObject({
+      url: 'https://example.test/private',
+    });
   });
 
   it('waits for an actual quiet network window', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-upload-policy.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-upload-policy.test.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveUploadFiles } from '../rsb-webview-upload-policy.js';
+
+let tempRoot = '';
+let allowedRoot = '';
+let outsideRoot = '';
+
+beforeEach(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-browser-upload-test-'));
+  allowedRoot = path.join(tempRoot, 'workspace');
+  outsideRoot = path.join(tempRoot, 'outside');
+  await fs.mkdir(allowedRoot);
+  await fs.mkdir(outsideRoot);
+});
+
+afterEach(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+describe('resolveUploadFiles', () => {
+  it('accepts ordinary files inside an allowed root', async () => {
+    const file = path.join(allowedRoot, 'report.txt');
+    await fs.writeFile(file, 'hello');
+
+    await expect(resolveUploadFiles([file], [allowedRoot])).resolves.toEqual([
+      await fs.realpath(file),
+    ]);
+  });
+
+  it('rejects files outside the session roots and sensitive names', async () => {
+    const outside = path.join(outsideRoot, 'outside.txt');
+    const secret = path.join(allowedRoot, '.env.local');
+    await fs.writeFile(outside, 'outside');
+    await fs.writeFile(secret, 'TOKEN=not-real');
+
+    await expect(resolveUploadFiles([outside], [allowedRoot])).rejects.toThrow(
+      'inside the current session directory',
+    );
+    await expect(resolveUploadFiles([secret], [allowedRoot])).rejects.toThrow(
+      'blocked for sensitive file',
+    );
+  });
+
+  it('resolves links before checking containment', async () => {
+    const outside = path.join(outsideRoot, 'linked.txt');
+    const linkDir = path.join(allowedRoot, 'linked-outside');
+    await fs.writeFile(outside, 'outside');
+    await fs.symlink(outsideRoot, linkDir, 'junction');
+
+    await expect(
+      resolveUploadFiles([path.join(linkDir, 'linked.txt')], [allowedRoot]),
+    ).rejects.toThrow('inside the current session directory');
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -147,6 +147,7 @@ export class RsbWebviewArtifacts {
   constructor(
     private readonly rootDir: () => string,
     private readonly logger: ArtifactLogger,
+    private readonly downloadGraceMs = DOWNLOAD_GRACE_MS,
   ) {}
 
   async capture<T>(
@@ -180,7 +181,7 @@ export class RsbWebviewArtifacts {
     let value: T;
     try {
       value = await action();
-      await wait(DOWNLOAD_GRACE_MS);
+      await wait(this.downloadGraceMs);
     } catch (err) {
       capture.accepting = false;
       this.captures.delete(wc);

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -1,0 +1,299 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { WebContents } from 'electron';
+
+interface ArtifactLogger {
+  warn(message: string, ...args: unknown[]): void;
+}
+
+interface DownloadItemLike {
+  getFilename(): string;
+  getURL(): string;
+  getMimeType(): string;
+  getTotalBytes(): number;
+  getReceivedBytes(): number;
+  setSavePath(filePath: string): void;
+  cancel(): void;
+  once(event: string, listener: (...args: unknown[]) => void): void;
+}
+
+interface SessionLike {
+  on(event: string, listener: (...args: unknown[]) => void): void;
+  removeListener(event: string, listener: (...args: unknown[]) => void): void;
+}
+
+export interface BrowserArtifact {
+  id: string;
+  fileName: string;
+  path?: string;
+  url?: string;
+  mimeType?: string;
+  bytes?: number;
+  state: 'completed' | 'cancelled' | 'interrupted';
+  startedAt: string;
+  finishedAt: string;
+}
+
+interface PendingDownload {
+  item: DownloadItemLike;
+  done: Promise<BrowserArtifact>;
+}
+
+interface ArtifactCapture {
+  id: string;
+  webContents: WebContents;
+  directory: string;
+  accepting: boolean;
+  pending: PendingDownload[];
+  usedNames: Set<string>;
+}
+
+const DOWNLOAD_GRACE_MS = 250;
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 60_000;
+const MAX_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+const MAX_RECENT_ARTIFACTS = 100;
+
+let captureSequence = 0;
+let artifactSequence = 0;
+
+function safeSegment(value: string): string {
+  const cleaned = value.replace(/[^A-Za-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '');
+  return (cleaned || 'session').slice(0, 64);
+}
+
+function safeFileName(raw: string): string {
+  const base = raw.split(/[\\/]/).pop() ?? '';
+  let cleaned = base
+    // eslint-disable-next-line no-control-regex -- control characters are invalid in filenames
+    .replace(/[\u0000-\u001f<>:"|?*]/g, '')
+    .replace(/^\.+/, '')
+    .replace(/[. ]+$/, '')
+    .trim();
+  if (!cleaned || cleaned === '..') cleaned = 'download';
+  if (cleaned.length > 160) cleaned = cleaned.slice(-160);
+  if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i.test(cleaned)) {
+    cleaned = `_${cleaned}`;
+  }
+  return cleaned;
+}
+
+function uniqueName(base: string, used: Set<string>): string {
+  const extension = path.extname(base);
+  const stem = base.slice(0, base.length - extension.length);
+  let candidate = base;
+  for (let index = 2; used.has(candidate.toLowerCase()); index += 1) {
+    candidate = `${stem}-${index}${extension}`;
+  }
+  used.add(candidate.toLowerCase());
+  return candidate;
+}
+
+function sessionFor(wc: WebContents): SessionLike {
+  const session = (wc as unknown as { session?: SessionLike }).session;
+  if (!session) throw new Error('webContents session is unavailable');
+  return session;
+}
+
+function boundedTimeout(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.min(MAX_DOWNLOAD_TIMEOUT_MS, Math.floor(value))
+    : DEFAULT_DOWNLOAD_TIMEOUT_MS;
+}
+
+function displayUrl(value: string): string | undefined {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.href;
+  } catch {
+    return undefined;
+  }
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Captures downloads only while an agent-owned browser action is in flight.
+ * Each action gets an isolated directory; failed and cancelled files are
+ * removed, while completed files remain available for later tool steps.
+ */
+export class RsbWebviewArtifacts {
+  private readonly sessionListeners = new Map<SessionLike, (...args: unknown[]) => void>();
+  private readonly captures = new Map<WebContents, ArtifactCapture>();
+  private readonly recent: BrowserArtifact[] = [];
+
+  constructor(
+    private readonly rootDir: () => string,
+    private readonly logger: ArtifactLogger,
+  ) {}
+
+  async capture<T>(
+    wc: WebContents,
+    context: { sessionId: string; timeoutMs?: number },
+    action: () => Promise<T>,
+  ): Promise<{ value: T; downloads: BrowserArtifact[] }> {
+    if (this.captures.has(wc)) {
+      throw new Error('another download-aware action is already running for this tab');
+    }
+    const session = sessionFor(wc);
+    this.observeSession(session);
+    const parent = path.join(this.rootDir(), safeSegment(context.sessionId));
+    await fs.promises.mkdir(parent, { recursive: true });
+    captureSequence += 1;
+    const directory = await fs.promises.mkdtemp(
+      path.join(parent, `${Date.now().toString(36)}-${captureSequence.toString(36)}-`),
+    );
+    const capture: ArtifactCapture = {
+      id: `${Date.now().toString(36)}-${captureSequence.toString(36)}`,
+      webContents: wc,
+      directory,
+      accepting: true,
+      pending: [],
+      usedNames: new Set(),
+    };
+    this.captures.set(wc, capture);
+
+    let value: T;
+    try {
+      value = await action();
+      await wait(DOWNLOAD_GRACE_MS);
+    } catch (err) {
+      capture.accepting = false;
+      this.captures.delete(wc);
+      for (const pending of capture.pending) pending.item.cancel();
+      await this.removeDirectory(directory);
+      throw err;
+    }
+    capture.accepting = false;
+    this.captures.delete(wc);
+
+    if (capture.pending.length === 0) {
+      await this.removeDirectory(directory);
+      return { value, downloads: [] };
+    }
+
+    const timeoutMs = boundedTimeout(context.timeoutMs);
+    const completion = Promise.all(capture.pending.map((entry) => entry.done));
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<BrowserArtifact[]>((_resolve, reject) => {
+      timeoutHandle = setTimeout(() => {
+        for (const pending of capture.pending) pending.item.cancel();
+        reject(new Error(`download did not finish within ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+    let downloads: BrowserArtifact[];
+    try {
+      downloads = await Promise.race([completion, timeout]);
+    } catch (err) {
+      await this.removeDirectory(directory);
+      throw err;
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
+    for (const artifact of downloads) {
+      this.recent.push(artifact);
+    }
+    if (this.recent.length > MAX_RECENT_ARTIFACTS) {
+      this.recent.splice(0, this.recent.length - MAX_RECENT_ARTIFACTS);
+    }
+    if (!downloads.some((artifact) => artifact.state === 'completed')) {
+      await this.removeDirectory(directory);
+    }
+    return { value, downloads };
+  }
+
+  diagnostics(): { activeCaptures: number; recentArtifacts: BrowserArtifact[] } {
+    return {
+      activeCaptures: this.captures.size,
+      recentArtifacts: this.recent.slice(-20).map((artifact) => ({ ...artifact })),
+    };
+  }
+
+  async dispose(): Promise<void> {
+    for (const [session, listener] of this.sessionListeners) {
+      session.removeListener('will-download', listener);
+    }
+    this.sessionListeners.clear();
+    const active = [...this.captures.values()];
+    this.captures.clear();
+    await Promise.all(active.map(async (capture) => {
+      capture.accepting = false;
+      for (const pending of capture.pending) pending.item.cancel();
+      await this.removeDirectory(capture.directory);
+    }));
+  }
+
+  private observeSession(session: SessionLike): void {
+    if (this.sessionListeners.has(session)) return;
+    const listener = (...args: unknown[]) => {
+      const item = args[1] as DownloadItemLike | undefined;
+      const wc = args[2] as WebContents | undefined;
+      if (!item || !wc) return;
+      const capture = this.captures.get(wc);
+      if (!capture?.accepting) return;
+      this.trackDownload(capture, item);
+    };
+    session.on('will-download', listener);
+    this.sessionListeners.set(session, listener);
+  }
+
+  private trackDownload(capture: ArtifactCapture, item: DownloadItemLike): void {
+    artifactSequence += 1;
+    const id = `artifact-${Date.now().toString(36)}-${artifactSequence.toString(36)}`;
+    const fileName = uniqueName(safeFileName(item.getFilename()), capture.usedNames);
+    const filePath = path.join(capture.directory, fileName);
+    const startedAt = new Date().toISOString();
+    item.setSavePath(filePath);
+    const done = new Promise<BrowserArtifact>((resolve) => {
+      item.once('done', (_event: unknown, rawState: unknown) => {
+        const state = rawState === 'completed'
+          ? 'completed'
+          : rawState === 'cancelled'
+            ? 'cancelled'
+            : 'interrupted';
+        if (state !== 'completed') {
+          try {
+            fs.rmSync(filePath, { force: true });
+          } catch (err) {
+            this.logger.warn('failed to remove incomplete browser artifact', {
+              artifactId: id,
+              err,
+            });
+          }
+        }
+        const totalBytes = item.getTotalBytes();
+        const receivedBytes = item.getReceivedBytes();
+        const url = displayUrl(item.getURL());
+        resolve({
+          id,
+          fileName,
+          ...(state === 'completed' ? { path: filePath } : {}),
+          ...(url ? { url } : {}),
+          ...(item.getMimeType() ? { mimeType: item.getMimeType() } : {}),
+          ...(Number.isFinite(totalBytes) && totalBytes > 0
+            ? { bytes: totalBytes }
+            : Number.isFinite(receivedBytes) && receivedBytes > 0
+              ? { bytes: receivedBytes }
+              : {}),
+          state,
+          startedAt,
+          finishedAt: new Date().toISOString(),
+        });
+      });
+    });
+    capture.pending.push({ item, done });
+  }
+
+  private async removeDirectory(directory: string): Promise<void> {
+    try {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    } catch (err) {
+      this.logger.warn('failed to clean browser artifact directory', { err });
+    }
+  }
+}

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -76,6 +76,10 @@ function safeSegment(value: string): string {
   return (cleaned || 'session').slice(0, 64);
 }
 
+export function artifactSessionRoot(rootDir: string, sessionId: string): string {
+  return path.join(rootDir, safeSegment(sessionId));
+}
+
 function safeFileName(raw: string): string {
   const base = raw.split(/[\\/]/).pop() ?? '';
   let cleaned = base
@@ -160,7 +164,7 @@ export class RsbWebviewArtifacts {
     }
     const session = sessionFor(wc);
     this.observeSession(session);
-    const parent = path.join(this.rootDir(), safeSegment(context.sessionId));
+    const parent = artifactSessionRoot(this.rootDir(), context.sessionId);
     await fs.promises.mkdir(parent, { recursive: true });
     captureSequence += 1;
     const directory = await fs.promises.mkdtemp(

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -42,6 +42,7 @@ interface PendingDownload {
   filePath?: string;
   knownTotalBytes?: number;
   limitReason?: string;
+  reservationReleased?: boolean;
 }
 
 interface ArtifactCapture {
@@ -302,6 +303,7 @@ export class RsbWebviewArtifacts {
           : rawState === 'cancelled'
             ? 'cancelled'
             : 'interrupted';
+      if (state !== 'completed') this.releaseReservation(capture, pending);
       if (state !== 'completed' && pending.filePath) {
         try {
           fs.rmSync(pending.filePath, { force: true });
@@ -325,14 +327,17 @@ export class RsbWebviewArtifacts {
         finishedAt: new Date().toISOString(),
       });
     });
-    capture.pending.push(pending);
 
     const quotaReason = this.quotaReason(capture, totalBytes);
     if (quotaReason) {
       this.cancelForQuota(pending, quotaReason);
+      if (capture.pending.length < MAX_DOWNLOADS_PER_CAPTURE) {
+        capture.pending.push(pending);
+      }
       return;
     }
 
+    capture.pending.push(pending);
     if (totalBytes) capture.reservedBytes += totalBytes;
     pending.filePath = filePath;
     item.setSavePath(filePath);
@@ -354,7 +359,7 @@ export class RsbWebviewArtifacts {
   }
 
   private quotaReason(capture: ArtifactCapture, totalBytes: number | undefined): string | undefined {
-    if (capture.pending.length > MAX_DOWNLOADS_PER_CAPTURE) {
+    if (capture.pending.length >= MAX_DOWNLOADS_PER_CAPTURE) {
       return 'capture exceeds the download count limit';
     }
     if (totalBytes && totalBytes > MAX_DOWNLOAD_BYTES_PER_FILE) {
@@ -383,6 +388,12 @@ export class RsbWebviewArtifacts {
       if (pending.knownTotalBytes || pending.limitReason) return sum;
       return sum + (this.positiveBytes(pending.item.getReceivedBytes()) ?? 0);
     }, 0);
+  }
+
+  private releaseReservation(capture: ArtifactCapture, pending: PendingDownload): void {
+    if (!pending.knownTotalBytes || pending.reservationReleased) return;
+    pending.reservationReleased = true;
+    capture.reservedBytes = Math.max(0, capture.reservedBytes - pending.knownTotalBytes);
   }
 
   private positiveBytes(value: number): number | undefined {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -15,6 +15,7 @@ interface DownloadItemLike {
   getReceivedBytes(): number;
   setSavePath(filePath: string): void;
   cancel(): void;
+  on(event: string, listener: (...args: unknown[]) => void): void;
   once(event: string, listener: (...args: unknown[]) => void): void;
 }
 
@@ -38,6 +39,9 @@ export interface BrowserArtifact {
 interface PendingDownload {
   item: DownloadItemLike;
   done: Promise<BrowserArtifact>;
+  filePath?: string;
+  knownTotalBytes?: number;
+  limitReason?: string;
 }
 
 interface ArtifactCapture {
@@ -47,12 +51,17 @@ interface ArtifactCapture {
   accepting: boolean;
   pending: PendingDownload[];
   usedNames: Set<string>;
+  reservedBytes: number;
 }
 
 const DOWNLOAD_GRACE_MS = 250;
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 60_000;
 const MAX_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+const MAX_DOWNLOADS_PER_CAPTURE = 8;
+const MAX_DOWNLOAD_BYTES_PER_FILE = 32 * 1024 * 1024;
+const MAX_DOWNLOAD_BYTES_PER_CAPTURE = 64 * 1024 * 1024;
 const MAX_RECENT_ARTIFACTS = 100;
+const MAX_RETAINED_ARTIFACT_BYTES = 256 * 1024 * 1024;
 
 let captureSequence = 0;
 let artifactSequence = 0;
@@ -119,13 +128,15 @@ function wait(ms: number): Promise<void> {
 
 /**
  * Captures downloads only while an agent-owned browser action is in flight.
- * Each action gets an isolated directory; failed and cancelled files are
- * removed, while completed files remain available for later tool steps.
+ * Each action gets an isolated directory with bounded count and byte quotas.
+ * Failed, cancelled, evicted, and disposed files are removed; completed files
+ * remain available for later tool steps until the retention budget is reached.
  */
 export class RsbWebviewArtifacts {
   private readonly sessionListeners = new Map<SessionLike, (...args: unknown[]) => void>();
   private readonly captures = new Map<WebContents, ArtifactCapture>();
   private readonly recent: BrowserArtifact[] = [];
+  private retainedBytes = 0;
 
   constructor(
     private readonly rootDir: () => string,
@@ -155,6 +166,7 @@ export class RsbWebviewArtifacts {
       accepting: true,
       pending: [],
       usedNames: new Set(),
+      reservedBytes: 0,
     };
     this.captures.set(wc, capture);
 
@@ -196,11 +208,13 @@ export class RsbWebviewArtifacts {
       if (timeoutHandle) clearTimeout(timeoutHandle);
     }
     for (const artifact of downloads) {
+      if (artifact.state === 'completed' && artifact.path && artifact.bytes === undefined) {
+        artifact.bytes = await this.fileSize(artifact.path);
+      }
       this.recent.push(artifact);
+      if (artifact.path && artifact.bytes) this.retainedBytes += artifact.bytes;
     }
-    if (this.recent.length > MAX_RECENT_ARTIFACTS) {
-      this.recent.splice(0, this.recent.length - MAX_RECENT_ARTIFACTS);
-    }
+    await this.trimRecent();
     if (!downloads.some((artifact) => artifact.state === 'completed')) {
       await this.removeDirectory(directory);
     }
@@ -226,6 +240,11 @@ export class RsbWebviewArtifacts {
       for (const pending of capture.pending) pending.item.cancel();
       await this.removeDirectory(capture.directory);
     }));
+    const retained = this.recent.splice(0);
+    this.retainedBytes = 0;
+    await Promise.all(retained.map((artifact) => (
+      artifact.path ? this.removeArtifactFile(artifact.path) : Promise.resolve()
+    )));
   }
 
   private observeSession(session: SessionLike): void {
@@ -248,45 +267,158 @@ export class RsbWebviewArtifacts {
     const fileName = uniqueName(safeFileName(item.getFilename()), capture.usedNames);
     const filePath = path.join(capture.directory, fileName);
     const startedAt = new Date().toISOString();
-    item.setSavePath(filePath);
+    const totalBytes = this.positiveBytes(item.getTotalBytes());
+    let finishDownload: (artifact: BrowserArtifact) => void = () => undefined;
     const done = new Promise<BrowserArtifact>((resolve) => {
-      item.once('done', (_event: unknown, rawState: unknown) => {
-        const state = rawState === 'completed'
+      finishDownload = resolve;
+    });
+    const pending: PendingDownload = {
+      item,
+      ...(totalBytes ? { knownTotalBytes: totalBytes } : {}),
+      done,
+    };
+    item.once('done', (_event: unknown, rawState: unknown) => {
+      const receivedBytes = this.positiveBytes(item.getReceivedBytes());
+      const observedBytes = Math.max(totalBytes ?? 0, receivedBytes ?? 0);
+      const exceededFileQuota = observedBytes > MAX_DOWNLOAD_BYTES_PER_FILE;
+      const exceededCaptureQuota = this.receivedBytes(capture) > MAX_DOWNLOAD_BYTES_PER_CAPTURE;
+      const state = pending.limitReason || exceededFileQuota || exceededCaptureQuota
+        ? 'cancelled'
+        : rawState === 'completed'
           ? 'completed'
           : rawState === 'cancelled'
             ? 'cancelled'
             : 'interrupted';
-        if (state !== 'completed') {
-          try {
-            fs.rmSync(filePath, { force: true });
-          } catch (err) {
-            this.logger.warn('failed to remove incomplete browser artifact', {
-              artifactId: id,
-              err,
-            });
-          }
+      if (state !== 'completed' && pending.filePath) {
+        try {
+          fs.rmSync(pending.filePath, { force: true });
+        } catch (err) {
+          this.logger.warn('failed to remove incomplete browser artifact', {
+            artifactId: id,
+            err,
+          });
         }
-        const totalBytes = item.getTotalBytes();
-        const receivedBytes = item.getReceivedBytes();
-        const url = displayUrl(item.getURL());
-        resolve({
-          id,
-          fileName,
-          ...(state === 'completed' ? { path: filePath } : {}),
-          ...(url ? { url } : {}),
-          ...(item.getMimeType() ? { mimeType: item.getMimeType() } : {}),
-          ...(Number.isFinite(totalBytes) && totalBytes > 0
-            ? { bytes: totalBytes }
-            : Number.isFinite(receivedBytes) && receivedBytes > 0
-              ? { bytes: receivedBytes }
-              : {}),
-          state,
-          startedAt,
-          finishedAt: new Date().toISOString(),
-        });
+      }
+      const url = displayUrl(item.getURL());
+      finishDownload({
+        id,
+        fileName,
+        ...(state === 'completed' && pending.filePath ? { path: pending.filePath } : {}),
+        ...(url ? { url } : {}),
+        ...(item.getMimeType() ? { mimeType: item.getMimeType() } : {}),
+        ...(observedBytes > 0 ? { bytes: observedBytes } : {}),
+        state,
+        startedAt,
+        finishedAt: new Date().toISOString(),
       });
     });
-    capture.pending.push({ item, done });
+    capture.pending.push(pending);
+
+    const quotaReason = this.quotaReason(capture, totalBytes);
+    if (quotaReason) {
+      this.cancelForQuota(pending, quotaReason);
+      return;
+    }
+
+    if (totalBytes) capture.reservedBytes += totalBytes;
+    pending.filePath = filePath;
+    item.setSavePath(filePath);
+    item.on('updated', () => {
+      if (pending.limitReason) return;
+      const receivedBytes = this.positiveBytes(item.getReceivedBytes());
+      if (
+        (receivedBytes && receivedBytes > MAX_DOWNLOAD_BYTES_PER_FILE)
+        || this.receivedBytes(capture) > MAX_DOWNLOAD_BYTES_PER_CAPTURE
+      ) {
+        this.cancelForQuota(
+          pending,
+          receivedBytes && receivedBytes > MAX_DOWNLOAD_BYTES_PER_FILE
+            ? 'single download exceeds the size limit'
+            : 'capture exceeds the total download limit',
+        );
+      }
+    });
+  }
+
+  private quotaReason(capture: ArtifactCapture, totalBytes: number | undefined): string | undefined {
+    if (capture.pending.length > MAX_DOWNLOADS_PER_CAPTURE) {
+      return 'capture exceeds the download count limit';
+    }
+    if (totalBytes && totalBytes > MAX_DOWNLOAD_BYTES_PER_FILE) {
+      return 'single download exceeds the size limit';
+    }
+    if (
+      totalBytes
+      && capture.reservedBytes + totalBytes > MAX_DOWNLOAD_BYTES_PER_CAPTURE
+    ) {
+      return 'capture exceeds the total download limit';
+    }
+    return undefined;
+  }
+
+  private cancelForQuota(pending: PendingDownload, reason: string): void {
+    pending.limitReason = reason;
+    this.logger.warn('browser download cancelled by quota', {
+      reason,
+      fileName: pending.item.getFilename(),
+    });
+    pending.item.cancel();
+  }
+
+  private receivedBytes(capture: ArtifactCapture): number {
+    return capture.reservedBytes + capture.pending.reduce((sum, pending) => {
+      if (pending.knownTotalBytes || pending.limitReason) return sum;
+      return sum + (this.positiveBytes(pending.item.getReceivedBytes()) ?? 0);
+    }, 0);
+  }
+
+  private positiveBytes(value: number): number | undefined {
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  }
+
+  private async fileSize(filePath: string): Promise<number | undefined> {
+    try {
+      const stat = await fs.promises.stat(filePath);
+      return stat.isFile() ? stat.size : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async trimRecent(): Promise<void> {
+    const evicted: BrowserArtifact[] = [];
+    while (
+      this.recent.length > MAX_RECENT_ARTIFACTS
+      || this.retainedBytes > MAX_RETAINED_ARTIFACT_BYTES
+    ) {
+      const artifact = this.recent.shift();
+      if (!artifact) break;
+      evicted.push(artifact);
+      if (artifact.path && artifact.bytes) this.retainedBytes -= artifact.bytes;
+    }
+    await Promise.all(evicted.map((artifact) => (
+      artifact.path ? this.removeArtifactFile(artifact.path) : Promise.resolve()
+    )));
+  }
+
+  private async removeArtifactFile(filePath: string): Promise<void> {
+    try {
+      await fs.promises.rm(filePath, { force: true });
+    } catch (err) {
+      this.logger.warn('failed to remove retained browser artifact', {
+        filePath,
+        err,
+      });
+      return;
+    }
+    try {
+      await fs.promises.rmdir(path.dirname(filePath));
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ENOTEMPTY') {
+        this.logger.warn('failed to remove empty browser artifact directory', { err });
+      }
+    }
   }
 
   private async removeDirectory(directory: string): Promise<void> {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -59,7 +59,7 @@ interface ArtifactCapture {
 // A click can schedule a download after the event handler returns (for
 // example, a page may first fetch a signed URL). Keep this wait bounded while
 // allowing normal deferred download starts to be observed.
-const DOWNLOAD_GRACE_MS = 1_000;
+const DOWNLOAD_GRACE_MS = 2_000;
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 60_000;
 const MAX_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 const MAX_DOWNLOADS_PER_CAPTURE = 8;

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -385,8 +385,12 @@ export class RsbWebviewArtifacts {
 
   private receivedBytes(capture: ArtifactCapture): number {
     return capture.reservedBytes + capture.pending.reduce((sum, pending) => {
-      if (pending.knownTotalBytes || pending.limitReason) return sum;
-      return sum + (this.positiveBytes(pending.item.getReceivedBytes()) ?? 0);
+      if (pending.limitReason) return sum;
+      const received = this.positiveBytes(pending.item.getReceivedBytes()) ?? 0;
+      if (pending.knownTotalBytes) {
+        return sum + Math.max(0, received - pending.knownTotalBytes);
+      }
+      return sum + received;
     }, 0);
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -76,8 +76,35 @@ function safeSegment(value: string): string {
   return (cleaned || 'session').slice(0, 64);
 }
 
+function processArtifactRoot(rootDir: string): string {
+  return path.join(rootDir, `process-${process.pid}`);
+}
+
 export function artifactSessionRoot(rootDir: string, sessionId: string): string {
-  return path.join(rootDir, safeSegment(sessionId));
+  return path.join(processArtifactRoot(rootDir), safeSegment(sessionId));
+}
+
+async function reclaimStaleProcessRoots(rootDir: string): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(rootDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  await Promise.all(entries.map(async (entry) => {
+    if (!entry.isDirectory()) return;
+    const match = /^process-(\d+)$/.exec(entry.name);
+    if (!match) return;
+    const pid = Number(match[1]);
+    if (!Number.isSafeInteger(pid) || pid === process.pid) return;
+    try {
+      process.kill(pid, 0);
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') return;
+    }
+    await fs.promises.rm(path.join(rootDir, entry.name), { recursive: true, force: true });
+  }));
 }
 
 function safeFileName(raw: string): string {
@@ -146,6 +173,7 @@ export class RsbWebviewArtifacts {
   private readonly captures = new Map<WebContents, ArtifactCapture>();
   private readonly recent: BrowserArtifact[] = [];
   private readonly artifactSessions = new Map<string, string>();
+  private readonly preparedRoots = new Set<string>();
   private retainedBytes = 0;
 
   constructor(
@@ -164,7 +192,13 @@ export class RsbWebviewArtifacts {
     }
     const session = sessionFor(wc);
     this.observeSession(session);
-    const parent = artifactSessionRoot(this.rootDir(), context.sessionId);
+    const rootDir = this.rootDir();
+    if (!this.preparedRoots.has(rootDir)) {
+      await fs.promises.mkdir(rootDir, { recursive: true });
+      await reclaimStaleProcessRoots(rootDir);
+      this.preparedRoots.add(rootDir);
+    }
+    const parent = artifactSessionRoot(rootDir, context.sessionId);
     await fs.promises.mkdir(parent, { recursive: true });
     captureSequence += 1;
     const directory = await fs.promises.mkdtemp(

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-artifacts.ts
@@ -46,6 +46,7 @@ interface PendingDownload {
 
 interface ArtifactCapture {
   id: string;
+  sessionId: string;
   webContents: WebContents;
   directory: string;
   accepting: boolean;
@@ -54,7 +55,10 @@ interface ArtifactCapture {
   reservedBytes: number;
 }
 
-const DOWNLOAD_GRACE_MS = 250;
+// A click can schedule a download after the event handler returns (for
+// example, a page may first fetch a signed URL). Keep this wait bounded while
+// allowing normal deferred download starts to be observed.
+const DOWNLOAD_GRACE_MS = 1_000;
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 60_000;
 const MAX_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 const MAX_DOWNLOADS_PER_CAPTURE = 8;
@@ -136,6 +140,7 @@ export class RsbWebviewArtifacts {
   private readonly sessionListeners = new Map<SessionLike, (...args: unknown[]) => void>();
   private readonly captures = new Map<WebContents, ArtifactCapture>();
   private readonly recent: BrowserArtifact[] = [];
+  private readonly artifactSessions = new Map<string, string>();
   private retainedBytes = 0;
 
   constructor(
@@ -161,6 +166,7 @@ export class RsbWebviewArtifacts {
     );
     const capture: ArtifactCapture = {
       id: `${Date.now().toString(36)}-${captureSequence.toString(36)}`,
+      sessionId: context.sessionId,
       webContents: wc,
       directory,
       accepting: true,
@@ -212,6 +218,7 @@ export class RsbWebviewArtifacts {
         artifact.bytes = await this.fileSize(artifact.path);
       }
       this.recent.push(artifact);
+      this.artifactSessions.set(artifact.id, context.sessionId);
       if (artifact.path && artifact.bytes) this.retainedBytes += artifact.bytes;
     }
     await this.trimRecent();
@@ -221,10 +228,15 @@ export class RsbWebviewArtifacts {
     return { value, downloads };
   }
 
-  diagnostics(): { activeCaptures: number; recentArtifacts: BrowserArtifact[] } {
+  diagnostics(sessionId?: string): { activeCaptures: number; recentArtifacts: BrowserArtifact[] } {
     return {
-      activeCaptures: this.captures.size,
-      recentArtifacts: this.recent.slice(-20).map((artifact) => ({ ...artifact })),
+      activeCaptures: [...this.captures.values()]
+        .filter((capture) => !sessionId || capture.sessionId === sessionId)
+        .length,
+      recentArtifacts: this.recent
+        .filter((artifact) => !sessionId || this.artifactSessions.get(artifact.id) === sessionId)
+        .slice(-20)
+        .map((artifact) => ({ ...artifact })),
     };
   }
 
@@ -241,6 +253,7 @@ export class RsbWebviewArtifacts {
       await this.removeDirectory(capture.directory);
     }));
     const retained = this.recent.splice(0);
+    this.artifactSessions.clear();
     this.retainedBytes = 0;
     await Promise.all(retained.map((artifact) => (
       artifact.path ? this.removeArtifactFile(artifact.path) : Promise.resolve()
@@ -394,6 +407,7 @@ export class RsbWebviewArtifacts {
       const artifact = this.recent.shift();
       if (!artifact) break;
       evicted.push(artifact);
+      this.artifactSessions.delete(artifact.id);
       if (artifact.path && artifact.bytes) this.retainedBytes -= artifact.bytes;
     }
     await Promise.all(evicted.map((artifact) => (
@@ -417,6 +431,17 @@ export class RsbWebviewArtifacts {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== 'ENOENT' && code !== 'ENOTEMPTY') {
         this.logger.warn('failed to remove empty browser artifact directory', { err });
+      }
+      return;
+    }
+    try {
+      // Capture directories live below a session directory. Reclaim that
+      // parent too once the last retained file for the session is gone.
+      await fs.promises.rmdir(path.dirname(path.dirname(filePath)));
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ENOTEMPTY') {
+        this.logger.warn('failed to remove empty browser artifact session directory', { err });
       }
     }
   }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -194,11 +194,11 @@ function buildSnapshotTree(nodes: RawAxNode[]): { tree: SnapshotTreeNode[]; root
     const nodeId = raw.nodeId;
     const backendDOMNodeId = raw.backendDOMNodeId;
     if (
-      raw.ignored === true
-      || typeof nodeId !== 'string'
-      || nodeId === ''
-      || typeof backendDOMNodeId !== 'number'
-      || backendDOMNodeId <= 0
+      raw.ignored === true ||
+      typeof nodeId !== 'string' ||
+      nodeId === '' ||
+      typeof backendDOMNodeId !== 'number' ||
+      backendDOMNodeId <= 0
     ) {
       continue;
     }
@@ -262,10 +262,7 @@ function shouldReference(node: SnapshotTreeNode): boolean {
   return Boolean(node.name) && !STRUCTURAL_ROLES.has(node.role);
 }
 
-function shouldRender(
-  node: SnapshotTreeNode,
-  req: BrowserControlRequest,
-): boolean {
+function shouldRender(node: SnapshotTreeNode, req: BrowserControlRequest): boolean {
   if (typeof req.depth === 'number' && node.depth > req.depth) return false;
   if (req.interactive === true) return INTERACTIVE_ROLES.has(node.role);
   if (req.compact === true && STRUCTURAL_ROLES.has(node.role) && !node.name && !node.ref) {
@@ -325,30 +322,38 @@ async function resolveHref(
   send: DebuggerTransport['sendCommand'],
   backendDOMNodeId: number,
 ): Promise<string | undefined> {
-  const resolved = await send('DOM.resolveNode', { backendNodeId: backendDOMNodeId }) as {
+  const resolved = (await send('DOM.resolveNode', { backendNodeId: backendDOMNodeId })) as {
     object?: { objectId?: string };
   };
   const objectId = resolved.object?.objectId;
   if (!objectId) return undefined;
   try {
-    const result = await send('Runtime.callFunctionOn', {
+    const result = (await send('Runtime.callFunctionOn', {
       objectId,
       functionDeclaration: 'function() { return typeof this.href === "string" ? this.href : ""; }',
       returnByValue: true,
-    }) as { result?: { value?: unknown } };
+    })) as { result?: { value?: unknown } };
     return typeof result.result?.value === 'string' && result.result.value !== ''
       ? result.result.value
       : undefined;
   } finally {
-    await send('Runtime.releaseObject', { objectId }).catch(() => undefined);
+    await releaseObject(send, objectId);
   }
+}
+
+async function releaseObject(
+  send: DebuggerTransport['sendCommand'],
+  objectId: string | undefined,
+): Promise<void> {
+  if (!objectId) return;
+  await send('Runtime.releaseObject', { objectId }).catch(() => undefined);
 }
 
 async function inspectPage(
   send: DebuggerTransport['sendCommand'],
   includeResources: boolean,
 ): Promise<PageInspection> {
-  const evaluated = await send('Runtime.evaluate', {
+  const evaluated = (await send('Runtime.evaluate', {
     expression: `(() => {
       const normalize = (value) => String(value ?? "").replace(/\\s+/g, " ").trim();
       const pageText = normalize(document.body?.innerText || "").slice(0, 6000);
@@ -423,7 +428,7 @@ async function inspectPage(
     })()`,
     awaitPromise: true,
     returnByValue: true,
-  }) as { result?: { value?: unknown }; exceptionDetails?: { text?: string } };
+  })) as { result?: { value?: unknown }; exceptionDetails?: { text?: string } };
   if (evaluated.exceptionDetails) {
     throw new Error(evaluated.exceptionDetails.text ?? 'page inspection failed');
   }
@@ -480,23 +485,27 @@ async function resolveFrameRoot(
   timeoutMs?: number,
 ): Promise<{ frameId: string; nodeId?: number }> {
   const frame = await resolveSelector(send, selector, timeoutMs);
-  const described = await send('DOM.describeNode', {
-    backendNodeId: frame.backendDOMNodeId,
-    depth: 1,
-  }) as {
-    node?: {
-      frameId?: string;
-      contentDocument?: { frameId?: string; nodeId?: number };
+  try {
+    const described = (await send('DOM.describeNode', {
+      backendNodeId: frame.backendDOMNodeId,
+      depth: 1,
+    })) as {
+      node?: {
+        frameId?: string;
+        contentDocument?: { frameId?: string; nodeId?: number };
+      };
     };
-  };
-  const frameId = described.node?.contentDocument?.frameId ?? described.node?.frameId;
-  if (!frameId) throw new Error(`frame selector did not resolve to an iframe: ${selector}`);
-  return {
-    frameId,
-    ...(described.node?.contentDocument?.nodeId
-      ? { nodeId: described.node.contentDocument.nodeId }
-      : {}),
-  };
+    const frameId = described.node?.contentDocument?.frameId ?? described.node?.frameId;
+    if (!frameId) throw new Error(`frame selector did not resolve to an iframe: ${selector}`);
+    return {
+      frameId,
+      ...(described.node?.contentDocument?.nodeId
+        ? { nodeId: described.node.contentDocument.nodeId }
+        : {}),
+    };
+  } finally {
+    await releaseObject(send, frame.objectId);
+  }
 }
 
 async function resolveSelectorInFrame(
@@ -504,14 +513,14 @@ async function resolveSelectorInFrame(
   frameNodeId: number,
   selector: string,
 ): Promise<ResolvedNode> {
-  const queried = await send('DOM.querySelector', {
+  const queried = (await send('DOM.querySelector', {
     nodeId: frameNodeId,
     selector,
-  }) as { nodeId?: number };
+  })) as { nodeId?: number };
   if (!queried.nodeId) throw new Error(`selector not found in frame: ${selector}`);
-  const described = await send('DOM.describeNode', {
+  const described = (await send('DOM.describeNode', {
     nodeId: queried.nodeId,
-  }) as { node?: { backendNodeId?: number } };
+  })) as { node?: { backendNodeId?: number } };
   if (!described.node?.backendNodeId) {
     throw new Error(`selector could not be resolved in frame: ${selector}`);
   }
@@ -527,10 +536,7 @@ async function resolveElementQuery(
   timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
   options?: { allowHidden?: boolean },
 ): Promise<ResolvedNode> {
-  if (
-    query.index !== undefined
-    && (!Number.isInteger(query.index) || query.index < 0)
-  ) {
+  if (query.index !== undefined && (!Number.isInteger(query.index) || query.index < 0)) {
     throw new Error('element query index must be a non-negative integer');
   }
   const hasLookupField = [
@@ -545,13 +551,9 @@ async function resolveElementQuery(
   if (!hasLookupField) {
     throw new Error('element query requires at least one field');
   }
-  const boundedTimeout = positiveInt(
-    timeoutMs,
-    DEFAULT_WAIT_TIMEOUT_MS,
-    MAX_WAIT_TIMEOUT_MS,
-  );
+  const boundedTimeout = positiveInt(timeoutMs, DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS);
   const allowHidden = options?.allowHidden === true;
-  const evaluated = await send('Runtime.evaluate', {
+  const evaluated = (await send('Runtime.evaluate', {
     expression: `(() => {
       const query = ${JSON.stringify(query)};
       const deadline = Date.now() + ${boundedTimeout};
@@ -687,7 +689,7 @@ async function resolveElementQuery(
     awaitPromise: true,
     returnByValue: false,
     timeout: boundedTimeout + 1_000,
-  }) as {
+  })) as {
     result?: { objectId?: string; subtype?: string };
     exceptionDetails?: {
       text?: string;
@@ -696,17 +698,18 @@ async function resolveElementQuery(
   };
   if (evaluated.exceptionDetails) {
     const details = evaluated.exceptionDetails;
-    const message = details.exception?.description
-      ?? (typeof details.exception?.value === 'string' ? details.exception.value : undefined)
-      ?? details.text
-      ?? 'element query failed';
+    const message =
+      details.exception?.description ??
+      (typeof details.exception?.value === 'string' ? details.exception.value : undefined) ??
+      details.text ??
+      'element query failed';
     throw new Error(message);
   }
   const objectId = evaluated.result?.objectId;
   if (!objectId || evaluated.result?.subtype === 'null') {
     throw new Error('element query did not resolve to an element');
   }
-  const described = await send('DOM.describeNode', { objectId }) as {
+  const described = (await send('DOM.describeNode', { objectId })) as {
     node?: { backendNodeId?: number };
   };
   return { objectId, backendDOMNodeId: described.node?.backendNodeId };
@@ -716,9 +719,9 @@ async function resolveRef(
   send: DebuggerTransport['sendCommand'],
   target: SnapshotRef,
 ): Promise<ResolvedNode> {
-  const resolved = await send('DOM.resolveNode', {
+  const resolved = (await send('DOM.resolveNode', {
     backendNodeId: target.backendDOMNodeId,
-  }) as { object?: { objectId?: string } };
+  })) as { object?: { objectId?: string } };
   const objectId = resolved.object?.objectId;
   if (!objectId) {
     throw new Error('snapshot ref is stale; take a new snapshot');
@@ -732,25 +735,38 @@ async function callOnNode<T>(
   functionDeclaration: string,
   args?: unknown[],
 ): Promise<T> {
-  const result = await send('Runtime.callFunctionOn', {
+  const result = (await send('Runtime.callFunctionOn', {
     objectId,
     functionDeclaration,
     arguments: args?.map((value) => ({ value })),
     returnByValue: true,
     awaitPromise: true,
     userGesture: true,
-  }) as {
+  })) as {
     result?: { value?: unknown };
     exceptionDetails?: { text?: string; exception?: { description?: string } };
   };
   if (result.exceptionDetails) {
     throw new Error(
-      result.exceptionDetails.exception?.description
-      ?? result.exceptionDetails.text
-      ?? 'page script failed',
+      result.exceptionDetails.exception?.description ??
+        result.exceptionDetails.text ??
+        'page script failed',
     );
   }
   return result.result?.value as T;
+}
+
+async function withReleasedNode<T>(
+  send: DebuggerTransport['sendCommand'],
+  resolve: () => Promise<ResolvedNode>,
+  body: (node: ResolvedNode) => Promise<T>,
+): Promise<T> {
+  const node = await resolve();
+  try {
+    return await body(node);
+  } finally {
+    await releaseObject(send, node.objectId);
+  }
 }
 
 async function fillNode(
@@ -772,7 +788,12 @@ async function fillNode(
         }
         const checked = value === true || value === 1 || value === "1" || value === "true";
         if (this.checked !== checked) {
-          this.checked = checked;
+          const setter = Object.getOwnPropertyDescriptor(
+            HTMLInputElement.prototype,
+            "checked",
+          )?.set;
+          if (setter) setter.call(this, checked);
+          else this.checked = checked;
           this.dispatchEvent(new Event("input", { bubbles: true }));
           this.dispatchEvent(new Event("change", { bubbles: true }));
         }
@@ -870,11 +891,7 @@ async function waitForActionable(
   node: ResolvedNode,
   options: { editable?: boolean; timeoutMs?: number } = {},
 ): Promise<void> {
-  const timeoutMs = positiveInt(
-    options.timeoutMs,
-    DEFAULT_WAIT_TIMEOUT_MS,
-    MAX_WAIT_TIMEOUT_MS,
-  );
+  const timeoutMs = positiveInt(options.timeoutMs, DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS);
   const result = await callOnNode<{ ok: boolean; reason?: string }>(
     send,
     node.objectId,
@@ -956,11 +973,11 @@ async function centerOfNode(
   options: { focus?: boolean } = {},
 ): Promise<{ x: number; y: number }> {
   if (options.focus !== false) await focusNode(send, node);
-  const box = await send('DOM.getBoxModel', {
+  const box = (await send('DOM.getBoxModel', {
     ...(node.backendDOMNodeId
       ? { backendNodeId: node.backendDOMNodeId }
       : { objectId: node.objectId }),
-  }) as { model?: { content?: number[]; border?: number[] } };
+  })) as { model?: { content?: number[]; border?: number[] } };
   const quad = box.model?.content ?? box.model?.border;
   if (!quad || quad.length < 8) throw new Error('target has no visible box');
   const xs = [quad[0], quad[2], quad[4], quad[6]];
@@ -1007,9 +1024,7 @@ function modifierMask(modifiers: unknown): number {
 }
 
 type TranslatedInputMethod =
-  | 'Input.dispatchKeyEvent'
-  | 'Input.dispatchMouseEvent'
-  | 'Input.insertText';
+  'Input.dispatchKeyEvent' | 'Input.dispatchMouseEvent' | 'Input.insertText';
 
 interface TranslatedInputCommand {
   method: TranslatedInputMethod;
@@ -1056,10 +1071,9 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
   };
   const eventWindow = (element: Element): Window & typeof globalThis =>
     element.ownerDocument.defaultView ?? window;
-  const modifiers = (mask: number): Pick<
-    KeyboardEventInit,
-    'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'
-  > => {
+  const modifiers = (
+    mask: number,
+  ): Pick<KeyboardEventInit, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'> => {
     const enabled = (value: number): boolean => Math.floor(mask / value) % 2 === 1;
     return {
       altKey: enabled(1),
@@ -1094,8 +1108,8 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
       const symbol = currentWindow.Symbol.for('cindy.rsb.action-target');
       if (Reflect.get(current, symbol) === command.targetTicket) return true;
       const root = current.getRootNode();
-      current = current.parentElement
-        ?? (root instanceof currentWindow.ShadowRoot ? root.host : null);
+      current =
+        current.parentElement ?? (root instanceof currentWindow.ShadowRoot ? root.host : null);
     }
     return false;
   };
@@ -1109,9 +1123,8 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     x: number,
     y: number,
   ): { target: Element; x: number; y: number } | null => {
-    const rootWindow = (
-      'defaultView' in root ? root.defaultView : root.ownerDocument.defaultView
-    ) ?? window;
+    const rootWindow =
+      ('defaultView' in root ? root.defaultView : root.ownerDocument.defaultView) ?? window;
     const target = root.elementFromPoint(x, y);
     if (!(target instanceof rootWindow.Element)) return null;
     if (target.shadowRoot) {
@@ -1123,8 +1136,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
         const frameDocument = target.contentDocument;
         if (frameDocument) {
           const bounds = target.getBoundingClientRect();
-          return pointTarget(frameDocument, x - bounds.left, y - bounds.top)
-            ?? { target, x, y };
+          return pointTarget(frameDocument, x - bounds.left, y - bounds.top) ?? { target, x, y };
         }
       } catch {
         throw new Error('cross-origin iframe input is not supported');
@@ -1132,16 +1144,9 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     }
     return { target, x, y };
   };
-  const dispatchMouse = (
-    target: Element,
-    type: string,
-    init: MouseEventInit,
-  ): boolean => target.dispatchEvent(new (eventWindow(target).MouseEvent)(type, init));
-  const mouseInit = (
-    target: Element,
-    x: number,
-    y: number,
-  ): MouseEventInit => ({
+  const dispatchMouse = (target: Element, type: string, init: MouseEventInit): boolean =>
+    target.dispatchEvent(new (eventWindow(target).MouseEvent)(type, init));
+  const mouseInit = (target: Element, x: number, y: number): MouseEventInit => ({
     ...modifiers(Number(params.modifiers ?? 0)),
     bubbles: true,
     button: mouseButton(params.button),
@@ -1185,7 +1190,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
       mousePress?: { button: unknown; moved: boolean; x: number; y: number } | null;
     };
   };
-  const state = stateRoot.__cindyRsbInputTranslationState ??= {};
+  const state = (stateRoot.__cindyRsbInputTranslationState ??= {});
   const translateMouse = (): void => {
     const type = stringParam(params.type, 'type');
     const screenX = numberParam(params.x, 'x');
@@ -1221,11 +1226,11 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
       const pressed = state.mousePress;
       state.mousePress = null;
       if (
-        !pressed
-        || pressed.moved
-        || pressed.button !== (params.button ?? 'left')
-        || Math.abs(pressed.x - screenX) > 1
-        || Math.abs(pressed.y - screenY) > 1
+        !pressed ||
+        pressed.moved ||
+        pressed.button !== (params.button ?? 'left') ||
+        Math.abs(pressed.x - screenX) > 1 ||
+        Math.abs(pressed.y - screenY) > 1
       ) {
         return;
       }
@@ -1245,9 +1250,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     }
     throw new Error(`unsupported mouse event type: ${type}`);
   };
-  const deepestActiveElement = (
-    root: Document | ShadowRoot,
-  ): Element | null => {
+  const deepestActiveElement = (root: Document | ShadowRoot): Element | null => {
     const active = root.activeElement;
     if (!active) return null;
     if (active instanceof eventWindow(active).HTMLIFrameElement) {
@@ -1258,36 +1261,34 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
         throw new Error('cross-origin iframe input is not supported');
       }
     }
-    return active.shadowRoot ? deepestActiveElement(active.shadowRoot) ?? active : active;
+    return active.shadowRoot ? (deepestActiveElement(active.shadowRoot) ?? active) : active;
   };
   const isDirectTextControl = (
     element: Element,
   ): element is HTMLInputElement | HTMLTextAreaElement => {
     const view = eventWindow(element);
     if (element instanceof view.HTMLTextAreaElement) return true;
-    return element instanceof view.HTMLInputElement
-      && ['password', 'search', 'tel', 'text', 'url'].includes(element.type);
+    return (
+      element instanceof view.HTMLInputElement &&
+      ['password', 'search', 'tel', 'text', 'url'].includes(element.type)
+    );
   };
   const isStructuredValueControl = (element: Element): element is HTMLInputElement =>
-    element instanceof eventWindow(element).HTMLInputElement
-    && ['date', 'datetime-local', 'month', 'time', 'week'].includes(element.type);
+    element instanceof eventWindow(element).HTMLInputElement &&
+    ['date', 'datetime-local', 'month', 'time', 'week'].includes(element.type);
   const isValueTextControl = (element: Element): element is HTMLInputElement =>
-    element instanceof eventWindow(element).HTMLInputElement
-    && (['email', 'number'].includes(element.type) || isStructuredValueControl(element));
+    element instanceof eventWindow(element).HTMLInputElement &&
+    (['email', 'number'].includes(element.type) || isStructuredValueControl(element));
   const isContentEditable = (element: Element): element is HTMLElement =>
     element instanceof eventWindow(element).HTMLElement && element.isContentEditable;
   const editableElement = (): Element | null => {
     const active = deepestActiveElement(document);
-    return active
-      && (isDirectTextControl(active) || isValueTextControl(active) || isContentEditable(active))
+    return active &&
+      (isDirectTextControl(active) || isValueTextControl(active) || isContentEditable(active))
       ? active
       : null;
   };
-  const createInputEvent = (
-    element: Element,
-    type: string,
-    init: InputEventInit,
-  ): Event => {
+  const createInputEvent = (element: Element, type: string, init: InputEventInit): Event => {
     const view = eventWindow(element);
     return typeof view.InputEvent === 'function'
       ? new view.InputEvent(type, init)
@@ -1297,11 +1298,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
           composed: init.composed,
         });
   };
-  const insertText = (
-    element: Element | null,
-    text: string,
-    inputType = 'insertText',
-  ): void => {
+  const insertText = (element: Element | null, text: string, inputType = 'insertText'): void => {
     if (!element) throw new Error('no editable element is focused');
     const beforeInput = createInputEvent(element, 'beforeinput', {
       bubbles: true,
@@ -1338,19 +1335,19 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     } else {
       throw new Error('focused element is not editable');
     }
-    element.dispatchEvent(createInputEvent(element, 'input', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-      data: text,
-      inputType,
-    }));
+    element.dispatchEvent(
+      createInputEvent(element, 'input', {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        data: text,
+        inputType,
+      }),
+    );
   };
   const deleteText = (element: Element | null, direction: 'backward' | 'forward'): void => {
     if (!element) return;
-    const inputType = direction === 'forward'
-      ? 'deleteContentForward'
-      : 'deleteContentBackward';
+    const inputType = direction === 'forward' ? 'deleteContentForward' : 'deleteContentBackward';
     const beforeInput = createInputEvent(element, 'beforeinput', {
       bubbles: true,
       cancelable: true,
@@ -1369,20 +1366,21 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
       }
       element.setRangeText('', start, end, 'end');
     } else if (isValueTextControl(element)) {
-      if (element.ownerDocument.execCommand?.(
-        direction === 'forward' ? 'forwardDelete' : 'delete',
-      )) return;
+      if (element.ownerDocument.execCommand?.(direction === 'forward' ? 'forwardDelete' : 'delete'))
+        return;
       if (direction === 'backward') element.value = element.value.slice(0, -1);
     } else {
       return;
     }
-    element.dispatchEvent(createInputEvent(element, 'input', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-      data: null,
-      inputType,
-    }));
+    element.dispatchEvent(
+      createInputEvent(element, 'input', {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        data: null,
+        inputType,
+      }),
+    );
   };
   const keyCode = (key: string): number => {
     const known: Record<string, number> = {
@@ -1396,7 +1394,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
       ArrowDown: 40,
       Delete: 46,
     };
-    return known[key] ?? (key.length === 1 ? key.toUpperCase().codePointAt(0) ?? 0 : 0);
+    return known[key] ?? (key.length === 1 ? (key.toUpperCase().codePointAt(0) ?? 0) : 0);
   };
   const translateKey = (): void => {
     const type = stringParam(params.type, 'type');
@@ -1450,16 +1448,14 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     else if (key === 'Delete') deleteText(activeEditable, 'forward');
     else if (key === 'Enter') {
       if (
-        activeEditable
-        && (
-          activeEditable instanceof eventWindow(activeEditable).HTMLTextAreaElement
-          || isContentEditable(activeEditable)
-        )
+        activeEditable &&
+        (activeEditable instanceof eventWindow(activeEditable).HTMLTextAreaElement ||
+          isContentEditable(activeEditable))
       ) {
         insertText(activeEditable, '\n', 'insertLineBreak');
       } else if (
-        activeEditable
-        && activeEditable instanceof eventWindow(activeEditable).HTMLInputElement
+        activeEditable &&
+        activeEditable instanceof eventWindow(activeEditable).HTMLInputElement
       ) {
         activeEditable.form?.requestSubmit();
       }
@@ -1493,16 +1489,13 @@ async function dispatchTranslatedInput(
   params: Record<string, unknown>,
   targetTicket?: string,
 ): Promise<void> {
-  const source = `(${translateInputCommand.toString()})(${
-    JSON.stringify({
-      method,
-      params,
-      ...(targetTicket ? { targetTicket } : {}),
-    } satisfies TranslatedInputCommand)
-  });`;
-  const userGesture = method === 'Input.dispatchMouseEvent'
-    && params.type === 'mouseReleased';
-  const result = await wc.executeJavaScript(source, userGesture) as TranslatedInputResult;
+  const source = `(${translateInputCommand.toString()})(${JSON.stringify({
+    method,
+    params,
+    ...(targetTicket ? { targetTicket } : {}),
+  } satisfies TranslatedInputCommand)});`;
+  const userGesture = method === 'Input.dispatchMouseEvent' && params.type === 'mouseReleased';
+  const result = (await wc.executeJavaScript(source, userGesture)) as TranslatedInputResult;
   if (result?.ok !== true) {
     throw new Error(result?.error ?? `failed to translate ${method}`);
   }
@@ -1548,30 +1541,41 @@ async function dispatchClick(
   const clickCount = request.doubleClick === true ? 2 : 1;
   const modifiers = modifierMask(request.modifiers);
   for (let count = 1; count <= clickCount; count += 1) {
-    await dispatchInput('Input.dispatchMouseEvent', {
-      type: 'mousePressed',
-      x,
-      y,
-      button,
-      clickCount: count,
-      modifiers,
-    }, targetTicket);
+    await dispatchInput(
+      'Input.dispatchMouseEvent',
+      {
+        type: 'mousePressed',
+        x,
+        y,
+        button,
+        clickCount: count,
+        modifiers,
+      },
+      targetTicket,
+    );
     if (typeof request.delayMs === 'number' && request.delayMs > 0) {
       await delay(Math.min(request.delayMs, 5_000));
     }
-    await dispatchInput('Input.dispatchMouseEvent', {
-      type: 'mouseReleased',
-      x,
-      y,
-      button,
-      clickCount: count,
-      modifiers,
-    }, targetTicket);
+    await dispatchInput(
+      'Input.dispatchMouseEvent',
+      {
+        type: 'mouseReleased',
+        x,
+        y,
+        button,
+        clickCount: count,
+        modifiers,
+      },
+      targetTicket,
+    );
   }
 }
 
 function parseKey(raw: string): { key: string; modifiers: number } {
-  const parts = raw.split('+').map((part) => part.trim()).filter(Boolean);
+  const parts = raw
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean);
   const key = parts.pop();
   if (!key) throw new Error('key required');
   return { key, modifiers: modifierMask(parts) };
@@ -1585,8 +1589,8 @@ async function dispatchKey(
   delayMs?: number,
 ): Promise<void> {
   const { key, modifiers } = parseKey(rawKey);
-  const keyCode = nativeKeyCode(key)
-    ?? (modifiers !== 0 && key.length === 1 ? key.toUpperCase() : undefined);
+  const keyCode =
+    nativeKeyCode(key) ?? (modifiers !== 0 && key.length === 1 ? key.toUpperCase() : undefined);
   // Printable unmodified characters and Enter retain the page-side path,
   // which emits the input/change events expected by web applications. Native
   // dispatch is reserved for navigation/editing keys whose browser defaults
@@ -1600,18 +1604,26 @@ async function dispatchKey(
     return;
   }
   const text = key.length === 1 && modifiers === 0 ? key : undefined;
-  await dispatchInput('Input.dispatchKeyEvent', {
-    type: 'keyDown',
-    key,
-    ...(text ? { text } : {}),
-    modifiers,
-  }, targetTicket);
+  await dispatchInput(
+    'Input.dispatchKeyEvent',
+    {
+      type: 'keyDown',
+      key,
+      ...(text ? { text } : {}),
+      modifiers,
+    },
+    targetTicket,
+  );
   if (delayMs && delayMs > 0) await delay(Math.min(delayMs, 5_000));
-  await dispatchInput('Input.dispatchKeyEvent', {
-    type: 'keyUp',
-    key,
-    modifiers,
-  }, targetTicket);
+  await dispatchInput(
+    'Input.dispatchKeyEvent',
+    {
+      type: 'keyUp',
+      key,
+      modifiers,
+    },
+    targetTicket,
+  );
 }
 
 export class RsbWebviewAutomation {
@@ -1629,9 +1641,7 @@ export class RsbWebviewAutomation {
 
   getHumanVerificationBarrier(tabId: string): HumanVerificationBarrier | undefined {
     const barrier = this.barriersByTab.get(tabId);
-    return barrier
-      ? { kind: barrier.kind, evidence: [...barrier.evidence] }
-      : undefined;
+    return barrier ? { kind: barrier.kind, evidence: [...barrier.evidence] } : undefined;
   }
 
   async snapshot(
@@ -1642,15 +1652,16 @@ export class RsbWebviewAutomation {
     if (req.labels === true) {
       throw new Error('snapshot labels are unavailable in the embedded browser backend');
     }
-    const snapshotReq = req.mode === 'efficient'
-      ? {
-          ...req,
-          interactive: req.interactive ?? true,
-          compact: req.compact ?? true,
-          depth: req.depth ?? EFFICIENT_SNAPSHOT_DEPTH,
-          maxChars: req.maxChars ?? EFFICIENT_SNAPSHOT_MAX_CHARS,
-        }
-      : req;
+    const snapshotReq =
+      req.mode === 'efficient'
+        ? {
+            ...req,
+            interactive: req.interactive ?? true,
+            compact: req.compact ?? true,
+            depth: req.depth ?? EFFICIENT_SNAPSHOT_DEPTH,
+            maxChars: req.maxChars ?? EFFICIENT_SNAPSHOT_MAX_CHARS,
+          }
+        : req;
     return withDebugger(wc, async (send) => {
       let inspection: PageInspection = { resources: [] };
       try {
@@ -1660,7 +1671,10 @@ export class RsbWebviewAutomation {
       }
       this.resourcesByTab.delete(tabId);
       if (inspection.resources.length > 0) {
-        this.resourcesByTab.set(tabId, new Set(inspection.resources.map((resource) => resource.url)));
+        this.resourcesByTab.set(
+          tabId,
+          new Set(inspection.resources.map((resource) => resource.url)),
+        );
       }
       if (inspection.barrier) {
         this.refsByTab.set(tabId, new Map());
@@ -1677,9 +1691,10 @@ export class RsbWebviewAutomation {
       this.barriersByTab.delete(tabId);
       await send('Accessibility.enable');
       let response: { nodes?: RawAxNode[] };
-      const frame = typeof snapshotReq.frame === 'string' && snapshotReq.frame !== ''
-        ? await resolveFrameRoot(send, snapshotReq.frame, snapshotReq.timeoutMs)
-        : undefined;
+      const frame =
+        typeof snapshotReq.frame === 'string' && snapshotReq.frame !== ''
+          ? await resolveFrameRoot(send, snapshotReq.frame, snapshotReq.timeoutMs)
+          : undefined;
       if (typeof snapshotReq.selector === 'string' && snapshotReq.selector !== '') {
         const selected = frame?.nodeId
           ? await resolveSelectorInFrame(send, frame.nodeId, snapshotReq.selector)
@@ -1689,26 +1704,33 @@ export class RsbWebviewAutomation {
         if (!selected) {
           throw new Error('frame document is unavailable for selector-scoped snapshot');
         }
-        response = await send('Accessibility.getPartialAXTree', {
-          backendNodeId: selected.backendDOMNodeId,
-          fetchRelatives: true,
-        }) as { nodes?: RawAxNode[] };
+        try {
+          response = (await send('Accessibility.getPartialAXTree', {
+            backendNodeId: selected.backendDOMNodeId,
+            fetchRelatives: true,
+          })) as { nodes?: RawAxNode[] };
+        } finally {
+          await releaseObject(send, selected.objectId);
+        }
       } else {
-        response = await send(
+        response = (await send(
           'Accessibility.getFullAXTree',
           frame ? { frameId: frame.frameId } : undefined,
-        ) as { nodes?: RawAxNode[] };
+        )) as { nodes?: RawAxNode[] };
       }
 
-      const { tree, roots } = buildSnapshotTree(Array.isArray(response.nodes) ? response.nodes : []);
+      const { tree, roots } = buildSnapshotTree(
+        Array.isArray(response.nodes) ? response.nodes : [],
+      );
       const refs: Record<string, SnapshotRef> = {};
       let refNumber = 1;
       const refOrder = tree
         .map((_node, index) => index)
-        .toSorted((left, right) => (
-          Number(INTERACTIVE_ROLES.has(tree[right].role))
-          - Number(INTERACTIVE_ROLES.has(tree[left].role))
-        ));
+        .toSorted(
+          (left, right) =>
+            Number(INTERACTIVE_ROLES.has(tree[right].role)) -
+            Number(INTERACTIVE_ROLES.has(tree[left].role)),
+        );
       for (const index of refOrder) {
         const node = tree[index];
         if (!shouldReference(node) || refNumber > MAX_SNAPSHOT_REFS) continue;
@@ -1792,11 +1814,7 @@ export class RsbWebviewAutomation {
     if (typeof request.fn !== 'string' || request.fn === '') {
       throw new Error('evaluate.fn (JS expression source) required');
     }
-    const timeoutMs = positiveInt(
-      request.timeoutMs,
-      DEFAULT_WAIT_TIMEOUT_MS,
-      MAX_WAIT_TIMEOUT_MS,
-    );
+    const timeoutMs = positiveInt(request.timeoutMs, DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS);
     return withDebugger(wc, async (send) => {
       let response: {
         result?: { value?: unknown };
@@ -1808,22 +1826,26 @@ export class RsbWebviewAutomation {
           throw new Error(`unknown or stale snapshot ref: ${request.ref}; take a new snapshot`);
         }
         const target = await resolveRef(send, snapshotRef);
-        response = await send('Runtime.callFunctionOn', {
-          objectId: target.objectId,
-          functionDeclaration: `function(fnSource) {
-            var candidate = eval("(" + fnSource + ")");
-            if (typeof candidate !== "function") {
-              throw new Error("evaluate source did not produce a function");
-            }
-            return Promise.resolve(candidate(this));
-          }`,
-          arguments: [{ value: request.fn }],
-          awaitPromise: true,
-          returnByValue: true,
-          timeout: timeoutMs,
-        }) as typeof response;
+        try {
+          response = (await send('Runtime.callFunctionOn', {
+            objectId: target.objectId,
+            functionDeclaration: `function(fnSource) {
+              var candidate = eval("(" + fnSource + ")");
+              if (typeof candidate !== "function") {
+                throw new Error("evaluate source did not produce a function");
+              }
+              return Promise.resolve(candidate(this));
+            }`,
+            arguments: [{ value: request.fn }],
+            awaitPromise: true,
+            returnByValue: true,
+            timeout: timeoutMs,
+          })) as typeof response;
+        } finally {
+          await releaseObject(send, target.objectId);
+        }
       } else {
-        response = await send('Runtime.evaluate', {
+        response = (await send('Runtime.evaluate', {
           expression: `(() => {
             var candidate = eval("(" + ${JSON.stringify(request.fn)} + ")");
             if (typeof candidate !== "function") {
@@ -1834,13 +1856,13 @@ export class RsbWebviewAutomation {
           awaitPromise: true,
           returnByValue: true,
           timeout: timeoutMs,
-        }) as typeof response;
+        })) as typeof response;
       }
       if (response.exceptionDetails) {
         throw new Error(
-          response.exceptionDetails.exception?.description
-          ?? response.exceptionDetails.text
-          ?? 'evaluate failed',
+          response.exceptionDetails.exception?.description ??
+            response.exceptionDetails.text ??
+            'evaluate failed',
         );
       }
       return response.result?.value;
@@ -1873,39 +1895,43 @@ export class RsbWebviewAutomation {
         target = await resolveRef(send, snapshotRef);
       }
 
-      const readiness = await callOnNode<{
-        ok: boolean;
-        reason?: string;
-        multiple?: boolean;
-      }>(
-        send,
-        target.objectId,
-        `function() {
-          if (!(this instanceof HTMLInputElement) || this.type !== "file") {
-            return { ok: false, reason: "upload target is not a file input" };
-          }
-          if (!this.isConnected) return { ok: false, reason: "upload target is detached" };
-          if (this.disabled || this.getAttribute("aria-disabled") === "true") {
-            return { ok: false, reason: "upload target is disabled" };
-          }
-          return { ok: true, multiple: this.multiple };
-        }`,
-      );
-      if (!readiness?.ok) {
-        throw new Error(readiness?.reason ?? 'upload target is not ready');
+      try {
+        const readiness = await callOnNode<{
+          ok: boolean;
+          reason?: string;
+          multiple?: boolean;
+        }>(
+          send,
+          target.objectId,
+          `function() {
+            if (!(this instanceof HTMLInputElement) || this.type !== "file") {
+              return { ok: false, reason: "upload target is not a file input" };
+            }
+            if (!this.isConnected) return { ok: false, reason: "upload target is detached" };
+            if (this.disabled || this.getAttribute("aria-disabled") === "true") {
+              return { ok: false, reason: "upload target is disabled" };
+            }
+            return { ok: true, multiple: this.multiple };
+          }`,
+        );
+        if (!readiness?.ok) {
+          throw new Error(readiness?.reason ?? 'upload target is not ready');
+        }
+        const paths = req.paths ?? [];
+        if (paths.length > 1 && readiness.multiple !== true) {
+          throw new Error('upload target accepts only one file');
+        }
+        await send('DOM.setFileInputFiles', {
+          files: paths,
+          objectId: target.objectId,
+        });
+        return {
+          tabId,
+          uploadedFiles: paths.length,
+        };
+      } finally {
+        await releaseObject(send, target.objectId);
       }
-      const paths = req.paths ?? [];
-      if (paths.length > 1 && readiness.multiple !== true) {
-        throw new Error('upload target accepts only one file');
-      }
-      await send('DOM.setFileInputFiles', {
-        files: paths,
-        objectId: target.objectId,
-      });
-      return {
-        tabId,
-        uploadedFiles: paths.length,
-      };
     });
   }
 
@@ -1945,12 +1971,13 @@ export class RsbWebviewAutomation {
         case 'saveResource':
           throw new Error('saveResource must be handled by the browser artifact manager');
         case 'click': {
-          const target = await resolveTarget();
-          await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
-          const ticket = await stampActionTarget(send, target);
-          const point = await centerOfNode(send, target);
-          await dispatchClick(dispatchInput, point.x, point.y, request, ticket);
-          return { tabId, kind: request.kind, ...point };
+          return withReleasedNode(send, resolveTarget, async (target) => {
+            await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+            const ticket = await stampActionTarget(send, target);
+            const point = await centerOfNode(send, target);
+            await dispatchClick(dispatchInput, point.x, point.y, request, ticket);
+            return { tabId, kind: request.kind, ...point };
+          });
         }
         case 'clickCoords': {
           const x = finiteNonNegative(request.x, 'clickCoords.x');
@@ -1969,13 +1996,19 @@ export class RsbWebviewAutomation {
               if (typeof field.ref !== 'string' || field.ref === '') {
                 throw new Error('fill.fields[].ref required');
               }
-              const target = await resolveTarget(field.ref, undefined, undefined);
-              await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
-              await fillNode(
+              const fieldRef = field.ref;
+              await withReleasedNode(
                 send,
-                target,
-                field.value,
-                typeof field.type === 'string' ? field.type : undefined,
+                () => resolveTarget(fieldRef, undefined, undefined),
+                async (target) => {
+                  await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+                  await fillNode(
+                    send,
+                    target,
+                    field.value,
+                    typeof field.type === 'string' ? field.type : undefined,
+                  );
+                },
               );
               filled += 1;
             }
@@ -1983,59 +2016,73 @@ export class RsbWebviewAutomation {
           }
           // Keep the single-target form accepted by existing embedded-backend
           // callers while also honoring the shared multi-field contract above.
-          const target = await resolveTarget();
-          await waitForActionable(send, target, {
-            editable: true,
-            timeoutMs: request.timeoutMs,
+          return withReleasedNode(send, resolveTarget, async (target) => {
+            await waitForActionable(send, target, {
+              editable: true,
+              timeoutMs: request.timeoutMs,
+            });
+            await focusNode(send, target, true);
+            if (typeof request.text !== 'string') throw new Error('fill.text required');
+            await fillNode(send, target, request.text);
+            if (request.submit === true) {
+              const ticket = await stampActionTarget(send, target);
+              await dispatchKey(dispatchInput, 'Enter', ticket);
+            }
+            return { tabId, kind: request.kind, textLength: request.text.length };
           });
-          await focusNode(send, target, true);
-          if (typeof request.text !== 'string') throw new Error('fill.text required');
-          await fillNode(send, target, request.text);
-          if (request.submit === true) {
-            const ticket = await stampActionTarget(send, target);
-            await dispatchKey(dispatchInput, 'Enter', ticket);
-          }
-          return { tabId, kind: request.kind, textLength: request.text.length };
         }
         case 'type': {
-          const target = await resolveTarget();
-          await waitForActionable(send, target, {
-            editable: true,
-            timeoutMs: request.timeoutMs,
-          });
-          await focusNode(send, target, true);
-          const ticket = await stampActionTarget(send, target);
-          if (typeof request.text !== 'string') throw new Error('type.text required');
-          const structured = await callOnNode<boolean>(
-            send,
-            target.objectId,
-            `function() {
-              return this instanceof HTMLInputElement
-                && ["date", "datetime-local", "month", "time", "week"].includes(this.type);
-            }`,
-          );
-          if (structured) {
-            await fillNode(send, target, request.text);
-          } else if (request.slowly === true) {
-            const perCharacterDelay = Math.min(request.delayMs ?? 50, 1_000);
-            for (const character of Array.from(request.text)) {
-              await dispatchInput('Input.insertText', { text: character }, ticket);
-              if (perCharacterDelay > 0) await delay(perCharacterDelay);
+          return withReleasedNode(send, resolveTarget, async (target) => {
+            await waitForActionable(send, target, {
+              editable: true,
+              timeoutMs: request.timeoutMs,
+            });
+            await focusNode(send, target, true);
+            const ticket = await stampActionTarget(send, target);
+            if (typeof request.text !== 'string') throw new Error('type.text required');
+            const structured = await callOnNode<boolean>(
+              send,
+              target.objectId,
+              `function() {
+                return this instanceof HTMLInputElement
+                  && ["date", "datetime-local", "month", "time", "week"].includes(this.type);
+              }`,
+            );
+            if (structured) {
+              await fillNode(send, target, request.text);
+            } else if (request.slowly === true) {
+              const perCharacterDelay = Math.min(request.delayMs ?? 50, 1_000);
+              for (const character of Array.from(request.text)) {
+                await dispatchInput('Input.insertText', { text: character }, ticket);
+                if (perCharacterDelay > 0) await delay(perCharacterDelay);
+              }
+            } else {
+              await selectEditableContents(send, target);
+              await dispatchInput('Input.insertText', { text: request.text }, ticket);
             }
-          } else {
-            await selectEditableContents(send, target);
-            await dispatchInput('Input.insertText', { text: request.text }, ticket);
-          }
-          if (request.submit === true) await dispatchKey(dispatchInput, 'Enter', ticket);
-          return { tabId, kind: request.kind, textLength: request.text.length };
+            if (request.submit === true) await dispatchKey(dispatchInput, 'Enter', ticket);
+            return { tabId, kind: request.kind, textLength: request.text.length };
+          });
         }
         case 'press': {
           let ticket: string | undefined;
           if (request.ref || request.selector || request.query) {
-            const target = await resolveTarget();
-            await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
-            await focusNode(send, target);
-            ticket = await stampActionTarget(send, target);
+            return withReleasedNode(send, resolveTarget, async (target) => {
+              await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+              await focusNode(send, target);
+              const targetTicket = await stampActionTarget(send, target);
+              if (typeof request.key !== 'string' || request.key === '') {
+                throw new Error('press.key required');
+              }
+              await dispatchKey(
+                dispatchInput,
+                request.key,
+                targetTicket,
+                options?.nativeKeyDispatch,
+                request.delayMs,
+              );
+              return { tabId, kind: request.kind, key: request.key };
+            });
           }
           if (typeof request.key !== 'string' || request.key === '') {
             throw new Error('press.key required');
@@ -2050,69 +2097,79 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, key: request.key };
         }
         case 'hover': {
-          const target = await resolveTarget();
-          await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
-          const ticket = await stampActionTarget(send, target);
-          const point = await centerOfNode(send, target, { focus: false });
-          await dispatchInput('Input.dispatchMouseEvent', {
-            type: 'mouseMoved',
-            x: point.x,
-            y: point.y,
-            modifiers: modifierMask(request.modifiers),
-          }, ticket);
-          return { tabId, kind: request.kind, ...point };
+          return withReleasedNode(send, resolveTarget, async (target) => {
+            await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+            const ticket = await stampActionTarget(send, target);
+            const point = await centerOfNode(send, target, { focus: false });
+            await dispatchInput(
+              'Input.dispatchMouseEvent',
+              {
+                type: 'mouseMoved',
+                x: point.x,
+                y: point.y,
+                modifiers: modifierMask(request.modifiers),
+              },
+              ticket,
+            );
+            return { tabId, kind: request.kind, ...point };
+          });
         }
         case 'drag': {
-          const start = await centerOfNode(
-            send,
-            await resolveTarget(request.startRef, undefined),
-          );
-          const end = await centerOfNode(
-            send,
-            await resolveTarget(request.endRef, undefined),
-          );
-          await send('Input.dispatchMouseEvent', {
-            type: 'mouseMoved',
-            x: start.x,
-            y: start.y,
-          });
-          await send('Input.dispatchMouseEvent', {
-            type: 'mousePressed',
-            x: start.x,
-            y: start.y,
-            button: 'left',
-            clickCount: 1,
-          });
-          for (let step = 1; step <= 8; step += 1) {
-            const ratio = step / 8;
+          let startTarget: ResolvedNode | undefined;
+          let endTarget: ResolvedNode | undefined;
+          try {
+            const resolvedStart = await resolveTarget(request.startRef, undefined);
+            startTarget = resolvedStart;
+            const resolvedEnd = await resolveTarget(request.endRef, undefined);
+            endTarget = resolvedEnd;
+            const start = await centerOfNode(send, resolvedStart);
+            const end = await centerOfNode(send, resolvedEnd);
             await send('Input.dispatchMouseEvent', {
               type: 'mouseMoved',
-              x: start.x + ((end.x - start.x) * ratio),
-              y: start.y + ((end.y - start.y) * ratio),
-              button: 'left',
-              buttons: 1,
+              x: start.x,
+              y: start.y,
             });
+            await send('Input.dispatchMouseEvent', {
+              type: 'mousePressed',
+              x: start.x,
+              y: start.y,
+              button: 'left',
+              clickCount: 1,
+            });
+            for (let step = 1; step <= 8; step += 1) {
+              const ratio = step / 8;
+              await send('Input.dispatchMouseEvent', {
+                type: 'mouseMoved',
+                x: start.x + (end.x - start.x) * ratio,
+                y: start.y + (end.y - start.y) * ratio,
+                button: 'left',
+                buttons: 1,
+              });
+            }
+            await send('Input.dispatchMouseEvent', {
+              type: 'mouseReleased',
+              x: end.x,
+              y: end.y,
+              button: 'left',
+              clickCount: 1,
+            });
+            return { tabId, kind: request.kind, start, end };
+          } finally {
+            await releaseObject(send, startTarget?.objectId);
+            await releaseObject(send, endTarget?.objectId);
           }
-          await send('Input.dispatchMouseEvent', {
-            type: 'mouseReleased',
-            x: end.x,
-            y: end.y,
-            button: 'left',
-            clickCount: 1,
-          });
-          return { tabId, kind: request.kind, start, end };
         }
         case 'select': {
-          const target = await resolveTarget();
-          await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
-          const values = Array.isArray(request.values)
-            ? request.values.filter((value): value is string => typeof value === 'string')
-            : [];
-          if (values.length === 0) throw new Error('select.values required');
-          const selected = await callOnNode<string[]>(
-            send,
-            target.objectId,
-            `function(values) {
+          return withReleasedNode(send, resolveTarget, async (target) => {
+            await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+            const values = Array.isArray(request.values)
+              ? request.values.filter((value): value is string => typeof value === 'string')
+              : [];
+            if (values.length === 0) throw new Error('select.values required');
+            const selected = await callOnNode<string[]>(
+              send,
+              target.objectId,
+              `function(values) {
               if (!(this instanceof HTMLSelectElement)) throw new Error("target is not a select element");
               if (values.length > 1 && !this.multiple) {
                 throw new Error("target select does not accept multiple values");
@@ -2132,9 +2189,10 @@ export class RsbWebviewAutomation {
               this.dispatchEvent(new Event("change", { bubbles: true }));
               return Array.from(this.selectedOptions, option => option.value);
             }`,
-            [values],
-          );
-          return { tabId, kind: request.kind, values: selected };
+              [values],
+            );
+            return { tabId, kind: request.kind, values: selected };
+          });
         }
         case 'resize': {
           if (request.width === undefined && request.height === undefined) {
@@ -2153,11 +2211,9 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, width, height };
         }
         case 'wait': {
-          const waitDeadline = Date.now() + positiveInt(
-            request.timeoutMs,
-            DEFAULT_WAIT_TIMEOUT_MS,
-            MAX_WAIT_TIMEOUT_MS,
-          );
+          const waitDeadline =
+            Date.now() +
+            positiveInt(request.timeoutMs, DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS);
           const timeMs = Math.min(
             typeof request.timeMs === 'number' && request.timeMs >= 0 ? request.timeMs : 0,
             MAX_WAIT_TIMEOUT_MS,
@@ -2169,12 +2225,12 @@ export class RsbWebviewAutomation {
             MAX_WAIT_TIMEOUT_MS,
           );
           const hasCondition = Boolean(
-            request.selector
-            || request.url
-            || request.loadState
-            || request.text
-            || request.textGone
-            || request.fn,
+            request.selector ||
+            request.url ||
+            request.loadState ||
+            request.text ||
+            request.textGone ||
+            request.fn,
           );
           if (hasCondition) {
             const params = {
@@ -2186,7 +2242,7 @@ export class RsbWebviewAutomation {
               fn: request.fn,
               timeoutMs,
             };
-            const result = await send('Runtime.evaluate', {
+            const result = (await send('Runtime.evaluate', {
               expression: `(() => {
                 const params = ${JSON.stringify(params)};
                 const deadline = Date.now() + params.timeoutMs;
@@ -2234,15 +2290,15 @@ export class RsbWebviewAutomation {
               awaitPromise: true,
               returnByValue: true,
               timeout: timeoutMs + 1_000,
-            }) as {
+            })) as {
               result?: { value?: unknown };
               exceptionDetails?: { exception?: { description?: string }; text?: string };
             };
             if (result.exceptionDetails) {
               throw new Error(
-                result.exceptionDetails.exception?.description
-                ?? result.exceptionDetails.text
-                ?? 'wait failed',
+                result.exceptionDetails.exception?.description ??
+                  result.exceptionDetails.text ??
+                  'wait failed',
               );
             }
             if (request.loadState === 'networkidle') {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -601,6 +601,16 @@ async function resolveElementQuery(
           let candidates;
           try {
             candidates = Array.from(document.querySelectorAll(query.css || "*")).filter(matches);
+            const hasNarrowingField = Boolean(
+              query.css || query.role || query.name || query.label || query.placeholder || query.testId
+            );
+            if (query.text && !hasNarrowingField) {
+              candidates = candidates.filter((element) => (
+                !Array.from(element.children).some((child) => (
+                  visible(child) && equals(child.textContent, query.text)
+                ))
+              ));
+            }
           } catch (error) {
             reject(error);
             return;
@@ -694,6 +704,52 @@ async function callOnNode<T>(
     );
   }
   return result.result?.value as T;
+}
+
+async function fillNode(
+  send: DebuggerTransport['sendCommand'],
+  target: ResolvedNode,
+  value: unknown,
+  declaredType?: string,
+): Promise<void> {
+  await callOnNode(
+    send,
+    target.objectId,
+    `function(value, declaredType) {
+      const type = String(declaredType || (
+        this instanceof HTMLInputElement ? this.type : ""
+      )).toLowerCase();
+      if (type === "checkbox" || type === "radio") {
+        if (!(this instanceof HTMLInputElement)) {
+          throw new Error("checkbox/radio fill target is not an input");
+        }
+        const checked = value === true || value === 1 || value === "1" || value === "true";
+        if (this.checked !== checked) {
+          this.checked = checked;
+          this.dispatchEvent(new Event("input", { bubbles: true }));
+          this.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+        return;
+      }
+      const text = value === undefined || value === null ? "" : String(value);
+      if (this instanceof HTMLSelectElement) {
+        const selected = Array.from(this.options).find((option) => (
+          option.value === text || option.label === text
+        ));
+        if (!selected) throw new Error("select option not found");
+        this.value = selected.value;
+      } else if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+        this.value = text;
+      } else if (this instanceof HTMLElement && this.isContentEditable) {
+        this.textContent = text;
+      } else {
+        throw new Error("fill target is not editable");
+      }
+      this.dispatchEvent(new Event("input", { bubbles: true }));
+      this.dispatchEvent(new Event("change", { bubbles: true }));
+    }`,
+    [value, declaredType],
+  );
 }
 
 async function focusNode(
@@ -1627,6 +1683,69 @@ export class RsbWebviewAutomation {
     }
   }
 
+  async evaluate(
+    tabId: string,
+    wc: WebContents,
+    request: Pick<BrowserActRequest, 'fn' | 'ref' | 'timeoutMs'>,
+  ): Promise<unknown> {
+    if (typeof request.fn !== 'string' || request.fn === '') {
+      throw new Error('evaluate.fn (JS expression source) required');
+    }
+    const timeoutMs = positiveInt(
+      request.timeoutMs,
+      DEFAULT_WAIT_TIMEOUT_MS,
+      MAX_WAIT_TIMEOUT_MS,
+    );
+    return withDebugger(wc, async (send) => {
+      let response: {
+        result?: { value?: unknown };
+        exceptionDetails?: { text?: string; exception?: { description?: string } };
+      };
+      if (request.ref) {
+        const snapshotRef = this.refsByTab.get(tabId)?.get(request.ref);
+        if (!snapshotRef) {
+          throw new Error(`unknown or stale snapshot ref: ${request.ref}; take a new snapshot`);
+        }
+        const target = await resolveRef(send, snapshotRef);
+        response = await send('Runtime.callFunctionOn', {
+          objectId: target.objectId,
+          functionDeclaration: `function(fnSource) {
+            var candidate = eval("(" + fnSource + ")");
+            if (typeof candidate !== "function") {
+              throw new Error("evaluate source did not produce a function");
+            }
+            return Promise.resolve(candidate(this));
+          }`,
+          arguments: [{ value: request.fn }],
+          awaitPromise: true,
+          returnByValue: true,
+          timeout: timeoutMs,
+        }) as typeof response;
+      } else {
+        response = await send('Runtime.evaluate', {
+          expression: `(() => {
+            var candidate = eval("(" + ${JSON.stringify(request.fn)} + ")");
+            if (typeof candidate !== "function") {
+              throw new Error("evaluate source did not produce a function");
+            }
+            return Promise.resolve(candidate());
+          })()`,
+          awaitPromise: true,
+          returnByValue: true,
+          timeout: timeoutMs,
+        }) as typeof response;
+      }
+      if (response.exceptionDetails) {
+        throw new Error(
+          response.exceptionDetails.exception?.description
+          ?? response.exceptionDetails.text
+          ?? 'evaluate failed',
+        );
+      }
+      return response.result?.value;
+    });
+  }
+
   async setFiles(
     tabId: string,
     wc: WebContents,
@@ -1738,8 +1857,46 @@ export class RsbWebviewAutomation {
           await dispatchClick(dispatchInput, x, y, request);
           return { tabId, kind: request.kind, x, y };
         }
-        case 'type':
         case 'fill': {
+          if (Array.isArray(request.fields) && request.fields.length > 0) {
+            let filled = 0;
+            for (const rawField of request.fields) {
+              if (!rawField || typeof rawField !== 'object') {
+                throw new Error('fill.fields entries must be objects');
+              }
+              const field = rawField as Record<string, unknown>;
+              if (typeof field.ref !== 'string' || field.ref === '') {
+                throw new Error('fill.fields[].ref required');
+              }
+              const target = await resolveTarget(field.ref, undefined, undefined);
+              await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+              await fillNode(
+                send,
+                target,
+                field.value,
+                typeof field.type === 'string' ? field.type : undefined,
+              );
+              filled += 1;
+            }
+            return { tabId, kind: request.kind, filled };
+          }
+          // Keep the single-target form accepted by existing embedded-backend
+          // callers while also honoring the shared multi-field contract above.
+          const target = await resolveTarget();
+          await waitForActionable(send, target, {
+            editable: true,
+            timeoutMs: request.timeoutMs,
+          });
+          await focusNode(send, target, true);
+          if (typeof request.text !== 'string') throw new Error('fill.text required');
+          await fillNode(send, target, request.text);
+          if (request.submit === true) {
+            const ticket = await stampActionTarget(send, target);
+            await dispatchKey(dispatchInput, 'Enter', ticket);
+          }
+          return { tabId, kind: request.kind, textLength: request.text.length };
+        }
+        case 'type': {
           const target = await resolveTarget();
           await waitForActionable(send, target, {
             editable: true,
@@ -1747,28 +1904,7 @@ export class RsbWebviewAutomation {
           });
           await focusNode(send, target, true);
           const ticket = await stampActionTarget(send, target);
-          if (typeof request.text !== 'string') throw new Error(`${request.kind}.text required`);
-          if (request.kind === 'fill') {
-            await callOnNode(
-              send,
-              target.objectId,
-              `function() {
-                if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
-                  this.select();
-                  return true;
-                }
-                if (this instanceof HTMLElement && this.isContentEditable) {
-                  const selection = this.ownerDocument.getSelection();
-                  const range = this.ownerDocument.createRange();
-                  range.selectNodeContents(this);
-                  selection?.removeAllRanges();
-                  selection?.addRange(range);
-                  return true;
-                }
-                throw new Error("target is not editable");
-              }`,
-            );
-          }
+          if (typeof request.text !== 'string') throw new Error('type.text required');
           if (request.slowly === true) {
             const perCharacterDelay = Math.min(request.delayMs ?? 50, 1_000);
             for (const character of Array.from(request.text)) {
@@ -1817,21 +1953,29 @@ export class RsbWebviewAutomation {
             send,
             await resolveTarget(request.endRef, undefined),
           );
-          await dispatchInput('Input.dispatchMouseEvent', {
+          await send('Input.dispatchMouseEvent', {
+            type: 'mouseMoved',
+            x: start.x,
+            y: start.y,
+          });
+          await send('Input.dispatchMouseEvent', {
             type: 'mousePressed',
             x: start.x,
             y: start.y,
             button: 'left',
             clickCount: 1,
           });
-          await dispatchInput('Input.dispatchMouseEvent', {
-            type: 'mouseMoved',
-            x: end.x,
-            y: end.y,
-            button: 'left',
-            buttons: 1,
-          });
-          await dispatchInput('Input.dispatchMouseEvent', {
+          for (let step = 1; step <= 8; step += 1) {
+            const ratio = step / 8;
+            await send('Input.dispatchMouseEvent', {
+              type: 'mouseMoved',
+              x: start.x + ((end.x - start.x) * ratio),
+              y: start.y + ((end.y - start.y) * ratio),
+              button: 'left',
+              buttons: 1,
+            });
+          }
+          await send('Input.dispatchMouseEvent', {
             type: 'mouseReleased',
             x: end.x,
             y: end.y,
@@ -1891,36 +2035,54 @@ export class RsbWebviewAutomation {
             MAX_WAIT_TIMEOUT_MS,
           );
           const hasCondition = Boolean(
-            request.selector || request.url || request.loadState || request.textGone,
+            request.selector
+            || request.url
+            || request.loadState
+            || request.text
+            || request.textGone
+            || request.fn,
           );
           if (hasCondition) {
             const params = {
               selector: request.selector,
               url: request.url,
               loadState: request.loadState,
+              text: request.text,
               textGone: request.textGone,
+              fn: request.fn,
               timeoutMs,
             };
             const result = await send('Runtime.evaluate', {
               expression: `(() => {
                 const params = ${JSON.stringify(params)};
                 const deadline = Date.now() + params.timeoutMs;
-                const matches = () => {
+                let predicate;
+                if (params.fn) {
+                  predicate = eval("(" + params.fn + ")");
+                  if (typeof predicate !== "function") throw new Error("wait.fn did not produce a function");
+                }
+                const matches = async () => {
                   if (params.selector && !document.querySelector(params.selector)) return false;
                   if (params.url && location.href !== params.url && !location.href.includes(params.url)) return false;
+                  if (params.text && !(document.body?.innerText || "").includes(params.text)) return false;
                   if (params.textGone && (document.body?.innerText || "").includes(params.textGone)) return false;
                   if (params.loadState === "load" && document.readyState !== "complete") return false;
                   if (params.loadState === "domcontentloaded" && document.readyState === "loading") return false;
                   if (params.loadState === "networkidle" && document.readyState !== "complete") return false;
+                  if (predicate && !await Promise.resolve(predicate())) return false;
                   return true;
                 };
                 return new Promise((resolve, reject) => {
-                  const poll = () => {
-                    if (matches()) return resolve({ url: location.href, readyState: document.readyState });
-                    if (Date.now() >= deadline) return reject(new Error("wait timed out"));
-                    setTimeout(poll, 100);
+                  const poll = async () => {
+                    try {
+                      if (await matches()) return resolve({ url: location.href, readyState: document.readyState });
+                      if (Date.now() >= deadline) return reject(new Error("wait timed out"));
+                      setTimeout(poll, 100);
+                    } catch (error) {
+                      reject(error);
+                    }
                   };
-                  poll();
+                  void poll();
                 });
               })()`,
               awaitPromise: true,

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -56,6 +56,15 @@ export interface RsbSnapshotResult {
   url: string;
   snapshot?: string;
   refs?: Record<string, SnapshotRef>;
+  resources?: Array<{
+    kind: string;
+    url: string;
+    label?: string;
+  }>;
+  barrier?: {
+    kind: 'human-verification';
+    evidence: string[];
+  };
   nodes?: Array<{
     ref?: string;
     role: string;
@@ -75,6 +84,11 @@ export interface RsbActResult {
   tabId: string;
   kind: BrowserActRequest['kind'];
   [key: string]: unknown;
+}
+
+interface PageInspection {
+  resources: Array<{ kind: string; url: string; label?: string }>;
+  barrier?: { kind: 'human-verification'; evidence: string[] };
 }
 
 const INTERACTIVE_ROLES = new Set([
@@ -305,6 +319,127 @@ async function resolveHref(
   return typeof result.result?.value === 'string' && result.result.value !== ''
     ? result.result.value
     : undefined;
+}
+
+async function inspectPage(
+  send: DebuggerTransport['sendCommand'],
+  includeResources: boolean,
+): Promise<PageInspection> {
+  const evaluated = await send('Runtime.evaluate', {
+    expression: `(() => {
+      const normalize = (value) => String(value ?? "").replace(/\\s+/g, " ").trim();
+      const pageText = normalize(document.body?.innerText || "").slice(0, 6000);
+      const title = normalize(document.title);
+      const evidence = [];
+      const titleMatch = /(verify you are human|checking your browser|just a moment|unusual traffic|captcha|人机验证|安全验证|访问验证)/i.test(title);
+      if (titleMatch) {
+        evidence.push("page title indicates manual verification");
+      }
+      const challengeSelector = [
+        '[data-sitekey]',
+        'iframe[src*="captcha" i]',
+        'iframe[src*="challenge" i]',
+        '[id*="captcha" i]',
+        '[class*="captcha" i]',
+      ].join(",");
+      const verificationControl = [...document.querySelectorAll(challengeSelector)].find((element) => {
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return rect.width >= 20 && rect.height >= 20 && style.visibility !== "hidden" && style.display !== "none";
+      });
+      if (verificationControl) {
+        evidence.push("page contains a verification control");
+      }
+      const textMatch = /(verify you are human|checking your browser|unusual traffic|complete the security check|i['’]?m not a robot|人机验证|安全验证|访问验证)/i.test(pageText);
+      if (textMatch) {
+        evidence.push("page text asks for a manual check");
+      }
+      const verificationBlocked = titleMatch || Boolean(verificationControl && textMatch);
+
+      const resources = [];
+      if (${JSON.stringify(includeResources)}) {
+        const seen = new Set();
+        const add = (kind, raw, label) => {
+          if (resources.length >= 200) return;
+          let url;
+          try {
+            url = new URL(String(raw || ""), document.baseURI);
+          } catch {
+            return;
+          }
+          if (!["http:", "https:"].includes(url.protocol)) return;
+          const href = url.href;
+          if (seen.has(href)) return;
+          seen.add(href);
+          const item = { kind, url: href };
+          const text = normalize(label);
+          if (text) item.label = text.slice(0, 200);
+          resources.push(item);
+        };
+        document.querySelectorAll('img[src],video[src],audio[src],source[src],a[download][href],link[rel~="stylesheet"][href],link[rel~="icon"][href],link[rel="manifest"][href]').forEach((element) => {
+          const tag = element.tagName.toLowerCase();
+          const rel = normalize(element.getAttribute("rel")).toLowerCase();
+          const kind = tag === "img"
+            ? "image"
+            : tag === "video" || tag === "source" && element.parentElement?.tagName.toLowerCase() === "video"
+              ? "video"
+              : tag === "audio" || tag === "source" && element.parentElement?.tagName.toLowerCase() === "audio"
+                ? "audio"
+                : tag === "a"
+                  ? "download"
+                  : rel.includes("stylesheet")
+                    ? "stylesheet"
+                    : "link";
+          add(kind, element.getAttribute("src") || element.getAttribute("href"), element.getAttribute("alt") || element.getAttribute("download") || element.getAttribute("title"));
+        });
+      }
+      return {
+        resources,
+        ...(verificationBlocked ? { barrier: { kind: "human-verification", evidence: [...new Set(evidence)] } } : {}),
+      };
+    })()`,
+    awaitPromise: true,
+    returnByValue: true,
+  }) as { result?: { value?: unknown }; exceptionDetails?: { text?: string } };
+  if (evaluated.exceptionDetails) {
+    throw new Error(evaluated.exceptionDetails.text ?? 'page inspection failed');
+  }
+  const value = evaluated.result?.value;
+  if (!value || typeof value !== 'object') return { resources: [] };
+  const raw = value as {
+    resources?: unknown;
+    barrier?: { kind?: unknown; evidence?: unknown };
+  };
+  const resources: PageInspection['resources'] = [];
+  if (Array.isArray(raw.resources)) {
+    for (const entry of raw.resources.slice(0, 200)) {
+      if (!entry || typeof entry !== 'object') continue;
+      const item = entry as { kind?: unknown; url?: unknown; label?: unknown };
+      if (typeof item.kind !== 'string' || typeof item.url !== 'string') continue;
+      if (item.url.length > 4096) continue;
+      try {
+        const parsed = new URL(item.url);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue;
+        if (parsed.username || parsed.password) continue;
+      } catch {
+        continue;
+      }
+      resources.push({
+        kind: item.kind.slice(0, 32),
+        url: item.url,
+        ...(typeof item.label === 'string' && item.label !== ''
+          ? { label: item.label.slice(0, 200) }
+          : {}),
+      });
+    }
+  }
+  const evidence = Array.isArray(raw.barrier?.evidence)
+    ? raw.barrier.evidence.filter((item): item is string => typeof item === 'string').slice(0, 8)
+    : [];
+  return {
+    resources,
+    ...(evidence.length > 0 ? { barrier: { kind: 'human-verification', evidence } } : {}),
+  };
 }
 
 async function resolveSelector(
@@ -1231,11 +1366,13 @@ async function dispatchKey(
 
 export class RsbWebviewAutomation {
   private readonly refsByTab = new Map<string, Map<string, SnapshotRef>>();
+  private readonly resourcesByTab = new Map<string, Set<string>>();
 
   constructor(private readonly logger: AutomationLogger) {}
 
   forgetTab(tabId: string): void {
     this.refsByTab.delete(tabId);
+    this.resourcesByTab.delete(tabId);
   }
 
   async snapshot(
@@ -1244,6 +1381,27 @@ export class RsbWebviewAutomation {
     req: BrowserControlRequest,
   ): Promise<RsbSnapshotResult> {
     return withDebugger(wc, async (send) => {
+      let inspection: PageInspection = { resources: [] };
+      try {
+        inspection = await inspectPage(send, req.urls === true);
+      } catch (err) {
+        this.logger.warn('failed to inspect page state', { tabId, err });
+      }
+      this.resourcesByTab.delete(tabId);
+      if (inspection.resources.length > 0) {
+        this.resourcesByTab.set(tabId, new Set(inspection.resources.map((resource) => resource.url)));
+      }
+      if (inspection.barrier) {
+        this.refsByTab.set(tabId, new Map());
+        return {
+          format: req.snapshotFormat ?? 'ai',
+          targetId: tabId,
+          url: wc.getURL(),
+          ...(inspection.resources.length > 0 ? { resources: inspection.resources } : {}),
+          barrier: inspection.barrier,
+          stats: { lines: 0, chars: 0, refs: 0, interactive: 0 },
+        };
+      }
       await send('Accessibility.enable');
       let response: { nodes?: RawAxNode[] };
       if (typeof req.selector === 'string' && req.selector !== '') {
@@ -1304,6 +1462,7 @@ export class RsbWebviewAutomation {
           format,
           targetId: tabId,
           url: wc.getURL(),
+          ...(inspection.resources.length > 0 ? { resources: inspection.resources } : {}),
           nodes: tree.slice(0, limit).map((node) => ({
             ...(node.ref && visible[node.ref] ? { ref: node.ref } : {}),
             role: node.role,
@@ -1318,11 +1477,18 @@ export class RsbWebviewAutomation {
         format,
         targetId: tabId,
         url: wc.getURL(),
+        ...(inspection.resources.length > 0 ? { resources: inspection.resources } : {}),
         snapshot,
         refs: visible,
         stats,
       };
     });
+  }
+
+  assertResource(tabId: string, url: string): void {
+    if (!this.resourcesByTab.get(tabId)?.has(url)) {
+      throw new Error('resource is not present in the latest page resource list');
+    }
   }
 
   async setFiles(
@@ -1416,6 +1582,8 @@ export class RsbWebviewAutomation {
       };
 
       switch (request.kind) {
+        case 'saveResource':
+          throw new Error('saveResource must be handled by the browser artifact manager');
         case 'click': {
           const target = await resolveTarget();
           await waitForActionable(send, target, { timeoutMs: request.timeoutMs });

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -97,6 +97,7 @@ interface PageInspection {
 }
 
 const INTERACTIVE_ROLES = new Set([
+  'alertdialog',
   'button',
   'checkbox',
   'combobox',
@@ -219,14 +220,24 @@ function buildSnapshotTree(nodes: RawAxNode[]): { tree: SnapshotTreeNode[]; root
       .map((node) => [node.nodeId, node]),
   );
   const childIndexes = new Set<number>();
-  for (let index = 0; index < tree.length; index += 1) {
-    const raw = rawById.get(tree[index].nodeId);
+  const visibleChildren = (rawId: string, seen = new Set<string>()): number[] => {
+    if (seen.has(rawId)) return [];
+    seen.add(rawId);
+    const raw = rawById.get(rawId);
+    const result: number[] = [];
     for (const childId of raw?.childIds ?? []) {
       const childIndex = byId.get(childId);
-      if (childIndex === undefined) continue;
-      tree[index].children.push(childIndex);
-      childIndexes.add(childIndex);
+      if (childIndex !== undefined) {
+        result.push(childIndex);
+      } else {
+        result.push(...visibleChildren(childId, new Set(seen)));
+      }
     }
+    return result;
+  };
+  for (let index = 0; index < tree.length; index += 1) {
+    tree[index].children = visibleChildren(tree[index].nodeId);
+    for (const childIndex of tree[index].children) childIndexes.add(childIndex);
   }
 
   const roots = tree.map((_node, index) => index).filter((index) => !childIndexes.has(index));
@@ -319,14 +330,18 @@ async function resolveHref(
   };
   const objectId = resolved.object?.objectId;
   if (!objectId) return undefined;
-  const result = await send('Runtime.callFunctionOn', {
-    objectId,
-    functionDeclaration: 'function() { return typeof this.href === "string" ? this.href : ""; }',
-    returnByValue: true,
-  }) as { result?: { value?: unknown } };
-  return typeof result.result?.value === 'string' && result.result.value !== ''
-    ? result.result.value
-    : undefined;
+  try {
+    const result = await send('Runtime.callFunctionOn', {
+      objectId,
+      functionDeclaration: 'function() { return typeof this.href === "string" ? this.href : ""; }',
+      returnByValue: true,
+    }) as { result?: { value?: unknown } };
+    return typeof result.result?.value === 'string' && result.result.value !== ''
+      ? result.result.value
+      : undefined;
+  } finally {
+    await send('Runtime.releaseObject', { objectId }).catch(() => undefined);
+  }
 }
 
 async function inspectPage(
@@ -454,15 +469,17 @@ async function resolveSelector(
   send: DebuggerTransport['sendCommand'],
   selector: string,
   timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+  options?: { allowHidden?: boolean },
 ): Promise<ResolvedNode> {
-  return resolveElementQuery(send, { css: selector }, timeoutMs);
+  return resolveElementQuery(send, { css: selector }, timeoutMs, options);
 }
 
 async function resolveFrameRoot(
   send: DebuggerTransport['sendCommand'],
   selector: string,
+  timeoutMs?: number,
 ): Promise<{ frameId: string; nodeId?: number }> {
-  const frame = await resolveSelector(send, selector);
+  const frame = await resolveSelector(send, selector, timeoutMs);
   const described = await send('DOM.describeNode', {
     backendNodeId: frame.backendDOMNodeId,
     depth: 1,
@@ -508,6 +525,7 @@ async function resolveElementQuery(
   send: DebuggerTransport['sendCommand'],
   query: BrowserElementQuery,
   timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+  options?: { allowHidden?: boolean },
 ): Promise<ResolvedNode> {
   if (
     query.index !== undefined
@@ -532,6 +550,7 @@ async function resolveElementQuery(
     DEFAULT_WAIT_TIMEOUT_MS,
     MAX_WAIT_TIMEOUT_MS,
   );
+  const allowHidden = options?.allowHidden === true;
   const evaluated = await send('Runtime.evaluate', {
     expression: `(() => {
       const query = ${JSON.stringify(query)};
@@ -546,6 +565,22 @@ async function resolveElementQuery(
         const explicit = element.getAttribute("role");
         if (explicit) return explicit.toLowerCase();
         const tag = element.tagName.toLowerCase();
+        if (tag === "article") return "article";
+        if (tag === "aside") return "complementary";
+        if (tag === "header") return element.closest("article,aside,main,nav,section") ? "generic" : "banner";
+        if (tag === "footer") return element.closest("article,aside,main,nav,section") ? "generic" : "contentinfo";
+        if (tag === "form") return "form";
+        if (tag === "h1" || tag === "h2" || tag === "h3" || tag === "h4" || tag === "h5" || tag === "h6") return "heading";
+        if (tag === "img") return element.getAttribute("alt") === "" ? "presentation" : "img";
+        if (tag === "main") return "main";
+        if (tag === "nav") return "navigation";
+        if (tag === "section") return element.getAttribute("aria-label") ? "region" : "generic";
+        if (tag === "table") return "table";
+        if (tag === "tr") return "row";
+        if (tag === "td" || tag === "th") return element.tagName === "TH" ? "columnheader" : "cell";
+        if (tag === "li") return "listitem";
+        if (tag === "ul" || tag === "ol") return "list";
+        if (tag === "output") return "status";
         if (tag === "button") return "button";
         if (tag === "a" && element.hasAttribute("href")) return "link";
         if (tag === "select") return element.multiple ? "listbox" : "combobox";
@@ -591,6 +626,9 @@ async function resolveElementQuery(
       };
       const visible = (element) => {
         if (!element.isConnected) return false;
+        if (${JSON.stringify(allowHidden)} && element instanceof HTMLInputElement && element.type === "file") {
+          return !element.disabled && element.getAttribute("aria-disabled") !== "true";
+        }
         const style = getComputedStyle(element);
         if (style.display === "none" || style.visibility === "hidden" || style.visibility === "collapse") return false;
         const rect = element.getBoundingClientRect();
@@ -748,7 +786,12 @@ async function fillNode(
         if (!selected) throw new Error("select option not found");
         this.value = selected.value;
       } else if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
-        this.value = text;
+        const setter = Object.getOwnPropertyDescriptor(
+          Object.getPrototypeOf(this),
+          "value",
+        )?.set;
+        if (setter) setter.call(this, text);
+        else this.value = text;
       } else if (this instanceof HTMLElement && this.isContentEditable) {
         this.textContent = text;
       } else {
@@ -776,7 +819,7 @@ async function focusNode(
       if ("disabled" in this && this.disabled) {
         return { ok: false, reason: "target is disabled" };
       }
-      if ("readOnly" in this && this.readOnly) {
+      if (requireEditable && "readOnly" in this && this.readOnly) {
         return { ok: false, reason: "target is read-only" };
       }
       if (requireEditable) {
@@ -797,6 +840,29 @@ async function focusNode(
     [requireEditable],
   );
   if (!result?.ok) throw new Error(result?.reason ?? 'unable to focus target');
+}
+
+async function selectEditableContents(
+  send: DebuggerTransport['sendCommand'],
+  node: ResolvedNode,
+): Promise<void> {
+  await callOnNode(
+    send,
+    node.objectId,
+    `function() {
+      if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+        this.select();
+        return;
+      }
+      if (this instanceof HTMLElement && this.isContentEditable) {
+        const selection = this.ownerDocument.defaultView?.getSelection();
+        const range = this.ownerDocument.createRange();
+        range.selectNodeContents(this);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+    }`,
+  );
 }
 
 async function waitForActionable(
@@ -928,6 +994,9 @@ function modifierMask(modifiers: unknown): number {
       case 'command':
       case 'cmd':
         mask |= 4;
+        break;
+      case 'controlormeta':
+        mask |= process.platform === 'darwin' ? 4 : 2;
         break;
       case 'shift':
         mask |= 8;
@@ -1449,6 +1518,7 @@ function nativeKeyCode(key: string): string | undefined {
     ArrowRight: 'RIGHT',
     ArrowDown: 'DOWN',
     Delete: 'DELETE',
+    Enter: 'ENTER',
     Home: 'HOME',
     End: 'END',
     PageUp: 'PAGEUP',
@@ -1512,6 +1582,7 @@ async function dispatchKey(
   rawKey: string,
   targetTicket?: string,
   nativeDispatch?: NativeKeyDispatcher,
+  delayMs?: number,
 ): Promise<void> {
   const { key, modifiers } = parseKey(rawKey);
   const keyCode = nativeKeyCode(key)
@@ -1524,6 +1595,7 @@ async function dispatchKey(
     const modifierNames = nativeModifiers(modifiers);
     await dispatchInput('Input.dispatchKeyEvent', { type: 'validate' }, targetTicket);
     await nativeDispatch('keyDown', keyCode, modifierNames);
+    if (delayMs && delayMs > 0) await delay(Math.min(delayMs, 5_000));
     await nativeDispatch('keyUp', keyCode, modifierNames);
     return;
   }
@@ -1534,6 +1606,7 @@ async function dispatchKey(
     ...(text ? { text } : {}),
     modifiers,
   }, targetTicket);
+  if (delayMs && delayMs > 0) await delay(Math.min(delayMs, 5_000));
   await dispatchInput('Input.dispatchKeyEvent', {
     type: 'keyUp',
     key,
@@ -1605,20 +1678,20 @@ export class RsbWebviewAutomation {
       await send('Accessibility.enable');
       let response: { nodes?: RawAxNode[] };
       const frame = typeof snapshotReq.frame === 'string' && snapshotReq.frame !== ''
-        ? await resolveFrameRoot(send, snapshotReq.frame)
+        ? await resolveFrameRoot(send, snapshotReq.frame, snapshotReq.timeoutMs)
         : undefined;
       if (typeof snapshotReq.selector === 'string' && snapshotReq.selector !== '') {
         const selected = frame?.nodeId
           ? await resolveSelectorInFrame(send, frame.nodeId, snapshotReq.selector)
           : frame
             ? undefined
-            : await resolveSelector(send, snapshotReq.selector);
+            : await resolveSelector(send, snapshotReq.selector, snapshotReq.timeoutMs);
         if (!selected) {
           throw new Error('frame document is unavailable for selector-scoped snapshot');
         }
         response = await send('Accessibility.getPartialAXTree', {
           backendNodeId: selected.backendDOMNodeId,
-          fetchRelatives: false,
+          fetchRelatives: true,
         }) as { nodes?: RawAxNode[] };
       } else {
         response = await send(
@@ -1630,7 +1703,14 @@ export class RsbWebviewAutomation {
       const { tree, roots } = buildSnapshotTree(Array.isArray(response.nodes) ? response.nodes : []);
       const refs: Record<string, SnapshotRef> = {};
       let refNumber = 1;
-      for (const node of tree) {
+      const refOrder = tree
+        .map((_node, index) => index)
+        .toSorted((left, right) => (
+          Number(INTERACTIVE_ROLES.has(tree[right].role))
+          - Number(INTERACTIVE_ROLES.has(tree[left].role))
+        ));
+      for (const index of refOrder) {
+        const node = tree[index];
         if (!shouldReference(node) || refNumber > MAX_SNAPSHOT_REFS) continue;
         const ref = `e${refNumber}`;
         refNumber += 1;
@@ -1778,9 +1858,9 @@ export class RsbWebviewAutomation {
     return withDebugger(wc, async (send) => {
       let target: ResolvedNode;
       if (req.query && typeof req.query === 'object') {
-        target = await resolveElementQuery(send, req.query, req.timeoutMs);
+        target = await resolveElementQuery(send, req.query, req.timeoutMs, { allowHidden: true });
       } else if (typeof req.element === 'string' && req.element !== '') {
-        target = await resolveSelector(send, req.element, req.timeoutMs);
+        target = await resolveSelector(send, req.element, req.timeoutMs, { allowHidden: true });
       } else {
         const ref = req.inputRef ?? req.ref;
         if (typeof ref !== 'string' || ref === '') {
@@ -1926,13 +2006,24 @@ export class RsbWebviewAutomation {
           await focusNode(send, target, true);
           const ticket = await stampActionTarget(send, target);
           if (typeof request.text !== 'string') throw new Error('type.text required');
-          if (request.slowly === true) {
+          const structured = await callOnNode<boolean>(
+            send,
+            target.objectId,
+            `function() {
+              return this instanceof HTMLInputElement
+                && ["date", "datetime-local", "month", "time", "week"].includes(this.type);
+            }`,
+          );
+          if (structured) {
+            await fillNode(send, target, request.text);
+          } else if (request.slowly === true) {
             const perCharacterDelay = Math.min(request.delayMs ?? 50, 1_000);
             for (const character of Array.from(request.text)) {
               await dispatchInput('Input.insertText', { text: character }, ticket);
               if (perCharacterDelay > 0) await delay(perCharacterDelay);
             }
           } else {
+            await selectEditableContents(send, target);
             await dispatchInput('Input.insertText', { text: request.text }, ticket);
           }
           if (request.submit === true) await dispatchKey(dispatchInput, 'Enter', ticket);
@@ -1949,7 +2040,13 @@ export class RsbWebviewAutomation {
           if (typeof request.key !== 'string' || request.key === '') {
             throw new Error('press.key required');
           }
-          await dispatchKey(dispatchInput, request.key, ticket, options?.nativeKeyDispatch);
+          await dispatchKey(
+            dispatchInput,
+            request.key,
+            ticket,
+            options?.nativeKeyDispatch,
+            request.delayMs,
+          );
           return { tabId, kind: request.kind, key: request.key };
         }
         case 'hover': {
@@ -2099,7 +2196,19 @@ export class RsbWebviewAutomation {
                   if (typeof predicate !== "function") throw new Error("wait.fn did not produce a function");
                 }
                 const matches = async () => {
-                  if (params.selector && !document.querySelector(params.selector)) return false;
+                  if (params.selector) {
+                    const element = document.querySelector(params.selector);
+                    if (!element) return false;
+                    const style = getComputedStyle(element);
+                    const rect = element.getBoundingClientRect();
+                    if (
+                      style.display === "none"
+                      || style.visibility === "hidden"
+                      || style.visibility === "collapse"
+                      || rect.width <= 0
+                      || rect.height <= 0
+                    ) return false;
+                  }
                   if (params.url && location.href !== params.url && !location.href.includes(params.url)) return false;
                   if (params.text && !(document.body?.innerText || "").includes(params.text)) return false;
                   if (params.textGone && (document.body?.innerText || "").includes(params.textGone)) return false;

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -1,0 +1,832 @@
+import type {
+  BrowserActRequest,
+  BrowserControlRequest,
+} from '@cindy/browser-control-runtime';
+import type { WebContents } from 'electron';
+
+interface AutomationLogger {
+  warn(message: string, ...args: unknown[]): void;
+}
+
+interface DebuggerTransport {
+  isAttached(): boolean;
+  attach(protocolVersion?: string): void;
+  detach(): void;
+  sendCommand(method: string, commandParams?: Record<string, unknown>): Promise<unknown>;
+}
+
+interface AxValue {
+  value?: unknown;
+}
+
+interface RawAxNode {
+  nodeId?: string;
+  ignored?: boolean;
+  role?: AxValue;
+  name?: AxValue;
+  value?: AxValue;
+  childIds?: string[];
+  backendDOMNodeId?: number;
+}
+
+interface SnapshotRef {
+  role: string;
+  name?: string;
+  value?: string;
+  backendDOMNodeId: number;
+}
+
+interface SnapshotTreeNode extends SnapshotRef {
+  nodeId: string;
+  children: number[];
+  depth: number;
+  ref?: string;
+  url?: string;
+}
+
+interface ResolvedNode {
+  objectId: string;
+  backendDOMNodeId?: number;
+}
+
+export interface RsbSnapshotResult {
+  format: 'ai' | 'aria';
+  targetId: string;
+  url: string;
+  snapshot?: string;
+  refs?: Record<string, SnapshotRef>;
+  nodes?: Array<{
+    ref?: string;
+    role: string;
+    name?: string;
+    value?: string;
+    backendDOMNodeId: number;
+  }>;
+  stats: {
+    lines: number;
+    chars: number;
+    refs: number;
+    interactive: number;
+  };
+}
+
+export interface RsbActResult {
+  tabId: string;
+  kind: BrowserActRequest['kind'];
+  [key: string]: unknown;
+}
+
+const INTERACTIVE_ROLES = new Set([
+  'button',
+  'checkbox',
+  'combobox',
+  'gridcell',
+  'link',
+  'listbox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'textbox',
+  'treeitem',
+]);
+
+const STRUCTURAL_ROLES = new Set([
+  'generic',
+  'group',
+  'list',
+  'none',
+  'presentation',
+  'rootwebarea',
+]);
+
+const DEFAULT_WAIT_TIMEOUT_MS = 10_000;
+const MAX_WAIT_TIMEOUT_MS = 60_000;
+const MAX_SNAPSHOT_REFS = 2_000;
+
+function axText(value: AxValue | undefined): string {
+  const raw = value?.value;
+  if (raw === undefined || raw === null) return '';
+  return typeof raw === 'string' ? raw : String(raw);
+}
+
+function finiteNonNegative(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} requires a non-negative finite number`);
+  }
+  return value;
+}
+
+function positiveInt(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(1, Math.floor(value)));
+}
+
+function escapeSnapshotText(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replace(/\s+/g, ' ').trim();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getDebugger(wc: WebContents): DebuggerTransport {
+  const candidate = (wc as unknown as { debugger?: DebuggerTransport }).debugger;
+  if (!candidate) {
+    throw new Error('webContents debugger is unavailable');
+  }
+  return candidate;
+}
+
+async function withDebugger<T>(
+  wc: WebContents,
+  body: (send: DebuggerTransport['sendCommand']) => Promise<T>,
+): Promise<T> {
+  const transport = getDebugger(wc);
+  const alreadyAttached = transport.isAttached();
+  if (!alreadyAttached) {
+    transport.attach('1.3');
+  }
+  try {
+    return await body(transport.sendCommand.bind(transport));
+  } finally {
+    if (!alreadyAttached && transport.isAttached()) {
+      transport.detach();
+    }
+  }
+}
+
+function buildSnapshotTree(nodes: RawAxNode[]): { tree: SnapshotTreeNode[]; roots: number[] } {
+  const tree: SnapshotTreeNode[] = [];
+  const byId = new Map<string, number>();
+  for (const raw of nodes) {
+    const nodeId = raw.nodeId;
+    const backendDOMNodeId = raw.backendDOMNodeId;
+    if (
+      raw.ignored === true
+      || typeof nodeId !== 'string'
+      || nodeId === ''
+      || typeof backendDOMNodeId !== 'number'
+      || backendDOMNodeId <= 0
+    ) {
+      continue;
+    }
+    byId.set(nodeId, tree.length);
+    tree.push({
+      nodeId,
+      role: axText(raw.role).toLowerCase() || 'unknown',
+      name: axText(raw.name) || undefined,
+      value: axText(raw.value) || undefined,
+      backendDOMNodeId,
+      children: [],
+      depth: 0,
+    });
+  }
+
+  const rawById = new Map(
+    nodes
+      .filter((node): node is RawAxNode & { nodeId: string } => typeof node.nodeId === 'string')
+      .map((node) => [node.nodeId, node]),
+  );
+  const childIndexes = new Set<number>();
+  for (let index = 0; index < tree.length; index += 1) {
+    const raw = rawById.get(tree[index].nodeId);
+    for (const childId of raw?.childIds ?? []) {
+      const childIndex = byId.get(childId);
+      if (childIndex === undefined) continue;
+      tree[index].children.push(childIndex);
+      childIndexes.add(childIndex);
+    }
+  }
+
+  const roots = tree.map((_node, index) => index).filter((index) => !childIndexes.has(index));
+  const stack = (roots.length > 0 ? roots : tree.length > 0 ? [0] : []).map((index) => ({
+    index,
+    depth: 0,
+  }));
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) break;
+    const node = tree[current.index];
+    node.depth = current.depth;
+    for (const child of node.children.toReversed()) {
+      stack.push({ index: child, depth: current.depth + 1 });
+    }
+  }
+  return { tree, roots };
+}
+
+function shouldReference(node: SnapshotTreeNode): boolean {
+  if (INTERACTIVE_ROLES.has(node.role)) return true;
+  return Boolean(node.name) && !STRUCTURAL_ROLES.has(node.role);
+}
+
+function shouldRender(
+  node: SnapshotTreeNode,
+  req: BrowserControlRequest,
+): boolean {
+  if (typeof req.depth === 'number' && node.depth > req.depth) return false;
+  if (req.interactive === true) return INTERACTIVE_ROLES.has(node.role);
+  if (req.compact === true && STRUCTURAL_ROLES.has(node.role) && !node.name && !node.ref) {
+    return false;
+  }
+  return true;
+}
+
+function renderSnapshotTree(
+  tree: SnapshotTreeNode[],
+  roots: number[],
+  req: BrowserControlRequest,
+): string[] {
+  const lines: string[] = [];
+  const visit = (index: number): void => {
+    const node = tree[index];
+    if (!node) return;
+    if (shouldRender(node, req)) {
+      const name = node.name ? ` "${escapeSnapshotText(node.name)}"` : '';
+      const ref = node.ref ? ` [ref=${node.ref}]` : '';
+      const value = node.value ? ` value="${escapeSnapshotText(node.value)}"` : '';
+      const url = node.url ? ` [url=${node.url}]` : '';
+      lines.push(`${'  '.repeat(node.depth)}- ${node.role}${name}${ref}${value}${url}`);
+    }
+    for (const child of node.children) visit(child);
+  };
+  for (const root of roots) visit(root);
+  return lines;
+}
+
+function truncateSnapshotLines(lines: string[], maxChars: number | undefined): string[] {
+  if (maxChars === undefined) return lines;
+  if (maxChars <= 0) return [];
+  const out: string[] = [];
+  let used = 0;
+  for (const line of lines) {
+    const added = line.length + (out.length > 0 ? 1 : 0);
+    if (used + added > maxChars) break;
+    out.push(line);
+    used += added;
+  }
+  return out;
+}
+
+function visibleRefs(
+  refs: Record<string, SnapshotRef>,
+  lines: string[],
+): Record<string, SnapshotRef> {
+  const rendered = lines.join('\n');
+  return Object.fromEntries(
+    Object.entries(refs).filter(([ref]) => rendered.includes(`[ref=${ref}]`)),
+  );
+}
+
+async function resolveHref(
+  send: DebuggerTransport['sendCommand'],
+  backendDOMNodeId: number,
+): Promise<string | undefined> {
+  const resolved = await send('DOM.resolveNode', { backendNodeId: backendDOMNodeId }) as {
+    object?: { objectId?: string };
+  };
+  const objectId = resolved.object?.objectId;
+  if (!objectId) return undefined;
+  const result = await send('Runtime.callFunctionOn', {
+    objectId,
+    functionDeclaration: 'function() { return typeof this.href === "string" ? this.href : ""; }',
+    returnByValue: true,
+  }) as { result?: { value?: unknown } };
+  return typeof result.result?.value === 'string' && result.result.value !== ''
+    ? result.result.value
+    : undefined;
+}
+
+async function resolveSelector(
+  send: DebuggerTransport['sendCommand'],
+  selector: string,
+): Promise<ResolvedNode> {
+  const evaluated = await send('Runtime.evaluate', {
+    expression: `document.querySelector(${JSON.stringify(selector)})`,
+    returnByValue: false,
+  }) as { result?: { objectId?: string; subtype?: string } };
+  const objectId = evaluated.result?.objectId;
+  if (!objectId || evaluated.result?.subtype === 'null') {
+    throw new Error(`selector not found: ${selector}`);
+  }
+  const described = await send('DOM.describeNode', { objectId }) as {
+    node?: { backendNodeId?: number };
+  };
+  return { objectId, backendDOMNodeId: described.node?.backendNodeId };
+}
+
+async function resolveRef(
+  send: DebuggerTransport['sendCommand'],
+  target: SnapshotRef,
+): Promise<ResolvedNode> {
+  const resolved = await send('DOM.resolveNode', {
+    backendNodeId: target.backendDOMNodeId,
+  }) as { object?: { objectId?: string } };
+  const objectId = resolved.object?.objectId;
+  if (!objectId) {
+    throw new Error('snapshot ref is stale; take a new snapshot');
+  }
+  return { objectId, backendDOMNodeId: target.backendDOMNodeId };
+}
+
+async function callOnNode<T>(
+  send: DebuggerTransport['sendCommand'],
+  objectId: string,
+  functionDeclaration: string,
+  args?: unknown[],
+): Promise<T> {
+  const result = await send('Runtime.callFunctionOn', {
+    objectId,
+    functionDeclaration,
+    arguments: args?.map((value) => ({ value })),
+    returnByValue: true,
+    awaitPromise: true,
+    userGesture: true,
+  }) as {
+    result?: { value?: unknown };
+    exceptionDetails?: { text?: string; exception?: { description?: string } };
+  };
+  if (result.exceptionDetails) {
+    throw new Error(
+      result.exceptionDetails.exception?.description
+      ?? result.exceptionDetails.text
+      ?? 'page script failed',
+    );
+  }
+  return result.result?.value as T;
+}
+
+async function focusNode(
+  send: DebuggerTransport['sendCommand'],
+  node: ResolvedNode,
+  requireEditable = false,
+): Promise<void> {
+  const result = await callOnNode<{ ok: boolean; reason?: string }>(
+    send,
+    node.objectId,
+    `function(requireEditable) {
+      if (!(this instanceof HTMLElement) && !(this instanceof SVGElement)) {
+        return { ok: false, reason: "target is not an element" };
+      }
+      if ("disabled" in this && this.disabled) {
+        return { ok: false, reason: "target is disabled" };
+      }
+      if ("readOnly" in this && this.readOnly) {
+        return { ok: false, reason: "target is read-only" };
+      }
+      if (requireEditable) {
+        const textInput = this instanceof HTMLInputElement
+          && !["button", "checkbox", "file", "hidden", "image", "radio", "range", "reset", "submit"].includes(this.type);
+        const editable = textInput
+          || this instanceof HTMLTextAreaElement
+          || (this instanceof HTMLElement && this.isContentEditable);
+        if (!editable) return { ok: false, reason: "target is not editable" };
+      }
+      this.scrollIntoView({ block: "center", inline: "center" });
+      if (typeof this.focus === "function") this.focus();
+      return { ok: true };
+    }`,
+    [requireEditable],
+  );
+  if (!result?.ok) throw new Error(result?.reason ?? 'unable to focus target');
+}
+
+async function centerOfNode(
+  send: DebuggerTransport['sendCommand'],
+  node: ResolvedNode,
+): Promise<{ x: number; y: number }> {
+  await focusNode(send, node);
+  const box = await send('DOM.getBoxModel', {
+    ...(node.backendDOMNodeId
+      ? { backendNodeId: node.backendDOMNodeId }
+      : { objectId: node.objectId }),
+  }) as { model?: { content?: number[]; border?: number[] } };
+  const quad = box.model?.content ?? box.model?.border;
+  if (!quad || quad.length < 8) throw new Error('target has no visible box');
+  const xs = [quad[0], quad[2], quad[4], quad[6]];
+  const ys = [quad[1], quad[3], quad[5], quad[7]];
+  return {
+    x: (Math.min(...xs) + Math.max(...xs)) / 2,
+    y: (Math.min(...ys) + Math.max(...ys)) / 2,
+  };
+}
+
+function mouseButton(value: unknown): 'left' | 'right' | 'middle' {
+  if (value === undefined || value === 'left') return 'left';
+  if (value === 'right' || value === 'middle') return value;
+  throw new Error('button must be left, right, or middle');
+}
+
+function modifierMask(modifiers: unknown): number {
+  if (!Array.isArray(modifiers)) return 0;
+  let mask = 0;
+  for (const raw of modifiers) {
+    if (typeof raw !== 'string') continue;
+    switch (raw.toLowerCase()) {
+      case 'alt':
+        mask |= 1;
+        break;
+      case 'control':
+      case 'ctrl':
+        mask |= 2;
+        break;
+      case 'meta':
+      case 'command':
+      case 'cmd':
+        mask |= 4;
+        break;
+      case 'shift':
+        mask |= 8;
+        break;
+    }
+  }
+  return mask;
+}
+
+async function dispatchClick(
+  send: DebuggerTransport['sendCommand'],
+  x: number,
+  y: number,
+  request: BrowserActRequest,
+): Promise<void> {
+  const button = mouseButton(request.button);
+  const clickCount = request.doubleClick === true ? 2 : 1;
+  const modifiers = modifierMask(request.modifiers);
+  for (let count = 1; count <= clickCount; count += 1) {
+    await send('Input.dispatchMouseEvent', {
+      type: 'mousePressed',
+      x,
+      y,
+      button,
+      clickCount: count,
+      modifiers,
+    });
+    if (typeof request.delayMs === 'number' && request.delayMs > 0) {
+      await delay(Math.min(request.delayMs, 5_000));
+    }
+    await send('Input.dispatchMouseEvent', {
+      type: 'mouseReleased',
+      x,
+      y,
+      button,
+      clickCount: count,
+      modifiers,
+    });
+  }
+}
+
+function parseKey(raw: string): { key: string; modifiers: number } {
+  const parts = raw.split('+').map((part) => part.trim()).filter(Boolean);
+  const key = parts.pop();
+  if (!key) throw new Error('key required');
+  return { key, modifiers: modifierMask(parts) };
+}
+
+async function dispatchKey(
+  send: DebuggerTransport['sendCommand'],
+  rawKey: string,
+): Promise<void> {
+  const { key, modifiers } = parseKey(rawKey);
+  const text = key.length === 1 && modifiers === 0 ? key : undefined;
+  await send('Input.dispatchKeyEvent', {
+    type: 'keyDown',
+    key,
+    ...(text ? { text } : {}),
+    modifiers,
+  });
+  await send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key,
+    modifiers,
+  });
+}
+
+export class RsbWebviewAutomation {
+  private readonly refsByTab = new Map<string, Map<string, SnapshotRef>>();
+
+  constructor(private readonly logger: AutomationLogger) {}
+
+  forgetTab(tabId: string): void {
+    this.refsByTab.delete(tabId);
+  }
+
+  async snapshot(
+    tabId: string,
+    wc: WebContents,
+    req: BrowserControlRequest,
+  ): Promise<RsbSnapshotResult> {
+    return withDebugger(wc, async (send) => {
+      await send('Accessibility.enable');
+      let response: { nodes?: RawAxNode[] };
+      if (typeof req.selector === 'string' && req.selector !== '') {
+        const selected = await resolveSelector(send, req.selector);
+        response = await send('Accessibility.getPartialAXTree', {
+          backendNodeId: selected.backendDOMNodeId,
+          fetchRelatives: false,
+        }) as { nodes?: RawAxNode[] };
+      } else {
+        response = await send('Accessibility.getFullAXTree') as { nodes?: RawAxNode[] };
+      }
+
+      const { tree, roots } = buildSnapshotTree(Array.isArray(response.nodes) ? response.nodes : []);
+      const refs: Record<string, SnapshotRef> = {};
+      let refNumber = 1;
+      for (const node of tree) {
+        if (!shouldReference(node) || refNumber > MAX_SNAPSHOT_REFS) continue;
+        const ref = `e${refNumber}`;
+        refNumber += 1;
+        node.ref = ref;
+        refs[ref] = {
+          role: node.role,
+          ...(node.name ? { name: node.name } : {}),
+          ...(node.value ? { value: node.value } : {}),
+          backendDOMNodeId: node.backendDOMNodeId,
+        };
+      }
+
+      if (req.urls === true) {
+        await Promise.all(
+          tree
+            .filter((node) => node.role === 'link' && node.ref)
+            .map(async (node) => {
+              try {
+                node.url = await resolveHref(send, node.backendDOMNodeId);
+              } catch (err) {
+                this.logger.warn('failed to resolve snapshot link URL', { tabId, err });
+              }
+            }),
+        );
+      }
+
+      const rawLines = renderSnapshotTree(tree, roots, req);
+      const lines = truncateSnapshotLines(rawLines, req.maxChars);
+      const visible = visibleRefs(refs, lines);
+      this.refsByTab.set(tabId, new Map(Object.entries(visible)));
+      const snapshot = lines.join('\n');
+      const format = req.snapshotFormat ?? 'ai';
+      const stats = {
+        lines: lines.length,
+        chars: snapshot.length,
+        refs: Object.keys(visible).length,
+        interactive: Object.values(visible).filter((ref) => INTERACTIVE_ROLES.has(ref.role)).length,
+      };
+      if (format === 'aria') {
+        const limit = positiveInt(req.limit, tree.length || 1, tree.length || 1);
+        return {
+          format,
+          targetId: tabId,
+          url: wc.getURL(),
+          nodes: tree.slice(0, limit).map((node) => ({
+            ...(node.ref && visible[node.ref] ? { ref: node.ref } : {}),
+            role: node.role,
+            ...(node.name ? { name: node.name } : {}),
+            ...(node.value ? { value: node.value } : {}),
+            backendDOMNodeId: node.backendDOMNodeId,
+          })),
+          stats,
+        };
+      }
+      return {
+        format,
+        targetId: tabId,
+        url: wc.getURL(),
+        snapshot,
+        refs: visible,
+        stats,
+      };
+    });
+  }
+
+  async act(
+    tabId: string,
+    wc: WebContents,
+    request: BrowserActRequest,
+  ): Promise<RsbActResult> {
+    return withDebugger(wc, async (send) => {
+      const resolveTarget = async (
+        ref = request.ref,
+        selector = request.selector,
+      ): Promise<ResolvedNode> => {
+        if (typeof selector === 'string' && selector !== '') {
+          return resolveSelector(send, selector);
+        }
+        if (typeof ref !== 'string' || ref === '') {
+          throw new Error(`${request.kind} requires ref or selector`);
+        }
+        const target = this.refsByTab.get(tabId)?.get(ref);
+        if (!target) throw new Error(`unknown or stale snapshot ref: ${ref}; take a new snapshot`);
+        return resolveRef(send, target);
+      };
+
+      switch (request.kind) {
+        case 'click': {
+          const point = await centerOfNode(send, await resolveTarget());
+          await dispatchClick(send, point.x, point.y, request);
+          return { tabId, kind: request.kind, ...point };
+        }
+        case 'clickCoords': {
+          const x = finiteNonNegative(request.x, 'clickCoords.x');
+          const y = finiteNonNegative(request.y, 'clickCoords.y');
+          await dispatchClick(send, x, y, request);
+          return { tabId, kind: request.kind, x, y };
+        }
+        case 'type':
+        case 'fill': {
+          const target = await resolveTarget();
+          await focusNode(send, target, true);
+          if (request.kind === 'fill') {
+            await callOnNode(
+              send,
+              target.objectId,
+              `function() {
+                if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+                  this.value = "";
+                  this.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "deleteContentBackward" }));
+                  return true;
+                }
+                if (this instanceof HTMLElement && this.isContentEditable) {
+                  this.textContent = "";
+                  this.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "deleteContentBackward" }));
+                  return true;
+                }
+                throw new Error("target is not editable");
+              }`,
+            );
+          }
+          if (typeof request.text !== 'string') throw new Error(`${request.kind}.text required`);
+          if (request.slowly === true) {
+            const perCharacterDelay = Math.min(request.delayMs ?? 50, 1_000);
+            for (const character of Array.from(request.text)) {
+              await send('Input.insertText', { text: character });
+              if (perCharacterDelay > 0) await delay(perCharacterDelay);
+            }
+          } else {
+            await send('Input.insertText', { text: request.text });
+          }
+          if (request.submit === true) await dispatchKey(send, 'Enter');
+          return { tabId, kind: request.kind, textLength: request.text.length };
+        }
+        case 'press': {
+          if (request.ref || request.selector) {
+            await focusNode(send, await resolveTarget());
+          }
+          if (typeof request.key !== 'string' || request.key === '') {
+            throw new Error('press.key required');
+          }
+          await dispatchKey(send, request.key);
+          return { tabId, kind: request.kind, key: request.key };
+        }
+        case 'hover': {
+          const point = await centerOfNode(send, await resolveTarget());
+          await send('Input.dispatchMouseEvent', {
+            type: 'mouseMoved',
+            x: point.x,
+            y: point.y,
+            modifiers: modifierMask(request.modifiers),
+          });
+          return { tabId, kind: request.kind, ...point };
+        }
+        case 'drag': {
+          const start = await centerOfNode(
+            send,
+            await resolveTarget(request.startRef, undefined),
+          );
+          const end = await centerOfNode(
+            send,
+            await resolveTarget(request.endRef, undefined),
+          );
+          await send('Input.dispatchMouseEvent', {
+            type: 'mousePressed',
+            x: start.x,
+            y: start.y,
+            button: 'left',
+            clickCount: 1,
+          });
+          await send('Input.dispatchMouseEvent', {
+            type: 'mouseMoved',
+            x: end.x,
+            y: end.y,
+            button: 'left',
+            buttons: 1,
+          });
+          await send('Input.dispatchMouseEvent', {
+            type: 'mouseReleased',
+            x: end.x,
+            y: end.y,
+            button: 'left',
+            clickCount: 1,
+          });
+          return { tabId, kind: request.kind, start, end };
+        }
+        case 'select': {
+          const target = await resolveTarget();
+          const values = Array.isArray(request.values)
+            ? request.values.filter((value): value is string => typeof value === 'string')
+            : [];
+          if (values.length === 0) throw new Error('select.values required');
+          const selected = await callOnNode<string[]>(
+            send,
+            target.objectId,
+            `function(values) {
+              if (!(this instanceof HTMLSelectElement)) throw new Error("target is not a select element");
+              for (const option of this.options) {
+                option.selected = values.includes(option.value) || values.includes(option.label);
+              }
+              this.dispatchEvent(new Event("input", { bubbles: true }));
+              this.dispatchEvent(new Event("change", { bubbles: true }));
+              return Array.from(this.selectedOptions, option => option.value);
+            }`,
+            [values],
+          );
+          return { tabId, kind: request.kind, values: selected };
+        }
+        case 'resize': {
+          const width = positiveInt(request.width, 0, 16_384);
+          const height = positiveInt(request.height, 0, 16_384);
+          if (width <= 0 || height <= 0) throw new Error('resize width and height required');
+          await send('Emulation.setDeviceMetricsOverride', {
+            width,
+            height,
+            deviceScaleFactor: 1,
+            mobile: false,
+          });
+          return { tabId, kind: request.kind, width, height };
+        }
+        case 'wait': {
+          const timeMs = Math.min(
+            typeof request.timeMs === 'number' && request.timeMs >= 0 ? request.timeMs : 0,
+            MAX_WAIT_TIMEOUT_MS,
+          );
+          if (timeMs > 0) await delay(timeMs);
+          const timeoutMs = positiveInt(
+            request.timeoutMs,
+            DEFAULT_WAIT_TIMEOUT_MS,
+            MAX_WAIT_TIMEOUT_MS,
+          );
+          const hasCondition = Boolean(
+            request.selector || request.url || request.loadState || request.textGone,
+          );
+          if (hasCondition) {
+            const params = {
+              selector: request.selector,
+              url: request.url,
+              loadState: request.loadState,
+              textGone: request.textGone,
+              timeoutMs,
+            };
+            const result = await send('Runtime.evaluate', {
+              expression: `(() => {
+                const params = ${JSON.stringify(params)};
+                const deadline = Date.now() + params.timeoutMs;
+                const matches = () => {
+                  if (params.selector && !document.querySelector(params.selector)) return false;
+                  if (params.url && location.href !== params.url && !location.href.includes(params.url)) return false;
+                  if (params.textGone && (document.body?.innerText || "").includes(params.textGone)) return false;
+                  if (params.loadState === "load" && document.readyState !== "complete") return false;
+                  if (params.loadState === "domcontentloaded" && document.readyState === "loading") return false;
+                  if (params.loadState === "networkidle" && document.readyState !== "complete") return false;
+                  return true;
+                };
+                return new Promise((resolve, reject) => {
+                  const poll = () => {
+                    if (matches()) return resolve({ url: location.href, readyState: document.readyState });
+                    if (Date.now() >= deadline) return reject(new Error("wait timed out"));
+                    setTimeout(poll, 100);
+                  };
+                  poll();
+                });
+              })()`,
+              awaitPromise: true,
+              returnByValue: true,
+              timeout: timeoutMs + 1_000,
+            }) as {
+              result?: { value?: unknown };
+              exceptionDetails?: { exception?: { description?: string }; text?: string };
+            };
+            if (result.exceptionDetails) {
+              throw new Error(
+                result.exceptionDetails.exception?.description
+                ?? result.exceptionDetails.text
+                ?? 'wait failed',
+              );
+            }
+            return { tabId, kind: request.kind, waitedMs: timeMs, state: result.result?.value };
+          }
+          return { tabId, kind: request.kind, waitedMs: timeMs };
+        }
+        case 'evaluate':
+        case 'close':
+          throw new Error(`${request.kind} is handled by the backend`);
+      }
+    });
+  }
+}

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -129,6 +129,8 @@ const STRUCTURAL_ROLES = new Set([
 const DEFAULT_WAIT_TIMEOUT_MS = 10_000;
 const MAX_WAIT_TIMEOUT_MS = 60_000;
 const MAX_SNAPSHOT_REFS = 2_000;
+const EFFICIENT_SNAPSHOT_MAX_CHARS = 8_000;
+const EFFICIENT_SNAPSHOT_DEPTH = 6;
 
 function axText(value: AxValue | undefined): string {
   const raw = value?.value;
@@ -507,6 +509,12 @@ async function resolveElementQuery(
   query: BrowserElementQuery,
   timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
 ): Promise<ResolvedNode> {
+  if (
+    query.index !== undefined
+    && (!Number.isInteger(query.index) || query.index < 0)
+  ) {
+    throw new Error('element query index must be a non-negative integer');
+  }
   const hasLookupField = [
     query.css,
     query.role,
@@ -1558,10 +1566,22 @@ export class RsbWebviewAutomation {
     wc: WebContents,
     req: BrowserControlRequest,
   ): Promise<RsbSnapshotResult> {
+    if (req.labels === true) {
+      throw new Error('snapshot labels are unavailable in the embedded browser backend');
+    }
+    const snapshotReq = req.mode === 'efficient'
+      ? {
+          ...req,
+          interactive: req.interactive ?? true,
+          compact: req.compact ?? true,
+          depth: req.depth ?? EFFICIENT_SNAPSHOT_DEPTH,
+          maxChars: req.maxChars ?? EFFICIENT_SNAPSHOT_MAX_CHARS,
+        }
+      : req;
     return withDebugger(wc, async (send) => {
       let inspection: PageInspection = { resources: [] };
       try {
-        inspection = await inspectPage(send, req.urls === true);
+        inspection = await inspectPage(send, snapshotReq.urls === true);
       } catch (err) {
         this.logger.warn('failed to inspect page state', { tabId, err });
       }
@@ -1573,7 +1593,7 @@ export class RsbWebviewAutomation {
         this.refsByTab.set(tabId, new Map());
         this.barriersByTab.set(tabId, inspection.barrier);
         return {
-          format: req.snapshotFormat ?? 'ai',
+          format: snapshotReq.snapshotFormat ?? 'ai',
           targetId: tabId,
           url: wc.getURL(),
           ...(inspection.resources.length > 0 ? { resources: inspection.resources } : {}),
@@ -1584,15 +1604,15 @@ export class RsbWebviewAutomation {
       this.barriersByTab.delete(tabId);
       await send('Accessibility.enable');
       let response: { nodes?: RawAxNode[] };
-      const frame = typeof req.frame === 'string' && req.frame !== ''
-        ? await resolveFrameRoot(send, req.frame)
+      const frame = typeof snapshotReq.frame === 'string' && snapshotReq.frame !== ''
+        ? await resolveFrameRoot(send, snapshotReq.frame)
         : undefined;
-      if (typeof req.selector === 'string' && req.selector !== '') {
+      if (typeof snapshotReq.selector === 'string' && snapshotReq.selector !== '') {
         const selected = frame?.nodeId
-          ? await resolveSelectorInFrame(send, frame.nodeId, req.selector)
+          ? await resolveSelectorInFrame(send, frame.nodeId, snapshotReq.selector)
           : frame
             ? undefined
-            : await resolveSelector(send, req.selector);
+            : await resolveSelector(send, snapshotReq.selector);
         if (!selected) {
           throw new Error('frame document is unavailable for selector-scoped snapshot');
         }
@@ -1623,7 +1643,7 @@ export class RsbWebviewAutomation {
         };
       }
 
-      if (req.urls === true) {
+      if (snapshotReq.urls === true) {
         await Promise.all(
           tree
             .filter((node) => node.role === 'link' && node.ref)
@@ -1637,12 +1657,12 @@ export class RsbWebviewAutomation {
         );
       }
 
-      const rawLines = renderSnapshotTree(tree, roots, req);
-      const lines = truncateSnapshotLines(rawLines, req.maxChars);
+      const rawLines = renderSnapshotTree(tree, roots, snapshotReq);
+      const lines = truncateSnapshotLines(rawLines, snapshotReq.maxChars);
       const visible = visibleRefs(refs, lines);
       this.refsByTab.set(tabId, new Map(Object.entries(visible)));
       const snapshot = lines.join('\n');
-      const format = req.snapshotFormat ?? 'ai';
+      const format = snapshotReq.snapshotFormat ?? 'ai';
       const stats = {
         lines: lines.length,
         chars: snapshot.length,
@@ -1997,6 +2017,17 @@ export class RsbWebviewAutomation {
             target.objectId,
             `function(values) {
               if (!(this instanceof HTMLSelectElement)) throw new Error("target is not a select element");
+              if (values.length > 1 && !this.multiple) {
+                throw new Error("target select does not accept multiple values");
+              }
+              const missing = values.filter((value) => (
+                !Array.from(this.options).some((option) => (
+                  option.value === value || option.label === value
+                ))
+              ));
+              if (missing.length > 0) {
+                throw new Error("select options not found: " + missing.join(", "));
+              }
               for (const option of this.options) {
                 option.selected = values.includes(option.value) || values.includes(option.label);
               }
@@ -2025,6 +2056,11 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, width, height };
         }
         case 'wait': {
+          const waitDeadline = Date.now() + positiveInt(
+            request.timeoutMs,
+            DEFAULT_WAIT_TIMEOUT_MS,
+            MAX_WAIT_TIMEOUT_MS,
+          );
           const timeMs = Math.min(
             typeof request.timeMs === 'number' && request.timeMs >= 0 ? request.timeMs : 0,
             MAX_WAIT_TIMEOUT_MS,
@@ -2101,7 +2137,9 @@ export class RsbWebviewAutomation {
               );
             }
             if (request.loadState === 'networkidle') {
-              await options?.waitForNetworkIdle?.(timeoutMs);
+              const remainingMs = waitDeadline - Date.now();
+              if (remainingMs <= 0) throw new Error('wait timed out');
+              await options?.waitForNetworkIdle?.(remainingMs);
             }
             return { tabId, kind: request.kind, waitedMs: timeMs, state: result.result?.value };
           }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -1,6 +1,7 @@
 import type {
   BrowserActRequest,
   BrowserControlRequest,
+  BrowserElementQuery,
 } from '@cindy/browser-control-runtime';
 import type { WebContents } from 'electron';
 
@@ -309,14 +310,158 @@ async function resolveHref(
 async function resolveSelector(
   send: DebuggerTransport['sendCommand'],
   selector: string,
+  timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
 ): Promise<ResolvedNode> {
+  return resolveElementQuery(send, { css: selector }, timeoutMs);
+}
+
+async function resolveElementQuery(
+  send: DebuggerTransport['sendCommand'],
+  query: BrowserElementQuery,
+  timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+): Promise<ResolvedNode> {
+  const hasLookupField = [
+    query.css,
+    query.role,
+    query.name,
+    query.text,
+    query.label,
+    query.placeholder,
+    query.testId,
+  ].some((value) => typeof value === 'string' && value !== '');
+  if (!hasLookupField) {
+    throw new Error('element query requires at least one field');
+  }
+  const boundedTimeout = positiveInt(
+    timeoutMs,
+    DEFAULT_WAIT_TIMEOUT_MS,
+    MAX_WAIT_TIMEOUT_MS,
+  );
   const evaluated = await send('Runtime.evaluate', {
-    expression: `document.querySelector(${JSON.stringify(selector)})`,
+    expression: `(() => {
+      const query = ${JSON.stringify(query)};
+      const deadline = Date.now() + ${boundedTimeout};
+      const normalize = (value) => String(value ?? "").replace(/\\s+/g, " ").trim();
+      const equals = (actual, expected) => {
+        const left = normalize(actual);
+        const right = normalize(expected);
+        return query.exact === true ? left === right : left.toLowerCase().includes(right.toLowerCase());
+      };
+      const implicitRole = (element) => {
+        const explicit = element.getAttribute("role");
+        if (explicit) return explicit.toLowerCase();
+        const tag = element.tagName.toLowerCase();
+        if (tag === "button") return "button";
+        if (tag === "a" && element.hasAttribute("href")) return "link";
+        if (tag === "select") return element.multiple ? "listbox" : "combobox";
+        if (tag === "textarea") return "textbox";
+        if (tag === "option") return "option";
+        if (tag === "input") {
+          const type = String(element.type || "text").toLowerCase();
+          if (["button", "submit", "reset", "image"].includes(type)) return "button";
+          if (type === "checkbox") return "checkbox";
+          if (type === "radio") return "radio";
+          if (type === "range") return "slider";
+          if (type === "number") return "spinbutton";
+          if (type === "search") return "searchbox";
+          if (!["hidden", "file"].includes(type)) return "textbox";
+        }
+        return "";
+      };
+      const labelText = (element) => {
+        if (element.labels?.length) {
+          return Array.from(element.labels).map((label) => label.textContent || "").join(" ");
+        }
+        const id = element.getAttribute("id");
+        if (id) {
+          const escaped = globalThis.CSS?.escape ? CSS.escape(id) : id.replace(/["\\\\]/g, "\\\\$&");
+          const label = document.querySelector('label[for="' + escaped + '"]');
+          if (label) return label.textContent || "";
+        }
+        return element.closest("label")?.textContent || "";
+      };
+      const accessibleName = (element) => {
+        const labelledBy = element.getAttribute("aria-labelledby");
+        if (labelledBy) {
+          const text = labelledBy.split(/\\s+/).map((id) => document.getElementById(id)?.textContent || "").join(" ");
+          if (normalize(text)) return text;
+        }
+        return element.getAttribute("aria-label")
+          || labelText(element)
+          || element.getAttribute("alt")
+          || element.getAttribute("title")
+          || (element instanceof HTMLInputElement ? element.value : "")
+          || element.textContent
+          || "";
+      };
+      const visible = (element) => {
+        if (!element.isConnected) return false;
+        const style = getComputedStyle(element);
+        if (style.display === "none" || style.visibility === "hidden" || style.visibility === "collapse") return false;
+        const rect = element.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+      const matches = (element) => {
+        if (query.role && implicitRole(element) !== String(query.role).toLowerCase()) return false;
+        if (query.name && !equals(accessibleName(element), query.name)) return false;
+        if (query.text && !equals(element.textContent, query.text)) return false;
+        if (query.label && !equals(labelText(element), query.label)) return false;
+        if (query.placeholder && !equals(element.getAttribute("placeholder"), query.placeholder)) return false;
+        if (query.testId && element.getAttribute("data-testid") !== query.testId) return false;
+        return visible(element);
+      };
+      return new Promise((resolve, reject) => {
+        const poll = () => {
+          let candidates;
+          try {
+            candidates = Array.from(document.querySelectorAll(query.css || "*")).filter(matches);
+          } catch (error) {
+            reject(error);
+            return;
+          }
+          const index = Number.isInteger(query.index) ? query.index : null;
+          if (index !== null && candidates[index]) {
+            resolve(candidates[index]);
+            return;
+          }
+          if (index === null && candidates.length === 1) {
+            resolve(candidates[0]);
+            return;
+          }
+          if (index === null && candidates.length > 1) {
+            reject(new Error("element query matched " + candidates.length + " elements; provide index"));
+            return;
+          }
+          if (Date.now() >= deadline) {
+            reject(new Error("element query timed out"));
+            return;
+          }
+          setTimeout(poll, 100);
+        };
+        poll();
+      });
+    })()`,
+    awaitPromise: true,
     returnByValue: false,
-  }) as { result?: { objectId?: string; subtype?: string } };
+    timeout: boundedTimeout + 1_000,
+  }) as {
+    result?: { objectId?: string; subtype?: string };
+    exceptionDetails?: {
+      text?: string;
+      exception?: { description?: string; value?: unknown };
+    };
+  };
+  if (evaluated.exceptionDetails) {
+    const details = evaluated.exceptionDetails;
+    const message = details.exception?.description
+      ?? (typeof details.exception?.value === 'string' ? details.exception.value : undefined)
+      ?? details.text
+      ?? 'element query failed';
+    throw new Error(message);
+  }
   const objectId = evaluated.result?.objectId;
   if (!objectId || evaluated.result?.subtype === 'null') {
-    throw new Error(`selector not found: ${selector}`);
+    throw new Error('element query did not resolve to an element');
   }
   const described = await send('DOM.describeNode', { objectId }) as {
     node?: { backendNodeId?: number };
@@ -400,6 +545,88 @@ async function focusNode(
   if (!result?.ok) throw new Error(result?.reason ?? 'unable to focus target');
 }
 
+async function waitForActionable(
+  send: DebuggerTransport['sendCommand'],
+  node: ResolvedNode,
+  options: { editable?: boolean; timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = positiveInt(
+    options.timeoutMs,
+    DEFAULT_WAIT_TIMEOUT_MS,
+    MAX_WAIT_TIMEOUT_MS,
+  );
+  const result = await callOnNode<{ ok: boolean; reason?: string }>(
+    send,
+    node.objectId,
+    `function(options) {
+      const deadline = Date.now() + options.timeoutMs;
+      const inspect = () => {
+        if (!(this instanceof Element) || !this.isConnected) return "target is detached";
+        const style = getComputedStyle(this);
+        const rect = this.getBoundingClientRect();
+        if (
+          style.display === "none"
+          || style.visibility === "hidden"
+          || style.visibility === "collapse"
+          || rect.width <= 0
+          || rect.height <= 0
+        ) return "target is not visible";
+        if (("disabled" in this && this.disabled) || this.getAttribute("aria-disabled") === "true") {
+          return "target is disabled";
+        }
+        if (options.editable) {
+          if ("readOnly" in this && this.readOnly) return "target is read-only";
+          const textInput = this instanceof HTMLInputElement
+            && !["button", "checkbox", "file", "hidden", "image", "radio", "range", "reset", "submit"].includes(this.type);
+          const editable = textInput
+            || this instanceof HTMLTextAreaElement
+            || (this instanceof HTMLElement && this.isContentEditable);
+          if (!editable) return "target is not editable";
+        }
+        return "";
+      };
+      return new Promise((resolve) => {
+        const poll = () => {
+          const reason = inspect();
+          if (!reason) {
+            this.scrollIntoView({ block: "center", inline: "center" });
+            resolve({ ok: true });
+            return;
+          }
+          if (Date.now() >= deadline) {
+            resolve({ ok: false, reason });
+            return;
+          }
+          setTimeout(poll, 100);
+        };
+        poll();
+      });
+    }`,
+    [{ editable: options.editable === true, timeoutMs }],
+  );
+  if (!result?.ok) throw new Error(result?.reason ?? 'target is not actionable');
+}
+
+let actionTicketSequence = 0;
+
+async function stampActionTarget(
+  send: DebuggerTransport['sendCommand'],
+  node: ResolvedNode,
+): Promise<string> {
+  actionTicketSequence += 1;
+  const ticket = `rsb-${Date.now().toString(36)}-${actionTicketSequence.toString(36)}`;
+  await callOnNode(
+    send,
+    node.objectId,
+    `function(ticket) {
+      Reflect.set(this, Symbol.for("cindy.rsb.action-target"), ticket);
+      return true;
+    }`,
+    [ticket],
+  );
+  return ticket;
+}
+
 async function centerOfNode(
   send: DebuggerTransport['sendCommand'],
   node: ResolvedNode,
@@ -460,6 +687,7 @@ type TranslatedInputMethod =
 interface TranslatedInputCommand {
   method: TranslatedInputMethod;
   params: Record<string, unknown>;
+  targetTicket?: string;
 }
 
 interface TranslatedInputResult {
@@ -470,17 +698,16 @@ interface TranslatedInputResult {
 type InputDispatcher = (
   method: TranslatedInputMethod,
   params: Record<string, unknown>,
+  targetTicket?: string,
 ) => Promise<void>;
 
 /**
  * Runs inside the guest page, not in Electron Main.
  *
- * Chromium's CDP Input domain is tied to the focused RenderWidgetHost. For an
- * embedded webview that can still be Cindy's composer even when the debugger
- * session and DOM node belong to the guest. Codex Desktop solves the same
- * in-app-browser problem by translating Input.* commands to page JavaScript
- * "to preserve focus". Keep this function self-contained so `toString()` can
- * safely serialize it into `webContents.executeJavaScript`.
+ * An embedded guest and Cindy's composer can disagree about which renderer
+ * owns native input focus. Dispatching equivalent DOM events inside the guest
+ * keeps browser actions scoped to the tab that supplied the element reference.
+ * Keep this function self-contained so `toString()` can safely serialize it.
  */
 function translateInputCommand(command: TranslatedInputCommand): TranslatedInputResult {
   const params = command.params;
@@ -524,6 +751,24 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
         return 4;
       default:
         throw new Error(`unsupported mouse button: ${String(button)}`);
+    }
+  };
+  const carriesTicket = (element: Element | null): boolean => {
+    if (!command.targetTicket) return true;
+    let current = element;
+    while (current) {
+      const currentWindow = current.ownerDocument.defaultView ?? window;
+      const symbol = currentWindow.Symbol.for('cindy.rsb.action-target');
+      if (Reflect.get(current, symbol) === command.targetTicket) return true;
+      const root = current.getRootNode();
+      current = current.parentElement
+        ?? (root instanceof currentWindow.ShadowRoot ? root.host : null);
+    }
+    return false;
+  };
+  const requireTicket = (element: Element | null): void => {
+    if (!carriesTicket(element)) {
+      throw new Error('page changed the action target before input was dispatched');
     }
   };
   const pointTarget = (
@@ -615,6 +860,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     const resolved = pointTarget(document, screenX, screenY);
     if (!resolved) throw new Error(`no element found at point ${screenX},${screenY}`);
     const { target, x, y } = resolved;
+    requireTicket(target);
     const init = mouseInit(target, x, y);
     if (type === 'mouseMoved') {
       if (Number(params.buttons ?? 0) !== 0 && state.mousePress) {
@@ -818,6 +1064,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     const type = stringParam(params.type, 'type');
     const key = stringParam(params.key, 'key');
     const target = deepestActiveElement(document) ?? document.body ?? document.documentElement;
+    requireTicket(target);
     const code = keyCode(key);
     const init: KeyboardEventInit & { keyCode: number; which: number } = {
       ...modifiers(Number(params.modifiers ?? 0)),
@@ -888,7 +1135,11 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
         translateKey();
         break;
       case 'Input.insertText':
-        insertText(editableElement(), stringParam(params.text, 'text'));
+        {
+          const target = editableElement();
+          requireTicket(target);
+          insertText(target, stringParam(params.text, 'text'));
+        }
         break;
     }
     return { ok: true };
@@ -901,9 +1152,14 @@ async function dispatchTranslatedInput(
   wc: WebContents,
   method: TranslatedInputMethod,
   params: Record<string, unknown>,
+  targetTicket?: string,
 ): Promise<void> {
   const source = `(${translateInputCommand.toString()})(${
-    JSON.stringify({ method, params } satisfies TranslatedInputCommand)
+    JSON.stringify({
+      method,
+      params,
+      ...(targetTicket ? { targetTicket } : {}),
+    } satisfies TranslatedInputCommand)
   });`;
   const userGesture = method === 'Input.dispatchMouseEvent'
     && params.type === 'mouseReleased';
@@ -918,6 +1174,7 @@ async function dispatchClick(
   x: number,
   y: number,
   request: BrowserActRequest,
+  targetTicket?: string,
 ): Promise<void> {
   const button = mouseButton(request.button);
   const clickCount = request.doubleClick === true ? 2 : 1;
@@ -930,7 +1187,7 @@ async function dispatchClick(
       button,
       clickCount: count,
       modifiers,
-    });
+    }, targetTicket);
     if (typeof request.delayMs === 'number' && request.delayMs > 0) {
       await delay(Math.min(request.delayMs, 5_000));
     }
@@ -941,7 +1198,7 @@ async function dispatchClick(
       button,
       clickCount: count,
       modifiers,
-    });
+    }, targetTicket);
   }
 }
 
@@ -955,6 +1212,7 @@ function parseKey(raw: string): { key: string; modifiers: number } {
 async function dispatchKey(
   dispatchInput: InputDispatcher,
   rawKey: string,
+  targetTicket?: string,
 ): Promise<void> {
   const { key, modifiers } = parseKey(rawKey);
   const text = key.length === 1 && modifiers === 0 ? key : undefined;
@@ -963,12 +1221,12 @@ async function dispatchKey(
     key,
     ...(text ? { text } : {}),
     modifiers,
-  });
+  }, targetTicket);
   await dispatchInput('Input.dispatchKeyEvent', {
     type: 'keyUp',
     key,
     modifiers,
-  });
+  }, targetTicket);
 }
 
 export class RsbWebviewAutomation {
@@ -1073,18 +1331,22 @@ export class RsbWebviewAutomation {
     request: BrowserActRequest,
   ): Promise<RsbActResult> {
     return withDebugger(wc, async (send) => {
-      const dispatchInput: InputDispatcher = async (method, params) => {
-        await dispatchTranslatedInput(wc, method, params);
+      const dispatchInput: InputDispatcher = async (method, params, targetTicket) => {
+        await dispatchTranslatedInput(wc, method, params, targetTicket);
       };
       const resolveTarget = async (
         ref = request.ref,
         selector = request.selector,
+        query = request.query,
       ): Promise<ResolvedNode> => {
+        if (query && typeof query === 'object') {
+          return resolveElementQuery(send, query, request.timeoutMs);
+        }
         if (typeof selector === 'string' && selector !== '') {
-          return resolveSelector(send, selector);
+          return resolveSelector(send, selector, request.timeoutMs);
         }
         if (typeof ref !== 'string' || ref === '') {
-          throw new Error(`${request.kind} requires ref or selector`);
+          throw new Error(`${request.kind} requires ref, selector, or query`);
         }
         const target = this.refsByTab.get(tabId)?.get(ref);
         if (!target) throw new Error(`unknown or stale snapshot ref: ${ref}; take a new snapshot`);
@@ -1093,8 +1355,11 @@ export class RsbWebviewAutomation {
 
       switch (request.kind) {
         case 'click': {
-          const point = await centerOfNode(send, await resolveTarget());
-          await dispatchClick(dispatchInput, point.x, point.y, request);
+          const target = await resolveTarget();
+          await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+          const ticket = await stampActionTarget(send, target);
+          const point = await centerOfNode(send, target);
+          await dispatchClick(dispatchInput, point.x, point.y, request, ticket);
           return { tabId, kind: request.kind, ...point };
         }
         case 'clickCoords': {
@@ -1106,7 +1371,12 @@ export class RsbWebviewAutomation {
         case 'type':
         case 'fill': {
           const target = await resolveTarget();
+          await waitForActionable(send, target, {
+            editable: true,
+            timeoutMs: request.timeoutMs,
+          });
           await focusNode(send, target, true);
+          const ticket = await stampActionTarget(send, target);
           if (typeof request.text !== 'string') throw new Error(`${request.kind}.text required`);
           if (request.kind === 'fill') {
             await callOnNode(
@@ -1132,33 +1402,40 @@ export class RsbWebviewAutomation {
           if (request.slowly === true) {
             const perCharacterDelay = Math.min(request.delayMs ?? 50, 1_000);
             for (const character of Array.from(request.text)) {
-              await dispatchInput('Input.insertText', { text: character });
+              await dispatchInput('Input.insertText', { text: character }, ticket);
               if (perCharacterDelay > 0) await delay(perCharacterDelay);
             }
           } else {
-            await dispatchInput('Input.insertText', { text: request.text });
+            await dispatchInput('Input.insertText', { text: request.text }, ticket);
           }
-          if (request.submit === true) await dispatchKey(dispatchInput, 'Enter');
+          if (request.submit === true) await dispatchKey(dispatchInput, 'Enter', ticket);
           return { tabId, kind: request.kind, textLength: request.text.length };
         }
         case 'press': {
-          if (request.ref || request.selector) {
-            await focusNode(send, await resolveTarget());
+          let ticket: string | undefined;
+          if (request.ref || request.selector || request.query) {
+            const target = await resolveTarget();
+            await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+            await focusNode(send, target);
+            ticket = await stampActionTarget(send, target);
           }
           if (typeof request.key !== 'string' || request.key === '') {
             throw new Error('press.key required');
           }
-          await dispatchKey(dispatchInput, request.key);
+          await dispatchKey(dispatchInput, request.key, ticket);
           return { tabId, kind: request.kind, key: request.key };
         }
         case 'hover': {
-          const point = await centerOfNode(send, await resolveTarget());
+          const target = await resolveTarget();
+          await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
+          const ticket = await stampActionTarget(send, target);
+          const point = await centerOfNode(send, target);
           await dispatchInput('Input.dispatchMouseEvent', {
             type: 'mouseMoved',
             x: point.x,
             y: point.y,
             modifiers: modifierMask(request.modifiers),
-          });
+          }, ticket);
           return { tabId, kind: request.kind, ...point };
         }
         case 'drag': {
@@ -1195,6 +1472,7 @@ export class RsbWebviewAutomation {
         }
         case 'select': {
           const target = await resolveTarget();
+          await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
           const values = Array.isArray(request.values)
             ? request.values.filter((value): value is string => typeof value === 'string')
             : [];
@@ -1216,6 +1494,10 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, values: selected };
         }
         case 'resize': {
+          if (request.width === undefined && request.height === undefined) {
+            await send('Emulation.clearDeviceMetricsOverride');
+            return { tabId, kind: request.kind, reset: true };
+          }
           const width = positiveInt(request.width, 0, 16_384);
           const height = positiveInt(request.height, 0, 16_384);
           if (width <= 0 || height <= 0) throw new Error('resize width and height required');

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -452,8 +452,469 @@ function modifierMask(modifiers: unknown): number {
   return mask;
 }
 
+type TranslatedInputMethod =
+  | 'Input.dispatchKeyEvent'
+  | 'Input.dispatchMouseEvent'
+  | 'Input.insertText';
+
+interface TranslatedInputCommand {
+  method: TranslatedInputMethod;
+  params: Record<string, unknown>;
+}
+
+interface TranslatedInputResult {
+  ok: boolean;
+  error?: string;
+}
+
+type InputDispatcher = (
+  method: TranslatedInputMethod,
+  params: Record<string, unknown>,
+) => Promise<void>;
+
+/**
+ * Runs inside the guest page, not in Electron Main.
+ *
+ * Chromium's CDP Input domain is tied to the focused RenderWidgetHost. For an
+ * embedded webview that can still be Cindy's composer even when the debugger
+ * session and DOM node belong to the guest. Codex Desktop solves the same
+ * in-app-browser problem by translating Input.* commands to page JavaScript
+ * "to preserve focus". Keep this function self-contained so `toString()` can
+ * safely serialize it into `webContents.executeJavaScript`.
+ */
+function translateInputCommand(command: TranslatedInputCommand): TranslatedInputResult {
+  const params = command.params;
+  const numberParam = (value: unknown, name: string): number => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error(`${name} must be a finite number`);
+    }
+    return value;
+  };
+  const stringParam = (value: unknown, name: string): string => {
+    if (typeof value !== 'string') throw new Error(`${name} must be a string`);
+    return value;
+  };
+  const eventWindow = (element: Element): Window & typeof globalThis =>
+    element.ownerDocument.defaultView ?? window;
+  const modifiers = (mask: number): Pick<
+    KeyboardEventInit,
+    'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'
+  > => {
+    const enabled = (value: number): boolean => Math.floor(mask / value) % 2 === 1;
+    return {
+      altKey: enabled(1),
+      ctrlKey: enabled(2),
+      metaKey: enabled(4),
+      shiftKey: enabled(8),
+    };
+  };
+  const mouseButton = (button: unknown): number => {
+    switch (button) {
+      case undefined:
+      case 'none':
+      case 'left':
+        return 0;
+      case 'middle':
+        return 1;
+      case 'right':
+        return 2;
+      case 'back':
+        return 3;
+      case 'forward':
+        return 4;
+      default:
+        throw new Error(`unsupported mouse button: ${String(button)}`);
+    }
+  };
+  const pointTarget = (
+    root: Document | ShadowRoot,
+    x: number,
+    y: number,
+  ): { target: Element; x: number; y: number } | null => {
+    const rootWindow = (
+      'defaultView' in root ? root.defaultView : root.ownerDocument.defaultView
+    ) ?? window;
+    const target = root.elementFromPoint(x, y);
+    if (!(target instanceof rootWindow.Element)) return null;
+    if (target.shadowRoot) {
+      const nested = target.shadowRoot.elementFromPoint(x, y);
+      if (nested instanceof rootWindow.Element) return { target: nested, x, y };
+    }
+    if (target instanceof rootWindow.HTMLIFrameElement) {
+      try {
+        const frameDocument = target.contentDocument;
+        if (frameDocument) {
+          const bounds = target.getBoundingClientRect();
+          return pointTarget(frameDocument, x - bounds.left, y - bounds.top)
+            ?? { target, x, y };
+        }
+      } catch {
+        throw new Error('cross-origin iframe input is not supported');
+      }
+    }
+    return { target, x, y };
+  };
+  const dispatchMouse = (
+    target: Element,
+    type: string,
+    init: MouseEventInit,
+  ): boolean => target.dispatchEvent(new (eventWindow(target).MouseEvent)(type, init));
+  const mouseInit = (
+    target: Element,
+    x: number,
+    y: number,
+  ): MouseEventInit => ({
+    ...modifiers(Number(params.modifiers ?? 0)),
+    bubbles: true,
+    button: mouseButton(params.button),
+    buttons: Number(params.buttons ?? 0),
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+    composed: true,
+    detail: Number(params.clickCount ?? 0),
+    screenX: x,
+    screenY: y,
+    view: eventWindow(target),
+  });
+  const isFocusable = (element: Element): element is HTMLElement => {
+    if (!(element instanceof eventWindow(element).HTMLElement)) return false;
+    if (element.isContentEditable || element.tabIndex >= 0) return true;
+    if (element.tagName === 'A') return element.hasAttribute('href');
+    return ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(element.tagName);
+  };
+  const focusMouseTarget = (target: Element): void => {
+    let focusTarget: HTMLElement | null = null;
+    if (target instanceof eventWindow(target).HTMLLabelElement && target.control) {
+      focusTarget = target.control;
+    } else {
+      for (let current: Element | null = target; current; current = current.parentElement) {
+        if (isFocusable(current)) {
+          focusTarget = current;
+          break;
+        }
+      }
+    }
+    if (!focusTarget) return;
+    try {
+      focusTarget.focus({ preventScroll: true });
+    } catch {
+      focusTarget.focus();
+    }
+  };
+  const stateRoot = globalThis as typeof globalThis & {
+    __cindyRsbInputTranslationState?: {
+      mousePress?: { button: unknown; moved: boolean; x: number; y: number } | null;
+    };
+  };
+  const state = stateRoot.__cindyRsbInputTranslationState ??= {};
+  const translateMouse = (): void => {
+    const type = stringParam(params.type, 'type');
+    const screenX = numberParam(params.x, 'x');
+    const screenY = numberParam(params.y, 'y');
+    const resolved = pointTarget(document, screenX, screenY);
+    if (!resolved) throw new Error(`no element found at point ${screenX},${screenY}`);
+    const { target, x, y } = resolved;
+    const init = mouseInit(target, x, y);
+    if (type === 'mouseMoved') {
+      if (Number(params.buttons ?? 0) !== 0 && state.mousePress) {
+        state.mousePress.moved = true;
+      }
+      dispatchMouse(target, 'pointermove', init);
+      dispatchMouse(target, 'mousemove', init);
+      return;
+    }
+    if (type === 'mousePressed') {
+      state.mousePress = {
+        button: params.button ?? 'left',
+        moved: false,
+        x: screenX,
+        y: screenY,
+      };
+      const pointerAllowed = dispatchMouse(target, 'pointerdown', init);
+      const mouseAllowed = dispatchMouse(target, 'mousedown', init);
+      if (pointerAllowed && mouseAllowed) focusMouseTarget(target);
+      return;
+    }
+    if (type === 'mouseReleased') {
+      dispatchMouse(target, 'pointerup', init);
+      dispatchMouse(target, 'mouseup', init);
+      const pressed = state.mousePress;
+      state.mousePress = null;
+      if (
+        !pressed
+        || pressed.moved
+        || pressed.button !== (params.button ?? 'left')
+        || Math.abs(pressed.x - screenX) > 1
+        || Math.abs(pressed.y - screenY) > 1
+      ) {
+        return;
+      }
+      if (params.button === 'right') {
+        dispatchMouse(target, 'contextmenu', init);
+        return;
+      }
+      if (params.button === 'middle') {
+        dispatchMouse(target, 'auxclick', init);
+        return;
+      }
+      dispatchMouse(target, 'click', init);
+      if (Number(params.clickCount ?? 0) >= 2) {
+        dispatchMouse(target, 'dblclick', init);
+      }
+      return;
+    }
+    throw new Error(`unsupported mouse event type: ${type}`);
+  };
+  const deepestActiveElement = (
+    root: Document | ShadowRoot,
+  ): Element | null => {
+    const active = root.activeElement;
+    if (!active) return null;
+    if (active instanceof eventWindow(active).HTMLIFrameElement) {
+      try {
+        const frameDocument = active.contentDocument;
+        if (frameDocument) return deepestActiveElement(frameDocument) ?? active;
+      } catch {
+        throw new Error('cross-origin iframe input is not supported');
+      }
+    }
+    return active.shadowRoot ? deepestActiveElement(active.shadowRoot) ?? active : active;
+  };
+  const isDirectTextControl = (
+    element: Element,
+  ): element is HTMLInputElement | HTMLTextAreaElement => {
+    const view = eventWindow(element);
+    if (element instanceof view.HTMLTextAreaElement) return true;
+    return element instanceof view.HTMLInputElement
+      && ['password', 'search', 'tel', 'text', 'url'].includes(element.type);
+  };
+  const isValueTextControl = (element: Element): element is HTMLInputElement =>
+    element instanceof eventWindow(element).HTMLInputElement
+    && ['email', 'number'].includes(element.type);
+  const isContentEditable = (element: Element): element is HTMLElement =>
+    element instanceof eventWindow(element).HTMLElement && element.isContentEditable;
+  const editableElement = (): Element | null => {
+    const active = deepestActiveElement(document);
+    return active
+      && (isDirectTextControl(active) || isValueTextControl(active) || isContentEditable(active))
+      ? active
+      : null;
+  };
+  const createInputEvent = (
+    element: Element,
+    type: string,
+    init: InputEventInit,
+  ): Event => {
+    const view = eventWindow(element);
+    return typeof view.InputEvent === 'function'
+      ? new view.InputEvent(type, init)
+      : new view.Event(type, {
+          bubbles: init.bubbles,
+          cancelable: init.cancelable,
+          composed: init.composed,
+        });
+  };
+  const insertText = (
+    element: Element | null,
+    text: string,
+    inputType = 'insertText',
+  ): void => {
+    if (!element) throw new Error('no editable element is focused');
+    const beforeInput = createInputEvent(element, 'beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      data: text,
+      inputType,
+    });
+    if (!element.dispatchEvent(beforeInput)) return;
+    if (isDirectTextControl(element)) {
+      const start = element.selectionStart ?? element.value.length;
+      const end = element.selectionEnd ?? element.value.length;
+      element.setRangeText(text, start, end, 'end');
+    } else if (isValueTextControl(element)) {
+      if (element.ownerDocument.execCommand?.('insertText', false, text)) return;
+      element.value += text;
+    } else if (isContentEditable(element)) {
+      const selection = eventWindow(element).getSelection();
+      let range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+      if (!range || !element.contains(range.commonAncestorContainer)) {
+        range = element.ownerDocument.createRange();
+        range.selectNodeContents(element);
+        range.collapse(false);
+      }
+      range.deleteContents();
+      const node = element.ownerDocument.createTextNode(text);
+      range.insertNode(node);
+      range.setStartAfter(node);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    } else {
+      throw new Error('focused element is not editable');
+    }
+    element.dispatchEvent(createInputEvent(element, 'input', {
+      bubbles: true,
+      cancelable: false,
+      composed: true,
+      data: text,
+      inputType,
+    }));
+  };
+  const deleteText = (element: Element | null, direction: 'backward' | 'forward'): void => {
+    if (!element) return;
+    const inputType = direction === 'forward'
+      ? 'deleteContentForward'
+      : 'deleteContentBackward';
+    const beforeInput = createInputEvent(element, 'beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      data: null,
+      inputType,
+    });
+    if (!element.dispatchEvent(beforeInput)) return;
+    if (isDirectTextControl(element)) {
+      const value = element.value;
+      let start = element.selectionStart ?? value.length;
+      let end = element.selectionEnd ?? value.length;
+      if (start === end) {
+        if (direction === 'forward') end = Math.min(value.length, end + 1);
+        else start = Math.max(0, start - 1);
+      }
+      element.setRangeText('', start, end, 'end');
+    } else if (isValueTextControl(element)) {
+      if (element.ownerDocument.execCommand?.(
+        direction === 'forward' ? 'forwardDelete' : 'delete',
+      )) return;
+      if (direction === 'backward') element.value = element.value.slice(0, -1);
+    } else {
+      return;
+    }
+    element.dispatchEvent(createInputEvent(element, 'input', {
+      bubbles: true,
+      cancelable: false,
+      composed: true,
+      data: null,
+      inputType,
+    }));
+  };
+  const keyCode = (key: string): number => {
+    const known: Record<string, number> = {
+      Backspace: 8,
+      Tab: 9,
+      Enter: 13,
+      Escape: 27,
+      ArrowLeft: 37,
+      ArrowUp: 38,
+      ArrowRight: 39,
+      ArrowDown: 40,
+      Delete: 46,
+    };
+    return known[key] ?? (key.length === 1 ? key.toUpperCase().codePointAt(0) ?? 0 : 0);
+  };
+  const translateKey = (): void => {
+    const type = stringParam(params.type, 'type');
+    const key = stringParam(params.key, 'key');
+    const target = deepestActiveElement(document) ?? document.body ?? document.documentElement;
+    const code = keyCode(key);
+    const init: KeyboardEventInit & { keyCode: number; which: number } = {
+      ...modifiers(Number(params.modifiers ?? 0)),
+      bubbles: true,
+      cancelable: true,
+      code: typeof params.code === 'string' ? params.code : '',
+      composed: true,
+      key,
+      keyCode: code,
+      which: code,
+    };
+    const makeKeyboardEvent = (eventType: string): KeyboardEvent => {
+      const event = new (eventWindow(target).KeyboardEvent)(eventType, init);
+      for (const [name, value] of [
+        ['keyCode', code],
+        ['which', code],
+        ['charCode', eventType === 'keypress' ? code : 0],
+      ] as const) {
+        try {
+          Object.defineProperty(event, name, { get: () => value });
+        } catch {
+          // Older Chromium builds may expose these properties as non-configurable.
+        }
+      }
+      return event;
+    };
+    if (type === 'keyUp') {
+      target.dispatchEvent(makeKeyboardEvent('keyup'));
+      return;
+    }
+    if (type !== 'keyDown' && type !== 'rawKeyDown' && type !== 'char') {
+      throw new Error(`unsupported key event type: ${type}`);
+    }
+    if (type !== 'char' && !target.dispatchEvent(makeKeyboardEvent('keydown'))) return;
+    const text = typeof params.text === 'string' ? params.text : '';
+    if (text) {
+      if (target.dispatchEvent(makeKeyboardEvent('keypress'))) {
+        insertText(editableElement(), text);
+      }
+      return;
+    }
+    const activeEditable = editableElement();
+    if (key === 'Backspace') deleteText(activeEditable, 'backward');
+    else if (key === 'Delete') deleteText(activeEditable, 'forward');
+    else if (key === 'Enter') {
+      if (
+        activeEditable
+        && (
+          activeEditable instanceof eventWindow(activeEditable).HTMLTextAreaElement
+          || isContentEditable(activeEditable)
+        )
+      ) {
+        insertText(activeEditable, '\n', 'insertLineBreak');
+      } else if (
+        activeEditable
+        && activeEditable instanceof eventWindow(activeEditable).HTMLInputElement
+      ) {
+        activeEditable.form?.requestSubmit();
+      }
+    }
+  };
+  try {
+    switch (command.method) {
+      case 'Input.dispatchMouseEvent':
+        translateMouse();
+        break;
+      case 'Input.dispatchKeyEvent':
+        translateKey();
+        break;
+      case 'Input.insertText':
+        insertText(editableElement(), stringParam(params.text, 'text'));
+        break;
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function dispatchTranslatedInput(
+  wc: WebContents,
+  method: TranslatedInputMethod,
+  params: Record<string, unknown>,
+): Promise<void> {
+  const source = `(${translateInputCommand.toString()})(${
+    JSON.stringify({ method, params } satisfies TranslatedInputCommand)
+  });`;
+  const userGesture = method === 'Input.dispatchMouseEvent'
+    && params.type === 'mouseReleased';
+  const result = await wc.executeJavaScript(source, userGesture) as TranslatedInputResult;
+  if (result?.ok !== true) {
+    throw new Error(result?.error ?? `failed to translate ${method}`);
+  }
+}
+
 async function dispatchClick(
-  send: DebuggerTransport['sendCommand'],
+  dispatchInput: InputDispatcher,
   x: number,
   y: number,
   request: BrowserActRequest,
@@ -462,7 +923,7 @@ async function dispatchClick(
   const clickCount = request.doubleClick === true ? 2 : 1;
   const modifiers = modifierMask(request.modifiers);
   for (let count = 1; count <= clickCount; count += 1) {
-    await send('Input.dispatchMouseEvent', {
+    await dispatchInput('Input.dispatchMouseEvent', {
       type: 'mousePressed',
       x,
       y,
@@ -473,7 +934,7 @@ async function dispatchClick(
     if (typeof request.delayMs === 'number' && request.delayMs > 0) {
       await delay(Math.min(request.delayMs, 5_000));
     }
-    await send('Input.dispatchMouseEvent', {
+    await dispatchInput('Input.dispatchMouseEvent', {
       type: 'mouseReleased',
       x,
       y,
@@ -492,18 +953,18 @@ function parseKey(raw: string): { key: string; modifiers: number } {
 }
 
 async function dispatchKey(
-  send: DebuggerTransport['sendCommand'],
+  dispatchInput: InputDispatcher,
   rawKey: string,
 ): Promise<void> {
   const { key, modifiers } = parseKey(rawKey);
   const text = key.length === 1 && modifiers === 0 ? key : undefined;
-  await send('Input.dispatchKeyEvent', {
+  await dispatchInput('Input.dispatchKeyEvent', {
     type: 'keyDown',
     key,
     ...(text ? { text } : {}),
     modifiers,
   });
-  await send('Input.dispatchKeyEvent', {
+  await dispatchInput('Input.dispatchKeyEvent', {
     type: 'keyUp',
     key,
     modifiers,
@@ -612,15 +1073,8 @@ export class RsbWebviewAutomation {
     request: BrowserActRequest,
   ): Promise<RsbActResult> {
     return withDebugger(wc, async (send) => {
-      // DOM focus alone is not enough for an embedded <webview>: Chromium's
-      // Input domain routes keyboard and mouse events through the currently
-      // focused RenderWidgetHost. If Cindy's chat composer still owns the
-      // Electron focus, those events land in the composer even though
-      // Runtime.callFunctionOn focused an element inside the guest document.
-      // Activate the guest before every real input action so CDP dispatches to
-      // the WebContents that supplied the snapshot/ref.
-      const focusGuest = (): void => {
-        wc.focus();
+      const dispatchInput: InputDispatcher = async (method, params) => {
+        await dispatchTranslatedInput(wc, method, params);
       };
       const resolveTarget = async (
         ref = request.ref,
@@ -639,70 +1093,67 @@ export class RsbWebviewAutomation {
 
       switch (request.kind) {
         case 'click': {
-          focusGuest();
           const point = await centerOfNode(send, await resolveTarget());
-          await dispatchClick(send, point.x, point.y, request);
+          await dispatchClick(dispatchInput, point.x, point.y, request);
           return { tabId, kind: request.kind, ...point };
         }
         case 'clickCoords': {
-          focusGuest();
           const x = finiteNonNegative(request.x, 'clickCoords.x');
           const y = finiteNonNegative(request.y, 'clickCoords.y');
-          await dispatchClick(send, x, y, request);
+          await dispatchClick(dispatchInput, x, y, request);
           return { tabId, kind: request.kind, x, y };
         }
         case 'type':
         case 'fill': {
-          focusGuest();
           const target = await resolveTarget();
           await focusNode(send, target, true);
+          if (typeof request.text !== 'string') throw new Error(`${request.kind}.text required`);
           if (request.kind === 'fill') {
             await callOnNode(
               send,
               target.objectId,
               `function() {
                 if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
-                  this.value = "";
-                  this.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "deleteContentBackward" }));
+                  this.select();
                   return true;
                 }
                 if (this instanceof HTMLElement && this.isContentEditable) {
-                  this.textContent = "";
-                  this.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "deleteContentBackward" }));
+                  const selection = this.ownerDocument.getSelection();
+                  const range = this.ownerDocument.createRange();
+                  range.selectNodeContents(this);
+                  selection?.removeAllRanges();
+                  selection?.addRange(range);
                   return true;
                 }
                 throw new Error("target is not editable");
               }`,
             );
           }
-          if (typeof request.text !== 'string') throw new Error(`${request.kind}.text required`);
           if (request.slowly === true) {
             const perCharacterDelay = Math.min(request.delayMs ?? 50, 1_000);
             for (const character of Array.from(request.text)) {
-              await send('Input.insertText', { text: character });
+              await dispatchInput('Input.insertText', { text: character });
               if (perCharacterDelay > 0) await delay(perCharacterDelay);
             }
           } else {
-            await send('Input.insertText', { text: request.text });
+            await dispatchInput('Input.insertText', { text: request.text });
           }
-          if (request.submit === true) await dispatchKey(send, 'Enter');
+          if (request.submit === true) await dispatchKey(dispatchInput, 'Enter');
           return { tabId, kind: request.kind, textLength: request.text.length };
         }
         case 'press': {
-          focusGuest();
           if (request.ref || request.selector) {
             await focusNode(send, await resolveTarget());
           }
           if (typeof request.key !== 'string' || request.key === '') {
             throw new Error('press.key required');
           }
-          await dispatchKey(send, request.key);
+          await dispatchKey(dispatchInput, request.key);
           return { tabId, kind: request.kind, key: request.key };
         }
         case 'hover': {
-          focusGuest();
           const point = await centerOfNode(send, await resolveTarget());
-          await send('Input.dispatchMouseEvent', {
+          await dispatchInput('Input.dispatchMouseEvent', {
             type: 'mouseMoved',
             x: point.x,
             y: point.y,
@@ -711,7 +1162,6 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, ...point };
         }
         case 'drag': {
-          focusGuest();
           const start = await centerOfNode(
             send,
             await resolveTarget(request.startRef, undefined),
@@ -720,21 +1170,21 @@ export class RsbWebviewAutomation {
             send,
             await resolveTarget(request.endRef, undefined),
           );
-          await send('Input.dispatchMouseEvent', {
+          await dispatchInput('Input.dispatchMouseEvent', {
             type: 'mousePressed',
             x: start.x,
             y: start.y,
             button: 'left',
             clickCount: 1,
           });
-          await send('Input.dispatchMouseEvent', {
+          await dispatchInput('Input.dispatchMouseEvent', {
             type: 'mouseMoved',
             x: end.x,
             y: end.y,
             button: 'left',
             buttons: 1,
           });
-          await send('Input.dispatchMouseEvent', {
+          await dispatchInput('Input.dispatchMouseEvent', {
             type: 'mouseReleased',
             x: end.x,
             y: end.y,

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -284,7 +284,8 @@ function renderSnapshotTree(
 }
 
 function truncateSnapshotLines(lines: string[], maxChars: number | undefined): string[] {
-  if (maxChars === undefined) return lines;
+  // The shared browser contract uses zero as the explicit "no limit" value.
+  if (maxChars === undefined || maxChars === 0) return lines;
   if (maxChars <= 0) return [];
   const out: string[] = [];
   let used = 0;

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -455,6 +455,52 @@ async function resolveSelector(
   return resolveElementQuery(send, { css: selector }, timeoutMs);
 }
 
+async function resolveFrameRoot(
+  send: DebuggerTransport['sendCommand'],
+  selector: string,
+): Promise<{ frameId: string; nodeId?: number }> {
+  const frame = await resolveSelector(send, selector);
+  const described = await send('DOM.describeNode', {
+    backendNodeId: frame.backendDOMNodeId,
+    depth: 1,
+  }) as {
+    node?: {
+      frameId?: string;
+      contentDocument?: { frameId?: string; nodeId?: number };
+    };
+  };
+  const frameId = described.node?.contentDocument?.frameId ?? described.node?.frameId;
+  if (!frameId) throw new Error(`frame selector did not resolve to an iframe: ${selector}`);
+  return {
+    frameId,
+    ...(described.node?.contentDocument?.nodeId
+      ? { nodeId: described.node.contentDocument.nodeId }
+      : {}),
+  };
+}
+
+async function resolveSelectorInFrame(
+  send: DebuggerTransport['sendCommand'],
+  frameNodeId: number,
+  selector: string,
+): Promise<ResolvedNode> {
+  const queried = await send('DOM.querySelector', {
+    nodeId: frameNodeId,
+    selector,
+  }) as { nodeId?: number };
+  if (!queried.nodeId) throw new Error(`selector not found in frame: ${selector}`);
+  const described = await send('DOM.describeNode', {
+    nodeId: queried.nodeId,
+  }) as { node?: { backendNodeId?: number } };
+  if (!described.node?.backendNodeId) {
+    throw new Error(`selector could not be resolved in frame: ${selector}`);
+  }
+  return {
+    objectId: '',
+    backendDOMNodeId: described.node.backendNodeId,
+  };
+}
+
 async function resolveElementQuery(
   send: DebuggerTransport['sendCommand'],
   query: BrowserElementQuery,
@@ -670,7 +716,10 @@ async function focusNode(
       }
       if (requireEditable) {
         const textInput = this instanceof HTMLInputElement
-          && !["button", "checkbox", "file", "hidden", "image", "radio", "range", "reset", "submit"].includes(this.type);
+          && [
+            "date", "datetime-local", "email", "month", "number", "password",
+            "search", "tel", "text", "time", "url", "week",
+          ].includes(this.type);
         const editable = textInput
           || this instanceof HTMLTextAreaElement
           || (this instanceof HTMLElement && this.isContentEditable);
@@ -717,7 +766,10 @@ async function waitForActionable(
         if (options.editable) {
           if ("readOnly" in this && this.readOnly) return "target is read-only";
           const textInput = this instanceof HTMLInputElement
-            && !["button", "checkbox", "file", "hidden", "image", "radio", "range", "reset", "submit"].includes(this.type);
+            && [
+              "date", "datetime-local", "email", "month", "number", "password",
+              "search", "tel", "text", "time", "url", "week",
+            ].includes(this.type);
           const editable = textInput
             || this instanceof HTMLTextAreaElement
             || (this instanceof HTMLElement && this.isContentEditable);
@@ -770,8 +822,9 @@ async function stampActionTarget(
 async function centerOfNode(
   send: DebuggerTransport['sendCommand'],
   node: ResolvedNode,
+  options: { focus?: boolean } = {},
 ): Promise<{ x: number; y: number }> {
-  await focusNode(send, node);
+  if (options.focus !== false) await focusNode(send, node);
   const box = await send('DOM.getBoxModel', {
     ...(node.backendDOMNodeId
       ? { backendNodeId: node.backendDOMNodeId }
@@ -1081,9 +1134,12 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     return element instanceof view.HTMLInputElement
       && ['password', 'search', 'tel', 'text', 'url'].includes(element.type);
   };
+  const isStructuredValueControl = (element: Element): element is HTMLInputElement =>
+    element instanceof eventWindow(element).HTMLInputElement
+    && ['date', 'datetime-local', 'month', 'time', 'week'].includes(element.type);
   const isValueTextControl = (element: Element): element is HTMLInputElement =>
     element instanceof eventWindow(element).HTMLInputElement
-    && ['email', 'number'].includes(element.type);
+    && (['email', 'number'].includes(element.type) || isStructuredValueControl(element));
   const isContentEditable = (element: Element): element is HTMLElement =>
     element instanceof eventWindow(element).HTMLElement && element.isContentEditable;
   const editableElement = (): Element | null => {
@@ -1125,6 +1181,8 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
       const start = element.selectionStart ?? element.value.length;
       const end = element.selectionEnd ?? element.value.length;
       element.setRangeText(text, start, end, 'end');
+    } else if (isStructuredValueControl(element)) {
+      element.value = text;
     } else if (isValueTextControl(element)) {
       if (element.ownerDocument.execCommand?.('insertText', false, text)) return;
       element.value += text;
@@ -1469,14 +1527,27 @@ export class RsbWebviewAutomation {
       this.barriersByTab.delete(tabId);
       await send('Accessibility.enable');
       let response: { nodes?: RawAxNode[] };
+      const frame = typeof req.frame === 'string' && req.frame !== ''
+        ? await resolveFrameRoot(send, req.frame)
+        : undefined;
       if (typeof req.selector === 'string' && req.selector !== '') {
-        const selected = await resolveSelector(send, req.selector);
+        const selected = frame?.nodeId
+          ? await resolveSelectorInFrame(send, frame.nodeId, req.selector)
+          : frame
+            ? undefined
+            : await resolveSelector(send, req.selector);
+        if (!selected) {
+          throw new Error('frame document is unavailable for selector-scoped snapshot');
+        }
         response = await send('Accessibility.getPartialAXTree', {
           backendNodeId: selected.backendDOMNodeId,
           fetchRelatives: false,
         }) as { nodes?: RawAxNode[] };
       } else {
-        response = await send('Accessibility.getFullAXTree') as { nodes?: RawAxNode[] };
+        response = await send(
+          'Accessibility.getFullAXTree',
+          frame ? { frameId: frame.frameId } : undefined,
+        ) as { nodes?: RawAxNode[] };
       }
 
       const { tree, roots } = buildSnapshotTree(Array.isArray(response.nodes) ? response.nodes : []);
@@ -1728,7 +1799,7 @@ export class RsbWebviewAutomation {
           const target = await resolveTarget();
           await waitForActionable(send, target, { timeoutMs: request.timeoutMs });
           const ticket = await stampActionTarget(send, target);
-          const point = await centerOfNode(send, target);
+          const point = await centerOfNode(send, target, { focus: false });
           await dispatchInput('Input.dispatchMouseEvent', {
             type: 'mouseMoved',
             x: point.x,

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -86,9 +86,14 @@ export interface RsbActResult {
   [key: string]: unknown;
 }
 
+export interface HumanVerificationBarrier {
+  kind: 'human-verification';
+  evidence: string[];
+}
+
 interface PageInspection {
   resources: Array<{ kind: string; url: string; label?: string }>;
-  barrier?: { kind: 'human-verification'; evidence: string[] };
+  barrier?: HumanVerificationBarrier;
 }
 
 const INTERACTIVE_ROLES = new Set([
@@ -836,6 +841,12 @@ type InputDispatcher = (
   targetTicket?: string,
 ) => Promise<void>;
 
+type NativeKeyDispatcher = (
+  type: 'keyDown' | 'keyUp',
+  keyCode: string,
+  modifiers: string[],
+) => Promise<void>;
+
 /**
  * Runs inside the guest page, not in Electron Main.
  *
@@ -1200,6 +1211,7 @@ function translateInputCommand(command: TranslatedInputCommand): TranslatedInput
     const key = stringParam(params.key, 'key');
     const target = deepestActiveElement(document) ?? document.body ?? document.documentElement;
     requireTicket(target);
+    if (type === 'validate') return;
     const code = keyCode(key);
     const init: KeyboardEventInit & { keyCode: number; which: number } = {
       ...modifiers(Number(params.modifiers ?? 0)),
@@ -1304,6 +1316,34 @@ async function dispatchTranslatedInput(
   }
 }
 
+function nativeKeyCode(key: string): string | undefined {
+  const known: Record<string, string> = {
+    Backspace: 'BACKSPACE',
+    Tab: 'TAB',
+    Escape: 'ESCAPE',
+    ArrowLeft: 'LEFT',
+    ArrowUp: 'UP',
+    ArrowRight: 'RIGHT',
+    ArrowDown: 'DOWN',
+    Delete: 'DELETE',
+    Home: 'HOME',
+    End: 'END',
+    PageUp: 'PAGEUP',
+    PageDown: 'PAGEDOWN',
+    Insert: 'INSERT',
+  };
+  return known[key];
+}
+
+function nativeModifiers(mask: number): string[] {
+  return [
+    ...(mask & 1 ? ['alt'] : []),
+    ...(mask & 2 ? ['control'] : []),
+    ...(mask & 4 ? ['meta'] : []),
+    ...(mask & 8 ? ['shift'] : []),
+  ];
+}
+
 async function dispatchClick(
   dispatchInput: InputDispatcher,
   x: number,
@@ -1348,8 +1388,22 @@ async function dispatchKey(
   dispatchInput: InputDispatcher,
   rawKey: string,
   targetTicket?: string,
+  nativeDispatch?: NativeKeyDispatcher,
 ): Promise<void> {
   const { key, modifiers } = parseKey(rawKey);
+  const keyCode = nativeKeyCode(key)
+    ?? (modifiers !== 0 && key.length === 1 ? key.toUpperCase() : undefined);
+  // Printable unmodified characters and Enter retain the page-side path,
+  // which emits the input/change events expected by web applications. Native
+  // dispatch is reserved for navigation/editing keys whose browser defaults
+  // cannot be reproduced by synthetic KeyboardEvents.
+  if (nativeDispatch && keyCode) {
+    const modifierNames = nativeModifiers(modifiers);
+    await dispatchInput('Input.dispatchKeyEvent', { type: 'validate' }, targetTicket);
+    await nativeDispatch('keyDown', keyCode, modifierNames);
+    await nativeDispatch('keyUp', keyCode, modifierNames);
+    return;
+  }
   const text = key.length === 1 && modifiers === 0 ? key : undefined;
   await dispatchInput('Input.dispatchKeyEvent', {
     type: 'keyDown',
@@ -1367,12 +1421,21 @@ async function dispatchKey(
 export class RsbWebviewAutomation {
   private readonly refsByTab = new Map<string, Map<string, SnapshotRef>>();
   private readonly resourcesByTab = new Map<string, Set<string>>();
+  private readonly barriersByTab = new Map<string, HumanVerificationBarrier>();
 
   constructor(private readonly logger: AutomationLogger) {}
 
   forgetTab(tabId: string): void {
     this.refsByTab.delete(tabId);
     this.resourcesByTab.delete(tabId);
+    this.barriersByTab.delete(tabId);
+  }
+
+  getHumanVerificationBarrier(tabId: string): HumanVerificationBarrier | undefined {
+    const barrier = this.barriersByTab.get(tabId);
+    return barrier
+      ? { kind: barrier.kind, evidence: [...barrier.evidence] }
+      : undefined;
   }
 
   async snapshot(
@@ -1393,6 +1456,7 @@ export class RsbWebviewAutomation {
       }
       if (inspection.barrier) {
         this.refsByTab.set(tabId, new Map());
+        this.barriersByTab.set(tabId, inspection.barrier);
         return {
           format: req.snapshotFormat ?? 'ai',
           targetId: tabId,
@@ -1402,6 +1466,7 @@ export class RsbWebviewAutomation {
           stats: { lines: 0, chars: 0, refs: 0, interactive: 0 },
         };
       }
+      this.barriersByTab.delete(tabId);
       await send('Accessibility.enable');
       let response: { nodes?: RawAxNode[] };
       if (typeof req.selector === 'string' && req.selector !== '') {
@@ -1557,6 +1622,10 @@ export class RsbWebviewAutomation {
     tabId: string,
     wc: WebContents,
     request: BrowserActRequest,
+    options?: {
+      nativeKeyDispatch?: NativeKeyDispatcher;
+      waitForNetworkIdle?: (timeoutMs: number) => Promise<void>;
+    },
   ): Promise<RsbActResult> {
     return withDebugger(wc, async (send) => {
       const dispatchInput: InputDispatcher = async (method, params, targetTicket) => {
@@ -1652,7 +1721,7 @@ export class RsbWebviewAutomation {
           if (typeof request.key !== 'string' || request.key === '') {
             throw new Error('press.key required');
           }
-          await dispatchKey(dispatchInput, request.key, ticket);
+          await dispatchKey(dispatchInput, request.key, ticket, options?.nativeKeyDispatch);
           return { tabId, kind: request.kind, key: request.key };
         }
         case 'hover': {
@@ -1796,6 +1865,9 @@ export class RsbWebviewAutomation {
                 ?? result.exceptionDetails.text
                 ?? 'wait failed',
               );
+            }
+            if (request.loadState === 'networkidle') {
+              await options?.waitForNetworkIdle?.(timeoutMs);
             }
             return { tabId, kind: request.kind, waitedMs: timeMs, state: result.result?.value };
           }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -612,6 +612,16 @@ export class RsbWebviewAutomation {
     request: BrowserActRequest,
   ): Promise<RsbActResult> {
     return withDebugger(wc, async (send) => {
+      // DOM focus alone is not enough for an embedded <webview>: Chromium's
+      // Input domain routes keyboard and mouse events through the currently
+      // focused RenderWidgetHost. If Cindy's chat composer still owns the
+      // Electron focus, those events land in the composer even though
+      // Runtime.callFunctionOn focused an element inside the guest document.
+      // Activate the guest before every real input action so CDP dispatches to
+      // the WebContents that supplied the snapshot/ref.
+      const focusGuest = (): void => {
+        wc.focus();
+      };
       const resolveTarget = async (
         ref = request.ref,
         selector = request.selector,
@@ -629,11 +639,13 @@ export class RsbWebviewAutomation {
 
       switch (request.kind) {
         case 'click': {
+          focusGuest();
           const point = await centerOfNode(send, await resolveTarget());
           await dispatchClick(send, point.x, point.y, request);
           return { tabId, kind: request.kind, ...point };
         }
         case 'clickCoords': {
+          focusGuest();
           const x = finiteNonNegative(request.x, 'clickCoords.x');
           const y = finiteNonNegative(request.y, 'clickCoords.y');
           await dispatchClick(send, x, y, request);
@@ -641,6 +653,7 @@ export class RsbWebviewAutomation {
         }
         case 'type':
         case 'fill': {
+          focusGuest();
           const target = await resolveTarget();
           await focusNode(send, target, true);
           if (request.kind === 'fill') {
@@ -676,6 +689,7 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, textLength: request.text.length };
         }
         case 'press': {
+          focusGuest();
           if (request.ref || request.selector) {
             await focusNode(send, await resolveTarget());
           }
@@ -686,6 +700,7 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, key: request.key };
         }
         case 'hover': {
+          focusGuest();
           const point = await centerOfNode(send, await resolveTarget());
           await send('Input.dispatchMouseEvent', {
             type: 'mouseMoved',
@@ -696,6 +711,7 @@ export class RsbWebviewAutomation {
           return { tabId, kind: request.kind, ...point };
         }
         case 'drag': {
+          focusGuest();
           const start = await centerOfNode(
             send,
             await resolveTarget(request.startRef, undefined),

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-automation.ts
@@ -1325,6 +1325,68 @@ export class RsbWebviewAutomation {
     });
   }
 
+  async setFiles(
+    tabId: string,
+    wc: WebContents,
+    req: Pick<
+      BrowserControlRequest,
+      'paths' | 'ref' | 'inputRef' | 'element' | 'query' | 'timeoutMs'
+    >,
+  ): Promise<{ tabId: string; uploadedFiles: number }> {
+    return withDebugger(wc, async (send) => {
+      let target: ResolvedNode;
+      if (req.query && typeof req.query === 'object') {
+        target = await resolveElementQuery(send, req.query, req.timeoutMs);
+      } else if (typeof req.element === 'string' && req.element !== '') {
+        target = await resolveSelector(send, req.element, req.timeoutMs);
+      } else {
+        const ref = req.inputRef ?? req.ref;
+        if (typeof ref !== 'string' || ref === '') {
+          throw new Error('upload requires inputRef, ref, element, or query');
+        }
+        const snapshotRef = this.refsByTab.get(tabId)?.get(ref);
+        if (!snapshotRef) {
+          throw new Error(`unknown or stale snapshot ref: ${ref}; take a new snapshot`);
+        }
+        target = await resolveRef(send, snapshotRef);
+      }
+
+      const readiness = await callOnNode<{
+        ok: boolean;
+        reason?: string;
+        multiple?: boolean;
+      }>(
+        send,
+        target.objectId,
+        `function() {
+          if (!(this instanceof HTMLInputElement) || this.type !== "file") {
+            return { ok: false, reason: "upload target is not a file input" };
+          }
+          if (!this.isConnected) return { ok: false, reason: "upload target is detached" };
+          if (this.disabled || this.getAttribute("aria-disabled") === "true") {
+            return { ok: false, reason: "upload target is disabled" };
+          }
+          return { ok: true, multiple: this.multiple };
+        }`,
+      );
+      if (!readiness?.ok) {
+        throw new Error(readiness?.reason ?? 'upload target is not ready');
+      }
+      const paths = req.paths ?? [];
+      if (paths.length > 1 && readiness.multiple !== true) {
+        throw new Error('upload target accepts only one file');
+      }
+      await send('DOM.setFileInputFiles', {
+        files: paths,
+        objectId: target.objectId,
+      });
+      return {
+        tabId,
+        uploadedFiles: paths.length,
+      };
+    });
+  }
+
   async act(
     tabId: string,
     wc: WebContents,

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -24,6 +24,7 @@ import type {
   BrowserControlRequest,
   BrowserControlResult,
 } from '@cindy/browser-control-runtime';
+import { isPublicHttpResourceUrl } from '@cindy/browser-control-runtime';
 import type { WebContents } from 'electron';
 
 import type { TabRegistry } from '../../rsb-browser-bridge/registry.js';
@@ -139,19 +140,6 @@ function safeTabMeta(wc: WebContents): { url: string; title: string } {
   return { url, title };
 }
 
-function isHttpResourceUrl(value: string): boolean {
-  try {
-    const parsed = new URL(value);
-    return (
-      (parsed.protocol === 'http:' || parsed.protocol === 'https:')
-      && !parsed.username
-      && !parsed.password
-    );
-  } catch {
-    return false;
-  }
-}
-
 function mayStartDownload(request: BrowserActRequest): boolean {
   return request.kind === 'click'
     || request.kind === 'clickCoords'
@@ -170,6 +158,8 @@ export class RsbWebviewBackend implements BrowserBackend {
   private readonly dialogs: RsbWebviewDialogs;
   private readonly network: RsbWebviewNetwork;
   private readonly activity: BrowserActivity[] = [];
+  private readonly activeCalls = new Set<Promise<BackendResult>>();
+  private disposing = false;
 
   constructor(private readonly opts: RsbWebviewBackendOptions) {
     this.automation = new RsbWebviewAutomation(opts.logger);
@@ -192,25 +182,36 @@ export class RsbWebviewBackend implements BrowserBackend {
   }
 
   async call(request: BackendRequest): Promise<BackendResult> {
+    if (this.disposing) return actionFailed(request.action, 'browser backend is disposing');
+    const operation = (async (): Promise<BackendResult> => {
+      try {
+        const result = await this.dispatch(request);
+        this.recordActivity(request, result.ok);
+        return result;
+      } catch (err) {
+        this.opts.logger.warn('rsb-webview backend.call threw', {
+          action: request.action,
+          err,
+        });
+        const result = actionFailed(
+          request.action,
+          err instanceof Error ? err.message : String(err),
+        );
+        this.recordActivity(request, false);
+        return result;
+      }
+    })();
+    this.activeCalls.add(operation);
     try {
-      const result = await this.dispatch(request);
-      this.recordActivity(request, result.ok);
-      return result;
-    } catch (err) {
-      this.opts.logger.warn('rsb-webview backend.call threw', {
-        action: request.action,
-        err,
-      });
-      const result = actionFailed(
-        request.action,
-        err instanceof Error ? err.message : String(err),
-      );
-      this.recordActivity(request, false);
-      return result;
+      return await operation;
+    } finally {
+      this.activeCalls.delete(operation);
     }
   }
 
   async dispose(): Promise<void> {
+    this.disposing = true;
+    await Promise.allSettled([...this.activeCalls]);
     // Switching backends never closes the user's tabs. Only the listeners and
     // debugger attachments owned by this backend are released.
     await this.artifacts?.dispose();
@@ -506,7 +507,7 @@ export class RsbWebviewBackend implements BrowserBackend {
 
     if (inner.kind === 'saveResource') {
       if (!this.artifacts) return actionFailed(req.action, 'managed downloads are unavailable');
-      if (typeof inner.url !== 'string' || !isHttpResourceUrl(inner.url)) {
+      if (typeof inner.url !== 'string' || !isPublicHttpResourceUrl(inner.url)) {
         return actionFailed(req.action, 'saveResource.url must be an http(s) URL from snapshot(urls:true)');
       }
       this.automation.assertResource(tabId, inner.url);

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -478,7 +478,12 @@ export class RsbWebviewBackend implements BrowserBackend {
           : {}),
     } as BackendRequest;
     if (inner.kind === 'close') {
-      return this.handleClose(requestWithInnerTarget);
+      const result = await this.handleClose(requestWithInnerTarget);
+      if (!result.ok || !result.data || typeof result.data !== 'object') return result;
+      return {
+        ...result,
+        data: { ...(result.data as Record<string, unknown>), kind: 'close' },
+      };
     }
 
     const tabId = await this.resolveDirectActionTarget(requestWithInnerTarget);
@@ -529,26 +534,11 @@ export class RsbWebviewBackend implements BrowserBackend {
       if (typeof inner.fn !== 'string' || inner.fn === '') {
         return actionFailed(req.action, 'evaluate.fn (JS expression source) required');
       }
-
-      // Safety / parity model:
-      //
-      // The vendored runtime's `act:evaluate` builds an in-page evaluator that
-      // does literally `eval("(" + fnSource + ")")` then calls the resulting
-      // function. JSON.stringify keeps the complete agent-provided source in a
-      // single JS string literal, preventing it from escaping this IIFE.
-      const wrapped = `(() => {
-        var candidate = eval("(" + ${JSON.stringify(inner.fn)} + ")");
-        if (typeof candidate !== "function") {
-          throw new Error("evaluate source did not produce a function");
-        }
-        var result = candidate();
-        return Promise.resolve(result);
-      })()`;
       return this.withTabPin(tabId, async () => {
         await this.tryObservePageSignals(wc, tabId);
         let value: unknown;
         try {
-          value = await wc.executeJavaScript(wrapped, /* userGesture */ false);
+          value = await this.automation.evaluate(tabId, wc, automationRequest);
         } catch (err) {
           return actionFailed(
             req.action,

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -35,7 +35,7 @@ import type {
   BrowserBackend,
 } from './types.js';
 import { RsbWebviewAutomation } from './rsb-webview-automation.js';
-import { RsbWebviewArtifacts } from './rsb-webview-artifacts.js';
+import { artifactSessionRoot, RsbWebviewArtifacts } from './rsb-webview-artifacts.js';
 import { RsbWebviewDialogs } from './rsb-webview-dialogs.js';
 import { RsbWebviewNetwork } from './rsb-webview-network.js';
 import { resolveUploadFiles } from './rsb-webview-upload-policy.js';
@@ -152,11 +152,15 @@ function isHttpResourceUrl(value: string): boolean {
   }
 }
 
-function mayStartDownload(kind: string): boolean {
-  return kind === 'click'
-    || kind === 'clickCoords'
-    || kind === 'press'
-    || kind === 'select';
+function mayStartDownload(request: BrowserActRequest): boolean {
+  return request.kind === 'click'
+    || request.kind === 'clickCoords'
+    || request.kind === 'press'
+    || request.kind === 'select'
+    || (
+      (request.kind === 'type' || request.kind === 'fill')
+      && request.submit === true
+    );
 }
 
 export class RsbWebviewBackend implements BrowserBackend {
@@ -645,7 +649,7 @@ export class RsbWebviewBackend implements BrowserBackend {
       };
 
       const captured = this.artifacts
-        && mayStartDownload(inner.kind)
+        && mayStartDownload(inner)
         ? await this.artifacts.capture(
           wc,
           {
@@ -688,7 +692,9 @@ export class RsbWebviewBackend implements BrowserBackend {
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
       const roots = [
-        ...(this.opts.artifactRoot ? [this.opts.artifactRoot()] : []),
+        ...(this.opts.artifactRoot
+          ? [artifactSessionRoot(this.opts.artifactRoot(), sessionId)]
+          : []),
         ...(this.opts.resolveUploadRoots
           ? await this.opts.resolveUploadRoots(sessionId)
           : []),

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -35,6 +35,7 @@ import type {
   BrowserBackend,
 } from './types.js';
 import { RsbWebviewAutomation } from './rsb-webview-automation.js';
+import { RsbWebviewArtifacts } from './rsb-webview-artifacts.js';
 import { RsbWebviewDialogs } from './rsb-webview-dialogs.js';
 import { RsbWebviewNetwork } from './rsb-webview-network.js';
 import { resolveUploadFiles } from './rsb-webview-upload-policy.js';
@@ -138,15 +139,39 @@ function safeTabMeta(wc: WebContents): { url: string; title: string } {
   return { url, title };
 }
 
+function isHttpResourceUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+      && !parsed.username
+      && !parsed.password
+    );
+  } catch {
+    return false;
+  }
+}
+
+function mayStartDownload(kind: string): boolean {
+  return kind === 'click'
+    || kind === 'clickCoords'
+    || kind === 'press'
+    || kind === 'select';
+}
+
 export class RsbWebviewBackend implements BrowserBackend {
   readonly kind = 'rsb-webview' as const;
   private readonly automation: RsbWebviewAutomation;
+  private readonly artifacts?: RsbWebviewArtifacts;
   private readonly dialogs: RsbWebviewDialogs;
   private readonly network: RsbWebviewNetwork;
   private readonly activity: BrowserActivity[] = [];
 
   constructor(private readonly opts: RsbWebviewBackendOptions) {
     this.automation = new RsbWebviewAutomation(opts.logger);
+    this.artifacts = opts.artifactRoot
+      ? new RsbWebviewArtifacts(opts.artifactRoot, opts.logger)
+      : undefined;
     this.dialogs = new RsbWebviewDialogs(opts.logger);
     this.network = new RsbWebviewNetwork(opts.logger);
   }
@@ -184,6 +209,7 @@ export class RsbWebviewBackend implements BrowserBackend {
   async dispose(): Promise<void> {
     // Switching backends never closes the user's tabs. Only the listeners and
     // debugger attachments owned by this backend are released.
+    await this.artifacts?.dispose();
     this.dialogs.dispose();
     this.network.dispose();
   }
@@ -259,6 +285,7 @@ export class RsbWebviewBackend implements BrowserBackend {
       totalRegisteredTabs: this.opts.registry.listAll().length,
       pinnedTabs: this.opts.registry.listPinned(),
       dialogs: this.dialogs.diagnostics(),
+      ...(this.artifacts ? { artifacts: this.artifacts.diagnostics() } : {}),
       network: this.network.diagnostics(),
       recentActivity: this.activity.slice(-20),
     });
@@ -449,6 +476,36 @@ export class RsbWebviewBackend implements BrowserBackend {
     if (!resolved.ok) return resolved.result;
     const wc = resolved.wc;
 
+    if (inner.kind === 'saveResource') {
+      if (!this.artifacts) return actionFailed(req.action, 'managed downloads are unavailable');
+      if (typeof inner.url !== 'string' || !isHttpResourceUrl(inner.url)) {
+        return actionFailed(req.action, 'saveResource.url must be an http(s) URL from snapshot(urls:true)');
+      }
+      this.automation.assertResource(tabId, inner.url);
+      const sessionId = this.resolveSessionId(requestWithInnerTarget);
+      if (!sessionId) return actionFailed(req.action, 'no active RSB session');
+      return this.withTabPin(tabId, async () => {
+        await this.tryObservePageSignals(wc, tabId);
+        const captured = await this.artifacts!.capture(
+          wc,
+          { sessionId, timeoutMs: inner.timeoutMs ?? req.timeoutMs },
+          async () => {
+            wc.downloadURL(inner.url!);
+            return undefined;
+          },
+        );
+        if (!captured.downloads.some((artifact) => artifact.state === 'completed')) {
+          return actionFailed(req.action, 'resource download did not complete');
+        }
+        return actionOk(req.action, {
+          tabId,
+          kind: inner.kind,
+          url: inner.url,
+          downloads: captured.downloads,
+        });
+      });
+    }
+
     if (inner.kind === 'evaluate') {
       if (typeof inner.fn !== 'string' || inner.fn === '') {
         return actionFailed(req.action, 'evaluate.fn (JS expression source) required');
@@ -488,10 +545,27 @@ export class RsbWebviewBackend implements BrowserBackend {
       });
     }
 
-    return this.withTabPin(tabId, async () => {
+    const runAction = async () => {
       await this.tryObservePageSignals(wc, tabId);
       const data = await this.automation.act(tabId, wc, inner);
-      return actionOk(req.action, data);
+      return data;
+    };
+    return this.withTabPin(tabId, async () => {
+      const captured = this.artifacts
+        && mayStartDownload(inner.kind)
+        ? await this.artifacts.capture(
+          wc,
+          {
+            sessionId: this.resolveSessionId(requestWithInnerTarget) ?? 'rsb',
+            timeoutMs: inner.timeoutMs ?? req.timeoutMs,
+          },
+          runAction,
+        )
+        : { value: await runAction(), downloads: [] };
+      return actionOk(req.action, {
+        ...captured.value,
+        ...(captured.downloads.length > 0 ? { downloads: captured.downloads } : {}),
+      });
     });
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -5,15 +5,14 @@
  * either:
  *   - Electron native API on the guest `WebContents` (navigate / screenshot /
  *     pdf / console)
+ *   - a bounded CDP session on the guest `WebContents` (snapshot / act)
  *   - the renderer's RSB store via the request/response bridge (open /
  *     focus / close)
  *   - the `TabRegistry` for status / tabs / profiles / doctor
  *
- * Scope (Phase 3): low-complexity actions only. Phase 4 layers CDP-driven
- * snapshot / act / extract / requests / responseBody / upload on top. Actions
- * not implemented in this phase respond with `BROWSER_RUNTIME_ACTION_FAILED`
- * + a clear message ("action 'X' not yet supported in rsb-webview backend")
- * so the MCP layer still surfaces a structured error.
+ * Actions outside the sidebar browser's current capability set respond with
+ * `BROWSER_RUNTIME_ACTION_FAILED` + a clear explanation, so the MCP layer still
+ * surfaces a structured error.
  *
  * Why this lives in main: the `WebContents` handles + CDP debugger access are
  * main-only; the backend has no business in the renderer. The renderer owns
@@ -21,6 +20,7 @@
  */
 
 import type {
+  BrowserActRequest,
   BrowserControlRequest,
   BrowserControlResult,
 } from '@cindy/browser-control-runtime';
@@ -34,6 +34,7 @@ import type {
   BackendResult,
   BrowserBackend,
 } from './types.js';
+import { RsbWebviewAutomation } from './rsb-webview-automation.js';
 
 interface BackendLogger {
   info(message: string, ...args: unknown[]): void;
@@ -127,8 +128,11 @@ function safeTabMeta(wc: WebContents): { url: string; title: string } {
 
 export class RsbWebviewBackend implements BrowserBackend {
   readonly kind = 'rsb-webview' as const;
+  private readonly automation: RsbWebviewAutomation;
 
-  constructor(private readonly opts: RsbWebviewBackendOptions) {}
+  constructor(private readonly opts: RsbWebviewBackendOptions) {
+    this.automation = new RsbWebviewAutomation(opts.logger);
+  }
 
   /**
    * Read the agent session id from an MCP-injected request, or fall back to
@@ -158,8 +162,8 @@ export class RsbWebviewBackend implements BrowserBackend {
 
   async dispose(): Promise<void> {
     // Nothing to tear down. Switching away from this backend doesn't kill
-    // any tabs — the user's RSB stays as-is. Pin set decays naturally as
-    // automation steps finish (in Phase 3 there are no pins).
+    // any tabs — the user's RSB stays as-is. Per-action debugger sessions and
+    // pins are released by their own finally blocks.
   }
 
   // ── dispatch ──────────────────────────────────────────────────────────────
@@ -186,6 +190,8 @@ export class RsbWebviewBackend implements BrowserBackend {
         return this.handleClose(request);
       case 'navigate':
         return this.handleNavigate(request);
+      case 'snapshot':
+        return this.handleSnapshot(request);
       case 'screenshot':
         return this.handleScreenshot(request);
       case 'pdf':
@@ -195,10 +201,9 @@ export class RsbWebviewBackend implements BrowserBackend {
       case 'act':
         return this.handleAct(request);
       default:
-        // Snapshot / extract / requests / responseBody / upload / dialog —
-        // Phase 4 CDP territory. `act` supports `evaluate` only in this phase
-        // (handled above); `act:click` / `act:type` / etc. require CDP Input
-        // domain and ARIA snapshot infrastructure that lands in a follow-up.
+        // requests / responseBody / upload / dialog are not wired to the
+        // embedded guest yet. Keep failure structured so callers can choose an
+        // external browser backend for those advanced capabilities.
         return actionFailed(
           request.action,
           `action '${request.action}' not yet supported in rsb-webview backend`,
@@ -313,6 +318,7 @@ export class RsbWebviewBackend implements BrowserBackend {
       this.opts.bridge,
     );
     if (!result.ok) return actionFailed(req.action, result.error);
+    this.automation.forgetTab(tabId);
     return actionOk(req.action, { tabId });
   }
 
@@ -326,8 +332,20 @@ export class RsbWebviewBackend implements BrowserBackend {
     const resolved = await this.resolveTabForDirectAction(req, tabId);
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
+      this.automation.forgetTab(tabId);
       await resolved.wc.loadURL(url);
       return actionOk(req.action, { tabId, url });
+    });
+  }
+
+  private async handleSnapshot(req: BackendRequest): Promise<BackendResult> {
+    const tabId = await this.resolveDirectActionTarget(req);
+    if (!tabId) return actionFailed(req.action, 'targetId required');
+    const resolved = await this.resolveTabForDirectAction(req, tabId);
+    if (!resolved.ok) return resolved.result;
+    return this.withTabPin(tabId, async () => {
+      const data = await this.automation.snapshot(tabId, resolved.wc, req);
+      return actionOk(req.action, data);
     });
   }
 
@@ -366,79 +384,70 @@ export class RsbWebviewBackend implements BrowserBackend {
     });
   }
 
-  /**
-   * Phase 4 lite — `act:evaluate` only. The CDP-driven act variants
-   * (click / type / press / hover / drag / select / fill / wait / clickCoords /
-   * resize) need an ARIA snapshot + Input domain subsystem that ships in a
-   * dedicated follow-up. evaluate is dispatch-cheap because it maps straight
-   * to `webContents.executeJavaScript` — included here so recipes that rely
-   * on evaluate (the majority of L1 / L2 site recipes) work today.
-   */
   private async handleAct(req: BackendRequest): Promise<BackendResult> {
-    const tabId = await this.resolveDirectActionTarget(req);
-    if (!tabId) return actionFailed(req.action, 'targetId required');
-    const resolved = await this.resolveTabForDirectAction(req, tabId);
-    if (!resolved.ok) return resolved.result;
-    const wc = resolved.wc;
-
-    const inner = (req as { request?: { kind?: string; fn?: string; as?: string } }).request;
+    const inner = (req as { request?: BrowserActRequest & { as?: string } }).request;
     if (!inner || typeof inner !== 'object') {
       return actionFailed(req.action, 'request body required');
     }
-    if (inner.kind !== 'evaluate') {
-      return actionFailed(
-        req.action,
-        `act:${String(inner.kind)} not yet supported in rsb-webview backend (Phase 4)`,
-      );
-    }
-    if (typeof inner.fn !== 'string' || inner.fn === '') {
-      return actionFailed(req.action, 'evaluate.fn (JS expression source) required');
+    const requestWithInnerTarget = {
+      ...req,
+      ...(typeof req.targetId === 'string'
+        ? {}
+        : typeof inner.targetId === 'string'
+          ? { targetId: inner.targetId }
+          : {}),
+    } as BackendRequest;
+    if (inner.kind === 'close') {
+      return this.handleClose(requestWithInnerTarget);
     }
 
-    // Safety / parity model:
-    //
-    // The vendored runtime's `act:evaluate` builds an in-page evaluator that
-    // does literally `eval("(" + fnSource + ")")` then calls the resulting
-    // function (see pw-tools-core.interactions.ts:1107-1131). The attack
-    // surface of "agent-provided JS runs in the guest page" is the SAME there
-    // — both forms are arbitrary JS in same-origin context. We mirror that
-    // pattern verbatim instead of a naive `(${fn})()` concat so:
-    //   (a) the architectural threat model is identical, not "subtly different
-    //       in a way only this code knows";
-    //   (b) we get the same "did not produce a function" guard for free;
-    //   (c) `JSON.stringify` ensures fn text is a JS string literal — no IIFE
-    //       escape via `})(); window.x=...;((`-style payloads.
-    // The caller's `fn` is still arbitrary JS that runs in the page; that's the
-    // designed capability (recipe authors do same-origin fetch / DOM scraping
-    // / page mutations through it). The guard only stops "smuggle multiple
-    // statements past the IIFE wrapper".
-    const wrapped = `(() => {
-      var candidate = eval("(" + ${JSON.stringify(inner.fn)} + ")");
-      if (typeof candidate !== "function") {
-        throw new Error("evaluate source did not produce a function");
+    const tabId = await this.resolveDirectActionTarget(requestWithInnerTarget);
+    if (!tabId) return actionFailed(req.action, 'targetId required');
+    const resolved = await this.resolveTabForDirectAction(requestWithInnerTarget, tabId);
+    if (!resolved.ok) return resolved.result;
+    const wc = resolved.wc;
+
+    if (inner.kind === 'evaluate') {
+      if (typeof inner.fn !== 'string' || inner.fn === '') {
+        return actionFailed(req.action, 'evaluate.fn (JS expression source) required');
       }
-      var result = candidate();
-      return Promise.resolve(result);
-    })()`;
-    return this.withTabPin(tabId, async () => {
-      let value: unknown;
-      try {
-        value = await wc.executeJavaScript(wrapped, /* userGesture */ false);
-      } catch (err) {
-        return actionFailed(
-          req.action,
-          err instanceof Error ? err.message : String(err),
-        );
-      }
-      return actionOk(req.action, {
-        tabId,
-        kind: 'evaluate',
-        // `as` is an output-variable name the recipe-runner uses to alias the
-        // returned value. Surfaced verbatim so the runner's substitution
-        // ({{var}}) works without an extra translation step.
-        ...(typeof inner.as === 'string' ? { as: inner.as } : {}),
-        result: value,
+
+      // Safety / parity model:
+      //
+      // The vendored runtime's `act:evaluate` builds an in-page evaluator that
+      // does literally `eval("(" + fnSource + ")")` then calls the resulting
+      // function. JSON.stringify keeps the complete agent-provided source in a
+      // single JS string literal, preventing it from escaping this IIFE.
+      const wrapped = `(() => {
+        var candidate = eval("(" + ${JSON.stringify(inner.fn)} + ")");
+        if (typeof candidate !== "function") {
+          throw new Error("evaluate source did not produce a function");
+        }
+        var result = candidate();
+        return Promise.resolve(result);
+      })()`;
+      return this.withTabPin(tabId, async () => {
+        let value: unknown;
+        try {
+          value = await wc.executeJavaScript(wrapped, /* userGesture */ false);
+        } catch (err) {
+          return actionFailed(
+            req.action,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        return actionOk(req.action, {
+          tabId,
+          kind: 'evaluate',
+          ...(typeof inner.as === 'string' ? { as: inner.as } : {}),
+          result: value,
+        });
       });
+    }
+
+    return this.withTabPin(tabId, async () => {
+      const data = await this.automation.act(tabId, wc, inner);
+      return actionOk(req.action, data);
     });
   }
 
@@ -510,7 +519,7 @@ export class RsbWebviewBackend implements BrowserBackend {
   private extractTargetId(req: BackendRequest): string | null {
     const v = (req as { targetId?: unknown }).targetId;
     if (typeof v === 'string' && v !== '') return v;
-    const sessionId = this.opts.getActiveSessionId();
+    const sessionId = this.resolveSessionId(req);
     if (!sessionId) return null;
     const records = this.opts.registry.listBySession(sessionId);
     // Last reported wins — RsbBrowserBridge replaces a tab's record on every

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -94,6 +94,7 @@ export interface RsbWebviewBackendOptions {
  */
 const TAB_REATTACH_TOTAL_MS = 5000;
 const TAB_REATTACH_POLL_MS = 250;
+const DEFAULT_NAVIGATION_TIMEOUT_MS = 60_000;
 
 /**
  * Standard error payload for an action we can't service. Keeps the shape
@@ -149,6 +150,31 @@ function mayStartDownload(request: BrowserActRequest): boolean {
       (request.kind === 'type' || request.kind === 'fill')
       && request.submit === true
     );
+}
+
+async function loadUrlWithTimeout(
+  wc: WebContents,
+  url: string,
+  timeoutMs: number,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      wc.loadURL(url),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          try {
+            wc.stop();
+          } catch {
+            // The guest may already be gone; the timeout must still settle.
+          }
+          reject(new Error(`navigation timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 export class RsbWebviewBackend implements BrowserBackend {
@@ -397,7 +423,11 @@ export class RsbWebviewBackend implements BrowserBackend {
     return this.withTabPin(tabId, async () => {
       this.automation.forgetTab(tabId);
       await this.tryObservePageSignals(resolved.wc, tabId);
-      await resolved.wc.loadURL(url);
+      await loadUrlWithTimeout(
+        resolved.wc,
+        url,
+        req.timeoutMs ?? DEFAULT_NAVIGATION_TIMEOUT_MS,
+      );
       return actionOk(req.action, { tabId, url });
     });
   }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -459,6 +459,13 @@ export class RsbWebviewBackend implements BrowserBackend {
     if (!inner || typeof inner !== 'object') {
       return actionFailed(req.action, 'request body required');
     }
+    if (
+      typeof req.targetId === 'string'
+      && typeof inner.targetId === 'string'
+      && req.targetId !== inner.targetId
+    ) {
+      return actionFailed(req.action, 'targetId mismatch between act request and nested request');
+    }
     const automationRequest = inner.timeoutMs === undefined && req.timeoutMs !== undefined
       ? { ...inner, timeoutMs: req.timeoutMs }
       : inner;

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -547,9 +547,10 @@ export class RsbWebviewBackend implements BrowserBackend {
 
     return this.withTabPin(tabId, async () => {
       await this.tryObserveNetwork(wc, tabId);
-      await this.dialogs.observe(wc);
-      const pendingDialog = this.dialogs.pending(wc);
+      const opening = await this.tryWatchPageDialog(wc, tabId);
+      const pendingDialog = opening ? this.dialogs.pending(wc) : undefined;
       if (pendingDialog) {
+        opening?.cancel();
         return actionOk(req.action, {
           tabId,
           kind: inner.kind,
@@ -557,12 +558,11 @@ export class RsbWebviewBackend implements BrowserBackend {
         });
       }
 
-      const opening = this.dialogs.watchOpening(wc);
       const actionStartedAt = Date.now();
       const runAction = async () => {
-        const dialogBeforeStart = this.dialogs.pending(wc);
+        const dialogBeforeStart = opening ? this.dialogs.pending(wc) : undefined;
         if (dialogBeforeStart) {
-          opening.cancel();
+          opening?.cancel();
           return {
             tabId,
             kind: inner.kind,
@@ -570,6 +570,7 @@ export class RsbWebviewBackend implements BrowserBackend {
           };
         }
         const actionPromise = this.automation.act(tabId, wc, inner);
+        if (!opening) return actionPromise;
         const outcome = await Promise.race([
           actionPromise.then((value) => ({ type: 'action' as const, value })),
           opening.opened.then((dialog) => ({ type: 'dialog' as const, dialog })),
@@ -804,6 +805,21 @@ export class RsbWebviewBackend implements BrowserBackend {
     });
     if (this.activity.length > 200) {
       this.activity.splice(0, this.activity.length - 200);
+    }
+  }
+
+  private async tryWatchPageDialog(
+    wc: WebContents,
+    tabId: string,
+  ): Promise<ReturnType<RsbWebviewDialogs['watchOpening']> | undefined> {
+    try {
+      await this.dialogs.observe(wc);
+      return this.dialogs.watchOpening(wc);
+    } catch (err) {
+      // Dialog capture enriches an action but should not make the action fail
+      // when another debugger client owns the guest or Page.enable is refused.
+      this.opts.logger.warn('RSB page dialog observation unavailable', { tabId, err });
+      return undefined;
     }
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -545,12 +545,82 @@ export class RsbWebviewBackend implements BrowserBackend {
       });
     }
 
-    const runAction = async () => {
-      await this.tryObservePageSignals(wc, tabId);
-      const data = await this.automation.act(tabId, wc, inner);
-      return data;
-    };
     return this.withTabPin(tabId, async () => {
+      await this.tryObserveNetwork(wc, tabId);
+      await this.dialogs.observe(wc);
+      const pendingDialog = this.dialogs.pending(wc);
+      if (pendingDialog) {
+        return actionOk(req.action, {
+          tabId,
+          kind: inner.kind,
+          barrier: { kind: 'page-dialog', dialog: pendingDialog },
+        });
+      }
+
+      const opening = this.dialogs.watchOpening(wc);
+      const actionStartedAt = Date.now();
+      const runAction = async () => {
+        const dialogBeforeStart = this.dialogs.pending(wc);
+        if (dialogBeforeStart) {
+          opening.cancel();
+          return {
+            tabId,
+            kind: inner.kind,
+            barrier: { kind: 'page-dialog', dialog: dialogBeforeStart },
+          };
+        }
+        const actionPromise = this.automation.act(tabId, wc, inner);
+        const outcome = await Promise.race([
+          actionPromise.then((value) => ({ type: 'action' as const, value })),
+          opening.opened.then((dialog) => ({ type: 'dialog' as const, dialog })),
+        ]);
+        if (outcome.type === 'action') {
+          opening.cancel();
+          const closedDialog = this.dialogs.recent(
+            wc,
+            undefined,
+            actionStartedAt,
+          );
+          if (closedDialog && closedDialog.type !== 'alert') {
+            return {
+              tabId,
+              kind: inner.kind,
+              barrier: { kind: 'page-dialog', dialog: closedDialog },
+            };
+          }
+          if (closedDialog) {
+            return {
+              ...outcome.value,
+              dialogs: [{ ...closedDialog, handled: true }],
+            };
+          }
+          return outcome.value;
+        }
+        if (outcome.dialog.type === 'alert') {
+          const value = await actionPromise;
+          const closedDialog = this.dialogs.recent(wc, outcome.dialog.id);
+          return {
+            ...value,
+            dialogs: [{
+              ...(closedDialog ?? outcome.dialog),
+              handled: true,
+            }],
+          };
+        }
+        void actionPromise.catch((err) => {
+          this.opts.logger.warn('browser action failed after a page dialog opened', {
+            tabId,
+            actionKind: inner.kind,
+            err,
+          });
+        });
+        return {
+          tabId,
+          kind: inner.kind,
+          barrier: { kind: 'page-dialog', dialog: outcome.dialog },
+        };
+      };
+
       const captured = this.artifacts
         && mayStartDownload(inner.kind)
         ? await this.artifacts.capture(
@@ -616,12 +686,69 @@ export class RsbWebviewBackend implements BrowserBackend {
     const resolved = await this.resolveTabForDirectAction(req, tabId);
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
-      const dialog = await this.dialogs.respond(resolved.wc, {
-        dialogId: req.dialogId,
-        accept: req.accept,
-        promptText: req.promptText,
-        timeoutMs: req.timeoutMs,
-      });
+      let dialog;
+      try {
+        dialog = await this.dialogs.respond(resolved.wc, {
+          dialogId: req.dialogId,
+          accept: req.accept,
+          promptText: req.promptText,
+          timeoutMs: req.timeoutMs,
+        });
+      } catch (err) {
+        if (
+          !(err instanceof Error)
+          || err.message !== 'no page dialog is pending'
+          || req.accept !== true
+        ) {
+          throw err;
+        }
+        const armed = this.dialogs.armNext(resolved.wc, {
+          accept: true,
+          promptText: req.promptText,
+          timeoutMs: req.timeoutMs,
+        });
+        void armed.response.catch((responseErr) => {
+          this.opts.logger.warn('prepared page dialog response expired', {
+            tabId,
+            err: responseErr,
+          });
+        });
+        return actionOk(req.action, {
+          tabId,
+          armed: true,
+          retryRequired: true,
+        });
+      }
+      if (dialog.deferred) {
+        if (
+          dialog.closedBy === 'armed'
+          || dialog.type === 'alert'
+          || req.accept !== true
+        ) {
+          return actionOk(req.action, {
+            tabId,
+            dialog,
+            handled: true,
+          });
+        }
+        const armed = this.dialogs.armNext(resolved.wc, {
+          accept: true,
+          promptText: req.promptText,
+          timeoutMs: req.timeoutMs,
+        });
+        void armed.response.catch((err) => {
+          this.opts.logger.warn('prepared page dialog response expired', {
+            tabId,
+            err,
+          });
+        });
+        return actionOk(req.action, {
+          tabId,
+          dialog,
+          armed: true,
+          retryRequired: true,
+        });
+      }
       return actionOk(req.action, { tabId, dialog });
     });
   }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -35,7 +35,9 @@ import type {
   BrowserBackend,
 } from './types.js';
 import { RsbWebviewAutomation } from './rsb-webview-automation.js';
+import { RsbWebviewDialogs } from './rsb-webview-dialogs.js';
 import { RsbWebviewNetwork } from './rsb-webview-network.js';
+import { resolveUploadFiles } from './rsb-webview-upload-policy.js';
 
 interface BackendLogger {
   info(message: string, ...args: unknown[]): void;
@@ -69,6 +71,8 @@ export interface RsbWebviewBackendOptions {
   /** Bridge config — same shape `registerTabOpResultHandler` uses. */
   bridge: RendererBridgeOptions;
   logger: BackendLogger;
+  artifactRoot?: () => string;
+  resolveUploadRoots?: (sessionId: string) => Promise<string[]>;
   /**
    * Timing overrides for the detached-window tab re-registration wait (tests
    * only — production uses the defaults below).
@@ -137,11 +141,13 @@ function safeTabMeta(wc: WebContents): { url: string; title: string } {
 export class RsbWebviewBackend implements BrowserBackend {
   readonly kind = 'rsb-webview' as const;
   private readonly automation: RsbWebviewAutomation;
+  private readonly dialogs: RsbWebviewDialogs;
   private readonly network: RsbWebviewNetwork;
   private readonly activity: BrowserActivity[] = [];
 
   constructor(private readonly opts: RsbWebviewBackendOptions) {
     this.automation = new RsbWebviewAutomation(opts.logger);
+    this.dialogs = new RsbWebviewDialogs(opts.logger);
     this.network = new RsbWebviewNetwork(opts.logger);
   }
 
@@ -178,6 +184,7 @@ export class RsbWebviewBackend implements BrowserBackend {
   async dispose(): Promise<void> {
     // Switching backends never closes the user's tabs. Only the listeners and
     // debugger attachments owned by this backend are released.
+    this.dialogs.dispose();
     this.network.dispose();
   }
 
@@ -215,14 +222,15 @@ export class RsbWebviewBackend implements BrowserBackend {
         return this.handleConsole(request);
       case 'act':
         return this.handleAct(request);
+      case 'upload':
+        return this.handleUpload(request);
+      case 'dialog':
+        return this.handleDialog(request);
       case 'requests':
         return this.handleRequests(request);
       case 'responseBody':
         return this.handleResponseBody(request);
       default:
-        // upload / dialog are not wired to the
-        // embedded guest yet. Keep failure structured so callers can choose an
-        // external browser backend for those advanced capabilities.
         return actionFailed(
           request.action,
           `action '${request.action}' not yet supported in rsb-webview backend`,
@@ -250,6 +258,7 @@ export class RsbWebviewBackend implements BrowserBackend {
       activeSessionId: sessionId,
       totalRegisteredTabs: this.opts.registry.listAll().length,
       pinnedTabs: this.opts.registry.listPinned(),
+      dialogs: this.dialogs.diagnostics(),
       network: this.network.diagnostics(),
       recentActivity: this.activity.slice(-20),
     });
@@ -354,7 +363,7 @@ export class RsbWebviewBackend implements BrowserBackend {
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
       this.automation.forgetTab(tabId);
-      await this.tryObserveNetwork(resolved.wc, tabId);
+      await this.tryObservePageSignals(resolved.wc, tabId);
       await resolved.wc.loadURL(url);
       return actionOk(req.action, { tabId, url });
     });
@@ -366,7 +375,17 @@ export class RsbWebviewBackend implements BrowserBackend {
     const resolved = await this.resolveTabForDirectAction(req, tabId);
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
-      await this.tryObserveNetwork(resolved.wc, tabId);
+      await this.tryObservePageSignals(resolved.wc, tabId);
+      const dialog = this.dialogs.pending(resolved.wc);
+      if (dialog) {
+        return actionOk(req.action, {
+          format: req.snapshotFormat ?? 'ai',
+          targetId: tabId,
+          url: resolved.wc.getURL(),
+          barrier: { kind: 'page-dialog', dialog },
+          stats: { lines: 0, chars: 0, refs: 0, interactive: 0 },
+        });
+      }
       const data = await this.automation.snapshot(tabId, resolved.wc, req);
       return actionOk(req.action, data);
     });
@@ -450,7 +469,7 @@ export class RsbWebviewBackend implements BrowserBackend {
         return Promise.resolve(result);
       })()`;
       return this.withTabPin(tabId, async () => {
-        await this.tryObserveNetwork(wc, tabId);
+        await this.tryObservePageSignals(wc, tabId);
         let value: unknown;
         try {
           value = await wc.executeJavaScript(wrapped, /* userGesture */ false);
@@ -470,7 +489,7 @@ export class RsbWebviewBackend implements BrowserBackend {
     }
 
     return this.withTabPin(tabId, async () => {
-      await this.tryObserveNetwork(wc, tabId);
+      await this.tryObservePageSignals(wc, tabId);
       const data = await this.automation.act(tabId, wc, inner);
       return actionOk(req.action, data);
     });
@@ -490,6 +509,46 @@ export class RsbWebviewBackend implements BrowserBackend {
       const buffer = ensureConsoleBuffer(resolved.wc, this.opts.logger);
       const messages = buffer.drain();
       return actionOk(req.action, { tabId, messages });
+    });
+  }
+
+  private async handleUpload(req: BackendRequest): Promise<BackendResult> {
+    const sessionId = this.resolveSessionId(req);
+    if (!sessionId) return actionFailed(req.action, 'no active RSB session');
+    const tabId = await this.resolveDirectActionTarget(req);
+    if (!tabId) return actionFailed(req.action, 'targetId required');
+    const resolved = await this.resolveTabForDirectAction(req, tabId);
+    if (!resolved.ok) return resolved.result;
+    return this.withTabPin(tabId, async () => {
+      const roots = [
+        ...(this.opts.artifactRoot ? [this.opts.artifactRoot()] : []),
+        ...(this.opts.resolveUploadRoots
+          ? await this.opts.resolveUploadRoots(sessionId)
+          : []),
+      ];
+      const paths = await resolveUploadFiles(req.paths, roots);
+      await this.tryObservePageSignals(resolved.wc, tabId);
+      const data = await this.automation.setFiles(tabId, resolved.wc, {
+        ...req,
+        paths,
+      });
+      return actionOk(req.action, data);
+    });
+  }
+
+  private async handleDialog(req: BackendRequest): Promise<BackendResult> {
+    const tabId = await this.resolveDirectActionTarget(req);
+    if (!tabId) return actionFailed(req.action, 'targetId required');
+    const resolved = await this.resolveTabForDirectAction(req, tabId);
+    if (!resolved.ok) return resolved.result;
+    return this.withTabPin(tabId, async () => {
+      const dialog = await this.dialogs.respond(resolved.wc, {
+        dialogId: req.dialogId,
+        accept: req.accept,
+        promptText: req.promptText,
+        timeoutMs: req.timeoutMs,
+      });
+      return actionOk(req.action, { tabId, dialog });
     });
   }
 
@@ -554,6 +613,15 @@ export class RsbWebviewBackend implements BrowserBackend {
       // Network capture enriches normal browsing actions but must not prevent
       // the underlying page action when DevTools owns the debugger.
       this.opts.logger.warn('RSB network observation unavailable', { tabId, err });
+    }
+  }
+
+  private async tryObservePageSignals(wc: WebContents, tabId: string): Promise<void> {
+    await this.tryObserveNetwork(wc, tabId);
+    try {
+      await this.dialogs.observe(wc);
+    } catch (err) {
+      this.opts.logger.warn('RSB page dialog observation unavailable', { tabId, err });
     }
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -35,10 +35,18 @@ import type {
   BrowserBackend,
 } from './types.js';
 import { RsbWebviewAutomation } from './rsb-webview-automation.js';
+import { RsbWebviewNetwork } from './rsb-webview-network.js';
 
 interface BackendLogger {
   info(message: string, ...args: unknown[]): void;
   warn(message: string, ...args: unknown[]): void;
+}
+
+interface BrowserActivity {
+  action: BrowserControlRequest['action'];
+  finishedAt: string;
+  ok: boolean;
+  targetId?: string;
 }
 
 export interface RsbWebviewBackendOptions {
@@ -129,9 +137,12 @@ function safeTabMeta(wc: WebContents): { url: string; title: string } {
 export class RsbWebviewBackend implements BrowserBackend {
   readonly kind = 'rsb-webview' as const;
   private readonly automation: RsbWebviewAutomation;
+  private readonly network: RsbWebviewNetwork;
+  private readonly activity: BrowserActivity[] = [];
 
   constructor(private readonly opts: RsbWebviewBackendOptions) {
     this.automation = new RsbWebviewAutomation(opts.logger);
+    this.network = new RsbWebviewNetwork(opts.logger);
   }
 
   /**
@@ -147,23 +158,27 @@ export class RsbWebviewBackend implements BrowserBackend {
 
   async call(request: BackendRequest): Promise<BackendResult> {
     try {
-      return await this.dispatch(request);
+      const result = await this.dispatch(request);
+      this.recordActivity(request, result.ok);
+      return result;
     } catch (err) {
       this.opts.logger.warn('rsb-webview backend.call threw', {
         action: request.action,
         err,
       });
-      return actionFailed(
+      const result = actionFailed(
         request.action,
         err instanceof Error ? err.message : String(err),
       );
+      this.recordActivity(request, false);
+      return result;
     }
   }
 
   async dispose(): Promise<void> {
-    // Nothing to tear down. Switching away from this backend doesn't kill
-    // any tabs — the user's RSB stays as-is. Per-action debugger sessions and
-    // pins are released by their own finally blocks.
+    // Switching backends never closes the user's tabs. Only the listeners and
+    // debugger attachments owned by this backend are released.
+    this.network.dispose();
   }
 
   // ── dispatch ──────────────────────────────────────────────────────────────
@@ -200,8 +215,12 @@ export class RsbWebviewBackend implements BrowserBackend {
         return this.handleConsole(request);
       case 'act':
         return this.handleAct(request);
+      case 'requests':
+        return this.handleRequests(request);
+      case 'responseBody':
+        return this.handleResponseBody(request);
       default:
-        // requests / responseBody / upload / dialog are not wired to the
+        // upload / dialog are not wired to the
         // embedded guest yet. Keep failure structured so callers can choose an
         // external browser backend for those advanced capabilities.
         return actionFailed(
@@ -231,6 +250,8 @@ export class RsbWebviewBackend implements BrowserBackend {
       activeSessionId: sessionId,
       totalRegisteredTabs: this.opts.registry.listAll().length,
       pinnedTabs: this.opts.registry.listPinned(),
+      network: this.network.diagnostics(),
+      recentActivity: this.activity.slice(-20),
     });
   }
 
@@ -333,6 +354,7 @@ export class RsbWebviewBackend implements BrowserBackend {
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
       this.automation.forgetTab(tabId);
+      await this.tryObserveNetwork(resolved.wc, tabId);
       await resolved.wc.loadURL(url);
       return actionOk(req.action, { tabId, url });
     });
@@ -344,6 +366,7 @@ export class RsbWebviewBackend implements BrowserBackend {
     const resolved = await this.resolveTabForDirectAction(req, tabId);
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
+      await this.tryObserveNetwork(resolved.wc, tabId);
       const data = await this.automation.snapshot(tabId, resolved.wc, req);
       return actionOk(req.action, data);
     });
@@ -427,6 +450,7 @@ export class RsbWebviewBackend implements BrowserBackend {
         return Promise.resolve(result);
       })()`;
       return this.withTabPin(tabId, async () => {
+        await this.tryObserveNetwork(wc, tabId);
         let value: unknown;
         try {
           value = await wc.executeJavaScript(wrapped, /* userGesture */ false);
@@ -446,6 +470,7 @@ export class RsbWebviewBackend implements BrowserBackend {
     }
 
     return this.withTabPin(tabId, async () => {
+      await this.tryObserveNetwork(wc, tabId);
       const data = await this.automation.act(tabId, wc, inner);
       return actionOk(req.action, data);
     });
@@ -468,7 +493,69 @@ export class RsbWebviewBackend implements BrowserBackend {
     });
   }
 
+  private async handleRequests(req: BackendRequest): Promise<BackendResult> {
+    const tabId = await this.resolveDirectActionTarget(req);
+    if (!tabId) return actionFailed(req.action, 'targetId required');
+    const resolved = await this.resolveTabForDirectAction(req, tabId);
+    if (!resolved.ok) return resolved.result;
+    return this.withTabPin(tabId, async () => {
+      await this.network.observe(resolved.wc);
+      const requests = this.network.readRequests(resolved.wc, {
+        filter: typeof req.filter === 'string' ? req.filter : undefined,
+        clear: req.clear === true,
+      });
+      return actionOk(req.action, { tabId, requests });
+    });
+  }
+
+  private async handleResponseBody(req: BackendRequest): Promise<BackendResult> {
+    const tabId = await this.resolveDirectActionTarget(req);
+    if (!tabId) return actionFailed(req.action, 'targetId required');
+    if (typeof req.url !== 'string' || req.url.trim() === '') {
+      return actionFailed(req.action, 'responseBody.url required');
+    }
+    const resolved = await this.resolveTabForDirectAction(req, tabId);
+    if (!resolved.ok) return resolved.result;
+    return this.withTabPin(tabId, async () => {
+      const response = await this.network.readResponseBody(resolved.wc, {
+        url: req.url!,
+        maxChars: req.maxChars,
+        timeoutMs: req.timeoutMs,
+      });
+      return actionOk(req.action, { tabId, response });
+    });
+  }
+
   // ── helpers ───────────────────────────────────────────────────────────────
+
+  private recordActivity(req: BackendRequest, ok: boolean): void {
+    const directTarget = (req as { targetId?: unknown }).targetId;
+    const nestedTarget = (req as { request?: { targetId?: unknown } }).request?.targetId;
+    const targetId = typeof directTarget === 'string' && directTarget !== ''
+      ? directTarget
+      : typeof nestedTarget === 'string' && nestedTarget !== ''
+        ? nestedTarget
+        : undefined;
+    this.activity.push({
+      action: req.action,
+      finishedAt: new Date().toISOString(),
+      ok,
+      ...(targetId ? { targetId } : {}),
+    });
+    if (this.activity.length > 200) {
+      this.activity.splice(0, this.activity.length - 200);
+    }
+  }
+
+  private async tryObserveNetwork(wc: WebContents, tabId: string): Promise<void> {
+    try {
+      await this.network.observe(wc);
+    } catch (err) {
+      // Network capture enriches normal browsing actions but must not prevent
+      // the underlying page action when DevTools owns the debugger.
+      this.opts.logger.warn('RSB network observation unavailable', { tabId, err });
+    }
+  }
 
   /**
    * Per-action automation pin. Wraps an action body so the targeted tab is

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -559,7 +559,7 @@ export class RsbWebviewBackend implements BrowserBackend {
       });
     }
 
-    return this.withTabPin(tabId, async () => {
+    return this.withTabPin(tabId, async (retainTabPin) => {
       await this.tryObserveNetwork(wc, tabId);
       const opening = await this.tryWatchPageDialog(wc, tabId);
       const pendingDialog = opening ? this.dialogs.pending(wc) : undefined;
@@ -642,6 +642,11 @@ export class RsbWebviewBackend implements BrowserBackend {
             err,
           });
         });
+        retainTabPin();
+        void actionPromise.then(
+          () => this.opts.registry.unpin(tabId),
+          () => this.opts.registry.unpin(tabId),
+        );
         return {
           tabId,
           kind: inner.kind,
@@ -882,7 +887,7 @@ export class RsbWebviewBackend implements BrowserBackend {
       for (;;) {
         const wc = this.opts.registry.getWebContentsByTabId(tabId);
         if (wc) {
-          await this.tryObserveNetwork(wc, tabId);
+          await this.tryObservePageSignals(wc, tabId);
           return;
         }
         if (Date.now() >= deadline) {
@@ -926,12 +931,18 @@ export class RsbWebviewBackend implements BrowserBackend {
    * acceptable until real concurrent use-cases emerge, then upgrade to
    * refcount.
    */
-  private async withTabPin<T>(tabId: string, body: () => Promise<T>): Promise<T> {
+  private async withTabPin<T>(
+    tabId: string,
+    body: (retainTabPin: () => void) => Promise<T>,
+  ): Promise<T> {
     this.opts.registry.pin(tabId);
+    let retained = false;
     try {
-      return await body();
+      return await body(() => {
+        retained = true;
+      });
     } finally {
-      this.opts.registry.unpin(tabId);
+      if (!retained) this.opts.registry.unpin(tabId);
     }
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -285,7 +285,7 @@ export class RsbWebviewBackend implements BrowserBackend {
       totalRegisteredTabs: this.opts.registry.listAll().length,
       pinnedTabs: this.opts.registry.listPinned(),
       dialogs: this.dialogs.diagnostics(),
-      ...(this.artifacts ? { artifacts: this.artifacts.diagnostics() } : {}),
+      ...(this.artifacts ? { artifacts: this.artifacts.diagnostics(sessionId ?? undefined) } : {}),
       network: this.network.diagnostics(),
       recentActivity: this.activity.slice(-20),
     });
@@ -342,6 +342,7 @@ export class RsbWebviewBackend implements BrowserBackend {
     if (!result.ok) {
       return actionFailed(req.action, result.error);
     }
+    if (result.tabId) void this.observeOpenedTab(result.tabId);
     return actionOk(req.action, {
       targetId: result.tabId,
       tabId: result.tabId,
@@ -458,6 +459,9 @@ export class RsbWebviewBackend implements BrowserBackend {
     if (!inner || typeof inner !== 'object') {
       return actionFailed(req.action, 'request body required');
     }
+    const automationRequest = inner.timeoutMs === undefined && req.timeoutMs !== undefined
+      ? { ...inner, timeoutMs: req.timeoutMs }
+      : inner;
     const requestWithInnerTarget = {
       ...req,
       ...(typeof req.targetId === 'string'
@@ -475,6 +479,14 @@ export class RsbWebviewBackend implements BrowserBackend {
     const resolved = await this.resolveTabForDirectAction(requestWithInnerTarget, tabId);
     if (!resolved.ok) return resolved.result;
     const wc = resolved.wc;
+    const humanVerification = this.automation.getHumanVerificationBarrier(tabId);
+    if (humanVerification) {
+      return actionOk(req.action, {
+        tabId,
+        kind: inner.kind,
+        barrier: humanVerification,
+      });
+    }
 
     if (inner.kind === 'saveResource') {
       if (!this.artifacts) return actionFailed(req.action, 'managed downloads are unavailable');
@@ -569,7 +581,20 @@ export class RsbWebviewBackend implements BrowserBackend {
             barrier: { kind: 'page-dialog', dialog: dialogBeforeStart },
           };
         }
-        const actionPromise = this.automation.act(tabId, wc, inner);
+        const actionPromise = this.automation.act(tabId, wc, automationRequest, {
+          nativeKeyDispatch: async (type, keyCode, modifiers) => {
+            const sendInputEvent = (wc as unknown as {
+              sendInputEvent?: (event: {
+                type: 'keyDown' | 'keyUp';
+                keyCode: string;
+                modifiers?: string[];
+              }) => void;
+            }).sendInputEvent;
+            if (!sendInputEvent) throw new Error('native keyboard input is unavailable');
+            sendInputEvent({ type, keyCode, modifiers });
+          },
+          waitForNetworkIdle: (timeoutMs) => this.network.waitForIdle(wc, { timeoutMs }),
+        });
         if (!opening) return actionPromise;
         const outcome = await Promise.race([
           actionPromise.then((value) => ({ type: 'action' as const, value })),
@@ -839,6 +864,36 @@ export class RsbWebviewBackend implements BrowserBackend {
       await this.dialogs.observe(wc);
     } catch (err) {
       this.opts.logger.warn('RSB page dialog observation unavailable', { tabId, err });
+    }
+  }
+
+  /**
+   * Arm Network.enable as soon as the renderer reports a newly-created tab.
+   * `open` starts navigation in the renderer, so waiting until a later
+   * `requests` call would lose the document's initial requests.
+   */
+  private async observeOpenedTab(tabId: string): Promise<void> {
+    try {
+      const deadline = Date.now() + 2_000;
+      for (;;) {
+        const wc = this.opts.registry.getWebContentsByTabId(tabId);
+        if (wc) {
+          await this.tryObserveNetwork(wc, tabId);
+          return;
+        }
+        if (Date.now() >= deadline) {
+          this.opts.logger.warn('new browser tab was not reported before network capture arm', {
+            tabId,
+          });
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    } catch (err) {
+      this.opts.logger.warn('failed to arm network capture for new browser tab', {
+        tabId,
+        err,
+      });
     }
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
@@ -209,12 +209,17 @@ export class RsbWebviewDialogs {
 
     const accepted = options.accept === true;
     state.handledIds.set(dialog.id, 'agent');
-    await state.debugger.sendCommand('Page.handleJavaScriptDialog', {
-      accept: accepted,
-      ...(accepted && typeof options.promptText === 'string'
-        ? { promptText: options.promptText }
-        : {}),
-    });
+    try {
+      await state.debugger.sendCommand('Page.handleJavaScriptDialog', {
+        accept: accepted,
+        ...(accepted && typeof options.promptText === 'string'
+          ? { promptText: options.promptText }
+          : {}),
+      });
+    } catch (err) {
+      state.handledIds.delete(dialog.id);
+      throw err;
+    }
     // Keep the pending record until Page.javascriptDialogClosed arrives. The
     // close event is the authoritative signal that Chromium finished handling
     // the modal and also records the recent outcome for action coordination.

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
@@ -366,6 +366,9 @@ export class RsbWebviewDialogs {
     try {
       state.debugger.removeListener('message', state.messageHandler);
       state.debugger.removeListener('detach', state.detachHandler);
+      (wc as unknown as {
+        removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
+      }).removeListener?.('destroyed', state.destroyedHandler);
     } catch {
       // The guest may already be destroyed.
     }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
@@ -111,17 +111,10 @@ export class RsbWebviewDialogs {
     return dialog ? { ...dialog } : undefined;
   }
 
-  recent(
-    wc: WebContents,
-    dialogId?: string,
-    openedAfter?: number,
-  ): BrowserPageDialog | undefined {
+  recent(wc: WebContents, dialogId?: string, openedAfter?: number): BrowserPageDialog | undefined {
     const dialog = this.states.get(wc)?.recent;
     if (!dialog || (dialogId && dialog.id !== dialogId)) return undefined;
-    if (
-      openedAfter !== undefined
-      && Date.parse(dialog.openedAt) < openedAfter
-    ) {
+    if (openedAfter !== undefined && Date.parse(dialog.openedAt) < openedAfter) {
       return undefined;
     }
     return { ...dialog };
@@ -172,10 +165,7 @@ export class RsbWebviewDialogs {
     if (options.dialogId && options.dialogId.length > 256) {
       throw new Error('dialogId is too long');
     }
-    if (
-      typeof options.promptText === 'string'
-      && options.promptText.length > MAX_PROMPT_TEXT
-    ) {
+    if (typeof options.promptText === 'string' && options.promptText.length > MAX_PROMPT_TEXT) {
       throw new Error(`promptText exceeds ${MAX_PROMPT_TEXT} characters`);
     }
     await this.observe(wc);
@@ -193,7 +183,11 @@ export class RsbWebviewDialogs {
         throw new Error(`dialog ${options.dialogId} is no longer pending`);
       }
       const recent = state.recent;
-      if (recent && (!options.dialogId || recent.id === options.dialogId)) {
+      // An undirected response must wait for a fresh dialog. A recent dialog
+      // is only meaningful when the caller explicitly targets its id; using a
+      // stale recent record here would prevent arm-next from observing the
+      // next dialog.
+      if (recent && options.dialogId && recent.id === options.dialogId) {
         return {
           ...recent,
           accepted: options.accept === true,
@@ -255,9 +249,7 @@ export class RsbWebviewDialogs {
       }, timeout);
       prepared = {
         accept: options.accept === true,
-        ...(typeof options.promptText === 'string'
-          ? { promptText: options.promptText }
-          : {}),
+        ...(typeof options.promptText === 'string' ? { promptText: options.promptText } : {}),
         resolve,
         reject,
         timer,
@@ -302,9 +294,8 @@ export class RsbWebviewDialogs {
     state.messageHandler = (...args: unknown[]) => {
       try {
         const method = text(args[1]);
-        const params = args[2] && typeof args[2] === 'object'
-          ? args[2] as Record<string, unknown>
-          : {};
+        const params =
+          args[2] && typeof args[2] === 'object' ? (args[2] as Record<string, unknown>) : {};
         if (method === 'Page.javascriptDialogOpening') {
           dialogSequence += 1;
           const dialog: BrowserPageDialog = {
@@ -326,17 +317,17 @@ export class RsbWebviewDialogs {
             state.prepared = undefined;
             clearTimeout(prepared.timer);
             state.handledIds.set(dialog.id, 'armed');
-            void state.debugger.sendCommand('Page.handleJavaScriptDialog', {
-              accept: prepared.accept,
-              ...(prepared.accept && typeof prepared.promptText === 'string'
-                ? { promptText: prepared.promptText }
-                : {}),
-            }).then(
-              () => prepared.resolve({ ...dialog, closedBy: 'armed' }),
-              (err) => prepared.reject(
-                err instanceof Error ? err : new Error(String(err)),
-              ),
-            );
+            void state.debugger
+              .sendCommand('Page.handleJavaScriptDialog', {
+                accept: prepared.accept,
+                ...(prepared.accept && typeof prepared.promptText === 'string'
+                  ? { promptText: prepared.promptText }
+                  : {}),
+              })
+              .then(
+                () => prepared.resolve({ ...dialog, closedBy: 'armed' }),
+                (err) => prepared.reject(err instanceof Error ? err : new Error(String(err))),
+              );
           }
         } else if (method === 'Page.javascriptDialogClosed') {
           const dialog = state.pending;
@@ -358,9 +349,11 @@ export class RsbWebviewDialogs {
     state.destroyedHandler = () => this.release(wc);
     electronDebugger.on('message', state.messageHandler);
     electronDebugger.on('detach', state.detachHandler);
-    (wc as unknown as {
-      once?: (event: string, listener: (...args: unknown[]) => void) => void;
-    }).once?.('destroyed', state.destroyedHandler);
+    (
+      wc as unknown as {
+        once?: (event: string, listener: (...args: unknown[]) => void) => void;
+      }
+    ).once?.('destroyed', state.destroyedHandler);
     return state;
   }
 
@@ -371,9 +364,11 @@ export class RsbWebviewDialogs {
     try {
       state.debugger.removeListener('message', state.messageHandler);
       state.debugger.removeListener('detach', state.detachHandler);
-      (wc as unknown as {
-        removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
-      }).removeListener?.('destroyed', state.destroyedHandler);
+      (
+        wc as unknown as {
+          removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
+        }
+      ).removeListener?.('destroyed', state.destroyedHandler);
     } catch {
       // The guest may already be destroyed.
     }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
@@ -215,7 +215,9 @@ export class RsbWebviewDialogs {
         ? { promptText: options.promptText }
         : {}),
     });
-    if (state.pending?.id === dialog.id) state.pending = undefined;
+    // Keep the pending record until Page.javascriptDialogClosed arrives. The
+    // close event is the authoritative signal that Chromium finished handling
+    // the modal and also records the recent outcome for action coordination.
     return { ...dialog, accepted, deferred: false };
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
@@ -19,6 +19,15 @@ export interface BrowserPageDialog {
   message: string;
   defaultValue?: string;
   openedAt: string;
+  closedBy?: 'agent' | 'armed' | 'auto';
+}
+
+interface PreparedResponse {
+  accept: boolean;
+  promptText?: string;
+  resolve(dialog: BrowserPageDialog): void;
+  reject(error: Error): void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 interface DialogState {
@@ -26,6 +35,13 @@ interface DialogState {
   ownedAttachment: boolean;
   enabled: boolean;
   pending?: BrowserPageDialog;
+  recent?: BrowserPageDialog;
+  prepared?: PreparedResponse;
+  handledIds: Map<string, 'agent' | 'armed'>;
+  openingWaiters: Set<{
+    resolve(dialog: BrowserPageDialog): void;
+    reject(error: Error): void;
+  }>;
   messageHandler: (...args: unknown[]) => void;
   detachHandler: (...args: unknown[]) => void;
   destroyedHandler: (...args: unknown[]) => void;
@@ -33,6 +49,8 @@ interface DialogState {
 
 const DEFAULT_WAIT_MS = 10_000;
 const MAX_WAIT_MS = 60_000;
+const DEFAULT_ARM_WAIT_MS = 120_000;
+const MAX_ARM_WAIT_MS = 300_000;
 const MAX_DIALOG_TEXT = 16_000;
 const MAX_PROMPT_TEXT = 32_000;
 
@@ -50,6 +68,12 @@ function boundedWait(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? Math.min(MAX_WAIT_MS, Math.floor(value))
     : DEFAULT_WAIT_MS;
+}
+
+function boundedArmWait(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.min(MAX_ARM_WAIT_MS, Math.floor(value))
+    : DEFAULT_ARM_WAIT_MS;
 }
 
 function debuggerFor(wc: WebContents): ElectronDebugger {
@@ -87,6 +111,55 @@ export class RsbWebviewDialogs {
     return dialog ? { ...dialog } : undefined;
   }
 
+  recent(
+    wc: WebContents,
+    dialogId?: string,
+    openedAfter?: number,
+  ): BrowserPageDialog | undefined {
+    const dialog = this.states.get(wc)?.recent;
+    if (!dialog || (dialogId && dialog.id !== dialogId)) return undefined;
+    if (
+      openedAfter !== undefined
+      && Date.parse(dialog.openedAt) < openedAfter
+    ) {
+      return undefined;
+    }
+    return { ...dialog };
+  }
+
+  watchOpening(wc: WebContents): {
+    opened: Promise<BrowserPageDialog>;
+    cancel(): void;
+  } {
+    const state = this.states.get(wc);
+    if (!state?.enabled) {
+      throw new Error('page dialog monitor is not active');
+    }
+    if (state.pending) {
+      return {
+        opened: Promise.resolve({ ...state.pending }),
+        cancel: () => {},
+      };
+    }
+    let active = true;
+    let waiter!: {
+      resolve(dialog: BrowserPageDialog): void;
+      reject(error: Error): void;
+    };
+    const opened = new Promise<BrowserPageDialog>((resolve, reject) => {
+      waiter = { resolve, reject };
+      state.openingWaiters.add(waiter);
+    });
+    return {
+      opened,
+      cancel: () => {
+        if (!active) return;
+        active = false;
+        state.openingWaiters.delete(waiter);
+      },
+    };
+  }
+
   async respond(
     wc: WebContents,
     options: {
@@ -95,7 +168,7 @@ export class RsbWebviewDialogs {
       promptText?: string;
       timeoutMs?: number;
     },
-  ): Promise<BrowserPageDialog & { accepted: boolean }> {
+  ): Promise<BrowserPageDialog & { accepted: boolean; deferred: boolean }> {
     if (options.dialogId && options.dialogId.length > 256) {
       throw new Error('dialogId is too long');
     }
@@ -119,11 +192,23 @@ export class RsbWebviewDialogs {
       if (current && options.dialogId && current.id !== options.dialogId) {
         throw new Error(`dialog ${options.dialogId} is no longer pending`);
       }
+      const recent = state.recent;
+      if (recent && (!options.dialogId || recent.id === options.dialogId)) {
+        return {
+          ...recent,
+          accepted: options.accept === true,
+          deferred: true,
+        };
+      }
+      if (recent && options.dialogId && recent.id !== options.dialogId) {
+        throw new Error(`dialog ${options.dialogId} is no longer pending`);
+      }
       if (Date.now() >= deadline) throw new Error('no page dialog is pending');
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
 
     const accepted = options.accept === true;
+    state.handledIds.set(dialog.id, 'agent');
     await state.debugger.sendCommand('Page.handleJavaScriptDialog', {
       accept: accepted,
       ...(accepted && typeof options.promptText === 'string'
@@ -131,7 +216,56 @@ export class RsbWebviewDialogs {
         : {}),
     });
     if (state.pending?.id === dialog.id) state.pending = undefined;
-    return { ...dialog, accepted };
+    return { ...dialog, accepted, deferred: false };
+  }
+
+  armNext(
+    wc: WebContents,
+    options: {
+      accept: boolean;
+      promptText?: string;
+      timeoutMs?: number;
+    },
+  ): { response: Promise<BrowserPageDialog>; cancel(): void } {
+    const state = this.states.get(wc);
+    if (!state?.enabled) {
+      throw new Error('page dialog monitor is not active');
+    }
+    if (state.prepared) {
+      clearTimeout(state.prepared.timer);
+      state.prepared.reject(new Error('page dialog response was replaced'));
+      state.prepared = undefined;
+    }
+    let active = true;
+    let prepared!: PreparedResponse;
+    const response = new Promise<BrowserPageDialog>((resolve, reject) => {
+      const timeout = boundedArmWait(options.timeoutMs);
+      const timer = setTimeout(() => {
+        if (!active || state.prepared !== prepared) return;
+        active = false;
+        state.prepared = undefined;
+        reject(new Error('armed page dialog response expired'));
+      }, timeout);
+      prepared = {
+        accept: options.accept === true,
+        ...(typeof options.promptText === 'string'
+          ? { promptText: options.promptText }
+          : {}),
+        resolve,
+        reject,
+        timer,
+      };
+      state.prepared = prepared;
+    });
+    return {
+      response,
+      cancel: () => {
+        if (!active || state.prepared !== prepared) return;
+        active = false;
+        clearTimeout(prepared.timer);
+        state.prepared = undefined;
+      },
+    };
   }
 
   diagnostics(): { observedTabs: number; pendingDialogs: number } {
@@ -152,6 +286,8 @@ export class RsbWebviewDialogs {
       debugger: electronDebugger,
       ownedAttachment: false,
       enabled: false,
+      openingWaiters: new Set(),
+      handledIds: new Map(),
       messageHandler: () => {},
       detachHandler: () => {},
       destroyedHandler: () => {},
@@ -164,7 +300,7 @@ export class RsbWebviewDialogs {
           : {};
         if (method === 'Page.javascriptDialogOpening') {
           dialogSequence += 1;
-          state.pending = {
+          const dialog: BrowserPageDialog = {
             id: `page-dialog-${Date.now().toString(36)}-${dialogSequence.toString(36)}`,
             type: boundedText(params.type, 64) || 'alert',
             message: boundedText(params.message),
@@ -173,7 +309,35 @@ export class RsbWebviewDialogs {
               : {}),
             openedAt: new Date().toISOString(),
           };
+          state.pending = dialog;
+          for (const waiter of state.openingWaiters) {
+            waiter.resolve({ ...dialog });
+          }
+          state.openingWaiters.clear();
+          const prepared = state.prepared;
+          if (prepared) {
+            state.prepared = undefined;
+            clearTimeout(prepared.timer);
+            state.handledIds.set(dialog.id, 'armed');
+            void state.debugger.sendCommand('Page.handleJavaScriptDialog', {
+              accept: prepared.accept,
+              ...(prepared.accept && typeof prepared.promptText === 'string'
+                ? { promptText: prepared.promptText }
+                : {}),
+            }).then(
+              () => prepared.resolve({ ...dialog, closedBy: 'armed' }),
+              (err) => prepared.reject(
+                err instanceof Error ? err : new Error(String(err)),
+              ),
+            );
+          }
         } else if (method === 'Page.javascriptDialogClosed') {
+          const dialog = state.pending;
+          if (dialog) {
+            const closedBy = state.handledIds.get(dialog.id) ?? 'auto';
+            state.handledIds.delete(dialog.id);
+            state.recent = { ...dialog, closedBy };
+          }
           state.pending = undefined;
         }
       } catch (err) {
@@ -203,6 +367,15 @@ export class RsbWebviewDialogs {
     } catch {
       // The guest may already be destroyed.
     }
+    if (state.prepared) {
+      clearTimeout(state.prepared.timer);
+      state.prepared.reject(new Error('page dialog monitor was released'));
+      state.prepared = undefined;
+    }
+    for (const waiter of state.openingWaiters) {
+      waiter.reject(new Error('page dialog monitor was released'));
+    }
+    state.openingWaiters.clear();
     if (state.ownedAttachment) {
       try {
         if (state.debugger.isAttached()) state.debugger.detach();

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-dialogs.ts
@@ -1,0 +1,214 @@
+import type { WebContents } from 'electron';
+
+interface DialogLogger {
+  warn(message: string, ...args: unknown[]): void;
+}
+
+interface ElectronDebugger {
+  isAttached(): boolean;
+  attach(protocolVersion?: string): void;
+  detach(): void;
+  sendCommand(method: string, commandParams?: Record<string, unknown>): Promise<unknown>;
+  on(event: string, listener: (...args: unknown[]) => void): void;
+  removeListener(event: string, listener: (...args: unknown[]) => void): void;
+}
+
+export interface BrowserPageDialog {
+  id: string;
+  type: string;
+  message: string;
+  defaultValue?: string;
+  openedAt: string;
+}
+
+interface DialogState {
+  debugger: ElectronDebugger;
+  ownedAttachment: boolean;
+  enabled: boolean;
+  pending?: BrowserPageDialog;
+  messageHandler: (...args: unknown[]) => void;
+  detachHandler: (...args: unknown[]) => void;
+  destroyedHandler: (...args: unknown[]) => void;
+}
+
+const DEFAULT_WAIT_MS = 10_000;
+const MAX_WAIT_MS = 60_000;
+const MAX_DIALOG_TEXT = 16_000;
+const MAX_PROMPT_TEXT = 32_000;
+
+let dialogSequence = 0;
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function boundedText(value: unknown, max = MAX_DIALOG_TEXT): string {
+  return text(value).slice(0, max);
+}
+
+function boundedWait(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.min(MAX_WAIT_MS, Math.floor(value))
+    : DEFAULT_WAIT_MS;
+}
+
+function debuggerFor(wc: WebContents): ElectronDebugger {
+  const candidate = (wc as unknown as { debugger?: ElectronDebugger }).debugger;
+  if (!candidate) throw new Error('webContents debugger is unavailable');
+  return candidate;
+}
+
+/**
+ * Tracks JavaScript modal prompts for each embedded page and responds through
+ * the page debugger. The monitor releases only attachments it created.
+ */
+export class RsbWebviewDialogs {
+  private readonly states = new Map<WebContents, DialogState>();
+
+  constructor(private readonly logger: DialogLogger) {}
+
+  async observe(wc: WebContents): Promise<void> {
+    let state = this.states.get(wc);
+    if (!state) {
+      state = this.createState(wc);
+      this.states.set(wc, state);
+    }
+    if (state.enabled && state.debugger.isAttached()) return;
+    if (!state.debugger.isAttached()) {
+      state.debugger.attach('1.3');
+      state.ownedAttachment = true;
+    }
+    await state.debugger.sendCommand('Page.enable');
+    state.enabled = true;
+  }
+
+  pending(wc: WebContents): BrowserPageDialog | undefined {
+    const dialog = this.states.get(wc)?.pending;
+    return dialog ? { ...dialog } : undefined;
+  }
+
+  async respond(
+    wc: WebContents,
+    options: {
+      dialogId?: string;
+      accept?: boolean;
+      promptText?: string;
+      timeoutMs?: number;
+    },
+  ): Promise<BrowserPageDialog & { accepted: boolean }> {
+    if (options.dialogId && options.dialogId.length > 256) {
+      throw new Error('dialogId is too long');
+    }
+    if (
+      typeof options.promptText === 'string'
+      && options.promptText.length > MAX_PROMPT_TEXT
+    ) {
+      throw new Error(`promptText exceeds ${MAX_PROMPT_TEXT} characters`);
+    }
+    await this.observe(wc);
+    const state = this.states.get(wc);
+    if (!state) throw new Error('page dialog monitor unavailable');
+    const deadline = Date.now() + boundedWait(options.timeoutMs);
+    let dialog: BrowserPageDialog | undefined;
+    for (;;) {
+      const current = state.pending;
+      if (current && (!options.dialogId || current.id === options.dialogId)) {
+        dialog = current;
+        break;
+      }
+      if (current && options.dialogId && current.id !== options.dialogId) {
+        throw new Error(`dialog ${options.dialogId} is no longer pending`);
+      }
+      if (Date.now() >= deadline) throw new Error('no page dialog is pending');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    const accepted = options.accept === true;
+    await state.debugger.sendCommand('Page.handleJavaScriptDialog', {
+      accept: accepted,
+      ...(accepted && typeof options.promptText === 'string'
+        ? { promptText: options.promptText }
+        : {}),
+    });
+    if (state.pending?.id === dialog.id) state.pending = undefined;
+    return { ...dialog, accepted };
+  }
+
+  diagnostics(): { observedTabs: number; pendingDialogs: number } {
+    let pendingDialogs = 0;
+    for (const state of this.states.values()) {
+      if (state.pending) pendingDialogs += 1;
+    }
+    return { observedTabs: this.states.size, pendingDialogs };
+  }
+
+  dispose(): void {
+    for (const wc of [...this.states.keys()]) this.release(wc);
+  }
+
+  private createState(wc: WebContents): DialogState {
+    const electronDebugger = debuggerFor(wc);
+    const state: DialogState = {
+      debugger: electronDebugger,
+      ownedAttachment: false,
+      enabled: false,
+      messageHandler: () => {},
+      detachHandler: () => {},
+      destroyedHandler: () => {},
+    };
+    state.messageHandler = (...args: unknown[]) => {
+      try {
+        const method = text(args[1]);
+        const params = args[2] && typeof args[2] === 'object'
+          ? args[2] as Record<string, unknown>
+          : {};
+        if (method === 'Page.javascriptDialogOpening') {
+          dialogSequence += 1;
+          state.pending = {
+            id: `page-dialog-${Date.now().toString(36)}-${dialogSequence.toString(36)}`,
+            type: boundedText(params.type, 64) || 'alert',
+            message: boundedText(params.message),
+            ...(boundedText(params.defaultPrompt)
+              ? { defaultValue: boundedText(params.defaultPrompt) }
+              : {}),
+            openedAt: new Date().toISOString(),
+          };
+        } else if (method === 'Page.javascriptDialogClosed') {
+          state.pending = undefined;
+        }
+      } catch (err) {
+        this.logger.warn('RSB page dialog event handler failed', err);
+      }
+    };
+    state.detachHandler = () => {
+      state.enabled = false;
+      state.ownedAttachment = false;
+    };
+    state.destroyedHandler = () => this.release(wc);
+    electronDebugger.on('message', state.messageHandler);
+    electronDebugger.on('detach', state.detachHandler);
+    (wc as unknown as {
+      once?: (event: string, listener: (...args: unknown[]) => void) => void;
+    }).once?.('destroyed', state.destroyedHandler);
+    return state;
+  }
+
+  private release(wc: WebContents): void {
+    const state = this.states.get(wc);
+    if (!state) return;
+    this.states.delete(wc);
+    try {
+      state.debugger.removeListener('message', state.messageHandler);
+      state.debugger.removeListener('detach', state.detachHandler);
+    } catch {
+      // The guest may already be destroyed.
+    }
+    if (state.ownedAttachment) {
+      try {
+        if (state.debugger.isAttached()) state.debugger.detach();
+      } catch {
+        // Detach is best effort during teardown.
+      }
+    }
+  }
+}

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
@@ -39,6 +39,8 @@ interface MonitorState {
   requests: RequestRecord[];
   byRequestId: Map<string, RequestRecord>;
   responses: Map<string, ResponseRecord>;
+  inFlight: Set<string>;
+  lastActivityAt: number;
   messageHandler: (...args: unknown[]) => void;
   detachHandler: (...args: unknown[]) => void;
   destroyedHandler: (...args: unknown[]) => void;
@@ -49,6 +51,7 @@ const DEFAULT_BODY_CHARS = 200_000;
 const MAX_BODY_CHARS = 1_000_000;
 const DEFAULT_BODY_WAIT_MS = 20_000;
 const MAX_BODY_WAIT_MS = 60_000;
+const DEFAULT_IDLE_WINDOW_MS = 500;
 const SENSITIVE_HEADERS = new Set([
   'authorization',
   'cookie',
@@ -187,6 +190,24 @@ export class RsbWebviewNetwork {
     }
   }
 
+  async waitForIdle(
+    wc: WebContents,
+    options: { timeoutMs?: number; idleMs?: number } = {},
+  ): Promise<void> {
+    await this.observe(wc);
+    const state = this.states.get(wc);
+    if (!state) throw new Error('network monitor unavailable');
+    const timeoutMs = boundedPositive(options.timeoutMs, DEFAULT_BODY_WAIT_MS, MAX_BODY_WAIT_MS);
+    const idleMs = boundedPositive(options.idleMs, DEFAULT_IDLE_WINDOW_MS, MAX_BODY_WAIT_MS);
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const now = Date.now();
+      if (state.inFlight.size === 0 && now - state.lastActivityAt >= idleMs) return;
+      if (now >= deadline) throw new Error('network did not become idle before timeout');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
   diagnostics(): { observedTabs: number; bufferedRequests: number } {
     let bufferedRequests = 0;
     for (const state of this.states.values()) bufferedRequests += state.requests.length;
@@ -206,6 +227,8 @@ export class RsbWebviewNetwork {
       requests: [],
       byRequestId: new Map(),
       responses: new Map(),
+      inFlight: new Set(),
+      lastActivityAt: Date.now(),
       messageHandler: () => {},
       detachHandler: () => {},
       destroyedHandler: () => {},
@@ -254,6 +277,8 @@ export class RsbWebviewNetwork {
       };
       state.requests.push(record);
       state.byRequestId.set(requestId, record);
+      state.inFlight.add(requestId);
+      state.lastActivityAt = Date.now();
       if (state.requests.length > MAX_REQUESTS) {
         const removed = state.requests.splice(0, state.requests.length - MAX_REQUESTS);
         for (const item of removed) {
@@ -280,11 +305,14 @@ export class RsbWebviewNetwork {
         headers: safeHeaders(response.headers),
         finished: false,
       });
+      state.lastActivityAt = Date.now();
       return;
     }
     if (method === 'Network.loadingFinished') {
       const response = state.responses.get(requestId);
       if (response) response.finished = true;
+      state.inFlight.delete(requestId);
+      state.lastActivityAt = Date.now();
       return;
     }
     if (method === 'Network.loadingFailed') {
@@ -293,6 +321,8 @@ export class RsbWebviewNetwork {
         request.ok = false;
         request.failureText = text(params.errorText) || 'request failed';
       }
+      state.inFlight.delete(requestId);
+      state.lastActivityAt = Date.now();
     }
   }
 

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
@@ -1,0 +1,317 @@
+import type { WebContents } from 'electron';
+
+interface NetworkLogger {
+  warn(message: string, ...args: unknown[]): void;
+}
+
+interface ElectronDebugger {
+  isAttached(): boolean;
+  attach(protocolVersion?: string): void;
+  detach(): void;
+  sendCommand(method: string, commandParams?: Record<string, unknown>): Promise<unknown>;
+  on(event: string, listener: (...args: unknown[]) => void): void;
+  removeListener(event: string, listener: (...args: unknown[]) => void): void;
+}
+
+interface RequestRecord {
+  id: string;
+  timestamp: string;
+  method: string;
+  url: string;
+  resourceType: string;
+  status?: number;
+  ok?: boolean;
+  failureText?: string;
+}
+
+interface ResponseRecord {
+  requestId: string;
+  url: string;
+  status?: number;
+  headers?: Record<string, string>;
+  finished: boolean;
+}
+
+interface MonitorState {
+  debugger: ElectronDebugger;
+  ownedAttachment: boolean;
+  enabled: boolean;
+  requests: RequestRecord[];
+  byRequestId: Map<string, RequestRecord>;
+  responses: Map<string, ResponseRecord>;
+  messageHandler: (...args: unknown[]) => void;
+  detachHandler: (...args: unknown[]) => void;
+  destroyedHandler: (...args: unknown[]) => void;
+}
+
+const MAX_REQUESTS = 500;
+const DEFAULT_BODY_CHARS = 200_000;
+const MAX_BODY_CHARS = 1_000_000;
+const DEFAULT_BODY_WAIT_MS = 20_000;
+const MAX_BODY_WAIT_MS = 60_000;
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+]);
+
+function boundedPositive(value: unknown, fallback: number, max: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.min(max, Math.max(1, Math.floor(value)))
+    : fallback;
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function number(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function safeHeaders(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [name, raw] of Object.entries(value)) {
+    if (SENSITIVE_HEADERS.has(name.toLowerCase())) continue;
+    if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+      out[name] = String(raw);
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function urlMatches(pattern: string, url: string): boolean {
+  if (!pattern.includes('*')) return url.includes(pattern);
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replaceAll('*', '.*');
+  return new RegExp(`^${escaped}$`, 'i').test(url);
+}
+
+function debuggerFor(wc: WebContents): ElectronDebugger {
+  const candidate = (wc as unknown as { debugger?: ElectronDebugger }).debugger;
+  if (!candidate) throw new Error('webContents debugger is unavailable');
+  return candidate;
+}
+
+/**
+ * Keeps a bounded request history for each live RSB guest. The monitor owns a
+ * debugger attachment only when it created one and releases that attachment
+ * when the guest or backend is disposed.
+ */
+export class RsbWebviewNetwork {
+  private readonly states = new Map<WebContents, MonitorState>();
+
+  constructor(private readonly logger: NetworkLogger) {}
+
+  async observe(wc: WebContents): Promise<void> {
+    let state = this.states.get(wc);
+    if (!state) {
+      state = this.createState(wc);
+      this.states.set(wc, state);
+    }
+    if (state.enabled && state.debugger.isAttached()) return;
+    if (!state.debugger.isAttached()) {
+      state.debugger.attach('1.3');
+      state.ownedAttachment = true;
+    }
+    await state.debugger.sendCommand('Network.enable', {
+      maxTotalBufferSize: 16 * 1024 * 1024,
+      maxResourceBufferSize: 4 * 1024 * 1024,
+      maxPostDataSize: 256 * 1024,
+    });
+    state.enabled = true;
+  }
+
+  readRequests(
+    wc: WebContents,
+    options: { filter?: string; clear?: boolean } = {},
+  ): RequestRecord[] {
+    const state = this.states.get(wc);
+    if (!state) return [];
+    const filter = options.filter?.trim();
+    const result = state.requests
+      .filter((entry) => !filter || entry.url.includes(filter))
+      .map((entry) => ({ ...entry }));
+    if (options.clear === true) {
+      state.requests = [];
+      state.byRequestId.clear();
+      state.responses.clear();
+    }
+    return result;
+  }
+
+  async readResponseBody(
+    wc: WebContents,
+    options: { url: string; maxChars?: number; timeoutMs?: number },
+  ): Promise<{
+    url: string;
+    status?: number;
+    headers?: Record<string, string>;
+    body: string;
+    truncated?: boolean;
+  }> {
+    const pattern = options.url.trim();
+    if (!pattern) throw new Error('responseBody.url required');
+    await this.observe(wc);
+    const state = this.states.get(wc);
+    if (!state) throw new Error('network monitor unavailable');
+    const timeoutMs = boundedPositive(options.timeoutMs, DEFAULT_BODY_WAIT_MS, MAX_BODY_WAIT_MS);
+    const maxChars = boundedPositive(options.maxChars, DEFAULT_BODY_CHARS, MAX_BODY_CHARS);
+    const deadline = Date.now() + timeoutMs;
+
+    for (;;) {
+      const response = [...state.responses.values()]
+        .reverse()
+        .find((entry) => entry.finished && urlMatches(pattern, entry.url));
+      if (response) {
+        const raw = await state.debugger.sendCommand('Network.getResponseBody', {
+          requestId: response.requestId,
+        }) as { body?: unknown; base64Encoded?: unknown };
+        const encoded = text(raw.body);
+        const body = raw.base64Encoded === true
+          ? Buffer.from(encoded, 'base64').toString('utf8')
+          : encoded;
+        return {
+          url: response.url,
+          ...(response.status !== undefined ? { status: response.status } : {}),
+          ...(response.headers ? { headers: response.headers } : {}),
+          body: body.length > maxChars ? body.slice(0, maxChars) : body,
+          ...(body.length > maxChars ? { truncated: true } : {}),
+        };
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`response not found for URL pattern: ${pattern}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  diagnostics(): { observedTabs: number; bufferedRequests: number } {
+    let bufferedRequests = 0;
+    for (const state of this.states.values()) bufferedRequests += state.requests.length;
+    return { observedTabs: this.states.size, bufferedRequests };
+  }
+
+  dispose(): void {
+    for (const wc of [...this.states.keys()]) this.release(wc);
+  }
+
+  private createState(wc: WebContents): MonitorState {
+    const electronDebugger = debuggerFor(wc);
+    const state: MonitorState = {
+      debugger: electronDebugger,
+      ownedAttachment: false,
+      enabled: false,
+      requests: [],
+      byRequestId: new Map(),
+      responses: new Map(),
+      messageHandler: () => {},
+      detachHandler: () => {},
+      destroyedHandler: () => {},
+    };
+    state.messageHandler = (...args: unknown[]) => {
+      try {
+        const method = text(args[1]);
+        const params = args[2] && typeof args[2] === 'object'
+          ? args[2] as Record<string, unknown>
+          : {};
+        this.consumeMessage(state, method, params);
+      } catch (err) {
+        this.logger.warn('RSB network event handler failed', err);
+      }
+    };
+    state.detachHandler = () => {
+      state.enabled = false;
+      state.ownedAttachment = false;
+    };
+    state.destroyedHandler = () => this.release(wc);
+    electronDebugger.on('message', state.messageHandler);
+    electronDebugger.on('detach', state.detachHandler);
+    (wc as unknown as {
+      once?: (event: string, listener: (...args: unknown[]) => void) => void;
+    }).once?.('destroyed', state.destroyedHandler);
+    return state;
+  }
+
+  private consumeMessage(
+    state: MonitorState,
+    method: string,
+    params: Record<string, unknown>,
+  ): void {
+    const requestId = text(params.requestId);
+    if (!requestId) return;
+    if (method === 'Network.requestWillBeSent') {
+      const request = params.request && typeof params.request === 'object'
+        ? params.request as Record<string, unknown>
+        : {};
+      const record: RequestRecord = {
+        id: requestId,
+        timestamp: new Date().toISOString(),
+        method: text(request.method) || 'GET',
+        url: text(request.url),
+        resourceType: text(params.type).toLowerCase() || 'other',
+      };
+      state.requests.push(record);
+      state.byRequestId.set(requestId, record);
+      if (state.requests.length > MAX_REQUESTS) {
+        const removed = state.requests.splice(0, state.requests.length - MAX_REQUESTS);
+        for (const item of removed) {
+          state.byRequestId.delete(item.id);
+          state.responses.delete(item.id);
+        }
+      }
+      return;
+    }
+    if (method === 'Network.responseReceived') {
+      const response = params.response && typeof params.response === 'object'
+        ? params.response as Record<string, unknown>
+        : {};
+      const status = number(response.status);
+      const request = state.byRequestId.get(requestId);
+      if (request) {
+        request.status = status;
+        request.ok = status !== undefined ? status >= 200 && status < 400 : undefined;
+      }
+      state.responses.set(requestId, {
+        requestId,
+        url: text(response.url) || request?.url || '',
+        status,
+        headers: safeHeaders(response.headers),
+        finished: false,
+      });
+      return;
+    }
+    if (method === 'Network.loadingFinished') {
+      const response = state.responses.get(requestId);
+      if (response) response.finished = true;
+      return;
+    }
+    if (method === 'Network.loadingFailed') {
+      const request = state.byRequestId.get(requestId);
+      if (request) {
+        request.ok = false;
+        request.failureText = text(params.errorText) || 'request failed';
+      }
+    }
+  }
+
+  private release(wc: WebContents): void {
+    const state = this.states.get(wc);
+    if (!state) return;
+    this.states.delete(wc);
+    try {
+      state.debugger.removeListener('message', state.messageHandler);
+      state.debugger.removeListener('detach', state.detachHandler);
+    } catch {
+      // The guest may already be destroyed.
+    }
+    if (state.ownedAttachment) {
+      try {
+        if (state.debugger.isAttached()) state.debugger.detach();
+      } catch {
+        // Detach is best effort during teardown.
+      }
+    }
+  }
+}

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
@@ -349,6 +349,9 @@ export class RsbWebviewNetwork {
     try {
       state.debugger.removeListener('message', state.messageHandler);
       state.debugger.removeListener('detach', state.detachHandler);
+      (wc as unknown as {
+        removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
+      }).removeListener?.('destroyed', state.destroyedHandler);
     } catch {
       // The guest may already be destroyed.
     }

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-network.ts
@@ -85,6 +85,17 @@ function safeHeaders(value: unknown): Record<string, string> | undefined {
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+function safeUrl(value: string): string {
+  try {
+    const parsed = new URL(value);
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.href;
+  } catch {
+    return value;
+  }
+}
+
 function urlMatches(pattern: string, url: string): boolean {
   if (!pattern.includes('*')) return url.includes(pattern);
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replaceAll('*', '.*');
@@ -162,11 +173,16 @@ export class RsbWebviewNetwork {
     const timeoutMs = boundedPositive(options.timeoutMs, DEFAULT_BODY_WAIT_MS, MAX_BODY_WAIT_MS);
     const maxChars = boundedPositive(options.maxChars, DEFAULT_BODY_CHARS, MAX_BODY_CHARS);
     const deadline = Date.now() + timeoutMs;
+    const existingResponseIds = new Set(state.responses.keys());
 
     for (;;) {
       const response = [...state.responses.values()]
         .reverse()
-        .find((entry) => entry.finished && urlMatches(pattern, entry.url));
+        .find((entry) => (
+          !existingResponseIds.has(entry.requestId)
+          && entry.finished
+          && urlMatches(pattern, entry.url)
+        ));
       if (response) {
         const raw = await state.debugger.sendCommand('Network.getResponseBody', {
           requestId: response.requestId,
@@ -272,7 +288,7 @@ export class RsbWebviewNetwork {
         id: requestId,
         timestamp: new Date().toISOString(),
         method: text(request.method) || 'GET',
-        url: text(request.url),
+        url: safeUrl(text(request.url)),
         resourceType: text(params.type).toLowerCase() || 'other',
       };
       state.requests.push(record);
@@ -300,7 +316,7 @@ export class RsbWebviewNetwork {
       }
       state.responses.set(requestId, {
         requestId,
-        url: text(response.url) || request?.url || '',
+        url: safeUrl(text(response.url) || request?.url || ''),
         status,
         headers: safeHeaders(response.headers),
         finished: false,

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-upload-policy.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-upload-policy.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const MAX_FILE_COUNT = 20;
+const MAX_FILE_BYTES = 100 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 500 * 1024 * 1024;
+
+const BLOCKED_FILE_NAMES = new Set([
+  '.env',
+  '.npmrc',
+  '.netrc',
+  '.pypirc',
+  'id_dsa',
+  'id_ecdsa',
+  'id_ed25519',
+  'id_rsa',
+]);
+
+function isInside(parent: string, child: string): boolean {
+  const fold = (value: string) =>
+    process.platform === 'win32' ? value.toLowerCase() : value;
+  const relative = path.relative(fold(parent), fold(child));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function isBlockedFile(filePath: string): boolean {
+  const name = path.basename(filePath).toLowerCase();
+  return BLOCKED_FILE_NAMES.has(name)
+    || name.startsWith('.env.')
+    || name.endsWith('.key');
+}
+
+/**
+ * Resolves upload candidates to their filesystem identity and confines every
+ * file to a host-provided root. Realpath checks prevent a workdir symlink or
+ * junction from granting access to a file outside that workdir.
+ */
+export async function resolveUploadFiles(
+  candidates: unknown,
+  allowedRoots: string[],
+): Promise<string[]> {
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    throw new Error('upload.paths must contain at least one file');
+  }
+  if (candidates.length > MAX_FILE_COUNT) {
+    throw new Error(`upload accepts at most ${MAX_FILE_COUNT} files`);
+  }
+
+  const roots: string[] = [];
+  for (const root of allowedRoots) {
+    if (!path.isAbsolute(root)) continue;
+    try {
+      const resolved = await fs.realpath(root);
+      const stat = await fs.stat(resolved);
+      if (stat.isDirectory()) roots.push(resolved);
+    } catch {
+      // A missing optional root grants nothing.
+    }
+  }
+  if (roots.length === 0) {
+    throw new Error('upload is unavailable without a local session directory');
+  }
+
+  const files: string[] = [];
+  let totalBytes = 0;
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string' || !path.isAbsolute(candidate)) {
+      throw new Error('every upload path must be an absolute local file path');
+    }
+    let resolved: string;
+    let stat;
+    try {
+      resolved = await fs.realpath(candidate);
+      stat = await fs.stat(resolved);
+    } catch {
+      throw new Error(`upload file does not exist: ${path.basename(candidate) || 'unnamed'}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`upload path is not a regular file: ${path.basename(resolved)}`);
+    }
+    if (!roots.some((root) => isInside(root, resolved))) {
+      throw new Error('upload files must stay inside the current session directory');
+    }
+    if (isBlockedFile(resolved)) {
+      throw new Error(`upload blocked for sensitive file: ${path.basename(resolved)}`);
+    }
+    if (stat.size > MAX_FILE_BYTES) {
+      throw new Error(`upload file exceeds ${MAX_FILE_BYTES} bytes: ${path.basename(resolved)}`);
+    }
+    totalBytes += stat.size;
+    if (totalBytes > MAX_TOTAL_BYTES) {
+      throw new Error(`upload batch exceeds ${MAX_TOTAL_BYTES} bytes`);
+    }
+    files.push(resolved);
+  }
+  return files;
+}

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-upload-policy.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-upload-policy.ts
@@ -25,9 +25,13 @@ function isInside(parent: string, child: string): boolean {
 
 function isBlockedFile(filePath: string): boolean {
   const name = path.basename(filePath).toLowerCase();
+  const sensitiveDirectory = filePath
+    .split(/[\\/]+/)
+    .some((segment) => ['.git', '.ssh'].includes(segment.toLowerCase()));
   return BLOCKED_FILE_NAMES.has(name)
     || name.startsWith('.env.')
-    || name.endsWith('.key');
+    || name.endsWith('.key')
+    || sensitiveDirectory;
 }
 
 /**
@@ -40,10 +44,10 @@ export async function resolveUploadFiles(
   allowedRoots: string[],
 ): Promise<string[]> {
   if (!Array.isArray(candidates) || candidates.length === 0) {
-    throw new Error('upload.paths must contain at least one file');
+    throw new Error('paths must contain at least one file');
   }
   if (candidates.length > MAX_FILE_COUNT) {
-    throw new Error(`upload accepts at most ${MAX_FILE_COUNT} files`);
+    throw new Error(`paths accepts at most ${MAX_FILE_COUNT} files`);
   }
 
   const roots: string[] = [];

--- a/apps/desktop/src/main/mcp-integrations/browser.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser.ts
@@ -177,6 +177,16 @@ const vendoredRuntime: BrowserControlRuntime = createBrowserControlRuntime({
 
 const externalBackend = new ExternalChromeBackend(vendoredRuntime, logger);
 
+type SessionUploadRootResolver = (sessionId: string) => Promise<string[]>;
+
+let resolveSessionUploadRoots: SessionUploadRootResolver = async () => [];
+
+export function setBrowserSessionUploadRootResolver(
+  resolver: SessionUploadRootResolver,
+): void {
+  resolveSessionUploadRoots = resolver;
+}
+
 /**
  * RSB-webview backend instance (Phase 3+). Lazily constructed because the
  * TabRegistry singleton must be available — which it is right after this
@@ -186,16 +196,7 @@ const rsbBackend = new RsbWebviewBackend({
   registry: getRsbBrowserBridge(),
   getActiveSessionId: () => getActiveRsbSessionId(),
   artifactRoot: () => nodePath.join(app.getPath('temp'), 'cindy-browser-artifacts'),
-  resolveUploadRoots: async (sessionId) => {
-    try {
-      const { getMaker } = await import('../maker-host/index.js');
-      const meta = await getMaker().getSessionMeta(sessionId);
-      if (!meta?.workDir || meta.remoteHostId) return [];
-      return [meta.workDir];
-    } catch {
-      return [];
-    }
-  },
+  resolveUploadRoots: (sessionId) => resolveSessionUploadRoots(sessionId),
   bridge: {
     // Lazy main-window lookup. Phase 2 uses the same pattern; once the host
     // window is available the dispatch lands cleanly, before that the request

--- a/apps/desktop/src/main/mcp-integrations/browser.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser.ts
@@ -8,7 +8,7 @@
 import './browser-runtime-env.js';
 import fs from 'node:fs';
 import nodePath from 'node:path';
-import { ipcMain } from 'electron';
+import { app, ipcMain } from 'electron';
 import {
   createBrowserControlRuntime,
   type BrowserControlRuntime,
@@ -185,6 +185,17 @@ const externalBackend = new ExternalChromeBackend(vendoredRuntime, logger);
 const rsbBackend = new RsbWebviewBackend({
   registry: getRsbBrowserBridge(),
   getActiveSessionId: () => getActiveRsbSessionId(),
+  artifactRoot: () => nodePath.join(app.getPath('temp'), 'cindy-browser-artifacts'),
+  resolveUploadRoots: async (sessionId) => {
+    try {
+      const { getMaker } = await import('../maker-host/index.js');
+      const meta = await getMaker().getSessionMeta(sessionId);
+      if (!meta?.workDir || meta.remoteHostId) return [];
+      return [meta.workDir];
+    } catch {
+      return [];
+    }
+  },
   bridge: {
     // Lazy main-window lookup. Phase 2 uses the same pattern; once the host
     // window is available the dispatch lands cleanly, before that the request

--- a/apps/desktop/src/main/mcp-integrations/browser.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser.ts
@@ -323,6 +323,7 @@ export async function setActiveBrowserBackendKind(kind: BackendKind): Promise<vo
  */
 export function getBrowserMcpDeps(): {
   getRuntime(): BrowserControlRuntime;
+  supportsResourceDownloads(): boolean;
   logger: typeof logger;
   getUserRecipes(): Promise<UserRecipesResult>;
   saveUserRecipe(input: Parameters<typeof writeUserRecipe>[0]): Promise<WriteUserRecipeResult>;
@@ -337,6 +338,7 @@ export function getBrowserMcpDeps(): {
     // the backend split. Swapping the active backend (Phase 5) is invisible from
     // @cindy/mcps' perspective.
     getRuntime: () => router,
+    supportsResourceDownloads: () => router.kind === 'rsb-webview',
     logger,
   };
 }

--- a/apps/desktop/src/main/mcp-integrations/browser.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser.ts
@@ -325,6 +325,7 @@ export async function setActiveBrowserBackendKind(kind: BackendKind): Promise<vo
 export function getBrowserMcpDeps(): {
   getRuntime(): BrowserControlRuntime;
   supportsResourceDownloads(): boolean;
+  supportsSemanticQueries(): boolean;
   logger: typeof logger;
   getUserRecipes(): Promise<UserRecipesResult>;
   saveUserRecipe(input: Parameters<typeof writeUserRecipe>[0]): Promise<WriteUserRecipeResult>;
@@ -340,6 +341,7 @@ export function getBrowserMcpDeps(): {
     // @cindy/mcps' perspective.
     getRuntime: () => router,
     supportsResourceDownloads: () => router.kind === 'rsb-webview',
+    supportsSemanticQueries: () => router.kind === 'rsb-webview',
     logger,
   };
 }

--- a/apps/desktop/src/main/webview-security.ts
+++ b/apps/desktop/src/main/webview-security.ts
@@ -107,6 +107,9 @@ export function applyWebviewHardening(
   webPreferences.allowRunningInsecureContent = false;
   webPreferences.webviewTag = false;
   webPreferences.plugins = false;
+  // Page dialogs are observed through the controlled debugger path. Keep the
+  // browser host interactive while a page is waiting for a response.
+  webPreferences.disableDialogs = true;
   // Codex 自定义字段(Electron 标准 WebPreferences 不认这个 key,Electron 会
   // 忽略;但 Codex 在 IPC 层 / fork 的 Electron 可能消费它)。我们一并设上保持
   // 字面 1:1,即便 Electron 标准侧 no-op 也无害。

--- a/apps/desktop/src/main/webview-security.ts
+++ b/apps/desktop/src/main/webview-security.ts
@@ -107,9 +107,10 @@ export function applyWebviewHardening(
   webPreferences.allowRunningInsecureContent = false;
   webPreferences.webviewTag = false;
   webPreferences.plugins = false;
-  // Page dialogs are observed through the controlled debugger path. Keep the
-  // browser host interactive while a page is waiting for a response.
-  webPreferences.disableDialogs = true;
+  // Keep Chromium dialogs enabled so Page.javascriptDialogOpening reaches the
+  // controlled debugger observer. The backend turns them into structured
+  // barriers instead of letting them silently bypass the automation contract.
+  webPreferences.disableDialogs = false;
   // Codex 自定义字段(Electron 标准 WebPreferences 不认这个 key,Electron 会
   // 忽略;但 Codex 在 IPC 层 / fork 的 Electron 可能消费它)。我们一并设上保持
   // 字面 1:1,即便 Electron 标准侧 no-op 也无害。

--- a/packages/browser-control-runtime/src/index.ts
+++ b/packages/browser-control-runtime/src/index.ts
@@ -24,6 +24,7 @@ export {
 // default profile between managed and real-Chrome takeover) WITHOUT recreating
 // the runtime — config reads hot-reload per request inside the dispatcher.
 export { setBrowserRuntimeConfig as setBrowserControlRuntimeConfig } from './shim/runtime-config-snapshot.js';
+export { isPublicHttpResourceUrl } from './resource-url-policy.js';
 // Re-export the effective-config type under a neutral name so host code stays
 // free of the vendored type's product-specific identifier.
 export type {

--- a/packages/browser-control-runtime/src/index.ts
+++ b/packages/browser-control-runtime/src/index.ts
@@ -8,6 +8,7 @@ export type {
   BrowserControlRuntime,
   BrowserControlRuntimeFactoryOptions,
   BrowserControlTarget,
+  BrowserElementQuery,
   BrowserImageType,
   BrowserSnapshotFormat,
   BrowserSnapshotMode,

--- a/packages/browser-control-runtime/src/resource-url-policy.ts
+++ b/packages/browser-control-runtime/src/resource-url-policy.ts
@@ -1,0 +1,19 @@
+import { isBlockedHostnameOrIp } from './_generated/leaf/src/infra/net/ssrf.js';
+
+/**
+ * Resource downloads are host-side writes and must not become a local-network
+ * fetch primitive for page content.
+ */
+export function isPublicHttpResourceUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+      && !parsed.username
+      && !parsed.password
+      && !isBlockedHostnameOrIp(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/browser-control-runtime/src/runtime.ts
+++ b/packages/browser-control-runtime/src/runtime.ts
@@ -152,6 +152,7 @@ export function planDispatch(req: BrowserControlRequest): DispatchPlan {
           ref: req.ref,
           inputRef: req.inputRef,
           element: req.element,
+          query: req.query,
           targetId: req.targetId,
           timeoutMs: req.timeoutMs,
         },

--- a/packages/browser-control-runtime/src/types.ts
+++ b/packages/browser-control-runtime/src/types.ts
@@ -123,6 +123,7 @@ export interface BrowserControlRequest {
   level?: string;
   paths?: string[];
   inputRef?: string;
+  query?: BrowserElementQuery;
   timeoutMs?: number;
   dialogId?: string;
   accept?: boolean;

--- a/packages/browser-control-runtime/src/types.ts
+++ b/packages/browser-control-runtime/src/types.ts
@@ -49,10 +49,27 @@ export type BrowserSnapshotMode = 'efficient';
 export type BrowserSnapshotRefs = 'role' | 'aria';
 export type BrowserImageType = 'png' | 'jpeg';
 
+/**
+ * Backend-neutral element lookup. A query may combine multiple semantic
+ * fields; every populated field must match the same element.
+ */
+export interface BrowserElementQuery {
+  css?: string;
+  role?: string;
+  name?: string;
+  text?: string;
+  label?: string;
+  placeholder?: string;
+  testId?: string;
+  exact?: boolean;
+  index?: number;
+}
+
 export interface BrowserActRequest {
   kind: BrowserActKind;
   targetId?: string;
   ref?: string;
+  query?: BrowserElementQuery;
   doubleClick?: boolean;
   button?: string;
   modifiers?: string[];

--- a/packages/browser-control-runtime/src/types.ts
+++ b/packages/browser-control-runtime/src/types.ts
@@ -41,6 +41,7 @@ export type BrowserActKind =
   | 'resize'
   | 'wait'
   | 'evaluate'
+  | 'saveResource'
   | 'close';
 
 export type BrowserControlTarget = 'sandbox' | 'host' | 'node';

--- a/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
+++ b/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
@@ -123,6 +123,73 @@ describe('createBrowserMcpServer', () => {
     await h.cleanup();
   });
 
+  it('passes through a page resource and rejects unsafe resource URLs', async () => {
+    const h = await makeHarness();
+    await h.client.callTool({
+      name: 'call_tool',
+      arguments: {
+        name: 'browser',
+        args: {
+          action: 'act',
+          targetId: 't1',
+          request: {
+            kind: 'saveResource',
+            url: 'https://cdn.example.test/archive.zip',
+          },
+        },
+      },
+    });
+    expect(h.calls).toEqual([
+      {
+        action: 'act',
+        targetId: 't1',
+        request: {
+          kind: 'saveResource',
+          url: 'https://cdn.example.test/archive.zip',
+        },
+      },
+    ]);
+
+    const blocked = await h.client.callTool({
+      name: 'call_tool',
+      arguments: {
+        name: 'browser',
+        args: {
+          action: 'act',
+          targetId: 't1',
+          request: { kind: 'saveResource', url: 'file:///tmp/secret' },
+        },
+      },
+    });
+    expect(h.calls).toHaveLength(1);
+    const parsed = JSON.parse(
+      (blocked.content as Array<{ text: string }>)[0].text,
+    ) as { ok: boolean; message?: string };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.message).toMatch(/http\(s\)/);
+
+    const credentialed = await h.client.callTool({
+      name: 'call_tool',
+      arguments: {
+        name: 'browser',
+        args: {
+          action: 'act',
+          targetId: 't1',
+          request: {
+            kind: 'saveResource',
+            url: 'https://user:secret@cdn.example.test/archive.zip',
+          },
+        },
+      },
+    });
+    expect(h.calls).toHaveLength(1);
+    const credentialedResult = JSON.parse(
+      (credentialed.content as Array<{ text: string }>)[0].text,
+    ) as { ok: boolean };
+    expect(credentialedResult.ok).toBe(false);
+    await h.cleanup();
+  });
+
   it('compiles extract into an act:evaluate call', async () => {
     const h = await makeHarness();
     await h.client.callTool({

--- a/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
+++ b/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
@@ -254,6 +254,32 @@ describe('createBrowserMcpServer', () => {
     await h.cleanup();
   });
 
+  it('rejects blank element query strings before calling the runtime', async () => {
+    const h = await makeHarness();
+    for (const field of ['css', 'role', 'name', 'text', 'label', 'placeholder', 'testId']) {
+      const blocked = await h.client.callTool({
+        name: 'call_tool',
+        arguments: {
+          name: 'browser',
+          args: {
+            action: 'act',
+            targetId: 't1',
+            request: {
+              kind: 'click',
+              query: { [field]: '   ' },
+            },
+          },
+        },
+      });
+      expect(JSON.parse((blocked.content as Array<{ text: string }>)[0].text)).toMatchObject({
+        ok: false,
+        errorCode: 'INVALID_ARGS',
+      });
+    }
+    expect(h.calls).toHaveLength(0);
+    await h.cleanup();
+  });
+
   it('compiles extract into an act:evaluate call', async () => {
     const h = await makeHarness();
     await h.client.callTool({

--- a/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
+++ b/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
@@ -224,6 +224,36 @@ describe('createBrowserMcpServer', () => {
     await h.cleanup();
   });
 
+  it('rejects semantic queries when the active backend does not support them', async () => {
+    let semanticQueriesSupported = true;
+    const h = await makeHarness({
+      supportsSemanticQueries: () => semanticQueriesSupported,
+    });
+    const request = {
+      name: 'browser',
+      args: {
+        action: 'act',
+        targetId: 't1',
+        request: {
+          kind: 'click',
+          query: { role: 'button', name: 'Continue' },
+        },
+      },
+    };
+
+    await h.client.callTool({ name: 'call_tool', arguments: request });
+    expect(h.calls).toHaveLength(1);
+
+    semanticQueriesSupported = false;
+    const blocked = await h.client.callTool({ name: 'call_tool', arguments: request });
+    expect(h.calls).toHaveLength(1);
+    expect(JSON.parse((blocked.content as Array<{ text: string }>)[0].text)).toMatchObject({
+      ok: false,
+      errorCode: 'INVALID_ARGS',
+    });
+    await h.cleanup();
+  });
+
   it('compiles extract into an act:evaluate call', async () => {
     const h = await makeHarness();
     await h.client.callTool({

--- a/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
+++ b/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
@@ -190,6 +190,40 @@ describe('createBrowserMcpServer', () => {
     await h.cleanup();
   });
 
+  it('re-evaluates resource download support when the backend changes', async () => {
+    let downloadsSupported = true;
+    const h = await makeHarness({
+      supportsResourceDownloads: () => downloadsSupported,
+    });
+    const request = {
+      name: 'browser',
+      args: {
+        action: 'act',
+        targetId: 't1',
+        request: {
+          kind: 'saveResource',
+          url: 'https://cdn.example.test/archive.zip',
+        },
+      },
+    };
+
+    await h.client.callTool({ name: 'call_tool', arguments: request });
+    expect(h.calls).toHaveLength(1);
+
+    downloadsSupported = false;
+    const blocked = await h.client.callTool({ name: 'call_tool', arguments: request });
+    expect(h.calls).toHaveLength(1);
+    expect(JSON.parse((blocked.content as Array<{ text: string }>)[0].text)).toMatchObject({
+      ok: false,
+      errorCode: 'INVALID_ARGS',
+    });
+
+    downloadsSupported = true;
+    await h.client.callTool({ name: 'call_tool', arguments: request });
+    expect(h.calls).toHaveLength(2);
+    await h.cleanup();
+  });
+
   it('compiles extract into an act:evaluate call', async () => {
     const h = await makeHarness();
     await h.client.callTool({

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -122,14 +122,15 @@ function actKindSchema(deps: BrowserMcpDeps) {
 }
 
 function elementQuerySchema(deps: BrowserMcpDeps) {
+  const nonBlankString = z.string().trim().min(1);
   return z.object({
-    css: z.string().optional(),
-    role: z.string().optional(),
-    name: z.string().optional(),
-    text: z.string().optional(),
-    label: z.string().optional(),
-    placeholder: z.string().optional(),
-    testId: z.string().optional(),
+    css: nonBlankString.optional(),
+    role: nonBlankString.optional(),
+    name: nonBlankString.optional(),
+    text: nonBlankString.optional(),
+    label: nonBlankString.optional(),
+    placeholder: nonBlankString.optional(),
+    testId: nonBlankString.optional(),
     exact: z.boolean().optional(),
     index: z.number().int().nonnegative().optional(),
   }).superRefine((query, ctx) => {

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -106,6 +106,13 @@ function getRuntime(deps: BrowserMcpDeps): BrowserControlRuntime {
   return deps.getRuntime();
 }
 
+function actKindSchema(deps: BrowserMcpDeps) {
+  const kinds = deps.supportsResourceDownloads?.() === false
+    ? ACT_KINDS.filter((kind) => kind !== 'saveResource')
+    : [...ACT_KINDS];
+  return z.enum(kinds as [typeof ACT_KINDS[number], ...typeof ACT_KINDS[number][]]);
+}
+
 function isSafeResourceUrl(value: string): boolean {
   if (!isHttpUrl(value)) return false;
   const parsed = new URL(value);
@@ -174,6 +181,7 @@ function toRuntimeRequest(args: Record<string, unknown>): BrowserControlRequest 
 }
 
 export function registerBrowserTools(registry: BrowserToolRegistry, deps: BrowserMcpDeps): void {
+  const actKind = actKindSchema(deps);
   registry.register({
     name: 'browser',
     category: 'browser',
@@ -248,7 +256,7 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
         .describe('action=saveRecipe: 可选,一并保存的站点指南对象(site/entry/recipes/notes…)'),
       request: z
         .object({
-          kind: z.enum(ACT_KINDS),
+          kind: actKind,
           targetId: z.string().optional(),
           ref: z.string().optional(),
           query: z
@@ -321,6 +329,16 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
               `url 必须是 http(s);不支持 file:// / chrome:// / data: 等协议(收到 "${u}")`,
             );
           }
+        }
+        if (
+          args.action === 'act'
+          && args.request?.kind === 'saveResource'
+          && deps.supportsResourceDownloads?.() === false
+        ) {
+          return errorResult(
+            args.action,
+            '当前浏览器后端不支持 saveResource，请使用内嵌浏览器后端',
+          );
         }
         if (
           args.action === 'act'

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -98,11 +98,18 @@ const ACT_KINDS = [
   'resize',
   'wait',
   'evaluate',
+  'saveResource',
   'close',
 ] as const;
 
 function getRuntime(deps: BrowserMcpDeps): BrowserControlRuntime {
   return deps.getRuntime();
+}
+
+function isSafeResourceUrl(value: string): boolean {
+  if (!isHttpUrl(value)) return false;
+  const parsed = new URL(value);
+  return parsed.username === '' && parsed.password === '';
 }
 
 // Server-enforced ceiling on a single tool result (~50k tokens). A huge page /
@@ -279,7 +286,7 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
           height: z.number().int().positive().optional(),
           timeMs: z.number().int().nonnegative().optional(),
           selector: z.string().optional(),
-          url: z.string().optional(),
+          url: z.string().optional().describe('saveResource 时使用 snapshot(urls:true) 返回的资源 URL'),
           loadState: z.string().optional(),
           textGone: z.string().optional(),
           timeoutMs: z.number().int().positive().optional(),
@@ -314,6 +321,19 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
               `url 必须是 http(s);不支持 file:// / chrome:// / data: 等协议(收到 "${u}")`,
             );
           }
+        }
+        if (
+          args.action === 'act'
+          && args.request?.kind === 'saveResource'
+          && (
+            typeof args.request.url !== 'string'
+            || !isSafeResourceUrl(args.request.url)
+          )
+        ) {
+          return errorResult(
+            args.action,
+            'saveResource.url 必须是 snapshot(urls:true) 返回的 http(s) 资源地址',
+          );
         }
 
         // recipe: run a declarative per-site flow (composition over primitives).

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -1,4 +1,8 @@
-import type { BrowserControlRequest, BrowserControlRuntime } from '@cindy/browser-control-runtime';
+import {
+  isPublicHttpResourceUrl,
+  type BrowserControlRequest,
+  type BrowserControlRuntime,
+} from '@cindy/browser-control-runtime';
 import { z } from 'zod';
 
 import type { BrowserMcpDeps } from '../types.js';
@@ -151,12 +155,6 @@ function elementQuerySchema(deps: BrowserMcpDeps) {
       });
     }
   });
-}
-
-function isSafeResourceUrl(value: string): boolean {
-  if (!isHttpUrl(value)) return false;
-  const parsed = new URL(value);
-  return parsed.username === '' && parsed.password === '';
 }
 
 // Server-enforced ceiling on a single tool result (~50k tokens). A huge page /
@@ -364,7 +362,7 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
           && args.request?.kind === 'saveResource'
           && (
             typeof args.request.url !== 'string'
-            || !isSafeResourceUrl(args.request.url)
+            || !isPublicHttpResourceUrl(args.request.url)
           )
         ) {
           return errorResult(

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -128,7 +128,22 @@ function elementQuerySchema(deps: BrowserMcpDeps) {
     testId: z.string().optional(),
     exact: z.boolean().optional(),
     index: z.number().int().nonnegative().optional(),
-  }).superRefine((_query, ctx) => {
+  }).superRefine((query, ctx) => {
+    const hasLookupField = [
+      query.css,
+      query.role,
+      query.name,
+      query.text,
+      query.label,
+      query.placeholder,
+      query.testId,
+    ].some((value) => typeof value === 'string' && value !== '');
+    if (!hasLookupField) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'element query requires at least one lookup field',
+      });
+    }
     if (deps.supportsSemanticQueries?.() === false) {
       ctx.addIssue({
         code: 'custom',

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -202,6 +202,20 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
       level: z.string().optional(),
       paths: z.array(z.string()).optional(),
       inputRef: z.string().optional(),
+      query: z
+        .object({
+          css: z.string().optional(),
+          role: z.string().optional(),
+          name: z.string().optional(),
+          text: z.string().optional(),
+          label: z.string().optional(),
+          placeholder: z.string().optional(),
+          testId: z.string().optional(),
+          exact: z.boolean().optional(),
+          index: z.number().int().nonnegative().optional(),
+        })
+        .optional()
+        .describe('action=upload 时定位文件输入框；字段语义与 act.request.query 一致'),
       timeoutMs: z.number().int().positive().optional(),
       dialogId: z.string().optional(),
       accept: z.boolean().optional(),

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -230,6 +230,23 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
           kind: z.enum(ACT_KINDS),
           targetId: z.string().optional(),
           ref: z.string().optional(),
+          query: z
+            .object({
+              css: z.string().optional(),
+              role: z.string().optional(),
+              name: z.string().optional(),
+              text: z.string().optional(),
+              label: z.string().optional(),
+              placeholder: z.string().optional(),
+              testId: z.string().optional(),
+              exact: z.boolean().optional(),
+              index: z.number().int().nonnegative().optional(),
+            })
+            .optional()
+            .describe(
+              '语义元素查询，可组合 role/name/text/label/placeholder/testId/css；' +
+                '默认要求唯一匹配，多项结果时用 index 明确选择。',
+            ),
           doubleClick: z.boolean().optional(),
           button: z.string().optional(),
           modifiers: z.array(z.string()).optional(),

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -117,6 +117,27 @@ function actKindSchema(deps: BrowserMcpDeps) {
   });
 }
 
+function elementQuerySchema(deps: BrowserMcpDeps) {
+  return z.object({
+    css: z.string().optional(),
+    role: z.string().optional(),
+    name: z.string().optional(),
+    text: z.string().optional(),
+    label: z.string().optional(),
+    placeholder: z.string().optional(),
+    testId: z.string().optional(),
+    exact: z.boolean().optional(),
+    index: z.number().int().nonnegative().optional(),
+  }).superRefine((_query, ctx) => {
+    if (deps.supportsSemanticQueries?.() === false) {
+      ctx.addIssue({
+        code: 'custom',
+        message: '当前浏览器后端不支持语义元素查询',
+      });
+    }
+  });
+}
+
 function isSafeResourceUrl(value: string): boolean {
   if (!isHttpUrl(value)) return false;
   const parsed = new URL(value);
@@ -186,6 +207,7 @@ function toRuntimeRequest(args: Record<string, unknown>): BrowserControlRequest 
 
 export function registerBrowserTools(registry: BrowserToolRegistry, deps: BrowserMcpDeps): void {
   const actKind = actKindSchema(deps);
+  const elementQuery = elementQuerySchema(deps);
   registry.register({
     name: 'browser',
     category: 'browser',
@@ -221,18 +243,7 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
       level: z.string().optional(),
       paths: z.array(z.string()).optional(),
       inputRef: z.string().optional(),
-      query: z
-        .object({
-          css: z.string().optional(),
-          role: z.string().optional(),
-          name: z.string().optional(),
-          text: z.string().optional(),
-          label: z.string().optional(),
-          placeholder: z.string().optional(),
-          testId: z.string().optional(),
-          exact: z.boolean().optional(),
-          index: z.number().int().nonnegative().optional(),
-        })
+      query: elementQuery
         .optional()
         .describe('action=upload 时定位文件输入框；字段语义与 act.request.query 一致'),
       timeoutMs: z.number().int().positive().optional(),
@@ -263,18 +274,7 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
           kind: actKind,
           targetId: z.string().optional(),
           ref: z.string().optional(),
-          query: z
-            .object({
-              css: z.string().optional(),
-              role: z.string().optional(),
-              name: z.string().optional(),
-              text: z.string().optional(),
-              label: z.string().optional(),
-              placeholder: z.string().optional(),
-              testId: z.string().optional(),
-              exact: z.boolean().optional(),
-              index: z.number().int().nonnegative().optional(),
-            })
+          query: elementQuery
             .optional()
             .describe(
               '语义元素查询，可组合 role/name/text/label/placeholder/testId/css；' +

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -107,10 +107,14 @@ function getRuntime(deps: BrowserMcpDeps): BrowserControlRuntime {
 }
 
 function actKindSchema(deps: BrowserMcpDeps) {
-  const kinds = deps.supportsResourceDownloads?.() === false
-    ? ACT_KINDS.filter((kind) => kind !== 'saveResource')
-    : [...ACT_KINDS];
-  return z.enum(kinds as [typeof ACT_KINDS[number], ...typeof ACT_KINDS[number][]]);
+  return z.enum(ACT_KINDS).superRefine((kind, ctx) => {
+    if (kind === 'saveResource' && deps.supportsResourceDownloads?.() === false) {
+      ctx.addIssue({
+        code: 'custom',
+        message: '当前浏览器后端不支持 saveResource',
+      });
+    }
+  });
 }
 
 function isSafeResourceUrl(value: string): boolean {

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -465,6 +465,8 @@ export type ControlWorkerAgent = 'claude-code' | 'codex';
 /** Browser automation MCP host deps. Core browser execution is injected by host. */
 export interface BrowserMcpDeps {
   getRuntime(): BrowserControlRuntime;
+  /** Whether the active backend accepts managed resource downloads. */
+  supportsResourceDownloads?(): boolean;
   logger?: LiziMcpLogger;
   /**
    * Optional L2 (user-local) recipe layer. The host scans userData, parses with

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -467,6 +467,8 @@ export interface BrowserMcpDeps {
   getRuntime(): BrowserControlRuntime;
   /** Whether the active backend accepts managed resource downloads. */
   supportsResourceDownloads?(): boolean;
+  /** Whether the active backend accepts semantic element queries. */
+  supportsSemanticQueries?(): boolean;
   logger?: LiziMcpLogger;
   /**
    * Optional L2 (user-local) recipe layer. The host scans userData, parses with


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Desktop 内嵌浏览器补齐可复用的页面自动化、调试取数、文件交接和页面弹窗处理能力，解决浏览器操作误输入聊天框以及原生弹窗阻塞消息发送的问题。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#623
- 本 PR 包含：
  - Accessibility snapshot 与稳定 ref 定位；
  - click、type、fill、press、select、hover、drag、wait 等浏览器动作；
  - Network 请求与 response body 读取；
  - 页面资源保存、受工作目录约束的上传和下载捕获；
  - alert 自动处理，以及 confirm/prompt 转为聊天内 `page-dialog` barrier 并支持预置响应后重试；
  - 浏览器动作目标隔离，避免输入落入 Cindy 聊天框。
- 明确不包含：Mobile 端、服务端、原生配置或依赖变更。
- 用户可见变化：Desktop 内嵌浏览器可以通过语义动作完成页面交互；页面 confirm/prompt 不再覆盖聊天输入区。
- 是否存在 breaking change：无

### UI 变化

不涉及：未修改 Renderer UI 组件、布局、样式或文案；弹窗 barrier 复用已有聊天承载机制。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；root runner 298 项，290 passed、8 skipped，Desktop unit PASS，其他 workspace 全部 PASS。

定向浏览器/弹窗测试
结果：77 passed。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/browser-control-runtime run --if-present typecheck
结果：通过。

pnpm --filter @cindy/mcps run --if-present typecheck
结果：通过。

pnpm check:dco
结果：通过；7 个 commit 全部带 Signed-off-by。
```

### 手工验证

在 Desktop dev 沙盒 `browser-phases` 中打开本地测试页，点击 Confirm：

```text
点击 Confirm → 聊天内出现 page-dialog → 接受并重试
→ 下一次 Confirm 自动接受 → 页面和聊天均显示 Confirm: accepted
```

### 未执行的验证

无。Mobile 本地验证不适用：本次没有修改 `apps/mobile`、移动端原生配置、依赖或 runtime fingerprint 输入。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 内嵌浏览器及其共享浏览器动作/MCP 契约；Mobile 和服务端不受影响。
- 风险：涉及 WebView 输入注入、文件路径校验、下载捕获和页面弹窗处理，错误处理或权限边界变化可能影响浏览器自动化。
- 移动端冷更判断：不会触发。改动未涉及 `apps/mobile` 原生配置、原生依赖、config plugin 或其他 runtime fingerprint 输入。
- 回滚 / 降级方式：回滚本 PR 的提交即可移除新增浏览器能力，现有聊天功能不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因