### PR TITLE
fix(desktop): oauth-spawn 保留归因块修复 auto 分类器 100% 429,并恢复持续故障降级兜底 (#758)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -64,6 +64,32 @@ describe('Claude Auto classifier request detection', () => {
     ).toBe(true);
   });
 
+  it('skips the leading attribution block injected by oauth-spawn CC (issue #758)', () => {
+    // oauth-spawn 归因默认开:system[0] 是 `x-anthropic-billing-header: ...`,
+    // 分类器身份前缀在其后 —— 检测必须跳过归因块,否则降级失灵。
+    const attribution = {
+      type: 'text',
+      text: 'x-anthropic-billing-header: cc_version=2.1.112.system; cc_entrypoint=cli; cch=00000;',
+    };
+    expect(
+      isClaudeAutoClassifierRequest(
+        requestBody({
+          system: [attribution, { type: 'text', text: `${CLASSIFIER_PREFIX}\nRules` }],
+        }),
+      ),
+    ).toBe(true);
+    // 归因块后面跟的是普通主 turn prompt → 仍不得命中。
+    expect(
+      isClaudeAutoClassifierRequest(
+        requestBody({
+          system: [attribution, { type: 'text', text: 'You are Claude Code, Anthropic official CLI' }],
+        }),
+      ),
+    ).toBe(false);
+    // 只有归因块、没有任何身份前缀 → 不命中。
+    expect(isClaudeAutoClassifierRequest(requestBody({ system: [attribution] }))).toBe(false);
+  });
+
   it('detects every classifier max_tokens shape (fast 256 / stage1 64 / thinking 8192)', () => {
     // 不再依赖固定 max_tokens——三条分类器路径(含 +k 变体)都必须命中,
     // 否则 fast / thinking 路径的 429 会漏检、不触发降级。

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -193,6 +193,24 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  it('does not treat 3xx classifier responses as recovery', () => {
+    // 3xx 不是分类器真正给出 verdict:若清账,「上游持续 3xx」的故障会永不升级。
+    const listener = vi.fn();
+    setClaudeAutoClassifierUnavailableListener(listener);
+    let t = 0;
+    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1', {
+      now: () => t,
+    });
+
+    observer(ctx({ status: 429 })); // episode 1
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 2
+    observer(ctx({ status: 302 })); // 分类器请求被重定向 → 不得清账
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 3 → 升级(证明前两段仍在账上)
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   it('expires episodes outside the 10-minute window', () => {
     const listener = vi.fn();
     setClaudeAutoClassifierUnavailableListener(listener);

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -123,16 +123,139 @@ describe('Claude Auto classifier request detection', () => {
 });
 
 describe('createClaudeAutoClassifierFailureObserver', () => {
-  it('keeps Auto for transient classifier failures', () => {
+  it('keeps Auto for a single transient failure burst (one episode)', () => {
+    // 一次动作的 SDK retry storm:多个瞬时失败在数秒内到达 → 归并为一个 episode,
+    // 不触发降级(#596 保护的场景)。
     const listener = vi.fn();
     setClaudeAutoClassifierUnavailableListener(listener);
-    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1');
+    let t = 0;
+    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1', {
+      now: () => t,
+    });
 
-    expect(observer(ctx({ status: 408 }))).toBeUndefined();
-    expect(observer(ctx({ status: 429 }))).toBeUndefined();
-    expect(observer(ctx({ status: 503 }))).toBeUndefined();
-    expect(observer(ctx({ status: 529 }))).toBeUndefined();
+    for (const status of [408, 429, 503, 529, 429, 429]) {
+      t += 1000; // 6 次失败散布在 6 秒内
+      expect(observer(ctx({ status }))).toBeUndefined();
+    }
 
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('escalates persistent transient failures after 3 episodes without a success (#758)', () => {
+    const signals: unknown[] = [];
+    setClaudeAutoClassifierUnavailableListener((signal) => signals.push(signal));
+    let t = 0;
+    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1', {
+      now: () => t,
+    });
+
+    observer(ctx({ status: 429 })); // episode 1
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 2
+    expect(signals).toEqual([]);
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 3 → 升级
+    expect(signals).toEqual([
+      { sessionId: 'session-1', agentKind: 'claude-code', status: 429 },
+    ]);
+
+    // 升级后记账清零:紧接着的失败重新从 episode 1 数起,不会连环降级。
+    t += 31_000;
+    observer(ctx({ status: 429 }));
+    expect(signals).toHaveLength(1);
+  });
+
+  it('resets the episode counter when a classifier request succeeds in between', () => {
+    const listener = vi.fn();
+    setClaudeAutoClassifierUnavailableListener(listener);
+    let t = 0;
+    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1', {
+      now: () => t,
+    });
+
+    observer(ctx({ status: 429 })); // episode 1
+    t += 31_000;
+    observer(ctx({ status: 503 })); // episode 2
+    observer(ctx({ status: 200 })); // 分类器恢复 → 清零
+    t += 31_000;
+    observer(ctx({ status: 429 })); // 重新从 episode 1 数起
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 2
+
+    expect(listener).not.toHaveBeenCalled();
+
+    // 恢复清零只认分类器请求本身:普通主 turn 的成功响应不得清零其它会话记账。
+    t += 31_000;
+    observer(ctx({ status: 200, requestBody: requestBody({ system: 'ordinary assistant' }) }));
+    observer(ctx({ status: 200, requestBody: Buffer.from('{bad json') })); // 有记账时坏 body 也不得抛
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 3 → 升级(前两段仍在账上)
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires episodes outside the 10-minute window', () => {
+    const listener = vi.fn();
+    setClaudeAutoClassifierUnavailableListener(listener);
+    let t = 0;
+    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1', {
+      now: () => t,
+    });
+
+    observer(ctx({ status: 429 })); // episode 1
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 2
+    t += 11 * 60_000; // 11 分钟后:前两段过期
+    observer(ctx({ status: 429 })); // 只剩这一段
+    t += 31_000;
+    observer(ctx({ status: 429 })); // 第二段
+    expect(listener).not.toHaveBeenCalled();
+    t += 31_000;
+    observer(ctx({ status: 429 })); // 第三段 → 升级
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears pending transient episodes when a deterministic failure downgrades immediately', () => {
+    const signals: unknown[] = [];
+    setClaudeAutoClassifierUnavailableListener((signal) => signals.push(signal));
+    let t = 0;
+    const observer = createClaudeAutoClassifierFailureObserver(() => 'session-1', {
+      now: () => t,
+    });
+
+    observer(ctx({ status: 429 })); // episode 1
+    t += 31_000;
+    observer(ctx({ status: 429 })); // episode 2
+    observer(ctx({ status: 401 })); // 确定性错误 → 立即降级,同时清零瞬时记账
+    expect(signals).toEqual([
+      { sessionId: 'session-1', agentKind: 'claude-code', status: 401 },
+    ]);
+
+    // 用户重开 Auto 后:残账已清,单次偶发失败不得被推过阈值,要重新数满 3 段。
+    t += 31_000;
+    observer(ctx({ status: 429 }));
+    t += 31_000;
+    observer(ctx({ status: 429 }));
+    expect(signals).toHaveLength(1);
+    t += 31_000;
+    observer(ctx({ status: 429 }));
+    expect(signals).toHaveLength(2);
+  });
+
+  it('tracks transient episodes per session independently', () => {
+    const listener = vi.fn();
+    setClaudeAutoClassifierUnavailableListener(listener);
+    let t = 0;
+    const observer = createClaudeAutoClassifierFailureObserver(
+      (sdkId) => (sdkId === 'sdk-1' ? 'session-1' : 'session-2'),
+      { now: () => t },
+    );
+
+    // 两个会话各自累计 2 段,交错到达 —— 谁都不该被对方推过阈值。
+    for (let i = 0; i < 2; i += 1) {
+      observer(ctx({ status: 429 }));
+      observer(ctx({ status: 429, requestHeaders: { 'x-claude-code-session-id': 'sdk-2' } }));
+      t += 31_000;
+    }
     expect(listener).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
@@ -18,7 +18,9 @@ describe('claudeBehaviorFlagsForSpawn', () => {
     // 回落)可能直连 api.anthropic.com,归因块必须保留,否则分类器子请求被上游 429。
     for (const credentialMode of ['oauth-bearer', 'provider-oauth', undefined]) {
       const flags = claudeBehaviorFlagsForSpawn({ credentialMode, oauthConnected: () => true });
-      expect(flags).not.toHaveProperty('CLAUDE_CODE_ATTRIBUTION_HEADER');
+      // 显式 '1' 而非缺席:local spawn 继承宿主 process.env,宿主 shell export 过
+      // CLAUDE_CODE_ATTRIBUTION_HEADER=0 时,缺席的 key 压不住继承值(#758 复现)。
+      expect(flags.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('1');
       // 其余行为开关不随 spawn 形态变化。
       expect(flags.CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS).toBe('1');
       expect(flags.ENABLE_TOOL_SEARCH).toBe('auto');

--- a/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
@@ -1,28 +1,41 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { claudeBehaviorFlagsForSpawn } from '../claude-behavior-flags.js';
 
 describe('claudeBehaviorFlagsForSpawn', () => {
-  it('keeps the CLI attribution default for oauth-spawn (issue #758)', () => {
-    // 连了 Claude.ai 订阅:claude-* 请求可能直连 api.anthropic.com,归因块必须保留,
-    // 否则 Auto 权限分类器子请求被上游 429,auto 模式全部写操作 fail-closed。
-    const flags = claudeBehaviorFlagsForSpawn(true);
-    expect(flags).not.toHaveProperty('CLAUDE_CODE_ATTRIBUTION_HEADER');
-    // 其余行为开关不随 spawn 形态变化。
-    expect(flags.CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS).toBe('1');
-    expect(flags.ENABLE_TOOL_SEARCH).toBe('auto');
+  it('disables attribution for gateway-key spawns without touching the keychain', () => {
+    // 显式 XD source / SSH remote 恒为 gateway-key:请求全走网关,无订阅直连路径。
+    // oauthConnected 必须不被调用 —— spawn 热路径不为此分支付出钥匙串读取。
+    const oauthConnected = vi.fn(() => true);
+    const flags = claudeBehaviorFlagsForSpawn({ credentialMode: 'gateway-key', oauthConnected });
+
+    expect(flags.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
+    expect(oauthConnected).not.toHaveBeenCalled();
   });
 
-  it('disables attribution for gateway-spawn to preserve gateway body-cache hits', () => {
-    const flags = claudeBehaviorFlagsForSpawn(false);
+  it('keeps the CLI attribution default for subscription-connected non-gateway spawns (issue #758)', () => {
+    // oauth-bearer / provider-oauth / 未显式指定:claude-* 请求(含分类器 scope-gate
+    // 回落)可能直连 api.anthropic.com,归因块必须保留,否则分类器子请求被上游 429。
+    for (const credentialMode of ['oauth-bearer', 'provider-oauth', undefined]) {
+      const flags = claudeBehaviorFlagsForSpawn({ credentialMode, oauthConnected: () => true });
+      expect(flags).not.toHaveProperty('CLAUDE_CODE_ATTRIBUTION_HEADER');
+      // 其余行为开关不随 spawn 形态变化。
+      expect(flags.CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS).toBe('1');
+      expect(flags.ENABLE_TOOL_SEARCH).toBe('auto');
+    }
+  });
+
+  it('disables attribution when no Claude.ai subscription is connected', () => {
+    // 未连订阅 = 不存在订阅直连路径,保留网关 body 缓存优化。
+    const flags = claudeBehaviorFlagsForSpawn({ oauthConnected: () => false });
     expect(flags.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
-    expect(flags.CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS).toBe('1');
-    expect(flags.ENABLE_TOOL_SEARCH).toBe('auto');
   });
 
   it('returns a fresh object per call — env-builder Object.assign must not mutate shared state', () => {
-    const a = claudeBehaviorFlagsForSpawn(false);
+    const a = claudeBehaviorFlagsForSpawn({ oauthConnected: () => false });
     a.CLAUDE_CODE_ATTRIBUTION_HEADER = 'mutated';
-    expect(claudeBehaviorFlagsForSpawn(false).CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
+    expect(
+      claudeBehaviorFlagsForSpawn({ oauthConnected: () => false }).CLAUDE_CODE_ATTRIBUTION_HEADER,
+    ).toBe('0');
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { claudeBehaviorFlagsForSpawn } from '../claude-behavior-flags.js';
+
+describe('claudeBehaviorFlagsForSpawn', () => {
+  it('keeps the CLI attribution default for oauth-spawn (issue #758)', () => {
+    // 连了 Claude.ai 订阅:claude-* 请求可能直连 api.anthropic.com,归因块必须保留,
+    // 否则 Auto 权限分类器子请求被上游 429,auto 模式全部写操作 fail-closed。
+    const flags = claudeBehaviorFlagsForSpawn(true);
+    expect(flags).not.toHaveProperty('CLAUDE_CODE_ATTRIBUTION_HEADER');
+    // 其余行为开关不随 spawn 形态变化。
+    expect(flags.CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS).toBe('1');
+    expect(flags.ENABLE_TOOL_SEARCH).toBe('auto');
+  });
+
+  it('disables attribution for gateway-spawn to preserve gateway body-cache hits', () => {
+    const flags = claudeBehaviorFlagsForSpawn(false);
+    expect(flags.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
+    expect(flags.CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS).toBe('1');
+    expect(flags.ENABLE_TOOL_SEARCH).toBe('auto');
+  });
+
+  it('returns a fresh object per call — env-builder Object.assign must not mutate shared state', () => {
+    const a = claudeBehaviorFlagsForSpawn(false);
+    a.CLAUDE_CODE_ATTRIBUTION_HEADER = 'mutated';
+    expect(claudeBehaviorFlagsForSpawn(false).CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
+  });
+});

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -251,8 +251,10 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       //   - fast mode 链路核验:tee SSE 抽上游 usage.speed(debug-gated);
       //   - 订阅余量旁路:读 anthropic-ratelimit-unified-* headers(仅订阅直连响应,
       //     同步读 header、零 body 开销),交 usageBroadcaster 落库 + 广播;
-      //   - Auto 权限分类器错误检测(status≥400,含 4xx/5xx):只在错误路径解析 request
-      //     body,通知 session coordinator 降级到 ask;不 tee/改写响应;
+      //   - Auto 权限分类器错误检测:确定性 4xx 立即通知 coordinator 降级到 ask;
+      //     瞬时 408/429/5xx 按 episode 阈值记账、持续故障才降级(见
+      //     claude-auto-permission-fallback.ts);只在错误路径与「该会话有瞬时记账」的
+      //     成功路径解析 request body;不 tee/改写响应;
       //   - 自定义供应商上游错误分类广播(status≥400 且会话路由到 user 供应商时才 tee,
       //     成功路径零开销;30s 节流,见 provider-upstream-error-observer)。
       responseObserver: composeResponseObservers(

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -128,22 +128,96 @@ export function isClaudeAutoClassifierRequest(requestBody: Buffer): boolean {
 }
 
 /**
- * 创建只读响应观察器。非错误响应(status < 400，含 2xx 成功与 3xx 重定向)均为 O(1) 短路，
- * 不 parse body、不返回 sink，因此不会 tee SSE 热路径。
+ * 瞬时故障(408/429/5xx)的升级阈值 —— #596 与 #758 的平衡点:
+ *
+ * #596 的诉求成立:一次偶发限流不该永久改写用户的 Auto 偏好。但把瞬时状态码
+ * **一律**静默吞掉,会让「确定性地返回 429」的故障(如 #758 归因块 429)把用户
+ * 留在无限硬失败 + 零提示的死锁里 —— 降级兜底恰恰是那种场景唯一的自救通道。
+ *
+ * 折中:瞬时失败按「故障段(episode)」记账,连续 EPISODE_THRESHOLD 段且中间
+ * 没有任何一次分类器成功 → 视为持续故障,交给降级协调器(降 ask + 广播 toast)。
+ *
+ * - EPISODE_MS:SDK 对 429/5xx 有自动重试,一次用户动作会在数秒内产生多个失败
+ *   响应;30s 内的失败归并为一段,避免把一次动作的 retry storm 数成 N 次。
+ * - WINDOW_MS:只统计最近 10 分钟——上午两次抖动 + 晚上一次不构成「持续」。
+ * - 阈值 3 段 ≈ 持续失败约 1 分钟,或用户间隔性重试 3 次;任一成功立即清零。
+ */
+const TRANSIENT_EPISODE_MS = 30_000;
+const TRANSIENT_WINDOW_MS = 10 * 60_000;
+const TRANSIENT_EPISODE_THRESHOLD = 3;
+/** 记账表大小上限(防长生命周期 proxy 泄漏);超限时先剔窗口过期项,再剔最老会话。 */
+const TRANSIENT_TRACKER_MAX_SESSIONS = 256;
+
+function isTransientClassifierStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * 创建只读响应观察器。成功路径(status < 400,含 2xx/3xx)几乎恒为 O(1) 短路——
+ * 仅当**该会话已有瞬时故障记账**时才 parse body 确认「分类器已恢复」并清零计数;
+ * 无记账时不 parse、不返回 sink,不碰 SSE 热路径。
+ *
+ * 降级信号分两类:
+ * - 非瞬时 4xx(400/401/403/404/422 等确定性错误)→ 立即通知协调器(与 #596 前一致);
+ * - 瞬时 408/429/5xx → 按上方 episode 阈值记账,持续故障才通知。
  */
 export function createClaudeAutoClassifierFailureObserver(
   resolveSessionId: (sdkSessionId: string) => string | null,
+  opts: { now?: () => number } = {},
 ): ResponseObserver {
+  const now = opts.now ?? Date.now;
+  // key = sdkSessionId(cc 侧会话 id,请求头自带,成功路径无需反解);
+  // value = 各 episode 的起始时间戳,升序。
+  const transientEpisodes = new Map<string, number[]>();
+
   return (ctx: ResponseObserverCtx) => {
-    // 分类器错误本身仍由 Claude Code fail-closed 为人工审批。这里只决定是否触发降级协调器：
-    // 限流/过载/上游故障等瞬时错误直接短路，不切 runtime、不持久化 ask、也不广播降级。
-    if (ctx.status < 400 || ctx.status === 408 || ctx.status === 429 || ctx.status >= 500) {
+    if (ctx.status < 400) {
+      // 分类器恢复 → 清零该会话的瞬时故障记账。仅在有记账时才 parse body。
+      if (transientEpisodes.size === 0) return undefined;
+      const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
+      if (!sdkSessionId || !transientEpisodes.has(sdkSessionId)) return undefined;
+      if (isClaudeAutoClassifierRequest(ctx.requestBody)) {
+        transientEpisodes.delete(sdkSessionId);
+      }
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
     if (!sdkSessionId) return undefined;
     const sessionId = resolveSessionId(sdkSessionId);
     if (!sessionId || !isClaudeAutoClassifierRequest(ctx.requestBody)) return undefined;
+
+    if (isTransientClassifierStatus(ctx.status)) {
+      const ts = now();
+      let episodes = transientEpisodes.get(sdkSessionId);
+      if (!episodes) {
+        if (transientEpisodes.size >= TRANSIENT_TRACKER_MAX_SESSIONS) {
+          for (const [key, starts] of transientEpisodes) {
+            if (starts.length === 0 || ts - starts[starts.length - 1] > TRANSIENT_WINDOW_MS) {
+              transientEpisodes.delete(key);
+            }
+          }
+          if (transientEpisodes.size >= TRANSIENT_TRACKER_MAX_SESSIONS) {
+            // 仍满(极端:256 个会话同时持续故障)→ 剔最早插入的一个,保住新会话的记账。
+            const oldest = transientEpisodes.keys().next().value;
+            if (oldest !== undefined) transientEpisodes.delete(oldest);
+          }
+        }
+        episodes = [];
+        transientEpisodes.set(sdkSessionId, episodes);
+      }
+      while (episodes.length > 0 && ts - episodes[0] > TRANSIENT_WINDOW_MS) {
+        episodes.shift();
+      }
+      if (episodes.length === 0 || ts - episodes[episodes.length - 1] >= TRANSIENT_EPISODE_MS) {
+        episodes.push(ts);
+      }
+      if (episodes.length < TRANSIENT_EPISODE_THRESHOLD) return undefined;
+    }
+
+    // 任何一次通知(瞬时升级或确定性 4xx 立即降级)都清零该会话的瞬时记账:降级后
+    // 用户重开 Auto 时从零累计,不因残账被单次偶发失败提前推过阈值。协调器自身有
+    // in-flight 去重 + 持久态 CAS,重复信号安全。
+    transientEpisodes.delete(sdkSessionId);
 
     try {
       notifyAutoPermissionClassifierUnavailable({

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -139,6 +139,10 @@ export function isClaudeAutoClassifierRequest(requestBody: Buffer): boolean {
  *
  * - EPISODE_MS:SDK 对 429/5xx 有自动重试,一次用户动作会在数秒内产生多个失败
  *   响应;30s 内的失败归并为一段,避免把一次动作的 retry storm 数成 N 次。
+ *   段以**段起点**为锚(固定桶),刻意不用「距最近一次失败的间隔」做锚:gap 锚定下
+ *   「失败每隔几秒持续到达」的确定性故障会被永远归并进同一段、永不达阈,重新退化成
+ *   #758 的无限 fail-closed。固定桶的代价是单次动作的 retry 链若拖过 30s 会跨段,
+ *   但 SDK 重试退避总时长远短于 30s,而真正连续失败 60s+ 的本就该判为持续故障。
  * - WINDOW_MS:只统计最近 10 分钟——上午两次抖动 + 晚上一次不构成「持续」。
  * - 阈值 3 段 ≈ 持续失败约 1 分钟,或用户间隔性重试 3 次;任一成功立即清零。
  */
@@ -175,8 +179,20 @@ export function createClaudeAutoClassifierFailureObserver(
       // 分类器恢复 → 清零该会话的瞬时故障记账。仅在有记账时才 parse body。
       if (transientEpisodes.size === 0) return undefined;
       const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
-      if (!sdkSessionId || !transientEpisodes.has(sdkSessionId)) return undefined;
-      if (isClaudeAutoClassifierRequest(ctx.requestBody)) {
+      if (!sdkSessionId) return undefined;
+      const episodes = transientEpisodes.get(sdkSessionId);
+      if (!episodes) return undefined;
+      // 过期即弃:记账已整体滑出窗口 → 直接删,该会话的后续成功响应回到零开销
+      // 短路 —— 不为一条陈年记账无限期 parse 每个成功请求的 body。
+      const ts = now();
+      if (episodes.length === 0 || ts - episodes[episodes.length - 1] > TRANSIENT_WINDOW_MS) {
+        transientEpisodes.delete(sdkSessionId);
+        return undefined;
+      }
+      // 恢复判据只认 2xx:3xx 重定向不代表分类器真正给出 verdict,不得清账 ——
+      // 否则「上游持续用 3xx 响应分类器」的故障形态会每轮清零、永不升级,
+      // 会话被留在无限 fail-closed。
+      if (ctx.status >= 200 && ctx.status < 300 && isClaudeAutoClassifierRequest(ctx.requestBody)) {
         transientEpisodes.delete(sdkSessionId);
       }
       return undefined;

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -70,14 +70,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function firstSystemText(system: unknown): string | null {
+/**
+ * oauth-spawn 的 CC 默认开归因(claude-behavior-flags.ts,issue #758),会把
+ * `x-anthropic-billing-header: cc_version=...` 作为 system 数组**第一个** text block
+ * 注入 —— 分类器身份前缀被顶到其后。匹配前必须跳过归因块,否则 oauth-spawn 下
+ * 分类器故障全部漏检、auto→ask 降级失灵。
+ */
+const ATTRIBUTION_SYSTEM_BLOCK_PREFIX = 'x-anthropic-billing-header:';
+
+function classifierIdentityText(system: unknown): string | null {
   if (typeof system === 'string') return system;
-  if (!Array.isArray(system) || system.length === 0) return null;
-  const first = system[0];
-  if (!isRecord(first) || first.type !== 'text' || typeof first.text !== 'string') {
-    return null;
+  if (!Array.isArray(system)) return null;
+  for (const block of system) {
+    if (!isRecord(block) || block.type !== 'text' || typeof block.text !== 'string') {
+      return null;
+    }
+    if (block.text.startsWith(ATTRIBUTION_SYSTEM_BLOCK_PREFIX)) continue;
+    return block.text;
   }
-  return first.text;
+  return null;
 }
 
 /**
@@ -92,8 +103,8 @@ const CLASSIFIER_MAX_TOKENS_CEILING = 16384;
  * 精确识别 Claude Code 内部 Auto 安全分类器请求。双判据都满足才算命中:
  *
  * 主判据 —— 分类器独有的 system 前缀:分类器请求带 `skipSystemPromptPrefix`,其 system 段
- * 恒以 CLASSIFIER_SYSTEM_PREFIX 开头;普通主 turn 的 system 是 Claude Code 常规 prompt,
- * 二者完全区分。前缀是分类器身份,本身已足够;
+ * (跳过可能存在的归因块后)恒以 CLASSIFIER_SYSTEM_PREFIX 开头;普通主 turn 的 system 是
+ * Claude Code 常规 prompt,二者完全区分。前缀是分类器身份,本身已足够;
  *
  * 副判据 —— max_tokens 上界(防御性,收窄理论碰撞面):不用固定值(分类器三种形态 max_tokens
  * 各不相同,早期实现取定值 64 只覆盖一条、漏检 fast/thinking,漏检时降级不触发、会话继续
@@ -113,7 +124,7 @@ export function isClaudeAutoClassifierRequest(requestBody: Buffer): boolean {
   if (typeof parsed.max_tokens !== 'number' || parsed.max_tokens > CLASSIFIER_MAX_TOKENS_CEILING) {
     return false;
   }
-  return firstSystemText(parsed.system)?.startsWith(CLASSIFIER_SYSTEM_PREFIX) === true;
+  return classifierIdentityText(parsed.system)?.startsWith(CLASSIFIER_SYSTEM_PREFIX) === true;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
+++ b/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
@@ -1,0 +1,32 @@
+/**
+ * Claude Code 子进程行为开关(per-spawn 求值)。
+ *
+ * CLAUDE_CODE_ATTRIBUTION_HEADER 不是无条件 '0',按 spawn 凭证形态决定(issue #758):
+ *
+ * - gateway-spawn(未连 Claude.ai 订阅):请求恒走网关,禁用归因块(CC 会把
+ *   `x-anthropic-billing-header: ...` 作为 system 数组第一个 text block 注入 body)
+ *   能提升网关按完整 body 缓存的命中率 → 保持 '0'(与 remote-ssh/claude-env.ts 一致)。
+ *
+ * - oauth-spawn(连了 Claude.ai 订阅):claude-* 请求可能被 compat proxy 路由到
+ *   api.anthropic.com 直连,Anthropic 一方 API 会对**无归因**的 Auto 权限分类器
+ *   子请求回 429 —— 分类器 100% 失败,auto 模式所有写操作 fail-closed,用户无法自救。
+ *   保持 CLI 默认(带归因);代价只是该 spawn 中路由到网关的请求丢缓存归一化(慢一点,
+ *   功能无损)。
+ *
+ * 判据与 compat proxy 的 oauth-spawn 判定同源(hasClaudeAiOAuth,见
+ * anthropic-compat-proxy-host.ts setClaudeProxyOAuthSpawnChecker),由 runtime-configs
+ * 在每次 spawn 读取 behaviorFlags 时求值。本模块保持零依赖,便于单测。
+ */
+
+const STATIC_CLAUDE_BEHAVIOR_FLAGS: Readonly<Record<string, string>> = {
+  CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS: '1',
+  // 网关 upstream 透传 tool_reference 块, 显式开启 ToolSearch
+  // 否则 CC 看到非 first-party host 默认 disable, 每次请求都全量塞工具定义。
+  ENABLE_TOOL_SEARCH: 'auto',
+};
+
+export function claudeBehaviorFlagsForSpawn(oauthSpawn: boolean): Record<string, string> {
+  return oauthSpawn
+    ? { ...STATIC_CLAUDE_BEHAVIOR_FLAGS }
+    : { ...STATIC_CLAUDE_BEHAVIOR_FLAGS, CLAUDE_CODE_ATTRIBUTION_HEADER: '0' };
+}

--- a/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
+++ b/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
@@ -1,21 +1,27 @@
 /**
  * Claude Code 子进程行为开关(per-spawn 求值)。
  *
- * CLAUDE_CODE_ATTRIBUTION_HEADER 不是无条件 '0',按 spawn 凭证形态决定(issue #758):
+ * CLAUDE_CODE_ATTRIBUTION_HEADER 不是无条件 '0',按本次 spawn 的凭证形态决定
+ * (issue #758):
  *
- * - gateway-spawn(未连 Claude.ai 订阅):请求恒走网关,禁用归因块(CC 会把
- *   `x-anthropic-billing-header: ...` 作为 system 数组第一个 text block 注入 body)
- *   能提升网关按完整 body 缓存的命中率 → 保持 '0'(与 remote-ssh/claude-env.ts 一致)。
+ * - `gateway-key` spawn(显式选 XD source、SSH remote 恒为此形态,或未连订阅的
+ *   fallback):请求全部携带网关 key,compat proxy 恒 passthrough 到网关,不存在
+ *   订阅直连路径。禁用归因块(CC 会把 `x-anthropic-billing-header: ...` 作为
+ *   system 数组第一个 text block 注入 body)能提升网关按完整 body 缓存的命中率
+ *   → 保持 '0'(与 remote-ssh/claude-env.ts 一致)。**此分支不读钥匙串**。
  *
- * - oauth-spawn(连了 Claude.ai 订阅):claude-* 请求可能被 compat proxy 路由到
+ * - 其余形态(oauth-bearer / provider-oauth / 未显式指定)且连了 Claude.ai 订阅:
+ *   claude-* 请求(含 Auto 分类器的 scope-gate 回落)可能被 compat proxy 路由到
  *   api.anthropic.com 直连,Anthropic 一方 API 会对**无归因**的 Auto 权限分类器
- *   子请求回 429 —— 分类器 100% 失败,auto 模式所有写操作 fail-closed,用户无法自救。
- *   保持 CLI 默认(带归因);代价只是该 spawn 中路由到网关的请求丢缓存归一化(慢一点,
- *   功能无损)。
+ *   子请求回 429 —— 分类器 100% 失败,auto 模式所有写操作 fail-closed,用户无法
+ *   自救。保持 CLI 默认(带归因);代价只是该 spawn 中路由到网关的请求丢缓存归一化
+ *   (慢一点,功能无损)。未连订阅时不存在直连路径,回到 '0'。
  *
- * 判据与 compat proxy 的 oauth-spawn 判定同源(hasClaudeAiOAuth,见
- * anthropic-compat-proxy-host.ts setClaudeProxyOAuthSpawnChecker),由 runtime-configs
- * 在每次 spawn 读取 behaviorFlags 时求值。本模块保持零依赖,便于单测。
+ * oauth 判据与 compat proxy 的 oauth-spawn 判定同源(hasClaudeAiOAuth,见
+ * anthropic-compat-proxy-host.ts setClaudeProxyOAuthSpawnChecker),经 `oauthConnected`
+ * 回调惰性注入 —— 只在非 gateway-key 分支才求值,每次 spawn 至多一次钥匙串读
+ * (与 spawn 期 auth gate 的既有读取同级,非 per-request 路径)。本模块保持零依赖,
+ * 便于单测。
  */
 
 const STATIC_CLAUDE_BEHAVIOR_FLAGS: Readonly<Record<string, string>> = {
@@ -25,8 +31,16 @@ const STATIC_CLAUDE_BEHAVIOR_FLAGS: Readonly<Record<string, string>> = {
   ENABLE_TOOL_SEARCH: 'auto',
 };
 
-export function claudeBehaviorFlagsForSpawn(oauthSpawn: boolean): Record<string, string> {
-  return oauthSpawn
+export interface ClaudeSpawnFlagsContext {
+  /** 本次 spawn 的凭证形态(maker-core AgentCredentialMode;undefined = adapter fallback)。 */
+  credentialMode?: string;
+  /** 是否连了 Claude.ai 订阅。惰性回调:gateway-key 分支不调用、不产生钥匙串读。 */
+  oauthConnected: () => boolean;
+}
+
+export function claudeBehaviorFlagsForSpawn(ctx: ClaudeSpawnFlagsContext): Record<string, string> {
+  const keepAttribution = ctx.credentialMode !== 'gateway-key' && ctx.oauthConnected();
+  return keepAttribution
     ? { ...STATIC_CLAUDE_BEHAVIOR_FLAGS }
     : { ...STATIC_CLAUDE_BEHAVIOR_FLAGS, CLAUDE_CODE_ATTRIBUTION_HEADER: '0' };
 }

--- a/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
+++ b/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
@@ -40,7 +40,11 @@ export interface ClaudeSpawnFlagsContext {
 
 export function claudeBehaviorFlagsForSpawn(ctx: ClaudeSpawnFlagsContext): Record<string, string> {
   const keepAttribution = ctx.credentialMode !== 'gateway-key' && ctx.oauthConnected();
+  // 保留归因也要**显式**写 '1',不能只是不设置:local spawn 继承宿主 process.env
+  // (env-builder cleanProcessEnv),用户 shell 若 export 过 CLAUDE_CODE_ATTRIBUTION_HEADER=0,
+  // 缺席的 key 压不住继承值,#758 会原样复现。CLI 判定(cli.js c5):仅
+  // '0'/'false'/'no'/'off' 视为禁用,'1' = 保留归因,与未设置同义。
   return keepAttribution
-    ? { ...STATIC_CLAUDE_BEHAVIOR_FLAGS }
+    ? { ...STATIC_CLAUDE_BEHAVIOR_FLAGS, CLAUDE_CODE_ATTRIBUTION_HEADER: '1' }
     : { ...STATIC_CLAUDE_BEHAVIOR_FLAGS, CLAUDE_CODE_ATTRIBUTION_HEADER: '0' };
 }

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -120,12 +120,15 @@ export function buildDesktopClaudeRuntimeConfig(endpointFn: () => string): Agent
   // 这样 AgentRuntimeConfig 接口(endpoint?: string)在结构类型上仍然成立 ——
   // 每次访问 runtimeConfig.endpoint 都会执行 endpointFn, 拿到当时最新的兼容模式状态。
   const config: AgentRuntimeConfig = {
-    // behaviorFlags 用 getter 而非静态值:env-builder 在每次 spawn 时读它,getter 让
-    // attribution 归因块跟随**当时**的 Claude.ai 订阅连接态(oauth-spawn 判据与 proxy
-    // 同源)。会话中途连/断订阅只影响新 spawn —— 与 cc 子进程凭证冻结语义一致。
-    get behaviorFlags() {
-      return claudeBehaviorFlagsForSpawn(hasClaudeAiOAuth());
-    },
+    // behaviorFlags 用函数形态:env-builder 在每次 spawn 时以该 spawn 的 credentialMode
+    // 调用 —— gateway-key spawn(显式 XD source / SSH remote)保持禁归因且不读钥匙串,
+    // 其余形态按**当时**的 Claude.ai 订阅连接态决定(判据与 proxy 同源)。会话中途
+    // 连/断订阅只影响新 spawn —— 与 cc 子进程凭证冻结语义一致。
+    behaviorFlags: (ctx) =>
+      claudeBehaviorFlagsForSpawn({
+        credentialMode: ctx.credentialMode,
+        oauthConnected: hasClaudeAiOAuth,
+      }),
     // xdt-maker 产品级 system prompt 注入：host 共用段 (host-system-prompt.md)
     // + Claude 专属段 (claude-system-prompt.md)，按顺序拼接后给 maker-core append。
     systemPrompt: composeHostPrompt(claudeSystemPrompt),

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -10,6 +10,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
+import { claudeBehaviorFlagsForSpawn } from './claude-behavior-flags.js';
+import { hasClaudeAiOAuth } from './claude-credentials-store.js';
 import claudeSystemPrompt from './claude-system-prompt.md?raw';
 import codexSystemPrompt from './codex-system-prompt.md?raw';
 import hostSystemPrompt from './host-system-prompt.md?raw';
@@ -75,13 +77,9 @@ function readMakerMemoryEnabled(): boolean {
   return readMemorySettings().maker;
 }
 
-const staticClaudeBehaviorFlags = {
-  CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS: '1',
-  CLAUDE_CODE_ATTRIBUTION_HEADER: '0',
-  // 网关 upstream 透传 tool_reference 块, 显式开启 ToolSearch
-  // 否则 CC 看到非 first-party host 默认 disable, 每次请求都全量塞工具定义。
-  ENABLE_TOOL_SEARCH: 'auto',
-};
+// behaviorFlags 拆到 claude-behavior-flags.ts(零依赖,可单测)。attribution 归因块
+// 按 spawn 形态决定 —— oauth-spawn 禁用 '0' 会让订阅直连的 Auto 分类器子请求被上游
+// 429,auto 模式所有写操作 fail-closed(issue #758),详见该模块头注释。
 
 /**
  * Claude Code 真正的上游 endpoint —— 既给本地 anthropic-compat-proxy 做 upstream,
@@ -122,9 +120,12 @@ export function buildDesktopClaudeRuntimeConfig(endpointFn: () => string): Agent
   // 这样 AgentRuntimeConfig 接口(endpoint?: string)在结构类型上仍然成立 ——
   // 每次访问 runtimeConfig.endpoint 都会执行 endpointFn, 拿到当时最新的兼容模式状态。
   const config: AgentRuntimeConfig = {
-    // behaviorFlags 现在全是静态值 (压缩阈值已拆到 autoCompactThresholdPct getter),
-    // 直接当普通属性挂; 引用共享无妨 —— env-builder 只读不改。
-    behaviorFlags: staticClaudeBehaviorFlags,
+    // behaviorFlags 用 getter 而非静态值:env-builder 在每次 spawn 时读它,getter 让
+    // attribution 归因块跟随**当时**的 Claude.ai 订阅连接态(oauth-spawn 判据与 proxy
+    // 同源)。会话中途连/断订阅只影响新 spawn —— 与 cc 子进程凭证冻结语义一致。
+    get behaviorFlags() {
+      return claudeBehaviorFlagsForSpawn(hasClaudeAiOAuth());
+    },
     // xdt-maker 产品级 system prompt 注入：host 共用段 (host-system-prompt.md)
     // + Claude 专属段 (claude-system-prompt.md)，按顺序拼接后给 maker-core append。
     systemPrompt: composeHostPrompt(claudeSystemPrompt),

--- a/apps/desktop/src/main/remote-ssh/claude-env.ts
+++ b/apps/desktop/src/main/remote-ssh/claude-env.ts
@@ -69,6 +69,9 @@ export function getRemoteClaudeEnv(): Record<string, string> | null {
     // tool defs on every request to non-first-party hosts (big bandwidth hit).
     CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS: '1',
     CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '75',
+    // 远端恒为 gateway-spawn(订阅 token 不上远端,见上方 doc),归因块只降网关缓存
+    // 命中率,保持禁用 —— 本地按 spawn 形态条件化的逻辑(claude-behavior-flags.ts,
+    // issue #758)不适用于这里。
     CLAUDE_CODE_ATTRIBUTION_HEADER: '0',
     ENABLE_TOOL_SEARCH: 'auto',
     // Telemetry off — endpoints would 401 against the company proxy

--- a/apps/desktop/src/main/remote-ssh/claude-env.ts
+++ b/apps/desktop/src/main/remote-ssh/claude-env.ts
@@ -38,7 +38,8 @@ import { claudeUpstreamEndpoint } from '../maker-host/runtime-configs.js';
  *
  * Keys mirror `buildClaudeEnv` for parity with local Claude behaviour, minus
  * local-only bits (loopback URL, MANAGED_BY_HOST). Bump alongside any new
- * behaviour flag added in `runtime-configs.ts`.
+ * behaviour flag added in `claude-behavior-flags.ts` (runtime-configs 的
+ * behaviorFlags 来源)。
  *
  * Claude 'oauth' (subscription) mode is intentionally NOT honored on remote:
  * the per-model OAuth↔gateway split lives in the LOCAL loopback proxy, which a

--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -82,6 +82,20 @@ describe('buildClaudeEnv', () => {
     expect(env.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
   });
 
+  it('lets behaviorFlags override an inherited CLAUDE_CODE_ATTRIBUTION_HEADER from the host env', async () => {
+    // local spawn 继承宿主 process.env:宿主 shell export 过 =0 时,flags 缺席压不住
+    // 继承值 —— 保留归因必须显式 '1'(desktop issue #758 的环境继承回归面)。
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0';
+    try {
+      const env = await buildClaudeEnv(createAuthAdapter(), {
+        behaviorFlags: () => ({ CLAUDE_CODE_ATTRIBUTION_HEADER: '1' }),
+      });
+      expect(env.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('1');
+    } finally {
+      delete process.env.CLAUDE_CODE_ATTRIBUTION_HEADER;
+    }
+  });
+
   it('injects the configured Claude subagent model', async () => {
     delete process.env.CLAUDE_CODE_SUBAGENT_MODEL;
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -69,6 +69,19 @@ describe('buildClaudeEnv', () => {
     expect(env.ANTHROPIC_API_KEY).toBe('key');
   });
 
+  it('evaluates function-form behaviorFlags with the spawn credentialMode', async () => {
+    const behaviorFlags = vi.fn(() => ({ CLAUDE_CODE_ATTRIBUTION_HEADER: '0' }));
+
+    const env = await buildClaudeEnv(
+      createAuthAdapter(),
+      { behaviorFlags },
+      { credentialMode: 'gateway-key' },
+    );
+
+    expect(behaviorFlags).toHaveBeenCalledWith({ credentialMode: 'gateway-key' });
+    expect(env.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
+  });
+
   it('injects the configured Claude subagent model', async () => {
     delete process.env.CLAUDE_CODE_SUBAGENT_MODEL;
 

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -190,8 +190,13 @@ export async function buildClaudeEnv(
   const cleanEnv = mode === 'remote' ? {} : cleanProcessEnv();
   const env: Record<string, string> = { ...cleanEnv };
 
-  if (runtimeConfig.behaviorFlags) {
-    Object.assign(env, runtimeConfig.behaviorFlags);
+  // 函数形态按本次 spawn 的凭证形态求值(如 attribution 归因块只对 gateway-key 禁用)。
+  const behaviorFlags =
+    typeof runtimeConfig.behaviorFlags === 'function'
+      ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode })
+      : runtimeConfig.behaviorFlags;
+  if (behaviorFlags) {
+    Object.assign(env, behaviorFlags);
   }
   // 远端模式优先用 remoteEndpoint（真上游网关）—— 本地 endpoint 是 loopback proxy URL，
   // 远端机器够不到（见 runtime-config.ts remoteEndpoint 文档 + index.ts 的 loopback guard）。

--- a/packages/maker-core/src/agents/codex/env-builder.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.ts
@@ -44,8 +44,13 @@ export async function buildCodexEnv(
     if (typeof v === 'string') env[k] = v;
   }
 
-  if (runtimeConfig.behaviorFlags) {
-    Object.assign(env, runtimeConfig.behaviorFlags);
+  // 函数形态按 spawn 凭证形态求值(与 claude-code/env-builder 同语义;Codex 当前无业务 flag)。
+  const behaviorFlags =
+    typeof runtimeConfig.behaviorFlags === 'function'
+      ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode })
+      : runtimeConfig.behaviorFlags;
+  if (behaviorFlags) {
+    Object.assign(env, behaviorFlags);
   }
   // endpoint 字段：Codex SDK 当前无对应 env，跳过
   const authOptions = options.credentialMode

--- a/packages/maker-core/src/interfaces/runtime-config.ts
+++ b/packages/maker-core/src/interfaces/runtime-config.ts
@@ -7,6 +7,13 @@
  * - 这样 CLI host 可以一行配置切换不走 proxy；业务 flag 也能交给用户 settings 调
  */
 
+import type { AgentCredentialMode } from './auth-adapter.js';
+
+/** 函数形态 behaviorFlags 的入参:本次 spawn 的凭证形态(undefined = 未显式指定,走 adapter fallback)。 */
+export interface BehaviorFlagsContext {
+  credentialMode?: AgentCredentialMode;
+}
+
 export interface AgentRuntimeConfig {
   /**
    * 接入端点。设为 undefined 表示走 SDK 默认（如 api.anthropic.com）。
@@ -33,8 +40,13 @@ export interface AgentRuntimeConfig {
   /**
    * 业务行为 flag。Agent 内部决定哪些 key 有意义。
    * Claude 当前用到：CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS
+   *
+   * 函数形态:flag 需要按本次 spawn 的凭证形态分叉时用(env-builder 在组装 env 时
+   * 以 spawn 的 credentialMode 调用)。典型:CLAUDE_CODE_ATTRIBUTION_HEADER 只对
+   * gateway-key spawn 禁用——oauth 侧禁用会让订阅直连的 Auto 分类器子请求被上游
+   * 429(desktop issue #758)。静态对象形态语义不变。
    */
-  behaviorFlags?: Record<string, string>;
+  behaviorFlags?: Record<string, string> | ((ctx: BehaviorFlagsContext) => Record<string, string>);
 
   /**
    * Host-managed default model for native subagents.


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #758:`CLAUDE_CODE_ATTRIBUTION_HEADER='0'` 被无条件注入所有本地 Claude Code 子进程,导致订阅 OAuth 用户在 auto 权限模式下,安全分类器子请求被 Anthropic 上游确定性 429——所有需要判定的工具调用 100% 失败,且用户无法自救(改配置本身需要分类器放行)。

两个 commit:

1. **根因修复**:behaviorFlags 按 spawn 形态求值——连了 Claude.ai 订阅(oauth-spawn,判据 `hasClaudeAiOAuth`,与 compat proxy 的 oauth-spawn 判定同源)保留 CLI 默认归因块;未连订阅(gateway-spawn)维持 `'0'` 不变(恒走网关,禁归因只有 body 缓存命中率收益、无副作用)。归因块实为请求体 system 数组第一个 text block(`x-anthropic-billing-header: ...`),重新打开后分类器故障检测的 system 前缀匹配需跳过它,否则 auto→ask 降级兜底会失明——已同步修复。

2. **持续故障升级阈值**:#596 把 408/429/5xx 一律视为瞬时故障、静默跳过降级,动机成立(偶发限流不该永久改写用户 Auto 偏好),但会把「确定性 429」类故障(如本 issue)留在无限硬失败 + 零提示的死锁里。本 commit 恢复兜底并保留 #596 的保护:瞬时失败按故障段(episode)记账,30s 内归并为一段(SDK 自动重试不数成 N 次),只统计最近 10 分钟,连续 3 段且中间无任何分类器成功 → 降级 ask + 现有 toast;任一成功立即清零;确定性 4xx 维持立即降级;任何一次降级都清零残账,避免用户重开 Auto 后被单次偶发失败提前推过阈值。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#758(附带收敛 #596 引入的降级兜底缺口)
- 本 PR 包含:desktop main 侧 Claude Code 行为开关条件化 + auto 分类器故障降级策略
- 明确不包含:Codex 侧 auto review 策略统一(等 `dash/fix-codex-auto-review-fallback` 合入后另行处理);远端 one-shot 链路(`remote-ssh/claude-env.ts` 恒为 gateway-spawn,保持 `'0'` 并已加注释)
- 用户可见变化:订阅 OAuth 用户 auto 模式恢复正常;分类器持续故障(~1 分钟)时会话自动降到 ask 并弹 toast,不再无限硬失败
- 是否存在 breaking change:无

### UI 变化

不涉及:未修改 UI、交互或文案(降级 toast 复用现有 `autoPermissionFallbackToast` 链路)。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:50 个 package 全部 PASS(exit 0)

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
结果:2 个测试文件、23 个测试全部通过(含新增:oauth/gateway spawn 的 flag 分叉、归因块跳过检测、单段 retry storm 不升级、3 段升级、成功清零、10 分钟窗口过期、会话隔离、确定性降级清残账)

pnpm --filter desktop run typecheck
结果:通过

pnpm check:dco
结果:2 commits signed off
```

### 手工验证

不涉及:本机无订阅 OAuth + auto 的复现环境。

### 未执行的验证

订阅 OAuth + auto 模式的端到端实机验证未执行(缺订阅测试环境)。判定链路依据:归因块生成逻辑已在内置 CLI bundle 中核实(`dk8()`:归因为 system 数组首个 text block,`CLAUDE_CODE_ATTRIBUTION_HEADER` 置 0 时省略);oauth-spawn 判据与 proxy 现有 `setClaudeProxyOAuthSpawnChecker(hasClaudeAiOAuth)` 同源。恳请 issue 作者 @fatwang2 或有订阅环境的同学在该分支上复验。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围:Claude Code 子进程 env 注入(仅 attribution 开关的条件化)与 auto 分类器错误响应观察逻辑。安全边界不变:分类器无 verdict 时当次工具调用仍 fail-closed;降级只朝收紧方向(auto→ask),绝不放宽。
- 回滚 / 降级方式:两个 commit 均可独立 revert。revert commit 1 恢复「无条件禁归因」;revert commit 2 恢复 #596 的「瞬时故障永不降级」。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(行为语义均以代码注释就地更新,含 proxy-host 观察器注释与 claude-env.ts 指引)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
