### PR TITLE
fix(proxy): 加密内容剥离不再掏空上下文压缩块

### DIFF
--- a/packages/anthropic-compat-proxy/src/transform.test.ts
+++ b/packages/anthropic-compat-proxy/src/transform.test.ts
@@ -69,6 +69,80 @@ describe('stripEncryptedContentFromBody', () => {
   it('returns null for non-JSON body', () => {
     expect(stripEncryptedContentFromBody(Buffer.from('not json', 'utf8'))).toBeNull();
   });
+
+  // 回归 (2026-07 Grok 会话卡死): 压缩块的 encrypted_content 是压缩 blob 本体,
+  // 剥掉只会留下上游无法解码的空壳 → xAI 400 "Could not decode the compaction blob"。
+  it('keeps the compaction blob intact while stripping reasoning blobs', () => {
+    const body = buf({
+      model: 'grok-4.5',
+      input: [
+        { type: 'compaction', id: 'cmp_abc', encrypted_content: 'BLOB' },
+        { type: 'reasoning', encrypted_content: 'gAAAAABxyz...', summary: [] },
+        { type: 'message', role: 'user', content: 'hi' },
+      ],
+    });
+    const out = stripEncryptedContentFromBody(body);
+    expect(out).not.toBeNull();
+    const parsed = JSON.parse(out!.toString('utf8'));
+    expect(parsed.input).toEqual([
+      { type: 'compaction', id: 'cmp_abc', encrypted_content: 'BLOB' },
+      { type: 'message', role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('keeps context_compaction blobs intact too', () => {
+    const body = buf({
+      model: 'grok-4.5',
+      input: [
+        { type: 'context_compaction', id: 'cc_1', encrypted_content: 'BLOB' },
+        { type: 'reasoning', encrypted_content: 'ENC' },
+      ],
+    });
+    const out = stripEncryptedContentFromBody(body);
+    expect(out).not.toBeNull();
+    const parsed = JSON.parse(out!.toString('utf8'));
+    expect(parsed.input).toEqual([{ type: 'context_compaction', id: 'cc_1', encrypted_content: 'BLOB' }]);
+  });
+
+  it('returns null when the only encrypted_content belongs to a compaction item', () => {
+    const body = buf({
+      model: 'grok-4.5',
+      input: [
+        { type: 'compaction', id: 'cmp_abc', encrypted_content: 'BLOB' },
+        { type: 'message', role: 'user', content: 'hi' },
+      ],
+    });
+    expect(stripEncryptedContentFromBody(body)).toBeNull();
+  });
+
+  it('keeps summary-only reasoning items when nothing was stripped this round', () => {
+    const body = buf({
+      model: 'grok-4.5',
+      input: [
+        { type: 'compaction', id: 'cmp_abc' },
+        { type: 'reasoning', summary: [{ type: 'summary_text', text: 's' }] },
+      ],
+    });
+    const out = stripEncryptedContentFromBody(body);
+    expect(out).not.toBeNull();
+    const parsed = JSON.parse(out!.toString('utf8'));
+    // 压缩空壳必丢;没剥过密文时,只带 summary 的 reasoning 是合法形态,保留。
+    expect(parsed.input).toEqual([{ type: 'reasoning', summary: [{ type: 'summary_text', text: 's' }] }]);
+  });
+
+  it('drops a compaction shell that already arrived without its blob', () => {
+    const body = buf({
+      model: 'grok-4.5',
+      input: [
+        { type: 'compaction', id: 'cmp_abc' },
+        { type: 'message', role: 'user', content: 'hi' },
+      ],
+    });
+    const out = stripEncryptedContentFromBody(body);
+    expect(out).not.toBeNull();
+    const parsed = JSON.parse(out!.toString('utf8'));
+    expect(parsed.input).toEqual([{ type: 'message', role: 'user', content: 'hi' }]);
+  });
 });
 
 describe('stripToolUseProviderSpecificFieldsFromBody', () => {
@@ -368,6 +442,31 @@ describe('createActiveStripTransform', () => {
     const out = transform({ model: 'gpt-5.5', input: [{ encrypted_content: 'gAAA' }] }, ctx);
 
     expect(out).toEqual({ model: 'gpt-5.5', input: [{}] });
+  });
+
+  // 主动剥离排在 codex-proxy transform 链首位, 跨来源压缩兼容 transform 排在其后并以
+  // "encrypted_content 非空" 为触发条件。这里先把压缩 blob 剥掉, 那条兼容路径就再也
+  // 认不出压缩块, 空壳会一路打到上游 → xAI 400 "Could not decode the compaction blob"。
+  it('leaves the compaction blob for the downstream cross-provider transform', () => {
+    const controller = createThreadStripController();
+    controller.markActive('thread-a', 'grok-4.5');
+    const transform = createActiveStripTransform({ controller, enabled: () => true, strip: stripEncryptedContentFromBody });
+
+    const out = transform(
+      {
+        model: 'grok-4.5',
+        input: [
+          { type: 'compaction', id: 'cmp_abc', encrypted_content: 'BLOB' },
+          { type: 'reasoning', encrypted_content: 'gAAA' },
+        ],
+      },
+      ctx,
+    );
+
+    expect(out).toEqual({
+      model: 'grok-4.5',
+      input: [{ type: 'compaction', id: 'cmp_abc', encrypted_content: 'BLOB' }],
+    });
   });
 
   it('strips active thread empty thinking blocks', () => {

--- a/packages/anthropic-compat-proxy/src/transform.test.ts
+++ b/packages/anthropic-compat-proxy/src/transform.test.ts
@@ -143,6 +143,50 @@ describe('stripEncryptedContentFromBody', () => {
     const parsed = JSON.parse(out!.toString('utf8'));
     expect(parsed.input).toEqual([{ type: 'message', role: 'user', content: 'hi' }]);
   });
+
+  // codex wire: Compaction.encrypted_content 必填、ContextCompaction 可选 —— 不带密文的
+  // context_compaction 是合法的可读压缩变体,不是空壳,删掉等于静默丢上下文。
+  it('preserves a blob-less context_compaction (legitimate readable variant)', () => {
+    const body = buf({
+      model: 'grok-4.5',
+      input: [
+        { type: 'context_compaction', id: 'cc_1', summary: 'earlier turns' },
+        { type: 'reasoning', encrypted_content: 'ENC' },
+      ],
+    });
+    const out = stripEncryptedContentFromBody(body);
+    expect(out).not.toBeNull();
+    const parsed = JSON.parse(out!.toString('utf8'));
+    expect(parsed.input).toEqual([{ type: 'context_compaction', id: 'cc_1', summary: 'earlier turns' }]);
+  });
+
+  // 空壳判定锚在协议层顶层 input[];嵌套结构里同名的 input 数组是别人的业务数据,
+  // 不能按 type 形状猜着删(删密文键仍然全树递归,那是定向删键)。
+  it('does not touch nested input arrays that are not protocol history', () => {
+    const body = buf({
+      model: 'grok-4.5',
+      input: [
+        { type: 'reasoning', encrypted_content: 'ENC' },
+        {
+          type: 'message',
+          role: 'user',
+          content: 'hi',
+          payload: { input: [{ type: 'compaction' }, { type: 'reasoning' }] },
+        },
+      ],
+    });
+    const out = stripEncryptedContentFromBody(body);
+    expect(out).not.toBeNull();
+    const parsed = JSON.parse(out!.toString('utf8'));
+    expect(parsed.input).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: 'hi',
+        payload: { input: [{ type: 'compaction' }, { type: 'reasoning' }] },
+      },
+    ]);
+  });
 });
 
 describe('stripToolUseProviderSpecificFieldsFromBody', () => {

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -108,8 +108,24 @@ export const stripToolUseProviderSpecificFields: RequestTransform = (body) => {
 };
 
 /**
+ * Responses `input[]` 里的上下文压缩块 (OpenAI `/v1/responses/compact` 与 xAI 同名接口
+ * 都回这个形态)。它的 `encrypted_content` 装的是**压缩 blob 本体** —— 压缩点之前的
+ * 全部历史,不是可有可无的推理链。
+ */
+function isCompactionItem(node: Record<string, unknown>): boolean {
+  return node.type === 'compaction' || node.type === 'context_compaction';
+}
+
+/**
  * 递归删除 body 里所有 `encrypted_content` 键, 返回删掉的个数。
  * 用于 invalid_encrypted_content 报错后的透明重试 (见 stripEncryptedContentFromBody)。
+ *
+ * **压缩块整块跳过**: 剥掉压缩 blob 换不回一个可用请求 —— 上游收到没有 blob 的
+ * 压缩空壳会直接判 "Could not decode the compaction blob. Ensure it is unmodified
+ * from the compact response." (xAI 实报, 2026-07 Grok 会话卡死)。压缩块该怎么处置
+ * 由上层按目标上游决定 (codex-proxy 的跨来源压缩兼容 transform 会把读不懂的加密块
+ * 换成明文占位), 而那条兼容路径正是以"encrypted_content 非空"为触发条件 —— 在这里
+ * 先剥就等于把它一并绕过。
  */
 function deepDeleteEncryptedContent(node: unknown): number {
   let removed = 0;
@@ -118,6 +134,7 @@ function deepDeleteEncryptedContent(node: unknown): number {
     return removed;
   }
   if (isPlainObject(node)) {
+    if (isCompactionItem(node)) return 0;
     if ('encrypted_content' in node) {
       delete node.encrypted_content;
       removed += 1;
@@ -135,14 +152,25 @@ function isReasoningItemWithoutEncryptedContent(item: unknown): boolean {
   return typeof item.encrypted_content !== 'string' || item.encrypted_content.length === 0;
 }
 
+/** 没有 blob 的压缩空壳 —— 上游无法解码, 留着必 400, 只能丢。 */
+function isCompactionItemWithoutBlob(item: unknown): boolean {
+  if (!isPlainObject(item) || !isCompactionItem(item)) return false;
+  return typeof item.encrypted_content !== 'string' || item.encrypted_content.length === 0;
+}
+
 /**
- * 从 Responses-style `input[]` 丢掉"无 encrypted_content 的 reasoning"空壳。
- * 只删 encrypted_content 键时,xAI 会把残留 reasoning item 判成 ModelInput 反序列化失败 (422)。
+ * 从 Responses-style `input[]` 丢掉解不开也修不好的空壳 item:
+ *   - 无 blob 的压缩块 (**恒丢**): 本函数不再制造这种空壳 (见 deepDeleteEncryptedContent),
+ *     但请求体可能已经带着它进来, 兜底丢掉, 别让它打到上游换一个 400;
+ *   - 无 encrypted_content 的 reasoning (**仅 dropReasoningShells**): 只删
+ *     encrypted_content 键时,xAI 会把残留 reasoning item 判成 ModelInput 反序列化失败
+ *     (422)。这一条只在本轮确实剥掉过密文时才做 —— 没剥过的请求里,"reasoning 只带
+ *     summary" 是合法形态, 不该顺手删掉。
  */
-function deepDropEmptyReasoningInputItems(node: unknown): number {
+function deepDropEncryptedShellInputItems(node: unknown, dropReasoningShells: boolean): number {
   let removed = 0;
   if (Array.isArray(node)) {
-    for (const item of node) removed += deepDropEmptyReasoningInputItems(item);
+    for (const item of node) removed += deepDropEncryptedShellInputItems(item, dropReasoningShells);
     return removed;
   }
   if (!isPlainObject(node)) return 0;
@@ -150,11 +178,14 @@ function deepDropEmptyReasoningInputItems(node: unknown): number {
   if (Array.isArray(node.input)) {
     const kept: unknown[] = [];
     for (const item of node.input) {
-      if (isReasoningItemWithoutEncryptedContent(item)) {
+      if (
+        isCompactionItemWithoutBlob(item) ||
+        (dropReasoningShells && isReasoningItemWithoutEncryptedContent(item))
+      ) {
         removed += 1;
         continue;
       }
-      removed += deepDropEmptyReasoningInputItems(item);
+      removed += deepDropEncryptedShellInputItems(item, dropReasoningShells);
       kept.push(item);
     }
     node.input = kept;
@@ -162,14 +193,14 @@ function deepDropEmptyReasoningInputItems(node: unknown): number {
 
   for (const key of Object.keys(node)) {
     if (key === 'input') continue;
-    removed += deepDropEmptyReasoningInputItems(node[key]);
+    removed += deepDropEncryptedShellInputItems(node[key], dropReasoningShells);
   }
   return removed;
 }
 
 /**
- * 把请求体里所有 `encrypted_content` 键递归删掉, 并丢掉因此变成空壳的 reasoning input item,
- * 返回新的 Buffer。
+ * 把请求体里所有 `encrypted_content` 键递归删掉 (压缩块除外), 并丢掉解不开也修不好的
+ * 空壳 input item, 返回新的 Buffer。
  *
  * 背景: gpt-5.5 等模型经 litellm/Azure 走 OpenAI Responses API (/v1/responses) 时,
  * 请求体的 reasoning item 带 `encrypted_content` (gAAA... 加密推理)。多部署负载均衡把
@@ -178,9 +209,12 @@ function deepDropEmptyReasoningInputItems(node: unknown): number {
  * 删掉 encrypted_content 再重发即可恢复 (代价: 模型丢失上一轮的加密推理链, 可见对话保留)。
  * 若只删键、保留 type=reasoning 空壳,xAI 会再报 ModelInput 422 —— 所以空壳一并丢掉。
  *
+ * **上下文压缩块除外**: 它的 encrypted_content 是压缩 blob 本体, 剥掉只会把请求变成
+ * 上游无法解码的空壳 (详见 deepDeleteEncryptedContent)。
+ *
  * 仅在 server.ts 收到该 400/422 后的"透明重试"路径调用, 正常请求不经过此函数。
  *
- * @returns 删掉了至少一个键或空壳 → 新 Buffer; body 非 JSON / 没有该键 → null (调用方据此决定不重试)
+ * @returns 删掉了至少一个键或空壳 → 新 Buffer; body 非 JSON / 无可剥内容 → null (调用方据此决定不重试)
  */
 export function stripEncryptedContentFromBody(rawBody: Buffer): Buffer | null {
   let parsed: unknown;
@@ -190,8 +224,10 @@ export function stripEncryptedContentFromBody(rawBody: Buffer): Buffer | null {
     return null;
   }
   const removedKeys = deepDeleteEncryptedContent(parsed);
-  if (removedKeys === 0) return null;
-  deepDropEmptyReasoningInputItems(parsed);
+  // 空壳清理独立计数: 请求体里可能只带着一个没有 blob 的压缩空壳 (没有任何
+  // encrypted_content 键可删), 那一样是必须处理的坏 payload, 不能因 removedKeys=0 放行。
+  const removedShells = deepDropEncryptedShellInputItems(parsed, removedKeys > 0);
+  if (removedKeys === 0 && removedShells === 0) return null;
   try {
     return Buffer.from(JSON.stringify(parsed), 'utf8');
   } catch {

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -152,49 +152,50 @@ function isReasoningItemWithoutEncryptedContent(item: unknown): boolean {
   return typeof item.encrypted_content !== 'string' || item.encrypted_content.length === 0;
 }
 
-/** 没有 blob 的压缩空壳 —— 上游无法解码, 留着必 400, 只能丢。 */
-function isCompactionItemWithoutBlob(item: unknown): boolean {
-  if (!isPlainObject(item) || !isCompactionItem(item)) return false;
+/**
+ * 缺 blob 的 `compaction` 空壳 —— 上游无法解码, 留着必 400, 只能丢。
+ *
+ * **只认 `compaction`, 不认 `context_compaction`**: codex wire 上 `Compaction.encrypted_content`
+ * 必填、`ContextCompaction.encrypted_content` 可选 —— 后者不带密文是合法的可读压缩变体
+ * (codex-proxy 的跨来源压缩兼容 transform 同样只处理带密文的项, 明文变体原样透传)。
+ * 把它当空壳删掉会静默丢掉真实的压缩上下文。
+ */
+function isCompactionShellWithoutBlob(item: unknown): boolean {
+  if (!isPlainObject(item) || item.type !== 'compaction') return false;
   return typeof item.encrypted_content !== 'string' || item.encrypted_content.length === 0;
 }
 
 /**
- * 从 Responses-style `input[]` 丢掉解不开也修不好的空壳 item:
- *   - 无 blob 的压缩块 (**恒丢**): 本函数不再制造这种空壳 (见 deepDeleteEncryptedContent),
- *     但请求体可能已经带着它进来, 兜底丢掉, 别让它打到上游换一个 400;
+ * 丢掉 Responses 请求体**协议层** `input[]` 里解不开也修不好的空壳 item:
+ *   - 缺 blob 的 `compaction` (**恒丢**): 本模块不再制造这种空壳
+ *     (见 deepDeleteEncryptedContent), 但请求体可能已经带着它进来, 兜底丢掉,
+ *     别让它打到上游换一个 400;
  *   - 无 encrypted_content 的 reasoning (**仅 dropReasoningShells**): 只删
  *     encrypted_content 键时,xAI 会把残留 reasoning item 判成 ModelInput 反序列化失败
  *     (422)。这一条只在本轮确实剥掉过密文时才做 —— 没剥过的请求里,"reasoning 只带
  *     summary" 是合法形态, 不该顺手删掉。
+ *
+ * **只看顶层 `input`, 不递归**: Responses 请求体的协议历史只有顶层这一个 `input[]`;
+ * 嵌套结构里同名的 `input` 数组(工具参数、业务对象等)不是协议历史, 按 `type` 形状
+ * 猜着删会静默改坏别人的数据。删密文键可以全树递归(定向删键, 只会少发不会发错),
+ * 判定"整项该不该留"必须锚在协议层。
  */
-function deepDropEncryptedShellInputItems(node: unknown, dropReasoningShells: boolean): number {
+function dropEncryptedShellInputItems(body: unknown, dropReasoningShells: boolean): number {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return 0;
+
   let removed = 0;
-  if (Array.isArray(node)) {
-    for (const item of node) removed += deepDropEncryptedShellInputItems(item, dropReasoningShells);
-    return removed;
-  }
-  if (!isPlainObject(node)) return 0;
-
-  if (Array.isArray(node.input)) {
-    const kept: unknown[] = [];
-    for (const item of node.input) {
-      if (
-        isCompactionItemWithoutBlob(item) ||
-        (dropReasoningShells && isReasoningItemWithoutEncryptedContent(item))
-      ) {
-        removed += 1;
-        continue;
-      }
-      removed += deepDropEncryptedShellInputItems(item, dropReasoningShells);
-      kept.push(item);
+  const kept: unknown[] = [];
+  for (const item of body.input) {
+    if (
+      isCompactionShellWithoutBlob(item) ||
+      (dropReasoningShells && isReasoningItemWithoutEncryptedContent(item))
+    ) {
+      removed += 1;
+      continue;
     }
-    node.input = kept;
+    kept.push(item);
   }
-
-  for (const key of Object.keys(node)) {
-    if (key === 'input') continue;
-    removed += deepDropEncryptedShellInputItems(node[key], dropReasoningShells);
-  }
+  if (removed > 0) body.input = kept;
   return removed;
 }
 
@@ -224,9 +225,10 @@ export function stripEncryptedContentFromBody(rawBody: Buffer): Buffer | null {
     return null;
   }
   const removedKeys = deepDeleteEncryptedContent(parsed);
-  // 空壳清理独立计数: 请求体里可能只带着一个没有 blob 的压缩空壳 (没有任何
+  // 空壳清理独立计数: 请求体里可能只带着一个缺 blob 的 compaction 空壳 (没有任何
   // encrypted_content 键可删), 那一样是必须处理的坏 payload, 不能因 removedKeys=0 放行。
-  const removedShells = deepDropEncryptedShellInputItems(parsed, removedKeys > 0);
+  // 这一步只扫顶层 input[] (单次线性扫描), 不是第二遍深度遍历。
+  const removedShells = dropEncryptedShellInputItems(parsed, removedKeys > 0);
   if (removedKeys === 0 && removedShells === 0) return null;
   try {
     return Buffer.from(JSON.stringify(parsed), 'utf8');


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复上下文压缩块(`type: compaction`)的 `encrypted_content` 被当成加密推理链剥掉,导致上游收到无法解码的压缩空壳、会话每轮报错的问题。

用户可见症状(xAI 侧):
`{"code":"invalid-argument","error":"Could not decode the compaction blob. Ensure it is unmodified from the compact response."}`

根因在 codex loopback proxy 的 transform 顺序:

1. 历史里带上下文压缩块。压缩块的 `encrypted_content` 装的是**压缩 blob 本体**(压缩点之前的全部历史),不是可有可无的推理链。
2. 某轮上游 400/422 → `invalid_encrypted_content` 恢复规则剥掉 `encrypted_content` 重发,同时把该 thread 标记为「主动剥离」(该开关默认开启)。标记只在**换模型**时清除。
3. 之后每个请求,`createActiveStripTransform` 排在 transform 链**首位**,`stripEncryptedContentFromBody` 递归删掉所有 `encrypted_content` —— **包括压缩块的那一份**;清理空壳时只处理 `type: reasoning`,压缩块被掏空后仍留在 `input[]` 里。
4. 排在其后的跨来源压缩兼容 transform(`createCrossProviderCompactionCompatTransform`,#265 引入)以「`encrypted_content` 非空」为触发条件,此时已认不出压缩块 → 不再替换为明文占位 → 空壳直接打到上游。
5. 该错误文案不匹配 `INVALID_ENCRYPTED_CONTENT_RE`,拿不到透明重试 → 同一会话每轮都撞同一个 400,会话卡死。

**影响面不止 xAI**:任何「历史里有压缩块 + 该 thread 被标记过主动剥离」的会话都会中招 ——

- xAI/Grok 路由:空壳打到 `api.x.ai`,报上面那条文案(用户反馈的现象);
- ChatGPT 订阅直连 + 远端压缩(#265 的 `cindy_openai` 身份):从别家供应商切回 OpenAI 触发一次加密内容 400 后,同样会把 OpenAI 自己签发的压缩 blob 掏空再发回去,上游一样拒。

修法:

- `deepDeleteEncryptedContent` 整块跳过 `compaction` / `context_compaction` —— 剥掉压缩 blob 换不回一个可用请求,压缩块该怎么处置交给上层按目标上游决定(跨来源压缩兼容 transform 会把读不懂的加密块换成明文占位)。
- 空壳清理兜底丢掉「没有 blob 的压缩块」(防御性,本函数不再制造这种空壳);同时把「无 `encrypted_content` 的 reasoning」收紧为**仅在本轮确实剥过密文时**才丢 —— 没剥过的请求里 reasoning 只带 summary 是合法形态,不该顺手删掉。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无 issue,来自用户反馈(Grok 4.5 + Codex 每轮报 compaction blob 解码失败)
- 本 PR 包含:`packages/anthropic-compat-proxy` 的 `stripEncryptedContentFromBody` 语义修正 + 6 条回归用例
- 明确不包含:
  - 跨来源压缩兼容 transform 的上游白名单不动。它当前把 `api.x.ai` 当成「读不懂 blob 的上游」,因此 **xAI 自己签发的**压缩 blob 在回放时也会被换成明文占位(压缩上下文静默丢失,但不报错)。要正确区分需要记录 blob 的签发上游(provenance),是独立的设计问题,另开 PR。
  - Codex 远端压缩身份(`cindy_openai`)在 `thread/start` 时冻结,会话中途切模型到 `xai/grok-*` 后不跟随的问题,同样另议。
- 用户可见变化:出现过一次加密内容 400 的会话不再每轮撞 `Could not decode the compaction blob`;压缩点之前的上下文仍按既有降级策略换成明文占位说明。
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:PASS(全部 workspace,0 FAIL;含 apps/desktop 96.7s、packages/anthropic-compat-proxy 2.5s、packages/maker-core 13.4s)

pnpm --filter @cindy/anthropic-compat-proxy typecheck
结果:exit 0

pnpm --filter desktop typecheck
结果:exit 0

pnpm check:dco
结果:DCO check passed
```

回归用例做了反向验证:临时移除 `deepDeleteEncryptedContent` 里的压缩块跳过后,`transform.test.ts` 4 条用例失败;恢复后 45 条全绿。

### 手工验证

不涉及(纯请求体改写逻辑,已用单测覆盖修复前后的行为差)。

### 未执行的验证

- 未用真实账号跑端到端链路(订阅会话切到 Grok 4.5 → 触发一次加密内容 400 → 后续轮次),手上没有可复现该历史状态的会话。用户侧可执行的验证步骤:在已出现该报错的会话里升级后继续对话,确认不再出现 `Could not decode the compaction blob`。
- 没有覆盖「activeStrip → crossProviderCompaction」整条 transform 链的集成用例:`codexProxyHost.test.ts` 把 `@cindy/anthropic-compat-proxy` 整包 mock 掉了,链路两端只能各自单测(proxy 侧断言压缩 blob 挺过剥离;desktop 侧既有用例断言非空 blob 会被换成明文占位)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

安全面复核:本改动不新增输入解析与外发字段。修复前发往非 ChatGPT 上游的是被掏空的 `{type:"compaction", id:"cmp_..."}`(泄漏一个 blob id),修复后该项被既有兼容 transform 替换为明文占位,外发内容只减不增。

### 影响与回滚

- 影响范围:只影响 `stripEncryptedContentFromBody` 这一条透明重试/主动剥离路径,被 codex-proxy 与 anthropic-compat-proxy 两个 host 共用。Anthropic Messages API 侧没有 `input[]` / 压缩块形态,该分支对它是 no-op。正常请求(未触发过 400 恢复)完全不经过此函数。
- 回滚 / 降级方式:单 commit,直接 revert 即可;用户侧也可在 设置 → 个性化 → 小技巧 关掉「静默剥离加密推理内容」绕过整条路径。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(改动点的 why 已写进函数头注)
- [x] 已确认测试结果或说明未执行原因
