### PR TITLE
refactor(desktop): 重构输入框结构化列表

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
@@ -9,31 +9,33 @@ const chatInputSource = readFileSync(
 
 /**
  * ChatInput 列表接续接线契约:
- * - Shift/Alt+Enter 换行前先尝试列表接续;
+ * - Shift/Alt+Enter 优先处理结构化列表，再兼容旧纯文本列表;
  * - 普通 Enter 一律保持"发送"语义,绝不被列表接续拦截(2026-07 产品定案:
- *   Enter=发送的肌肉记忆优先,不做 Claude 式"列表内 Enter 继续列表");
+ *   Enter=发送的肌肉记忆优先);
  * - 守住 IME composition 边界。
- * 接续行为本身的用例见 lib/__tests__/composerListContinuation*.test.ts
- * (纯前缀匹配 + 真实编辑器)。
+ * 结构化与旧纯文本接续行为由各自的编辑器测试覆盖。
  */
 describe('ChatInput list continuation wiring contract', () => {
-  it('imports the shared helper from lib/composerListContinuation', () => {
-    expect(chatInputSource).toContain(
-      "import { applyListBackspace, applyListContinuation } from '@/lib/composerListContinuation';",
-    );
+  it('imports both structured-list commands and the legacy plain-text fallback', () => {
+    expect(chatInputSource).toContain('handleStructuredListBackspace');
+    expect(chatInputSource).toContain('handleStructuredListBreak');
+    expect(chatInputSource).toContain('applyListBackspace');
+    expect(chatInputSource).toContain('applyListContinuation');
   });
 
-  it('tries list continuation on Shift/Alt+Enter before the default hard break', () => {
+  it('tries structured and legacy continuation on Shift/Alt+Enter', () => {
     const block = extractBetween(
       chatInputSource,
-      '// Shift/Alt+Enter — markdown 列表接续',
+      '// Shift/Alt+Enter — split or exit a structured item.',
       '// Plain Enter keeps the existing queue semantics.',
     );
     expect(block).toContain('(event.shiftKey || event.altKey) &&');
     expect(block).toContain('!event.metaKey');
     expect(block).toContain('!event.ctrlKey');
     expect(block).toContain('!event.isComposing');
-    expect(block).toContain('if (applyListContinuation(view)) {');
+    expect(block).toContain(
+      'if (handleStructuredListBreak(view) || applyListContinuation(view)) {',
+    );
     // 非列表行必须放行给 ComposerHardBreak 默认换行
     expect(block).toContain('return false;');
   });
@@ -41,8 +43,8 @@ describe('ChatInput list continuation wiring contract', () => {
   it('intercepts bare Backspace for empty-item deletion, leaving modified backspace alone', () => {
     const block = extractBetween(
       chatInputSource,
-      '// Backspace — 空列表项整体回删',
-      '// Shift/Alt+Enter — markdown 列表接续',
+      '// Backspace — structured list items exit through the schema command;',
+      '// Shift/Alt+Enter — split or exit a structured item.',
     );
     expect(block).toContain("event.key === 'Backspace'");
     expect(block).toContain('!event.metaKey');
@@ -50,7 +52,7 @@ describe('ChatInput list continuation wiring contract', () => {
     expect(block).toContain('!event.altKey');
     expect(block).toContain('!event.shiftKey');
     expect(block).toContain('!event.isComposing');
-    expect(block).toContain('applyListBackspace(view)');
+    expect(block).toContain('(handleStructuredListBackspace(view) || applyListBackspace(view))');
   });
 
   it('never intercepts plain Enter — send semantics stay untouched', () => {
@@ -59,6 +61,7 @@ describe('ChatInput list continuation wiring contract', () => {
       '// Plain Enter keeps the existing queue semantics.',
       "void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');",
     );
+    expect(plainEnterBlock).not.toContain('handleStructuredListBreak');
     expect(plainEnterBlock).not.toContain('applyListContinuation');
   });
 

--- a/apps/desktop/src/renderer/__tests__/composerDocState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerDocState.test.ts
@@ -9,7 +9,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   composerDocIsEmpty,
   docContainsAtomChip,
+  docContainsStructuredList,
 } from '@/components/new-chat/composerDocState';
+import { ComposerBulletList, ComposerListItem } from '@/components/new-chat/ComposerListNodes';
 import { ComposerQuoteNode } from '@/components/new-chat/ComposerQuoteNode';
 import { MentionChipNode } from '@/components/new-chat/MentionChipNode';
 import { PastedTextChipNode } from '@/components/new-chat/PastedTextChipNode';
@@ -23,7 +25,16 @@ afterEach(() => {
 
 function makeEditor(): Editor {
   const editor = new Editor({
-    extensions: [Document, Paragraph, Text, MentionChipNode, PastedTextChipNode, ComposerQuoteNode],
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      ComposerListItem,
+      ComposerBulletList,
+      MentionChipNode,
+      PastedTextChipNode,
+      ComposerQuoteNode,
+    ],
     content: { type: 'doc', content: [{ type: 'paragraph', content: [] }] },
   });
   editors.push(editor);
@@ -42,6 +53,21 @@ describe('composerDocState', () => {
   it('treats a doc with text as non-empty', () => {
     const editor = makeEditor();
     editor.commands.insertContent('draft');
+    expect(composerDocIsEmpty(editor.state.doc)).toBe(false);
+  });
+
+  it('treats an empty structured list item as non-empty content', () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }],
+        },
+      ],
+    });
+    expect(docContainsStructuredList(editor.state.doc)).toBe(true);
     expect(composerDocIsEmpty(editor.state.doc)).toBe(false);
   });
 

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -135,7 +135,7 @@ describe('composer list document normalization', () => {
       content: [
         {
           type: 'orderedList',
-          attrs: { start: 2, marker: '、' },
+          attrs: { start: 2, marker: '、', separator: '' },
           content: [
             {
               type: 'listItem',
@@ -172,6 +172,34 @@ describe('composer list document normalization', () => {
             {
               type: 'listItem',
               content: [{ type: 'paragraph', content: [{ type: 'text', text: 'next' }] }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('preserves non-default ordered marker spacing', () => {
+    expect(plainTextToComposerDocument('1.   item\n2.\tsecond')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.', separator: '   ' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'item' }] }],
+            },
+          ],
+        },
+        {
+          type: 'orderedList',
+          attrs: { start: 2, marker: '.', separator: '\t' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'second' }] }],
             },
           ],
         },

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -231,6 +231,27 @@ describe('composer list document normalization', () => {
     });
   });
 
+  it('keeps multiline paragraphs intact while inside a fenced code block', () => {
+    const document = {
+      type: 'doc' as const,
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: '```' }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: '1. literal' },
+            { type: 'hardBreak' },
+            { type: 'text', text: '2. literal' },
+          ],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: '```' }] },
+      ],
+    };
+
+    const normalized = normalizeComposerDocumentJSON(document);
+    expect(normalized.content?.[1]).toEqual(document.content[1]);
+  });
+
   it('leaves existing structured content unchanged', () => {
     const document = {
       type: 'doc' as const,

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -87,6 +87,48 @@ describe('composer list document normalization', () => {
     });
   });
 
+  it('keeps non-contiguous ordered rows as separate lists', () => {
+    expect(
+      normalizeComposerDocumentJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: '1. first' },
+              { type: 'hardBreak' },
+              { type: 'text', text: '3. third' },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }],
+            },
+          ],
+        },
+        {
+          type: 'orderedList',
+          attrs: { start: 3, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'third' }] }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('leaves existing structured content unchanged', () => {
     const document = {
       type: 'doc' as const,

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeComposerDocumentJSON,
+  plainTextToComposerDocument,
+} from '@/lib/composerListDocument';
+
+describe('composer list document normalization', () => {
+  it('promotes plain ordered rows into one structured list', () => {
+    expect(plainTextToComposerDocument('1. first\n2. second')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'second' }] }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('keeps surrounding paragraphs and task bodies intact', () => {
+    expect(plainTextToComposerDocument('intro\n- [ ] todo\n- [x] done\noutro')).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'intro' }] },
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: '[ ] todo' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: '[x] done' }] }],
+            },
+          ],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'outro' }] },
+      ],
+    });
+  });
+
+  it('does not consume indented rows as top-level lists', () => {
+    expect(plainTextToComposerDocument('1. parent\n  - child')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'parent' }] }],
+            },
+          ],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: '  - child' }] },
+      ],
+    });
+  });
+
+  it('strips each ordered marker at its own width and ignores decimal text', () => {
+    expect(plainTextToComposerDocument('9. nine\n10. ten').content?.[0]?.content).toEqual([
+      {
+        type: 'listItem',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'nine' }] }],
+      },
+      {
+        type: 'listItem',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'ten' }] }],
+      },
+    ]);
+    expect(plainTextToComposerDocument('3.14159')).toEqual({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: '3.14159' }] }],
+    });
+  });
+
+  it('leaves existing structured content unchanged', () => {
+    const document = {
+      type: 'doc' as const,
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 3, marker: ')' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'existing' }] }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(normalizeComposerDocumentJSON(document)).toEqual(document);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -129,6 +129,28 @@ describe('composer list document normalization', () => {
     });
   });
 
+  it('keeps optional spaces after CJK ordered markers in item text', () => {
+    expect(plainTextToComposerDocument('2、项目\n3、 项目')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 2, marker: '、' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: '项目' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: ' 项目' }] }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('leaves existing structured content unchanged', () => {
     const document = {
       type: 'doc' as const,

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -28,6 +28,15 @@ describe('composer list document normalization', () => {
     });
   });
 
+  it('restores a generated seven-digit ordered continuation as one list', () => {
+    const document = plainTextToComposerDocument('999999. first\n1000000. second');
+    expect(document.content?.[0]).toMatchObject({
+      type: 'orderedList',
+      attrs: { start: 999999, marker: '.' },
+    });
+    expect(document.content?.[0]?.content).toHaveLength(2);
+  });
+
   it('keeps surrounding paragraphs and task bodies intact', () => {
     expect(plainTextToComposerDocument('intro\n- [ ] todo\n- [x] done\noutro')).toEqual({
       type: 'doc',

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -151,6 +151,58 @@ describe('composer list document normalization', () => {
     });
   });
 
+  it('preserves accepted unordered marker syntax and spacing', () => {
+    expect(plainTextToComposerDocument('+   item\n• next')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          attrs: { marker: '+', separator: '   ' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'item' }] }],
+            },
+          ],
+        },
+        {
+          type: 'bulletList',
+          attrs: { marker: '•', separator: ' ' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'next' }] }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('does not promote marker-shaped lines inside fenced code', () => {
+    expect(
+      plainTextToComposerDocument('before\n```js\n1. literal\n```\n2. real'),
+    ).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'before' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: '```js' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: '1. literal' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: '```' }] },
+        {
+          type: 'orderedList',
+          attrs: { start: 2, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'real' }] }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('leaves existing structured content unchanged', () => {
     const document = {
       type: 'doc' as const,

--- a/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListDocument.test.ts
@@ -37,6 +37,15 @@ describe('composer list document normalization', () => {
     expect(document.content?.[0]?.content).toHaveLength(2);
   });
 
+  it('restores a generated eight-digit ordered continuation as one list', () => {
+    const document = plainTextToComposerDocument('9999999. first\n10000000. second');
+    expect(document.content?.[0]).toMatchObject({
+      type: 'orderedList',
+      attrs: { start: 9999999, marker: '.' },
+    });
+    expect(document.content?.[0]?.content).toHaveLength(2);
+  });
+
   it('keeps surrounding paragraphs and task bodies intact', () => {
     expect(plainTextToComposerDocument('intro\n- [ ] todo\n- [x] done\noutro')).toEqual({
       type: 'doc',

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -48,7 +48,7 @@ const TestAtom = TiptapNode.create({
   },
 });
 
-function makeEditor(lines: string[], structuredLists = false): Editor {
+function makeEditor(lines: string[]): Editor {
   const content: Array<Record<string, unknown>> = [];
   lines.forEach((line, i) => {
     if (i > 0) content.push({ type: 'hardBreak' });
@@ -62,7 +62,7 @@ function makeEditor(lines: string[], structuredLists = false): Editor {
       Text,
       HardBreak,
       TestAtom,
-      ComposerListIndentDecoration.configure({ structuredLists }),
+      ComposerListIndentDecoration,
     ],
     content: { type: 'doc', content: [{ type: 'paragraph', content }] },
   });
@@ -82,9 +82,9 @@ afterEach(() => {
 });
 
 describe('buildListIndentDecorations', () => {
-  it('leaves promotable top-level rows to structured-list normalization', () => {
-    const ed = makeEditor(['1. one', '  - nested', '> quote'], true);
-    expect(indentSpans(ed)).toEqual(['  - nested', '> quote']);
+  it('keeps fallback decoration for rows that have not been promoted yet', () => {
+    const ed = makeEditor(['1. one', '  - nested', '> quote']);
+    expect(indentSpans(ed)).toEqual(['1. one', '  - nested', '> quote']);
   });
 
   it('builds paired hanging-indent variables without embedding user text', () => {
@@ -921,7 +921,7 @@ describe('wiring contract', () => {
       "import { ComposerListIndentDecoration } from './ComposerListIndentDecoration';",
     );
     expect(src).toMatch(
-      /CjkPunctDecoration,\s*\n\s*ComposerListIndentDecoration\.configure\(\{ structuredLists: true \}\),/,
+      /CjkPunctDecoration,\s*\n\s*ComposerListIndentDecoration,/,
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -48,7 +48,7 @@ const TestAtom = TiptapNode.create({
   },
 });
 
-function makeEditor(lines: string[]): Editor {
+function makeEditor(lines: string[], structuredLists = false): Editor {
   const content: Array<Record<string, unknown>> = [];
   lines.forEach((line, i) => {
     if (i > 0) content.push({ type: 'hardBreak' });
@@ -56,7 +56,14 @@ function makeEditor(lines: string[]): Editor {
   });
   editor = new Editor({
     element: document.createElement('div'),
-    extensions: [Document, Paragraph, Text, HardBreak, TestAtom, ComposerListIndentDecoration],
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      HardBreak,
+      TestAtom,
+      ComposerListIndentDecoration.configure({ structuredLists }),
+    ],
     content: { type: 'doc', content: [{ type: 'paragraph', content }] },
   });
   return editor;
@@ -75,6 +82,11 @@ afterEach(() => {
 });
 
 describe('buildListIndentDecorations', () => {
+  it('leaves promotable top-level rows to structured-list normalization', () => {
+    const ed = makeEditor(['1. one', '  - nested', '> quote'], true);
+    expect(indentSpans(ed)).toEqual(['  - nested', '> quote']);
+  });
+
   it('builds paired hanging-indent variables without embedding user text', () => {
     const latinStyle = listPrefixIndentStyle('2. ');
     expect(latinStyle).toContain('--composer-list-hang:1.8ch;');
@@ -908,7 +920,9 @@ describe('wiring contract', () => {
     expect(src).toContain(
       "import { ComposerListIndentDecoration } from './ComposerListIndentDecoration';",
     );
-    expect(src).toMatch(/CjkPunctDecoration,\s*\n\s*ComposerListIndentDecoration,/);
+    expect(src).toMatch(
+      /CjkPunctDecoration,\s*\n\s*ComposerListIndentDecoration\.configure\(\{ structuredLists: true \}\),/,
+    );
   });
 
   it('globals.css defines the indent class', () => {

--- a/apps/desktop/src/renderer/__tests__/composerQuoteDocument.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerQuoteDocument.test.ts
@@ -7,6 +7,7 @@ import HardBreak from '@tiptap/extension-hard-break';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ComposerQuoteNode } from '@/components/new-chat/ComposerQuoteNode';
 import {
+  COMPOSER_QUOTE_NODE_TYPE,
   appendQuoteToComposerDocument,
   composerHistoryEntryToDocument,
   prependLegacyQuotesToComposerDocument,
@@ -140,6 +141,36 @@ describe('composerQuoteDocument', () => {
             { type: 'text', text: 'a2' },
           ],
         },
+      ],
+    });
+  });
+
+  it('keeps a sibling list row separate when it follows a quote segment', () => {
+    expect(
+      quoteSegmentsToComposerDocument([
+        { kind: 'text', text: '- first' },
+        { kind: 'quote', quote: { text: 'quoted' } },
+        { kind: 'text', text: '- second' },
+      ]),
+    ).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: '- first' },
+            {
+              type: COMPOSER_QUOTE_NODE_TYPE,
+              attrs: {
+                text: 'quoted',
+                sourcePath: null,
+                startLine: null,
+                endLine: null,
+              },
+            },
+          ],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: '- second' }] },
       ],
     });
   });

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -15,7 +15,11 @@ import {
   handleStructuredListBreak,
   promoteTrailingPlainListParagraph,
 } from '@/components/new-chat/ComposerListNodes';
-import { serializeEditorContent } from '@/components/new-chat/composerContentSerialization';
+import {
+  serializeEditorContent,
+  serializeEditorSlice,
+} from '@/components/new-chat/composerContentSerialization';
+import { COMPOSER_QUOTE_NODE_TYPE } from '@/lib/composerQuoteDocument';
 
 const TestMentionChip = Node.create({
   name: 'mentionChip',
@@ -53,6 +57,24 @@ const TestPastedTextChip = Node.create({
   },
 });
 
+const TestQuote = Node.create({
+  name: COMPOSER_QUOTE_NODE_TYPE,
+  inline: true,
+  group: 'inline',
+  atom: true,
+  addAttributes() {
+    return {
+      text: { default: '' },
+      sourcePath: { default: null },
+      startLine: { default: null },
+      endLine: { default: null },
+    };
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', HTMLAttributes];
+  },
+});
+
 const editors: Editor[] = [];
 
 function makeEditor(content?: Record<string, unknown>): Editor {
@@ -68,6 +90,7 @@ function makeEditor(content?: Record<string, unknown>): Editor {
       HardBreak,
       TestMentionChip,
       TestPastedTextChip,
+      TestQuote,
     ],
     content: content ?? { type: 'doc', content: [{ type: 'paragraph' }] },
   });
@@ -108,7 +131,7 @@ describe('composer structured list input rules', () => {
     {
       typed: '• ',
       listType: 'bulletList',
-      attrs: {},
+      attrs: { marker: '•', separator: ' ' },
     },
     {
       typed: '1. ',
@@ -135,6 +158,23 @@ describe('composer structured list input rules', () => {
     expect(list?.attrs).toMatchObject(attrs);
     expect(list?.firstChild?.type.name).toBe('listItem');
     expect(list?.firstChild?.firstChild?.type.name).toBe('paragraph');
+  });
+
+  it('does not promote an indented marker to a top-level list', () => {
+    const editor = makeEditor();
+
+    typeThroughInputRules(editor, '  - ');
+
+    expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
+    expect(editor.state.doc.firstChild?.textContent).toBe('  - ');
+  });
+
+  it('reserves enough marker width for long ordered-list numbers', () => {
+    const editor = makeEditor();
+
+    typeThroughInputRules(editor, '123456. ');
+
+    expect(editor.view.dom.querySelector('ol')?.getAttribute('data-marker-digits')).toBe('6');
   });
 
   it.each([
@@ -171,7 +211,11 @@ describe('composer structured list input rules', () => {
         },
         {
           type: listType,
-          ...(Object.keys(attrs).length > 0 ? { attrs } : {}),
+          ...(listType === 'bulletList'
+            ? { attrs: { marker: '-', separator: ' ', ...attrs } }
+            : Object.keys(attrs).length > 0
+              ? { attrs }
+              : {}),
           content: [
             {
               type: 'listItem',
@@ -344,6 +388,7 @@ describe('composer structured list keyboard commands', () => {
     expect(editor.getJSON().content).toEqual([
       {
         type: 'bulletList',
+        attrs: { marker: '-', separator: ' ' },
         content: [
           {
             type: 'listItem',
@@ -412,6 +457,7 @@ describe('composer structured list keyboard commands', () => {
     expect(editor.getJSON().content).toEqual([
       {
         type: 'bulletList',
+        attrs: { marker: '-', separator: ' ' },
         content: [
           { type: 'listItem', content: [{ type: 'paragraph' }] },
           {
@@ -454,6 +500,7 @@ describe('composer structured list keyboard commands', () => {
     expect(editor.getJSON().content).toEqual([
       {
         type: 'bulletList',
+        attrs: { marker: '-', separator: ' ' },
         content: [
           {
             type: 'listItem',
@@ -635,6 +682,81 @@ describe('composer structured list serialization', () => {
     });
 
     expect(serializeEditorContent(editor).text).toBe('2、项目\n3、 项目');
+  });
+
+  it('keeps list markers when copying a selected structured fragment', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'second' }] }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const slice = editor.state.doc.slice(0, editor.state.doc.content.size);
+    expect(serializeEditorSlice(editor, slice)).toBe('1. first\n2. second');
+  });
+
+  it('preserves non-default bullet markers and spacing when sending', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          attrs: { marker: '+', separator: '   ' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'item' }] }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('+   item');
+  });
+
+  it('keeps a dragged quote inside its list item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'before ' },
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+                    { type: 'text', text: ' after' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe(
+      '- before > <!-- cindy-composer-quote -->\n  > quoted after',
+    );
   });
 
   it('preserves nested markers and projects atom ranges into wire offsets', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -19,6 +19,7 @@ import {
   serializeEditorContent,
   serializeEditorSlice,
 } from '@/components/new-chat/composerContentSerialization';
+import { parseChatQuoteSegments } from '@/lib/chatQuotes';
 import { COMPOSER_QUOTE_NODE_TYPE } from '@/lib/composerQuoteDocument';
 
 const TestMentionChip = Node.create({
@@ -620,6 +621,26 @@ describe('composer live plain-list promotion', () => {
     expect(serializeEditorContent(editor).text).toBe('3、 项目');
   });
 
+  it('does not promote a multiline paragraph as one list item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: '1. first' },
+            { type: 'hardBreak' },
+            { type: 'text', text: '2. second' },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(promoteTrailingPlainListParagraph(editor.view)).toBe(false);
+    expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
+  });
+
   it('promotes a trailing bullet-glyph row inserted outside input rules', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -780,9 +801,9 @@ describe('composer structured list serialization', () => {
                 {
                   type: 'paragraph',
                   content: [
-                    { type: 'text', text: 'before ' },
+                    { type: 'text', text: 'before' },
                     { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
-                    { type: 'text', text: ' after' },
+                    { type: 'text', text: 'after' },
                   ],
                 },
               ],
@@ -792,9 +813,15 @@ describe('composer structured list serialization', () => {
       ],
     });
 
-    expect(serializeEditorContent(editor).text).toBe(
-      '- before > <!-- cindy-composer-quote -->\n  > quoted after',
+    const serialized = serializeEditorContent(editor).text;
+    expect(serialized).toBe(
+      '- before\n  > <!-- cindy-composer-quote -->\n  > quoted\n  after',
     );
+    expect(parseChatQuoteSegments(serialized)).toEqual([
+      { kind: 'text', text: '- before' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+      { kind: 'text', text: '  after' },
+    ]);
   });
 
   it('preserves nested markers and projects atom ranges into wire offsets', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -147,6 +147,11 @@ describe('composer structured list input rules', () => {
       attrs: { start: 3, marker: ')' },
     },
     {
+      typed: '10000000. ',
+      listType: 'orderedList',
+      attrs: { start: 10000000, marker: '.' },
+    },
+    {
       typed: '2、',
       listType: 'orderedList',
       attrs: { start: 2, marker: '、' },
@@ -1184,6 +1189,40 @@ describe('composer structured list serialization', () => {
     ]);
   });
 
+  it('keeps a pasted quote-like chip separate from a list quote chip', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+                    {
+                      type: 'pastedTextChip',
+                      attrs: { text: '> pasted reply', display: '> pasted reply' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parseChatQuoteSegments(serializeEditorContent(editor).text)).toEqual([
+      { kind: 'text', text: '- ' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+      { kind: 'text', text: '  > pasted reply' },
+    ]);
+  });
+
   it('reuses a hard-break continuation line for a list quote chip', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -1216,6 +1255,40 @@ describe('composer structured list serialization', () => {
     expect(parseChatQuoteSegments(serialized)).toEqual([
       { kind: 'text', text: '- before' },
       { kind: 'quote', quote: { text: 'quoted' } },
+    ]);
+  });
+
+  it('does not duplicate an indented break after a list quote chip', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: 'after' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const serialized = serializeEditorContent(editor).text;
+    expect(serialized).not.toContain('\n  \n  ');
+    expect(parseChatQuoteSegments(serialized)).toEqual([
+      { kind: 'text', text: '- ' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+      { kind: 'text', text: '  after' },
     ]);
   });
 

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -317,6 +317,22 @@ describe('composer structured list input rules', () => {
     expect(editor.state.doc.firstChild?.textContent).toBe('```1. ');
   });
 
+  it('keeps hard-break markers literal after a preceding open fence', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: '```' }] },
+        { type: 'paragraph', content: [{ type: 'hardBreak' }] },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    typeThroughInputRules(editor, '1. ');
+
+    expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+    expect(editor.state.doc.lastChild?.textContent).toBe('1. ');
+  });
+
   it('keeps ordinary list markers literal after a preceding open fence', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -504,6 +520,33 @@ describe('composer structured list keyboard commands', () => {
     selectDocumentEnd(editor);
 
     expect(handleStructuredListBackspace(editor.view)).toBe(true);
+    expect(editor.getJSON().content).toEqual([{ type: 'paragraph' }]);
+  });
+
+  it('treats a whitespace-only CJK marker item as empty on break', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '、', separator: '' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: ' ' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBreak(editor.view)).toBe(true);
     expect(editor.getJSON().content).toEqual([{ type: 'paragraph' }]);
   });
 

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -1393,6 +1393,21 @@ describe('composer structured list serialization', () => {
     expect(serializeEditorContent(editor).text).toBe('2. ');
   });
 
+  it('preserves the trailing separator for a generated nine-digit marker', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 99999999, marker: '.' },
+          content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('99999999. ');
+  });
+
   it('keeps partial inline boundaries when copying one ordered-list item', () => {
     const editor = makeEditor({
       type: 'doc',

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -604,6 +604,22 @@ describe('composer live plain-list promotion', () => {
     expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
   });
 
+  it('keeps optional CJK spacing during live promotion', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: '3、 项目' }],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(promoteTrailingPlainListParagraph(editor.view)).toBe(true);
+    expect(serializeEditorContent(editor).text).toBe('3、 项目');
+  });
+
   it('promotes a trailing bullet-glyph row inserted outside input rules', () => {
     const editor = makeEditor({
       type: 'doc',

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -311,6 +311,22 @@ describe('composer structured list input rules', () => {
     expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
     expect(editor.state.doc.firstChild?.textContent).toBe('```1. ');
   });
+
+  it('keeps ordinary list markers literal after a preceding open fence', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: '```' }] },
+        { type: 'paragraph' },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    typeThroughInputRules(editor, '1. ');
+
+    expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+    expect(editor.state.doc.lastChild?.textContent).toBe('1. ');
+  });
 });
 
 describe('composer structured list keyboard commands', () => {
@@ -970,6 +986,44 @@ describe('composer structured list serialization', () => {
     expect(serializeEditorContent(editor).text).toBe('- first\n  second');
   });
 
+  it('indents multiline pasted-text chips inside a list item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'prefix ' },
+                    {
+                      type: 'pastedTextChip',
+                      attrs: { text: 'first\nsecond', display: 'Pasted text (2 lines)' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const serialized = serializeEditorContent(editor);
+    expect(serialized.text).toBe('- prefix first\n  second');
+    expect(serialized.pastedTextRanges).toEqual([
+      {
+        start: '- prefix '.length,
+        end: serialized.text.length,
+        display: 'Pasted text (2 lines)',
+      },
+    ]);
+  });
+
   it('keeps a dragged quote inside its list item', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -1130,6 +1184,41 @@ describe('composer structured list serialization', () => {
     ]);
   });
 
+  it('reuses a hard-break continuation line for a list quote chip', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'before' },
+                    { type: 'hardBreak' },
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const serialized = serializeEditorContent(editor).text;
+    expect(serialized).toBe(
+      '- before\n  > <!-- cindy-composer-quote -->\n  > quoted',
+    );
+    expect(parseChatQuoteSegments(serialized)).toEqual([
+      { kind: 'text', text: '- before' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+    ]);
+  });
+
   it('preserves indentation on an empty nested list item', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -1265,6 +1354,68 @@ describe('composer structured list serialization', () => {
     );
 
     expect(serializeEditorSlice(editor, slice)).toBe('2. eco');
+  });
+
+  it('adjusts the nested ordered list that contains the copied selection start', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'outer-first' }] },
+                {
+                  type: 'orderedList',
+                  attrs: { start: 5, marker: '.' },
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [
+                        { type: 'paragraph', content: [{ type: 'text', text: 'nested-first' }] },
+                      ],
+                    },
+                    {
+                      type: 'listItem',
+                      content: [
+                        { type: 'paragraph', content: [{ type: 'text', text: 'nested-second' }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'outer-second' }] },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    let nestedSecondPosition = 0;
+    let outerSecondPosition = 0;
+    editor.state.doc.descendants((node, position) => {
+      if (node.isText && node.text === 'nested-second') nestedSecondPosition = position;
+      if (node.isText && node.text === 'outer-second') outerSecondPosition = position;
+    });
+    editor.commands.setTextSelection({
+      from: nestedSecondPosition,
+      to: outerSecondPosition + 'outer-second'.length,
+    });
+    const slice = editor.state.doc.slice(
+      editor.state.selection.from,
+      editor.state.selection.to,
+    );
+
+    const copied = serializeEditorSlice(editor, slice);
+    expect(copied).toContain('6. nested-second');
+    expect(copied).not.toContain('1. nested-second');
   });
 
   it('preserves nested markers and projects atom ranges into wire offsets', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -5,7 +5,6 @@ import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import HardBreak from '@tiptap/extension-hard-break';
-import { Fragment, Slice } from '@tiptap/pm/model';
 import { TextSelection } from '@tiptap/pm/state';
 
 import {
@@ -14,9 +13,9 @@ import {
   ComposerOrderedList,
   handleStructuredListBackspace,
   handleStructuredListBreak,
+  isTrailingEmptyTopLevelParagraph,
   promoteTrailingPlainListParagraph,
 } from '@/components/new-chat/ComposerListNodes';
-import { plainTextToComposerDocument } from '@/lib/composerListDocument';
 import {
   serializeEditorContent,
   serializeEditorSlice,
@@ -292,6 +291,24 @@ describe('composer structured list input rules', () => {
     expect(list?.type.name).toBe('orderedList');
     expect(list?.attrs).toMatchObject({ start: 1, marker: '.' });
     expect(list?.lastChild?.textContent).toBe('12e21ed');
+  });
+
+  it('keeps markers literal after a hard break inside a fenced code block', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: '```' }, { type: 'hardBreak' }],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    typeThroughInputRules(editor, '1. ');
+
+    expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
+    expect(editor.state.doc.firstChild?.textContent).toBe('```1. ');
   });
 });
 
@@ -593,6 +610,22 @@ describe('composer structured list keyboard commands', () => {
 });
 
 describe('composer live plain-list promotion', () => {
+  it('recognizes only the trailing empty top-level paragraph as a list-paste boundary', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'before' }] },
+        { type: 'paragraph' },
+      ],
+    });
+
+    editor.commands.setTextSelection(2);
+    expect(isTrailingEmptyTopLevelParagraph(editor.view)).toBe(false);
+
+    selectDocumentEnd(editor);
+    expect(isTrailingEmptyTopLevelParagraph(editor.view)).toBe(true);
+  });
+
   it('promotes a trailing pasted row beside an existing structured list', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -883,6 +916,34 @@ describe('composer structured list serialization', () => {
     expect(serializeEditorContent(editor).text).toBe('-\tparent\n    - child');
   });
 
+  it('indents hard-break continuation lines inside a list item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'first' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: 'second' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('- first\n  second');
+  });
+
   it('keeps a dragged quote inside its list item', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -939,6 +1000,56 @@ describe('composer structured list serialization', () => {
     expect(parseChatQuoteSegments(serialized)).toEqual([
       { kind: 'text', text: 'parent\n  - child' },
       { kind: 'quote', quote: { text: 'quoted' } },
+    ]);
+  });
+
+  it('indents a restored quote after a no-space CJK list marker', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: '  2、项目' }] },
+        {
+          type: 'paragraph',
+          content: [{ type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } }],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe(
+      'parent\n  2、项目\n    > <!-- cindy-composer-quote -->\n    > quoted',
+    );
+  });
+
+  it('keeps quote-like reply text separate from a list quote chip', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+                    { type: 'text', text: '> reply' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const serialized = serializeEditorContent(editor).text;
+    expect(parseChatQuoteSegments(serialized)).toEqual([
+      { kind: 'text', text: '- ' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+      { kind: 'text', text: '  > reply' },
     ]);
   });
 
@@ -1043,27 +1154,40 @@ describe('composer structured list serialization', () => {
     expect(serializeEditorContent(editor).text).toBe('2. ');
   });
 
-  it('inserts normalized list blocks at a non-terminal selection', () => {
+  it('keeps partial inline boundaries when copying one ordered-list item', () => {
     const editor = makeEditor({
       type: 'doc',
       content: [
-        { type: 'paragraph', content: [{ type: 'text', text: 'before' }] },
-        { type: 'paragraph', content: [{ type: 'text', text: 'after' }] },
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'second' }] }],
+            },
+          ],
+        },
       ],
     });
-    editor.commands.setTextSelection(2);
-    const replacement = plainTextToComposerDocument('1. first\n2. second').content!.map((node) =>
-      editor.state.schema.nodeFromJSON(node),
+    let secondTextPosition = 0;
+    editor.state.doc.descendants((node, position) => {
+      if (node.isText && node.text === 'second') secondTextPosition = position;
+    });
+    editor.commands.setTextSelection({
+      from: secondTextPosition + 1,
+      to: secondTextPosition + 4,
+    });
+    const slice = editor.state.doc.slice(
+      editor.state.selection.from,
+      editor.state.selection.to,
     );
-    const tr = editor.state.tr.replaceSelection(new Slice(Fragment.from(replacement), 0, 0));
-    editor.view.dispatch(tr);
 
-    expect(editor.state.doc.textContent).toContain('first');
-    expect(editor.state.doc.textContent).toContain('second');
-    expect(editor.state.doc.childCount).toBeGreaterThan(2);
-    expect(editor.state.doc.content.content.some((node) => node.type.name === 'orderedList')).toBe(
-      true,
-    );
+    expect(serializeEditorSlice(editor, slice)).toBe('2. eco');
   });
 
   it('preserves nested markers and projects atom ranges into wire offsets', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -106,6 +106,11 @@ describe('composer structured list input rules', () => {
       attrs: {},
     },
     {
+      typed: '• ',
+      listType: 'bulletList',
+      attrs: {},
+    },
+    {
       typed: '1. ',
       listType: 'orderedList',
       attrs: { start: 1, marker: '.' },
@@ -548,6 +553,23 @@ describe('composer live plain-list promotion', () => {
 
     expect(promoteTrailingPlainListParagraph(editor.view)).toBe(false);
     expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+  });
+
+  it('promotes a trailing bullet-glyph row inserted outside input rules', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: '• item' }],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(promoteTrailingPlainListParagraph(editor.view)).toBe(true);
+    expect(editor.state.doc.firstChild?.type.name).toBe('bulletList');
+    expect(editor.state.doc.firstChild?.firstChild?.textContent).toBe('item');
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -1,0 +1,701 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { Editor, Node } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import HardBreak from '@tiptap/extension-hard-break';
+import { TextSelection } from '@tiptap/pm/state';
+
+import {
+  ComposerBulletList,
+  ComposerListItem,
+  ComposerOrderedList,
+  handleStructuredListBackspace,
+  handleStructuredListBreak,
+  promoteTrailingPlainListParagraph,
+} from '@/components/new-chat/ComposerListNodes';
+import { serializeEditorContent } from '@/components/new-chat/composerContentSerialization';
+
+const TestMentionChip = Node.create({
+  name: 'mentionChip',
+  inline: true,
+  group: 'inline',
+  atom: true,
+  addAttributes() {
+    return {
+      kind: { default: 'file' },
+      label: { default: '' },
+      path: { default: '' },
+      titled: { default: false },
+      agentText: { default: undefined },
+      agentTextTruncated: { default: undefined },
+    };
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', HTMLAttributes];
+  },
+});
+
+const TestPastedTextChip = Node.create({
+  name: 'pastedTextChip',
+  inline: true,
+  group: 'inline',
+  atom: true,
+  addAttributes() {
+    return {
+      text: { default: '' },
+      display: { default: '' },
+    };
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', HTMLAttributes];
+  },
+});
+
+const editors: Editor[] = [];
+
+function makeEditor(content?: Record<string, unknown>): Editor {
+  const editor = new Editor({
+    element: document.createElement('div'),
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      ComposerListItem,
+      ComposerBulletList,
+      ComposerOrderedList,
+      HardBreak,
+      TestMentionChip,
+      TestPastedTextChip,
+    ],
+    content: content ?? { type: 'doc', content: [{ type: 'paragraph' }] },
+  });
+  editors.push(editor);
+  return editor;
+}
+
+function typeThroughInputRules(editor: Editor, text: string): void {
+  for (const character of text) {
+    const { from, to } = editor.state.selection;
+    const handled =
+      editor.view.someProp('handleTextInput', (handler) =>
+        handler(editor.view, from, to, character, () =>
+          editor.state.tr.insertText(character, from, to),
+        ),
+      ) === true;
+    if (!handled) {
+      editor.view.dispatch(editor.state.tr.insertText(character, from, to));
+    }
+  }
+}
+
+function selectDocumentEnd(editor: Editor): void {
+  editor.view.dispatch(editor.state.tr.setSelection(TextSelection.atEnd(editor.state.doc)));
+}
+
+afterEach(() => {
+  for (const editor of editors.splice(0)) editor.destroy();
+});
+
+describe('composer structured list input rules', () => {
+  it.each([
+    {
+      typed: '- ',
+      listType: 'bulletList',
+      attrs: {},
+    },
+    {
+      typed: '1. ',
+      listType: 'orderedList',
+      attrs: { start: 1, marker: '.' },
+    },
+    {
+      typed: '3) ',
+      listType: 'orderedList',
+      attrs: { start: 3, marker: ')' },
+    },
+    {
+      typed: '2、',
+      listType: 'orderedList',
+      attrs: { start: 2, marker: '、' },
+    },
+  ])('turns $typed into a $listType node', ({ typed, listType, attrs }) => {
+    const editor = makeEditor();
+
+    typeThroughInputRules(editor, typed);
+
+    const list = editor.state.doc.firstChild;
+    expect(list?.type.name).toBe(listType);
+    expect(list?.attrs).toMatchObject(attrs);
+    expect(list?.firstChild?.type.name).toBe('listItem');
+    expect(list?.firstChild?.firstChild?.type.name).toBe('paragraph');
+  });
+
+  it.each([
+    {
+      typed: '- ',
+      listType: 'bulletList',
+      attrs: {},
+    },
+    {
+      typed: '1. ',
+      listType: 'orderedList',
+      attrs: { start: 1, marker: '.' },
+    },
+  ])(
+    'turns $typed after a hard break into the same structured $listType',
+    ({ typed, listType, attrs }) => {
+      const editor = makeEditor({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'intro' }, { type: 'hardBreak' }],
+          },
+        ],
+      });
+      selectDocumentEnd(editor);
+
+      typeThroughInputRules(editor, typed);
+
+      expect(editor.getJSON().content).toEqual([
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'intro' }],
+        },
+        {
+          type: listType,
+          ...(Object.keys(attrs).length > 0 ? { attrs } : {}),
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph' }],
+            },
+          ],
+        },
+      ]);
+    },
+  );
+
+  it('turns a marker after an empty hard-break paragraph following a list into structure', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'item' }] }],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'hardBreak' }],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    typeThroughInputRules(editor, '1. 12e21ed');
+
+    const list = editor.state.doc.lastChild;
+    expect(list?.type.name).toBe('orderedList');
+    expect(list?.attrs).toMatchObject({ start: 1, marker: '.' });
+    expect(list?.lastChild?.textContent).toBe('12e21ed');
+  });
+});
+
+describe('composer structured list keyboard commands', () => {
+  it('splits a non-empty item and exits from the empty continuation item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'first' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBreak(editor.view)).toBe(true);
+    expect(editor.state.doc.firstChild?.childCount).toBe(2);
+    expect(editor.state.selection.$from.parent.type.name).toBe('paragraph');
+    expect(editor.state.selection.$from.parent.content.size).toBe(0);
+
+    expect(handleStructuredListBreak(editor.view)).toBe(true);
+    expect(editor.getJSON().content).toEqual([
+      {
+        type: 'orderedList',
+        attrs: { start: 1, marker: '.' },
+        content: [
+          {
+            type: 'listItem',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'first' }],
+              },
+            ],
+          },
+        ],
+      },
+      { type: 'paragraph' },
+    ]);
+  });
+
+  it('lifts an empty list item on Backspace', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph' }],
+            },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBackspace(editor.view)).toBe(true);
+    expect(editor.getJSON().content).toEqual([{ type: 'paragraph' }]);
+  });
+
+  it('does not lift a non-empty item from a later empty paragraph', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'kept content' }],
+                },
+                { type: 'paragraph' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBackspace(editor.view)).toBe(false);
+    expect(editor.state.doc.firstChild?.type.name).toBe('bulletList');
+  });
+
+  it('continues task syntax as an unchecked item and exits from an empty task', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: '[x] completed' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBreak(editor.view)).toBe(true);
+    const list = editor.state.doc.firstChild;
+    expect(list?.childCount).toBe(2);
+    expect(list?.lastChild?.textContent).toBe('[ ] ');
+    expect(serializeEditorContent(editor).text).toBe('- [x] completed\n- [ ]');
+
+    expect(handleStructuredListBreak(editor.view)).toBe(true);
+    expect(editor.getJSON().content).toEqual([
+      {
+        type: 'bulletList',
+        content: [
+          {
+            type: 'listItem',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: '[x] completed' }],
+              },
+            ],
+          },
+        ],
+      },
+      { type: 'paragraph' },
+    ]);
+  });
+
+  it('removes an empty task prefix before lifting on Backspace', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: '[ ] ' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBackspace(editor.view)).toBe(true);
+    expect(editor.getJSON().content).toEqual([{ type: 'paragraph' }]);
+  });
+
+  it('does not add a task prefix when splitting before the task marker', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: '[x] hello' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    editor.commands.setTextSelection(3);
+
+    expect(handleStructuredListBreak(editor.view)).toBe(true);
+    expect(editor.getJSON().content).toEqual([
+      {
+        type: 'bulletList',
+        content: [
+          { type: 'listItem', content: [{ type: 'paragraph' }] },
+          {
+            type: 'listItem',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: '[x] hello' }] }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('does not lift earlier content when the current paragraph only has a task prefix', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'kept' }],
+                },
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: '[ ] ' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBreak(editor.view)).toBe(false);
+    expect(handleStructuredListBackspace(editor.view)).toBe(false);
+    expect(editor.getJSON().content).toEqual([
+      {
+        type: 'bulletList',
+        content: [
+          {
+            type: 'listItem',
+            content: [
+              { type: 'paragraph', content: [{ type: 'text', text: 'kept' }] },
+              { type: 'paragraph', content: [{ type: 'text', text: '[ ] ' }] },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('returns from an empty paragraph after a list to the final item on Backspace', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'first' }],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'second' }],
+                },
+              ],
+            },
+          ],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(handleStructuredListBackspace(editor.view)).toBe(true);
+    expect(editor.state.doc.childCount).toBe(1);
+    expect(editor.state.doc.firstChild?.childCount).toBe(2);
+    expect(editor.state.selection.$from.parent.textContent).toBe('second');
+    expect(editor.state.selection.$from.parentOffset).toBe('second'.length);
+  });
+});
+
+describe('composer live plain-list promotion', () => {
+  it('promotes a trailing pasted row beside an existing structured list', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: '1. 12e21ed' }],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(promoteTrailingPlainListParagraph(editor.view)).toBe(true);
+
+    const list = editor.state.doc.lastChild;
+    expect(list?.type.name).toBe('orderedList');
+    expect(list?.lastChild?.textContent).toBe('12e21ed');
+    expect(editor.state.doc.textContent).not.toContain('1. 12e21ed');
+  });
+
+  it('leaves decimal text as a paragraph', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: '3.14159' }],
+        },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(promoteTrailingPlainListParagraph(editor.view)).toBe(false);
+    expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+  });
+});
+
+describe('composer structured list serialization', () => {
+  it('uses the full parent marker width for nested list indentation', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 10, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'parent' }],
+                },
+                {
+                  type: 'bulletList',
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [
+                        {
+                          type: 'paragraph',
+                          content: [{ type: 'text', text: 'child' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('10. parent\n    - child');
+  });
+
+  it('preserves nested markers and projects atom ranges into wire offsets', () => {
+    const href = 'cindy://session/session-a?message=message-a';
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'parent' }],
+                },
+                {
+                  type: 'orderedList',
+                  attrs: { start: 3, marker: ')' },
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [
+                        {
+                          type: 'paragraph',
+                          content: [
+                            { type: 'text', text: 'open ' },
+                            {
+                              type: 'mentionChip',
+                              attrs: {
+                                kind: 'session',
+                                label: 'message',
+                                path: href,
+                                titled: false,
+                              },
+                            },
+                            { type: 'text', text: ' then ' },
+                            {
+                              type: 'pastedTextChip',
+                              attrs: {
+                                text: 'pasted text',
+                                display: 'Pasted text (1 line)',
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'read ' },
+                    {
+                      type: 'mentionChip',
+                      attrs: {
+                        kind: 'file',
+                        label: 'guide.md',
+                        path: 'docs/guide.md',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const serialized = serializeEditorContent(editor);
+    expect(serialized.text).toBe(
+      `- parent\n  3) open ${href} then pasted text\n- read @docs/guide.md`,
+    );
+    expect(serialized.mentions).toEqual([
+      { type: 'file', name: 'guide.md', path: 'docs/guide.md' },
+    ]);
+
+    const referenceStart = serialized.text.indexOf(href);
+    expect(serialized.agentReferences).toEqual([
+      {
+        kind: 'message',
+        start: referenceStart,
+        end: referenceStart + href.length,
+        href,
+        sessionId: 'session-a',
+        messageClientId: 'message-a',
+      },
+    ]);
+    expect(
+      serialized.text.slice(serialized.agentReferences[0].start, serialized.agentReferences[0].end),
+    ).toBe(href);
+
+    const pastedStart = serialized.text.indexOf('pasted text');
+    expect(serialized.pastedTextRanges).toEqual([
+      {
+        start: pastedStart,
+        end: pastedStart + 'pasted text'.length,
+        display: 'Pasted text (1 line)',
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -5,7 +5,7 @@ import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import HardBreak from '@tiptap/extension-hard-break';
-import { TextSelection } from '@tiptap/pm/state';
+import { AllSelection, TextSelection } from '@tiptap/pm/state';
 
 import {
   ComposerBulletList,
@@ -784,6 +784,19 @@ describe('composer live plain-list promotion', () => {
     expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
   });
 
+  it('recognizes a whole-document selection as a top-level block selection', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'first' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'second' }] },
+      ],
+    });
+    editor.view.dispatch(editor.state.tr.setSelection(new AllSelection(editor.state.doc)));
+
+    expect(isTopLevelBlockSelection(editor.view)).toBe(true);
+  });
+
   it('promotes a trailing bullet-glyph row inserted outside input rules', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -1485,6 +1498,41 @@ describe('composer structured list serialization', () => {
     );
 
     expect(serializeEditorSlice(editor, slice)).toBe('2. eco');
+  });
+
+  it('keeps the visible ordinal when copying an empty ordered-list item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph' }],
+            },
+          ],
+        },
+      ],
+    });
+    let emptyParagraphPosition = 0;
+    editor.state.doc.descendants((node, position) => {
+      if (node.type.name === 'paragraph' && node.content.size === 0) {
+        emptyParagraphPosition = position;
+      }
+    });
+    editor.commands.setTextSelection(emptyParagraphPosition + 1);
+    const slice = editor.state.doc.slice(
+      emptyParagraphPosition,
+      emptyParagraphPosition + 1,
+    );
+
+    expect(serializeEditorSlice(editor, slice)).toBe('2. ');
   });
 
   it('adjusts the nested ordered list that contains the copied selection start', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -5,6 +5,7 @@ import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import HardBreak from '@tiptap/extension-hard-break';
+import { Fragment, Slice } from '@tiptap/pm/model';
 import { TextSelection } from '@tiptap/pm/state';
 
 import {
@@ -15,6 +16,7 @@ import {
   handleStructuredListBreak,
   promoteTrailingPlainListParagraph,
 } from '@/components/new-chat/ComposerListNodes';
+import { plainTextToComposerDocument } from '@/lib/composerListDocument';
 import {
   serializeEditorContent,
   serializeEditorSlice,
@@ -168,6 +170,38 @@ describe('composer structured list input rules', () => {
 
     expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
     expect(editor.state.doc.firstChild?.textContent).toBe('  - ');
+  });
+
+  it.each(['0. ', '0001. '])('keeps %s as plain text', (typed) => {
+    const editor = makeEditor();
+
+    typeThroughInputRules(editor, typed);
+
+    expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
+    expect(editor.state.doc.firstChild?.textContent).toBe(typed);
+  });
+
+  it('does not join an explicitly non-contiguous ordered marker with the preceding list', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }] }],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    typeThroughInputRules(editor, '3. ');
+
+    expect(editor.state.doc.childCount).toBe(2);
+    expect(editor.state.doc.firstChild?.type.name).toBe('orderedList');
+    expect(editor.state.doc.firstChild?.childCount).toBe(1);
+    expect(editor.state.doc.lastChild?.type.name).toBe('orderedList');
+    expect(editor.state.doc.lastChild?.attrs.start).toBe(3);
   });
 
   it('reserves enough marker width for long ordered-list numbers', () => {
@@ -822,6 +856,105 @@ describe('composer structured list serialization', () => {
       { kind: 'quote', quote: { text: 'quoted' } },
       { kind: 'text', text: '  after' },
     ]);
+  });
+
+  it('does not duplicate restored continuation indentation after a list quote', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+                    { type: 'text', text: '  after' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe(
+      '- \n  > <!-- cindy-composer-quote -->\n  > quoted\n  after',
+    );
+  });
+
+  it('keeps adjacent list quote chips as separate quote segments', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'first' } },
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'second' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const serialized = serializeEditorContent(editor).text;
+    expect(parseChatQuoteSegments(serialized)).toEqual([
+      { kind: 'text', text: '- ' },
+      { kind: 'quote', quote: { text: 'first' } },
+      { kind: 'quote', quote: { text: 'second' } },
+    ]);
+  });
+
+  it('preserves an empty structured list item separator at the end of serialized text', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 2, marker: '.' },
+          content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('2. ');
+  });
+
+  it('inserts normalized list blocks at a non-terminal selection', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'before' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'after' }] },
+      ],
+    });
+    editor.commands.setTextSelection(2);
+    const replacement = plainTextToComposerDocument('1. first\n2. second').content!.map((node) =>
+      editor.state.schema.nodeFromJSON(node),
+    );
+    const tr = editor.state.tr.replaceSelection(new Slice(Fragment.from(replacement), 0, 0));
+    editor.view.dispatch(tr);
+
+    expect(editor.state.doc.textContent).toContain('first');
+    expect(editor.state.doc.textContent).toContain('second');
+    expect(editor.state.doc.childCount).toBeGreaterThan(2);
+    expect(editor.state.doc.content.content.some((node) => node.type.name === 'orderedList')).toBe(
+      true,
+    );
   });
 
   it('preserves nested markers and projects atom ranges into wire offsets', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -782,6 +782,36 @@ describe('composer structured list serialization', () => {
     expect(serializeEditorSlice(editor, slice)).toBe('1. first\n2. second');
   });
 
+  it('keeps the original ordinal when copying from the middle of an ordered list', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'second' }] }],
+            },
+          ],
+        },
+      ],
+    });
+    let secondTextPosition = 0;
+    editor.state.doc.descendants((node, position) => {
+      if (node.isText && node.text === 'second') secondTextPosition = position;
+    });
+    editor.commands.setTextSelection(secondTextPosition + 1);
+    const slice = editor.state.doc.slice(secondTextPosition, editor.state.doc.content.size);
+
+    expect(serializeEditorSlice(editor, slice)).toBe('2. second');
+  });
+
   it('preserves non-default bullet markers and spacing when sending', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -822,6 +852,37 @@ describe('composer structured list serialization', () => {
     expect(serializeEditorContent(editor).text).toBe('1.\titem');
   });
 
+  it('expands tab separators when indenting nested list content', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          attrs: { marker: '-', separator: '\t' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
+                {
+                  type: 'bulletList',
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'child' }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('-\tparent\n    - child');
+  });
+
   it('keeps a dragged quote inside its list item', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -856,6 +917,54 @@ describe('composer structured list serialization', () => {
       { kind: 'quote', quote: { text: 'quoted' } },
       { kind: 'text', text: '  after' },
     ]);
+  });
+
+  it('keeps a restored nested list quote under its literal list row', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: '  - child' }] },
+        {
+          type: 'paragraph',
+          content: [{ type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } }],
+        },
+      ],
+    });
+
+    const serialized = serializeEditorContent(editor).text;
+    expect(serialized).toBe(
+      'parent\n  - child\n    > <!-- cindy-composer-quote -->\n    > quoted',
+    );
+    expect(parseChatQuoteSegments(serialized)).toEqual([
+      { kind: 'text', text: 'parent\n  - child' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+    ]);
+  });
+
+  it('preserves indentation on an empty nested list item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
+                {
+                  type: 'bulletList',
+                  content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('- parent\n  - ');
   });
 
   it('does not duplicate restored continuation indentation after a list quote', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -13,6 +13,7 @@ import {
   ComposerOrderedList,
   handleStructuredListBackspace,
   handleStructuredListBreak,
+  isTopLevelBlockSelection,
   isTrailingEmptyTopLevelParagraph,
   promoteTrailingPlainListParagraph,
 } from '@/components/new-chat/ComposerListNodes';
@@ -626,6 +627,16 @@ describe('composer live plain-list promotion', () => {
     expect(isTrailingEmptyTopLevelParagraph(editor.view)).toBe(true);
   });
 
+  it('recognizes a whole top-level paragraph selection for structured paste', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'replace me' }] }],
+    });
+    editor.commands.setTextSelection({ from: 1, to: 11 });
+
+    expect(isTopLevelBlockSelection(editor.view)).toBe(true);
+  });
+
   it('promotes a trailing pasted row beside an existing structured list', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -660,6 +671,7 @@ describe('composer live plain-list promotion', () => {
     const editor = makeEditor({
       type: 'doc',
       content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
         {
           type: 'paragraph',
           content: [{ type: 'text', text: '3.14159' }],
@@ -723,6 +735,20 @@ describe('composer live plain-list promotion', () => {
     expect(promoteTrailingPlainListParagraph(editor.view)).toBe(true);
     expect(editor.state.doc.firstChild?.type.name).toBe('bulletList');
     expect(editor.state.doc.firstChild?.firstChild?.textContent).toBe('item');
+  });
+
+  it('does not promote a marker inside an unclosed fenced block', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: '```' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: '1. literal' }] },
+      ],
+    });
+    selectDocumentEnd(editor);
+
+    expect(promoteTrailingPlainListParagraph(editor.view)).toBe(false);
+    expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
   });
 });
 
@@ -1021,6 +1047,26 @@ describe('composer structured list serialization', () => {
     );
   });
 
+  it('keeps an inline restored quote under its literal list row', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: '  - child' },
+            { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe(
+      'parent\n  - child\n    > <!-- cindy-composer-quote -->\n    > quoted',
+    );
+  });
+
   it('keeps quote-like reply text separate from a list quote chip', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -1050,6 +1096,37 @@ describe('composer structured list serialization', () => {
       { kind: 'text', text: '- ' },
       { kind: 'quote', quote: { text: 'quoted' } },
       { kind: 'text', text: '  > reply' },
+    ]);
+  });
+
+  it('keeps a bare quote marker separate from a list quote chip', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: COMPOSER_QUOTE_NODE_TYPE, attrs: { text: 'quoted' } },
+                    { type: 'text', text: '>' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parseChatQuoteSegments(serializeEditorContent(editor).text)).toEqual([
+      { kind: 'text', text: '- ' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+      { kind: 'text', text: '  >' },
     ]);
   });
 

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -613,6 +613,30 @@ describe('composer structured list serialization', () => {
     expect(serializeEditorContent(editor).text).toBe('10. parent\n    - child');
   });
 
+  it('preserves the optional space after CJK ordered markers', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 2, marker: '、' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: '项目' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: ' 项目' }] }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('2、项目\n3、 项目');
+  });
+
   it('preserves nested markers and projects atom ranges into wire offsets', () => {
     const href = 'cindy://session/session-a?message=message-a';
     const editor = makeEditor({

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -213,9 +213,11 @@ describe('composer structured list input rules', () => {
           type: listType,
           ...(listType === 'bulletList'
             ? { attrs: { marker: '-', separator: ' ', ...attrs } }
-            : Object.keys(attrs).length > 0
-              ? { attrs }
-              : {}),
+            : listType === 'orderedList'
+              ? { attrs: { separator: ' ', ...attrs } }
+              : Object.keys(attrs).length > 0
+                ? { attrs }
+                : {}),
           content: [
             {
               type: 'listItem',
@@ -291,7 +293,7 @@ describe('composer structured list keyboard commands', () => {
     expect(editor.getJSON().content).toEqual([
       {
         type: 'orderedList',
-        attrs: { start: 1, marker: '.' },
+        attrs: { start: 1, marker: '.', separator: ' ' },
         content: [
           {
             type: 'listItem',
@@ -727,6 +729,26 @@ describe('composer structured list serialization', () => {
     });
 
     expect(serializeEditorContent(editor).text).toBe('+   item');
+  });
+
+  it('preserves non-default ordered marker spacing when sending', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.', separator: '\t' },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'item' }] }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('1.\titem');
   });
 
   it('keeps a dragged quote inside its list item', () => {

--- a/apps/desktop/src/renderer/__tests__/ghostComposerPlacement.test.ts
+++ b/apps/desktop/src/renderer/__tests__/ghostComposerPlacement.test.ts
@@ -6,6 +6,11 @@ import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  ComposerBulletList,
+  ComposerListItem,
+  ComposerOrderedList,
+} from '@/components/new-chat/ComposerListNodes';
 import { placeGhostAtComposerStart } from '@/components/new-chat/ghostComposerPlacement';
 import { MentionChipNode } from '@/components/new-chat/MentionChipNode';
 import type { InstalledGhost } from '../../shared/ghost';
@@ -79,5 +84,63 @@ describe('placeGhostAtComposerStart', () => {
     placeGhostAtComposerStart(editor, selected, [disabledCurrent, selected]);
 
     expect(editor.getText()).toBe('$feishu 帮我整理这段内容');
+  });
+
+  it('adds a command paragraph before a leading structured list', () => {
+    const editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        ComposerListItem,
+        ComposerBulletList,
+        ComposerOrderedList,
+        MentionChipNode,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'first' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    editors.push(editor);
+    const selected = ghost('mivo');
+
+    expect(placeGhostAtComposerStart(editor, selected, [selected])).toBe(true);
+    expect(editor.getJSON().content).toEqual([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: '$mivo ' }],
+      },
+      {
+        type: 'bulletList',
+        attrs: { marker: '-', separator: ' ' },
+        content: [
+          {
+            type: 'listItem',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'first' }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/ghostComposerPlacement.test.ts
+++ b/apps/desktop/src/renderer/__tests__/ghostComposerPlacement.test.ts
@@ -193,4 +193,41 @@ describe('placeGhostAtComposerStart', () => {
       content: [{ type: 'text', text: '$old later text' }],
     });
   });
+
+  it('does not replace a command that appears after an empty structured list', () => {
+    const editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        ComposerListItem,
+        ComposerBulletList,
+        ComposerOrderedList,
+        MentionChipNode,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }],
+          },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: '$old later text' }],
+          },
+        ],
+      },
+    });
+    editors.push(editor);
+
+    expect(placeGhostAtComposerStart(editor, ghost('mivo'), [ghost('mivo'), ghost('old')])).toBe(
+      true,
+    );
+    expect(editor.getJSON().content?.[0]).toEqual({
+      type: 'paragraph',
+      content: [{ type: 'text', text: '$mivo ' }],
+    });
+    expect(editor.getJSON().content?.[1]?.type).toBe('bulletList');
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/ghostComposerPlacement.test.ts
+++ b/apps/desktop/src/renderer/__tests__/ghostComposerPlacement.test.ts
@@ -143,4 +143,54 @@ describe('placeGhostAtComposerStart', () => {
       },
     ]);
   });
+
+  it('does not replace a command that appears after leading list content', () => {
+    const editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        ComposerListItem,
+        ComposerBulletList,
+        ComposerOrderedList,
+        MentionChipNode,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'first' }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: '$old later text' }],
+          },
+        ],
+      },
+    });
+    editors.push(editor);
+
+    expect(placeGhostAtComposerStart(editor, ghost('mivo'), [ghost('mivo'), ghost('old')])).toBe(
+      true,
+    );
+    expect(editor.getJSON().content?.[0]).toEqual({
+      type: 'paragraph',
+      content: [{ type: 'text', text: '$mivo ' }],
+    });
+    expect(editor.getJSON().content?.[2]).toEqual({
+      type: 'paragraph',
+      content: [{ type: 'text', text: '$old later text' }],
+    });
+  });
 });

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5004,7 +5004,7 @@ export function ChatInput({
 
             {/* Browser comment chip:页面评论收敛为一个「N 条注释」胶囊,
             hover 浮出逐条预览(截图缩略 + 目标标签 + 评论文字,可逐条删),
-            X 清空全部。发送时序化为 `# Browser comments:` 段 + 截图附件。 */}
+            X 清空全部。发送时序列化为 `# Browser comments:` 段 + 截图附件。 */}
             {browserComments.length > 0 && (
               <div className="pb-1.5">
                 <div className="group/bcomment relative inline-flex">

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1379,7 +1379,7 @@ export function ChatInput({
         enabled: window.electronAPI.platform === 'win32',
       }),
       CjkPunctDecoration,
-      ComposerListIndentDecoration.configure({ structuredLists: true }),
+      ComposerListIndentDecoration,
       VoiceInputDraftDecoration,
       MentionDragCaretDecoration,
       GhostCommandDecoration,
@@ -2716,8 +2716,11 @@ export function ChatInput({
       setBrowserComments(draft.browserComments ?? []);
       // 同值外部写入不做全量 setContent,避免把用户停在中段的光标弹到末尾、
       // 打断 IME 组合。appendQuoteToDraft 会改变正文文档,自然走下方 setContent。
+      const normalizedDraftText = draft.text
+        ? normalizeComposerDocumentJSON(draft.text)
+        : null;
       const textUnchanged =
-        JSON.stringify(draft.text ?? null) ===
+        JSON.stringify(normalizedDraftText) ===
         JSON.stringify(editor.isEmpty ? null : editor.getJSON());
       if (textUnchanged) {
         if (!editor.isFocused) editor.commands.focus();
@@ -2725,8 +2728,8 @@ export function ChatInput({
       }
       isRestoringRef.current = true;
       try {
-        if (draft.text) {
-          editor.commands.setContent(normalizeComposerDocumentJSON(draft.text));
+        if (normalizedDraftText) {
+          editor.commands.setContent(normalizedDraftText);
           editor.commands.focus('end');
         } else {
           editor.commands.clearContent();

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1554,25 +1554,23 @@ export function ChatInput({
                 $from.parent.firstChild?.type.name === 'hardBreak')) &&
             $from.parentOffset === $from.parent.content.size;
 
-          if (
-            state.selection.empty &&
-            paragraphEndsDocument &&
-            paragraphIsEmptyLine &&
-            composerDocumentContainsList(normalizedPaste)
-          ) {
+          if (composerDocumentContainsList(normalizedPaste)) {
             event.preventDefault();
             const replacement = (normalizedPaste.content ?? []).map((node) =>
               state.schema.nodeFromJSON(node),
             );
-            if ($from.parent.content.size > 0) {
+            if (paragraphEndsDocument && paragraphIsEmptyLine && $from.parent.content.size > 0) {
               replacement.unshift(state.schema.nodes.paragraph.create());
             }
             const fragment = Fragment.from(replacement);
-            const tr = state.tr.replaceWith(
-              paragraphPosition,
-              paragraphPosition + $from.parent.nodeSize,
-              fragment,
-            );
+            const tr =
+              paragraphEndsDocument && paragraphIsEmptyLine
+                ? state.tr.replaceWith(
+                    paragraphPosition,
+                    paragraphPosition + $from.parent.nodeSize,
+                    fragment,
+                  )
+                : state.tr.replaceSelection(new Slice(fragment, 0, 0));
             tr.setSelection(TextSelection.atEnd(tr.doc));
             view.dispatch(tr.scrollIntoView());
             return true;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -129,7 +129,7 @@ import {
   pastedProjectChipAttrs,
 } from './pastePipeline';
 import { upgradePastedPathsToChips, type PendingPathRange } from './pathPaste';
-import { docContainsAtomChip } from './composerDocState';
+import { composerDocIsEmpty } from './composerDocState';
 import {
   isComposerBlankPointerTarget,
   isInteractiveFocusedElement,
@@ -640,26 +640,7 @@ function hasFocusMovedToInteractiveElement(focusAnchor: Element | null, editor: 
  */
 function isEditorEmpty(editor: Editor | null): boolean {
   if (!editor) return true;
-  const doc = editor.state.doc;
-  if (doc.childCount === 0) return true;
-  let hasContent = false;
-  doc.descendants((node) => {
-    if (hasContent) return false;
-    if (
-      node.type.name === 'mentionChip' ||
-      node.type.name === 'pastedTextChip' ||
-      node.type.name === COMPOSER_QUOTE_NODE_TYPE
-    ) {
-      hasContent = true;
-      return false;
-    }
-    if (node.isText && (node.text ?? '').trim().length > 0) {
-      hasContent = true;
-      return false;
-    }
-    return true;
-  });
-  return !hasContent;
+  return composerDocIsEmpty(editor.state.doc);
 }
 
 /**
@@ -1563,15 +1544,16 @@ export function ChatInput({
               replacement.unshift(state.schema.nodes.paragraph.create());
             }
             const fragment = Fragment.from(replacement);
+            const pasteIntoTrailingEmptyLine = paragraphEndsDocument && paragraphIsEmptyLine;
             const tr =
-              paragraphEndsDocument && paragraphIsEmptyLine
+              pasteIntoTrailingEmptyLine
                 ? state.tr.replaceWith(
                     paragraphPosition,
                     paragraphPosition + $from.parent.nodeSize,
                     fragment,
                   )
                 : state.tr.replaceSelection(new Slice(fragment, 0, 0));
-            tr.setSelection(TextSelection.atEnd(tr.doc));
+            if (pasteIntoTrailingEmptyLine) tr.setSelection(TextSelection.atEnd(tr.doc));
             view.dispatch(tr.scrollIntoView());
             return true;
           }
@@ -1735,8 +1717,8 @@ export function ChatInput({
           // 浏览中途新增/修改任意 chip 后 eq 失配,仍不介入。
           const isUnmodifiedHydratedHistory =
             idx >= 0 && hydratedHistoryDocumentRef.current?.eq(editorInstance) === true;
-          if (docContainsAtomChip(editorInstance) && !isUnmodifiedHydratedHistory) return false;
-          const isEmpty = editorInstance.textContent.trim().length === 0;
+          if (!isUnmodifiedHydratedHistory && !composerDocIsEmpty(editorInstance)) return false;
+          const isEmpty = composerDocIsEmpty(editorInstance);
           const replaceWithHistoryEntry = (entry: ComposerHistoryEntry) => {
             const historyDocument = view.state.schema.nodeFromJSON(
               composerHistoryEntryToDocument(entry),

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -35,6 +35,7 @@ import {
   handleStructuredListBackspace,
   handleStructuredListBreak,
   hasTrailingPlainListParagraph,
+  isTopLevelBlockSelection,
   isTrailingEmptyTopLevelParagraph,
   promoteTrailingPlainListParagraph,
 } from './ComposerListNodes';
@@ -1526,23 +1527,29 @@ export function ChatInput({
           const { state } = view;
           const { $from } = state.selection;
           const pasteIntoTrailingEmptyLine = isTrailingEmptyTopLevelParagraph(view);
+          const pasteIntoBlockSelection = isTopLevelBlockSelection(view);
 
-          if (composerDocumentContainsList(normalizedPaste) && pasteIntoTrailingEmptyLine) {
+          if (
+            composerDocumentContainsList(normalizedPaste) &&
+            (pasteIntoTrailingEmptyLine || pasteIntoBlockSelection)
+          ) {
             event.preventDefault();
             const paragraphPosition = $from.before(1);
             const replacement = (normalizedPaste.content ?? []).map((node) =>
               state.schema.nodeFromJSON(node),
             );
-            if ($from.parent.content.size > 0) {
+            if (pasteIntoTrailingEmptyLine && $from.parent.content.size > 0) {
               replacement.unshift(state.schema.nodes.paragraph.create());
             }
             const fragment = Fragment.from(replacement);
-            const tr = state.tr.replaceWith(
-              paragraphPosition,
-              paragraphPosition + $from.parent.nodeSize,
-              fragment,
-            );
-            tr.setSelection(TextSelection.atEnd(tr.doc));
+            const tr = pasteIntoTrailingEmptyLine
+              ? state.tr.replaceWith(
+                  paragraphPosition,
+                  paragraphPosition + $from.parent.nodeSize,
+                  fragment,
+                )
+              : state.tr.replaceSelection(new Slice(fragment, 0, 0));
+            if (pasteIntoTrailingEmptyLine) tr.setSelection(TextSelection.atEnd(tr.doc));
             view.dispatch(tr.scrollIntoView());
             return true;
           }
@@ -1690,6 +1697,20 @@ export function ChatInput({
             return true;
           }
           return false;
+        }
+
+        // A history undo intentionally restores the marker as plain text. Keep
+        // the queued live promotion from immediately converting it again.
+        if (
+          event.key.toLowerCase() === 'z' &&
+          (event.metaKey || event.ctrlKey) &&
+          !event.shiftKey &&
+          !event.altKey
+        ) {
+          suppressListNormalizationRef.current = true;
+          queueMicrotask(() => {
+            suppressListNormalizationRef.current = false;
+          });
         }
 
         // ↑ / ↓ — browse user message history when editor is empty
@@ -2555,7 +2576,7 @@ export function ChatInput({
       // alone.
       if (storageKey !== undefined) {
         const draft = getComposerDraft(storageKey);
-        if (draft?.text && editor.isEmpty) {
+        if (draft?.text && composerDocIsEmpty(editor.state.doc)) {
           isRestoringRef.current = true;
           try {
             editor.commands.setContent(normalizeComposerDocumentJSON(draft.text));
@@ -2691,7 +2712,7 @@ export function ChatInput({
         : null;
       const textUnchanged =
         JSON.stringify(normalizedDraftText) ===
-        JSON.stringify(editor.isEmpty ? null : editor.getJSON());
+        JSON.stringify(composerDocIsEmpty(editor.state.doc) ? null : editor.getJSON());
       if (textUnchanged) {
         if (!editor.isFocused) editor.commands.focus();
         return;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -25,9 +25,18 @@ import Text from '@tiptap/extension-text';
 import History from '@tiptap/extension-history';
 import Placeholder from '@tiptap/extension-placeholder';
 import HardBreak from '@tiptap/extension-hard-break';
-import type { Editor } from '@tiptap/core';
+import type { Editor, JSONContent } from '@tiptap/core';
 import { CjkPunctDecoration } from './CjkPunctDecoration';
 import { ComposerListIndentDecoration } from './ComposerListIndentDecoration';
+import {
+  ComposerBulletList,
+  ComposerListItem,
+  ComposerOrderedList,
+  handleStructuredListBackspace,
+  handleStructuredListBreak,
+  hasTrailingPlainListParagraph,
+  promoteTrailingPlainListParagraph,
+} from './ComposerListNodes';
 import { WindowsSelectionReplacement } from './WindowsSelectionReplacement';
 import {
   setVoiceInputDraftDecoration,
@@ -37,7 +46,6 @@ import {
 import { MentionDragCaretDecoration, setMentionDragCaret } from './MentionDragCaretDecoration';
 import { GhostCommandDecoration, setGhostCommandRoster } from './GhostCommandDecoration';
 import {
-  getDecoratedSlashCommandMatches,
   replaceSlashCommandRunWithText,
   setSlashCommandRoster,
   SlashCommandDecoration,
@@ -49,19 +57,12 @@ import { toast } from '@/lib/toast';
 import { mapIpcErrorToI18nKey } from '@/utils/ipcError';
 import { Tip } from '@/components/ui/tooltip';
 import type { AttachedFile, MentionedResource, ImageAnnotationStroke } from '@/lib/fileTypes';
-import { formatQuoteForSend } from '@/lib/chatQuotes';
 import {
   commentPreviewTag,
   formatBrowserCommentsForSend,
   removeBrowserCommentAndRepairChains,
   type BrowserCommentDraftItem,
 } from '@/lib/browserComments';
-import { formatMentionRef } from '@/lib/mentionRefFormat';
-import {
-  parseProjectDeepLinkHref,
-  parseSessionDeepLinkHref,
-  projectDisplayName,
-} from '@/lib/deepLink';
 import { isGlobalDropIntercepted } from '@/lib/globalDropIntercept';
 import { shouldOpenTextLightbox } from '@/lib/filePreview';
 import {
@@ -111,17 +112,12 @@ import { ComposerQuoteNode } from './ComposerQuoteNode';
 import {
   COMPOSER_QUOTE_NODE_TYPE,
   composerHistoryEntryToDocument,
-  composerQuoteAttrsToChatQuote,
-  serializeComposerContentBlocksWithRanges,
   type ComposerHistoryEntry,
-  type ComposerQuoteAttrs,
-  type ComposerSerializedBlock,
 } from '@/lib/composerQuoteDocument';
 import type { PastedTextRange, SlashCommandRange } from '@/lib/imageRef';
 import {
   pastedSessionChipAttrs,
   resolveSessionMessageReferencesForSend,
-  serializeSessionChipText,
   resolveSessionChipTitles,
 } from './sessionLinkPaste';
 import {
@@ -131,7 +127,6 @@ import {
   LONG_PASTE_MAX_CHARS,
   segmentPastedContent,
   pastedProjectChipAttrs,
-  serializeProjectChipText,
 } from './pastePipeline';
 import { upgradePastedPathsToChips, type PendingPathRange } from './pathPaste';
 import { docContainsAtomChip } from './composerDocState';
@@ -148,17 +143,23 @@ import {
 } from './PastedTextChipNode';
 import { ToolPayloadLightbox } from '@/components/chat/ToolPayloadLightbox';
 import { Fragment, Slice, type Node as ProseMirrorNode } from '@tiptap/pm/model';
-import { Selection } from '@tiptap/pm/state';
+import { Selection, TextSelection } from '@tiptap/pm/state';
 import * as sessionService from '@/lib/sessionService';
 import { getModelById } from '@/lib/modelDefinitions';
 import { loadAllCommands, filterSlashCommands, type UnifiedCommand } from '@/lib/slashCommands';
-import { applyListBackspace, applyListContinuation } from '@/lib/composerListContinuation';
 import { scanAtResources, filterAtResources, type AtResourceItem } from '@/lib/atResourceService';
+import { applyListBackspace, applyListContinuation } from '@/lib/composerListContinuation';
 import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
 import { getAppShortcutCombos } from '@/lib/appShortcutStore';
 import { getNextPermissionMode } from '@/lib/permissionModeCycle';
 import { matchesKeyboardEvent } from '../../../shared/appShortcuts';
 import { createLogger } from '@/lib/logger';
+import { serializeEditorContent } from './composerContentSerialization';
+import {
+  composerDocumentContainsList,
+  normalizeComposerDocumentJSON,
+  plainTextToComposerDocument,
+} from '@/lib/composerListDocument';
 import { useAgentCapabilities, type AgentKind } from '@/hooks/useAgentCapabilities';
 import { useConnectedSource } from '@/hooks/useConnectedSource';
 import { useProviders } from '@/hooks/useProviders';
@@ -634,196 +635,6 @@ function hasFocusMovedToInteractiveElement(focusAnchor: Element | null, editor: 
 }
 
 /**
- * Serialize the Tiptap document to the plain-string format the Agent SDK
- * expects (command-palette F6):
- *   - file chip  → `@{relPath}`
- *   - dir chip   → `@{relPath}/`
- *   - agent chip → `@.claude/agents/{name}.md` (falls back to `@{name}` when
- *                  the host tells us the mapping is stale — see submit handler)
- *   - session chip → `[title](cindy://session/…)` / bare deep link href
- *   - plain text → as-is
- * Paragraphs are joined with `\n`.
- */
-function serializeEditorContent(editor: Editor): {
-  text: string;
-  mentions: MentionedResource[];
-  hasQuotes: boolean;
-  agentReferences: AgentInputReference[];
-  pastedTextRanges: PastedTextRange[];
-  slashCommandRanges: SlashCommandRange[];
-} {
-  const doc = editor.state.doc;
-  const decoratedSlashMatches = getDecoratedSlashCommandMatches(editor);
-  const blocks: ComposerSerializedBlock[] = [];
-  const mentions: MentionedResource[] = [];
-  const seenMentions = new Set<string>();
-  let hasQuotes = false;
-
-  const addMention = (attrs: MentionChipAttrs) => {
-    // slash 不是资源;session / project 深链不进 mentions(不是文件系统资源,
-    // MentionedResource.type 也不含它们)——只序列化进正文文本。
-    if (attrs.kind === 'slash' || attrs.kind === 'session' || attrs.kind === 'project') return;
-    const key = `${attrs.kind}:${attrs.path}`;
-    if (seenMentions.has(key)) return;
-    seenMentions.add(key);
-    mentions.push({ type: attrs.kind, name: attrs.label, path: attrs.path });
-  };
-
-  doc.forEach((pNode, paragraphOffset) => {
-    if (pNode.type.name === COMPOSER_QUOTE_NODE_TYPE) {
-      hasQuotes = true;
-      blocks.push({
-        kind: 'quote',
-        text: formatQuoteForSend(composerQuoteAttrsToChatQuote(pNode.attrs as ComposerQuoteAttrs)),
-      });
-      return;
-    }
-    if (pNode.type.name !== 'paragraph') return;
-    let buf = '';
-    let bufAgentReferences: AgentInputReference[] = [];
-    let bufPastedTextRanges: PastedTextRange[] = [];
-    let bufSlashCommandRanges: SlashCommandRange[] = [];
-    let emittedInlineSegment = false;
-    const flushText = (force = false) => {
-      if (!force && !buf) return;
-      blocks.push({
-        kind: 'text',
-        text: buf,
-        ...(bufAgentReferences.length > 0 ? { agentReferences: bufAgentReferences } : {}),
-        ...(bufPastedTextRanges.length > 0 ? { pastedTextRanges: bufPastedTextRanges } : {}),
-        ...(bufSlashCommandRanges.length > 0 ? { slashCommandRanges: bufSlashCommandRanges } : {}),
-      });
-      buf = '';
-      bufAgentReferences = [];
-      bufPastedTextRanges = [];
-      bufSlashCommandRanges = [];
-      emittedInlineSegment = true;
-    };
-    pNode.forEach((child, childOffset) => {
-      if (child.type.name === COMPOSER_QUOTE_NODE_TYPE) {
-        flushText();
-        hasQuotes = true;
-        blocks.push({
-          kind: 'quote',
-          text: formatQuoteForSend(
-            composerQuoteAttrsToChatQuote(child.attrs as ComposerQuoteAttrs),
-          ),
-        });
-        emittedInlineSegment = true;
-      } else if (child.type.name === 'mentionChip') {
-        const attrs = child.attrs as MentionChipAttrs;
-        addMention(attrs);
-        if (attrs.kind === 'slash') {
-          buf += `/${attrs.path} `;
-        } else if (attrs.kind === 'session') {
-          // 会话深链 chip:有标题 → `[标题](href)`(消息侧 / 手机端 markdown
-          // 链路显式 label 优先),标题未解析 → 裸 href。
-          const wire = serializeSessionChipText(attrs);
-          const start = buf.length;
-          buf += wire;
-          const target = parseSessionDeepLinkHref(attrs.path);
-          if (target?.messageClientId) {
-            bufAgentReferences.push({
-              kind: 'message',
-              start,
-              end: buf.length,
-              href: attrs.path,
-              sessionId: target.sessionId,
-              messageClientId: target.messageClientId,
-              ...(attrs.agentText ? { text: attrs.agentText } : {}),
-              ...(attrs.agentTextTruncated ? { truncated: true } : {}),
-            });
-          } else if (target) {
-            bufAgentReferences.push({
-              kind: 'session',
-              start,
-              end: buf.length,
-              href: attrs.path,
-              sessionId: target.sessionId,
-              ...(attrs.titled && attrs.label ? { title: attrs.label } : {}),
-            });
-          }
-        } else if (attrs.kind === 'project') {
-          // 项目深链 chip:同 session 的取舍——显式标题走 markdown 形式,
-          // 目录名占位是 href 可推导的,裸 href 即可(消息侧自行取 basename)。
-          const wire = serializeProjectChipText(attrs);
-          const start = buf.length;
-          buf += wire;
-          const target = parseProjectDeepLinkHref(attrs.path);
-          if (target) {
-            bufAgentReferences.push({
-              kind: 'project',
-              start,
-              end: buf.length,
-              href: attrs.path,
-              name: attrs.label || projectDisplayName(target.workingDir),
-              workingDir: target.workingDir,
-            });
-          }
-        } else if (attrs.kind === 'dir') {
-          // 含空格的 path 用 `@"..."` 引号形式序列化（formatMentionRef），否则
-          // 下游 `@\S+` 切词会从空格处把 chip 截断。dir 的尾 `/` 一并纳入引号内，
-          // 与 maker-core quotedMentionText 的 dir 形式 `@"path/"` 对齐。
-          buf += `@${formatMentionRef(`${attrs.path}/`)}`;
-        } else if (attrs.kind === 'agent') {
-          // F2.7: agent chip serializes to `@.claude/agents/{name}.md` when
-          // the stored path is canonical (contains `/`), else falls back to
-          // `@{name}` — spec: "映射失败按裸名 @{name} 退化发送".
-          // insertAtResource stores the canonical path when the scan found
-          // the file; the fallback branch fires for chips whose source file
-          // vanished between scan and submit (or any future code path that
-          // can only recover the bare name) so Agent reports the error back
-          // inline instead of us silently dropping the mention.
-          const p = attrs.path;
-          if (p.includes('/')) {
-            // Canonical path — emit as-is (already `.claude/agents/foo.md`)
-            buf += `@${formatMentionRef(p)}`;
-          } else {
-            // Bare-name fallback — strip any accidental `.md` tail, emit
-            // just the label so Agent can diagnose "unknown agent"
-            const bare = p.replace(/\.md$/, '');
-            buf += `@${formatMentionRef(bare)}`;
-          }
-        } else {
-          buf += `@${formatMentionRef(attrs.path)}`;
-        }
-      } else if (child.type.name === 'pastedTextChip') {
-        // Agent 仍收到完整原文；本地只记录纯展示 range，让发送后能恢复同款
-        // chip，而不往 prompt 塞任何 marker 或改变缓存前缀。
-        const attrs = child.attrs as PastedTextChipAttrs;
-        const start = buf.length;
-        buf += attrs.text;
-        bufPastedTextRanges.push({ start, end: buf.length, display: attrs.display });
-      } else if (child.type.name === 'hardBreak') {
-        // Shift+Enter inserts a Tiptap HardBreak node (inline <br>).
-        // Without this branch the node is silently dropped and the sent
-        // message loses all line breaks. Translate to '\n' here so the
-        // downstream UserMessage (whitespace-pre-wrap) renders it correctly.
-        buf += '\n';
-      } else if (child.isText) {
-        const childText = child.text ?? '';
-        const bufferStart = buf.length;
-        const documentStart = paragraphOffset + 1 + childOffset;
-        buf += childText;
-        for (const match of decoratedSlashMatches) {
-          if (match.from < documentStart || match.to > documentStart + childText.length) continue;
-          bufSlashCommandRanges.push({
-            start: bufferStart + match.from - documentStart,
-            end: bufferStart + match.to - documentStart,
-          });
-        }
-      }
-    });
-    // Preserve truly empty paragraphs as line breaks, but do not synthesize an
-    // empty text segment after a quote chip at the end of a paragraph.
-    flushText(!emittedInlineSegment);
-  });
-
-  const serialized = serializeComposerContentBlocksWithRanges(blocks);
-  return { ...serialized, mentions, hasQuotes };
-}
-
-/**
  * Is the editor document "empty" (no text and no chips)? Used to mimic the
  * textarea's `message.trim().length > 0` gate for the Send button.
  */
@@ -927,9 +738,8 @@ function detectTrigger(editor: Editor): TriggerState {
 
   // Slash detection — mirror @ semantics: trigger when `/` sits at the start
   // of the current paragraph OR is preceded by whitespace, with no whitespace
-  // between it and the caret. Matches Codex desktop behaviour. (The old
-  // "must be doc[0]" rule was too strict — users couldn't fire / after a
-  // Shift+Enter or in the middle of a sentence.)
+  // between it and the caret. The previous "must be doc[0]" rule was too
+  // strict — users couldn't fire / after a Shift+Enter or in a sentence.
   const slashIdx = textSoFar.lastIndexOf('/');
   if (slashIdx >= 0) {
     const beforeSlash = slashIdx === 0 ? '' : textSoFar[slashIdx - 1];
@@ -1184,7 +994,7 @@ export function ChatInput({
   const userHistoryRef = useRef(userHistory);
   userHistoryRef.current = userHistory;
   const historyIndexRef = useRef(-1); // -1 = current draft (not browsing)
-  const draftRef = useRef(''); // saves draft when user starts browsing
+  const draftRef = useRef<JSONContent | null>(null); // saves draft when user starts browsing
   const hydratedHistoryDocumentRef = useRef<ProseMirrorNode | null>(null);
 
   // ── composer-draft-per-session ─────────────────────────────────────
@@ -1257,6 +1067,8 @@ export function ChatInput({
   const [isDragOver, setIsDragOver] = useState(false);
   const dragCounterRef = useRef(0);
   const composerMentionDragActiveRef = useRef(false);
+  const suppressListNormalizationRef = useRef(false);
+  const listPromotionQueuedRef = useRef(false);
   const lastComposerSelectionFromRef = useRef<number | null>(null);
   const internalMentionDragActiveRef = useRef(false);
   const [workingDir, setWorkingDir] = useState<string | null>(initialWorkingDir ?? null);
@@ -1531,9 +1343,10 @@ export function ChatInput({
   }, [initialWorkingDir]);
 
   // ── Tiptap editor ──────────────────────────────────────────────────
-  // A minimal editor: plain text + hard-break + history + our atomic
-  // mention chip node. We do NOT include StarterKit because it brings
-  // headings / lists / marks we don't want in a chat input.
+  // The composer remains intentionally small: it has paragraphs, hard breaks,
+  // atomic chips, and only the list nodes needed to preserve Markdown list
+  // structure while editing. It does not use StarterKit, whose headings and
+  // marks are not part of the chat input contract.
   const editor = useEditor({
     // Match the legacy textarea's `autoFocus` prop — on mount, focus the
     // editor at the end so the user can continue typing after restored text.
@@ -1546,6 +1359,9 @@ export function ChatInput({
       Document,
       Paragraph,
       Text,
+      ComposerListItem,
+      ComposerBulletList,
+      ComposerOrderedList,
       ComposerHardBreak,
       History,
       Placeholder.configure({
@@ -1563,7 +1379,7 @@ export function ChatInput({
         enabled: window.electronAPI.platform === 'win32',
       }),
       CjkPunctDecoration,
-      ComposerListIndentDecoration,
+      ComposerListIndentDecoration.configure({ structuredLists: true }),
       VoiceInputDraftDecoration,
       MentionDragCaretDecoration,
       GhostCommandDecoration,
@@ -1604,6 +1420,16 @@ export function ChatInput({
         dragend: () => {
           internalMentionDragActiveRef.current = false;
           setMentionDragCaret(editorRef.current, null);
+          return false;
+        },
+        compositionend: (view) => {
+          // The final IME commit can bypass input rules. Wait until
+          // ProseMirror releases its native composition DOM, then promote a
+          // trailing Markdown list row if one was committed as plain text.
+          setTimeout(() => {
+            if (view.isDestroyed || view.composing) return;
+            promoteTrailingPlainListParagraph(view);
+          }, 0);
           return false;
         },
       },
@@ -1709,6 +1535,48 @@ export function ChatInput({
         const segments = text
           ? segmentPastedContent(text, { workingDir: workingDirRef.current })
           : null;
+        // Plain Markdown pasted into the final empty row should enter the same
+        // structured document model as a typed list marker. Paste does not run
+        // Tiptap input rules, so normalize it explicitly at this boundary.
+        if (text && !segments) {
+          const normalizedPaste = plainTextToComposerDocument(text);
+          const { state } = view;
+          const { $from } = state.selection;
+          const paragraphPosition = $from.depth === 1 ? $from.before(1) : -1;
+          const paragraphEndsDocument =
+            paragraphPosition >= 0 &&
+            paragraphPosition + $from.parent.nodeSize === state.doc.content.size;
+          const paragraphIsEmptyLine =
+            $from.parent.type.name === 'paragraph' &&
+            ($from.parent.content.size === 0 ||
+              ($from.parent.childCount === 1 &&
+                $from.parent.firstChild?.type.name === 'hardBreak')) &&
+            $from.parentOffset === $from.parent.content.size;
+
+          if (
+            state.selection.empty &&
+            paragraphEndsDocument &&
+            paragraphIsEmptyLine &&
+            composerDocumentContainsList(normalizedPaste)
+          ) {
+            event.preventDefault();
+            const replacement = (normalizedPaste.content ?? []).map((node) =>
+              state.schema.nodeFromJSON(node),
+            );
+            if ($from.parent.content.size > 0) {
+              replacement.unshift(state.schema.nodes.paragraph.create());
+            }
+            const fragment = Fragment.from(replacement);
+            const tr = state.tr.replaceWith(
+              paragraphPosition,
+              paragraphPosition + $from.parent.nodeSize,
+              fragment,
+            );
+            tr.setSelection(TextSelection.atEnd(tr.doc));
+            view.dispatch(tr.scrollIntoView());
+            return true;
+          }
+        }
         if (segments) {
           event.preventDefault();
           const { state } = view;
@@ -1759,9 +1627,14 @@ export function ChatInput({
             }
           }
           flushText();
-          view.dispatch(
-            state.tr.replaceSelection(new Slice(Fragment.from(nodes), 0, 0)).scrollIntoView(),
-          );
+          suppressListNormalizationRef.current = true;
+          try {
+            view.dispatch(
+              state.tr.replaceSelection(new Slice(Fragment.from(nodes), 0, 0)).scrollIntoView(),
+            );
+          } finally {
+            suppressListNormalizationRef.current = false;
+          }
           const ed = editorRef.current;
           if (ed) {
             resolveSessionChipTitles(ed);
@@ -1883,7 +1756,7 @@ export function ChatInput({
             if (idx === -1 && !isEmpty) return false;
             if (idx === -1) {
               // Save current draft before browsing
-              draftRef.current = editorInstance.textContent;
+              draftRef.current = view.state.doc.toJSON();
             }
             const next = Math.min(idx + 1, history.length - 1);
             if (next === idx) return false; // already at oldest
@@ -1901,12 +1774,14 @@ export function ChatInput({
               // Restore draft
               const draft = draftRef.current;
               if (draft) {
-                tr.replaceWith(0, view.state.doc.content.size, view.state.schema.text(draft));
+                const draftDocument = view.state.schema.nodeFromJSON(draft);
+                tr.replaceWith(0, view.state.doc.content.size, draftDocument.content);
               } else {
                 tr.delete(0, view.state.doc.content.size);
               }
               view.dispatch(tr);
               hydratedHistoryDocumentRef.current = null;
+              draftRef.current = null;
             } else {
               replaceWithHistoryEntry(history[next]);
             }
@@ -1915,9 +1790,9 @@ export function ChatInput({
           }
         }
 
-        // Backspace — 空列表项整体回删(对齐 Claude):行内容只剩前缀(如
-        // "2. ")且光标在行尾时,一次退格删掉整个前缀并回到上一行行尾,
-        // 而不是一个字符一个字符啃前缀。带修饰键(词删 / 行删)不拦截。
+        // Backspace — structured list items exit through the schema command;
+        // legacy plain Markdown rows keep the prefix-deletion fallback so
+        // pasted and restored text remains editable without a migration pass.
         if (
           event.key === 'Backspace' &&
           !event.metaKey &&
@@ -1925,15 +1800,15 @@ export function ChatInput({
           !event.altKey &&
           !event.shiftKey &&
           !event.isComposing &&
-          applyListBackspace(view)
+          (handleStructuredListBackspace(view) || applyListBackspace(view))
         ) {
           event.preventDefault();
           return true;
         }
 
-        // Shift/Alt+Enter — markdown 列表接续(纯文本):当前行以列表 / 待办 /
-        // 引用前缀开头时,换行后自动补下一个前缀(序号 +1);前缀后无内容时改为
-        // 清掉前缀退出列表。其余情况 return false 走 ComposerHardBreak 默认换行。
+        // Shift/Alt+Enter — split or exit a structured item. The plain-text
+        // fallback remains for old drafts and pasted Markdown that has not
+        // gone through an input rule.
         if (
           event.key === 'Enter' &&
           (event.shiftKey || event.altKey) &&
@@ -1941,7 +1816,7 @@ export function ChatInput({
           !event.ctrlKey &&
           !event.isComposing
         ) {
-          if (applyListContinuation(view)) {
+          if (handleStructuredListBreak(view) || applyListContinuation(view)) {
             event.preventDefault();
             return true;
           }
@@ -1991,6 +1866,24 @@ export function ChatInput({
     },
     // Tick state on every update so triggerState below recomputes.
     onUpdate: ({ editor: ed }) => {
+      if (
+        !suppressListNormalizationRef.current &&
+        !ed.view.composing &&
+        !listPromotionQueuedRef.current &&
+        hasTrailingPlainListParagraph(ed.view)
+      ) {
+        listPromotionQueuedRef.current = true;
+        queueMicrotask(() => {
+          listPromotionQueuedRef.current = false;
+          if (
+            !ed.isDestroyed &&
+            !suppressListNormalizationRef.current &&
+            !ed.view.composing
+          ) {
+            promoteTrailingPlainListParagraph(ed.view);
+          }
+        });
+      }
       setTick((t) => t + 1);
       if (!composerMentionDragActiveRef.current) {
         lastComposerSelectionFromRef.current = ed.state.selection.from;
@@ -2695,7 +2588,7 @@ export function ChatInput({
         if (draft?.text && editor.isEmpty) {
           isRestoringRef.current = true;
           try {
-            editor.commands.setContent(draft.text);
+            editor.commands.setContent(normalizeComposerDocumentJSON(draft.text));
           } finally {
             isRestoringRef.current = false;
           }
@@ -2753,7 +2646,7 @@ export function ChatInput({
       try {
         const draft = storageKey !== undefined ? getComposerDraft(storageKey) : undefined;
         if (draft?.text) {
-          editor.commands.setContent(draft.text);
+          editor.commands.setContent(normalizeComposerDocumentJSON(draft.text));
         } else {
           editor.commands.clearContent();
         }
@@ -2768,7 +2661,7 @@ export function ChatInput({
       // arrow-key history was relative to the previous session.
       historyIndexRef.current = -1;
       hydratedHistoryDocumentRef.current = null;
-      draftRef.current = '';
+      draftRef.current = null;
 
       if (!focusOnStorageKeyChangeRef.current) return;
       if (disableAutofocusRef.current || disabledRef.current) return;
@@ -2833,7 +2726,7 @@ export function ChatInput({
       isRestoringRef.current = true;
       try {
         if (draft.text) {
-          editor.commands.setContent(draft.text);
+          editor.commands.setContent(normalizeComposerDocumentJSON(draft.text));
           editor.commands.focus('end');
         } else {
           editor.commands.clearContent();
@@ -3537,7 +3430,7 @@ export function ChatInput({
       setBrowserComments([]);
       historyIndexRef.current = -1;
       hydratedHistoryDocumentRef.current = null;
-      draftRef.current = '';
+      draftRef.current = null;
       // composer-draft-per-session: drop the saved draft now that this
       // session's content has been sent. Without this, switching away then
       // back would re-restore the just-sent text/files into the composer.
@@ -5109,9 +5002,9 @@ export function ChatInput({
               />
             )}
 
-            {/* browser-comment-chip(Codex 风格):页面评论收敛为一个「N 条注释」
-            胶囊,hover 浮出逐条预览(截图缩略 + 目标标签 + 评论文字,可逐条删),
-            X 清空全部。发送时序列化为 `# Browser comments:` 段 + 截图附件。 */}
+            {/* Browser comment chip:页面评论收敛为一个「N 条注释」胶囊,
+            hover 浮出逐条预览(截图缩略 + 目标标签 + 评论文字,可逐条删),
+            X 清空全部。发送时序化为 `# Browser comments:` 段 + 截图附件。 */}
             {browserComments.length > 0 && (
               <div className="pb-1.5">
                 <div className="group/bcomment relative inline-flex">
@@ -5254,7 +5147,7 @@ export function ChatInput({
                   // 页面评论走丢弃语义(清 state + 清截图缓存):目标不接管评论截图,
                   // 与发送后清空(消息接管截图,不清缓存)不同,这里不清会留磁盘孤儿。
                   clearBrowserComments();
-                  draftRef.current = '';
+                  draftRef.current = null;
                   if (storageKey) clearComposerDraft(storageKey);
                 }}
               />
@@ -5618,7 +5511,6 @@ function VoiceInputButton({
   canReleaseToSend,
   releaseToSendActive,
   onReleaseToSendChange,
-  visualVariant,
   className,
 }: {
   state: import('@cindy/voice-input-core').VoiceInputState;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -35,6 +35,7 @@ import {
   handleStructuredListBackspace,
   handleStructuredListBreak,
   hasTrailingPlainListParagraph,
+  isTrailingEmptyTopLevelParagraph,
   promoteTrailingPlainListParagraph,
 } from './ComposerListNodes';
 import { WindowsSelectionReplacement } from './WindowsSelectionReplacement';
@@ -1524,36 +1525,24 @@ export function ChatInput({
           const normalizedPaste = plainTextToComposerDocument(text);
           const { state } = view;
           const { $from } = state.selection;
-          const paragraphPosition = $from.depth === 1 ? $from.before(1) : -1;
-          const paragraphEndsDocument =
-            paragraphPosition >= 0 &&
-            paragraphPosition + $from.parent.nodeSize === state.doc.content.size;
-          const paragraphIsEmptyLine =
-            $from.parent.type.name === 'paragraph' &&
-            ($from.parent.content.size === 0 ||
-              ($from.parent.childCount === 1 &&
-                $from.parent.firstChild?.type.name === 'hardBreak')) &&
-            $from.parentOffset === $from.parent.content.size;
+          const pasteIntoTrailingEmptyLine = isTrailingEmptyTopLevelParagraph(view);
 
-          if (composerDocumentContainsList(normalizedPaste)) {
+          if (composerDocumentContainsList(normalizedPaste) && pasteIntoTrailingEmptyLine) {
             event.preventDefault();
+            const paragraphPosition = $from.before(1);
             const replacement = (normalizedPaste.content ?? []).map((node) =>
               state.schema.nodeFromJSON(node),
             );
-            if (paragraphEndsDocument && paragraphIsEmptyLine && $from.parent.content.size > 0) {
+            if ($from.parent.content.size > 0) {
               replacement.unshift(state.schema.nodes.paragraph.create());
             }
             const fragment = Fragment.from(replacement);
-            const pasteIntoTrailingEmptyLine = paragraphEndsDocument && paragraphIsEmptyLine;
-            const tr =
-              pasteIntoTrailingEmptyLine
-                ? state.tr.replaceWith(
-                    paragraphPosition,
-                    paragraphPosition + $from.parent.nodeSize,
-                    fragment,
-                  )
-                : state.tr.replaceSelection(new Slice(fragment, 0, 0));
-            if (pasteIntoTrailingEmptyLine) tr.setSelection(TextSelection.atEnd(tr.doc));
+            const tr = state.tr.replaceWith(
+              paragraphPosition,
+              paragraphPosition + $from.parent.nodeSize,
+              fragment,
+            );
+            tr.setSelection(TextSelection.atEnd(tr.doc));
             view.dispatch(tr.scrollIntoView());
             return true;
           }

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -154,7 +154,7 @@ import { getAppShortcutCombos } from '@/lib/appShortcutStore';
 import { getNextPermissionMode } from '@/lib/permissionModeCycle';
 import { matchesKeyboardEvent } from '../../../shared/appShortcuts';
 import { createLogger } from '@/lib/logger';
-import { serializeEditorContent } from './composerContentSerialization';
+import { serializeEditorContent, serializeEditorSlice } from './composerContentSerialization';
 import {
   composerDocumentContainsList,
   normalizeComposerDocumentJSON,
@@ -1386,6 +1386,7 @@ export function ChatInput({
       SlashCommandDecoration,
     ],
     editorProps: {
+      clipboardTextSerializer: (slice) => serializeEditorSlice(editorRef.current, slice),
       attributes: {
         class: cn(
           // py + 负 my:.ProseMirror 自身是 overflow 裁剪容器,inline 装饰

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
@@ -1,8 +1,9 @@
 /**
- * Tiptap 扩展 —— composer 列表行缩进(纯视觉,对齐 Claude 原生 App 的
- * "进入列表模式"反馈)。
+ * Tiptap 扩展 —— composer 纯文本 Markdown 列表的兼容缩进。
  *
- * 行为:当某一"行"(段落内以 hardBreak 划分)以列表 / 待办 / 引用前缀开头
+ * 结构化 bullet / ordered list 由 schema 和原生列表布局负责；本扩展只处理
+ * 粘贴或旧草稿中仍为文本的列表，以及待办 / 引用前缀。当某一"行"
+ * (段落内以 hardBreak 划分)以列表 / 待办 / 引用前缀开头
  * (`1. ` / `- ` / `- [ ] ` / `> ` 等,与列表接续共用 matchListPrefix 判定),
  * 单行段落使用 node decoration,hardBreak 分隔的多行段落按行使用 inline
  * decoration；连续数字/字母正文使用 marker/body 两个盒子，避免长串把
@@ -21,7 +22,7 @@
  *   全量成本可忽略,不值得做增量映射);
  * - IME composition 开始前临时移除 decoration,结束后的下一轮 task 再按
  *   当前 doc 补算,避免微软拼音输入时改写 composition DOM;
- * - 这是纯文本编辑器的视觉缩进,不改变 doc JSON / 发送文本。
+ * - 这是兼容文本行的视觉缩进,不改变 doc JSON / 发送文本。
  */
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
@@ -49,6 +50,10 @@ type ListDecorationPluginState = {
 
 type CompositionMeta = 'suspend' | 'resume';
 
+interface ComposerListIndentOptions {
+  structuredLists: boolean;
+}
+
 const PLUGIN_STATE_KEY = new PluginKey<ListDecorationPluginState>(
   'composerListIndentDecorationState',
 );
@@ -60,6 +65,8 @@ const CJK_PUNCTUATION_RE = /[\u3000-\u303f\uff00-\uffef]/;
 // 普通句子里偶然出现长 token 时，交给 overflow-wrap:anywhere，保留空格
 // 的自然断词行为，避免把整句变成逐字断行。
 const LONG_ALPHANUMERIC_BODY_RE = /^\s*[A-Za-z0-9]{12,}\s*$/;
+const PROMOTABLE_TOP_LEVEL_LIST_RE =
+  /^(?:[-+*•][ \t]+|\d{1,6}[.)][ \t]+|\d{1,6}、[ \t]*)/;
 
 interface ListIndentValues {
   ch: number;
@@ -149,6 +156,7 @@ export function buildListIndentDecorations(
   doc: PMNode,
   slashCommandMatches: ReadonlyArray<Pick<SlashCommandMatch, 'from' | 'to'>> = [],
   voiceReplacementRange: VoiceInputReplacementRange | null = null,
+  structuredLists = false,
 ): DecorationSet {
   const decorations: Decoration[] = [];
 
@@ -200,9 +208,21 @@ export function buildListIndentDecorations(
     lineEndOffset = block.content.size;
     flushLine(); // 段落最后一行
 
+    const compatibilityMatch = (line: (typeof lines)[number]) => {
+      const match = matchListPrefix(line.text);
+      if (
+        match &&
+        structuredLists &&
+        !line.hasInlineAtom &&
+        PROMOTABLE_TOP_LEVEL_LIST_RE.test(line.text)
+      ) {
+        return null;
+      }
+      return match;
+    };
     const lineMatches = lines.map((line) => ({
       line,
-      match: matchListPrefix(line.text),
+      match: compatibilityMatch(line),
     }));
     const hasFallbackLine = lineMatches.some(({ line, match }) => {
       if (!match) return false;
@@ -243,7 +263,7 @@ export function buildListIndentDecorations(
     }
 
     const addLineDecoration = (line: (typeof lines)[number]) => {
-      const match = matchListPrefix(line.text);
+      const match = compatibilityMatch(line);
       if (!match) {
         if (hasFallbackLine && lines.length > 1 && line.end > line.start) {
           const hasCjkPunctuation = CJK_PUNCTUATION_RE.test(line.text);
@@ -316,7 +336,7 @@ export function buildListIndentDecorations(
 
     if (lines.length === 1) {
       const [line] = lines;
-      const match = line && matchListPrefix(line.text);
+      const match = line && compatibilityMatch(line);
       const prefix = match ? line.text.slice(0, match.prefixLength) : '';
       const body = line && match ? line.text.slice(match.prefixLength) : '';
       const from = line ? contentBase + line.start : contentBase;
@@ -398,11 +418,18 @@ export function buildListIndentDecorations(
   return DecorationSet.create(doc, decorations);
 }
 
-export const ComposerListIndentDecoration = Extension.create({
+export const ComposerListIndentDecoration = Extension.create<ComposerListIndentOptions>({
   name: 'composerListIndentDecoration',
+
+  addOptions() {
+    return {
+      structuredLists: false,
+    };
+  },
 
   addProseMirrorPlugins() {
     let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+    const structuredLists = this.options.structuredLists;
 
     return [
       new Plugin<ListDecorationPluginState>({
@@ -414,6 +441,8 @@ export const ComposerListIndentDecoration = Extension.create({
               decorations: buildListIndentDecorations(
                 state.doc,
                 findSlashCommandMatches(state.doc, roster),
+                null,
+                structuredLists,
               ),
               suspendedForComposition: false,
             };
@@ -446,6 +475,7 @@ export const ComposerListIndentDecoration = Extension.create({
                 tr.doc,
                 findSlashCommandMatches(tr.doc, roster),
                 voiceReplacement.range,
+                structuredLists,
               ),
               suspendedForComposition: false,
             };

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
@@ -50,10 +50,6 @@ type ListDecorationPluginState = {
 
 type CompositionMeta = 'suspend' | 'resume';
 
-interface ComposerListIndentOptions {
-  structuredLists: boolean;
-}
-
 const PLUGIN_STATE_KEY = new PluginKey<ListDecorationPluginState>(
   'composerListIndentDecorationState',
 );
@@ -65,9 +61,6 @@ const CJK_PUNCTUATION_RE = /[\u3000-\u303f\uff00-\uffef]/;
 // 普通句子里偶然出现长 token 时，交给 overflow-wrap:anywhere，保留空格
 // 的自然断词行为，避免把整句变成逐字断行。
 const LONG_ALPHANUMERIC_BODY_RE = /^\s*[A-Za-z0-9]{12,}\s*$/;
-const PROMOTABLE_TOP_LEVEL_LIST_RE =
-  /^(?:[-+*•][ \t]+|\d{1,6}[.)][ \t]+|\d{1,6}、[ \t]*)/;
-
 interface ListIndentValues {
   ch: number;
   em: number;
@@ -156,7 +149,6 @@ export function buildListIndentDecorations(
   doc: PMNode,
   slashCommandMatches: ReadonlyArray<Pick<SlashCommandMatch, 'from' | 'to'>> = [],
   voiceReplacementRange: VoiceInputReplacementRange | null = null,
-  structuredLists = false,
 ): DecorationSet {
   const decorations: Decoration[] = [];
 
@@ -209,16 +201,7 @@ export function buildListIndentDecorations(
     flushLine(); // 段落最后一行
 
     const compatibilityMatch = (line: (typeof lines)[number]) => {
-      const match = matchListPrefix(line.text);
-      if (
-        match &&
-        structuredLists &&
-        !line.hasInlineAtom &&
-        PROMOTABLE_TOP_LEVEL_LIST_RE.test(line.text)
-      ) {
-        return null;
-      }
-      return match;
+      return matchListPrefix(line.text);
     };
     const lineMatches = lines.map((line) => ({
       line,
@@ -418,18 +401,11 @@ export function buildListIndentDecorations(
   return DecorationSet.create(doc, decorations);
 }
 
-export const ComposerListIndentDecoration = Extension.create<ComposerListIndentOptions>({
+export const ComposerListIndentDecoration = Extension.create({
   name: 'composerListIndentDecoration',
-
-  addOptions() {
-    return {
-      structuredLists: false,
-    };
-  },
 
   addProseMirrorPlugins() {
     let resumeTimer: ReturnType<typeof setTimeout> | null = null;
-    const structuredLists = this.options.structuredLists;
 
     return [
       new Plugin<ListDecorationPluginState>({
@@ -442,7 +418,6 @@ export const ComposerListIndentDecoration = Extension.create<ComposerListIndentO
                 state.doc,
                 findSlashCommandMatches(state.doc, roster),
                 null,
-                structuredLists,
               ),
               suspendedForComposition: false,
             };
@@ -475,7 +450,6 @@ export const ComposerListIndentDecoration = Extension.create<ComposerListIndentO
                 tr.doc,
                 findSlashCommandMatches(tr.doc, roster),
                 voiceReplacement.range,
-                structuredLists,
               ),
               suspendedForComposition: false,
             };

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -164,6 +164,25 @@ function hardBreakListInputRule(
   });
 }
 
+function fenceAwareWrappingInputRule(
+  config: Parameters<typeof wrappingInputRule>[0],
+): InputRule {
+  const rule = wrappingInputRule(config);
+  return new InputRule({
+    find: rule.find,
+    handler: (props) => {
+      const $markerStart = props.state.doc.resolve(props.range.from);
+      if (
+        $markerStart.depth === 1 &&
+        documentFenceStateBefore(props.state.doc, $markerStart.before(1))
+      ) {
+        return null;
+      }
+      return rule.handler(props);
+    },
+  });
+}
+
 const listItemConfig: NodeConfig = {
   name: 'listItem',
   group: 'block',
@@ -211,7 +230,7 @@ export const ComposerBulletList = Node.create({
   },
   addInputRules() {
     return [
-      wrappingInputRule({
+      fenceAwareWrappingInputRule({
         find: BULLET_MARKER_RE,
         type: this.type,
         joinPredicate: (match, before) =>
@@ -302,13 +321,13 @@ export const ComposerOrderedList = Node.create({
   },
   addInputRules() {
     return [
-      wrappingInputRule({
+      fenceAwareWrappingInputRule({
         find: ORDERED_MARKER_RE,
         type: this.type,
         joinPredicate: canJoinOrderedList,
         getAttributes: orderedAttrs,
       }),
-      wrappingInputRule({
+      fenceAwareWrappingInputRule({
         find: CJK_ORDERED_MARKER_RE,
         type: this.type,
         joinPredicate: canJoinOrderedList,

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -13,8 +13,8 @@ import { Selection, TextSelection } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
 const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
-const ORDERED_MARKER_RE = /^([1-9]\d{0,6})([.)])([ \t]+)$/;
-const CJK_ORDERED_MARKER_RE = /^([1-9]\d{0,6})(、)$/;
+const ORDERED_MARKER_RE = /^([1-9]\d{0,7})([.)])([ \t]+)$/;
+const CJK_ORDERED_MARKER_RE = /^([1-9]\d{0,7})(、)$/;
 
 type BulletMarker = '-' | '+' | '*' | '•';
 type OrderedMarker = '.' | ')' | '、';
@@ -89,7 +89,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { marker: bullet[1], separator: bullet[2] },
     };
   }
-  const ordered = text.match(/^([1-9]\d{0,6})([.)])([ \t]+)/);
+  const ordered = text.match(/^([1-9]\d{0,7})([.)])([ \t]+)/);
   if (ordered) {
     return {
       kind: 'ordered',
@@ -97,7 +97,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { start: Number(ordered[1]), marker: ordered[2], separator: ordered[3] },
     };
   }
-  const cjkOrdered = text.match(/^([1-9]\d{0,6})(、)([ \t]*)/);
+  const cjkOrdered = text.match(/^([1-9]\d{0,7})(、)([ \t]*)/);
   if (cjkOrdered) {
     return {
       kind: 'ordered',

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -60,7 +60,9 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
   if (cjkOrdered) {
     return {
       kind: 'ordered',
-      prefixLength: cjkOrdered[0].length,
+      // Keep optional spacing in the item body so direct transactions and
+      // normalized documents serialize CJK markers identically.
+      prefixLength: cjkOrdered[1].length + cjkOrdered[2].length,
       attrs: { start: Number(cjkOrdered[1]), marker: '、' },
     };
   }

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -554,12 +554,19 @@ export function isTrailingEmptyTopLevelParagraph(view: EditorView): boolean {
 export function isTopLevelBlockSelection(view: EditorView): boolean {
   const { state } = view;
   const { $from, $to } = state.selection;
-  return (
+  const spansTopLevelBlocks =
     !state.selection.empty &&
     $from.depth === 1 &&
     $to.depth === 1 &&
     $from.parentOffset === 0 &&
     $to.parentOffset === $to.parent.content.size
+  if (spansTopLevelBlocks) return true;
+  return (
+    !state.selection.empty &&
+    $from.depth === 0 &&
+    $to.depth === 0 &&
+    $from.pos === 0 &&
+    $to.pos === state.doc.content.size
   );
 }
 

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -12,9 +12,11 @@ import { liftListItem, splitListItem } from '@tiptap/pm/schema-list';
 import { Selection, TextSelection } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
-const ORDERED_MARKER_RE = /^\s*(\d{1,6})([.)])\s$/;
-const CJK_ORDERED_MARKER_RE = /^\s*(\d{1,6})(、)$/;
+const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
+const ORDERED_MARKER_RE = /^(\d{1,6})([.)])\s$/;
+const CJK_ORDERED_MARKER_RE = /^(\d{1,6})(、)$/;
 
+type BulletMarker = '-' | '+' | '*' | '•';
 type OrderedMarker = '.' | ')' | '、';
 
 interface OrderedListAttrs {
@@ -39,7 +41,11 @@ interface PlainListParagraphMarker {
 function plainListParagraphMarker(text: string): PlainListParagraphMarker | null {
   const bullet = text.match(/^([-+*•])([ \t]+)/);
   if (bullet) {
-    return { kind: 'bullet', prefixLength: bullet[0].length, attrs: {} };
+    return {
+      kind: 'bullet',
+      prefixLength: bullet[0].length,
+      attrs: { marker: bullet[1], separator: bullet[2] },
+    };
   }
   const ordered = text.match(/^(\d{1,6})([.)])([ \t]+)/);
   if (ordered) {
@@ -133,6 +139,25 @@ export const ComposerBulletList = Node.create({
   group: 'block',
   content: 'listItem+',
   defining: true,
+  addAttributes() {
+    return {
+      marker: {
+        default: '-',
+        parseHTML: (element) => {
+          const value = element.getAttribute('data-marker');
+          return value === '+' || value === '*' || value === '•' ? value : '-';
+        },
+        renderHTML: (attributes) =>
+          attributes.marker === '-' ? {} : { 'data-marker': attributes.marker },
+      },
+      separator: {
+        default: ' ',
+        parseHTML: (element) => element.getAttribute('data-separator') || ' ',
+        renderHTML: (attributes) =>
+          attributes.separator === ' ' ? {} : { 'data-separator': attributes.separator },
+      },
+    };
+  },
   parseHTML() {
     return [{ tag: 'ul' }];
   },
@@ -142,10 +167,17 @@ export const ComposerBulletList = Node.create({
   addInputRules() {
     return [
       wrappingInputRule({
-        find: /^\s*([-+*•])\s$/,
+        find: BULLET_MARKER_RE,
         type: this.type,
+        getAttributes: (match) => ({
+          marker: match[1] as BulletMarker,
+          separator: match[2],
+        }),
       }),
-      hardBreakListInputRule(/^\s*([-+*•])\s$/, this.type),
+      hardBreakListInputRule(BULLET_MARKER_RE, this.type, (match) => ({
+        marker: match[1] as BulletMarker,
+        separator: match[2],
+      })),
     ];
   },
 });
@@ -187,8 +219,18 @@ export const ComposerOrderedList = Node.create({
   parseHTML() {
     return [{ tag: 'ol' }];
   },
-  renderHTML({ HTMLAttributes }) {
-    return ['ol', mergeAttributes(HTMLAttributes), 0];
+  renderHTML({ node, HTMLAttributes }) {
+    const start = Number(node.attrs.start);
+    const lastItem = start + Math.max(node.childCount - 1, 0);
+    const markerDigits =
+      Number.isInteger(start) && start > 0 && Number.isInteger(lastItem)
+        ? String(lastItem).length
+        : 1;
+    return [
+      'ol',
+      mergeAttributes(HTMLAttributes, { 'data-marker-digits': String(markerDigits) }),
+      0,
+    ];
   },
   addInputRules() {
     return [

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -13,8 +13,8 @@ import { Selection, TextSelection } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
 const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
-const ORDERED_MARKER_RE = /^([1-9]\d{0,7})([.)])([ \t]+)$/;
-const CJK_ORDERED_MARKER_RE = /^([1-9]\d{0,7})(、)$/;
+const ORDERED_MARKER_RE = /^([1-9]\d{0,8})([.)])([ \t]+)$/;
+const CJK_ORDERED_MARKER_RE = /^([1-9]\d{0,8})(、)$/;
 
 type BulletMarker = '-' | '+' | '*' | '•';
 type OrderedMarker = '.' | ')' | '、';
@@ -89,7 +89,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { marker: bullet[1], separator: bullet[2] },
     };
   }
-  const ordered = text.match(/^([1-9]\d{0,7})([.)])([ \t]+)/);
+  const ordered = text.match(/^([1-9]\d{0,8})([.)])([ \t]+)/);
   if (ordered) {
     return {
       kind: 'ordered',
@@ -97,7 +97,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { start: Number(ordered[1]), marker: ordered[2], separator: ordered[3] },
     };
   }
-  const cjkOrdered = text.match(/^([1-9]\d{0,7})(、)([ \t]*)/);
+  const cjkOrdered = text.match(/^([1-9]\d{0,8})(、)([ \t]*)/);
   if (cjkOrdered) {
     return {
       kind: 'ordered',
@@ -138,6 +138,7 @@ function hardBreakListInputRule(
       const hardBreak = paragraph.nodeAt(markerOffset - 1);
       if (hardBreak?.type.name !== 'hardBreak') return null;
       if (paragraphOffsetIsInsideFence(paragraph, markerOffset)) return null;
+      if (documentFenceStateBefore(state.doc, $markerStart.before(1))) return null;
 
       const before = paragraph.content.cut(0, markerOffset - hardBreak.nodeSize);
       const after = paragraph.content.cut(range.to - paragraphStart);
@@ -349,11 +350,21 @@ function selectedListItemDepth(view: EditorView): number | null {
 
 function selectedListItemIsEmpty(view: EditorView, depth: number): boolean {
   const item = view.state.selection.$from.node(depth);
+  const paragraph = item.firstChild;
   return (
     item.childCount === 1 &&
-    item.firstChild?.type.name === 'paragraph' &&
-    item.firstChild.content.size === 0
+    paragraph?.type.name === 'paragraph' &&
+    paragraph.content.content.every((node) => node.isText && !(node.text ?? '').trim())
   );
+}
+
+function liftEmptyStructuredListItem(view: EditorView, itemType: NodeType): boolean {
+  const { $from } = view.state.selection;
+  const paragraph = $from.parent;
+  if (paragraph.type.name === 'paragraph' && paragraph.content.size > 0) {
+    view.dispatch(view.state.tr.delete($from.start(), $from.end()));
+  }
+  return liftListItem(itemType)(view.state, view.dispatch);
 }
 
 function selectedListItemIsOnlyTaskParagraph(view: EditorView, depth: number): boolean {
@@ -438,7 +449,7 @@ export function handleStructuredListBreak(view: EditorView): boolean {
     return clearTaskPrefixAndLift(view, itemDepth, taskPrefix);
   }
   if (selectedListItemIsEmpty(view, itemDepth)) {
-    return liftListItem(itemType)(state, view.dispatch);
+    return liftEmptyStructuredListItem(view, itemType);
   }
   const split = splitListItem(itemType)(state, view.dispatch);
   if (split && taskPrefix?.caretAtOrAfterPrefix) {
@@ -455,6 +466,10 @@ export function handleStructuredListBackspace(view: EditorView): boolean {
   const { $from } = state.selection;
   const itemDepth = selectedListItemDepth(view);
   const taskPrefix = selectedTaskPrefix(view);
+  const emptyItem = itemDepth !== null && selectedListItemIsEmpty(view, itemDepth);
+  const emptyItemCaret =
+    emptyItem &&
+    ($from.parentOffset === 0 || $from.parentOffset === $from.parent.content.size);
   if (
     !itemType ||
     !state.selection.empty ||
@@ -464,12 +479,12 @@ export function handleStructuredListBackspace(view: EditorView): boolean {
         !taskPrefix.caretAtOrAfterPrefix ||
         !taskPrefix.caretAtParagraphEnd ||
         !selectedListItemIsOnlyTaskParagraph(view, itemDepth)
-      : $from.parentOffset !== 0 || !selectedListItemIsEmpty(view, itemDepth))
+      : (!emptyItemCaret && $from.parentOffset !== 0) || !emptyItem)
   ) {
     return false;
   }
   if (taskPrefix) return clearTaskPrefixAndLift(view, itemDepth, taskPrefix);
-  return liftListItem(itemType)(state, view.dispatch);
+  return liftEmptyStructuredListItem(view, itemType);
 }
 
 /**

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -142,10 +142,10 @@ export const ComposerBulletList = Node.create({
   addInputRules() {
     return [
       wrappingInputRule({
-        find: /^\s*([-+*])\s$/,
+        find: /^\s*([-+*•])\s$/,
         type: this.type,
       }),
-      hardBreakListInputRule(/^\s*([-+*])\s$/, this.type),
+      hardBreakListInputRule(/^\s*([-+*•])\s$/, this.type),
     ];
   },
 });

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -425,6 +425,12 @@ function getTrailingPlainListParagraph(view: EditorView): {
   }
 
   const paragraph = $from.parent;
+  let hasHardBreak = false;
+  paragraph.forEach((child) => {
+    if (child.type.name === 'hardBreak') hasHardBreak = true;
+  });
+  if (hasHardBreak) return null;
+
   const text = paragraph.textBetween(0, paragraph.content.size, '\uFFFC', '\uFFFC');
   const marker = plainListParagraphMarker(text);
   const first = paragraph.firstChild;

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -1,0 +1,405 @@
+/**
+ * Structured list nodes for the chat composer.
+ *
+ * The composer stores list structure in its ProseMirror document and only
+ * turns it back into Markdown at send time. This keeps wrapping, nested
+ * items, and inline atoms in one layout tree instead of estimating marker
+ * widths with decorations.
+ */
+import { InputRule, Node, mergeAttributes, wrappingInputRule, type NodeConfig } from '@tiptap/core';
+import { Fragment, type Node as PMNode, type NodeType } from '@tiptap/pm/model';
+import { liftListItem, splitListItem } from '@tiptap/pm/schema-list';
+import { Selection, TextSelection } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+
+const ORDERED_MARKER_RE = /^\s*(\d{1,6})([.)])\s$/;
+const CJK_ORDERED_MARKER_RE = /^\s*(\d{1,6})(、)$/;
+
+type OrderedMarker = '.' | ')' | '、';
+
+interface OrderedListAttrs {
+  start: number;
+  marker: OrderedMarker;
+}
+
+interface SelectedTaskPrefix {
+  from: number;
+  to: number;
+  bodyIsEmpty: boolean;
+  caretAtOrAfterPrefix: boolean;
+  caretAtParagraphEnd: boolean;
+}
+
+interface PlainListParagraphMarker {
+  kind: 'bullet' | 'ordered';
+  prefixLength: number;
+  attrs: Record<string, unknown>;
+}
+
+function plainListParagraphMarker(text: string): PlainListParagraphMarker | null {
+  const bullet = text.match(/^([-+*•])([ \t]+)/);
+  if (bullet) {
+    return { kind: 'bullet', prefixLength: bullet[0].length, attrs: {} };
+  }
+  const ordered = text.match(/^(\d{1,6})([.)])([ \t]+)/);
+  if (ordered) {
+    return {
+      kind: 'ordered',
+      prefixLength: ordered[0].length,
+      attrs: { start: Number(ordered[1]), marker: ordered[2] },
+    };
+  }
+  const cjkOrdered = text.match(/^(\d{1,6})(、)([ \t]*)/);
+  if (cjkOrdered) {
+    return {
+      kind: 'ordered',
+      prefixLength: cjkOrdered[0].length,
+      attrs: { start: Number(cjkOrdered[1]), marker: '、' },
+    };
+  }
+  return null;
+}
+
+function hardBreakListInputRule(
+  find: RegExp,
+  type: NodeType,
+  getAttributes: (match: RegExpMatchArray) => object = () => ({}),
+): InputRule {
+  return new InputRule({
+    find: (text) => {
+      const lineStart = text.lastIndexOf('\n');
+      if (lineStart < 0) return null;
+      const line = text.slice(lineStart + 1);
+      const match = line.match(find);
+      if (!match) return null;
+      return {
+        text: line,
+        index: lineStart + 1,
+        data: { attributes: getAttributes(match) },
+      };
+    },
+    handler: ({ state, range, match }) => {
+      const $markerStart = state.doc.resolve(range.from);
+      if ($markerStart.depth !== 1 || $markerStart.parent.type.name !== 'paragraph') return null;
+
+      const paragraph = $markerStart.parent;
+      const paragraphStart = $markerStart.start();
+      const markerOffset = range.from - paragraphStart;
+      const hardBreak = paragraph.nodeAt(markerOffset - 1);
+      if (hardBreak?.type.name !== 'hardBreak') return null;
+
+      const before = paragraph.content.cut(0, markerOffset - hardBreak.nodeSize);
+      const after = paragraph.content.cut(range.to - paragraphStart);
+      const paragraphType = state.schema.nodes.paragraph;
+      const itemType = state.schema.nodes.listItem;
+      if (!paragraphType || !itemType) return null;
+
+      const leadingParagraph = paragraph.type.create(paragraph.attrs, before, paragraph.marks);
+      const listParagraph = paragraphType.create(null, after);
+      const list = type.create(
+        (match.data?.attributes as Record<string, unknown> | undefined) ?? {},
+        itemType.create(null, listParagraph),
+      );
+      const paragraphPosition = $markerStart.before(1);
+      const replacement = Fragment.fromArray([leadingParagraph, list]);
+      const tr = state.tr.replaceWith(
+        paragraphPosition,
+        paragraphPosition + paragraph.nodeSize,
+        replacement,
+      );
+      const listPosition = paragraphPosition + leadingParagraph.nodeSize;
+      tr.setSelection(TextSelection.create(tr.doc, listPosition + 3));
+    },
+  });
+}
+
+const listItemConfig: NodeConfig = {
+  name: 'listItem',
+  group: 'block',
+  content: 'paragraph block*',
+  defining: true,
+  parseHTML() {
+    return [{ tag: 'li' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['li', mergeAttributes(HTMLAttributes), 0];
+  },
+};
+
+export const ComposerListItem = Node.create(listItemConfig);
+
+export const ComposerBulletList = Node.create({
+  name: 'bulletList',
+  group: 'block',
+  content: 'listItem+',
+  defining: true,
+  parseHTML() {
+    return [{ tag: 'ul' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['ul', mergeAttributes(HTMLAttributes), 0];
+  },
+  addInputRules() {
+    return [
+      wrappingInputRule({
+        find: /^\s*([-+*])\s$/,
+        type: this.type,
+      }),
+      hardBreakListInputRule(/^\s*([-+*])\s$/, this.type),
+    ];
+  },
+});
+
+function orderedAttrs(match: RegExpMatchArray): OrderedListAttrs {
+  const marker = (match[2] ?? '、') as OrderedMarker;
+  return {
+    start: Number(match[1] ?? 1),
+    marker,
+  };
+}
+
+export const ComposerOrderedList = Node.create({
+  name: 'orderedList',
+  group: 'block',
+  content: 'listItem+',
+  defining: true,
+  addAttributes() {
+    return {
+      start: {
+        default: 1,
+        parseHTML: (element) => {
+          const value = Number(element.getAttribute('start'));
+          return Number.isInteger(value) && value > 0 ? value : 1;
+        },
+        renderHTML: (attributes) => (attributes.start === 1 ? {} : { start: attributes.start }),
+      },
+      marker: {
+        default: '.',
+        parseHTML: (element) => {
+          const value = element.getAttribute('data-marker');
+          return value === ')' || value === '、' ? value : '.';
+        },
+        renderHTML: (attributes) =>
+          attributes.marker === '.' ? {} : { 'data-marker': attributes.marker },
+      },
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'ol' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['ol', mergeAttributes(HTMLAttributes), 0];
+  },
+  addInputRules() {
+    return [
+      wrappingInputRule({
+        find: ORDERED_MARKER_RE,
+        type: this.type,
+        getAttributes: orderedAttrs,
+      }),
+      wrappingInputRule({
+        find: CJK_ORDERED_MARKER_RE,
+        type: this.type,
+        getAttributes: orderedAttrs,
+      }),
+      hardBreakListInputRule(ORDERED_MARKER_RE, this.type, orderedAttrs),
+      hardBreakListInputRule(CJK_ORDERED_MARKER_RE, this.type, orderedAttrs),
+    ];
+  },
+});
+
+function selectedListItemDepth(view: EditorView): number | null {
+  const { $from } = view.state.selection;
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    if ($from.node(depth).type.name === 'listItem') return depth;
+  }
+  return null;
+}
+
+function selectedListItemIsEmpty(view: EditorView, depth: number): boolean {
+  const item = view.state.selection.$from.node(depth);
+  return (
+    item.childCount === 1 &&
+    item.firstChild?.type.name === 'paragraph' &&
+    item.firstChild.content.size === 0
+  );
+}
+
+function selectedListItemIsOnlyTaskParagraph(view: EditorView, depth: number): boolean {
+  const item = view.state.selection.$from.node(depth);
+  return item.childCount === 1 && item.firstChild === view.state.selection.$from.parent;
+}
+
+function selectedTaskPrefix(view: EditorView): SelectedTaskPrefix | null {
+  const { $from } = view.state.selection;
+  const paragraph = $from.parent;
+  if (paragraph.type.name !== 'paragraph') return null;
+  const text = paragraph.textBetween(0, paragraph.content.size, '\uFFFC', '\uFFFC');
+  const match = text.match(/^\[[ xX]\](?:[ \t]+|$)/);
+  if (!match) return null;
+  return {
+    from: $from.start(),
+    to: $from.start() + match[0].length,
+    bodyIsEmpty: text.slice(match[0].length).trim().length === 0,
+    caretAtOrAfterPrefix: $from.parentOffset >= match[0].length,
+    caretAtParagraphEnd: $from.parentOffset === paragraph.content.size,
+  };
+}
+
+function clearTaskPrefixAndLift(
+  view: EditorView,
+  itemDepth: number,
+  taskPrefix: SelectedTaskPrefix,
+): boolean {
+  if (
+    !taskPrefix.bodyIsEmpty ||
+    !taskPrefix.caretAtParagraphEnd ||
+    !selectedListItemIsOnlyTaskParagraph(view, itemDepth)
+  ) {
+    return false;
+  }
+  view.dispatch(view.state.tr.delete(taskPrefix.from, taskPrefix.to));
+  const itemType = view.state.schema.nodes.listItem;
+  if (itemType) liftListItem(itemType)(view.state, view.dispatch);
+  return true;
+}
+
+function backspaceAfterStructuredList(view: EditorView): boolean {
+  const { state } = view;
+  const { $from } = state.selection;
+  if (
+    !state.selection.empty ||
+    $from.depth !== 1 ||
+    $from.parent.type.name !== 'paragraph' ||
+    $from.parent.content.size !== 0 ||
+    $from.parentOffset !== 0
+  ) {
+    return false;
+  }
+  const paragraphPosition = $from.before(1);
+  const previous = state.doc.resolve(paragraphPosition).nodeBefore;
+  if (previous?.type.name !== 'bulletList' && previous?.type.name !== 'orderedList') return false;
+
+  const tr = state.tr.delete(paragraphPosition, paragraphPosition + $from.parent.nodeSize);
+  tr.setSelection(Selection.near(tr.doc.resolve(paragraphPosition), -1));
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+/**
+ * Continue a structured list on the composer's explicit newline shortcuts.
+ * An empty item exits the list; a non-empty item becomes two sibling items.
+ * Markdown task prefixes remain editable text, with new items reset to
+ * unchecked state.
+ */
+export function handleStructuredListBreak(view: EditorView): boolean {
+  const { state } = view;
+  const itemType = state.schema.nodes.listItem;
+  const itemDepth = selectedListItemDepth(view);
+  if (!itemType || !state.selection.empty || itemDepth === null) return false;
+  const taskPrefix = selectedTaskPrefix(view);
+  if (
+    taskPrefix?.bodyIsEmpty &&
+    taskPrefix.caretAtOrAfterPrefix &&
+    taskPrefix.caretAtParagraphEnd
+  ) {
+    if (!selectedListItemIsOnlyTaskParagraph(view, itemDepth)) return false;
+    return clearTaskPrefixAndLift(view, itemDepth, taskPrefix);
+  }
+  if (selectedListItemIsEmpty(view, itemDepth)) {
+    return liftListItem(itemType)(state, view.dispatch);
+  }
+  const split = splitListItem(itemType)(state, view.dispatch);
+  if (split && taskPrefix?.caretAtOrAfterPrefix) {
+    view.dispatch(view.state.tr.insertText('[ ] ').scrollIntoView());
+  }
+  return split;
+}
+
+/** Exit an empty structured item with one Backspace, matching plain-list input. */
+export function handleStructuredListBackspace(view: EditorView): boolean {
+  const { state } = view;
+  if (backspaceAfterStructuredList(view)) return true;
+  const itemType = state.schema.nodes.listItem;
+  const { $from } = state.selection;
+  const itemDepth = selectedListItemDepth(view);
+  const taskPrefix = selectedTaskPrefix(view);
+  if (
+    !itemType ||
+    !state.selection.empty ||
+    itemDepth === null ||
+    (taskPrefix
+      ? !taskPrefix.bodyIsEmpty ||
+        !taskPrefix.caretAtOrAfterPrefix ||
+        !taskPrefix.caretAtParagraphEnd ||
+        !selectedListItemIsOnlyTaskParagraph(view, itemDepth)
+      : $from.parentOffset !== 0 || !selectedListItemIsEmpty(view, itemDepth))
+  ) {
+    return false;
+  }
+  if (taskPrefix) return clearTaskPrefixAndLift(view, itemDepth, taskPrefix);
+  return liftListItem(itemType)(state, view.dispatch);
+}
+
+/**
+ * Upgrade a plain list row appended by paste, IME, dictation, or another
+ * direct transaction that does not run input rules.
+ *
+ * The command is intentionally scoped to the final top-level paragraph and
+ * an end-of-document caret. Restored documents and multi-row text are
+ * normalized before insertion; this closes the remaining live-editing gap
+ * without rescanning or rebuilding the full document after every keystroke.
+ */
+function getTrailingPlainListParagraph(view: EditorView): {
+  paragraph: PMNode;
+  marker: PlainListParagraphMarker;
+  paragraphPosition: number;
+} | null {
+  const { state } = view;
+  const { $from } = state.selection;
+  if (
+    !state.selection.empty ||
+    $from.depth !== 1 ||
+    $from.parent.type.name !== 'paragraph' ||
+    $from.parentOffset !== $from.parent.content.size ||
+    $from.after(1) !== state.doc.content.size
+  ) {
+    return null;
+  }
+
+  const paragraph = $from.parent;
+  const text = paragraph.textBetween(0, paragraph.content.size, '\uFFFC', '\uFFFC');
+  const marker = plainListParagraphMarker(text);
+  const first = paragraph.firstChild;
+  if (!marker || first?.type.name !== 'text' || (first.text?.length ?? 0) < marker.prefixLength) {
+    return null;
+  }
+  return { paragraph, marker, paragraphPosition: $from.before(1) };
+}
+
+export function hasTrailingPlainListParagraph(view: EditorView): boolean {
+  return getTrailingPlainListParagraph(view) !== null;
+}
+
+export function promoteTrailingPlainListParagraph(view: EditorView): boolean {
+  const trailing = getTrailingPlainListParagraph(view);
+  if (!trailing) return false;
+  const { state } = view;
+  const { paragraph, marker, paragraphPosition } = trailing;
+
+  const paragraphType = state.schema.nodes.paragraph;
+  const itemType = state.schema.nodes.listItem;
+  const listType =
+    marker.kind === 'ordered' ? state.schema.nodes.orderedList : state.schema.nodes.bulletList;
+  if (!paragraphType || !itemType || !listType) return false;
+
+  const body = paragraph.content.cut(marker.prefixLength);
+  const list = listType.create(
+    marker.attrs,
+    itemType.create(null, paragraphType.create(paragraph.attrs, body)),
+  );
+  const tr = state.tr.replaceWith(paragraphPosition, paragraphPosition + paragraph.nodeSize, list);
+  tr.setSelection(TextSelection.atEnd(tr.doc));
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -13,7 +13,7 @@ import { Selection, TextSelection } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
 const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
-const ORDERED_MARKER_RE = /^(\d{1,6})([.)])\s$/;
+const ORDERED_MARKER_RE = /^(\d{1,6})([.)])([ \t]+)$/;
 const CJK_ORDERED_MARKER_RE = /^(\d{1,6})(、)$/;
 
 type BulletMarker = '-' | '+' | '*' | '•';
@@ -22,6 +22,7 @@ type OrderedMarker = '.' | ')' | '、';
 interface OrderedListAttrs {
   start: number;
   marker: OrderedMarker;
+  separator: string;
 }
 
 interface SelectedTaskPrefix {
@@ -52,7 +53,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
     return {
       kind: 'ordered',
       prefixLength: ordered[0].length,
-      attrs: { start: Number(ordered[1]), marker: ordered[2] },
+      attrs: { start: Number(ordered[1]), marker: ordered[2], separator: ordered[3] },
     };
   }
   const cjkOrdered = text.match(/^(\d{1,6})(、)([ \t]*)/);
@@ -187,6 +188,7 @@ function orderedAttrs(match: RegExpMatchArray): OrderedListAttrs {
   return {
     start: Number(match[1] ?? 1),
     marker,
+    ...(marker === '、' ? { separator: '' } : { separator: match[3] ?? ' ' }),
   };
 }
 
@@ -213,6 +215,17 @@ export const ComposerOrderedList = Node.create({
         },
         renderHTML: (attributes) =>
           attributes.marker === '.' ? {} : { 'data-marker': attributes.marker },
+      },
+      separator: {
+        default: ' ',
+        parseHTML: (element) => {
+          const marker = element.getAttribute('data-marker');
+          return marker === '、' ? '' : element.getAttribute('data-separator') || ' ';
+        },
+        renderHTML: (attributes) =>
+          attributes.marker === '、' || attributes.separator === ' '
+            ? {}
+            : { 'data-separator': attributes.separator },
       },
     };
   },

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -13,8 +13,8 @@ import { Selection, TextSelection } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
 const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
-const ORDERED_MARKER_RE = /^(\d{1,6})([.)])([ \t]+)$/;
-const CJK_ORDERED_MARKER_RE = /^(\d{1,6})(、)$/;
+const ORDERED_MARKER_RE = /^([1-9]\d{0,5})([.)])([ \t]+)$/;
+const CJK_ORDERED_MARKER_RE = /^([1-9]\d{0,5})(、)$/;
 
 type BulletMarker = '-' | '+' | '*' | '•';
 type OrderedMarker = '.' | ')' | '、';
@@ -48,7 +48,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { marker: bullet[1], separator: bullet[2] },
     };
   }
-  const ordered = text.match(/^(\d{1,6})([.)])([ \t]+)/);
+  const ordered = text.match(/^([1-9]\d{0,5})([.)])([ \t]+)/);
   if (ordered) {
     return {
       kind: 'ordered',
@@ -56,7 +56,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { start: Number(ordered[1]), marker: ordered[2], separator: ordered[3] },
     };
   }
-  const cjkOrdered = text.match(/^(\d{1,6})(、)([ \t]*)/);
+  const cjkOrdered = text.match(/^([1-9]\d{0,5})(、)([ \t]*)/);
   if (cjkOrdered) {
     return {
       kind: 'ordered',
@@ -172,6 +172,8 @@ export const ComposerBulletList = Node.create({
       wrappingInputRule({
         find: BULLET_MARKER_RE,
         type: this.type,
+        joinPredicate: (match, before) =>
+          before.attrs.marker === match[1] && before.attrs.separator === match[2],
         getAttributes: (match) => ({
           marker: match[1] as BulletMarker,
           separator: match[2],
@@ -192,6 +194,15 @@ function orderedAttrs(match: RegExpMatchArray): OrderedListAttrs {
     marker,
     ...(marker === '、' ? { separator: '' } : { separator: match[3] ?? ' ' }),
   };
+}
+
+function canJoinOrderedList(match: RegExpMatchArray, before: PMNode): boolean {
+  const attrs = orderedAttrs(match);
+  return (
+    before.attrs.marker === attrs.marker &&
+    (before.attrs.separator ?? (attrs.marker === '、' ? '' : ' ')) === attrs.separator &&
+    before.attrs.start + before.childCount === attrs.start
+  );
 }
 
 export const ComposerOrderedList = Node.create({
@@ -252,11 +263,13 @@ export const ComposerOrderedList = Node.create({
       wrappingInputRule({
         find: ORDERED_MARKER_RE,
         type: this.type,
+        joinPredicate: canJoinOrderedList,
         getAttributes: orderedAttrs,
       }),
       wrappingInputRule({
         find: CJK_ORDERED_MARKER_RE,
         type: this.type,
+        joinPredicate: canJoinOrderedList,
         getAttributes: orderedAttrs,
       }),
       hardBreakListInputRule(ORDERED_MARKER_RE, this.type, orderedAttrs),

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -13,8 +13,8 @@ import { Selection, TextSelection } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
 const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
-const ORDERED_MARKER_RE = /^([1-9]\d{0,5})([.)])([ \t]+)$/;
-const CJK_ORDERED_MARKER_RE = /^([1-9]\d{0,5})(、)$/;
+const ORDERED_MARKER_RE = /^([1-9]\d{0,6})([.)])([ \t]+)$/;
+const CJK_ORDERED_MARKER_RE = /^([1-9]\d{0,6})(、)$/;
 
 type BulletMarker = '-' | '+' | '*' | '•';
 type OrderedMarker = '.' | ')' | '、';
@@ -55,9 +55,8 @@ function isFenceClosing(text: string, state: FenceState): boolean {
   return pattern.test(text);
 }
 
-function paragraphOffsetIsInsideFence(paragraph: PMNode, offset: number): boolean {
-  const text = paragraph.textBetween(0, offset, '\n', '\n');
-  let fence: FenceState | null = null;
+function scanFenceState(text: string, initialFence: FenceState | null): FenceState | null {
+  let fence = initialFence;
   for (const line of text.split('\n')) {
     if (fence) {
       if (isFenceClosing(line, fence)) fence = null;
@@ -65,7 +64,20 @@ function paragraphOffsetIsInsideFence(paragraph: PMNode, offset: number): boolea
     }
     fence = fenceOpening(line);
   }
-  return fence !== null;
+  return fence;
+}
+
+function paragraphOffsetIsInsideFence(paragraph: PMNode, offset: number): boolean {
+  return scanFenceState(paragraph.textBetween(0, offset, '\n', '\n'), null) !== null;
+}
+
+function documentFenceStateBefore(doc: PMNode, position: number): FenceState | null {
+  let fence: FenceState | null = null;
+  doc.forEach((node, nodeOffset) => {
+    if (nodeOffset >= position || node.type.name !== 'paragraph') return;
+    fence = scanFenceState(node.textBetween(0, node.content.size, '\n', '\n'), fence);
+  });
+  return fence;
 }
 
 function plainListParagraphMarker(text: string): PlainListParagraphMarker | null {
@@ -77,7 +89,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { marker: bullet[1], separator: bullet[2] },
     };
   }
-  const ordered = text.match(/^([1-9]\d{0,5})([.)])([ \t]+)/);
+  const ordered = text.match(/^([1-9]\d{0,6})([.)])([ \t]+)/);
   if (ordered) {
     return {
       kind: 'ordered',
@@ -85,7 +97,7 @@ function plainListParagraphMarker(text: string): PlainListParagraphMarker | null
       attrs: { start: Number(ordered[1]), marker: ordered[2], separator: ordered[3] },
     };
   }
-  const cjkOrdered = text.match(/^([1-9]\d{0,5})(、)([ \t]*)/);
+  const cjkOrdered = text.match(/^([1-9]\d{0,6})(、)([ \t]*)/);
   if (cjkOrdered) {
     return {
       kind: 'ordered',
@@ -134,7 +146,7 @@ function hardBreakListInputRule(
       if (!paragraphType || !itemType) return null;
 
       const leadingParagraph = paragraph.type.create(paragraph.attrs, before, paragraph.marks);
-      const listParagraph = paragraphType.create(null, after);
+      const listParagraph = paragraph.type.create(paragraph.attrs, after, paragraph.marks);
       const list = type.create(
         (match.data?.attributes as Record<string, unknown> | undefined) ?? {},
         itemType.create(null, listParagraph),
@@ -505,11 +517,24 @@ export function isTrailingEmptyTopLevelParagraph(view: EditorView): boolean {
   );
 }
 
+export function isTopLevelBlockSelection(view: EditorView): boolean {
+  const { state } = view;
+  const { $from, $to } = state.selection;
+  return (
+    !state.selection.empty &&
+    $from.depth === 1 &&
+    $to.depth === 1 &&
+    $from.parentOffset === 0 &&
+    $to.parentOffset === $to.parent.content.size
+  );
+}
+
 export function promoteTrailingPlainListParagraph(view: EditorView): boolean {
   const trailing = getTrailingPlainListParagraph(view);
   if (!trailing) return false;
   const { state } = view;
   const { paragraph, marker, paragraphPosition } = trailing;
+  if (documentFenceStateBefore(state.doc, paragraphPosition)) return false;
 
   const paragraphType = state.schema.nodes.paragraph;
   const itemType = state.schema.nodes.listItem;

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -39,6 +39,35 @@ interface PlainListParagraphMarker {
   attrs: Record<string, unknown>;
 }
 
+interface FenceState {
+  char: '`' | '~';
+  length: number;
+}
+
+function fenceOpening(text: string): FenceState | null {
+  const match = text.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  if (!match || (match[1][0] === '`' && match[2].includes('`'))) return null;
+  return { char: match[1][0] as FenceState['char'], length: match[1].length };
+}
+
+function isFenceClosing(text: string, state: FenceState): boolean {
+  const pattern = new RegExp(`^ {0,3}${state.char}{${state.length},}[ \\t]*$`);
+  return pattern.test(text);
+}
+
+function paragraphOffsetIsInsideFence(paragraph: PMNode, offset: number): boolean {
+  const text = paragraph.textBetween(0, offset, '\n', '\n');
+  let fence: FenceState | null = null;
+  for (const line of text.split('\n')) {
+    if (fence) {
+      if (isFenceClosing(line, fence)) fence = null;
+      continue;
+    }
+    fence = fenceOpening(line);
+  }
+  return fence !== null;
+}
+
 function plainListParagraphMarker(text: string): PlainListParagraphMarker | null {
   const bullet = text.match(/^([-+*•])([ \t]+)/);
   if (bullet) {
@@ -96,6 +125,7 @@ function hardBreakListInputRule(
       const markerOffset = range.from - paragraphStart;
       const hardBreak = paragraph.nodeAt(markerOffset - 1);
       if (hardBreak?.type.name !== 'hardBreak') return null;
+      if (paragraphOffsetIsInsideFence(paragraph, markerOffset)) return null;
 
       const before = paragraph.content.cut(0, markerOffset - hardBreak.nodeSize);
       const after = paragraph.content.cut(range.to - paragraphStart);
@@ -455,6 +485,24 @@ function getTrailingPlainListParagraph(view: EditorView): {
 
 export function hasTrailingPlainListParagraph(view: EditorView): boolean {
   return getTrailingPlainListParagraph(view) !== null;
+}
+
+export function isTrailingEmptyTopLevelParagraph(view: EditorView): boolean {
+  const { state } = view;
+  const { $from } = state.selection;
+  if (
+    !state.selection.empty ||
+    $from.depth !== 1 ||
+    $from.parent.type.name !== 'paragraph' ||
+    $from.parentOffset !== $from.parent.content.size ||
+    $from.after(1) !== state.doc.content.size
+  ) {
+    return false;
+  }
+  return (
+    $from.parent.content.size === 0 ||
+    ($from.parent.childCount === 1 && $from.parent.firstChild?.type.name === 'hardBreak')
+  );
 }
 
 export function promoteTrailingPlainListParagraph(view: EditorView): boolean {

--- a/apps/desktop/src/renderer/components/new-chat/GhostCommandDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/GhostCommandDecoration.ts
@@ -77,9 +77,7 @@ export function findGhostCommandMatch(
       // A command after a leading structured list is not a message-start
       // command. Let the placement path insert the selected command before
       // that list instead of replacing the later paragraph.
-      if (para.textContent.trim().length > 0) return null;
-      paraPos += para.nodeSize;
-      continue;
+      return null;
     }
     let childPos = paraPos + 1; // 段落内容起点
     for (let ci = 0; ci < para.childCount; ci++) {

--- a/apps/desktop/src/renderer/components/new-chat/GhostCommandDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/GhostCommandDecoration.ts
@@ -74,6 +74,10 @@ export function findGhostCommandMatch(
   for (let pi = 0; pi < doc.childCount; pi++) {
     const para = doc.child(pi);
     if (para.type.name !== 'paragraph') {
+      // A command after a leading structured list is not a message-start
+      // command. Let the placement path insert the selected command before
+      // that list instead of replacing the later paragraph.
+      if (para.textContent.trim().length > 0) return null;
       paraPos += para.nodeSize;
       continue;
     }

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -38,7 +38,7 @@ export interface SerializedComposerContent {
 type OrderedMarker = '.' | ')' | '、';
 
 const EMPTY_LIST_ITEM_MARKER_RE =
-  /(?:^|\n)[ \t]*(?:[1-9]\d{0,5}[.)][ \t]+|[1-9]\d{0,5}、[ \t]*|[-+*•][ \t]+)$/;
+  /(?:^|\n)[ \t]*(?:[1-9]\d{0,6}[.)][ \t]+|[1-9]\d{0,6}、[ \t]*|[-+*•][ \t]+)$/;
 
 const TAB_SIZE = 4;
 
@@ -56,8 +56,8 @@ function expandedIndentWidth(text: string): number {
 
 function literalListContinuationPrefix(text: string): string | null {
   const match =
-    text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,5}[.)])([ \t]+)/) ??
-    text.match(/^([ \t]+)[1-9]\d{0,5}、[ \t]*/);
+    text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,6}[.)])([ \t]+)/) ??
+    text.match(/^([ \t]+)[1-9]\d{0,6}、[ \t]*/);
   if (!match) return null;
   return ' '.repeat(expandedIndentWidth(match[0]));
 }
@@ -161,7 +161,7 @@ function serializeComposerDocument(
         const quoteText = formatQuoteForSend(
           composerQuoteAttrsToChatQuote(child.attrs as ComposerQuoteAttrs),
         );
-        if (prefix) {
+      if (prefix || continuationIndent) {
           // A quote chip inside a list item is part of that item. Keeping it
           // in the current text block preserves the list marker. Put the
           // encoded quote on its own continuation lines so history parsing
@@ -189,7 +189,7 @@ function serializeComposerDocument(
         const textAfterIndent = alreadyIndented
           ? childText.slice(continuationAfterQuote.length)
           : childText;
-        const needsQuoteBoundary = /^>[ \t]/.test(textAfterIndent);
+        const needsQuoteBoundary = /^>(?:[ \t]|$)/.test(textAfterIndent);
         buffer += `${needsQuoteBoundary ? '\n\n' : '\n'}${
           alreadyIndented ? '' : continuationAfterQuote
         }`;
@@ -363,6 +363,25 @@ function serializeComposerDocument(
             .map((line) => `${literalContinuation}${line}`)
             .join('\n'),
         });
+        return;
+      }
+      const inlineQuoteOffset = (() => {
+        let offset = 0;
+        for (let index = 0; index < node.childCount; index += 1) {
+          const child = node.child(index);
+          if (child.type.name === COMPOSER_QUOTE_NODE_TYPE) return offset;
+          offset += child.nodeSize;
+        }
+        return null;
+      })();
+      const inlineLiteralContinuation =
+        inlineQuoteOffset !== null
+          ? literalListContinuationPrefix(
+              node.textBetween(0, inlineQuoteOffset, '\n', '\uFFFC'),
+            )
+          : null;
+      if (inlineLiteralContinuation) {
+        serializeParagraph(node, nodeOffset, '', inlineLiteralContinuation);
         return;
       }
       serializeParagraph(node, nodeOffset);

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -161,7 +161,7 @@ function serializeComposerDocument(
         const quoteText = formatQuoteForSend(
           composerQuoteAttrsToChatQuote(child.attrs as ComposerQuoteAttrs),
         );
-      if (prefix || continuationIndent) {
+        if (prefix || continuationIndent) {
           // A quote chip inside a list item is part of that item. Keeping it
           // in the current text block preserves the list marker. Put the
           // encoded quote on its own continuation lines so history parsing

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -38,7 +38,7 @@ export interface SerializedComposerContent {
 type OrderedMarker = '.' | ')' | '、';
 
 const EMPTY_LIST_ITEM_MARKER_RE =
-  /(?:^|\n)[ \t]*(?:[1-9]\d{0,7}[.)][ \t]+|[1-9]\d{0,7}、[ \t]*|[-+*•][ \t]+)$/;
+  /(?:^|\n)[ \t]*(?:[1-9]\d{0,8}[.)][ \t]+|[1-9]\d{0,8}、[ \t]*|[-+*•][ \t]+)$/;
 
 const TAB_SIZE = 4;
 
@@ -56,8 +56,8 @@ function expandedIndentWidth(text: string): number {
 
 function literalListContinuationPrefix(text: string): string | null {
   const match =
-    text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,7}[.)])([ \t]+)/) ??
-    text.match(/^([ \t]+)[1-9]\d{0,7}、[ \t]*/);
+    text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,8}[.)])([ \t]+)/) ??
+    text.match(/^([ \t]+)[1-9]\d{0,8}、[ \t]*/);
   if (!match) return null;
   return ' '.repeat(expandedIndentWidth(match[0]));
 }

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -94,6 +94,7 @@ function serializeComposerDocument(
     let bufferPastedTextRanges: PastedTextRange[] = [];
     let bufferSlashCommandRanges: SlashCommandRange[] = [];
     let emittedInlineSegment = false;
+    let continuationAfterQuote: string | null = null;
 
     const flushText = (force = false) => {
       if (!force && !buffer) return;
@@ -136,19 +137,26 @@ function serializeComposerDocument(
         );
         if (prefix) {
           // A quote chip inside a list item is part of that item. Keeping it
-          // in the current text block preserves the list marker instead of
-          // emitting an empty item followed by a top-level quote block.
+          // in the current text block preserves the list marker. Put the
+          // encoded quote on its own continuation lines so history parsing
+          // can still recognize the private marker and source metadata.
           const continuationPrefix = ' '.repeat(prefix.length);
           const quoteLines = quoteText.split('\n');
-          buffer += quoteLines
-            .map((line, index) => (index === 0 ? line : `${continuationPrefix}${line}`))
-            .join('\n');
+          buffer += `\n${quoteLines
+            .map((line) => `${continuationPrefix}${line}`)
+            .join('\n')}`;
+          continuationAfterQuote = continuationPrefix;
         } else {
           flushText();
           blocks.push({ kind: 'quote', text: quoteText });
           emittedInlineSegment = true;
         }
         return;
+      }
+
+      if (continuationAfterQuote !== null) {
+        buffer += `\n${continuationAfterQuote}`;
+        continuationAfterQuote = null;
       }
 
       if (child.type.name === 'mentionChip') {

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -1,5 +1,6 @@
 import type { Editor } from '@tiptap/core';
-import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Slice, type Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { EditorState } from '@tiptap/pm/state';
 import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
 
 import type { MentionedResource } from '@/lib/fileTypes';
@@ -40,15 +41,27 @@ function orderedListMarker(node: ProseMirrorNode): OrderedMarker {
   return node.attrs.marker === ')' || node.attrs.marker === '、' ? node.attrs.marker : '.';
 }
 
+function bulletListMarker(node: ProseMirrorNode): string {
+  const marker = node.attrs.marker;
+  return marker === '+' || marker === '*' || marker === '•' ? marker : '-';
+}
+
+function bulletListSeparator(node: ProseMirrorNode): string {
+  return typeof node.attrs.separator === 'string' && /^[ \t]+$/.test(node.attrs.separator)
+    ? node.attrs.separator
+    : ' ';
+}
+
 /**
  * Convert the composer's structured document into the Markdown wire format.
  *
  * List markers are editor structure rather than paragraph text, so their
  * serialized width is included when projecting inline reference ranges.
  */
-export function serializeEditorContent(editor: Editor): SerializedComposerContent {
-  const doc = editor.state.doc;
-  const decoratedSlashMatches = getDecoratedSlashCommandMatches(editor);
+function serializeComposerDocument(
+  doc: ProseMirrorNode,
+  decoratedSlashMatches: readonly SlashCommandMatch[],
+): SerializedComposerContent {
   const blocks: ComposerSerializedBlock[] = [];
   const mentions: MentionedResource[] = [];
   const seenMentions = new Set<string>();
@@ -110,15 +123,24 @@ export function serializeEditorContent(editor: Editor): SerializedComposerConten
 
     paragraph.forEach((child, childOffset) => {
       if (child.type.name === COMPOSER_QUOTE_NODE_TYPE) {
-        flushText();
         hasQuotes = true;
-        blocks.push({
-          kind: 'quote',
-          text: formatQuoteForSend(
-            composerQuoteAttrsToChatQuote(child.attrs as ComposerQuoteAttrs),
-          ),
-        });
-        emittedInlineSegment = true;
+        const quoteText = formatQuoteForSend(
+          composerQuoteAttrsToChatQuote(child.attrs as ComposerQuoteAttrs),
+        );
+        if (prefix) {
+          // A quote chip inside a list item is part of that item. Keeping it
+          // in the current text block preserves the list marker instead of
+          // emitting an empty item followed by a top-level quote block.
+          const continuationPrefix = ' '.repeat(prefix.length);
+          const quoteLines = quoteText.split('\n');
+          buffer += quoteLines
+            .map((line, index) => (index === 0 ? line : `${continuationPrefix}${line}`))
+            .join('\n');
+        } else {
+          flushText();
+          blocks.push({ kind: 'quote', text: quoteText });
+          emittedInlineSegment = true;
+        }
         return;
       }
 
@@ -236,7 +258,7 @@ export function serializeEditorContent(editor: Editor): SerializedComposerConten
       const itemPosition = listPosition + 1 + itemOffset;
       const itemMarker = isOrdered
         ? `${start + itemIndex}${marker}${marker === '、' ? '' : ' '}`
-        : '- ';
+        : `${bulletListMarker(listNode)}${bulletListSeparator(listNode)}`;
       const itemIndent = `${indent}${' '.repeat(itemMarker.length)}`;
       let firstParagraph = true;
 
@@ -281,4 +303,29 @@ export function serializeEditorContent(editor: Editor): SerializedComposerConten
     mentions,
     hasQuotes,
   };
+}
+
+export function serializeEditorContent(editor: Editor): SerializedComposerContent {
+  return serializeComposerDocument(editor.state.doc, getDecoratedSlashCommandMatches(editor));
+}
+
+/**
+ * Serialize a selected editor fragment for plain-text clipboard consumers.
+ * Replacing an empty document with the open slice lets ProseMirror rebuild
+ * list context around selections that begin or end inside a list item.
+ */
+export function serializeEditorSlice(editor: Editor | null, slice: Slice): string {
+  if (!editor) {
+    return slice.content.textBetween(0, slice.content.size, '\n');
+  }
+
+  try {
+    const emptyDoc = editor.state.schema.topNodeType.createAndFill();
+    if (!emptyDoc) throw new Error('composer schema cannot create an empty document');
+    const state = EditorState.create({ schema: editor.state.schema, doc: emptyDoc });
+    const replaced = state.tr.replace(0, state.doc.content.size, slice).doc;
+    return serializeComposerDocument(replaced, []).text;
+  } catch {
+    return slice.content.textBetween(0, slice.content.size, '\n');
+  }
 }

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -1,5 +1,5 @@
 import type { Editor } from '@tiptap/core';
-import { Slice, type Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Fragment, Slice, type Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { EditorState } from '@tiptap/pm/state';
 import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
 
@@ -38,7 +38,27 @@ export interface SerializedComposerContent {
 type OrderedMarker = '.' | ')' | '、';
 
 const EMPTY_LIST_ITEM_MARKER_RE =
-  /(?:^|\n)(?:[1-9]\d{0,5}[.)][ \t]+|[1-9]\d{0,5}、[ \t]*|[-+*•][ \t]+)$/;
+  /(?:^|\n)[ \t]*(?:[1-9]\d{0,5}[.)][ \t]+|[1-9]\d{0,5}、[ \t]*|[-+*•][ \t]+)$/;
+
+const TAB_SIZE = 4;
+
+function expandedIndentWidth(text: string): number {
+  let column = 0;
+  for (const character of text) {
+    if (character === '\t') {
+      column += TAB_SIZE - (column % TAB_SIZE);
+    } else {
+      column += 1;
+    }
+  }
+  return column;
+}
+
+function literalListContinuationPrefix(text: string): string | null {
+  const match = text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,5}[.)、])([ \t]+)/);
+  if (!match) return null;
+  return ' '.repeat(expandedIndentWidth(match[0]));
+}
 
 function orderedListMarker(node: ProseMirrorNode): OrderedMarker {
   return node.attrs.marker === ')' || node.attrs.marker === '、' ? node.attrs.marker : '.';
@@ -143,7 +163,7 @@ function serializeComposerDocument(
           // in the current text block preserves the list marker. Put the
           // encoded quote on its own continuation lines so history parsing
           // can still recognize the private marker and source metadata.
-          const continuationPrefix = ' '.repeat(prefix.length);
+          const continuationPrefix = ' '.repeat(expandedIndentWidth(prefix));
           const quoteLines = quoteText.split('\n');
           const quoteSeparator = continuationAfterQuote === null ? '' : '\n';
           buffer += `${quoteSeparator}\n${quoteLines
@@ -281,7 +301,7 @@ function serializeComposerDocument(
       const itemMarker = isOrdered
         ? `${start + itemIndex}${marker}${separator}`
         : `${bulletListMarker(listNode)}${bulletListSeparator(listNode)}`;
-      const itemIndent = `${indent}${' '.repeat(itemMarker.length)}`;
+      const itemIndent = ' '.repeat(expandedIndentWidth(`${indent}${itemMarker}`));
       let firstParagraph = true;
 
       item.forEach((child, childOffset) => {
@@ -302,7 +322,7 @@ function serializeComposerDocument(
     });
   };
 
-  doc.forEach((node, nodeOffset) => {
+  doc.forEach((node, nodeOffset, nodeIndex) => {
     if (node.type.name === COMPOSER_QUOTE_NODE_TYPE) {
       hasQuotes = true;
       blocks.push({
@@ -312,6 +332,27 @@ function serializeComposerDocument(
       return;
     }
     if (node.type.name === 'paragraph') {
+      const onlyQuote =
+        node.childCount === 1 && node.firstChild?.type.name === COMPOSER_QUOTE_NODE_TYPE;
+      const previous = nodeIndex > 0 ? doc.child(nodeIndex - 1) : null;
+      const literalContinuation =
+        onlyQuote && previous?.type.name === 'paragraph'
+          ? literalListContinuationPrefix(previous.textContent)
+          : null;
+      if (literalContinuation) {
+        hasQuotes = true;
+        const quoteText = formatQuoteForSend(
+          composerQuoteAttrsToChatQuote(node.firstChild!.attrs as ComposerQuoteAttrs),
+        );
+        blocks.push({
+          kind: 'text',
+          text: quoteText
+            .split('\n')
+            .map((line) => `${literalContinuation}${line}`)
+            .join('\n'),
+        });
+        return;
+      }
       serializeParagraph(node, nodeOffset);
       return;
     }
@@ -348,7 +389,77 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
     const emptyDoc = editor.state.schema.topNodeType.createAndFill();
     if (!emptyDoc) throw new Error('composer schema cannot create an empty document');
     const state = EditorState.create({ schema: editor.state.schema, doc: emptyDoc });
-    const replaced = state.tr.replace(0, state.doc.content.size, slice).doc;
+    const { $from } = editor.state.selection;
+    let sourceList: ProseMirrorNode | null = null;
+    let sourceListDepth: number | null = null;
+    for (let depth = $from.depth; depth > 0; depth -= 1) {
+      const list = $from.node(depth);
+      if (list.type.name !== 'orderedList') continue;
+      sourceList = list;
+      sourceListDepth = depth;
+      break;
+    }
+    let replaced = state.tr.replace(0, state.doc.content.size, slice).doc;
+    const sourceIndex = sourceListDepth === null ? null : $from.index(sourceListDepth);
+    const firstOrderedList = (() => {
+      let found: { node: ProseMirrorNode; position: number } | null = null;
+      replaced.descendants((node, position) => {
+        if (found === null && node.type.name === 'orderedList') {
+          found = { node, position };
+          return false;
+        }
+        return found === null;
+      });
+      return found;
+    })();
+
+    // A text-only slice from inside a list item loses the enclosing list.
+    // Rebuild the selected source items so plain-text copies keep their marker.
+    if (sourceList && sourceIndex !== null && firstOrderedList === null) {
+      const endResolved = editor.state.doc.resolve(editor.state.selection.to);
+      const endIndex =
+        sourceListDepth !== null && endResolved.node(sourceListDepth) === sourceList
+          ? endResolved.index(sourceListDepth) + 1
+          : sourceIndex;
+      const items = sourceList.content.content.slice(sourceIndex, Math.max(sourceIndex + 1, endIndex));
+      if (items.length > 0) {
+        const copiedList = sourceList.copy(Fragment.from(items));
+        replaced = state.tr.replace(
+          0,
+          state.doc.content.size,
+          new Slice(Fragment.from(copiedList), 0, 0),
+        ).doc;
+      }
+    }
+
+    // A partial selection keeps the source list's attrs but may omit earlier
+    // siblings. Shift the copied ordered-list start to the selected item.
+    const copiedStart =
+      sourceList && sourceIndex !== null
+        ? Number(sourceList.attrs.start) + sourceIndex
+        : null;
+    if (copiedStart !== null) {
+      let orderedListPosition: number | null = null;
+      replaced.descendants((node, position) => {
+        if (orderedListPosition === null && node.type.name === 'orderedList') {
+          orderedListPosition = position;
+          return false;
+        }
+        return orderedListPosition === null;
+      });
+      if (orderedListPosition !== null) {
+        const node = replaced.nodeAt(orderedListPosition);
+        if (node) {
+          const replacedState = EditorState.create({ schema: editor.state.schema, doc: replaced });
+          replaced = replacedState.tr
+            .setNodeMarkup(orderedListPosition, node.type, {
+              ...node.attrs,
+              start: copiedStart,
+            })
+            .doc;
+        }
+      }
+    }
     return serializeComposerDocument(replaced, []).text;
   } catch {
     return slice.content.textBetween(0, slice.content.size, '\n');

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -41,6 +41,13 @@ function orderedListMarker(node: ProseMirrorNode): OrderedMarker {
   return node.attrs.marker === ')' || node.attrs.marker === '、' ? node.attrs.marker : '.';
 }
 
+function orderedListSeparator(node: ProseMirrorNode, marker: OrderedMarker): string {
+  if (marker === '、') return '';
+  return typeof node.attrs.separator === 'string' && /^[ \t]+$/.test(node.attrs.separator)
+    ? node.attrs.separator
+    : ' ';
+}
+
 function bulletListMarker(node: ProseMirrorNode): string {
   const marker = node.attrs.marker;
   return marker === '+' || marker === '*' || marker === '•' ? marker : '-';
@@ -252,12 +259,13 @@ function serializeComposerDocument(
         ? listNode.attrs.start
         : 1;
     const marker = orderedListMarker(listNode);
+    const separator = orderedListSeparator(listNode, marker);
 
     listNode.forEach((item, itemOffset, itemIndex) => {
       if (item.type.name !== 'listItem') return;
       const itemPosition = listPosition + 1 + itemOffset;
       const itemMarker = isOrdered
-        ? `${start + itemIndex}${marker}${marker === '、' ? '' : ' '}`
+        ? `${start + itemIndex}${marker}${separator}`
         : `${bulletListMarker(listNode)}${bulletListSeparator(listNode)}`;
       const itemIndent = `${indent}${' '.repeat(itemMarker.length)}`;
       let firstParagraph = true;

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -189,7 +189,20 @@ function serializeComposerDocument(
       }
 
       if (continuationAfterQuote !== null) {
-        const childText = child.isText ? (child.text ?? '') : '';
+        if (child.type.name === 'hardBreak') {
+          // The quote parser needs a blank-line boundary, while the hard
+          // break itself still needs one indented continuation line. Emit
+          // both together so we do not leave an indentation-only line
+          // between two separately serialized breaks.
+          buffer += `\n\n${continuationIndent}`;
+          continuationAfterQuote = null;
+          return;
+        }
+        const childText = child.isText
+          ? (child.text ?? '')
+          : child.type.name === 'pastedTextChip'
+            ? String((child.attrs as PastedTextChipAttrs).text ?? '')
+            : '';
         const alreadyIndented =
           child.isText && childText.startsWith(continuationAfterQuote);
         const textAfterIndent = alreadyIndented

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -38,7 +38,7 @@ export interface SerializedComposerContent {
 type OrderedMarker = '.' | ')' | '、';
 
 const EMPTY_LIST_ITEM_MARKER_RE =
-  /(?:^|\n)[ \t]*(?:[1-9]\d{0,6}[.)][ \t]+|[1-9]\d{0,6}、[ \t]*|[-+*•][ \t]+)$/;
+  /(?:^|\n)[ \t]*(?:[1-9]\d{0,7}[.)][ \t]+|[1-9]\d{0,7}、[ \t]*|[-+*•][ \t]+)$/;
 
 const TAB_SIZE = 4;
 
@@ -56,8 +56,8 @@ function expandedIndentWidth(text: string): number {
 
 function literalListContinuationPrefix(text: string): string | null {
   const match =
-    text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,6}[.)])([ \t]+)/) ??
-    text.match(/^([ \t]+)[1-9]\d{0,6}、[ \t]*/);
+    text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,7}[.)])([ \t]+)/) ??
+    text.match(/^([ \t]+)[1-9]\d{0,7}、[ \t]*/);
   if (!match) return null;
   return ' '.repeat(expandedIndentWidth(match[0]));
 }
@@ -169,9 +169,15 @@ function serializeComposerDocument(
           const continuationPrefix =
             continuationIndent || ' '.repeat(expandedIndentWidth(prefix));
           const quoteLines = quoteText.split('\n');
-          const quoteSeparator = continuationAfterQuote === null ? '' : '\n';
-          buffer += `${quoteSeparator}\n${quoteLines
-            .map((line) => `${continuationPrefix}${line}`)
+          const hasContinuationLine =
+            continuationAfterQuote === null &&
+            buffer.endsWith(`\n${continuationPrefix}`);
+          const quoteSeparator =
+            continuationAfterQuote !== null ? '\n\n' : hasContinuationLine ? '' : '\n';
+          buffer += `${quoteSeparator}${quoteLines
+            .map((line, index) =>
+              hasContinuationLine && index === 0 ? line : `${continuationPrefix}${line}`,
+            )
             .join('\n')}`;
           continuationAfterQuote = continuationPrefix;
         } else {
@@ -266,7 +272,9 @@ function serializeComposerDocument(
       if (child.type.name === 'pastedTextChip') {
         const attrs = child.attrs as PastedTextChipAttrs;
         const start = buffer.length;
-        buffer += attrs.text;
+        buffer += continuationIndent
+          ? attrs.text.replace(/\n/g, `\n${continuationIndent}`)
+          : attrs.text;
         bufferPastedTextRanges.push({ start, end: buffer.length, display: attrs.display });
         return;
       }
@@ -466,14 +474,21 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
         ? Number(sourceList.attrs.start) + sourceIndex
         : null;
     if (copiedStart !== null) {
-      let orderedListPosition: number | null = null;
+      let firstContentPosition: number | null = null;
       replaced.descendants((node, position) => {
-        if (orderedListPosition === null && node.type.name === 'orderedList') {
-          orderedListPosition = position;
+        if (firstContentPosition === null && (node.isText || node.isAtom)) {
+          firstContentPosition = position;
           return false;
         }
-        return orderedListPosition === null;
+        return firstContentPosition === null;
       });
+      const $firstContent = replaced.resolve(firstContentPosition ?? 0);
+      let orderedListPosition: number | null = null;
+      for (let depth = $firstContent.depth; depth > 0; depth -= 1) {
+        if ($firstContent.node(depth).type.name !== 'orderedList') continue;
+        orderedListPosition = $firstContent.before(depth);
+        break;
+      }
       if (orderedListPosition !== null) {
         const node = replaced.nodeAt(orderedListPosition);
         if (node) {

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -429,8 +429,9 @@ export function serializeEditorContent(editor: Editor): SerializedComposerConten
 
 /**
  * Serialize a selected editor fragment for plain-text clipboard consumers.
- * Replacing an empty document with the open slice lets ProseMirror rebuild
- * list context around selections that begin or end inside a list item.
+ * Replacing an empty document with the open slice lets ProseMirror retain
+ * surrounding structure; ordered-list context is rebuilt below when an
+ * inline-only slice omits it.
  */
 export function serializeEditorSlice(editor: Editor | null, slice: Slice): string {
   if (!editor) {

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -55,7 +55,9 @@ function expandedIndentWidth(text: string): number {
 }
 
 function literalListContinuationPrefix(text: string): string | null {
-  const match = text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,5}[.)、])([ \t]+)/);
+  const match =
+    text.match(/^([ \t]+)(?:[-+*•]|[1-9]\d{0,5}[.)])([ \t]+)/) ??
+    text.match(/^([ \t]+)[1-9]\d{0,5}、[ \t]*/);
   if (!match) return null;
   return ' '.repeat(expandedIndentWidth(match[0]));
 }
@@ -111,6 +113,7 @@ function serializeComposerDocument(
     paragraph: ProseMirrorNode,
     paragraphPosition: number,
     prefix = '',
+    continuationIndent = '',
   ) => {
     let buffer = prefix;
     let bufferAgentReferences: AgentInputReference[] = [];
@@ -163,7 +166,8 @@ function serializeComposerDocument(
           // in the current text block preserves the list marker. Put the
           // encoded quote on its own continuation lines so history parsing
           // can still recognize the private marker and source metadata.
-          const continuationPrefix = ' '.repeat(expandedIndentWidth(prefix));
+          const continuationPrefix =
+            continuationIndent || ' '.repeat(expandedIndentWidth(prefix));
           const quoteLines = quoteText.split('\n');
           const quoteSeparator = continuationAfterQuote === null ? '' : '\n';
           buffer += `${quoteSeparator}\n${quoteLines
@@ -179,9 +183,16 @@ function serializeComposerDocument(
       }
 
       if (continuationAfterQuote !== null) {
+        const childText = child.isText ? (child.text ?? '') : '';
         const alreadyIndented =
-          child.isText && (child.text ?? '').startsWith(continuationAfterQuote);
-        buffer += `\n${alreadyIndented ? '' : continuationAfterQuote}`;
+          child.isText && childText.startsWith(continuationAfterQuote);
+        const textAfterIndent = alreadyIndented
+          ? childText.slice(continuationAfterQuote.length)
+          : childText;
+        const needsQuoteBoundary = /^>[ \t]/.test(textAfterIndent);
+        buffer += `${needsQuoteBoundary ? '\n\n' : '\n'}${
+          alreadyIndented ? '' : continuationAfterQuote
+        }`;
         continuationAfterQuote = null;
       }
 
@@ -261,7 +272,7 @@ function serializeComposerDocument(
       }
 
       if (child.type.name === 'hardBreak') {
-        buffer += '\n';
+        buffer += `\n${continuationIndent}`;
         return;
       }
 
@@ -311,6 +322,7 @@ function serializeComposerDocument(
             child,
             childPosition,
             firstParagraph ? `${indent}${itemMarker}` : itemIndent,
+            itemIndent,
           );
           firstParagraph = false;
           return;
@@ -416,14 +428,10 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
     // A text-only slice from inside a list item loses the enclosing list.
     // Rebuild the selected source items so plain-text copies keep their marker.
     if (sourceList && sourceIndex !== null && firstOrderedList === null) {
-      const endResolved = editor.state.doc.resolve(editor.state.selection.to);
-      const endIndex =
-        sourceListDepth !== null && endResolved.node(sourceListDepth) === sourceList
-          ? endResolved.index(sourceListDepth) + 1
-          : sourceIndex;
-      const items = sourceList.content.content.slice(sourceIndex, Math.max(sourceIndex + 1, endIndex));
-      if (items.length > 0) {
-        const copiedList = sourceList.copy(Fragment.from(items));
+      const itemType = editor.state.schema.nodes.listItem;
+      if (itemType?.validContent(replaced.content)) {
+        const copiedItem = itemType.create(null, replaced.content);
+        const copiedList = sourceList.copy(Fragment.from(copiedItem));
         replaced = state.tr.replace(
           0,
           state.doc.content.size,

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -1,0 +1,282 @@
+import type { Editor } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
+
+import type { MentionedResource } from '@/lib/fileTypes';
+import { formatQuoteForSend } from '@/lib/chatQuotes';
+import { formatMentionRef } from '@/lib/mentionRefFormat';
+import {
+  parseProjectDeepLinkHref,
+  parseSessionDeepLinkHref,
+  projectDisplayName,
+} from '@/lib/deepLink';
+import {
+  COMPOSER_QUOTE_NODE_TYPE,
+  composerQuoteAttrsToChatQuote,
+  serializeComposerContentBlocksWithRanges,
+  type ComposerQuoteAttrs,
+  type ComposerSerializedBlock,
+} from '@/lib/composerQuoteDocument';
+import type { PastedTextRange, SlashCommandRange } from '@/lib/imageRef';
+
+import type { MentionChipAttrs } from './MentionChipNode';
+import type { PastedTextChipAttrs } from './PastedTextChipNode';
+import { getDecoratedSlashCommandMatches, type SlashCommandMatch } from './SlashCommandDecoration';
+import { serializeSessionChipText } from './sessionLinkPaste';
+import { serializeProjectChipText } from './pastePipeline';
+
+export interface SerializedComposerContent {
+  text: string;
+  mentions: MentionedResource[];
+  hasQuotes: boolean;
+  agentReferences: AgentInputReference[];
+  pastedTextRanges: PastedTextRange[];
+  slashCommandRanges: SlashCommandRange[];
+}
+
+type OrderedMarker = '.' | ')' | '、';
+
+function orderedListMarker(node: ProseMirrorNode): OrderedMarker {
+  return node.attrs.marker === ')' || node.attrs.marker === '、' ? node.attrs.marker : '.';
+}
+
+/**
+ * Convert the composer's structured document into the Markdown wire format.
+ *
+ * List markers are editor structure rather than paragraph text, so their
+ * serialized width is included when projecting inline reference ranges.
+ */
+export function serializeEditorContent(editor: Editor): SerializedComposerContent {
+  const doc = editor.state.doc;
+  const decoratedSlashMatches = getDecoratedSlashCommandMatches(editor);
+  const blocks: ComposerSerializedBlock[] = [];
+  const mentions: MentionedResource[] = [];
+  const seenMentions = new Set<string>();
+  let hasQuotes = false;
+
+  const addMention = (attrs: MentionChipAttrs) => {
+    // Slash commands and deep links are represented in the wire text but are
+    // not filesystem resources.
+    if (attrs.kind === 'slash' || attrs.kind === 'session' || attrs.kind === 'project') return;
+    const key = `${attrs.kind}:${attrs.path}`;
+    if (seenMentions.has(key)) return;
+    seenMentions.add(key);
+    mentions.push({ type: attrs.kind, name: attrs.label, path: attrs.path });
+  };
+
+  const serializeParagraph = (
+    paragraph: ProseMirrorNode,
+    paragraphPosition: number,
+    prefix = '',
+  ) => {
+    let buffer = prefix;
+    let bufferAgentReferences: AgentInputReference[] = [];
+    let bufferPastedTextRanges: PastedTextRange[] = [];
+    let bufferSlashCommandRanges: SlashCommandRange[] = [];
+    let emittedInlineSegment = false;
+
+    const flushText = (force = false) => {
+      if (!force && !buffer) return;
+      blocks.push({
+        kind: 'text',
+        text: buffer,
+        ...(bufferAgentReferences.length > 0 ? { agentReferences: bufferAgentReferences } : {}),
+        ...(bufferPastedTextRanges.length > 0 ? { pastedTextRanges: bufferPastedTextRanges } : {}),
+        ...(bufferSlashCommandRanges.length > 0
+          ? { slashCommandRanges: bufferSlashCommandRanges }
+          : {}),
+      });
+      buffer = '';
+      bufferAgentReferences = [];
+      bufferPastedTextRanges = [];
+      bufferSlashCommandRanges = [];
+      emittedInlineSegment = true;
+    };
+
+    const appendSlashCommandRanges = (
+      matches: readonly SlashCommandMatch[],
+      documentStart: number,
+      textLength: number,
+      bufferStart: number,
+    ) => {
+      for (const match of matches) {
+        if (match.from < documentStart || match.to > documentStart + textLength) continue;
+        bufferSlashCommandRanges.push({
+          start: bufferStart + match.from - documentStart,
+          end: bufferStart + match.to - documentStart,
+        });
+      }
+    };
+
+    paragraph.forEach((child, childOffset) => {
+      if (child.type.name === COMPOSER_QUOTE_NODE_TYPE) {
+        flushText();
+        hasQuotes = true;
+        blocks.push({
+          kind: 'quote',
+          text: formatQuoteForSend(
+            composerQuoteAttrsToChatQuote(child.attrs as ComposerQuoteAttrs),
+          ),
+        });
+        emittedInlineSegment = true;
+        return;
+      }
+
+      if (child.type.name === 'mentionChip') {
+        const attrs = child.attrs as MentionChipAttrs;
+        addMention(attrs);
+        if (attrs.kind === 'slash') {
+          buffer += `/${attrs.path} `;
+          return;
+        }
+        if (attrs.kind === 'session') {
+          const wire = serializeSessionChipText(attrs);
+          const start = buffer.length;
+          buffer += wire;
+          const target = parseSessionDeepLinkHref(attrs.path);
+          if (target?.messageClientId) {
+            bufferAgentReferences.push({
+              kind: 'message',
+              start,
+              end: buffer.length,
+              href: attrs.path,
+              sessionId: target.sessionId,
+              messageClientId: target.messageClientId,
+              ...(attrs.agentText ? { text: attrs.agentText } : {}),
+              ...(attrs.agentTextTruncated ? { truncated: true } : {}),
+            });
+          } else if (target) {
+            bufferAgentReferences.push({
+              kind: 'session',
+              start,
+              end: buffer.length,
+              href: attrs.path,
+              sessionId: target.sessionId,
+              ...(attrs.titled && attrs.label ? { title: attrs.label } : {}),
+            });
+          }
+          return;
+        }
+        if (attrs.kind === 'project') {
+          const wire = serializeProjectChipText(attrs);
+          const start = buffer.length;
+          buffer += wire;
+          const target = parseProjectDeepLinkHref(attrs.path);
+          if (target) {
+            bufferAgentReferences.push({
+              kind: 'project',
+              start,
+              end: buffer.length,
+              href: attrs.path,
+              name: attrs.label || projectDisplayName(target.workingDir),
+              workingDir: target.workingDir,
+            });
+          }
+          return;
+        }
+        if (attrs.kind === 'dir') {
+          buffer += `@${formatMentionRef(`${attrs.path}/`)}`;
+          return;
+        }
+        if (attrs.kind === 'agent') {
+          const path = attrs.path;
+          buffer += path.includes('/')
+            ? `@${formatMentionRef(path)}`
+            : `@${formatMentionRef(path.replace(/\.md$/, ''))}`;
+          return;
+        }
+        buffer += `@${formatMentionRef(attrs.path)}`;
+        return;
+      }
+
+      if (child.type.name === 'pastedTextChip') {
+        const attrs = child.attrs as PastedTextChipAttrs;
+        const start = buffer.length;
+        buffer += attrs.text;
+        bufferPastedTextRanges.push({ start, end: buffer.length, display: attrs.display });
+        return;
+      }
+
+      if (child.type.name === 'hardBreak') {
+        buffer += '\n';
+        return;
+      }
+
+      if (child.isText) {
+        const childText = child.text ?? '';
+        const bufferStart = buffer.length;
+        const documentStart = paragraphPosition + 1 + childOffset;
+        buffer += childText;
+        appendSlashCommandRanges(
+          decoratedSlashMatches,
+          documentStart,
+          childText.length,
+          bufferStart,
+        );
+      }
+    });
+
+    // Preserve truly empty paragraphs as line breaks, but do not synthesize an
+    // empty text segment after a quote chip at the end of a paragraph.
+    flushText(!emittedInlineSegment);
+  };
+
+  const serializeList = (listNode: ProseMirrorNode, listPosition: number, indent: string) => {
+    const isOrdered = listNode.type.name === 'orderedList';
+    const start =
+      typeof listNode.attrs.start === 'number' &&
+      Number.isInteger(listNode.attrs.start) &&
+      listNode.attrs.start > 0
+        ? listNode.attrs.start
+        : 1;
+    const marker = orderedListMarker(listNode);
+
+    listNode.forEach((item, itemOffset, itemIndex) => {
+      if (item.type.name !== 'listItem') return;
+      const itemPosition = listPosition + 1 + itemOffset;
+      const itemMarker = isOrdered ? `${start + itemIndex}${marker} ` : '- ';
+      const itemIndent = `${indent}${' '.repeat(itemMarker.length)}`;
+      let firstParagraph = true;
+
+      item.forEach((child, childOffset) => {
+        const childPosition = itemPosition + 1 + childOffset;
+        if (child.type.name === 'paragraph') {
+          serializeParagraph(
+            child,
+            childPosition,
+            firstParagraph ? `${indent}${itemMarker}` : itemIndent,
+          );
+          firstParagraph = false;
+          return;
+        }
+        if (child.type.name === 'bulletList' || child.type.name === 'orderedList') {
+          serializeList(child, childPosition, itemIndent);
+        }
+      });
+    });
+  };
+
+  doc.forEach((node, nodeOffset) => {
+    if (node.type.name === COMPOSER_QUOTE_NODE_TYPE) {
+      hasQuotes = true;
+      blocks.push({
+        kind: 'quote',
+        text: formatQuoteForSend(composerQuoteAttrsToChatQuote(node.attrs as ComposerQuoteAttrs)),
+      });
+      return;
+    }
+    if (node.type.name === 'paragraph') {
+      serializeParagraph(node, nodeOffset);
+      return;
+    }
+    if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
+      serializeList(node, nodeOffset, '');
+    }
+  });
+
+  return {
+    ...serializeComposerContentBlocksWithRanges(blocks),
+    mentions,
+    hasQuotes,
+  };
+}

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -37,6 +37,9 @@ export interface SerializedComposerContent {
 
 type OrderedMarker = '.' | ')' | '、';
 
+const EMPTY_LIST_ITEM_MARKER_RE =
+  /(?:^|\n)(?:[1-9]\d{0,5}[.)][ \t]+|[1-9]\d{0,5}、[ \t]*|[-+*•][ \t]+)$/;
+
 function orderedListMarker(node: ProseMirrorNode): OrderedMarker {
   return node.attrs.marker === ')' || node.attrs.marker === '、' ? node.attrs.marker : '.';
 }
@@ -142,7 +145,8 @@ function serializeComposerDocument(
           // can still recognize the private marker and source metadata.
           const continuationPrefix = ' '.repeat(prefix.length);
           const quoteLines = quoteText.split('\n');
-          buffer += `\n${quoteLines
+          const quoteSeparator = continuationAfterQuote === null ? '' : '\n';
+          buffer += `${quoteSeparator}\n${quoteLines
             .map((line) => `${continuationPrefix}${line}`)
             .join('\n')}`;
           continuationAfterQuote = continuationPrefix;
@@ -155,7 +159,9 @@ function serializeComposerDocument(
       }
 
       if (continuationAfterQuote !== null) {
-        buffer += `\n${continuationAfterQuote}`;
+        const alreadyIndented =
+          child.isText && (child.text ?? '').startsWith(continuationAfterQuote);
+        buffer += `\n${alreadyIndented ? '' : continuationAfterQuote}`;
         continuationAfterQuote = null;
       }
 
@@ -314,8 +320,11 @@ function serializeComposerDocument(
     }
   });
 
+  const lastTextBlock = blocks.at(-1);
+  const preserveTrailingWhitespace =
+    lastTextBlock?.kind === 'text' && EMPTY_LIST_ITEM_MARKER_RE.test(lastTextBlock.text);
   return {
-    ...serializeComposerContentBlocksWithRanges(blocks),
+    ...serializeComposerContentBlocksWithRanges(blocks, { preserveTrailingWhitespace }),
     mentions,
     hasQuotes,
   };

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -234,7 +234,9 @@ export function serializeEditorContent(editor: Editor): SerializedComposerConten
     listNode.forEach((item, itemOffset, itemIndex) => {
       if (item.type.name !== 'listItem') return;
       const itemPosition = listPosition + 1 + itemOffset;
-      const itemMarker = isOrdered ? `${start + itemIndex}${marker} ` : '- ';
+      const itemMarker = isOrdered
+        ? `${start + itemIndex}${marker}${marker === '、' ? '' : ' '}`
+        : '- ';
       const itemIndent = `${indent}${' '.repeat(itemMarker.length)}`;
       let firstParagraph = true;
 

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -454,9 +454,11 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
     }
     let replaced = state.tr.replace(0, state.doc.content.size, slice).doc;
     const sourceIndex = sourceListDepth === null ? null : $from.index(sourceListDepth);
-    const firstOrderedList = (() => {
+    const findFirstOrderedList = (
+      document: ProseMirrorNode,
+    ): { node: ProseMirrorNode; position: number } | null => {
       let found: { node: ProseMirrorNode; position: number } | null = null;
-      replaced.descendants((node, position) => {
+      document.descendants((node, position) => {
         if (found === null && node.type.name === 'orderedList') {
           found = { node, position };
           return false;
@@ -464,7 +466,8 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
         return found === null;
       });
       return found;
-    })();
+    };
+    let firstOrderedList = findFirstOrderedList(replaced);
 
     // A text-only slice from inside a list item loses the enclosing list.
     // Rebuild the selected source items so plain-text copies keep their marker.
@@ -478,6 +481,7 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
           state.doc.content.size,
           new Slice(Fragment.from(copiedList), 0, 0),
         ).doc;
+        firstOrderedList = findFirstOrderedList(replaced);
       }
     }
 
@@ -496,12 +500,16 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
         }
         return firstContentPosition === null;
       });
-      const $firstContent = replaced.resolve(firstContentPosition ?? 0);
-      let orderedListPosition: number | null = null;
-      for (let depth = $firstContent.depth; depth > 0; depth -= 1) {
-        if ($firstContent.node(depth).type.name !== 'orderedList') continue;
-        orderedListPosition = $firstContent.before(depth);
-        break;
+      let orderedListPosition: number | null = firstContentPosition === null
+        ? firstOrderedList?.position ?? null
+        : null;
+      if (firstContentPosition !== null) {
+        const $firstContent = replaced.resolve(firstContentPosition);
+        for (let depth = $firstContent.depth; depth > 0; depth -= 1) {
+          if ($firstContent.node(depth).type.name !== 'orderedList') continue;
+          orderedListPosition = $firstContent.before(depth);
+          break;
+        }
       }
       if (orderedListPosition !== null) {
         const node = replaced.nodeAt(orderedListPosition);

--- a/apps/desktop/src/renderer/components/new-chat/composerDocState.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerDocState.ts
@@ -23,7 +23,24 @@ export function docContainsAtomChip(doc: ProseMirrorNode): boolean {
   return found;
 }
 
+/** Structured list nodes carry a visible marker even when their paragraph is empty. */
+export function docContainsStructuredList(doc: ProseMirrorNode): boolean {
+  let found = false;
+  doc.descendants((node) => {
+    if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
+      found = true;
+      return false;
+    }
+    return !found;
+  });
+  return found;
+}
+
 /** 输入框文档是否"真空"(无文本且无 chip)——textContent 判空的 chip-aware 版。 */
 export function composerDocIsEmpty(doc: ProseMirrorNode): boolean {
-  return !docContainsAtomChip(doc) && doc.textContent.trim().length === 0;
+  return (
+    !docContainsAtomChip(doc) &&
+    !docContainsStructuredList(doc) &&
+    doc.textContent.trim().length === 0
+  );
 }

--- a/apps/desktop/src/renderer/components/new-chat/ghostComposerPlacement.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ghostComposerPlacement.ts
@@ -47,8 +47,16 @@ export function placeGhostAtComposerStart(
     );
   } else {
     const firstBlock = doc.firstChild;
-    if (!firstBlock?.isTextblock) return false;
-    transaction.insertText(`$${command} `, 1);
+    if (firstBlock?.isTextblock) {
+      transaction.insertText(`$${command} `, 1);
+    } else {
+      const paragraphType = editor.state.schema.nodes.paragraph;
+      if (!paragraphType) return false;
+      transaction.insert(
+        0,
+        paragraphType.create(null, editor.state.schema.text(`$${command} `)),
+      );
+    }
   }
 
   editor.view.dispatch(transaction);

--- a/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
@@ -89,6 +89,24 @@ describe('draftHasContent', () => {
       ),
     ).toBe(true);
   });
+
+  it('counts an empty structured list item as content', () => {
+    expect(
+      draftHasContent(
+        draft({
+          text: {
+            type: 'doc',
+            content: [
+              {
+                type: 'bulletList',
+                content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }],
+              },
+            ],
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe('owner isolation', () => {

--- a/apps/desktop/src/renderer/lib/__tests__/composerListContinuation.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/composerListContinuation.test.ts
@@ -11,6 +11,13 @@ describe('computeListContinuation', () => {
       expect(computeListContinuation('12) bar')).toEqual({ action: 'continue', insert: '13) ' });
     });
 
+    it('七位数序号正常自增', () => {
+      expect(computeListContinuation('999999. item')).toEqual({
+        action: 'continue',
+        insert: '1000000. ',
+      });
+    });
+
     it('保留分隔符后的多余空白', () => {
       expect(computeListContinuation('3.  foo')).toEqual({ action: 'continue', insert: '4.  ' });
     });
@@ -29,7 +36,7 @@ describe('computeListContinuation', () => {
       expect(computeListContinuation('5、')).toEqual({ action: 'exit' });
     });
 
-    it('光标在标记后、正文前(`1. |todo`)不算空项 → 接续拆分,不退出(codex P2)', () => {
+    it('光标在标记后、正文前(`1. |todo`)不算空项 → 接续拆分,不退出', () => {
       // 光标前 = "1. "(rest 空),但光标后仍有 "todo" → 整行非空 → continue
       expect(computeListContinuation('1. ', 'todo')).toEqual({ action: 'continue', insert: '2. ' });
       // 光标后是空白也算空项

--- a/apps/desktop/src/renderer/lib/__tests__/composerListContinuation.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/composerListContinuation.test.ts
@@ -18,6 +18,13 @@ describe('computeListContinuation', () => {
       });
     });
 
+    it('八位数序号正常接续', () => {
+      expect(computeListContinuation('10000000. item')).toEqual({
+        action: 'continue',
+        insert: '10000001. ',
+      });
+    });
+
     it('保留分隔符后的多余空白', () => {
       expect(computeListContinuation('3.  foo')).toEqual({ action: 'continue', insert: '4.  ' });
     });

--- a/apps/desktop/src/renderer/lib/__tests__/composerListContinuation.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/composerListContinuation.test.ts
@@ -44,8 +44,9 @@ describe('computeListContinuation', () => {
   });
 
   describe('无序列表', () => {
-    it('`- ` / `* ` / `• ` 原样接续', () => {
+    it('`- ` / `+ ` / `* ` / `• ` 原样接续', () => {
       expect(computeListContinuation('- item')).toEqual({ action: 'continue', insert: '- ' });
+      expect(computeListContinuation('+ item')).toEqual({ action: 'continue', insert: '+ ' });
       expect(computeListContinuation('* item')).toEqual({ action: 'continue', insert: '* ' });
       expect(computeListContinuation('• item')).toEqual({ action: 'continue', insert: '• ' });
     });

--- a/apps/desktop/src/renderer/lib/composerDraftStore.ts
+++ b/apps/desktop/src/renderer/lib/composerDraftStore.ts
@@ -141,6 +141,7 @@ function tiptapDocHasContent(node: JSONContent | null | undefined): boolean {
     node.type === 'pastedTextChip' ||
     node.type === COMPOSER_QUOTE_NODE_TYPE
   ) return true;
+  if (node.type === 'bulletList' || node.type === 'orderedList') return true;
   if (typeof node.text === 'string' && node.text.trim().length > 0) return true;
   if (Array.isArray(node.content)) {
     return node.content.some(tiptapDocHasContent);

--- a/apps/desktop/src/renderer/lib/composerDraftStore.ts
+++ b/apps/desktop/src/renderer/lib/composerDraftStore.ts
@@ -40,6 +40,7 @@ import {
 } from '@/lib/composerQuoteDocument';
 import type { JSONContent } from '@tiptap/core';
 import { createLogger } from '@/lib/logger';
+import { plainTextToComposerDocument } from './composerListDocument';
 
 const log = createLogger('ComposerDraftStore');
 
@@ -241,14 +242,15 @@ export function saveDraft(
   opts?: { silent?: boolean },
 ): void {
   const key = draftKey(sessionId);
-  const normalized = draft.quotes && draft.quotes.length > 0
-    ? {
-        ...draft,
-        text: prependLegacyQuotesToComposerDocument(draft.text, draft.quotes),
-        quotes: [],
-      }
-    : draft;
-  drafts.set(key, normalized);
+  const withQuotes =
+    draft.quotes && draft.quotes.length > 0
+      ? {
+          ...draft,
+          text: prependLegacyQuotesToComposerDocument(draft.text, draft.quotes),
+          quotes: [],
+        }
+      : draft;
+  drafts.set(key, withQuotes);
   if (!opts?.silent) {
     const set = listeners.get(key);
     if (set) for (const fn of set) {
@@ -395,17 +397,7 @@ export function appendBrowserCommentToDraft(
  * (e.g. `@some/path`), which is acceptable for an undo affordance.
  */
 export function plainTextToTiptapDoc(text: string): JSONContent {
-  if (!text) {
-    return { type: 'doc', content: [{ type: 'paragraph' }] };
-  }
-  return {
-    type: 'doc',
-    content: text.split('\n').map((line) =>
-      line.length === 0
-        ? { type: 'paragraph' }
-        : { type: 'paragraph', content: [{ type: 'text', text: line }] },
-    ),
-  };
+  return plainTextToComposerDocument(text);
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/composerListContinuation.ts
+++ b/apps/desktop/src/renderer/lib/composerListContinuation.ts
@@ -21,8 +21,8 @@ export interface ListPrefixMatch {
 
 // 顺序敏感:checkbox 必须先于 bullet 匹配(`- [ ] ` 也满足 bullet 的模式)。
 // checkbox 允许行在 `]` 处截止(`(\s+|$)`),这样 "- [ ]" 也能识别成空项退出。
-const CHECKBOX_RE = /^(\s*)([-*])(\s+)\[[ xX]\](\s+|$)/;
-const BULLET_RE = /^(\s*)([-*•])(\s+)/;
+const CHECKBOX_RE = /^(\s*)([-+*])(\s+)\[[ xX]\](\s+|$)/;
+const BULLET_RE = /^(\s*)([-+*•])(\s+)/;
 const ORDERED_RE = /^(\s*)(\d{1,6})([.)])(\s+)/;
 // 中文顿号序号(`1、`)不要求后随空格,符合中文输入习惯。
 const ORDERED_CJK_RE = /^(\s*)(\d{1,6})(、)(\s*)/;

--- a/apps/desktop/src/renderer/lib/composerListContinuation.ts
+++ b/apps/desktop/src/renderer/lib/composerListContinuation.ts
@@ -2,15 +2,10 @@ import type { EditorView } from '@tiptap/pm/view';
 import type { ResolvedPos } from '@tiptap/pm/model';
 
 /**
- * Composer 列表接续(纯文本 markdown 辅助):Shift/Alt+Enter 换行时,若当前行
- * 以列表 / 待办 / 引用前缀开头且有内容,自动在新行补下一个前缀(有序列表序号
- * +1);前缀后没有内容时(空项)则清掉前缀退出列表。普通 Enter 保持"发送"
- * 语义不变(2026-07 产品定案:Enter=发送的
- * 肌肉记忆优先,不做 Claude 式"列表内 Enter 继续列表")。
- *
- * ChatInput 是刻意的纯文本编辑器(不引入富文本 list schema),这里是 GitHub
- * 评论框式的"前缀接续"实现:发送给 agent 的内容仍是纯 markdown 文本,
- * 消息管线 / 草稿存储 / mention chip 均不受影响。
+ * Composer 纯文本 Markdown 列表的兼容接续。结构化 bullet / ordered list
+ * 由编辑器 schema 处理；本模块继续覆盖粘贴或旧草稿中的文本前缀，以及尚未
+ * 结构化的待办和引用前缀。Shift/Alt+Enter 接续或退出当前项，普通 Enter
+ * 始终保持发送语义。
  */
 
 export type ListContinuation =
@@ -84,7 +79,7 @@ export function computeListContinuation(
   if (!match) return null;
   const rest = lineBeforeCaret.slice(match.prefixLength);
   // 空项判定看**整行**(光标前 rest + 光标后正文):否则 `1. |todo`(光标在标记后、
-  // 正文前)会被当成空项退出、删掉标记留下裸 "todo"(codex P2)。光标后仍有正文时
+  // 正文前)会被当成空项退出、删掉标记留下裸 "todo"。光标后仍有正文时
   // 走 continue —— 在光标处插换行 + 下一前缀,把 "todo" 顺成下一项(拆分列表)。
   if (rest.trim().length === 0 && lineAfterCaret.trim().length === 0) return { action: 'exit' };
   return { action: 'continue', insert: match.nextPrefix };
@@ -162,7 +157,7 @@ export function applyListContinuation(view: EditorView): boolean {
 }
 
 /**
- * 空列表项整体回删(对齐 Claude):当前行只剩前缀(如 "2. ")且光标在行尾时,
+ * 空列表项整体回删:当前行只剩前缀(如 "2. ")且光标在行尾时,
  * 一次 Backspace 删掉整个前缀——有上一行则连同前面的换行一起删,光标落到
  * 上一行行尾;是首行则只删前缀(等效退出列表)。其余情况返回 false,调用方
  * 走默认退格。

--- a/apps/desktop/src/renderer/lib/composerListContinuation.ts
+++ b/apps/desktop/src/renderer/lib/composerListContinuation.ts
@@ -23,9 +23,9 @@ export interface ListPrefixMatch {
 // checkbox 允许行在 `]` 处截止(`(\s+|$)`),这样 "- [ ]" 也能识别成空项退出。
 const CHECKBOX_RE = /^(\s*)([-+*])(\s+)\[[ xX]\](\s+|$)/;
 const BULLET_RE = /^(\s*)([-+*•])(\s+)/;
-const ORDERED_RE = /^(\s*)(\d{1,6})([.)])(\s+)/;
+const ORDERED_RE = /^(\s*)(\d{1,7})([.)])(\s+)/;
 // 中文顿号序号(`1、`)不要求后随空格,符合中文输入习惯。
-const ORDERED_CJK_RE = /^(\s*)(\d{1,6})(、)(\s*)/;
+const ORDERED_CJK_RE = /^(\s*)(\d{1,7})(、)(\s*)/;
 const QUOTE_RE = /^(\s*)(>)(\s+)/;
 
 /**

--- a/apps/desktop/src/renderer/lib/composerListContinuation.ts
+++ b/apps/desktop/src/renderer/lib/composerListContinuation.ts
@@ -23,9 +23,9 @@ export interface ListPrefixMatch {
 // checkbox 允许行在 `]` 处截止(`(\s+|$)`),这样 "- [ ]" 也能识别成空项退出。
 const CHECKBOX_RE = /^(\s*)([-+*])(\s+)\[[ xX]\](\s+|$)/;
 const BULLET_RE = /^(\s*)([-+*•])(\s+)/;
-const ORDERED_RE = /^(\s*)(\d{1,8})([.)])(\s+)/;
+const ORDERED_RE = /^(\s*)(\d{1,9})([.)])(\s+)/;
 // 中文顿号序号(`1、`)不要求后随空格,符合中文输入习惯。
-const ORDERED_CJK_RE = /^(\s*)(\d{1,8})(、)(\s*)/;
+const ORDERED_CJK_RE = /^(\s*)(\d{1,9})(、)(\s*)/;
 const QUOTE_RE = /^(\s*)(>)(\s+)/;
 
 /**

--- a/apps/desktop/src/renderer/lib/composerListContinuation.ts
+++ b/apps/desktop/src/renderer/lib/composerListContinuation.ts
@@ -23,9 +23,9 @@ export interface ListPrefixMatch {
 // checkbox 允许行在 `]` 处截止(`(\s+|$)`),这样 "- [ ]" 也能识别成空项退出。
 const CHECKBOX_RE = /^(\s*)([-+*])(\s+)\[[ xX]\](\s+|$)/;
 const BULLET_RE = /^(\s*)([-+*•])(\s+)/;
-const ORDERED_RE = /^(\s*)(\d{1,7})([.)])(\s+)/;
+const ORDERED_RE = /^(\s*)(\d{1,8})([.)])(\s+)/;
 // 中文顿号序号(`1、`)不要求后随空格,符合中文输入习惯。
-const ORDERED_CJK_RE = /^(\s*)(\d{1,7})(、)(\s*)/;
+const ORDERED_CJK_RE = /^(\s*)(\d{1,8})(、)(\s*)/;
 const QUOTE_RE = /^(\s*)(>)(\s+)/;
 
 /**

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -17,7 +17,7 @@ interface ComposerLine {
 }
 
 const BULLET_RE = /^([-+*•])([ \t]+)/;
-const ORDERED_RE = /^([1-9]\d{0,5})([.)、])([ \t]*)/;
+const ORDERED_RE = /^([1-9]\d{0,6})([.)、])([ \t]*)/;
 
 function inlineNodeText(node: JSONContent): string {
   if (node.type === 'text') return node.text ?? '';

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -17,7 +17,7 @@ interface ComposerLine {
 }
 
 const BULLET_RE = /^([-+*•])([ \t]+)/;
-const ORDERED_RE = /^([1-9]\d{0,7})([.)、])([ \t]*)/;
+const ORDERED_RE = /^([1-9]\d{0,8})([.)、])([ \t]*)/;
 
 function inlineNodeText(node: JSONContent): string {
   if (node.type === 'text') return node.text ?? '';

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -135,6 +135,16 @@ function sameListMarker(left: ListMarker, right: ListMarker): boolean {
   return left.kind === right.kind && left.marker === right.marker;
 }
 
+function canAppendListLine(
+  current: ListMarker,
+  currentLineCount: number,
+  next: ListMarker,
+): boolean {
+  if (!sameListMarker(current, next)) return false;
+  if (current.kind === 'bullet') return true;
+  return next.start === (current.start ?? 1) + currentLineCount;
+}
+
 function paragraphToBlocks(paragraph: JSONContent): JSONContent[] {
   const lines = splitParagraphLines(paragraph);
   if (!lines.some((line) => parseListMarker(line.text))) return [paragraph];
@@ -169,7 +179,7 @@ function paragraphToBlocks(paragraph: JSONContent): JSONContent[] {
       plainLines.push(line);
       continue;
     }
-    if (listMarker && !sameListMarker(listMarker, marker)) flushList();
+    if (listMarker && !canAppendListLine(listMarker, listLines.length, marker)) flushList();
     flushPlain();
     listMarker ??= marker;
     listLines.push(line);

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -17,7 +17,7 @@ interface ComposerLine {
 }
 
 const BULLET_RE = /^([-+*•])([ \t]+)/;
-const ORDERED_RE = /^([1-9]\d{0,6})([.)、])([ \t]*)/;
+const ORDERED_RE = /^([1-9]\d{0,7})([.)、])([ \t]*)/;
 
 function inlineNodeText(node: JSONContent): string {
   if (node.type === 'text') return node.text ?? '';

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -1,0 +1,247 @@
+import type { JSONContent } from '@tiptap/core';
+
+type ListKind = 'bullet' | 'ordered';
+type OrderedMarker = '.' | ')' | '、';
+
+interface ListMarker {
+  kind: ListKind;
+  prefixLength: number;
+  marker: string;
+  start?: number;
+}
+
+interface ComposerLine {
+  content: JSONContent[];
+  text: string;
+}
+
+const BULLET_RE = /^([-+*•])([ \t]+)/;
+const ORDERED_RE = /^(\d{1,6})([.)、])([ \t]*)/;
+
+function inlineNodeText(node: JSONContent): string {
+  if (node.type === 'text') return node.text ?? '';
+  return '\uFFFC';
+}
+
+function pushLine(lines: ComposerLine[], content: JSONContent[]): void {
+  lines.push({
+    content,
+    text: content.map(inlineNodeText).join(''),
+  });
+}
+
+function splitParagraphLines(paragraph: JSONContent): ComposerLine[] {
+  const lines: ComposerLine[] = [];
+  let current: JSONContent[] = [];
+
+  const appendText = (text: string, node: JSONContent) => {
+    const parts = text.split('\n');
+    parts.forEach((part, index) => {
+      if (part) current.push({ ...node, text: part });
+      if (index < parts.length - 1) {
+        pushLine(lines, current);
+        current = [];
+      }
+    });
+  };
+
+  for (const node of paragraph.content ?? []) {
+    if (node.type === 'hardBreak') {
+      pushLine(lines, current);
+      current = [];
+      continue;
+    }
+    if (node.type === 'text' && (node.text ?? '').includes('\n')) {
+      appendText(node.text ?? '', node);
+      continue;
+    }
+    current.push(node);
+  }
+  pushLine(lines, current);
+  return lines;
+}
+
+function parseListMarker(text: string): ListMarker | null {
+  // Only unindented rows are promoted here. Indented rows may be nested
+  // Markdown, and the visual fallback remains responsible for those until
+  // their parent item is also represented structurally.
+  if (/^[ \t]/.test(text)) return null;
+
+  const bullet = text.match(BULLET_RE);
+  if (bullet) {
+    return {
+      kind: 'bullet',
+      prefixLength: bullet[0].length,
+      marker: 'bullet',
+    };
+  }
+
+  const ordered = text.match(ORDERED_RE);
+  if (ordered) {
+    const marker = ordered[2] as OrderedMarker;
+    if (marker !== '、' && ordered[3].length === 0) return null;
+    return {
+      kind: 'ordered',
+      prefixLength: ordered[0].length,
+      marker,
+      start: Number(ordered[1]),
+    };
+  }
+  return null;
+}
+
+function stripPrefix(content: JSONContent[], prefixLength: number): JSONContent[] | null {
+  const first = content[0];
+  if (!first || first.type !== 'text') return null;
+  const text = first.text ?? '';
+  if (text.length < prefixLength) return null;
+  const remaining = text.slice(prefixLength);
+  const rest = remaining ? [{ ...first, text: remaining }, ...content.slice(1)] : content.slice(1);
+  return rest;
+}
+
+function paragraphFromLine(line: ComposerLine, attrs?: JSONContent['attrs']): JSONContent {
+  return {
+    type: 'paragraph',
+    ...(attrs ? { attrs } : {}),
+    ...(line.content.length > 0 ? { content: line.content } : {}),
+  };
+}
+
+function listFromLines(
+  lines: ComposerLine[],
+  marker: ListMarker,
+  paragraphAttrs?: JSONContent['attrs'],
+): JSONContent {
+  const items = lines.map((line) => {
+    const lineMarker = parseListMarker(line.text);
+    const content =
+      stripPrefix(line.content, lineMarker?.prefixLength ?? marker.prefixLength) ?? line.content;
+    return {
+      type: 'listItem',
+      content: [paragraphFromLine({ content, text: '' }, paragraphAttrs)],
+    };
+  });
+  return {
+    type: marker.kind === 'ordered' ? 'orderedList' : 'bulletList',
+    ...(marker.kind === 'ordered'
+      ? { attrs: { start: marker.start ?? 1, marker: marker.marker } }
+      : {}),
+    content: items,
+  };
+}
+
+function sameListMarker(left: ListMarker, right: ListMarker): boolean {
+  return left.kind === right.kind && left.marker === right.marker;
+}
+
+function paragraphToBlocks(paragraph: JSONContent): JSONContent[] {
+  const lines = splitParagraphLines(paragraph);
+  if (!lines.some((line) => parseListMarker(line.text))) return [paragraph];
+
+  const blocks: JSONContent[] = [];
+  let plainLines: ComposerLine[] = [];
+  let listLines: ComposerLine[] = [];
+  let listMarker: ListMarker | null = null;
+
+  const flushPlain = () => {
+    if (plainLines.length === 0) return;
+    plainLines.forEach((line) => blocks.push(paragraphFromLine(line, paragraph.attrs)));
+    plainLines = [];
+  };
+  const flushList = () => {
+    if (listLines.length === 0 || !listMarker) return;
+    blocks.push(listFromLines(listLines, listMarker, paragraph.attrs));
+    listLines = [];
+    listMarker = null;
+  };
+
+  for (const line of lines) {
+    const marker = parseListMarker(line.text);
+    if (!marker) {
+      flushList();
+      plainLines.push(line);
+      continue;
+    }
+    const stripped = stripPrefix(line.content, marker.prefixLength);
+    if (!stripped) {
+      flushList();
+      plainLines.push(line);
+      continue;
+    }
+    if (listMarker && !sameListMarker(listMarker, marker)) flushList();
+    flushPlain();
+    listMarker ??= marker;
+    listLines.push(line);
+  }
+  flushList();
+  flushPlain();
+  return blocks;
+}
+
+function canMergeLists(left: JSONContent, right: JSONContent): boolean {
+  if (left.type !== right.type) return false;
+  if (left.type === 'bulletList') return true;
+  const leftStart = Number(left.attrs?.start);
+  const rightStart = Number(right.attrs?.start);
+  return (
+    left.attrs?.marker === right.attrs?.marker &&
+    Number.isInteger(leftStart) &&
+    Number.isInteger(rightStart) &&
+    leftStart + (left.content?.length ?? 0) === rightStart
+  );
+}
+
+function mergeLists(left: JSONContent, right: JSONContent): JSONContent {
+  return {
+    ...left,
+    content: [...(left.content ?? []), ...(right.content ?? [])],
+  };
+}
+
+/**
+ * Promote plain Markdown list rows at composer document boundaries to the
+ * structured list nodes used by the editor.
+ *
+ * This is deliberately a one-way normalization: malformed rows, indented
+ * nested rows, and paragraphs containing inline atoms that obscure the marker
+ * remain plain text and can still use the compatibility renderer.
+ */
+export function normalizeComposerDocumentJSON(document: JSONContent): JSONContent {
+  if (document.type !== 'doc' || !Array.isArray(document.content)) return document;
+
+  const normalized: JSONContent[] = [];
+  for (const node of document.content) {
+    const blocks = node.type === 'paragraph' ? paragraphToBlocks(node) : [node];
+    for (const block of blocks) {
+      const previous = normalized.at(-1);
+      if (previous && canMergeLists(previous, block)) {
+        normalized[normalized.length - 1] = mergeLists(previous, block);
+      } else {
+        normalized.push(block);
+      }
+    }
+  }
+  return { ...document, content: normalized };
+}
+
+/** Build a normalized composer document from plain clipboard/history text. */
+export function plainTextToComposerDocument(text: string): JSONContent {
+  const content = text
+    .split('\n')
+    .map((line) =>
+      line.length > 0
+        ? { type: 'paragraph', content: [{ type: 'text', text: line }] }
+        : { type: 'paragraph' },
+    );
+  return normalizeComposerDocumentJSON({ type: 'doc', content });
+}
+
+export function composerDocumentContainsList(document: JSONContent): boolean {
+  return (
+    document.type === 'doc' &&
+    (document.content ?? []).some(
+      (node) => node.type === 'bulletList' || node.type === 'orderedList',
+    )
+  );
+}

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -90,7 +90,7 @@ function parseListMarker(text: string): ListMarker | null {
       prefixLength:
         marker === '、' ? ordered[1].length + marker.length : ordered[0].length,
       marker,
-      separator: ordered[3],
+      separator: marker === '、' ? '' : ordered[3],
       start: Number(ordered[1]),
     };
   }
@@ -131,7 +131,9 @@ function listFromLines(
   });
   const attrs =
     marker.kind === 'ordered'
-      ? { start: marker.start ?? 1, marker: marker.marker }
+      ? marker.separator === ' ' && marker.marker !== '、'
+        ? { start: marker.start ?? 1, marker: marker.marker }
+        : { start: marker.start ?? 1, marker: marker.marker, separator: marker.separator }
       : marker.marker === '-' && marker.separator === ' '
         ? undefined
         : { marker: marker.marker, separator: marker.separator };
@@ -262,6 +264,8 @@ function canMergeLists(left: JSONContent, right: JSONContent): boolean {
   const rightStart = Number(right.attrs?.start);
   return (
     left.attrs?.marker === right.attrs?.marker &&
+    (left.attrs?.separator ?? (left.attrs?.marker === '、' ? '' : ' ')) ===
+      (right.attrs?.separator ?? (right.attrs?.marker === '、' ? '' : ' ')) &&
     Number.isInteger(leftStart) &&
     Number.isInteger(rightStart) &&
     leftStart + (left.content?.length ?? 0) === rightStart

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -185,17 +185,19 @@ function paragraphToBlocks(
   initialFence: FenceState | null,
 ): { blocks: JSONContent[]; fence: FenceState | null } {
   const lines = splitParagraphLines(paragraph);
-  if (!lines.some((line) => parseListMarker(line.text)) && !initialFence) {
-    let fence: FenceState | null = initialFence;
-    for (const line of lines) {
-      const opening = fenceOpening(line.text);
-      if (fence) {
-        if (isFenceClosing(line.text, fence)) fence = null;
-      } else if (opening) {
-        fence = opening;
-      }
+  let scannedFence: FenceState | null = initialFence;
+  let hasPromotableList = false;
+  for (const line of lines) {
+    if (scannedFence) {
+      if (isFenceClosing(line.text, scannedFence)) scannedFence = null;
+      continue;
     }
-    return { blocks: [paragraph], fence };
+    if (parseListMarker(line.text)) hasPromotableList = true;
+    const opening = fenceOpening(line.text);
+    if (opening) scannedFence = opening;
+  }
+  if (!hasPromotableList) {
+    return { blocks: [paragraph], fence: scannedFence };
   }
 
   const blocks: JSONContent[] = [];

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -90,7 +90,7 @@ function parseListMarker(text: string): ListMarker | null {
       prefixLength:
         marker === '、' ? ordered[1].length + marker.length : ordered[0].length,
       marker,
-      separator: marker === '、' ? ordered[3] : ordered[3],
+      separator: ordered[3],
       start: Number(ordered[1]),
     };
   }

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -7,6 +7,7 @@ interface ListMarker {
   kind: ListKind;
   prefixLength: number;
   marker: string;
+  separator: string;
   start?: number;
 }
 
@@ -72,7 +73,8 @@ function parseListMarker(text: string): ListMarker | null {
     return {
       kind: 'bullet',
       prefixLength: bullet[0].length,
-      marker: 'bullet',
+      marker: bullet[1],
+      separator: bullet[2],
     };
   }
 
@@ -88,6 +90,7 @@ function parseListMarker(text: string): ListMarker | null {
       prefixLength:
         marker === '、' ? ordered[1].length + marker.length : ordered[0].length,
       marker,
+      separator: marker === '、' ? ordered[3] : ordered[3],
       start: Number(ordered[1]),
     };
   }
@@ -126,17 +129,25 @@ function listFromLines(
       content: [paragraphFromLine({ content, text: '' }, paragraphAttrs)],
     };
   });
+  const attrs =
+    marker.kind === 'ordered'
+      ? { start: marker.start ?? 1, marker: marker.marker }
+      : marker.marker === '-' && marker.separator === ' '
+        ? undefined
+        : { marker: marker.marker, separator: marker.separator };
   return {
     type: marker.kind === 'ordered' ? 'orderedList' : 'bulletList',
-    ...(marker.kind === 'ordered'
-      ? { attrs: { start: marker.start ?? 1, marker: marker.marker } }
-      : {}),
+    ...(attrs ? { attrs } : {}),
     content: items,
   };
 }
 
 function sameListMarker(left: ListMarker, right: ListMarker): boolean {
-  return left.kind === right.kind && left.marker === right.marker;
+  return (
+    left.kind === right.kind &&
+    left.marker === right.marker &&
+    left.separator === right.separator
+  );
 }
 
 function canAppendListLine(
@@ -149,14 +160,47 @@ function canAppendListLine(
   return next.start === (current.start ?? 1) + currentLineCount;
 }
 
-function paragraphToBlocks(paragraph: JSONContent): JSONContent[] {
+interface FenceState {
+  char: '`' | '~';
+  length: number;
+}
+
+function fenceOpening(text: string): FenceState | null {
+  const match = text.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  if (!match) return null;
+  if (match[1][0] === '`' && match[2].includes('`')) return null;
+  return { char: match[1][0] as FenceState['char'], length: match[1].length };
+}
+
+function isFenceClosing(text: string, state: FenceState): boolean {
+  const escapedChar = state.char === '`' ? '`' : '~';
+  const pattern = new RegExp(`^ {0,3}${escapedChar}{${state.length},}[ \\t]*$`);
+  return pattern.test(text);
+}
+
+function paragraphToBlocks(
+  paragraph: JSONContent,
+  initialFence: FenceState | null,
+): { blocks: JSONContent[]; fence: FenceState | null } {
   const lines = splitParagraphLines(paragraph);
-  if (!lines.some((line) => parseListMarker(line.text))) return [paragraph];
+  if (!lines.some((line) => parseListMarker(line.text)) && !initialFence) {
+    let fence: FenceState | null = initialFence;
+    for (const line of lines) {
+      const opening = fenceOpening(line.text);
+      if (fence) {
+        if (isFenceClosing(line.text, fence)) fence = null;
+      } else if (opening) {
+        fence = opening;
+      }
+    }
+    return { blocks: [paragraph], fence };
+  }
 
   const blocks: JSONContent[] = [];
   let plainLines: ComposerLine[] = [];
   let listLines: ComposerLine[] = [];
   let listMarker: ListMarker | null = null;
+  let fence = initialFence;
 
   const flushPlain = () => {
     if (plainLines.length === 0) return;
@@ -171,6 +215,19 @@ function paragraphToBlocks(paragraph: JSONContent): JSONContent[] {
   };
 
   for (const line of lines) {
+    if (fence) {
+      flushList();
+      plainLines.push(line);
+      if (isFenceClosing(line.text, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line.text);
+    if (opening) {
+      flushList();
+      plainLines.push(line);
+      fence = opening;
+      continue;
+    }
     const marker = parseListMarker(line.text);
     if (!marker) {
       flushList();
@@ -190,12 +247,17 @@ function paragraphToBlocks(paragraph: JSONContent): JSONContent[] {
   }
   flushList();
   flushPlain();
-  return blocks;
+  return { blocks, fence };
 }
 
 function canMergeLists(left: JSONContent, right: JSONContent): boolean {
   if (left.type !== right.type) return false;
-  if (left.type === 'bulletList') return true;
+  if (left.type === 'bulletList') {
+    return (
+      (left.attrs?.marker ?? '-') === (right.attrs?.marker ?? '-') &&
+      (left.attrs?.separator ?? ' ') === (right.attrs?.separator ?? ' ')
+    );
+  }
   const leftStart = Number(left.attrs?.start);
   const rightStart = Number(right.attrs?.start);
   return (
@@ -225,9 +287,14 @@ export function normalizeComposerDocumentJSON(document: JSONContent): JSONConten
   if (document.type !== 'doc' || !Array.isArray(document.content)) return document;
 
   const normalized: JSONContent[] = [];
+  let fence: FenceState | null = null;
   for (const node of document.content) {
-    const blocks = node.type === 'paragraph' ? paragraphToBlocks(node) : [node];
-    for (const block of blocks) {
+    const result: { blocks: JSONContent[]; fence: FenceState | null } =
+      node.type === 'paragraph'
+        ? paragraphToBlocks(node, fence)
+        : { blocks: [node], fence };
+    fence = result.fence;
+    for (const block of result.blocks) {
       const previous = normalized.at(-1);
       if (previous && canMergeLists(previous, block)) {
         normalized[normalized.length - 1] = mergeLists(previous, block);

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -82,7 +82,11 @@ function parseListMarker(text: string): ListMarker | null {
     if (marker !== '、' && ordered[3].length === 0) return null;
     return {
       kind: 'ordered',
-      prefixLength: ordered[0].length,
+      // CJK ordered markers are valid with or without a following space.
+      // Keep that space in the item body so serialization preserves the
+      // user's original form without adding another list attribute.
+      prefixLength:
+        marker === '、' ? ordered[1].length + marker.length : ordered[0].length,
       marker,
       start: Number(ordered[1]),
     };

--- a/apps/desktop/src/renderer/lib/composerListDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerListDocument.ts
@@ -17,7 +17,7 @@ interface ComposerLine {
 }
 
 const BULLET_RE = /^([-+*•])([ \t]+)/;
-const ORDERED_RE = /^(\d{1,6})([.)、])([ \t]*)/;
+const ORDERED_RE = /^([1-9]\d{0,5})([.)、])([ \t]*)/;
 
 function inlineNodeText(node: JSONContent): string {
   if (node.type === 'text') return node.text ?? '';

--- a/apps/desktop/src/renderer/lib/composerQuoteDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerQuoteDocument.ts
@@ -213,6 +213,7 @@ export function serializeComposerContentBlocks(blocks: readonly ComposerSerializ
 /** Serialize blocks and project block-relative presentation ranges into wire offsets. */
 export function serializeComposerContentBlocksWithRanges(
   blocks: readonly ComposerSerializedBlock[],
+  options: { preserveTrailingWhitespace?: boolean } = {},
 ): {
   text: string;
   agentReferences: AgentInputReference[];
@@ -275,7 +276,7 @@ export function serializeComposerContentBlocksWithRanges(
   });
 
   const leadingTrim = serialized.length - serialized.trimStart().length;
-  const text = serialized.trim();
+  const text = options.preserveTrailingWhitespace ? serialized.trimStart() : serialized.trim();
   return {
     text,
     agentReferences: agentReferences

--- a/apps/desktop/src/renderer/lib/composerQuoteDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerQuoteDocument.ts
@@ -11,6 +11,7 @@ import type { JSONContent } from '@tiptap/core';
 import type { AgentInputReference } from '../../shared/agentInputQueue';
 import { parseChatQuoteSegments, type ChatQuote, type ChatQuoteSegment } from '@/lib/chatQuotes';
 import type { PastedTextRange, SlashCommandRange } from '@/lib/imageRef';
+import { normalizeComposerDocumentJSON } from './composerListDocument';
 
 export const COMPOSER_QUOTE_NODE_TYPE = 'composerQuote';
 
@@ -192,12 +193,12 @@ export function quoteSegmentsToComposerDocument(
 export function composerHistoryEntryToDocument(entry: ComposerHistoryEntry): JSONContent {
   if (entry.quotesEncoded === true) {
     const quotedDocument = quoteSegmentsToComposerDocument(parseChatQuoteSegments(entry.content));
-    if (quotedDocument) return quotedDocument;
+    if (quotedDocument) return normalizeComposerDocumentJSON(quotedDocument);
   }
-  return {
+  return normalizeComposerDocumentJSON({
     type: 'doc',
     content: [paragraph(entry.content ? [{ type: 'text', text: entry.content }] : [])],
-  };
+  });
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/composerQuoteDocument.ts
+++ b/apps/desktop/src/renderer/lib/composerQuoteDocument.ts
@@ -81,6 +81,8 @@ function isPureLineBreakText(text: string): boolean {
   return true;
 }
 
+const LIST_ROW_MARKER_RE = /^(?:[-+*•][ \t]+|[1-9]\d{0,8}[.)][ \t]+|[1-9]\d{0,8}、[ \t]*)/;
+
 function normalizeTopLevelQuoteNodes(document: JSONContent | null | undefined): JSONContent[] {
   const source =
     document?.type === 'doc' && Array.isArray(document.content) ? document.content : [];
@@ -155,6 +157,7 @@ export function quoteSegmentsToComposerDocument(
   const content: JSONContent[] = [];
   let inlineContent: JSONContent[] = [];
   let hasContent = false;
+  let quoteJustEnded = false;
 
   const finishParagraph = () => {
     content.push(paragraph(inlineContent));
@@ -165,6 +168,7 @@ export function quoteSegmentsToComposerDocument(
     if (segment.kind === 'quote') {
       inlineContent.push(quoteNode(segment.quote));
       hasContent = true;
+      quoteJustEnded = true;
       continue;
     }
     if (!segment.text) continue;
@@ -180,8 +184,12 @@ export function quoteSegmentsToComposerDocument(
     }
     const lines = segment.text.split('\n');
     lines.forEach((line, index) => {
+      if (quoteJustEnded && line && LIST_ROW_MARKER_RE.test(line) && inlineContent.length > 0) {
+        finishParagraph();
+      }
       if (line) inlineContent.push({ type: 'text', text: line });
       if (index < lines.length - 1) finishParagraph();
+      if (line) quoteJustEnded = false;
     });
   }
   if (!hasContent) return null;

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -326,14 +326,14 @@ html:lang(ko) {
    (command-palette F2.5). The Placeholder extension injects
    `p.is-editor-empty::before` with the placeholder text in a `data-*`
    attribute; we style it to match the old textarea placeholder. */
-.ProseMirror p.is-editor-empty:first-child::before {
+.ProseMirror > p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   color: var(--chat-input-placeholder-subtle);
   float: left;
   height: 0;
   pointer-events: none;
 }
-[data-voice-draft-active='true'] .ProseMirror p.is-editor-empty:first-child::before {
+[data-voice-draft-active='true'] .ProseMirror > p.is-editor-empty:first-child::before {
   content: none;
 }
 .ProseMirror {

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -375,6 +375,9 @@ html:lang(ko) {
 [data-chat-input-root] .ProseMirror ol[data-marker-digits='8'] {
   --composer-list-padding: 5.8em;
 }
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='9'] {
+  --composer-list-padding: 6.4em;
+}
 [data-chat-input-root] .ProseMirror ul {
   list-style-type: disc;
 }

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -372,6 +372,9 @@ html:lang(ko) {
 [data-chat-input-root] .ProseMirror ol[data-marker-digits='7'] {
   --composer-list-padding: 5.2em;
 }
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='8'] {
+  --composer-list-padding: 5.8em;
+}
 [data-chat-input-root] .ProseMirror ul {
   list-style-type: disc;
 }

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -113,8 +113,8 @@
 
   /* F3: Global disable focus outline — Chromium default :focus-visible draws
      a yellow/orange ring on buttons, options and menu items after Esc/click
-     transitions focus. Claude Desktop has no such ring; suppress it on every
-     non-input element. Inputs keep their focus hint via --*-border-focus. */
+     transitions focus. Suppress it on non-input elements while inputs keep
+     their focus hint via --*-border-focus. */
   *:focus,
   *:focus-visible {
     outline: none !important;

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -351,7 +351,25 @@ html:lang(ko) {
    without decoration-owned width measurements. */
 [data-chat-input-root] .ProseMirror :is(ul, ol) {
   margin: 0;
-  padding-inline-start: 1.5em;
+  padding-inline-start: var(--composer-list-padding, 1.5em);
+}
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='2'] {
+  --composer-list-padding: 2.2em;
+}
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='3'] {
+  --composer-list-padding: 2.8em;
+}
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='4'] {
+  --composer-list-padding: 3.4em;
+}
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='5'] {
+  --composer-list-padding: 4em;
+}
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='6'] {
+  --composer-list-padding: 4.6em;
+}
+[data-chat-input-root] .ProseMirror ol[data-marker-digits='7'] {
+  --composer-list-padding: 5.2em;
 }
 [data-chat-input-root] .ProseMirror ul {
   list-style-type: disc;

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -351,6 +351,7 @@ html:lang(ko) {
    without decoration-owned width measurements. */
 [data-chat-input-root] .ProseMirror :is(ul, ol) {
   margin: 0;
+  --composer-list-padding: 1.5em;
   padding-inline-start: var(--composer-list-padding, 1.5em);
 }
 [data-chat-input-root] .ProseMirror ol[data-marker-digits='2'] {

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -13,7 +13,7 @@
       'Inter Variable', Inter, -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB',
       'HarmonyOS Sans SC', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Noto Sans CJK SC',
       'Source Han Sans SC', 'Segoe UI', Roboto, sans-serif;
-    /* 默认代码字体走 Codex / 系统等宽风格(mac 上 SF Mono 不对网页暴露字体名,
+    /* 默认代码字体使用系统等宽字体(mac 上 SF Mono 不对网页暴露字体名,
        实际命中 Menlo;Win 命中 Consolas)。JetBrains Mono 已降级为可选预设、不再是
        默认。CJK 显式回退 PingFang/雅黑,保证代码块中英混排统一等宽。 */
     --app-font-code-default:
@@ -346,6 +346,33 @@ html:lang(ko) {
 .cm-editor .cm-dropCursor {
   border-left-color: var(--caret-accent) !important;
 }
+/* Structured composer lists keep markers and body text in the same layout
+   tree. Continuation lines therefore follow the list item content edge
+   without decoration-owned width measurements. */
+[data-chat-input-root] .ProseMirror :is(ul, ol) {
+  margin: 0;
+  padding-inline-start: 1.5em;
+}
+[data-chat-input-root] .ProseMirror ul {
+  list-style-type: disc;
+}
+[data-chat-input-root] .ProseMirror ol {
+  list-style-type: decimal;
+}
+[data-chat-input-root] .ProseMirror ol[data-marker=')'] > li::marker {
+  content: counter(list-item) ') ';
+}
+[data-chat-input-root] .ProseMirror ol[data-marker='、'] > li::marker {
+  content: counter(list-item) '、';
+}
+[data-chat-input-root] .ProseMirror li {
+  padding-inline-start: 0.15em;
+  overflow-wrap: anywhere;
+}
+[data-chat-input-root] .ProseMirror li > p {
+  margin: 0;
+}
+
 /* composer 列表行缩进(ComposerListIndentDecoration):单行列表使用段落级
    decoration,多行列表的无特殊标点行使用 inline-block 换行容器。padding-left
    留出"基础缩进 + 前缀宽度",首行再用负 text-indent 把列表标记悬挂回基础

--- a/packages/maker-shared/src/__tests__/chatQuotes.test.ts
+++ b/packages/maker-shared/src/__tests__/chatQuotes.test.ts
@@ -104,6 +104,16 @@ describe('parseChatQuoteSegments', () => {
     ]);
   });
 
+  it('parses explicitly marked quotes nested under list indentation', () => {
+    const content = '- before\n  > <!-- cindy-composer-quote -->\n  > quoted\n  after';
+    expect(parseChatQuoteSegments(content)).toEqual([
+      { kind: 'text', text: '- before' },
+      { kind: 'quote', quote: { text: 'quoted' } },
+      { kind: 'text', text: '  after' },
+    ]);
+    expect(stripChatQuoteMarkerLines(content)).toBe('- before\n  > quoted\n  after');
+  });
+
   it('keeps internal quote and prose blank lines', () => {
     const content = `before\n\n${formatQuoteForSend({ text: 'a\n\nb' })}\n\nafter\n\nstill after`;
     expect(parseChatQuoteSegments(content)).toEqual([

--- a/packages/maker-shared/src/chatQuotes.ts
+++ b/packages/maker-shared/src/chatQuotes.ts
@@ -54,7 +54,7 @@ const QUOTE_BLOCK_MARKER_LINE = `> ${QUOTE_BLOCK_MARKER}`;
 export function stripChatQuoteMarkerLines(content: string): string {
   return content
     .split('\n')
-    .filter((line) => line !== QUOTE_BLOCK_MARKER_LINE)
+    .filter((line) => line.trimStart() !== QUOTE_BLOCK_MARKER_LINE)
     .join('\n');
 }
 
@@ -186,7 +186,11 @@ export function parseChatQuoteSegments(
   let index = 0;
   while (index < lines.length) {
     const line = lines[index];
-    const marked = line === QUOTE_BLOCK_MARKER_LINE;
+    const markerIndent =
+      line.trimStart() === QUOTE_BLOCK_MARKER_LINE
+        ? line.slice(0, line.length - line.trimStart().length)
+        : null;
+    const marked = markerIndent !== null;
     const legacyLeading = allowLegacyLeadingQuotes && line.startsWith('> ');
     if (!marked && !legacyLeading) {
       textLines.push(line);
@@ -203,12 +207,13 @@ export function parseChatQuoteSegments(
     const quoteLines: string[] = [];
     while (index < lines.length) {
       const quoteLine = lines[index];
-      if (quoteLine.startsWith('> ')) {
-        quoteLines.push(quoteLine.slice(2));
+      const quotePrefix = `${markerIndent ?? ''}>`;
+      if (quoteLine.startsWith(`${quotePrefix} `)) {
+        quoteLines.push(quoteLine.slice(quotePrefix.length + 1));
         index += 1;
         continue;
       }
-      if (quoteLine === '>') {
+      if (quoteLine === quotePrefix) {
         quoteLines.push('');
         index += 1;
         continue;


### PR DESCRIPTION
## 这次改了什么

### 摘要

重构 Desktop 对话输入框的列表编辑模型，用结构化节点统一无序列表、有序列表和任务项的编辑、恢复与发送序列化，修复列表续接、退出、回删及嵌套缩进中的边界问题。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：输入框结构化列表节点、草稿与历史恢复、纯文本和 Markdown 粘贴升级、发送序列化、旧内容兼容兜底及回归测试
- 明确不包含：消息正文 Markdown 渲染重构
- 用户可见变化：列表缩进与编号由结构化节点统一呈现；Shift/Alt+Enter、Backspace、嵌套列表发送等行为更稳定
- 是否存在 breaking change：无

### UI 变化

- 输入框内可安全识别的普通列表统一使用结构化列表布局；复杂旧内容、缩进行和含原子节点的内容继续走兼容兜底
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4「Inputs & Forms」、§10「Light / Dark Dual-Mode Delivery Gate」、§14.3「Keyboard & IME」；复用输入框现有语义 token 和 Light/Dark 样式，不新增硬编码颜色，并保留现有 Enter 发送与 IME 边界

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；runner 297 pass / 1 skip，Desktop、Mobile 及相关 packages 全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

定向列表、草稿、历史与粘贴测试
结果：132/132 通过

git diff --check
结果：通过
```

### 手工验证

- macOS Desktop dev：验证空列表项回删不再生成后续编号
-  Windows Desktop dev 验证ok
- 一些截图
<img width="1928" height="474" alt="image" src="https://github.com/user-attachments/assets/f65e1f7d-f1b8-4219-a455-b68a33f2f6fa" />
<img width="1896" height="388" alt="image" src="https://github.com/user-attachments/assets/c4c74513-8820-4671-837d-4ef18e90c2be" />


## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：输入框历史内容兼容

### 影响与回滚

- 影响范围：Desktop 对话输入框的列表输入、草稿与历史恢复、粘贴以及发送文本序列化
- 回滚 / 降级方式：可整体回退本提交；无法安全升级的旧内容仍保留纯文本兼容路径，复杂缩进和原子内容不会被强制转换

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

## CI 结果

- 状态：待运行
