### PR TITLE
fix(desktop): 隐藏浏览器标签延迟创建 WebView

### DIFF
--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
@@ -27,12 +27,25 @@ interface MockWebview {
 
 let mockWebview: MockWebview;
 
+type MockPoolEntry = {
+  wrapper: HTMLDivElement;
+  webview: MockWebview;
+  guestFailure: null | {
+    kind: 'render-process-gone' | 'unresponsive';
+    reason: string;
+  };
+};
+
 const poolMocks = vi.hoisted(() => ({
   releaseListeners: new Set<(tabId: string) => void>(),
-  currentEntry: null as { wrapper: HTMLDivElement; webview: MockWebview } | null,
+  entryCreatedListeners: new Set<(tabId: string) => void>(),
+  currentEntry: null as MockPoolEntry | null,
   fireRelease(tabId: string) {
     this.currentEntry = null;
     for (const cb of [...this.releaseListeners]) cb(tabId);
+  },
+  fireEntryCreated(tabId: string) {
+    for (const cb of [...this.entryCreatedListeners]) cb(tabId);
   },
 }));
 
@@ -44,17 +57,24 @@ const bridgeMocks = vi.hoisted(() => ({
 vi.mock('../../lib/browserWebviewPool', () => ({
   browserWebviewPool: {
     acquire: vi.fn(() => {
-      const entry = poolMocks.currentEntry ?? {
+      if (poolMocks.currentEntry) return poolMocks.currentEntry;
+      const entry: MockPoolEntry = {
         wrapper: document.createElement('div'),
         webview: mockWebview,
+        guestFailure: null,
       };
       poolMocks.currentEntry = entry;
+      poolMocks.fireEntryCreated('tab-a');
       return entry;
     }),
     peek: vi.fn(() => poolMocks.currentEntry),
     onRelease: vi.fn((cb: (tabId: string) => void) => {
       poolMocks.releaseListeners.add(cb);
       return () => poolMocks.releaseListeners.delete(cb);
+    }),
+    onEntryCreated: vi.fn((cb: (tabId: string) => void) => {
+      poolMocks.entryCreatedListeners.add(cb);
+      return () => poolMocks.entryCreatedListeners.delete(cb);
     }),
   },
 }));
@@ -125,6 +145,7 @@ describe('useBrowserWebview', () => {
     cleanup();
     vi.clearAllMocks();
     poolMocks.releaseListeners.clear();
+    poolMocks.entryCreatedListeners.clear();
     bridgeMocks.resourceCb = null;
   });
 
@@ -156,6 +177,63 @@ describe('useBrowserWebview', () => {
 
     expect(acquire).toHaveBeenCalledTimes(1);
     expect(result!.wrapper).not.toBeNull();
+  });
+
+  it('touches an existing entry through acquire when it becomes visible', async () => {
+    const { browserWebviewPool } = await import('../../lib/browserWebviewPool');
+    const existing: MockPoolEntry = {
+      wrapper: document.createElement('div'),
+      webview: mockWebview,
+      guestFailure: null,
+    };
+    poolMocks.currentEntry = existing;
+    let result: UseBrowserWebviewResult | null = null;
+
+    render(createElement(HookProbe, {
+      visible: true,
+      onResult: (next) => { result = next; },
+    }));
+
+    expect(browserWebviewPool.acquire).toHaveBeenCalledOnce();
+    expect(result!.wrapper).toBe(existing.wrapper);
+  });
+
+  it('observes an entry explicitly created while hidden without navigating it', async () => {
+    const { browserWebviewPool } = await import('../../lib/browserWebviewPool');
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: false,
+      onResult: (next) => { result = next; },
+    }));
+
+    act(() => {
+      browserWebviewPool.acquire('tab-a');
+    });
+
+    expect(browserWebviewPool.acquire).toHaveBeenCalledOnce();
+    expect(result!.wrapper).toBeNull();
+    expect(mockWebview.addEventListener).toHaveBeenCalledWith(
+      'render-process-gone',
+      expect.any(Function),
+    );
+    expect(mockWebview.loadURL).not.toHaveBeenCalled();
+  });
+
+  it('restores a guest crash captured before hidden hook listeners bind', async () => {
+    const { browserWebviewPool } = await import('../../lib/browserWebviewPool');
+    bridgeMocks.consumePendingKillCause.mockReturnValueOnce('memory');
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: false,
+      onResult: (next) => { result = next; },
+    }));
+
+    act(() => {
+      const entry = browserWebviewPool.acquire('tab-a');
+      entry.guestFailure = { kind: 'render-process-gone', reason: 'killed' };
+    });
+
+    expect(result!.crash).toEqual({ reason: 'killed', cause: 'resource-memory' });
   });
 
   it('restores the real webview URL when an optimistic navigation is aborted', () => {
@@ -241,6 +319,13 @@ describe('useBrowserWebview', () => {
     expect(acquire).toHaveBeenCalledTimes(1);
     const firstWrapper = result!.wrapper;
 
+    act(() => {
+      for (let i = 0; i <= BROWSER_NAVIGATION_FUSE_LIMIT; i += 1) {
+        result!.navigate(`https://example.com/old-${i}`);
+      }
+    });
+    expect(result!.crash).toEqual({ reason: 'navigation-loop' });
+
     view.rerender(
       createElement(HookProbe, { visible: false, onResult: (next) => { result = next; } }),
     );
@@ -258,6 +343,9 @@ describe('useBrowserWebview', () => {
     expect(result!.wrapper).not.toBe(firstWrapper);
     expect(result!.url).toBe('');
     expect(result!.crash).toBeNull();
+
+    act(() => result!.navigate('https://example.com/replacement'));
+    expect(mockWebview.loadURL).toHaveBeenCalledWith('https://example.com/replacement');
   });
 
   it('does not re-acquire when a foreign tab is released', async () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
@@ -29,7 +29,9 @@ let mockWebview: MockWebview;
 
 const poolMocks = vi.hoisted(() => ({
   releaseListeners: new Set<(tabId: string) => void>(),
+  currentEntry: null as { wrapper: HTMLDivElement; webview: MockWebview } | null,
   fireRelease(tabId: string) {
+    this.currentEntry = null;
     for (const cb of [...this.releaseListeners]) cb(tabId);
   },
 }));
@@ -41,10 +43,15 @@ const bridgeMocks = vi.hoisted(() => ({
 
 vi.mock('../../lib/browserWebviewPool', () => ({
   browserWebviewPool: {
-    acquire: vi.fn(() => ({
-      wrapper: document.createElement('div'),
-      webview: mockWebview,
-    })),
+    acquire: vi.fn(() => {
+      const entry = poolMocks.currentEntry ?? {
+        wrapper: document.createElement('div'),
+        webview: mockWebview,
+      };
+      poolMocks.currentEntry = entry;
+      return entry;
+    }),
+    peek: vi.fn(() => poolMocks.currentEntry),
     onRelease: vi.fn((cb: (tabId: string) => void) => {
       poolMocks.releaseListeners.add(cb);
       return () => poolMocks.releaseListeners.delete(cb);
@@ -111,6 +118,7 @@ function HookProbe({
 describe('useBrowserWebview', () => {
   beforeEach(() => {
     mockWebview = makeMockWebview('https://www.taptap.cn/');
+    poolMocks.currentEntry = null;
   });
 
   afterEach(() => {
@@ -120,13 +128,43 @@ describe('useBrowserWebview', () => {
     bridgeMocks.resourceCb = null;
   });
 
+  it('does not materialize a tab without explicit visibility', async () => {
+    const { browserWebviewPool } = await import('../../lib/browserWebviewPool');
+    const acquire = vi.mocked(browserWebviewPool.acquire);
+    let result: UseBrowserWebviewResult | null = null;
+
+    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+
+    expect(acquire).not.toHaveBeenCalled();
+    expect(result!.wrapper).toBeNull();
+  });
+
+  it('does not materialize a hidden tab until it becomes visible', async () => {
+    const { browserWebviewPool } = await import('../../lib/browserWebviewPool');
+    const acquire = vi.mocked(browserWebviewPool.acquire);
+    let result: UseBrowserWebviewResult | null = null;
+    const view = render(
+      createElement(HookProbe, { visible: false, onResult: (next) => { result = next; } }),
+    );
+
+    expect(acquire).not.toHaveBeenCalled();
+    expect(result!.wrapper).toBeNull();
+
+    view.rerender(
+      createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }),
+    );
+
+    expect(acquire).toHaveBeenCalledTimes(1);
+    expect(result!.wrapper).not.toBeNull();
+  });
+
   it('restores the real webview URL when an optimistic navigation is aborted', () => {
     let result: UseBrowserWebviewResult | null = null;
     const current = () => {
       if (result === null) throw new Error('hook result was not captured');
       return result;
     };
-    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+    render(createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }));
 
     expect(current().url).toBe('https://www.taptap.cn/');
 
@@ -149,7 +187,7 @@ describe('useBrowserWebview', () => {
       if (result === null) throw new Error('hook result was not captured');
       return result;
     };
-    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+    render(createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }));
 
     act(() => {
       mockWebview.dispatch('did-redirect-navigation', {
@@ -172,7 +210,7 @@ describe('useBrowserWebview', () => {
       if (result === null) throw new Error('hook result was not captured');
       return result;
     };
-    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+    render(createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }));
 
     act(() => {
       for (let i = 0; i <= BROWSER_NAVIGATION_FUSE_LIMIT; i += 1) {
@@ -198,10 +236,14 @@ describe('useBrowserWebview', () => {
     const acquire = vi.mocked(browserWebviewPool.acquire);
     let result: UseBrowserWebviewResult | null = null;
     const view = render(
-      createElement(HookProbe, { visible: false, onResult: (next) => { result = next; } }),
+      createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }),
     );
     expect(acquire).toHaveBeenCalledTimes(1);
     const firstWrapper = result!.wrapper;
+
+    view.rerender(
+      createElement(HookProbe, { visible: false, onResult: (next) => { result = next; } }),
+    );
 
     // 后台淘汰(资源看门狗 / LRU):entry 被 release,不可见期间不得重建。
     act(() => poolMocks.fireRelease('tab-a'));
@@ -229,7 +271,7 @@ describe('useBrowserWebview', () => {
 
   it('marks a watchdog kill as resource-memory when the notice arrived first', () => {
     let result: UseBrowserWebviewResult | null = null;
-    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+    render(createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }));
 
     bridgeMocks.consumePendingKillCause.mockReturnValueOnce('memory');
     act(() => {
@@ -240,7 +282,7 @@ describe('useBrowserWebview', () => {
 
   it('upgrades the crash when gone + late notice land in the same React batch', () => {
     let result: UseBrowserWebviewResult | null = null;
-    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+    render(createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }));
 
     // 两个事件在同一次 act(同一批,React 尚未 commit)内先后到达 ——
     // 订阅回调必须能看到 crash 已发生(靠同步写 ref,不能等渲染期镜像)。
@@ -253,7 +295,7 @@ describe('useBrowserWebview', () => {
 
   it('upgrades an existing crash on a late kill-notice and consumes the pending cause', () => {
     let result: UseBrowserWebviewResult | null = null;
-    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+    render(createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }));
 
     // crash 事件先到:此时还没有 pending cause,banner 是笼统的 killed。
     act(() => {
@@ -272,7 +314,7 @@ describe('useBrowserWebview', () => {
 
   it('shows and dismisses the cpu resource alert', () => {
     let result: UseBrowserWebviewResult | null = null;
-    render(createElement(HookProbe, { onResult: (next) => { result = next; } }));
+    render(createElement(HookProbe, { visible: true, onResult: (next) => { result = next; } }));
 
     act(() => {
       bridgeMocks.resourceCb?.({ tabId: 'tab-a', kind: 'cpu-alert', cpuPercent: 95 });

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
@@ -95,10 +95,9 @@ export interface UseBrowserWebviewResult {
 
 /**
  * @param visible 本 tab 当前是否真的展示给用户(active && shellVisible)。
- *   用于"淘汰后重建":资源看门狗 / LRU 淘汰会销毁后台 tab 的 pool entry,而
- *   Shell 常驻挂载所有 TabBody(不卸载),acquire effect 不会自然重跑 —— 这里
- *   监听 pool release,等 tab 重新可见时 bump epoch 重新 acquire,否则用户切回
- *   被淘汰的 tab 会看到空壳。不可见期间保持懒惰,不为看不见的 tab 重建 webview。
+ *   用于"淘汰后重建":资源看门狗 / LRU 淘汰会销毁 pool entry。可见 tab 被
+ *   release 时由通知重跑 acquire；后台 tab 切回可见时由 visible 变化自然重跑。
+ *   不可见期间保持懒惰,不为看不见的 tab 重建 webview。
  */
 export function useBrowserWebview(
   tabId: string,
@@ -128,33 +127,36 @@ export function useBrowserWebview(
   // 需要读当前 crash 值来决定升级 / 挂起,useState 闭包会 stale,走 ref。
   const crashRef = useRef(crash);
   crashRef.current = crash;
-  // 淘汰后重建:entry 被 pool release 后置位;tab 重新可见时 bump epoch 让
-  // acquire effect 重跑(见函数头注释)。
+  // Pool 生命周期通知触发 effect 重跑：可见 entry 被释放，或隐藏 hook 需要
+  // 观察 Agent 后续显式创建的 entry。
   const [entryEpoch, setEntryEpoch] = useState(0);
-  const releasedRef = useRef(false);
   const visibleRef = useRef(visible === true);
   visibleRef.current = visible === true;
 
   useEffect(() => {
-    const unsub = browserWebviewPool.onRelease((releasedTabId) => {
+    const unsubRelease = browserWebviewPool.onRelease((releasedTabId) => {
       if (releasedTabId !== tabId) return;
+      // 已释放的 wrapper 不再属于 Pool，先撤销发布，避免下一次渲染把旧代际
+      // 重新接回 DOM。webviewRef 保留到新 entry 到来，用于识别代际并复位状态。
+      setWrapper(null);
       // 可见中被 release(理论上只有用户关 tab —— 此时本组件即将 unmount,
       // bump 一次也无害);不可见的淘汰恢复推迟到重新可见。
       if (visibleRef.current) {
         setEntryEpoch((e) => e + 1);
-      } else {
-        releasedRef.current = true;
       }
     });
-    return unsub;
+    const unsubEntryCreated = browserWebviewPool.onEntryCreated((createdTabId) => {
+      if (createdTabId !== tabId || visibleRef.current) return;
+      // Agent open / ensure 可显式为隐藏 tab 创建 entry。当前 effect 之前因 entry
+      // 不存在而没有监听 webview；通知后只绑定观察，不改变可见性或主动导航。
+      setEntryEpoch((e) => e + 1);
+    });
+    return () => {
+      unsubRelease();
+      unsubEntryCreated();
+    };
   }, [tabId]);
 
-  useEffect(() => {
-    if (visible && releasedRef.current) {
-      releasedRef.current = false;
-      setEntryEpoch((e) => e + 1);
-    }
-  }, [visible]);
   const setObservedUrl = useCallback((nextUrl: string) => {
     const suppress = suppressStaleUrlRef.current;
     if (suppress) {
@@ -176,8 +178,16 @@ export function useBrowserWebview(
     // 物化 webview，避免恢复会话就在后台加载持久化 URL。
     const existing = browserWebviewPool.peek(tabId);
     if (!existing && visible !== true) return;
-    const entry = existing ?? browserWebviewPool.acquire(tabId);
-    if (webviewRef.current && webviewRef.current !== entry.webview) {
+    // 可见意味着一次真实访问，必须走 acquire() 更新 LRU；隐藏时只 peek，避免
+    // Agent 显式创建的后台 entry 因 hook 观察而被误算成用户访问。
+    const entry = visible === true ? browserWebviewPool.acquire(tabId) : existing;
+    if (!entry) return;
+    const observingNewWebview = webviewRef.current !== entry.webview;
+    if (observingNewWebview) {
+      navigationAttemptsRef.current = [];
+      navigationFuseTrippedRef.current = false;
+    }
+    if (webviewRef.current && observingNewWebview) {
       // 重新物化(淘汰后再激活):上一代 webview 的观测 state 全部失效。复位为
       // 空值,让 BrowserTabBody 的"按 wrapper 代际"首次导航重新驱动加载,否则
       // stale url 会让导航判定"已在目标页"而跳过。
@@ -190,11 +200,24 @@ export function useBrowserWebview(
       setCanGoBack(false);
       setCanGoForward(false);
       setIsAudible(false);
+      crashRef.current = null;
       setCrash(null);
       setResourceAlert(null);
     }
     webviewRef.current = entry.webview;
     setWrapper(entry.wrapper);
+
+    if (observingNewWebview && entry.guestFailure) {
+      const cause = entry.guestFailure.kind === 'render-process-gone'
+        ? consumePendingKillCause(tabId)
+        : null;
+      const restored = {
+        reason: entry.guestFailure.reason,
+        ...(cause === 'memory' ? { cause: 'resource-memory' as const } : {}),
+      };
+      crashRef.current = restored;
+      setCrash(restored);
+    }
 
     // canGoBack/Forward 不是 event 字段,得在每次导航后主动查 —— webview API
     // 提供 `canGoBack()` / `canGoForward()` 同步方法。
@@ -432,7 +455,9 @@ export function useBrowserWebview(
   const dismissResourceAlert = useCallback(() => setResourceAlert(null), []);
 
   return {
-    wrapper,
+    // 隐藏时仍观察已有 entry 的 guest 生命周期，但不把 wrapper 交给 caller，
+    // 避免隐藏 Body 把它移出停车区并触发首次导航。
+    wrapper: visible === true ? wrapper : null,
     url,
     title,
     favicon,

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
@@ -172,7 +172,11 @@ export function useBrowserWebview(
   }, []);
 
   useEffect(() => {
-    const entry = browserWebviewPool.acquire(tabId);
+    // Shell 会常驻挂载所有 TabBody；没有明确可见时，只复用已有 entry，不首次
+    // 物化 webview，避免恢复会话就在后台加载持久化 URL。
+    const existing = browserWebviewPool.peek(tabId);
+    if (!existing && visible !== true) return;
+    const entry = existing ?? browserWebviewPool.acquire(tabId);
     if (webviewRef.current && webviewRef.current !== entry.webview) {
       // 重新物化(淘汰后再激活):上一代 webview 的观测 state 全部失效。复位为
       // 空值,让 BrowserTabBody 的"按 wrapper 代际"首次导航重新驱动加载,否则
@@ -369,7 +373,7 @@ export function useBrowserWebview(
       // **不**释放 pool entry —— webview DOM 节点继续保活,切回该 tab 时可直接
       // 复用。释放是 plugin 在用户主动关闭 tab 时显式调 pool.release(tabId)。
     };
-  }, [tabId, sessionId, setObservedUrl, entryEpoch]);
+  }, [tabId, sessionId, setObservedUrl, entryEpoch, visible]);
 
   const navigate = useCallback((nextUrl: string) => {
     const wv = webviewRef.current;

--- a/apps/desktop/src/renderer/features/right-sidebar/lib/__tests__/browserWebviewPool.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/lib/__tests__/browserWebviewPool.test.ts
@@ -43,6 +43,36 @@ describe('browserWebviewPool', () => {
     expect(a2.webview).toBe(a1.webview);
   });
 
+  it('notifies only when a new entry is created', () => {
+    const onEntryCreated = vi.fn();
+    const unsub = browserWebviewPool.onEntryCreated(onEntryCreated);
+
+    browserWebviewPool.acquire('tab-a');
+    browserWebviewPool.acquire('tab-a');
+
+    expect(onEntryCreated).toHaveBeenCalledOnce();
+    expect(onEntryCreated).toHaveBeenCalledWith('tab-a');
+    unsub();
+  });
+
+  it('captures guest failure before hook listeners bind and clears it on recovery', () => {
+    const entry = browserWebviewPool.acquire('tab-a');
+    const gone = new Event('render-process-gone');
+    Object.defineProperty(gone, 'details', { value: { reason: 'crashed' } });
+
+    entry.webview.dispatchEvent(gone);
+    expect(entry.guestFailure).toEqual({ kind: 'render-process-gone', reason: 'crashed' });
+
+    entry.webview.dispatchEvent(new Event('did-start-loading'));
+    expect(entry.guestFailure).toBeNull();
+
+    entry.webview.dispatchEvent(new Event('unresponsive'));
+    expect(entry.guestFailure).toEqual({ kind: 'unresponsive', reason: 'unresponsive' });
+
+    entry.webview.dispatchEvent(new Event('responsive'));
+    expect(entry.guestFailure).toBeNull();
+  });
+
   it('creates webviews with allowpopups so main can route popups into tabs', () => {
     const entry = browserWebviewPool.acquire('tab-a');
     expect(entry.webview.getAttribute('allowpopups')).toBe('true');
@@ -196,8 +226,11 @@ describe('browserWebviewPool', () => {
     browserWebviewPool.onPinChange(() => {
       throw new Error('pin listener exploded');
     });
-    browserWebviewPool.acquire('tab-a');
+    browserWebviewPool.onEntryCreated(() => {
+      throw new Error('entry-created listener exploded');
+    });
 
+    expect(() => browserWebviewPool.acquire('tab-a')).not.toThrow();
     expect(() => browserWebviewPool.pinForAutomation('tab-a')).not.toThrow();
     expect(() => browserWebviewPool.release('tab-a')).not.toThrow();
     expect(browserWebviewPool.peek('tab-a')).toBeNull();
@@ -205,12 +238,16 @@ describe('browserWebviewPool', () => {
 
   it('unsubscribe removes the listener', () => {
     const onRelease = vi.fn();
-    const unsub = browserWebviewPool.onRelease(onRelease);
-    unsub();
+    const onEntryCreated = vi.fn();
+    const unsubRelease = browserWebviewPool.onRelease(onRelease);
+    const unsubEntryCreated = browserWebviewPool.onEntryCreated(onEntryCreated);
+    unsubRelease();
+    unsubEntryCreated();
 
     browserWebviewPool.acquire('tab-a');
     browserWebviewPool.release('tab-a');
 
     expect(onRelease).not.toHaveBeenCalled();
+    expect(onEntryCreated).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/lib/browserWebviewPool.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/lib/browserWebviewPool.ts
@@ -32,6 +32,10 @@ import type { WebviewTag } from 'electron';
 
 import { BROWSER_PARTITION } from './browserPartition';
 
+export type BrowserWebviewGuestFailure =
+  | { kind: 'render-process-gone'; reason: string }
+  | { kind: 'unresponsive'; reason: 'unresponsive' };
+
 interface PoolEntry {
   tabId: string;
   /** webview 的外层 wrapper 容器,LRU 在它身上(caller 把它 appendChild 到自己
@@ -42,6 +46,8 @@ interface PoolEntry {
   /** 单调递增计数,LRU 用 —— 越大越新,淘汰挑最小那个。比 Date.now() 不依赖
    *  系统时钟,且能区分同帧多次访问。 */
   lastAccess: number;
+  /** Pool 创建 webview 后立即记录 guest 故障，避免 React hook 尚未绑定时丢事件。 */
+  guestFailure: BrowserWebviewGuestFailure | null;
 }
 
 const POOL_CAPACITY = 5;
@@ -126,15 +132,18 @@ class BrowserWebviewPoolImpl {
     // webview 元素自身透明 —— 灰底兜底交给 wrapper 处理(见上方注释)。
     webview.setAttribute('style', 'flex:1;width:100%;height:100%;');
     wrapper.appendChild(webview);
-    container.appendChild(wrapper);
 
     const entry: PoolEntry = {
       tabId,
       wrapper,
       webview,
       lastAccess: ++this.accessCounter,
+      guestFailure: null,
     };
+    this.observeGuestLifecycle(entry);
+    container.appendChild(wrapper);
     this.entries.set(tabId, entry);
+    this.fireEntryCreated(tabId);
     return entry;
   }
 
@@ -216,6 +225,47 @@ class BrowserWebviewPoolImpl {
   }
 
   /**
+   * 订阅新 entry 创建。Shell 中已挂载但隐藏的 hook 用它观察 Agent 显式创建的
+   * webview；命中已有 entry 的 acquire 不触发。
+   */
+  onEntryCreated(listener: (tabId: string) => void): () => void {
+    this.entryCreatedListeners.add(listener);
+    return () => {
+      this.entryCreatedListeners.delete(listener);
+    };
+  }
+
+  /**
+   * guest 生命周期监听必须在 wrapper 接入 document 前安装。Agent 可以在隐藏 tab
+   * 上显式创建并立即驱动 webview；React hook 收到 entry-created 后才会重新绑定，
+   * 这段间隙内的崩溃 / 卡死状态由 entry 暂存。
+   */
+  private observeGuestLifecycle(entry: PoolEntry): void {
+    const onRenderProcessGone = (event: Electron.RenderProcessGoneEvent) => {
+      entry.guestFailure = {
+        kind: 'render-process-gone',
+        reason: event.details.reason,
+      };
+    };
+    const onUnresponsive = () => {
+      entry.guestFailure = { kind: 'unresponsive', reason: 'unresponsive' };
+    };
+    const onResponsive = () => {
+      if (entry.guestFailure?.kind === 'unresponsive') {
+        entry.guestFailure = null;
+      }
+    };
+    const onStartLoading = () => {
+      entry.guestFailure = null;
+    };
+
+    entry.webview.addEventListener('render-process-gone', onRenderProcessGone);
+    entry.webview.addEventListener('unresponsive', onUnresponsive);
+    entry.webview.addEventListener('responsive', onResponsive);
+    entry.webview.addEventListener('did-start-loading', onStartLoading);
+  }
+
+  /**
    * LRU 淘汰 —— 内部用。优先挑最旧的**未 pinned** entry。如果所有 entry 都
    * pinned,fallback 到挑最旧的(capacity 限制比 pin 更高优先级);理论上不会
    * 发生(pin 数远小于 POOL_CAPACITY),fallback 是防御式兜底,触发时:
@@ -239,6 +289,7 @@ class BrowserWebviewPoolImpl {
 
   private pinListeners = new Set<(tabId: string, pinned: boolean) => void>();
   private releaseListeners = new Set<(tabId: string) => void>();
+  private entryCreatedListeners = new Set<(tabId: string) => void>();
 
   private firePinChange(tabId: string, pinned: boolean): void {
     for (const l of this.pinListeners) {
@@ -256,6 +307,16 @@ class BrowserWebviewPoolImpl {
         l(tabId);
       } catch {
         // listener throw must not stop the pool from advancing
+      }
+    }
+  }
+
+  private fireEntryCreated(tabId: string): void {
+    for (const l of this.entryCreatedListeners) {
+      try {
+        l(tabId);
+      } catch {
+        // listener throw must not break entry creation
       }
     }
   }

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
@@ -107,11 +107,15 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
   useLayoutEffect(() => {
     const slot = slotRef.current;
     const wrapper = browser.wrapper;
-    if (!slot || !wrapper) return;
+    if (!tabVisible || !slot || !wrapper) return;
     slot.appendChild(wrapper);
     return () => {
-      // pool 的 ensureContainer 仍然在,把 wrapper 挪回去。即使 pool container
-      // 被外部清掉(理论上不会发生),wrapper.remove() 也无害。
+      // release / LRU 淘汰后的旧 wrapper 已不再属于 Pool，不能因 React effect
+      // cleanup 被重新接回 DOM；只有当前代际仍归 Pool 持有时才停回停车区。
+      if (browserWebviewPool.peek(tabId)?.wrapper !== wrapper) {
+        wrapper.remove();
+        return;
+      }
       const parking = document.getElementById('browser-webview-pool');
       if (parking) {
         parking.appendChild(wrapper);
@@ -119,7 +123,7 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
         wrapper.remove();
       }
     };
-  }, [browser.wrapper]);
+  }, [browser.wrapper, tabId, tabVisible]);
 
   // hook 事件 → patchState。注意 onPatchState 引用稳定,这里只在 url / title /
   // favicon 真实改变(由 webview 推上来)时才写回,不会无限循环。
@@ -174,7 +178,7 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
   // 是空的,必须重新用持久化 URL 驱动一次加载(review P1:淘汰后空壳)。
   useEffect(() => {
     const wrapper = browser.wrapper;
-    if (!wrapper || lastNavigatedWrapperRef.current === wrapper) return;
+    if (!tabVisible || !wrapper || lastNavigatedWrapperRef.current === wrapper) return;
     lastNavigatedWrapperRef.current = wrapper;
     const nextUrl = stateUrlRef.current || 'about:blank';
     const currentUrl = browserUrlRef.current;
@@ -182,7 +186,7 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
     // about:blank 默认状态下也要 navigate,确保 webview 真的处于 about:blank,
     // 不会停留在 pool 创建时未 setAttribute('src') 的"未初始化"状态。
     navigateRef.current(nextUrl);
-  }, [tabId, browser.wrapper]);
+  }, [tabId, browser.wrapper, tabVisible]);
 
   const reloadRef = useRef(browser.reload);
   const goBackRef = useRef(browser.goBack);

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
@@ -11,6 +11,10 @@ import { BrowserTabBody } from '../BrowserTabBody';
 const browserNavigate = vi.fn();
 let browserState: UseBrowserWebviewResult;
 
+const poolMocks = vi.hoisted(() => ({
+  currentWrapper: null as HTMLDivElement | null,
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -25,8 +29,10 @@ vi.mock('../../../lib/browserWebviewPool', () => ({
   browserWebviewPool: {
     release: vi.fn(),
     // useBrowserComment 经 peek 取 webview 挂 ipc-message 监听;导航测试里没有
-    // 真 webview,返回 null 即可(hook 对 null 全程静默降级)。
-    peek: vi.fn(() => null),
+    // 真 webview。wrapper 仅用于验证 layout cleanup 的 Pool 代际归属。
+    peek: vi.fn(() => poolMocks.currentWrapper
+      ? { wrapper: poolMocks.currentWrapper, webview: null }
+      : null),
   },
 }));
 
@@ -59,7 +65,11 @@ function makeBrowserState(
   };
 }
 
-function renderBrowserTab(stateUrl: string, patchState = vi.fn()): ReactElement {
+function renderBrowserTab(
+  stateUrl: string,
+  patchState = vi.fn(),
+  active = true,
+): ReactElement {
   const ctx: TabKindHostContext = {
     tabId: 'tab-browser',
     sessionId: 'session-a',
@@ -70,7 +80,7 @@ function renderBrowserTab(stateUrl: string, patchState = vi.fn()): ReactElement 
     setCloseInterceptor: vi.fn(() => () => undefined),
   };
   return createElement(BrowserTabBody, {
-    active: true,
+    active,
     ctx,
     state: {
       url: stateUrl,
@@ -95,8 +105,57 @@ describe('BrowserTabBody navigation', () => {
 
   afterEach(() => {
     cleanup();
+    poolMocks.currentWrapper = null;
+    document.getElementById('browser-webview-pool')?.remove();
     vi.clearAllMocks();
     browserState = makeBrowserState();
+  });
+
+  it('keeps an eagerly created hidden wrapper parked without navigating', () => {
+    const parking = document.createElement('div');
+    parking.id = 'browser-webview-pool';
+    document.body.appendChild(parking);
+    parking.appendChild(sharedWrapper);
+    poolMocks.currentWrapper = sharedWrapper;
+    browserState = makeBrowserState({ wrapper: sharedWrapper, url: '' });
+
+    const view = render(renderBrowserTab('https://example.com/persisted', vi.fn(), false));
+
+    expect(sharedWrapper.parentElement).toBe(parking);
+    expect(browserNavigate).not.toHaveBeenCalled();
+
+    view.rerender(renderBrowserTab('https://example.com/persisted', vi.fn(), true));
+
+    expect(sharedWrapper.parentElement).not.toBe(parking);
+    expect(browserNavigate).toHaveBeenCalledOnce();
+    expect(browserNavigate).toHaveBeenCalledWith('https://example.com/persisted');
+  });
+
+  it('does not reconnect a released wrapper when a replacement arrives', () => {
+    const parking = document.createElement('div');
+    parking.id = 'browser-webview-pool';
+    document.body.appendChild(parking);
+    parking.appendChild(sharedWrapper);
+    poolMocks.currentWrapper = sharedWrapper;
+    browserState = makeBrowserState({ wrapper: sharedWrapper });
+    const patchState = vi.fn();
+    const view = render(renderBrowserTab('https://www.taptap.cn/', patchState));
+
+    expect(sharedWrapper.isConnected).toBe(true);
+    poolMocks.currentWrapper = null;
+    sharedWrapper.remove();
+    browserState = makeBrowserState({ wrapper: null });
+    view.rerender(renderBrowserTab('https://www.taptap.cn/', patchState));
+
+    const replacement = document.createElement('div');
+    parking.appendChild(replacement);
+    poolMocks.currentWrapper = replacement;
+    browserState = makeBrowserState({ wrapper: replacement, url: '' });
+    view.rerender(renderBrowserTab('https://www.taptap.cn/', patchState));
+
+    expect(sharedWrapper.isConnected).toBe(false);
+    expect(replacement.isConnected).toBe(true);
+    expect(replacement.parentElement).not.toBe(parking);
   });
 
   it('does not patch the old webview URL back over a user-entered navigation while loading', () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
@@ -28,8 +28,9 @@ vi.mock('../../../hooks/useBrowserWebview', () => ({
 vi.mock('../../../lib/browserWebviewPool', () => ({
   browserWebviewPool: {
     release: vi.fn(),
-    // useBrowserComment 经 peek 取 webview 挂 ipc-message 监听;导航测试里没有
-    // 真 webview。wrapper 仅用于验证 layout cleanup 的 Pool 代际归属。
+    // BrowserTabBody 还会调用 useBrowserComment；该 hook 经 peek 获取 webview
+    // 并监听 ipc-message。导航测试没有真 webview，wrapper 仅用于验证 layout
+    // cleanup 的 Pool 代际归属。
     peek: vi.fn(() => poolMocks.currentWrapper
       ? { wrapper: poolMocks.currentWrapper, webview: null }
       : null),


### PR DESCRIPTION
## 问题

右侧栏会常驻挂载一个会话中的全部 TabBody。此前 `useBrowserWebview` 在挂载时无条件调用 `browserWebviewPool.acquire(tabId)`，导致未选中、右侧栏未展开的浏览器标签也会在后台创建 WebView 并加载持久化 URL。

当持久化 URL 是浏览器认为应下载的资源时，仅打开或切换会话就可能触发系统保存框，即使用户没有打开该网页标签。

## 根因

浏览器标签的组件挂载状态不等于用户可见状态，但首次 WebView 物化没有检查 `active && shellVisible`，因此隐藏标签也被恢复加载。

## 修改

- 无已有 entry 且 `visible !== true` 时不创建 WebView；标签明确可见后才允许首次物化。
- 已有 entry 继续复用和保活；切换标签或收起、展开侧栏不会刷新已加载页面。
- 可见 entry 统一通过 `acquire(tabId)` 复用并更新 LRU，避免刚激活的页面被当作旧 entry 淘汰。
- Pool 新增 entry-created 通知，允许常驻挂载的隐藏 hook 观察 Agent `open` / `ensure` 后续显式创建的 WebView。
- Pool 在 WebView 接入 DOM 前记录 `render-process-gone` / `unresponsive`，hook 晚绑定时仍可恢复崩溃状态和资源终止原因。
- 隐藏 entry 保持在停车区，不发布 wrapper、不触发额外导航；释放后的旧 wrapper 不会被 React cleanup 重新接回 DOM。
- 新一代 WebView 会复位上一代的导航熔断状态，同时保留 Agent eager spawn、Pool 容量和现有释放语义。
- 增加 LRU、延迟创建、提前崩溃恢复、隐藏导航、释放代际和熔断复位回归测试。

## 验证

- CN 开发环境手动验证：打开 OAID 会话及从该会话切换到其他会话，不再弹出 POM 保存框；真正选择对应网页标签时仍可正常加载。
- 仓库根 `pnpm test:unit`：通过。
- 右侧栏完整测试：378 项通过。
- WebView 聚焦回归测试：45 项通过。
- Desktop TypeScript typecheck：通过。
- `git diff --check`：通过。
- 最终独立代码复查：未发现剩余的具体正确性问题。

## 复现视频

https://github.com/user-attachments/assets/1497c30f-0dd7-4a20-a44a-d8a79e4c386b

🤖 Generated with [Claude Code](https://claude.com/claude-code)