### PR TITLE
fix(desktop): guard provider model fetch IPC

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -1001,6 +1001,27 @@ describe('provider:test-connection handler', () => {
 });
 
 describe('provider:models-fetch handler', () => {
+  it('rejects an untrusted sender before issuing a credentialed model request', async () => {
+    const harness = new IpcHarness();
+    const assertTrustedSender = vi.fn(() => {
+      throwIpcError('PERMISSION_DENIED', '此操作只能从 Cindy 主页面发起');
+    });
+    const deps = makeDeps({ assertTrustedSender });
+    registerProviderHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_FETCH, {
+        agent: 'codex',
+        baseUrl: 'https://attacker.example/v1',
+        authMethod: 'apiKey',
+        apiKey: 'credential-must-not-leave-main',
+        headers: { 'x-api-key': 'custom-credential' },
+      }),
+    ).rejects.toThrow(/PERMISSION_DENIED/);
+    expect(assertTrustedSender).toHaveBeenCalledOnce();
+    expect(deps.fetchModels).not.toHaveBeenCalled();
+  });
+
   it('forwards parsed input and returns the structured result', async () => {
     const harness = new IpcHarness();
     const fetchModels = vi.fn(async () => ({

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -741,7 +741,11 @@ export function registerProviderHandlers(
   });
 
   // 获取模型列表：查询型结构化返回（同上例外条款）；网络/上游失败在结果 code 里，不抛。
-  registry.handle(MAKER_INVOKE.PROVIDER_MODELS_FETCH, async (_event, input: unknown) => {
+  registry.handle(MAKER_INVOKE.PROVIDER_MODELS_FETCH, async (event, input: unknown) => {
+    // 这条查询会把 renderer 提供的 API key / 自定义 headers 带到目标 endpoint；
+    // 与重新发现一样，必须先确认调用方是 Cindy 自有顶层页面，避免 WebView / 子 frame
+    // 把 Main 变成可向任意 http(s) 地址发凭证请求的代理。
+    assertTrustedProviderMutationSender(event);
     const parsed = parseModelsFetchInput(input);
     if (!parsed) throwIpcError('INVALID_PARAMS', 'invalid models-fetch input');
     return deps.fetchModels(parsed);

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -740,7 +740,7 @@ export function registerProviderHandlers(
     }
   });
 
-  // 获取模型列表：查询型结构化返回（同上例外条款）；网络/上游失败在结果 code 里，不抛。
+  // 获取模型列表：查询型结构化返回（同上例外条款）；仅网络/上游失败在结果 code 里，不抛。
   registry.handle(MAKER_INVOKE.PROVIDER_MODELS_FETCH, async (event, input: unknown) => {
     // 这条查询会把 renderer 提供的 API key / 自定义 headers 带到目标 endpoint；
     // 与重新发现一样，必须先确认调用方是 Cindy 自有顶层页面，避免 WebView / 子 frame


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #526 合并后 Codex review 发现的 IPC 信任边界缺口：`PROVIDER_MODELS_FETCH` 会携带 renderer 提供的 API key / 自定义 headers 请求目标 endpoint，现在与 provider CRUD / models rediscover 共用同一个 fail-closed 可信 app renderer 守卫，并在解析参数和发起网络请求前拒绝 WebView、子 frame 与其他非 app renderer。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#526 合并后 review https://github.com/makecindy/cindy/pull/526#pullrequestreview-4793085055；架构讨论 #528
- 本 PR 包含：模型列表获取 IPC 的 sender guard；不可信 sender 不触发网络依赖的回归测试
- 明确不包含：provider 路由、OAuth/device-code 行为或 UI 的其他调整
- 用户可见变化：无；仅收紧 IPC 调用来源
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/providerHandlers.test.ts
结果：44 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全仓 unit tier 通过

pnpm check:dco
结果：1 commit signed off

git diff --check
结果：通过
```

### 手工验证

不涉及；回归测试直接从内存 IPC harness 注入不可信 sender，断言返回 `PERMISSION_DENIED` 且 `fetchModels` 未调用。

### 未执行的验证

未运行 `pnpm test:all`：改动仅复用既有 sender guard，并已完成定向回归、Desktop typecheck 与仓库 unit 门禁。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `maker:provider:models-fetch`；合法 Cindy 顶层 renderer 仍按原流程获取模型，非受信 renderer 现在 fail closed。
- 回滚 / 降级方式：回滚本提交会恢复旧行为，但会重新暴露 credentialed request IPC，因此不建议降级。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
