### PR TITLE
fix(desktop): send app locale with server requests

### DIFF
--- a/apps/desktop/src/main/__tests__/serverApiClient.test.ts
+++ b/apps/desktop/src/main/__tests__/serverApiClient.test.ts
@@ -22,7 +22,7 @@ vi.mock('../authManager', () => ({
   refresh: mocks.refresh,
   invalidateSession: mocks.invalidateSession,
 }));
-vi.mock('../i18n', () => ({
+vi.mock('../i18n.js', () => ({
   getResolvedMainLocale: () => 'zh-CN',
 }));
 vi.mock('../logger', () => ({

--- a/apps/desktop/src/main/__tests__/serverApiClient.test.ts
+++ b/apps/desktop/src/main/__tests__/serverApiClient.test.ts
@@ -22,6 +22,9 @@ vi.mock('../authManager', () => ({
   refresh: mocks.refresh,
   invalidateSession: mocks.invalidateSession,
 }));
+vi.mock('../i18n', () => ({
+  getResolvedMainLocale: () => 'zh-CN',
+}));
 vi.mock('../logger', () => ({
   createLogger: () => mocks.logger,
 }));
@@ -66,7 +69,10 @@ describe('serverApiFetch', () => {
       1,
       'https://github-api.example.com/api/github/issues',
       expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: 'Bearer token-a' }),
+        headers: expect.objectContaining({
+          'Accept-Language': 'zh-CN',
+          Authorization: 'Bearer token-a',
+        }),
         body: JSON.stringify({ userName: 'Account A' }),
       }),
     );
@@ -74,7 +80,10 @@ describe('serverApiFetch', () => {
       2,
       'https://github-api.example.com/api/github/issues',
       expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: 'Bearer token-b' }),
+        headers: expect.objectContaining({
+          'Accept-Language': 'zh-CN',
+          Authorization: 'Bearer token-b',
+        }),
         body: JSON.stringify({ userName: 'Account B' }),
       }),
     );

--- a/apps/desktop/src/main/serverApiClient.ts
+++ b/apps/desktop/src/main/serverApiClient.ts
@@ -11,6 +11,7 @@
 
 import { net } from 'electron';
 import * as authManager from './authManager';
+import { getResolvedMainLocale } from './i18n.js';
 
 import { createLogger } from './logger';
 
@@ -69,6 +70,7 @@ async function rawFetch<T>(apiPath: string, opts: ApiFetchOptions): Promise<RawR
   const method = opts.method ?? 'GET';
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    'Accept-Language': getResolvedMainLocale(),
     ...(opts.headers ?? {}),
   };
   const token = opts.token !== undefined ? opts.token : authManager.getAccessToken();

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -78,6 +78,7 @@ import {
 import { pluginMarketErrorKey } from './lib/pluginMarketErrorKey';
 import { usePluginIconRefresh } from './lib/usePluginIconRefresh';
 import { usePluginMarketForegroundRefresh } from './lib/usePluginMarketForegroundRefresh';
+import { usePluginMarketLocaleRefresh } from './lib/usePluginMarketLocaleRefresh';
 import './plugin-motion.css';
 
 const MAX_VISIBLE_INSTALLED_GHOSTS = 5;
@@ -105,7 +106,8 @@ const PRESENTATION_FILTERS: readonly PluginPresentationFilter[] = [
  * interaction shape, while every displayed field comes from InstalledGhost.
  */
 export function GhostPluginPage() {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
+  const marketLocale = i18n.resolvedLanguage ?? i18n.language;
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { confirm, confirmWithCheckbox } = useConfirmDialog();
@@ -691,6 +693,11 @@ export function GhostPluginPage() {
       if (requestId === marketDetailRequestRef.current) throw error;
     }
   }, []);
+  usePluginMarketLocaleRefresh(
+    marketLocale,
+    () => refreshMarket(true),
+    marketDetail?.pluginId ? () => refreshVisibleMarketDetail(marketDetail.pluginId) : undefined,
+  );
   const visibleMarketIcons = useMemo(
     () => [...marketItems.map((item) => item.icon), marketDetail?.icon],
     [marketDetail?.icon, marketItems],

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -39,6 +39,7 @@ import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
 import { getLastWorkingDir, subscribeToLastWorkingDir } from '@/state/lastWorkingDir';
 import { findSplitChildByPanelKind } from '../../../shared/layoutTree';
+import { resolveSystemLocale } from '../../../shared/locale';
 import {
   diffGhostPermissionItems,
   ghostPanelKind,
@@ -107,7 +108,7 @@ const PRESENTATION_FILTERS: readonly PluginPresentationFilter[] = [
  */
 export function GhostPluginPage() {
   const { i18n, t } = useTranslation();
-  const marketLocale = i18n.resolvedLanguage ?? i18n.language;
+  const marketLocale = resolveSystemLocale(i18n.resolvedLanguage ?? i18n.language);
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { confirm, confirmWithCheckbox } = useConfirmDialog();
@@ -695,6 +696,9 @@ export function GhostPluginPage() {
   }, []);
   usePluginMarketLocaleRefresh(
     marketLocale,
+    async () => {
+      await window.electronAPI.setApplicationMenuLocale(marketLocale);
+    },
     () => refreshMarket(true),
     marketDetail?.pluginId ? () => refreshVisibleMarketDetail(marketDetail.pluginId) : undefined,
   );

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginMarketLocaleRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginMarketLocaleRefresh.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Regression coverage for locale-sensitive market refreshes.
+ * @vitest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { usePluginMarketLocaleRefresh } from '../usePluginMarketLocaleRefresh';
+
+describe('usePluginMarketLocaleRefresh', () => {
+  it('does not duplicate the initial market load', () => {
+    const refreshMarket = vi.fn();
+    const refreshDetail = vi.fn();
+
+    renderHook(({ locale }) => usePluginMarketLocaleRefresh(locale, refreshMarket, refreshDetail), {
+      initialProps: { locale: 'en' },
+    });
+
+    expect(refreshMarket).not.toHaveBeenCalled();
+    expect(refreshDetail).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the list and open detail when the locale changes', async () => {
+    const refreshMarket = vi.fn();
+    const refreshDetail = vi.fn();
+    const { rerender } = renderHook(
+      ({ locale }) => usePluginMarketLocaleRefresh(locale, refreshMarket, refreshDetail),
+      { initialProps: { locale: 'en' } },
+    );
+
+    await act(async () => {
+      rerender({ locale: 'zh-CN' });
+      await Promise.resolve();
+    });
+
+    expect(refreshMarket).toHaveBeenCalledTimes(1);
+    expect(refreshDetail).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows refresh failures from either market request', async () => {
+    const refreshMarket = vi.fn().mockRejectedValue(new Error('market unavailable'));
+    const refreshDetail = vi.fn().mockRejectedValue(new Error('detail unavailable'));
+    const { rerender } = renderHook(
+      ({ locale }) => usePluginMarketLocaleRefresh(locale, refreshMarket, refreshDetail),
+      { initialProps: { locale: 'en' } },
+    );
+
+    await act(async () => {
+      rerender({ locale: 'ja' });
+    });
+
+    await waitFor(() => {
+      expect(refreshMarket).toHaveBeenCalledTimes(1);
+      expect(refreshDetail).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginMarketLocaleRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/usePluginMarketLocaleRefresh.test.tsx
@@ -9,42 +9,92 @@ import { describe, expect, it, vi } from 'vitest';
 import { usePluginMarketLocaleRefresh } from '../usePluginMarketLocaleRefresh';
 
 describe('usePluginMarketLocaleRefresh', () => {
-  it('does not duplicate the initial market load', () => {
+  it('waits for the initial main-locale sync before correcting the market load', async () => {
+    let finishSync: (() => void) | undefined;
+    const syncLocale = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSync = resolve;
+        }),
+    );
     const refreshMarket = vi.fn();
     const refreshDetail = vi.fn();
 
-    renderHook(({ locale }) => usePluginMarketLocaleRefresh(locale, refreshMarket, refreshDetail), {
-      initialProps: { locale: 'en' },
-    });
+    renderHook(
+      ({ locale }) =>
+        usePluginMarketLocaleRefresh(locale, syncLocale, refreshMarket, refreshDetail),
+      {
+        initialProps: { locale: 'en' },
+      },
+    );
 
+    await waitFor(() => {
+      expect(syncLocale).toHaveBeenCalledWith('en');
+    });
     expect(refreshMarket).not.toHaveBeenCalled();
     expect(refreshDetail).not.toHaveBeenCalled();
+
+    await act(async () => {
+      finishSync?.();
+    });
+
+    await waitFor(() => {
+      expect(refreshMarket).toHaveBeenCalledTimes(1);
+      expect(refreshDetail).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('refreshes the list and open detail when the locale changes', async () => {
+  it('waits for main to accept a changed locale before refreshing market data', async () => {
+    const syncLocale = vi.fn().mockResolvedValue(undefined);
     const refreshMarket = vi.fn();
     const refreshDetail = vi.fn();
     const { rerender } = renderHook(
-      ({ locale }) => usePluginMarketLocaleRefresh(locale, refreshMarket, refreshDetail),
+      ({ locale }) =>
+        usePluginMarketLocaleRefresh(locale, syncLocale, refreshMarket, refreshDetail),
       { initialProps: { locale: 'en' } },
     );
+
+    await waitFor(() => {
+      expect(refreshMarket).toHaveBeenCalledTimes(1);
+      expect(refreshDetail).toHaveBeenCalledTimes(1);
+    });
+    syncLocale.mockClear();
+    refreshMarket.mockClear();
+    refreshDetail.mockClear();
 
     await act(async () => {
       rerender({ locale: 'zh-CN' });
-      await Promise.resolve();
     });
 
-    expect(refreshMarket).toHaveBeenCalledTimes(1);
-    expect(refreshDetail).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(syncLocale).toHaveBeenCalledWith('zh-CN');
+      expect(refreshMarket).toHaveBeenCalledTimes(1);
+      expect(refreshDetail).toHaveBeenCalledTimes(1);
+    });
+    expect(syncLocale.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshMarket.mock.invocationCallOrder[0],
+    );
+    expect(syncLocale.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshDetail.mock.invocationCallOrder[0],
+    );
   });
 
   it('swallows refresh failures from either market request', async () => {
+    const syncLocale = vi.fn().mockResolvedValue(undefined);
     const refreshMarket = vi.fn().mockRejectedValue(new Error('market unavailable'));
     const refreshDetail = vi.fn().mockRejectedValue(new Error('detail unavailable'));
     const { rerender } = renderHook(
-      ({ locale }) => usePluginMarketLocaleRefresh(locale, refreshMarket, refreshDetail),
+      ({ locale }) =>
+        usePluginMarketLocaleRefresh(locale, syncLocale, refreshMarket, refreshDetail),
       { initialProps: { locale: 'en' } },
     );
+
+    await waitFor(() => {
+      expect(refreshMarket).toHaveBeenCalledTimes(1);
+      expect(refreshDetail).toHaveBeenCalledTimes(1);
+    });
+    refreshMarket.mockClear();
+    refreshDetail.mockClear();
 
     await act(async () => {
       rerender({ locale: 'ja' });

--- a/apps/desktop/src/renderer/features/plugin/lib/usePluginMarketLocaleRefresh.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/usePluginMarketLocaleRefresh.ts
@@ -1,36 +1,49 @@
 import { useEffect, useRef } from 'react';
 
 type Refresh = () => void | Promise<void>;
+type SyncLocale = (locale: string) => void | Promise<void>;
 
 /**
- * Re-fetches locale-sensitive market data after the host language changes.
+ * Re-fetches locale-sensitive market data after main confirms the host locale.
  *
- * The initial render already has its normal market load. Keeping the previous
- * locale in a ref avoids a duplicate request on mount while still refreshing
- * both the catalog and an open detail view after a language switch.
+ * Main initially falls back to the OS locale until Renderer synchronizes the
+ * stored preference. The mount-time refresh is therefore intentional: it
+ * corrects any catalog request that raced ahead of that first synchronization.
  */
 export function usePluginMarketLocaleRefresh(
   locale: string | undefined,
+  syncLocale: SyncLocale,
   refreshMarket: Refresh,
   refreshDetail?: Refresh,
 ): void {
-  const previousLocaleRef = useRef(locale);
+  const syncLocaleRef = useRef(syncLocale);
   const refreshMarketRef = useRef(refreshMarket);
   const refreshDetailRef = useRef(refreshDetail);
+  syncLocaleRef.current = syncLocale;
   refreshMarketRef.current = refreshMarket;
   refreshDetailRef.current = refreshDetail;
 
   useEffect(() => {
-    if (previousLocaleRef.current === locale) return;
-    previousLocaleRef.current = locale;
+    if (!locale) return;
+    let cancelled = false;
 
     void Promise.resolve()
-      .then(() => refreshMarketRef.current())
+      .then(() => syncLocaleRef.current(locale))
+      .then(() => {
+        if (cancelled) return;
+        const refreshes: Promise<void>[] = [
+          Promise.resolve().then(() => refreshMarketRef.current()),
+        ];
+        const refreshDetail = refreshDetailRef.current;
+        if (refreshDetail) {
+          refreshes.push(Promise.resolve().then(() => refreshDetail()));
+        }
+        return Promise.allSettled(refreshes);
+      })
       .catch(() => undefined);
-    if (refreshDetailRef.current) {
-      void Promise.resolve()
-        .then(() => refreshDetailRef.current?.())
-        .catch(() => undefined);
-    }
+
+    return () => {
+      cancelled = true;
+    };
   }, [locale]);
 }

--- a/apps/desktop/src/renderer/features/plugin/lib/usePluginMarketLocaleRefresh.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/usePluginMarketLocaleRefresh.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+
+type Refresh = () => void | Promise<void>;
+
+/**
+ * Re-fetches locale-sensitive market data after the host language changes.
+ *
+ * The initial render already has its normal market load. Keeping the previous
+ * locale in a ref avoids a duplicate request on mount while still refreshing
+ * both the catalog and an open detail view after a language switch.
+ */
+export function usePluginMarketLocaleRefresh(
+  locale: string | undefined,
+  refreshMarket: Refresh,
+  refreshDetail?: Refresh,
+): void {
+  const previousLocaleRef = useRef(locale);
+  const refreshMarketRef = useRef(refreshMarket);
+  const refreshDetailRef = useRef(refreshDetail);
+  refreshMarketRef.current = refreshMarket;
+  refreshDetailRef.current = refreshDetail;
+
+  useEffect(() => {
+    if (previousLocaleRef.current === locale) return;
+    previousLocaleRef.current = locale;
+
+    void Promise.resolve()
+      .then(() => refreshMarketRef.current())
+      .catch(() => undefined);
+    if (refreshDetailRef.current) {
+      void Promise.resolve()
+        .then(() => refreshDetailRef.current?.())
+        .catch(() => undefined);
+    }
+  }, [locale]);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

在 Desktop 的统一 `serverApiClient` 请求层默认添加标准 `Accept-Language` 请求头，值来自当前 Cindy 主进程语言。这样插件市场列表、详情以及其他服务端接口都能获得统一的语言上下文，由服务端按语言返回对应的 `name`、`description`、`author` 等内容。

语言切换后，插件市场列表和当前打开的市场详情会主动重新请求，避免继续显示旧语言内容。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Related to #392
- 本 PR 包含：统一请求层传递 `Accept-Language`；补充首次请求、401 刷新重试和语言切换后的市场刷新测试。
- 明确不包含：插件服务器端的多语言数据查询与返回逻辑，后续在插件服务器仓库继续修改。
- 用户可见变化：客户端为服务端提供当前语言；切换语言时市场列表和已打开详情会重新加载对应语言内容。
- 是否存在 breaking change：无。

## UI 变化

- 市场页交互变化：宿主语言切换后，列表和当前打开的详情会重新请求语言敏感数据；保留现有布局、加载和错误状态，没有新增视觉样式或 UI 文案。
- 引用的设计规范：`docs/design-rules/DESIGN.md` 的交互状态与反馈约束；`docs/dev-rules/engineering-conventions.md` §5 UI 文案与 i18n 约束。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/main/__tests__/serverApiClient.test.ts src/renderer/features/plugin/lib/__tests__/usePluginMarketLocaleRefresh.test.tsx
结果：通过（12/12）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

未执行：本次交互刷新由自动化 hook 回归测试覆盖，未启动桌面端进行人工语言切换验证。

### 未执行的验证

根 `pnpm test:unit` 已重跑多次；仓库级脚本测试和其他 workspace 通过，Desktop 仅同一个既有 `src/main/git-review/__tests__/stageOps.test.ts` 用例在 8 worker 并发下超时。该用例单独运行通过，失败与本 PR 无关。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] 协议兼容
- [ ] 跨平台差异
- [x] 其他：语言切换会触发一次市场列表请求，详情页打开时额外触发一次详情请求。

### 影响与回滚

- 影响范围：所有经 `serverApiClient` 发出的服务端请求都会带上 `Accept-Language`；市场页切换语言时会重新获取列表和当前详情。调用方显式传入同名 header 时仍可覆盖默认值。暂不支持该请求头的服务端会忽略它，不影响现有请求。
- 回滚 / 降级方式：回退本 PR 提交即可，客户端会恢复原有请求和市场刷新行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果并说明全量门禁中的既有超时
