### PR TITLE
fix(maker-core): fall back to user approval for Codex Auto

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -483,6 +483,12 @@ describe('CodexAgent permissions', () => {
       input: { command: 'rm -rf build' },
       suggestions: undefined,
     });
+    if (!handle.setPermissionMode) throw new Error('expected setPermissionMode');
+    await handle.setPermissionMode('ask');
+    expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+      threadId: 'start-thread-id',
+      turnId: 'turn-wechat-policy',
+    });
     await handle.close();
   });
 
@@ -4507,7 +4513,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
-  it('falls back to untrusted for remote non-subscription sessions (Auto)', async () => {
+  it('falls back to user approvals for remote non-subscription sessions (Auto)', async () => {
     // gateway / 第三方 provider 的 reviewer 模型路由仍未验证 — 远程同样回退。
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);
@@ -4524,8 +4530,10 @@ describe('CodexAgent MCP thread context hooks', () => {
       approvalPolicy?: string;
       approvalsReviewer?: string;
     };
-    expect(startParams.approvalPolicy).toBe('untrusted');
-    expect(startParams).not.toHaveProperty('approvalsReviewer');
+    expect(startParams).toMatchObject({
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+    });
     await handle.close();
   });
 
@@ -4600,7 +4608,48 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
-  it('falls back to untrusted approvals on XD and interrupts the active turn when tightened to Ask', async () => {
+  it('maps Ask to the explicit user reviewer on a supported app-server', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        return { turn: { id: 'turn-user-approval-policy' } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-user-approval-policy',
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      workingDir: '/repo',
+      permissionMode: 'ask',
+    });
+
+    const startParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+      sandbox?: string;
+    };
+    expect(startParams).toMatchObject({
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+      sandbox: 'workspace-write',
+    });
+
+    await handle.send({ type: 'user', content: 'hello' });
+    const turnParams = host.request.mock.calls.find(([method]) => method === Method.TurnStart)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+      sandboxPolicy?: { type?: string };
+    };
+    expect(turnParams).toMatchObject({
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+      sandboxPolicy: { type: 'workspaceWrite' },
+    });
+    await handle.close();
+  });
+
+  it('falls back to user approvals on XD without interrupting when the UI switches to Ask', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {
       if (method === Method.TurnStart) {
@@ -4622,10 +4671,10 @@ describe('CodexAgent MCP thread context hooks', () => {
       sandbox?: string;
     };
     expect(startParams).toMatchObject({
-      approvalPolicy: 'untrusted',
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
       sandbox: 'workspace-write',
     });
-    expect(startParams).not.toHaveProperty('approvalsReviewer');
 
     await handle.send({ type: 'user', content: 'hello' });
     const turnParams = host.request.mock.calls.find(([method]) => method === Method.TurnStart)?.[1] as {
@@ -4634,20 +4683,51 @@ describe('CodexAgent MCP thread context hooks', () => {
       sandboxPolicy?: { type?: string };
     };
     expect(turnParams).toMatchObject({
-      approvalPolicy: 'untrusted',
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
       sandboxPolicy: { type: 'workspaceWrite' },
     });
-    expect(turnParams).not.toHaveProperty('approvalsReviewer');
-    if (!handle.setPermissionMode) throw new Error('expected setPermissionMode');
-    await handle.setPermissionMode('ask');
-    expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.commandExecutionApproval) throw new Error('expected commandExecutionApproval handler');
+    await expect(handlers.commandExecutionApproval({
       threadId: 'start-thread-id',
       turnId: 'turn-xd-auto-fallback',
+      itemId: 'cmd-no-resolver',
+      command: 'curl https://example.com',
+      cwd: '/repo',
+    })).resolves.toEqual({ decision: 'decline' });
+    if (!handle.setPermissionMode) throw new Error('expected setPermissionMode');
+    await handle.setPermissionMode('ask');
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnInterrupt)).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('overrides a resumed thread with the user reviewer when Auto falls back on XD', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-xd-auto-fallback-resume',
+      model: 'gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    const resumeParams = host.request.mock.calls.find(([method]) => method === Method.ThreadResume)?.[1] as {
+      approvalPolicy?: string;
+      approvalsReviewer?: string;
+      sandbox?: string;
+    };
+    expect(resumeParams).toMatchObject({
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+      sandbox: 'workspace-write',
     });
     await handle.close();
   });
 
-  it('falls back to untrusted approvals without reviewer fields on an older app-server', async () => {
+  it('falls back to on-request approvals without reviewer fields on an older app-server', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {
       if (method === Method.TurnStart) {
@@ -4667,7 +4747,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       approvalPolicy?: string;
       approvalsReviewer?: string;
     };
-    expect(startParams.approvalPolicy).toBe('untrusted');
+    expect(startParams.approvalPolicy).toBe('on-request');
     expect(startParams).not.toHaveProperty('approvalsReviewer');
 
     await handle.send({ type: 'user', content: 'hello' });
@@ -4675,7 +4755,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       approvalPolicy?: string;
       approvalsReviewer?: string;
     };
-    expect(turnParams.approvalPolicy).toBe('untrusted');
+    expect(turnParams.approvalPolicy).toBe('on-request');
     expect(turnParams).not.toHaveProperty('approvalsReviewer');
     await handle.close();
   });
@@ -4835,7 +4915,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       approvalsReviewer?: string;
     };
     expect(turnParams.approvalPolicy).toBe('on-request');
-    expect(turnParams).not.toHaveProperty('approvalsReviewer');
+    expect(turnParams.approvalsReviewer).toBe('user');
     expect(classifierUnavailable).toHaveBeenCalledWith({
       sessionId: 'session-guardian-timeout-runtime',
       agentKind: 'codex',

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -309,26 +309,33 @@ type CodexPermissionConfig = {
   approvalsReviewer?: ApprovalsReviewer;
 };
 function mapPermissionToCodex(
-  permissionMode?: string,
-  approvalsReviewerSupported = true,
+  permissionMode: string | undefined,
+  approvalsReviewerProtocolSupported: boolean,
+  approvalsReviewerRouteSupported: boolean,
 ): CodexPermissionConfig {
+  const manualApprovalConfig: CodexPermissionConfig = {
+    approvalPolicy: 'on-request',
+    sandbox: 'workspace-write',
+    ...(approvalsReviewerProtocolSupported ? { approvalsReviewer: 'user' } : {}),
+  };
   // 严格 kebab-case (v2.rs serde rename_all="kebab-case"), camelCase 会被 server -32600 reject
   switch (permissionMode) {
     case 'bypassPermissions':
       return { approvalPolicy: 'never', sandbox: 'danger-full-access' };
     case 'auto':
-      if (!approvalsReviewerSupported) {
-        // 旧 app-server 或未验证 reviewer 模型路由时回退到原生 untrusted:
-        // 可信命令自动执行,其余请求交给用户。既不能发送未知字段,也不能让
-        // 首个越界动作撞上 provider 不支持的隐藏审核模型。
-        return { approvalPolicy: 'untrusted', sandbox: 'workspace-write' };
+      if (!approvalsReviewerProtocolSupported || !approvalsReviewerRouteSupported) {
+        // 旧 app-server 或未验证 reviewer 模型路由时回退到人工 on-request。
+        // 不能用 untrusted:它拒绝 require_escalated,即使用户批准普通命令,
+        // 网络/沙箱外写入仍会留在受限 sandbox 内。新版协议显式写 user,
+        // 还可覆盖恢复 thread 中 sticky 的 auto_review;旧版则安全省略未知字段。
+        return manualApprovalConfig;
       }
       // Codex app-server 原生 auto_review 与 Claude Auto 的分工一致:
       // 常规 workspace 动作直接执行,越界动作交给内置 reviewer 判断,而不是交给 UI。
       // workspace-write 仍是硬安全边界; auto_review 只替换审批者,不扩大沙箱。
       return { approvalPolicy: 'on-request', sandbox: 'workspace-write', approvalsReviewer: 'auto_review' };
     default:
-      return { approvalPolicy: 'on-request', sandbox: 'workspace-write' };
+      return manualApprovalConfig;
   }
 }
 
@@ -2295,8 +2302,9 @@ export class CodexAgent extends BaseAgent {
     // model through the session's model provider. Cindy's gateway, third-party
     // providers, and other non-subscription credentials do not have a verified
     // route for that model. Keep Auto usable on those routes by falling back to
-    // Codex's native `untrusted` policy instead of letting the first write fail
-    // in the reviewer.
+    // manual on-request approvals instead of letting the first write fail in the
+    // reviewer. Remote OAuth subscriptions use the daemon's synced subscription
+    // credential and keep the verified reviewer route.
     const approvalsReviewerRouteSupported = sessionCredentialMode === 'oauth-bearer';
     const approvalsReviewerSupported =
       approvalsReviewerProtocolSupported && approvalsReviewerRouteSupported;
@@ -2309,12 +2317,13 @@ export class CodexAgent extends BaseAgent {
       );
     }
     if (mutablePermissionMode === 'auto' && !approvalsReviewerSupported) {
-      log.warn('Codex Auto falling back to untrusted approvals: automatic reviewer is unavailable on this route', {
+      log.warn('Codex Auto falling back to user approvals: automatic reviewer is unavailable on this route', {
         userAgent: initResp.userAgent,
         providerId: opts.providerId ?? null,
         credentialMode: sessionCredentialMode ?? 'unknown',
         remote: Boolean(opts.remoteHostId),
         protocolSupported: approvalsReviewerProtocolSupported,
+        routeSupported: approvalsReviewerRouteSupported,
       });
     }
     // 闭包 capture 一次, 整个 session 复用 — codexHome 是 server 进程级常量, host 不变就不变。
@@ -2400,7 +2409,11 @@ export class CodexAgent extends BaseAgent {
       }
     };
     function currentApprovalConfig(): CodexPermissionConfig {
-      return mapPermissionToCodex(mutablePermissionMode, approvalsReviewerSupported);
+      return mapPermissionToCodex(
+        mutablePermissionMode,
+        approvalsReviewerProtocolSupported,
+        approvalsReviewerRouteSupported,
+      );
     }
 
     function shouldUseReadonlyReferencesProfile(): boolean {
@@ -3169,8 +3182,9 @@ export class CodexAgent extends BaseAgent {
         (req.kind === 'permission' &&
           forceTurnConfirmation(req.toolName, req.input));
       // Full access 的普通审批不应打断用户。Auto 在已验证路由上由 app-server
-      // auto_review 负责；降级路由则由 untrusted 把越界请求发回客户端。两条路径
-      // 只要收到请求都走 UI，不能绕过 reviewer / 降级审批直接放行。forcePrompt 高风险 MCP inner tool
+      // auto_review 负责；降级路由则由 user reviewer 把越界请求发回客户端。
+      // 两条路径只要收到请求都走 UI，不能绕过 reviewer / 降级审批直接放行。
+      // forcePrompt 高风险 MCP inner tool
       // (如 contacts delete/merge/系统回写)在任何模式下都必须拿到用户的逐次确认。
       if (
         !forcePrompt &&
@@ -3299,9 +3313,9 @@ export class CodexAgent extends BaseAgent {
     let pendingTightenInterrupt = false;
     /**
      * 最近一次 send 的 turn 是否以无人值守策略发射 (覆盖在飞与运行中两个阶段)。
-     * Auto (auto_review 或 untrusted 降级) / never 发射的 turn 在收紧时需要中断;
-     * user reviewer 发射的 turn 审批请求照常流经本地、收紧即时生效,即使期间 UI
-     * 短暂切过宽松档也不得误杀。
+     * auto_review / never / Auto policy turn 在收紧时需要中断;普通 user reviewer
+     * 发射的 turn 审批请求照常流经本地、收紧即时生效,即使期间 UI 短暂切过
+     * 宽松档也不得误杀。
      */
     let turnLaunchedUnattended = false;
     /**
@@ -4885,10 +4899,14 @@ export class CodexAgent extends BaseAgent {
           if (sendOpts?.throwOnStartFailure) throw new Error(message);
           return;
         }
-        const { approvalPolicy } = turnWorkspaceConfig;
-        // 记录本 turn 是否由无人值守策略发射。Auto 即使因路由能力降级为
-        // untrusted,切回 Ask 时也必须中断当前 turn,避免旧策略继续执行 trusted 操作。
-        turnLaunchedUnattended = mutablePermissionMode === 'auto' || approvalPolicy === 'never';
+        const { approvalPolicy, approvalsReviewer } = turnWorkspaceConfig;
+        // 记录本 turn 是否由无人值守策略发射。普通降级路由显式使用 user reviewer,
+        // 与 Ask 权限等价；policy turn 则以 untrusted + read-only 发射，并由 host
+        // 自动接受非强制回调，仍属于无人值守执行。
+        turnLaunchedUnattended =
+          approvalPolicy === 'never' ||
+          approvalsReviewer === 'auto_review' ||
+          (activeTurnPermissionPolicy !== null && mutablePermissionMode === 'auto');
         if (!turnLaunchedUnattended) {
           pendingTightenInterrupt = false;
         }
@@ -5445,8 +5463,8 @@ export class CodexAgent extends BaseAgent {
       async setPermissionMode(newMode: PermissionMode) {
         log.debug('setPermissionMode', { from: mutablePermissionMode, to: newMode });
         // Full access 才能批量放行挂起的 ask。切到 Auto 时，已有请求不能绕过
-        // reviewer / untrusted 降级审批，先 fail-closed 关闭；后续重试按当前路由能力
-        // 选择 auto_review 或 untrusted。
+        // reviewer / 人工降级审批，先 fail-closed 关闭；后续重试按当前路由能力
+        // 选择 auto_review 或 user reviewer。
         const allowPending = newMode === 'bypassPermissions';
         dismissAllPending(`permission_mode_changed_to_${newMode}`, allowPending ? 'allow' : 'deny');
         const wasAuto = mutablePermissionMode === 'auto';
@@ -5465,8 +5483,9 @@ export class CodexAgent extends BaseAgent {
         if (!tightensCurrentTurn) {
           pendingTightenInterrupt = false;
         } else if (!closed && turnLaunchedUnattended) {
-          // 只中断 Auto (含 untrusted 降级) / never 发射的 turn; user reviewer 发射的
-          // turn 审批请求照常流经本地、收紧即时生效,期间 UI 短暂切过宽松档不构成中断理由。
+          // 只中断 auto_review / never / Auto policy turn;普通 user reviewer 发射的
+          // turn 审批请求照常流经本地、收紧即时生效,期间 UI 短暂切过宽松档
+          // 不构成中断理由。
           if (currentTurnId !== null) {
             await interruptTurnForPermissionTighten(currentTurnId);
           } else if (isTurnStartPending) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex Auto 在第三方 provider、远程 daemon 或旧版 app-server 上无法可靠路由隐藏的 `codex-auto-review` 模型。上游预降级原先使用 `untrusted`，但该策略会拒绝 `require_escalated`，导致用户即使在审批卡片点击 Allow，命令仍留在受限 sandbox 中而执行失败。

本 PR 将不支持 Auto Review 的路由明确降级为 `on-request + approvalsReviewer: user`。新版协议会显式覆盖恢复线程中可能残留的 `auto_review`；旧版协议只发送 `on-request`，避免发送未知字段。人工审批 turn 不再被误判为无人值守 turn，因此切换到 Ask 不会被错误中断。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Codex Auto Review 在不支持 `codex-auto-review` 的 provider 上审批后仍无法执行
- 本 PR 包含：maker-core Codex 权限映射、恢复线程覆盖和权限切换状态判断；对应回归测试
- 明确不包含：跨 Provider 路由 `codex-auto-review`、Gateway 模型代理、UI 改动
- 用户可见变化：不支持自动 reviewer 的路由会展示并执行人工审批；Allow 后可按用户授权执行
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（当前 diff）
  
pnpm --filter @cindy/maker-core test -- src/agents/codex/index.test.ts
结果：46 个测试文件、667 个测试通过
  
pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过；该 package 当前没有 typecheck script，按仓库门禁自动跳过
  
pnpm check:dco
结果：通过；1 个 commit 带 Signed-off-by
```

### 手工验证

未在提交后重新启动 Desktop 实例验证；此前复现路径为第三方 provider 下弹出审批卡片，点击 Allow 后命令仍未成功执行。

### 未执行的验证

未执行提交后的 Desktop 实机回归；需要在 XD/第三方 provider 的 Auto 模式下验证审批卡片 Allow 与 Deny，并确认 OpenAI OAuth 路由仍使用原生 Auto Review。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：Codex 权限策略映射、第三方/远程/旧版 app-server 的 Auto 降级路径，以及运行中权限切换的中断判断
- 安全语义：降级仅把审批者改为用户，不扩大 sandbox；挂起请求在切换权限模式时仍 fail-closed
- 回滚 / 降级方式：回滚本提交即可恢复原先的 `untrusted` 降级

maker-core 核心指标评估：
- 缓存率：未修改 prompt、tool/MCP 或会话前缀
- 性能：仅调整同步权限映射和布尔状态判断，没有新增网络请求或串行 await
- 返回准确性：未修改 translator、事件顺序、模型映射或 usage 计量；权限决策由显式代码与测试约束
- 实测结论：maker-core 667 项测试和全仓单测通过，未观察到相关回归

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
