### PR TITLE
fix(desktop): 钉死 drizzle companion 脚本的 CommonJS 模块格式

### DIFF
--- a/apps/desktop/drizzle/scripts/package.json
+++ b/apps/desktop/drizzle/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/apps/desktop/src/main/localDb/__tests__/migrationScriptModuleFormat.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/migrationScriptModuleFormat.test.ts
@@ -1,0 +1,66 @@
+/**
+ * 回归 #690：companion 脚本用 `module.exports` 导出，靠 Node type stripping 以
+ * CommonJS `require()` 加载。模块格式由「最近的 package.json `type` 字段」决定——
+ * 当安装路径的某个祖先目录存在 `"type": "module"` 的 package.json（Windows 安装在
+ * 用户目录下、或 macOS 从 Downloads 直接运行时都可能撞上用户自己的 package.json），
+ * 脚本会被当作 ESM 加载，`module.exports` 直接抛
+ * "module is not defined in ES module scope"，全部迁移失败（MIGRATE_FAILED）。
+ *
+ * 修复：`drizzle/scripts/package.json` 钉死 `{"type": "commonjs"}`，让最近的
+ * package.json 永远是我们自己的。本测试把真实 scripts 目录整体拷进一个
+ * `"type": "module"` 祖先目录下，再用子进程逐个 require，验证钉子生效。
+ */
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const realScriptsDir = path.resolve(__dirname, '../../../../drizzle/scripts');
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of cleanupDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('migration companion script module format', () => {
+  it('drizzle/scripts 携带 type=commonjs 钉子', () => {
+    const pkg = JSON.parse(
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('node:fs').readFileSync(path.join(realScriptsDir, 'package.json'), 'utf8'),
+    ) as { type?: string };
+    expect(pkg.type).toBe('commonjs');
+  });
+
+  it('祖先目录 type=module 时所有 companion 脚本仍可 require 并导出 run()', () => {
+    const ancestor = mkdtempSync(path.join(tmpdir(), 'cindy-esm-ancestor-'));
+    cleanupDirs.push(ancestor);
+    writeFileSync(path.join(ancestor, 'package.json'), '{"type":"module"}\n', 'utf8');
+    const scriptsDir = path.join(ancestor, 'drizzle', 'scripts');
+    cpSync(realScriptsDir, scriptsDir, { recursive: true });
+
+    const scriptFiles = readdirSync(scriptsDir).filter((name) => /^\d{4}_.*\.ts$/.test(name));
+    expect(scriptFiles.length).toBeGreaterThan(0);
+
+    const probe = `
+      const results = {};
+      for (const file of ${JSON.stringify(scriptFiles)}) {
+        try {
+          const mod = require(${JSON.stringify(scriptsDir)} + '/' + file);
+          results[file] = typeof mod.run;
+        } catch (err) {
+          results[file] = 'throw: ' + err.message.split('\\n')[0];
+        }
+      }
+      process.stdout.write(JSON.stringify(results));
+    `;
+    const stdout = execFileSync(process.execPath, ['-e', probe], { encoding: 'utf8' });
+    const results = JSON.parse(stdout) as Record<string, string>;
+    for (const file of scriptFiles) {
+      expect(results[file], file).toBe('function');
+    }
+  });
+});

--- a/apps/desktop/src/main/localDb/__tests__/migrationScriptModuleFormat.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/migrationScriptModuleFormat.test.ts
@@ -11,12 +11,23 @@
  * `"type": "module"` 祖先目录下，再用子进程逐个 require，验证钉子生效。
  */
 import { execFileSync } from 'node:child_process';
-import { cpSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const realScriptsDir = path.resolve(__dirname, '../../../../drizzle/scripts');
+
+/**
+ * 子进程 require 原始 `.ts` 依赖 Node type stripping：22.18+ 默认开启
+ * （`process.features.typescript` 为 'strip'），22.6–22.17 需显式
+ * `--experimental-strip-types`，更早的 22.x 完全不支持（跳过本用例——生产
+ * 运行时是 Electron 41 / Node 24，钉子本身不受影响）。
+ */
+const typeStripArgs = process.features.typescript ? [] : ['--experimental-strip-types'];
+const [nodeMajor = 0, nodeMinor = 0] = process.versions.node.split('.').map(Number);
+const nodeCanStripTypes =
+  Boolean(process.features.typescript) || nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 6);
 
 const cleanupDirs: string[] = [];
 
@@ -29,38 +40,43 @@ afterEach(() => {
 describe('migration companion script module format', () => {
   it('drizzle/scripts 携带 type=commonjs 钉子', () => {
     const pkg = JSON.parse(
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      require('node:fs').readFileSync(path.join(realScriptsDir, 'package.json'), 'utf8'),
+      readFileSync(path.join(realScriptsDir, 'package.json'), 'utf8'),
     ) as { type?: string };
     expect(pkg.type).toBe('commonjs');
   });
 
-  it('祖先目录 type=module 时所有 companion 脚本仍可 require 并导出 run()', () => {
-    const ancestor = mkdtempSync(path.join(tmpdir(), 'cindy-esm-ancestor-'));
-    cleanupDirs.push(ancestor);
-    writeFileSync(path.join(ancestor, 'package.json'), '{"type":"module"}\n', 'utf8');
-    const scriptsDir = path.join(ancestor, 'drizzle', 'scripts');
-    cpSync(realScriptsDir, scriptsDir, { recursive: true });
+  it.runIf(nodeCanStripTypes)(
+    '祖先目录 type=module 时所有 companion 脚本仍可 require 并导出 run()',
+    () => {
+      const ancestor = mkdtempSync(path.join(tmpdir(), 'cindy-esm-ancestor-'));
+      cleanupDirs.push(ancestor);
+      writeFileSync(path.join(ancestor, 'package.json'), '{"type":"module"}\n', 'utf8');
+      const scriptsDir = path.join(ancestor, 'drizzle', 'scripts');
+      cpSync(realScriptsDir, scriptsDir, { recursive: true });
 
-    const scriptFiles = readdirSync(scriptsDir).filter((name) => /^\d{4}_.*\.ts$/.test(name));
-    expect(scriptFiles.length).toBeGreaterThan(0);
+      const scriptFiles = readdirSync(scriptsDir).filter((name) => /^\d{4}_.*\.ts$/.test(name));
+      expect(scriptFiles.length).toBeGreaterThan(0);
 
-    const probe = `
-      const results = {};
-      for (const file of ${JSON.stringify(scriptFiles)}) {
-        try {
-          const mod = require(${JSON.stringify(scriptsDir)} + '/' + file);
-          results[file] = typeof mod.run;
-        } catch (err) {
-          results[file] = 'throw: ' + err.message.split('\\n')[0];
+      const probe = `
+        const results = {};
+        for (const file of ${JSON.stringify(scriptFiles)}) {
+          try {
+            const mod = require(${JSON.stringify(scriptsDir)} + '/' + file);
+            results[file] = typeof mod.run;
+          } catch (err) {
+            const msg = String(err && err.message ? err.message : err);
+            results[file] = 'throw: ' + msg.split('\\n')[0];
+          }
         }
+        process.stdout.write(JSON.stringify(results));
+      `;
+      const stdout = execFileSync(process.execPath, [...typeStripArgs, '-e', probe], {
+        encoding: 'utf8',
+      });
+      const results = JSON.parse(stdout) as Record<string, string>;
+      for (const file of scriptFiles) {
+        expect(results[file], file).toBe('function');
       }
-      process.stdout.write(JSON.stringify(results));
-    `;
-    const stdout = execFileSync(process.execPath, ['-e', probe], { encoding: 'utf8' });
-    const results = JSON.parse(stdout) as Record<string, string>;
-    for (const file of scriptFiles) {
-      expect(results[file], file).toBe('function');
-    }
-  });
+    },
+  );
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #690：全新安装点击登录即弹 `MIGRATE_FAILED: module is not defined in ES module scope`。

根因（已在本机复现）：drizzle 迁移的 companion 脚本是原始 `.ts` 文件，用 `module.exports` 导出，生产环境靠 Node type stripping 以 CommonJS `require()` 加载。Node 判定 `.ts` 文件模块格式时查找**最近的祖先 package.json 的 `type` 字段**——一旦安装路径的某个祖先目录存在用户自己的 `{"type": "module"}` package.json（Windows 默认装在用户目录下、macOS 从 Downloads 直接运行都可能撞上，开发者家目录里有残留 package.json 很常见），全部 25 个 companion 脚本会被当作 ESM 加载，`module.exports` 抛出该 ReferenceError，迁移整体失败。复现实验：无钉子 + `"type": "module"` 祖先目录下，25/25 脚本全部加载失败；加钉子后全部恢复。

修法：在 `apps/desktop/drizzle/scripts/` 放置 `{"type": "commonjs"}` 的 package.json，使最近的 package.json 永远是我们自己的，模块格式与安装环境解耦。该目录已随 forge `extraResource` 整目录发包，dev（源码路径）与 packaged 同时生效。`listMigrations` 只匹配 `NNNN_*.sql` 与同名 `.ts`，新增文件对扫描完全惰性；不触碰任何已冻结的 migration 文件。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #690
- 本 PR 包含：`drizzle/scripts/package.json` 格式钉子；回归测试 `migrationScriptModuleFormat.test.ts`（把真实 scripts 目录拷进 `"type": "module"` 祖先目录下，子进程逐个 `require` 并断言导出 `run()`；另断言钉子文件存在且为 commonjs）
- 明确不包含：companion 加载器改造、migration 内容变更
- 用户可见变化：受影响环境不再在登录时弹 MIGRATE_FAILED；正常环境无变化
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/localDb/__tests__/migrationScriptModuleFormat.test.ts
结果：2 passed

pnpm --filter desktop db:validate
结果：6/6 步通过（25 个配套脚本 CJS 校验、历史 runtime identity 冻结均不受影响）

pnpm --filter desktop test:migration-replay
结果：6 passed

pnpm test:unit（仓库根，全量）
结果：exit 0，全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

macOS（darwin arm64）：
- 用仓内 Electron 41.2.0（Node 24.14.0）`require()` 打包路径下的 companion 脚本，加载正常；
- 复现实验：将 scripts 目录（去掉钉子）拷入 `{"type": "module"}` 祖先目录，25/25 脚本 `run` 导出丢失或抛错；恢复钉子后 25/25 正常。

### 未执行的验证

Windows / Linux 实机未验证——机制是 Node 跨平台的 package.json 查找规则，回归测试已在纯 Node 层覆盖同一路径。issue 报告环境（"新安装的"）无更多细节，无法逐一还原原始环境，但该根因可完整解释「全新安装 + 登录触发全量迁移 + ESM scope 报错」的组合。

## 风险

### 风险分类

- [x] SQLite / migration

### 影响与回滚

- 影响范围：仅影响 companion 脚本的模块格式解析；不改动任何 migration SQL / companion 内容、hash 与执行顺序，`db:validate` 的历史冻结校验通过。
- 回滚 / 降级方式：删除 `drizzle/scripts/package.json` 即回到原行为（回归测试会随之失败）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
