### PR TITLE
feat(desktop): 让问答输入框随长回答自适应扩展

### DIFF
--- a/apps/desktop/src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import '@/i18n';
+import type { PendingAskUser } from '@/lib/makerChatStore';
+import { AskUserQuestionPrompt } from '../components/new-chat/AskUserQuestionPrompt';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderAskUser(
+  pending: PendingAskUser,
+  onAnswer: (requestId: string, answers: Record<string, string>) => void,
+) {
+  return render(
+    createElement(AskUserQuestionPrompt, {
+      pending,
+      onAnswer,
+      viewerState: 'expanded',
+      onViewerStateChange: () => {},
+      draft: null,
+      onDraftChange: () => {},
+    }),
+  );
+}
+
+function mockScrollHeight(textarea: HTMLTextAreaElement, height: number): void {
+  Object.defineProperty(textarea, 'scrollHeight', {
+    configurable: true,
+    value: height,
+  });
+}
+
+describe('AskUserQuestionPrompt long answers', () => {
+  it('grows the custom-answer textarea and caps very long content with internal scrolling', async () => {
+    const { getByPlaceholderText, getByText } = renderAskUser(
+      {
+        requestId: 'req-options',
+        questions: [{ question: 'Pick one?', options: [{ label: 'A' }, { label: 'B' }] }],
+      },
+      vi.fn(),
+    );
+
+    fireEvent.click(getByText('Type something else...'));
+    const textarea = getByPlaceholderText('Type your answer...') as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe('TEXTAREA');
+
+    mockScrollHeight(textarea, 96);
+    fireEvent.change(textarea, {
+      target: { value: 'A long answer that wraps onto several lines' },
+    });
+    await waitFor(() => expect(textarea.style.height).toBe('96px'));
+    expect(textarea.style.overflowY).toBe('hidden');
+
+    mockScrollHeight(textarea, 260);
+    fireEvent.change(textarea, {
+      target: { value: 'An even longer answer that should stay inside the prompt card'.repeat(8) },
+    });
+    await waitFor(() => expect(textarea.style.height).toBe('148px'));
+    expect(textarea.style.overflowY).toBe('auto');
+
+    mockScrollHeight(textarea, 44);
+    fireEvent.change(textarea, { target: { value: 'Short again' } });
+    await waitFor(() => expect(textarea.style.height).toBe('44px'));
+    expect(textarea.style.overflowY).toBe('hidden');
+  });
+
+  it('uses a multiline free-text editor where Shift+Enter adds a line and Enter submits', () => {
+    const onAnswer = vi.fn();
+    const { getByPlaceholderText } = renderAskUser(
+      {
+        requestId: 'req-free-text',
+        questions: [{ question: 'Explain your decision' }],
+      },
+      onAnswer,
+    );
+
+    const textarea = getByPlaceholderText('Type your answer...') as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe('TEXTAREA');
+    fireEvent.change(textarea, { target: { value: 'First point\nSecond point' } });
+
+    expect(fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true })).toBe(true);
+    expect(onAnswer).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onAnswer).toHaveBeenCalledWith('req-free-text', {
+      'Explain your decision': 'First point\nSecond point',
+    });
+  });
+
+  it('submits selected options and a multiline custom answer with Enter in multi-select mode', () => {
+    const onAnswer = vi.fn();
+    const { getByPlaceholderText, getByText } = renderAskUser(
+      {
+        requestId: 'req-multi',
+        questions: [
+          {
+            question: 'Choose details',
+            multiSelect: true,
+            options: [{ label: 'A' }, { label: 'B' }],
+          },
+        ],
+      },
+      onAnswer,
+    );
+
+    fireEvent.click(getByText('A'));
+    fireEvent.click(getByText('Type something else...'));
+    const textarea = getByPlaceholderText('Type your answer...');
+    fireEvent.change(textarea, { target: { value: 'Extra\ncontext' } });
+
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(onAnswer).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onAnswer).toHaveBeenCalledWith('req-multi', {
+      'Choose details': JSON.stringify(['A', 'Extra\ncontext']),
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -12,11 +12,53 @@
  *   - Skip: empty string ""
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+  type TextareaHTMLAttributes,
+} from 'react';
 
 import { InteractionPromptCardShell } from '@/components/interaction-portal';
+import { useAutoResize } from '@/hooks/useAutoResize';
 import { cn } from '@/lib/utils';
 import type { AskUserDraft, AskUserViewerState, PendingAskUser } from '@/lib/makerChatStore';
+
+const ASK_USER_ANSWER_MAX_HEIGHT_PX = 148;
+
+interface AutoGrowingAnswerTextareaProps extends Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'value'
+> {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  value: string;
+}
+
+/**
+ * Keeps AskUserQuestion answers readable in place while preserving the prompt
+ * card's context. Six-ish lines stay visible; longer answers scroll internally
+ * instead of growing over the question and option list.
+ */
+function AutoGrowingAnswerTextarea({
+  textareaRef,
+  value,
+  className,
+  ...props
+}: AutoGrowingAnswerTextareaProps) {
+  useAutoResize(textareaRef, value, ASK_USER_ANSWER_MAX_HEIGHT_PX);
+
+  return (
+    <textarea
+      {...props}
+      ref={textareaRef}
+      rows={1}
+      value={value}
+      className={cn('resize-none', className)}
+    />
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -90,7 +132,7 @@ export function AskUserQuestionPrompt({
   // Custom input
   const [customInput, setCustomInput] = useState('');
   const [showCustomInput, setShowCustomInput] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // ── Animation state ──
   const [slideDirection, setSlideDirection] = useState<'left' | 'right' | null>(null);
@@ -570,11 +612,11 @@ export function AskUserQuestionPrompt({
             {/* "Type something else..." row */}
             <div className="h-px bg-[var(--ask-option-divider)]" />
             {showCustomInput ? (
-              <div className="flex items-center gap-2 px-[16px] py-[14px]">
+              <div className="flex items-start gap-2 px-[16px] py-[14px]">
                 {isMultiSelect && (
                   <div
                     className={cn(
-                      'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px]',
+                      'mt-[2px] flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px]',
                       customInput.trim()
                         ? 'bg-[var(--ask-checkbox-checked-bg)]'
                         : 'border-[1.5px] border-[var(--ask-checkbox-border)]',
@@ -596,15 +638,15 @@ export function AskUserQuestionPrompt({
                     )}
                   </div>
                 )}
-                <input
-                  ref={inputRef}
-                  type="text"
+                <AutoGrowingAnswerTextarea
+                  textareaRef={inputRef}
                   value={customInput}
                   onChange={(e) => setCustomInput(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.nativeEvent.isComposing && !isMultiSelect) {
+                    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
                       e.preventDefault();
-                      handleCustomSubmit();
+                      if (isMultiSelect) handleNext();
+                      else handleCustomSubmit();
                     }
                     if (e.key === 'Escape') {
                       e.preventDefault();
@@ -614,7 +656,7 @@ export function AskUserQuestionPrompt({
                   }}
                   placeholder="Type your answer..."
                   className={cn(
-                    'flex-1 bg-transparent text-14 font-normal outline-none',
+                    'min-h-[22px] min-w-0 flex-1 bg-transparent text-14 font-normal leading-[22px] outline-none',
                     'text-[var(--ask-input-text)] placeholder:text-[var(--ask-input-placeholder)]',
                     'select-text',
                   )}
@@ -625,7 +667,7 @@ export function AskUserQuestionPrompt({
                     onClick={handleCustomSubmit}
                     disabled={!customInput.trim()}
                     className={cn(
-                      'shrink-0 rounded-[9999px] px-[16px] py-[6px]',
+                      'self-end shrink-0 rounded-[9999px] px-[16px] py-[6px]',
                       'text-13 font-medium',
                       customInput.trim()
                         ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
@@ -663,14 +705,13 @@ export function AskUserQuestionPrompt({
 
         {/* Free-text input when no options */}
         {options.length === 0 && (
-          <div className="flex gap-2">
-            <input
-              ref={inputRef}
-              type="text"
+          <div className="flex items-end gap-2">
+            <AutoGrowingAnswerTextarea
+              textareaRef={inputRef}
               value={customInput}
               onChange={(e) => setCustomInput(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
                   e.preventDefault();
                   if (customInput.trim()) advance(customInput.trim());
                 }
@@ -682,7 +723,7 @@ export function AskUserQuestionPrompt({
               placeholder="Type your answer..."
               autoFocus
               className={cn(
-                'h-10 flex-1 rounded-[12px] border px-3 text-14 outline-none',
+                'min-h-10 min-w-0 flex-1 rounded-[8px] border px-3 py-[8px] text-14 leading-[22px] outline-none',
                 'border-[var(--ask-input-border)] bg-[var(--ask-input-bg)] text-[var(--ask-input-text)]',
                 'placeholder:text-[var(--ask-input-placeholder)]',
               )}
@@ -692,7 +733,7 @@ export function AskUserQuestionPrompt({
               onClick={() => customInput.trim() && advance(customInput.trim())}
               disabled={!customInput.trim()}
               className={cn(
-                'rounded-[9999px] px-4 text-14 font-medium transition-colors',
+                'h-10 rounded-[9999px] px-4 text-14 font-medium transition-colors',
                 customInput.trim()
                   ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
                   : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',


### PR DESCRIPTION
## 这次改了什么

### 摘要

AskUserQuestion 的自定义回答和无选项纯文本回答此前都是单行输入框。回答较长时，用户只能反复水平移动光标检查内容。

本 PR 将两处统一为就地自适应的多行文本框：内容随输入增高，约 6 行后在框内滚动；不离开当前问题，也不增加额外弹窗与保存步骤。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户直接反馈（无 GitHub Issue）
- 本 PR 包含：
  - 自定义回答与纯文本回答由单行 `input` 改为自适应 `textarea`
  - 复用现有 `useAutoResize`，内容增长与删除时同步增高 / 回缩，148px 后启用内部滚动
  - 保留 IME 组合输入保护；统一 Enter 发送、Shift+Enter 换行
  - 覆盖单选自定义回答、无选项回答与多选自定义回答
  - 新增长度增长、上限滚动、回缩与键盘语义回归测试
- 明确不包含：弹窗式长文本编辑器、Mobile UI、AskUserQuestion 的既有英文文案 i18n 整理
- 用户可见变化：长回答可直接查看和编辑多行内容；超长回答不会无限撑高问题卡
- 是否存在 breaking change：无

### UI 变化

回答框从固定单行改为自适应多行；未新增颜色、阴影、图标或视觉层级。未附新截图，原因见「未执行的验证」。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4 Inputs & Forms / §5 Border Radius：多行输入采用 8px inner-control 圆角，沿用现有 Ask 输入色彩 token
  - `docs/design-rules/DESIGN.md` §10 Light / Dark：不新增硬编码颜色或单主题分支，两种模式继续消费同一组现有语义 token
  - `docs/design-rules/DESIGN.md` §14.3 Keyboard & IME：Enter 发送、Shift+Enter 换行，IME 组合中的 Enter 不发送
  - `docs/design-rules/DESIGN.md` §8 Adaptive Behavior：高度有上限，超出后内部滚动，避免遮蔽问题与选项上下文

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run   src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx   src/renderer/__tests__/imeEnterCompositionGuard.test.ts
结果：8/8 通过

pnpm --filter desktop exec eslint   src/renderer/components/new-chat/AskUserQuestionPrompt.tsx   src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

env GIT_CONFIG_GLOBAL=/dev/null pnpm test:unit
结果：通过；脚本 runner 298 passed / 1 skipped，全部 required workspace PASS
说明：仅隔离本机全局 core.hooksPath，避免其污染 check-dco 临时仓 fixture；localhost mock-server 测试在允许回环绑定的测试环境运行
```

### 手工验证

不涉及：未启动 Desktop dev 实例，未接管用户当前 Cindy。

### 未执行的验证

- Light / Dark 实机目检未执行；实现未新增颜色，全部沿用现有 Ask token，但不将此等同于双模式已目检
- Windows / macOS 实机交互未执行；改动为 Renderer 原生 textarea，无平台分支
- 未附新截图或录屏

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：输入框键盘交互

### 影响与回滚

- 影响范围：Desktop Renderer 的 AskUserQuestion 回答输入区域；不改回答编码、草稿存储、IPC、协议或 Mobile
- 风险：多选自定义回答中，Enter 现在执行 Next / Submit；需要输入换行时使用 Shift+Enter，与全局 Ask 输入约定一致
- 回滚 / 降级方式：直接 revert 本 PR commit；无数据迁移与兼容负担

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；无需新增长期文档
- [x] 已确认测试结果或说明未执行原因
