### PR TITLE
fix(claude): 修复 OAuth auto 权限分类器失败

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -84,6 +84,7 @@ describe('cc routingTransform — xAI 会话的辅助请求回落默认路由 (i
     // 落到 ② 段 gatewayDefaultRouteDecision:换网关 key(绝不是 upstreamOverride api.x.ai)。
     expect(decision).toEqual({
       headerOverride: { 'x-api-key': 'sk-gw', authorization: 'Bearer sk-gw' },
+      headerDelete: ['x-anthropic-billing-header'],
     });
   });
 
@@ -93,11 +94,23 @@ describe('cc routingTransform — xAI 会话的辅助请求回落默认路由 (i
       { model: 'claude-haiku-4-5-20251001' },
       ctxWith({ ...SESSION_HEADER, 'x-api-key': 'sk-frozen' }),
     );
-    expect(decision).toBeNull();
+    expect(decision).toEqual({
+      headerDelete: ['x-anthropic-billing-header'],
+    });
   });
 
   it('claude-haiku 分类器请求(无网关 key 的 oauth-spawn)→ 直连 Anthropic 订阅', () => {
     gatewayKey = null;
+    const transform = createModelRoutingTransform();
+    const decision = transform(
+      { model: 'claude-haiku-4-5-20251001' },
+      ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
+    );
+    expect(decision).toEqual({ upstreamOverride: 'https://api.anthropic.com' });
+  });
+
+  it('显式 Anthropic 订阅路由保留 attribution header', () => {
+    setSessionProvider('sess-grok', 'anthropic');
     const transform = createModelRoutingTransform();
     const decision = transform(
       { model: 'claude-haiku-4-5-20251001' },

--- a/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
@@ -72,7 +72,7 @@ describe('claude session route observation (routing transform ② 段)', () => {
       { model: 'claude-opus-4-8[1m]' },
       ctxWith({ ...SESSION_HEADER, 'x-api-key': 'sk-frozen' }),
     );
-    expect(decision).toBeNull();  // passthrough
+    expect(decision).toEqual({ headerDelete: ['x-anthropic-billing-header'] });
     expect(readClaudeSessionRoute('sess-1')).toBe('gateway');
   });
 
@@ -83,7 +83,10 @@ describe('claude session route observation (routing transform ② 段)', () => {
       { model: 'claude-opus-4-8[1m]' },
       ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
     );
-    expect(decision).toEqual({ headerOverride: { 'x-api-key': 'sk-live' } });
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': 'sk-live' },
+      headerDelete: ['x-anthropic-billing-header'],
+    });
     expect(readClaudeSessionRoute('sess-1')).toBe('gateway');
   });
 
@@ -103,7 +106,7 @@ describe('claude session route observation (routing transform ② 段)', () => {
       { model: 'gpt-5.5[1m]' },
       ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
     );
-    expect(decision).toBeNull();
+    expect(decision).toEqual({ headerDelete: ['x-anthropic-billing-header'] });
     expect(readClaudeSessionRoute('sess-1')).toBeNull();
   });
 

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -31,6 +31,7 @@ import {
   stripNonAnthropicFields,
   stripToolUseProviderSpecificFields,
   type ProxyHandle,
+  type RoutingDecision,
   type RoutingTransform,
 } from '@cindy/anthropic-compat-proxy';
 
@@ -127,6 +128,20 @@ function hasHeader(headers: Readonly<Record<string, string>>, name: string): boo
   return false;
 }
 
+const CLAUDE_ATTRIBUTION_HEADER = 'x-anthropic-billing-header';
+
+/**
+ * Claude Code 的 attribution header 会让 Cindy 网关 / 第三方 upstream 绕过 prompt cache，
+ * 但 Anthropic OAuth 直连要求保留它。按最终 request route 删除，而不是按整个 spawn
+ * 设置 CLAUDE_CODE_ATTRIBUTION_HEADER，才能兼容同一 OAuth 进程里的两种流量。
+ */
+function withoutClaudeAttribution(decision: RoutingDecision = {}): RoutingDecision {
+  return {
+    ...decision,
+    headerDelete: [...new Set([...(decision.headerDelete ?? []), CLAUDE_ATTRIBUTION_HEADER])],
+  };
+}
+
 /**
  * per-request 路由 transform。两段:
  *   ① 会话显式选了供应商 → 据 catalog 统一路由(per-session,取代全局开关推断)。
@@ -199,7 +214,15 @@ export function createModelRoutingTransform(): RoutingTransform {
       // 不在订阅直连供应商(xai / openai-cc)声明的 modelPrefixes 范围内 → 返回 null,
       // 落到下方 ② 段 spawn 默认路由,分类器照常走网关/直连(issue #886)。
       const perSession = resolveSessionRouteDecision(sessionId, 'claude-code', gatewayKey, wireModel);
-      if (perSession) return perSession;
+      if (perSession) {
+        if (getSessionProvider(sessionId) === 'anthropic') return perSession;
+        if ('then' in perSession) {
+          return perSession.then((resolved) =>
+            resolved ? withoutClaudeAttribution(resolved) : null,
+          );
+        }
+        return withoutClaudeAttribution(perSession);
+      }
     }
 
     // ② 未显式选供应商 → 据请求凭证判定 spawn 形态(见上方注释)。
@@ -210,13 +233,13 @@ export function createModelRoutingTransform(): RoutingTransform {
     if (hasHeader(ctx.headers, 'x-api-key')) {
       // gateway-spawn:自带网关 key,passthrough。
       if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
-      return null;
+      return withoutClaudeAttribution();
     }
     const decision = gatewayDefaultRouteDecision('claude-code', gatewayKey);
     if (decision) {
       // oauth-spawn 默认:全量换网关 key(防订阅 token 泄漏到网关)。
       if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
-      return decision;
+      return withoutClaudeAttribution(decision);
     }
     // 没网关 key:Anthropic 模型只能直连(唯一出路),其余 passthrough + 记一条诊断。
     // 判据 = 前缀地板 ∪ 目录 anthropic 供应商模型集合(新家族改 OSS 目录即可,无需发版)。
@@ -228,7 +251,7 @@ export function createModelRoutingTransform(): RoutingTransform {
       // 无 key 的非 Anthropic 模型 passthrough 大概率 401 —— 路由归属不明确, 不记录。
       log.warn('claude oauth-spawn but no gateway key; non-anthropic passthrough (可能 401)', { wireModel });
     }
-    return null;
+    return withoutClaudeAttribution();
   };
 }
 

--- a/apps/desktop/src/main/remote-ssh/__tests__/claudeEnv.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/claudeEnv.test.ts
@@ -57,6 +57,7 @@ describe('getRemoteClaudeEnv', () => {
     expect(env).toMatchObject({
       ANTHROPIC_API_KEY: 'sk-xd-gateway-key',
       ANTHROPIC_BASE_URL: TEST_XD_GATEWAY_BASE_URL,
+      CLAUDE_CODE_ATTRIBUTION_HEADER: '0',
       ENABLE_TOOL_SEARCH: 'auto',
       DISABLE_TELEMETRY: '1',
     });

--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AuthAdapter } from '../../../interfaces/auth-adapter.js';
 import type { AgentRuntimeConfig } from '../../../interfaces/runtime-config.js';
-import { buildClaudeEnv } from '../env-builder.js';
+import { buildClaudeEnv, stripSensitiveAnthropicEnv } from '../env-builder.js';
 
 const MODEL_CONTEXT_WINDOWS_ENV = 'XDT_MAKER_MODEL_CONTEXT_WINDOWS';
 
@@ -29,6 +29,7 @@ describe('buildClaudeEnv', () => {
   const originalTerm = process.env.TERM;
   const originalPsOutputRendering = process.env.PSStyle__OutputRendering;
   const originalSubagentModel = process.env.CLAUDE_CODE_SUBAGENT_MODEL;
+  const originalAttributionHeader = process.env.CLAUDE_CODE_ATTRIBUTION_HEADER;
 
   afterEach(() => {
     if (originalDisableCron === undefined) {
@@ -46,6 +47,7 @@ describe('buildClaudeEnv', () => {
     restore('TERM', originalTerm);
     restore('PSStyle__OutputRendering', originalPsOutputRendering);
     restore('CLAUDE_CODE_SUBAGENT_MODEL', originalSubagentModel);
+    restore('CLAUDE_CODE_ATTRIBUTION_HEADER', originalAttributionHeader);
   });
 
   it('disables Claude Code native cron for host-managed sessions', async () => {
@@ -327,6 +329,32 @@ describe('buildClaudeEnv', () => {
       expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
       expect(env.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
       expect(env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL).toBeUndefined();
+    });
+
+    it('从宿主环境剥离继承的 attribution 开关，避免 SDK 二次合并回子进程', async () => {
+      const hostEnv: NodeJS.ProcessEnv = {
+        CLAUDE_CODE_ATTRIBUTION_HEADER: '0',
+        KEEP_ME: '1',
+      };
+      expect(stripSensitiveAnthropicEnv(hostEnv)).toContain('CLAUDE_CODE_ATTRIBUTION_HEADER');
+      expect(hostEnv.CLAUDE_CODE_ATTRIBUTION_HEADER).toBeUndefined();
+      expect(hostEnv.KEEP_ME).toBe('1');
+
+      process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0';
+      const env = await buildClaudeEnv(
+        createAuthAdapter({ CLAUDE_CODE_OAUTH_TOKEN: 'at-live' }),
+        {},
+      );
+      expect(env.CLAUDE_CODE_ATTRIBUTION_HEADER).toBeUndefined();
+    });
+
+    it('固定网关 host 仍可通过 behaviorFlags 显式重加 attribution 禁用开关', async () => {
+      const env = await buildClaudeEnv(
+        createAuthAdapter({ ANTHROPIC_API_KEY: 'sk-gw' }),
+        { behaviorFlags: { CLAUDE_CODE_ATTRIBUTION_HEADER: '0' } },
+      );
+
+      expect(env.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
     });
 
     it('合并顺序:process.env 的订阅 token 被剥离,authEnv 注入值存活', async () => {

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -87,6 +87,9 @@ export const SENSITIVE_ANTHROPIC_ENV_KEYS = [
   'CLAUDE_CODE_OAUTH_SCOPES',
   'CLAUDE_CODE_SUBSCRIPTION_TYPE',
   'CLAUDE_CODE_RATE_LIMIT_TIER',
+  // 请求归因开关也不能从启动 Cindy 的 shell 继承。Claude Agent SDK 会在 spawn 时
+  // 再次合并 process.env；固定网关 host 如需禁用归因，应通过 behaviorFlags 显式重加。
+  'CLAUDE_CODE_ATTRIBUTION_HEADER',
   // endpoint 重定向
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_UNIX_SOCKET',


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 子进程原先无条件收到 `CLAUDE_CODE_ATTRIBUTION_HEADER=0`。Anthropic 订阅 OAuth 会话的 auto 权限分类器旁路请求会因此被上游拒绝，导致需要分类的工具调用持续 fail-closed。

本 PR 在 Claude 环境完成鉴权组装后按实际凭证分流：只要子进程携带 `CLAUDE_CODE_OAUTH_TOKEN`，就移除宿主注入的 attribution 禁用开关；网关、第三方供应商和 SSH 远程网关路径继续保留该开关与 prompt-cache 优化。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#758
- 本 PR 包含：OAuth 与网关两类 Claude spawn 的 attribution 环境分流；对应回归测试；Desktop 配置注释。
- 明确不包含：分类器连续失败后的 UI 降级提示；Claude Code 上游行为修改；远程 SSH 鉴权改造。
- 用户可见变化：Anthropic 订阅 OAuth 会话在 auto 权限模式下可恢复正常工具安全分类。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/env-builder.test.ts
结果：通过，1 个文件 / 22 个测试。

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/runtimeConfigs.test.ts src/main/remote-ssh/__tests__/claudeEnv.test.ts
结果：通过，2 个文件 / 4 个测试。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：通过，全仓 unit tier 全部通过。

pnpm check:dco
结果：通过，1 个提交已签名。
```

### 手工验证

不涉及：当前环境没有可用于真实 Anthropic 订阅 OAuth + auto 分类器调用的测试账号；由最终 spawn env 的分支回归测试覆盖。

### 未执行的验证

- 未执行 Desktop 实机 OAuth 工具调用：缺少对应订阅测试环境。
- 未实测 macOS：改动为跨平台环境对象分支，不涉及路径或平台 API；Windows 类型检查与全量单测已通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Claude Code 子进程启动时的环境组装。OAuth spawn 恢复上游默认 attribution；网关、第三方 provider 和 SSH 远程网关仍为 `0`，缓存优化不变。逻辑只在 spawn 时做一次键删除，不进入逐 token / 事件热路径。
- 缓存与行为评估：网关路径由单测锁定继续保留 `0`；OAuth 路径会采用 Anthropic 默认 attribution，这是修复分类器所需的预期变化。未改变 prompt 内容、工具定义、事件映射、模型路由或 usage 计量。
- 移动端冷更分析：不涉及 `apps/mobile`、原生配置、原生依赖、config plugin 或 runtime fingerprint 输入，不触发冷更。
- 远程与手机版适配：SSH 远程会话固定使用网关 key，现有 `claude-env.ts` 保持不变；设备互联与手机版不新增 IPC、入口或协议，因此不涉及。
- 回滚 / 降级方式：回滚本提交即可恢复原环境注入行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因