### PR TITLE
fix(desktop): hide prices from model menu

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -1141,6 +1141,7 @@ describe('ModelSelector trigger variants', () => {
       // 一级菜单保持单行并保留折价标签；折后价和标准价只在完整详情展示。
       const row = screen.getByRole('option', { name: /Qwen 3\.7/ });
       expect(row.className).toContain('min-h-9');
+      expect(within(row).getByText('Qwen 3.7').className).toContain('leading-5');
       expect(screen.getByRole('listbox', { name: 'Model list' }).style.maxHeight).toBe('226px');
       expect(row.textContent).not.toContain('¥6 / ¥18');
       expect(row.textContent).not.toContain('¥12 / ¥36');

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -359,9 +359,10 @@ describe('ModelSelector trigger variants', () => {
     expect(modelListMaxHeightForRows()).toBeUndefined();
     expect(modelListMaxHeightForRows(Number.NaN)).toBeUndefined();
     expect(modelListMaxHeightForRows(Number.POSITIVE_INFINITY)).toBeUndefined();
-    expect(modelListMaxHeightForRows(0)).toBe(44);
-    expect(modelListMaxHeightForRows(6)).toBe(274);
-    expect(modelListMaxHeightForRows(7)).toBe(300);
+    expect(modelListMaxHeightForRows(0)).toBe(36);
+    expect(modelListMaxHeightForRows(6)).toBe(226);
+    expect(modelListMaxHeightForRows(7)).toBe(264);
+    expect(modelListMaxHeightForRows(8)).toBe(300);
     expect(modelListMaxHeightForRows(100)).toBe(300);
   });
 
@@ -991,7 +992,7 @@ describe('ModelSelector trigger variants', () => {
     expect(screen.getByTestId('model-options-popover').className).toContain('z-[10020]');
   });
 
-  it('keeps non-Gateway prices in their source currency without an approximate marker', () => {
+  it('keeps non-Gateway prices in model details without repeating them in the primary row', () => {
     vi.useFakeTimers();
     render(
       React.createElement(ModelSelectorContent, {
@@ -1016,7 +1017,7 @@ describe('ModelSelector trigger variants', () => {
     expect(within(options).getByText('Source: Anthropic')).toBeTruthy();
     expect(within(options).getByText('200K context')).toBeTruthy();
     const priceTitle = within(options).getByText('newChat.modelSelector.pricing.title');
-    expect(row.textContent).toContain('$3 / $15');
+    expect(row.textContent).not.toContain('$3 / $15');
     expect(row.textContent).not.toContain('¥');
     expect(row.textContent).not.toContain('≈');
     expect(within(options).getByText('$3')).toBeTruthy();
@@ -1051,7 +1052,41 @@ describe('ModelSelector trigger variants', () => {
     vi.useRealTimers();
   });
 
-  it('keeps discounted Gateway prices aligned between the row and model details', () => {
+  it('keeps non-price access labels in the primary model row', () => {
+    providersRef.providers = [
+      {
+        ...(providersRef.DEFAULT_PROVIDERS[0] as Record<string, unknown>),
+        access: { kind: 'subscription', product: 'Claude Pro' },
+      },
+    ];
+
+    try {
+      render(
+        React.createElement(ModelSelectorContent, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          currentProviderId: 'anthropic',
+          onProviderChange: vi.fn(),
+        }),
+      );
+
+      const row = screen.getByRole('option', { name: /Opus 4\.8/ });
+      const tags = row.querySelector('[data-model-tags]');
+      expect(tags).not.toBeNull();
+      expect(
+        within(tags as HTMLElement).getByText('settings.providers.models.subscription'),
+      ).toBeTruthy();
+      expect(row.textContent).not.toContain('$3 / $15');
+      expect(row.querySelector('[data-model-promotion-badge]')).toBeNull();
+    } finally {
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
+  it('keeps discounted Gateway prices in details while retaining the primary-row label', () => {
     providersRef.providers = [
       {
         id: 'xd',
@@ -1103,21 +1138,16 @@ describe('ModelSelector trigger variants', () => {
         }),
       );
 
-      // 行内折后价在上、标准价划线在下,折价徽标挂在模型名一侧的 tags 区。
+      // 一级菜单保持单行并保留折价标签；折后价和标准价只在完整详情展示。
       const row = screen.getByRole('option', { name: /Qwen 3\.7/ });
-      expect(row.className).toContain('min-h-11');
-      expect(screen.getByRole('listbox', { name: 'Model list' }).style.maxHeight).toBe('274px');
-      expect(row.textContent).toContain('¥6 / ¥18');
-      expect(row.textContent).toContain('¥12 / ¥36');
+      expect(row.className).toContain('min-h-9');
+      expect(screen.getByRole('listbox', { name: 'Model list' }).style.maxHeight).toBe('226px');
+      expect(row.textContent).not.toContain('¥6 / ¥18');
+      expect(row.textContent).not.toContain('¥12 / ¥36');
       const rowBadge = within(row).getByText('立省 50%');
       expect(rowBadge.hasAttribute('data-model-promotion-badge')).toBe(true);
       expect(rowBadge.parentElement?.hasAttribute('data-model-tags')).toBe(true);
-      const priceStack = within(row).getByText('¥6 / ¥18').parentElement;
-      expect(priceStack?.getAttribute('data-model-price-stack')).toBe('true');
-      expect(priceStack).not.toBe(rowBadge.parentElement);
-      expect(rowBadge.compareDocumentPosition(priceStack as Node)).toBe(
-        Node.DOCUMENT_POSITION_FOLLOWING,
-      );
+      expect(row.querySelector('[data-model-price-stack]')).toBeNull();
 
       fireEvent.pointerEnter(row);
       const details = screen.getByRole('group', { name: /Qwen 3\.7/ });
@@ -1139,7 +1169,7 @@ describe('ModelSelector trigger variants', () => {
     }
   });
 
-  it('shows explicit double-zero Gateway models as free in the row and model details', () => {
+  it('keeps explicit free labels in the row while leaving full information in details', () => {
     providersRef.providers = [
       {
         id: 'xd',

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1256,7 +1256,7 @@ function ModelSelectorContentView({
               )}
               <span className="flex min-w-0 flex-1 items-center gap-1.5">
                 <span className="flex min-w-0 flex-1 items-center gap-1.5">
-                  <span className="truncate text-14 font-medium text-[var(--model-item-text)]">
+                  <span className="truncate text-14 font-medium leading-5 text-[var(--model-item-text)]">
                     {model.displayName}
                   </span>
                   {rowEffort && (

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -27,7 +27,6 @@ import { useModelPricing } from '@/hooks/useModelPricing';
 import { useProviders } from '@/hooks/useProviders';
 import { useDeviceProviders } from '@/hooks/useDeviceProviders';
 import {
-  formatModelPricePair,
   modelPriceDiscountLabelValues,
   modelPriceDetailRows,
   modelPricePresentation,
@@ -90,8 +89,8 @@ const PROVIDER_TITLE_KEY: Record<string, string> = {
 // 配置面板锚在主菜单内缩 8px 的模型行上；补偿这段内缩，让两块面板贴边但不重叠。
 const MODEL_OPTIONS_SIDE_OFFSET = 8;
 const MODEL_LIST_DEFAULT_MAX_HEIGHT_PX = 300;
-// 折扣模型的价格会叠成两行：27.5px 价格栈 + 16px 纵向 padding，向上取整为 44px。
-const MODEL_LIST_CONSTRAINED_ROW_HEIGHT_PX = 44;
+// 一级菜单只保留单行模型信息与必要标签：20px 内容 + 16px 纵向 padding。
+const MODEL_LIST_ROW_HEIGHT_PX = 36;
 const MODEL_LIST_ROW_GAP_PX = 2;
 
 export function modelListMaxHeightForRows(maxVisibleRows?: number): number | undefined {
@@ -99,7 +98,7 @@ export function modelListMaxHeightForRows(maxVisibleRows?: number): number | und
   const rows = Math.max(1, Math.floor(maxVisibleRows));
   return Math.min(
     MODEL_LIST_DEFAULT_MAX_HEIGHT_PX,
-    rows * MODEL_LIST_CONSTRAINED_ROW_HEIGHT_PX + Math.max(0, rows - 1) * MODEL_LIST_ROW_GAP_PX,
+    rows * MODEL_LIST_ROW_HEIGHT_PX + Math.max(0, rows - 1) * MODEL_LIST_ROW_GAP_PX,
   );
 }
 
@@ -1235,7 +1234,7 @@ function ModelSelectorContentView({
             }}
             className={cn(
               'flex w-full cursor-pointer items-center justify-between rounded-[8px] px-3 py-2',
-              constrainedListMaxHeight !== undefined && 'min-h-11',
+              constrainedListMaxHeight !== undefined && 'min-h-9',
               'transition-colors duration-100 hover:bg-[var(--model-item-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
               isSelected && 'bg-[var(--model-item-hover)]',
               isEditingThis &&
@@ -1292,29 +1291,9 @@ function ModelSelectorContentView({
                 )}
               </span>
             </span>
-            {(rowPrice?.kind === 'priced' || isSelected) && (
-              <span className="ml-2 flex shrink-0 items-center gap-1.5">
-                {rowPrice?.kind === 'priced' && (
-                  <span
-                    data-model-price-stack={rowPrice.original ? 'true' : undefined}
-                    className={cn(
-                      'flex tabular-nums text-11 font-normal leading-[1.25]',
-                      rowPrice.original ? 'flex-col items-end' : 'items-center',
-                    )}
-                  >
-                    <span className="text-[var(--text-secondary)]">
-                      {formatModelPricePair(rowPrice.current)}
-                    </span>
-                    {rowPrice.original && (
-                      <span className="text-[var(--text-tertiary)] line-through">
-                        {formatModelPricePair(rowPrice.original)}
-                      </span>
-                    )}
-                  </span>
-                )}
-                {isSelected && (
-                  <Check size={15} className="shrink-0 text-[var(--model-item-check)]" />
-                )}
+            {isSelected && (
+              <span className="ml-2 flex shrink-0 items-center">
+                <Check size={15} className="shrink-0 text-[var(--model-item-check)]" />
               </span>
             )}
           </div>


### PR DESCRIPTION
## 这次改了什么

### 摘要

精简 Desktop 新建会话的模型选择 UI：输入区域继续保留现有必要标签；二级模型菜单不再重复展示数值价格，但保留限免、折扣、订阅及其他必要标签；三级悬浮详情保持完整价格与模型信息。移除价格栈后同步收紧菜单行高和六行可见区域高度。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Cindy PC 模型菜单信息层级调整（无 Issue）
- 本 PR 包含：移除二级模型菜单行内数值价格；保留必要标签；保留三级详情完整价格；更新菜单行高及对应测试
- 明确不包含：输入区域现有标签、三级详情内容、计价逻辑、Provider 数据和 Mobile UI 的调整
- 用户可见变化：二级模型菜单更简洁，价格只在三级详情展示
- 是否存在 breaking change：无

### UI 变化

- 平台：Desktop / macOS
- 截图或录屏：未附；已从本 PR worktree 启动 CN 区域开发版，当前窗口可用于验收
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §1 Visual Theme & Atmosphere：删除重复价格信息，遵循“只保留必要内容”和单一清晰信息层级
  - `docs/design-rules/DESIGN.md` §4 Component Stylings / Select & Dropdown：继续使用模型菜单统一的 `px-3`、8px 行圆角、`--model-item-hover` 及选中态 check；价格移除后保持单行 option row
  - `docs/design-rules/DESIGN.md` §5 Layout Principles：沿用 8px 间距体系，并按单行内容调整行高与菜单可见高度
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：未新增颜色或单模式补丁，复用现有语义 token；双模式目检状态在下方如实说明

## 怎么验证的

### 自动验证

```text
env PATH="/opt/homebrew/bin:$PATH" pnpm test:unit
结果：通过；runner 298 passed / 1 skipped，所有 required workspaces 均通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过，27/27

pnpm --filter desktop exec eslint src/renderer/components/new-chat/ModelSelector.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过

git diff --check
结果：通过

pnpm check:dco
结果：通过，1 个提交已签名

pnpm --filter desktop lint
结果：未通过；main 基线存在 90 个与本 PR 无关的既有错误，本 PR 的两个变更文件未命中这些错误
```

### 手工验证

- macOS，从 `/Users/caojianbo/Source/xdtmaker/cindy/.cindy-worktrees/hide-model-prices` 运行 `pnpm restart:desktop:remote --region=cn`
- `pnpm desktop:whoami --all` 显示该 worktree 为 `source=MATCH`、`state=ready`
- 启动日志确认 `Desktop region: cn`，并使用 CN auth / device-link endpoint

### 未执行的验证

- 未分别目检 Light / Dark 下的模型菜单；本次未新增颜色，继续走现有 themed styles，但不将其视为双模式实机验证
- 未执行 Windows 实机目检
- 未附截图或录屏

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的模型选择菜单及其单元测试，不影响计价数据或三级详情
- 回滚 / 降级方式：revert `2416656eefc5b0e3328b8d9b2c1ead2a99cef198`

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增产品或开发文档）
- [x] 已确认测试结果或说明未执行原因