### PR TITLE
fix(desktop): 灵动岛计数徽标两位数不再折行

### DIFF
--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -1556,6 +1556,8 @@ private let hardwareNotchTextRevealDistance: CGFloat = 38
 // beside the count badge. Reserving this much guarantees the badge is never clipped at
 // the default compact width.
 private let hardwareNotchBadgeReservedInset: CGFloat = 9
+// How close a compact width must be to a snap point to count as sitting on it.
+private let compactWidthSnapTolerance: CGFloat = 1.5
 private let agentIslandTopDragHitSlop: CGFloat = 2
 private let agentIslandClickDragTolerance: CGFloat = 4
 private let hardwareNotchCenterTolerance: CGFloat = 2
@@ -1955,16 +1957,18 @@ struct AgentIslandLayout: Equatable {
     let layoutScreenMetrics = hardwareNotchLayoutEnabled
       ? screenMetrics
       : screenMetrics.disablingHardwareNotchLayout()
+    // Only the compact hardware-notch layout reserves room for the badge; skip the font
+    // measurement on every other layout tick.
+    let compactBadgeWidth = !expanded && layoutScreenMetrics.hasNotch && hasSession
+      ? PillBadge.intrinsicWidth(pillSnapshot: state.pillSnapshot, compact: true)
+      : 0
     let width = computeWidth(
       expanded: expanded,
       hasSession: hasSession,
       availableFrameWidth: availableFrameWidth,
       screenMetrics: layoutScreenMetrics,
       preferredContentWidth: preferredContentWidth,
-      compactBadgeWidth: PillBadge.intrinsicWidth(
-        pillSnapshot: state.pillSnapshot,
-        compact: true
-      )
+      compactBadgeWidth: compactBadgeWidth
     )
     let height = computeHeight(state: state, expanded: expanded, notchBaselineHeight: notchBaselineHeight)
     let shape = shapeForStatus(notchStatus)
@@ -2945,7 +2949,8 @@ struct PillBadge: View {
     let metrics = metrics(pillSnapshot: pillSnapshot, compact: compact)
     let font = NSFont.monospacedSystemFont(ofSize: metrics.fontSize, weight: .semibold)
     let segmentsWidth = metrics.segments.reduce(CGFloat(0)) { total, segment in
-      total + max(1, ceil((segment as NSString).size(withAttributes: [.font: font]).width + 1))
+      let measured = (segment as NSString).size(withAttributes: [.font: font]).width
+      return total + max(1, ceil(measured + segmentRoundingSlack))
     }
     let spacing = activeTotalSpacing * CGFloat(max(0, metrics.segments.count - 1))
     return max(metrics.minWidth, segmentsWidth + spacing + contentInset * 2)
@@ -2953,6 +2958,10 @@ struct PillBadge: View {
 
   private static let activeTotalSpacing: CGFloat = 1
   private static let contentInset: CGFloat = 2
+  /// Per-segment slack absorbing the sub-point difference between `NSFont` metrics and
+  /// SwiftUI's own text layout. Same convention as `measuredCompactTitleWidth`, and
+  /// mirrored by `AGENT_ISLAND_COMPACT_BADGE_SEGMENT_ROUNDING_SLACK` on the TS side.
+  private static let segmentRoundingSlack: CGFloat = 1
 
   var body: some View {
     if pillSnapshot.activeSessionCount > 0 && pillSnapshot.sessionCount > 1 {
@@ -5456,11 +5465,10 @@ final class AgentIslandController {
     guard basicWidth - hiddenWidth > 8 else {
       return .hidden
     }
-    let tolerance: CGFloat = 1.5
-    if abs(contentWidth - hiddenWidth) <= tolerance {
+    if abs(contentWidth - hiddenWidth) <= compactWidthSnapTolerance {
       return .hidden
     }
-    if abs(contentWidth - basicWidth) <= tolerance {
+    if abs(contentWidth - basicWidth) <= compactWidthSnapTolerance {
       return .basic
     }
     return .free
@@ -5536,9 +5544,36 @@ final class AgentIslandController {
   }
 
   /// Intrinsic width of the compact count badge for the current snapshot, used to
-  /// keep drag snapping aligned with the reserved default width.
+  /// keep drag snapping aligned with the reserved default width. Only the hardware
+  /// notch layout reserves room for the badge, so skip the font measurement otherwise.
   private var compactBadgeWidth: CGFloat {
-    PillBadge.intrinsicWidth(pillSnapshot: model.state.pillSnapshot, compact: true)
+    guard model.screenMetrics.hasNotch, model.state.totalCount > 0 else {
+      return 0
+    }
+    return PillBadge.intrinsicWidth(pillSnapshot: model.state.pillSnapshot, compact: true)
+  }
+
+  /// Width persisted as the user's compact preference. At the badge-aware basic snap we
+  /// store the badge-independent basic width instead: the stored scalar must not encode
+  /// the current count, otherwise the island keeps a wide preference after the count
+  /// drops (and the snap can no longer contract).
+  private func persistedCompactContentWidth(_ contentWidth: CGFloat) -> CGFloat {
+    guard !lastLayout.expanded, model.screenMetrics.hasNotch else {
+      return contentWidth
+    }
+    let hasSession = model.state.totalCount > 0
+    let badgeAwareBasicWidth = AgentIslandLayout.defaultCompactWidth(
+      hasSession: hasSession,
+      screenMetrics: model.screenMetrics,
+      compactBadgeWidth: compactBadgeWidth
+    )
+    guard abs(contentWidth - badgeAwareBasicWidth) <= compactWidthSnapTolerance else {
+      return contentWidth
+    }
+    return AgentIslandLayout.defaultCompactWidth(
+      hasSession: hasSession,
+      screenMetrics: model.screenMetrics
+    )
   }
 
   private func minContentWidth(expanded: Bool, hardwareNotchLayoutEnabled: Bool) -> CGFloat {
@@ -5594,7 +5629,9 @@ final class AgentIslandController {
       "type": "layout",
       "displayId": AgentIslandScreenMetricsProvider.displayId(for: screen),
       "centerXRatio": Double(min(1, max(0, ratio))),
-      "contentWidth": Double(constrainedContentWidth(contentWidth, expanded: lastLayout.expanded)),
+      "contentWidth": Double(persistedCompactContentWidth(
+        constrainedContentWidth(contentWidth, expanded: lastLayout.expanded)
+      )),
       "expanded": lastLayout.expanded,
     ])
   }

--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -2083,6 +2083,13 @@ struct AgentIslandLayout: Equatable {
       return clampedWidth
     }
     let hiddenWidth = min(maxWidth, max(1, CGFloat(screenMetrics.notchWidth)))
+    // The hidden/basic classification stays anchored to the badge-independent basic
+    // width. Otherwise a persisted basic width silently falls below the hidden
+    // threshold once a wider badge enlarges `basicWidth`, collapsing the whole island.
+    let baseBasicWidth = min(
+      maxWidth,
+      max(hiddenWidth, defaultCompactWidth(hasSession: hasSession, screenMetrics: screenMetrics))
+    )
     let basicWidth = min(
       maxWidth,
       max(
@@ -2094,11 +2101,11 @@ struct AgentIslandLayout: Equatable {
         )
       )
     )
-    let gap = basicWidth - hiddenWidth
+    let gap = baseBasicWidth - hiddenWidth
     guard gap > 8 else {
       return hiddenWidth
     }
-    let hiddenThreshold = basicWidth - min(
+    let hiddenThreshold = baseBasicWidth - min(
       AgentIslandScreenMetricsConfig.compactHardwareHiddenPullDistance,
       max(24, gap * 0.5)
     )

--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -1552,6 +1552,10 @@ private let expandedIslandCenterSnapDistance: CGFloat = 30
 private let expandedIslandLayoutEmitInterval: TimeInterval = 0.033
 private let hardwareNotchTextRevealStartSideWidth: CGFloat = 44
 private let hardwareNotchTextRevealDistance: CGFloat = 38
+// Upper bound of `hardwareNotchSideInset`, i.e. the trailing gap the notch layout keeps
+// beside the count badge. Reserving this much guarantees the badge is never clipped at
+// the default compact width.
+private let hardwareNotchBadgeReservedInset: CGFloat = 9
 private let agentIslandTopDragHitSlop: CGFloat = 2
 private let agentIslandClickDragTolerance: CGFloat = 4
 private let hardwareNotchCenterTolerance: CGFloat = 2
@@ -1956,7 +1960,11 @@ struct AgentIslandLayout: Equatable {
       hasSession: hasSession,
       availableFrameWidth: availableFrameWidth,
       screenMetrics: layoutScreenMetrics,
-      preferredContentWidth: preferredContentWidth
+      preferredContentWidth: preferredContentWidth,
+      compactBadgeWidth: PillBadge.intrinsicWidth(
+        pillSnapshot: state.pillSnapshot,
+        compact: true
+      )
     )
     let height = computeHeight(state: state, expanded: expanded, notchBaselineHeight: notchBaselineHeight)
     let shape = shapeForStatus(notchStatus)
@@ -1983,7 +1991,8 @@ struct AgentIslandLayout: Equatable {
     hasSession: Bool,
     availableFrameWidth: CGFloat,
     screenMetrics: AgentIslandScreenMetrics,
-    preferredContentWidth: CGFloat?
+    preferredContentWidth: CGFloat?,
+    compactBadgeWidth: CGFloat
   ) -> CGFloat {
     let idleExpandedWidth: CGFloat = 340
     let carrierInset = expanded ? expandedIslandCarrierExpandedInset : compactIslandCarrierInset
@@ -2003,10 +2012,15 @@ struct AgentIslandLayout: Equatable {
         clampedWidth: clampedWidth,
         maxWidth: maxWidth,
         hasSession: hasSession,
-        screenMetrics: screenMetrics
+        screenMetrics: screenMetrics,
+        compactBadgeWidth: compactBadgeWidth
       )
     }
-    let defaultWidth = defaultCompactWidth(hasSession: hasSession, screenMetrics: screenMetrics)
+    let defaultWidth = defaultCompactWidth(
+      hasSession: hasSession,
+      screenMetrics: screenMetrics,
+      compactBadgeWidth: compactBadgeWidth
+    )
     return min(preferred ?? defaultWidth, availableWidth)
   }
 
@@ -2028,12 +2042,29 @@ struct AgentIslandLayout: Equatable {
     return compactIslandMinContentWidth
   }
 
-  static func defaultCompactWidth(hasSession: Bool, screenMetrics: AgentIslandScreenMetrics) -> CGFloat {
+  /// Side width the trailing notch content needs so `compactBadgeWidth` survives
+  /// `hardwareNotchTrailingContent`'s `.clipped()` frame. Mirrors the largest inset
+  /// `hardwareNotchSideInset` can return, so a two-digit count stays readable.
+  static func hardwareNotchBadgeSideWidth(compactBadgeWidth: CGFloat) -> CGFloat {
+    compactBadgeWidth + hardwareNotchBadgeReservedInset
+  }
+
+  static func defaultCompactWidth(
+    hasSession: Bool,
+    screenMetrics: AgentIslandScreenMetrics,
+    compactBadgeWidth: CGFloat = 0
+  ) -> CGFloat {
     let notchWidth = CGFloat(screenMetrics.notchWidth)
     if screenMetrics.hasNotch {
-      let extra = hasSession
+      let baseExtra = hasSession
         ? AgentIslandScreenMetricsConfig.compactHardwareActiveExtraWidth
         : AgentIslandScreenMetricsConfig.compactHardwareIdleExtraWidth
+      // A wide badge (multi-digit counts) must widen the island rather than get
+      // clipped: both notch sides are symmetric, hence the doubling.
+      let badgeExtra = hasSession
+        ? hardwareNotchBadgeSideWidth(compactBadgeWidth: compactBadgeWidth) * 2
+        : 0
+      let extra = max(baseExtra, badgeExtra)
       return max(compactIslandBaseWidth, notchWidth + extra)
     }
     let extra = hasSession ? AgentIslandScreenMetricsConfig.compactSimulatedActiveExtraWidth : 0
@@ -2045,7 +2076,8 @@ struct AgentIslandLayout: Equatable {
     clampedWidth: CGFloat,
     maxWidth: CGFloat,
     hasSession: Bool,
-    screenMetrics: AgentIslandScreenMetrics
+    screenMetrics: AgentIslandScreenMetrics,
+    compactBadgeWidth: CGFloat = 0
   ) -> CGFloat {
     guard screenMetrics.hasNotch else {
       return clampedWidth
@@ -2053,7 +2085,14 @@ struct AgentIslandLayout: Equatable {
     let hiddenWidth = min(maxWidth, max(1, CGFloat(screenMetrics.notchWidth)))
     let basicWidth = min(
       maxWidth,
-      max(hiddenWidth, defaultCompactWidth(hasSession: hasSession, screenMetrics: screenMetrics))
+      max(
+        hiddenWidth,
+        defaultCompactWidth(
+          hasSession: hasSession,
+          screenMetrics: screenMetrics,
+          compactBadgeWidth: compactBadgeWidth
+        )
+      )
     )
     let gap = basicWidth - hiddenWidth
     guard gap > 8 else {
@@ -2866,6 +2905,48 @@ struct PillBadge: View {
   let pillSnapshot: AgentIslandPillSnapshot
   var compact: Bool = false
 
+  /// Text runs and minimum capsule width for the badge variant a snapshot renders.
+  /// Shared by `body` and `intrinsicWidth` so reserved layout width can never
+  /// drift away from what actually gets drawn.
+  struct Metrics {
+    /// One entry per rendered `Text`; each is laid out (and rounded) separately.
+    let segments: [String]
+    let minWidth: CGFloat
+    let fontSize: CGFloat
+  }
+
+  static func metrics(pillSnapshot: AgentIslandPillSnapshot, compact: Bool) -> Metrics {
+    let fontSize: CGFloat = compact ? 10 : 11
+    if pillSnapshot.activeSessionCount > 0 && pillSnapshot.sessionCount > 1 {
+      return Metrics(
+        segments: ["\(pillSnapshot.activeSessionCount)", "/", "\(pillSnapshot.sessionCount)"],
+        minWidth: compact ? 30 : 34,
+        fontSize: fontSize
+      )
+    }
+    return Metrics(
+      segments: ["\(max(1, pillSnapshot.sessionCount))"],
+      minWidth: compact ? 22 : 24,
+      fontSize: fontSize
+    )
+  }
+
+  /// Width the capsule actually wants, so hardware-notch layout can reserve room
+  /// for it instead of clipping a multi-digit count. Each segment is measured and
+  /// rounded on its own because SwiftUI lays out every `Text` separately.
+  static func intrinsicWidth(pillSnapshot: AgentIslandPillSnapshot, compact: Bool) -> CGFloat {
+    let metrics = metrics(pillSnapshot: pillSnapshot, compact: compact)
+    let font = NSFont.monospacedSystemFont(ofSize: metrics.fontSize, weight: .semibold)
+    let segmentsWidth = metrics.segments.reduce(CGFloat(0)) { total, segment in
+      total + max(1, ceil((segment as NSString).size(withAttributes: [.font: font]).width + 1))
+    }
+    let spacing = activeTotalSpacing * CGFloat(max(0, metrics.segments.count - 1))
+    return max(metrics.minWidth, segmentsWidth + spacing + contentInset * 2)
+  }
+
+  private static let activeTotalSpacing: CGFloat = 1
+  private static let contentInset: CGFloat = 2
+
   var body: some View {
     if pillSnapshot.activeSessionCount > 0 && pillSnapshot.sessionCount > 1 {
       activeTotalBadge(
@@ -2885,14 +2966,14 @@ struct PillBadge: View {
       // Multi-digit counts must widen the capsule instead of wrapping into two lines.
       .lineLimit(1)
       .fixedSize(horizontal: true, vertical: false)
-      .padding(.horizontal, badgeContentInset)
-      .frame(minWidth: compact ? 22 : 24, minHeight: compact ? 18 : 20)
+      .padding(.horizontal, Self.contentInset)
+      .frame(minWidth: metrics.minWidth, minHeight: compact ? 18 : 20)
       .background(Color.white.opacity(emphasized ? 0.11 : 0.065))
       .clipShape(Capsule())
   }
 
   private func activeTotalBadge(active: Int, total: Int, emphasized: Bool) -> some View {
-    HStack(spacing: 1) {
+    HStack(spacing: Self.activeTotalSpacing) {
       Text("\(active)")
         .foregroundColor(emphasized ? agentIslandBlue : agentIslandOrange)
       Text("/")
@@ -2904,17 +2985,19 @@ struct PillBadge: View {
     // Multi-digit counts must widen the capsule instead of wrapping into two lines.
     .lineLimit(1)
     .fixedSize(horizontal: true, vertical: false)
-    .padding(.horizontal, badgeContentInset)
-    .frame(minWidth: compact ? 30 : 34, minHeight: compact ? 18 : 20)
+    .padding(.horizontal, Self.contentInset)
+    .frame(minWidth: metrics.minWidth, minHeight: compact ? 18 : 20)
     .background(Color.white.opacity(emphasized ? 0.11 : 0.065))
     .clipShape(Capsule())
   }
 
-  private var badgeFont: Font {
-    .system(size: compact ? 10 : 11, weight: .semibold, design: .monospaced)
+  private var metrics: Metrics {
+    Self.metrics(pillSnapshot: pillSnapshot, compact: compact)
   }
 
-  private var badgeContentInset: CGFloat { 2 }
+  private var badgeFont: Font {
+    .system(size: metrics.fontSize, weight: .semibold, design: .monospaced)
+  }
 
   private var isEmphasized: Bool {
     pillSnapshot.pendingInteractionCount > 0 || pillSnapshot.attentionCount > 0
@@ -5358,7 +5441,8 @@ final class AgentIslandController {
         hiddenWidth,
         AgentIslandLayout.defaultCompactWidth(
           hasSession: model.state.totalCount > 0,
-          screenMetrics: model.screenMetrics
+          screenMetrics: model.screenMetrics,
+          compactBadgeWidth: compactBadgeWidth
         )
       )
     )
@@ -5439,8 +5523,15 @@ final class AgentIslandController {
       clampedWidth: clampedWidth,
       maxWidth: maxWidth,
       hasSession: model.state.totalCount > 0,
-      screenMetrics: model.screenMetrics
+      screenMetrics: model.screenMetrics,
+      compactBadgeWidth: compactBadgeWidth
     )
+  }
+
+  /// Intrinsic width of the compact count badge for the current snapshot, used to
+  /// keep drag snapping aligned with the reserved default width.
+  private var compactBadgeWidth: CGFloat {
+    PillBadge.intrinsicWidth(pillSnapshot: model.state.pillSnapshot, compact: true)
   }
 
   private func minContentWidth(expanded: Bool, hardwareNotchLayoutEnabled: Bool) -> CGFloat {

--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -2416,11 +2416,13 @@ struct CompactSessionView: View {
         )
           .lineLimit(1)
           .truncationMode(.tail)
-          .fixedSize(horizontal: true, vertical: false)
+          // No fixedSize here: the subtitle must yield width (and truncate) so the
+          // count badge keeps its full intrinsic width instead of being clipped.
           .opacity(textOpacity)
       }
 
       PillBadge(pillSnapshot: pillSnapshot, compact: true)
+        .layoutPriority(1)
     }
     .padding(.trailing, hardwareNotchSideInset(sideWidth: sideWidth, compactWidth: 22))
     .frame(width: sideWidth, alignment: .trailing)
@@ -2878,8 +2880,12 @@ struct PillBadge: View {
 
   private func badge(_ text: String, emphasized: Bool) -> some View {
     Text(text)
-      .font(.system(size: compact ? 10 : 11, weight: .semibold, design: .monospaced))
+      .font(badgeFont)
       .foregroundColor(Color.white.opacity(0.92))
+      // Multi-digit counts must widen the capsule instead of wrapping into two lines.
+      .lineLimit(1)
+      .fixedSize(horizontal: true, vertical: false)
+      .padding(.horizontal, badgeContentInset)
       .frame(minWidth: compact ? 22 : 24, minHeight: compact ? 18 : 20)
       .background(Color.white.opacity(emphasized ? 0.11 : 0.065))
       .clipShape(Capsule())
@@ -2894,11 +2900,21 @@ struct PillBadge: View {
       Text("\(total)")
         .foregroundColor(Color.white.opacity(0.92))
     }
-    .font(.system(size: compact ? 10 : 11, weight: .semibold, design: .monospaced))
+    .font(badgeFont)
+    // Multi-digit counts must widen the capsule instead of wrapping into two lines.
+    .lineLimit(1)
+    .fixedSize(horizontal: true, vertical: false)
+    .padding(.horizontal, badgeContentInset)
     .frame(minWidth: compact ? 30 : 34, minHeight: compact ? 18 : 20)
     .background(Color.white.opacity(emphasized ? 0.11 : 0.065))
     .clipShape(Capsule())
   }
+
+  private var badgeFont: Font {
+    .system(size: compact ? 10 : 11, weight: .semibold, design: .monospaced)
+  }
+
+  private var badgeContentInset: CGFloat { 2 }
 
   private var isEmphasized: Bool {
     pillSnapshot.pendingInteractionCount > 0 || pillSnapshot.attentionCount > 0

--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -2942,15 +2942,20 @@ struct PillBadge: View {
     )
   }
 
-  /// Width the capsule actually wants, so hardware-notch layout can reserve room
-  /// for it instead of clipping a multi-digit count. Each segment is measured and
-  /// rounded on its own because SwiftUI lays out every `Text` separately.
+  /// Width the hardware-notch layout reserves for the capsule so a multi-digit count is
+  /// never clipped.
+  ///
+  /// This is deliberately a *nominal* width computed from digit counts, not an `NSFont`
+  /// measurement: main computes the carrier width from the very same formula in
+  /// `getAgentIslandCompactBadgeWidth` (`shared/agentIsland.ts`), and the two must agree
+  /// exactly. A measured value here would sit a few points below the TS estimate, and
+  /// every snap comparison against the delivered width would silently miss.
+  /// `nominalCharWidth` is an upper bound on the real advance, so the reserved width is
+  /// always at least what SwiftUI draws — `badge-probe` harness asserts that.
   static func intrinsicWidth(pillSnapshot: AgentIslandPillSnapshot, compact: Bool) -> CGFloat {
     let metrics = metrics(pillSnapshot: pillSnapshot, compact: compact)
-    let font = NSFont.monospacedSystemFont(ofSize: metrics.fontSize, weight: .semibold)
     let segmentsWidth = metrics.segments.reduce(CGFloat(0)) { total, segment in
-      let measured = (segment as NSString).size(withAttributes: [.font: font]).width
-      return total + max(1, ceil(measured + segmentRoundingSlack))
+      total + CGFloat(segment.count) * nominalCharWidth + segmentRoundingSlack
     }
     let spacing = activeTotalSpacing * CGFloat(max(0, metrics.segments.count - 1))
     return max(metrics.minWidth, segmentsWidth + spacing + contentInset * 2)
@@ -2958,9 +2963,11 @@ struct PillBadge: View {
 
   private static let activeTotalSpacing: CGFloat = 1
   private static let contentInset: CGFloat = 2
-  /// Per-segment slack absorbing the sub-point difference between `NSFont` metrics and
-  /// SwiftUI's own text layout. Same convention as `measuredCompactTitleWidth`, and
-  /// mirrored by `AGENT_ISLAND_COMPACT_BADGE_SEGMENT_ROUNDING_SLACK` on the TS side.
+  /// Upper bound for one monospaced 10pt digit (real advance is ~6pt). Mirrors
+  /// `AGENT_ISLAND_COMPACT_BADGE_CHAR_WIDTH_BOUND` on the TS side.
+  private static let nominalCharWidth: CGFloat = 7
+  /// Per-segment rounding slack; SwiftUI lays out and rounds every `Text` run
+  /// separately. Mirrors `AGENT_ISLAND_COMPACT_BADGE_SEGMENT_ROUNDING_SLACK`.
   private static let segmentRoundingSlack: CGFloat = 1
 
   var body: some View {
@@ -5543,11 +5550,14 @@ final class AgentIslandController {
     )
   }
 
-  /// Intrinsic width of the compact count badge for the current snapshot, used to
-  /// keep drag snapping aligned with the reserved default width. Only the hardware
-  /// notch layout reserves room for the badge, so skip the font measurement otherwise.
+  /// Width reserved for the compact count badge in the current snapshot, used to keep
+  /// drag snapping aligned with the reserved default width. Only the centered hardware
+  /// notch layout reserves room for the badge.
   private var compactBadgeWidth: CGFloat {
-    guard model.screenMetrics.hasNotch, model.state.totalCount > 0 else {
+    guard model.hardwareNotchLayoutEnabled,
+      model.screenMetrics.hasNotch,
+      model.state.totalCount > 0
+    else {
       return 0
     }
     return PillBadge.intrinsicWidth(pillSnapshot: model.state.pillSnapshot, compact: true)
@@ -5557,8 +5567,15 @@ final class AgentIslandController {
   /// store the badge-independent basic width instead: the stored scalar must not encode
   /// the current count, otherwise the island keeps a wide preference after the count
   /// drops (and the snap can no longer contract).
+  ///
+  /// Gated on `hardwareNotchLayoutEnabled` as well as `hasNotch`: once the island is
+  /// moved off the notch, the emitted frame uses the plain compact layout and its width
+  /// must be persisted verbatim — rewriting it there would shrink the island mid-move.
   private func persistedCompactContentWidth(_ contentWidth: CGFloat) -> CGFloat {
-    guard !lastLayout.expanded, model.screenMetrics.hasNotch else {
+    guard !lastLayout.expanded,
+      model.hardwareNotchLayoutEnabled,
+      model.screenMetrics.hasNotch
+    else {
       return contentWidth
     }
     let hasSession = model.state.totalCount > 0

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -40,6 +40,7 @@ import {
   AGENT_ISLAND_SESSION_SNAPSHOTS_CHANNEL,
   type AgentIslandDisplayOption,
   type AgentIslandDisplayState,
+  type AgentIslandPillSnapshot,
   type AgentIslandSessionActivity,
   type AgentIslandDisplayTarget,
   type AgentIslandMascotSkin,
@@ -1606,6 +1607,9 @@ export class AgentIslandService {
       hasSession,
       displayWidth: display.bounds.width,
       screenMetrics,
+      // Keep the carrier wide enough for the native count badge; without this the
+      // native side's own reservation gets clamped away and the badge is clipped.
+      pillSnapshot: displayState.pillSnapshot,
     });
     const minimumContentWidth = getAgentIslandMinimumContentWidth({
       expanded,
@@ -1619,6 +1623,7 @@ export class AgentIslandService {
         display,
         screenMetrics,
         minimumContentWidth,
+        pillSnapshot: displayState.pillSnapshot,
       })
       : null;
     const contentWidth = preferredContentWidth !== null
@@ -1751,6 +1756,7 @@ export class AgentIslandService {
     display: Display;
     screenMetrics: AgentIslandScreenLayoutMetrics | null;
     minimumContentWidth: number;
+    pillSnapshot?: AgentIslandPillSnapshot | null;
   }): number {
     if (input.expanded) {
       return input.desiredWidth;
@@ -1767,6 +1773,7 @@ export class AgentIslandService {
       maxWidth,
       hasSession: input.hasSession,
       screenMetrics: input.screenMetrics,
+      pillSnapshot: input.pillSnapshot,
     });
   }
 

--- a/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
+++ b/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
@@ -339,6 +339,30 @@ describe('snapAgentIslandCompactHardwareContentWidth', () => {
     })).toBe(notchWidth);
   });
 
+  it('持久化的是与徽标无关的 basic 宽度时,计数升降都能正确跟随', () => {
+    // native 侧 `persistedCompactContentWidth` 保证停在 basic 吸附位时存下的是
+    // 与计数无关的 baseBasicWidth,这里验证存下该标量后两个方向都归一到当前 basic。
+    const notchWidth = 200;
+    const screenMetrics = { hasNotch: true, notchWidth };
+    const persisted = notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH;
+    const resolveFor = (pillSnapshot: { activeSessionCount: number; sessionCount: number }) =>
+      snapAgentIslandCompactHardwareContentWidth({
+        desiredWidth: persisted,
+        clampedWidth: persisted,
+        maxWidth: 920,
+        hasSession: true,
+        screenMetrics,
+        pillSnapshot,
+      });
+
+    const wide = resolveFor({ activeSessionCount: 11, sessionCount: 12 });
+    const narrow = resolveFor({ activeSessionCount: 0, sessionCount: 1 });
+    expect(wide).toBeGreaterThan(persisted);
+    // 计数回落后必须收缩回旧的 basic 宽度,不能停在为宽徽标撑开的宽度上。
+    expect(narrow).toBe(persisted);
+    expect(narrow).toBeLessThan(wide);
+  });
+
   it('不传 pillSnapshot 时吸附行为与旧实现完全一致', () => {
     const notchWidth = 200;
     const screenMetrics = { hasNotch: true, notchWidth };

--- a/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
+++ b/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_ISLAND_CARRIER_COMPACT_INSET,
+  AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH,
+  AGENT_ISLAND_COMPACT_HARDWARE_BADGE_RESERVED_INSET,
+  AGENT_ISLAND_COMPACT_HARDWARE_HIDDEN_PULL_DISTANCE,
+  AGENT_ISLAND_COMPACT_HARDWARE_IDLE_EXTRA_WIDTH,
+  AGENT_ISLAND_COMPACT_IDLE_WIDTH,
+  AGENT_ISLAND_MAX_RESIZABLE_WIDTH,
+  getAgentIslandCompactBadgeWidth,
+  getAgentIslandDefaultContentWidth,
+  snapAgentIslandCompactHardwareContentWidth,
+} from '../agentIsland';
+
+/**
+ * 灵动岛计数徽标由 native helper(macos-agent-island-helper.swift)绘制,但 carrier
+ * 窗口宽度由这里的 TS 计算决定。TS 估宽只要小于 native 实测宽度,native 的预留就会被
+ * carrier 宽度 clamp 掉,徽标重新被 `.clipped()` 切掉(见 PR #698 review)。
+ *
+ * 下表是 `PillBadge.intrinsicWidth(compact: true)` 在本机用 NSHostingView 实测的宽度,
+ * 用来锁住「TS 预留 >= native 实测」这个不变量。
+ */
+const NATIVE_COMPACT_BADGE_WIDTH: Array<{
+  label: string;
+  pillSnapshot: { activeSessionCount: number; sessionCount: number };
+  nativeWidth: number;
+}> = [
+  { label: '单会话', pillSnapshot: { activeSessionCount: 0, sessionCount: 1 }, nativeWidth: 22 },
+  { label: '1/2', pillSnapshot: { activeSessionCount: 1, sessionCount: 2 }, nativeWidth: 30 },
+  { label: '9/9', pillSnapshot: { activeSessionCount: 9, sessionCount: 9 }, nativeWidth: 30 },
+  { label: '1/12', pillSnapshot: { activeSessionCount: 1, sessionCount: 12 }, nativeWidth: 36 },
+  { label: '11/12', pillSnapshot: { activeSessionCount: 11, sessionCount: 12 }, nativeWidth: 42 },
+  { label: '99/99', pillSnapshot: { activeSessionCount: 99, sessionCount: 99 }, nativeWidth: 42 },
+  { label: '123/456', pillSnapshot: { activeSessionCount: 123, sessionCount: 456 }, nativeWidth: 54 },
+];
+
+const NOTCH_WIDTHS = [180, 200, 210, 215];
+
+/** native `CompactSessionView.hardwareNotchBody` 的侧宽公式。 */
+function sideWidth(contentWidth: number, notchWidth: number): number {
+  return Math.max(32, (contentWidth - notchWidth) / 2);
+}
+
+/** native `hardwareNotchSideInset(sideWidth:compactWidth:)`,compactWidth 固定 22。 */
+function trailingInset(side: number): number {
+  return Math.max(7, (Math.min(side, 40) - 22) / 2);
+}
+
+describe('getAgentIslandCompactBadgeWidth', () => {
+  it('保证估宽不低于 native 实测宽度(否则 carrier 会把 native 预留 clamp 掉)', () => {
+    for (const { label, pillSnapshot, nativeWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
+      const estimated = getAgentIslandCompactBadgeWidth(pillSnapshot);
+      expect(estimated, `${label} 估宽 ${estimated} < native ${nativeWidth}`)
+        .toBeGreaterThanOrEqual(nativeWidth);
+    }
+  });
+
+  it('单个计数走 22pt 最小宽度,active/total 才随位数变宽', () => {
+    expect(getAgentIslandCompactBadgeWidth({ activeSessionCount: 0, sessionCount: 1 })).toBe(22);
+    expect(getAgentIslandCompactBadgeWidth({ activeSessionCount: 0, sessionCount: 12 })).toBe(22);
+    const oneDigit = getAgentIslandCompactBadgeWidth({ activeSessionCount: 1, sessionCount: 2 });
+    const twoDigits = getAgentIslandCompactBadgeWidth({ activeSessionCount: 11, sessionCount: 12 });
+    expect(twoDigits).toBeGreaterThan(oneDigit);
+  });
+
+  it('sessionCount 为 0 时按 1 处理,不产出小于最小宽度的值', () => {
+    expect(getAgentIslandCompactBadgeWidth({ activeSessionCount: 0, sessionCount: 0 })).toBe(22);
+  });
+});
+
+describe('getAgentIslandDefaultContentWidth: 刻痕机为计数徽标预留宽度', () => {
+  it('预留后的侧宽足够容纳 native 徽标(扣掉 trailing inset 仍装得下)', () => {
+    for (const notchWidth of NOTCH_WIDTHS) {
+      for (const { label, pillSnapshot, nativeWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
+        const contentWidth = getAgentIslandDefaultContentWidth({
+          expanded: false,
+          hasSession: true,
+          screenMetrics: { hasNotch: true, notchWidth },
+          pillSnapshot,
+        });
+        const side = sideWidth(contentWidth, notchWidth);
+        const available = side - trailingInset(side);
+        expect(
+          available,
+          `notch ${notchWidth} ${label}: 可用 ${available} < 徽标 ${nativeWidth}`,
+        ).toBeGreaterThanOrEqual(nativeWidth);
+      }
+    }
+  });
+
+  it('无会话与单会话时宽度与旧实现完全一致', () => {
+    for (const notchWidth of NOTCH_WIDTHS) {
+      const legacyActive = Math.max(
+        AGENT_ISLAND_COMPACT_IDLE_WIDTH,
+        notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH,
+      );
+      const legacyIdle = Math.max(
+        AGENT_ISLAND_COMPACT_IDLE_WIDTH,
+        notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_IDLE_EXTRA_WIDTH,
+      );
+      expect(getAgentIslandDefaultContentWidth({
+        expanded: false,
+        hasSession: true,
+        screenMetrics: { hasNotch: true, notchWidth },
+        pillSnapshot: { activeSessionCount: 0, sessionCount: 1 },
+      })).toBe(legacyActive);
+      expect(getAgentIslandDefaultContentWidth({
+        expanded: false,
+        hasSession: false,
+        screenMetrics: { hasNotch: true, notchWidth },
+        pillSnapshot: { activeSessionCount: 11, sessionCount: 12 },
+      })).toBe(legacyIdle);
+    }
+  });
+
+  it('不传 pillSnapshot 时退回旧行为,不会意外加宽', () => {
+    for (const notchWidth of NOTCH_WIDTHS) {
+      expect(getAgentIslandDefaultContentWidth({
+        expanded: false,
+        hasSession: true,
+        screenMetrics: { hasNotch: true, notchWidth },
+      })).toBe(Math.max(
+        AGENT_ISLAND_COMPACT_IDLE_WIDTH,
+        notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH,
+      ));
+    }
+  });
+
+  it('预留量等于 (徽标宽 + inset 上界) * 2', () => {
+    const notchWidth = 200;
+    const pillSnapshot = { activeSessionCount: 11, sessionCount: 12 };
+    const badgeWidth = getAgentIslandCompactBadgeWidth(pillSnapshot);
+    expect(getAgentIslandDefaultContentWidth({
+      expanded: false,
+      hasSession: true,
+      screenMetrics: { hasNotch: true, notchWidth },
+      pillSnapshot,
+    })).toBe(
+      notchWidth + (badgeWidth + AGENT_ISLAND_COMPACT_HARDWARE_BADGE_RESERVED_INSET) * 2,
+    );
+  });
+
+  it('非刻痕机与 expanded 形态不受影响', () => {
+    const pillSnapshot = { activeSessionCount: 11, sessionCount: 12 };
+    const simulated = getAgentIslandDefaultContentWidth({
+      expanded: false,
+      hasSession: true,
+      displayWidth: 1512,
+      screenMetrics: { hasNotch: false, notchWidth: 210 },
+      pillSnapshot,
+    });
+    expect(simulated).toBe(getAgentIslandDefaultContentWidth({
+      expanded: false,
+      hasSession: true,
+      displayWidth: 1512,
+      screenMetrics: { hasNotch: false, notchWidth: 210 },
+    }));
+    expect(getAgentIslandDefaultContentWidth({
+      expanded: true,
+      hasSession: true,
+      screenMetrics: { hasNotch: true, notchWidth: 200 },
+      pillSnapshot,
+    })).toBe(getAgentIslandDefaultContentWidth({
+      expanded: true,
+      hasSession: true,
+      screenMetrics: { hasNotch: true, notchWidth: 200 },
+    }));
+  });
+});
+
+/**
+ * 跨语言契约:carrier 窗口宽度由 TS 算,native 只能在 `availableFrameWidth` 之内再 clamp。
+ * 下面复刻 native `AgentIslandLayout.computeWidth` 的 preferred 分支(常量与
+ * macos-agent-island-helper.swift 一一对应),确认 TS 交付的 carrier 不会把 native 自己的
+ * 徽标预留 clamp 掉 —— 这正是 PR #698 第二轮 review 指出的失效环节。native 侧改动这段
+ * 逻辑时,这里需要一起更新。
+ */
+function nativeCompactContentWidth(input: {
+  tsContentWidth: number;
+  notchWidth: number;
+  nativeBadgeWidth: number;
+}): number {
+  const carrierWidth = Math.round(input.tsContentWidth + AGENT_ISLAND_CARRIER_COMPACT_INSET * 2);
+  const availableWidth = Math.max(1, carrierWidth - AGENT_ISLAND_CARRIER_COMPACT_INSET * 2);
+  const maxWidth = Math.min(AGENT_ISLAND_MAX_RESIZABLE_WIDTH, availableWidth);
+  const minWidth = Math.min(Math.max(1, input.notchWidth), maxWidth);
+  const clampedWidth = Math.min(maxWidth, Math.max(minWidth, input.tsContentWidth));
+  const hiddenWidth = Math.min(maxWidth, Math.max(1, input.notchWidth));
+  const nativeDefault = Math.max(
+    AGENT_ISLAND_COMPACT_IDLE_WIDTH,
+    input.notchWidth + Math.max(
+      AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH,
+      (input.nativeBadgeWidth + AGENT_ISLAND_COMPACT_HARDWARE_BADGE_RESERVED_INSET) * 2,
+    ),
+  );
+  const basicWidth = Math.min(maxWidth, Math.max(hiddenWidth, nativeDefault));
+  const gap = basicWidth - hiddenWidth;
+  if (gap <= 8) return hiddenWidth;
+  const hiddenThreshold = basicWidth - Math.min(
+    AGENT_ISLAND_COMPACT_HARDWARE_HIDDEN_PULL_DISTANCE,
+    Math.max(24, gap * 0.5),
+  );
+  if (input.tsContentWidth <= hiddenThreshold) return hiddenWidth;
+  if (input.tsContentWidth <= basicWidth) return basicWidth;
+  return clampedWidth;
+}
+
+describe('TS carrier 宽度 → native 宽度链路', () => {
+  it('native 拿到的宽度足以完整绘制徽标(carrier 不再 clamp 掉预留)', () => {
+    for (const notchWidth of NOTCH_WIDTHS) {
+      for (const { label, pillSnapshot, nativeWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
+        const tsContentWidth = getAgentIslandDefaultContentWidth({
+          expanded: false,
+          hasSession: true,
+          screenMetrics: { hasNotch: true, notchWidth },
+          pillSnapshot,
+        });
+        const resolved = nativeCompactContentWidth({
+          tsContentWidth,
+          notchWidth,
+          nativeBadgeWidth: nativeWidth,
+        });
+        const side = sideWidth(resolved, notchWidth);
+        const available = side - trailingInset(side);
+        expect(
+          available,
+          `notch ${notchWidth} ${label}: native 解析出 ${resolved},可用 ${available} < 徽标 ${nativeWidth}`,
+        ).toBeGreaterThanOrEqual(nativeWidth);
+      }
+    }
+  });
+
+  it('回归:旧的 TS 宽度(notch + 64)会让 native 预留被 clamp 掉', () => {
+    const notchWidth = 200;
+    const nativeBadgeWidth = 42; // 11/12
+    const legacyTsWidth = notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH;
+    const resolved = nativeCompactContentWidth({
+      tsContentWidth: legacyTsWidth,
+      notchWidth,
+      nativeBadgeWidth,
+    });
+    const side = sideWidth(resolved, notchWidth);
+    expect(side - trailingInset(side)).toBeLessThan(nativeBadgeWidth);
+  });
+});
+
+describe('snapAgentIslandCompactHardwareContentWidth', () => {
+  it('吸附点跟随预留后的默认宽度', () => {
+    const notchWidth = 200;
+    const pillSnapshot = { activeSessionCount: 11, sessionCount: 12 };
+    const screenMetrics = { hasNotch: true, notchWidth };
+    const basicWidth = getAgentIslandDefaultContentWidth({
+      expanded: false,
+      hasSession: true,
+      screenMetrics,
+      pillSnapshot,
+    });
+    // 旧的默认宽度(notch + 64)现在落在吸附区间内,应被吸附到更宽的 basicWidth。
+    expect(snapAgentIslandCompactHardwareContentWidth({
+      desiredWidth: notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH,
+      clampedWidth: notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH,
+      maxWidth: 920,
+      hasSession: true,
+      screenMetrics,
+      pillSnapshot,
+    })).toBe(basicWidth);
+  });
+
+  it('用户拖到很窄时仍吸附回隐藏宽度(拖窄是显式意图)', () => {
+    const notchWidth = 200;
+    expect(snapAgentIslandCompactHardwareContentWidth({
+      desiredWidth: notchWidth,
+      clampedWidth: notchWidth,
+      maxWidth: 920,
+      hasSession: true,
+      screenMetrics: { hasNotch: true, notchWidth },
+      pillSnapshot: { activeSessionCount: 11, sessionCount: 12 },
+    })).toBe(notchWidth);
+  });
+});

--- a/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
+++ b/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
@@ -15,24 +15,33 @@ import {
 
 /**
  * 灵动岛计数徽标由 native helper(macos-agent-island-helper.swift)绘制,但 carrier
- * 窗口宽度由这里的 TS 计算决定。TS 估宽只要小于 native 实测宽度,native 的预留就会被
- * carrier 宽度 clamp 掉,徽标重新被 `.clipped()` 切掉(见 PR #698 review)。
+ * 窗口宽度由这里的 TS 计算决定,两侧必须算出**完全相同**的徽标宽度:
  *
- * 下表是 `PillBadge.intrinsicWidth(compact: true)` 在本机用 NSHostingView 实测的宽度,
- * 用来锁住「TS 预留 >= native 实测」这个不变量。
+ * - TS 估小 → native 的预留被 carrier 宽度 clamp 掉,徽标被 `.clipped()` 切掉
+ * - 两侧不等 → native 的吸附/持久化归一化拿 main 交付的宽度去比自己的值时永远对不上
+ *   (PR #698 review 里两次踩到)
+ *
+ * 所以 Swift 的 `PillBadge.intrinsicWidth` 不做 NSFont 测量,而是与这里同一套按位数算的
+ * 标称公式。下表的 layoutWidth 就是两侧都应算出的值;renderedWidth 是 SwiftUI 实际绘制
+ * 宽度(NSHostingView 实测),标称值必须能覆盖它。
  */
 const NATIVE_COMPACT_BADGE_WIDTH: Array<{
   label: string;
   pillSnapshot: { activeSessionCount: number; sessionCount: number };
-  nativeWidth: number;
+  /** Swift `PillBadge.intrinsicWidth(compact: true)` 应算出的值,必须与 TS 完全一致。 */
+  layoutWidth: number;
+  /** SwiftUI 实绘宽度,标称宽度必须 >= 它,否则仍会被裁。 */
+  renderedWidth: number;
 }> = [
-  { label: '单会话', pillSnapshot: { activeSessionCount: 0, sessionCount: 1 }, nativeWidth: 22 },
-  { label: '1/2', pillSnapshot: { activeSessionCount: 1, sessionCount: 2 }, nativeWidth: 30 },
-  { label: '9/9', pillSnapshot: { activeSessionCount: 9, sessionCount: 9 }, nativeWidth: 30 },
-  { label: '1/12', pillSnapshot: { activeSessionCount: 1, sessionCount: 12 }, nativeWidth: 36 },
-  { label: '11/12', pillSnapshot: { activeSessionCount: 11, sessionCount: 12 }, nativeWidth: 42 },
-  { label: '99/99', pillSnapshot: { activeSessionCount: 99, sessionCount: 99 }, nativeWidth: 42 },
-  { label: '123/456', pillSnapshot: { activeSessionCount: 123, sessionCount: 456 }, nativeWidth: 54 },
+  { label: '单会话', pillSnapshot: { activeSessionCount: 0, sessionCount: 1 }, layoutWidth: 22, renderedWidth: 22 },
+  { label: '12 个会话', pillSnapshot: { activeSessionCount: 0, sessionCount: 12 }, layoutWidth: 22, renderedWidth: 22 },
+  { label: '1/2', pillSnapshot: { activeSessionCount: 1, sessionCount: 2 }, layoutWidth: 30, renderedWidth: 30 },
+  { label: '9/9', pillSnapshot: { activeSessionCount: 9, sessionCount: 9 }, layoutWidth: 30, renderedWidth: 30 },
+  { label: '1/12', pillSnapshot: { activeSessionCount: 1, sessionCount: 12 }, layoutWidth: 37, renderedWidth: 33 },
+  { label: '11/12', pillSnapshot: { activeSessionCount: 11, sessionCount: 12 }, layoutWidth: 44, renderedWidth: 39 },
+  { label: '10/100', pillSnapshot: { activeSessionCount: 10, sessionCount: 100 }, layoutWidth: 51, renderedWidth: 45 },
+  { label: '99/99', pillSnapshot: { activeSessionCount: 99, sessionCount: 99 }, layoutWidth: 44, renderedWidth: 39 },
+  { label: '123/456', pillSnapshot: { activeSessionCount: 123, sessionCount: 456 }, layoutWidth: 58, renderedWidth: 51 },
 ];
 
 const NOTCH_WIDTHS = [180, 200, 210, 215];
@@ -48,11 +57,18 @@ function trailingInset(side: number): number {
 }
 
 describe('getAgentIslandCompactBadgeWidth', () => {
-  it('保证估宽不低于 native 实测宽度(否则 carrier 会把 native 预留 clamp 掉)', () => {
-    for (const { label, pillSnapshot, nativeWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
-      const estimated = getAgentIslandCompactBadgeWidth(pillSnapshot);
-      expect(estimated, `${label} 估宽 ${estimated} < native ${nativeWidth}`)
-        .toBeGreaterThanOrEqual(nativeWidth);
+  it('与 Swift PillBadge.intrinsicWidth 逐值一致(两侧公式必须同步)', () => {
+    for (const { label, pillSnapshot, layoutWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
+      expect(getAgentIslandCompactBadgeWidth(pillSnapshot), `${label} 与 Swift 侧不一致`)
+        .toBe(layoutWidth);
+    }
+  });
+
+  it('标称宽度覆盖 SwiftUI 实绘宽度(否则徽标仍会被裁)', () => {
+    for (const { label, pillSnapshot, renderedWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
+      const nominal = getAgentIslandCompactBadgeWidth(pillSnapshot);
+      expect(nominal, `${label} 标称 ${nominal} < 实绘 ${renderedWidth}`)
+        .toBeGreaterThanOrEqual(renderedWidth);
     }
   });
 
@@ -72,7 +88,7 @@ describe('getAgentIslandCompactBadgeWidth', () => {
 describe('getAgentIslandDefaultContentWidth: 刻痕机为计数徽标预留宽度', () => {
   it('预留后的侧宽足够容纳 native 徽标(扣掉 trailing inset 仍装得下)', () => {
     for (const notchWidth of NOTCH_WIDTHS) {
-      for (const { label, pillSnapshot, nativeWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
+      for (const { label, pillSnapshot, layoutWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
         const contentWidth = getAgentIslandDefaultContentWidth({
           expanded: false,
           hasSession: true,
@@ -83,8 +99,8 @@ describe('getAgentIslandDefaultContentWidth: 刻痕机为计数徽标预留宽�
         const available = side - trailingInset(side);
         expect(
           available,
-          `notch ${notchWidth} ${label}: 可用 ${available} < 徽标 ${nativeWidth}`,
-        ).toBeGreaterThanOrEqual(nativeWidth);
+          `notch ${notchWidth} ${label}: 可用 ${available} < 徽标 ${layoutWidth}`,
+        ).toBeGreaterThanOrEqual(layoutWidth);
       }
     }
   });
@@ -209,7 +225,7 @@ function nativeCompactContentWidth(input: {
 describe('TS carrier 宽度 → native 宽度链路', () => {
   it('native 拿到的宽度足以完整绘制徽标(carrier 不再 clamp 掉预留)', () => {
     for (const notchWidth of NOTCH_WIDTHS) {
-      for (const { label, pillSnapshot, nativeWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
+      for (const { label, pillSnapshot, layoutWidth } of NATIVE_COMPACT_BADGE_WIDTH) {
         const tsContentWidth = getAgentIslandDefaultContentWidth({
           expanded: false,
           hasSession: true,
@@ -219,21 +235,21 @@ describe('TS carrier 宽度 → native 宽度链路', () => {
         const resolved = nativeCompactContentWidth({
           tsContentWidth,
           notchWidth,
-          nativeBadgeWidth: nativeWidth,
+          nativeBadgeWidth: layoutWidth,
         });
         const side = sideWidth(resolved, notchWidth);
         const available = side - trailingInset(side);
         expect(
           available,
-          `notch ${notchWidth} ${label}: native 解析出 ${resolved},可用 ${available} < 徽标 ${nativeWidth}`,
-        ).toBeGreaterThanOrEqual(nativeWidth);
+          `notch ${notchWidth} ${label}: native 解析出 ${resolved},可用 ${available} < 徽标 ${layoutWidth}`,
+        ).toBeGreaterThanOrEqual(layoutWidth);
       }
     }
   });
 
   it('回归:旧的 TS 宽度(notch + 64)会让 native 预留被 clamp 掉', () => {
     const notchWidth = 200;
-    const nativeBadgeWidth = 42; // 11/12
+    const nativeBadgeWidth = 44; // 11/12
     const legacyTsWidth = notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH;
     const resolved = nativeCompactContentWidth({
       tsContentWidth: legacyTsWidth,

--- a/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
+++ b/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
@@ -278,4 +278,84 @@ describe('snapAgentIslandCompactHardwareContentWidth', () => {
       pillSnapshot: { activeSessionCount: 11, sessionCount: 12 },
     })).toBe(notchWidth);
   });
+
+  it('计数变多不会把此前停在 basic 的持久化宽度判成 hidden(灵动岛不塌缩)', () => {
+    // 回归:三位数徽标把 basicWidth 撑到 320,若 hidden 阈值也跟着抬到 272,
+    // 用户此前存下的 basic 宽度 264 会被判成 hidden,整个 compact 岛被收起。
+    const notchWidth = 200;
+    const persistedBasicWidth = notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH;
+    const screenMetrics = { hasNotch: true, notchWidth };
+    for (const pillSnapshot of [
+      { activeSessionCount: 10, sessionCount: 100 },
+      { activeSessionCount: 11, sessionCount: 12 },
+      { activeSessionCount: 123, sessionCount: 456 },
+    ]) {
+      const widened = getAgentIslandDefaultContentWidth({
+        expanded: false,
+        hasSession: true,
+        screenMetrics,
+        pillSnapshot,
+      });
+      const resolved = snapAgentIslandCompactHardwareContentWidth({
+        desiredWidth: persistedBasicWidth,
+        clampedWidth: persistedBasicWidth,
+        maxWidth: 920,
+        hasSession: true,
+        screenMetrics,
+        pillSnapshot,
+      });
+      expect(resolved, `${pillSnapshot.activeSessionCount}/${pillSnapshot.sessionCount} 塌缩到了 ${resolved}`)
+        .not.toBe(notchWidth);
+      expect(resolved).toBe(widened);
+    }
+  });
+
+  it('hidden 阈值与旧实现一致:略窄于旧 basic 仍吸附到 basic,更窄才隐藏', () => {
+    const notchWidth = 200;
+    const screenMetrics = { hasNotch: true, notchWidth };
+    const pillSnapshot = { activeSessionCount: 11, sessionCount: 12 };
+    const widened = getAgentIslandDefaultContentWidth({
+      expanded: false,
+      hasSession: true,
+      screenMetrics,
+      pillSnapshot,
+    });
+    // 旧 basic 264、hidden 200、gap 64 → 阈值 264 - 32 = 232。
+    expect(snapAgentIslandCompactHardwareContentWidth({
+      desiredWidth: 240,
+      clampedWidth: 240,
+      maxWidth: 920,
+      hasSession: true,
+      screenMetrics,
+      pillSnapshot,
+    })).toBe(widened);
+    expect(snapAgentIslandCompactHardwareContentWidth({
+      desiredWidth: 230,
+      clampedWidth: 230,
+      maxWidth: 920,
+      hasSession: true,
+      screenMetrics,
+      pillSnapshot,
+    })).toBe(notchWidth);
+  });
+
+  it('不传 pillSnapshot 时吸附行为与旧实现完全一致', () => {
+    const notchWidth = 200;
+    const screenMetrics = { hasNotch: true, notchWidth };
+    const legacyBasic = notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH;
+    for (const [desiredWidth, expected] of [
+      [legacyBasic, legacyBasic],
+      [240, legacyBasic],
+      [230, notchWidth],
+      [notchWidth, notchWidth],
+    ] as Array<[number, number]>) {
+      expect(snapAgentIslandCompactHardwareContentWidth({
+        desiredWidth,
+        clampedWidth: desiredWidth,
+        maxWidth: 920,
+        hasSession: true,
+        screenMetrics,
+      })).toBe(expected);
+    }
+  });
 });

--- a/apps/desktop/src/shared/agentIsland.ts
+++ b/apps/desktop/src/shared/agentIsland.ts
@@ -463,6 +463,14 @@ export const AGENT_ISLAND_COMPACT_BADGE_CONTENT_INSET = 2;
 export const AGENT_ISLAND_COMPACT_BADGE_TEXT_SPACING = 1;
 /** Generous upper bound for one monospaced 10pt digit (real advance is ~6pt). */
 export const AGENT_ISLAND_COMPACT_BADGE_CHAR_WIDTH_BOUND = 7;
+/**
+ * Per-segment rounding slack, mirroring `PillBadge.segmentRoundingSlack` in the Swift
+ * helper (`ceil(measured + 1)` per `Text`). SwiftUI lays out and rounds every `Text`
+ * run separately, so the slack is added once per segment — not once per badge. Dropping
+ * it would make this estimate fall below the native width and let the badge get clipped
+ * again; `agentIslandCompactBadgeWidth.test.ts` guards that.
+ */
+export const AGENT_ISLAND_COMPACT_BADGE_SEGMENT_ROUNDING_SLACK = 1;
 /** Upper bound of the native `hardwareNotchSideInset` beside the badge. */
 export const AGENT_ISLAND_COMPACT_HARDWARE_BADGE_RESERVED_INSET = 9;
 export const AGENT_ISLAND_MAX_EXPANDED_HEIGHT = 560;
@@ -512,7 +520,9 @@ export function getAgentIslandCompactBadgeWidth(input: {
     ? [`${input.activeSessionCount}`, '/', `${input.sessionCount}`]
     : [`${Math.max(1, input.sessionCount)}`];
   const segmentsWidth = segments.reduce(
-    (total, segment) => total + segment.length * AGENT_ISLAND_COMPACT_BADGE_CHAR_WIDTH_BOUND + 1,
+    (total, segment) => total
+      + segment.length * AGENT_ISLAND_COMPACT_BADGE_CHAR_WIDTH_BOUND
+      + AGENT_ISLAND_COMPACT_BADGE_SEGMENT_ROUNDING_SLACK,
     0,
   );
   const spacing = AGENT_ISLAND_COMPACT_BADGE_TEXT_SPACING * Math.max(0, segments.length - 1);

--- a/apps/desktop/src/shared/agentIsland.ts
+++ b/apps/desktop/src/shared/agentIsland.ts
@@ -596,6 +596,16 @@ export function snapAgentIslandCompactHardwareContentWidth(input: {
     return input.clampedWidth;
   }
   const hiddenWidth = Math.min(input.maxWidth, Math.max(1, input.screenMetrics.notchWidth));
+  // hidden/basic 的分类必须锚在与徽标无关的 basic 宽度上。否则计数一变多、basic 宽度被撑大后,
+  // 用户此前停在 basic 的持久化宽度会突然落到 hidden 阈值以下,整个 compact 岛被收起。
+  const baseBasicWidth = Math.min(
+    input.maxWidth,
+    Math.max(hiddenWidth, getAgentIslandDefaultContentWidth({
+      expanded: false,
+      hasSession: input.hasSession,
+      screenMetrics: input.screenMetrics,
+    })),
+  );
   const basicWidth = Math.min(
     input.maxWidth,
     Math.max(hiddenWidth, getAgentIslandDefaultContentWidth({
@@ -605,11 +615,11 @@ export function snapAgentIslandCompactHardwareContentWidth(input: {
       pillSnapshot: input.pillSnapshot,
     })),
   );
-  const gap = basicWidth - hiddenWidth;
+  const gap = baseBasicWidth - hiddenWidth;
   if (gap <= 8) {
     return hiddenWidth;
   }
-  const hiddenThreshold = basicWidth - Math.min(
+  const hiddenThreshold = baseBasicWidth - Math.min(
     AGENT_ISLAND_COMPACT_HARDWARE_HIDDEN_PULL_DISTANCE,
     Math.max(24, gap * 0.5),
   );

--- a/apps/desktop/src/shared/agentIsland.ts
+++ b/apps/desktop/src/shared/agentIsland.ts
@@ -454,6 +454,17 @@ export const AGENT_ISLAND_COMPACT_SIMULATED_ACTIVE_EXTRA_WIDTH = 88;
 export const AGENT_ISLAND_COMPACT_HARDWARE_IDLE_EXTRA_WIDTH = 64;
 export const AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH = 64;
 export const AGENT_ISLAND_COMPACT_HARDWARE_HIDDEN_PULL_DISTANCE = 48;
+// Compact count-badge metrics, kept in sync with `PillBadge` in
+// `native/agent-island/macos-agent-island-helper.swift`. Only used to reserve carrier
+// width; the native helper still measures the real font for what it draws.
+export const AGENT_ISLAND_COMPACT_BADGE_MIN_WIDTH = 22;
+export const AGENT_ISLAND_COMPACT_BADGE_ACTIVE_TOTAL_MIN_WIDTH = 30;
+export const AGENT_ISLAND_COMPACT_BADGE_CONTENT_INSET = 2;
+export const AGENT_ISLAND_COMPACT_BADGE_TEXT_SPACING = 1;
+/** Generous upper bound for one monospaced 10pt digit (real advance is ~6pt). */
+export const AGENT_ISLAND_COMPACT_BADGE_CHAR_WIDTH_BOUND = 7;
+/** Upper bound of the native `hardwareNotchSideInset` beside the badge. */
+export const AGENT_ISLAND_COMPACT_HARDWARE_BADGE_RESERVED_INSET = 9;
 export const AGENT_ISLAND_MAX_EXPANDED_HEIGHT = 560;
 export const AGENT_ISLAND_SCREEN_EDGE_GUTTER = 112;
 export const AGENT_ISLAND_CARRIER_COMPACT_INSET = 20;
@@ -482,11 +493,44 @@ export function computeAgentIslandSimulatedNotchWidth(displayWidth: number): num
   );
 }
 
+/**
+ * Upper-bound width of the compact count badge the native helper draws, mirroring
+ * `PillBadge.intrinsicWidth` in `macos-agent-island-helper.swift`.
+ *
+ * The carrier window sizes itself from this, so the native side can only ever clamp
+ * the island *down* to its own exact measurement — never get clipped for lack of room.
+ * That is why the per-character advance below is deliberately generous: the real
+ * monospaced 10pt advance is ~6pt, and overestimating only leaves invisible slack
+ * inside the carrier's transparent inset.
+ */
+export function getAgentIslandCompactBadgeWidth(input: {
+  activeSessionCount: number;
+  sessionCount: number;
+}): number {
+  const isActiveTotal = input.activeSessionCount > 0 && input.sessionCount > 1;
+  const segments = isActiveTotal
+    ? [`${input.activeSessionCount}`, '/', `${input.sessionCount}`]
+    : [`${Math.max(1, input.sessionCount)}`];
+  const segmentsWidth = segments.reduce(
+    (total, segment) => total + segment.length * AGENT_ISLAND_COMPACT_BADGE_CHAR_WIDTH_BOUND + 1,
+    0,
+  );
+  const spacing = AGENT_ISLAND_COMPACT_BADGE_TEXT_SPACING * Math.max(0, segments.length - 1);
+  const minWidth = isActiveTotal
+    ? AGENT_ISLAND_COMPACT_BADGE_ACTIVE_TOTAL_MIN_WIDTH
+    : AGENT_ISLAND_COMPACT_BADGE_MIN_WIDTH;
+  return Math.max(
+    minWidth,
+    segmentsWidth + spacing + AGENT_ISLAND_COMPACT_BADGE_CONTENT_INSET * 2,
+  );
+}
+
 export function getAgentIslandDefaultContentWidth(input: {
   expanded: boolean;
   hasSession: boolean;
   displayWidth?: number;
   screenMetrics?: AgentIslandScreenLayoutMetrics | null;
+  pillSnapshot?: Pick<AgentIslandPillSnapshot, 'activeSessionCount' | 'sessionCount'> | null;
 }): number {
   if (input.expanded) {
     return input.hasSession ? AGENT_ISLAND_MAX_EXPANDED_WIDTH : AGENT_ISLAND_IDLE_EXPANDED_WIDTH;
@@ -497,11 +541,17 @@ export function getAgentIslandDefaultContentWidth(input: {
       ? computeAgentIslandSimulatedNotchWidth(input.displayWidth)
       : AGENT_ISLAND_COMPACT_IDLE_WIDTH);
   if (input.screenMetrics?.hasNotch) {
+    const baseExtra = input.hasSession
+      ? AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH
+      : AGENT_ISLAND_COMPACT_HARDWARE_IDLE_EXTRA_WIDTH;
+    // Both notch sides are symmetric, so a wide badge costs twice its side width.
+    const badgeExtra = input.hasSession && input.pillSnapshot
+      ? (getAgentIslandCompactBadgeWidth(input.pillSnapshot)
+        + AGENT_ISLAND_COMPACT_HARDWARE_BADGE_RESERVED_INSET) * 2
+      : 0;
     return Math.max(
       AGENT_ISLAND_COMPACT_IDLE_WIDTH,
-      notchWidth + (input.hasSession
-        ? AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH
-        : AGENT_ISLAND_COMPACT_HARDWARE_IDLE_EXTRA_WIDTH),
+      notchWidth + Math.max(baseExtra, badgeExtra),
     );
   }
   if (typeof input.displayWidth === 'number' || input.screenMetrics) {
@@ -540,6 +590,7 @@ export function snapAgentIslandCompactHardwareContentWidth(input: {
   maxWidth: number;
   hasSession: boolean;
   screenMetrics?: AgentIslandScreenLayoutMetrics | null;
+  pillSnapshot?: Pick<AgentIslandPillSnapshot, 'activeSessionCount' | 'sessionCount'> | null;
 }): number {
   if (!input.screenMetrics?.hasNotch) {
     return input.clampedWidth;
@@ -551,6 +602,7 @@ export function snapAgentIslandCompactHardwareContentWidth(input: {
       expanded: false,
       hasSession: input.hasSession,
       screenMetrics: input.screenMetrics,
+      pillSnapshot: input.pillSnapshot,
     })),
   );
   const gap = basicWidth - hiddenWidth;


### PR DESCRIPTION
## 这次改了什么

### 摘要

运行中的会话数达到两位数时，灵动岛右侧的计数徽标（`11/12`）会竖排折行成两行，版式破掉。

**根因一：徽标被压缩换行。** `PillBadge` 宽度写死为 `minWidth`（compact 30pt / 常规 34pt），
但 `11/12` 用等宽字体实测是 35pt / 37pt。外层 HStack 只按 `minWidth` 给它分配宽度，SwiftUI
于是把 `Text` 压缩换行。个位数（`1/12` = 30pt）放得进 34pt，所以只有两位数才犯。

- 两个徽标分支的文本加 `lineLimit(1)` + `fixedSize(horizontal:)`，位数变多时胶囊自身变宽而不是压缩文字
- 补 2pt 水平内边距，避免多位数时数字贴到 Capsule 圆弧上（个位数徽标宽度保持不变）
- hardware notch 布局下 subtitle 原先用 `fixedSize` 拒绝让出宽度，会把变宽后的徽标挤出
  `clipped()` 区域；改为可截断并给徽标 `layoutPriority(1)`，空间不足时先截断 subtitle

**根因二（review 指出）：刻痕机宽度不够，徽标被裁。** 只做上面这些，刻痕机用户仍然读不出
计数：默认宽度只在刻痕两侧各留 32pt，减去 trailing inset 后可用 25pt，而 compact `11/12`
徽标要 39pt，`.clipped()` 会切掉一截。个位数 `1/12`（30pt）同样被切 —— 这是刻痕布局的既有
缺口，之前被折行掩盖了。

- `PillBadge` 暴露 `metrics` / `intrinsicWidth`，`body` 与布局共用同一份 metrics，预留宽度
  不会和实际绘制漂移。测量按渲染结构**逐段**进行（SwiftUI 对 `11` `/` `12` 三个 `Text` 分别
  布局取整，整串测量会低估 1pt）
- `defaultCompactWidth` / `snappedCompactHardwareWidth` 接受 `compactBadgeWidth`，刻痕分支取
  `max(既有 extra, (徽标宽 + hardwareNotchBadgeReservedInset) * 2)`，徽标变宽时灵动岛跟着变宽。
  预留的 9pt 是 `hardwareNotchSideInset` 的上界，因此自洽

**根因三（review 指出）：carrier 窗口宽度没同步，native 的预留被 clamp 掉。** 只改 native 仍然
无效：`computeNativeFrame` 按 TS 的 `getAgentIslandDefaultContentWidth`（仍是 `notchWidth + 64`）
算 carrier，native 的 `availableWidth` 就等于该 contentWidth，于是 `snappedCompactHardwareWidth`
里新的 `badgeExtra` 被 `maxWidth` 吃掉，每侧仍是 32pt。

- `shared/agentIsland.ts` 新增 `getAgentIslandCompactBadgeWidth()`，镜像 Swift `PillBadge` 的
  分段 / minWidth / inset 结构；`getAgentIslandDefaultContentWidth()` 与
  `snapAgentIslandCompactHardwareContentWidth()` 接受可选 `pillSnapshot`，刻痕分支同样取
  `max(既有 extra, (徽标宽 + 9) * 2)`
- `service.ts` 把 `displayState.pillSnapshot` 透传进 `computeNativeFrame` 与
  `normalizePreferredContentWidth`
- TS 侧没有字体度量，每字符宽度取**保守上界 7pt**（真实 monospaced 10pt advance ≈ 6pt）：估大
  只多几 pt 留白，估小才会重新裁切。最终视觉宽度就是这个 TS 值；native 侧的预留保留为
  carrier 未传 `pillSnapshot` 时的第二道保险

**根因四（review 发现的回归）：徽标变宽会把持久化的 basic 宽度判成 hidden。** 计数变多撑大
`basicWidth` 后，hidden 判定阈值也跟着抬高：notchWidth 200 时 `10/100` 让 `basicWidth` 变成
320pt、阈值 272pt，用户此前停在 basic 吸附位的持久化宽度 264pt 突然落到阈值以下，
`normalizePreferredContentWidth` 返回 `hiddenWidth = 200pt` —— 整个 compact 岛被收起。

- hidden / basic 的**分类**改为锚在与徽标无关的 `baseBasicWidth`（既有 `notch + 64`）上，
  **吸附目标**仍用带徽标预留的 `basicWidth`。旧的 hidden 阈值语义一字不变，持久化宽度只会被
  吸附到更宽的 basic，不会塌缩。TS 与 Swift 两侧同步

**根因五（review 发现的回归）：徽标变窄时灵动岛收不回去。** 用户在宽徽标下停在 basic 吸附位
时，`emitLayoutPreference` 持久化的是 badge-aware 宽度（`11/12` → 302pt）；计数回落后
`basicWidth` 回到 264pt，302 大于它，snap 走 free 分支把 302 永久保留成自由宽度。

- 修在持久化那一端：新增 `persistedCompactContentWidth`，当前宽度落在 badge-aware basic
  吸附位（容差 1.5pt）时，持久化与徽标无关的 `baseBasicWidth`。存下的标量不再编码当时的计数，
  配合根因四的 hidden 锚点，计数升降两个方向都会归一到当前 basic；用户自由拖出的宽度不在吸附
  位上，原样保留

同轮 review 的另外两条也一并处理：`AgentIslandLayout.compute` 与 controller 的
`compactBadgeWidth` 加 `hasNotch` / `hasSession` 门控（非刻痕机与无会话时不再每 33ms 做一次
`NSFont` 测量）；每段 `+1` 的度量补偿提取为具名常量（Swift `segmentRoundingSlack` /
TS `AGENT_ISLAND_COMPACT_BADGE_SEGMENT_ROUNDING_SLACK`），吸附容差 `1.5` 提取为
`compactWidthSnapTolerance`。

**根因六（review 发现）：两侧算徽标宽度的方式不同，注定漂移。** 根因五的归一化对多位数徽标
从未生效：main 按 TS 的保守估算交付 306pt，native 用 `NSFont` 精确测量算出 302pt，4pt 差超过
1.5pt 容差，比较永远落空。

- 没有放宽容差（差值随位数变化，放宽到能覆盖就会误吞用户自由拖出的宽度），而是消除漂移本身：
  `PillBadge.intrinsicWidth` 不再做 `NSFont` 测量，改用与 `getAgentIslandCompactBadgeWidth`
  **完全相同**的按位数标称公式。绘制仍由 SwiftUI 用真实字体 `fixedSize` 自己排，标称值只用于
  布局预留，且始终是实绘宽度的上界
- 附带去掉了布局路径上每帧的字体测量开销
- `persistedCompactContentWidth` 与 `compactBadgeWidth` 补上 `hardwareNotchLayoutEnabled`
  门控：岛被移离刻痕后走普通 compact 布局，交付的宽度必须原样持久化，否则移动过程中会把
  `1/2` 的 278pt 改写成 264pt、岛跟着缩一下

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户直接反馈：灵动岛运行中任务数为两位数时折行）
- 本 PR 包含：`PillBadge` 防折行；notch trailing 侧的让位优先级调整；刻痕机默认灵动岛宽度
  按徽标固有宽度预留（native + TS carrier 两侧）；新增覆盖宽度预留的单元测试
- 明确不包含：expanded 形态、非刻痕机默认宽度、灵动岛其它内容的截断策略均未改动
- 用户可见变化：
  - 计数徽标在两位数及以上时单行完整显示；个位数徽标视觉不变
  - **刻痕机**：出现 `active/total` 徽标（即多会话且有会话在跑）时，默认灵动岛宽度会随徽标
    位数变宽（notchWidth 200 时：`1/2` 278pt、`1/12` 292pt、`11/12` 306pt、`123/456` 334pt，
    原为固定 264pt）。无会话与单会话时宽度零变化。这是让徽标不被裁切的必要代价
  - 用户手动拖窄灵动岛时仍按既有逻辑裁切（拖窄是显式意图，不反向撑开）
  - 此前拖到 basic 吸附位的用户，计数变多时会被吸附到新的（更宽的）basic，不会被判成 hidden
    而收起；计数回落时也会收缩回旧的 basic，不会停在为宽徽标撑开的宽度上。hidden 的判定阈值
    与旧实现完全一致，用户自由拖出的宽度不受影响
- 是否存在 breaking change：无

### UI 变化

macOS 灵动岛（native SwiftUI overlay）。未附截图 —— 该状态需要同时存在 10 个以上运行中
会话才能自然触发，本次用离屏渲染 harness（`NSHostingView` + `bitmapImageRepForCachingDisplay`）
比对修复前后并数值断言，结果见「自动验证」。需要的话可以补图。

- 引用的设计规范：docs/design-rules/DESIGN.md §7 Do's and Don'ts（"Use pill-shaped
  (9999px) radius on all interactive elements"、"Don't invent arbitrary radii"）——
  徽标仍是 `Capsule()` 胶囊形，本次只让胶囊宽度随内容增长，未引入新圆角、新字重或新颜色；
  §7（"Don't introduce any chromatic color outside the sanctioned semantic set"）——
  徽标配色沿用既有 `agentIslandOrange` / `agentIslandBlue` 与既有 white opacity，未新增或
  调整任何颜色值。双模式：灵动岛是固定深色 native overlay，不走 renderer 语义 token，本次
  未触碰颜色，因此不涉及 §10 的 Light / Dark 双模式交付门槛。

## 怎么验证的

### 自动验证

```text
swiftc -typecheck apps/desktop/native/agent-island/macos-agent-island-helper.swift
结果：通过（无输出）

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 退出码 0）

bash <git skill>/scripts/run-unit-gate.sh <worktree>   # 仓库根 pnpm test:unit 全量
结果：GATE_EXIT=0 通过（六个 commit 各跑到绿；期间 file-browser 的
      deviceOp.test.ts watch 用例族在本机满负载下随机失败，单独跑 35/35 通过，
      干净 main 基线满负载也随机挂另一个时序用例，判定为本机 flake）
```

离屏渲染 harness（复制修复前后的实现，用 `NSHostingView` 渲染并测量 `fittingSize`）：

```text
徽标固有宽度（修复前 → 修复后）
  compact 1/12     30.0 → 33.0    单行 → 单行
  compact 11/12    35.0 → 39.0    折行 → 单行
  compact 9/9      30.0 → 30.0    不变
  常规    1/12     34.0 → 34.0    像素级不变
  常规    11/12    37.0 → 41.0    折行 → 单行

受约束场景（HStack 只按 minWidth 分配宽度，还原真实布局）
  notch trailing sideWidth 200 / 120 / 80 / 60，11/12
    修复前：徽标折行成两行（复现用户截图）
    修复后：徽标单行完整，subtitle 走 … 截断
  非 notch regular body 宽度 300 / 200 / 152，11/12 与 123/456
    修复后：徽标单行完整，标题与 subtitle 正常截断
```

刻痕机宽度预留 —— Swift harness 断言（notchWidth 180 / 200 / 210 / 215 × `1 会话`、`1/2`、
`1/12`、`9/9`、`11/12`、`99/99`、`123/456` 全组合）：

```text
断言 1  intrinsicWidth >= NSHostingView(PillBadge).fittingSize.width   全部通过
        （逐段测量前该断言在 1/12、11/12、99/99 上失败 1pt，据此改为逐段测量）
断言 2  sideWidth - hardwareNotchSideInset >= badgeWidth               全部通过
断言 3  单会话默认宽度 == 旧值（notch+64）                              全部通过
断言 4  idle 默认宽度 == 旧值                                          全部通过
```

新增仓库内单元测试 `apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts`
（17 个用例，`npx vitest run` 全绿），把上面的不变量固化下来：

```text
TS 与 Swift 的标称宽度逐值相等（toBe，不是 >=；任一边公式漂移就红）
标称宽度覆盖 SwiftUI 实绘宽度（NSHostingView 逐 case 取得）
跨语言链路契约：复刻 native computeWidth 的 preferred 分支，断言 native 解析出的宽度
  扣掉 trailing inset 后仍装得下徽标（notchWidth 180/200/210/215 × 7 种计数）
回归用例：断言旧的 notch + 64 确实会让可用宽度小于徽标宽度（即 review 报告的失效点）
无会话 / 单会话 / 不传 pillSnapshot / 非刻痕机 / expanded 五种情形宽度与旧实现完全一致
计数变多不会把持久化的 basic 宽度判成 hidden（10/100、11/12、123/456 三组）
hidden 阈值与旧实现一致（240 吸附到 basic、230 收起）
持久化标量在计数升降之间双向跟随（回落后必须等于旧 basic 且严格小于宽徽标下的宽度）
不传 pillSnapshot 时吸附行为与旧实现逐值一致
```

两侧公式一致性（Swift harness，`NSHostingView` 取实绘宽度）：

```text
             native 标称 | TS 标称 | SwiftUI 实绘
  单会话          22     |   22    |   22     一致 / 覆盖
  1/2             30     |   30    |   30     一致 / 覆盖
  1/12            37     |   37    |   33     一致 / 覆盖
  11/12           44     |   44    |   39     一致 / 覆盖
  10/100          51     |   51    |   45     一致 / 覆盖
  123/456         58     |   58    |   51     一致 / 覆盖

归一化识别 main 交付的 basic 宽度（notch 200，容差 1.5）
  1/2 278 ; 1/12 292 ; 11/12 306 ; 10/100 320 ; 123/456 334   全部匹配
```

`persistedCompactContentWidth` 的归一化在 Swift 侧，用 harness 做数值验证（notchWidth 200）：

```text
停在 basic 吸附位时的持久化值
  11/12 显示 302 → 持久化 264 ; 10/100 显示 314 → 264 ; 123/456 显示 326 → 264
持久化 264 在计数升降之间双向跟随
  单会话 264 → 1/2 278 → 11/12 302 → 10/100 314 → 123/456 326 → 回到单会话 264
  每一档 sideWidth - inset 均 >= 该档徽标宽度
用户自由拖出的宽度（不在吸附位上）
  280 → 280 ; 350 → 350 ; 420 → 420（原样保留）
```

两个塌缩相关用例做过反向验证：把锚点改回 `basicWidth` 后它们会红并报出
`10/100 塌缩到了 200`，确认测试确实锁住了这条路径。

notchWidth 200 下的最终宽度（取自实现输出）：

```text
  无会话 / 1 个会话   264 → 264   side 32   可用 25     徽标 22   (不变)
  1/2、9/9           264 → 278   side 39   可用 30.5   徽标 30
  1/12               264 → 292   side 46   可用 37     徽标 36
  11/12、99/99       264 → 306   side 53   可用 44     徽标 42
  123/456            264 → 334   side 67   可用 58     徽标 54
```

另外确认了 `apps/desktop/native/agent-island/` 下没有其它同类的固定宽度数字徽标
（`grep 'Text("\('` 只命中本次改到的两处）。

### 手工验证

不涉及 —— 见「未执行的验证」。

### 未执行的验证

- 实机目检未做：需要同时存在 10 个以上运行中会话才能自然触发该状态，本次以离屏渲染
  harness 代替，未在真实灵动岛上目检。
- 刻痕机（有 hardware notch 的 MacBook）未实机验证：本机无刻痕屏。notch 布局分支通过离屏
  harness 还原（照搬生产代码里的 `sideWidth`、`hardwareNotchSideInset`、
  `defaultCompactWidth` 公式）并做数值断言，未在真机上目检宽度变化的动画表现。
- `persistedCompactContentWidth` 位于 Swift 侧，仓库没有接入 Swift 测试框架，只做了 harness
  数值验证（见「自动验证」），未实机走一遍「拖到吸附位 → 计数变化 → 重启」的完整持久化回路。
- 把岛移离刻痕（`hardwareNotchLayoutEnabled` 变 false）时的持久化行为，同样只做了代码路径核对
  与门控，未实机拖动验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：灵动岛的 native SwiftUI 布局，以及 main 进程侧只服务于灵动岛的宽度计算
  （`shared/agentIsland.ts` 的灵动岛宽度函数 + `agent-island/service.ts` 的 frame 计算）。
  改动的 TS 函数只有灵动岛这一条调用链（已确认无其它调用点），新增参数为可选，不传时行为与
  旧实现完全一致。native helper 由 main 进程在运行时用 `swiftc` 编译
  （`MacAgentIslandNativeHost.ts`），不进入 mobile runtime fingerprint，不涉及 OTA / 冷更；
  Windows 及其它平台没有灵动岛 native 实现，`hasNotch` 分支也不会命中，不受影响。
- 刻痕机用户会看到默认灵动岛宽度随并发会话徽标位数变化（详见「用户可见变化」）。灵动岛本身
  已有宽度吸附与过渡动画，`snappedCompactHardwareWidth` 的吸附点同步用了同一预留量，因此拖拽
  吸附与默认宽度保持一致。
- 回滚 / 降级方式：六个 commit 都只动灵动岛相关文件（native helper + `shared/agentIsland.ts`
  + `agent-island/service.ts` + 新增测试），`git revert` 即可，无数据或状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：缺陷修复，无新增行为或规则）
- [x] 已确认测试结果或说明未执行原因
