### PR TITLE
feat(desktop): 更新重启前提示运行中任务风险

### DIFF
--- a/apps/desktop/src/main/__tests__/clientEndpointsService.test.ts
+++ b/apps/desktop/src/main/__tests__/clientEndpointsService.test.ts
@@ -1209,8 +1209,13 @@ describe('netlog 产物事后核对(verifyEndpointNetLogCapture)', () => {
     // 它能抓住 symlink / 类型变化,抓不住"号被回收后重建"。
     const capture = prepareEndpointNetLogFile(logDir)!;
     fs.writeFileSync(capture.file, '{}', 'utf8');
-    expect(verifyEndpointNetLogCapture({ ...capture, dirIno: capture.dirIno + 1 })).toBe(false);
-    expect(verifyEndpointNetLogCapture({ ...capture, dirDev: capture.dirDev + 1 })).toBe(false);
+    // Windows 可能把 ino 暴露为 0；生产逻辑会有意跳过无法执行的 inode 身份核对。
+    if (!capture.dirIno) return;
+    // 不用 +1：Windows 的 inode 可能超过 Number.MAX_SAFE_INTEGER，+1 后数值仍相等。
+    const otherIno = capture.dirIno === 1 ? 2 : 1;
+    const otherDev = capture.dirDev === 1 ? 2 : 1;
+    expect(verifyEndpointNetLogCapture({ ...capture, dirIno: otherIno })).toBe(false);
+    expect(verifyEndpointNetLogCapture({ ...capture, dirDev: otherDev })).toBe(false);
   });
 
   it('目标被换成 symlink → 不通过', () => {

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
@@ -76,7 +76,7 @@ describe('UpdateBanner busy-turn restart hint', () => {
     expect(hint.className).not.toContain('text-[var(--warning-fg)]');
   });
 
-  it('keeps relaunch behavior unchanged while the text-only snapshot is pending', () => {
+  it('keeps relaunch behavior unchanged while the text-only snapshot is pending', async () => {
     let resolveTurnCheck!: (busy: boolean) => void;
     anySessionInTurn.mockImplementation(
       () => new Promise<boolean>((resolve) => { resolveTurnCheck = resolve; }),
@@ -84,6 +84,7 @@ describe('UpdateBanner busy-turn restart hint', () => {
     render(<UpdateBanner isCollapsed={false} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'update.banner.ariaExpanded' }));
+    await waitFor(() => expect(anySessionInTurn).toHaveBeenCalledTimes(1));
 
     const confirmButton = screen.getByRole('button', { name: 'update.banner.confirmAria' });
     expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
@@ -91,5 +92,17 @@ describe('UpdateBanner busy-turn restart hint', () => {
     expect(relaunchToUpdate).toHaveBeenCalledTimes(1);
 
     resolveTurnCheck(false);
+  });
+
+  it('keeps the neutral hint when the one-shot probe throws synchronously', async () => {
+    anySessionInTurn.mockImplementation(() => {
+      throw new Error('electron bridge is not registered');
+    });
+    render(<UpdateBanner isCollapsed={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'update.banner.ariaExpanded' }));
+
+    await waitFor(() => expect(anySessionInTurn).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('update.banner.confirmHint')).toBeTruthy();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
@@ -3,8 +3,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { anySessionInTurn } = vi.hoisted(() => ({
+const { anySessionInTurn, relaunchToUpdate } = vi.hoisted(() => ({
   anySessionInTurn: vi.fn<() => Promise<boolean>>(),
+  relaunchToUpdate: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -38,11 +39,12 @@ import { UpdateBanner } from '@/components/sidebar/UpdateBanner';
 
 beforeEach(() => {
   anySessionInTurn.mockReset();
+  relaunchToUpdate.mockReset();
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
     value: {
       anySessionInTurn,
-      relaunchToUpdate: vi.fn(),
+      relaunchToUpdate,
       clientEndpoints: { websiteUrl: 'https://cindy.ai' },
     } as unknown as Window['electronAPI'],
   });
@@ -74,4 +76,20 @@ describe('UpdateBanner busy-turn restart hint', () => {
     expect(hint.className).not.toContain('text-[var(--warning-fg)]');
   });
 
+  it('keeps relaunch behavior unchanged while the text-only snapshot is pending', () => {
+    let resolveTurnCheck!: (busy: boolean) => void;
+    anySessionInTurn.mockImplementation(
+      () => new Promise<boolean>((resolve) => { resolveTurnCheck = resolve; }),
+    );
+    render(<UpdateBanner isCollapsed={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'update.banner.ariaExpanded' }));
+
+    const confirmButton = screen.getByRole('button', { name: 'update.banner.confirmAria' });
+    expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(confirmButton);
+    expect(relaunchToUpdate).toHaveBeenCalledTimes(1);
+
+    resolveTurnCheck(false);
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
@@ -3,8 +3,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { anySessionInTurn } = vi.hoisted(() => ({
+const { anySessionInTurn, relaunchToUpdate } = vi.hoisted(() => ({
   anySessionInTurn: vi.fn<() => Promise<boolean>>(),
+  relaunchToUpdate: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -42,7 +43,7 @@ beforeEach(() => {
     configurable: true,
     value: {
       anySessionInTurn,
-      relaunchToUpdate: vi.fn(),
+      relaunchToUpdate,
       clientEndpoints: { websiteUrl: 'https://cindy.ai' },
     } as unknown as Window['electronAPI'],
   });
@@ -72,5 +73,25 @@ describe('UpdateBanner busy-turn restart hint', () => {
     const hint = screen.getByText('update.banner.confirmHint');
     expect(hint.className).toContain('text-sidebar-muted');
     expect(hint.className).not.toContain('text-[var(--warning-fg)]');
+  });
+
+  it('does not allow relaunch until the turn check has resolved', async () => {
+    let resolveTurnCheck!: (busy: boolean) => void;
+    anySessionInTurn.mockImplementation(
+      () => new Promise<boolean>((resolve) => { resolveTurnCheck = resolve; }),
+    );
+    render(<UpdateBanner isCollapsed={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'update.banner.ariaExpanded' }));
+
+    const confirmButton = screen.getByRole('button', { name: 'update.banner.confirmAria' });
+    expect((confirmButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(confirmButton);
+    expect(relaunchToUpdate).not.toHaveBeenCalled();
+
+    resolveTurnCheck(false);
+    await waitFor(() => expect((confirmButton as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(confirmButton);
+    expect(relaunchToUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { anySessionInTurn } = vi.hoisted(() => ({
+  anySessionInTurn: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/hooks/useUpdateStatus', () => ({
+  useUpdateStatus: () => ({
+    status: 'ready',
+    version: '1.2.3',
+    errorCode: null,
+  }),
+}));
+
+vi.mock('@/hooks/useUpdateBannerDismiss', () => ({
+  useUpdateBannerDismiss: () => ({
+    dismissed: false,
+    dismiss: vi.fn(),
+    restore: vi.fn(),
+    isNewUpdateAfterDismiss: vi.fn(() => false),
+  }),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { UpdateBanner } from '@/components/sidebar/UpdateBanner';
+
+beforeEach(() => {
+  anySessionInTurn.mockReset();
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      anySessionInTurn,
+      relaunchToUpdate: vi.fn(),
+      clientEndpoints: { websiteUrl: 'https://cindy.ai' },
+    } as unknown as Window['electronAPI'],
+  });
+});
+
+afterEach(cleanup);
+
+describe('UpdateBanner busy-turn restart hint', () => {
+  it('shows the warning hint in the semantic warning color while any turn is running', async () => {
+    anySessionInTurn.mockResolvedValue(true);
+    render(<UpdateBanner isCollapsed={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'update.banner.ariaExpanded' }));
+
+    const hint = await screen.findByText('update.banner.confirmBusyHint');
+    expect(anySessionInTurn).toHaveBeenCalledTimes(1);
+    expect(hint.className).toContain('text-[var(--warning-fg)]');
+  });
+
+  it('keeps the existing neutral hint when no turn is running', async () => {
+    anySessionInTurn.mockResolvedValue(false);
+    render(<UpdateBanner isCollapsed={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'update.banner.ariaExpanded' }));
+
+    await waitFor(() => expect(anySessionInTurn).toHaveBeenCalledTimes(1));
+    const hint = screen.getByText('update.banner.confirmHint');
+    expect(hint.className).toContain('text-sidebar-muted');
+    expect(hint.className).not.toContain('text-[var(--warning-fg)]');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyHint.test.tsx
@@ -3,9 +3,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { anySessionInTurn, relaunchToUpdate } = vi.hoisted(() => ({
+const { anySessionInTurn } = vi.hoisted(() => ({
   anySessionInTurn: vi.fn<() => Promise<boolean>>(),
-  relaunchToUpdate: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -43,7 +42,7 @@ beforeEach(() => {
     configurable: true,
     value: {
       anySessionInTurn,
-      relaunchToUpdate,
+      relaunchToUpdate: vi.fn(),
       clientEndpoints: { websiteUrl: 'https://cindy.ai' },
     } as unknown as Window['electronAPI'],
   });
@@ -75,23 +74,4 @@ describe('UpdateBanner busy-turn restart hint', () => {
     expect(hint.className).not.toContain('text-[var(--warning-fg)]');
   });
 
-  it('does not allow relaunch until the turn check has resolved', async () => {
-    let resolveTurnCheck!: (busy: boolean) => void;
-    anySessionInTurn.mockImplementation(
-      () => new Promise<boolean>((resolve) => { resolveTurnCheck = resolve; }),
-    );
-    render(<UpdateBanner isCollapsed={false} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'update.banner.ariaExpanded' }));
-
-    const confirmButton = screen.getByRole('button', { name: 'update.banner.confirmAria' });
-    expect((confirmButton as HTMLButtonElement).disabled).toBe(true);
-    fireEvent.click(confirmButton);
-    expect(relaunchToUpdate).not.toHaveBeenCalled();
-
-    resolveTurnCheck(false);
-    await waitFor(() => expect((confirmButton as HTMLButtonElement).disabled).toBe(false));
-    fireEvent.click(confirmButton);
-    expect(relaunchToUpdate).toHaveBeenCalledTimes(1);
-  });
 });

--- a/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
@@ -57,6 +57,8 @@ interface UpdateBannerProps {
   onOpenVersionNotice?: (version: string) => void;
 }
 
+type SessionTurnCheck = 'pending' | 'idle' | 'busy';
+
 export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerProps) {
   const { status, version, errorCode } = useUpdateStatus();
   // 用户主动关闭态(仅本次进程内存,由 UserInfoSection 的火焰按钮唤回)。
@@ -67,7 +69,8 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   const [confirming, setConfirming] = useState(false);
   // 复用关闭窗口保护链路的权威 busy 探针：只统计仍在执行的逻辑 turn，
   // 不把 keepalive、已结束但仍在渲染收尾的状态误判为运行中任务。
-  const [hasSessionInTurn, setHasSessionInTurn] = useState(false);
+  const [sessionTurnCheck, setSessionTurnCheck] = useState<SessionTurnCheck>('idle');
+  const hasSessionInTurn = sessionTurnCheck === 'busy';
   // 进入确认态后把焦点移到「取消」按钮 —— 键盘用户点入口键后原触发元素会卸载,
   // 若不主动聚焦,焦点会丢失、无法继续操作。刻意聚焦「取消」而非「确认」:让默认落在
   // 安全动作上,避免再按一次 Enter/Space 就直接更新的误操作(即 Radix 对破坏性操作
@@ -111,18 +114,18 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   // ready 主界面出现，但仍与 WindowControls 保持同样的安全兜底语义。
   useEffect(() => {
     if (!confirming) {
-      setHasSessionInTurn(false);
+      setSessionTurnCheck('idle');
       return;
     }
 
     let cancelled = false;
-    setHasSessionInTurn(false);
+    setSessionTurnCheck('pending');
     void window.electronAPI.anySessionInTurn()
       .then((busy) => {
-        if (!cancelled) setHasSessionInTurn(busy);
+        if (!cancelled) setSessionTurnCheck(busy ? 'busy' : 'idle');
       })
       .catch(() => {
-        if (!cancelled) setHasSessionInTurn(false);
+        if (!cancelled) setSessionTurnCheck('idle');
       });
 
     return () => {
@@ -181,6 +184,13 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
     setConfirming(false);
   };
 
+  const beginConfirming = () => {
+    // Mark the check as pending synchronously so a click in the first render
+    // after opening cannot bypass the busy-state query.
+    setSessionTurnCheck('pending');
+    setConfirming(true);
+  };
+
   // 用户点 X:整块 banner 收起,同时把确认态一并复位,避免下次通过火焰按钮唤回时
   // 直接落在「确认重启」界面(那是两步流程的第二步,越过第一步显示不合适)。
   // 传入当前 status/version 让 store 记录快照,用于后续区分「同一更新 remount」
@@ -201,6 +211,7 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   if (dismissed && (status === 'ready' || isPreparing)) return null;
 
   const handleRelaunch = () => {
+    if (sessionTurnCheck === 'pending') return;
     const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
     window.electronAPI.relaunchToUpdate(theme);
   };
@@ -277,12 +288,13 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
           <Tip text={t('update.banner.confirmTooltip')} side="right">
             <button
               onClick={handleRelaunch}
+              disabled={sessionTurnCheck === 'pending'}
               aria-label={t('update.banner.confirmAria')}
               className={cn(
                 'flex w-full items-center justify-center py-2 transition-colors',
                 // Bare ghost icon on the sidebar — use the readable foreground, not the
                 // on-fill pill text color (which is dark-on-dark in E1D neutral themes).
-                'text-foreground hover:bg-sidebar-item-hover',
+                'text-foreground hover:bg-sidebar-item-hover disabled:cursor-wait disabled:opacity-70',
               )}
             >
               <Check className="h-5 w-5" strokeWidth={2.25} />
@@ -315,7 +327,7 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
         >
           <button
             ref={relaunchTriggerRef}
-            onClick={() => { if (!isPreparing) setConfirming(true); }}
+            onClick={() => { if (!isPreparing) beginConfirming(); }}
             disabled={isPreparing}
             aria-label={isPreparing
               ? t('update.banner.preparingAria')
@@ -433,12 +445,13 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
           <div className="flex w-full flex-col gap-2">
             <button
               onClick={handleRelaunch}
+              disabled={sessionTurnCheck === 'pending'}
               aria-label={t('update.banner.confirmAria')}
               className={cn(
                 'flex w-full items-center justify-center gap-2 rounded-full border py-2',
                 'text-[13px] font-medium transition-colors',
                 'bg-[var(--update-btn-bg)] border-[var(--update-btn-border)] text-[var(--update-btn-text)]',
-                'hover:bg-[var(--update-btn-hover)]',
+                'hover:bg-[var(--update-btn-hover)] disabled:cursor-wait disabled:opacity-70',
               )}
             >
               {t('update.banner.confirmButton')}
@@ -459,7 +472,7 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
         ) : (
           <button
             ref={relaunchTriggerRef}
-            onClick={() => setConfirming(true)}
+            onClick={beginConfirming}
             aria-label={t('update.banner.ariaExpanded', { version: version ?? '' })}
             className={cn(
               'flex w-full items-center justify-center gap-2 rounded-full border py-2',

--- a/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
@@ -117,7 +117,10 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
 
     let cancelled = false;
     setHasSessionInTurn(false);
-    void window.electronAPI.anySessionInTurn()
+    // Start the probe in a microtask so a synchronously unavailable IPC bridge
+    // is converted into a rejected promise and handled by the same fallback.
+    void Promise.resolve()
+      .then(() => window.electronAPI.anySessionInTurn())
       .then((busy) => {
         if (!cancelled) setHasSessionInTurn(busy);
       })

--- a/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
@@ -381,7 +381,7 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
           <p
             className={cn(
               'text-center text-xs',
-              confirming && hasSessionInTurn
+              !isPreparing && confirming && hasSessionInTurn
                 ? 'text-[var(--warning-fg)]'
                 : 'text-sidebar-muted',
             )}

--- a/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
@@ -65,6 +65,9 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   const { dismissed, dismiss, restore, isNewUpdateAfterDismiss } = useUpdateBannerDismiss();
   // 就地确认态:替代原先的屏幕中央 ConfirmDialog。
   const [confirming, setConfirming] = useState(false);
+  // 复用关闭窗口保护链路的权威 busy 探针：只统计仍在执行的逻辑 turn，
+  // 不把 keepalive、已结束但仍在渲染收尾的状态误判为运行中任务。
+  const [hasSessionInTurn, setHasSessionInTurn] = useState(false);
   // 进入确认态后把焦点移到「取消」按钮 —— 键盘用户点入口键后原触发元素会卸载,
   // 若不主动聚焦,焦点会丢失、无法继续操作。刻意聚焦「取消」而非「确认」:让默认落在
   // 安全动作上,避免再按一次 Enter/Space 就直接更新的误操作(即 Radix 对破坏性操作
@@ -102,6 +105,30 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   useEffect(() => {
     if (status !== 'ready') setConfirming(false);
   }, [status]);
+
+  // 每次进入确认态都重新查询，避免沿用上一次打开弹层时的 busy 结果。
+  // handler 在 splash / login 阶段尚未注册时可能 reject；此 banner 只会在
+  // ready 主界面出现，但仍与 WindowControls 保持同样的安全兜底语义。
+  useEffect(() => {
+    if (!confirming) {
+      setHasSessionInTurn(false);
+      return;
+    }
+
+    let cancelled = false;
+    setHasSessionInTurn(false);
+    void window.electronAPI.anySessionInTurn()
+      .then((busy) => {
+        if (!cancelled) setHasSessionInTurn(busy);
+      })
+      .catch(() => {
+        if (!cancelled) setHasSessionInTurn(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [confirming]);
 
   // 新更新到达时自动 restore:isNewUpdateAfterDismiss 先检查当前 status 是否为
   // active update 态(ready / superseding),再对比 dismiss 时的快照——两个条件
@@ -351,11 +378,22 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
             延伸而不是第三段独立文案;没有链接时这个 wrapper 只有一个子元素,布局与
             加链接前完全一致。 */}
         <div className="flex flex-col items-center gap-1">
-          <p className="text-xs text-sidebar-muted">
+          <p
+            className={cn(
+              'text-center text-xs',
+              confirming && hasSessionInTurn
+                ? 'text-[var(--warning-fg)]'
+                : 'text-sidebar-muted',
+            )}
+          >
             {isPreparing
               ? t('update.banner.preparingSubtitle')
               : confirming
-                ? t('update.banner.confirmHint')
+                ? t(
+                    hasSessionInTurn
+                      ? 'update.banner.confirmBusyHint'
+                      : 'update.banner.confirmHint',
+                  )
                 : t('update.banner.subtitle')}
           </p>
           {notesVersion && (

--- a/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
@@ -57,8 +57,6 @@ interface UpdateBannerProps {
   onOpenVersionNotice?: (version: string) => void;
 }
 
-type SessionTurnCheck = 'pending' | 'idle' | 'busy';
-
 export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerProps) {
   const { status, version, errorCode } = useUpdateStatus();
   // 用户主动关闭态(仅本次进程内存,由 UserInfoSection 的火焰按钮唤回)。
@@ -69,8 +67,7 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   const [confirming, setConfirming] = useState(false);
   // 复用关闭窗口保护链路的权威 busy 探针：只统计仍在执行的逻辑 turn，
   // 不把 keepalive、已结束但仍在渲染收尾的状态误判为运行中任务。
-  const [sessionTurnCheck, setSessionTurnCheck] = useState<SessionTurnCheck>('idle');
-  const hasSessionInTurn = sessionTurnCheck === 'busy';
+  const [hasSessionInTurn, setHasSessionInTurn] = useState(false);
   // 进入确认态后把焦点移到「取消」按钮 —— 键盘用户点入口键后原触发元素会卸载,
   // 若不主动聚焦,焦点会丢失、无法继续操作。刻意聚焦「取消」而非「确认」:让默认落在
   // 安全动作上,避免再按一次 Enter/Space 就直接更新的误操作(即 Radix 对破坏性操作
@@ -114,18 +111,18 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   // ready 主界面出现，但仍与 WindowControls 保持同样的安全兜底语义。
   useEffect(() => {
     if (!confirming) {
-      setSessionTurnCheck('idle');
+      setHasSessionInTurn(false);
       return;
     }
 
     let cancelled = false;
-    setSessionTurnCheck('pending');
+    setHasSessionInTurn(false);
     void window.electronAPI.anySessionInTurn()
       .then((busy) => {
-        if (!cancelled) setSessionTurnCheck(busy ? 'busy' : 'idle');
+        if (!cancelled) setHasSessionInTurn(busy);
       })
       .catch(() => {
-        if (!cancelled) setSessionTurnCheck('idle');
+        if (!cancelled) setHasSessionInTurn(false);
       });
 
     return () => {
@@ -184,13 +181,6 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
     setConfirming(false);
   };
 
-  const beginConfirming = () => {
-    // Mark the check as pending synchronously so a click in the first render
-    // after opening cannot bypass the busy-state query.
-    setSessionTurnCheck('pending');
-    setConfirming(true);
-  };
-
   // 用户点 X:整块 banner 收起,同时把确认态一并复位,避免下次通过火焰按钮唤回时
   // 直接落在「确认重启」界面(那是两步流程的第二步,越过第一步显示不合适)。
   // 传入当前 status/version 让 store 记录快照,用于后续区分「同一更新 remount」
@@ -211,7 +201,6 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   if (dismissed && (status === 'ready' || isPreparing)) return null;
 
   const handleRelaunch = () => {
-    if (sessionTurnCheck === 'pending') return;
     const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
     window.electronAPI.relaunchToUpdate(theme);
   };
@@ -288,13 +277,12 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
           <Tip text={t('update.banner.confirmTooltip')} side="right">
             <button
               onClick={handleRelaunch}
-              disabled={sessionTurnCheck === 'pending'}
               aria-label={t('update.banner.confirmAria')}
               className={cn(
                 'flex w-full items-center justify-center py-2 transition-colors',
                 // Bare ghost icon on the sidebar — use the readable foreground, not the
                 // on-fill pill text color (which is dark-on-dark in E1D neutral themes).
-                'text-foreground hover:bg-sidebar-item-hover disabled:cursor-wait disabled:opacity-70',
+                'text-foreground hover:bg-sidebar-item-hover',
               )}
             >
               <Check className="h-5 w-5" strokeWidth={2.25} />
@@ -327,7 +315,7 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
         >
           <button
             ref={relaunchTriggerRef}
-            onClick={() => { if (!isPreparing) beginConfirming(); }}
+            onClick={() => { if (!isPreparing) setConfirming(true); }}
             disabled={isPreparing}
             aria-label={isPreparing
               ? t('update.banner.preparingAria')
@@ -445,13 +433,12 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
           <div className="flex w-full flex-col gap-2">
             <button
               onClick={handleRelaunch}
-              disabled={sessionTurnCheck === 'pending'}
               aria-label={t('update.banner.confirmAria')}
               className={cn(
                 'flex w-full items-center justify-center gap-2 rounded-full border py-2',
                 'text-[13px] font-medium transition-colors',
                 'bg-[var(--update-btn-bg)] border-[var(--update-btn-border)] text-[var(--update-btn-text)]',
-                'hover:bg-[var(--update-btn-hover)] disabled:cursor-wait disabled:opacity-70',
+                'hover:bg-[var(--update-btn-hover)]',
               )}
             >
               {t('update.banner.confirmButton')}
@@ -472,7 +459,7 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
         ) : (
           <button
             ref={relaunchTriggerRef}
-            onClick={beginConfirming}
+            onClick={() => setConfirming(true)}
             aria-label={t('update.banner.ariaExpanded', { version: version ?? '' })}
             className={cn(
               'flex w-full items-center justify-center gap-2 rounded-full border py-2',

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3909,6 +3909,7 @@
       "preparingAria": "Preparing newer version, please wait",
       "confirmTitle": "Restart to update?",
       "confirmHint": "The app will restart automatically",
+      "confirmBusyHint": "A task is still running. Restarting will interrupt it",
       "confirmButton": "Restart now",
       "cancel": "Cancel",
       "confirmTooltip": "Confirm restart to apply the update",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3908,6 +3908,7 @@
       "preparingAria": "新しいバージョンを準備中、お待ちください",
       "confirmTitle": "再起動して更新?",
       "confirmHint": "アプリが自動的に再起動します",
+      "confirmBusyHint": "実行中のタスクがあります。再起動すると中断されます",
       "confirmButton": "再起動",
       "cancel": "キャンセル",
       "confirmTooltip": "再起動して更新を適用",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3908,6 +3908,7 @@
       "preparingAria": "새 버전 준비 중입니다. 잠시만 기다려 주세요",
       "confirmTitle": "재시작하여 업데이트?",
       "confirmHint": "앱이 자동으로 재시작됩니다",
+      "confirmBusyHint": "아직 실행 중인 작업이 있습니다. 재시작하면 작업이 중단됩니다",
       "confirmButton": "재시작",
       "cancel": "취소",
       "confirmTooltip": "재시작하여 업데이트 적용",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3908,6 +3908,7 @@
       "preparingAria": "正在准备新版本，请稍候",
       "confirmTitle": "确认重启更新？",
       "confirmHint": "应用会自动重启",
+      "confirmBusyHint": "当前仍有任务在执行，重启会直接中断",
       "confirmButton": "确认重启",
       "cancel": "取消",
       "confirmTooltip": "确认重启并应用更新",

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -412,6 +412,7 @@ Theme switching: `useTheme.ts` provides `theme` (System / Light / Dark mode) plu
 | `--perm-bypass-selected-text` | `#EA6B17` | `#EA6B17` | Heart Orange, permission semantics (auto-follows `var(--warning-accent)`, finalized 2026-07-17) |
 | `--settings-integration-warning` | `#EA6B17` | `#EA6B17` | Warning semantics (auto-follows `var(--warning-accent)`, finalized 2026-07-17) |
 | `--warning-bg-soft` | rgba(234,107,23,0.12) | rgba(234,107,23,0.18) | Warning alpha surface (alpha recomputed against `#EA6B17`, 2026-07-17) |
+| `--warning-fg` | `#F3A115` | `#F3A115` | Warning text/icons, including the update-restart busy-turn interruption hint |
 | `--focus-ring` / `--focus-ring-soft` | `#417CDD` / @50% | same | A11y focus ring, finalized 2026-07-17 (replaces #3b82f6), theme-invariant |
 | `--shadow-menu` / `--cmd-palette-shadow` / `--confirm-shadow` | rgba | rgba (deeper) | Shadows, theme-invariant |
 | `--overlay-modal` / `--overlay-lightbox` | rgba | rgba (deeper) | Modal / lightbox backdrop |


### PR DESCRIPTION
## 这次改了什么

### 摘要

更新确认界面在进入确认态时调用一次 `anySessionInTurn()` 判断当前是否仍有任务执行。若 busy，提示改为“当前仍有任务在执行，重启会直接中断”并使用语义 warning 色；若非 busy，继续显示“应用会自动重启”。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：#675
- 本 PR 包含：Desktop 更新确认界面的单次 busy 状态判断、四语文案和回归测试。
- 明确不包含：updater 实际退出/重启逻辑，不改变按钮状态、确认交互或重启行为本身。
- 用户可见变化：有运行中任务时，确认界面显示中断风险并标黄；无运行中任务时保持现状。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark 双模式交付门槛」及「Semantic Exemption Colors」；busy 提示复用 `--warning-fg`。
- busy 时显示 `当前仍有任务在执行，重启会直接中断`，使用 `--warning-fg` 语义色。
- idle 时保持 `应用会自动重启` 及原有中性文本色。
- 仅在确认界面开启时做一次状态快照；停留期间不轮询、不订阅、不维护状态。
- 遵循 `docs/design-rules/DESIGN.md` 的语义色与双模式规则，未新增硬编码颜色。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（desktop、mobile、共享 packages、协议 packages 全部通过）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/updateBannerBusyHint.test.tsx
结果：3 tests passed

pnpm --filter desktop exec eslint src/renderer/components/sidebar/UpdateBanner.tsx src/renderer/__tests__/updateBannerBusyHint.test.tsx
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

未启动 Desktop 做实机点击验证；已通过 jsdom 回归测试覆盖 busy、idle，以及查询 pending 时按钮行为保持不变。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：Desktop renderer 更新确认界面及对应 i18n；不涉及 Mobile runtime fingerprint，不触发移动端冷更。
- 回滚方式：回滚本 PR commit 即可恢复原有提示逻辑。

## 关联 Issue

- #675

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 带 DCO 签名（`git commit -s`）
- [x] UI 改动已说明设计规范依据
- [x] 未提交凭证、令牌或授权文件
- [x] 已完成并记录测试验证

## 界面效果证据

<!-- pr-765-ui-evidence -->

更新确认界面仅根据进入确认态时的一次性 `anySessionInTurn()` 快照切换提示文本和语义颜色：

```html
<!-- 主 turn 非 busy：保持现状 -->
<p class="text-sidebar-muted">
  应用会自动重启
</p>

<!-- 主 turn busy：仅修改提示文本并使用 warning 语义色 -->
<p style="color: var(--warning-fg)">
  当前仍有任务在执行，重启会直接中断
</p>
```

- 查询只在进入确认界面时执行一次；停留期间不轮询、不订阅、不维护 busy 状态。
- 查询结果不禁用按钮、不阻止重启，也不改变确认交互或 updater 重启路径。
- `--warning-fg` 为 Light / Dark 共用语义 token，未使用单主题硬编码颜色。
