### PR TITLE
fix(desktop): Chat 桥接图片输入验证清单加入火山方舟豆包 Seed 系列

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -283,11 +283,24 @@ describe('chatBridgeCapabilitiesForRoute', () => {
   });
 
   it.each([
+    ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-2-1-pro-260628'],
+    ['https://ark.ap-southeast-1.volces.com/api/v3/', 'doubao-seed-1-6-vision-260615'],
+  ])('enables image_url for Doubao Seed on official Volcengine Ark host: %s (#771)', async (upstream, model) => {
+    const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
+    expect(chatBridgeCapabilitiesForRoute(upstream, model).imageInput).toBe('image_url');
+  });
+
+  it.each([
     ['https://api.moonshot.cn/v1', 'kimi-k2.6'],
     ['https://api.deepseek.com/v1', 'kimi-k3'],
     ['https://api.moonshot.cn.evil.example/v1', 'kimi-k3'],
     ['http://api.moonshot.cn/v1', 'kimi-k3'],
     ['not-a-url', 'kimi-k3'],
+    ['https://api.deepseek.com/v1', 'deepseek-v4-pro'],
+    ['https://ark.cn-beijing.volces.com/api/v3', 'deepseek-v4-pro'],
+    ['https://api.deepseek.com/v1', 'doubao-seed-2-1-pro-260628'],
+    ['https://ark.cn-beijing.volces.com.evil.example/api/v3', 'doubao-seed-2-1-pro-260628'],
+    ['http://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-2-1-pro-260628'],
   ])('keeps image input disabled for non-matching route %s / %s', async (upstream, model) => {
     const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
     expect(chatBridgeCapabilitiesForRoute(upstream, model).imageInput).toBeUndefined();

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -301,6 +301,11 @@ describe('chatBridgeCapabilitiesForRoute', () => {
     ['https://api.deepseek.com/v1', 'doubao-seed-2-1-pro-260628'],
     ['https://ark.cn-beijing.volces.com.evil.example/api/v3', 'doubao-seed-2-1-pro-260628'],
     ['http://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-2-1-pro-260628'],
+    // Seed 1.6 之前的版本号不放行(1.6 起才是原生多模态品牌线),锁死版本契约。
+    ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-1-5-pro-260101'],
+    ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-1-0'],
+    ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-pro'],
+    ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-1-5-vision-pro'],
   ])('keeps image input disabled for non-matching route %s / %s', async (upstream, model) => {
     const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
     expect(chatBridgeCapabilitiesForRoute(upstream, model).imageInput).toBeUndefined();

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -215,6 +215,10 @@ function isGoogleGeminiChatUpstream(upstream: string): boolean {
 }
 
 const MOONSHOT_CHAT_HOSTS = new Set(['api.moonshot.cn', 'api.moonshot.ai']);
+/** 火山方舟(豆包)官方 DNS 边界:ark.<region>.volces.com(如 ark.cn-beijing.volces.com)。 */
+const VOLCENGINE_ARK_CHAT_HOST_RE = /^ark\.[a-z0-9-]+\.volces\.com$/;
+/** 豆包 Seed 系列(1.6 起)原生多模态,官方 Chat Completions 支持 image_url 图片输入。 */
+const DOUBAO_VISION_MODEL_RE = /^doubao-seed-/;
 
 function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined): string {
   return stripPrefix && model.startsWith(stripPrefix)
@@ -223,28 +227,35 @@ function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined):
 }
 
 /**
- * 图片桥接必须按已验证的上游能力显式开启。这里认官方 Moonshot DNS 边界 + Kimi K3
- * 上游 model，不认 provider id（预设创建后会生成用户自定义 id），也不对所有
- * openai-chat 供应商放开。未命中继续沿用 fail-closed 默认。
+ * 图片桥接必须按已验证的上游能力显式开启。这里认官方 DNS 边界 + 上游 model
+ * (Moonshot 的 Kimi K3、火山方舟的豆包 Seed 系列),不认 provider id(预设创建后
+ * 会生成用户自定义 id),也不对所有 openai-chat 供应商放开。未命中继续沿用
+ * fail-closed 默认——无图片能力的上游(如 DeepSeek)保持发送前显式报错,不静默吞图。
  */
 export function chatBridgeCapabilitiesForRoute(
   upstream: string,
   realModel: string,
   fallback: ChatBridgeCapabilities = CHAT_BRIDGE_DEFAULT_CAPABILITIES,
 ): ChatBridgeCapabilities {
-  if (realModel !== 'kimi-k3') return fallback;
-  try {
-    const url = new URL(upstream);
-    if (url.protocol !== 'https:' || !MOONSHOT_CHAT_HOSTS.has(url.hostname.toLowerCase())) {
-      return fallback;
-    }
-  } catch {
-    return fallback;
-  }
+  if (!isVerifiedImageChatRoute(upstream, realModel)) return fallback;
   return {
     ...fallback,
     imageInput: 'image_url',
   };
+}
+
+function isVerifiedImageChatRoute(upstream: string, realModel: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(upstream);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:') return false;
+  const host = url.hostname.toLowerCase();
+  if (realModel === 'kimi-k3') return MOONSHOT_CHAT_HOSTS.has(host);
+  if (DOUBAO_VISION_MODEL_RE.test(realModel)) return VOLCENGINE_ARK_CHAT_HOST_RE.test(host);
+  return false;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -217,8 +217,20 @@ function isGoogleGeminiChatUpstream(upstream: string): boolean {
 const MOONSHOT_CHAT_HOSTS = new Set(['api.moonshot.cn', 'api.moonshot.ai']);
 /** 火山方舟(豆包)官方 DNS 边界:ark.<region>.volces.com(如 ark.cn-beijing.volces.com)。 */
 const VOLCENGINE_ARK_CHAT_HOST_RE = /^ark\.[a-z0-9-]+\.volces\.com$/;
-/** 豆包 Seed 系列(1.6 起)原生多模态,官方 Chat Completions 支持 image_url 图片输入。 */
-const DOUBAO_VISION_MODEL_RE = /^doubao-seed-/;
+/**
+ * 豆包 Seed 系列 model id 的版本前缀:doubao-seed-<major>-<minor>-…。
+ * 只放行 1.6 起的版本——Seed 品牌线从 1.6 开始原生多模态(官方 Chat Completions
+ * 支持 image_url);万一上游日后出现更低版本号的 seed 变体,不被顺带放行。
+ */
+const DOUBAO_SEED_VERSION_RE = /^doubao-seed-(\d+)-(\d+)(?:-|$)/;
+
+function isDoubaoVisionModel(model: string): boolean {
+  const m = DOUBAO_SEED_VERSION_RE.exec(model);
+  if (!m) return false;
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  return major > 1 || (major === 1 && minor >= 6);
+}
 
 function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined): string {
   return stripPrefix && model.startsWith(stripPrefix)
@@ -254,7 +266,7 @@ function isVerifiedImageChatRoute(upstream: string, realModel: string): boolean 
   if (url.protocol !== 'https:') return false;
   const host = url.hostname.toLowerCase();
   if (realModel === 'kimi-k3') return MOONSHOT_CHAT_HOSTS.has(host);
-  if (DOUBAO_VISION_MODEL_RE.test(realModel)) return VOLCENGINE_ARK_CHAT_HOST_RE.test(host);
+  if (isDoubaoVisionModel(realModel)) return VOLCENGINE_ARK_CHAT_HOST_RE.test(host);
   return false;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #771 的问题 2:豆包(Doubao-Seed-2.1-pro 等)经 Chat Completions 桥接发图报 `input content part 'input_image'` 不支持。桥接层其实已具备 `input_image → image_url` 翻译能力(PR #582),但图片桥接按「已验证上游」显式开启(fail-closed),验证清单此前只有 Moonshot Kimi K3(与 Gemini 基础能力)。

把火山方舟官方 DNS 边界(`ark.<region>.volces.com`,仅 https)+ 豆包 Seed 系列模型(1.6 起原生多模态,官方 Chat Completions 支持 image_url)加入验证清单;判定逻辑收敛为 `isVerifiedImageChatRoute`。未命中路由(如 DeepSeek)保持 fail-closed 显式报错,不静默吞图。

问题 1(Responses 原生模式 `namespace` 工具类型被豆包拒收)源于上游 Responses 实现不完整,不在本 PR 范围。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Refs #771(只覆盖问题 2,不关闭)
- 本 PR 包含:`chatBridgeCapabilitiesForRoute` 验证清单扩展与测试
- 明确不包含:问题 1 的 namespace 工具降级;对所有 openai-chat 供应商放开图片
- 用户可见变化:豆包 Seed 模型经 Chat 桥接可发图
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果:77 passed(新增:ark 官方域 + doubao-seed 模型 → image_url;非官方域/evil 子域/http/非 Seed 模型/跨组合 → 保持禁用)

pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm test:unit(仓库根,全量)
结果:exit 0,全部通过

pnpm check:dco
结果:通过
```

### 手工验证

不涉及(路由判定纯函数,行为由单测覆盖)。

### 未执行的验证

未用真实方舟 API key 端到端发图验证——豆包 Seed 系列的 Chat Completions image_url 支持以官方文档与 issue 报告者实测为依据;若维护者有方舟凭证建议合并前抽测一次。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 `ark.<region>.volces.com` https 上游 + `doubao-seed-*` 模型的组合新增 image_url 能力;其余路由字节级不变。若个别 Seed 变体实际无视觉能力,失败形态是上游显式 400(响亮),不是静默吞图。
- 回滚 / 降级方式:revert 本 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
