### PR TITLE
fix(desktop): surface custom provider key save failures

### DIFF
--- a/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
@@ -1,12 +1,79 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   appendDiscoveredCustomProviderModels,
+  createCustomProvider,
   customProviderModelConfigFromCatalogModel,
   providerViewToCustomProviderConfig,
   replaceCustomProviderModelId,
+  updateCustomProvider,
 } from '../customProviders';
-import type { ProviderView } from '@cindy/model-providers';
+import type { CustomProviderConfig, ProviderView } from '@cindy/model-providers';
+
+const createCustomProviderMock = vi.fn();
+const updateCustomProviderMock = vi.fn();
+const safeStorageStoreMock = vi.fn();
+
+const customProviderConfig = {
+  id: 'test-provider',
+  name: 'Test Provider',
+  runtimes: {
+    codex: {
+      baseUrl: 'https://example.com/v1',
+      models: [{ id: 'test-model', name: 'Test Model' }],
+    },
+  },
+} satisfies CustomProviderConfig;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('window', {
+    electronAPI: {
+      maker: {
+        createCustomProvider: createCustomProviderMock,
+        updateCustomProvider: updateCustomProviderMock,
+      },
+      safeStorageStore: safeStorageStoreMock,
+    },
+  });
+  createCustomProviderMock.mockResolvedValue(undefined);
+  updateCustomProviderMock.mockResolvedValue(undefined);
+  safeStorageStoreMock.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('custom provider key persistence', () => {
+  it('rejects create when safe storage reports that the key was not stored', async () => {
+    safeStorageStoreMock.mockResolvedValue(false);
+
+    await expect(
+      createCustomProvider(customProviderConfig, { codex: 'test-key' }),
+    ).rejects.toThrow('Failed to securely store the API key for codex.');
+
+    expect(createCustomProviderMock).toHaveBeenCalledWith(customProviderConfig);
+    expect(safeStorageStoreMock).toHaveBeenCalledWith(
+      'provider_key_test-provider_codex',
+      'test-key',
+    );
+  });
+
+  it('rejects update when safe storage reports that the key was not stored', async () => {
+    safeStorageStoreMock.mockResolvedValue(false);
+
+    await expect(
+      updateCustomProvider(customProviderConfig, { codex: 'replacement-key' }),
+    ).rejects.toThrow('Failed to securely store the API key for codex.');
+
+    expect(updateCustomProviderMock).toHaveBeenCalledWith(customProviderConfig);
+    expect(safeStorageStoreMock).toHaveBeenCalledWith(
+      'provider_key_test-provider_codex',
+      'replacement-key',
+    );
+  });
+});
 
 describe('replaceCustomProviderModelId', () => {
   it('drops hidden metadata when the model id changes', () => {

--- a/apps/desktop/src/renderer/lib/customProviders.ts
+++ b/apps/desktop/src/renderer/lib/customProviders.ts
@@ -124,7 +124,13 @@ async function saveKeys(providerId: string, keys: RuntimeKeys): Promise<void> {
   for (const agent of ALL_AGENTS) {
     const key = keys[agent]?.trim();
     if (key) {
-      await window.electronAPI.safeStorageStore(customProviderSecretStorageKey(providerId, agent), key);
+      const stored = await window.electronAPI.safeStorageStore(
+        customProviderSecretStorageKey(providerId, agent),
+        key,
+      );
+      if (!stored) {
+        throw new Error(`Failed to securely store the API key for ${agent}.`);
+      }
     }
   }
 }


### PR DESCRIPTION
> 已关闭：当前 `main` 已采用更强的 main-process 原子凭证提交方案，配置与密钥通过同一 per-provider queue 暂存/回滚。本 PR 的 renderer 两步写入已被覆盖，继续合并反而会退回可能部分提交的实现。

## 这次改了什么

### 摘要

自定义模型供应商保存 API key 时，`safeStorageStore` 会用 `false` 表示系统安全存储不可用。原实现忽略了这个返回值，仍继续显示创建或更新成功，导致用户只会在后续请求中看到鉴权失败。

本 PR 检查实际存储结果，并在 key 未落盘时让创建/更新流程进入现有的保存失败处理。新增回归测试覆盖 create 和 update 两条路径。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：自定义供应商 API key 安全存储失败的错误传播；create/update 回归测试
- 明确不包含：密钥存储格式、供应商配置结构、模型路由与 UI 布局调整
- 用户可见变化：安全存储不可用时不再误报创建/更新成功，而是显示现有的保存失败提示并允许重试
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修正现有保存流程的失败分支，不修改 UI 布局、交互或文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/customProviders.test.ts
结果：1 file passed，9 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：仓库 runner tests 通过（297 passed，1 skipped）；所有 required unit workspaces 通过

pnpm check:dco
结果：1 commit signed off
```

### 手工验证

macOS 本地开发版中创建自定义供应商，并分别通过 Claude Code 与 Codex runtime 发起真实模型会话；两条正常存储路径均成功。

### 未执行的验证

未在系统安全存储真实不可用的主机上手工验证；该失败分支通过 mock `safeStorageStore(false)` 的 create/update 回归测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅自定义模型供应商在提交非空 API key 时的安全存储结果处理；成功路径不变
- 回滚 / 降级方式：回滚本提交即可恢复原行为；不涉及数据迁移或持久化结构变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
