### PR TITLE
feat(settings): 优化对话导入工作区

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
@@ -72,9 +72,8 @@ describe('SessionImportSection initial scan', () => {
   });
 
   it('keeps scan summary explanations visible instead of relying on pointer-only title tooltips', () => {
-    expect(source).toContain(
-      'className="mt-1 text-11 leading-[1.4] text-[var(--settings-section-desc)]">{hint}</p>',
-    );
+    expect(source).toContain('mt-1 text-11 leading-[1.4] text-[var(--settings-section-desc)]');
+    expect(source).toMatch(/>\s*\{hint\}\s*<\/p>/);
     expect(source).not.toContain('title={hint}');
     expect(source).not.toContain('className="sr-only">{hint}</span>');
   });
@@ -91,7 +90,7 @@ describe('SessionImportSection initial scan', () => {
       'shrink-0 whitespace-nowrap rounded-full border border-[var(--settings-input-border)]',
     );
     expect(source).toContain(
-      'className="min-w-0 flex-1 truncate text-13 font-medium text-[var(--settings-section-sublabel)]"',
+      'min-w-0 flex-1 truncate text-13 font-medium text-[var(--settings-section-sublabel)]',
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
@@ -78,6 +78,15 @@ describe('SessionImportSection initial scan', () => {
     );
   });
 
+  it('keeps metadata pills on one line and lets long session titles truncate instead of stretching rows', () => {
+    expect(source).toContain(
+      'shrink-0 whitespace-nowrap rounded-full border border-[var(--settings-input-border)]',
+    );
+    expect(source).toContain(
+      'className="min-w-0 flex-1 truncate text-13 font-medium text-[var(--settings-section-sublabel)]"',
+    );
+  });
+
   it('uses the sidebar time formatter for project and session-row timestamps', () => {
     expect(source).toContain(
       "import { formatSidebarTime, formatSidebarTimeAbsolute } from '@/features/cc-agent/lib/formatSidebarTime';",

--- a/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
@@ -71,6 +71,14 @@ describe('SessionImportSection initial scan', () => {
     );
   });
 
+  it('keeps scan summary explanations visible instead of relying on pointer-only title tooltips', () => {
+    expect(source).toContain(
+      'className="mt-1 text-11 leading-[1.4] text-[var(--settings-section-desc)]">{hint}</p>',
+    );
+    expect(source).not.toContain('title={hint}');
+    expect(source).not.toContain('className="sr-only">{hint}</span>');
+  });
+
   it('surfaces selections hidden by the current filters next to the import button', () => {
     expect(source).toContain('const hiddenSelectedCount = selectedItems.length - visibleSelectedCount;');
     expect(source).toMatch(

--- a/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionImportAutoScan.test.ts
@@ -42,7 +42,7 @@ describe('SessionImportSection initial scan', () => {
 
   it('places project selection before the expand control and indents project child rows', () => {
     expect(source).toContain('grid min-h-14 grid-cols-[16px_20px_minmax(0,1fr)_auto] items-center gap-x-2 px-4 py-2');
-    expect(source).toContain('className="flex h-6 w-5 items-center justify-center rounded-md');
+    expect(source).toContain('className="flex h-6 w-5 items-center justify-center rounded-full');
     expect(source).toMatch(
       /checked=\{selectedCount === group\.items\.length\}[\s\S]*onClick=\{\(\) => toggleGroup\(group\.key\)\}/,
     );

--- a/apps/desktop/src/renderer/components/settings/AboutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AboutSection.tsx
@@ -97,13 +97,14 @@ export function AboutSection() {
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
-        {t('settings.about.title')}
-      </h2>
-
-      <p className="text-13 leading-[1.6] text-[var(--settings-section-desc)]">
-        {t('settings.about.description')}
-      </p>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
+          {t('settings.about.title')}
+        </h2>
+        <p className="text-13 leading-[1.5] text-[var(--settings-section-desc)]">
+          {t('settings.about.description')}
+        </p>
+      </div>
 
       {/* Info Card */}
       <div

--- a/apps/desktop/src/renderer/components/settings/CollaborationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/CollaborationSection.tsx
@@ -54,7 +54,7 @@ export function CollaborationSection() {
   return (
     <div className="flex flex-col gap-6 px-1">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="text-15 font-medium text-[var(--text-primary)]">
+        <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.collaboration.title')}
         </h2>
         <DefaultOverrideControls

--- a/apps/desktop/src/renderer/components/settings/CollaborationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/CollaborationSection.tsx
@@ -45,14 +45,14 @@ export function CollaborationSection() {
 
   if (!settings) {
     return (
-      <div className="px-1 py-8 text-center text-13 text-[var(--text-tertiary)]">
+      <div className="py-8 text-center text-13 text-[var(--text-tertiary)]">
         {t('settings.collaboration.loading')}
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-6 px-1">
+    <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.collaboration.title')}

--- a/apps/desktop/src/renderer/components/settings/HelpSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/HelpSection.tsx
@@ -21,13 +21,14 @@ export function HelpSection({ onAskHelp }: HelpSectionProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
-        {t('settings.help.title')}
-      </h2>
-
-      <p className="text-13 leading-[1.6] text-[var(--settings-section-desc)]">
-        {t('settings.help.description')}
-      </p>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
+          {t('settings.help.title')}
+        </h2>
+        <p className="text-13 leading-[1.5] text-[var(--settings-section-desc)]">
+          {t('settings.help.description')}
+        </p>
+      </div>
 
       <div className={cardClass}>
         <div className="flex items-start gap-3">

--- a/apps/desktop/src/renderer/components/settings/ImBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImBotSection.tsx
@@ -98,7 +98,7 @@ export function ImBotSection({
   return (
     <div className="flex flex-col gap-2 px-1">
       <div className="flex items-center gap-2">
-        <h2 className="text-15 font-medium text-[var(--text-primary)]">
+        <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.sections.imBot')}
         </h2>
         <span className="rounded-full border border-[var(--settings-badge-border)] bg-[var(--settings-badge-bg)] px-2 py-[1px] text-10 font-medium uppercase leading-[1.5] tracking-wide text-[var(--text-secondary)]">

--- a/apps/desktop/src/renderer/components/settings/ImBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImBotSection.tsx
@@ -96,7 +96,7 @@ export function ImBotSection({
   const effectiveGroup = cindyGroupAvailable ? group : 'personal';
 
   return (
-    <div className="flex flex-col gap-2 px-1">
+    <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
         <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.sections.imBot')}

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1359,14 +1359,14 @@ export function ProvidersSection() {
 
   return (
     <div className="flex flex-col gap-[14px]">
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1">
         <h2
-          className="text-18 font-semibold leading-[1.2]"
+          className="text-16 font-medium leading-[1.2]"
           style={{ color: 'var(--settings-section-title)' }}
         >
           {t('settings.providers.title')}
         </h2>
-        <p className="text-13 leading-snug" style={{ color: 'var(--settings-section-desc)' }}>
+        <p className="text-13 leading-[1.5]" style={{ color: 'var(--settings-section-desc)' }}>
           {t('settings.providers.subtitle')}
         </p>
       </div>

--- a/apps/desktop/src/renderer/components/settings/RemoteControlSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteControlSection.tsx
@@ -227,10 +227,10 @@ export function RemoteControlSection() {
   return (
     <div className="flex flex-col gap-2 px-1">
       <div className="flex flex-col gap-1">
-        <h2 className="text-15 font-medium text-[var(--text-primary)]">
+        <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.remoteControl.title')}
         </h2>
-        <p className="text-12 text-[var(--text-tertiary)]">
+        <p className="text-13 leading-[1.5] text-[var(--settings-section-desc)]">
           {t('settings.remoteControl.description')}
         </p>
       </div>

--- a/apps/desktop/src/renderer/components/settings/RemoteControlSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteControlSection.tsx
@@ -225,7 +225,7 @@ export function RemoteControlSection() {
   const sshSum = sshSummary(hosts, t);
 
   return (
-    <div className="flex flex-col gap-2 px-1">
+    <div className="flex flex-col gap-2">
       <div className="flex flex-col gap-1">
         <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.remoteControl.title')}

--- a/apps/desktop/src/renderer/components/settings/SessionImportSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SessionImportSection.tsx
@@ -167,22 +167,22 @@ export function SessionImportSection() {
   }, [runScan, selectedItems, t]);
 
   return (
-    <div className="flex flex-col gap-[14px]">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 flex-col gap-1">
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <header className="flex shrink-0 flex-col items-stretch justify-between gap-3 xl:flex-row xl:items-end xl:gap-6">
+        <div className="flex min-w-0 max-w-[620px] flex-col gap-1">
           <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
             {t('settings.sessionImport.title')}
           </h2>
-          <p className="max-w-[720px] text-13 leading-[1.5] text-[var(--settings-section-desc)]">
+          <p className="text-13 leading-[1.5] text-[var(--settings-section-desc)]">
             {t('settings.sessionImport.description')}
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 items-center justify-end gap-2 select-none">
           <button
             type="button"
             onClick={() => setShareWizardOpen(true)}
             className={cn(
-              'inline-flex h-9 shrink-0 items-center gap-2 rounded-md px-3 text-13 font-medium',
+              'inline-flex h-10 shrink-0 items-center gap-2 rounded-full px-4 text-13 font-medium active:scale-[0.98]',
               'border border-[var(--settings-btn-secondary-border)]',
               'bg-[var(--settings-btn-secondary-bg)] text-[var(--settings-btn-secondary-text)]',
               'transition-colors hover:bg-[var(--settings-menu-bg-hover)]',
@@ -196,17 +196,17 @@ export function SessionImportSection() {
             onClick={() => runScan({ force: true })}
             disabled={scanning}
             className={cn(
-              'inline-flex h-9 shrink-0 items-center gap-2 rounded-md px-3 text-13 font-medium',
-              'border border-[var(--settings-btn-secondary-border)]',
-              'bg-[var(--settings-btn-secondary-bg)] text-[var(--settings-btn-secondary-text)]',
-              'transition-colors hover:bg-[var(--settings-menu-bg-hover)] disabled:cursor-not-allowed disabled:opacity-60',
+              'inline-flex h-10 shrink-0 items-center gap-2 rounded-full px-5 text-13 font-medium active:scale-[0.98]',
+              'border border-[var(--settings-btn-primary-border)]',
+              'bg-[var(--settings-btn-primary-bg)] text-[var(--settings-btn-primary-text)]',
+              'transition-colors hover:bg-[var(--settings-btn-primary-hover-bg)] disabled:cursor-not-allowed disabled:opacity-60',
             )}
           >
             <Spinner icon={RefreshCw} size={15} spinning={scanning} />
             {scanning ? t('settings.sessionImport.scanning') : t('settings.sessionImport.scan')}
           </button>
         </div>
-      </div>
+      </header>
 
       {shareWizardOpen && (
         <SessionShareImportWizard open={shareWizardOpen} onOpenChange={setShareWizardOpen} />
@@ -214,12 +214,12 @@ export function SessionImportSection() {
 
       <div
         className={cn(
-          'rounded-xl border border-[var(--settings-theme-card-border)]',
-          'bg-[var(--settings-theme-card-bg)] p-5',
+          'flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl',
+          'border border-[var(--settings-theme-card-border)] bg-[var(--settings-theme-card-bg)]',
         )}
       >
         {!scan ? (
-          <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 text-center">
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
             <Download size={24} className="text-[var(--settings-section-title)] opacity-70" />
             <div className="flex max-w-[420px] flex-col gap-1">
               <p className="text-13 font-medium text-[var(--settings-section-sublabel)]">
@@ -231,18 +231,20 @@ export function SessionImportSection() {
             </div>
           </div>
         ) : (
-          <div className="flex flex-col gap-4">
-            <ScanSummary scan={scan} />
-            <FilterBar
-              sourceValue={sourceFilter}
-              placementValue={placementFilter}
-              onSourceChange={setSourceFilter}
-              onPlacementChange={setPlacementFilter}
-            />
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="flex shrink-0 flex-col gap-3 border-b border-[var(--settings-input-border)] p-4">
+              <ScanSummary scan={scan} />
+              <FilterBar
+                sourceValue={sourceFilter}
+                placementValue={placementFilter}
+                onSourceChange={setSourceFilter}
+                onPlacementChange={setPlacementFilter}
+              />
+            </div>
 
-            <div className="flex flex-col rounded-lg border border-[var(--settings-input-border)]">
+            <div className="flex min-h-0 flex-1 flex-col">
               {listItems.length > 0 && (
-                <label className="flex cursor-pointer items-center gap-2 border-b border-[var(--settings-input-border)] px-4 py-2.5 hover:bg-[var(--settings-menu-bg-hover)]">
+                <label className="flex shrink-0 cursor-pointer items-center gap-2 border-b border-[var(--settings-input-border)] px-4 py-2.5 hover:bg-[var(--settings-menu-bg-hover)] select-none">
                   <input
                     type="checkbox"
                     checked={visibleCandidates.length > 0 && visibleSelectedCount === visibleCandidates.length}
@@ -260,9 +262,9 @@ export function SessionImportSection() {
                   </span>
                 </label>
               )}
-              <div className="flex max-h-[520px] flex-col overflow-y-auto">
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]">
                 {listItems.length === 0 ? (
-                  <div className="px-4 py-10 text-center text-12 text-[var(--settings-section-desc)]">
+                  <div className="flex min-h-[160px] flex-1 items-center justify-center px-4 py-10 text-center text-12 text-[var(--settings-section-desc)]">
                     {t('settings.sessionImport.noCandidates')}
                   </div>
                 ) : (
@@ -303,7 +305,7 @@ export function SessionImportSection() {
                           <button
                             type="button"
                             onClick={() => toggleGroup(group.key)}
-                            className="flex h-6 w-5 items-center justify-center rounded-md text-[var(--settings-section-sublabel)] hover:bg-[var(--settings-menu-bg-hover)]"
+                            className="flex h-6 w-5 items-center justify-center rounded-full text-[var(--settings-section-sublabel)] hover:bg-[var(--settings-menu-bg-hover)] active:scale-[0.98]"
                             aria-label={isOpen ? t('settings.sessionImport.collapse') : t('settings.sessionImport.expand')}
                           >
                             {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
@@ -354,7 +356,7 @@ export function SessionImportSection() {
               </div>
             </div>
 
-            <div className="flex items-center justify-between gap-3">
+            <footer className="flex shrink-0 items-center justify-between gap-3 border-t border-[var(--settings-input-border)] px-4 py-3 select-none">
               <p className="text-12 text-[var(--settings-section-desc)]">
                 {t('settings.sessionImport.selected', { count: selectedItems.length })}
                 {hiddenSelectedCount > 0 && (
@@ -366,7 +368,7 @@ export function SessionImportSection() {
                 onClick={importSelected}
                 disabled={selectedItems.length === 0 || importing}
                 className={cn(
-                  'inline-flex h-9 items-center gap-2 rounded-md px-3 text-13 font-medium',
+                  'inline-flex h-10 items-center gap-2 rounded-full px-5 text-13 font-medium active:scale-[0.98]',
                   'border border-[var(--settings-btn-primary-border)]',
                   'bg-[var(--settings-btn-primary-bg)] text-[var(--settings-btn-primary-text)]',
                   'transition-colors hover:bg-[var(--settings-btn-primary-hover-bg)] disabled:cursor-not-allowed disabled:opacity-60',
@@ -375,7 +377,7 @@ export function SessionImportSection() {
                 <Check size={15} />
                 {importing ? t('settings.sessionImport.importing') : t('settings.sessionImport.importSelected')}
               </button>
-            </div>
+            </footer>
           </div>
         )}
       </div>
@@ -449,12 +451,15 @@ function ScanSummary({ scan }: { scan: ScanResult }) {
 
 function SummaryCell({ label, value, hint }: { label: string; value: number; hint: string }) {
   return (
-    <div className="rounded-lg border border-[var(--settings-input-border)] px-3 py-2">
-      <p className="text-11 text-[var(--settings-section-desc)]">{label}</p>
-      <p className="mt-1 text-18 font-medium text-[var(--settings-section-title)]">{value}</p>
-      <p className="mt-1 min-h-[28px] text-11 leading-[1.25] text-[var(--settings-section-desc)]">
-        {hint}
+    <div
+      title={hint}
+      className="flex min-w-0 items-baseline gap-2 rounded-xl border border-[var(--settings-input-border)] px-3 py-2"
+    >
+      <p className="shrink-0 text-18 font-medium tabular-nums text-[var(--settings-section-title)]">
+        {value}
       </p>
+      <p className="truncate text-11 text-[var(--settings-section-desc)]">{label}</p>
+      <span className="sr-only">{hint}</span>
     </div>
   );
 }
@@ -474,7 +479,7 @@ function FilterBar({
   const sourceFilters: SourceFilter[] = ['all', 'codex', 'claude'];
   const placementFilters: PlacementFilter[] = ['all', 'project', 'dialogue'];
   return (
-    <div className="flex flex-col gap-2">
+    <div className="grid gap-2 xl:grid-cols-2">
       <SegmentedFilter
         label={t('settings.sessionImport.filters.source')}
         values={sourceFilters}
@@ -507,8 +512,8 @@ function SegmentedFilter<T extends string>({
   onChange: (value: T) => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <span className="w-[72px] text-11 font-medium text-[var(--settings-section-desc)]">
+    <div className="flex min-w-0 flex-wrap items-center gap-2 select-none">
+      <span className="w-[56px] text-11 font-medium text-[var(--settings-section-desc)]">
         {label}
       </span>
       {values.map((filter) => (
@@ -517,7 +522,7 @@ function SegmentedFilter<T extends string>({
           type="button"
           onClick={() => onChange(filter)}
           className={cn(
-            'h-8 rounded-md border px-3 text-12 font-medium transition-colors',
+            'h-8 rounded-full border px-3 text-12 font-medium transition-colors active:scale-[0.98]',
             value === filter
               ? 'border-[var(--settings-menu-border-selected)] bg-[var(--settings-menu-bg-selected)] text-[var(--settings-menu-text-selected)]'
               : 'border-[var(--settings-input-border)] text-[var(--settings-section-sublabel)] hover:bg-[var(--settings-menu-bg-hover)]',
@@ -557,16 +562,16 @@ function SessionImportRow({
       />
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="rounded border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 uppercase text-[var(--settings-section-desc)]">
+          <span className="rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 uppercase text-[var(--settings-section-desc)]">
             {item.source === 'codex' ? 'Codex' : 'Claude'}
           </span>
           {item.archived && (
-            <span className="rounded border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
+            <span className="rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
               {t('settings.sessionImport.archived')}
             </span>
           )}
           {item.workspaceKind === 'dialogue' && (
-            <span className="rounded border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
+            <span className="rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
               {t('settings.sessionImport.filters.dialogue')}
             </span>
           )}

--- a/apps/desktop/src/renderer/components/settings/SessionImportSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SessionImportSection.tsx
@@ -167,7 +167,7 @@ export function SessionImportSection() {
   }, [runScan, selectedItems, t]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4">
+    <div className="flex h-full min-h-0 w-full min-w-0 flex-col gap-4">
       <header className="flex shrink-0 flex-col items-stretch justify-between gap-3 xl:flex-row xl:items-end xl:gap-6">
         <div className="flex min-w-0 max-w-[620px] flex-col gap-1">
           <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
@@ -550,7 +550,7 @@ function SessionImportRow({
   return (
     <label
       className={cn(
-        'flex cursor-pointer items-start gap-3 py-3 hover:bg-[var(--settings-menu-bg-hover)]',
+        'flex min-w-0 cursor-pointer items-start gap-3 py-3 hover:bg-[var(--settings-menu-bg-hover)]',
         isProjectChild ? 'pl-[40px] pr-4' : 'px-4',
       )}
     >
@@ -558,26 +558,26 @@ function SessionImportRow({
         type="checkbox"
         checked={checked}
         onChange={onToggle}
-        className="mt-1 h-4 w-4 accent-[var(--settings-menu-text-selected)]"
+        className="mt-1 h-4 w-4 shrink-0 accent-[var(--settings-menu-text-selected)]"
       />
       <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 uppercase text-[var(--settings-section-desc)]">
+        <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+          <span className="shrink-0 whitespace-nowrap rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 uppercase text-[var(--settings-section-desc)]">
             {item.source === 'codex' ? 'Codex' : 'Claude'}
           </span>
           {item.archived && (
-            <span className="rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
+            <span className="shrink-0 whitespace-nowrap rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
               {t('settings.sessionImport.archived')}
             </span>
           )}
           {item.workspaceKind === 'dialogue' && (
-            <span className="rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
+            <span className="shrink-0 whitespace-nowrap rounded-full border border-[var(--settings-input-border)] px-1.5 py-0.5 text-10 text-[var(--settings-section-desc)]">
               {t('settings.sessionImport.filters.dialogue')}
             </span>
           )}
           <p
             title={item.title || undefined}
-            className="truncate text-13 font-medium text-[var(--settings-section-sublabel)]"
+            className="min-w-0 flex-1 truncate text-13 font-medium text-[var(--settings-section-sublabel)]"
           >
             {item.title || t('settings.sessionImport.untitled')}
           </p>

--- a/apps/desktop/src/renderer/components/settings/SessionImportSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SessionImportSection.tsx
@@ -451,15 +451,14 @@ function ScanSummary({ scan }: { scan: ScanResult }) {
 
 function SummaryCell({ label, value, hint }: { label: string; value: number; hint: string }) {
   return (
-    <div
-      title={hint}
-      className="flex min-w-0 items-baseline gap-2 rounded-xl border border-[var(--settings-input-border)] px-3 py-2"
-    >
-      <p className="shrink-0 text-18 font-medium tabular-nums text-[var(--settings-section-title)]">
-        {value}
-      </p>
-      <p className="truncate text-11 text-[var(--settings-section-desc)]">{label}</p>
-      <span className="sr-only">{hint}</span>
+    <div className="min-w-0 rounded-xl border border-[var(--settings-input-border)] px-3 py-2">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <p className="shrink-0 text-18 font-medium tabular-nums text-[var(--settings-section-title)]">
+          {value}
+        </p>
+        <p className="truncate text-11 text-[var(--settings-section-desc)]">{label}</p>
+      </div>
+      <p className="mt-1 text-11 leading-[1.4] text-[var(--settings-section-desc)]">{hint}</p>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -237,6 +237,8 @@ export function SettingsView() {
         </aside>
 
         {/* Content column — capped and centered in the remaining space.
+            Most tabs scroll as a page; Session Import uses a fixed-height workspace
+            so only its candidate list scrolls and the import action stays visible.
             right padding mirrors sidebar's 24px left inset.
             pt-[56px] pushes content top to align with the first nav tab (General),
             skipping the "Settings" header height (h1 24/1.1 + pb-18 + gap-2 ≈ 52px).
@@ -244,11 +246,22 @@ export function SettingsView() {
             切换时预留 gutter,避免居中内容左右跳变。 */}
         <div
           ref={contentScrollRef}
-          className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-y-auto pl-4 pr-6 pt-[56px] [scrollbar-gutter:stable]"
+          className={cn(
+            'flex h-full min-h-0 min-w-0 flex-1 flex-col pl-4 pr-6 pt-[56px]',
+            activeTab === 'import'
+              ? 'overflow-hidden'
+              : 'overflow-y-auto [scrollbar-gutter:stable]',
+          )}
         >
           {/* key={activeTab}:切分区时 wrapper 重挂跑 150ms 淡入(面板内容本就
               按 activeTab 条件卸载重挂,key 不额外丢状态;滚动容器在外层不重挂)。 */}
-          <div key={activeTab} className="mx-auto w-full max-w-[920px] pb-32 animate-fade-in">
+          <div
+            key={activeTab}
+            className={cn(
+              'mx-auto w-full max-w-[920px] animate-fade-in',
+              activeTab === 'import' ? 'h-full min-h-0' : 'pb-32',
+            )}
+          >
             {activeTab === 'general' && (
               <div
                 role="tabpanel"
@@ -467,8 +480,13 @@ export function SettingsView() {
             )}
 
             {activeTab === 'import' && (
-              <div role="tabpanel" id="settings-panel-import" aria-labelledby="settings-tab-import">
-                <section aria-label={t('settings.sections.import')}>
+              <div
+                role="tabpanel"
+                id="settings-panel-import"
+                aria-labelledby="settings-tab-import"
+                className="h-full min-h-0"
+              >
+                <section className="h-full min-h-0" aria-label={t('settings.sections.import')}>
                   <SessionImportSection />
                 </section>
               </div>

--- a/apps/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -258,7 +258,7 @@ export function SettingsView() {
           <div
             key={activeTab}
             className={cn(
-              'mx-auto w-full max-w-[920px] animate-fade-in',
+              'mx-auto w-full min-w-0 max-w-[920px] px-1 animate-fade-in',
               activeTab === 'import' ? 'h-full min-h-0' : 'pb-32',
             )}
           >

--- a/apps/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -242,15 +242,13 @@ export function SettingsView() {
             right padding mirrors sidebar's 24px left inset.
             pt-[56px] pushes content top to align with the first nav tab (General),
             skipping the "Settings" header height (h1 24/1.1 + pb-18 + gap-2 ≈ 52px).
-            scrollbar-gutter:stable —— 全局滚动条占位 12px,长短页(有/无滚动条)
-            切换时预留 gutter,避免居中内容左右跳变。 */}
+            scrollbar-gutter:stable —— 所有分区都预留同一滚动条槽位；即使
+            Session Import 自身不滚动，也要保持与普通滚动页相同的内容宽度。 */}
         <div
           ref={contentScrollRef}
           className={cn(
-            'flex h-full min-h-0 min-w-0 flex-1 flex-col pl-4 pr-6 pt-[56px]',
-            activeTab === 'import'
-              ? 'overflow-hidden'
-              : 'overflow-y-auto [scrollbar-gutter:stable]',
+            'flex h-full min-h-0 min-w-0 flex-1 flex-col pl-4 pr-6 pt-[56px] [scrollbar-gutter:stable]',
+            activeTab === 'import' ? 'overflow-hidden' : 'overflow-y-auto',
           )}
         >
           {/* key={activeTab}:切分区时 wrapper 重挂跑 150ms 淡入(面板内容本就

--- a/apps/desktop/src/renderer/components/settings/VoiceInputSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/VoiceInputSection.tsx
@@ -1724,13 +1724,14 @@ export function VoiceInputSection() {
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
-        {t('settings.voiceInput.title')}
-      </h2>
-
-      <p className="text-13 leading-[1.5] text-[var(--settings-section-desc)]">
-        {t('settings.voiceInput.description')}
-      </p>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
+          {t('settings.voiceInput.title')}
+        </h2>
+        <p className="text-13 leading-[1.5] text-[var(--settings-section-desc)]">
+          {t('settings.voiceInput.description')}
+        </p>
+      </div>
 
       <VoiceInputServiceSourceCard />
 

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -727,7 +727,7 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
     <>
       <div>
         <div className="flex items-start justify-between gap-6">
-          <h2 className="text-20 font-medium tracking-[-0.01em] text-[var(--settings-section-title)]">
+          <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
             {t('billing.settings.title')}
           </h2>
           <button


### PR DESCRIPTION
## 这次改了什么

### 摘要

重构 Desktop 设置页的「对话导入」体验，并统一设置页的内容宽度与标题层级。导入页现在是固定高度工作区：顶部入口与筛选固定、候选列表独立滚动、底部导入操作始终可见；长标题与元数据不会再撑高列表行。所有设置分区共享同一 `920px` 内容框、水平内边距和 scrollbar gutter，切换「对话导入」与「远程连接」等页面时不再出现宽度跳变。

同时统一帮助、关于、模型供应商、用量与计费、语音输入、IM 机器人、远程连接、协同设置等页面的标题/描述字号、行高和间距；扫描统计的解释恢复为常显文本，键盘、触屏和鼠标用户均可直接获取含义。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #752
- 本 PR 包含：
  - 对话导入页固定工作区、列表内滚动和常驻底部操作区
  - 扫描、`.cshare` 导入、筛选与统计区域的布局和样式优化
  - 长会话标题截断、元数据标签禁止压缩换行
  - 设置页公共 `max-w-[920px]` 内容框、`px-1` 内边距与 scrollbar gutter 统一
  - 多个设置分区的标题、描述字号与间距统一
  - 导入统计说明常显及对应源码级回归测试
- 明确不包含：会话扫描/导入数据逻辑、服务端、数据库、协议和移动端功能改动
- 用户可见变化：导入按钮始终可见；长会话不会撑坏列表；设置页切换时宽度稳定；页面标题层级一致；统计说明可直接阅读
- 是否存在 breaking change：无

### UI 变化

- 平台：Desktop Renderer
- 实机反馈：根据本地页面截图与「对话导入 / 远程连接」切换反馈，已修复长文本撑高和滚动槽位造成的宽度差异
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §3 Typography Rules：设置页标题统一为 16px/500/1.2，描述统一为 13px/1.5，标题与描述间距 4px
  - `DESIGN.md` §4 Component Stylings：按钮、筛选项和元数据标签使用 pill；卡片使用 12px container radius
  - `DESIGN.md` §5 Layout Principles：设置表单使用统一 reading-width 内容框；导入工作区只让候选列表滚动
  - `DESIGN.md` §10 Light/Dark Dual-Mode Delivery Gate：颜色全部复用现有语义 token，无单模式硬编码
  - `DESIGN.md` §14.1/§14.4：关键操作常驻可见；统计解释不依赖仅鼠标可触发的原生 tooltip

## 怎么验证的

### 自动验证

```text
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false pnpm test:unit
结果：通过；Desktop、Mobile 及所有要求的共享 workspace unit tests 均通过

pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/sessionImportAutoScan.test.ts
结果：通过，11 tests passed

git diff --check
结果：通过

pnpm check:dco
结果：通过，5 commits signed off
```

> `tag.gpgSign=false` 仅覆盖测试进程，用于避免用户级 Git 配置把测试中的轻量 tag 强制转换为签名 tag；未修改全局 Git 配置。

### 手工验证

- 根据 Desktop 本地截图修复长标题将元数据标签压成竖排的问题
- 根据「对话导入 / 远程连接」切换反馈，将 scrollbar gutter 移至所有设置分区共享的公共滚动容器

### 未执行的验证

- 未执行 build 和 typecheck：遵循当前工作区前端快速开发约定
- 未由提交者独立完成 Light/Dark 最终实机目检；实现全部使用现有语义 token

## Review 反馈处理

- Greptile / Copilot：统计解释仅存在于 `title`，键盘和触屏用户难以访问 → 已改为常显说明，并新增回归断言
- Copilot：Import 页移除 scrollbar gutter 会导致跨页宽度跳变 → 已将 stable gutter 提升到所有设置分区共享的公共容器

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 设置页布局、样式和导入统计说明呈现
- 回滚 / 降级方式：回滚本 PR 即可；不涉及数据迁移、协议或持久化格式

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因
