### PR TITLE
fix(desktop): 新建对话页语音上屏文字前不再多一个空行(#736 续修)

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
@@ -38,4 +38,20 @@ describe('external draft notification empty-document handling', () => {
     expect(block).toContain('tiptapDocHasContent(');
     expect(block).not.toMatch(/const normalizedDraftText = draft\.text\s*\n?\s*\?/);
   });
+
+  // 同一口径也必须覆盖 storageKey 对齐分支:它依赖 voiceInput.isBusy,录音开始与
+  // 结束各重跑一次。漏判空时新建对话页(草稿键固定、常留一份空正文)会在语音结束
+  // 时重建 doc,把插入点推到 block 边界 —— 上屏文字前多一个空行。
+  it('also collapses an empty draft document on the storageKey-aligned hydration path', () => {
+    const start = chatInput.indexOf('// First-mount hydration path');
+    expect(start).toBeGreaterThan(-1);
+    const end = chatInput.indexOf('editorStorageKeyRef.current = storageKey;', start);
+    expect(end).toBeGreaterThan(start);
+    const block = chatInput.slice(start, end);
+
+    expect(block).toContain('tiptapDocHasContent(draft.text)');
+    expect(block).toContain('composerDocIsEmpty(editor.state.doc)');
+    // 不能再直接拿 draft.text 当"有草稿"的判据。
+    expect(block).not.toMatch(/if \(draft\?\.text && composerDocIsEmpty/);
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/voiceInputDraftDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputDraftDecoration.test.ts
@@ -276,6 +276,31 @@ describe('voice input draft decoration anti-flicker contract', () => {
     expect(rebuilt.doc.resolve(anchor!.from).parent.isTextblock).toBe(true);
   });
 
+  // 全选(AllSelection)后开始听写:替换区间就是 0..content.size,两端必须原样保留,
+  // 否则外层节点(列表包装等)留在替换范围外、上屏文字塞进列表项而不是替换整篇。
+  // 但 widget 是 inline 的,渲染位置要单独吸附回段落内,不然又变成段落外的裸 span。
+  it('keeps a whole-document replacement range while rendering widgets inline', () => {
+    const { plugin, state } = makeState('已经上屏的文字');
+    const full = { from: 0, to: state.doc.content.size };
+    const listening = applyDraftMeta(state, {
+      text: '新的听写文字',
+      source: 'partial',
+      ...full,
+      caretState: 'listening',
+    });
+
+    expect(plugin.getState(listening)).toMatchObject(full);
+    const decorations = plugin.getState(listening)!.decorations.find();
+    const replaced = decorations.find(
+      (deco) => (deco.spec as { key?: string }).key === undefined,
+    );
+    expect({ from: replaced!.from, to: replaced!.to }).toEqual(full);
+    for (const deco of decorations.filter((d) => (d.spec as { key?: string }).key)) {
+      expect(deco.from).toBe(1);
+      expect(listening.doc.resolve(deco.from).parent.isTextblock).toBe(true);
+    }
+  });
+
   it('deduplicates identical setVoiceInputDraftDecoration calls without dispatching', () => {
     const { state } = makeState('前文');
     let current = state;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2579,10 +2579,17 @@ export function ChatInput({
       // alone.
       if (storageKey !== undefined) {
         const draft = getComposerDraft(storageKey);
-        if (draft?.text && composerDocIsEmpty(editor.state.doc)) {
+        // 判空同外部草稿订阅:草稿正文可能是「空文档 JSON」而不是 undefined。此时
+        // 编辑器本来就是空的,setContent 只会原地重建 doc(replace(0, size)),把按
+        // 位置存活的状态(语音插入点、草稿装饰锚点)推到 block 边界上。本 effect 依赖
+        // voiceInput.isBusy,录音开始与结束各会重跑一次——新建对话页的草稿键固定、
+        // 常留着一份空正文,于是上屏文字前凭空多出一个空行。
+        const draftDocument =
+          draft?.text && tiptapDocHasContent(draft.text) ? draft.text : null;
+        if (draftDocument && composerDocIsEmpty(editor.state.doc)) {
           isRestoringRef.current = true;
           try {
-            editor.commands.setContent(normalizeComposerDocumentJSON(draft.text));
+            editor.commands.setContent(normalizeComposerDocumentJSON(draftDocument));
           } finally {
             isRestoringRef.current = false;
           }

--- a/apps/desktop/src/renderer/components/new-chat/VoiceInputDraftDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/VoiceInputDraftDecoration.ts
@@ -4,7 +4,10 @@ import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import type { VoiceInputDraftSource } from '@cindy/voice-input-core';
 
-import { clampEditorTextRangeToDoc } from '../../voice-input/editorRangeMapping';
+import {
+  clampEditorTextRangeToDoc,
+  clampToInlinePosition,
+} from '../../voice-input/editorRangeMapping';
 import { MIC_WAVE_ICON_SVG } from '../../voice-input/VoiceInputMicWaveIcon';
 
 /**
@@ -40,9 +43,10 @@ export type VoiceInputReplacementRangeUpdate = {
   range: VoiceInputReplacementRange | null;
 };
 
-// 位置一律吸附到「能承载 inline 内容」的位置(见 clampToInlinePosition):草稿与
-// caret 都是 inline widget,落在 block 边界上会被 ProseMirror 渲染到段落之外,
-// 浏览器给它单独一行 —— 就是听写时凭空多出的那个空行。
+// 折叠锚点吸附到「能承载 inline 内容」的位置(见 clampToInlinePosition):落在 block
+// 边界上时 ProseMirror 会把 inline widget 渲染到段落之外,浏览器给它单独一行 ——
+// 就是听写时凭空多出的那个空行。非折叠区间保留两端(全选后听写要替换整篇),widget
+// 的渲染位置在 createDecorations 里单独吸附。
 function clampRange(doc: PMNode, from: number, to: number): { from: number; to: number } {
   return clampEditorTextRangeToDoc({ from, to }, doc);
 }
@@ -110,6 +114,12 @@ function createDecorations(
 ): DecorationSet {
   if (!text && !caretState) return DecorationSet.empty;
   const range = clampRange(doc, from, to);
+  // The replaced range keeps its own endpoints (a dictation started over
+  // AllSelection must still replace the whole document), but the inline widgets
+  // have to sit at a position that can hold inline content: at a block boundary
+  // ProseMirror renders them at doc level, where the browser gives the span its
+  // own line — a stray blank line above the caret.
+  const widgetPosition = clampToInlinePosition(doc, range.from);
   const decorations: Decoration[] = [];
   if (text && range.to > range.from) {
     decorations.push(
@@ -128,7 +138,7 @@ function createDecorations(
     // browser only repaints the glyphs that actually changed.
     decorations.push(
       Decoration.widget(
-        range.from,
+        widgetPosition,
         () => {
           const node = document.createElement('span');
           node.dataset.voiceDraftInline = 'true';
@@ -137,7 +147,7 @@ function createDecorations(
           return node;
         },
         {
-          key: `voice-input-draft:${range.from}:${range.to}`,
+          key: `voice-input-draft:${widgetPosition}:${range.to}`,
           side: 1,
         },
       ),
@@ -151,10 +161,10 @@ function createDecorations(
     // the next text will land.
     decorations.push(
       Decoration.widget(
-        range.from,
+        widgetPosition,
         () => createCaretElement(caretState),
         {
-          key: `voice-input-caret:${caretState}:${range.from}`,
+          key: `voice-input-caret:${caretState}:${widgetPosition}`,
           side: 2,
         },
       ),

--- a/apps/desktop/src/renderer/components/new-chat/VoiceInputDraftDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/VoiceInputDraftDecoration.ts
@@ -1,15 +1,10 @@
 import { Extension, type Editor } from '@tiptap/core';
-import {
-  Plugin,
-  PluginKey,
-  TextSelection,
-  type EditorState,
-  type Transaction,
-} from '@tiptap/pm/state';
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import type { VoiceInputDraftSource } from '@cindy/voice-input-core';
 
+import { clampEditorTextRangeToDoc } from '../../voice-input/editorRangeMapping';
 import { MIC_WAVE_ICON_SVG } from '../../voice-input/VoiceInputMicWaveIcon';
 
 /**
@@ -45,33 +40,11 @@ export type VoiceInputReplacementRangeUpdate = {
   range: VoiceInputReplacementRange | null;
 };
 
-function clampPosition(doc: PMNode, position: number): number {
-  return Math.max(0, Math.min(position, doc.content.size));
-}
-
-/**
- * Snap a position onto the nearest place that can hold inline content.
- *
- * The draft/caret widgets are inline: rendered at a position whose parent is
- * NOT a textblock (0 or a boundary between blocks), ProseMirror puts them in
- * the doc-level DOM — an inline span between two `<p>`s, which the browser then
- * gives its own line. That reads as a stray blank line above the dictation
- * caret. Anchors reach such a position whenever the composer document is
- * rebuilt wholesale while dictation is live (external draft restore does a
- * `replace(0, size)`), because mapping a collapsed anchor across a full
- * replacement pushes it out to the block boundary.
- */
-function clampToInlinePosition(doc: PMNode, position: number): number {
-  const clamped = clampPosition(doc, position);
-  const $pos = doc.resolve(clamped);
-  if ($pos.parent.isTextblock) return clamped;
-  return TextSelection.near($pos, 1).from;
-}
-
+// 位置一律吸附到「能承载 inline 内容」的位置(见 clampToInlinePosition):草稿与
+// caret 都是 inline widget,落在 block 边界上会被 ProseMirror 渲染到段落之外,
+// 浏览器给它单独一行 —— 就是听写时凭空多出的那个空行。
 function clampRange(doc: PMNode, from: number, to: number): { from: number; to: number } {
-  const safeFrom = clampToInlinePosition(doc, Math.min(from, to));
-  const safeTo = clampToInlinePosition(doc, Math.max(from, to));
-  return safeFrom <= safeTo ? { from: safeFrom, to: safeTo } : { from: safeFrom, to: safeFrom };
+  return clampEditorTextRangeToDoc({ from, to }, doc);
 }
 
 /**

--- a/apps/desktop/src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
@@ -108,4 +108,26 @@ describe('clampEditorTextRangeToDoc', () => {
     expect(clampEditorTextRangeToDoc({ from: 999, to: 999 }, doc)).toEqual({ from: 3, to: 3 });
     expect(clampEditorTextRangeToDoc({ from: 3, to: 1 }, doc)).toEqual({ from: 1, to: 3 });
   });
+
+  // 只有折叠锚点该被吸附。非折叠区间的两端是"要替换什么"的一部分:全选(AllSelection)
+  // 后开始听写,区间就是 0..content.size;把两端往里收会把外层节点(列表包装等)留在
+  // 替换范围外,上屏文字于是塞进第一个列表项,而不是替换整篇。
+  it('preserves the endpoints of a non-collapsed (AllSelection) range', () => {
+    const doc = stateWith('hello').doc;
+    expect(clampEditorTextRangeToDoc({ from: 0, to: doc.content.size }, doc)).toEqual({
+      from: 0,
+      to: doc.content.size,
+    });
+  });
+
+  it('keeps a mapped non-collapsed range spanning the whole document', () => {
+    const state = stateWith('hello');
+    const size = state.doc.content.size;
+    // 无关的 doc 变更(此处在区间内插入)不该让整篇替换范围被收进段落内。
+    const tr = state.tr.insertText('X', 3);
+    const mapped = mapEditorTextRange({ from: 0, to: size }, tr);
+
+    expect(mapped!.from).toBe(0);
+    expect(mapped!.to).toBe(tr.doc.content.size);
+  });
 });

--- a/apps/desktop/src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it } from 'vitest';
 import { Schema } from '@tiptap/pm/model';
 import { EditorState } from '@tiptap/pm/state';
 
-import { mapEditorTextRange } from '../editorRangeMapping';
+import { clampEditorTextRangeToDoc, mapEditorTextRange } from '../editorRangeMapping';
 
 const schema = new Schema({
   nodes: {
@@ -71,5 +71,41 @@ describe('mapEditorTextRange', () => {
 
     expect(mapped).toEqual({ from: 9, to: 14 });
     expect(state.tr.insertText('XY', 1).doc.textBetween(mapped!.from, mapped!.to)).toBe('world');
+  });
+
+  // 整篇替换(外部草稿恢复走 setContent → replace(0, size))会把锚点映射到 block
+  // 边界。那不是听写能插入的位置:insertText 会另起一个段落,上屏文字前面凭空多出
+  // 一个空行(新建对话页语音结束时多一个回车的成因)。映射结果必须吸附回段落内。
+  it('snaps an anchor back inside the paragraph after a full-document replacement', () => {
+    const state = stateWith('');
+    const tr = state.tr.replaceWith(0, state.doc.content.size, schema.node('paragraph'));
+    const mapped = mapEditorTextRange({ from: 1, to: 1 }, tr);
+
+    expect(mapped).toEqual({ from: 1, to: 1 });
+    expect(tr.doc.resolve(mapped!.from).parent.isTextblock).toBe(true);
+    // 用映射后的位置上屏时不得再生成第二个段落。
+    const inserted = tr.doc.type.schema === schema
+      ? EditorState.create({ doc: tr.doc }).tr.insertText('上屏文字', mapped!.from, mapped!.to).doc
+      : null;
+    expect(inserted?.childCount).toBe(1);
+    expect(inserted?.textContent).toBe('上屏文字');
+  });
+});
+
+describe('clampEditorTextRangeToDoc', () => {
+  it('pulls block-boundary positions onto the nearest inline position', () => {
+    const doc = stateWith('hi').doc;
+    // 0 是 doc 起点、doc.content.size 是段落之后 —— 两者都不是 inline 位置。
+    expect(clampEditorTextRangeToDoc({ from: 0, to: 0 }, doc)).toEqual({ from: 1, to: 1 });
+    expect(clampEditorTextRangeToDoc({ from: doc.content.size, to: doc.content.size }, doc)).toEqual({
+      from: 3,
+      to: 3,
+    });
+  });
+
+  it('clamps out-of-bounds offsets and normalizes inverted ranges', () => {
+    const doc = stateWith('hi').doc;
+    expect(clampEditorTextRangeToDoc({ from: 999, to: 999 }, doc)).toEqual({ from: 3, to: 3 });
+    expect(clampEditorTextRangeToDoc({ from: 3, to: 1 }, doc)).toEqual({ from: 1, to: 3 });
   });
 });

--- a/apps/desktop/src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
@@ -13,7 +13,11 @@ import { describe, expect, it } from 'vitest';
 import { Schema } from '@tiptap/pm/model';
 import { EditorState } from '@tiptap/pm/state';
 
-import { clampEditorTextRangeToDoc, mapEditorTextRange } from '../editorRangeMapping';
+import {
+  clampEditorTextRangeToDoc,
+  mapEditorTextRange,
+  resolveInsertedTextRange,
+} from '../editorRangeMapping';
 
 const schema = new Schema({
   nodes: {
@@ -129,5 +133,30 @@ describe('clampEditorTextRangeToDoc', () => {
 
     expect(mapped!.from).toBe(0);
     expect(mapped!.to).toBe(tr.doc.content.size);
+  });
+});
+
+// 上屏范围必须从事务推导:替换区间可以从 block 边界开始(全选后听写就是
+// 0..content.size),ProseMirror 把 inline 文本 fit 进段落后字形落在边界之后。用插入
+// 前的 from 记录会让润色回填读到截断文本而丢弃润色,预览与词典学习 watch 也一起错位。
+describe('resolveInsertedTextRange', () => {
+  it('reports where the text landed after a whole-document replacement', () => {
+    const state = stateWith('旧的内容');
+    const to = state.doc.content.size;
+    const tr = state.tr.insertText('上屏文字', 0, to);
+    const range = resolveInsertedTextRange(tr, 0, '上屏文字'.length);
+
+    expect(tr.doc.childCount).toBe(1);
+    expect(range).toEqual({ start: 1, end: 1 + '上屏文字'.length });
+    expect(tr.doc.textBetween(range.start, range.end)).toBe('上屏文字');
+  });
+
+  it('reports the inserted span for an ordinary collapsed insertion', () => {
+    const state = stateWith('abc');
+    const tr = state.tr.insertText('XY', 2, 2);
+    const range = resolveInsertedTextRange(tr, 2, 2);
+
+    expect(range).toEqual({ start: 2, end: 4 });
+    expect(tr.doc.textBetween(range.start, range.end)).toBe('XY');
   });
 });

--- a/apps/desktop/src/renderer/voice-input/editorRangeMapping.ts
+++ b/apps/desktop/src/renderer/voice-input/editorRangeMapping.ts
@@ -50,6 +50,34 @@ export function clampEditorTextRangeToDoc(range: EditorTextRange, doc: PMNode): 
 }
 
 /**
+ * Where the text an `insertText(text, from, to)` transaction just wrote ended up.
+ *
+ * The pre-insertion `from` is NOT that place. A replacement range may legally
+ * start at a block boundary (dictation over `AllSelection` spans
+ * `0..doc.content.size`), and ProseMirror then fits the inline text INTO a
+ * textblock — the glyphs land one position after that boundary. Recording the
+ * pre-insertion endpoint would offset everything keyed to this range:
+ * `applyRefinedText` would read a truncated `currentText` and drop the
+ * refinement, and refinement previews plus dictionary-learning watches would
+ * point at the wrong span.
+ *
+ * Mapping the range's START with association `-1` keeps it in front of the
+ * inserted slice; snapping that onto an inline position lands exactly on the
+ * first inserted character, however the slice was fitted.
+ */
+export function resolveInsertedTextRange(
+  transaction: Transaction,
+  replacedFrom: number,
+  textLength: number,
+): { start: number; end: number } {
+  const start = clampToInlinePosition(
+    transaction.doc,
+    transaction.mapping.map(replacedFrom, -1),
+  );
+  return { start, end: Math.min(start + textLength, transaction.doc.content.size) };
+}
+
+/**
  * Move a stored range through a document change, so offsets captured earlier
  * keep pointing at the same content.
  *

--- a/apps/desktop/src/renderer/voice-input/editorRangeMapping.ts
+++ b/apps/desktop/src/renderer/voice-input/editorRangeMapping.ts
@@ -30,11 +30,23 @@ export function clampToInlinePosition(doc: PMNode, position: number): number {
   return TextSelection.near($pos, 1).from;
 }
 
-/** Clamp a stored range into valid, ordered inline positions of `doc`. */
+/**
+ * Clamp a stored range into valid, ordered positions of `doc`.
+ *
+ * Only a COLLAPSED anchor is snapped onto an inline position. A non-collapsed
+ * range carries replacement semantics that the endpoints are part of: dictation
+ * started over `AllSelection` (Ctrl/Cmd+A) spans `0..doc.content.size`, and
+ * snapping those endpoints inward would leave the outer nodes — a bullet/ordered
+ * list wrapper, say — outside the replacement, so the transcript would land
+ * inside the first list item instead of replacing the whole composer. Such a
+ * range is only bounds-checked.
+ */
 export function clampEditorTextRangeToDoc(range: EditorTextRange, doc: PMNode): EditorTextRange {
-  const from = clampToInlinePosition(doc, Math.min(range.from, range.to));
-  const to = clampToInlinePosition(doc, Math.max(range.from, range.to));
-  return from <= to ? { from, to } : { from, to: from };
+  const lower = Math.max(0, Math.min(Math.min(range.from, range.to), doc.content.size));
+  const upper = Math.max(0, Math.min(Math.max(range.from, range.to), doc.content.size));
+  if (lower !== upper) return { from: lower, to: upper };
+  const snapped = clampToInlinePosition(doc, lower);
+  return { from: snapped, to: snapped };
 }
 
 /**
@@ -49,9 +61,10 @@ export function clampEditorTextRangeToDoc(range: EditorTextRange, doc: PMNode): 
  * inverted; keep it collapsed after the insertion rather than letting a
  * downstream min/max clamp swap it back into a range spanning that text.
  *
- * The mapped result is snapped back onto inline positions: a full-document
- * replacement maps every anchor out to a block boundary, which is not a place
- * dictation may insert at (see `clampToInlinePosition`).
+ * A mapped COLLAPSED anchor is snapped back onto an inline position: a
+ * full-document replacement maps it out to a block boundary, which is not a
+ * place dictation may insert at (see `clampToInlinePosition`). Non-collapsed
+ * ranges keep their endpoints — see `clampEditorTextRangeToDoc`.
  *
  * Lives in its own module so it can be tested without pulling in the voice
  * input hook and its Electron bridge.

--- a/apps/desktop/src/renderer/voice-input/editorRangeMapping.ts
+++ b/apps/desktop/src/renderer/voice-input/editorRangeMapping.ts
@@ -1,9 +1,41 @@
-import type { Transaction } from '@tiptap/pm/state';
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { TextSelection, type Transaction } from '@tiptap/pm/state';
 
 export type EditorTextRange = {
   from: number;
   to: number;
 };
+
+/**
+ * Snap a position onto the nearest place that can hold inline content.
+ *
+ * Dictation positions must always address inline content: the transcript is
+ * inserted with `tr.insertText`, and the live draft/caret decorations are inline
+ * widgets. A position whose parent is NOT a textblock (0, or a boundary between
+ * two blocks) makes ProseMirror wrap the inserted text in a NEW paragraph — the
+ * transcript then lands one line below, leaving an empty paragraph in front of
+ * it — and renders the widgets at doc level, where the browser gives them their
+ * own line. Both read as "dictation added a stray blank line".
+ *
+ * Anchors reach such a position whenever the composer document is rebuilt
+ * wholesale while dictation is live (an external draft restore replaces the full
+ * document), because mapping an anchor across a full replacement pushes it out
+ * to the block boundary. Clamping to `doc.content.size` alone does not help:
+ * that upper bound is itself a block boundary.
+ */
+export function clampToInlinePosition(doc: PMNode, position: number): number {
+  const clamped = Math.max(0, Math.min(position, doc.content.size));
+  const $pos = doc.resolve(clamped);
+  if ($pos.parent.isTextblock) return clamped;
+  return TextSelection.near($pos, 1).from;
+}
+
+/** Clamp a stored range into valid, ordered inline positions of `doc`. */
+export function clampEditorTextRangeToDoc(range: EditorTextRange, doc: PMNode): EditorTextRange {
+  const from = clampToInlinePosition(doc, Math.min(range.from, range.to));
+  const to = clampToInlinePosition(doc, Math.max(range.from, range.to));
+  return from <= to ? { from, to } : { from, to: from };
+}
 
 /**
  * Move a stored range through a document change, so offsets captured earlier
@@ -17,6 +49,10 @@ export type EditorTextRange = {
  * inverted; keep it collapsed after the insertion rather than letting a
  * downstream min/max clamp swap it back into a range spanning that text.
  *
+ * The mapped result is snapped back onto inline positions: a full-document
+ * replacement maps every anchor out to a block boundary, which is not a place
+ * dictation may insert at (see `clampToInlinePosition`).
+ *
  * Lives in its own module so it can be tested without pulling in the voice
  * input hook and its Electron bridge.
  */
@@ -27,5 +63,5 @@ export function mapEditorTextRange(
   if (!range) return null;
   const from = transaction.mapping.map(range.from, 1);
   const to = transaction.mapping.map(range.to, -1);
-  return from > to ? { from, to: from } : { from, to };
+  return clampEditorTextRangeToDoc(from > to ? { from, to: from } : { from, to }, transaction.doc);
 }

--- a/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
+++ b/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Editor } from '@tiptap/core';
+import type { Node as PMNode } from '@tiptap/pm/model';
 import type { Transaction } from '@tiptap/pm/state';
 import { useTranslation } from 'react-i18next';
 import type {
@@ -59,7 +60,11 @@ import { resolveVoiceInputStartGuards } from './startGuards';
 import { getVoiceInputWorkletUrl } from './workletUrl';
 import { buildRefinementPreviewText } from './refinementPreviewText';
 import { isVoiceInputEventScopeActive, shouldHandleVoiceInputEvent } from './eventScope';
-import { mapEditorTextRange, type EditorTextRange } from './editorRangeMapping';
+import {
+  clampEditorTextRangeToDoc,
+  mapEditorTextRange,
+  type EditorTextRange,
+} from './editorRangeMapping';
 import { isVoiceInputServiceConnectionError, VOICE_INPUT_ERROR_CODE_KEYS } from './overlayErrors';
 import {
   VOICE_INPUT_DICTIONARY_LEARNING_TRACK_TIMEOUT_MS,
@@ -530,11 +535,12 @@ export function useVoiceInput(
     };
   }, []);
 
-  const clampEditorTextRange = useCallback((range: EditorTextRange, docSize: number): EditorTextRange => {
-    const from = Math.max(0, Math.min(Math.min(range.from, range.to), docSize));
-    const to = Math.max(0, Math.min(Math.max(range.from, range.to), docSize));
-    return { from, to };
-  }, []);
+  // 钳制到「能承载 inline 内容」的位置,而不是只钳到 doc.content.size:后者本身就是
+  // 一个 block 边界,在那里 insertText 会另起一个段落,上屏文字前凭空多一个空行。
+  const clampEditorTextRange = useCallback(
+    (range: EditorTextRange, doc: PMNode): EditorTextRange => clampEditorTextRangeToDoc(range, doc),
+    [],
+  );
 
   const clearDictionaryLearningWatchTimer = useCallback((watch: DictionaryLearningWatch | undefined) => {
     if (watch?.pendingAdviceTimer !== undefined) {
@@ -611,7 +617,7 @@ export function useVoiceInput(
       const { doc } = current.state;
       const range = clampEditorTextRange(
         { from: currentWatch.start, to: currentWatch.end },
-        doc.content.size,
+        doc,
       );
       const afterText = doc.textBetween(range.from, range.to, '\n', '\n');
       if (!afterText || afterText === currentWatch.baselineText) {
@@ -677,7 +683,7 @@ export function useVoiceInput(
       .flatMap((watch) => {
         const start = transaction.mapping.map(watch.start, -1);
         const end = transaction.mapping.map(watch.end, -1);
-        const range = clampEditorTextRange({ from: start, to: end }, transaction.doc.content.size);
+        const range = clampEditorTextRange({ from: start, to: end }, transaction.doc);
         const currentText = transaction.doc.textBetween(range.from, range.to, '\n', '\n');
         if (!currentText) {
           finalizeDictionaryLearningWatch(watch.segmentId, 'clear_input_box');
@@ -762,7 +768,7 @@ export function useVoiceInput(
     const { doc, selection } = current.state;
     const range = clampEditorTextRange(
       insertionRangeRef.current ?? { from: selection.from, to: selection.to },
-      doc.content.size,
+      doc,
     );
     return {
       ...baseContext,
@@ -808,7 +814,7 @@ export function useVoiceInput(
     current.commands.focus();
     const { state, dispatch } = current.view;
     const range = insertionRangeRef.current
-      ? clampEditorTextRange(insertionRangeRef.current, state.doc.content.size)
+      ? clampEditorTextRange(insertionRangeRef.current, state.doc)
       : { from: state.selection.from, to: state.selection.to };
     insertionRangeRef.current = null;
     const start = range.from;
@@ -995,10 +1001,13 @@ export function useVoiceInput(
             const range = segmentId ? submittedRangesRef.current.get(segmentId) : undefined;
             const current = editorRef.current;
             if (range && current && !current.isDestroyed) {
-              const docSize = current.state.doc.content.size;
-              if (range.start <= docSize) {
+              const currentDoc = current.state.doc;
+              if (range.start <= currentDoc.content.size) {
                 const baseText = event.segment.basedOnText ?? range.submittedText;
-                draftDisplayRangeRef.current = clampEditorTextRange({ from: range.start, to: range.end }, docSize);
+                draftDisplayRangeRef.current = clampEditorTextRange(
+                  { from: range.start, to: range.end },
+                  currentDoc,
+                );
                 setDraftText(buildRefinementPreviewText(baseText, event.text));
                 setDraftSource('refinement');
               }

--- a/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
+++ b/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
@@ -63,6 +63,7 @@ import { isVoiceInputEventScopeActive, shouldHandleVoiceInputEvent } from './eve
 import {
   clampEditorTextRangeToDoc,
   mapEditorTextRange,
+  resolveInsertedTextRange,
   type EditorTextRange,
 } from './editorRangeMapping';
 import { isVoiceInputServiceConnectionError, VOICE_INPUT_ERROR_CODE_KEYS } from './overlayErrors';
@@ -817,17 +818,19 @@ export function useVoiceInput(
       ? clampEditorTextRange(insertionRangeRef.current, state.doc)
       : { from: state.selection.from, to: state.selection.to };
     insertionRangeRef.current = null;
-    const start = range.from;
     applyingVoiceTextRef.current = true;
     try {
-      dispatch(state.tr.insertText(text, range.from, range.to));
+      const transaction = state.tr.insertText(text, range.from, range.to);
+      // 上屏范围必须从事务推导,不能用插入前的 from:替换区间可以合法地从 block
+      // 边界开始(全选后听写就是 0..content.size),ProseMirror 会把 inline 文本
+      // fit 进段落,字形实际落在边界之后。用旧 from 记录会让润色回填、润色预览与
+      // 词典学习 watch 整体错位(润色会因读到截断文本而被丢弃)。
+      const inserted = resolveInsertedTextRange(transaction, range.from, text.length);
+      dispatch(transaction);
+      return inserted;
     } finally {
       applyingVoiceTextRef.current = false;
     }
-    return {
-      start,
-      end: start + text.length,
-    };
   }, [clampEditorTextRange]);
 
   const applyRefinedText = useCallback((event: Extract<VoiceInputRendererEvent, { type: 'refined' }>): boolean => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

#736 的续修。#736 修掉了"语音录音**开始**时输入框首行多一个空行"，但用户实机复验发现**新建对话页**在语音**结束、文字上屏**时前面仍会多一个回车（已有会话正常）。这个 PR 补齐两处同源缺口：

1. **`ChatInput` 的 storageKey 对齐分支同样用 `draft?.text` 当"有草稿"判据**，漏掉了「空文档 JSON」（草稿存储里的空正文是 `{doc:[空 paragraph]}`，不是 `undefined`）。这个 effect 依赖 `voiceInput.isBusy` —— 录音开始与结束各重跑一次，于是每次录音都白重建一次 doc（`replace(0, size)`）。**只在新建对话页复现**的原因：新建对话页草稿键固定（`__new_maker_draft__`）、常留着一份空正文；已有会话的草稿键随会话变化，通常没有这份残留。
2. **位置钳制只钳到 `doc.content.size`，而那本身就是 block 边界。** doc 被重建后插入点被映射到边界上，`tr.insertText` 于是把文字包进一个**新段落** —— 上屏文字前凭空多出一个空段落，就是那个"结束时多出来的回车"。#736 只在装饰侧做了 inline 位置吸附，插入点这一侧没做。

把 inline 位置吸附收敛成共享实现 `clampToInlinePosition` / `clampEditorTextRangeToDoc`（`voice-input/editorRangeMapping.ts`）：语音插入点、词典学习 watch 范围、润色预览锚点与草稿装饰锚点全部走它，`mapEditorTextRange` 映射后也吸附回段落内。装饰侧 #736 留下的本地实现删掉，不再两处并存。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#736 的 follow-up（用户实机反馈）
- 本 PR 包含：
  - `editorRangeMapping.ts` 新增共享的 inline 位置吸附（`clampToInlinePosition` / `clampEditorTextRangeToDoc`），并让 `mapEditorTextRange` 的映射结果也吸附回段落内；
  - `useVoiceInput.ts` 的全部位置钳制（插入点、词典学习 watch、润色上下文、润色预览锚点）从"钳到 `doc.content.size`"改为吸附到 inline 位置；
  - `VoiceInputDraftDecoration.ts` 改用共享实现，删掉本地副本；
  - `ChatInput.tsx` storageKey 对齐分支按共享判空 `tiptapDocHasContent` 跳过空草稿重建；
  - 4 条测试（见下）。
- 明确不包含：不动语音识别、润色、词典、草稿存储格式，也不动结构化列表模型。
- 用户可见变化：新建对话页语音上屏的文字前不再多一个空行，与已有会话行为一致。
- 是否存在 breaking change：无

### UI 变化

不涉及：只改位置计算与一处判空，没有新增/修改任何样式、布局、动效或文案。缺陷表现是布局副作用，修复后回到既有设计的预期形态。

- 引用的设计规范：不涉及（无视觉/交互/文案变更）

## 怎么验证的

### 自动验证

```text
pnpm test:unit（仓库根全量，本 worktree 在 cindy-protocol submodule 就位后重跑）
结果：GATE_EXIT=0，无 FAIL

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/voice-input/__tests__/editorRangeMapping.test.ts
结果：8 passed（含新增 3 条）

pnpm --filter desktop exec vitest run src/renderer/__tests__/composerExternalDraftEmptyDoc.test.ts
结果：2 passed（含新增 1 条）
```

新增的测试：

- `editorRangeMapping.test.ts`：整篇替换后锚点吸附回段落内（并断言用该位置 `insertText` **不会**生成第二个段落 —— 直接锁住本 bug）；block 边界 / 越界 / 倒序范围的钳制归一。
- `composerExternalDraftEmptyDoc.test.ts`：storageKey 对齐分支也必须用共享判空跳过空文档草稿，不能只判断 `draft.text` 是否存在。

### 手工验证

定位阶段在 desktop dev（`pnpm restart:desktop:remote --preserve-running`，`pnpm desktop:whoami` 校验 root + commit 匹配）里用临时探针抓过真实录音的插件状态、DOM 与几何，据此确认 doc 被 `replace(0, size)` 重建、锚点被推到 block 边界（探针已全部删除，不在本 PR diff 内）。

本轮修复的实机复验由用户在同一 dev 实例上进行中（新建对话页 + 已有会话各录一次）。

### 未执行的验证

- 本轮修复的实机复验结果尚未由我确认（用户正在 dev 实例上测）；自动化侧已有直接锁住该行为的回归测试。
- Windows 未验证：改动是纯 ProseMirror 位置计算 + 一处判空，无平台分支。
- Light / Dark 双模式未逐一目检：本 PR 不涉及颜色 token 或任何样式改动。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：语音听写的插入点 / 装饰锚点 / 词典学习 watch 的位置钳制（统一吸附到 inline 位置，block 边界与越界值不再被当成合法插入点）；输入框首挂载与语音状态切换时的草稿恢复路径（编辑器与草稿都为空时**少做**一次无意义的整段 `setContent`，非空草稿的恢复逻辑不变）。
- 回滚 / 降级方式：直接 revert 本 commit，无数据/协议/存储格式变更，无需迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已写明理由）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：无对外行为或规则变更）
- [x] 已确认测试结果或说明未执行原因
