### PR TITLE
feat(desktop): SSH 远程主机 Agent 流量走本地 Proxy 隧道 + 修复远端 codex 永卡 generating (#677)

### DIFF
--- a/apps/desktop/src/main/maker-host/codex-remote-transport.ts
+++ b/apps/desktop/src/main/maker-host/codex-remote-transport.ts
@@ -33,6 +33,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import type { RemoteHost, ExecStreamHandle } from '@cindy/maker-remote-ssh';
+import { REMOTE_INSTALL_ROOT } from '@cindy/maker-remote-ssh';
 
 // ws lib doesn't export Receiver / Sender from its main entry — they live as
 // internal classes under ws/lib/. The package's `exports` field also
@@ -133,6 +134,13 @@ export interface SshDaemonTransportOptions {
    * up and tearing the transport down. Default 15 s.
    */
   handshakeTimeoutMs?: number;
+  /**
+   * daemon 探活前跑的钩子 (async): agent-proxy 的 env marker 对账走这里 —
+   * marker 漂移时钩子会重写 marker 并 pkill 旧 daemon, 随后的 version 探活
+   * 失败 → bootstrap 新 daemon 吃到新 env。钩子失败会中止 transport 建立,
+   * 错误经 fireClose 上浮 (比"隧道没建好就让 daemon 裸连"更诚实)。
+   */
+  beforeDaemonProbe?: () => Promise<void>;
 }
 
 /** Standard WebSocket GUID — appended to client key for Accept hash check. */
@@ -166,7 +174,7 @@ type State = 'connecting' | 'open' | 'closed';
  */
 export function createSshDaemonTransport(opts: SshDaemonTransportOptions): Transport {
   const logger = opts.logger.child('codex-ssh-daemon-transport');
-  const installRoot = opts.installRoot ?? '$HOME/.xdt-server/v1';
+  const installRoot = opts.installRoot ?? REMOTE_INSTALL_ROOT;
   const handshakeTimeoutMs = opts.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
   const autoStartDaemon = opts.autoStartDaemon !== false;
 
@@ -187,6 +195,11 @@ export function createSshDaemonTransport(opts: SshDaemonTransportOptions): Trans
   //
   // The `_` is $0 (script name placeholder); positional $1+ are the codex
   // subcommand/flags forwarded to `exec "$@"` (shellQuote-safe pass-through).
+  //
+  // agent-proxy.env: 「Agent 流量走本地 Proxy」隧道开启时由 agent-proxy 的
+  // reconcile 写入 (export HTTPS_PROXY=http://127.0.0.1:<forwardPort> 等)。
+  // daemon bootstrap / 一次性命令统一 source — codex 的后端流量因此经隧道
+  // 流回用户本地 Proxy。文件不存在 = 功能未开启, 直连。
   const codexCmd = (subArgs: string[]): string => {
     // installRoot is interpolated UNQUOTED so the default `$HOME/.xdt-server/v1`
     // gets shell-expanded remotely. We don't know remote $HOME from the client
@@ -201,6 +214,7 @@ if [ ! -x "$CODEX" ]; then
   printf 'codex not installed at %s — run P1 install flow first\\n' "$CODEX" >&2
   exit 127
 fi
+if [ -f "$INSTALL_ROOT/agent-proxy.env" ]; then . "$INSTALL_ROOT/agent-proxy.env"; fi
 exec "$CODEX" "$@"
 `.trim();
     const quotedArgs = subArgs.map(shellQuote).join(' ');
@@ -359,6 +373,11 @@ exec "$CODEX" "$@"
 
   /** Async kickoff: probe daemon, optionally start it, open proxy, do handshake. */
   const bootstrap = async (): Promise<void> => {
+    // 0) agent-proxy 对账钩子等 (隧道 + env marker 就绪后再碰 daemon)。
+    if (opts.beforeDaemonProbe) {
+      await opts.beforeDaemonProbe();
+    }
+
     // 1) Probe daemon. Output is one JSON object on stdout.
     let socketPath = opts.socketPath ?? '';
     if (!socketPath) {

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -61,6 +61,10 @@ import { resolveSessionCcDebugFile } from '../logger.js';
 import { resetProviderModelAutoRefreshCooldowns } from './provider-model-auto-refresh.js';
 import { createSshDaemonTransport } from './codex-remote-transport.js';
 import { getRemoteSshPool } from '../remote-ssh/index.js';
+import {
+  getRemoteAgentProxyEnv,
+  reconcileCodexAgentProxyEnv,
+} from '../remote-ssh/agent-proxy.js';
 import { openCcManagerSession } from './cc-manager-client.js';
 import { getRemoteClaudeBinaryPath } from '../remote-ssh/cc-manager-install.js';
 import { createReadImageHook } from './claude-hooks/read-image-hook.js';
@@ -429,6 +433,20 @@ export function getMaker(): Maker {
         if (host?.getStatus() !== 'ready') {
           throw new Error(`remote ssh host not ready: ${remoteHostId}`);
         }
+        // 「Agent 流量走本地 Proxy」: pref 开启时确保 SSH 反向隧道就绪, 把代理
+        // env 合入 startParams.env — cc-mgr daemon 按 session spawn SDK, 每次
+        // 会话都吃到当前配置, 无需像 codex daemon 那样重启。隧道 arm 失败
+        // (sshd 拒 remote forwarding 等) 直接抛错, 不静默回落直连。
+        const proxyEnv = await getRemoteAgentProxyEnv(host);
+        const startParamsWithProxy = proxyEnv
+          ? {
+              ...(startParams as Record<string, unknown>),
+              env: {
+                ...((startParams as { env?: Record<string, string> }).env ?? {}),
+                ...proxyEnv,
+              },
+            }
+          : startParams;
         // SDK can't self-locate its native CLI binary on remote (bundled-into-cc-mgr
         // optional-dep resolver is frozen to desktop build platform). Probe + cache
         // the path here and pass it down; cc-manager-client merges it into the SDK
@@ -437,7 +455,7 @@ export function getMaker(): Maker {
         const { remoteQuery, dispose, detach } = await openCcManagerSession({
           host,
           sessionId,
-          startParams: startParams as unknown as Parameters<typeof openCcManagerSession>[0]['startParams'],
+          startParams: startParamsWithProxy as unknown as Parameters<typeof openCcManagerSession>[0]['startParams'],
           claudeBinaryPath,
           onApprovalRequest: onApprovalRequest as Parameters<typeof openCcManagerSession>[0]['onApprovalRequest'],
         });
@@ -618,6 +636,12 @@ export function getMaker(): Maker {
         return createSshDaemonTransport({
           remoteHost,
           logger: desktopMakerLogger,
+          // 「Agent 流量走本地 Proxy」: pref 开启时先建 SSH 反向隧道 + 对账
+          // codex daemon 的 env marker (漂移 → 重写 + 重启 daemon), 然后才让
+          // transport 探活/拉起 daemon。pref 关闭时 reconcile 是幂等 no-op。
+          beforeDaemonProbe: async () => {
+            await reconcileCodexAgentProxyEnv(remoteHost);
+          },
         });
       },
     });

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -640,7 +640,16 @@ export function getMaker(): Maker {
           // codex daemon 的 env marker (漂移 → 重写 + 重启 daemon), 然后才让
           // transport 探活/拉起 daemon。pref 关闭时 reconcile 是幂等 no-op。
           beforeDaemonProbe: async () => {
-            await reconcileCodexAgentProxyEnv(remoteHost);
+            // markerChanged && !daemonRestarted = 旧 daemon 活着跑旧 env —
+            // 继续 probe 会 attach 到 stale daemon, UI 报 tunnel active 而
+            // codex 流量走旧路由 (codex R10 P1): 按 bootstrap 失败抛出, 让
+            // session start 显式报错, 而不是静默复用。
+            const reconciled = await reconcileCodexAgentProxyEnv(remoteHost);
+            if (reconciled.markerChanged && !reconciled.daemonRestarted) {
+              throw new Error(
+                'codex daemon survived pkill after agent-proxy env change; refusing to attach the stale daemon (retry or restart the host)',
+              );
+            }
           },
         });
       },

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -162,7 +162,7 @@ describe('ensureAgentProxyTunnel', () => {
     setSshHostAgentProxy('test-host', PREF);
     const { host, state } = makeFakeHost();
     const result = await ensureAgentProxyTunnel(host);
-    expect(result).toEqual({ remotePort: 17893 });
+    expect(result).toEqual({ remotePort: 17893, staleForwards: [] });
     expect(state.forwards).toEqual([{ localHost: '127.0.0.1', localPort: 7890, remotePort: 17893 }]);
   });
 
@@ -176,8 +176,10 @@ describe('ensureAgentProxyTunnel', () => {
 
     setSshHostAgentProxy('test-host', { ...PREF, localPort: 1080 });
     const result = await ensureAgentProxyTunnel(host);
-    expect(result).toEqual({ remotePort: 17893 });
-    // 旧 7890 已拆, 只剩新 1080。
+    expect(result).toMatchObject({ remotePort: 17893 });
+    expect(result?.staleForwards).toHaveLength(1);
+    expect(result?.staleForwards[0]).toMatchObject({ localHost: '127.0.0.1', localPort: 7890 });
+    // 旧 7890 已拆 (默认 closeStale 立即拆), 只剩新 1080。
     expect(state.forwards).toEqual([{ localHost: '127.0.0.1', localPort: 1080, remotePort: 17893 }]);
   });
 });
@@ -285,6 +287,68 @@ describe('reconcileCodexAgentProxyEnv', () => {
     // 两次 reconcile 各发了一次 pkill: 第一次失败 (mock 拦截), 第二次重试成功。
     expect(failedPkillCount).toBe(1);
     expect(state.pkillCount).toBe(1);
+  });
+
+  it('closes the old forward only after the daemon restart succeeds during a rebind (codex R17 P2)', async () => {
+    // rebind (7890 → 1080): reconcile 先建后拆 — daemon 重启成功后才拆旧。
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost({ marker: null });
+    // 端口递增分配, 让 rebind 后 desired marker 与旧 marker 不同 (fake 默认
+    // 恒 17893 时 marker 内容不变会走 fast path, 测不到拆旧时机)。
+    let nextPort = 17893;
+    host.ensureRemoteForward = async (spec: { localHost: string; localPort: number }) => {
+      const remotePort = nextPort;
+      nextPort += 1;
+      state.forwards.push({ ...spec, remotePort });
+      return { remotePort, close: async () => {} };
+    };
+    // 先 enable 成功 (旧目标 7890: forward + marker 都就位)。
+    await reconcileCodexAgentProxyEnv(host);
+    expect(state.forwards).toEqual([{ localHost: '127.0.0.1', localPort: 7890, remotePort: 17893 }]);
+
+    setSshHostAgentProxy('test-host', { ...PREF, localPort: 1080 });
+    const result = await reconcileCodexAgentProxyEnv(host);
+    expect(result).toEqual({ markerChanged: true, daemonRestarted: true });
+    // daemon 重启成功 → 旧 7890 已拆, 只剩新 1080。
+    expect(state.forwards).toEqual([{ localHost: '127.0.0.1', localPort: 1080, remotePort: 17894 }]);
+  });
+
+  it('keeps the old forward when the daemon survives pkill during a rebind (codex R17 P2)', async () => {
+    // rebind + pkill 失败: marker 回滚 (R10), 旧 7890 forward 保留 (存活
+    // daemon 流量不断), 新 1080 forward 闲置待下轮 reconcile 复用。
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost({ marker: null });
+    let nextPort = 17893;
+    host.ensureRemoteForward = async (spec: { localHost: string; localPort: number }) => {
+      const remotePort = nextPort;
+      nextPort += 1;
+      state.forwards.push({ ...spec, remotePort });
+      return { remotePort, close: async () => {} };
+    };
+    await reconcileCodexAgentProxyEnv(host);
+    const oldMarker = state.marker;
+
+    setSshHostAgentProxy('test-host', { ...PREF, localPort: 1080 });
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('pkill')) {
+        return {
+          stdout: '',
+          stderr: 'daemon still alive after TERM(5s)+KILL(2s)',
+          exitCode: 3,
+          signal: null,
+        };
+      }
+      return baseExec(cmd, execOpts);
+    };
+    const result = await reconcileCodexAgentProxyEnv(host);
+    expect(result).toEqual({ markerChanged: true, daemonRestarted: false });
+    // marker 回滚到旧值; 旧 7890 保留; 新 1080 闲置 (不拆任何 forward)。
+    expect(state.marker).toBe(oldMarker);
+    expect(state.forwards).toEqual([
+      { localHost: '127.0.0.1', localPort: 7890, remotePort: 17893 },
+      { localHost: '127.0.0.1', localPort: 1080, remotePort: 17894 },
+    ]);
   });
 });
 

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -98,6 +98,11 @@ function makeFakeHost(opts: { marker?: string | null; remotePort?: number } = {}
     async closeAllRemoteForwards() {
       state.forwards = [];
     },
+    async closeRemoteForward(localHost: string, localPort: number) {
+      state.forwards = state.forwards.filter(
+        (f) => !(f.localHost === localHost && f.localPort === localPort),
+      );
+    },
     listRemoteForwards() {
       return state.forwards.map((f) => ({ ...f, armed: true }));
     },
@@ -156,6 +161,21 @@ describe('ensureAgentProxyTunnel', () => {
     const result = await ensureAgentProxyTunnel(host);
     expect(result).toEqual({ remotePort: 17893 });
     expect(state.forwards).toEqual([{ localHost: '127.0.0.1', localPort: 7890, remotePort: 17893 }]);
+  });
+
+  it('closes stale forwards whose target no longer matches the pref (review R5)', async () => {
+    // pref 目标被编辑 (7890 → 1080): 旧目标的 forward 必须拆掉, 否则残留并
+    // 随重连 re-arm, 远端多暴露一个隧道口。
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost();
+    await ensureAgentProxyTunnel(host);
+    expect(state.forwards).toHaveLength(1);
+
+    setSshHostAgentProxy('test-host', { ...PREF, localPort: 1080 });
+    const result = await ensureAgentProxyTunnel(host);
+    expect(result).toEqual({ remotePort: 17893 });
+    // 旧 7890 已拆, 只剩新 1080。
+    expect(state.forwards).toEqual([{ localHost: '127.0.0.1', localPort: 1080, remotePort: 17893 }]);
   });
 });
 

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -47,6 +47,7 @@ import {
   buildAgentProxyEnvUppercase,
   buildAgentProxyMarkerContent,
   ensureAgentProxyTunnel,
+  killRemoteCodexDaemon,
   reconcileCodexAgentProxyEnv,
 } from '../agent-proxy';
 import {
@@ -214,6 +215,38 @@ describe('reconcileCodexAgentProxyEnv', () => {
     const result = await reconcileCodexAgentProxyEnv(host);
     expect(result).toEqual({ markerChanged: false, daemonRestarted: false });
     expect(state.pkillCount).toBe(0);
+  });
+});
+
+describe('killRemoteCodexDaemon', () => {
+  it('waits for the daemon to actually exit after TERM before returning (greptile R6 P2)', async () => {
+    // pkill 只保证信号送达 — 脚本必须 TERM 后轮询等进程消失, 没死透再 KILL,
+    // 防旧 daemon 在 dying 窗口里响应探活被复用 (旧 env, marker 变更静默落空)。
+    const { host, state } = makeFakeHost();
+    const result = await killRemoteCodexDaemon(host);
+    expect(result).toEqual({ ok: true });
+    expect(state.pkillCount).toBe(1);
+    const script = state.execCalls.find((c) => c.cmd.includes('pkill'))?.cmd ?? '';
+    expect(script).toContain('pgrep');
+    expect(script).toContain('pkill -9');
+  });
+
+  it('reports pkill_failed when the daemon survives TERM+KILL', async () => {
+    const { host } = makeFakeHost();
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('pkill')) {
+        return {
+          stdout: '',
+          stderr: 'daemon still alive after TERM(5s)+KILL(2s)',
+          exitCode: 3,
+          signal: null,
+        };
+      }
+      return baseExec(cmd, execOpts);
+    };
+    const result = await killRemoteCodexDaemon(host);
+    expect(result).toMatchObject({ ok: false, reason: 'pkill_failed' });
   });
 });
 

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -216,6 +216,36 @@ describe('reconcileCodexAgentProxyEnv', () => {
     expect(result).toEqual({ markerChanged: false, daemonRestarted: false });
     expect(state.pkillCount).toBe(0);
   });
+
+  it('fails closed when the marker write fails: throws and does not kill the daemon (codex R7 P1)', async () => {
+    // exec 对非零退出码 resolve 不 throw — 写失败必须显式挡, 否则 reconcile
+    // 继续 pkill, daemon 起来没 marker 直连, fail-closed 破。
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost({ marker: null });
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('cat > "') && cmd.includes('agent-proxy.env')) {
+        return { stdout: '', stderr: 'Permission denied', exitCode: 1, signal: null };
+      }
+      return baseExec(cmd, execOpts);
+    };
+    await expect(reconcileCodexAgentProxyEnv(host)).rejects.toThrow(/write agent-proxy marker failed/);
+    expect(state.pkillCount).toBe(0);
+  });
+
+  it('fails closed when the marker delete fails: throws and does not kill the daemon (codex R7 P1)', async () => {
+    setSshHostAgentProxy('test-host', null);
+    const { host, state } = makeFakeHost({ marker: "export HTTPS_PROXY='http://127.0.0.1:17893'" });
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('rm -f "') && cmd.includes('agent-proxy.env')) {
+        return { stdout: '', stderr: 'Read-only file system', exitCode: 1, signal: null };
+      }
+      return baseExec(cmd, execOpts);
+    };
+    await expect(reconcileCodexAgentProxyEnv(host)).rejects.toThrow(/delete agent-proxy marker failed/);
+    expect(state.pkillCount).toBe(0);
+  });
 });
 
 describe('killRemoteCodexDaemon', () => {

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -248,6 +248,44 @@ describe('reconcileCodexAgentProxyEnv', () => {
     await expect(reconcileCodexAgentProxyEnv(host)).rejects.toThrow(/delete agent-proxy marker failed/);
     expect(state.pkillCount).toBe(0);
   });
+
+  it('rolls the marker back when pkill fails so the next reconcile retries the kill (codex R10 P2)', async () => {
+    // disable 场景 (desired=null, current=旧 proxy marker): pkill 失败时若让
+    // marker 停在 null, 下次 reconcile 命中 fast path (null===null) 永不重试
+    // kill — 存活 daemon 握着指向已拆隧道的 proxy env 一直跑到手动重启。
+    setSshHostAgentProxy('test-host', null);
+    const staleMarker = "export HTTPS_PROXY='http://127.0.0.1:17893'";
+    const { host, state } = makeFakeHost({ marker: staleMarker });
+    let pkillShouldFail = true;
+    let failedPkillCount = 0;
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('pkill') && pkillShouldFail) {
+        failedPkillCount += 1;
+        return {
+          stdout: '',
+          stderr: 'daemon still alive after TERM(5s)+KILL(2s)',
+          exitCode: 3,
+          signal: null,
+        };
+      }
+      return baseExec(cmd, execOpts);
+    };
+
+    const first = await reconcileCodexAgentProxyEnv(host);
+    expect(first).toEqual({ markerChanged: true, daemonRestarted: false });
+    // marker 已回滚到原值 (与存活 daemon 的 env 一致)。
+    expect(state.marker).toBe(staleMarker);
+
+    // 下次 reconcile 仍 drift → 重写 + 重试 kill (自愈); pkill 恢复后清干净。
+    pkillShouldFail = false;
+    const second = await reconcileCodexAgentProxyEnv(host);
+    expect(second).toEqual({ markerChanged: true, daemonRestarted: true });
+    expect(state.marker).toBeNull();
+    // 两次 reconcile 各发了一次 pkill: 第一次失败 (mock 拦截), 第二次重试成功。
+    expect(failedPkillCount).toBe(1);
+    expect(state.pkillCount).toBe(1);
+  });
 });
 
 describe('killRemoteCodexDaemon', () => {
@@ -319,7 +357,9 @@ describe('applyAgentProxyForHost disable path', () => {
     const { host, state } = makeFakeHost({ marker: null });
 
     let killStarted = false;
-    let releaseKill: (() => void) | null = null;
+    // 对象持有 release: TS 不对属性做 closure 收窄 (let 声明会被 narrow 成
+    // undefined → CI typecheck TS2349 "Type 'never' has no call signatures")。
+    const killGate: { release?: () => void } = {};
     const baseExec = host.exec.bind(host);
     host.exec = async (cmd: string, execOpts?: { input?: string }) => {
       if (cmd.includes('pkill')) {
@@ -327,7 +367,7 @@ describe('applyAgentProxyForHost disable path', () => {
         // 不能拿 execCalls 当等待信号)。
         killStarted = true;
         await new Promise<void>((resolve) => {
-          releaseKill = resolve;
+          killGate.release = resolve;
         });
       }
       return baseExec(cmd, execOpts);
@@ -352,7 +392,7 @@ describe('applyAgentProxyForHost disable path', () => {
     await Promise.resolve();
     expect(state.execCalls.length).toBe(execCountWhileFirstBlocked);
 
-    releaseKill?.();
+    killGate.release?.();
     const [r1, r2] = await Promise.all([first, second]);
     expect(r1.markerChanged).toBe(true);
     expect(r1.daemonRestarted).toBe(true);
@@ -360,6 +400,34 @@ describe('applyAgentProxyForHost disable path', () => {
     expect(r2).toEqual({ markerChanged: false, daemonRestarted: false });
     expect(order).toEqual(['first-done', 'second-done']);
     expect(state.pkillCount).toBe(1);
+  });
+});
+
+describe('applyAgentProxyForHost enable path', () => {
+  it('reports apply error and rolls the marker back when the daemon survives pkill (codex R10 P1)', async () => {
+    // marker 漂移 (null → 新 proxy marker) 但 pkill 失败: 旧 daemon 还活着跑
+    // 旧 env — 不得按成功落 active, 卡片显示错误; marker 回滚到 null 供下次
+    // reconcile 重试。
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost({ marker: null });
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('pkill')) {
+        return {
+          stdout: '',
+          stderr: 'daemon still alive after TERM(5s)+KILL(2s)',
+          exitCode: 3,
+          signal: null,
+        };
+      }
+      return baseExec(cmd, execOpts);
+    };
+    await applyAgentProxyForHost(host);
+    const tunnelState = getAgentProxyTunnelState('test-host');
+    expect(tunnelState?.active).toBe(false);
+    expect(tunnelState?.lastError).toMatch(/survived pkill/);
+    // 原 marker 为 null → 回滚即删除。
+    expect(state.marker).toBeNull();
   });
 });
 

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -51,7 +51,9 @@ import {
 } from '../agent-proxy';
 import {
   getSshHostAgentProxy,
+  getSshHostAutoConnect,
   setSshHostAgentProxy,
+  setSshHostAutoConnect,
 } from '../ssh-host-prefs-store';
 
 interface ExecCall {
@@ -211,10 +213,22 @@ describe('ssh-host-prefs-store agentProxy', () => {
   });
 
   it('keeps autoConnect when writing agentProxy and vice versa', () => {
+    // 双向共存回归 (review: PR #715 五轮审核 P2 — 原测试只写了两次 agentProxy,
+    // 没真正交叉 autoConnect): prefs 是同一 JSON 文件里的 sibling 字段,
+    // 任一侧写入不得把另一侧冲掉。
+    setSshHostAutoConnect('h1', true);
     setSshHostAgentProxy('h1', PREF);
-    // 写 autoConnect 不应丢 agentProxy — 走公开 API 验证共存。
-    setSshHostAgentProxy('h1', PREF);
+    expect(getSshHostAutoConnect('h1')).toBe(true);
     expect(getSshHostAgentProxy('h1')).toEqual(PREF);
+    // 反向: 先写 agentProxy 再改 autoConnect, agentProxy 不丢。
+    setSshHostAutoConnect('h1', false);
+    expect(getSshHostAgentProxy('h1')).toEqual(PREF);
+    expect(getSshHostAutoConnect('h1')).toBe(false);
+    // 清 agentProxy 不影响 autoConnect。
+    setSshHostAutoConnect('h1', true);
+    setSshHostAgentProxy('h1', null);
+    expect(getSshHostAgentProxy('h1')).toBeNull();
+    expect(getSshHostAutoConnect('h1')).toBe(true);
   });
 
   it('rejects malformed prefs at write time', () => {

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -1,0 +1,228 @@
+/**
+ * agent-proxy 策略层单测。
+ *
+ * 覆盖:
+ *   - buildAgentProxyEnv / buildAgentProxyEnvUppercase / buildAgentProxyMarkerContent
+ *     的内容契约 (env 键集、URL 形态、NO_PROXY)
+ *   - reconcileCodexAgentProxyEnv 的对账状态机:
+ *     marker 一致 → 零副作用; 漂移 → 重写 + pkill; 关闭 → 删除 + pkill
+ *   - ensureAgentProxyTunnel 的 pref gate (关 → null, 开 → 建隧道)
+ *
+ * prefs store 依赖 electron app.getPath, 用 vi.mock 替换; RemoteHost 用
+ * 最小 fake (exec 脚本断言 + ensureRemoteForward stub)。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── electron mock: prefs store 落盘到内存 Map ────────────────────────────────
+let prefsFileContent: string | null = null;
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/cindy-test-userdata',
+  },
+}));
+
+// fs sync API 被 prefs store 直接用; 用内存实现替身。
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: () => prefsFileContent != null,
+      readFileSync: () => prefsFileContent ?? '',
+      writeFileSync: (_p: string, content: string) => {
+        prefsFileContent = content;
+      },
+      renameSync: () => {},
+      unlinkSync: () => {
+        prefsFileContent = null;
+      },
+    },
+  };
+});
+
+import {
+  buildAgentProxyEnv,
+  buildAgentProxyEnvUppercase,
+  buildAgentProxyMarkerContent,
+  ensureAgentProxyTunnel,
+  reconcileCodexAgentProxyEnv,
+} from '../agent-proxy';
+import {
+  getSshHostAgentProxy,
+  setSshHostAgentProxy,
+} from '../ssh-host-prefs-store';
+
+interface ExecCall {
+  cmd: string;
+  input?: string;
+}
+
+/** 最小 RemoteHost fake: 记录 exec, cat/rm marker + pkill 走脚本内容断言。 */
+function makeFakeHost(opts: { marker?: string | null; remotePort?: number } = {}) {
+  const state = {
+    marker: opts.marker ?? null,
+    execCalls: [] as ExecCall[],
+    pkillCount: 0,
+    forwards: [] as Array<{ localHost: string; localPort: number; remotePort: number }>,
+  };
+  const host = {
+    id: 'test-host',
+    async exec(cmd: string, execOpts?: { input?: string }) {
+      state.execCalls.push({ cmd, input: execOpts?.input });
+      if (cmd.includes('cat "') && cmd.includes('agent-proxy.env')) {
+        return { stdout: state.marker ?? '', stderr: '', exitCode: 0, signal: null };
+      }
+      if (cmd.includes('cat > "') && cmd.includes('agent-proxy.env')) {
+        state.marker = (execOpts?.input ?? '').trim();
+        return { stdout: '', stderr: '', exitCode: 0, signal: null };
+      }
+      if (cmd.includes('rm -f "') && cmd.includes('agent-proxy.env')) {
+        state.marker = null;
+        return { stdout: '', stderr: '', exitCode: 0, signal: null };
+      }
+      if (cmd.includes('pkill')) {
+        state.pkillCount += 1;
+        return { stdout: '', stderr: '', exitCode: 0, signal: null };
+      }
+      return { stdout: '', stderr: '', exitCode: 0, signal: null };
+    },
+    async ensureRemoteForward(spec: { localHost: string; localPort: number }) {
+      const remotePort = opts.remotePort ?? 17893;
+      state.forwards.push({ ...spec, remotePort });
+      return { remotePort, close: async () => {} };
+    },
+    async closeAllRemoteForwards() {
+      state.forwards = [];
+    },
+    listRemoteForwards() {
+      return state.forwards.map((f) => ({ ...f, armed: true }));
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { host: host as any, state };
+}
+
+const PREF = { enabled: true, localHost: '127.0.0.1', localPort: 7890 };
+
+beforeEach(() => {
+  prefsFileContent = null;
+});
+
+describe('buildAgentProxyEnv', () => {
+  it('builds dual-case proxy env pointing at the tunnel port', () => {
+    const env = buildAgentProxyEnv(17893);
+    expect(env.HTTPS_PROXY).toBe('http://127.0.0.1:17893');
+    expect(env.HTTP_PROXY).toBe('http://127.0.0.1:17893');
+    expect(env.https_proxy).toBe('http://127.0.0.1:17893');
+    expect(env.http_proxy).toBe('http://127.0.0.1:17893');
+    expect(env.NO_PROXY).toContain('localhost');
+    expect(env.no_proxy).toContain('127.0.0.1');
+  });
+
+  it('uppercase-only variant satisfies the env-block gatekeeper', () => {
+    const env = buildAgentProxyEnvUppercase(17893);
+    for (const key of Object.keys(env)) {
+      expect(key).toMatch(/^[A-Z_][A-Z0-9_]*$/);
+    }
+    expect(Object.keys(env)).toEqual(['HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY']);
+  });
+});
+
+describe('buildAgentProxyMarkerContent', () => {
+  it('is a sourceable shell snippet with the tunnel URL', () => {
+    const content = buildAgentProxyMarkerContent(18000);
+    expect(content).toContain("export HTTPS_PROXY='http://127.0.0.1:18000'");
+    expect(content).toContain("export https_proxy='http://127.0.0.1:18000'");
+    expect(content).toContain("export NO_PROXY='localhost,127.0.0.1,::1'");
+    expect(content.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('ensureAgentProxyTunnel', () => {
+  it('returns null when the pref is off', async () => {
+    const { host, state } = makeFakeHost();
+    const result = await ensureAgentProxyTunnel(host);
+    expect(result).toBeNull();
+    expect(state.forwards).toHaveLength(0);
+  });
+
+  it('opens the forward to the pref target when enabled', async () => {
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost();
+    const result = await ensureAgentProxyTunnel(host);
+    expect(result).toEqual({ remotePort: 17893 });
+    expect(state.forwards).toEqual([{ localHost: '127.0.0.1', localPort: 7890, remotePort: 17893 }]);
+  });
+});
+
+describe('reconcileCodexAgentProxyEnv', () => {
+  it('no-ops when the marker already matches the desired content', async () => {
+    setSshHostAgentProxy('test-host', PREF);
+    const desired = buildAgentProxyMarkerContent(17893).trim();
+    const { host, state } = makeFakeHost({ marker: desired });
+    const result = await reconcileCodexAgentProxyEnv(host);
+    expect(result).toEqual({ markerChanged: false, daemonRestarted: false });
+    expect(state.pkillCount).toBe(0);
+  });
+
+  it('writes the marker and kills the daemon when drifted', async () => {
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost({ marker: null });
+    const result = await reconcileCodexAgentProxyEnv(host);
+    expect(result).toEqual({ markerChanged: true, daemonRestarted: true });
+    expect(state.marker).toBe(buildAgentProxyMarkerContent(17893).trim());
+    expect(state.pkillCount).toBe(1);
+  });
+
+  it('deletes the marker and kills the daemon when the pref is off', async () => {
+    // 模块级 prefs cache 跨用例共享 — 显式清除, 模拟 "pref 关闭" 场景。
+    setSshHostAgentProxy('test-host', null);
+    const { host, state } = makeFakeHost({ marker: "export HTTPS_PROXY='http://127.0.0.1:17893'" });
+    const result = await reconcileCodexAgentProxyEnv(host);
+    expect(result).toEqual({ markerChanged: true, daemonRestarted: true });
+    expect(state.marker).toBeNull();
+    expect(state.pkillCount).toBe(1);
+  });
+
+  it('leaves a missing marker alone when the pref is off', async () => {
+    setSshHostAgentProxy('test-host', null);
+    const { host, state } = makeFakeHost({ marker: null });
+    const result = await reconcileCodexAgentProxyEnv(host);
+    expect(result).toEqual({ markerChanged: false, daemonRestarted: false });
+    expect(state.pkillCount).toBe(0);
+  });
+});
+
+describe('ssh-host-prefs-store agentProxy', () => {
+  it('round-trips an enabled pref', () => {
+    setSshHostAgentProxy('h1', PREF);
+    expect(getSshHostAgentProxy('h1')).toEqual(PREF);
+  });
+
+  it('returns null for disabled / cleared / unknown hosts', () => {
+    setSshHostAgentProxy('h1', { ...PREF, enabled: false });
+    expect(getSshHostAgentProxy('h1')).toBeNull();
+    setSshHostAgentProxy('h2', PREF);
+    setSshHostAgentProxy('h2', null);
+    expect(getSshHostAgentProxy('h2')).toBeNull();
+    expect(getSshHostAgentProxy('never-set')).toBeNull();
+  });
+
+  it('keeps autoConnect when writing agentProxy and vice versa', () => {
+    setSshHostAgentProxy('h1', PREF);
+    // 写 autoConnect 不应丢 agentProxy — 走公开 API 验证共存。
+    setSshHostAgentProxy('h1', PREF);
+    expect(getSshHostAgentProxy('h1')).toEqual(PREF);
+  });
+
+  it('rejects malformed prefs at write time', () => {
+    expect(() =>
+      setSshHostAgentProxy('h1', { enabled: true, localHost: 'bad host', localPort: 7890 }),
+    ).toThrow(/invalid agentProxy/);
+    expect(() =>
+      setSshHostAgentProxy('h1', { enabled: true, localHost: '127.0.0.1', localPort: 0 }),
+    ).toThrow(/invalid agentProxy/);
+  });
+});

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -319,7 +319,17 @@ describe('ssh-host-prefs-store agentProxy', () => {
       setSshHostAgentProxy('h1', { enabled: true, localHost: 'bad host', localPort: 7890 }),
     ).toThrow(/invalid agentProxy/);
     expect(() =>
+      setSshHostAgentProxy('h1', { enabled: true, localPort: 7890, localHost: '127.0.0.1' }),
+    ).not.toThrow();
+    expect(() =>
       setSshHostAgentProxy('h1', { enabled: true, localHost: '127.0.0.1', localPort: 0 }),
+    ).toThrow(/invalid agentProxy/);
+    // 引号同样拒 (与 IPC / renderer 校验对齐, review: PR #715 copilot R8)。
+    expect(() =>
+      setSshHostAgentProxy('h1', { enabled: true, localHost: `12'7.0.0.1`, localPort: 7890 }),
+    ).toThrow(/invalid agentProxy/);
+    expect(() =>
+      setSshHostAgentProxy('h1', { enabled: true, localHost: '12"7.0.0.1', localPort: 7890 }),
     ).toThrow(/invalid agentProxy/);
   });
 });

--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxy.test.ts
@@ -43,10 +43,12 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 import {
+  applyAgentProxyForHost,
   buildAgentProxyEnv,
   buildAgentProxyEnvUppercase,
   buildAgentProxyMarkerContent,
   ensureAgentProxyTunnel,
+  getAgentProxyTunnelState,
   killRemoteCodexDaemon,
   reconcileCodexAgentProxyEnv,
 } from '../agent-proxy';
@@ -277,6 +279,87 @@ describe('killRemoteCodexDaemon', () => {
     };
     const result = await killRemoteCodexDaemon(host);
     expect(result).toMatchObject({ ok: false, reason: 'pkill_failed' });
+  });
+});
+
+describe('applyAgentProxyForHost disable path', () => {
+  it('reports apply error when the daemon survives pkill during proxy disable (codex R9 P2)', async () => {
+    // 先 enable 建隧道 (marker 已就位)。
+    setSshHostAgentProxy('test-host', PREF);
+    const { host } = makeFakeHost({ marker: "export HTTPS_PROXY='http://127.0.0.1:17893'" });
+    await applyAgentProxyForHost(host);
+    expect(getAgentProxyTunnelState('test-host')?.active).toBe(true);
+
+    // disable: 隧道拆 + marker 清, 但 daemon 没死透 — 旧 daemon 还握着指向
+    // 已关闭端口的 proxy env, 卡片必须落错误而不是谎称「已关闭」。
+    setSshHostAgentProxy('test-host', null);
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('pkill')) {
+        return {
+          stdout: '',
+          stderr: 'daemon still alive after TERM(5s)+KILL(2s)',
+          exitCode: 3,
+          signal: null,
+        };
+      }
+      return baseExec(cmd, execOpts);
+    };
+    await applyAgentProxyForHost(host);
+    const state = getAgentProxyTunnelState('test-host');
+    expect(state?.active).toBe(false);
+    expect(state?.lastError).toMatch(/survived pkill/);
+  });
+
+  it('serializes concurrent reconciles per host so a fast-path caller never probes mid-restart (codex R9 P2)', async () => {
+    // 并发 reconcile (两个 transport 的 beforeDaemonProbe 同时触发): 第一个
+    // 还在等 killRemoteCodexDaemon 时, 第二个必须排队, 不得走 marker-match
+    // fast path 直接去 probe 旧 daemon。
+    setSshHostAgentProxy('test-host', PREF);
+    const { host, state } = makeFakeHost({ marker: null });
+
+    let killStarted = false;
+    let releaseKill: (() => void) | null = null;
+    const baseExec = host.exec.bind(host);
+    host.exec = async (cmd: string, execOpts?: { input?: string }) => {
+      if (cmd.includes('pkill')) {
+        // 进入 kill-and-wait 即翻牌 (baseExec 的记录要等释放后才有,
+        // 不能拿 execCalls 当等待信号)。
+        killStarted = true;
+        await new Promise<void>((resolve) => {
+          releaseKill = resolve;
+        });
+      }
+      return baseExec(cmd, execOpts);
+    };
+
+    const order: string[] = [];
+    const first = reconcileCodexAgentProxyEnv(host).then((r) => {
+      order.push('first-done');
+      return r;
+    });
+    // 等第一个写完 marker 并卡在 kill-and-wait 阶段。
+    await vi.waitFor(() => {
+      expect(killStarted).toBe(true);
+    });
+    const second = reconcileCodexAgentProxyEnv(host).then((r) => {
+      order.push('second-done');
+      return r;
+    });
+    // 第二个已入队但不得开工: 给它一拍机会, 确认没有第二个 cat/pkill 发生。
+    await Promise.resolve();
+    const execCountWhileFirstBlocked = state.execCalls.length;
+    await Promise.resolve();
+    expect(state.execCalls.length).toBe(execCountWhileFirstBlocked);
+
+    releaseKill?.();
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1.markerChanged).toBe(true);
+    expect(r1.daemonRestarted).toBe(true);
+    // 第二个在第一个完成后才走对账: 此时 marker 已一致 → fast path 零副作用。
+    expect(r2).toEqual({ markerChanged: false, daemonRestarted: false });
+    expect(order).toEqual(['first-done', 'second-done']);
+    expect(state.pkillCount).toBe(1);
   });
 });
 

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -252,19 +252,41 @@ async function writeRemoteMarker(host: RemoteHost, content: string | null): Prom
 export async function killRemoteCodexDaemon(
   host: RemoteHost,
 ): Promise<{ ok: true } | { ok: false; reason: 'pkill_failed'; detail?: string }> {
+  // TERM 后必须等到进程真正消失 (review: PR #715 greptile R6): pkill 只保证
+  // 信号送达 — 旧 daemon 若在 dying 窗口里响应 daemon version 探活,
+  // transport 会复用它 (旧 env), marker 变更静默落空。先 TERM + 轮询 5s,
+  // 没死透再 KILL + 轮询 2s; 仍活着按失败上报 (调用方走降级提示)。
+  // pgrep 不会匹配自身; bash 包装进程 cmdline 里的 pattern 文本经 [c]odex
+  // trick 处理后同样不命中 (与 pkill 的自排除同理)。
   const killScript = `
 USER_NAME=$(id -un 2>/dev/null)
 if [ -z "$USER_NAME" ]; then echo "id -un returned empty" >&2; exit 2; fi
-pkill -u "$USER_NAME" -f '\\.xdt-server.*codex-home.*[c]odex app-server'
+PAT='\\.xdt-server.*codex-home.*[c]odex app-server'
+pkill -u "$USER_NAME" -f "$PAT"
 rc=$?
 case "$rc" in
-  0|1) exit 0 ;;
+  0) ;;
+  1) exit 0 ;;
   *) echo "pkill rc=$rc" >&2; exit "$rc" ;;
 esac
+i=0
+while [ $i -lt 5 ]; do
+  pgrep -u "$USER_NAME" -f "$PAT" >/dev/null 2>&1 || exit 0
+  i=$((i+1)); sleep 1
+done
+pkill -9 -u "$USER_NAME" -f "$PAT" 2>/dev/null || true
+i=0
+while [ $i -lt 2 ]; do
+  pgrep -u "$USER_NAME" -f "$PAT" >/dev/null 2>&1 || exit 0
+  i=$((i+1)); sleep 1
+done
+echo "daemon still alive after TERM(5s)+KILL(2s)" >&2
+exit 3
 `;
   try {
     const result = await host.exec(`bash -c ${shellQuote(killScript)}`, {
-      timeoutMs: 5_000,
+      // 脚本最坏路径: TERM 轮询 5s + KILL 轮询 2s + ssh/exec 开销 — 给 15s。
+      timeoutMs: 15_000,
       label: 'kill-codex-daemon',
     });
     if (result.exitCode !== 0) {

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -129,44 +129,75 @@ export function buildAgentProxyMarkerContent(remotePort: number): string {
 
 /* ============================== 隧道管理 ============================== */
 
+export interface AgentProxyTunnelInfo {
+  remotePort: number;
+  /** 与新 pref 不匹配的旧 forward (rebind 场景), 由调用方决定拆除时机。 */
+  staleForwards: Array<{ localHost: string; localPort: number }>;
+}
+
 /**
  * pref 开启时确保隧道在跑, 返回远端端口; pref 关闭返回 null。
  * host 必须 ready (调用方保证); arm 失败抛错并记录到 tunnel state。
+ *
+ * rebind (目标被编辑) 场景**先建后拆** (codex R17 P2): 新 forward 建立
+ * 失败时旧 forward 原样保留, 存活 daemon 流量不断。closeStale !== false
+ * (默认) 建成功后立即拆旧 (R5 语义: 不拆会残留并随重连 re-arm, 远端
+ * 多暴露一个隧道口); reconcile 传 closeStale: false, 把拆旧推迟到
+ * daemon 重启成功之后 (pkill 失败时旧隧道保留兜底)。
  */
 export async function ensureAgentProxyTunnel(
   host: RemoteHost,
-): Promise<{ remotePort: number } | null> {
+  opts?: { closeStale?: boolean },
+): Promise<AgentProxyTunnelInfo | null> {
   const pref = getSshHostAgentProxy(host.id);
   if (!pref) return null;
-  // 目标被编辑过 (localHost/localPort 变了) 时, 旧目标的 forward 必须拆掉 —
-  // RemoteHost 按目标 key 登记, 不拆会残留并随重连 re-arm, 远端多暴露一个
-  // 隧道口 (review: PR #715 R5)。
-  for (const f of host.listRemoteForwards()) {
-    if (f.localHost !== pref.localHost || f.localPort !== pref.localPort) {
-      try {
-        await host.closeRemoteForward(f.localHost, f.localPort);
-      } catch (err) {
-        log.warn('close stale remote forward failed (best-effort)', {
-          hostId: host.id,
-          staleTarget: `${f.localHost}:${f.localPort}`,
-          error: String((err as Error)?.message ?? err),
-        });
-      }
-    }
-  }
   try {
     const fwd = await host.ensureRemoteForward({
       localHost: pref.localHost,
       localPort: pref.localPort,
     });
+    const staleForwards = host
+      .listRemoteForwards()
+      .filter((f) => f.localHost !== pref.localHost || f.localPort !== pref.localPort);
+    if (opts?.closeStale !== false) {
+      for (const f of staleForwards) {
+        try {
+          await host.closeRemoteForward(f.localHost, f.localPort);
+        } catch (err) {
+          log.warn('close stale remote forward failed (best-effort)', {
+            hostId: host.id,
+            staleTarget: `${f.localHost}:${f.localPort}`,
+            error: String((err as Error)?.message ?? err),
+          });
+        }
+      }
+    }
     tunnelStates.set(host.id, { active: true, remotePort: fwd.remotePort });
     emitState(host.id);
-    return { remotePort: fwd.remotePort };
+    return { remotePort: fwd.remotePort, staleForwards };
   } catch (err) {
     const msg = String((err as Error)?.message ?? err);
     tunnelStates.set(host.id, { active: false, lastError: msg });
     emitState(host.id);
     throw err;
+  }
+}
+
+/** 拆旧 forward (rebind 残留) — best-effort, 单个失败不阻塞其余。 */
+async function closeStaleForwards(
+  host: RemoteHost,
+  staleForwards: Array<{ localHost: string; localPort: number }>,
+): Promise<void> {
+  for (const f of staleForwards) {
+    try {
+      await host.closeRemoteForward(f.localHost, f.localPort);
+    } catch (err) {
+      log.warn('close stale remote forward failed (best-effort)', {
+        hostId: host.id,
+        staleTarget: `${f.localHost}:${f.localPort}`,
+        error: String((err as Error)?.message ?? err),
+      });
+    }
   }
 }
 
@@ -361,14 +392,22 @@ async function reconcileCodexAgentProxyEnvSerialized(
 ): Promise<{ markerChanged: boolean; daemonRestarted: boolean }> {
   const pref = getSshHostAgentProxy(host.id);
   let desired: string | null = null;
+  let staleForwards: Array<{ localHost: string; localPort: number }> = [];
   if (pref) {
-    const tunnel = await ensureAgentProxyTunnel(host);
+    // 拆旧推迟到 daemon 重启成功后 (codex R17 P2): pkill 失败时旧隧道保留,
+    // 存活 daemon 仍指旧端口, 流量不断; 新 forward 闲置在 pref 目标上
+    // (语义正确, 下次 reconcile 直接用)。
+    const tunnel = await ensureAgentProxyTunnel(host, { closeStale: false });
     if (!tunnel) throw new Error('agentProxy pref enabled but tunnel refused to start');
     desired = buildAgentProxyMarkerContent(tunnel.remotePort);
+    staleForwards = tunnel.staleForwards;
   }
 
   const current = await readRemoteMarker(host);
   if (current === (desired ? desired.trim() : null)) {
+    // marker 一致 (fast path): daemon env 已是新目标, rebind 残留的旧
+    // forward 可以安全拆 (R5 语义; pref 关路径由 closeAllForwards 统一拆)。
+    if (staleForwards.length > 0) await closeStaleForwards(host, staleForwards);
     return { markerChanged: false, daemonRestarted: false };
   }
 
@@ -385,6 +424,8 @@ async function reconcileCodexAgentProxyEnvSerialized(
     // 已拆隧道的 proxy env 跑到手动重启, enable 后旧 daemon 一直跑旧 env。
     // 回滚后 marker 与存活 daemon env 一致, 下次 reconcile 仍 drift →
     // 重写 + 重试 kill, 可自愈。回滚失败仅 warn: 调用方已按失败上报。
+    // 不拆任何 forward (codex R17 P2): 旧 forward 保留兜底, 存活 daemon
+    // 仍指旧端口, 流量不断。
     try {
       await writeRemoteMarker(host, current);
     } catch (rollbackErr) {
@@ -393,8 +434,11 @@ async function reconcileCodexAgentProxyEnvSerialized(
         error: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
       });
     }
+    return { markerChanged: true, daemonRestarted: false };
   }
-  return { markerChanged: true, daemonRestarted: kill.ok };
+  // daemon 重启成功: 拆旧 (R5 语义, 时机后移到重启成功后, codex R17 P2)。
+  if (staleForwards.length > 0) await closeStaleForwards(host, staleForwards);
+  return { markerChanged: true, daemonRestarted: true };
 }
 
 /**

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -53,6 +53,19 @@ export function clearAgentProxyTunnelState(hostId: string): void {
   tunnelStates.delete(hostId);
 }
 
+/**
+ * 断连时把隧道标记为非活跃 (review: PR #715 copilot R3): 状态只在内存,
+ * 断连后 forward 已 disarm, UI 不应继续显示「已建立」。愿望仍在 —
+ * reconnect ready 时 applyAgentProxyForHost 会重建并重新标活跃。
+ * 仅在确实有 active 记录时动作 (避免无意义 broadcast 刷屏)。
+ */
+export function markAgentProxyTunnelInactive(hostId: string): void {
+  const cur = tunnelStates.get(hostId);
+  if (!cur?.active) return;
+  tunnelStates.set(hostId, { active: false });
+  emitState(hostId);
+}
+
 // broadcast 由 index.ts 注入 (避免循环依赖): 隧道状态变化后推一版
 // status snapshot 给 renderer, HostSnapshotWithPrefs 会带上最新 tunnel state。
 let broadcaster: ((hostId: string) => void) | null = null;

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -332,6 +332,31 @@ exit 3
 export async function reconcileCodexAgentProxyEnv(
   host: RemoteHost,
 ): Promise<{ markerChanged: boolean; daemonRestarted: boolean }> {
+  // per-host 串行链 (codex R9 P2): 并发 reconcile (两个 transport 的
+  // beforeDaemonProbe 与 ready-hook 同时触发) 时, 若第一个还在等
+  // killRemoteCodexDaemon 而第二个走 marker-match fast path, 第二个会直接去
+  // probe 旧 daemon — attach 到 stale-env daemon, 或握手途中被 pkill。
+  // 所有调用按 host 排队, 后来者等前一个写完 marker + 杀完 daemon 再走自己
+  // 的对账 (那时 fast path 才真的代表「环境已一致」)。
+  const prev = reconcileChains.get(host.id) ?? Promise.resolve();
+  const run = prev.then(() => reconcileCodexAgentProxyEnvSerialized(host));
+  // 链上只存 settled 版 (前一个失败不堵后一个); 调用方拿自己的 run 结果。
+  const tracked = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  reconcileChains.set(host.id, tracked);
+  void tracked.then(() => {
+    if (reconcileChains.get(host.id) === tracked) reconcileChains.delete(host.id);
+  });
+  return run;
+}
+
+const reconcileChains = new Map<string, Promise<void>>();
+
+async function reconcileCodexAgentProxyEnvSerialized(
+  host: RemoteHost,
+): Promise<{ markerChanged: boolean; daemonRestarted: boolean }> {
   const pref = getSshHostAgentProxy(host.id);
   let desired: string | null = null;
   if (pref) {
@@ -365,7 +390,16 @@ export async function applyAgentProxyForHost(host: RemoteHost): Promise<void> {
   try {
     if (!pref) {
       await closeAllForwards(host);
-      await reconcileCodexAgentProxyEnv(host);
+      const reconciled = await reconcileCodexAgentProxyEnv(host);
+      // 隧道已拆但旧 daemon 没死透 = 它还握着指向已关闭端口的 proxy env,
+      // 后续 codex turn 全部 proxy-connect 失败, 而 marker/隧道状态已清、
+      // UI 显示 proxy 已关 (codex R9 P2) — 按 apply 失败上报, 让用户在
+      // 卡片上看到错误而不是一个说谎的「已关闭」。
+      if (reconciled.markerChanged && !reconciled.daemonRestarted) {
+        throw new Error(
+          'codex daemon survived pkill after proxy disable; it still holds the old proxy env (retry disable or restart the host)',
+        );
+      }
       tunnelStates.delete(host.id);
       emitState(host.id);
       return;

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -199,16 +199,22 @@ async function writeRemoteMarker(host: RemoteHost, content: string | null): Prom
  * 从 SYNC_CODEX_AUTH handler 抽出的共享实现 — daemon 启动时 in-memory 缓存
  * auth.json / env, 不支持 hot-reload; 变了只能杀, 下次探活失败自动 bootstrap。
  *
- * pattern 设计 (与 auth sync 原实现一致):
+ * pattern 设计 (与 auth sync 原实现一致, review 后收紧):
  * - 匹配 `codex app-server` 两词而非 `codex app-server daemon`: daemon 主进程
  *   的 cmdline 是 `codex app-server --remote-control --listen unix://`, 不含
  *   "daemon" 字 (只有 worker 子进程 cmdline 含 `daemon pid-update-loop`)。
  *   早期 pattern 带 daemon 只杀到 worker, 主进程活着继续用旧 auth/env。
- * - 匹配整条 cmdline 同时含 `.xdt-server` 和 `codex app-server` — 只杀我们
- *   自己装的 daemon, 不误伤用户自己装在别处的 codex app-server。一次性
- *   `codex --print` / `codex exec` 不命中。短暂探活命令
+ * - 要求 cmdline 同时含 `.xdt-server` 与 `codex-home` 两段路径 (顺序):
+ *   只杀我们 isolated CODEX_HOME 里装的 daemon 家族 (主进程 + pid-update-loop
+ *   worker + sock proxy 子进程), 不误伤 (review: PR #715 五轮审核 P1):
+ *   · 用户自己装在别处的 codex (无 .xdt-server 段);
+ *   · .xdt-server 树下非 codex-home 的进程;
+ *   · 用户手动维护的同名 codex-home standalone install (无 .xdt-server 前缀)。
+ *   一次性 `codex --print` / `codex exec` 不命中。短暂探活命令
  *   `codex app-server daemon version` 理论命中但只跑几毫秒, 即使命中也无害
- *   (desktop 探活失败会自动 bootstrap)。
+ *   (desktop 探活失败会自动 bootstrap)。同一远端账号的多台 Cindy 客户端
+ *   共享这一个 daemon singleton, 一侧 pkill 会影响另一侧的 in-flight turn —
+ *   这是 daemon 单例语义的固有边界, 不是 pattern 能解决的 (与 auth sync 相同)。
  * - `[c]odex` 字符类 trick: pkill 自己的 cmdline 字面含 `[c]odex` (带方括号),
  *   不匹配连续 5 字符 `codex`, 不会自杀。
  * - `id -un` 而非 `$USER` 取用户名 + `-u` 限定只杀当前 SSH user 的进程。
@@ -220,7 +226,7 @@ export async function killRemoteCodexDaemon(
   const killScript = `
 USER_NAME=$(id -un 2>/dev/null)
 if [ -z "$USER_NAME" ]; then echo "id -un returned empty" >&2; exit 2; fi
-pkill -u "$USER_NAME" -f '\\.xdt-server.*[c]odex app-server'
+pkill -u "$USER_NAME" -f '\\.xdt-server.*codex-home.*[c]odex app-server'
 rc=$?
 case "$rc" in
   0|1) exit 0 ;;

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -207,19 +207,32 @@ async function readRemoteMarker(host: RemoteHost): Promise<string | null> {
 
 async function writeRemoteMarker(host: RemoteHost, content: string | null): Promise<void> {
   if (content == null) {
-    await host.exec(`bash -c 'rm -f "${REMOTE_AGENT_PROXY_ENV_PATH}"'`, {
+    const result = await host.exec(`bash -c 'rm -f "${REMOTE_AGENT_PROXY_ENV_PATH}"'`, {
       timeoutMs: 10_000,
       label: 'delete-agent-proxy-marker',
     });
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `delete agent-proxy marker failed (exit ${result.exitCode}): ${result.stderr.trim().slice(0, 200)}`,
+      );
+    }
     return;
   }
   // mkdir -p 兜底: install root 通常在 codex 安装时已建, 但 proxy-only
   // 场景 (只开了 claude 没装 codex) 目录可能还不存在。内容走 stdin,
   // 不进 cmd (与 repo 的 secret-hygiene 惯例一致, 虽然 marker 本身无密钥)。
-  await host.exec(
+  const result = await host.exec(
     `bash -c 'mkdir -p "${REMOTE_INSTALL_ROOT}" && cat > "${REMOTE_AGENT_PROXY_ENV_PATH}"'`,
     { timeoutMs: 10_000, label: 'write-agent-proxy-marker', input: content },
   );
+  // exec 对非零退出码 resolve 不 throw — 写失败必须显式挡 (review: PR #715
+  // codex R7 P1): 否则 reconcile 会继续 pkill, daemon 起来没 marker 直连,
+  // fail-closed 破。throw 由调用方收口 (apply 落 tunnel state / probe 中断)。
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `write agent-proxy marker failed (exit ${result.exitCode}): ${result.stderr.trim().slice(0, 200)}`,
+    );
+  }
 }
 
 /**

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -138,6 +138,22 @@ export async function ensureAgentProxyTunnel(
 ): Promise<{ remotePort: number } | null> {
   const pref = getSshHostAgentProxy(host.id);
   if (!pref) return null;
+  // 目标被编辑过 (localHost/localPort 变了) 时, 旧目标的 forward 必须拆掉 —
+  // RemoteHost 按目标 key 登记, 不拆会残留并随重连 re-arm, 远端多暴露一个
+  // 隧道口 (review: PR #715 R5)。
+  for (const f of host.listRemoteForwards()) {
+    if (f.localHost !== pref.localHost || f.localPort !== pref.localPort) {
+      try {
+        await host.closeRemoteForward(f.localHost, f.localPort);
+      } catch (err) {
+        log.warn('close stale remote forward failed (best-effort)', {
+          hostId: host.id,
+          staleTarget: `${f.localHost}:${f.localPort}`,
+          error: String((err as Error)?.message ?? err),
+        });
+      }
+    }
+  }
   try {
     const fwd = await host.ensureRemoteForward({
       localHost: pref.localHost,

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -1,0 +1,315 @@
+/**
+ * agent-proxy —— 「Agent 流量经 SSH 隧道走本地 Proxy」的策略层。
+ *
+ * 链路与职责切分:
+ *
+ *   远端 codex daemon / claude CLI
+ *     │  HTTPS_PROXY=http://127.0.0.1:<remotePort>   (env 注入)
+ *     ▼
+ *   远端 127.0.0.1:<remotePort>                     (sshd remote forwarding, ssh -R)
+ *     │  SSH 连接内多路复用 channel                    (RemoteHost.ensureRemoteForward)
+ *     ▼
+ *   本机 pipe → 用户自己的本地 Proxy (如 127.0.0.1:7890)
+ *
+ * Cindy 不提供 Proxy, 只提供隧道。域名解析发生在用户 Proxy 那一端
+ * (HTTP CONNECT 语义), 远端完全不需要能解 chatgpt.com / api.anthropic.com。
+ *
+ * 两个 agent 的 env 注入方式不同:
+ *   - claude-code: cc-mgr daemon 按 session spawn SDK, startParams.env 每
+ *     次会话重建 — 直接在 remoteCcQueryFactory 里 merge, 即时生效。
+ *   - codex: app-server daemon 是远端常驻进程, env 只能在 daemon 启动时
+ *     生效。所以写一个 marker 文件 ($INSTALL_ROOT/agent-proxy.env),
+ *     daemon wrapper 启动前 source 它; marker 漂移时 pkill daemon
+ *     (daemon version 探活失败 → 下次 transport bootstrap 重新拉起,
+ *     与 auth sync 的 daemonRestart 同套路)。
+ */
+
+import {
+  REMOTE_AGENT_PROXY_ENV_PATH,
+  REMOTE_INSTALL_ROOT,
+  type RemoteHost,
+} from '@cindy/maker-remote-ssh';
+
+import { createLogger } from '../logger.js';
+import { getSshHostAgentProxy } from './ssh-host-prefs-store.js';
+
+const log = createLogger('remote-ssh/agent-proxy');
+
+/** UI 展示用的隧道实时状态 (内存态, 不持久化)。 */
+export interface AgentProxyTunnelState {
+  active: boolean;
+  remotePort?: number;
+  lastError?: string;
+}
+
+const tunnelStates = new Map<string, AgentProxyTunnelState>();
+
+export function getAgentProxyTunnelState(hostId: string): AgentProxyTunnelState | null {
+  return tunnelStates.get(hostId) ?? null;
+}
+
+/** host 删除时同步清掉内存态。 */
+export function clearAgentProxyTunnelState(hostId: string): void {
+  tunnelStates.delete(hostId);
+}
+
+// broadcast 由 index.ts 注入 (避免循环依赖): 隧道状态变化后推一版
+// status snapshot 给 renderer, HostSnapshotWithPrefs 会带上最新 tunnel state。
+let broadcaster: ((hostId: string) => void) | null = null;
+export function initAgentProxy(deps: { broadcast: (hostId: string) => void }): void {
+  broadcaster = deps.broadcast;
+}
+function emitState(hostId: string): void {
+  try {
+    broadcaster?.(hostId);
+  } catch { /* broadcast must not throw into ssh paths */ }
+}
+
+/* ============================== env 构造 ============================== */
+
+/**
+ * 注入远端 agent 进程的代理 env。大小写两份: Rust (reqwest) / Node /
+ * Go / curl 对 HTTPS_PROXY vs https_proxy 的读取习惯不一致, 全给最稳。
+ * NO_PROXY 只排除 loopback — 用户自己的 Proxy 规则决定内网域名直连与否,
+ * 那是 Proxy 软件的职责, 不是我们的。
+ */
+export function buildAgentProxyEnv(remotePort: number): Record<string, string> {
+  const url = `http://127.0.0.1:${remotePort}`;
+  const noProxy = 'localhost,127.0.0.1,::1';
+  return {
+    HTTPS_PROXY: url,
+    HTTP_PROXY: url,
+    NO_PROXY: noProxy,
+    https_proxy: url,
+    http_proxy: url,
+    no_proxy: noProxy,
+  };
+}
+
+/**
+ * 仅大写版本 — env-block.ts 的 gatekeeper 拒小写 key (防 stdin 协议注入),
+ * one-shot 的 envBlock 路径只能拿大写; claude/codex 都认大写。
+ */
+export function buildAgentProxyEnvUppercase(remotePort: number): Record<string, string> {
+  const url = `http://127.0.0.1:${remotePort}`;
+  return {
+    HTTPS_PROXY: url,
+    HTTP_PROXY: url,
+    NO_PROXY: 'localhost,127.0.0.1,::1',
+  };
+}
+
+/** codex daemon wrapper source 的 marker 文件内容。 */
+export function buildAgentProxyMarkerContent(remotePort: number): string {
+  const url = `http://127.0.0.1:${remotePort}`;
+  return [
+    '# Written by Cindy — agent proxy tunnel env. Sourced by the codex daemon wrapper.',
+    `export HTTPS_PROXY='${url}'`,
+    `export HTTP_PROXY='${url}'`,
+    `export NO_PROXY='localhost,127.0.0.1,::1'`,
+    `export https_proxy='${url}'`,
+    `export http_proxy='${url}'`,
+    `export no_proxy='localhost,127.0.0.1,::1'`,
+    '',
+  ].join('\n');
+}
+
+/* ============================== 隧道管理 ============================== */
+
+/**
+ * pref 开启时确保隧道在跑, 返回远端端口; pref 关闭返回 null。
+ * host 必须 ready (调用方保证); arm 失败抛错并记录到 tunnel state。
+ */
+export async function ensureAgentProxyTunnel(
+  host: RemoteHost,
+): Promise<{ remotePort: number } | null> {
+  const pref = getSshHostAgentProxy(host.id);
+  if (!pref) return null;
+  try {
+    const fwd = await host.ensureRemoteForward({
+      localHost: pref.localHost,
+      localPort: pref.localPort,
+    });
+    tunnelStates.set(host.id, { active: true, remotePort: fwd.remotePort });
+    emitState(host.id);
+    return { remotePort: fwd.remotePort };
+  } catch (err) {
+    const msg = String((err as Error)?.message ?? err);
+    tunnelStates.set(host.id, { active: false, lastError: msg });
+    emitState(host.id);
+    throw err;
+  }
+}
+
+/**
+ * claude-code session 路径: pref 开启 → 确保隧道 + 返回要 merge 进
+ * startParams.env 的代理 env; 关闭 → null (调用方原样透传 startParams)。
+ */
+export async function getRemoteAgentProxyEnv(
+  host: RemoteHost,
+): Promise<Record<string, string> | null> {
+  const tunnel = await ensureAgentProxyTunnel(host);
+  if (!tunnel) return null;
+  return buildAgentProxyEnv(tunnel.remotePort);
+}
+
+/** 拆除本 host 的所有 forward (pref 关闭时调用)。 */
+async function closeAllForwards(host: RemoteHost): Promise<void> {
+  try {
+    await host.closeAllRemoteForwards();
+  } catch (err) {
+    log.warn('close remote forwards failed (best-effort)', {
+      hostId: host.id,
+      error: String((err as Error)?.message ?? err),
+    });
+  }
+}
+
+/* ============================== codex daemon env marker ============================== */
+
+async function readRemoteMarker(host: RemoteHost): Promise<string | null> {
+  const result = await host.exec(
+    `bash -c 'cat "${REMOTE_AGENT_PROXY_ENV_PATH}" 2>/dev/null || true'`,
+    { timeoutMs: 10_000, label: 'read-agent-proxy-marker' },
+  );
+  const content = result.stdout.trim();
+  return content ? content : null;
+}
+
+async function writeRemoteMarker(host: RemoteHost, content: string | null): Promise<void> {
+  if (content == null) {
+    await host.exec(`bash -c 'rm -f "${REMOTE_AGENT_PROXY_ENV_PATH}"'`, {
+      timeoutMs: 10_000,
+      label: 'delete-agent-proxy-marker',
+    });
+    return;
+  }
+  // mkdir -p 兜底: install root 通常在 codex 安装时已建, 但 proxy-only
+  // 场景 (只开了 claude 没装 codex) 目录可能还不存在。内容走 stdin,
+  // 不进 cmd (与 repo 的 secret-hygiene 惯例一致, 虽然 marker 本身无密钥)。
+  await host.exec(
+    `bash -c 'mkdir -p "${REMOTE_INSTALL_ROOT}" && cat > "${REMOTE_AGENT_PROXY_ENV_PATH}"'`,
+    { timeoutMs: 10_000, label: 'write-agent-proxy-marker', input: content },
+  );
+}
+
+/**
+ * pkill 远端 codex app-server daemon (含 sock proxy 子进程)。
+ *
+ * 从 SYNC_CODEX_AUTH handler 抽出的共享实现 — daemon 启动时 in-memory 缓存
+ * auth.json / env, 不支持 hot-reload; 变了只能杀, 下次探活失败自动 bootstrap。
+ *
+ * pattern 设计 (与 auth sync 原实现一致):
+ * - 匹配 `codex app-server` 两词而非 `codex app-server daemon`: daemon 主进程
+ *   的 cmdline 是 `codex app-server --remote-control --listen unix://`, 不含
+ *   "daemon" 字 (只有 worker 子进程 cmdline 含 `daemon pid-update-loop`)。
+ *   早期 pattern 带 daemon 只杀到 worker, 主进程活着继续用旧 auth/env。
+ * - 匹配整条 cmdline 同时含 `.xdt-server` 和 `codex app-server` — 只杀我们
+ *   自己装的 daemon, 不误伤用户自己装在别处的 codex app-server。一次性
+ *   `codex --print` / `codex exec` 不命中。短暂探活命令
+ *   `codex app-server daemon version` 理论命中但只跑几毫秒, 即使命中也无害
+ *   (desktop 探活失败会自动 bootstrap)。
+ * - `[c]odex` 字符类 trick: pkill 自己的 cmdline 字面含 `[c]odex` (带方括号),
+ *   不匹配连续 5 字符 `codex`, 不会自杀。
+ * - `id -un` 而非 `$USER` 取用户名 + `-u` 限定只杀当前 SSH user 的进程。
+ * - rc=0 杀到 / rc=1 没匹配 (从没启过 daemon, 也算成功) / rc>1 真错误。
+ */
+export async function killRemoteCodexDaemon(
+  host: RemoteHost,
+): Promise<{ ok: true } | { ok: false; reason: 'pkill_failed'; detail?: string }> {
+  const killScript = `
+USER_NAME=$(id -un 2>/dev/null)
+if [ -z "$USER_NAME" ]; then echo "id -un returned empty" >&2; exit 2; fi
+pkill -u "$USER_NAME" -f '\\.xdt-server.*[c]odex app-server'
+rc=$?
+case "$rc" in
+  0|1) exit 0 ;;
+  *) echo "pkill rc=$rc" >&2; exit "$rc" ;;
+esac
+`;
+  try {
+    const result = await host.exec(`bash -c ${shellQuote(killScript)}`, {
+      timeoutMs: 5_000,
+      label: 'kill-codex-daemon',
+    });
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim().slice(0, 200);
+      log.warn('failed to kill remote codex daemon', { hostId: host.id, exitCode: result.exitCode, stderr: detail });
+      return { ok: false, reason: 'pkill_failed', detail };
+    }
+    return { ok: true };
+  } catch (err) {
+    const detail = String((err as Error).message ?? err);
+    log.warn('failed to kill remote codex daemon (exec error)', { hostId: host.id, error: detail });
+    return { ok: false, reason: 'pkill_failed', detail };
+  }
+}
+
+/**
+ * codex 路径的 env 对账: 比较远端 marker 与期望值, 漂移则重写 marker +
+ * pkill daemon (下次 transport bootstrap 时 daemon version 探活失败 →
+ * 重新 bootstrap, wrapper source 新 marker, env 生效)。
+ *
+ * 调用点:
+ *   1. codex-remote-transport bootstrap 的 beforeDaemonProbe (每个新
+ *      app-server host 建立前) — 兜底所有路径 (app 重启 / 端口变化 /
+ *      远端被别的客户端动过)。
+ *   2. pref 变更 / host ready 的 applyAgentProxyForHost — 即时生效。
+ *
+ * marker 一致时零副作用 (1 次 cat RTT)。pkill 失败不抛错 — marker 已写,
+ * 下次 daemon 自然重启时也会生效, 这里只降级为 warn。
+ */
+export async function reconcileCodexAgentProxyEnv(
+  host: RemoteHost,
+): Promise<{ markerChanged: boolean; daemonRestarted: boolean }> {
+  const pref = getSshHostAgentProxy(host.id);
+  let desired: string | null = null;
+  if (pref) {
+    const tunnel = await ensureAgentProxyTunnel(host);
+    if (!tunnel) throw new Error('agentProxy pref enabled but tunnel refused to start');
+    desired = buildAgentProxyMarkerContent(tunnel.remotePort);
+  }
+
+  const current = await readRemoteMarker(host);
+  if (current === (desired ? desired.trim() : null)) {
+    return { markerChanged: false, daemonRestarted: false };
+  }
+
+  log.info('codex agent-proxy env marker drifted, rewriting + restarting daemon', {
+    hostId: host.id,
+    enabled: pref != null,
+  });
+  await writeRemoteMarker(host, desired);
+  const kill = await killRemoteCodexDaemon(host);
+  return { markerChanged: true, daemonRestarted: kill.ok };
+}
+
+/**
+ * host ready / pref 变更后的统一应用入口 (幂等):
+ *   - pref 开 → 建隧道 + codex marker 对账
+ *   - pref 关 → 拆隧道 + 清 marker (有残留 daemon 时重启之)
+ * 失败不抛 — 状态落 tunnelStates 给 UI, session 路径会再显式重试并拿到错误。
+ */
+export async function applyAgentProxyForHost(host: RemoteHost): Promise<void> {
+  const pref = getSshHostAgentProxy(host.id);
+  try {
+    if (!pref) {
+      await closeAllForwards(host);
+      await reconcileCodexAgentProxyEnv(host);
+      tunnelStates.delete(host.id);
+      emitState(host.id);
+      return;
+    }
+    await ensureAgentProxyTunnel(host);
+    await reconcileCodexAgentProxyEnv(host);
+  } catch (err) {
+    const msg = String((err as Error)?.message ?? err);
+    log.warn('apply agent-proxy failed (will retry on next session)', { hostId: host.id, error: msg });
+    tunnelStates.set(host.id, { active: false, lastError: msg });
+    emitState(host.id);
+  }
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/apps/desktop/src/main/remote-ssh/agent-proxy.ts
+++ b/apps/desktop/src/main/remote-ssh/agent-proxy.ts
@@ -326,8 +326,10 @@ exit 3
  *      远端被别的客户端动过)。
  *   2. pref 变更 / host ready 的 applyAgentProxyForHost — 即时生效。
  *
- * marker 一致时零副作用 (1 次 cat RTT)。pkill 失败不抛错 — marker 已写,
- * 下次 daemon 自然重启时也会生效, 这里只降级为 warn。
+ * marker 一致时零副作用 (1 次 cat RTT)。pkill 失败不抛错 — marker 回滚到
+ * 原值 (与存活 daemon 的 env 保持一致, 否则下次 reconcile 命中 fast path
+ * 永不重试 kill, codex R10 P1/P2), 调用方按 markerChanged && !daemonRestarted
+ * 组合上报失败。
  */
 export async function reconcileCodexAgentProxyEnv(
   host: RemoteHost,
@@ -376,6 +378,22 @@ async function reconcileCodexAgentProxyEnvSerialized(
   });
   await writeRemoteMarker(host, desired);
   const kill = await killRemoteCodexDaemon(host);
+  if (!kill.ok) {
+    // daemon 没死透 → marker 回滚到原值 (codex R10 P1/P2): 存活 daemon 的
+    // env 仍来自原 marker; 若让 marker 停在新值, 下次 reconcile 命中
+    // marker-match fast path 永不重试 kill — disable 后旧 daemon 握着指向
+    // 已拆隧道的 proxy env 跑到手动重启, enable 后旧 daemon 一直跑旧 env。
+    // 回滚后 marker 与存活 daemon env 一致, 下次 reconcile 仍 drift →
+    // 重写 + 重试 kill, 可自愈。回滚失败仅 warn: 调用方已按失败上报。
+    try {
+      await writeRemoteMarker(host, current);
+    } catch (rollbackErr) {
+      log.warn('agent-proxy marker rollback after pkill failure failed', {
+        hostId: host.id,
+        error: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+      });
+    }
+  }
   return { markerChanged: true, daemonRestarted: kill.ok };
 }
 
@@ -405,7 +423,15 @@ export async function applyAgentProxyForHost(host: RemoteHost): Promise<void> {
       return;
     }
     await ensureAgentProxyTunnel(host);
-    await reconcileCodexAgentProxyEnv(host);
+    const reconciled = await reconcileCodexAgentProxyEnv(host);
+    // 隧道建好但旧 daemon 没死透 = 它还跑着旧 env (无 proxy / 旧端口), 不得
+    // 按成功落 active 状态 (codex R10 P1) — 与 disable 分支同款按失败上报,
+    // 让卡片显示错误而不是说谎的「已开启」。
+    if (reconciled.markerChanged && !reconciled.daemonRestarted) {
+      throw new Error(
+        'codex daemon survived pkill after proxy enable/rebind; it still runs with the previous env (retry or restart the host)',
+      );
+    }
   } catch (err) {
     const msg = String((err as Error)?.message ?? err);
     log.warn('apply agent-proxy failed (will retry on next session)', { hostId: host.id, error: msg });

--- a/apps/desktop/src/main/remote-ssh/index.ts
+++ b/apps/desktop/src/main/remote-ssh/index.ts
@@ -71,6 +71,7 @@ import {
   getAgentProxyTunnelState,
   initAgentProxy,
   killRemoteCodexDaemon,
+  markAgentProxyTunnelInactive,
   reconcileCodexAgentProxyEnv,
   type AgentProxyTunnelState,
 } from './agent-proxy.js';
@@ -506,8 +507,10 @@ function normalizeAgentProxyInput(raw: unknown): SshHostAgentProxyPref | null | 
   const enabled = obj.enabled === true;
   if (!enabled) return null;
   const localHost = requireString(obj.localHost, 'agentProxy.localHost').trim();
-  // localHost 会进远端 env (HTTPS_PROXY=http://<host>:<port>) — 空白和引号
-  // 都会破坏 marker shell 片段, 直接拒。host:port 里的 port 单独给。
+  // localHost 是本机隧道转发目标 (net.connect 的目的地; 远端 env 永远指向
+  // 127.0.0.1:<隧道口>, 不含这个值)。空白/引号在这里虽无注入面, 但必然是
+  // 用户填错 — 直接拒, 免得隧道建起来却转到一个荒诞地址 (review: PR #715
+  // copilot R3 注释修正)。
   if (!localHost || /\s/.test(localHost) || localHost.includes("'") || localHost.includes('"')) {
     throwIpcError('INVALID_PARAMS', 'agentProxy.localHost must be a plain host (no whitespace/quotes), e.g. 127.0.0.1');
   }
@@ -560,6 +563,11 @@ export function registerRemoteSshIpc(): void {
     if (snap.status === 'ready') {
       const host = getPool().get(snap.config.id);
       if (host) void applyAgentProxyForHost(host);
+    } else {
+      // 断连 / 重连中: 隧道已 disarm, 状态标非活跃, detail 面板不显示
+      // 过期的「已建立」(review: PR #715 copilot R3)。reconnect ready 时
+      // 上面的 apply 会重建并重新标活跃。
+      markAgentProxyTunnelInactive(snap.config.id);
     }
   });
   // agent-proxy 内部状态 (隧道成败 / 端口) 变化 → 推一版最新 snapshot,

--- a/apps/desktop/src/main/remote-ssh/index.ts
+++ b/apps/desktop/src/main/remote-ssh/index.ts
@@ -856,7 +856,16 @@ export function registerRemoteSshIpc(): void {
     } else {
       // codex one-shot: wrapper 读的是 marker 文件而非直接 env — 先跑
       // reconcile (隧道 + marker 对账), 保证 quick test 与真实 daemon 链路一致。
-      await reconcileCodexAgentProxyEnv(host);
+      // markerChanged && !daemonRestarted = 旧 daemon 活着跑旧 env, marker 已
+      // 回滚 — one-shot 若继续会 source 不到新 proxy marker 而直连, 与
+      // daemon-probe 路径的 fail-closed 不一致 (codex R12 P1): 显式失败。
+      const reconciled = await reconcileCodexAgentProxyEnv(host);
+      if (reconciled.markerChanged && !reconciled.daemonRestarted) {
+        throwIpcError(
+          'INTERNAL',
+          'codex daemon survived pkill after agent-proxy env change; quick test would run with the wrong network route (retry or restart the host)',
+        );
+      }
     }
 
     const cmd = oneShotCommand(agentKind, probe.binaryPath, envBlock != null);

--- a/apps/desktop/src/main/remote-ssh/index.ts
+++ b/apps/desktop/src/main/remote-ssh/index.ts
@@ -559,15 +559,20 @@ export function registerRemoteSshIpc(): void {
   // 所有路径 (手动 connect / autoConnect / 断线重连) 的统一点, 失败只落
   // tunnel state 不阻断连接, session 路径会显式重试。
   getPool().onAnyStatus((snap) => {
-    broadcastStatus(snap);
     if (snap.status === 'ready') {
+      broadcastStatus(snap);
       const host = getPool().get(snap.config.id);
       if (host) void applyAgentProxyForHost(host);
     } else {
       // 断连 / 重连中: 隧道已 disarm, 状态标非活跃, detail 面板不显示
       // 过期的「已建立」(review: PR #715 copilot R3)。reconnect ready 时
       // 上面的 apply 会重建并重新标活跃。
+      // 先标非活跃再广播 (mark 自带一次 emitState 推送): 事件流里不出现
+      // status≠ready 但 tunnel.active=true 的 stale 帧, renderer 不会
+      // 闪一帧「已建立」再翻「等待连接」(review: PR #715 收官审查 P2)。
       markAgentProxyTunnelInactive(snap.config.id);
+      const host = getPool().get(snap.config.id);
+      broadcastStatus(host ? host.snapshot() : snap);
     }
   });
   // agent-proxy 内部状态 (隧道成败 / 端口) 变化 → 推一版最新 snapshot,

--- a/apps/desktop/src/main/remote-ssh/index.ts
+++ b/apps/desktop/src/main/remote-ssh/index.ts
@@ -54,12 +54,26 @@ import {
   readPubkey,
 } from './ssh-keys.js';
 import {
+  getSshHostAgentProxy,
   getSshHostAutoConnect,
   hasAnyAutoConnectHost,
   readSshHostPrefs,
   removeSshHostPref,
+  setSshHostAgentProxy,
   setSshHostAutoConnect,
+  type SshHostAgentProxyPref,
 } from './ssh-host-prefs-store.js';
+import {
+  applyAgentProxyForHost,
+  buildAgentProxyEnvUppercase,
+  clearAgentProxyTunnelState,
+  ensureAgentProxyTunnel,
+  getAgentProxyTunnelState,
+  initAgentProxy,
+  killRemoteCodexDaemon,
+  reconcileCodexAgentProxyEnv,
+  type AgentProxyTunnelState,
+} from './agent-proxy.js';
 import {
   clearCcManagerInstallCache,
   runCcMgrUpgrade,
@@ -455,13 +469,26 @@ async function ensureHydrated(): Promise<void> {
 /**
  * Snapshot wrapper used in IPC payloads. `HostSnapshot` lives in the
  * transport-only package (@cindy/maker-remote-ssh) and stays free of
- * desktop-side prefs; we wrap it here so renderer gets autoConnect in a
- * single round-trip instead of having to call a second IPC per row.
+ * desktop-side prefs; we wrap it here so renderer gets autoConnect +
+ * agentProxy (+ tunnel 实时状态) in a single round-trip instead of having
+ * to call a second IPC per row.
  */
-export type HostSnapshotWithPrefs = HostSnapshot & { autoConnect: boolean };
+export type HostSnapshotWithPrefs = HostSnapshot & {
+  autoConnect: boolean;
+  /** 未开启 / 未配置 → null。 */
+  agentProxy: SshHostAgentProxyPref | null;
+  /** 隧道实时状态 (仅内存); pref 关闭或无记录 → null。 */
+  agentProxyTunnel: AgentProxyTunnelState | null;
+};
 
 function withPrefs(snapshot: HostSnapshot): HostSnapshotWithPrefs {
-  return { ...snapshot, autoConnect: getSshHostAutoConnect(snapshot.config.id) };
+  const id = snapshot.config.id;
+  return {
+    ...snapshot,
+    autoConnect: getSshHostAutoConnect(id),
+    agentProxy: getSshHostAgentProxy(id),
+    agentProxyTunnel: getAgentProxyTunnelState(id),
+  };
 }
 
 function broadcastStatus(snapshot: HostSnapshot): void {
@@ -472,7 +499,28 @@ function broadcastStatus(snapshot: HostSnapshot): void {
   }
 }
 
-function normalizeAddInput(raw: unknown): AddHostInput {
+function normalizeAgentProxyInput(raw: unknown): SshHostAgentProxyPref | null | undefined {
+  if (raw === undefined) return undefined; // 调用方没提这个字段 — 不动现有 pref
+  if (raw === null) return null; // 显式关闭
+  const obj = requireObject(raw, 'agentProxy');
+  const enabled = obj.enabled === true;
+  if (!enabled) return null;
+  const localHost = requireString(obj.localHost, 'agentProxy.localHost').trim();
+  // localHost 会进远端 env (HTTPS_PROXY=http://<host>:<port>) — 空白和引号
+  // 都会破坏 marker shell 片段, 直接拒。host:port 里的 port 单独给。
+  if (!localHost || /\s/.test(localHost) || localHost.includes("'") || localHost.includes('"')) {
+    throwIpcError('INVALID_PARAMS', 'agentProxy.localHost must be a plain host (no whitespace/quotes), e.g. 127.0.0.1');
+  }
+  const localPort = typeof obj.localPort === 'number' && Number.isInteger(obj.localPort) && obj.localPort > 0 && obj.localPort < 65536
+    ? obj.localPort
+    : NaN;
+  if (!Number.isInteger(localPort)) {
+    throwIpcError('INVALID_PARAMS', 'agentProxy.localPort must be an integer in 1..65535');
+  }
+  return { enabled: true, localHost, localPort };
+}
+
+function normalizeAddInput(raw: unknown): AddHostInput & { agentProxy?: SshHostAgentProxyPref | null } {
   const obj = requireObject(raw, 'host');
   const id = requireString(obj.id, 'id').trim();
   // Alias must be safe to drop into ~/.ssh/config Host directive.
@@ -495,7 +543,8 @@ function normalizeAddInput(raw: unknown): AddHostInput {
   if (authMethod === 'key' && !identityFile) {
     throwIpcError('INVALID_PARAMS', 'identityFile required when authMethod is "key"');
   }
-  return { id, hostname, port, user, authMethod, identityFile };
+  const agentProxy = normalizeAgentProxyInput(obj.agentProxy);
+  return { id, hostname, port, user, authMethod, identityFile, ...(agentProxy !== undefined ? { agentProxy } : {}) };
 }
 
 export function registerRemoteSshIpc(): void {
@@ -503,7 +552,24 @@ export function registerRemoteSshIpc(): void {
   registered = true;
 
   // Wire pool status → renderer broadcast (once, at registration time).
-  getPool().onAnyStatus(broadcastStatus);
+  // ready 转换时顺带应用 agent-proxy 愿望 (建隧道 + codex env 对账): 这是
+  // 所有路径 (手动 connect / autoConnect / 断线重连) 的统一点, 失败只落
+  // tunnel state 不阻断连接, session 路径会显式重试。
+  getPool().onAnyStatus((snap) => {
+    broadcastStatus(snap);
+    if (snap.status === 'ready') {
+      const host = getPool().get(snap.config.id);
+      if (host) void applyAgentProxyForHost(host);
+    }
+  });
+  // agent-proxy 内部状态 (隧道成败 / 端口) 变化 → 推一版最新 snapshot,
+  // 让 detail 面板的隧道状态行即时刷新。
+  initAgentProxy({
+    broadcast: (hostId) => {
+      const host = getPool().get(hostId);
+      if (host) broadcastStatus(host.snapshot());
+    },
+  });
 
   ipcMain.handle(REMOTE_SSH_INVOKE.LIST, async () => {
     await ensureHydrated();
@@ -544,6 +610,9 @@ export function registerRemoteSshIpc(): void {
     }
 
     const host = getPool().add(cfg);
+    if (input.agentProxy !== undefined) {
+      setSshHostAgentProxy(cfg.id, input.agentProxy);
+    }
     return { host: withPrefs(host.snapshot()) };
   });
 
@@ -571,9 +640,16 @@ export function registerRemoteSshIpc(): void {
       source: existing.config.source,
     };
 
-    // Disconnect first if active — changing hostname / user / auth method
-    // invalidates the open channel. User will reconnect when ready.
-    if (existing.getStatus() !== 'disconnected') {
+    // 仅当连接字段真的变了才断开 — 只改 agentProxy 偏好不该打断正在用的
+    // SSH 连接 (隧道/会话都在上面)。
+    const prev = existing.config;
+    const connectionFieldsChanged =
+      prev.hostname !== cfg.hostname ||
+      prev.user !== cfg.user ||
+      prev.port !== cfg.port ||
+      prev.authMethod !== cfg.authMethod ||
+      prev.identityFile !== cfg.identityFile;
+    if (connectionFieldsChanged && existing.getStatus() !== 'disconnected') {
       await existing.disconnect();
     }
 
@@ -583,6 +659,15 @@ export function registerRemoteSshIpc(): void {
       throwIpcError('SSH_CONFIG_IO_FAILED', `update ~/.ssh/config failed: ${String(err)}`);
     }
     existing.updateConfig(cfg);
+
+    // agentProxy 偏好: 写盘 + host 活着就立即应用 (建/拆隧道 + codex daemon
+    // env 对账)。host 未连时只落 pref, 下次 ready 时由 ready hook 应用。
+    if (input.agentProxy !== undefined) {
+      setSshHostAgentProxy(cfg.id, input.agentProxy);
+      if (existing.getStatus() === 'ready') {
+        await applyAgentProxyForHost(existing);
+      }
+    }
     return { host: withPrefs(existing.snapshot()) };
   });
 
@@ -610,6 +695,7 @@ export function registerRemoteSshIpc(): void {
     // 同步清掉 prefs 里的孤儿 autoConnect 标志, 避免后续重新 add 同名 host 时
     // 拿到旧偏好造成"莫名其妙又自动连了"。同步清 agent install cache。
     removeSshHostPref(id);
+    clearAgentProxyTunnelState(id);
     remoteAgentInstalledCache.delete(id);
     clearCcManagerInstallCache(id);
     return { ok: true as const };
@@ -736,6 +822,10 @@ export function registerRemoteSshIpc(): void {
     // Claude: inject local API key + upstream endpoint via STDIN (not cmd
     // args) — see claude-env.ts header for security model. Codex relies on
     // ~/.codex/auth.json on the remote (synced via "Sync auth").
+    //
+    // agentProxy pref 开启时把代理 env 一并注入 (quick test 因此同时验证
+    // 隧道链路是否可用): claude 走 envBlock (gatekeeper 只收大写), codex
+    // 的 wrapper 统一 source agent-proxy.env marker, 与 daemon 行为一致。
     let envBlock: string | null = null;
     if (agentKind === 'claude-code') {
       const env = getRemoteClaudeEnv();
@@ -745,7 +835,15 @@ export function registerRemoteSshIpc(): void {
           'Cindy AI is not connected in Cindy; connect it in Settings → Model Providers first',
         );
       }
-      envBlock = serializeEnvBlock(env);
+      const proxyTunnel = await ensureAgentProxyTunnel(host);
+      const envWithProxy = proxyTunnel
+        ? { ...env, ...buildAgentProxyEnvUppercase(proxyTunnel.remotePort) }
+        : env;
+      envBlock = serializeEnvBlock(envWithProxy);
+    } else {
+      // codex one-shot: wrapper 读的是 marker 文件而非直接 env — 先跑
+      // reconcile (隧道 + marker 对账), 保证 quick test 与真实 daemon 链路一致。
+      await reconcileCodexAgentProxyEnv(host);
     }
 
     const cmd = oneShotCommand(agentKind, probe.binaryPath, envBlock != null);
@@ -831,74 +929,20 @@ export function registerRemoteSshIpc(): void {
     // Retry 还是撞同一个 401。pkill 杀掉后, desktop 端下次 send 走 ensureStarted →
     // `daemon version` 探活失败 → bootstrap 新 daemon → 读到新 auth.json → 成功。
     //
-    // pattern 设计:
-    // - 匹配 `codex app-server` 两词 literal —— 覆盖 daemon 主进程 + sock proxy
-    //   子进程 + 任何 `codex app-server <subcommand>` 长跑进程。**注意**: daemon
-    //   主进程的 cmdline 是 `codex app-server --remote-control --listen unix://`,
-    //   **不包含 "daemon" 字**; 只有 worker 子进程 cmdline 含 `daemon pid-update-loop`。
-    //   早期 pattern 写 `codex app-server daemon` 只杀 worker 不杀主进程, 导致
-    //   sync 后 daemon 还在跑用旧 auth, 复现 401。
-    // - 第一个字母套字符类 `[c]odex` —— 经典 ps/grep 自排除 trick: regex `[c]odex`
-    //   等价于 `codex`, 匹配真 daemon 的 cmdline; 但 pkill 命令自身的 cmdline 里
-    //   出现的是字面 `[c]odex` (有方括号), regex 找不到 5 连续字符 `codex`, 所以
-    //   pkill 不会把自己 kill 掉。
-    // - 用 `id -un` 而非 `$USER` 取当前用户名 + `-u "$USER_NAME"` 限制只杀当前
-    //   SSH user 的进程, 防误伤别人。某些非交互 ssh shell ($USER 未设) 会让
-    //   `pkill -u ""` 默默匹配 0 进程, 用 `id -un` 兜底; 取到空再 exit 2。
-    // - 误杀风险评估: 短暂的 `codex app-server daemon version` 探活命令也会被命中,
-    //   但它本身只跑几毫秒, 命中窗口极小; desktop 端探活失败会自动重试 bootstrap,
-    //   即使命中也无害。一次性的 `codex --print` / `codex exec` 不命中此 pattern。
-    // - exit code: pkill rc=0 杀到, rc=1 没匹配 (全新机器从没启过 daemon, 也算成功),
-    //   rc>1 真错误 (pattern 不合法 / 权限 / pkill 缺失) → script 透传 rc, 上层
-    //   log.warn 但不抛 IPC error, 因为 auth.json 已经推到远端是已经完成的事,
-    //   失败时用户至少能从日志看到 daemon 重启失败。
+    // pkill 实现抽成了共享 helper (agent-proxy.ts:killRemoteCodexDaemon) —
+    // agent-proxy 的 env marker 漂移时也要走同一条 daemon 重启路径。pattern 的
+    // 设计考量 ([c]odex 自排除 / .xdt-server 路径限定 / id -un 取用户) 见 helper 注释。
+    //
     // pkill 失败时不再 silently swallow — propagate 给 renderer 显示软提示 "auth
     // 已推上去, 但 daemon 没重启成功, 要 reconnect / 手动重启 daemon 后才能用新
     // auth"。auth.json 已成功落盘所以 ok=true; daemonRestart 字段告诉 renderer
     // 是否需要降级显示。
-    let daemonRestart: { ok: true } | { ok: false; reason: 'pkill_failed'; detail?: string } = {
-      ok: true as const,
-    };
-    // pkill pattern: 加 .xdt-server 路径限定 — 远端 transport 把 xdt 自家 daemon
-    // 装在 $HOME/.xdt-server/v1/codex-home + 通过 $HOME/.xdt-server/v1/<bin> 启动,
-    // 进程 cmdline 必然含 ".xdt-server" 子串。旧 pattern `'[c]odex app-server'`
-    // 在共享 SSH 账号场景误杀用户**自己装在别处的** codex app-server。
-    // - `[c]odex` 自排除 trick 保留: pkill 自己的 cmdline 字面包含 `[c]odex`, 不
-    //   匹配 5 连续字符 `codex`, 所以不杀 pkill 自己。
-    // - `.*` 跨段匹配 — 用户进程 cmdline 形如 `node .../xdt-server/.../codex
-    //   app-server --remote-control ...`, 我们要求整条 cmdline 同时含 .xdt-server
-    //   AND `codex app-server`。
-    try {
-      const killScript = `
-USER_NAME=$(id -un 2>/dev/null)
-if [ -z "$USER_NAME" ]; then echo "id -un returned empty" >&2; exit 2; fi
-pkill -u "$USER_NAME" -f '\\.xdt-server.*[c]odex app-server'
-rc=$?
-case "$rc" in
-  0|1) exit 0 ;;
-  *) echo "pkill rc=$rc" >&2; exit "$rc" ;;
-esac
-`;
-      const result = await host.exec(`bash -c ${shellQuoteSh(killScript)}`, {
-        timeoutMs: 5_000,
-        label: 'kill-codex-daemon-post-sync',
-      });
-      if (result.exitCode !== 0) {
-        const detail = result.stderr.trim().slice(0, 200);
-        log.warn('failed to kill remote codex daemon after auth sync (auth.json pushed ok, but daemon may still use old auth)', {
-          hostId: id,
-          exitCode: result.exitCode,
-          stderr: detail,
-        });
-        daemonRestart = { ok: false, reason: 'pkill_failed', detail };
-      }
-    } catch (err) {
-      const detail = String((err as Error).message ?? err);
-      log.warn('failed to kill remote codex daemon after auth sync (will reload on next reconnect)', {
+    const daemonRestart = await killRemoteCodexDaemon(host);
+    if (!daemonRestart.ok) {
+      log.warn('failed to kill remote codex daemon after auth sync (auth.json pushed ok, but daemon may still use old auth)', {
         hostId: id,
-        error: detail,
+        detail: daemonRestart.detail,
       });
-      daemonRestart = { ok: false, reason: 'pkill_failed', detail };
     }
 
     return { ok: true as const, daemonRestart };
@@ -1448,7 +1492,14 @@ function oneShotCommand(
   let envSetup: string;
   if (agentKind === 'codex') {
     const codexHome = binaryPath.replace(/\/packages\/standalone\/current\/codex$/, '');
-    envSetup = `export CODEX_HOME=${shellQuoteSh(codexHome)}`;
+    const installRoot = codexHome.replace(/\/codex-home$/, '');
+    const markerPath = `${installRoot}/agent-proxy.env`;
+    // source agent-proxy marker (agentProxy pref 开启时由 reconcile 写入) —
+    // 与 daemon wrapper 同源, quick test 走的就是真实会话的代理链路。
+    envSetup = [
+      `export CODEX_HOME=${shellQuoteSh(codexHome)}`,
+      `if [ -f ${shellQuoteSh(markerPath)} ]; then . ${shellQuoteSh(markerPath)}; fi`,
+    ].join('\n');
   } else {
     const installDir = binaryPath.replace(/\/node_modules\/\.bin\/[^/]+$/, '');
     const nodeBinDir = `${installDir}/node/bin`;

--- a/apps/desktop/src/main/remote-ssh/ssh-host-prefs-store.ts
+++ b/apps/desktop/src/main/remote-ssh/ssh-host-prefs-store.ts
@@ -1,5 +1,5 @@
 /**
- * ssh-host-prefs-store —— 每台 SSH 远端机器的本地偏好(目前只有 autoConnect)。
+ * ssh-host-prefs-store —— 每台 SSH 远端机器的本地偏好(autoConnect + agentProxy)。
  *
  * 设计上跟 ~/.ssh/config 解耦: 不污染用户的 ssh config (那是 ssh 客户端通用配置),
  * 用一个独立 JSON 落 <userData>/ssh-host-prefs.json. 数据极小, 同步 R/W + 内存
@@ -7,12 +7,15 @@
  *
  * Schema:
  *   {
- *     "<hostId>": { "autoConnect": true },
+ *     "<hostId>": {
+ *       "autoConnect": true,
+ *       "agentProxy": { "enabled": true, "localHost": "127.0.0.1", "localPort": 7890 }
+ *     },
  *     ...
  *   }
  *
- * 缺失 host 默认 autoConnect=false (启动不自动连, 新建对话不显远程项目入口)。
- * 这样老用户升级零破坏 —— 没有 prefs 文件就当所有 host 都没勾。
+ * 缺失 host 默认 autoConnect=false (启动不自动连, 新建对话不显远程项目入口)、
+ * agentProxy=未开启。这样老用户升级零破坏 —— 没有 prefs 文件就当所有 host 都没勾。
  */
 
 import { app } from 'electron';
@@ -23,8 +26,20 @@ import { createLogger } from '../logger.js';
 
 const log = createLogger('ssh-host-prefs-store');
 
+/**
+ * Agent 流量经 SSH 隧道走本地 Proxy 的 per-host 配置。
+ * Cindy 不提供 Proxy, 只建隧道: 远端 127.0.0.1:<forwardPort> → 本地
+ * localHost:localPort (用户自己的 Proxy, 如 Clash 的 7890 混合端口)。
+ */
+export interface SshHostAgentProxyPref {
+  enabled: boolean;
+  localHost: string;
+  localPort: number;
+}
+
 export interface SshHostPref {
   autoConnect: boolean;
+  agentProxy?: SshHostAgentProxyPref;
 }
 
 export type SshHostPrefs = Record<string, SshHostPref>;
@@ -33,13 +48,27 @@ function settingsFilePath(): string {
   return path.join(app.getPath('userData'), 'ssh-host-prefs.json');
 }
 
+function normalizeAgentProxy(raw: unknown): SshHostAgentProxyPref | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const v = raw as Record<string, unknown>;
+  const localHost = typeof v.localHost === 'string' ? v.localHost.trim() : '';
+  const localPort = typeof v.localPort === 'number' ? v.localPort : NaN;
+  if (!localHost || /\s/.test(localHost)) return undefined;
+  if (!Number.isInteger(localPort) || localPort < 1 || localPort > 65535) return undefined;
+  return { enabled: v.enabled === true, localHost, localPort };
+}
+
 function normalize(raw: unknown): SshHostPrefs {
   if (!raw || typeof raw !== 'object') return {};
   const out: SshHostPrefs = {};
   for (const [hostId, value] of Object.entries(raw as Record<string, unknown>)) {
     if (!value || typeof value !== 'object') continue;
     const v = value as Record<string, unknown>;
-    out[hostId] = { autoConnect: v.autoConnect === true };
+    const agentProxy = normalizeAgentProxy(v.agentProxy);
+    out[hostId] = {
+      autoConnect: v.autoConnect === true,
+      ...(agentProxy ? { agentProxy } : {}),
+    };
   }
   return out;
 }
@@ -73,15 +102,47 @@ export function getSshHostAutoConnect(hostId: string): boolean {
   return readSshHostPrefs()[hostId]?.autoConnect === true;
 }
 
+/** 单 host 的 agentProxy 配置; 未配置 / enabled=false / 数据非法 → null. */
+export function getSshHostAgentProxy(hostId: string): SshHostAgentProxyPref | null {
+  const pref = readSshHostPrefs()[hostId]?.agentProxy;
+  if (!pref || pref.enabled !== true) return null;
+  return pref;
+}
+
+/** 写入单 host 的 agentProxy 配置 (null = 关闭并清除), atomic write + 更新 cache. */
+export function setSshHostAgentProxy(hostId: string, agentProxy: SshHostAgentProxyPref | null): void {
+  const current = { ...readSshHostPrefs() };
+  // 不 spread 旧 entry — 旧 agentProxy 会借 spread 复活, null 语义就是清除。
+  const next: SshHostPref = { autoConnect: current[hostId]?.autoConnect === true };
+  if (agentProxy) {
+    const normalized = normalizeAgentProxy(agentProxy);
+    if (!normalized) {
+      throw new Error(`invalid agentProxy pref: localHost/localPort malformed`);
+    }
+    next.agentProxy = { ...normalized, enabled: agentProxy.enabled === true };
+  }
+  current[hostId] = next;
+  writePrefs(current);
+  log.info('ssh host agentProxy written', {
+    hostId,
+    enabled: next.agentProxy?.enabled === true,
+    localTarget: next.agentProxy ? `${next.agentProxy.localHost}:${next.agentProxy.localPort}` : null,
+  });
+}
+
+function writePrefs(prefs: SshHostPrefs): void {
+  const file = settingsFilePath();
+  const tmp = `${file}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(prefs, null, 2), 'utf-8');
+  fs.renameSync(tmp, file);
+  cached = prefs;
+}
+
 /** 写入单 host 的 autoConnect, atomic write + 更新 cache. */
 export function setSshHostAutoConnect(hostId: string, autoConnect: boolean): void {
   const current = { ...readSshHostPrefs() };
   current[hostId] = { ...current[hostId], autoConnect };
-  const file = settingsFilePath();
-  const tmp = `${file}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(current, null, 2), 'utf-8');
-  fs.renameSync(tmp, file);
-  cached = current;
+  writePrefs(current);
   log.info('ssh host autoConnect written', { hostId, autoConnect });
 }
 
@@ -100,10 +161,6 @@ export function removeSshHostPref(hostId: string): void {
   if (!(hostId in current)) return;
   const next = { ...current };
   delete next[hostId];
-  const file = settingsFilePath();
-  const tmp = `${file}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(next, null, 2), 'utf-8');
-  fs.renameSync(tmp, file);
-  cached = next;
+  writePrefs(next);
   log.info('ssh host pref removed', { hostId });
 }

--- a/apps/desktop/src/main/remote-ssh/ssh-host-prefs-store.ts
+++ b/apps/desktop/src/main/remote-ssh/ssh-host-prefs-store.ts
@@ -53,7 +53,12 @@ function normalizeAgentProxy(raw: unknown): SshHostAgentProxyPref | undefined {
   const v = raw as Record<string, unknown>;
   const localHost = typeof v.localHost === 'string' ? v.localHost.trim() : '';
   const localPort = typeof v.localPort === 'number' ? v.localPort : NaN;
-  if (!localHost || /\s/.test(localHost)) return undefined;
+  // 引号与空白同样拒 (与 IPC normalizeAgentProxyInput / renderer 校验对齐,
+  // review: PR #715 copilot R8): 手编 prefs 的脏值不应在启动时被恢复成
+  // 可用 pref, 然后晚到 net.connect 才以难懂的方式失败。
+  if (!localHost || /\s/.test(localHost) || localHost.includes("'") || localHost.includes('"')) {
+    return undefined;
+  }
   if (!Number.isInteger(localPort) || localPort < 1 || localPort > 65535) return undefined;
   return { enabled: v.enabled === true, localHost, localPort };
 }

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -2904,6 +2904,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         statusChangedAt: number;
         /** Phase D — 启动时是否自动连接 (本地 prefs, 不写入 ~/.ssh/config). */
         autoConnect: boolean;
+        /** Agent 流量经 SSH 隧道走本地 Proxy (本地 prefs); 未开启 → null. */
+        agentProxy: { enabled: boolean; localHost: string; localPort: number } | null;
+        /** 隧道实时状态 (内存态); 无记录 → null. */
+        agentProxyTunnel: { active: boolean; remotePort?: number; lastError?: string } | null;
       }>;
     }> => ipcRenderer.invoke('maker:remote-ssh:list'),
     reloadConfig: (): Promise<{ hosts: unknown[] }> =>
@@ -2915,6 +2919,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       user: string;
       authMethod?: 'agent' | 'key';
       identityFile?: string;
+      agentProxy?: { enabled: boolean; localHost: string; localPort: number } | null;
     }): Promise<{ host: unknown }> => ipcRenderer.invoke('maker:remote-ssh:add', host),
     update: (host: {
       id: string;
@@ -2923,6 +2928,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       user: string;
       authMethod?: 'agent' | 'key';
       identityFile?: string;
+      agentProxy?: { enabled: boolean; localHost: string; localPort: number } | null;
     }): Promise<{ host: unknown }> => ipcRenderer.invoke('maker:remote-ssh:update', host),
     remove: (id: string): Promise<{ ok: true }> =>
       ipcRenderer.invoke('maker:remote-ssh:remove', { id }),

--- a/apps/desktop/src/renderer/__tests__/remoteProjectIdentity.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remoteProjectIdentity.test.ts
@@ -23,6 +23,8 @@ function sshHost(
     status: 'ready',
     statusChangedAt: 0,
     autoConnect: false,
+    agentProxy: null,
+    agentProxyTunnel: null,
   };
 }
 

--- a/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
@@ -781,7 +781,7 @@ function QuickTestResult({ result }: { result: RemoteAgentOneShotResult }) {
             style={{
               backgroundColor: 'var(--settings-input-bg, #faf9f5)',
               borderColor: 'var(--settings-input-border, #d7d7d4)',
-              color: 'var(--error-fg, #dc2626)',
+              color: 'var(--error-fg)',
               fontFamily: 'var(--app-font-code, var(--app-font-code-default))',
               margin: 0,
             }}

--- a/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
@@ -284,6 +284,11 @@ function AgentProxyTunnelCard({ hostId }: { hostId: string }) {
     icon = <AlertCircle size={14} />;
     text = t('settings.remote.detail.agentProxyError', { message: tunnel.lastError });
     isError = true;
+  } else if (snap?.status !== 'ready') {
+    // 主机断连时隧道已 disarm 且没有在途的建立动作 — 不能渲染
+    // 「建立中」spinner (误导, review: PR #715 greptile R4)。
+    icon = <AlertCircle size={14} />;
+    text = t('settings.remote.detail.agentProxyWaiting', { target: localTarget });
   } else {
     icon = <Spinner size={12} />;
     text = t('settings.remote.detail.agentProxyPending', { target: localTarget });

--- a/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
@@ -270,14 +270,22 @@ function AgentProxyTunnelCard({ hostId }: { hostId: string }) {
   }, []);
 
   const pref = snap?.agentProxy ?? null;
-  if (!pref) return null;
   const tunnel = snap?.agentProxyTunnel ?? null;
-  const localTarget = `${pref.localHost}:${pref.localPort}`;
+  // pref 已关但 disable 失败 (daemon 没死透, 错误已落 lastError) 时仍渲染
+  // 错误卡片 (codex R17 P2) — 否则 Settings 看起来像成功关闭, 存活 daemon
+  // 还握着指向已拆端口的 proxy env, 用户毫无察觉。
+  if (!pref && !tunnel?.lastError) return null;
+  const localTarget = pref ? `${pref.localHost}:${pref.localPort}` : '';
 
   let icon;
   let text: string;
   let isError = false;
-  if (snap?.status !== 'ready') {
+  if (!pref) {
+    // disable 失败分支: pref 已清, 只有 lastError 可显示。
+    icon = <AlertCircle size={14} />;
+    text = t('settings.remote.detail.agentProxyError', { message: tunnel?.lastError ?? '' });
+    isError = true;
+  } else if (snap?.status !== 'ready') {
     // 主机断连/重连中: 隧道已 disarm 或正在拆除 — 即使隧道状态快照还没翻到
     // 非活跃 (断连帧先于 mark-inactive 帧到达), 也优先显示「等待连接」,
     // 不渲染过期的「已建立」(review: PR #715 收官审查 P2)。断连时

--- a/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
@@ -312,7 +312,7 @@ function AgentProxyTunnelCard({ hostId }: { hostId: string }) {
         className="flex items-center gap-2 rounded-lg p-3 text-12"
         style={{
           border: '1px solid var(--settings-theme-card-border)',
-          color: isError ? 'var(--error-fg, #dc2626)' : 'var(--settings-integration-subtitle)',
+          color: isError ? 'var(--error-fg)' : 'var(--settings-integration-subtitle)',
         }}
       >
         <Waypoints size={14} className="shrink-0" />

--- a/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
@@ -262,8 +262,11 @@ function AgentProxyTunnelCard({ hostId }: { hostId: string }) {
     () => remoteSshHostsStore.get()?.find((h) => h.config.id === hostId) ?? null,
   );
   // 触发一次 ensure, 保证 cold start (没开过 Settings 列表) 也有快照。
+  // ensure() 可能因 IPC 失败 reject — 裸 void 会把 rejection 抛成 renderer
+  // unhandled rejection; 与 useRemoteSshHosts hook 同款 catch 守护
+  // (review: PR #715 copilot R7)。
   useEffect(() => {
-    void remoteSshHostsStore.ensure();
+    void remoteSshHostsStore.ensure().catch(() => {});
   }, []);
 
   const pref = snap?.agentProxy ?? null;
@@ -274,7 +277,15 @@ function AgentProxyTunnelCard({ hostId }: { hostId: string }) {
   let icon;
   let text: string;
   let isError = false;
-  if (tunnel?.active && tunnel.remotePort != null) {
+  if (snap?.status !== 'ready') {
+    // 主机断连/重连中: 隧道已 disarm 或正在拆除 — 即使隧道状态快照还没翻到
+    // 非活跃 (断连帧先于 mark-inactive 帧到达), 也优先显示「等待连接」,
+    // 不渲染过期的「已建立」(review: PR #715 收官审查 P2)。断连时
+    // markAgentProxyTunnelInactive 会清掉 lastError, 错误分支只在 ready
+    // 状态 (连接正常但建隧道失败) 下有语义。
+    icon = <AlertCircle size={14} />;
+    text = t('settings.remote.detail.agentProxyWaiting', { target: localTarget });
+  } else if (tunnel?.active && tunnel.remotePort != null) {
     icon = <CheckCircle2 size={14} />;
     text = t('settings.remote.detail.agentProxyActive', {
       port: tunnel.remotePort,
@@ -284,11 +295,6 @@ function AgentProxyTunnelCard({ hostId }: { hostId: string }) {
     icon = <AlertCircle size={14} />;
     text = t('settings.remote.detail.agentProxyError', { message: tunnel.lastError });
     isError = true;
-  } else if (snap?.status !== 'ready') {
-    // 主机断连时隧道已 disarm 且没有在途的建立动作 — 不能渲染
-    // 「建立中」spinner (误导, review: PR #715 greptile R4)。
-    icon = <AlertCircle size={14} />;
-    text = t('settings.remote.detail.agentProxyWaiting', { target: localTarget });
   } else {
     icon = <Spinner size={12} />;
     text = t('settings.remote.detail.agentProxyPending', { target: localTarget });

--- a/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteHostDetail.tsx
@@ -13,10 +13,10 @@
  * that's Phase C (RemoteAgent as a BaseAgent subclass).
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { CheckCircle2, AlertCircle, Play, Upload, Sparkles } from 'lucide-react';
+import { CheckCircle2, AlertCircle, Play, Upload, Sparkles, Waypoints } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
@@ -25,6 +25,7 @@ import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { Spinner } from '@/components/ui/spinner';
 import * as sessionService from '@/lib/sessionService';
 import { buildCodexSyncWarning } from '@/utils/codexAuthSync';
+import { remoteSshHostsStore } from '@/lib/remoteSshHostsStore';
 
 type AgentKind = RemoteAgentKind;
 const AGENT_KINDS: ReadonlyArray<AgentKind> = ['claude-code', 'codex'];
@@ -240,9 +241,73 @@ export function RemoteHostDetail({ hostId }: Props) {
         <QuickTestPanel hostId={hostId} availableKinds={installedKinds} />
       )}
 
+      <AgentProxyTunnelCard hostId={hostId} />
+
       {agents.codex.probe?.installed && (
         <StartRemoteSessionPanel hostId={hostId} />
       )}
+    </div>
+  );
+}
+
+// ── agent proxy tunnel status card ──────────────────────────────────────────
+//
+// 「Agent 流量走本地 Proxy」pref 开启时显示隧道实时状态。快照来自
+// remoteSshHostsStore (main 端 status push 驱动, withPrefs 携带 tunnel state)。
+
+function AgentProxyTunnelCard({ hostId }: { hostId: string }) {
+  const { t } = useTranslation();
+  const snap = useSyncExternalStore(
+    (cb) => remoteSshHostsStore.subscribe(cb),
+    () => remoteSshHostsStore.get()?.find((h) => h.config.id === hostId) ?? null,
+  );
+  // 触发一次 ensure, 保证 cold start (没开过 Settings 列表) 也有快照。
+  useEffect(() => {
+    void remoteSshHostsStore.ensure();
+  }, []);
+
+  const pref = snap?.agentProxy ?? null;
+  if (!pref) return null;
+  const tunnel = snap?.agentProxyTunnel ?? null;
+  const localTarget = `${pref.localHost}:${pref.localPort}`;
+
+  let icon;
+  let text: string;
+  let isError = false;
+  if (tunnel?.active && tunnel.remotePort != null) {
+    icon = <CheckCircle2 size={14} />;
+    text = t('settings.remote.detail.agentProxyActive', {
+      port: tunnel.remotePort,
+      target: localTarget,
+    });
+  } else if (tunnel?.lastError) {
+    icon = <AlertCircle size={14} />;
+    text = t('settings.remote.detail.agentProxyError', { message: tunnel.lastError });
+    isError = true;
+  } else {
+    icon = <Spinner size={12} />;
+    text = t('settings.remote.detail.agentProxyPending', { target: localTarget });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p
+        className="text-13 font-medium"
+        style={{ color: 'var(--settings-section-sublabel)' }}
+      >
+        {t('settings.remote.detail.agentProxyTitle')}
+      </p>
+      <div
+        className="flex items-center gap-2 rounded-lg p-3 text-12"
+        style={{
+          border: '1px solid var(--settings-theme-card-border)',
+          color: isError ? 'var(--error-fg, #dc2626)' : 'var(--settings-integration-subtitle)',
+        }}
+      >
+        <Waypoints size={14} className="shrink-0" />
+        {icon}
+        <span className="break-all">{text}</span>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
@@ -270,6 +270,9 @@ interface AddFormState {
   port: string;
   authMethod: 'agent' | 'key';
   identityFile: string;
+  /** 「Agent 流量走本地 Proxy」隧道开关 + 本地 Proxy 地址 (host:port)。 */
+  agentProxyEnabled: boolean;
+  agentProxyAddr: string;
 }
 
 const EMPTY_FORM: AddFormState = {
@@ -279,7 +282,30 @@ const EMPTY_FORM: AddFormState = {
   port: '22',
   authMethod: 'agent',
   identityFile: '',
+  agentProxyEnabled: false,
+  agentProxyAddr: '127.0.0.1:7890',
 };
+
+/**
+ * 解析 "host:port" 输入 — 支持 IPv6 bracket 形态 ([::1]:7890)。
+ * 返回 null = 无法解析 (表单校验据此拦截提交)。
+ */
+export function parseProxyAddrInput(input: string): { localHost: string; localPort: number } | null {
+  const s = input.trim();
+  if (!s) return null;
+  const bracket = /^\[([^\]]+)\]:(\d+)$/.exec(s);
+  if (bracket) {
+    const localPort = parseInt(bracket[2]!, 10);
+    return bracket[1] && Number.isInteger(localPort) ? { localHost: bracket[1]!, localPort } : null;
+  }
+  const idx = s.lastIndexOf(':');
+  if (idx <= 0) return null;
+  const localHost = s.slice(0, idx).trim();
+  const localPort = parseInt(s.slice(idx + 1), 10);
+  if (!localHost || /\s/.test(localHost) || !Number.isInteger(localPort)) return null;
+  if (localPort < 1 || localPort > 65535) return null;
+  return { localHost, localPort };
+}
 
 interface HostFormProps {
   /**
@@ -315,6 +341,7 @@ function HostForm({ mode, initial, busy, onSubmit, onCancel }: HostFormProps) {
     if (!form.hostname.trim()) return false;
     if (!form.user.trim()) return false;
     if (form.authMethod === 'key' && !form.identityFile.trim()) return false;
+    if (form.agentProxyEnabled && !parseProxyAddrInput(form.agentProxyAddr)) return false;
     return true;
   }, [form]);
 
@@ -503,6 +530,51 @@ function HostForm({ mode, initial, busy, onSubmit, onCancel }: HostFormProps) {
                 {t('settings.remote.button.manageKeys')}
               </button>
             </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Agent Proxy 隧道 ──
+          开关 + 本地 Proxy 地址。pref 落 desktop 本地 ssh-host-prefs.json
+          (不写 ~/.ssh/config); 生效路径: 远端 127.0.0.1:<port> → 本机 Proxy,
+          codex daemon 经 env marker (重启生效), claude 按 session env (即时)。 */}
+      <div className="flex flex-col gap-2">
+        <label
+          className="flex items-center gap-2 cursor-pointer select-none"
+          title={t('settings.remote.add.agentProxyTip')}
+        >
+          <input
+            type="checkbox"
+            checked={form.agentProxyEnabled}
+            onChange={(e) => setForm({ ...form, agentProxyEnabled: e.target.checked })}
+            className="cursor-pointer accent-[var(--settings-menu-text-selected)]"
+          />
+          <span
+            className="text-12 font-medium"
+            style={{ color: 'var(--settings-section-sublabel)' }}
+          >
+            {t('settings.remote.add.agentProxy')}
+          </span>
+        </label>
+        {form.agentProxyEnabled && (
+          <div className="flex flex-col gap-1">
+            <LabeledInput
+              label={t('settings.remote.add.agentProxyAddr')}
+              placeholder="127.0.0.1:7890"
+              value={form.agentProxyAddr}
+              onChange={(v) => setForm({ ...form, agentProxyAddr: v })}
+            />
+            <span
+              className="text-11"
+              style={{ color: 'var(--settings-integration-subtitle)' }}
+            >
+              {t('settings.remote.add.agentProxyHint')}
+            </span>
+            {form.agentProxyAddr.trim() && !parseProxyAddrInput(form.agentProxyAddr) && (
+              <span className="text-11" style={{ color: 'var(--error-fg, #dc2626)' }}>
+                {t('settings.remote.add.agentProxyAddrInvalid')}
+              </span>
+            )}
           </div>
         )}
       </div>
@@ -797,6 +869,11 @@ export function RemoteSection({ showTitle = true }: { showTitle?: boolean } = {}
       //   agent → optional pin (FilteredAgent only offers this one key)
       // Empty string from the input = unset, send undefined.
       const trimmedIdentityFile = form.identityFile.trim();
+      const proxyAddr = form.agentProxyEnabled ? parseProxyAddrInput(form.agentProxyAddr) : null;
+      if (form.agentProxyEnabled && !proxyAddr) {
+        toast.error(t('settings.remote.add.agentProxyAddrInvalid'));
+        return;
+      }
       await window.electronAPI.remoteSsh.update({
         id: form.id.trim(),
         hostname: form.hostname.trim(),
@@ -804,6 +881,7 @@ export function RemoteSection({ showTitle = true }: { showTitle?: boolean } = {}
         port: Number.isFinite(port) && port > 0 ? port : 22,
         authMethod: form.authMethod,
         identityFile: trimmedIdentityFile || undefined,
+        agentProxy: proxyAddr ? { enabled: true, ...proxyAddr } : null,
       });
       // refresh() pulls the latest snapshot; updateConfig already fired a
       // status event, but a full refresh is the safest way to also reflect
@@ -824,6 +902,11 @@ export function RemoteSection({ showTitle = true }: { showTitle?: boolean } = {}
       const port = parseInt(form.port, 10);
       // identityFile is meaningful in BOTH auth modes (see handleEdit).
       const trimmedIdentityFile = form.identityFile.trim();
+      const proxyAddr = form.agentProxyEnabled ? parseProxyAddrInput(form.agentProxyAddr) : null;
+      if (form.agentProxyEnabled && !proxyAddr) {
+        toast.error(t('settings.remote.add.agentProxyAddrInvalid'));
+        return;
+      }
       await window.electronAPI.remoteSsh.add({
         id: form.id.trim(),
         hostname: form.hostname.trim(),
@@ -831,6 +914,7 @@ export function RemoteSection({ showTitle = true }: { showTitle?: boolean } = {}
         port: Number.isFinite(port) && port > 0 ? port : 22,
         authMethod: form.authMethod,
         identityFile: trimmedIdentityFile || undefined,
+        agentProxy: proxyAddr ? { enabled: true, ...proxyAddr } : null,
       });
       await refresh();
       setAdding(false);
@@ -955,6 +1039,10 @@ export function RemoteSection({ showTitle = true }: { showTitle?: boolean } = {}
                     port: String(snap.config.port ?? 22),
                     authMethod: snap.config.authMethod === 'key' ? 'key' : 'agent',
                     identityFile: snap.config.identityFile ?? '',
+                    agentProxyEnabled: snap.agentProxy?.enabled === true,
+                    agentProxyAddr: snap.agentProxy
+                      ? `${snap.agentProxy.localHost}:${snap.agentProxy.localPort}`
+                      : '127.0.0.1:7890',
                   }}
                   onSubmit={handleEdit}
                   onCancel={() => setEditingId(null)}

--- a/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
@@ -295,13 +295,19 @@ export function parseProxyAddrInput(input: string): { localHost: string; localPo
   if (!s) return null;
   const bracket = /^\[([^\]]+)\]:(\d+)$/.exec(s);
   if (bracket) {
-    const localPort = parseInt(bracket[2]!, 10);
-    return bracket[1] && Number.isInteger(localPort) ? { localHost: bracket[1]!, localPort } : null;
+    const localPort = Number(bracket[2]);
+    return bracket[1] && Number.isInteger(localPort) && localPort >= 1 && localPort <= 65535
+      ? { localHost: bracket[1]!, localPort }
+      : null;
   }
   const idx = s.lastIndexOf(':');
   if (idx <= 0) return null;
   const localHost = s.slice(0, idx).trim();
-  const localPort = parseInt(s.slice(idx + 1), 10);
+  const portText = s.slice(idx + 1);
+  // 严格数字校验 (review: PR #715 五轮审核 P2): parseInt 会把 "7890abc"
+  // 静默截断成 7890, 表单和 main 侧都会接受这个并非用户本意的端口。
+  if (!/^\d+$/.test(portText)) return null;
+  const localPort = Number(portText);
   if (!localHost || /\s/.test(localHost) || !Number.isInteger(localPort)) return null;
   if (localPort < 1 || localPort > 65535) return null;
   return { localHost, localPort };

--- a/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
@@ -584,7 +584,7 @@ function HostForm({ mode, initial, busy, onSubmit, onCancel }: HostFormProps) {
               {t('settings.remote.add.agentProxyHint')}
             </span>
             {form.agentProxyAddr.trim() && !parseProxyAddrInput(form.agentProxyAddr) && (
-              <span className="text-11" style={{ color: 'var(--error-fg, #dc2626)' }}>
+              <span className="text-11" style={{ color: 'var(--error-fg)' }}>
                 {t('settings.remote.add.agentProxyAddrInvalid')}
               </span>
             )}

--- a/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
@@ -295,9 +295,11 @@ export function parseProxyAddrInput(input: string): { localHost: string; localPo
   if (!s) return null;
   const bracket = /^\[([^\]]+)\]:(\d+)$/.exec(s);
   if (bracket) {
+    const localHost = bracket[1]!;
     const localPort = Number(bracket[2]);
-    return bracket[1] && Number.isInteger(localPort) && localPort >= 1 && localPort <= 65535
-      ? { localHost: bracket[1]!, localPort }
+    // bracket 内的 host 同样拒空白 (与非 bracket 分支及 main 侧 IPC 校验一致)。
+    return localHost && !/\s/.test(localHost) && Number.isInteger(localPort) && localPort >= 1 && localPort <= 65535
+      ? { localHost, localPort }
       : null;
   }
   const idx = s.lastIndexOf(':');

--- a/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteSection.tsx
@@ -297,8 +297,10 @@ export function parseProxyAddrInput(input: string): { localHost: string; localPo
   if (bracket) {
     const localHost = bracket[1]!;
     const localPort = Number(bracket[2]);
-    // bracket 内的 host 同样拒空白 (与非 bracket 分支及 main 侧 IPC 校验一致)。
-    return localHost && !/\s/.test(localHost) && Number.isInteger(localPort) && localPort >= 1 && localPort <= 65535
+    // bracket 内的 host 同样拒空白与引号 (与非 bracket 分支及 main 侧
+    // IPC 校验一致, review: PR #715 R5)。
+    return localHost && !/\s/.test(localHost) && !localHost.includes("'") && !localHost.includes('"')
+        && Number.isInteger(localPort) && localPort >= 1 && localPort <= 65535
       ? { localHost, localPort }
       : null;
   }
@@ -310,7 +312,10 @@ export function parseProxyAddrInput(input: string): { localHost: string; localPo
   // 静默截断成 7890, 表单和 main 侧都会接受这个并非用户本意的端口。
   if (!/^\d+$/.test(portText)) return null;
   const localPort = Number(portText);
-  if (!localHost || /\s/.test(localHost) || !Number.isInteger(localPort)) return null;
+  // 引号校验与 main 侧 normalizeAgentProxyInput 一致 (review: PR #715 R5) —
+  // 渲染层放行、main 层拒绝的两套标准会让用户填了合法表象却被 IPC 打回。
+  if (!localHost || /\s/.test(localHost) || localHost.includes("'") || localHost.includes('"')) return null;
+  if (!Number.isInteger(localPort)) return null;
   if (localPort < 1 || localPort > 65535) return null;
   return { localHost, localPort };
 }

--- a/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
+++ b/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
@@ -12,9 +12,9 @@ describe('parseProxyAddrInput', () => {
     expect(parseProxyAddrInput('[::1]:7890')).toEqual({ localHost: '::1', localPort: 7890 });
   });
 
-  it('takes the last colon so bare IPv6 without brackets is rejected (ambiguous)', () => {
-    // ::1:7890 → lastIndexOf(':') 切出 host=': :1' 含空白? 不含 — host='::1', port=7890。
-    // 裸 IPv6 语义模糊, 这里的行为是接受 last-colon 切分结果; 文档推荐 bracket 形态。
+  it('accepts bare IPv6 by splitting at the last colon (bracket form recommended)', () => {
+    // ::1:7890 → lastIndexOf(':') 切出 host='::1', port=7890。裸 IPv6 语义
+    // 模糊但有确定行为: 按 last-colon 切分接受; 文档/UI hint 推荐 bracket 形态。
     expect(parseProxyAddrInput('::1:7890')).toEqual({ localHost: '::1', localPort: 7890 });
   });
 

--- a/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
+++ b/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseProxyAddrInput } from '../RemoteSection';
+
+describe('parseProxyAddrInput', () => {
+  it('parses host:port', () => {
+    expect(parseProxyAddrInput('127.0.0.1:7890')).toEqual({ localHost: '127.0.0.1', localPort: 7890 });
+    expect(parseProxyAddrInput(' localhost:1080 ')).toEqual({ localHost: 'localhost', localPort: 1080 });
+  });
+
+  it('parses bracketed IPv6', () => {
+    expect(parseProxyAddrInput('[::1]:7890')).toEqual({ localHost: '::1', localPort: 7890 });
+  });
+
+  it('takes the last colon so bare IPv6 without brackets is rejected (ambiguous)', () => {
+    // ::1:7890 → lastIndexOf(':') 切出 host=': :1' 含空白? 不含 — host='::1', port=7890。
+    // 裸 IPv6 语义模糊, 这里的行为是接受 last-colon 切分结果; 文档推荐 bracket 形态。
+    expect(parseProxyAddrInput('::1:7890')).toEqual({ localHost: '::1', localPort: 7890 });
+  });
+
+  it('rejects malformed input', () => {
+    expect(parseProxyAddrInput('')).toBeNull();
+    expect(parseProxyAddrInput('7890')).toBeNull();
+    expect(parseProxyAddrInput(':7890')).toBeNull();
+    expect(parseProxyAddrInput('host:')).toBeNull();
+    expect(parseProxyAddrInput('host:abc')).toBeNull();
+    expect(parseProxyAddrInput('host:0')).toBeNull();
+    expect(parseProxyAddrInput('host:70000')).toBeNull();
+    expect(parseProxyAddrInput('bad host:7890')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
+++ b/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
@@ -32,6 +32,10 @@ describe('parseProxyAddrInput', () => {
     expect(parseProxyAddrInput('[::1]:7890abc')).toBeNull();
     // bracket 内的 host 同样拒空白 (与非 bracket 分支一致)。
     expect(parseProxyAddrInput('[::1 ]:7890')).toBeNull();
+    // 引号与 main 侧 normalizeAgentProxyInput 校验一致, 两个分支都拒。
+    expect(parseProxyAddrInput("ho'st:7890")).toBeNull();
+    expect(parseProxyAddrInput('ho"st:7890')).toBeNull();
+    expect(parseProxyAddrInput("[::1']:7890")).toBeNull();
     expect(parseProxyAddrInput('host:7890 ')).toEqual({ localHost: 'host', localPort: 7890 }); // 整串 trim 后合法
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
+++ b/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
@@ -30,6 +30,8 @@ describe('parseProxyAddrInput', () => {
     // 端口必须纯数字 — parseInt 的静默截断 ("7890abc" → 7890) 不接受。
     expect(parseProxyAddrInput('host:7890abc')).toBeNull();
     expect(parseProxyAddrInput('[::1]:7890abc')).toBeNull();
+    // bracket 内的 host 同样拒空白 (与非 bracket 分支一致)。
+    expect(parseProxyAddrInput('[::1 ]:7890')).toBeNull();
     expect(parseProxyAddrInput('host:7890 ')).toEqual({ localHost: 'host', localPort: 7890 }); // 整串 trim 后合法
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
+++ b/apps/desktop/src/renderer/components/settings/__tests__/RemoteSection.parseProxyAddr.test.ts
@@ -27,5 +27,9 @@ describe('parseProxyAddrInput', () => {
     expect(parseProxyAddrInput('host:0')).toBeNull();
     expect(parseProxyAddrInput('host:70000')).toBeNull();
     expect(parseProxyAddrInput('bad host:7890')).toBeNull();
+    // 端口必须纯数字 — parseInt 的静默截断 ("7890abc" → 7890) 不接受。
+    expect(parseProxyAddrInput('host:7890abc')).toBeNull();
+    expect(parseProxyAddrInput('[::1]:7890abc')).toBeNull();
+    expect(parseProxyAddrInput('host:7890 ')).toEqual({ localHost: 'host', localPort: 7890 }); // 整串 trim 后合法
   });
 });

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -290,6 +290,7 @@
         "agentProxyTitle": "Agent proxy tunnel",
         "agentProxyActive": "Remote 127.0.0.1:{{port}} → local {{target}} · established",
         "agentProxyPending": "Establishing tunnel → local {{target}}",
+        "agentProxyWaiting": "Host not connected; tunnel will be established on reconnect → local {{target}}",
         "agentProxyError": "Tunnel failed: {{message}}",
         "button": {
           "install": "Install",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -267,6 +267,11 @@
           "keyHint": "Read a private key file directly. We don't store passphrases, so encrypted keys aren't supported — use this only when ssh-agent isn't available."
         },
         "identityFile": "Identity file path",
+        "agentProxy": "Route agent traffic via local proxy",
+        "agentProxyTip": "Open a 127.0.0.1 port on the remote that tunnels back over SSH to a proxy on this machine; remote codex / Claude Code traffic flows out through it",
+        "agentProxyAddr": "Local proxy address",
+        "agentProxyHint": "Opens a 127.0.0.1 port on the remote, tunneled over SSH back to your local proxy (e.g. Clash on 7890). {{appName}} does not provide a proxy — only the tunnel; the remote agent's HTTPS_PROXY points at the tunnel and domains are resolved by your proxy. Toggling restarts the remote codex daemon once to take effect.",
+        "agentProxyAddrInvalid": "Expected host:port, e.g. 127.0.0.1:7890",
         "cancel": "Cancel",
         "submit": "Add machine"
       },
@@ -282,6 +287,10 @@
         "statusInstalled": "Installed",
         "statusNotInstalled": "Not installed",
         "claudeCodeName": "Claude Code",
+        "agentProxyTitle": "Agent proxy tunnel",
+        "agentProxyActive": "Remote 127.0.0.1:{{port}} → local {{target}} · established",
+        "agentProxyPending": "Establishing tunnel → local {{target}}",
+        "agentProxyError": "Tunnel failed: {{message}}",
         "button": {
           "install": "Install",
           "reinstall": "Reinstall",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -290,6 +290,7 @@
         "agentProxyTitle": "Agent プロキシトンネル",
         "agentProxyActive": "リモート 127.0.0.1:{{port}} → ローカル {{target}} · 確立済み",
         "agentProxyPending": "トンネル確立中 → ローカル {{target}}",
+        "agentProxyWaiting": "ホスト未接続 — 再接続後に自動確立 → ローカル {{target}}",
         "agentProxyError": "トンネルの確立に失敗: {{message}}",
         "button": {
           "install": "インストール",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -267,6 +267,11 @@
           "keyHint": "秘密鍵ファイルを直接読み込みます。パスフレーズは保存しないため、暗号化された鍵には非対応 — ssh-agent が使えない場合のみご使用ください。"
         },
         "identityFile": "秘密鍵ファイルのパス",
+        "agentProxy": "Agent トラフィックをローカルプロキシ経由にする",
+        "agentProxyTip": "リモートに 127.0.0.1 ポートを開き、SSH トンネルでこのマシンのプロキシに中継します。リモートの codex / Claude Code の通信がそこから出ます",
+        "agentProxyAddr": "ローカルプロキシのアドレス",
+        "agentProxyHint": "リモートの 127.0.0.1 にポートを開き、SSH トンネルでローカルプロキシ（例: Clash の 7890）に中継します。{{appName}} はプロキシを提供せず、トンネルのみを張ります。リモート Agent の HTTPS_PROXY がトンネル口を指し、ドメインはお使いのプロキシ側で解決されます。切り替え後、リモートの codex daemon が一度再起動します。",
+        "agentProxyAddrInvalid": "host:port 形式で入力してください（例: 127.0.0.1:7890）",
         "cancel": "キャンセル",
         "submit": "マシンを追加"
       },
@@ -282,6 +287,10 @@
         "statusInstalled": "インストール済み",
         "statusNotInstalled": "未インストール",
         "claudeCodeName": "Claude Code",
+        "agentProxyTitle": "Agent プロキシトンネル",
+        "agentProxyActive": "リモート 127.0.0.1:{{port}} → ローカル {{target}} · 確立済み",
+        "agentProxyPending": "トンネル確立中 → ローカル {{target}}",
+        "agentProxyError": "トンネルの確立に失敗: {{message}}",
         "button": {
           "install": "インストール",
           "reinstall": "再インストール",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -290,6 +290,7 @@
         "agentProxyTitle": "Agent 프록시 터널",
         "agentProxyActive": "원격 127.0.0.1:{{port}} → 로컬 {{target}} · 설정됨",
         "agentProxyPending": "터널 설정 중 → 로컬 {{target}}",
+        "agentProxyWaiting": "호스트 미연결 — 재연결 후 자동 설정 → 로컬 {{target}}",
         "agentProxyError": "터널 설정 실패: {{message}}",
         "button": {
           "install": "설치",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -267,6 +267,11 @@
           "keyHint": "개인 키 파일을 직접 읽습니다. 암호를 저장하지 않으므로 암호화된 키는 지원되지 않습니다 — ssh-agent 를 사용할 수 없을 때만 사용하세요."
         },
         "identityFile": "개인 키 파일 경로",
+        "agentProxy": "Agent 트래픽을 로컬 프록시로 우회",
+        "agentProxyTip": "원격에 127.0.0.1 포트를 열고 SSH 터널로 이 컴퓨터의 프록시로 중계합니다. 원격 codex / Claude Code 트래픽이 그 경로로 나갑니다",
+        "agentProxyAddr": "로컬 프록시 주소",
+        "agentProxyHint": "원격 127.0.0.1에 포트를 열고 SSH 터널로 로컬 프록시(예: Clash 7890)로 중계합니다. {{appName}}은(는) 프록시를 제공하지 않고 터널만 만듭니다. 원격 Agent의 HTTPS_PROXY가 터널 포트를 가리키고, 도메인은 프록시에서 해석됩니다. 전환 후 원격 codex daemon이 한 번 재시작됩니다.",
+        "agentProxyAddrInvalid": "host:port 형식이어야 합니다(예: 127.0.0.1:7890)",
         "cancel": "취소",
         "submit": "머신 추가"
       },
@@ -282,6 +287,10 @@
         "statusInstalled": "설치됨",
         "statusNotInstalled": "설치되지 않음",
         "claudeCodeName": "Claude Code",
+        "agentProxyTitle": "Agent 프록시 터널",
+        "agentProxyActive": "원격 127.0.0.1:{{port}} → 로컬 {{target}} · 설정됨",
+        "agentProxyPending": "터널 설정 중 → 로컬 {{target}}",
+        "agentProxyError": "터널 설정 실패: {{message}}",
         "button": {
           "install": "설치",
           "reinstall": "재설치",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -290,6 +290,7 @@
         "agentProxyTitle": "Agent Proxy 隧道",
         "agentProxyActive": "远端 127.0.0.1 端口 {{port}} → 本机 {{target}} · 已建立",
         "agentProxyPending": "隧道建立中 → 本机 {{target}}",
+        "agentProxyWaiting": "主机未连接，重连后自动建立 → 本机 {{target}}",
         "agentProxyError": "隧道建立失败：{{message}}",
         "button": {
           "install": "安装",
@@ -7377,7 +7378,6 @@
         "cancelFailed": "取消订阅失败，请稍后重试。"
       },
       "topupCard": {
-
         "action": "购买点数"
       }
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -267,6 +267,11 @@
           "keyHint": "直接读私钥文件。为了不存密码，不支持加密的密钥 —— 仅在 ssh-agent 不可用时使用。"
         },
         "identityFile": "私钥文件路径",
+        "agentProxy": "Agent 流量走本地 Proxy",
+        "agentProxyTip": "在远端开一个 127.0.0.1 端口，经 SSH 隧道转回本机 Proxy，远端 codex / Claude Code 的流量由此流出",
+        "agentProxyAddr": "本地 Proxy 地址",
+        "agentProxyHint": "在远端 127.0.0.1 开端口，经 SSH 隧道转回本机 Proxy（如 Clash 的 7890）。{{appName}} 不提供 Proxy，只建隧道；远端 agent 的 HTTPS_PROXY 会指向隧道口，域名由你的 Proxy 解析。切换后远端 codex daemon 会重启一次以生效。",
+        "agentProxyAddrInvalid": "格式应为 host:port，例如 127.0.0.1:7890",
         "cancel": "取消",
         "submit": "添加机器"
       },
@@ -282,6 +287,10 @@
         "statusInstalled": "已安装",
         "statusNotInstalled": "未安装",
         "claudeCodeName": "Claude Code",
+        "agentProxyTitle": "Agent Proxy 隧道",
+        "agentProxyActive": "远端 127.0.0.1 端口 {{port}} → 本机 {{target}} · 已建立",
+        "agentProxyPending": "隧道建立中 → 本机 {{target}}",
+        "agentProxyError": "隧道建立失败：{{message}}",
         "button": {
           "install": "安装",
           "reinstall": "重新安装",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -44,10 +44,14 @@ interface EnvCheckResult {
 // surface and the core package's contract in sync. `VoiceInputShortcut` is
 // renderer-only (defined in voice-input/shortcut.ts) so it stays inline.
 // HostSnapshot 来自 transport-only package; desktop main 端 wrap 时附加
-// autoConnect 偏好字段 (本地 prefs, 不写入 ~/.ssh/config), 渲染层统一用
+// autoConnect / agentProxy 偏好字段 (本地 prefs, 不写入 ~/.ssh/config), 渲染层统一用
 // 这个扩展类型即可一次拿到完整信息, 不必再为单个字段单独 IPC。
 type RemoteHostSnapshot = import('@cindy/maker-remote-ssh').HostSnapshot & {
   autoConnect: boolean;
+  /** Agent 流量经 SSH 隧道走本地 Proxy 的 per-host 配置; 未开启 → null。 */
+  agentProxy: { enabled: boolean; localHost: string; localPort: number } | null;
+  /** 隧道实时状态 (main 进程内存态); 无记录 → null。 */
+  agentProxyTunnel: { active: boolean; remotePort?: number; lastError?: string } | null;
 };
 /** 设备互联:REST 设备视图(同 shared/deviceLinkIpc.ts DeviceLinkDeviceView) */
 interface DeviceLinkDeviceInfo {
@@ -2765,6 +2769,8 @@ interface ElectronAPI {
       user: string;
       authMethod?: 'agent' | 'key';
       identityFile?: string;
+      /** 「Agent 流量走本地 Proxy」pref; null = 关闭, 缺省 = 不动。 */
+      agentProxy?: { enabled: boolean; localHost: string; localPort: number } | null;
     }) => Promise<{ host: RemoteHostSnapshot }>;
     update: (host: {
       id: string;
@@ -2773,6 +2779,7 @@ interface ElectronAPI {
       user: string;
       authMethod?: 'agent' | 'key';
       identityFile?: string;
+      agentProxy?: { enabled: boolean; localHost: string; localPort: number } | null;
     }) => Promise<{ host: RemoteHostSnapshot }>;
     remove: (id: string) => Promise<{ ok: true }>;
     connect: (id: string) => Promise<{ host: RemoteHostSnapshot | null }>;

--- a/packages/maker-core/src/agents/codex/app-server/host.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppServerHost } from './host.js';
+import type { Logger } from '../../../interfaces/logger.js';
+import type { Transport, LineHandler, StderrHandler, CloseHandler } from './transport.js';
+
+/** 任何请求都永不回应的 transport — 模拟远端 daemon bootstrap 挂死 / SSH 通道无响应。 */
+class HangingTransport implements Transport {
+  private readonly closeHandlers = new Set<CloseHandler>();
+
+  async writeLine(_line: string): Promise<void> {
+    // 请求照收, 永远不回 response → initialize 挂起。
+  }
+
+  onLine(_handler: LineHandler): () => void {
+    return () => {};
+  }
+
+  onClose(handler: CloseHandler): () => void {
+    this.closeHandlers.add(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
+  onStderr(_handler: StderrHandler): () => void {
+    return () => {};
+  }
+
+  async close(reason = 'test close'): Promise<void> {
+    for (const handler of this.closeHandlers) handler({ reason });
+  }
+}
+
+/** 所有请求延迟 respondDelayMs 回应的 transport — initialize 最终能完成。 */
+class DelayedTransport implements Transport {
+  private readonly lineHandlers = new Set<LineHandler>();
+  private readonly closeHandlers = new Set<CloseHandler>();
+
+  constructor(private readonly respondDelayMs: number) {}
+
+  async writeLine(line: string): Promise<void> {
+    const msg = JSON.parse(line) as { id?: unknown };
+    if (msg.id == null) return; // notification (initialized 等), 无 response
+    setTimeout(() => {
+      const result = {
+        userAgent: 'mock-codex/test',
+        codexHome: '/tmp/codex-home',
+        platformOs: 'linux',
+      };
+      for (const handler of this.lineHandlers) handler(JSON.stringify({ id: msg.id, result }));
+    }, this.respondDelayMs);
+  }
+
+  onLine(handler: LineHandler): () => void {
+    this.lineHandlers.add(handler);
+    return () => this.lineHandlers.delete(handler);
+  }
+
+  onClose(handler: CloseHandler): () => void {
+    this.closeHandlers.add(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
+  onStderr(_handler: StderrHandler): () => void {
+    return () => {};
+  }
+
+  async close(reason = 'test close'): Promise<void> {
+    for (const handler of this.closeHandlers) handler({ reason });
+  }
+}
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => logger,
+};
+
+describe('AppServerHost.request startup timeout', () => {
+  it('bounds a hung ensureStarted by the caller-provided timeoutMs (greptile R6 P1)', async () => {
+    // 冷启动 / transport 重建时 ensureStarted 本身也可能永不返回 — 调用方显式
+    // 给的 timeoutMs 必须同样覆盖启动路径, 否则「关键 RPC 加超时」形同虚设。
+    const host = new AppServerHost({
+      createTransport: () => new HangingTransport(),
+      logger,
+      clientInfo: { name: 'cindy-test', version: '0.0.0' },
+    });
+
+    await expect(host.request('turn/start', {}, { timeoutMs: 50 })).rejects.toThrow(
+      'app-server startup (for turn/start) timed out after 50ms',
+    );
+
+    await host.shutdown();
+  });
+
+  it('keeps the in-flight bootstrap reusable for a later request after a startup timeout', async () => {
+    // 超时只截断本次等待 — bootstrap 仍在后台继续 (startPromise 保留),
+    // 后续 request 直接复用, 不重新 spawn。
+    const createTransport = vi.fn(() => new DelayedTransport(60));
+    const host = new AppServerHost({
+      createTransport,
+      logger,
+      clientInfo: { name: 'cindy-test', version: '0.0.0' },
+    });
+
+    await expect(host.request('turn/start', {}, { timeoutMs: 20 })).rejects.toThrow(
+      /app-server startup.*timed out/,
+    );
+
+    // 后台 bootstrap (60ms) 完成后, 同一个 startPromise 直接可用。
+    await expect(host.request('turn/start', {}, { timeoutMs: 1_000 })).resolves.toMatchObject({
+      userAgent: 'mock-codex/test',
+    });
+    expect(createTransport).toHaveBeenCalledTimes(1);
+
+    await host.shutdown();
+  });
+});

--- a/packages/maker-core/src/agents/codex/app-server/host.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.test.ts
@@ -140,3 +140,28 @@ describe('AppServerHost.request startup timeout', () => {
     await host.shutdown();
   });
 });
+
+describe('AppServerHost.ensureStartedWithTimeout', () => {
+  it('rejects when startup hangs past the budget and keeps the shared bootstrap reusable (codex R13 P1)', async () => {
+    // startSession 的 initialize 直调与 request() 的 startup deadline 同款语义:
+    // 超时只截断本次等待, startPromise 后台继续, 后续调用直接复用不重新 spawn。
+    const createTransport = vi.fn(() => new DelayedTransport(60));
+    const host = new AppServerHost({
+      createTransport,
+      logger,
+      clientInfo: { name: 'cindy-test', version: '0.0.0' },
+    });
+
+    await expect(host.ensureStartedWithTimeout(20, 'startSession initialize')).rejects.toThrow(
+      'app-server startup (for startSession initialize) timed out after 20ms',
+    );
+
+    // 后台 bootstrap (60ms) 完成后, 同一个 startPromise 直接可用。
+    await expect(host.ensureStartedWithTimeout(1_000, 'startSession initialize')).resolves.toMatchObject({
+      userAgent: 'mock-codex/test',
+    });
+    expect(createTransport).toHaveBeenCalledTimes(1);
+
+    await host.shutdown();
+  });
+});

--- a/packages/maker-core/src/agents/codex/app-server/host.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.test.ts
@@ -118,4 +118,25 @@ describe('AppServerHost.request startup timeout', () => {
 
     await host.shutdown();
   });
+
+  it('treats timeoutMs as an overall deadline across startup + request (copilot R9)', async () => {
+    // timeoutMs 不是「startup 一次 + request 再一次」的双重施加: startup 用掉
+    // 的预算要从 request 里扣, 最坏等待仍是 1× timeoutMs — 否则 60s 关键 RPC
+    // 在冷启动路径上最坏拖到 ~120s, UI 长时间卡 generating。
+    // DelayedTransport(40): startup ~40ms, 预算 50ms → request 只剩 ~10ms。
+    // 1× 语义 ~50ms 超时; 2× 语义要 ~90ms (40 + 50) 才超时。
+    const host = new AppServerHost({
+      createTransport: () => new DelayedTransport(40),
+      logger,
+      clientInfo: { name: 'cindy-test', version: '0.0.0' },
+    });
+
+    const startedAt = Date.now();
+    await expect(host.request('turn/start', {}, { timeoutMs: 50 })).rejects.toThrow(
+      /timed out after \d+ms|consumed the entire/,
+    );
+    expect(Date.now() - startedAt).toBeLessThan(70);
+
+    await host.shutdown();
+  });
 });

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -309,6 +309,38 @@ export class AppServerHost {
     return this.startPromise;
   }
 
+  /**
+   * ensureStarted 的限时变体 (codex R13 P1): startSession 直调路径用。
+   * 冷启动 / transport 重建时 bootstrap 也可能永不返回 (远端 daemon 挂死 /
+   * SSH 通道无响应) — request() 的关键 RPC 已带 startup+request 整体
+   * deadline, 但 startSession 的 initialize 直调绕开了它, 需要同款上界,
+   * 否则 UI 无限卡 session 初始化。
+   *
+   * 与 request() 内 startup deadline 同款语义: 超时只 reject 本次等待,
+   * startPromise 后台继续 (并发共享, 下次调用可直接复用其结果), 挂
+   * swallow catch 防迟到 settle 变 unhandled rejection。
+   */
+  async ensureStartedWithTimeout(timeoutMs: number, label: string): Promise<InitializeResponse> {
+    const started = this.ensureStarted();
+    let timer: NodeJS.Timeout | null = null;
+    try {
+      return await Promise.race([
+        started,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error(`app-server startup (for ${label}) timed out after ${timeoutMs}ms`));
+          }, timeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    } catch (err) {
+      started.catch(() => { /* late startup failure swallowed after timeout */ });
+      throw err;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
   private async bootstrap(capabilities?: InitializeCapabilities): Promise<InitializeResponse> {
     const client = new AppServerClient({
       createTransport: this.opts.createTransport,

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -494,7 +494,33 @@ export class AppServerHost {
     params?: unknown,
     opts?: { timeoutMs?: number },
   ): Promise<R> {
-    await this.ensureStarted();
+    // 冷启动 / transport 重建时 ensureStarted 本身也可能永不返回 (远端 daemon
+    // bootstrap 挂死 / SSH 通道无响应) — 调用方显式给 timeoutMs 时同样给它
+    // 上界, 否则「关键 RPC 加超时」在启动路径上形同虚设 (greptile R6 P1)。
+    const started = this.ensureStarted();
+    if (opts?.timeoutMs != null) {
+      let timer: NodeJS.Timeout | null = null;
+      try {
+        await Promise.race([
+          started,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              reject(new Error(`app-server startup (for ${method}) timed out after ${opts.timeoutMs}ms`));
+            }, opts.timeoutMs);
+            timer.unref?.();
+          }),
+        ]);
+      } catch (err) {
+        // 超时后 started 仍在后台继续 (下次 request 可直接复用) — 挂一个
+        // swallow catch 防它迟到 reject 时变成 unhandled rejection。
+        started.catch(() => { /* late startup failure swallowed after timeout */ });
+        throw err;
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    } else {
+      await started;
+    }
     if (!this.client) throw new Error('AppServerHost: client missing after ensureStarted (unreachable)');
     return this.client.request<R>(method, params, opts);
   }

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -497,8 +497,12 @@ export class AppServerHost {
     // 冷启动 / transport 重建时 ensureStarted 本身也可能永不返回 (远端 daemon
     // bootstrap 挂死 / SSH 通道无响应) — 调用方显式给 timeoutMs 时同样给它
     // 上界, 否则「关键 RPC 加超时」在启动路径上形同虚设 (greptile R6 P1)。
+    // timeoutMs 是 startup + request 的整体 deadline (copilot R9): startup 用掉
+    // 的预算从 request 里扣, 否则最坏等 2× timeoutMs, 与「关键 RPC 60s 上界」
+    // 的意图冲突, UI 仍可能长时间卡 generating。
     const started = this.ensureStarted();
     if (opts?.timeoutMs != null) {
+      const deadline = Date.now() + opts.timeoutMs;
       let timer: NodeJS.Timeout | null = null;
       try {
         await Promise.race([
@@ -518,9 +522,14 @@ export class AppServerHost {
       } finally {
         if (timer) clearTimeout(timer);
       }
-    } else {
-      await started;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(`app-server startup (for ${method}) consumed the entire ${opts.timeoutMs}ms timeout budget`);
+      }
+      if (!this.client) throw new Error('AppServerHost: client missing after ensureStarted (unreachable)');
+      return this.client.request<R>(method, params, { ...opts, timeoutMs: remaining });
     }
+    await started;
     if (!this.client) throw new Error('AppServerHost: client missing after ensureStarted (unreachable)');
     return this.client.request<R>(method, params, opts);
   }

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -484,6 +484,10 @@ export class AppServerHost {
   /**
    * 透传 JSON-RPC request 到底层 client (会先 ensureStarted)。
    * thread/start / turn/start / turn/interrupt / thread/resume / thread/fork 都走这里。
+   *
+   * `opts.timeoutMs` 按需传入: 裸 RPC 默认**无超时** (协议上 response 可能任意晚),
+   * 但 turn/start 这类「daemon 失联就永远挂住」的关键路径应显式给上限 —
+   * 超时 reject 后上层按 turn 启动失败收口, 而不是让 UI 无限 generating。
    */
   async request<R = unknown>(
     method: string,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -7386,6 +7386,140 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('rejects a late orphan server request after the replacement turn was accepted (codex R17 P1)', async () => {
+    // 替换 turn 已被接受 (currentTurnId 非 null): 孤儿迟到的审批请求既不是
+    // idle 也不是 buffered, gate 必须直接拒 — 否则为隐藏孤儿 turn 上 UI。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-late-orphan-request-accepted',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const interactionResolver = vi.fn(() => new Promise<never>(() => {}));
+    handle.setInteractionResolver(interactionResolver);
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // send2 正常激活 turn-2 (started 缓冲 → 响应一致 → 激活)。
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+
+    // 孤儿 approval 迟到 (currentTurnId=turn-2 非 null): 直接拒, UI 未被调。
+    await expect(
+      handlers.commandExecutionApproval?.({
+        threadId: 'start-thread-id',
+        turnId: 'orphan-turn',
+        itemId: 'o-item',
+        command: 'rm -rf /tmp/x',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+    expect(interactionResolver).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
+  it('settles a held server request when the send is cancelled at the after-turn/start boundary (codex R17 P2)', async () => {
+    // 挂起的 waiter 在 send 本地取消边界 (turn/start 响应到了但 session 已
+    // closed) 必须被统一释放 — 否则 handler 永远悬挂, dispatchServerRequest
+    // 永不返回。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-held-request-cancelled',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const interactionResolver = vi.fn(() => new Promise<never>(() => {}));
+    handle.setInteractionResolver(interactionResolver);
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // send2 在飞 + buffered started + 审批挂起。
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    const approvalPromise = handlers.commandExecutionApproval?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      itemId: 'item-1',
+      command: 'ls',
+      cwd: '/repo',
+    });
+    await Promise.resolve();
+    expect(interactionResolver).not.toHaveBeenCalled();
+
+    // session close → turn/start 响应才到: 本地取消边界命中, 挂起请求按
+    // decline 统一释放 (不再悬挂)。
+    await handle.close();
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await expect(approvalPromise).resolves.toEqual({ decision: 'decline' });
+    expect(interactionResolver).not.toHaveBeenCalled();
+  });
+
   it('does not escalate rate-limit backoff retries to a terminal backend-unreachable error (codex R12 P2)', async () => {
     // 429 / usage-limit 的 willRetry 是 provider 退避窗口, daemon 会在窗口后
     // 自己成功 — 不得计入 retry 升级, 否则可恢复的限流被误杀成「后端不可达」。

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6162,11 +6162,63 @@ describe('CodexAgent turn lifecycle', () => {
     });
     expect(handle.isTurnRunning?.()).toBe(false);
 
+    // 升级时补 turn/interrupt (review: PR #715 五轮审核 P1) — daemon 侧原 turn
+    // 不得继续空转烧远端资源 / 撞下一轮 send 的新 turn。
+    await vi.waitFor(() => {
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnInterrupt,
+        expect.objectContaining({ threadId: 'start-thread-id', turnId: 'turn-1' }),
+      );
+    });
+
     // 升级后晚到的 turnCompleted 不得重复发终态事件 (墓碑路径)。
     handlers.turnCompleted?.({
       threadId: 'start-thread-id',
       turn: { id: 'turn-1', status: 'failed', error: { message: 'x' } },
     });
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+    await handle.close();
+  });
+
+  it('does NOT escalate an invalid-credential retry-loop either (auth-related, review P1)', async () => {
+    // invalid_api_key / authentication_error 这类「凭证无效」错误没有 401 字面,
+    // 但 translator 同样按 auth UX 分类 — 升级判定必须排除同一集合, 否则会被
+    // 误升级成「后端不可达」(提示用户去查网络/代理, 方向全错)。
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-auth-related-no-escalation',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1' },
+    });
+    const invalidKeyError = {
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      willRetry: true,
+      error: { message: 'authentication_error: invalid_api_key — key revoked' },
+    } as const;
+    for (let i = 0; i < 35; i += 1) {
+      handlers.error?.(invalidKeyError);
+    }
+    // auth UX 透出 (isTerminal:false), 但不升级终态、不发 interrupt。
+    const first = await nextEvent(iterator);
+    expect(first).toMatchObject({
+      type: 'error',
+      data: { isTerminal: false },
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(host.request).not.toHaveBeenCalledWith(
+      Method.TurnInterrupt,
+      expect.anything(),
+    );
     await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
     await handle.close();
   });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4360,6 +4360,34 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('preserves the reviewer route for default remote sessions via the host effective mode (codex R17 P1)', async () => {
+    // Settings 创建的默认远程 session: 无 providerId + 无前缀 model,
+    // resolveAgentCredentialMode 解析为 undefined — 必须兜底到 host 创建时
+    // 登记的 effective mode (auth fallback 的实际钥匙), 否则远程订阅用户
+    // 的 reviewer 仍被回退 (默认值路径正是大多数用户的路径)。
+    const agent = new CodexAgent(createDeps());
+    (agent as unknown as { hostEffectiveCredentialModes: Map<string, string> })
+      .hostEffectiveCredentialModes.set('remote:gpu-box', 'oauth-bearer');
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-remote-default-auto',
+      model: 'gpt-5.5-codex',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+      remoteHostId: 'gpu-box',
+    });
+
+    const startParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+    };
+    expect(startParams).toMatchObject({
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'auto_review',
+    });
+    await handle.close();
+  });
+
   it('maps auto permission mode to Codex built-in automatic approval review', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4313,6 +4313,53 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('enables the built-in reviewer for remote OAuth-subscription sessions (Auto)', async () => {
+    // 远程 daemon 用的是 auth sync 推过去的同一份订阅凭证, reviewer 调用
+    // 发生在 daemon 本地 — 订阅下与本地同构, 不再一律回退 untrusted。
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-remote-oauth-auto',
+      model: 'gpt-5.4',
+      providerId: 'openai',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+      remoteHostId: 'gpu-box',
+    });
+
+    const startParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+    };
+    expect(startParams).toMatchObject({
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'auto_review',
+    });
+    await handle.close();
+  });
+
+  it('falls back to untrusted for remote non-subscription sessions (Auto)', async () => {
+    // gateway / 第三方 provider 的 reviewer 模型路由仍未验证 — 远程同样回退。
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-remote-gateway-auto',
+      model: 'codex/gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+      remoteHostId: 'gpu-box',
+    });
+
+    const startParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+    };
+    expect(startParams.approvalPolicy).toBe('untrusted');
+    expect(startParams).not.toHaveProperty('approvalsReviewer');
+    await handle.close();
+  });
+
   it('maps auto permission mode to Codex built-in automatic approval review', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -7290,6 +7290,55 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('rejects an idle orphan server request after a failed turn/start (greptile R16 P1)', async () => {
+    // 守卫立 + 无新 send (idle: 无 pending, currentTurnId===null): 孤儿 turn
+    // 的审批请求到达 — 没有 RPC 在飞可等对账, 直接拒 (不挂起), 不上 UI;
+    // 用户响应若放行会发往旧 turn, interrupt 输竞态时操作真实执行。
+    const firstStart = deferred<unknown>();
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return firstStart.promise;
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-idle-orphan-request',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const interactionResolver = vi.fn(() => new Promise<never>(() => {}));
+    handle.setInteractionResolver(interactionResolver);
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // idle: 孤儿 approval 到达 → 直接 decline, UI 未被调。
+    await expect(
+      handlers.commandExecutionApproval?.({
+        threadId: 'start-thread-id',
+        turnId: 'orphan-turn',
+        itemId: 'o-item',
+        command: 'rm -rf /tmp/x',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+    expect(interactionResolver).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
   it('does not escalate rate-limit backoff retries to a terminal backend-unreachable error (codex R12 P2)', async () => {
     // 429 / usage-limit 的 willRetry 是 provider 退避窗口, daemon 会在窗口后
     // 自己成功 — 不得计入 retry 升级, 否则可恢复的限流被误杀成「后端不可达」。

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6526,6 +6526,216 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('replays a buffered terminal error on reconcile so the send settles instead of hanging (greptile R11 P1)', async () => {
+    // 合法 turn 的 started 先于响应到达并进缓冲, 缓冲期间 daemon 直接发了
+    // terminal error: 直接丢弃会把尸体 turn 激活成 in-flight, send 永久卡
+    // generating — 终态必须缓存, 对账确认合法后重放收口。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-terminal-error',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    // 第一次 send 失败立孤儿守卫。
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // 第二次 send: 自己的 started 先到进缓冲; 缓冲期间 daemon 直接 terminal error。
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    handlers.error?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      scope: 'turn',
+      willRetry: false,
+      error: { message: 'instant backend failure' },
+    });
+    // 缓冲期间终态不出事件 (缓存等响应)。
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    // 响应 id 一致 → 合法: 重放 terminal error → send 收口 (error + Done),
+    // 尸体 turn 不被激活, 也不吃 interrupt。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'error',
+      data: { message: 'instant backend failure', isTerminal: true },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+    expect(host.request.mock.calls.some(([method]) => method === Method.TurnInterrupt)).toBe(false);
+    await handle.close();
+  });
+
+  it('replays a buffered turnCompleted on reconcile so the send settles instead of hanging (greptile R11 P1)', async () => {
+    // 合法 turn 缓冲期间 daemon 直接完成 (极快 turn / started-before-resp 后
+    // 立即 completed): completed 缓存, 对账一致后重放 — send 收 Done+done
+    // 收口, 尸体 turn 不被激活 (重放自动记墓碑挡住激活路径)。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-completed',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    handlers.turnCompleted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2', status: 'completed' } });
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    // 重放 completed → status Done + done 事件收口; 尸体 turn 不激活。
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'done' });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+    await handle.close();
+  });
+
+  it('discards buffered terminal events once the response proves the turn an orphan (greptile R11 P1)', async () => {
+    // 缓冲期间孤儿 turn 的 terminal error + completed 都进缓存; 响应 id 不同
+    // → 缓存丢弃 + 墓碑 + interrupt; send2 不被孤儿终态收口, 响应的 turn
+    // 正常激活 (R10 隔离语义不被重放机制破坏)。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-orphan-terminal',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'orphan-turn' } });
+    handlers.error?.({
+      threadId: 'start-thread-id',
+      turnId: 'orphan-turn',
+      scope: 'turn',
+      willRetry: false,
+      error: { message: 'orphan failure' },
+    });
+    handlers.turnCompleted?.({ threadId: 'start-thread-id', turn: { id: 'orphan-turn', status: 'failed' } });
+    // 孤儿终态全在缓存里, 事件流无输出。
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+
+    // 响应 turn-2 ≠ orphan-turn → 孤儿终态随缓存一并丢弃: 墓碑 + interrupt,
+    // turn-2 正常激活, send2 不被提前收口。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await vi.waitFor(() => {
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnInterrupt,
+        expect.objectContaining({ threadId: 'start-thread-id', turnId: 'orphan-turn' }),
+      );
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    await handle.close();
+  });
+
   it('clears running state and emits done status after terminal error notification', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6438,6 +6438,8 @@ describe('CodexAgent turn lifecycle', () => {
       if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
       await Promise.resolve();
     }
+    // send2 开头的 turn-start status 先消费掉, 后续事件流才只反映通知路径。
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
     handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'orphan-turn' } });
     expect(handle.isTurnRunning?.()).toBe(false);
     expect(handle.getCurrentTurnId?.()).toBeNull();
@@ -6447,6 +6449,15 @@ describe('CodexAgent turn lifecycle', () => {
           method === Method.TurnInterrupt && (params as { turnId?: string }).turnId === 'orphan-turn',
       ),
     ).toBe(false);
+
+    // 缓冲期间孤儿 turn 的 item/error 事件不得穿透到本次 send 的事件流
+    // (greptile R10 P1): stale guard 把 buffered id 一并隔离。
+    handlers.itemStarted?.({
+      threadId: 'start-thread-id',
+      turnId: 'orphan-turn',
+      item: { type: 'agentMessage', id: 'orphan-item', text: 'orphan output' },
+    });
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
 
     // 第二次响应 turn-2 ≠ orphan-turn → 孤儿坐实: interrupt + 墓碑; turn-2 激活。
     secondStart.resolve({ turn: { id: 'turn-2' } });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6736,6 +6736,185 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('replays early item events of a valid buffered turn after the response accepts it (codex R12 P1)', async () => {
+    // 合法 turn 的 started 先于响应进缓冲, 缓冲期间 daemon 已开始产出
+    // (itemStarted): 事件进队列, 响应 id 一致 → 激活后按序重放 — 早期输出
+    // 不永久丢失 (只缓存终态会把 turn 的开头段丢掉)。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-early-events',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    handlers.itemStarted?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: { type: 'agentMessage', id: 'early-item', text: 'early output' },
+    });
+    // 缓冲期间不进事件流 (R10 隔离语义保持)。
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    // 激活后重放: 早期 item 事件出现在事件流, turn 正常在跑。
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Generating...' },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'text',
+      data: { text: 'early output', isFinal: false },
+    });
+    await handle.close();
+  });
+
+  it('holds a buffered turn approval request and declines it once the response proves the turn an orphan (codex R12 P1)', async () => {
+    // 孤儿 turn 在对账前发审批请求: 请求挂起不上 UI; 响应证明孤儿 →
+    // 按 decline 释放 — 用户不能为隐藏 turn 批准操作。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-approval',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const interactionResolver = vi.fn(() => new Promise<never>(() => {}));
+    handle.setInteractionResolver(interactionResolver);
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'orphan-turn' } });
+    const approvalPromise = handlers.commandExecutionApproval?.({
+      threadId: 'start-thread-id',
+      turnId: 'orphan-turn',
+      itemId: 'orphan-item',
+      command: 'rm -rf /tmp/x',
+      cwd: '/repo',
+    });
+    // 挂起期间不上 UI。
+    await Promise.resolve();
+    expect(interactionResolver).not.toHaveBeenCalled();
+
+    // 响应证明孤儿 → 审批按 decline 释放, UI 自始至终没被调用。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await expect(approvalPromise).resolves.toEqual({ decision: 'decline' });
+    expect(interactionResolver).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
+  it('does not escalate rate-limit backoff retries to a terminal backend-unreachable error (codex R12 P2)', async () => {
+    // 429 / usage-limit 的 willRetry 是 provider 退避窗口, daemon 会在窗口后
+    // 自己成功 — 不得计入 retry 升级, 否则可恢复的限流被误杀成「后端不可达」。
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-rate-limit-backoff',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      remoteHostId: 'gpu-box',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1' },
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    // 超过升级阈值 (30 次) 的 429 willRetry — 不升级, turn 持续在跑。
+    const rateLimited = {
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      willRetry: true,
+      error: { message: 'unexpected status 429 Too Many Requests, url: https://chatgpt.com/backend-api/codex/responses' },
+    } as const;
+    for (let i = 0; i < 32; i += 1) {
+      handlers.error?.(rateLimited);
+    }
+    // 第 2 次仍会透出一条非终态提示 (networkRetryNotice 机制不受排除影响)。
+    const notice = await nextEvent(iterator);
+    expect(notice).toMatchObject({
+      type: 'error',
+      data: { isTerminal: false, willRetry: true },
+    });
+    // 无终态事件 — 事件流安静, turn 仍在跑。
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+    expect(handle.isTurnRunning?.()).toBe(true);
+    await handle.close();
+  });
+
   it('clears running state and emits done status after terminal error notification', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -1550,7 +1550,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     });
 
     await waitForExpectation(() => {
-      expect(host.request).toHaveBeenCalledWith(Method.ThreadStart, expect.anything());
+      expect(host.request).toHaveBeenCalledWith(Method.ThreadStart, expect.anything(), expect.objectContaining({ timeoutMs: expect.any(Number) }));
     });
 
     const guard = await agent.beginLocalHostCredentialChange('test credential change');
@@ -1845,6 +1845,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
       expect.objectContaining({
         threadId: '123e4567-e89b-12d3-a456-426614174000',
       }),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );
     const resumeParams = host.request.mock.calls.find(([method]) => method === Method.ThreadResume)?.[1] as {
       developerInstructions?: string;
@@ -2291,6 +2292,7 @@ describe('CodexAgent send', () => {
       expect.objectContaining({
         effort: 'low',
       }),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );
     await handle.close();
   });
@@ -2314,6 +2316,7 @@ describe('CodexAgent send', () => {
         expect.objectContaining({
           effort: 'minimal',
         }),
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
       );
       await handle.close();
     },
@@ -2336,6 +2339,7 @@ describe('CodexAgent send', () => {
       expect.objectContaining({
         effort: 'medium',
       }),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );
     await handle.close();
   });
@@ -2357,6 +2361,7 @@ describe('CodexAgent send', () => {
       expect.objectContaining({
         effort: 'max',
       }),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );
     await handle.close();
   });
@@ -2378,6 +2383,7 @@ describe('CodexAgent send', () => {
       expect.objectContaining({
         effort: 'ultra',
       }),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );
     await handle.close();
   });
@@ -2401,6 +2407,7 @@ describe('CodexAgent send', () => {
       expect.objectContaining({
         effort: 'low',
       }),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );
     await handle.close();
   });
@@ -2430,6 +2437,7 @@ describe('CodexAgent send', () => {
         expect.objectContaining({
           effort: 'minimal',
         }),
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
       );
       await handle.close();
     },
@@ -6096,6 +6104,110 @@ describe('CodexAgent rewind', () => {
 });
 
 describe('CodexAgent turn lifecycle', () => {
+  it('escalates a persistent willRetry retry-loop to a terminal error (issue #677)', async () => {
+    // 远端摸不到 Codex 后端时 daemon 无限发 willRetry=true — 升级逻辑应在阈值处
+    // 合成终态错误并复位 turn (isTurnRunning=false + Done status), 消息里带原始
+    // 末次错误与 SSH 代理隧道提示 (session 带 remoteHostId)。
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-retry-escalation',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      remoteHostId: 'gpu-box',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    expect(handlers).toBeDefined();
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1' },
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    const willRetryError = {
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      willRetry: true,
+      error: { message: 'unexpected status 403 Forbidden, url: https://chatgpt.com/backend-api/codex/responses' },
+    } as const;
+    // 第 1 次 silent, 第 2 次透一条非终止提示, 之后静默直到升级阈值 (30 次)。
+    handlers.error?.(willRetryError);
+    handlers.error?.(willRetryError);
+    const notice = await nextEvent(iterator);
+    expect(notice).toMatchObject({
+      type: 'error',
+      data: { isTerminal: false, willRetry: true },
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    for (let i = 0; i < 28; i += 1) {
+      handlers.error?.(willRetryError);
+    }
+    // 第 30 次触发升级: 终态 error + Done status, turn 复位。
+    const terminalError = await nextEvent(iterator);
+    expect(terminalError.type).toBe('error');
+    const terminalData = terminalError.data as { message: string; isTerminal: boolean };
+    expect(terminalData.isTerminal).toBe(true);
+    expect(terminalData.message).toContain('Codex backend unreachable');
+    expect(terminalData.message).toContain('gpu-box');
+    expect(terminalData.message).toContain('403 Forbidden');
+    expect(terminalData.message).toContain('Route agent traffic via local proxy');
+    const statusEvent = await nextEvent(iterator);
+    expect(statusEvent).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    // 升级后晚到的 turnCompleted 不得重复发终态事件 (墓碑路径)。
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'failed', error: { message: 'x' } },
+    });
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+    await handle.close();
+  });
+
+  it('does NOT escalate an auth-missing retry-loop (has its own sync-auth UX)', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-auth-no-escalation',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      remoteHostId: 'gpu-box',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1' },
+    });
+    const authError = {
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      willRetry: true,
+      error: { message: 'unexpected status 401 Unauthorized: Missing bearer' },
+    } as const;
+    // auth retry-loop: 第一条透出 (等待式 sync UX), 其余 dedupe; 超阈值也不升级。
+    for (let i = 0; i < 35; i += 1) {
+      handlers.error?.(authError);
+    }
+    const first = await nextEvent(iterator);
+    expect(first).toMatchObject({
+      type: 'error',
+      data: { isTerminal: false, willRetry: true },
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+    await handle.close();
+  });
+
   it('clears running state and emits done status after terminal error notification', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6323,6 +6323,73 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('clears an accepted started-before-resp turn when turn/start later fails (greptile R6 P1)', async () => {
+    // started-before-resp 是协议允许的乱序: turnStarted 先于响应到达并被接受
+    // (currentTurnId/isTurnInFlight 置位) — 随后 turn/start RPC 失败时, 失败收口
+    // 必须把这个活跃 turn 一起收掉, 否则 UI 已 Done 但 isTurnRunning() 永真,
+    // 下一条 send 被 in-flight guard 挡死。
+    const turnStart = deferred<unknown>();
+    let failTurnStart = true;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        if (failTurnStart) return turnStart.promise;
+        return { turn: { id: 'turn-2' } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-started-before-resp-failure',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const sendPromise = handle.send({ type: 'user', content: 'hello' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(1);
+
+    // started-before-resp: turnStarted 先于响应到达并被接受, turn 状态置位。
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'early-turn' } });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('early-turn');
+
+    // turn/start 随后失败 → 失败收口把活跃 turn 一起收掉: 清状态 + 补 interrupt。
+    turnStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await sendPromise;
+
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+    await vi.waitFor(() => {
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnInterrupt,
+        expect.objectContaining({ threadId: 'start-thread-id', turnId: 'early-turn' }),
+      );
+    });
+
+    // 该 turn 已立墓碑: 迟到的 turnCompleted 被挡, 不产生 UI 事件。
+    handlers.turnCompleted?.({ threadId: 'start-thread-id', turn: { id: 'early-turn', status: 'completed' } });
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+
+    // 下一条 send 不被 in-flight guard 挡死, turn 正常激活。
+    failTurnStart = false;
+    await handle.send({ type: 'user', content: 'again' });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    await handle.close();
+  });
+
   it('clears running state and emits done status after terminal error notification', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -7177,6 +7177,119 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('quarantines idle orphan turn events after a failed turn/start (codex R15 P1)', async () => {
+    // 守卫立 + 无新 send (idle: 无 pending, currentTurnId===null): 孤儿 turn 的
+    // item/completed 到达 — 预缓冲只对 pending 窗口生效, idle 时未知 id 必须
+    // 直接当孤儿拦 (立墓碑), 否则 item 穿透渲染 / completed 走
+    // currentTurnId===null 的收口分支 emit 假 done。
+    const firstStart = deferred<unknown>();
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return firstStart.promise;
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-idle-orphan-events',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // idle 状态 (无 send 在飞): 孤儿 item/completed 到达, 全部被拦。
+    handlers.itemStarted?.({
+      threadId: 'start-thread-id',
+      turnId: 'orphan-turn',
+      item: { type: 'agentMessage', id: 'o-item', text: 'orphan output' },
+    });
+    handlers.turnCompleted?.({ threadId: 'start-thread-id', turn: { id: 'orphan-turn', status: 'completed' } });
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+    await handle.close();
+  });
+
+  it('holds a server request that arrives before the orphan turnStarted (codex R15 P1)', async () => {
+    // 孤儿 turn 的审批请求先于它的 turnStarted 到达: id 未入 buffer, gate
+    // 不得放行上 UI — 与 notification 预缓冲同款, 挂起到对账, 证明孤儿后
+    // 按 decline 释放。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-early-orphan-request',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const interactionResolver = vi.fn(() => new Promise<never>(() => {}));
+    handle.setInteractionResolver(interactionResolver);
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    // 孤儿 approval 先到 (它的 turnStarted 尚未到达): 挂起不上 UI。
+    const approvalPromise = handlers.commandExecutionApproval?.({
+      threadId: 'start-thread-id',
+      turnId: 'orphan-turn',
+      itemId: 'o-item',
+      command: 'rm -rf /tmp/x',
+      cwd: '/repo',
+    });
+    await Promise.resolve();
+    expect(interactionResolver).not.toHaveBeenCalled();
+
+    // 响应 turn-2 ≠ orphan-turn → 孤儿坐实: 审批按 decline 释放。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await expect(approvalPromise).resolves.toEqual({ decision: 'decline' });
+    expect(interactionResolver).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
   it('does not escalate rate-limit backoff retries to a terminal backend-unreachable error (codex R12 P2)', async () => {
     // 429 / usage-limit 的 willRetry 是 provider 退避窗口, daemon 会在窗口后
     // 自己成功 — 不得计入 retry 升级, 否则可恢复的限流被误杀成「后端不可达」。
@@ -8545,6 +8658,40 @@ describe('CodexAgent plan mode', () => {
       turn: { id: turnId, status: 'completed' },
     });
   }
+
+  it('keeps a stored proposed plan across a duplicate turnStarted for the same turn (codex R15 P1)', async () => {
+    // plan item 已被 intercept 存 proposedPlanText 后, 同 id 的晚到/重复
+    // turnStarted 不得清空 (wasSameTurn) — 否则 turnCompleted 时 plan_review
+    // 丢失 (buffered turn 的 item 先重放、started 后到的乱序会踩中)。
+    const agent = new CodexAgent(createDeps());
+    const host = installTurnHost(agent);
+    const handle = await startPlanSession(agent, host, 'session-plan-dup-started');
+    const seen: unknown[] = [];
+    handle.setInteractionResolver(async (req) => {
+      seen.push(req);
+      return { kind: 'plan_review', behavior: 'allow' };
+    });
+    await handle.send({ type: 'user', content: 'make a plan' });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-1' } });
+    handlers.itemCompleted?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: { type: 'plan', id: 'turn-1-plan', text: '1. do X\n2. do Y' },
+    } as never);
+    // 同 id 的重复 started (晚到): 不得清掉已存的 plan。
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-1' } });
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(seen.length).toBeGreaterThan(0);
+    });
+    expect(seen[0]).toMatchObject({ kind: 'plan_review', plan: '1. do X\n2. do Y' });
+    await handle.close();
+  });
 
   it('carries collaborationMode plan on turn/start and omits it for normal sessions', async () => {
     const agent = new CodexAgent(createDeps());

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6872,6 +6872,83 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('settles a held user-input request as empty when the server resolves it during the reconcile window (greptile R13 P1)', async () => {
+    // buffered turn 的 requestUserInput 挂起到对账; 挂起期间服务端发
+    // serverRequest/resolved 取消该请求 (broker 未注册, cancel 不命中) —
+    // 对账放行后 handler 必须直接回空响应, 不上 UI 等一个已结束的交互
+    // (否则用户提交会向已结束请求发迟到响应)。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-resolved-input',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const interactionResolver = vi.fn(() => new Promise<never>(() => {}));
+    handle.setInteractionResolver(interactionResolver);
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    const inputPromise = handlers.requestUserInput?.(
+      {
+        threadId: 'start-thread-id',
+        turnId: 'turn-2',
+        itemId: 'item-1',
+        questions: [{
+          id: 'q1',
+          header: 'Mode',
+          question: 'Which mode should Codex use?',
+          isOther: false,
+          isSecret: false,
+          options: [{ label: 'Fast', description: 'Move quickly' }],
+        }],
+      },
+      { requestId: 'req-held' },
+    );
+    // 挂起期间服务端取消该请求 (broker 未注册 → cancel 不命中, 记入 resolved 集合)。
+    handlers.serverRequestResolved?.({ threadId: 'start-thread-id', requestId: 'req-held' });
+
+    // 对账合法 → gate 放行 → handler 发现请求已被服务端取消 → 直接空响应,
+    // 全程不上 UI。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await expect(inputPromise).resolves.toEqual({ answers: {} });
+    expect(interactionResolver).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
   it('does not escalate rate-limit backoff retries to a terminal backend-unreachable error (codex R12 P2)', async () => {
     // 429 / usage-limit 的 willRetry 是 provider 退避窗口, daemon 会在窗口后
     // 自己成功 — 不得计入 retry 升级, 否则可恢复的限流被误杀成「后端不可达」。

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -7033,6 +7033,150 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('quarantines an orphan terminal error that arrives before its turnStarted (codex R14 P1)', async () => {
+    // 孤儿 turn 的终态 error 可以比它的 turnStarted 先到: id 尚未入 buffer,
+    // 若只按 buffered 集合拦截会穿透 (targetsPendingTurn=true 被按在飞 send
+    // 的终态处理, 终结合法的新 send) — 孤儿守卫 + pending + 无活跃 turn 时
+    // 未知 id 的 error 视同 started 预缓冲, 等对账。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-orphan-error-first',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    // 孤儿 turn 的 terminal error 先于它的 turnStarted 到达: 预缓冲, 不穿透。
+    handlers.error?.({
+      threadId: 'start-thread-id',
+      turnId: 'orphan-turn',
+      scope: 'turn',
+      willRetry: false,
+      error: { message: 'orphan turn died server-side' },
+    });
+    // send2 不被终结: 事件流安静, 无 error / Done 出来。
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+
+    // 响应 turn-2 ≠ orphan-turn → 孤儿坐实: 墓碑 + interrupt; turn-2 激活。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await vi.waitFor(() => {
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnInterrupt,
+        expect.objectContaining({ threadId: 'start-thread-id', turnId: 'orphan-turn' }),
+      );
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    await handle.close();
+  });
+
+  it('keeps the orphan guard after a successful turn so a late orphan turnStarted is tombstoned (codex R14 P1)', async () => {
+    // 失败 RPC 的 turnStarted 可能在新 turn 完成后才到 (currentTurnId 已回
+    // null, 无 pending): 守卫若在成功响应时解除, 迟到的孤儿 started 会被
+    // 正常激活成假 running (会话永久卡) — 守卫保持, 按孤儿墓碑 + interrupt。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-late-orphan-started',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // 第二次 send 正常完成: started 缓冲 → 响应激活 → completed 收口。
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    handlers.turnCompleted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2', status: 'completed' } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+    await nextEvent(iterator); // done 事件
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+
+    // 失败 RPC 的孤儿 started 此刻才迟到: 守卫保持 → 墓碑 + interrupt,
+    // 不得激活成假 running。
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'orphan-turn' } });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+    await vi.waitFor(() => {
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnInterrupt,
+        expect.objectContaining({ threadId: 'start-thread-id', turnId: 'orphan-turn' }),
+      );
+    });
+    await handle.close();
+  });
+
   it('does not escalate rate-limit backoff retries to a terminal backend-unreachable error (codex R12 P2)', async () => {
     // 429 / usage-limit 的 willRetry 是 provider 退避窗口, daemon 会在窗口后
     // 自己成功 — 不得计入 retry 升级, 否则可恢复的限流被误杀成「后端不可达」。

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6208,6 +6208,69 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('ignores an orphan turnStarted after a failed turn/start and interrupts it server-side (greptile P1)', async () => {
+    // turn/start RPC 失败 (超时/拒绝) 不代表 server 没建 turn — daemon 实际
+    // 建了的 turn 迟到的 started 不得重新激活已报终态错误的会话。
+    let failTurnStart = true;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        if (failTurnStart) {
+          throw new Error('codex app-server turn/start timed out after 60000ms');
+        }
+        return { turn: { id: 'turn-2' } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-orphan-turnstarted',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    await handle.send({ type: 'user', content: 'hello' });
+    // send 开头先推 status isRunning:true, 然后才是 turn/start 失败的终态序列。
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { isRunning: true },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'error',
+      data: { isTerminal: true },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // daemon 实际建了 turn → 迟到 started: 立墓碑 + 补 interrupt, 不重新激活。
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'orphan-turn-id' },
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+    await vi.waitFor(() => {
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnInterrupt,
+        expect.objectContaining({ turnId: 'orphan-turn-id' }),
+      );
+    });
+    // 孤儿事件不再产生任何 UI 事件。
+    await expect(nextEvent(iterator)).rejects.toThrow('timed out waiting for event');
+
+    // 守卫不挡后续正常发送: 下一次 turn/start 成功后 turn 正常激活
+    // (handleTurnStartResp 清守卫标记并置 currentTurnId)。
+    failTurnStart = false;
+    await handle.send({ type: 'user', content: 'again' });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    await handle.close();
+  });
+
   it('clears running state and emits done status after terminal error notification', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6390,6 +6390,131 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('buffers an ambiguous turnStarted during a retry-pending window and interrupts it once the response proves it an orphan (codex R9 P2)', async () => {
+    // 第一次 turn/start 失败立孤儿守卫; 第二次 send 的 turn/start 在飞期间
+    // 第一次的迟到 started 到达 — 归属不明 (协议不带 request id), 必须缓冲
+    // 隔离而不是接受 (否则孤儿 item 事件渲染到第二次 send 下)。响应到了按
+    // turnId 对账: 不一致 → interrupt + 墓碑; 响应的 turn 正常激活。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-orphan-started',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    // 第一次 send → turn/start 悬挂 → 失败 (立孤儿守卫)。
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    // 第二次 send → turn/start 在飞 → 第一次的迟到 started 到达: 缓冲隔离,
+    // 既不激活也不立即 interrupt (归属未定)。
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'orphan-turn' } });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+    expect(
+      host.request.mock.calls.some(
+        ([method, params]) =>
+          method === Method.TurnInterrupt && (params as { turnId?: string }).turnId === 'orphan-turn',
+      ),
+    ).toBe(false);
+
+    // 第二次响应 turn-2 ≠ orphan-turn → 孤儿坐实: interrupt + 墓碑; turn-2 激活。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await vi.waitFor(() => {
+      expect(host.request).toHaveBeenCalledWith(
+        Method.TurnInterrupt,
+        expect.objectContaining({ threadId: 'start-thread-id', turnId: 'orphan-turn' }),
+      );
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    await handle.close();
+  });
+
+  it('activates a buffered turnStarted when the turn/start response returns the same id (codex R9 P2)', async () => {
+    // 同款 pending 窗口, 但到达的 started 就是在飞 RPC 自己的 (合法
+    // started-before-resp 与孤儿守卫共存): 缓冲期间不激活; 响应 id 一致 →
+    // 正常激活, 不发 interrupt。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-started-accepted',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    // 在飞 RPC 自己的 started 先到: 缓冲, 不立即激活。
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'early-turn' } });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.getCurrentTurnId?.()).toBeNull();
+
+    // 响应 id 一致 → 激活, 全程无 interrupt。
+    secondStart.resolve({ turn: { id: 'early-turn' } });
+    await send2;
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.getCurrentTurnId?.()).toBe('early-turn');
+    expect(
+      host.request.mock.calls.some(([method]) => method === Method.TurnInterrupt),
+    ).toBe(false);
+    await handle.close();
+  });
+
   it('clears running state and emits done status after terminal error notification', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -368,6 +368,9 @@ function installFakeHost(
   const getRemoteCompactionProviderId = vi.fn(() => opts.remoteCompactionProviderId ?? null);
   const host = {
     ensureStarted,
+    // startSession 的 initialize 直调走限时变体 (codex R13 P1): fake 里
+    // 直接委托 ensureStarted (超时语义由 host.test.ts 的真 transport 覆盖)。
+    ensureStartedWithTimeout: vi.fn(async (_timeoutMs: number, _label: string) => ensureStarted()),
     request,
     subscribeThread,
     unsubscribeThread,
@@ -6946,6 +6949,87 @@ describe('CodexAgent turn lifecycle', () => {
     await send2;
     await expect(inputPromise).resolves.toEqual({ answers: {} });
     expect(interactionResolver).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
+  it('rejects a held server request when the accepted turn was tombstoned by a replayed terminal event (codex R13 P2)', async () => {
+    // 合法 buffered turn 的 server request 挂起到对账, 但队列里还有该 turn
+    // 的 turnCompleted: 对账先 settle(true) 再重放 — 重放把 turn 当场收口,
+    // waiter 恢复时必须复查墓碑, 拒绝为一个刚死的 turn 上 UI。
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<unknown>();
+    let attempt = 0;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        if (attempt === 1) return firstStart.promise;
+        return secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-buffered-request-tombstoned',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const subscribeCalls = host.subscribeThread.mock.calls as unknown as Array<[string, ThreadEventHandlers]>;
+    const handlers = subscribeCalls[0]?.[1];
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const interactionResolver = vi.fn(() => new Promise<never>(() => {}));
+    handle.setInteractionResolver(interactionResolver);
+
+    const send1 = handle.send({ type: 'user', content: 'first' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+      await Promise.resolve();
+    }
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await send1;
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'error', data: { isTerminal: true } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+
+    const send2 = handle.send({ type: 'user', content: 'second' });
+    for (let i = 0; i < 5; i += 1) {
+      if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+      await Promise.resolve();
+    }
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status', data: { isRunning: true } });
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+    const inputPromise = handlers.requestUserInput?.(
+      {
+        threadId: 'start-thread-id',
+        turnId: 'turn-2',
+        itemId: 'item-1',
+        questions: [{
+          id: 'q1',
+          header: 'Mode',
+          question: 'Which mode should Codex use?',
+          isOther: false,
+          isSecret: false,
+          options: [{ label: 'Fast', description: 'Move quickly' }],
+        }],
+      },
+      { requestId: 'req-tombstoned' },
+    );
+    // 同一 turn 的 completed 也进缓冲 — 对账时重放会把 turn 收口。
+    handlers.turnCompleted?.({ threadId: 'start-thread-id', turn: { id: 'turn-2', status: 'completed' } });
+
+    // 对账: 激活 → settle(true) → 重放 completed (turn 收口) → waiter 恢复
+    // 复查墓碑 → 空响应拒绝, UI 不上; send 被重放的 completed 正常收口。
+    secondStart.resolve({ turn: { id: 'turn-2' } });
+    await send2;
+    await expect(inputPromise).resolves.toEqual({ answers: {} });
+    expect(interactionResolver).not.toHaveBeenCalled();
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'status',
+      data: { status: 'Done', isRunning: false },
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4165,7 +4165,9 @@ export class CodexAgent extends BaseAgent {
         // Reset auth retry-loop dedupe key — 让下一个 turn 重新可以 emit 第一条
         // auth error。详见 translator.translateErrorNotification dedupe 逻辑。
         translatorRt.lastAuthErrorKey = null;
-        // 网络类 retry-loop 透出状态同理:新 turn 重新计数,可再透出一条。
+        // 持续重试透出状态同理 (字段名沿旧称 networkRetryNotice, 实际已对任意
+        // 持续性 willRetry 错误透出, 不限 networkish — issue #677): 新 turn
+        // 重新计数, 可再透出一条。
         translatorRt.networkRetryNotice = null;
         // retry 升级计数同样按 turn 隔离 — 新 turn 从零计。
         turnRetryTracker.reset();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -79,7 +79,7 @@ import { scanCodexCustomizations } from './customization-scanner.js';
 import { commandExecutionDisplayInput } from './command-display.js';
 import {
   newCodexRuntimeState,
-  isAuthMissingErrorMessage,
+  isAuthRelatedErrorMessage,
   translateErrorNotification,
   translateItemNotification,
   translateReasoningSummaryTextDelta,
@@ -4340,15 +4340,32 @@ export class CodexAgent extends BaseAgent {
         // willRetry 不收口, 但持续性不可达 (403 / Network unreachable / timeout)
         // 意味着 retry 永远不会成功。同 turn 计数/时长超阈值后合成终态错误,
         // 落入下面与原生终态 error 完全相同的收口路径。
-        // auth 缺失 (401) 排除: 它有「同步登录态」的等待式 UX, 升级会抢走那个路径。
+        // auth 相关错误 (缺失 401 / 无效凭证 marker) 排除: 它们走 auth 修复 UX
+        // (「同步登录态」/ 重新登录), 升级成「后端不可达」会抢路径并误导排查
+        // (review: PR #715 五轮审核 P1 — 判定与 translator 共用 isAuthRelated*)。
         if (!isTerminalError && targetsCurrentTurn) {
           const rawMessage = params.error?.message ?? '';
-          if (!isAuthMissingErrorMessage(rawMessage)) {
+          if (!isAuthRelatedErrorMessage(rawMessage)) {
             const decision = turnRetryTracker.track(
               params.turnId || currentTurnId || '(pending)',
               Date.now(),
             );
             if (decision.escalate) {
+              // 本地收口后 daemon 侧原 turn 还在无限 retry — fire-and-forget 补
+              // interrupt, 否则它继续烧远端资源, 还可能与下一轮 send 的新 turn
+              // 撞车 (review: PR #715 五轮审核 P1)。失败仅 warn: 本地已按终态
+              // 处理, daemon 死亡/重启时该 turn 自然消失。
+              if (params.threadId && params.turnId) {
+                host.request(Method.TurnInterrupt, {
+                  threadId: params.threadId,
+                  turnId: params.turnId,
+                }).catch((e: unknown) => {
+                  log.warn('escalated turn interrupt failed (best-effort)', {
+                    turnId: params.turnId,
+                    error: e instanceof Error ? e.message : String(e),
+                  });
+                });
+              }
               const message = buildBackendUnreachableMessage({
                 isRemote: Boolean(opts.remoteHostId),
                 remoteHostId: opts.remoteHostId,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2253,14 +2253,17 @@ export class CodexAgent extends BaseAgent {
     // 同一份订阅凭证, reviewer 调用发生在 daemon 本地 — 订阅下走 daemon →
     // chatgpt.com 直连, 与本地订阅同构 (远端出网由用户网络或 agent-proxy
     // 隧道保障)。resolveAgentCredentialMode 只看 providerId/model, 远程同样
-    // 可判; 远程订阅与本地订阅同等启用 (#667 的远程一律回退是隧道方案
-    // 缺位时的保守, 隧道落地后放开)。
+    // 可判; 默认远程 session (无 providerId + 无前缀 model) 解析不出时,
+    // 兜底用 host 创建时登记的 effective mode (auth fallback 的实际钥匙 —
+    // 订阅即 oauth-bearer), 与本地默认 session 的兜底链对齐 (codex R17 P1)。
+    // 远程订阅与本地订阅同等启用 (#667 的远程一律回退是隧道方案缺位时的
+    // 保守, 隧道落地后放开)。
     const sessionCredentialMode = opts.remoteHostId
       ? resolveAgentCredentialMode({
           agentKind: 'codex',
           providerId: opts.providerId,
           model: opts.model,
-        })
+        }) ?? this.hostEffectiveCredentialModes.get(currentHostKey)
       : credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
     const approvalsReviewerProtocolSupported =
       supportsCodexApprovalsReviewerProtocol(initResp.userAgent);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2239,7 +2239,10 @@ export class CodexAgent extends BaseAgent {
     let initResp: Awaited<ReturnType<AppServerHost['ensureStarted']>>;
     try {
       assertCurrentHost('initialize');
-      initResp = await host.ensureStarted();
+      // 直调也必须有上界 (codex R13 P1): 冷启动 / transport 重建时
+      // bootstrap 挂死 (远端 daemon 无响应 / SSH 通道死) 会让 startSession
+      // 永不返回, UI 无限卡初始化 — 与 request() 的 startup deadline 同款。
+      initResp = await host.ensureStartedWithTimeout(CRITICAL_THREAD_RPC_TIMEOUT_MS, 'startSession initialize');
       assertCurrentHost('initialize');
     } catch (error) {
       releaseHostBindingLeaseIfNeeded();
@@ -3857,7 +3860,13 @@ export class CodexAgent extends BaseAgent {
       if (!turnId) return true;
       if (terminalErroredTurnIds.has(turnId) || completedTurnIds.has(turnId)) return false;
       if (!bufferedOrphanTurnIds.has(turnId)) return true;
-      return waitForBufferedTurnReconcile(turnId);
+      // 挂起到对账; waiter 恢复前复查墓碑 (codex R13 P2): 对账先 settle(true)
+      // 再同步重放队列, 队列里若有终态会把该 turn 当场收口 — waiter 在
+      // microtask 里恢复时 turn 已死, 此时再上 UI 就是为一个刚收口的 turn
+      // 批审批。微任务时机保证这次复查一定看到重放后的最终状态。
+      return waitForBufferedTurnReconcile(turnId).then(
+        (valid) => valid && !terminalErroredTurnIds.has(turnId) && !completedTurnIds.has(turnId),
+      );
     };
 
     const stopActiveRolloutPlanFallback = (): void => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -79,6 +79,7 @@ import { scanCodexCustomizations } from './customization-scanner.js';
 import { commandExecutionDisplayInput } from './command-display.js';
 import {
   newCodexRuntimeState,
+  isAuthMissingErrorMessage,
   translateErrorNotification,
   translateItemNotification,
   translateReasoningSummaryTextDelta,
@@ -89,6 +90,10 @@ import {
   extractRolloutUpdatePlanFunctionCallEvent,
   type CodexRuntimeState,
 } from './translator.js';
+import {
+  TurnRetryTracker,
+  buildBackendUnreachableMessage,
+} from './retry-escalation.js';
 import { AppServerHost, type ThreadEventHandlers, type ThreadSubscription } from './app-server/host.js';
 import { AppServerRequestTimeoutError } from './app-server/client.js';
 import { createStdioTransport } from './app-server/stdioTransport.js';
@@ -660,6 +665,14 @@ const TIGHTEN_INTERRUPT_ACK_TIMEOUT_MS = 10_000;
 // bounded so a live-but-unresponsive daemon cannot freeze the queued message or
 // ignore Stop.
 const PROFILE_LIFECYCLE_ACK_TIMEOUT_MS = 10_000;
+
+// thread/start / thread/resume / turn/start 的 RPC 上限。AppServerClient.request
+// 默认无超时 — 远端 daemon 失联 (SSH 隧道半开 / daemon 挂起但 socket 未断) 时
+// 裸 await 永久挂起, session 永远停在 generating (issue #677 同类断链面)。
+// 60s 足够覆盖慢 SSH 链路 + daemon 冷启动, 超时后走既有的「启动失败」收口
+// (terminal error + Done status)。注意: 超时只代表**我们不再等**, server 侧
+// 可能实际已建 thread/turn — 迟到事件按 stale turn 丢弃, 不影响 UI 复位。
+const CRITICAL_THREAD_RPC_TIMEOUT_MS = 60_000;
 
 // 计划批准后自动发起实施 turn 的固定输入 — 与官方 TUI 逐字一致
 // (codex-rs/tui/src/chatwidget/plan_implementation.rs 的
@@ -2081,6 +2094,10 @@ export class CodexAgent extends BaseAgent {
     // turn id 在同一 thread 内唯一;墓碑随 session handle 释放,不跨 session 泄漏。
     const completedTurnIds = new Set<string>();
     const terminalErroredTurnIds = new Set<string>();
+    // daemon 后端 retry-loop 的终局升级 (issue #677): 远端摸不到 Codex 后端时
+    // daemon 无限 willRetry, turn 永不收口。同 turn 重试超阈值 → 合成终态错误,
+    // 走与终态 error 完全相同的收口路径 (terminalErroredTurnIds + Done status)。
+    const turnRetryTracker = new TurnRetryTracker();
     const deferredTerminalTurnCompletions = new Map<string, TurnCompletedParams>();
     // 最近一次 thread/tokenUsage/updated 的 last 增量 + contextWindow,
     // 缓存供 turn end 日志读取 (协议本身不在 turn/completed 里带 usage)。
@@ -2584,7 +2601,9 @@ export class CodexAgent extends BaseAgent {
       try {
         acquireHostBindingLeaseIfNeeded();
         assertCurrentHost('thread/resume');
-        const resp = await host.request<ThreadResumeResponse>(Method.ThreadResume, params);
+        const resp = await host.request<ThreadResumeResponse>(Method.ThreadResume, params, {
+          timeoutMs: CRITICAL_THREAD_RPC_TIMEOUT_MS,
+        });
         assertCurrentHost('thread/resume');
         if (Object.hasOwn(resp, 'serviceTier')) {
           mutableServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
@@ -2647,7 +2666,9 @@ export class CodexAgent extends BaseAgent {
       try {
         acquireHostBindingLeaseIfNeeded();
         assertCurrentHost('thread/start');
-        const resp = await host.request<ThreadStartResponse>(Method.ThreadStart, params);
+        const resp = await host.request<ThreadStartResponse>(Method.ThreadStart, params, {
+          timeoutMs: CRITICAL_THREAD_RPC_TIMEOUT_MS,
+        });
         assertCurrentHost('thread/start');
         if (Object.hasOwn(resp, 'serviceTier')) {
           mutableServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
@@ -4121,6 +4142,8 @@ export class CodexAgent extends BaseAgent {
         translatorRt.lastAuthErrorKey = null;
         // 网络类 retry-loop 透出状态同理:新 turn 重新计数,可再透出一条。
         translatorRt.networkRetryNotice = null;
+        // retry 升级计数同样按 turn 隔离 — 新 turn 从零计。
+        turnRetryTracker.reset();
         log.debug('SDK ▶ turn start', {
           turnId: params.turn.id,
           model: mutableModel,
@@ -4264,7 +4287,8 @@ export class CodexAgent extends BaseAgent {
       },
       error: (params) => {
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
-        const isTerminalError = params.willRetry !== true;
+        let effectiveParams = params;
+        let isTerminalError = params.willRetry !== true;
         const isTransportError = params.scope === 'transport';
         if (isTransportError) {
           subscriptionInvalidatedByTransport = true;
@@ -4275,7 +4299,7 @@ export class CodexAgent extends BaseAgent {
         const targetsCurrentTurn =
           params.turnId === currentTurnId || (params.turnId === '' && isTurnInFlight) || targetsPendingTurn;
         if (isTerminalError && isTransportError && !targetsCurrentTurn) {
-          translateErrorNotification(params, eventQueue, { rt: translatorRt, log });
+          translateErrorNotification(effectiveParams, eventQueue, { rt: translatorRt, log });
           return;
         }
         if (isTerminalError && !targetsCurrentTurn) {
@@ -4286,11 +4310,43 @@ export class CodexAgent extends BaseAgent {
           });
           return;
         }
+        // ── retry-loop 终局升级 (issue #677) ──
+        // 远端摸不到 Codex 后端时 daemon 无限发 willRetry=true — 协议层设计上
+        // willRetry 不收口, 但持续性不可达 (403 / Network unreachable / timeout)
+        // 意味着 retry 永远不会成功。同 turn 计数/时长超阈值后合成终态错误,
+        // 落入下面与原生终态 error 完全相同的收口路径。
+        // auth 缺失 (401) 排除: 它有「同步登录态」的等待式 UX, 升级会抢走那个路径。
+        if (!isTerminalError && targetsCurrentTurn) {
+          const rawMessage = params.error?.message ?? '';
+          if (!isAuthMissingErrorMessage(rawMessage)) {
+            const decision = turnRetryTracker.track(
+              params.turnId || currentTurnId || '(pending)',
+              Date.now(),
+            );
+            if (decision.escalate) {
+              const message = buildBackendUnreachableMessage({
+                isRemote: Boolean(opts.remoteHostId),
+                remoteHostId: opts.remoteHostId,
+                retryCount: decision.retryCount,
+                elapsedMs: decision.elapsedMs,
+                lastError: rawMessage,
+              });
+              log.error('codex retry-loop escalated to terminal error (backend unreachable)', {
+                threadId: params.threadId,
+                turnId: params.turnId,
+                retryCount: decision.retryCount,
+                elapsedMs: decision.elapsedMs,
+              });
+              effectiveParams = { ...params, willRetry: false, error: { message } };
+              isTerminalError = true;
+            }
+          }
+        }
         const wasTurnRunning = isTurnInFlight || targetsPendingTurn;
-        translateErrorNotification(params, eventQueue, { rt: translatorRt, log });
+        translateErrorNotification(effectiveParams, eventQueue, { rt: translatorRt, log });
         // 与 translator 的 terminal 判定保持一致：willRetry=false 或缺省都视为终态。
         if (!isTerminalError) return;
-        const terminalTurnId = params.turnId || currentTurnId;
+        const terminalTurnId = effectiveParams.turnId || currentTurnId;
         if (terminalTurnId) {
           terminalErroredTurnIds.add(terminalTurnId);
           dismissPendingUserInputForTurn(terminalTurnId, 'turn_failed');
@@ -4527,7 +4583,9 @@ export class CodexAgent extends BaseAgent {
         };
         let finalErr: unknown = null;
         try {
-          const resp = await host.request<TurnStartResponse>(Method.TurnStart, turnParams);
+          const resp = await host.request<TurnStartResponse>(Method.TurnStart, turnParams, {
+            timeoutMs: CRITICAL_THREAD_RPC_TIMEOUT_MS,
+          });
           markTurnConfigAccepted();
           if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start')) {
             return;
@@ -4564,7 +4622,9 @@ export class CodexAgent extends BaseAgent {
                 ...(resumeModel && resumeModel !== 'gpt-5' ? { model: resumeModel } : {}),
                 ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
               };
-              const resumeResp = await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams);
+              const resumeResp = await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams, {
+                timeoutMs: CRITICAL_THREAD_RPC_TIMEOUT_MS,
+              });
               if (mutableModel === resumeModel && resumeModel === 'gpt-5' && resumeResp.model) {
                 mutableModel = resumeResp.model;
               }
@@ -4601,7 +4661,9 @@ export class CodexAgent extends BaseAgent {
                 }
               }
               log.info('thread/resume after stale daemon ok, retrying turn/start', { threadId });
-              const resp = await host.request<TurnStartResponse>(Method.TurnStart, turnParams);
+              const resp = await host.request<TurnStartResponse>(Method.TurnStart, turnParams, {
+                timeoutMs: CRITICAL_THREAD_RPC_TIMEOUT_MS,
+              });
               markTurnConfigAccepted();
               if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start retry')) {
                 return;

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2090,6 +2090,12 @@ export class CodexAgent extends BaseAgent {
     // turn/start RPC 失败(超时/拒绝)后置位: server 可能实际已建 turn,
     // 迟到的孤儿 turnStarted 由 turnStarted handler 拦下并补 interrupt。
     let turnStartFailedWithoutTurnId = false;
+    // 孤儿守卫生效期间又有新 turn/start 在飞时, 到达的 turnStarted 归属不明
+    // (协议不带 request id: 可能是失败 RPC 的孤儿, 也可能是在飞 RPC 合法的
+    // started-before-resp) — 先缓冲隔离, 等响应到了按 turnId 对账: 一致激活,
+    // 不一致 interrupt + 墓碑 (codex R9 P2)。缓冲期间不置 currentTurnId,
+    // 孤儿 turn 的 item 事件不会被渲染到本次 send 下。
+    const bufferedOrphanTurnIds = new Set<string>();
     type TurnCompletedParams = Parameters<NonNullable<ThreadEventHandlers['turnCompleted']>>[0];
     // 正常完成的 turn 也必须保留墓碑:app-server 允许 turn/completed 早于仍在
     // 后台收尾的 item 事件到达。没有这层墓碑时,currentTurnId 已清空,迟到 item
@@ -4127,10 +4133,20 @@ export class CodexAgent extends BaseAgent {
         if (turnsCompletedBeforeStartResp.has(params.turn.id)) return;
         // turn/start RPC 已失败(超时/拒绝)但 daemon 实际已建 turn — 迟到的孤儿
         // turnStarted 不得重新激活已报终态错误的会话 (greptile P1): 立墓碑 +
-        // 补 interrupt 让 daemon 停掉这个没人消费的 turn。仅在没有新 turn/start
-        // 在飞时判定 — 在飞期间到达的 started 按正常路径处理 (与成功路径的
-        // started-先于-resp 乱序共存; 该固有歧义不由本守卫承担)。
-        if (turnStartFailedWithoutTurnId && !isTurnStartPending && currentTurnId === null) {
+        // 补 interrupt 让 daemon 停掉这个没人消费的 turn。
+        if (turnStartFailedWithoutTurnId && currentTurnId === null) {
+          if (isTurnStartPending) {
+            // 新 turn/start 在飞 → 归属不明 (失败 RPC 的孤儿 vs 在飞 RPC 合法的
+            // started-before-resp, 协议层无法区分): 缓冲隔离, 等响应按 turnId
+            // 对账 (codex R9 P2)。直接接受会让孤儿 turn 的 item 事件渲染到
+            // 本次 send 下。
+            bufferedOrphanTurnIds.add(params.turn.id);
+            log.debug('buffering ambiguous turnStarted until turn/start response arrives', {
+              turnId: params.turn.id,
+              threadId,
+            });
+            return;
+          }
           terminalErroredTurnIds.add(params.turn.id);
           log.warn('ignoring orphan turnStarted from a failed turn/start — interrupting server-side turn', {
             turnId: params.turn.id,
@@ -4204,6 +4220,9 @@ export class CodexAgent extends BaseAgent {
         }
       },
       turnCompleted: (params) => {
+        // daemon 自己跑完的 buffered 孤儿 turn 无需再等对账 — 出缓冲防泄漏
+        // (codex R9 P2); completed 本体走既有 stale/墓碑路径。
+        bufferedOrphanTurnIds.delete(params.turn.id);
         handleTurnCompleted(params);
       },
       itemStarted: (params) => {
@@ -4597,6 +4616,38 @@ export class CodexAgent extends BaseAgent {
         // 普通 LLM 错误 / 超时 / auth 失败照原路径报错。
         const handleTurnStartResp = (resp: TurnStartResponse): void => {
           if (resp.turn?.id) {
+            // 缓冲的歧义 started 对账 (codex R9 P2): 本响应确立在飞 RPC 的
+            // turnId — 缓冲里 id 一致的是它的合法 started (下方正常激活),
+            // 不一致的是失败 RPC 的孤儿 (interrupt + 墓碑, 没人消费)。
+            if (bufferedOrphanTurnIds.size > 0) {
+              const wasBuffered = bufferedOrphanTurnIds.has(resp.turn.id);
+              for (const bufferedId of bufferedOrphanTurnIds) {
+                if (bufferedId === resp.turn.id) continue;
+                terminalErroredTurnIds.add(bufferedId);
+                log.warn('buffered turnStarted proven orphan by turn/start response — interrupting', {
+                  turnId: bufferedId,
+                  acceptedTurnId: resp.turn.id,
+                  threadId,
+                });
+                if (threadId) {
+                  host.request(Method.TurnInterrupt, { threadId, turnId: bufferedId }).catch((e2: unknown) => {
+                    log.warn('buffered orphan turn interrupt failed (best-effort)', {
+                      turnId: bufferedId,
+                      error: e2 instanceof Error ? e2.message : String(e2),
+                    });
+                  });
+                }
+              }
+              bufferedOrphanTurnIds.clear();
+              if (wasBuffered) {
+                // 合法 started 曾被缓冲: 补做 turnStarted 正常路径被跳过的
+                // per-turn 状态重置 (与 turnStarted handler 同款)。
+                proposedPlanText = null;
+                translatorRt.lastAuthErrorKey = null;
+                translatorRt.networkRetryNotice = null;
+                turnRetryTracker.reset();
+              }
+            }
             // turn/start 成功 → 孤儿守卫解除 (上次失败的 RPC 若也有迟到 started,
             // 那是一次新的语义重叠, 由 turn id 匹配路径处理)。
             turnStartFailedWithoutTurnId = false;
@@ -4762,6 +4813,20 @@ export class CodexAgent extends BaseAgent {
             isTurnInFlight = false;
             currentTurnPlanModeActive = false;
           }
+          // 缓冲的歧义 started 随本次失败一并坐实孤儿身份 (codex R9 P2):
+          // 没人消费, 全部 interrupt + 墓碑。
+          for (const bufferedId of bufferedOrphanTurnIds) {
+            terminalErroredTurnIds.add(bufferedId);
+            if (threadId) {
+              host.request(Method.TurnInterrupt, { threadId, turnId: bufferedId }).catch((e2: unknown) => {
+                log.warn('buffered orphan turn interrupt failed (best-effort)', {
+                  turnId: bufferedId,
+                  error: e2 instanceof Error ? e2.message : String(e2),
+                });
+              });
+            }
+          }
+          bufferedOrphanTurnIds.clear();
           log.error('turn/start failed', { error: String(finalErr) });
           eventQueue.push({
             type: 'error',

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2097,6 +2097,16 @@ export class CodexAgent extends BaseAgent {
     // 孤儿 turn 的 item 事件不会被渲染到本次 send 下。
     const bufferedOrphanTurnIds = new Set<string>();
     type TurnCompletedParams = Parameters<NonNullable<ThreadEventHandlers['turnCompleted']>>[0];
+    type ErrorNotificationParams = Parameters<NonNullable<ThreadEventHandlers['error']>>[0];
+    // 缓冲隔离期间到达的终态事件按 turnId 暂存 (greptile R11 P1): 对账证明
+    // 合法时重放收口 send, 证明孤儿时丢弃 — 直接丢会让合法 turn 的 send
+    // 永久卡 generating (turn 已死, 响应到达后激活一具尸体); 直接处理会让
+    // 孤儿终态提前收口在飞 send。一个 turn 至多一条终态, 单槽覆盖即可。
+    const bufferedTerminalEvents = new Map<
+      string,
+      | { kind: 'completed'; params: TurnCompletedParams }
+      | { kind: 'error'; params: ErrorNotificationParams }
+    >();
     // 正常完成的 turn 也必须保留墓碑:app-server 允许 turn/completed 早于仍在
     // 后台收尾的 item 事件到达。没有这层墓碑时,currentTurnId 已清空,迟到 item
     // 会重新发出 running status,而该 turn 的 done 已消费完,会话将永久假忙。
@@ -4226,9 +4236,15 @@ export class CodexAgent extends BaseAgent {
         }
       },
       turnCompleted: (params) => {
-        // daemon 自己跑完的 buffered 孤儿 turn 无需再等对账 — 出缓冲防泄漏
-        // (codex R9 P2); completed 本体走既有 stale/墓碑路径。
-        bufferedOrphanTurnIds.delete(params.turn.id);
+        // 缓冲隔离期间收到终态: 缓存等响应按归属对账 (greptile R11 P1) — 合法
+        // 则重放收口 send, 孤儿则丢弃 + 墓碑。直接处理会让孤儿 completed
+        // 提前收口在飞 send (handleTurnCompleted 在 currentTurnId===null 下
+        // 也会收口 emit done); 直接丢弃会把尸体 turn 激活成 in-flight,
+        // send 永久卡 generating。
+        if (bufferedOrphanTurnIds.has(params.turn.id)) {
+          bufferedTerminalEvents.set(params.turn.id, { kind: 'completed', params });
+          return;
+        }
         handleTurnCompleted(params);
       },
       itemStarted: (params) => {
@@ -4338,6 +4354,16 @@ export class CodexAgent extends BaseAgent {
         log.warn('Codex Guardian warning', { threadId: params.threadId, message: params.message });
       },
       error: (params) => {
+        // 缓冲隔离期间收到终态 error: 缓存等对账 (greptile R11 P1) — 吞下会
+        // 让合法 turn 的 send 永久卡 generating (turn 已死却被激活)。
+        // willRetry 的非终态 error 不决定 turn 生死, 丢弃即可 (合法 turn
+        // 激活后 daemon 还会继续发)。
+        if (params.turnId && bufferedOrphanTurnIds.has(params.turnId)) {
+          if (params.willRetry !== true) {
+            bufferedTerminalEvents.set(params.turnId, { kind: 'error', params });
+          }
+          return;
+        }
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         let effectiveParams = params;
         let isTerminalError = params.willRetry !== true;
@@ -4630,6 +4656,9 @@ export class CodexAgent extends BaseAgent {
               for (const bufferedId of bufferedOrphanTurnIds) {
                 if (bufferedId === resp.turn.id) continue;
                 terminalErroredTurnIds.add(bufferedId);
+                // 孤儿缓冲期间收到的终态一并丢弃 (greptile R11 P1) — 不得
+                // 让孤儿 error/completed 收口本次 send。
+                bufferedTerminalEvents.delete(bufferedId);
                 log.warn('buffered turnStarted proven orphan by turn/start response — interrupting', {
                   turnId: bufferedId,
                   acceptedTurnId: resp.turn.id,
@@ -4652,6 +4681,20 @@ export class CodexAgent extends BaseAgent {
                 translatorRt.lastAuthErrorKey = null;
                 translatorRt.networkRetryNotice = null;
                 turnRetryTracker.reset();
+                // 缓冲期间已收到终态 (greptile R11 P1): 重放让 send 收口 —
+                // 直接丢弃会把尸体 turn 激活成 in-flight, UI 永久卡
+                // generating。重放时 isTurnStartPending 仍为 true (finally
+                // 复位在本响应处理之后): completed 自动记墓碑 +
+                // currentTurnId===null 下收口 emit done; terminal error 的
+                // targetsPendingTurn=true → 正常终端路径 (墓碑 + 错误透出 +
+                // Done 状态)。随后下方激活逻辑被墓碑挡住, 不激活尸体。
+                const terminalEvent = bufferedTerminalEvents.get(resp.turn.id);
+                bufferedTerminalEvents.delete(resp.turn.id);
+                if (terminalEvent?.kind === 'completed') {
+                  handleTurnCompleted(terminalEvent.params);
+                } else if (terminalEvent?.kind === 'error') {
+                  handlers.error?.(terminalEvent.params);
+                }
               }
             }
             // turn/start 成功 → 孤儿守卫解除 (上次失败的 RPC 若也有迟到 started,
@@ -4833,6 +4876,7 @@ export class CodexAgent extends BaseAgent {
             }
           }
           bufferedOrphanTurnIds.clear();
+          bufferedTerminalEvents.clear();
           log.error('turn/start failed', { error: String(finalErr) });
           eventQueue.push({
             type: 'error',

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3635,6 +3635,10 @@ export class CodexAgent extends BaseAgent {
       if (turnGate === false) return { answers: {} };
       if (turnGate instanceof Promise && !(await turnGate)) return { answers: {} };
       const requestId = String(meta.requestId);
+      // 挂起期间服务端已取消本请求 (greptile R13 P1): 直接回空响应, 不注册
+      // broker 不上 UI — 否则 UI 会等一个服务端已结束的交互, 用户提交后向
+      // 已结束请求发迟到响应。
+      if (resolvedWhileBufferedRequestIds.delete(requestId)) return { answers: {} };
       const questions = normalizeRequestUserInputQuestions(params.questions);
       if (questions.length === 0) return { answers: {} };
       const kind = classifyUserInputRequest(params);
@@ -3693,6 +3697,14 @@ export class CodexAgent extends BaseAgent {
         };
       }
       const requestId = String(meta.requestId);
+      // 挂起期间服务端已取消本请求 (greptile R13 P1): 直接回失败响应, 不注册
+      // broker 不上 UI (与 resolved 的 cancel 响应同款文案)。
+      if (resolvedWhileBufferedRequestIds.delete(requestId)) {
+        return {
+          contentItems: [{ type: 'inputText', text: 'Request was resolved before user input was submitted.' }],
+          success: false,
+        };
+      }
       const questions = normalizeDynamicAskUserQuestions(params.arguments);
       if (questions.length === 0) {
         return {
@@ -3735,6 +3747,12 @@ export class CodexAgent extends BaseAgent {
           data: { requestId, reason: 'server_request_resolved', resolvedAs: 'deny' },
           source: 'codex',
         });
+      } else if (bufferedOrphanTurnIds.size > 0) {
+        // cancel 未命中且有 buffered turn: 可能是挂起中的请求 (尚未注册到
+        // broker) 被服务端取消 (greptile R13 P1) — 记下 requestId, 对账放行
+        // 后 handler 自查回空响应, 不上 UI。requestId 是一次性的 (消费即删),
+        // 最坏泄漏 = 一条字符串, 随 session 释放。
+        resolvedWhileBufferedRequestIds.add(requestId);
       }
     }
 
@@ -3810,6 +3828,10 @@ export class CodexAgent extends BaseAgent {
     // false, 调用方返回拒绝响应。挂起窗口 = turn/start RPC 窗口 (最坏
     // 60s), 远小于 daemon 侧审批等待时长。
     const bufferedReconcileWaiters = new Map<string, Array<(valid: boolean) => void>>();
+    // 挂起期间到达的 serverRequest/resolved (greptile R13 P1): 请求还没注册
+    // 到 broker, cancel 不命中 — 记下 requestId, 对账放行后 handler 自查:
+    // 服务端已取消的请求直接回空响应, 不再上 UI 让用户向已结束的请求提交。
+    const resolvedWhileBufferedRequestIds = new Set<string>();
 
     const waitForBufferedTurnReconcile = (turnId: string): Promise<boolean> =>
       new Promise((resolve) => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -94,6 +94,7 @@ import {
   TurnRetryTracker,
   buildBackendUnreachableMessage,
 } from './retry-escalation.js';
+import { extractNonSecretErrorSignals } from '@cindy/maker-shared/error-redaction';
 import { AppServerHost, type ThreadEventHandlers, type ThreadSubscription } from './app-server/host.js';
 import { AppServerRequestTimeoutError } from './app-server/client.js';
 import { createStdioTransport } from './app-server/stdioTransport.js';
@@ -2097,16 +2098,13 @@ export class CodexAgent extends BaseAgent {
     // 孤儿 turn 的 item 事件不会被渲染到本次 send 下。
     const bufferedOrphanTurnIds = new Set<string>();
     type TurnCompletedParams = Parameters<NonNullable<ThreadEventHandlers['turnCompleted']>>[0];
-    type ErrorNotificationParams = Parameters<NonNullable<ThreadEventHandlers['error']>>[0];
-    // 缓冲隔离期间到达的终态事件按 turnId 暂存 (greptile R11 P1): 对账证明
-    // 合法时重放收口 send, 证明孤儿时丢弃 — 直接丢会让合法 turn 的 send
-    // 永久卡 generating (turn 已死, 响应到达后激活一具尸体); 直接处理会让
-    // 孤儿终态提前收口在飞 send。一个 turn 至多一条终态, 单槽覆盖即可。
-    const bufferedTerminalEvents = new Map<
-      string,
-      | { kind: 'completed'; params: TurnCompletedParams }
-      | { kind: 'error'; params: ErrorNotificationParams }
-    >();
+    // 缓冲隔离期间到达的**所有** turn 事件按 turnId 排队 (greptile R11 P1 +
+    // codex R12 P1): 对账证明合法时激活后按到达序重放 (早期 item/usage 不丢,
+    // 终态自然收口 send), 证明孤儿时整队丢弃。只拦 turnStarted 或只缓存终态
+    // 都会出反例: 前者让孤儿输出渲染到在飞 send 下, 后者把合法 turn 的
+    // 早期输出/终态永久丢掉 (send 卡 generating)。队列元素是重放闭包 —
+    // 重放时 buffer 已清空且 turn 已激活, 闭包重进 handler 走正常路径。
+    const bufferedTurnEventQueues = new Map<string, Array<() => void>>();
     // 正常完成的 turn 也必须保留墓碑:app-server 允许 turn/completed 早于仍在
     // 后台收尾的 item 事件到达。没有这层墓碑时,currentTurnId 已清空,迟到 item
     // 会重新发出 running status,而该 turn 的 done 已消费完,会话将永久假忙。
@@ -3286,6 +3284,10 @@ export class CodexAgent extends BaseAgent {
     const commandExecutionApproval = async (
       params: CommandExecutionRequestApprovalParams,
     ): Promise<CommandExecutionRequestApprovalResponse> => {
+      // buffered/墓碑 turn 的审批请求不得上 UI (codex R12 P1) — 孤儿直接拒。
+      const turnGate = gateServerRequestTurn(params.turnId);
+      if (turnGate === false) return { decision: 'decline' };
+      if (turnGate instanceof Promise && !(await turnGate)) return { decision: 'decline' };
       // requestId: approvalId 优先 (zsh-exec-bridge 多 callback 场景); 否则用 itemId
       const requestId = params.approvalId ?? params.itemId;
       const decision = await awaitApprovalDecision(requestId, 'commandExecution', {
@@ -3304,6 +3306,10 @@ export class CodexAgent extends BaseAgent {
     const fileChangeApproval = async (
       params: FileChangeRequestApprovalParams,
     ): Promise<FileChangeRequestApprovalResponse> => {
+      // buffered/墓碑 turn 的审批请求不得上 UI (codex R12 P1) — 孤儿直接拒。
+      const turnGate = gateServerRequestTurn(params.turnId);
+      if (turnGate === false) return { decision: 'decline' };
+      if (turnGate instanceof Promise && !(await turnGate)) return { decision: 'decline' };
       const requestId = params.itemId;
       const decision = await awaitApprovalDecision(requestId, 'fileChange', {
         kind: 'permission',
@@ -3407,6 +3413,12 @@ export class CodexAgent extends BaseAgent {
     const mcpServerElicitation = async (
       params: McpServerElicitationRequestParams,
     ): Promise<McpServerElicitationRequestResponse> => {
+      // buffered/墓碑 turn 的 elicitation 不得上 UI / auto-approve (codex R12 P1)。
+      const turnGate = gateServerRequestTurn(params.turnId);
+      if (turnGate === false) return { action: 'decline', content: null, _meta: null };
+      if (turnGate instanceof Promise && !(await turnGate)) {
+        return { action: 'decline', content: null, _meta: null };
+      }
       if (!isMcpToolApprovalElicitation(params)) {
         log.warn('unsupported MCP server elicitation -> decline', {
           serverName: params.serverName,
@@ -3469,6 +3481,11 @@ export class CodexAgent extends BaseAgent {
     const permissionsApproval = async (
       params: PermissionsRequestApprovalParams,
     ): Promise<PermissionsRequestApprovalResponse> => {
+      // buffered/墓碑 turn 的审批请求不得上 UI (codex R12 P1) — 孤儿直接拒
+      // (空 permissions 即拒绝授权, 与非 accept 分支同款)。
+      const turnGate = gateServerRequestTurn(params.turnId);
+      if (turnGate === false) return { permissions: {}, scope: 'turn' };
+      if (turnGate instanceof Promise && !(await turnGate)) return { permissions: {}, scope: 'turn' };
       const requestId = params.itemId ?? params.turnId;
       const decision = await awaitApprovalDecision(requestId, 'commandExecution', {
         kind: 'permission',
@@ -3613,6 +3630,10 @@ export class CodexAgent extends BaseAgent {
       params: ToolRequestUserInputParams,
       meta: { requestId: string | number },
     ): Promise<ToolRequestUserInputResponse> => {
+      // buffered/墓碑 turn 的输入请求不得上 UI (codex R12 P1) — 空 answers 即拒。
+      const turnGate = gateServerRequestTurn(params.turnId);
+      if (turnGate === false) return { answers: {} };
+      if (turnGate instanceof Promise && !(await turnGate)) return { answers: {} };
       const requestId = String(meta.requestId);
       const questions = normalizeRequestUserInputQuestions(params.questions);
       if (questions.length === 0) return { answers: {} };
@@ -3647,6 +3668,24 @@ export class CodexAgent extends BaseAgent {
       params: DynamicToolCallParams,
       meta: { requestId: string | number },
     ): Promise<DynamicToolCallResponse> => {
+      // buffered/墓碑 turn 的 tool call 不得上 UI (codex R12 P1)。
+      const turnGate = gateServerRequestTurn(params.turnId);
+      if (turnGate === false) {
+        return {
+          contentItems: [
+            { type: 'inputText', text: 'Request was rejected because the owning turn is no longer active.' },
+          ],
+          success: false,
+        };
+      }
+      if (turnGate instanceof Promise && !(await turnGate)) {
+        return {
+          contentItems: [
+            { type: 'inputText', text: 'Request was rejected because the owning turn is no longer active.' },
+          ],
+          success: false,
+        };
+      }
       if (!isAskUserDynamicTool(params)) {
         return {
           contentItems: [{ type: 'inputText', text: `Unsupported dynamic tool: ${params.tool}` }],
@@ -3749,6 +3788,54 @@ export class CodexAgent extends BaseAgent {
       // 忽略; 若响应证明合法 (id 一致)  buffer 已清空, 后续事件正常。
       if (bufferedOrphanTurnIds.has(turnId)) return true;
       return currentTurnId !== null && turnId !== currentTurnId;
+    };
+
+    // buffered turn 的事件入口闸 (greptile R11 P1 + codex R12 P1): 命中缓冲
+    // 则把「重进本 handler」的闭包按到达序排进该 turn 的队列, 等对账 —
+    // 合法则激活后按序重放 (早期输出不丢, 终态自然收口), 孤儿则整队丢弃。
+    // 返回 true = 已入队, 调用方直接 return。重放闭包执行时 buffer 已清空
+    // 且 turn 已激活, 重进 handler 会走正常路径, 不会二次入队。
+    const enqueueIfBufferedTurn = (turnId: string | null | undefined, replay: () => void): boolean => {
+      if (!turnId || !bufferedOrphanTurnIds.has(turnId)) return false;
+      const queue = bufferedTurnEventQueues.get(turnId) ?? [];
+      queue.push(replay);
+      bufferedTurnEventQueues.set(turnId, queue);
+      return true;
+    };
+
+    // buffered turn 的 server request (审批/输入) 挂起信号 (codex R12 P1):
+    // 归属未定前请求不得上 UI — 用户可能为隐藏的孤儿 turn 批准操作, 而
+    // best-effort interrupt 输了竞态时操作会真实执行。每个 buffered id 一组
+    // waiter, 对账时 settle: 合法 → true 继续正常流程; 孤儿 / RPC 失败 →
+    // false, 调用方返回拒绝响应。挂起窗口 = turn/start RPC 窗口 (最坏
+    // 60s), 远小于 daemon 侧审批等待时长。
+    const bufferedReconcileWaiters = new Map<string, Array<(valid: boolean) => void>>();
+
+    const waitForBufferedTurnReconcile = (turnId: string): Promise<boolean> =>
+      new Promise((resolve) => {
+        const waiters = bufferedReconcileWaiters.get(turnId) ?? [];
+        waiters.push(resolve);
+        bufferedReconcileWaiters.set(turnId, waiters);
+      });
+
+    const settleBufferedTurnReconcile = (turnId: string, valid: boolean): void => {
+      const waiters = bufferedReconcileWaiters.get(turnId);
+      if (!waiters) return;
+      bufferedReconcileWaiters.delete(turnId);
+      for (const resolve of waiters) resolve(valid);
+    };
+
+    // server request 入口闸 (codex R12 P1): true = 放行; false = 拒绝
+    // (terminal/completed 墓碑 turn — 批了也没人消费; buffered 孤儿)。
+    // buffered 归属未定 → 返回 Promise 挂起到对账再定。非 async 签名是故意的:
+    // 同步快速路径不引入 microtask 延迟 — handler 第一行的 broker.track 与
+    // 紧随其后的 serverRequest/resolved 存在竞态, 哪怕一跳 await 也会让
+    // resolved 抢在 track 之前到达 (测试回归实证)。
+    const gateServerRequestTurn = (turnId: string | null | undefined): boolean | Promise<boolean> => {
+      if (!turnId) return true;
+      if (terminalErroredTurnIds.has(turnId) || completedTurnIds.has(turnId)) return false;
+      if (!bufferedOrphanTurnIds.has(turnId)) return true;
+      return waitForBufferedTurnReconcile(turnId);
     };
 
     const stopActiveRolloutPlanFallback = (): void => {
@@ -4213,6 +4300,7 @@ export class CodexAgent extends BaseAgent {
         });
       },
       tokenUsageUpdated: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.tokenUsageUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         const last = params.tokenUsage?.last;
         if (!last) return;
@@ -4236,18 +4324,16 @@ export class CodexAgent extends BaseAgent {
         }
       },
       turnCompleted: (params) => {
-        // 缓冲隔离期间收到终态: 缓存等响应按归属对账 (greptile R11 P1) — 合法
-        // 则重放收口 send, 孤儿则丢弃 + 墓碑。直接处理会让孤儿 completed
-        // 提前收口在飞 send (handleTurnCompleted 在 currentTurnId===null 下
-        // 也会收口 emit done); 直接丢弃会把尸体 turn 激活成 in-flight,
-        // send 永久卡 generating。
-        if (bufferedOrphanTurnIds.has(params.turn.id)) {
-          bufferedTerminalEvents.set(params.turn.id, { kind: 'completed', params });
-          return;
-        }
+        // buffered turn 的终态同样进队列等对账 (greptile R11 P1 + codex R12 P1):
+        // 合法 → 激活后按序重放, handleTurnCompleted 自然收口 send; 孤儿 →
+        // 整队丢弃。直接处理会让孤儿 completed 提前收口在飞 send
+        // (handleTurnCompleted 在 currentTurnId===null 下也收口 emit done);
+        // 直接丢弃会把尸体 turn 激活成 in-flight, send 永久卡 generating。
+        if (enqueueIfBufferedTurn(params.turn.id, () => handlers.turnCompleted?.(params))) return;
         handleTurnCompleted(params);
       },
       itemStarted: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.itemStarted?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         if (interceptProposedPlanItem(params.item)) return;
         noteActiveToolContext(params.item, params.turnId);
@@ -4261,6 +4347,7 @@ export class CodexAgent extends BaseAgent {
         });
       },
       itemUpdated: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.itemUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         if (interceptProposedPlanItem(params.item)) return;
         noteActiveToolContext(params.item, params.turnId);
@@ -4273,6 +4360,7 @@ export class CodexAgent extends BaseAgent {
         });
       },
       itemCompleted: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.itemCompleted?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         if (interceptProposedPlanItem(params.item)) return;
         noteActiveToolContext(params.item, params.turnId);
@@ -4288,19 +4376,23 @@ export class CodexAgent extends BaseAgent {
         if (isTurnInFlight) pushStatus('Generating...');
       },
       turnPlanUpdated: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.turnPlanUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         latestPlanByTurn.set(params.turnId, params.plan);
         translatePlanUpdatedNotification(params, eventQueue);
       },
       reasoningSummaryTextDelta: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningSummaryTextDelta?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         translateReasoningSummaryTextDelta(params, eventQueue, { rt: translatorRt, log });
       },
       reasoningSummaryPartAdded: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningSummaryPartAdded?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         translateReasoningSummaryPartAdded(params, eventQueue, { rt: translatorRt, log });
       },
       reasoningTextDelta: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningTextDelta?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         translateReasoningTextDelta(params, eventQueue, { rt: translatorRt, log });
       },
@@ -4336,6 +4428,7 @@ export class CodexAgent extends BaseAgent {
         }
       },
       autoApprovalReviewStarted: (params: ItemGuardianApprovalReviewStartedNotification) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.autoApprovalReviewStarted?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         log.debug('Codex automatic approval review started', {
           reviewId: params.reviewId,
@@ -4345,6 +4438,7 @@ export class CodexAgent extends BaseAgent {
         });
       },
       autoApprovalReviewCompleted: (params) => {
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.autoApprovalReviewCompleted?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         handleGuardianReviewCompleted(params);
       },
@@ -4354,16 +4448,10 @@ export class CodexAgent extends BaseAgent {
         log.warn('Codex Guardian warning', { threadId: params.threadId, message: params.message });
       },
       error: (params) => {
-        // 缓冲隔离期间收到终态 error: 缓存等对账 (greptile R11 P1) — 吞下会
-        // 让合法 turn 的 send 永久卡 generating (turn 已死却被激活)。
-        // willRetry 的非终态 error 不决定 turn 生死, 丢弃即可 (合法 turn
-        // 激活后 daemon 还会继续发)。
-        if (params.turnId && bufferedOrphanTurnIds.has(params.turnId)) {
-          if (params.willRetry !== true) {
-            bufferedTerminalEvents.set(params.turnId, { kind: 'error', params });
-          }
-          return;
-        }
+        // buffered turn 的 error (含终态) 同样进队列等对账 (greptile R11 P1 +
+        // codex R12 P1): 合法 → 激活后重放走正常终端路径收口 send; 孤儿 →
+        // 丢弃, 不得让孤儿 error 终结合法 send。
+        if (enqueueIfBufferedTurn(params.turnId, () => handlers.error?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         let effectiveParams = params;
         let isTerminalError = params.willRetry !== true;
@@ -4396,9 +4484,16 @@ export class CodexAgent extends BaseAgent {
         // auth 相关错误 (缺失 401 / 无效凭证 marker) 排除: 它们走 auth 修复 UX
         // (「同步登录态」/ 重新登录), 升级成「后端不可达」会抢路径并误导排查
         // (review: PR #715 五轮审核 P1 — 判定与 translator 共用 isAuthRelated*)。
+        // rate-limit / usage-limit (429 / quota) 同样排除 (codex R12 P2):
+        // 那是 provider 让等的正常退避窗口, daemon 的 willRetry 会在窗口后
+        // 成功; 升级成「后端不可达」+ proxy/VPN 引导既误杀可恢复重试又误导
+        // 排查方向。willRetry 透出 (networkRetryNotice) 不受影响, 用户仍能
+        // 看到「在限流退避」。
         if (!isTerminalError && targetsCurrentTurn) {
           const rawMessage = params.error?.message ?? '';
-          if (!isAuthRelatedErrorMessage(rawMessage)) {
+          const retrySignals = extractNonSecretErrorSignals(rawMessage);
+          const isRateLimitBackoff = retrySignals.errorStatus === 429 || retrySignals.usageLimit;
+          if (!isAuthRelatedErrorMessage(rawMessage) && !isRateLimitBackoff) {
             const decision = turnRetryTracker.track(
               params.turnId || currentTurnId || '(pending)',
               Date.now(),
@@ -4656,9 +4751,11 @@ export class CodexAgent extends BaseAgent {
               for (const bufferedId of bufferedOrphanTurnIds) {
                 if (bufferedId === resp.turn.id) continue;
                 terminalErroredTurnIds.add(bufferedId);
-                // 孤儿缓冲期间收到的终态一并丢弃 (greptile R11 P1) — 不得
-                // 让孤儿 error/completed 收口本次 send。
-                bufferedTerminalEvents.delete(bufferedId);
+                // 孤儿的事件队列整队丢弃 (greptile R11 P1) — 任何事件都不得
+                // 渲染到 / 收口本次 send; 挂起的审批/输入请求按拒绝释放
+                // (codex R12 P1)。
+                bufferedTurnEventQueues.delete(bufferedId);
+                settleBufferedTurnReconcile(bufferedId, false);
                 log.warn('buffered turnStarted proven orphan by turn/start response — interrupting', {
                   turnId: bufferedId,
                   acceptedTurnId: resp.turn.id,
@@ -4681,20 +4778,6 @@ export class CodexAgent extends BaseAgent {
                 translatorRt.lastAuthErrorKey = null;
                 translatorRt.networkRetryNotice = null;
                 turnRetryTracker.reset();
-                // 缓冲期间已收到终态 (greptile R11 P1): 重放让 send 收口 —
-                // 直接丢弃会把尸体 turn 激活成 in-flight, UI 永久卡
-                // generating。重放时 isTurnStartPending 仍为 true (finally
-                // 复位在本响应处理之后): completed 自动记墓碑 +
-                // currentTurnId===null 下收口 emit done; terminal error 的
-                // targetsPendingTurn=true → 正常终端路径 (墓碑 + 错误透出 +
-                // Done 状态)。随后下方激活逻辑被墓碑挡住, 不激活尸体。
-                const terminalEvent = bufferedTerminalEvents.get(resp.turn.id);
-                bufferedTerminalEvents.delete(resp.turn.id);
-                if (terminalEvent?.kind === 'completed') {
-                  handleTurnCompleted(terminalEvent.params);
-                } else if (terminalEvent?.kind === 'error') {
-                  handlers.error?.(terminalEvent.params);
-                }
               }
             }
             // turn/start 成功 → 孤儿守卫解除 (上次失败的 RPC 若也有迟到 started,
@@ -4709,6 +4792,26 @@ export class CodexAgent extends BaseAgent {
               currentTurnPlanModeActive = turnStartsInPlanMode;
               pendingTurnStartPlanMode = null;
               startRolloutPlanFallback(resp.turn.id);
+              // 合法 buffered turn 激活成功: 挂起的审批/输入请求放行 (走正常
+              // UI 流程), 再按到达序重放缓存事件 (greptile R11 P1 +
+              // codex R12 P1): 早期 item/usage 不再永久丢失; 队列里若有终态
+              // (turn 在缓冲期间已结束), 重放自然收口 send — 不会把尸体 turn
+              // 挂成 in-flight 永久卡 generating。重放闭包重进 handler 时
+              // buffer 已清空 + currentTurnId 已置, 全部走正常路径。
+              settleBufferedTurnReconcile(resp.turn.id, true);
+              const replayQueue = bufferedTurnEventQueues.get(resp.turn.id);
+              if (replayQueue) {
+                bufferedTurnEventQueues.delete(resp.turn.id);
+                log.debug('replaying buffered events for accepted turn', {
+                  turnId: resp.turn.id,
+                  eventCount: replayQueue.length,
+                });
+                for (const replay of replayQueue) replay();
+              }
+            } else {
+              // 未激活 (墓碑): 队列丢弃, 挂起请求按拒绝释放 — 不得穿透。
+              bufferedTurnEventQueues.delete(resp.turn.id);
+              settleBufferedTurnReconcile(resp.turn.id, false);
             }
             // turn/start 在飞期间权限被收紧 → 本 turn 携带的还是旧宽松策略,
             // 拿到 id 立即补中断 (fire-and-forget, 失败仅 warn); turn 已终结则
@@ -4866,6 +4969,7 @@ export class CodexAgent extends BaseAgent {
           // 没人消费, 全部 interrupt + 墓碑。
           for (const bufferedId of bufferedOrphanTurnIds) {
             terminalErroredTurnIds.add(bufferedId);
+            settleBufferedTurnReconcile(bufferedId, false);
             if (threadId) {
               host.request(Method.TurnInterrupt, { threadId, turnId: bufferedId }).catch((e2: unknown) => {
                 log.warn('buffered orphan turn interrupt failed (best-effort)', {
@@ -4876,7 +4980,7 @@ export class CodexAgent extends BaseAgent {
             }
           }
           bufferedOrphanTurnIds.clear();
-          bufferedTerminalEvents.clear();
+          bufferedTurnEventQueues.clear();
           log.error('turn/start failed', { error: String(finalErr) });
           eventQueue.push({
             type: 'error',

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4741,6 +4741,27 @@ export class CodexAgent extends BaseAgent {
           // turn/start 只是响应没回来。立孤儿守卫: 之后迟到的 turnStarted 不得
           // 重新激活会话 (greptile P1: 已报终态错误的会话又回到 generating)。
           turnStartFailedWithoutTurnId = true;
+          // turnStarted 也可能已先于响应到达并被接受 (started-before-resp 是
+          // 协议允许的乱序) — 此时 currentTurnId/isTurnInFlight 已置位, 失败
+          // 收口必须把这个活跃 turn 一起收掉: 立墓碑挡后续事件 + 清 turn 状态 +
+          // 补 interrupt (daemon 侧该 turn 还在跑)。否则 UI 已 Done 但
+          // handle.isTurnRunning() 永真, 下一条 send 被 in-flight guard 挡死
+          // (greptile R6 P1)。
+          if (currentTurnId) {
+            const orphanTurnId = currentTurnId;
+            terminalErroredTurnIds.add(orphanTurnId);
+            if (threadId) {
+              host.request(Method.TurnInterrupt, { threadId, turnId: orphanTurnId }).catch((e2: unknown) => {
+                log.warn('turn/start-failure orphan interrupt failed (best-effort)', {
+                  turnId: orphanTurnId,
+                  error: e2 instanceof Error ? e2.message : String(e2),
+                });
+              });
+            }
+            currentTurnId = null;
+            isTurnInFlight = false;
+            currentTurnPlanModeActive = false;
+          }
           log.error('turn/start failed', { error: String(finalErr) });
           eventQueue.push({
             type: 'error',

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2249,18 +2249,28 @@ export class CodexAgent extends BaseAgent {
       throw error;
     }
     if (initResp.codexHome) this.codexHome = initResp.codexHome;
+    // reviewer 路由的凭证模式判定: 远程 daemon 用的是 auth sync 推过去的
+    // 同一份订阅凭证, reviewer 调用发生在 daemon 本地 — 订阅下走 daemon →
+    // chatgpt.com 直连, 与本地订阅同构 (远端出网由用户网络或 agent-proxy
+    // 隧道保障)。resolveAgentCredentialMode 只看 providerId/model, 远程同样
+    // 可判; 远程订阅与本地订阅同等启用 (#667 的远程一律回退是隧道方案
+    // 缺位时的保守, 隧道落地后放开)。
     const sessionCredentialMode = opts.remoteHostId
-      ? undefined
+      ? resolveAgentCredentialMode({
+          agentKind: 'codex',
+          providerId: opts.providerId,
+          model: opts.model,
+        })
       : credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
     const approvalsReviewerProtocolSupported =
       supportsCodexApprovalsReviewerProtocol(initResp.userAgent);
     // Codex's built-in reviewer currently selects the hidden `codex-auto-review`
     // model through the session's model provider. Cindy's gateway, third-party
-    // providers, and remote daemons do not have a verified route for that model.
-    // Keep Auto usable on those routes by falling back to Codex's native
-    // `untrusted` policy instead of letting the first write fail in the reviewer.
-    const approvalsReviewerRouteSupported =
-      !opts.remoteHostId && sessionCredentialMode === 'oauth-bearer';
+    // providers, and other non-subscription credentials do not have a verified
+    // route for that model. Keep Auto usable on those routes by falling back to
+    // Codex's native `untrusted` policy instead of letting the first write fail
+    // in the reviewer.
+    const approvalsReviewerRouteSupported = sessionCredentialMode === 'oauth-bearer';
     const approvalsReviewerSupported =
       approvalsReviewerProtocolSupported && approvalsReviewerRouteSupported;
     const readonlyReferenceDirsSupported = supportsCodexReadonlyReferenceDirs(initResp.userAgent);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3893,6 +3893,14 @@ export class CodexAgent extends BaseAgent {
     const gateServerRequestTurn = (turnId: string | null | undefined): boolean | Promise<boolean> => {
       if (!turnId) return true;
       if (terminalErroredTurnIds.has(turnId) || completedTurnIds.has(turnId)) return false;
+      // idle 孤儿 (greptile R16 P1): 无 RPC 在飞时未知 id 的请求只可能来自
+      // 失败 RPC 的孤儿 turn — 直接拒, 不得放行上 UI (用户响应会发往旧
+      // turn, interrupt 输掉竞态时操作会真实执行)。与 notification 的
+      // idle 孤儿闸同款判定, 立墓碑让后续事件一并拦。
+      if (isIdleOrphanTurnId(turnId)) {
+        terminalErroredTurnIds.add(turnId);
+        return false;
+      }
       if (!bufferedOrphanTurnIds.has(turnId)) {
         // 与 enqueueIfBufferedTurn 同款预缓冲 (codex R15 P1): 孤儿 turn 的
         // server request 同样可以比它的 turnStarted 先到 — id 未入 buffer

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3816,8 +3816,23 @@ export class CodexAgent extends BaseAgent {
     // 合法则激活后按序重放 (早期输出不丢, 终态自然收口), 孤儿则整队丢弃。
     // 返回 true = 已入队, 调用方直接 return。重放闭包执行时 buffer 已清空
     // 且 turn 已激活, 重进 handler 会走正常路径, 不会二次入队。
+    //
+    // 孤儿证据可以比它的 turnStarted 先到 (codex R14 P1): error/item 先到
+    // 时 id 尚未入 buffer, 会穿透 stale guard 被按在飞 send 处理 — 孤儿
+    // 守卫生效 + 新 RPC 在飞 + 无活跃 turn 时, 未知 id 视同 started 先进
+    // buffer 再入队, 等对账。
     const enqueueIfBufferedTurn = (turnId: string | null | undefined, replay: () => void): boolean => {
-      if (!turnId || !bufferedOrphanTurnIds.has(turnId)) return false;
+      if (!turnId) return false;
+      if (!bufferedOrphanTurnIds.has(turnId)) {
+        if (!(turnStartFailedWithoutTurnId && isTurnStartPending && currentTurnId === null)) {
+          return false;
+        }
+        bufferedOrphanTurnIds.add(turnId);
+        log.debug('buffering ambiguous turn event (evidence before turnStarted) until turn/start response arrives', {
+          turnId,
+          threadId,
+        });
+      }
       const queue = bufferedTurnEventQueues.get(turnId) ?? [];
       queue.push(replay);
       bufferedTurnEventQueues.set(turnId, queue);
@@ -4811,9 +4826,14 @@ export class CodexAgent extends BaseAgent {
                 turnRetryTracker.reset();
               }
             }
-            // turn/start 成功 → 孤儿守卫解除 (上次失败的 RPC 若也有迟到 started,
-            // 那是一次新的语义重叠, 由 turn id 匹配路径处理)。
-            turnStartFailedWithoutTurnId = false;
+            // turn/start 成功后孤儿守卫**保持**, 不解除 (codex R14 P1): 失败
+            // RPC 的孤儿证据 (turnStarted/error/completed) 可能任意晚才到 —
+            // 解除后迟到的孤儿 started 在 currentTurnId===null 窗口会被正常
+            // 激活成假 running (会话永久卡)。守卫保持下: 未知 id 的迟到
+            // started 按孤儿墓碑 + interrupt; 合法 turn 的 started 由
+            // currentTurnId 匹配 (重复 started 幂等) 或 buffered 对账放行,
+            // 不受影响。守卫在 RPC 失败路径 (4413) 已把在飞 buffer 坐实孤儿,
+            // 语义依然自洽。
             // 墓碑: 该 turn 的终态已抢在本响应之前到达 (典型: 收紧补中断后
             // turnCompleted(interrupted) 先回), 不得重新置活, 否则会话卡 running。
             const alreadyCompleted = turnsCompletedBeforeStartResp.has(resp.turn.id);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3732,6 +3732,12 @@ export class CodexAgent extends BaseAgent {
       if (!turnId) return false;
       if (completedTurnIds.has(turnId)) return true;
       if (terminalErroredTurnIds.has(turnId)) return true;
+      // 缓冲隔离中的歧义 turn (codex R9 P2): id 只拦 turnStarted 不够 —
+      // 缓冲期间 currentTurnId 为 null, 孤儿 turn 的 item/usage/error 会穿透
+      // stale guard 被按当前 pending turn 处理 (旧输出显示在新消息下 / 用量
+      // 计错 turn / 孤儿 error 终结合法新 turn, greptile R10 P1)。其事件一律
+      // 忽略; 若响应证明合法 (id 一致)  buffer 已清空, 后续事件正常。
+      if (bufferedOrphanTurnIds.has(turnId)) return true;
       return currentTurnId !== null && turnId !== currentTurnId;
     };
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3798,6 +3798,18 @@ export class CodexAgent extends BaseAgent {
       return /Codex send (?:cancelled|cannot be accepted)/i.test(text);
     }
 
+    // idle 孤儿判定 (codex R15 P1): 孤儿守卫生效 + 无 RPC 在飞 + 无活跃 turn
+    // 时, 未知 id 的事件只可能来自失败 RPC 的孤儿 turn (合法 turn 的 id 都
+    // 已知)。与 pending 窗口的 buffer 隔离互补: idle 时没有对账 RPC 在飞,
+    // 事件直接按孤儿处理 (立墓碑), 不缓冲。
+    const isIdleOrphanTurnId = (turnId: string | null | undefined): turnId is string =>
+      Boolean(turnId)
+      && turnStartFailedWithoutTurnId
+      && !isTurnStartPending
+      && currentTurnId === null
+      && !completedTurnIds.has(turnId as string)
+      && !terminalErroredTurnIds.has(turnId as string);
+
     const shouldIgnoreStaleTurnEvent =(turnId: string | null | undefined): boolean => {
       if (!turnId) return false;
       if (completedTurnIds.has(turnId)) return true;
@@ -3808,6 +3820,13 @@ export class CodexAgent extends BaseAgent {
       // 计错 turn / 孤儿 error 终结合法新 turn, greptile R10 P1)。其事件一律
       // 忽略; 若响应证明合法 (id 一致)  buffer 已清空, 后续事件正常。
       if (bufferedOrphanTurnIds.has(turnId)) return true;
+      // idle 孤儿 (codex R15 P1): 立墓碑并丢弃。补 interrupt 由 turnStarted
+      // 的孤儿分支负责 (幂等); started 不到的孤儿在 daemon 侧自然跑完,
+      // 其 completed 由 turnCompleted handler 的同款判定拦。
+      if (isIdleOrphanTurnId(turnId)) {
+        terminalErroredTurnIds.add(turnId);
+        return true;
+      }
       return currentTurnId !== null && turnId !== currentTurnId;
     };
 
@@ -3874,7 +3893,20 @@ export class CodexAgent extends BaseAgent {
     const gateServerRequestTurn = (turnId: string | null | undefined): boolean | Promise<boolean> => {
       if (!turnId) return true;
       if (terminalErroredTurnIds.has(turnId) || completedTurnIds.has(turnId)) return false;
-      if (!bufferedOrphanTurnIds.has(turnId)) return true;
+      if (!bufferedOrphanTurnIds.has(turnId)) {
+        // 与 enqueueIfBufferedTurn 同款预缓冲 (codex R15 P1): 孤儿 turn 的
+        // server request 同样可以比它的 turnStarted 先到 — id 未入 buffer
+        // 时若直接放行, 审批框会为隐藏孤儿 turn 上 UI。守卫生效 + RPC 在飞
+        // + 无活跃 turn 时视同 buffered, 挂起到对账。
+        if (!(turnStartFailedWithoutTurnId && isTurnStartPending && currentTurnId === null)) {
+          return true;
+        }
+        bufferedOrphanTurnIds.add(turnId);
+        log.debug('buffering ambiguous turn server request (evidence before turnStarted) until turn/start response arrives', {
+          turnId,
+          threadId,
+        });
+      }
       // 挂起到对账; waiter 恢复前复查墓碑 (codex R13 P2): 对账先 settle(true)
       // 再同步重放队列, 队列里若有终态会把该 turn 当场收口 — waiter 在
       // microtask 里恢复时 turn 已死, 此时再上 UI 就是为一个刚收口的 turn
@@ -4276,14 +4308,18 @@ export class CodexAgent extends BaseAgent {
         }
       },
       turnStarted: (params) => {
-        // terminal error 已经为该 turn 收口时，晚到的 start 只能忽略，等待 completed 做清理。
-        if (shouldIgnoreStaleTurnEvent(params.turn.id)) return;
-        // 终态已先到的 turn (墓碑) 不得被乱序晚到的 started 重新置活。
-        if (turnsCompletedBeforeStartResp.has(params.turn.id)) return;
         // turn/start RPC 已失败(超时/拒绝)但 daemon 实际已建 turn — 迟到的孤儿
         // turnStarted 不得重新激活已报终态错误的会话 (greptile P1): 立墓碑 +
-        // 补 interrupt 让 daemon 停掉这个没人消费的 turn。
-        if (turnStartFailedWithoutTurnId && currentTurnId === null) {
+        // 补 interrupt 让 daemon 停掉这个没人消费的 turn。分支先于 stale 闸
+        // (codex R15 P1): 闸对 idle 孤儿只立墓碑, turnStarted 必须走这里补
+        // interrupt; 被闸先拦就发不出了。已墓碑/已完成的 id 不重复进分支
+        // (interrupt 不重复发), 交给下面的闸拦。
+        if (
+          turnStartFailedWithoutTurnId
+          && currentTurnId === null
+          && !terminalErroredTurnIds.has(params.turn.id)
+          && !completedTurnIds.has(params.turn.id)
+        ) {
           if (isTurnStartPending) {
             // 新 turn/start 在飞 → 归属不明 (失败 RPC 的孤儿 vs 在飞 RPC 合法的
             // started-before-resp, 协议层无法区分): 缓冲隔离, 等响应按 turnId
@@ -4312,6 +4348,10 @@ export class CodexAgent extends BaseAgent {
           }
           return;
         }
+        // terminal error 已经为该 turn 收口时，晚到的 start 只能忽略，等待 completed 做清理。
+        if (shouldIgnoreStaleTurnEvent(params.turn.id)) return;
+        // 终态已先到的 turn (墓碑) 不得被乱序晚到的 started 重新置活。
+        if (turnsCompletedBeforeStartResp.has(params.turn.id)) return;
         threadMayHaveRollout = true;
         const wasSameTurn = currentTurnId === params.turn.id;
         currentTurnId = params.turn.id;
@@ -4324,8 +4364,11 @@ export class CodexAgent extends BaseAgent {
         }
         if (!wasSameTurn) currentTurnPlanModeActive = pendingTurnStartPlanMode ?? planCycleActive;
         // 新 turn 开始 → 丢弃上一 turn 未消费的 proposed plan (正常路径已在
-        // handleTurnCompleted 清空, 这里防御 stale)。
-        proposedPlanText = null;
+        // handleTurnCompleted 清空, 这里防御 stale)。same-turn 的晚到 started
+        // 不清 (codex R15 P1): buffered turn 的 item 事件可能先于它的 started
+        // 被重放 (interceptProposedPlanItem 已存 plan), 随后到达的同 id
+        // started 若无条件清空, plan 模式下刚重放的 proposed plan 永久丢失。
+        if (!wasSameTurn) proposedPlanText = null;
         terminalErroredTurnIds.delete(params.turn.id);
         // Reset auth retry-loop dedupe key — 让下一个 turn 重新可以 emit 第一条
         // auth error。详见 translator.translateErrorNotification dedupe 逻辑。
@@ -4376,6 +4419,15 @@ export class CodexAgent extends BaseAgent {
         // (handleTurnCompleted 在 currentTurnId===null 下也收口 emit done);
         // 直接丢弃会把尸体 turn 激活成 in-flight, send 永久卡 generating。
         if (enqueueIfBufferedTurn(params.turn.id, () => handlers.turnCompleted?.(params))) return;
+        // 只拦 idle 孤儿 (codex R15 P1): 无 pending 时它的 completed 会走
+        // currentTurnId===null 的收口分支 emit 假 done。terminal/completed
+        // 墓碑 turn 的迟到 completed 仍走 handleTurnCompleted 的正常
+        // bookkeeping (suppressTerminalUi 分支, 不重复出 UI 事件) — 不能上
+        // 整个 stale 闸。
+        if (isIdleOrphanTurnId(params.turn.id)) {
+          terminalErroredTurnIds.add(params.turn.id);
+          return;
+        }
         handleTurnCompleted(params);
       },
       itemStarted: (params) => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3894,6 +3894,20 @@ export class CodexAgent extends BaseAgent {
       for (const resolve of waiters) resolve(valid);
     };
 
+    // 放弃对账时统一释放 (codex R17 P2): close / cancel 边界直接从 send
+    // return、或 session close 时, buffered turn 的挂起请求永远等不到
+    // settle — handler 永远悬挂, dispatchServerRequest 永不返回, server
+    // 侧请求卡死。所有不走路径对账的退出点都必须调用。
+    const abandonBufferedTurns = (reason: string): void => {
+      if (bufferedOrphanTurnIds.size === 0) return;
+      log.debug('abandoning buffered turns', { reason, turnIds: [...bufferedOrphanTurnIds] });
+      for (const bufferedId of bufferedOrphanTurnIds) {
+        settleBufferedTurnReconcile(bufferedId, false);
+      }
+      bufferedOrphanTurnIds.clear();
+      bufferedTurnEventQueues.clear();
+    };
+
     // server request 入口闸 (codex R12 P1): true = 放行; false = 拒绝
     // (terminal/completed 墓碑 turn — 批了也没人消费; buffered 孤儿)。
     // buffered 归属未定 → 返回 Promise 挂起到对账再定。非 async 签名是故意的:
@@ -3908,6 +3922,13 @@ export class CodexAgent extends BaseAgent {
       // turn, interrupt 输掉竞态时操作会真实执行)。与 notification 的
       // idle 孤儿闸同款判定, 立墓碑让后续事件一并拦。
       if (isIdleOrphanTurnId(turnId)) {
+        terminalErroredTurnIds.add(turnId);
+        return false;
+      }
+      // 孤儿守卫 + 已有活跃 turn: id ≠ currentTurnId 的请求来自失败 RPC 的
+      // 孤儿 (codex R17 P1) — 替换 turn 已被接受后, 孤儿迟到的审批/输入
+      // 请求既不是 idle 也不是 buffered, 不得放行上 UI。
+      if (turnStartFailedWithoutTurnId && currentTurnId !== null && turnId !== currentTurnId) {
         terminalErroredTurnIds.add(turnId);
         return false;
       }
@@ -4790,6 +4811,7 @@ export class CodexAgent extends BaseAgent {
         }
         if (rejectClosedOrCancelledSend(sendOpts, 'after input preparation')) {
           isTurnStartPending = false;
+          abandonBufferedTurns('send cancelled after input preparation');
           flushDeferredTerminalTurnCompletionsIfIdle();
           return;
         }
@@ -4959,6 +4981,9 @@ export class CodexAgent extends BaseAgent {
           });
           markTurnConfigAccepted();
           if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start')) {
+            // 本地取消边界直接 return: 挂起的 buffered 请求没有 settle 者
+            // (codex R17 P2), 统一释放。
+            abandonBufferedTurns('send cancelled after turn/start');
             return;
           }
           handleTurnStartResp(resp);
@@ -5037,6 +5062,7 @@ export class CodexAgent extends BaseAgent {
               });
               markTurnConfigAccepted();
               if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start retry')) {
+                abandonBufferedTurns('send cancelled after turn/start retry');
                 return;
               }
               handleTurnStartResp(resp);
@@ -5279,6 +5305,10 @@ export class CodexAgent extends BaseAgent {
         if (closed) return;
         closed = true;
         unregisterCodexMcpContext(threadId);
+        // close 时 buffer 里可能还有等对账的挂起请求 (codex R17 P2):
+        // 统一按拒绝释放, 否则 handler 永远悬挂, dispatchServerRequest
+        // 永不返回, server 侧请求卡死。
+        abandonBufferedTurns('session closed');
         // 把挂起的 approval 强制 deny + emit interaction_dismissed (UI 关 dialog),
         // 否则 server 那边没回 response 会卡; UI 上的 PermissionPrompt 也会留尸
         try { dismissAllPending('session_closed', 'deny'); } catch (e) { log.warn('dismissAllPending threw', { error: String(e) }); }

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2087,6 +2087,9 @@ export class CodexAgent extends BaseAgent {
     let currentTurnId: string | null = null;
     let isTurnInFlight = false;
     let isTurnStartPending = false;
+    // turn/start RPC 失败(超时/拒绝)后置位: server 可能实际已建 turn,
+    // 迟到的孤儿 turnStarted 由 turnStarted handler 拦下并补 interrupt。
+    let turnStartFailedWithoutTurnId = false;
     type TurnCompletedParams = Parameters<NonNullable<ThreadEventHandlers['turnCompleted']>>[0];
     // 正常完成的 turn 也必须保留墓碑:app-server 允许 turn/completed 早于仍在
     // 后台收尾的 item 事件到达。没有这层墓碑时,currentTurnId 已清空,迟到 item
@@ -4122,6 +4125,28 @@ export class CodexAgent extends BaseAgent {
         if (shouldIgnoreStaleTurnEvent(params.turn.id)) return;
         // 终态已先到的 turn (墓碑) 不得被乱序晚到的 started 重新置活。
         if (turnsCompletedBeforeStartResp.has(params.turn.id)) return;
+        // turn/start RPC 已失败(超时/拒绝)但 daemon 实际已建 turn — 迟到的孤儿
+        // turnStarted 不得重新激活已报终态错误的会话 (greptile P1): 立墓碑 +
+        // 补 interrupt 让 daemon 停掉这个没人消费的 turn。仅在没有新 turn/start
+        // 在飞时判定 — 在飞期间到达的 started 按正常路径处理 (与成功路径的
+        // started-先于-resp 乱序共存; 该固有歧义不由本守卫承担)。
+        if (turnStartFailedWithoutTurnId && !isTurnStartPending && currentTurnId === null) {
+          terminalErroredTurnIds.add(params.turn.id);
+          log.warn('ignoring orphan turnStarted from a failed turn/start — interrupting server-side turn', {
+            turnId: params.turn.id,
+            threadId,
+          });
+          if (threadId) {
+            host.request(Method.TurnInterrupt, { threadId, turnId: params.turn.id })
+              .catch((e: unknown) => {
+                log.warn('orphan turn interrupt failed (best-effort)', {
+                  turnId: params.turn.id,
+                  error: e instanceof Error ? e.message : String(e),
+                });
+              });
+          }
+          return;
+        }
         threadMayHaveRollout = true;
         const wasSameTurn = currentTurnId === params.turn.id;
         currentTurnId = params.turn.id;
@@ -4553,6 +4578,9 @@ export class CodexAgent extends BaseAgent {
         // 普通 LLM 错误 / 超时 / auth 失败照原路径报错。
         const handleTurnStartResp = (resp: TurnStartResponse): void => {
           if (resp.turn?.id) {
+            // turn/start 成功 → 孤儿守卫解除 (上次失败的 RPC 若也有迟到 started,
+            // 那是一次新的语义重叠, 由 turn id 匹配路径处理)。
+            turnStartFailedWithoutTurnId = false;
             // 墓碑: 该 turn 的终态已抢在本响应之前到达 (典型: 收紧补中断后
             // turnCompleted(interrupted) 先回), 不得重新置活, 否则会话卡 running。
             const alreadyCompleted = turnsCompletedBeforeStartResp.has(resp.turn.id);
@@ -4690,6 +4718,10 @@ export class CodexAgent extends BaseAgent {
           // failed 分支同语义), 否则 planCycleActive 泄漏, 下一条常规消息仍会
           // 携带 collaborationMode plan(勾选与 chip 早已熄灭, 行为与 UI 脱节)。
           endPlanCycleAfterPreStartFailure('turn/start failed');
+          // RPC 级失败(超时/拒绝)不代表 server 没建 turn — daemon 可能已接受
+          // turn/start 只是响应没回来。立孤儿守卫: 之后迟到的 turnStarted 不得
+          // 重新激活会话 (greptile P1: 已报终态错误的会话又回到 generating)。
+          turnStartFailedWithoutTurnId = true;
           log.error('turn/start failed', { error: String(finalErr) });
           eventQueue.push({
             type: 'error',

--- a/packages/maker-core/src/agents/codex/retry-escalation.test.ts
+++ b/packages/maker-core/src/agents/codex/retry-escalation.test.ts
@@ -1,0 +1,108 @@
+/**
+ * retry-escalation 单测 — TurnRetryTracker 的升级阈值与
+ * buildBackendUnreachableMessage 的文案契约 (issue #677)。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  TurnRetryTracker,
+  buildBackendUnreachableMessage,
+  RETRY_ESCALATION_MAX_COUNT,
+  RETRY_ESCALATION_MAX_ELAPSED_MS,
+} from './retry-escalation.js';
+
+describe('TurnRetryTracker', () => {
+  it('does not escalate before the count threshold', () => {
+    const t = new TurnRetryTracker();
+    let last;
+    for (let i = 0; i < RETRY_ESCALATION_MAX_COUNT - 1; i += 1) {
+      last = t.track('turn-1', 1000 + i * 1000);
+    }
+    expect(last!.escalate).toBe(false);
+    expect(last!.retryCount).toBe(RETRY_ESCALATION_MAX_COUNT - 1);
+  });
+
+  it('escalates at the count threshold', () => {
+    const t = new TurnRetryTracker();
+    let last;
+    for (let i = 0; i < RETRY_ESCALATION_MAX_COUNT; i += 1) {
+      last = t.track('turn-1', 1000 + i * 100); // 快速重试, elapsed 很小
+    }
+    expect(last!.escalate).toBe(true);
+    expect(last!.retryCount).toBe(RETRY_ESCALATION_MAX_COUNT);
+  });
+
+  it('escalates when the elapsed time crosses the cap even with few retries', () => {
+    const t = new TurnRetryTracker();
+    t.track('turn-1', 0);
+    const slow = t.track('turn-1', RETRY_ESCALATION_MAX_ELAPSED_MS + 1);
+    expect(slow.retryCount).toBe(2);
+    expect(slow.escalate).toBe(true);
+  });
+
+  it('treats a turnId change as a fresh sequence', () => {
+    const t = new TurnRetryTracker();
+    for (let i = 0; i < RETRY_ESCALATION_MAX_COUNT - 1; i += 1) {
+      t.track('turn-1', i * 1000);
+    }
+    const fresh = t.track('turn-2', 999_000);
+    expect(fresh.retryCount).toBe(1);
+    expect(fresh.escalate).toBe(false);
+  });
+
+  it('reset() clears the sequence', () => {
+    const t = new TurnRetryTracker();
+    for (let i = 0; i < RETRY_ESCALATION_MAX_COUNT - 1; i += 1) {
+      t.track('turn-1', i * 1000);
+    }
+    t.reset();
+    const fresh = t.track('turn-1', 999_000);
+    expect(fresh.retryCount).toBe(1);
+    expect(fresh.escalate).toBe(false);
+  });
+});
+
+describe('buildBackendUnreachableMessage', () => {
+  it('remote variant names the host, keeps the last error, and points at the proxy tunnel setting', () => {
+    const msg = buildBackendUnreachableMessage({
+      isRemote: true,
+      remoteHostId: 'gpu-box',
+      retryCount: 30,
+      elapsedMs: 32_000,
+      lastError: 'unexpected status 403 Forbidden',
+    });
+    expect(msg).toContain('"gpu-box"');
+    expect(msg).toContain('chatgpt.com');
+    expect(msg).toContain('403 Forbidden');
+    expect(msg).toContain('30 times');
+    expect(msg).toContain('32s');
+    expect(msg).toContain('Route agent traffic via local proxy');
+  });
+
+  it('local variant omits the tunnel hint and host', () => {
+    const msg = buildBackendUnreachableMessage({
+      isRemote: false,
+      retryCount: 5,
+      elapsedMs: 121_000,
+      lastError: 'fetch failed',
+    });
+    expect(msg).toContain('fetch failed');
+    expect(msg).toContain('121s');
+    expect(msg).not.toContain('local proxy');
+    expect(msg).not.toContain('SSH remote hosts');
+  });
+
+  it('collapses whitespace and truncates a pathological last error', () => {
+    const long = `line1\nline2   ${'x'.repeat(500)}`;
+    const msg = buildBackendUnreachableMessage({
+      isRemote: true,
+      remoteHostId: 'h',
+      retryCount: 1,
+      elapsedMs: 0,
+      lastError: long,
+    });
+    expect(msg).not.toContain('\nline2');
+    expect(msg.length).toBeLessThan(900);
+  });
+});

--- a/packages/maker-core/src/agents/codex/retry-escalation.ts
+++ b/packages/maker-core/src/agents/codex/retry-escalation.ts
@@ -1,0 +1,90 @@
+/**
+ * retry-escalation — codex daemon 后端重试循环的终局升级。
+ *
+ * 背景 (issue #677): 远端机器摸不到 Codex 后端 (chatgpt.com 直连超时 / 403 /
+ * websocket unreachable) 时, daemon 会以 ~1s 间隔无限发 willRetry=true 的
+ * error notification — 协议注释明确 willRetry=true 时 server 会自动重试,
+ * 客户端不应中断 turn。但 daemon 对**持续性**不可达没有退避上限, turn 在
+ * UI 上永远转圈 (renderer 只有终态 error / Done 才复位 generating)。
+ *
+ * 这里的策略: 同 turn 的 willRetry 错误达到阈值 (次数或持续时长) 就合成一
+ * 条**终态**错误收口, 消息里带原始末次错误 + 可操作的排查方向 (代理/VPN/
+ * 403/超时 + SSH 代理隧道入口)。auth 缺失 (401) 不在此列 — 它有自己
+ * 「同步登录态」的等待式 UX, 由调用方排除。
+ *
+ * claude-code 侧有等价的 upstream_response_idle_timeout watchdog
+ * (claude-code/index.ts), codex 此前没有任何对应物。
+ */
+
+/** 同 turn 重试次数达到该值即升级 (daemon 重试约 1 次/秒, ≈30s)。 */
+export const RETRY_ESCALATION_MAX_COUNT = 30;
+/** 同 turn 首次 willRetry 至今超过该时长即升级 — 兜底重试频率异常的情形。 */
+export const RETRY_ESCALATION_MAX_ELAPSED_MS = 120_000;
+
+export interface RetryEscalationDecision {
+  escalate: boolean;
+  retryCount: number;
+  elapsedMs: number;
+}
+
+export class TurnRetryTracker {
+  private turnId: string | null = null;
+  private count = 0;
+  private firstAt = 0;
+
+  /** 新 turn / turn 终结时复位。 */
+  reset(): void {
+    this.turnId = null;
+    this.count = 0;
+    this.firstAt = 0;
+  }
+
+  /** 记录一次 willRetry=true 错误; turnId 变化视为新序列重新计数。 */
+  track(turnId: string, now: number): RetryEscalationDecision {
+    if (this.turnId !== turnId) {
+      this.turnId = turnId;
+      this.count = 0;
+      this.firstAt = now;
+    }
+    this.count += 1;
+    const elapsedMs = now - this.firstAt;
+    return {
+      escalate:
+        this.count >= RETRY_ESCALATION_MAX_COUNT ||
+        elapsedMs >= RETRY_ESCALATION_MAX_ELAPSED_MS,
+      retryCount: this.count,
+      elapsedMs,
+    };
+  }
+}
+
+/**
+ * 升级时合成给用户的终态错误消息。保留末次原始错误 (截断) 作为诊断锚点;
+ * 按 local/remote 给出不同的排查指向 (remote 才有 SSH 代理隧道入口)。
+ */
+export function buildBackendUnreachableMessage(opts: {
+  isRemote: boolean;
+  remoteHostId?: string;
+  retryCount: number;
+  elapsedMs: number;
+  lastError: string;
+}): string {
+  const last = opts.lastError.trim().replace(/\s+/g, ' ').slice(0, 300) || '(no error detail)';
+  const elapsedS = Math.round(opts.elapsedMs / 1000);
+  const head =
+    `Codex backend unreachable — the daemon retried ${opts.retryCount} times over ${elapsedS}s ` +
+    `without success (last error: "${last}").`;
+  if (!opts.isRemote) {
+    return (
+      `${head}\nThe Codex backend (chatgpt.com) is not responding. Likely causes: network outage, ` +
+      `proxy/VPN required, request blocked (403), or timeout. Check your connection and retry.`
+    );
+  }
+  const host = opts.remoteHostId ? ` "${opts.remoteHostId}"` : '';
+  return (
+    `${head}\nThe remote host${host} cannot reach the Codex backend (chatgpt.com) directly. ` +
+    `Likely causes: proxy/VPN required on the remote, outbound blocked (403), timeout, or websocket unreachable.\n` +
+    `Hint: in Settings → SSH remote hosts, edit this host and enable "Route agent traffic via local proxy" ` +
+    `to tunnel agent traffic back to a proxy on this machine, or fix the remote network, then retry.`
+  );
+}

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -2,8 +2,9 @@
  * translator.translateErrorNotification — auth retry-loop dedupe + isAuthMissing 触发。
  *
  * 覆盖 fix(desktop,maker-core): 远端 codex daemon 重启 / auth 状态异常的端到端恢复
- * 这一 commit 里 ❶+❹ 修法的核心 invariant:
- *   1. willRetry=true + transient (非 auth) → silent (不 push error event)
+ * 这一 commit 里 ❶+❹ 修法的核心 invariant (❶ 后经 issue #677 泛化):
+ *   1. willRetry=true + transient (非 auth) → 第 1 次 silent; 同 turn 第 2 次透出
+ *      **一条**非终止提示 (#677 起不再限定 networkish pattern), 之后静默
  *   2. willRetry=true + auth 关键字 → push 第一条, 同 thread+turn 后续 dedupe
  *   3. willRetry=true + auth + 不同 turn → key reset, 又能 push
  *   4. willRetry=false → 不论 auth 与否都 push
@@ -347,7 +348,10 @@ describe('translateErrorNotification', () => {
     expect(events).toHaveLength(2);
   });
 
-  it('willRetry=true 非网络非 auth 错误 → 依旧全部静默', async () => {
+  it('willRetry=true 非网络非 auth 错误 → 第 2 次同样透出一条(issue #677 泛化),之后静默', async () => {
+    // #677 之前只透 networkish pattern; 但 "rate limit backing off" / 403 /
+    // websocket unreachable 这类持续性重试同样是「daemon 空转」信号, 用户必须
+    // 能看到一条非终止提示。终局收口由 TurnRetryTracker 升级负责 (不在这里)。
     const rt = newCodexRuntimeState();
     const ctx = makeCtx(rt);
     const q = createAsyncQueue<AgentEvent>();
@@ -359,7 +363,30 @@ describe('translateErrorNotification', () => {
       );
     }
     const events = await collect(q);
-    expect(events).toHaveLength(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('error');
+    expect(events[0].data).toMatchObject({ isTerminal: false, willRetry: true });
+  });
+
+  it('willRetry=true 远端后端不可达文案 (403 / websocket unreachable) → 第 2 次透出提示', async () => {
+    // issue #677 的原始断链面: 这两类文案不匹配旧的 networkish pattern,
+    // 远端 daemon retry-loop 时 UI 一条事件都收不到。
+    const rt = newCodexRuntimeState();
+    const ctx = makeCtx(rt);
+    const q = createAsyncQueue<AgentEvent>();
+    const messages = [
+      'unexpected status 403 Forbidden, url: https://chatgpt.com/backend-api/codex/responses',
+      'failed to connect to websocket: Network unreachable',
+    ];
+    for (let round = 0; round < 2; round += 1) {
+      for (const message of messages) {
+        translateErrorNotification(makeParams({ willRetry: true, message }), q, ctx);
+      }
+    }
+    const events = await collect(q);
+    // 同 thread+turn 只透一条 (第 2 次触发时), 与其余重试风暴隔离。
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toMatchObject({ isTerminal: false, willRetry: true });
   });
 });
 

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -197,6 +197,24 @@ export function isAuthMissingErrorMessage(message: string, errorStatus?: number)
   return errorStatus === 401 || /\b401\b|Missing bearer/i.test(message);
 }
 
+/**
+ * auth 相关错误 (缺失 OR 无效) 的更宽判定 — translator 会把
+ * authentication_error / authentication_failed / invalid_api_key /
+ * api key not valid 这些 marker 同样推断成 errorStatus=401 走 auth UX
+ * (translateErrorNotification 的 hasAuthErrorMarker)。retry-loop 升级判定
+ * 必须排除同一集合, 否则这些真 auth 错误会被升级成「后端不可达」终态,
+ * 抢走 auth 修复路径并误导排查方向 (review: PR #715 五轮审核 P1)。
+ *
+ * 与 isAuthMissingErrorMessage 的分工: Missing 版只认「没给凭证」
+ * (401 / Missing bearer), 用于触发「同步登录态」等待式 UX; Related 版
+ * 额外认「凭证无效」类 marker, 只用于「不要按网络不可达处理」的排除判断。
+ */
+export function isAuthRelatedErrorMessage(message: string, errorStatus?: number): boolean {
+  if (isAuthMissingErrorMessage(message, errorStatus)) return true;
+  return /\bauthentication_(?:error|failed)\b|\binvalid[\s_-]*api[\s_-]*key\b|\bapi key not valid\b/i
+    .test(message);
+}
+
 /** error notification (顶层非 item.*) → AgentEvent error。 */
 export function translateErrorNotification(
   params: ErrorNotification['params'],

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -31,7 +31,6 @@ import type { AgentEvent, AgentTaskStatus, AgentTaskUpdateEventData } from '../.
 import { normalizeAccountRateLimitSnapshot } from '../../types/account-rate-limits.js';
 import type { AsyncQueue } from '../shared/async-queue.js';
 import { stripTerminalControlSequences } from '../shared/terminal-output.js';
-import { isNetworkishErrorMessage } from '../shared/network-error.js';
 import { commandExecutionDisplayInput, type CommandExecutionDisplayInput } from './command-display.js';
 import type {
   ItemCompletedNotification,
@@ -184,6 +183,20 @@ export function translateItemNotification(
   }
 }
 
+/**
+ * auth 缺失 (401/Unauthorized/Missing bearer) 判定 — daemon 怎么 retry 也不可能
+ * 自愈, 必须用户介入。收紧 pattern: 避开非 HTTP-auth 错误误伤 (eg. 工具执行报错
+ * "Unauthorized file system access" 含 Unauthorized 字面但不是 401)。要求带
+ * \b401\b 边界, 或 Missing bearer 精确短语 (OpenAI 401 message 标准措辞)。
+ *
+ * 从 translateErrorNotification 抽出成 export — codex/index.ts 的 retry 升级
+ * 逻辑要排除这一类 (auth 缺失走自己「同步登录态」的等待式 UX, 不应被升级成
+ * 终态 backend-unreachable)。
+ */
+export function isAuthMissingErrorMessage(message: string, errorStatus?: number): boolean {
+  return errorStatus === 401 || /\b401\b|Missing bearer/i.test(message);
+}
+
 /** error notification (顶层非 item.*) → AgentEvent error。 */
 export function translateErrorNotification(
   params: ErrorNotification['params'],
@@ -213,32 +226,30 @@ export function translateErrorNotification(
   // 透出来并标记 isTerminal=false → renderer 端 ErrorBanner 的 401 识别会触发 →
   // 显示「同步登录态」button；main 端 active-turn keepalive 继续保持,等待 daemon
   // retry 或用户修复登录态后的后续事件。
-  // 收紧 pattern: 避开非 HTTP-auth 错误误伤 (eg. 工具执行报错 "Unauthorized file
-  // system access" 含 Unauthorized 字面但不是 401)。要求带 \b401\b 边界, 或
-  // Missing bearer 精确短语 (OpenAI 401 message 标准措辞)。
-  const isAuthMissing =
-    errorStatus === 401 || /\b401\b|Missing bearer/i.test(safeMessage);
+  const isAuthMissing = isAuthMissingErrorMessage(safeMessage, errorStatus);
   if (params.willRetry && !isAuthMissing) {
     ctx.log.warn('codex error (will retry)', { message: safeMessage, threadId: params.threadId, turnId: params.turnId });
-    // 网络类错误(502/连接失败等)持续重试 = 网络可能断了,daemon 卡在 retry-loop
-    // 里 turn 无限转圈。同 turn 第 2 次时透出**一条**非终止提示(isTerminal:false,
-    // renderer 走 recoverableError → "网络异常,正在自动重试…" banner,恢复后随
-    // 正常事件自动清;不结束 turn、不落 error 行)。第 1 次不透出:单次抖动 daemon
-    // 一次重试就过,提示只会闪一下徒增噪音。
-    if (isNetworkishErrorMessage(message)) {
-      const key = `${params.threadId ?? ''}|${params.turnId ?? ''}`;
-      const notice = ctx.rt.networkRetryNotice;
-      const count = notice?.key === key ? notice.count + 1 : 1;
-      const emitted = notice?.key === key ? notice.emitted : false;
-      ctx.rt.networkRetryNotice = { key, count, emitted };
-      if (count >= 2 && !emitted) {
-        ctx.rt.networkRetryNotice = { key, count, emitted: true };
-        queue.push({
-          type: 'error',
-          data: { ...safeErrorData, isTerminal: false, willRetry: true },
-          source: 'codex',
-        });
-      }
+    // 持续重试的错误 = daemon 卡在 retry-loop 里 turn 无限转圈。同 turn 第 2 次时
+    // 透出**一条**非终止提示 (isTerminal:false, renderer 走 recoverableError →
+    // "正在自动重试…" banner, 恢复后随正常事件自动清; 不结束 turn、不落 error 行)。
+    // 第 1 次不透出: 单次抖动 daemon 一次重试就过, 提示只会闪一下徒增噪音。
+    //
+    // 不限定 networkish pattern (issue #677): 远端后端不可达的典型文案
+    // ("unexpected status 403 Forbidden" / "failed to connect to websocket:
+    // Network unreachable") 不命中 networkish, 但同样是「daemon 在空转」的信号,
+    // 用户必须看得到。终局收口由 codex/index.ts 的 TurnRetryTracker 升级负责。
+    const key = `${params.threadId ?? ''}|${params.turnId ?? ''}`;
+    const notice = ctx.rt.networkRetryNotice;
+    const count = notice?.key === key ? notice.count + 1 : 1;
+    const emitted = notice?.key === key ? notice.emitted : false;
+    ctx.rt.networkRetryNotice = { key, count, emitted };
+    if (count >= 2 && !emitted) {
+      ctx.rt.networkRetryNotice = { key, count, emitted: true };
+      queue.push({
+        type: 'error',
+        data: { ...safeErrorData, isTerminal: false, willRetry: true },
+        source: 'codex',
+      });
     }
     return;
   }

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -843,7 +843,9 @@ export class RemoteHost {
       const now = Date.now();
       if (now - rec.lastLocalErrorAt > 30_000) {
         rec.lastLocalErrorAt = now;
-        const suppressed = rec.localErrorCount - rec.lastLocalErrorLoggedCount;
+        // 距上次日志被吞掉的条数, 不含本次 (localErrorCount 已含本次, -1 扣除;
+        // 否则首条日志就会误报 suppressed=1, review: PR #715 greptile R4)。
+        const suppressed = rec.localErrorCount - rec.lastLocalErrorLoggedCount - 1;
         rec.lastLocalErrorLoggedCount = rec.localErrorCount;
         this.log.warn('ssh remote forward: local target unreachable', {
           id: this.id,

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -520,7 +520,15 @@ export class RemoteHost {
    * 指定, 通常是 127.0.0.1 上的 Proxy 端口。
    */
   async ensureRemoteForward(spec: RemoteForwardSpec): Promise<RemoteForward> {
-    if (!spec.localHost || /\s/.test(spec.localHost)) {
+    // 引号与空白同样拒 (与 desktop IPC / prefs-store 校验对齐, review:
+    // PR #715 copilot R8): localHost 是 net.connect 的目的地, 含引号的值
+    // 会晚到 connect 时才以难懂的错误失败, 入口直接给清晰校验错误。
+    if (
+      !spec.localHost ||
+      /\s/.test(spec.localHost) ||
+      spec.localHost.includes("'") ||
+      spec.localHost.includes('"')
+    ) {
       throw new Error(`ensureRemoteForward: invalid localHost "${spec.localHost}"`);
     }
     if (!Number.isInteger(spec.localPort) || spec.localPort < 1 || spec.localPort > 65535) {

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -589,19 +589,27 @@ export class RemoteHost {
    * 在当前 client 上注册 forwardIn。端口冲突 / sshd 拒绝时按候选序列重试,
    * 全部失败抛错 (调用方决定是登记愿望待重试还是直接失败)。
    *
-   * 每次 forwardIn 带 10s 看门狗: 连接在请求在飞时断开的话, ssh2 对
-   * outstanding global request 的回调不保证触发, 裸 await 会永久挂起。
+   * 候选顺序: 先试上次实际绑定的端口 (record.remotePort) — 重连后隧道口
+   * 尽量不变, 远端进程 env (HTTPS_PROXY=http://127.0.0.1:<port>) 不用跟着
+   * 重写; 再按首选基数顺延。每次 forwardIn 带 10s 看门狗: 连接在请求在飞
+   * 时断开的话, ssh2 对 outstanding global request 的回调不保证触发,
+   * 裸 await 会永久挂起。
    */
   private async armForward(record: ForwardRecord): Promise<void> {
     const client = this.requireReady();
     this.attachForwardListener(client);
 
     const base = record.spec.preferredRemotePort ?? DEFAULT_REMOTE_FORWARD_PORT_BASE;
-    const errors: string[] = [];
+    const candidates = [record.remotePort];
     for (let i = 0; i < REMOTE_FORWARD_PORT_SCAN_SPAN; i++) {
-      const port = base + i;
+      if (!candidates.includes(base + i)) candidates.push(base + i);
+    }
+    const errors: string[] = [];
+    for (const port of candidates) {
       const bound = await new Promise<number | null>((resolve) => {
+        let settled = false;
         const timer = setTimeout(() => {
+          settled = true;
           errors.push(`${port}: forwardIn timed out after 10s`);
           resolve(null);
         }, 10_000);
@@ -609,6 +617,21 @@ export class RemoteHost {
         try {
           client.forwardIn('127.0.0.1', port, (err, boundPort) => {
             clearTimeout(timer);
+            if (settled) {
+              // 看门狗已判失败, 迟到的成功会在服务端留下没有 record 的野
+              // 监听 (端口被占 + 连接被默默转走) — 立刻拆除。
+              if (!err) {
+                this.log.warn('late forwardIn success after watchdog timeout — unbinding', {
+                  id: this.id,
+                  port: boundPort || port,
+                });
+                try {
+                  client.unforwardIn('127.0.0.1', boundPort || port, () => { /* best-effort */ });
+                } catch { /* client may be dead */ }
+              }
+              return;
+            }
+            settled = true;
             if (err) {
               errors.push(`${port}: ${err.message}`);
               resolve(null);
@@ -618,11 +641,30 @@ export class RemoteHost {
           });
         } catch (err) {
           clearTimeout(timer);
+          if (settled) return;
+          settled = true;
           errors.push(`${port}: ${(err as Error).message}`);
           resolve(null);
         }
       });
       if (bound == null) continue;
+      // close() 可能发生在 arm 在飞期间: record 已被摘除的话, 刚绑上的
+      // 端口同样是野监听 — 立即 unforward, 以失败收尾 (armForwardDeduped
+      // 的调用方都已 catch)。
+      if (this.forwards.get(forwardKey(record.spec)) !== record) {
+        this.log.warn('forward closed while arming — unbinding just-bound port', {
+          id: this.id,
+          port: bound,
+        });
+        await new Promise<void>((resolve) => {
+          try {
+            client.unforwardIn('127.0.0.1', bound, () => resolve());
+          } catch {
+            resolve();
+          }
+        });
+        throw new Error(`remote forward to ${forwardKey(record.spec)} was closed while arming`);
+      }
       record.remotePort = bound;
       record.armed = true;
       this.log.info('ssh remote forward armed', {
@@ -633,7 +675,7 @@ export class RemoteHost {
       return;
     }
     throw new Error(
-      `remote port forwarding failed on ${this.id} (tried 127.0.0.1:${base}–${base + REMOTE_FORWARD_PORT_SCAN_SPAN - 1}). ` +
+      `remote port forwarding failed on ${this.id} (tried 127.0.0.1:${candidates.join(',')}). ` +
       `The remote sshd may disallow remote forwarding (AllowTcpForwarding) or the ports are busy. ` +
       errors.slice(0, 3).join('; '),
     );

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -135,6 +135,13 @@ interface ForwardRecord {
   localErrorCount: number;
 }
 
+/**
+ * arm 在飞期间连接被换 (断线/重连), forwardIn 的迟到成功落在旧 client 上。
+ * armForward 以此错误收尾; ensureRemoteForward / rearmForwards 识别后立即
+ * 在当前连接重试一次, 而不是把隧道误标 active 或等下次 reconnect。
+ */
+class StaleForwardArmError extends Error {}
+
 function forwardKey(spec: Pick<RemoteForwardSpec, 'localHost' | 'localPort'>): string {
   return `${spec.localHost}:${spec.localPort}`;
 }
@@ -521,7 +528,7 @@ export class RemoteHost {
     if (existing) {
       // 已登记但未 arm (连接刚建好 / 上次 arm 失败) — 趁 ready 补一次。
       if (!existing.armed && this.status === 'ready') {
-        await this.armForwardDeduped(existing);
+        await this.armWithStaleRetry(existing);
       }
       return this.forwardHandle(key, existing);
     }
@@ -535,9 +542,25 @@ export class RemoteHost {
     };
     this.forwards.set(key, record);
     if (this.status === 'ready') {
-      await this.armForwardDeduped(record);
+      await this.armWithStaleRetry(record);
     }
     return this.forwardHandle(key, record);
+  }
+
+  /**
+   * arm + 旧连接迟到回调的一次即时重试 (见 StaleForwardArmError)。
+   * 其余错误原样抛出给调用方 (session 路径 fail-closed / ready-hook 记状态)。
+   */
+  private async armWithStaleRetry(record: ForwardRecord): Promise<void> {
+    try {
+      await this.armForwardDeduped(record);
+    } catch (err) {
+      if (err instanceof StaleForwardArmError && this.status === 'ready') {
+        await this.armForwardDeduped(record);
+        return;
+      }
+      throw err;
+    }
   }
 
   /**
@@ -573,10 +596,26 @@ export class RemoteHost {
         record.armed = false;
         // 连接活着就显式 unforward; 断线时服务端侧随连接消失, 无需操作。
         if (this.status === 'ready' && this.client) {
+          // 与 forwardIn 对称的看门狗 (review: PR #715 五轮审核 P2): 半开连接
+          // 上 ssh2 global request 回调可能丢失, 裸 await 会把 Settings 的
+          // 关闭 proxy / 更新 host 流程永久挂住。超时后照常返回 — record 已
+          // 摘除, 服务端残留随连接死亡消失。
           await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+              this.log.warn('unforwardIn timed out — proceeding (server remnant dies with connection)', {
+                id: this.id,
+                port: record.remotePort,
+              });
+              resolve();
+            }, 5_000);
+            timer.unref?.();
             try {
-              this.client!.unforwardIn('127.0.0.1', record.remotePort, () => resolve());
+              this.client!.unforwardIn('127.0.0.1', record.remotePort, () => {
+                clearTimeout(timer);
+                resolve();
+              });
             } catch {
+              clearTimeout(timer);
               resolve();
             }
           });
@@ -665,6 +704,23 @@ export class RemoteHost {
         });
         throw new Error(`remote forward to ${forwardKey(record.spec)} was closed while arming`);
       }
+      // 连接代际校验 (review: PR #715 五轮审核 P1): arm 在飞期间发生了
+      // 断线/重连的话, this.client 已换成新连接, 这个绑定落在旧 (将死) 连接
+      // 上 — 若不拦截, record 会被误标 armed, rearmForwards 见 armed 直接
+      // 跳过, 隧道「以为建好了实际新连接上没有」。旧 client 上 best-effort
+      // 拆除 (多半已死), 以专门错误收尾让调用方立即在当前连接重试。
+      if (this.client !== client) {
+        this.log.warn('forwardIn resolved on a stale connection — unbinding and re-arming', {
+          id: this.id,
+          port: bound,
+        });
+        try {
+          client.unforwardIn('127.0.0.1', bound, () => { /* best-effort; client likely dead */ });
+        } catch { /* dead */ }
+        throw new StaleForwardArmError(
+          `remote forward to ${forwardKey(record.spec)} armed on a stale connection`,
+        );
+      }
       record.remotePort = bound;
       record.armed = true;
       this.log.info('ssh remote forward armed', {
@@ -686,15 +742,28 @@ export class RemoteHost {
     for (const record of this.forwards.values()) {
       const prevPort = record.remotePort;
       record.armed = false;
-      try {
-        await this.armForwardDeduped(record);
-      } catch (err) {
+      // 旧连接的迟到 arm 回调会以 StaleForwardArmError 收尾 — 当前连接还没
+      // arm, 立即重试一次 (record.arming 已被 finally 清掉, 可重新发起)。
+      // 其余错误 (端口占用 / sshd 拒绝) 不重试, 等下次 reconnect 或 session
+      // 路径的 ensureRemoteForward 显式触发。
+      let armed = false;
+      let lastErr: Error | null = null;
+      for (let attempt = 0; attempt < 2 && !armed; attempt++) {
+        try {
+          await this.armForwardDeduped(record);
+          armed = true;
+        } catch (err) {
+          lastErr = err as Error;
+          if (!(err instanceof StaleForwardArmError)) break;
+        }
+      }
+      if (!armed) {
         // arm 失败不阻断连接 — 记日志, 下次 reconnect 再试; session 路径
         // (ensureRemoteForward on ready host) 会显式重试并拿到错误。
         this.log.warn('ssh remote forward re-arm failed', {
           id: this.id,
           localTarget: forwardKey(record.spec),
-          error: (err as Error).message,
+          error: lastErr?.message,
         });
         continue;
       }
@@ -715,9 +784,12 @@ export class RemoteHost {
   private armForwardDeduped(record: ForwardRecord): Promise<void> {
     if (record.armed) return Promise.resolve();
     if (!record.arming) {
-      record.arming = this.armForward(record).finally(() => {
-        record.arming = undefined;
+      // finally 只在引用仍是自己时清 — markForwardsDisarmed 可能在在飞期间
+      // 清掉旧引用, 新 arm 已重新赋值; 无条件清会误删新 promise 再造竞争。
+      const p = this.armForward(record).finally(() => {
+        if (record.arming === p) record.arming = undefined;
       });
+      record.arming = p;
     }
     return record.arming;
   }
@@ -1048,6 +1120,10 @@ export class RemoteHost {
   private markForwardsDisarmed(): void {
     for (const record of this.forwards.values()) {
       record.armed = false;
+      // 在飞 arm 是在旧连接上发起的 — 清掉引用让新连接的 rearm 重新发起,
+      // 旧 promise 的迟到成功由 armForward 的连接代际校验拦截
+      // (StaleForwardArmError), 不会误标 armed。
+      record.arming = undefined;
     }
   }
 

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -695,10 +695,19 @@ export class RemoteHost {
           id: this.id,
           port: bound,
         });
+        // 与 forwardHandle.close() 相同的 5s 看门狗: 半开连接上 unforwardIn
+        // 回调可能丢失, 这里挂住会把 ensureRemoteForward 的调用方
+        // (Settings 关闭 proxy / 更新 host) 一起拖死 (worker 核验补充)。
         await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => resolve(), 5_000);
+          timer.unref?.();
           try {
-            client.unforwardIn('127.0.0.1', bound, () => resolve());
+            client.unforwardIn('127.0.0.1', bound, () => {
+              clearTimeout(timer);
+              resolve();
+            });
           } catch {
+            clearTimeout(timer);
             resolve();
           }
         });

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -16,7 +16,8 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { Client, type ConnectConfig, type ClientChannel } from 'ssh2';
+import net from 'node:net';
+import { Client, type ConnectConfig, type ClientChannel, type TcpConnectionDetails } from 'ssh2';
 
 import type { HostConfig, HostSnapshot, RemoteStatus } from './types.js';
 import { resolveAuth } from './credentials.js';
@@ -83,6 +84,59 @@ export interface ExecResult {
 export interface ExecStreamOpts {
   pty?: boolean;
   env?: Record<string, string>;
+}
+
+// ── Remote TCP forwarding (OpenSSH `ssh -R` 等价物) ─────────────────────────
+//
+// 用途: 让远端进程 (codex daemon / claude CLI) 把 HTTPS_PROXY 指向远端
+// 127.0.0.1 上的一个端口, 该端口的连接经**同一条 SSH 连接**的多路复用通道
+// 转回本机, 再 pipe 到用户自己的本地 Proxy (如 127.0.0.1:7890)。Cindy 不提供
+// Proxy, 只提供这条隧道。
+//
+// 为什么复用同一条 ssh2 Client 而不起第二条连接: SSH 协议按 channel id 解
+// 复用, forwardIn 的 tcp-forward channel 与 exec channel 在同一条连接上互
+// 不干扰 —— 消息不会"打乱"。多路复用是 SSH 的原生能力。
+//
+// 端口策略: 用**固定首选端口**而不是 port 0, 这样断线重连后隧道口不变,
+// 远端 daemon env (HTTPS_PROXY=http://127.0.0.1:<port>) 不用跟着重写。
+// 首选端口被占用时向后探测少量候选; 真换端口时通过 onRearmed 通知上层
+// (上层在下次 session start 时重写远端 env marker 并重启 daemon, 自愈)。
+
+/** 首选远端绑定端口基数; 被占用时向后探测 PORT_SCAN_SPAN 个候选。 */
+export const DEFAULT_REMOTE_FORWARD_PORT_BASE = 17893;
+const REMOTE_FORWARD_PORT_SCAN_SPAN = 8;
+
+export interface RemoteForwardSpec {
+  /** 本机 (运行 Cindy 的机器) 转发目标 — 用户本地 Proxy 的监听地址。 */
+  localHost: string;
+  localPort: number;
+  /** 远端 127.0.0.1 首选绑定端口; 缺省 DEFAULT_REMOTE_FORWARD_PORT_BASE。 */
+  preferredRemotePort?: number;
+  /** 断线重连后端口被重绑到不同值时回调一次 (首次绑定不回调)。 */
+  onRearmed?: (remotePort: number) => void;
+}
+
+export interface RemoteForward {
+  /** 当前实际绑定的远端端口 (重连后可能变化)。 */
+  readonly remotePort: number;
+  /** 停止转发并释放登记。幂等。 */
+  close(): Promise<void>;
+}
+
+interface ForwardRecord {
+  spec: RemoteForwardSpec;
+  remotePort: number;
+  /** forwardIn 已在当前 live client 上注册成功。 */
+  armed: boolean;
+  /** 进行中的 arm, 去重 ensureRemoteForward 与 rearmForwards 的并发竞争。 */
+  arming?: Promise<void>;
+  /** 本地 Proxy 连接失败的节流日志状态。 */
+  lastLocalErrorAt: number;
+  localErrorCount: number;
+}
+
+function forwardKey(spec: Pick<RemoteForwardSpec, 'localHost' | 'localPort'>): string {
+  return `${spec.localHost}:${spec.localPort}`;
 }
 
 export interface ExecStreamHandle {
@@ -226,6 +280,13 @@ export class RemoteHost {
    * Reset at the start of every connect attempt.
    */
   private hostKeyError: string | null = null;
+  /**
+   * 已登记的 remote forwarding 愿望清单 (key = localHost:localPort)。
+   * 连接断开不清空 — 重连成功后 doConnect 会逐个 re-arm, 尽量绑回原端口。
+   */
+  private forwards = new Map<string, ForwardRecord>();
+  /** 'tcp connection' 是按 client 实例挂的, 每次 doConnect 新建 client 都要重挂。 */
+  private forwardListenerClient: Client | null = null;
 
   constructor(config: HostConfig, deps: RemoteHostDeps) {
     this.id = config.id;
@@ -305,6 +366,7 @@ export class RemoteHost {
   async disconnect(): Promise<void> {
     this.userDisconnected = true;
     this.clearReconnectTimer();
+    this.markForwardsDisarmed();
     if (this.client) {
       try {
         this.client.end();
@@ -432,6 +494,250 @@ export class RemoteHost {
         resolve(wrapChannel(channel));
       });
     });
+  }
+
+  // ── remote TCP forwarding (ssh -R) ────────────────────────────────────────
+
+  /**
+   * 登记并 (若已连接) 立即建立一条 remote forwarding: 远端 127.0.0.1:<port>
+   * 进来的 TCP 连接经本 SSH 连接转回, pipe 到本机 spec.localHost:localPort。
+   *
+   * 幂等: 同 (localHost, localPort) 重复调用返回同一条 forward。
+   * 未连接时只登记愿望, 下次 connect 成功后自动 arm (doConnect → rearmForwards)。
+   *
+   * 安全约束: 远端只绑 127.0.0.1 — 隧道口仅远端本机进程可达, 不对远端所在
+   * 网络暴露 (即不要 GatewayPorts 语义)。本地目标由调用方 (用户 pref) 显式
+   * 指定, 通常是 127.0.0.1 上的 Proxy 端口。
+   */
+  async ensureRemoteForward(spec: RemoteForwardSpec): Promise<RemoteForward> {
+    if (!spec.localHost || /\s/.test(spec.localHost)) {
+      throw new Error(`ensureRemoteForward: invalid localHost "${spec.localHost}"`);
+    }
+    if (!Number.isInteger(spec.localPort) || spec.localPort < 1 || spec.localPort > 65535) {
+      throw new Error(`ensureRemoteForward: invalid localPort ${spec.localPort}`);
+    }
+    const key = forwardKey(spec);
+    const existing = this.forwards.get(key);
+    if (existing) {
+      // 已登记但未 arm (连接刚建好 / 上次 arm 失败) — 趁 ready 补一次。
+      if (!existing.armed && this.status === 'ready') {
+        await this.armForwardDeduped(existing);
+      }
+      return this.forwardHandle(key, existing);
+    }
+
+    const record: ForwardRecord = {
+      spec,
+      remotePort: spec.preferredRemotePort ?? DEFAULT_REMOTE_FORWARD_PORT_BASE,
+      armed: false,
+      lastLocalErrorAt: 0,
+      localErrorCount: 0,
+    };
+    this.forwards.set(key, record);
+    if (this.status === 'ready') {
+      await this.armForwardDeduped(record);
+    }
+    return this.forwardHandle(key, record);
+  }
+
+  /**
+   * 当前登记的 forward 列表 (诊断 / snapshot 用)。armed=false 表示愿望已
+   * 登记但当前没在转发 (未连接 / arm 失败待重连)。
+   */
+  listRemoteForwards(): Array<{ localHost: string; localPort: number; remotePort: number; armed: boolean }> {
+    return Array.from(this.forwards.values()).map((r) => ({
+      localHost: r.spec.localHost,
+      localPort: r.spec.localPort,
+      remotePort: r.remotePort,
+      armed: r.armed,
+    }));
+  }
+
+  /** 关闭并清除所有已登记 forward (pref 关闭路径)。连接断开时是纯本地清理。 */
+  async closeAllRemoteForwards(): Promise<void> {
+    const keys = Array.from(this.forwards.keys());
+    for (const key of keys) {
+      const record = this.forwards.get(key);
+      if (!record) continue;
+      await this.forwardHandle(key, record).close();
+    }
+  }
+
+  private forwardHandle(key: string, record: ForwardRecord): RemoteForward {
+    return {
+      get remotePort() {
+        return record.remotePort;
+      },
+      close: async () => {
+        if (!this.forwards.delete(key)) return;
+        record.armed = false;
+        // 连接活着就显式 unforward; 断线时服务端侧随连接消失, 无需操作。
+        if (this.status === 'ready' && this.client) {
+          await new Promise<void>((resolve) => {
+            try {
+              this.client!.unforwardIn('127.0.0.1', record.remotePort, () => resolve());
+            } catch {
+              resolve();
+            }
+          });
+        }
+      },
+    };
+  }
+
+  /**
+   * 在当前 client 上注册 forwardIn。端口冲突 / sshd 拒绝时按候选序列重试,
+   * 全部失败抛错 (调用方决定是登记愿望待重试还是直接失败)。
+   *
+   * 每次 forwardIn 带 10s 看门狗: 连接在请求在飞时断开的话, ssh2 对
+   * outstanding global request 的回调不保证触发, 裸 await 会永久挂起。
+   */
+  private async armForward(record: ForwardRecord): Promise<void> {
+    const client = this.requireReady();
+    this.attachForwardListener(client);
+
+    const base = record.spec.preferredRemotePort ?? DEFAULT_REMOTE_FORWARD_PORT_BASE;
+    const errors: string[] = [];
+    for (let i = 0; i < REMOTE_FORWARD_PORT_SCAN_SPAN; i++) {
+      const port = base + i;
+      const bound = await new Promise<number | null>((resolve) => {
+        const timer = setTimeout(() => {
+          errors.push(`${port}: forwardIn timed out after 10s`);
+          resolve(null);
+        }, 10_000);
+        timer.unref?.();
+        try {
+          client.forwardIn('127.0.0.1', port, (err, boundPort) => {
+            clearTimeout(timer);
+            if (err) {
+              errors.push(`${port}: ${err.message}`);
+              resolve(null);
+            } else {
+              resolve(boundPort || port);
+            }
+          });
+        } catch (err) {
+          clearTimeout(timer);
+          errors.push(`${port}: ${(err as Error).message}`);
+          resolve(null);
+        }
+      });
+      if (bound == null) continue;
+      record.remotePort = bound;
+      record.armed = true;
+      this.log.info('ssh remote forward armed', {
+        id: this.id,
+        remotePort: bound,
+        localTarget: forwardKey(record.spec),
+      });
+      return;
+    }
+    throw new Error(
+      `remote port forwarding failed on ${this.id} (tried 127.0.0.1:${base}–${base + REMOTE_FORWARD_PORT_SCAN_SPAN - 1}). ` +
+      `The remote sshd may disallow remote forwarding (AllowTcpForwarding) or the ports are busy. ` +
+      errors.slice(0, 3).join('; '),
+    );
+  }
+
+  /** connect 成功后重挂所有已登记 forward; 端口变了通知上层。 */
+  private async rearmForwards(): Promise<void> {
+    for (const record of this.forwards.values()) {
+      const prevPort = record.remotePort;
+      record.armed = false;
+      try {
+        await this.armForwardDeduped(record);
+      } catch (err) {
+        // arm 失败不阻断连接 — 记日志, 下次 reconnect 再试; session 路径
+        // (ensureRemoteForward on ready host) 会显式重试并拿到错误。
+        this.log.warn('ssh remote forward re-arm failed', {
+          id: this.id,
+          localTarget: forwardKey(record.spec),
+          error: (err as Error).message,
+        });
+        continue;
+      }
+      if (record.remotePort !== prevPort) {
+        this.log.warn('ssh remote forward re-bound to a different port', {
+          id: this.id,
+          prevPort,
+          remotePort: record.remotePort,
+        });
+        try {
+          record.spec.onRearmed?.(record.remotePort);
+        } catch { /* listener must not throw */ }
+      }
+    }
+  }
+
+  /** 同一条 forward 的并发 arm 共享一个 in-flight promise。 */
+  private armForwardDeduped(record: ForwardRecord): Promise<void> {
+    if (record.armed) return Promise.resolve();
+    if (!record.arming) {
+      record.arming = this.armForward(record).finally(() => {
+        record.arming = undefined;
+      });
+    }
+    return record.arming;
+  }
+
+  /** 每个 client 实例挂一次 'tcp connection' 分发器。 */
+  private attachForwardListener(client: Client): void {
+    if (this.forwardListenerClient === client) return;
+    this.forwardListenerClient = client;
+    client.on('tcp connection', (details: TcpConnectionDetails, accept, reject) => {
+      this.handleForwardedConnection(details, accept, reject);
+    });
+  }
+
+  private handleForwardedConnection(
+    details: TcpConnectionDetails,
+    accept: () => ClientChannel,
+    reject: () => void,
+  ): void {
+    let record: ForwardRecord | undefined;
+    for (const r of this.forwards.values()) {
+      if (r.armed && r.remotePort === details.destPort) {
+        record = r;
+        break;
+      }
+    }
+    if (!record) {
+      reject();
+      return;
+    }
+    const rec = record;
+    const channel = accept();
+    const sock = net.connect({ host: rec.spec.localHost, port: rec.spec.localPort });
+
+    sock.on('error', (err) => {
+      // 本地 Proxy 没起 / 拒连 — 远端 agent 会看到连接立刻被断, 错误在
+      // agent 侧浮现 (proxy connect failed)。这里只做节流日志。
+      rec.localErrorCount += 1;
+      const now = Date.now();
+      if (now - rec.lastLocalErrorAt > 30_000) {
+        rec.lastLocalErrorAt = now;
+        this.log.warn('ssh remote forward: local target unreachable', {
+          id: this.id,
+          localTarget: forwardKey(rec.spec),
+          error: err.message,
+          suppressedCount: rec.localErrorCount,
+        });
+      }
+      try { channel.close(); } catch { /* already gone */ }
+    });
+    channel.on('error', () => {
+      sock.destroy();
+    });
+    // 远端关掉转发 channel → 本地到 Proxy 的 socket 同步销毁; 否则本地
+    // Proxy 侧会积一堆半开连接 (pipe 的 end 只处理正常 EOF, 不覆盖 destroy)。
+    channel.on('close', () => {
+      sock.destroy();
+    });
+    sock.on('close', () => {
+      try { channel.close(); } catch { /* already gone */ }
+    });
+    channel.pipe(sock);
+    sock.pipe(channel);
   }
 
   // ── internals ────────────────────────────────────────────────────────────
@@ -565,6 +871,9 @@ export class RemoteHost {
         this.reconnectAttempts = 0;
         this.setStatus('ready');
         this.log.info('ssh ready', { id: this.id, auth: auth.label });
+        // 后台重挂已登记的 remote forwards; 不阻塞 connect 返回 (session
+        // 路径会自己 await ensureRemoteForward 拿到 arm 错误)。
+        void this.rearmForwards();
         resolve();
       };
 
@@ -634,6 +943,7 @@ export class RemoteHost {
 
   private handlePostReadyClose(): void {
     this.client = null;
+    this.markForwardsDisarmed();
     if (this.userDisconnected) {
       this.setStatus('disconnected');
       return;
@@ -689,6 +999,13 @@ export class RemoteHost {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+  }
+
+  /** 连接断了后服务端侧的转发监听随之消失; 愿望保留, 等下次 ready 重挂。 */
+  private markForwardsDisarmed(): void {
+    for (const record of this.forwards.values()) {
+      record.armed = false;
     }
   }
 

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -133,6 +133,9 @@ interface ForwardRecord {
   /** 本地 Proxy 连接失败的节流日志状态。 */
   lastLocalErrorAt: number;
   localErrorCount: number;
+  /** 上次实际打日志时的 localErrorCount — suppressedCount 报「距上次日志被吞掉
+   *  几条」而不是单调总计数 (review: PR #715 copilot R3)。 */
+  lastLocalErrorLoggedCount: number;
 }
 
 /**
@@ -539,6 +542,7 @@ export class RemoteHost {
       armed: false,
       lastLocalErrorAt: 0,
       localErrorCount: 0,
+      lastLocalErrorLoggedCount: 0,
     };
     this.forwards.set(key, record);
     if (this.status === 'ready') {
@@ -839,13 +843,18 @@ export class RemoteHost {
       const now = Date.now();
       if (now - rec.lastLocalErrorAt > 30_000) {
         rec.lastLocalErrorAt = now;
+        const suppressed = rec.localErrorCount - rec.lastLocalErrorLoggedCount;
+        rec.lastLocalErrorLoggedCount = rec.localErrorCount;
         this.log.warn('ssh remote forward: local target unreachable', {
           id: this.id,
           localTarget: forwardKey(rec.spec),
           error: err.message,
-          suppressedCount: rec.localErrorCount,
+          suppressedCount: suppressed,
         });
       }
+      // error 后 socket 必须销毁 (review: PR #715 copilot R3) — 只关 channel
+      // 不 destroy 会把本地侧留成半开, Proxy 进程上积 CLOSE_WAIT。
+      sock.destroy();
       try { channel.close(); } catch { /* already gone */ }
     });
     channel.on('error', () => {
@@ -1134,6 +1143,10 @@ export class RemoteHost {
       // (StaleForwardArmError), 不会误标 armed。
       record.arming = undefined;
     }
+    // 分发器挂在旧 client 上 — 清掉引用, 否则 RemoteHost 长期持有死 client
+    // (抑制 GC + 多次重连后旧 client 上 listener 堆积, review: PR #715
+    // copilot R3)。新 client 首次 arm 时 attachForwardListener 会重新挂。
+    this.forwardListenerClient = null;
   }
 
   private setStatus(next: RemoteStatus): void {

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -580,6 +580,19 @@ export class RemoteHost {
     }));
   }
 
+  /**
+   * 关闭指定本地目标的单条 forward (无该登记时 no-op)。与 closeAll 不同
+   * 不会在 ensure 语义下误触发 arm — 用于「目标变了, 先拆旧的」
+   * (review: PR #715 R5: pref 的 localHost/localPort 被编辑后, 旧目标的
+   * forward 会残留并随重连 re-arm, 远端多暴露一个隧道口)。
+   */
+  async closeRemoteForward(localHost: string, localPort: number): Promise<void> {
+    const key = `${localHost}:${localPort}`;
+    const record = this.forwards.get(key);
+    if (!record) return;
+    await this.forwardHandle(key, record).close();
+  }
+
   /** 关闭并清除所有已登记 forward (pref 关闭路径)。连接断开时是纯本地清理。 */
   async closeAllRemoteForwards(): Promise<void> {
     const keys = Array.from(this.forwards.keys());

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -852,6 +852,23 @@ export class RemoteHost {
     accept: () => ClientChannel,
     reject: () => void,
   ): void {
+    // fail-closed (PR #715 copilot): 远端 sshd 若配了 permissive GatewayPorts,
+    // 隧道口可能绑在非 loopback 接口 — 远端网络的任意机器都能经隧道借用
+    // 本机的本地 Proxy。只接受 loopback 来源的转发连接 (远端 daemon 与
+    // sshd 同机, 合法来源恒为 loopback; IPv6 / IPv4-mapped 形式都认)。
+    if (
+      details.srcIP !== '127.0.0.1'
+      && details.srcIP !== '::1'
+      && details.srcIP !== '::ffff:127.0.0.1'
+    ) {
+      this.log.warn('ssh remote forward: rejecting non-loopback forwarded connection', {
+        id: this.id,
+        srcIP: details.srcIP,
+        destPort: details.destPort,
+      });
+      reject();
+      return;
+    }
     let record: ForwardRecord | undefined;
     for (const r of this.forwards.values()) {
       if (r.armed && r.remotePort === details.destPort) {

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -526,6 +526,16 @@ export class RemoteHost {
     if (!Number.isInteger(spec.localPort) || spec.localPort < 1 || spec.localPort > 65535) {
       throw new Error(`ensureRemoteForward: invalid localPort ${spec.localPort}`);
     }
+    // preferredRemotePort 同样入口校验 (review: PR #715 copilot R7): 0 会静默
+    // 变成「远端绑 ephemeral 端口」语义, 越界值则晚到 arm 才失败, 都难排查。
+    if (
+      spec.preferredRemotePort !== undefined &&
+      (!Number.isInteger(spec.preferredRemotePort) ||
+        spec.preferredRemotePort < 1 ||
+        spec.preferredRemotePort > 65535)
+    ) {
+      throw new Error(`ensureRemoteForward: invalid preferredRemotePort ${spec.preferredRemotePort}`);
+    }
     const key = forwardKey(spec);
     const existing = this.forwards.get(key);
     if (existing) {

--- a/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
@@ -357,6 +357,31 @@ describe('RemoteHost remote forwarding', () => {
     });
   });
 
+  it('re-arms on the current connection when forwardIn resolves on a stale one (review P1)', async () => {
+    // arm 在飞期间断线/重连: 旧 client 的迟到成功不得把隧道误标 armed —
+    // 应在旧 client 上 unbind 并在当前连接上重试。
+    const client1 = new ManualForwardClient();
+    const client2 = new ManualForwardClient();
+    const host = makeReadyHost(client1);
+    const pending = host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+    // 断线/重连窗口: markForwardsDisarmed 清掉在飞 arm 引用, client 换成新连接。
+    (host as unknown as { markForwardsDisarmed(): void }).markForwardsDisarmed();
+    (host as unknown as { client: unknown }).client = client2;
+    // 旧连接迟到成功 → StaleForwardArmError → armWithStaleRetry 立即在 client2 重试。
+    client1.succeed(DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    await flush();
+    expect(client1.unforwardInCalls).toContainEqual({
+      addr: '127.0.0.1',
+      port: DEFAULT_REMOTE_FORWARD_PORT_BASE,
+    });
+    // 重试落在 client2 上, 完成绑定。
+    expect(client2.pending.has(DEFAULT_REMOTE_FORWARD_PORT_BASE)).toBe(true);
+    client2.succeed(DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    const fwd = await pending;
+    expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    expect(host.listRemoteForwards()[0]?.armed).toBe(true);
+  });
+
   it('keeps the wish when re-arm fails, without throwing (logged only)', async () => {
     const client1 = new FakeClient();
     const host = makeReadyHost(client1);

--- a/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
@@ -193,6 +193,14 @@ describe('RemoteHost remote forwarding', () => {
     await expect(
       host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890, preferredRemotePort: 70000 }),
     ).rejects.toThrow(/preferredRemotePort/);
+    // localHost 的引号与空白同样拒 (与 desktop IPC / prefs-store 对齐,
+    // review: PR #715 copilot R8) — 否则晚到 net.connect 才以难懂的错误失败。
+    await expect(
+      host.ensureRemoteForward({ localHost: `12'7.0.0.1`, localPort: 7890 }),
+    ).rejects.toThrow(/localHost/);
+    await expect(
+      host.ensureRemoteForward({ localHost: '12"7.0.0.1', localPort: 7890 }),
+    ).rejects.toThrow(/localHost/);
   });
 
   it('is idempotent for the same local target (no duplicate forwardIn)', async () => {

--- a/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
@@ -10,7 +10,7 @@
  *   - 断线重连 re-arm: 愿望保留、端口变化触发 onRearmed
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { Duplex, PassThrough } from 'node:stream';
 import net from 'node:net';
@@ -36,6 +36,8 @@ const noopLogger = {
 
 interface ForwardInCall { addr: string; port: number }
 
+type ForwardInCallback = (err: Error | undefined, port: number) => void;
+
 /** 可按端口决定成败的 fake ssh2 Client。 */
 class FakeClient extends EventEmitter {
   forwardInCalls: ForwardInCall[] = [];
@@ -44,7 +46,7 @@ class FakeClient extends EventEmitter {
   constructor(private readonly allowPort: (port: number) => boolean = () => true) {
     super();
   }
-  forwardIn(addr: string, port: number, cb: (err: Error | undefined, port: number) => void): void {
+  forwardIn(addr: string, port: number, cb: ForwardInCallback): void {
     this.forwardInCalls.push({ addr, port });
     queueMicrotask(() => {
       if (this.allowPort(port)) cb(undefined, port);
@@ -54,6 +56,24 @@ class FakeClient extends EventEmitter {
   unforwardIn(addr: string, port: number, cb: () => void): void {
     this.unforwardInCalls.push({ addr, port });
     queueMicrotask(() => cb());
+  }
+}
+
+/** forwardIn 回调完全手动驱动的 fake — 用来造在飞 / 迟到回调的竞态场景。 */
+class ManualForwardClient extends EventEmitter {
+  pending = new Map<number, ForwardInCallback>();
+  unforwardInCalls: ForwardInCall[] = [];
+  forwardIn(_addr: string, port: number, cb: ForwardInCallback): void {
+    this.pending.set(port, cb);
+  }
+  unforwardIn(addr: string, port: number, cb: () => void): void {
+    this.unforwardInCalls.push({ addr, port });
+    queueMicrotask(() => cb());
+  }
+  succeed(port: number): void {
+    const cb = this.pending.get(port);
+    this.pending.delete(port);
+    cb?.(undefined, port);
   }
 }
 
@@ -89,7 +109,13 @@ function makeFakeChannel(): FakeChannelBundle {
   return { channel, fromRemote, toRemote, closed: () => closed };
 }
 
-function makeReadyHost(client: FakeClient): RemoteHost {
+/** makeReadyHost 接受的最小 fake client 面 (FakeClient / ManualForwardClient 共用)。 */
+interface FakeSshClient extends EventEmitter {
+  forwardIn(addr: string, port: number, cb: ForwardInCallback): void;
+  unforwardIn(addr: string, port: number, cb: () => void): void;
+}
+
+function makeReadyHost(client: FakeSshClient): RemoteHost {
   const host = new RemoteHost(HOST_CONFIG, { logger: noopLogger });
   (host as unknown as { status: string }).status = 'ready';
   (host as unknown as { client: unknown }).client = client;
@@ -265,6 +291,70 @@ describe('RemoteHost remote forwarding', () => {
     expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
     expect(rearmed).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
     expect(host.listRemoteForwards()[0]?.armed).toBe(true);
+  });
+
+  it('re-arm prefers the last bound port (no churn / no onRearmed when it is still free)', async () => {
+    // 首轮 base 被占 → 绑到 base+1; 重连后 base 已空闲, 仍应留在 base+1
+    // (远端 daemon env / marker 指向它, 端口 churn 会触发无谓的 env 重写)。
+    const client1 = new FakeClient((port) => port !== DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    const host = makeReadyHost(client1);
+    let rearmed: number | null = null;
+    const fwd = await host.ensureRemoteForward({
+      localHost: '127.0.0.1',
+      localPort: 7890,
+      onRearmed: (port) => { rearmed = port; },
+    });
+    expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
+
+    (host as unknown as { markForwardsDisarmed(): void }).markForwardsDisarmed();
+    const client2 = new FakeClient(() => true); // 全部空闲
+    (host as unknown as { client: unknown }).client = client2;
+    await (host as unknown as { rearmForwards(): Promise<void> }).rearmForwards();
+
+    expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
+    expect(rearmed).toBeNull();
+    expect(client2.forwardInCalls.map((c) => c.port)).toEqual([DEFAULT_REMOTE_FORWARD_PORT_BASE + 1]);
+  });
+
+  it('unbinds a late forwardIn success that races the 10s watchdog', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new ManualForwardClient();
+      const host = makeReadyHost(client);
+      const pending = host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+      // 第一个候选卡在在飞状态; 看门狗 10s 后判失败, 转下一候选。
+      await vi.advanceTimersByTimeAsync(10_100);
+      expect(client.pending.has(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1)).toBe(true);
+      // 迟到的成功: 必须立刻 unbind, 不能在服务端留下野监听。
+      client.succeed(DEFAULT_REMOTE_FORWARD_PORT_BASE);
+      expect(client.unforwardInCalls).toContainEqual({
+        addr: '127.0.0.1',
+        port: DEFAULT_REMOTE_FORWARD_PORT_BASE,
+      });
+      client.succeed(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
+      const fwd = await pending;
+      expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('unbinds the just-bound port when close() races an in-flight arm', async () => {
+    const client = new ManualForwardClient();
+    const host = makeReadyHost(client);
+    const pending = host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+    pending.catch(() => { /* assertion below via rejects */ });
+    // arm 在飞 (forwardIn 未回调) 时关掉 forward。
+    await host.closeAllRemoteForwards();
+    expect(host.listRemoteForwards()).toEqual([]);
+    // 迟到的绑定成功: record 已摘除, 必须 unbind 而不是留野监听。
+    client.succeed(DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    await expect(pending).rejects.toThrow(/closed while arming/);
+    await flush();
+    expect(client.unforwardInCalls).toContainEqual({
+      addr: '127.0.0.1',
+      port: DEFAULT_REMOTE_FORWARD_PORT_BASE,
+    });
   });
 
   it('keeps the wish when re-arm fails, without throwing (logged only)', async () => {

--- a/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
@@ -185,6 +185,14 @@ describe('RemoteHost remote forwarding', () => {
     await expect(
       host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 0 }),
     ).rejects.toThrow(/localPort/);
+    // preferredRemotePort 同样入口校验: 0 会静默变成远端 ephemeral 绑端口语义
+    // (review: PR #715 copilot R7)。
+    await expect(
+      host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890, preferredRemotePort: 0 }),
+    ).rejects.toThrow(/preferredRemotePort/);
+    await expect(
+      host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890, preferredRemotePort: 70000 }),
+    ).rejects.toThrow(/preferredRemotePort/);
   });
 
   it('is idempotent for the same local target (no duplicate forwardIn)', async () => {

--- a/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
@@ -274,6 +274,24 @@ describe('RemoteHost remote forwarding', () => {
     expect(rejected).toBe(true);
   });
 
+  it('rejects forwarded connections from non-loopback sources (fail-closed, PR #715 copilot)', async () => {
+    // 远端 sshd 配了 permissive GatewayPorts 时, 隧道口绑到非 loopback 接口,
+    // 远端网络的任意机器都能经隧道借用本机 Proxy — 只接受 loopback 来源
+    // (远端 daemon 与 sshd 同机, 合法来源恒为 loopback)。
+    const client = new FakeClient();
+    const host = makeReadyHost(client);
+    const fwd = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+
+    let rejected = false;
+    client.emit(
+      'tcp connection',
+      { srcIP: '192.168.1.50', srcPort: 55003, destIP: '192.168.1.10', destPort: fwd.remotePort },
+      () => { throw new Error('unexpected accept'); },
+      () => { rejected = true; },
+    );
+    expect(rejected).toBe(true);
+  });
+
   it('close() unforwards on the live client and drops the record', async () => {
     const client = new FakeClient();
     const host = makeReadyHost(client);

--- a/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
@@ -382,6 +382,24 @@ describe('RemoteHost remote forwarding', () => {
     expect(host.listRemoteForwards()[0]?.armed).toBe(true);
   });
 
+  it('clears the forward listener client on disconnect; a new client re-attaches (review R3)', async () => {
+    // forwardListenerClient 不清会让 RemoteHost 长期持有死 client (抑制 GC +
+    // 多次重连后旧 client listener 堆积); 断连后必须置空, 新连接 arm 时重挂。
+    const client1 = new FakeClient();
+    const host = makeReadyHost(client1);
+    await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+    expect(client1.listenerCount('tcp connection')).toBe(1);
+
+    (host as unknown as { markForwardsDisarmed(): void }).markForwardsDisarmed();
+    expect((host as unknown as { forwardListenerClient: unknown }).forwardListenerClient).toBeNull();
+
+    const client2 = new FakeClient();
+    (host as unknown as { client: unknown }).client = client2;
+    await (host as unknown as { rearmForwards(): Promise<void> }).rearmForwards();
+    expect(client2.listenerCount('tcp connection')).toBe(1);
+    expect((host as unknown as { forwardListenerClient: unknown }).forwardListenerClient).toBe(client2);
+  });
+
   it('keeps the wish when re-arm fails, without throwing (logged only)', async () => {
     const client1 = new FakeClient();
     const host = makeReadyHost(client1);

--- a/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remoteHostForward.test.ts
@@ -1,0 +1,299 @@
+/**
+ * RemoteHost remote forwarding (ssh -R 等价物) 测试。
+ *
+ * 用 fake ssh2 Client (EventEmitter + forwardIn/unforwardIn) 注入私有字段,
+ * 本地端用真实 net server (127.0.0.1 回环) 验证字节 pipe:
+ *   - 首选端口绑定 / 端口冲突顺延 / 全部失败时报错提及 AllowTcpForwarding
+ *   - 'tcp connection' 分发到正确的 forward 并双向 pipe
+ *   - 本地目标不可达时只断 channel 不炸进程
+ *   - ensure 幂等 / close 调 unforwardIn
+ *   - 断线重连 re-arm: 愿望保留、端口变化触发 onRearmed
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Duplex, PassThrough } from 'node:stream';
+import net from 'node:net';
+
+import { RemoteHost, DEFAULT_REMOTE_FORWARD_PORT_BASE } from '../RemoteHost.js';
+import type { HostConfig } from '../types.js';
+
+const HOST_CONFIG: HostConfig = {
+  id: 'test-host',
+  hostname: '10.0.0.1',
+  port: 22,
+  user: 'deploy',
+  authMethod: 'agent',
+  source: 'manual',
+};
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+interface ForwardInCall { addr: string; port: number }
+
+/** 可按端口决定成败的 fake ssh2 Client。 */
+class FakeClient extends EventEmitter {
+  forwardInCalls: ForwardInCall[] = [];
+  unforwardInCalls: ForwardInCall[] = [];
+  /** 返回 false 的端口 forwardIn 失败 (模拟被占用 / sshd 拒绝)。 */
+  constructor(private readonly allowPort: (port: number) => boolean = () => true) {
+    super();
+  }
+  forwardIn(addr: string, port: number, cb: (err: Error | undefined, port: number) => void): void {
+    this.forwardInCalls.push({ addr, port });
+    queueMicrotask(() => {
+      if (this.allowPort(port)) cb(undefined, port);
+      else cb(new Error('Unable to bind'), 0);
+    });
+  }
+  unforwardIn(addr: string, port: number, cb: () => void): void {
+    this.unforwardInCalls.push({ addr, port });
+    queueMicrotask(() => cb());
+  }
+}
+
+interface FakeChannelBundle {
+  channel: Duplex & { close: () => void };
+  /** test 写入 → channel readable → 本地 sock (模拟远端发来的字节)。 */
+  fromRemote: PassThrough;
+  /** 本地 sock 写入 → test 读出 (模拟要送回远端的字节)。 */
+  toRemote: PassThrough;
+  closed: () => boolean;
+}
+
+function makeFakeChannel(): FakeChannelBundle {
+  const fromRemote = new PassThrough();
+  const toRemote = new PassThrough();
+  let closed = false;
+  // 手工拼 Duplex (@types/node 没有 {readable,writable} pair overload 的类型):
+  // readable 侧由 fromRemote 推, writable 侧落进 toRemote 供断言。
+  const channel = new Duplex({
+    read() {},
+    write(chunk: Buffer, _enc: BufferEncoding, cb: (err?: Error | null) => void) {
+      if (toRemote.write(chunk)) cb();
+      else toRemote.once('drain', () => cb());
+    },
+  }) as Duplex & { close: () => void };
+  fromRemote.on('data', (chunk: Buffer) => channel.push(chunk));
+  fromRemote.on('end', () => channel.push(null));
+  channel.close = () => {
+    if (closed) return;
+    closed = true;
+    channel.destroy();
+  };
+  return { channel, fromRemote, toRemote, closed: () => closed };
+}
+
+function makeReadyHost(client: FakeClient): RemoteHost {
+  const host = new RemoteHost(HOST_CONFIG, { logger: noopLogger });
+  (host as unknown as { status: string }).status = 'ready';
+  (host as unknown as { client: unknown }).client = client;
+  return host;
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+/** 起一个在 127.0.0.1 随机端口的 echo server, 返回端口与关闭函数。 */
+async function startEchoServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = net.createServer((sock) => sock.pipe(sock));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  return {
+    port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe('RemoteHost remote forwarding', () => {
+  it('arms forwardIn on the preferred port and lists it as armed', async () => {
+    const client = new FakeClient();
+    const host = makeReadyHost(client);
+    const fwd = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+
+    expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    expect(client.forwardInCalls).toEqual([
+      { addr: '127.0.0.1', port: DEFAULT_REMOTE_FORWARD_PORT_BASE },
+    ]);
+    expect(host.listRemoteForwards()).toEqual([
+      {
+        localHost: '127.0.0.1',
+        localPort: 7890,
+        remotePort: DEFAULT_REMOTE_FORWARD_PORT_BASE,
+        armed: true,
+      },
+    ]);
+  });
+
+  it('falls back to the next candidate port when the preferred one is taken', async () => {
+    const client = new FakeClient((port) => port !== DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    const host = makeReadyHost(client);
+    const fwd = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+
+    expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
+    expect(client.forwardInCalls.map((c) => c.port)).toEqual([
+      DEFAULT_REMOTE_FORWARD_PORT_BASE,
+      DEFAULT_REMOTE_FORWARD_PORT_BASE + 1,
+    ]);
+  });
+
+  it('throws an actionable error when every candidate port fails', async () => {
+    const client = new FakeClient(() => false);
+    const host = makeReadyHost(client);
+    await expect(
+      host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 }),
+    ).rejects.toThrow(/AllowTcpForwarding/);
+  });
+
+  it('rejects invalid local targets before touching ssh', async () => {
+    const host = makeReadyHost(new FakeClient());
+    await expect(
+      host.ensureRemoteForward({ localHost: 'bad host', localPort: 7890 }),
+    ).rejects.toThrow(/localHost/);
+    await expect(
+      host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 0 }),
+    ).rejects.toThrow(/localPort/);
+  });
+
+  it('is idempotent for the same local target (no duplicate forwardIn)', async () => {
+    const client = new FakeClient();
+    const host = makeReadyHost(client);
+    const a = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+    const b = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+    expect(a.remotePort).toBe(b.remotePort);
+    expect(client.forwardInCalls).toHaveLength(1);
+  });
+
+  it('pipes a forwarded connection to the local target and back', async () => {
+    const echo = await startEchoServer();
+    try {
+      const client = new FakeClient();
+      const host = makeReadyHost(client);
+      const fwd = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: echo.port });
+
+      const fake = makeFakeChannel();
+      client.emit(
+        'tcp connection',
+        { srcIP: '127.0.0.1', srcPort: 55000, destIP: '127.0.0.1', destPort: fwd.remotePort },
+        () => fake.channel,
+        () => { throw new Error('unexpected reject'); },
+      );
+      fake.fromRemote.write('ping-through-tunnel');
+      await flush();
+
+      // echo server 原样弹回 → 应出现在要送回远端的流里。
+      expect(fake.toRemote.read()?.toString()).toBe('ping-through-tunnel');
+      fake.channel.close();
+    } finally {
+      await echo.close();
+    }
+  });
+
+  it('closes the channel (no crash) when the local target is unreachable', async () => {
+    // 先占一个端口再释放, 拿到一个几乎必然拒连的端口。
+    const probe = await startEchoServer();
+    const deadPort = probe.port;
+    await probe.close();
+
+    const client = new FakeClient();
+    const host = makeReadyHost(client);
+    const fwd = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: deadPort });
+
+    const fake = makeFakeChannel();
+    client.emit(
+      'tcp connection',
+      { srcIP: '127.0.0.1', srcPort: 55001, destIP: '127.0.0.1', destPort: fwd.remotePort },
+      () => fake.channel,
+      () => { throw new Error('unexpected reject'); },
+    );
+    // ECONNREFUSED 是异步的; 等它发生。
+    await flush();
+    expect(fake.closed()).toBe(true);
+  });
+
+  it('rejects connections to unknown destPorts', async () => {
+    const client = new FakeClient();
+    const host = makeReadyHost(client);
+    await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+
+    let rejected = false;
+    client.emit(
+      'tcp connection',
+      { srcIP: '127.0.0.1', srcPort: 55002, destIP: '127.0.0.1', destPort: 1 },
+      () => { throw new Error('unexpected accept'); },
+      () => { rejected = true; },
+    );
+    expect(rejected).toBe(true);
+  });
+
+  it('close() unforwards on the live client and drops the record', async () => {
+    const client = new FakeClient();
+    const host = makeReadyHost(client);
+    const fwd = await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+    await fwd.close();
+
+    expect(client.unforwardInCalls).toEqual([
+      { addr: '127.0.0.1', port: DEFAULT_REMOTE_FORWARD_PORT_BASE },
+    ]);
+    expect(host.listRemoteForwards()).toEqual([]);
+  });
+
+  it('re-arms on reconnect and reports a changed port via onRearmed', async () => {
+    const client1 = new FakeClient();
+    const host = makeReadyHost(client1);
+    let rearmed: number | null = null;
+    const fwd = await host.ensureRemoteForward({
+      localHost: '127.0.0.1',
+      localPort: 7890,
+      onRearmed: (port) => { rearmed = port; },
+    });
+    expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE);
+
+    // 模拟断线重连: 标记 disarm (handlePostReadyClose 路径) 并换上新 client,
+    // 新连接上原端口已被别人占 → 应顺延并回调 onRearmed。
+    (host as unknown as { markForwardsDisarmed(): void }).markForwardsDisarmed();
+    const client2 = new FakeClient((port) => port !== DEFAULT_REMOTE_FORWARD_PORT_BASE);
+    (host as unknown as { client: unknown }).client = client2;
+    await (host as unknown as { rearmForwards(): Promise<void> }).rearmForwards();
+
+    expect(fwd.remotePort).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
+    expect(rearmed).toBe(DEFAULT_REMOTE_FORWARD_PORT_BASE + 1);
+    expect(host.listRemoteForwards()[0]?.armed).toBe(true);
+  });
+
+  it('keeps the wish when re-arm fails, without throwing (logged only)', async () => {
+    const client1 = new FakeClient();
+    const host = makeReadyHost(client1);
+    await host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+
+    (host as unknown as { markForwardsDisarmed(): void }).markForwardsDisarmed();
+    const client2 = new FakeClient(() => false);
+    (host as unknown as { client: unknown }).client = client2;
+    await (host as unknown as { rearmForwards(): Promise<void> }).rearmForwards();
+
+    const listed = host.listRemoteForwards();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.armed).toBe(false);
+  });
+
+  it('defers arming until connect when the host is not ready', async () => {
+    const client = new FakeClient();
+    const host = new RemoteHost(HOST_CONFIG, { logger: noopLogger });
+    // disconnected 状态: 只登记愿望, 不碰 ssh。
+    const fwdPromise = host.ensureRemoteForward({ localHost: '127.0.0.1', localPort: 7890 });
+    await expect(fwdPromise).resolves.toBeDefined();
+    expect(client.forwardInCalls).toHaveLength(0);
+
+    // 连接建立 → doConnect onReady 路径的 rearmForwards 把它挂上。
+    (host as unknown as { status: string }).status = 'ready';
+    (host as unknown as { client: unknown }).client = client;
+    await (host as unknown as { rearmForwards(): Promise<void> }).rearmForwards();
+    expect(client.forwardInCalls).toHaveLength(1);
+  });
+});

--- a/packages/maker-remote-ssh/src/constants.ts
+++ b/packages/maker-remote-ssh/src/constants.ts
@@ -5,3 +5,16 @@ export const REMOTE_CC_MGR_LOG_PATH = `${REMOTE_CC_MGR_DIR}/cc-mgr.log`;
 export const REMOTE_CC_MGR_PID_PATH = `${REMOTE_CC_MGR_DIR}/cc-mgr.pid`;
 export const REMOTE_XDT_NODE_PATH = '$HOME/.xdt-server/v1/node/bin/node';
 export const REMOTE_CLAUDE_SHIM_PATH = '$HOME/.xdt-server/v1/node_modules/.bin/claude';
+
+/**
+ * 远端 install root (codex-home / node / cc-manager 的公共父目录)。
+ * codex-remote-transport 的 daemon wrapper 与 agent-proxy 的 env marker
+ * 都以它为基准; 改这里要同步两端。
+ */
+export const REMOTE_INSTALL_ROOT = '$HOME/.xdt-server/v1';
+/**
+ * Agent Proxy 隧道 env marker: 远端 shell 片段 (export HTTPS_PROXY=...),
+ * codex daemon wrapper 启动前 source 它。删文件 = 关闭代理。路径在
+ * install root 而非 CODEX_HOME 内, 避免被 codex 自己的目录管理误删。
+ */
+export const REMOTE_AGENT_PROXY_ENV_PATH = `${REMOTE_INSTALL_ROOT}/agent-proxy.env`;

--- a/packages/maker-remote-ssh/src/index.ts
+++ b/packages/maker-remote-ssh/src/index.ts
@@ -6,7 +6,7 @@
  * claude/codex over an exec channel + session ingest.
  */
 
-export { RemoteHost, isAuthFailure, authFailureHint } from './RemoteHost.js';
+export { RemoteHost, isAuthFailure, authFailureHint, DEFAULT_REMOTE_FORWARD_PORT_BASE } from './RemoteHost.js';
 export type {
   RemoteHostDeps,
   StatusListener,
@@ -14,6 +14,8 @@ export type {
   ExecResult,
   ExecStreamOpts,
   ExecStreamHandle,
+  RemoteForward,
+  RemoteForwardSpec,
 } from './RemoteHost.js';
 
 export {
@@ -59,6 +61,8 @@ export {
   REMOTE_CC_MGR_PID_PATH,
   REMOTE_XDT_NODE_PATH,
   REMOTE_CLAUDE_SHIM_PATH,
+  REMOTE_INSTALL_ROOT,
+  REMOTE_AGENT_PROXY_ENV_PATH,
 } from './constants.js';
 
 export { ConnectionPool } from './ConnectionPool.js';


### PR DESCRIPTION
## 这次改了什么

### 摘要

两件事，同一个 issue（#677）：

**① 修复：远端 codex 摸不到后端时 session 永卡 `generating`、无任何错误浮现。**

远端 SSH 机器无法访问 `chatgpt.com`（403 / timeout / websocket unreachable）时，远端 codex daemon 会以 ~1s 间隔无限发送 `willRetry=true` 的 error notification，而客户端按协议设计对 willRetry 不收口——turn 永不结束，renderer 只有终态 error / Done 才复位 generating，用户零感知。三处断链面全部修复：

- **retry-loop 终局升级**：新增 `TurnRetryTracker`，同 turn willRetry 错误达 30 次或持续 120s 即合成终态错误，走与原生终态 error 完全相同的收口路径（`terminalErroredTurnIds` + Done status + 墓碑挡晚到事件）。错误消息带末次原始错误与排查方向；remote session 额外指向 ② 的隧道设置。auth 缺失（401）特意排除——它有「同步登录态」等待式 UX，不能抢路径。
- **透出提示泛化**：原先同 turn 第 2 次重试才透出的非终止提示只认 networkish pattern，而 `unexpected status 403 Forbidden` / `failed to connect to websocket: Network unreachable` 都不命中——一条事件都收不到。现在任何持续性重试错误第 2 次都透一条（`isTerminal:false`，不结束 turn，恢复后自动清）。
- **关键 RPC 加 60s 超时**：`thread/start` / `thread/resume` / `turn/start` 原先裸 await 无上限，daemon 失联时同样永挂。`AppServerHost.request` 增加 `timeoutMs` 透传（client 早已支持），超时走既有启动失败收口。注意：超时只代表不再等，server 侧可能已建 turn——迟到事件按 stale turn 丢弃，不影响 UI 复位。

claude-code 远端不受此 bug 影响（原生 stream watchdog + upstream idle 兜底），本次不动。

**② 功能：SSH 远程主机支持「Agent 流量走本地 Proxy」隧道。**

issue 的根本纾解：让远端 agent（codex daemon / Claude Code）的流量经 SSH 反向隧道（`ssh -R` 语义）从**用户本机自己的 Proxy**（如 Clash 的 127.0.0.1:7890）流出。Cindy 不提供 Proxy，只建隧道；域名由用户 Proxy 端解析（HTTP CONNECT 语义），远端完全不需要能解析/直连后端域名。

```
远端 codex daemon / claude CLI   HTTPS_PROXY=http://127.0.0.1:<隧道口>
        │  sshd remote forwarding（复用同一条 SSH 连接的多路复用 channel）
本机 pipe → 用户本地 Proxy（默认 127.0.0.1:7890）
```

- **复用现有 SSH 连接**（`forwardIn` 与 exec channel 按 channel id 解复用，互不干扰，不另起连接）；固定首选端口 17893（冲突顺延少量候选），断线重连自动 re-arm 且尽量绑回原端口——远端 daemon env 不因重连失效；端口真变了经 `onRearmed` 通知，下次 session start 自愈。
- **codex**：daemon 是远端常驻进程，env 只能在启动时生效——写远端 marker 文件（`$INSTALL_ROOT/agent-proxy.env`）由 daemon wrapper source；配置漂移时重写 + pkill daemon（与 auth sync 的 daemonRestart 同一模式，pkill 实现抽成共享 helper），下次 transport bootstrap 的 `beforeDaemonProbe` 钩子兜底拉起。
- **claude-code**：cc-mgr 按 session spawn SDK，`remoteCcQueryFactory` 把代理 env 直接合入 `startParams.env`，即时生效，无需重启。
- **Settings UI**：主机 add/edit 表单加开关 + 本地 Proxy 地址输入（`host:port` 校验，支持 IPv6 bracket）；展开详情显示隧道实时状态（建立中 / 已建立:远端端口→本机目标 / 失败原因）；pref 落本地 `ssh-host-prefs.json`（不污染 `~/.ssh/config`）；quick test 同步走隧道便于用户验证链路；edit 仅改 pref 时不再断连（原逻辑任何编辑都 disconnect）。
- **fail-closed**：隧道 arm 失败（如 sshd `AllowTcpForwarding` 禁止 remote forwarding、候选端口全占用）在 session 路径直接报错，不静默回落直连。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#677
- 本 PR 包含：
  - `packages/maker-remote-ssh`：`RemoteHost` remote port forwarding API（`ensureRemoteForward` / `closeAllRemoteForwards` / `listRemoteForwards`，断线 re-arm + 端口候选 + 看门狗 + 半开连接清理）
  - desktop main：`agent-proxy.ts` 策略层（隧道管理 / env 构造 / codex marker 对账 / pkill 共享 helper）+ prefs store 扩展 + IPC 接入 + codex transport `beforeDaemonProbe` + maker-host 两处注入
  - `packages/maker-core`：codex retry 升级（`retry-escalation.ts`）+ translator 透出泛化 + `AppServerHost.request` 超时透传
  - Settings UI（RemoteSection / RemoteHostDetail）+ i18n 四语（Proxy 按术语表保留英文）
  - 测试：forwarding 12 例、agent-proxy 13 例、retry-escalation 8 例、translator 31 例（含 #677 场景回归）、escalation 接线 2 例、parseProxyAddr 4 例
  - 附带：`markdownTargetRendererContract.test.ts` 行尾归一化（Windows autocrlf 检出下预存失败，与 42b61e4c 同款修复，合并不冲突）
- 明确不包含：
  - 自动探测系统 Proxy 填充地址（手工输入，默认 127.0.0.1:7890；后续可借 PR #649 的 PAC 解析做预填）
  - SOCKS5 形式的远端 env（远端统一给 `http://`；SOCKS-only 的 Proxy 软件请填其 HTTP/混合端口）
  - 远端端口自定义（固定 17893 起候选）
  - mobile 端入口
- 用户可见变化：远端 codex 后端不可达时 ~2 分钟内浮现明确错误（含可能原因与隧道入口提示）而不是永远转圈；设置 → SSH 远程主机 的 add/edit 表单新增「Agent 流量走本地 Proxy」开关与地址；展开主机详情可见隧道状态。
- 是否存在 breaking change：无。未开启隧道的 host 行为与改动前一致（marker 不存在 = 直连；codex wrapper 多一行 `[ -f ... ] && .` 判空）。

### UI 变化

设置 → SSH 远程主机：add/edit 表单新增开关 + 地址输入（校验失败内联提示）；展开详情新增隧道状态卡片（仅在该 host 开启隧道时渲染）。Light / Dark 双模式均走语义 token（`--settings-*` / `--error-fg`），未硬编码颜色；未实机目检（见「未执行的验证」）。

- 引用的设计规范：DESIGN.md 双模式交付门槛（语义 token、禁止单模式硬编码）——实现满足（全部走 `var(--settings-*)` token）；实机双模式目检未做，如实标注。

## 怎么验证的

### 自动验证

```text
pnpm test:unit（仓库根全量门禁）
结果：全绿（本 worktree，Windows）。新增用例：
  packages/maker-remote-ssh remoteHostForward.test.ts  12 passed
  apps/desktop agentProxy.test.ts                      13 passed
  packages/maker-core retry-escalation.test.ts          8 passed
  packages/maker-core translator.test.ts               31 passed（含 #677 403/websocket 文案回归）
  packages/maker-core index.test.ts（escalation 接线）  2 passed
  apps/desktop RemoteSection.parseProxyAddr.test.ts     4 passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过

（packages/maker-remote-ssh）npx tsc --noEmit（该包 build script）
结果：通过

eslint（desktop + maker-core 全部改动文件）
结果：通过，无输出

pnpm check:i18n-glossary
结果：✅ 27 条已裁决 / 2 条待讨论，四语无新增违规（zh-CN 一处全角冒号已修）

pnpm check:dco
结果：DCO check passed: 4 commits signed off
```

### 手工验证

不涉及（未实机，见下）。

### 未执行的验证

- **Electron 实机 + 真实 SSH 主机 + 真实 Proxy 端到端未验**：需要一台摸不到 chatgpt.com 的真实远端与本机代理环境。隧道建立 / marker 对账 / daemon 重启 / claude env 合并 / 升级收口均为主进程与 maker-core 层逻辑，由上述单测与 fake-host 集成测试覆盖；ssh2 `forwardIn` 的字节 pipe 用 127.0.0.1 回环 echo server 做了端到端验证。
- **Light / Dark 双模式实机目检未做**：UI 全部走语义 token，无双模式条件分支。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
  - **安全面**：远端转发只绑 `127.0.0.1`（隧道口不对远端所在网络暴露，无 GatewayPorts 语义）；本地目标地址经 IPC 校验（拒空白/引号，防 marker shell 片段注入）；marker 内容不含密钥；pkill pattern 沿用 auth sync 已验证的 `.xdt-server` 路径限定 + `[c]odex` 自排除 + `id -un` 用户限定。
  - **行为面**：开启/关闭隧道或改地址会 pkill 远端 codex daemon 一次（env 只能启动时生效，与 auth sync 的 daemonRestart 同语义）——该 host 上 in-flight 的 codex turn 会中断；claude session 不受影响（按 session 合并 env）。host 编辑仅在连接字段变化时才断连（行为改善，proxy-only 编辑不断连）。
  - **跨平台**：远端假定为 POSIX shell（与既有 bootstrap 同一假设）；本机 Windows/macOS/Linux 的 `net.connect` 行为一致。Windows 开发机特有：`markdownTargetRendererContract.test.ts` 行尾归一化修复（预存问题）。
  - **多端**（按 remote-and-mobile-adaptation 三问）：① 本功能即 SSH 远程工作区能力，全部经 exec/forwardIn 远程通道；② 未新增 IPC channel / push topic（agentProxy 折叠进既有 add/update invoke 与 STATUS_CHANGED push 的 payload，allowlist 无需登记）；③ mobile 无 SSH 主机管理入口，不涉及。
- 回滚 / 降级方式：整体 revert 即可；已开启隧道的 host 残留仅为远端 `agent-proxy.env` marker 与 `ssh-host-prefs.json` 本地 pref，revert 后 marker 不再被 source（wrapper 判空行一并回退），无数据迁移。GLOSSARY.md 工作副本行尾已按仓库现状恢复 LF（无内容变更）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（新模块 / 新方法均有顶部设计注释；GLOSSARY 无需新增术语）
- [x] 已确认测试结果或说明未执行原因
