### PR TITLE
fix(desktop): 灵动岛徽标吸附不再吞掉用户的自由宽度

### DIFF
--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -1957,8 +1957,8 @@ struct AgentIslandLayout: Equatable {
     let layoutScreenMetrics = hardwareNotchLayoutEnabled
       ? screenMetrics
       : screenMetrics.disablingHardwareNotchLayout()
-    // Only the compact hardware-notch layout reserves room for the badge; skip the font
-    // measurement on every other layout tick.
+    // Only the compact hardware-notch layout reserves room for the badge; every other
+    // layout tick skips the reservation entirely and passes 0.
     let compactBadgeWidth = !expanded && layoutScreenMetrics.hasNotch && hasSession
       ? PillBadge.intrinsicWidth(pillSnapshot: state.pillSnapshot, compact: true)
       : 0
@@ -2116,7 +2116,11 @@ struct AgentIslandLayout: Equatable {
     if desiredWidth <= hiddenThreshold {
       return hiddenWidth
     }
-    if desiredWidth <= basicWidth {
+    // Only widths at or below the badge-independent basic snap upgrade to the current
+    // (possibly wider) basic. Comparing against `basicWidth` would swallow free widths
+    // sitting between the two snap points, and `persistedCompactContentWidth` would then
+    // canonicalize them away — permanently overwriting the user's preference.
+    if desiredWidth <= baseBasicWidth {
       return basicWidth
     }
     return clampedWidth

--- a/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
+++ b/apps/desktop/src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
@@ -72,9 +72,12 @@ describe('getAgentIslandCompactBadgeWidth', () => {
     }
   });
 
-  it('单个计数走 22pt 最小宽度,active/total 才随位数变宽', () => {
+  it('单个计数在 22pt 最小宽度内不变宽,超出后同样按位数增长', () => {
     expect(getAgentIslandCompactBadgeWidth({ activeSessionCount: 0, sessionCount: 1 })).toBe(22);
     expect(getAgentIslandCompactBadgeWidth({ activeSessionCount: 0, sessionCount: 12 })).toBe(22);
+    // 位数够多时单个计数也会超过最小宽度 —— 公式对两种形态都是按 segment 长度算的。
+    expect(getAgentIslandCompactBadgeWidth({ activeSessionCount: 0, sessionCount: 1234 }))
+      .toBeGreaterThan(22);
     const oneDigit = getAgentIslandCompactBadgeWidth({ activeSessionCount: 1, sessionCount: 2 });
     const twoDigits = getAgentIslandCompactBadgeWidth({ activeSessionCount: 11, sessionCount: 12 });
     expect(twoDigits).toBeGreaterThan(oneDigit);
@@ -377,6 +380,47 @@ describe('snapAgentIslandCompactHardwareContentWidth', () => {
     // 计数回落后必须收缩回旧的 basic 宽度,不能停在为宽徽标撑开的宽度上。
     expect(narrow).toBe(persisted);
     expect(narrow).toBeLessThan(wide);
+  });
+
+  it('介于旧 basic 与新 basic 之间的自由宽度不被吞掉', () => {
+    // 回归:用户此前把岛拖到 280(旧 basic 264 之上,属自由宽度)。若按放大后的 basicWidth
+    // 判定,280 会被"升级"成 306,再被 native 的持久化归一化写回 264,永久覆盖用户偏好。
+    const notchWidth = 200;
+    const screenMetrics = { hasNotch: true, notchWidth };
+    const baseBasic = notchWidth + AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH;
+    for (const pillSnapshot of [
+      { activeSessionCount: 11, sessionCount: 12 },
+      { activeSessionCount: 123, sessionCount: 456 },
+    ]) {
+      const widened = getAgentIslandDefaultContentWidth({
+        expanded: false,
+        hasSession: true,
+        screenMetrics,
+        pillSnapshot,
+      });
+      for (const freeWidth of [baseBasic + 16, widened - 4]) {
+        expect(
+          snapAgentIslandCompactHardwareContentWidth({
+            desiredWidth: freeWidth,
+            clampedWidth: freeWidth,
+            maxWidth: 920,
+            hasSession: true,
+            screenMetrics,
+            pillSnapshot,
+          }),
+          `自由宽度 ${freeWidth} 被吸附掉了`,
+        ).toBe(freeWidth);
+      }
+      // 恰好停在旧 basic 吸附位的仍然跟随到新 basic。
+      expect(snapAgentIslandCompactHardwareContentWidth({
+        desiredWidth: baseBasic,
+        clampedWidth: baseBasic,
+        maxWidth: 920,
+        hasSession: true,
+        screenMetrics,
+        pillSnapshot,
+      })).toBe(widened);
+    }
   });
 
   it('不传 pillSnapshot 时吸附行为与旧实现完全一致', () => {

--- a/apps/desktop/src/shared/agentIsland.ts
+++ b/apps/desktop/src/shared/agentIsland.ts
@@ -455,8 +455,11 @@ export const AGENT_ISLAND_COMPACT_HARDWARE_IDLE_EXTRA_WIDTH = 64;
 export const AGENT_ISLAND_COMPACT_HARDWARE_ACTIVE_EXTRA_WIDTH = 64;
 export const AGENT_ISLAND_COMPACT_HARDWARE_HIDDEN_PULL_DISTANCE = 48;
 // Compact count-badge metrics, kept in sync with `PillBadge` in
-// `native/agent-island/macos-agent-island-helper.swift`. Only used to reserve carrier
-// width; the native helper still measures the real font for what it draws.
+// `native/agent-island/macos-agent-island-helper.swift`. These describe the *nominal*
+// width used to reserve carrier space — the native helper computes the same nominal
+// value (it does not measure the font for layout), while the badge itself is still
+// drawn by SwiftUI with the real font. The nominal value is an upper bound of what
+// gets drawn, so reserved space is never short.
 export const AGENT_ISLAND_COMPACT_BADGE_MIN_WIDTH = 22;
 export const AGENT_ISLAND_COMPACT_BADGE_ACTIVE_TOTAL_MIN_WIDTH = 30;
 export const AGENT_ISLAND_COMPACT_BADGE_CONTENT_INSET = 2;
@@ -636,7 +639,10 @@ export function snapAgentIslandCompactHardwareContentWidth(input: {
   if (input.desiredWidth <= hiddenThreshold) {
     return hiddenWidth;
   }
-  if (input.desiredWidth <= basicWidth) {
+  // 只有落在与徽标无关的 basic 吸附位及以下的宽度才升级到当前(可能更宽的)basic。
+  // 用 basicWidth 判定会把介于两个吸附点之间的自由宽度(如旧 basic 264 与 11/12 的 306
+  // 之间的 280)一并吞掉,再被 native 的持久化归一化改写成 264,永久覆盖用户偏好。
+  if (input.desiredWidth <= baseBasicWidth) {
     return basicWidth;
   }
   return input.clampedWidth;


### PR DESCRIPTION
## 这次改了什么

### 摘要

#698（灵动岛计数徽标两位数折行）合并后，review 又指出一处会**永久覆盖用户宽度偏好**的回归，外加三处注释 / 用例标题与合并后的实现不符。本 PR 收口这四条。

**主问题：落在两个吸附点之间的自由宽度被吞掉。** #698 让刻痕机的 basic 吸附宽度随徽标位数变宽（notchWidth 200 时 `11/12` → 306pt），而吸附判定写的是「`desiredWidth <= basicWidth` 就升级到 basic」。于是用户此前拖出来的 280pt（在旧 basic 264 之上，本属自由宽度）遇到 `11/12` 会被返回 306；接着 native 的 `persistedCompactContentWidth` 认出 306 是 badge-aware basic，把它归一化成 264 写回偏好 —— 用户的 280pt 就被永久覆盖了。

- 吸附判定改为只把**落在与徽标无关的 `baseBasicWidth` 及以下**的宽度升级到当前 basic，之上的一律走 `clampedWidth` 原样保留
- 停在旧 basic 吸附位的仍然跟随到新 basic（#698 要解决的场景不受影响），hidden 判定也不变
- TS（`snapAgentIslandCompactHardwareContentWidth`）与 Swift（`snappedCompactHardwareWidth`）两侧同步

**三处措辞修正**（都是 #698 最后一轮把字体测量改成标称公式后没同步）：

- `shared/agentIsland.ts` 常量注释仍写着 native 会测量真实字体 —— 实际布局预留两侧都用标称公式，只有绘制用真实字体
- Swift `AgentIslandLayout.compute` 里的注释仍写着 "skip the font measurement" —— 实际已经没有字体测量了
- 测试用例标题说「单个计数走 22pt 最小宽度，active/total 才随位数变宽」，但公式对两种形态都按 segment 长度算，单个计数位数够多时同样增长；标题改为与断言一致，并补了一条 `1234` 的断言

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#698 合并后的 review follow-up
- 本 PR 包含：吸附判定改用 `baseBasicWidth` 作为升级门槛；三处注释 / 用例标题修正；一个覆盖该回归的用例
- 明确不包含：#698 已交付的徽标防折行、carrier 宽度预留、持久化归一化本身都不改动
- 用户可见变化：刻痕机上用户手动拖出的、介于旧 basic 与徽标撑宽后 basic 之间的宽度，不再在计数变化时被吸附走并被覆盖
- 是否存在 breaking change：无

### UI 变化

不涉及：只改宽度吸附的分类阈值，不改任何视觉元素、样式或文案。#698 已交付的徽标外观不受影响。

- 引用的设计规范：不涉及 —— 无视觉 / 交互 / 文案变化，改动仅限宽度吸附的判定条件。

## 怎么验证的

### 自动验证

```text
swiftc -typecheck apps/desktop/native/agent-island/macos-agent-island-helper.swift
结果：通过（无输出）

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 退出码 0）

bash <git skill>/scripts/run-unit-gate.sh <worktree>   # 仓库根 pnpm test:unit 全量
结果：GATE_EXIT=0 通过

npx vitest run src/shared/__tests__/agentIslandCompactBadgeWidth.test.ts
结果：18 passed
```

新增用例「介于旧 basic 与新 basic 之间的自由宽度不被吞掉」覆盖 `11/12` 与 `123/456` 两组，每组各测 `baseBasic + 16` 与 `新 basic - 4` 两个自由宽度，并同时断言恰好停在旧 basic 吸附位的宽度仍然跟随到新 basic。

反向验证：把判定改回 `desiredWidth <= basicWidth` 时该用例会红（其余 17 个仍绿），确认它锁住的就是这条路径。

### 手工验证

不涉及 —— 见「未执行的验证」。

### 未执行的验证

- 刻痕机未实机验证：本机无刻痕屏，宽度吸附逻辑以单元测试与数值断言覆盖，未在真机上拖动验证。
- `persistedCompactContentWidth` 位于 Swift 侧，仓库没有接入 Swift 测试框架；本 PR 未改它，只是通过修正上游吸附判定让它不再收到被误升级的宽度。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅刻痕机 compact 灵动岛的宽度吸附判定（TS `shared/agentIsland.ts` 与 Swift helper 各一处条件）。非刻痕机走 `hasNotch` 早退分支，不受影响；不进入 mobile runtime fingerprint，不涉及 OTA / 冷更。
- 行为收窄方向：本 PR 只会让**更少**的宽度被吸附（从 `<= basicWidth` 收到 `<= baseBasicWidth`），不会新增吸附行为。
- 回滚 / 降级方式：单 commit、两处条件 + 注释 + 测试，`git revert` 即可，无数据或状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：缺陷修复，无新增行为或规则）
- [x] 已确认测试结果或说明未执行原因
