### PR TITLE
test(desktop): 修正 deviceId 测试在 Windows 上的 PATH 分隔符断言

### DIFF
--- a/apps/desktop/src/main/__tests__/deviceId.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceId.test.ts
@@ -47,9 +47,15 @@ describe('ensureSystemBinPathForMachineId', () => {
   it('追加而非前置:不覆盖已有的用户 PATH 项', () => {
     process.env.PATH = '/opt/homebrew/bin:/usr/bin:/bin';
     ensureSystemBinPathForMachineId();
-    const dirs = (process.env.PATH ?? '').split(path.delimiter);
-    expect(dirs[0]).toBe('/opt/homebrew/bin'); // 原有优先项仍在最前
-    if (PATCHES_PATH) expect(dirs).toContain('/usr/sbin');
+    if (PATCHES_PATH) {
+      // 用例的 PATH 是 Unix 写法(':' 分隔),只有在 path.delimiter 同为 ':' 的
+      // 平台上拆分才有意义;Windows 上 delimiter 是 ';',拆出来仍是整条字符串。
+      const dirs = (process.env.PATH ?? '').split(path.delimiter);
+      expect(dirs[0]).toBe('/opt/homebrew/bin'); // 原有优先项仍在最前
+      expect(dirs).toContain('/usr/sbin');
+    } else {
+      expect(process.env.PATH).toBe('/opt/homebrew/bin:/usr/bin:/bin'); // Windows: 不动 PATH
+    }
   });
 
   it('保留原 PATH 的空段(Unix 下代表 CWD),不改语义', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

`apps/desktop/src/main/__tests__/deviceId.test.ts` 的用例「追加而非前置:不覆盖已有的用户 PATH 项」在 Windows 上必然失败：

```
AssertionError: expected '/opt/homebrew/bin:/usr/bin:/bin' to be '/opt/homebrew/bin'

Expected: "/opt/homebrew/bin"
Received: "/opt/homebrew/bin:/usr/bin:/bin"
```

用例用 **Unix 风格的 `:`** 构造 PATH，却用 **`path.delimiter`** 去拆分 —— 后者在 Windows 上是 `;`，`split` 拆不开这条字符串，`dirs` 只有一个元素（整条 PATH），于是 `dirs[0]` 拿到的是整串而非首项。

被测函数 `ensureSystemBinPathForMachineId()` 在 Windows 上是 no-op（`deviceId.ts` 首行即 `if (process.platform !== 'darwin' && process.platform !== 'linux') return;`，注册表取指纹不依赖 PATH），所以**这是测试自身的缺陷，不是产品代码问题**。

该文件头部已声明约定：

> 每个用例在所有平台都断言:darwin/linux 断言补齐,其它平台(Windows)断言 no-op,避免非目标平台上整套用例空跑通过。

同文件其余 4 个用例都带了 `if (PATCHES_PATH)` 分支，唯独这条漏了 —— `expect(dirs[0])` 是无条件断言，而它依赖的 `dirs` 在 Windows 上根本没被正确拆分。本次按同一模式补齐：

- **darwin / linux**：断言原有优先项仍在最前，且已补上 `/usr/sbin`（原用例对后者只做了 `if (PATCHES_PATH)` 的单行断言，语义不变）
- **Windows**：断言 PATH 未被改动，与同文件用例 1、4、5 的 `else` 分支同款

同时补了一行注释说明为什么拆分必须收在平台分支内，避免以后再被改回去。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #707
- 本 PR 包含：`apps/desktop/src/main/__tests__/deviceId.test.ts` 中单个用例的平台分支补齐
- 明确不包含：
  - 不改动产品代码（`deviceId.ts` 未触碰）
  - 不改动同文件其它 4 个用例
  - #706（Windows CRLF 导致 GLOSSARY.md 门禁必红）是另一个独立的 Windows 门禁问题，不在本 PR 修
- 用户可见变化：无（纯测试改动）
- 是否存在 breaking change：无

### UI 变化

不涉及

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/deviceId.test.ts
结果：Test Files 1 passed (1) / Tests 5 passed (5)      ← 修复前该文件 1 failed

pnpm --filter desktop run --if-present typecheck
结果：通过（exit 0）
      注：本次改动位于 src/** 下，确实在 tsconfig.json 的 include 覆盖范围内。

pnpm test:unit
结果：全部 workspace PASS，退出码 0（apps/desktop unit 156.3s PASS）
      修复前同一命令在本机为 1 failed / 1226 passed，唯一失败项即本 PR 修复的用例。
```

### 手工验证

不涉及：纯测试改动，无运行时行为变化。

### 未执行的验证

- **macOS / Linux 上的实际执行**：本机为 Windows，未在 darwin/linux 实跑。该分支下的断言相较原用例只增强不削弱（新增 `expect(dirs).toContain('/usr/sbin')` 由原来的单行 `if (PATCHES_PATH)` 改写而来，语义一致），且 `PATCHES_PATH` 为真时走的代码路径与原用例相同，预期不受影响；CI 会在 Linux 上覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅测试代码。产品代码未改动，不影响任何运行时行为、打包产物或用户数据。已分别考虑 macOS / Windows：darwin/linux 走 `PATCHES_PATH` 为真的分支（断言补齐行为，与原用例同路径且更严格），Windows 走 `else` 分支（断言 no-op，与被测函数的 Windows 早退语义一致）。
- 回滚 / 降级方式：`git revert` 即可，无任何状态或依赖。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动含注释说明平台分支的原因）
- [x] 已确认测试结果或说明未执行原因
