### PR TITLE
fix(scripts): GLOSSARY.md 同步校验忽略行尾差异

### DIFF
--- a/scripts/__tests__/glossary-rules.test.mjs
+++ b/scripts/__tests__/glossary-rules.test.mjs
@@ -29,7 +29,7 @@ import {
   makeSourceTermMatcher,
 } from '../shared/glossary-rules.mjs';
 import { validateAgainstSchema } from '../shared/json-schema-lite.mjs';
-import { renderGlossaryDoc } from '../shared/glossary-doc.mjs';
+import { normalizeDocEol, renderGlossaryDoc } from '../shared/glossary-doc.mjs';
 
 const ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 
@@ -342,9 +342,23 @@ test('glossary.json: locales 与 desktop SUPPORTED_LOCALES 一致', () => {
 test('GLOSSARY.md 与 glossary.json 同步', () => {
   const doc = fs.readFileSync(path.join(ROOT, 'i18n', 'GLOSSARY.md'), 'utf8');
   assert.equal(
-    doc,
-    renderGlossaryDoc(glossary),
+    normalizeDocEol(doc),
+    normalizeDocEol(renderGlossaryDoc(glossary)),
     'i18n/GLOSSARY.md 已过期,运行 pnpm i18n:glossary-doc 重新生成',
+  );
+});
+
+// 契约:同步校验只看内容,不看行尾。autocrlf=true 的 Windows checkout 会把
+// GLOSSARY.md 转成 CRLF,而渲染结果恒为 LF;若比较不归一化,门禁在 Windows 上
+// 必红且无法自愈(重新生成写 LF,下次 checkout 又变 CRLF)。
+test('GLOSSARY.md 同步校验对 CRLF 检出不误报', () => {
+  const rendered = renderGlossaryDoc(glossary);
+  const asCrlf = rendered.replace(/\n/g, '\r\n');
+  assert.notEqual(asCrlf, rendered, '前置条件:CRLF 版本应与 LF 版本逐字符不同');
+  assert.equal(
+    normalizeDocEol(asCrlf),
+    normalizeDocEol(rendered),
+    'CRLF 检出必须被判为同步——比较前要归一化行尾',
   );
 });
 

--- a/scripts/check-i18n-glossary.mjs
+++ b/scripts/check-i18n-glossary.mjs
@@ -40,7 +40,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { renderGlossaryDoc } from './shared/glossary-doc.mjs';
+import { normalizeDocEol, renderGlossaryDoc } from './shared/glossary-doc.mjs';
 import { validateAgainstSchema } from './shared/json-schema-lite.mjs';
 import {
   ELLIPSIS_LOCALES,
@@ -504,7 +504,7 @@ if (stale.length > 0) {
 // GLOSSARY.md 是给人和 AI 查阅的入口,过期比不存在更糟——大家会照着过期的表写文案。
 // 用与生成器完全相同的渲染函数比对,不做「差不多就行」的模糊校验。
 const docStale = fs.existsSync(DOC_PATH)
-  ? fs.readFileSync(DOC_PATH, 'utf8') !== renderGlossaryDoc(glossary)
+  ? normalizeDocEol(fs.readFileSync(DOC_PATH, 'utf8')) !== normalizeDocEol(renderGlossaryDoc(glossary))
   : true;
 if (docStale) {
   console.error(

--- a/scripts/generate-glossary-doc.mjs
+++ b/scripts/generate-glossary-doc.mjs
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { renderGlossaryDoc } from './shared/glossary-doc.mjs';
+import { normalizeDocEol, renderGlossaryDoc } from './shared/glossary-doc.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const GLOSSARY_PATH = path.join(repoRoot, 'i18n', 'glossary.json');
@@ -27,7 +27,7 @@ const rendered = renderGlossaryDoc(glossary);
 
 if (checkOnly) {
   const existing = fs.existsSync(DOC_PATH) ? fs.readFileSync(DOC_PATH, 'utf8') : '';
-  if (existing !== rendered) {
+  if (normalizeDocEol(existing) !== normalizeDocEol(rendered)) {
     console.error(
       '[generate-glossary-doc] ❌ i18n/GLOSSARY.md 与 i18n/glossary.json 不同步。\n' +
         '  运行 pnpm i18n:glossary-doc 重新生成。',

--- a/scripts/shared/glossary-doc.mjs
+++ b/scripts/shared/glossary-doc.mjs
@@ -40,6 +40,23 @@ function forbiddenLabel(entry) {
   return `${entry.text}（仅当英文含 ${entry.whenEn}）`;
 }
 
+/**
+ * 归一化行尾,供「已落盘的 GLOSSARY.md」与「渲染结果」比较时使用。
+ *
+ * renderGlossaryDoc 恒以 LF 收尾(见函数末尾的 join('\n')),但 .gitattributes
+ * 未给 *.md 固定 eol——`core.autocrlf=true` 的 Windows checkout(Git for Windows
+ * 安装时的默认选项)会把 GLOSSARY.md 转成 CRLF。此时逐字符比较会假报「文档过期」,
+ * 而且无法自愈:重新生成写出的是 LF,下次 checkout 又被转回 CRLF,门禁永远红。
+ *
+ * 与 apps/desktop/scripts/help-kb-guard.mjs 的 norm() 同款处理。放在共享模块里
+ * 是为了让三处比较点(本文件的消费方 generate-glossary-doc.mjs --check、
+ * check-i18n-glossary.mjs、glossary-rules.test.mjs)用同一份逻辑,不会出现某处
+ * 漏加归一化又把 Windows 拦回去。
+ */
+export function normalizeDocEol(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
 export function renderGlossaryDoc(glossary) {
   const terms = sortTerms(glossary.terms);
   const decided = terms.filter((t) => t.status === 'decided');


### PR DESCRIPTION
## 这次改了什么

### 摘要

在 `core.autocrlf=true` 的 Windows 开发机上（Git for Windows 安装时的默认选项），`i18n/GLOSSARY.md` 的同步门禁**必然失败，且开发者无法自行修复**。

`.gitattributes` 只给 `*.sh`、`*.mjs`、`*.sql`、`.githooks/**` 固定了 `text eol=lf`，没有覆盖 `*.md`。于是文档被 checkout 成 CRLF，而 `renderGlossaryDoc()` 恒以 LF 收尾（末尾 `join('\n')`），三处**严格字符串相等**比较因此全部判为「文档过期」：

| 比较点 | 触发命令 |
|---|---|
| `scripts/check-i18n-glossary.mjs` | `pnpm check:i18n-glossary`（CI 门禁） |
| `scripts/__tests__/glossary-rules.test.mjs` | `pnpm test:unit`（提交前门禁） |
| `scripts/generate-glossary-doc.mjs` | `--check` 模式 |

**无法自愈**是关键：错误信息提示跑 `pnpm i18n:glossary-doc` 重新生成，但生成器写出的是 LF，下次 checkout 又被转回 CRLF，门禁永远红。而 `git status` 全程干净（索引里是 LF），从 git 侧完全看不出问题 —— 很容易被误诊成「文档真的过期了」而去改 `glossary.json`。

结果是任何 `autocrlf=true` 的 Windows 开发者都无法通过 `AGENTS.md` 的提交前测试门禁。Linux/macOS CI 不受影响，所以问题只在 Windows 本地暴露。

### 修法

与 `apps/desktop/scripts/help-kb-guard.mjs:19-23` 的 `norm()` 完全一致：比较前归一化行尾。这也是 #673（`test(desktop): make markdown renderer contract CRLF-safe`）的思路。

归一化函数 `normalizeDocEol` 放进**已被三处共用**的 `scripts/shared/glossary-doc.mjs`，单点定义 —— 避免三处各写一份、其中某处漏加又把 Windows 拦回去。

另补一条契约测试固化「同步校验只看内容，不看行尾」，防止回归。

### 为什么没动 `.gitattributes`

给 `*.md`（或单独给 `i18n/GLOSSARY.md`）加 `text eol=lf` 是另一种可行策略，但：

- 它对**存量 checkout 不自动生效**，开发者需要 renormalize（`git rm --cached -r . && git reset --hard`）才能拿到 LF，属于要求所有人配合的一次性迁移
- 本改动对开发者的 git 配置**无任何假设**，装好就好使

两者不冲突，可以叠加。是否再加 `.gitattributes` 规则留给维护者决定，本 PR 不擅自扩大范围。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #706
- 本 PR 包含：`shared/glossary-doc.mjs` 新增 `normalizeDocEol` 导出；三处比较点改用它；一条 CRLF 契约回归测试
- 明确不包含：
  - `.gitattributes` 的 eol 规则（理由见上）
  - 不改变任何术语校验逻辑、渲染输出或 `GLOSSARY.md` 内容本身
- 用户可见变化：无（工程门禁改动）
- 是否存在 breaking change：无

### UI 变化

不涉及

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部 workspace PASS（50 个），退出码 0，无失败项
      其中新增用例：✔ GLOSSARY.md 同步校验对 CRLF 检出不误报
                    ✔ GLOSSARY.md 与 glossary.json 同步

pnpm --filter cindy run --if-present typecheck
结果：跳过 —— 仓库根 package（name: cindy）没有 typecheck script，
      且本次改动全是 .mjs 文件。按 AGENTS.md「没有 typecheck script 的
      package 该步自动跳过」。
```

**针对性验证** —— 把工作区的 `i18n/GLOSSARY.md` 实际转成 CRLF 后，三处门禁逐个跑：

```text
[1] pnpm check:i18n-glossary                 EXIT=0  ✅ 术语表 27 条已裁决 / 3 条待讨论，无新增违规
[2] node scripts/generate-glossary-doc.mjs --check   EXIT=0  ✅ GLOSSARY.md 与术语表同步
[3] node --test scripts/__tests__/glossary-rules.test.mjs  EXIT=0
```

修复前 [1] 与 [3] 在同样条件下均为 EXIT=1（报「文档过期」）。

**反向验证** —— 确认归一化没有削弱门禁。在 CRLF 基础上再篡改一处正文内容（`# Cindy 术语表` → `# Cindy 术语表(故意篡改)`），三处必须仍然失败：

```text
[1] pnpm check:i18n-glossary                 EXIT=1  ❌ i18n/GLOSSARY.md 与 i18n/glossary.json 不同步
[2] node scripts/generate-glossary-doc.mjs --check   EXIT=1  ❌ 不同步
[3] node --test scripts/__tests__/glossary-rules.test.mjs  EXIT=1  AssertionError: i18n/GLOSSARY.md 已过期
```

即：只忽略行尾，内容差异照常拦截。验证后文档已 `git checkout --` 恢复。

### 手工验证

不涉及：工程门禁改动，无运行时行为。

### 未执行的验证

- **`pnpm lint` 未通过，但与本 PR 无关**：失败项是 `packages/project-context/src/toc.ts:148` 的 `no-useless-escape`，该行来自 `bb3f71d0`（首次开源提交）即已存在；且各 package 的 lint 脚本是 `eslint src/`，**不覆盖仓库根的 `scripts/`**，即本 PR 改动的 4 个文件根本不在 lint 范围内。lint 也不在 `AGENTS.md` 的提交前门禁要求中。
- **macOS / Linux 上的实际执行**：本机为 Windows。归一化只做 `\r\n` → `\n`，在本就是 LF 的平台上是恒等变换，不改变既有行为；CI 会在 Linux 上覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅工程脚本与其测试，不进产物、不影响运行时。已分别考虑 macOS / Windows：Windows（CRLF checkout）由必红变为正确通过；macOS / Linux 本就是 LF，`replace(/\r\n/g, '\n')` 为恒等变换，行为不变。唯一的语义变化是「同步」判定不再区分行尾 —— 反向验证已确认内容差异仍被拦截。
- 回滚 / 降级方式：`git revert` 即可。无状态、无迁移、无协议约定；回滚后 Windows 恢复为原先的必红状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`normalizeDocEol` 带完整 doc comment，说明成因、无法自愈的原因与单点定义的理由）
- [x] 已确认测试结果或说明未执行原因
