### PR TITLE
fix(desktop): 补充 Codex 重置卡悬停信息

### DIFF
--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
+import type { MobileCodexRateLimitsResult } from '@cindy/maker-shared/device-link-contract';
 import {
   AGENT_ISLAND_GET_DISPLAY_OPTIONS_CHANNEL,
   AGENT_ISLAND_PREVIEW_SOUND_CHANNEL,
@@ -4581,6 +4582,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('maker:usage:today', agentKind),
       getAccount: (agentKind: 'claude-code' | 'codex'): Promise<unknown> =>
         ipcRenderer.invoke('maker:usage:account', agentKind),
+      /** Codex app-server authoritative windows and banked reset-credit metadata. */
+      getCodexRateLimits: (): Promise<MobileCodexRateLimitsResult> =>
+        ipcRenderer.invoke('maker:usage:codex-rate-limits'),
       /** Claude 订阅账号余量 (5h/周/分模型窗口, cached-first, main 侧按需后台刷新)。 */
       getClaudeSubscription: (): Promise<unknown | null> =>
         ipcRenderer.invoke('maker:usage:claude-subscription'),

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -16,6 +16,12 @@ const rendererTypesPath = resolve(__dirname, '..', 'vite-env.d.ts');
 const source = readFileSync(sourcePath, 'utf8').replace(/\r\n/g, '\n');
 const preloadSource = readFileSync(preloadPath, 'utf8').replace(/\r\n/g, '\n');
 const rendererTypesSource = readFileSync(rendererTypesPath, 'utf8').replace(/\r\n/g, '\n');
+const localeSources = ['en', 'zh-CN', 'ja', 'ko'].map((locale) =>
+  readFileSync(
+    resolve(__dirname, '..', 'i18n', 'locales', locale, 'common.json'),
+    'utf8',
+  ).replace(/\r\n/g, '\n'),
+);
 
 describe('TodaySpendChip dashboard routing', () => {
   it('separates the latest user-round total from final-segment token details', () => {
@@ -128,13 +134,24 @@ describe('TodaySpendChip dashboard routing', () => {
     expect(source).toContain(
       'useCodexRateLimits(isCodexOauth && !isAnyRemoteSession)',
     );
-    // 直接复用 Mobile 的汇总与本地时间格式,tooltip 只追加重置卡相关行。
+    // 复用 Mobile 的中性汇总字段；Desktop 按当前界面语言渲染 label / 次数 / 本地时间。
     expect(source).toContain('summarizeCodexRateLimitReset');
     // 复用 chip 现有 tick 时间基准,跨日时本地时间文案会重新格式化。
     expect(source).toContain(
       'summarizeCodexRateLimitReset(codexRateLimits, windowLabelNowMs)',
     );
-    expect(source).toContain('resetSummary?.resetRows');
+    expect(source).toContain('resetSummary?.hasResetCreditCount');
+    expect(source).toContain('resetSummary?.earliestExpiryAt');
+    expect(source).toContain("t('todaySpend.codex.resetCreditsAvailableLine'");
+    expect(source).toContain("t('todaySpend.codex.resetCreditEarliestExpiryLine'");
+    expect(source).toContain('i18n.resolvedLanguage ?? i18n.language');
+    expect(source).not.toContain('resetSummary?.resetRows');
+    for (const localeSource of localeSources) {
+      expect(localeSource).toContain('"resetCreditsAvailableLine"');
+      expect(localeSource).toContain('"resetCreditEarliestExpiryLine"');
+    }
+    // 长时间挂载时每次重新悬停都会刷新，首次瞬态失败与外部消费/授予不会永久陈旧。
+    expect(source).toContain('onMouseEnter={refreshCodexRateLimits}');
   });
 
   it('keeps Codex OAuth subscription details in the chip and tooltip', () => {

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -130,6 +130,10 @@ describe('TodaySpendChip dashboard routing', () => {
     );
     // 直接复用 Mobile 的汇总与本地时间格式,tooltip 只追加重置卡相关行。
     expect(source).toContain('summarizeCodexRateLimitReset');
+    // 复用 chip 现有 tick 时间基准,跨日时本地时间文案会重新格式化。
+    expect(source).toContain(
+      'summarizeCodexRateLimitReset(codexRateLimits, windowLabelNowMs)',
+    );
     expect(source).toContain('resetSummary?.resetRows');
   });
 

--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -10,8 +10,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const sourcePath = resolve(__dirname, '..', 'components', 'status', 'TodaySpendChip.tsx');
+const preloadPath = resolve(__dirname, '..', '..', 'preload', 'preload.ts');
+const rendererTypesPath = resolve(__dirname, '..', 'vite-env.d.ts');
 // Windows CRLF 检出下 \n 字面量断言会失配,统一归一化成 LF 再断言。
 const source = readFileSync(sourcePath, 'utf8').replace(/\r\n/g, '\n');
+const preloadSource = readFileSync(preloadPath, 'utf8').replace(/\r\n/g, '\n');
+const rendererTypesSource = readFileSync(rendererTypesPath, 'utf8').replace(/\r\n/g, '\n');
 
 describe('TodaySpendChip dashboard routing', () => {
   it('separates the latest user-round total from final-segment token details', () => {
@@ -107,6 +111,26 @@ describe('TodaySpendChip dashboard routing', () => {
     // 不跨槽回退(账号多限额桶互相污染, 2026-07-24 实报 bug)
     expect(source).toContain("shouldReadLocalCodexAccountUsage ? 'codex' : undefined,");
     expect(source).toContain("isChatgptBridge ? 'openai-web' : 'app-server',");
+  });
+
+  it('shows the shared mobile Codex reset-credit summary for local Desktop sessions', () => {
+    // 主进程已有 authoritative read;Desktop renderer 需补齐 preload + 类型链路。
+    expect(preloadSource).toContain(
+      'getCodexRateLimits: (): Promise<MobileCodexRateLimitsResult>',
+    );
+    expect(preloadSource).toContain(
+      "ipcRenderer.invoke('maker:usage:codex-rate-limits')",
+    );
+    expect(rendererTypesSource).toContain(
+      'getCodexRateLimits: () => Promise<',
+    );
+    // 仅本机 Codex OAuth 会话读取本机账号数据;远程 / bridge 不张冠李戴。
+    expect(source).toContain(
+      'useCodexRateLimits(isCodexOauth && !isAnyRemoteSession)',
+    );
+    // 直接复用 Mobile 的汇总与本地时间格式,tooltip 只追加重置卡相关行。
+    expect(source).toContain('summarizeCodexRateLimitReset');
+    expect(source).toContain('resetSummary?.resetRows');
   });
 
   it('keeps Codex OAuth subscription details in the chip and tooltip', () => {

--- a/apps/desktop/src/renderer/__tests__/useCodexRateLimits.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useCodexRateLimits.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { MobileCodexRateLimitsResult } from '@cindy/maker-shared/device-link-contract';
@@ -30,7 +30,7 @@ describe('useCodexRateLimits', () => {
 
     const { result: hook } = renderHook(() => useCodexRateLimits(true));
 
-    await waitFor(() => expect(hook.current).toBe(result));
+    await waitFor(() => expect(hook.current.snapshot).toBe(result));
     expect(getCodexRateLimits).toHaveBeenCalledTimes(1);
   });
 
@@ -42,8 +42,58 @@ describe('useCodexRateLimits', () => {
 
     const { result: hook } = renderHook(() => useCodexRateLimits(false));
 
-    expect(hook.current).toBeNull();
+    expect(hook.current.snapshot).toBeNull();
     expect(getCodexRateLimits).not.toHaveBeenCalled();
+  });
+
+  it('retries a transient initial failure when the tooltip asks for fresh data', async () => {
+    const getCodexRateLimits = vi.fn()
+      .mockRejectedValueOnce(new Error('app-server starting'))
+      .mockResolvedValueOnce(result);
+    vi.stubGlobal('electronAPI', {
+      maker: { usage: { getCodexRateLimits } },
+    });
+
+    const { result: hook } = renderHook(() => useCodexRateLimits(true));
+
+    await waitFor(() => expect(getCodexRateLimits).toHaveBeenCalledTimes(1));
+    expect(hook.current.snapshot).toBeNull();
+
+    act(() => hook.current.refresh());
+
+    await waitFor(() => expect(hook.current.snapshot).toBe(result));
+    expect(getCodexRateLimits).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the old account and refetches after a Codex auth change', async () => {
+    const nextResult: MobileCodexRateLimitsResult = {
+      ...result,
+      account: { ...result.account, accountId: 'next-account' },
+      rateLimitResetCredits: { availableCount: 1, credits: [] },
+    };
+    const getCodexRateLimits = vi.fn()
+      .mockResolvedValueOnce(result)
+      .mockResolvedValueOnce(nextResult);
+    let onStateChanged: ((payload: { agentKind: string }) => void) | undefined;
+    vi.stubGlobal('electronAPI', {
+      maker: {
+        auth: {
+          onStateChanged: vi.fn((callback) => {
+            onStateChanged = callback;
+            return vi.fn();
+          }),
+        },
+        usage: { getCodexRateLimits },
+      },
+    });
+
+    const { result: hook } = renderHook(() => useCodexRateLimits(true));
+    await waitFor(() => expect(hook.current.snapshot).toBe(result));
+
+    act(() => onStateChanged?.({ agentKind: 'codex' }));
+
+    await waitFor(() => expect(hook.current.snapshot).toBe(nextResult));
+    expect(getCodexRateLimits).toHaveBeenCalledTimes(2);
   });
 
   it('degrades to null when the preload API is absent or the read fails', async () => {

--- a/apps/desktop/src/renderer/__tests__/useCodexRateLimits.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useCodexRateLimits.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { MobileCodexRateLimitsResult } from '@cindy/maker-shared/device-link-contract';
+import {
+  readCodexRateLimitsSafely,
+  useCodexRateLimits,
+} from '@/hooks/useCodexRateLimits';
+
+const result: MobileCodexRateLimitsResult = {
+  account: { email: null, accountId: null, planType: 'plus' },
+  rateLimits: {},
+  rateLimitsByLimitId: null,
+  rateLimitResetCredits: { availableCount: 2, credits: [] },
+  resetOffer: null,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useCodexRateLimits', () => {
+  it('loads the existing Desktop Codex rate-limit channel when enabled', async () => {
+    const getCodexRateLimits = vi.fn().mockResolvedValue(result);
+    vi.stubGlobal('electronAPI', {
+      maker: { usage: { getCodexRateLimits } },
+    });
+
+    const { result: hook } = renderHook(() => useCodexRateLimits(true));
+
+    await waitFor(() => expect(hook.current).toBe(result));
+    expect(getCodexRateLimits).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not read local Codex account data when disabled', () => {
+    const getCodexRateLimits = vi.fn().mockResolvedValue(result);
+    vi.stubGlobal('electronAPI', {
+      maker: { usage: { getCodexRateLimits } },
+    });
+
+    const { result: hook } = renderHook(() => useCodexRateLimits(false));
+
+    expect(hook.current).toBeNull();
+    expect(getCodexRateLimits).not.toHaveBeenCalled();
+  });
+
+  it('degrades to null when the preload API is absent or the read fails', async () => {
+    await expect(readCodexRateLimitsSafely(undefined)).resolves.toBeNull();
+    await expect(readCodexRateLimitsSafely(
+      vi.fn().mockRejectedValue(new Error('app-server unavailable')),
+    )).resolves.toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -34,6 +34,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
+import {
+  summarizeCodexRateLimitReset,
+  type CodexRateLimitResetSummary,
+} from '@cindy/maker-shared/session-controls';
 
 import { cn } from '@/lib/utils';
 import {
@@ -72,6 +76,7 @@ import {
   type ClaudeUsageWindow,
 } from '../../../shared/claudeSubscriptionUsage';
 import { useCodexRuntimeRoute } from '@/hooks/useCodexRuntimeRoute';
+import { useCodexRateLimits } from '@/hooks/useCodexRateLimits';
 import { useXaiRateLimit, type XaiRateLimitSnapshot } from '@/hooks/useXaiRateLimit';
 import { makerChatStore, type ChatMessage } from '@/lib/makerChatStore';
 import { buildTurnUsageTooltipLines } from '@/lib/turnUsageTooltip';
@@ -452,6 +457,7 @@ function buildCodexTooltipNode(
   snapshot: RateLimitSnapshot | null,
   sessionTokens: number | null,
   sessionValueMoney: RegionalMoney | null,
+  resetSummary: CodexRateLimitResetSummary | null,
   t: TFunction,
   usageDashboardLabel: string | null,
   nowMs: number,
@@ -460,6 +466,7 @@ function buildCodexTooltipNode(
   const lines: string[] = [];
   if (!snapshot) {
     lines.push(t('todaySpend.codex.waitingDetail'));
+    pushCodexResetCreditLines(lines, resetSummary);
     appendLatestTurnUsageLines(lines, latestTurnUsage, t);
     pushDashboardLinkLine(lines, usageDashboardLabel);
     return buildTooltipNode(lines);
@@ -490,6 +497,7 @@ function buildCodexTooltipNode(
     lines.push(t('todaySpend.codex.balanceAvailable'));
   }
   pushSessionValueLines(lines, sessionValueMoney, sessionTokens, t);
+  pushCodexResetCreditLines(lines, resetSummary);
 
   for (const window of getCodexWindowUsages(snapshot, t, nowMs)) {
     const base = t('todaySpend.codex.windowLine', {
@@ -856,6 +864,16 @@ function pushSessionValueLines(
   }
 }
 
+/** 与 Mobile 共用同一组 label/value 与本地时间格式；账号行不进入紧凑 tooltip。 */
+function pushCodexResetCreditLines(
+  lines: string[],
+  resetSummary: CodexRateLimitResetSummary | null,
+): void {
+  for (const row of resetSummary?.resetRows ?? []) {
+    lines.push(`${row.label}：${row.value}`);
+  }
+}
+
 /**
  * xAI(SuperGrok bridge)tooltip —— 尽力档:有限流快照(bridge 抓到 x-ratelimit-* 头)就
  * 显示剩余请求/tokens,拿不到诚实标注「无订阅额度明细」,只显示价值估算 + token 累计。
@@ -1056,6 +1074,11 @@ export function TodaySpendChip({
     // app-server 形态下据当前模型匹配限额桶(账号可能同时有主配额桶与模型专属
     // 促销桶, 见 useAccountUsage.matchCodexBucketForModel)。
     modelId,
+  );
+  const codexRateLimits = useCodexRateLimits(isCodexOauth && !isAnyRemoteSession);
+  const codexResetSummary = React.useMemo(
+    () => summarizeCodexRateLimitReset(codexRateLimits, Date.now()),
+    [codexRateLimits],
   );
   // xAI 限流快照同为本机 main 抓的 —— 远程会话(SSH / device-link)同样抑制,回落价值估算。
   const xaiRateLimit = useXaiRateLimit(usesXaiQuotaForm && !isAnyRemoteSession);
@@ -1263,6 +1286,7 @@ export function TodaySpendChip({
       accountUsage,
       sessionTokens,
       sessionEstimatedValueMoney,
+      codexResetSummary,
       t,
       usageDashboardLabel,
       windowLabelNowMs,

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -238,6 +238,28 @@ function formatResetAt(epochSeconds: number | null | undefined): string | null {
   ).format(date);
 }
 
+/** Codex 重置卡到期时间：沿用产品的“当天时分、跨天月日+时分”，按界面语言本地化。 */
+function formatResetCreditExpiryAt(
+  epochSeconds: number | null | undefined,
+  nowMs: number,
+  locale: string,
+): string | null {
+  if (typeof epochSeconds !== 'number' || !Number.isFinite(epochSeconds) || epochSeconds <= 0) {
+    return null;
+  }
+  const date = new Date(epochSeconds * 1000);
+  const now = new Date(nowMs);
+  const sameDay = date.getFullYear() === now.getFullYear()
+    && date.getMonth() === now.getMonth()
+    && date.getDate() === now.getDate();
+  return new Intl.DateTimeFormat(
+    locale,
+    sameDay
+      ? { hour: 'numeric', minute: '2-digit' }
+      : { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' },
+  ).format(date);
+}
+
 /**
  * chip 主体用的紧凑剩余时长(距 reset 还有多久): 单级精度 + 向上取整 ——
  * 「7天」/「3小时」/「45分钟」/「41秒」。Codex 与 Claude 订阅两种形态统一用它当窗口
@@ -459,6 +481,7 @@ function buildCodexTooltipNode(
   sessionValueMoney: RegionalMoney | null,
   resetSummary: CodexRateLimitResetSummary | null,
   t: TFunction,
+  locale: string,
   usageDashboardLabel: string | null,
   nowMs: number,
   latestTurnUsage: LatestTurnUsageSummary | null,
@@ -466,7 +489,7 @@ function buildCodexTooltipNode(
   const lines: string[] = [];
   if (!snapshot) {
     lines.push(t('todaySpend.codex.waitingDetail'));
-    pushCodexResetCreditLines(lines, resetSummary);
+    pushCodexResetCreditLines(lines, resetSummary, t, locale, nowMs);
     appendLatestTurnUsageLines(lines, latestTurnUsage, t);
     pushDashboardLinkLine(lines, usageDashboardLabel);
     return buildTooltipNode(lines);
@@ -497,7 +520,7 @@ function buildCodexTooltipNode(
     lines.push(t('todaySpend.codex.balanceAvailable'));
   }
   pushSessionValueLines(lines, sessionValueMoney, sessionTokens, t);
-  pushCodexResetCreditLines(lines, resetSummary);
+  pushCodexResetCreditLines(lines, resetSummary, t, locale, nowMs);
 
   for (const window of getCodexWindowUsages(snapshot, t, nowMs)) {
     const base = t('todaySpend.codex.windowLine', {
@@ -864,13 +887,26 @@ function pushSessionValueLines(
   }
 }
 
-/** 与 Mobile 共用同一组 label/value 与本地时间格式；账号行不进入紧凑 tooltip。 */
+/** 与 Mobile 共用中性汇总字段；Desktop label、次数和时间按当前界面语言展示。 */
 function pushCodexResetCreditLines(
   lines: string[],
   resetSummary: CodexRateLimitResetSummary | null,
+  t: TFunction,
+  locale: string,
+  nowMs: number,
 ): void {
-  for (const row of resetSummary?.resetRows ?? []) {
-    lines.push(`${row.label}：${row.value}`);
+  if (resetSummary?.hasResetCreditCount) {
+    lines.push(t('todaySpend.codex.resetCreditsAvailableLine', {
+      count: resetSummary.availableCount,
+    }));
+  }
+  const expiryAt = formatResetCreditExpiryAt(
+    resetSummary?.earliestExpiryAt,
+    nowMs,
+    locale,
+  );
+  if (expiryAt) {
+    lines.push(t('todaySpend.codex.resetCreditEarliestExpiryLine', { at: expiryAt }));
   }
 }
 
@@ -961,7 +997,8 @@ export function TodaySpendChip({
   remoteHostId,
   deviceLinkDeviceId,
 }: TodaySpendChipProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const formatterLocale = i18n.resolvedLanguage ?? i18n.language;
   // device-link 远程会话:turn 跑在被控端、消耗被控端账号,计费形态(订阅/网关)与账号
   // 余量的事实都在被控端 —— 本机的 route 观察 / 账号快照与之无关,一律不读、不据此分类。
   const isDeviceLinkRemote = Boolean(deviceLinkDeviceId);
@@ -1075,7 +1112,10 @@ export function TodaySpendChip({
     // 促销桶, 见 useAccountUsage.matchCodexBucketForModel)。
     modelId,
   );
-  const codexRateLimits = useCodexRateLimits(isCodexOauth && !isAnyRemoteSession);
+  const {
+    snapshot: codexRateLimits,
+    refresh: refreshCodexRateLimits,
+  } = useCodexRateLimits(isCodexOauth && !isAnyRemoteSession);
   // xAI 限流快照同为本机 main 抓的 —— 远程会话(SSH / device-link)同样抑制,回落价值估算。
   const xaiRateLimit = useXaiRateLimit(usesXaiQuotaForm && !isAnyRemoteSession);
   // cc 与 codex-api 共用同一把 XD gateway key 的 LiteLLM quota; codex-oauth 不订阅。
@@ -1288,6 +1328,7 @@ export function TodaySpendChip({
       sessionEstimatedValueMoney,
       codexResetSummary,
       t,
+      formatterLocale,
       usageDashboardLabel,
       windowLabelNowMs,
       latestTurnUsage,
@@ -1424,7 +1465,12 @@ export function TodaySpendChip({
   );
 
   return (
-    <div ref={chipRef} className="inline-flex h-5 shrink-0 items-center gap-3">
+    <div
+      ref={chipRef}
+      className="inline-flex h-5 shrink-0 items-center gap-3"
+      onMouseEnter={refreshCodexRateLimits}
+      onFocusCapture={refreshCodexRateLimits}
+    >
       <Tip text={tooltipNode}>
         {isDashboardClickable ? (
           <button

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1076,10 +1076,6 @@ export function TodaySpendChip({
     modelId,
   );
   const codexRateLimits = useCodexRateLimits(isCodexOauth && !isAnyRemoteSession);
-  const codexResetSummary = React.useMemo(
-    () => summarizeCodexRateLimitReset(codexRateLimits, Date.now()),
-    [codexRateLimits],
-  );
   // xAI 限流快照同为本机 main 抓的 —— 远程会话(SSH / device-link)同样抑制,回落价值估算。
   const xaiRateLimit = useXaiRateLimit(usesXaiQuotaForm && !isAnyRemoteSession);
   // cc 与 codex-api 共用同一把 XD gateway key 的 LiteLLM quota; codex-oauth 不订阅。
@@ -1119,6 +1115,10 @@ export function TodaySpendChip({
           ? t('todaySpend.openClaudeUsage')
           : null;
   const [windowLabelNowMs, setWindowLabelNowMs] = React.useState(() => Date.now());
+  const codexResetSummary = React.useMemo(
+    () => summarizeCodexRateLimitReset(codexRateLimits, windowLabelNowMs),
+    [codexRateLimits, windowLabelNowMs],
+  );
 
   // 当前形态下 chip 展示的限额窗口段 (Codex 订阅 / Claude 订阅共用结构);
   // 其它形态为空数组, 两个 rollup slot 空转。

--- a/apps/desktop/src/renderer/hooks/useCodexRateLimits.ts
+++ b/apps/desktop/src/renderer/hooks/useCodexRateLimits.ts
@@ -1,8 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { MobileCodexRateLimitsResult } from '@cindy/maker-shared/device-link-contract';
 
 type CodexRateLimitsReader = () => Promise<MobileCodexRateLimitsResult>;
+type CodexAuthStateSubscriber = (
+  callback: (payload: { agentKind?: string }) => void,
+) => () => void;
 
 function readCodexRateLimitsReader(): CodexRateLimitsReader | undefined {
   return (window as unknown as {
@@ -14,6 +17,18 @@ function readCodexRateLimitsReader(): CodexRateLimitsReader | undefined {
       };
     };
   }).electronAPI?.maker?.usage?.getCodexRateLimits;
+}
+
+function readCodexAuthStateSubscriber(): CodexAuthStateSubscriber | undefined {
+  return (window as unknown as {
+    electronAPI?: {
+      maker?: {
+        auth?: {
+          onStateChanged?: CodexAuthStateSubscriber;
+        };
+      };
+    };
+  }).electronAPI?.maker?.auth?.onStateChanged;
 }
 
 /** Missing/older preload and failed app-server reads both degrade to no extra tooltip rows. */
@@ -28,24 +43,46 @@ export async function readCodexRateLimitsSafely(
   }
 }
 
-export function useCodexRateLimits(enabled: boolean): MobileCodexRateLimitsResult | null {
+export interface CodexRateLimitsState {
+  snapshot: MobileCodexRateLimitsResult | null;
+  /** Best-effort authoritative refetch, used when the tooltip is opened again. */
+  refresh: () => void;
+}
+
+export function useCodexRateLimits(enabled: boolean): CodexRateLimitsState {
   const [snapshot, setSnapshot] = useState<MobileCodexRateLimitsResult | null>(null);
+  const requestVersionRef = useRef(0);
+
+  const refresh = useCallback(() => {
+    if (!enabled) return;
+    const requestVersion = ++requestVersionRef.current;
+    void readCodexRateLimitsSafely(readCodexRateLimitsReader()).then((next) => {
+      if (requestVersionRef.current === requestVersion) setSnapshot(next);
+    });
+  }, [enabled]);
 
   useEffect(() => {
     if (!enabled) {
+      requestVersionRef.current += 1;
       setSnapshot(null);
       return;
     }
 
-    let cancelled = false;
-    void readCodexRateLimitsSafely(readCodexRateLimitsReader()).then((next) => {
-      if (!cancelled) setSnapshot(next);
+    refresh();
+    const onStateChanged = readCodexAuthStateSubscriber();
+    const unsubscribe = onStateChanged?.((payload) => {
+      if (payload.agentKind !== 'codex') return;
+      // Never show the previous account while the new authoritative read settles.
+      requestVersionRef.current += 1;
+      setSnapshot(null);
+      refresh();
     });
 
     return () => {
-      cancelled = true;
+      requestVersionRef.current += 1;
+      unsubscribe?.();
     };
-  }, [enabled]);
+  }, [enabled, refresh]);
 
-  return snapshot;
+  return { snapshot, refresh };
 }

--- a/apps/desktop/src/renderer/hooks/useCodexRateLimits.ts
+++ b/apps/desktop/src/renderer/hooks/useCodexRateLimits.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+import type { MobileCodexRateLimitsResult } from '@cindy/maker-shared/device-link-contract';
+
+type CodexRateLimitsReader = () => Promise<MobileCodexRateLimitsResult>;
+
+function readCodexRateLimitsReader(): CodexRateLimitsReader | undefined {
+  return (window as unknown as {
+    electronAPI?: {
+      maker?: {
+        usage?: {
+          getCodexRateLimits?: CodexRateLimitsReader;
+        };
+      };
+    };
+  }).electronAPI?.maker?.usage?.getCodexRateLimits;
+}
+
+/** Missing/older preload and failed app-server reads both degrade to no extra tooltip rows. */
+export async function readCodexRateLimitsSafely(
+  reader: CodexRateLimitsReader | undefined,
+): Promise<MobileCodexRateLimitsResult | null> {
+  if (!reader) return null;
+  try {
+    return await reader();
+  } catch {
+    return null;
+  }
+}
+
+export function useCodexRateLimits(enabled: boolean): MobileCodexRateLimitsResult | null {
+  const [snapshot, setSnapshot] = useState<MobileCodexRateLimitsResult | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSnapshot(null);
+      return;
+    }
+
+    let cancelled = false;
+    void readCodexRateLimitsSafely(readCodexRateLimitsReader()).then((next) => {
+      if (!cancelled) setSnapshot(next);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return snapshot;
+}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3165,6 +3165,8 @@
       "balanceAvailable": "Balance available",
       "balanceDepleted": "Balance depleted",
       "balanceUnlimited": "Balance Unlimited",
+      "resetCreditsAvailableLine": "Available resets: {{count}}",
+      "resetCreditEarliestExpiryLine": "Earliest expiry: {{at}}",
       "windowLine": "{{label}} {{remaining}} left ({{used}} used)",
       "windowSegment": "{{label}} {{remaining}} left",
       "resetAt": "resets {{at}}",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3164,6 +3164,8 @@
       "balanceAvailable": "残高あり",
       "balanceDepleted": "残高なし",
       "balanceUnlimited": "残高無制限",
+      "resetCreditsAvailableLine": "利用可能なリセット：{{count}}回",
+      "resetCreditEarliestExpiryLine": "最も早い有効期限：{{at}}",
       "windowLine": "{{label}} 残り {{remaining}} (使用済み {{used}})",
       "windowSegment": "{{label}} 残り {{remaining}}",
       "resetAt": "{{at}} にリセット",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3164,6 +3164,8 @@
       "balanceAvailable": "잔액 사용 가능",
       "balanceDepleted": "잔액 소진",
       "balanceUnlimited": "잔액 무제한",
+      "resetCreditsAvailableLine": "사용 가능한 재설정: {{count}}회",
+      "resetCreditEarliestExpiryLine": "가장 빠른 만료: {{at}}",
       "windowLine": "{{label}} 남음 {{remaining}} (사용 {{used}})",
       "windowSegment": "{{label}} {{remaining}} 남음",
       "resetAt": "{{at}} 재설정",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3164,6 +3164,8 @@
       "balanceAvailable": "余额可用",
       "balanceDepleted": "余额已耗尽",
       "balanceUnlimited": "余额不限",
+      "resetCreditsAvailableLine": "可用重置：{{count}} 次",
+      "resetCreditEarliestExpiryLine": "最早过期：{{at}}",
       "windowLine": "{{label}} 剩余 {{remaining}} (已用 {{used}})",
       "windowSegment": "{{label}} 剩余 {{remaining}}",
       "resetAt": "{{at}} 重置",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -4324,6 +4324,10 @@ interface ElectronAPI {
         cachedTokens?: number;
       }>;
       getAccount: (agentKind: 'claude-code' | 'codex') => Promise<unknown | null>;
+      /** Codex app-server authoritative windows and banked reset-credit metadata. */
+      getCodexRateLimits: () => Promise<
+        import('@cindy/maker-shared/device-link-contract').MobileCodexRateLimitsResult
+      >;
       /** provider-scoped 模型单价表；XD 价格与 model-access /models 同快照更新。 */
       getModelPricing: () => Promise<
         import('../shared/regionalMoney').ModelPricingCatalog | null

--- a/packages/maker-shared/src/__tests__/sessionControls.test.ts
+++ b/packages/maker-shared/src/__tests__/sessionControls.test.ts
@@ -82,10 +82,10 @@ describe('summarizeCodexRateLimitReset', () => {
     ]);
     expect(summary?.rows[3]).toMatchObject({ label: '最早过期' });
     expect(summary?.rows[3].value).toMatch(/^\d{2}:\d{2}$/);
-    expect(summary?.resetRows).toEqual([
-      { label: '可用重置', value: '2 次' },
-      { label: '最早过期', value: summary?.rows[3].value },
-    ]);
+    expect(summary).toMatchObject({
+      hasResetCreditCount: true,
+      earliestExpiryAt: base.resetOffer.expiresAt,
+    });
   });
 
   it('does not offer reset before exhaustion and leaves offer expiry to desktop', () => {
@@ -121,7 +121,13 @@ describe('summarizeCodexRateLimitReset', () => {
       resetOffer: null,
     }, NOW_MS);
 
-    expect(summary).toMatchObject({ availableCount: 0, shouldPrompt: true, canReset: false });
+    expect(summary).toMatchObject({
+      availableCount: 0,
+      hasResetCreditCount: false,
+      earliestExpiryAt: null,
+      shouldPrompt: true,
+      canReset: false,
+    });
     expect(summary?.rows).not.toContainEqual(expect.objectContaining({ label: '可用重置' }));
   });
 });

--- a/packages/maker-shared/src/__tests__/sessionControls.test.ts
+++ b/packages/maker-shared/src/__tests__/sessionControls.test.ts
@@ -82,6 +82,10 @@ describe('summarizeCodexRateLimitReset', () => {
     ]);
     expect(summary?.rows[3]).toMatchObject({ label: '最早过期' });
     expect(summary?.rows[3].value).toMatch(/^\d{2}:\d{2}$/);
+    expect(summary?.resetRows).toEqual([
+      { label: '可用重置', value: '2 次' },
+      { label: '最早过期', value: summary?.rows[3].value },
+    ]);
   });
 
   it('does not offer reset before exhaustion and leaves offer expiry to desktop', () => {

--- a/packages/maker-shared/src/sessionControls.ts
+++ b/packages/maker-shared/src/sessionControls.ts
@@ -144,6 +144,8 @@ export function summarizeAccountRateLimits(value: unknown, nowMs: number): {
 /** Mobile presentation model for banked Codex reset credits and their bound account. */
 export interface CodexRateLimitResetSummary {
   rows: Array<{ label: string; value: string }>;
+  /** Reset-credit-only rows, shared by Mobile and compact Desktop surfaces. */
+  resetRows: Array<{ label: string; value: string }>;
   availableCount: number;
   canReset: boolean;
   shouldPrompt: boolean;
@@ -159,19 +161,21 @@ export function summarizeCodexRateLimitReset(
 ): CodexRateLimitResetSummary | null {
   if (!value) return null;
   const rows: Array<{ label: string; value: string }> = [];
+  const resetRows: Array<{ label: string; value: string }> = [];
   if (value.account.email) rows.push({ label: '账号', value: value.account.email });
   if (value.account.accountId) rows.push({ label: 'Workspace', value: value.account.accountId });
 
   const availableCount = Math.max(0, Math.floor(value.rateLimitResetCredits?.availableCount ?? 0));
   if (value.rateLimitResetCredits) {
-    rows.push({ label: '可用重置', value: `${availableCount} 次` });
+    resetRows.push({ label: '可用重置', value: `${availableCount} 次` });
   }
 
   const earliestExpiry = value.resetOffer?.expiresAt ?? earliestCreditExpiry(
     value.rateLimitResetCredits?.credits ?? null,
   );
   const expiryText = formatRateLimitResetAt(earliestExpiry, nowMs);
-  if (expiryText) rows.push({ label: '最早过期', value: expiryText });
+  if (expiryText) resetRows.push({ label: '最早过期', value: expiryText });
+  rows.push(...resetRows);
 
   const snapshots = [
     value.rateLimits,
@@ -190,6 +194,7 @@ export function summarizeCodexRateLimitReset(
 
   return {
     rows,
+    resetRows,
     availableCount,
     shouldPrompt,
     canReset: shouldPrompt

--- a/packages/maker-shared/src/sessionControls.ts
+++ b/packages/maker-shared/src/sessionControls.ts
@@ -141,11 +141,13 @@ export function summarizeAccountRateLimits(value: unknown, nowMs: number): {
   return rows.length > 0 ? { rows } : null;
 }
 
-/** Mobile presentation model for banked Codex reset credits and their bound account. */
+/** Shared reset-credit summary; `rows` preserves Mobile UI while neutral fields serve other surfaces. */
 export interface CodexRateLimitResetSummary {
   rows: Array<{ label: string; value: string }>;
-  /** Reset-credit-only rows, shared by Mobile and compact Desktop surfaces. */
-  resetRows: Array<{ label: string; value: string }>;
+  /** Whether app-server returned reset-credit availability (including an explicit zero). */
+  hasResetCreditCount: boolean;
+  /** Earliest available reset-credit expiry, as Unix epoch seconds. */
+  earliestExpiryAt: number | null;
   availableCount: number;
   canReset: boolean;
   shouldPrompt: boolean;
@@ -161,21 +163,20 @@ export function summarizeCodexRateLimitReset(
 ): CodexRateLimitResetSummary | null {
   if (!value) return null;
   const rows: Array<{ label: string; value: string }> = [];
-  const resetRows: Array<{ label: string; value: string }> = [];
   if (value.account.email) rows.push({ label: '账号', value: value.account.email });
   if (value.account.accountId) rows.push({ label: 'Workspace', value: value.account.accountId });
 
+  const hasResetCreditCount = Boolean(value.rateLimitResetCredits);
   const availableCount = Math.max(0, Math.floor(value.rateLimitResetCredits?.availableCount ?? 0));
-  if (value.rateLimitResetCredits) {
-    resetRows.push({ label: '可用重置', value: `${availableCount} 次` });
+  if (hasResetCreditCount) {
+    rows.push({ label: '可用重置', value: `${availableCount} 次` });
   }
 
-  const earliestExpiry = value.resetOffer?.expiresAt ?? earliestCreditExpiry(
+  const earliestExpiryAt = value.resetOffer?.expiresAt ?? earliestCreditExpiry(
     value.rateLimitResetCredits?.credits ?? null,
   );
-  const expiryText = formatRateLimitResetAt(earliestExpiry, nowMs);
-  if (expiryText) resetRows.push({ label: '最早过期', value: expiryText });
-  rows.push(...resetRows);
+  const expiryText = formatRateLimitResetAt(earliestExpiryAt, nowMs);
+  if (expiryText) rows.push({ label: '最早过期', value: expiryText });
 
   const snapshots = [
     value.rateLimits,
@@ -194,7 +195,8 @@ export function summarizeCodexRateLimitReset(
 
   return {
     rows,
-    resetRows,
+    hasResetCreditCount,
+    earliestExpiryAt,
     availableCount,
     shouldPrompt,
     canReset: shouldPrompt


### PR DESCRIPTION
## 这次改了什么

### 摘要

Desktop 会话底部的“本轮花费 / 会话花费”悬停提示缺少 Codex 重置卡信息，和 Mobile 的会话信息面板不一致。本 PR 补齐 Desktop 的 preload → renderer 数据链路，复用 `maker-shared` 对可用数量与最早到期卡的统一计算，并由 Desktop 按当前界面语言和本地时间规范展示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：主动查重未发现相同 Issue 或在办 PR；#379、#382 仅为相关背景，并非重复项
- 本 PR 包含：补齐 `getCodexRateLimits` preload 与 renderer 类型；本机 Codex OAuth 会话读取权威快照；tooltip 增加“可用重置”和“最早过期”；共享汇总输出中性数量/到期字段；Desktop 四语言本地化；悬停、键盘聚焦及 Codex 换号时刷新；新增缺口、刷新、汇总、本地化与降级测试
- 明确不包含：Mobile 行为改动、重置卡消费操作、远程会话或 `chatgpt/` bridge 的本机账号读取、无关 UI 重构
- 用户可见变化：本机 Codex OAuth 会话的 Desktop 用量 tooltip 会按当前界面语言显示可用重置数；存在可用卡到期数据时显示最早到期的本地时间。再次悬停会刷新数据，换号时不会沿用旧账号快照
- 是否存在 breaking change：无

### UI 变化

- Desktop：仅在现有用量 tooltip 中追加两行文本；不改变 chip、布局、颜色或动效。hover/focus 会在后台 best-effort 刷新权威数据
- 截图：未附。该状态依赖已登录且账号真实返回 reset credits，本次未启动 Desktop 做账号态截图
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Theme System（沿用现有 tooltip 与主题 token，无新增样式）；§11 Voice & Content（接入 en / zh-CN / ja / ko i18n，并沿用“当天时分、跨天月日+时分”的本地时间规范）；§14.4 Motion & Transitions（未新增动效）

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run src/renderer/__tests__/useCodexRateLimits.test.ts src/renderer/__tests__/todaySpendChip.test.ts  # apps/desktop
结果：PASS（23 tests）

pnpm exec vitest run src/__tests__/sessionControls.test.ts  # packages/maker-shared
结果：PASS（25 tests）

pnpm typecheck  # apps/desktop
结果：PASS

Desktop 定向 ESLint（使用 --no-inline-config，规避 TodaySpendChip 既有且配置未安装的 react-hooks 规则注释）
结果：PASS

maker-shared 定向 ESLint
结果：PASS

git diff --check
结果：PASS
```

此前提交还运行过 `env GIT_CONFIG_GLOBAL=/dev/null pnpm test:unit`，当时完整 required unit workspaces 通过；最新 Review 修复由上述 48 项定向测试、Desktop typecheck 与 GitHub CI 继续覆盖。

### 手工验证

不涉及：未接管用户 Desktop / Codex 登录态；自动测试覆盖 IPC 暴露、仅本机会话启用、换号清旧数据、首次瞬态失败后重试、四语言资源、共享数量/到期语义及接口缺失/读取失败降级。

### 未执行或基线限制

- 未运行完整构建、打包、Xcode 或模拟器测试：改动限于既有 Desktop IPC 的 preload 暴露、renderer hook 与纯展示逻辑
- 未做真实账号截图：需要可返回 reset credits 的 Codex 账号态
- `packages/maker-shared` 的全量 `tsc --noEmit` 当前被 5 个与本 PR 无关的既有测试类型错误阻断（`brandIdentity.test.ts` 2 项、`composerPalette.test.ts` 3 项）；本 PR 涉及的共享源码已由 Desktop typecheck、定向测试与 lint 覆盖

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅本机 Codex OAuth 会话的 Desktop 用量 tooltip；刷新是 best-effort，且仅在挂载首读、tooltip 悬停/聚焦或 Codex auth 变化时发生
- 回滚 / 降级方式：接口缺失、读取失败或无数据时不追加任何行，保留原 tooltip；代码回滚只需 revert 本 PR 提交，无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试与说明
- [x] 已确认测试结果或说明未执行原因