### PR TITLE
fix(desktop): 退出挂死三层修复——外部硬杀 watchdog + post-async 预算 + 退出期不误启 browser 服务

### DIFF
--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -198,7 +198,7 @@ describe('armShutdownHardKillWatchdog', () => {
     return { spawn, child };
   }
 
-  it('POSIX (darwin): /bin/sh -c "sleep <grace>; kill -9 <pid>" — detached + ignore + unref', async () => {
+  it('POSIX (darwin): /bin/sh 捕获 lstart → sleep → lstart+command 双校验后 kill -9 — detached + ignore + unref', async () => {
     const { armShutdownHardKillWatchdog, SHUTDOWN_HARD_KILL_GRACE_SECONDS } =
       await freshLifecycle();
     const { spawn, child } = fakeSpawn();
@@ -217,11 +217,16 @@ describe('armShutdownHardKillWatchdog', () => {
       Record<string, unknown>,
     ];
     expect(cmd).toBe('/bin/sh');
-    // 杀前身份校验(review P1):ps 的 command 仍含本进程 execPath 才补刀,
-    // PID 复用给无关进程时校验不过、放弃补刀。
+    // 杀前身份校验(review P1 两轮):命令行匹配区分不了同一 App 的两次运行
+    // (更新器重启的新实例复用 PID 会被误杀), 所以布防时先捕获进程创建时间
+    // (lstart), 补刀前重取比对;不一致 = PID 已易主, 放弃。execPath grep 保留
+    // 作第二道校验。
     expect(args).toEqual([
       '-c',
-      `sleep ${SHUTDOWN_HARD_KILL_GRACE_SECONDS}; `
+      'started="$(ps -p 12345 -o lstart= 2>/dev/null)"; '
+      + '[ -n "$started" ] || exit 0; '
+      + `sleep ${SHUTDOWN_HARD_KILL_GRACE_SECONDS}; `
+      + '[ "$(ps -p 12345 -o lstart= 2>/dev/null)" = "$started" ] && '
       + "ps -p 12345 -o command= 2>/dev/null | grep -qF '/Apps/Cindy Test/Electron' && "
       + 'kill -9 12345 2>/dev/null',
     ]);
@@ -232,7 +237,7 @@ describe('armShutdownHardKillWatchdog', () => {
     );
   });
 
-  it('win32: cmd.exe /d /s /c "ping -n <grace+1> … & taskkill /f /pid <pid>" — windowsHide + unref', async () => {
+  it('win32: PowerShell 捕获 StartTime → Start-Sleep → StartTime+Path 双校验后 Stop-Process — windowsHide + unref', async () => {
     const { armShutdownHardKillWatchdog, SHUTDOWN_HARD_KILL_GRACE_SECONDS } =
       await freshLifecycle();
     const { spawn, child } = fakeSpawn();
@@ -241,7 +246,7 @@ describe('armShutdownHardKillWatchdog', () => {
       spawn,
       pid: 67890,
       platform: 'win32',
-      execPath: 'C\\Cindy\\Cindy.exe'.replace(/\\\\/g, '\\'),
+      execPath: 'C:\\Cindy\\Cindy.exe',
     });
 
     expect(spawn).toHaveBeenCalledTimes(1);
@@ -250,18 +255,32 @@ describe('armShutdownHardKillWatchdog', () => {
       string[],
       Record<string, unknown>,
     ];
-    // 规范拼写 COMSPEC(Windows env 大小写不敏感, 代码用规范名对齐 shellResolver);
-    // 非 Windows 测试机上没有该变量, 走 'cmd.exe' 兜底。
-    expect(cmd).toBe(process.env.COMSPEC ?? 'cmd.exe');
-    // 杀前身份校验:tasklist 映像名仍匹配本进程 exe 才 taskkill。
-    expect(args).toEqual([
-      '/d',
-      '/s',
-      '/c',
-      `ping -n ${SHUTDOWN_HARD_KILL_GRACE_SECONDS + 1} 127.0.0.1 >nul & `
-      + 'tasklist /FI "PID eq 67890" /NH | findstr /I /C:"Cindy.exe" >nul && '
-      + 'taskkill /f /pid 67890',
+    // cmd/tasklist 只能比映像名, 区分不了两次运行;换 Windows PowerShell 5.1
+    // (SystemRoot 绝对路径, 不依赖 PATH) 以进程创建时间为身份锚点。
+    expect(cmd).toBe(
+      `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+    );
+    expect(args.slice(0, 5)).toEqual([
+      '-NoProfile',
+      '-NonInteractive',
+      '-WindowStyle',
+      'Hidden',
+      '-Command',
     ]);
+    const script = args[5];
+    // 布防时捕获创建时间;取不到 (进程已死) 则直接退出, 失败方向永远是"少杀"。
+    expect(script).toContain(
+      '$started = Get-Process -Id 67890 | Select-Object -ExpandProperty StartTime; if (-not $started) { exit }; ',
+    );
+    expect(script).toContain(`Start-Sleep -Seconds ${SHUTDOWN_HARD_KILL_GRACE_SECONDS}; `);
+    // 补刀前 StartTime + Path 双校验;属性读取走 Select-Object -ExpandProperty
+    // 兼容 Constrained Language Mode。
+    expect(script).toContain(
+      '$p = Get-Process -Id 67890; '
+      + 'if ($p -and ($p | Select-Object -ExpandProperty StartTime) -eq $started '
+      + "-and ($p | Select-Object -ExpandProperty Path) -eq 'C:\\Cindy\\Cindy.exe') "
+      + '{ Stop-Process -Id 67890 -Force }',
+    );
     expect(opts).toEqual({ detached: true, windowsHide: true, stdio: 'ignore' });
     expect(child.unref).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -338,6 +338,27 @@ describe('armShutdownHardKillWatchdog', () => {
     );
   });
 
+  it('async spawn "error" resets the flag and retries ONCE (review P1: watchdog must not stay absent)', async () => {
+    // 异步启动失败(ENOENT/EACCES)时 watchdog 实际不在位;shutdown 又只布防
+    // 一次——必须回置并立即重试,否则退出挂死将无人补刀。单次重试闸防死循环。
+    const { armShutdownHardKillWatchdog } = await freshLifecycle();
+    const children: Array<{ once: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> }> = [];
+    const spawn = vi.fn(() => {
+      const child = { once: vi.fn(), unref: vi.fn() };
+      children.push(child);
+      return child;
+    });
+
+    armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    // 第一个 child 异步报错 → 立即重试布防第二个
+    (children[0].once.mock.calls[0][1] as (err: Error) => void)(new Error('EACCES'));
+    expect(spawn).toHaveBeenCalledTimes(2);
+    // 第二个也报错:重试闸已用,不再无限重试
+    (children[1].once.mock.calls[0][1] as (err: Error) => void)(new Error('EACCES'));
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
   it('sync spawn failure resets the armed flag so a later call can retry (review)', async () => {
     // 布防标志若在 spawn 前置位且失败不回置,进程余下生命周期都会跳过布防——
     // watchdog 实际不在位却再也无法重试。

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -337,6 +337,22 @@ describe('armShutdownHardKillWatchdog', () => {
       expect.any(Error),
     );
   });
+
+  it('sync spawn failure resets the armed flag so a later call can retry (review)', async () => {
+    // 布防标志若在 spawn 前置位且失败不回置,进程余下生命周期都会跳过布防——
+    // watchdog 实际不在位却再也无法重试。
+    const { armShutdownHardKillWatchdog } = await freshLifecycle();
+    const failingSpawn = vi.fn(() => {
+      throw new Error('spawn-boom');
+    });
+    armShutdownHardKillWatchdog({ spawn: failingSpawn, pid: 1, platform: 'darwin' });
+
+    const { spawn, child } = fakeSpawn();
+    armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(child.unref).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('installQuitHandler render-process-gone', () => {

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -333,14 +333,15 @@ describe('armShutdownHardKillWatchdog', () => {
       armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' }),
     ).not.toThrow();
     expect(mocks.logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('failed to arm shutdown hard-kill watchdog'),
+      expect.stringContaining('watchdog process failed to start'),
       expect.any(Error),
     );
   });
 
-  it('async spawn "error" resets the flag and retries ONCE (review P1: watchdog must not stay absent)', async () => {
-    // 异步启动失败(ENOENT/EACCES)时 watchdog 实际不在位;shutdown 又只布防
-    // 一次——必须回置并立即重试,否则退出挂死将无人补刀。单次重试闸防死循环。
+  it('async spawn "error" retries within the 3-attempt budget, then marks the backstop ABSENT (review ×2)', async () => {
+    // 异步启动失败(ENOENT/EACCES)时 watchdog 实际不在位:预算内立即重试
+    // (吸收 EAGAIN 类瞬时抖动);全部失败 = 环境级问题,进程内不可能布防任何
+    // 外部补刀——打明确的缺席标记(error 级)供退出尸检定位,不再无限重试。
     const { armShutdownHardKillWatchdog } = await freshLifecycle();
     const children: Array<{ once: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> }> = [];
     const spawn = vi.fn(() => {
@@ -351,28 +352,40 @@ describe('armShutdownHardKillWatchdog', () => {
 
     armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
     expect(spawn).toHaveBeenCalledTimes(1);
-    // 第一个 child 异步报错 → 立即重试布防第二个
+    // 第 1、2 个 child 异步报错 → 各自立即重试
     (children[0].once.mock.calls[0][1] as (err: Error) => void)(new Error('EACCES'));
     expect(spawn).toHaveBeenCalledTimes(2);
-    // 第二个也报错:重试闸已用,不再无限重试
     (children[1].once.mock.calls[0][1] as (err: Error) => void)(new Error('EACCES'));
-    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenCalledTimes(3);
+    // 第 3 个也报错:预算耗尽 → 缺席标记,不再重试
+    (children[2].once.mock.calls[0][1] as (err: Error) => void)(new Error('EACCES'));
+    expect(spawn).toHaveBeenCalledTimes(3);
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('external kill backstop ABSENT'),
+      expect.any(Error),
+    );
+    // 预算耗尽后再布防:no-op(环境已证实无法 spawn)
+    armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
+    expect(spawn).toHaveBeenCalledTimes(3);
   });
 
-  it('sync spawn failure resets the armed flag so a later call can retry (review)', async () => {
-    // 布防标志若在 spawn 前置位且失败不回置,进程余下生命周期都会跳过布防——
-    // watchdog 实际不在位却再也无法重试。
+  it('sync spawn failure consumes the shared budget and marks ABSENT on exhaustion (review)', async () => {
+    // 同步 throw 与异步 error 共享 3 次预算:同一环境级失败在一次布防里就地
+    // 重试到耗尽并打缺席标记;之后其它入口的布防调用 no-op,不再空转。
     const { armShutdownHardKillWatchdog } = await freshLifecycle();
     const failingSpawn = vi.fn(() => {
       throw new Error('spawn-boom');
     });
     armShutdownHardKillWatchdog({ spawn: failingSpawn, pid: 1, platform: 'darwin' });
+    expect(failingSpawn).toHaveBeenCalledTimes(3);
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('external kill backstop ABSENT'),
+      expect.any(Error),
+    );
 
-    const { spawn, child } = fakeSpawn();
+    const { spawn } = fakeSpawn();
     armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
-
-    expect(spawn).toHaveBeenCalledTimes(1);
-    expect(child.unref).toHaveBeenCalledTimes(1);
+    expect(spawn).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -203,7 +203,12 @@ describe('armShutdownHardKillWatchdog', () => {
       await freshLifecycle();
     const { spawn, child } = fakeSpawn();
 
-    armShutdownHardKillWatchdog({ spawn, pid: 12345, platform: 'darwin' });
+    armShutdownHardKillWatchdog({
+      spawn,
+      pid: 12345,
+      platform: 'darwin',
+      execPath: '/Apps/Cindy Test/Electron',
+    });
 
     expect(spawn).toHaveBeenCalledTimes(1);
     const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
@@ -212,9 +217,13 @@ describe('armShutdownHardKillWatchdog', () => {
       Record<string, unknown>,
     ];
     expect(cmd).toBe('/bin/sh');
+    // 杀前身份校验(review P1):ps 的 command 仍含本进程 execPath 才补刀,
+    // PID 复用给无关进程时校验不过、放弃补刀。
     expect(args).toEqual([
       '-c',
-      `sleep ${SHUTDOWN_HARD_KILL_GRACE_SECONDS}; kill -9 12345 2>/dev/null`,
+      `sleep ${SHUTDOWN_HARD_KILL_GRACE_SECONDS}; `
+      + "ps -p 12345 -o command= 2>/dev/null | grep -qF '/Apps/Cindy Test/Electron' && "
+      + 'kill -9 12345 2>/dev/null',
     ]);
     expect(opts).toEqual({ detached: true, stdio: 'ignore' });
     expect(child.unref).toHaveBeenCalledTimes(1);
@@ -228,7 +237,12 @@ describe('armShutdownHardKillWatchdog', () => {
       await freshLifecycle();
     const { spawn, child } = fakeSpawn();
 
-    armShutdownHardKillWatchdog({ spawn, pid: 67890, platform: 'win32' });
+    armShutdownHardKillWatchdog({
+      spawn,
+      pid: 67890,
+      platform: 'win32',
+      execPath: 'C\\Cindy\\Cindy.exe'.replace(/\\\\/g, '\\'),
+    });
 
     expect(spawn).toHaveBeenCalledTimes(1);
     const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
@@ -236,13 +250,17 @@ describe('armShutdownHardKillWatchdog', () => {
       string[],
       Record<string, unknown>,
     ];
-    // 非 Windows 测试机上没有 comspec 环境变量, 走 'cmd.exe' 兜底
-    expect(cmd).toBe(process.env.comspec ?? 'cmd.exe');
+    // 规范拼写 COMSPEC(Windows env 大小写不敏感, 代码用规范名对齐 shellResolver);
+    // 非 Windows 测试机上没有该变量, 走 'cmd.exe' 兜底。
+    expect(cmd).toBe(process.env.COMSPEC ?? 'cmd.exe');
+    // 杀前身份校验:tasklist 映像名仍匹配本进程 exe 才 taskkill。
     expect(args).toEqual([
       '/d',
       '/s',
       '/c',
-      `ping -n ${SHUTDOWN_HARD_KILL_GRACE_SECONDS + 1} 127.0.0.1 >nul & taskkill /f /pid 67890`,
+      `ping -n ${SHUTDOWN_HARD_KILL_GRACE_SECONDS + 1} 127.0.0.1 >nul & `
+      + 'tasklist /FI "PID eq 67890" /NH | findstr /I /C:"Cindy.exe" >nul && '
+      + 'taskkill /f /pid 67890',
     ]);
     expect(opts).toEqual({ detached: true, windowsHide: true, stdio: 'ignore' });
     expect(child.unref).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -29,6 +29,14 @@ const mocks = vi.hoisted(() => ({
     error: vi.fn(),
   },
   disableDevTerminalMirror: vi.fn(),
+  // 默认 spawn stub —— beginShutdown 会布防真实 watchdog, 不 mock 的话
+  // render-process-gone 等用例会真的 spawn `sleep 20; kill -9 <vitest pid>`,
+  // 慢跑/watch 模式下会把测试进程杀掉。
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: mocks.spawn,
 }));
 
 vi.mock('../logger', async () => {
@@ -145,6 +153,26 @@ describe('runQuitDisposers', () => {
     expect(elapsed).toBeLessThan(200);
   });
 
+  it('post-async disposer that never resolves is bounded by timeout — later post-async still runs', async () => {
+    const { onQuit, runQuitDisposers } = await freshLifecycle();
+    let laterRan = false;
+
+    // 永不 resolve 的 post-async disposer (生产事故形态: 无界 await 卡死退出)
+    onQuit('hang-post', () => new Promise(() => { /* never */ }), 'post-async');
+    onQuit('later-post', () => { laterRan = true; }, 'post-async');
+
+    const start = Date.now();
+    await runQuitDisposers(50);
+    const elapsed = Date.now() - start;
+
+    expect(laterRan).toBe(true);
+    // 单个 post-async 预算 50ms, 实际不应远超 (无其它阻塞)
+    expect(elapsed).toBeLessThan(500);
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('post-async disposer "hang-post" timed out after 50ms'),
+    );
+  });
+
   it('rejected async disposer does not break the chain', async () => {
     const { onQuit, runQuitDisposers } = await freshLifecycle();
     let postRan = false;
@@ -156,6 +184,93 @@ describe('runQuitDisposers', () => {
     await runQuitDisposers(500);
 
     expect(postRan).toBe(true);
+  });
+});
+
+describe('armShutdownHardKillWatchdog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function fakeSpawn() {
+    const child = { unref: vi.fn() };
+    const spawn = vi.fn(() => child);
+    return { spawn, child };
+  }
+
+  it('POSIX (darwin): /bin/sh -c "sleep <grace>; kill -9 <pid>" — detached + ignore + unref', async () => {
+    const { armShutdownHardKillWatchdog, SHUTDOWN_HARD_KILL_GRACE_SECONDS } =
+      await freshLifecycle();
+    const { spawn, child } = fakeSpawn();
+
+    armShutdownHardKillWatchdog({ spawn, pid: 12345, platform: 'darwin' });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(cmd).toBe('/bin/sh');
+    expect(args).toEqual([
+      '-c',
+      `sleep ${SHUTDOWN_HARD_KILL_GRACE_SECONDS}; kill -9 12345 2>/dev/null`,
+    ]);
+    expect(opts).toEqual({ detached: true, stdio: 'ignore' });
+    expect(child.unref).toHaveBeenCalledTimes(1);
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining(`grace=${SHUTDOWN_HARD_KILL_GRACE_SECONDS}s`),
+    );
+  });
+
+  it('win32: cmd.exe /d /s /c "ping -n <grace+1> … & taskkill /f /pid <pid>" — windowsHide + unref', async () => {
+    const { armShutdownHardKillWatchdog, SHUTDOWN_HARD_KILL_GRACE_SECONDS } =
+      await freshLifecycle();
+    const { spawn, child } = fakeSpawn();
+
+    armShutdownHardKillWatchdog({ spawn, pid: 67890, platform: 'win32' });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    // 非 Windows 测试机上没有 comspec 环境变量, 走 'cmd.exe' 兜底
+    expect(cmd).toBe(process.env.comspec ?? 'cmd.exe');
+    expect(args).toEqual([
+      '/d',
+      '/s',
+      '/c',
+      `ping -n ${SHUTDOWN_HARD_KILL_GRACE_SECONDS + 1} 127.0.0.1 >nul & taskkill /f /pid 67890`,
+    ]);
+    expect(opts).toEqual({ detached: true, windowsHide: true, stdio: 'ignore' });
+    expect(child.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent — a second arm does not spawn again', async () => {
+    const { armShutdownHardKillWatchdog } = await freshLifecycle();
+    const { spawn } = fakeSpawn();
+
+    armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
+    armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('spawn throwing does not propagate (watchdog failure must not block shutdown)', async () => {
+    const { armShutdownHardKillWatchdog } = await freshLifecycle();
+    const spawn = vi.fn(() => {
+      throw new Error('spawn-boom');
+    });
+
+    expect(() =>
+      armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' }),
+    ).not.toThrow();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to arm shutdown hard-kill watchdog'),
+      expect.any(Error),
+    );
   });
 });
 
@@ -226,6 +341,8 @@ describe('installQuitHandler render-process-gone', () => {
       await vi.waitFor(() => {
         expect(app.exit).toHaveBeenCalledWith(1);
       });
+      // beginShutdown 应布防外部硬杀 watchdog (走默认 spawn, 被顶部 mock 接住)
+      expect(mocks.spawn).toHaveBeenCalledTimes(1);
     } finally {
       restore();
     }

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -193,7 +193,7 @@ describe('armShutdownHardKillWatchdog', () => {
   });
 
   function fakeSpawn() {
-    const child = { unref: vi.fn() };
+    const child = { once: vi.fn(), unref: vi.fn() };
     const spawn = vi.fn(() => child);
     return { spawn, child };
   }
@@ -256,6 +256,34 @@ describe('armShutdownHardKillWatchdog', () => {
     armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
 
     expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('async spawn "error" event is warn-logged, not an uncaughtException (review P1)', async () => {
+    // spawn 可能在返回后经 'error' 事件异步报失败 (ENOENT/EACCES); 必须挂
+    // listener 留痕, 否则 watchdog 静默未布防且错误落入 uncaughtException。
+    const { armShutdownHardKillWatchdog } = await freshLifecycle();
+    const { spawn, child } = fakeSpawn();
+
+    armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' });
+
+    expect(child.once).toHaveBeenCalledWith('error', expect.any(Function));
+    const errorListener = child.once.mock.calls[0][1] as (err: Error) => void;
+    expect(() => errorListener(new Error('ENOENT'))).not.toThrow();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('watchdog process failed to start'),
+      expect.any(Error),
+    );
+  });
+
+  it('tolerates fake spawn children without once() (listener attach is optional)', async () => {
+    const { armShutdownHardKillWatchdog } = await freshLifecycle();
+    const child = { unref: vi.fn() };
+    const spawn = vi.fn(() => child);
+
+    expect(() =>
+      armShutdownHardKillWatchdog({ spawn, pid: 1, platform: 'darwin' }),
+    ).not.toThrow();
+    expect(child.unref).toHaveBeenCalledTimes(1);
   });
 
   it('spawn throwing does not propagate (watchdog failure must not block shutdown)', async () => {

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -197,8 +197,29 @@ type WatchdogSpawn = (
 };
 
 let _watchdogArmed = false;
-/** 异步 spawn 失败后的单次重试闸(防 error→重试→error 无限循环)。 */
-let _watchdogSpawnRetried = false;
+/**
+ * watchdog spawn 总尝试预算(同步/异步失败共享计数,防 error→重试死循环):
+ * 3 次足以吸收 EAGAIN(fork 上限)这类瞬时抖动;仍然全失败 = 环境级问题
+ * (ENOENT/EACCES),本进程从内部**不可能**布防任何外部补刀,重试再多也无意义
+ * (review:此为可接受的终态)。耗尽时打一条明确的缺席标记(error 级),让
+ * 退出尸检一眼看出"这次 shutdown 没有外部兜底"。
+ */
+const WATCHDOG_MAX_SPAWN_ATTEMPTS = 3;
+let _watchdogSpawnAttempts = 0;
+
+function noteWatchdogSpawnFailure(err: unknown, options: Parameters<typeof armShutdownHardKillWatchdog>[0]): void {
+  _watchdogArmed = false;
+  if (_watchdogSpawnAttempts < WATCHDOG_MAX_SPAWN_ATTEMPTS) {
+    log.warn('shutdown hard-kill watchdog process failed to start (retrying)', err);
+    armShutdownHardKillWatchdog(options);
+    return;
+  }
+  log.error(
+    `shutdown hard-kill watchdog UNAVAILABLE after ${_watchdogSpawnAttempts} spawn attempts — ` +
+      'external kill backstop ABSENT for this shutdown (continuing without it)',
+    err,
+  );
+}
 
 /**
  * 布防外部硬杀 watchdog: spawn 一个 detached 的外部杀手进程, 宽限期后对本进程
@@ -230,7 +251,9 @@ export function armShutdownHardKillWatchdog(
   } = {},
 ): void {
   if (_watchdogArmed) return;
+  if (_watchdogSpawnAttempts >= WATCHDOG_MAX_SPAWN_ATTEMPTS) return; // 预算耗尽,缺席标记已打
   _watchdogArmed = true;
+  _watchdogSpawnAttempts += 1;
   const spawnFn = options.spawn ?? spawn;
   const pid = options.pid ?? process.pid;
   const platform = options.platform ?? process.platform;
@@ -287,25 +310,18 @@ export function armShutdownHardKillWatchdog(
     // 不挂 listener 会变成 uncaughtException, 且 watchdog 实际未布防却无任何
     // 日志痕迹 —— 这里 warn 留痕, 让退出尸检能看出"补刀兜底当时不在位"。
     child.once?.('error', (err) => {
-      log.warn('shutdown hard-kill watchdog process failed to start (continuing shutdown)', err);
-      // 异步启动失败 = 实际未布防(review P1):回置标志并立即重试一次——
-      // EACCES/EAGAIN(fork 上限)这类瞬时失败第二次往往能成;仍失败则放弃
-      // (ENOENT 级环境缺失重试无意义),单次重试闸防 error→重试死循环。
-      _watchdogArmed = false;
-      if (!_watchdogSpawnRetried) {
-        _watchdogSpawnRetried = true;
-        armShutdownHardKillWatchdog(options);
-      }
+      // 异步启动失败 = 实际未布防(review P1 两轮):回置标志,预算内立即重试,
+      // 耗尽则打缺席标记(见 noteWatchdogSpawnFailure)。
+      noteWatchdogSpawnFailure(err, options);
     });
     child.unref();
     // log 放在 spawn 之后 (review P1): 统一 logger 同步写日志文件, 坏盘/网络盘
     // 上可能阻塞 —— watchdog 必须在任何可能卡住的盘 IO 之前先布防好。
     log.info(`arming shutdown hard-kill watchdog: pid=${pid} grace=${graceSeconds}s`);
   } catch (err) {
-    // 同步 spawn 失败 = 实际未布防:回置标志,让后续调用还有机会重试(review)。
-    // 异步 'error' 事件不回置——child 对象已创建,重试会叠出第二个 watchdog。
-    _watchdogArmed = false;
-    log.warn('failed to arm shutdown hard-kill watchdog (continuing shutdown)', err);
+    // 同步 spawn 失败 = 实际未布防:与异步 error 共享尝试预算,预算内重试,
+    // 耗尽打缺席标记(日志由 noteWatchdogSpawnFailure 统一输出)。
+    noteWatchdogSpawnFailure(err, options);
   }
 }
 

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -207,9 +207,12 @@ let _watchdogArmed = false;
  *     2026-07-06 观测到 exit 已打日志但 PID 存活 32h, 彼时 JS 事件循环已死,
  *     进程无法自救, 只有外部进程能补刀。
  *
- * 正常退出时本进程早已死透, 补刀落空无害 (kill 静默失败)。PID 复用窗口的取舍:
- * 20s 内 OS 把同一 PID 回收再分配给别的进程的概率极小, 沿用 updateScriptMacOS
- * 外部 kill -9 兜底的既有先例, 不做额外防护。
+ * 正常退出时本进程早已死透, 补刀落空无害 (kill 静默失败)。PID 复用防护 (review
+ * P1 两轮): 映像名/命令行校验区分不了同一 App 的两次运行 (正常退出后更新器立即
+ * 重启、新实例在宽限期内拿到复用 PID 会被误杀), 所以 watchdog 在布防时刻 (本进程
+ * 必然存活) 先捕获目标 PID 的**进程创建时间**, 补刀前重取一次, 不一致 = PID 已易主,
+ * 放弃。残余窗口只剩 "本进程在 watchdog 子进程完成首次捕获前 (毫秒级) 就退出且
+ * PID 立即复用给另一个同路径进程", 视为可接受。
  *
  * 幂等: 进程生命周期内只布防一次。spawn/pid/platform 可注入, 便于单测;
  * 布防失败只 warn, 绝不阻断正常退出。
@@ -232,27 +235,34 @@ export function armShutdownHardKillWatchdog(
   const graceSeconds = options.graceSeconds ?? SHUTDOWN_HARD_KILL_GRACE_SECONDS;
   const execPath = options.execPath ?? process.execPath;
   try {
-    // 杀前校验进程身份 (review P1): 宽限期内 OS 复用了该 PID 时, 盲杀会误伤
-    // 无关进程。POSIX 比对 ps 的 command 是否仍含本进程 execPath;Windows 比对
-    // tasklist 的映像名。校验不过 = 本进程已死且 PID 易主, 直接放弃补刀。
+    // 杀前校验进程身份 (review P1 两轮): 宽限期内 OS 复用了该 PID 时, 盲杀会误伤。
+    // 映像名/命令行校验区分不了同一 App 的两次运行 (更新器重启的新实例), 所以以
+    // **进程创建时间**为身份锚点: 布防时刻本进程必然存活, watchdog 子进程先捕获
+    // 目标 PID 的创建时间, 补刀前重取比对, 不一致 = PID 已易主, 放弃补刀。
     const child =
       platform === 'win32'
         ? (() => {
-            const imageName = execPath.split(/[\\/]/).pop() ?? 'Cindy.exe';
-            // `timeout /t` 在无控制台的 detached 进程里不可用 ("输入重定向不受支持"),
-            // `ping -n <N+1>` 是标准的 cmd 延时 hack (首个包立即发, 之后每包间隔 1s)。
-            // 环境变量规范拼写是 COMSPEC (Windows env 大小写不敏感, 但代码里用规范名,
-            // 对齐 terminal/shellResolver 的既有约定);不能假设 cmd.exe 一定在 PATH。
+            // cmd 拿不到进程创建时间 (wmic 已从新版 Windows 移除), 改用 Windows
+            // PowerShell 5.1 —— 所有受支持 Windows 内置, 用 SystemRoot 绝对路径,
+            // 不假设它在 PATH。属性读取走 Select-Object -ExpandProperty 而非语言级
+            // .StartTime, 兼容企业锁死环境的 Constrained Language Mode (其下语言级
+            // 属性访问被禁, cmdlet 内部反射不受限);取不到创建时间时直接退出不杀,
+            // 失败方向是"少杀"而非"误杀"。字符串 -eq 大小写不敏感, 路径比对安全。
+            const psExe =
+              `${process.env.SystemRoot ?? 'C:\\Windows'}` +
+              '\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+            const script =
+              `$ErrorActionPreference='SilentlyContinue'; ` +
+              `$started = Get-Process -Id ${pid} | Select-Object -ExpandProperty StartTime; ` +
+              `if (-not $started) { exit }; ` +
+              `Start-Sleep -Seconds ${graceSeconds}; ` +
+              `$p = Get-Process -Id ${pid}; ` +
+              `if ($p -and ($p | Select-Object -ExpandProperty StartTime) -eq $started ` +
+              `-and ($p | Select-Object -ExpandProperty Path) -eq '${execPath.replace(/'/g, "''")}') ` +
+              `{ Stop-Process -Id ${pid} -Force }`;
             return spawnFn(
-              process.env.COMSPEC ?? 'cmd.exe',
-              [
-                '/d',
-                '/s',
-                '/c',
-                `ping -n ${graceSeconds + 1} 127.0.0.1 >nul & ` +
-                  `tasklist /FI "PID eq ${pid}" /NH | findstr /I /C:"${imageName}" >nul && ` +
-                  `taskkill /f /pid ${pid}`,
-              ],
+              psExe,
+              ['-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden', '-Command', script],
               { detached: true, windowsHide: true, stdio: 'ignore' },
             );
           })()
@@ -260,7 +270,12 @@ export function armShutdownHardKillWatchdog(
             '/bin/sh',
             [
               '-c',
-              `sleep ${graceSeconds}; ` +
+              // lstart 是完整启动时间字符串 (秒级), 同 PID + 同启动秒 + 同 execPath
+              // 的碰撞视为不可能。捕获时进程已死则直接退出 (不需要补刀)。
+              `started="$(ps -p ${pid} -o lstart= 2>/dev/null)"; ` +
+                `[ -n "$started" ] || exit 0; ` +
+                `sleep ${graceSeconds}; ` +
+                `[ "$(ps -p ${pid} -o lstart= 2>/dev/null)" = "$started" ] && ` +
                 `ps -p ${pid} -o command= 2>/dev/null | grep -qF '${execPath.replace(/'/g, `'\\''`)}' && ` +
                 `kill -9 ${pid} 2>/dev/null`,
             ],

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -18,6 +18,10 @@
  * 然后 `app.exit(<code>)` 强制退出。`will-quit` / `quit` 事件不会触发——任何
  * 真正必须执行的清理都必须注册到这里, 而不是挂 `will-quit`。
  *
+ * shutdown 开始时同步布防外部硬杀 watchdog (armShutdownHardKillWatchdog):
+ * disposer 挂死、事件循环被 sync 代码阻塞、甚至 app.exit 在 native teardown
+ * 挂死 (JS 已死) 时, 由 detached 外部进程在宽限期后 kill -9 补刀, 保证退出有界。
+ *
  * installQuitHandler() 同时把以下入口都收到这条 disposer chain:
  *
  *   - app.on('before-quit')             —— 用户/代码主动退出 (Cmd+Q / 关窗 / app.quit)
@@ -28,6 +32,8 @@
  * unhandledRejection 只记日志、不退出 —— 悬空 Promise 不必然致命, 让上游决定。
  * 真硬崩 (segfault / kill -9) JS 层无能为力, 这里覆盖不到; 子进程靠 stdin EOF 自死。
  */
+
+import { spawn } from 'node:child_process';
 
 import { app, BrowserWindow, session } from 'electron';
 
@@ -141,17 +147,101 @@ export async function runQuitDisposers(timeoutMs = 2000): Promise<void> {
   }
 
   // ── Phase 3: post-async ──────────────────────────────────────────────────
+  // 返回 Promise 的 disposer 同样纳入 timeoutMs 预算 (逐个 race, 串行语义不变)。
+  // 此前这里是无界 await —— 生产实证: 单个挂死的 post-async disposer 就能让
+  // "runQuitDisposers completed" 永远打不出来, 进程卡在退出路径上不死。
   for (const d of registry.filter((x) => x.phase === 'post-async')) {
     try {
       const ret = d.fn();
       if (ret && typeof (ret as Promise<unknown>).then === 'function') {
-        await (ret as Promise<unknown>).catch((err) =>
+        const settled = (ret as Promise<unknown>).catch((err) =>
           log.error(`post-async disposer "${d.name}" threw`, err),
         );
+        let timer: NodeJS.Timeout | undefined;
+        let timedOut = false;
+        await Promise.race([
+          settled,
+          new Promise<void>((resolve) => {
+            timer = setTimeout(() => {
+              timedOut = true;
+              resolve();
+            }, timeoutMs);
+          }),
+        ]);
+        clearTimeout(timer);
+        if (timedOut) {
+          log.warn(`post-async disposer "${d.name}" timed out after ${timeoutMs}ms — continuing`);
+        }
       }
     } catch (err) {
       log.error(`post-async disposer "${d.name}" threw`, err);
     }
+  }
+}
+
+/**
+ * 外部硬杀 watchdog 的宽限期 (秒)。disposer 预算 6s 的 3 倍余量; 比更新脚本的
+ * 120s (updateScriptMacOS) 激进得多 —— 这是常规退出路径, 用户在旁边等。
+ */
+export const SHUTDOWN_HARD_KILL_GRACE_SECONDS = 20;
+
+/** 最小 spawn 形状 —— 单测注入 fake 用, 真实实现是 node:child_process 的 spawn。 */
+type WatchdogSpawn = (
+  command: string,
+  args: string[],
+  options: { detached: boolean; stdio: 'ignore'; windowsHide?: boolean },
+) => { unref(): void };
+
+let _watchdogArmed = false;
+
+/**
+ * 布防外部硬杀 watchdog: spawn 一个 detached 的外部杀手进程, 宽限期后对本进程
+ * PID 补 kill。这是唯一能同时覆盖三类退出挂死的手段:
+ *   - sync disposer 阻塞事件循环 (JS 层 setTimeout 根本不会触发)
+ *   - post-async 无界 await (Phase 3 已加预算, 这里是第二道保险)
+ *   - app.exit() 在 native teardown 挂死 —— 实证见 updateScriptMacOS.ts:
+ *     2026-07-06 观测到 exit 已打日志但 PID 存活 32h, 彼时 JS 事件循环已死,
+ *     进程无法自救, 只有外部进程能补刀。
+ *
+ * 正常退出时本进程早已死透, 补刀落空无害 (kill 静默失败)。PID 复用窗口的取舍:
+ * 20s 内 OS 把同一 PID 回收再分配给别的进程的概率极小, 沿用 updateScriptMacOS
+ * 外部 kill -9 兜底的既有先例, 不做额外防护。
+ *
+ * 幂等: 进程生命周期内只布防一次。spawn/pid/platform 可注入, 便于单测;
+ * 布防失败只 warn, 绝不阻断正常退出。
+ */
+export function armShutdownHardKillWatchdog(
+  options: {
+    spawn?: WatchdogSpawn;
+    pid?: number;
+    platform?: NodeJS.Platform;
+    graceSeconds?: number;
+  } = {},
+): void {
+  if (_watchdogArmed) return;
+  _watchdogArmed = true;
+  const spawnFn = options.spawn ?? spawn;
+  const pid = options.pid ?? process.pid;
+  const platform = options.platform ?? process.platform;
+  const graceSeconds = options.graceSeconds ?? SHUTDOWN_HARD_KILL_GRACE_SECONDS;
+  log.info(`arming shutdown hard-kill watchdog: pid=${pid} grace=${graceSeconds}s`);
+  try {
+    if (platform === 'win32') {
+      // `timeout /t` 在无控制台的 detached 进程里不可用 ("输入重定向不受支持"),
+      // `ping -n <N+1>` 是标准的 cmd 延时 hack (首个包立即发, 之后每包间隔 1s)。
+      spawnFn(
+        process.env.comspec ?? 'cmd.exe',
+        ['/d', '/s', '/c', `ping -n ${graceSeconds + 1} 127.0.0.1 >nul & taskkill /f /pid ${pid}`],
+        { detached: true, windowsHide: true, stdio: 'ignore' },
+      ).unref();
+    } else {
+      spawnFn('/bin/sh', ['-c', `sleep ${graceSeconds}; kill -9 ${pid} 2>/dev/null`], {
+        detached: true,
+        stdio: 'ignore',
+      }).unref();
+    }
+  } catch (err) {
+    log.warn('failed to arm shutdown hard-kill watchdog (continuing shutdown)', err);
   }
 }
 
@@ -172,6 +262,9 @@ function beginShutdown(timeoutMs: number, reason: string): Promise<void> {
   _isDisposing = true;
   log.info(`beginShutdown timeoutMs=${timeoutMs} reason=${reason}`);
   noteShutdownBegin(reason);
+  // 先布防外部硬杀 watchdog 再跑 disposer chain —— disposer 或 app.exit 挂死时
+  // 由外部进程在宽限期后补刀, 保证退出永远有界。
+  armShutdownHardKillWatchdog();
   _disposeStarted = runQuitDisposers(timeoutMs)
     .then(() => {
       log.info('runQuitDisposers completed');

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -220,6 +220,8 @@ export function armShutdownHardKillWatchdog(
     pid?: number;
     platform?: NodeJS.Platform;
     graceSeconds?: number;
+    /** 进程身份锚点 (杀前校验用), 默认 process.execPath;测试注入。 */
+    execPath?: string;
   } = {},
 ): void {
   if (_watchdogArmed) return;
@@ -228,21 +230,42 @@ export function armShutdownHardKillWatchdog(
   const pid = options.pid ?? process.pid;
   const platform = options.platform ?? process.platform;
   const graceSeconds = options.graceSeconds ?? SHUTDOWN_HARD_KILL_GRACE_SECONDS;
-  log.info(`arming shutdown hard-kill watchdog: pid=${pid} grace=${graceSeconds}s`);
+  const execPath = options.execPath ?? process.execPath;
   try {
+    // 杀前校验进程身份 (review P1): 宽限期内 OS 复用了该 PID 时, 盲杀会误伤
+    // 无关进程。POSIX 比对 ps 的 command 是否仍含本进程 execPath;Windows 比对
+    // tasklist 的映像名。校验不过 = 本进程已死且 PID 易主, 直接放弃补刀。
     const child =
       platform === 'win32'
-        ? // `timeout /t` 在无控制台的 detached 进程里不可用 ("输入重定向不受支持"),
-          // `ping -n <N+1>` 是标准的 cmd 延时 hack (首个包立即发, 之后每包间隔 1s)。
-          spawnFn(
-            process.env.comspec ?? 'cmd.exe',
-            ['/d', '/s', '/c', `ping -n ${graceSeconds + 1} 127.0.0.1 >nul & taskkill /f /pid ${pid}`],
-            { detached: true, windowsHide: true, stdio: 'ignore' },
-          )
-        : spawnFn('/bin/sh', ['-c', `sleep ${graceSeconds}; kill -9 ${pid} 2>/dev/null`], {
-            detached: true,
-            stdio: 'ignore',
-          });
+        ? (() => {
+            const imageName = execPath.split(/[\\/]/).pop() ?? 'Cindy.exe';
+            // `timeout /t` 在无控制台的 detached 进程里不可用 ("输入重定向不受支持"),
+            // `ping -n <N+1>` 是标准的 cmd 延时 hack (首个包立即发, 之后每包间隔 1s)。
+            // 环境变量规范拼写是 COMSPEC (Windows env 大小写不敏感, 但代码里用规范名,
+            // 对齐 terminal/shellResolver 的既有约定);不能假设 cmd.exe 一定在 PATH。
+            return spawnFn(
+              process.env.COMSPEC ?? 'cmd.exe',
+              [
+                '/d',
+                '/s',
+                '/c',
+                `ping -n ${graceSeconds + 1} 127.0.0.1 >nul & ` +
+                  `tasklist /FI "PID eq ${pid}" /NH | findstr /I /C:"${imageName}" >nul && ` +
+                  `taskkill /f /pid ${pid}`,
+              ],
+              { detached: true, windowsHide: true, stdio: 'ignore' },
+            );
+          })()
+        : spawnFn(
+            '/bin/sh',
+            [
+              '-c',
+              `sleep ${graceSeconds}; ` +
+                `ps -p ${pid} -o command= 2>/dev/null | grep -qF '${execPath.replace(/'/g, `'\\''`)}' && ` +
+                `kill -9 ${pid} 2>/dev/null`,
+            ],
+            { detached: true, stdio: 'ignore' },
+          );
     // spawn 的失败可能在返回后经 'error' 事件异步上报 (ENOENT/EACCES 等);
     // 不挂 listener 会变成 uncaughtException, 且 watchdog 实际未布防却无任何
     // 日志痕迹 —— 这里 warn 留痕, 让退出尸检能看出"补刀兜底当时不在位"。
@@ -250,6 +273,9 @@ export function armShutdownHardKillWatchdog(
       log.warn('shutdown hard-kill watchdog process failed to start (continuing shutdown)', err);
     });
     child.unref();
+    // log 放在 spawn 之后 (review P1): 统一 logger 同步写日志文件, 坏盘/网络盘
+    // 上可能阻塞 —— watchdog 必须在任何可能卡住的盘 IO 之前先布防好。
+    log.info(`arming shutdown hard-kill watchdog: pid=${pid} grace=${graceSeconds}s`);
   } catch (err) {
     log.warn('failed to arm shutdown hard-kill watchdog (continuing shutdown)', err);
   }
@@ -270,11 +296,13 @@ let _disposeStarted: Promise<void> | null = null;
 function beginShutdown(timeoutMs: number, reason: string): Promise<void> {
   if (_disposeStarted) return _disposeStarted;
   _isDisposing = true;
+  // watchdog 必须是 shutdown 的第一个动作 (review P1): log 与 noteShutdownBegin
+  // 都是同步盘 IO (日志文件 / run-marker 的 mkdirSync+writeFileSync), 落在坏盘
+  // 或网络盘上可能无限阻塞 —— 那正是 watchdog 要兜的挂死形态, 不能让布防
+  // 排在它们后面。spawn 本身不做盘写。
+  armShutdownHardKillWatchdog();
   log.info(`beginShutdown timeoutMs=${timeoutMs} reason=${reason}`);
   noteShutdownBegin(reason);
-  // 先布防外部硬杀 watchdog 再跑 disposer chain —— disposer 或 app.exit 挂死时
-  // 由外部进程在宽限期后补刀, 保证退出永远有界。
-  armShutdownHardKillWatchdog();
   _disposeStarted = runQuitDisposers(timeoutMs)
     .then(() => {
       log.info('runQuitDisposers completed');

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -190,7 +190,11 @@ type WatchdogSpawn = (
   command: string,
   args: string[],
   options: { detached: boolean; stdio: 'ignore'; windowsHide?: boolean },
-) => { unref(): void };
+) => {
+  unref(): void;
+  /** ChildProcess 的 'error' 事件订阅; fake 可省略 (可选调用)。 */
+  once?(event: 'error', listener: (err: Error) => void): unknown;
+};
 
 let _watchdogArmed = false;
 
@@ -226,20 +230,26 @@ export function armShutdownHardKillWatchdog(
   const graceSeconds = options.graceSeconds ?? SHUTDOWN_HARD_KILL_GRACE_SECONDS;
   log.info(`arming shutdown hard-kill watchdog: pid=${pid} grace=${graceSeconds}s`);
   try {
-    if (platform === 'win32') {
-      // `timeout /t` 在无控制台的 detached 进程里不可用 ("输入重定向不受支持"),
-      // `ping -n <N+1>` 是标准的 cmd 延时 hack (首个包立即发, 之后每包间隔 1s)。
-      spawnFn(
-        process.env.comspec ?? 'cmd.exe',
-        ['/d', '/s', '/c', `ping -n ${graceSeconds + 1} 127.0.0.1 >nul & taskkill /f /pid ${pid}`],
-        { detached: true, windowsHide: true, stdio: 'ignore' },
-      ).unref();
-    } else {
-      spawnFn('/bin/sh', ['-c', `sleep ${graceSeconds}; kill -9 ${pid} 2>/dev/null`], {
-        detached: true,
-        stdio: 'ignore',
-      }).unref();
-    }
+    const child =
+      platform === 'win32'
+        ? // `timeout /t` 在无控制台的 detached 进程里不可用 ("输入重定向不受支持"),
+          // `ping -n <N+1>` 是标准的 cmd 延时 hack (首个包立即发, 之后每包间隔 1s)。
+          spawnFn(
+            process.env.comspec ?? 'cmd.exe',
+            ['/d', '/s', '/c', `ping -n ${graceSeconds + 1} 127.0.0.1 >nul & taskkill /f /pid ${pid}`],
+            { detached: true, windowsHide: true, stdio: 'ignore' },
+          )
+        : spawnFn('/bin/sh', ['-c', `sleep ${graceSeconds}; kill -9 ${pid} 2>/dev/null`], {
+            detached: true,
+            stdio: 'ignore',
+          });
+    // spawn 的失败可能在返回后经 'error' 事件异步上报 (ENOENT/EACCES 等);
+    // 不挂 listener 会变成 uncaughtException, 且 watchdog 实际未布防却无任何
+    // 日志痕迹 —— 这里 warn 留痕, 让退出尸检能看出"补刀兜底当时不在位"。
+    child.once?.('error', (err) => {
+      log.warn('shutdown hard-kill watchdog process failed to start (continuing shutdown)', err);
+    });
+    child.unref();
   } catch (err) {
     log.warn('failed to arm shutdown hard-kill watchdog (continuing shutdown)', err);
   }

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -197,6 +197,8 @@ type WatchdogSpawn = (
 };
 
 let _watchdogArmed = false;
+/** 异步 spawn 失败后的单次重试闸(防 error→重试→error 无限循环)。 */
+let _watchdogSpawnRetried = false;
 
 /**
  * 布防外部硬杀 watchdog: spawn 一个 detached 的外部杀手进程, 宽限期后对本进程
@@ -286,6 +288,14 @@ export function armShutdownHardKillWatchdog(
     // 日志痕迹 —— 这里 warn 留痕, 让退出尸检能看出"补刀兜底当时不在位"。
     child.once?.('error', (err) => {
       log.warn('shutdown hard-kill watchdog process failed to start (continuing shutdown)', err);
+      // 异步启动失败 = 实际未布防(review P1):回置标志并立即重试一次——
+      // EACCES/EAGAIN(fork 上限)这类瞬时失败第二次往往能成;仍失败则放弃
+      // (ENOENT 级环境缺失重试无意义),单次重试闸防 error→重试死循环。
+      _watchdogArmed = false;
+      if (!_watchdogSpawnRetried) {
+        _watchdogSpawnRetried = true;
+        armShutdownHardKillWatchdog(options);
+      }
     });
     child.unref();
     // log 放在 spawn 之后 (review P1): 统一 logger 同步写日志文件, 坏盘/网络盘
@@ -360,6 +370,10 @@ export function installQuitHandler(timeoutMs = 2000): void {
   // ── Layer 1: graceful quit (before-quit) ────────────────────────────────
   // preventDefault 阻断默认 quit, 等 disposer chain 跑完再 app.exit(0)。
   app.on('before-quit', (e) => {
+    // arm-first(review P1):本 handler 必然走向退出,而下面第一行 log 就是
+    // 同步盘 IO——日志落在坏盘/网络盘上时会在布防前就挂死,watchdog 形同虚设。
+    // 幂等,与 beginShutdown 里的布防互为兜底。
+    armShutdownHardKillWatchdog();
     log.info('before-quit received');
     if (_isDisposing) return;
     e.preventDefault();
@@ -375,6 +389,8 @@ export function installQuitHandler(timeoutMs = 2000): void {
   if (process.platform === 'win32') shutdownSignals.push('SIGBREAK');
   for (const sig of shutdownSignals) {
     process.on(sig, () => {
+      // arm-first(review P1):同 before-quit,先布防再碰日志盘 IO。
+      armShutdownHardKillWatchdog();
       log.info(`received ${sig}, gracefully shutting down`);
       if (_isDisposing) return;
       if (app.isReady()) {
@@ -415,6 +431,9 @@ export function installQuitHandler(timeoutMs = 2000): void {
       broadcastTransientNetworkErrorTip(err);
       return;
     }
+    // arm-first(review P1):只在确定退出的分支布防——上面 broken-stdio /
+    // 瞬时网络两个不退出的分支绝不能布防,否则 20s 后 watchdog 会误杀健康进程。
+    armShutdownHardKillWatchdog();
     log.error('uncaughtException — shutting down', err);
     if (_isDisposing) return;
     void beginShutdown(timeoutMs, 'uncaughtException').finally(() => app.exit(1));
@@ -449,6 +468,9 @@ export function installQuitHandler(timeoutMs = 2000): void {
       );
       return;
     }
+    // arm-first(review P1):沙箱/webview 两个不退出的分支在上面已 return,
+    // 走到这里必然退出。
+    armShutdownHardKillWatchdog();
     log.error(`render-process-gone: reason=${details.reason} exitCode=${details.exitCode}`);
     if (_isDisposing) return;
     void beginShutdown(timeoutMs, `render-process-gone:${details.reason}`).finally(() =>

--- a/apps/desktop/src/main/lifecycle.ts
+++ b/apps/desktop/src/main/lifecycle.ts
@@ -292,6 +292,9 @@ export function armShutdownHardKillWatchdog(
     // 上可能阻塞 —— watchdog 必须在任何可能卡住的盘 IO 之前先布防好。
     log.info(`arming shutdown hard-kill watchdog: pid=${pid} grace=${graceSeconds}s`);
   } catch (err) {
+    // 同步 spawn 失败 = 实际未布防:回置标志,让后续调用还有机会重试(review)。
+    // 异步 'error' 事件不回置——child 对象已创建,重试会叠出第二个 watchdog。
+    _watchdogArmed = false;
     log.warn('failed to arm shutdown hard-kill watchdog (continuing shutdown)', err);
   }
 }

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -178,9 +178,9 @@ describe('stopRuntimeForQuitIfUsed', () => {
   it('a successful stop RESETS usage — use → backend-switch stop → quit skips (review P1)', async () => {
     // 使用后切换后端(ExternalChromeBackend.dispose)已成功停掉服务;若使用态
     // 终身保留,退出时会再派一次 stop,vendored bridge 会先把已停的服务重新
-    // 拉起——这正是本包装要避免的退出期启动。
+    // 拉起——这正是本包装要避免的退出期启动。stopped:true = 真正 tear down。
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
-      async (req) => ({ ok: true, action: req.action, status: 200 }),
+      async (req) => ({ ok: true, action: req.action, status: 200, data: req.action === 'stop' ? { stopped: true } : undefined }),
     );
     const tracked = trackBrowserRuntimeUsage({ call });
     const logger = fakeLogger();
@@ -224,7 +224,7 @@ describe('stopRuntimeForQuitIfUsed', () => {
     let resolveSlow!: (r: BrowserControlResult) => void;
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>((req) =>
       req.action === 'stop'
-        ? Promise.resolve({ ok: true, action: req.action, status: 200 })
+        ? Promise.resolve({ ok: true, action: req.action, status: 200, data: { stopped: true } })
         : new Promise((resolve) => {
             resolveSlow = resolve;
           }),
@@ -260,7 +260,7 @@ describe('stopRuntimeForQuitIfUsed', () => {
     await tracked.call({ action: 'status' }); // usage = true
     const switchStop = tracked.call({ action: 'stop' }); // 后端切换的 stop,在途
     const quit = stopRuntimeForQuitIfUsed(tracked, logger);
-    resolveStop({ ok: true, action: 'stop', status: 200 });
+    resolveStop({ ok: true, action: 'stop', status: 200, data: { stopped: true } });
     await switchStop;
     await quit;
 
@@ -292,7 +292,7 @@ describe('stopRuntimeForQuitIfUsed', () => {
 
     const pendingStop = tracked.call({ action: 'stop' }); // 先派发的 stop
     const lateStart = tracked.call({ action: 'start' }); // stop 之后新进的 start
-    resolveStop({ ok: true, action: 'stop', status: 200 }); // stop 成功:只作废更早的调用
+    resolveStop({ ok: true, action: 'stop', status: 200, data: { stopped: true } }); // stop 真正 tear down:只作废更早的调用
     await pendingStop;
     resolveStart({ ok: true, action: 'start', status: 200 }); // start 应答:重新计使用
     await lateStart;
@@ -302,9 +302,40 @@ describe('stopRuntimeForQuitIfUsed', () => {
     expect(call.mock.calls.map(([req]) => req.action)).toEqual(['stop', 'start', 'stop']); // quit 照常清理
   });
 
+  it('a NO-OP stop (stopped:false) does not invalidate a racing cold start (review P1)', async () => {
+    // 后端切换的 stop 撞上冷启动:vendored /stop 见 running===null 返回
+    // stopped:false(HTTP 200)——它没有 tear down 任何东西,更没覆盖到那次
+    // 在途 launch。若照样清使用态+抬屏障,晚到的 start 应答会被忽略,quit
+    // 跳过清理,新拉起的 Chrome 和 profile 锁被留下。
+    let resolveStart!: (r: BrowserControlResult) => void;
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>((req) => {
+      if (req.action === 'start') {
+        return new Promise((resolve) => {
+          resolveStart = resolve;
+        });
+      }
+      return Promise.resolve(
+        req.action === 'stop'
+          ? { ok: true, action: req.action, status: 200, data: { stopped: false } }
+          : { ok: true, action: req.action, status: 200 },
+      );
+    });
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    const coldStart = tracked.call({ action: 'start' }); // 冷启动在途(先派发)
+    await tracked.call({ action: 'stop' }); // 后端切换的 no-op stop
+    resolveStart({ ok: true, action: 'start', status: 200 }); // launch 完成
+    await coldStart;
+    expect(tracked.everCalled()).toBe(true);
+
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+    expect(call.mock.calls.map(([req]) => req.action)).toEqual(['start', 'stop', 'stop']); // quit 照常清理
+  });
+
   it('usage flips back on when non-stop traffic resumes after a successful stop', async () => {
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
-      async (req) => ({ ok: true, action: req.action, status: 200 }),
+      async (req) => ({ ok: true, action: req.action, status: 200, data: req.action === 'stop' ? { stopped: true } : undefined }),
     );
     const tracked = trackBrowserRuntimeUsage({ call });
     const logger = fakeLogger();

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -136,7 +136,10 @@ describe('stopRuntimeForQuitIfUsed', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
   });
 
-  it('beginQuiescence rejects NEW non-stop calls so nothing can boot mid-shutdown (review P1)', async () => {
+  it('beginQuiescence blocks NEW non-stop calls with a RESOLVED ok:false result (review ×2)', async () => {
+    // 底层 runtime 的契约是 call 永不 reject(总是 resolve BrowserControlResult,
+    // 调用方只看 res.ok)——门禁必须 resolve ok:false 而不是 reject,否则会在
+    // 只检查 res.ok 的调用方处变成 unhandledRejection。
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
       async (req) => ({ ok: true, action: req.action, status: 200 }),
     );
@@ -144,7 +147,11 @@ describe('stopRuntimeForQuitIfUsed', () => {
 
     tracked.beginQuiescence();
 
-    await expect(tracked.call({ action: 'status' })).rejects.toThrow('shutting down');
+    const res = await tracked.call({ action: 'status' });
+    expect(res.ok).toBe(false);
+    expect(res.errorCode).toBe('BROWSER_RUNTIME_UNAVAILABLE');
+    // 无 status → 不计使用
+    expect(tracked.everCalled()).toBe(false);
     expect(call).not.toHaveBeenCalled();
     // stop 仍放行(quit 路径自己要发 stop)
     await tracked.call({ action: 'stop' });
@@ -166,6 +173,63 @@ describe('stopRuntimeForQuitIfUsed', () => {
 
     expect(call).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+
+  it('a successful stop RESETS usage — use → backend-switch stop → quit skips (review P1)', async () => {
+    // 使用后切换后端(ExternalChromeBackend.dispose)已成功停掉服务;若使用态
+    // 终身保留,退出时会再派一次 stop,vendored bridge 会先把已停的服务重新
+    // 拉起——这正是本包装要避免的退出期启动。
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => ({ ok: true, action: req.action, status: 200 }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'status' });
+    expect(tracked.everCalled()).toBe(true);
+    await tracked.call({ action: 'stop' });
+    expect(tracked.everCalled()).toBe(false);
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    expect(call).toHaveBeenCalledTimes(2); // status + 后端切换的 stop,quit 未再派
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+
+  it('a failed stop does NOT reset usage — service may still be up, quit stop stays', async () => {
+    let stopCount = 0;
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => {
+        if (req.action !== 'stop') return { ok: true, action: req.action, status: 200 };
+        stopCount += 1;
+        return stopCount === 1
+          ? { ok: false, action: req.action, status: 500, errorCode: 'BROWSER_RUNTIME_ACTION_FAILED', message: 'busy' }
+          : { ok: true, action: req.action, status: 200 };
+      },
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'status' });
+    await tracked.call({ action: 'stop' }); // 失败的 stop:服务可能还活着
+    expect(tracked.everCalled()).toBe(true);
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    expect(call.mock.calls.map(([req]) => req.action)).toEqual(['status', 'stop', 'stop']);
+  });
+
+  it('usage flips back on when non-stop traffic resumes after a successful stop', async () => {
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => ({ ok: true, action: req.action, status: 200 }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'status' });
+    await tracked.call({ action: 'stop' });
+    await tracked.call({ action: 'start' }); // 服务被重新使用
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    expect(call.mock.calls.map(([r]) => r.action)).toEqual(['status', 'stop', 'start', 'stop']);
   });
 });
 

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -89,7 +89,9 @@ describe('stopRuntimeForQuitIfUsed', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('tracking wrapper records usage even when the tracked call rejects', async () => {
+  it('does not count a rejected call as usage — service liveness unproven', async () => {
+    // Review P1: marking at dispatch time would treat a failed-boot call as
+    // "service is up", and the quit-time stop would then re-run the boot.
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(async () => {
       throw new Error('dispatch exploded');
     });
@@ -99,8 +101,38 @@ describe('stopRuntimeForQuitIfUsed', () => {
     await expect(tracked.call({ action: 'status' })).rejects.toThrow('dispatch exploded');
     await stopRuntimeForQuitIfUsed(tracked, logger);
 
-    // used → stop dispatched; its rejection is swallowed by stopRuntimeForQuit
-    expect(call).toHaveBeenCalledTimes(2);
-    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+
+  it('does not count an ok:false result as usage — startup failures surface as not-ok', async () => {
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => ({ ok: false, action: req.action, status: 500 }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'status' });
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+
+  it('does not count a stop dispatch as usage — teardown is not traffic', async () => {
+    // Review P1: ExternalChromeBackend.dispose (backend switching) sends a
+    // stop through the same wrapper; counting it would make the quit path
+    // dispatch a second stop that re-boots the service.
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => ({ ok: true, action: req.action, status: 200 }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'stop' });
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
   });
 });

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -217,6 +217,32 @@ describe('stopRuntimeForQuitIfUsed', () => {
     expect(call.mock.calls.map(([req]) => req.action)).toEqual(['status', 'stop', 'stop']);
   });
 
+  it('a pre-stop call settling AFTER a successful stop does not re-mark usage (review ×2)', async () => {
+    // BackendRouter.setBackend 处理旧后端 dispose 时不等其在途调用排空:在途
+    // 调用可能在 stop 成功重置之后才 settle——它应答的是已被拆掉的服务实例,
+    // 若翻回使用态,退出路径会再派 stop 把服务重新拉起。epoch 必须拦住它。
+    let resolveSlow!: (r: BrowserControlResult) => void;
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>((req) =>
+      req.action === 'stop'
+        ? Promise.resolve({ ok: true, action: req.action, status: 200 })
+        : new Promise((resolve) => {
+            resolveSlow = resolve;
+          }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    const slow = tracked.call({ action: 'snapshot' }); // stop 前已在途
+    await tracked.call({ action: 'stop' }); // 后端切换的成功 stop
+    resolveSlow({ ok: true, action: 'snapshot', status: 200 }); // 晚到的旧应答
+    await slow;
+    expect(tracked.everCalled()).toBe(false);
+
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+    expect(call.mock.calls.map(([req]) => req.action)).toEqual(['snapshot', 'stop']); // quit 未再派
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+
   it('usage flips back on when non-stop traffic resumes after a successful stop', async () => {
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
       async (req) => ({ ok: true, action: req.action, status: 200 }),

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -105,7 +105,9 @@ describe('stopRuntimeForQuitIfUsed', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
   });
 
-  it('does not count an ok:false result as usage — startup failures surface as not-ok', async () => {
+  it('counts an ok:false WITH http status as usage — the service answered, it is up (review)', async () => {
+    // HTTP >=400 走的是 dispatcher 真实应答:服务已启动,只是 action 失败;
+    // 跳过 stop 会把已启动的服务/Chrome 留成孤儿(锁住 profile)。
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
       async (req) => ({ ok: false, action: req.action, status: 500 }),
     );
@@ -115,8 +117,38 @@ describe('stopRuntimeForQuitIfUsed', () => {
     await tracked.call({ action: 'status' });
     await stopRuntimeForQuitIfUsed(tracked, logger);
 
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call.mock.calls[1][0]).toEqual({ action: 'stop' });
+  });
+
+  it('does not count an ok:false WITHOUT status as usage — thrown boots have no http reply', async () => {
+    // catch 路径(启动 throw / disabled)不带 status:服务存活未证实,不计使用。
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => ({ ok: false, action: req.action, errorCode: 'BROWSER_RUNTIME_UNAVAILABLE', message: 'disabled' }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'status' });
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
     expect(call).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+
+  it('beginQuiescence rejects NEW non-stop calls so nothing can boot mid-shutdown (review P1)', async () => {
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => ({ ok: true, action: req.action, status: 200 }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+
+    tracked.beginQuiescence();
+
+    await expect(tracked.call({ action: 'status' })).rejects.toThrow('shutting down');
+    expect(call).not.toHaveBeenCalled();
+    // stop 仍放行(quit 路径自己要发 stop)
+    await tracked.call({ action: 'stop' });
+    expect(call).toHaveBeenCalledTimes(1);
   });
 
   it('does not count a stop dispatch as usage — teardown is not traffic', async () => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { stopRuntimeForQuit } from '../browser-dispose.js';
+import {
+  stopRuntimeForQuit,
+  stopRuntimeForQuitIfUsed,
+  trackBrowserRuntimeUsage,
+} from '../browser-dispose.js';
 import type { BrowserControlRequest, BrowserControlResult } from '@cindy/browser-control-runtime';
 
 function fakeLogger() {
-  return { warn: vi.fn() };
+  return { info: vi.fn(), warn: vi.fn() };
 }
 
 describe('stopRuntimeForQuit', () => {
@@ -45,6 +49,58 @@ describe('stopRuntimeForQuit', () => {
     const logger = fakeLogger();
 
     await expect(stopRuntimeForQuit({ call }, logger)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('stopRuntimeForQuitIfUsed', () => {
+  it('skips the stop dispatch entirely when the runtime was never used', async () => {
+    // The vendored dispatch bridge boots the browser control service before
+    // routing ANY action — so "never used" must mean zero calls, not a no-op stop.
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(async () => ({
+      ok: true,
+      action: 'stop',
+      status: 200,
+    }));
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    expect(call).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('never used this session'),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('stops normally when the runtime saw traffic this session', async () => {
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      async (req) => ({ ok: true, action: req.action, status: 200 }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'status' });
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call.mock.calls[1][0]).toEqual({ action: 'stop' });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('tracking wrapper records usage even when the tracked call rejects', async () => {
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(async () => {
+      throw new Error('dispatch exploded');
+    });
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await expect(tracked.call({ action: 'status' })).rejects.toThrow('dispatch exploded');
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+
+    // used → stop dispatched; its rejection is swallowed by stopRuntimeForQuit
+    expect(call).toHaveBeenCalledTimes(2);
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -243,6 +243,65 @@ describe('stopRuntimeForQuitIfUsed', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
   });
 
+  it('quit waits for an in-flight backend-switch stop, then skips its own stop (review)', async () => {
+    // stop 若不进 inFlight,settleInFlight 之后它才落定重置使用态,quit 已经
+    // 多派了一次 stop——vendored bridge 会为路由这次 stop 把刚停掉的服务再拉起。
+    let resolveStop!: (r: BrowserControlResult) => void;
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>((req) =>
+      req.action === 'stop'
+        ? new Promise((resolve) => {
+            resolveStop = resolve;
+          })
+        : Promise.resolve({ ok: true, action: req.action, status: 200 }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    await tracked.call({ action: 'status' }); // usage = true
+    const switchStop = tracked.call({ action: 'stop' }); // 后端切换的 stop,在途
+    const quit = stopRuntimeForQuitIfUsed(tracked, logger);
+    resolveStop({ ok: true, action: 'stop', status: 200 });
+    await switchStop;
+    await quit;
+
+    expect(call.mock.calls.map(([req]) => req.action)).toEqual(['status', 'stop']); // quit 未再派
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+
+  it('a call admitted AFTER a pending stop re-marks usage once it answers (review P1)', async () => {
+    // 后端切换的 stop 在途期间,一条 start(比 stop 晚派发)赢得竞态并拉起了
+    // 新 Chrome:它的应答必须重新计入使用,否则 quit 会跳过清理、泄漏进程与
+    // profile 锁(epoch-per-stop 方案会误伤这类新调用,seq 屏障不会)。
+    let resolveStop!: (r: BrowserControlResult) => void;
+    let resolveStart!: (r: BrowserControlResult) => void;
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>((req) => {
+      if (req.action === 'stop' && !resolveStop) {
+        return new Promise((resolve) => {
+          resolveStop = resolve;
+        });
+      }
+      if (req.action === 'start') {
+        return new Promise((resolve) => {
+          resolveStart = resolve;
+        });
+      }
+      return Promise.resolve({ ok: true, action: req.action, status: 200 });
+    });
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    const pendingStop = tracked.call({ action: 'stop' }); // 先派发的 stop
+    const lateStart = tracked.call({ action: 'start' }); // stop 之后新进的 start
+    resolveStop({ ok: true, action: 'stop', status: 200 }); // stop 成功:只作废更早的调用
+    await pendingStop;
+    resolveStart({ ok: true, action: 'start', status: 200 }); // start 应答:重新计使用
+    await lateStart;
+    expect(tracked.everCalled()).toBe(true);
+
+    await stopRuntimeForQuitIfUsed(tracked, logger);
+    expect(call.mock.calls.map(([req]) => req.action)).toEqual(['stop', 'start', 'stop']); // quit 照常清理
+  });
+
   it('usage flips back on when non-stop traffic resumes after a successful stop', async () => {
     const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
       async (req) => ({ ok: true, action: req.action, status: 200 }),

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browser-dispose.test.ts
@@ -136,3 +136,47 @@ describe('stopRuntimeForQuitIfUsed', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
   });
 });
+
+describe('stopRuntimeForQuitIfUsed — quit racing an in-flight first call (review P1)', () => {
+  it('waits for a still-booting call; success → stop dispatched', async () => {
+    let resolveFirst!: (r: BrowserControlResult) => void;
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>((req) =>
+      req.action === 'stop'
+        ? Promise.resolve({ ok: true, action: req.action, status: 200 })
+        : new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    void tracked.call({ action: 'start' });
+    const quit = stopRuntimeForQuitIfUsed(tracked, logger);
+    // 在途启动尚未落定,quit 必须等待而不是立即判"never used"
+    resolveFirst({ ok: true, action: 'start', status: 200 });
+    await quit;
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call.mock.calls[1][0]).toEqual({ action: 'stop' });
+  });
+
+  it('waits for a still-booting call; failure → skip (service liveness unproven)', async () => {
+    let rejectFirst!: (err: Error) => void;
+    const call = vi.fn<(req: BrowserControlRequest) => Promise<BrowserControlResult>>(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+    );
+    const tracked = trackBrowserRuntimeUsage({ call });
+    const logger = fakeLogger();
+
+    void tracked.call({ action: 'start' }).catch(() => undefined);
+    const quit = stopRuntimeForQuitIfUsed(tracked, logger);
+    rejectFirst(new Error('boot exploded'));
+    await quit;
+
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('never used this session'));
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -27,8 +27,8 @@ interface QuitInfoLogger extends QuitLogger {
  */
 export interface UsageTrackedBrowserRuntime extends Pick<BrowserControlRuntime, 'call'> {
   /**
-   * True iff at least one NON-stop `call` completed with an ok result — i.e.
-   * the control service provably booted and served real traffic this session.
+   * True iff at least one NON-stop `call` produced an HTTP response — i.e. the
+   * control service provably booted and answered this session.
    */
   everCalled(): boolean;
   /**
@@ -40,34 +40,49 @@ export interface UsageTrackedBrowserRuntime extends Pick<BrowserControlRuntime, 
    * process and its locked user-data-dir.
    */
   settleInFlight(): Promise<void>;
+  /**
+   * Quit gate (review P1): after this, NEW non-stop calls are rejected instead
+   * of dispatched. Without it a call admitted between "settleInFlight saw an
+   * empty set" and "everCalled read" could boot the service mid-shutdown after
+   * the skip decision was already made.
+   */
+  beginQuiescence(): void;
 }
 
 export function trackBrowserRuntimeUsage(
   inner: Pick<BrowserControlRuntime, 'call'>,
 ): UsageTrackedBrowserRuntime {
   let everCalled = false;
+  let quiescing = false;
   const inFlight = new Set<Promise<unknown>>();
   return {
     call(request) {
+      if (quiescing && request.action !== 'stop') {
+        return Promise.reject(
+          new Error('browser runtime is shutting down — new calls are rejected'),
+        );
+      }
       const result = inner.call(request);
-      // Mark "used" only when the call SETTLES successfully, and only for
-      // non-stop actions (review feedback, both P1):
-      //  - marking at dispatch time would treat a still-booting or failed-boot
-      //    call as "service is up", and the quit-time stop would then re-run
-      //    the service boot we are trying to avoid;
+      // Mark "used" only when the response carries an HTTP `status`, and only
+      // for non-stop actions (review feedback, three P1s across two rounds):
+      //  - `status` present means the dispatcher really answered over the
+      //    control service — it booted. This includes ok:false HTTP >=400
+      //    responses (service is up, the action failed) which MUST count,
+      //    otherwise quit skips the stop and leaks the running service.
+      //  - `status` absent covers planDispatch rejections and thrown boots
+      //    (`BROWSER_RUNTIME_UNAVAILABLE` / catch-path failures): service
+      //    liveness unproven — counting those would make the quit-time stop
+      //    re-run the very boot we're avoiding.
       //  - `stop` itself is teardown, not usage — ExternalChromeBackend.dispose
       //    dispatches one during backend switching, and counting it would make
       //    the quit path dispatch a second stop that re-boots the service.
-      // An ok:false result means the dispatch bridge answered but the action
-      // failed (startup failures surface here too) — service liveness is not
-      // proven, so stay conservative; a skipped quit-stop is recovered by the
-      // vendored stale-lock path on next launch (see stopRuntimeForQuit docs).
+      // A wrongly-skipped quit-stop is recovered by the vendored stale-lock
+      // path on next launch (see stopRuntimeForQuit docs).
       if (request.action !== 'stop') {
         const settled = result.then(
           (response) => {
-            if ((response as { ok?: unknown } | null | undefined)?.ok !== false) {
-              everCalled = true;
-            }
+            const status = (response as { status?: unknown } | null | undefined)?.status;
+            if (typeof status === 'number') everCalled = true;
           },
           () => {
             // Rejected dispatch proves nothing about service liveness — ignore.
@@ -86,6 +101,9 @@ export function trackBrowserRuntimeUsage(
         await Promise.all([...inFlight]);
       }
     },
+    beginQuiescence: () => {
+      quiescing = true;
+    },
   };
 }
 
@@ -100,10 +118,13 @@ export async function stopRuntimeForQuitIfUsed(
   logger: QuitInfoLogger,
 ): Promise<void> {
   // Quit can race the very first call (e.g. openBrowserForLogin still awaiting
-  // `start`): wait for in-flight calls to settle before deciding, otherwise a
-  // still-booting Chrome would be misread as "never used" and outlive the app.
+  // `start`): close the gate to NEW calls first, then wait for in-flight ones
+  // to settle before deciding — otherwise a still-booting Chrome would be
+  // misread as "never used" and outlive the app, or a call admitted right
+  // after the settle-check could boot the service mid-shutdown (review P1).
   // Bounded externally: this runs inside the async disposer phase (timeoutMs
   // race) with the hard-kill watchdog behind it.
+  runtime.beginQuiescence();
   await runtime.settleInFlight();
   if (!runtime.everCalled()) {
     logger.info('browser runtime never used this session — skipping quit-time stop');

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -27,8 +27,9 @@ interface QuitInfoLogger extends QuitLogger {
  */
 export interface UsageTrackedBrowserRuntime extends Pick<BrowserControlRuntime, 'call'> {
   /**
-   * True iff at least one NON-stop `call` produced an HTTP response — i.e. the
-   * control service provably booted and answered this session.
+   * True iff at least one NON-stop `call` produced an HTTP response since the
+   * last successful `stop` — i.e. the control service provably booted and
+   * answered, and has not been torn down again since.
    */
   everCalled(): boolean;
   /**
@@ -58,9 +59,17 @@ export function trackBrowserRuntimeUsage(
   return {
     call(request) {
       if (quiescing && request.action !== 'stop') {
-        return Promise.reject(
-          new Error('browser runtime is shutting down — new calls are rejected'),
-        );
+        // Resolve (not reject): the underlying runtime's contract is that
+        // `call` always resolves a BrowserControlResult — callers only check
+        // `res.ok` and a rejection here would surface as an unhandled
+        // rejection (review). No `status` field, so this never counts as
+        // usage either.
+        return Promise.resolve({
+          ok: false,
+          action: request.action,
+          errorCode: 'BROWSER_RUNTIME_UNAVAILABLE',
+          message: 'browser runtime is shutting down — new calls are not dispatched',
+        });
       }
       const result = inner.call(request);
       // Mark "used" only when the response carries an HTTP `status`, and only
@@ -90,6 +99,23 @@ export function trackBrowserRuntimeUsage(
         );
         inFlight.add(settled);
         void settled.finally(() => inFlight.delete(settled));
+      } else {
+        // A settled SUCCESSFUL stop proves the service is down again (review
+        // P1: ExternalChromeBackend.dispose stops it mid-session on backend
+        // switch). Keeping usage true past that point would make the
+        // quit-time stop boot the already-stopped service — the exact
+        // startup this wrapper exists to prevent. Later non-stop traffic
+        // flips usage back on. ok:false / rejected stops leave state
+        // unchanged: the service may still be up, and a possibly-redundant
+        // quit stop is the safe direction there.
+        void result.then(
+          (response) => {
+            if ((response as { ok?: unknown } | null | undefined)?.ok === true) {
+              everCalled = false;
+            }
+          },
+          () => {},
+        );
       }
       return result;
     },

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -133,7 +133,21 @@ export function trackBrowserRuntimeUsage(
         // quit stop is the safe direction there.
         settled = result.then(
           (response) => {
-            if ((response as { ok?: unknown } | null | undefined)?.ok === true) {
+            const r = response as
+              | { ok?: unknown; data?: { stopped?: unknown } | null }
+              | null
+              | undefined;
+            // Only a stop that actually tore something down invalidates usage
+            // (review P1): the vendored /stop reports `data.stopped`, and a
+            // no-op stop (`stopped:false` — nothing running at that instant,
+            // e.g. it raced a cold `start` whose launch it did NOT cover)
+            // must leave usage and the barrier untouched, so the racing
+            // start's later response re-marks usage and quit still cleans up
+            // the Chrome it launched. Vendored state machine guarantees
+            // `stopped:true` only after the launch finished (`running` is
+            // assigned post-launch), so a mid-launch race always lands here
+            // as `stopped:false`.
+            if (r?.ok === true && r.data?.stopped === true) {
               everCalled = false;
               stopInvalidationBarrier = Math.max(stopInvalidationBarrier, mySeq);
             }

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -27,18 +27,22 @@ interface QuitInfoLogger extends QuitLogger {
  */
 export interface UsageTrackedBrowserRuntime extends Pick<BrowserControlRuntime, 'call'> {
   /**
-   * True iff at least one NON-stop `call` produced an HTTP response since the
-   * last successful `stop` — i.e. the control service provably booted and
-   * answered, and has not been torn down again since.
+   * True iff a NON-stop `call` produced an HTTP response and no successful
+   * `stop` has invalidated it since — i.e. the control service provably
+   * booted and answered, and (as far as dispatch ordering can tell) has not
+   * been torn down again afterwards.
    */
   everCalled(): boolean;
   /**
-   * Resolves once every in-flight NON-stop call has settled (results and
-   * rejections are swallowed). The quit path awaits this before reading
-   * `everCalled()` — quitting while the very first call is still booting the
-   * managed Chrome must not be misread as "never used" (review P1): that call
-   * can finish launching Chrome right after we skipped the stop, orphaning the
-   * process and its locked user-data-dir.
+   * Resolves once every in-flight call — `stop` included — has settled
+   * (results and rejections are swallowed). The quit path awaits this before
+   * reading `everCalled()`:
+   *  - a still-booting first call must not be misread as "never used"
+   *    (review P1): it can finish launching Chrome right after we skipped
+   *    the stop, orphaning the process and its locked user-data-dir;
+   *  - an in-flight backend-switch `stop` must settle first too (review):
+   *    reading usage before its reset lands would make quit dispatch a
+   *    second stop against a service that is already going down.
    */
   settleInFlight(): Promise<void>;
   /**
@@ -55,13 +59,19 @@ export function trackBrowserRuntimeUsage(
 ): UsageTrackedBrowserRuntime {
   let everCalled = false;
   let quiescing = false;
-  // Usage epoch: bumped on every SUCCESSFUL stop. A non-stop call only marks
-  // usage if the epoch it was dispatched under is still current — a call that
-  // was in flight across a backend-switch stop (BackendRouter.setBackend
-  // disposes the old backend without draining its calls) settles against a
-  // service that has since been torn down, and must not re-mark usage
-  // (review ×2: late settle would re-enable the quit-time stop → boot).
-  let usageEpoch = 0;
+  // Dispatch-order barrier (review ×3, two rounds): every call gets a
+  // monotonically increasing dispatch sequence; a SUCCESSFUL stop raises the
+  // barrier to its own sequence. A non-stop response only marks usage when
+  // its dispatch sequence is ABOVE the barrier:
+  //  - calls dispatched BEFORE the stop settle late against a torn-down
+  //    service → blocked (late settle must not re-enable the quit stop);
+  //  - calls admitted AFTER the stop was dispatched (e.g. a start racing
+  //    ExternalChromeBackend.dispose during a backend switch) are newer than
+  //    the barrier → their response re-marks usage, so quit still cleans up
+  //    the freshly launched Chrome (an epoch-per-stop scheme wrongly
+  //    invalidated these).
+  let dispatchSeq = 0;
+  let stopInvalidationBarrier = -1;
   const inFlight = new Set<Promise<unknown>>();
   return {
     call(request) {
@@ -94,14 +104,16 @@ export function trackBrowserRuntimeUsage(
       //    the quit path dispatch a second stop that re-boots the service.
       // A wrongly-skipped quit-stop is recovered by the vendored stale-lock
       // path on next launch (see stopRuntimeForQuit docs).
+      const mySeq = dispatchSeq;
+      dispatchSeq += 1;
+      let settled: Promise<unknown>;
       if (request.action !== 'stop') {
-        const dispatchEpoch = usageEpoch;
-        const settled = result.then(
+        settled = result.then(
           (response) => {
             const status = (response as { status?: unknown } | null | undefined)?.status;
-            // Epoch must still match: a success settling after a later
-            // successful stop belongs to the torn-down service instance.
-            if (typeof status === 'number' && dispatchEpoch === usageEpoch) {
+            // Barrier check: only calls dispatched after the latest
+            // successful stop may (re-)mark usage — see barrier comment.
+            if (typeof status === 'number' && mySeq > stopInvalidationBarrier) {
               everCalled = true;
             }
           },
@@ -109,29 +121,31 @@ export function trackBrowserRuntimeUsage(
             // Rejected dispatch proves nothing about service liveness — ignore.
           },
         );
-        inFlight.add(settled);
-        void settled.finally(() => inFlight.delete(settled));
       } else {
         // A settled SUCCESSFUL stop proves the service is down again (review
         // P1: ExternalChromeBackend.dispose stops it mid-session on backend
         // switch). Keeping usage true past that point would make the
         // quit-time stop boot the already-stopped service — the exact
-        // startup this wrapper exists to prevent. Later non-stop traffic
-        // flips usage back on. ok:false / rejected stops leave state
+        // startup this wrapper exists to prevent. The barrier only
+        // invalidates calls dispatched BEFORE this stop; anything admitted
+        // after it can re-mark usage. ok:false / rejected stops leave state
         // unchanged: the service may still be up, and a possibly-redundant
         // quit stop is the safe direction there.
-        void result.then(
+        settled = result.then(
           (response) => {
             if ((response as { ok?: unknown } | null | undefined)?.ok === true) {
               everCalled = false;
-              // Invalidate in-flight pre-stop calls' usage marking (see
-              // usageEpoch above).
-              usageEpoch += 1;
+              stopInvalidationBarrier = Math.max(stopInvalidationBarrier, mySeq);
             }
           },
           () => {},
         );
       }
+      // Stops are tracked in inFlight too (review): settleInFlight must let a
+      // racing backend-switch stop land its usage reset before the quit path
+      // reads everCalled, or quit dispatches a second stop.
+      inFlight.add(settled);
+      void settled.finally(() => inFlight.delete(settled));
       return result;
     },
     everCalled: () => everCalled,

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -26,7 +26,10 @@ interface QuitInfoLogger extends QuitLogger {
  * That service boot is an exit-hang amplifier we must not run during quit.
  */
 export interface UsageTrackedBrowserRuntime extends Pick<BrowserControlRuntime, 'call'> {
-  /** True iff at least one `call` went through this wrapper. */
+  /**
+   * True iff at least one NON-stop `call` completed with an ok result — i.e.
+   * the control service provably booted and served real traffic this session.
+   */
   everCalled(): boolean;
 }
 
@@ -36,8 +39,32 @@ export function trackBrowserRuntimeUsage(
   let everCalled = false;
   return {
     call(request) {
-      everCalled = true;
-      return inner.call(request);
+      const result = inner.call(request);
+      // Mark "used" only when the call SETTLES successfully, and only for
+      // non-stop actions (review feedback, both P1):
+      //  - marking at dispatch time would treat a still-booting or failed-boot
+      //    call as "service is up", and the quit-time stop would then re-run
+      //    the service boot we are trying to avoid;
+      //  - `stop` itself is teardown, not usage — ExternalChromeBackend.dispose
+      //    dispatches one during backend switching, and counting it would make
+      //    the quit path dispatch a second stop that re-boots the service.
+      // An ok:false result means the dispatch bridge answered but the action
+      // failed (startup failures surface here too) — service liveness is not
+      // proven, so stay conservative; a skipped quit-stop is recovered by the
+      // vendored stale-lock path on next launch (see stopRuntimeForQuit docs).
+      if (request.action !== 'stop') {
+        void result.then(
+          (response) => {
+            if ((response as { ok?: unknown } | null | undefined)?.ok !== false) {
+              everCalled = true;
+            }
+          },
+          () => {
+            // Rejected dispatch proves nothing about service liveness — ignore.
+          },
+        );
+      }
+      return result;
     },
     everCalled: () => everCalled,
   };

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -55,6 +55,13 @@ export function trackBrowserRuntimeUsage(
 ): UsageTrackedBrowserRuntime {
   let everCalled = false;
   let quiescing = false;
+  // Usage epoch: bumped on every SUCCESSFUL stop. A non-stop call only marks
+  // usage if the epoch it was dispatched under is still current — a call that
+  // was in flight across a backend-switch stop (BackendRouter.setBackend
+  // disposes the old backend without draining its calls) settles against a
+  // service that has since been torn down, and must not re-mark usage
+  // (review ×2: late settle would re-enable the quit-time stop → boot).
+  let usageEpoch = 0;
   const inFlight = new Set<Promise<unknown>>();
   return {
     call(request) {
@@ -88,10 +95,15 @@ export function trackBrowserRuntimeUsage(
       // A wrongly-skipped quit-stop is recovered by the vendored stale-lock
       // path on next launch (see stopRuntimeForQuit docs).
       if (request.action !== 'stop') {
+        const dispatchEpoch = usageEpoch;
         const settled = result.then(
           (response) => {
             const status = (response as { status?: unknown } | null | undefined)?.status;
-            if (typeof status === 'number') everCalled = true;
+            // Epoch must still match: a success settling after a later
+            // successful stop belongs to the torn-down service instance.
+            if (typeof status === 'number' && dispatchEpoch === usageEpoch) {
+              everCalled = true;
+            }
           },
           () => {
             // Rejected dispatch proves nothing about service liveness — ignore.
@@ -112,6 +124,9 @@ export function trackBrowserRuntimeUsage(
           (response) => {
             if ((response as { ok?: unknown } | null | undefined)?.ok === true) {
               everCalled = false;
+              // Invalidate in-flight pre-stop calls' usage marking (see
+              // usageEpoch above).
+              usageEpoch += 1;
             }
           },
           () => {},

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -10,13 +10,65 @@ interface QuitLogger {
   warn(message: string, ...args: unknown[]): void;
 }
 
+/** `stopRuntimeForQuitIfUsed` additionally logs the skip decision at info. */
+interface QuitInfoLogger extends QuitLogger {
+  info(message: string, ...args: unknown[]): void;
+}
+
+/**
+ * Usage-tracking wrapper around the vendored runtime: records whether ANY
+ * request was dispatched through it this session. The quit path uses this to
+ * skip the stop dispatch entirely when the runtime was never touched — the
+ * vendored dispatch bridge (`dispatchBrowserControlRequest`) unconditionally
+ * boots the browser control service (dynamic playwright import included)
+ * before routing ANY action, `stop` included, so an unguarded quit-time stop
+ * on a browser-less session would START the very service it is shutting down.
+ * That service boot is an exit-hang amplifier we must not run during quit.
+ */
+export interface UsageTrackedBrowserRuntime extends Pick<BrowserControlRuntime, 'call'> {
+  /** True iff at least one `call` went through this wrapper. */
+  everCalled(): boolean;
+}
+
+export function trackBrowserRuntimeUsage(
+  inner: Pick<BrowserControlRuntime, 'call'>,
+): UsageTrackedBrowserRuntime {
+  let everCalled = false;
+  return {
+    call(request) {
+      everCalled = true;
+      return inner.call(request);
+    },
+    everCalled: () => everCalled,
+  };
+}
+
+/**
+ * Quit-path stop, short-circuited when the runtime saw zero traffic this
+ * session (see `trackBrowserRuntimeUsage`). If any request DID go through,
+ * the control service already exists, so dispatching `stop` cannot newly
+ * boot anything — it only tears down whatever the session created.
+ */
+export async function stopRuntimeForQuitIfUsed(
+  runtime: UsageTrackedBrowserRuntime,
+  logger: QuitInfoLogger,
+): Promise<void> {
+  if (!runtime.everCalled()) {
+    logger.info('browser runtime never used this session — skipping quit-time stop');
+    return;
+  }
+  await stopRuntimeForQuit(runtime, logger);
+}
+
 /**
  * Stop the managed browser on the app-quit path.
  *
  * Swallows/logs all failures: this runs inside the lifecycle disposer chain
  * where throwing would only stall shutdown, and a failed stop is recovered by
- * the vendored stale-lock path on next launch. `stop` is idempotent — a no-op if
- * the browser was never started.
+ * the vendored stale-lock path on next launch. `stop` won't kill anything that
+ * isn't running — but note the dispatch itself boots the browser control
+ * service if it isn't up yet, so quit-time callers should prefer
+ * `stopRuntimeForQuitIfUsed` to avoid starting services during shutdown.
  *
  * An unprofiled `stop` resolves the DEFAULT profile, which is sufficient because
  * the runtime is configured with exactly one managed profile (the sync.mjs patch

--- a/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-dispose.ts
@@ -31,12 +31,22 @@ export interface UsageTrackedBrowserRuntime extends Pick<BrowserControlRuntime, 
    * the control service provably booted and served real traffic this session.
    */
   everCalled(): boolean;
+  /**
+   * Resolves once every in-flight NON-stop call has settled (results and
+   * rejections are swallowed). The quit path awaits this before reading
+   * `everCalled()` — quitting while the very first call is still booting the
+   * managed Chrome must not be misread as "never used" (review P1): that call
+   * can finish launching Chrome right after we skipped the stop, orphaning the
+   * process and its locked user-data-dir.
+   */
+  settleInFlight(): Promise<void>;
 }
 
 export function trackBrowserRuntimeUsage(
   inner: Pick<BrowserControlRuntime, 'call'>,
 ): UsageTrackedBrowserRuntime {
   let everCalled = false;
+  const inFlight = new Set<Promise<unknown>>();
   return {
     call(request) {
       const result = inner.call(request);
@@ -53,7 +63,7 @@ export function trackBrowserRuntimeUsage(
       // proven, so stay conservative; a skipped quit-stop is recovered by the
       // vendored stale-lock path on next launch (see stopRuntimeForQuit docs).
       if (request.action !== 'stop') {
-        void result.then(
+        const settled = result.then(
           (response) => {
             if ((response as { ok?: unknown } | null | undefined)?.ok !== false) {
               everCalled = true;
@@ -63,10 +73,19 @@ export function trackBrowserRuntimeUsage(
             // Rejected dispatch proves nothing about service liveness — ignore.
           },
         );
+        inFlight.add(settled);
+        void settled.finally(() => inFlight.delete(settled));
       }
       return result;
     },
     everCalled: () => everCalled,
+    settleInFlight: async () => {
+      // Snapshot-loop until quiescent: an in-flight call may itself trigger
+      // follow-up calls (e.g. login flow chaining start → focus).
+      while (inFlight.size > 0) {
+        await Promise.all([...inFlight]);
+      }
+    },
   };
 }
 
@@ -80,6 +99,12 @@ export async function stopRuntimeForQuitIfUsed(
   runtime: UsageTrackedBrowserRuntime,
   logger: QuitInfoLogger,
 ): Promise<void> {
+  // Quit can race the very first call (e.g. openBrowserForLogin still awaiting
+  // `start`): wait for in-flight calls to settle before deciding, otherwise a
+  // still-booting Chrome would be misread as "never used" and outlive the app.
+  // Bounded externally: this runs inside the async disposer phase (timeoutMs
+  // race) with the hard-kill watchdog behind it.
+  await runtime.settleInFlight();
   if (!runtime.everCalled()) {
     logger.info('browser runtime never used this session — skipping quit-time stop');
     return;

--- a/apps/desktop/src/main/mcp-integrations/browser.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser.ts
@@ -19,7 +19,7 @@ import { createLogger } from '../logger.js';
 import { extractBrowserAvailability, type BrowserAvailability } from './browser-availability.js';
 import { loadUserBrowserRecipes, type UserRecipesResult } from '../browser-recipes/loader.js';
 import { writeUserRecipe, type WriteUserRecipeResult } from '../browser-recipes/writer.js';
-import { stopRuntimeForQuit } from './browser-dispose.js';
+import { stopRuntimeForQuitIfUsed, trackBrowserRuntimeUsage } from './browser-dispose.js';
 import {
   BackendRouter,
   ExternalChromeBackend,
@@ -159,21 +159,26 @@ healLegacyManagedProfileDir();
 // Single shared runtime for the desktop process. Boots with the managed profile
 // (electron-free, safe at module-eval); logs route into the unified logger.
 //
-// `vendoredRuntime` is the raw upstream object. We never hand it out directly —
-// it sits behind the `ExternalChromeBackend` wrapper, which itself sits behind
-// the `BackendRouter`. The router is what callers (@cindy/mcps via
-// `getBrowserMcpDeps`, host helpers below) receive, so swapping the active
-// backend in Phase 5 is a single `router.setBackend()` call away.
-const vendoredRuntime: BrowserControlRuntime = createBrowserControlRuntime({
-  config: buildManagedConfig(),
-  logSink: (level, scope, args) => {
-    // Bind to `logger`: the unified logger's methods rely on `this`, and calling
-    // a detached `logger[level]` reference would lose it (undefined in strict
-    // mode) and silently break the browser runtime's log channel.
-    const fn = (logger[level] ?? logger.info).bind(logger);
-    fn(`[${scope}]`, ...args);
-  },
-});
+// `vendoredRuntime` is the raw upstream object behind a thin usage-tracking
+// wrapper (see `trackBrowserRuntimeUsage`): every consumer in this module —
+// the `ExternalChromeBackend` (behind the `BackendRouter`, which is what
+// @cindy/mcps via `getBrowserMcpDeps` and host helpers below receive), the
+// availability probe and the login helper — calls through the wrapper, so
+// `disposeBrowserRuntime` can tell whether the runtime saw ANY traffic this
+// session. We never hand the raw object out; swapping the active backend in
+// Phase 5 is a single `router.setBackend()` call away.
+const vendoredRuntime = trackBrowserRuntimeUsage(
+  createBrowserControlRuntime({
+    config: buildManagedConfig(),
+    logSink: (level, scope, args) => {
+      // Bind to `logger`: the unified logger's methods rely on `this`, and calling
+      // a detached `logger[level]` reference would lose it (undefined in strict
+      // mode) and silently break the browser runtime's log channel.
+      const fn = (logger[level] ?? logger.info).bind(logger);
+      fn(`[${scope}]`, ...args);
+    },
+  }),
+);
 
 const externalBackend = new ExternalChromeBackend(vendoredRuntime, logger);
 
@@ -452,8 +457,7 @@ export async function openBrowserForLogin(): Promise<void> {
  * spawned process owned by the vendored runtime; nothing else sends `stop`, so
  * without this the headed Chrome + its locked user-data-dir survive app
  * quit / crash / dev-reload, and the next launch has to recover a stale
- * SingletonLock. Delegates to the active backend's `dispose` via the router —
- * for the external backend that is the electron-free `stopRuntimeForQuit`
+ * SingletonLock. Goes through the electron-free `stopRuntimeForQuitIfUsed`
  * (which swallows errors — see browser-dispose.ts).
  *
  * NOTE (Windows): the vendored stop sends SIGTERM→SIGKILL to the launched Chrome
@@ -473,8 +477,11 @@ export function disposeBrowserRuntime(): Promise<void> {
   // doesn't know about the swap and Phase 5 swap-time dispose already ran;
   // a stale-lock recovery on next launch is the symptom).
   //
-  // `stopRuntimeForQuit` is idempotent — if Chrome never started this turn
-  // it's a no-op; if it's running it stops cleanly. Safe to call regardless
-  // of which backend is currently active.
-  return stopRuntimeForQuit(vendoredRuntime, logger);
+  // Short-circuit via the usage tracker: the vendored dispatch bridge boots
+  // the browser control service (dynamic playwright import included) before
+  // routing ANY action, `stop` included — so on a session that never touched
+  // the browser runtime, an unconditional stop would START services during
+  // quit, which is an exit-hang amplifier. If the runtime WAS used, `stop` is
+  // idempotent and safe regardless of which backend is currently active.
+  return stopRuntimeForQuitIfUsed(vendoredRuntime, logger);
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 desktop 退出流程可能永久挂死的问题。生产事故现场（2026-07-26，personal client）：`before-quit` → `beginShutdown timeoutMs=6000` → `runQuitDisposers completed` 之后进程再无任何动作，PID 存活、空转烧 CPU，且仍持有 device-link 设备身份，导致手机端所有请求黑洞（该放大链的手机侧修复在配套 PR）。

根因与修复分三层：

1. **外部硬杀 watchdog（核心）**。此前退出路径唯一的「超时」只是 Phase 2 async disposers 的 `Promise.race`，超时仅打 warn、从不强杀进程；而 `app.exit()` 本身可能在 native teardown 挂死 —— 仓库已有实证（`updateScriptMacOS.ts` 注释，2026-07-06 观测：exit 已打日志但 PID 存活 32h，彼时 JS 事件循环已死、进程无法自救），更新链路为此专门用外部 shell `kill -9` 兜底，但常规退出路径没有等价物。现在 `beginShutdown` 起点幂等布防一个 detached 外部杀手进程（POSIX：`sh -c 'sleep 20; kill -9 <pid>'`；Windows：`cmd /c ping -n 21 … & taskkill /f /pid <pid>`），宽限期 20 秒后补刀。它是唯一能同时覆盖三类挂死形态的手段：sync disposer 阻塞事件循环（JS timer 不会触发）、post-async 无界 await、`app.exit` native teardown 挂死（JS 已死）。正常退出时进程早已消失，补刀落空无害；PID 复用窗口取舍沿用更新脚本先例，见代码注释。
2. **Phase 3 纳入超时预算**。post-async disposer 此前是无界 `await`，单个挂死即可让 `runQuitDisposers completed` 永远打不出来。现逐个用与 Phase 2 相同的 `timeoutMs` 做 race，超时打 warn 继续。
3. **退出期不再误启动 browser control 服务**。vendored dispatch 桥在路由任何 action（含 `stop`）前都会无条件先启动 browser control 服务（含动态 import playwright）—— 从未用过浏览器的会话，退出路径反而会新建服务，是 exit-hang 放大器（事故日志中 shutdown 期间那条「Browser control service ready」即此）。给 vendored runtime 加用量追踪包装（`trackBrowserRuntimeUsage`，模块私有 const，所有消费方均经包装的 `call`），`disposeBrowserRuntime` 改走 `stopRuntimeForQuitIfUsed`：零流量会话直接短路，用过则照常 stop。不改 `_generated/**`。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（生产事故直接修复；事故还牵出两个独立问题——「DB gate 失败的实例不写日志且继续持有 device-link 身份当黑洞」与「mobile 对失联设备无熔断」，后者在配套 PR 处理，前者建议另立 issue）
- 本 PR 包含：`lifecycle.ts` 的外部硬杀 watchdog 与 post-async 超时预算；`browser.ts`/`browser-dispose.ts` 的退出期零流量短路；对应单测
- 明确不包含：mobile 端熔断（配套 PR）；被控端 `runInvoke` 无超时问题；`ExternalChromeBackend.dispose`（Phase 5 backend 切换路径，非退出路径）维持原行为
- 用户可见变化：退出/重启不再可能无限挂死（最坏 20 秒被强杀）；从未用过浏览器的会话退出更快更干净
- 是否存在 breaking change：无

### 远程/手机/SSH 三形态结论

不涉及：本 PR 只改 desktop main 进程自身的退出编排与本机子进程管理，不触 workdir 文件/agent 数据（SSH 形态无关），无新增/修改 IPC channel 或推送事件（无 allowlist 变更），手机版无对应入口。

### UI 变化

不涉及（无任何 UI/文案改动）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/lifecycle.test.ts \
  src/main/mcp-integrations/__tests__/browser-dispose.test.ts
结果：Test Files 2 passed (2)，Tests 19 passed (19)（新增 9 例）

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit（仓库根全量门禁）
结果：GATE_EXIT=0，全绿
```

新增用例：post-async 超时后续 disposer 仍执行；watchdog 双平台（darwin/win32）spawn 参数形态、detached/stdio 选项与 `unref`；幂等（重复布防只 spawn 一次）；spawn 抛错不外传；browser 零流量短路与有流量照常 stop。测试文件顶部 `vi.mock('node:child_process')`，防止既有用例触发 `beginShutdown` 时真的 spawn `kill -9 <vitest pid>` 误杀测试进程。

### 手工验证

不涉及实机 UI。挂死场景（native teardown 卡死）无法在本机稳定复现，watchdog 行为由注入 spawn 的单测覆盖；真实布防日志（`arming shutdown hard-kill watchdog`）可在下次任意退出的 main log 中确认。

### 未执行的验证

- Windows 实机未验证（无 Windows 环境）：`ping -n` 延时 + `taskkill /f` 是 cmd 标准做法，参数形态有单测锁定，但实机行为标注待验证。
- 20 秒宽限内 PID 复用导致误杀的概率窗口未做额外防护（沿用 `updateScriptMacOS` 先例，见代码注释）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：进程强杀语义

### 影响与回滚

- 影响范围：所有退出路径（before-quit / SIGINT / SIGTERM / uncaughtException / render-process-gone）都会布防 watchdog。行为变化：任何 shutdown 超过 20 秒都会被 SIGKILL —— 若存在「合法超过 20 秒的退出清理」会被截断；现状 disposer 总预算 6 秒 + flush 为毫秒级，20 秒为 3 倍余量。强杀时 Chromium 的 graceful storage close 被跳过，但该路径本就 `app.exit()` 强退（文件头注释既有约定），且 `flushStorageData` 在 post-async 已先行落盘，无新增数据风险。
- 跨平台：macOS/Linux 与 Windows 分别实现（见上）；Windows 实机待验证。
- 回滚 / 降级方式：`git revert` 本 commit 即可，无状态残留、无数据格式变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（设计取舍全部落在代码注释与本描述）
- [x] 已确认测试结果或说明未执行原因
