### PR TITLE
fix(desktop): 修复跨引擎切换后的 provider 路由

### DIFF
--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -720,6 +720,23 @@ describe('远程 set-* 持久化回流', () => {
     expect(persist).toHaveBeenCalledWith('sess-1', { model: 'claude-x' });
   });
 
+  it('set-model 持久化 trim 后的 providerId', async () => {
+    const persist = vi.fn();
+    setRemoteSettingsPersist(persist);
+    registry.register('maker:set-model', () => undefined);
+
+    const r = await runInvoke('ctrl-a', {
+      channel: 'maker:set-model',
+      args: ['sess-1', 'claude-x', '  anthropic  '],
+    });
+
+    expect(r).toMatchObject({ ok: true });
+    expect(persist).toHaveBeenCalledWith('sess-1', {
+      model: 'claude-x',
+      providerId: 'anthropic',
+    });
+  });
+
   it('set-fast-mode → {fastMode}', async () => {
     const persist = vi.fn();
     setRemoteSettingsPersist(persist);

--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -373,6 +373,23 @@ describe('sendToSession ordering', () => {
     expect(handlerBlock).toContain('return anySessionInTurn(maker);');
   });
 
+  it('serializes SET_MODEL behind the send-time agent switch for the same session', () => {
+    const setModelBlock = extractBetween(
+      source,
+      'ipcMain.handle(MAKER_INVOKE.SET_MODEL',
+      'ipcMain.handle(MAKER_INVOKE.SET_EFFORT',
+    );
+
+    expect(setModelBlock).toContain(
+      'return withSendToSessionLock(sessionId, async () => {',
+    );
+    expectOrder(
+      setModelBlock,
+      'return withSendToSessionLock(sessionId, async () => {',
+      'applySetModelThenCancelAgentSwitchIntent(',
+    );
+  });
+
   it('publishes Agent Island prompt preview from send intent and wires commit rollback', () => {
     const makerSendCreateDbMessageBlock = extractBetween(
       source,

--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -379,6 +379,11 @@ describe('sendToSession ordering', () => {
       'ipcMain.handle(MAKER_INVOKE.SET_MODEL',
       'ipcMain.handle(MAKER_INVOKE.SET_EFFORT',
     );
+    const directSendSwitchBlock = extractBetween(
+      source,
+      'pendingAgentSwitchApplyHolder = (sessionId, signal) =>',
+      'ipcMain.handle(MAKER_INVOKE.MARK_ORCA_ROLE',
+    );
 
     expect(setModelBlock).toContain(
       'return withSendToSessionLock(sessionId, async () => {',
@@ -387,6 +392,14 @@ describe('sendToSession ordering', () => {
       setModelBlock,
       'return withSendToSessionLock(sessionId, async () => {',
       'applySetModelThenCancelAgentSwitchIntent(',
+    );
+    expect(directSendSwitchBlock).toContain(
+      'withSendToSessionLock(sessionId, () =>',
+    );
+    expectOrder(
+      directSendSwitchBlock,
+      'withSendToSessionLock(sessionId, () =>',
+      'applyPendingAgentSwitchIfIdle(',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -381,7 +381,7 @@ describe('sendToSession ordering', () => {
     );
     const directSendSwitchBlock = extractBetween(
       source,
-      'pendingAgentSwitchApplyHolder = (sessionId, signal) =>',
+      'pendingAgentSwitchApplyHolder = async (sessionId, signal) =>',
       'ipcMain.handle(MAKER_INVOKE.MARK_ORCA_ROLE',
     );
 
@@ -393,14 +393,13 @@ describe('sendToSession ordering', () => {
       'return withSendToSessionLock(sessionId, async () => {',
       'applySetModelThenCancelAgentSwitchIntent(',
     );
-    expect(directSendSwitchBlock).toContain(
-      'withSendToSessionLock(sessionId, () =>',
-    );
+    expect(directSendSwitchBlock).toContain('const release = await acquireSendToSessionLock(sessionId);');
     expectOrder(
       directSendSwitchBlock,
-      'withSendToSessionLock(sessionId, () =>',
+      'const release = await acquireSendToSessionLock(sessionId);',
       'applyPendingAgentSwitchIfIdle(',
     );
+    expectOrder(directSendSwitchBlock, 'applyPendingAgentSwitchIfIdle(', 'return release;');
   });
 
   it('publishes Agent Island prompt preview from send intent and wires commit rollback', () => {

--- a/apps/desktop/src/main/__tests__/setSessionsStatusInDb.test.ts
+++ b/apps/desktop/src/main/__tests__/setSessionsStatusInDb.test.ts
@@ -16,6 +16,9 @@ const h = vi.hoisted(() => ({
   tapWindowBroadcast: vi.fn(),
   webContentsSend: vi.fn(),
   closeSession: vi.fn(),
+  withSendToSessionLock: vi.fn(
+    async (_sessionId: string, task: () => Promise<unknown>) => task(),
+  ),
   isSessionStillRemovable: vi.fn(),
   recycleWorktreeForRemovedSession: vi.fn(),
   userDataPath: '',
@@ -45,6 +48,9 @@ vi.mock('../agent-island/service.js', () => ({
 vi.mock('../imageCacheStore', () => ({ removeSession: vi.fn() }));
 vi.mock('../maker-host/index.js', () => ({
   getMakerIfReady: () => ({ closeSession: h.closeSession }),
+}));
+vi.mock('../maker-ipc/register.js', () => ({
+  withSendToSessionLock: h.withSendToSessionLock,
 }));
 vi.mock('../worktree/sessionRemovalRecycle.js', () => ({
   isSessionStillRemovable: h.isSessionStillRemovable,
@@ -131,8 +137,24 @@ describe('setSessionsStatusInDb', () => {
       expect(h.isSessionStillRemovable).toHaveBeenCalledWith('s1');
     });
 
+    expect(h.withSendToSessionLock).not.toHaveBeenCalled();
     expect(h.closeSession).not.toHaveBeenCalled();
     expect(h.recycleWorktreeForRemovedSession).not.toHaveBeenCalled();
+  });
+
+  it('serializes archive-driven close with the session route lock', async () => {
+    h.tx.mockResolvedValueOnce([
+      { sessionId: 's1', title: 'T1', workingDir: '/repo', workspaceKind: 'project', status: 'archived' },
+    ]);
+
+    await setSessionsStatusInDb(['s1'], 'archived');
+    await vi.waitFor(() => {
+      expect(h.closeSession).toHaveBeenCalledWith('s1');
+    });
+
+    expect(h.withSendToSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(h.isSessionStillRemovable).toHaveBeenCalledTimes(2);
+    expect(h.recycleWorktreeForRemovedSession).toHaveBeenCalledWith('s1');
   });
 
   it('keeps batch archived status wired to worktree recycle scheduling', () => {

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -47,6 +47,7 @@ import {
 import { app } from 'electron';
 import type { DeviceLinkClient } from '@cindy/device-link';
 import { createLogger } from '../logger';
+import { normalizeSessionProviderId } from '../maker-host/session-provider-store.js';
 import { readDeviceLinkSettings } from './settings-store';
 import { dispatchLocalInvoke } from './invoke-registry';
 import { runDeviceLinkInvokeContext } from './invoke-context';
@@ -178,7 +179,7 @@ async function persistRemoteSetting(channel: string, args: unknown[], result: un
   if (channel === 'maker:set-model') {
     const patch: Record<string, unknown> = { model: args[1] };
     if (args.length > 2) {
-      patch.providerId = typeof args[2] === 'string' && args[2].trim() ? args[2] : null;
+      patch.providerId = normalizeSessionProviderId(typeof args[2] === 'string' ? args[2] : null);
     }
     await settingsPersist(sessionId, patch);
     return;

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -852,6 +852,45 @@ describe('GoalController', () => {
     expect(h.session.sends.at(-1)?.content).toContain('keep going');
   });
 
+  it('resumeOnOpen 在释放 route 锁前挂 listener，并在会话随即关闭后迁移到重建会话', async () => {
+    const firstSession = new FakeSession('s1', 'claude-code');
+    const recreatedSession = new FakeSession('s1', 'claude-code');
+    let live: FakeSession | undefined = firstSession;
+    let acquireCount = 0;
+    const acquirePendingAgentSwitch = vi.fn(async () => {
+      acquireCount += 1;
+      if (acquireCount === 1) {
+        return () => {
+          // 模拟 resumeOnOpen 释放锁后，queued SET_MODEL 立即关闭刚确保的 session。
+          live = undefined;
+        };
+      }
+      return () => {};
+    });
+    const local = makeController({
+      getSession: () => live,
+      ensureSession: async () => {
+        if (!live) live = recreatedSession;
+        return live;
+      },
+      acquirePendingAgentSwitch,
+    });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'survive rewire' }));
+
+    await local.controller.resumeOnOpen('s1');
+    expect(recreatedSession.sends).toHaveLength(1);
+
+    recreatedSession.emitGoalTurn({
+      toolUse: true,
+      verdictJson: '```json\n{"goal_status":"complete","reason":"rewired"}\n```',
+      tokens: 5,
+    });
+    await tick();
+
+    expect(local.completions).toHaveLength(1);
+    expect(local.completions[0].summary.reason).toBe('rewired');
+  });
+
   it('resumeOnOpen is a no-op for non-active goals and for goals already being managed', async () => {
     // paused → 不自动续(走手动 resume)
     await h.storage.set(seededGoal({ status: 'paused', objective: 'p' }));

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -406,13 +406,15 @@ describe('GoalController', () => {
     const oldSession = new FakeSession('s1', 'claude-code');
     const switchedSession = new FakeSession('s1', 'codex');
     let live = oldSession;
-    const applyPendingAgentSwitch = vi.fn(async () => {
+    const releaseAgentSwitchLock = vi.fn();
+    const acquirePendingAgentSwitch = vi.fn(async () => {
       live = switchedSession;
+      return releaseAgentSwitchLock;
     });
     const local = makeController({
       getSession: () => live,
       ensureSession: async () => live,
-      applyPendingAgentSwitch,
+      acquirePendingAgentSwitch,
     });
 
     await local.controller.setGoal({
@@ -421,10 +423,11 @@ describe('GoalController', () => {
       agentKind: 'claude-code',
     });
 
-    expect(applyPendingAgentSwitch).toHaveBeenCalledWith('s1');
+    expect(acquirePendingAgentSwitch).toHaveBeenCalledWith('s1');
     expect(oldSession.sends).toHaveLength(0);
     expect(switchedSession.sends).toHaveLength(1);
     expect(switchedSession.sends[0].originKind).toBe('goal');
+    expect(releaseAgentSwitchLock).toHaveBeenCalledTimes(1);
   });
 
   it('migrates the Goal listener to the switched session so the new engine turn can finalize (reviewer P1)', async () => {
@@ -432,13 +435,14 @@ describe('GoalController', () => {
     const switchedSession = new FakeSession('s1', 'codex');
     let live: FakeSession = oldSession;
     // deferred switch commit:关旧 live session + spawn 目标引擎 → maker.getSession 换新对象。
-    const applyPendingAgentSwitch = vi.fn(async () => {
+    const acquirePendingAgentSwitch = vi.fn(async () => {
       live = switchedSession;
+      return () => {};
     });
     const local = makeController({
       getSession: () => live,
       ensureSession: async () => live,
-      applyPendingAgentSwitch,
+      acquirePendingAgentSwitch,
     });
 
     // setGoal 先在 oldSession 上挂 listener,首轮 fireTurn 落实切换 → listener 必须迁到 switchedSession。

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -599,12 +599,16 @@ export class GoalController {
     let session: SessionLike | undefined;
     try {
       session = await this.deps.ensureSession(sessionId);
+      if (session) {
+        // 锁内先建立 listener 身份。释放后即使 queued SET_MODEL 立刻关闭该 session，
+        // fireTurn 也能凭 unsubscribers 标记把 listener 迁移到重新创建的新 session。
+        this.resetTurn(sessionId);
+        this.attachListener(sessionId);
+      }
     } finally {
       releaseAgentSwitchLock();
     }
     if (!session) return; // 活化失败(如 device-link 远程不可用)→ 留 dormant,下次打开再试
-    this.resetTurn(sessionId);
-    this.attachListener(sessionId);
     this.emit(state);
     if (!this.isBusy(sessionId)) {
       await this.fireTurn(sessionId);

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -594,8 +594,14 @@ export class GoalController {
     // deferred agent switch 的 commit 会关闭旧 live session。必须在 ensureSession
     // 之前执行,随后重新读取/bootstrap 的才是目标引擎;否则这一轮 directive 会继续
     // 发给 fireTurn 开始时捕获的旧 session。
-    await this.deps.applyPendingAgentSwitch?.(sessionId);
-    const session = await this.deps.ensureSession(sessionId);
+    const releaseAgentSwitchLock =
+      (await this.deps.acquirePendingAgentSwitch?.(sessionId)) ?? (() => {});
+    let session: SessionLike | undefined;
+    try {
+      session = await this.deps.ensureSession(sessionId);
+    } finally {
+      releaseAgentSwitchLock();
+    }
     if (!session) return; // 活化失败(如 device-link 远程不可用)→ 留 dormant,下次打开再试
     this.resetTurn(sessionId);
     this.attachListener(sessionId);
@@ -988,31 +994,37 @@ export class GoalController {
       this.scheduleContinuation(sessionId);
       return;
     }
-    // fireTurn 每次都可能是登记 deferred intent 后的第一条直发消息。apply 会关闭
-    // 旧引擎并 bootstrap 目标引擎,所以必须在拿 session 引用之前执行。
-    await this.deps.applyPendingAgentSwitch?.(sessionId);
-    const session = await this.deps.ensureSession(sessionId);
-    if (!session) {
-      this.deps.logger.warn('[goal] no live session to fire (resume failed)', { sessionId, kind });
-      return;
-    }
-    // deferred switch 可能刚把 live session 换成目标引擎的新对象;本会话若有 goal
-    // listener,必须迁到新 session,否则这轮 turn 的 done/error 事件进不了 finalizeTurn,
-    // 目标卡死在 active(reviewer P1)。attachListener 按 session 身份判等,未换则 no-op;
-    // 只对已在管(非 dormant)的 goal 重挂,不给 dormant 会话平白加 listener。
-    if (this.unsubscribers.has(sessionId)) {
-      this.attachListener(sessionId);
-    }
-
-    this.resetTurn(sessionId);
-    const content =
-      kind === 'first'
-        ? buildFirstTurnDirective(state.objective, { maxTurns: state.maxTurns })
-        : buildContinuationDirective(state.objective, state.lastReason);
-
     this.firing.add(sessionId);
+    let releaseAgentSwitchLock = (): void => {};
     let baselineStarted = false;
     try {
+      // fireTurn 每次都可能是登记 deferred intent 后的第一条直发消息。锁必须覆盖
+      // apply、重新读取 live session 和 Session.send；否则并发 SET_MODEL 能在 fresh
+      // session 创建后、send 前再次换 route，让本轮落到 UI 未显示的来源。
+      releaseAgentSwitchLock =
+        (await this.deps.acquirePendingAgentSwitch?.(sessionId)) ?? (() => {});
+      const session = await this.deps.ensureSession(sessionId);
+      if (!session) {
+        this.deps.logger.warn('[goal] no live session to fire (resume failed)', {
+          sessionId,
+          kind,
+        });
+        return;
+      }
+      // deferred switch 可能刚把 live session 换成目标引擎的新对象;本会话若有 goal
+      // listener,必须迁到新 session,否则这轮 turn 的 done/error 事件进不了 finalizeTurn,
+      // 目标卡死在 active(reviewer P1)。attachListener 按 session 身份判等,未换则 no-op;
+      // 只对已在管(非 dormant)的 goal 重挂,不给 dormant 会话平白加 listener。
+      if (this.unsubscribers.has(sessionId)) {
+        this.attachListener(sessionId);
+      }
+
+      this.resetTurn(sessionId);
+      const content =
+        kind === 'first'
+          ? buildFirstTurnDirective(state.objective, { maxTurns: state.maxTurns })
+          : buildContinuationDirective(state.objective, state.lastReason);
+
       // 目标文案的落库只发生在 setGoal 创建 / 编辑时(各一次),不挂在这里 —— Fix A 后 kind
       // 由 turnsUsed 派生,'first' 可能被 busy 重试 / 暂停后重发,放这里会重复落库。
       // 这里只负责把完整 directive(含裁决约定)发给模型。
@@ -1054,6 +1066,7 @@ export class GoalController {
       // SESSION_RUNNING:会话已有 turn 在跑(用户抢发等);该 turn 的 done 会再触发裁决。
       this.deps.logger.warn('[goal] fireTurn send failed', { sessionId, kind, error: String(e) });
     } finally {
+      releaseAgentSwitchLock();
       this.firing.delete(sessionId);
     }
   }

--- a/apps/desktop/src/main/goal-host/index.ts
+++ b/apps/desktop/src/main/goal-host/index.ts
@@ -12,7 +12,7 @@ import type { Maker } from '@cindy/maker-core';
 
 import { createLogger } from '../logger.js';
 import {
-  applyPendingAgentSwitchForDirectSend,
+  acquirePendingAgentSwitchForDirectSend,
   isSessionInTurn,
 } from '../maker-ipc/register.js';
 import { createMessage } from '../localDb/ipc/messages.js';
@@ -49,7 +49,7 @@ export function startGoalController(deps: StartGoalControllerDeps): GoalControll
         maker: deps.maker,
         warn: (message, meta) => logger.warn(message, meta),
       }),
-    applyPendingAgentSwitch: applyPendingAgentSwitchForDirectSend,
+    acquirePendingAgentSwitch: acquirePendingAgentSwitchForDirectSend,
     isSessionInTurn,
     beforeDispatchUserTurn: deps.beforeDispatchUserTurn,
     onUndispatchedUserTurn: deps.onUndispatchedUserTurn,

--- a/apps/desktop/src/main/goal-host/types.ts
+++ b/apps/desktop/src/main/goal-host/types.ts
@@ -176,8 +176,11 @@ export interface GoalControllerDeps {
    * goal 设了却发不出第一轮"的关键。
    */
   ensureSession(sessionId: string): Promise<SessionLike | undefined>;
-  /** 发下一轮前落实运行中登记的 deferred agent switch,并 bootstrap 新 live session。 */
-  applyPendingAgentSwitch?: (sessionId: string) => Promise<void>;
+  /**
+   * 锁住本 session、落实 deferred agent switch 并 bootstrap 新 live session。
+   * 调用方在重新读取 live session 且 Session.send 返回后执行 release。
+   */
+  acquirePendingAgentSwitch?: (sessionId: string) => Promise<() => void>;
   /** ← maker-ipc/register.isSessionInTurn(main 侧 turn 活跃跟踪)。 */
   isSessionInTurn(sessionId: string): boolean;
   beforeDispatchUserTurn?: (sessionId: string) => void | Promise<void>;

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -32,7 +32,7 @@ const mocks = vi.hoisted(() => ({
   readPermissionMode: vi.fn(async () => 'auto'),
   updatePermissionMode: vi.fn(async () => {}),
   updateModelEffort: vi.fn(async () => {}),
-  getSessionProvider: vi.fn(() => null),
+  getSessionProvider: vi.fn<() => string | null>(() => null),
   setSessionProvider: vi.fn(),
   isSessionInTurn: vi.fn(() => false),
   withSendToSessionLock: vi.fn(
@@ -783,6 +783,38 @@ describe('model:pick 持久化失败', () => {
       'model-card',
       expect.objectContaining({ body: slackUi.cards.model.failed('effort rejected') }),
     );
+  });
+
+  it('回滚时保留 DB 快照中明确清空的 provider', async () => {
+    const live = {
+      agentKind: 'claude-code',
+      remoteHostId: null,
+      model: 'claude-sonnet-4-6',
+      setModel: vi.fn(async () => {}),
+      setEffort: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('effort rejected'))
+        .mockResolvedValue(undefined),
+    };
+    (turnRunner.getMakerSessionById as ReturnType<typeof vi.fn>).mockReturnValue(live);
+    mocks.readModelRouteSnapshot.mockResolvedValueOnce({
+      model: 'claude-sonnet-4-6',
+      effort: 'medium',
+      providerId: null,
+    });
+    mocks.getSessionProvider.mockReturnValueOnce('stale-provider');
+    const im = makeIm();
+
+    await pressModelPick(im);
+
+    expect(mocks.updateModelEffort).toHaveBeenNthCalledWith(
+      2,
+      'sess-target',
+      'claude-sonnet-4-6',
+      'medium',
+      null,
+    );
+    expect(mocks.setSessionProvider).toHaveBeenCalledWith('sess-target', null);
   });
 });
 

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -35,6 +35,9 @@ const mocks = vi.hoisted(() => ({
   getSessionProvider: vi.fn(() => null),
   setSessionProvider: vi.fn(),
   isSessionInTurn: vi.fn(() => false),
+  withSendToSessionLock: vi.fn(
+    async (_sessionId: string, task: () => Promise<unknown>) => task(),
+  ),
   // 禁止回落 cwd:TEMP 是 Windows 独有变量,macOS 上回落 cwd 会让传递 import 的
   // 写盘副作用落进仓库工作区(见 authAdaptersImportPurity.test.ts 记录的事故)。
   userDataDir: process.env.TMPDIR ?? process.env.TEMP ?? '/tmp',
@@ -90,6 +93,7 @@ vi.mock('../../../maker-ipc/register', () => ({
   clearPendingCredentialSwitchForSession: mocks.clearPendingCredentialSwitchForSession,
   wakeSessionInputAfterCredentialSwitch: mocks.wakeSessionInputAfterCredentialSwitch,
   getPendingCredentialSwitchTarget: mocks.getPendingCredentialSwitchTarget,
+  withSendToSessionLock: mocks.withSendToSessionLock,
 }));
 vi.mock('../pendingInteractions', () => ({
   resolvePending: vi.fn(() => false),
@@ -581,6 +585,31 @@ describe('model:pick 持久化失败', () => {
       },
     } as unknown as IMCardActionEvent);
   }
+
+  it('在共享 session 锁内提交 DB 与运行态选择', async () => {
+    const lockGate = deferred();
+    mocks.withSendToSessionLock.mockImplementationOnce(async (_sessionId, task) => {
+      await lockGate.promise;
+      return task();
+    });
+    const im = makeIm();
+
+    const pickPromise = pressModelPick(im);
+    await vi.waitFor(() => {
+      expect(mocks.withSendToSessionLock).toHaveBeenCalledWith(
+        'sess-target',
+        expect.any(Function),
+      );
+    });
+    expect(mocks.updateModelEffort).not.toHaveBeenCalled();
+    expect(mocks.applyRuntimeSetModelChange).not.toHaveBeenCalled();
+
+    lockGate.resolve();
+    await pickPromise;
+
+    expect(mocks.updateModelEffort).toHaveBeenCalled();
+    expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalled();
+  });
 
   it('busy provider 切换注入 pending hooks，并在 deferred 时不 mid-turn 改 effort', async () => {
     const live = {

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   getSessionProvider: vi.fn<() => string | null>(() => null),
   setSessionProvider: vi.fn(),
   isSessionInTurn: vi.fn(() => false),
+  cancelPendingAgentSwitchForSession: vi.fn(),
   withSendToSessionLock: vi.fn(
     async (_sessionId: string, task: () => Promise<unknown>) => task(),
   ),
@@ -90,6 +91,7 @@ vi.mock('../../../maker-ipc/runtimeSetModel', () => ({
   applyRuntimeSetModelChange: mocks.applyRuntimeSetModelChange,
 }));
 vi.mock('../../../maker-ipc/register', () => ({
+  cancelPendingAgentSwitchForSession: mocks.cancelPendingAgentSwitchForSession,
   isSessionInTurn: mocks.isSessionInTurn,
   registerPendingCredentialSwitchForSession: mocks.registerPendingCredentialSwitchForSession,
   clearPendingCredentialSwitchForSession: mocks.clearPendingCredentialSwitchForSession,
@@ -611,6 +613,7 @@ describe('model:pick 持久化失败', () => {
 
     expect(mocks.updateModelEffort).toHaveBeenCalled();
     expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalled();
+    expect(mocks.cancelPendingAgentSwitchForSession).toHaveBeenCalledWith('sess-target');
   });
 
   it('在持久化和运行态切换前统一归一化 providerId', async () => {
@@ -700,6 +703,7 @@ describe('model:pick 持久化失败', () => {
       'anthropic',
     );
     expect(mocks.applyRuntimeSetModelChange).not.toHaveBeenCalled();
+    expect(mocks.cancelPendingAgentSwitchForSession).not.toHaveBeenCalled();
     expect(mocks.setSessionProvider).not.toHaveBeenCalled();
     expect(live.setModel).not.toHaveBeenCalled();
     expect(live.setEffort).not.toHaveBeenCalled();
@@ -738,6 +742,7 @@ describe('model:pick 持久化失败', () => {
       'model-card',
       expect.objectContaining({ body: slackUi.cards.model.failed('runtime rejected') }),
     );
+    expect(mocks.cancelPendingAgentSwitchForSession).not.toHaveBeenCalled();
   });
 
   it('live setEffort 失败时恢复 route store 和 live model', async () => {
@@ -783,6 +788,7 @@ describe('model:pick 持久化失败', () => {
       'model-card',
       expect.objectContaining({ body: slackUi.cards.model.failed('effort rejected') }),
     );
+    expect(mocks.cancelPendingAgentSwitchForSession).not.toHaveBeenCalled();
   });
 
   it('回滚时保留 DB 快照中明确清空的 provider', async () => {

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -82,6 +82,8 @@ vi.mock('../sessionRepo', () => ({
 }));
 vi.mock('../../../maker-host/session-provider-store', () => ({
   getSessionProvider: mocks.getSessionProvider,
+  normalizeSessionProviderId: (providerId: string | null | undefined) =>
+    providerId === undefined ? undefined : providerId?.trim() || null,
   setSessionProvider: mocks.setSessionProvider,
 }));
 vi.mock('../../../maker-ipc/runtimeSetModel', () => ({
@@ -564,7 +566,7 @@ describe('/permission Full access 确认', () => {
 });
 
 describe('model:pick 持久化失败', () => {
-  async function pressModelPick(im: ChannelIM): Promise<void> {
+  async function pressModelPick(im: ChannelIM, providerId = 'anthropic'): Promise<void> {
     const attach = createCardActionHandler(adapter, cards, turnRunner);
     let handler: ((e: IMCardActionEvent) => Promise<void>) | null = null;
     (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
@@ -581,7 +583,7 @@ describe('model:pick 持久化失败', () => {
         modelId: 'claude-opus-4-7',
         modelLabel: 'Opus 4.7',
         effort: 'high',
-        providerId: 'anthropic',
+        providerId,
       },
     } as unknown as IMCardActionEvent);
   }
@@ -609,6 +611,22 @@ describe('model:pick 持久化失败', () => {
 
     expect(mocks.updateModelEffort).toHaveBeenCalled();
     expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalled();
+  });
+
+  it('在持久化和运行态切换前统一归一化 providerId', async () => {
+    const im = makeIm();
+
+    await pressModelPick(im, '  anthropic  ');
+
+    expect(mocks.updateModelEffort).toHaveBeenCalledWith(
+      'sess-target',
+      'claude-opus-4-7',
+      'high',
+      'anthropic',
+    );
+    expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'anthropic' }),
+    );
   });
 
   it('busy provider 切换注入 pending hooks，并在 deferred 时不 mid-turn 改 effort', async () => {

--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -455,7 +455,20 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
       },
     ]);
     mocks.bindingGet.mockReturnValue(undefined);
-    mocks.desktopSessionRows.mockResolvedValue([]);
+    mocks.desktopSessionRows.mockResolvedValue([
+      {
+        id: 'feishu-session',
+        status: 'active',
+        agentKind: 'claude-code',
+        workingDir: 'F:\\XDMaker',
+        model: 'claude-opus-4-7',
+        effort: 'xhigh',
+        permissionMode: 'bypassPermissions',
+        fastMode: false,
+        sdkSessionId: null,
+        providerId: null,
+      },
+    ]);
     mocks.findActiveSession.mockResolvedValue({
       id: 'feishu-session',
       agentKind: 'claude-code',
@@ -594,7 +607,12 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     const switchedSession = createSessionHarness(async () => {
       order.push('send');
       // agent switch 已完成后的关闭不属于切换自己的瞬态 close，必须正常清缓存。
-      emitMakerEvent({ type: 'session:closed', sessionId: 'feishu-session' });
+      emitMakerEvent({
+        type: 'session:closed',
+        sessionId: 'feishu-session',
+        session: switchedSession.session,
+        reason: 'requested',
+      });
       return {
         accepted: false,
         reason: 'cancelled-before-dispatch',
@@ -618,7 +636,12 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     const acquirePendingAgentSwitch = vi.fn(async () => {
       order.push('apply');
       live = switchedSession.session;
-      emitMakerEvent({ type: 'session:closed', sessionId: 'feishu-session' });
+      emitMakerEvent({
+        type: 'session:closed',
+        sessionId: 'feishu-session',
+        session: oldSession.session,
+        reason: 'agent-switch',
+      });
       return releaseAgentSwitchLock;
     });
     const localRunner = createTurnRunner(fakeAdapter, fakeRepo, fakeCards, {
@@ -639,6 +662,104 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
       expect(switchedSession.send).toHaveBeenCalledTimes(1);
       expect(mocks.wireSessionToIpcExternal).toHaveBeenLastCalledWith(switchedSession.session);
       expect(order).toEqual(['apply', 'send', 'release']);
+      expect(localRunner.getMakerSessionById('feishu-session')).toBeNull();
+    } finally {
+      localRunner.disposeAllSessions();
+    }
+  });
+
+  it('does not suppress a requested close during no-op switch acquisition', async () => {
+    const oldSession = createSessionHarness(async () => ({ accepted: true }));
+    let live: Session | undefined = oldSession.session;
+    const maker = {
+      createSession: vi.fn(async () => oldSession.session),
+      getSession: vi.fn(() => live),
+      on: vi.fn((listener: (event: MakerEvent) => void) => {
+        makerEventListeners.push(listener);
+        return () => {
+          makerEventListeners = makerEventListeners.filter((candidate) => candidate !== listener);
+        };
+      }),
+    };
+    mocks.getMaker.mockReturnValue(maker);
+    const acquirePendingAgentSwitch = vi.fn(async () => {
+      live = undefined;
+      emitMakerEvent({
+        type: 'session:closed',
+        sessionId: 'feishu-session',
+        session: oldSession.session,
+        reason: 'requested',
+      });
+      return vi.fn();
+    });
+    const localRunner = createTurnRunner(fakeAdapter, fakeRepo, fakeCards, {
+      acquirePendingAgentSwitch,
+    });
+
+    try {
+      await localRunner.runAgentTurn({
+        botContextId: 'cli_test_bot',
+        userId: 'ou_user',
+        userMessageId: 'msg-close-race',
+        text: 'do not recreate',
+        attachments: [],
+      });
+
+      expect(oldSession.send).not.toHaveBeenCalled();
+      expect(maker.createSession).toHaveBeenCalledTimes(1);
+      expect(localRunner.getMakerSessionById('feishu-session')).toBeNull();
+    } finally {
+      localRunner.disposeAllSessions();
+    }
+  });
+
+  it('does not suppress a concurrent close of the replacement session', async () => {
+    const oldSession = createSessionHarness(async () => ({ accepted: true }));
+    const switchedSession = createSessionHarness(async () => ({ accepted: true }));
+    let live: Session | undefined = oldSession.session;
+    const maker = {
+      createSession: vi.fn(async () => oldSession.session),
+      getSession: vi.fn(() => live),
+      on: vi.fn((listener: (event: MakerEvent) => void) => {
+        makerEventListeners.push(listener);
+        return () => {
+          makerEventListeners = makerEventListeners.filter((candidate) => candidate !== listener);
+        };
+      }),
+    };
+    mocks.getMaker.mockReturnValue(maker);
+    const acquirePendingAgentSwitch = vi.fn(async () => {
+      live = switchedSession.session;
+      emitMakerEvent({
+        type: 'session:closed',
+        sessionId: 'feishu-session',
+        session: oldSession.session,
+        reason: 'agent-switch',
+      });
+      live = undefined;
+      emitMakerEvent({
+        type: 'session:closed',
+        sessionId: 'feishu-session',
+        session: switchedSession.session,
+        reason: 'requested',
+      });
+      return vi.fn();
+    });
+    const localRunner = createTurnRunner(fakeAdapter, fakeRepo, fakeCards, {
+      acquirePendingAgentSwitch,
+    });
+
+    try {
+      await localRunner.runAgentTurn({
+        botContextId: 'cli_test_bot',
+        userId: 'ou_user',
+        userMessageId: 'msg-replacement-close-race',
+        text: 'do not send after replacement closes',
+        attachments: [],
+      });
+
+      expect(oldSession.send).not.toHaveBeenCalled();
+      expect(switchedSession.send).not.toHaveBeenCalled();
       expect(localRunner.getMakerSessionById('feishu-session')).toBeNull();
     } finally {
       localRunner.disposeAllSessions();
@@ -1125,7 +1246,12 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
 
     expect(getRunner().getMakerSessionById('feishu-session')).toBe(first.session);
 
-    emitMakerEvent({ type: 'session:closed', sessionId: 'feishu-session' });
+    emitMakerEvent({
+      type: 'session:closed',
+      sessionId: 'feishu-session',
+      session: first.session,
+      reason: 'requested',
+    });
 
     expect(getRunner().getMakerSessionById('feishu-session')).toBeNull();
 

--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -586,14 +586,18 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
   });
 
   it('applies a deferred switch and sends the first queued IM message through the refreshed session', async () => {
+    const order: string[] = [];
     const oldSession = createSessionHarness(async () => ({
       accepted: false,
       reason: 'cancelled-before-dispatch',
     }));
-    const switchedSession = createSessionHarness(async () => ({
-      accepted: false,
-      reason: 'cancelled-before-dispatch',
-    }));
+    const switchedSession = createSessionHarness(async () => {
+      order.push('send');
+      return {
+        accepted: false,
+        reason: 'cancelled-before-dispatch',
+      };
+    });
     let live: Session | undefined = oldSession.session;
     const maker = {
       createSession: vi.fn(async () => oldSession.session),
@@ -606,12 +610,17 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
       }),
     };
     mocks.getMaker.mockReturnValue(maker);
-    const applyPendingAgentSwitch = vi.fn(async () => {
+    const releaseAgentSwitchLock = vi.fn(() => {
+      order.push('release');
+    });
+    const acquirePendingAgentSwitch = vi.fn(async () => {
+      order.push('apply');
       live = switchedSession.session;
       emitMakerEvent({ type: 'session:closed', sessionId: 'feishu-session' });
+      return releaseAgentSwitchLock;
     });
     const localRunner = createTurnRunner(fakeAdapter, fakeRepo, fakeCards, {
-      applyPendingAgentSwitch,
+      acquirePendingAgentSwitch,
     });
 
     try {
@@ -623,10 +632,11 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
         attachments: [],
       });
 
-      expect(applyPendingAgentSwitch).toHaveBeenCalledWith('feishu-session');
+      expect(acquirePendingAgentSwitch).toHaveBeenCalledWith('feishu-session');
       expect(oldSession.send).not.toHaveBeenCalled();
       expect(switchedSession.send).toHaveBeenCalledTimes(1);
       expect(mocks.wireSessionToIpcExternal).toHaveBeenLastCalledWith(switchedSession.session);
+      expect(order).toEqual(['apply', 'send', 'release']);
     } finally {
       localRunner.disposeAllSessions();
     }

--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -593,6 +593,8 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     }));
     const switchedSession = createSessionHarness(async () => {
       order.push('send');
+      // agent switch 已完成后的关闭不属于切换自己的瞬态 close，必须正常清缓存。
+      emitMakerEvent({ type: 'session:closed', sessionId: 'feishu-session' });
       return {
         accepted: false,
         reason: 'cancelled-before-dispatch',
@@ -637,6 +639,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
       expect(switchedSession.send).toHaveBeenCalledTimes(1);
       expect(mocks.wireSessionToIpcExternal).toHaveBeenLastCalledWith(switchedSession.session);
       expect(order).toEqual(['apply', 'send', 'release']);
+      expect(localRunner.getMakerSessionById('feishu-session')).toBeNull();
     } finally {
       localRunner.disposeAllSessions();
     }

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -273,7 +273,9 @@ export function createCardActionHandler(
         const msg = err instanceof Error ? err.message : String(err);
         log.warn(`model:pick route snapshot failed (non-fatal): ${msg}`);
       }
-      const previousProviderId = previousRoute?.providerId ?? getSessionProvider(sessionId);
+      const previousProviderId = previousRoute
+        ? previousRoute.providerId
+        : getSessionProvider(sessionId);
       const restorePersistentRoute = async (reason: string): Promise<void> => {
         if (!previousRoute) return;
         try {

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -27,7 +27,11 @@ import { requiresFullAccessConfirmation } from '@cindy/maker-shared/permission-m
 
 import { createLogger } from '../../logger';
 import { getMaker } from '../../maker-host';
-import { getSessionProvider, setSessionProvider } from '../../maker-host/session-provider-store';
+import {
+  getSessionProvider,
+  normalizeSessionProviderId,
+  setSessionProvider,
+} from '../../maker-host/session-provider-store';
 import {
   clearPendingCredentialSwitchForSession,
   getPendingCredentialSwitchTarget,
@@ -240,8 +244,9 @@ export function createCardActionHandler(
     const effort = (event.payload.effort ?? null) as Effort | null;
     // providerId:新卡片携带(供应商/模型名 picker);老卡片(升级前发出的)没有 → undefined,
     // 此时保持旧行为(只切 model/effort,不动会话的供应商选择)。
-    const providerId =
-      typeof event.payload.providerId === 'string' ? event.payload.providerId : undefined;
+    const providerId = normalizeSessionProviderId(
+      typeof event.payload.providerId === 'string' ? event.payload.providerId : undefined,
+    );
 
     if (!sessionId || !modelId) {
       log.warn('model:pick missing sessionId/modelId — ignoring');

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -33,6 +33,7 @@ import {
   getPendingCredentialSwitchTarget,
   isSessionInTurn,
   registerPendingCredentialSwitchForSession,
+  withSendToSessionLock,
   wakeSessionInputAfterCredentialSwitch,
 } from '../../maker-ipc/register';
 import { applyRuntimeSetModelChange } from '../../maker-ipc/runtimeSetModel';
@@ -259,94 +260,99 @@ export function createCardActionHandler(
       }
     };
 
-    let previousRoute: Awaited<ReturnType<typeof readModelRouteSnapshot>> = null;
-    try {
-      previousRoute = await readModelRouteSnapshot(sessionId);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn(`model:pick route snapshot failed (non-fatal): ${msg}`);
-    }
-    const previousProviderId = previousRoute?.providerId ?? getSessionProvider(sessionId);
-    const restorePersistentRoute = async (reason: string): Promise<void> => {
-      if (!previousRoute) return;
+    const failureReason = await withSendToSessionLock(sessionId, async () => {
+      let previousRoute: Awaited<ReturnType<typeof readModelRouteSnapshot>> = null;
       try {
-        await updateModelEffort(
-          sessionId,
-          previousRoute.model,
-          previousRoute.effort,
-          providerId !== undefined ? previousRoute.providerId : undefined,
-        );
-      } catch (restoreErr) {
-        const restoreMsg = restoreErr instanceof Error ? restoreErr.message : String(restoreErr);
-        log.warn(`model:pick DB rollback after ${reason} failed (non-fatal): ${restoreMsg}`);
+        previousRoute = await readModelRouteSnapshot(sessionId);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(`model:pick route snapshot failed (non-fatal): ${msg}`);
       }
-    };
-    const rollbackRuntimeChange = async (reason: string): Promise<void> => {
-      if (providerId !== undefined) {
-        setSessionProvider(sessionId, previousProviderId);
-      }
-      const liveForRollback = turnRunner.getMakerSessionById(sessionId);
-      if (!liveForRollback || !previousRoute) return;
-      try {
-        await liveForRollback.setModel(previousRoute.model);
-        if (effort) {
-          await liveForRollback.setEffort(previousRoute.effort);
+      const previousProviderId = previousRoute?.providerId ?? getSessionProvider(sessionId);
+      const restorePersistentRoute = async (reason: string): Promise<void> => {
+        if (!previousRoute) return;
+        try {
+          await updateModelEffort(
+            sessionId,
+            previousRoute.model,
+            previousRoute.effort,
+            providerId !== undefined ? previousRoute.providerId : undefined,
+          );
+        } catch (restoreErr) {
+          const restoreMsg = restoreErr instanceof Error ? restoreErr.message : String(restoreErr);
+          log.warn(`model:pick DB rollback after ${reason} failed (non-fatal): ${restoreMsg}`);
         }
-      } catch (rollbackErr) {
-        const rollbackMsg =
-          rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
-        log.warn(`model:pick live rollback after ${reason} failed (non-fatal): ${rollbackMsg}`);
+      };
+      const rollbackRuntimeChange = async (reason: string): Promise<void> => {
+        if (providerId !== undefined) {
+          setSessionProvider(sessionId, previousProviderId);
+        }
+        const liveForRollback = turnRunner.getMakerSessionById(sessionId);
+        if (!liveForRollback || !previousRoute) return;
+        try {
+          await liveForRollback.setModel(previousRoute.model);
+          if (effort) {
+            await liveForRollback.setEffort(previousRoute.effort);
+          }
+        } catch (rollbackErr) {
+          const rollbackMsg =
+            rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+          log.warn(`model:pick live rollback after ${reason} failed (non-fatal): ${rollbackMsg}`);
+        }
+      };
+
+      // 持久化与运行态切换必须和 send / agent switch 共用 session 锁，保证后选覆盖先选。
+      try {
+        await updateModelEffort(sessionId, modelId, effort ?? 'high', providerId);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`model:pick DB update failed: ${msg}`);
+        return msg;
       }
-    };
 
-    // 先持久化,再做可能关闭 live session 的运行态切换;避免失败卡已经返回但 live session 被关掉。
-    try {
-      await updateModelEffort(sessionId, modelId, effort ?? 'high', providerId);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error(`model:pick DB update failed: ${msg}`);
-      await patchModelPickFailed(msg);
-      return;
-    }
+      try {
+        const runtimeChange = await applyRuntimeSetModelChange({
+          maker: getMaker(),
+          sessionId,
+          model: modelId,
+          providerId,
+          isSessionInTurn,
+          registerPendingCredentialSwitch: registerPendingCredentialSwitchForSession,
+          clearPendingCredentialSwitch: clearPendingCredentialSwitchForSession,
+          wakeSessionInputQueue: wakeSessionInputAfterCredentialSwitch,
+          getPendingCredentialSwitch: getPendingCredentialSwitchTarget,
+          logger: log,
+        });
 
-    try {
-      const runtimeChange = await applyRuntimeSetModelChange({
-        maker: getMaker(),
-        sessionId,
-        model: modelId,
-        providerId,
-        isSessionInTurn,
-        registerPendingCredentialSwitch: registerPendingCredentialSwitchForSession,
-        clearPendingCredentialSwitch: clearPendingCredentialSwitchForSession,
-        wakeSessionInputQueue: wakeSessionInputAfterCredentialSwitch,
-        getPendingCredentialSwitch: getPendingCredentialSwitchTarget,
-        logger: log,
-      });
+        const liveAfterModel = turnRunner.getMakerSessionById(sessionId);
+        if (runtimeChange.status !== 'deferred' && liveAfterModel && effort) {
+          try {
+            await liveAfterModel.setEffort(effort);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            log.warn(`model:pick live setEffort failed: ${msg}`);
+            await restorePersistentRoute('setEffort');
+            await rollbackRuntimeChange('setEffort');
+            return msg;
+          }
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(`model:pick runtime setModel failed: ${msg}`);
+        await restorePersistentRoute('runtime setModel');
+        return msg;
+      }
 
       const liveAfterModel = turnRunner.getMakerSessionById(sessionId);
-      if (runtimeChange.status !== 'deferred' && liveAfterModel && effort) {
-        try {
-          await liveAfterModel.setEffort(effort);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          log.warn(`model:pick live setEffort failed: ${msg}`);
-          await restorePersistentRoute('setEffort');
-          await rollbackRuntimeChange('setEffort');
-          await patchModelPickFailed(msg);
-          return;
-        }
+      if (!liveAfterModel) {
+        log.info(`model:pick: no live session for ${sessionId.slice(-8)} — DB updated only`);
       }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn(`model:pick runtime setModel failed: ${msg}`);
-      await restorePersistentRoute('runtime setModel');
-      await patchModelPickFailed(msg);
-      return;
-    }
+      return null;
+    });
 
-    const liveAfterModel = turnRunner.getMakerSessionById(sessionId);
-    if (!liveAfterModel) {
-      log.info(`model:pick: no live session for ${sessionId.slice(-8)} — DB updated only`);
+    if (failureReason !== null) {
+      await patchModelPickFailed(failureReason);
+      return;
     }
 
     try {

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -33,6 +33,7 @@ import {
   setSessionProvider,
 } from '../../maker-host/session-provider-store';
 import {
+  cancelPendingAgentSwitchForSession,
   clearPendingCredentialSwitchForSession,
   getPendingCredentialSwitchTarget,
   isSessionInTurn,
@@ -354,6 +355,9 @@ export function createCardActionHandler(
       if (!liveAfterModel) {
         log.info(`model:pick: no live session for ${sessionId.slice(-8)} — DB updated only`);
       }
+      // 这次 IM 选择晚于 renderer 登记的跨引擎 intent；只有整条 route 更新成功后
+      // 才取消旧 intent，失败回滚时仍保留它供下一次发送重试。
+      cancelPendingAgentSwitchForSession(sessionId);
       return null;
     });
 

--- a/apps/desktop/src/main/im/shared/orchestrator.ts
+++ b/apps/desktop/src/main/im/shared/orchestrator.ts
@@ -11,7 +11,7 @@
  */
 
 import { createLogger } from '../../logger';
-import { applyPendingAgentSwitchForDirectSend } from '../../maker-ipc/register';
+import { acquirePendingAgentSwitchForDirectSend } from '../../maker-ipc/register';
 import { createImSessionRepo, type ImSessionRepo } from './sessionRepo';
 import { createCardBuilders, type ImCardBuilders } from './cardBuilders';
 import { createTurnRunner, type ImTurnRunner } from './turnRunner';
@@ -56,7 +56,7 @@ export function createImOrchestrator(adapter: ImChannelAdapter): ImOrchestrator 
   const repo = createImSessionRepo(adapter.config, adapter.sessions);
   const cards = createCardBuilders(adapter.ui, repo.getDefaultEffortFor);
   const turnRunner = createTurnRunner(adapter, repo, cards, {
-    applyPendingAgentSwitch: applyPendingAgentSwitchForDirectSend,
+    acquirePendingAgentSwitch: acquirePendingAgentSwitchForDirectSend,
   });
   const slash = createSlashHandlers(adapter, repo, cards, turnRunner);
   const attachMessageHandler = createMessageHandler(adapter, slash, turnRunner);

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -643,14 +643,22 @@ export function createTurnRunner(
     );
 
     let releaseAgentSwitchLock = (): void => {};
-    if (deps.acquirePendingAgentSwitch) {
-      agentSwitchCloseSuppressed.add(rowId);
-    }
     try {
       // deferred 切换会关闭旧 session。apply 成功后重新读取 maker 里的 live
       // session 并原地换绑 IM listener,确保当前这条消息发给目标引擎且队列不丢。
-      releaseAgentSwitchLock = (await deps.acquirePendingAgentSwitch?.(rowId)) ?? (() => {});
-      await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
+      if (deps.acquirePendingAgentSwitch) {
+        agentSwitchCloseSuppressed.add(rowId);
+        try {
+          releaseAgentSwitchLock = await deps.acquirePendingAgentSwitch(rowId);
+          await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
+        } finally {
+          // 只覆盖 agent switch 关闭旧引擎并换绑新 session 的窗口。刷新完成后的
+          // send 期间若会话被其它路径关闭，必须让全局订阅清掉陈旧 SessionState。
+          agentSwitchCloseSuppressed.delete(rowId);
+        }
+      } else {
+        await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
+      }
       // session-agent-switch:本路径直发 session.send(不经 makerSendTransaction),
       // 交接注入自己接——切换后首条消息若来自 IM 渠道,新引擎同样需要交接上下文
       // (2026-07-20 审计)。落库(persistUserMessage)仍是渠道原文。
@@ -725,7 +733,6 @@ export function createTurnRunner(
       });
     } finally {
       releaseAgentSwitchLock();
-      agentSwitchCloseSuppressed.delete(rowId);
     }
   }
 

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -299,8 +299,8 @@ export interface ImTurnRunner {
 }
 
 export interface ImTurnRunnerDeps {
-  /** IM 直发前落实 deferred agent switch,并 bootstrap 新 live session。 */
-  applyPendingAgentSwitch?: (sessionId: string) => Promise<void>;
+  /** 锁住 session 并落实 deferred switch；IM 在刷新 live session + send 后 release。 */
+  acquirePendingAgentSwitch?: (sessionId: string) => Promise<() => void>;
 }
 
 export function createTurnRunner(
@@ -642,9 +642,14 @@ export function createTurnRunner(
       `enqueued turn for session=${rowId.slice(-8)} queueDepth=${state.queue.length} pendingSends=${state.sendQueue.length}`,
     );
 
+    let releaseAgentSwitchLock = (): void => {};
+    if (deps.acquirePendingAgentSwitch) {
+      agentSwitchCloseSuppressed.add(rowId);
+    }
     try {
       // deferred 切换会关闭旧 session。apply 成功后重新读取 maker 里的 live
       // session 并原地换绑 IM listener,确保当前这条消息发给目标引擎且队列不丢。
+      releaseAgentSwitchLock = (await deps.acquirePendingAgentSwitch?.(rowId)) ?? (() => {});
       await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
       // session-agent-switch:本路径直发 session.send(不经 makerSendTransaction),
       // 交接注入自己接——切换后首条消息若来自 IM 渠道,新引擎同样需要交接上下文
@@ -718,6 +723,9 @@ export function createTurnRunner(
         context: buildSendContext(rowId),
         error: normalized.error,
       });
+    } finally {
+      releaseAgentSwitchLock();
+      agentSwitchCloseSuppressed.delete(rowId);
     }
   }
 
@@ -726,62 +734,56 @@ export function createTurnRunner(
     sessionId: string,
     userId: string,
   ): Promise<void> {
-    if (!deps.applyPendingAgentSwitch) return;
+    if (!deps.acquirePendingAgentSwitch) return;
     const previous = state.makerSession;
-    agentSwitchCloseSuppressed.add(sessionId);
-    try {
-      await deps.applyPendingAgentSwitch(sessionId);
-      const maker = getMaker();
-      let current = maker.getSession(sessionId);
-      // apply 已提交 DB 但 bootstrap 失败时,直发路径也要像 makerSendTransaction 的
-      // lazy-create 一样按最新 DB 行自愈,不能退回已关闭的 previous.send()。
-      if (!current) {
-        const [row] = await getDbClient()
-          .drizzle.select()
-          .from(sessionsTable)
-          .where(eq(sessionsTable.id, sessionId))
-          .limit(1);
-        if (!row?.workingDir) {
-          throw new Error(`session ${sessionId} missing after deferred agent switch`);
-        }
-        const agentKind = toCoreAgentKind(row.agentKind);
-        hydrateSessionProvider(sessionId, row.providerId ?? null);
-        if (row.effort) setSessionEffort(sessionId, row.effort);
-        setSessionFastMode(sessionId, !!row.fastMode);
-        current = await maker.createSession({
-          id: sessionId,
-          agentKind,
-          workingDir: row.workingDir,
-          model: row.model,
-          effort: row.effort,
-          permissionMode: row.permissionMode,
-          fastMode: row.fastMode,
-          providerId: row.providerId ?? undefined,
-          resumeSessionId: row.sdkSessionId ?? undefined,
-          vendorOptions: state.attached
-            ? undefined
-            : adapter.buildVendorOptions(userId, state.scopeKey),
-        });
+    const maker = getMaker();
+    let current = maker.getSession(sessionId);
+    // apply 已提交 DB 但 bootstrap 失败时,直发路径也要像 makerSendTransaction 的
+    // lazy-create 一样按最新 DB 行自愈,不能退回已关闭的 previous.send()。
+    if (!current) {
+      const [row] = await getDbClient()
+        .drizzle.select()
+        .from(sessionsTable)
+        .where(eq(sessionsTable.id, sessionId))
+        .limit(1);
+      if (!row?.workingDir) {
+        throw new Error(`session ${sessionId} missing after deferred agent switch`);
       }
-      if (current === previous) return;
-
-      for (const unsubscribe of state.unsubscribers) {
-        try {
-          unsubscribe();
-        } catch {
-          /* closed old session listener */
-        }
-      }
-      state.unsubscribers = [];
-      previous.setInteractionListener(null);
-      state.makerSession = current;
-      wireSessionToIpcExternal(current);
-      state.unsubscribers.push(current.onEvent(handleEventFor(sessionId, userId)));
-      current.setInteractionListener(handleInteractionFor(sessionId, userId, state.scopeKey));
-      sessionStates.set(sessionId, state);
-    } finally {
-      agentSwitchCloseSuppressed.delete(sessionId);
+      const agentKind = toCoreAgentKind(row.agentKind);
+      hydrateSessionProvider(sessionId, row.providerId ?? null);
+      if (row.effort) setSessionEffort(sessionId, row.effort);
+      setSessionFastMode(sessionId, !!row.fastMode);
+      current = await maker.createSession({
+        id: sessionId,
+        agentKind,
+        workingDir: row.workingDir,
+        model: row.model,
+        effort: row.effort,
+        permissionMode: row.permissionMode,
+        fastMode: row.fastMode,
+        providerId: row.providerId ?? undefined,
+        resumeSessionId: row.sdkSessionId ?? undefined,
+        vendorOptions: state.attached
+          ? undefined
+          : adapter.buildVendorOptions(userId, state.scopeKey),
+      });
     }
+    if (current === previous) return;
+
+    for (const unsubscribe of state.unsubscribers) {
+      try {
+        unsubscribe();
+      } catch {
+        /* closed old session listener */
+      }
+    }
+    state.unsubscribers = [];
+    previous.setInteractionListener(null);
+    state.makerSession = current;
+    wireSessionToIpcExternal(current);
+    state.unsubscribers.push(current.onEvent(handleEventFor(sessionId, userId)));
+    current.setInteractionListener(handleInteractionFor(sessionId, userId, state.scopeKey));
+    sessionStates.set(sessionId, state);
   }
 
   /**

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -328,8 +328,14 @@ export function createTurnRunner(
    *  the cache, both spawn a maker session, and the second clobbers the first
    *  in `sessionStates`. */
   const wiringInFlight = new Map<string, Promise<SessionState>>();
-  /** agent switch 主动 close 旧引擎时保留 IM 队列,待新 live session 原地接管。 */
-  const agentSwitchCloseSuppressed = new Set<string>();
+  /**
+   * agent switch 主动 close 的旧 Session。只有对象身份和 close reason 都匹配才
+   * 忽略；同一业务 sessionId 下的用户关闭或新引擎关闭必须照常清缓存。
+   */
+  const agentSwitchCloseSuppressed = new Map<
+    string,
+    { expectedSession: MakerSession }
+  >();
   type MakerInstance = ReturnType<typeof getMaker>;
   let subscribedMaker: MakerInstance | null = null;
   let unsubscribeMakerEvents: (() => void) | null = null;
@@ -340,7 +346,11 @@ export function createTurnRunner(
     subscribedMaker = maker;
     unsubscribeMakerEvents = maker.on((event) => {
       if (event.type !== 'session:closed') return;
-      if (agentSwitchCloseSuppressed.has(event.sessionId)) return;
+      const suppression = agentSwitchCloseSuppressed.get(event.sessionId);
+      if (
+        suppression?.expectedSession === event.session &&
+        event.reason === 'agent-switch'
+      ) return;
       forgetClosedSession(event.sessionId, 'maker session closed');
     });
   }
@@ -647,15 +657,19 @@ export function createTurnRunner(
       // deferred 切换会关闭旧 session。apply 成功后重新读取 maker 里的 live
       // session 并原地换绑 IM listener,确保当前这条消息发给目标引擎且队列不丢。
       if (deps.acquirePendingAgentSwitch) {
-        agentSwitchCloseSuppressed.add(rowId);
+        const suppression = {
+          expectedSession: state.makerSession,
+        };
+        agentSwitchCloseSuppressed.set(rowId, suppression);
         try {
           releaseAgentSwitchLock = await deps.acquirePendingAgentSwitch(rowId);
-          await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
         } finally {
-          // 只覆盖 agent switch 关闭旧引擎并换绑新 session 的窗口。刷新完成后的
-          // send 期间若会话被其它路径关闭，必须让全局订阅清掉陈旧 SessionState。
           agentSwitchCloseSuppressed.delete(rowId);
         }
+        if (sessionStates.get(rowId) !== state) {
+          throw new Error(`session ${rowId} closed while refreshing deferred agent switch`);
+        }
+        await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
       } else {
         await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
       }
@@ -744,16 +758,23 @@ export function createTurnRunner(
     if (!deps.acquirePendingAgentSwitch) return;
     const previous = state.makerSession;
     const maker = getMaker();
+    const [row] = await getDbClient()
+      .drizzle.select()
+      .from(sessionsTable)
+      .where(eq(sessionsTable.id, sessionId))
+      .limit(1);
+    if (!row || row.status === 'archived' || row.status === 'deleted') {
+      forgetClosedSession(
+        sessionId,
+        `session became ${row?.status ?? 'missing'} during route refresh`,
+      );
+      throw new Error(`session ${sessionId} is not active after deferred agent switch`);
+    }
     let current = maker.getSession(sessionId);
     // apply 已提交 DB 但 bootstrap 失败时,直发路径也要像 makerSendTransaction 的
     // lazy-create 一样按最新 DB 行自愈,不能退回已关闭的 previous.send()。
     if (!current) {
-      const [row] = await getDbClient()
-        .drizzle.select()
-        .from(sessionsTable)
-        .where(eq(sessionsTable.id, sessionId))
-        .limit(1);
-      if (!row?.workingDir) {
+      if (!row.workingDir) {
         throw new Error(`session ${sessionId} missing after deferred agent switch`);
       }
       const agentKind = toCoreAgentKind(row.agentKind);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -71,15 +71,19 @@ export function broadcastSessionPatched(sessionId: string, patch: Record<string,
 function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unknown): void {
   if (status !== 'deleted' && status !== 'archived') return;
   void (async () => {
-    const [mh, recycle] = await Promise.all([
+    const [mh, recycle, routeLock] = await Promise.all([
       import('../../maker-host/index.js'),
       import('../../worktree/sessionRemovalRecycle.js'),
+      import('../../maker-ipc/register.js'),
     ]);
     if (!(await recycle.isSessionStillRemovable(sessionId))) return;
-    await mh
-      .getMakerIfReady()
-      ?.closeSession(sessionId)
-      .catch(() => undefined);
+    await routeLock.withSendToSessionLock(sessionId, async () => {
+      if (!(await recycle.isSessionStillRemovable(sessionId))) return;
+      await mh
+        .getMakerIfReady()
+        ?.closeSession(sessionId)
+        .catch(() => undefined);
+    });
     await recycle.recycleWorktreeForRemovedSession(sessionId);
   })().catch((err) => {
     log.warn('worktree recycle after session status change failed', {

--- a/apps/desktop/src/main/maker-host/session-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/session-provider-store.ts
@@ -16,9 +16,18 @@
 
 const bySession = new Map<string, string | null>();
 
+/** Canonical provider id used by runtime routing and every persistence adapter. */
+export function normalizeSessionProviderId(
+  providerId: string | null | undefined,
+): string | null | undefined {
+  if (providerId === undefined) return undefined;
+  if (typeof providerId !== 'string') return null;
+  return providerId.trim() || null;
+}
+
 /** 设定某会话的供应商(SET_MODEL 携带 providerId 时调用)。null/'' = 清除显式选择。 */
 export function setSessionProvider(sessionId: string, providerId: string | null): void {
-  bySession.set(sessionId, providerId && providerId.trim() ? providerId : null);
+  bySession.set(sessionId, normalizeSessionProviderId(providerId) ?? null);
 }
 
 /** 读取某会话的供应商;未设置或已清除返回 null(调用方据此走默认路由)。 */
@@ -32,7 +41,7 @@ export function getSessionProvider(sessionId: string): string | null {
  */
 export function hydrateSessionProvider(sessionId: string, providerId: string | null): void {
   if (!bySession.has(sessionId)) {
-    bySession.set(sessionId, providerId && providerId.trim() ? providerId : null);
+    bySession.set(sessionId, normalizeSessionProviderId(providerId) ?? null);
   }
 }
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -77,6 +77,45 @@ describe('applyRuntimeSetModelChange', () => {
     expect(getSessionProvider(sessionId)).toBe('xd');
   });
 
+  it('normalizes a whitespace provider before route and busy-session decisions', async () => {
+    const sessionId = rememberSession('runtime-set-model-normalize-provider');
+    const setModel = vi.fn(async () => {});
+    const registerPendingCredentialSwitch = vi.fn();
+    const clearPendingCredentialSwitch = vi.fn();
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        model: 'gpt-5.4',
+        setModel,
+      }),
+      listActiveSessions: () => [
+        {
+          id: sessionId,
+          agentKind: 'codex',
+          remoteHostId: null,
+          isTurnRunning: () => true,
+        },
+      ],
+      closeSession: vi.fn(async () => {}),
+    };
+
+    const result = await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'gpt-5.4',
+      providerId: '   ',
+      registerPendingCredentialSwitch,
+      clearPendingCredentialSwitch,
+    });
+
+    expect(result).toEqual({ status: 'applied' });
+    expect(registerPendingCredentialSwitch).not.toHaveBeenCalled();
+    expect(clearPendingCredentialSwitch).toHaveBeenCalledWith(sessionId);
+    expect(setModel).toHaveBeenCalledWith('gpt-5.4');
+    expect(getSessionProvider(sessionId)).toBeNull();
+  });
+
   it('soft-closes local Codex sessions instead of reusing a host across credential families', async () => {
     const sessionId = rememberSession('runtime-set-model-close-codex');
     setSessionProvider(sessionId, 'openai');

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
@@ -129,6 +129,24 @@ describe('performSessionAgentSwitch', () => {
     );
   });
 
+  it.each([
+    ['空白值', '  ', null],
+    ['首尾空格', ' anthropic ', 'anthropic'],
+  ])('%s providerId 在 DB 与内存路由中使用同一归一化值', async (_case, providerId, expected) => {
+    const { deps } = makeDeps();
+
+    await performSessionAgentSwitch(deps, {
+      ...validParams,
+      providerId,
+    });
+
+    expect(deps.applyAgentSwitchToDb).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ providerId: expected }),
+    );
+    expect(deps.setSessionProvider).toHaveBeenCalledWith('s1', expected);
+  });
+
   it('参数校验:非法 sessionId / targetAgentKind / model 抛 INVALID_PARAMS', async () => {
     const { deps } = makeDeps();
     await expect(performSessionAgentSwitch(deps, { ...validParams, sessionId: 7 })).rejects.toThrow(/INVALID_PARAMS/);

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
@@ -43,6 +43,9 @@ function makeDeps(overrides: Partial<MakerSessionAgentSwitchHandlerDeps> = {}): 
     applyAgentSwitchToDb: vi.fn(async () => {
       calls.push('db');
     }),
+    setSessionProvider: vi.fn(() => {
+      calls.push('provider');
+    }),
     insertBoundaryMessage: vi.fn(async () => {
       calls.push('boundary');
       return 'boundary-client-1';
@@ -75,13 +78,14 @@ describe('performSessionAgentSwitch', () => {
     const { deps, calls } = makeDeps();
     const result = await performSessionAgentSwitch(deps, validParams);
     expect(result).toEqual({ switched: true, agentKind: 'codex', model: 'gpt-5.5', engineReady: true });
-    expect(calls).toEqual(['close', 'db', 'boundary', 'pending', 'bootstrap']);
+    expect(calls).toEqual(['close', 'db', 'provider', 'boundary', 'pending', 'bootstrap']);
     expect(deps.applyAgentSwitchToDb).toHaveBeenCalledWith('s1', {
       agentKind: 'codex',
       model: 'gpt-5.5',
       providerId: null,
       sdkSessionId: null,
     });
+    expect(deps.setSessionProvider).toHaveBeenCalledWith('s1', null);
     const boundary = vi.mocked(deps.insertBoundaryMessage).mock.calls[0][1];
     expect(boundary.fromAgentKind).toBe('cc');
     expect(boundary.toAgentKind).toBe('codex');
@@ -105,9 +109,24 @@ describe('performSessionAgentSwitch', () => {
       model: 'claude-fable-5',
     });
     expect(result.switched).toBe(true);
+    expect(deps.setSessionProvider).not.toHaveBeenCalled();
     const boundary = vi.mocked(deps.insertBoundaryMessage).mock.calls[0][1];
     expect(boundary.fromAgentKind).toBe('codex');
     expect(boundary.toAgentKind).toBe('cc');
+  });
+
+  it('跨引擎 DB 提交后立即覆盖旧 provider route', async () => {
+    const { deps } = makeDeps();
+
+    await performSessionAgentSwitch(deps, {
+      ...validParams,
+      providerId: 'anthropic',
+    });
+
+    expect(deps.setSessionProvider).toHaveBeenCalledWith('s1', 'anthropic');
+    expect(vi.mocked(deps.applyAgentSwitchToDb).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(deps.setSessionProvider).mock.invocationCallOrder[0],
+    );
   });
 
   it('参数校验:非法 sessionId / targetAgentKind / model 抛 INVALID_PARAMS', async () => {
@@ -156,7 +175,7 @@ describe('performSessionAgentSwitch', () => {
     const { deps, calls } = makeDeps({ getLiveSession: vi.fn(() => null) });
     const result = await performSessionAgentSwitch(deps, validParams);
     expect(result.switched).toBe(true);
-    expect(calls).toEqual(['db', 'boundary', 'pending', 'bootstrap']);
+    expect(calls).toEqual(['db', 'provider', 'boundary', 'pending', 'bootstrap']);
   });
 
   it('边界行插入失败降级:仍设 pending 并 bootstrap,返回成功', async () => {
@@ -167,7 +186,7 @@ describe('performSessionAgentSwitch', () => {
     });
     const result = await performSessionAgentSwitch(deps, validParams);
     expect(result.switched).toBe(true);
-    expect(calls).toEqual(['close', 'db', 'pending', 'bootstrap']);
+    expect(calls).toEqual(['close', 'db', 'provider', 'pending', 'bootstrap']);
     expect(deps.log.warn).toHaveBeenCalled();
   });
 
@@ -190,6 +209,7 @@ describe('performSessionAgentSwitch', () => {
     });
     await expect(performSessionAgentSwitch(deps, validParams)).rejects.toThrow('db locked');
     expect(calls).toEqual(['close']);
+    expect(deps.setSessionProvider).not.toHaveBeenCalled();
   });
 });
 
@@ -264,7 +284,7 @@ describe('deferred switch (turn running)', () => {
       skipBootstrap: true,
     });
     expect(result).toMatchObject({ switched: true });
-    expect(calls).toEqual(['close', 'db', 'boundary', 'pending']);
+    expect(calls).toEqual(['close', 'db', 'provider', 'boundary', 'pending']);
   });
 
   it('意图制:effort/fastMode 经意图透传到 applyAgentSwitchToDb', async () => {
@@ -301,7 +321,7 @@ describe('deferred switch (turn running)', () => {
     await applyPendingAgentSwitchIfIdle(deps, 's1');
     expect(store.has('s1')).toBe(false);
     // skipBootstrap:不含 'bootstrap'
-    expect(calls).toEqual(['close', 'db', 'boundary', 'pending']);
+    expect(calls).toEqual(['close', 'db', 'provider', 'boundary', 'pending']);
     expect(deps.applyAgentSwitchToDb).toHaveBeenCalledWith('s1', {
       agentKind: 'codex',
       model: 'gpt-5.5',
@@ -432,7 +452,7 @@ describe('deferred switch (turn running)', () => {
 
     await applyPendingAgentSwitchIfIdle(deps, 's1', { signal: controller.signal });
 
-    expect(calls).toEqual(['close', 'db', 'boundary', 'pending']);
+    expect(calls).toEqual(['close', 'db', 'provider', 'boundary', 'pending']);
     expect(store.has('s1')).toBe(false);
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
@@ -289,6 +289,19 @@ describe('deferred switch (turn running)', () => {
     });
   });
 
+  it('跨引擎意图淘汰较早的 pending credential switch', async () => {
+    const supersedePendingCredentialSwitch = vi.fn();
+    const { deps, store } = makeDepsWithPending({ supersedePendingCredentialSwitch });
+
+    await performSessionAgentSwitch(deps, validParams);
+
+    expect(supersedePendingCredentialSwitch).toHaveBeenCalledWith('s1');
+    expect(store.get('s1')).toMatchObject({
+      targetAgentKind: 'codex',
+      model: 'gpt-5.5',
+    });
+  });
+
   it('意图制:反复改选只覆盖意图,applyNow 才执行真切换', async () => {
     const { deps, calls, store } = makeDepsWithPending();
     await performSessionAgentSwitch(deps, validParams);

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionProviderBootstrap.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionProviderBootstrap.test.ts
@@ -1,39 +1,64 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { persistAndHydrateSessionProvider } from '../sessionProviderBootstrap.js';
+import {
+  clearSessionProvider,
+  getSessionProvider,
+  setSessionProvider,
+} from '../../maker-host/session-provider-store.js';
+import { persistAndActivateSessionProvider } from '../sessionProviderBootstrap.js';
 
-describe('persistAndHydrateSessionProvider', () => {
-  it('persists explicit providerId=null and hydrates the cleared route', async () => {
+const TEST_SESSION_ID = 'session-provider-bootstrap-test';
+
+afterEach(() => {
+  clearSessionProvider(TEST_SESSION_ID);
+});
+
+describe('persistAndActivateSessionProvider', () => {
+  it('persists explicit providerId=null and activates the cleared route', async () => {
     let storedProviderId: string | null = 'anthropic';
-    const hydrateSessionProvider = vi.fn();
+    const activateSessionProvider = vi.fn();
 
-    await persistAndHydrateSessionProvider({
+    await persistAndActivateSessionProvider({
       sessionId: 'session-1',
       providerId: null,
       updateProviderId: vi.fn(async (_sessionId, providerId) => {
         storedProviderId = providerId;
       }),
       readProviderId: vi.fn(async () => storedProviderId),
-      hydrateSessionProvider,
+      setSessionProvider: activateSessionProvider,
     });
 
     expect(storedProviderId).toBeNull();
-    expect(hydrateSessionProvider).toHaveBeenCalledWith('session-1', null);
+    expect(activateSessionProvider).toHaveBeenCalledWith('session-1', null);
   });
 
-  it('leaves DB unchanged for providerId=undefined but still hydrates persisted value', async () => {
+  it('leaves DB unchanged for providerId=undefined but still activates persisted value', async () => {
     const updateProviderId = vi.fn(async () => {});
-    const hydrateSessionProvider = vi.fn();
+    const activateSessionProvider = vi.fn();
 
-    await persistAndHydrateSessionProvider({
+    await persistAndActivateSessionProvider({
       sessionId: 'session-1',
       providerId: undefined,
       updateProviderId,
       readProviderId: vi.fn(async () => 'openrouter'),
-      hydrateSessionProvider,
+      setSessionProvider: activateSessionProvider,
     });
 
     expect(updateProviderId).not.toHaveBeenCalled();
-    expect(hydrateSessionProvider).toHaveBeenCalledWith('session-1', 'openrouter');
+    expect(activateSessionProvider).toHaveBeenCalledWith('session-1', 'openrouter');
+  });
+
+  it('replaces the previous engine provider route with the persisted provider', async () => {
+    setSessionProvider(TEST_SESSION_ID, 'openai');
+
+    await persistAndActivateSessionProvider({
+      sessionId: TEST_SESSION_ID,
+      providerId: 'anthropic',
+      updateProviderId: vi.fn(async () => {}),
+      readProviderId: vi.fn(async () => 'anthropic'),
+      setSessionProvider,
+    });
+
+    expect(getSessionProvider(TEST_SESSION_ID)).toBe('anthropic');
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionProviderBootstrap.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionProviderBootstrap.test.ts
@@ -3,9 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   clearSessionProvider,
   getSessionProvider,
+  hydrateSessionProvider,
   setSessionProvider,
 } from '../../maker-host/session-provider-store.js';
-import { persistAndActivateSessionProvider } from '../sessionProviderBootstrap.js';
+import { persistAndHydrateSessionProvider } from '../sessionProviderBootstrap.js';
 
 const TEST_SESSION_ID = 'session-provider-bootstrap-test';
 
@@ -13,51 +14,73 @@ afterEach(() => {
   clearSessionProvider(TEST_SESSION_ID);
 });
 
-describe('persistAndActivateSessionProvider', () => {
-  it('persists explicit providerId=null and activates the cleared route', async () => {
+describe('persistAndHydrateSessionProvider', () => {
+  it('persists explicit providerId=null and hydrates the cleared route', async () => {
     let storedProviderId: string | null = 'anthropic';
-    const activateSessionProvider = vi.fn();
+    const hydrateSessionProvider = vi.fn();
 
-    await persistAndActivateSessionProvider({
+    await persistAndHydrateSessionProvider({
       sessionId: 'session-1',
       providerId: null,
       updateProviderId: vi.fn(async (_sessionId, providerId) => {
         storedProviderId = providerId;
       }),
       readProviderId: vi.fn(async () => storedProviderId),
-      setSessionProvider: activateSessionProvider,
+      hydrateSessionProvider,
     });
 
     expect(storedProviderId).toBeNull();
-    expect(activateSessionProvider).toHaveBeenCalledWith('session-1', null);
+    expect(hydrateSessionProvider).toHaveBeenCalledWith('session-1', null);
   });
 
-  it('leaves DB unchanged for providerId=undefined but still activates persisted value', async () => {
+  it('leaves DB unchanged for providerId=undefined but still hydrates persisted value', async () => {
     const updateProviderId = vi.fn(async () => {});
-    const activateSessionProvider = vi.fn();
+    const hydrateSessionProvider = vi.fn();
 
-    await persistAndActivateSessionProvider({
+    await persistAndHydrateSessionProvider({
       sessionId: 'session-1',
       providerId: undefined,
       updateProviderId,
       readProviderId: vi.fn(async () => 'openrouter'),
-      setSessionProvider: activateSessionProvider,
+      hydrateSessionProvider,
     });
 
     expect(updateProviderId).not.toHaveBeenCalled();
-    expect(activateSessionProvider).toHaveBeenCalledWith('session-1', 'openrouter');
+    expect(hydrateSessionProvider).toHaveBeenCalledWith('session-1', 'openrouter');
   });
 
-  it('replaces the previous engine provider route with the persisted provider', async () => {
-    setSessionProvider(TEST_SESSION_ID, 'openai');
+  it('does not treat a missing DB row as an explicit provider clear', async () => {
+    setSessionProvider(TEST_SESSION_ID, 'anthropic');
 
-    await persistAndActivateSessionProvider({
+    await persistAndHydrateSessionProvider({
       sessionId: TEST_SESSION_ID,
-      providerId: 'anthropic',
+      providerId: undefined,
       updateProviderId: vi.fn(async () => {}),
-      readProviderId: vi.fn(async () => 'anthropic'),
-      setSessionProvider,
+      readProviderId: vi.fn(async () => undefined),
+      hydrateSessionProvider,
     });
+
+    expect(getSessionProvider(TEST_SESSION_ID)).toBe('anthropic');
+  });
+
+  it('does not overwrite a runtime provider selected while the DB read is in flight', async () => {
+    let resolveRead!: (providerId: string | null) => void;
+    const persistedProviderId = new Promise<string | null>((resolve) => {
+      resolveRead = resolve;
+    });
+    const readProviderId = vi.fn(async () => persistedProviderId);
+    const hydration = persistAndHydrateSessionProvider({
+      sessionId: TEST_SESSION_ID,
+      providerId: undefined,
+      updateProviderId: vi.fn(async () => {}),
+      readProviderId,
+      hydrateSessionProvider,
+    });
+    expect(readProviderId).toHaveBeenCalledWith(TEST_SESSION_ID);
+
+    setSessionProvider(TEST_SESSION_ID, 'anthropic');
+    resolveRead('openai');
+    await hydration;
 
     expect(getSessionProvider(TEST_SESSION_ID)).toBe('anthropic');
   });

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -374,7 +374,7 @@ import { prependHandoffToUserMessage } from './agentHandoff.js';
 import { hydrateQueuedAgentReferences } from './agentInputReferences.js';
 import { agentHandoffPending } from './agentHandoffPendingSingleton.js';
 import { type MakerSessionCreateOpts, withCreateSessionStderr } from './sessionRequest.js';
-import { persistAndHydrateSessionProvider } from './sessionProviderBootstrap.js';
+import { persistAndActivateSessionProvider } from './sessionProviderBootstrap.js';
 import { registerMakerSessionSendHandler } from './sessionSendHandler.js';
 import { registerStopAgentTaskHandler } from './stopAgentTaskHandler.js';
 import { registerStopSessionBackgroundTasksHandler } from './stopSessionBackgroundTasksHandler.js';
@@ -390,7 +390,7 @@ import {
   refreshCustomProvidersIntoCatalog,
 } from '../maker-host/createDesktopProviderService.js';
 import { connectedProvidersForAgent, effectiveSourceIdForModel } from '@cindy/model-providers';
-import { hydrateSessionProvider, getSessionProvider } from '../maker-host/session-provider-store.js';
+import { getSessionProvider, setSessionProvider } from '../maker-host/session-provider-store.js';
 import { getActiveCatalog, setDiscoveredProviderModels } from '../maker-host/active-catalog.js';
 import { testProviderConnection } from '../maker-host/provider-diagnostics.js';
 import { fetchProviderModels } from '../maker-host/provider-model-fetch.js';
@@ -3901,18 +3901,19 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     wireSessionToIpc(session);
     markOrcaMcpHydratedIfNeeded(session.id, o);
 
-    // per-session 供应商:从 DB(sessions.provider_id)回填路由 store —— 跨重启恢复会话显式选定的
-    // 供应商,让首个请求就按所选来源路由;无值则保持未设(→ 默认路由,行为不变)。hydrate 不覆盖
-    // 运行中已有的选择。读失败不致命(回落默认路由)。所有 create/resume 路径都经本funnel,单点覆盖。
+    // per-session 供应商:从 DB(sessions.provider_id)激活路由 store —— 新引擎实例必须以
+    // DB 已提交的选择覆盖同一 Cindy session 上一引擎留下的内存值,否则 Codex → Claude
+    // 切换后仍可能按旧来源路由。读失败不致命(回落现有路由)。所有 create/resume 路径
+    // 都经本 funnel,单点覆盖。
     //
     // device-link 远程 create(P2):DesktopSessionStorage.create 从 maker-core SessionMeta 建行,
-    // SessionMeta 不含 providerId → 远程新建行 provider_id 恒 NULL。这里在 hydrate 前用 create opts
-    // 的 providerId 补写 DB。providerId=null 是显式清除来源,也必须写库覆盖旧值;只有
+    // SessionMeta 不含 providerId → 远程新建行 provider_id 恒 NULL。这里在激活路由前用 create
+    // opts 的 providerId 补写 DB。providerId=null 是显式清除来源,也必须写库覆盖旧值;只有
     // providerId=undefined 才表示调用方没有携带来源选择。懒启动路径会在 maker.createSession
     // 前从 DB 预补 o.providerId,所以下面同时承担「新建落库」和「恢复路由 store」两件事。
     try {
       const db = getDbClient().drizzle;
-      await persistAndHydrateSessionProvider({
+      await persistAndActivateSessionProvider({
         sessionId: session.id,
         providerId: o.providerId,
         updateProviderId: async (targetSessionId, providerId) => {
@@ -3929,7 +3930,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
             .limit(1);
           return pRow?.providerId;
         },
-        hydrateSessionProvider,
+        setSessionProvider,
       });
       // bridge 会话态(effort / fast)同点 hydrate:让 resume / 重启后的首个 bridge 请求就带上
       // 用户上次选定的思维深度与 Fast(否则要等用户再点一次开关才写进内存 store)。
@@ -3941,7 +3942,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       if (efRow?.effort) setSessionEffort(session.id, efRow.effort);
       setSessionFastMode(session.id, !!efRow?.fastMode);
     } catch (err) {
-      log.debug('hydrate session provider failed (non-fatal)', {
+      log.debug('activate session provider failed (non-fatal)', {
         sessionId: session.id,
         error: err instanceof Error ? err.message : String(err),
       });

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -1548,21 +1548,47 @@ const pendingFailedTurnAssistantPersistId = new Map<string, string>();
  */
 const sendToSessionLocks = new Map<string, Promise<unknown>>();
 
-/** Serialize every local send / runtime release / route mutation for one session. */
-export function withSendToSessionLock<T>(
-  sessionId: string,
-  task: () => Promise<T>,
-): Promise<T> {
+/**
+ * Acquire the per-session send/route lock until the returned release callback runs.
+ *
+ * Direct-send callers need this lease form because applying a deferred agent switch,
+ * refreshing the resulting live Session, and calling Session.send happen in different
+ * modules but must remain one atomic route decision.
+ */
+async function acquireSendToSessionLock(sessionId: string): Promise<() => void> {
   const previous = sendToSessionLocks.get(sessionId);
   const waitPrevious = previous ? previous.catch(() => undefined) : Promise.resolve();
-  const run = waitPrevious.then(task);
+  let releaseGate!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    releaseGate = resolve;
+  });
+  const run = waitPrevious.then(() => gate);
   const tracked = run.finally(() => {
     if (sendToSessionLocks.get(sessionId) === tracked) {
       sendToSessionLocks.delete(sessionId);
     }
   });
   sendToSessionLocks.set(sessionId, tracked);
-  return tracked;
+  await waitPrevious;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    releaseGate();
+  };
+}
+
+/** Serialize every local send / runtime release / route mutation for one session. */
+export async function withSendToSessionLock<T>(
+  sessionId: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireSendToSessionLock(sessionId);
+  try {
+    return await task();
+  } finally {
+    release();
+  }
 }
 
 let agentInputCoordinatorHolder: AgentInputCoordinator | null = null;
@@ -1571,7 +1597,8 @@ const SESSION_REWIND_INPUT_LOCK_ID = 'session-rewind';
 const SESSION_REWIND_STOP_TIMEOUT_MS = 15_000;
 let pendingCredentialSwitchHolder: PendingCredentialSwitchService | null = null;
 let deferredCodexRestartHolder: DeferredCodexRestartService | null = null;
-let pendingAgentSwitchApplyHolder: ((sessionId: string, signal?: AbortSignal) => Promise<void>) | null = null;
+let pendingAgentSwitchApplyHolder:
+  ((sessionId: string, signal?: AbortSignal) => Promise<() => void>) | null = null;
 let gitSnapshotCoordinator: GitSnapshotCoordinator | null = null;
 const sessionTurnActivityTracker = new SessionTurnActivityTracker();
 
@@ -1678,17 +1705,18 @@ export function clearDeferredCodexRestartForOwnerBoundary(): void {
 }
 
 /**
- * Goal / IM / scheduler 直发 `Session.send()` 前的 deferred agent-switch 桥。
+ * Goal / IM / scheduler 直发 `Session.send()` 的 deferred agent-switch 锁桥。
  *
  * 与 renderer 的 makerSendTransaction 不同,这些调用方没有后续 lazy-create 阶段;
- * holder 因此要求 apply 成功时同步 bootstrap 新引擎,调用方再重新读取 live session。
- * 启动期 holder 尚未就绪时不可能已有进程内 pending intent,no-op 即可。
+ * holder 因此先在 session 锁内同步 bootstrap 新引擎,调用方重新读取 live session
+ * 并完成 send 后才 release。启动期 holder 尚未就绪时不可能已有进程内 pending
+ * intent,返回 no-op release 即可。
  */
-export async function applyPendingAgentSwitchForDirectSend(
+export async function acquirePendingAgentSwitchForDirectSend(
   sessionId: string,
   signal?: AbortSignal,
-): Promise<void> {
-  await pendingAgentSwitchApplyHolder?.(sessionId, signal);
+): Promise<() => void> {
+  return pendingAgentSwitchApplyHolder?.(sessionId, signal) ?? (() => {});
 }
 
 /**
@@ -4259,13 +4287,19 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     withCloseSuppressed: withRehydrateCloseSuppressed,
     log,
   });
-  pendingAgentSwitchApplyHolder = (sessionId, signal) =>
-    withSendToSessionLock(sessionId, () =>
-      applyPendingAgentSwitchIfIdle(agentSwitchDeps, sessionId, {
+  pendingAgentSwitchApplyHolder = async (sessionId, signal) => {
+    const release = await acquireSendToSessionLock(sessionId);
+    try {
+      await applyPendingAgentSwitchIfIdle(agentSwitchDeps, sessionId, {
         bootstrapAfterSwitch: true,
         signal,
-      }),
-    );
+      });
+      return release;
+    } catch (err) {
+      release();
+      throw err;
+    }
+  };
 
   ipcMain.handle(MAKER_INVOKE.MARK_ORCA_ROLE, async (_e, sessionId: unknown, role: unknown) => {
     if (typeof sessionId !== 'string') throwIpcError('INVALID_PARAMS', 'sessionId required');

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -1548,7 +1548,7 @@ const pendingFailedTurnAssistantPersistId = new Map<string, string>();
  */
 const sendToSessionLocks = new Map<string, Promise<unknown>>();
 
-/** Serialize every local send / runtime release for one session. */
+/** Serialize every local send / runtime release / route mutation for one session. */
 function withSendToSessionLock<T>(sessionId: string, task: () => Promise<T>): Promise<T> {
   const previous = sendToSessionLocks.get(sessionId);
   const waitPrevious = previous ? previous.catch(() => undefined) : Promise.resolve();
@@ -7035,41 +7035,46 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     ) {
       throwIpcError('INVALID_PARAMS', 'providerId must be string, null, or undefined');
     }
-    try {
-      const result = await applySetModelThenCancelAgentSwitchIntent(
-        agentSwitchPending,
-        sessionId,
-        () => applyRuntimeSetModelChange({
-          maker,
+    // 与 send 事务共用 session 锁:发送时刻执行的跨引擎切换必须先落定,
+    // 后到的 SET_MODEL 才能写 route。否则切换 DB await 恢复后会用旧 provider
+    // 覆盖用户刚选的新 route，形成 DB 与进程内路由分叉。
+    return withSendToSessionLock(sessionId, async () => {
+      try {
+        const result = await applySetModelThenCancelAgentSwitchIntent(
+          agentSwitchPending,
           sessionId,
-          model,
-          providerId,
-          isSessionInTurn,
-          registerPendingCredentialSwitch: registerPendingCredentialSwitchForSession,
-          clearPendingCredentialSwitch: clearPendingCredentialSwitchForSession,
-          wakeSessionInputQueue: wakeSessionInputAfterCredentialSwitch,
-          getPendingCredentialSwitch: getPendingCredentialSwitchTarget,
-          // 解析隐式来源的凭证家族,精确判定是否跨远端压缩身份边界(见
-          // shouldCloseSessionForCredentialSwitch.codexAuthInjection)。
-          codexAuthInjection: getCodexProxyAuthInjectionState(),
-          logger: log,
-        }),
-        (id) => broadcastSessionPatched(id, {
-          agentSwitchIntent: null,
-          agentSwitchIntentCanceled: true,
-        }),
-      );
-      // deferred = 会话自己在跑,选择已登记、turn 结束自动生效。renderer 据此提示
-      // "任务结束后生效"而不是当成已即时切换。
-      return { deferred: result.status === 'deferred' };
-    } catch (err) {
-      if (err instanceof CredentialModeSwitchBusyError) {
-        // 兜底(正常路径 busy 已转 deferred):切模型撞上凭证切换忙,独立 code,
-        // renderer toast 走 ipcError.CREDENTIAL_SWITCH_BUSY 专属文案。
-        throwIpcError('CREDENTIAL_SWITCH_BUSY', err.message);
+          () => applyRuntimeSetModelChange({
+            maker,
+            sessionId,
+            model,
+            providerId,
+            isSessionInTurn,
+            registerPendingCredentialSwitch: registerPendingCredentialSwitchForSession,
+            clearPendingCredentialSwitch: clearPendingCredentialSwitchForSession,
+            wakeSessionInputQueue: wakeSessionInputAfterCredentialSwitch,
+            getPendingCredentialSwitch: getPendingCredentialSwitchTarget,
+            // 解析隐式来源的凭证家族,精确判定是否跨远端压缩身份边界(见
+            // shouldCloseSessionForCredentialSwitch.codexAuthInjection)。
+            codexAuthInjection: getCodexProxyAuthInjectionState(),
+            logger: log,
+          }),
+          (id) => broadcastSessionPatched(id, {
+            agentSwitchIntent: null,
+            agentSwitchIntentCanceled: true,
+          }),
+        );
+        // deferred = 会话自己在跑,选择已登记、turn 结束自动生效。renderer 据此提示
+        // "任务结束后生效"而不是当成已即时切换。
+        return { deferred: result.status === 'deferred' };
+      } catch (err) {
+        if (err instanceof CredentialModeSwitchBusyError) {
+          // 兜底(正常路径 busy 已转 deferred):切模型撞上凭证切换忙,独立 code,
+          // renderer toast 走 ipcError.CREDENTIAL_SWITCH_BUSY 专属文案。
+          throwIpcError('CREDENTIAL_SWITCH_BUSY', err.message);
+        }
+        throw err;
       }
-      throw err;
-    }
+    });
   });
 
   ipcMain.handle(MAKER_INVOKE.SET_EFFORT, async (_e, sessionId: unknown, effort: unknown) => {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -1599,6 +1599,7 @@ let pendingCredentialSwitchHolder: PendingCredentialSwitchService | null = null;
 let deferredCodexRestartHolder: DeferredCodexRestartService | null = null;
 let pendingAgentSwitchApplyHolder:
   ((sessionId: string, signal?: AbortSignal) => Promise<() => void>) | null = null;
+let cancelPendingAgentSwitchHolder: ((sessionId: string) => void) | null = null;
 let gitSnapshotCoordinator: GitSnapshotCoordinator | null = null;
 const sessionTurnActivityTracker = new SessionTurnActivityTracker();
 
@@ -1717,6 +1718,11 @@ export async function acquirePendingAgentSwitchForDirectSend(
   signal?: AbortSignal,
 ): Promise<() => void> {
   return pendingAgentSwitchApplyHolder?.(sessionId, signal) ?? (() => {});
+}
+
+/** Later successful model/provider picks supersede an earlier cross-engine intent. */
+export function cancelPendingAgentSwitchForSession(sessionId: string): void {
+  cancelPendingAgentSwitchHolder?.(sessionId);
 }
 
 /**
@@ -4128,6 +4134,13 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
 
   // turn 运行中登记的切换意图(下一条消息发送时刻由 send 事务 apply)。
   const agentSwitchPending = createPendingAgentSwitchRegistry();
+  cancelPendingAgentSwitchHolder = (sessionId) => {
+    agentSwitchPending.clear(sessionId);
+    broadcastSessionPatched(sessionId, {
+      agentSwitchIntent: null,
+      agentSwitchIntentCanceled: true,
+    });
+  };
 
   // session-agent-switch:lazy-create 前以 DB 行为真源校正 createOpts。切换后
   // 残留在 renderer store / 排队项里的旧 agentKind/resumeSessionId 若原样 spawn,
@@ -4187,7 +4200,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       return row ?? null;
     },
     getLiveSession: (sessionId) => maker.getSession(sessionId),
-    closeSession: (sessionId) => maker.closeSession(sessionId),
+    closeSession: (sessionId) => maker.closeSession(sessionId, 'agent-switch'),
     listMessagesForHandoff: (sessionId, after) => listMessagesForAgentHandoff(sessionId, 400, after),
     findParkedEngineSession: (sessionId, targetDbKind) =>
       findParkedEngineSession(sessionId, targetDbKind),
@@ -6983,15 +6996,17 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     // 同时覆盖"主动 closeSession"和"内部异常关闭"两条路径。
     // opts.preserveWorkspace=true(/clear、鉴权重连等软重启)时抑制这些重副作用,
     // 业务体与选项解析见 closeSessionRequest.ts。
-    await handleCloseSessionRequest(
-      {
-        closeSession: (sid) => maker.closeSession(sid),
-        withRehydrateCloseSuppressed,
-        cleanupPendingInteractions: (sid) =>
-          cleanupPendingInteractionsForSession(sid, 'session_closed'),
-      },
-      sessionId,
-      opts,
+    await withSendToSessionLock(sessionId, () =>
+      handleCloseSessionRequest(
+        {
+          closeSession: (sid) => maker.closeSession(sid),
+          withRehydrateCloseSuppressed,
+          cleanupPendingInteractions: (sid) =>
+            cleanupPendingInteractionsForSession(sid, 'session_closed'),
+        },
+        sessionId,
+        opts,
+      ),
     );
   });
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4257,10 +4257,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     log,
   });
   pendingAgentSwitchApplyHolder = (sessionId, signal) =>
-    applyPendingAgentSwitchIfIdle(agentSwitchDeps, sessionId, {
-      bootstrapAfterSwitch: true,
-      signal,
-    });
+    withSendToSessionLock(sessionId, () =>
+      applyPendingAgentSwitchIfIdle(agentSwitchDeps, sessionId, {
+        bootstrapAfterSwitch: true,
+        signal,
+      }),
+    );
 
   ipcMain.handle(MAKER_INVOKE.MARK_ORCA_ROLE, async (_e, sessionId: unknown, role: unknown) => {
     if (typeof sessionId !== 'string') throwIpcError('INVALID_PARAMS', 'sessionId required');

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -1549,7 +1549,10 @@ const pendingFailedTurnAssistantPersistId = new Map<string, string>();
 const sendToSessionLocks = new Map<string, Promise<unknown>>();
 
 /** Serialize every local send / runtime release / route mutation for one session. */
-function withSendToSessionLock<T>(sessionId: string, task: () => Promise<T>): Promise<T> {
+export function withSendToSessionLock<T>(
+  sessionId: string,
+  task: () => Promise<T>,
+): Promise<T> {
   const previous = sendToSessionLocks.get(sessionId);
   const waitPrevious = previous ? previous.catch(() => undefined) : Promise.resolve();
   const run = waitPrevious.then(task);

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4193,6 +4193,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       findParkedEngineSession(sessionId, targetDbKind),
     applyAgentSwitchToDb: applyAgentSwitchToSessionRow,
     setSessionProvider,
+    supersedePendingCredentialSwitch: clearPendingCredentialSwitchForSession,
     insertBoundaryMessage: async (sessionId, content) => {
       const clientId = `agent-switch:${createId()}`;
       await createDbMessage(sessionId, {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -374,7 +374,7 @@ import { prependHandoffToUserMessage } from './agentHandoff.js';
 import { hydrateQueuedAgentReferences } from './agentInputReferences.js';
 import { agentHandoffPending } from './agentHandoffPendingSingleton.js';
 import { type MakerSessionCreateOpts, withCreateSessionStderr } from './sessionRequest.js';
-import { persistAndActivateSessionProvider } from './sessionProviderBootstrap.js';
+import { persistAndHydrateSessionProvider } from './sessionProviderBootstrap.js';
 import { registerMakerSessionSendHandler } from './sessionSendHandler.js';
 import { registerStopAgentTaskHandler } from './stopAgentTaskHandler.js';
 import { registerStopSessionBackgroundTasksHandler } from './stopSessionBackgroundTasksHandler.js';
@@ -390,7 +390,11 @@ import {
   refreshCustomProvidersIntoCatalog,
 } from '../maker-host/createDesktopProviderService.js';
 import { connectedProvidersForAgent, effectiveSourceIdForModel } from '@cindy/model-providers';
-import { getSessionProvider, setSessionProvider } from '../maker-host/session-provider-store.js';
+import {
+  getSessionProvider,
+  hydrateSessionProvider,
+  setSessionProvider,
+} from '../maker-host/session-provider-store.js';
 import { getActiveCatalog, setDiscoveredProviderModels } from '../maker-host/active-catalog.js';
 import { testProviderConnection } from '../maker-host/provider-diagnostics.js';
 import { fetchProviderModels } from '../maker-host/provider-model-fetch.js';
@@ -3901,19 +3905,18 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     wireSessionToIpc(session);
     markOrcaMcpHydratedIfNeeded(session.id, o);
 
-    // per-session 供应商:从 DB(sessions.provider_id)激活路由 store —— 新引擎实例必须以
-    // DB 已提交的选择覆盖同一 Cindy session 上一引擎留下的内存值,否则 Codex → Claude
-    // 切换后仍可能按旧来源路由。读失败不致命(回落现有路由)。所有 create/resume 路径
-    // 都经本 funnel,单点覆盖。
+    // per-session 供应商:从 DB(sessions.provider_id)回填路由 store —— 跨重启恢复会话显式选定的
+    // 供应商,让首个请求就按所选来源路由;无值则保持未设(→ 默认路由,行为不变)。hydrate 不覆盖
+    // 运行中已有的选择。读失败不致命(回落默认路由)。所有 create/resume 路径都经本funnel,单点覆盖。
     //
     // device-link 远程 create(P2):DesktopSessionStorage.create 从 maker-core SessionMeta 建行,
-    // SessionMeta 不含 providerId → 远程新建行 provider_id 恒 NULL。这里在激活路由前用 create
-    // opts 的 providerId 补写 DB。providerId=null 是显式清除来源,也必须写库覆盖旧值;只有
+    // SessionMeta 不含 providerId → 远程新建行 provider_id 恒 NULL。这里在 hydrate 前用 create opts
+    // 的 providerId 补写 DB。providerId=null 是显式清除来源,也必须写库覆盖旧值;只有
     // providerId=undefined 才表示调用方没有携带来源选择。懒启动路径会在 maker.createSession
     // 前从 DB 预补 o.providerId,所以下面同时承担「新建落库」和「恢复路由 store」两件事。
     try {
       const db = getDbClient().drizzle;
-      await persistAndActivateSessionProvider({
+      await persistAndHydrateSessionProvider({
         sessionId: session.id,
         providerId: o.providerId,
         updateProviderId: async (targetSessionId, providerId) => {
@@ -3930,7 +3933,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
             .limit(1);
           return pRow?.providerId;
         },
-        setSessionProvider,
+        hydrateSessionProvider,
       });
       // bridge 会话态(effort / fast)同点 hydrate:让 resume / 重启后的首个 bridge 请求就带上
       // 用户上次选定的思维深度与 Fast(否则要等用户再点一次开关才写进内存 store)。
@@ -3942,7 +3945,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
       if (efRow?.effort) setSessionEffort(session.id, efRow.effort);
       setSessionFastMode(session.id, !!efRow?.fastMode);
     } catch (err) {
-      log.debug('activate session provider failed (non-fatal)', {
+      log.debug('hydrate session provider failed (non-fatal)', {
         sessionId: session.id,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -4158,6 +4161,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions 
     findParkedEngineSession: (sessionId, targetDbKind) =>
       findParkedEngineSession(sessionId, targetDbKind),
     applyAgentSwitchToDb: applyAgentSwitchToSessionRow,
+    setSessionProvider,
     insertBoundaryMessage: async (sessionId, content) => {
       const clientId = `agent-switch:${createId()}`;
       await createDbMessage(sessionId, {

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -108,16 +108,24 @@ export async function applyRuntimeSetModelChange(
   input: ApplyRuntimeSetModelChangeInput,
 ): Promise<ApplyRuntimeSetModelChangeResult> {
   const { maker, sessionId, model, providerId, isSessionInTurn, logger } = input;
+  const normalizedProviderId =
+    providerId === undefined
+      ? undefined
+      : typeof providerId === 'string'
+        ? providerId.trim() || null
+        : null;
   const sess = maker.getSession(sessionId);
   const currentProviderId = getSessionProvider(sessionId);
   // model-only 调用以 pending 的 providerId 为「当前来源意图」:用户先 deferred 选了
   // 新来源、再换模型时,决策与登记都要沿用那个来源,不能回落到 store 里的旧值
   // (否则会把 pending 的来源覆盖丢)。
   const pendingTarget =
-    providerId === undefined ? input.getPendingCredentialSwitch?.(sessionId) : undefined;
+    normalizedProviderId === undefined
+      ? input.getPendingCredentialSwitch?.(sessionId)
+      : undefined;
   const nextProviderId =
-    providerId !== undefined
-      ? typeof providerId === 'string' ? providerId : null
+    normalizedProviderId !== undefined
+      ? normalizedProviderId
       : pendingTarget !== undefined
         ? pendingTarget.providerId
         : currentProviderId;

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -1,6 +1,10 @@
 import type { AgentKind } from '@cindy/maker-core';
 
-import { getSessionProvider, setSessionProvider } from '../maker-host/session-provider-store.js';
+import {
+  getSessionProvider,
+  normalizeSessionProviderId,
+  setSessionProvider,
+} from '../maker-host/session-provider-store.js';
 // type-only import:编译期擦除,不会把 codex-proxy-host 的运行时依赖拖进本模块/单测。
 import type { CodexProxyAuthInjection } from '../maker-host/codex-proxy-host.js';
 import {
@@ -108,12 +112,7 @@ export async function applyRuntimeSetModelChange(
   input: ApplyRuntimeSetModelChangeInput,
 ): Promise<ApplyRuntimeSetModelChangeResult> {
   const { maker, sessionId, model, providerId, isSessionInTurn, logger } = input;
-  const normalizedProviderId =
-    providerId === undefined
-      ? undefined
-      : typeof providerId === 'string'
-        ? providerId.trim() || null
-        : null;
+  const normalizedProviderId = normalizeSessionProviderId(providerId);
   const sess = maker.getSession(sessionId);
   const currentProviderId = getSessionProvider(sessionId);
   // model-only 调用以 pending 的 providerId 为「当前来源意图」:用户先 deferred 选了

--- a/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
@@ -302,6 +302,8 @@ export async function performSessionAgentSwitch(
   if (providerId !== undefined && providerId !== null && typeof providerId !== 'string') {
     throwIpcError('INVALID_PARAMS', 'providerId must be string | null');
   }
+  const normalizedProviderId =
+    typeof providerId === 'string' ? providerId.trim() || null : providerId;
 
   const row = await deps.getSessionRow(sessionId);
   throwIfAgentSwitchAborted(signal);
@@ -334,7 +336,7 @@ export async function performSessionAgentSwitch(
     const intent: PendingAgentSwitchIntent = {
       targetAgentKind,
       model,
-      providerId: providerId as string | null | undefined,
+      providerId: normalizedProviderId,
       ...(typeof params.effort === 'string' && params.effort ? { effort: params.effort } : {}),
       ...(typeof params.fastMode === 'boolean' ? { fastMode: params.fastMode } : {}),
     };
@@ -394,13 +396,13 @@ export async function performSessionAgentSwitch(
     await deps.applyAgentSwitchToDb(sessionId, {
       agentKind: toDbKind,
       model,
-      providerId: providerId as string | null | undefined,
+      providerId: normalizedProviderId,
       sdkSessionId: parked?.sdkSessionId ?? null,
       ...(typeof params.effort === 'string' && params.effort ? { effort: params.effort } : {}),
       ...(typeof params.fastMode === 'boolean' ? { fastMode: params.fastMode } : {}),
     });
-    if (providerId !== undefined) {
-      deps.setSessionProvider(sessionId, providerId as string | null);
+    if (normalizedProviderId !== undefined) {
+      deps.setSessionProvider(sessionId, normalizedProviderId);
     }
 
     const boundaryContent: AgentSwitchBoundaryContent = {
@@ -467,7 +469,7 @@ export async function performSessionAgentSwitch(
               deps.pendingSwitches?.set(sessionId, {
                 targetAgentKind,
                 model,
-                providerId: providerId as string | null | undefined,
+                providerId: normalizedProviderId,
                 ...(typeof params.effort === 'string' && params.effort ? { effort: params.effort } : {}),
                 ...(typeof params.fastMode === 'boolean' ? { fastMode: params.fastMode } : {}),
                 resumeFallbackRecovery: {
@@ -489,7 +491,7 @@ export async function performSessionAgentSwitch(
             deps.pendingSwitches?.set(sessionId, {
               targetAgentKind,
               model,
-              providerId: providerId as string | null | undefined,
+              providerId: normalizedProviderId,
               ...(typeof params.effort === 'string' && params.effort ? { effort: params.effort } : {}),
               ...(typeof params.fastMode === 'boolean' ? { fastMode: params.fastMode } : {}),
               resumeFallbackRecovery: {

--- a/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
@@ -132,6 +132,11 @@ export interface MakerSessionAgentSwitchHandlerDeps {
       fastMode?: boolean;
     },
   ): Promise<void>;
+  /**
+   * DB 提交成功后同步跨引擎 provider route。这里只在显式携带 providerId 的
+   * 生命周期切换边界调用，避免普通 create/resume 的异步 DB 读取覆盖运行时 SET_MODEL。
+   */
+  setSessionProvider(sessionId: string, providerId: string | null): void;
   /** 返回边界行 clientId(resume 回落时原子改写定位用)。 */
   insertBoundaryMessage(sessionId: string, content: AgentSwitchBoundaryContent): Promise<string>;
   /**
@@ -394,6 +399,9 @@ export async function performSessionAgentSwitch(
       ...(typeof params.effort === 'string' && params.effort ? { effort: params.effort } : {}),
       ...(typeof params.fastMode === 'boolean' ? { fastMode: params.fastMode } : {}),
     });
+    if (providerId !== undefined) {
+      deps.setSessionProvider(sessionId, providerId as string | null);
+    }
 
     const boundaryContent: AgentSwitchBoundaryContent = {
       fromAgentKind: fromDbKind,

--- a/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
@@ -137,6 +137,11 @@ export interface MakerSessionAgentSwitchHandlerDeps {
    * 生命周期切换边界调用，避免普通 create/resume 的异步 DB 读取覆盖运行时 SET_MODEL。
    */
   setSessionProvider(sessionId: string, providerId: string | null): void;
+  /**
+   * 新的跨引擎选择淘汰较早的 deferred model/provider 选择。后者可能正在等待
+   * close 完成，必须先清登记，避免它在新 agent route 提交后回写旧 provider。
+   */
+  supersedePendingCredentialSwitch?(sessionId: string): void;
   /** 返回边界行 clientId(resume 回落时原子改写定位用)。 */
   insertBoundaryMessage(sessionId: string, content: AgentSwitchBoundaryContent): Promise<string>;
   /**
@@ -328,6 +333,10 @@ export async function performSessionAgentSwitch(
     deps.onPendingSwitchChanged?.(sessionId, null);
     return { switched: false, agentKind: targetAgentKind, model, engineReady: true };
   }
+
+  // 跨引擎选择比此前登记的凭证切换更新；即使旧切换已在 await close，清掉登记后
+  // 它也会在收口前重读并放弃，避免 DB 已是新 agent、内存 route 却被旧 provider 覆盖。
+  deps.supersedePendingCredentialSwitch?.(sessionId);
 
   // 意图制:外部调用(非 applyNow)一律只登记意图——空闲/运行中同一语义,
   // 用户反复改选零成本;renderer 乐观显示意图,真切换在下一条消息发送时刻执行。

--- a/apps/desktop/src/main/maker-ipc/sessionProviderBootstrap.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionProviderBootstrap.ts
@@ -1,16 +1,20 @@
-export interface PersistAndHydrateSessionProviderInput {
+export interface PersistAndActivateSessionProviderInput {
   sessionId: string;
   providerId: string | null | undefined;
   updateProviderId: (sessionId: string, providerId: string | null) => Promise<void>;
   readProviderId: (sessionId: string) => Promise<string | null | undefined>;
-  hydrateSessionProvider: (sessionId: string, providerId: string | null) => void;
+  setSessionProvider: (sessionId: string, providerId: string | null) => void;
 }
 
 /**
  * create-session 后同步 provider route：显式 null 要落库覆盖旧来源，undefined 才表示不改库。
+ *
+ * 新引擎实例是生命周期边界，DB 中的 provider_id 是它的权威路由。这里必须覆盖同一
+ * Cindy session 上一引擎留下的内存值；仅缺值才写入的 hydrate 语义只适合不打断 live
+ * session 的普通恢复路径。
  */
-export async function persistAndHydrateSessionProvider(
-  input: PersistAndHydrateSessionProviderInput,
+export async function persistAndActivateSessionProvider(
+  input: PersistAndActivateSessionProviderInput,
 ): Promise<void> {
   const createProviderId =
     typeof input.providerId === 'string' && input.providerId.trim()
@@ -20,5 +24,5 @@ export async function persistAndHydrateSessionProvider(
     await input.updateProviderId(input.sessionId, createProviderId);
   }
   const persistedProviderId = await input.readProviderId(input.sessionId);
-  input.hydrateSessionProvider(input.sessionId, persistedProviderId ?? null);
+  input.setSessionProvider(input.sessionId, persistedProviderId ?? null);
 }

--- a/apps/desktop/src/main/maker-ipc/sessionProviderBootstrap.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionProviderBootstrap.ts
@@ -1,20 +1,16 @@
-export interface PersistAndActivateSessionProviderInput {
+export interface PersistAndHydrateSessionProviderInput {
   sessionId: string;
   providerId: string | null | undefined;
   updateProviderId: (sessionId: string, providerId: string | null) => Promise<void>;
   readProviderId: (sessionId: string) => Promise<string | null | undefined>;
-  setSessionProvider: (sessionId: string, providerId: string | null) => void;
+  hydrateSessionProvider: (sessionId: string, providerId: string | null) => void;
 }
 
 /**
  * create-session 后同步 provider route：显式 null 要落库覆盖旧来源，undefined 才表示不改库。
- *
- * 新引擎实例是生命周期边界，DB 中的 provider_id 是它的权威路由。这里必须覆盖同一
- * Cindy session 上一引擎留下的内存值；仅缺值才写入的 hydrate 语义只适合不打断 live
- * session 的普通恢复路径。
  */
-export async function persistAndActivateSessionProvider(
-  input: PersistAndActivateSessionProviderInput,
+export async function persistAndHydrateSessionProvider(
+  input: PersistAndHydrateSessionProviderInput,
 ): Promise<void> {
   const createProviderId =
     typeof input.providerId === 'string' && input.providerId.trim()
@@ -24,5 +20,8 @@ export async function persistAndActivateSessionProvider(
     await input.updateProviderId(input.sessionId, createProviderId);
   }
   const persistedProviderId = await input.readProviderId(input.sessionId);
-  input.setSessionProvider(input.sessionId, persistedProviderId ?? null);
+  // undefined 表示 DB 没有对应行，不能把它解释为“显式清空”并覆盖运行时选择。
+  if (persistedProviderId !== undefined) {
+    input.hydrateSessionProvider(input.sessionId, persistedProviderId);
+  }
 }

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerSendOutcome.test.ts
@@ -298,15 +298,22 @@ describe('MakerScheduleRunner send outcome policy', () => {
   });
 
   it('applies a deferred switch before heartbeat meta lookup and creates the target engine session', async () => {
-    const h = createSessionHarness(async () => ({
-      accepted: false,
-      reason: 'cancelled-before-dispatch',
-    }));
     const order: string[] = [];
-    const applyPendingAgentSwitch = vi.fn(async () => {
-      order.push('apply');
+    const h = createSessionHarness(async () => {
+      order.push('send');
+      return {
+        accepted: false,
+        reason: 'cancelled-before-dispatch',
+      };
     });
-    const { runner, maker } = createRunnerHarness(h.session, { applyPendingAgentSwitch });
+    const releaseAgentSwitchLock = vi.fn(() => {
+      order.push('release');
+    });
+    const acquirePendingAgentSwitch = vi.fn(async () => {
+      order.push('apply');
+      return releaseAgentSwitchLock;
+    });
+    const { runner, maker } = createRunnerHarness(h.session, { acquirePendingAgentSwitch });
     vi.mocked(maker.getSessionMeta).mockImplementation(async () => {
       order.push('meta');
       return {
@@ -338,7 +345,7 @@ describe('MakerScheduleRunner send outcome policy', () => {
     ).rejects.toThrow(/cancelled-before-dispatch/);
 
     expect(order.slice(0, 2)).toEqual(['apply', 'meta']);
-    expect(applyPendingAgentSwitch).toHaveBeenCalledWith('scheduler-session', ctx.signal);
+    expect(acquirePendingAgentSwitch).toHaveBeenCalledWith('scheduler-session', ctx.signal);
     expect(maker.createSession).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'scheduler-session',
@@ -347,6 +354,7 @@ describe('MakerScheduleRunner send outcome policy', () => {
       }),
     );
     expect(h.send).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['apply', 'meta', 'send', 'release']);
   });
 
   it('captures the scheduler git baseline after the user row exists and aborts it when send is rejected', async () => {

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerSendOutcome.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getSessionRowSnapshot: vi.fn(),
   ensureDialogueWorkspaceDir: vi.fn(),
   wireSessionToIpc: vi.fn(),
+  isSessionInTurn: vi.fn(() => false),
   resolveWorkingDir: vi.fn(),
   backfillSessionMeta: vi.fn(),
 }));
@@ -38,7 +39,7 @@ vi.mock('../../localDb/dialogueWorkspace', () => ({
 
 vi.mock('../../maker-ipc/register.js', () => ({
   wireSessionToIpc: mocks.wireSessionToIpc,
-  isSessionInTurn: () => false,
+  isSessionInTurn: mocks.isSessionInTurn,
   noteSilentStopUserSend: vi.fn(),
   onSilentStopSettled: vi.fn(() => () => {}),
 }));
@@ -238,6 +239,7 @@ describe('MakerScheduleRunner send outcome policy', () => {
     mocks.createMessage.mockResolvedValue(undefined);
     mocks.backfillSessionMeta.mockResolvedValue(undefined);
     mocks.resolveWorkingDir.mockResolvedValue({ ok: true, path: 'F:\\XDMaker' });
+    mocks.isSessionInTurn.mockReturnValue(false);
     mocks.getSessionRowSnapshot.mockResolvedValue({
       status: 'active',
     });
@@ -355,6 +357,73 @@ describe('MakerScheduleRunner send outcome policy', () => {
     );
     expect(h.send).toHaveBeenCalledTimes(1);
     expect(order).toEqual(['apply', 'meta', 'send', 'release']);
+  });
+
+  it('releases the heartbeat route lock before deferring to recent user activity', async () => {
+    const order: string[] = [];
+    const h = createSessionHarness(async () => ({ accepted: true }));
+    const releaseAgentSwitchLock = vi.fn(() => {
+      order.push('release');
+    });
+    const acquirePendingAgentSwitch = vi.fn(async () => releaseAgentSwitchLock);
+    const { runner, maker } = createRunnerHarness(h.session, { acquirePendingAgentSwitch });
+    vi.mocked(maker.getSessionMeta).mockResolvedValue({
+      id: 'scheduler-session',
+      agentKind: 'codex',
+      workDir: 'F:\\XDMaker',
+      model: 'gpt-5.5-codex',
+      effort: 'high',
+      permissionMode: 'bypassPermissions',
+      fastMode: false,
+    } as never);
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'active',
+      userSendAt: Date.now(),
+      providerId: null,
+    });
+    mocks.isSessionInTurn.mockReturnValue(true);
+
+    const result = await runner.fire(
+      baseSchedule({ targetSessionId: 'scheduler-session' }),
+      createFireContext(),
+    );
+
+    expect(result).toMatchObject({
+      sessionId: 'scheduler-session',
+      deferred: true,
+    });
+    expect(order).toEqual(['release']);
+    expect(releaseAgentSwitchLock).toHaveBeenCalledTimes(1);
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it('releases the heartbeat route lock before reporting an archived target', async () => {
+    const order: string[] = [];
+    const h = createSessionHarness(async () => ({ accepted: true }));
+    const releaseAgentSwitchLock = vi.fn(() => {
+      order.push('release');
+    });
+    const acquirePendingAgentSwitch = vi.fn(async () => releaseAgentSwitchLock);
+    const { runner, notifier } = createRunnerHarness(h.session, { acquirePendingAgentSwitch });
+    notifier.notify.mockImplementation(async () => {
+      order.push('notify');
+    });
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'archived',
+      userSendAt: null,
+      providerId: null,
+    });
+
+    await expect(
+      runner.fire(
+        baseSchedule({ targetSessionId: 'scheduler-session' }),
+        createFireContext(),
+      ),
+    ).rejects.toThrow(/target session not available/);
+
+    expect(order).toEqual(['release', 'notify']);
+    expect(releaseAgentSwitchLock).toHaveBeenCalledTimes(1);
+    expect(h.send).not.toHaveBeenCalled();
   });
 
   it('captures the scheduler git baseline after the user row exists and aborts it when send is rejected', async () => {

--- a/apps/desktop/src/main/scheduler-host/index.ts
+++ b/apps/desktop/src/main/scheduler-host/index.ts
@@ -25,7 +25,7 @@ import { dialogueWorkspaceRootDir } from '../localDb/dialogueWorkspace';
 import { getAgentIslandService } from '../agent-island/service.js';
 import { getDesktopNotificationsEnabled } from '../notificationService.js';
 import {
-  applyPendingAgentSwitchForDirectSend,
+  acquirePendingAgentSwitchForDirectSend,
   broadcastSessionCreated,
   enqueueSchedulerPrompt,
   hasQueuedSchedulerPrompt,
@@ -74,7 +74,7 @@ export async function startScheduler(deps: StartSchedulerDeps): Promise<Schedule
     logger: deps.logger,
     beforeDispatchUserTurn: deps.beforeDispatchUserTurn,
     onUndispatchedUserTurn: deps.onUndispatchedUserTurn,
-    applyPendingAgentSwitch: applyPendingAgentSwitchForDirectSend,
+    acquirePendingAgentSwitch: acquirePendingAgentSwitchForDirectSend,
     onSessionCreated: broadcastSessionCreated,
     // 心跳撞忙排队桥:实现挂在 maker-ipc/register.ts 的 coordinator 装配处
     // (holder 未就绪时 isSessionBusy 返回 false → runner 走原直发路径)。

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -177,8 +177,11 @@ export interface MakerScheduleRunnerDeps {
   logger: Logger;
   beforeDispatchUserTurn?: (sessionId: string) => void | Promise<void>;
   onUndispatchedUserTurn?: (sessionId: string) => void;
-  /** heartbeat 直发前落实 deferred agent switch,并 bootstrap 新 live session。 */
-  applyPendingAgentSwitch?: (sessionId: string, signal?: AbortSignal) => Promise<void>;
+  /**
+   * 锁住 heartbeat session、落实 deferred switch 并 bootstrap 新 live session。
+   * runner 在 Session.send 返回后 release。
+   */
+  acquirePendingAgentSwitch?: (sessionId: string, signal?: AbortSignal) => Promise<() => void>;
   /** 新建可见会话落库后通知本机窗口与 device-link 列表订阅者。 */
   onSessionCreated?: (sessionId: string) => void;
   /** 可选:撞忙排队桥。未注入时心跳撞忙回退为顺延(deferFire)旧行为。 */
@@ -270,6 +273,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
       throwIfFireAborted(ctx.signal, 'runner entry');
       return await this.fireInner(schedule, ctx, holder);
     } finally {
+      holder.releaseAgentSwitchLock?.();
+      holder.releaseAgentSwitchLock = undefined;
       holder.headlessGhostSetupTurn?.close();
       if (
         holder.sessionId &&
@@ -414,7 +419,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
       // 直发路径不经过 makerSendTransaction。先落实 pending switch,再读取 meta/row,
       // 才能让本轮 createSession 与 send 都指向切换后的 live engine。
       throwIfFireAborted(ctx.signal, 'credential switch setup');
-      await this.deps.applyPendingAgentSwitch?.(sessionId, ctx.signal);
+      holder.releaseAgentSwitchLock =
+        (await this.deps.acquirePendingAgentSwitch?.(sessionId, ctx.signal)) ?? undefined;
       throwIfFireAborted(ctx.signal, 'credential switch setup');
       const [meta, row] = await Promise.all([
         this.deps.maker.getSessionMeta(sessionId).catch(() => null),
@@ -436,6 +442,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
             this.deps.logger.warn?.('[runner] persistent rebind clear failed', err);
           }
           isHeartbeat = false;
+          holder.releaseAgentSwitchLock?.();
+          holder.releaseAgentSwitchLock = undefined;
           sessionId = randomUUID();
           // resumeSessionId / heartbeatWorkingDir / heartbeatModel 仍是 undefined,
           // 下方 workingDir 解析自然走 schedule.workingDir + schedule.useWorktree 分支
@@ -476,8 +484,12 @@ export class MakerScheduleRunner implements ScheduleRunner {
           // await 崩溃恢复快照读回再查重,覆盖"重启后快照未恢复、内存队列还空"
           // 的窗口(review P1)—— 命中时返回 duplicate,下方按同一语义收口。
           if (this.deps.schedulerQueue.hasQueuedPrompt(sessionId, schedule.id)) {
+            holder.releaseAgentSwitchLock?.();
+            holder.releaseAgentSwitchLock = undefined;
             return await this.settleDuplicateQueuedFire(schedule, ctx, sessionId);
           }
+          holder.releaseAgentSwitchLock?.();
+          holder.releaseAgentSwitchLock = undefined;
           return await this.fireHeartbeatViaQueue(schedule, ctx, sessionId, {
             model: meta?.model,
             effort: meta?.effort,
@@ -998,6 +1010,9 @@ export class MakerScheduleRunner implements ScheduleRunner {
         reason: normalized.reason,
         error: normalized.error,
       });
+    } finally {
+      holder.releaseAgentSwitchLock?.();
+      holder.releaseAgentSwitchLock = undefined;
     }
 
     // 7. 等 turn end，组装 run，主动 notify
@@ -1688,6 +1703,8 @@ interface EphemeralSessionHolder {
   worktreeSessionId?: string;
   /** true = heartbeat 复用会话或持续会话,收尾时不关闭。 */
   keepAlive?: boolean;
+  /** heartbeat direct-send route lock; released immediately after Session.send settles. */
+  releaseAgentSwitchLock?: () => void;
 }
 
 interface HeadlessGhostSetupTurnGuard {

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -429,6 +429,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
       const archived =
         !row || row.status === 'archived' || row.status === 'deleted';
       if (archived) {
+        holder.releaseAgentSwitchLock?.();
+        holder.releaseAgentSwitchLock = undefined;
         // persistentSession=true：自我续命。清空死的 targetSessionId,本次 fire 走新建分支,
         // session 创建成功后 4.7.1 会重新绑定到新 sessionId。这样用户即便手动归档/删除
         // 了之前持续会话的 session,自动化也不会卡死,而是无感开新的继续跑。
@@ -442,8 +444,6 @@ export class MakerScheduleRunner implements ScheduleRunner {
             this.deps.logger.warn?.('[runner] persistent rebind clear failed', err);
           }
           isHeartbeat = false;
-          holder.releaseAgentSwitchLock?.();
-          holder.releaseAgentSwitchLock = undefined;
           sessionId = randomUUID();
           // resumeSessionId / heartbeatWorkingDir / heartbeatModel 仍是 undefined,
           // 下方 workingDir 解析自然走 schedule.workingDir + schedule.useWorktree 分支
@@ -470,6 +470,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
         const recentlyUserDriven =
           row?.userSendAt != null && Date.now() - row.userSendAt < ACTIVE_YIELD_WINDOW_MS;
         if (recentlyUserDriven && isSessionInTurn(sessionId) && this.canDefer(schedule)) {
+          holder.releaseAgentSwitchLock?.();
+          holder.releaseAgentSwitchLock = undefined;
           return this.deferFire(schedule, sessionId, 'user-active');
         }
         // B1.5 撞忙排队(替代旧的"盲发 → SESSION_RUNNING → 顺延"路径):会话忙

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -174,6 +174,37 @@ describe('Maker session creation singleflight', () => {
   });
 });
 
+describe('Maker session close events', () => {
+  it('preserves the explicit close reason and exact Session identity', async () => {
+    const maker = new Maker({
+      agents: {
+        codex: createAgent(async () => createHandle({ id: 'thread-1' })),
+      },
+      storage: createStorage(),
+      logger: createLogger(),
+    });
+    const closed = vi.fn();
+    maker.on((event) => {
+      if (event.type === 'session:closed') closed(event);
+    });
+    const session = await maker.createSession({
+      id: 'session-1',
+      agentKind: 'codex',
+      workingDir: '/repo',
+      model: 'gpt-5.4',
+    });
+
+    await maker.closeSession('session-1', 'agent-switch');
+
+    expect(closed).toHaveBeenCalledWith({
+      type: 'session:closed',
+      sessionId: 'session-1',
+      session,
+      reason: 'agent-switch',
+    });
+  });
+});
+
 describe('Maker before-start lifecycle hook', () => {
   it('awaits host preparation before starting the agent', async () => {
     const order: string[] = [];

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -110,9 +110,16 @@ export interface CreateSessionOptions extends StartSessionOptions {
   id?: string;
 }
 
+export type MakerSessionCloseReason = 'requested' | 'agent-switch' | 'unexpected';
+
 export type MakerEvent =
   | { type: 'session:created'; session: Session }
-  | { type: 'session:closed'; sessionId: string };
+  | {
+      type: 'session:closed';
+      sessionId: string;
+      session: Session;
+      reason: MakerSessionCloseReason;
+    };
 
 export type MakerEventListener = (event: MakerEvent) => void;
 
@@ -155,6 +162,8 @@ export class Maker {
   private readonly sdkSessionPersistenceTails = new Map<string, Promise<void>>();
   /** 已确认失效的 vendor id；用于丢弃 CAS 之后才到达的旧 query session_id 事件。 */
   private readonly invalidSdkSessionIds = new Map<string, Set<string>>();
+  /** Explicit close cause keyed by the exact Session instance that will emit closed. */
+  private readonly closeReasons = new WeakMap<Session, MakerSessionCloseReason>();
   /** Maker Memory 顶层单例 (可选). undefined 时 maker memory 功能整体禁用. */
   public readonly makerMemory: MakerMemoryManager | undefined;
 
@@ -361,7 +370,12 @@ export class Maker {
       if (status === 'closed') {
         // 不再持久化运行态: 'closed' 是 SDK 子进程的瞬态, 重启即灭, 无意义存盘。
         this.activeSessions.delete(meta.id);
-        this.emit({ type: 'session:closed', sessionId: meta.id });
+        this.emit({
+          type: 'session:closed',
+          sessionId: meta.id,
+          session,
+          reason: this.closeReasons.get(session) ?? 'unexpected',
+        });
         // 注入的副作用钩子 (worktree / temp 文件 / image cache 清理等)。
         // fire-and-forget, 异常只记日志, 不影响其他清理。在 storage update / activeSessions
         // delete / emit 之后调 —— 钩子里的逻辑可能对外发 IPC 或读 maker state, 让 Maker
@@ -475,9 +489,15 @@ export class Maker {
   }
 
   /** 关闭并移除一个 session */
-  async closeSession(id: string): Promise<void> {
+  async closeSession(
+    id: string,
+    reason: Exclude<MakerSessionCloseReason, 'unexpected'> = 'requested',
+  ): Promise<void> {
     const sess = this.activeSessions.get(id);
     if (sess) {
+      // First closer owns the cause. A later concurrent close must not relabel
+      // a user-requested close as an internal replacement (or vice versa).
+      if (!this.closeReasons.has(sess)) this.closeReasons.set(sess, reason);
       await sess.close();
       // status listener 会自动清理 activeSessions 并 emit
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 会话跨 Claude Code / Codex 引擎切换后沿用旧 provider route 的问题。

- 普通 create / resume 只在内存尚无 route 时从数据库 hydrate，避免异步旧值回滚运行中的新选择。
- 跨引擎切换在数据库 commit point 后同步目标 provider，使新引擎首次请求走正确来源。
- `providerId` 统一 trim，空白值按显式清除处理，数据库、pending intent、内存 route、IM picker 与 device-link 持久化使用同一个值。
- `SET_MODEL`、renderer send、scheduler ／ goal ／ IM direct-send 与 IM `model:pick` 共用 session 串行锁，保证并发时后发生的用户选择稳定获胜。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#680（Fable 客户端误路由部分）
- 本 PR 包含：Desktop 本机会话 provider route 的恢复、跨引擎切换同步、并发顺序保护及回归测试。
- 明确不包含：上游网关模型白名单、Voyage embedding 服务端配置。
- 用户可见变化：跨引擎切换后的首个请求使用新选择的 provider；切换期间再次选择模型或来源时，以较新的选择为准。
- 是否存在 breaking change：无。
- SSH 远程工作区：不涉及；现有跨引擎切换明确拒绝 remote session，本 PR 不改变该能力边界。
- 设备互联 / 手机版控制：无需新增 IPC 或 allowlist；远程 `maker:set-model` 仍进入被控 Desktop 的同一 handler，因此自动获得相同的串行保护。
- 手机版 UI：不涉及；没有新增或修改入口、交互或文案。

### UI 变化

不涉及：仅修改 Desktop main 进程的会话路由时序和测试。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/main/__tests__/makerSendToSessionOrdering.test.ts \
  src/main/goal-host/__tests__/controller.test.ts \
  src/main/scheduler-host/__tests__/runnerSendOutcome.test.ts \
  src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts \
  src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts \
  src/main/__tests__/deviceLinkDispatch.test.ts \
  src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
结果：7 files / 248 tests passed

pnpm --filter desktop exec vitest run \
  src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts \
  src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts \
  src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts \
  src/main/goal-host/__tests__/controller.test.ts
结果：4 files / 86 tests passed

pnpm --filter @cindy/maker-core exec vitest run src/maker.test.ts
结果：1 file / 32 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：仓库根完整单测门禁通过（Desktop、Mobile 与全部适用 workspace 通过）

pnpm check:dco
结果：10 commits signed off，检查通过
```

### 手工验证

不涉及：本次是 main 进程时序修复，已用聚焦并发契约测试覆盖。

### 未执行的验证

- 未做 macOS / Windows 实机操作；改动只使用既有 Promise/session lock，不含平台分支。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 本机会话的 create/resume、跨引擎切换、`SET_MODEL`、direct-send 与 IM `model:pick` 时序。
- 回滚 / 降级方式：回滚本 PR 即恢复原 provider route 行为；不涉及 schema、migration 或持久数据格式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及额外文档）
- [x] 已确认测试结果或说明未执行原因
