### PR TITLE
fix(desktop): 修复中文输入时括号字形抖动

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -373,7 +373,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     }
   });
 
-  it('suspends list and CJK decorations for the full IME composition', () => {
+  it('suspends list decoration but keeps stable CJK punctuation during IME composition', () => {
     vi.useFakeTimers();
     editor = new Editor({
       element: document.createElement('div'),
@@ -392,21 +392,25 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     });
 
     expect(editor.view.dom.querySelector('.composer-list-block-indent')).not.toBeNull();
-    expect(editor.view.dom.querySelectorAll('span[style*="font-family"]').length).toBeGreaterThan(
-      0,
-    );
+    const punctuationCount =
+      editor.view.dom.querySelectorAll('span[style*="font-family"]').length;
+    expect(punctuationCount).toBeGreaterThan(0);
 
     editor.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
     expect(editor.view.composing).toBe(true);
     expect(editor.view.dom.querySelector('.composer-list-block-indent')).toBeNull();
-    expect(editor.view.dom.querySelector('span[style*="font-family"]')).toBeNull();
+    expect(editor.view.dom.querySelectorAll('span[style*="font-family"]')).toHaveLength(
+      punctuationCount,
+    );
 
     editor.view.dispatch(
       editor.state.tr.insertText('中', editor.state.doc.content.size - 1).setMeta('composition', 1),
     );
     expect(editor.getText()).toBe('1. 《旧》中');
     expect(editor.view.dom.querySelector('.composer-list-block-indent')).toBeNull();
-    expect(editor.view.dom.querySelector('span[style*="font-family"]')).toBeNull();
+    expect(editor.view.dom.querySelectorAll('span[style*="font-family"]')).toHaveLength(
+      punctuationCount,
+    );
 
     editor.view.dom.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
     expect(editor.view.composing).toBe(false);
@@ -418,6 +422,43 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     expect(editor.view.dom.querySelectorAll('span[style*="font-family"]').length).toBeGreaterThan(
       0,
     );
+  });
+
+  it('keeps full-width parentheses from changing width across repeated IME composition', () => {
+    vi.useFakeTimers();
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [Document, Paragraph, Text, CjkPunctDecoration],
+      content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: '（已有内容）' }] }],
+      },
+    });
+
+    const punctuationSelector = 'span[style*="font-family"]';
+    expect(editor.view.dom.querySelectorAll(punctuationSelector)).toHaveLength(2);
+
+    for (const [input, expected] of [
+      ['新', '（已有内容）新'],
+      ['字', '（已有内容）新字'],
+    ] as const) {
+      editor.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      expect(editor.view.composing).toBe(true);
+      expect(editor.view.dom.querySelectorAll(punctuationSelector)).toHaveLength(2);
+
+      editor.view.dispatch(
+        editor.state.tr
+          .insertText(input, editor.state.doc.content.size - 1)
+          .setMeta('composition', 1),
+      );
+      expect(editor.getText()).toBe(expected);
+      expect(editor.view.dom.querySelectorAll(punctuationSelector)).toHaveLength(2);
+
+      editor.view.dom.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+      vi.runOnlyPendingTimers();
+      expect(editor.view.composing).toBe(false);
+      expect(editor.view.dom.querySelectorAll(punctuationSelector)).toHaveLength(2);
+    }
   });
 
   it('renders the indent span into the DOM for list lines', () => {

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
@@ -21,10 +21,11 @@
  *
  * 边界处理
  * --------
- * - IME 组合期 (用户打 pinyin 还没选字): compositionstart 前临时移除
- *   decoration,compositionend 后再按当前 doc 补算,避免改写输入法维护的 DOM。
- * - 性能: chat input 文本量很小,doc 变化、slash roster 或 voice replacement
- *   range 变化时采用全量重扫;不使用 DecorationSet.map 增量映射,以保持边界逻辑简单。
+ * - IME 组合期 (用户打 pinyin 还没选字): 保留组合开始前已有的 decoration,
+ *   只随 transaction 映射其位置,compositionend 后再按当前 doc 补算。这样既不
+ *   重建输入法维护的 DOM,也不会让已有标点在每次组字时切回另一套字形。
+ * - 性能: chat input 文本量很小,正常 doc 变化、slash roster 或 voice replacement
+ *   range 变化时采用全量重扫;只有组合期为保持已有 DOM 稳定才映射旧 decoration。
  * - 不污染源数据: decoration 只是渲染层,doc JSON 里没有 span,copy/paste/save
  *   拿到的都是纯文本
  *
@@ -260,7 +261,7 @@ export const CjkPunctDecoration = Extension.create({
             const compositionMeta = tr.getMeta(PLUGIN_KEY) as CompositionMeta | undefined;
             if (compositionMeta === 'suspend') {
               return {
-                decorations: DecorationSet.empty,
+                decorations: old.decorations,
                 suspendedForComposition: true,
               };
             }
@@ -268,7 +269,12 @@ export const CjkPunctDecoration = Extension.create({
             const rosterUpdate = getSlashCommandRosterUpdate(tr);
             const voiceReplacement = resolveVoiceInputReplacementRange(tr, oldState);
             if (old.suspendedForComposition && compositionMeta !== 'resume') {
-              return old;
+              return {
+                decorations: tr.docChanged
+                  ? old.decorations.map(tr.mapping, tr.doc)
+                  : old.decorations,
+                suspendedForComposition: true,
+              };
             }
             // doc、命令 roster 和 voice replacement 都没变 → decoration 位置不变,
             // 直接复用;任一输入变化都需要重新扫描。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复桌面端聊天输入框在中文输入法连续组字时，已有全角括号因字体标记被反复移除和恢复而出现宽度抖动的问题。输入法组字期间保留已有标点的显示标记，只对组字完成后的文档重新计算标记。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 回归测试

### 范围

- 关联 Issue / 需求：用户反馈：微信中文输入法输入括号后继续打字，括号在全角和半角视觉宽度之间反复切换。
- 本 PR 包含：Desktop composer 的 CJK 标点 decoration 组合输入处理，以及全角括号连续组字回归测试。
- 明确不包含：不改变文档内容、草稿存储、发送文本、输入法候选词或列表缩进逻辑。
- 用户可见变化：使用中文输入法连续输入时，已有括号保持稳定宽度，后续文字不再来回移动。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.3「Keyboard & IME」；本次没有新增视觉样式或颜色，保留现有双模式字体 token 和输入框布局，仅修正输入法组合期间的显示稳定性。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/composerListIndentDecoration.test.ts
结果：通过，35 个测试。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：通过；仓库脚本 291 个测试通过、8 个按规则跳过，Desktop 1269 个测试通过，Mobile 和所有参与单测的共享包通过。
说明：测试进程临时将本机 Python 3.11 放在 PATH 前面，以避开系统默认 Python 2.7 对协议测试的语法限制；未修改仓库或系统配置。

pnpm check:dco
结果：通过；本 PR 的 1 个提交均带有匹配作者的 Signed-off-by。
```

### 手工验证

未在实际运行中的 Cindy 窗口里手工操作微信输入法；当前 worktree 不连接宿主正在运行的 Desktop 实例。已用 jsdom + Tiptap 回归测试模拟连续两次 IME composition，并验证全角括号的两个字体标记在组字前、组字中和组字后均保持存在。

### 未执行的验证

未在 macOS 上实测；代码使用 ProseMirror 通用 transaction 映射，不含平台专用分支。未录制截图或视频，因为本次没有视觉样式变化。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：Desktop 聊天输入框内 CJK 标点在输入法组合期间的渲染 decoration；列表 decoration 仍按原规则在组字期间暂停。
- 回滚 / 降级方式：回滚提交 `c0363f94` 即可恢复原处理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果

<!-- cindy-pr-steward:v1 -->
