### PR TITLE
fix(mobile): 审核模式豁免 android,避免 review 字段冻结安卓热更

### DIFF
--- a/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
+++ b/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
@@ -409,6 +409,21 @@ describe('isReviewModeActive(送审版本号匹配纯函数)', () => {
       vi.resetModules();
     }
   });
+
+  it('APP_PLATFORM 只认 ios / android:其余内联值收敛为空串,不逸出取值域', async () => {
+    // web / 未来新平台 / 被改写成意外值时都按「拿不到平台」处理(此处
+    // Constants.platform 亦无平台段),而不是把原值透传给平台门控。
+    for (const value of ['web', 'ANDROID_TV', 'unknown']) {
+      process.env.EXPO_OS = value;
+      try {
+        const { env } = await freshModules();
+        expect(env.APP_PLATFORM).toBe('');
+      } finally {
+        delete process.env.EXPO_OS;
+        vi.resetModules();
+      }
+    }
+  });
 });
 
 describe('applyResolvedClientEndpoints', () => {

--- a/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
+++ b/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
@@ -385,6 +385,30 @@ describe('isReviewModeActive(送审版本号匹配纯函数)', () => {
     expect(env.isReviewModeActive('1.4.0', '')).toBe(false);
     expect(env.isReviewModeActive('', '')).toBe(false);
   });
+
+  it('android 恒 false:清单 review 命中同版本号也不冻结安卓的更新检查', async () => {
+    const { env } = await freshModules();
+    // iOS 保持原语义(命中即进审核模式),android 在同样输入下豁免。
+    expect(env.isReviewModeActive('0.1.0', '0.1.0', false, 'ios')).toBe(true);
+    expect(env.isReviewModeActive('0.1.0', '0.1.0', false, 'android')).toBe(false);
+    // TestFlight 豁免与平台豁免互不干扰。
+    expect(env.isReviewModeActive('0.1.0', '0.1.0', true, 'android')).toBe(false);
+    // 平台未知(内联缺失且 Constants.platform 无平台段)时不弱化 iOS 送审合规。
+    expect(env.isReviewModeActive('0.1.0', '0.1.0', false, '')).toBe(true);
+  });
+
+  it('APP_PLATFORM 取 EXPO_OS 内联值;缺失时回落 Constants.platform 平台段', async () => {
+    process.env.EXPO_OS = 'android';
+    try {
+      const { env } = await freshModules();
+      expect(env.APP_PLATFORM).toBe('android');
+      // 平台默认参数走 APP_PLATFORM,安卓 bundle 下审核模式恒关。
+      expect(env.isReviewModeActive('0.1.0', '0.1.0')).toBe(false);
+    } finally {
+      delete process.env.EXPO_OS;
+      vi.resetModules();
+    }
+  });
 });
 
 describe('applyResolvedClientEndpoints', () => {

--- a/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
+++ b/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
@@ -410,6 +410,33 @@ describe('isReviewModeActive(送审版本号匹配纯函数)', () => {
     }
   });
 
+  it('EXPO_OS 内联缺失时回落 Constants.platform 平台段(安卓豁免不靠单一信号)', async () => {
+    // 这条兜底是「安卓被审核模式误冻结热更」的最后一道防线:babel 内联一旦失效
+    // (自定义 babel 配置等),没有它就会静默回归高代价故障,故单独断言。
+    delete process.env.EXPO_OS;
+    const platformCases = [
+      { manifest: { android: { versionCode: 12 } }, expected: 'android' },
+      { manifest: { ios: { buildNumber: '12' } }, expected: 'ios' },
+      // 无平台段(web / 结构变化)→ 空串,走平台未知语义。
+      { manifest: {}, expected: '' },
+    ];
+    for (const { manifest, expected } of platformCases) {
+      vi.doMock('expo-constants', () => ({
+        default: { expoConfig: null, platform: manifest },
+      }));
+      try {
+        vi.resetModules();
+        const env = await import('@/config/env');
+        expect(env.APP_PLATFORM).toBe(expected);
+        // 兜底判出 android 时同样恒豁免审核模式。
+        expect(env.isReviewModeActive('0.1.0', '0.1.0')).toBe(expected !== 'android');
+      } finally {
+        vi.doUnmock('expo-constants');
+        vi.resetModules();
+      }
+    }
+  });
+
   it('APP_PLATFORM 只认 ios / android:其余内联值收敛为空串,不逸出取值域', async () => {
     // web / 未来新平台 / 被改写成意外值时都按「拿不到平台」处理(此处
     // Constants.platform 亦无平台段),而不是把原值透传给平台门控。

--- a/apps/mobile/src/config/env.ts
+++ b/apps/mobile/src/config/env.ts
@@ -222,25 +222,54 @@ export let VOICE_API_BASE_URL = normalizeBaseUrlWithDefault(
 export const APP_BINARY_VERSION =
   (Constants.nativeAppVersion ?? Constants.expoConfig?.version ?? '').trim();
 
+// 运行平台标识('ios' / 'android';拿不到即空串)。审核模式的平台门控要在 env.ts
+// 顶层就能判定,而这里不能引 react-native 的 Platform:env.ts 被 node 环境单测直接
+// 导入,react-native 真模块会把 Flow 语法拖进依赖链(同 vitest.config.ts 对
+// expo-localization 的处理)。改用两路互不依赖的 RN-free 信号:
+// 1. `process.env.EXPO_OS` —— babel-preset-expo 打包期按目标平台内联(仓内无
+//    babel.config.js,@expo/metro-config 回落 expo/internal/babel-preset,该内联恒生效);
+//    JS 常量,不进 @expo/fingerprint,不改 runtimeVersion。
+// 2. `Constants.platform` 的平台段兜底 —— 万一内联缺失(自定义 babel 配置等)仍能判出
+//    Android,避免「安卓被审核模式误冻结热更」这个高代价失效模式静默复发。
+function resolveAppPlatform(): string {
+  const inlined = (process.env.EXPO_OS ?? '').trim().toLowerCase();
+  if (inlined) return inlined;
+  const platformManifest = Constants.platform;
+  if (platformManifest?.android) return 'android';
+  if (platformManifest?.ios) return 'ios';
+  return '';
+}
+
+export const APP_PLATFORM = resolveAppPlatform();
+
 /**
  * 纯函数:清单 review(送审版本号)与二进制版本号严格相等、且当前安装不是
  * TestFlight 时才进入审核模式;
  * 任一侧为空恒 false(清单没填 = 关闭;拿不到版本号 = 宁可不进审核模式,
  * 也不能让线上用户误失去更新通道)。
+ * Android 恒 false:审核模式只为 iOS 商店送审存在(见下方 REVIEW_MODE 注释),
+ * 而清单 review 是 region 级单值、不分平台,iOS 送审期间填的版本号会连带命中同版本号的
+ * 安卓自建装机,把它们的热更与整包检查一起冻结(2026-07 实踩:review="0.1.0" 冻结全部
+ * 0.1.0 安卓装机)。安卓自建线不过商店审核,没有需要关闭更新检查的场景,故在此豁免。
+ * 只豁免 android:iOS(含平台未知)一律保持原语义,不弱化送审合规。
  */
 export function isReviewModeActive(
   reviewVersion: string | null | undefined,
   appBinaryVersion: string,
   isTestFlight = false,
+  platform: string = APP_PLATFORM,
 ): boolean {
+  if (platform === 'android') return false;
   const review = reviewVersion?.trim();
   const binary = appBinaryVersion.trim();
   return !isTestFlight && Boolean(review) && review === binary;
 }
 
 // 手机版审核模式(清单可选字段 review = 送审版本号,缺失/空串 = 关闭):App 审核
-// 期间线上清单填送审构建的二进制版本号,仅版本命中且 StoreKit 未识别为 TestFlight
-// 的构建关闭全部 JS 显式更新检查。TestFlight 不进入审核模式,但由整包更新策略单独
+// 期间线上清单填送审构建的二进制版本号,仅 **iOS** 上版本命中且 StoreKit 未识别为
+// TestFlight 的构建关闭全部 JS 显式更新检查;android 恒不进审核模式(清单 review 是
+// region 级单值不分平台,安卓自建线不过商店审核,理由见 isReviewModeActive)。
+// TestFlight 不进入审核模式,但由整包更新策略单独
 // 禁用会外跳安装的整包检查,只保留 JS OTA。设置页在审核模式隐藏统一「检查更新」入口;
 // 存量其它版本用户不受影响。覆盖边界与运维义务(原生层后台检查管不到、
 // 过审发布后须清空字段)见 maker-shared clientEndpoints 的 CLIENT_ENDPOINT_REVIEW_KEY

--- a/apps/mobile/src/config/env.ts
+++ b/apps/mobile/src/config/env.ts
@@ -260,12 +260,14 @@ export const APP_PLATFORM: AppPlatform = resolveAppPlatform();
  * 安卓自建装机,把它们的热更与整包检查一起冻结(2026-07 实踩:review="0.1.0" 冻结全部
  * 0.1.0 安卓装机)。安卓自建线不过商店审核,没有需要关闭更新检查的场景,故在此豁免。
  * 只豁免 android:iOS(含平台未知)一律保持原语义,不弱化送审合规。
+ * platform 形参收敛为 AppPlatform 而非 string:拼写 / 大小写错误('Android')会静默
+ * 走回 iOS 语义、丢掉安卓豁免,这类误用要在类型层就挡住,不留给运行期。
  */
 export function isReviewModeActive(
   reviewVersion: string | null | undefined,
   appBinaryVersion: string,
   isTestFlight = false,
-  platform: string = APP_PLATFORM,
+  platform: AppPlatform = APP_PLATFORM,
 ): boolean {
   if (platform === 'android') return false;
   const review = reviewVersion?.trim();

--- a/apps/mobile/src/config/env.ts
+++ b/apps/mobile/src/config/env.ts
@@ -222,7 +222,7 @@ export let VOICE_API_BASE_URL = normalizeBaseUrlWithDefault(
 export const APP_BINARY_VERSION =
   (Constants.nativeAppVersion ?? Constants.expoConfig?.version ?? '').trim();
 
-// 运行平台标识('ios' / 'android';拿不到即空串)。审核模式的平台门控要在 env.ts
+// 运行平台标识:只会是 'ios' / 'android' / ''(拿不到)。审核模式的平台门控要在 env.ts
 // 顶层就能判定,而这里不能引 react-native 的 Platform:env.ts 被 node 环境单测直接
 // 导入,react-native 真模块会把 Flow 语法拖进依赖链(同 vitest.config.ts 对
 // expo-localization 的处理)。改用两路互不依赖的 RN-free 信号:
@@ -231,16 +231,24 @@ export const APP_BINARY_VERSION =
 //    JS 常量,不进 @expo/fingerprint,不改 runtimeVersion。
 // 2. `Constants.platform` 的平台段兜底 —— 万一内联缺失(自定义 babel 配置等)仍能判出
 //    Android,避免「安卓被审核模式误冻结热更」这个高代价失效模式静默复发。
-function resolveAppPlatform(): string {
+// 取值收敛为白名单:两路信号都只认 'ios' / 'android',其余(web、未来新平台、
+// 被改写成意外值)一律当作「拿不到」→ 空串,由消费方按平台未知的语义处理,
+// 不让未预期的值逸出取值域后再去参与平台门控。
+const NATIVE_PLATFORMS = ['ios', 'android'] as const;
+
+export type AppPlatform = (typeof NATIVE_PLATFORMS)[number] | '';
+
+function resolveAppPlatform(): AppPlatform {
   const inlined = (process.env.EXPO_OS ?? '').trim().toLowerCase();
-  if (inlined) return inlined;
+  const matched = NATIVE_PLATFORMS.find((platform) => platform === inlined);
+  if (matched) return matched;
   const platformManifest = Constants.platform;
   if (platformManifest?.android) return 'android';
   if (platformManifest?.ios) return 'ios';
   return '';
 }
 
-export const APP_PLATFORM = resolveAppPlatform();
+export const APP_PLATFORM: AppPlatform = resolveAppPlatform();
 
 /**
  * 纯函数:清单 review(送审版本号)与二进制版本号严格相等、且当前安装不是


### PR DESCRIPTION
## 这次改了什么

### 摘要

`endpoint.json` 的 `review`(送审版本号)是 **region 级单值、不分平台**,而
`isReviewModeActive` 只按「版本号相等 + 非 TestFlight」判定,**没有平台门控**。iOS 送审期间把
`review` 填成线上版本号时,同版本号的**安卓自建装机会一起进入审核模式**,
`useStartupOtaGate` / `useBundleUpdatePrompt` / `useResumeUpdateCheck` 与设置页「检查更新」入口
全部关闭,**热更与整包检查同时被冻结**。

2026-07 实踩:线上 global 清单 `review="0.1.0"` 命中 0.1.0 安卓装机,启动闸门 `enabled=false`
从不发起 OTA check,已 promote 到 stable 的热更拉不到,设置页恒显示「随整包」。

审核模式只为 iOS 商店送审存在,安卓自建线不过商店审核,没有需要关闭更新检查的场景,故对
android 豁免。**只豁免 android**:iOS(含平台未知)一律保持原语义,不弱化送审合规。

两处实现细节:

- 门控放在纯函数 `isReviewModeActive` 内,使 `REVIEW_MODE` 的**模块初值**与
  `applyResolvedClientEndpoints` 里的 **live binding 重算**两处同时覆盖,不会出现初值与回填
  语义不一致。
- 平台标识**不引 `react-native` 的 `Platform`**:`env.ts` 被 node 环境单测直接导入,
  `react-native` 真模块会把 Flow 语法拖进依赖链(同 `vitest.config.ts` 对 `expo-localization`
  的既有处理)。改用 RN-free 双信号——babel-preset-expo 打包期内联的 `process.env.EXPO_OS`
  (仓内无 `babel.config.js`,`@expo/metro-config` 回落 `expo/internal/babel-preset`,该内联恒
  生效),加 `Constants.platform` 平台段兜底。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(线上排查发现)
- 本 PR 包含:`isReviewModeActive` 的 android 豁免 + `APP_PLATFORM` 平台检测 + 单测
- 明确不包含:**清空线上 `endpoint.json` 的 `review` 字段**(发布链/服务端操作,不在本仓);
  `review` 字段的分平台 schema 拆分(如 `reviewIos`/`reviewAndroid`)
- 用户可见变化:安卓装机不再因清单 `review` 命中而失去热更/整包更新检查与设置页「检查更新」
  入口;iOS 行为不变
- 是否存在 breaking change:无

### UI 变化

不涉及:仅改更新检查的启用判定,未改动任何界面、样式或文案。设置页「检查更新」入口的
显示条件本身未改(仍读 `REVIEW_MODE`),只是安卓上该值不再被 `review` 置真。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
node apps/mobile/scripts/ci-fingerprint.mjs compute --output /tmp/fp-before.json   # 改动前
node apps/mobile/scripts/ci-fingerprint.mjs compute --output /tmp/fp-after.json    # 改动后
node apps/mobile/scripts/ci-fingerprint.mjs compare --base /tmp/fp-before.json --current /tmp/fp-after.json
结果:fingerprint unchanged
  ios:     2b016e7e125e5bb75c263a91339d87848ea0a0ad -> 同值
  android: e3c49d1905c129296ba79db6c676f36384af4172 -> 同值

pnpm --filter mobile exec vitest run src/__tests__/clientEndpointStartup.test.ts
结果:24 passed(含 2 个新增用例)

pnpm --filter mobile run --if-present typecheck
结果:通过(tsc --noEmit 无输出)

pnpm test:unit
结果:exit=0,零 FAIL(apps/mobile、apps/desktop 及全部 packages PASS)

pnpm check:dco
结果:DCO check passed: 1 commit signed off — range c46da140..76df4d86 (base upstream/main)
```

新增单测覆盖:同样输入下 `ios` 命中审核模式 / `android` 豁免;TestFlight 豁免与平台豁免互不
干扰;平台未知时不弱化 iOS 送审合规;`EXPO_OS=android` 时 `APP_PLATFORM` 与默认参数链路生效。

### 手工验证

不涉及。

### 未执行的验证

- **未做 Android 实机验证**。要实机验证「审核模式不再冻结 Android」,前提是先清空线上
  `review` 字段或搭一个带 `review` 的测试清单,这两件都在发布链侧、超出本仓改动范围。
  `APP_PLATFORM` 在真机取到 `'android'` 这一步,靠 babel 回落链路的代码核实
  (`@expo/metro-config/build/loadBabelConfig.js:63`)+ 单测覆盖,而非实机确认。
- 未跑 `pnpm test:all`:本改动为单文件纯函数判定 + 单测,`test:unit` 全绿已覆盖;最终以 CI 为准。

## 风险

### 风险分类

- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异

### 影响与回滚

- **fingerprint / 冷更:不触发冷更。** 改动只涉及 `apps/mobile/src` 下的 TS(JS bundle 内容),
  不碰 resolved ExpoConfig、`apps/mobile/package.json`、`eas.json` production 段、`plugins/`、
  `modules/`、`fingerprint.config.cjs` 或原生依赖。已按
  `docs/dev-rules/mobile-development.md` 的「冷更边界」要求在改动前后各跑一次
  `ci-fingerprint.mjs compute` 并 `compare`,**ios / android 两个平台均 unchanged**,可走热更发布。
- 影响范围:安卓所有区域的自建装机(解冻更新检查);iOS 与 TestFlight 行为逐字节不变。
- 跨平台差异:本 PR **有意**引入平台差异——审核模式从此仅对 iOS 生效,理由与边界写在
  `isReviewModeActive` 与 `REVIEW_MODE` 的注释里。
- 回滚 / 降级方式:revert 本 commit 即恢复原判定(安卓重新受 `review` 影响);无数据、无 schema、
  无协议变更,回滚无残留。

### ⚠️ 本改动不能自我送达(需配套的发布链操作)

存量**已被冻结**的安卓装机收不到任何热更(闸门 `enabled=false`,根本不发 OTA 请求),因此拿不到
本修复。**要解当前线上故障,必须先在发布链清空 `endpoint.json` 的 `review` 字段**(纯服务端配置,
立即生效,且它本身就足够)。本 PR 是**防复发加固**:清空后再发热更,以后 iOS 送审设 `review`
就不会再误伤 Android。

建议配套的运维约定(未包含在本 PR):送审时 `review` 不要等于线上正式包版本号,过审后第一时间
清空。若认为该约定值得成文,可另开 PR 补进 dev-rules。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明(不涉及 UI)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(判定语义与平台边界写进 `env.ts` 注释;dev-rules 无需改动)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
