### PR TITLE
fix(desktop): 保留问题反馈确认面板草稿

### DIFF
--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -50,6 +50,10 @@ vi.mock('@/lib/composerDraftStore', () => ({
 import { makerChatStore } from '@/lib/makerChatStore';
 import { remoteProjectsStore } from '@/features/device-link/remoteProjectsStore';
 import * as messageService from '@/lib/messageService';
+import {
+  getIssueConfirmDraft,
+  saveIssueConfirmDraft,
+} from '@/lib/issueConfirmDraftStore';
 
 type RemotePush = { deviceId: string; channel: string; payload: unknown };
 type ResolveCall = { requestId: string; decision: Record<string, unknown> };
@@ -297,6 +301,67 @@ describe('device-link 远程交互往返 — plan_review', () => {
       requestId: 'plan-2',
       decision: { kind: 'plan_review', behavior: 'deny', reason: '再想想边界条件' },
     });
+  });
+});
+
+describe('device-link 远程交互往返 — issue_confirm draft', () => {
+  const issueRequest = {
+    kind: 'issue_confirm',
+    requestId: 'issue-draft-1',
+    draft: { title: '原始标题', body: '原始正文', type: 'bug' },
+    env: {
+      appVersion: '0.1.18',
+      platform: 'darwin',
+      arch: 'arm64',
+      osVersion: '15.0',
+    },
+    submissionIdentity: { kind: 'github-user', login: 'tester' },
+  };
+
+  it('逐键保存不通知 makerChatStore 全局订阅,响应后清除草稿', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, issueRequest);
+    await flush();
+    expect(makerChatStore.getSnapshot(s).pendingIssueConfirm?.requestId).toBe('issue-draft-1');
+
+    const globalListener = vi.fn();
+    const unsubscribe = makerChatStore.subscribeAll(globalListener);
+    saveIssueConfirmDraft(s, 'issue-draft-1', {
+      title: '编辑后的标题',
+      body: '编辑后的正文',
+      type: 'feature',
+    });
+
+    expect(getIssueConfirmDraft(s, 'issue-draft-1')).toMatchObject({
+      title: '编辑后的标题',
+      body: '编辑后的正文',
+      type: 'feature',
+    });
+    expect(globalListener).not.toHaveBeenCalled();
+
+    makerChatStore.respondToIssueConfirm(s, { confirmed: false });
+    await flush();
+    expect(getIssueConfirmDraft(s, 'issue-draft-1')).toBeUndefined();
+    expect(makerChatStore.getSnapshot(s).pendingIssueConfirm).toBeNull();
+    unsubscribe();
+    makerChatStore.purgeSession(s);
+  });
+
+  it('interaction dismissed 时清除对应草稿', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, issueRequest);
+    await flush();
+    saveIssueConfirmDraft(s, 'issue-draft-1', {
+      title: '未提交标题',
+      body: '未提交正文',
+      type: 'bug',
+    });
+
+    host.hostDismiss(s, 'issue-draft-1', 'timeout');
+    await flush();
+    expect(getIssueConfirmDraft(s, 'issue-draft-1')).toBeUndefined();
+    expect(makerChatStore.getSnapshot(s).pendingIssueConfirm).toBeNull();
+    makerChatStore.purgeSession(s);
   });
 });
 

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1124,7 +1124,6 @@ export function CCAgentSessionView({
     planViewerState,
     setPlanViewerState,
     pendingIssueConfirm,
-    updateIssueConfirmDraft,
     respondToIssueConfirm,
     pendingRenameSessionsConfirm,
     respondToRenameSessionsConfirm,
@@ -3095,10 +3094,11 @@ export function CCAgentSessionView({
                     onViewerStateChange={setPluginSetupViewerState}
                     onCommand={respondToPluginSetup}
                   />
-                ) : pendingIssueConfirm ? (
+                ) : pendingIssueConfirm && sessionId ? (
                   <IssueConfirmCard
+                    key={`${sessionId}:${pendingIssueConfirm.requestId}`}
+                    sessionId={sessionId}
                     pending={pendingIssueConfirm}
-                    onDraftChange={updateIssueConfirmDraft}
                     onRespond={respondToIssueConfirm}
                   />
                 ) : pendingRenameSessionsConfirm ? (

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1124,6 +1124,7 @@ export function CCAgentSessionView({
     planViewerState,
     setPlanViewerState,
     pendingIssueConfirm,
+    updateIssueConfirmDraft,
     respondToIssueConfirm,
     pendingRenameSessionsConfirm,
     respondToRenameSessionsConfirm,
@@ -3097,6 +3098,7 @@ export function CCAgentSessionView({
                 ) : pendingIssueConfirm ? (
                   <IssueConfirmCard
                     pending={pendingIssueConfirm}
+                    onDraftChange={updateIssueConfirmDraft}
                     onRespond={respondToIssueConfirm}
                   />
                 ) : pendingRenameSessionsConfirm ? (

--- a/apps/desktop/src/renderer/features/cc-agent/IssueConfirmCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/IssueConfirmCard.tsx
@@ -13,7 +13,7 @@
  *   Esc            → 取消
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -22,9 +22,16 @@ import { shouldLabelIssueRegion } from '../../../shared/issueRegionCode';
 
 interface IssueConfirmCardProps {
   pending: PendingIssueConfirm;
+  onDraftChange: (requestId: string, patch: Partial<PendingIssueConfirm['draft']>) => void;
   onRespond: (
     result:
-      | { confirmed: true; title: string; body: string; type: 'bug' | 'feature'; uiLanguage: string }
+      | {
+          confirmed: true;
+          title: string;
+          body: string;
+          type: 'bug' | 'feature';
+          uiLanguage: string;
+        }
       | { confirmed: false },
   ) => void;
 }
@@ -35,18 +42,11 @@ const TITLE_MAX = 200;
 // githubIssueSubmitService clamp 到 server 上限 SERVER_DESC_MAX(5000)。
 const BODY_MAX = 4500;
 
-export function IssueConfirmCard({ pending, onRespond }: IssueConfirmCardProps) {
+export function IssueConfirmCard({ pending, onDraftChange, onRespond }: IssueConfirmCardProps) {
   const { t, i18n } = useTranslation();
-  const [title, setTitle] = useState(pending.draft.title);
-  const [body, setBody] = useState(pending.draft.body);
-  const [type, setType] = useState<'bug' | 'feature'>(pending.draft.type);
-
-  // 同一会话内连续两次提交(新 requestId)时重置编辑态。
-  useEffect(() => {
-    setTitle(pending.draft.title);
-    setBody(pending.draft.body);
-    setType(pending.draft.type);
-  }, [pending.requestId, pending.draft.title, pending.draft.body, pending.draft.type]);
+  const titleInputId = useId();
+  const bodyInputId = useId();
+  const { title, body, type } = pending.draft;
 
   const canSubmit = title.trim().length > 0 && body.trim().length > 0;
 
@@ -97,7 +97,8 @@ export function IssueConfirmCard({ pending, onRespond }: IssueConfirmCardProps) 
   const typeButton = (value: 'bug' | 'feature', label: string) => (
     <button
       type="button"
-      onClick={() => setType(value)}
+      aria-pressed={type === value}
+      onClick={() => onDraftChange(pending.requestId, { type: value })}
       className={cn(
         'rounded-[6px] border px-2.5 py-[3px] text-12 font-medium transition-colors',
         type === value
@@ -128,14 +129,18 @@ export function IssueConfirmCard({ pending, onRespond }: IssueConfirmCardProps) 
       </div>
 
       {/* Issue title input */}
-      <label className="mt-3 block text-12 font-medium text-[var(--status-bar-meta)]">
+      <label
+        htmlFor={titleInputId}
+        className="mt-3 block text-12 font-medium text-[var(--status-bar-meta)]"
+      >
         {t('issueAgent.confirm.titleLabel')}
       </label>
       <input
+        id={titleInputId}
         type="text"
         value={title}
         maxLength={TITLE_MAX}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => onDraftChange(pending.requestId, { title: e.target.value })}
         className={cn(
           'mt-1 w-full rounded-[8px] border px-3 py-2',
           'border-[var(--perm-code-border)] bg-[var(--perm-code-bg)]',
@@ -145,13 +150,17 @@ export function IssueConfirmCard({ pending, onRespond }: IssueConfirmCardProps) 
       />
 
       {/* Issue body textarea */}
-      <label className="mt-3 block text-12 font-medium text-[var(--status-bar-meta)]">
+      <label
+        htmlFor={bodyInputId}
+        className="mt-3 block text-12 font-medium text-[var(--status-bar-meta)]"
+      >
         {t('issueAgent.confirm.bodyLabel')}
       </label>
       <textarea
+        id={bodyInputId}
         value={body}
         maxLength={BODY_MAX}
-        onChange={(e) => setBody(e.target.value)}
+        onChange={(e) => onDraftChange(pending.requestId, { body: e.target.value })}
         rows={8}
         className={cn(
           'mt-1 w-full resize-y rounded-[8px] border px-3 py-2',

--- a/apps/desktop/src/renderer/features/cc-agent/IssueConfirmCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/IssueConfirmCard.tsx
@@ -13,16 +13,21 @@
  *   Esc            → 取消
  */
 
-import { useCallback, useEffect, useId } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import {
+  getIssueConfirmDraft,
+  saveIssueConfirmDraft,
+  type IssueConfirmDraft,
+} from '@/lib/issueConfirmDraftStore';
 import { cn } from '@/lib/utils';
 import type { PendingIssueConfirm } from '@/lib/makerChatStore';
 import { shouldLabelIssueRegion } from '../../../shared/issueRegionCode';
 
 interface IssueConfirmCardProps {
+  sessionId: string;
   pending: PendingIssueConfirm;
-  onDraftChange: (requestId: string, patch: Partial<PendingIssueConfirm['draft']>) => void;
   onRespond: (
     result:
       | {
@@ -42,13 +47,30 @@ const TITLE_MAX = 200;
 // githubIssueSubmitService clamp 到 server 上限 SERVER_DESC_MAX(5000)。
 const BODY_MAX = 4500;
 
-export function IssueConfirmCard({ pending, onDraftChange, onRespond }: IssueConfirmCardProps) {
+export function IssueConfirmCard({ sessionId, pending, onRespond }: IssueConfirmCardProps) {
   const { t, i18n } = useTranslation();
   const titleInputId = useId();
   const bodyInputId = useId();
-  const { title, body, type } = pending.draft;
+  const [draft, setDraft] = useState<IssueConfirmDraft>(
+    () => getIssueConfirmDraft(sessionId, pending.requestId) ?? pending.draft,
+  );
+  const { title, body, type } = draft;
 
   const canSubmit = title.trim().length > 0 && body.trim().length > 0;
+
+  const updateDraft = useCallback(
+    (patch: Partial<IssueConfirmDraft>) => {
+      const next = { ...draft, ...patch };
+      if (next.title === draft.title && next.body === draft.body && next.type === draft.type) {
+        return;
+      }
+      // Save synchronously with the input event so an immediate session switch
+      // cannot unmount the card before its latest edit reaches the draft slot.
+      saveIssueConfirmDraft(sessionId, pending.requestId, next);
+      setDraft(next);
+    },
+    [draft, pending.requestId, sessionId],
+  );
 
   // 构建区域代号,与登录页区域徽标同一套不对称命名(DESIGN.md §16.3):cn → CN、
   // dev → Dev、global 不标。「哪些区域要标」只有 ISSUE_REGION_CODE 一个事实源 ——
@@ -98,7 +120,7 @@ export function IssueConfirmCard({ pending, onDraftChange, onRespond }: IssueCon
     <button
       type="button"
       aria-pressed={type === value}
-      onClick={() => onDraftChange(pending.requestId, { type: value })}
+      onClick={() => updateDraft({ type: value })}
       className={cn(
         'rounded-[6px] border px-2.5 py-[3px] text-12 font-medium transition-colors',
         type === value
@@ -140,7 +162,7 @@ export function IssueConfirmCard({ pending, onDraftChange, onRespond }: IssueCon
         type="text"
         value={title}
         maxLength={TITLE_MAX}
-        onChange={(e) => onDraftChange(pending.requestId, { title: e.target.value })}
+        onChange={(e) => updateDraft({ title: e.target.value })}
         className={cn(
           'mt-1 w-full rounded-[8px] border px-3 py-2',
           'border-[var(--perm-code-border)] bg-[var(--perm-code-bg)]',
@@ -160,7 +182,7 @@ export function IssueConfirmCard({ pending, onDraftChange, onRespond }: IssueCon
         id={bodyInputId}
         value={body}
         maxLength={BODY_MAX}
-        onChange={(e) => onDraftChange(pending.requestId, { body: e.target.value })}
+        onChange={(e) => updateDraft({ body: e.target.value })}
         rows={8}
         className={cn(
           'mt-1 w-full resize-y rounded-[8px] border px-3 py-2',

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/IssueConfirmCard.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/IssueConfirmCard.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { IssueConfirmCard } from '../IssueConfirmCard';
+import type { PendingIssueConfirm } from '@/lib/makerChatStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'zh-CN' },
+  }),
+}));
+
+const initialPending: PendingIssueConfirm = {
+  requestId: 'issue-request-a',
+  draft: {
+    title: '原始标题',
+    body: '原始正文',
+    type: 'bug',
+  },
+  env: {
+    appVersion: '0.1.18',
+    platform: 'win32',
+    arch: 'x64',
+    osVersion: '10.0',
+  },
+  submissionIdentity: {
+    kind: 'github-user',
+    login: 'tester',
+  },
+};
+
+function Harness() {
+  const [pending, setPending] = useState(initialPending);
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <>
+      <button type="button" onClick={() => setVisible((current) => !current)}>
+        switch session
+      </button>
+      {visible ? (
+        <IssueConfirmCard
+          pending={pending}
+          onDraftChange={(requestId, patch) =>
+            setPending((current) =>
+              current.requestId === requestId
+                ? {
+                    ...current,
+                    draft: { ...current.draft, ...patch },
+                  }
+                : current,
+            )
+          }
+          onRespond={vi.fn()}
+        />
+      ) : null}
+    </>
+  );
+}
+
+afterEach(cleanup);
+
+describe('IssueConfirmCard draft persistence', () => {
+  it('restores title, body and type after a session-switch remount', () => {
+    render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('issueAgent.confirm.titleLabel'), {
+      target: { value: '编辑后的标题' },
+    });
+    fireEvent.change(screen.getByLabelText('issueAgent.confirm.bodyLabel'), {
+      target: { value: '编辑后的正文' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'issueAgent.confirm.typeFeature' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch session' }));
+    expect(screen.queryByLabelText('issueAgent.confirm.titleLabel')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch session' }));
+    expect((screen.getByLabelText('issueAgent.confirm.titleLabel') as HTMLInputElement).value).toBe(
+      '编辑后的标题',
+    );
+    expect(
+      (screen.getByLabelText('issueAgent.confirm.bodyLabel') as HTMLTextAreaElement).value,
+    ).toBe('编辑后的正文');
+    expect(
+      screen
+        .getByRole('button', { name: 'issueAgent.confirm.typeFeature' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/IssueConfirmCard.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/IssueConfirmCard.test.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { IssueConfirmCard } from '../IssueConfirmCard';
+import { clearIssueConfirmDraftsForSession } from '@/lib/issueConfirmDraftStore';
 import type { PendingIssueConfirm } from '@/lib/makerChatStore';
 
 vi.mock('react-i18next', () => ({
@@ -34,7 +35,6 @@ const initialPending: PendingIssueConfirm = {
 };
 
 function Harness() {
-  const [pending, setPending] = useState(initialPending);
   const [visible, setVisible] = useState(true);
 
   return (
@@ -43,26 +43,17 @@ function Harness() {
         switch session
       </button>
       {visible ? (
-        <IssueConfirmCard
-          pending={pending}
-          onDraftChange={(requestId, patch) =>
-            setPending((current) =>
-              current.requestId === requestId
-                ? {
-                    ...current,
-                    draft: { ...current.draft, ...patch },
-                  }
-                : current,
-            )
-          }
-          onRespond={vi.fn()}
-        />
+        <IssueConfirmCard sessionId="session-a" pending={initialPending} onRespond={vi.fn()} />
       ) : null}
     </>
   );
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  clearIssueConfirmDraftsForSession('session-a');
+  clearIssueConfirmDraftsForSession('session-b');
+});
 
 describe('IssueConfirmCard draft persistence', () => {
   it('restores title, body and type after a session-switch remount', () => {
@@ -91,5 +82,57 @@ describe('IssueConfirmCard draft persistence', () => {
         .getByRole('button', { name: 'issueAgent.confirm.typeFeature' })
         .getAttribute('aria-pressed'),
     ).toBe('true');
+  });
+
+  it('isolates drafts by both sessionId and requestId', () => {
+    const onRespond = vi.fn();
+    const { rerender } = render(
+      <IssueConfirmCard
+        key="session-a:issue-request-a"
+        sessionId="session-a"
+        pending={initialPending}
+        onRespond={onRespond}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('issueAgent.confirm.titleLabel'), {
+      target: { value: '会话 A 的编辑' },
+    });
+
+    rerender(
+      <IssueConfirmCard
+        key="session-b:issue-request-a"
+        sessionId="session-b"
+        pending={initialPending}
+        onRespond={onRespond}
+      />,
+    );
+    expect((screen.getByLabelText('issueAgent.confirm.titleLabel') as HTMLInputElement).value).toBe(
+      '原始标题',
+    );
+
+    rerender(
+      <IssueConfirmCard
+        key="session-a:issue-request-b"
+        sessionId="session-a"
+        pending={{ ...initialPending, requestId: 'issue-request-b' }}
+        onRespond={onRespond}
+      />,
+    );
+    expect((screen.getByLabelText('issueAgent.confirm.titleLabel') as HTMLInputElement).value).toBe(
+      '原始标题',
+    );
+
+    rerender(
+      <IssueConfirmCard
+        key="session-a:issue-request-a"
+        sessionId="session-a"
+        pending={initialPending}
+        onRespond={onRespond}
+      />,
+    );
+    expect((screen.getByLabelText('issueAgent.confirm.titleLabel') as HTMLInputElement).value).toBe(
+      '会话 A 的编辑',
+    );
   });
 });

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -220,6 +220,11 @@ interface UseCCAgentChatReturn {
   cancelPlanReview: (requestId: string) => void;
   /** issue_confirm: Currently pending GitHub issue confirm card */
   pendingIssueConfirm: PendingIssueConfirm | null;
+  /** issue_confirm: Persist edited fields across session-switch remounts. */
+  updateIssueConfirmDraft: (
+    requestId: string,
+    patch: Partial<PendingIssueConfirm['draft']>,
+  ) => void;
   /** issue_confirm: Respond to the pending issue confirm card */
   respondToIssueConfirm: (
     result:
@@ -560,6 +565,14 @@ export function useCCAgentChat(
     [sessionId],
   );
 
+  const updateIssueConfirmDraft = useCallback(
+    (requestId: string, patch: Partial<PendingIssueConfirm['draft']>) => {
+      if (!sessionId) return;
+      makerChatStore.updateIssueConfirmDraft(sessionId, requestId, patch);
+    },
+    [sessionId],
+  );
+
   const respondToRenameSessionsConfirm = useCallback(
     (result: { confirmed: true } | { confirmed: false }) => {
       if (!sessionId) return;
@@ -840,6 +853,7 @@ export function useCCAgentChat(
     respondToPlanReview,
     cancelPlanReview,
     pendingIssueConfirm: lightState.pendingIssueConfirm,
+    updateIssueConfirmDraft,
     respondToIssueConfirm,
     pendingRenameSessionsConfirm: lightState.pendingRenameSessionsConfirm,
     respondToRenameSessionsConfirm,

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -220,11 +220,6 @@ interface UseCCAgentChatReturn {
   cancelPlanReview: (requestId: string) => void;
   /** issue_confirm: Currently pending GitHub issue confirm card */
   pendingIssueConfirm: PendingIssueConfirm | null;
-  /** issue_confirm: Persist edited fields across session-switch remounts. */
-  updateIssueConfirmDraft: (
-    requestId: string,
-    patch: Partial<PendingIssueConfirm['draft']>,
-  ) => void;
   /** issue_confirm: Respond to the pending issue confirm card */
   respondToIssueConfirm: (
     result:
@@ -565,14 +560,6 @@ export function useCCAgentChat(
     [sessionId],
   );
 
-  const updateIssueConfirmDraft = useCallback(
-    (requestId: string, patch: Partial<PendingIssueConfirm['draft']>) => {
-      if (!sessionId) return;
-      makerChatStore.updateIssueConfirmDraft(sessionId, requestId, patch);
-    },
-    [sessionId],
-  );
-
   const respondToRenameSessionsConfirm = useCallback(
     (result: { confirmed: true } | { confirmed: false }) => {
       if (!sessionId) return;
@@ -853,7 +840,6 @@ export function useCCAgentChat(
     respondToPlanReview,
     cancelPlanReview,
     pendingIssueConfirm: lightState.pendingIssueConfirm,
-    updateIssueConfirmDraft,
     respondToIssueConfirm,
     pendingRenameSessionsConfirm: lightState.pendingRenameSessionsConfirm,
     respondToRenameSessionsConfirm,

--- a/apps/desktop/src/renderer/lib/issueConfirmDraftStore.ts
+++ b/apps/desktop/src/renderer/lib/issueConfirmDraftStore.ts
@@ -1,0 +1,48 @@
+/**
+ * In-memory drafts for the submit_github_issue confirmation card.
+ *
+ * This input state is intentionally separate from makerChatStore: title/body
+ * changes happen on every keystroke and must not invalidate running-status
+ * snapshots or notify session/global chat subscribers. Keys include both the
+ * session and request so parallel sessions and consecutive requests cannot
+ * share edits. Renderer restart intentionally drops all entries.
+ */
+
+export interface IssueConfirmDraft {
+  title: string;
+  body: string;
+  type: 'bug' | 'feature';
+}
+
+const draftsBySession = new Map<string, Map<string, IssueConfirmDraft>>();
+
+export function getIssueConfirmDraft(
+  sessionId: string,
+  requestId: string,
+): IssueConfirmDraft | undefined {
+  return draftsBySession.get(sessionId)?.get(requestId);
+}
+
+export function saveIssueConfirmDraft(
+  sessionId: string,
+  requestId: string,
+  draft: IssueConfirmDraft,
+): void {
+  let sessionDrafts = draftsBySession.get(sessionId);
+  if (!sessionDrafts) {
+    sessionDrafts = new Map();
+    draftsBySession.set(sessionId, sessionDrafts);
+  }
+  sessionDrafts.set(requestId, draft);
+}
+
+export function clearIssueConfirmDraft(sessionId: string, requestId: string): void {
+  const sessionDrafts = draftsBySession.get(sessionId);
+  if (!sessionDrafts) return;
+  sessionDrafts.delete(requestId);
+  if (sessionDrafts.size === 0) draftsBySession.delete(sessionId);
+}
+
+export function clearIssueConfirmDraftsForSession(sessionId: string): void {
+  draftsBySession.delete(sessionId);
+}

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -7117,6 +7117,40 @@ function respondToIssueConfirm(
     .catch((err) => log.error('Failed to respond to issue confirm:', err));
 }
 
+/**
+ * issue_confirm:把用户在确认卡片里的编辑同步进 session-keyed store。
+ *
+ * 卡片会在切换对话时随路由卸载;pendingIssueConfirm 本身按 sessionId 常驻,
+ * 因此把编辑态收口到它的 draft 就能在返回原对话时恢复。requestId guard
+ * 防止旧卡片的迟到 input 事件覆盖同一会话里新一轮确认请求。
+ */
+function updateIssueConfirmDraft(
+  sessionId: string,
+  requestId: string,
+  patch: Partial<PendingIssueConfirm['draft']>,
+): void {
+  if (!sessionId) return;
+  setState(sessionId, (s) => {
+    const pending = s.pendingIssueConfirm;
+    if (!pending || pending.requestId !== requestId) return s;
+    const nextDraft = { ...pending.draft, ...patch };
+    if (
+      nextDraft.title === pending.draft.title &&
+      nextDraft.body === pending.draft.body &&
+      nextDraft.type === pending.draft.type
+    ) {
+      return s;
+    }
+    return {
+      ...s,
+      pendingIssueConfirm: {
+        ...pending,
+        draft: nextDraft,
+      },
+    };
+  });
+}
+
 function parseRenameSessionsConfirmItem(
   raw: unknown,
 ): PendingRenameSessionsConfirm['changes'][number] | null {
@@ -7999,6 +8033,7 @@ export const makerChatStore = {
   updateSystemCardData,
   respondToPermission,
   respondToIssueConfirm,
+  updateIssueConfirmDraft,
   respondToRenameSessionsConfirm,
   respondToGhostGrantConfirm,
   answerUserQuestion,

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -190,6 +190,11 @@ import {
 } from '@/lib/imageRef';
 import { saveDraft as saveComposerDraft, plainTextToTiptapDoc } from '@/lib/composerDraftStore';
 import {
+  clearIssueConfirmDraft,
+  clearIssueConfirmDraftsForSession,
+  type IssueConfirmDraft,
+} from '@/lib/issueConfirmDraftStore';
+import {
   canStartComposerSteer,
   canStartQueuedSteer,
   deriveErrorRetryText,
@@ -573,7 +578,7 @@ export interface PendingPlanReview {
  */
 export interface PendingIssueConfirm {
   requestId: string;
-  draft: { title: string; body: string; type: 'bug' | 'feature' };
+  draft: IssueConfirmDraft;
   /**
    * 只读展示的环境信息(main 会附进 issue body)。`region` 是本构建的区域身份
    * (中国版 / 国际版 / 开发版);main 侧 payload 未带时按 undefined 处理,卡片
@@ -1192,6 +1197,7 @@ function isBeforeOrAtRendererClearBoundary(sessionId: string, createdAt: string)
  */
 function _purgeSession(sessionId: string): void {
   discardPendingTextDelta(sessionId);
+  clearIssueConfirmDraftsForSession(sessionId);
   // 代际递增(bump 而非 delete,原因见 _messagesEpoch 注释):作废 in-flight 翻页,
   // 避免其提交把旧窗口 merge 进 purge 后重建的空 slice。
   bumpMessagesEpoch(sessionId);
@@ -1392,6 +1398,10 @@ function setState(sessionId: string, updater: (prev: SessionChatState) => Sessio
   const prev = getOrCreateState(sessionId);
   const next = updater(prev);
   if (next === prev) return;
+  const previousIssueRequestId = prev.pendingIssueConfirm?.requestId;
+  if (previousIssueRequestId && next.pendingIssueConfirm?.requestId !== previousIssueRequestId) {
+    clearIssueConfirmDraft(sessionId, previousIssueRequestId);
+  }
   sessions.set(sessionId, next);
   // running-status 快照缓存失效(getRunningSnapshot 纯 getter 契约:只有
   // mutation 才允许让下一次读重算)。必须在 notify 之前置位。
@@ -6786,6 +6796,7 @@ async function clearSessionAfterGuard(sessionId: string, clearedAt: string): Pro
       // F-AUQ-DRAFT: Clear session also wipes any in-progress draft.
       askUserDraft: null,
       pendingPlanReview: null,
+      pendingIssueConfirm: null,
       pendingQueue: [],
       steeringQueueClientIds: [],
       queuePaused: false,
@@ -7115,40 +7126,6 @@ function respondToIssueConfirm(
   makerApiFor(sessionId)
     .resolveInteraction(requestId, result)
     .catch((err) => log.error('Failed to respond to issue confirm:', err));
-}
-
-/**
- * issue_confirm:把用户在确认卡片里的编辑同步进 session-keyed store。
- *
- * 卡片会在切换对话时随路由卸载;pendingIssueConfirm 本身按 sessionId 常驻,
- * 因此把编辑态收口到它的 draft 就能在返回原对话时恢复。requestId guard
- * 防止旧卡片的迟到 input 事件覆盖同一会话里新一轮确认请求。
- */
-function updateIssueConfirmDraft(
-  sessionId: string,
-  requestId: string,
-  patch: Partial<PendingIssueConfirm['draft']>,
-): void {
-  if (!sessionId) return;
-  setState(sessionId, (s) => {
-    const pending = s.pendingIssueConfirm;
-    if (!pending || pending.requestId !== requestId) return s;
-    const nextDraft = { ...pending.draft, ...patch };
-    if (
-      nextDraft.title === pending.draft.title &&
-      nextDraft.body === pending.draft.body &&
-      nextDraft.type === pending.draft.type
-    ) {
-      return s;
-    }
-    return {
-      ...s,
-      pendingIssueConfirm: {
-        ...pending,
-        draft: nextDraft,
-      },
-    };
-  });
 }
 
 function parseRenameSessionsConfirmItem(
@@ -8033,7 +8010,6 @@ export const makerChatStore = {
   updateSystemCardData,
   respondToPermission,
   respondToIssueConfirm,
-  updateIssueConfirmDraft,
   respondToRenameSessionsConfirm,
   respondToGhostGrantConfirm,
   answerUserQuestion,


### PR DESCRIPTION
## 这次改了什么

### 摘要

- 将 `/issue` 反馈确认面板中的标题、正文和反馈类型同步到现有的会话级内存状态，切换对话再返回时自动恢复。
- 使用 `sessionId + requestId` 隔离草稿，避免不同对话或新旧确认请求互相覆盖；提交、取消、超时或对话清理时随现有 pending 请求一并清除。
- 补充表单标签关联、类型按钮的 `aria-pressed` 语义，以及模拟切换对话卸载/重挂的回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#763
- 本 PR 包含：Desktop `/issue` 问题反馈确认面板的会话内草稿恢复。
- 明确不包含：应用重启后的持久恢复、其他确认面板、Mobile 反馈表单。
- 用户可见变化：编辑确认面板后切换到其他对话，再返回原对话时，标题、正文和类型保持不变。
- 是否存在 breaking change：无。

### UI 变化

- 无视觉像素变化，未新增文案、布局、颜色、动效或响应式分支；现有语义 token 同时覆盖 Light / Dark。
- 交互变化仅为切换对话后的草稿恢复，并补齐表单 `label` 关联与类型按钮选中语义。
- 未附截图或录屏：组件外观不变，状态恢复由自动化测试覆盖。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Inputs & Forms、§10 Light / Dark Dual-Mode Delivery Gate、§14.2 Focus Management；本改动复用现有样式和 token，不新增单模式样式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/cc-agent/__tests__/IssueConfirmCard.test.tsx
结果：通过（1 个文件，1 个用例）

pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit
结果：通过（全仓 unit tier）

pnpm check:dco
结果：通过（1 个提交已签名）
```

### 手工验证

- 未执行：当前 worktree 的 Renderer 改动不会作用到宿主正在运行的 Cindy 实例。

### 未执行的验证

- 未做 Light / Dark 实机目检：本次无视觉样式变化，完整复用现有双模式语义 token。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 内存中的 `issue_confirm` 编辑态；不新增持久化、IPC、协议或用户数据写入。
- 移动端冷更判断：不会触发。改动未涉及 `apps/mobile`、原生配置、原生依赖、config plugin 或 runtime fingerprint 输入。
- 回滚 / 降级方式：回滚本提交即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本改动无需新增用户或开发文档）
- [x] 已确认测试结果或说明未执行原因