### PR TITLE
fix(desktop): 修正 Windows 安装器与卸载器的 Description

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -1076,6 +1076,16 @@ if (isWin) {
         // 接受)/ dev 'CindyDev'(仍与正式包隔离)。显式设值防 app-builder
         // 回落 package.json productName 造成 dev 与正式包同目录。
         productName: CINDY_EXE,
+        // Setup.exe 与 Uninstall <App>.exe 的 FileDescription 版本资源。
+        // app-builder-lib 只从 metadata(= apps/desktop/package.json)取
+        // description,没有顶层 config 字段;extraMetadata 是唯一的覆盖通道
+        // (packager.ts 在读完 package.json 后 deepAssign 进 metadata)。
+        // 这里显式设值与 packagerConfig.win32metadata 同源:不设时回落
+        // package.json 的 npm 包描述,UAC 提权弹窗、文件属性、快捷方式悬停
+        // 提示上就会显示那段面向开发者的文本(Issue: 安装/卸载显示错误描述)。
+        // prepackaged 模式下 doPack 直接 return,extraMetadata 不会重写
+        // 已由 electron-forge 打好的 app.asar 内 package.json。
+        extraMetadata: { description: CINDY_EXE },
         nsis: {
           oneClick: false,
           allowToChangeInstallationDirectory: true,

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -1080,12 +1080,18 @@ if (isWin) {
         // app-builder-lib 只从 metadata(= apps/desktop/package.json)取
         // description,没有顶层 config 字段;extraMetadata 是唯一的覆盖通道
         // (packager.ts 在读完 package.json 后 deepAssign 进 metadata)。
-        // 这里显式设值与 packagerConfig.win32metadata 同源:不设时回落
-        // package.json 的 npm 包描述,UAC 提权弹窗、文件属性、快捷方式悬停
-        // 提示上就会显示那段面向开发者的文本(Issue: 安装/卸载显示错误描述)。
+        // 不设时回落 package.json 的 npm 包描述,UAC 提权弹窗、文件属性、
+        // 快捷方式悬停提示上就会显示那段面向开发者的文本。
+        //
+        // ⚠️ 取 displayName 而非 CINDY_EXE:展示名两区(含 dev)共用 'Cindy',
+        // 而 exe 名 dev 派生为 'CindyDev'。用后者会让 dev 包的安装器显示
+        // CindyDev、装完的主 exe 却显示 Cindy(win32metadata 同样取
+        // displayName)——安装前后自相矛盾,正是本次要消除的那类不一致。
+        // 文件名层的区分由 productName / shortcutName 承担,与展示层解耦。
+        //
         // prepackaged 模式下 doPack 直接 return,extraMetadata 不会重写
         // 已由 electron-forge 打好的 app.asar 内 package.json。
-        extraMetadata: { description: CINDY_EXE },
+        extraMetadata: { description: BRAND_IDENTITY.displayName },
         nsis: {
           oneClick: false,
           allowToChangeInstallationDirectory: true,
@@ -1141,11 +1147,13 @@ const config: ForgeConfig = {
     appBundleId: CINDY_APP_ID,
     // exe 资源元数据(任务管理器进程名、文件右键属性的显示层)。只影响展示,
     // 与 exe 文件名 / AUMID / userData 等标识符解耦;显示层两区共用 Cindy
-    // (与 mac 显示名口径一致)。
+    // (与 mac 显示名口径一致)。FileDescription 走 BRAND_IDENTITY.displayName,
+    // 与 NSIS maker 的 extraMetadata.description 同一表达式——安装器/卸载器
+    // 与主 exe 的「说明」字段必须同值,否则 dev 包会安装前后显示两个名字。
     win32metadata: {
       CompanyName: 'XD',
       ProductName: 'Cindy',
-      FileDescription: 'Cindy',
+      FileDescription: BRAND_IDENTITY.displayName,
     },
     icon: 'resources/icon',
     // 自定义 URL scheme: xdt-maker://session/<id> | xdt-maker://project/<encoded-workingDir>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "productName": "Cindy",
   "version": "0.0.0",
-  "description": "Cindy desktop client (真实版本号在 release 时由脚本通过 APP_VERSION 注入,见 forge.config.ts)",
+  "description": "Cindy desktop client",
   "main": ".vite/build/index.js",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 安装程序与卸载程序的 Description（FileDescription 版本资源）显示的不是产品描述，而是一段面向开发者的中文注释：

```
Cindy desktop client (真实版本号在 release 时由脚本通过 APP_VERSION 注入,见 forge.config.ts)
```

用户在 UAC 提权对话框、文件右键属性、快捷方式悬停提示上都会看到它。与系统显示语言无关——版本资源写在 `/LANG=1033` 块里，任何语言的 Windows 都读到同一串中文。

根因是 `apps/desktop/package.json` 的 `description` 字段被当成注释使用。它不是注释，会被 electron-builder 读走：`appInfo.description` ← `metadata.description`，再由 `NsisTarget` 的 `computeVersionKey()` 写进 `FileDescription`；该函数同时用于 installer 与 uninstaller 脚本，所以两个 exe 都被污染。快捷方式提示则来自 NSIS 模板的 `${APP_DESCRIPTION}`，同样取自 `appInfo.description`。

主程序 `Cindy.exe` 不受影响，是因为 `packagerConfig.win32metadata` 已显式设了 `FileDescription: 'Cindy'`——那条只作用于 electron-packager 产出的主 exe，NSIS 的 installer/uninstaller 走 electron-builder，不读 `win32metadata`，于是漏网。

改动两处：

1. `package.json` 的 `description` 恢复为正常产品描述。原注释是冗余信息——同一机制在 `scripts/ci/lib.mjs` 的 `writePackageVersion` 上方与 `forge.config.ts` 的 `packagerConfig` 处已各有一份更完整的说明，删掉不丢信息。
2. `forge.config.ts` 的 `getAppBuilderConfig()` 显式提供 `extraMetadata.description`，与 `win32metadata.FileDescription` 对齐，防止再次回落 `package.json`。这与相邻 `productName` 的既有注释思路一致（「显式设值防 app-builder 回落 package.json」）。

关于第 2 点的选型：electron-builder 的 `Configuration` 没有顶层 `description` 字段，`extraMetadata` 是唯一的覆盖通道（`packager.ts` 读完 package.json 后 `deepAssign(this.metadata, configuration.extraMetadata)`）。prepackaged 模式下 `doPack` 直接 return，因此 `extraMetadata` **不会**重写已由 electron-forge 打好的 `app.asar` 内的 package.json——只影响 NSIS 的版本资源计算。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #708
- 基线：已 rebase 到 `3de98396`（含 #694），与最新 main 无冲突
- 本 PR 包含：`apps/desktop/package.json` 的 `description` 字段；`forge.config.ts` 中 NSIS maker 的 `extraMetadata.description`
- 明确不包含：
  - #706（Windows CRLF 导致 GLOSSARY.md 门禁必红）是独立的既有问题，不在本 PR 修。#707（`deviceId.test.ts` PATH 分隔符）已由 #694 在上游修复并关闭
  - `CompanyName` 在主 exe（`XD`）与安装器（`X.D. Network Inc.`）之间的口径差异——两者都是合法公司名，不是缺陷，未纳入本次范围
- 用户可见变化：Windows 安装器/卸载器的 UAC 提权对话框、文件属性「说明」、快捷方式悬停提示，从那段开发者注释改为 `Cindy`
- 是否存在 breaking change：无

### UI 变化

不涉及：改动仅为 Windows exe 的版本资源元数据（FileDescription），不触及任何应用内界面、组件、样式或 UI 文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过（exit 0）
注意：apps/desktop/tsconfig.json 的 include 只有 ["src/**/*", "*.d.ts"]，
      不覆盖 forge.config.ts，因此该结果并未校验本 PR 对 forge.config.ts 的改动。
      改用下面的实际加载验证来补这个缺口。

实际加载 forge.config.ts 并调用 getAppBuilderConfig()：
结果：
  NSIS  productName          = "Cindy"
  NSIS  extraMetadata        = {"description":"Cindy"}
  packager win32metadata     = {"CompanyName":"XD","ProductName":"Cindy","FileDescription":"Cindy"}
证实 extraMetadata 确实进入 NSIS maker 配置，且与 win32metadata 口径一致。

pnpm test:unit
结果：全部 workspace PASS（50 个），退出码 0，无失败项
      apps/desktop unit 167.1s PASS / apps/mobile unit 22.3s PASS
      本次记录跑在 rebase 到 3de98396 之后。此前该命令在本机有 1 项失败
      （deviceId.test.ts 的 PATH 分隔符用例），与本 PR 无关，已由 #694
      在上游修复，rebase 后不再复现。
```

### 手工验证

平台：Windows 11 Pro 10.0.26200

```text
pnpm release:package --no-sign   （region=cn，版本无关包）
产物：apps/desktop/release/artifacts/cn/unversioned/win32-x64/cindy-unversioned-Setup.exe

(Get-Item cindy-unversioned-Setup.exe).VersionInfo
  FileDescription : Cindy      ← 修复前是那段开发者注释
  ProductName     : Cindy
  ProductVersion  : 0.0.0      （版本无关包，符合预期）

对照 packaged 主 exe（out\Cindy-win32-x64\Cindy.exe）：
  FileDescription : Cindy      ← 与安装器口径一致
```

### 未执行的验证

- **卸载器 `Uninstall Cindy.exe` 的实机确认**：验证时尚未执行安装，未能直接读取该 exe 的版本资源。依据是它与安装器共用同一个 `NsisTarget.computeVersionKey()`（该函数同时喂给 installer 与 uninstaller 脚本），安装器既已为 `Cindy`，卸载器必然同值。建议合入前由任一 Windows 环境安装一次复核——这也正是 #708 最初被发现的入口。
- **macOS / Linux**：本改动位于 `if (isWin)` 分支内的 NSIS maker 配置，对 mac/linux 产物无影响，未单独打包验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Windows。改动只作用于 NSIS 产出的 installer/uninstaller 的版本资源字符串，以及 `package.json` 的 npm 包描述字段。不改变 exe 文件名、AUMID、appId、安装目录、userData 路径等任何标识符，也不影响热更新链路（`extraMetadata` 在 prepackaged 模式下不重写 `app.asar`，产物内容字节层面只有版本资源段变化）。mac/linux 走不同 maker，不受影响。
- 回滚 / 降级方式：`git revert` 即可，无数据迁移、无持久化状态、无协议约定。已安装的旧版本不受影响——版本资源是随包烘焙的静态数据，回滚只影响后续构建的产物。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已说明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动含解释性注释，说明为何用 `extraMetadata` 及其对 asar 的边界）
- [x] 已确认测试结果或说明未执行原因
