### PR TITLE
feat(mobile): device-link「目标设备无响应」熔断,切断请求风暴放大链

### DIFF
--- a/apps/mobile/app/automations/[deviceId].tsx
+++ b/apps/mobile/app/automations/[deviceId].tsx
@@ -13,6 +13,7 @@ import { Text, TextInput } from '@/components/AppText';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { ConnectionBanner } from '@/components/ConnectionBanner';
+import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import { goBackGuarded } from '@/utils/backGuard';
 import {
   MainWindowActionButton,
@@ -118,6 +119,9 @@ export default function AutomationsScreen() {
   const router = useRouter();
   const { width: screenWidth } = useWindowDimensions();
   const { connectionIssue, openLink, status, subscribe, unsubscribe } = useDeviceLink();
+  // 熔断 open(电脑端未响应):relay 可能仍 online,banner 文案单独入参。
+  const unresponsiveDevices = useUnresponsiveDevices();
+  const deviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
   const maker = useMobileMakerTransport(deviceId);
   const scheduleEventSnapshot = useRemoteScheduleEventSnapshot(deviceId);
   const remoteSessions = useRemoteSessions();
@@ -741,6 +745,7 @@ export default function AutomationsScreen() {
       />
 
       <ConnectionBanner
+        deviceUnresponsive={deviceUnresponsive}
         error={error}
         issue={connectionIssue}
         lastSyncedAt={lastSyncedAt}

--- a/apps/mobile/app/automations/[deviceId].tsx
+++ b/apps/mobile/app/automations/[deviceId].tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronRight } from 'lucide-react-native';
 import {
   ActivityIndicator,
@@ -243,6 +243,19 @@ export default function AutomationsScreen() {
   useEffect(() => {
     if (selectedScheduleId) void syncRuns(selectedScheduleId);
   }, [selectedScheduleId, syncRuns]);
+
+  // 熔断恢复重载(review P1):首载撞上熔断快速失败时,探测成功关熔断不会重跑
+  // 本页加载(rehydrate 只回填 remoteSessionStore,不管本页的 schedules /
+  // runsBySchedule),列表会一直空/陈旧到手动同步或无关调度事件。只在
+  // open→closed 的翻转沿触发,平时零开销。
+  const prevDeviceUnresponsiveRef = useRef(deviceUnresponsive);
+  useEffect(() => {
+    const was = prevDeviceUnresponsiveRef.current;
+    prevDeviceUnresponsiveRef.current = deviceUnresponsive;
+    if (!was || deviceUnresponsive) return;
+    void loadSchedules();
+    if (selectedScheduleId) void syncRuns(selectedScheduleId);
+  }, [deviceUnresponsive, loadSchedules, selectedScheduleId, syncRuns]);
 
   useEffect(() => {
     if (scheduleEventSnapshot.scheduleListVersion === 0) return;

--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -16,7 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { ConnectionBanner, useShowConnectionBanner } from '@/components/ConnectionBanner';
-import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
+import { unresponsiveDevicesStore, useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import { goBackGuarded } from '@/utils/backGuard';
 import { configureCollapseAnimation } from '@/utils/collapseAnimation';
 import { useGuardedPush } from '@/utils/useGuardedPush';
@@ -187,7 +187,7 @@ export default function DeviceDetailScreen() {
       remoteSessionStore.setDeviceSessions(deviceId, deviceName, Array.isArray(list) ? list : []);
       // 节流缓存与首页共用同一 key(deviceId):两页交替浏览时不重复全量拉取(单飞 + TTL,
       // 拥塞背景见 scheduleIndex 注释)。
-      void loadSessionScheduleIndexThrottled(deviceId, () => loadSessionScheduleIndex(maker))
+      void loadSessionScheduleIndexThrottled(deviceId, () => loadSessionScheduleIndex(maker, { isDeviceUnresponsive: () => unresponsiveDevicesStore.has(deviceId) }))
         .then(setScheduleIndex)
         .catch(() => setScheduleIndex(new Map()));
       setLastSyncedAt(Date.now());
@@ -226,7 +226,7 @@ export default function DeviceDetailScreen() {
       scheduleEventSnapshot.scheduleListVersion === 0
       && scheduleEventSnapshot.unreadClearVersion === 0
     ) return;
-    void loadSessionScheduleIndexThrottled(deviceId, () => loadSessionScheduleIndex(maker), { force: true })
+    void loadSessionScheduleIndexThrottled(deviceId, () => loadSessionScheduleIndex(maker, { isDeviceUnresponsive: () => unresponsiveDevicesStore.has(deviceId) }), { force: true })
       .then(setScheduleIndex)
       .catch(() => {
         // 失败保留旧徽标,与整页 load 的容错口径一致。

--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -16,6 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { ConnectionBanner, useShowConnectionBanner } from '@/components/ConnectionBanner';
+import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import { goBackGuarded } from '@/utils/backGuard';
 import { configureCollapseAnimation } from '@/utils/collapseAnimation';
 import { useGuardedPush } from '@/utils/useGuardedPush';
@@ -153,8 +154,11 @@ export default function DeviceDetailScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 熔断 open(电脑端未响应):relay 可能仍 online,可见性与 banner 文案单独入参。
+  const unresponsiveDevices = useUnresponsiveDevices();
+  const deviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
   // 自动化 / 项目分支视图的条件挂载 banner:普通弱网断线也要有可见信号(防闪延迟后)
-  const showConnectionBanner = useShowConnectionBanner(status, error, connectionIssue);
+  const showConnectionBanner = useShowConnectionBanner(status, error, connectionIssue, deviceUnresponsive);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   const [selectedSessionIds, setSelectedSessionIds] = useState<string[]>([]);
   const [expandedAutomationGroups, setExpandedAutomationGroups] = useState<string[]>([]);
@@ -503,6 +507,7 @@ export default function DeviceDetailScreen() {
         />
         {showConnectionBanner ? (
           <ConnectionBanner
+            deviceUnresponsive={deviceUnresponsive}
             error={error}
             issue={connectionIssue}
             lastSyncedAt={lastSyncedAt}
@@ -575,6 +580,7 @@ export default function DeviceDetailScreen() {
         />
         {showConnectionBanner ? (
           <ConnectionBanner
+            deviceUnresponsive={deviceUnresponsive}
             error={error}
             issue={connectionIssue}
             lastSyncedAt={lastSyncedAt}
@@ -652,6 +658,7 @@ export default function DeviceDetailScreen() {
       />
 
       <ConnectionBanner
+        deviceUnresponsive={deviceUnresponsive}
         error={error}
         issue={connectionIssue}
         lastSyncedAt={lastSyncedAt}

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -78,6 +78,7 @@ import {
 } from '@/device-link/remoteStatus';
 import { withTransientRemoteRetry } from '@/device-link/remoteRetry';
 import { revokedDevicesStore, useRevokedDevices } from '@/device-link/revokedDevicesStore';
+import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import { remoteScheduleEventStore } from '@/scheduler/remoteScheduleEvents';
 import {
   buildMobileHomePresentation,
@@ -237,7 +238,16 @@ export default function HomeScreen() {
   const [pinnedCollapsed, setPinnedCollapsed] = useState(false);
   // 已展开的自动化组 key(页面级 state:SectionList 虚拟化回收行组件时展开态不丢)。
   const [expandedAutomationGroups, setExpandedAutomationGroups] = useState<string[]>([]);
-  const [deviceConnectionStates, setDeviceConnectionStates] = useState<Record<string, HomeDeviceConnectionState>>({});
+  const [rawDeviceConnectionStates, setDeviceConnectionStates] = useState<Record<string, HomeDeviceConnectionState>>({});
+  // 熔断 open(电脑端未响应)的设备复用既有 failed 渲染路径(红圈),不新增视觉:
+  // 内部态映射覆盖在 hydrate 状态之上,熔断关闭后自动回落到原状态。
+  const unresponsiveDevices = useUnresponsiveDevices();
+  const deviceConnectionStates = useMemo<Record<string, HomeDeviceConnectionState>>(() => {
+    if (unresponsiveDevices.size === 0) return rawDeviceConnectionStates;
+    const merged: Record<string, HomeDeviceConnectionState> = { ...rawDeviceConnectionStates };
+    for (const deviceId of unresponsiveDevices) merged[deviceId] = 'failed';
+    return merged;
+  }, [rawDeviceConnectionStates, unresponsiveDevices]);
   const [scheduleIndex, setScheduleIndex] = useState<Map<string, RemoteSessionScheduleInfo>>(() => new Map());
 
   const updateDeviceConnectionState = useCallback((deviceId: string, state: HomeDeviceConnectionState) => {

--- a/apps/mobile/app/files/[sessionId].tsx
+++ b/apps/mobile/app/files/[sessionId].tsx
@@ -49,6 +49,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Text, TextInput } from '@/components/AppText';
 import { ScreenBackButton } from '@/components/MobilePrimitives';
 import { ConnectionBanner, useShowConnectionBanner } from '@/components/ConnectionBanner';
+import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import { goBackGuarded } from '@/utils/backGuard';
 import { useAuth } from '@/auth/AuthContext';
 import { DEVICE_LINK_API_BASE_URL } from '@/config/env';
@@ -146,7 +147,9 @@ export default function RemoteFileBrowserScreen() {
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const showConnectionBanner = useShowConnectionBanner(status, error, connectionIssue);
+  const unresponsiveDevices = useUnresponsiveDevices();
+  const deviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
+  const showConnectionBanner = useShowConnectionBanner(status, error, connectionIssue, deviceUnresponsive);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -775,6 +778,7 @@ export default function RemoteFileBrowserScreen() {
       {showConnectionBanner ? (
         <ConnectionBanner
           density="compact"
+          deviceUnresponsive={deviceUnresponsive}
           error={error}
           issue={connectionIssue}
           lastSyncedAt={lastSyncedAt}

--- a/apps/mobile/app/files/[sessionId].tsx
+++ b/apps/mobile/app/files/[sessionId].tsx
@@ -193,6 +193,9 @@ export default function RemoteFileBrowserScreen() {
   }, []);
 
   // 会话兜底拉取(直接经 deep link 进入时 store 里可能还没有)。
+  // deviceUnresponsive 进依赖(review P1,同 preview 页):深链进入且无缓存
+  // 会话时,首次 getSession 撞上熔断 open 会永久失败——本页不注册 reseed
+  // handler,fs-watch 重订阅也不会主动发事件,恢复后必须自动重跑。
   useEffect(() => {
     if (knownSession) {
       setSession(knownSession);
@@ -203,9 +206,12 @@ export default function RemoteFileBrowserScreen() {
       await openLink(deviceId);
       return maker.getSession(sessionId);
     })
-      .then(setSession)
+      .then((loaded) => {
+        setSession(loaded);
+        setError(null);
+      })
       .catch((err) => setError(formatRemoteError(err)));
-  }, [deviceId, knownSession, maker, openLink, sessionId]);
+  }, [deviceId, deviceUnresponsive, knownSession, maker, openLink, sessionId]);
 
   // workdir 就绪后加载偏好(异步存储可能比同步内存新)。
   useEffect(() => {
@@ -255,6 +261,18 @@ export default function RemoteFileBrowserScreen() {
     sortModeRef.current = sortMode;
     setItems(buildFileBrowserGridItems(rawEntriesRef.current, sortMode, Date.now()));
   }, [sortMode]);
+
+  // 熔断恢复:目录静默刷新(缓存保留不清列表,规则 7)。首次 listDir 撞上
+  // 熔断快速失败、或 open 期间目录停更时,恢复不会有任何文件事件来救——
+  // 只在 open→closed 翻转沿触发一次;workdir 尚未就绪时 loadDirectory 自身
+  // no-op(session bootstrap 的恢复重跑会先把 workdir 补回来)。
+  const prevDeviceUnresponsiveRef = useRef(deviceUnresponsive);
+  useEffect(() => {
+    const was = prevDeviceUnresponsiveRef.current;
+    prevDeviceUnresponsiveRef.current = deviceUnresponsive;
+    if (!was || deviceUnresponsive) return;
+    void loadDirectory({ refreshing: true });
+  }, [deviceUnresponsive, loadDirectory]);
 
   // 缓存优先:内存同步命中立即上屏;miss 再试 AsyncStorage 快照(跨启动);
   // 无论命中与否都发一次静默刷新拿最新。

--- a/apps/mobile/app/files/preview/[sessionId].tsx
+++ b/apps/mobile/app/files/preview/[sessionId].tsx
@@ -33,6 +33,7 @@ import { goBackGuarded } from '@/utils/backGuard';
 import { useAuth } from '@/auth/AuthContext';
 import { DEVICE_LINK_API_BASE_URL } from '@/config/env';
 import { useDeviceLink } from '@/device-link/DeviceLinkContext';
+import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import { formatRemoteError } from '@/device-link/remoteStatus';
 import { withTransientRemoteRetry } from '@/device-link/remoteRetry';
 import { useMobileMakerTransport } from '@/device-link/useMobileMakerTransport';
@@ -145,6 +146,13 @@ export default function RemoteFilePreviewScreen() {
     unmountedRef.current = true;
   }, []);
 
+  // deviceUnresponsive 进依赖(review P1):深链进入且无缓存会话时,首次
+  // getSession 若撞上熔断 open 会拿到 DEVICE_UNRESPONSIVE 快速失败;本页只
+  // track openLink、不持有 topic,恢复 rehydrate 的 reseed 也覆盖不到——不随
+  // 熔断状态翻转重跑的话,探测成功后预览页仍永久空白。翻转重跑最多多发一次
+  // 轻量请求(open 期间是本地快速失败,零管道流量)。
+  const unresponsiveDevices = useUnresponsiveDevices();
+  const deviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
   useEffect(() => {
     if (knownSession) {
       setSession(knownSession);
@@ -155,9 +163,13 @@ export default function RemoteFilePreviewScreen() {
       await openLink(deviceId);
       return maker.getSession(sessionId);
     })
-      .then(setSession)
+      .then((loaded) => {
+        setSession(loaded);
+        // 清掉熔断 open 期间留下的错误快照,恢复后不再残留降级横幅。
+        setError(null);
+      })
       .catch((err) => setError(formatRemoteError(err)));
-  }, [deviceId, knownSession, maker, openLink, sessionId]);
+  }, [deviceId, deviceUnresponsive, knownSession, maker, openLink, sessionId]);
 
   // absPath 单文件模式:不列目录,直接以合成 item 装单页 pager。
   useEffect(() => {

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -65,6 +65,7 @@ import { ConnectionBanner, useShowConnectionBanner } from '@/components/Connecti
 import { PaperPlaneIcon } from '@/components/PaperPlaneIcon';
 import { useDeviceLink } from '@/device-link/DeviceLinkContext';
 import { useRevokedDevices } from '@/device-link/revokedDevicesStore';
+import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import {
   describeRemoteError,
   formatRemoteError,
@@ -658,6 +659,7 @@ export default function SessionScreen() {
     unsubscribe,
   } = useDeviceLink();
   const revokedDevices = useRevokedDevices();
+  const unresponsiveDevices = useUnresponsiveDevices();
   const maker = useMobileMakerTransport(deviceId);
   const sessions = useRemoteSessions();
   const messages = useSessionMessages(sessionId, deviceId);
@@ -1151,11 +1153,13 @@ export default function SessionScreen() {
   );
   const localCodexRateLimitControl = canUseLocalCodexRateLimitControl(currentSession);
   const isDeviceAccessRevoked = !!deviceId && revokedDevices.has(deviceId);
+  // 熔断 open:被控电脑「进程活着但不回包」的半死态;relay status 恒 online,必须单独入参。
+  const isDeviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
   const connectionError = isDeviceAccessRevoked
     ? '[ACCESS_REVOKED] access revoked by target device'
     : error;
   // 弱网普通断线也要有可见信号(消息流静默停更没有任何提示),经防闪延迟后显示
-  const showConnectionBanner = useShowConnectionBanner(status, connectionError, connectionIssue);
+  const showConnectionBanner = useShowConnectionBanner(status, connectionError, connectionIssue, isDeviceUnresponsive);
   const hasCurrentSession = currentSession !== null;
   const currentAgentKind = useMemo(
     () => currentSession ? agentKindForSession(currentSession) : null,
@@ -6456,6 +6460,7 @@ export default function SessionScreen() {
             {showConnectionBanner ? (
               <ConnectionBanner
                 density="compact"
+                deviceUnresponsive={isDeviceUnresponsive}
                 error={connectionError}
                 issue={connectionIssue}
                 lastSyncedAt={lastSyncedAt}

--- a/apps/mobile/src/__tests__/accessRevoked.test.ts
+++ b/apps/mobile/src/__tests__/accessRevoked.test.ts
@@ -90,3 +90,40 @@ describe('mobile device-link access revocation', () => {
     expect(revokedDevicesStore.has('dev-1')).toBe(false);
   });
 });
+
+describe('撤权与「设备无响应」熔断的竞态(review P1)', () => {
+  it('markDeviceAccessRevoked 清掉该设备的熔断状态与 UI 镜像', async () => {
+    const { acquireDeviceSendSlot, settleDeviceSend, unresponsiveDevicesStore } =
+      await import('@/device-link/unresponsiveDevicesStore');
+    const { markDeviceAccessRevoked, clearDeviceAccessRevoked } =
+      await import('@/device-link/accessRevoked');
+    const dev = 'revoke-breaker-dev';
+    clearDeviceAccessRevoked(dev);
+    for (let i = 0; i < 3; i++) {
+      const probe = acquireDeviceSendSlot(dev);
+      settleDeviceSend(dev, probe, 'timeout');
+    }
+    expect(unresponsiveDevicesStore.has(dev)).toBe(true);
+
+    markDeviceAccessRevoked(dev);
+    expect(unresponsiveDevicesStore.has(dev)).toBe(false);
+    clearDeviceAccessRevoked(dev);
+  });
+
+  it('已撤权设备的在途超时降级为不定论,不再把熔断重新打开', async () => {
+    const { acquireDeviceSendSlot, settleDeviceSend, unresponsiveDevicesStore } =
+      await import('@/device-link/unresponsiveDevicesStore');
+    const { markDeviceAccessRevoked, clearDeviceAccessRevoked } =
+      await import('@/device-link/accessRevoked');
+    const dev = 'revoke-race-dev';
+    clearDeviceAccessRevoked(dev);
+    markDeviceAccessRevoked(dev);
+    // link-close(revoked) 后,撤权前发出的在途请求陆续超时——不应计入熔断
+    for (let i = 0; i < 5; i++) {
+      const probe = acquireDeviceSendSlot(dev);
+      settleDeviceSend(dev, probe, 'timeout');
+    }
+    expect(unresponsiveDevicesStore.has(dev)).toBe(false);
+    clearDeviceAccessRevoked(dev);
+  });
+});

--- a/apps/mobile/src/__tests__/connectionBannerVisibility.test.ts
+++ b/apps/mobile/src/__tests__/connectionBannerVisibility.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { resolveConnectionBannerVisibility } from '@/components/connectionBannerVisibility';
+
+const base = {
+  offline: false,
+  offlineLongEnough: false,
+  hasError: false,
+  hasIssue: false,
+  deviceUnresponsive: false,
+};
+
+describe('resolveConnectionBannerVisibility', () => {
+  it('连接正常且无错误时不显示(不渲染常驻状态条)', () => {
+    expect(resolveConnectionBannerVisibility(base)).toBe(false);
+  });
+
+  it('请求级 error 立即显示', () => {
+    expect(resolveConnectionBannerVisibility({ ...base, hasError: true })).toBe(true);
+  });
+
+  it('目标设备熔断 open(电脑端未响应)即使 relay 仍 online 也立即显示', () => {
+    // 2026-07 事故形态:桌面进程活着、presence 恒 online,但 invoke 永不回包——
+    // 只看 status 的旧判定完全失明,unresponsive 必须是独立显示条件。
+    expect(resolveConnectionBannerVisibility({ ...base, deviceUnresponsive: true })).toBe(true);
+  });
+
+  it('普通弱网断线:未超过防闪窗口不显示,超过后显示', () => {
+    expect(resolveConnectionBannerVisibility({ ...base, offline: true })).toBe(false);
+    expect(resolveConnectionBannerVisibility({ ...base, offline: true, offlineLongEnough: true })).toBe(true);
+  });
+
+  it('可分类连接问题(鉴权失效 / 被顶号等)在断线时立即显示,不等防闪窗口', () => {
+    expect(resolveConnectionBannerVisibility({ ...base, offline: true, hasIssue: true })).toBe(true);
+  });
+});

--- a/apps/mobile/src/__tests__/connectionBannerVisibility.test.ts
+++ b/apps/mobile/src/__tests__/connectionBannerVisibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveConnectionBannerVisibility } from '@/components/connectionBannerVisibility';
+import {
+  resolveConnectionBannerVisibility,
+  resolveEffectiveConnectionError,
+} from '@/components/connectionBannerVisibility';
 
 const base = {
   offline: false,
@@ -31,5 +34,28 @@ describe('resolveConnectionBannerVisibility', () => {
 
   it('可分类连接问题(鉴权失效 / 被顶号等)在断线时立即显示,不等防闪窗口', () => {
     expect(resolveConnectionBannerVisibility({ ...base, offline: true, hasIssue: true })).toBe(true);
+  });
+});
+
+describe('resolveEffectiveConnectionError', () => {
+  it('熔断已关后残留的 DEVICE_UNRESPONSIVE 错误按陈旧丢弃(review P1)', () => {
+    // 屏幕在熔断 open 期间重试失败会把这类文案存进 error;探测成功自动关熔断
+    // 只翻转 deviceUnresponsive,不清屏幕 error——不丢弃的话恢复后 banner 会
+    // 带着"自动重试中"常驻到用户手动同步。
+    expect(
+      resolveEffectiveConnectionError('[DEVICE_UNRESPONSIVE] circuit open', false),
+    ).toBeNull();
+  });
+
+  it('熔断仍 open 时保留原文(banner 的 unresponsive 分支优先,error 不会被展示)', () => {
+    expect(
+      resolveEffectiveConnectionError('[DEVICE_UNRESPONSIVE] circuit open', true),
+    ).toBe('[DEVICE_UNRESPONSIVE] circuit open');
+  });
+
+  it('其他错误与空值原样透传', () => {
+    expect(resolveEffectiveConnectionError('[NOT_CONNECTED] offline', false)).toBe('[NOT_CONNECTED] offline');
+    expect(resolveEffectiveConnectionError(null, false)).toBeNull();
+    expect(resolveEffectiveConnectionError(null, true)).toBeNull();
   });
 });

--- a/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
@@ -4,6 +4,7 @@ import {
   BREAKER_PROBE_BACKOFF_BASE_MS,
   BREAKER_PROBE_BACKOFF_MAX_MS,
   createDeviceResponsivenessBreaker,
+  type BreakerSendSlot,
 } from '@/device-link/deviceResponsivenessBreaker';
 
 const DEV = 'dev-1';
@@ -19,16 +20,34 @@ function harness(startAt = 1_000_000) {
   };
 }
 
-/** closed 态一次「acquire→超时」;acquire 必须是 allow。 */
-function timeoutOnce(breaker: ReturnType<typeof harness>['breaker'], deviceId = DEV): void {
-  expect(breaker.acquire(deviceId)).toBe('allow');
-  breaker.settle(deviceId, false, 'timeout');
+type Breaker = ReturnType<typeof harness>['breaker'];
+
+/** closed 态一次「acquire→settle」;acquire 必须是 allow。 */
+function settleOnce(
+  breaker: Breaker,
+  outcome: 'timeout' | 'responded' | 'inconclusive',
+  deviceId = DEV,
+): void {
+  const slot = breaker.acquire(deviceId);
+  expect(slot.decision).toBe('allow');
+  breaker.settle(deviceId, slot, outcome);
+}
+
+function timeoutOnce(breaker: Breaker, deviceId = DEV): void {
+  settleOnce(breaker, 'timeout', deviceId);
 }
 
 /** 打开熔断:连续 threshold 次超时。 */
 function openBreaker(h: ReturnType<typeof harness>): void {
   for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) timeoutOnce(h.breaker);
   expect(h.breaker.isOpen(DEV)).toBe(true);
+}
+
+/** 到点探测:acquire 必须拿到 probe 席位,返回票据供 settle。 */
+function acquireProbe(h: ReturnType<typeof harness>, deviceId = DEV): BreakerSendSlot {
+  const slot = h.breaker.acquire(deviceId);
+  expect(slot.decision).toBe('probe');
+  return slot;
 }
 
 describe('deviceResponsivenessBreaker', () => {
@@ -43,14 +62,14 @@ describe('deviceResponsivenessBreaker', () => {
     expect(h.onOpenChanged).toHaveBeenCalledTimes(1);
     expect(h.onOpenChanged).toHaveBeenCalledWith(DEV, true);
     // open 后、探测窗口内:新请求快速失败
-    expect(h.breaker.acquire(DEV)).toBe('reject');
+    expect(h.breaker.acquire(DEV).decision).toBe('reject');
   });
 
   it('真实回包(即使是业务错误应答)重置连续计数', () => {
     const h = harness();
     timeoutOnce(h.breaker);
     timeoutOnce(h.breaker);
-    h.breaker.settle(DEV, false, 'responded');
+    settleOnce(h.breaker, 'responded');
     // 重置后再来 2 次超时仍不该 open(等价于从零累计)
     timeoutOnce(h.breaker);
     timeoutOnce(h.breaker);
@@ -63,7 +82,7 @@ describe('deviceResponsivenessBreaker', () => {
     const h = harness();
     timeoutOnce(h.breaker);
     timeoutOnce(h.breaker);
-    h.breaker.settle(DEV, false, 'inconclusive');
+    settleOnce(h.breaker, 'inconclusive');
     expect(h.breaker.isOpen(DEV)).toBe(false);
     // 计数保留:第 3 次超时直接 open
     timeoutOnce(h.breaker);
@@ -75,22 +94,22 @@ describe('deviceResponsivenessBreaker', () => {
     openBreaker(h);
     // 窗口未到:一律 reject
     h.advance(BREAKER_PROBE_BACKOFF_BASE_MS - 1);
-    expect(h.breaker.acquire(DEV)).toBe('reject');
+    expect(h.breaker.acquire(DEV).decision).toBe('reject');
     // 到点:仅第一个 acquire 拿到探测席位,其余照旧 reject
     h.advance(1);
-    expect(h.breaker.acquire(DEV)).toBe('probe');
-    expect(h.breaker.acquire(DEV)).toBe('reject');
+    acquireProbe(h);
+    expect(h.breaker.acquire(DEV).decision).toBe('reject');
   });
 
   it('探测成功即 close 并通知;后续请求恢复 allow', () => {
     const h = harness();
     openBreaker(h);
     h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
-    expect(h.breaker.acquire(DEV)).toBe('probe');
-    h.breaker.settle(DEV, true, 'responded');
+    const probe = acquireProbe(h);
+    h.breaker.settle(DEV, probe, 'responded');
     expect(h.breaker.isOpen(DEV)).toBe(false);
     expect(h.onOpenChanged).toHaveBeenLastCalledWith(DEV, false);
-    expect(h.breaker.acquire(DEV)).toBe('allow');
+    expect(h.breaker.acquire(DEV).decision).toBe('allow');
   });
 
   it('探测再超时:回 open 并加深退避(10s→20s→…封顶 120s)', () => {
@@ -100,10 +119,10 @@ describe('deviceResponsivenessBreaker', () => {
     // 连续探测失败,窗口每轮翻倍直至封顶(时间单调推进,纯 Date.now 差值驱动)
     for (let round = 0; round < 6; round++) {
       h.advance(backoff - 1);
-      expect(h.breaker.acquire(DEV)).toBe('reject');
+      expect(h.breaker.acquire(DEV).decision).toBe('reject');
       h.advance(1);
-      expect(h.breaker.acquire(DEV)).toBe('probe');
-      h.breaker.settle(DEV, true, 'timeout');
+      const probe = acquireProbe(h);
+      h.breaker.settle(DEV, probe, 'timeout');
       backoff = Math.min(backoff * 2, BREAKER_PROBE_BACKOFF_MAX_MS);
     }
     expect(backoff).toBe(BREAKER_PROBE_BACKOFF_MAX_MS);
@@ -112,39 +131,116 @@ describe('deviceResponsivenessBreaker', () => {
 
   it('open 期间旧请求(非探测)超时不推进退避窗口', () => {
     const h = harness();
+    // open 前已在途的请求(同一代,尚未有 responded 翻篇)
+    const older1 = h.breaker.acquire(DEV);
+    const older2 = h.breaker.acquire(DEV);
     openBreaker(h);
-    // open 前已在途的请求陆续超时(wasProbe=false):不影响 10s 首个探测窗口
-    h.breaker.settle(DEV, false, 'timeout');
-    h.breaker.settle(DEV, false, 'timeout');
+    // 旧请求陆续超时(非探测):不影响 10s 首个探测窗口
+    h.breaker.settle(DEV, older1, 'timeout');
+    h.breaker.settle(DEV, older2, 'timeout');
     h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
-    expect(h.breaker.acquire(DEV)).toBe('probe');
+    acquireProbe(h);
   });
 
   it('探测 inconclusive(如探测期间掉线)释放单飞,可立即再探测', () => {
     const h = harness();
     openBreaker(h);
     h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
-    expect(h.breaker.acquire(DEV)).toBe('probe');
-    h.breaker.settle(DEV, true, 'inconclusive');
+    const probe = acquireProbe(h);
+    h.breaker.settle(DEV, probe, 'inconclusive');
     // 窗口基准未动(早已到点),新的探测立即放行
-    expect(h.breaker.acquire(DEV)).toBe('probe');
+    acquireProbe(h);
   });
 
   it('per-device 隔离:一台设备 open 不影响另一台', () => {
     const h = harness();
     openBreaker(h);
-    expect(h.breaker.acquire('dev-2')).toBe('allow');
+    expect(h.breaker.acquire('dev-2').decision).toBe('allow');
     expect(h.breaker.isOpen('dev-2')).toBe(false);
   });
 
-  it('resetAll 清空状态并对 open 中的设备发 close 通知', () => {
+  it('resetAll 清空状态并对 open 中的设备发 close 通知;在途旧代结果作废', () => {
     const h = harness();
+    const inFlight = h.breaker.acquire(DEV);
     openBreaker(h);
     h.onOpenChanged.mockClear();
     h.breaker.resetAll();
     expect(h.breaker.isOpen(DEV)).toBe(false);
-    expect(h.breaker.acquire(DEV)).toBe('allow');
+    expect(h.breaker.acquire(DEV).decision).toBe('allow');
     expect(h.onOpenChanged).toHaveBeenCalledWith(DEV, false);
+    // resetAll 前派出的请求超时不再计数(切号后旧账不入新账)
+    h.breaker.settle(DEV, inFlight, 'timeout');
+    h.breaker.settle(DEV, inFlight, 'timeout');
+    h.breaker.settle(DEV, inFlight, 'timeout');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+  });
+});
+
+describe('generation:恢复前派出的旧请求结果不采信(review P1)', () => {
+  it('探测成功关熔断后,恢复前在途的长超时请求陆续超时不会重新 open', () => {
+    const h = harness();
+    // 事故场景:30/40s 长通道请求先在途(尚未落定)
+    const longA = h.breaker.acquire(DEV);
+    const longB = h.breaker.acquire(DEV);
+    const longC = h.breaker.acquire(DEV);
+    // 3 条 15s 请求先超时 → open
+    openBreaker(h);
+    // 探测成功 → close(设备已恢复)
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
+    const probe = acquireProbe(h);
+    h.breaker.settle(DEV, probe, 'responded');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    // 恢复前派出的长请求这才等满超时:属旧代,一律忽略,不得把刚恢复的熔断再打开
+    h.breaker.settle(DEV, longA, 'timeout');
+    h.breaker.settle(DEV, longB, 'timeout');
+    h.breaker.settle(DEV, longC, 'timeout');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    // 新一代请求照常计数:3 次新超时仍能 open
+    openBreaker(h);
+  });
+
+  it('普通 responded 也翻篇:之前在途请求的晚到超时不计入连续计数', () => {
+    const h = harness();
+    const stale = h.breaker.acquire(DEV);
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    settleOnce(h.breaker, 'responded'); // 设备活着,计数清零 + 翻篇
+    h.breaker.settle(DEV, stale, 'timeout'); // 晚到的旧超时:忽略
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(false); // 新代只累计了 2 次
+  });
+
+  it('clear(撤权)翻篇:清除前在途请求的超时不会重建计数', () => {
+    const h = harness();
+    const stale = h.breaker.acquire(DEV);
+    timeoutOnce(h.breaker);
+    h.breaker.clear(DEV);
+    h.breaker.settle(DEV, stale, 'timeout');
+    h.breaker.settle(DEV, stale, 'timeout');
+    h.breaker.settle(DEV, stale, 'timeout');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+  });
+
+  it('旧代 responded 同样不采信(不会误关新一代已 open 的熔断)', () => {
+    const h = harness();
+    const stale = h.breaker.acquire(DEV);
+    settleOnce(h.breaker, 'responded'); // 翻篇:stale 变旧代
+    openBreaker(h); // 新代 open
+    h.breaker.settle(DEV, stale, 'responded'); // 旧代晚到成功:忽略
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+  });
+});
+
+describe('clear(单设备清除,撤权场景)', () => {
+  it('open 中清除:删状态并发 close 通知', () => {
+    const h = harness();
+    openBreaker(h);
+    h.onOpenChanged.mockClear();
+    h.breaker.clear(DEV);
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    expect(h.onOpenChanged).toHaveBeenCalledWith(DEV, false);
+    expect(h.breaker.acquire(DEV).decision).toBe('allow');
   });
 });
 
@@ -164,10 +260,10 @@ describe('probeDue(只读探测窗口判定,给 rehydrate 主动探测用)', () 
     h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
     expect(h.breaker.probeDue(DEV)).toBe(true);
     expect(h.breaker.probeDue(DEV)).toBe(true);
-    expect(h.breaker.acquire(DEV)).toBe('probe');
+    const probe = acquireProbe(h);
     // 探测在途时 probeDue 收回 false(rehydrate 不应重复带上该设备)
     expect(h.breaker.probeDue(DEV)).toBe(false);
-    h.breaker.settle(DEV, true, 'responded');
+    h.breaker.settle(DEV, probe, 'responded');
     expect(h.breaker.probeDue(DEV)).toBe(false);
     expect(h.breaker.isOpen(DEV)).toBe(false);
   });

--- a/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BREAKER_FAILURE_THRESHOLD,
+  BREAKER_PROBE_BACKOFF_BASE_MS,
+  BREAKER_PROBE_BACKOFF_MAX_MS,
+  createDeviceResponsivenessBreaker,
+} from '@/device-link/deviceResponsivenessBreaker';
+
+const DEV = 'dev-1';
+
+function harness(startAt = 1_000_000) {
+  let at = startAt;
+  const onOpenChanged = vi.fn();
+  const breaker = createDeviceResponsivenessBreaker({ now: () => at, onOpenChanged });
+  return {
+    breaker,
+    onOpenChanged,
+    advance: (ms: number) => { at += ms; },
+  };
+}
+
+/** closed 态一次「acquire→超时」;acquire 必须是 allow。 */
+function timeoutOnce(breaker: ReturnType<typeof harness>['breaker'], deviceId = DEV): void {
+  expect(breaker.acquire(deviceId)).toBe('allow');
+  breaker.settle(deviceId, false, 'timeout');
+}
+
+/** 打开熔断:连续 threshold 次超时。 */
+function openBreaker(h: ReturnType<typeof harness>): void {
+  for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) timeoutOnce(h.breaker);
+  expect(h.breaker.isOpen(DEV)).toBe(true);
+}
+
+describe('deviceResponsivenessBreaker', () => {
+  it('连续 3 次 INVOKE_TIMEOUT 才 open;不足阈值保持 closed', () => {
+    const h = harness();
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    expect(h.onOpenChanged).not.toHaveBeenCalled();
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+    expect(h.onOpenChanged).toHaveBeenCalledTimes(1);
+    expect(h.onOpenChanged).toHaveBeenCalledWith(DEV, true);
+    // open 后、探测窗口内:新请求快速失败
+    expect(h.breaker.acquire(DEV)).toBe('reject');
+  });
+
+  it('真实回包(即使是业务错误应答)重置连续计数', () => {
+    const h = harness();
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    h.breaker.settle(DEV, false, 'responded');
+    // 重置后再来 2 次超时仍不该 open(等价于从零累计)
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+  });
+
+  it('inconclusive(NOT_CONNECTED 等本机链路问题)不计数也不重置', () => {
+    const h = harness();
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    h.breaker.settle(DEV, false, 'inconclusive');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    // 计数保留:第 3 次超时直接 open
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+  });
+
+  it('half-open:退避窗口(Date.now 差值驱动)到点放行单个探测,单飞互斥', () => {
+    const h = harness();
+    openBreaker(h);
+    // 窗口未到:一律 reject
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS - 1);
+    expect(h.breaker.acquire(DEV)).toBe('reject');
+    // 到点:仅第一个 acquire 拿到探测席位,其余照旧 reject
+    h.advance(1);
+    expect(h.breaker.acquire(DEV)).toBe('probe');
+    expect(h.breaker.acquire(DEV)).toBe('reject');
+  });
+
+  it('探测成功即 close 并通知;后续请求恢复 allow', () => {
+    const h = harness();
+    openBreaker(h);
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
+    expect(h.breaker.acquire(DEV)).toBe('probe');
+    h.breaker.settle(DEV, true, 'responded');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    expect(h.onOpenChanged).toHaveBeenLastCalledWith(DEV, false);
+    expect(h.breaker.acquire(DEV)).toBe('allow');
+  });
+
+  it('探测再超时:回 open 并加深退避(10s→20s→…封顶 120s)', () => {
+    const h = harness();
+    openBreaker(h);
+    let backoff = BREAKER_PROBE_BACKOFF_BASE_MS;
+    // 连续探测失败,窗口每轮翻倍直至封顶(时间单调推进,纯 Date.now 差值驱动)
+    for (let round = 0; round < 6; round++) {
+      h.advance(backoff - 1);
+      expect(h.breaker.acquire(DEV)).toBe('reject');
+      h.advance(1);
+      expect(h.breaker.acquire(DEV)).toBe('probe');
+      h.breaker.settle(DEV, true, 'timeout');
+      backoff = Math.min(backoff * 2, BREAKER_PROBE_BACKOFF_MAX_MS);
+    }
+    expect(backoff).toBe(BREAKER_PROBE_BACKOFF_MAX_MS);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+  });
+
+  it('open 期间旧请求(非探测)超时不推进退避窗口', () => {
+    const h = harness();
+    openBreaker(h);
+    // open 前已在途的请求陆续超时(wasProbe=false):不影响 10s 首个探测窗口
+    h.breaker.settle(DEV, false, 'timeout');
+    h.breaker.settle(DEV, false, 'timeout');
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
+    expect(h.breaker.acquire(DEV)).toBe('probe');
+  });
+
+  it('探测 inconclusive(如探测期间掉线)释放单飞,可立即再探测', () => {
+    const h = harness();
+    openBreaker(h);
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
+    expect(h.breaker.acquire(DEV)).toBe('probe');
+    h.breaker.settle(DEV, true, 'inconclusive');
+    // 窗口基准未动(早已到点),新的探测立即放行
+    expect(h.breaker.acquire(DEV)).toBe('probe');
+  });
+
+  it('per-device 隔离:一台设备 open 不影响另一台', () => {
+    const h = harness();
+    openBreaker(h);
+    expect(h.breaker.acquire('dev-2')).toBe('allow');
+    expect(h.breaker.isOpen('dev-2')).toBe(false);
+  });
+
+  it('resetAll 清空状态并对 open 中的设备发 close 通知', () => {
+    const h = harness();
+    openBreaker(h);
+    h.onOpenChanged.mockClear();
+    h.breaker.resetAll();
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    expect(h.breaker.acquire(DEV)).toBe('allow');
+    expect(h.onOpenChanged).toHaveBeenCalledWith(DEV, false);
+  });
+});

--- a/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
@@ -147,3 +147,28 @@ describe('deviceResponsivenessBreaker', () => {
     expect(h.onOpenChanged).toHaveBeenCalledWith(DEV, false);
   });
 });
+
+describe('probeDue(只读探测窗口判定,给 rehydrate 主动探测用)', () => {
+  it('closed 设备恒 false;open 后窗口未到 false、窗口到 true', () => {
+    const h = harness();
+    expect(h.breaker.probeDue(DEV)).toBe(false);
+    openBreaker(h);
+    expect(h.breaker.probeDue(DEV)).toBe(false);
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
+    expect(h.breaker.probeDue(DEV)).toBe(true);
+  });
+
+  it('是只读的:不占用探测席位,acquire 仍能拿到 probe', () => {
+    const h = harness();
+    openBreaker(h);
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
+    expect(h.breaker.probeDue(DEV)).toBe(true);
+    expect(h.breaker.probeDue(DEV)).toBe(true);
+    expect(h.breaker.acquire(DEV)).toBe('probe');
+    // 探测在途时 probeDue 收回 false(rehydrate 不应重复带上该设备)
+    expect(h.breaker.probeDue(DEV)).toBe(false);
+    h.breaker.settle(DEV, true, 'responded');
+    expect(h.breaker.probeDue(DEV)).toBe(false);
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+  });
+});

--- a/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
@@ -230,6 +230,20 @@ describe('generation:恢复前派出的旧请求结果不采信(review P1)', () 
     h.breaker.settle(DEV, stale, 'responded'); // 旧代晚到成功:忽略
     expect(h.breaker.isOpen(DEV)).toBe(true);
   });
+
+  it('resetAll 覆盖「仅 acquire 过、无任何 settle」的设备(review:切号旧账不入新账)', () => {
+    const h = harness();
+    // dev-2 只发放过席位,从未 settle:没有 state,代数登记必须发生在 acquire 时
+    const stale = h.breaker.acquire('dev-2');
+    h.breaker.resetAll();
+    h.breaker.settle('dev-2', stale, 'timeout');
+    h.breaker.settle('dev-2', stale, 'timeout');
+    h.breaker.settle('dev-2', stale, 'timeout');
+    expect(h.breaker.isOpen('dev-2')).toBe(false);
+    // 新代请求照常计数
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) timeoutOnce(h.breaker, 'dev-2');
+    expect(h.breaker.isOpen('dev-2')).toBe(true);
+  });
 });
 
 describe('clear(单设备清除,撤权场景)', () => {

--- a/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
@@ -50,11 +50,21 @@ describe('classifyDeviceSendSuccess(成功回包 → 熔断信号分类)', () =>
     }
   });
 
-  it('代表性探测与业务 DB 通道的成功仍是有效恢复证据', () => {
+  it('代表性探测与业务 DB 通道的成功仍是有效恢复证据(闭合态)', () => {
     expect(classifyDeviceSendSuccess(DEVICE_RESPONSIVENESS_PROBE_CHANNEL)).toBe('responded');
     expect(classifyDeviceSendSuccess('local-db:messages:list')).toBe('responded');
     expect(classifyDeviceSendSuccess('maker:send')).toBe('responded');
     expect(classifyDeviceSendSuccess('file-browser:remote-op')).toBe('responded');
+  });
+
+  it('持有探测席位时只有指定探测通道能关熔断(review P1:纯内存 IPC handler 不算)', () => {
+    // maker:list-agent-commands 等 handler 是同步内存实现,DB 卡死时照常应答;
+    // 半开窗口里凑巧抢到探测席位的成功不能作恢复证据。
+    expect(classifyDeviceSendSuccess(DEVICE_RESPONSIVENESS_PROBE_CHANNEL, true)).toBe('responded');
+    expect(classifyDeviceSendSuccess('maker:list-agent-commands', true)).toBe('inconclusive');
+    expect(classifyDeviceSendSuccess('local-db:messages:list', true)).toBe('inconclusive');
+    // 闭合态(非探测)不受影响
+    expect(classifyDeviceSendSuccess('maker:list-agent-commands', false)).toBe('responded');
   });
 });
 

--- a/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
@@ -5,7 +5,9 @@ import {
   REMOTE_INVOKE_ALLOWLIST,
 } from '@cindy/device-link';
 import {
+  BREAKER_NEUTRAL_INVOKE_CHANNELS,
   buildDeviceResponsivenessProbeArgs,
+  classifyDeviceSendSuccess,
   DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
 } from '@/device-link/unresponsiveDevicesStore';
 
@@ -27,5 +29,28 @@ describe('DEVICE_RESPONSIVENESS_PROBE_CHANNEL 契约', () => {
     expect(buildDeviceResponsivenessProbeArgs()).toEqual([1, 'all', { includePinned: true }]);
     // 每次新数组,调用方可安全透传给 invoke(不共享可变引用)。
     expect(buildDeviceResponsivenessProbeArgs()).not.toBe(buildDeviceResponsivenessProbeArgs());
+  });
+});
+
+describe('classifyDeviceSendSuccess(成功回包 → 熔断信号分类)', () => {
+  it('dispatch 特判通道(media / voice)成功按不定论,不作恢复证据(review P1)', () => {
+    // 这四条在被控端 runInvoke 里、dispatchLocalInvoke 之前特判应答,IPC/DB
+    // 卡死时照常成功;half-open 时抢到探测席位不得误关熔断。
+    expect([...BREAKER_NEUTRAL_INVOKE_CHANNELS].sort()).toEqual([
+      'device-link:media:fetch',
+      'device-link:voice:credential-sync',
+      'device-link:voice:dictionary-learning',
+      'device-link:voice:transcribe',
+    ]);
+    for (const channel of BREAKER_NEUTRAL_INVOKE_CHANNELS) {
+      expect(classifyDeviceSendSuccess(channel)).toBe('inconclusive');
+    }
+  });
+
+  it('代表性探测与业务 DB 通道的成功仍是有效恢复证据', () => {
+    expect(classifyDeviceSendSuccess(DEVICE_RESPONSIVENESS_PROBE_CHANNEL)).toBe('responded');
+    expect(classifyDeviceSendSuccess('local-db:messages:list')).toBe('responded');
+    expect(classifyDeviceSendSuccess('maker:send')).toBe('responded');
+    expect(classifyDeviceSendSuccess('file-browser:remote-op')).toBe('responded');
   });
 });

--- a/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DeviceLinkError,
   DL_SUBSCRIBE_CHANNEL,
   DL_UNSUBSCRIBE_CHANNEL,
   REMOTE_INVOKE_ALLOWLIST,
+  type DeviceLinkErrorCode,
 } from '@cindy/device-link';
 import {
   BREAKER_NEUTRAL_INVOKE_CHANNELS,
   buildDeviceResponsivenessProbeArgs,
   classifyDeviceSendSuccess,
+  classifyLinkOpenFailure,
   DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
 } from '@/device-link/unresponsiveDevicesStore';
 
@@ -52,5 +55,24 @@ describe('classifyDeviceSendSuccess(成功回包 → 熔断信号分类)', () =>
     expect(classifyDeviceSendSuccess('local-db:messages:list')).toBe('responded');
     expect(classifyDeviceSendSuccess('maker:send')).toBe('responded');
     expect(classifyDeviceSendSuccess('file-browser:remote-op')).toBe('responded');
+  });
+});
+
+describe('classifyLinkOpenFailure(openLink 失败 → 熔断信号分类)', () => {
+  const err = (code: DeviceLinkErrorCode) => new DeviceLinkError(code, code);
+
+  it('终态 relay 应答(开关关闭 / 不在线 / 版本不符)按真实应答关熔断(review P1)', () => {
+    // 设备状态已由 relay 明确回答,「响应性」判定失去意义:继续 unresponsive
+    // 会让设备被永远探测,横幅还压着更可操作的错误态(如「已关闭远程控制」)。
+    expect(classifyLinkOpenFailure(err('REMOTE_DISABLED'))).toBe('responded');
+    expect(classifyLinkOpenFailure(err('DEVICE_OFFLINE'))).toBe('responded');
+    expect(classifyLinkOpenFailure(err('VERSION_MISMATCH'))).toBe('responded');
+  });
+
+  it('传输层失败维持不定论,超时仍计失败', () => {
+    expect(classifyLinkOpenFailure(err('NOT_CONNECTED'))).toBe('inconclusive');
+    expect(classifyLinkOpenFailure(err('LINK_NOT_OPEN'))).toBe('inconclusive');
+    expect(classifyLinkOpenFailure(err('INVOKE_TIMEOUT'))).toBe('timeout');
+    expect(classifyLinkOpenFailure(new Error('boom'))).toBe('inconclusive');
   });
 });

--- a/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DL_SUBSCRIBE_CHANNEL,
+  DL_UNSUBSCRIBE_CHANNEL,
+  REMOTE_INVOKE_ALLOWLIST,
+} from '@cindy/device-link';
+import {
+  buildDeviceResponsivenessProbeArgs,
+  DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
+} from '@/device-link/unresponsiveDevicesStore';
+
+describe('DEVICE_RESPONSIVENESS_PROBE_CHANNEL 契约', () => {
+  it('探测通道在 allowlist 内(被控端不会以 CHANNEL_NOT_ALLOWED 拒绝)', () => {
+    expect(REMOTE_INVOKE_ALLOWLIST).toContain(DEVICE_RESPONSIVENESS_PROBE_CHANNEL);
+  });
+
+  it('探测通道不是 dispatch 在 runInvoke 之前特判的通道(review P1:必须穿过 IPC/DB 路径)', () => {
+    // link-accept / subscribe / unsubscribe 在被控端 dispatch 里于 runInvoke 之前
+    // 特判应答:IPC/DB 子系统卡死时它们照常回包,不能作为熔断恢复证据。
+    expect(DEVICE_RESPONSIVENESS_PROBE_CHANNEL).not.toBe(DL_SUBSCRIBE_CHANNEL);
+    expect(DEVICE_RESPONSIVENESS_PROBE_CHANNEL).not.toBe(DL_UNSUBSCRIBE_CHANNEL);
+    // local-db 前缀 = 走 dispatchLocalInvoke 的真实 DB 读,正是事故里卡死的路径。
+    expect(DEVICE_RESPONSIVENESS_PROBE_CHANNEL.startsWith('local-db:')).toBe(true);
+  });
+
+  it('探测参数是最小读:limit=1,与 devices 页正常拉取同一参数形状', () => {
+    expect(buildDeviceResponsivenessProbeArgs()).toEqual([1, 'all', { includePinned: true }]);
+    // 每次新数组,调用方可安全透传给 invoke(不共享可变引用)。
+    expect(buildDeviceResponsivenessProbeArgs()).not.toBe(buildDeviceResponsivenessProbeArgs());
+  });
+});

--- a/apps/mobile/src/__tests__/filesConnectionBanner.test.ts
+++ b/apps/mobile/src/__tests__/filesConnectionBanner.test.ts
@@ -9,9 +9,9 @@ describe('mobile files page connection banner noise budget', () => {
     expect(source.split('<ConnectionBanner').length).toBe(2);
 
     // banner 渲染条件与会话页对齐(useShowConnectionBanner):请求级 error /
-    // 可分类连接问题立即显示;普通弱网断线持续超过防闪窗口后也显示;
-    // 连接正常时不渲染常驻状态条。
-    expect(source).toContain('useShowConnectionBanner(status, error, connectionIssue)');
+    // 可分类连接问题 / 目标设备熔断 open(电脑端未响应)立即显示;普通弱网断线
+    // 持续超过防闪窗口后也显示;连接正常时不渲染常驻状态条。
+    expect(source).toContain('useShowConnectionBanner(status, error, connectionIssue, deviceUnresponsive)');
     expect(source).toContain('{showConnectionBanner ? (');
     expect(source).toContain('density="compact"');
     expect(source).toContain('variant="inline"');

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -236,7 +236,10 @@ describe('mobile home desktop-first surface', () => {
     const source = readSource('app/devices/index.tsx');
 
     expect(source).toContain("type HomeDeviceConnectionState = 'idle' | 'syncing' | 'failed';");
-    expect(source).toContain('const [deviceConnectionStates, setDeviceConnectionStates]');
+    expect(source).toContain('const [rawDeviceConnectionStates, setDeviceConnectionStates]');
+    // 熔断 open 的设备复用 failed 渲染路径:内部态映射(merged memo)覆盖在 hydrate 状态之上
+    expect(source).toContain('const unresponsiveDevices = useUnresponsiveDevices();');
+    expect(source).toContain("for (const deviceId of unresponsiveDevices) merged[deviceId] = 'failed';");
     expect(source).toContain("updateDeviceConnectionState(device.deviceId, 'syncing');");
     expect(source).toContain("updateDeviceConnectionState(device.deviceId, 'failed');");
     expect(source).toContain("updateDeviceConnectionState(device.deviceId, 'idle');");

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -7,9 +7,12 @@ import {
 } from '@/device-link/invokeTimeouts';
 
 describe('resolveMobileInvokeTimeoutMs', () => {
-  it('mobile 精确表优先:media / 文件搜索保住收紧前的 30s 窗口', () => {
+  it('mobile 精确表优先:media / 文件搜索 / 词典学习保住收紧前的 30s 窗口', () => {
     expect(resolveMobileInvokeTimeoutMs('device-link:media:fetch')).toBe(30_000);
     expect(resolveMobileInvokeTimeoutMs('file-browser:remote-op')).toBe(30_000);
+    // 词典学习:桌面 advisor 的 managed refiner 单次尝试空闲窗 12s 且会换备选
+    // profile 重试,合法执行可超 15s;15s 默认误超时会把后台学习计入熔断失败。
+    expect(resolveMobileInvokeTimeoutMs('device-link:voice:dictionary-learning')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -24,6 +24,10 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     expect(resolveMobileInvokeTimeoutMs('maker:rewind:commit')).toBe(30_000);
     // context-usage:非运行中会话走 lazy-create(SSH 就绪等待 20s + 会话拉起)。
     expect(resolveMobileInvokeTimeoutMs('maker:get-context-usage')).toBe(30_000);
+    // codex rate-limit 读/消耗:账号 app-server 冷启动无更短 deadline;reset
+    // 有真实副作用,误超时后重试有重复扣减风险。
+    expect(resolveMobileInvokeTimeoutMs('maker:usage:codex-rate-limits')).toBe(30_000);
+    expect(resolveMobileInvokeTimeoutMs('maker:usage:codex-rate-limit-reset')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -35,6 +35,10 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     // create-session:冷启动 app-server / agent 拉起无更短 deadline;goal 路径
     // 无稳定客户端会话 id,误超时重试会建出第二个会话。
     expect(resolveMobileInvokeTimeoutMs('maker:create-session')).toBe(30_000);
+    // goal set/resume:restoreSessionForGoal 同样 await createSession 重启持久化
+    // agent;两者有真实副作用,误超时重试会改动/重启已在跑的 goal。
+    expect(resolveMobileInvokeTimeoutMs('maker:goal:set')).toBe(30_000);
+    expect(resolveMobileInvokeTimeoutMs('maker:goal:resume')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -22,6 +22,8 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     // rewind:commit:DB 读 + 线程回滚 + Git 回退 + SQLite 事务,非幂等——误超时
     // 后对话与文件已被回退,重试会作用在已变更的历史上。
     expect(resolveMobileInvokeTimeoutMs('maker:rewind:commit')).toBe(30_000);
+    // context-usage:非运行中会话走 lazy-create(SSH 就绪等待 20s + 会话拉起)。
+    expect(resolveMobileInvokeTimeoutMs('maker:get-context-usage')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -19,6 +19,9 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     // fork:载入完整消息前缀 + SDK fork + 事务批量拷贝,大会话 15-30s;非幂等,
     // 误超时后桌面仍会建出新会话,重试会分叉重复副本。
     expect(resolveMobileInvokeTimeoutMs('maker:fork')).toBe(30_000);
+    // rewind:commit:DB 读 + 线程回滚 + Git 回退 + SQLite 事务,非幂等——误超时
+    // 后对话与文件已被回退,重试会作用在已变更的历史上。
+    expect(resolveMobileInvokeTimeoutMs('maker:rewind:commit')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -32,6 +32,9 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     expect(resolveMobileInvokeTimeoutMs('maker:send')).toBe(30_000);
     // regenerate-title:OAuth 刷新(~10s)+ 标题请求自身 12s,合法总预算 ~22s。
     expect(resolveMobileInvokeTimeoutMs('maker:regenerate-title')).toBe(30_000);
+    // create-session:冷启动 app-server / agent 拉起无更短 deadline;goal 路径
+    // 无稳定客户端会话 id,误超时重试会建出第二个会话。
+    expect(resolveMobileInvokeTimeoutMs('maker:create-session')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -28,6 +28,10 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     // 有真实副作用,误超时后重试有重复扣减风险。
     expect(resolveMobileInvokeTimeoutMs('maker:usage:codex-rate-limits')).toBe(30_000);
     expect(resolveMobileInvokeTimeoutMs('maker:usage:codex-rate-limit-reset')).toBe(30_000);
+    // send:接收前等 SSH 就绪(20s 窗口);非幂等,误超时重试会把消息发两遍。
+    expect(resolveMobileInvokeTimeoutMs('maker:send')).toBe(30_000);
+    // regenerate-title:OAuth 刷新(~10s)+ 标题请求自身 12s,合法总预算 ~22s。
+    expect(resolveMobileInvokeTimeoutMs('maker:regenerate-title')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -13,6 +13,12 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     // 词典学习:桌面 advisor 的 managed refiner 单次尝试空闲窗 12s 且会换备选
     // profile 重试,合法执行可超 15s;15s 默认误超时会把后台学习计入熔断失败。
     expect(resolveMobileInvokeTimeoutMs('device-link:voice:dictionary-learning')).toBe(30_000);
+    // 语音转写:桌面端 OSS 下载 + 批量网关转写,两段都无更短 deadline,中速网络
+    // 合法可超 15s,连续几条误超时会错误打开设备级熔断。
+    expect(resolveMobileInvokeTimeoutMs('device-link:voice:transcribe')).toBe(30_000);
+    // fork:载入完整消息前缀 + SDK fork + 事务批量拷贝,大会话 15-30s;非幂等,
+    // 误超时后桌面仍会建出新会话,重试会分叉重复副本。
+    expect(resolveMobileInvokeTimeoutMs('maker:fork')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
+import {
+  MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS,
+  MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS,
+  resolveMobileInvokeTimeoutMs,
+} from '@/device-link/invokeTimeouts';
+
+describe('resolveMobileInvokeTimeoutMs', () => {
+  it('mobile 精确表优先:media / 文件搜索保住收紧前的 30s 窗口', () => {
+    expect(resolveMobileInvokeTimeoutMs('device-link:media:fetch')).toBe(30_000);
+    expect(resolveMobileInvokeTimeoutMs('file-browser:remote-op')).toBe(30_000);
+    expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
+  });
+
+  it('maker:schedule:* 前缀整类放宽:桌面 handler 会等 scheduler 就绪(30s 上限)', () => {
+    expect(resolveMobileInvokeTimeoutMs('maker:schedule:list')).toBe(MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS);
+    expect(resolveMobileInvokeTimeoutMs('maker:schedule:list-runs')).toBe(MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS);
+    expect(resolveMobileInvokeTimeoutMs('maker:schedule:mark-run-read')).toBe(MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS);
+    expect(MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS).toBeGreaterThan(30_000);
+  });
+
+  it('其余通道回退协议契约表;无登记则 undefined(client 默认 15s)', () => {
+    for (const [channel, ms] of Object.entries(INVOKE_TIMEOUT_OVERRIDES_MS)) {
+      expect(resolveMobileInvokeTimeoutMs(channel)).toBe(ms);
+    }
+    expect(resolveMobileInvokeTimeoutMs('maker:get-capabilities')).toBe(
+      INVOKE_TIMEOUT_OVERRIDES_MS['maker:get-capabilities'],
+    );
+  });
+});

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -335,7 +335,7 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
-  it('DEVICE_UNRESPONSIVE:批循环命中即 break,剩余 listRuns 不再发', async () => {
+  it('DEVICE_UNRESPONSIVE:批循环命中立即止损并上抛,不产出部分索引', async () => {
     const listRuns = vi.fn(async () => {
       throw Object.assign(
         new Error('target device dev-1 is unresponsive (circuit open)'),
@@ -352,11 +352,14 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
         listRuns,
       },
     } as unknown as Pick<MobileMakerTransport, 'schedule'>;
-    const index = await loadSessionScheduleIndex(maker);
+    // 上抛而不是截断成功(review P1):部分索引若被当成功提交,会进入 30s 正
+    // 缓存,首页/详情页拿着不完整徽标还以为是新鲜数据;上抛让节流层走失败负
+    // 缓存,熔断恢复后重拉全量。
+    await expect(loadSessionScheduleIndex(maker)).rejects.toMatchObject({
+      code: 'DEVICE_UNRESPONSIVE',
+    });
     // 熔断快速失败会在每个 listRuns 上重复出现:第一个命中后立即止损
     expect(listRuns).toHaveBeenCalledTimes(1);
-    // schedules 列表已到手:targetSessionId 绑定的兜底条目仍然可用(名称 / 分组不丢)
-    expect(index.get('session-a')).toMatchObject({ scheduleId: 'sched-1', scheduleName: 'a' });
   });
 
   it('listRuns 串行执行(同一时刻最多一个在途,不挤占 device-link 管道)', async () => {

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -336,6 +336,28 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
+  it('末项竞态的 INVOKE_TIMEOUT 失败:熔断 open 时同样按未响应记负缓存,恢复即旁路', async () => {
+    // 末项竞态抛的是原始 INVOKE_TIMEOUT(非快速失败码);节流层补查 store
+    // (key 即 deviceId)才能让这类失败同样享受「恢复即旁路」。
+    resetScheduleIndexThrottleForTesting();
+    const load = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('invoke timed out'), { code: 'INVOKE_TIMEOUT' }))
+      .mockResolvedValueOnce(new Map<string, RemoteSessionScheduleInfo>());
+    const now = () => 1000;
+    unresponsiveDevicesStore.markUnresponsive('dev-t');
+    try {
+      await expect(loadSessionScheduleIndexThrottled('dev-t', load, { now })).rejects.toMatchObject({
+        code: 'INVOKE_TIMEOUT',
+      });
+      await Promise.resolve();
+      unresponsiveDevicesStore.clearUnresponsive('dev-t');
+      await expect(loadSessionScheduleIndexThrottled('dev-t', load, { now })).resolves.toBeInstanceOf(Map);
+      expect(load).toHaveBeenCalledTimes(2);
+    } finally {
+      unresponsiveDevicesStore.clearUnresponsive('dev-t');
+    }
+  });
+
   it('DEVICE_UNRESPONSIVE 负缓存:熔断仍 open 时复用,恢复后立即旁路重拉(review P1)', async () => {
     // 熔断关闭触发的 reseed/重载若在失败 TTL 内吃到同一个 rejected promise,
     // 索引会被 catch 路径替换成空集,且无定时器在 TTL 过期后补拉——徽标要等
@@ -394,6 +416,28 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     });
     // 熔断快速失败会在每个 listRuns 上重复出现:第一个命中后立即止损
     expect(listRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it('末项竞态:最后一个 listRuns 的超时恰好开熔断时同样上抛,不产出部分索引(review P1)', async () => {
+    // 该超时是凑满阈值的第 3 条:settle 开了熔断,但本次在途请求抛出的仍是
+    // 原始 INVOKE_TIMEOUT 而非快速失败码——必须查实时熔断状态兜住。
+    let calls = 0;
+    const maker = {
+      schedule: {
+        list: async () => [
+          { id: 'sched-1', name: 'a', status: 'active', targetSessionId: 'session-a' },
+          { id: 'sched-2', name: 'b', status: 'active', targetSessionId: 'session-b' },
+        ],
+        listRuns: vi.fn(async () => {
+          calls += 1;
+          if (calls === 1) return [];
+          throw Object.assign(new Error('invoke timed out'), { code: 'INVOKE_TIMEOUT' });
+        }),
+      },
+    } as unknown as Pick<MobileMakerTransport, 'schedule'>;
+    await expect(
+      loadSessionScheduleIndex(maker, { isDeviceUnresponsive: () => calls >= 2 }),
+    ).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
   });
 
   it('listRuns 串行执行(同一时刻最多一个在途,不挤占 device-link 管道)', async () => {

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { MobileMakerTransport } from '@/device-link/mobileMakerTransport';
+import { unresponsiveDevicesStore } from '@/device-link/unresponsiveDevicesStore';
 import {
   loadSessionScheduleIndex,
   loadSessionScheduleIndexThrottled,
@@ -333,6 +334,39 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     await Promise.resolve();
     await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now, force: true })).resolves.toBeInstanceOf(Map);
     expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it('DEVICE_UNRESPONSIVE 负缓存:熔断仍 open 时复用,恢复后立即旁路重拉(review P1)', async () => {
+    // 熔断关闭触发的 reseed/重载若在失败 TTL 内吃到同一个 rejected promise,
+    // 索引会被 catch 路径替换成空集,且无定时器在 TTL 过期后补拉——徽标要等
+    // 无关触发源才回来。恢复(设备移出 unresponsive 集合)必须使负缓存失效。
+    resetScheduleIndexThrottleForTesting();
+    const unresponsiveError = Object.assign(
+      new Error('target device dev-1 is unresponsive (circuit open)'),
+      { code: 'DEVICE_UNRESPONSIVE' },
+    );
+    const load = vi.fn()
+      .mockRejectedValueOnce(unresponsiveError)
+      .mockResolvedValueOnce(new Map<string, RemoteSessionScheduleInfo>());
+    const now = () => 1000;
+    unresponsiveDevicesStore.markUnresponsive('dev-1');
+    try {
+      await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).rejects.toMatchObject({
+        code: 'DEVICE_UNRESPONSIVE',
+      });
+      await Promise.resolve();
+      // 熔断仍 open:失败 TTL 内复用负缓存,不压请求
+      await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).rejects.toMatchObject({
+        code: 'DEVICE_UNRESPONSIVE',
+      });
+      expect(load).toHaveBeenCalledTimes(1);
+      // 设备恢复(探测成功关熔断):TTL 未过也立即旁路重拉
+      unresponsiveDevicesStore.clearUnresponsive('dev-1');
+      await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).resolves.toBeInstanceOf(Map);
+      expect(load).toHaveBeenCalledTimes(2);
+    } finally {
+      unresponsiveDevicesStore.clearUnresponsive('dev-1');
+    }
   });
 
   it('DEVICE_UNRESPONSIVE:批循环命中立即止损并上抛,不产出部分索引', async () => {

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { MobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { unresponsiveDevicesStore } from '@/device-link/unresponsiveDevicesStore';
 import {
+  invalidateTransientScheduleIndexFailures,
   loadSessionScheduleIndex,
   loadSessionScheduleIndexThrottled,
   replaceSessionScheduleIndexEntries,
@@ -333,6 +334,29 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).rejects.toThrow('boom');
     await Promise.resolve();
     await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now, force: true })).resolves.toBeInstanceOf(Map);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it('瞬态失败(NOT_CONNECTED)的负缓存在重连失效钩子后立即重拉(review P1)', async () => {
+    // 普通断线的负缓存若挺过重连,30s 内 reseed 会吃旧 rejected promise,
+    // 详情页替换成空索引且无人补拉;rehydrate 开始时调用失效钩子解决。
+    resetScheduleIndexThrottleForTesting();
+    const load = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('not connected'), { code: 'NOT_CONNECTED' }))
+      .mockResolvedValueOnce(new Map<string, RemoteSessionScheduleInfo>());
+    const now = () => 1000;
+    await expect(loadSessionScheduleIndexThrottled('dev-n', load, { now })).rejects.toMatchObject({
+      code: 'NOT_CONNECTED',
+    });
+    await Promise.resolve();
+    // 失效前:TTL 内复用负缓存
+    await expect(loadSessionScheduleIndexThrottled('dev-n', load, { now })).rejects.toMatchObject({
+      code: 'NOT_CONNECTED',
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+    // 重连(rehydrate 开始)→ 瞬态负缓存失效 → 立即重拉
+    invalidateTransientScheduleIndexFailures();
+    await expect(loadSessionScheduleIndexThrottled('dev-n', load, { now })).resolves.toBeInstanceOf(Map);
     expect(load).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -5,6 +5,7 @@ import {
   loadSessionScheduleIndexThrottled,
   replaceSessionScheduleIndexEntries,
   resetScheduleIndexThrottleForTesting,
+  SCHEDULE_INDEX_FAILURE_TTL_MS,
   SCHEDULE_INDEX_THROTTLE_TTL_MS,
 } from '@/session/scheduleIndex';
 import type { RemoteSessionScheduleInfo } from '@/session/sessionList';
@@ -301,17 +302,61 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
-  it('失败不占坑:reject 后下一次触发正常重试', async () => {
+  it('失败负缓存:reject 后 TTL 内复用同一次失败不重放批次,过期后正常重试', async () => {
+    resetScheduleIndexThrottleForTesting();
+    const load = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(new Map<string, RemoteSessionScheduleInfo>());
+    let at = 1000;
+    const now = () => at;
+    await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).rejects.toThrow('boom');
+    // 失败时间戳写入是微任务,先让它落地。
+    await Promise.resolve();
+    // 失败 TTL 内的被动触发直接吃负缓存(同一个 rejected promise),不再压请求上管道:
+    // 旧的「失败即清坑」+ 多触发源交叠,是被控端无响应时反复全量重放的放大器。
+    at += SCHEDULE_INDEX_FAILURE_TTL_MS - 1;
+    await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).rejects.toThrow('boom');
+    expect(load).toHaveBeenCalledTimes(1);
+    // 负缓存过期后正常重试
+    at += 1;
+    await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).resolves.toBeInstanceOf(Map);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it('失败负缓存:force(用户显式动作)穿透负缓存立即重拉', async () => {
     resetScheduleIndexThrottleForTesting();
     const load = vi.fn()
       .mockRejectedValueOnce(new Error('boom'))
       .mockResolvedValueOnce(new Map<string, RemoteSessionScheduleInfo>());
     const now = () => 1000;
     await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).rejects.toThrow('boom');
-    // reject 清坑是微任务,先让它落地。
     await Promise.resolve();
-    await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now })).resolves.toBeInstanceOf(Map);
+    await expect(loadSessionScheduleIndexThrottled('dev-1', load, { now, force: true })).resolves.toBeInstanceOf(Map);
     expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it('DEVICE_UNRESPONSIVE:批循环命中即 break,剩余 listRuns 不再发', async () => {
+    const listRuns = vi.fn(async () => {
+      throw Object.assign(
+        new Error('target device dev-1 is unresponsive (circuit open)'),
+        { code: 'DEVICE_UNRESPONSIVE' },
+      );
+    });
+    const maker = {
+      schedule: {
+        list: async () => [
+          { id: 'sched-1', name: 'a', status: 'active', targetSessionId: 'session-a' },
+          { id: 'sched-2', name: 'b', status: 'active' },
+          { id: 'sched-3', name: 'c', status: 'active' },
+        ],
+        listRuns,
+      },
+    } as unknown as Pick<MobileMakerTransport, 'schedule'>;
+    const index = await loadSessionScheduleIndex(maker);
+    // 熔断快速失败会在每个 listRuns 上重复出现:第一个命中后立即止损
+    expect(listRuns).toHaveBeenCalledTimes(1);
+    // schedules 列表已到手:targetSessionId 绑定的兜底条目仍然可用(名称 / 分组不丢)
+    expect(index.get('session-a')).toMatchObject({ scheduleId: 'sched-1', scheduleName: 'a' });
   });
 
   it('listRuns 串行执行(同一时刻最多一个在途,不挤占 device-link 管道)', async () => {

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -42,10 +42,10 @@ describe('mobile session main layer desktop-first noise budget', () => {
     const syncEnd = source.indexOf('function MessageHistoryToggle', syncStart);
     const syncSource = source.slice(syncStart, syncEnd);
 
-    // banner 渲染条件(useShowConnectionBanner):请求级 error / 可分类连接问题
-    // 立即显示;普通弱网断线经防闪窗口后也显示,不再彻底静默。
+    // banner 渲染条件(useShowConnectionBanner):请求级 error / 可分类连接问题 /
+    // 目标设备熔断 open(电脑端未响应)立即显示;普通弱网断线经防闪窗口后也显示,不再彻底静默。
     expect(routeSource).toContain('{showConnectionBanner ? (');
-    expect(source).toContain('useShowConnectionBanner(status, connectionError, connectionIssue)');
+    expect(source).toContain('useShowConnectionBanner(status, connectionError, connectionIssue, isDeviceUnresponsive)');
     expect(routeSource).not.toContain('connectionError || (loading && !currentSession)');
     expect(syncSource).toContain("t('session.screen.awaitingSync')");
     expect(syncSource).toContain("t('session.screen.resync')");

--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -11,6 +11,7 @@ import {
   relayStatusLabel,
 } from '@/device-link/remoteStatus';
 import { MainWindowActionButton, StatusDot } from '@/components/MobilePrimitives';
+import { resolveConnectionBannerVisibility } from '@/components/connectionBannerVisibility';
 import { fontWeight, useThemedStyles, type ThemeColors } from '@/theme';
 import { lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
 
@@ -20,14 +21,17 @@ const OFFLINE_BANNER_DELAY_MS = 1_200;
 /**
  * 条件挂载 ConnectionBanner 的统一可见性判定:
  * - 请求级 error / 可分类连接问题(鉴权失效、被顶号等)→ 立即显示;
+ * - 当前关联设备熔断 open(电脑端未响应,relay 可能仍 online)→ 立即显示;
  * - 普通弱网断线(status 非 online 且无分类 issue)→ 持续超过静默窗口才显示,
  *   既让用户看得到「正在重连」(否则消息流静默停更没有任何信号),又不因
  *   一次快速重连闪一下布局(规则 7:杜绝跳变)。
+ * 判定核在 resolveConnectionBannerVisibility(纯函数,单测覆盖)。
  */
 export function useShowConnectionBanner(
   status: DeviceLinkStatus,
   error: string | null,
   issue: DeviceLinkConnectionIssue | null,
+  deviceUnresponsive = false,
 ): boolean {
   const offline = status !== 'online';
   const [offlineLongEnough, setOfflineLongEnough] = useState(false);
@@ -39,13 +43,20 @@ export function useShowConnectionBanner(
     const timer = setTimeout(() => setOfflineLongEnough(true), OFFLINE_BANNER_DELAY_MS);
     return () => clearTimeout(timer);
   }, [offline]);
-  return Boolean(error) || (offline && (issue !== null || offlineLongEnough));
+  return resolveConnectionBannerVisibility({
+    offline,
+    offlineLongEnough,
+    hasError: Boolean(error),
+    hasIssue: issue !== null,
+    deviceUnresponsive,
+  });
 }
 
 export function ConnectionBanner({
   status,
   loading,
   density = 'default',
+  deviceUnresponsive = false,
   error,
   issue = null,
   lastSyncedAt,
@@ -55,6 +66,8 @@ export function ConnectionBanner({
   status: DeviceLinkStatus;
   loading: boolean;
   density?: 'default' | 'compact';
+  /** 当前关联设备熔断 open(电脑端未响应);relay 可能仍 online,单独入参 */
+  deviceUnresponsive?: boolean;
   error: string | null;
   /** 连接层失败原因(useDeviceLink().connectionIssue);比请求级 error 更根因,优先展示 */
   issue?: DeviceLinkConnectionIssue | null;
@@ -67,28 +80,37 @@ export function ConnectionBanner({
   // 链路已 online 说明 issue 已过期(client 侧 online 会清除,这里兜底不展示)。
   // issue 优先于请求级 error:链路断因明确时,invoke 失败都是它的下游症状(NOT_CONNECTED)。
   const activeIssue = status !== 'online' ? issue : null;
-  const friendlyError = activeIssue ? null : describeRemoteError(error);
+  // 熔断 open 优先于请求级 error:open 期间的请求失败绝大多数就是熔断快速失败本身,
+  // 状态级提示(未响应 + 自动重试中)比单次请求的错误原文更能解释现状。
+  const showUnresponsive = !activeIssue && deviceUnresponsive;
+  const friendlyError = activeIssue || showUnresponsive ? null : describeRemoteError(error);
   const tone = activeIssue
     ? 'off'
-    : friendlyError ? 'muted' : status === 'online' ? 'ready' : status === 'connecting' ? 'busy' : 'off';
+    : showUnresponsive
+      ? 'busy'
+      : friendlyError ? 'muted' : status === 'online' ? 'ready' : status === 'connecting' ? 'busy' : 'off';
   const compact = density === 'compact';
   const title = activeIssue
     ? connectionIssueTitle(activeIssue.kind)
-    : friendlyError ? t('deviceLink.syncFailed') : relayStatusLabel(status);
+    : showUnresponsive
+      ? t('deviceLink.deviceUnresponsiveTitle')
+      : friendlyError ? t('deviceLink.syncFailed') : relayStatusLabel(status);
   const copy = activeIssue
     ? connectionIssueHint(activeIssue.kind)
-    : friendlyError ?? relayStatusHint(status, lastSyncedAt);
+    : showUnresponsive
+      ? t('deviceLink.deviceUnresponsiveHint')
+      : friendlyError ?? relayStatusHint(status, lastSyncedAt);
   return (
     <View
       style={[
         styles.root,
         compact && styles.rootCompact,
         variant === 'inline' && styles.rootInline,
-        (friendlyError || activeIssue) && styles.rootError,
+        (friendlyError || activeIssue || showUnresponsive) && styles.rootError,
       ]}
       testID="connection.banner"
     >
-      <StatusDot tone={tone} pulsing={!activeIssue && status === 'connecting'} />
+      <StatusDot tone={tone} pulsing={!activeIssue && (status === 'connecting' || showUnresponsive)} />
       <View style={[styles.textBlock, compact && styles.textBlockCompact]}>
         <Text
           ellipsizeMode="tail"
@@ -101,7 +123,7 @@ export function ConnectionBanner({
         {!compact ? (
           <Text
             ellipsizeMode="tail"
-            numberOfLines={friendlyError || activeIssue ? 2 : 1}
+            numberOfLines={friendlyError || activeIssue || showUnresponsive ? 2 : 1}
             style={styles.copy}
             testID="connection.copy"
           >

--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -11,7 +11,10 @@ import {
   relayStatusLabel,
 } from '@/device-link/remoteStatus';
 import { MainWindowActionButton, StatusDot } from '@/components/MobilePrimitives';
-import { resolveConnectionBannerVisibility } from '@/components/connectionBannerVisibility';
+import {
+  resolveConnectionBannerVisibility,
+  resolveEffectiveConnectionError,
+} from '@/components/connectionBannerVisibility';
 import { fontWeight, useThemedStyles, type ThemeColors } from '@/theme';
 import { lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
 
@@ -46,7 +49,9 @@ export function useShowConnectionBanner(
   return resolveConnectionBannerVisibility({
     offline,
     offlineLongEnough,
-    hasError: Boolean(error),
+    // 熔断已关后屏幕残留的 DEVICE_UNRESPONSIVE 错误按陈旧丢弃(review P1),
+    // 否则恢复后 banner 会带着"自动重试中"文案常驻到用户手动同步。
+    hasError: Boolean(resolveEffectiveConnectionError(error, deviceUnresponsive)),
     hasIssue: issue !== null,
     deviceUnresponsive,
   });
@@ -83,7 +88,10 @@ export function ConnectionBanner({
   // 熔断 open 优先于请求级 error:open 期间的请求失败绝大多数就是熔断快速失败本身,
   // 状态级提示(未响应 + 自动重试中)比单次请求的错误原文更能解释现状。
   const showUnresponsive = !activeIssue && deviceUnresponsive;
-  const friendlyError = activeIssue || showUnresponsive ? null : describeRemoteError(error);
+  // 熔断已关后残留的 DEVICE_UNRESPONSIVE 错误是陈旧快照,按 null 处理(与
+  // useShowConnectionBanner 同一判定,否则会出现可见但无内容的空壳 banner)。
+  const effectiveError = resolveEffectiveConnectionError(error, deviceUnresponsive);
+  const friendlyError = activeIssue || showUnresponsive ? null : describeRemoteError(effectiveError);
   const tone = activeIssue
     ? 'off'
     : showUnresponsive

--- a/apps/mobile/src/components/connectionBannerVisibility.ts
+++ b/apps/mobile/src/components/connectionBannerVisibility.ts
@@ -1,0 +1,21 @@
+/**
+ * connectionBannerVisibility.ts — ConnectionBanner 可见性判定的决策核。
+ * 纯函数(不依赖 React / react-native),node 可单测;useShowConnectionBanner
+ * 只负责喂时间维度的 offlineLongEnough,判定逻辑全在这里:
+ *  - 请求级 error / 可分类连接问题(鉴权失效、被顶号等)→ 立即显示;
+ *  - 关联设备熔断 open(电脑端未响应)→ 立即显示——relay 可能仍 online,
+ *    只看 status 的旧判定对「进程活着但内部卡死」的半死态完全失明
+ *    (2026-07 事故:presence 恒 online,banner 一直不出现,用户零信号);
+ *  - 普通弱网断线 → 持续超过防闪窗口才显示(规则 7:杜绝跳变)。
+ */
+export function resolveConnectionBannerVisibility(input: {
+  offline: boolean;
+  offlineLongEnough: boolean;
+  hasError: boolean;
+  hasIssue: boolean;
+  deviceUnresponsive: boolean;
+}): boolean {
+  return input.hasError
+    || input.deviceUnresponsive
+    || (input.offline && (input.hasIssue || input.offlineLongEnough));
+}

--- a/apps/mobile/src/components/connectionBannerVisibility.ts
+++ b/apps/mobile/src/components/connectionBannerVisibility.ts
@@ -19,3 +19,20 @@ export function resolveConnectionBannerVisibility(input: {
     || input.deviceUnresponsive
     || (input.offline && (input.hasIssue || input.offlineLongEnough));
 }
+
+/**
+ * 屏幕层持有的请求级 error 是快照:熔断 open 期间的重试失败会把
+ * DEVICE_UNRESPONSIVE 文案存进去,而探测成功自动关熔断只翻转
+ * deviceUnresponsive,不会替屏幕清 error(review P1)。熔断已关时这类
+ * 错误必然是陈旧的——它描述的状态(未响应 + 自动重试中)已不成立,
+ * 按 null 处理,让 banner 随恢复自动消失;熔断仍 open 时保留原样
+ * (banner 的 unresponsive 分支优先,error 本就不会被展示)。
+ * hook 与组件都要用同一份结果,否则会出现「可见但无内容可渲染」的空壳。
+ */
+export function resolveEffectiveConnectionError(
+  error: string | null,
+  deviceUnresponsive: boolean,
+): string | null {
+  if (error && !deviceUnresponsive && error.includes('DEVICE_UNRESPONSIVE')) return null;
+  return error;
+}

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -6,6 +6,7 @@ import {
   DL_SUBSCRIBE_CHANNEL,
   DL_UNSUBSCRIBE_CHANNEL,
   FILE_BROWSER_EVENT_CHANNEL,
+  INVOKE_TIMEOUT_OVERRIDES_MS,
   PROTOCOL_VERSION,
   type DeviceLinkConnectionIssue,
   type DeviceLinkStatus,
@@ -53,6 +54,13 @@ import {
 } from '@/device-link/topicRegistry';
 import { remoteSessionStore } from '@/session/remoteSessionStore';
 import { revokedDevicesStore } from '@/device-link/revokedDevicesStore';
+import {
+  acquireDeviceSendSlot,
+  classifyDeviceSendFailure,
+  resetDeviceResponsivenessTracking,
+  settleDeviceSend,
+  unresponsiveDevicesStore,
+} from '@/device-link/unresponsiveDevicesStore';
 import { remoteScheduleEventStore } from '@/scheduler/remoteScheduleEvents';
 import { buildMobileDeviceName } from '@/device-link/mobileDeviceIdentity';
 import { updatePresenceAvailability } from '@/device-link/presenceRecovery';
@@ -218,7 +226,13 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
           do {
             state.rerun = false;
             if (client.getStatus() !== 'online') return;
-            const result = await rehydrateDeviceLinkTopics(registryRef.current.snapshot(), {
+            // 熔断 open 的设备跳过补齐:它的每一步都会快速失败(DEVICE_UNRESPONSIVE,
+            // permanent 不计瞬时重试),还会白白占用探测单飞窗口。恢复(探测成功关熔断)
+            // 后由下方 effect 里的 store 订阅补触发一次全量补齐回填。
+            const plans = registryRef.current
+              .snapshot()
+              .filter((plan) => !unresponsiveDevicesStore.has(plan.deviceId));
+            const result = await rehydrateDeviceLinkTopics(plans, {
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
@@ -261,6 +275,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       remoteSessionStore.clear();
       remoteScheduleEventStore.clearAll();
       revokedDevicesStore.clearAll();
+      resetDeviceResponsivenessTracking();
       // 登出 / 进程内切号:清掉所有 per-account 残留,避免下一个账号串到上一个账号的数据。
       // - 供应商目录是 module 级单例缓存(useDeviceProviders 按 deviceId 命中),不随组件卸载清;
       // - lastPresenceSnapshot 是本 context 的 state,home 屏据它 patch 设备列表。
@@ -295,6 +310,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         pongMissLimit: 1,
         getTokenTimeoutMs: 10_000,
         handshakeTimeoutMs: 12_000,
+        // 请求超时收紧到 15s(默认 30s):被控端卡死时 30s 才失败让用户干等半分钟,
+        // 也把熔断器凑齐「连续超时」信号的时间拖长一倍。长执行通道(desktop-cmd:run /
+        // worktree:create 等)在 sendInvoke 按 INVOKE_TIMEOUT_OVERRIDES_MS 单独放宽,
+        // 与桌面控制端同一张协议契约表,不受此默认值影响。
+        requestTimeoutMs: 15_000,
       },
     });
     clientRef.current = client;
@@ -375,6 +395,17 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     }));
     client.start();
 
+    // 熔断恢复回填:探测成功可能发生在任意业务请求上(不局限某个页面),设备从
+    // unresponsive 集合移除时补一次 rehydrate——它 open 期间被跳过的订阅 / 快照
+    // 不该等到下一次重连或回前台才回来。只在「有设备恢复」时触发,open 方向不动。
+    let lastUnresponsiveSnapshot = unresponsiveDevicesStore.getSnapshot();
+    const offUnresponsive = unresponsiveDevicesStore.subscribe(() => {
+      const next = unresponsiveDevicesStore.getSnapshot();
+      const recovered = [...lastUnresponsiveSnapshot].some((deviceId) => !next.has(deviceId));
+      lastUnresponsiveSnapshot = next;
+      if (recovered) void rehydrateWithClient(client);
+    });
+
     // 退后台的断连宽限状态:stopTimer 挂着表示还没真正 stop;backgroundAt 用于
     // 回前台时判断 JS 是否在计时器触发前就被挂起(见 BACKGROUND_SUSPEND_SUSPECT_MS)。
     const backgroundState: { stopTimer: ReturnType<typeof setTimeout> | null; backgroundAt: number } = {
@@ -434,6 +465,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     return () => {
       sub.remove();
       clearBackgroundStopTimer();
+      offUnresponsive();
       offFrame();
       offPresence();
       offStatus();
@@ -657,12 +689,27 @@ function sendOpenLinkWithAccessHandling(
 }
 
 async function sendOpenLink(client: DeviceLinkClient, deviceId: string): Promise<LinkAcceptPayload> {
-  await ensureOnlineForRequest(client);
-  return client.openLink(deviceId, {
-    controllerName: mobileDeviceName(),
-    protocolVersion: PROTOCOL_VERSION,
-    appVersion: Constants.expoConfig?.version ?? '0.0.0',
-  });
+  // 熔断门禁放在连接等待之前:open 时快速失败,不消耗 1.5s 重连等待也不上管道。
+  const probe = acquireDeviceSendSlot(deviceId);
+  try {
+    await ensureOnlineForRequest(client);
+  } catch (err) {
+    settleDeviceSend(deviceId, probe, 'inconclusive');
+    throw err;
+  }
+  try {
+    const accepted = await client.openLink(deviceId, {
+      controllerName: mobileDeviceName(),
+      protocolVersion: PROTOCOL_VERSION,
+      appVersion: Constants.expoConfig?.version ?? '0.0.0',
+    });
+    // link-accept 是目标设备的真实回包 → 重置熔断计数。
+    settleDeviceSend(deviceId, probe, 'responded');
+    return accepted;
+  } catch (err) {
+    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    throw err;
+  }
 }
 
 function sendInvokeWithAccessHandling<T>(
@@ -682,11 +729,29 @@ async function sendInvoke<T>(
   args: unknown[],
   opts?: { preSend?: () => void },
 ): Promise<T> {
-  await ensureOnlineForRequest(client);
-  // 连接就绪后、真正发送前的最后检查点:重连等待期间调用方状态可能已失效
-  // (写被同字段新写取代),抛错即中止发送。
-  opts?.preSend?.();
-  const result = await client.invoke(deviceId, { channel, args });
+  // 熔断门禁放在连接等待之前:open 时快速失败,不消耗 1.5s 重连等待也不上管道。
+  const probe = acquireDeviceSendSlot(deviceId);
+  try {
+    await ensureOnlineForRequest(client);
+    // 连接就绪后、真正发送前的最后检查点:重连等待期间调用方状态可能已失效
+    // (写被同字段新写取代),抛错即中止发送。
+    opts?.preSend?.();
+  } catch (err) {
+    // 未真正发送(等待连接失败 / preSend 中止):对设备响应性不定论。
+    settleDeviceSend(deviceId, probe, 'inconclusive');
+    throw err;
+  }
+  let result: InvokeResultPayload;
+  try {
+    // 长执行通道(desktop-cmd:run / worktree:create 等)按协议契约表放宽超时,
+    // 与桌面控制端用法对齐,避免 mobile 收紧的默认 15s 误伤合法慢操作。
+    result = await client.invoke(deviceId, { channel, args }, INVOKE_TIMEOUT_OVERRIDES_MS[channel]);
+  } catch (err) {
+    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    throw err;
+  }
+  // 收到 invoke-result 帧即为目标设备真实回包(即使 ok:false 的业务错误)→ 重置熔断。
+  settleDeviceSend(deviceId, probe, 'responded');
   return unwrapInvoke<T>(result);
 }
 
@@ -703,11 +768,25 @@ async function sendSubscribe(
   deviceId: string,
   topics: readonly string[],
 ): Promise<void> {
-  await ensureOnlineForRequest(client);
-  const result = await client.invoke(deviceId, {
-    channel: DL_SUBSCRIBE_CHANNEL,
-    args: [{ topics, controllerName: mobileDeviceName() }],
-  });
+  // subscribe 同样走隧道请求超时等待(默认 15s),一样计入并受熔断限制(见 sendInvoke 注释)。
+  const probe = acquireDeviceSendSlot(deviceId);
+  try {
+    await ensureOnlineForRequest(client);
+  } catch (err) {
+    settleDeviceSend(deviceId, probe, 'inconclusive');
+    throw err;
+  }
+  let result: InvokeResultPayload;
+  try {
+    result = await client.invoke(deviceId, {
+      channel: DL_SUBSCRIBE_CHANNEL,
+      args: [{ topics, controllerName: mobileDeviceName() }],
+    });
+  } catch (err) {
+    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    throw err;
+  }
+  settleDeviceSend(deviceId, probe, 'responded');
   unwrapInvoke(result);
 }
 
@@ -716,11 +795,24 @@ async function sendUnsubscribe(
   deviceId: string,
   topics: readonly string[],
 ): Promise<void> {
-  await ensureOnlineForRequest(client);
-  const result = await client.invoke(deviceId, {
-    channel: DL_UNSUBSCRIBE_CHANNEL,
-    args: [{ topics }],
-  });
+  const probe = acquireDeviceSendSlot(deviceId);
+  try {
+    await ensureOnlineForRequest(client);
+  } catch (err) {
+    settleDeviceSend(deviceId, probe, 'inconclusive');
+    throw err;
+  }
+  let result: InvokeResultPayload;
+  try {
+    result = await client.invoke(deviceId, {
+      channel: DL_UNSUBSCRIBE_CHANNEL,
+      args: [{ topics }],
+    });
+  } catch (err) {
+    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    throw err;
+  }
+  settleDeviceSend(deviceId, probe, 'responded');
   unwrapInvoke(result);
 }
 

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -463,10 +463,8 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     }));
     client.start();
 
-    // 熔断恢复回填:探测成功可能发生在任意业务请求上(不局限某个页面),设备从
-    // unresponsive 集合移除时补一次 rehydrate——它 open 期间被跳过的订阅 / 快照
-    // 不该等到下一次重连或回前台才回来。只在「有设备恢复」时触发,open 方向不动。
-    // 双向触发(review P1):
+    // 熔断状态变化触发 rehydrate:unresponsive 集合的新增与移除都各触发一次
+    // (review P1 + 注释勘误):
     // - 设备恢复(移除):补一次 rehydrate,把 open 期间被跳过的订阅/快照拉回来;
     // - 设备进入 open(新增):也要触发一次——熔断可能由普通页面请求凑满超时打开,
     //   此刻若没有已在跑的 rehydrate 退避循环,代表性探测根本无人发起,

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -267,29 +267,44 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
             // subscribe 甚至根本不会发包。探测窗口到点就发一条真正穿过
             // runInvoke → local-db 的最小读(见 DEVICE_RESPONSIVENESS_PROBE_CHANNEL),
             // 由它的回包决定熔断开合;这也是无业务流量时的主动恢复通道。
-            const openDevices = grantedPlans.filter(
-              (plan) => unresponsiveDevicesStore.has(plan.deviceId),
-            );
+            // 探测候选取 registry 计划与 unresponsive 集合的并集(review P1):
+            // 仅有直接 invoke、从未登记 openLink/subscribe 的设备(如只停留在
+            // 首页的设备行)不在 registry 里,熔断 open 后若不纳入,它既收不到
+            // 探测也不占未完成信号,会在没有业务流量时永久停留在未响应态。
+            const openDeviceIds = new Set<string>();
+            for (const plan of grantedPlans) {
+              if (unresponsiveDevicesStore.has(plan.deviceId)) openDeviceIds.add(plan.deviceId);
+            }
+            for (const deviceId of unresponsiveDevicesStore.getSnapshot()) {
+              if (!revokedDevicesStore.has(deviceId)) openDeviceIds.add(deviceId);
+            }
             const plans = grantedPlans.filter(
               (plan) => !unresponsiveDevicesStore.has(plan.deviceId),
             );
-            for (const plan of openDevices) {
-              if (!isDeviceProbeDue(plan.deviceId)) continue;
-              await probeUnresponsiveDevice(client, plan.deviceId);
-            }
+            // 探测与健康设备的 rehydrate 并发跑(review P1):探测一台死设备最长
+            // 要等 openLink + DB 读两次超时(~30s),串行在前会把其它健康桌面的
+            // 订阅恢复 / 快照回填拖住整轮;多台 open 设备之间仍串行,避免探测
+            // 本身成为并发突发。
+            const probeRun = (async () => {
+              for (const deviceId of openDeviceIds) {
+                if (!isDeviceProbeDue(deviceId)) continue;
+                await probeUnresponsiveDevice(client, deviceId);
+              }
+            })();
             const result = await rehydrateDeviceLinkTopics(plans, {
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
               rebuildSessionSnapshot: (deviceId, sessionId) => rebuildSessionSnapshot(client, deviceId, sessionId),
             });
+            await probeRun;
             // 探测后仍 open 的设备持续计入"未完成"信号(review P1:不能在探测
             // 真正跑完并成功前撤掉重试安排),退避重试循环(2s→30s)继续走:
             // 窗口未到的轮次只做本地检查,零管道流量。探测成功关熔断会触发
             // 下方 effect 的 store 订阅,补一轮全量 rehydrate 把该设备的订阅 /
             // 快照拉回来。
-            const stillOpenDevices = openDevices.filter(
-              (plan) => unresponsiveDevicesStore.has(plan.deviceId),
+            const stillOpenDevices = [...openDeviceIds].filter(
+              (deviceId) => unresponsiveDevicesStore.has(deviceId),
             ).length;
             lastTransientFailures = result.transientFailures + stillOpenDevices;
           } while (state.rerun && client.getStatus() === 'online');

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -42,6 +42,7 @@ import { clearAllDeviceModelMeta, evictDeviceModelMeta } from '@/device-link/dev
 import { dispatchFileBrowserWatchEvent } from '@/device-link/fileBrowserWatch';
 import { resolveMobileInvokeTimeoutMs } from '@/device-link/invokeTimeouts';
 import { rehydrateDeviceLinkTopics } from '@/device-link/rehydrate';
+import { invalidateTransientScheduleIndexFailures } from '@/session/scheduleIndex';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 import { createRnWebSocket } from '@/device-link/rnWebSocket';
 import type { MobileGoalStatusPayload } from '@cindy/maker-shared/device-link-contract';
@@ -59,6 +60,7 @@ import {
   buildDeviceResponsivenessProbeArgs,
   classifyDeviceSendFailure,
   classifyDeviceSendSuccess,
+  classifyLinkOpenFailure,
   DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
   isDeviceProbeDue,
   resetDeviceResponsivenessTracking,
@@ -248,6 +250,10 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       run = (async () => {
         let lastTransientFailures = 0;
         try {
+          // 链路已恢复(rehydrate 只在 online 时运行,重连必经):普通断线期间
+          // 产生的 schedule-index 瞬态负缓存立即失效,让本轮 reseed 拉到新数据
+          // 而不是吃 30s TTL 内的旧 rejected promise(review P1)。
+          invalidateTransientScheduleIndexFailures();
           do {
             state.rerun = false;
             if (client.getStatus() !== 'online') return;
@@ -787,7 +793,9 @@ async function sendOpenLink(client: DeviceLinkClient, deviceId: string): Promise
     return accepted;
   } catch (err) {
     // 超时仍计失败:link-open 都等不到回包说明被控端连链路层都没在应答。
-    settleDeviceSend(deviceId, slot, classifyDeviceSendFailure(err));
+    // 终态 relay 应答(REMOTE_DISABLED / DEVICE_OFFLINE / VERSION_MISMATCH)
+    // 关熔断,把 UI 让给对应的可操作错误态(review P1:否则设备被永远探测)。
+    settleDeviceSend(deviceId, slot, classifyLinkOpenFailure(err));
     throw err;
   }
 }

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -56,7 +56,9 @@ import { remoteSessionStore } from '@/session/remoteSessionStore';
 import { revokedDevicesStore } from '@/device-link/revokedDevicesStore';
 import {
   acquireDeviceSendSlot,
+  buildDeviceResponsivenessProbeArgs,
   classifyDeviceSendFailure,
+  DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
   isDeviceProbeDue,
   resetDeviceResponsivenessTracking,
   settleDeviceSend,
@@ -178,6 +180,27 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     markHeldRemoteTopicsSubscribed(remoteSubscribedTopicsRef.current, registryRef.current, deviceId, toSend);
   }, []);
 
+  // 熔断 open 设备的显式代表性探测:openLink 建链(成功按不定论,不关熔断),
+  // 再发一条真正穿过被控端 runInvoke → dispatchLocalInvoke → local-db 的最小读,
+  // 由 sendInvoke 内部的熔断收尾决定开合(真实回包 → 关;超时 → 加深退避)。
+  // 错误全吞:结果已在 send 层按熔断语义上报,这里不需要二次处理。
+  const probeUnresponsiveDevice = useCallback(
+    async (client: DeviceLinkClient, deviceId: string): Promise<void> => {
+      try {
+        await sendOpenLinkOnce(client, deviceId);
+        await sendInvokeWithAccessHandling(
+          client,
+          deviceId,
+          DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
+          buildDeviceResponsivenessProbeArgs(),
+        );
+      } catch {
+        // swallow — settle 已在 sendOpenLink / sendInvoke 内完成。
+      }
+    },
+    [sendOpenLinkOnce],
+  );
+
   const clearRehydrateRetry = useCallback((resetAttempt: boolean) => {
     const retry = rehydrateRetryRef.current;
     if (retry.timer) {
@@ -227,13 +250,6 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
           do {
             state.rerun = false;
             if (client.getStatus() !== 'online') return;
-            // 熔断 open 的设备:探测窗口未到时跳过本轮(每一步都会本地快速失败,
-            // 还会白白占用探测单飞席位);**窗口已到则重新纳入**——openLink 先行
-            // (成功按不定论、释放席位不关熔断),紧随的 subscribe(真实 invoke
-            // 通道)接棒成为 half-open 探测,这就是无业务流量时的主动探测通道
-            // (review P1:恢复不能只靠业务请求被动触发,否则用户挂机时设备
-            // 会无限期停留在未响应态)。恢复(探测成功关熔断)后由下方 effect 里
-            // 的 store 订阅补触发一次全量补齐回填。
             const allPlans = registryRef.current.snapshot();
             // 撤权设备直接出局(review P1):撤权是终态,openLink 只会等来
             // link-close(revoked) + 超时;若不过滤,撤权时清熔断状态触发的这轮
@@ -242,20 +258,39 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
             const grantedPlans = allPlans.filter(
               (plan) => !revokedDevicesStore.has(plan.deviceId),
             );
-            const plans = grantedPlans.filter(
-              (plan) =>
-                !unresponsiveDevicesStore.has(plan.deviceId) || isDeviceProbeDue(plan.deviceId),
+            // 熔断 open 的设备整体退出常规 rehydrate(每一步都会本地快速失败),
+            // 改走显式代表性探测(review P1 多轮收敛):不能依赖 openLink /
+            // subscribe 顺带探测——link-accept 与 subscribe 都在被控端 dispatch
+            // 里于 runInvoke 之前特判应答,IPC/DB 卡死时照常回包会误关熔断;
+            // 订阅已被 remoteSubscribedTopicsRef 记录或计划里没有 topic 时,
+            // subscribe 甚至根本不会发包。探测窗口到点就发一条真正穿过
+            // runInvoke → local-db 的最小读(见 DEVICE_RESPONSIVENESS_PROBE_CHANNEL),
+            // 由它的回包决定熔断开合;这也是无业务流量时的主动恢复通道。
+            const openDevices = grantedPlans.filter(
+              (plan) => unresponsiveDevicesStore.has(plan.deviceId),
             );
-            const skippedOpenDevices = grantedPlans.length - plans.length;
+            const plans = grantedPlans.filter(
+              (plan) => !unresponsiveDevicesStore.has(plan.deviceId),
+            );
+            for (const plan of openDevices) {
+              if (!isDeviceProbeDue(plan.deviceId)) continue;
+              await probeUnresponsiveDevice(client, plan.deviceId);
+            }
             const result = await rehydrateDeviceLinkTopics(plans, {
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
               rebuildSessionSnapshot: (deviceId, sessionId) => rebuildSessionSnapshot(client, deviceId, sessionId),
             });
-            // 被跳过的熔断设备计入"未完成"信号,让退避重试循环(2s→30s)继续走:
-            // 每轮只做本地窗口检查,零管道流量,窗口一到下一轮就把设备带上探测。
-            lastTransientFailures = result.transientFailures + skippedOpenDevices;
+            // 探测后仍 open 的设备持续计入"未完成"信号(review P1:不能在探测
+            // 真正跑完并成功前撤掉重试安排),退避重试循环(2s→30s)继续走:
+            // 窗口未到的轮次只做本地检查,零管道流量。探测成功关熔断会触发
+            // 下方 effect 的 store 订阅,补一轮全量 rehydrate 把该设备的订阅 /
+            // 快照拉回来。
+            const stillOpenDevices = openDevices.filter(
+              (plan) => unresponsiveDevicesStore.has(plan.deviceId),
+            ).length;
+            lastTransientFailures = result.transientFailures + stillOpenDevices;
           } while (state.rerun && client.getStatus() === 'online');
         } finally {
           if (state.inFlight === run) {
@@ -268,7 +303,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       state.inFlight = run;
       return run;
     },
-    [scheduleRehydrateRetry, sendOpenLinkOnce, sendTrackedSubscribe],
+    [probeUnresponsiveDevice, scheduleRehydrateRetry, sendOpenLinkOnce, sendTrackedSubscribe],
   );
 
   useEffect(() => {
@@ -418,9 +453,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     // 双向触发(review P1):
     // - 设备恢复(移除):补一次 rehydrate,把 open 期间被跳过的订阅/快照拉回来;
     // - 设备进入 open(新增):也要触发一次——熔断可能由普通页面请求凑满超时打开,
-    //   此刻若没有已在跑的 rehydrate 退避循环,probeDue 过滤逻辑根本无人执行,
-    //   主动探测永远不会启动。触发的这轮会因 skippedOpenDevices>0 进入 2s→30s
-    //   退避循环,成为探测心跳(每轮零管道流量,窗口到了自动带上探测)。
+    //   此刻若没有已在跑的 rehydrate 退避循环,代表性探测根本无人发起,
+    //   主动恢复永远不会启动。触发的这轮会因 stillOpenDevices>0 进入 2s→30s
+    //   退避循环,成为探测心跳(窗口未到的轮次零管道流量,到点自动发探测)。
     let lastUnresponsiveSnapshot = unresponsiveDevicesStore.getSnapshot();
     const offUnresponsive = unresponsiveDevicesStore.subscribe(() => {
       const next = unresponsiveDevicesStore.getSnapshot();

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -858,7 +858,11 @@ async function sendSubscribe(
     settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
     throw err;
   }
-  settleDeviceSend(deviceId, probe, 'responded');
+  // subscribe/unsubscribe 是控制帧,被控端 dispatch 在 runInvoke 之前特判应答
+  // (review P1):IPC/DB 卡死时照常回包,成功不能作为熔断恢复证据——探测窗口
+  // 到点时页面卸载恰好发的一条控制帧会抢占探测席位并误关熔断。与 openLink
+  // 同语义:成功按不定论,超时仍计失败(连控制帧都不应答 = 彻底无响应)。
+  settleDeviceSend(deviceId, probe, 'inconclusive');
   unwrapInvoke(result);
 }
 
@@ -884,7 +888,8 @@ async function sendUnsubscribe(
     settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
     throw err;
   }
-  settleDeviceSend(deviceId, probe, 'responded');
+  // 控制帧成功按不定论,不作熔断恢复证据(同 sendSubscribe,review P1)。
+  settleDeviceSend(deviceId, probe, 'inconclusive');
   unwrapInvoke(result);
 }
 

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -121,6 +121,9 @@ const REHYDRATE_RETRY_MAX_MS = 30_000;
  */
 const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'device-link:media:fetch': 30_000,
+  // searchCollect 在桌面端有 20s 的执行预算(SEARCH_COLLECT_TIMEOUT_MS),15s
+  // 默认会在合法慢搜索(大 workdir / SSH)完成前掐断;30s 同收紧前默认,零回归。
+  'file-browser:remote-op': 30_000,
 };
 
 /**
@@ -418,12 +421,20 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     // 熔断恢复回填:探测成功可能发生在任意业务请求上(不局限某个页面),设备从
     // unresponsive 集合移除时补一次 rehydrate——它 open 期间被跳过的订阅 / 快照
     // 不该等到下一次重连或回前台才回来。只在「有设备恢复」时触发,open 方向不动。
+    // 双向触发(review P1):
+    // - 设备恢复(移除):补一次 rehydrate,把 open 期间被跳过的订阅/快照拉回来;
+    // - 设备进入 open(新增):也要触发一次——熔断可能由普通页面请求凑满超时打开,
+    //   此刻若没有已在跑的 rehydrate 退避循环,probeDue 过滤逻辑根本无人执行,
+    //   主动探测永远不会启动。触发的这轮会因 skippedOpenDevices>0 进入 2s→30s
+    //   退避循环,成为探测心跳(每轮零管道流量,窗口到了自动带上探测)。
     let lastUnresponsiveSnapshot = unresponsiveDevicesStore.getSnapshot();
     const offUnresponsive = unresponsiveDevicesStore.subscribe(() => {
       const next = unresponsiveDevicesStore.getSnapshot();
-      const recovered = [...lastUnresponsiveSnapshot].some((deviceId) => !next.has(deviceId));
+      const changed =
+        next.size !== lastUnresponsiveSnapshot.size
+        || [...lastUnresponsiveSnapshot].some((deviceId) => !next.has(deviceId));
       lastUnresponsiveSnapshot = next;
-      if (recovered) void rehydrateWithClient(client);
+      if (changed) void rehydrateWithClient(client);
     });
 
     // 退后台的断连宽限状态:stopTimer 挂着表示还没真正 stop;backgroundAt 用于

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -750,11 +750,11 @@ function sendOpenLinkWithAccessHandling(
 
 async function sendOpenLink(client: DeviceLinkClient, deviceId: string): Promise<LinkAcceptPayload> {
   // 熔断门禁放在连接等待之前:open 时快速失败,不消耗 1.5s 重连等待也不上管道。
-  const probe = acquireDeviceSendSlot(deviceId);
+  const slot = acquireDeviceSendSlot(deviceId);
   try {
     await ensureOnlineForRequest(client);
   } catch (err) {
-    settleDeviceSend(deviceId, probe, 'inconclusive');
+    settleDeviceSend(deviceId, slot, 'inconclusive');
     throw err;
   }
   try {
@@ -769,11 +769,11 @@ async function sendOpenLink(client: DeviceLinkClient, deviceId: string): Promise
     // 超时后再 open,形成周期性风暴。这里按不定论处理:不关熔断也不计失败;
     // openLink 若是探测,单飞席位随之释放、退避窗口不动,紧随其后的 subscribe
     // (真实 invoke 通道)会立即接棒成为新探测,由它的回包决定开合。
-    settleDeviceSend(deviceId, probe, 'inconclusive');
+    settleDeviceSend(deviceId, slot, 'inconclusive');
     return accepted;
   } catch (err) {
     // 超时仍计失败:link-open 都等不到回包说明被控端连链路层都没在应答。
-    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    settleDeviceSend(deviceId, slot, classifyDeviceSendFailure(err));
     throw err;
   }
 }
@@ -796,7 +796,7 @@ async function sendInvoke<T>(
   opts?: { preSend?: () => void },
 ): Promise<T> {
   // 熔断门禁放在连接等待之前:open 时快速失败,不消耗 1.5s 重连等待也不上管道。
-  const probe = acquireDeviceSendSlot(deviceId);
+  const slot = acquireDeviceSendSlot(deviceId);
   try {
     await ensureOnlineForRequest(client);
     // 连接就绪后、真正发送前的最后检查点:重连等待期间调用方状态可能已失效
@@ -804,7 +804,7 @@ async function sendInvoke<T>(
     opts?.preSend?.();
   } catch (err) {
     // 未真正发送(等待连接失败 / preSend 中止):对设备响应性不定论。
-    settleDeviceSend(deviceId, probe, 'inconclusive');
+    settleDeviceSend(deviceId, slot, 'inconclusive');
     throw err;
   }
   let result: InvokeResultPayload;
@@ -819,11 +819,11 @@ async function sendInvoke<T>(
       resolveMobileInvokeTimeoutMs(channel),
     );
   } catch (err) {
-    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    settleDeviceSend(deviceId, slot, classifyDeviceSendFailure(err));
     throw err;
   }
   // 收到 invoke-result 帧即为目标设备真实回包(即使 ok:false 的业务错误)→ 重置熔断。
-  settleDeviceSend(deviceId, probe, 'responded');
+  settleDeviceSend(deviceId, slot, 'responded');
   return unwrapInvoke<T>(result);
 }
 
@@ -841,11 +841,11 @@ async function sendSubscribe(
   topics: readonly string[],
 ): Promise<void> {
   // subscribe 同样走隧道请求超时等待(默认 15s),一样计入并受熔断限制(见 sendInvoke 注释)。
-  const probe = acquireDeviceSendSlot(deviceId);
+  const slot = acquireDeviceSendSlot(deviceId);
   try {
     await ensureOnlineForRequest(client);
   } catch (err) {
-    settleDeviceSend(deviceId, probe, 'inconclusive');
+    settleDeviceSend(deviceId, slot, 'inconclusive');
     throw err;
   }
   let result: InvokeResultPayload;
@@ -855,14 +855,14 @@ async function sendSubscribe(
       args: [{ topics, controllerName: mobileDeviceName() }],
     });
   } catch (err) {
-    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    settleDeviceSend(deviceId, slot, classifyDeviceSendFailure(err));
     throw err;
   }
   // subscribe/unsubscribe 是控制帧,被控端 dispatch 在 runInvoke 之前特判应答
   // (review P1):IPC/DB 卡死时照常回包,成功不能作为熔断恢复证据——探测窗口
   // 到点时页面卸载恰好发的一条控制帧会抢占探测席位并误关熔断。与 openLink
   // 同语义:成功按不定论,超时仍计失败(连控制帧都不应答 = 彻底无响应)。
-  settleDeviceSend(deviceId, probe, 'inconclusive');
+  settleDeviceSend(deviceId, slot, 'inconclusive');
   unwrapInvoke(result);
 }
 
@@ -871,11 +871,11 @@ async function sendUnsubscribe(
   deviceId: string,
   topics: readonly string[],
 ): Promise<void> {
-  const probe = acquireDeviceSendSlot(deviceId);
+  const slot = acquireDeviceSendSlot(deviceId);
   try {
     await ensureOnlineForRequest(client);
   } catch (err) {
-    settleDeviceSend(deviceId, probe, 'inconclusive');
+    settleDeviceSend(deviceId, slot, 'inconclusive');
     throw err;
   }
   let result: InvokeResultPayload;
@@ -885,11 +885,11 @@ async function sendUnsubscribe(
       args: [{ topics }],
     });
   } catch (err) {
-    settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
+    settleDeviceSend(deviceId, slot, classifyDeviceSendFailure(err));
     throw err;
   }
   // 控制帧成功按不定论,不作熔断恢复证据(同 sendSubscribe,review P1)。
-  settleDeviceSend(deviceId, probe, 'inconclusive');
+  settleDeviceSend(deviceId, slot, 'inconclusive');
   unwrapInvoke(result);
 }
 

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -845,9 +845,10 @@ async function sendInvoke<T>(
     throw err;
   }
   // 收到 invoke-result 帧即为目标设备真实回包(即使 ok:false 的业务错误)。但
-  // dispatch 特判通道(media/voice,见 BREAKER_NEUTRAL_INVOKE_CHANNELS)的成功
-  // 不走 IPC/DB 路径,不作恢复证据——按通道分类收尾(review P1)。
-  settleDeviceSend(deviceId, slot, classifyDeviceSendSuccess(channel));
+  // dispatch 特判通道(media/voice)的成功不走 IPC/DB 路径,且持有探测席位时
+  // 只有指定探测通道能关熔断(纯内存 IPC handler 的回包不算)——按通道 +
+  // 席位分类收尾(review P1 多轮收敛,见 classifyDeviceSendSuccess)。
+  settleDeviceSend(deviceId, slot, classifyDeviceSendSuccess(channel, slot.decision === 'probe'));
   return unwrapInvoke<T>(result);
 }
 

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -228,17 +228,25 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
             state.rerun = false;
             if (client.getStatus() !== 'online') return;
             // 熔断 open 的设备:探测窗口未到时跳过本轮(每一步都会本地快速失败,
-            // 还会白白占用探测单飞席位);**窗口已到则重新纳入**——它的首个请求
-            // (openLink)会自然成为 half-open 探测,这就是无业务流量时的主动探测
-            // 通道(review P1:恢复不能只靠业务请求被动触发,否则用户挂机时设备
+            // 还会白白占用探测单飞席位);**窗口已到则重新纳入**——openLink 先行
+            // (成功按不定论、释放席位不关熔断),紧随的 subscribe(真实 invoke
+            // 通道)接棒成为 half-open 探测,这就是无业务流量时的主动探测通道
+            // (review P1:恢复不能只靠业务请求被动触发,否则用户挂机时设备
             // 会无限期停留在未响应态)。恢复(探测成功关熔断)后由下方 effect 里
             // 的 store 订阅补触发一次全量补齐回填。
             const allPlans = registryRef.current.snapshot();
-            const plans = allPlans.filter(
+            // 撤权设备直接出局(review P1):撤权是终态,openLink 只会等来
+            // link-close(revoked) + 超时;若不过滤,撤权时清熔断状态触发的这轮
+            // rehydrate 会对它重新 openLink,且其超时已按撤权降级为不定论,
+            // 熔断兜不住,退避循环会为它无限空转。也不计入 transientFailures。
+            const grantedPlans = allPlans.filter(
+              (plan) => !revokedDevicesStore.has(plan.deviceId),
+            );
+            const plans = grantedPlans.filter(
               (plan) =>
                 !unresponsiveDevicesStore.has(plan.deviceId) || isDeviceProbeDue(plan.deviceId),
             );
-            const skippedOpenDevices = allPlans.length - plans.length;
+            const skippedOpenDevices = grantedPlans.length - plans.length;
             const result = await rehydrateDeviceLinkTopics(plans, {
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
@@ -720,10 +728,16 @@ async function sendOpenLink(client: DeviceLinkClient, deviceId: string): Promise
       protocolVersion: PROTOCOL_VERSION,
       appVersion: Constants.expoConfig?.version ?? '0.0.0',
     });
-    // link-accept 是目标设备的真实回包 → 重置熔断计数。
-    settleDeviceSend(deviceId, probe, 'responded');
+    // link-accept 只证明链路层活着,不证明 invoke 路径健康(review P1):事故形态
+    // 正是 link-open 在被控端 IPC/DB 路径之外应答正常、invoke 全部挂死——若凭
+    // link-accept 关熔断,恢复流程会立刻放进订阅 + 快照 + 业务 invoke 突发,3 次
+    // 超时后再 open,形成周期性风暴。这里按不定论处理:不关熔断也不计失败;
+    // openLink 若是探测,单飞席位随之释放、退避窗口不动,紧随其后的 subscribe
+    // (真实 invoke 通道)会立即接棒成为新探测,由它的回包决定开合。
+    settleDeviceSend(deviceId, probe, 'inconclusive');
     return accepted;
   } catch (err) {
+    // 超时仍计失败:link-open 都等不到回包说明被控端连链路层都没在应答。
     settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
     throw err;
   }

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -58,6 +58,7 @@ import {
   acquireDeviceSendSlot,
   buildDeviceResponsivenessProbeArgs,
   classifyDeviceSendFailure,
+  classifyDeviceSendSuccess,
   DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
   isDeviceProbeDue,
   resetDeviceResponsivenessTracking,
@@ -822,8 +823,10 @@ async function sendInvoke<T>(
     settleDeviceSend(deviceId, slot, classifyDeviceSendFailure(err));
     throw err;
   }
-  // 收到 invoke-result 帧即为目标设备真实回包(即使 ok:false 的业务错误)→ 重置熔断。
-  settleDeviceSend(deviceId, slot, 'responded');
+  // 收到 invoke-result 帧即为目标设备真实回包(即使 ok:false 的业务错误)。但
+  // dispatch 特判通道(media/voice,见 BREAKER_NEUTRAL_INVOKE_CHANNELS)的成功
+  // 不走 IPC/DB 路径,不作恢复证据——按通道分类收尾(review P1)。
+  settleDeviceSend(deviceId, slot, classifyDeviceSendSuccess(channel));
   return unwrapInvoke<T>(result);
 }
 

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -57,6 +57,7 @@ import { revokedDevicesStore } from '@/device-link/revokedDevicesStore';
 import {
   acquireDeviceSendSlot,
   classifyDeviceSendFailure,
+  isDeviceProbeDue,
   resetDeviceResponsivenessTracking,
   settleDeviceSend,
   unresponsiveDevicesStore,
@@ -110,6 +111,17 @@ interface RehydrateRetryState {
 /** 补齐仍有瞬时失败时的退避重跑曲线:2s → 4s → … → 30s 封顶。 */
 const REHYDRATE_RETRY_BASE_MS = 2_000;
 const REHYDRATE_RETRY_MAX_MS = 30_000;
+
+/**
+ * mobile 侧的 invoke 超时补充表(优先于协议契约表 INVOKE_TIMEOUT_OVERRIDES_MS)。
+ * media:fetch 是「桌面拉文件再传 OSS」的长操作(最大 2GB,15-30s 属正常),
+ * 收紧后的默认 15s 会掐断此前能成功的传输(review P1);30s 与收紧前的全局
+ * 默认一致,保持该通道行为零回归。新增合法慢通道时优先登记进协议契约表
+ * (桌面控制端共用),仅 mobile 特有的差异才放这里。
+ */
+const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
+  'device-link:media:fetch': 30_000,
+};
 
 /**
  * 退后台断开连接前的宽限:几秒内切回前台的快速 App 切换不触发整套
@@ -226,19 +238,27 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
           do {
             state.rerun = false;
             if (client.getStatus() !== 'online') return;
-            // 熔断 open 的设备跳过补齐:它的每一步都会快速失败(DEVICE_UNRESPONSIVE,
-            // permanent 不计瞬时重试),还会白白占用探测单飞窗口。恢复(探测成功关熔断)
-            // 后由下方 effect 里的 store 订阅补触发一次全量补齐回填。
-            const plans = registryRef.current
-              .snapshot()
-              .filter((plan) => !unresponsiveDevicesStore.has(plan.deviceId));
+            // 熔断 open 的设备:探测窗口未到时跳过本轮(每一步都会本地快速失败,
+            // 还会白白占用探测单飞席位);**窗口已到则重新纳入**——它的首个请求
+            // (openLink)会自然成为 half-open 探测,这就是无业务流量时的主动探测
+            // 通道(review P1:恢复不能只靠业务请求被动触发,否则用户挂机时设备
+            // 会无限期停留在未响应态)。恢复(探测成功关熔断)后由下方 effect 里
+            // 的 store 订阅补触发一次全量补齐回填。
+            const allPlans = registryRef.current.snapshot();
+            const plans = allPlans.filter(
+              (plan) =>
+                !unresponsiveDevicesStore.has(plan.deviceId) || isDeviceProbeDue(plan.deviceId),
+            );
+            const skippedOpenDevices = allPlans.length - plans.length;
             const result = await rehydrateDeviceLinkTopics(plans, {
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
               rebuildSessionSnapshot: (deviceId, sessionId) => rebuildSessionSnapshot(client, deviceId, sessionId),
             });
-            lastTransientFailures = result.transientFailures;
+            // 被跳过的熔断设备计入"未完成"信号,让退避重试循环(2s→30s)继续走:
+            // 每轮只做本地窗口检查,零管道流量,窗口一到下一轮就把设备带上探测。
+            lastTransientFailures = result.transientFailures + skippedOpenDevices;
           } while (state.rerun && client.getStatus() === 'online');
         } finally {
           if (state.inFlight === run) {
@@ -745,7 +765,11 @@ async function sendInvoke<T>(
   try {
     // 长执行通道(desktop-cmd:run / worktree:create 等)按协议契约表放宽超时,
     // 与桌面控制端用法对齐,避免 mobile 收紧的默认 15s 误伤合法慢操作。
-    result = await client.invoke(deviceId, { channel, args }, INVOKE_TIMEOUT_OVERRIDES_MS[channel]);
+    result = await client.invoke(
+      deviceId,
+      { channel, args },
+      MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS[channel] ?? INVOKE_TIMEOUT_OVERRIDES_MS[channel],
+    );
   } catch (err) {
     settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));
     throw err;

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -6,7 +6,6 @@ import {
   DL_SUBSCRIBE_CHANNEL,
   DL_UNSUBSCRIBE_CHANNEL,
   FILE_BROWSER_EVENT_CHANNEL,
-  INVOKE_TIMEOUT_OVERRIDES_MS,
   PROTOCOL_VERSION,
   type DeviceLinkConnectionIssue,
   type DeviceLinkStatus,
@@ -41,6 +40,7 @@ import { normalizeMobileAgentCapabilities } from '@/session/agentCapabilities';
 import { evictComposerPaletteCacheForDevice, resetComposerPaletteCache } from '@/session/composerPaletteCache';
 import { clearAllDeviceModelMeta, evictDeviceModelMeta } from '@/device-link/deviceModelMetaCache';
 import { dispatchFileBrowserWatchEvent } from '@/device-link/fileBrowserWatch';
+import { resolveMobileInvokeTimeoutMs } from '@/device-link/invokeTimeouts';
 import { rehydrateDeviceLinkTopics } from '@/device-link/rehydrate';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 import { createRnWebSocket } from '@/device-link/rnWebSocket';
@@ -111,20 +111,6 @@ interface RehydrateRetryState {
 /** 补齐仍有瞬时失败时的退避重跑曲线:2s → 4s → … → 30s 封顶。 */
 const REHYDRATE_RETRY_BASE_MS = 2_000;
 const REHYDRATE_RETRY_MAX_MS = 30_000;
-
-/**
- * mobile 侧的 invoke 超时补充表(优先于协议契约表 INVOKE_TIMEOUT_OVERRIDES_MS)。
- * media:fetch 是「桌面拉文件再传 OSS」的长操作(最大 2GB,15-30s 属正常),
- * 收紧后的默认 15s 会掐断此前能成功的传输(review P1);30s 与收紧前的全局
- * 默认一致,保持该通道行为零回归。新增合法慢通道时优先登记进协议契约表
- * (桌面控制端共用),仅 mobile 特有的差异才放这里。
- */
-const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
-  'device-link:media:fetch': 30_000,
-  // searchCollect 在桌面端有 20s 的执行预算(SEARCH_COLLECT_TIMEOUT_MS),15s
-  // 默认会在合法慢搜索(大 workdir / SSH)完成前掐断;30s 同收紧前默认,零回归。
-  'file-browser:remote-op': 30_000,
-};
 
 /**
  * 退后台断开连接前的宽限:几秒内切回前台的快速 App 切换不触发整套
@@ -335,7 +321,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         handshakeTimeoutMs: 12_000,
         // 请求超时收紧到 15s(默认 30s):被控端卡死时 30s 才失败让用户干等半分钟,
         // 也把熔断器凑齐「连续超时」信号的时间拖长一倍。长执行通道(desktop-cmd:run /
-        // worktree:create 等)在 sendInvoke 按 INVOKE_TIMEOUT_OVERRIDES_MS 单独放宽,
+        // worktree:create / schedule 等)在 sendInvoke 按 invokeTimeouts 解析规则单独放宽,
         // 与桌面控制端同一张协议契约表,不受此默认值影响。
         requestTimeoutMs: 15_000,
       },
@@ -779,7 +765,9 @@ async function sendInvoke<T>(
     result = await client.invoke(
       deviceId,
       { channel, args },
-      MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS[channel] ?? INVOKE_TIMEOUT_OVERRIDES_MS[channel],
+      // 长通道(media / 文件搜索 / schedule 就绪窗口等)按 invokeTimeouts 解析
+      // 规则保留更长窗口,避免 mobile 收紧的默认 15s 误伤合法慢操作。
+      resolveMobileInvokeTimeoutMs(channel),
     );
   } catch (err) {
     settleDeviceSend(deviceId, probe, classifyDeviceSendFailure(err));

--- a/apps/mobile/src/device-link/accessRevoked.ts
+++ b/apps/mobile/src/device-link/accessRevoked.ts
@@ -5,12 +5,16 @@ import { evictDeviceModelMeta } from '@/device-link/deviceModelMetaCache';
 import { evictAgentCapabilitiesForDevice } from '@/session/agentCapabilitiesCache';
 import { evictComposerPaletteCacheForDevice } from '@/session/composerPaletteCache';
 import { revokedDevicesStore } from '@/device-link/revokedDevicesStore';
+import { clearDeviceResponsivenessTrackingFor } from '@/device-link/unresponsiveDevicesStore';
 import {
   isAccessRevokedRemoteError,
 } from '@cindy/maker-shared/device-link-contract';
 
 export function markDeviceAccessRevoked(deviceId: string): void {
   revokedDevicesStore.markRevoked(deviceId);
+  // 撤权优先于熔断(review P1):清掉该设备的 unresponsive 状态,撤权走自己的
+  // 专属 UI;后续在途请求的超时也由 settleDeviceSend 按已撤权降级为不定论。
+  clearDeviceResponsivenessTrackingFor(deviceId);
   remoteSessionStore.removeDevice(deviceId);
   evictDeviceProviders(deviceId);
   evictDeviceModelMeta(deviceId);

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -57,6 +57,13 @@ export interface DeviceResponsivenessBreaker {
   /** 请求收尾上报。wasProbe 必须回传 acquire 的结果('probe' → true)。 */
   settle(deviceId: string, wasProbe: boolean, outcome: BreakerSettleOutcome): void;
   isOpen(deviceId: string): boolean;
+  /**
+   * 只读:open 且探测窗口已到、无在途探测 —— 即「现在发一个请求会成为探测」。
+   * 给 rehydrate 这类自动恢复路径做**主动探测**判定用:设备恢复但用户没有发起
+   * 任何业务请求时,half-open 不能只靠业务流量被动触发,否则设备会无限期停留
+   * 在未响应态(review P1)。不占用探测席位、不改任何状态。
+   */
+  probeDue(deviceId: string): boolean;
   /** 清空全部状态(登出 / 切号);open 中的设备会触发 onOpenChanged(false)。 */
   resetAll(): void;
 }
@@ -131,6 +138,11 @@ export function createDeviceResponsivenessBreaker(
     acquire,
     settle,
     isOpen: (deviceId) => states.get(deviceId)?.open === true,
+    probeDue: (deviceId) => {
+      const state = states.get(deviceId);
+      if (!state?.open || state.probeInFlight) return false;
+      return now() - state.openedAt >= state.probeBackoffMs;
+    },
     resetAll: () => {
       const openIds = [...states.entries()].filter(([, s]) => s.open).map(([id]) => id);
       states.clear();

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -111,6 +111,10 @@ export function createDeviceResponsivenessBreaker(
   };
 
   const acquire = (deviceId: string): BreakerSendSlot => {
+    // 首次发放即登记(review):仅 acquire 过、还没有任何 settle/state 的设备也
+    // 必须被 resetAll 的全量翻篇覆盖,否则登出前的在途请求会在切号后按当前代
+    // 被采信,把旧账号的超时累进新账号的计数。
+    if (!generations.has(deviceId)) generations.set(deviceId, 0);
     const generation = generationOf(deviceId);
     const state = states.get(deviceId);
     if (!state?.open) return { decision: 'allow', generation };

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -22,6 +22,18 @@
 
 export type BreakerAcquireDecision = 'allow' | 'probe' | 'reject';
 
+/**
+ * acquire 发放的席位票据,settle 时原样带回。generation 是发放时该设备的代数:
+ * responded / clear / resetAll 都会递增代数,settle 时代数不匹配 = 这是恢复
+ * (或清除)之前派出的旧请求,其结果一律不采信(review P1:熔断 open 前派出的
+ * 30/40s 长超时请求,会在探测成功关熔断之后才陆续超时,若照常计数,3 条陈旧
+ * 超时会立刻把刚恢复的熔断重新打开)。
+ */
+export interface BreakerSendSlot {
+  decision: BreakerAcquireDecision;
+  generation: number;
+}
+
 export type BreakerSettleOutcome =
   /** 收到目标设备真实回包(含业务错误应答)。 */
   | 'responded'
@@ -50,12 +62,12 @@ export interface DeviceResponsivenessBreakerOptions {
 export interface DeviceResponsivenessBreaker {
   /**
    * 发送前门禁:closed → 'allow';open 且探测窗口已到、无在途探测 → 'probe'
-   * (调用方必须以同一 wasProbe 调 settle 释放单飞);其余 → 'reject'(调用方
-   * 应快速失败,不上管道)。
+   * (调用方必须把返回的票据原样带给 settle 以释放单飞);其余 → 'reject'
+   * (调用方应快速失败,不上管道)。
    */
-  acquire(deviceId: string): BreakerAcquireDecision;
-  /** 请求收尾上报。wasProbe 必须回传 acquire 的结果('probe' → true)。 */
-  settle(deviceId: string, wasProbe: boolean, outcome: BreakerSettleOutcome): void;
+  acquire(deviceId: string): BreakerSendSlot;
+  /** 请求收尾上报。slot 必须是 acquire 返回的票据;代数不匹配的旧请求被忽略。 */
+  settle(deviceId: string, slot: BreakerSendSlot, outcome: BreakerSettleOutcome): void;
   isOpen(deviceId: string): boolean;
   /**
    * 清除单个设备的全部熔断状态(撤权等「该设备的响应性已无意义」的场景);
@@ -90,22 +102,37 @@ export function createDeviceResponsivenessBreaker(
   const probeBackoffMaxMs = options.probeBackoffMaxMs ?? BREAKER_PROBE_BACKOFF_MAX_MS;
   const now = options.now ?? Date.now;
   const states = new Map<string, DeviceBreakerState>();
-
-  const acquire = (deviceId: string): BreakerAcquireDecision => {
-    const state = states.get(deviceId);
-    if (!state?.open) return 'allow';
-    if (state.probeInFlight) return 'reject';
-    if (now() - state.openedAt < state.probeBackoffMs) return 'reject';
-    state.probeInFlight = true;
-    return 'probe';
+  // 每设备代数:responded / clear / resetAll 递增。settle 只采信「派发时代数
+  // 仍是当前代」的结果——恢复前派出的长超时请求晚到的超时不再污染新一代计数。
+  const generations = new Map<string, number>();
+  const generationOf = (deviceId: string): number => generations.get(deviceId) ?? 0;
+  const bumpGeneration = (deviceId: string): void => {
+    generations.set(deviceId, generationOf(deviceId) + 1);
   };
 
-  const settle = (deviceId: string, wasProbe: boolean, outcome: BreakerSettleOutcome): void => {
+  const acquire = (deviceId: string): BreakerSendSlot => {
+    const generation = generationOf(deviceId);
+    const state = states.get(deviceId);
+    if (!state?.open) return { decision: 'allow', generation };
+    if (state.probeInFlight) return { decision: 'reject', generation };
+    if (now() - state.openedAt < state.probeBackoffMs) return { decision: 'reject', generation };
+    state.probeInFlight = true;
+    return { decision: 'probe', generation };
+  };
+
+  const settle = (deviceId: string, slot: BreakerSendSlot, outcome: BreakerSettleOutcome): void => {
+    // 旧代请求(恢复 / 清除之前派出):结果一律不采信。探测席位也无需释放——
+    // 代数递增的同时旧 state 必然已被删除,新一代 state 的 probeInFlight 从
+    // false 起步。
+    if (slot.generation !== generationOf(deviceId)) return;
+    const wasProbe = slot.decision === 'probe';
     const state = states.get(deviceId);
     // 无论结果如何,探测单飞先释放:inconclusive 的探测(如探测期间掉线)不该
     // 永久占住唯一探测席位;窗口基准未动,下一次 acquire 会立即放行新探测。
     if (state && wasProbe) state.probeInFlight = false;
     if (outcome === 'responded') {
+      // 真实回包即代数翻篇:此后到达的、更早派出的请求结果全部失效。
+      bumpGeneration(deviceId);
       if (!state) return;
       const wasOpen = state.open;
       states.delete(deviceId);
@@ -144,6 +171,8 @@ export function createDeviceResponsivenessBreaker(
     settle,
     isOpen: (deviceId) => states.get(deviceId)?.open === true,
     clear: (deviceId) => {
+      // 清除同样翻篇:撤权等场景下,在途请求的任何结果都不该再影响该设备。
+      bumpGeneration(deviceId);
       const state = states.get(deviceId);
       if (!state) return;
       states.delete(deviceId);
@@ -155,6 +184,10 @@ export function createDeviceResponsivenessBreaker(
       return now() - state.openedAt >= state.probeBackoffMs;
     },
     resetAll: () => {
+      // 全量翻篇(登出 / 切号):所有已知设备代数递增,在途结果全部作废。
+      for (const deviceId of new Set([...states.keys(), ...generations.keys()])) {
+        bumpGeneration(deviceId);
+      }
       const openIds = [...states.entries()].filter(([, s]) => s.open).map(([id]) => id);
       states.clear();
       for (const deviceId of openIds) options.onOpenChanged?.(deviceId, false);

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -1,0 +1,140 @@
+/**
+ * deviceResponsivenessBreaker.ts — per-device「目标设备无响应」熔断器(纯逻辑,node 可单测)。
+ * ---------------------------------------------------------------------------
+ * 事故链背景(2026-07 生产):桌面端进程活着(relay 心跳 / presence 全正常)但内部
+ * 卡死(DB gate 失败),invoke 永不回包。手机端每个请求都等满超时,重试链 + 多触发源
+ * 重放把请求堆成风暴,JS 线程停摆(实测最长 114s),期间连超时 timer 都被冻结。
+ * 本熔断器把「对同一台无响应设备的持续请求」收敛为周期性单飞探测:
+ *
+ *   - 失败信号:**仅** INVOKE_TIMEOUT(等满超时无回包)计入连续失败;
+ *   - 任何真实回包(成功,或 IPC_ERROR / CHANNEL_NOT_ALLOWED / REMOTE_DISABLED /
+ *     ACCESS_REVOKED 等目标设备正常应答的错误)都重置计数并关熔断;
+ *   - NOT_CONNECTED / relay 层错误 / 发送前本地中止是本机链路问题,不定论
+ *     (inconclusive):既不计失败,也不当作设备健康的证据;
+ *   - 连续 failureThreshold 次超时 → open:该设备的新请求快速失败
+ *     (DEVICE_UNRESPONSIVE,permanent 不重试);
+ *   - half-open:open 后按退避窗口(10s 起 ×2,封顶 120s)放行**单个**探测请求
+ *     (单飞),真实回包即 close,再超时回 open 并加深退避。
+ *
+ * 所有时间判定用 now()(默认 Date.now)差值,不依赖 setTimeout——JS 停摆时计时器
+ * 不可信是本次事故的实证(30s 超时 timer 被冻结,超时机制整体失效)。
+ */
+
+export type BreakerAcquireDecision = 'allow' | 'probe' | 'reject';
+
+export type BreakerSettleOutcome =
+  /** 收到目标设备真实回包(含业务错误应答)。 */
+  | 'responded'
+  /** 等满超时无回包(INVOKE_TIMEOUT)。 */
+  | 'timeout'
+  /** 本机链路 / relay 层失败或发送前中止:对设备响应性不定论。 */
+  | 'inconclusive';
+
+export const BREAKER_FAILURE_THRESHOLD = 3;
+export const BREAKER_PROBE_BACKOFF_BASE_MS = 10_000;
+export const BREAKER_PROBE_BACKOFF_MAX_MS = 120_000;
+
+export interface DeviceResponsivenessBreakerOptions {
+  /** 连续超时多少次进入 open;默认 3。 */
+  failureThreshold?: number;
+  /** open 后首个探测窗口;默认 10s。 */
+  probeBackoffBaseMs?: number;
+  /** 探测退避封顶;默认 120s。 */
+  probeBackoffMaxMs?: number;
+  /** 时钟注入,测试用;默认 Date.now。 */
+  now?: () => number;
+  /** open 状态翻转时回调(接 UI store);同状态不重复触发。 */
+  onOpenChanged?: (deviceId: string, open: boolean) => void;
+}
+
+export interface DeviceResponsivenessBreaker {
+  /**
+   * 发送前门禁:closed → 'allow';open 且探测窗口已到、无在途探测 → 'probe'
+   * (调用方必须以同一 wasProbe 调 settle 释放单飞);其余 → 'reject'(调用方
+   * 应快速失败,不上管道)。
+   */
+  acquire(deviceId: string): BreakerAcquireDecision;
+  /** 请求收尾上报。wasProbe 必须回传 acquire 的结果('probe' → true)。 */
+  settle(deviceId: string, wasProbe: boolean, outcome: BreakerSettleOutcome): void;
+  isOpen(deviceId: string): boolean;
+  /** 清空全部状态(登出 / 切号);open 中的设备会触发 onOpenChanged(false)。 */
+  resetAll(): void;
+}
+
+interface DeviceBreakerState {
+  consecutiveTimeouts: number;
+  open: boolean;
+  /** 最近一次 open / 探测失败的时刻(探测窗口基准)。 */
+  openedAt: number;
+  probeBackoffMs: number;
+  probeInFlight: boolean;
+}
+
+export function createDeviceResponsivenessBreaker(
+  options: DeviceResponsivenessBreakerOptions = {},
+): DeviceResponsivenessBreaker {
+  const failureThreshold = options.failureThreshold ?? BREAKER_FAILURE_THRESHOLD;
+  const probeBackoffBaseMs = options.probeBackoffBaseMs ?? BREAKER_PROBE_BACKOFF_BASE_MS;
+  const probeBackoffMaxMs = options.probeBackoffMaxMs ?? BREAKER_PROBE_BACKOFF_MAX_MS;
+  const now = options.now ?? Date.now;
+  const states = new Map<string, DeviceBreakerState>();
+
+  const acquire = (deviceId: string): BreakerAcquireDecision => {
+    const state = states.get(deviceId);
+    if (!state?.open) return 'allow';
+    if (state.probeInFlight) return 'reject';
+    if (now() - state.openedAt < state.probeBackoffMs) return 'reject';
+    state.probeInFlight = true;
+    return 'probe';
+  };
+
+  const settle = (deviceId: string, wasProbe: boolean, outcome: BreakerSettleOutcome): void => {
+    const state = states.get(deviceId);
+    // 无论结果如何,探测单飞先释放:inconclusive 的探测(如探测期间掉线)不该
+    // 永久占住唯一探测席位;窗口基准未动,下一次 acquire 会立即放行新探测。
+    if (state && wasProbe) state.probeInFlight = false;
+    if (outcome === 'responded') {
+      if (!state) return;
+      const wasOpen = state.open;
+      states.delete(deviceId);
+      if (wasOpen) options.onOpenChanged?.(deviceId, false);
+      return;
+    }
+    if (outcome !== 'timeout') return; // inconclusive:不计数、不重置。
+    if (state?.open) {
+      // open 期间的超时:只有探测请求推进退避。open 前已在途的旧请求可能在
+      // open 后陆续超时,若都加深退避,一波并发失败会把窗口直接推到封顶。
+      if (wasProbe) {
+        state.openedAt = now();
+        state.probeBackoffMs = Math.min(state.probeBackoffMs * 2, probeBackoffMaxMs);
+      }
+      return;
+    }
+    const next = state ?? {
+      consecutiveTimeouts: 0,
+      open: false,
+      openedAt: 0,
+      probeBackoffMs: probeBackoffBaseMs,
+      probeInFlight: false,
+    };
+    states.set(deviceId, next);
+    next.consecutiveTimeouts += 1;
+    if (next.consecutiveTimeouts >= failureThreshold) {
+      next.open = true;
+      next.openedAt = now();
+      next.probeBackoffMs = probeBackoffBaseMs;
+      options.onOpenChanged?.(deviceId, true);
+    }
+  };
+
+  return {
+    acquire,
+    settle,
+    isOpen: (deviceId) => states.get(deviceId)?.open === true,
+    resetAll: () => {
+      const openIds = [...states.entries()].filter(([, s]) => s.open).map(([id]) => id);
+      states.clear();
+      for (const deviceId of openIds) options.onOpenChanged?.(deviceId, false);
+    },
+  };
+}

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -58,6 +58,11 @@ export interface DeviceResponsivenessBreaker {
   settle(deviceId: string, wasProbe: boolean, outcome: BreakerSettleOutcome): void;
   isOpen(deviceId: string): boolean;
   /**
+   * 清除单个设备的全部熔断状态(撤权等「该设备的响应性已无意义」的场景);
+   * open 中则触发 onOpenChanged(false)。
+   */
+  clear(deviceId: string): void;
+  /**
    * 只读:open 且探测窗口已到、无在途探测 —— 即「现在发一个请求会成为探测」。
    * 给 rehydrate 这类自动恢复路径做**主动探测**判定用:设备恢复但用户没有发起
    * 任何业务请求时,half-open 不能只靠业务流量被动触发,否则设备会无限期停留
@@ -138,6 +143,12 @@ export function createDeviceResponsivenessBreaker(
     acquire,
     settle,
     isOpen: (deviceId) => states.get(deviceId)?.open === true,
+    clear: (deviceId) => {
+      const state = states.get(deviceId);
+      if (!state) return;
+      states.delete(deviceId);
+      if (state.open) options.onOpenChanged?.(deviceId, false);
+    },
     probeDue: (deviceId) => {
       const state = states.get(deviceId);
       if (!state?.open || state.probeInFlight) return false;

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -9,11 +9,15 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *  - media:fetch:桌面拉文件传 OSS,最大 2GB;
  *  - file-browser:remote-op:searchCollect 桌面执行预算 20s(SEARCH_COLLECT_TIMEOUT_MS);
  *  - maker:schedule:*:桌面 handler 会等 scheduler 就绪(READINESS_TIMEOUT_MS=30s,
- *    冷启动 / 登出登录窗口内就绪可能落在 15-30s),40s = 就绪上限 + 执行余量。
+ *    冷启动 / 登出登录窗口内就绪可能落在 15-30s),40s = 就绪上限 + 执行余量;
+ *  - voice:dictionary-learning:桌面 advisor 走 managed refiner,单次尝试空闲窗
+ *    12s(VOICE_INPUT_MANAGED_REFINER_IDLE_TIMEOUT_MS)且主模型卡住会换备选
+ *    profile 再试,合法执行可超 15s;误超时会让后台学习白白计入熔断失败。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'device-link:media:fetch': 30_000,
+  'device-link:voice:dictionary-learning': 30_000,
   'file-browser:remote-op': 30_000,
 };
 

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -21,7 +21,11 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *    仍会建出并广播新会话,用户重试会分叉出重复副本;
  *  - maker:rewind:commit:transcript/DB 读 + SDK/Codex 线程回滚 + Git 文件回退 +
  *    收尾 SQLite 事务,同样非幂等——误超时后对话与文件已被回退,重试会作用在
- *    已变更的历史上。
+ *    已变更的历史上;
+ *  - maker:get-context-usage:非运行中会话走 lazy-create 分支
+ *    (ensureRemoteReadyForSessionStart + bootstrapSession),SSH 工作区仅就绪
+ *    等待就允许 20s,再叠会话拉起;15s 会在桌面端继续启动时提前掐断,反复
+ *    尝试还会误开设备级熔断。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
@@ -30,6 +34,7 @@ export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'device-link:voice:transcribe': 30_000,
   'file-browser:remote-op': 30_000,
   'maker:fork': 30_000,
+  'maker:get-context-usage': 30_000,
   'maker:rewind:commit': 30_000,
 };
 

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -18,7 +18,10 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *    语音误超时就会错误打开设备级熔断;
  *  - maker:fork:桌面端 forkSessionAtMessage 载入完整可见消息前缀 + SDK fork +
  *    事务内批量拷贝,大会话可落在 15-30s;且该操作**非幂等**——误超时后桌面端
- *    仍会建出并广播新会话,用户重试会分叉出重复副本。
+ *    仍会建出并广播新会话,用户重试会分叉出重复副本;
+ *  - maker:rewind:commit:transcript/DB 读 + SDK/Codex 线程回滚 + Git 文件回退 +
+ *    收尾 SQLite 事务,同样非幂等——误超时后对话与文件已被回退,重试会作用在
+ *    已变更的历史上。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
@@ -27,6 +30,7 @@ export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'device-link:voice:transcribe': 30_000,
   'file-browser:remote-op': 30_000,
   'maker:fork': 30_000,
+  'maker:rewind:commit': 30_000,
 };
 
 export const MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS = 40_000;

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -12,13 +12,21 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *    冷启动 / 登出登录窗口内就绪可能落在 15-30s),40s = 就绪上限 + 执行余量;
  *  - voice:dictionary-learning:桌面 advisor 走 managed refiner,单次尝试空闲窗
  *    12s(VOICE_INPUT_MANAGED_REFINER_IDLE_TIMEOUT_MS)且主模型卡住会换备选
- *    profile 再试,合法执行可超 15s;误超时会让后台学习白白计入熔断失败。
+ *    profile 再试,合法执行可超 15s;误超时会让后台学习白白计入熔断失败;
+ *  - voice:transcribe:桌面端先 downloadToBuffer 从 OSS 拉音频再走批量网关转写,
+ *    两段都无更短的执行 deadline,中速/慢网络下合法执行可超 15s,且连续几条
+ *    语音误超时就会错误打开设备级熔断;
+ *  - maker:fork:桌面端 forkSessionAtMessage 载入完整可见消息前缀 + SDK fork +
+ *    事务内批量拷贝,大会话可落在 15-30s;且该操作**非幂等**——误超时后桌面端
+ *    仍会建出并广播新会话,用户重试会分叉出重复副本。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'device-link:media:fetch': 30_000,
   'device-link:voice:dictionary-learning': 30_000,
+  'device-link:voice:transcribe': 30_000,
   'file-browser:remote-op': 30_000,
+  'maker:fork': 30_000,
 };
 
 export const MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS = 40_000;

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -1,0 +1,27 @@
+import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
+
+/**
+ * mobile 侧 invoke 超时解析(优先级:mobile 精确表 → schedule 前缀规则 →
+ * 协议契约表 → undefined = client 默认 15s)。
+ *
+ * 背景:mobile 把默认请求超时从 30s 收紧到 15s 后,凡是桌面端有更长执行预算的
+ * 通道都必须在这里保住原有窗口,否则合法慢操作会被提前掐断(review 三轮反馈):
+ *  - media:fetch:桌面拉文件传 OSS,最大 2GB;
+ *  - file-browser:remote-op:searchCollect 桌面执行预算 20s(SEARCH_COLLECT_TIMEOUT_MS);
+ *  - maker:schedule:*:桌面 handler 会等 scheduler 就绪(READINESS_TIMEOUT_MS=30s,
+ *    冷启动 / 登出登录窗口内就绪可能落在 15-30s),40s = 就绪上限 + 执行余量。
+ * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
+ */
+export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
+  'device-link:media:fetch': 30_000,
+  'file-browser:remote-op': 30_000,
+};
+
+export const MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS = 40_000;
+
+export function resolveMobileInvokeTimeoutMs(channel: string): number | undefined {
+  const exact = MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS[channel];
+  if (exact !== undefined) return exact;
+  if (channel.startsWith('maker:schedule:')) return MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS;
+  return INVOKE_TIMEOUT_OVERRIDES_MS[channel];
+}

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -33,7 +33,10 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *    ensureRemoteReadyForSessionStart(SSH 就绪窗口 20s)再落库/派发;误超时后
  *    桌面仍会接收并发出该消息,用户重试会把同一条消息发两遍;
  *  - maker:regenerate-title:桌面路径先 getValidClaudeAiOAuth(刷新最长 ~10s)
- *    再发标题请求(自身 TITLE_TIMEOUT_MS=12s),合法总预算 ~22s。
+ *    再发标题请求(自身 TITLE_TIMEOUT_MS=12s),合法总预算 ~22s;
+ *  - maker:create-session:桌面 await maker.createSession → agent.startSession /
+ *    Codex host.ensureStarted,冷启动 app-server 无更短 deadline;goal 路径无
+ *    稳定的客户端会话 id,误超时后重试会建出第二个会话。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
@@ -41,6 +44,7 @@ export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'device-link:voice:dictionary-learning': 30_000,
   'device-link:voice:transcribe': 30_000,
   'file-browser:remote-op': 30_000,
+  'maker:create-session': 30_000,
   'maker:fork': 30_000,
   'maker:get-context-usage': 30_000,
   'maker:regenerate-title': 30_000,

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -28,7 +28,12 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *    尝试还会误开设备级熔断;
  *  - maker:usage:codex-rate-limits / codex-rate-limit-reset:账号 app-server
  *    冷启动或 RPC 慢时无更短 deadline;reset 还串行做消耗 + 身份校验 + 额度
- *    刷新且有真实副作用,误超时后桌面会继续完成消耗,重试有重复扣减风险。
+ *    刷新且有真实副作用,误超时后桌面会继续完成消耗,重试有重复扣减风险;
+ *  - maker:send:makerSendTransaction 接收消息前会等
+ *    ensureRemoteReadyForSessionStart(SSH 就绪窗口 20s)再落库/派发;误超时后
+ *    桌面仍会接收并发出该消息,用户重试会把同一条消息发两遍;
+ *  - maker:regenerate-title:桌面路径先 getValidClaudeAiOAuth(刷新最长 ~10s)
+ *    再发标题请求(自身 TITLE_TIMEOUT_MS=12s),合法总预算 ~22s。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
@@ -38,7 +43,9 @@ export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'file-browser:remote-op': 30_000,
   'maker:fork': 30_000,
   'maker:get-context-usage': 30_000,
+  'maker:regenerate-title': 30_000,
   'maker:rewind:commit': 30_000,
+  'maker:send': 30_000,
   'maker:usage:codex-rate-limit-reset': 30_000,
   'maker:usage:codex-rate-limits': 30_000,
 };

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -36,7 +36,11 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *    再发标题请求(自身 TITLE_TIMEOUT_MS=12s),合法总预算 ~22s;
  *  - maker:create-session:桌面 await maker.createSession → agent.startSession /
  *    Codex host.ensureStarted,冷启动 app-server 无更短 deadline;goal 路径无
- *    稳定的客户端会话 id,误超时后重试会建出第二个会话。
+ *    稳定的客户端会话 id,误超时后重试会建出第二个会话;
+ *  - maker:goal:set / goal:resume:GoalController.ensureSession 的
+ *    restoreSessionForGoal 同样 await createSession 重启持久化 agent,冷启动
+ *    可超 15s;两者都有真实副作用(set 落库目标并发首轮,resume 先标 active),
+ *    误超时后重试会改动/重启已在跑的 goal。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
@@ -47,6 +51,8 @@ export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'maker:create-session': 30_000,
   'maker:fork': 30_000,
   'maker:get-context-usage': 30_000,
+  'maker:goal:resume': 30_000,
+  'maker:goal:set': 30_000,
   'maker:regenerate-title': 30_000,
   'maker:rewind:commit': 30_000,
   'maker:send': 30_000,

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -25,7 +25,10 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *  - maker:get-context-usage:非运行中会话走 lazy-create 分支
  *    (ensureRemoteReadyForSessionStart + bootstrapSession),SSH 工作区仅就绪
  *    等待就允许 20s,再叠会话拉起;15s 会在桌面端继续启动时提前掐断,反复
- *    尝试还会误开设备级熔断。
+ *    尝试还会误开设备级熔断;
+ *  - maker:usage:codex-rate-limits / codex-rate-limit-reset:账号 app-server
+ *    冷启动或 RPC 慢时无更短 deadline;reset 还串行做消耗 + 身份校验 + 额度
+ *    刷新且有真实副作用,误超时后桌面会继续完成消耗,重试有重复扣减风险。
  * 新增合法慢通道优先登记协议契约表(桌面控制端共用),仅 mobile 特有差异放这里。
  */
 export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
@@ -36,6 +39,8 @@ export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'maker:fork': 30_000,
   'maker:get-context-usage': 30_000,
   'maker:rewind:commit': 30_000,
+  'maker:usage:codex-rate-limit-reset': 30_000,
+  'maker:usage:codex-rate-limits': 30_000,
 };
 
 export const MOBILE_SCHEDULE_CHANNEL_TIMEOUT_MS = 40_000;

--- a/apps/mobile/src/device-link/remoteStatus.ts
+++ b/apps/mobile/src/device-link/remoteStatus.ts
@@ -1,4 +1,5 @@
 import {
+  describeRemoteError as describeRemoteErrorShared,
   humanizeRemoteError as humanizeRemoteErrorShared,
   isDeviceUnresponsiveRemoteError,
 } from '@cindy/maker-shared/device-link-contract';
@@ -8,7 +9,6 @@ export {
   connectionIssueHint,
   connectionIssueTitle,
   describeAgentAuthError,
-  describeRemoteError,
   formatRemoteError,
   isPreconditionFailedRemoteError,
   relayStatusHint,
@@ -16,14 +16,23 @@ export {
 } from '@cindy/maker-shared/device-link-contract';
 
 /**
- * mobile 侧的 humanizeRemoteError:熔断快速失败(DEVICE_UNRESPONSIVE)先走
- * 四语言 i18n(与 ConnectionBanner 同一组文案),其余委托 maker-shared 原实现。
- * 共享层的文案是中文硬编码(历史现状),直接透出会让 en/ja/ko 用户在
- * Alert 里看到中文(review P1)——本 PR 新增的错误码不再走那条老路。
+ * mobile 侧的 humanizeRemoteError / describeRemoteError:熔断快速失败
+ * (DEVICE_UNRESPONSIVE)先走四语言 i18n(与 ConnectionBanner 同一组文案),
+ * 其余委托 maker-shared 原实现。共享层的文案是中文硬编码(历史现状),直接
+ * 透出会让 en/ja/ko 用户在 Alert / banner 里看到中文(review P1 两轮)——
+ * 本 PR 新增的错误码不再走那条老路。mobile 代码一律从本文件 import,
+ * 不要直接 import 共享层的这两个函数。
  */
 export function humanizeRemoteError(error: unknown): string {
   if (isDeviceUnresponsiveRemoteError(error)) {
     return i18n.t('deviceLink.deviceUnresponsiveHint');
   }
   return humanizeRemoteErrorShared(error);
+}
+
+export function describeRemoteError(error: string | null): string | null {
+  if (error?.includes('DEVICE_UNRESPONSIVE')) {
+    return i18n.t('deviceLink.deviceUnresponsiveHint');
+  }
+  return describeRemoteErrorShared(error);
 }

--- a/apps/mobile/src/device-link/remoteStatus.ts
+++ b/apps/mobile/src/device-link/remoteStatus.ts
@@ -1,11 +1,29 @@
+import {
+  humanizeRemoteError as humanizeRemoteErrorShared,
+  isDeviceUnresponsiveRemoteError,
+} from '@cindy/maker-shared/device-link-contract';
+import { i18n } from '@/i18n';
+
 export {
   connectionIssueHint,
   connectionIssueTitle,
   describeAgentAuthError,
   describeRemoteError,
   formatRemoteError,
-  humanizeRemoteError,
   isPreconditionFailedRemoteError,
   relayStatusHint,
   relayStatusLabel,
 } from '@cindy/maker-shared/device-link-contract';
+
+/**
+ * mobile 侧的 humanizeRemoteError:熔断快速失败(DEVICE_UNRESPONSIVE)先走
+ * 四语言 i18n(与 ConnectionBanner 同一组文案),其余委托 maker-shared 原实现。
+ * 共享层的文案是中文硬编码(历史现状),直接透出会让 en/ja/ko 用户在
+ * Alert 里看到中文(review P1)——本 PR 新增的错误码不再走那条老路。
+ */
+export function humanizeRemoteError(error: unknown): string {
+  if (isDeviceUnresponsiveRemoteError(error)) {
+    return i18n.t('deviceLink.deviceUnresponsiveHint');
+  }
+  return humanizeRemoteErrorShared(error);
+}

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -1,0 +1,122 @@
+/**
+ * unresponsiveDevicesStore.ts — 「目标设备无响应」熔断的 per-device 状态镜像 + 接线。
+ * ---------------------------------------------------------------------------
+ * 结构照 revokedDevicesStore 模板:module 级 Set + subscribe/getSnapshot +
+ * useSyncExternalStore hook,供 UI(首页设备行 failed 态、ConnectionBanner)订阅。
+ * 状态机本体在 deviceResponsivenessBreaker.ts(纯逻辑,可单测);本文件持有
+ * module 级单例并暴露 DeviceLinkContext 发送路径用的门禁 / 收尾 helper。
+ */
+import { useSyncExternalStore } from 'react';
+import { DeviceLinkError, type DeviceLinkErrorCode } from '@cindy/device-link';
+import {
+  createDeviceResponsivenessBreaker,
+  type BreakerSettleOutcome,
+} from '@/device-link/deviceResponsivenessBreaker';
+
+const unresponsive = new Set<string>();
+let snapshot: ReadonlySet<string> = new Set();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  snapshot = new Set(unresponsive);
+  for (const listener of listeners) listener();
+}
+
+/**
+ * 熔断 open 的目标设备集合(控制端本地判定)。真实回包(探测成功或任意业务
+ * 请求得到应答)即移除;被控端始终权威,这里只是「暂时别再压请求上去」的镜像。
+ */
+export const unresponsiveDevicesStore = {
+  markUnresponsive(deviceId: string): void {
+    if (!deviceId || unresponsive.has(deviceId)) return;
+    unresponsive.add(deviceId);
+    emit();
+  },
+
+  clearUnresponsive(deviceId: string): void {
+    if (!unresponsive.delete(deviceId)) return;
+    emit();
+  },
+
+  clearAll(): void {
+    if (unresponsive.size === 0) return;
+    unresponsive.clear();
+    emit();
+  },
+
+  has(deviceId: string): boolean {
+    return unresponsive.has(deviceId);
+  },
+
+  getSnapshot(): ReadonlySet<string> {
+    return snapshot;
+  },
+
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
+export function useUnresponsiveDevices(): ReadonlySet<string> {
+  return useSyncExternalStore(unresponsiveDevicesStore.subscribe, unresponsiveDevicesStore.getSnapshot);
+}
+
+/**
+ * DEVICE_UNRESPONSIVE 尚未收编进 @cindy/device-link 的 DeviceLinkErrorCode 联合
+ * (本改动零接触共享协议包,收编留 follow-up)。所有下游分类都按字符串匹配
+ * (maker-shared 的 PERMANENT 标记 / describeRemoteError / isDeviceUnresponsiveRemoteError),
+ * 不依赖联合类型,这里以 DeviceLinkError 形态抛出保持 code 字段惯例一致。
+ */
+const DEVICE_UNRESPONSIVE_ERROR_CODE: string = 'DEVICE_UNRESPONSIVE';
+
+export function createDeviceUnresponsiveError(deviceId: string): DeviceLinkError {
+  return new DeviceLinkError(
+    DEVICE_UNRESPONSIVE_ERROR_CODE as DeviceLinkErrorCode,
+    `target device ${deviceId} is unresponsive (circuit open)`,
+  );
+}
+
+const breaker = createDeviceResponsivenessBreaker({
+  onOpenChanged: (deviceId, open) => {
+    if (open) unresponsiveDevicesStore.markUnresponsive(deviceId);
+    else unresponsiveDevicesStore.clearUnresponsive(deviceId);
+  },
+});
+
+/**
+ * 发送门禁(DeviceLinkContext 四条 send* 路径的第一步):熔断 open 且无探测
+ * 窗口时抛 DEVICE_UNRESPONSIVE 快速失败(不等重连、不上管道);返回值 = 本次
+ * 请求是否为探测(单飞),必须原样回传给 settleDeviceSend。
+ */
+export function acquireDeviceSendSlot(deviceId: string): boolean {
+  const decision = breaker.acquire(deviceId);
+  if (decision === 'reject') throw createDeviceUnresponsiveError(deviceId);
+  return decision === 'probe';
+}
+
+export function settleDeviceSend(
+  deviceId: string,
+  wasProbe: boolean,
+  outcome: BreakerSettleOutcome,
+): void {
+  breaker.settle(deviceId, wasProbe, outcome);
+}
+
+/**
+ * 发送失败 → 熔断信号分类:仅 INVOKE_TIMEOUT(等满超时无回包)计失败;其余
+ * (NOT_CONNECTED / relay 层错误 / 断连批量 reject)是本机链路问题,不定论。
+ * 注意:invoke-result 携带的业务错误(ok:false)不会走到这里——收到 result
+ * 帧本身就是真实回包,发送路径在 unwrap 前已按 responded 上报。
+ */
+export function classifyDeviceSendFailure(error: unknown): BreakerSettleOutcome {
+  return error instanceof DeviceLinkError && error.code === 'INVOKE_TIMEOUT'
+    ? 'timeout'
+    : 'inconclusive';
+}
+
+/** 登出 / 进程内切号:清空熔断状态与 UI 镜像,避免串到下一个账号。 */
+export function resetDeviceResponsivenessTracking(): void {
+  breaker.resetAll();
+  unresponsiveDevicesStore.clearAll();
+}

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -89,6 +89,14 @@ const breaker = createDeviceResponsivenessBreaker({
  * 窗口时抛 DEVICE_UNRESPONSIVE 快速失败(不等重连、不上管道);返回值 = 本次
  * 请求是否为探测(单飞),必须原样回传给 settleDeviceSend。
  */
+/**
+ * 只读:该设备当前是否「探测已到窗口」——rehydrate 等自动恢复路径据此决定
+ * 是否把熔断 open 的设备重新纳入本轮(它的首个请求会自然成为探测)。
+ */
+export function isDeviceProbeDue(deviceId: string): boolean {
+  return breaker.probeDue(deviceId);
+}
+
 export function acquireDeviceSendSlot(deviceId: string): boolean {
   const decision = breaker.acquire(deviceId);
   if (decision === 'reject') throw createDeviceUnresponsiveError(deviceId);

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -146,12 +146,34 @@ export function clearDeviceResponsivenessTrackingFor(deviceId: string): void {
  * 发送失败 → 熔断信号分类:仅 INVOKE_TIMEOUT(等满超时无回包)计失败;其余
  * (NOT_CONNECTED / relay 层错误 / 断连批量 reject)是本机链路问题,不定论。
  * 注意:invoke-result 携带的业务错误(ok:false)不会走到这里——收到 result
- * 帧本身就是真实回包,发送路径在 unwrap 前已按 responded 上报。
+ * 帧本身就是真实回包,发送路径在 unwrap 前已按成功分类上报。
  */
 export function classifyDeviceSendFailure(error: unknown): BreakerSettleOutcome {
   return error instanceof DeviceLinkError && error.code === 'INVOKE_TIMEOUT'
     ? 'timeout'
     : 'inconclusive';
+}
+
+/**
+ * 被控端 dispatch 在 runInvoke 里、进入 dispatchLocalInvoke(IPC/DB 路径)之前
+ * 特判应答的 invoke 通道(dispatch.ts:media:fetch / voice:* 三条,credential-sync
+ * 已下线但保留匹配):它们的成功只证明桌面进程与 device-link 服务活着,不证明
+ * 打开熔断的 IPC/DB 子系统已恢复。half-open 时这类请求可能抢到探测席位,若按
+ * responded 收尾会误关熔断、放进新一轮 DB 请求突发(review P1 第七轮)——与
+ * 控制帧(subscribe/unsubscribe/link-accept)同语义,成功一律按不定论收尾。
+ * 走 dispatchLocalInvoke 的其余通道(含代表性探测与全部业务 DB 读写)的回包
+ * 仍是有效恢复证据。超时分类不受影响(classifyDeviceSendFailure)。
+ */
+export const BREAKER_NEUTRAL_INVOKE_CHANNELS: ReadonlySet<string> = new Set([
+  'device-link:media:fetch',
+  'device-link:voice:credential-sync',
+  'device-link:voice:dictionary-learning',
+  'device-link:voice:transcribe',
+]);
+
+/** 发送成功 → 熔断信号分类:dispatch 特判通道不定论,其余为真实恢复证据。 */
+export function classifyDeviceSendSuccess(channel: string): BreakerSettleOutcome {
+  return BREAKER_NEUTRAL_INVOKE_CHANNELS.has(channel) ? 'inconclusive' : 'responded';
 }
 
 /** 登出 / 进程内切号:清空熔断状态与 UI 镜像,避免串到下一个账号。 */

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -8,6 +8,7 @@
  */
 import { useSyncExternalStore } from 'react';
 import { DeviceLinkError, type DeviceLinkErrorCode } from '@cindy/device-link';
+import { revokedDevicesStore } from '@/device-link/revokedDevicesStore';
 import {
   createDeviceResponsivenessBreaker,
   type BreakerSettleOutcome,
@@ -85,11 +86,6 @@ const breaker = createDeviceResponsivenessBreaker({
 });
 
 /**
- * 发送门禁(DeviceLinkContext 四条 send* 路径的第一步):熔断 open 且无探测
- * 窗口时抛 DEVICE_UNRESPONSIVE 快速失败(不等重连、不上管道);返回值 = 本次
- * 请求是否为探测(单飞),必须原样回传给 settleDeviceSend。
- */
-/**
  * 只读:该设备当前是否「探测已到窗口」——rehydrate 等自动恢复路径据此决定
  * 是否把熔断 open 的设备重新纳入本轮(它的首个请求会自然成为探测)。
  */
@@ -97,6 +93,11 @@ export function isDeviceProbeDue(deviceId: string): boolean {
   return breaker.probeDue(deviceId);
 }
 
+/**
+ * 发送门禁(DeviceLinkContext 四条 send* 路径的第一步):熔断 open 且无探测
+ * 窗口时抛 DEVICE_UNRESPONSIVE 快速失败(不等重连、不上管道);返回值 = 本次
+ * 请求是否为探测(单飞),必须原样回传给 settleDeviceSend。
+ */
 export function acquireDeviceSendSlot(deviceId: string): boolean {
   const decision = breaker.acquire(deviceId);
   if (decision === 'reject') throw createDeviceUnresponsiveError(deviceId);
@@ -108,7 +109,21 @@ export function settleDeviceSend(
   wasProbe: boolean,
   outcome: BreakerSettleOutcome,
 ): void {
-  breaker.settle(deviceId, wasProbe, outcome);
+  // 撤权竞态防护(review P1):撤权时桌面端发 link-close(revoked) 但不 resolve
+  // 在途请求,它们随后超时——这不是"设备无响应",是访问被收回。已撤权设备的
+  // 超时一律降级为不定论,不再计入熔断,避免 unresponsive 状态与撤权状态并存。
+  const effective = outcome === 'timeout' && revokedDevicesStore.has(deviceId)
+    ? 'inconclusive'
+    : outcome;
+  breaker.settle(deviceId, wasProbe, effective);
+}
+
+/**
+ * 清除单个设备的熔断状态与 UI 镜像。撤权时调用:设备的「响应性」已无意义,
+ * 且撤权有自己的专属 UI,不应再叠加「电脑端未响应」降级态。
+ */
+export function clearDeviceResponsivenessTrackingFor(deviceId: string): void {
+  breaker.clear(deviceId);
 }
 
 /**

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -11,6 +11,7 @@ import { DeviceLinkError, type DeviceLinkErrorCode } from '@cindy/device-link';
 import { revokedDevicesStore } from '@/device-link/revokedDevicesStore';
 import {
   createDeviceResponsivenessBreaker,
+  type BreakerSendSlot,
   type BreakerSettleOutcome,
 } from '@/device-link/deviceResponsivenessBreaker';
 
@@ -109,18 +110,19 @@ export function buildDeviceResponsivenessProbeArgs(): unknown[] {
 
 /**
  * 发送门禁(DeviceLinkContext 四条 send* 路径的第一步):熔断 open 且无探测
- * 窗口时抛 DEVICE_UNRESPONSIVE 快速失败(不等重连、不上管道);返回值 = 本次
- * 请求是否为探测(单飞),必须原样回传给 settleDeviceSend。
+ * 窗口时抛 DEVICE_UNRESPONSIVE 快速失败(不等重连、不上管道);返回的席位票据
+ * (含探测标记与设备代数)必须原样回传给 settleDeviceSend——代数不匹配的
+ * 旧请求结果会被忽略(review P1:恢复前派出的长超时请求不再污染新一代计数)。
  */
-export function acquireDeviceSendSlot(deviceId: string): boolean {
-  const decision = breaker.acquire(deviceId);
-  if (decision === 'reject') throw createDeviceUnresponsiveError(deviceId);
-  return decision === 'probe';
+export function acquireDeviceSendSlot(deviceId: string): BreakerSendSlot {
+  const slot = breaker.acquire(deviceId);
+  if (slot.decision === 'reject') throw createDeviceUnresponsiveError(deviceId);
+  return slot;
 }
 
 export function settleDeviceSend(
   deviceId: string,
-  wasProbe: boolean,
+  slot: BreakerSendSlot,
   outcome: BreakerSettleOutcome,
 ): void {
   // 撤权竞态防护(review P1):撤权时桌面端发 link-close(revoked) 但不 resolve
@@ -129,7 +131,7 @@ export function settleDeviceSend(
   const effective = outcome === 'timeout' && revokedDevicesStore.has(deviceId)
     ? 'inconclusive'
     : outcome;
-  breaker.settle(deviceId, wasProbe, effective);
+  breaker.settle(deviceId, slot, effective);
 }
 
 /**

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -87,10 +87,24 @@ const breaker = createDeviceResponsivenessBreaker({
 
 /**
  * 只读:该设备当前是否「探测已到窗口」——rehydrate 等自动恢复路径据此决定
- * 是否把熔断 open 的设备重新纳入本轮(它的首个请求会自然成为探测)。
+ * 是否对熔断 open 的设备发起显式代表性探测。
  */
 export function isDeviceProbeDue(deviceId: string): boolean {
   return breaker.probeDue(deviceId);
+}
+
+/**
+ * 代表性探测请求(review P1 多轮收敛):half-open 探测必须穿过被控端
+ * runInvoke → dispatchLocalInvoke → local-db 读路径才算数——link-accept 与
+ * subscribe/unsubscribe 都在 dispatch 里于 runInvoke **之前**特判应答,
+ * IPC/DB 子系统卡死时它们照常回包,不能作为恢复证据。sessions:list limit=1
+ * 是最便宜的真实 DB 读,恰好就是事故里被卡死的那类请求;args 形状与
+ * devices 页的正常拉取一致([limit, statusFilter, opts])。
+ */
+export const DEVICE_RESPONSIVENESS_PROBE_CHANNEL = 'local-db:sessions:list';
+
+export function buildDeviceResponsivenessProbeArgs(): unknown[] {
+  return [1, 'all', { includePinned: true }];
 }
 
 /**

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -171,8 +171,16 @@ export const BREAKER_NEUTRAL_INVOKE_CHANNELS: ReadonlySet<string> = new Set([
   'device-link:voice:transcribe',
 ]);
 
-/** 发送成功 → 熔断信号分类:dispatch 特判通道不定论,其余为真实恢复证据。 */
-export function classifyDeviceSendSuccess(channel: string): BreakerSettleOutcome {
+/**
+ * 发送成功 → 熔断信号分类:dispatch 特判通道不定论,其余为真实恢复证据。
+ * wasProbe(review P1 收敛):持有 half-open 探测席位时,只有指定探测通道
+ * (穿过 local-db 读路径)的回包才允许关熔断——普通 IPC handler 里还有大量
+ * 纯内存实现(如 maker:list-agent-commands 的同步列表),DB 子系统卡死时它们
+ * 照常应答,凑巧抢到探测席位的成功不能作恢复证据。闭合态(非探测)的回包
+ * 仍按通道分类:重置连续计数只是计数语义,不触发恢复突发。
+ */
+export function classifyDeviceSendSuccess(channel: string, wasProbe = false): BreakerSettleOutcome {
+  if (wasProbe && channel !== DEVICE_RESPONSIVENESS_PROBE_CHANNEL) return 'inconclusive';
   return BREAKER_NEUTRAL_INVOKE_CHANNELS.has(channel) ? 'inconclusive' : 'responded';
 }
 

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -176,6 +176,27 @@ export function classifyDeviceSendSuccess(channel: string): BreakerSettleOutcome
   return BREAKER_NEUTRAL_INVOKE_CHANNELS.has(channel) ? 'inconclusive' : 'responded';
 }
 
+/**
+ * openLink 专用的终态 relay 应答码(review P1):relay 明确回答了目标设备的
+ * 状态(开关关闭 / 不在线 / 版本不符)——「响应性」判定就此失去意义,继续
+ * 保持 unresponsive 会让设备被永远探测,横幅还压着更可操作的真实状态
+ * (如「已关闭允许远程控制」)。按真实应答关熔断,把 UI 让给对应的错误态;
+ * 开关重开 / 设备上线后的首次请求若再超时,熔断照常重新累计。
+ * NOT_CONNECTED / LINK_NOT_OPEN 等传输层失败仍不定论,超时仍计失败。
+ */
+const TERMINAL_LINK_OPEN_ERROR_CODES: ReadonlySet<string> = new Set([
+  'DEVICE_OFFLINE',
+  'REMOTE_DISABLED',
+  'VERSION_MISMATCH',
+]);
+
+export function classifyLinkOpenFailure(error: unknown): BreakerSettleOutcome {
+  if (error instanceof DeviceLinkError && TERMINAL_LINK_OPEN_ERROR_CODES.has(error.code)) {
+    return 'responded';
+  }
+  return classifyDeviceSendFailure(error);
+}
+
 /** 登出 / 进程内切号:清空熔断状态与 UI 镜像,避免串到下一个账号。 */
 export function resetDeviceResponsivenessTracking(): void {
   breaker.resetAll();

--- a/apps/mobile/src/i18n/locales/en/deviceLink.json
+++ b/apps/mobile/src/i18n/locales/en/deviceLink.json
@@ -3,6 +3,8 @@
   "resync": "Resync",
   "resyncing": "Resyncing",
   "syncShort": "Sync",
+  "deviceUnresponsiveTitle": "Computer not responding",
+  "deviceUnresponsiveHint": "Your computer isn't answering right now. Retrying automatically.",
   "connectStep1": "Install and open {{appName}} on your computer",
   "connectStep2": "Sign in with the same account as your phone",
   "connectStep3": "Under Settings → Remote Access, turn on \"Allow same-account devices to control this computer\"",

--- a/apps/mobile/src/i18n/locales/ja/deviceLink.json
+++ b/apps/mobile/src/i18n/locales/ja/deviceLink.json
@@ -3,6 +3,8 @@
   "resync": "再同期",
   "resyncing": "再同期しています",
   "syncShort": "同期",
+  "deviceUnresponsiveTitle": "パソコンが応答していません",
+  "deviceUnresponsiveHint": "パソコンが一時的に応答していません。自動的に再試行しています。",
   "connectStep1": "パソコンに {{appName}} をインストールして起動する",
   "connectStep2": "スマートフォンと同じアカウントでログインする",
   "connectStep3": "「設定 → リモート接続」で「同じアカウントのデバイスにこのパソコンの操作を許可」をオンにする",

--- a/apps/mobile/src/i18n/locales/ko/deviceLink.json
+++ b/apps/mobile/src/i18n/locales/ko/deviceLink.json
@@ -3,6 +3,8 @@
   "resync": "다시 동기화",
   "resyncing": "다시 동기화하는 중",
   "syncShort": "동기화",
+  "deviceUnresponsiveTitle": "컴퓨터가 응답하지 않습니다",
+  "deviceUnresponsiveHint": "컴퓨터가 일시적으로 응답하지 않습니다. 자동으로 다시 시도하고 있습니다.",
   "connectStep1": "컴퓨터에 {{appName}}을(를) 설치하고 실행하세요",
   "connectStep2": "휴대폰과 동일한 계정으로 로그인하세요",
   "connectStep3": "'설정 → 원격 연결'에서 '동일 계정 기기의 이 컴퓨터 제어 허용'을 켜세요",

--- a/apps/mobile/src/i18n/locales/zh-CN/deviceLink.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/deviceLink.json
@@ -3,6 +3,8 @@
   "resync": "重新同步",
   "resyncing": "正在重新同步",
   "syncShort": "同步",
+  "deviceUnresponsiveTitle": "电脑端未响应",
+  "deviceUnresponsiveHint": "电脑暂时没有回应请求，正在自动重试。",
   "connectStep1": "在电脑上安装并打开 {{appName}}",
   "connectStep2": "用与手机相同的账号登录",
   "connectStep3": "在「设置 → 远程连接」中开启「允许同账号设备控制本机」",

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -74,6 +74,8 @@ interface ScheduleIndexThrottleEntry {
   failedAt: number | null;
   /** 失败原因是 DEVICE_UNRESPONSIVE(熔断快速失败);恢复旁路判定用。 */
   failedUnresponsive: boolean;
+  /** 失败原因是瞬态链路问题(NOT_CONNECTED 等);重连失效判定用。 */
+  failedTransient: boolean;
 }
 
 const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>();
@@ -103,7 +105,13 @@ export function loadSessionScheduleIndexThrottled(
     if (withinTtl && !failedUnresponsiveButRecovered) return existing.promise;
   }
   const promise = load();
-  const entry: ScheduleIndexThrottleEntry = { at: now(), promise, failedAt: null, failedUnresponsive: false };
+  const entry: ScheduleIndexThrottleEntry = {
+    at: now(),
+    promise,
+    failedAt: null,
+    failedUnresponsive: false,
+    failedTransient: false,
+  };
   scheduleIndexThrottleEntries.set(key, entry);
   promise.then(
     () => {
@@ -120,10 +128,26 @@ export function loadSessionScheduleIndexThrottled(
         // 同样享受「恢复即旁路」而不是干等 30s TTL。
         entry.failedUnresponsive =
           isDeviceUnresponsiveRemoteError(error) || unresponsiveDevicesStore.has(key);
+        entry.failedTransient = !entry.failedUnresponsive && isTransientRemoteError(error);
       }
     },
   );
   return promise;
+}
+
+/**
+ * 重连恢复钩子(review P1):普通断线(NOT_CONNECTED 等瞬态失败)产生的负缓存
+ * 在链路恢复后立即失效——否则 30s 失败 TTL 内重连触发的 reseed 会吃到旧的
+ * rejected promise,设备详情页把索引替换成空集、首页保留陈旧数据,且没有任何
+ * 定时器在 TTL 过期后补拉。由 DeviceLinkContext 在每轮 rehydrate(只在 online
+ * 时运行,重连必经)开始时调用;熔断类负缓存不受影响(走各自的恢复旁路)。
+ */
+export function invalidateTransientScheduleIndexFailures(): void {
+  for (const [key, entry] of scheduleIndexThrottleEntries) {
+    if (entry.failedAt !== null && entry.failedTransient) {
+      scheduleIndexThrottleEntries.delete(key);
+    }
+  }
 }
 
 /** 测试用:清空节流登记表。 */

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -84,9 +84,17 @@ export function loadSessionScheduleIndexThrottled(
   const promise = load();
   const entry: ScheduleIndexThrottleEntry = { at: now(), promise, failedAt: null };
   scheduleIndexThrottleEntries.set(key, entry);
-  promise.catch(() => {
-    if (scheduleIndexThrottleEntries.get(key) === entry) entry.failedAt = now();
-  });
+  promise.then(
+    () => {
+      // TTL 语义是「完成后 TTL 内复用」:一轮 load 本身耗时较长(1+N 串行)时,
+      // 若从启动时刻起算,可复用窗口会被吃掉大半甚至直接过期(review 反馈)。
+      // 成功落定时把基准挪到 resolve 时刻;在途期间的复用由单飞(同一 promise)保证。
+      if (scheduleIndexThrottleEntries.get(key) === entry) entry.at = now();
+    },
+    () => {
+      if (scheduleIndexThrottleEntries.get(key) === entry) entry.failedAt = now();
+    },
+  );
   return promise;
 }
 

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -25,19 +25,18 @@ export async function loadSessionScheduleIndex(
   const pairs: Array<readonly [string, RemoteScheduleRun[]]> = [];
   for (const schedule of schedules) {
     let runs: RemoteScheduleRun[] = [];
-    let deviceUnresponsive = false;
     try {
       runs = normalizeScheduleRuns(await maker.schedule.listRuns(schedule.id, SCHEDULE_INDEX_RUN_LIMIT));
     } catch (error) {
       if (options.throwOnTransientRunListError && isTransientRemoteError(error)) throw error;
+      // 目标设备熔断 open(DEVICE_UNRESPONSIVE 快速失败):剩余 N-1 个 listRuns 会
+      // 同样逐个失败,立即止损。**上抛而不是截断成功**(review P1):把部分索引当
+      // 成功返回会被调用方提交并进入 30s 正缓存——首页/详情页拿着不完整徽标还
+      // 以为是新鲜数据;上抛让节流层走失败负缓存,熔断恢复后重拉全量。
+      if (isDeviceUnresponsiveRemoteError(error)) throw error;
       runs = [];
-      deviceUnresponsive = isDeviceUnresponsiveRemoteError(error);
     }
     pairs.push([schedule.id, runs] as const);
-    // 目标设备熔断 open(DEVICE_UNRESPONSIVE 快速失败):剩余 N-1 个 listRuns 会
-    // 同样地逐个失败,立即止损跳出。缺 runs 只影响未读徽标,schedule 名称 / 分组
-    // 由 schedules 列表兜底,下一轮(熔断恢复或负缓存过期后)自然补齐。
-    if (deviceUnresponsive) break;
   }
   return buildSessionScheduleIndex(schedules, new Map(pairs));
 }

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -10,6 +10,12 @@ const SCHEDULE_INDEX_RUN_LIMIT = 50;
 
 type LoadSessionScheduleIndexOptions = {
   throwOnTransientRunListError?: boolean;
+  /**
+   * 该目标设备当前是否熔断 open(实时查询)。最后一项 listRuns 的超时恰好把
+   * 熔断打开时,catch 到的还是原始 INVOKE_TIMEOUT 而非快速失败码——只按错误码
+   * 判断会把残缺索引当成功提交进 30s 正缓存(review P1)。
+   */
+  isDeviceUnresponsive?: () => boolean;
 };
 
 export async function loadSessionScheduleIndex(
@@ -34,7 +40,11 @@ export async function loadSessionScheduleIndex(
       // 同样逐个失败,立即止损。**上抛而不是截断成功**(review P1):把部分索引当
       // 成功返回会被调用方提交并进入 30s 正缓存——首页/详情页拿着不完整徽标还
       // 以为是新鲜数据;上抛让节流层走失败负缓存,熔断恢复后重拉全量。
-      if (isDeviceUnresponsiveRemoteError(error)) throw error;
+      // isDeviceUnresponsive 兜住末项竞态(review P1):最后一项的超时恰好凑满
+      // 阈值开熔断时,抛的是 INVOKE_TIMEOUT,只看错误码会漏判。
+      if (isDeviceUnresponsiveRemoteError(error) || options.isDeviceUnresponsive?.()) {
+        throw error;
+      }
       runs = [];
     }
     pairs.push([schedule.id, runs] as const);
@@ -105,7 +115,11 @@ export function loadSessionScheduleIndexThrottled(
     (error) => {
       if (scheduleIndexThrottleEntries.get(key) === entry) {
         entry.failedAt = now();
-        entry.failedUnresponsive = isDeviceUnresponsiveRemoteError(error);
+        // 末项竞态下抛出的是原始 INVOKE_TIMEOUT(见 loadSessionScheduleIndex
+        // 注释),此时熔断已 open——补查 store(key 即 deviceId),保证这类失败
+        // 同样享受「恢复即旁路」而不是干等 30s TTL。
+        entry.failedUnresponsive =
+          isDeviceUnresponsiveRemoteError(error) || unresponsiveDevicesStore.has(key);
       }
     },
   );
@@ -121,7 +135,9 @@ export function loadDeviceSessionScheduleIndex(
   deviceId: string,
   invoke: RemoteInvoke,
 ): Promise<Map<string, RemoteSessionScheduleInfo>> {
-  return loadSessionScheduleIndex(createMobileMakerTransport({ deviceId, invoke }));
+  return loadSessionScheduleIndex(createMobileMakerTransport({ deviceId, invoke }), {
+    isDeviceUnresponsive: () => unresponsiveDevicesStore.has(deviceId),
+  });
 }
 
 export function replaceSessionScheduleIndexEntries(

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -1,5 +1,6 @@
 import { isDeviceUnresponsiveRemoteError } from '@cindy/maker-shared/device-link-contract';
 import { createMobileMakerTransport, type MobileMakerTransport, type RemoteInvoke } from '@/device-link/mobileMakerTransport';
+import { unresponsiveDevicesStore } from '@/device-link/unresponsiveDevicesStore';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 import { normalizeScheduleList, normalizeScheduleRuns } from '@/scheduler/scheduleModel';
 import type { RemoteScheduleRun } from '@/scheduler/types';
@@ -61,6 +62,8 @@ interface ScheduleIndexThrottleEntry {
   promise: Promise<Map<string, RemoteSessionScheduleInfo>>;
   /** 该轮加载失败的时刻;非 null 表示条目处于负缓存态。 */
   failedAt: number | null;
+  /** 失败原因是 DEVICE_UNRESPONSIVE(熔断快速失败);恢复旁路判定用。 */
+  failedUnresponsive: boolean;
 }
 
 const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>();
@@ -75,13 +78,22 @@ export function loadSessionScheduleIndexThrottled(
   const failureTtlMs = options.failureTtlMs ?? SCHEDULE_INDEX_FAILURE_TTL_MS;
   const existing = scheduleIndexThrottleEntries.get(key);
   if (!options.force && existing) {
+    // 熔断恢复旁路(review P1):DEVICE_UNRESPONSIVE 负缓存的存在意义是「open
+    // 期间别再压请求」,设备一旦恢复(移出 unresponsive 集合)就立刻失效——
+    // 否则熔断关闭触发的 reseed/重载会在失败 TTL 内吃到同一个 rejected
+    // promise,把索引替换成空集,且无任何定时器在 TTL 过期后补拉,徽标要等
+    // 无关触发源才回来。key 即 deviceId(两处调用方约定,见 devices 页注释)。
+    const failedUnresponsiveButRecovered =
+      existing.failedAt !== null
+      && existing.failedUnresponsive
+      && !unresponsiveDevicesStore.has(key);
     const withinTtl = existing.failedAt !== null
       ? now() - existing.failedAt < failureTtlMs
       : now() - existing.at < ttlMs;
-    if (withinTtl) return existing.promise;
+    if (withinTtl && !failedUnresponsiveButRecovered) return existing.promise;
   }
   const promise = load();
-  const entry: ScheduleIndexThrottleEntry = { at: now(), promise, failedAt: null };
+  const entry: ScheduleIndexThrottleEntry = { at: now(), promise, failedAt: null, failedUnresponsive: false };
   scheduleIndexThrottleEntries.set(key, entry);
   promise.then(
     () => {
@@ -90,8 +102,11 @@ export function loadSessionScheduleIndexThrottled(
       // 成功落定时把基准挪到 resolve 时刻;在途期间的复用由单飞(同一 promise)保证。
       if (scheduleIndexThrottleEntries.get(key) === entry) entry.at = now();
     },
-    () => {
-      if (scheduleIndexThrottleEntries.get(key) === entry) entry.failedAt = now();
+    (error) => {
+      if (scheduleIndexThrottleEntries.get(key) === entry) {
+        entry.failedAt = now();
+        entry.failedUnresponsive = isDeviceUnresponsiveRemoteError(error);
+      }
     },
   );
   return promise;

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -80,6 +80,12 @@ interface ScheduleIndexThrottleEntry {
 
 const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>();
 
+/** 本机链路未通(NOT_CONNECTED / LINK_NOT_OPEN):重连即恢复的失败类别。 */
+function isLocalLinkDownError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return code === 'NOT_CONNECTED' || code === 'LINK_NOT_OPEN';
+}
+
 export function loadSessionScheduleIndexThrottled(
   key: string,
   load: () => Promise<Map<string, RemoteSessionScheduleInfo>>,
@@ -128,7 +134,10 @@ export function loadSessionScheduleIndexThrottled(
         // 同样享受「恢复即旁路」而不是干等 30s TTL。
         entry.failedUnresponsive =
           isDeviceUnresponsiveRemoteError(error) || unresponsiveDevicesStore.has(key);
-        entry.failedTransient = !entry.failedUnresponsive && isTransientRemoteError(error);
+        // 收窄为真正的本机链路失败(review):isTransientRemoteError 把
+        // INVOKE_TIMEOUT(目标不回包)也算 transient,若沿用,重连失效钩子会把
+        // 「设备不回包」的负缓存也当断线恢复清掉,削弱止损效果。
+        entry.failedTransient = !entry.failedUnresponsive && isLocalLinkDownError(error);
       }
     },
   );

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -1,3 +1,4 @@
+import { isDeviceUnresponsiveRemoteError } from '@cindy/maker-shared/device-link-contract';
 import { createMobileMakerTransport, type MobileMakerTransport, type RemoteInvoke } from '@/device-link/mobileMakerTransport';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 import { normalizeScheduleList, normalizeScheduleRuns } from '@/scheduler/scheduleModel';
@@ -24,13 +25,19 @@ export async function loadSessionScheduleIndex(
   const pairs: Array<readonly [string, RemoteScheduleRun[]]> = [];
   for (const schedule of schedules) {
     let runs: RemoteScheduleRun[] = [];
+    let deviceUnresponsive = false;
     try {
       runs = normalizeScheduleRuns(await maker.schedule.listRuns(schedule.id, SCHEDULE_INDEX_RUN_LIMIT));
     } catch (error) {
       if (options.throwOnTransientRunListError && isTransientRemoteError(error)) throw error;
       runs = [];
+      deviceUnresponsive = isDeviceUnresponsiveRemoteError(error);
     }
     pairs.push([schedule.id, runs] as const);
+    // 目标设备熔断 open(DEVICE_UNRESPONSIVE 快速失败):剩余 N-1 个 listRuns 会
+    // 同样地逐个失败,立即止损跳出。缺 runs 只影响未读徽标,schedule 名称 / 分组
+    // 由 schedules 列表兜底,下一轮(熔断恢复或负缓存过期后)自然补齐。
+    if (deviceUnresponsive) break;
   }
   return buildSessionScheduleIndex(schedules, new Map(pairs));
 }
@@ -42,13 +49,19 @@ export async function loadSessionScheduleIndex(
  *  - 同 key 在途请求直接复用(单飞);
  *  - 完成后 TTL 内的触发复用上次结果(index 只喂次要徽标,短暂陈旧无感);
  *  - `force`(用户显式操作,如标记已读后的重建)绕过 TTL 立即重拉;
- *  - 失败不占坑:reject 后清除条目,下次触发正常重试。
+ *  - 失败负缓存:reject 后失败 TTL 内复用同一个 rejected promise,不重放 1+N 批次
+ *    (参照 remoteMediaResolveQueue)。旧的「失败即清坑」+ 多触发源交叠,是 2026-07
+ *    被控端无响应事故里首页反复全量重放、堆积请求风暴的放大器之一;`force` 照常穿透。
  */
 export const SCHEDULE_INDEX_THROTTLE_TTL_MS = 30_000;
+/** 失败负缓存时长:窗口内的被动触发直接吃上次失败,不再压请求上管道。 */
+export const SCHEDULE_INDEX_FAILURE_TTL_MS = 30_000;
 
 interface ScheduleIndexThrottleEntry {
   at: number;
   promise: Promise<Map<string, RemoteSessionScheduleInfo>>;
+  /** 该轮加载失败的时刻;非 null 表示条目处于负缓存态。 */
+  failedAt: number | null;
 }
 
 const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>();
@@ -56,17 +69,23 @@ const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>
 export function loadSessionScheduleIndexThrottled(
   key: string,
   load: () => Promise<Map<string, RemoteSessionScheduleInfo>>,
-  options: { force?: boolean; ttlMs?: number; now?: () => number } = {},
+  options: { force?: boolean; ttlMs?: number; failureTtlMs?: number; now?: () => number } = {},
 ): Promise<Map<string, RemoteSessionScheduleInfo>> {
   const now = options.now ?? Date.now;
   const ttlMs = options.ttlMs ?? SCHEDULE_INDEX_THROTTLE_TTL_MS;
+  const failureTtlMs = options.failureTtlMs ?? SCHEDULE_INDEX_FAILURE_TTL_MS;
   const existing = scheduleIndexThrottleEntries.get(key);
-  if (!options.force && existing && now() - existing.at < ttlMs) return existing.promise;
+  if (!options.force && existing) {
+    const withinTtl = existing.failedAt !== null
+      ? now() - existing.failedAt < failureTtlMs
+      : now() - existing.at < ttlMs;
+    if (withinTtl) return existing.promise;
+  }
   const promise = load();
-  const entry: ScheduleIndexThrottleEntry = { at: now(), promise };
+  const entry: ScheduleIndexThrottleEntry = { at: now(), promise, failedAt: null };
   scheduleIndexThrottleEntries.set(key, entry);
   promise.catch(() => {
-    if (scheduleIndexThrottleEntries.get(key) === entry) scheduleIndexThrottleEntries.delete(key);
+    if (scheduleIndexThrottleEntries.get(key) === entry) entry.failedAt = now();
   });
   return promise;
 }

--- a/packages/maker-shared/src/__tests__/deviceLinkContract.test.ts
+++ b/packages/maker-shared/src/__tests__/deviceLinkContract.test.ts
@@ -12,6 +12,7 @@ import {
   formatRemoteError,
   humanizeRemoteError,
   isAccessRevokedRemoteError,
+  isDeviceUnresponsiveRemoteError,
   isPreconditionFailedRemoteError,
   isMobileRemoteInvokeChannel,
   isTransientRemoteError,
@@ -148,6 +149,12 @@ describe('device-link shared contract', () => {
     expect(isTransientRemoteError(Object.assign(new Error('remote disabled'), { code: 'REMOTE_DISABLED' }))).toBe(false);
     expect(isTransientRemoteError("[CHANNEL_NOT_ALLOWED] channel 'x' not allowed")).toBe(false);
     expect(isTransientRemoteError(new Error('unexpected'))).toBe(false);
+    // 熔断快速失败必须是 permanent:归为瞬时会让 withTransientRemoteRetry 把
+    // 本地直拒再重试 6 次,熔断等于白做。code 与 message 两种形态都要拦住。
+    expect(isTransientRemoteError(
+      Object.assign(new Error('target device dev-1 is unresponsive (circuit open)'), { code: 'DEVICE_UNRESPONSIVE' }),
+    )).toBe(false);
+    expect(isTransientRemoteError('[DEVICE_UNRESPONSIVE] target device dev-1 is unresponsive')).toBe(false);
 
     const op = vi.fn()
       .mockRejectedValueOnce(new Error('DbClient not ready'))
@@ -160,5 +167,24 @@ describe('device-link shared contract', () => {
     const permanent = vi.fn().mockRejectedValue(new Error('[REMOTE_DISABLED] remote control disabled'));
     await expect(withTransientRemoteRetry(permanent, { sleep: noSleep })).rejects.toThrow('remote control disabled');
     expect(permanent).toHaveBeenCalledTimes(1);
+
+    // 熔断快速失败不重试:一次上抛,让调用方走降级路径
+    const unresponsive = vi.fn().mockRejectedValue(
+      Object.assign(new Error('target device dev-1 is unresponsive (circuit open)'), { code: 'DEVICE_UNRESPONSIVE' }),
+    );
+    await expect(withTransientRemoteRetry(unresponsive, { sleep: noSleep })).rejects.toThrow('unresponsive');
+    expect(unresponsive).toHaveBeenCalledTimes(1);
+  });
+
+  it('recognizes device-unresponsive breaker fast-fails and maps them to readable copy', () => {
+    expect(isDeviceUnresponsiveRemoteError(
+      Object.assign(new Error('target device dev-1 is unresponsive (circuit open)'), { code: 'DEVICE_UNRESPONSIVE' }),
+    )).toBe(true);
+    expect(isDeviceUnresponsiveRemoteError('[DEVICE_UNRESPONSIVE] target device dev-1 is unresponsive')).toBe(true);
+    expect(isDeviceUnresponsiveRemoteError(new Error('[DEVICE_UNRESPONSIVE] fast fail'))).toBe(true);
+    expect(isDeviceUnresponsiveRemoteError(new Error('unexpected'))).toBe(false);
+    expect(isDeviceUnresponsiveRemoteError(Object.assign(new Error('offline'), { code: 'DEVICE_OFFLINE' }))).toBe(false);
+    expect(describeRemoteError('[DEVICE_UNRESPONSIVE] target device dev-1 is unresponsive'))
+      .toBe('电脑端未响应，正在自动重试，请稍后再试。');
   });
 });

--- a/packages/maker-shared/src/deviceLinkContract.ts
+++ b/packages/maker-shared/src/deviceLinkContract.ts
@@ -329,6 +329,11 @@ export type DeviceLinkRelayStatus = 'online' | 'connecting' | 'stopped';
 const PERMANENT_REMOTE_ERROR_MARKERS = [
   'REMOTE_DISABLED',
   'CHANNEL_NOT_ALLOWED',
+  // 控制端「目标设备无响应」熔断器的快速失败(见 apps/mobile 的
+  // unresponsiveDevicesStore):被控端连续 INVOKE_TIMEOUT 后熔断 open,新请求
+  // 本地直拒。必须归为 permanent——否则 withTransientRemoteRetry 会把熔断
+  // 快速失败再原地重试 6 次,熔断等于白做。
+  'DEVICE_UNRESPONSIVE',
 ] as const;
 
 const TRANSIENT_REMOTE_ERROR_MARKERS = [
@@ -463,6 +468,7 @@ export function describeRemoteError(error: string | null): string | null {
   if (error.includes('REMOTE_DISABLED')) return '被控电脑已关闭允许远程控制。';
   if (error.includes('CHANNEL_NOT_ALLOWED')) return '当前电脑端版本不支持这个远程能力。';
   if (error.includes('ACCESS_REVOKED')) return '这台电脑已撤销手机访问权限。';
+  if (error.includes('DEVICE_UNRESPONSIVE')) return '电脑端未响应，正在自动重试，请稍后再试。';
   if (error.includes('VERSION_MISMATCH')) return '与服务端协议版本不一致，请升级 App 后重试。';
   if (error.includes('PAYLOAD_TOO_LARGE')) return '这次传输的内容过大，请拆分后重试。';
   if (error.includes('MEDIA_FETCH_FAILED')) return '获取电脑端文件失败，可以稍后重试。';
@@ -506,6 +512,14 @@ export function isAccessRevokedRemoteError(error: unknown): boolean {
   if (code === 'ACCESS_REVOKED') return true;
   const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
   return message.includes('ACCESS_REVOKED') || message.includes('DEVICE_LINK_ACCESS_REVOKED');
+}
+
+/** 控制端熔断器快速失败(目标设备无响应)的识别;code 与 message 两种形态都认。 */
+export function isDeviceUnresponsiveRemoteError(error: unknown): boolean {
+  const code = readStringField(error, 'code');
+  if (code === 'DEVICE_UNRESPONSIVE') return true;
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  return message.includes('DEVICE_UNRESPONSIVE');
 }
 
 export function isPreconditionFailedRemoteError(error: unknown): boolean {


### PR DESCRIPTION
## 这次改了什么

### 摘要

给 mobile 端 device-link 增加 per-device「目标设备无响应」熔断，切断把整个 App 拖死的请求风暴放大链。

生产事故（2026-07-27）：桌面端进程活着（relay 心跳 / presence 全部正常）但内部卡死（DB gate 失败），依赖 DB 的 invoke 永不回包。手机端现状没有任何机制观测「目标设备不回包」这个维度 —— 三层在线判据（relay 连接态 / presence / 错误码派生）全部只看链路不看应答。后果层层放大：请求 30s 超时 → `withTransientRemoteRetry` 把 `INVOKE_TIMEOUT` 当瞬态重试 6 次（退避总计 6.75s，形同虚设）→ `scheduleIndex` 的 1+N 串行批次「失败即清坑」、多触发源反复全量重放 → 请求堆积 + 状态更新风暴 → **JS 线程停摆实测最长 114 秒**（停摆期间 30s 超时 timer 一并冻结，超时机制整体失效）→ 全 App 卡死，且 ConnectionBanner 恒不显示（它只看 relay status，本次恒 online）。

熔断设计：

- **失败信号只认 `INVOKE_TIMEOUT`**（等满超时无回包）。任何真实回包 —— 成功，或 `IPC_ERROR`/`CHANNEL_NOT_ALLOWED`/`REMOTE_DISABLED`/`ACCESS_REVOKED` 等目标设备正常应答的错误 —— 都重置计数并关熔断；`NOT_CONNECTED`/relay 层错误/发送前本地中止属本机链路问题，**不定论**（不计数也不重置），避免本机网络抖动污染判定。
- 连续 3 次超时 → open：该设备新请求**快速失败**（新错误码 `DEVICE_UNRESPONSIVE`，permanent 分类，不进瞬态重试）。
- half-open：退避窗口 10s 起 ×2、封顶 120s，放行**单个**探测请求（单飞）；真实回包即 close，再超时回 open 并加深退避。open 前积压的旧请求超时不加深退避，防止一波并发超时把窗口直接推到封顶。
- **所有时间判定用 `Date.now()` 差值，不依赖 setTimeout** —— JS 停摆时计时器不可信是本次事故的实证；停摆恢复后的第一个请求即可成为探测。

配套切断放大器：

- `scheduleIndex` 失败改**负缓存**（30s 内复用同一 rejected promise，不再「失败即清坑」让节流失效；`force` 穿透保留）；批循环命中 `DEVICE_UNRESPONSIVE` 立即 break 剩余 listRuns。
- mobile `requestTimeoutMs` 收紧到 15s（默认 30s 让用户干等半分钟、也把熔断凑齐信号的时间拖长一倍）；`sendInvoke` 按协议契约表 `INVOKE_TIMEOUT_OVERRIDES_MS` 给长执行通道（`desktop-cmd:run` 40s / `worktree:create` 60s 等）保留长超时，与桌面控制端同一张表，不误伤合法慢操作。
- rehydrate 跳过熔断 open 设备的 plan（不再无限重放）；熔断关闭时经 store 订阅补触发一次回填。
- `maker-shared`：`DEVICE_UNRESPONSIVE` 进 `PERMANENT_REMOTE_ERROR_MARKERS`（**必须**，否则 `withTransientRemoteRetry` 会把熔断快速失败再重试 6 次，熔断白做）+ 中文文案 + `isDeviceUnresponsiveRemoteError` helper。纯 additive。

最小降级 UI：

- 首页设备行：熔断 open 复用既有 `failed` 渲染路径（内部态映射，零新增视觉）。
- ConnectionBanner：新增 deviceUnresponsive 入参，relay 仍 online 时也能显示「电脑端未响应，正在自动重试」（i18n 四语言）。

### 变更类型

- [x] `feat` 新功能（防御性基础设施；行为上是缺陷修复的配套）
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：与 #712（desktop 退出挂死修复）同一事故的两端；#712 修故障源，本 PR 修放大链
- 本 PR 包含：熔断状态机 + store、DeviceLinkContext 四条 send* 路径接入、maker-shared permanent 分类（additive）、scheduleIndex 负缓存、超时收紧 + 长通道白名单、rehydrate 跳过、降级 UI 与四语言文案
- 明确不包含（follow-up）：`packages/device-link` 零改动（`DEVICE_UNRESPONSIVE` 收编进 `DeviceLinkErrorCode` 联合、pending map 观测等共享层方案）；被控端 `runInvoke` 对本地 handler 无超时（`apps/desktop/src/main/device-link/dispatch.ts`，DB gate 挂死时永不回 invoke-result 的根因侧，建议另立 issue）
- 用户可见变化：被控电脑无响应时，App 不再全局卡死转圈 —— 相关设备行进入失败态、顶部横幅提示「电脑端未响应，正在自动重试」，其余功能不受影响；电脑恢复后自动回填订阅与快照
- 是否存在 breaking change：无（`maker-shared` 改动纯 additive，desktop typecheck + 全量测试确认零桌面行为变化）

### 远程/手机/SSH 三形态结论

本 PR 即是「设备互联/手机」形态自身的健壮性修复：无新增 IPC channel 或推送事件（复用既有通道，无 allowlist 变更）；SSH 远程工作区不涉及（不触 workdir/agent 数据）；桌面端仅 maker-shared additive 标记，行为零变化。

### UI 变化

- 引用的设计规范：`DESIGN.md` 双模式交付门槛（颜色一律走语义 token，两种模式同时实现）——本次零新增颜色、零新增组件：横幅复用 `ConnectionBanner` 既有样式与既有 themed token，首页设备行复用既有 `failed` 态渲染路径；新增文案走 i18n 四语言体系并通过 `check:i18n-glossary`（「电脑」等术语沿用现有 catalog 译法）。无新的视觉/交互模式引入。

- 首页设备行：熔断 open 显示为既有的失败态（红圈），无新视觉。
- ConnectionBanner：新增「电脑端未响应，正在自动重试」横幅（relay 在线时也可出现）。复用既有 themed token，无新增颜色；Light/Dark 双模式按构造成立，**实机双模式目检未做**（如实说明）。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile test            → 254 files / 2426 passed（含新增 breaker 状态机 10 例、
                                        banner 可见性 5 例、scheduleIndex 负缓存/force/break 用例）
pnpm --filter mobile typecheck       → 通过
pnpm --filter @cindy/maker-shared exec vitest run → 48 files / 673 passed；typecheck 通过
pnpm --filter desktop typecheck      → 通过（零桌面行为变化佐证）
pnpm check:i18n-glossary             → 通过
pnpm test:unit（仓库根全量门禁）      → GATE_EXIT=0
```

### 手工验证

未做实机故障注入（需要一台可控的「进程活着但 DB gate 挂死」的桌面端配合）。熔断状态机的全部转换（连续超时开、真实回包关、half-open 单飞、退避加深、Date.now 驱动）由纯单测覆盖。

### 未执行的验证

- 实机端到端故障复现未做（原因如上）；建议合入后用 #712 前的僵死实例场景回归一次。
- Light/Dark 实机目检未做（复用既有 token 与组件，无新增颜色）。
- 用户显式动作绕过 open 直接探测：未实现（forceRefresh 路径无法低成本辨识来源；首个探测窗口仅 10s，手动刷新大概率自然落为探测请求；scheduleIndex 的 `force` 穿透负缓存已保留）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：误熔断 / 超时收紧

### 影响与回滚

- 影响范围：mobile 对被控设备的全部 device-link 请求路径。两个需要留意的行为变化：(1) 默认请求超时 30s→15s —— 长执行通道已按协议契约表白名单放宽，但若存在**未登记**的合法慢通道，会更早超时（表现为该操作报「暂时不可用」，不会崩）；(2) 真实的极端网络劣化（往返 >15s×3）理论上可触发误熔断，代价是 10s 后的单飞探测自动恢复，且横幅有明确提示。
- 纯 JS/TS，不触原生输入，**不改 runtime fingerprint、不触发冷更**。
- 回滚 / 降级方式：`git revert` 本 commit；无持久化状态（熔断状态全内存，重启即清）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（设计取舍在 breaker 文件头注释与本描述）
- [x] 已确认测试结果或说明未执行原因

