### PR TITLE
fix(responses-chat-bridge): 跳过 auto-compact 产生的空 user 消息

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -411,6 +411,43 @@ describe('translateResponsesRequest', () => {
     ]);
   });
 
+  it('drops empty user messages produced by auto-compact collapsing image-only turns', () => {
+    // Codex auto-compact 的 replacement_history 把「无文字纯图片」用户消息折叠成单个
+    // 空 input_text；桥接层若原样透传，Moonshot/Kimi 会以
+    // "the message at position N with role 'user' must not be empty" 拒绝整次请求。
+    const out = translateResponsesRequest(base({
+      input: [
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '第一条' }] },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '' }] },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '   ' }] },
+        { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '继续' }] },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '继续' }] },
+      ],
+    }));
+
+    expect(out.messages).toEqual([
+      { role: 'user', content: '第一条' },
+      { role: 'assistant', content: '继续' },
+      { role: 'user', content: '继续' },
+    ]);
+  });
+
+  it('keeps image-only user messages (no text) as valid multimodal content', () => {
+    const imageUrl = 'data:image/png;base64,aW1hZ2U=';
+    const out = translateResponsesRequest(base({
+      input: [{
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_image', image_url: imageUrl }],
+      }],
+    }), { capabilities: { imageInput: 'image_url' } });
+
+    expect(out.messages).toEqual([{
+      role: 'user',
+      content: [{ type: 'image_url', image_url: { url: imageUrl } }],
+    }]);
+  });
+
   it('keeps pure-text JSON shape unchanged when image capability is enabled', () => {
     const out = translateResponsesRequest(base({
       input: [{

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -216,7 +216,13 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
         assistant = flushAssistant(messages, assistant, opts);
         const role = normalizeRole(item.role, opts.developerRole);
         if (role === 'user') {
-          messages.push({ role, content });
+          // 空 user(纯空白文本且无图片)整条跳过 —— Codex auto-compact 会把
+          // 无文字的纯图片消息折叠成空 input_text,部分上游(Moonshot/Kimi)
+          // 会以 "message at position N with role 'user' must not be empty" 400。
+          const isEmptyUser =
+            (typeof content === 'string' && content.trim().length === 0)
+            || (Array.isArray(content) && content.length === 0);
+          if (!isEmptyUser) messages.push({ role, content });
         } else {
           if (typeof content !== 'string') {
             throw new UnsupportedResponsesFeatureError(`input[${index}].content`);


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端在 Codex 会话里发送**纯图片、无文字**的消息后，若该会话触发 Codex auto-compact，compaction 的 `replacement_history` 会把纯图片消息折叠成单个空 `input_text` block（图片和 `<image>` 文本标记都丢失），产生空 user 消息。会话恢复重放历史经 `responses-chat-bridge` 转发到 Moonshot/Kimi 上游时，上游以 `the message at position N with role 'user' must not be empty` 拒绝整次请求（400）。

本修复在桥接层 `translateInput` 对**纯空白且无图片**的 user 消息整条跳过，与既有「空 assistant 整条跳过」口径对齐；带图片的多模态 user 消息不受影响。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无独立 issue；关联同一 compacted blob 族问题 #780（加密内容剥离掏空压缩块）、#771（OpenAI 兼容上游 input_image 桥接缺口）
- 本 PR 包含：
  - `packages/responses-chat-bridge/src/translate-request.ts`：空 user 跳过
  - `packages/responses-chat-bridge/src/__tests__/translate-request.test.ts`：2 个回归用例（空 user 跳过、纯图片 user 保留为多模态）
- 明确不包含：Codex core compaction 丢图片的上游根因修复（需在 Codex 上游不塌缩多模态消息，超出本仓范围）；image capability 扩大到 Kimi 以外上游
- 用户可见变化：修复「手机端发纯图片消息 + auto-compact 后，Kimi 路由会话恢复重放报 upstream_error 400」；无其它可见变化
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-chat-bridge test
结果：3 个测试文件 64 个用例全过（含新增 2 个）

pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果：tsc --noEmit 通过

pnpm check:dco
结果：DCO check passed（1 commit signed off, range upstream/main..HEAD）
```

### 手工验证

根因定位基于本机真实 rollout 复盘：`~/Library/Application Support/Cindy/codex-home/sessions/2026/07/27/rollout-...019fa24f....jsonl` 第 4927 行 compacted 记录的 `replacement_history` 含 4 条空 user（位置 18/20/22/23），第 4932 行即上游 400 `must not be empty`。修复针对该精确路径。

### 未执行的验证

- 全仓 `pnpm test:unit`：遵循「不在本地跑全量单测」的约束，只跑了受影响 package 的定向测试与 typecheck；全量门禁以 CI 为准。
- 真实 Kimi 上游端到端重放：需要触发 auto-compact 的实机会话，本地无法稳定复现；回归用例已按 rollout 实测的输入形态构造。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 `responses-chat-bridge` 的 Responses→Chat 请求翻译；只影响「纯空白无图片的 user 消息」这一种此前必然导致上游 400 的输入，不改变任何合法消息的翻译结果。带图片多模态消息行为不变。
- 回滚 / 降级方式：revert 本 commit 即恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（commit message 含根因与复现路径）
- [x] 已确认测试结果或说明未执行原因
