### PR TITLE
fix(desktop): 语音录音时输入框首行不再多一个空行

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
@@ -16,16 +16,22 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+// CRLF 归一化:Windows checkout 下源码带 \r\n,否则跨 checkout 断言会假失败
+// (同 chatInputSessionFocus 等既有源码契约测试)。
 const chatInput = readFileSync(
   path.join(path.resolve(__dirname, '..'), 'components/new-chat/ChatInput.tsx'),
   'utf8',
-);
+).replace(/\r\n?/g, '\n');
 
 describe('external draft notification empty-document handling', () => {
   it('collapses an empty draft document to null before comparing with the editor', () => {
     const start = chatInput.indexOf('return subscribeComposerDraft(storageKey, () => {');
     expect(start).toBeGreaterThan(-1);
-    const block = chatInput.slice(start, chatInput.indexOf('const textUnchanged', start));
+    // 两个锚点都必须真实命中:end 缺失时 indexOf 返回 -1,slice(start, -1) 会切出
+    // 一大段无关源码,让下面的 toContain 假通过、契约形同失效。
+    const end = chatInput.indexOf('const textUnchanged', start);
+    expect(end).toBeGreaterThan(start);
+    const block = chatInput.slice(start, end);
 
     expect(block).toContain('normalizeComposerDocumentJSON(draft.text)');
     // 判空必须走共享实现,与 draftHasContent / isEditorEmpty 同源。

--- a/apps/desktop/src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
@@ -1,0 +1,35 @@
+/**
+ * composerExternalDraftEmptyDoc.test.ts — 外部草稿通知的「空文档」判空口径
+ * ---------------------------------------------------------------------------
+ * ChatInput 订阅 composerDraftStore 的外部写入后,只有在草稿正文与编辑器当前
+ * 文档真的不同时才做全量 setContent。草稿正文在存储里是 Tiptap JSON:空草稿
+ * 常常是 `{doc:[空 paragraph]}` 而不是 `null`,而比较的另一侧对「编辑器为空」
+ * 一律折叠成 `null`。两侧口径不一致时,每条外部通知都会拿一份空文档原地重建
+ * doc(`replace(0, size)`),把所有按位置存活的编辑器状态强行跨整篇映射——语音
+ * 录音时 caret 锚点被推出段落、首行多一个空行就是这么来的。
+ *
+ * 契约锁在源码层:该分支必须用 composerDraftStore 的判空把空文档折叠成 null,
+ * 不能只判断 `draft.text` 是否存在。
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const chatInput = readFileSync(
+  path.join(path.resolve(__dirname, '..'), 'components/new-chat/ChatInput.tsx'),
+  'utf8',
+);
+
+describe('external draft notification empty-document handling', () => {
+  it('collapses an empty draft document to null before comparing with the editor', () => {
+    const start = chatInput.indexOf('return subscribeComposerDraft(storageKey, () => {');
+    expect(start).toBeGreaterThan(-1);
+    const block = chatInput.slice(start, chatInput.indexOf('const textUnchanged', start));
+
+    expect(block).toContain('normalizeComposerDocumentJSON(draft.text)');
+    // 判空必须走共享实现,与 draftHasContent / isEditorEmpty 同源。
+    expect(block).toContain('tiptapDocHasContent(');
+    expect(block).not.toMatch(/const normalizedDraftText = draft\.text\s*\n?\s*\?/);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/voiceInputDraftDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputDraftDecoration.test.ts
@@ -225,6 +225,57 @@ describe('voice input draft decoration anti-flicker contract', () => {
     expect(node.dataset.voiceDraftSource).toBeUndefined();
   });
 
+  // 录音期间输入框文档被整段重建(外部草稿通知走 setContent → replace(0, size))时,
+  // 折叠锚点跨整篇映射会被推到 block 边界:widget 的 pos 落在 doc 层,ProseMirror 就
+  // 把这个 inline span 渲染到 <p> 外面,浏览器给它单独一行 —— 表现为"第一句话出现前
+  // 先多一个换行"。锚点必须留在段落内的 inline 位置。
+  it('keeps the caret anchor inside the paragraph when the document is rebuilt wholesale', () => {
+    const { plugin, state } = makeState('');
+    const listening = applyDraftMeta(state, {
+      text: '',
+      source: null,
+      from: 1,
+      to: 1,
+      caretState: 'listening',
+    });
+    expect(plugin.getState(listening)).toMatchObject({ from: 1, to: 1 });
+
+    const rebuilt = listening.apply(
+      listening.tr.replaceWith(
+        0,
+        listening.doc.content.size,
+        schema.nodes.paragraph.create(),
+      ),
+    );
+    const anchor = plugin.getState(rebuilt);
+    expect(anchor).toMatchObject({ from: 1, to: 1 });
+    const widget = plugin.getState(rebuilt)?.decorations.find()[0];
+    expect(widget?.from).toBe(1);
+    expect(rebuilt.doc.resolve(widget!.from).parent.isTextblock).toBe(true);
+  });
+
+  it('keeps a collapsed anchor collapsed across a full-document replacement', () => {
+    const { plugin, state } = makeState('已经上屏的文字');
+    const listening = applyDraftMeta(state, {
+      text: '流式草稿',
+      source: 'partial',
+      from: 1 + '已经上屏的文字'.length,
+      to: 1 + '已经上屏的文字'.length,
+      caretState: 'listening',
+    });
+    const rebuilt = listening.apply(
+      listening.tr.replaceWith(
+        0,
+        listening.doc.content.size,
+        schema.nodes.paragraph.create(null, schema.text('已经上屏的文字')),
+      ),
+    );
+    const anchor = plugin.getState(rebuilt);
+    // 膨胀成区间会让 voice-input-draft-replaced 把正文整段 display:none 隐藏掉。
+    expect(anchor?.from).toBe(anchor?.to);
+    expect(rebuilt.doc.resolve(anchor!.from).parent.isTextblock).toBe(true);
+  });
+
   it('deduplicates identical setVoiceInputDraftDecoration calls without dispatching', () => {
     const { state } = makeState('前文');
     let current = state;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -72,6 +72,7 @@ import {
   saveDraft as saveComposerDraft,
   clearDraft as clearComposerDraft,
   subscribeDraft as subscribeComposerDraft,
+  tiptapDocHasContent,
 } from '@/lib/composerDraftStore';
 import { subscribeSessionLinkInsert } from '@/lib/composerActionsBus';
 import { ModelSelector, type ModelMemoryAccessors } from './ModelSelector';
@@ -2707,9 +2708,13 @@ export function ChatInput({
       setBrowserComments(draft.browserComments ?? []);
       // 同值外部写入不做全量 setContent,避免把用户停在中段的光标弹到末尾、
       // 打断 IME 组合。appendQuoteToDraft 会改变正文文档,自然走下方 setContent。
-      const normalizedDraftText = draft.text
-        ? normalizeComposerDocumentJSON(draft.text)
-        : null;
+      // 空草稿在存储里可能是 `{doc:[空 paragraph]}` 而不是 undefined,而右侧对
+      // "编辑器为空"一律折叠成 null。两侧判空口径必须一致,否则每次外部草稿通知都
+      // 会拿一份空文档整段 setContent:doc 被原地重建,所有按位置存活的状态(语音
+      // 草稿锚点等)被迫跨整篇映射(#720 后语音录音时首行多一个空行的成因)。
+      const draftDocument = draft.text ? normalizeComposerDocumentJSON(draft.text) : null;
+      const normalizedDraftText =
+        draftDocument && tiptapDocHasContent(draftDocument) ? draftDocument : null;
       const textUnchanged =
         JSON.stringify(normalizedDraftText) ===
         JSON.stringify(composerDocIsEmpty(editor.state.doc) ? null : editor.getJSON());

--- a/apps/desktop/src/renderer/components/new-chat/VoiceInputDraftDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/VoiceInputDraftDecoration.ts
@@ -1,5 +1,11 @@
 import { Extension, type Editor } from '@tiptap/core';
-import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
+import {
+  Plugin,
+  PluginKey,
+  TextSelection,
+  type EditorState,
+  type Transaction,
+} from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import type { VoiceInputDraftSource } from '@cindy/voice-input-core';
@@ -43,10 +49,29 @@ function clampPosition(doc: PMNode, position: number): number {
   return Math.max(0, Math.min(position, doc.content.size));
 }
 
+/**
+ * Snap a position onto the nearest place that can hold inline content.
+ *
+ * The draft/caret widgets are inline: rendered at a position whose parent is
+ * NOT a textblock (0 or a boundary between blocks), ProseMirror puts them in
+ * the doc-level DOM — an inline span between two `<p>`s, which the browser then
+ * gives its own line. That reads as a stray blank line above the dictation
+ * caret. Anchors reach such a position whenever the composer document is
+ * rebuilt wholesale while dictation is live (external draft restore does a
+ * `replace(0, size)`), because mapping a collapsed anchor across a full
+ * replacement pushes it out to the block boundary.
+ */
+function clampToInlinePosition(doc: PMNode, position: number): number {
+  const clamped = clampPosition(doc, position);
+  const $pos = doc.resolve(clamped);
+  if ($pos.parent.isTextblock) return clamped;
+  return TextSelection.near($pos, 1).from;
+}
+
 function clampRange(doc: PMNode, from: number, to: number): { from: number; to: number } {
-  const safeFrom = clampPosition(doc, Math.min(from, to));
-  const safeTo = clampPosition(doc, Math.max(from, to));
-  return { from: safeFrom, to: safeTo };
+  const safeFrom = clampToInlinePosition(doc, Math.min(from, to));
+  const safeTo = clampToInlinePosition(doc, Math.max(from, to));
+  return safeFrom <= safeTo ? { from: safeFrom, to: safeTo } : { from: safeFrom, to: safeFrom };
 }
 
 /**
@@ -263,8 +288,13 @@ export function createVoiceInputDraftPlugin(): Plugin<VoiceInputDraftDecorationS
           }
         }
         if (tr.docChanged) {
-          const mappedFrom = tr.mapping.map(old.from, -1);
-          const mappedTo = tr.mapping.map(old.to, 1);
+          // A collapsed anchor must stay collapsed: mapping it with opposite
+          // biases grows it into a range, and a non-empty range makes the
+          // `voice-input-draft-replaced` decoration hide whatever text now sits
+          // inside it (a full-document rebuild would blank the existing draft).
+          const collapsed = old.from === old.to;
+          const mappedFrom = tr.mapping.map(old.from, collapsed ? 1 : -1);
+          const mappedTo = collapsed ? mappedFrom : tr.mapping.map(old.to, 1);
           return createState(
             tr.doc,
             old.text,

--- a/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/composerDraftStore.test.ts
@@ -13,6 +13,7 @@ import {
   setComposerDraftOwner,
   subscribeDraft,
   subscribeDraftPresence,
+  tiptapDocHasContent,
   type ComposerDraft,
 } from '@/lib/composerDraftStore';
 
@@ -271,5 +272,17 @@ describe('draft presence subscription', () => {
 
     unsubPresence();
     unsubContent();
+  });
+
+  // ChatInput 的外部草稿订阅用这个判空把「空文档 JSON」折叠成 null,再与
+  // 「编辑器为空」比较。两侧口径不一致时,每次外部草稿通知都会拿一份空文档整段
+  // setContent,把按位置存活的编辑器状态(语音草稿锚点)连带重建 —— 语音录音时
+  // 首行多出一个空行就是这么来的。
+  it('treats an empty / whitespace-only document as having no content', () => {
+    expect(tiptapDocHasContent(emptyDoc)).toBe(false);
+    expect(tiptapDocHasContent(whitespaceDoc)).toBe(false);
+    expect(tiptapDocHasContent(null)).toBe(false);
+    expect(tiptapDocHasContent(textDoc)).toBe(true);
+    expect(tiptapDocHasContent(mentionDoc)).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/lib/composerDraftStore.ts
+++ b/apps/desktop/src/renderer/lib/composerDraftStore.ts
@@ -134,7 +134,7 @@ const presenceCache = new Map<string, boolean>();
  * Empty paragraphs / whitespace-only → no content. 两处判定必须同步演进,
  * 否则「只含 chip 的草稿」侧边栏不亮未发送标记(review P2)。
  */
-function tiptapDocHasContent(node: JSONContent | null | undefined): boolean {
+export function tiptapDocHasContent(node: JSONContent | null | undefined): boolean {
   if (!node) return false;
   if (
     node.type === 'mentionChip' ||


### PR DESCRIPTION
## 这次改了什么

### 摘要

桌面版语音输入在**第一句话出现之前必然多一个换行**（输入框为空时录音，麦克风光标那一行上下多出一个空行、输入框从 1 行变 2 行）。

根因有两层，都在这个 PR 里收口：

1. **外部草稿通知的判空口径两侧不一致。** `ChatInput` 订阅 `composerDraftStore` 的外部写入后，只有草稿正文与编辑器当前文档不同才做全量 `setContent`。但草稿存储里的"空正文"是 `{doc:[空 paragraph]}`，而比较的另一侧对"编辑器为空"一律折叠成 `null` —— 于是**每条外部草稿通知都会拿一份空文档整段 `setContent`**，把 doc 原地重建一次（实测事务：`replace from 0 to 2`，带 `preventUpdate` meta）。这是 #720 把草稿从字符串改成 Tiptap JSON 之后引入的。
2. **文档被整段重建时，语音草稿装饰的折叠锚点会被推出段落。** `VoiceInputDraftDecoration` 的 `docChanged` 分支用 `map(from, -1)` / `map(to, 1)` 反向 bias 映射，折叠锚点 `{1,1}` 被撑成 `{0,2}`。位置 0 的父节点不是 textblock，ProseMirror 于是把 inline 的 caret / 草稿 widget 渲染到 `<p>` **外面**（doc 层的裸 `<span>`），浏览器给它单独一行 —— 这就是那个多出来的换行。

顺带修掉一个更隐蔽的同源隐患：锚点从折叠膨胀成区间后，`voice-input-draft-replaced`（`display:none`）会把区间内**已有的正文整段隐藏**。

**第二轮（实机复验发现，新建对话页仍复现「语音结束时文字前多一个回车」）**，补齐两处同源缺口：

3. **`ChatInput` 的 storageKey 对齐分支同样用 `draft?.text` 当"有草稿"判据**，漏掉空文档 JSON。这个 effect 依赖 `voiceInput.isBusy` —— 录音开始与结束各重跑一次；新建对话页草稿键固定（`__new_maker_draft__`）、常留着一份空正文，于是每次录音都白重建一次 doc。已有会话的草稿键随会话变化、通常没有这份空正文残留，所以只在新建对话页复现。
4. **位置钳制只钳到 `doc.content.size`，而那本身就是 block 边界。** doc 被重建后插入点被映射到边界上，`tr.insertText` 于是把文字包进一个**新段落**，上屏文字前凭空多出一个空段落 —— 这就是"结束时前面多一个回车"。

把 inline 位置吸附收敛成共享实现 `clampEditorTextRangeToDoc` / `clampToInlinePosition`（`editorRangeMapping.ts`），语音插入点、词典学习 watch 范围、润色预览锚点与草稿装饰锚点全部走它；`mapEditorTextRange` 映射后也吸附回段落内。装饰侧原先的本地实现删掉，不再两处并存。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实机反馈）
- 本 PR 包含：
  - `ChatInput.tsx` 外部草稿比较改走共享判空 `tiptapDocHasContent`，空草稿通知不再重建文档；
  - `VoiceInputDraftDecoration.ts` 锚点一律吸附到最近的 inline 位置（`clampToInlinePosition`），折叠锚点跨 doc 变更保持折叠；
  - `composerDraftStore.ts` 导出 `tiptapDocHasContent`（判空口径单一实现，与 `draftHasContent` / `isEditorEmpty` 同源）；
  - `editorRangeMapping.ts` 新增共享的 inline 位置吸附（`clampToInlinePosition` / `clampEditorTextRangeToDoc`），`useVoiceInput` 的全部位置钳制与 `mapEditorTextRange` 改走它；
  - `ChatInput.tsx` storageKey 对齐分支同样按共享判空跳过空草稿重建；
  - 7 条测试（见下）。
- 明确不包含：不动语音识别、润色、词典、草稿存储格式，也不动 #720 的结构化列表模型本身。
- 用户可见变化：语音录音期间与上屏后输入框都不再多出空行，麦克风光标与上屏文字都停在正确的插入点（新建对话页与已有会话一致）。
- 是否存在 breaking change：无

### UI 变化

不涉及：只修正装饰锚点的位置计算与一处多余的文档重建，没有新增/修改任何样式、布局、动效或文案。缺陷表现是布局副作用，修复后回到既有设计的预期形态。

- 引用的设计规范：不涉及（无视觉/交互/文案变更）

## 怎么验证的

### 自动验证

```text
pnpm test:unit（仓库根全量）
结果：GATE_EXIT=0，50 个 workspace PASS，无 FAIL
  首轮曾有 3 例 src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts 失败
  （EINVAL rename /tmp/native-provider-auth-binding-test/...）。该文件用固定 /tmp
  目录，单跑在本分支与 origin/main 基线均 21/21 通过，重跑门禁全绿 → 并发偶发，
  与本改动无关，未混入修复。

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/voiceInputDraftDecoration.test.ts
结果：8 passed（含本 PR 新增 2 条回归；把 VoiceInputDraftDecoration 的改动
      反向 apply 后这 2 条确实失败，修复后通过）

pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/composerDraftStore.test.ts
结果：14 passed

pnpm --filter desktop exec vitest run src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
结果：2 passed

pnpm --filter desktop exec vitest run src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
结果：8 passed（含本 PR 新增 3 条：整篇替换后锚点吸附回段落内、block 边界位置吸附、
      越界与倒序范围归一）

第二轮修复后重跑：pnpm test:unit（仓库根全量）GATE_EXIT=0；
pnpm --filter desktop typecheck 通过。
```

新增/加强的测试：

- `voiceInputDraftDecoration.test.ts`：文档被整段重建后，caret 锚点仍落在段落内的 inline 位置（widget 的 `from` 解析出的父节点 `isTextblock`）；折叠锚点跨整段替换保持折叠（防止正文被 `display:none` 隐藏）。
- `composerDraftStore.test.ts`：`tiptapDocHasContent` 对空文档 / 纯空白文档判为无内容。
- `composerExternalDraftEmptyDoc.test.ts`：锁住外部草稿分支与 storageKey 对齐分支都必须用共享判空跳过空文档，不能只判断 `draft.text` 是否存在。
- `editorRangeMapping.test.ts`：整篇替换后锚点吸附回段落内（并断言用该位置 `insertText` 不会生成第二个段落）；block 边界 / 越界 / 倒序范围的钳制归一。

### 手工验证

macOS / desktop dev（`pnpm restart:desktop:remote --preserve-running`，本 worktree，`pnpm desktop:whoami` 校验 root + commit 匹配），在 renderer 里埋临时探针打印真实录音时的插件状态、DOM 与几何（探针已全部删除，不在本 PR diff 内）：

- 修复前：`pluginState {from:0, to:2}`，DOM 为 `<div class="ProseMirror"><span data-voice-caret …></span><p><br></p></div>`，`.ProseMirror` 高 50px（两行）。
- 修复后：`pluginState {from:1, to:1}`，DOM 只有一个 `<p>`（caret widget 在段落内），`.ProseMirror` 高 28px（单行）。

第二轮的现象由用户在同一 dev 实例上实机复验发现（新建对话页语音结束时文字前仍多一个回车；已有会话正常），据此定位到上面第 3、4 点。第二轮修复后的实机复验待用户在新建对话页确认。

### 未执行的验证

- 第二轮修复的实机复验（新建对话页语音上屏）尚未由我确认，等用户在 dev 实例上复验；自动化侧已有对应回归测试覆盖。
- Windows 未验证：改动是纯 ProseMirror 位置计算 + 两处判空，无平台分支。
- Light / Dark 双模式未逐一目检：本 PR 不涉及颜色 token 或任何样式改动。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：语音听写的插入点 / 装饰锚点 / 词典学习 watch 的位置钳制（统一吸附到 inline 位置，越界与 block 边界不再被当成合法插入点）；输入框对外部草稿写入（rewind / fork 预填、引用插入等）与首挂载 / 语音状态切换时的草稿恢复路径。后两者只是**少做**一次无意义的整段 `setContent`（编辑器与草稿都为空时），非空草稿的恢复逻辑不变。
- 回滚 / 降级方式：直接 revert 本 commit，无数据/协议/存储格式变更，无需迁移。
