### PR TITLE
fix(mobile): #730 review 收口——权限阶段手势取消、录音中创建豁免收窄

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -3697,6 +3697,19 @@ export default function SessionScreen() {
     return () => subscription.remove();
   }, [cancelVoiceForAppBackground]);
 
+  // 手势被系统/滚动终止时的撤销:比 app 后台版多一步——同时作废还开着的麦克风
+  // 权限请求。后台版必须让权限弹窗存活(见上方 AppState 注释:权限弹窗会短暂
+  // 触发 background),手势取消恰相反:首次使用时按下即录会先弹权限,此时
+  // startupInFlight/controller 都还是 false,只作废预热不够——权限批准归来后
+  // 启动会继续、麦克风开录,而那次按下早已被取消(review P1)。
+  const cancelVoiceForGestureTermination = useCallback(() => {
+    voicePermissionRequestSeqRef.current += 1;
+    voicePermissionRequestAbortRef.current?.abort();
+    voicePermissionRequestAbortRef.current = null;
+    voicePermissionRequestInFlightRef.current = false;
+    cancelVoiceForAppBackground();
+  }, [cancelVoiceForAppBackground]);
+
   useEffect(() => {
     return () => {
       const controller = voiceControllerSessionRef.current;
@@ -3882,7 +3895,7 @@ export default function SessionScreen() {
         // 正常松手(含拖出按钮后松开)不走这里,对齐桌面「pointercancel 才撤销」。
         if (!voiceStartedOnPressInRef.current) return;
         voiceStartedOnPressInRef.current = false;
-        cancelVoiceForAppBackground();
+        cancelVoiceForGestureTermination();
       }}
       style={[
         styles.composerInlineToolButton,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -782,10 +782,17 @@ export default function NewRemoteSessionScreen() {
   const deviceSelectorDisabled = creating || voiceIsProcessing || !deviceHasChoices;
   // 上传中不再挡创建:附件走乐观管线(pendingUploads),create() 内部会 await 全部
   // 在途上传落定后再组首条消息,抢点创建不会丢图(#589 的 attachmentBusy 门由此取代)。
-  // listening 时豁免「缺正文/附件」校验:此刻点创建 = 结束录音并用转写创建
-  // (create() 的 listening 分支),最终转写在 create() 内部重新校验;不豁免的话
-  // 空草稿录音期间创建按钮永远按不动,「点创建停录并创建」形同虚设(review P1)。
-  const canCreate = (!createValidation || voiceIsListening) && !creating && !voiceIsProcessing;
+  // listening 时**只**豁免「缺正文/附件」这一条校验:此刻点创建 = 结束录音并用
+  // 转写创建(create() 的 listening 分支),最终转写在 create() 内部重新校验;
+  // 不豁免的话空草稿录音期间创建按钮永远按不动。缺项目路径/模型等其它校验不
+  // 豁免——那些不会被转写补上,放行只会「可点但必失败」(review 二轮收窄)。
+  // validateNewSessionDraft 的校验顺序是 路径→模型→正文,命中缺正文文案即代表
+  // 前两项都已通过。
+  const createValidationIsMissingPayload =
+    createValidation === t('session.new.enterFirstMessageOrAttachment');
+  const canCreate = (!createValidation || (voiceIsListening && createValidationIsMissingPayload))
+    && !creating
+    && !voiceIsProcessing;
   const voiceIsBusy = voiceIsListening || voiceIsProcessing;
   // 录音计时(红点+m:ss 胶囊,与会话页/桌面同形态);pillWidth 同步驱动工具排占位。
   // counting 只认真实采集,启动链路(权限弹窗等)不计入时长,pending 期显示 0:00。

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -135,6 +135,7 @@ import {
   buildRecentWorkspaceOptions,
   filterRemoteDirectoryEntries,
   normalizeCreateSessionResult,
+  isNewSessionDraftMissingPayloadOnly,
   parseNewSessionDeviceOptions,
   pickAgentDefaultRuntime,
   pickInitialNewSessionWorkspace,
@@ -788,8 +789,13 @@ export default function NewRemoteSessionScreen() {
   // 豁免——那些不会被转写补上,放行只会「可点但必失败」(review 二轮收窄)。
   // validateNewSessionDraft 的校验顺序是 路径→模型→正文,命中缺正文文案即代表
   // 前两项都已通过。
-  const createValidationIsMissingPayload =
-    createValidation === t('session.new.enterFirstMessageOrAttachment');
+  // 结构化判定,不比对本地化文案:locale 异步恢复(如深链直达后语言落地)时
+  // memo 住的旧语言校验文案与新 t() 输出不等,字符串比对会让豁免静默失效
+  // (review 三轮收口)。
+  const createValidationIsMissingPayload = useMemo(
+    () => isNewSessionDraftMissingPayloadOnly(draft, draftContent),
+    [draft, draftContent],
+  );
   const canCreate = (!createValidation || (voiceIsListening && createValidationIsMissingPayload))
     && !creating
     && !voiceIsProcessing;

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -865,7 +865,10 @@ describe('new session composer surface', () => {
     expect(newSource).toContain("|| voiceStartPending\n    || voiceState === 'listening'\n    || voiceState === 'submitting'\n    || voiceState === 'refining';");
     // listening 时只豁免「缺正文/附件」校验(路径/模型等其它校验不放行,
     // 否则按钮可点但必失败):点创建 = 停录并用最终转写创建(review 二轮收窄)。
-    expect(newSource).toContain("createValidation === t('session.new.enterFirstMessageOrAttachment');");
+    // 判定必须是结构化的 isNewSessionDraftMissingPayloadOnly,禁止比对本地化
+    // 文案——locale 异步恢复时字符串比对会静默失效(review 三轮收口)。
+    expect(newSource).toContain('isNewSessionDraftMissingPayloadOnly(draft, draftContent)');
+    expect(newSource).not.toContain("=== t('session.new.enterFirstMessageOrAttachment')");
     expect(newSource).toContain('const canCreate = (!createValidation || (voiceIsListening && createValidationIsMissingPayload))');
     expect(newSource).not.toContain('(!createValidation || voiceIsListening) &&');
     expect(newSource).toContain('const composerShowCreateButton = composerHasMessage');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -863,8 +863,11 @@ describe('new session composer surface', () => {
     // 语音生命周期内创建按钮常驻(2026-07-25 对齐桌面):录音中点创建=结束录音并
     // 用转写创建;否则首段转写落地瞬间按钮冒出来会把语音胶囊整格推左。
     expect(newSource).toContain("|| voiceStartPending\n    || voiceState === 'listening'\n    || voiceState === 'submitting'\n    || voiceState === 'refining';");
-    // listening 时豁免缺正文校验:点创建 = 停录并用最终转写创建(review P1)。
-    expect(newSource).toContain('const canCreate = (!createValidation || voiceIsListening) && !creating && !voiceIsProcessing;');
+    // listening 时只豁免「缺正文/附件」校验(路径/模型等其它校验不放行,
+    // 否则按钮可点但必失败):点创建 = 停录并用最终转写创建(review 二轮收窄)。
+    expect(newSource).toContain("createValidation === t('session.new.enterFirstMessageOrAttachment');");
+    expect(newSource).toContain('const canCreate = (!createValidation || (voiceIsListening && createValidationIsMissingPayload))');
+    expect(newSource).not.toContain('(!createValidation || voiceIsListening) &&');
     expect(newSource).toContain('const composerShowCreateButton = composerHasMessage');
     expect(newSource).toContain('const deviceSelectorDisabled = creating || voiceIsProcessing || !deviceHasChoices;');
     // 按下即录(pressIn 起录):同一手势的松手由 voiceStartedOnPressInRef 吞掉,

--- a/apps/mobile/src/session/newSession.ts
+++ b/apps/mobile/src/session/newSession.ts
@@ -159,6 +159,22 @@ export function validateNewSessionDraft(
   return null;
 }
 
+/**
+ * 校验失败是否**仅**缺正文/附件(项目路径与模型均已通过)。
+ * 语音听写中「点创建 = 停录并用转写创建」的豁免判定:只有这一类失败会被
+ * 最终转写补上,才允许放行。结构化判定,与 validateNewSessionDraft 同模块
+ * 同顺序维护——不要在调用方比对本地化文案(locale 异步恢复时 memo 住的
+ * 旧语言文案与新 t() 输出不等,豁免会静默失效)。
+ */
+export function isNewSessionDraftMissingPayloadOnly(
+  draft: NewSessionDraft,
+  content: NewSessionDraftContentState = {},
+): boolean {
+  if (draft.workspaceKind === 'project' && !draft.workingDir.trim()) return false;
+  if (!draft.model.trim()) return false;
+  return !hasFirstMessagePayload(draft, content);
+}
+
 export function summarizeNewSessionDraft(
   draft: NewSessionDraft,
   content: NewSessionDraftContentState = {},


### PR DESCRIPTION
## 这次改了什么

### 摘要

#730（手机语音输入对齐桌面）合并时，第二轮 review 修复刚好错过合并窗口——本 PR 承载这两条收口（原 review threads 见 #730）：

1. **权限阶段的手势取消漏口**（Codex P1）：首次使用时「按下即录」会先弹麦克风权限，此时 `startupInFlightRef` / controller / recording refs 都还是 false，`cancelVoiceForAppBackground()` 走非 owner 分支只作废预热——权限批准归来后启动继续、麦克风开录，而那次按下早已被手势取消。新增 `cancelVoiceForGestureTermination`：先作废权限请求世代（`voicePermissionRequestSeqRef` +1 并 abort），再走后台版取消；后台版本身保持不动（权限弹窗会短暂触发 background，必须存活）。`new.tsx` 的 `cancelVoiceForDeviceSwitch` 本就作废权限世代，无需改。
2. **新建会话录音中创建豁免收窄**（Copilot + Codex P1）：`|| voiceIsListening` 原来会把缺项目路径/模型等校验一并放行，按钮「可点但必失败」。收窄为只豁免「缺正文/附件」一条——`validateNewSessionDraft` 校验顺序为 路径→模型→正文，命中缺正文文案即代表前两项已过；缺路径/模型时创建按钮保持禁用。契约断言同步收紧。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#730 的 review follow-up（合并前最后一轮 review threads 的修复）
- 本 PR 包含：`apps/mobile/app/sessions/[sessionId].tsx`（`cancelVoiceForGestureTermination` + onTouchCancel 接线）、`apps/mobile/app/sessions/new.tsx`（`createValidationIsMissingPayload` 收窄）、`apps/mobile/src/__tests__/newSession.test.ts`（断言收紧）
- 明确不包含：#730 上 `sessionOperation.ts` 新文案的 i18n 反馈——该共享模块所有既有文案（约 15 条 disabledReason/guidance/status）均为中文字面量、无任何 i18n 依赖，属模块级既有债务，单独本地化一条无济于事，已在原 thread 回复说明并记为后续整体重构项
- 用户可见变化：首次使用语音时若手势被滚动/系统打断，权限弹窗批准后不再意外开始录音；新建会话缺路径/模型时创建按钮在录音中保持禁用
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：无视觉/布局/文案变化，仅手势取消路径与按钮可用性判定收窄（视觉规范引用见 #730）。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile typecheck
结果：0 错误

pnpm --filter mobile test
结果：Test Files 258 passed (258)，Tests 2496 passed (2496)

根 pnpm test:unit（统一走 run-unit-gate.sh，基于合并后 main c0a482a1 + cherry-pick）
结果：见 PR checks（本地跑通后 push）
```

### 手工验证

内容与 #730 合并前在旧分支上验证的 `9a8442fd` 逐字节一致（cherry-pick），当时本地门禁 `GATE_EXIT=0`。权限弹窗中断路径依赖首次授权状态，模拟器重置权限实测未做（逻辑路径由既有 `voicePermissionRequestSeqRef` 世代机制保证，startVoiceRecording 已有对应的世代检查分支）。

### 未执行的验证

- 真机/重置权限场景的手工复现未做（见上）。
- Dark 模式不涉及（无视觉变化）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：mobile 语音按钮手势取消路径与新建会话创建按钮可用性。纯 JS/TS，不触 fingerprint。
- 回滚 / 降级方式：`git revert` 单 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（决策以代码注释 + 契约测试固化）
- [x] 已确认测试结果或说明未执行原因
