### PR TITLE
feat(cindy-helper): send_to_session create 支持 working_dir 指定目标项目目录

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
@@ -10,6 +10,7 @@ import { afterAll, describe, expect, it } from 'vitest';
 import { validateHandoffWorkingDir } from '../handoffWorkingDir.js';
 
 const dir = mkdtempSync(path.join(tmpdir(), 'cindy-handoff-wd-'));
+const realpathSyncDir = (await import('node:fs')).realpathSync(dir);
 const file = path.join(dir, 'plain.txt');
 writeFileSync(file, 'x');
 
@@ -19,13 +20,13 @@ afterAll(() => {
 
 describe('validateHandoffWorkingDir', () => {
   it('已存在目录(绝对路径)→ ok 且返回规范化路径', async () => {
-    expect(await validateHandoffWorkingDir(dir)).toEqual({ ok: true, dir: path.resolve(dir) });
+    expect(await validateHandoffWorkingDir(dir)).toEqual({ ok: true, dir: realpathSyncDir });
   });
 
   it('带前后空白的合法路径 → trim 后通过,返回规范化路径(review 反馈)', async () => {
     expect(await validateHandoffWorkingDir(`  ${dir}  `)).toEqual({
       ok: true,
-      dir: path.resolve(dir),
+      dir: realpathSyncDir,
     });
   });
 
@@ -45,6 +46,22 @@ describe('validateHandoffWorkingDir', () => {
     const r = await validateHandoffWorkingDir(file);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.message).toContain('不是目录');
+  });
+
+  it('软链目录 → 返回真身路径(review 反馈:base repo 解析看真身)', async () => {
+    const linkPath = path.join(dir, 'link-to-dir');
+    const target = path.join(dir, 'real-target');
+    const { mkdirSync, symlinkSync, realpathSync } = await import('node:fs');
+    mkdirSync(target);
+    try {
+      symlinkSync(target, linkPath, 'dir');
+    } catch {
+      return; // Windows 无特权时目录软链可能 EPERM,建不出夹具就跳过(守卫仍在)。
+    }
+    expect(await validateHandoffWorkingDir(linkPath)).toEqual({
+      ok: true,
+      dir: realpathSync(target),
+    });
   });
 
   it('空串 / 纯空白 → 报不能为空', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
@@ -1,6 +1,6 @@
 /**
  * send_to_session create 的 working_dir 覆盖校验(#811):绝对路径 + 已存在目录,
- * 其余形态给出可行动错误文案。
+ * 通过时返回规范化路径(trim + resolve),失败给出可行动错误文案。
  */
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -18,23 +18,40 @@ afterAll(() => {
 });
 
 describe('validateHandoffWorkingDir', () => {
-  it('已存在目录(绝对路径)→ null', async () => {
-    expect(await validateHandoffWorkingDir(dir)).toBeNull();
+  it('已存在目录(绝对路径)→ ok 且返回规范化路径', async () => {
+    expect(await validateHandoffWorkingDir(dir)).toEqual({ ok: true, dir: path.resolve(dir) });
+  });
+
+  it('带前后空白的合法路径 → trim 后通过,返回规范化路径(review 反馈)', async () => {
+    expect(await validateHandoffWorkingDir(`  ${dir}  `)).toEqual({
+      ok: true,
+      dir: path.resolve(dir),
+    });
   });
 
   it('相对路径 → 报绝对路径要求', async () => {
-    expect(await validateHandoffWorkingDir('relative/path')).toContain('绝对路径');
+    const r = await validateHandoffWorkingDir('relative/path');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('绝对路径');
   });
 
   it('不存在的路径 → 报不存在', async () => {
-    expect(await validateHandoffWorkingDir(path.join(dir, 'nope'))).toContain('不存在');
+    const r = await validateHandoffWorkingDir(path.join(dir, 'nope'));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('不存在');
   });
 
   it('指向文件 → 报不是目录', async () => {
-    expect(await validateHandoffWorkingDir(file)).toContain('不是目录');
+    const r = await validateHandoffWorkingDir(file);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('不是目录');
   });
 
-  it('空串 → 报不能为空', async () => {
-    expect(await validateHandoffWorkingDir('')).toContain('不能为空');
+  it('空串 / 纯空白 → 报不能为空', async () => {
+    for (const input of ['', '   ']) {
+      const r = await validateHandoffWorkingDir(input);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.message).toContain('不能为空');
+    }
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
@@ -1,0 +1,40 @@
+/**
+ * send_to_session create 的 working_dir 覆盖校验(#811):绝对路径 + 已存在目录,
+ * 其余形态给出可行动错误文案。
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { validateHandoffWorkingDir } from '../handoffWorkingDir.js';
+
+const dir = mkdtempSync(path.join(tmpdir(), 'cindy-handoff-wd-'));
+const file = path.join(dir, 'plain.txt');
+writeFileSync(file, 'x');
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('validateHandoffWorkingDir', () => {
+  it('已存在目录(绝对路径)→ null', async () => {
+    expect(await validateHandoffWorkingDir(dir)).toBeNull();
+  });
+
+  it('相对路径 → 报绝对路径要求', async () => {
+    expect(await validateHandoffWorkingDir('relative/path')).toContain('绝对路径');
+  });
+
+  it('不存在的路径 → 报不存在', async () => {
+    expect(await validateHandoffWorkingDir(path.join(dir, 'nope'))).toContain('不存在');
+  });
+
+  it('指向文件 → 报不是目录', async () => {
+    expect(await validateHandoffWorkingDir(file)).toContain('不是目录');
+  });
+
+  it('空串 → 报不能为空', async () => {
+    expect(await validateHandoffWorkingDir('')).toContain('不能为空');
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/handoffWorkingDir.ts
+++ b/apps/desktop/src/main/maker-ipc/handoffWorkingDir.ts
@@ -1,0 +1,27 @@
+/**
+ * send_to_session create 模式的 working_dir 覆盖校验(#811)。
+ *
+ * 只做存在性与形状校验(绝对路径 + 已存在目录):调用方 agent 本就拥有本机文件
+ * 访问面,目录选择不构成新增权限;校验的目的是把「目录写错」在创建 session 之前
+ * 拦下来,给出可行动的错误,而不是让新 session 落在不存在的目录里静默失败。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** 校验通过返回 null;否则返回给调用方的错误文案(进 INVALID_ARGS.message)。 */
+export async function validateHandoffWorkingDir(dir: string): Promise<string | null> {
+  if (typeof dir !== 'string' || dir.trim().length === 0) {
+    return 'working_dir 不能为空';
+  }
+  if (!path.isAbsolute(dir)) {
+    return `working_dir 必须是绝对路径:${dir}`;
+  }
+  try {
+    const st = await fs.promises.stat(dir);
+    if (!st.isDirectory()) return `working_dir 不是目录:${dir}`;
+  } catch {
+    return `working_dir 不存在或不可访问:${dir}`;
+  }
+  return null;
+}

--- a/apps/desktop/src/main/maker-ipc/handoffWorkingDir.ts
+++ b/apps/desktop/src/main/maker-ipc/handoffWorkingDir.ts
@@ -9,19 +9,30 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-/** 校验通过返回 null;否则返回给调用方的错误文案(进 INVALID_ARGS.message)。 */
-export async function validateHandoffWorkingDir(dir: string): Promise<string | null> {
-  if (typeof dir !== 'string' || dir.trim().length === 0) {
-    return 'working_dir 不能为空';
+export type HandoffWorkingDirValidation =
+  | { ok: true; dir: string }
+  | { ok: false; message: string };
+
+/**
+ * 校验并规范化 working_dir 覆盖。通过时返回规范化后的目录(trim + resolve,
+ * 调用方必须使用它,不要再用原始输入);失败时 message 进 INVALID_ARGS。
+ */
+export async function validateHandoffWorkingDir(
+  rawDir: string,
+): Promise<HandoffWorkingDirValidation> {
+  const trimmed = typeof rawDir === 'string' ? rawDir.trim() : '';
+  if (trimmed.length === 0) {
+    return { ok: false, message: 'working_dir 不能为空' };
   }
-  if (!path.isAbsolute(dir)) {
-    return `working_dir 必须是绝对路径:${dir}`;
+  if (!path.isAbsolute(trimmed)) {
+    return { ok: false, message: `working_dir 必须是绝对路径:${trimmed}` };
   }
+  const dir = path.resolve(trimmed);
   try {
     const st = await fs.promises.stat(dir);
-    if (!st.isDirectory()) return `working_dir 不是目录:${dir}`;
+    if (!st.isDirectory()) return { ok: false, message: `working_dir 不是目录:${dir}` };
   } catch {
-    return `working_dir 不存在或不可访问:${dir}`;
+    return { ok: false, message: `working_dir 不存在或不可访问:${dir}` };
   }
-  return null;
+  return { ok: true, dir };
 }

--- a/apps/desktop/src/main/maker-ipc/handoffWorkingDir.ts
+++ b/apps/desktop/src/main/maker-ipc/handoffWorkingDir.ts
@@ -27,7 +27,14 @@ export async function validateHandoffWorkingDir(
   if (!path.isAbsolute(trimmed)) {
     return { ok: false, message: `working_dir 必须是绝对路径:${trimmed}` };
   }
-  const dir = path.resolve(trimmed);
+  // realpath 消解软链(review 反馈):软链落在某个受管 worktree 树内、真身却指向
+  // 别的仓库时,后续 base repo 解析必须看真身;realpath 同时兜住存在性。
+  let dir: string;
+  try {
+    dir = await fs.promises.realpath(path.resolve(trimmed));
+  } catch {
+    return { ok: false, message: `working_dir 不存在或不可访问:${path.resolve(trimmed)}` };
+  }
   try {
     const st = await fs.promises.stat(dir);
     if (!st.isDirectory()) return { ok: false, message: `working_dir 不是目录:${dir}` };

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4585,14 +4585,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           }
           // working_dir 覆盖(#811):把新 session 落到指定项目目录,而不是恒继承
           // dispatcher 的目录。先于 worktree 预建校验——use_worktree 的 base 仓库
-          // 也从覆盖后的目录解析。
+          // 也从覆盖后的目录(校验器规范化后的形态)解析。
           let resolvedWorkDir = meta.workDir;
           if (workingDirOverride !== undefined) {
-            const invalid = await validateHandoffWorkingDir(workingDirOverride);
-            if (invalid) {
-              return { ok: false, errorCode: 'INVALID_ARGS', message: invalid };
+            const checked = await validateHandoffWorkingDir(workingDirOverride);
+            if (!checked.ok) {
+              return { ok: false, errorCode: 'INVALID_ARGS', message: checked.message };
             }
-            resolvedWorkDir = workingDirOverride;
+            resolvedWorkDir = checked.dir;
           }
           // useWorktree:为新 session 预建正规 session worktree(与 UI 新会话勾选
           // worktree 同类:worktreeStore 绑定 + 关闭时 auto-stash 清理),新 session 的
@@ -4610,7 +4610,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                 createWorktree: worktreeManager.createWorktree,
                 createId: () => randomUUID(),
               },
-              dispatcherSessionId,
+              // working_dir 覆盖时不带 dispatcherSessionId:resolveHandoffBaseRepo
+              // 的「dispatcher 自身 worktree」捷径按路径包含判定——覆盖目录若指向
+              // dispatcher worktree 树内的**嵌套独立仓库**,捷径会跳过 detectCwd、
+              // 误用 dispatcher 的 baseRepo。去掉捷径后 detectCwd 按目录自身探测
+              // git 根;覆盖目录落在登记过的 worktree 内时,listAll 反查分支仍生效。
+              workingDirOverride !== undefined ? undefined : dispatcherSessionId,
               resolvedWorkDir,
             );
             if (!prep.ok) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -306,6 +306,7 @@ import { refreshCodexMcpEnvironment } from './codexMcpRefresh.js';
 import { broadcastSchedulerChanged } from './schedule.js';
 import { validateExtraDirs } from './extraDirsValidator.js';
 import { prepareHandoffWorktree, shouldRecycleHandoffWorktreeOnFailure } from './handoffWorktree.js';
+import { validateHandoffWorkingDir } from './handoffWorkingDir.js';
 import { registerProjectPluginPolicyHandlers } from './projectPluginPolicyHandlers.js';
 import {
   restoreMissingManagedWorktreeForSession,
@@ -803,6 +804,8 @@ interface OrcaCollabService {
       title?: string;
       /** create 分支可选:true = 为新 session 预建独立 git worktree 并以其为 workingDir(jump 忽略)。 */
       useWorktree?: boolean;
+      /** create 分支可选:新 session 的工作目录覆盖(绝对路径,须已存在;jump 忽略)。#811 */
+      workingDir?: string;
       /** Host-owned create defaults for non-session callers such as scheduler script tasks. */
       createDefaults?: SendToSessionCreateDefaults;
     },
@@ -4515,6 +4518,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       dispatcherSessionId?: string;
       title?: string;
       useWorktree?: boolean;
+      /** create 分支可选:新 session 的工作目录覆盖(绝对路径,须已存在;jump 忽略)。#811 */
+      workingDir?: string;
       onAccepted?: () => void | Promise<void>;
       onAcceptedRollback?: () => void | Promise<void>;
       origin?: AgentInputQueuedMessage['origin'];
@@ -4531,6 +4536,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       dispatcherSessionId,
       title,
       useWorktree,
+      workingDir: workingDirOverride,
       onAccepted,
       onAcceptedRollback,
       origin,
@@ -4577,6 +4583,17 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
               message: `dispatcher session ${dispatcherSessionId} not found`,
             };
           }
+          // working_dir 覆盖(#811):把新 session 落到指定项目目录,而不是恒继承
+          // dispatcher 的目录。先于 worktree 预建校验——use_worktree 的 base 仓库
+          // 也从覆盖后的目录解析。
+          let resolvedWorkDir = meta.workDir;
+          if (workingDirOverride !== undefined) {
+            const invalid = await validateHandoffWorkingDir(workingDirOverride);
+            if (invalid) {
+              return { ok: false, errorCode: 'INVALID_ARGS', message: invalid };
+            }
+            resolvedWorkDir = workingDirOverride;
+          }
           // useWorktree:为新 session 预建正规 session worktree(与 UI 新会话勾选
           // worktree 同类:worktreeStore 绑定 + 关闭时 auto-stash 清理),新 session 的
           // id 必须用预生成的那个(worktree 绑定已按它登记)。失败硬报 WORKTREE_UNAVAILABLE
@@ -4594,7 +4611,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                 createId: () => randomUUID(),
               },
               dispatcherSessionId,
-              meta.workDir,
+              resolvedWorkDir,
             );
             if (!prep.ok) {
               return { ok: false, errorCode: 'WORKTREE_UNAVAILABLE', message: prep.message };
@@ -4608,7 +4625,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             .limit(1);
           inherited = {
             agentKind: meta.agentKind,
-            workingDir: meta.workDir,
+            workingDir: resolvedWorkDir,
             model: meta.model,
             effort: (row?.effort ?? undefined) as SendToSessionCreateDefaults['effort'],
             fastMode: !!row?.fastMode,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4588,6 +4588,16 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           // 也从覆盖后的目录(校验器规范化后的形态)解析。
           let resolvedWorkDir = meta.workDir;
           if (workingDirOverride !== undefined) {
+            // 远程 SSH 会话的 workDir 是远端路径,本机 stat 校验对它无意义
+            // (本机恰好同名目录会假阳性、远端合法目录会假阴性)——fail-closed
+            // 拒绝,待远程校验通道具备后再放开。
+            if (meta.remoteHostId) {
+              return {
+                ok: false,
+                errorCode: 'INVALID_ARGS',
+                message: 'working_dir 暂不支持远程会话(远端路径无法在本机校验)',
+              };
+            }
             const checked = await validateHandoffWorkingDir(workingDirOverride);
             if (!checked.ok) {
               return { ok: false, errorCode: 'INVALID_ARGS', message: checked.message };
@@ -4631,13 +4641,20 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           inherited = {
             agentKind: meta.agentKind,
             workingDir: resolvedWorkDir,
+            // 覆盖目录必有真实项目目录 → 归 project 工作区(标题/侧栏分组按项目
+            // 语义走);未覆盖时保持缺省继承,行为不变。
+            ...(workingDirOverride !== undefined ? { workspaceKind: 'project' as const } : {}),
             model: meta.model,
             effort: (row?.effort ?? undefined) as SendToSessionCreateDefaults['effort'],
             fastMode: !!row?.fastMode,
             providerId: row?.providerId ?? undefined,
-            permissionMode: inheritSourcePermissionMode
-              ? permissionModeOrAsk(row?.permissionMode)
-              : 'bypassPermissions',
+            // working_dir 覆盖时强制继承来源会话的权限档(review 反馈):把新目录
+            // 以 Full access 打开是相对 dispatcher 的权限升级,跨项目 handoff
+            // 不应隐式发生;未覆盖时保持既有缺省(bypassPermissions)不变。
+            permissionMode:
+              inheritSourcePermissionMode || workingDirOverride !== undefined
+                ? permissionModeOrAsk(row?.permissionMode)
+                : 'bypassPermissions',
           };
         } else {
           if (useWorktree) {

--- a/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
+++ b/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
@@ -290,13 +290,13 @@ export function createDesktopMcpProviders(deps: DesktopMcpProvidersDeps): LiziMc
           return { ok: false, errorCode: 'INTERNAL', message };
         }
       },
-      sendToSession: async ({ targetSessionId, message, dispatcherSessionId, title, useWorktree }) => {
+      sendToSession: async ({ targetSessionId, message, dispatcherSessionId, title, useWorktree, workingDir }) => {
         const svc = tryGetOrcaCollabService();
         if (!svc) {
           return { ok: false, errorCode: 'HOST_NOT_READY', message: 'orca collab service not initialized' };
         }
         try {
-          return await svc.sendToSession({ targetSessionId, message, dispatcherSessionId, title, useWorktree });
+          return await svc.sendToSession({ targetSessionId, message, dispatcherSessionId, title, useWorktree, workingDir });
         } catch (err) {
           return { ok: false, errorCode: 'INTERNAL', message: err instanceof Error ? err.message : String(err) };
         }

--- a/packages/lizi-mcps/src/__tests__/sendToSessionTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/sendToSessionTool.test.ts
@@ -213,3 +213,56 @@ describe('send_to_session tool', () => {
     expect(parse(res)).toMatchObject({ ok: false, errorCode: 'HOST_NOT_READY' });
   });
 });
+
+describe('send_to_session · working_dir (#811)', () => {
+  it('create + working_dir → host 收到 workingDir 覆盖', async () => {
+    const { registry, sendToSession } = setup();
+    const res = await registry.call('send_to_session', {
+      message: '请接手项目 B 的任务',
+      title: '项目 B · 任务交接',
+      working_dir: '/abs/path/project-b',
+    });
+    expect(sendToSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workingDir: '/abs/path/project-b',
+        targetSessionId: undefined,
+      }),
+    );
+    expect(parse(res)).toMatchObject({ ok: true, wake_kind: 'created' });
+  });
+
+  it('working_dir 与 use_worktree 可组合透传', async () => {
+    const { registry, sendToSession } = setup();
+    await registry.call('send_to_session', {
+      message: 'x',
+      working_dir: '/abs/path/project-b',
+      use_worktree: true,
+    });
+    expect(sendToSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workingDir: '/abs/path/project-b', useWorktree: true }),
+    );
+  });
+
+  it('省略 working_dir → host 收到 undefined(继承 dispatcher 目录的既有行为不变)', async () => {
+    const { registry, sendToSession } = setup();
+    await registry.call('send_to_session', { message: 'x' });
+    expect(sendToSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workingDir: undefined }),
+    );
+  });
+
+  it('host 返 INVALID_ARGS(路径校验失败)→ 错误码透传', async () => {
+    const { registry } = setup({
+      result: {
+        ok: false,
+        errorCode: 'INVALID_ARGS',
+        message: 'working_dir 不存在或不可访问:/nope',
+      },
+    });
+    const res = await registry.call('send_to_session', {
+      message: 'x',
+      working_dir: '/nope',
+    });
+    expect(parse(res)).toMatchObject({ ok: false, errorCode: 'INVALID_ARGS' });
+  });
+});

--- a/packages/lizi-mcps/src/xdt-helper/send_to_session.ts
+++ b/packages/lizi-mcps/src/xdt-helper/send_to_session.ts
@@ -65,7 +65,7 @@ const DESCRIPTION = [
   '',
   '【working_dir(仅 create 模式)】缺省新 session 继承当前 session 的 workingDir;传 working_dir(绝对路径,目录须已存在)可把新 session 直接落到另一个项目目录——「从项目 A 的对话把任务 handoff 到项目 B 的全新对话」一次调用完成,无需先在 B 里找一个旧对话中转。与 use_worktree 组合时,worktree 的 base git 仓库从 working_dir 解析。路径不是绝对路径 / 不存在 / 不是目录 → 返 INVALID_ARGS(message 带原因)。jump 模式忽略此参数。',
   '',
-  '【use_worktree(仅 create 模式)】use_worktree=true 时,host 会先从当前 workingDir 解析出 base git 仓库(当前 session 自己在 worktree 里跑也能正确反推主仓库),为新 session 预建一个正规 session worktree(<baseRepo>/.cindy-worktrees/<自动名> + xdt/<自动名> 分支,UI 有徽标,session 关闭时自动 stash 未提交改动后回收),新 session 的 workingDir 即该 worktree 路径,返回里带 worktree_path。适用:新 session 要改代码 / checkout 分支,不能污染当前工作树时(如 PR 修复跟进)。workingDir 不是 git 仓库 / git 未装 / worktree 创建失败 → 返 WORKTREE_UNAVAILABLE(不静默降级);调用方可视情况去掉该参数重试(新 session 将直接共享当前 workingDir)。jump 模式忽略此参数。',
+  '【use_worktree(仅 create 模式)】use_worktree=true 时,host 会先从**新 session 的 workingDir**(即 working_dir 覆盖后的目录;未覆盖时为当前 workingDir,此时 session 自己在 worktree 里跑也能正确反推主仓库)解析出 base git 仓库,为新 session 预建一个正规 session worktree(<baseRepo>/.cindy-worktrees/<自动名> + xdt/<自动名> 分支,UI 有徽标,session 关闭时自动 stash 未提交改动后回收),新 session 的 workingDir 即该 worktree 路径,返回里带 worktree_path。适用:新 session 要改代码 / checkout 分支,不能污染当前工作树时(如 PR 修复跟进)。workingDir 不是 git 仓库 / git 未装 / worktree 创建失败 → 返 WORKTREE_UNAVAILABLE(不静默降级);调用方可视情况去掉该参数重试(新 session 将直接共享当前 workingDir)。jump 模式忽略此参数。',
   '当前 dispatcher session 不会被本工具关闭或改写,消息投递成功后立即返回。',
   '',
   '【典型场景】skill 把某个外部业务对象(issue / jira / pr / 任意自定义 key)绑定到一个 session:首次处理时不传 id 让工具新建并拿回 id 写绑定;二次处理同一对象时传 id 把新消息路由回那个 session,保留完整上下文。',

--- a/packages/lizi-mcps/src/xdt-helper/send_to_session.ts
+++ b/packages/lizi-mcps/src/xdt-helper/send_to_session.ts
@@ -21,6 +21,8 @@ export type SendToSessionCallback = (params: {
   title?: string;
   /** create 模式可选:true = 为新 session 预建独立 git worktree 并以其为 workingDir(jump 忽略)。 */
   useWorktree?: boolean;
+  /** create 模式可选:新 session 的工作目录覆盖(绝对路径,须已存在;jump 忽略)。#811 */
+  workingDir?: string;
 }) => Promise<
   ControlResult<
     {
@@ -59,7 +61,9 @@ const DESCRIPTION = [
   '',
   '把一条控制层 handoff 消息投递到一个 session。两种模式:',
   '- 传 target_session_id → jump:投递到该既有 session(已关闭会自动 resume),wake_kind 返 resumed / already-active;目标正在跑 turn 时消息进入其输入队列、当前 turn 结束后自动派发,wake_kind 返 queued(无需重试)。',
-  '- 不传 target_session_id → create:为业务对象新建一个专属 session(继承当前 session 的 workingDir / model / effort / fastMode),投递首条消息,wake_kind 返 created,并在返回里回传新建的 target_session_id 供调用方建立绑定。可加 use_worktree=true 让新 session 在自己的独立 git worktree 里工作(见下)。',
+  '- 不传 target_session_id → create:为业务对象新建一个专属 session(继承当前 session 的 workingDir / model / effort / fastMode),投递首条消息,wake_kind 返 created,并在返回里回传新建的 target_session_id 供调用方建立绑定。可加 working_dir 把新 session 落到另一个项目目录(见下),可加 use_worktree=true 让新 session 在自己的独立 git worktree 里工作(见下)。',
+  '',
+  '【working_dir(仅 create 模式)】缺省新 session 继承当前 session 的 workingDir;传 working_dir(绝对路径,目录须已存在)可把新 session 直接落到另一个项目目录——「从项目 A 的对话把任务 handoff 到项目 B 的全新对话」一次调用完成,无需先在 B 里找一个旧对话中转。与 use_worktree 组合时,worktree 的 base git 仓库从 working_dir 解析。路径不是绝对路径 / 不存在 / 不是目录 → 返 INVALID_ARGS(message 带原因)。jump 模式忽略此参数。',
   '',
   '【use_worktree(仅 create 模式)】use_worktree=true 时,host 会先从当前 workingDir 解析出 base git 仓库(当前 session 自己在 worktree 里跑也能正确反推主仓库),为新 session 预建一个正规 session worktree(<baseRepo>/.cindy-worktrees/<自动名> + xdt/<自动名> 分支,UI 有徽标,session 关闭时自动 stash 未提交改动后回收),新 session 的 workingDir 即该 worktree 路径,返回里带 worktree_path。适用:新 session 要改代码 / checkout 分支,不能污染当前工作树时(如 PR 修复跟进)。workingDir 不是 git 仓库 / git 未装 / worktree 创建失败 → 返 WORKTREE_UNAVAILABLE(不静默降级);调用方可视情况去掉该参数重试(新 session 将直接共享当前 workingDir)。jump 模式忽略此参数。',
   '当前 dispatcher session 不会被本工具关闭或改写,消息投递成功后立即返回。',
@@ -114,10 +118,16 @@ export function registerSendToSessionTool(
         .boolean()
         .optional()
         .describe(
-          '仅 create 模式可选:true = 为新 session 预建独立 git worktree(自动从当前 workingDir 解析 base 仓库)并以其为 workingDir,返回带 worktree_path;失败返 WORKTREE_UNAVAILABLE 不静默降级。新 session 要改代码 / checkout 分支时建议开。jump 模式忽略。',
+          '仅 create 模式可选:true = 为新 session 预建独立 git worktree(自动从新 session 的 workingDir 解析 base 仓库)并以其为 workingDir,返回带 worktree_path;失败返 WORKTREE_UNAVAILABLE 不静默降级。新 session 要改代码 / checkout 分支时建议开。jump 模式忽略。',
+        ),
+      working_dir: z
+        .string()
+        .optional()
+        .describe(
+          '仅 create 模式可选:新 session 的工作目录(绝对路径,目录须已存在)。缺省继承当前 session 的 workingDir;用于把任务 handoff 到另一个项目目录的全新对话。不合法返 INVALID_ARGS。jump 模式忽略。',
         ),
     },
-    handler: async ({ target_session_id, message, title, use_worktree }) => {
+    handler: async ({ target_session_id, message, title, use_worktree, working_dir }) => {
       const ctx = deps.getSessionContext();
       const result = await deps.sendToSession({
         targetSessionId: target_session_id,
@@ -125,6 +135,7 @@ export function registerSendToSessionTool(
         dispatcherSessionId: ctx.sessionId,
         title,
         useWorktree: use_worktree,
+        workingDir: working_dir,
       });
 
       if (!result.ok) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

实现 #811 的方案 A:`send_to_session` create 模式新增可选 `working_dir`(绝对路径,目录须已存在),把新 session 直接落到另一个项目目录——「从项目 A 的对话把任务 handoff 到项目 B 的全新对话」一次调用完成,不再需要打开 UI 手工提交,或先 jump 到 B 的旧对话二次中转。

- 工具 schema → mcp-providers → `sendToSessionInternal` 全链路透传;jump 模式忽略(与 `use_worktree` 的忽略语义一致);
- host 侧校验(独立模块 `validateHandoffWorkingDir`)后以其覆盖继承目录,不合法返 `INVALID_ARGS` 带原因。校验只做存在性与形状——调用方 agent 本就拥有本机文件访问面,目录选择不构成新增权限,校验目的是把「目录写错」拦在建 session 之前;
- 与 `use_worktree` 组合时,worktree 的 base git 仓库从覆盖后目录解析;`resolveHandoffBaseRepo` 的「dispatcher 自身 worktree」分支有路径前缀守卫(isSamePathOrUnder),覆盖目录在 dispatcher worktree 之外时不会误用旧绑定;
- 工具描述同步补 `working_dir` 一节与 INVALID_ARGS 语义。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:Fixes #811(方案 A;issue 中方案 B 的 Deep Link 扩展不在范围)
- 本 PR 包含:send_to_session 工具/回调/host 内部链路 + 校验模块 + 测试
- 明确不包含:createDefaults(scheduler script 等无 dispatcher 调用方)路径的目录覆盖;renderer 侧任何改动
- 用户可见变化:helper 的 send_to_session 工具多一个可选参数
- 是否存在 breaking change:无(纯新增可选参数)

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/mcps exec vitest run src/__tests__/sendToSessionTool.test.ts
结果:15 passed(新增:working_dir 透传、与 use_worktree 组合、缺省 undefined 行为不变、INVALID_ARGS 透传)

pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
结果:5 passed(合法目录/相对路径/不存在/指向文件/空串)

pnpm --filter desktop run --if-present typecheck && pnpm --filter @cindy/mcps exec tsc --noEmit
结果:均通过

pnpm test:unit(仓库根,全量)
结果:exit 0,全部通过

pnpm check:dco
结果:通过
```

### 手工验证

不涉及(host create 分支的覆盖逻辑经由既有 sendToSessionInternal 路径,新增部分由校验器与工具层单测覆盖)。

### 未执行的验证

未在真实双项目环境端到端跑一次 handoff;host create 分支无独立集成测试(该函数深嵌 register.ts 接线,与既有 use_worktree 同状况),覆盖逻辑走查过 resolveHandoffBaseRepo 的三种解析分支。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围:仅 create 模式显式传 `working_dir` 时的新路径;未传参数时行为字节级不变。安全面:目录选择权本就在拥有全量文件工具的 agent 手里,本参数不扩大权限;`inheritSourcePermissionMode` 语义不受影响。
- 回滚 / 降级方式:revert 本 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
