### PR TITLE
fix(cindy-brain): 插件手册补 icon 字段与官方仓发布门禁,scaffold 默认生成占位图标

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
@@ -274,7 +274,18 @@ describe('scaffoldGhostDir', () => {
       if (!result.ok) return;
       expect(result.files).toContain('ghost.json');
       expect(result.files).toContain('main.js');
+      expect(result.files).toContain('assets/icon.png');
       expect(result.files.includes('node/worker.cjs')).toBe(template.startsWith('node-'));
+
+      // 骨架默认带占位图标(#809):清单声明 + 文件真实存在且是 PNG。
+      const manifestJson = JSON.parse(
+        await fs.promises.readFile(path.join(dir, 'ghost.json'), 'utf8'),
+      ) as { icon?: string };
+      expect(manifestJson.icon).toBe('assets/icon.png');
+      const iconBytes = await fs.promises.readFile(path.join(dir, 'assets/icon.png'));
+      expect(iconBytes.subarray(0, 8)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      );
 
       const packed = await packGhostDir(dir);
       expect(packed.ok, JSON.stringify(packed)).toBe(true);
@@ -492,6 +503,13 @@ describe('FORGE_GUIDE', () => {
       '创建工作区会话(workspace 槽)',
       'cindy.workspace',
       "kind: 'ensure-session'",
+      // 2026-07-28 图标与官方仓门禁(#809):§1/§2 的 icon 字段说明、
+      // §8.1 官方插件仓的四语言 locale 与 assets/icon.png 惯例。
+      '"icon": "assets/icon.png"',
+      '不收 svg',
+      '发布到官方插件仓的额外门禁',
+      'makecindy/cindy-official-plugins',
+      '四语言 locale 缺一不可',
     ]) {
       expect(FORGE_GUIDE).toContain(marker);
     }

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -93,6 +93,7 @@ function scaffoldManifest(input: ForgeScaffoldInput): Record<string, unknown> {
     version: '1.0.0',
     kind: 'chip',
     entry: 'main.js',
+    icon: 'assets/icon.png',
   };
   if (input.template === 'agent-action') {
     return {
@@ -362,9 +363,17 @@ readline.createInterface({ input: process.stdin }).on('line', function (line) {
 }
 
 /** 按模板产出相对路径到源码内容的完整映射。 */
-function scaffoldFiles(input: ForgeScaffoldInput): Record<string, string> {
+/**
+ * 占位图标(128×128 纯色 PNG,离线生成后内嵌)。让「有图标」成为骨架默认:
+ * 不配 icon 的插件在面板和身份头里只有默认拼图占位符,作者往往到发布才发现。
+ * 官方插件仓惯例图标放 assets/icon.png(见 FORGE_GUIDE §8.1),骨架直接对齐。
+ */
+const SCAFFOLD_ICON_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABEElEQVR42u3SMREAIAwAsfpFAAsKOETgtCyYgGZ4A3+J1leqbmECAEYAIABuY259HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQADodQCqFQAAmACAynYAQtWXyojiIUQAAAAASUVORK5CYII=';
+
+function scaffoldFiles(input: ForgeScaffoldInput): Record<string, string | Buffer> {
   const manifest = scaffoldManifest(input);
-  const files: Record<string, string> = {
+  const files: Record<string, string | Buffer> = {
     [GHOST_MANIFEST_FILE]: `${JSON.stringify(manifest, null, 2)}\n`,
     'main.js':
       input.template === 'agent-action'
@@ -374,6 +383,7 @@ function scaffoldFiles(input: ForgeScaffoldInput): Record<string, string> {
           : input.template === 'node-mcp'
             ? nodeMcpMainSource()
             : plainMainSource(),
+    'assets/icon.png': Buffer.from(SCAFFOLD_ICON_PNG_BASE64, 'base64'),
   };
   if (input.template === 'node-json-rpc') files['node/worker.cjs'] = nodeJsonRpcWorkerSource();
   if (input.template === 'node-mcp') files['node/worker.cjs'] = nodeMcpWorkerSource();
@@ -444,7 +454,7 @@ export async function scaffoldGhostDir(
     return { ok: false, errorCode: 'INVALID_INPUT', message: 'dir 必须在当前会话工作目录内' };
   }
   const files = scaffoldFiles(input);
-  const validation = validateGhostManifest(JSON.parse(files[GHOST_MANIFEST_FILE]));
+  const validation = validateGhostManifest(JSON.parse(files[GHOST_MANIFEST_FILE] as string));
   if (!validation.ok) {
     return {
       ok: false,
@@ -707,6 +717,8 @@ export const FORGE_GUIDE = `# 意识(Ghost)编写手册
 my-ghost/
 ├── ghost.json    ← 身份卡(必须,zip 根部)
 ├── main.js       ← 电子脑:后台逻辑入口(声明了 tools/cindy 时必须)
+├── assets/
+│   └── icon.png  ← 建议:插件图标(声明 icon 字段时必须存在;scaffold 会生成占位图,请替换成自己的)
 ├── locales/      ← 可选:宿主驱动的清单文案翻译(声明 locales 时英文必须存在)
 │   ├── en.json
 │   ├── zh-CN.json
@@ -729,6 +741,7 @@ my-ghost/
   "name": "我的意识",           // 展示名
   "description": "一句话说清这段意识是干嘛的(给人看:装入确认框/详情页)",  // 1–300 字
   "whenToUse": "需要生成图片、插画、配图、修图、P 图、改图时找我",  // 1–300 字,给模型看:进 agent 会话的意识花名册,是"用户不点名时 AI 能不能想起你"的关键。写成场景枚举,可反复调优;缺省时花名册回落用 description
+  "icon": "assets/icon.png",   // 建议:插件图标(包内相对路径;扩展名限 png/jpg/jpeg/webp/gif,不收 svg——svg 可携带脚本,虽经 <img> 渲染不执行,仍不给这个面)。不配则面板与消息身份头显示默认拼图占位符;官方插件仓惯例放 assets/icon.png
   "locales": {                 // 可选:插件只跟随宿主语言;不支持/缺失语言固定回退 en
     "en": "locales/en.json",
     "zh-CN": "locales/zh-CN.json",
@@ -2494,6 +2507,20 @@ const ensured = await cindy.workspace({
 
 界面最终会区分:Cindy 随包官方、此版本已审核、发布者已验证、未验证/无签名。正式
 签名和审核应由商店/发布流水线完成；本地 Forge 不替用户生成或保存正式密钥。
+
+### 8.1 发布到官方插件仓的额外门禁
+
+要提交到官方插件仓 \`makecindy/cindy-official-plugins\` 的插件,除本手册的打包/装入
+校验外还有仓级 CI 硬门禁,过不了整次发布被拦:
+
+- **四语言 locale 缺一不可**:\`locales\` 必须**恰好**包含 \`zh-CN\` / \`en\` / \`ja\` /
+  \`ko\` 四份,且每份都完整覆盖 \`name\` / \`description\` / \`whenToUse\` 与**全部**
+  \`tools[].description\`(工具键集合与清单逐一对齐)。注意这比 §2.1 的本地门槛
+  (「声明 locales 时英文必须存在、翻译可部分提供」)严格得多;
+- **图标**:惯例统一放 \`assets/icon.png\` 并在清单声明 \`icon\` 字段,不要散落在
+  包根;
+- 其余要求(目录命名、审核流程等)以该仓根部的 \`CONTRIBUTING.md\` 为准,提交前
+  在仓内跑一遍 \`node --test .tests/\` 自查。
 
 ## 9. 常见拒装原因速查
 

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -362,7 +362,6 @@ readline.createInterface({ input: process.stdin }).on('line', function (line) {
 `;
 }
 
-/** 按模板产出相对路径到源码内容的完整映射。 */
 /**
  * 占位图标(128×128 纯色 PNG,离线生成后内嵌)。让「有图标」成为骨架默认:
  * 不配 icon 的插件在面板和身份头里只有默认拼图占位符,作者往往到发布才发现。
@@ -371,6 +370,7 @@ readline.createInterface({ input: process.stdin }).on('line', function (line) {
 const SCAFFOLD_ICON_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABEElEQVR42u3SMREAIAwAsfpFAAsKOETgtCyYgGZ4A3+J1leqbmECAEYAIABuY259HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQADodQCqFQAAmACAynYAQtWXyojiIUQAAAAASUVORK5CYII=';
 
+/** 按模板产出相对路径到源码内容的完整映射。 */
 function scaffoldFiles(input: ForgeScaffoldInput): Record<string, string | Buffer> {
   const manifest = scaffoldManifest(input);
   const files: Record<string, string | Buffer> = {
@@ -454,7 +454,13 @@ export async function scaffoldGhostDir(
     return { ok: false, errorCode: 'INVALID_INPUT', message: 'dir 必须在当前会话工作目录内' };
   }
   const files = scaffoldFiles(input);
-  const validation = validateGhostManifest(JSON.parse(files[GHOST_MANIFEST_FILE] as string));
+  // 显式收窄而非 as 断言:manifest 恒为 JSON 字符串,二进制项(占位图标)另存;
+  // 未来若误把 manifest 写成 Buffer,这里在编译/测试期就报,而不是运行期 parse 炸。
+  const manifestRaw = files[GHOST_MANIFEST_FILE];
+  if (typeof manifestRaw !== 'string') {
+    return { ok: false, errorCode: 'INTERNAL', message: 'scaffold manifest 必须是 JSON 字符串' };
+  }
+  const validation = validateGhostManifest(JSON.parse(manifestRaw));
   if (!validation.ok) {
     return {
       ok: false,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #809:按 `ghost_forge_guide` 手册 + `ghost_forge_scaffold` 做出来的插件没有图标,且必然过不了官方插件仓 `makecindy/cindy-official-plugins` 的 CI 门禁。三个缺口都是「撞了 CI 才知道」的隐性要求:

1. 手册 §1 目录结构与 §2 身份卡样例补上 `icon` 字段:包内相对路径、扩展名白名单 png/jpg/jpeg/webp/gif、不收 svg 的理由,与 `shared/ghost.ts` 的校验口径一致;
2. 新增 §8.1「发布到官方插件仓的额外门禁」:四语言 locale(zh-CN/en/ja/ko 恰好四份且完整覆盖 name/description/whenToUse 与全部 tools[].description,已对照官方仓 `.tests/localization.test.mjs` 逐条核实)、图标放 `assets/icon.png` 的惯例、CONTRIBUTING 与 `node --test .tests/` 自查入口;
3. `ghost_forge_scaffold` 默认生成 128×128 占位 `assets/icon.png`(离线生成的 329 字节 PNG,内嵌 base64)并在 ghost.json 声明——让「有图标」成为骨架默认而不是可选。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #809
- 本 PR 包含:FORGE_GUIDE 文本、scaffoldManifest/scaffoldFiles 生成逻辑、测试
- 明确不包含:官方插件仓自身的 CI/文档改动
- 用户可见变化:scaffold 产出的插件默认带占位图标;手册可查到 icon 完整约束与官方仓门禁
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/forge.test.ts src/main/cindy-brain/__tests__/forge.oauth.test.ts
结果:23 passed(含 scaffold 四模板「生成→打包→装入检查」全链路断言:图标文件存在、PNG 魔数正确、清单声明 icon;FORGE_GUIDE 关键标记新增 icon/官方仓门禁条目)

pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm test:unit(仓库根,全量)
结果:exit 0,全部通过

pnpm check:dco
结果:通过
```

### 手工验证

用 gh 拉取官方仓 `.tests/localization.test.mjs` 与 `taptap-maker` 目录结构,逐条核实 §8.1 描述的门禁与惯例属实。

### 未执行的验证

未在真实 Cindy 客户端里跑 scaffold → 官方仓 CI 全流程;门禁逻辑已按官方仓测试源码逐条对照。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 FORGE_GUIDE 文本与 scaffold 生成产物;既有插件与装入校验不受影响。
- 回滚 / 降级方式:revert 本 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
