### PR TITLE
fix(desktop): 修复跨平台路径大小写判定

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/paths.test.ts
@@ -43,21 +43,17 @@ describe('isPathWithin', () => {
   });
 
   it('大小写: Windows 不敏感, 其它平台敏感(规则 15)', () => {
-    // 两个分支都要锁住 —— 只在当前平台上跑, 另一半会在重构时悄悄回归
-    const original = process.platform;
-    const setPlatform = (value: NodeJS.Platform): void => {
-      Object.defineProperty(process, 'platform', { value, configurable: true });
-    };
-    try {
-      setPlatform('win32');
-      expect(isPathWithin(BASE, path.join(BASE.toUpperCase(), 'SUB'))).toBe(true);
-      expect(isPathWithin(BASE.toUpperCase(), BASE)).toBe(true);
+    // 路径格式和 path 实现都按目标平台构造，避免宿主系统语义污染模拟分支。
+    const windowsBase = path.win32.resolve('C:\\repos\\demo');
+    expect(
+      isPathWithin(windowsBase, path.win32.join(windowsBase.toUpperCase(), 'SUB'), 'win32'),
+    ).toBe(true);
+    expect(isPathWithin(windowsBase.toUpperCase(), windowsBase, 'win32')).toBe(true);
 
-      setPlatform('linux');
-      expect(isPathWithin(BASE, path.join(BASE.toUpperCase(), 'SUB'))).toBe(false);
-      expect(isPathWithin(BASE.toUpperCase(), BASE)).toBe(false);
-    } finally {
-      setPlatform(original);
-    }
+    const posixBase = path.posix.resolve('/repos/demo');
+    expect(isPathWithin(posixBase, path.posix.join(posixBase.toUpperCase(), 'SUB'), 'linux')).toBe(
+      false,
+    );
+    expect(isPathWithin(posixBase.toUpperCase(), posixBase, 'linux')).toBe(false);
   });
 });

--- a/apps/desktop/src/main/hook-control/paths.ts
+++ b/apps/desktop/src/main/hook-control/paths.ts
@@ -11,12 +11,6 @@
 
 import path from 'node:path';
 
-/** 路径比较前的规范化。Windows 大小写不敏感(规则 15)。 */
-function normalizePathForCompare(p: string): string {
-  const resolved = path.resolve(p);
-  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
-}
-
 /**
  * target 是否落在 base 目录内(含相等)。Windows 大小写不敏感(规则 15)。
  *
@@ -25,9 +19,21 @@ function normalizePathForCompare(p: string): string {
  * 输入(SessionMeta.workDir 在 DB workingDir 为 null 时落成空串, 见
  * maker-host/session-storage.ts)。安全判定在这里 fail closed
  * (PR #733 review 指出)。
+ *
+ * platform 参数是跨平台测试缝：Node 的默认 path 实现在进程启动时就按宿主系统固定，
+ * 只 mock process.platform 并不能切换 path.relative 的大小写语义。
  */
-export function isPathWithin(base: string, target: string): boolean {
+export function isPathWithin(
+  base: string,
+  target: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
   if (base.trim() === '' || target.trim() === '') return false;
-  const rel = path.relative(normalizePathForCompare(base), normalizePathForCompare(target));
-  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  const normalize = (value: string): string => {
+    const resolved = pathApi.resolve(value);
+    return platform === 'win32' ? resolved.toLowerCase() : resolved;
+  };
+  const rel = pathApi.relative(normalize(base), normalize(target));
+  return rel === '' || (!rel.startsWith('..') && !pathApi.isAbsolute(rel));
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Windows 环境模拟 Linux 路径大小写时，Node 默认 path 实现仍按 Windows 语义比较、导致回归测试误报的问题。路径判定现在显式选择目标平台的 path 实现，测试同时覆盖 Windows 大小写不敏感和 POSIX 大小写敏感语义。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`isPathWithin` 的跨平台 path 选择和大小写回归测试修复
- 明确不包含：业务范围、UI、协议、数据库或移动端改动
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/hook-control/__tests__/paths.test.ts
结果：5 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm exec prettier --check apps/desktop/src/main/hook-control/paths.ts apps/desktop/src/main/hook-control/__tests__/paths.test.ts
结果：通过

pnpm test:unit
结果：通过（全仓单测；Desktop、Mobile、所有 packages 和 protocol workspaces 均通过）

pnpm check:dco
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：仅 Desktop 主进程的纯路径包含判定；默认运行时仍按 `process.platform` 选择 Windows 或 POSIX path 实现。已在 Windows 环境覆盖两种语义。
- 移动端冷更判断：改动未触及 `apps/mobile`、原生配置、原生依赖或 runtime fingerprint，不会触发移动端冷更。
- 回滚 / 降级方式：回退本 PR commit 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因