### PR TITLE
fix(desktop): reject reserved plugin locale keys

### DIFF
--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -820,6 +820,10 @@ key、未知字段、原清单没有的条目、类型或长度不合格、文�
 不一致、无效 JSON 或单文件超过 64KB 都会在 Forge 打包期、内置播种期与安装期拒绝。
 清单列表、详情页、Panel 标题、安装/配置提示和 Agent 工具目录都消费同一份本地化结果。
 
+所有会作为对象索引的稳定标识——tool name、network secrets / connections key、
+node secretBindings key、setup kv key——都不能使用 \`__proto__\`、\`constructor\` 或
+\`prototype\`；这些名称是宿主保留键，打包时会直接拒绝。
+
 十五个卡槽:\`tool\`(注册工具给 AI)、\`cindy\`(请 Cindy 本体代办:出图/改图)、\`agent\`(让
 当前 Agent 开始一个普通用户回合,见 §4.11)、\`panel\`(常驻
 面板)、\`card\`(聊天卡片:自绘工具调用的过程与结果,见 §4.5)、\`subscribe\`(旁听会话
@@ -849,7 +853,7 @@ Claude Code 与 Codex 都能发现,见 §4.16)、\`workspace\`(请主机为项�
   "entries": ["node/build.cjs"],       // 可选 ≤4 条:额外工作进程入口(每入口一个独立进程,调用时用 entry 指名,见 §4.12.1;不能与 entry / 浏览器沙箱 entry / 彼此重复)
   "childSpawn": true,                  // 可选:worker 可请宿主代启申报入口的原样 stdio 子进程(见 §4.12.4;装入确认框单列一行)
   "secretBindings": [{                 // 可选 1–4 条:safeStorage 持久化凭证按方法临时注入 Worker
-    "key": "mail_code",                // 插件内唯一,小写字母开头,1–32 位小写/数字/下划线
+    "key": "mail_code",                // 插件内唯一,小写字母开头,1–32 位小写/数字/下划线;禁用宿主保留键(见 §2.1)
     "label": "邮箱授权码",             // 安装确认与设置页展示名
     "methods": ["mail/action"],         // 只在这些 JSON-RPC 方法中注入,每条 1–128 位
     "entry": "node/worker.cjs",         // 可选:逐字命中 node.entry/entries;缺省仅主入口
@@ -898,7 +902,7 @@ node 详单**不接受** \`command\` / \`args\` / \`shell\` / \`env\` 或其它�
 "network": {
   "hosts": ["api.example.com", "*.weather.com"],   // 1–8 条;小写域名至少两段;通配只允许最左 "*.";装入确认框逐条展示给用户
   "secrets": [{                                     // 可选 0–4 条:需要用户填的凭证(你只声明名字和注入位置,值用户填、主机保管)
-    "key": "api_token",                             // 小写字母开头,小写/数字/下划线,1–32
+    "key": "api_token",                             // 小写字母开头,小写/数字/下划线,1–32;禁用宿主保留键(见 §2.1)
     "label": "Example API Token",                   // 给用户看的名称(设置页/确认框)
     "source": "user",                               // 可选:凭证值来源。"user"(缺省)=用户可在调用前的主机 Setup 卡内填写,也可在你的 settingsHtml 里长期管理/替换/清除(当前仍要求同时声明 settingsHtml,见 §4.7);"login-email"=主机登录邮箱自动派生(用户不填;声明它时不允许再写 url,见 §4.7);"oauth"=主机托管 OAuth 授权,值 = 授权换来的 access token(必须同时声明 oauth 详单,见 §4.7 与下方 oauth 字段)
     "hint": "在控制台生成后粘贴",                     // 可选提示(主机 Setup 卡与 settingsHtml 都会用到)
@@ -932,7 +936,7 @@ node 详单**不接受** \`command\` / \`args\` / \`shell\` / \`env\` 或其它�
     }
   }],
   "connections": [{                                 // 可选 0–2 条:多连接声明——"地址 + 凭证成对多条"(自建实例场景如 GitLab,详见 §4.7「多连接」)。声明了 connections 时 hosts 可缺省/为空(静态域名与动态连接至少有其一);声明 connections 必须同时声明 settingsHtml
-    "key": "gitlab",                                // 小写字母开头,小写/数字/下划线,1–32;与 secrets[].key 共用命名空间,撞名拒装
+    "key": "gitlab",                                // 小写字母开头,小写/数字/下划线,1–32;禁用宿主保留键;与 secrets[].key 共用命名空间,撞名拒装
     "label": "GitLab 实例",                          // 给用户看的连接类型名(1–64 字;确认框与设置页展示)
     "hint": "填实例域名与 Personal Access Token",     // 可选 ≤200 字提示(建议写进你的 settingsHtml 文案)
     "inject": { "header": "Private-Token", "format": "{value}" },  // 凭证注入形态(规则同 secrets 的 inject);**不允许**声明 inject.hosts——凭证恒只注入对应连接自身的地址,写了拒装
@@ -959,7 +963,7 @@ node 详单**不接受** \`command\` / \`args\` / \`shell\` / \`env\` 或其它�
 - 条目三种引用:\`secret:<key>\`(\`network.secrets\` 或 \`node.secretBindings\` 声明的
   凭证:Node 绑定与 user 源查已保存、oauth 源查已连接账号;账号全过期时主机弹「重新连接」
   话术)、\`connection:<key>\`(该连接声明下至少添加一条)、
-  \`{ "kv": "<键名>", "label": "..." }\`(你 /kv 参数里的顶层键非空;键名主机无先验,
+  \`{ "kv": "<键名>", "label": "..." }\`(你 /kv 参数里的顶层键非空且不能是宿主保留键;键名主机无先验,
   label 必填)。Node 凭证同样可参与 setup.requires。
 - 引用必须逐字指向已声明的 key,悬空引用**打包期就拒**;\`login-email\` 源凭证恒就绪,
   引用它同样拒(没有配置动作可引导)。kv 引用要求已声明 settingsHtml(没有设置页没人填)。
@@ -974,7 +978,7 @@ node 详单**不接受** \`command\` / \`args\` / \`shell\` / \`env\` 或其它�
 
 \`\`\`json
 "tools": [{
-  "name": "gen_image",
+  "name": "gen_image", // 小写字母开头,1–64 位小写/数字/下划线/连字符;禁用宿主保留键(见 §2.1)
   "description": "根据文字描述生成一张图片,并把它挂进画廊面板。返回可在聊天中渲染的图片地址。",
   "parameters": {
     "type": "object",

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -598,6 +598,33 @@ describe('ghost · 清单校验', () => {
     }, parsed.manifest).ok).toBe(false);
   });
 
+  it('locale 外部 key 累加器使用无原型字典，JSON 自有 __proto__ 属性不会丢失', () => {
+    const manifest: GhostManifest = {
+      schemaVersion: 2,
+      id: 'defensive-locale',
+      name: 'Defensive locale',
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      slots: ['panel'],
+      panel: { html: 'panel.html' },
+      setup: {
+        requires: [{ anyOf: [{ kind: 'kv', key: '__proto__', label: 'Base label' }] }],
+      },
+    };
+    const rawLocale = JSON.parse('{"setup":{"kv":{"__proto__":{"label":"Localized label"}}}}');
+    const resource = validateGhostManifestLocaleResource(rawLocale, manifest);
+    expect(resource.ok).toBe(true);
+    if (!resource.ok) return;
+    expect(Object.getPrototypeOf(resource.resource.setup?.kv)).toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(resource.resource.setup?.kv, '__proto__')).toBe(true);
+    expect(resolveGhostManifestLocale(manifest, resource.resource).setup?.requires[0]?.anyOf[0]).toEqual({
+      kind: 'kv',
+      key: '__proto__',
+      label: 'Localized label',
+    });
+  });
+
   it('icon:可选包内相对路径,扩展名白名单;非法路径/扩展名 → 拒', () => {
     const base = validateGhostManifest({ ...goodManifest(), icon: 'assets/icon.png' });
     expect(base.ok && (base as { ok: true; manifest: GhostManifest }).manifest.icon).toBe('assets/icon.png');
@@ -931,6 +958,70 @@ describe('ghost · 芯片型清单(schemaVersion 2)', () => {
         Array.from({ length: 17 }, (_, i) => ({ name: `t${i}`, description: 'y' })),
       ).ok,
     ).toBe(false);
+  });
+
+  it('会进入 locale 对象索引的清单 key 统一拒绝对象保留键名', () => {
+    const reservedKeys = ['__proto__', 'constructor', 'prototype'];
+    const withoutPanel = (manifest: Record<string, unknown>) => {
+      const result = { ...manifest };
+      delete result.panel;
+      return result;
+    };
+
+    for (const key of reservedKeys) {
+      expect(validateGhostManifest(withoutPanel({
+        ...goodManifest(),
+        slots: ['tool'],
+        tools: [{ name: key, description: 'Reserved tool' }],
+      })).ok, `tool ${key}`).toBe(false);
+
+      expect(validateGhostManifest({
+        ...goodManifest(),
+        settingsHtml: 'settings.html',
+        slots: ['panel', 'network'],
+        network: {
+          hosts: ['api.example.com'],
+          secrets: [{
+            key,
+            label: 'Reserved secret',
+            inject: { header: 'Authorization', format: 'Bearer {value}' },
+          }],
+        },
+      }).ok, `network secret ${key}`).toBe(false);
+
+      expect(validateGhostManifest({
+        ...goodManifest(),
+        settingsHtml: 'settings.html',
+        slots: ['panel', 'network'],
+        network: {
+          hosts: [],
+          connections: [{
+            key,
+            label: 'Reserved connection',
+            inject: { header: 'Authorization', format: 'Bearer {value}' },
+          }],
+        },
+      }).ok, `network connection ${key}`).toBe(false);
+
+      expect(validateGhostManifest({
+        ...goodManifest(),
+        settingsHtml: 'settings.html',
+        slots: ['panel', 'node'],
+        node: {
+          entry: 'node/worker.cjs',
+          protocol: 'json-rpc-stdio',
+          secretBindings: [{ key, label: 'Reserved node secret', methods: ['run'] }],
+        },
+      }).ok, `node secret ${key}`).toBe(false);
+
+      expect(validateGhostManifest(JSON.parse(JSON.stringify({
+        ...goodManifest(),
+        settingsHtml: 'settings.html',
+        setup: {
+          requires: [{ anyOf: [{ kv: key, label: 'Reserved setup value' }] }],
+        },
+      }))).ok, `setup kv ${key}`).toBe(false);
+    }
   });
 
   it('panel.html 与 panel 槽必须成对出现', () => {

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -1782,6 +1782,12 @@ export function layoutWithGhostPanel(layout: Layout, manifest: GhostManifest): L
 
 export type ManifestValidation = { ok: true; manifest: GhostManifest } | { ok: false; reason: string };
 
+const GHOST_MANIFEST_RESERVED_RECORD_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isGhostManifestReservedRecordKey(value: string): boolean {
+  return GHOST_MANIFEST_RESERVED_RECORD_KEYS.has(value);
+}
+
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
@@ -1830,7 +1836,7 @@ function ghostJsonPointerChild(pointer: string, segment: string | number): strin
 function collectGhostSchemaLocaleShape(
   schema: unknown,
   pointer = '',
-  result: Record<string, GhostSchemaLocaleShape> = {},
+  result: Record<string, GhostSchemaLocaleShape> = Object.create(null) as Record<string, GhostSchemaLocaleShape>,
 ): Record<string, GhostSchemaLocaleShape> {
   if (!isPlainObject(schema)) return result;
   const title = typeof schema.title === 'string';
@@ -1961,7 +1967,7 @@ export function validateGhostManifestLocaleResource(
     const actualNames = Object.keys(raw.tools);
     const unknown = actualNames.find((name) => !expectedNames.has(name));
     if (unknown) return { ok: false, reason: `locale.tools 含未知工具 ${JSON.stringify(unknown)}` };
-    tools = {};
+    tools = Object.create(null) as NonNullable<GhostManifestLocaleResource['tools']>;
     for (const tool of manifest.tools) {
       const localized = raw.tools[tool.name];
       if (localized === undefined) continue; // 缺译:该工具整体回退原文
@@ -2011,7 +2017,7 @@ export function validateGhostManifestLocaleResource(
             reason: `locale.tools[${JSON.stringify(tool.name)}].parameters 含未知路径 ${JSON.stringify(unknownPointer)}`,
           };
         }
-        parameters = {};
+        parameters = Object.create(null) as Record<string, GhostSchemaLocaleText>;
         for (const pointer of parameterPointers) {
           const shape = parameterShape[pointer];
           const localizedText = localized.parameters[pointer];
@@ -2103,7 +2109,7 @@ export function validateGhostManifestLocaleResource(
     if (unknownKey) {
       return { ok: false, reason: `${fieldPath} 含未知 key ${JSON.stringify(unknownKey)}` };
     }
-    const labels: Record<string, { label: string; hint?: string }> = {};
+    const labels = Object.create(null) as Record<string, { label: string; hint?: string }>;
     for (const declaration of declarations) {
       const localized = rawValue[declaration.key];
       if (localized === undefined) continue; // 缺译:该项回退原文
@@ -2209,13 +2215,15 @@ export function validateGhostManifestLocaleResource(
     }
     const kv = validateLocalizedLabels(raw.setup.kv, 'locale.setup.kv', [...setupKvDecls.values()]);
     if (!kv.ok) return kv;
-    setup = kv.labels !== undefined
-      ? {
-          kv: Object.fromEntries(
-            Object.entries(kv.labels).map(([key, localized]) => [key, { label: localized.label }]),
-          ),
-        }
-      : {};
+    if (kv.labels !== undefined) {
+      const localizedKv = Object.create(null) as Record<string, { label: string }>;
+      for (const [key, localized] of Object.entries(kv.labels)) {
+        localizedKv[key] = { label: localized.label };
+      }
+      setup = { kv: localizedKv };
+    } else {
+      setup = {};
+    }
   }
 
   return {
@@ -2593,6 +2601,9 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
     const seenNames = new Set<string>();
     for (const t of raw.tools) {
       if (!isPlainObject(t)) return { ok: false, reason: 'tools 每项必须是对象' };
+      if (typeof t.name === 'string' && isGhostManifestReservedRecordKey(t.name)) {
+        return { ok: false, reason: `tools[].name 不允许使用对象保留键名 ${JSON.stringify(t.name)}` };
+      }
       if (typeof t.name !== 'string' || !/^[a-z][a-z0-9_-]{0,63}$/.test(t.name)) {
         return { ok: false, reason: 'tools[].name 必须是小写字母开头的 1–64 位小写/数字/下划线/连字符' };
       }
@@ -2833,6 +2844,12 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
           return {
             ok: false,
             reason: `node.secretBindings[] 含不允许的字段 ${JSON.stringify(unknownBindingField)}`,
+          };
+        }
+        if (typeof binding.key === 'string' && isGhostManifestReservedRecordKey(binding.key)) {
+          return {
+            ok: false,
+            reason: `node.secretBindings[].key 不允许使用对象保留键名 ${JSON.stringify(binding.key)}`,
           };
         }
         if (typeof binding.key !== 'string' || !/^[a-z][a-z0-9_]{0,31}$/.test(binding.key)) {
@@ -3178,6 +3195,9 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
       const seenKeys = new Set<string>();
       for (const s of n.secrets) {
         if (!isPlainObject(s)) return { ok: false, reason: 'network.secrets 每项必须是对象' };
+        if (typeof s.key === 'string' && isGhostManifestReservedRecordKey(s.key)) {
+          return { ok: false, reason: `network.secrets[].key 不允许使用对象保留键名 ${JSON.stringify(s.key)}` };
+        }
         if (typeof s.key !== 'string' || !/^[a-z][a-z0-9_]{0,31}$/.test(s.key)) {
           return { ok: false, reason: 'network.secrets[].key 必须是小写字母开头的 1–32 位小写/数字/下划线' };
         }
@@ -3733,6 +3753,9 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
       const nodeSecretKeySet = new Set((node?.secretBindings ?? []).map((s) => s.key));
       for (const c of n.connections) {
         if (!isPlainObject(c)) return { ok: false, reason: 'network.connections 每项必须是对象' };
+        if (typeof c.key === 'string' && isGhostManifestReservedRecordKey(c.key)) {
+          return { ok: false, reason: `network.connections[].key 不允许使用对象保留键名 ${JSON.stringify(c.key)}` };
+        }
         if (typeof c.key !== 'string' || !/^[a-z][a-z0-9_]{0,31}$/.test(c.key)) {
           return { ok: false, reason: 'network.connections[].key 必须是小写字母开头的 1–32 位小写/数字/下划线' };
         }
@@ -3859,6 +3882,9 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
             item = { kind: 'connection', key: refKey };
           }
         } else if (isPlainObject(it)) {
+          if (typeof it.kv === 'string' && isGhostManifestReservedRecordKey(it.kv)) {
+            return { ok: false, reason: `setup kv 条目的 kv 不允许使用对象保留键名 ${JSON.stringify(it.kv)}` };
+          }
           if (typeof it.kv !== 'string' || !GHOST_SETUP_KV_KEY_RE.test(it.kv)) {
             return { ok: false, reason: 'setup kv 条目的 kv 必须是 1–64 位字母/数字/下划线/点/连字符的键名' };
           }


### PR DESCRIPTION
## 这次改了什么

### 摘要

加固插件 manifest 和 locale 资源处理：拒绝 `__proto__`、`constructor`、`prototype` 等对象保留键，并将按外部 key 累加的 locale 容器改为无原型字典，避免合法 JSON 自有属性在归一化过程中丢失。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Related to #391
- 本 PR 包含：插件 tool name、network secret / connection key、node secret binding key、setup kv key 的保留键校验；locale 累加器加固；回归测试；Forge 编写手册同步。
- 明确不包含：插件运行时权限、数据库、网络协议、UI 行为调整。
- 用户可见变化：使用对象保留键的插件会在打包或安装校验阶段收到明确错误，不再进入 locale 标签丢失的异常状态。
- 是否存在 breaking change：有。此前使用 `__proto__`、`constructor` 或 `prototype` 作为上述稳定标识的第三方插件将被拒绝；官方插件仓库未发现相关用法。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
PATH=/tmp/cindy-pnpm10-bin:$PATH pnpm test:unit
结果：全部 workspace 通过；Desktop unit 通过，其他 required workspace 均通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec eslint src/shared/ghost.ts src/shared/__tests__/ghost.test.ts src/main/cindy-brain/forge.ts
结果：通过。

pnpm --filter desktop exec vitest run src/shared/__tests__/ghost.test.ts src/main/cindy-brain/__tests__/forge.test.ts
结果：2 个测试文件、157 条测试通过。

pnpm check:dco
结果：1 个提交签名检查通过。
```

### 手工验证

不涉及 UI；由回归测试覆盖 JSON.parse 生成的自有 `__proto__` 属性路径，以及五类 manifest 稳定标识对三个保留键的拒绝行为。

### 未执行的验证

未启动 Desktop 做界面验证：本次不涉及 UI，且校验与 locale 解析路径已有自动化覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：插件 manifest 兼容性收紧

### 影响与回滚

- 影响范围：仅插件 manifest 与 locale 资源校验。正常稳定标识不受影响；使用对象保留键的插件会被拒绝。
- 回滚 / 降级方式：回滚本提交即可恢复旧校验；不涉及数据迁移或用户数据写入。
- 作者契约：已同步 `FORGE_GUIDE` 的 locale、tool、network、node 与 setup key 规则。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
