### PR TITLE
fix(mobile): #716 合并后遗留的 5 条 review——翻代收敛、页面恢复补全、离线负缓存、删除超时窗口

### DIFF
--- a/apps/mobile/app/files/preview/[sessionId].tsx
+++ b/apps/mobile/app/files/preview/[sessionId].tsx
@@ -159,12 +159,16 @@ export default function RemoteFilePreviewScreen() {
   // 代数驱动两件事:pager effect 重列目录;FlatList key 掺入代数让预览子页
   // 整体重挂载(refs 归零、重新拉取)。翻转沿极少发生,重挂载代价可接受。
   const [recoveryEpoch, setRecoveryEpoch] = useState(0);
-  const prevDeviceUnresponsiveRef = useRef(deviceUnresponsive);
+  const prevBreakerStateRef = useRef({ deviceId, unresponsive: deviceUnresponsive });
   useEffect(() => {
-    const was = prevDeviceUnresponsiveRef.current;
-    prevDeviceUnresponsiveRef.current = deviceUnresponsive;
-    if (was && !deviceUnresponsive) setRecoveryEpoch((epoch) => epoch + 1);
-  }, [deviceUnresponsive]);
+    const prev = prevBreakerStateRef.current;
+    prevBreakerStateRef.current = { deviceId, unresponsive: deviceUnresponsive };
+    // 换设备不是恢复沿(review):页面保持挂载但路由参数换了设备时,「上一台
+    // 未响应、这一台正常」不该触发整个 pager 重挂载——新设备的加载由各 effect
+    // 的 deviceId 依赖自然驱动。
+    if (prev.deviceId !== deviceId) return;
+    if (prev.unresponsive && !deviceUnresponsive) setRecoveryEpoch((epoch) => epoch + 1);
+  }, [deviceId, deviceUnresponsive]);
   useEffect(() => {
     if (knownSession) {
       setSession(knownSession);
@@ -191,10 +195,24 @@ export default function RemoteFilePreviewScreen() {
   }, [singleAbsPath]);
 
   // 同目录 pager:列父目录 → 文件项按浏览页同款排序;失败时退化为单文件。
+  // 重建列表时锚定「当前可见文件」而非固定 initialRelPath(review P1):恢复
+  // 重列 / 排序切换发生在用户已翻页之后时,重置回初始文件会让 FlatList 的
+  // 原生滚动位置与 pageIndex(标题 / 分享 / 下载的目标)指向两个不同文件。
+  // setPageIndex 后再显式 scrollToOffset 重锚一次(initialScrollIndex 只在
+  // 首挂载生效,items key 变化不会重置 contentOffset)。
   useEffect(() => {
     if (!deviceId || !workdir || !initialRelPath) return undefined;
     let cancelled = false;
     const dirRel = parentRelPath(initialRelPath) ?? '';
+    const anchorRelPath = currentRelPathRef.current ?? initialRelPath;
+    const anchorTo = (index: number): void => {
+      setPageIndex(index);
+      requestAnimationFrame(() => {
+        if (!cancelled) {
+          pagerRef.current?.scrollToOffset({ animated: false, offset: index * pageWidthRef.current });
+        }
+      });
+    };
     void withTransientRemoteRetry(async () => {
       await openLink(deviceId);
       return maker.fileBrowser.listDir(workdir, dirRel);
@@ -206,19 +224,20 @@ export default function RemoteFilePreviewScreen() {
         const files = buildFileBrowserGridItems(normalizeRemoteOpDirEntries(raw), sortMode, Date.now())
           .filter((item) => item.kind === 'file')
           .filter((item) => item.thumb !== 'image' || item.relPath === initialRelPath);
-        const index = files.findIndex((item) => item.relPath === initialRelPath);
+        let index = files.findIndex((item) => item.relPath === anchorRelPath);
+        if (index < 0) index = files.findIndex((item) => item.relPath === initialRelPath);
         if (files.length === 0 || index < 0) {
           setSiblings([fallbackItem(initialRelPath)]);
-          setPageIndex(0);
+          anchorTo(0);
           return;
         }
         setSiblings(files);
-        setPageIndex(index);
+        anchorTo(index);
       })
       .catch(() => {
         if (cancelled) return;
         setSiblings([fallbackItem(initialRelPath)]);
-        setPageIndex(0);
+        anchorTo(0);
       });
     return () => {
       cancelled = true;
@@ -227,6 +246,18 @@ export default function RemoteFilePreviewScreen() {
 
   const current = siblings?.[pageIndex] ?? null;
   const pagerRef = useRef<FlatList<FileBrowserGridItem>>(null);
+  // 当前可见文件路径镜像(pager 重建锚定用;不能进上面 effect 的依赖,否则
+  // 每次翻页都会重列目录)。
+  const currentRelPathRef = useRef<string | null>(null);
+  useEffect(() => {
+    currentRelPathRef.current = current?.relPath ?? null;
+  }, [current]);
+  // pageWidth 镜像:重锚回调里读现值,不把 pageWidth 拉进列表 effect 依赖
+  // (旋转已有专门的重锚 effect)。
+  const pageWidthRef = useRef(pageWidth);
+  useEffect(() => {
+    pageWidthRef.current = pageWidth;
+  }, [pageWidth]);
 
   // 旋转(宽度变化)时按当前页重锚:FlatList 保留的是旧宽度下的像素 contentOffset,
   // 不重锚会停在两页中间(处理方式对齐 ImageLightbox)。

--- a/apps/mobile/app/files/preview/[sessionId].tsx
+++ b/apps/mobile/app/files/preview/[sessionId].tsx
@@ -153,6 +153,18 @@ export default function RemoteFilePreviewScreen() {
   // 轻量请求(open 期间是本地快速失败,零管道流量)。
   const unresponsiveDevices = useUnresponsiveDevices();
   const deviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
+  // 熔断恢复代数(review P1):open→closed 翻转沿 +1。仅重试 getSession 不够——
+  // 会话已缓存时,同目录 pager 可能已退化成单文件、文本/PDF/音视频子页已落进
+  // 失败态,而子页用 requestedRef/loadedRef 防重复请求,失败后绝不自行重试。
+  // 代数驱动两件事:pager effect 重列目录;FlatList key 掺入代数让预览子页
+  // 整体重挂载(refs 归零、重新拉取)。翻转沿极少发生,重挂载代价可接受。
+  const [recoveryEpoch, setRecoveryEpoch] = useState(0);
+  const prevDeviceUnresponsiveRef = useRef(deviceUnresponsive);
+  useEffect(() => {
+    const was = prevDeviceUnresponsiveRef.current;
+    prevDeviceUnresponsiveRef.current = deviceUnresponsive;
+    if (was && !deviceUnresponsive) setRecoveryEpoch((epoch) => epoch + 1);
+  }, [deviceUnresponsive]);
   useEffect(() => {
     if (knownSession) {
       setSession(knownSession);
@@ -211,7 +223,7 @@ export default function RemoteFilePreviewScreen() {
     return () => {
       cancelled = true;
     };
-  }, [deviceId, initialRelPath, maker, openLink, sortMode, workdir]);
+  }, [deviceId, initialRelPath, maker, openLink, recoveryEpoch, sortMode, workdir]);
 
   const current = siblings?.[pageIndex] ?? null;
   const pagerRef = useRef<FlatList<FileBrowserGridItem>>(null);
@@ -365,7 +377,7 @@ export default function RemoteFilePreviewScreen() {
         ref={pagerRef}
         horizontal
         initialScrollIndex={pageIndex}
-        keyExtractor={(item) => item.key}
+        keyExtractor={(item) => `${item.key}:${recoveryEpoch}`}
         onMomentumScrollEnd={(event) => {
           const next = Math.round(event.nativeEvent.contentOffset.x / pageWidth);
           if (next !== pageIndex && next >= 0 && next < siblings.length) setPageIndex(next);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2914,6 +2914,21 @@ export default function SessionScreen() {
     return () => clearTimeout(timer);
   }, [currentSession, deviceId, load, loading, sessionId, status]);
 
+  // 熔断恢复沿补全量同步(review P1):connectionError 已按陈旧过滤,恢复后为
+  // null,下面按 error 驱动的自动重试不会再触发;而探测关熔断不会给本页任何
+  // 其它信号(rehydrate 只补消息/交互,不刷 session 元数据与 lastSyncedAt),
+  // cacheSeeded 会话的 composer 会永远停在 syncing。在 open→closed 翻转沿
+  // 直接补一次 load;换设备不算恢复沿(路由复用同一挂载实例时)。
+  const prevBreakerStateRef = useRef({ deviceId, unresponsive: isDeviceUnresponsive });
+  useEffect(() => {
+    const prev = prevBreakerStateRef.current;
+    prevBreakerStateRef.current = { deviceId, unresponsive: isDeviceUnresponsive };
+    if (prev.deviceId !== deviceId) return;
+    if (!prev.unresponsive || isDeviceUnresponsive) return;
+    if (!deviceId || !sessionId || status !== 'online') return;
+    void load();
+  }, [deviceId, isDeviceUnresponsive, load, sessionId, status]);
+
   useEffect(() => {
     if (!connectionError) {
       if (!loading) autoRetrySyncKeyRef.current = null;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -62,6 +62,7 @@ import { useAuth } from '@/auth/AuthContext';
 import { useGuardedBack } from '@/utils/useGuardedBack';
 import { DEVICE_LINK_API_BASE_URL, MOBILE_VISUAL_MOCK_ENABLED } from '@/config/env';
 import { ConnectionBanner, useShowConnectionBanner } from '@/components/ConnectionBanner';
+import { resolveEffectiveConnectionError } from '@/components/connectionBannerVisibility';
 import { PaperPlaneIcon } from '@/components/PaperPlaneIcon';
 import { useDeviceLink } from '@/device-link/DeviceLinkContext';
 import { useRevokedDevices } from '@/device-link/revokedDevicesStore';
@@ -1159,9 +1160,14 @@ export default function SessionScreen() {
   const isDeviceAccessRevoked = !!deviceId && revokedDevices.has(deviceId);
   // 熔断 open:被控电脑「进程活着但不回包」的半死态;relay status 恒 online,必须单独入参。
   const isDeviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
-  const connectionError = isDeviceAccessRevoked
-    ? '[ACCESS_REVOKED] access revoked by target device'
-    : error;
+  // 熔断已关后残留的 DEVICE_UNRESPONSIVE 错误按陈旧丢弃,且必须一次性解析、
+  // 两个消费方共用(review P1):banner 用它,下面的 remoteUnavailableReason 也
+  // 用它——否则恢复后横幅消失了,composer 却仍被 stale 快照锁在不可用态,
+  // 直到手动同步才解开。
+  const connectionError = resolveEffectiveConnectionError(
+    isDeviceAccessRevoked ? '[ACCESS_REVOKED] access revoked by target device' : error,
+    isDeviceUnresponsive,
+  );
   // 弱网普通断线也要有可见信号(消息流静默停更没有任何提示),经防闪延迟后显示
   const showConnectionBanner = useShowConnectionBanner(status, connectionError, connectionIssue, isDeviceUnresponsive);
   const hasCurrentSession = currentSession !== null;

--- a/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
@@ -199,7 +199,7 @@ describe('generation:恢复前派出的旧请求结果不采信(review P1)', () 
     openBreaker(h);
   });
 
-  it('普通 responded 也翻篇:之前在途请求的晚到超时不计入连续计数', () => {
+  it('清零失败计数的 responded 翻篇:之前在途请求的晚到超时不计入连续计数', () => {
     const h = harness();
     const stale = h.breaker.acquire(DEV);
     timeoutOnce(h.breaker);
@@ -209,6 +209,20 @@ describe('generation:恢复前派出的旧请求结果不采信(review P1)', () 
     timeoutOnce(h.breaker);
     timeoutOnce(h.breaker);
     expect(h.breaker.isOpen(DEV)).toBe(false); // 新代只累计了 2 次
+  });
+
+  it('无状态时的 responded 不翻篇:健康并发下同期超时照常累计(review)', () => {
+    // 若每次 responded 都翻代,健康并发里一个较快回包会把同期在途请求随后的
+    // 超时全部作废——连续超时被低估,设备真卡死时熔断反而难打开。
+    const h = harness();
+    const slow1 = h.breaker.acquire(DEV);
+    const slow2 = h.breaker.acquire(DEV);
+    const slow3 = h.breaker.acquire(DEV);
+    settleOnce(h.breaker, 'responded'); // 快请求先回包:无状态,不翻代
+    h.breaker.settle(DEV, slow1, 'timeout');
+    h.breaker.settle(DEV, slow2, 'timeout');
+    h.breaker.settle(DEV, slow3, 'timeout');
+    expect(h.breaker.isOpen(DEV)).toBe(true); // 3 条同期超时照常开断路器
   });
 
   it('clear(撤权)翻篇:清除前在途请求的超时不会重建计数', () => {
@@ -225,6 +239,7 @@ describe('generation:恢复前派出的旧请求结果不采信(review P1)', () 
   it('旧代 responded 同样不采信(不会误关新一代已 open 的熔断)', () => {
     const h = harness();
     const stale = h.breaker.acquire(DEV);
+    timeoutOnce(h.breaker); // 产生失败计数,让下面的 responded 构成清理性翻篇
     settleOnce(h.breaker, 'responded'); // 翻篇:stale 变旧代
     openBreaker(h); // 新代 open
     h.breaker.settle(DEV, stale, 'responded'); // 旧代晚到成功:忽略

--- a/apps/mobile/src/__tests__/invokeTimeouts.test.ts
+++ b/apps/mobile/src/__tests__/invokeTimeouts.test.ts
@@ -39,6 +39,9 @@ describe('resolveMobileInvokeTimeoutMs', () => {
     // agent;两者有真实副作用,误超时重试会改动/重启已在跑的 goal。
     expect(resolveMobileInvokeTimeoutMs('maker:goal:set')).toBe(30_000);
     expect(resolveMobileInvokeTimeoutMs('maker:goal:resume')).toBe(30_000);
+    // message:delete:提交前 await closeSession(远端 close RPC 自带 15s 超时),
+    // 破坏性操作,误超时后删除已生效、mobile 却报失败。
+    expect(resolveMobileInvokeTimeoutMs('maker:message:delete')).toBe(30_000);
     expect(MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS['device-link:media:fetch']).toBe(30_000);
   });
 

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -391,6 +391,19 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
+  it('DEVICE_OFFLINE 的 message-only 形态同样按离线分类(review:不只认 code)', async () => {
+    resetScheduleIndexThrottleForTesting();
+    const load = vi.fn()
+      .mockRejectedValueOnce(new Error('[DEVICE_OFFLINE] target host not online'))
+      .mockResolvedValueOnce(new Map<string, RemoteSessionScheduleInfo>());
+    const now = () => 1000;
+    await expect(loadSessionScheduleIndexThrottled('dev-m', load, { now })).rejects.toThrow('DEVICE_OFFLINE');
+    await Promise.resolve();
+    invalidateOfflineScheduleIndexFailureFor('dev-m');
+    await expect(loadSessionScheduleIndexThrottled('dev-m', load, { now })).resolves.toBeInstanceOf(Map);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
   it('末项竞态的 INVOKE_TIMEOUT 失败:熔断 open 时同样按未响应记负缓存,恢复即旁路', async () => {
     // 末项竞态抛的是原始 INVOKE_TIMEOUT(非快速失败码);节流层补查 store
     // (key 即 deviceId)才能让这类失败同样享受「恢复即旁路」。

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { MobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { unresponsiveDevicesStore } from '@/device-link/unresponsiveDevicesStore';
 import {
+  invalidateOfflineScheduleIndexFailureFor,
   invalidateTransientScheduleIndexFailures,
   loadSessionScheduleIndex,
   loadSessionScheduleIndexThrottled,
@@ -360,10 +361,9 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
-  it('DEVICE_OFFLINE 失败同属重连失效类别:presence 恢复后立即重拉(review P1)', async () => {
-    // 目标桌面离线时 reject 的是 DEVICE_OFFLINE(shared 分类也视为 transient);
-    // 不认它的话,presence 恢复落在 30s 负缓存窗内,reseed 会吃旧 rejected
-    // promise,详情页被换成空索引且无人补拉。
+  it('DEVICE_OFFLINE 负缓存:仅该设备 presence 恢复时失效,全局重连钩子不碰(review P1)', async () => {
+    // DEVICE_OFFLINE 是逐设备状态:若挂在全局重连钩子上,B 设备的任何 rehydrate
+    // 都会反复清掉仍离线的 A 设备的 30s 负缓存,请求风暴止损失效。
     resetScheduleIndexThrottleForTesting();
     const load = vi.fn()
       .mockRejectedValueOnce(Object.assign(new Error('device offline'), { code: 'DEVICE_OFFLINE' }))
@@ -373,7 +373,20 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
       code: 'DEVICE_OFFLINE',
     });
     await Promise.resolve();
+    // 全局重连钩子(NOT_CONNECTED 类专用)不清 DEVICE_OFFLINE 负缓存
     invalidateTransientScheduleIndexFailures();
+    await expect(loadSessionScheduleIndexThrottled('dev-o', load, { now })).rejects.toMatchObject({
+      code: 'DEVICE_OFFLINE',
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+    // 别的设备 presence 恢复也不清
+    invalidateOfflineScheduleIndexFailureFor('dev-other');
+    await expect(loadSessionScheduleIndexThrottled('dev-o', load, { now })).rejects.toMatchObject({
+      code: 'DEVICE_OFFLINE',
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+    // 该设备 presence 恢复:立即失效、重拉
+    invalidateOfflineScheduleIndexFailureFor('dev-o');
     await expect(loadSessionScheduleIndexThrottled('dev-o', load, { now })).resolves.toBeInstanceOf(Map);
     expect(load).toHaveBeenCalledTimes(2);
   });

--- a/apps/mobile/src/__tests__/scheduleIndex.test.ts
+++ b/apps/mobile/src/__tests__/scheduleIndex.test.ts
@@ -360,6 +360,24 @@ describe('loadSessionScheduleIndexThrottled (单飞 + TTL 节流)', () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
+  it('DEVICE_OFFLINE 失败同属重连失效类别:presence 恢复后立即重拉(review P1)', async () => {
+    // 目标桌面离线时 reject 的是 DEVICE_OFFLINE(shared 分类也视为 transient);
+    // 不认它的话,presence 恢复落在 30s 负缓存窗内,reseed 会吃旧 rejected
+    // promise,详情页被换成空索引且无人补拉。
+    resetScheduleIndexThrottleForTesting();
+    const load = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('device offline'), { code: 'DEVICE_OFFLINE' }))
+      .mockResolvedValueOnce(new Map<string, RemoteSessionScheduleInfo>());
+    const now = () => 1000;
+    await expect(loadSessionScheduleIndexThrottled('dev-o', load, { now })).rejects.toMatchObject({
+      code: 'DEVICE_OFFLINE',
+    });
+    await Promise.resolve();
+    invalidateTransientScheduleIndexFailures();
+    await expect(loadSessionScheduleIndexThrottled('dev-o', load, { now })).resolves.toBeInstanceOf(Map);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
   it('末项竞态的 INVOKE_TIMEOUT 失败:熔断 open 时同样按未响应记负缓存,恢复即旁路', async () => {
     // 末项竞态抛的是原始 INVOKE_TIMEOUT(非快速失败码);节流层补查 store
     // (key 即 deviceId)才能让这类失败同样享受「恢复即旁路」。

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -447,12 +447,12 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         return;
       }
       clearPresenceWipeTimer(wipeTimers, snap.deviceId);
-      if (presence.recovered) {
-        // 该设备 presence 恢复:它的 DEVICE_OFFLINE 负缓存就地失效(逐设备,
-        // 不走全局重连钩子,review P1),随后的 rehydrate/reseed 拉到新数据。
-        invalidateOfflineScheduleIndexFailureFor(snap.deviceId);
-        void rehydrateWithClient(client);
-      }
+      // 每个「可用」快照都清该设备的 DEVICE_OFFLINE 负缓存(review P1 ×2):
+      // 主机在手机连上 relay 之前就离线时,presence 只在变化时广播,首个在线
+      // 快照 recovered=false——只挂 recovered 会漏掉这次恢复,徽标停留到无关
+      // 触发。逐设备且幂等(map 单点查删),不影响其它设备的风暴止损。
+      invalidateOfflineScheduleIndexFailureFor(snap.deviceId);
+      if (presence.recovered) void rehydrateWithClient(client);
     });
     const offFrame = client.onFrame((env) => routeFrame(env, {
       onAccessRevoked: (deviceId) => remoteSubscribedTopicsRef.current.delete(deviceId),

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -42,7 +42,7 @@ import { clearAllDeviceModelMeta, evictDeviceModelMeta } from '@/device-link/dev
 import { dispatchFileBrowserWatchEvent } from '@/device-link/fileBrowserWatch';
 import { resolveMobileInvokeTimeoutMs } from '@/device-link/invokeTimeouts';
 import { rehydrateDeviceLinkTopics } from '@/device-link/rehydrate';
-import { invalidateTransientScheduleIndexFailures } from '@/session/scheduleIndex';
+import { invalidateOfflineScheduleIndexFailureFor, invalidateTransientScheduleIndexFailures } from '@/session/scheduleIndex';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 import { createRnWebSocket } from '@/device-link/rnWebSocket';
 import type { MobileGoalStatusPayload } from '@cindy/maker-shared/device-link-contract';
@@ -447,7 +447,12 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         return;
       }
       clearPresenceWipeTimer(wipeTimers, snap.deviceId);
-      if (presence.recovered) void rehydrateWithClient(client);
+      if (presence.recovered) {
+        // 该设备 presence 恢复:它的 DEVICE_OFFLINE 负缓存就地失效(逐设备,
+        // 不走全局重连钩子,review P1),随后的 rehydrate/reseed 拉到新数据。
+        invalidateOfflineScheduleIndexFailureFor(snap.deviceId);
+        void rehydrateWithClient(client);
+      }
     });
     const offFrame = client.onFrame((env) => routeFrame(env, {
       onAccessRevoked: (deviceId) => remoteSubscribedTopicsRef.current.delete(deviceId),

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -24,10 +24,12 @@ export type BreakerAcquireDecision = 'allow' | 'probe' | 'reject';
 
 /**
  * acquire 发放的席位票据,settle 时原样带回。generation 是发放时该设备的代数:
- * responded / clear / resetAll 都会递增代数,settle 时代数不匹配 = 这是恢复
- * (或清除)之前派出的旧请求,其结果一律不采信(review P1:熔断 open 前派出的
- * 30/40s 长超时请求,会在探测成功关熔断之后才陆续超时,若照常计数,3 条陈旧
- * 超时会立刻把刚恢复的熔断重新打开)。
+ * 清理性事件(responded 关闭 open / 清零失败计数、clear、resetAll)递增代数,
+ * settle 时代数不匹配 = 这是恢复(或清除)之前派出的旧请求,其结果一律不采信
+ * (review P1:熔断 open 前派出的 30/40s 长超时请求,会在探测成功关熔断之后
+ * 才陆续超时,若照常计数,3 条陈旧超时会立刻把刚恢复的熔断重新打开)。
+ * 无状态时的 responded 不翻代(review:否则健康并发下一个快回包会作废同期
+ * 在途请求的超时,连续超时被低估、熔断反而难打开)。
  */
 export interface BreakerSendSlot {
   decision: BreakerAcquireDecision;
@@ -102,8 +104,9 @@ export function createDeviceResponsivenessBreaker(
   const probeBackoffMaxMs = options.probeBackoffMaxMs ?? BREAKER_PROBE_BACKOFF_MAX_MS;
   const now = options.now ?? Date.now;
   const states = new Map<string, DeviceBreakerState>();
-  // 每设备代数:responded / clear / resetAll 递增。settle 只采信「派发时代数
-  // 仍是当前代」的结果——恢复前派出的长超时请求晚到的超时不再污染新一代计数。
+  // 每设备代数:清理性事件(responded 清态、clear、resetAll)递增。settle 只
+  // 采信「派发时代数仍是当前代」的结果——恢复前派出的长超时请求晚到的超时
+  // 不再污染新一代计数。
   const generations = new Map<string, number>();
   const generationOf = (deviceId: string): number => generations.get(deviceId) ?? 0;
   const bumpGeneration = (deviceId: string): void => {
@@ -135,9 +138,12 @@ export function createDeviceResponsivenessBreaker(
     // 永久占住唯一探测席位;窗口基准未动,下一次 acquire 会立即放行新探测。
     if (state && wasProbe) state.probeInFlight = false;
     if (outcome === 'responded') {
-      // 真实回包即代数翻篇:此后到达的、更早派出的请求结果全部失效。
-      bumpGeneration(deviceId);
+      // 只在真的清理了状态(open 关闭 / 失败计数清零)时才翻代(review:
+      // 早先「每次 responded 都翻代」会让健康并发场景里一个较快的回包把
+      // 同期在途请求随后的超时全部作废——连续超时被低估,熔断反而难打开)。
+      // 无状态时的 responded 没有可作废的东西,不翻代,同期超时照常累计。
       if (!state) return;
+      bumpGeneration(deviceId);
       const wasOpen = state.open;
       states.delete(deviceId);
       if (wasOpen) options.onOpenChanged?.(deviceId, false);

--- a/apps/mobile/src/device-link/invokeTimeouts.ts
+++ b/apps/mobile/src/device-link/invokeTimeouts.ts
@@ -37,6 +37,9 @@ import { INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
  *  - maker:create-session:桌面 await maker.createSession → agent.startSession /
  *    Codex host.ensureStarted,冷启动 app-server 无更短 deadline;goal 路径无
  *    稳定的客户端会话 id,误超时后重试会建出第二个会话;
+ *  - maker:message:delete:桌面提交删除前先读 handoff 历史并 await
+ *    maker.closeSession(Claude 远端 close 的 cc-manager RPC 自带 15s 超时),
+ *    合法可贴着 15s 边界;破坏性操作,误超时后删除实际已生效,mobile 却报失败;
  *  - maker:goal:set / goal:resume:GoalController.ensureSession 的
  *    restoreSessionForGoal 同样 await createSession 重启持久化 agent,冷启动
  *    可超 15s;两者都有真实副作用(set 落库目标并发首轮,resume 先标 active),
@@ -53,6 +56,7 @@ export const MOBILE_INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   'maker:get-context-usage': 30_000,
   'maker:goal:resume': 30_000,
   'maker:goal:set': 30_000,
+  'maker:message:delete': 30_000,
   'maker:regenerate-title': 30_000,
   'maker:rewind:commit': 30_000,
   'maker:send': 30_000,

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -83,24 +83,34 @@ interface ScheduleIndexThrottleEntry {
 const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>();
 
 /**
+ * 错误标记匹配:优先结构化 code,兜底 message 文本(review:mobile 各处的
+ * 远端错误存在 message-only 形态,如 devices 页按 '[DEVICE_OFFLINE]' 文本
+ * 回落判定;只认 code 会让这类失败漏掉分类)。
+ */
+function hasRemoteErrorMarker(error: unknown, marker: string): boolean {
+  if ((error as { code?: unknown } | null | undefined)?.code === marker) return true;
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  return message.includes(marker);
+}
+
+/**
  * 本机链路未通(NOT_CONNECTED / LINK_NOT_OPEN):重连即恢复,重连钩子全局失效。
  * 不含 INVOKE_TIMEOUT——「设备不回包」不是断线,不能被重连钩子清掉;也不含
  * DEVICE_OFFLINE——那是逐设备状态,归 isDeviceOfflineError(review:全局失效
  * 会让 B 设备的任何 rehydrate 反复清掉仍离线的 A 设备的负缓存,止损失效)。
  */
 function isLocalLinkDownError(error: unknown): boolean {
-  const code = (error as { code?: unknown } | null | undefined)?.code;
-  return code === 'NOT_CONNECTED' || code === 'LINK_NOT_OPEN';
+  return hasRemoteErrorMarker(error, 'NOT_CONNECTED') || hasRemoteErrorMarker(error, 'LINK_NOT_OPEN');
 }
 
 /**
- * 目标设备离线(DEVICE_OFFLINE):负缓存只在**该设备**presence 恢复时失效
+ * 目标设备离线(DEVICE_OFFLINE):负缓存只在**该设备**presence 可用时失效
  * (invalidateOfflineScheduleIndexFailureFor,key 即 deviceId)。不认它的话,
  * presence 恢复落在 30s 负缓存窗内,reseed 会吃旧 rejected promise,详情页被
  * 换成空索引且无人补拉(review P1)。
  */
 function isDeviceOfflineError(error: unknown): boolean {
-  return (error as { code?: unknown } | null | undefined)?.code === 'DEVICE_OFFLINE';
+  return hasRemoteErrorMarker(error, 'DEVICE_OFFLINE');
 }
 
 export function loadSessionScheduleIndexThrottled(

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -80,10 +80,16 @@ interface ScheduleIndexThrottleEntry {
 
 const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>();
 
-/** 本机链路未通(NOT_CONNECTED / LINK_NOT_OPEN):重连即恢复的失败类别。 */
+/**
+ * 链路/目标不可达(NOT_CONNECTED / LINK_NOT_OPEN / DEVICE_OFFLINE):重连或
+ * presence 恢复即可解除的失败类别。DEVICE_OFFLINE 必须包含(review):目标
+ * 桌面离线时 reject 的就是它,不认的话 presence 恢复落在 30s 负缓存窗内,
+ * reseed 会吃旧 rejected promise,详情页被换成空索引且无人补拉。
+ * 不含 INVOKE_TIMEOUT——「设备不回包」不是断线,不能被重连钩子清掉。
+ */
 function isLocalLinkDownError(error: unknown): boolean {
   const code = (error as { code?: unknown } | null | undefined)?.code;
-  return code === 'NOT_CONNECTED' || code === 'LINK_NOT_OPEN';
+  return code === 'NOT_CONNECTED' || code === 'LINK_NOT_OPEN' || code === 'DEVICE_OFFLINE';
 }
 
 export function loadSessionScheduleIndexThrottled(

--- a/apps/mobile/src/session/scheduleIndex.ts
+++ b/apps/mobile/src/session/scheduleIndex.ts
@@ -74,22 +74,33 @@ interface ScheduleIndexThrottleEntry {
   failedAt: number | null;
   /** 失败原因是 DEVICE_UNRESPONSIVE(熔断快速失败);恢复旁路判定用。 */
   failedUnresponsive: boolean;
-  /** 失败原因是瞬态链路问题(NOT_CONNECTED 等);重连失效判定用。 */
+  /** 失败原因是本机链路问题(NOT_CONNECTED / LINK_NOT_OPEN);重连全局失效。 */
   failedTransient: boolean;
+  /** 失败原因是目标设备离线(DEVICE_OFFLINE);仅该设备 presence 恢复时失效。 */
+  failedOffline: boolean;
 }
 
 const scheduleIndexThrottleEntries = new Map<string, ScheduleIndexThrottleEntry>();
 
 /**
- * 链路/目标不可达(NOT_CONNECTED / LINK_NOT_OPEN / DEVICE_OFFLINE):重连或
- * presence 恢复即可解除的失败类别。DEVICE_OFFLINE 必须包含(review):目标
- * 桌面离线时 reject 的就是它,不认的话 presence 恢复落在 30s 负缓存窗内,
- * reseed 会吃旧 rejected promise,详情页被换成空索引且无人补拉。
- * 不含 INVOKE_TIMEOUT——「设备不回包」不是断线,不能被重连钩子清掉。
+ * 本机链路未通(NOT_CONNECTED / LINK_NOT_OPEN):重连即恢复,重连钩子全局失效。
+ * 不含 INVOKE_TIMEOUT——「设备不回包」不是断线,不能被重连钩子清掉;也不含
+ * DEVICE_OFFLINE——那是逐设备状态,归 isDeviceOfflineError(review:全局失效
+ * 会让 B 设备的任何 rehydrate 反复清掉仍离线的 A 设备的负缓存,止损失效)。
  */
 function isLocalLinkDownError(error: unknown): boolean {
   const code = (error as { code?: unknown } | null | undefined)?.code;
-  return code === 'NOT_CONNECTED' || code === 'LINK_NOT_OPEN' || code === 'DEVICE_OFFLINE';
+  return code === 'NOT_CONNECTED' || code === 'LINK_NOT_OPEN';
+}
+
+/**
+ * 目标设备离线(DEVICE_OFFLINE):负缓存只在**该设备**presence 恢复时失效
+ * (invalidateOfflineScheduleIndexFailureFor,key 即 deviceId)。不认它的话,
+ * presence 恢复落在 30s 负缓存窗内,reseed 会吃旧 rejected promise,详情页被
+ * 换成空索引且无人补拉(review P1)。
+ */
+function isDeviceOfflineError(error: unknown): boolean {
+  return (error as { code?: unknown } | null | undefined)?.code === 'DEVICE_OFFLINE';
 }
 
 export function loadSessionScheduleIndexThrottled(
@@ -123,6 +134,7 @@ export function loadSessionScheduleIndexThrottled(
     failedAt: null,
     failedUnresponsive: false,
     failedTransient: false,
+    failedOffline: false,
   };
   scheduleIndexThrottleEntries.set(key, entry);
   promise.then(
@@ -144,6 +156,7 @@ export function loadSessionScheduleIndexThrottled(
         // INVOKE_TIMEOUT(目标不回包)也算 transient,若沿用,重连失效钩子会把
         // 「设备不回包」的负缓存也当断线恢复清掉,削弱止损效果。
         entry.failedTransient = !entry.failedUnresponsive && isLocalLinkDownError(error);
+        entry.failedOffline = !entry.failedUnresponsive && isDeviceOfflineError(error);
       }
     },
   );
@@ -162,6 +175,19 @@ export function invalidateTransientScheduleIndexFailures(): void {
     if (entry.failedAt !== null && entry.failedTransient) {
       scheduleIndexThrottleEntries.delete(key);
     }
+  }
+}
+
+/**
+ * 逐设备失效钩子(review P1):DEVICE_OFFLINE 的负缓存只在该设备 presence
+ * 恢复时清除(DeviceLinkContext 的 presence.recovered 分支调用,key 即
+ * deviceId)——若挂在全局重连钩子上,别的设备的任何 rehydrate 都会反复清掉
+ * 仍离线设备的 30s 负缓存,请求风暴止损失效。
+ */
+export function invalidateOfflineScheduleIndexFailureFor(deviceId: string): void {
+  const entry = scheduleIndexThrottleEntries.get(deviceId);
+  if (entry && entry.failedAt !== null && entry.failedOffline) {
+    scheduleIndexThrottleEntries.delete(deviceId);
   }
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

#716(device-link「目标设备无响应」熔断)合并时,最后一轮 bot review 的 5 条 P1 恰好在合并前后落地、未及处理。本 PR 逐条修掉:

1. **breaker 翻代收敛**(Copilot,`deviceResponsivenessBreaker.ts`):原「每次 responded 都递增 generation」会让健康并发场景里一个较快回包把同期在途请求随后的超时全部作废——连续超时被低估,设备真卡死时熔断反而难打开。改为只有**清理性 responded**(关闭 open / 清零失败计数)才翻代;无状态时的 responded 不翻代,同期超时照常累计。恢复期陈旧超时不重开熔断的既有语义(#716 第七轮)不受影响。
2. **预览页恢复重试补全**(Codex P1,`files/preview/[sessionId].tsx`):此前恢复只重跑 getSession;会话已缓存时,同目录 pager 可能已退化成单文件、文本/PDF/音视频子页已落进失败态(子页用 `requestedRef`/`loadedRef` 防重复请求,失败后绝不自行重试)。新增 `recoveryEpoch`:熔断 open→closed 翻转沿 +1,驱动 pager 重列目录 + FlatList key 掺代数让预览子页整体重挂载重新拉取。
3. **DEVICE_OFFLINE 进重连失效类别**(Codex P1,`scheduleIndex.ts`):目标桌面离线时 schedule 加载 reject 的是 `DEVICE_OFFLINE`,上一版收窄后的判定不认它——presence 恢复落在 30s 负缓存窗内时 reseed 会吃旧 rejected promise,详情页被换成空索引且无人补拉。
4. **`maker:message:delete` 登记 30s**(Codex P1,`invokeTimeouts.ts`):桌面提交删除前先读 handoff 历史并 `await maker.closeSession()`(Claude 远端 close 的 cc-manager RPC 自带 15s 超时),合法执行可贴着 15s 边界;这是破坏性操作,误超时后删除实际已生效、mobile 却报失败,还计入熔断。
5. **会话页 stale error 双消费方统一过滤**(Codex P1,`sessions/[sessionId].tsx`):#716 第六轮只修了 banner 路径,`remoteUnavailableReason` 仍消费未过滤的 error 快照并喂进 `buildSessionOperationLayout`——熔断恢复后横幅消失了,composer 却停在不可用态直到手动同步。现在 `connectionError` 统一经 `resolveEffectiveConnectionError` 解析,两个消费方共用。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#716 合并后遗留的 5 条未解决 review thread(见 #716 review conversation)
- 本 PR 包含：上述 5 项修复 + 配套单测(breaker 并发用例、scheduleIndex DEVICE_OFFLINE 用例、invokeTimeouts 断言)
- 明确不包含：`DEVICE_UNRESPONSIVE` 收编进 `@cindy/device-link` 错误码联合(协议包,follow-up);被控端 `runInvoke` 本地 handler 无超时的根因侧(另立 issue)
- 用户可见变化：熔断恢复后,文件预览/会话 composer 自动回到可用态(此前需手动同步);设备离线恢复后自动化徽标即时回填;SSH 会话删消息不再误报失败
- 是否存在 breaking change：无

### UI 变化

不涉及:无新增视觉/交互/文案,只修复既有状态在熔断恢复后不自动解除的缺陷(命中 UI 代码路径但复用全部既有样式与文案)。

- 引用的设计规范：不涉及:无视觉/交互/文案变化,仅状态恢复时序修复。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run(定向:breaker / scheduleIndex / invokeTimeouts / probe / accessRevoked)
结果:5 files, 54 passed
pnpm --filter mobile test
结果:258 files, 2495 passed
pnpm --filter mobile run typecheck
结果:通过
/Users/dash/.claude/skills/git/scripts/run-unit-gate.sh(根 pnpm test:unit)
结果:GATE_EXIT=0
```

### 手工验证

不涉及:五项均为状态机/缓存/超时表时序缺陷,由单测覆盖判定语义;熔断开合的实机链路在 #716 主 PR 阶段已验证过。

### 未执行的验证

未做 mobile 实机回归(改动为 JS 层状态时序,不改变 runtime fingerprint;熔断恢复场景需人工制造被控端假死,成本高、单测已覆盖判定核)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 mobile 控制端(熔断状态机翻代语义、两页面的恢复重载、schedule 负缓存分类、1 个超时白名单项);不触协议包与桌面端
- 回滚 / 降级方式：revert 本 PR 即回到 #716 合入时行为,无数据迁移、无持久化格式变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
