### PR TITLE
fix(desktop): 会话模型入口明确显示当前 Agent

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -444,6 +444,74 @@ describe('ModelSelector trigger variants', () => {
     expect(trigger.getAttribute('aria-label')).toContain('超高');
   });
 
+  it('keeps the session Agent explicit when Claude Code uses an OpenAI-branded model', () => {
+    const model = {
+      id: 'chatgpt/gpt-5.6-terra',
+      displayName: 'GPT-5.6-Terra',
+      contextWindow: 400000,
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'medium',
+    };
+    visibleModelsRef.models = [model];
+    providersRef.providers = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'oauth' },
+        routing: { 'claude-code': {} },
+        connected: true,
+        models: {
+          'claude-code': [
+            {
+              id: model.id,
+              name: model.displayName,
+              contextWindow: model.contextWindow,
+              efforts: model.efforts,
+              defaultEffort: model.defaultEffort,
+            },
+          ],
+        },
+      },
+    ];
+
+    try {
+      const props = {
+        modelId: model.id,
+        effort: 'medium' as Effort,
+        onModelChange: vi.fn(),
+        onEffortChange: vi.fn(),
+        vendorKey: 'cc' as const,
+        currentProviderId: 'openai',
+        showAgentIdentity: true,
+      };
+      const view = render(React.createElement(ModelSelector, props));
+
+      let trigger = screen.getByRole('button', {
+        name: /Current: Claude Code · GPT-5\.6-Terra, effort: medium/,
+      });
+      expect(trigger.textContent).toContain('Claude Code');
+      expect(trigger.textContent).toContain('GPT-5.6-Terra');
+      expect(trigger.getAttribute('title')).toBe('Claude Code · GPT-5.6-Terra');
+
+      view.rerender(
+        React.createElement(ModelSelector, {
+          ...props,
+          compactToolbar: true,
+        }),
+      );
+      trigger = screen.getByRole('button', {
+        name: /Current: Claude Code · GPT-5\.6-Terra, effort: medium/,
+      });
+      expect(trigger.textContent).not.toContain('Claude Code');
+      expect(trigger.getAttribute('aria-label')).toContain('Claude Code');
+    } finally {
+      visibleModelsRef.models = null;
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
   it('keeps the disconnected status in the compact trigger title', () => {
     render(
       React.createElement(ModelSelector, {

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -28,6 +28,8 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'effortLevels.xhigh': '超高',
         'settings.providers.anthropic.title': 'Anthropic',
         'newChat.modelSelector.trigger.placeholder': '选择模型',
+        'newChat.modelSelector.trigger.agent.claudeCode': 'Claude Code',
+        'newChat.modelSelector.trigger.agent.codex': 'Codex',
         'newChat.modelSelector.pricing.free': '限时免费',
         'newChat.modelSelector.source.disconnected': '已断开',
       };

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -591,6 +591,9 @@ describe('ModelSelector trigger variants', () => {
         onModelChange: vi.fn(),
         onEffortChange: vi.fn(),
         vendorKey: displayAgent === 'codex' ? 'codex' : 'cc',
+        // ChatInput 只在真实 runtime 身份已落定时显示 Agent；intent 期间 vendor/model
+        // 是下一条消息的目标预览，不能把目标 Agent 写成当前身份。
+        showAgentIdentity: !intent,
         currentProviderId: intent?.providerId ?? null,
         onProviderChange: vi.fn(),
         onNavigateToProviders: vi.fn(),
@@ -599,6 +602,11 @@ describe('ModelSelector trigger variants', () => {
 
     const view = render(React.createElement(IntentTrigger, { refresh: 0 }));
     try {
+      let trigger = screen.getByRole('button', {
+        name: /Current: Claude Code · Opus 4\.8/,
+      });
+      expect(trigger.textContent).toContain('Claude Code');
+
       act(() => {
         makerChatStore.noteAgentSwitchIntent(sessionId, 'codex', {
           model: 'gpt-5.5',
@@ -608,8 +616,10 @@ describe('ModelSelector trigger variants', () => {
       });
       view.rerender(React.createElement(IntentTrigger, { refresh: 1 }));
 
-      const trigger = screen.getByRole('button', { name: /Current: GPT-5\.5/ });
+      trigger = screen.getByRole('button', { name: /Current: GPT-5\.5/ });
       expect(trigger.textContent).toContain('GPT-5.5');
+      expect(trigger.textContent).not.toContain('Codex');
+      expect(trigger.getAttribute('aria-label')).not.toContain('Codex');
       // providerId=null 仍应按目标模型的默认可连来源解析 icon。
       expect(trigger.textContent).toContain('Z');
       expect(trigger.textContent).not.toContain('newChat.modelSelector.source.connect');

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -18,6 +18,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         source?: string;
         value?: string;
         model?: string;
+        agent?: string;
         effort?: string;
         price?: string;
         percent?: string;
@@ -47,6 +48,15 @@ vi.mock('react-i18next', async (importOriginal) => ({
       }
       if (key === 'newChat.modelSelector.trigger.ariaWithEffort') {
         return `Select model. Current: ${options?.model}, effort: ${options?.effort}`;
+      }
+      if (key === 'newChat.modelSelector.trigger.agent.pending') {
+        return `Next: ${options?.agent}`;
+      }
+      if (key === 'newChat.modelSelector.trigger.pendingAria') {
+        return `Select model. Next message: ${options?.agent} · ${options?.model}`;
+      }
+      if (key === 'newChat.modelSelector.trigger.pendingAriaWithEffort') {
+        return `Select model. Next message: ${options?.agent} · ${options?.model}, effort: ${options?.effort}`;
       }
       if (key === 'newChat.modelSelector.pricing.discount') {
         return `立省 ${options?.percent}%`;
@@ -354,6 +364,7 @@ import {
   ModelSelectorContent,
   modelEffortLabel,
   modelListMaxHeightForRows,
+  resolveModelSelectorAgentIdentity,
 } from '@/components/new-chat/ModelSelector';
 import { makerChatStore } from '@/lib/makerChatStore';
 
@@ -486,7 +497,7 @@ describe('ModelSelector trigger variants', () => {
         onEffortChange: vi.fn(),
         vendorKey: 'cc' as const,
         currentProviderId: 'openai',
-        showAgentIdentity: true,
+        agentIdentity: { vendorKey: 'cc' as const, state: 'current' as const },
       };
       const view = render(React.createElement(ModelSelector, props));
 
@@ -512,6 +523,23 @@ describe('ModelSelector trigger variants', () => {
       visibleModelsRef.models = null;
       providersRef.providers = providersRef.DEFAULT_PROVIDERS;
     }
+  });
+
+  it('does not infer a current Agent from the fallback vendor before session identity loads', () => {
+    render(
+      React.createElement(ModelSelector, {
+        modelId: 'claude-opus-4-8',
+        effort: 'high' as Effort,
+        onModelChange: vi.fn(),
+        onEffortChange: vi.fn(),
+        vendorKey: 'cc',
+        agentIdentity: resolveModelSelectorAgentIdentity(null, null),
+      }),
+    );
+
+    const trigger = screen.getByRole('button', { name: /Current: Opus 4\.8/ });
+    expect(trigger.textContent).not.toContain('Claude Code');
+    expect(trigger.getAttribute('aria-label')).not.toContain('Claude Code');
   });
 
   it('keeps the disconnected status in the compact trigger title', () => {
@@ -593,9 +621,8 @@ describe('ModelSelector trigger variants', () => {
         onModelChange: vi.fn(),
         onEffortChange: vi.fn(),
         vendorKey: displayAgent === 'codex' ? 'codex' : 'cc',
-        // ChatInput 只在真实 runtime 身份已落定时显示 Agent；intent 期间 vendor/model
-        // 是下一条消息的目标预览，不能把目标 Agent 写成当前身份。
-        showAgentIdentity: !intent,
+        // 稳态来自已加载的真实 runtime；intent 是下一条消息的明确目标，不能写成 Current。
+        agentIdentity: resolveModelSelectorAgentIdentity('claude-code', intent?.target),
         currentProviderId: intent?.providerId ?? null,
         onProviderChange: vi.fn(),
         onNavigateToProviders: vi.fn(),
@@ -618,10 +645,19 @@ describe('ModelSelector trigger variants', () => {
       });
       view.rerender(React.createElement(IntentTrigger, { refresh: 1 }));
 
-      trigger = screen.getByRole('button', { name: /Current: GPT-5\.5/ });
+      trigger = screen.getByRole('button', {
+        name: /Next message: Codex · GPT-5\.5, effort: medium/,
+      });
       expect(trigger.textContent).toContain('GPT-5.5');
-      expect(trigger.textContent).not.toContain('Codex');
-      expect(trigger.getAttribute('aria-label')).not.toContain('Codex');
+      expect(trigger.textContent).toContain('Next: Codex');
+      expect(trigger.getAttribute('aria-label')).not.toContain('Current');
+      // 切换失败时 intent 会保留供重试；重复渲染仍明确标成“下条消息”，不会隐藏身份。
+      view.rerender(React.createElement(IntentTrigger, { refresh: 2 }));
+      expect(
+        screen.getByRole('button', {
+          name: /Next message: Codex · GPT-5\.5, effort: medium/,
+        }),
+      ).toBeTruthy();
       // providerId=null 仍应按目标模型的默认可连来源解析 icon。
       expect(trigger.textContent).toContain('Z');
       expect(trigger.textContent).not.toContain('newChat.modelSelector.source.connect');

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5275,6 +5275,9 @@ export function ChatInput({
                     onFastModeChange={handleFastModeChange}
                     modelMemory={modelMemory}
                     vendorKey={vendorKey}
+                    // 已创建会话要同时显式展示 Agent + 模型。来源图标只代表模型路由，
+                    // 不能拿它代替 Agent 身份（例如 Claude Code 也可运行 OpenAI 模型）。
+                    showAgentIdentity={!!sessionId && !!vendorKey}
                     // session-agent-switch:本机已建会话提供显式两步引擎切换(列表顶部
                     // Claude/Codex 分段,先选 Agent 再选模型)。草稿(无 sessionId)与
                     // device-link / SSH 远程会话不传(v1 不支持切换)。

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5275,9 +5275,10 @@ export function ChatInput({
                     onFastModeChange={handleFastModeChange}
                     modelMemory={modelMemory}
                     vendorKey={vendorKey}
-                    // 已创建会话要同时显式展示 Agent + 模型。来源图标只代表模型路由，
-                    // 不能拿它代替 Agent 身份（例如 Claude Code 也可运行 OpenAI 模型）。
-                    showAgentIdentity={!!sessionId && !!vendorKey}
+                    // 已创建且身份已落定的会话同时展示 Agent + 模型。切换 intent 期间
+                    // vendorKey / 模型是“下一条消息”的目标预览，不能冒充当前 runtime 身份；
+                    // 等 reducer 确认切换并清除 intent 后再恢复明确的 Agent 文案。
+                    showAgentIdentity={!!sessionId && !!vendorKey && !agentSwitchIntent}
                     // session-agent-switch:本机已建会话提供显式两步引擎切换(列表顶部
                     // Claude/Codex 分段,先选 Agent 再选模型)。草稿(无 sessionId)与
                     // device-link / SSH 远程会话不传(v1 不支持切换)。

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -81,7 +81,11 @@ import {
   tiptapDocHasContent,
 } from '@/lib/composerDraftStore';
 import { subscribeSessionLinkInsert } from '@/lib/composerActionsBus';
-import { ModelSelector, type ModelMemoryAccessors } from './ModelSelector';
+import {
+  ModelSelector,
+  resolveModelSelectorAgentIdentity,
+  type ModelMemoryAccessors,
+} from './ModelSelector';
 import {
   createEffortChangeCoordinator,
   enqueueEffortChange,
@@ -289,6 +293,11 @@ interface ChatInputProps {
   ) => boolean | void | Promise<boolean | void>;
   /** Session ID for binding workingDir. When absent, folder picker is hidden. */
   sessionId?: string;
+  /**
+   * 已由 session/runtime 元数据确认的当前 Agent。null/undefined 表示身份尚未加载；
+   * 不能用 vendorKey 的 Claude Code 默认回退冒充真实身份。
+   */
+  runtimeAgentKind?: AgentKind | null;
   /** Initial workingDir from session data. */
   initialWorkingDir?: string | null;
   /**
@@ -788,6 +797,7 @@ function detectTrigger(editor: Editor): TriggerState {
 export function ChatInput({
   onSend,
   sessionId,
+  runtimeAgentKind,
   initialWorkingDir,
   remoteHostId,
   deviceLinkDeviceId,
@@ -5275,10 +5285,17 @@ export function ChatInput({
                     onFastModeChange={handleFastModeChange}
                     modelMemory={modelMemory}
                     vendorKey={vendorKey}
-                    // 已创建且身份已落定的会话同时展示 Agent + 模型。切换 intent 期间
-                    // vendorKey / 模型是“下一条消息”的目标预览，不能冒充当前 runtime 身份；
-                    // 等 reducer 确认切换并清除 intent 后再恢复明确的 Agent 文案。
-                    showAgentIdentity={!!sessionId && !!vendorKey && !agentSwitchIntent}
+                    // 稳态只接受父层已加载的 session/runtime 身份；intent 存在时则明确标成
+                    // “下条消息”的目标。这样冷启动不猜 Claude Code，切换失败保留 intent
+                    // 供重试时也不会长期隐藏身份或把目标冒充为当前 Agent。
+                    agentIdentity={
+                      sessionId
+                        ? resolveModelSelectorAgentIdentity(
+                            runtimeAgentKind,
+                            agentSwitchIntent?.target,
+                          )
+                        : undefined
+                    }
                     // session-agent-switch:本机已建会话提供显式两步引擎切换(列表顶部
                     // Claude/Codex 分段,先选 Agent 再选模型)。草稿(无 sessionId)与
                     // device-link / SSH 远程会话不传(v1 不支持切换)。

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -300,6 +300,11 @@ interface ModelSelectorProps {
   modelMemory?: ModelMemoryAccessors;
   /** When provided, only models with this vendorKey are shown in the dropdown. */
   vendorKey?: 'cc' | 'codex';
+  /**
+   * 已创建会话的 trigger 同时展示 Agent 与模型，避免 Claude Code 使用 OpenAI 模型时
+   * 只看来源图标而误判成 Codex。紧凑布局仅视觉收起 Agent，aria/title 仍保留完整身份。
+   */
+  showAgentIdentity?: boolean;
   /** device-link 远程会话所属被控端 id;非空 = 列被控端的模型 + 退化为纯列表(不分供应商段)。 */
   deviceId?: string;
   /**
@@ -1547,6 +1552,7 @@ export function ModelSelector({
   onFastModeChange,
   modelMemory,
   vendorKey,
+  showAgentIdentity = false,
   deviceId,
   excludeSubscriptionDirect,
   excludeChatBridgedCodex,
@@ -1657,6 +1663,15 @@ export function ModelSelector({
     : (currentModel?.displayName ??
       (unknownLabel !== '' ? unknownLabel : null) ??
       t('newChat.modelSelector.trigger.placeholder'));
+  const agentIdentityLabel =
+    showAgentIdentity && vendorKey && !fallbackOption?.active
+      ? vendorKey === 'cc'
+        ? 'Claude Code'
+        : 'Codex'
+      : null;
+  const displayIdentityLabel = agentIdentityLabel
+    ? `${agentIdentityLabel} · ${displayLabel}`
+    : displayLabel;
   const efforts = currentModel?.efforts ?? [];
 
   const currentAgentKind: AgentKind | null = useMemo(() => {
@@ -1761,16 +1776,16 @@ export function ModelSelector({
   const baseAriaLabel = noSource
     ? t('newChat.modelSelector.source.connect')
     : showSourceDisconnected
-      ? `${t('newChat.modelSelector.source.disconnected')}: ${displayLabel}`
+      ? `${t('newChat.modelSelector.source.disconnected')}: ${displayIdentityLabel}`
       : effortLabel
         ? t('newChat.modelSelector.trigger.ariaWithEffort', {
-            model: displayLabel,
+            model: displayIdentityLabel,
             effort: effortLabel,
           })
-        : t('newChat.modelSelector.trigger.aria', { model: displayLabel });
+        : t('newChat.modelSelector.trigger.aria', { model: displayIdentityLabel });
   // compact 会隐藏断连状态文字；原生 title 仍需保留同一状态，避免鼠标用户悬停
   // 错误图标时只看到模型名、无法判断发送为何被阻断。
-  const triggerTitle = showSourceDisconnected ? baseAriaLabel : displayLabel;
+  const triggerTitle = showSourceDisconnected ? baseAriaLabel : displayIdentityLabel;
   // 多实例同屏(IM 目录偏好)时前置「字段名 · 行别名」,读屏才能区分行与行。
   const ariaLabel = ariaContext ? `${ariaContext}:${baseAriaLabel}` : baseAriaLabel;
   const isBudget = modelId.startsWith('codex/');
@@ -1780,6 +1795,28 @@ export function ModelSelector({
   // 正常会话在侧栏 + 浏览器 split-pane 下也必须让长模型名承担收缩。
   const isCompactToolbar = compactToolbar && !isFieldTrigger;
   const isUltraCompactToolbar = ultraCompactToolbar && isCompactToolbar;
+  const agentIdentityPrefix =
+    agentIdentityLabel && !isCompactToolbar ? (
+      <>
+        <span
+          className={cn(
+            'shrink-0 font-normal text-[var(--model-trigger-meta)]',
+            isCreateAgentVariant ? 'text-[12px]' : dense ? 'text-[12.5px]' : 'text-[13px]',
+          )}
+        >
+          {agentIdentityLabel}
+        </span>
+        <span
+          className={cn(
+            'shrink-0 font-normal text-[var(--model-trigger-meta)]',
+            isCreateAgentVariant ? 'text-[12px]' : dense ? 'text-[12.5px]' : 'text-[13px]',
+          )}
+          aria-hidden="true"
+        >
+          ·
+        </span>
+      </>
+    ) : null;
   // 保留 useMorphPopover 作用域开关(仅 composer 工具条 opt-in;settings/CreateWorker 用 Radix 回退),
   // 但去掉 !isCreateAgentVariant —— 新建对话框工具条也走脱身上浮 morph,与会话内统一(2026-07-22)。
   const morphEnabled = useMorphPopover && !isFieldTrigger;
@@ -1871,6 +1908,7 @@ export function ModelSelector({
             logoKind={disconnectedProvider?.logoKind}
             colorClass="text-[var(--error-fg)]"
           />
+          {agentIdentityPrefix}
           <span
             className={cn(
               'min-w-0 font-normal text-[var(--text-primary)]',
@@ -1922,6 +1960,7 @@ export function ModelSelector({
               }
             />
           )}
+          {agentIdentityPrefix}
           <span
             className={cn(
               'min-w-0 font-normal',

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -267,6 +267,32 @@ function ModelPromotionBadge({ children }: { children: ReactNode }) {
   );
 }
 
+export interface ModelSelectorAgentIdentity {
+  vendorKey: 'cc' | 'codex';
+  /**
+   * current = 已由会话/runtime 元数据确认的当前 Agent；
+   * pending = 已登记、将在下一条消息应用的切换目标。
+   */
+  state: 'current' | 'pending';
+}
+
+export function resolveModelSelectorAgentIdentity(
+  runtimeAgentKind: AgentKind | null | undefined,
+  pendingTarget: AgentKind | null | undefined,
+): ModelSelectorAgentIdentity | undefined {
+  if (pendingTarget) {
+    return {
+      vendorKey: pendingTarget === 'codex' ? 'codex' : 'cc',
+      state: 'pending',
+    };
+  }
+  if (!runtimeAgentKind) return undefined;
+  return {
+    vendorKey: runtimeAgentKind === 'codex' ? 'codex' : 'cc',
+    state: 'current',
+  };
+}
+
 interface ModelSelectorProps {
   modelId: string;
   effort: Effort;
@@ -302,9 +328,10 @@ interface ModelSelectorProps {
   vendorKey?: 'cc' | 'codex';
   /**
    * 已创建会话的 trigger 同时展示 Agent 与模型，避免 Claude Code 使用 OpenAI 模型时
-   * 只看来源图标而误判成 Codex。紧凑布局仅视觉收起 Agent，aria/title 仍保留完整身份。
+   * 只看来源图标而误判成 Codex。必须由权威 session/runtime 身份或明确切换 intent 提供，
+   * 不得从用于模型列表过滤的 vendorKey 推断。紧凑布局仅视觉收起，aria/title 保留完整语义。
    */
-  showAgentIdentity?: boolean;
+  agentIdentity?: ModelSelectorAgentIdentity;
   /** device-link 远程会话所属被控端 id;非空 = 列被控端的模型 + 退化为纯列表(不分供应商段)。 */
   deviceId?: string;
   /**
@@ -1552,7 +1579,7 @@ export function ModelSelector({
   onFastModeChange,
   modelMemory,
   vendorKey,
-  showAgentIdentity = false,
+  agentIdentity,
   deviceId,
   excludeSubscriptionDirect,
   excludeChatBridgedCodex,
@@ -1663,12 +1690,16 @@ export function ModelSelector({
     : (currentModel?.displayName ??
       (unknownLabel !== '' ? unknownLabel : null) ??
       t('newChat.modelSelector.trigger.placeholder'));
-  const agentIdentityLabel =
-    showAgentIdentity && vendorKey && !fallbackOption?.active
-      ? vendorKey === 'cc'
+  const agentName =
+    agentIdentity && !fallbackOption?.active
+      ? agentIdentity.vendorKey === 'cc'
         ? t('newChat.modelSelector.trigger.agent.claudeCode')
         : t('newChat.modelSelector.trigger.agent.codex')
       : null;
+  const agentIdentityLabel =
+    agentName && agentIdentity?.state === 'pending'
+      ? t('newChat.modelSelector.trigger.agent.pending', { agent: agentName })
+      : agentName;
   const displayIdentityLabel = agentIdentityLabel
     ? `${agentIdentityLabel} · ${displayLabel}`
     : displayLabel;
@@ -1777,12 +1808,23 @@ export function ModelSelector({
     ? t('newChat.modelSelector.source.connect')
     : showSourceDisconnected
       ? `${t('newChat.modelSelector.source.disconnected')}: ${displayIdentityLabel}`
-      : effortLabel
-        ? t('newChat.modelSelector.trigger.ariaWithEffort', {
-            model: displayIdentityLabel,
-            effort: effortLabel,
-          })
-        : t('newChat.modelSelector.trigger.aria', { model: displayIdentityLabel });
+      : agentIdentity?.state === 'pending' && agentName
+        ? effortLabel
+          ? t('newChat.modelSelector.trigger.pendingAriaWithEffort', {
+              agent: agentName,
+              model: displayLabel,
+              effort: effortLabel,
+            })
+          : t('newChat.modelSelector.trigger.pendingAria', {
+              agent: agentName,
+              model: displayLabel,
+            })
+        : effortLabel
+          ? t('newChat.modelSelector.trigger.ariaWithEffort', {
+              model: displayIdentityLabel,
+              effort: effortLabel,
+            })
+          : t('newChat.modelSelector.trigger.aria', { model: displayIdentityLabel });
   // compact 会隐藏断连状态文字；原生 title 仍需保留同一状态，避免鼠标用户悬停
   // 错误图标时只看到模型名、无法判断发送为何被阻断。
   const triggerTitle = showSourceDisconnected ? baseAriaLabel : displayIdentityLabel;

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1666,8 +1666,8 @@ export function ModelSelector({
   const agentIdentityLabel =
     showAgentIdentity && vendorKey && !fallbackOption?.active
       ? vendorKey === 'cc'
-        ? 'Claude Code'
-        : 'Codex'
+        ? t('newChat.modelSelector.trigger.agent.claudeCode')
+        : t('newChat.modelSelector.trigger.agent.codex')
       : null;
   const displayIdentityLabel = agentIdentityLabel
     ? `${agentIdentityLabel} · ${displayLabel}`

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3169,6 +3169,15 @@ export function CCAgentSessionView({
                   onSend={handleSend}
                   onBeforeVoiceInputStart={handleBeforeVoiceInputStart}
                   sessionId={sessionId}
+                  // session=null 是冷启动 / 直链 GET 尚未回流的合法首帧；显式传 null，
+                  // 让 ChatInput 暂不显示 Agent 身份，不能跟随 displayAgentKind 的 cc 回退。
+                  runtimeAgentKind={
+                    session
+                      ? session.agentKind === 'codex'
+                        ? 'codex'
+                        : 'claude-code'
+                      : null
+                  }
                   initialWorkingDir={session?.workingDir}
                   remoteHostId={session?.remoteHostId ?? null}
                   deviceLinkDeviceId={remoteDeviceId}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -4017,7 +4017,11 @@
       "trigger": {
         "placeholder": "Select model",
         "aria": "Select model. Current: {{model}}",
-        "ariaWithEffort": "Select model. Current: {{model}}, effort: {{effort}}"
+        "ariaWithEffort": "Select model. Current: {{model}}, effort: {{effort}}",
+        "agent": {
+          "claudeCode": "Claude Code",
+          "codex": "Codex"
+        }
       },
       "category": {
         "anthropic": "Anthropic",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -4018,9 +4018,12 @@
         "placeholder": "Select model",
         "aria": "Select model. Current: {{model}}",
         "ariaWithEffort": "Select model. Current: {{model}}, effort: {{effort}}",
+        "pendingAria": "Select model. Next message: {{agent}} · {{model}}",
+        "pendingAriaWithEffort": "Select model. Next message: {{agent}} · {{model}}, effort: {{effort}}",
         "agent": {
           "claudeCode": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pending": "Next: {{agent}}"
         }
       },
       "category": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4017,9 +4017,12 @@
         "placeholder": "モデルを選択",
         "aria": "モデルを選択。現在：{{model}}",
         "ariaWithEffort": "モデルを選択。現在：{{model}}、推論強度：{{effort}}",
+        "pendingAria": "モデルを選択。次のメッセージ：{{agent}} · {{model}}",
+        "pendingAriaWithEffort": "モデルを選択。次のメッセージ：{{agent}} · {{model}}、推論強度：{{effort}}",
         "agent": {
           "claudeCode": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pending": "次回：{{agent}}"
         }
       },
       "category": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4016,7 +4016,11 @@
       "trigger": {
         "placeholder": "モデルを選択",
         "aria": "モデルを選択。現在：{{model}}",
-        "ariaWithEffort": "モデルを選択。現在：{{model}}、推論強度：{{effort}}"
+        "ariaWithEffort": "モデルを選択。現在：{{model}}、推論強度：{{effort}}",
+        "agent": {
+          "claudeCode": "Claude Code",
+          "codex": "Codex"
+        }
       },
       "category": {
         "anthropic": "Anthropic",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4016,7 +4016,11 @@
       "trigger": {
         "placeholder": "모델 선택",
         "aria": "모델 선택. 현재: {{model}}",
-        "ariaWithEffort": "모델 선택. 현재: {{model}}, 추론 강도: {{effort}}"
+        "ariaWithEffort": "모델 선택. 현재: {{model}}, 추론 강도: {{effort}}",
+        "agent": {
+          "claudeCode": "Claude Code",
+          "codex": "Codex"
+        }
       },
       "category": {
         "anthropic": "Anthropic",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4017,9 +4017,12 @@
         "placeholder": "모델 선택",
         "aria": "모델 선택. 현재: {{model}}",
         "ariaWithEffort": "모델 선택. 현재: {{model}}, 추론 강도: {{effort}}",
+        "pendingAria": "모델 선택. 다음 메시지: {{agent}} · {{model}}",
+        "pendingAriaWithEffort": "모델 선택. 다음 메시지: {{agent}} · {{model}}, 추론 강도: {{effort}}",
         "agent": {
           "claudeCode": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pending": "다음: {{agent}}"
         }
       },
       "category": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4016,7 +4016,11 @@
       "trigger": {
         "placeholder": "选择模型",
         "aria": "选择模型。当前：{{model}}",
-        "ariaWithEffort": "选择模型。当前：{{model}}，推理强度：{{effort}}"
+        "ariaWithEffort": "选择模型。当前：{{model}}，推理强度：{{effort}}",
+        "agent": {
+          "claudeCode": "Claude Code",
+          "codex": "Codex"
+        }
       },
       "category": {
         "anthropic": "Anthropic",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4017,9 +4017,12 @@
         "placeholder": "选择模型",
         "aria": "选择模型。当前：{{model}}",
         "ariaWithEffort": "选择模型。当前：{{model}}，推理强度：{{effort}}",
+        "pendingAria": "选择模型。下条消息：{{agent}} · {{model}}",
+        "pendingAriaWithEffort": "选择模型。下条消息：{{agent}} · {{model}}，推理强度：{{effort}}",
         "agent": {
           "claudeCode": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pending": "下条：{{agent}}"
         }
       },
       "category": {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 可以运行 OpenAI 来源的模型。会话输入框的模型入口此前只显示来源/模型品牌图标与模型名，因此 OpenAI 图标很容易被误读为“当前 Agent 是 Codex”。

本 PR 在**已创建会话**的模型入口中同时显示 `Agent · 模型`，例如 `Claude Code · GPT-5.6-Terra`；OpenAI 图标仍表示模型来源，不冒充 Agent 身份。紧凑布局为保留发送区宽度只视觉收起 Agent 文案，但 `aria-label` 和 `title` 继续保留完整身份。

稳定态只显示已由会话元数据确认的当前 Agent；冷启动元数据未到达时不猜测身份。Agent 切换 intent 存续时，入口明确显示“下条消息：目标 Agent · 目标模型”，不会把目标冒充为当前身份，发送失败保留 intent 时也保持这一语义。Agent 文案通过 en / zh-CN / ja / ko i18n 键提供。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户截图反馈；新建任务默认策略另见 #834
- 本 PR 包含：桌面端已创建会话的模型入口身份展示、紧凑态无障碍语义、回归测试
- 明确不包含：新建任务默认 Agent / 模型策略；会话 Agent 或模型的持久化、切换、路由逻辑
- 用户可见变化：会话模型入口由“模型名”变为“Agent · 模型名”
- 是否存在 breaking change：无

### UI 变化

- 变化：保留现有模型来源图标，在非紧凑会话工具栏增加当前 Agent 文案；原始反馈截图含私密对话，未附公开截图
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md §15.13 Iconography`：Agent 身份不能与 Anthropic / OpenAI provider 或模型品牌标混用；模型选择继续按模型品牌渲染。本 PR 保留来源图标，同时用独立文字明确 Agent，二者语义不混用。
  - `docs/design-rules/DESIGN.md §14.4 Composer toolbar`：沿用现有 model selector 的 pill、token、字号与紧凑宽度规则，没有新增颜色、圆角或动效；窄态不扩张既有 148px / 64px 边界。
  - 可访问性：紧凑态只隐藏可见 Agent 文案，`aria-label` / `title` 仍包含 `Agent · 模型`。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：32 passed

pnpm --filter desktop typecheck
结果：通过

pnpm --dir apps/desktop exec eslint src/renderer/components/new-chat/ModelSelector.tsx src/renderer/components/new-chat/ChatInput.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过

pnpm test:guard
结果：通过

pnpm check:i18n
pnpm check:i18n-glossary
结果：通过（仅仓库既有 i18n 警告，无新增 key）

GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null pnpm test:unit
结果：全部 workspace 通过；desktop unit 166.2s
```

### 手工验证

- 只读核对反馈会话的本地 session / message 元数据：`agent_kind=cc`，运行模型为 OpenAI 来源的 GPT 模型；确认没有切回 Codex。
- 未上传会话内容、数据库数据或原始截图。

### 未执行的验证

- 未启动可见 Electron 桌面做截图，避免干扰当前桌面；原始截图含私密对话。DOM 回归覆盖普通态、紧凑态、可访问名称与悬停标题。
- 不涉及 mobile / Xcode / 模拟器。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅桌面 renderer 中已创建会话的 ModelSelector trigger 展示；模型选择、Agent 切换、来源路由和持久化逻辑不变。
- 回滚 / 降级方式：回退本 PR 即可恢复原展示；`agentIdentity` 未提供时，其他 ModelSelector 消费方行为不变。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需产品文档）
- [x] 已确认测试结果或说明未执行原因