### PR TITLE
fix(responses-chat-bridge): drop Codex tool_search replay items instead of failing

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -299,6 +299,86 @@ describe('translateResponsesRequest', () => {
     }))).toThrowError(UnsupportedResponsesFeatureError);
   });
 
+  it('drops replayed Codex tool_search items without breaking tool-call merging', () => {
+    const dropped: Array<[string, number]> = [];
+    const out = translateResponsesRequest(base({
+      input: [
+        { type: 'message', role: 'user', content: 'hi' },
+        { type: 'tool_search_call', id: 'ts_1' },
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'shell',
+          arguments: '{"cmd":"ls"}',
+        },
+        { type: 'tool_search_output', id: 'ts_1', output: {} },
+        { type: 'tool_search_call_output', call_id: 'ts_1', output: {} },
+        { type: 'function_call_output', call_id: 'call_1', output: 'ok' },
+      ],
+    }), { onDroppedInputItem: (type, index) => dropped.push([type, index]) });
+
+    expect(out.messages).toEqual([
+      { role: 'user', content: 'hi' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'shell', arguments: '{"cmd":"ls"}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'ok' },
+    ]);
+    expect(dropped).toEqual([
+      ['tool_search_call', 1],
+      ['tool_search_output', 3],
+      ['tool_search_call_output', 4],
+    ]);
+  });
+
+  it('does not let dropped tool_search items split assistant merging', () => {
+    const dropped: string[] = [];
+    const out = translateResponsesRequest(base({
+      input: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: 'planning',
+        },
+        { type: 'tool_search_call', id: 'ts_1' },
+        { type: 'tool_search_output', id: 'ts_1', output: {} },
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'shell',
+          arguments: '{"cmd":"ls"}',
+        },
+        { type: 'tool_search_call_output', call_id: 'ts_1', output: {} },
+        {
+          type: 'function_call',
+          call_id: 'call_2',
+          name: 'shell',
+          arguments: '{"cmd":"pwd"}',
+        },
+        { type: 'function_call_output', call_id: 'call_1', output: 'a' },
+        { type: 'function_call_output', call_id: 'call_2', output: 'b' },
+      ],
+    }), { onDroppedInputItem: (type) => dropped.push(type) });
+
+    expect(out.messages).toEqual([
+      {
+        role: 'assistant',
+        content: 'planning',
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'shell', arguments: '{"cmd":"ls"}' } },
+          { id: 'call_2', type: 'function', function: { name: 'shell', arguments: '{"cmd":"pwd"}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'a' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'b' },
+    ]);
+    expect(dropped).toEqual(['tool_search_call', 'tool_search_output', 'tool_search_call_output']);
+  });
+
   it('translates capability-gated Kimi user images and preserves replayed history order', () => {
     const imageUrl = 'data:image/png;base64,aW1hZ2U=';
     const out = translateResponsesRequest(base({

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -130,6 +130,11 @@ export function createResponsesChatHandler(
           onDroppedTool: (type, index) => {
             log.warn?.('responses-chat bridge dropped non-function tool', { type, index });
           },
+          onDroppedInputItem: (type, index) => {
+            // tool_search_* 是 Codex 每轮重放的历史内建 item，属于预期兼容路径，
+            // 不发 warn 避免随会话长度二次增长日志。
+            log.debug?.('responses-chat bridge dropped built-in input item', { type, index });
+          },
         });
       } catch (error) {
         if (error instanceof UnsupportedResponsesFeatureError) {

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -123,6 +123,8 @@ interface TranslateInputOptions {
   toolCallReasoningPlaceholder: boolean;
   /** Gemini 3 OpenAI 兼容层:为每步首个回放 tool call 注入官方允许的签名跳过值。 */
   googleThoughtSignaturePlaceholder: boolean;
+  /** 丢弃的无上下文内建 input item(Codex tool_search 等)回调,供 handler 记 log。 */
+  onDroppedInputItem?: (type: string, index: number) => void;
 }
 
 /** cc-switch 的占位口径:kimi/DeepSeek 要求 tool_call assistant 消息带非空 reasoning_content。 */
@@ -182,6 +184,18 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
   for (let index = 0; index < input.length; index += 1) {
     const item = input[index];
     if (!isPlainObject(item)) throw new UnsupportedResponsesFeatureError(`input[${index}]`);
+    const itemType = typeof item.type === 'string' ? item.type : undefined;
+    if (
+      itemType === 'tool_search_call'
+      || itemType === 'tool_search_output'
+      || itemType === 'tool_search_call_output'
+    ) {
+      // Codex 内建 tool_search 的回放 item：与 namespace/web_search 工具声明同口径，
+      // 对第三方 Chat 上游无意义且不承载用户上下文，必须作为“非边界”item 剥掉降级
+      // —— 在 flushAssistant 之前处理，避免拆分本应合并的 assistant message。
+      opts.onDroppedInputItem?.(itemType, index);
+      continue;
+    }
 
     if ('role' in item && typeof item.role === 'string') {
       const content = messageContent(
@@ -336,6 +350,8 @@ export interface TranslateResponsesRequestOptions {
   capabilities?: ChatBridgeCapabilities;
   /** 被剥掉的非 function 工具(Codex 内建 namespace / local_shell 等)回调,供 handler 记 log。 */
   onDroppedTool?: (type: string, index: number) => void;
+  /** 被剥掉的无上下文内建 input item(Codex tool_search 等)回调,供 handler 记 log。 */
+  onDroppedInputItem?: (type: string, index: number) => void;
 }
 
 /** Convert a Codex Responses request to a streaming Chat Completions request. */
@@ -353,6 +369,7 @@ export function translateResponsesRequest(
     imageInput: capabilities.imageInput,
     toolCallReasoningPlaceholder: capabilities.toolCallReasoningPlaceholder === true,
     googleThoughtSignaturePlaceholder: capabilities.googleThoughtSignaturePlaceholder === true,
+    onDroppedInputItem: opts.onDroppedInputItem,
   });
   if (input.instructions) {
     messages.unshift({ role: developerRole, content: input.instructions });


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 最新版本会在 Responses `input` 历史中回放 `tool_search_call` / `tool_search_output` / `tool_search_call_output` 内建 item。这些 item 是 Codex 内部工具搜索调用记录，对第三方 Chat Completions 上游无等价语义、也不承载用户上下文。

本 PR 将这三类 item 改为显式丢弃（与 `reasoning` 及非 `function` 工具声明的降级口径一致），不再抛 `unsupported_feature` 中断整条请求。丢弃逻辑放在 `flushAssistant` 之前，作为非边界 item 处理，避免拆分本应合并的 assistant message。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - `packages/responses-chat-bridge/src/translate-request.ts`：丢弃 `tool_search_call` / `tool_search_output` / `tool_search_call_output`
  - `packages/responses-chat-bridge/src/handler.ts`：接入 `onDroppedInputItem` 回调记 `debug` log
  - `packages/responses-chat-bridge/src/__tests__/translate-request.test.ts`：新增回归测试
- 明确不包含：第一个空 user 消息问题（用户要求暂不修复）
- 用户可见变化：Kimi 等 Chat Completions 供应商不再因 `tool_search_call` 直接 400
- 是否存在 breaking change：无

### UI 变化

- 不涉及：改动纯在桥接层，无 UI/文案/交互变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-chat-bridge test
```
结果：62 tests passed (3 test files)

```text
pnpm --filter @cindy/responses-chat-bridge run typecheck
```
结果：`tsc --noEmit` 通过

### 手工验证

- 不涉及：问题由 Responses→Chat 桥接层抛出，回归测试覆盖。

### 未执行的验证

- 未在实机 Cindy 桌面端触发真实 `tool_search_call` 链路端到端验证。
- 未跑仓库根 `pnpm test:unit`（已知该命令在当前环境有问题）。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅限 `packages/responses-chat-bridge`，即 Codex Responses → Chat Completions 桥接层；影响所有经该桥接的第三方 Chat 供应商（如 Kimi）。
- 回滚 / 降级方式：回滚本 PR 即可恢复原有 `unsupported_feature` 拒绝行为；降级后 tool_search 请求会再次 400。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
