### PR TITLE
fix(bridge): explain omitted tool result images

### DIFF
--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -179,6 +179,48 @@ describe('translateRequest', () => {
     expect(out.input).toEqual([{ type: 'function_call_output', call_id: 'c1', output: 'r1\nr2' }]);
   });
 
+  it('explains omitted tool-result images without forwarding image data', () => {
+    const secretImageData = 'base64-image-data-must-not-leak';
+    const out = translateRequest(
+      {
+        model: 'chatgpt/gpt-5.5',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'image-call',
+                content: [
+                  {
+                    type: 'image',
+                    source: {
+                      type: 'base64',
+                      media_type: 'image/png',
+                      data: secretImageData,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      { model: 'gpt-5.5' },
+    );
+
+    const output = out.input[0];
+    expect(output).toMatchObject({
+      type: 'function_call_output',
+      call_id: 'image-call',
+    });
+    if (output.type !== 'function_call_output') throw new Error('expected function_call_output');
+    expect(output.output).toContain('only supports plain-text tool results');
+    expect(output.output).toContain('Do not guess or fabricate');
+    expect(output.output).toContain('attach the image directly to a chat message');
+    expect(output.output).not.toContain(secretImageData);
+  });
+
   it('serverSideTools 恒定追加在 function tools 之后(位置固定 → 前缀稳定)', () => {
     const req: AnthropicMessagesRequest = {
       model: 'xai/grok-4.5',

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -33,6 +33,12 @@ import type {
   ResponsesToolChoice,
 } from './types.js';
 
+const TOOL_RESULT_IMAGE_OMITTED =
+  '[image omitted: this tool returned an image, but this provider route only supports ' +
+  'plain-text tool results, so the image data was not delivered. Do not guess or fabricate ' +
+  'the image contents. Ask the user to paste the relevant content as text or attach the image ' +
+  'directly to a chat message.]';
+
 /** system(string 或 text block 数组)拍平成 instructions 字符串。 */
 function systemToInstructions(system: AnthropicMessagesRequest['system']): string | undefined {
   if (system == null) return undefined;
@@ -57,8 +63,8 @@ function toolResultToString(content: unknown): string {
           const rec = b as Record<string, unknown>;
           if (rec.type === 'text' && typeof rec.text === 'string') return rec.text;
           // 工具结果里嵌图片等非文本内容:Responses 的 function_call_output 只吃字符串,
-          // 退化成占位描述,不丢整条(模型仍知道该工具产出过内容)。
-          if (rec.type === 'image') return '[image]';
+          // 退化成明确的文本说明,既不丢整条,也避免模型猜测无法送达的图像内容。
+          if (rec.type === 'image') return TOOL_RESULT_IMAGE_OMITTED;
           return JSON.stringify(rec);
         }
         return String(b);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `anthropic-responses-bridge` 将工具结果中的图片静默降级为裸 `[image]` 的问题。

Responses 的 `function_call_output` 只能承载字符串，因此图片本体仍不会进入工具结果；新的占位说明会明确告诉模型图片因当前 provider route 的纯文本工具结果限制而未送达，要求模型不要猜测图片内容，并引导用户改贴相关文本或把图片直接附到聊天消息。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #795
- 本 PR 包含：替换工具结果图片的无说明占位符；增加回归测试，覆盖说明文案和原始图片数据不进入输出
- 明确不包含：修改图片传输能力、UI、服务端或 provider wire schema
- 用户可见变化：使用 `chatgpt/`、`xai/` 等 bridge 路由时，模型能明确说明工具图片未送达，不再把裸 `[image]` 当作空结果或猜测内容
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/anthropic-responses-bridge test
结果：57 passed，3 个 live 条件测试 skipped，0 failed

pnpm --filter @cindy/anthropic-responses-bridge run --if-present typecheck
结果：通过

pnpm --filter @cindy/anthropic-responses-bridge lint
结果：通过

pnpm test:unit
结果：runner 298 passed、1 skipped；Desktop、Mobile 与所有要求的 packages 全部通过

pnpm check:dco
结果：1 个提交通过 DCO 检查

git diff --check
结果：通过
```

### 手工验证

不涉及；转换结果由单元测试直接断言。

### 未执行的验证

未调用真实 ChatGPT / xAI 上游：本次仅修改确定性的本地请求转换文本，完整转换与 handler 单元测试已覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅工具结果中 `type: "image"` block 转换成 Responses `function_call_output` 字符串时的占位文案；文本结果和聊天消息中的图片路径不变
- 回滚 / 降级方式：回滚本 PR 的单个提交即可恢复原 `[image]` 占位符

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
