### PR TITLE
fix(desktop): 修复 macOS 终端中文输入乱码

### DIFF
--- a/apps/desktop/src/main/terminal/__tests__/ptyManager.test.ts
+++ b/apps/desktop/src/main/terminal/__tests__/ptyManager.test.ts
@@ -121,7 +121,10 @@ let allSpawns: FakePty[] = [];
 let dataPayloads: Array<{ target: WebContents; payload: DataPayload }> = [];
 let exitPayloads: Array<{ target: WebContents; payload: ExitPayload }> = [];
 
-function makeManager(opts?: { resolveFallbackOwner?: (dead: WebContents) => WebContents | null }) {
+function makeManager(opts?: {
+  resolveFallbackOwner?: (dead: WebContents) => WebContents | null;
+  platform?: NodeJS.Platform;
+}) {
   return new PtyManager({
     spawn: (command, args, options) => {
       const fake = makeFakePty({
@@ -144,6 +147,7 @@ function makeManager(opts?: { resolveFallbackOwner?: (dead: WebContents) => WebC
       },
     },
     resolveFallbackOwner: opts?.resolveFallbackOwner,
+    platform: opts?.platform,
   });
 }
 
@@ -453,6 +457,118 @@ describe('PtyManager.spawn env scrubbing', () => {
     // 仍会被剥。这是有意设计:不让调用方意外引入 host 标记。
     // 这条 case 验证"剥永远生效",不是"opts.env 能塞回"。
     expect(lastSpawn!.__spawnEnv.TERM_PROGRAM).toBeUndefined();
+  });
+
+  it('macOS 继承到空/C locale 时为 PTY 补 UTF-8 字符 locale', () => {
+    const original = {
+      LANG: process.env.LANG,
+      LC_ALL: process.env.LC_ALL,
+      LC_CTYPE: process.env.LC_CTYPE,
+    };
+    try {
+      process.env.LANG = '';
+      process.env.LC_ALL = '';
+      process.env.LC_CTYPE = 'C';
+
+      const mgr = makeManager({ platform: 'darwin' });
+      const owner = makeFakeWebContents() as unknown as WebContents;
+      mgr.create({ id: 't1', cwd: '/tmp', owner });
+
+      expect(lastSpawn!.__spawnEnv.LC_CTYPE).toBe('UTF-8');
+      expect(lastSpawn!.__spawnEnv.LC_ALL).toBe('');
+
+      delete process.env.LC_CTYPE;
+      process.env.LANG = 'C';
+      mgr.create({ id: 't2', cwd: '/tmp', owner });
+      expect(lastSpawn!.__spawnEnv.LC_CTYPE).toBe('UTF-8');
+    } finally {
+      for (const [key, value] of Object.entries(original)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it('调用方显式传入的 locale 在平台兜底之后生效', () => {
+    const original = {
+      LANG: process.env.LANG,
+      LC_ALL: process.env.LC_ALL,
+      LC_CTYPE: process.env.LC_CTYPE,
+    };
+    try {
+      process.env.LANG = '';
+      process.env.LC_ALL = '';
+      process.env.LC_CTYPE = 'C';
+
+      const mgr = makeManager({ platform: 'darwin' });
+      const owner = makeFakeWebContents() as unknown as WebContents;
+      mgr.create({
+        id: 't1',
+        cwd: '/tmp',
+        owner,
+        env: { LC_CTYPE: 'ja_JP.UTF-8' },
+      });
+
+      expect(lastSpawn!.__spawnEnv.LC_CTYPE).toBe('ja_JP.UTF-8');
+    } finally {
+      for (const [key, value] of Object.entries(original)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it('不覆盖用户显式设置的 LC_ALL 或非 C/POSIX 字符 locale', () => {
+    const original = {
+      LANG: process.env.LANG,
+      LC_ALL: process.env.LC_ALL,
+      LC_CTYPE: process.env.LC_CTYPE,
+    };
+    try {
+      process.env.LANG = '';
+      process.env.LC_ALL = 'C';
+      process.env.LC_CTYPE = 'C';
+
+      const mgr = makeManager({ platform: 'darwin' });
+      const owner = makeFakeWebContents() as unknown as WebContents;
+      mgr.create({ id: 't1', cwd: '/tmp', owner });
+      expect(lastSpawn!.__spawnEnv.LC_ALL).toBe('C');
+      expect(lastSpawn!.__spawnEnv.LC_CTYPE).toBe('C');
+
+      process.env.LC_ALL = '';
+      process.env.LC_CTYPE = 'en_US.UTF-8';
+      mgr.create({ id: 't2', cwd: '/tmp', owner });
+      expect(lastSpawn!.__spawnEnv.LC_CTYPE).toBe('en_US.UTF-8');
+    } finally {
+      for (const [key, value] of Object.entries(original)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it('Windows 不改变 C locale', () => {
+    const original = {
+      LANG: process.env.LANG,
+      LC_ALL: process.env.LC_ALL,
+      LC_CTYPE: process.env.LC_CTYPE,
+    };
+    try {
+      process.env.LANG = '';
+      process.env.LC_ALL = '';
+      process.env.LC_CTYPE = 'C';
+
+      const mgr = makeManager({ platform: 'win32' });
+      const owner = makeFakeWebContents() as unknown as WebContents;
+      mgr.create({ id: 't1', cwd: '/tmp', owner });
+
+      expect(lastSpawn!.__spawnEnv.LC_CTYPE).toBe('C');
+    } finally {
+      for (const [key, value] of Object.entries(original)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 });
 

--- a/apps/desktop/src/main/terminal/ptyManager.ts
+++ b/apps/desktop/src/main/terminal/ptyManager.ts
@@ -372,7 +372,8 @@ export class PtyManager {
     const rows = opts.rows && opts.rows > 0 ? opts.rows : DEFAULT_ROWS;
     const resolved = resolveShellForCreate(opts.shellPref ?? null);
 
-    // 合并 env:先复制父进程环境,再做平台兜底,最后应用调用方显式覆盖。
+    // 合并 env:先复制父进程环境,做平台兜底,再应用调用方显式覆盖。
+    // ENV_KEYS_TO_STRIP 与 TERM 仍在下方强制执行,不允许 opts.env 改写。
     const env: Record<string, string> = {};
     for (const [k, v] of Object.entries(process.env)) {
       if (typeof v === 'string') env[k] = v;

--- a/apps/desktop/src/main/terminal/ptyManager.ts
+++ b/apps/desktop/src/main/terminal/ptyManager.ts
@@ -157,6 +157,8 @@ interface PtySession {
 export interface PtyManagerDeps {
   spawn?: PtySpawnFn;
   sink: PtyEventSink;
+  /** 仅供测试注入平台；生产代码默认使用当前 Node 平台。 */
+  platform?: NodeJS.Platform;
   /**
    * owner webContents destroyed 时的接管者解析(典型:主窗 webContents)。
    * 返回一个活着的、不同于 dead owner 的 webContents 时,该 owner 的 session
@@ -176,11 +178,13 @@ export class PtyManager {
   private readonly trackedOwners = new WeakSet<WebContents>();
   private readonly spawnFn: PtySpawnFn;
   private readonly sink: PtyEventSink;
+  private readonly platform: NodeJS.Platform;
   private readonly resolveFallbackOwner?: (deadOwner: WebContents) => WebContents | null;
 
   constructor(deps: PtyManagerDeps) {
     this.spawnFn = deps.spawn ?? defaultPtySpawn;
     this.sink = deps.sink;
+    this.platform = deps.platform ?? process.platform;
     this.resolveFallbackOwner = deps.resolveFallbackOwner;
   }
 
@@ -368,11 +372,12 @@ export class PtyManager {
     const rows = opts.rows && opts.rows > 0 ? opts.rows : DEFAULT_ROWS;
     const resolved = resolveShellForCreate(opts.shellPref ?? null);
 
-    // 合并 env:用户 env 覆盖 process.env,再注入 TERM,最后剥掉 host terminal app 标记。
+    // 合并 env:先复制父进程环境,再做平台兜底,最后应用调用方显式覆盖。
     const env: Record<string, string> = {};
     for (const [k, v] of Object.entries(process.env)) {
       if (typeof v === 'string') env[k] = v;
     }
+    ensureMacTerminalUtf8Locale(env, this.platform);
     if (opts.env) {
       for (const [k, v] of Object.entries(opts.env)) {
         if (typeof v === 'string') env[k] = v;
@@ -473,4 +478,23 @@ export class PtyManager {
       });
     }
   }
+}
+
+/**
+ * macOS Finder/Dock 启动的 GUI 进程可能继承到空/C locale。zsh 的行编辑器
+ * 需要 UTF-8 的 LC_CTYPE 才能正确识别中文等多字节输入；只设置 LANG 不够，
+ * 因为非空 LC_CTYPE 会覆盖 LANG。非空 LC_ALL 通常表示用户主动指定，保留其
+ * 语义；调用方通过 opts.env 传入的显式覆盖也在本函数之后生效。
+ */
+function ensureMacTerminalUtf8Locale(
+  env: Record<string, string>,
+  platform: NodeJS.Platform,
+): void {
+  if (platform !== 'darwin' || env.LC_ALL?.trim()) return;
+
+  const charLocale = env.LC_CTYPE?.trim() || env.LANG?.trim() || 'C';
+  const normalized = charLocale.toUpperCase();
+  if (normalized !== 'C' && normalized !== 'POSIX') return;
+
+  env.LC_CTYPE = 'UTF-8';
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 图形界面启动的 Desktop 进程继承空/C/POSIX 字符 locale 时，PTY 中 zsh 无法正确识别 UTF-8 中文输入、导致回显乱码的问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#754
- 本 PR 包含：Desktop PTY 环境构造中的 macOS locale 兜底，以及对应单元测试。
- 明确不包含：Windows 行为、Mobile、UI、服务端或全局进程环境修改。
- 用户可见变化：macOS 特定 locale 配置下，终端中文输入和回显恢复正常。
- 是否存在 breaking change：无。

### UI 变化

不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/terminal/__tests__/ptyManager.test.ts
结果：1 个测试文件通过，36 个测试通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec eslint src/main/terminal/ptyManager.ts src/main/terminal/__tests__/ptyManager.test.ts
结果：通过。

git diff --check origin/main...HEAD
结果：通过。
```

### 手工验证

未执行 macOS 实机验证；本次逻辑由平台注入单元测试覆盖，macOS 实机复现条件与 Issue 一致。

### 未执行的验证

- `pnpm test:unit`：未通过，失败点是现有 Windows 工作区 CRLF 导致的 `i18n/GLOSSARY.md` 与 `i18n/glossary.json` 同步测试，与本 PR 文件无关。
- Desktop 全量 lint：未通过，仓库当前存在 87 个与本 PR 无关的既有 lint 错误。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 macOS Desktop 新建 PTY；Windows 不变，已有 UTF-8 或其他非 C/POSIX locale 不变，非空 `LC_ALL` 不变。
- 移动端冷更判断：不会触发。改动只在 `apps/desktop/src/main/terminal/ptyManager.ts` 及其测试中，不涉及 `apps/mobile`、原生配置、依赖、插件、模块或 fingerprint 输入。
- 回滚方式：回滚本 PR 提交即可恢复原有 PTY 环境构造逻辑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已记录实际测试结果与未执行项