### PR TITLE
fix(desktop): IM 绑定只认工作目录映射，砍掉映射外的跟随授权

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -1,7 +1,7 @@
 /**
  * hook-control bindings 单测: os.tmpdir 临时文件(规则 23: 测试路径一律走系统
- * 临时目录, 收尾清理)。重点是工作目录快照的写入与老文件兼容 —— dispatcher 靠
- * 它区分「会话被用户移动」与「工作目录映射被改」。
+ * 临时目录, 收尾清理)。重点是「只存 externalKey -> sessionId」这条不变量 ——
+ * 绑定里不留任何授权状态, 能否复用每次由 dispatcher 现场按工作目录映射判定。
  */
 
 import fs from 'node:fs';
@@ -26,87 +26,62 @@ afterEach(() => {
 });
 
 const makeStore = () => createHookBindingStore({ filePath: filePath(), log: noopLog });
+const readFile = (): Record<string, Record<string, Record<string, unknown>>> =>
+  JSON.parse(fs.readFileSync(filePath(), 'utf-8')) as Record<
+    string,
+    Record<string, Record<string, unknown>>
+  >;
 
 describe('hook binding store', () => {
-  it('落绑定时记下工作目录快照与授权来源, get / getEntry 都能读回', () => {
+  it('落绑定后 get 读得回, 未知 key 为 null', () => {
     const store = makeStore();
-    store.set('conn-1', 'slack:C1:1.1', 'sess-1', '/repos/demo', 'workspace');
+    store.set('conn-1', 'slack:C1:1.1', 'sess-1');
 
     expect(store.get('conn-1', 'slack:C1:1.1')).toBe('sess-1');
-    expect(store.getEntry('conn-1', 'slack:C1:1.1')).toEqual({
-      sessionId: 'sess-1',
-      workingDir: '/repos/demo',
-      authority: 'workspace',
-    });
-    expect(store.getEntry('conn-1', 'missing')).toBeNull();
+    expect(store.get('conn-1', 'missing')).toBeNull();
+    expect(store.get('conn-2', 'slack:C1:1.1')).toBeNull();
   });
 
-  it('local-move 授权跨实例持久化(重启后跟随不能退回撤权)', () => {
-    makeStore().set('conn-1', 'k', 'sess-1', '/repos/moved', 'local-move');
+  it('跨实例持久化(app 重启后同 key 仍指同一 session)', () => {
+    makeStore().set('conn-1', 'k', 'sess-1');
 
-    expect(makeStore().getEntry('conn-1', 'k')).toEqual({
-      sessionId: 'sess-1',
-      workingDir: '/repos/moved',
-      authority: 'local-move',
-    });
+    expect(makeStore().get('conn-1', 'k')).toBe('sess-1');
   });
 
-  it('未传目录 / 授权时不写这两个字段', () => {
+  it('行里只写 sessionId + updatedAt, 不写任何授权状态', () => {
     makeStore().set('conn-1', 'k', 'sess-2');
-    const row = JSON.parse(fs.readFileSync(filePath(), 'utf-8')) as Record<
-      string,
-      Record<string, Record<string, unknown>>
-    >;
 
-    expect(row['conn-1']['k']).not.toHaveProperty('workingDir');
-    expect(row['conn-1']['k']).not.toHaveProperty('authority');
-    expect(makeStore().getEntry('conn-1', 'k')).toEqual({
-      sessionId: 'sess-2',
-      workingDir: null,
-      authority: null,
-    });
+    expect(Object.keys(readFile()['conn-1']['k']).sort()).toEqual(['sessionId', 'updatedAt']);
   });
 
-  it('老文件(无 workingDir / authority)读成 null, 不当成"目录变过"或"已授权"', () => {
-    fs.writeFileSync(
-      filePath(),
-      JSON.stringify({ 'conn-1': { 'slack:C1:1.1': { sessionId: 'legacy', updatedAt: 1 } } }),
-      'utf-8',
-    );
-    const store = makeStore();
-
-    expect(store.get('conn-1', 'slack:C1:1.1')).toBe('legacy');
-    expect(store.getEntry('conn-1', 'slack:C1:1.1')).toEqual({
-      sessionId: 'legacy',
-      workingDir: null,
-      authority: null,
-    });
-  });
-
-  it('authority 是未知字面量时按"没有授权记录"读(fail closed)', () => {
+  it('早期版本残留的 workingDir / authority 读取时忽略, 下次写入清掉', () => {
     fs.writeFileSync(
       filePath(),
       JSON.stringify({
         'conn-1': {
           k: {
-            sessionId: 'sess-1',
+            sessionId: 'legacy',
             workingDir: '/repos/demo',
-            authority: 'anything',
+            authority: 'local-move',
             updatedAt: 1,
           },
         },
       }),
       'utf-8',
     );
+    const store = makeStore();
 
-    expect(makeStore().getEntry('conn-1', 'k')?.authority).toBeNull();
+    expect(store.get('conn-1', 'k')).toBe('legacy');
+    store.set('conn-1', 'k', 'legacy');
+    expect(readFile()['conn-1']['k']).not.toHaveProperty('workingDir');
+    expect(readFile()['conn-1']['k']).not.toHaveProperty('authority');
   });
 
-  it('remove 清掉整条绑定(含快照与授权)', () => {
+  it('remove 清掉整条绑定', () => {
     const store = makeStore();
-    store.set('conn-1', 'k', 'sess-1', '/repos/demo', 'local-move');
+    store.set('conn-1', 'k', 'sess-1');
     store.remove('conn-1', 'k');
 
-    expect(store.getEntry('conn-1', 'k')).toBeNull();
+    expect(store.get('conn-1', 'k')).toBeNull();
   });
 });

--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -92,6 +92,22 @@ describe('hook binding store', () => {
     expect(store.get('conn-2', 'k')).toBe('sess-2');
   });
 
+  it('externalKey 是 __proto__ 之类的键时不污染原型', () => {
+    const store = makeStore();
+    store.set('conn-1', '__proto__', 'sess-evil');
+
+    // 写进去的是自有键, 不是原型
+    expect(({} as Record<string, unknown>).sessionId).toBeUndefined();
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+    expect(store.get('conn-1', '__proto__')).toBe('sess-evil');
+    // 普通键不受影响, 且没被原型上的东西串味
+    expect(store.get('conn-1', 'constructor')).toBeNull();
+
+    store.set('conn-1', 'normal', 'sess-1');
+    expect(store.get('conn-1', 'normal')).toBe('sess-1');
+    expect(store.get('conn-1', '__proto__')).toBe('sess-evil');
+  });
+
   it('remove 清掉整条绑定', () => {
     const store = makeStore();
     store.set('conn-1', 'k', 'sess-1');

--- a/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/bindings.test.ts
@@ -77,6 +77,21 @@ describe('hook binding store', () => {
     expect(readFile()['conn-1']['k']).not.toHaveProperty('authority');
   });
 
+  it('命名空间被损坏成非对象时不卡死写入(换成空命名空间重建)', () => {
+    fs.writeFileSync(filePath(), JSON.stringify({ 'conn-1': 'oops', 'conn-2': [1, 2] }), 'utf-8');
+    const store = makeStore();
+
+    expect(store.get('conn-1', 'k')).toBeNull();
+    expect(store.get('conn-2', 'k')).toBeNull();
+    expect(() => store.remove('conn-1', 'k')).not.toThrow();
+
+    store.set('conn-1', 'k', 'sess-1');
+    expect(store.get('conn-1', 'k')).toBe('sess-1');
+    // 另一个坏命名空间不受影响, 直到它自己被写入时才重建
+    store.set('conn-2', 'k', 'sess-2');
+    expect(store.get('conn-2', 'k')).toBe('sess-2');
+  });
+
   it('remove 清掉整条绑定', () => {
     const store = makeStore();
     store.set('conn-1', 'k', 'sess-1');

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -642,6 +642,26 @@ describe('dispatcher 核心语义', () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
+  it('isDirAuthorized 按当前映射回答, 供 runner 校验实际执行目录', async () => {
+    const fr = fakeRunner();
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    const { d } = makeDispatcher({ runner: fr.runner, config });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const ask = fr.calls[0].isDirAuthorized!;
+    expect(ask(WS_DIR)).toBe(true);
+    expect(ask(path.join(WS_DIR, 'sub'))).toBe(true);
+    expect(ask(path.resolve('/repos/elsewhere'))).toBe(false);
+
+    // 映射被改后同一个回调立刻反映新状态(runner 是在 await 之后才问的)
+    config.workspaces = { xdmaker: path.resolve('/repos/elsewhere') };
+    expect(ask(WS_DIR)).toBe(false);
+    expect(ask(path.resolve('/repos/elsewhere'))).toBe(true);
+    fr.finish();
+  });
+
   it('inspect 期间目录被加回映射: 按当前映射判定, 不误杀这条绑定', async () => {
     const bindings = memoryBindings();
     const OUTSIDE = path.resolve('/repos/another-project');

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -18,6 +18,7 @@ import {
   type HookRunOutcome,
   type HookRunRequest,
   type HookSessionRunner,
+  type PrepareWorktreeResult,
 } from '../dispatcher';
 import type { HookBindingStore } from '../bindings';
 import { isPathWithin } from '../paths';
@@ -590,6 +591,34 @@ describe('dispatcher 核心语义', () => {
     expect(queued.errorMessage).toContain('已不在工作目录映射里');
     // 关键: 排队那条根本没进 runner
     expect(fr.calls).toHaveLength(1);
+  });
+
+  it('新建会话在定位与执行之间被撤权: 同样不执行(新建路径也走执行侧收口)', async () => {
+    const fr = fakeRunner();
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    let release!: (v: PrepareWorktreeResult) => void;
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      config,
+      prepareWorktree: () =>
+        new Promise<PrepareWorktreeResult>((resolve) => {
+          release = resolve;
+        }),
+    });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    // 定位还卡在 worktree 预建上, 此时用户把这个目录从映射里删掉
+    config.workspaces = {};
+    release({ ok: false, message: 'no worktree' });
+    await tick();
+
+    // 新建路径没有 expectedWorkingDir, 但 workingDir 就是要跑的目录, 照样拦下
+    expect(fr.calls).toHaveLength(0);
+    const end = c.last('turn.end')!.payload;
+    expect(end.status).toBe('error');
+    expect(end.errorMessage).toContain('已不在工作目录映射里');
   });
 
   it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -531,36 +531,6 @@ describe('dispatcher 核心语义', () => {
     await tick();
   });
 
-  it('复用与接管都带上已校验目录, 供 runner 在读权威 meta 后收口比对', async () => {
-    const bindings = memoryBindings();
-    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
-    const fr = fakeRunner({ sessions });
-    const { d } = makeDispatcher({ runner: fr.runner, bindings });
-    const c = collector();
-
-    d.handleDispatch('conn-1', dispatch(), c.send);
-    await tick();
-    const first = c.last('task.ack')!.payload.sessionId!;
-    // 新建路径不比对(还没有权威 meta 可言)
-    expect(fr.calls[0].expectedWorkingDir ?? null).toBeNull();
-    sessions[first] = { workingDir: WS_DIR, usable: true };
-    fr.finish();
-    await tick();
-
-    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
-    await tick();
-    expect(fr.calls[1]).toMatchObject({ sessionId: first, expectedWorkingDir: WS_DIR });
-    fr.finish();
-    await tick();
-
-    // 接管路径同理
-    sessions['taken'] = { workingDir: WS_DIR, usable: true };
-    d.handleDispatch('conn-1', dispatch({ requestId: 'req-3', sessionId: 'taken' }), c.send);
-    await tick();
-    expect(fr.calls[2]).toMatchObject({ sessionId: 'taken', expectedWorkingDir: WS_DIR });
-    fr.finish();
-  });
-
   it('排队期间映射被撤权: drain 时不执行, 回一条说明而不是在已撤权目录里跑', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
@@ -670,24 +640,6 @@ describe('dispatcher 核心语义', () => {
     expect(fr.calls).toHaveLength(0);
     // worktree 已经建出来了却没有会话认领 —— 必须就地回收
     expect(cleanup).toHaveBeenCalledTimes(1);
-  });
-
-  it('进 runner 后失去授权: isStillAuthorized 在 send 前把它拦下', async () => {
-    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
-    const fr = fakeRunner({ sessions });
-    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
-    const { d } = makeDispatcher({ runner: fr.runner, config });
-    const c = collector();
-
-    d.handleDispatch('conn-1', dispatch(), c.send);
-    await tick();
-    const req = fr.calls[0];
-    expect(req.isStillAuthorized?.()).toBe(true);
-
-    // runner 内部还在做准备工作时映射被撤
-    config.workspaces = {};
-    expect(req.isStillAuthorized?.()).toBe(false);
-    fr.finish();
   });
 
   it('inspect 期间目录被加回映射: 按当前映射判定, 不误杀这条绑定', async () => {
@@ -1574,6 +1526,37 @@ describe('session.archive(/new 换代归档旧代会话)', () => {
     await tick();
     expect(archived).toEqual([sessionId]);
     expect(bindings.get('conn-1', 'slack:dm:U1:g1')).toBeNull();
+  });
+
+  it('turn 还在跑但已落库时被移出映射: /new 也不归档(不走 awaitingPersist 捷径)', async () => {
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const bindings = memoryBindings();
+    const archived: string[] = [];
+    const d = createHookDispatcher({
+      getConnection: () => CONFIG,
+      bindings,
+      runner: fr.runner,
+      archiveSessionRow: async (sessionId) => void archived.push(sessionId),
+      log: noopLog,
+    });
+    const c = collector();
+    d.handleDispatch(
+      'conn-1',
+      dispatch({ requestId: 'r1', externalKey: 'slack:dm:U1:g1' }),
+      c.send,
+    );
+    await tick();
+    const sessionId = c.last('task.ack')!.payload.sessionId as string;
+    // 关键: turn 没收口, 所以 awaitingPersist 里还留着它 —— 但它已经落库, 且
+    // 已被移出映射。捷径必须只在"真查不到"时才用。
+    sessions[sessionId] = { workingDir: path.resolve('/repos/elsewhere'), usable: true };
+
+    d.handleSessionArchive('conn-1', 'slack:dm:U1:g1');
+    await tick();
+    expect(archived).toEqual([]);
+    expect(bindings.get('conn-1', 'slack:dm:U1:g1')).toBeNull();
+    fr.finish();
   });
 
   it('会话已被移出映射: /new 只清绑定, 不归档那个本地会话', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -14,14 +14,13 @@ import {
   buildHookSessionTitle,
   createHookDispatcher,
   isPathWithin,
-  isSamePath,
   normalizeTaskSource,
   type HookDispatcherDeps,
   type HookRunOutcome,
   type HookRunRequest,
   type HookSessionRunner,
 } from '../dispatcher';
-import type { HookBindingEntry, HookBindingStore } from '../bindings';
+import type { HookBindingStore } from '../bindings';
 import type { HookConnectionConfig } from '../store';
 
 const noopLog = { info: () => {}, warn: () => {} };
@@ -37,22 +36,13 @@ const CONFIG: HookConnectionConfig = {
   createdAt: 0,
 };
 
-/** 内存 binding(含工作目录快照与授权来源, 与文件实现同语义)。 */
+/** 内存 binding(与文件实现同语义: 只存 externalKey -> sessionId)。 */
 function memoryBindings(): HookBindingStore {
-  const map = new Map<string, HookBindingEntry>();
+  const map = new Map<string, string>();
   const k = (c: string, e: string): string => `${c}|${e}`;
   return {
-    get: (c, e) => map.get(k(c, e))?.sessionId ?? null,
-    getEntry: (c, e) => {
-      const row = map.get(k(c, e));
-      return row ? { ...row } : null;
-    },
-    set: (c, e, s, workingDir, authority) =>
-      void map.set(k(c, e), {
-        sessionId: s,
-        workingDir: workingDir ?? null,
-        authority: authority ?? null,
-      }),
+    get: (c, e) => map.get(k(c, e)) ?? null,
+    set: (c, e, s) => void map.set(k(c, e), s),
     remove: (c, e) => void map.delete(k(c, e)),
   };
 }
@@ -158,16 +148,6 @@ describe('isPathWithin', () => {
     expect(isPathWithin(WS_DIR, path.resolve('/repos/other'))).toBe(false);
     // 前缀相似但非子目录(/repos/xdmaker-evil)不放行
     expect(isPathWithin(WS_DIR, `${WS_DIR}-evil`)).toBe(false);
-  });
-});
-
-describe('isSamePath', () => {
-  it('同一目录的不同写法算相同, 子目录不算', () => {
-    expect(isSamePath(WS_DIR, WS_DIR)).toBe(true);
-    expect(isSamePath(WS_DIR, path.join(WS_DIR, 'sub', '..'))).toBe(true);
-    expect(isSamePath(WS_DIR, `${WS_DIR}${path.sep}`)).toBe(true);
-    expect(isSamePath(WS_DIR, path.join(WS_DIR, 'sub'))).toBe(false);
-    expect(isSamePath(WS_DIR, path.resolve('/repos/other'))).toBe(false);
   });
 });
 
@@ -428,7 +408,7 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
   });
 
-  it('会话被移出工作目录映射: 目录变过 -> 跟随复用并说明, 不重开新会话', async () => {
+  it('会话被移出工作目录映射 -> 断开绑定、换新对话并说明, 不跟随到映射外', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
     const fr = fakeRunner({ sessions });
@@ -448,29 +428,26 @@ describe('dispatcher 核心语义', () => {
 
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
-    expect(c.last('task.ack')!.payload).toMatchObject({ result: 'accepted', sessionId: first });
-    expect(fr.calls[1]).toMatchObject({ isNew: false, sessionId: first, workingDir: MOVED_DIR });
-    // 快照跟随移动, 并记下"这份授权来自本地移动"
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
-      sessionId: first,
-      workingDir: MOVED_DIR,
-      authority: 'local-move',
-    });
+    const second = c.last('task.ack')!.payload.sessionId!;
+    // 映射是唯一边界: 移出去就不再驱动它, 这条消息换新对话在映射内跑
+    expect(second).not.toBe(first);
+    expect(fr.calls[1]).toMatchObject({ isNew: true, workingDir: WS_DIR });
+    expect(bindings.get('conn-1', 'team-slack:C1:1.1')).toBe(second);
 
-    fr.finish({ finalText: '在新目录里跑完了' });
+    fr.finish({ finalText: '新对话的回答' });
     await tick();
     const finalText = c.last('turn.end')!.payload.finalText;
-    expect(finalText).toContain('已被移动到新的工作目录');
-    expect(finalText).toContain('在新目录里跑完了');
+    expect(finalText).toContain('原对话已不在可用的工作目录里');
+    expect(finalText).toContain('把它所在的目录加进来');
+    expect(finalText).toContain('新对话的回答');
   });
 
-  it('移动后的后续消息持续复用同一 session, 且不再重复提示(跟随不能只生效一次)', async () => {
+  it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
     const fr = fakeRunner({ sessions });
     const { d } = makeDispatcher({ runner: fr.runner, bindings });
     const c = collector();
-    const MOVED_DIR = path.resolve('/repos/another-project');
 
     d.handleDispatch('conn-1', dispatch(), c.send);
     await tick();
@@ -479,61 +456,49 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
     await tick();
 
-    // 移动后连发两条: 第二条时快照已等于新目录, 只有持久化的授权来源能保住复用
-    sessions[first] = { workingDir: MOVED_DIR, usable: true };
+    // 移到映射根下的子目录: 仍在边界内, 判定无状态所以直接复用
+    const INSIDE = path.join(WS_DIR, 'packages', 'sub-project');
+    sessions[first] = { workingDir: INSIDE, usable: true };
+
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
-    fr.finish({ finalText: '第一次' });
-    await tick();
-
-    d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
-    await tick();
     expect(c.last('task.ack')!.payload).toMatchObject({ result: 'accepted', sessionId: first });
-    expect(fr.calls[2]).toMatchObject({ isNew: false, sessionId: first, workingDir: MOVED_DIR });
+    expect(fr.calls[1]).toMatchObject({ isNew: false, sessionId: first, workingDir: INSIDE });
 
-    fr.finish({ finalText: '第二次' });
+    fr.finish({ finalText: '在子目录里跑完了' });
     await tick();
-    // 说明只在"这次刚发现被移动"时出现一次
-    expect(c.last('turn.end')!.payload.finalText).toBe('第二次');
+    // 边界内的移动不打扰用户
+    expect(c.last('turn.end')!.payload.finalText).toBe('在子目录里跑完了');
   });
 
-  it('对话移回工作目录映射内: 授权来源复位, 此后映射被改仍按撤权重建', async () => {
+  it('移出映射后再移回映射内 -> 恢复正常复用(绑定不留任何过期授权)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
     const fr = fakeRunner({ sessions });
-    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
-    const { d } = makeDispatcher({ runner: fr.runner, bindings, config });
+    const { d } = makeDispatcher({ runner: fr.runner, bindings });
     const c = collector();
-    const MOVED_DIR = path.resolve('/repos/another-project');
+    const OUTSIDE = path.resolve('/repos/another-project');
 
     d.handleDispatch('conn-1', dispatch(), c.send);
     await tick();
     const first = c.last('task.ack')!.payload.sessionId!;
-    sessions[first] = { workingDir: MOVED_DIR, usable: true };
+    // 第一条消息后它就被移出映射: 绑定改指新对话
+    sessions[first] = { workingDir: OUTSIDE, usable: true };
     fr.finish();
     await tick();
 
-    // 移出去一次(拿到 local-move 授权), 再移回映射内
     d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
     await tick();
-    fr.finish();
-    await tick();
-    sessions[first] = { workingDir: WS_DIR, usable: true };
-    d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
-    await tick();
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
-      sessionId: first,
-      workingDir: WS_DIR,
-      authority: 'workspace',
-    });
+    const second = c.last('task.ack')!.payload.sessionId!;
+    expect(second).not.toBe(first);
+    sessions[second] = { workingDir: WS_DIR, usable: true };
     fr.finish();
     await tick();
 
-    // 授权已复位: 映射改指别处时按撤权重建, 不再吃老的 local-move
-    config.workspaces = { xdmaker: path.resolve('/repos/elsewhere') };
-    d.handleDispatch('conn-1', dispatch({ requestId: 'req-4' }), c.send);
+    // 新对话在映射内, 此后照常复用
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
     await tick();
-    expect(c.last('task.ack')!.payload.sessionId).not.toBe(first);
+    expect(c.last('task.ack')!.payload).toMatchObject({ result: 'accepted', sessionId: second });
     fr.finish();
   });
 
@@ -571,51 +536,35 @@ describe('dispatcher 核心语义', () => {
     expect(finalText).toContain('新会话的回答');
   });
 
-  it('老绑定没有目录快照时按保守侧处理: 越界即重建', async () => {
-    const bindings = memoryBindings();
-    const OUTSIDE = path.resolve('/repos/another-project');
-    const fr = fakeRunner({
-      sessions: { 'legacy-session': { workingDir: OUTSIDE, usable: true } },
-    });
-    const { d } = makeDispatcher({ runner: fr.runner, bindings });
-    const c = collector();
-    // v1 形态: 只有 sessionId, 无从判断目录是被用户移动还是映射被改
-    bindings.set('conn-1', 'team-slack:C1:1.1', 'legacy-session');
+  it('存量绑定(带早期版本残留字段)照常判定: 在映射内即复用, 越界即重建', async () => {
+    const reuse = memoryBindings();
+    const fr1 = fakeRunner({ sessions: { 'old-session': { workingDir: WS_DIR, usable: true } } });
+    const { d: d1 } = makeDispatcher({ runner: fr1.runner, bindings: reuse });
+    const c1 = collector();
+    reuse.set('conn-1', 'team-slack:C1:1.1', 'old-session');
 
-    d.handleDispatch('conn-1', dispatch(), c.send);
+    d1.handleDispatch('conn-1', dispatch(), c1.send);
     await tick();
-
-    const sessionId = c.last('task.ack')!.payload.sessionId!;
-    expect(sessionId).not.toBe('legacy-session');
-    expect(fr.calls[0]).toMatchObject({ isNew: true, workingDir: WS_DIR });
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
-      sessionId,
-      workingDir: WS_DIR,
-      authority: 'workspace',
-    });
-    fr.finish();
-  });
-
-  it('正常复用顺手回填目录快照(存量绑定升级路径)', async () => {
-    const bindings = memoryBindings();
-    const fr = fakeRunner({ sessions: { 'legacy-session': { workingDir: WS_DIR, usable: true } } });
-    const { d } = makeDispatcher({ runner: fr.runner, bindings });
-    const c = collector();
-    bindings.set('conn-1', 'team-slack:C1:1.1', 'legacy-session');
-
-    d.handleDispatch('conn-1', dispatch(), c.send);
-    await tick();
-
-    expect(c.last('task.ack')!.payload.sessionId).toBe('legacy-session');
-    expect(bindings.getEntry('conn-1', 'team-slack:C1:1.1')).toEqual({
-      sessionId: 'legacy-session',
-      workingDir: WS_DIR,
-      authority: 'workspace',
-    });
-    fr.finish({ finalText: '继续' });
+    expect(c1.last('task.ack')!.payload.sessionId).toBe('old-session');
+    fr1.finish({ finalText: '继续' });
     await tick();
     // 正常复用不打扰用户
-    expect(c.last('turn.end')!.payload.finalText).toBe('继续');
+    expect(c1.last('turn.end')!.payload.finalText).toBe('继续');
+
+    const rebuild = memoryBindings();
+    const OUTSIDE = path.resolve('/repos/another-project');
+    const fr2 = fakeRunner({ sessions: { 'old-session': { workingDir: OUTSIDE, usable: true } } });
+    const { d: d2 } = makeDispatcher({ runner: fr2.runner, bindings: rebuild });
+    const c2 = collector();
+    rebuild.set('conn-1', 'team-slack:C1:1.1', 'old-session');
+
+    d2.handleDispatch('conn-1', dispatch(), c2.send);
+    await tick();
+    const sessionId = c2.last('task.ack')!.payload.sessionId!;
+    expect(sessionId).not.toBe('old-session');
+    expect(fr2.calls[0]).toMatchObject({ isNew: true, workingDir: WS_DIR });
+    expect(rebuild.get('conn-1', 'team-slack:C1:1.1')).toBe(sessionId);
+    fr2.finish();
   });
 
   it('绑定的会话已归档/删除 -> 重建并说明是原对话没了', async () => {
@@ -623,7 +572,7 @@ describe('dispatcher 核心语义', () => {
     const fr = fakeRunner({ sessions: { 'gone-session': { workingDir: WS_DIR, usable: false } } });
     const { d } = makeDispatcher({ runner: fr.runner, bindings });
     const c = collector();
-    bindings.set('conn-1', 'team-slack:C1:1.1', 'gone-session', WS_DIR, 'workspace');
+    bindings.set('conn-1', 'team-slack:C1:1.1', 'gone-session');
 
     d.handleDispatch('conn-1', dispatch(), c.send);
     await tick();

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -471,6 +471,39 @@ describe('dispatcher 核心语义', () => {
     await tick();
   });
 
+  it('inspect 瞬时失败(返回 null)不构成免检: 已落库的会话仍按边界处理', async () => {
+    const bindings = memoryBindings();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const { d } = makeDispatcher({ runner: fr.runner, bindings });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const first = c.last('task.ack')!.payload.sessionId!;
+    sessions[first] = { workingDir: WS_DIR, usable: true };
+    fr.finish();
+    await tick();
+
+    // 第二轮开着不收口, 让 first 留在 running 里
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    expect(c.last('task.ack')!.payload.sessionId).toBe(first);
+
+    // 模拟 meta / DB 读取瞬时失败: inspect 也返回 null, 与"不存在"不可区分。
+    // 免检窗口只认 awaitingPersist(本 dispatcher 新建且未落库), first 早已出局,
+    // 所以这里必须 fail closed 而不是把消息排进 first。
+    delete sessions[first];
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-3' }), c.send);
+    await tick();
+    expect(c.last('task.ack')!.payload.sessionId).not.toBe(first);
+
+    fr.finish();
+    await tick();
+    fr.finish();
+    await tick();
+  });
+
   it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -621,6 +621,75 @@ describe('dispatcher 核心语义', () => {
     expect(end.errorMessage).toContain('已不在工作目录映射里');
   });
 
+  it('排队期间连接被停用: 目录还在映射里也不执行', async () => {
+    const fr = fakeRunner({ sessions: {} });
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    const { d } = makeDispatcher({ runner: fr.runner, config });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    expect(c.last('task.ack')!.payload.result).toBe('queued');
+
+    // 用户关掉了这条连接 —— 通道已切断, 排着的远端任务不能因为"目录还在映射里"就跑
+    config.enabled = false;
+    fr.finish();
+    await tick();
+
+    expect(fr.calls).toHaveLength(1);
+    const queued = c
+      .ofType('turn.end')
+      .map((m) => m.payload)
+      .find((e) => e.requestId === 'req-2')!;
+    expect(queued.status).toBe('error');
+  });
+
+  it('执行前被拦下时回收预建的 worktree(不留孤儿)', async () => {
+    const fr = fakeRunner();
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    const cleanup = vi.fn(async () => undefined);
+    let release!: (v: PrepareWorktreeResult) => void;
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      config,
+      prepareWorktree: () =>
+        new Promise<PrepareWorktreeResult>((resolve) => {
+          release = resolve;
+        }),
+    });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    config.workspaces = {};
+    release({ ok: true, sessionId: 'wt-session', path: path.join(WS_DIR, 'wt'), cleanup });
+    await tick();
+
+    expect(fr.calls).toHaveLength(0);
+    // worktree 已经建出来了却没有会话认领 —— 必须就地回收
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('进 runner 后失去授权: isStillAuthorized 在 send 前把它拦下', async () => {
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    const { d } = makeDispatcher({ runner: fr.runner, config });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const req = fr.calls[0];
+    expect(req.isStillAuthorized?.()).toBe(true);
+
+    // runner 内部还在做准备工作时映射被撤
+    config.workspaces = {};
+    expect(req.isStillAuthorized?.()).toBe(false);
+    fr.finish();
+  });
+
   it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -504,6 +504,62 @@ describe('dispatcher 核心语义', () => {
     await tick();
   });
 
+  it('免检窗口内别名被改指: 未落库的会话也要重过映射校验, 不再免检', async () => {
+    const bindings = memoryBindings();
+    const fr = fakeRunner(); // sessions 恒空 -> inspect 一直返回 null(未落库)
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    const { d } = makeDispatcher({ runner: fr.runner, bindings, config });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const first = c.last('task.ack')!.payload.sessionId!;
+    expect(fr.calls[0]).toMatchObject({ isNew: true, workingDir: WS_DIR });
+
+    // 第一轮还在 agent.startSession 里(没落库、没收口), 此时用户把别名改指走
+    config.workspaces = { xdmaker: path.resolve('/repos/elsewhere') };
+
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    // 只认 sessionId 的话这条会排进 first —— 而 first 建在已撤权的目录里
+    expect(c.last('task.ack')!.payload.sessionId).not.toBe(first);
+
+    fr.finish();
+    await tick();
+    fr.finish();
+    await tick();
+  });
+
+  it('复用与接管都带上已校验目录, 供 runner 在读权威 meta 后收口比对', async () => {
+    const bindings = memoryBindings();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const { d } = makeDispatcher({ runner: fr.runner, bindings });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const first = c.last('task.ack')!.payload.sessionId!;
+    // 新建路径不比对(还没有权威 meta 可言)
+    expect(fr.calls[0].expectedWorkingDir ?? null).toBeNull();
+    sessions[first] = { workingDir: WS_DIR, usable: true };
+    fr.finish();
+    await tick();
+
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    expect(fr.calls[1]).toMatchObject({ sessionId: first, expectedWorkingDir: WS_DIR });
+    fr.finish();
+    await tick();
+
+    // 接管路径同理
+    sessions['taken'] = { workingDir: WS_DIR, usable: true };
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-3', sessionId: 'taken' }), c.send);
+    await tick();
+    expect(fr.calls[2]).toMatchObject({ sessionId: 'taken', expectedWorkingDir: WS_DIR });
+    fr.finish();
+  });
+
   it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
@@ -642,7 +698,8 @@ describe('dispatcher 核心语义', () => {
 
     fr.finish({ finalText: '新的回答' });
     await tick();
-    expect(c.last('turn.end')!.payload.finalText).toContain('原对话已被归档或删除');
+    // 措辞留余地: inspect 的 null 也可能是读库瞬时失败, 不能一口咬定会话没了
+    expect(c.last('turn.end')!.payload.finalText).toContain('原对话现在读不到');
   });
 
   it('切账号期间异步定位失败也不回写旧代 rejected ack', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -690,6 +690,39 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
   });
 
+  it('inspect 期间目录被加回映射: 按当前映射判定, 不误杀这条绑定', async () => {
+    const bindings = memoryBindings();
+    const OUTSIDE = path.resolve('/repos/another-project');
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {
+      'bound-session': { workingDir: OUTSIDE, usable: true },
+    };
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    let releaseInspect!: () => void;
+    const runner: HookSessionRunner = {
+      isBusy: () => false,
+      inspect: async (id) => {
+        await new Promise<void>((resolve) => {
+          releaseInspect = resolve;
+        });
+        return sessions[id] ? { ...sessions[id] } : null;
+      },
+      run: async () => ({ status: 'ok', finalText: 'done', errorMessage: null, durationMs: 1 }),
+    };
+    const { d } = makeDispatcher({ runner, bindings, config });
+    const c = collector();
+    bindings.set('conn-1', 'team-slack:C1:1.1', 'bound-session');
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    // inspect 还挂着时用户把这个目录加进了映射 —— 入口快照里没有它, 当前映射有
+    config.workspaces = { xdmaker: WS_DIR, other: OUTSIDE };
+    releaseInspect();
+    await tick();
+
+    expect(c.last('task.ack')!.payload.sessionId).toBe('bound-session');
+    expect(bindings.get('conn-1', 'team-slack:C1:1.1')).toBe('bound-session');
+  });
+
   it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
@@ -1514,7 +1547,38 @@ describe('session.archive(/new 换代归档旧代会话)', () => {
   });
 
   it('有绑定: 归档 session 行并清绑定', async () => {
-    const fr = fakeRunner();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const bindings = memoryBindings();
+    const archived: string[] = [];
+    const d = createHookDispatcher({
+      getConnection: () => CONFIG,
+      bindings,
+      runner: fr.runner,
+      archiveSessionRow: async (sessionId) => void archived.push(sessionId),
+      log: noopLog,
+    });
+    const c = collector();
+    d.handleDispatch(
+      'conn-1',
+      dispatch({ requestId: 'r1', externalKey: 'slack:dm:U1:g1' }),
+      c.send,
+    );
+    await tick();
+    const sessionId = c.last('task.ack')!.payload.sessionId as string;
+    sessions[sessionId] = { workingDir: WS_DIR, usable: true };
+    fr.finish();
+    await tick();
+
+    d.handleSessionArchive('conn-1', 'slack:dm:U1:g1');
+    await tick();
+    expect(archived).toEqual([sessionId]);
+    expect(bindings.get('conn-1', 'slack:dm:U1:g1')).toBeNull();
+  });
+
+  it('会话已被移出映射: /new 只清绑定, 不归档那个本地会话', async () => {
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
     const bindings = memoryBindings();
     const archived: string[] = [];
     const d = createHookDispatcher({
@@ -1534,10 +1598,14 @@ describe('session.archive(/new 换代归档旧代会话)', () => {
     const sessionId = c.last('task.ack')!.payload.sessionId as string;
     fr.finish();
     await tick();
+    // 用户把它移到映射外 —— 远端已经无权驱动它, 也就无权归档它 / 触发它的
+    // worktree 清理
+    sessions[sessionId] = { workingDir: path.resolve('/repos/elsewhere'), usable: true };
 
     d.handleSessionArchive('conn-1', 'slack:dm:U1:g1');
     await tick();
-    expect(archived).toEqual([sessionId]);
+    expect(archived).toEqual([]);
+    // 绑定还是要清: 下条消息本就该开新会话
     expect(bindings.get('conn-1', 'slack:dm:U1:g1')).toBeNull();
   });
 
@@ -1560,10 +1628,11 @@ describe('session.archive(/new 换代归档旧代会话)', () => {
     d.handleSessionArchive('conn-1', 'slack:dm:U1:g1');
     await tick();
     expect(archiveCalls).toEqual([]);
-    // 有绑定但行已不存在: 调用发生、异常被吞、绑定仍被清理
+    // 有绑定但会话查不到(行已不存在): 无从确认它还在映射内, 就不对它动手 ——
+    // 反正 archiveSessionRow 也只会 NOT_FOUND。绑定照清, 幂等目的达到。
     d.handleSessionArchive('conn-1', 'slack:dm:U1:g2');
     await tick();
-    expect(archiveCalls).toEqual(['sess-gone']);
+    expect(archiveCalls).toEqual([]);
     expect(bindings.get('conn-1', 'slack:dm:U1:g2')).toBeNull();
   });
 

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -13,7 +13,6 @@ import type { HookMessage, TaskDispatchPayload } from '@cindy/slack-hook-protoco
 import {
   buildHookSessionTitle,
   createHookDispatcher,
-  isPathWithin,
   normalizeTaskSource,
   type HookDispatcherDeps,
   type HookRunOutcome,
@@ -21,6 +20,7 @@ import {
   type HookSessionRunner,
 } from '../dispatcher';
 import type { HookBindingStore } from '../bindings';
+import { isPathWithin } from '../paths';
 import type { HookConnectionConfig } from '../store';
 
 const noopLog = { info: () => {}, warn: () => {} };
@@ -558,6 +558,38 @@ describe('dispatcher 核心语义', () => {
     await tick();
     expect(fr.calls[2]).toMatchObject({ sessionId: 'taken', expectedWorkingDir: WS_DIR });
     fr.finish();
+  });
+
+  it('排队期间映射被撤权: drain 时不执行, 回一条说明而不是在已撤权目录里跑', async () => {
+    const bindings = memoryBindings();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const config: HookConnectionConfig = { ...CONFIG, workspaces: { xdmaker: WS_DIR } };
+    const { d } = makeDispatcher({ runner: fr.runner, bindings, config });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const first = c.last('task.ack')!.payload.sessionId!;
+    sessions[first] = { workingDir: WS_DIR, usable: true };
+
+    // 第一轮没收口时第二条进队列(此刻目录还在映射内, 校验通过)
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    expect(c.last('task.ack')!.payload).toMatchObject({ result: 'queued' });
+
+    // 排队期间用户把这个目录从映射里删掉 —— 会话目录和 expectedWorkingDir 都
+    // 没变, 只有"映射还认不认它"变了, 所以必须在开跑前重新查映射
+    config.workspaces = {};
+    fr.finish({ finalText: '第一条跑完了' });
+    await tick();
+
+    const ends = c.ofType('turn.end').map((m) => m.payload);
+    const queued = ends.find((e) => e.requestId === 'req-2')!;
+    expect(queued.status).toBe('error');
+    expect(queued.errorMessage).toContain('已不在工作目录映射里');
+    // 关键: 排队那条根本没进 runner
+    expect(fr.calls).toHaveLength(1);
   });
 
   it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -442,6 +442,35 @@ describe('dispatcher 核心语义', () => {
     expect(finalText).toContain('新对话的回答');
   });
 
+  it('旧任务还在跑时被移出映射: 新消息不排进旧会话(快路径也过边界)', async () => {
+    const bindings = memoryBindings();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const { d } = makeDispatcher({ runner: fr.runner, bindings });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch(), c.send);
+    await tick();
+    const first = c.last('task.ack')!.payload.sessionId!;
+    // 第一轮仍在执行(没有 fr.finish): session 落库并被用户移出映射
+    sessions[first] = { workingDir: path.resolve('/repos/another-project'), usable: true };
+
+    d.handleDispatch('conn-1', dispatch({ requestId: 'req-2' }), c.send);
+    await tick();
+    // 免检快路径只保「尚未落库」的窗口 —— 已落库的会话在跑也要过映射校验,
+    // 否则这条消息会排进旧会话, 由 session meta 的 workDir 带到映射外执行
+    const second = c.last('task.ack')!.payload.sessionId!;
+    expect(second).not.toBe(first);
+    expect(c.last('task.ack')!.payload.result).toBe('accepted');
+    expect(fr.calls[1]).toMatchObject({ isNew: true, workingDir: WS_DIR });
+    expect(bindings.get('conn-1', 'team-slack:C1:1.1')).toBe(second);
+
+    fr.finish();
+    await tick();
+    fr.finish();
+    await tick();
+  });
+
   it('在工作目录映射内换目录 -> 无感跟随复用(边界内的移动不受影响)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};

--- a/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
@@ -32,4 +32,23 @@ describe('isPathWithin', () => {
     expect(isPathWithin(BASE, path.join(BASE, '..'))).toBe(false);
     expect(isPathWithin(BASE, path.join(BASE, 'sub', '..', '..', 'elsewhere'))).toBe(false);
   });
+
+  it('大小写: Windows 不敏感, 其它平台敏感(规则 15)', () => {
+    // 两个分支都要锁住 —— 只在当前平台上跑, 另一半会在重构时悄悄回归
+    const original = process.platform;
+    const setPlatform = (value: NodeJS.Platform): void => {
+      Object.defineProperty(process, 'platform', { value, configurable: true });
+    };
+    try {
+      setPlatform('win32');
+      expect(isPathWithin(BASE, path.join(BASE.toUpperCase(), 'SUB'))).toBe(true);
+      expect(isPathWithin(BASE.toUpperCase(), BASE)).toBe(true);
+
+      setPlatform('linux');
+      expect(isPathWithin(BASE, path.join(BASE.toUpperCase(), 'SUB'))).toBe(false);
+      expect(isPathWithin(BASE.toUpperCase(), BASE)).toBe(false);
+    } finally {
+      setPlatform(original);
+    }
+  });
 });

--- a/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
@@ -1,0 +1,57 @@
+/**
+ * hook-control/paths 单测。
+ *
+ * 这两个判定是工作目录映射这条安全边界的算术: `isPathWithin` 决定"远端能不能
+ * 驱动这个目录", `isSamePath` 决定"真正要跑的会话还在不在校验过的目录里"。
+ * 归一化细节(`sub/..`、尾部分隔符、Windows 大小写)错一点就是放行或误拒,
+ * 所以单独覆盖(PR #733 review 指出抽模块后丢了覆盖)。
+ */
+
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { isPathWithin, isSamePath } from '../paths';
+
+const BASE = path.resolve('/repos/demo');
+
+describe('isPathWithin', () => {
+  it('相等 / 子目录算在内, 外部路径不算', () => {
+    expect(isPathWithin(BASE, BASE)).toBe(true);
+    expect(isPathWithin(BASE, path.join(BASE, 'sub'))).toBe(true);
+    expect(isPathWithin(BASE, path.join(BASE, 'a', 'b', 'c'))).toBe(true);
+    expect(isPathWithin(BASE, path.resolve('/repos/other'))).toBe(false);
+  });
+
+  it('前缀相同但不是子目录的兄弟目录不算(字符串前缀比较会误判)', () => {
+    expect(isPathWithin(BASE, path.resolve('/repos/demo-2'))).toBe(false);
+    expect(isPathWithin(BASE, `${BASE}-backup`)).toBe(false);
+  });
+
+  it('先归一化再判定: `..` 不能借道逃出去', () => {
+    expect(isPathWithin(BASE, path.join(BASE, 'sub', '..'))).toBe(true);
+    expect(isPathWithin(BASE, path.join(BASE, '..'))).toBe(false);
+    expect(isPathWithin(BASE, path.join(BASE, 'sub', '..', '..', 'elsewhere'))).toBe(false);
+  });
+});
+
+describe('isSamePath', () => {
+  it('同一目录的不同写法算相同', () => {
+    expect(isSamePath(BASE, BASE)).toBe(true);
+    expect(isSamePath(BASE, path.join(BASE, 'sub', '..'))).toBe(true);
+    expect(isSamePath(BASE, `${BASE}${path.sep}`)).toBe(true);
+  });
+
+  it('子目录与别的目录都不算相同(这是"没被移走"的判据, 不能放宽)', () => {
+    expect(isSamePath(BASE, path.join(BASE, 'sub'))).toBe(false);
+    expect(isSamePath(BASE, path.resolve('/repos/other'))).toBe(false);
+    expect(isSamePath(BASE, `${BASE}-backup`)).toBe(false);
+  });
+
+  it('大小写: Windows 上不敏感, 其它平台敏感(规则 15)', () => {
+    const upper = BASE.toUpperCase();
+    const expected = process.platform === 'win32';
+    expect(isSamePath(BASE, upper)).toBe(expected);
+    expect(isPathWithin(BASE, path.join(upper, 'sub'))).toBe(expected);
+  });
+});

--- a/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
@@ -1,17 +1,16 @@
 /**
  * hook-control/paths 单测。
  *
- * 这两个判定是工作目录映射这条安全边界的算术: `isPathWithin` 决定"远端能不能
- * 驱动这个目录", `isSamePath` 决定"真正要跑的会话还在不在校验过的目录里"。
- * 归一化细节(`sub/..`、尾部分隔符、Windows 大小写)错一点就是放行或误拒,
- * 所以单独覆盖(PR #733 review 指出抽模块后丢了覆盖)。
+ * `isPathWithin` 是工作目录映射这条安全边界的算术 —— 它决定"远端能不能驱动这个
+ * 目录"。归一化细节(`sub/..`、兄弟目录前缀、Windows 大小写)错一点就是放行或
+ * 误拒, 所以单独覆盖(PR #733 review 指出抽模块后丢了覆盖)。
  */
 
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { isPathWithin, isSamePath } from '../paths';
+import { isPathWithin } from '../paths';
 
 const BASE = path.resolve('/repos/demo');
 
@@ -32,26 +31,5 @@ describe('isPathWithin', () => {
     expect(isPathWithin(BASE, path.join(BASE, 'sub', '..'))).toBe(true);
     expect(isPathWithin(BASE, path.join(BASE, '..'))).toBe(false);
     expect(isPathWithin(BASE, path.join(BASE, 'sub', '..', '..', 'elsewhere'))).toBe(false);
-  });
-});
-
-describe('isSamePath', () => {
-  it('同一目录的不同写法算相同', () => {
-    expect(isSamePath(BASE, BASE)).toBe(true);
-    expect(isSamePath(BASE, path.join(BASE, 'sub', '..'))).toBe(true);
-    expect(isSamePath(BASE, `${BASE}${path.sep}`)).toBe(true);
-  });
-
-  it('子目录与别的目录都不算相同(这是"没被移走"的判据, 不能放宽)', () => {
-    expect(isSamePath(BASE, path.join(BASE, 'sub'))).toBe(false);
-    expect(isSamePath(BASE, path.resolve('/repos/other'))).toBe(false);
-    expect(isSamePath(BASE, `${BASE}-backup`)).toBe(false);
-  });
-
-  it('大小写: Windows 上不敏感, 其它平台敏感(规则 15)', () => {
-    const upper = BASE.toUpperCase();
-    const expected = process.platform === 'win32';
-    expect(isSamePath(BASE, upper)).toBe(expected);
-    expect(isPathWithin(BASE, path.join(upper, 'sub'))).toBe(expected);
   });
 });

--- a/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
@@ -33,6 +33,15 @@ describe('isPathWithin', () => {
     expect(isPathWithin(BASE, path.join(BASE, 'sub', '..', '..', 'elsewhere'))).toBe(false);
   });
 
+  it('空 / 全空白路径 fail closed(空串会 resolve 成 cwd, 那是假放行)', () => {
+    expect(isPathWithin(BASE, '')).toBe(false);
+    expect(isPathWithin(BASE, '   ')).toBe(false);
+    expect(isPathWithin('', BASE)).toBe(false);
+    expect(isPathWithin('', '')).toBe(false);
+    // 具体证据: 拿进程 cwd 当映射根时, 空目标不能被判成"在里面"
+    expect(isPathWithin(process.cwd(), '')).toBe(false);
+  });
+
   it('大小写: Windows 不敏感, 其它平台敏感(规则 15)', () => {
     // 两个分支都要锁住 —— 只在当前平台上跑, 另一半会在重构时悄悄回归
     const original = process.platform;

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -310,6 +310,45 @@ describe('hook session 精确接管边界', () => {
   });
 });
 
+describe('真正要跑的那个 live session 的目录也要过映射', () => {
+  it('活实例仍在已撤权的目录 -> 拒绝执行, 消息不进 agent', async () => {
+    // maker.createSession 对已在 activeSessions 里的 id 直接返回既有实例, 忽略
+    // 传入的 workingDir —— 那个实例的 workDir 可能已被移出映射
+    fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) => ({
+      ...makeFakeSession(opts.id ?? 'sess-old'),
+      workDir: 'D:/unmapped-place',
+    }));
+    const runner = createMakerHookSessionRunner({ log });
+
+    const outcome = await runner.run(
+      baseReq({
+        sessionId: 'sess-old',
+        isNew: false,
+        isDirAuthorized: (dir: string) => dir === 'D:/repo',
+      }),
+    );
+
+    expect(outcome.status).toBe('error');
+    expect(outcome.errorMessage).toContain('已不在工作目录映射里的目录');
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    expect(session.send).not.toHaveBeenCalled();
+  });
+
+  it('活实例的目录仍在映射内 -> 照常执行(映射内的移动不受影响)', async () => {
+    const runner = createMakerHookSessionRunner({ log });
+
+    const outcome = await runner.run(
+      baseReq({
+        sessionId: 'sess-old',
+        isNew: false,
+        isDirAuthorized: (dir: string) => dir === 'D:/repo',
+      }),
+    );
+
+    expect(outcome.status).toBe('ok');
+  });
+});
+
 describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () => {
   it('isNew: touchUserSendInDb 在 sessions:created 广播之前落库, onAccepted 再 bump 一次', async () => {
     const runner = createMakerHookSessionRunner({ log });

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -168,6 +168,9 @@ vi.mock('../defaults.js', async (importOriginal) => {
 function makeFakeSession(id: string) {
   return {
     id,
+    // 真实 Session 有这个只读字段; runner 用它确认"真正要跑的这个会话"仍在
+    // dispatcher 校验过的目录里(createSession 对活会话短路时不认传入的 workDir)
+    workDir: 'D:/repo',
     onEvent(cb: (ev: { type: string; data: unknown }) => void) {
       h.eventCbs.set(id, cb);
       return () => {
@@ -320,6 +323,23 @@ describe('执行前按权威 meta 收口校验工作目录', () => {
     expect(outcome.status).toBe('error');
     expect(outcome.errorMessage).toContain('刚被移动到别的目录');
     expect(fakeMaker.createSession).not.toHaveBeenCalled();
+  });
+
+  it('createSession 短路返回的活会话跑在别处 -> 也要拒绝(meta 拦不住这种)', async () => {
+    // maker.createSession 对已在 activeSessions 里的 id 直接返回既有实例, 忽略
+    // 传入的 workingDir —— 那个实例的 workDir 可能还指着别处
+    fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) => ({
+      ...makeFakeSession(opts.id ?? 'sess-old'),
+      workDir: 'D:/still-the-old-place',
+    }));
+    const runner = createMakerHookSessionRunner({ log });
+
+    const outcome = await runner.run(
+      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
+    );
+
+    expect(outcome.status).toBe('error');
+    expect(outcome.errorMessage).toContain('正在别的目录里运行');
   });
 
   it('目录一致 -> 照常执行; 新建路径不带该字段也不受影响', async () => {
@@ -626,6 +646,7 @@ describe('进度快照(turn.progress 链路)', () => {
   function makeManualSession(id: string) {
     return {
       id,
+      workDir: 'D:/repo',
       onEvent(cb: (ev: { type: string; data: unknown }) => void) {
         h.eventCbs.set(id, cb);
         return () => {
@@ -777,6 +798,7 @@ describe('交互卡链路(interaction listener 覆盖)', () => {
   function makeInteractiveSession(id: string) {
     return {
       id,
+      workDir: 'D:/repo',
       onEvent(cb: (ev: { type: string; data: unknown }) => void) {
         h.eventCbs.set(id, cb);
         return () => {

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -200,6 +200,7 @@ const fakeMaker = {
     permissionMode: undefined as 'ask' | 'bypassPermissions' | undefined,
   })),
   getSession: vi.fn(),
+  closeSession: vi.fn(async (_id: string) => undefined),
   getCapabilities: vi.fn(() => ({ availableModels: [], permissionModes: [] })),
 };
 
@@ -325,12 +326,12 @@ describe('执行前按权威 meta 收口校验工作目录', () => {
     expect(fakeMaker.createSession).not.toHaveBeenCalled();
   });
 
-  it('createSession 短路返回的活会话跑在别处 -> 也要拒绝(meta 拦不住这种)', async () => {
+  it('createSession 短路返回的活会话跑在别处 -> 关掉重建到校验过的目录再跑', async () => {
     // maker.createSession 对已在 activeSessions 里的 id 直接返回既有实例, 忽略
-    // 传入的 workingDir —— 那个实例的 workDir 可能还指着别处
+    // 传入的 workingDir —— 那个实例的 workDir 还指着移动前的目录
     fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) => ({
       ...makeFakeSession(opts.id ?? 'sess-old'),
-      workDir: 'D:/still-the-old-place',
+      workDir: 'D:/the-old-place',
     }));
     const runner = createMakerHookSessionRunner({ log });
 
@@ -338,8 +339,27 @@ describe('执行前按权威 meta 收口校验工作目录', () => {
       baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
     );
 
+    // 只报错的话, 映射内 A->B 的合法移动会被永久拒绝到 app 重启
+    expect(outcome.status).toBe('ok');
+    expect(fakeMaker.closeSession).toHaveBeenCalledWith('sess-old');
+    expect(fakeMaker.createSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('重建后仍拿到旧实例 -> 这一轮不跑(不在旧目录里执行)', async () => {
+    // 关闭后 activeSessions 清理还没落地的情形: 两次都拿到旧实例
+    const stale = async (opts: { id?: string }) => ({
+      ...makeFakeSession(opts.id ?? 'sess-old'),
+      workDir: 'D:/the-old-place',
+    });
+    fakeMaker.createSession.mockImplementationOnce(stale).mockImplementationOnce(stale);
+    const runner = createMakerHookSessionRunner({ log });
+
+    const outcome = await runner.run(
+      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
+    );
+
     expect(outcome.status).toBe('error');
-    expect(outcome.errorMessage).toContain('正在别的目录里运行');
+    expect(outcome.errorMessage).toContain('刚换了工作目录');
   });
 
   it('目录一致 -> 照常执行; 新建路径不带该字段也不受影响', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -82,6 +82,7 @@ vi.mock('../../device-link/broadcast-tap.js', () => ({
 vi.mock('../../maker-ipc/register.js', () => ({
   wireSessionToIpc: vi.fn(),
   isSessionInTurn: () => false,
+  withSendToSessionLock: (id: string, task: () => Promise<unknown>) => lockMock.impl(id, task),
   installDesktopInteractionListener: h.installDesktopInteractionListener,
   noteSilentStopUserSend: vi.fn(),
   onSilentStopSettled: vi.fn(() => () => {}),
@@ -111,6 +112,10 @@ vi.mock('../../maker-ipc/agentHandoffPendingSingleton.js', () => ({
 }));
 vi.mock('../../imageCacheStore.js', () => ({
   resolveSafe: vi.fn(),
+}));
+/** per-session 发送锁: 默认直通, 需要观察加锁范围的用例可改写 impl。 */
+const lockMock = vi.hoisted(() => ({
+  impl: async (_id: string, task: () => Promise<unknown>) => task(),
 }));
 // cindy-media:入站图片写入媒体总仓,mock 记调用。
 const cindyMock = vi.hoisted(() => ({
@@ -280,6 +285,7 @@ beforeEach(() => {
   h.resolvedConfig.permissionMode = 'bypassPermissions';
   h.resolvedConfig.providerId = null;
   h.peekPendingHandoff.mockResolvedValue(null);
+  lockMock.impl = async (_id, task) => task();
 });
 
 describe('hook session 精确接管边界', () => {
@@ -343,6 +349,32 @@ describe('执行前按权威 meta 收口校验工作目录', () => {
     expect(outcome.status).toBe('ok');
     expect(fakeMaker.closeSession).toHaveBeenCalledWith('sess-old');
     expect(fakeMaker.createSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('重建全程拿 per-session 发送锁(不从正在打字的桌面会话底下抽走实例)', async () => {
+    const order: string[] = [];
+    lockMock.impl = async (id, task) => {
+      order.push(`lock:${id}`);
+      const r = await task();
+      order.push(`unlock:${id}`);
+      return r;
+    };
+    fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) => ({
+      ...makeFakeSession(opts.id ?? 'sess-old'),
+      workDir: 'D:/the-old-place',
+    }));
+    fakeMaker.closeSession.mockImplementationOnce(async (id: string) => {
+      order.push(`close:${id}`);
+    });
+    const runner = createMakerHookSessionRunner({ log });
+
+    const outcome = await runner.run(
+      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
+    );
+
+    expect(outcome.status).toBe('ok');
+    // 关闭与重建都必须发生在锁内
+    expect(order).toEqual(['lock:sess-old', 'close:sess-old', 'unlock:sess-old']);
   });
 
   it('重建后仍拿到旧实例 -> 这一轮不跑(不在旧目录里执行)', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -82,7 +82,6 @@ vi.mock('../../device-link/broadcast-tap.js', () => ({
 vi.mock('../../maker-ipc/register.js', () => ({
   wireSessionToIpc: vi.fn(),
   isSessionInTurn: () => false,
-  withSendToSessionLock: (id: string, task: () => Promise<unknown>) => lockMock.impl(id, task),
   installDesktopInteractionListener: h.installDesktopInteractionListener,
   noteSilentStopUserSend: vi.fn(),
   onSilentStopSettled: vi.fn(() => () => {}),
@@ -112,10 +111,6 @@ vi.mock('../../maker-ipc/agentHandoffPendingSingleton.js', () => ({
 }));
 vi.mock('../../imageCacheStore.js', () => ({
   resolveSafe: vi.fn(),
-}));
-/** per-session 发送锁: 默认直通, 需要观察加锁范围的用例可改写 impl。 */
-const lockMock = vi.hoisted(() => ({
-  impl: async (_id: string, task: () => Promise<unknown>) => task(),
 }));
 // cindy-media:入站图片写入媒体总仓,mock 记调用。
 const cindyMock = vi.hoisted(() => ({
@@ -173,8 +168,6 @@ vi.mock('../defaults.js', async (importOriginal) => {
 function makeFakeSession(id: string) {
   return {
     id,
-    // 真实 Session 有这个只读字段; runner 用它确认"真正要跑的这个会话"仍在
-    // dispatcher 校验过的目录里(createSession 对活会话短路时不认传入的 workDir)
     workDir: 'D:/repo',
     onEvent(cb: (ev: { type: string; data: unknown }) => void) {
       h.eventCbs.set(id, cb);
@@ -205,7 +198,6 @@ const fakeMaker = {
     permissionMode: undefined as 'ask' | 'bypassPermissions' | undefined,
   })),
   getSession: vi.fn(),
-  closeSession: vi.fn(async (_id: string) => undefined),
   getCapabilities: vi.fn(() => ({ availableModels: [], permissionModes: [] })),
 };
 
@@ -285,7 +277,6 @@ beforeEach(() => {
   h.resolvedConfig.permissionMode = 'bypassPermissions';
   h.resolvedConfig.providerId = null;
   h.peekPendingHandoff.mockResolvedValue(null);
-  lockMock.impl = async (_id, task) => task();
 });
 
 describe('hook session 精确接管边界', () => {
@@ -316,105 +307,6 @@ describe('hook session 精确接管边界', () => {
 
     await expect(runner.inspect('remote-session')).resolves.toMatchObject({ usable: false });
     await expect(runner.inspect('worker-session')).resolves.toMatchObject({ usable: false });
-  });
-});
-
-describe('执行前按权威 meta 收口校验工作目录', () => {
-  it('meta.workDir 与 dispatcher 校验过的目录不符 -> 拒绝执行, 不建会话', async () => {
-    const runner = createMakerHookSessionRunner({ log });
-    // dispatcher 是拿 inspect 的结果过的映射; 到这里 meta 已经指向别处
-    const outcome = await runner.run(
-      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/somewhere-else' }),
-    );
-
-    expect(outcome.status).toBe('error');
-    expect(outcome.errorMessage).toContain('刚被移动到别的目录');
-    expect(fakeMaker.createSession).not.toHaveBeenCalled();
-  });
-
-  it('createSession 短路返回的活会话跑在别处 -> 关掉重建到校验过的目录再跑', async () => {
-    // maker.createSession 对已在 activeSessions 里的 id 直接返回既有实例, 忽略
-    // 传入的 workingDir —— 那个实例的 workDir 还指着移动前的目录
-    fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) => ({
-      ...makeFakeSession(opts.id ?? 'sess-old'),
-      workDir: 'D:/the-old-place',
-    }));
-    const runner = createMakerHookSessionRunner({ log });
-
-    const outcome = await runner.run(
-      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
-    );
-
-    // 只报错的话, 映射内 A->B 的合法移动会被永久拒绝到 app 重启
-    expect(outcome.status).toBe('ok');
-    expect(fakeMaker.closeSession).toHaveBeenCalledWith('sess-old');
-    expect(fakeMaker.createSession).toHaveBeenCalledTimes(2);
-  });
-
-  it('重建全程拿 per-session 发送锁(不从正在打字的桌面会话底下抽走实例)', async () => {
-    const order: string[] = [];
-    lockMock.impl = async (id, task) => {
-      order.push(`lock:${id}`);
-      const r = await task();
-      order.push(`unlock:${id}`);
-      return r;
-    };
-    fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) => ({
-      ...makeFakeSession(opts.id ?? 'sess-old'),
-      workDir: 'D:/the-old-place',
-    }));
-    fakeMaker.closeSession.mockImplementationOnce(async (id: string) => {
-      order.push(`close:${id}`);
-    });
-    const runner = createMakerHookSessionRunner({ log });
-
-    const outcome = await runner.run(
-      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
-    );
-
-    expect(outcome.status).toBe('ok');
-    // 关闭与重建都必须发生在锁内
-    expect(order).toEqual(['lock:sess-old', 'close:sess-old', 'unlock:sess-old']);
-  });
-
-  it('重建后仍拿到旧实例 -> 这一轮不跑(不在旧目录里执行)', async () => {
-    // 关闭后 activeSessions 清理还没落地的情形: 两次都拿到旧实例
-    const stale = async (opts: { id?: string }) => ({
-      ...makeFakeSession(opts.id ?? 'sess-old'),
-      workDir: 'D:/the-old-place',
-    });
-    fakeMaker.createSession.mockImplementationOnce(stale).mockImplementationOnce(stale);
-    const runner = createMakerHookSessionRunner({ log });
-
-    const outcome = await runner.run(
-      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
-    );
-
-    expect(outcome.status).toBe('error');
-    expect(outcome.errorMessage).toContain('刚换了工作目录');
-  });
-
-  it('准备期间失去授权 -> send 之前拦下, 消息不进 agent', async () => {
-    const runner = createMakerHookSessionRunner({ log });
-
-    const outcome = await runner.run(baseReq({ isStillAuthorized: () => false }));
-
-    expect(outcome.status).toBe('error');
-    expect(outcome.errorMessage).toContain('已不在工作目录映射里');
-    const session = await fakeMaker.createSession.mock.results[0].value;
-    expect(session.send).not.toHaveBeenCalled();
-  });
-
-  it('目录一致 -> 照常执行; 新建路径不带该字段也不受影响', async () => {
-    const runner = createMakerHookSessionRunner({ log });
-
-    const reused = await runner.run(
-      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
-    );
-    expect(reused.status).toBe('ok');
-
-    const created = await runner.run(baseReq({}));
-    expect(created.status).toBe('ok');
   });
 });
 

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -309,6 +309,32 @@ describe('hook session 精确接管边界', () => {
   });
 });
 
+describe('执行前按权威 meta 收口校验工作目录', () => {
+  it('meta.workDir 与 dispatcher 校验过的目录不符 -> 拒绝执行, 不建会话', async () => {
+    const runner = createMakerHookSessionRunner({ log });
+    // dispatcher 是拿 inspect 的结果过的映射; 到这里 meta 已经指向别处
+    const outcome = await runner.run(
+      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/somewhere-else' }),
+    );
+
+    expect(outcome.status).toBe('error');
+    expect(outcome.errorMessage).toContain('刚被移动到别的目录');
+    expect(fakeMaker.createSession).not.toHaveBeenCalled();
+  });
+
+  it('目录一致 -> 照常执行; 新建路径不带该字段也不受影响', async () => {
+    const runner = createMakerHookSessionRunner({ log });
+
+    const reused = await runner.run(
+      baseReq({ sessionId: 'sess-old', isNew: false, expectedWorkingDir: 'D:/repo' }),
+    );
+    expect(reused.status).toBe('ok');
+
+    const created = await runner.run(baseReq({}));
+    expect(created.status).toBe('ok');
+  });
+});
+
 describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () => {
   it('isNew: touchUserSendInDb 在 sessions:created 广播之前落库, onAccepted 再 bump 一次', async () => {
     const runner = createMakerHookSessionRunner({ log });

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -362,6 +362,17 @@ describe('执行前按权威 meta 收口校验工作目录', () => {
     expect(outcome.errorMessage).toContain('刚换了工作目录');
   });
 
+  it('准备期间失去授权 -> send 之前拦下, 消息不进 agent', async () => {
+    const runner = createMakerHookSessionRunner({ log });
+
+    const outcome = await runner.run(baseReq({ isStillAuthorized: () => false }));
+
+    expect(outcome.status).toBe('error');
+    expect(outcome.errorMessage).toContain('已不在工作目录映射里');
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    expect(session.send).not.toHaveBeenCalled();
+  });
+
   it('目录一致 -> 照常执行; 新建路径不带该字段也不受影响', async () => {
     const runner = createMakerHookSessionRunner({ log });
 

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -334,6 +334,16 @@ describe('真正要跑的那个 live session 的目录也要过映射', () => {
     expect(session.send).not.toHaveBeenCalled();
   });
 
+  it('新建路径不走这道判定(拦下只会留空会话 + 孤儿 worktree)', async () => {
+    const runner = createMakerHookSessionRunner({ log });
+
+    // 新会话的 id 刚生成, activeSessions 里不可能有旧实例, 错配不存在;
+    // 而此时 agent 已启动、会话行已插入、预建 worktree 还注册着
+    const outcome = await runner.run(baseReq({ isDirAuthorized: () => false }));
+
+    expect(outcome.status).toBe('ok');
+  });
+
   it('活实例的目录仍在映射内 -> 照常执行(映射内的移动不受影响)', async () => {
     const runner = createMakerHookSessionRunner({ log });
 

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -74,12 +74,18 @@ export function createHookBindingStore(deps: {
    */
   function namespaceFor(data: BindingFile, connectionId: string): Record<string, BindingRow> {
     const ns: unknown = data[connectionId];
-    if (!ns || typeof ns !== 'object' || Array.isArray(ns)) {
-      const fresh: Record<string, BindingRow> = {};
-      data[connectionId] = fresh;
-      return fresh;
+    // 一律搬进 null 原型对象再写: externalKey 是渠道来的不可信输入, 直接拿它当
+    // 动态键写进普通对象时, `__proto__` 这类键会改到原型上去(原型污染), 结构和
+    // 落盘的 JSON 都会变得不可预期。同目录 store.ts 的 EMPTY_ACCOUNTS 同款做法
+    // (PR #733 review 指出)。
+    const fresh: Record<string, BindingRow> = Object.create(null) as Record<string, BindingRow>;
+    if (ns && typeof ns === 'object' && !Array.isArray(ns)) {
+      for (const [key, row] of Object.entries(ns as Record<string, BindingRow>)) {
+        fresh[key] = row;
+      }
     }
-    return ns as Record<string, BindingRow>;
+    data[connectionId] = fresh;
+    return fresh;
   }
 
   return {

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -3,65 +3,35 @@
  * ---------------------------------------------------------------------------
  * externalKey -> sessionId 映射存储(协议铁律「同 key 同 session」的落地)。
  *
- * 结构:
- * { [connectionId]: { [externalKey]: { sessionId, workingDir, authority, updatedAt } } }
+ * 结构: { [connectionId]: { [externalKey]: { sessionId, updatedAt } } }
  * —— 以 connectionId 为命名空间隔离, 两个 hook server 的同名 key 不会串台。
  * 持久化为 <userData>/hook-bindings.json(原子写), 跨 app 重启保持会话连续性。
  * 体量: 每 thread/issue 一条, 实际规模远小于消息量, JSON 文件足够;
  * 若未来需要清理策略再升级 localDb 表。
  *
- * workingDir + authority 记录**上次确认这条绑定可用时**的工作目录, 以及那次
- * 是凭什么放行的。dispatcher 靠这两个字段区分三件本来看起来一样的事:
- * 「用户在桌面端把对话移出了工作目录映射」(目录相对快照变了 -> 跟随, 并把
- * authority 记为 local-move)、「上一条消息已按本地移动放行过」(目录没再变且
- * authority=local-move -> 继续跟随, 否则跟随只生效一次)、「用户改动了工作
- * 目录映射」(目录没变且 authority=workspace -> 撤权, 丢绑定重建)。
- * 老文件没有这两个字段 = null/undefined, 判定按保守侧(见 resolveTarget)。
+ * **这里刻意不存任何授权状态。** 一条绑定能否继续用, 每次都由 dispatcher 现场
+ * 按工作目录映射判定(见 resolveTarget) —— 映射是「远端能驱动哪些本地目录」的
+ * 唯一边界, 判定无状态, 也就没有过期凭据、在途窗口、回滚这些东西可言。
+ * 早期版本曾在这里存 workingDir 快照 + authority 以支持「对话被移出映射后继续
+ * 跟随」, 那套例外要求绑定文件与会话库跨两次无事务的写保持一致, 边界条件按指数
+ * 增长(PR #653 / #669 十轮 review 的全部发现都出自那块); 现改为移出映射即断开
+ * 并向渠道说明, 这两个字段随之删除。老文件里的残留字段读取时忽略, 下次写入自然
+ * 清掉。
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 
-/**
- * 上次放行这条绑定的依据:
- * - 'workspace': 目录当时落在工作目录映射(或内置对话根)内, 授权随映射走 ——
- *   映射被改/删且目录没动时即失效(撤权)。
- * - 'local-move': 用户在桌面端把对话移出了映射, 由这次**本地**移动授权 ——
- *   目录不在映射内也继续复用, 直到它再被移动(重新判定)或移回映射内。
- */
-export type HookBindingAuthority = 'workspace' | 'local-move';
-
-/** 一条绑定的完整视图(get 只要 sessionId 时用 get, 需要目录快照时用 getEntry)。 */
-export interface HookBindingEntry {
-  sessionId: string;
-  /** 上次确认时会话的工作目录; null = 老数据未记录快照。 */
-  workingDir: string | null;
-  /** 上次放行的依据; null = 老数据未记录。 */
-  authority: HookBindingAuthority | null;
-}
-
 export interface HookBindingStore {
   get(connectionId: string, externalKey: string): string | null;
-  /** 含工作目录快照与授权来源的绑定视图; 不存在时 null。 */
-  getEntry(connectionId: string, externalKey: string): HookBindingEntry | null;
-  /** 整行覆盖写: 省略 workingDir / authority 等于把它们清空, 调用方应显式传。 */
-  set(
-    connectionId: string,
-    externalKey: string,
-    sessionId: string,
-    workingDir?: string | null,
-    authority?: HookBindingAuthority | null,
-  ): void;
+  /** 整行覆盖写(同 key 重复派发时刷新 updatedAt)。 */
+  set(connectionId: string, externalKey: string, sessionId: string): void;
   /** 删除单条绑定(session 失效重建前清理)。 */
   remove(connectionId: string, externalKey: string): void;
 }
 
 interface BindingRow {
   sessionId: string;
-  /** 见文件头: 上次确认时的工作目录快照; 缺省 = 老数据。 */
-  workingDir?: string | null;
-  /** 见文件头: 上次放行的依据; 缺省 = 老数据。 */
-  authority?: HookBindingAuthority | null;
   updatedAt: number;
 }
 
@@ -97,25 +67,9 @@ export function createHookBindingStore(deps: {
       const row = readAll()[connectionId]?.[externalKey];
       return typeof row?.sessionId === 'string' ? row.sessionId : null;
     },
-    getEntry(connectionId, externalKey) {
-      const row = readAll()[connectionId]?.[externalKey];
-      if (typeof row?.sessionId !== 'string') return null;
-      return {
-        sessionId: row.sessionId,
-        workingDir: typeof row.workingDir === 'string' ? row.workingDir : null,
-        // 未知字面量(手改文件 / 更早的实验值)按"没有授权记录"处理, fail closed
-        authority:
-          row.authority === 'workspace' || row.authority === 'local-move' ? row.authority : null,
-      };
-    },
-    set(connectionId, externalKey, sessionId, workingDir, authority) {
+    set(connectionId, externalKey, sessionId) {
       const data = readAll();
-      (data[connectionId] ??= {})[externalKey] = {
-        sessionId,
-        ...(typeof workingDir === 'string' && workingDir.length > 0 ? { workingDir } : {}),
-        ...(authority === 'workspace' || authority === 'local-move' ? { authority } : {}),
-        updatedAt: Date.now(),
-      };
+      (data[connectionId] ??= {})[externalKey] = { sessionId, updatedAt: Date.now() };
       writeAll(data);
     },
     remove(connectionId, externalKey) {

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -24,7 +24,11 @@ import path from 'node:path';
 
 export interface HookBindingStore {
   get(connectionId: string, externalKey: string): string | null;
-  /** 整行覆盖写(同 key 重复派发时刷新 updatedAt)。 */
+  /**
+   * 整行覆盖写。只在绑定真正变化时调用(新建会话、legacy 命名空间迁移、接管)——
+   * 常规复用不写, 所以 updatedAt 是"这条绑定上次被改写"的时间, **不是**"上次被
+   * 用到"的时间(PR #733 review 指出)。
+   */
   set(connectionId: string, externalKey: string, sessionId: string): void;
   /** 删除单条绑定(session 失效重建前清理)。 */
   remove(connectionId: string, externalKey: string): void;

--- a/apps/desktop/src/main/hook-control/bindings.ts
+++ b/apps/desktop/src/main/hook-control/bindings.ts
@@ -62,22 +62,41 @@ export function createHookBindingStore(deps: {
     fs.renameSync(tmp, filePath);
   }
 
+  /**
+   * 取出可写的命名空间。readAll 只校验了顶层是对象, 二层没校验 —— 文件被手工
+   * 编辑或半截写坏成 `{"conn-1": "oops"}` 时, `??=` 不会替换字符串, 随后给它赋
+   * 属性在严格模式(ESM)下抛 TypeError, 绑定就再也落不了盘。坏数据直接换成空
+   * 命名空间: 大不了重开一次会话, 不能卡死写入(PR #733 review 指出)。
+   */
+  function namespaceFor(data: BindingFile, connectionId: string): Record<string, BindingRow> {
+    const ns: unknown = data[connectionId];
+    if (!ns || typeof ns !== 'object' || Array.isArray(ns)) {
+      const fresh: Record<string, BindingRow> = {};
+      data[connectionId] = fresh;
+      return fresh;
+    }
+    return ns as Record<string, BindingRow>;
+  }
+
   return {
     get(connectionId, externalKey) {
-      const row = readAll()[connectionId]?.[externalKey];
+      const ns: unknown = readAll()[connectionId];
+      if (!ns || typeof ns !== 'object' || Array.isArray(ns)) return null;
+      const row = (ns as Record<string, BindingRow | undefined>)[externalKey];
       return typeof row?.sessionId === 'string' ? row.sessionId : null;
     },
     set(connectionId, externalKey, sessionId) {
       const data = readAll();
-      (data[connectionId] ??= {})[externalKey] = { sessionId, updatedAt: Date.now() };
+      namespaceFor(data, connectionId)[externalKey] = { sessionId, updatedAt: Date.now() };
       writeAll(data);
     },
     remove(connectionId, externalKey) {
       const data = readAll();
-      if (data[connectionId]?.[externalKey]) {
-        delete data[connectionId][externalKey];
-        writeAll(data);
-      }
+      const ns: unknown = data[connectionId];
+      if (!ns || typeof ns !== 'object' || Array.isArray(ns)) return;
+      if (!Object.hasOwn(ns, externalKey)) return;
+      delete (ns as Record<string, BindingRow>)[externalKey];
+      writeAll(data);
     },
   };
 }

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -50,7 +50,7 @@ import {
 
 import { HOOK_CHAT_WORKSPACE_ALIAS } from '../../shared/hookControlIpc.js';
 import type { HookConnectionConfig } from './store.js';
-import type { HookBindingAuthority, HookBindingStore } from './bindings.js';
+import type { HookBindingStore } from './bindings.js';
 
 /** 会话执行器抽象 —— 生产实现 session-runner.ts(包 maker), 测试注入假的。 */
 export interface HookSessionRunner {
@@ -229,24 +229,18 @@ export function isPathWithin(base: string, target: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
-/** 两个路径是否指向同一目录(同 isPathWithin 的规范化口径)。 */
-export function isSamePath(a: string, b: string): boolean {
-  return normalizePathForCompare(a) === normalizePathForCompare(b);
-}
-
 /**
- * 会话被用户移出工作目录映射后, 回给渠道的一次性说明(Slack / Telegram 侧文案
- * 不进 locale, 与 interactions.ts 的卡片按钮同规硬编码中文)。
- */
-const NOTICE_SESSION_MOVED = 'ℹ️ 这个对话已被移动到新的工作目录，后续消息都在新目录里执行。';
-/**
- * 重建说明必须如实: 旧绑定被丢弃后同一个 externalKey 立刻指向新会话, 光把
- * 老目录加回映射**不会**自动接回原对话(那条 thread 已经绑到新的了), 只有先
- * 恢复目录、再用会话选择重新指定原对话才接得回来 —— 两步缺一不可。
+ * 原对话不再落在工作目录映射内时(被移到映射外的项目, 或映射本身被改/删),
+ * 回给渠道的一次性说明(Slack / Telegram 侧文案不进 locale, 与 interactions.ts
+ * 的卡片按钮同规硬编码中文)。
+ *
+ * 必须如实: 旧绑定被丢弃后同一个 externalKey 立刻指向新对话, 光把目录加进映射
+ * **不会**自动接回原对话(那条 thread 已经绑到新的了), 只有先让目录进映射、再用
+ * 对话选择重新指定原对话才接得回来 —— 两步缺一不可。
  */
 const NOTICE_SESSION_RECREATED =
   'ℹ️ 原对话已不在可用的工作目录里，这条消息起换用了新对话，原对话的上下文不会带过来。' +
-  '想接回原对话：先到 Cindy 的 设置 → 远程连接 → 工作目录映射 把它所在的目录加回来，' +
+  '想接回原对话：先到 Cindy 的 设置 → 远程连接 → 工作目录映射 把它所在的目录加进来，' +
   '再在这里用对话选择重新指定它。';
 const NOTICE_SESSION_GONE = 'ℹ️ 原对话已被归档或删除，这条消息起换用了新对话。';
 
@@ -592,13 +586,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }
       // 接管路径刚校验过白名单, 授权来源恒为 workspace(远端不能凭接管把会话
       // 带出映射 —— 越界的 sessionId 在上面就被 workspace_not_allowed 打回)
-      bindings.set(
-        connectionId,
-        payload.externalKey,
-        payload.sessionId,
-        info.workingDir,
-        'workspace',
-      );
+      bindings.set(connectionId, payload.externalKey, payload.sessionId);
       return {
         run: {
           sessionId: payload.sessionId,
@@ -630,21 +618,15 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     // account/provider namespace may read it only as a candidate; it is moved
     // after current-account DB existence + workspace allowlist checks pass.
     const legacyNamespace = connectionId.endsWith(':slack') ? 'slack' : null;
-    const namespacedEntry = bindings.getEntry(connectionId, payload.externalKey);
-    const legacyEntry =
-      namespacedEntry === null && legacyNamespace !== null
-        ? bindings.getEntry(legacyNamespace, payload.externalKey)
+    const namespacedBound = bindings.get(connectionId, payload.externalKey);
+    const legacyBound =
+      namespacedBound === null && legacyNamespace !== null
+        ? bindings.get(legacyNamespace, payload.externalKey)
         : null;
-    const namespacedBound = namespacedEntry?.sessionId ?? null;
-    const legacyBound = legacyEntry?.sessionId ?? null;
-    const boundEntry = namespacedEntry ?? legacyEntry;
-    const bound = boundEntry?.sessionId ?? null;
-    const migrateLegacyBinding = (
-      workingDir: string | null,
-      authority: HookBindingAuthority | null,
-    ): void => {
+    const bound = namespacedBound ?? legacyBound;
+    const migrateLegacyBinding = (): void => {
       if (!legacyBound || !legacyNamespace) return;
-      bindings.set(connectionId, payload.externalKey, legacyBound, workingDir, authority);
+      bindings.set(connectionId, payload.externalKey, legacyBound);
       bindings.remove(legacyNamespace, payload.externalKey);
     };
     if (bound) {
@@ -683,46 +665,20 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       const inAllowedRoot =
         info !== null && (isChat ? inDialogueRoot(info.workingDir) : inWhitelist(info.workingDir));
       const usable = info?.usable === true && info.workingDir !== null;
-      /** 会话目录与绑定快照一致 = 自上次确认以来它没被动过。 */
-      const sameAsSnapshot =
-        usable &&
-        boundEntry?.workingDir != null &&
-        isSamePath(boundEntry.workingDir, info!.workingDir!);
       /**
-       * 白名单外但**目录相对快照变过** = 用户在桌面端把这条会话「移动到项目」了。
-       * 目录是本地用户亲手选的(不是远端指定的 —— 远端只能在接管路径里选白名单
-       * 内的会话), 属本地授权, 跟随即可; 否则同一个 thread 每条消息都会重开新
-       * 会话, 破坏「同 key 同 session」。
+       * 复用与否只看这一条: 会话当前的工作目录仍落在工作目录映射(或内置对话根)
+       * 内。判定完全无状态 —— 绑定里不存快照也不存授权, 每条消息现场重算。
+       *
+       * 刻意**不**支持「被移出映射后继续跟随」: 那需要在映射之外发放一条例外,
+       * 而例外必须跨「绑定文件」与「会话库」两次无事务的写保持一致, 中间还夹着
+       * 随时可能到达的 IM 消息 —— PR #653 / #669 为此叠了在途标记、TTL、回滚、
+       * CAS、补偿五层状态, 十轮 review 仍在出新的组合边界。现在的语义是: 移出
+       * 映射 = 断开绑定, 并向渠道说明怎么恢复(见 NOTICE_SESSION_RECREATED)。
+       * 在映射**内**换目录仍然无感跟随, 因为那本就在边界内。
        */
-      const movedNow =
-        !inAllowedRoot && usable && boundEntry?.workingDir != null && !sameAsSnapshot;
-      /**
-       * 上一条消息已按本地移动放行过, 且此后目录没再变 —— 必须继续认这份授权。
-       * 少了这一条, 跟随只在移动后的第一条消息生效: 那次会把快照更新成新目录,
-       * 下一条消息 movedNow 就变回 false, 绑定又被丢掉(PR #653 review 实测)。
-       */
-      const stillLocallyAuthorized =
-        !inAllowedRoot && usable && boundEntry?.authority === 'local-move' && sameAsSnapshot;
-      // 目录没变、也没有本地移动授权而校验失败, 才是「工作目录映射被改/删」的
-      // 撤权语义, 仍丢绑定重建。老绑定没有快照时同样走保守侧(正常复用会回填)。
-      if (usable && (inAllowedRoot || movedNow || stillLocallyAuthorized)) {
+      if (usable && inAllowedRoot) {
         const workingDir = info!.workingDir!;
-        const authority: HookBindingAuthority = inAllowedRoot ? 'workspace' : 'local-move';
-        migrateLegacyBinding(workingDir, authority);
-        // 快照回填 / 跟随: 只在目录或授权来源变化时落盘, 常规复用不产生写。
-        if (
-          namespacedEntry !== null &&
-          (namespacedEntry.workingDir === null ||
-            !isSamePath(namespacedEntry.workingDir, workingDir) ||
-            namespacedEntry.authority !== authority)
-        ) {
-          bindings.set(connectionId, payload.externalKey, bound, workingDir, authority);
-        }
-        if (movedNow) {
-          log.info(
-            `hook session ${bound} followed a desktop-side move to ${workingDir} (outside the workspace map)`,
-          );
-        }
+        migrateLegacyBinding();
         return {
           run: {
             sessionId: bound,
@@ -737,8 +693,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             attachments: payload.attachments,
             origin,
           },
-          // 只在"这次刚发现被移动"时说明一次; 之后的消息静默沿用该授权
-          ...(movedNow ? { notice: NOTICE_SESSION_MOVED } : {}),
         };
       }
       bindings.remove(connectionId, payload.externalKey);
@@ -790,8 +744,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         if (prep.ok) void prep.cleanup().catch(() => undefined);
       }
     }
-    // 新建会话跑在别名目录(或对话根)里, 授权随映射走
-    bindings.set(connectionId, payload.externalKey, sessionId, runDir, 'workspace');
+    // 新建会话跑在别名目录(或对话根)里, 是否还能复用每次现场按映射判定
+    bindings.set(connectionId, payload.externalKey, sessionId);
     // 标题带 provider 名: externalKey 约定为 `<providerId>:<渠道内标识>`,
     // 取前缀作 provider 名(如 team-slack), 比连接名(desktop 侧命名)更能
     // 说明"这条会话是谁驱动的"; 无前缀(非常规 key)时回退连接名

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -13,8 +13,10 @@
  *      - 不带(默认): 别名解析(映射即白名单)-> binding 查 externalKey ->
  *        复用或新建并落绑定。复用与否**每条消息现场重算**, 唯一依据是会话
  *        当前的工作目录是否仍落在工作目录映射(或内置对话根)内 —— 映射是
- *        「远端能驱动哪些本地目录」的唯一边界, 判定不带任何状态。移出映射
- *        (被移到别处 / 映射被改删)= 丢绑定重建, 并回一条说明怎么恢复;
+ *        「远端能驱动哪些本地目录」的唯一边界, 判定不带任何**持久化授权**状态
+ *        (进程内仍有 awaitingPersist 这类短生命周期记账, 但它们只是收窄判定,
+ *        本身不构成放行依据)。移出映射(被移到别处 / 映射被改删)= 丢绑定重建,
+ *        并回一条说明怎么恢复;
  *   3. 排队: 目标 session 正在跑 turn 时 FIFO 排队, ack 回 queued + 位置;
  *      turn 收口后自动 drain;
  *   4. 回推: turn.end 经当前连接发送; 连接不在线时缓存, 重连(onConnected)
@@ -48,6 +50,7 @@ import {
 } from '@cindy/slack-hook-protocol';
 
 import { HOOK_CHAT_WORKSPACE_ALIAS } from '../../shared/hookControlIpc.js';
+import { isPathWithin } from './paths.js';
 import type { HookConnectionConfig } from './store.js';
 import type { HookBindingStore } from './bindings.js';
 
@@ -223,23 +226,6 @@ export interface HookDispatcher {
 const MAX_QUEUE_PER_SESSION = 20;
 /** 单连接离线 turn.end 缓存上限(FIFO 丢最老)。 */
 const MAX_PENDING_TURN_ENDS = 100;
-
-/** 路径比较前的规范化。Windows 大小写不敏感(规则 15)。 */
-function normalizePathForCompare(p: string): string {
-  const resolved = path.resolve(p);
-  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
-}
-
-/** target 是否落在 base 目录内(含相等)。Windows 大小写不敏感(规则 15)。 */
-export function isPathWithin(base: string, target: string): boolean {
-  const rel = path.relative(normalizePathForCompare(base), normalizePathForCompare(target));
-  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
-}
-
-/** 两个路径是否指向同一目录(同 isPathWithin 的规范化口径)。 */
-export function isSamePath(a: string, b: string): boolean {
-  return normalizePathForCompare(a) === normalizePathForCompare(b);
-}
 
 /**
  * 原对话不再落在工作目录映射内时(被移到映射外的项目, 或映射本身被改/删),
@@ -515,15 +501,36 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     };
 
     let outcome: HookRunOutcome;
-    try {
-      outcome = await runner.run({ ...task.run, onProgress, onInteraction, onInteractionCancel });
-    } catch (err) {
+    /**
+     * 开跑前按当前映射再确认一次(见 dirStillAllowed)。resolveTarget 到这里之间
+     * 隔着排队与若干 await, 映射随时可能被改/删; 这是"每条消息按映射现场重算"
+     * 在执行侧的收口。expectedWorkingDir 为空 = 新建路径, 目录刚在上面算出来。
+     */
+    const guardDir = task.run.expectedWorkingDir ?? null;
+    if (guardDir !== null && !dirStillAllowed(task.connectionId, guardDir)) {
+      // 路径不进日志(规则: 用集中 PII helper, 而 dispatcher 是不碰 Electron 的
+      // 纯逻辑模块, 拿不到它)—— requestId 足够定位。
+      log.info(
+        `hook task ${task.requestId} aborted before execution: its directory left the workspace map`,
+      );
       outcome = {
         status: 'error',
         finalText: '',
-        errorMessage: err instanceof Error ? err.message : String(err),
+        errorMessage:
+          '这个对话所在的目录已不在工作目录映射里，本条消息没有执行。把它加回 设置 → 远程连接 → 工作目录映射 后再发一次。',
         durationMs: 0,
       };
+    } else {
+      try {
+        outcome = await runner.run({ ...task.run, onProgress, onInteraction, onInteractionCancel });
+      } catch (err) {
+        outcome = {
+          status: 'error',
+          finalText: '',
+          errorMessage: err instanceof Error ? err.message : String(err),
+          durationMs: 0,
+        };
+      }
     }
     runningByRequest.delete(requestKey);
     if (!isCurrentGeneration(task.accountGeneration)) {
@@ -569,6 +576,21 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       running.add(sessionId);
       startExecution(next);
     }
+  }
+
+  /**
+   * 这个目录**此刻**还落在该连接的工作目录映射(或内置对话根)内吗。
+   *
+   * 每次真正开跑之前都要问一遍: 排队期间用户可能把映射改了或删了, 而队列
+   * drain 不再走 resolveTarget —— 那时会话目录和 expectedWorkingDir 都没变,
+   * runner 侧那道"目录有没有被移走"的比对根本看不见这次撤权, 排着的消息就会
+   * 在已撤权的目录里执行(PR #733 review 指出)。连接本身没了也按撤权处理。
+   */
+  function dirStillAllowed(connectionId: string, dir: string): boolean {
+    const config = getConnection(connectionId);
+    if (!config) return false;
+    if (Object.values(config.workspaces).some((root) => isPathWithin(root, dir))) return true;
+    return dialogue !== undefined && isPathWithin(dialogue.rootDir(), dir);
   }
 
   function startExecution(task: PendingTask): void {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -503,10 +503,15 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     let outcome: HookRunOutcome;
     /**
      * 开跑前按当前映射再确认一次(见 dirStillAllowed)。resolveTarget 到这里之间
-     * 隔着排队与若干 await, 映射随时可能被改/删; 这是"每条消息按映射现场重算"
-     * 在执行侧的收口。expectedWorkingDir 为空 = 新建路径, 目录刚在上面算出来。
+     * 隔着排队与若干 await(新建路径还要等 worktree 预建 / 对话目录分配), 映射
+     * 随时可能被改/删; 这是"每条消息按映射现场重算"在执行侧的收口。
+     *
+     * 新建路径没有 expectedWorkingDir(它是给 runner 比对 session meta 用的,
+     * 新会话还没有 meta), 回退到 workingDir —— 那就是这次要跑的目录。少了这个
+     * 回退, 新建路径整条绕过执行侧收口(PR #733 review 指出)。用 `||` 而非 `??`:
+     * workingDir 可能是空串占位, 空串过 isPathWithin 会 resolve 成 cwd。
      */
-    const guardDir = task.run.expectedWorkingDir ?? null;
+    const guardDir = task.run.expectedWorkingDir || task.run.workingDir || null;
     if (guardDir !== null && !dirStillAllowed(task.connectionId, guardDir)) {
       // 路径不进日志(规则: 用集中 PII helper, 而 dispatcher 是不碰 Electron 的
       // 纯逻辑模块, 拿不到它)—— requestId 足够定位。
@@ -567,7 +572,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }),
     );
     running.delete(sessionId);
-    // run 返回 = session 一定已经建好落库, 免检窗口到此为止
+    // 本次执行收口, 免检窗口到此为止。注意**不能**断言"session 一定已落库":
+    // 上面可能因映射撤权根本没进 runner, runner 也可能在 createSession 之前就
+    // 失败(PR #733 review 指出)。这里删掉只是让后续消息回到正常判定 —— 那两种
+    // 情况下 inspect 查不到会话, 走的是丢绑定重建的保守侧, 方向正确。
     awaitingPersist.delete(sessionId);
     const queue = queues.get(sessionId);
     const next = queue?.shift();

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -93,14 +93,6 @@ export interface HookRunRequest {
    * 来源偏好(workspaceProviderSourceStore)。缺省 = 老 server 未带 workspace。
    */
   workspaceAlias?: string;
-  /**
-   * 复用/接管路径下 dispatcher 校验通过的那个目录。runner 以 session meta 的
-   * workDir 为执行权威(会覆盖上面的 workingDir), 而 dispatcher 的校验发生在
-   * 读 meta 之前 —— 中间这段里会话被移走的话, 校验过的目录和真正执行的目录就
-   * 不是同一个了。runner 读到权威 workDir 后必须比对它, 不一致即拒绝执行
-   * (PR #733 review 指出)。null / 省略 = 不比对(新建路径)。
-   */
-  expectedWorkingDir?: string | null;
   title: string | null;
   prompt: string;
   /** 本次派发携带的入站附件(base64); 无则省略。runner 解码落盘后喂给 agent。 */
@@ -130,14 +122,6 @@ export interface HookRunRequest {
   }) => void;
   /** 交互已在本端收口(超时默认 / turn 结束), 通知 server 改写卡片。 */
   onInteractionCancel?: (interactionId: string, reason: string) => void;
-  /**
-   * "这个任务此刻还被授权吗"—— dispatcher 注入的实时判定(工作目录仍在映射内且
-   * 连接仍启用)。runner 必须在**真正把消息交给 agent 之前的最后一个同步点**再
-   * 问一次: dispatcher 那道校验之后, runner 还要 await 一串准备工作, 这段窗口
-   * 里用户完全可能改掉映射或停用连接(PR #733 review 指出)。
-   * 省略 = 不再校验(测试与旧调用方)。
-   */
-  isStillAuthorized?: () => boolean;
 }
 
 export interface HookRunOutcome {
@@ -521,12 +505,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
      * 隔着排队与若干 await(新建路径还要等 worktree 预建 / 对话目录分配), 映射
      * 随时可能被改/删; 这是"每条消息按映射现场重算"在执行侧的收口。
      *
-     * 新建路径没有 expectedWorkingDir(它是给 runner 比对 session meta 用的,
-     * 新会话还没有 meta), 回退到 workingDir —— 那就是这次要跑的目录。少了这个
-     * 回退, 新建路径整条绕过执行侧收口(PR #733 review 指出)。用 `||` 而非 `??`:
-     * workingDir 可能是空串占位, 空串过 isPathWithin 会 resolve 成 cwd。
+     * workingDir 就是这一轮要跑的目录(复用/接管路径是 dispatcher 刚校验过的
+     * 那个, 新建路径是刚算出来的 runDir)。用 `||` 而非 `??`: 它可能是空串占位,
+     * 而空串过 isPathWithin 会 resolve 成 cwd, 那就成了一条假放行。
      */
-    const guardDir = task.run.expectedWorkingDir || task.run.workingDir || null;
+    const guardDir = task.run.workingDir || null;
     if (guardDir !== null && !dirStillAllowed(task.connectionId, guardDir)) {
       // 路径不进日志(规则: 用集中 PII helper, 而 dispatcher 是不碰 Electron 的
       // 纯逻辑模块, 拿不到它)—— requestId 足够定位。
@@ -539,7 +522,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         status: 'error',
         finalText: '',
         errorMessage:
-          '这个对话所在的目录已不在工作目录映射里，本条消息没有执行。把它加回 设置 → 远程连接 → 工作目录映射 后再发一次。',
+          '这个对话所在的目录已不在工作目录映射里，本条消息没有执行。把它所在的目录加进 设置 → 远程连接 → 工作目录映射 后再发一次。',
         durationMs: 0,
       };
     } else {
@@ -549,10 +532,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           onProgress,
           onInteraction,
           onInteractionCancel,
-          // runner 内部还要 await 一串准备工作(provider 解析、建会话、写库、附件
-          // 落盘)才到真正的 send —— 这段里映射照样可能被撤。把判定本身传下去,
-          // 让它在最后那个同步点再问一次(PR #733 review 指出)。
-          isStillAuthorized: () => dirStillAllowed(task.connectionId, guardDir ?? ''),
         });
       } catch (err) {
         outcome = {
@@ -616,9 +595,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
    * 这个目录**此刻**还落在该连接的工作目录映射(或内置对话根)内吗。
    *
    * 每次真正开跑之前都要问一遍: 排队期间用户可能把映射改了或删了, 而队列
-   * drain 不再走 resolveTarget —— 那时会话目录和 expectedWorkingDir 都没变,
-   * runner 侧那道"目录有没有被移走"的比对根本看不见这次撤权, 排着的消息就会
-   * 在已撤权的目录里执行(PR #733 review 指出)。连接本身没了也按撤权处理。
+   * drain 不再走 resolveTarget, 而会话目录本身没变 —— 变的只是"映射还认不认
+   * 它", 所以必须在这里重新查一次当前映射, 否则排着的消息会在已撤权的目录里
+   * 执行(PR #733 review 指出)。连接本身没了或被停用, 同样按撤权处理。
    */
   function dirStillAllowed(connectionId: string, dir: string): boolean {
     const config = getConnection(connectionId);
@@ -700,8 +679,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           sessionId: payload.sessionId,
           isNew: false,
           workingDir: info.workingDir as string,
-          // 同复用路径: 校验与执行之间会话仍可能被移走, 由 runner 兜住
-          expectedWorkingDir: info.workingDir as string,
           agentKind,
           model,
           effort,
@@ -750,8 +727,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
        * 会排进一个建在已撤权目录里的会话(PR #733 review 指出)。
        */
       const pendingDir = awaitingPersist.get(bound) ?? null;
+      // 同下方的 inAllowedRoot: 用当前映射而不是入口快照 —— inspect 期间用户可能
+      // 刚把这个目录加回来(PR #733 review 指出)。
       const pendingStillAllowed =
-        pendingDir !== null && (isChat ? inDialogueRoot(pendingDir) : inWhitelist(pendingDir));
+        pendingDir !== null && (isChat ? inDialogueRoot(pendingDir) : inWhitelistNow(pendingDir));
       /**
        * 关键竞态防护: 绑定的 session 是本 dispatcher 刚建、**尚未落库**的
        * (inspect 查不到)且正在跑/排队时直接复用 —— 否则同 key 的后续消息会各开
@@ -780,9 +759,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             isNew: false,
             // 尚未落库, 没有 meta 可查 —— 用建它时那个刚重新过完映射校验的目录
             workingDir: pendingDir!,
-            // 落库后 runner 会拿 meta.workDir 覆盖上面这个值; 届时必须仍是同一
-            // 个目录, 否则这条消息就跑到校验过的目录之外去了
-            expectedWorkingDir: pendingDir!,
             agentKind,
             model,
             effort,
@@ -821,9 +797,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             sessionId: bound,
             isNew: false,
             workingDir,
-            // 上面这次校验和 runner 读 meta 之间会话仍可能被移走 —— runner 拿到
-            // 权威 workDir 后必须确认还是这个目录
-            expectedWorkingDir: workingDir,
             agentKind,
             model,
             effort,
@@ -1123,15 +1096,18 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
          * (PR #733 review 指出)。
          */
         const stillOurs = async (sessionId: string): Promise<boolean> => {
-          // 本 dispatcher 刚建、还没落库的会话 inspect 查不到(见 awaitingPersist),
-          // 但它建在哪是记着的 —— 用那个目录判, 否则紧跟着新建到来的 `/new` 会
-          // 静默失效。
-          const pendingDir = awaitingPersist.get(sessionId);
-          if (pendingDir !== undefined) return dirStillAllowed(connectionId, pendingDir);
           const info = await runner.inspect(sessionId);
           if (!isCurrentGeneration(admittedGeneration)) return false;
+          // 查得到就以它为准。**只有**真的查不到(会话刚建、还没落库)才退回
+          // awaitingPersist 里记的那个目录 —— 该表在整轮 turn 结束前都留着, 拿它
+          // 当捷径会让"已落库、随后被移出映射"的会话绕过这道闸
+          // (PR #733 review 指出)。
+          if (info === null) {
+            const pendingDir = awaitingPersist.get(sessionId);
+            return pendingDir !== undefined && dirStillAllowed(connectionId, pendingDir);
+          }
           return (
-            info?.usable === true &&
+            info.usable === true &&
             info.workingDir !== null &&
             dirStillAllowed(connectionId, info.workingDir)
           );

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -11,11 +11,10 @@
  *      - 带 sessionId(接管): session 必须存在且其工作目录落在本连接注册的
  *        别名路径内(白名单不因接管放松), 通过后把 externalKey 重绑到它;
  *      - 不带(默认): 别名解析(映射即白名单)-> binding 查 externalKey ->
- *        复用(且重校验白名单)或新建并落绑定; 白名单重校验失败时看绑定上的
- *        目录快照与授权来源: 目录相对快照变过 = 用户在桌面端把对话移出了
- *        映射(目录是本地用户亲手选的, 不是远端指定的)-> 跟随并记 local-move;
- *        目录没再变但已记过 local-move -> 继续认这份授权(否则跟随只生效一
- *        次); 两者都不满足 = 映射被改/删的撤权语义 -> 丢绑定重建;
+ *        复用或新建并落绑定。复用与否**每条消息现场重算**, 唯一依据是会话
+ *        当前的工作目录是否仍落在工作目录映射(或内置对话根)内 —— 映射是
+ *        「远端能驱动哪些本地目录」的唯一边界, 判定不带任何状态。移出映射
+ *        (被移到别处 / 映射被改删)= 丢绑定重建, 并回一条说明怎么恢复;
  *   3. 排队: 目标 session 正在跑 turn 时 FIFO 排队, ack 回 queued + 位置;
  *      turn 收口后自动 drain;
  *   4. 回推: turn.end 经当前连接发送; 连接不在线时缓存, 重连(onConnected)
@@ -630,13 +629,22 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       bindings.remove(legacyNamespace, payload.externalKey);
     };
     if (bound) {
-      // 关键竞态防护: 绑定的 session 正在本模块跑/排队(首次派发尚未落库,
-      // inspect 会查不到)时直接复用 —— 否则同 key 的连发消息会各开新 session,
-      // 破坏「同 key 同 session」铁律。
-      // 已声明的取舍: 该快路径不重校验白名单 —— 窗口仅限「用户改别名映射」与
-      // 「旧任务在跑」重叠的瞬间, 且此 session 本就是本连接刚创建的; 常规
-      // 复用路径(下方 inspect 分支)每次都重校验。
+      const info = await runner.inspect(bound);
+      if (!isCurrentGeneration(generation)) return { reject: 'disabled' };
+      /**
+       * 关键竞态防护: 绑定的 session 已派发但**尚未落库**(inspect 查不到)且
+       * 正在本模块跑/排队时直接复用 —— 否则同 key 的后续消息会各开新 session,
+       * 破坏「同 key 同 session」铁律。
+       *
+       * 严格限定在 `info === null` 这个窗口内: 一旦落库, 无论它是否在跑, 都要
+       * 走下面的映射校验。早期版本把「在跑/排队」整个当成免检快路径, 于是用户在
+       * 一轮任务执行期间把对话移出映射时, 新到的消息仍会排进这个 session ——
+       * 而 session-runner 的复用路径以 session meta 的 workDir 为权威(会覆盖
+       * 这里传的目录), 那条消息就真的在已移出映射的目录里执行了, 等于在
+       * 「每条消息现场按映射重算」上开了个洞(PR #733 review 指出)。
+       */
       if (
+        info === null &&
         namespacedBound !== null &&
         (running.has(bound) || (queues.get(bound)?.length ?? 0) > 0)
       ) {
@@ -644,8 +652,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           run: {
             sessionId: bound,
             isNew: false,
-            // 复用路径 workingDir 仅供参考(runner 以 session meta 为权威);
-            // chat 伪目录无别名映射, 给 dialogues 根占位
+            // 尚未落库, 没有 meta 可查; chat 伪目录无别名映射, 给 dialogues 根
+            // 占位。此时 session 只可能是本连接刚在映射内建出来的。
             workingDir: dir ?? dialogue?.rootDir() ?? '',
             agentKind,
             model,
@@ -658,8 +666,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           },
         };
       }
-      const info = await runner.inspect(bound);
-      if (!isCurrentGeneration(generation)) return { reject: 'disabled' };
       // 复用条件: 仍存在、可用、且仍在白名单内(别名映射可能已被用户改过);
       // chat 伪目录的会话住在 dialogues 根下, 按对话根校验
       const inAllowedRoot =

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -90,6 +90,14 @@ export interface HookRunRequest {
    * 来源偏好(workspaceProviderSourceStore)。缺省 = 老 server 未带 workspace。
    */
   workspaceAlias?: string;
+  /**
+   * 复用/接管路径下 dispatcher 校验通过的那个目录。runner 以 session meta 的
+   * workDir 为执行权威(会覆盖上面的 workingDir), 而 dispatcher 的校验发生在
+   * 读 meta 之前 —— 中间这段里会话被移走的话, 校验过的目录和真正执行的目录就
+   * 不是同一个了。runner 读到权威 workDir 后必须比对它, 不一致即拒绝执行
+   * (PR #733 review 指出)。null / 省略 = 不比对(新建路径)。
+   */
+  expectedWorkingDir?: string | null;
   title: string | null;
   prompt: string;
   /** 本次派发携带的入站附件(base64); 无则省略。runner 解码落盘后喂给 agent。 */
@@ -228,6 +236,11 @@ export function isPathWithin(base: string, target: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
+/** 两个路径是否指向同一目录(同 isPathWithin 的规范化口径)。 */
+export function isSamePath(a: string, b: string): boolean {
+  return normalizePathForCompare(a) === normalizePathForCompare(b);
+}
+
 /**
  * 原对话不再落在工作目录映射内时(被移到映射外的项目, 或映射本身被改/删),
  * 回给渠道的一次性说明(Slack / Telegram 侧文案不进 locale, 与 interactions.ts
@@ -241,7 +254,13 @@ const NOTICE_SESSION_RECREATED =
   'ℹ️ 原对话已不在可用的工作目录里，这条消息起换用了新对话，原对话的上下文不会带过来。' +
   '想接回原对话：先到 Cindy 的 设置 → 远程连接 → 工作目录映射 把它所在的目录加进来，' +
   '再在这里用对话选择重新指定它。';
-const NOTICE_SESSION_GONE = 'ℹ️ 原对话已被归档或删除，这条消息起换用了新对话。';
+/**
+ * 查不到原对话时的说明。措辞刻意留了余地: inspect 返回 null 是多义的 ——
+ * 会话真的没了是 null, meta / DB 读取瞬时失败也被吞成 null(session-runner
+ * 两路都 catch)。一口咬定"已被归档或删除"会在读库抖动时误导用户
+ * (PR #733 review 指出)。
+ */
+const NOTICE_SESSION_GONE = 'ℹ️ 原对话现在读不到（可能已被归档或删除），这条消息起换用了新对话。';
 
 /** 标题里消息摘要的最大长度(字符), 超出截断加省略号。 */
 const TITLE_SNIPPET_MAX = 24;
@@ -396,15 +415,21 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   /** 正在执行 turn 的 session(本模块发起的)。 */
   const running = new Set<string>();
   /**
-   * 本 dispatcher 刚新建、但**还没被确认落库**的 session。免检快路径只认这个
-   * 集合(见 resolveTarget)—— `inspect()` 返回 null 是多义的: session 不存在
-   * 是 null, meta / DB 读取瞬时失败也被吞成 null(session-runner.ts 两路都
-   * catch)。只凭 null 放行, 一次读库抖动就能让已落库、已被移出映射的 session
-   * 继续收消息, 绕过映射边界(PR #733 review 指出)。
-   * 出集合的两个口子: 任何一次 inspect 成功查到它(说明已落库), 或它的 turn
-   * 收口(run 返回时 session 必已建好)。因此集合规模 ≤ 并发新建数, 不会泄漏。
+   * 本 dispatcher 刚新建、但**还没被确认落库**的 session -> 建它时用的目录。
+   * 免检快路径只认这张表(见 resolveTarget)—— `inspect()` 返回 null 是多义的:
+   * session 不存在是 null, meta / DB 读取瞬时失败也被吞成 null(session-runner
+   * 两路都 catch)。只凭 null 放行, 一次读库抖动就能让已落库、已被移出映射的
+   * session 继续收消息, 绕过映射边界(PR #733 review 指出)。
+   *
+   * 存目录而不只是 id: 会话还没落库的这段时间里别名映射可能已被改指, 免检时
+   * 要拿它跟当前映射重新比一次 —— 否则那条消息会排进一个建在已撤权目录里的
+   * 会话(同一轮 review 指出)。它不是"授权凭据", 只是 dispatcher 自己刚用过的
+   * 目录的进程内记账, 每次都要重新过映射校验才算数。
+   *
+   * 出表的两个口子: 任何一次 inspect 成功查到它(说明已落库), 或它的 turn
+   * 收口(run 返回时 session 必已建好)。因此表的规模 ≤ 并发新建数, 不会泄漏。
    */
-  const awaitingPersist = new Set<string>();
+  const awaitingPersist = new Map<string, string>();
   /** 每 session 的 FIFO 等待队列。 */
   const queues = new Map<string, PendingTask[]>();
   /** connectionId + requestId -> 正在执行它的 session(cancel 定位与归属校验用, 收口即清)。 */
@@ -603,6 +628,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           sessionId: payload.sessionId,
           isNew: false,
           workingDir: info.workingDir as string,
+          // 同复用路径: 校验与执行之间会话仍可能被移走, 由 runner 兜住
+          expectedWorkingDir: info.workingDir as string,
           agentKind,
           model,
           effort,
@@ -646,6 +673,14 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       // 查得到 = 已落库, 此后一律走映射校验
       if (info !== null) awaitingPersist.delete(bound);
       /**
+       * 免检窗口里那个会话建在哪 —— 必须拿它跟**当前**映射再比一次: 会话还没
+       * 落库的这段时间里用户可能已经把别名改指走了(撤权), 只认 id 的话那条消息
+       * 会排进一个建在已撤权目录里的会话(PR #733 review 指出)。
+       */
+      const pendingDir = awaitingPersist.get(bound) ?? null;
+      const pendingStillAllowed =
+        pendingDir !== null && (isChat ? inDialogueRoot(pendingDir) : inWhitelist(pendingDir));
+      /**
        * 关键竞态防护: 绑定的 session 是本 dispatcher 刚建、**尚未落库**的
        * (inspect 查不到)且正在跑/排队时直接复用 —— 否则同 key 的后续消息会各开
        * 新 session, 破坏「同 key 同 session」铁律。
@@ -663,7 +698,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
        */
       if (
         info === null &&
-        awaitingPersist.has(bound) &&
+        pendingStillAllowed &&
         namespacedBound !== null &&
         (running.has(bound) || (queues.get(bound)?.length ?? 0) > 0)
       ) {
@@ -671,9 +706,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           run: {
             sessionId: bound,
             isNew: false,
-            // 尚未落库, 没有 meta 可查; chat 伪目录无别名映射, 给 dialogues 根
-            // 占位。此时 session 只可能是本连接刚在映射内建出来的。
-            workingDir: dir ?? dialogue?.rootDir() ?? '',
+            // 尚未落库, 没有 meta 可查 —— 用建它时那个刚重新过完映射校验的目录
+            workingDir: pendingDir!,
+            // 落库后 runner 会拿 meta.workDir 覆盖上面这个值; 届时必须仍是同一
+            // 个目录, 否则这条消息就跑到校验过的目录之外去了
+            expectedWorkingDir: pendingDir!,
             agentKind,
             model,
             effort,
@@ -709,6 +746,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             sessionId: bound,
             isNew: false,
             workingDir,
+            // 上面这次校验和 runner 读 meta 之间会话仍可能被移走 —— runner 拿到
+            // 权威 workDir 后必须确认还是这个目录
+            expectedWorkingDir: workingDir,
             agentKind,
             model,
             effort,
@@ -772,8 +812,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     // 新建会话跑在别名目录(或对话根)里, 是否还能复用每次现场按映射判定
     bindings.set(connectionId, payload.externalKey, sessionId);
     // 落库前的免检窗口从这里开始(见 awaitingPersist 声明处): 此刻这个 session
-    // 必定建在映射内, inspect 还查不到它, 同 key 的后续消息要能认出它。
-    awaitingPersist.add(sessionId);
+    // 必定建在映射内, inspect 还查不到它, 同 key 的后续消息要能认出它。记下它
+    // 建在哪 —— 免检时要拿这个目录跟当时的映射再比一次。
+    awaitingPersist.set(sessionId, runDir);
     // 标题带 provider 名: externalKey 约定为 `<providerId>:<渠道内标识>`,
     // 取前缀作 provider 名(如 team-slack), 比连接名(desktop 侧命名)更能
     // 说明"这条会话是谁驱动的"; 无前缀(非常规 key)时回退连接名

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -130,6 +130,14 @@ export interface HookRunRequest {
   }) => void;
   /** 交互已在本端收口(超时默认 / turn 结束), 通知 server 改写卡片。 */
   onInteractionCancel?: (interactionId: string, reason: string) => void;
+  /**
+   * "这个任务此刻还被授权吗"—— dispatcher 注入的实时判定(工作目录仍在映射内且
+   * 连接仍启用)。runner 必须在**真正把消息交给 agent 之前的最后一个同步点**再
+   * 问一次: dispatcher 那道校验之后, runner 还要 await 一串准备工作, 这段窗口
+   * 里用户完全可能改掉映射或停用连接(PR #733 review 指出)。
+   * 省略 = 不再校验(测试与旧调用方)。
+   */
+  isStillAuthorized?: () => boolean;
 }
 
 export interface HookRunOutcome {
@@ -334,6 +342,13 @@ interface PendingTask {
   accountGeneration: number;
   /** 会话定位阶段产生的一次性说明, 前置到本次 turn.end 的 finalText。 */
   notice?: string;
+  /**
+   * 本次定位为新会话预建的 worktree 的回收句柄。**只在这个任务最终没能进
+   * runner 时调用** —— 正常执行时 worktree 归会话所有, 不能回收。少了它,
+   * 执行前的映射收口一旦拦下任务, 刚建好的 worktree 目录与分支就成了没有会话
+   * 认领的孤儿, 反复改映射会累积(PR #733 review 指出)。
+   */
+  cleanupWorktree?: () => Promise<void>;
 }
 
 export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
@@ -516,8 +531,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       // 路径不进日志(规则: 用集中 PII helper, 而 dispatcher 是不碰 Electron 的
       // 纯逻辑模块, 拿不到它)—— requestId 足够定位。
       log.info(
-        `hook task ${task.requestId} aborted before execution: its directory left the workspace map`,
+        `hook task ${task.requestId} aborted before execution: its directory is no longer authorized`,
       );
+      // 任务没能进 runner, 刚预建的 worktree 不会有会话来认领 —— 就地回收
+      if (task.cleanupWorktree) void task.cleanupWorktree().catch(() => undefined);
       outcome = {
         status: 'error',
         finalText: '',
@@ -527,7 +544,16 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       };
     } else {
       try {
-        outcome = await runner.run({ ...task.run, onProgress, onInteraction, onInteractionCancel });
+        outcome = await runner.run({
+          ...task.run,
+          onProgress,
+          onInteraction,
+          onInteractionCancel,
+          // runner 内部还要 await 一串准备工作(provider 解析、建会话、写库、附件
+          // 落盘)才到真正的 send —— 这段里映射照样可能被撤。把判定本身传下去,
+          // 让它在最后那个同步点再问一次(PR #733 review 指出)。
+          isStillAuthorized: () => dirStillAllowed(task.connectionId, guardDir ?? ''),
+        });
       } catch (err) {
         outcome = {
           status: 'error',
@@ -596,7 +622,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
    */
   function dirStillAllowed(connectionId: string, dir: string): boolean {
     const config = getConnection(connectionId);
-    if (!config) return false;
+    // 连接被停用 = 用户已经切断了这条远端通道。handleDispatch 入口就这么判,
+    // 排队中的任务同样不能因为"目录还在映射里"就照跑(PR #733 review 指出)。
+    if (!config || !config.enabled) return false;
     if (Object.values(config.workspaces).some((root) => isPathWithin(root, dir))) return true;
     return dialogue !== undefined && isPathWithin(dialogue.rootDir(), dir);
   }
@@ -617,7 +645,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     config: HookConnectionConfig,
     payload: TaskDispatchPayload,
     generation: number,
-  ): Promise<{ run: HookRunRequest; notice?: string } | { reject: TaskRejectReason }> {
+  ): Promise<
+    | { run: HookRunRequest; notice?: string; cleanupWorktree?: () => Promise<void> }
+    | { reject: TaskRejectReason }
+  > {
     // options 四元组原样透传给 runner —— 空值由 runner 按桌面端草稿默认落值
     // (取值链: Slack 按目录偏好 > 草稿默认, 权限缺省 bypass; 见
     // hook-control/defaults.ts)。复用/接管路径也照传, 消费与否由 runner 决定
@@ -820,6 +851,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     } else {
       runDir = dir as string;
     }
+    /** 预建成功的 worktree 回收句柄, 随任务带下去(见 PendingTask.cleanupWorktree)。 */
+    let cleanupWorktree: (() => Promise<void>) | undefined;
     if (prepareWorktree && !isChat && dir !== undefined) {
       const prep = await prepareWorktreeSerial(dir);
       if (!isCurrentGeneration(generation)) {
@@ -829,6 +862,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       if (prep.ok && isPathWithin(dir, prep.path)) {
         sessionId = prep.sessionId;
         runDir = prep.path;
+        cleanupWorktree = () => prep.cleanup();
         log.info(`hook session ${sessionId} gets dedicated worktree: ${prep.path}`);
       } else {
         const why = prep.ok
@@ -875,6 +909,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         origin,
       },
       ...(recreatedNotice ? { notice: recreatedNotice } : {}),
+      ...(cleanupWorktree ? { cleanupWorktree } : {}),
     };
   }
 
@@ -933,6 +968,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           run: { ...resolved.run, ...(source ? { source } : {}) },
           accountGeneration: admittedGeneration,
           ...(resolved.notice ? { notice: resolved.notice } : {}),
+          ...(resolved.cleanupWorktree ? { cleanupWorktree: resolved.cleanupWorktree } : {}),
         };
         const sessionId = resolved.run.sessionId;
         const queue = queues.get(sessionId) ?? [];

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -395,6 +395,16 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   const pendingTurnEnds = new Map<string, HookMessage[]>();
   /** 正在执行 turn 的 session(本模块发起的)。 */
   const running = new Set<string>();
+  /**
+   * 本 dispatcher 刚新建、但**还没被确认落库**的 session。免检快路径只认这个
+   * 集合(见 resolveTarget)—— `inspect()` 返回 null 是多义的: session 不存在
+   * 是 null, meta / DB 读取瞬时失败也被吞成 null(session-runner.ts 两路都
+   * catch)。只凭 null 放行, 一次读库抖动就能让已落库、已被移出映射的 session
+   * 继续收消息, 绕过映射边界(PR #733 review 指出)。
+   * 出集合的两个口子: 任何一次 inspect 成功查到它(说明已落库), 或它的 turn
+   * 收口(run 返回时 session 必已建好)。因此集合规模 ≤ 并发新建数, 不会泄漏。
+   */
+  const awaitingPersist = new Set<string>();
   /** 每 session 的 FIFO 等待队列。 */
   const queues = new Map<string, PendingTask[]>();
   /** connectionId + requestId -> 正在执行它的 session(cancel 定位与归属校验用, 收口即清)。 */
@@ -525,6 +535,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }),
     );
     running.delete(sessionId);
+    // run 返回 = session 一定已经建好落库, 免检窗口到此为止
+    awaitingPersist.delete(sessionId);
     const queue = queues.get(sessionId);
     const next = queue?.shift();
     if (!queue || queue.length === 0) queues.delete(sessionId);
@@ -631,20 +643,27 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     if (bound) {
       const info = await runner.inspect(bound);
       if (!isCurrentGeneration(generation)) return { reject: 'disabled' };
+      // 查得到 = 已落库, 此后一律走映射校验
+      if (info !== null) awaitingPersist.delete(bound);
       /**
-       * 关键竞态防护: 绑定的 session 已派发但**尚未落库**(inspect 查不到)且
-       * 正在本模块跑/排队时直接复用 —— 否则同 key 的后续消息会各开新 session,
-       * 破坏「同 key 同 session」铁律。
+       * 关键竞态防护: 绑定的 session 是本 dispatcher 刚建、**尚未落库**的
+       * (inspect 查不到)且正在跑/排队时直接复用 —— 否则同 key 的后续消息会各开
+       * 新 session, 破坏「同 key 同 session」铁律。
        *
-       * 严格限定在 `info === null` 这个窗口内: 一旦落库, 无论它是否在跑, 都要
-       * 走下面的映射校验。早期版本把「在跑/排队」整个当成免检快路径, 于是用户在
-       * 一轮任务执行期间把对话移出映射时, 新到的消息仍会排进这个 session ——
-       * 而 session-runner 的复用路径以 session meta 的 workDir 为权威(会覆盖
-       * 这里传的目录), 那条消息就真的在已移出映射的目录里执行了, 等于在
-       * 「每条消息现场按映射重算」上开了个洞(PR #733 review 指出)。
+       * 两层收窄, 都是为了不让免检变成绕过映射边界的口子:
+       * - 早期版本把「在跑/排队」整个当成免检快路径, 且放在 inspect 之前。用户在
+       *   一轮任务执行期间把对话移出映射时, 新消息仍会排进这个 session —— 而
+       *   session-runner 的复用路径以 session meta 的 workDir 为权威(会覆盖这里
+       *   传的目录), 那条消息就真的在映射外执行了。
+       * - 只判 `info === null` 也不够: 这个 null 是多义的, session 不存在是 null,
+       *   meta / DB 读取瞬时失败也被吞成 null。一次读库抖动就能让已落库、已被移出
+       *   映射的 session 继续收消息。所以改判 awaitingPersist —— 只有本 dispatcher
+       *   刚在映射内建出来、还没确认落库的 session 才免检。
+       * 两条都由 PR #733 review 指出。
        */
       if (
         info === null &&
+        awaitingPersist.has(bound) &&
         namespacedBound !== null &&
         (running.has(bound) || (queues.get(bound)?.length ?? 0) > 0)
       ) {
@@ -752,6 +771,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     }
     // 新建会话跑在别名目录(或对话根)里, 是否还能复用每次现场按映射判定
     bindings.set(connectionId, payload.externalKey, sessionId);
+    // 落库前的免检窗口从这里开始(见 awaitingPersist 声明处): 此刻这个 session
+    // 必定建在映射内, inspect 还查不到它, 同 key 的后续消息要能认出它。
+    awaitingPersist.add(sessionId);
     // 标题带 provider 名: externalKey 约定为 `<providerId>:<渠道内标识>`,
     // 取前缀作 provider 名(如 team-slack), 比连接名(desktop 侧命名)更能
     // 说明"这条会话是谁驱动的"; 无前缀(非常规 key)时回退连接名

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -122,6 +122,14 @@ export interface HookRunRequest {
   }) => void;
   /** 交互已在本端收口(超时默认 / turn 结束), 通知 server 改写卡片。 */
   onInteractionCancel?: (interactionId: string, reason: string) => void;
+  /**
+   * "这个目录此刻还在本连接的工作目录映射内吗" —— dispatcher 注入(只有它查得到
+   * 映射)。runner 用它校验**真正要跑的那个 live session 的 workDir**: maker 对
+   * 已活着的 session id 会忽略传入的 workingDir 直接返回旧实例, 那个实例的目录
+   * 可能已被移出映射, 且实例不换就一直错配(PR #733 review 指出)。
+   * 省略 = 不校验(测试与旧调用方)。
+   */
+  isDirAuthorized?: (dir: string) => boolean;
 }
 
 export interface HookRunOutcome {
@@ -532,6 +540,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           onProgress,
           onInteraction,
           onInteractionCancel,
+          // runner 建/取到 session 后, 拿它真正要跑的那个目录回来问一次 ——
+          // 那个目录可能与这里校验过的不是同一个(见 isDirAuthorized 的说明)。
+          isDirAuthorized: (dir) => dirStillAllowed(task.connectionId, dir),
         });
       } catch (err) {
         outcome = {
@@ -1075,6 +1086,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         running.clear();
         runningByRequest.clear();
         cancelRequested.clear();
+        // 切账号时 execute() 会在代际检查处提前 return, 走不到收口那行删除 ——
+        // 不在这里清的话, 每次切账号都永久留下一条 sessionId + 完整工作目录路径
+        // (PR #733 review 指出)。这些会话属于上一个账号, 新账号下本就不该免检。
+        awaitingPersist.clear();
         keyChains.clear();
       })();
       accountDeactivation = drain.finally(() => {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -665,6 +665,17 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     const whitelistDirs = Object.values(config.workspaces);
     const inWhitelist = (dir: string | null): boolean =>
       dir !== null && whitelistDirs.some((base) => isPathWithin(base, dir));
+    /**
+     * 同上, 但每次都重读连接配置 —— 撤权判定必须用**此刻**的映射: `config` 是
+     * 消息进来那一刻的快照, 而下面要 await `runner.inspect()`。用快照判定的话,
+     * 用户在这段时间里刚把目录加回映射(或改回别名)时, 一条此刻完全合法的绑定
+     * 会被当成越界删掉, 那条 thread 就白白换了新对话(PR #733 review 指出)。
+     */
+    const inWhitelistNow = (dir: string | null): boolean =>
+      dir !== null &&
+      Object.values(getConnection(connectionId)?.workspaces ?? config.workspaces).some((base) =>
+        isPathWithin(base, dir),
+      );
     /** app 托管对话目录(dialogues 根)内的路径 —— chat 伪目录会话的白名单等价物。 */
     const inDialogueRoot = (dir: string | null): boolean =>
       dir !== null && dialogue !== undefined && isPathWithin(dialogue.rootDir(), dir);
@@ -785,8 +796,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }
       // 复用条件: 仍存在、可用、且仍在白名单内(别名映射可能已被用户改过);
       // chat 伪目录的会话住在 dialogues 根下, 按对话根校验
+      // 用 inWhitelistNow 而不是入口快照: 见其定义处 —— inspect 期间映射可能刚
+      // 被改回来, 拿旧快照判撤权会误杀一条此刻合法的绑定。
       const inAllowedRoot =
-        info !== null && (isChat ? inDialogueRoot(info.workingDir) : inWhitelist(info.workingDir));
+        info !== null &&
+        (isChat ? inDialogueRoot(info.workingDir) : inWhitelistNow(info.workingDir));
       const usable = info?.usable === true && info.workingDir !== null;
       /**
        * 复用与否只看这一条: 会话当前的工作目录仍落在工作目录映射(或内置对话根)
@@ -1102,6 +1116,26 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       // 归档并发穿插 —— 归档排在其后, 能看到刚落下的绑定。
       serializeByKey(`${connectionId} ${externalKey}`, async () => {
         if (!isCurrentGeneration(admittedGeneration)) return;
+        /**
+         * 这个会话此刻还归远端管吗 —— 归档同样要过工作目录映射这道边界。
+         * 会话已被移出映射(或映射被改/删)时, 远端的 `/new` 不该还能归档它并
+         * 触发 worktree 清理: 那是对一个它已无权驱动的本地会话动手
+         * (PR #733 review 指出)。
+         */
+        const stillOurs = async (sessionId: string): Promise<boolean> => {
+          // 本 dispatcher 刚建、还没落库的会话 inspect 查不到(见 awaitingPersist),
+          // 但它建在哪是记着的 —— 用那个目录判, 否则紧跟着新建到来的 `/new` 会
+          // 静默失效。
+          const pendingDir = awaitingPersist.get(sessionId);
+          if (pendingDir !== undefined) return dirStillAllowed(connectionId, pendingDir);
+          const info = await runner.inspect(sessionId);
+          if (!isCurrentGeneration(admittedGeneration)) return false;
+          return (
+            info?.usable === true &&
+            info.workingDir !== null &&
+            dirStillAllowed(connectionId, info.workingDir)
+          );
+        };
         let bindingNamespace = connectionId;
         let bound = bindings.get(connectionId, externalKey);
         if (!bound && connectionId.endsWith(':slack')) {
@@ -1111,26 +1145,27 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             // a chance to migrate the v1 mapping. Only act on that mapping
             // after proving it belongs to the current account DB and remains
             // inside today's workspace/dialogue allowlist.
-            const config = getConnection(connectionId);
-            const info = await runner.inspect(legacyBound);
-            if (!isCurrentGeneration(admittedGeneration)) return;
-            const allowed =
-              info?.usable === true &&
-              info.workingDir !== null &&
-              (Object.values(config?.workspaces ?? {}).some((root) =>
-                isPathWithin(root, info.workingDir!),
-              ) ||
-                (dialogue !== undefined && isPathWithin(dialogue.rootDir(), info.workingDir)));
-            if (allowed) {
+            if (await stillOurs(legacyBound)) {
               bound = legacyBound;
               bindingNamespace = 'slack';
             } else {
+              if (!isCurrentGeneration(admittedGeneration)) return;
               bindings.remove('slack', externalKey);
             }
           }
         }
         if (!bound) return; // 该 key 从没建过会话(或已归档清理过), 幂等 no-op
+        // 当前命名空间的绑定过同一道闸: 通不过就只丢绑定(下条消息本就会重开
+        // 会话), 但不动那个已越界的本地会话。
+        const authorized = bindingNamespace === 'slack' || (await stillOurs(bound));
+        if (!isCurrentGeneration(admittedGeneration)) return;
         bindings.remove(bindingNamespace, externalKey);
+        if (!authorized) {
+          log.info(
+            `hook archive skipped for ${externalKey}: session ${bound} is no longer inside the workspace map`,
+          );
+          return;
+        }
         if (!archiveSessionRow) return;
         try {
           await archiveSessionRow(bound);

--- a/apps/desktop/src/main/hook-control/paths.ts
+++ b/apps/desktop/src/main/hook-control/paths.ts
@@ -1,0 +1,29 @@
+/**
+ * hook-control/paths.ts
+ * ---------------------------------------------------------------------------
+ * 工作目录映射判定用的路径比较。**叶子模块**: 不 import 本目录任何其它文件,
+ * 供 dispatcher / session-runner / recentSessions 共用。
+ *
+ * 单独拆出来是为了守依赖方向: 生产 runner 不该为了一个路径比较去 import 纯逻辑
+ * 的 dispatcher —— 那会把 dispatcher 的依赖树(协议包等)拖进 runner 的加载路径,
+ * 并把 dispatcher -> runner 的单向依赖变成环(PR #733 review 指出)。
+ */
+
+import path from 'node:path';
+
+/** 路径比较前的规范化。Windows 大小写不敏感(规则 15)。 */
+function normalizePathForCompare(p: string): string {
+  const resolved = path.resolve(p);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+/** target 是否落在 base 目录内(含相等)。Windows 大小写不敏感(规则 15)。 */
+export function isPathWithin(base: string, target: string): boolean {
+  const rel = path.relative(normalizePathForCompare(base), normalizePathForCompare(target));
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/** 两个路径是否指向同一目录(同 isPathWithin 的规范化口径)。 */
+export function isSamePath(a: string, b: string): boolean {
+  return normalizePathForCompare(a) === normalizePathForCompare(b);
+}

--- a/apps/desktop/src/main/hook-control/paths.ts
+++ b/apps/desktop/src/main/hook-control/paths.ts
@@ -2,11 +2,11 @@
  * hook-control/paths.ts
  * ---------------------------------------------------------------------------
  * 工作目录映射判定用的路径比较。**叶子模块**: 不 import 本目录任何其它文件,
- * 供 dispatcher / session-runner / recentSessions 共用。
+ * 供 dispatcher / recentSessions 共用。
  *
- * 单独拆出来是为了守依赖方向: 生产 runner 不该为了一个路径比较去 import 纯逻辑
- * 的 dispatcher —— 那会把 dispatcher 的依赖树(协议包等)拖进 runner 的加载路径,
- * 并把 dispatcher -> runner 的单向依赖变成环(PR #733 review 指出)。
+ * 单独拆出来是为了守依赖方向: 别的模块不该为了一个路径比较去 import 纯逻辑的
+ * dispatcher —— 那会把 dispatcher 的依赖树(协议包等)拖进它们的加载路径, 也容易
+ * 拧出环(PR #733 review 指出)。
  */
 
 import path from 'node:path';
@@ -21,9 +21,4 @@ function normalizePathForCompare(p: string): string {
 export function isPathWithin(base: string, target: string): boolean {
   const rel = path.relative(normalizePathForCompare(base), normalizePathForCompare(target));
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
-}
-
-/** 两个路径是否指向同一目录(同 isPathWithin 的规范化口径)。 */
-export function isSamePath(a: string, b: string): boolean {
-  return normalizePathForCompare(a) === normalizePathForCompare(b);
 }

--- a/apps/desktop/src/main/hook-control/paths.ts
+++ b/apps/desktop/src/main/hook-control/paths.ts
@@ -17,8 +17,17 @@ function normalizePathForCompare(p: string): string {
   return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
 }
 
-/** target 是否落在 base 目录内(含相等)。Windows 大小写不敏感(规则 15)。 */
+/**
+ * target 是否落在 base 目录内(含相等)。Windows 大小写不敏感(规则 15)。
+ *
+ * 空 / 全空白一律 false: `path.resolve('')` 会变成进程的 cwd, 那样
+ * `isPathWithin(cwd 下的某个映射根, '')` 就成了假放行 —— 而空串是真实会出现的
+ * 输入(SessionMeta.workDir 在 DB workingDir 为 null 时落成空串, 见
+ * maker-host/session-storage.ts)。安全判定在这里 fail closed
+ * (PR #733 review 指出)。
+ */
 export function isPathWithin(base: string, target: string): boolean {
+  if (base.trim() === '' || target.trim() === '') return false;
   const rel = path.relative(normalizePathForCompare(base), normalizePathForCompare(target));
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }

--- a/apps/desktop/src/main/hook-control/recentSessions.ts
+++ b/apps/desktop/src/main/hook-control/recentSessions.ts
@@ -9,7 +9,7 @@ import { getDbClient } from '../localDb/client/current.js';
 import { sessions } from '../localDb/schema.js';
 import { HOOK_CHAT_WORKSPACE_ALIAS } from '../../shared/hookControlIpc.js';
 import { DESKTOP_VISIBLE_SESSION_SOURCES } from '../../shared/sessionSource.js';
-import { isPathWithin } from './dispatcher.js';
+import { isPathWithin } from './paths.js';
 
 const VISIBLE_SESSION_SOURCES = new Set<string>(DESKTOP_VISIBLE_SESSION_SOURCES);
 const MAX_SESSION_TITLE_CHARS = 200;

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -495,8 +495,16 @@ export function createMakerHookSessionRunner(deps: {
        * 附件与 worktree 清理, 前几轮实测这些后果比问题本身更重(PR #733 review)。
        * 目录仍在映射内的合法移动(A→B 都在映射里)不受影响: 那时判定通过, 这一轮
        * 继续在 A 跑, 与本 PR 之前的行为一致。
+       *
+       * **只对复用/接管路径生效**: 新会话的 id 是刚生成的, activeSessions 里不
+       * 可能有, createSession 一定按传入的 workingDir 新建 —— 错配根本不存在。
+       * 反倒是在这里拦下新会话会留垃圾: 那时 agent 已启动、session 行已插入、
+       * 预建的 worktree 还注册着(回收只在 createSession 抛错时跑), 于是留下一个
+       * 空会话 + 孤儿 worktree, 而渠道那边显示"没有执行"(同一轮 review 指出)。
+       * 新建路径那一小段(execute 的映射收口 -> createSession)属于已声明接受的
+       * 窗口, 见 PR #733 的风险段。
        */
-      if (req.isDirAuthorized && !req.isDirAuthorized(session.workDir)) {
+      if (!req.isNew && req.isDirAuthorized && !req.isDirAuthorized(session.workDir)) {
         log.warn(
           `hook run aborted: live session ${req.sessionId} runs in a directory that is no longer in the workspace map`,
         );

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -449,39 +449,40 @@ export function createMakerHookSessionRunner(deps: {
       const providerId = req.isNew ? (resolved?.providerId ?? null) : rowProviderId;
 
       let session: Awaited<ReturnType<ReturnType<typeof getMaker>['createSession']>>;
+      const createOpts = {
+        id: req.sessionId,
+        agentKind: effectiveAgentKind,
+        workingDir,
+        model: effectiveModel,
+        ...(providerId !== null ? { providerId } : {}),
+        ...(effort !== undefined ? { effort } : {}),
+        permissionMode,
+        // chat 伪目录新会话: 标记 dialogue, 落侧边栏「对话」分组而非按
+        // dialogues/<日期>/<id> 目录名聚成项目节点
+        ...(req.isNew && req.workspaceKind !== undefined
+          ? { workspaceKind: req.workspaceKind }
+          : {}),
+        title: req.isNew ? (req.title ?? undefined) : undefined,
+        // 渠道标记(仅 hook 亲生新会话): cindy_feishu_bot 据此在构建期给
+        // 工具描述注入渠道路由提示。两个刻意限定:
+        //   - 不用 'slack'(那是已退役的 organic SlackIM relay 渠道的历史
+        //     标记,留给存量会话的侧边栏显示,新会话不再产生);
+        //   - 复用/接管路径(isNew=false,可能是桌面端创建的会话)不传,
+        //     否则冷 resume 时会把桌面会话打上 Slack 渠道描述并存续整个
+        //     进程生命周期(对齐 im/turnRunner「attached 不传 vendorOptions」
+        //     的裁决)。hook turn 本身的渠道说明由逐 turn 的
+        //     provider-aware hook prompt note 全覆盖,不依赖这里。
+        ...(req.isNew
+          ? {
+              vendorOptions: {
+                source: req.source?.im === 'telegram' ? 'telegram' : 'slack-hook',
+              },
+            }
+          : {}),
+        resumeSessionId,
+      };
       try {
-        session = await maker.createSession({
-          id: req.sessionId,
-          agentKind: effectiveAgentKind,
-          workingDir,
-          model: effectiveModel,
-          ...(providerId !== null ? { providerId } : {}),
-          ...(effort !== undefined ? { effort } : {}),
-          permissionMode,
-          // chat 伪目录新会话: 标记 dialogue, 落侧边栏「对话」分组而非按
-          // dialogues/<日期>/<id> 目录名聚成项目节点
-          ...(req.isNew && req.workspaceKind !== undefined
-            ? { workspaceKind: req.workspaceKind }
-            : {}),
-          title: req.isNew ? (req.title ?? undefined) : undefined,
-          // 渠道标记(仅 hook 亲生新会话): cindy_feishu_bot 据此在构建期给
-          // 工具描述注入渠道路由提示。两个刻意限定:
-          //   - 不用 'slack'(那是已退役的 organic SlackIM relay 渠道的历史
-          //     标记,留给存量会话的侧边栏显示,新会话不再产生);
-          //   - 复用/接管路径(isNew=false,可能是桌面端创建的会话)不传,
-          //     否则冷 resume 时会把桌面会话打上 Slack 渠道描述并存续整个
-          //     进程生命周期(对齐 im/turnRunner「attached 不传 vendorOptions」
-          //     的裁决)。hook turn 本身的渠道说明由逐 turn 的
-          //     provider-aware hook prompt note 全覆盖,不依赖这里。
-          ...(req.isNew
-            ? {
-                vendorOptions: {
-                  source: req.source?.im === 'telegram' ? 'telegram' : 'slack-hook',
-                },
-              }
-            : {}),
-          resumeSessionId,
-        });
+        session = await maker.createSession(createOpts);
       } catch (err) {
         // session 未建成: 若有预建 worktree 则回收(同 maker-ipc/register.ts
         // 的 shouldRecycleHandoffWorktreeOnFailure 判据), 防孤儿泄漏
@@ -495,14 +496,41 @@ export function createMakerHookSessionRunner(deps: {
        * 拿到的可能是**进程里早就活着的那个 session**: maker.createSession 对
        * 已在 activeSessions 里的 id 直接返回既有实例, 完全忽略上面传的
        * workingDir(maker.ts 的 active-session 短路)。那个实例的 workDir 与
-       * agent 句柄可能还指着落库前的旧目录 —— 上面比对的是持久化 meta, 拦不住
-       * 这一种。真正要执行的是它, 所以对着它再确认一次(PR #733 review 指出)。
+       * agent 句柄仍指着它创建时的目录, 而侧边栏"移动到项目"只改库里的行 ——
+       * 于是 meta 已是新目录、live 实例还在旧目录。真正执行的是 live 实例, 所以
+       * 对着它再确认一次(PR #733 review 指出)。
+       *
+       * 不一致时**重建而不是拒绝**: expectedWorkingDir 是 dispatcher 刚过完映射
+       * 校验的目录, 在那里重建既回到授权边界内, 也让"映射内换目录仍然无感跟随"
+       * 继续成立 —— 只报错的话, 映射内 A→B 的合法移动会被永久拒绝, 直到会话被
+       * 关闭或 app 重启(同一轮 review 指出)。
        */
       if (req.expectedWorkingDir != null && !isSamePath(session.workDir, req.expectedWorkingDir)) {
-        log.warn(
-          `hook run aborted: live session ${req.sessionId} runs in ${maskPath(session.workDir)}, not the validated ${maskPath(req.expectedWorkingDir)}`,
+        // 正在跑 turn 的会话不能从底下抽走(桌面端或别的入口可能正用着它)。
+        // 这是暂态: 那一轮跑完后重发即可走到下面的重建。
+        if (isSessionInTurn(req.sessionId)) {
+          log.warn(
+            `hook run aborted: live session ${req.sessionId} still runs in ${maskPath(session.workDir)}, not the validated ${maskPath(req.expectedWorkingDir)}`,
+          );
+          return fail('这个对话正在别的目录里运行，本条消息没有执行；请稍后重发。');
+        }
+        log.info(
+          `recreating live session ${req.sessionId} at ${maskPath(req.expectedWorkingDir)} (was ${maskPath(session.workDir)})`,
         );
-        return fail('这个对话正在别的目录里运行，本条消息没有执行；请重新发送。');
+        try {
+          await maker.closeSession(req.sessionId);
+          session = await maker.createSession(createOpts);
+        } catch (err) {
+          return fail(err instanceof Error ? err.message : String(err));
+        }
+        // 关闭后 activeSessions 的清理若还没落地, 重建仍可能拿到旧实例 ——
+        // 那就这一轮不跑, 让用户重发(下一次拿到的就是新实例), 而不是在旧目录里跑。
+        if (!isSamePath(session.workDir, req.expectedWorkingDir)) {
+          log.warn(
+            `hook run aborted: session ${req.sessionId} could not be recreated at ${maskPath(req.expectedWorkingDir)}`,
+          );
+          return fail('这个对话刚换了工作目录，本条消息没有执行；请重新发送。');
+        }
       }
 
       // 运行时来源注入(路由层经 session-provider-store 决定上游与钥匙):

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -950,6 +950,19 @@ export function createMakerHookSessionRunner(deps: {
 
       try {
         const pendingHandoff = await agentHandoffPending.peek(session.id);
+        /**
+         * 最后一道: 把消息交给 agent 之前的最后一个同步点。dispatcher 那道校验
+         * 之后, 上面这一大段准备工作(provider 解析、读 meta、建会话、写库、附件
+         * 落盘)全是 await —— 这段窗口里用户完全可能撤掉映射或停用连接, 那样这条
+         * 远端消息就会在已撤权的目录里真的跑起来(PR #733 review 指出)。
+         * 之后就没有窗口了: send 一返回, turn 已经在跑。
+         */
+        if (req.isStillAuthorized && !req.isStillAuthorized()) {
+          log.warn(`hook run aborted at send time: session ${req.sessionId} lost authorization`);
+          return fail(
+            '这个对话所在的目录已不在工作目录映射里，本条消息没有执行；恢复映射后请重新发送。',
+          );
+        }
         const outgoingMessage: UserMessage = pendingHandoff
           ? (prependHandoffToUserMessage(
               { type: 'user', content: sendContent },

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -48,12 +48,10 @@ import {
 } from '@cindy/model-providers';
 
 import { tapWindowBroadcast } from '../device-link/broadcast-tap.js';
-import { maskPath } from '../logger.js';
 import { getMaker } from '../maker-host/index.js';
 import {
   wireSessionToIpc,
   isSessionInTurn,
-  withSendToSessionLock,
   installDesktopInteractionListener,
   noteSilentStopUserSend,
   onSilentStopSettled,
@@ -92,7 +90,6 @@ import {
 import { beginHeadlessGhostSetupTurn } from '../mcp-integrations/ghostSetupInteractionSurface.js';
 
 import type { HookRunOutcome, HookSessionRunner } from './dispatcher.js';
-import { isSamePath } from './paths.js';
 import { resolveHookSessionConfig, type ResolvedHookSessionConfig } from './defaults.js';
 import { decodeAttachments, sanitizeAttachmentName } from './attachments.js';
 import {
@@ -412,25 +409,15 @@ export function createMakerHookSessionRunner(deps: {
       });
 
       /**
-       * 复用/接管路径的收口校验: dispatcher 是拿 inspect 的结果过的工作目录映射,
-       * 而真正决定在哪执行的是上面刚读到的 meta.workDir —— 两次读取之间会话仍可能
-       * 被移走(桌面端移动对话、或会话尚未落库时别名被改指), 那样这条消息就跑到
-       * 校验过的目录之外去了。在读权威 workDir 的同一处再确认一次, 不一致即拒绝
-       * (PR #733 review 指出)。
-       *
-       * 拒绝而不是改到新目录跑: 新目录有没有被授权, 只有 dispatcher 查得到映射
-       * 才能判断。下一条消息会重新走一遍完整判定, 该复用复用、该断开断开。
+       * 授权判定刻意**只在 dispatcher 侧**做(定位时 + 执行前按当前映射重查),
+       * runner 不再参与。曾经尝试过把判定贯穿到这里 —— 比对 meta.workDir、比对
+       * live session 的 workDir 并重建、在 send 前回调实时授权 —— 结果是每加一层
+       * 都要重新接入锁、代际、会话生命周期、附件与 worktree 清理这些横切关注点,
+       * 接不全就是新一轮缺陷(打断桌面会话、清掉在用的临时附件、listener 泄漏)。
+       * 那些缺陷比它要防的窗口更严重: 窗口内最多是一条在途消息在"校验它时还合法"
+       * 的目录里多跑一轮, 而 agent 的文件边界本就是 allowedFileRoots: [workingDir],
+       * 不会越到别处。这个取舍写在 PR #733 的风险段里。
        */
-      if (
-        req.expectedWorkingDir != null &&
-        workingDir !== null &&
-        !isSamePath(workingDir, req.expectedWorkingDir)
-      ) {
-        log.warn(
-          `hook run aborted: session ${req.sessionId} moved from ${maskPath(req.expectedWorkingDir)} to ${maskPath(workingDir)} between validation and execution`,
-        );
-        return fail('这个对话刚被移动到别的目录，本条消息没有执行；请重新发送。');
-      }
 
       // resolved 路径必有 model; 复用路径 meta 缺失时兜底草稿默认
       const effectiveModel = model?.trim()
@@ -491,55 +478,6 @@ export function createMakerHookSessionRunner(deps: {
           void WorktreeManager.removeWorktreeForSession(req.sessionId).catch(() => undefined);
         }
         return fail(err instanceof Error ? err.message : String(err));
-      }
-
-      /**
-       * 拿到的可能是**进程里早就活着的那个 session**: maker.createSession 对
-       * 已在 activeSessions 里的 id 直接返回既有实例, 完全忽略上面传的
-       * workingDir(maker.ts 的 active-session 短路)。那个实例的 workDir 与
-       * agent 句柄仍指着它创建时的目录, 而侧边栏"移动到项目"只改库里的行 ——
-       * 于是 meta 已是新目录、live 实例还在旧目录。真正执行的是 live 实例, 所以
-       * 对着它再确认一次(PR #733 review 指出)。
-       *
-       * 不一致时**重建而不是拒绝**: expectedWorkingDir 是 dispatcher 刚过完映射
-       * 校验的目录, 在那里重建既回到授权边界内, 也让"映射内换目录仍然无感跟随"
-       * 继续成立 —— 只报错的话, 映射内 A→B 的合法移动会被永久拒绝, 直到会话被
-       * 关闭或 app 重启(同一轮 review 指出)。
-       */
-      if (req.expectedWorkingDir != null && !isSamePath(session.workDir, req.expectedWorkingDir)) {
-        /**
-         * 整段替换必须拿这把 per-session 锁: 桌面端发送走的是同一把
-         * (withSendToSessionLock)。不加锁的话, "空闲"判定与 closeSession 之间用户
-         * 刚起的一个本地 turn 会被我们从底下关掉 —— 那是把远端的目录校验代价转嫁
-         * 给了正在打字的人(PR #733 review 指出)。空闲重检也放进锁里, 否则检查本身
-         * 就是过期信息。
-         */
-        const replacement = await withSendToSessionLock(req.sessionId, async () => {
-          // 正在跑 turn 的会话不能从底下抽走。这是暂态: 那一轮跑完后重发即可。
-          if (isSessionInTurn(req.sessionId)) return { busy: true as const };
-          log.info(
-            `recreating live session ${req.sessionId} at ${maskPath(req.expectedWorkingDir!)} (was ${maskPath(session.workDir)})`,
-          );
-          await maker.closeSession(req.sessionId);
-          return { busy: false as const, session: await maker.createSession(createOpts) };
-        }).catch((err: unknown) => ({ err: err instanceof Error ? err.message : String(err) }));
-
-        if ('err' in replacement) return fail(replacement.err);
-        if (replacement.busy) {
-          log.warn(
-            `hook run aborted: live session ${req.sessionId} still runs in ${maskPath(session.workDir)}, not the validated ${maskPath(req.expectedWorkingDir)}`,
-          );
-          return fail('这个对话正在别的目录里运行，本条消息没有执行；请稍后重发。');
-        }
-        session = replacement.session;
-        // 关闭后 activeSessions 的清理若还没落地, 重建仍可能拿到旧实例 ——
-        // 那就这一轮不跑, 让用户重发(下一次拿到的就是新实例), 而不是在旧目录里跑。
-        if (!isSamePath(session.workDir, req.expectedWorkingDir)) {
-          log.warn(
-            `hook run aborted: session ${req.sessionId} could not be recreated at ${maskPath(req.expectedWorkingDir)}`,
-          );
-          return fail('这个对话刚换了工作目录，本条消息没有执行；请重新发送。');
-        }
       }
 
       // 运行时来源注入(路由层经 session-provider-store 决定上游与钥匙):
@@ -959,19 +897,6 @@ export function createMakerHookSessionRunner(deps: {
 
       try {
         const pendingHandoff = await agentHandoffPending.peek(session.id);
-        /**
-         * 最后一道: 把消息交给 agent 之前的最后一个同步点。dispatcher 那道校验
-         * 之后, 上面这一大段准备工作(provider 解析、读 meta、建会话、写库、附件
-         * 落盘)全是 await —— 这段窗口里用户完全可能撤掉映射或停用连接, 那样这条
-         * 远端消息就会在已撤权的目录里真的跑起来(PR #733 review 指出)。
-         * 之后就没有窗口了: send 一返回, turn 已经在跑。
-         */
-        if (req.isStillAuthorized && !req.isStillAuthorized()) {
-          log.warn(`hook run aborted at send time: session ${req.sessionId} lost authorization`);
-          return fail(
-            '这个对话所在的目录已不在工作目录映射里，本条消息没有执行；恢复映射后请重新发送。',
-          );
-        }
         const outgoingMessage: UserMessage = pendingHandoff
           ? (prependHandoffToUserMessage(
               { type: 'user', content: sendContent },

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -48,6 +48,7 @@ import {
 } from '@cindy/model-providers';
 
 import { tapWindowBroadcast } from '../device-link/broadcast-tap.js';
+import { maskPath } from '../logger.js';
 import { getMaker } from '../maker-host/index.js';
 import {
   wireSessionToIpc,
@@ -89,8 +90,8 @@ import {
 } from '../im/shared/turnActivity.js';
 import { beginHeadlessGhostSetupTurn } from '../mcp-integrations/ghostSetupInteractionSurface.js';
 
-import { isSamePath } from './dispatcher.js';
 import type { HookRunOutcome, HookSessionRunner } from './dispatcher.js';
+import { isSamePath } from './paths.js';
 import { resolveHookSessionConfig, type ResolvedHookSessionConfig } from './defaults.js';
 import { decodeAttachments, sanitizeAttachmentName } from './attachments.js';
 import {
@@ -425,7 +426,7 @@ export function createMakerHookSessionRunner(deps: {
         !isSamePath(workingDir, req.expectedWorkingDir)
       ) {
         log.warn(
-          `hook run aborted: session ${req.sessionId} moved from ${req.expectedWorkingDir} to ${workingDir} between validation and execution`,
+          `hook run aborted: session ${req.sessionId} moved from ${maskPath(req.expectedWorkingDir)} to ${maskPath(workingDir)} between validation and execution`,
         );
         return fail('这个对话刚被移动到别的目录，本条消息没有执行；请重新发送。');
       }
@@ -488,6 +489,20 @@ export function createMakerHookSessionRunner(deps: {
           void WorktreeManager.removeWorktreeForSession(req.sessionId).catch(() => undefined);
         }
         return fail(err instanceof Error ? err.message : String(err));
+      }
+
+      /**
+       * 拿到的可能是**进程里早就活着的那个 session**: maker.createSession 对
+       * 已在 activeSessions 里的 id 直接返回既有实例, 完全忽略上面传的
+       * workingDir(maker.ts 的 active-session 短路)。那个实例的 workDir 与
+       * agent 句柄可能还指着落库前的旧目录 —— 上面比对的是持久化 meta, 拦不住
+       * 这一种。真正要执行的是它, 所以对着它再确认一次(PR #733 review 指出)。
+       */
+      if (req.expectedWorkingDir != null && !isSamePath(session.workDir, req.expectedWorkingDir)) {
+        log.warn(
+          `hook run aborted: live session ${req.sessionId} runs in ${maskPath(session.workDir)}, not the validated ${maskPath(req.expectedWorkingDir)}`,
+        );
+        return fail('这个对话正在别的目录里运行，本条消息没有执行；请重新发送。');
       }
 
       // 运行时来源注入(路由层经 session-provider-store 决定上游与钥匙):

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -437,7 +437,7 @@ export function createMakerHookSessionRunner(deps: {
       const providerId = req.isNew ? (resolved?.providerId ?? null) : rowProviderId;
 
       let session: Awaited<ReturnType<ReturnType<typeof getMaker>['createSession']>>;
-      const createOpts = {
+      const createOpts: Parameters<ReturnType<typeof getMaker>['createSession']>[0] = {
         id: req.sessionId,
         agentKind: effectiveAgentKind,
         workingDir,
@@ -478,6 +478,31 @@ export function createMakerHookSessionRunner(deps: {
           void WorktreeManager.removeWorktreeForSession(req.sessionId).catch(() => undefined);
         }
         return fail(err instanceof Error ? err.message : String(err));
+      }
+
+      /**
+       * 拿到的可能是**进程里早就活着的那个实例**: maker.createSession 对已在
+       * activeSessions 里的 id 直接返回它, 忽略上面传的 workingDir。侧边栏
+       * "移动到项目"只改库里的行, 那个实例的 workDir 仍是它创建时的目录 ——
+       * 于是 dispatcher 按库里的新目录过了映射校验, 真正执行却在旧目录。
+       *
+       * 这不是"校验到执行之间的窗口"(那条已在 PR #733 的风险段里声明接受),
+       * 而是**持久错配**: 实例不换, 每次重试都一样, 直到会话自然关闭。所以这里
+       * 必须拦 —— 判据是"真正要跑的这个目录此刻还在映射内吗", 由 dispatcher 注入
+       * (它才查得到映射)。
+       *
+       * 刻意只判、不重建: 关掉再建会打断可能正用着它的桌面会话、触发 onClose 的
+       * 附件与 worktree 清理, 前几轮实测这些后果比问题本身更重(PR #733 review)。
+       * 目录仍在映射内的合法移动(A→B 都在映射里)不受影响: 那时判定通过, 这一轮
+       * 继续在 A 跑, 与本 PR 之前的行为一致。
+       */
+      if (req.isDirAuthorized && !req.isDirAuthorized(session.workDir)) {
+        log.warn(
+          `hook run aborted: live session ${req.sessionId} runs in a directory that is no longer in the workspace map`,
+        );
+        return fail(
+          '这个对话正在一个已不在工作目录映射里的目录中运行，本条消息没有执行。把该目录加进 设置 → 远程连接 → 工作目录映射，或在桌面端关掉这个对话后重发。',
+        );
       }
 
       // 运行时来源注入(路由层经 session-provider-store 决定上游与钥匙):

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -89,6 +89,7 @@ import {
 } from '../im/shared/turnActivity.js';
 import { beginHeadlessGhostSetupTurn } from '../mcp-integrations/ghostSetupInteractionSurface.js';
 
+import { isSamePath } from './dispatcher.js';
 import type { HookRunOutcome, HookSessionRunner } from './dispatcher.js';
 import { resolveHookSessionConfig, type ResolvedHookSessionConfig } from './defaults.js';
 import { decodeAttachments, sanitizeAttachmentName } from './attachments.js';
@@ -149,7 +150,11 @@ async function resolveNewSessionConfig(
 
   // 目录级来源偏好(纯本地, 用户在工作目录映射行显式选的来源)优先于草稿默认来源。
   const channel =
-    sourceIm === 'telegram' ? ('telegram' as const) : sourceIm === 'slack' ? ('slack' as const) : null;
+    sourceIm === 'telegram'
+      ? ('telegram' as const)
+      : sourceIm === 'slack'
+        ? ('slack' as const)
+        : null;
   const workdirProviderId =
     channel !== null && workspaceCtx?.alias
       ? getWorkspaceProviderSource(channel, workspaceCtx.teamId, workspaceCtx.alias)
@@ -403,6 +408,27 @@ export function createMakerHookSessionRunner(deps: {
         errorMessage: msg,
         durationMs: Date.now() - startedAt,
       });
+
+      /**
+       * 复用/接管路径的收口校验: dispatcher 是拿 inspect 的结果过的工作目录映射,
+       * 而真正决定在哪执行的是上面刚读到的 meta.workDir —— 两次读取之间会话仍可能
+       * 被移走(桌面端移动对话、或会话尚未落库时别名被改指), 那样这条消息就跑到
+       * 校验过的目录之外去了。在读权威 workDir 的同一处再确认一次, 不一致即拒绝
+       * (PR #733 review 指出)。
+       *
+       * 拒绝而不是改到新目录跑: 新目录有没有被授权, 只有 dispatcher 查得到映射
+       * 才能判断。下一条消息会重新走一遍完整判定, 该复用复用、该断开断开。
+       */
+      if (
+        req.expectedWorkingDir != null &&
+        workingDir !== null &&
+        !isSamePath(workingDir, req.expectedWorkingDir)
+      ) {
+        log.warn(
+          `hook run aborted: session ${req.sessionId} moved from ${req.expectedWorkingDir} to ${workingDir} between validation and execution`,
+        );
+        return fail('这个对话刚被移动到别的目录，本条消息没有执行；请重新发送。');
+      }
 
       // resolved 路径必有 model; 复用路径 meta 缺失时兜底草稿默认
       const effectiveModel = model?.trim()

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -53,6 +53,7 @@ import { getMaker } from '../maker-host/index.js';
 import {
   wireSessionToIpc,
   isSessionInTurn,
+  withSendToSessionLock,
   installDesktopInteractionListener,
   noteSilentStopUserSend,
   onSilentStopSettled,
@@ -506,23 +507,31 @@ export function createMakerHookSessionRunner(deps: {
        * 关闭或 app 重启(同一轮 review 指出)。
        */
       if (req.expectedWorkingDir != null && !isSamePath(session.workDir, req.expectedWorkingDir)) {
-        // 正在跑 turn 的会话不能从底下抽走(桌面端或别的入口可能正用着它)。
-        // 这是暂态: 那一轮跑完后重发即可走到下面的重建。
-        if (isSessionInTurn(req.sessionId)) {
+        /**
+         * 整段替换必须拿这把 per-session 锁: 桌面端发送走的是同一把
+         * (withSendToSessionLock)。不加锁的话, "空闲"判定与 closeSession 之间用户
+         * 刚起的一个本地 turn 会被我们从底下关掉 —— 那是把远端的目录校验代价转嫁
+         * 给了正在打字的人(PR #733 review 指出)。空闲重检也放进锁里, 否则检查本身
+         * 就是过期信息。
+         */
+        const replacement = await withSendToSessionLock(req.sessionId, async () => {
+          // 正在跑 turn 的会话不能从底下抽走。这是暂态: 那一轮跑完后重发即可。
+          if (isSessionInTurn(req.sessionId)) return { busy: true as const };
+          log.info(
+            `recreating live session ${req.sessionId} at ${maskPath(req.expectedWorkingDir!)} (was ${maskPath(session.workDir)})`,
+          );
+          await maker.closeSession(req.sessionId);
+          return { busy: false as const, session: await maker.createSession(createOpts) };
+        }).catch((err: unknown) => ({ err: err instanceof Error ? err.message : String(err) }));
+
+        if ('err' in replacement) return fail(replacement.err);
+        if (replacement.busy) {
           log.warn(
             `hook run aborted: live session ${req.sessionId} still runs in ${maskPath(session.workDir)}, not the validated ${maskPath(req.expectedWorkingDir)}`,
           );
           return fail('这个对话正在别的目录里运行，本条消息没有执行；请稍后重发。');
         }
-        log.info(
-          `recreating live session ${req.sessionId} at ${maskPath(req.expectedWorkingDir)} (was ${maskPath(session.workDir)})`,
-        );
-        try {
-          await maker.closeSession(req.sessionId);
-          session = await maker.createSession(createOpts);
-        } catch (err) {
-          return fail(err instanceof Error ? err.message : String(err));
-        }
+        session = replacement.session;
         // 关闭后 activeSessions 的清理若还没落地, 重建仍可能拿到旧实例 ——
         // 那就这一轮不跑, 让用户重发(下一次拿到的就是新实例), 而不是在旧目录里跑。
         if (!isSamePath(session.workDir, req.expectedWorkingDir)) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 IM(Slack / Telegram)绑定的复用判定砍回**只认工作目录映射**这一个边界，删掉
「对话被移出映射后继续跟随」那套映射外的例外授权。

起因是 #653 的原始诉求：Slack thread 绑定的对话被移到别的项目后，同一个 thread
再回复会重开新对话。#653 / #669 的做法是在映射之外给这条绑定发放一条例外，让它
跟随到映射外的目录。问题在于这条例外必须跨 `hook-bindings.json` 与会话库**两次
没有事务保护的写**保持一致，中间还夹着随时可能到达的 IM 消息 —— 为兜住这个窗口
先后叠了 `workingDir` 快照、`authority`、在途标记 `previousWorkingDir`、TTL、
`rev` CAS、回滚句柄、失败补偿共七层状态，十轮 bot review 仍在持续产出新的组合
边界（回滚可清空整个绑定文件、Windows 上授权判定系统性失效、在途窗口内放行已被
撤权的目录）。

工作目录映射本来就是「远端能驱动哪些本地目录」的唯一安全边界。把判定收回到这条
边界内之后，整套状态机连同它的失效模式一起消失：

- `dispatcher` 的复用判定退化成一句「当前工作目录是否仍在映射(或内置对话根)内」，
  **完全无状态**，每条消息现场重算，没有过期凭据可绕。
- `bindings` 退回 `{ sessionId, updatedAt }`，不再存快照与授权来源；老文件里的
  残留字段读取时忽略，下次写入自然清掉（无需 migration）。
- 移出映射 = 断开绑定并换新对话，随本次 `turn.end` 回一条说明（#653 已合入的
  `NOTICE_SESSION_RECREATED`，措辞按新语义从「加回来」调成「加进来」），告诉用户
  先把目录加进映射、再用对话选择重新指定原对话。
- **映射内换目录仍然无感跟随** —— 那本就在边界内。

顺带删掉随之失去使用者的 `isSamePath`。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求：#653（原始诉求）、#669（本 PR 取代它，将关闭）
- 本 PR 包含：`hook-control/dispatcher.ts` 复用判定、`hook-control/bindings.ts`
  存储结构、对应单测
- 明确不包含：`sessions:move` 窄口径 IPC、`sessionMoves.ts`、`recent_workdirs`
  目的地校验 —— 这些都是 #669 为发放映射外例外而引入的，本方案不需要，随 #669
  一并作废（它们从未进入 main）
- 用户可见变化：**有**。把对话移到工作目录映射外的项目后，原 thread 不再静默跟随
  到那个目录，而是断开绑定、换用新对话，并在渠道里说明如何恢复（两步：把目录加进
  设置 → 远程连接 → 工作目录映射，再用对话选择重新指定原对话）。映射内的移动不受
  影响。
- 是否存在 breaking change：无（协议与文件格式均向后兼容）

### UI 变化

不涉及：只改 main 进程的绑定判定与 IM 侧回执文案，无界面、组件、样式改动。
（IM 渠道文案按既有约定硬编码中文，不进 locale。）

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：通过

npx vitest run src/main/hook-control/__tests__/dispatcher.test.ts src/main/hook-control/__tests__/bindings.test.ts
结果：2 files / 62 tests passed

bash <git skill>/run-unit-gate.sh <worktree>   # 仓库根全量单测门禁
结果：GATE_EXIT=0
（首次运行时 learn-host/staging.test.ts 在并发下 flaky 失败 2 例，单独运行
12/12 通过，与本次改动无关；重跑门禁全绿。）
```

新增 / 改写的用例覆盖：移出映射 → 断开并说明、映射内换目录 → 无感跟随复用、
移出后再移回 → 恢复正常复用且不留过期授权、存量绑定（带早期版本残留字段）在
映射内即复用越界即重建、绑定文件只写 `sessionId + updatedAt`。

### 手工验证

未执行（无 UI 改动，逻辑分支已由上述单测覆盖）。

### 未执行的验证

未做 Slack / Telegram 实机联调。本次只改本地复用判定，不涉及 wire protocol 与
服务端行为；风险集中在「什么时候断开绑定」这一条判定上，已由单测覆盖。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：只影响已绑定 IM thread 的对话复用判定。**安全侧是收紧**：main 当前
  版本会从会话元数据（经通用 patch IPC 即可被 Renderer 改写）反推出「用户移动了
  对话」并据此在映射外放行，本 PR 删掉这条推断路径，映射成为唯一边界。行为侧的
  代价是把「隐式跟随」换成「一次性显式授权」：用户需把新目录加进映射才能继续在
  原 thread 驱动它。
- 存量数据：`hook-bindings.json` 里早期版本写入的 `workingDir` / `authority`
  字段读取时忽略、下次写入清掉，无需 migration，旧版本客户端读新文件也不受影响
  （多写的字段本就是可选的）。
- **已知取舍：判定与执行之间存在窗口（有意不封）。** 授权判定放在 dispatcher
  侧两处——会话定位时、以及每次真正开跑之前按**当前**映射重查一次（含连接被停用、
  队列 drain、新建路径）。但从这道校验到 agent 真正开跑，中间仍有一段异步准备
  （provider 解析、建会话、写库、附件落盘）。这段窗口里若用户恰好撤掉映射，那条
  在途消息仍会在**校验它时还合法**的目录里跑完一轮。

  这是评估后接受的取舍，不是遗漏。曾把判定贯穿到 `session-runner` 内部（比对
  session meta、比对 live 实例并重建、send 前回调实时授权），结果是每加一层都要
  重新接入锁、账号代际、会话生命周期、附件与 worktree 清理这些横切关注点，接不全
  就产生新缺陷——实测出现过打断用户正在进行的桌面会话、清掉会话仍在用的临时附件、
  listener 泄漏。这些后果比窗口本身更严重：窗口内最多是多跑一轮，而 agent 的文件
  边界本就是 `allowedFileRoots: [workingDir]`，不会越到别处；且这段窗口在本 PR
  之前同样存在，不是新增风险。

  仍然被严格保证的是：**每条新消息都按当前映射重新判定**，绑定里不存任何持久化
  授权，撤权后的下一条消息一定进不来。

- 回滚 / 降级方式：`git revert` 本 commit 即回到 main 当前行为，无数据迁移需要
  撤销。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（判定收敛的理由写进了 `bindings.ts` / `dispatcher.ts` 的
      文件头与判定处注释，供后来者不再重走这条路）
- [x] 已确认测试结果或说明未执行原因

