### PR TITLE
fix(maker-shared): 脱敏网关 principal 并识别 ExceededBudget 额度信号

### DIFF
--- a/packages/maker-shared/src/errorRedaction.test.ts
+++ b/packages/maker-shared/src/errorRedaction.test.ts
@@ -134,6 +134,14 @@ describe('redactSensitiveText', () => {
     expect(extractNonSecretErrorSignals('{"code":"ExceededBudget"}')).toEqual({
       usageLimit: true,
     });
+    // 网关结构化错误也常用 error / message 字段承载额度码(review 反馈:只认
+    // code|type 会把 {"error":"ExceededBudget"} 判成普通错误进 blocked)。
+    expect(extractNonSecretErrorSignals('{"error":"ExceededBudget","spend":12.3}')).toEqual({
+      usageLimit: true,
+    });
+    expect(extractNonSecretErrorSignals('{"message":"budget_exceeded"}')).toEqual({
+      usageLimit: true,
+    });
     expect(extractNonSecretErrorSignals('upstream said budget_exceeded, status=429')).toEqual({
       errorStatus: 429,
       usageLimit: true,

--- a/packages/maker-shared/src/errorRedaction.test.ts
+++ b/packages/maker-shared/src/errorRedaction.test.ts
@@ -112,6 +112,38 @@ describe('redactSensitiveText', () => {
     expect(output).not.toMatch(/abc123|def456|ghi789/);
   });
 
+  it('redacts gateway principals while keeping surrounding diagnostics', () => {
+    const output = redactSensitiveText(
+      '{"error":"ExceededBudget","principal":"aigw:v1:cindy:usr_a1b2c3","spend":12.34,"budget":10}',
+    );
+
+    expect(output).not.toContain('usr_a1b2c3');
+    expect(output).toContain('aigw:[REDACTED]');
+    expect(output).toContain('ExceededBudget');
+    expect(output).toContain('"spend":12.34');
+
+    const inline = redactSensitiveText('Request rejected (429): budget check failed for aigw:v1:cindy:usr_a1b2c3, retry later');
+    expect(inline).not.toContain('usr_a1b2c3');
+    expect(inline).toContain('aigw:[REDACTED], retry later');
+  });
+
+  it('recognizes gateway budget-exhaustion signals', () => {
+    expect(
+      extractNonSecretErrorSignals('Request rejected (429): ExceededBudget for aigw:v1:cindy:usr_a1b2c3'),
+    ).toEqual({ errorStatus: 429, usageLimit: true });
+    expect(extractNonSecretErrorSignals('{"code":"ExceededBudget"}')).toEqual({
+      usageLimit: true,
+    });
+    expect(extractNonSecretErrorSignals('upstream said budget_exceeded, status=429')).toEqual({
+      errorStatus: 429,
+      usageLimit: true,
+    });
+    // A 504 gateway timeout is not a quota signal and carries no supported status.
+    expect(
+      extractNonSecretErrorSignals('{"code":"origin_gateway_timeout","status":504}'),
+    ).toEqual({ usageLimit: false });
+  });
+
   it('keeps redaction idempotent for existing placeholders', () => {
     const output = 'access_token=[REDACTED] key=[REDACTED_KEY]';
 

--- a/packages/maker-shared/src/errorRedaction.test.ts
+++ b/packages/maker-shared/src/errorRedaction.test.ts
@@ -127,6 +127,17 @@ describe('redactSensitiveText', () => {
     expect(inline).toContain('aigw:[REDACTED], retry later');
   });
 
+  it('keeps gateway principal redaction idempotent (review 反馈)', () => {
+    // 没有 negative lookahead 时第二遍会匹配 `aigw:[REDACTED`(`]` 在排除集里),
+    // 每跑一遍多长出一个 `]`;多路径重复调用 redactSensitiveText 是常态。
+    const once = redactSensitiveText('aigw:v1:cindy:usr_a1b2c3');
+    expect(once).toBe('aigw:[REDACTED]');
+    expect(redactSensitiveText(once)).toBe('aigw:[REDACTED]');
+    expect(redactSensitiveText(redactSensitiveText(once))).toBe('aigw:[REDACTED]');
+    const inJson = redactSensitiveText(redactSensitiveText('{"principal":"aigw:v1:cindy:usr_a1b2c3"}'));
+    expect(inJson).toContain('"aigw:[REDACTED]"');
+  });
+
   it('recognizes gateway budget-exhaustion signals', () => {
     expect(
       extractNonSecretErrorSignals('Request rejected (429): ExceededBudget for aigw:v1:cindy:usr_a1b2c3'),

--- a/packages/maker-shared/src/errorRedaction.ts
+++ b/packages/maker-shared/src/errorRedaction.ts
@@ -52,7 +52,7 @@ export function extractNonSecretErrorSignals(input: string): NonSecretErrorSigna
       input,
     ) ?? /\brequest\s+rejected\s*\(\s*(401|429|529)\s*\)/i.exec(input);
   const usageLimit =
-    /(?:^|[\s,{;])(?:rate\s+limit(?:ed|s|ing)?|usage\s+limit(?:ed|s|ing)?|too\s+many\s+requests|quota(?:["']?\s*[:=]\s*["']?|\s+)(?:exhausted|exceeded)|(?:["']?(?:code|type)["']?\s*[:=]\s*["']?)?(?:rate_limit_exceeded|insufficient_quota|exceeded[-_ ]?budget|budget[-_ ]?exceeded))\b/i.test(
+    /(?:^|[\s,{;])(?:rate\s+limit(?:ed|s|ing)?|usage\s+limit(?:ed|s|ing)?|too\s+many\s+requests|quota(?:["']?\s*[:=]\s*["']?|\s+)(?:exhausted|exceeded)|(?:["']?(?:code|type|error|message)["']?\s*[:=]\s*["']?)?(?:rate_limit_exceeded|insufficient_quota|exceeded[-_ ]?budget|budget[-_ ]?exceeded))\b/i.test(
       input,
     );
 

--- a/packages/maker-shared/src/errorRedaction.ts
+++ b/packages/maker-shared/src/errorRedaction.ts
@@ -31,8 +31,10 @@ export function redactSensitiveText(input: string): string {
   );
   // Gateway principals (`aigw:...`) are stable per-user identifiers; quota and
   // routing errors embed them verbatim. Strip the whole value so persisted or
-  // displayed errors cannot leak an internal user id.
-  output = output.replace(/\baigw:[^\s"'`,;)\]}]+/gi, 'aigw:[REDACTED]');
+  // displayed errors cannot leak an internal user id. The negative lookahead
+  // keeps this idempotent: without it a second pass matches `aigw:[REDACTED`
+  // (`]` is in the excluded set) and grows the placeholder to `[REDACTED]]`.
+  output = output.replace(/\baigw:(?!\[REDACTED\])[^\s"'`,;)\]}]+/gi, 'aigw:[REDACTED]');
   return output;
 }
 

--- a/packages/maker-shared/src/errorRedaction.ts
+++ b/packages/maker-shared/src/errorRedaction.ts
@@ -29,6 +29,10 @@ export function redactSensitiveText(input: string): string {
     /([?&](?:api[-_]?key|access[-_]?token|refresh[-_]?token|token)=)[^&#\s]+/gi,
     '$1[REDACTED]',
   );
+  // Gateway principals (`aigw:...`) are stable per-user identifiers; quota and
+  // routing errors embed them verbatim. Strip the whole value so persisted or
+  // displayed errors cannot leak an internal user id.
+  output = output.replace(/\baigw:[^\s"'`,;)\]}]+/gi, 'aigw:[REDACTED]');
   return output;
 }
 
@@ -46,9 +50,9 @@ export function extractNonSecretErrorSignals(input: string): NonSecretErrorSigna
   const statusMatch =
     /(?:^|[\s,{;])["']?(?:status(?:[-_ ]?code)?|http(?:[-_ ]?status)?|code)["']?\s*(?:[:=]\s*)?["']?(401|429|529)["']?(?=$|[\s,;:}\]])/i.exec(
       input,
-    );
+    ) ?? /\brequest\s+rejected\s*\(\s*(401|429|529)\s*\)/i.exec(input);
   const usageLimit =
-    /(?:^|[\s,{;])(?:rate\s+limit(?:ed|s|ing)?|usage\s+limit(?:ed|s|ing)?|too\s+many\s+requests|quota(?:["']?\s*[:=]\s*["']?|\s+)(?:exhausted|exceeded)|(?:["']?(?:code|type)["']?\s*[:=]\s*["']?)?(?:rate_limit_exceeded|insufficient_quota))\b/i.test(
+    /(?:^|[\s,{;])(?:rate\s+limit(?:ed|s|ing)?|usage\s+limit(?:ed|s|ing)?|too\s+many\s+requests|quota(?:["']?\s*[:=]\s*["']?|\s+)(?:exhausted|exceeded)|(?:["']?(?:code|type)["']?\s*[:=]\s*["']?)?(?:rate_limit_exceeded|insufficient_quota|exceeded[-_ ]?budget|budget[-_ ]?exceeded))\b/i.test(
       input,
     );
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

#741 的共享脱敏 / 分类边界部分（issue「代码核查结论」第一条指出的 `errorRedaction.ts` 缺口）：

1. `redactSensitiveText` 新增整体脱敏 `aigw:` 前缀的网关内部 principal（→ `aigw:[REDACTED]`），使 429 `ExceededBudget` 等网关错误正文里形如 `aigw:v1:cindy:<id>` 的稳定内部用户标识在进入事件链、落库与展示之前就被清掉，同时保留周边诊断上下文（错误码、spend/budget 数值等）。
2. `extractNonSecretErrorSignals` 将 `ExceededBudget` / `budget_exceeded` 归入 `usageLimit` 信号，并支持从 `Request rejected (401|429|529)` 形态提取状态码，让额度耗尽走既有的 usageLimit 分类而不是未知错误。504 网关超时不会被误判为额度信号（有反例用例）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Refs #741（部分修复，不关闭）
- 本 PR 包含：`packages/maker-shared/src/errorRedaction.ts` 的 principal 脱敏与信号识别，及对应测试
- 明确不包含：#741 其余验收项——错误卡 / Error Banner 的四语言产品文案映射、历史存量错误的渲染层防御性处理、额度入口跳转。这些属 UI 层，留待后续 PR
- 用户可见变化：额度类错误文本中的内部 principal 显示为 `aigw:[REDACTED]`；额度耗尽错误开始携带 usageLimit / 429 信号，供既有分类链路消费
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-shared test
结果：49 files / 690 tests 全部通过（含新增 2 个用例：principal 脱敏保留诊断上下文、ExceededBudget/Request rejected (429) 信号识别与 504 反例）

pnpm test:unit（仓库根，全量）
结果：exit 0，全部通过

pnpm check:dco
结果：通过
```

### 手工验证

不涉及（纯函数改动，行为由单测覆盖）。

### 未执行的验证

未在真实网关额度耗尽环境端到端复现——issue 引用的 Discord 截图含内部标识未公开，测试样本按 issue 描述的错误形态（`ExceededBudget`、`Request rejected (429)`、`aigw:v1:cindy:<id>`、`origin_gateway_timeout`）构造。若维护者有真实（已脱敏）错误正文样本，欢迎补充为用例。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：所有经 `redactSensitiveText` 的错误文本会额外匹配 `aigw:` 前缀 token；`usageLimit` 信号新增两种触发形态，下游（usageLimit 分类、goal-host 非终态处理）按既有语义消费。误报面：正文中恰好出现非 principal 的 `aigw:...` 字样会被一并脱敏——按 fail-closed 取舍可接受。
- 回滚 / 降级方式：revert 本 commit 即可，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
