### PR TITLE
fix(desktop): 显示 Web Search 实际查询内容

### DIFF
--- a/apps/desktop/src/main/__tests__/codexTranslator.test.ts
+++ b/apps/desktop/src/main/__tests__/codexTranslator.test.ts
@@ -287,6 +287,12 @@ describe('webSearch', () => {
       query: '',
       action: { type: 'findInPage', url: 'https://example.com/page', pattern: 'needle' },
     });
+    feedItem('started', {
+      type: 'webSearch',
+      id: 'ws-find-escaped',
+      query: '',
+      action: { type: 'findInPage', url: 'https://example.com/page', pattern: "foo'\\bar" },
+    });
 
     expect(coll.events.map((event) => (
       event.data as { input: { query: string } }
@@ -294,11 +300,17 @@ describe('webSearch', () => {
       'first query ...',
       'https://example.com/page',
       "'needle' in https://example.com/page",
+      "'foo\\'\\\\bar' in https://example.com/page",
     ]);
   });
 
-  it('started 参数为空时等 updated 补齐，且只落一条 tool_use', () => {
-    feedItem('started', { type: 'webSearch', id: 'ws-late', query: '', action: null });
+  it('started 只有 legacy query 时等 updated action 补齐，且只落一条 tool_use', () => {
+    feedItem('started', {
+      type: 'webSearch',
+      id: 'ws-late',
+      query: 'placeholder query',
+      action: null,
+    });
     expect(coll.events).toHaveLength(0);
 
     feedItem('updated', {
@@ -319,7 +331,34 @@ describe('webSearch', () => {
       'tool_result_full',
       'tool_result',
     ]);
-    expect((coll.events[0].data as { input: { query: string } }).input.query).toBe('late query');
+    expect((coll.events[0].data as { input: unknown }).input).toEqual({
+      query: 'late query',
+      action: { type: 'search', query: 'late query', queries: null },
+    });
+  });
+
+  it('只有 legacy query 时在 completed 补发调用记录', () => {
+    feedItem('started', {
+      type: 'webSearch',
+      id: 'ws-legacy-only',
+      query: 'legacy query',
+      action: null,
+    });
+    expect(coll.events).toHaveLength(0);
+
+    feedItem('completed', {
+      type: 'webSearch',
+      id: 'ws-legacy-only',
+      query: 'legacy query',
+      action: null,
+    });
+
+    expect(coll.events.map((event) => event.type)).toEqual([
+      'tool_use',
+      'tool_result_full',
+      'tool_result',
+    ]);
+    expect((coll.events[0].data as { input: { query: string } }).input.query).toBe('legacy query');
   });
 
   it('缺失 started/updated 时 completed 仍先补 tool_use', () => {
@@ -336,6 +375,14 @@ describe('webSearch', () => {
       'tool_result',
     ]);
     expect((coll.events[0].data as { input: { query: string } }).input.query).toBe('completed query');
+  });
+
+  it('completed 仍无有效参数时不生成空白调用记录', () => {
+    feedItem('started', { type: 'webSearch', id: 'ws-empty', query: '', action: null });
+    feedItem('updated', { type: 'webSearch', id: 'ws-empty', query: '', action: null });
+    feedItem('completed', { type: 'webSearch', id: 'ws-empty', query: '', action: null });
+
+    expect(coll.events).toHaveLength(0);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/codexTranslator.test.ts
+++ b/apps/desktop/src/main/__tests__/codexTranslator.test.ts
@@ -252,6 +252,91 @@ describe('webSearch', () => {
     feedItem('updated', { type: 'webSearch', id: 'ws2', query: 'x' });
     expect(coll.events).toHaveLength(0);
   });
+
+  it('优先从 action 归一实际查询内容并保留完整参数', () => {
+    const action = {
+      type: 'search',
+      query: 'actual query',
+      queries: ['actual query', 'backup query'],
+    };
+    feedItem('started', { type: 'webSearch', id: 'ws-action', query: '', action });
+
+    expect(coll.events).toHaveLength(1);
+    expect((coll.events[0].data as { input: unknown }).input).toEqual({
+      query: 'actual query',
+      action,
+    });
+  });
+
+  it('多查询、打开页面和页内查找都生成可读摘要', () => {
+    feedItem('started', {
+      type: 'webSearch',
+      id: 'ws-many',
+      query: '',
+      action: { type: 'search', query: null, queries: ['', 'first query', 'second query'] },
+    });
+    feedItem('started', {
+      type: 'webSearch',
+      id: 'ws-open',
+      query: '',
+      action: { type: 'openPage', url: 'https://example.com/page' },
+    });
+    feedItem('started', {
+      type: 'webSearch',
+      id: 'ws-find',
+      query: '',
+      action: { type: 'findInPage', url: 'https://example.com/page', pattern: 'needle' },
+    });
+
+    expect(coll.events.map((event) => (
+      event.data as { input: { query: string } }
+    ).input.query)).toEqual([
+      'first query ...',
+      'https://example.com/page',
+      "'needle' in https://example.com/page",
+    ]);
+  });
+
+  it('started 参数为空时等 updated 补齐，且只落一条 tool_use', () => {
+    feedItem('started', { type: 'webSearch', id: 'ws-late', query: '', action: null });
+    expect(coll.events).toHaveLength(0);
+
+    feedItem('updated', {
+      type: 'webSearch',
+      id: 'ws-late',
+      query: '',
+      action: { type: 'search', query: 'late query', queries: null },
+    });
+    feedItem('completed', {
+      type: 'webSearch',
+      id: 'ws-late',
+      query: '',
+      action: { type: 'search', query: 'late query', queries: null },
+    });
+
+    expect(coll.events.map((event) => event.type)).toEqual([
+      'tool_use',
+      'tool_result_full',
+      'tool_result',
+    ]);
+    expect((coll.events[0].data as { input: { query: string } }).input.query).toBe('late query');
+  });
+
+  it('缺失 started/updated 时 completed 仍先补 tool_use', () => {
+    feedItem('completed', {
+      type: 'webSearch',
+      id: 'ws-completed-only',
+      query: '',
+      action: { type: 'search', query: 'completed query', queries: null },
+    });
+
+    expect(coll.events.map((event) => event.type)).toEqual([
+      'tool_use',
+      'tool_result_full',
+      'tool_result',
+    ]);
+    expect((coll.events[0].data as { input: { query: string } }).input.query).toBe('completed query');
+  });
 });
 
 // ── fileChange ──────────────────────────────────────────────────────────────

--- a/apps/desktop/src/main/__tests__/codexTranslator.test.ts
+++ b/apps/desktop/src/main/__tests__/codexTranslator.test.ts
@@ -268,7 +268,7 @@ describe('webSearch', () => {
     });
   });
 
-  it('多查询、打开页面和页内查找都生成可读摘要', () => {
+  it('兼容 app-server snake_case 与历史 camelCase action 并生成可读摘要', () => {
     feedItem('started', {
       type: 'webSearch',
       id: 'ws-many',
@@ -279,13 +279,13 @@ describe('webSearch', () => {
       type: 'webSearch',
       id: 'ws-open',
       query: '',
-      action: { type: 'openPage', url: 'https://example.com/page' },
+      action: { type: 'open_page', url: 'https://example.com/page' },
     });
     feedItem('started', {
       type: 'webSearch',
       id: 'ws-find',
       query: '',
-      action: { type: 'findInPage', url: 'https://example.com/page', pattern: 'needle' },
+      action: { type: 'find_in_page', url: 'https://example.com/page', pattern: 'needle' },
     });
     feedItem('started', {
       type: 'webSearch',
@@ -348,7 +348,7 @@ describe('webSearch', () => {
       type: 'webSearch',
       id: 'ws-final-action',
       query: '',
-      action: { type: 'openPage', url: 'https://example.com/final' },
+      action: { type: 'open_page', url: 'https://example.com/final' },
     });
 
     expect(coll.events.map((event) => event.type)).toEqual([
@@ -371,7 +371,7 @@ describe('webSearch', () => {
         toolName: 'web_search',
         input: {
           query: 'https://example.com/final',
-          action: { type: 'openPage', url: 'https://example.com/final' },
+          action: { type: 'open_page', url: 'https://example.com/final' },
         },
       },
     ]);

--- a/apps/desktop/src/main/__tests__/codexTranslator.test.ts
+++ b/apps/desktop/src/main/__tests__/codexTranslator.test.ts
@@ -337,6 +337,46 @@ describe('webSearch', () => {
     });
   });
 
+  it('completed 的权威 action 变化时用同一 id 补发 tool_use 更新', () => {
+    feedItem('started', {
+      type: 'webSearch',
+      id: 'ws-final-action',
+      query: '',
+      action: { type: 'search', query: 'early query', queries: null },
+    });
+    feedItem('completed', {
+      type: 'webSearch',
+      id: 'ws-final-action',
+      query: '',
+      action: { type: 'openPage', url: 'https://example.com/final' },
+    });
+
+    expect(coll.events.map((event) => event.type)).toEqual([
+      'tool_use',
+      'tool_use',
+      'tool_result_full',
+      'tool_result',
+    ]);
+    expect(coll.events.slice(0, 2).map((event) => event.data)).toEqual([
+      {
+        toolUseId: 'ws-final-action',
+        toolName: 'web_search',
+        input: {
+          query: 'early query',
+          action: { type: 'search', query: 'early query', queries: null },
+        },
+      },
+      {
+        toolUseId: 'ws-final-action',
+        toolName: 'web_search',
+        input: {
+          query: 'https://example.com/final',
+          action: { type: 'openPage', url: 'https://example.com/final' },
+        },
+      },
+    ]);
+  });
+
   it('completed 快照丢失字段时仍用 started 的 legacy query 补发调用记录', () => {
     feedItem('started', {
       type: 'webSearch',

--- a/apps/desktop/src/main/__tests__/codexTranslator.test.ts
+++ b/apps/desktop/src/main/__tests__/codexTranslator.test.ts
@@ -337,7 +337,7 @@ describe('webSearch', () => {
     });
   });
 
-  it('只有 legacy query 时在 completed 补发调用记录', () => {
+  it('completed 快照丢失字段时仍用 started 的 legacy query 补发调用记录', () => {
     feedItem('started', {
       type: 'webSearch',
       id: 'ws-legacy-only',
@@ -349,7 +349,7 @@ describe('webSearch', () => {
     feedItem('completed', {
       type: 'webSearch',
       id: 'ws-legacy-only',
-      query: 'legacy query',
+      query: '',
       action: null,
     });
 

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -121,6 +121,44 @@ describe('update_plan tool_use persistence', () => {
     );
   });
 
+  it('updates the existing web_search row when completed carries authoritative input', async () => {
+    const firstPersistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'search-1',
+        toolName: 'web_search',
+        input: { query: 'early query', action: { type: 'search', query: 'early query' } },
+      },
+      null,
+    );
+    const secondPersistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'search-1',
+        toolName: 'web_search',
+        input: { query: 'https://example.com/final', action: { type: 'openPage', url: 'https://example.com/final' } },
+      },
+      null,
+    );
+
+    expect(secondPersistId).toBe(firstPersistId);
+
+    await flushWrites();
+    expect(createMessage).toHaveBeenCalledTimes(1);
+    expect(updateMessageContent).toHaveBeenCalledWith(
+      SESSION,
+      firstPersistId,
+      {
+        toolUseId: 'search-1',
+        toolName: 'web_search',
+        input: {
+          query: 'https://example.com/final',
+          action: { type: 'openPage', url: 'https://example.com/final' },
+        },
+      },
+    );
+  });
+
   it('does not dedupe ordinary repeated tool_use ids', async () => {
     const firstPersistId = onToolUseEvent(
       SESSION,

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -346,7 +346,7 @@ const toolUseCreatedAtBySession = new Map<string, Map<string, number>>();
  * 需要按 tool_use 的 input.args 去 mediaToolResultFallback 池里认领结果。
  */
 const toolUseInfoBySession = new Map<string, Map<string, { toolName: string; input: unknown }>>();
-const planToolUsePersistIdBySession = new Map<string, Map<string, string>>();
+const updatableToolUsePersistIdBySession = new Map<string, Map<string, string>>();
 
 function rememberToolUseId(sessionId: string, toolUseId: string, createdAt: number): void {
   let set = knownToolUseIdsBySession.get(sessionId);
@@ -384,11 +384,15 @@ function clampAfterLatestToolUse(sessionId: string, toolUseIds: string[], create
   return latestToolUseCreatedAt + 1;
 }
 
-function rememberPlanToolUsePersistId(sessionId: string, toolUseId: string, persistId: string): void {
-  let idMap = planToolUsePersistIdBySession.get(sessionId);
+function isUpdatableToolUse(toolName: string): boolean {
+  return toolName === 'update_plan' || toolName === 'web_search';
+}
+
+function rememberUpdatableToolUsePersistId(sessionId: string, toolUseId: string, persistId: string): void {
+  let idMap = updatableToolUsePersistIdBySession.get(sessionId);
   if (!idMap) {
     idMap = new Map();
-    planToolUsePersistIdBySession.set(sessionId, idMap);
+    updatableToolUsePersistIdBySession.set(sessionId, idMap);
   }
   idMap.set(toolUseId, persistId);
 }
@@ -414,16 +418,16 @@ export function onToolUseEvent(
       input: data.input,
     });
   }
-  const existingPlanPersistId = toolName === 'update_plan' && toolUseId
-    ? planToolUsePersistIdBySession.get(sessionId)?.get(toolUseId)
+  const existingPersistId = isUpdatableToolUse(toolName) && toolUseId
+    ? updatableToolUsePersistIdBySession.get(sessionId)?.get(toolUseId)
     : undefined;
-  if (existingPlanPersistId) {
+  if (existingPersistId) {
     const content = { toolUseId, toolName, input: data.input };
-    enqueueWrite(`tool_use_update:${sessionId}:${existingPlanPersistId}`, () =>
-      updateDbMessageContent(sessionId, existingPlanPersistId, content),
+    enqueueWrite(`tool_use_update:${sessionId}:${existingPersistId}`, () =>
+      updateDbMessageContent(sessionId, existingPersistId, content),
     );
-    notePersistedMessage(sessionId, 'tool_use', existingPlanPersistId);
-    return existingPlanPersistId;
+    notePersistedMessage(sessionId, 'tool_use', existingPersistId);
+    return existingPersistId;
   }
   const persistId = createId();
   const meta = agentMeta ?? lastAgentMetaBySession.get(sessionId) ?? null;
@@ -436,8 +440,8 @@ export function onToolUseEvent(
     agentMeta: meta,
     createdAt,
   });
-  if (toolName === 'update_plan' && toolUseId) {
-    rememberPlanToolUsePersistId(sessionId, toolUseId, persistId);
+  if (isUpdatableToolUse(toolName) && toolUseId) {
+    rememberUpdatableToolUsePersistId(sessionId, toolUseId, persistId);
   }
   notePersistedMessage(sessionId, 'tool_use', persistId);
   return persistId;
@@ -875,7 +879,7 @@ export function resetTurnPersistState(sessionId: string): void {
   knownToolUseIdsBySession.delete(sessionId);
   toolUseCreatedAtBySession.delete(sessionId);
   toolUseInfoBySession.delete(sessionId);
-  planToolUsePersistIdBySession.delete(sessionId);
+  updatableToolUsePersistIdBySession.delete(sessionId);
   lastAgentMetaBySession.delete(sessionId);
   _turnStartedAtBySession.delete(sessionId);
   _turnDedupIdBySession.delete(sessionId);
@@ -1148,7 +1152,7 @@ export function clearSessionPersistState(sessionId: string): void {
   knownToolUseIdsBySession.delete(sessionId);
   toolUseCreatedAtBySession.delete(sessionId);
   toolUseInfoBySession.delete(sessionId);
-  planToolUsePersistIdBySession.delete(sessionId);
+  updatableToolUsePersistIdBySession.delete(sessionId);
   toolResultIdByToolUseId.delete(sessionId);
   pendingFullTextByToolUseId.delete(sessionId);
   toolResultContentByClientId.delete(sessionId);

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -418,6 +418,51 @@ describe('makerChatStore text delta batching', () => {
     expect(messages[0]?.clientId).toBe('assistant-1');
   });
 
+  it('updates a repeated web_search tool_use row in place', () => {
+    onEvent?.({
+      sessionId: SESSION_ID,
+      event: {
+        type: 'tool_use',
+        source: 'codex',
+        data: {
+          toolUseId: 'search-1',
+          toolName: 'web_search',
+          input: { query: 'early query' },
+        },
+      },
+      persistId: 'search-message-1',
+    });
+    onEvent?.({
+      sessionId: SESSION_ID,
+      event: {
+        type: 'tool_use',
+        source: 'codex',
+        data: {
+          toolUseId: 'search-1',
+          toolName: 'web_search',
+          input: {
+            query: 'https://example.com/final',
+            action: { type: 'openPage', url: 'https://example.com/final' },
+          },
+        },
+      },
+      persistId: 'search-message-1',
+    });
+
+    const messages = makerChatStore.getSnapshot(SESSION_ID).messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      clientId: 'search-message-1',
+      role: 'tool_use',
+      toolUseId: 'search-1',
+      toolName: 'web_search',
+      toolInput: {
+        query: 'https://example.com/final',
+        action: { type: 'openPage', url: 'https://example.com/final' },
+      },
+    });
+  });
+
   it('flushes pending text before a permission interaction request on the separate IPC channel', () => {
     const snapshots: Array<{ roles: string[]; pendingPermission: string | null }> = [];
     const unsubscribe = makerChatStore.subscribe(SESSION_ID, () => {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2305,17 +2305,17 @@ export function handleStreamEvent(
       const finalized = finalizeStreamingInState(state);
       const clientId = event.persistId ?? crypto.randomUUID();
 
-      const existingUpdatePlanIdx =
-        toolName === 'update_plan'
+      const existingUpdatableToolIdx =
+        toolName === 'update_plan' || toolName === 'web_search'
           ? finalized.messages.findIndex(
               (m) =>
-                m.role === 'tool_use' && m.toolName === 'update_plan' && m.toolUseId === toolUseId,
+                m.role === 'tool_use' && m.toolName === toolName && m.toolUseId === toolUseId,
             )
           : -1;
-      if (existingUpdatePlanIdx >= 0) {
+      if (existingUpdatableToolIdx >= 0) {
         const messages = finalized.messages.slice();
-        messages[existingUpdatePlanIdx] = {
-          ...messages[existingUpdatePlanIdx],
+        messages[existingUpdatableToolIdx] = {
+          ...messages[existingUpdatableToolIdx],
           content: formatToolUseSummary(toolName, input),
           toolInput: input,
         };

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -878,6 +878,10 @@ function nonEmptyWebSearchText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function quoteWebSearchText(value: string): string {
+  return `'${value.replace(/['\\]/g, (char) => `\\${char}`)}'`;
+}
+
 function webSearchActionDetail(action: WebSearchAction | null | undefined): string {
   if (!action) return '';
   switch (action.type) {
@@ -895,8 +899,8 @@ function webSearchActionDetail(action: WebSearchAction | null | undefined): stri
     case 'findInPage': {
       const url = nonEmptyWebSearchText(action.url);
       const pattern = nonEmptyWebSearchText(action.pattern);
-      if (pattern && url) return `'${pattern}' in ${url}`;
-      if (pattern) return `'${pattern}'`;
+      if (pattern && url) return `${quoteWebSearchText(pattern)} in ${url}`;
+      if (pattern) return quoteWebSearchText(pattern);
       return url;
     }
     default:
@@ -904,11 +908,14 @@ function webSearchActionDetail(action: WebSearchAction | null | undefined): stri
   }
 }
 
-function webSearchInput(item: WebSearchItem): {
+function webSearchInput(
+  item: WebSearchItem,
+  actionDetail = webSearchActionDetail(item.action),
+): {
   query: string;
   action?: WebSearchAction;
 } {
-  const query = webSearchActionDetail(item.action) || nonEmptyWebSearchText(item.query);
+  const query = actionDetail || nonEmptyWebSearchText(item.query);
   return {
     query,
     ...(item.action ? { action: item.action } : {}),
@@ -939,18 +946,19 @@ function handleWebSearch(
   queue: AsyncQueue<AgentEvent>,
   ctx: CodexTranslateContext,
 ): void {
-  const input = webSearchInput(item);
+  const actionDetail = webSearchActionDetail(item.action);
+  const input = webSearchInput(item, actionDetail);
 
   if (phase === 'started') {
     if (ctx.rt.emittedToolUse.has(item.id)) return;
-    // 某些 Codex 版本在 started 只给空 legacy query，updated 才补 action；
-    // 延迟这一条展示事件，避免空参数先落库后无法无损更新。
-    if (!input.query) return;
+    // started 的 legacy query 可能为空或只是占位符，updated 才补真实 action；
+    // 延迟到 action 到达或 completed，避免旧参数先落库后无法无损更新。
+    if (!actionDetail) return;
     emitWebSearchToolUse(item, input, queue, ctx);
     return;
   }
   if (phase === 'updated') {
-    if (ctx.rt.emittedToolUse.has(item.id) || !input.query) return;
+    if (ctx.rt.emittedToolUse.has(item.id) || !actionDetail) return;
     emitWebSearchToolUse(item, input, queue, ctx);
     return;
   }
@@ -960,6 +968,8 @@ function handleWebSearch(
   ctx.rt.emittedToolUse.delete(item.id);
   // 防御缺失 started/updated 的历史或异常事件序列，保持 tool_use → result 顺序。
   if (!toolUseEmitted) {
+    // completed 仍无可展示参数时整条忽略，避免补发空白 tool_use 和孤立 result。
+    if (!input.query) return;
     emitWebSearchToolUse(item, input, queue, ctx);
     ctx.rt.emittedToolUse.delete(item.id);
   }

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -426,8 +426,8 @@ interface McpToolCallItem {
 
 type WebSearchAction =
   | { type: 'search'; query?: string | null; queries?: string[] | null }
-  | { type: 'openPage'; url?: string | null }
-  | { type: 'findInPage'; url?: string | null; pattern?: string | null }
+  | { type: 'open_page' | 'openPage'; url?: string | null }
+  | { type: 'find_in_page' | 'findInPage'; url?: string | null; pattern?: string | null }
   | { type: string; [k: string]: unknown };
 
 interface WebSearchItem {
@@ -905,8 +905,10 @@ function webSearchActionDetail(action: WebSearchAction | null | undefined): stri
       if (queries.length === 0) return '';
       return queries.length > 1 ? `${queries[0]} ...` : queries[0];
     }
+    case 'open_page':
     case 'openPage':
       return nonEmptyWebSearchText(action.url);
+    case 'find_in_page':
     case 'findInPage': {
       const url = nonEmptyWebSearchText(action.url);
       const pattern = nonEmptyWebSearchText(action.pattern);

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -59,6 +59,8 @@ export interface CodexRuntimeState {
   itemTextLen: Map<string, number>;
   /** 已经 emit 过 tool_use 的 item.id (避免 started + 第一次 updated 重复)。 */
   emittedToolUse: Set<string>;
+  /** 尚未 emit 的 Web Search 候选输入，供跨 started/updated/completed 快照补全。 */
+  pendingWebSearchInput: Map<string, WebSearchInput>;
   /**
    * Auth retry-loop dedupe key (`<threadId>|<turnId>`)。daemon 撞 401 时
    * willRetry=true 通知会按 retry 频率 (~每秒) 持续发, 不 dedupe 会让
@@ -84,6 +86,7 @@ export function newCodexRuntimeState(): CodexRuntimeState {
     reasoningTextLen: new Map(),
     itemTextLen: new Map(),
     emittedToolUse: new Set(),
+    pendingWebSearchInput: new Map(),
     lastAuthErrorKey: null,
     networkRetryNotice: null,
   };
@@ -429,6 +432,11 @@ interface WebSearchItem {
   id: string;
   query: string;
   action?: WebSearchAction | null;
+}
+
+interface WebSearchInput {
+  query: string;
+  action?: WebSearchAction;
 }
 
 type PatchApplyStatus = 'inProgress' | 'completed' | 'failed' | 'declined';
@@ -911,10 +919,7 @@ function webSearchActionDetail(action: WebSearchAction | null | undefined): stri
 function webSearchInput(
   item: WebSearchItem,
   actionDetail = webSearchActionDetail(item.action),
-): {
-  query: string;
-  action?: WebSearchAction;
-} {
+): WebSearchInput {
   const query = actionDetail || nonEmptyWebSearchText(item.query);
   return {
     query,
@@ -922,9 +927,24 @@ function webSearchInput(
   };
 }
 
+function rememberWebSearchInput(
+  item: WebSearchItem,
+  input: WebSearchInput,
+  actionDetail: string,
+  ctx: CodexTranslateContext,
+): WebSearchInput {
+  const pending = ctx.rt.pendingWebSearchInput.get(item.id);
+  // 真实 action 优先级最高；在它到达前，保留最新的非空 legacy query 作为兜底。
+  if (input.query && (actionDetail || !webSearchActionDetail(pending?.action))) {
+    ctx.rt.pendingWebSearchInput.set(item.id, input);
+    return input;
+  }
+  return pending ?? input;
+}
+
 function emitWebSearchToolUse(
   item: WebSearchItem,
-  input: ReturnType<typeof webSearchInput>,
+  input: WebSearchInput,
   queue: AsyncQueue<AgentEvent>,
   ctx: CodexTranslateContext,
 ): void {
@@ -947,7 +967,8 @@ function handleWebSearch(
   ctx: CodexTranslateContext,
 ): void {
   const actionDetail = webSearchActionDetail(item.action);
-  const input = webSearchInput(item, actionDetail);
+  const currentInput = webSearchInput(item, actionDetail);
+  const input = rememberWebSearchInput(item, currentInput, actionDetail, ctx);
 
   if (phase === 'started') {
     if (ctx.rt.emittedToolUse.has(item.id)) return;
@@ -966,6 +987,7 @@ function handleWebSearch(
   // completed
   const toolUseEmitted = ctx.rt.emittedToolUse.has(item.id);
   ctx.rt.emittedToolUse.delete(item.id);
+  ctx.rt.pendingWebSearchInput.delete(item.id);
   // 防御缺失 started/updated 的历史或异常事件序列，保持 tool_use → result 顺序。
   if (!toolUseEmitted) {
     // completed 仍无可展示参数时整条忽略，避免补发空白 tool_use 和孤立 result。

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -61,6 +61,8 @@ export interface CodexRuntimeState {
   emittedToolUse: Set<string>;
   /** 尚未 emit 的 Web Search 候选输入，供跨 started/updated/completed 快照补全。 */
   pendingWebSearchInput: Map<string, WebSearchInput>;
+  /** 已 emit 的 Web Search 输入，用于判断 completed 是否带来权威参数更新。 */
+  emittedWebSearchInput: Map<string, WebSearchInput>;
   /**
    * Auth retry-loop dedupe key (`<threadId>|<turnId>`)。daemon 撞 401 时
    * willRetry=true 通知会按 retry 频率 (~每秒) 持续发, 不 dedupe 会让
@@ -87,6 +89,7 @@ export function newCodexRuntimeState(): CodexRuntimeState {
     itemTextLen: new Map(),
     emittedToolUse: new Set(),
     pendingWebSearchInput: new Map(),
+    emittedWebSearchInput: new Map(),
     lastAuthErrorKey: null,
     networkRetryNotice: null,
   };
@@ -949,6 +952,7 @@ function emitWebSearchToolUse(
   ctx: CodexTranslateContext,
 ): void {
   ctx.rt.emittedToolUse.add(item.id);
+  ctx.rt.emittedWebSearchInput.set(item.id, input);
   queue.push({
     type: 'tool_use',
     data: {
@@ -986,14 +990,23 @@ function handleWebSearch(
 
   // completed
   const toolUseEmitted = ctx.rt.emittedToolUse.has(item.id);
+  const emittedInput = ctx.rt.emittedWebSearchInput.get(item.id);
   ctx.rt.emittedToolUse.delete(item.id);
   ctx.rt.pendingWebSearchInput.delete(item.id);
+  ctx.rt.emittedWebSearchInput.delete(item.id);
   // 防御缺失 started/updated 的历史或异常事件序列，保持 tool_use → result 顺序。
   if (!toolUseEmitted) {
     // completed 仍无可展示参数时整条忽略，避免补发空白 tool_use 和孤立 result。
     if (!input.query) return;
     emitWebSearchToolUse(item, input, queue, ctx);
     ctx.rt.emittedToolUse.delete(item.id);
+    ctx.rt.emittedWebSearchInput.delete(item.id);
+  } else if (input.query && JSON.stringify(input) !== JSON.stringify(emittedInput)) {
+    // started/updated 用于实时展示；completed 可能补充权威 URL、pattern 或修正后的
+    // query。沿用同一 toolUseId 补发，由 Desktop 持久层与 renderer 原位更新。
+    emitWebSearchToolUse(item, input, queue, ctx);
+    ctx.rt.emittedToolUse.delete(item.id);
+    ctx.rt.emittedWebSearchInput.delete(item.id);
   }
   queue.push({
     type: 'tool_result_full',

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -871,7 +871,67 @@ function mcpContentTextParts(content: unknown[] | undefined): string[] {
 }
 
 // ── webSearch → tool_use + tool_result_full + tool_result ────────────────────
-// v2 加了 action 字段 (Search/OpenPage/FindInPage), 用 query 兜底显示。
+// v2 的 legacy query 可能为空，真实动作优先在 action 中；归一成 query 供现有
+// maker-shared / Desktop / Mobile 展示链路消费，同时保留 action 供展开详情核验。
+
+function nonEmptyWebSearchText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function webSearchActionDetail(action: WebSearchAction | null | undefined): string {
+  if (!action) return '';
+  switch (action.type) {
+    case 'search': {
+      const query = nonEmptyWebSearchText(action.query);
+      if (query) return query;
+      const queries = Array.isArray(action.queries)
+        ? action.queries.map(nonEmptyWebSearchText).filter(Boolean)
+        : [];
+      if (queries.length === 0) return '';
+      return queries.length > 1 ? `${queries[0]} ...` : queries[0];
+    }
+    case 'openPage':
+      return nonEmptyWebSearchText(action.url);
+    case 'findInPage': {
+      const url = nonEmptyWebSearchText(action.url);
+      const pattern = nonEmptyWebSearchText(action.pattern);
+      if (pattern && url) return `'${pattern}' in ${url}`;
+      if (pattern) return `'${pattern}'`;
+      return url;
+    }
+    default:
+      return '';
+  }
+}
+
+function webSearchInput(item: WebSearchItem): {
+  query: string;
+  action?: WebSearchAction;
+} {
+  const query = webSearchActionDetail(item.action) || nonEmptyWebSearchText(item.query);
+  return {
+    query,
+    ...(item.action ? { action: item.action } : {}),
+  };
+}
+
+function emitWebSearchToolUse(
+  item: WebSearchItem,
+  input: ReturnType<typeof webSearchInput>,
+  queue: AsyncQueue<AgentEvent>,
+  ctx: CodexTranslateContext,
+): void {
+  ctx.rt.emittedToolUse.add(item.id);
+  queue.push({
+    type: 'tool_use',
+    data: {
+      toolUseId: item.id,
+      toolName: 'web_search',
+      input,
+    },
+    source: 'codex',
+  });
+}
 
 function handleWebSearch(
   phase: ItemPhase,
@@ -879,24 +939,30 @@ function handleWebSearch(
   queue: AsyncQueue<AgentEvent>,
   ctx: CodexTranslateContext,
 ): void {
+  const input = webSearchInput(item);
+
   if (phase === 'started') {
     if (ctx.rt.emittedToolUse.has(item.id)) return;
-    ctx.rt.emittedToolUse.add(item.id);
-    queue.push({
-      type: 'tool_use',
-      data: {
-        toolUseId: item.id,
-        toolName: 'web_search',
-        input: { query: item.query, action: item.action ?? undefined },
-      },
-      source: 'codex',
-    });
+    // 某些 Codex 版本在 started 只给空 legacy query，updated 才补 action；
+    // 延迟这一条展示事件，避免空参数先落库后无法无损更新。
+    if (!input.query) return;
+    emitWebSearchToolUse(item, input, queue, ctx);
     return;
   }
-  if (phase === 'updated') return;
+  if (phase === 'updated') {
+    if (ctx.rt.emittedToolUse.has(item.id) || !input.query) return;
+    emitWebSearchToolUse(item, input, queue, ctx);
+    return;
+  }
 
   // completed
+  const toolUseEmitted = ctx.rt.emittedToolUse.has(item.id);
   ctx.rt.emittedToolUse.delete(item.id);
+  // 防御缺失 started/updated 的历史或异常事件序列，保持 tool_use → result 顺序。
+  if (!toolUseEmitted) {
+    emitWebSearchToolUse(item, input, queue, ctx);
+    ctx.rt.emittedToolUse.delete(item.id);
+  }
   queue.push({
     type: 'tool_result_full',
     data: { toolUseId: item.id, fullText: '', isError: false },


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex Web Search 调用记录只显示通用名称、未显示实际查询内容的问题。Codex app-server 的实际参数位于 `action` 中，translator 现在会将搜索词、页面 URL 或页内查找内容归一化到 `input.query`，同时保留完整 `action`；当 started 事件尚无有效参数时，会等待 updated/completed 事件再发出调用记录，避免空白记录和重复事件。

### 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 构建 / 工具链
- [ ] 其他

### 范围

- 关联 Issue：#776
- 包含：
  - Codex translator 对 Web Search action 的参数归一化
  - started / updated / completed 事件顺序的兼容处理
  - 单查询、多查询、打开页面、页内查找、延迟参数和 completed-only 回归测试
- 不包含：
  - Renderer 布局、样式和 UI 文案调整
  - Claude 会话链路
  - Web Search 的实际执行逻辑
- 用户可见变化：“已工作”中的 Web Search 记录会显示实际查询词或 URL，而不再只有通用工具名。
- Breaking change：无。

### UI 变化

未修改 UI 组件、布局、样式或文案，仅修正 translator 输出给现有调用记录 UI 的数据内容。

引用的设计规范：不涉及：纯数据流逻辑修复，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

- [x] `pnpm test:unit -- --workspace-concurrency=1`：全部通过。为避免本机 8 worker 下两个 git-review 用例偶发超时，使用 CPU affinity 让仓库自适应为 Desktop `--maxWorkers=2`；未减少测试范围。
- [x] `pnpm --filter desktop exec vitest run src/main/__tests__/codexTranslator.test.ts`：23 个测试通过。
- [x] `pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/translator.test.ts`：30 个测试通过。
- [x] `pnpm --filter desktop run --if-present typecheck`：通过。
- [x] `pnpm --filter @cindy/maker-core run --if-present typecheck`：该 package 无 typecheck script，按门禁自动跳过。
- [x] `pnpm check:dco`：通过。

### 手工验证

- Windows 独立 dev 沙盒 `issue776`，Global 区域。
- 登录后分别执行多次 Web Search、直接页面访问和代码搜索。
- 用户提供的完成态截图确认：“已工作”记录能显示实际搜索词与访问 URL，折叠和完成态展示正常。

### 未执行的验证

- 未执行 macOS GUI 目检；改动位于跨平台 TypeScript translator，Windows 沙盒已覆盖实际 app-server 事件链路。
- 未执行 Mobile GUI 目检；本次未修改 Mobile 或共享 UI。

## 风险

### 风险分类

- [ ] 用户数据 / 本地存储
- [ ] 凭证 / 授权
- [ ] 数据库 / Migration
- [ ] IPC / Electron 安全边界
- [ ] 网络 / 协议兼容
- [ ] UI / 主题 / i18n
- [x] 其他：Codex 工具事件映射与事件顺序

### 影响与回滚

- 影响范围：仅 Codex Web Search 调用记录的展示数据和发出时机。
- 回滚方式：revert 本 PR 的提交即可恢复原 translator 行为。
- Mobile 冷更新：否；未修改 `apps/mobile`、原生配置、原生依赖、config plugin、原生模块或其他 runtime fingerprint 输入。
- Maker Core 指标评估：
  - 缓存率：无影响；未修改 prompt、tool 定义或模型输入结构。
  - 性能：每个 Web Search 事件只对少量 action 字段做线性字符串归一化，无新增 I/O 或网络请求。
  - 准确率：提高；新增测试覆盖事件延迟与 completed-only 情况，确保不丢失或重复调用记录。

### 提交前检查

- [x] 已 review 完整 diff，改动范围与 Issue 一致。
- [x] 已通过根目录完整单元测试门禁。
- [x] 已对涉及 package 执行 typecheck 门禁。
- [x] Commit 已带与作者一致的 DCO Signed-off-by。
- [x] 未提交凭证、令牌、密钥或本地用户数据。
- [x] 无需补充产品或开发文档；没有新增配置、协议或公共 API。