### PR TITLE
fix(cindy-brain): 插件通用 OAuth 引擎支持 xAI 新版跨源 code 投递

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
@@ -172,17 +172,37 @@ describe('startGhostOauthFlow', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('state 不匹配 → CALLBACK_INVALID,不碰 token 端点', async () => {
-    const fetchImpl = vi.fn();
+  it('state 不匹配 → 400 拒绝但不结算登录:陈旧/伪造回调后,正确回调仍能完成授权', async () => {
+    // 与第一方 grok 监听器同口径(#841 review):跨源投递时代表旧登录尝试的
+    // consent 页可能带旧 state 持续重试,不能让它杀死新发起的登录。伪造 state
+    // 的 code 也绝不能进 token 交换。
+    const fetchImpl = vi.fn(async () => jsonResponse({ access_token: 'at-stale' }));
+    let forgedStatus = 0;
     const result = await startGhostOauthFlow({
       config: BASE_CONFIG,
       fetchImpl: fetchImpl as unknown as typeof fetch,
       openExternal: (url) => {
-        browserRedirect(url, () => ({ code: 'c4', state: 'forged-state' }));
+        const u = new URL(url);
+        const cb = new URL(u.searchParams.get('redirect_uri') ?? '');
+        const state = u.searchParams.get('state') ?? '';
+        setImmediate(() => {
+          void (async () => {
+            const forged = new URL(cb.toString());
+            forged.searchParams.set('code', 'c4');
+            forged.searchParams.set('state', 'forged-state');
+            forgedStatus = (await fetch(forged.toString())).status;
+            const good = new URL(cb.toString());
+            good.searchParams.set('code', 'c-good');
+            good.searchParams.set('state', state);
+            await fetch(good.toString());
+          })().catch(() => undefined);
+        });
       },
     });
-    expect(result).toMatchObject({ ok: false, error: 'CALLBACK_INVALID' });
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: true });
+    expect(forgedStatus).toBe(400);
+    // token 交换只发生一次(用正确回调的 code),伪造 code 不进交换。
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('授权服务器回 error 参数 → CALLBACK_INVALID', async () => {
@@ -190,7 +210,11 @@ describe('startGhostOauthFlow', () => {
       config: BASE_CONFIG,
       fetchImpl: vi.fn() as unknown as typeof fetch,
       openExternal: (url) => {
-        browserRedirect(url, () => ({ error: 'access_denied' }));
+        // state 先行校验后,error 参数只在 state 匹配时才结算(与 grok 同口径)。
+        browserRedirect(url, (au) => ({
+          error: 'access_denied',
+          state: au.searchParams.get('state') ?? '',
+        }));
       },
     });
     expect(result).toMatchObject({ ok: false, error: 'CALLBACK_INVALID' });
@@ -205,6 +229,7 @@ describe('startGhostOauthFlow', () => {
         const u = new URL(url);
         const cb = new URL(u.searchParams.get('redirect_uri') ?? '');
         cb.searchParams.set('error', "$'<b>x</b>$&");
+        cb.searchParams.set('state', u.searchParams.get('state') ?? '');
         setImmediate(() => {
           void fetch(cb.toString(), { headers: { 'accept-language': 'zh-CN,zh;q=0.9' } })
             .then(async (r) => {
@@ -649,22 +674,72 @@ describe('startGhostOauthFlow', () => {
     expect(delivery!.headers.get('access-control-allow-origin')).toBe('https://auth.example.com');
   });
 
-  it('跨源投递的 state 校验不放松:声明域带错 state 投递 → 400 且响应带 CORS 头', async () => {
+  it('consent 页与授权端点不同域:hosts 白名单命中的 https origin 也允许投递(#841 review)', async () => {
     const fixedPort = await probeFreePort();
-    let badDeliveryWork: Promise<Response> | null = null;
+    let preflightConsent: Response | null = null;
+    let preflightOther: Response | null = null;
     const result = await startGhostOauthFlow({
-      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'x' })) as unknown as typeof fetch,
-      openExternal: () => {
-        badDeliveryWork = fetch(`http://127.0.0.1:${fixedPort}/callback?code=c-bad&state=WRONG`, {
-          headers: { origin: 'https://auth.example.com' },
+      config: {
+        ...BASE_CONFIG,
+        pkce: false,
+        redirectPort: fixedPort,
+        // xAI 形态:authorizeUrl 在 auth 域,实际投递来自 hosts 白名单里的 accounts 域。
+        corsDeliveryHosts: ['accounts.example.org', '*.wild.example.org'],
+      },
+      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-hosts' })) as unknown as typeof fetch,
+      openExternal: (url) => {
+        const state = new URL(url).searchParams.get('state') ?? '';
+        const cb = `http://127.0.0.1:${fixedPort}/callback`;
+        setImmediate(() => {
+          void (async () => {
+            preflightConsent = await fetch(cb, {
+              method: 'OPTIONS',
+              headers: { origin: 'https://accounts.example.org' },
+            });
+            // hosts 白名单没有的域拿不到 CORS 头;http 形态的白名单域同样不放行。
+            preflightOther = await fetch(cb, {
+              method: 'OPTIONS',
+              headers: { origin: 'http://accounts.example.org' },
+            });
+            await fetch(`${cb}?code=c-hosts&state=${state}`, {
+              headers: { origin: 'https://sub.wild.example.org' },
+            });
+          })().catch(() => undefined);
         });
       },
     });
-    expect(result).toMatchObject({ ok: false, error: 'CALLBACK_INVALID' });
-    const badDelivery = await badDeliveryWork!;
-    expect(badDelivery.status).toBe(400);
-    expect(badDelivery.headers.get('access-control-allow-origin')).toBe('https://auth.example.com');
+    expect(result).toMatchObject({ ok: true });
+    expect(preflightConsent!.headers.get('access-control-allow-origin')).toBe(
+      'https://accounts.example.org',
+    );
+    expect(preflightConsent!.headers.get('access-control-allow-private-network')).toBe('true');
+    expect(preflightOther!.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('跨源投递的 state 校验不放松:声明域带错 state 投递 → 400 带 CORS 头且不结算,正确投递仍成功', async () => {
+    const fixedPort = await probeFreePort();
+    let badDelivery: Response | null = null;
+    const result = await startGhostOauthFlow({
+      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'x' })) as unknown as typeof fetch,
+      openExternal: (url) => {
+        const state = new URL(url).searchParams.get('state') ?? '';
+        const cb = `http://127.0.0.1:${fixedPort}/callback`;
+        setImmediate(() => {
+          void (async () => {
+            badDelivery = await fetch(`${cb}?code=c-bad&state=WRONG`, {
+              headers: { origin: 'https://auth.example.com' },
+            });
+            await fetch(`${cb}?code=c-ok&state=${state}`, {
+              headers: { origin: 'https://auth.example.com' },
+            });
+          })().catch(() => undefined);
+        });
+      },
+    });
+    expect(result).toMatchObject({ ok: true });
+    expect(badDelivery!.status).toBe(400);
+    expect(badDelivery!.headers.get('access-control-allow-origin')).toBe('https://auth.example.com');
   });
 
   it('publicRedirectUri 为 http → INVALID_CONFIG,不拉浏览器', async () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
@@ -599,6 +599,74 @@ describe('startGhostOauthFlow', () => {
     expect(defaultPathStatus).toBe(404);
   });
 
+  it('跨源 code 投递(#810):声明域的 OPTIONS 预检拿到 CORS/PNA 头,GET 投递带头成功;非法来源拿不到头;无 Origin 的 302 回调不变', async () => {
+    const fixedPort = await probeFreePort();
+    let browserWork: Promise<{
+      preflightAllowed: Response;
+      preflightEvil: Response;
+      delivery: Response;
+    }> | null = null;
+    const result = await startGhostOauthFlow({
+      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-cors' })) as unknown as typeof fetch,
+      openExternal: (url) => {
+        const state = new URL(url).searchParams.get('state') ?? '';
+        const cb = `http://127.0.0.1:${fixedPort}/callback`;
+        browserWork = (async () => {
+          // 声明域(authorizeUrl 的 origin)发预检:必须拿到 CORS + PNA 头。
+          const preflightAllowed = await fetch(cb, {
+            method: 'OPTIONS',
+            headers: { origin: 'https://auth.example.com' },
+          });
+          // 任意其它网站发预检:204 但不带 CORS 头(浏览器会拦下后续请求)。
+          const preflightEvil = await fetch(cb, {
+            method: 'OPTIONS',
+            headers: { origin: 'https://evil.example' },
+          });
+          // 声明域的页面 JS 跨源 GET 投递 code(xAI 新版流程形态)。
+          const delivery = await fetch(`${cb}?code=c-cors&state=${state}`, {
+            headers: { origin: 'https://auth.example.com' },
+          });
+          return { preflightAllowed, preflightEvil, delivery };
+        })();
+      },
+    });
+    expect(result).toMatchObject({ ok: true });
+    const { preflightAllowed, preflightEvil, delivery } = await browserWork!;
+
+    expect(preflightAllowed!.status).toBe(204);
+    expect(preflightAllowed!.headers.get('access-control-allow-origin')).toBe(
+      'https://auth.example.com',
+    );
+    expect(preflightAllowed!.headers.get('access-control-allow-private-network')).toBe('true');
+    expect(preflightAllowed!.headers.get('access-control-allow-methods')).toContain('OPTIONS');
+
+    expect(preflightEvil!.status).toBe(204);
+    expect(preflightEvil!.headers.get('access-control-allow-origin')).toBeNull();
+    expect(preflightEvil!.headers.get('access-control-allow-private-network')).toBeNull();
+
+    expect(delivery!.status).toBe(200);
+    expect(delivery!.headers.get('access-control-allow-origin')).toBe('https://auth.example.com');
+  });
+
+  it('跨源投递的 state 校验不放松:声明域带错 state 投递 → 400 且响应带 CORS 头', async () => {
+    const fixedPort = await probeFreePort();
+    let badDeliveryWork: Promise<Response> | null = null;
+    const result = await startGhostOauthFlow({
+      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'x' })) as unknown as typeof fetch,
+      openExternal: () => {
+        badDeliveryWork = fetch(`http://127.0.0.1:${fixedPort}/callback?code=c-bad&state=WRONG`, {
+          headers: { origin: 'https://auth.example.com' },
+        });
+      },
+    });
+    expect(result).toMatchObject({ ok: false, error: 'CALLBACK_INVALID' });
+    const badDelivery = await badDeliveryWork!;
+    expect(badDelivery.status).toBe(400);
+    expect(badDelivery.headers.get('access-control-allow-origin')).toBe('https://auth.example.com');
+  });
+
   it('publicRedirectUri 为 http → INVALID_CONFIG,不拉浏览器', async () => {
     const openExternal = vi.fn();
     await expect(

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -921,7 +921,7 @@ node 详单**不接受** \`command\` / \`args\` / \`shell\` / \`env\` 或其它�
     },
     "oauth": {                                      // source:"oauth" 时必填(其它来源禁写):主机托管 OAuth 授权详单(见 §4.7)
       "authorizeUrl": "https://accounts.example.com/authorize",  // 授权页(https;域名必须命中 hosts 白名单)
-      "tokenUrl": "https://accounts.example.com/token",          // code/refresh 交换端点(https;域名必须命中 hosts)
+      "tokenUrl": "https://accounts.example.com/token",          // code/refresh 交换端点(https;域名必须命中 hosts)。注:个别服务商(如 xAI)的新版 consent 页不再 302 回 loopback,而是页面 JS 跨源投递授权 code——主机允许的投递来源 = authorizeUrl/tokenUrl 的 origin + hosts 白名单命中的 https 域;consent 页与授权端点不同域时,把 consent 域(如 accounts.x.ai)也声明进 hosts 即可
       "clientId": "xxx.apps.example.com",           // 可选:内置 OAuth 客户端 ID(用户零配置开箱即用;用户在设置页自填的覆盖内置,清除自填即回落)
       "clientIdAlternatives": ["xxx-global.apps.example.com"],  // 可选 ≤8 条:仅 tokenBroker 模式;意识按 app-context 选 App 时,connect 只接受默认值或这里声明的公开 ID
       "clientSecret": "xxx",                        // 可选(须与 clientId 成对):内置 client 的 secret;桌面应用的 client 凭证本非机密,纯 PKCE 服务商可省略

--- a/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
@@ -442,6 +442,12 @@ export class GhostOauthAccountManager {
        * clientIdAlternatives 明确列出的值;用于意识按宿主 region 选 App。
        */
       clientId?: string;
+      /**
+       * 该插件 manifest 的 network.hosts 白名单(接线处传入)。跨源 code 投递
+       * 的 CORS 允许面 = 端点 origin + 本白名单命中的 https origin,见
+       * GhostOauthClientConfig.corsDeliveryHosts。
+       */
+      deliveryHosts?: readonly string[];
     },
   ): Promise<GhostOauthConnectResult> {
     if (opts?.clientId !== undefined) {
@@ -456,6 +462,7 @@ export class GhostOauthAccountManager {
     }
     const config = this.readClientConfig(ghostId, secretKey, decl, opts?.clientId);
     if (!config) return { ok: false, error: 'NO_CLIENT_CONFIG' };
+    if (opts?.deliveryHosts?.length) config.corsDeliveryHosts = opts.deliveryHosts;
     if (decl.brokerBounce && !config.publicRedirectUri) {
       return {
         ok: false,

--- a/apps/desktop/src/main/cindy-brain/ghostOauthFlow.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthFlow.ts
@@ -31,7 +31,7 @@
 import * as http from 'node:http';
 import * as crypto from 'node:crypto';
 
-import { GHOST_OAUTH_RESERVED_AUTHORIZE_PARAMS } from '../../shared/ghost.js';
+import { GHOST_OAUTH_RESERVED_AUTHORIZE_PARAMS, ghostNetworkHostMatches } from '../../shared/ghost.js';
 import {
   buildOAuthReturnAction,
   getGhostOAuthResultCopy,
@@ -95,6 +95,14 @@ export interface GhostOauthClientConfig {
    * 缺省的 /callback,如 slack 的 /slack-mcp/callback)。缺省 '/callback'。
    */
   callbackPath?: string;
+  /**
+   * 可选:该插件 manifest 的 network.hosts 白名单(装入确认框展示、用户同意
+   * 过的域名面;含最左通配)。跨源 code 投递的允许来源 = authorizeUrl/tokenUrl
+   * 的 origin + 本白名单命中的 https origin——xAI 这类「授权端点在 auth.x.ai、
+   * consent 页从 accounts.x.ai 投递」的服务商,把投递域声明进 hosts 即可,
+   * 不引入白名单之外的新信任面。
+   */
+  corsDeliveryHosts?: readonly string[];
 }
 
 /** extraAuthorizeParams 不允许顶掉的协议保留参数(清单校验拒装,这里防御性重验)。 */
@@ -110,13 +118,21 @@ const RESERVED_AUTHORIZE_PARAMS: ReadonlySet<string> = new Set(
 // 把同一机制移植进通用引擎。
 //
 // 通用引擎不能绑死某个服务商:允许来源从该插件声明的 authorizeUrl / tokenUrl 的
-// origin 派生——只有「你声明要去授权的那个域」才允许跨源把 code 投回来,任意其它
-// 网站的预检拿不到 CORS 头。真实性校验仍靠 state(+PKCE),与 302 回调同一套。
+// origin 派生,并叠加 manifest network.hosts 白名单命中的 https origin(装入确认框
+// 展示、用户同意过的域名面)——xAI 这类「授权端点在 auth.x.ai、consent 页从
+// accounts.x.ai 投递」的服务商,把投递域声明进 hosts 即被覆盖;任意其它网站的
+// 预检拿不到 CORS 头。真实性校验仍靠 state(+PKCE),与 302 回调同一套。
 
-/** 从插件声明的 OAuth 端点派生跨源投递允许来源(仅 https origin)。 */
-export function ghostCallbackCorsAllowedOrigins(
-  config: Pick<GhostOauthClientConfig, 'authorizeUrl' | 'tokenUrl'>,
-): ReadonlySet<string> {
+/** 跨源投递允许面(端点 origin 精确集合 + hosts 白名单模式)。 */
+export interface GhostCallbackCorsAllowlist {
+  origins: ReadonlySet<string>;
+  hostPatterns: readonly string[];
+}
+
+/** 从插件声明的 OAuth 端点与 hosts 白名单派生跨源投递允许面(仅 https origin)。 */
+export function ghostCallbackCorsAllowlist(
+  config: Pick<GhostOauthClientConfig, 'authorizeUrl' | 'tokenUrl' | 'corsDeliveryHosts'>,
+): GhostCallbackCorsAllowlist {
   const origins = new Set<string>();
   for (const raw of [config.authorizeUrl, config.tokenUrl]) {
     try {
@@ -126,15 +142,31 @@ export function ghostCallbackCorsAllowedOrigins(
       /* isSafeHttpsUrl 已在流程入口校验;这里防御性忽略 */
     }
   }
-  return origins;
+  return { origins, hostPatterns: config.corsDeliveryHosts ?? [] };
 }
 
-/** origin 在允许集合内时返回回调响应应附带的 CORS/PNA 头;否则为空(不放行)。 */
+function isAllowedDeliveryOrigin(
+  allowlist: GhostCallbackCorsAllowlist,
+  origin: string,
+): boolean {
+  if (allowlist.origins.has(origin)) return true;
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:') return false;
+  const hostname = url.hostname.toLowerCase();
+  return allowlist.hostPatterns.some((pattern) => ghostNetworkHostMatches(pattern, hostname));
+}
+
+/** origin 在允许面内时返回回调响应应附带的 CORS/PNA 头;否则为空(不放行)。 */
 export function ghostCallbackCorsHeaders(
-  allowedOrigins: ReadonlySet<string>,
+  allowlist: GhostCallbackCorsAllowlist,
   origin: string | undefined,
 ): Record<string, string> {
-  if (!origin || !allowedOrigins.has(origin)) return {};
+  if (!origin || !isAllowedDeliveryOrigin(allowlist, origin)) return {};
   return {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -566,7 +598,7 @@ async function runGhostOauthFlow(
       settled = true;
       resolve(v);
     };
-    const corsAllowedOrigins = ghostCallbackCorsAllowedOrigins(config);
+    const corsAllowlist = ghostCallbackCorsAllowlist(config);
     server.on('request', (req, res) => {
       // 页面语言按浏览器 Accept-Language 就近命中(zh/ja/ko, 缺省英文)
       const lang = pickOAuthResultPageLang(
@@ -575,7 +607,7 @@ async function runGhostOauthFlow(
           : undefined,
       );
       const cors = ghostCallbackCorsHeaders(
-        corsAllowedOrigins,
+        corsAllowlist,
         typeof req.headers.origin === 'string' ? req.headers.origin : undefined,
       );
       // CORS/PNA preflight 必须 204 放行且不触碰登录流状态 —— 它没有 code 参数,
@@ -598,6 +630,16 @@ async function runGhostOauthFlow(
           res.end('Not Found');
           return;
         }
+        // state 是回调真实性的唯一凭证,最先校验(与第一方 grok 监听器同口径):
+        // 跨源 fetch 投递时代表旧登录尝试的 consent 页可能带旧 state 持续重试,
+        // 这类请求一律 400 但**不结算**当前登录——陈旧 tab 的一次滞留重试不能
+        // 杀死新发起的登录;error / code 参数只在 state 匹配时才有意义。
+        const gotState = url.searchParams.get('state');
+        if (gotState !== state) {
+          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
+          res.end(errorHtml('invalid-callback', lang, brandName));
+          return;
+        }
         const err = url.searchParams.get('error');
         if (err) {
           res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
@@ -606,11 +648,10 @@ async function runGhostOauthFlow(
           return;
         }
         const code = url.searchParams.get('code');
-        const gotState = url.searchParams.get('state');
-        if (!code || !gotState || gotState !== state) {
+        if (!code) {
           res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
           res.end(errorHtml('invalid-callback', lang, brandName));
-          finish({ kind: 'invalid', detail: 'callback 参数缺失或 state 不匹配' });
+          finish({ kind: 'invalid', detail: 'callback 缺 code 参数' });
           return;
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
@@ -618,7 +659,9 @@ async function runGhostOauthFlow(
         finish({ kind: 'code', code });
       } catch (err2) {
         try {
-          res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
+          // 跨源 fetch 场景缺 CORS 头会让浏览器把 500 响应整体拦下,页面侧
+          // 无从感知失败 —— 内部错误同样带头。
+          res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
           res.end(errorHtml('internal', lang, brandName));
         } catch {
           /* 响应通道已坏,无事可做 */

--- a/apps/desktop/src/main/cindy-brain/ghostOauthFlow.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthFlow.ts
@@ -102,6 +102,48 @@ const RESERVED_AUTHORIZE_PARAMS: ReadonlySet<string> = new Set(
   GHOST_OAUTH_RESERVED_AUTHORIZE_PARAMS,
 );
 
+// ── 跨源 code 投递(#810)─────────────────────────────────────────────────────
+// xAI 新版 consent 页(accounts.x.ai)授权完成后不再 302 重定向回 loopback,而是由
+// 页面 JS **跨源 fetch** 本回调地址投递 code;Chrome 对「公网 https 页面 → 127.0.0.1」
+// 要求回调服务器应答 CORS preflight 并返回 Private Network Access 头,否则投递被浏览
+// 器拦下,授权卡死在「复制 code」页。第一方 Grok 登录已修(grok-oauth-login.ts),这里
+// 把同一机制移植进通用引擎。
+//
+// 通用引擎不能绑死某个服务商:允许来源从该插件声明的 authorizeUrl / tokenUrl 的
+// origin 派生——只有「你声明要去授权的那个域」才允许跨源把 code 投回来,任意其它
+// 网站的预检拿不到 CORS 头。真实性校验仍靠 state(+PKCE),与 302 回调同一套。
+
+/** 从插件声明的 OAuth 端点派生跨源投递允许来源(仅 https origin)。 */
+export function ghostCallbackCorsAllowedOrigins(
+  config: Pick<GhostOauthClientConfig, 'authorizeUrl' | 'tokenUrl'>,
+): ReadonlySet<string> {
+  const origins = new Set<string>();
+  for (const raw of [config.authorizeUrl, config.tokenUrl]) {
+    try {
+      const url = new URL(raw);
+      if (url.protocol === 'https:') origins.add(url.origin);
+    } catch {
+      /* isSafeHttpsUrl 已在流程入口校验;这里防御性忽略 */
+    }
+  }
+  return origins;
+}
+
+/** origin 在允许集合内时返回回调响应应附带的 CORS/PNA 头;否则为空(不放行)。 */
+export function ghostCallbackCorsHeaders(
+  allowedOrigins: ReadonlySet<string>,
+  origin: string | undefined,
+): Record<string, string> {
+  if (!origin || !allowedOrigins.has(origin)) return {};
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Private-Network': 'true',
+    Vary: 'Origin',
+  };
+}
+
 /** 一次授权 / 刷新成功后的令牌包(交由 token manager 落库;本模块不持久化)。 */
 export interface GhostOauthTokenBundle {
   accessToken: string;
@@ -524,6 +566,7 @@ async function runGhostOauthFlow(
       settled = true;
       resolve(v);
     };
+    const corsAllowedOrigins = ghostCallbackCorsAllowedOrigins(config);
     server.on('request', (req, res) => {
       // 页面语言按浏览器 Accept-Language 就近命中(zh/ja/ko, 缺省英文)
       const lang = pickOAuthResultPageLang(
@@ -531,6 +574,18 @@ async function runGhostOauthFlow(
           ? req.headers['accept-language']
           : undefined,
       );
+      const cors = ghostCallbackCorsHeaders(
+        corsAllowedOrigins,
+        typeof req.headers.origin === 'string' ? req.headers.origin : undefined,
+      );
+      // CORS/PNA preflight 必须 204 放行且不触碰登录流状态 —— 它没有 code 参数,
+      // 落进下方缺 code 分支会直接终止整个登录(grok 侧 issue #491 的卡死教训)。
+      // 非允许来源的预检同样 204 但不带 CORS 头,浏览器会拦下后续请求。
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204, cors);
+        res.end();
+        return;
+      }
       try {
         const url = new URL(req.url ?? '/', 'http://127.0.0.1');
         if (url.pathname === '/favicon.ico') {
@@ -545,7 +600,7 @@ async function runGhostOauthFlow(
         }
         const err = url.searchParams.get('error');
         if (err) {
-          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
           res.end(errorHtml('provider-error', lang, brandName, err));
           finish({ kind: 'invalid', detail: `authorize error=${err}` });
           return;
@@ -553,12 +608,12 @@ async function runGhostOauthFlow(
         const code = url.searchParams.get('code');
         const gotState = url.searchParams.get('state');
         if (!code || !gotState || gotState !== state) {
-          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
           res.end(errorHtml('invalid-callback', lang, brandName));
           finish({ kind: 'invalid', detail: 'callback 参数缺失或 state 不匹配' });
           return;
         }
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', ...cors });
         res.end(successHtml(brandName, lang));
         finish({ kind: 'code', code });
       } catch (err2) {

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -2057,6 +2057,9 @@ export async function executeGhostSetupAction(args: {
       args.ghostId,
       secretKey,
       decl,
+      runtimeManifest.network?.hosts?.length
+        ? { deliveryHosts: runtimeManifest.network.hosts }
+        : undefined,
     );
     return connected.ok
       ? { ok: true }
@@ -2693,6 +2696,7 @@ export function registerGhostIpc(): void {
       pathname,
       readBodyText,
       oauthSecrets,
+      networkHosts: runtimeManifest.network?.hosts,
       manager: getGhostOauthAccountManager(),
       ghostId,
       onChanged: (secretKey) => {

--- a/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
@@ -53,7 +53,11 @@ export interface GhostOauthEndpointManager {
     ghostId: string,
     secretKey: string,
     decl: GhostOauthDecl,
-    opts?: { scopes?: readonly string[]; clientId?: string },
+    opts?: {
+      scopes?: readonly string[];
+      clientId?: string;
+      deliveryHosts?: readonly string[];
+    },
   ): Promise<GhostOauthConnectResult>;
   disconnectAccount(ghostId: string, secretKey: string, accountId: string): void;
   setDefaultAccount(ghostId: string, secretKey: string, accountId: string): boolean;
@@ -67,13 +71,15 @@ export async function handleGhostOauthRequest(args: {
   readBodyText: () => Promise<string>;
   /** 当前清单里 source:'oauth' 的凭证(key → 授权详单;现查在装清单,不吃缓存)。 */
   oauthSecrets: ReadonlyMap<string, GhostOauthDecl>;
+  /** 清单 network.hosts 白名单——跨源 code 投递允许面的派生输入(见 connectAccount)。 */
+  networkHosts?: readonly string[];
   manager: GhostOauthEndpointManager;
   ghostId: string;
   /** Successful semantic persistence only; never receives credential values. */
   onChanged?: (secretKey: string) => void;
   log?: { warn(message: string, meta?: Record<string, unknown>): void };
 }): Promise<GhostOauthRequestOutcome> {
-  const { method, pathname, readBodyText, oauthSecrets, manager, ghostId, log } = args;
+  const { method, pathname, readBodyText, oauthSecrets, networkHosts, manager, ghostId, log } = args;
   const notifyChanged = (secretKey: string): void => {
     try {
       args.onChanged?.(secretKey);
@@ -230,14 +236,17 @@ export async function handleGhostOauthRequest(args: {
       return { status: 400 };
     }
     try {
-      const opts =
-        scopesOverride !== undefined || clientIdOverride !== undefined
-          ? {
-              ...(scopesOverride !== undefined ? { scopes: scopesOverride } : {}),
-              ...(clientIdOverride !== undefined ? { clientId: clientIdOverride } : {}),
-            }
-          : undefined;
-      const result = await manager.connectAccount(ghostId, secretKey, decl, opts);
+      const opts = {
+        ...(scopesOverride !== undefined ? { scopes: scopesOverride } : {}),
+        ...(clientIdOverride !== undefined ? { clientId: clientIdOverride } : {}),
+        ...(networkHosts?.length ? { deliveryHosts: networkHosts } : {}),
+      };
+      const result = await manager.connectAccount(
+        ghostId,
+        secretKey,
+        decl,
+        Object.keys(opts).length > 0 ? opts : undefined,
+      );
       // 结构化透传(ok:false 也是 200——授权被拒/超时是业务态不是协议错;
       // detail 可能含服务端错误摘录,已由引擎保证不含凭证字节)。
       return { status: 200, body: JSON.stringify(result) };


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #810:插件用 `source: "oauth"` 对接 xAI 时,授权卡死在「复制 code」页。xAI 新版 consent 页(accounts.x.ai)授权完成后不再 302 重定向回 loopback,而是页面 JS 跨源 fetch 回调地址投递 code——Chrome 对「公网 https 页面 → 127.0.0.1」要求应答 CORS preflight 并返回 Private Network Access 头。第一方 Grok 模型登录已修(grok-oauth-login.ts),但插件通用 OAuth 引擎(ghostOauthFlow)只处理 GET 302 回调,投递被浏览器拦下且无粘贴通道。

移植同一机制并按通用引擎改造:

- **允许来源不绑死服务商**:从该插件声明的 `authorizeUrl` / `tokenUrl` 的 origin 派生(仅 https)——只有「声明要去授权的那个域」允许跨源投递,任意其它来源的预检拿不到 CORS 头;
- OPTIONS 预检 204 放行且不触碰登录流状态(grok 侧 issue #491 的卡死教训:预检没有 code 参数,落进缺 code 分支会终止整个登录);
- 回调各响应(成功/错误)附带 CORS/PNA 头;state(+PKCE)校验不放松,与 302 回调同一套;
- 原有 GET 302 重定向回调(无 Origin 头)行为不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #810
- 本 PR 包含:`ghostCallbackCorsAllowedOrigins` / `ghostCallbackCorsHeaders` 与回调服务器接线、测试
- 明确不包含:issue 附带提到的「复制 code / 跳转回调双模式呈现不一致」的授权页体验梳理
- 用户可见变化:插件对接 xAI 的 OAuth 授权可自动完成,不再停在「复制 code」页
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
结果:40 passed(新增:声明域预检拿到 CORS/PNA 头、跨源 GET 投递成功且响应带头、非法来源预检 204 无 CORS 头、错误 state 仍 400;既有 302/PKCE/broker/固定端口用例全量回归)

pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm test:unit(仓库根,全量)
结果:exit 0,全部通过

pnpm check:dco
结果:通过
```

### 手工验证

不涉及(回调服务器行为由真实 loopback HTTP 单测覆盖)。

### 未执行的验证

未用真实 xAI OAuth 应用端到端走完授权——投递形态(跨源 GET fetch + PNA 预检)以 grok-oauth-login.ts 在生产验证过的同一机制为依据。注意:若插件声明的 authorizeUrl origin 与实际投递 origin 不同域(如声明 auth.x.ai 而投递来自 accounts.x.ai),按本设计需要插件把对应域声明进 authorizeUrl/tokenUrl 之一;已知限制如实列出,供维护者权衡是否需要显式的投递域声明字段。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围:loopback 回调服务器新增 OPTIONS 应答与按白名单附带的 CORS 头;code 真实性仍由 state(+PKCE)保证,非白名单来源行为与改动前一致(浏览器侧拦截)。
- 回滚 / 降级方式:revert 本 commit,回到 302-only 行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
