### PR TITLE
fix(desktop): 项目菜单首项字号与兄弟项不一致

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectNode.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectNode.tsx
@@ -422,7 +422,7 @@ export function ProjectNode({
             onClick={() => {
               beginRename();
             }}
-            className="h-7 px-2.5 rounded-md text-13 leading-none text-[var(--msg-assistant-text)] focus:bg-[var(--cmd-palette-item-hover)]"
+            className={MENU_ITEM_CLASS}
           >
             {t('ccAgent.sidebar.projectAction.rename')}
           </DropdownMenuItem>


### PR DESCRIPTION
## 这次改了什么

### 摘要

项目右键菜单里第一项「重命名项目」沿用了旧的内联规范(\`h-7 px-2.5 rounded-md text-13 leading-none text-[var(--msg-assistant-text)]\`),其余菜单项早已统一走共享常量 \`MENU_ITEM_CLASS\`(\`h-8 / px-2 / rounded-lg / text-sm / --cmd-palette-item-text\`),导致同一张菜单里首项字号 13px、行高 28px、颜色 token 都与兄弟项的 14px / 32px / 另一组 token 不一致,视觉上「字体大大小小」。

把首项也改为引用 \`MENU_ITEM_CLASS\`,对齐 \`menuStyles.ts\` 的统一约定。

### 变更类型

- [ ] \`feat\` 新功能
- [x] \`fix\` 缺陷修复
- [ ] \`refactor\` / \`perf\` 重构或性能优化
- [ ] \`docs\` / \`test\` / \`chore\` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:用户反馈项目右键菜单字号不一致
- 本 PR 包含:\`apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectNode.tsx\` 1 行 className 替换
- 明确不包含:其它菜单、其它页面的样式梳理;\`SessionProjectMoveSubmenu\` 等刻意使用其它规范的子菜单不动
- 用户可见变化:项目右键菜单首项字号、行高、颜色 token 与兄弟项一致
- 是否存在 breaking change:无

### UI 变化

涉及 UI(desktop 侧栏项目右键菜单);视觉效果为首项字号 13→14、行高 28→32、颜色 token 切换到 \`--cmd-palette-item-text\`,与兄弟项完全同款。未附截图:改动仅是把漏迁的 className 替换为已在本菜单兄弟项使用的共享常量,渲染结果等于兄弟项现有样式。

- 引用的设计规范:
  - \`docs/design-rules/DESIGN.md\` §5 Inner control(8px):dropdown/menu rows 使用 8px 圆角,对应 \`MENU_ITEM_CLASS\` 中的 \`rounded-lg\`
  - \`docs/design-rules/DESIGN.md\` §10 token 体系:菜单文字颜色走 \`--cmd-palette-item-text\` token,不再用会话气泡专用的 \`--msg-assistant-text\`
  - \`apps/desktop/src/renderer/features/cc-agent/sidebar/menuStyles.ts\`:侧栏菜单统一 surface/item 常量约定,本 PR 把漏迁的首项对齐到 \`MENU_ITEM_CLASS\`

## 怎么验证的

### 自动验证

\`\`\`text
pnpm --filter desktop run --if-present typecheck
结果:通过(tsc --noEmit -p tsconfig.json 无报错)
\`\`\`

### 手工验证

- 操作路径:Desktop 侧栏 → 项目行右键 → 项目菜单
- 平台 / 环境:macOS,worktree \`fix-project-menu-font\` 基于 \`upstream/main\` (\`8aedb3a7\`)
- 改动前:首项字号 13px / 行高 28px,其它项 14px / 32px,首项颜色 token 也与兄弟项不同
- 改动后:首项与兄弟项完全同款(同 \`MENU_ITEM_CLASS\`)
- 双模式目检:未实机分别验证 Light / Dark,但本 PR 只是把首项切换到兄弟项已经在用的同一组共享常量与 token,无新增 token、无新增条件分支,无双模式风险

### 未执行的验证

- 未跑根 \`pnpm test:unit\`:按本任务约定跳过,以 typecheck 为准
- 未跑 \`pnpm test:all\`:本 PR 仅 1 行 className 修改,无逻辑改动

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 desktop 侧栏项目右键菜单首项视觉,无行为变化
- 回滚 / 降级方式:revert 本 PR 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(\`git commit -s\`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(commit message 说明根因与对齐目标)
- [x] 已确认测试结果或说明未执行原因