### PR TITLE
fix(mobile): clarify paired desktop version label

### DIFF
--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -743,9 +743,9 @@ export default function SettingsScreen() {
                 <Text style={styles.rowLabel}>{t('settings.version.currentLabel')}</Text>
                 <Text style={styles.versionValue} numberOfLines={1}>{t('settings.version.bundleVersion', { version: appVersion })}</Text>
                 <Text style={styles.rowDetail} numberOfLines={1} testID="settings.otaVersion">{t('settings.version.otaVersion', { version: otaVersion })}</Text>
-                {/* 二级版本号:自建线打包所配对的桌面产品线版本(0.0.x);仅自建线且已注入时显示 */}
+                {/* 二级版本号:自建线打包所配对的桌面产品线版本(0.0.x),不是在线电脑的实时版本;仅自建线且已注入时显示 */}
                 {IS_OTA_SELFHOST && DESKTOP_PACKAGE_VERSION ? (
-                  <Text style={styles.rowDetail} numberOfLines={1} testID="settings.desktopVersion">{t('settings.version.desktopVersion', { version: DESKTOP_PACKAGE_VERSION })}</Text>
+                  <Text style={styles.rowDetail} numberOfLines={1} testID="settings.desktopVersion">{t('settings.version.pairedDesktopVersion', { version: DESKTOP_PACKAGE_VERSION })}</Text>
                 ) : null}
                 {IS_TESTFLIGHT_BUILD ? (
                   <Text style={styles.rowDetail} numberOfLines={2} testID="settings.testFlightUpdateHint">

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -224,5 +224,11 @@ describe('mobile settings overview', () => {
     expect(source).toContain(
       "testID=\"settings.otaVersion\">{t('settings.version.otaVersion', { version: otaVersion })}",
     );
+    expect(source).toContain(
+      "testID=\"settings.desktopVersion\">{t('settings.version.pairedDesktopVersion', { version: DESKTOP_PACKAGE_VERSION })}",
+    );
+    expect(source).not.toContain("'settings.version.desktopVersion'");
+    expect(i18n.t('settings.version.pairedDesktopVersion', { version: '0.1.18' }))
+      .toBe('配套桌面版本 0.1.18');
   });
 });

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -16,7 +16,7 @@
     "currentLabel": "Current Version",
     "bundleVersion": "App package {{version}}",
     "otaVersion": "OTA version {{version}}",
-    "desktopVersion": "Desktop {{version}}",
+    "pairedDesktopVersion": "Matching desktop release {{version}}",
     "devNoOta": "Development build; OTA updates unavailable",
     "checkAction": "Check for Updates",
     "testFlightCheckAction": "Check for Content Updates",

--- a/apps/mobile/src/i18n/locales/ja/settings.json
+++ b/apps/mobile/src/i18n/locales/ja/settings.json
@@ -16,7 +16,7 @@
     "currentLabel": "現在のバージョン",
     "bundleVersion": "アプリ本体 {{version}}",
     "otaVersion": "OTA バージョン {{version}}",
-    "desktopVersion": "デスクトップ版 {{version}}",
+    "pairedDesktopVersion": "対応デスクトップ版 {{version}}",
     "devNoOta": "開発ビルドのため OTA 更新は利用できません",
     "checkAction": "更新を確認",
     "testFlightCheckAction": "コンテンツ更新を確認",

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -16,7 +16,7 @@
     "currentLabel": "현재 버전",
     "bundleVersion": "앱 패키지 {{version}}",
     "otaVersion": "OTA 버전 {{version}}",
-    "desktopVersion": "데스크톱 버전 {{version}}",
+    "pairedDesktopVersion": "연동 대상 데스크톱 버전 {{version}}",
     "devNoOta": "개발 빌드에서는 OTA 업데이트를 사용할 수 없습니다",
     "checkAction": "업데이트 확인",
     "testFlightCheckAction": "콘텐츠 업데이트 확인",

--- a/apps/mobile/src/i18n/locales/zh-CN/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/settings.json
@@ -16,7 +16,7 @@
     "currentLabel": "当前版本",
     "bundleVersion": "整包版本 {{version}}",
     "otaVersion": "热更版本 {{version}}",
-    "desktopVersion": "桌面版 {{version}}",
+    "pairedDesktopVersion": "配套桌面版本 {{version}}",
     "devNoOta": "开发版，热更不可用",
     "checkAction": "检查更新",
     "testFlightCheckAction": "检查内容更新",


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端设置页展示的是构建时注入的配套桌面产品线版本，并不是当前在线电脑的实时版本。本 PR 将容易误解的“桌面版”改为“配套桌面版本”，避免用户把静态值当成已连接桌面的实际版本。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #800
- 本 PR 包含：重命名该设置项的 i18n key；同步 zh-CN / en / ja / ko 文案；补充回归测试。
- 明确不包含：不读取 `DeviceView.appVersion`，不新增按设备展示的实时版本，也不修改 device-link、IPC 或协议。
- 用户可见变化：自建线移动端“设置 → 版本”中的 `桌面版 0.1.18` 改为 `配套桌面版本 0.1.18`。
- 是否存在 breaking change：无。

### UI 变化

改动后界面文字（移动端“设置 → 版本”；沿用原有布局、字号、颜色和语义 token）：

```html
<section aria-label="版本">
  <div>整包版本 0.1.0</div>
  <div>热更版本 dbae5a7e</div>
  <div>配套桌面版本 0.1.18</div>
</section>
```

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11 Voice & Content；文案保持克制、直接，准确说明该值是构建时配套版本。文案继续通过 i18n key 提供，并同步四种语言。此次未修改组件结构或样式，Light / Dark 均继续使用原有主题样式。

## 怎么验证的

### 自动验证

```text
pnpm check:i18n
结果：通过（四种语言 key 一致；仅保留仓库已有非阻塞警告）

pnpm check:i18n-glossary
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/mobileSettings.test.ts
结果：通过（8 tests）

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过。当前机器 8-worker 下一个无关 Desktop Git 测试会因资源竞争超时；单独复跑通过（19 tests），随后仅将本次测试进程的可用并行度降为 4，未跳过测试，完整 unit tier 全部通过。
```

### 手工验证

审阅移动端设置页的渲染路径与四语言资源；上方 HTML 给出改动后的界面文字证据。

### 未执行的验证

未启动 Android / iOS 模拟器或真机进行目检：本 PR 仅替换现有单行版本文案，不改布局、样式、交互、原生配置或 runtime fingerprint。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅自建线且构建时注入 `DESKTOP_PACKAGE_VERSION` 时显示的移动端设置文案；不影响工作目录、Agent 进程、会话数据、IPC、推送事件或设备连接。
- 回滚 / 降级方式：恢复原 i18n key 与四语言文案即可；无数据迁移或协议回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外产品文档）
- [x] 已确认测试结果或说明未执行原因
