### PR TITLE
fix(anthropic-responses-bridge): tool_result 图像占位文案说明协议限制并禁止臆测

### DIFF
--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -199,7 +199,9 @@ describe('translateRequest', () => {
       ],
     };
     const out = translateRequest(req, { model: 'gpt-5.5' });
-    const item = out.input?.[0] as { type: string; output: string };
+    // 先断言长度再取元素:input 缺失时给出清晰断言失败而不是 TypeError。
+    expect(out.input).toHaveLength(1);
+    const item = out.input![0] as { type: string; output: string };
     expect(item.type).toBe('function_call_output');
     expect(item.output).toContain('screenshot below');
     // 占位文案要素:确认有图、说明送不到是路由限制、禁止臆测、给出改走 user 消息的出路。

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -179,6 +179,38 @@ describe('translateRequest', () => {
     expect(out.input).toEqual([{ type: 'function_call_output', call_id: 'c1', output: 'r1\nr2' }]);
   });
 
+  it('tool_result 图像块降级为带说明的占位文案,图像数据不外泄 (#795)', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'gpt-5.5',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'c1',
+              content: [
+                { type: 'text', text: 'screenshot below' },
+                { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAABBBB' } },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const out = translateRequest(req, { model: 'gpt-5.5' });
+    const item = out.input?.[0] as { type: string; output: string };
+    expect(item.type).toBe('function_call_output');
+    expect(item.output).toContain('screenshot below');
+    // 占位文案要素:确认有图、说明送不到是路由限制、禁止臆测、给出改走 user 消息的出路。
+    expect(item.output).toContain('[image omitted:');
+    expect(item.output).toContain('Do NOT guess');
+    expect(item.output).toContain('attach the image');
+    // 图像字节与旧版裸占位符都不应出现。
+    expect(item.output).not.toContain('AAAABBBB');
+    expect(item.output).not.toContain('[image]');
+  });
+
   it('serverSideTools 恒定追加在 function tools 之后(位置固定 → 前缀稳定)', () => {
     const req: AnthropicMessagesRequest = {
       model: 'xai/grok-4.5',

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -58,7 +58,19 @@ function toolResultToString(content: unknown): string {
           if (rec.type === 'text' && typeof rec.text === 'string') return rec.text;
           // 工具结果里嵌图片等非文本内容:Responses 的 function_call_output 只吃字符串,
           // 退化成占位描述,不丢整条(模型仍知道该工具产出过内容)。
-          if (rec.type === 'image') return '[image]';
+          // 占位文案必须说明「有图但送不到、不要猜」:字符串限制是协议层的,与模型
+          // 是否具备视觉能力无关;不带说明的 '[image]' 会被模型当作空结果,诱发反复
+          // 重读或臆测图像内容。图像走 user 消息路径仍可正常送达(input_image)。
+          if (rec.type === 'image') {
+            return (
+              '[image omitted: this tool returned an image, but tool results on this '
+              + 'provider route are delivered as plain text only, so the image data could '
+              + 'not be included. Do NOT guess or fabricate what the image contains. '
+              + 'Tell the user the image could not be delivered on the current route, and '
+              + 'ask them to paste the relevant content as text or attach the image '
+              + 'directly to a chat message instead.]'
+            );
+          }
           return JSON.stringify(rec);
         }
         return String(b);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #795：订阅直连模型（chatgpt/、xai/ 前缀）经 anthropic-responses-bridge 时，tool_result 内嵌图像降级为裸 `'[image]'` 占位符，模型无从知晓「曾有图像存在但送不到」，会当作空结果反复重读或臆测图像内容。

Responses 的 `function_call_output` 只接受字符串，降级本身不可避免（协议层限制，与模型视觉能力无关）。本 PR 把占位文案改为说明三点：图像因当前路由限制无法随工具结果送达；禁止猜测或编造图像内容；引导模型告知用户改贴文本或把图直接附到聊天消息（user 消息图像经此 bridge 仍正常转为 `input_image`）。

措辞采纳 issue 报告者（盖世大宝）随附补丁的方向：中性描述协议限制，刻意不建议「换视觉模型」——该路径上全是视觉模型，换了没用。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #795
- 本 PR 包含：`translate-request.ts` 的 `toolResultToString` 图像占位文案；回归测试
- 明确不包含：其他非文本 block 类型的占位策略、#794 讨论的能力门控
- 用户可见变化：模型收到的 function_call_output 占位文案变化，遇图会明确告知用户送达失败并给出替代路径，而不是臆测
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/anthropic-responses-bridge exec vitest run
结果：3 files 57 passed | 3 skipped（skipped 为 live-bridge 联网用例，默认跳过）。新增用例断言：占位要素齐全（[image omitted: / Do NOT guess / attach the image）、同一 tool_result 的文本块保留、图像 base64 字节不外泄、旧版裸 '[image]' 不再出现

pnpm --filter @cindy/anthropic-responses-bridge run --if-present typecheck
结果：通过

pnpm test:unit（仓库根，全量）
结果：exit 0，全部通过

pnpm check:dco
结果：通过
```

### 手工验证

不涉及（纯翻译函数改动，行为由单测覆盖）。

### 未执行的验证

未跑 live-bridge 联网用例（默认 skip，需要真实订阅凭证）；占位文案对模型行为的实际引导效果属提示词性质，无法用单测断言。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 anthropic-responses-bridge 路径上 tool_result 含 image block 时发给上游的占位字符串内容；wire 结构不变。
- 回滚 / 降级方式：revert 本 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
