### PR TITLE
fix(anthropic-compat-proxy): glm-5.2 的 tool_result 图像降级为说明性占位文本

### DIFF
--- a/packages/anthropic-compat-proxy/src/transform.test.ts
+++ b/packages/anthropic-compat-proxy/src/transform.test.ts
@@ -12,6 +12,7 @@ import {
   stripEmptyThinkingFromBody,
   stripEncryptedContentFromBody,
   stripImageGenerationItemsWithoutIdFromBody,
+  stripNonAnthropicFields,
   stripToolUseProviderSpecificFields,
   stripToolUseProviderSpecificFieldsFromBody,
 } from './transform.js';
@@ -672,5 +673,74 @@ describe('recovery rule factories', () => {
     expect(
       rule.strip(buf({ messages: [{ role: 'assistant', content: [{ type: 'tool_use', provider_specific_fields: null }] }] })),
     ).not.toBeNull();
+  });
+});
+
+describe('stripNonAnthropicFields · glm-5.2 tool_result 图像降级 (#794)', () => {
+  const imageBlock = {
+    type: 'image',
+    source: { type: 'base64', media_type: 'image/png', data: 'AAAABBBB' },
+  };
+  const makeBody = (model: string): Record<string, unknown> => ({
+    model,
+    messages: [
+      { role: 'user', content: 'read the scan' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 't1',
+            content: [{ type: 'text', text: 'scan follows' }, imageBlock],
+          },
+        ],
+      },
+    ],
+  });
+
+  it.each(['glm-5.2', 'z-ai/glm-5.2'])(
+    '%s:tool_result 图像替换为说明性占位文本,图像字节不外泄',
+    (model) => {
+      const out = stripNonAnthropicFields(makeBody(model), {
+        headers: {},
+      } as never) as Record<string, unknown> | null;
+      expect(out).not.toBeNull();
+      const json = JSON.stringify(out);
+      expect(json).not.toContain('AAAABBBB');
+      expect(json).toContain('[image omitted:');
+      expect(json).toContain('Do NOT guess');
+      // 同一 tool_result 的文本块保留,块结构仍是 tool_result。
+      expect(json).toContain('scan follows');
+      expect(json).toContain('tool_result');
+    },
+  );
+
+  it('glm-5.2 无图像时返回 null(cache 安全契约,字节透传)', () => {
+    const body = {
+      model: 'glm-5.2',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 't1', content: [{ type: 'text', text: 'ok' }] },
+          ],
+        },
+      ],
+    };
+    expect(stripNonAnthropicFields(body, { headers: {} } as never)).toBeNull();
+  });
+
+  it('未登记的 model 不受影响(字节透传)', () => {
+    expect(
+      stripNonAnthropicFields(makeBody('claude-opus-5'), { headers: {} } as never),
+    ).toBeNull();
+  });
+
+  it('user 消息里的图像不动,只处理 tool_result 内嵌图像', () => {
+    const body = {
+      model: 'glm-5.2',
+      messages: [{ role: 'user', content: [imageBlock] }],
+    };
+    expect(stripNonAnthropicFields(body, { headers: {} } as never)).toBeNull();
   });
 });

--- a/packages/anthropic-compat-proxy/src/transform.test.ts
+++ b/packages/anthropic-compat-proxy/src/transform.test.ts
@@ -698,12 +698,10 @@ describe('stripNonAnthropicFields · glm-5.2 tool_result 图像降级 (#794)', (
     ],
   });
 
-  it.each(['glm-5.2', 'z-ai/glm-5.2'])(
+  it.each(['glm-5.2', 'z-ai/glm-5.2', 'glm-5.2[1m]', 'z-ai/glm-5.2[1m]'])(
     '%s:tool_result 图像替换为说明性占位文本,图像字节不外泄',
     (model) => {
-      const out = stripNonAnthropicFields(makeBody(model), {
-        headers: {},
-      } as never) as Record<string, unknown> | null;
+      const out = stripNonAnthropicFields(makeBody(model), ctx) as Record<string, unknown> | null;
       expect(out).not.toBeNull();
       const json = JSON.stringify(out);
       expect(json).not.toContain('AAAABBBB');
@@ -727,12 +725,12 @@ describe('stripNonAnthropicFields · glm-5.2 tool_result 图像降级 (#794)', (
         },
       ],
     };
-    expect(stripNonAnthropicFields(body, { headers: {} } as never)).toBeNull();
+    expect(stripNonAnthropicFields(body, ctx)).toBeNull();
   });
 
   it('未登记的 model 不受影响(字节透传)', () => {
     expect(
-      stripNonAnthropicFields(makeBody('claude-opus-5'), { headers: {} } as never),
+      stripNonAnthropicFields(makeBody('claude-opus-5'), ctx),
     ).toBeNull();
   });
 
@@ -741,6 +739,6 @@ describe('stripNonAnthropicFields · glm-5.2 tool_result 图像降级 (#794)', (
       model: 'glm-5.2',
       messages: [{ role: 'user', content: [imageBlock] }],
     };
-    expect(stripNonAnthropicFields(body, { headers: {} } as never)).toBeNull();
+    expect(stripNonAnthropicFields(body, ctx)).toBeNull();
   });
 });

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -476,6 +476,58 @@ const stripGpt54Mini: ModelStripHandler = (body) => {
   return next;
 };
 
+/**
+ * 纯文本模型的 tool_result 图像降级(#794)。
+ *
+ * 实测(z-ai/glm-5.2,Anthropic 兼容直通):tool_result 里的 image block 原样发给
+ * 上游,上游静默丢弃且不报错——模型把工具结果当成空,反复重读或直接臆造图片内容
+ * (实测单任务空转 66 分钟并编造译文)。把 image block 替换为说明性占位文本:
+ * 明确告知有图但当前模型收不到、禁止臆测、引导贴文本或换视觉模型。
+ *
+ * 只处理 tool_result 内嵌图像;user 消息图像走各桥接的 input_image 路径,不归这里。
+ */
+const TOOL_RESULT_IMAGE_OMITTED_TEXT =
+  '[image omitted: this tool returned an image, but the current model is text-only, '
+  + 'so the image could not be delivered. Do NOT guess or fabricate what the image '
+  + 'contains. Tell the user the image could not be delivered to the current model, '
+  + 'and ask them to paste the relevant content as text or switch to a vision-capable '
+  + 'model.]';
+
+function replaceToolResultImagesWithNotice(
+  body: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return null;
+
+  let replaced = 0;
+  const nextMessages = messages.map((msg) => {
+    if (!isPlainObject(msg) || !Array.isArray(msg.content)) return msg;
+    let msgChanged = false;
+    const nextContent = msg.content.map((block) => {
+      if (!isPlainObject(block) || block.type !== 'tool_result' || !Array.isArray(block.content)) {
+        return block;
+      }
+      let blockChanged = false;
+      const nextInner = block.content.map((inner) => {
+        if (!isPlainObject(inner) || inner.type !== 'image') return inner;
+        replaced += 1;
+        blockChanged = true;
+        return { type: 'text', text: TOOL_RESULT_IMAGE_OMITTED_TEXT };
+      });
+      if (!blockChanged) return block;
+      msgChanged = true;
+      return { ...block, content: nextInner };
+    });
+    return msgChanged ? { ...msg, content: nextContent } : msg;
+  });
+
+  if (replaced === 0) return null; // cache 安全契约:无改动 → null → 字节透传
+  return { ...body, messages: nextMessages };
+}
+
+/** glm-5.2 (智谱,官方仅文本/代码模态) —— 直通与网关两条路由同一 model id。 */
+const stripGlm52: ModelStripHandler = (body) => replaceToolResultImagesWithNotice(body);
+
 // ───────────────────────────────────────────────────────────────────────────
 // 分发表
 // ───────────────────────────────────────────────────────────────────────────
@@ -490,6 +542,10 @@ const STRIP_HANDLERS: Readonly<Record<string, ModelStripHandler>> = {
   // 「折扣GPT」低价路由 —— 与 gpt-5.4 打同一个 Azure 后端, 同样会因 output_config 报 400,
   // 镜像 gpt-5.4 的 strip 行为 (复用同一 handler)。codex/gpt-5.5 暂不加, 与 gpt-5.5 一致。
   'codex/gpt-5.4': stripGpt54,
+  // 纯文本模型 tool_result 图像会被上游静默吞掉 (#794) —— 带/不带命名空间前缀两种
+  // 形态的 model id 都登记 (直通路由 body.model 可能保留 z-ai/ 前缀)。
+  'glm-5.2': stripGlm52,
+  'z-ai/glm-5.2': stripGlm52,
 };
 
 /**

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -542,10 +542,13 @@ const STRIP_HANDLERS: Readonly<Record<string, ModelStripHandler>> = {
   // 「折扣GPT」低价路由 —— 与 gpt-5.4 打同一个 Azure 后端, 同样会因 output_config 报 400,
   // 镜像 gpt-5.4 的 strip 行为 (复用同一 handler)。codex/gpt-5.5 暂不加, 与 gpt-5.5 一致。
   'codex/gpt-5.4': stripGpt54,
-  // 纯文本模型 tool_result 图像会被上游静默吞掉 (#794) —— 带/不带命名空间前缀两种
-  // 形态的 model id 都登记 (直通路由 body.model 可能保留 z-ai/ 前缀)。
+  // 纯文本模型 tool_result 图像会被上游静默吞掉 (#794) —— 带/不带命名空间前缀,
+  // 以及 claude-code SDK 按目录 1M 窗口追加 [1m] 后缀 (toSdkModelString) 的形态
+  // 都登记 (直通路由 body.model 可能保留 z-ai/ 前缀与 [1m] 后缀)。
   'glm-5.2': stripGlm52,
   'z-ai/glm-5.2': stripGlm52,
+  'glm-5.2[1m]': stripGlm52,
+  'z-ai/glm-5.2[1m]': stripGlm52,
 };
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #794:claude-code + 第三方 Anthropic 兼容直通路由下,纯文本模型(实测 z-ai/glm-5.2)的 tool_result 内嵌图像被上游服务端静默丢弃且不报错——模型把工具结果当成空,反复重读或臆造图片内容(报告中单任务空转 66 分钟并产出编造的法律文件译文)。

按 compat-proxy `STRIP_HANDLERS` 既有的 per-model 实测命中模式,给 glm-5.2(带/不带 `z-ai/` 命名空间前缀两种 body.model 形态)登记 handler:把 tool_result 里的 image block 替换为说明性占位文本——明确告知有图但当前模型收不到、禁止臆测、引导贴文本或换视觉模型(措辞与 #795 同族;因本模型确为纯文本,额外给出换视觉模型的出路)。

仓库当前没有按 model 声明图像能力的元数据(issue 提到的 `MultimodalCapability.image` 尚不存在),故不做通用能力门控;待能力契约建立后可泛化,本 handler 届时可自然并入。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #794
- 本 PR 包含:`replaceToolResultImagesWithNotice` + glm-5.2 handler 登记与测试
- 明确不包含:通用 per-model 图像能力元数据;user 消息图像(走各桥接 input_image 路径,#582/#771 已分别处理)
- 用户可见变化:glm-5.2 会话中工具返回图像时,模型会明确告知用户图像送不到并给出替代路径
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/anthropic-compat-proxy exec vitest run src/transform.test.ts
结果:52 passed(新增:两种 model id 形态替换成功且图像字节不外泄、同 tool_result 文本块保留、无图像返 null 字节透传、未登记模型零干预、user 消息图像不动)

pnpm --filter @cindy/anthropic-compat-proxy run --if-present typecheck
结果:通过

pnpm test:unit(仓库根,全量)
结果:exit 0,全部通过

pnpm check:dco
结果:通过
```

### 手工验证

不涉及(transform 纯函数,行为由单测覆盖)。

### 未执行的验证

未用真实 z-ai 凭证端到端复现;上游静默吞图的行为以 issue 报告者的链路分析为依据(其明确指出仓内无任何环节丢图、丢弃发生在上游)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 body.model 为 `glm-5.2` / `z-ai/glm-5.2` 且 tool_result 含 image block 的请求;无图像时返回 null 保持字节透传(cache 安全契约),其余模型零干预。
- 回滚 / 降级方式:revert 本 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
