### PR TITLE
fix(desktop): restore rail sidebar chrome actions

### DIFF
--- a/apps/desktop/src/renderer/components/layout/ContentHeader.tsx
+++ b/apps/desktop/src/renderer/components/layout/ContentHeader.tsx
@@ -27,6 +27,7 @@ import type { ReactNode } from 'react';
 import { useFeatureContentHeader } from '@/features/feature-context';
 import { useMacFullscreen } from '@/hooks/useMacFullscreen';
 import { cn } from '@/lib/utils';
+import { CHROME_ACTIONS_GEOMETRY } from './chromeActionsGeometry';
 
 /**
  * Windows 窗口控制按钮宽度（3 × 46px）。窗口控制按钮已 hoist 到 MainLayout
@@ -63,6 +64,8 @@ interface ContentHeaderProps {
   sidebarVisible: boolean;
   /** 折叠态是否需要为 ChromeActions 浮动按钮簇预留占位。设置页为 false。 */
   showCollapsedActions: boolean;
+  /** 左侧栏是否处于 rail 态（拖到最窄但仍保留图标列）。 */
+  isSidebarRail: boolean;
   /** mac 右上浮层按钮是否在场(2026-07-09 口径:右栏在场即 true,不分贴哪侧 ——
    *  折叠 toggle 恒钉窗口右上角,面板贴左时它压在本 header 右端)。mac 据此在
    *  右端留折叠按钮占位 + 决定是否留住空 header;Windows 仅影响空 header 判定,
@@ -75,6 +78,7 @@ interface ContentHeaderProps {
 export function ContentHeader({
   sidebarVisible,
   showCollapsedActions,
+  isSidebarRail,
   rightSidebarAvailable,
   hidden,
 }: ContentHeaderProps) {
@@ -84,6 +88,12 @@ export function ContentHeader({
   // Sidebar 不可见时红绿灯落在 header 上方 → 非全屏让位。78px = 70px 红绿灯
   // 占位 + 8px 呼吸间隙（与原 TitleBar 的 pl-[70px] + px-2 等效）。
   const needsTrafficLightInset = isMac && !isFullscreen && !sidebarVisible;
+  // rail 态时，Sidebar 仍占 78px；mac 非全屏的 ChromeActions 却紧贴其右缘
+  // (x=78)。Sidebar 顶栏里的 no-drag 洞会被自身 overflow-hidden 裁掉，必须在
+  // main 的 drag header 左缘再挖一个洞，否则点击浮动的收放/菜单按钮会被 Electron
+  // 当成窗口拖拽吞掉。完全收起态 main 从 x=0 开始，既有 spacer 已覆盖该位置；
+  // 全屏态按钮回到 rail 内，也由 Sidebar 的既有洞覆盖。
+  const needsRailChromeActionsHitHole = isMac && !isFullscreen && isSidebarRail;
 
   // 设置页：Sidebar 隐藏且无折叠按钮占位 → header 退化为"隐形 chrome"
   // （仅拖拽区 + Windows 窗口控制），不画下边框。
@@ -113,7 +123,7 @@ export function ContentHeader({
         // 红绿灯同轴(对齐 Codex 的紧凑 titlebar)。与 ChromeActions / Sidebar
         // 顶行 / MainLayout 右上浮层同一常量,改动必须连同 main 侧
         // trafficLightPosition 一起同步。
-        'flex h-[46px] w-full shrink-0 items-center select-none',
+        'relative flex h-[46px] w-full shrink-0 items-center select-none',
         // 下边框只画在右栏（header 在 main 内部，不会延伸到 Sidebar 上方），
         // Sidebar 侧保持无横线的连续表面；设置页隐形 chrome 不画
         // （用户决策 2026-06-11）。
@@ -127,6 +137,19 @@ export function ContentHeader({
       // 36px Tab 条那层(在面板身上,语义准)。
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
     >
+      {needsRailChromeActionsHitHole && (
+        <div
+          aria-hidden
+          data-testid="content-header-rail-chrome-actions-hit-hole"
+          className="absolute left-0 top-0 h-full"
+          style={
+            {
+              width: CHROME_ACTIONS_GEOMETRY.clusterWidth,
+              WebkitAppRegion: 'no-drag',
+            } as React.CSSProperties
+          }
+        />
+      )}
       {/* 折叠态占位 spacer：真实按钮在 MainLayout 的 ChromeActions 浮层里
           （钉死左上角、不随折叠重建的常驻实例）。本 spacer 以与侧栏宽度动画
           相同的时长/缓动伸缩，把标题平滑推到浮动按钮右侧（项目规则 8）。
@@ -176,6 +199,7 @@ export function ContentHeader({
 export function ContentHeaderSlot({
   sidebarVisible,
   showCollapsedActions,
+  isSidebarRail,
   rightSidebarAvailable,
   children,
 }: Omit<ContentHeaderProps, 'hidden'> & { children: ReactNode }) {
@@ -185,6 +209,7 @@ export function ContentHeaderSlot({
       <ContentHeader
         sidebarVisible={sidebarVisible}
         showCollapsedActions={showCollapsedActions}
+        isSidebarRail={isSidebarRail}
         rightSidebarAvailable={rightSidebarAvailable}
         hidden={hidden}
       />

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -54,6 +54,7 @@ import { RightSidebarDetach } from '@/components/layout/RightSidebarDetach';
 import { useSidebarResize } from '@/hooks/useSidebarResize';
 import { useSidebarCardMode } from '@/hooks/useSidebarCardMode';
 import { useSidebarPeek } from '@/hooks/useSidebarPeek';
+import { useMacFullscreen } from '@/hooks/useMacFullscreen';
 import {
   useRightSidebarResize,
   RIGHT_SIDEBAR_AVAILABLE_WIDTH_FALLBACK,
@@ -345,6 +346,7 @@ export function MainLayout() {
     return undefined;
   }, [isDragging]);
   const isMac = window.electronAPI?.platform === 'darwin';
+  const { isFullscreen } = useMacFullscreen();
   const {
     open: noticeOpen,
     mode: noticeMode,
@@ -402,6 +404,8 @@ export function MainLayout() {
   // RightSidebar 的 unified topbar。peek 抽屉会强制退出 rail，不能沿用 rail 命中区。
   const hasRailChromeActions =
     !isSettingsRoute &&
+    isMac &&
+    !isFullscreen &&
     isRailMode &&
     !isSidebarCollapsed &&
     !sidebarPeek.isPeekVisible;

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -396,6 +396,20 @@ export function MainLayout() {
     isCollapsed: isSidebarCollapsed,
     enabled: !isSettingsRoute,
   });
+  // ChromeActions 固定在窗口左上。rail 态下它跨到内容区，必须由当前最左且可见
+  // 的面板顶栏挖 no-drag 命中区：默认是 chat-main；工具面板换到左侧时则交给
+  // RightSidebar 的 unified topbar。peek 抽屉会强制退出 rail，不能沿用 rail 命中区。
+  const hasRailChromeActions =
+    !isSettingsRoute &&
+    isRailMode &&
+    !isSidebarCollapsed &&
+    !sidebarPeek.isPeekVisible;
+  const rightSidebarOwnsRailChromeActions =
+    hasRailChromeActions &&
+    rightSidebarSide === 'left' &&
+    !isRightSidebarCollapsed &&
+    !rsbDetached &&
+    !isRightSidebarMaximized;
   // peek 中固定展开(pinning)时若持久化的 rail 模式还开着:退出 rail —— 用户
   // 刚在全宽抽屉里预览并选择固定,落到 78px 窄轨会与所见不符且造成宽度跳变。
   useEffect(() => {
@@ -1190,7 +1204,7 @@ export function MainLayout() {
                 <ContentHeaderSlot
                   sidebarVisible={!isSettingsRoute && !isSidebarCollapsed && !isRailMode}
                   showCollapsedActions={!isSettingsRoute && (isSidebarCollapsed || isRailMode)}
-                  isSidebarRail={!isSettingsRoute && isRailMode && !isSidebarCollapsed}
+                  isSidebarRail={hasRailChromeActions && !rightSidebarOwnsRailChromeActions}
                   // M2(2026-07-09 口径修订):mac 右上浮层随面板在场常驻(折叠
                   // toggle 永远钉窗口右上角),ContentHeader 右端占位不再分侧别。
                   rightSidebarAvailable={rightSidebarAvailable}
@@ -1241,6 +1255,7 @@ export function MainLayout() {
                   onMaximize={handleMaximizeRightSidebar}
                   isMaximized={isRightSidebarMaximized}
                   reserveLeftChromeActions={isRightSidebarMaximized && isSidebarCollapsed}
+                  railChromeActionsHitHole={rightSidebarOwnsRailChromeActions}
                   sessionId={rightSidebarSessionId}
                   workdir={rightSidebarWorkdirInfo.workdir}
                   remoteHostId={rightSidebarWorkdirInfo.remoteHostId}

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -751,6 +751,7 @@ export function MainLayout() {
     rightSidebarAvailable,
     rightSidebarLoaded: rsbWindow.loaded,
     isRightSidebarCollapsed,
+    isRightSidebarMaximized,
     rsbDetached,
   });
   const handleMaximizeRightSidebar = useCallback(() => {

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -1190,6 +1190,7 @@ export function MainLayout() {
                 <ContentHeaderSlot
                   sidebarVisible={!isSettingsRoute && !isSidebarCollapsed && !isRailMode}
                   showCollapsedActions={!isSettingsRoute && (isSidebarCollapsed || isRailMode)}
+                  isSidebarRail={!isSettingsRoute && isRailMode && !isSidebarCollapsed}
                   // M2(2026-07-09 口径修订):mac 右上浮层随面板在场常驻(折叠
                   // toggle 永远钉窗口右上角),ContentHeader 右端占位不再分侧别。
                   rightSidebarAvailable={rightSidebarAvailable}

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { BrowserWebviewPool } from '@/components/layout/BrowserWebviewPool';
 import { ChromeActions } from '@/components/layout/ChromeActions';
 import { ContentHeaderSlot } from '@/components/layout/ContentHeader';
+import { rightSidebarOwnsRailChromeActions as resolveRightSidebarRailChromeActionsOwner } from '@/components/layout/railChromeActions';
 import { FadeSwitcher } from '@/components/layout/FadeSwitcher';
 import { RightSidebar, type RightSidebarHandle } from '@/components/layout/RightSidebar';
 import { RightSidebarMaximize } from '@/components/layout/RightSidebarMaximize';
@@ -740,12 +741,14 @@ export function MainLayout() {
   // - 折叠 RSB 时自动退出(否则 maximize 状态下点折叠会导致主区 hidden + RSB 也 0 宽 → 全黑)
   // - 不持久化:刷新 / 切 session 默认非 maximize,跟"临时聚焦视图"语义一致
   const [isRightSidebarMaximized, setIsRightSidebarMaximized] = useState(false);
-  const rightSidebarOwnsRailChromeActions =
-    hasRailChromeActions &&
-    rightSidebarSide === 'left' &&
-    !isRightSidebarCollapsed &&
-    !rsbDetached &&
-    !isRightSidebarMaximized;
+  const rightSidebarOwnsRailChromeActions = resolveRightSidebarRailChromeActionsOwner({
+    hasRailChromeActions,
+    rightSidebarSide,
+    rightSidebarAvailable,
+    rightSidebarLoaded: rsbWindow.loaded,
+    isRightSidebarCollapsed,
+    rsbDetached,
+  });
   const handleMaximizeRightSidebar = useCallback(() => {
     setIsRightSidebarMaximized((v) => !v);
   }, []);

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -404,12 +404,6 @@ export function MainLayout() {
     isRailMode &&
     !isSidebarCollapsed &&
     !sidebarPeek.isPeekVisible;
-  const rightSidebarOwnsRailChromeActions =
-    hasRailChromeActions &&
-    rightSidebarSide === 'left' &&
-    !isRightSidebarCollapsed &&
-    !rsbDetached &&
-    !isRightSidebarMaximized;
   // peek 中固定展开(pinning)时若持久化的 rail 模式还开着:退出 rail —— 用户
   // 刚在全宽抽屉里预览并选择固定,落到 78px 窄轨会与所见不符且造成宽度跳变。
   useEffect(() => {
@@ -746,6 +740,12 @@ export function MainLayout() {
   // - 折叠 RSB 时自动退出(否则 maximize 状态下点折叠会导致主区 hidden + RSB 也 0 宽 → 全黑)
   // - 不持久化:刷新 / 切 session 默认非 maximize,跟"临时聚焦视图"语义一致
   const [isRightSidebarMaximized, setIsRightSidebarMaximized] = useState(false);
+  const rightSidebarOwnsRailChromeActions =
+    hasRailChromeActions &&
+    rightSidebarSide === 'left' &&
+    !isRightSidebarCollapsed &&
+    !rsbDetached &&
+    !isRightSidebarMaximized;
   const handleMaximizeRightSidebar = useCallback(() => {
     setIsRightSidebarMaximized((v) => !v);
   }, []);

--- a/apps/desktop/src/renderer/components/layout/RightSidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/RightSidebar.tsx
@@ -68,6 +68,8 @@ interface RightSidebarProps {
   isMaximized?: boolean;
   /** 左侧栏完全收起且 RSB maximize 时，为顶栏左上角浮动 ChromeActions 让位。 */
   reserveLeftChromeActions?: boolean;
+  /** 工具面板位于最左且左侧栏为 rail 时，顶栏承接 ChromeActions 的 no-drag 命中区。 */
+  railChromeActionsHitHole?: boolean;
   /** 「在新窗口中打开侧边栏」:开偏好 + 弹出子窗口。Win 端 TabBar 内渲染按钮
    *  (Mac 走 MainLayout 浮层,不经此 prop)。 */
   onDetach?: () => void;
@@ -87,6 +89,7 @@ export const RightSidebar = forwardRef<RightSidebarHandle, RightSidebarProps>(fu
     onMaximize,
     isMaximized,
     reserveLeftChromeActions = false,
+    railChromeActionsHitHole = false,
     sessionId,
     workdir,
     remoteHostId,
@@ -258,6 +261,7 @@ export const RightSidebar = forwardRef<RightSidebarHandle, RightSidebarProps>(fu
           onMaximize={onMaximize}
           isMaximized={isMaximized}
           reserveLeftChromeActions={reserveLeftChromeActions}
+          railChromeActionsHitHole={railChromeActionsHitHole}
           onDetach={onDetach}
           // B3:主窗口内嵌形态 Tab 条空白处 = 拖面板手势面(窗口拖动走左栏顶行)。
           chromeWindowDrag={false}

--- a/apps/desktop/src/renderer/components/layout/__tests__/ContentHeader.chrome-actions.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/__tests__/ContentHeader.chrome-actions.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/useMacFullscreen', () => ({
+  useMacFullscreen: () => ({ isMac: true, isFullscreen: false }),
+}));
+
+import { FeatureSidebarSlotProvider } from '@/features/feature-context';
+import { CHROME_ACTIONS_GEOMETRY } from '../chromeActionsGeometry';
+import { ContentHeader } from '../ContentHeader';
+
+describe('ContentHeader rail ChromeActions hit hole', () => {
+  it('keeps the macOS rail-edge ChromeActions area outside the window drag region', () => {
+    render(
+      <FeatureSidebarSlotProvider isCollapsed>
+        <ContentHeader
+          sidebarVisible={false}
+          showCollapsedActions
+          isSidebarRail
+          rightSidebarAvailable={false}
+          hidden={false}
+        />
+      </FeatureSidebarSlotProvider>,
+    );
+
+    const hitHole = screen.getByTestId('content-header-rail-chrome-actions-hit-hole');
+    const header = hitHole.parentElement as HTMLElement;
+
+    expect(
+      (header.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
+    ).toBe('drag');
+    expect(
+      (hitHole.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
+    ).toBe('no-drag');
+    expect(hitHole.className).toContain('left-0');
+    expect(hitHole.style.width).toBe(`${CHROME_ACTIONS_GEOMETRY.clusterWidth}px`);
+  });
+
+  it('does not remove the fully collapsed header drag area', () => {
+    render(
+      <FeatureSidebarSlotProvider isCollapsed>
+        <ContentHeader
+          sidebarVisible={false}
+          showCollapsedActions
+          isSidebarRail={false}
+          rightSidebarAvailable={false}
+          hidden={false}
+        />
+      </FeatureSidebarSlotProvider>,
+    );
+
+    expect(screen.queryByTestId('content-header-rail-chrome-actions-hit-hole')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/layout/__tests__/railChromeActions.test.ts
+++ b/apps/desktop/src/renderer/components/layout/__tests__/railChromeActions.test.ts
@@ -8,6 +8,7 @@ const baseInput = {
   rightSidebarAvailable: true,
   rightSidebarLoaded: true,
   isRightSidebarCollapsed: false,
+  isRightSidebarMaximized: false,
   rsbDetached: false,
 };
 
@@ -24,5 +25,31 @@ describe('rightSidebarOwnsRailChromeActions', () => {
     ['the sidebar is docked right', { rightSidebarSide: 'right' as const }],
   ])('keeps the ContentHeader as owner when %s', (_reason, overrides) => {
     expect(rightSidebarOwnsRailChromeActions({ ...baseInput, ...overrides })).toBe(false);
+  });
+
+  it('assigns the hit hole to a rendered maximized right-docked sidebar', () => {
+    expect(
+      rightSidebarOwnsRailChromeActions({
+        ...baseInput,
+        rightSidebarSide: 'right',
+        isRightSidebarMaximized: true,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['the route has not declared the sidebar', { rightSidebarAvailable: false }],
+    ['the embedded sidebar has not loaded', { rightSidebarLoaded: false }],
+    ['the sidebar is collapsed', { isRightSidebarCollapsed: true }],
+    ['the sidebar is detached', { rsbDetached: true }],
+  ])('keeps the ContentHeader as owner for a maximized right sidebar when %s', (_reason, overrides) => {
+    expect(
+      rightSidebarOwnsRailChromeActions({
+        ...baseInput,
+        rightSidebarSide: 'right',
+        isRightSidebarMaximized: true,
+        ...overrides,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/components/layout/__tests__/railChromeActions.test.ts
+++ b/apps/desktop/src/renderer/components/layout/__tests__/railChromeActions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { rightSidebarOwnsRailChromeActions } from '../railChromeActions';
+
+const baseInput = {
+  hasRailChromeActions: true,
+  rightSidebarSide: 'left' as const,
+  rightSidebarAvailable: true,
+  rightSidebarLoaded: true,
+  isRightSidebarCollapsed: false,
+  rsbDetached: false,
+};
+
+describe('rightSidebarOwnsRailChromeActions', () => {
+  it('assigns the hit hole to a rendered, expanded left-side right sidebar', () => {
+    expect(rightSidebarOwnsRailChromeActions(baseInput)).toBe(true);
+  });
+
+  it.each([
+    ['the route has not declared the sidebar', { rightSidebarAvailable: false }],
+    ['the embedded sidebar has not loaded', { rightSidebarLoaded: false }],
+    ['the sidebar is collapsed', { isRightSidebarCollapsed: true }],
+    ['the sidebar is detached', { rsbDetached: true }],
+    ['the sidebar is docked right', { rightSidebarSide: 'right' as const }],
+  ])('keeps the ContentHeader as owner when %s', (_reason, overrides) => {
+    expect(rightSidebarOwnsRailChromeActions({ ...baseInput, ...overrides })).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/components/layout/railChromeActions.ts
+++ b/apps/desktop/src/renderer/components/layout/railChromeActions.ts
@@ -4,13 +4,15 @@ export interface RailChromeActionsOwnerInput {
   rightSidebarAvailable: boolean;
   rightSidebarLoaded: boolean;
   isRightSidebarCollapsed: boolean;
+  isRightSidebarMaximized: boolean;
   rsbDetached: boolean;
 }
 
 /**
  * The rail ChromeActions hit hole belongs to the leftmost rendered pane. A
  * saved left-side layout alone is not enough: the right sidebar can be absent
- * while its route capability is resolving, detached, or collapsed.
+ * while its route capability is resolving, detached, or collapsed. Maximized
+ * right sidebars also own the hole because they become the only rendered pane.
  */
 export function rightSidebarOwnsRailChromeActions({
   hasRailChromeActions,
@@ -18,14 +20,14 @@ export function rightSidebarOwnsRailChromeActions({
   rightSidebarAvailable,
   rightSidebarLoaded,
   isRightSidebarCollapsed,
+  isRightSidebarMaximized,
   rsbDetached,
 }: RailChromeActionsOwnerInput): boolean {
+  const isRendered = rightSidebarAvailable && rightSidebarLoaded && !isRightSidebarCollapsed && !rsbDetached;
+
   return (
     hasRailChromeActions &&
-    rightSidebarSide === 'left' &&
-    rightSidebarAvailable &&
-    rightSidebarLoaded &&
-    !isRightSidebarCollapsed &&
-    !rsbDetached
+    isRendered &&
+    (rightSidebarSide === 'left' || isRightSidebarMaximized)
   );
 }

--- a/apps/desktop/src/renderer/components/layout/railChromeActions.ts
+++ b/apps/desktop/src/renderer/components/layout/railChromeActions.ts
@@ -1,0 +1,31 @@
+export interface RailChromeActionsOwnerInput {
+  hasRailChromeActions: boolean;
+  rightSidebarSide: 'left' | 'right';
+  rightSidebarAvailable: boolean;
+  rightSidebarLoaded: boolean;
+  isRightSidebarCollapsed: boolean;
+  rsbDetached: boolean;
+}
+
+/**
+ * The rail ChromeActions hit hole belongs to the leftmost rendered pane. A
+ * saved left-side layout alone is not enough: the right sidebar can be absent
+ * while its route capability is resolving, detached, or collapsed.
+ */
+export function rightSidebarOwnsRailChromeActions({
+  hasRailChromeActions,
+  rightSidebarSide,
+  rightSidebarAvailable,
+  rightSidebarLoaded,
+  isRightSidebarCollapsed,
+  rsbDetached,
+}: RailChromeActionsOwnerInput): boolean {
+  return (
+    hasRailChromeActions &&
+    rightSidebarSide === 'left' &&
+    rightSidebarAvailable &&
+    rightSidebarLoaded &&
+    !isRightSidebarCollapsed &&
+    !rsbDetached
+  );
+}

--- a/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
@@ -100,6 +100,8 @@ interface RightSidebarShellProps {
    * 子窗口不应消费这段空间。
    */
   reserveLeftChromeActions?: boolean;
+  /** 工具面板处于最左 rail 邻位时，顶栏为浮动 ChromeActions 挖 no-drag 命中区。 */
+  railChromeActionsHitHole?: boolean;
   /** 「在新窗口中打开侧边栏」;仅 Win 端 TabBar 内渲染按钮(Mac 走 MainLayout 浮层)。 */
   onDetach?: () => void;
   /** TabBar 横带是否作为窗口拖拽区(见 TabBar 同名 prop):主窗口内嵌形态传
@@ -133,6 +135,7 @@ export function RightSidebarShell({
   panelSide = 'right',
   onAllTabsClosed,
   reserveLeftChromeActions = false,
+  railChromeActionsHitHole = false,
 }: RightSidebarShellProps) {
   const { isFullscreen } = useMacFullscreen();
   const chromeActionsLeft =
@@ -383,6 +386,19 @@ export function RightSidebarShell({
           className="relative flex h-[46px] shrink-0 flex-none items-center border-b border-[var(--border-default)] bg-[var(--panel-bg)] px-2"
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         >
+          {railChromeActionsHitHole && (
+            <div
+              aria-hidden
+              data-testid="right-sidebar-rail-chrome-actions-hit-hole"
+              className="absolute left-0 top-0 h-full"
+              style={
+                {
+                  width: CHROME_ACTIONS_GEOMETRY.clusterWidth,
+                  WebkitAppRegion: 'no-drag',
+                } as React.CSSProperties
+              }
+            />
+          )}
           {leftChromeActionsSpacerWidth > 0 && (
             <div
               aria-hidden

--- a/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
@@ -100,7 +100,7 @@ interface RightSidebarShellProps {
    * 子窗口不应消费这段空间。
    */
   reserveLeftChromeActions?: boolean;
-  /** 工具面板处于最左 rail 邻位时，顶栏为浮动 ChromeActions 挖 no-drag 命中区。 */
+  /** 工具面板处于最左 rail 邻位时，顶栏为浮动 ChromeActions 挖 no-drag 命中区并预留布局空间。 */
   railChromeActionsHitHole?: boolean;
   /** 「在新窗口中打开侧边栏」;仅 Win 端 TabBar 内渲染按钮(Mac 走 MainLayout 浮层)。 */
   onDetach?: () => void;
@@ -148,6 +148,10 @@ export function RightSidebarShell({
     unifiedTopbar && reserveLeftChromeActions
       ? chromeActionsLeft + CHROME_ACTIONS_GEOMETRY.clusterWidth
       : 0;
+  // rail 邻位时浮动 ChromeActions 从工具面板左缘开始。命中洞保持 absolute
+  // 对齐窗口坐标；另加正常流中的 spacer，把 TabStrip 推到按钮簇之后。
+  const railChromeActionsSpacerWidth =
+    unifiedTopbar && railChromeActionsHitHole ? CHROME_ACTIONS_GEOMETRY.clusterWidth : 0;
   const { t } = useTranslation();
 
   // RSB browser bridge (Phase 2):在 Shell 整个生命周期内只 init 一次。bridge 内部
@@ -394,6 +398,19 @@ export function RightSidebarShell({
               style={
                 {
                   width: CHROME_ACTIONS_GEOMETRY.clusterWidth,
+                  WebkitAppRegion: 'no-drag',
+                } as React.CSSProperties
+              }
+            />
+          )}
+          {railChromeActionsSpacerWidth > 0 && (
+            <div
+              aria-hidden
+              data-testid="right-sidebar-rail-chrome-actions-spacer"
+              className="h-full shrink-0"
+              style={
+                {
+                  width: railChromeActionsSpacerWidth,
                   WebkitAppRegion: 'no-drag',
                 } as React.CSSProperties
               }

--- a/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
@@ -151,7 +151,9 @@ export function RightSidebarShell({
   // rail 邻位时浮动 ChromeActions 从工具面板左缘开始。命中洞保持 absolute
   // 对齐窗口坐标；另加正常流中的 spacer，把 TabStrip 推到按钮簇之后。
   const railChromeActionsSpacerWidth =
-    unifiedTopbar && railChromeActionsHitHole ? CHROME_ACTIONS_GEOMETRY.clusterWidth : 0;
+    unifiedTopbar && !isFullscreen && railChromeActionsHitHole
+      ? CHROME_ACTIONS_GEOMETRY.clusterWidth
+      : 0;
   const { t } = useTranslation();
 
   // RSB browser bridge (Phase 2):在 Shell 整个生命周期内只 init 一次。bridge 内部
@@ -390,7 +392,7 @@ export function RightSidebarShell({
           className="relative flex h-[46px] shrink-0 flex-none items-center border-b border-[var(--border-default)] bg-[var(--panel-bg)] px-2"
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         >
-          {railChromeActionsHitHole && (
+          {!isFullscreen && railChromeActionsHitHole && (
             <div
               aria-hidden
               data-testid="right-sidebar-rail-chrome-actions-hit-hole"

--- a/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
@@ -421,6 +421,24 @@ describe('RightSidebarShell empty state', () => {
     ).toBe('no-drag');
   });
 
+  it('does not reserve rail ChromeActions space in fullscreen', async () => {
+    installElectronApi(tabsIpc, true);
+    render(
+      createElement(RightSidebarShell, {
+        sessionId: 's1',
+        workdir: '/tmp/repo',
+        remoteHostId: null,
+        isMac: true,
+        unifiedTopbar: true,
+        railChromeActionsHitHole: true,
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByTestId('right-sidebar-unified-topbar')).toBeTruthy());
+    expect(screen.queryByTestId('right-sidebar-rail-chrome-actions-hit-hole')).toBeNull();
+    expect(screen.queryByTestId('right-sidebar-rail-chrome-actions-spacer')).toBeNull();
+  });
+
   it('renders detach/maximize in the topbar when panel is docked left (mac M2), spacer when right or maximized', async () => {
     // 贴左:窗口右上浮层只剩折叠 toggle(恒钉窗口右上角,2026-07-09 Lizi 口径),
     // detach / maximize 是面板自属控件,必须由 Shell 顶栏右端自渲染,否则面板

--- a/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
@@ -395,6 +395,27 @@ describe('RightSidebarShell empty state', () => {
     );
   });
 
+  it('adds a no-drag hit hole when the unified topbar is the rail ChromeActions owner', async () => {
+    render(
+      createElement(RightSidebarShell, {
+        sessionId: 's1',
+        workdir: '/tmp/repo',
+        remoteHostId: null,
+        isMac: true,
+        unifiedTopbar: true,
+        railChromeActionsHitHole: true,
+      }),
+    );
+
+    const topbar = await screen.findByTestId('right-sidebar-unified-topbar');
+    const hitHole = screen.getByTestId('right-sidebar-rail-chrome-actions-hit-hole');
+    expect(topbar.contains(hitHole)).toBe(true);
+    expect(hitHole.style.width).toBe(`${CHROME_ACTIONS_GEOMETRY.clusterWidth}px`);
+    expect(
+      (hitHole.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
+    ).toBe('no-drag');
+  });
+
   it('renders detach/maximize in the topbar when panel is docked left (mac M2), spacer when right or maximized', async () => {
     // 贴左:窗口右上浮层只剩折叠 toggle(恒钉窗口右上角,2026-07-09 Lizi 口径),
     // detach / maximize 是面板自属控件,必须由 Shell 顶栏右端自渲染,否则面板

--- a/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
@@ -414,6 +414,11 @@ describe('RightSidebarShell empty state', () => {
     expect(
       (hitHole.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
     ).toBe('no-drag');
+    const spacer = screen.getByTestId('right-sidebar-rail-chrome-actions-spacer');
+    expect(spacer.style.width).toBe(`${CHROME_ACTIONS_GEOMETRY.clusterWidth}px`);
+    expect(
+      (spacer.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
+    ).toBe('no-drag');
   });
 
   it('renders detach/maximize in the topbar when panel is docked left (mac M2), spacer when right or maximized', async () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
@@ -435,8 +435,10 @@ describe('RightSidebarShell empty state', () => {
     );
 
     await waitFor(() => expect(screen.getByTestId('right-sidebar-unified-topbar')).toBeTruthy());
-    expect(screen.queryByTestId('right-sidebar-rail-chrome-actions-hit-hole')).toBeNull();
-    expect(screen.queryByTestId('right-sidebar-rail-chrome-actions-spacer')).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByTestId('right-sidebar-rail-chrome-actions-hit-hole')).toBeNull();
+      expect(screen.queryByTestId('right-sidebar-rail-chrome-actions-spacer')).toBeNull();
+    });
   });
 
   it('renders detach/maximize in the topbar when panel is docked left (mac M2), spacer when right or maximized', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 非全屏下左侧栏收窄为 rail 状态后，左上角的侧栏收放按钮和菜单按钮点击被窗口拖拽区域吞掉的问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：rail 收起态左上角 ChromeActions 无法点击
- 本 PR 包含：仅在 macOS 非全屏 rail 态补齐与 ChromeActions 对齐的 Electron `no-drag` 命中区；补充回归测试
- 明确不包含：侧边栏布局、菜单内容、Windows 交互或其他窗口 chrome 改动
- 用户可见变化：rail 态下可正常点击收放侧栏和菜单中的帮助、Issue、检查更新
- 是否存在 breaking change：无

### UI 变化

- 平台：Desktop（macOS）
- 界面效果：无视觉改动；仅修复 rail 状态下现有顶栏按钮的点击命中。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §5「Layout Structure」保留 Sidebar 与 Content Area 的三栏结构；§4「Buttons」保留既有 28px 标题栏图标按钮规格。本次未修改颜色、间距、半径或文案，继续使用现有主题 token。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/layout/__tests__/ContentHeader.chrome-actions.test.tsx --maxWorkers=1
结果：通过，2 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false pnpm test:unit
结果：通过（exit code 0）

pnpm check:dco
结果：通过，1 commit signed off
```

### 手工验证

未执行：当前运行的是已安装 Cindy，未启动本分支的 Desktop 开发实例；回归测试覆盖 macOS 非全屏 rail 与完全收起态。

### 未执行的验证

未执行本分支 Desktop 实机验证（原因同上）；未执行 Windows 实机验证（本次仅新增 macOS 非全屏 Electron drag-region 命中区，Windows 不进入该分支）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 macOS 非全屏的 Desktop rail 状态左上角 ChromeActions 点击区域
- 回滚 / 降级方式：回滚本 PR 的单个 commit；无数据、协议或配置迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因
