### PR TITLE
feat(prompt): 注入产品身份锚点并补 about-cindy 能力条目

### DIFF
--- a/apps/desktop/src/main/maker-host/host-system-prompt.md
+++ b/apps/desktop/src/main/maker-host/host-system-prompt.md
@@ -1,0 +1,2 @@
+You are Cindy, an open-source AI assistant.
+Source: https://github.com/makecindy/cindy

--- a/packages/lizi-mcps/src/__tests__/getCapabilitiesTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/getCapabilitiesTool.test.ts
@@ -76,61 +76,70 @@ describe('capabilities data source', () => {
     expect(entry!.detail).toContain('https://github.com/makecindy/cindy');
     // 执行位置不能被写死成客户端:SSH 远程工作区下 agent 进程在远端主机。
     expect(entry!.detail).toContain('SSH 远程工作区');
+    // 官网是区域敏感的:两个都要给,只给国际版会把大陆用户导错。
+    expect(entry!.detail).toContain('https://cindy.cn');
+    expect(entry!.detail).toContain('https://cindy.app');
   });
 });
 
 describe('get_capabilities tool', () => {
   it('不传 key 时返回包含 about-cindy 的索引', async () => {
     const h = await connect(createXdtHelperMcpServer({ logger: makeLogger() }, sessionCtx));
+    try {
+      const payload = parsePayload(
+        await h.client.callTool({
+          name: 'call_tool',
+          arguments: { name: 'get_capabilities', args: {} },
+        }),
+      );
 
-    const payload = parsePayload(
-      await h.client.callTool({ name: 'call_tool', arguments: { name: 'get_capabilities', args: {} } }),
-    );
-
-    expect(payload.ok).toBe(true);
-    const caps = payload.capabilities as Array<{ key: string; detail?: unknown }>;
-    expect(caps.map((c) => c.key)).toContain('about-cindy');
-    // 索引不应该带 detail —— 否则渐进式发现省 token 的意义就没了。
-    expect(caps.every((c) => c.detail === undefined)).toBe(true);
-
-    await h.cleanup();
+      expect(payload.ok).toBe(true);
+      const caps = payload.capabilities as Array<{ key: string; detail?: unknown }>;
+      expect(caps.map((c) => c.key)).toContain('about-cindy');
+      // 索引不应该带 detail —— 否则渐进式发现省 token 的意义就没了。
+      expect(caps.every((c) => c.detail === undefined)).toBe(true);
+    } finally {
+      await h.cleanup();
+    }
   });
 
   it('传 key=about-cindy 时返回 ok 与非空 detail', async () => {
     const h = await connect(createXdtHelperMcpServer({ logger: makeLogger() }, sessionCtx));
+    try {
+      const payload = parsePayload(
+        await h.client.callTool({
+          name: 'call_tool',
+          arguments: { name: 'get_capabilities', args: { key: 'about-cindy' } },
+        }),
+      );
 
-    const payload = parsePayload(
-      await h.client.callTool({
-        name: 'call_tool',
-        arguments: { name: 'get_capabilities', args: { key: 'about-cindy' } },
-      }),
-    );
-
-    expect(payload.ok).toBe(true);
-    const capability = payload.capability as { key: string; detail: string };
-    expect(capability.key).toBe('about-cindy');
-    expect(capability.detail.trim().length).toBeGreaterThan(0);
-
-    await h.cleanup();
+      expect(payload.ok).toBe(true);
+      const capability = payload.capability as { key: string; detail: string };
+      expect(capability.key).toBe('about-cindy');
+      expect(capability.detail.trim().length).toBeGreaterThan(0);
+    } finally {
+      await h.cleanup();
+    }
   });
 
   it('未知 key 返回 UNKNOWN_KEY,且 available 列表与当前清单同步', async () => {
     const h = await connect(createXdtHelperMcpServer({ logger: makeLogger() }, sessionCtx));
+    try {
+      const payload = parsePayload(
+        await h.client.callTool({
+          name: 'call_tool',
+          arguments: { name: 'get_capabilities', args: { key: 'no-such-capability' } },
+        }),
+      );
 
-    const payload = parsePayload(
-      await h.client.callTool({
-        name: 'call_tool',
-        arguments: { name: 'get_capabilities', args: { key: 'no-such-capability' } },
-      }),
-    );
-
-    expect(payload.ok).toBe(false);
-    expect(payload.errorCode).toBe('UNKNOWN_KEY');
-    const data = payload.data as { requested: string; available: string[] };
-    expect(data.requested).toBe('no-such-capability');
-    expect(data.available).toContain('about-cindy');
-    expect(data.available).toEqual(CAPABILITIES.map((c) => c.key));
-
-    await h.cleanup();
+      expect(payload.ok).toBe(false);
+      expect(payload.errorCode).toBe('UNKNOWN_KEY');
+      const data = payload.data as { requested: string; available: string[] };
+      expect(data.requested).toBe('no-such-capability');
+      expect(data.available).toContain('about-cindy');
+      expect(data.available).toEqual(CAPABILITIES.map((c) => c.key));
+    } finally {
+      await h.cleanup();
+    }
   });
 });

--- a/packages/lizi-mcps/src/__tests__/getCapabilitiesTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/getCapabilitiesTool.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { createXdtHelperMcpServer } from '../lizi_xdtHelperMcpServer.js';
+import { CAPABILITIES, findCapability, listCapabilityIndex } from '../xdt-helper/capabilities.js';
+import type { LiziMcpLogger } from '../types.js';
+
+/**
+ * get_capabilities 的行为契约测试。
+ *
+ * 此前只有 toolErrorTelemetry.test.ts 覆盖了它的 schema / 遥测,没有任何测试校验
+ * 「能力索引与按 key 查询」这条真正被模型走的路径 —— 新增或改名 capability 时,
+ * 索引缺项、detail 为空、UNKNOWN_KEY 的 available 列表过期都不会被发现。
+ */
+
+const sessionCtx = {
+  agentKind: 'claude-code' as const,
+  workingDir: '/tmp',
+  sessionId: 'sess-capabilities',
+};
+
+function makeLogger(): LiziMcpLogger {
+  return { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+async function connect(server: McpServer) {
+  const [clientTx, serverTx] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'capabilities-test-client', version: '0.0.0' });
+  await Promise.all([server.connect(serverTx), client.connect(clientTx)]);
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+/** call_tool 的返回体是 JSON 文本块,取出来解析。 */
+function parsePayload(result: unknown): Record<string, unknown> {
+  const content = (result as { content?: Array<{ type: string; text?: string }> }).content;
+  const first = content?.[0];
+  if (!first || first.type !== 'text' || !first.text) {
+    throw new Error('tool result has no text content');
+  }
+  return JSON.parse(first.text) as Record<string, unknown>;
+}
+
+describe('capabilities data source', () => {
+  it('每条 capability 的 key / title / oneLiner / detail 都非空', () => {
+    expect(CAPABILITIES.length).toBeGreaterThan(0);
+    for (const entry of CAPABILITIES) {
+      expect(entry.key.trim()).not.toBe('');
+      expect(entry.title.trim()).not.toBe('');
+      expect(entry.oneLiner.trim()).not.toBe('');
+      expect(entry.detail.trim()).not.toBe('');
+    }
+  });
+
+  it('key 不重复', () => {
+    const keys = CAPABILITIES.map((c) => c.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('listCapabilityIndex 只暴露索引字段,不带 detail', () => {
+    for (const item of listCapabilityIndex()) {
+      expect(Object.keys(item).sort()).toEqual(['key', 'oneLiner', 'title']);
+    }
+  });
+
+  it('about-cindy 覆盖产品身份与源码仓库', () => {
+    const entry = findCapability('about-cindy');
+    expect(entry).toBeDefined();
+    expect(entry!.detail).toContain('https://github.com/makecindy/cindy');
+    // 执行位置不能被写死成客户端:SSH 远程工作区下 agent 进程在远端主机。
+    expect(entry!.detail).toContain('SSH 远程工作区');
+  });
+});
+
+describe('get_capabilities tool', () => {
+  it('不传 key 时返回包含 about-cindy 的索引', async () => {
+    const h = await connect(createXdtHelperMcpServer({ logger: makeLogger() }, sessionCtx));
+
+    const payload = parsePayload(
+      await h.client.callTool({ name: 'call_tool', arguments: { name: 'get_capabilities', args: {} } }),
+    );
+
+    expect(payload.ok).toBe(true);
+    const caps = payload.capabilities as Array<{ key: string; detail?: unknown }>;
+    expect(caps.map((c) => c.key)).toContain('about-cindy');
+    // 索引不应该带 detail —— 否则渐进式发现省 token 的意义就没了。
+    expect(caps.every((c) => c.detail === undefined)).toBe(true);
+
+    await h.cleanup();
+  });
+
+  it('传 key=about-cindy 时返回 ok 与非空 detail', async () => {
+    const h = await connect(createXdtHelperMcpServer({ logger: makeLogger() }, sessionCtx));
+
+    const payload = parsePayload(
+      await h.client.callTool({
+        name: 'call_tool',
+        arguments: { name: 'get_capabilities', args: { key: 'about-cindy' } },
+      }),
+    );
+
+    expect(payload.ok).toBe(true);
+    const capability = payload.capability as { key: string; detail: string };
+    expect(capability.key).toBe('about-cindy');
+    expect(capability.detail.trim().length).toBeGreaterThan(0);
+
+    await h.cleanup();
+  });
+
+  it('未知 key 返回 UNKNOWN_KEY,且 available 列表与当前清单同步', async () => {
+    const h = await connect(createXdtHelperMcpServer({ logger: makeLogger() }, sessionCtx));
+
+    const payload = parsePayload(
+      await h.client.callTool({
+        name: 'call_tool',
+        arguments: { name: 'get_capabilities', args: { key: 'no-such-capability' } },
+      }),
+    );
+
+    expect(payload.ok).toBe(false);
+    expect(payload.errorCode).toBe('UNKNOWN_KEY');
+    const data = payload.data as { requested: string; available: string[] };
+    expect(data.requested).toBe('no-such-capability');
+    expect(data.available).toContain('about-cindy');
+    expect(data.available).toEqual(CAPABILITIES.map((c) => c.key));
+
+    await h.cleanup();
+  });
+});

--- a/packages/lizi-mcps/src/xdt-helper/capabilities.ts
+++ b/packages/lizi-mcps/src/xdt-helper/capabilities.ts
@@ -32,13 +32,11 @@ export const CAPABILITIES: readonly CapabilityEntry[] = [
     title: `${BRAND_NAME} 自身信息(产品身份 / 开源仓库 / 源码位置)`,
     oneLiner: `${BRAND_NAME} 是什么产品、谁做的、开不开源、源码在哪、当前 agent 与它的关系。`,
     detail: [
-      `【是什么】${BRAND_NAME} 是 XD Inc. 出品的开源 AI 助手(open-source AI assistant), 以桌面 / 移动客户端形态交付,官网 https://cindy.app,源码仓库 https://github.com/makecindy/cindy,以 Apache-2.0 开源。它把多种 harness、模型和工具收进同一个 agent,用真实文件和已登录的应用完成工作。`,
-      `【当前 agent 与它的关系】跟用户对话的这个 agent 由 ${BRAND_NAME} 编排:会话、工具、上下文与 memory 都由 ${BRAND_NAME} 管理, 底层 harness 是 Claude Code 或 Codex(会话中途可切 harness / 模型, workspace、memory、skill、工具保持连续)。用户问"你是谁 / 你是什么"时以本条为准, 不要用训练数据猜, 也不要只凭工作目录路径或工具名反推。`,
-      `【${BRAND_NAME} 是编排方, 不等于执行位置】被问"你跑在哪 / 代码在哪台机器上执行 / 文件在哪"时不要拿本条当答案。agent 进程与 workdir 既可能在用户本机, 也可能在 SSH 远程工作区的远端主机上(此时 workdir、agent 进程与文件都在远端); 手机 / 另一台桌面还可以通过设备互联隧道驱动被控桌面端。执行位置以当前会话的实际工作区为准, 拿不准就说明这一点, 不要断言。`,
-      `【源码在哪】上面那个 GitHub 仓库放的是 ${BRAND_NAME} 客户端本体:desktop、mobile 及两端共享的 packages, pnpm monorepo。服务端不在该仓库, 也不开源。`,
-      '【用户本机有没有源码】安装版客户端不携带源码, agent 侧无法推断用户是否 clone 过、clone 在哪。需要读改源码时请用户给出本地路径或用工程模式打开该目录, 不要假设某个固定路径存在, 更不要凭工作目录里出现品牌名就断定当前目录是源码仓库。',
-      `【版本号】不在本条目里(它随客户端版本变)。用户想知道装的是哪一版, 引导去 App 内"设置 → 关于"查看; 用 submit_github_issue 提反馈时, 客户端版本 / OS / 界面语言由系统自动附加, 不用 agent 自己填。`,
-      `【模型怎么来】用户可以登录官方 ${BRAND_NAME} 服务(用量透明扣费)、授权自己已经在付费的 Claude Code / Codex Coding Plan 继续在 ${BRAND_NAME} 里用(不重复付费)、接自己的 API key, 或跑本地模型。定价与下载见 https://cindy.app。`,
+      `【是什么】${BRAND_NAME} 是 XD Inc. 出品的开源 AI 助手(open-source AI assistant), 以桌面 / 移动客户端形态交付, 源码 https://github.com/makecindy/cindy (Apache-2.0)。官网分区域: 中国大陆 https://cindy.cn, 国际版 https://cindy.app —— 给下载 / 定价链接前先确认用户所在区域, 不要一律给国际版。`,
+      `【身份归本条, 执行位置不归】问"你是谁 / 你是什么"以本条为准, 不要用训练数据猜, 也不要凭工作目录路径或工具名反推。但 ${BRAND_NAME} 只是编排方(管会话、工具、上下文与 memory; 底层 harness 是 Claude Code 或 Codex, 可中途切换且上下文连续), 不代表代码在哪执行: agent 进程与 workdir 可能在本机, 也可能在 SSH 远程工作区的远端主机(文件与进程都在远端), 或经设备互联隧道驱动的被控桌面端。问"你跑在哪 / 文件在哪台机器"时以当前会话实际工作区为准, 拿不准就说明, 不要断言。`,
+      `【源码范围】该仓库是客户端本体(desktop、mobile 及共享 packages 的 pnpm monorepo), 服务端不在其中也不开源。安装版不携带源码, agent 侧无法推断用户是否 clone 过、clone 在哪: 要读改源码就让用户给路径或用工程模式打开, 不要假设固定路径, 更不要因为工作目录里出现品牌名就断定当前目录是源码仓库。`,
+      `【版本号不要猜】本条不含版本号。CN 版可在"设置 → 关于"看到客户端版本; 国际版该页当前不展示它(只有更新开关与 agent 二进制版本), 别把用户支使过去空找。用 submit_github_issue 提反馈时客户端版本 / OS / 界面语言由系统自动附加, 不用 agent 填。`,
+      `【模型怎么来】登录官方 ${BRAND_NAME} 服务按量透明扣费、授权已付费的 Claude Code / Codex Coding Plan 继续用(不重复付费)、接自己的 API key, 或跑本地模型。价格见对应区域官网。`,
     ].join(' '),
   },
   {

--- a/packages/lizi-mcps/src/xdt-helper/capabilities.ts
+++ b/packages/lizi-mcps/src/xdt-helper/capabilities.ts
@@ -32,8 +32,9 @@ export const CAPABILITIES: readonly CapabilityEntry[] = [
     title: `${BRAND_NAME} 自身信息(产品身份 / 开源仓库 / 源码位置)`,
     oneLiner: `${BRAND_NAME} 是什么产品、谁做的、开不开源、源码在哪、当前 agent 与它的关系。`,
     detail: [
-      `【是什么】${BRAND_NAME} 是 XD Inc. 出品的开源 AI agent 客户端,官网 https://cindy.app,源码仓库 https://github.com/makecindy/cindy,以 Apache-2.0 开源。它把多种 harness、模型和工具收进同一个 agent,在用户自己的机器上用真实文件和已登录的应用完成工作。`,
-      `【当前 agent 与它的关系】正在跟用户对话的这个 agent 就运行在 ${BRAND_NAME} 客户端里, 由 Claude Code 或 Codex harness 驱动(会话中途可切 harness / 模型, workspace、memory、skill、工具保持连续)。用户问"你是谁 / 你是什么 / 你跑在哪"时以本条为准, 不要用训练数据猜, 也不要只凭工作目录路径或工具名反推。`,
+      `【是什么】${BRAND_NAME} 是 XD Inc. 出品的开源 AI 助手(open-source AI assistant), 以桌面 / 移动客户端形态交付,官网 https://cindy.app,源码仓库 https://github.com/makecindy/cindy,以 Apache-2.0 开源。它把多种 harness、模型和工具收进同一个 agent,用真实文件和已登录的应用完成工作。`,
+      `【当前 agent 与它的关系】跟用户对话的这个 agent 由 ${BRAND_NAME} 编排:会话、工具、上下文与 memory 都由 ${BRAND_NAME} 管理, 底层 harness 是 Claude Code 或 Codex(会话中途可切 harness / 模型, workspace、memory、skill、工具保持连续)。用户问"你是谁 / 你是什么"时以本条为准, 不要用训练数据猜, 也不要只凭工作目录路径或工具名反推。`,
+      `【${BRAND_NAME} 是编排方, 不等于执行位置】被问"你跑在哪 / 代码在哪台机器上执行 / 文件在哪"时不要拿本条当答案。agent 进程与 workdir 既可能在用户本机, 也可能在 SSH 远程工作区的远端主机上(此时 workdir、agent 进程与文件都在远端); 手机 / 另一台桌面还可以通过设备互联隧道驱动被控桌面端。执行位置以当前会话的实际工作区为准, 拿不准就说明这一点, 不要断言。`,
       `【源码在哪】上面那个 GitHub 仓库放的是 ${BRAND_NAME} 客户端本体:desktop、mobile 及两端共享的 packages, pnpm monorepo。服务端不在该仓库, 也不开源。`,
       '【用户本机有没有源码】安装版客户端不携带源码, agent 侧无法推断用户是否 clone 过、clone 在哪。需要读改源码时请用户给出本地路径或用工程模式打开该目录, 不要假设某个固定路径存在, 更不要凭工作目录里出现品牌名就断定当前目录是源码仓库。',
       `【版本号】不在本条目里(它随客户端版本变)。用户想知道装的是哪一版, 引导去 App 内"设置 → 关于"查看; 用 submit_github_issue 提反馈时, 客户端版本 / OS / 界面语言由系统自动附加, 不用 agent 自己填。`,

--- a/packages/lizi-mcps/src/xdt-helper/capabilities.ts
+++ b/packages/lizi-mcps/src/xdt-helper/capabilities.ts
@@ -28,6 +28,19 @@ export interface CapabilityEntry {
 
 export const CAPABILITIES: readonly CapabilityEntry[] = [
   {
+    key: 'about-cindy',
+    title: `${BRAND_NAME} 自身信息(产品身份 / 开源仓库 / 源码位置)`,
+    oneLiner: `${BRAND_NAME} 是什么产品、谁做的、开不开源、源码在哪、当前 agent 与它的关系。`,
+    detail: [
+      `【是什么】${BRAND_NAME} 是 XD Inc. 出品的开源 AI agent 客户端,官网 https://cindy.app,源码仓库 https://github.com/makecindy/cindy,以 Apache-2.0 开源。它把多种 harness、模型和工具收进同一个 agent,在用户自己的机器上用真实文件和已登录的应用完成工作。`,
+      `【当前 agent 与它的关系】正在跟用户对话的这个 agent 就运行在 ${BRAND_NAME} 客户端里, 由 Claude Code 或 Codex harness 驱动(会话中途可切 harness / 模型, workspace、memory、skill、工具保持连续)。用户问"你是谁 / 你是什么 / 你跑在哪"时以本条为准, 不要用训练数据猜, 也不要只凭工作目录路径或工具名反推。`,
+      `【源码在哪】上面那个 GitHub 仓库放的是 ${BRAND_NAME} 客户端本体:desktop、mobile 及两端共享的 packages, pnpm monorepo。服务端不在该仓库, 也不开源。`,
+      '【用户本机有没有源码】安装版客户端不携带源码, agent 侧无法推断用户是否 clone 过、clone 在哪。需要读改源码时请用户给出本地路径或用工程模式打开该目录, 不要假设某个固定路径存在, 更不要凭工作目录里出现品牌名就断定当前目录是源码仓库。',
+      `【版本号】不在本条目里(它随客户端版本变)。用户想知道装的是哪一版, 引导去 App 内"设置 → 关于"查看; 用 submit_github_issue 提反馈时, 客户端版本 / OS / 界面语言由系统自动附加, 不用 agent 自己填。`,
+      `【模型怎么来】用户可以登录官方 ${BRAND_NAME} 服务(用量透明扣费)、授权自己已经在付费的 Claude Code / Codex Coding Plan 继续在 ${BRAND_NAME} 里用(不重复付费)、接自己的 API key, 或跑本地模型。定价与下载见 https://cindy.app。`,
+    ].join(' '),
+  },
+  {
     key: 'ai-chat',
     title: 'AI 对话',
     oneLiner: '与 Claude Code / Codex agent 实时对话,支持代码执行、工具调用、多模态输入。',

--- a/packages/lizi-mcps/src/xdt-helper/capabilities.ts
+++ b/packages/lizi-mcps/src/xdt-helper/capabilities.ts
@@ -30,7 +30,7 @@ export const CAPABILITIES: readonly CapabilityEntry[] = [
   {
     key: 'about-cindy',
     title: `${BRAND_NAME} 自身信息(产品身份 / 开源仓库 / 源码位置)`,
-    oneLiner: `${BRAND_NAME} 是什么产品、谁做的、开不开源、源码在哪、当前 agent 与它的关系。`,
+    oneLiner: `${BRAND_NAME} 是什么、谁做的、开不开源、源码在哪、agent 跑在哪、版本号怎么查, 以及模型接入(官方服务 / 复用 Coding Plan / 自带 API key / 本地模型)与分区域官网下载定价。`,
     detail: [
       `【是什么】${BRAND_NAME} 是 XD Inc. 出品的开源 AI 助手(open-source AI assistant), 以桌面 / 移动客户端形态交付, 源码 https://github.com/makecindy/cindy (Apache-2.0)。官网分区域: 中国大陆 https://cindy.cn, 国际版 https://cindy.app —— 给下载 / 定价链接前先确认用户所在区域, 不要一律给国际版。`,
       `【身份归本条, 执行位置不归】问"你是谁 / 你是什么"以本条为准, 不要用训练数据猜, 也不要凭工作目录路径或工具名反推。但 ${BRAND_NAME} 只是编排方(管会话、工具、上下文与 memory; 底层 harness 是 Claude Code 或 Codex, 可中途切换且上下文连续), 不代表代码在哪执行: agent 进程与 workdir 可能在本机, 也可能在 SSH 远程工作区的远端主机(文件与进程都在远端), 或经设备互联隧道驱动的被控桌面端。问"你跑在哪 / 文件在哪台机器"时以当前会话实际工作区为准, 拿不准就说明, 不要断言。`,

--- a/packages/lizi-mcps/src/xdt-helper/get_capabilities.ts
+++ b/packages/lizi-mcps/src/xdt-helper/get_capabilities.ts
@@ -2,7 +2,7 @@
  * xdt-helper/get_capabilities.ts — get_capabilities tool
  *
  * 渐进式发现:
- *  - 不传 key  → 返回 12 条 {key, title, oneLiner} 索引,模型挑感兴趣的再细查
+ *  - 不传 key  → 返回全部 {key, title, oneLiner} 索引,模型挑感兴趣的再细查
  *  - 传 key   → 返回单条 {key, title, oneLiner, detail}
  *  - key 不存在 → 返回可用 key 列表 + UNKNOWN_KEY 错误码,让模型自纠
  *
@@ -22,7 +22,9 @@ export function registerGetCapabilitiesTool(registry: XdtHelperToolRegistry): vo
     description:
       `查询 ${BRAND_NAME} 自身能力。不传参数 → 返回所有能力的 {key, title, oneLiner} 索引;` +
       '传 key=<具体能力 key> → 返回该能力的完整 detail。' +
-      `当用户问"${BRAND_NAME} 能做什么 / 有哪些功能 / 支持 X 吗"时调用本工具,而不是用训练数据回答。`,
+      `当用户问"${BRAND_NAME} 能做什么 / 有哪些功能 / 支持 X 吗"时调用本工具,而不是用训练数据回答。` +
+      `用户问"你是谁 / 你是什么 / 你跑在哪 / ${BRAND_NAME} 是什么产品 / 谁做的 / 开不开源 / 源码在哪"时,` +
+      '同样调本工具取 key=about-cindy,不要靠工作目录路径、工具名或训练数据推断。',
     inputShape: {
       key: z
         .string()

--- a/packages/maker-core/src/agents/claude-code/system-prompt-append.ts
+++ b/packages/maker-core/src/agents/claude-code/system-prompt-append.ts
@@ -3,10 +3,11 @@
 //
 // 真正的内容写在同目录的 system-prompt-append.md，vite 编译时通过 ?raw 内联为字符串。
 //
-// 当前 .md 是空的 —— host 层的产品级规则也已全部清空（2026-07-16 经 Lizi 确认：
-// 内部系统 MCP 路由随飞书等迁入意识(Ghost)体系、免责声明随产品对外化、mermaid 渲染
-// 规范与实时信息查询一并移除），host 层注入口保留：
-//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral)
+// 当前 .md 是空的 —— 原有的产品级规则已于 2026-07-16 经 Lizi 确认清空（内部系统 MCP
+// 路由随飞书等迁入意识(Ghost)体系、免责声明随产品对外化、mermaid 渲染规范与实时信息
+// 查询一并移除）。host 层注入口保留：
+//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral；当前只有
+//   一句产品身份锚点，让模型知道自己是 Cindy 及源码位置)
 //   apps/desktop/src/main/maker-host/claude-system-prompt.md (Claude host 专属；当前为空——
 //   原「绘图走 art MCP」规则已删，画图路由交给意识(Ghost)触发体系)
 // 由 host 通过 runtimeConfig.systemPrompt 注入，跟本常量在 startSession 拼成一段

--- a/packages/maker-core/src/agents/claude-code/system-prompt-append.ts
+++ b/packages/maker-core/src/agents/claude-code/system-prompt-append.ts
@@ -6,8 +6,8 @@
 // 当前 .md 是空的 —— 原有的产品级规则已于 2026-07-16 经 Lizi 确认清空（内部系统 MCP
 // 路由随飞书等迁入意识(Ghost)体系、免责声明随产品对外化、mermaid 渲染规范与实时信息
 // 查询一并移除）。host 层注入口保留：
-//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral；当前只有
-//   一句产品身份锚点，让模型知道自己是 Cindy 及源码位置)
+//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral；当前是两行
+//   产品身份锚点：身份声明 + 源码仓库地址，让模型知道自己是 Cindy 及源码在哪)
 //   apps/desktop/src/main/maker-host/claude-system-prompt.md (Claude host 专属；当前为空——
 //   原「绘图走 art MCP」规则已删，画图路由交给意识(Ghost)触发体系)
 // 由 host 通过 runtimeConfig.systemPrompt 注入，跟本常量在 startSession 拼成一段

--- a/packages/maker-core/src/agents/codex/system-prompt-append.ts
+++ b/packages/maker-core/src/agents/codex/system-prompt-append.ts
@@ -8,8 +8,8 @@
 // 当前 .md 是空的 —— 原有的产品级规则已于 2026-07-16 经 Lizi 确认清空（内部系统 MCP
 // 路由随飞书等迁入意识(Ghost)体系、免责声明随产品对外化、mermaid 渲染规范与实时信息
 // 查询一并移除）。host 层注入口保留：
-//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral；当前只有
-//   一句产品身份锚点，让模型知道自己是 Cindy 及源码位置)
+//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral；当前是两行
+//   产品身份锚点：身份声明 + 源码仓库地址，让模型知道自己是 Cindy 及源码在哪)
 //   apps/desktop/src/main/maker-host/codex-system-prompt.md (Codex host 专属；当前为空——
 //   原「绘图走 codex imagegen」规则已删，画图路由交给意识(Ghost)触发体系)
 // 由 host 通过 runtimeConfig.systemPrompt 注入，跟本常量在 startSession 拼成一段

--- a/packages/maker-core/src/agents/codex/system-prompt-append.ts
+++ b/packages/maker-core/src/agents/codex/system-prompt-append.ts
@@ -5,10 +5,11 @@
 //
 // 真正的内容写在同目录的 system-prompt-append.md，vite 编译时通过 ?raw 内联为字符串。
 //
-// 当前 .md 是空的 —— host 层的产品级规则也已全部清空（2026-07-16 经 Lizi 确认：
-// 内部系统 MCP 路由随飞书等迁入意识(Ghost)体系、免责声明随产品对外化、mermaid 渲染
-// 规范与实时信息查询一并移除），host 层注入口保留：
-//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral)
+// 当前 .md 是空的 —— 原有的产品级规则已于 2026-07-16 经 Lizi 确认清空（内部系统 MCP
+// 路由随飞书等迁入意识(Ghost)体系、免责声明随产品对外化、mermaid 渲染规范与实时信息
+// 查询一并移除）。host 层注入口保留：
+//   apps/desktop/src/main/maker-host/host-system-prompt.md  (vendor-neutral；当前只有
+//   一句产品身份锚点，让模型知道自己是 Cindy 及源码位置)
 //   apps/desktop/src/main/maker-host/codex-system-prompt.md (Codex host 专属；当前为空——
 //   原「绘图走 codex imagegen」规则已删，画图路由交给意识(Ghost)触发体系)
 // 由 host 通过 runtimeConfig.systemPrompt 注入，跟本常量在 startSession 拼成一段


### PR DESCRIPTION
## 这次改了什么

### 摘要

在此之前，跑在 Cindy 里的 agent 拿不到任何关于 Cindy 自身的信息：host 层三个注入口
（`host-system-prompt.md` / `claude-system-prompt.md` / `codex-system-prompt.md`）全是 0 字节，
maker-core 的 engine append 也是空的。模型只能从工作目录路径（对话模式的 workdir 恰好在
`Application Support/Cindy/` 下）和 `cindy_*` MCP 工具名反推自己的宿主。

这种推断能碰对，但很脆弱：换成工程模式（workdir 是用户自己的项目目录）后，最强的那条路径
线索直接消失；用户关掉内置 MCP 后线索更少。而且即便猜对了「我在 Cindy 里」，也答不出
Cindy 是什么产品、开不开源、源码在哪——`get_capabilities` 原有的 20 条能力条目里一条都没覆盖。

本 PR 分两层补上：常驻的极简身份锚点进 system prompt，详细信息留在按需拉取的能力条目里。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（对话中发现的能力缺口）
- 本 PR 包含：
  - `host-system-prompt.md`：补一句产品身份锚点（此前 0 字节），Claude 与 Codex 两侧共享。
    内容仅两行：`You are Cindy, an open-source AI assistant.` + 源码地址，约 20 token。
  - `capabilities.ts`：新增 `about-cindy` 条目（5 段），承载按需拉取的详情——产品身份与分区域
    官网、「Cindy 是编排方不等于执行位置」、开源仓库范围（客户端本体，服务端不在内）与本地源码
    怎么定位、版本号查询入口（分区域）、模型接入的四种方式。
  - `get_capabilities.ts`：触发条件扩展到「你是谁 / 你跑在哪 / 源码在哪」类提问；顺带修掉
    注释里过时的「12 条索引」（实际早已不是 12 条）。
  - `__tests__/getCapabilitiesTool.test.ts`（新增）：补上此前完全缺失的行为契约测试——能力索引与
    按 key 查询这条真正被模型走的路径。含区域链接、执行位置表述的防回归断言。
  - `system-prompt-append.ts`（claude-code / codex）：同步注释。原文写着「host 层的产品级
    规则也已全部清空」，本 PR 正好打破该描述，不同步会误导后续读者。
- 明确不包含：
  - 未动 `claude-system-prompt.md` / `codex-system-prompt.md`（两个 agent 专属段仍为空）。
  - 未做版本号动态注入。`XdtHelperMcpDeps` 有现成注入机制，但会把纯静态的 `CAPABILITIES`
    常量改成动态构造，且要连带改 server 构造与 desktop 注入点，超出本 PR 目标。当前做法是
    引导用户去「设置 → 关于」查看。
- 用户可见变化：被问到「你是谁 / Cindy 是什么 / 源码在哪」时，agent 的回答从「靠线索推断」
  变为「有权威事实源」。不涉及界面。
- 是否存在 breaking change：无

### 远程 / 手机适配结论

按 `docs/dev-rules/remote-and-mobile-adaptation.md` 的 PR 门禁，逐条给出结论：

**1. SSH 远程工作区下能否正常工作 —— 部分适配 + 既有限制已跟踪**

- **身份锚点生效**：`host-system-prompt.md` 经 `runtimeConfig.systemPrompt` 进入 SDK options 的
  `systemPrompt` 字段，该字段随 options 一起 JSON 序列化传给远端 daemon（与会被 strip 的
  `canUseTool` / `pathToClaudeCodeExecutable` 等 callback/path 字段不同）。远程工作区用户问
  「你是谁 / 开不开源 / 源码在哪」能拿到正确答案。
- **`about-cindy` 详情层在远程不可达**：远端 cc 只支持 stdio/sse/http transport，会 filter 掉全部
  in-process SDK MCP（含 `cindy_helper`），代码内已 warn；远端 Codex 的
  `prepareCodexExtraSpawnConfig` 在 `ctx.remoteHostId` 时直接返回空配置、不装 MCP bridge。
  这是 remote cc MVP 的既有限制，非本 PR 引入。影响面为详情层（版本号入口、模型接入、执行位置
  说明）在远程会话取不到，核心身份问答不受影响。已在 review thread 记录为 follow-up。
- **本 PR 不引入远程通道风险**：没有新增任何 workdir 文件访问、agent 进程操作或会话数据读写，
  不存在「用本机 `fs` 读远端 workdir」类问题。
- **条目内容本身已按远程场景适配**：`about-cindy` 专门有一段说明 Cindy 是编排方、不等于执行位置，
  要求 agent 在被问「你跑在哪 / 文件在哪台机器」时以当前会话实际工作区为准、拿不准不要断言，
  正是为了避免远程工作区用户拿到错误的执行位置。

**2. IPC channel / 推送事件是否需要手机·远程控制登记 —— 不涉及**

本 PR 只改动静态 prompt 文本（`.md`）与 MCP 工具的静态数据常量，没有新增或修改任何 IPC channel、
推送事件或 topic 路由，因此不需要在 `packages/device-link/src/allowlist.ts` 登记 invoke / push
白名单。

**3. 手机版是否需要对应入口 / UI —— 不涉及，且无需单独适配**

`apps/mobile` 不依赖 `@cindy/maker-core`（其 `package.json` 只引 `auth-client`、`device-link`、
`maker-shared`、`model-providers`、`voice-input-core`），手机端不自己跑 agent，而是通过 device-link
隧道驱动被控桌面端。agent 与 system prompt 都在 desktop 侧生效，因此手机发起的会话自动覆盖到本次
新增的身份锚点，无需 mobile 侧改动。本 PR 也没有任何 UI 变更。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
# 仓库根全量单元测试门禁（覆盖本 PR 全部 5 个文件的最终状态）
pnpm test:unit
结果：GATE_EXIT=0，通过

# 受影响 package 的 typecheck
pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm --filter @cindy/maker-core run --if-present typecheck
pnpm --filter @cindy/mcps run --if-present typecheck
结果：两个 package 均无 typecheck script，--if-present 跳过（exit 0）

# 定向测试（含新增的 getCapabilitiesTool.test.ts）
pnpm --filter @cindy/mcps run test
结果：34 files / 400 tests 全部通过

# DCO
pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

### 手工验证

未执行。见下节。

### 未执行的验证

1. **prompt cache 命中率未实测。** `maker-core-and-agent-behavior.md` §3.4 要求附实测结论，
   本 PR 给不出。机制层面可以确定的是：新增段完全静态、位于前缀固定位置（host 段，第 4 段），
   属于**一次性失效后重新稳定**，而非持续性劣化——不会每轮变化，也没有调整各段拼接顺序。
   如需合并前实测，可用 `usage-tracker.ts` 的 per-turn / session 命中率或 `/context` 做改动
   前后对比。
2. **未在真实客户端验证两个 harness 下的自称稳定性。** 已知 Claude Code preset 内含
   `You are Claude Code, Anthropic's official CLI for Claude.` / `You are a Claude agent, built on
   Anthropic's Claude Agent SDK.`，本 PR 注入的 `You are Cindy, ...` 与其在**同一个 system 段内并列**
   （Codex 侧走 `developerInstructions` 独立字段，不与 base prompt 混排，耦合更弱）。这是
   `systemPrompt.append` 的常规用法（后置且更具体的指令通常胜出），预期为软冲突而非硬冲突，
   但实际自称是否稳定需要起客户端实测。尝试用仓库内 `claude` 二进制做 one-shot 对照实验时
   受阻于未登录（Cindy 通过 env 注入凭据），未继续（不去提取用户凭据）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

**system prompt 改动已确认**：`maker-core-and-agent-behavior.md` §4 要求 system prompt 改动
必须先经维护者确认。本次注入内容（含具体文案与英文表述）由仓库维护者在需求讨论中直接给定
并要求写入，已取得确认。

### 影响与回滚

- 影响范围：所有新建会话的 system 段增加约 20 token 的静态前缀，Claude 与 Codex 两侧同时生效。
  首次生效时 prompt cache 前缀失效一轮，随后重新稳定。按 §3.3，任何进入模型的 prompt 内容
  改动都可能带来行为漂移——本次为有意为之，目的是让 agent 对自身身份有权威事实源而非靠推断。
  一个已知但未消解的点：`an open-source AI assistant` 比 preset 的
  `interactive agent that helps users with software engineering tasks` 更泛，理论上存在稀释工程
  定位的可能；维护者已知悉并选择保留当前措辞。
- 回滚 / 降级方式：把 `host-system-prompt.md` 清空即可完全回退 system prompt 层（空段会被
  `composeHostPrompt` 的 `.filter` 跳过，回到本 PR 之前的行为）。`about-cindy` 条目与
  `get_capabilities` 描述属于按需拉取层，不进常驻上下文，可独立保留或一并 revert。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（同步了两处会被本 PR 打破的代码注释）
- [x] 已确认测试结果或说明未执行原因
