### PR TITLE
feat(desktop): Grok 会话自动注入 x_search，并隐藏加密推理块

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -656,6 +656,8 @@ describe('codex proxy host', () => {
       tools: [
         { type: 'function', name: 'read_file' },
         { type: 'web_search', filters: { allowed_domains: ['docs.x.ai'] }, enable_image_search: true },
+        // Codex 不知道 xAI 还有 x_search;由 host 恒定补在末尾,Grok 才有 X 的实时视野。
+        { type: 'x_search' },
       ],
       input: [
         { type: 'message', role: 'system', content: 'BASE_PROMPT\n\nPRODUCT_PROMPT' },
@@ -693,6 +695,64 @@ describe('codex proxy host', () => {
       ],
     });
     clearSessionProvider('session-xai');
+  });
+
+  describe('xAI 服务端搜索工具(x_search)注入', () => {
+    async function runXaiTransforms(sessionSuffix: string, body: Record<string, unknown>): Promise<unknown> {
+      const host = await freshCodexProxyHost();
+      const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+      mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+        url: 'http://127.0.0.1:43210',
+        dispose: vi.fn(async () => undefined),
+      });
+      await host.ensureCodexProxyReady();
+      const sessionId = `session-xsearch-${sessionSuffix}`;
+      const threadId = `thread-xsearch-${sessionSuffix}`;
+      host.registerComposed(sessionId, threadId, 'PRODUCT_PROMPT');
+      setSessionProvider(sessionId, 'xai');
+
+      const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+      const ctx = { method: 'POST', url: '/responses', headers: { 'thread-id': threadId } };
+      let current: unknown = body;
+      for (const transform of transforms) {
+        const next = transform(current, ctx);
+        if (next !== null && next !== undefined) current = next;
+      }
+      clearSessionProvider(sessionId);
+      return current;
+    }
+
+    it('请求原本没有 tools 时也补上 x_search(Grok 默认就该能搜 X)', async () => {
+      const out = (await runXaiTransforms('no-tools', {
+        model: 'xai/grok-4.5',
+        input: [{ role: 'user', content: 'X 上今天 AI 圈在聊什么' }],
+      })) as Record<string, unknown>;
+
+      expect(out.tools).toEqual([{ type: 'x_search' }]);
+    });
+
+    it('上游已声明 x_search 时不重复注入,也不覆盖其参数', async () => {
+      const out = (await runXaiTransforms('already-declared', {
+        model: 'xai/grok-4.5',
+        tools: [{ type: 'x_search', from_date: '2026-07-01', to_date: '2026-07-28' }],
+        input: [{ role: 'user', content: 'hi' }],
+      })) as Record<string, unknown>;
+
+      expect(out.tools).toEqual([{ type: 'x_search', from_date: '2026-07-01', to_date: '2026-07-28' }]);
+    });
+
+    it.each(['xai/grok-code-fast', 'xai/grok-build-preview'])(
+      '编码模型 %s 不注入(该系列没有 agentic 搜索工具面,带上会被上游拒)',
+      async (model) => {
+        const out = (await runXaiTransforms(`coding-${model}`, {
+          model,
+          tools: [{ type: 'function', name: 'read_file' }],
+          input: [{ role: 'user', content: 'hi' }],
+        })) as Record<string, unknown>;
+
+        expect(out.tools).toEqual([{ type: 'function', name: 'read_file' }]);
+      },
+    );
   });
 
   it('leaves custom_tool_call history untouched for non-xAI requests', async () => {
@@ -1344,6 +1404,10 @@ describe('codex proxy host', () => {
 
     expect(current).toEqual({
       model: 'grok-future',
+      // reasoning 对未知模型保守剥掉(目录查不到能力),但 x_search 反过来按黑名单放行:
+      // 只排除 grok-code / grok-build,未知的新 Grok 通用模型默认当作能搜 X —— 否则每出一个
+      // 新模型都要等目录更新才恢复搜 X,而搜 X 正是选 Grok 的主要理由。
+      tools: [{ type: 'x_search' }],
       input: [
         { type: 'message', role: 'system', content: 'BASE_PROMPT\n\nPRODUCT_PROMPT' },
         { type: 'message', role: 'user', content: 'hello' },

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -741,6 +741,50 @@ describe('codex proxy host', () => {
       expect(out.tools).toEqual([{ type: 'x_search', from_date: '2026-07-01', to_date: '2026-07-28' }]);
     });
 
+    it('tool_choice:required + 唯一 function tool → 收窄成指名该 function,x_search 仍照常声明', async () => {
+      // required 作用于整个 tools 数组,附加 x_search 后模型可能用搜索顶替被强制的 function
+      // call。与 bridge 侧同口径:收窄 tool_choice,不摘工具声明(摘了会让前缀中途变动)。
+      const out = (await runXaiTransforms('forced-single', {
+        model: 'xai/grok-4.5',
+        tools: [{ type: 'function', name: 'read_file' }],
+        tool_choice: 'required',
+        input: [{ role: 'user', content: 'hi' }],
+      })) as Record<string, unknown>;
+
+      expect(out.tool_choice).toEqual({ type: 'function', name: 'read_file' });
+      expect(out.tools).toEqual([{ type: 'function', name: 'read_file' }, { type: 'x_search' }]);
+    });
+
+    it('tool_choice:required + 多个 function tool → 保留 required(Responses 无法表达子集限定)', async () => {
+      const out = (await runXaiTransforms('forced-multi', {
+        model: 'xai/grok-4.5',
+        tools: [
+          { type: 'function', name: 'read_file' },
+          { type: 'function', name: 'write_file' },
+        ],
+        tool_choice: 'required',
+        input: [{ role: 'user', content: 'hi' }],
+      })) as Record<string, unknown>;
+
+      expect(out.tool_choice).toBe('required');
+      expect(out.tools).toEqual([
+        { type: 'function', name: 'read_file' },
+        { type: 'function', name: 'write_file' },
+        { type: 'x_search' },
+      ]);
+    });
+
+    it('tool_choice:auto 不被改写', async () => {
+      const out = (await runXaiTransforms('auto-choice', {
+        model: 'xai/grok-4.5',
+        tools: [{ type: 'function', name: 'read_file' }],
+        tool_choice: 'auto',
+        input: [{ role: 'user', content: 'hi' }],
+      })) as Record<string, unknown>;
+
+      expect(out.tool_choice).toBe('auto');
+    });
+
     it.each(['xai/grok-code-fast', 'xai/grok-build-preview'])(
       '编码模型 %s 不注入(该系列没有 agentic 搜索工具面,带上会被上游拒)',
       async (model) => {

--- a/apps/desktop/src/main/maker-host/anthropic-responses-bridge-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-responses-bridge-host.ts
@@ -35,6 +35,7 @@ import {
 } from './chatgpt-bridge-auth-invalidation.js';
 import { buildChatgptBridgeHeaders } from './chatgpt-bridge-headers.js';
 import { recordXaiRateLimitSnapshot } from '../usageBroadcaster.js';
+import { xaiServerSideTools } from './xai-server-side-tools.js';
 import { CHATGPT_MODEL_PREFIX, XAI_MODEL_PREFIX } from '../../shared/subscriptionModels.js';
 
 const log = createMakerLogger('cc-bridge');
@@ -281,6 +282,8 @@ function xaiProviderConfig(): BridgeProviderConfig {
     maxOutputTokensSupported: true,
     // grok-code-fast / grok-build 系列不支持 reasoningEffort(实测 400),其余 grok 模型支持。
     supportsReasoning: (model) => !(model.startsWith('grok-code') || model.startsWith('grok-build')),
+    // Grok 的 X 实时视野来自 xAI 服务端工具 x_search:不声明就搜不了 X(见 xai-server-side-tools.ts)。
+    serverSideTools: xaiServerSideTools,
     buildHeaders: async () => ({
       authorization: `Bearer ${await getGrokAccessToken()}`,
     }),

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -60,6 +60,7 @@ import { getSessionProvider } from './session-provider-store.js';
 import { composeResponseObservers } from './claude-rate-limit-headers-observer.js';
 import { createProviderUpstreamErrorObserver, reportProviderUpstreamError } from './provider-upstream-error-observer.js';
 import { createXaiProxyAuthInvalidationObserver } from './xai-auth-invalidation-host.js';
+import { xaiServerSideTools } from './xai-server-side-tools.js';
 import { encryptedStripController, imageGenerationStripController } from './thread-strip-controllers.js';
 import { createMakerLogger } from './logger-adapter.js';
 import { resolveDesktopOutboundProxy } from './outbound-proxy-resolver.js';
@@ -641,6 +642,30 @@ function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown
 }
 
 /**
+ * 给 xAI 会话恒定补上 xAI 的服务端搜索工具(当前是 `x_search`,Grok 原生搜 X)。
+ *
+ * Codex 自己只会声明 OpenAI 系的内建工具,不知道 xAI 还有 x_search;不补的话用户选了
+ * Grok 也拿不到 X 的实时视野(见 xai-server-side-tools.ts)。补在**已有 tools 末尾**:
+ * 位置固定 + 只由 model 决定 → 同一会话逐轮请求的 tools 列表恒定,不破坏前缀稳定性。
+ * 上游已经带了同名工具(用户/Codex 自己声明过)则原样保留,不重复也不覆盖其参数。
+ */
+function ensureXaiServerSideTools(body: Record<string, unknown>): Record<string, unknown> | null {
+  const realModel = xaiRealModelId(body.model);
+  if (!realModel) return null;
+  const serverTools = xaiServerSideTools(realModel);
+  if (serverTools.length === 0) return null;
+
+  const existing = Array.isArray(body.tools) ? body.tools : [];
+  const declaredTypes = new Set(
+    existing.map((tool) => (isPlainObject(tool) && typeof tool.type === 'string' ? tool.type : '')),
+  );
+  const missing = serverTools.filter((tool) => !declaredTypes.has(tool.type));
+  if (missing.length === 0) return null;
+
+  return { ...body, tools: [...existing, ...missing] };
+}
+
+/**
  * ByteDance Seed accepts standard function tools and web search. Codex also
  * emits namespaced and other built-in descriptors that Volcengine rejects
  * before the request reaches the model. Its web-search descriptor must also
@@ -925,6 +950,14 @@ function createXaiResponsesCompatTransform(): RequestTransform {
     const withSanitizedTools = sanitizeXaiTools(current);
     if (withSanitizedTools) {
       current = withSanitizedTools;
+      changed = true;
+    }
+
+    // 补服务端工具排在 sanitize 之后:先按 xAI schema 清掉 Codex 专属工具,再追加 x_search,
+    // 保证注入项不会被同一轮的裁剪逻辑改形或丢掉。
+    const withServerSideTools = ensureXaiServerSideTools(current);
+    if (withServerSideTools) {
+      current = withServerSideTools;
       changed = true;
     }
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -648,7 +648,26 @@ function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown
  * Grok 也拿不到 X 的实时视野(见 xai-server-side-tools.ts)。补在**已有 tools 末尾**:
  * 位置固定 + 只由 model 决定 → 同一会话逐轮请求的 tools 列表恒定,不破坏前缀稳定性。
  * 上游已经带了同名工具(用户/Codex 自己声明过)则原样保留,不重复也不覆盖其参数。
+ *
+ * `tool_choice:'required'`(必须调用所提供工具之一)的处理与 bridge 侧同口径:required 作用于
+ * 整个 tools 数组,附加服务端工具后模型可能用 x_search 顶替调用方强制要的 function call。
+ * 这里同样**不**因此摘掉工具声明(那会让 tools 前缀在会话中途变动),而是在能精确表达时把
+ * tool_choice 收窄成指名唯一那个 function;有多个 function tool 时 Responses 无法表达
+ * 「required 但只限这几个」,保留 required 并接受该残余风险。
  */
+function narrowXaiForcedToolChoice(
+  body: Record<string, unknown>,
+  tools: unknown[],
+): Record<string, unknown> | null {
+  if (body.tool_choice !== 'required') return null;
+  const functionTools = tools.filter(
+    (tool) => isPlainObject(tool) && tool.type === 'function' && typeof tool.name === 'string',
+  );
+  if (functionTools.length !== 1) return null;
+  const only = functionTools[0] as Record<string, unknown>;
+  return { ...body, tool_choice: { type: 'function', name: only.name } };
+}
+
 function ensureXaiServerSideTools(body: Record<string, unknown>): Record<string, unknown> | null {
   const realModel = xaiRealModelId(body.model);
   if (!realModel) return null;
@@ -660,9 +679,12 @@ function ensureXaiServerSideTools(body: Record<string, unknown>): Record<string,
     existing.map((tool) => (isPlainObject(tool) && typeof tool.type === 'string' ? tool.type : '')),
   );
   const missing = serverTools.filter((tool) => !declaredTypes.has(tool.type));
-  if (missing.length === 0) return null;
-
-  return { ...body, tools: [...existing, ...missing] };
+  // 工具已齐时仍要判 tool_choice 收窄:x_search 可能是上游自己声明的。
+  const nextTools = missing.length > 0 ? [...existing, ...missing] : existing;
+  const withTools = missing.length > 0 ? { ...body, tools: nextTools } : body;
+  const narrowed = narrowXaiForcedToolChoice(withTools, nextTools);
+  if (narrowed) return narrowed;
+  return missing.length > 0 ? withTools : null;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/xai-server-side-tools.ts
+++ b/apps/desktop/src/main/maker-host/xai-server-side-tools.ts
@@ -1,0 +1,46 @@
+/**
+ * xAI(SuperGrok 订阅)的**服务端工具**声明 —— 当前只有 `x_search`(Grok 原生搜 X)。
+ *
+ * 背景:Grok 本身没有实时 X 数据权限,能不能搜 X 完全取决于请求 `tools[]` 里有没有
+ * `{ type: 'x_search' }`。这是 xAI 在**上游**执行的服务端工具:模型自己发起关键词 /
+ * 语义 / 用户 / thread 检索,客户端既收不到 tool call、也不需要回 tool_result,结果直接
+ * 融进回答与 citations。少了这条声明,同样的 Grok 模型就只是个没有 X 实时视野的普通模型。
+ *
+ * 因此 Cindy 对 xAI 会话恒定附加该声明,让「选了 Grok」= 「能搜 X」,而不是要求用户自己
+ * 想办法把工具塞进请求。两条到 api.x.ai 的链路共用本模块,避免两处门控漂移:
+ *   - Codex agent  → `codex-proxy-host.ts` 的 xAI compat transform
+ *   - Claude Code  → `anthropic-responses-bridge-host.ts` 的 xai provider 配置
+ *
+ * 稳定性约束:声明只由 model 决定,不掺任何会话态或每轮变化的内容,且恒定排在 function
+ * tools 之后 —— 请求前缀逐轮一致,不破坏 prompt 缓存(见
+ * `docs/dev-rules/maker-core-and-agent-behavior.md` §3.1「会话中途不得增删/重排 tool」)。
+ */
+
+import type { ResponsesServerTool } from '@cindy/anthropic-responses-bridge';
+
+/** xAI 原生 X 搜索工具的 wire 形态(参数全省略 = 由模型自行决定检索范围与时间窗)。 */
+export const XAI_X_SEARCH_TOOL_TYPE = 'x_search';
+
+/**
+ * 该(去前缀后的)xAI model 是否暴露服务端搜索工具。
+ *
+ * grok-code / grok-build 系列是编码特化模型,不提供 agentic 搜索工具面(与本仓
+ * `supportsReasoning` 的门控口径一致:同一批模型也不吃 reasoningEffort);给它们带上
+ * `x_search` 只会让上游 400,拖垮本来正常的编码会话。
+ *
+ * 刻意用**黑名单**而不是「只放行目录里已知的模型」:未知的新 Grok 通用模型默认当作能搜 X。
+ * 白名单意味着 xAI 每发一个新模型,用户都要等本地目录更新才恢复搜 X —— 而搜 X 正是选 Grok
+ * 的主要理由,静默丢能力比偶发的上游报错更难被发现。新出的编码系模型若沿用 grok-code /
+ * grok-build 命名会自动落进排除区;万一 xAI 换了命名,在这里补一条即可。
+ */
+export function xaiSupportsServerSideSearch(model: string): boolean {
+  return !(model.startsWith('grok-code') || model.startsWith('grok-build'));
+}
+
+/**
+ * 某个 xAI model 恒定附加的服务端工具列表(不支持的模型返回空数组)。
+ * 每次返回新对象,调用方可以安全地并入自己的 tools 数组而不共享引用。
+ */
+export function xaiServerSideTools(model: string): ResponsesServerTool[] {
+  return xaiSupportsServerSideSearch(model) ? [{ type: XAI_X_SEARCH_TOOL_TYPE }] : [];
+}

--- a/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
@@ -95,19 +95,20 @@ describe('handleStreamEvent — omitted thinking placeholder (live)', () => {
     expect(msg?.isStreaming).toBe(false);
   });
 
-  it('keeps redacted thinking (independent stage, untouched by the filter)', () => {
+  it('drops redacted thinking (加密推理无明文可读,不进渲染列表)', () => {
     const next = handleStreamEvent(EMPTY_SESSION_STATE, {
       sessionId: SESSION_ID,
       type: 'thinking',
       data: { stage: 'redacted', blockId: 'tb-red' },
     });
-    const msg = next.messages.find((m) => m.role === 'thinking');
-    expect(msg?.thinkingRedacted).toBe(true);
+    expect(next.messages.find((m) => m.role === 'thinking')).toBeUndefined();
+    // 不产生任何消息,也不改动既有 state。
+    expect(next.messages).toEqual(EMPTY_SESSION_STATE.messages);
   });
 });
 
 describe('mapServerMessages — omitted thinking placeholder (restore)', () => {
-  it('filters empty+zero-duration rows, keeps content / duration / redacted rows', () => {
+  it('filters empty+zero-duration rows 与 redacted 行,keeps content / duration 行', () => {
     const mapped = makerChatStore.__mapServerMessagesForTest([
       thinkingRow('t-empty', { kind: 'thinking', text: '', durationMs: 0, isRedacted: false }),
       thinkingRow('t-text', { kind: 'thinking', text: 'real reasoning', durationMs: 0, isRedacted: false }),
@@ -118,8 +119,8 @@ describe('mapServerMessages — omitted thinking placeholder (restore)', () => {
     expect(ids).not.toContain('t-empty');
     expect(ids).toContain('t-text');
     expect(ids).toContain('t-dur');
-    expect(ids).toContain('t-red');
-    expect(mapped.find((m) => m.clientId === 't-red')?.thinkingRedacted).toBe(true);
+    // 历史里的加密推理行同样不复原(与 live 路径同判定);DB 行本身保留不动。
+    expect(ids).not.toContain('t-red');
   });
 
   it('legacy rows without text/durationMs fields are treated as placeholders', () => {

--- a/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
@@ -44,6 +44,30 @@ describe('isOmittedThinkingPlaceholder', () => {
   });
 });
 
+describe('isNonAnchorHistoryRow — 历史初始页 backfill 判定', () => {
+  const isNonAnchor = makerChatStore.__isNonAnchorHistoryRowForTest;
+
+  it('被隐藏的 thinking 行算无锚点(否则整页被过滤后不会触发补页)', () => {
+    // 一轮搜索密集、产出可见正文前就失败的会话,最新 50 行可能全是加密推理:
+    // 映射结果为空 → MessageStream 不自动翻页 → 更老的消息再也拉不回来。
+    expect(isNonAnchor(thinkingRow('t-red', { kind: 'thinking', text: '', durationMs: 0, isRedacted: true }))).toBe(true);
+    expect(isNonAnchor(thinkingRow('t-empty', { kind: 'thinking', text: '', durationMs: 0, isRedacted: false }))).toBe(true);
+  });
+
+  it('有明文或有时长的 thinking 行是可见锚点,不触发补页', () => {
+    expect(isNonAnchor(thinkingRow('t-text', { kind: 'thinking', text: 'real reasoning', durationMs: 0, isRedacted: false }))).toBe(false);
+    expect(isNonAnchor(thinkingRow('t-dur', { kind: 'thinking', text: '', durationMs: 900, isRedacted: false }))).toBe(false);
+  });
+
+  it('tool_result 仍算无锚点(orphan 会被丢弃),普通消息不算', () => {
+    const row = (role: string): Message =>
+      ({ id: 'r', clientId: 'c', sessionId: SESSION_ID, role, content: 'hi', createdAt: '2026-07-02T00:00:00.000Z' } as unknown as Message);
+    expect(isNonAnchor(row('tool_result'))).toBe(true);
+    expect(isNonAnchor(row('assistant'))).toBe(false);
+    expect(isNonAnchor(row('user'))).toBe(false);
+  });
+});
+
 describe('handleStreamEvent — omitted thinking placeholder (live)', () => {
   it('drops a final-only empty thinking block (no start, durationMs=0)', () => {
     const next = handleStreamEvent(EMPTY_SESSION_STATE, {

--- a/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
@@ -66,6 +66,17 @@ describe('isNonAnchorHistoryRow — 历史初始页 backfill 判定', () => {
     expect(isNonAnchor(row('assistant'))).toBe(false);
     expect(isNonAnchor(row('user'))).toBe(false);
   });
+
+  it('合成指令行算无锚点(渲染 null),否则混进一条就会提前停止回填', () => {
+    // 与 loadOlderMessages 的可见锚点判定同口径。string 与 {text} 两种 content 形态都要覆盖。
+    const synthetic = (content: unknown): Message =>
+      ({ id: 'r', clientId: 'c', sessionId: SESSION_ID, role: 'user', content, createdAt: '2026-07-02T00:00:00.000Z' } as unknown as Message);
+    expect(isNonAnchor(synthetic('[UI_ACTION_TRIGGER] retry'))).toBe(true);
+    expect(isNonAnchor(synthetic({ text: '[UI_ACTION_TRIGGER] retry' }))).toBe(true);
+    // 真实用户消息仍是锚点。
+    expect(isNonAnchor(synthetic('帮我查一下'))).toBe(false);
+    expect(isNonAnchor(synthetic({ text: '帮我查一下' }))).toBe(false);
+  });
 });
 
 describe('handleStreamEvent — omitted thinking placeholder (live)', () => {

--- a/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
@@ -105,6 +105,18 @@ describe('handleStreamEvent — omitted thinking placeholder (live)', () => {
     // 不产生任何消息,也不改动既有 state。
     expect(next.messages).toEqual(EMPTY_SESSION_STATE.messages);
   });
+
+  it('redacted 事件带 agentMeta 时仍刷新 lastAgentMeta(不展示 ≠ 丢事件)', () => {
+    const next = handleStreamEvent(EMPTY_SESSION_STATE, {
+      sessionId: SESSION_ID,
+      type: 'thinking',
+      data: { stage: 'redacted', blockId: 'tb-red-meta' },
+      agentMeta: { model: 'xai/grok-4.5', parentUuid: 'parent-1' },
+    });
+    // 消息列表仍不新增,但 mid-turn 抢救用的 lastAgentMeta 不能被静默吞掉。
+    expect(next.messages).toEqual(EMPTY_SESSION_STATE.messages);
+    expect(next.lastAgentMeta).toEqual({ model: 'xai/grok-4.5', parentUuid: 'parent-1' });
+  });
 });
 
 describe('mapServerMessages — omitted thinking placeholder (restore)', () => {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5126,7 +5126,8 @@ function ensureInitialMessages(sessionId: string): void {
       // 两类命中(见 isNonAnchorHistoryRow):
       //   - 全是 tool_result:配对的 tool_use 父消息在更老的页里,orphan 会被丢弃;
       //   - 全是被隐藏的 thinking 行:如一轮搜索密集、在产出可见正文前就失败的会话,
-      //     最新 50 行可能全是加密推理。
+      //     最新 50 行可能全是加密推理;
+      //   - 合成指令行:渲染 null,混在上面两类里同样撑不出可见锚点。
       // 这里继续往前翻页,直到出现可渲染锚点或翻完。
       // 上限 10 页(500 行)防御异常长的连续无锚点队列。
       let merged: Message[] = existing;
@@ -8330,13 +8331,20 @@ function isHiddenThinkingRow(m: Message): boolean {
 /**
  * 该服务端行**渲染后不会留下可见锚点**(初始页全是这类行时必须继续往前翻页)。
  *
- * `tool_result` 的配对 tool_use 父消息可能在更老的页里,MessageStream 会丢弃 orphan;
- * 被 `isHiddenThinkingRow` 过滤掉的行则直接不进列表。任何一类占满整页,都会让映射结果为空,
- * 而 MessageStream 在 `visibleRenderItems.length === 0` 时不触发自动翻页 —— 结果是
- * DB 里有几千条消息、重开会话却渲染 0 项,更老的用户/助手消息再也拉不回来。
+ * 三类:
+ *   - `tool_result`:配对的 tool_use 父消息可能在更老的页里,MessageStream 会丢弃 orphan;
+ *   - 被 `isHiddenThinkingRow` 过滤掉的行:直接不进渲染列表;
+ *   - 合成指令行(`isSyntheticTriggerRow`):MessageStream 渲染 null、content 置空,
+ *     与 `loadOlderMessages` 的可见锚点判定同口径(见该处「合成指令行渲染 null,不算可见
+ *     锚点」)。少了这一类,一页里只要混进一条合成 user 行就会被当成锚点提前停止回填,
+ *     而它映射后同样不产生可见内容 —— 症状与完全不回填一样。
+ *
+ * 任何组合占满整页,都会让映射结果为空,而 MessageStream 在 `visibleRenderItems.length === 0`
+ * 时不触发自动翻页 —— 结果是 DB 里有几千条消息、重开会话却渲染 0 项,更老的用户/助手消息
+ * 再也拉不回来。
  */
 function isNonAnchorHistoryRow(m: Message): boolean {
-  return m.role === 'tool_result' || isHiddenThinkingRow(m);
+  return m.role === 'tool_result' || isHiddenThinkingRow(m) || isSyntheticTriggerRow(m);
 }
 
 function mapServerMessages(serverMsgs: Message[]): ChatMessage[] {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5120,12 +5120,15 @@ function ensureInitialMessages(sessionId: string): void {
         return;
       }
 
-      // orphan-tool_result-backfill: 初始页若全是 tool_result 行,它们的
-      // 配对 tool_use 父消息位于更老的位置(不在本页中)。MessageStream
-      // 会丢弃所有 orphan tool_result —— 结果是 DB 里有 2000+ 条消息,
-      // 重启后 ChatView 渲染 0 项,看起来"内容消失了"。
-      // 这里继续往前翻页,直到出现非 tool_result 行(可渲染锚点)或翻完。
-      // 上限 10 页(500 行)防御异常长的连续 tool_result 队列。
+      // no-anchor-backfill: 初始页若全是"渲染后不留可见锚点"的行,映射结果就是空列表,
+      // 而 MessageStream 在 visibleRenderItems.length === 0 时不触发自动翻页 —— 结果是
+      // DB 里有 2000+ 条消息,重启后 ChatView 渲染 0 项,看起来"内容消失了"。
+      // 两类命中(见 isNonAnchorHistoryRow):
+      //   - 全是 tool_result:配对的 tool_use 父消息在更老的页里,orphan 会被丢弃;
+      //   - 全是被隐藏的 thinking 行:如一轮搜索密集、在产出可见正文前就失败的会话,
+      //     最新 50 行可能全是加密推理。
+      // 这里继续往前翻页,直到出现可渲染锚点或翻完。
+      // 上限 10 页(500 行)防御异常长的连续无锚点队列。
       let merged: Message[] = existing;
       let oldestRow = oldestMessageRow(merged, 'newest-first');
       if (!oldestRow) {
@@ -5144,7 +5147,7 @@ function ensureInitialMessages(sessionId: string): void {
       while (
         hasMore &&
         pagesFetched < MAX_BACKFILL_PAGES &&
-        merged.every((m) => m.role === 'tool_result')
+        merged.every(isNonAnchorHistoryRow)
       ) {
         pagesFetched += 1;
         try {
@@ -5160,7 +5163,7 @@ function ensureInitialMessages(sessionId: string): void {
           oldestRow = oldestMessageRow(merged, 'newest-first') ?? oldestRow;
           hasMore = serverMessagePageHasMore(older);
         } catch (err) {
-          log.warn('orphan-tool_result backfill failed', err);
+          log.warn('no-anchor history backfill failed', err);
           break;
         }
       }
@@ -8049,6 +8052,8 @@ export const makerChatStore = {
   __hydratePersistedMessageForTest: hydratePersistedMessage,
   /** Exposed for tests only. */
   __mapServerMessagesForTest: mapServerMessages,
+  /** Exposed for tests only: 历史初始页 backfill 的"无可见锚点"判定。 */
+  __isNonAnchorHistoryRowForTest: isNonAnchorHistoryRow,
   /** Exposed for tests only. */
   __mergeMessagesForTest: mergeMessages,
   /** Exposed for tests only. */
@@ -8300,6 +8305,40 @@ function isSyntheticTriggerRow(m: Message): boolean {
   return false;
 }
 
+/**
+ * 该 thinking 服务端行是否**不进渲染列表**(DB 行照旧保留,只是不展示)。
+ *
+ * 两类:
+ *   - `isRedacted` 加密推理:没有任何明文可读,卡片只能显示"无法显示的思考过程",对用户是
+ *     纯噪音;上游开服务端工具后一轮能出十几条,会淹掉真实产出。与 live 路径
+ *     (handleStreamEvent 的 stage==='redacted')同判定。
+ *   - omitted-display 占位行(空文本 + 0 时长,非 redacted):不复原成 "Thought for 1s" 卡片。
+ *     上游恢复明文下发后新数据自然不再命中。
+ *
+ * 单一来源:mapServerMessages 的过滤与 `isNonAnchorHistoryRow` 的 backfill 判定都用它,
+ * 避免"过滤掉了却没触发补页"这类漂移。将来要恢复展示某一类,只改这里。
+ */
+function isHiddenThinkingRow(m: Message): boolean {
+  if (m.role !== 'thinking' || !m.content || typeof m.content !== 'object') return false;
+  const c = m.content as Record<string, unknown>;
+  if (c.isRedacted === true) return true;
+  const text = typeof c.text === 'string' ? c.text : '';
+  const durationMs = typeof c.durationMs === 'number' ? c.durationMs : 0;
+  return isOmittedThinkingPlaceholder(text, durationMs);
+}
+
+/**
+ * 该服务端行**渲染后不会留下可见锚点**(初始页全是这类行时必须继续往前翻页)。
+ *
+ * `tool_result` 的配对 tool_use 父消息可能在更老的页里,MessageStream 会丢弃 orphan;
+ * 被 `isHiddenThinkingRow` 过滤掉的行则直接不进列表。任何一类占满整页,都会让映射结果为空,
+ * 而 MessageStream 在 `visibleRenderItems.length === 0` 时不触发自动翻页 —— 结果是
+ * DB 里有几千条消息、重开会话却渲染 0 项,更老的用户/助手消息再也拉不回来。
+ */
+function isNonAnchorHistoryRow(m: Message): boolean {
+  return m.role === 'tool_result' || isHiddenThinkingRow(m);
+}
+
 function mapServerMessages(serverMsgs: Message[]): ChatMessage[] {
   // Build per-clientId createdAt lookup so we can patch it onto every
   // mapped ChatMessage uniformly (each branch below builds a different
@@ -8312,24 +8351,7 @@ function mapServerMessages(serverMsgs: Message[]): ChatMessage[] {
   const remoteRowsTrimmedById = new Map(
     serverMsgs.map((m) => [m.clientId, m.agentMeta?.remoteRowsTrimmed === true]),
   );
-  const filtered = serverMsgs.filter((m) => {
-    // 历史里的 omitted-display thinking 占位行(空文本 + 0 时长,非 redacted)
-    // 与 live 路径同判定,不复原成 "Thought for 1s" 卡片。DB 行保留不动,
-    // 上游恢复明文下发后新数据自然不再命中。
-    if (m.role === 'thinking' && m.content && typeof m.content === 'object') {
-      const c = m.content as Record<string, unknown>;
-      const text = typeof c.text === 'string' ? c.text : '';
-      const durationMs = typeof c.durationMs === 'number' ? c.durationMs : 0;
-      // 加密推理(redacted)一律不展示:它没有任何明文可读,卡片只能显示"无法显示的
-      // 思考过程",对用户是纯噪音;上游开服务端工具后一轮能出十几条,会淹掉真实产出。
-      // 与 live 路径(handleStreamEvent 的 stage==='redacted')同判定。DB 行照旧保留,
-      // 只是不进渲染列表 —— 将来要恢复展示,删掉这一条即可。
-      if (c.isRedacted === true) return false;
-      if (isOmittedThinkingPlaceholder(text, durationMs)) return false;
-      return true;
-    }
-    return true;
-  });
+  const filtered = serverMsgs.filter((m) => !isHiddenThinkingRow(m));
   const ordered = filtered.sort(compareMessageTimeline);
   const legacyUserTurnCosts = projectLegacyUserTurnCosts(ordered);
   const mapped = ordered.map((m) => {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2159,22 +2159,13 @@ export function handleStreamEvent(
         };
       }
 
-      // stage === 'redacted' —— 落库已收口 main(onThinkingEvent),renderer 只做 UI。
-      return {
-        ...state,
-        messages: [
-          ...state.messages,
-          {
-            clientId: data.blockId,
-            role: 'thinking',
-            content: '',
-            isStreaming: false,
-            thinkingRedacted: true,
-            createdAt: new Date().toISOString(),
-            ...assistantMetaFields,
-          },
-        ],
-      };
+      // stage === 'redacted' —— 加密推理不进渲染列表。
+      //
+      // 这类块没有任何明文可读,卡片只能显示"无法显示的思考过程";上游(如 Grok 开了
+      // 服务端搜索)一轮能产出十几条,会把真实产出淹掉。落库仍由 main(onThinkingEvent)
+      // 照旧收口、encrypted_content 也不受影响(回放走 agent 侧 transcript,不依赖这里),
+      // 这里只是不展示。恢复展示 = 删掉这个提前 return,并同步 mapServerMessages 的同名过滤。
+      return state;
     }
 
     case 'agent_task_update': {
@@ -8325,7 +8316,12 @@ function mapServerMessages(serverMsgs: Message[]): ChatMessage[] {
       const c = m.content as Record<string, unknown>;
       const text = typeof c.text === 'string' ? c.text : '';
       const durationMs = typeof c.durationMs === 'number' ? c.durationMs : 0;
-      if (c.isRedacted !== true && isOmittedThinkingPlaceholder(text, durationMs)) return false;
+      // 加密推理(redacted)一律不展示:它没有任何明文可读,卡片只能显示"无法显示的
+      // 思考过程",对用户是纯噪音;上游开服务端工具后一轮能出十几条,会淹掉真实产出。
+      // 与 live 路径(handleStreamEvent 的 stage==='redacted')同判定。DB 行照旧保留,
+      // 只是不进渲染列表 —— 将来要恢复展示,删掉这一条即可。
+      if (c.isRedacted === true) return false;
+      if (isOmittedThinkingPlaceholder(text, durationMs)) return false;
       return true;
     }
     return true;

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2165,7 +2165,11 @@ export function handleStreamEvent(
       // 服务端搜索)一轮能产出十几条,会把真实产出淹掉。落库仍由 main(onThinkingEvent)
       // 照旧收口、encrypted_content 也不受影响(回放走 agent 侧 transcript,不依赖这里),
       // 这里只是不展示。恢复展示 = 删掉这个提前 return,并同步 mapServerMessages 的同名过滤。
-      return state;
+      //
+      // 不展示 ≠ 丢事件:仍按本函数开头的不变量刷新 lastAgentMeta(带 agentMeta 的事件都要刷,
+      // mid-turn 抢救 assistant 累积流时拿它当 fallback)。否则这条事件携带的 model /
+      // parentUuid 会被静默吞掉。
+      return incomingMeta ? { ...state, lastAgentMeta: incomingMeta } : state;
     }
 
     case 'agent_task_update': {

--- a/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
@@ -115,6 +115,34 @@ describe('createResponsesHandler', () => {
     expect(seen[0].body.model).toBe('grok-4.3');
   });
 
+  it('provider.serverSideTools 按去前缀 model 决定,并随请求下发给上游', async () => {
+    const seen: Array<{ body: Record<string, unknown> }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
+      seen.push({ body: JSON.parse(String(init.body)) });
+      return new Response(sse(OK_SSE), { status: 200, headers: { 'content-type': 'text/event-stream' } });
+    }));
+    const askedModels: string[] = [];
+    const handler = createResponsesHandler({
+      providers: [providerConfig({
+        prefix: 'xai/',
+        serverSideTools: (model) => {
+          askedModels.push(model);
+          return model.startsWith('grok-code') ? [] : [{ type: 'x_search' }];
+        },
+      })],
+    });
+
+    await invoke(handler, { model: 'xai/grok-4.5', messages: [] });
+    expect(seen[0].body.tools).toEqual([{ type: 'x_search' }]);
+    // 门控拿到的是剥掉前缀与 [1m] 后缀的真实 model id。
+    expect(askedModels).toEqual(['grok-4.5']);
+
+    // 编码模型:门控返回空 → 完全不发 tools。
+    seen.length = 0;
+    await invoke(handler, { model: 'xai/grok-code-fast', messages: [] });
+    expect(seen[0].body.tools).toBeUndefined();
+  });
+
   it('count_tokens 本地估算;无匹配 provider → 400;buildHeaders 抛错 → 502', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('should not fetch'); }));
     const handler = createResponsesHandler({ providers: [providerConfig()] });

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -197,9 +197,10 @@ describe('translateRequest', () => {
     expect(out.tool_choice).toBe('auto');
   });
 
-  it('tool_choice:any(→required)时不附加服务端工具,保住「必须调用调用方 function」的语义', () => {
+  it('tool_choice:any + 唯一 function tool → 收窄成指名该 function,工具声明不动', () => {
     // required 作用于整个 tools 数组:带上 x_search 的话上游可以只跑搜索就满足 required,
-    // 调用方强制要的那次本地 function call 永远不发生。
+    // 调用方强制要的那次本地 function call 永远不发生。解法是收窄 tool_choice,
+    // 而不是摘掉服务端工具——后者会让 tools 前缀在会话中途变动、prompt 缓存全程失效。
     const out = translateRequest(
       {
         model: 'xai/grok-4.5',
@@ -209,10 +210,41 @@ describe('translateRequest', () => {
       },
       { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
     );
+    expect(out.tool_choice).toEqual({ type: 'function', name: 'f' });
+    // 服务端工具照常声明:它只由 model 决定,不因某一轮的 tool_choice 增删。
+    expect(out.tools?.at(-1)).toEqual({ type: 'x_search' });
+  });
+
+  it('tool_choice:any + 多个 function tool → 保留 required,工具声明仍不动(前缀稳定优先)', () => {
+    // Responses 无法表达「required 但只限这几个」;此时保留 required 并接受残余风险,
+    // 不为它牺牲 tools 声明的跨轮稳定性。
+    const out = translateRequest(
+      {
+        model: 'xai/grok-4.5',
+        tools: [
+          { name: 'f1', input_schema: { type: 'object', properties: {} } },
+          { name: 'f2', input_schema: { type: 'object', properties: {} } },
+        ],
+        tool_choice: { type: 'any' },
+        messages: [],
+      },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
     expect(out.tool_choice).toBe('required');
-    expect(out.tools).toEqual([
-      { type: 'function', name: 'f', description: undefined, strict: false, parameters: { type: 'object', properties: {} } },
-    ]);
+    expect(out.tools?.at(-1)).toEqual({ type: 'x_search' });
+  });
+
+  it('没有服务端工具时 tool_choice:any 原样保持 required(不做多余收窄)', () => {
+    const out = translateRequest(
+      {
+        model: 'chatgpt/gpt-5.5',
+        tools: [{ name: 'f', input_schema: { type: 'object', properties: {} } }],
+        tool_choice: { type: 'any' },
+        messages: [],
+      },
+      { model: 'gpt-5.5' },
+    );
+    expect(out.tool_choice).toBe('required');
   });
 
   it('tool_choice 指名具体 function / auto 时仍附加服务端工具(不会被顶替)', () => {
@@ -240,7 +272,7 @@ describe('translateRequest', () => {
     expect(auto.tools?.at(-1)).toEqual({ type: 'x_search' });
   });
 
-  it('tool_choice:any 但请求没带 function tool → required 无意义,服务端工具照常下发', () => {
+  it('tool_choice:any 但请求没带 function tool → 服务端工具照常下发,且不发 tool_choice', () => {
     const out = translateRequest(
       { model: 'xai/grok-4.5', tool_choice: { type: 'any' }, messages: [] },
       { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -272,6 +272,40 @@ describe('translateRequest', () => {
     expect(auto.tools?.at(-1)).toEqual({ type: 'x_search' });
   });
 
+  it('tool_choice:none 且没有 function tool → 仍下发 none(否则等于放开服务端工具)', () => {
+    // none 是调用方显式禁止用工具;我们仍会声明 x_search(声明只由 model 决定),
+    // 不把 none 传下去就等于把调用方的禁令反过来。
+    const out = translateRequest(
+      { model: 'xai/grok-4.5', tool_choice: { type: 'none' }, messages: [] },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+    expect(out.tools).toEqual([{ type: 'x_search' }]);
+    expect(out.tool_choice).toBe('none');
+    // parallel_tool_calls 只描述本地 function tool 的并行策略,纯服务端工具轮不发。
+    expect(out.parallel_tool_calls).toBeUndefined();
+  });
+
+  it('tool_choice:none 且有 function tool → 照常下发 none', () => {
+    const out = translateRequest(
+      {
+        model: 'xai/grok-4.5',
+        tools: [{ name: 'f', input_schema: { type: 'object', properties: {} } }],
+        tool_choice: { type: 'none' },
+        messages: [],
+      },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+    expect(out.tool_choice).toBe('none');
+  });
+
+  it('tool_choice:{type:tool} 但没有 function tool → 不下发(会指向不存在的 function)', () => {
+    const out = translateRequest(
+      { model: 'xai/grok-4.5', tool_choice: { type: 'tool', name: 'ghost' }, messages: [] },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+    expect(out.tool_choice).toBeUndefined();
+  });
+
   it('tool_choice:any 但请求没带 function tool → 服务端工具照常下发,且不发 tool_choice', () => {
     const out = translateRequest(
       { model: 'xai/grok-4.5', tool_choice: { type: 'any' }, messages: [] },

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -197,6 +197,58 @@ describe('translateRequest', () => {
     expect(out.tool_choice).toBe('auto');
   });
 
+  it('tool_choice:any(→required)时不附加服务端工具,保住「必须调用调用方 function」的语义', () => {
+    // required 作用于整个 tools 数组:带上 x_search 的话上游可以只跑搜索就满足 required,
+    // 调用方强制要的那次本地 function call 永远不发生。
+    const out = translateRequest(
+      {
+        model: 'xai/grok-4.5',
+        tools: [{ name: 'f', input_schema: { type: 'object', properties: {} } }],
+        tool_choice: { type: 'any' },
+        messages: [],
+      },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+    expect(out.tool_choice).toBe('required');
+    expect(out.tools).toEqual([
+      { type: 'function', name: 'f', description: undefined, strict: false, parameters: { type: 'object', properties: {} } },
+    ]);
+  });
+
+  it('tool_choice 指名具体 function / auto 时仍附加服务端工具(不会被顶替)', () => {
+    const named = translateRequest(
+      {
+        model: 'xai/grok-4.5',
+        tools: [{ name: 'f', input_schema: { type: 'object', properties: {} } }],
+        tool_choice: { type: 'tool', name: 'f' },
+        messages: [],
+      },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+    expect(named.tool_choice).toEqual({ type: 'function', name: 'f' });
+    expect(named.tools?.at(-1)).toEqual({ type: 'x_search' });
+
+    const auto = translateRequest(
+      {
+        model: 'xai/grok-4.5',
+        tools: [{ name: 'f', input_schema: { type: 'object', properties: {} } }],
+        tool_choice: { type: 'auto' },
+        messages: [],
+      },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+    expect(auto.tools?.at(-1)).toEqual({ type: 'x_search' });
+  });
+
+  it('tool_choice:any 但请求没带 function tool → required 无意义,服务端工具照常下发', () => {
+    const out = translateRequest(
+      { model: 'xai/grok-4.5', tool_choice: { type: 'any' }, messages: [] },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+    expect(out.tools).toEqual([{ type: 'x_search' }]);
+    expect(out.tool_choice).toBeUndefined();
+  });
+
   it('纯服务端工具轮(请求没带 function tool)也下发 tools,但不发 tool_choice / parallel_tool_calls', () => {
     const out = translateRequest(
       { model: 'xai/grok-4.5', messages: [] },

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -179,6 +179,44 @@ describe('translateRequest', () => {
     expect(out.input).toEqual([{ type: 'function_call_output', call_id: 'c1', output: 'r1\nr2' }]);
   });
 
+  it('serverSideTools 恒定追加在 function tools 之后(位置固定 → 前缀稳定)', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'xai/grok-4.5',
+      tools: [{ name: 'f', description: 'd', input_schema: { type: 'object', properties: {} } }],
+      tool_choice: { type: 'auto' },
+      messages: [],
+    };
+    const out = translateRequest(req, { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] });
+
+    expect(out.tools).toEqual([
+      { type: 'function', name: 'f', description: 'd', strict: false, parameters: { type: 'object', properties: {} } },
+      { type: 'x_search' },
+    ]);
+    // 本地 function tool 仍在 → 调用策略字段照发。
+    expect(out.parallel_tool_calls).toBe(true);
+    expect(out.tool_choice).toBe('auto');
+  });
+
+  it('纯服务端工具轮(请求没带 function tool)也下发 tools,但不发 tool_choice / parallel_tool_calls', () => {
+    const out = translateRequest(
+      { model: 'xai/grok-4.5', messages: [] },
+      { model: 'grok-4.5', serverSideTools: [{ type: 'x_search' }] },
+    );
+
+    expect(out.tools).toEqual([{ type: 'x_search' }]);
+    // tool_choice 只描述本地 function tool 的调用策略;没有 function tool 时发它会指向不存在的工具。
+    expect(out.tool_choice).toBeUndefined();
+    expect(out.parallel_tool_calls).toBeUndefined();
+  });
+
+  it('不传 serverSideTools 时 tools 行为与改造前一致(空数组不落 tools 字段)', () => {
+    const out = translateRequest({ model: 'gpt-5.5', messages: [] }, { model: 'gpt-5.5' });
+    expect(out.tools).toBeUndefined();
+
+    const empty = translateRequest({ model: 'gpt-5.5', messages: [] }, { model: 'gpt-5.5', serverSideTools: [] });
+    expect(empty.tools).toBeUndefined();
+  });
+
   it('maps thinking budget → reasoning effort', () => {
     const low = translateRequest(
       { model: 'gpt-5.5', messages: [], thinking: { type: 'enabled', budget_tokens: 2000 } },

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
@@ -573,29 +573,40 @@ describe('SseTranslator', () => {
     expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
   });
 
-  it('reasoning 一条 summary delta 都不发且与 message 交错 → 占位仍在,redacted_thinking 排在正文之前', () => {
+  it('reasoning 一条 summary delta 都不发时,正文照常流式吐出,不被缓冲到 reasoning done', () => {
     // xai/grok 开服务端工具(x_search)后的实测形态:reasoning item 只有 added / done,
-    // 中间不发任何 summary delta。占位若等首个 delta 就永远等不到 —— 正文会抢先吐完,
-    // 加密推理块被挤到答案后面(UI 上「无法显示的思考过程」出现在结果之后)。
-    const out = run([
-      { type: 'response.created', response: { id: 'r', model: 'grok-4.5' } },
-      { type: 'response.output_item.added', output_index: 0, item: { id: 'rs_1', type: 'reasoning' } },
-      // reasoning 未 done,message item 直接插进来吐正文:必须 defer
-      { type: 'response.output_item.added', output_index: 1, item: { type: 'message' } },
-      { type: 'response.output_text.delta', output_index: 1, delta: '答案正文' },
+    // 中间不发任何 summary delta,且可能到整轮末尾才 done。
+    // 这里锁定的性质是「可见答案不许被扣住」:曾经为了把加密推理块排到正文之前,在
+    // output_item.added 处给 reasoning 占位,结果 output_text.delta(属 DEFERRABLE_TYPES)
+    // 被全量缓冲,长搜索轮看起来完全卡死。加密推理块没有明文、renderer 也不展示,
+    // 它排在正文之后没有可见后果 —— 流式性优先。
+    const t = new SseTranslator('xai/grok-4.5');
+    const created = t.push({ type: 'response.created', response: { id: 'r', model: 'grok-4.5' } });
+    const reasoningAdded = t.push({ type: 'response.output_item.added', output_index: 0, item: { id: 'rs_1', type: 'reasoning' } });
+    const msgAdded = t.push({ type: 'response.output_item.added', output_index: 1, item: { type: 'message' } });
+    // 关键:reasoning 尚未 done,这条 text delta 必须**立刻**吐出去,不能进 deferred 队列。
+    const textDelta = t.push({ type: 'response.output_text.delta', output_index: 1, delta: '答案正文' });
+
+    const textDeltaOut = textDelta.filter(
+      (e) => e.event === 'content_block_delta' && (e.data.delta as Record<string, unknown>).type === 'text_delta',
+    );
+    expect(textDeltaOut).toHaveLength(1);
+    expect((textDeltaOut[0].data.delta as Record<string, unknown>).text).toBe('答案正文');
+
+    const rest = [
       { type: 'response.output_item.done', output_index: 1, item: { type: 'message' } },
       { type: 'response.output_item.done', output_index: 0, item: { id: 'rs_1', type: 'reasoning', encrypted_content: 'ENC', summary: [] } },
       { type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 1, output_tokens: 1 } } },
-    ]);
+    ].flatMap((ev) => t.push(ev));
+
+    const out = [...created, ...reasoningAdded, ...msgAdded, ...textDelta, ...rest];
     assertSequentialBlocks(out);
+    // 加密推理仍然完整保留(供 translate-request 回放),只是排在正文之后。
     const starts = byType(out, 'content_block_start');
-    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['redacted_thinking', 'text']);
-    expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
-    // 正文不因 defer 而丢字。
-    const textDelta = byType(out, 'content_block_delta').find(
-      (e) => (e.data.delta as Record<string, unknown>).type === 'text_delta',
-    );
-    expect((textDelta?.data.delta as Record<string, unknown>).text).toBe('答案正文');
+    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['text', 'redacted_thinking']);
+    const redacted = starts.find((e) => (e.data.content_block as Record<string, unknown>).type === 'redacted_thinking');
+    // 带 provider 前缀(构造用的是 xai/ 模型),出处过滤靠它。
+    expect((redacted!.data.content_block as Record<string, unknown>).data).toBe('xai/#id=rs_1#ENC');
   });
 
   it('reasoning 只发纯空白 summary delta → 不开 thinking 块,encrypted_content 走 redacted_thinking', () => {

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
@@ -573,59 +573,6 @@ describe('SseTranslator', () => {
     expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
   });
 
-  it('reasoning 一条 summary delta 都不发时,正文照常流式吐出,不被缓冲到 reasoning done', () => {
-    // xai/grok 开服务端工具(x_search)后的实测形态:reasoning item 只有 added / done,
-    // 中间不发任何 summary delta,且可能到整轮末尾才 done。
-    // 这里锁定的性质是「可见答案不许被扣住」:曾经为了把加密推理块排到正文之前,在
-    // output_item.added 处给 reasoning 占位,结果 output_text.delta(属 DEFERRABLE_TYPES)
-    // 被全量缓冲,长搜索轮看起来完全卡死。改为不占位、正文照常流,而那条注定放错位置的
-    // 加密推理直接丢掉(见下方断言)。
-    const t = new SseTranslator('xai/grok-4.5');
-    const created = t.push({ type: 'response.created', response: { id: 'r', model: 'grok-4.5' } });
-    const reasoningAdded = t.push({ type: 'response.output_item.added', output_index: 0, item: { id: 'rs_1', type: 'reasoning' } });
-    const msgAdded = t.push({ type: 'response.output_item.added', output_index: 1, item: { type: 'message' } });
-    // 关键:reasoning 尚未 done,这条 text delta 必须**立刻**吐出去,不能进 deferred 队列。
-    const textDelta = t.push({ type: 'response.output_text.delta', output_index: 1, delta: '答案正文' });
-
-    const textDeltaOut = textDelta.filter(
-      (e) => e.event === 'content_block_delta' && (e.data.delta as Record<string, unknown>).type === 'text_delta',
-    );
-    expect(textDeltaOut).toHaveLength(1);
-    expect((textDeltaOut[0].data.delta as Record<string, unknown>).text).toBe('答案正文');
-
-    const rest = [
-      { type: 'response.output_item.done', output_index: 1, item: { type: 'message' } },
-      { type: 'response.output_item.done', output_index: 0, item: { id: 'rs_1', type: 'reasoning', encrypted_content: 'ENC', summary: [] } },
-      { type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 1, output_tokens: 1 } } },
-    ].flatMap((ev) => t.push(ev));
-
-    const out = [...created, ...reasoningAdded, ...msgAdded, ...textDelta, ...rest];
-    assertSequentialBlocks(out);
-    // 正文已经先落块 → 这条加密推理被**丢掉**,而不是发一个注定放错位置的块:它唯一用途是
-    // 回放,而 translate-request 按 block 顺序还原 input[],排在正文之后会让回放变成
-    // 「message 在 reasoning 之前」,偏离上游 output_index 顺序,下一轮可能被上游拒收。
-    const starts = byType(out, 'content_block_start');
-    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['text']);
-  });
-
-  it('reasoning 零 summary delta 但先于正文 done → 加密推理照常保留(位置正确,可回放)', () => {
-    // 与上一条只差 reasoning done 的时机:这里它在 message item 之前收口,块顺序天然是
-    // reasoning → text,与上游 output_index 一致,能正确回放,不该丢。
-    const out = run([
-      { type: 'response.created', response: { id: 'r', model: 'grok-4.5' } },
-      { type: 'response.output_item.added', output_index: 0, item: { id: 'rs_1', type: 'reasoning' } },
-      { type: 'response.output_item.done', output_index: 0, item: { id: 'rs_1', type: 'reasoning', encrypted_content: 'ENC', summary: [] } },
-      { type: 'response.output_item.added', output_index: 1, item: { type: 'message' } },
-      { type: 'response.output_text.delta', output_index: 1, delta: '答案正文' },
-      { type: 'response.output_item.done', output_index: 1, item: { type: 'message' } },
-      { type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 1, output_tokens: 1 } } },
-    ]);
-    assertSequentialBlocks(out);
-    const starts = byType(out, 'content_block_start');
-    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['redacted_thinking', 'text']);
-    expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
-  });
-
   it('reasoning 只发纯空白 summary delta → 不开 thinking 块,encrypted_content 走 redacted_thinking', () => {
     const out = run([
       { type: 'response.created', response: { id: 'r', model: 'gpt-5.6-sol' } },

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
@@ -578,8 +578,8 @@ describe('SseTranslator', () => {
     // 中间不发任何 summary delta,且可能到整轮末尾才 done。
     // 这里锁定的性质是「可见答案不许被扣住」:曾经为了把加密推理块排到正文之前,在
     // output_item.added 处给 reasoning 占位,结果 output_text.delta(属 DEFERRABLE_TYPES)
-    // 被全量缓冲,长搜索轮看起来完全卡死。加密推理块没有明文、renderer 也不展示,
-    // 它排在正文之后没有可见后果 —— 流式性优先。
+    // 被全量缓冲,长搜索轮看起来完全卡死。改为不占位、正文照常流,而那条注定放错位置的
+    // 加密推理直接丢掉(见下方断言)。
     const t = new SseTranslator('xai/grok-4.5');
     const created = t.push({ type: 'response.created', response: { id: 'r', model: 'grok-4.5' } });
     const reasoningAdded = t.push({ type: 'response.output_item.added', output_index: 0, item: { id: 'rs_1', type: 'reasoning' } });
@@ -601,12 +601,29 @@ describe('SseTranslator', () => {
 
     const out = [...created, ...reasoningAdded, ...msgAdded, ...textDelta, ...rest];
     assertSequentialBlocks(out);
-    // 加密推理仍然完整保留(供 translate-request 回放),只是排在正文之后。
+    // 正文已经先落块 → 这条加密推理被**丢掉**,而不是发一个注定放错位置的块:它唯一用途是
+    // 回放,而 translate-request 按 block 顺序还原 input[],排在正文之后会让回放变成
+    // 「message 在 reasoning 之前」,偏离上游 output_index 顺序,下一轮可能被上游拒收。
     const starts = byType(out, 'content_block_start');
-    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['text', 'redacted_thinking']);
-    const redacted = starts.find((e) => (e.data.content_block as Record<string, unknown>).type === 'redacted_thinking');
-    // 带 provider 前缀(构造用的是 xai/ 模型),出处过滤靠它。
-    expect((redacted!.data.content_block as Record<string, unknown>).data).toBe('xai/#id=rs_1#ENC');
+    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['text']);
+  });
+
+  it('reasoning 零 summary delta 但先于正文 done → 加密推理照常保留(位置正确,可回放)', () => {
+    // 与上一条只差 reasoning done 的时机:这里它在 message item 之前收口,块顺序天然是
+    // reasoning → text,与上游 output_index 一致,能正确回放,不该丢。
+    const out = run([
+      { type: 'response.created', response: { id: 'r', model: 'grok-4.5' } },
+      { type: 'response.output_item.added', output_index: 0, item: { id: 'rs_1', type: 'reasoning' } },
+      { type: 'response.output_item.done', output_index: 0, item: { id: 'rs_1', type: 'reasoning', encrypted_content: 'ENC', summary: [] } },
+      { type: 'response.output_item.added', output_index: 1, item: { type: 'message' } },
+      { type: 'response.output_text.delta', output_index: 1, delta: '答案正文' },
+      { type: 'response.output_item.done', output_index: 1, item: { type: 'message' } },
+      { type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]);
+    assertSequentialBlocks(out);
+    const starts = byType(out, 'content_block_start');
+    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['redacted_thinking', 'text']);
+    expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
   });
 
   it('reasoning 只发纯空白 summary delta → 不开 thinking 块,encrypted_content 走 redacted_thinking', () => {

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
@@ -573,6 +573,31 @@ describe('SseTranslator', () => {
     expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
   });
 
+  it('reasoning 一条 summary delta 都不发且与 message 交错 → 占位仍在,redacted_thinking 排在正文之前', () => {
+    // xai/grok 开服务端工具(x_search)后的实测形态:reasoning item 只有 added / done,
+    // 中间不发任何 summary delta。占位若等首个 delta 就永远等不到 —— 正文会抢先吐完,
+    // 加密推理块被挤到答案后面(UI 上「无法显示的思考过程」出现在结果之后)。
+    const out = run([
+      { type: 'response.created', response: { id: 'r', model: 'grok-4.5' } },
+      { type: 'response.output_item.added', output_index: 0, item: { id: 'rs_1', type: 'reasoning' } },
+      // reasoning 未 done,message item 直接插进来吐正文:必须 defer
+      { type: 'response.output_item.added', output_index: 1, item: { type: 'message' } },
+      { type: 'response.output_text.delta', output_index: 1, delta: '答案正文' },
+      { type: 'response.output_item.done', output_index: 1, item: { type: 'message' } },
+      { type: 'response.output_item.done', output_index: 0, item: { id: 'rs_1', type: 'reasoning', encrypted_content: 'ENC', summary: [] } },
+      { type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]);
+    assertSequentialBlocks(out);
+    const starts = byType(out, 'content_block_start');
+    expect(starts.map((e) => (e.data.content_block as Record<string, unknown>).type)).toEqual(['redacted_thinking', 'text']);
+    expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
+    // 正文不因 defer 而丢字。
+    const textDelta = byType(out, 'content_block_delta').find(
+      (e) => (e.data.delta as Record<string, unknown>).type === 'text_delta',
+    );
+    expect((textDelta?.data.delta as Record<string, unknown>).text).toBe('答案正文');
+  });
+
   it('reasoning 只发纯空白 summary delta → 不开 thinking 块,encrypted_content 走 redacted_thinking', () => {
     const out = run([
       { type: 'response.created', response: { id: 'r', model: 'gpt-5.6-sol' } },

--- a/packages/anthropic-responses-bridge/src/handler.ts
+++ b/packages/anthropic-responses-bridge/src/handler.ts
@@ -253,6 +253,10 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
     // Fast 模式:prefs.fast × provider.fastServiceTier(codex='priority')。
     const serviceTier = prefs?.fast === true && provider.fastServiceTier ? provider.fastServiceTier : undefined;
 
+    // 上游服务端工具(如 xAI x_search):只由 provider 按 model 静态声明,不受会话态影响,
+    // 保证同一会话逐轮请求带同一份工具列表(前缀稳定)。
+    const serverSideTools = provider.serverSideTools?.(realModel);
+
     const responsesReq = translateRequest(parsed, {
       model: realModel,
       promptCacheKey: sessionId,
@@ -260,6 +264,7 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
       reasoningEffort,
       serviceTier,
       providerPrefix: provider.prefix,
+      serverSideTools,
     });
 
     const abort = new AbortController();

--- a/packages/anthropic-responses-bridge/src/index.ts
+++ b/packages/anthropic-responses-bridge/src/index.ts
@@ -35,8 +35,10 @@ export type {
   BridgeProviderConfig,
   BridgeUpstreamErrorInfo,
   BridgeWireProtocol,
+  ResponsesFunctionTool,
   ResponsesInputItem,
   ResponsesRequest,
+  ResponsesServerTool,
   ResponsesTool,
   UpstreamRateLimitInfo,
 } from './types.js';

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -25,6 +25,7 @@ import type {
   AnthropicMessagesRequest,
   AnthropicToolChoice,
   ResponsesContentPart,
+  ResponsesFunctionTool,
   ResponsesInputItem,
   ResponsesRequest,
   ResponsesServerTool,
@@ -240,6 +241,31 @@ function budgetToEffort(thinking: AnthropicMessagesRequest['thinking']): 'low' |
   return 'high';
 }
 
+/**
+ * 解析最终下发的 `tool_choice`,在**不动摇工具声明**的前提下尽量保住「强制调用本地工具」语义。
+ *
+ * Anthropic `tool_choice:{type:'any'}` → Responses `required`,意为「必须调用所提供工具之一」。
+ * 但 Responses 的 required 作用于**整个** tools 数组:同时声明了服务端工具(如 x_search)时,
+ * 上游可以靠跑一次搜索就满足 required,调用方强制要的那次本地 function call 永远不发生。
+ *
+ * 处理方式是收窄 tool_choice、而不是把服务端工具摘掉(摘掉会破坏 tools 前缀的跨轮稳定性):
+ *   - 恰好只有一个 function tool → 直接指名它,语义完全等价且不可能被服务端工具顶替;
+ *   - 有多个 function tool → Responses 无法表达「required 但只限这几个」,保留 required。
+ *     残余风险:模型可能用服务端工具满足 required。相比让 tools 声明在会话中途变动(缓存全程
+ *     失效、且违反 §3.1),这里选择保留声明稳定性并接受该残余风险。
+ *   - `{type:'tool',name}` / `auto` / `none` 本就不会被服务端工具顶替,原样透传。
+ */
+function resolveToolChoice(
+  raw: AnthropicToolChoice | undefined,
+  functionTools: ResponsesFunctionTool[],
+  hasServerSideTools: boolean,
+): ResponsesToolChoice | undefined {
+  const choice = toolChoiceToResponses(raw);
+  if (choice !== 'required' || !hasServerSideTools) return choice;
+  if (functionTools.length === 1) return { type: 'function', name: functionTools[0].name };
+  return choice;
+}
+
 /** Responses 端点接受的 reasoning effort 档(codex / api.x.ai 通用)。 */
 export type ResponsesReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
@@ -298,27 +324,24 @@ export function translateRequest(
     input.push(...messageToInputItems(msg, reasoningReplay));
   }
 
-  const functionTools: ResponsesTool[] = (req.tools ?? []).map((t) => ({
+  // 显式用 ResponsesFunctionTool(而非放宽后的 ResponsesTool 联合):function tool 的
+  // name / parameters 等必填字段要在编译期被校验,别被服务端工具那个 `type: string`
+  // 兜底分支放过去。
+  const functionTools: ResponsesFunctionTool[] = (req.tools ?? []).map((t) => ({
     type: 'function',
     name: t.name,
     description: t.description,
     strict: false,
     parameters: t.input_schema ?? { type: 'object', properties: {} },
   }));
-  const toolChoice = toolChoiceToResponses(req.tool_choice);
-  // Anthropic `tool_choice:{type:'any'}` → Responses `required`,语义是「必须调用所提供工具
-  // 之一」。而 Responses 的 required 作用于**整个** tools 数组:附加服务端工具后,上游可以
-  // 靠跑一次 x_search 就满足 required,调用方强制要的那次本地 function call 永远不发生
-  // ——用 any 逼出客户端工具调用的流程会被静默打断。这种强制轮宁可不带服务端工具:
-  // 少一次搜索只是能力打折,丢掉被强制的工具调用是行为错误。
-  //
-  // 只对 required 生效:`{type:'tool',name}` 指名到具体 function、`auto` / `none` 都不会被
-  // 服务端工具顶替。functionTools 为空时 required 无意义(下面也不会下发 tool_choice),
-  // 不必为它牺牲搜索能力。
-  const forcedFunctionChoice = functionTools.length > 0 && toolChoice === 'required';
-  // 服务端工具恒定排在 function tools 之后:位置固定 → 请求前缀逐轮稳定(缓存友好)。
-  const serverSideTools = forcedFunctionChoice ? [] : (opts.serverSideTools ?? []);
+  // 服务端工具的声明**只由 model 决定**,不受任何单轮请求态(含 tool_choice)影响 ——
+  // 这是 BridgeProviderConfig.serverSideTools 的契约,也是 prompt 前缀稳定性的前提:
+  // 若某一轮因 tool_choice 把它摘掉、下一轮又装回来,同一会话的 tools 前缀就会来回变化,
+  // 缓存全程失效(见 docs/dev-rules/maker-core-and-agent-behavior.md §3.1)。
+  // 恒定排在 function tools 之后,位置固定。
+  const serverSideTools = opts.serverSideTools ?? [];
   const tools: ResponsesTool[] = [...functionTools, ...serverSideTools];
+  const toolChoice = resolveToolChoice(req.tool_choice, functionTools, serverSideTools.length > 0);
 
   const out: ResponsesRequest = {
     model: opts.model,

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -6,6 +6,7 @@
  *   messages[]                → input[](按 block 顺序拆成 message / function_call /
  *                               function_call_output / reasoning 四种 item)
  *   tools[].input_schema      → function tools[].parameters
+ *   (provider 声明)            → 追加在 function tools 之后的上游服务端工具(如 xAI x_search)
  *   tool_choice               → tool_choice
  *   thinking.budget_tokens    → reasoning.effort
  *   max_tokens                → max_output_tokens
@@ -26,6 +27,7 @@ import type {
   ResponsesContentPart,
   ResponsesInputItem,
   ResponsesRequest,
+  ResponsesServerTool,
   ResponsesTool,
   ResponsesToolChoice,
 } from './types.js';
@@ -270,6 +272,12 @@ export interface TranslateRequestOptions {
    * 省略 = 不回放任何带 signature 的 reasoning(保守:无法证明出处即不回放)。
    */
   providerPrefix?: string;
+  /**
+   * 上游自带的服务端工具声明(如 xAI 的 `{ type: 'x_search' }`),由 provider 配置按 model 决定。
+   * 恒定追加在 function tools **之后**,顺序稳定,保证请求前缀在会话内逐轮一致。
+   * 请求本身没有任何 function tool 时也会单独下发(纯服务端工具轮)。
+   */
+  serverSideTools?: ResponsesServerTool[];
 }
 
 /**
@@ -290,13 +298,15 @@ export function translateRequest(
     input.push(...messageToInputItems(msg, reasoningReplay));
   }
 
-  const tools: ResponsesTool[] | undefined = req.tools?.map((t) => ({
+  const functionTools: ResponsesTool[] = (req.tools ?? []).map((t) => ({
     type: 'function',
     name: t.name,
     description: t.description,
     strict: false,
     parameters: t.input_schema ?? { type: 'object', properties: {} },
   }));
+  // 服务端工具恒定排在 function tools 之后:位置固定 → 请求前缀逐轮稳定(缓存友好)。
+  const tools: ResponsesTool[] = [...functionTools, ...(opts.serverSideTools ?? [])];
 
   const out: ResponsesRequest = {
     model: opts.model,
@@ -316,8 +326,10 @@ export function translateRequest(
 
   const instructions = systemToInstructions(req.system);
   if (instructions) out.instructions = instructions;
-  if (tools && tools.length > 0) {
-    out.tools = tools;
+  if (tools.length > 0) out.tools = tools;
+  // parallel_tool_calls / tool_choice 只描述**本地 function tool** 的调用策略:纯服务端工具轮
+  // (客户端没带任何 function tool)不发这两个字段,避免 tool_choice 指向不存在的 function。
+  if (functionTools.length > 0) {
     out.parallel_tool_calls = true;
     const tc = toolChoiceToResponses(req.tool_choice);
     if (tc) out.tool_choice = tc;

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -362,11 +362,16 @@ export function translateRequest(
   const instructions = systemToInstructions(req.system);
   if (instructions) out.instructions = instructions;
   if (tools.length > 0) out.tools = tools;
-  // parallel_tool_calls / tool_choice 只描述**本地 function tool** 的调用策略:纯服务端工具轮
-  // (客户端没带任何 function tool)不发这两个字段,避免 tool_choice 指向不存在的 function。
-  if (functionTools.length > 0) {
-    out.parallel_tool_calls = true;
-    if (toolChoice) out.tool_choice = toolChoice;
+  // parallel_tool_calls 只描述**本地 function tool** 的并行策略,纯服务端工具轮不发。
+  if (functionTools.length > 0) out.parallel_tool_calls = true;
+  // tool_choice:
+  //   - 有 function tool → 原样下发(含 required / 指名 function / auto / none);
+  //   - 没有 function tool → 只下发 `none`。`none` 是调用方**显式禁止用工具**,而我们仍会
+  //     声明服务端工具(声明只由 model 决定,见上),不把 none 传下去就等于放开 x_search、
+  //     把调用方的禁令反过来了。其余档在无 function tool 时不发:指名 function 会指向不存在
+  //     的工具;required 则会把「必须用工具」落到服务端工具上,等于替调用方决定去搜一次。
+  if (toolChoice && (functionTools.length > 0 || toolChoice === 'none')) {
+    out.tool_choice = toolChoice;
   }
   if (opts.maxOutputTokensSupported && typeof req.max_tokens === 'number' && req.max_tokens > 0) {
     out.max_output_tokens = req.max_tokens;

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -305,8 +305,20 @@ export function translateRequest(
     strict: false,
     parameters: t.input_schema ?? { type: 'object', properties: {} },
   }));
+  const toolChoice = toolChoiceToResponses(req.tool_choice);
+  // Anthropic `tool_choice:{type:'any'}` → Responses `required`,语义是「必须调用所提供工具
+  // 之一」。而 Responses 的 required 作用于**整个** tools 数组:附加服务端工具后,上游可以
+  // 靠跑一次 x_search 就满足 required,调用方强制要的那次本地 function call 永远不发生
+  // ——用 any 逼出客户端工具调用的流程会被静默打断。这种强制轮宁可不带服务端工具:
+  // 少一次搜索只是能力打折,丢掉被强制的工具调用是行为错误。
+  //
+  // 只对 required 生效:`{type:'tool',name}` 指名到具体 function、`auto` / `none` 都不会被
+  // 服务端工具顶替。functionTools 为空时 required 无意义(下面也不会下发 tool_choice),
+  // 不必为它牺牲搜索能力。
+  const forcedFunctionChoice = functionTools.length > 0 && toolChoice === 'required';
   // 服务端工具恒定排在 function tools 之后:位置固定 → 请求前缀逐轮稳定(缓存友好)。
-  const tools: ResponsesTool[] = [...functionTools, ...(opts.serverSideTools ?? [])];
+  const serverSideTools = forcedFunctionChoice ? [] : (opts.serverSideTools ?? []);
+  const tools: ResponsesTool[] = [...functionTools, ...serverSideTools];
 
   const out: ResponsesRequest = {
     model: opts.model,
@@ -331,8 +343,7 @@ export function translateRequest(
   // (客户端没带任何 function tool)不发这两个字段,避免 tool_choice 指向不存在的 function。
   if (functionTools.length > 0) {
     out.parallel_tool_calls = true;
-    const tc = toolChoiceToResponses(req.tool_choice);
-    if (tc) out.tool_choice = tc;
+    if (toolChoice) out.tool_choice = toolChoice;
   }
   if (opts.maxOutputTokensSupported && typeof req.max_tokens === 'number' && req.max_tokens > 0) {
     out.max_output_tokens = req.max_tokens;

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -106,21 +106,11 @@ export class SseTranslator {
     this.signaturePrefix = slash > 0 ? model.slice(0, slash + 1) : '';
   }
 
-  /** deferred 事件队列(见 DEFERRABLE_TYPES 注释):仅在 tool_use 块打开期间入队。 */
-  private deferred: unknown[] = [];
-
   /**
-   * 是否已经有**更靠后**的 output item 落过块(blockIndex 被分配即视为已发射)。
-   *
-   * 用于判断此刻再为 `outputIndex` 发块会不会造成「块顺序与上游 output_index 顺序相反」。
-   * blocks 里每个 item 的 blockIndex 初始为 -1,只有真正 emit content_block_start 时才赋值。
+   * deferred 事件队列(见 DEFERRABLE_TYPES 注释):**任一不可打断块**(tool_use / thinking)
+   * 打开期间,其它 item 的 DEFERRABLE_TYPES 事件都会入队 —— 不只是 tool_use。
    */
-  private hasEmittedLaterItem(outputIndex: number): boolean {
-    for (const [idx, st] of this.blocks) {
-      if (idx > outputIndex && st.blockIndex >= 0) return true;
-    }
-    return false;
-  }
+  private deferred: unknown[] = [];
 
   /** 当前打开的块是否不可打断(tool_use / thinking,见 DEFERRABLE_TYPES 注释)。 */
   private openBlockIsUninterruptible(): boolean {
@@ -297,13 +287,6 @@ export class SseTranslator {
     if (itemType === 'reasoning') {
       // 先登记,不开块 —— 有可见 summary 时在首个 summary delta 处开 thinking 块;
       // 无可见 summary 则在 output_item.done 处作为 redacted_thinking 整块吐。
-      //
-      // 刻意**不**在这里把本 item 占为「当前打开项」。曾经试过(为了让零 summary delta 的
-      // 加密推理块排在正文之前),但 `response.output_text.delta` 属于 DEFERRABLE_TYPES:
-      // 一旦这里占位,「reasoning added → 正文全部吐完 → reasoning done」这种上游序列会把
-      // **整个可见答案**缓冲到 reasoning done 才一次性放出 —— 长搜索轮看起来完全卡死。
-      // 用户可见的流式输出优先于加密推理块的相对位置:该块本就没有明文、renderer 也不展示
-      // (见 makerChatStore 的 redacted 过滤),排在正文之后不产生任何可见后果。
       this.blocks.set(outputIndex, { blockIndex: -1, kind: 'thinking', opened: false });
     } else if (itemType === 'message') {
       // 先登记,不开块 —— 首个非空 output_text.delta 时才开 text 块。曾经在
@@ -459,7 +442,7 @@ export class SseTranslator {
         out.push({ event: 'content_block_stop', data: { type: 'content_block_stop', index: st.blockIndex } });
         st.opened = false;
         if (this.openOutputIndex === outputIndex) this.openOutputIndex = null;
-      } else if (encrypted && !this.hasEmittedLaterItem(outputIndex)) {
+      } else if (encrypted) {
         // 无可见 summary(含全程只发空白 summary delta),或曾在流收尾强制排空时被
         // 关掉(签名没地方挂,仅 stream-end 路径,正常流中 thinking 块不可打断):
         // 作为 redacted_thinking 整块一次性吐(data=encrypted_content),reasoning
@@ -475,13 +458,6 @@ export class SseTranslator {
         // 块已即时开+关,标记为已闭合,避免结尾 closeAllOpenBlocks 重复关。
         st.opened = false;
       }
-      // encrypted 存在、但更靠后的 item 已经先落块(典型:reasoning added → 正文吐完 →
-      // reasoning done)→ **丢掉**这条加密推理,不发一个注定放错位置的块。
-      // 理由:该块唯一用途是回放(renderer 不展示它),而 translate-request 按 block 顺序
-      // 还原 input[],此处再吐会让回放变成「message 在 reasoning 之前」,偏离上游
-      // output_index 的原始顺序;Responses 的 reasoning 回放对顺序敏感,下一轮可能连带
-      // 整个请求被拒。丢掉只损失这一条推理状态的连续性,不会让后续请求失败 —— 相比
-      // 「放错位置」这是严格更安全的降级。正常序列(reasoning 先 done)不受影响。
       // 既无 summary 又无 encrypted_content:什么都不吐(空 reasoning)。
       // 释放"占位未开块"的 in-flight 标记(空白 summary delta 只占位不开块,
       // 见 onReasoningSummaryDelta):不释放会让 deferred 队列等不到解锁事件。

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -285,15 +285,12 @@ export class SseTranslator {
       // 先登记,不开块 —— 有可见 summary 时在首个 summary delta 处开 thinking 块;
       // 无可见 summary 则在 output_item.done 处作为 redacted_thinking 整块吐。
       //
-      // 登记的同时就把本 item 占为「当前打开项」(opened=false 的占位态):不可打断语义必须
-      // 从 item 出生就生效,不能等首个 summary delta。上游**一条 summary delta 都不发**、
-      // 只在 done 时给 encrypted_content 时(实测 xai/grok 开服务端工具后的常见形态),
-      // 等 delta 才占位就等不到:后续 message item 会抢先吐完正文,本 item 的 done 再兜底成
-      // redacted_thinking,块顺序变成「正文 → 推理」——UI 上加密推理排到答案后面,
-      // 且 translate-request 回放 reasoning 的顺序也跟着错位(Responses 回放顺序敏感)。
-      // 占位由 item.done 释放;上游始终不发 done 时,流收尾的强制排空兜底(见 drainDeferred)。
-      this.closeOpenBlockForOtherItem(outputIndex, out);
-      this.openOutputIndex = outputIndex;
+      // 刻意**不**在这里把本 item 占为「当前打开项」。曾经试过(为了让零 summary delta 的
+      // 加密推理块排在正文之前),但 `response.output_text.delta` 属于 DEFERRABLE_TYPES:
+      // 一旦这里占位,「reasoning added → 正文全部吐完 → reasoning done」这种上游序列会把
+      // **整个可见答案**缓冲到 reasoning done 才一次性放出 —— 长搜索轮看起来完全卡死。
+      // 用户可见的流式输出优先于加密推理块的相对位置:该块本就没有明文、renderer 也不展示
+      // (见 makerChatStore 的 redacted 过滤),排在正文之后不产生任何可见后果。
       this.blocks.set(outputIndex, { blockIndex: -1, kind: 'thinking', opened: false });
     } else if (itemType === 'message') {
       // 先登记,不开块 —— 首个非空 output_text.delta 时才开 text 块。曾经在

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -109,6 +109,19 @@ export class SseTranslator {
   /** deferred 事件队列(见 DEFERRABLE_TYPES 注释):仅在 tool_use 块打开期间入队。 */
   private deferred: unknown[] = [];
 
+  /**
+   * 是否已经有**更靠后**的 output item 落过块(blockIndex 被分配即视为已发射)。
+   *
+   * 用于判断此刻再为 `outputIndex` 发块会不会造成「块顺序与上游 output_index 顺序相反」。
+   * blocks 里每个 item 的 blockIndex 初始为 -1,只有真正 emit content_block_start 时才赋值。
+   */
+  private hasEmittedLaterItem(outputIndex: number): boolean {
+    for (const [idx, st] of this.blocks) {
+      if (idx > outputIndex && st.blockIndex >= 0) return true;
+    }
+    return false;
+  }
+
   /** 当前打开的块是否不可打断(tool_use / thinking,见 DEFERRABLE_TYPES 注释)。 */
   private openBlockIsUninterruptible(): boolean {
     if (this.openOutputIndex === null) return false;
@@ -446,7 +459,7 @@ export class SseTranslator {
         out.push({ event: 'content_block_stop', data: { type: 'content_block_stop', index: st.blockIndex } });
         st.opened = false;
         if (this.openOutputIndex === outputIndex) this.openOutputIndex = null;
-      } else if (encrypted) {
+      } else if (encrypted && !this.hasEmittedLaterItem(outputIndex)) {
         // 无可见 summary(含全程只发空白 summary delta),或曾在流收尾强制排空时被
         // 关掉(签名没地方挂,仅 stream-end 路径,正常流中 thinking 块不可打断):
         // 作为 redacted_thinking 整块一次性吐(data=encrypted_content),reasoning
@@ -462,6 +475,13 @@ export class SseTranslator {
         // 块已即时开+关,标记为已闭合,避免结尾 closeAllOpenBlocks 重复关。
         st.opened = false;
       }
+      // encrypted 存在、但更靠后的 item 已经先落块(典型:reasoning added → 正文吐完 →
+      // reasoning done)→ **丢掉**这条加密推理,不发一个注定放错位置的块。
+      // 理由:该块唯一用途是回放(renderer 不展示它),而 translate-request 按 block 顺序
+      // 还原 input[],此处再吐会让回放变成「message 在 reasoning 之前」,偏离上游
+      // output_index 的原始顺序;Responses 的 reasoning 回放对顺序敏感,下一轮可能连带
+      // 整个请求被拒。丢掉只损失这一条推理状态的连续性,不会让后续请求失败 —— 相比
+      // 「放错位置」这是严格更安全的降级。正常序列(reasoning 先 done)不受影响。
       // 既无 summary 又无 encrypted_content:什么都不吐(空 reasoning)。
       // 释放"占位未开块"的 in-flight 标记(空白 summary delta 只占位不开块,
       // 见 onReasoningSummaryDelta):不释放会让 deferred 队列等不到解锁事件。

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -284,6 +284,16 @@ export class SseTranslator {
     if (itemType === 'reasoning') {
       // 先登记,不开块 —— 有可见 summary 时在首个 summary delta 处开 thinking 块;
       // 无可见 summary 则在 output_item.done 处作为 redacted_thinking 整块吐。
+      //
+      // 登记的同时就把本 item 占为「当前打开项」(opened=false 的占位态):不可打断语义必须
+      // 从 item 出生就生效,不能等首个 summary delta。上游**一条 summary delta 都不发**、
+      // 只在 done 时给 encrypted_content 时(实测 xai/grok 开服务端工具后的常见形态),
+      // 等 delta 才占位就等不到:后续 message item 会抢先吐完正文,本 item 的 done 再兜底成
+      // redacted_thinking,块顺序变成「正文 → 推理」——UI 上加密推理排到答案后面,
+      // 且 translate-request 回放 reasoning 的顺序也跟着错位(Responses 回放顺序敏感)。
+      // 占位由 item.done 释放;上游始终不发 done 时,流收尾的强制排空兜底(见 drainDeferred)。
+      this.closeOpenBlockForOtherItem(outputIndex, out);
+      this.openOutputIndex = outputIndex;
       this.blocks.set(outputIndex, { blockIndex: -1, kind: 'thinking', opened: false });
     } else if (itemType === 'message') {
       // 先登记,不开块 —— 首个非空 output_text.delta 时才开 text 块。曾经在

--- a/packages/anthropic-responses-bridge/src/types.ts
+++ b/packages/anthropic-responses-bridge/src/types.ts
@@ -94,13 +94,25 @@ export type ResponsesContentPart =
   | { type: 'output_text'; text: string }
   | { type: 'input_image'; image_url: string };
 
-export interface ResponsesTool {
+export interface ResponsesFunctionTool {
   type: 'function';
   name: string;
   description?: string;
   strict?: boolean;
   parameters: Record<string, unknown>;
 }
+
+/**
+ * 上游自带的**服务端工具**声明(不是本地 function tool):模型在上游侧自行执行,
+ * 客户端既不收工具调用请求、也不回 tool_result。当前用于 xAI 的 `x_search`(原生
+ * 搜 X)/ `web_search`。形状按各上游 schema 透传,只约束必须有 `type`。
+ */
+export interface ResponsesServerTool {
+  type: string;
+  [k: string]: unknown;
+}
+
+export type ResponsesTool = ResponsesFunctionTool | ResponsesServerTool;
 
 export type ResponsesToolChoice = 'auto' | 'none' | 'required' | { type: 'function'; name: string };
 
@@ -186,6 +198,13 @@ export interface BridgeProviderConfig {
    * 对 reasoningEffort 报 400)bridge 将**完全不发** reasoning 字段。省略 = 全部支持。
    */
   supportsReasoning?: (model: string) => boolean;
+  /**
+   * 该(去前缀后的)model 恒定附加的上游**服务端工具**声明(如 xAI 的 `{ type: 'x_search' }`)。
+   * 返回值按 model 决定、**同一会话内必须恒定**——服务端工具同样进请求前缀,会话中途增删会
+   * 破坏 prompt 前缀稳定性(见 docs/dev-rules/maker-core-and-agent-behavior.md §3.1)。
+   * 省略 / 返回空数组 = 不附加。附加位置恒为 function tools 之后,顺序稳定。
+   */
+  serverSideTools?: (model: string) => ResponsesServerTool[];
   /**
    * Fast 模式(host 经 prefs.fast 闭包传入)映射到的 Responses `service_tier` 值。codex 后端为
    * 'priority'(models_cache 的 service_tiers 声明,UI 名 "Fast")。省略 = 该 provider 不支持


### PR DESCRIPTION
## 这次改了什么

### 摘要

让「模型切到 Grok」真的等于「能搜 X」。

Grok 本身没有实时 X 数据权限——能不能搜 X，完全取决于请求 `tools[]` 里有没有 xAI 的服务端工具 `x_search`。此前 Cindy 只是**放行**这个工具（`XAI_SUPPORTED_TOOL_TYPES` 里有它），但从不主动声明，所以用户选了 Grok 也拿不到 X 的实时视野，只会得到一个没有 X 视野的普通模型。

本 PR 让 xAI 会话恒定声明 `x_search`，并顺带修掉打开它之后暴露出来的两个**既有**显示问题。

`x_search` 是 xAI 在上游执行的服务端工具：模型自己发起关键词 / 语义 / 用户 / thread 检索，客户端既收不到 tool call、也不需要回 tool_result，结果直接融进回答与 citations。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户反馈「Grok 搜不了 X」）
- 本 PR 包含：
  1. **两条到 `api.x.ai` 的链路各自注入 `x_search`**，门控收敛在新增的 `xai-server-side-tools.ts` 一处，避免两边漂移：
     - Codex agent → `codex-proxy-host.ts` 的 xAI compat transform，排在 `sanitizeXaiTools` **之后**追加（先按 xAI schema 清掉 Codex 专属工具，再补，保证注入项不被同轮裁剪改形）
     - Claude Code → `anthropic-responses-bridge` 新增 provider 级 `serverSideTools` 声明位，`xai` provider 按 model 决定
  2. **修加密推理块排到正文之后**（详见下）
  3. **加密推理不再展示**（详见下）
- 明确不包含：
  - 交错模型「正文 → 工作块 → 正文」的渲染合并。经对照实验确认这是既有行为、且与本 PR 无关（见「手工验证」），属独立产品决策，不混进本 PR
  - 未注入 `web_search`（Codex 侧本来就会自带；只做用户要的 X 原生检索）
  - 未加设置开关（见下「为什么默认开启」）
- 用户可见变化：
  - xAI Grok 会话具备真实的 X 检索能力，回答带可点开的真实推文链接与 citations
  - 「无法显示的思考过程」卡片不再出现（含历史会话重开）
  - 有明文的思考仍正常显示，且回到正文**之前**
- 是否存在 breaking change：无

#### 几个刻意的设计决定

**服务端工具位置恒定**：恒定排在 function tools **之后**，且只由 model 决定、不掺任何会话态或每轮变化的内容。同一会话逐轮请求的 tools 列表完全一致，不破坏请求前缀稳定性（`docs/dev-rules/maker-core-and-agent-behavior.md` §3.1「会话中途不得增删/重排 tool」）。

**纯服务端工具轮不发 `tool_choice` / `parallel_tool_calls`**：这两个字段只描述本地 function tool 的调用策略；请求本身没带任何 function tool 时发它们会指向不存在的 function。没有 `serverSideTools` 时 tools 相关行为与改造前逐字节一致（有测试锁定）。

**门控用黑名单而非白名单**：只排除 `grok-code*` / `grok-build*`（编码特化模型，无 agentic 搜索工具面，与既有 `supportsReasoning` 门控同口径），**未知的新 Grok 通用模型默认当作能搜 X**。白名单意味着 xAI 每发一个新模型，用户都要等本地目录更新才恢复搜 X——而搜 X 正是选 Grok 的主要理由，静默丢能力比偶发上游报错更难被发现。取舍已写进模块注释，并同步更新了 `grok-future` 那条既有用例的断言。

**为什么默认开启、不加开关**：搜 X 是选 Grok 的主要理由，默认关等于默认残废；且开关若能在会话中途切换，会破坏上面的前缀稳定性不变量。

#### 关于加密推理块的排序：本 PR **不改** translate-sse（已回退到基线）

用户最初看到的现象是「无法显示的思考过程」出现在答案之后。根因分两层，本 PR 只解决第二层：

- 排序层：Grok 开服务端工具后，reasoning item 常常一条 `summary delta` 都不发、只在 `output_item.done` 时给回 `encrypted_content`，且可能到整轮末尾才 done，于是兜底的 `redacted_thinking` 落在正文之后。
- 展示层：该块没有明文，卡片只能显示「无法显示的思考过程」。

**修复展示层（下方修复 2）就已经让用户可见问题彻底消失**，因此排序层最终不动。

过程如实记录：我在 `translate-sse` 上试过两版，都被 review 发现引入新回归，均已撤回 ——

1. 在 `output_item.added` 处给 reasoning 占位（`#discussion_r3662011853`）：`response.output_text.delta` 属于 `DEFERRABLE_TYPES`，占位会把**整个可见答案**缓冲到 reasoning done 才放出，长搜索轮全程卡死。
2. 丢弃「注定放错位置」的加密推理（`#discussion_r3662287822`）：该 guard 对**任何**更靠后的块生效，包括 `function_call`，于是 tool call 前的推理状态也被丢，违反 stateless 回放契约。

退一步看，本 PR 原本不需要动这个文件：排序层那点偏差（零 delta 交错时回放次序偏离上游 `output_index`）是**本 PR 之前就存在**的行为，与 `x_search` 注入无关。要正确修它，先得回答一个目前没有证据的问题：xAI 对乱序 reasoning 回放的真实反应是**拒收还是忽略**——这决定了该选「缓冲非文本 item 保序」「丢弃」还是「照发」。在没有实测前继续边改边试，只会每次换一个新的失败模式。

**所以本 PR 在 `translate-sse` 上交付与基线一致的代码（仅一处注释准确性修正），零新增风险；排序层作为独立既有问题另开跟进，先做上游行为实测。**

#### 修复 2：加密推理不再展示

`apps/desktop/src/renderer/lib/makerChatStore.ts`

`redacted_thinking` 块没有任何明文可读，卡片只能显示「无法显示的思考过程」，对用户是纯噪音；上游开服务端工具后一轮能产出十几条，会把真实产出淹掉。

实时（`handleStreamEvent` 的 `stage === 'redacted'`）与历史（`mapServerMessages`）两条入口一起过滤，重开会话也不会冒出来。过滤谓词抽成 `isHiddenThinkingRow()` 作单一来源。

**配套修复历史翻页（Codex P1，`#discussion_r3662011855`）**：整页都被过滤时，映射结果为空，而 `MessageStream` 在 `visibleRenderItems.length === 0` 时不触发自动翻页 → DB 里有几千条消息却渲染 0 项，更老的消息再也拉不回来（典型触发：搜索密集、在产出可见正文前就失败的会话，最新 50 行全是加密推理）。把既有的初始页 backfill 条件从「全是 `tool_result`」推广为「全是无可见锚点的行」（`isNonAnchorHistoryRow`），一并覆盖了 omitted 占位行这一同源既有隐患。

另外 redacted 分支虽不产生消息，但仍按 `handleStreamEvent` 的不变量刷新 `lastAgentMeta`（Copilot，`#discussion_r3661910834`），不吞掉事件携带的 `model` / `parentUuid`。

**数据不受影响**：main 侧（`onThinkingEvent`）照旧落库，`encrypted_content` 的回放走 agent 侧 transcript、不依赖渲染列表。这纯粹是显示层收敛，要恢复展示只需删掉那两处判断（注释已写明）。

### UI 变化

- 引用的设计规范：不涉及：本次 UI 侧改动只是**移除**两类卡片的渲染（加密推理块不再进渲染列表），没有新增或修改任何界面、组件、布局、样式、动效或 UI 文案，因此不引入新的视觉决策，也不涉及 Light / Dark 双模式适配（被移除的元素在两种模式下都同样不再出现）。已按规则通读 `docs/design-rules/DESIGN.md`，确认无适用于「移除渲染」的章节约束。

## 怎么验证的

### 自动验证

最新 head（`d31bc9aa`，含四轮 review 修复）：

```text
pnpm test:unit（经 git skill 的 run-unit-gate.sh）
结果：EXIT=0，全部 workspace PASS

（前一轮 head 2de3002c 上该门禁曾 EXIT=1，唯一失败项是
 src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts，与本 PR 改动无关
 且已判定为并行下的 flake：该文件单独运行 21 passed、apps/desktop 全量重跑
 --maxWorkers=1 为 EXIT=0（1307 files / 14372 passed）。本轮同一门禁直接 EXIT=0。）

pnpm --filter desktop run typecheck
结果：EXIT=0

pnpm --filter @cindy/anthropic-responses-bridge run typecheck
结果：EXIT=0

pnpm --filter @cindy/anthropic-responses-bridge exec vitest run
结果：56 passed | 3 skipped（skip 为需要真实凭证的 live-bridge 用例）

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
结果：81 passed

pnpm check:dco
结果：DCO check passed: 3 commits signed off
```

新增 / 更新的用例：

- bridge `translate-request`：服务端工具追加位置恒在 function tools 之后；纯服务端工具轮不发 `tool_choice` / `parallel_tool_calls`；不传 / 传空数组时行为与改造前一致（防回归）
- bridge `handler`：`serverSideTools` 拿到的是剥掉前缀与 `[1m]` 后缀的真实 model id，且编码模型返回空数组时完全不发 `tools`
- bridge `translate-sse`：无行为改动（已回退到基线），既有 24 条用例全部通过
- desktop `codexProxyHost`：请求原本无 `tools` 时也补齐；上游已声明 `x_search` 时不重复注入也不覆盖其参数；`grok-code-fast` / `grok-build-preview` 不注入
- bridge `translate-request`（review 追加）：`any` + 唯一 function tool → 收窄成指名该 function 且 `x_search` 仍在末尾；`any` + 多个 function tool → 保留 `required` 且声明不动；无服务端工具时不做多余收窄
- desktop `codexProxyHost`（review 追加）：`required` + 唯一 function tool 收窄、多个时保留、`auto` 不被改写
- desktop `emptyThinkingPlaceholder`（review 追加）：`isNonAnchorHistoryRow` 谓词（redacted / omitted 算无锚点，有明文或有时长算锚点，`tool_result` 仍算无锚点）；redacted 事件带 `agentMeta` 时仍刷新 `lastAgentMeta`
- bridge `translate-request`（review 追加）：无 function tool + `none` → 仍下发 `none` 且不发 `parallel_tool_calls`；有 function tool + `none` → 照常下发；无 function tool + 指名 function → 不下发
- 更新既有断言 3 条（均为本 PR 刻意反转的契约）：xAI 归一化用例的 tools 期望值、未知 xAI 模型用例、以及 2 条原本要求「保留 redacted thinking」的断言

### 手工验证

平台 macOS（darwin-arm64），region `cn`，账号为本机已登录 SuperGrok 订阅。从功能 worktree 直接运行：

```text
pnpm restart:desktop:remote -- --preserve-running
pnpm desktop:whoami   → Desktop source: MATCH（root/commit/ready 全部匹配，EXIT=0）
```

模型 `xai/grok-4.5`，提问「看X上有什么新闻」：

- **`x_search` 确认生效**：回答给出 7 月 27–28 日的真实 X 时间线内容与 5 条 citations（真实账号、可点开），非模型编造
- 「无法显示的思考过程」卡片已不再出现
- 有明文的思考正常显示

**额外做了一次对照实验**（用于排除本 PR 引入回归）：用户观察到交错模型会出现「正文 → 工作块 → 正文」的形态。构造 Grok 交错事件流（正文流到一半插入新 reasoning item），分别用本 PR 改后与临时还原成改前的 `translate-sse` 跑同一组事件：

```text
改后：块顺序 = ["text","thinking","text"]
改前：块顺序 = ["text","thinking","text"]   ← 完全一致
```

确认该形态是交错模型的既有行为、与本 PR 无关（探针已删除，改动已还原，测试重跑全绿）。它反映的是模型真实时序（先写出阶段性答案，再发起下一轮检索），是否合并渲染属独立产品决策，本 PR 不处理。

### 未执行的验证

- **未验证服务端工具是否额外消耗 SuperGrok 订阅额度**：xAI 未在文档中说明服务端工具的计费方式，本机也无法从订阅侧观测到分项用量。风险为额度消耗快于预期，不影响功能正确性。
- **未验证 Codex agent 路径的实机搜 X**：手工验证走的是 Claude Code → bridge 这条链路；Codex 侧仅有单元测试覆盖（注入形态、门控、去重）。两条链路共用同一份门控模块，注入形态由测试锁定。
- **UI 未做 Light / Dark 双模式目检**：本次 UI 改动只移除渲染、不引入任何颜色或样式，两种模式下表现同为「该卡片不出现」，无可目检的视觉差异。
- 未跑 `pnpm test:all` / `pnpm build`：改动集中在 Responses 请求组装与渲染过滤，无原生依赖、无构建链变动，根 `pnpm test:unit` 与两个受影响 package 的 typecheck 已覆盖；最终以 CI 为准。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

未命中 system prompt：本 PR 不改动任何进入模型 system 段的文本（`x_search` 是 `tools[]` 字段，不是提示词）。

### 影响与回滚

- 影响范围：
  - **仅限 xAI（SuperGrok）会话**。其它 provider 的请求体逐字节不变：Codex 侧注入在 `inferredProviderId !== 'xai'` 即 return 的分支内；bridge 侧 `serverSideTools` 未声明时（如 `chatgpt/` provider）走原路径，且有测试锁定「不传 / 传空数组时 tools 行为不变」。
  - `translate-sse` 已回退到基线（仅一处注释修正），因此对所有经 bridge 的 Responses 供应商（含 ChatGPT 订阅）**行为逐字节不变**。24 条 SSE 用例（含 ChatGPT 形态）全部通过。
  - 加密推理过滤影响所有模型的 UI，但只影响**没有明文可读**的块；有明文的思考不受影响。历史 backfill 的推广同样影响所有模型，但只在「初始页全是无锚点行」这一原本会渲染 0 项的场景下多翻几页（上限 10 页）。
  - `tool_choice` 收窄只在「解析结果为 `required` **且**声明了服务端工具」时生效：唯一 function tool 时指名它，多个时原样保留 `required`。没有服务端工具的供应商（如 `chatgpt/`）完全不受影响，有测试锁定。
  - **协议兼容**：`x_search` 是 xAI 私有的服务端工具类型。若某个 Grok 模型不支持它，上游会返 400。已用黑名单排除已知不支持的编码系模型；未知新模型按「默认可搜」处理，属刻意取舍（见上）。
- 回滚 / 降级方式：
  - 整体回滚：revert 本 commit 即可，无数据迁移、无持久化格式变更。
  - 分项降级（无需回滚全部）：
    - 停止注入 `x_search`：把 `xaiServerSideTools()` 改为恒返空数组，两条链路同时失效
    - 恢复展示加密推理：删掉 `makerChatStore` 那两处判断（注释已标注位置）
    - 撤回历史翻页修复：把 backfill 循环条件从 `isNonAnchorHistoryRow` 改回 `m.role === 'tool_result'`
  - 加密推理的 DB 行始终保留，恢复展示不丢历史数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动理由与取舍写在代码注释里；未新增 docs 规则文件——`docs/dev-rules/` 现无 xAI/Grok 专项章节，本 PR 也未改变既有规则）
- [x] 已确认测试结果或说明未执行原因




