### PR TITLE
fix(desktop): 语音输入浮窗开在焦点所在的显示器上

### DIFF
--- a/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
+++ b/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
@@ -34,6 +34,12 @@ struct Options {
   var targetPid: pid_t?
   var targetBundleId = ""
   var targetName = ""
+  /// Only collect the focused window frame when the caller actually needs it.
+  /// On a single-display Mac the answer cannot change which display the overlay
+  /// opens on, and on an AX-slow target these extra requests each cost up to the
+  /// configured messaging timeout — that would delay the paste target capture for
+  /// nothing.
+  var withFocusedFrame = false
 }
 
 struct Snapshot {
@@ -140,6 +146,8 @@ func parseOptions() throws -> Options {
     case "--target-name":
       guard let value = iterator.next() else { throw HelperError.missingValue(arg) }
       options.targetName = value
+    case "--with-focused-frame":
+      options.withFocusedFrame = true
     default:
       throw HelperError.invalidArgument("Unknown argument: \(arg)")
     }
@@ -441,7 +449,7 @@ let AX_SELECTED_TEXT_MARKER_RANGE = "AXSelectedTextMarkerRange" as CFString
 let AX_TEXT_MARKER_RANGE_FOR_UI_ELEMENT = "AXTextMarkerRangeForUIElement" as CFString
 let AX_STRING_FOR_TEXT_MARKER_RANGE = "AXStringForTextMarkerRange" as CFString
 
-func captureTargetPayload() -> [String: Any] {
+func captureTargetPayload(withFocusedFrame: Bool) -> [String: Any] {
   guard let app = NSWorkspace.shared.frontmostApplication else {
     return [
       "ok": false,
@@ -455,7 +463,7 @@ func captureTargetPayload() -> [String: Any] {
   // on" and "which app do we paste into" from disagreeing — two separate helper
   // processes would each read frontmostApplication at a slightly different
   // moment.
-  let focusedFrame = focusedWindowFrame(for: app)
+  let focusedFrame = withFocusedFrame ? focusedWindowFrame(for: app) : nil
   // Stream the frame out on its own line right away, before the (potentially
   // slow) context capture below. The overlay only waits ~90ms for it in order
   // to pick a display, while the AX context walk used by Chromium-style editors
@@ -1398,7 +1406,7 @@ do {
   let options = try parseOptions()
   switch options.command {
   case "capture-target":
-    emit(captureTargetPayload())
+    emit(captureTargetPayload(withFocusedFrame: options.withFocusedFrame))
   case "paste-verified":
     emit(pasteVerifiedPayload(options: options))
   default:

--- a/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
+++ b/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
@@ -491,6 +491,117 @@ func captureTargetPayload() -> [String: Any] {
   return payload
 }
 
+// Reports the frontmost window's frame so the global voice overlay can open on
+// the display the user is actually working on. This is deliberately the
+// cheapest possible command in this helper: no AXEnhancedUserInterface flip, no
+// text extraction, no subtree walk — the overlay's visible appearance waits on
+// this answer for a few dozen milliseconds, so it must stay fast.
+//
+// Coordinates are AX/CGWindow screen coordinates: origin at the top-left of the
+// primary display, y growing downwards, in points. That matches Electron's DIP
+// screen coordinate space on macOS, so main can feed the frame straight into
+// screen.getDisplayMatching().
+func focusedWindowFramePayload() -> [String: Any] {
+  guard let app = NSWorkspace.shared.frontmostApplication else {
+    return [
+      "ok": false,
+      "error": "No frontmost application"
+    ]
+  }
+  var payload: [String: Any] = [
+    "target": [
+      "processName": app.localizedName ?? "",
+      "bundleId": app.bundleIdentifier ?? "",
+      "pid": Int(app.processIdentifier)
+    ]
+  ]
+  if let frame = axFocusedWindowFrame(for: app) {
+    payload["ok"] = true
+    payload["frame"] = frame
+    payload["frameSource"] = "ax"
+    return payload
+  }
+  // CGWindowList needs no Accessibility grant and still reports geometry when
+  // Screen Recording is denied (only window titles are gated), so it covers the
+  // pre-permission first run and apps whose AX focused window is unavailable.
+  if let frame = frontWindowFrameFromWindowList(pid: app.processIdentifier) {
+    payload["ok"] = true
+    payload["frame"] = frame
+    payload["frameSource"] = "window-list"
+    return payload
+  }
+  payload["ok"] = false
+  payload["error"] = "No focused window frame"
+  return payload
+}
+
+func axFocusedWindowFrame(for app: NSRunningApplication) -> [String: Any]? {
+  guard AXIsProcessTrusted() else { return nil }
+  let axApp = AXUIElementCreateApplication(app.processIdentifier)
+  AXUIElementSetMessagingTimeout(axApp, 0.2)
+  guard let windowValue = copyAttribute(axApp, kAXFocusedWindowAttribute as CFString),
+        CFGetTypeID(windowValue) == AXUIElementGetTypeID() else {
+    return nil
+  }
+  let window = windowValue as! AXUIElement
+  AXUIElementSetMessagingTimeout(window, 0.2)
+  guard let origin = axPointAttribute(window, kAXPositionAttribute as CFString),
+        let size = axSizeAttribute(window, kAXSizeAttribute as CFString) else {
+    return nil
+  }
+  return [
+    "x": Double(origin.x),
+    "y": Double(origin.y),
+    "width": Double(size.width),
+    "height": Double(size.height)
+  ]
+}
+
+func axPointAttribute(_ element: AXUIElement, _ attribute: CFString) -> CGPoint? {
+  guard let value = copyAttribute(element, attribute),
+        CFGetTypeID(value) == AXValueGetTypeID() else {
+    return nil
+  }
+  var point = CGPoint.zero
+  guard AXValueGetValue(value as! AXValue, .cgPoint, &point) else { return nil }
+  return point
+}
+
+func axSizeAttribute(_ element: AXUIElement, _ attribute: CFString) -> CGSize? {
+  guard let value = copyAttribute(element, attribute),
+        CFGetTypeID(value) == AXValueGetTypeID() else {
+    return nil
+  }
+  var size = CGSize.zero
+  guard AXValueGetValue(value as! AXValue, .cgSize, &size) else { return nil }
+  return size
+}
+
+func frontWindowFrameFromWindowList(pid: pid_t) -> [String: Any]? {
+  let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+  guard let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+    return nil
+  }
+  // The list is ordered front to back, so the first normal-layer window owned by
+  // the frontmost process is the one the user is looking at.
+  for window in windows {
+    guard let ownerPid = window[kCGWindowOwnerPID as String] as? pid_t, ownerPid == pid else { continue }
+    guard let layer = window[kCGWindowLayer as String] as? Int, layer == 0 else { continue }
+    guard let boundsDict = window[kCGWindowBounds as String] as? [String: Any],
+          let rect = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else {
+      continue
+    }
+    if rect.width <= 0 || rect.height <= 0 { continue }
+    return [
+      "x": Double(rect.origin.x),
+      "y": Double(rect.origin.y),
+      "width": Double(rect.width),
+      "height": Double(rect.height)
+    ]
+  }
+  return nil
+}
+
 // Extracts before/selected/after text around the cursor in the focused element.
 // Used by the global voice overlay path to give the refiner the same kind of
 // surrounding context that ChatInput already provides for in-app dictation —
@@ -1270,6 +1381,8 @@ do {
   switch options.command {
   case "capture-target":
     emit(captureTargetPayload())
+  case "focused-window-frame":
+    emit(focusedWindowFramePayload())
   case "paste-verified":
     emit(pasteVerifiedPayload(options: options))
   default:

--- a/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
+++ b/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
@@ -448,6 +448,14 @@ func captureTargetPayload() -> [String: Any] {
       "error": "No frontmost application"
     ]
   }
+  // Read the focused window frame FIRST, before any AX mutation below: it must
+  // describe the same frontmostApplication snapshot as the paste target, and it
+  // must not observe a layout perturbed by the AXEnhancedUserInterface flip.
+  // Deriving both from one helper run is what keeps "which display do we open
+  // on" and "which app do we paste into" from disagreeing — two separate helper
+  // processes would each read frontmostApplication at a slightly different
+  // moment.
+  let focusedFrame = focusedWindowFrame(for: app)
   var context = captureFocusedElementContext(for: app)
   var enhancedAxAttempted = false
   var enhancedAxHelped = false
@@ -488,51 +496,31 @@ func captureTargetPayload() -> [String: Any] {
   if let context = context {
     payload["context"] = context
   }
+  if let focusedFrame = focusedFrame {
+    payload["frame"] = focusedFrame.frame
+    payload["frameSource"] = focusedFrame.source
+  }
   return payload
 }
 
 // Reports the frontmost window's frame so the global voice overlay can open on
-// the display the user is actually working on. This is deliberately the
-// cheapest possible command in this helper: no AXEnhancedUserInterface flip, no
-// text extraction, no subtree walk — the overlay's visible appearance waits on
-// this answer for a few dozen milliseconds, so it must stay fast.
+// the display the user is actually working on.
 //
 // Coordinates are AX/CGWindow screen coordinates: origin at the top-left of the
 // primary display, y growing downwards, in points. That matches Electron's DIP
 // screen coordinate space on macOS, so main can feed the frame straight into
 // screen.getDisplayMatching().
-func focusedWindowFramePayload() -> [String: Any] {
-  guard let app = NSWorkspace.shared.frontmostApplication else {
-    return [
-      "ok": false,
-      "error": "No frontmost application"
-    ]
-  }
-  var payload: [String: Any] = [
-    "target": [
-      "processName": app.localizedName ?? "",
-      "bundleId": app.bundleIdentifier ?? "",
-      "pid": Int(app.processIdentifier)
-    ]
-  ]
+func focusedWindowFrame(for app: NSRunningApplication) -> (frame: [String: Any], source: String)? {
   if let frame = axFocusedWindowFrame(for: app) {
-    payload["ok"] = true
-    payload["frame"] = frame
-    payload["frameSource"] = "ax"
-    return payload
+    return (frame, "ax")
   }
   // CGWindowList needs no Accessibility grant and still reports geometry when
   // Screen Recording is denied (only window titles are gated), so it covers the
   // pre-permission first run and apps whose AX focused window is unavailable.
   if let frame = frontWindowFrameFromWindowList(pid: app.processIdentifier) {
-    payload["ok"] = true
-    payload["frame"] = frame
-    payload["frameSource"] = "window-list"
-    return payload
+    return (frame, "window-list")
   }
-  payload["ok"] = false
-  payload["error"] = "No focused window frame"
-  return payload
+  return nil
 }
 
 func axFocusedWindowFrame(for app: NSRunningApplication) -> [String: Any]? {
@@ -1381,8 +1369,6 @@ do {
   switch options.command {
   case "capture-target":
     emit(captureTargetPayload())
-  case "focused-window-frame":
-    emit(focusedWindowFramePayload())
   case "paste-verified":
     emit(pasteVerifiedPayload(options: options))
   default:

--- a/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
+++ b/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
@@ -599,20 +599,30 @@ func frontWindowFrameFromWindowList(pid: pid_t) -> [String: Any]? {
   guard let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
     return nil
   }
-  // The list is ordered front to back, so the first normal-layer window owned by
-  // the frontmost process is the one the user is looking at.
+  // The list is ordered front to back, so the first window owned by the frontmost
+  // process is the one the user is looking at.
+  //
+  // Deliberately NOT restricted to layer 0: a focused text field can live in a
+  // floating NSPanel / utility window, which sits on a higher layer. Requiring
+  // layer 0 would skip it and return the app's ordinary document window instead —
+  // on a different display that means the overlay opens away from the field that
+  // is about to receive the paste. Front-to-back order already encodes "which of
+  // this app's windows is on top", so take the first usable one regardless of layer.
   for window in windows {
     // 这些值是 NSNumber。不要写 `as? pid_t`：NSNumber 只桥接到 Int，条件转换到
     // Int32 会一律失败，整条兜底就变成永远返回 nil。
     guard let ownerPid = (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
           ownerPid == pid else { continue }
-    guard let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue,
-          layer == 0 else { continue }
+    // 完全透明的窗口不是用户在看的东西（点击穿透层、隐藏的辅助窗口）。
+    if let alpha = (window[kCGWindowAlpha as String] as? NSNumber)?.doubleValue, alpha <= 0 {
+      continue
+    }
     guard let boundsDict = window[kCGWindowBounds as String] as? [String: Any],
           let rect = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else {
       continue
     }
-    if rect.width <= 0 || rect.height <= 0 { continue }
+    // 退化尺寸同样跳过：1x1 之类的占位窗口没法用来判断用户在哪块屏。
+    if rect.width <= 1 || rect.height <= 1 { continue }
     return [
       "x": Double(rect.origin.x),
       "y": Double(rect.origin.y),

--- a/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
+++ b/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
@@ -456,6 +456,19 @@ func captureTargetPayload() -> [String: Any] {
   // processes would each read frontmostApplication at a slightly different
   // moment.
   let focusedFrame = focusedWindowFrame(for: app)
+  // Stream the frame out on its own line right away, before the (potentially
+  // slow) context capture below. The overlay only waits ~90ms for it in order
+  // to pick a display, while the AX context walk used by Chromium-style editors
+  // can take hundreds of milliseconds — emitting only at exit would make the
+  // frame routinely arrive too late to be useful. The frame is repeated in the
+  // final payload so buffered callers keep working.
+  if let focusedFrame = focusedFrame {
+    emitLine([
+      "event": "focused-window-frame",
+      "frame": focusedFrame.frame,
+      "frameSource": focusedFrame.source
+    ])
+  }
   var context = captureFocusedElementContext(for: app)
   var enhancedAxAttempted = false
   var enhancedAxHelped = false
@@ -1335,6 +1348,23 @@ func buildPasteResult(
     "enhancedAxAttempted": enhancedAxAttempted,
     "enhancedAxHelped": enhancedAxHelped
   ]
+}
+
+/**
+ Writes one JSON line and flushes it immediately.
+
+ stdout is a pipe here, so libc buffers it fully — without the explicit flush an
+ early "progress" line would not reach the parent until the process exits, which
+ would defeat the whole point of streaming it. The parent treats the LAST JSON
+ line as the command result and earlier lines as tagged progress events.
+ */
+func emitLine(_ payload: [String: Any]) {
+  guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+        let text = String(data: data, encoding: .utf8) else {
+    return
+  }
+  print(text)
+  fflush(stdout)
 }
 
 func emit(_ payload: [String: Any]) {

--- a/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
+++ b/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
@@ -531,15 +531,23 @@ func captureTargetPayload(withFocusedFrame: Bool) -> [String: Any] {
 // primary display, y growing downwards, in points. That matches Electron's DIP
 // screen coordinate space on macOS, so main can feed the frame straight into
 // screen.getDisplayMatching().
+// CGWindowList is deliberately consulted FIRST. It is an in-process window-server
+// query: no Accessibility grant, no per-request messaging timeout, and it still
+// reports geometry when Screen Recording is denied (only window titles are gated).
+// The AX path can spend one 200 ms messaging timeout per request (focused window,
+// position, size) against an unresponsive target, which would blow the caller's
+// ~90 ms display-selection deadline and silently degrade the overlay back to the
+// mouse display — exactly the case this feature exists to fix.
+//
+// For *picking a display* the frontmost normal-layer window of the frontmost app
+// is as good as the AX focused window; AX only stays as the fallback for apps that
+// expose no on-screen normal-layer window.
 func focusedWindowFrame(for app: NSRunningApplication) -> (frame: [String: Any], source: String)? {
-  if let frame = axFocusedWindowFrame(for: app) {
-    return (frame, "ax")
-  }
-  // CGWindowList needs no Accessibility grant and still reports geometry when
-  // Screen Recording is denied (only window titles are gated), so it covers the
-  // pre-permission first run and apps whose AX focused window is unavailable.
   if let frame = frontWindowFrameFromWindowList(pid: app.processIdentifier) {
     return (frame, "window-list")
+  }
+  if let frame = axFocusedWindowFrame(for: app) {
+    return (frame, "ax")
   }
   return nil
 }
@@ -594,8 +602,12 @@ func frontWindowFrameFromWindowList(pid: pid_t) -> [String: Any]? {
   // The list is ordered front to back, so the first normal-layer window owned by
   // the frontmost process is the one the user is looking at.
   for window in windows {
-    guard let ownerPid = window[kCGWindowOwnerPID as String] as? pid_t, ownerPid == pid else { continue }
-    guard let layer = window[kCGWindowLayer as String] as? Int, layer == 0 else { continue }
+    // 这些值是 NSNumber。不要写 `as? pid_t`：NSNumber 只桥接到 Int，条件转换到
+    // Int32 会一律失败，整条兜底就变成永远返回 nil。
+    guard let ownerPid = (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+          ownerPid == pid else { continue }
+    guard let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue,
+          layer == 0 else { continue }
     guard let boundsDict = window[kCGWindowBounds as String] as? [String: Any],
           let rect = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else {
       continue

--- a/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
+++ b/apps/desktop/native/voice-input/macos-text-insertion-helper.swift
@@ -463,20 +463,41 @@ func captureTargetPayload(withFocusedFrame: Bool) -> [String: Any] {
   // on" and "which app do we paste into" from disagreeing — two separate helper
   // processes would each read frontmostApplication at a slightly different
   // moment.
-  let focusedFrame = withFocusedFrame ? focusedWindowFrame(for: app) : nil
-  // Stream the frame out on its own line right away, before the (potentially
-  // slow) context capture below. The overlay only waits ~90ms for it in order
-  // to pick a display, while the AX context walk used by Chromium-style editors
-  // can take hundreds of milliseconds — emitting only at exit would make the
-  // frame routinely arrive too late to be useful. The frame is repeated in the
-  // final payload so buffered callers keep working.
-  if let focusedFrame = focusedFrame {
-    emitLine([
-      "event": "focused-window-frame",
-      "frame": focusedFrame.frame,
-      "frameSource": focusedFrame.source
-    ])
+  // Two frames, streamed in cost order, each on its own line before the
+  // (potentially slow) context capture below:
+  //
+  // 1. CGWindowList — an in-process window-server query with no Accessibility
+  //    grant and no per-request timeout. It always lands inside the caller's
+  //    ~90 ms display-selection deadline, but z-order is only an approximation of
+  //    focus: an app's unfocused always-on-top palette can sit in front of the
+  //    focused document.
+  // 2. AX kAXFocusedWindow — authoritative about focus, but each request can burn
+  //    a messaging timeout against an unresponsive target, so it may miss the
+  //    deadline entirely.
+  //
+  // Emitting both lets the caller use the accurate answer whenever it arrives in
+  // time and still have a usable one when it does not. The final payload carries
+  // the best available frame so buffered callers keep working.
+  var bestFrame: (frame: [String: Any], source: String)? = nil
+  if withFocusedFrame {
+    if let listFrame = frontWindowFrameFromWindowList(pid: app.processIdentifier) {
+      bestFrame = (listFrame, "window-list")
+      emitLine([
+        "event": "focused-window-frame",
+        "frame": listFrame,
+        "frameSource": "window-list"
+      ])
+    }
+    if let axFrame = axFocusedWindowFrame(for: app) {
+      bestFrame = (axFrame, "ax")
+      emitLine([
+        "event": "focused-window-frame",
+        "frame": axFrame,
+        "frameSource": "ax"
+      ])
+    }
   }
+  let focusedFrame = bestFrame
   var context = captureFocusedElementContext(for: app)
   var enhancedAxAttempted = false
   var enhancedAxHelped = false
@@ -531,26 +552,6 @@ func captureTargetPayload(withFocusedFrame: Bool) -> [String: Any] {
 // primary display, y growing downwards, in points. That matches Electron's DIP
 // screen coordinate space on macOS, so main can feed the frame straight into
 // screen.getDisplayMatching().
-// CGWindowList is deliberately consulted FIRST. It is an in-process window-server
-// query: no Accessibility grant, no per-request messaging timeout, and it still
-// reports geometry when Screen Recording is denied (only window titles are gated).
-// The AX path can spend one 200 ms messaging timeout per request (focused window,
-// position, size) against an unresponsive target, which would blow the caller's
-// ~90 ms display-selection deadline and silently degrade the overlay back to the
-// mouse display — exactly the case this feature exists to fix.
-//
-// For *picking a display* the frontmost normal-layer window of the frontmost app
-// is as good as the AX focused window; AX only stays as the fallback for apps that
-// expose no on-screen normal-layer window.
-func focusedWindowFrame(for app: NSRunningApplication) -> (frame: [String: Any], source: String)? {
-  if let frame = frontWindowFrameFromWindowList(pid: app.processIdentifier) {
-    return (frame, "window-list")
-  }
-  if let frame = axFocusedWindowFrame(for: app) {
-    return (frame, "ax")
-  }
-  return nil
-}
 
 func axFocusedWindowFrame(for app: NSRunningApplication) -> [String: Any]? {
   guard AXIsProcessTrusted() else { return nil }
@@ -599,15 +600,16 @@ func frontWindowFrameFromWindowList(pid: pid_t) -> [String: Any]? {
   guard let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
     return nil
   }
-  // The list is ordered front to back, so the first window owned by the frontmost
-  // process is the one the user is looking at.
+  // This is the deadline-safe approximation only; AX kAXFocusedWindow is what
+  // actually knows where focus is, and the caller prefers it whenever it arrives
+  // in time (see captureTargetPayload).
   //
-  // Deliberately NOT restricted to layer 0: a focused text field can live in a
-  // floating NSPanel / utility window, which sits on a higher layer. Requiring
-  // layer 0 would skip it and return the app's ordinary document window instead —
-  // on a different display that means the overlay opens away from the field that
-  // is about to receive the paste. Front-to-back order already encodes "which of
-  // this app's windows is on top", so take the first usable one regardless of layer.
+  // Within that role, prefer the frontmost layer-0 window: an app's document
+  // windows live on layer 0, while higher layers hold palettes, tooltips and
+  // always-on-top helpers that are commonly NOT focused. Only if the app exposes
+  // no layer-0 window at all do we fall back to its frontmost window on any layer
+  // (some apps are panel-only).
+  var fallbackAnyLayer: [String: Any]? = nil
   for window in windows {
     // 这些值是 NSNumber。不要写 `as? pid_t`：NSNumber 只桥接到 Int，条件转换到
     // Int32 会一律失败，整条兜底就变成永远返回 nil。
@@ -623,14 +625,17 @@ func frontWindowFrameFromWindowList(pid: pid_t) -> [String: Any]? {
     }
     // 退化尺寸同样跳过：1x1 之类的占位窗口没法用来判断用户在哪块屏。
     if rect.width <= 1 || rect.height <= 1 { continue }
-    return [
+    let frame: [String: Any] = [
       "x": Double(rect.origin.x),
       "y": Double(rect.origin.y),
       "width": Double(rect.width),
       "height": Double(rect.height)
     ]
+    let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue
+    if layer == 0 { return frame }
+    if fallbackAnyLayer == nil { fallbackAnyLayer = frame }
   }
-  return nil
+  return fallbackAnyLayer
 }
 
 // Extracts before/selected/after text around the cursor in the focused element.

--- a/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
@@ -285,4 +285,40 @@ describe('voice input global shortcut registration', () => {
       expect(() => parseMacTextInsertionHelperResult('not json')).toThrow();
     });
   });
+
+  // 词典 toast 锚点按证据逐条登记,靠这个 key 关联。renderer 并发发起 advisor,
+  // key 必须只依赖往返途中不会变的字段,且不同证据不能撞成同一个 key。
+  describe('voiceInputDictionaryToastAnchorKey', () => {
+    const evidence = {
+      source: 'external_overlay',
+      beforeText: '把这段话写进文档',
+      afterText: '把这段话写进文档里',
+    };
+
+    it('同一条证据在 renderer 往返后仍算出同一个 key', async () => {
+      const { voiceInputDictionaryToastAnchorKey } = await import('../global.js');
+      // renderer 只会往 context 里加语言字段,不改 source / beforeText / afterText。
+      const roundTripped = {
+        ...evidence,
+        context: { uiLanguage: 'zh-CN', sourceLanguage: 'zh' },
+        debug: true,
+      };
+      expect(voiceInputDictionaryToastAnchorKey(roundTripped))
+        .toBe(voiceInputDictionaryToastAnchorKey(evidence));
+    });
+
+    it('不同证据得到不同 key(并发请求不会互相消费锚点)', async () => {
+      const { voiceInputDictionaryToastAnchorKey } = await import('../global.js');
+      const other = { ...evidence, afterText: '把这段话写进文档中' };
+      expect(voiceInputDictionaryToastAnchorKey(other))
+        .not.toBe(voiceInputDictionaryToastAnchorKey(evidence));
+    });
+
+    it('key 不含用户听写原文', async () => {
+      const { voiceInputDictionaryToastAnchorKey } = await import('../global.js');
+      const key = voiceInputDictionaryToastAnchorKey(evidence);
+      expect(key).toMatch(/^[0-9a-f]{32}$/);
+      expect(key).not.toContain('文档');
+    });
+  });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
@@ -290,7 +290,7 @@ describe('voice input global shortcut registration', () => {
   // key 必须只依赖往返途中不会变的字段,且不同证据不能撞成同一个 key。
   describe('voiceInputDictionaryToastAnchorKey', () => {
     const evidence = {
-      source: 'external_overlay',
+      source: 'external_overlay' as const,
       beforeText: '把这段话写进文档',
       afterText: '把这段话写进文档里',
     };

--- a/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
@@ -286,39 +286,12 @@ describe('voice input global shortcut registration', () => {
     });
   });
 
-  // 词典 toast 锚点按证据逐条登记,靠这个 key 关联。renderer 并发发起 advisor,
-  // key 必须只依赖往返途中不会变的字段,且不同证据不能撞成同一个 key。
-  describe('voiceInputDictionaryToastAnchorKey', () => {
-    const evidence = {
-      source: 'external_overlay' as const,
-      beforeText: '把这段话写进文档',
-      afterText: '把这段话写进文档里',
-    };
-
-    it('同一条证据在 renderer 往返后仍算出同一个 key', async () => {
-      const { voiceInputDictionaryToastAnchorKey } = await import('../global.js');
-      // renderer 只会往 context 里加语言字段,不改 source / beforeText / afterText。
-      const roundTripped = {
-        ...evidence,
-        context: { uiLanguage: 'zh-CN', sourceLanguage: 'zh' },
-        debug: true,
-      };
-      expect(voiceInputDictionaryToastAnchorKey(roundTripped))
-        .toBe(voiceInputDictionaryToastAnchorKey(evidence));
-    });
-
-    it('不同证据得到不同 key(并发请求不会互相消费锚点)', async () => {
-      const { voiceInputDictionaryToastAnchorKey } = await import('../global.js');
-      const other = { ...evidence, afterText: '把这段话写进文档中' };
-      expect(voiceInputDictionaryToastAnchorKey(other))
-        .not.toBe(voiceInputDictionaryToastAnchorKey(evidence));
-    });
-
-    it('key 不含用户听写原文', async () => {
-      const { voiceInputDictionaryToastAnchorKey } = await import('../global.js');
-      const key = voiceInputDictionaryToastAnchorKey(evidence);
-      expect(key).toMatch(/^[0-9a-f]{32}$/);
-      expect(key).not.toContain('文档');
+  // 词典 toast 锚点按「请求到达顺序」绑定:renderer 收到证据会立刻发起 advisor 请求,
+  // 所以请求到达顺序 == 证据发布顺序,并发只发生在响应上。取走必须是 FIFO 且一次性。
+  describe('takeOverlayDictionaryToastAnchor', () => {
+    it('没有待取锚点时返回 null', async () => {
+      const { takeOverlayDictionaryToastAnchor } = await import('../global.js');
+      expect(takeOverlayDictionaryToastAnchor()).toBeNull();
     });
   });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
@@ -255,4 +255,34 @@ describe('voice input global shortcut registration', () => {
     expect(shouldRestoreOverlayPasteTarget(undefined, 'darwin')).toBe(true);
     expect(shouldRestoreOverlayPasteTarget(undefined, 'win32')).toBe(false);
   });
+
+  // helper 会在最终结果之前先流式吐出前台窗口 frame(浮窗选屏只等这一行),所以
+  // 结果解析必须认最后一行,不能把第一行进度事件当成命令结果。
+  describe('parseMacTextInsertionHelperResult', () => {
+    it('多行输出时取最后一行作为结果', async () => {
+      const { parseMacTextInsertionHelperResult } = await import('../global.js');
+      const stdout = [
+        '{"event":"focused-window-frame","frame":{"x":0,"y":0,"width":800,"height":600},"frameSource":"ax"}',
+        '{"ok":true,"target":{"processName":"Chrome","bundleId":"com.google.Chrome","pid":42}}',
+        '',
+      ].join('\n');
+
+      const result = parseMacTextInsertionHelperResult(stdout);
+      expect(result.ok).toBe(true);
+      expect(result.event).toBeUndefined();
+      expect(result.target?.processName).toBe('Chrome');
+    });
+
+    it('单行输出保持原行为', async () => {
+      const { parseMacTextInsertionHelperResult } = await import('../global.js');
+      expect(parseMacTextInsertionHelperResult('{"ok":true,"outcome":"verified_success"}\n').ok)
+        .toBe(true);
+    });
+
+    it('空输出与非法 JSON 抛错(由调用方转成 PasteCommandError)', async () => {
+      const { parseMacTextInsertionHelperResult } = await import('../global.js');
+      expect(() => parseMacTextInsertionHelperResult('   \n\n')).toThrow();
+      expect(() => parseMacTextInsertionHelperResult('not json')).toThrow();
+    });
+  });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   clampOverlayBoundsToWorkArea,
+  normalizeFocusedWindowFrame,
   normalizeSavedOverlayPosition,
   resolveDraggedOverlayBounds,
   resolveOverlayInitialBounds,
   type OverlayPlacementDisplay,
+  type SavedOverlayPosition,
 } from '../overlayPlacement.js';
 
 // 与 global.ts 保持一致的几何常量(避免 import 触发 electron 依赖)。
@@ -135,60 +137,137 @@ describe('resolveDraggedOverlayBounds', () => {
 describe('resolveOverlayInitialBounds', () => {
   const fallbackBounds = { x: 660, y: 800, width: WIDTH, height: HEIGHT };
 
-  it('无保存位置时使用默认位置', () => {
-    const result = resolveOverlayInitialBounds({
-      savedPosition: null,
-      displays: [primary],
+  function initial(
+    savedPosition: SavedOverlayPosition | null,
+    options?: {
+      displays?: OverlayPlacementDisplay[];
+      activeDisplay?: OverlayPlacementDisplay | null;
+    },
+  ) {
+    const displays = options?.displays ?? [primary];
+    return resolveOverlayInitialBounds({
+      savedPosition,
+      displays,
+      activeDisplay: options?.activeDisplay === undefined ? displays[0] ?? null : options.activeDisplay,
       size: SIZE,
       ...geometry,
       fallbackBounds,
     });
-    expect(result).toEqual(fallbackBounds);
+  }
+
+  it('无保存位置时使用默认位置', () => {
+    expect(initial(null)).toEqual(fallbackBounds);
   });
 
   it('保存位置有效时记忆优先', () => {
-    const result = resolveOverlayInitialBounds({
-      savedPosition: { x: 100, y: 200, displayId: 1, updatedAt: 1 },
-      displays: [primary],
-      size: SIZE,
-      ...geometry,
-      fallbackBounds,
-    });
-    expect(result).toEqual({ x: 100, y: 200, width: WIDTH, height: HEIGHT });
+    expect(initial({ x: 100, y: 200, displayId: 1, updatedAt: 1 }))
+      .toEqual({ x: 100, y: 200, width: WIDTH, height: HEIGHT });
   });
 
   it('保存位置所在屏幕已不存在时回退默认位置', () => {
-    const result = resolveOverlayInitialBounds({
-      savedPosition: { x: 3000, y: 500, displayId: 2, updatedAt: 1 }, // 中心在已拔掉的副屏
+    // 中心在已拔掉的副屏，displayId 也找不到对应屏。
+    expect(initial({ x: 3000, y: 500, displayId: 2, updatedAt: 1 })).toEqual(fallbackBounds);
+  });
+
+  it('屏幕重新排布让旧坐标落到空隙时，仍按 displayId 认回记忆', () => {
+    const result = initial({ x: 3000, y: 500, displayId: 1, updatedAt: 1 }, {
       displays: [primary],
-      size: SIZE,
-      ...geometry,
-      fallbackBounds,
+      activeDisplay: primary,
     });
-    expect(result).toEqual(fallbackBounds);
+    // 记忆有效但坐标越界 → clamp 回主屏右边界，而不是退回默认位置。
+    expect(result.x).toBe(primary.workArea.x + primary.workArea.width - WIDTH - (EDGE_PADDING - CONTENT_INSET));
   });
 
   it('保存位置轻微越界时 clamp 回可见区域', () => {
-    const result = resolveOverlayInitialBounds({
-      savedPosition: { x: -200, y: 950, updatedAt: 1 }, // 中心仍在主屏内
-      displays: [primary],
-      size: SIZE,
-      ...geometry,
-      fallbackBounds,
-    });
+    const result = initial({ x: -200, y: 950, updatedAt: 1 }); // 中心仍在主屏内
     expect(result.x).toBe(primary.workArea.x + EDGE_PADDING - CONTENT_INSET);
     expect(result.y).toBe(primary.workArea.y + primary.workArea.height - HEIGHT - (EDGE_PADDING - CONTENT_INSET));
   });
 
   it('非有限坐标回退默认位置', () => {
-    const result = resolveOverlayInitialBounds({
-      savedPosition: { x: Number.NaN, y: 200, updatedAt: 1 },
-      displays: [primary],
-      size: SIZE,
-      ...geometry,
-      fallbackBounds,
-    });
-    expect(result).toEqual(fallbackBounds);
+    expect(initial({ x: Number.NaN, y: 200, updatedAt: 1 })).toEqual(fallbackBounds);
+  });
+
+  it('焦点屏就是保存位置所在屏时原样恢复', () => {
+    const saved = { x: 1920 + 300, y: 900, displayId: 2, updatedAt: 1 };
+    expect(initial(saved, { displays: [primary, secondary], activeDisplay: secondary }))
+      .toEqual({ x: saved.x, y: saved.y, width: WIDTH, height: HEIGHT });
+  });
+
+  it('焦点屏是另一块屏时，把保存位置按比例迁移过去', () => {
+    // 主屏上卡片中心在 workArea 的 (25%, 50%) 处。
+    const centerRatioX = 0.25;
+    const centerRatioY = 0.5;
+    const saved = {
+      x: Math.round(primary.workArea.x + primary.workArea.width * centerRatioX - WIDTH / 2),
+      y: Math.round(primary.workArea.y + primary.workArea.height * centerRatioY - HEIGHT / 2),
+      displayId: primary.id,
+      updatedAt: 1,
+    };
+    const result = initial(saved, { displays: [primary, secondary], activeDisplay: secondary });
+    // 保存位置本身是整数像素，比例换算会带 1px 以内的取整误差。
+    expect(result.x).toBeCloseTo(secondary.workArea.x + secondary.workArea.width * centerRatioX - WIDTH / 2, -0.5);
+    expect(result.y).toBeCloseTo(secondary.workArea.y + secondary.workArea.height * centerRatioY - HEIGHT / 2, -0.5);
+  });
+
+  it('迁移保留水平居中：主屏居中的记忆在副屏也居中', () => {
+    const saved = {
+      x: Math.round(primary.workArea.x + (primary.workArea.width - WIDTH) / 2),
+      y: 800,
+      displayId: primary.id,
+      updatedAt: 1,
+    };
+    const result = initial(saved, { displays: [primary, secondary], activeDisplay: secondary });
+    expect(result.x).toBe(Math.round(secondary.workArea.x + (secondary.workArea.width - WIDTH) / 2));
+  });
+
+  it('迁移到更小的屏时 clamp 进可见区域', () => {
+    const small: OverlayPlacementDisplay = {
+      id: 3,
+      workArea: { x: -1280, y: 0, width: 1280, height: 800 },
+    };
+    // 副屏上贴着右下角的记忆，迁到小屏后仍需留出 edgePadding。
+    const saved = {
+      x: secondary.workArea.x + secondary.workArea.width - WIDTH - (EDGE_PADDING - CONTENT_INSET),
+      y: secondary.workArea.y + secondary.workArea.height - HEIGHT - (EDGE_PADDING - CONTENT_INSET),
+      displayId: secondary.id,
+      updatedAt: 1,
+    };
+    const result = initial(saved, { displays: [secondary, small], activeDisplay: small });
+    expect(result.x).toBeLessThanOrEqual(
+      small.workArea.x + small.workArea.width - WIDTH - (EDGE_PADDING - CONTENT_INSET),
+    );
+    expect(result.y).toBeLessThanOrEqual(
+      small.workArea.y + small.workArea.height - HEIGHT - (EDGE_PADDING - CONTENT_INSET),
+    );
+    expect(result.x).toBeGreaterThanOrEqual(small.workArea.x + EDGE_PADDING - CONTENT_INSET);
+  });
+
+  it('拿不到焦点屏时退回保存位置所在屏（防御分支）', () => {
+    const saved = { x: 1920 + 300, y: 900, displayId: 2, updatedAt: 1 };
+    expect(initial(saved, { displays: [primary, secondary], activeDisplay: null }))
+      .toEqual({ x: saved.x, y: saved.y, width: WIDTH, height: HEIGHT });
+  });
+});
+
+describe('normalizeFocusedWindowFrame', () => {
+  it('接受合法 frame', () => {
+    expect(normalizeFocusedWindowFrame({ x: 10, y: 20, width: 800, height: 600 }))
+      .toEqual({ x: 10, y: 20, width: 800, height: 600 });
+  });
+
+  it('负坐标合法（副屏在主屏左侧时窗口 x 为负）', () => {
+    expect(normalizeFocusedWindowFrame({ x: -1200, y: -30, width: 640, height: 480 }))
+      .toEqual({ x: -1200, y: -30, width: 640, height: 480 });
+  });
+
+  it('缺字段 / 非法值 / 零尺寸返回 null', () => {
+    expect(normalizeFocusedWindowFrame(null)).toBeNull();
+    expect(normalizeFocusedWindowFrame('frame')).toBeNull();
+    expect(normalizeFocusedWindowFrame({ x: 0, y: 0, width: 800 })).toBeNull();
+    expect(normalizeFocusedWindowFrame({ x: 0, y: 0, width: 0, height: 600 })).toBeNull();
+    expect(normalizeFocusedWindowFrame({ x: 0, y: 0, width: 800, height: -600 })).toBeNull();
+    expect(normalizeFocusedWindowFrame({ x: Number.NaN, y: 0, width: 800, height: 600 })).toBeNull();
   });
 });
 

--- a/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
@@ -218,13 +218,27 @@ describe('resolveOverlayInitialBounds', () => {
     expect(Math.abs(result.x - expectedX)).toBeLessThanOrEqual(1);
   });
 
-  it('屏幕重新排布让旧坐标落到空隙时，仍按 displayId 认回记忆', () => {
-    const result = initial({ x: 3000, y: 500, displayId: 1, updatedAt: 1 }, {
+  it('旧快照没有比例、坐标又已不在归属屏内时回退默认位置', () => {
+    // 升级前存下的绝对坐标 + 之后的显示器重排：反推不出有意义的比例，夹到 0~1
+    // 只会得到一个贴边的假位置，不如回退默认。
+    expect(initial({ x: 3000, y: 500, displayId: primary.id, updatedAt: 1 }, {
       displays: [primary],
       activeDisplay: primary,
-    });
-    // 记忆有效但坐标越界 → clamp 回主屏右边界，而不是退回默认位置。
-    expect(result.x).toBe(primary.workArea.x + primary.workArea.width - WIDTH - (EDGE_PADDING - CONTENT_INSET));
+    })).toEqual(fallbackBounds);
+  });
+
+  it('同样场景下带比例的快照仍能还原记忆（这正是持久化比例的意义）', () => {
+    const result = initial({
+      x: 3000,
+      y: 500,
+      displayId: primary.id,
+      ratioX: 0.5,
+      ratioY: 0.86,
+      updatedAt: 1,
+    }, { displays: [primary], activeDisplay: primary });
+    const expectedX = primary.workArea.x + primary.workArea.width * 0.5 - WIDTH / 2;
+    expect(Math.abs(result.x - expectedX)).toBeLessThanOrEqual(1);
+    expect(result).not.toEqual(fallbackBounds);
   });
 
   it('旧坐标落进另一块屏时，归属屏认 displayId 而不认坐标落点', () => {

--- a/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   clampOverlayBoundsToWorkArea,
+  computeOverlayPositionRatio,
+  isBoundsCenterOnDisplay,
   normalizeFocusedWindowFrame,
   normalizeSavedOverlayPosition,
   resolveDraggedOverlayBounds,
@@ -178,6 +180,57 @@ describe('resolveOverlayInitialBounds', () => {
     expect(result.x).toBe(primary.workArea.x + primary.workArea.width - WIDTH - (EDGE_PADDING - CONTENT_INSET));
   });
 
+  it('旧坐标落进另一块屏时，归属屏认 displayId 而不认坐标落点', () => {
+    // 记忆存的是主屏（displayId 1）+ 比例 (0.25, 0.5)，但显示器重排后旧坐标
+    // 落进了副屏范围。归属屏必须仍是主屏，且按比例还原到焦点屏（主屏）。
+    const result = initial({
+      x: secondary.workArea.x + 400,
+      y: secondary.workArea.y + 400,
+      displayId: primary.id,
+      ratioX: 0.25,
+      ratioY: 0.5,
+      updatedAt: 1,
+    }, { displays: [primary, secondary], activeDisplay: primary });
+    const expectedX = primary.workArea.x + primary.workArea.width * 0.25 - WIDTH / 2;
+    const expectedY = primary.workArea.y + primary.workArea.height * 0.5 - HEIGHT / 2;
+    expect(Math.abs(result.x - expectedX)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.y - expectedY)).toBeLessThanOrEqual(1);
+  });
+
+  it('同屏但坐标已被重排作废时按保存的比例还原，而不是用失效坐标', () => {
+    // 主屏 workArea 已右移，旧坐标 (100, 200) 不再落在它内部。
+    const movedPrimary: OverlayPlacementDisplay = {
+      id: primary.id,
+      workArea: { x: 2560, y: 0, width: 1920, height: 1055 },
+    };
+    const result = initial({
+      x: 100,
+      y: 200,
+      displayId: primary.id,
+      ratioX: 0.5,
+      ratioY: 0.8,
+      updatedAt: 1,
+    }, { displays: [movedPrimary], activeDisplay: movedPrimary });
+    const expectedX = movedPrimary.workArea.x + movedPrimary.workArea.width * 0.5 - WIDTH / 2;
+    const expectedY = movedPrimary.workArea.y + movedPrimary.workArea.height * 0.8 - HEIGHT / 2;
+    expect(Math.abs(result.x - expectedX)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.y - expectedY)).toBeLessThanOrEqual(1);
+  });
+
+  it('跨屏时保存的比例优先于按坐标反推的比例', () => {
+    const result = initial({
+      // 坐标反推会得到 (0.25, 0.5)，但快照里明确记着 (0.8, 0.3)。
+      x: Math.round(primary.workArea.x + primary.workArea.width * 0.25 - WIDTH / 2),
+      y: Math.round(primary.workArea.y + primary.workArea.height * 0.5 - HEIGHT / 2),
+      displayId: primary.id,
+      ratioX: 0.8,
+      ratioY: 0.3,
+      updatedAt: 1,
+    }, { displays: [primary, secondary], activeDisplay: secondary });
+    const expectedX = secondary.workArea.x + secondary.workArea.width * 0.8 - WIDTH / 2;
+    expect(Math.abs(result.x - expectedX)).toBeLessThanOrEqual(1);
+  });
+
   it('保存位置轻微越界时 clamp 回可见区域', () => {
     const result = initial({ x: -200, y: 950, updatedAt: 1 }); // 中心仍在主屏内
     expect(result.x).toBe(primary.workArea.x + EDGE_PADDING - CONTENT_INSET);
@@ -206,8 +259,10 @@ describe('resolveOverlayInitialBounds', () => {
     };
     const result = initial(saved, { displays: [primary, secondary], activeDisplay: secondary });
     // 保存位置本身是整数像素，比例换算会带 1px 以内的取整误差。
-    expect(result.x).toBeCloseTo(secondary.workArea.x + secondary.workArea.width * centerRatioX - WIDTH / 2, -0.5);
-    expect(result.y).toBeCloseTo(secondary.workArea.y + secondary.workArea.height * centerRatioY - HEIGHT / 2, -0.5);
+    const expectedX = secondary.workArea.x + secondary.workArea.width * centerRatioX - WIDTH / 2;
+    const expectedY = secondary.workArea.y + secondary.workArea.height * centerRatioY - HEIGHT / 2;
+    expect(Math.abs(result.x - expectedX)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.y - expectedY)).toBeLessThanOrEqual(1);
   });
 
   it('迁移保留水平居中：主屏居中的记忆在副屏也居中', () => {
@@ -250,6 +305,43 @@ describe('resolveOverlayInitialBounds', () => {
   });
 });
 
+describe('computeOverlayPositionRatio', () => {
+  it('按卡片中心算屏内相对比例', () => {
+    const bounds = {
+      x: Math.round(primary.workArea.x + primary.workArea.width * 0.25 - WIDTH / 2),
+      y: Math.round(primary.workArea.y + primary.workArea.height * 0.75 - HEIGHT / 2),
+      width: WIDTH,
+      height: HEIGHT,
+    };
+    const ratio = computeOverlayPositionRatio(bounds, primary.workArea);
+    expect(ratio.ratioX).toBeCloseTo(0.25, 3);
+    expect(ratio.ratioY).toBeCloseTo(0.75, 3);
+  });
+
+  it('中心在 workArea 之外时把比例夹进 0~1', () => {
+    const ratio = computeOverlayPositionRatio(
+      { x: -9999, y: 99999, width: WIDTH, height: HEIGHT },
+      primary.workArea,
+    );
+    expect(ratio.ratioX).toBe(0);
+    expect(ratio.ratioY).toBe(1);
+  });
+});
+
+describe('isBoundsCenterOnDisplay', () => {
+  it('中心落在现存屏幕内时为 true', () => {
+    expect(isBoundsCenterOnDisplay({ x: 100, y: 200, width: WIDTH, height: HEIGHT }, [primary]))
+      .toBe(true);
+  });
+
+  it('对应屏幕已拔掉时为 false', () => {
+    expect(isBoundsCenterOnDisplay(
+      { x: secondary.workArea.x + 300, y: 500, width: WIDTH, height: HEIGHT },
+      [primary],
+    )).toBe(false);
+  });
+});
+
 describe('normalizeFocusedWindowFrame', () => {
   it('接受合法 frame', () => {
     expect(normalizeFocusedWindowFrame({ x: 10, y: 20, width: 800, height: 600 }))
@@ -273,8 +365,8 @@ describe('normalizeFocusedWindowFrame', () => {
 
 describe('normalizeSavedOverlayPosition', () => {
   it('接受合法快照', () => {
-    expect(normalizeSavedOverlayPosition({ x: 1, y: 2, displayId: 3, updatedAt: 4 }))
-      .toEqual({ x: 1, y: 2, displayId: 3, updatedAt: 4 });
+    expect(normalizeSavedOverlayPosition({ x: 1, y: 2, displayId: 3, ratioX: 0.5, ratioY: 0.8, updatedAt: 4 }))
+      .toEqual({ x: 1, y: 2, displayId: 3, ratioX: 0.5, ratioY: 0.8, updatedAt: 4 });
   });
 
   it('缺字段 / 非法值返回 null', () => {
@@ -286,6 +378,18 @@ describe('normalizeSavedOverlayPosition', () => {
 
   it('displayId / updatedAt 非法时降级而不丢整条记录', () => {
     expect(normalizeSavedOverlayPosition({ x: 1, y: 2, displayId: 'nope' }))
-      .toEqual({ x: 1, y: 2, displayId: undefined, updatedAt: 0 });
+      .toEqual({ x: 1, y: 2, displayId: undefined, ratioX: undefined, ratioY: undefined, updatedAt: 0 });
+  });
+
+  it('旧快照没有比例字段时保持 undefined（由坐标反推）', () => {
+    expect(normalizeSavedOverlayPosition({ x: 1, y: 2, displayId: 3, updatedAt: 4 }))
+      .toEqual({ x: 1, y: 2, displayId: 3, ratioX: undefined, ratioY: undefined, updatedAt: 4 });
+  });
+
+  it('比例超出 0~1 或非有限数时丢弃该字段', () => {
+    expect(normalizeSavedOverlayPosition({ x: 1, y: 2, ratioX: 1.5, ratioY: -0.2, updatedAt: 4 }))
+      .toEqual({ x: 1, y: 2, displayId: undefined, ratioX: undefined, ratioY: undefined, updatedAt: 4 });
+    expect(normalizeSavedOverlayPosition({ x: 1, y: 2, ratioX: Number.NaN, ratioY: 0.5, updatedAt: 4 }))
+      .toEqual({ x: 1, y: 2, displayId: undefined, ratioX: undefined, ratioY: 0.5, updatedAt: 4 });
   });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/overlayPlacement.test.ts
@@ -157,6 +157,11 @@ describe('resolveOverlayInitialBounds', () => {
     });
   }
 
+  /** 按 global.ts 落盘时的算法，为一个绝对坐标算出屏内相对比例。 */
+  function ratioOf(x: number, y: number, display: OverlayPlacementDisplay) {
+    return computeOverlayPositionRatio({ x, y, width: WIDTH, height: HEIGHT }, display.workArea);
+  }
+
   it('无保存位置时使用默认位置', () => {
     expect(initial(null)).toEqual(fallbackBounds);
   });
@@ -169,6 +174,48 @@ describe('resolveOverlayInitialBounds', () => {
   it('保存位置所在屏幕已不存在时回退默认位置', () => {
     // 中心在已拔掉的副屏，displayId 也找不到对应屏。
     expect(initial({ x: 3000, y: 500, displayId: 2, updatedAt: 1 })).toEqual(fallbackBounds);
+  });
+
+  it('displayId 记着但那块屏已拔掉时回退默认位置，即使旧坐标现在落进了另一块屏', () => {
+    // 记忆属于副屏（已拔掉），旧坐标现在落在主屏范围内。不能因此把记忆改判给
+    // 主屏并恢复那个陈旧坐标。
+    expect(initial({ x: 300, y: 500, displayId: secondary.id, updatedAt: 1 }, {
+      displays: [primary],
+      activeDisplay: primary,
+    })).toEqual(fallbackBounds);
+  });
+
+  it('同屏 workArea 未变时，带比例的记忆还原回原坐标（1px 取整误差内）', () => {
+    const saved = {
+      x: 400,
+      y: 700,
+      displayId: primary.id,
+      ...ratioOf(400, 700, primary),
+      updatedAt: 1,
+    };
+    const result = initial(saved, { displays: [primary], activeDisplay: primary });
+    expect(Math.abs(result.x - saved.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.y - saved.y)).toBeLessThanOrEqual(1);
+  });
+
+  it('同屏但分辨率变了时按比例走，不沿用旧的绝对坐标', () => {
+    // 在 1920 宽的屏上水平居中存下；该屏换成 2560 宽后仍应居中，而不是停在
+    // 旧坐标（那会变成偏左）。旧坐标中心仍落在新 workArea 内，所以这条正是
+    // 「坐标看起来还有效但其实已经不对」的场景。
+    const savedX = Math.round(primary.workArea.x + (primary.workArea.width - WIDTH) / 2);
+    const widerPrimary: OverlayPlacementDisplay = {
+      id: primary.id,
+      workArea: { x: primary.workArea.x, y: primary.workArea.y, width: 2560, height: 1055 },
+    };
+    const result = initial({
+      x: savedX,
+      y: 700,
+      displayId: primary.id,
+      ...ratioOf(savedX, 700, primary),
+      updatedAt: 1,
+    }, { displays: [widerPrimary], activeDisplay: widerPrimary });
+    const expectedX = Math.round(widerPrimary.workArea.x + (widerPrimary.workArea.width - WIDTH) / 2);
+    expect(Math.abs(result.x - expectedX)).toBeLessThanOrEqual(1);
   });
 
   it('屏幕重新排布让旧坐标落到空隙时，仍按 displayId 认回记忆', () => {

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -11,6 +11,7 @@ import {
 import type { Display, NativeImage, Point, Rectangle, WebContents } from 'electron';
 import path from 'node:path';
 import { execFile, spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import {
   inspectExternalEditedInsertedText,
@@ -242,11 +243,19 @@ let overlayDragSession: { startBounds: Rectangle; startCursor: Point } | null = 
 // 最近一次「浮窗真正呈现在哪」的 bounds。浮窗 hide 后会被停到屏幕外，实时
 // bounds 不能当锚点，全局浮窗路径的词典 toast 靠这份记录跟到同一块屏、同一位置。
 let lastPresentedOverlayBounds: Rectangle | null = null;
-// 从「发布证据」交棒给「显示 toast」的锚点，一次性消费。快照本身是在建 watch 时
-// （刚粘贴完）拍的，见 ExternalDictionaryLearningWatch.toastAnchor：词典建议要等
-// 延迟轮询 + 模型往返，期间用户可能已在另一块屏开了新一次浮窗，锚点必须跟着来源
-// 会话走，并在显示时用呈现代次复核，否则旧会话的 toast 会盖在新浮窗上。
-let pendingDictionaryToastAnchor: { bounds: Rectangle; presentationSeq: number } | null = null;
+// 从「发布证据」交棒给「显示 toast」的锚点，按证据逐条登记、一次性消费。
+//
+// 快照本身是在建 watch 时（刚粘贴完）拍的，见
+// ExternalDictionaryLearningWatch.toastAnchor：词典建议要等延迟轮询 + 模型往返，
+// 期间用户可能已在另一块屏开了新一次浮窗，锚点必须跟着来源会话走，并在显示时用
+// 呈现代次复核，否则旧会话的 toast 会盖在新浮窗上。
+//
+// 用 Map 而不是单个槽：renderer 是并发发起 advisor 的，不排队也不互等。会话 A 的
+// 请求还在跑时会话 B 就可能发布证据，共用一个槽会让先返回的 A 消费掉 B 的锚点。
+const dictionaryToastAnchors = new Map<string, { bounds: Rectangle; presentationSeq: number }>();
+// 登记表只用于「刚刚发布、还没出 toast」的证据，超过这个数就丢最旧的，
+// 避免 advisor 从不返回时无界增长。
+const DICTIONARY_TOAST_ANCHOR_MAX_ENTRIES = 8;
 // 浮窗呈现代次。焦点屏查询是异步的，它的回调必须能认出「这次呈现还算不算数」：
 // 会话被取消（hide / 复位到 idle）或已经开始了新一次呈现时，迟到的回调不得再
 // 定位或显示窗口——浮窗是缓存复用的，hide 并不销毁它，只靠 isDestroyed() 判断
@@ -288,8 +297,11 @@ export type DictionaryToastEntryPayload = {
 
 type DictionaryToastPayload = {
   entries: DictionaryToastEntryPayload[];
-  /** true = 该 toast 来自全局浮窗听写，可以贴着刚才的浮窗位置出现。 */
-  anchorToOverlay: boolean;
+  /**
+   * 非 null = 该 toast 来自全局浮窗听写，凭这个 key 去取它自己那条证据登记的锚点，
+   * 贴着产生它的那次浮窗位置出现。
+   */
+  anchorKey: string | null;
 };
 
 const EXTERNAL_DICTIONARY_LEARNING_POLL_DELAYS_MS = [2500, 6500, 14000];
@@ -716,7 +728,7 @@ export function registerGlobalVoiceInputIpc(): void {
       const entries = normalizeDictionaryToastEntries(payload);
       if (entries.length === 0) return { ok: false, error: 'Dictionary toast payload is incomplete.' };
       // Renderer 侧（应用内听写）触发的 toast 与全局浮窗位置无关。
-      showDictionaryToastWindow({ entries, anchorToOverlay: false });
+      showDictionaryToastWindow({ entries, anchorKey: null });
       return { ok: true };
     },
   );
@@ -1419,23 +1431,24 @@ function showDictionaryToastWindow(payload: DictionaryToastPayload): void {
 }
 
 /**
- * `anchorToOverlay` 只应由全局浮窗那条听写链路传 true。应用内听写的 toast 不能
- * 借用浮窗位置：用户可能在另一块屏的 Cindy 窗口里操作，甚至浮窗那块屏早已拔掉。
+ * `anchorKey` 只应由全局浮窗那条听写链路传（用
+ * `voiceInputDictionaryToastAnchorKey()` 从证据算出）。应用内听写不传：它的 toast
+ * 不能借用浮窗位置，用户可能在另一块屏的 Cindy 窗口里操作，甚至浮窗那块屏早已拔掉。
  */
 export function showVoiceInputDictionaryToast(
   entries: DictionaryToastEntryPayload[],
-  options?: { anchorToOverlay?: boolean },
+  options?: { anchorKey?: string | null },
 ): void {
   if (entries.length === 0) return;
   showDictionaryToastWindow({
     entries,
-    anchorToOverlay: Boolean(options?.anchorToOverlay),
+    anchorKey: options?.anchorKey ?? null,
   });
 }
 
 function createDictionaryToastWindow(payload: DictionaryToastPayload): BrowserWindow {
   const bounds = computeDictionaryToastBounds(
-    resolveDictionaryToastAnchorBounds(payload.anchorToOverlay),
+    resolveDictionaryToastAnchorBounds(payload.anchorKey),
   );
   const window = new BrowserWindow({
     ...bounds,
@@ -1741,20 +1754,19 @@ function computeOverlayBounds(display: Display): Rectangle {
 
 /**
  * 全局浮窗听写的词典 toast 贴着「产生它的那次浮窗所在的位置」出现。浮窗 hide 后会
- * 被停到屏幕外的 OVERLAY_IDLE_BOUNDS，实时 bounds 不能当锚点，所以用发布证据时拍
- * 下的快照（见 pendingDictionaryToastAnchor）。
+ * 被停到屏幕外的 OVERLAY_IDLE_BOUNDS，实时 bounds 不能当锚点，所以用建 watch 时拍下、
+ * 发布证据时按 key 登记的快照（见 dictionaryToastAnchors）。
  *
  * 三个条件都满足才用它，否则退回鼠标所在屏的默认位置：
- * - 调用方确实是全局浮窗链路（应用内听写与浮窗位置无关）；
+ * - 调用方是全局浮窗链路并带来了自己那条证据的 key（应用内听写不传）；
  * - 呈现代次没变——变了说明期间又开过浮窗，这条 toast 会盖在新浮窗上；
  * - 锚点中心仍落在某块现存屏幕上——否则外接屏拔掉后 toast 会整个落到屏幕外。
  */
-function resolveDictionaryToastAnchorBounds(anchorToOverlay: boolean): Rectangle {
-  if (!anchorToOverlay) return computeOverlayBounds(getCursorDisplay());
-  // 一次性消费：锚点只对它自己那条证据有效。若真有两条建议请求并发，后一条拿不到
-  // 锚点就退回默认位置——退化成「位置不贴心」，而不是「贴到别的会话上去」。
-  const anchor = pendingDictionaryToastAnchor;
-  pendingDictionaryToastAnchor = null;
+function resolveDictionaryToastAnchorBounds(anchorKey: string | null): Rectangle {
+  if (!anchorKey) return computeOverlayBounds(getCursorDisplay());
+  // 一次性消费：锚点只对它自己那条证据有效。
+  const anchor = dictionaryToastAnchors.get(anchorKey);
+  dictionaryToastAnchors.delete(anchorKey);
   if (anchor
     && anchor.presentationSeq === overlayPresentationSeq
     && isBoundsCenterOnDisplay(anchor.bounds, getOverlayPlacementDisplays())) {
@@ -2501,11 +2513,42 @@ function publishExternalDictionaryLearningEvidence(
 ): void {
   const window = getOverlayWindow();
   if (!window || window.isDestroyed()) return;
-  // 锚点是建 watch 时拍的（那才是这条证据对应的浮窗现场），这里只是交棒给 toast。
-  // 证据要经 renderer 往返再回到 main，不把几何值放进那条链路：renderer 传回来的
-  // 坐标属于不可信输入。
-  pendingDictionaryToastAnchor = toastAnchor;
+  // 锚点是建 watch 时拍的（那才是这条证据对应的浮窗现场），这里按证据 key 登记，
+  // 等这条证据的建议回来时凭同一个 key 取走。
+  //
+  // key 由 main 从证据内容派生，不放进 IPC payload：证据要经 renderer 往返，
+  // renderer 传回的几何值不可信，而 renderer 回传时只会往 context 里加语言字段、
+  // 不改 source / beforeText / afterText，所以 main 能在收到建议请求时重算出同一个
+  // key。真被改过就查不到锚点，退回默认位置，不会指向别的会话。
+  if (toastAnchor) {
+    registerDictionaryToastAnchor(voiceInputDictionaryToastAnchorKey(evidence), toastAnchor);
+  }
   window.webContents.send('voice-input:dictionary-learning-evidence', { evidence });
+}
+
+/**
+ * 词典 toast 锚点的证据 key。只取 renderer 往返途中不会改动的字段，并做摘要，
+ * 避免把用户听写文本原样留在 Map 的 key 里（日志、堆快照都可能带出去）。
+ */
+export function voiceInputDictionaryToastAnchorKey(
+  evidence: Pick<DictationDictionaryAdviceInput, 'source' | 'beforeText' | 'afterText'>,
+): string {
+  return createHash('sha256')
+    .update(`${evidence.source ?? ''} ${evidence.beforeText ?? ''} ${evidence.afterText ?? ''}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+function registerDictionaryToastAnchor(
+  key: string,
+  anchor: { bounds: Rectangle; presentationSeq: number },
+): void {
+  dictionaryToastAnchors.set(key, anchor);
+  while (dictionaryToastAnchors.size > DICTIONARY_TOAST_ANCHOR_MAX_ENTRIES) {
+    const oldest = dictionaryToastAnchors.keys().next();
+    if (oldest.done) break;
+    dictionaryToastAnchors.delete(oldest.value);
+  }
 }
 
 // Length-only summary for normal diagnostics. Full text debug is isolated in

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -242,10 +242,10 @@ let overlayDragSession: { startBounds: Rectangle; startCursor: Point } | null = 
 // 最近一次「浮窗真正呈现在哪」的 bounds。浮窗 hide 后会被停到屏幕外，实时
 // bounds 不能当锚点，全局浮窗路径的词典 toast 靠这份记录跟到同一块屏、同一位置。
 let lastPresentedOverlayBounds: Rectangle | null = null;
-// 发布外部听写的词典学习证据时对锚点拍的快照。词典建议是异步的（模型往返），
-// 期间用户可能已经在另一块屏开了新一次浮窗，把 lastPresentedOverlayBounds 覆盖成
-// 新会话的位置——那时旧会话的 toast 会盖在新浮窗上。所以连同当时的呈现代次一起
-// 记下来：代次变了就说明这条 toast 已经不属于当前现场，退回默认位置。
+// 从「发布证据」交棒给「显示 toast」的锚点，一次性消费。快照本身是在建 watch 时
+// （刚粘贴完）拍的，见 ExternalDictionaryLearningWatch.toastAnchor：词典建议要等
+// 延迟轮询 + 模型往返，期间用户可能已在另一块屏开了新一次浮窗，锚点必须跟着来源
+// 会话走，并在显示时用呈现代次复核，否则旧会话的 toast 会盖在新浮窗上。
 let pendingDictionaryToastAnchor: { bounds: Rectangle; presentationSeq: number } | null = null;
 // 浮窗呈现代次。焦点屏查询是异步的，它的回调必须能认出「这次呈现还算不算数」：
 // 会话被取消（hide / 复位到 idle）或已经开始了新一次呈现时，迟到的回调不得再
@@ -268,6 +268,12 @@ type ExternalDictionaryLearningWatch = {
   timers: NodeJS.Timeout[];
   completed: boolean;
   inspecting: boolean;
+  /**
+   * 这次听写的浮窗现场，建 watch 时（刚粘贴完、浮窗刚收起）就拍下来。
+   * watch 会延迟轮询几十秒，期间用户可能已经在另一块屏开了新一次浮窗，所以锚点
+   * 必须跟着 watch 走，不能等发布证据时再去读进程级的「最近一次浮窗位置」。
+   */
+  toastAnchor: { bounds: Rectangle; presentationSeq: number } | null;
   pendingEdit?: {
     editedText: string;
     detectedAt: number;
@@ -1739,17 +1745,20 @@ function computeOverlayBounds(display: Display): Rectangle {
  * - 锚点中心仍落在某块现存屏幕上——否则外接屏拔掉后 toast 会整个落到屏幕外。
  */
 function resolveDictionaryToastAnchorBounds(anchorToOverlay: boolean): Rectangle {
+  if (!anchorToOverlay) return computeOverlayBounds(getCursorDisplay());
+  // 一次性消费：锚点只对它自己那条证据有效。若真有两条建议请求并发，后一条拿不到
+  // 锚点就退回默认位置——退化成「位置不贴心」，而不是「贴到别的会话上去」。
   const anchor = pendingDictionaryToastAnchor;
-  if (anchorToOverlay && anchor
+  pendingDictionaryToastAnchor = null;
+  if (anchor
     && anchor.presentationSeq === overlayPresentationSeq
     && isBoundsCenterOnDisplay(anchor.bounds, getOverlayPlacementDisplays())) {
     return anchor.bounds;
   }
-  if (anchorToOverlay && anchor) {
-    log.debug('dictionary toast anchor dropped', {
-      staleSession: anchor.presentationSeq !== overlayPresentationSeq,
-    });
-  }
+  log.debug('dictionary toast anchor dropped', {
+    hasAnchor: Boolean(anchor),
+    staleSession: Boolean(anchor && anchor.presentationSeq !== overlayPresentationSeq),
+  });
   return computeOverlayBounds(getCursorDisplay());
 }
 
@@ -2115,6 +2124,9 @@ function scheduleExternalDictionaryLearningWatch(
     timers: [],
     completed: false,
     inspecting: false,
+    toastAnchor: lastPresentedOverlayBounds
+      ? { bounds: lastPresentedOverlayBounds, presentationSeq: overlayPresentationSeq }
+      : null,
   };
   externalDictionaryLearningWatch = watch;
   EXTERNAL_DICTIONARY_LEARNING_POLL_DELAYS_MS.forEach((delayMs) => {
@@ -2374,7 +2386,7 @@ function finalizePendingExternalDictionaryLearningEdit(
       selectedText: originalContext.selectedText,
       selectionAfter: originalContext.selectionAfter,
     },
-  });
+  }, watch.toastAnchor);
   log.debug('external dictionary learning pending evidence finalized', {
     target: describePasteTarget(watch.target),
     triggerReason,
@@ -2480,14 +2492,14 @@ function isSameMacPasteTarget(lhs: MacPasteTarget, rhs: MacPasteTarget): boolean
 
 function publishExternalDictionaryLearningEvidence(
   evidence: Pick<DictationDictionaryAdviceInput, 'source' | 'rawTranscriptText' | 'beforeText' | 'afterText' | 'context'>,
+  toastAnchor: ExternalDictionaryLearningWatch['toastAnchor'],
 ): void {
   const window = getOverlayWindow();
   if (!window || window.isDestroyed()) return;
-  // 在这里给 toast 锚点拍快照：这条证据对应的浮窗现场就是「刚刚那一次」。之后
-  // 模型往返期间新开的浮窗会推进呈现代次，届时这份快照自动失效。
-  pendingDictionaryToastAnchor = lastPresentedOverlayBounds
-    ? { bounds: lastPresentedOverlayBounds, presentationSeq: overlayPresentationSeq }
-    : null;
+  // 锚点是建 watch 时拍的（那才是这条证据对应的浮窗现场），这里只是交棒给 toast。
+  // 证据要经 renderer 往返再回到 main，不把几何值放进那条链路：renderer 传回来的
+  // 坐标属于不可信输入。
+  pendingDictionaryToastAnchor = toastAnchor;
   window.webContents.send('voice-input:dictionary-learning-evidence', { evidence });
 }
 

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -1427,6 +1427,15 @@ function normalizeDictionaryToastEntries(payload: unknown): DictionaryToastEntry
 }
 
 function showDictionaryToastWindow(payload: DictionaryToastPayload): void {
+  // 有浮窗正在呈现（用户正在录音）时不弹 toast。toast 是 alwaysOnTop 的，且它的默认
+  // 位置就是浮窗的默认位置——旧会话的建议迟到时退回默认位置，恰好会盖住正在录音的
+  // 新浮窗五秒。词条本身已经落库，这个提示不重要到值得挡住用户的操作界面。
+  if (isOverlayPresentationOpen(getOverlayWindow())) {
+    log.debug('dictionary toast suppressed: overlay presentation is open', {
+      entries: payload.entries.length,
+    });
+    return;
+  }
   closeDictionaryToastWindow();
   const window = createDictionaryToastWindow(payload);
   dictionaryToastWindow = window;
@@ -1781,6 +1790,9 @@ function computeOverlayBounds(display: Display): Rectangle {
  * - 调用方是全局浮窗链路并带来了自己那次会话的锚点（应用内听写不传）；
  * - 呈现代次没变——变了说明期间又开过浮窗，这条 toast 会盖在新浮窗上；
  * - 锚点中心仍落在某块现存屏幕上——否则外接屏拔掉后 toast 会整个落到屏幕外。
+ *
+ * 注意「退回默认位置」本身不足以避免遮挡：默认位置就是浮窗的默认位置。真正在录音
+ * 时的遮挡由 showDictionaryToastWindow() 的「有浮窗呈现就不弹」拦掉。
  */
 function resolveDictionaryToastAnchorBounds(anchor: DictionaryToastAnchor | null): Rectangle {
   if (!anchor) return computeOverlayBounds(getCursorDisplay());

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -1567,9 +1567,14 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   if (pendingModifierOverlaySubmit) {
     pendingModifierOverlaySubmit = false;
     setImmediate(() => {
-      if (!window.isDestroyed() && overlayPresentationActive) {
-        window.webContents.send('voice-input:global-overlay-command', { type: 'submit' });
+      // 同 show()：这条延迟提交也必须绑定呈现代次。窗口是跨会话复用的，
+      // overlayPresentationActive 是进程级状态，取消后紧接着重启会让它重新为
+      // true，届时旧会话的回调会把刚开始录音的新会话直接提交掉。
+      if (!isCurrentOverlayPresentation(window, presentationSeq)) {
+        log.debug('pending modifier submit dropped: presentation no longer current');
+        return;
       }
+      window.webContents.send('voice-input:global-overlay-command', { type: 'submit' });
     });
   }
   const show = (): void => {

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -242,20 +242,18 @@ let overlayDragSession: { startBounds: Rectangle; startCursor: Point } | null = 
 // 最近一次「浮窗真正呈现在哪」的 bounds。浮窗 hide 后会被停到屏幕外，实时
 // bounds 不能当锚点，全局浮窗路径的词典 toast 靠这份记录跟到同一块屏、同一位置。
 let lastPresentedOverlayBounds: Rectangle | null = null;
-// 从「发布证据」交棒给「显示 toast」的锚点队列，先进先出、一次性消费。
+// 从「发布证据」交棒给「显示 toast」的锚点队列，一次性消费。
 //
 // 快照是在粘贴开始前拍的（见 pasteTextToFocusedTarget）：那才是产生这条听写的浮窗
 // 现场。之后的粘贴 await、延迟轮询、模型往返期间用户都可能开新会话，锚点必须跟着
 // 来源会话走，并在显示时用呈现代次复核，否则旧会话的 toast 会盖在新浮窗上。
 //
-// 为什么 FIFO 队列就够、不需要给每条证据编 ID：renderer 收到证据会立刻发起 advisor
-// 请求，所以**请求到达 main 的顺序 == 证据发布顺序**；并发只发生在 advisor 的响应上。
-// main 在请求到达时（await 之前）就把队首锚点绑给这次请求，之后谁先返回都不会串台，
-// 内容相同的两次修正也不会互相覆盖。
+// 为什么不需要给每条证据编 ID：锚点的身份就是它的呈现代次。代次变过的锚点对任何
+// 请求都无效（那正是「期间又开过浮窗」），所以取用时直接丢弃过期的、拿代次仍匹配
+// 的那个——见 takeOverlayDictionaryToastAnchor()。
 const pendingDictionaryToastAnchors: DictionaryToastAnchor[] = [];
 // 队列只用于「刚发布、还没出 toast」的证据。renderer 侧若因功能开关未发起 advisor，
-// 对应锚点不会被取走，所以设上限丢最旧，避免无界增长；残留的旧锚点也过不了呈现代次
-// 复核，只会退化成默认位置。
+// 对应锚点不会被取走，所以设上限丢最旧，避免无界增长。
 const DICTIONARY_TOAST_ANCHOR_MAX_ENTRIES = 8;
 // 浮窗呈现代次。焦点屏查询是异步的，它的回调必须能认出「这次呈现还算不算数」：
 // 会话被取消（hide / 复位到 idle）或已经开始了新一次呈现时，迟到的回调不得再
@@ -2557,14 +2555,24 @@ function captureOverlayToastAnchor(): DictionaryToastAnchor | null {
 }
 
 /**
- * 取走队首的浮窗 toast 锚点，绑定给「这一次」词典建议请求。
+ * 取走属于「当前这次浮窗呈现」的 toast 锚点，绑定给这一次词典建议请求。
  *
- * 必须在建议请求刚到达、任何 await 之前调用：那时的到达顺序与证据发布顺序一致，
- * 绑定之后无论哪个请求先返回都不会拿到别人的锚点，内容相同的两次修正也不会互相
- * 覆盖。应用内听写不要调用它。
+ * 身份靠呈现代次，不靠队列位置：代次已经变过的锚点无论给谁都过不了
+ * resolveDictionaryToastAnchorBounds() 的复核（那正是「期间又开过浮窗」的定义），
+ * 所以这里遇到就直接丢弃，继续找代次仍匹配的那个。这样两种情况都不会错位：
+ * - 旧会话的建议迟到（此时已开过新浮窗）→ 它的锚点已过期，取不到，走默认位置；
+ * - renderer 因功能开关没发起请求，锚点留在队列里 → 下次请求会把它当过期丢掉，
+ *   拿到自己那份，不会一直错位一格。
+ *
+ * 必须在请求刚到达、任何 await 之前调用（代次此刻才代表这次请求的来源会话）。
+ * 应用内听写不要调用它。
  */
 export function takeOverlayDictionaryToastAnchor(): DictionaryToastAnchor | null {
-  return pendingDictionaryToastAnchors.shift() ?? null;
+  while (pendingDictionaryToastAnchors.length > 0) {
+    const candidate = pendingDictionaryToastAnchors.shift();
+    if (candidate && candidate.presentationSeq === overlayPresentationSeq) return candidate;
+  }
+  return null;
 }
 
 // Length-only summary for normal diagnostics. Full text debug is isolated in

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -1567,7 +1567,13 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
     });
   }
   const show = (): void => {
-    if (window.isDestroyed()) return;
+    // 两条路径（单屏的 setImmediate、多屏的等待回调）都要过这道校验：显示总是
+    // 延后至少一个 tick，期间用户可能已经取消。取消只让缓存窗口进 idle、不销毁，
+    // 所以只查 isDestroyed() 会让已取消的浮窗重新出现。
+    if (!isCurrentOverlayPresentation(window, presentationSeq)) {
+      log.debug('global overlay show skipped: presentation no longer current');
+      return;
+    }
     log.debug('global overlay ready to show', {
       elapsedSinceShortcutMs: Date.now() - shortcutInvokedAt,
     });

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -154,7 +154,9 @@ type MacTextInsertionHelperResult = {
   afterNumberOfCharacters?: number;
   enhancedAxAttempted?: boolean;
   enhancedAxHelped?: boolean;
-  /** focused-window-frame 命令：前台窗口 frame（DIP 屏幕坐标）。 */
+  /** 流式进度行的事件名；命令的最终结果行没有这个字段。 */
+  event?: string;
+  /** 前台窗口 frame（DIP 屏幕坐标），进度行与最终结果行都会带。 */
   frame?: unknown;
   frameSource?: string;
 };
@@ -240,6 +242,11 @@ let overlayDragSession: { startBounds: Rectangle; startCursor: Point } | null = 
 // 最近一次「浮窗真正呈现在哪」的 bounds。浮窗 hide 后会被停到屏幕外，实时
 // bounds 不能当锚点，全局浮窗路径的词典 toast 靠这份记录跟到同一块屏、同一位置。
 let lastPresentedOverlayBounds: Rectangle | null = null;
+// 发布外部听写的词典学习证据时对锚点拍的快照。词典建议是异步的（模型往返），
+// 期间用户可能已经在另一块屏开了新一次浮窗，把 lastPresentedOverlayBounds 覆盖成
+// 新会话的位置——那时旧会话的 toast 会盖在新浮窗上。所以连同当时的呈现代次一起
+// 记下来：代次变了就说明这条 toast 已经不属于当前现场，退回默认位置。
+let pendingDictionaryToastAnchor: { bounds: Rectangle; presentationSeq: number } | null = null;
 // 浮窗呈现代次。焦点屏查询是异步的，它的回调必须能认出「这次呈现还算不算数」：
 // 会话被取消（hide / 复位到 idle）或已经开始了新一次呈现时，迟到的回调不得再
 // 定位或显示窗口——浮窗是缓存复用的，hide 并不销毁它，只靠 isDestroyed() 判断
@@ -1500,8 +1507,22 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   //    读取，不会出现「浮窗开在 A 屏、粘贴却进了 B 屏的 App」。
   // 2. Tell the renderer to start microphone capture as soon as it is ready.
   // 3. Show the overlay on the next tick so UI display no longer gates mic start.
-  const captureOverlayPromise = captureMacPasteTarget();
-  const focusedDisplayQuery = startFocusedDisplayQuery(captureOverlayPromise);
+  //
+  // frame 走流式：helper 读到它就单独吐一行，不必等后面的 AX 上下文采集，所以
+  // 90ms 的选屏截止时间才有意义。
+  let resolveFocusedWindowFrame: (frame: Rectangle | null) => void = () => {};
+  const focusedWindowFramePromise = new Promise<Rectangle | null>((resolve) => {
+    resolveFocusedWindowFrame = resolve;
+  });
+  const captureOverlayPromise = captureMacPasteTarget({
+    onFocusedWindowFrame: (frame) => resolveFocusedWindowFrame(frame),
+  });
+  // 兜底：helper 没吐 frame（AX 与 CGWindowList 都没结果）、走了 osascript 回退，
+  // 或整个 capture 失败时，用最终结果收敛这个 promise，别让它永远悬着。
+  void captureOverlayPromise
+    .then((captured) => resolveFocusedWindowFrame(captured?.frame ?? null))
+    .catch(() => resolveFocusedWindowFrame(null));
+  const focusedDisplayQuery = startFocusedDisplayQuery(focusedWindowFramePromise);
   positionOverlayWindow(window);
   prepareOverlayForDisplay(window);
 
@@ -1624,7 +1645,7 @@ function getCursorDisplay(): Display {
 }
 
 /**
- * 从粘贴目标快照里派生「前台窗口在哪块屏」，返回 null 表示不查、直接用鼠标所在屏：
+ * 把前台窗口 frame 换算成「焦点屏」，返回 null 表示不查、直接用鼠标所在屏：
  * - 只有一块屏时答案唯一，不该为它推迟浮窗显示。
  * - 非 macOS 平台没有可用的低成本前台窗口查询（Electron 只能看自己的窗口），
  *   Windows 一律按鼠标所在屏判定。
@@ -1633,20 +1654,19 @@ function getCursorDisplay(): Display {
  * 打字时，粘贴目标在 B 屏，浮窗也应该开在 B 屏，所以这里优先认前台窗口。
  */
 function startFocusedDisplayQuery(
-  captureOverlayPromise: Promise<CapturedOverlayTarget | null>,
+  focusedWindowFramePromise: Promise<Rectangle | null>,
 ): Promise<Display | null> | null {
   if (process.platform !== 'darwin') return null;
   if (screen.getAllDisplays().length <= 1) return null;
   const startedAt = Date.now();
-  return captureOverlayPromise
-    .then((captured) => {
-      if (!captured?.frame) return null;
+  return focusedWindowFramePromise
+    .then((frame) => {
+      if (!frame) return null;
       // getDisplayMatching 按重叠面积选屏，跨屏摆放的窗口也能落到主要那块。
-      const display = screen.getDisplayMatching(captured.frame);
+      const display = screen.getDisplayMatching(frame);
       log.debug('focused display resolved', {
         elapsedMs: Date.now() - startedAt,
         displayId: display?.id,
-        target: describePasteTarget(captured.target),
       });
       return display ?? null;
     })
@@ -1703,17 +1723,26 @@ function computeOverlayBounds(display: Display): Rectangle {
 }
 
 /**
- * 全局浮窗听写的词典 toast 贴着「刚才浮窗所在的位置」出现。浮窗 hide 后会被停到
- * 屏幕外的 OVERLAY_IDLE_BOUNDS，实时 bounds 不能当锚点，所以用最近一次定位结果。
+ * 全局浮窗听写的词典 toast 贴着「产生它的那次浮窗所在的位置」出现。浮窗 hide 后会
+ * 被停到屏幕外的 OVERLAY_IDLE_BOUNDS，实时 bounds 不能当锚点，所以用发布证据时拍
+ * 下的快照（见 pendingDictionaryToastAnchor）。
  *
- * 这份缓存是进程级的，可能早于当前显示器拓扑：复用前必须确认它的中心还落在某块
- * 现存屏幕上（否则外接屏拔掉后 toast 会整个落到屏幕外）。不满足条件、或调用方
- * 不是全局浮窗链路时，一律退回鼠标所在屏的默认位置。
+ * 三个条件都满足才用它，否则退回鼠标所在屏的默认位置：
+ * - 调用方确实是全局浮窗链路（应用内听写与浮窗位置无关）；
+ * - 呈现代次没变——变了说明期间又开过浮窗，这条 toast 会盖在新浮窗上；
+ * - 锚点中心仍落在某块现存屏幕上——否则外接屏拔掉后 toast 会整个落到屏幕外。
  */
 function resolveDictionaryToastAnchorBounds(anchorToOverlay: boolean): Rectangle {
-  if (anchorToOverlay && lastPresentedOverlayBounds
-    && isBoundsCenterOnDisplay(lastPresentedOverlayBounds, getOverlayPlacementDisplays())) {
-    return lastPresentedOverlayBounds;
+  const anchor = pendingDictionaryToastAnchor;
+  if (anchorToOverlay && anchor
+    && anchor.presentationSeq === overlayPresentationSeq
+    && isBoundsCenterOnDisplay(anchor.bounds, getOverlayPlacementDisplays())) {
+    return anchor.bounds;
+  }
+  if (anchorToOverlay && anchor) {
+    log.debug('dictionary toast anchor dropped', {
+      staleSession: anchor.presentationSeq !== overlayPresentationSeq,
+    });
   }
   return computeOverlayBounds(getCursorDisplay());
 }
@@ -1960,10 +1989,25 @@ type CapturedOverlayTarget = {
   frame: Rectangle | null;
 };
 
-async function captureMacPasteTarget(): Promise<CapturedOverlayTarget | null> {
+/**
+ * `onFocusedWindowFrame` 会在 helper 吐出前台窗口 frame 那一行时立刻回调——远早于
+ * 整个 capture 完成（AX 上下文采集在 Chromium 系编辑器里可能要几百毫秒）。浮窗
+ * 选屏只等这一行，所以不能等最终结果。
+ */
+async function captureMacPasteTarget(
+  options?: { onFocusedWindowFrame?: (frame: Rectangle | null) => void },
+): Promise<CapturedOverlayTarget | null> {
   if (process.platform !== 'darwin') return null;
+  const onFocusedWindowFrame = options?.onFocusedWindowFrame;
   try {
-    const helperResult = await runMacTextInsertionHelper(['--command', 'capture-target']);
+    const helperResult = await runMacTextInsertionHelper(['--command', 'capture-target'], {
+      onProgress: onFocusedWindowFrame
+        ? (event) => {
+          if (event.event !== 'focused-window-frame') return;
+          onFocusedWindowFrame(normalizeFocusedWindowFrame(event.frame));
+        }
+        : undefined,
+    });
     if (helperResult.ok && helperResult.target?.processName) {
       const frame = normalizeFocusedWindowFrame(helperResult.frame);
       log.debug(PASTE_DEBUG_TAG, 'capture target result (native)', {
@@ -2433,6 +2477,11 @@ function publishExternalDictionaryLearningEvidence(
 ): void {
   const window = getOverlayWindow();
   if (!window || window.isDestroyed()) return;
+  // 在这里给 toast 锚点拍快照：这条证据对应的浮窗现场就是「刚刚那一次」。之后
+  // 模型往返期间新开的浮窗会推进呈现代次，届时这份快照自动失效。
+  pendingDictionaryToastAnchor = lastPresentedOverlayBounds
+    ? { bounds: lastPresentedOverlayBounds, presentationSeq: overlayPresentationSeq }
+    : null;
   window.webContents.send('voice-input:dictionary-learning-evidence', { evidence });
 }
 
@@ -2518,17 +2567,29 @@ function macTextInsertionTargetArgs(pasteTarget: MacPasteTarget): string[] {
   return args;
 }
 
+/**
+ * helper 可以在最终结果之前先流式吐出若干「进度行」（每行一个 JSON，带 `event`
+ * 字段），最后一行才是命令结果。`onProgress` 会在进度行到达时同步回调；只有传了
+ * 它才走 spawn 逐行读取，其余调用保持原来的 execFile 缓冲路径。
+ */
 async function runMacTextInsertionHelper(
   args: string[],
-  options?: { input?: string; timeoutMs?: number },
+  options?: {
+    input?: string;
+    timeoutMs?: number;
+    onProgress?: (event: MacTextInsertionHelperResult) => void;
+  },
 ): Promise<MacTextInsertionHelperResult> {
   const helperPath = await resolveMacTextInsertionHelperPath();
-  const stdout = await execFilePromise(helperPath, args, 'Could not run macOS text insertion helper.', {
-    timeoutMs: options?.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
-    input: options?.input,
-  });
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+  const stdout = options?.onProgress
+    ? await spawnHelperWithProgressPromise(helperPath, args, timeoutMs, options.onProgress)
+    : await execFilePromise(helperPath, args, 'Could not run macOS text insertion helper.', {
+      timeoutMs,
+      input: options?.input,
+    });
   try {
-    return JSON.parse(stdout) as MacTextInsertionHelperResult;
+    return parseMacTextInsertionHelperResult(stdout);
   } catch (error) {
     // Don't include stdout in the error message: the helper may have printed
     // partial JSON or debug output containing AX-captured surrounding text from
@@ -2539,6 +2600,92 @@ async function runMacTextInsertionHelper(
       `Invalid helper response: ${error instanceof Error ? error.message : String(error)}. Stdout bytes: ${stdout.length}.`,
     );
   }
+}
+
+/** 取 stdout 的最后一行 JSON 作为命令结果（前面的行是流式进度事件）。 */
+export function parseMacTextInsertionHelperResult(stdout: string): MacTextInsertionHelperResult {
+  const lines = stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+  const lastLine = lines[lines.length - 1];
+  if (lastLine === undefined) throw new Error('Empty helper response');
+  return JSON.parse(lastLine) as MacTextInsertionHelperResult;
+}
+
+/**
+ * spawn helper 并逐行解析 stdout：非最后一行的 JSON 交给 onProgress，完整 stdout
+ * 仍然返回给调用方按最后一行取结果。只有需要「结果之前先拿到中间事件」的调用会
+ * 走这里（目前只有 capture-target 的前台窗口 frame）。
+ */
+function spawnHelperWithProgressPromise(
+  command: string,
+  args: string[],
+  timeoutMs: number,
+  onProgress: (event: MacTextInsertionHelperResult) => void,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+    let stdout = '';
+    let pending = '';
+    let stderr = '';
+    let settled = false;
+
+    const settle = (run: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      run();
+    };
+    const timer = setTimeout(() => {
+      settle(() => {
+        child.kill('SIGTERM');
+        reject(new PasteCommandError(
+          'Could not run macOS text insertion helper.',
+          `Helper timed out after ${timeoutMs}ms.`,
+        ));
+      });
+    }, timeoutMs);
+
+    // 每收到一个完整换行就尝试解析：带 event 字段的是进度事件，最后一行结果不在
+    // 这里派发（由调用方从完整 stdout 取）。解析失败的行直接忽略——stdout 可能
+    // 含用户输入框文本，不进日志。
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      pending += text;
+      const lines = pending.split('\n');
+      pending = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as MacTextInsertionHelperResult & { event?: string };
+          if (parsed.event) onProgress(parsed);
+        } catch {
+          // 半行 / 非 JSON 输出：忽略，最终结果仍按最后一行解析。
+        }
+      }
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      settle(() => reject(new PasteCommandError(
+        'Could not run macOS text insertion helper.',
+        error.message,
+      )));
+    });
+    child.on('close', (code) => {
+      settle(() => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(new PasteCommandError(
+          'Could not run macOS text insertion helper.',
+          stderr.trim() || `Helper exited with code ${code}.`,
+        ));
+      });
+    });
+  });
 }
 
 let macTextInsertionHelperPathPromise: Promise<string> | null = null;

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -1541,28 +1541,44 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   // 2. Tell the renderer to start microphone capture as soon as it is ready.
   // 3. Show the overlay on the next tick so UI display no longer gates mic start.
   //
-  // frame 走流式：helper 读到它就单独吐一行，不必等后面的 AX 上下文采集，所以
-  // 90ms 的选屏截止时间才有意义。
+  // frame 走流式：helper 读到就单独吐一行，不必等后面的 AX 上下文采集，所以 90ms 的
+  // 选屏截止时间才有意义。helper 会吐两条——先是便宜有界的 CGWindowList（z-order
+  // 近似，一定赶得上截止线），再是权威但可能超时的 AX kAXFocusedWindow。这里保留
+  // 「当前最好的一条」，AX 到了就立刻放行，没到就用已经到手的近似值。
   //
   // 要不要采集 frame 在 spawn 之前就定：单屏（或非 macOS）下答案改变不了落屏结果，
   // 就不让 helper 去读——AX 慢的目标 App 里那几次读取会白白推迟粘贴目标采集。
-  let resolveFocusedWindowFrame: (frame: Rectangle | null) => void = () => {};
-  const focusedWindowFramePromise = new Promise<Rectangle | null>((resolve) => {
-    resolveFocusedWindowFrame = resolve;
+  let bestFocusedWindowFrame: Rectangle | null = null;
+  let hasAuthoritativeFrame = false;
+  let resolvePreferredFrame: () => void = () => {};
+  const preferredFrameArrived = new Promise<void>((resolve) => {
+    resolvePreferredFrame = resolve;
   });
   const wantsFocusedDisplay = shouldResolveFocusedDisplay();
   const captureOverlayPromise = captureMacPasteTarget(
     wantsFocusedDisplay
-      ? { onFocusedWindowFrame: (frame) => resolveFocusedWindowFrame(frame) }
+      ? {
+        onFocusedWindowFrame: (frame, source) => {
+          if (!frame || hasAuthoritativeFrame) return;
+          bestFocusedWindowFrame = frame;
+          if (source !== 'ax') return;
+          // AX 是权威答案，到了就不再等，也不再被后续行覆盖。
+          hasAuthoritativeFrame = true;
+          resolvePreferredFrame();
+        },
+      }
       : undefined,
   );
-  // 兜底：helper 没吐 frame（AX 与 CGWindowList 都没结果）、走了 osascript 回退，
-  // 或整个 capture 失败时，用最终结果收敛这个 promise，别让它永远悬着。
+  // 兜底：helper 一条 frame 都没吐（AX 与 CGWindowList 都没结果）、走了 osascript
+  // 回退，或整个 capture 失败时，用最终结果收敛，别让选屏一直等到截止线。
   void captureOverlayPromise
-    .then((captured) => resolveFocusedWindowFrame(captured?.frame ?? null))
-    .catch(() => resolveFocusedWindowFrame(null));
+    .then((captured) => {
+      if (!hasAuthoritativeFrame && captured?.frame) bestFocusedWindowFrame = captured.frame;
+      resolvePreferredFrame();
+    })
+    .catch(() => resolvePreferredFrame());
   const focusedDisplayQuery = wantsFocusedDisplay
-    ? startFocusedDisplayQuery(focusedWindowFramePromise)
+    ? startFocusedDisplayQuery(preferredFrameArrived, () => bestFocusedWindowFrame)
     : null;
   positionOverlayWindow(window);
   prepareOverlayForDisplay(window);
@@ -1638,7 +1654,7 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   // 所以重定位不会被看成跳动；超时则维持鼠标所在屏的定位直接显示。
   // 这段等待期里呈现已经算「打开」（麦克风在录），见 overlayPresentationAwaitingShow。
   overlayPresentationAwaitingShow = true;
-  void awaitFocusedDisplay(focusedDisplayQuery).then((focusedDisplay) => {
+  void focusedDisplayQuery.then((focusedDisplay) => {
     if (!isCurrentOverlayPresentation(window, presentationSeq)) {
       // 等待期间用户取消了浮窗、或者已经开始了新一次呈现：这次的答案作废。
       log.debug('focused display result dropped: overlay presentation no longer current');
@@ -1718,54 +1734,51 @@ function shouldResolveFocusedDisplay(): boolean {
 }
 
 /**
- * 把前台窗口 frame 换算成「焦点屏」。
+ * 把前台窗口 frame 换算成「焦点屏」，并给它加显示截止时间。
  *
- * 注意鼠标所在屏和键盘焦点所在屏可以不同：鼠标停在 A 屏、正在 B 屏的编辑器里
- * 打字时，粘贴目标在 B 屏，浮窗也应该开在 B 屏，所以这里优先认前台窗口。
+ * `preferredFrameArrived` 在权威答案（AX kAXFocusedWindow）到达、或 capture 整体
+ * 收敛时兑现；截止线到了就用 `readBestFrame()` 当时已有的最好答案（通常是先到的
+ * CGWindowList 近似值），而不是干脆放弃——放弃就退回鼠标所在屏，恰恰是本功能要修的
+ * 那个错。两者都没有才返回 null。
+ *
+ * 注意鼠标所在屏和键盘焦点所在屏可以不同：鼠标停在 A 屏、正在 B 屏的编辑器里打字时，
+ * 粘贴目标在 B 屏，浮窗也应该开在 B 屏，所以这里优先认前台窗口。
  */
 function startFocusedDisplayQuery(
-  focusedWindowFramePromise: Promise<Rectangle | null>,
+  preferredFrameArrived: Promise<void>,
+  readBestFrame: () => Rectangle | null,
 ): Promise<Display | null> {
   const startedAt = Date.now();
-  return focusedWindowFramePromise
-    .then((frame) => {
-      if (!frame) return null;
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (timedOut: boolean): void => {
+      if (settled) return;
+      settled = true;
+      const frame = readBestFrame();
+      if (!frame) {
+        log.debug('focused display unresolved, falling back to cursor display', {
+          elapsedMs: Date.now() - startedAt,
+          timedOut,
+        });
+        resolve(null);
+        return;
+      }
       // getDisplayMatching 按重叠面积选屏，跨屏摆放的窗口也能落到主要那块。
       const display = screen.getDisplayMatching(frame);
       log.debug('focused display resolved', {
         elapsedMs: Date.now() - startedAt,
         displayId: display?.id,
+        // true = 没等到 AX 权威答案，用的是先到的近似 frame。
+        timedOut,
       });
-      return display ?? null;
-    })
-    .catch((error) => {
-      log.debug('focused display query failed, falling back to cursor display', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    });
-}
-
-/** 给焦点屏查询加显示截止时间：迟到的答案直接丢弃，不再挪已经可见的浮窗。 */
-function awaitFocusedDisplay(query: Promise<Display | null>): Promise<Display | null> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const settle = (display: Display | null): void => {
-      if (settled) return;
-      settled = true;
-      resolve(display);
+      resolve(display ?? null);
     };
-    const timer = setTimeout(() => {
-      log.debug('focused display query deadline exceeded', {
-        deadlineMs: OVERLAY_FOCUSED_DISPLAY_DEADLINE_MS,
-      });
-      settle(null);
-    }, OVERLAY_FOCUSED_DISPLAY_DEADLINE_MS);
-    void query
-      .catch(() => null)
-      .then((display) => {
+    const timer = setTimeout(() => settle(true), OVERLAY_FOCUSED_DISPLAY_DEADLINE_MS);
+    void preferredFrameArrived
+      .catch(() => undefined)
+      .then(() => {
         clearTimeout(timer);
-        settle(display);
+        settle(false);
       });
   });
 }
@@ -2062,12 +2075,15 @@ type CapturedOverlayTarget = {
 };
 
 /**
- * `onFocusedWindowFrame` 会在 helper 吐出前台窗口 frame 那一行时立刻回调——远早于
- * 整个 capture 完成（AX 上下文采集在 Chromium 系编辑器里可能要几百毫秒）。浮窗
- * 选屏只等这一行，所以不能等最终结果。
+ * `onFocusedWindowFrame` 会在 helper 吐出前台窗口 frame 行时立刻回调——远早于整个
+ * capture 完成（AX 上下文采集在 Chromium 系编辑器里可能要几百毫秒）。浮窗选屏只等
+ * 这些行，所以不能等最终结果。
+ *
+ * helper 会吐两条：`window-list`（便宜有界的 z-order 近似）和 `ax`（权威的
+ * kAXFocusedWindow，可能超时）。`source` 原样透传，由调用方决定取舍。
  */
 async function captureMacPasteTarget(
-  options?: { onFocusedWindowFrame?: (frame: Rectangle | null) => void },
+  options?: { onFocusedWindowFrame?: (frame: Rectangle | null, source: string) => void },
 ): Promise<CapturedOverlayTarget | null> {
   if (process.platform !== 'darwin') return null;
   const onFocusedWindowFrame = options?.onFocusedWindowFrame;
@@ -2081,7 +2097,10 @@ async function captureMacPasteTarget(
       onProgress: onFocusedWindowFrame
         ? (event) => {
           if (event.event !== 'focused-window-frame') return;
-          onFocusedWindowFrame(normalizeFocusedWindowFrame(event.frame));
+          onFocusedWindowFrame(
+            normalizeFocusedWindowFrame(event.frame),
+            typeof event.frameSource === 'string' ? event.frameSource : 'unknown',
+          );
         }
         : undefined,
     });

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -11,7 +11,6 @@ import {
 import type { Display, NativeImage, Point, Rectangle, WebContents } from 'electron';
 import path from 'node:path';
 import { execFile, spawn } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import {
   inspectExternalEditedInsertedText,
@@ -243,18 +242,20 @@ let overlayDragSession: { startBounds: Rectangle; startCursor: Point } | null = 
 // 最近一次「浮窗真正呈现在哪」的 bounds。浮窗 hide 后会被停到屏幕外，实时
 // bounds 不能当锚点，全局浮窗路径的词典 toast 靠这份记录跟到同一块屏、同一位置。
 let lastPresentedOverlayBounds: Rectangle | null = null;
-// 从「发布证据」交棒给「显示 toast」的锚点，按证据逐条登记、一次性消费。
+// 从「发布证据」交棒给「显示 toast」的锚点队列，先进先出、一次性消费。
 //
-// 快照本身是在建 watch 时（刚粘贴完）拍的，见
-// ExternalDictionaryLearningWatch.toastAnchor：词典建议要等延迟轮询 + 模型往返，
-// 期间用户可能已在另一块屏开了新一次浮窗，锚点必须跟着来源会话走，并在显示时用
-// 呈现代次复核，否则旧会话的 toast 会盖在新浮窗上。
+// 快照是在粘贴开始前拍的（见 pasteTextToFocusedTarget）：那才是产生这条听写的浮窗
+// 现场。之后的粘贴 await、延迟轮询、模型往返期间用户都可能开新会话，锚点必须跟着
+// 来源会话走，并在显示时用呈现代次复核，否则旧会话的 toast 会盖在新浮窗上。
 //
-// 用 Map 而不是单个槽：renderer 是并发发起 advisor 的，不排队也不互等。会话 A 的
-// 请求还在跑时会话 B 就可能发布证据，共用一个槽会让先返回的 A 消费掉 B 的锚点。
-const dictionaryToastAnchors = new Map<string, { bounds: Rectangle; presentationSeq: number }>();
-// 登记表只用于「刚刚发布、还没出 toast」的证据，超过这个数就丢最旧的，
-// 避免 advisor 从不返回时无界增长。
+// 为什么 FIFO 队列就够、不需要给每条证据编 ID：renderer 收到证据会立刻发起 advisor
+// 请求，所以**请求到达 main 的顺序 == 证据发布顺序**；并发只发生在 advisor 的响应上。
+// main 在请求到达时（await 之前）就把队首锚点绑给这次请求，之后谁先返回都不会串台，
+// 内容相同的两次修正也不会互相覆盖。
+const pendingDictionaryToastAnchors: DictionaryToastAnchor[] = [];
+// 队列只用于「刚发布、还没出 toast」的证据。renderer 侧若因功能开关未发起 advisor，
+// 对应锚点不会被取走，所以设上限丢最旧，避免无界增长；残留的旧锚点也过不了呈现代次
+// 复核，只会退化成默认位置。
 const DICTIONARY_TOAST_ANCHOR_MAX_ENTRIES = 8;
 // 浮窗呈现代次。焦点屏查询是异步的，它的回调必须能认出「这次呈现还算不算数」：
 // 会话被取消（hide / 复位到 idle）或已经开始了新一次呈现时，迟到的回调不得再
@@ -282,7 +283,7 @@ type ExternalDictionaryLearningWatch = {
    * watch 会延迟轮询几十秒，期间用户可能已经在另一块屏开了新一次浮窗，所以锚点
    * 必须跟着 watch 走，不能等发布证据时再去读进程级的「最近一次浮窗位置」。
    */
-  toastAnchor: { bounds: Rectangle; presentationSeq: number } | null;
+  toastAnchor: DictionaryToastAnchor | null;
   pendingEdit?: {
     editedText: string;
     detectedAt: number;
@@ -295,13 +296,19 @@ export type DictionaryToastEntryPayload = {
   term: string;
 };
 
+/** 一次浮窗听写的「现场」：浮窗当时的位置 + 当时的呈现代次。 */
+export type DictionaryToastAnchor = {
+  bounds: Rectangle;
+  presentationSeq: number;
+};
+
 type DictionaryToastPayload = {
   entries: DictionaryToastEntryPayload[];
   /**
-   * 非 null = 该 toast 来自全局浮窗听写，凭这个 key 去取它自己那条证据登记的锚点，
-   * 贴着产生它的那次浮窗位置出现。
+   * 非 null = 该 toast 来自全局浮窗听写，且已绑定产生它的那次浮窗现场，
+   * 显示时贴着那个位置出现（仍要过呈现代次与屏幕存在性复核）。
    */
-  anchorKey: string | null;
+  anchor: DictionaryToastAnchor | null;
 };
 
 const EXTERNAL_DICTIONARY_LEARNING_POLL_DELAYS_MS = [2500, 6500, 14000];
@@ -728,7 +735,7 @@ export function registerGlobalVoiceInputIpc(): void {
       const entries = normalizeDictionaryToastEntries(payload);
       if (entries.length === 0) return { ok: false, error: 'Dictionary toast payload is incomplete.' };
       // Renderer 侧（应用内听写）触发的 toast 与全局浮窗位置无关。
-      showDictionaryToastWindow({ entries, anchorKey: null });
+      showDictionaryToastWindow({ entries, anchor: null });
       return { ok: true };
     },
   );
@@ -1431,24 +1438,24 @@ function showDictionaryToastWindow(payload: DictionaryToastPayload): void {
 }
 
 /**
- * `anchorKey` 只应由全局浮窗那条听写链路传（用
- * `voiceInputDictionaryToastAnchorKey()` 从证据算出）。应用内听写不传：它的 toast
- * 不能借用浮窗位置，用户可能在另一块屏的 Cindy 窗口里操作，甚至浮窗那块屏早已拔掉。
+ * `anchor` 只应由全局浮窗那条听写链路传（用 `takeOverlayDictionaryToastAnchor()`
+ * 在请求到达时取得）。应用内听写不传：它的 toast 不能借用浮窗位置，用户可能在另一
+ * 块屏的 Cindy 窗口里操作，甚至浮窗那块屏早已拔掉。
  */
 export function showVoiceInputDictionaryToast(
   entries: DictionaryToastEntryPayload[],
-  options?: { anchorKey?: string | null },
+  options?: { anchor?: DictionaryToastAnchor | null },
 ): void {
   if (entries.length === 0) return;
   showDictionaryToastWindow({
     entries,
-    anchorKey: options?.anchorKey ?? null,
+    anchor: options?.anchor ?? null,
   });
 }
 
 function createDictionaryToastWindow(payload: DictionaryToastPayload): BrowserWindow {
   const bounds = computeDictionaryToastBounds(
-    resolveDictionaryToastAnchorBounds(payload.anchorKey),
+    resolveDictionaryToastAnchorBounds(payload.anchor),
   );
   const window = new BrowserWindow({
     ...bounds,
@@ -1529,19 +1536,27 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   //
   // frame 走流式：helper 读到它就单独吐一行，不必等后面的 AX 上下文采集，所以
   // 90ms 的选屏截止时间才有意义。
+  //
+  // 要不要采集 frame 在 spawn 之前就定：单屏（或非 macOS）下答案改变不了落屏结果，
+  // 就不让 helper 去读——AX 慢的目标 App 里那几次读取会白白推迟粘贴目标采集。
   let resolveFocusedWindowFrame: (frame: Rectangle | null) => void = () => {};
   const focusedWindowFramePromise = new Promise<Rectangle | null>((resolve) => {
     resolveFocusedWindowFrame = resolve;
   });
-  const captureOverlayPromise = captureMacPasteTarget({
-    onFocusedWindowFrame: (frame) => resolveFocusedWindowFrame(frame),
-  });
+  const wantsFocusedDisplay = shouldResolveFocusedDisplay();
+  const captureOverlayPromise = captureMacPasteTarget(
+    wantsFocusedDisplay
+      ? { onFocusedWindowFrame: (frame) => resolveFocusedWindowFrame(frame) }
+      : undefined,
+  );
   // 兜底：helper 没吐 frame（AX 与 CGWindowList 都没结果）、走了 osascript 回退，
   // 或整个 capture 失败时，用最终结果收敛这个 promise，别让它永远悬着。
   void captureOverlayPromise
     .then((captured) => resolveFocusedWindowFrame(captured?.frame ?? null))
     .catch(() => resolveFocusedWindowFrame(null));
-  const focusedDisplayQuery = startFocusedDisplayQuery(focusedWindowFramePromise);
+  const focusedDisplayQuery = wantsFocusedDisplay
+    ? startFocusedDisplayQuery(focusedWindowFramePromise)
+    : null;
   positionOverlayWindow(window);
   prepareOverlayForDisplay(window);
 
@@ -1675,19 +1690,26 @@ function getCursorDisplay(): Display {
 }
 
 /**
- * 把前台窗口 frame 换算成「焦点屏」，返回 null 表示不查、直接用鼠标所在屏：
- * - 只有一块屏时答案唯一，不该为它推迟浮窗显示。
+ * 是否值得去问「前台窗口在哪块屏」。false 时既不采集 frame 也不推迟显示，直接用
+ * 鼠标所在屏：
+ * - 只有一块屏时答案唯一；
  * - 非 macOS 平台没有可用的低成本前台窗口查询（Electron 只能看自己的窗口），
  *   Windows 一律按鼠标所在屏判定。
+ */
+function shouldResolveFocusedDisplay(): boolean {
+  if (process.platform !== 'darwin') return false;
+  return screen.getAllDisplays().length > 1;
+}
+
+/**
+ * 把前台窗口 frame 换算成「焦点屏」。
  *
  * 注意鼠标所在屏和键盘焦点所在屏可以不同：鼠标停在 A 屏、正在 B 屏的编辑器里
  * 打字时，粘贴目标在 B 屏，浮窗也应该开在 B 屏，所以这里优先认前台窗口。
  */
 function startFocusedDisplayQuery(
   focusedWindowFramePromise: Promise<Rectangle | null>,
-): Promise<Display | null> | null {
-  if (process.platform !== 'darwin') return null;
-  if (screen.getAllDisplays().length <= 1) return null;
+): Promise<Display | null> {
   const startedAt = Date.now();
   return focusedWindowFramePromise
     .then((frame) => {
@@ -1754,27 +1776,22 @@ function computeOverlayBounds(display: Display): Rectangle {
 
 /**
  * 全局浮窗听写的词典 toast 贴着「产生它的那次浮窗所在的位置」出现。浮窗 hide 后会
- * 被停到屏幕外的 OVERLAY_IDLE_BOUNDS，实时 bounds 不能当锚点，所以用建 watch 时拍下、
- * 发布证据时按 key 登记的快照（见 dictionaryToastAnchors）。
+ * 被停到屏幕外的 OVERLAY_IDLE_BOUNDS，实时 bounds 不能当锚点，所以用粘贴前拍下、
+ * 请求到达时按序绑定的快照（见 pendingDictionaryToastAnchors）。
  *
  * 三个条件都满足才用它，否则退回鼠标所在屏的默认位置：
- * - 调用方是全局浮窗链路并带来了自己那条证据的 key（应用内听写不传）；
+ * - 调用方是全局浮窗链路并带来了自己那次会话的锚点（应用内听写不传）；
  * - 呈现代次没变——变了说明期间又开过浮窗，这条 toast 会盖在新浮窗上；
  * - 锚点中心仍落在某块现存屏幕上——否则外接屏拔掉后 toast 会整个落到屏幕外。
  */
-function resolveDictionaryToastAnchorBounds(anchorKey: string | null): Rectangle {
-  if (!anchorKey) return computeOverlayBounds(getCursorDisplay());
-  // 一次性消费：锚点只对它自己那条证据有效。
-  const anchor = dictionaryToastAnchors.get(anchorKey);
-  dictionaryToastAnchors.delete(anchorKey);
-  if (anchor
-    && anchor.presentationSeq === overlayPresentationSeq
+function resolveDictionaryToastAnchorBounds(anchor: DictionaryToastAnchor | null): Rectangle {
+  if (!anchor) return computeOverlayBounds(getCursorDisplay());
+  if (anchor.presentationSeq === overlayPresentationSeq
     && isBoundsCenterOnDisplay(anchor.bounds, getOverlayPlacementDisplays())) {
     return anchor.bounds;
   }
   log.debug('dictionary toast anchor dropped', {
-    hasAnchor: Boolean(anchor),
-    staleSession: Boolean(anchor && anchor.presentationSeq !== overlayPresentationSeq),
+    staleSession: anchor.presentationSeq !== overlayPresentationSeq,
   });
   return computeOverlayBounds(getCursorDisplay());
 }
@@ -1789,6 +1806,10 @@ function computeDictionaryToastBounds(overlayBounds: Rectangle): Rectangle {
 }
 
 async function pasteTextToFocusedTarget(text: string, rawTranscriptText?: string): Promise<void> {
+  // 词典 toast 锚点必须在这里、任何 await 之前拍：renderer 已经把浮窗收起并让粘贴
+  // 在后台跑，用户完全可以在 pasteTextToMacTarget() 返回前开下一次会话。等到建 watch
+  // 时再读 lastPresentedOverlayBounds / 呈现代次，拿到的就是新会话的现场了。
+  const toastAnchor = captureOverlayToastAnchor();
   const pasteTarget = await resolveOverlayPasteTarget();
   log.debug(PASTE_DEBUG_TAG, 'paste start', {
     chars: text.length,
@@ -1797,7 +1818,7 @@ async function pasteTextToFocusedTarget(text: string, rawTranscriptText?: string
   });
   if (process.platform === 'darwin') {
     await pasteTextToMacTarget(text, pasteTarget);
-    scheduleExternalDictionaryLearningWatch(text, rawTranscriptText, pasteTarget, overlayPasteContext);
+    scheduleExternalDictionaryLearningWatch(text, rawTranscriptText, pasteTarget, overlayPasteContext, toastAnchor);
     return;
   }
 
@@ -2032,7 +2053,12 @@ async function captureMacPasteTarget(
   if (process.platform !== 'darwin') return null;
   const onFocusedWindowFrame = options?.onFocusedWindowFrame;
   try {
-    const helperResult = await runMacTextInsertionHelper(['--command', 'capture-target'], {
+    // 只有真要用 frame 时才让 helper 去读它：AX 慢的目标 App 里 focusedWindow /
+    // position / size 三次请求各自可能吃满 200ms messaging timeout，而单屏下这个答案
+    // 根本改变不了落屏结果，白白推迟粘贴目标采集。
+    const args = ['--command', 'capture-target'];
+    if (onFocusedWindowFrame) args.push('--with-focused-frame');
+    const helperResult = await runMacTextInsertionHelper(args, {
       onProgress: onFocusedWindowFrame
         ? (event) => {
           if (event.event !== 'focused-window-frame') return;
@@ -2109,6 +2135,7 @@ function scheduleExternalDictionaryLearningWatch(
   rawTranscriptText: string | undefined,
   target: MacPasteTarget | null,
   context: MacPasteContext | null,
+  toastAnchor: DictionaryToastAnchor | null,
 ): void {
   if (process.platform !== 'darwin') return;
   cancelExternalDictionaryLearningWatch();
@@ -2141,9 +2168,7 @@ function scheduleExternalDictionaryLearningWatch(
     timers: [],
     completed: false,
     inspecting: false,
-    toastAnchor: lastPresentedOverlayBounds
-      ? { bounds: lastPresentedOverlayBounds, presentationSeq: overlayPresentationSeq }
-      : null,
+    toastAnchor,
   };
   externalDictionaryLearningWatch = watch;
   EXTERNAL_DICTIONARY_LEARNING_POLL_DELAYS_MS.forEach((delayMs) => {
@@ -2509,46 +2534,37 @@ function isSameMacPasteTarget(lhs: MacPasteTarget, rhs: MacPasteTarget): boolean
 
 function publishExternalDictionaryLearningEvidence(
   evidence: Pick<DictationDictionaryAdviceInput, 'source' | 'rawTranscriptText' | 'beforeText' | 'afterText' | 'context'>,
-  toastAnchor: ExternalDictionaryLearningWatch['toastAnchor'],
+  toastAnchor: DictionaryToastAnchor | null,
 ): void {
   const window = getOverlayWindow();
   if (!window || window.isDestroyed()) return;
-  // 锚点是建 watch 时拍的（那才是这条证据对应的浮窗现场），这里按证据 key 登记，
-  // 等这条证据的建议回来时凭同一个 key 取走。
-  //
-  // key 由 main 从证据内容派生，不放进 IPC payload：证据要经 renderer 往返，
-  // renderer 传回的几何值不可信，而 renderer 回传时只会往 context 里加语言字段、
-  // 不改 source / beforeText / afterText，所以 main 能在收到建议请求时重算出同一个
-  // key。真被改过就查不到锚点，退回默认位置，不会指向别的会话。
+  // 锚点是粘贴开始前拍的（那才是这条证据对应的浮窗现场），这里排进队列，等这条
+  // 证据的建议请求到达 main 时按到达顺序取走。几何值不进 IPC payload：证据要经
+  // renderer 往返，renderer 传回的坐标属于不可信输入。
   if (toastAnchor) {
-    registerDictionaryToastAnchor(voiceInputDictionaryToastAnchorKey(evidence), toastAnchor);
+    pendingDictionaryToastAnchors.push(toastAnchor);
+    while (pendingDictionaryToastAnchors.length > DICTIONARY_TOAST_ANCHOR_MAX_ENTRIES) {
+      pendingDictionaryToastAnchors.shift();
+    }
   }
   window.webContents.send('voice-input:dictionary-learning-evidence', { evidence });
 }
 
-/**
- * 词典 toast 锚点的证据 key。只取 renderer 往返途中不会改动的字段，并做摘要，
- * 避免把用户听写文本原样留在 Map 的 key 里（日志、堆快照都可能带出去）。
- */
-export function voiceInputDictionaryToastAnchorKey(
-  evidence: Pick<DictationDictionaryAdviceInput, 'source' | 'beforeText' | 'afterText'>,
-): string {
-  return createHash('sha256')
-    .update(`${evidence.source ?? ''} ${evidence.beforeText ?? ''} ${evidence.afterText ?? ''}`)
-    .digest('hex')
-    .slice(0, 32);
+/** 拍下「当前这次浮窗现场」，供之后给它的词典 toast 定位。 */
+function captureOverlayToastAnchor(): DictionaryToastAnchor | null {
+  if (!lastPresentedOverlayBounds) return null;
+  return { bounds: lastPresentedOverlayBounds, presentationSeq: overlayPresentationSeq };
 }
 
-function registerDictionaryToastAnchor(
-  key: string,
-  anchor: { bounds: Rectangle; presentationSeq: number },
-): void {
-  dictionaryToastAnchors.set(key, anchor);
-  while (dictionaryToastAnchors.size > DICTIONARY_TOAST_ANCHOR_MAX_ENTRIES) {
-    const oldest = dictionaryToastAnchors.keys().next();
-    if (oldest.done) break;
-    dictionaryToastAnchors.delete(oldest.value);
-  }
+/**
+ * 取走队首的浮窗 toast 锚点，绑定给「这一次」词典建议请求。
+ *
+ * 必须在建议请求刚到达、任何 await 之前调用：那时的到达顺序与证据发布顺序一致，
+ * 绑定之后无论哪个请求先返回都不会拿到别人的锚点，内容相同的两次修正也不会互相
+ * 覆盖。应用内听写不要调用它。
+ */
+export function takeOverlayDictionaryToastAnchor(): DictionaryToastAnchor | null {
+  return pendingDictionaryToastAnchors.shift() ?? null;
 }
 
 // Length-only summary for normal diagnostics. Full text debug is isolated in

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -1659,7 +1659,16 @@ function isCurrentOverlayPresentation(window: BrowserWindow, presentationSeq: nu
 
 function showPassiveOverlayWindow(window: BrowserWindow): void {
   if (window.isDestroyed()) return;
-  positionOverlayWindow(window);
+  // 被动呈现走的是「启动失败 / 粘贴失败后把浮窗重新亮出来」，属于同一次会话的延续，
+  // 必须留在它刚才所在的位置：这时重新按鼠标所在屏定位，会让错误提示从用户正在用的
+  // 那块屏跳到鼠标那块屏。浮窗 hide 后被停到屏幕外，所以用最近一次实际呈现的 bounds，
+  // 那块屏已经不存在时才退回默认定位。
+  const previousBounds = lastPresentedOverlayBounds;
+  if (previousBounds && isBoundsCenterOnDisplay(previousBounds, getOverlayPlacementDisplays())) {
+    window.setBounds(previousBounds);
+  } else {
+    positionOverlayWindow(window);
+  }
   registerOverlayCancelShortcut();
   window.setAlwaysOnTop(true, 'floating');
   window.setVisibleOnAllWorkspaces(true, {

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -37,6 +37,8 @@ import {
   type MacInputMonitoringPermissionSnapshot,
 } from './MacModifierShortcutListener.js';
 import {
+  computeOverlayPositionRatio,
+  isBoundsCenterOnDisplay,
   normalizeFocusedWindowFrame,
   resolveDraggedOverlayBounds,
   resolveOverlayInitialBounds,
@@ -239,8 +241,13 @@ let dictionaryToastCloseTimer: NodeJS.Timeout | null = null;
 // 避免 renderer screenX/screenY 在 Windows 缩放下的坐标系不一致问题。
 let overlayDragSession: { startBounds: Rectangle; startCursor: Point } | null = null;
 // 最近一次「浮窗真正呈现在哪」的 bounds。浮窗 hide 后会被停到屏幕外，实时
-// bounds 不能当锚点，词典 toast 靠这份记录跟到同一块屏、同一位置。
+// bounds 不能当锚点，全局浮窗路径的词典 toast 靠这份记录跟到同一块屏、同一位置。
 let lastPresentedOverlayBounds: Rectangle | null = null;
+// 浮窗呈现代次。焦点屏查询是异步的，它的回调必须能认出「这次呈现还算不算数」：
+// 会话被取消（hide / 复位到 idle）或已经开始了新一次呈现时，迟到的回调不得再
+// 定位或显示窗口——浮窗是缓存复用的，hide 并不销毁它，只靠 isDestroyed() 判断
+// 会让已取消的浮窗重新出现。
+let overlayPresentationSeq = 0;
 
 type ExternalDictionaryLearningWatch = {
   id: string;
@@ -263,6 +270,12 @@ type ExternalDictionaryLearningWatch = {
 export type DictionaryToastEntryPayload = {
   entryId: string;
   term: string;
+};
+
+type DictionaryToastPayload = {
+  entries: DictionaryToastEntryPayload[];
+  /** true = 该 toast 来自全局浮窗听写，可以贴着刚才的浮窗位置出现。 */
+  anchorToOverlay: boolean;
 };
 
 const EXTERNAL_DICTIONARY_LEARNING_POLL_DELAYS_MS = [2500, 6500, 14000];
@@ -586,6 +599,9 @@ export function registerGlobalVoiceInputIpc(): void {
       x: bounds.x,
       y: bounds.y,
       displayId: display?.id,
+      // 同时存屏内相对比例：显示器重排后绝对坐标会失效，比例仍能还原用户
+      // 当时把浮窗放在这块屏的哪个位置。
+      ...(display ? computeOverlayPositionRatio(bounds, display.workArea) : {}),
       updatedAt: Date.now(),
     });
     log.debug('global overlay drag position saved', { x: bounds.x, y: bounds.y });
@@ -675,7 +691,8 @@ export function registerGlobalVoiceInputIpc(): void {
     (_event, payload: unknown): { ok: true } | { ok: false; error: string } => {
       const entries = normalizeDictionaryToastEntries(payload);
       if (entries.length === 0) return { ok: false, error: 'Dictionary toast payload is incomplete.' };
-      showDictionaryToastWindow({ entries });
+      // Renderer 侧（应用内听写）触发的 toast 与全局浮窗位置无关。
+      showDictionaryToastWindow({ entries, anchorToOverlay: false });
       return { ok: true };
     },
   );
@@ -1136,6 +1153,8 @@ function destroyOverlayWindow(): void {
   overlayWindow = null;
   overlayLoaded = false;
   overlayPresentationActive = false;
+  // 同 setOverlayIdlePresentationState：作废本次呈现，pending 的异步定位回调失效。
+  overlayPresentationSeq += 1;
   pendingOverlayStart = null;
   pendingModifierOverlaySubmit = false;
   pendingModifierOverlaySuppressNextTap = false;
@@ -1153,6 +1172,8 @@ function destroyOverlayWindow(): void {
 function setOverlayIdlePresentationState(window: BrowserWindow): void {
   if (window.isDestroyed()) return;
   overlayPresentationActive = false;
+  // 作废本次呈现：pending 的焦点屏回调据此放弃定位与显示。
+  overlayPresentationSeq += 1;
   // `show: false` at BrowserWindow construction is not enough on macOS: a
   // prewarmed native window can still be unhidden when the app is activated by
   // a normal menu shortcut such as Cmd+,. Park the warm cache outside visible
@@ -1358,7 +1379,7 @@ function normalizeDictionaryToastEntries(payload: unknown): DictionaryToastEntry
     .slice(0, DICTIONARY_TOAST_MAX_ENTRIES);
 }
 
-function showDictionaryToastWindow(payload: { entries: DictionaryToastEntryPayload[] }): void {
+function showDictionaryToastWindow(payload: DictionaryToastPayload): void {
   closeDictionaryToastWindow();
   const window = createDictionaryToastWindow(payload);
   dictionaryToastWindow = window;
@@ -1367,13 +1388,25 @@ function showDictionaryToastWindow(payload: { entries: DictionaryToastEntryPaylo
   }, DICTIONARY_TOAST_DURATION_MS);
 }
 
-export function showVoiceInputDictionaryToast(entries: DictionaryToastEntryPayload[]): void {
+/**
+ * `anchorToOverlay` 只应由全局浮窗那条听写链路传 true。应用内听写的 toast 不能
+ * 借用浮窗位置：用户可能在另一块屏的 Cindy 窗口里操作，甚至浮窗那块屏早已拔掉。
+ */
+export function showVoiceInputDictionaryToast(
+  entries: DictionaryToastEntryPayload[],
+  options?: { anchorToOverlay?: boolean },
+): void {
   if (entries.length === 0) return;
-  showDictionaryToastWindow({ entries });
+  showDictionaryToastWindow({
+    entries,
+    anchorToOverlay: Boolean(options?.anchorToOverlay),
+  });
 }
 
-function createDictionaryToastWindow(payload: { entries: DictionaryToastEntryPayload[] }): BrowserWindow {
-  const bounds = computeDictionaryToastBounds(resolveDictionaryToastAnchorBounds());
+function createDictionaryToastWindow(payload: DictionaryToastPayload): BrowserWindow {
+  const bounds = computeDictionaryToastBounds(
+    resolveDictionaryToastAnchorBounds(payload.anchorToOverlay),
+  );
   const window = new BrowserWindow({
     ...bounds,
     frame: false,
@@ -1443,6 +1476,7 @@ function createDictionaryToastWindow(payload: { entries: DictionaryToastEntryPay
 function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: number): void {
   if (window.isDestroyed()) return;
 
+  const presentationSeq = ++overlayPresentationSeq;
   // 焦点屏查询要最先发起：它是个子进程，能和下面的建窗、定位、麦克风启动并行。
   const focusedDisplayQuery = startFocusedDisplayQuery();
   positionOverlayWindow(window);
@@ -1511,10 +1545,22 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   // 多屏：先等一小会儿焦点屏答案，拿到就在显示前重新定位。窗口此刻还没可见，
   // 所以重定位不会被看成跳动；超时则维持鼠标所在屏的定位直接显示。
   void awaitFocusedDisplay(focusedDisplayQuery).then((focusedDisplay) => {
-    if (window.isDestroyed()) return;
+    if (!isCurrentOverlayPresentation(window, presentationSeq)) {
+      // 等待期间用户取消了浮窗、或者已经开始了新一次呈现：这次的答案作废。
+      log.debug('focused display result dropped: overlay presentation no longer current');
+      return;
+    }
     if (focusedDisplay) positionOverlayWindow(window, focusedDisplay);
     show();
   });
+}
+
+/** 判断一次异步定位结果是否还属于「当前这次浮窗呈现」。 */
+function isCurrentOverlayPresentation(window: BrowserWindow, presentationSeq: number): boolean {
+  return overlayPresentationSeq === presentationSeq
+    && overlayPresentationActive
+    && overlayWindow === window
+    && !window.isDestroyed();
 }
 
 function showPassiveOverlayWindow(window: BrowserWindow): void {
@@ -1641,12 +1687,19 @@ function computeOverlayBounds(display: Display): Rectangle {
 }
 
 /**
- * 词典 toast 贴着「刚才浮窗所在的位置」出现。浮窗 hide 后会被停到屏幕外的
- * OVERLAY_IDLE_BOUNDS，它的实时 bounds 不能当锚点，所以记住最近一次定位结果；
- * 本次启动还没开过浮窗时退回鼠标所在屏的默认位置。
+ * 全局浮窗听写的词典 toast 贴着「刚才浮窗所在的位置」出现。浮窗 hide 后会被停到
+ * 屏幕外的 OVERLAY_IDLE_BOUNDS，实时 bounds 不能当锚点，所以用最近一次定位结果。
+ *
+ * 这份缓存是进程级的，可能早于当前显示器拓扑：复用前必须确认它的中心还落在某块
+ * 现存屏幕上（否则外接屏拔掉后 toast 会整个落到屏幕外）。不满足条件、或调用方
+ * 不是全局浮窗链路时，一律退回鼠标所在屏的默认位置。
  */
-function resolveDictionaryToastAnchorBounds(): Rectangle {
-  return lastPresentedOverlayBounds ?? computeOverlayBounds(getCursorDisplay());
+function resolveDictionaryToastAnchorBounds(anchorToOverlay: boolean): Rectangle {
+  if (anchorToOverlay && lastPresentedOverlayBounds
+    && isBoundsCenterOnDisplay(lastPresentedOverlayBounds, getOverlayPlacementDisplays())) {
+    return lastPresentedOverlayBounds;
+  }
+  return computeOverlayBounds(getCursorDisplay());
 }
 
 function computeDictionaryToastBounds(overlayBounds: Rectangle): Rectangle {

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -37,6 +37,7 @@ import {
   type MacInputMonitoringPermissionSnapshot,
 } from './MacModifierShortcutListener.js';
 import {
+  normalizeFocusedWindowFrame,
   resolveDraggedOverlayBounds,
   resolveOverlayInitialBounds,
   type OverlayPlacementDisplay,
@@ -151,6 +152,9 @@ type MacTextInsertionHelperResult = {
   afterNumberOfCharacters?: number;
   enhancedAxAttempted?: boolean;
   enhancedAxHelped?: boolean;
+  /** focused-window-frame 命令：前台窗口 frame（DIP 屏幕坐标）。 */
+  frame?: unknown;
+  frameSource?: string;
 };
 
 const OVERLAY_QUERY = 'view=voice-input-overlay';
@@ -167,6 +171,9 @@ const OVERLAY_EDGE_PADDING = 24;
 // 拖动时卡片中心距 workArea 水平中线小于该值即吸附到水平居中（灵动岛式，
 // 第一版只做 X 轴中线吸附，不做四边吸附）。
 const OVERLAY_SNAP_THRESHOLD_X = 48;
+// 多屏下等待「前台窗口在哪块屏」的上限。超时就用鼠标所在屏，宁可判定退化
+// 也不让浮窗出现明显延迟；答案迟到时不再挪窗，避免可见的跨屏跳动。
+const OVERLAY_FOCUSED_DISPLAY_DEADLINE_MS = 90;
 const DICTIONARY_TOAST_QUERY = 'view=voice-input-dictionary-toast';
 const DICTIONARY_TOAST_CARD_WIDTH = 360;
 const DICTIONARY_TOAST_CARD_ESTIMATED_HEIGHT = 68;
@@ -191,6 +198,9 @@ const OVERLAY_IDLE_BOUNDS: Rectangle = {
 const MAC_CORE_EDITING_SHORTCUTS = new Set(['KeyA', 'KeyC', 'KeyV', 'KeyX', 'KeyZ', 'Comma']);
 const DEFAULT_COMMAND_TIMEOUT_MS = 2500;
 const MAC_TEXT_INSERTION_HELPER_PASTE_TIMEOUT_MS = 5000;
+// focused-window-frame 只读两个 AX 属性，比 DEFAULT_COMMAND_TIMEOUT_MS 短得多：
+// 它的答案过了显示截止时间就没用了，没必要让子进程继续挂着。
+const MAC_FOCUSED_WINDOW_FRAME_TIMEOUT_MS = 800;
 const CLIPBOARD_RESTORE_DELAY_MS = 600;
 const OVERLAY_CANCEL_ACCELERATOR = 'Escape';
 const PASTE_DEBUG_TAG = '[global-paste-debug]';
@@ -228,6 +238,9 @@ let dictionaryToastCloseTimer: NodeJS.Timeout | null = null;
 // 坐标一律由 main 从 screen.getCursorScreenPoint() 读取（DIP 坐标系），
 // 避免 renderer screenX/screenY 在 Windows 缩放下的坐标系不一致问题。
 let overlayDragSession: { startBounds: Rectangle; startCursor: Point } | null = null;
+// 最近一次「浮窗真正呈现在哪」的 bounds。浮窗 hide 后会被停到屏幕外，实时
+// bounds 不能当锚点，词典 toast 靠这份记录跟到同一块屏、同一位置。
+let lastPresentedOverlayBounds: Rectangle | null = null;
 
 type ExternalDictionaryLearningWatch = {
   id: string;
@@ -568,6 +581,7 @@ export function registerGlobalVoiceInputIpc(): void {
     // 走 positionOverlayWindow 的记忆优先路径。
     const bounds = window.getBounds();
     const display = screen.getDisplayMatching(bounds);
+    lastPresentedOverlayBounds = bounds;
     voiceInputOverlayPositionStore.save({
       x: bounds.x,
       y: bounds.y,
@@ -582,9 +596,12 @@ export function registerGlobalVoiceInputIpc(): void {
     if (window && event.sender === window.webContents) {
       overlayDragSession = null;
       voiceInputOverlayPositionStore.clear();
-      const cursorPoint = screen.getCursorScreenPoint();
-      const display = screen.getDisplayNearestPoint(cursorPoint);
-      window.setBounds(computeOverlayBounds(display));
+      // 复位到「浮窗当前所在这块屏」的默认位置：双击复位时浮窗已经在用户眼前，
+      // 不该因为鼠标所在屏判定跑到另一块屏上去。
+      const display = screen.getDisplayMatching(window.getBounds());
+      const bounds = computeOverlayBounds(display);
+      lastPresentedOverlayBounds = bounds;
+      window.setBounds(bounds);
       log.debug('global overlay position reset to default');
     }
     return { ok: true };
@@ -1214,9 +1231,8 @@ async function showOverlayWindow(shortcutInvokedAt = Date.now()): Promise<void> 
 }
 
 function createOverlayWindow(shortcutInvokedAt: number): BrowserWindow {
-  const cursorPoint = screen.getCursorScreenPoint();
-  const display = screen.getDisplayNearestPoint(cursorPoint);
-  const bounds = computeOverlayBounds(display);
+  // 建窗时的 bounds 只是占位：真正的定位在 positionOverlayWindow 里按焦点屏做。
+  const bounds = computeOverlayBounds(getCursorDisplay());
   // The global voice overlay behaves like an input-method candidate panel:
   // visible above other apps, not part of normal app switching, and not allowed
   // to take over the text field that will receive the paste.
@@ -1357,9 +1373,7 @@ export function showVoiceInputDictionaryToast(entries: DictionaryToastEntryPaylo
 }
 
 function createDictionaryToastWindow(payload: { entries: DictionaryToastEntryPayload[] }): BrowserWindow {
-  const cursorPoint = screen.getCursorScreenPoint();
-  const display = screen.getDisplayNearestPoint(cursorPoint);
-  const bounds = computeDictionaryToastBounds(display);
+  const bounds = computeDictionaryToastBounds(resolveDictionaryToastAnchorBounds());
   const window = new BrowserWindow({
     ...bounds,
     frame: false,
@@ -1429,6 +1443,8 @@ function createDictionaryToastWindow(payload: { entries: DictionaryToastEntryPay
 function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: number): void {
   if (window.isDestroyed()) return;
 
+  // 焦点屏查询要最先发起：它是个子进程，能和下面的建窗、定位、麦克风启动并行。
+  const focusedDisplayQuery = startFocusedDisplayQuery();
   positionOverlayWindow(window);
   prepareOverlayForDisplay(window);
 
@@ -1477,7 +1493,7 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
       }
     });
   }
-  setImmediate(() => {
+  const show = (): void => {
     if (window.isDestroyed()) return;
     log.debug('global overlay ready to show', {
       elapsedSinceShortcutMs: Date.now() - shortcutInvokedAt,
@@ -1487,6 +1503,17 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
     // combinations can still perturb app-level presence. Restore immediately
     // after showing without focusing the main app.
     scheduleMainAppPresenceRestore('global-voice-overlay-shown');
+  };
+  if (!focusedDisplayQuery) {
+    setImmediate(show);
+    return;
+  }
+  // 多屏：先等一小会儿焦点屏答案，拿到就在显示前重新定位。窗口此刻还没可见，
+  // 所以重定位不会被看成跳动；超时则维持鼠标所在屏的定位直接显示。
+  void awaitFocusedDisplay(focusedDisplayQuery).then((focusedDisplay) => {
+    if (window.isDestroyed()) return;
+    if (focusedDisplay) positionOverlayWindow(window, focusedDisplay);
+    show();
   });
 }
 
@@ -1504,19 +1531,93 @@ function showPassiveOverlayWindow(window: BrowserWindow): void {
   scheduleMainAppPresenceRestore('global-voice-overlay-passive-shown');
 }
 
-function positionOverlayWindow(window: BrowserWindow): void {
-  const cursorPoint = screen.getCursorScreenPoint();
-  const display = screen.getDisplayNearestPoint(cursorPoint);
-  // 记忆优先：用户拖动过就用保存位置（clamp 进现存屏幕可见区域），保存
-  // 位置所在屏幕已不存在或从未拖动过则回退鼠标所在屏幕的默认位置。
-  window.setBounds(resolveOverlayInitialBounds({
+/**
+ * 把浮窗定位到焦点屏。`display` 省略时退回鼠标所在屏。
+ *
+ * 屏内位置沿用「记忆优先」：用户拖动过就用保存位置（clamp 进可见区域），
+ * 保存位置在别的屏上时按相对比例迁移过来，从未拖动过则用该屏默认位置。
+ */
+function positionOverlayWindow(window: BrowserWindow, display = getCursorDisplay()): void {
+  const displays = getOverlayPlacementDisplays();
+  const bounds = resolveOverlayInitialBounds({
     savedPosition: voiceInputOverlayPositionStore.read(),
-    displays: getOverlayPlacementDisplays(),
+    displays,
+    activeDisplay: displays.find((candidate) => candidate.id === display.id) ?? null,
     size: { width: OVERLAY_WIDTH, height: OVERLAY_HEIGHT },
     contentInset: OVERLAY_SHADOW_PADDING,
     edgePadding: OVERLAY_EDGE_PADDING,
     fallbackBounds: computeOverlayBounds(display),
-  }));
+  });
+  lastPresentedOverlayBounds = bounds;
+  window.setBounds(bounds);
+}
+
+function getCursorDisplay(): Display {
+  return screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+}
+
+/**
+ * 发起「前台窗口在哪块屏」查询，返回 null 表示不查、直接用鼠标所在屏：
+ * - 只有一块屏时答案唯一，不值得多开一个进程、也不该为它推迟浮窗显示。
+ * - 非 macOS 平台没有可用的低成本前台窗口查询（Electron 只能看自己的窗口），
+ *   Windows 一律按鼠标所在屏判定。
+ *
+ * 注意鼠标所在屏和键盘焦点所在屏可以不同：鼠标停在 A 屏、正在 B 屏的编辑器里
+ * 打字时，粘贴目标在 B 屏，浮窗也应该开在 B 屏，所以这里优先问前台窗口。
+ */
+function startFocusedDisplayQuery(): Promise<Display | null> | null {
+  if (process.platform !== 'darwin') return null;
+  if (screen.getAllDisplays().length <= 1) return null;
+  const startedAt = Date.now();
+  return queryMacFocusedWindowFrame()
+    .then((frame) => {
+      if (!frame) return null;
+      // getDisplayMatching 按重叠面积选屏，跨屏摆放的窗口也能落到主要那块。
+      const display = screen.getDisplayMatching(frame);
+      log.debug('focused display resolved', {
+        elapsedMs: Date.now() - startedAt,
+        displayId: display?.id,
+      });
+      return display ?? null;
+    })
+    .catch((error) => {
+      log.debug('focused display query failed, falling back to cursor display', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    });
+}
+
+/** 给焦点屏查询加显示截止时间：迟到的答案直接丢弃，不再挪已经可见的浮窗。 */
+function awaitFocusedDisplay(query: Promise<Display | null>): Promise<Display | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (display: Display | null): void => {
+      if (settled) return;
+      settled = true;
+      resolve(display);
+    };
+    const timer = setTimeout(() => {
+      log.debug('focused display query deadline exceeded', {
+        deadlineMs: OVERLAY_FOCUSED_DISPLAY_DEADLINE_MS,
+      });
+      settle(null);
+    }, OVERLAY_FOCUSED_DISPLAY_DEADLINE_MS);
+    void query
+      .catch(() => null)
+      .then((display) => {
+        clearTimeout(timer);
+        settle(display);
+      });
+  });
+}
+
+async function queryMacFocusedWindowFrame(): Promise<Rectangle | null> {
+  const result = await runMacTextInsertionHelper(['--command', 'focused-window-frame'], {
+    timeoutMs: MAC_FOCUSED_WINDOW_FRAME_TIMEOUT_MS,
+  });
+  if (!result.ok) return null;
+  return normalizeFocusedWindowFrame(result.frame);
 }
 
 function getOverlayPlacementDisplays(): OverlayPlacementDisplay[] {
@@ -1539,8 +1640,16 @@ function computeOverlayBounds(display: Display): Rectangle {
   return { x, y, width: OVERLAY_WIDTH, height: OVERLAY_HEIGHT };
 }
 
-function computeDictionaryToastBounds(display: Display): Rectangle {
-  const overlayBounds = computeOverlayBounds(display);
+/**
+ * 词典 toast 贴着「刚才浮窗所在的位置」出现。浮窗 hide 后会被停到屏幕外的
+ * OVERLAY_IDLE_BOUNDS，它的实时 bounds 不能当锚点，所以记住最近一次定位结果；
+ * 本次启动还没开过浮窗时退回鼠标所在屏的默认位置。
+ */
+function resolveDictionaryToastAnchorBounds(): Rectangle {
+  return lastPresentedOverlayBounds ?? computeOverlayBounds(getCursorDisplay());
+}
+
+function computeDictionaryToastBounds(overlayBounds: Rectangle): Rectangle {
   return {
     x: Math.round(overlayBounds.x + (overlayBounds.width - DICTIONARY_TOAST_WIDTH) / 2),
     y: Math.round(overlayBounds.y + (overlayBounds.height - DICTIONARY_TOAST_HEIGHT) / 2),

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -200,9 +200,6 @@ const OVERLAY_IDLE_BOUNDS: Rectangle = {
 const MAC_CORE_EDITING_SHORTCUTS = new Set(['KeyA', 'KeyC', 'KeyV', 'KeyX', 'KeyZ', 'Comma']);
 const DEFAULT_COMMAND_TIMEOUT_MS = 2500;
 const MAC_TEXT_INSERTION_HELPER_PASTE_TIMEOUT_MS = 5000;
-// focused-window-frame 只读两个 AX 属性，比 DEFAULT_COMMAND_TIMEOUT_MS 短得多：
-// 它的答案过了显示截止时间就没用了，没必要让子进程继续挂着。
-const MAC_FOCUSED_WINDOW_FRAME_TIMEOUT_MS = 800;
 const CLIPBOARD_RESTORE_DELAY_MS = 600;
 const OVERLAY_CANCEL_ACCELERATOR = 'Escape';
 const PASTE_DEBUG_TAG = '[global-paste-debug]';
@@ -248,6 +245,10 @@ let lastPresentedOverlayBounds: Rectangle | null = null;
 // 定位或显示窗口——浮窗是缓存复用的，hide 并不销毁它，只靠 isDestroyed() 判断
 // 会让已取消的浮窗重新出现。
 let overlayPresentationSeq = 0;
+// 多屏下浮窗会先等最多 90ms 的焦点屏答案再显示。这段窗口里呈现已经开始（麦克风
+// 在录）但窗口还不可见，所以「浮窗是否已打开」不能只看 isVisible()：否则等待期
+// 内再按一次快捷键不会走提交分支，而是又开一次呈现，用户那一下就丢了。
+let overlayPresentationAwaitingShow = false;
 
 type ExternalDictionaryLearningWatch = {
   id: string;
@@ -327,7 +328,17 @@ export function prewarmGlobalVoiceInputOverlay(): void {
 }
 
 export function isGlobalVoiceInputOverlayVisible(): boolean {
-  return Boolean(overlayPresentationActive && getOverlayWindow()?.isVisible());
+  return isOverlayPresentationOpen(getOverlayWindow());
+}
+
+/**
+ * 一次浮窗呈现是否处于「已打开」状态：呈现生效，且窗口已可见或正等着显示。
+ * 快捷键的提交分支、Dock 激活让位判断都必须用这个，而不是裸 isVisible()。
+ */
+function isOverlayPresentationOpen(overlay: BrowserWindow | null): boolean {
+  if (!overlay || overlay.isDestroyed()) return false;
+  if (!overlayPresentationActive) return false;
+  return overlay.isVisible() || overlayPresentationAwaitingShow;
 }
 
 /**
@@ -871,13 +882,14 @@ function stableVoiceInputShortcutKey(shortcut: VoiceInputShortcut): string {
 function handleGlobalVoiceInputShortcut(phase?: Extract<GlobalVoiceInputShortcutPhase, 'start'>): void {
   const invokedAt = Date.now();
   const overlay = getOverlayWindow();
-  const overlayOpen = Boolean(overlay && overlayPresentationActive && overlay.isVisible());
+  const overlayOpen = isOverlayPresentationOpen(overlay);
   log.debug('global shortcut invoked', {
     overlayOpen,
     overlayVisible: Boolean(overlay?.isVisible()),
+    overlayAwaitingShow: overlayPresentationAwaitingShow,
     appFocused: Boolean(BrowserWindow.getFocusedWindow()),
   });
-  if (overlay && overlayPresentationActive && overlay.isVisible()) {
+  if (overlay && overlayOpen) {
     if (phase === 'start') {
       pendingModifierOverlaySuppressNextTap = false;
       pendingModifierOverlaySuppressNextRelease = true;
@@ -925,7 +937,7 @@ function handleGlobalVoiceInputShortcutTap(): void {
   }
   if (sendShortcutToActiveInlineVoiceInput('tap')) return;
   const overlay = getOverlayWindow();
-  if (overlay && overlayPresentationActive && overlay.isVisible()) {
+  if (overlay && isOverlayPresentationOpen(overlay)) {
     overlay.webContents.send('voice-input:global-overlay-command', { type: 'submit' });
     return;
   }
@@ -1155,6 +1167,7 @@ function destroyOverlayWindow(): void {
   overlayPresentationActive = false;
   // 同 setOverlayIdlePresentationState：作废本次呈现，pending 的异步定位回调失效。
   overlayPresentationSeq += 1;
+  overlayPresentationAwaitingShow = false;
   pendingOverlayStart = null;
   pendingModifierOverlaySubmit = false;
   pendingModifierOverlaySuppressNextTap = false;
@@ -1174,6 +1187,7 @@ function setOverlayIdlePresentationState(window: BrowserWindow): void {
   overlayPresentationActive = false;
   // 作废本次呈现：pending 的焦点屏回调据此放弃定位与显示。
   overlayPresentationSeq += 1;
+  overlayPresentationAwaitingShow = false;
   // `show: false` at BrowserWindow construction is not enough on macOS: a
   // prewarmed native window can still be unhidden when the app is activated by
   // a normal menu shortcut such as Cmd+,. Park the warm cache outside visible
@@ -1234,7 +1248,10 @@ function unregisterOverlayCancelShortcut(): void {
 
 async function showOverlayWindow(shortcutInvokedAt = Date.now()): Promise<void> {
   const existing = getOverlayWindow();
-  if (existing?.isVisible()) {
+  // 第一个条件是原有行为（窗口已可见就提交）；第二个补上「呈现已开始、正等着
+  // 显示」这段窗口，否则等待期内的第二次按键会再开一次呈现，renderer 收到重复
+  // start 会忽略，用户那一下等于丢了。
+  if (existing && (existing.isVisible() || isOverlayPresentationOpen(existing))) {
     existing.webContents.send('voice-input:global-overlay-command', { type: 'submit' });
     return;
   }
@@ -1477,16 +1494,17 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   if (window.isDestroyed()) return;
 
   const presentationSeq = ++overlayPresentationSeq;
-  // 焦点屏查询要最先发起：它是个子进程，能和下面的建窗、定位、麦克风启动并行。
-  const focusedDisplayQuery = startFocusedDisplayQuery();
-  positionOverlayWindow(window);
-  prepareOverlayForDisplay(window);
-
   // Startup ordering is intentional:
-  // 1. Capture the paste target before showing the overlay.
+  // 1. Capture the paste target before showing the overlay. 这一次调用同时带回
+  //    前台窗口 frame，焦点屏由它派生——和 target 同一次 frontmostApplication
+  //    读取，不会出现「浮窗开在 A 屏、粘贴却进了 B 屏的 App」。
   // 2. Tell the renderer to start microphone capture as soon as it is ready.
   // 3. Show the overlay on the next tick so UI display no longer gates mic start.
   const captureOverlayPromise = captureMacPasteTarget();
+  const focusedDisplayQuery = startFocusedDisplayQuery(captureOverlayPromise);
+  positionOverlayWindow(window);
+  prepareOverlayForDisplay(window);
+
   overlayPasteTarget = null;
   overlayPasteContext = null;
   overlayPasteTargetPromise = captureOverlayPromise.then((captured) => captured?.target ?? null);
@@ -1532,6 +1550,7 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
     log.debug('global overlay ready to show', {
       elapsedSinceShortcutMs: Date.now() - shortcutInvokedAt,
     });
+    overlayPresentationAwaitingShow = false;
     window.showInactive();
     // showInactive preserves the user's focused app, but some Electron/macOS
     // combinations can still perturb app-level presence. Restore immediately
@@ -1544,6 +1563,8 @@ function startLoadedOverlaySession(window: BrowserWindow, shortcutInvokedAt: num
   }
   // 多屏：先等一小会儿焦点屏答案，拿到就在显示前重新定位。窗口此刻还没可见，
   // 所以重定位不会被看成跳动；超时则维持鼠标所在屏的定位直接显示。
+  // 这段等待期里呈现已经算「打开」（麦克风在录），见 overlayPresentationAwaitingShow。
+  overlayPresentationAwaitingShow = true;
   void awaitFocusedDisplay(focusedDisplayQuery).then((focusedDisplay) => {
     if (!isCurrentOverlayPresentation(window, presentationSeq)) {
       // 等待期间用户取消了浮窗、或者已经开始了新一次呈现：这次的答案作废。
@@ -1603,26 +1624,29 @@ function getCursorDisplay(): Display {
 }
 
 /**
- * 发起「前台窗口在哪块屏」查询，返回 null 表示不查、直接用鼠标所在屏：
- * - 只有一块屏时答案唯一，不值得多开一个进程、也不该为它推迟浮窗显示。
+ * 从粘贴目标快照里派生「前台窗口在哪块屏」，返回 null 表示不查、直接用鼠标所在屏：
+ * - 只有一块屏时答案唯一，不该为它推迟浮窗显示。
  * - 非 macOS 平台没有可用的低成本前台窗口查询（Electron 只能看自己的窗口），
  *   Windows 一律按鼠标所在屏判定。
  *
  * 注意鼠标所在屏和键盘焦点所在屏可以不同：鼠标停在 A 屏、正在 B 屏的编辑器里
- * 打字时，粘贴目标在 B 屏，浮窗也应该开在 B 屏，所以这里优先问前台窗口。
+ * 打字时，粘贴目标在 B 屏，浮窗也应该开在 B 屏，所以这里优先认前台窗口。
  */
-function startFocusedDisplayQuery(): Promise<Display | null> | null {
+function startFocusedDisplayQuery(
+  captureOverlayPromise: Promise<CapturedOverlayTarget | null>,
+): Promise<Display | null> | null {
   if (process.platform !== 'darwin') return null;
   if (screen.getAllDisplays().length <= 1) return null;
   const startedAt = Date.now();
-  return queryMacFocusedWindowFrame()
-    .then((frame) => {
-      if (!frame) return null;
+  return captureOverlayPromise
+    .then((captured) => {
+      if (!captured?.frame) return null;
       // getDisplayMatching 按重叠面积选屏，跨屏摆放的窗口也能落到主要那块。
-      const display = screen.getDisplayMatching(frame);
+      const display = screen.getDisplayMatching(captured.frame);
       log.debug('focused display resolved', {
         elapsedMs: Date.now() - startedAt,
         displayId: display?.id,
+        target: describePasteTarget(captured.target),
       });
       return display ?? null;
     })
@@ -1656,14 +1680,6 @@ function awaitFocusedDisplay(query: Promise<Display | null>): Promise<Display | 
         settle(display);
       });
   });
-}
-
-async function queryMacFocusedWindowFrame(): Promise<Rectangle | null> {
-  const result = await runMacTextInsertionHelper(['--command', 'focused-window-frame'], {
-    timeoutMs: MAC_FOCUSED_WINDOW_FRAME_TIMEOUT_MS,
-  });
-  if (!result.ok) return null;
-  return normalizeFocusedWindowFrame(result.frame);
 }
 
 function getOverlayPlacementDisplays(): OverlayPlacementDisplay[] {
@@ -1936,6 +1952,12 @@ function scheduleClipboardRestore(snapshot: ClipboardSnapshot | null, expectedTe
 type CapturedOverlayTarget = {
   target: MacPasteTarget;
   context: MacPasteContext | null;
+  /**
+   * 前台窗口 frame（DIP 屏幕坐标），来自与 target 同一次 helper 调用、同一次
+   * frontmostApplication 读取，所以「浮窗开在哪块屏」与「粘贴进哪个 App」不会
+   * 各自认到不同的前台 App。osascript 兜底路径拿不到 frame。
+   */
+  frame: Rectangle | null;
 };
 
 async function captureMacPasteTarget(): Promise<CapturedOverlayTarget | null> {
@@ -1943,15 +1965,19 @@ async function captureMacPasteTarget(): Promise<CapturedOverlayTarget | null> {
   try {
     const helperResult = await runMacTextInsertionHelper(['--command', 'capture-target']);
     if (helperResult.ok && helperResult.target?.processName) {
+      const frame = normalizeFocusedWindowFrame(helperResult.frame);
       log.debug(PASTE_DEBUG_TAG, 'capture target result (native)', {
         target: describePasteTarget(helperResult.target),
         context: summarizePasteContext(helperResult.context),
         enhancedAxAttempted: Boolean(helperResult.enhancedAxAttempted),
         enhancedAxHelped: Boolean(helperResult.enhancedAxHelped),
+        hasFocusedWindowFrame: Boolean(frame),
+        frameSource: helperResult.frameSource,
       });
       return {
         target: helperResult.target,
         context: helperResult.context ?? null,
+        frame,
       };
     }
   } catch (error) {
@@ -1993,6 +2019,8 @@ async function captureMacPasteTarget(): Promise<CapturedOverlayTarget | null> {
     return {
       target: { processName, bundleId: bundleId ?? '', pid },
       context: null,
+      // osascript 只报前台 App，不报窗口几何：焦点屏退回鼠标所在屏。
+      frame: null,
     };
   } catch (error) {
     log.warn('capture paste target failed', { error: stringifyError(error) });
@@ -2357,6 +2385,8 @@ async function captureMacPasteTargetForLearning(
     return {
       target: helperResult.target,
       context: helperResult.context,
+      // 词典学习只关心文本上下文，不需要窗口几何（浮窗此时早已关掉）。
+      frame: null,
     };
   } catch (error) {
     log.debug('external dictionary learning capture failed', {

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -2755,11 +2755,17 @@ function spawnHelperWithProgressPromise(
       });
     }, timeoutMs);
 
+    // setEncoding 必须在这里显式设：否则每个 Buffer 各自 toString()，一个跨 chunk
+    // 边界被切开的多字节 UTF-8 字符会两边各变成替换字符。AX 上下文里全是中文这类
+    // 非 ASCII 文本，而最终 JSON 仍能解析成功，损坏会静默流进 refine 与词典学习。
+    // 设了编码后由流内部的 StringDecoder 跨 chunk 保留半个字符。
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
     // 每收到一个完整换行就尝试解析：带 event 字段的是进度事件，最后一行结果不在
     // 这里派发（由调用方从完整 stdout 取）。解析失败的行直接忽略——stdout 可能
     // 含用户输入框文本，不进日志。
-    child.stdout.on('data', (chunk: Buffer) => {
-      const text = chunk.toString();
+    child.stdout.on('data', (text: string) => {
       stdout += text;
       pending += text;
       const lines = pending.split('\n');
@@ -2775,8 +2781,8 @@ function spawnHelperWithProgressPromise(
         }
       }
     });
-    child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString();
+    child.stderr.on('data', (text: string) => {
+      stderr += text;
     });
     child.on('error', (error) => {
       settle(() => reject(new PasteCommandError(

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -80,8 +80,8 @@ import {
   refreshVoiceInputInputMonitoringPermissionSnapshot,
   registerActiveInlineVoiceInputWebContents,
   showVoiceInputDictionaryToast,
+  takeOverlayDictionaryToastAnchor,
   unregisterActiveInlineVoiceInputWebContents,
-  voiceInputDictionaryToastAnchorKey,
 } from './global.js';
 import {
   registerVoiceInputDataStoreIpc,
@@ -314,6 +314,12 @@ export async function adviseAndRecordVoiceInputDictionaryLearning(
   }
 
   const sourceLabel = options.sourceLabel ?? payload.source ?? 'in_app';
+  // 锚点必须在任何 await 之前取：请求到达 main 的顺序与浮窗发布证据的顺序一致，
+  // 在这里绑定就等于「这次请求认自己那次会话的浮窗现场」；等 advisor 返回后再取，
+  // 并发请求会互相抢到别人的锚点。跳过分支也要取走，否则它会留给下一次请求。
+  const toastAnchor = sourceLabel === 'external_overlay'
+    ? takeOverlayDictionaryToastAnchor()
+    : null;
   const skipReason = getDictationDictionaryAdviceSkipReason(payload);
   if (skipReason) {
     log.debug('dictionary learning advice skipped', {
@@ -381,14 +387,10 @@ export async function adviseAndRecordVoiceInputDictionaryLearning(
           entryId: entry.id,
           term: entry.text,
         })),
-        // 只有全局浮窗听写的 toast 才贴着「产生它的那次浮窗」的位置出现，且要带上
-        // 本条证据自己的 key —— 并发的 advisor 请求各自认自己的锚点，先返回的不会
-        // 消费掉别人的。应用内听写用户在哪块屏操作与浮窗无关，不传 key、走默认位置。
-        {
-          anchorKey: sourceLabel === 'external_overlay'
-            ? voiceInputDictionaryToastAnchorKey(payload)
-            : null,
-        },
+        // 锚点在本函数入口、任何 await 之前就绑定好了（见 toastAnchor），这里只是
+        // 把它交给 toast：并发的 advisor 请求各认自己那次会话的现场，先返回的不会
+        // 消费掉别人的。应用内听写不带锚点，走默认位置。
+        { anchor: toastAnchor },
       );
     }
     log.debug('dictionary learning advice', {

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -314,9 +314,9 @@ export async function adviseAndRecordVoiceInputDictionaryLearning(
   }
 
   const sourceLabel = options.sourceLabel ?? payload.source ?? 'in_app';
-  // 锚点必须在任何 await 之前取：请求到达 main 的顺序与浮窗发布证据的顺序一致，
-  // 在这里绑定就等于「这次请求认自己那次会话的浮窗现场」；等 advisor 返回后再取，
-  // 并发请求会互相抢到别人的锚点。跳过分支也要取走，否则它会留给下一次请求。
+  // 锚点必须在任何 await 之前取：此刻的呈现代次才代表这次请求的来源会话，绑定后
+  // 无论 advisor 何时返回都只认自己那份。等 advisor 返回后再取，并发请求会互相抢。
+  // 跳过分支同样取走，让过期锚点尽早出队。
   const toastAnchor = sourceLabel === 'external_overlay'
     ? takeOverlayDictionaryToastAnchor()
     : null;

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -380,6 +380,9 @@ export async function adviseAndRecordVoiceInputDictionaryLearning(
           entryId: entry.id,
           term: entry.text,
         })),
+        // 只有全局浮窗听写的 toast 才贴着刚才的浮窗位置出现；应用内听写用户在
+        // 哪块屏操作与浮窗无关，按默认位置来。
+        { anchorToOverlay: sourceLabel === 'external_overlay' },
       );
     }
     log.debug('dictionary learning advice', {

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -307,17 +307,28 @@ const DICTIONARY_LEARNING_TEXT_DEBUG = !app.isPackaged;
 
 export async function adviseAndRecordVoiceInputDictionaryLearning(
   payload: DictationDictionaryAdviceInput | undefined,
-  options: { senderId?: number | string; sourceLabel?: string } = {},
+  options: {
+    senderId?: number | string;
+    sourceLabel?: string;
+    /**
+     * 该请求是否真的来自全局浮窗的 renderer。只有 main 依据 `event.sender` 反查得出
+     * 的结论才算，不能用 payload.source —— 那是 renderer 自报的，别的 renderer 拿
+     * 共享的 adviseDictionaryLearning 桥填个 'external_overlay' 就能消费掉浮窗锚点，
+     * 让真正的浮窗请求失去锚点、自己拿到浮窗的位置。
+     */
+    fromOverlaySender?: boolean;
+  } = {},
 ): Promise<DictionaryAdviceIpcResult> {
   if (!payload?.beforeText || !payload.afterText) {
     return { ok: true, actions: [], elapsedMs: 0 };
   }
 
   const sourceLabel = options.sourceLabel ?? payload.source ?? 'in_app';
-  // 锚点必须在任何 await 之前取：此刻的呈现代次才代表这次请求的来源会话，绑定后
-  // 无论 advisor 何时返回都只认自己那份。等 advisor 返回后再取，并发请求会互相抢。
-  // 跳过分支同样取走，让过期锚点尽早出队。
-  const toastAnchor = sourceLabel === 'external_overlay'
+  // 锚点资格只认 main 侧由 event.sender 反查出的 fromOverlaySender，不认 payload.source
+  // 这个 renderer 自报字段。锚点必须在任何 await 之前取：此刻的呈现代次才代表这次请求
+  // 的来源会话，绑定后无论 advisor 何时返回都只认自己那份；等 advisor 返回后再取，
+  // 并发请求会互相抢。跳过分支同样取走，让过期锚点尽早出队。
+  const toastAnchor = options.fromOverlaySender === true
     ? takeOverlayDictionaryToastAnchor()
     : null;
   const skipReason = getDictationDictionaryAdviceSkipReason(payload);
@@ -1895,7 +1906,12 @@ export function registerVoiceInputIpc(): void {
   ipcMain.handle(
     'voice-input:dictionary-learning:advise',
     async (event, payload: DictationDictionaryAdviceInput | undefined): Promise<DictionaryAdviceIpcResult> => {
-      return adviseAndRecordVoiceInputDictionaryLearning(payload, { senderId: event.sender.id });
+      return adviseAndRecordVoiceInputDictionaryLearning(payload, {
+        senderId: event.sender.id,
+        // 这个桥是所有 renderer 共享的：浮窗 toast 锚点的资格由真实 sender 决定，
+        // 不看 payload 里自报的 source。
+        fromOverlaySender: isGlobalVoiceInputOverlaySender(event.sender),
+      });
     },
   );
 

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -81,6 +81,7 @@ import {
   registerActiveInlineVoiceInputWebContents,
   showVoiceInputDictionaryToast,
   unregisterActiveInlineVoiceInputWebContents,
+  voiceInputDictionaryToastAnchorKey,
 } from './global.js';
 import {
   registerVoiceInputDataStoreIpc,
@@ -380,9 +381,14 @@ export async function adviseAndRecordVoiceInputDictionaryLearning(
           entryId: entry.id,
           term: entry.text,
         })),
-        // 只有全局浮窗听写的 toast 才贴着刚才的浮窗位置出现；应用内听写用户在
-        // 哪块屏操作与浮窗无关，按默认位置来。
-        { anchorToOverlay: sourceLabel === 'external_overlay' },
+        // 只有全局浮窗听写的 toast 才贴着「产生它的那次浮窗」的位置出现，且要带上
+        // 本条证据自己的 key —— 并发的 advisor 请求各自认自己的锚点，先返回的不会
+        // 消费掉别人的。应用内听写用户在哪块屏操作与浮窗无关，不传 key、走默认位置。
+        {
+          anchorKey: sourceLabel === 'external_overlay'
+            ? voiceInputDictionaryToastAnchorKey(payload)
+            : null,
+        },
       );
     }
     log.debug('dictionary learning advice', {

--- a/apps/desktop/src/main/voice-input/overlayPlacement.ts
+++ b/apps/desktop/src/main/voice-input/overlayPlacement.ts
@@ -62,10 +62,16 @@ export function normalizeSavedOverlayPosition(value: unknown): SavedOverlayPosit
 export type ResolveOverlayInitialBoundsInput = {
   savedPosition: SavedOverlayPosition | null;
   displays: OverlayPlacementDisplay[];
+  /**
+   * 用户焦点所在的屏（前台窗口所在屏优先，取不到时是鼠标所在屏）。
+   * 浮窗必须开在这块屏上，保存位置只决定「在这块屏的什么位置」。
+   * null = 调用方拿不到任何屏快照（防御分支）。
+   */
+  activeDisplay: OverlayPlacementDisplay | null;
   size: { width: number; height: number };
   contentInset: number;
   edgePadding: number;
-  /** 无保存位置或保存位置不可用时的默认 bounds（现有 computeOverlayBounds 结果）。 */
+  /** 无保存位置或保存位置不可用时的默认 bounds（焦点屏上的 computeOverlayBounds 结果）。 */
   fallbackBounds: Rectangle;
 };
 
@@ -185,13 +191,35 @@ export function resolveDraggedOverlayBounds({
 }
 
 /**
- * 打开浮窗时的初始位置：有有效保存位置则「记忆优先」，否则回退默认。
- * 保存位置的卡片中心不在任何现存 display 的 workArea 内（典型：外接屏
- * 已拔掉）时同样回退默认，避免浮窗打开在看不见的位置。
+ * 把 bounds 按「卡片中心在 workArea 里的相对比例」搬到另一块屏。
+ * 分辨率不同的两块屏之间也成立：贴边保持贴边，水平居中（比例 0.5）
+ * 仍然落在新屏的水平中线上。
+ */
+function migrateBoundsToWorkArea(bounds: Rectangle, from: Rectangle, to: Rectangle): Rectangle {
+  const center = boundsCenter(bounds);
+  const ratioX = from.width > 0 ? (center.x - from.x) / from.width : 0.5;
+  const ratioY = from.height > 0 ? (center.y - from.y) / from.height : 0.5;
+  return {
+    x: Math.round(to.x + to.width * ratioX - bounds.width / 2),
+    y: Math.round(to.y + to.height * ratioY - bounds.height / 2),
+    width: bounds.width,
+    height: bounds.height,
+  };
+}
+
+/**
+ * 打开浮窗时的初始位置。
+ *
+ * 「浮窗开在焦点屏」是硬约束，位置记忆只在焦点屏内部生效：
+ * - 无保存位置 / 保存位置不可用（典型：外接屏已拔掉）→ 焦点屏默认位置。
+ * - 保存位置就在焦点屏上 → 原样恢复（clamp 回可见区域）。
+ * - 保存位置在另一块屏上 → 按相对比例迁移到焦点屏，用户「习惯放在偏下
+ *   居中 / 靠右下」这类偏好跟着走，而不是把浮窗留在用户没在看的那块屏。
  */
 export function resolveOverlayInitialBounds({
   savedPosition,
   displays,
+  activeDisplay,
   size,
   contentInset,
   edgePadding,
@@ -205,12 +233,38 @@ export function resolveOverlayInitialBounds({
     width: size.width,
     height: size.height,
   };
-  const display = findDisplayContainingPoint(displays, boundsCenter(saved));
-  if (!display) return fallbackBounds;
+  // 先认坐标落点，再认保存下来的 displayId：屏幕重新排布后旧坐标可能
+  // 已经落到空隙里，但那块屏本身还在，仍然算「记忆有效」。
+  const savedDisplay = findDisplayContainingPoint(displays, boundsCenter(saved))
+    ?? displays.find((display) => display.id === savedPosition.displayId)
+    ?? null;
+  if (!savedDisplay) return fallbackBounds;
+  const targetDisplay = activeDisplay ?? savedDisplay;
+  const bounds = targetDisplay.id === savedDisplay.id
+    ? saved
+    : migrateBoundsToWorkArea(saved, savedDisplay.workArea, targetDisplay.workArea);
   return clampOverlayBoundsToWorkArea({
-    bounds: saved,
-    workArea: display.workArea,
+    bounds,
+    workArea: targetDisplay.workArea,
     contentInset,
     edgePadding,
   });
+}
+
+/**
+ * 校验 macOS helper 返回的前台窗口 frame。宽高必须为正：AX 偶尔会给出
+ * 0 尺寸的占位窗口，那种 frame 不能用来判断焦点屏。
+ */
+export function normalizeFocusedWindowFrame(value: unknown): Rectangle | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<Rectangle>;
+  if (!Number.isFinite(candidate.x) || !Number.isFinite(candidate.y)) return null;
+  if (!Number.isFinite(candidate.width) || !Number.isFinite(candidate.height)) return null;
+  if ((candidate.width as number) <= 0 || (candidate.height as number) <= 0) return null;
+  return {
+    x: candidate.x as number,
+    y: candidate.y as number,
+    width: candidate.width as number,
+    height: candidate.height as number,
+  };
 }

--- a/apps/desktop/src/main/voice-input/overlayPlacement.ts
+++ b/apps/desktop/src/main/voice-input/overlayPlacement.ts
@@ -255,8 +255,9 @@ function boundsFromRatio(
  * - 快照带屏内相对比例 → 一律按比例还原到焦点屏。workArea 没变时它还原出的就是
  *   原坐标（±1px 取整），变了（分辨率 / 缩放 / 排布调整）则跟着新尺寸走，不会
  *   把「原来居中」变成「偏左」。
- * - 旧快照没有比例 → 同屏且坐标仍落在该屏内时按绝对坐标原样恢复，否则按坐标
- *   反推出的比例还原，避免恢复到一个早已失效的坐标上。
+ * - 旧快照没有比例 → 坐标仍落在归属屏内时：同屏按绝对坐标原样恢复，跨屏按坐标
+ *   反推的比例迁移；坐标已经不在归属屏内（升级前的坐标 + 之后的显示器重排）则
+ *   无从还原原意，回退默认位置，不去夹出一个贴边的假位置。
  *
  * 记忆所属屏认 `displayId`：显示器重排后旧坐标可能正好落进另一块屏，那是坐标
  * 失效而不是「用户当时放在那块屏」。`displayId` 记着但已不在 = 那块屏被拔掉，
@@ -287,17 +288,26 @@ export function resolveOverlayInitialBounds({
   const savedRatio = savedPosition.ratioX !== undefined && savedPosition.ratioY !== undefined
     ? { ratioX: savedPosition.ratioX, ratioY: savedPosition.ratioY }
     : null;
-  const savedCoordsStillValid = targetDisplay.id === savedDisplay.id
-    && rectContainsPoint(savedDisplay.workArea, boundsCenter(saved));
-  const bounds = !savedRatio && savedCoordsStillValid
-    ? saved
-    : boundsFromRatio(
-      // 旧快照没有比例：按绝对坐标反推，结果夹到 0~1，避免坐标已经失效
-      // （落在归属屏外）时把浮窗甩到屏外。
-      savedRatio ?? computeOverlayPositionRatio(saved, savedDisplay.workArea),
-      targetDisplay.workArea,
-      size,
-    );
+  const savedCoordsUsable = rectContainsPoint(savedDisplay.workArea, boundsCenter(saved));
+  if (!savedRatio) {
+    // 旧快照没有比例，只能从绝对坐标反推。坐标已经不在归属屏内时（典型：升级前
+    // 存的坐标 + 之后显示器重排改了这块屏的 workArea 原点）反推不出有意义的比例
+    // ——夹到 0~1 会把「原本居中」恢复成贴边，不如老老实实回退默认位置。
+    if (!savedCoordsUsable) return fallbackBounds;
+    if (targetDisplay.id === savedDisplay.id) {
+      return clampOverlayBoundsToWorkArea({
+        bounds: saved,
+        workArea: targetDisplay.workArea,
+        contentInset,
+        edgePadding,
+      });
+    }
+  }
+  const bounds = boundsFromRatio(
+    savedRatio ?? computeOverlayPositionRatio(saved, savedDisplay.workArea),
+    targetDisplay.workArea,
+    size,
+  );
   return clampOverlayBoundsToWorkArea({
     bounds,
     workArea: targetDisplay.workArea,

--- a/apps/desktop/src/main/voice-input/overlayPlacement.ts
+++ b/apps/desktop/src/main/voice-input/overlayPlacement.ts
@@ -43,8 +43,25 @@ export type SavedOverlayPosition = {
   x: number;
   y: number;
   displayId?: number;
+  /**
+   * 卡片中心在保存时那块屏 workArea 里的相对比例（0~1）。
+   *
+   * 绝对坐标一旦遇到显示器重新排布就会失效（同一块屏的 workArea 原点变了），
+   * 光靠 x/y 无法还原「用户当时把它放在这块屏的哪个位置」。比例与屏幕排布无关，
+   * 是跨屏迁移与重排后恢复的权威依据；x/y 只用于同屏且坐标仍然有效时的像素级
+   * 原样恢复。旧快照没有这两个字段，按 x/y 反推。
+   */
+  ratioX?: number;
+  ratioY?: number;
   updatedAt: number;
 };
+
+function normalizeRatio(value: unknown): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  const ratio = value as number;
+  if (ratio < 0 || ratio > 1) return undefined;
+  return ratio;
+}
 
 /** 校验持久化快照，字段缺失 / 非有限数一律视为无保存位置。 */
 export function normalizeSavedOverlayPosition(value: unknown): SavedOverlayPosition | null {
@@ -55,7 +72,21 @@ export function normalizeSavedOverlayPosition(value: unknown): SavedOverlayPosit
     x: candidate.x as number,
     y: candidate.y as number,
     displayId: Number.isFinite(candidate.displayId) ? (candidate.displayId as number) : undefined,
+    ratioX: normalizeRatio(candidate.ratioX),
+    ratioY: normalizeRatio(candidate.ratioY),
     updatedAt: Number.isFinite(candidate.updatedAt) ? (candidate.updatedAt as number) : 0,
+  };
+}
+
+/** 落盘前算出屏内相对比例，让记忆不依赖屏幕排布。 */
+export function computeOverlayPositionRatio(
+  bounds: Rectangle,
+  workArea: Rectangle,
+): { ratioX: number; ratioY: number } {
+  const center = boundsCenter(bounds);
+  return {
+    ratioX: clampRatio(workArea.width > 0 ? (center.x - workArea.x) / workArea.width : 0.5),
+    ratioY: clampRatio(workArea.height > 0 ? (center.y - workArea.y) / workArea.height : 0.5),
   };
 }
 
@@ -116,6 +147,18 @@ function boundsCenter(bounds: Rectangle): Point {
     x: bounds.x + bounds.width / 2,
     y: bounds.y + bounds.height / 2,
   };
+}
+
+function clampRatio(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
+}
+
+/** 卡片中心是否还落在某块现存屏幕的 workArea 里（判断缓存锚点是否仍然可见）。 */
+export function isBoundsCenterOnDisplay(
+  bounds: Rectangle,
+  displays: OverlayPlacementDisplay[],
+): boolean {
+  return findDisplayContainingPoint(displays, boundsCenter(bounds)) !== null;
 }
 
 /**
@@ -190,20 +233,17 @@ export function resolveDraggedOverlayBounds({
   return clamped;
 }
 
-/**
- * 把 bounds 按「卡片中心在 workArea 里的相对比例」搬到另一块屏。
- * 分辨率不同的两块屏之间也成立：贴边保持贴边，水平居中（比例 0.5）
- * 仍然落在新屏的水平中线上。
- */
-function migrateBoundsToWorkArea(bounds: Rectangle, from: Rectangle, to: Rectangle): Rectangle {
-  const center = boundsCenter(bounds);
-  const ratioX = from.width > 0 ? (center.x - from.x) / from.width : 0.5;
-  const ratioY = from.height > 0 ? (center.y - from.y) / from.height : 0.5;
+/** 把「屏内相对比例」还原成某块屏上的窗口 bounds。 */
+function boundsFromRatio(
+  ratio: { ratioX: number; ratioY: number },
+  workArea: Rectangle,
+  size: { width: number; height: number },
+): Rectangle {
   return {
-    x: Math.round(to.x + to.width * ratioX - bounds.width / 2),
-    y: Math.round(to.y + to.height * ratioY - bounds.height / 2),
-    width: bounds.width,
-    height: bounds.height,
+    x: Math.round(workArea.x + workArea.width * ratio.ratioX - size.width / 2),
+    y: Math.round(workArea.y + workArea.height * ratio.ratioY - size.height / 2),
+    width: size.width,
+    height: size.height,
   };
 }
 
@@ -211,10 +251,15 @@ function migrateBoundsToWorkArea(bounds: Rectangle, from: Rectangle, to: Rectang
  * 打开浮窗时的初始位置。
  *
  * 「浮窗开在焦点屏」是硬约束，位置记忆只在焦点屏内部生效：
- * - 无保存位置 / 保存位置不可用（典型：外接屏已拔掉）→ 焦点屏默认位置。
- * - 保存位置就在焦点屏上 → 原样恢复（clamp 回可见区域）。
- * - 保存位置在另一块屏上 → 按相对比例迁移到焦点屏，用户「习惯放在偏下
- *   居中 / 靠右下」这类偏好跟着走，而不是把浮窗留在用户没在看的那块屏。
+ * - 无保存位置 / 记忆所属屏已不存在（典型：外接屏已拔掉）→ 焦点屏默认位置。
+ * - 记忆就在焦点屏上、且绝对坐标仍落在该屏内 → 像素级原样恢复。
+ * - 其余情况（跨屏，或同屏但坐标已被显示器重排作废）→ 按屏内相对比例还原到
+ *   焦点屏，用户「习惯放在偏下居中 / 靠右下」这类偏好跟着走，而不是把浮窗
+ *   留在用户没在看的那块屏、或者恢复到一个早已失效的坐标上。
+ *
+ * 记忆所属屏优先认 `displayId`，坐标落点只作旧快照（无 displayId）的兜底：
+ * 显示器重排后旧坐标可能正好落进另一块屏，那是坐标失效而不是「用户当时放在
+ * 那块屏」，不能据此换掉记忆的归属屏。
  */
 export function resolveOverlayInitialBounds({
   savedPosition,
@@ -233,22 +278,36 @@ export function resolveOverlayInitialBounds({
     width: size.width,
     height: size.height,
   };
-  // 先认坐标落点，再认保存下来的 displayId：屏幕重新排布后旧坐标可能
-  // 已经落到空隙里，但那块屏本身还在，仍然算「记忆有效」。
-  const savedDisplay = findDisplayContainingPoint(displays, boundsCenter(saved))
-    ?? displays.find((display) => display.id === savedPosition.displayId)
+  const savedDisplay = displays.find((display) => display.id === savedPosition.displayId)
+    ?? findDisplayContainingPoint(displays, boundsCenter(saved))
     ?? null;
   if (!savedDisplay) return fallbackBounds;
   const targetDisplay = activeDisplay ?? savedDisplay;
-  const bounds = targetDisplay.id === savedDisplay.id
+  const savedCoordsStillValid = rectContainsPoint(savedDisplay.workArea, boundsCenter(saved));
+  const bounds = targetDisplay.id === savedDisplay.id && savedCoordsStillValid
     ? saved
-    : migrateBoundsToWorkArea(saved, savedDisplay.workArea, targetDisplay.workArea);
+    : boundsFromRatio(resolveSavedRatio(savedPosition, saved, savedDisplay.workArea), targetDisplay.workArea, size);
   return clampOverlayBoundsToWorkArea({
     bounds,
     workArea: targetDisplay.workArea,
     contentInset,
     edgePadding,
   });
+}
+
+/**
+ * 取记忆的屏内相对比例：快照里带比例就用它，旧快照按绝对坐标反推。
+ * 反推结果夹到 0~1，避免坐标已经失效（落在归属屏外）时把浮窗甩到屏外。
+ */
+function resolveSavedRatio(
+  savedPosition: SavedOverlayPosition,
+  saved: Rectangle,
+  workArea: Rectangle,
+): { ratioX: number; ratioY: number } {
+  if (savedPosition.ratioX !== undefined && savedPosition.ratioY !== undefined) {
+    return { ratioX: savedPosition.ratioX, ratioY: savedPosition.ratioY };
+  }
+  return computeOverlayPositionRatio(saved, workArea);
 }
 
 /**

--- a/apps/desktop/src/main/voice-input/overlayPlacement.ts
+++ b/apps/desktop/src/main/voice-input/overlayPlacement.ts
@@ -252,14 +252,15 @@ function boundsFromRatio(
  *
  * 「浮窗开在焦点屏」是硬约束，位置记忆只在焦点屏内部生效：
  * - 无保存位置 / 记忆所属屏已不存在（典型：外接屏已拔掉）→ 焦点屏默认位置。
- * - 记忆就在焦点屏上、且绝对坐标仍落在该屏内 → 像素级原样恢复。
- * - 其余情况（跨屏，或同屏但坐标已被显示器重排作废）→ 按屏内相对比例还原到
- *   焦点屏，用户「习惯放在偏下居中 / 靠右下」这类偏好跟着走，而不是把浮窗
- *   留在用户没在看的那块屏、或者恢复到一个早已失效的坐标上。
+ * - 快照带屏内相对比例 → 一律按比例还原到焦点屏。workArea 没变时它还原出的就是
+ *   原坐标（±1px 取整），变了（分辨率 / 缩放 / 排布调整）则跟着新尺寸走，不会
+ *   把「原来居中」变成「偏左」。
+ * - 旧快照没有比例 → 同屏且坐标仍落在该屏内时按绝对坐标原样恢复，否则按坐标
+ *   反推出的比例还原，避免恢复到一个早已失效的坐标上。
  *
- * 记忆所属屏优先认 `displayId`，坐标落点只作旧快照（无 displayId）的兜底：
- * 显示器重排后旧坐标可能正好落进另一块屏，那是坐标失效而不是「用户当时放在
- * 那块屏」，不能据此换掉记忆的归属屏。
+ * 记忆所属屏认 `displayId`：显示器重排后旧坐标可能正好落进另一块屏，那是坐标
+ * 失效而不是「用户当时放在那块屏」。`displayId` 记着但已不在 = 那块屏被拔掉，
+ * 直接回退默认位置；只有完全没有 `displayId` 的旧快照才从坐标反推归属屏。
  */
 export function resolveOverlayInitialBounds({
   savedPosition,
@@ -278,36 +279,31 @@ export function resolveOverlayInitialBounds({
     width: size.width,
     height: size.height,
   };
-  const savedDisplay = displays.find((display) => display.id === savedPosition.displayId)
-    ?? findDisplayContainingPoint(displays, boundsCenter(saved))
-    ?? null;
+  const savedDisplay = savedPosition.displayId !== undefined
+    ? displays.find((display) => display.id === savedPosition.displayId) ?? null
+    : findDisplayContainingPoint(displays, boundsCenter(saved));
   if (!savedDisplay) return fallbackBounds;
   const targetDisplay = activeDisplay ?? savedDisplay;
-  const savedCoordsStillValid = rectContainsPoint(savedDisplay.workArea, boundsCenter(saved));
-  const bounds = targetDisplay.id === savedDisplay.id && savedCoordsStillValid
+  const savedRatio = savedPosition.ratioX !== undefined && savedPosition.ratioY !== undefined
+    ? { ratioX: savedPosition.ratioX, ratioY: savedPosition.ratioY }
+    : null;
+  const savedCoordsStillValid = targetDisplay.id === savedDisplay.id
+    && rectContainsPoint(savedDisplay.workArea, boundsCenter(saved));
+  const bounds = !savedRatio && savedCoordsStillValid
     ? saved
-    : boundsFromRatio(resolveSavedRatio(savedPosition, saved, savedDisplay.workArea), targetDisplay.workArea, size);
+    : boundsFromRatio(
+      // 旧快照没有比例：按绝对坐标反推，结果夹到 0~1，避免坐标已经失效
+      // （落在归属屏外）时把浮窗甩到屏外。
+      savedRatio ?? computeOverlayPositionRatio(saved, savedDisplay.workArea),
+      targetDisplay.workArea,
+      size,
+    );
   return clampOverlayBoundsToWorkArea({
     bounds,
     workArea: targetDisplay.workArea,
     contentInset,
     edgePadding,
   });
-}
-
-/**
- * 取记忆的屏内相对比例：快照里带比例就用它，旧快照按绝对坐标反推。
- * 反推结果夹到 0~1，避免坐标已经失效（落在归属屏外）时把浮窗甩到屏外。
- */
-function resolveSavedRatio(
-  savedPosition: SavedOverlayPosition,
-  saved: Rectangle,
-  workArea: Rectangle,
-): { ratioX: number; ratioY: number } {
-  if (savedPosition.ratioX !== undefined && savedPosition.ratioY !== undefined) {
-    return { ratioX: savedPosition.ratioX, ratioY: savedPosition.ratioY };
-  }
-  return computeOverlayPositionRatio(saved, workArea);
 }
 
 /**

--- a/scripts/voice-input-benchmark.mjs
+++ b/scripts/voice-input-benchmark.mjs
@@ -1724,12 +1724,21 @@ function round(value) {
   return value === undefined ? undefined : Math.round(value);
 }
 
+// helper 可以在最终结果之前先流式吐出进度行（capture-target 会先单独吐一行前台
+// 窗口 frame，好让浮窗尽早选屏），所以结果一律取最后一行非空 JSON。
+function parseHelperResult(stdout) {
+  const lines = String(stdout).split('\n').map((line) => line.trim()).filter(Boolean);
+  const lastLine = lines[lines.length - 1];
+  if (lastLine === undefined) throw new Error('Empty helper response');
+  return JSON.parse(lastLine);
+}
+
 async function pasteIntoFrontmostTarget(text) {
   if (process.platform !== 'darwin') {
     throw new Error('--paste is currently supported only on macOS');
   }
   const helper = await buildMacTextInsertionHelper();
-  const capture = JSON.parse(await execFileStdout(helper, ['--command', 'capture-target']));
+  const capture = parseHelperResult(await execFileStdout(helper, ['--command', 'capture-target']));
   if (!capture.ok || !capture.target) {
     throw new Error(capture.error ?? 'Could not capture frontmost paste target');
   }
@@ -1740,7 +1749,7 @@ async function pasteIntoFrontmostTarget(text) {
     '--target-name', capture.target.processName ?? '',
   ];
   const stdout = await spawnWithInput(helper, args, text, 5000);
-  return JSON.parse(stdout);
+  return parseHelperResult(stdout);
 }
 
 async function buildMacTextInsertionHelper() {


### PR DESCRIPTION
## 这次改了什么

### 摘要

多显示器下语音输入浮窗会开在错误的屏上：只要用户拖动过一次浮窗，它就永久钉在「上次拖动的那块屏」。原因是 `positionOverlayWindow()` 无条件按保存的**绝对坐标**恢复（`resolveOverlayInitialBounds`），只有那块屏被拔掉时才回退默认；而没有保存位置时也只按鼠标所在屏判定，鼠标所在屏又不等于键盘焦点所在屏（鼠标停在 A 屏、在 B 屏的编辑器里打字时，粘贴目标在 B 屏）。

改成「浮窗必须开在焦点屏，位置记忆只决定屏内的位置」：

- **焦点屏判定：前台窗口所在屏优先、鼠标所在屏兜底。** Electron 没有跨 App 的前台窗口 API，所以让已有的 macOS text insertion helper 的 `capture-target` 一并返回前台窗口 frame：读 `kAXFocusedWindow` 的 position/size，AX 不可用时退到 `CGWindowListCopyWindowInfo`（不需要任何新权限）。**frame 与粘贴目标来自同一次 helper 调用、同一次 `NSWorkspace.frontmostApplication` 读取**，所以「浮窗开在哪块屏」与「粘贴进哪个 App」不会各自认到不同的前台 App。显示前最多等 `OVERLAY_FOCUSED_DISPLAY_DEADLINE_MS = 90ms`，超时就按鼠标所在屏直接显示，迟到的答案丢弃、不挪已可见的窗口（避免可见的跨屏跳动）。**单屏和非 macOS 完全不发起查询**，弹出延迟与改动前一致。麦克风不受影响：`start` 指令本来就在 show 之前发出。
- **位置记忆的语义从「绝对坐标」改成「(归属屏, 屏内相对位置)」。** 落盘时记下卡片中心相对该屏 `workArea` 的比例 `ratioX` / `ratioY`；`resolveOverlayInitialBounds` 新增 `activeDisplay`，有比例就一律按比例还原到焦点屏再 clamp。`workArea` 没变时比例还原出的就是原坐标（±1px 取整），变了（分辨率 / 缩放 / 排布）则跟着新尺寸走，不会把「原来居中」变成「偏左」；跨分辨率也成立，吸附过水平居中的记忆迁过去仍然居中。归属屏认 `displayId`：记着但已不在 = 那块屏被拔掉，回退默认位置；只有完全没有 `displayId` 的旧快照才从坐标反推归属屏与比例。
- **顺带修掉两个同源不一致**：双击复位改为复位到「浮窗当前所在那块屏」（原来按鼠标所在屏，可能跳屏）；全局浮窗听写的词典 toast 跟随最近一次浮窗的实际位置（原来固定按鼠标所在屏的默认位置算，用户拖过浮窗就对不上），应用内听写的 toast 仍走默认位置。

### Review follow-up（c46e248b）

首轮 auto-review 提了 5 条，全部按技术判断修掉并已 resolve：

- **归属屏识别顺序**（greptile P1）：改为 `displayId` 优先、坐标落点兜底，并补上比例持久化——单纯调换顺序不够，显示器重排后绝对坐标本身已失效。
- **过期会话仍会显示浮窗**（greptile P1 + Codex P1，同一缺陷）：浮窗是缓存复用的，`hide` 不销毁窗口，原先只查 `isDestroyed()` 会让 90ms 等待期间被取消的会话重新 `show()`（缓存窗口留在 `isVisible() === true`，下一次快捷键会误走 submit 分支），或让迟到的旧答案覆盖新会话的落屏。新增呈现代次 `overlayPresentationSeq`，回调经 `isCurrentOverlayPresentation()` 校验代次 + `overlayPresentationActive` + 窗口同一性 + 未销毁；`hide` / 复位 idle / 销毁都作废本次呈现。
- **toast 锚点未校验**（Codex P1）：`showVoiceInputDictionaryToast` 新增 `anchorToOverlay`，只有 `source === "external_overlay"` 的链路才贴浮窗位置；复用前用新纯函数 `isBoundsCenterOnDisplay()` 确认锚点中心仍落在现存屏幕上，否则退回当前屏默认位置（修掉「外接屏拔掉后 toast 落到屏外」和「在 B 屏工作却把 toast 显示到 A 屏」）。
- **测试断言**（Copilot）：`toBeCloseTo(x, -0.5)` 换成显式 1px 容差。

### Review follow-up 第二轮（239eab7c）

第二轮 Codex 又提了 4 条 P1，同样全部修掉并已 resolve：

- **焦点屏与粘贴目标可能不同源**：原先 `focused-window-frame` 与 `capture-target` 是两个进程，各自读一次 `NSWorkspace.frontmostApplication`，两次读取之间焦点若变化就会「浮窗开在 A 屏、粘贴进 B 屏的 App」。改为 `capture-target` 一并返回 frame（在任何 AX 变更**之前**读，不受 `AXEnhancedUserInterface` 翻转影响），独立命令删除。本机实测两者耗时相当（各约 20ms），合并后仍在 90ms 截止线内，还少一次进程 spawn。
- **同屏换分辨率时沿用了失效坐标**：原先「同屏且坐标仍落在该屏内」就直接用绝对坐标，于是 1920 宽上居中的记忆换到 2560 宽后会偏左。改为有比例就一律按比例还原。
- **`displayId` 已不存在时的兜底不对**：原先会退到坐标落点，可能把记忆改判给恰好覆盖旧坐标的另一块屏并恢复陈旧坐标。现在 `displayId` 记着但不在现存屏中就直接回退默认位置。
- **等待期内的第二次按键会丢**：90ms 等待期里呈现已生效、麦克风在录但窗口还不可见，只看 `isVisible()` 会让第二次按键又开一次呈现（renderer 忽略重复 `start`）。新增 `overlayPresentationAwaitingShow`，快捷键提交分支与 Dock 激活让位判断统一走 `isOverlayPresentationOpen()`。

### Review follow-up 第三轮（2ad0f028）

第三轮 Codex 又提了 2 条 P1，同样修掉并已 resolve：

- **frame 被慢的上下文采集挡在后面**：上一轮把 frame 折进 `capture-target` 的最终 payload，漏了 stdout 是管道、libc 全缓冲——即使 frame 读在最前面，也要等整个 `captureFocusedElementContext()` 走完才随进程退出一起吐出。Chromium 系编辑器走窗口树兜底时那一步可能要几百毫秒，frame 会稳定错过 90ms 截止线，等于这个功能在最需要它的 App 里静默失效。改成 helper 读到 frame 就 `emitLine()` 单独吐一行并 `fflush(stdout)`，再去做上下文采集；仍是同一个进程、同一次 `frontmostApplication` 读取，第二轮的原子性没有回退。TS 侧 `runMacTextInsertionHelper` 新增 `onProgress`（带它时走 spawn 逐行读），命令结果一律按 stdout **最后一行** JSON 解析（`parseMacTextInsertionHelperResult`，已导出并补单测）。
- **延迟到达的词典 toast 会锚到新会话**：词典建议要等模型往返，期间用户可能已在另一块屏开了新一次浮窗、把 `lastPresentedOverlayBounds` 覆盖成新会话位置，旧会话的 toast 就会盖在新浮窗上五秒。证据是经 renderer 往返回到 main 的，所以没把 bounds 顺着那条链路传（renderer 传回的几何值属于不可信输入），改为 main 侧在发布证据时拍 `{ bounds, presentationSeq }` 快照；代次变了即判定为过期现场，退回默认位置。

### Review follow-up 第四轮（da871c96）

- **无比例旧快照 + 坐标失效时不该编造位置**（greptile P1）：旧快照有 `displayId` 但没有比例，且之后显示器重排改了该屏 `workArea` 原点时，从失效坐标反推比例再夹到 0~1 会把「原本居中」恢复成贴边。改为这种情况直接回退默认位置；带比例的快照在同样场景下仍能正确还原（补了对照用例）。
- **单屏路径的延迟显示没校验取消**（greptile P1）：只有多屏等待回调查了呈现代次，单屏与非 macOS 的 `setImmediate(show)` 没查，用户在那一个 tick 内取消会让已取消的浮窗重新出现。校验挪进 `show()` 本身，两条路径都覆盖。

### Review follow-up 第五轮（c28ad373）

- **benchmark 脚本没跟上流式输出**（Codex P1）：`scripts/voice-input-benchmark.mjs` 的 `--paste` 路径把 `capture-target` 整段 stdout 丢给 `JSON.parse`，helper 改流式后会在粘贴前抛错。抽出 `parseHelperResult()` 取最后一行非空 JSON，两处解析都走它。没选「流式改 opt-in」——那会让两种输出形态长期并存、更容易再漏消费方。
- **toast 锚点的取值时机被自己绕过**（Codex P1）：上一轮把快照放在 `publishExternalDictionaryLearningEvidence()` 里，而那个函数正是延迟轮询的 watch 调用的（最长几十秒后），此时进程级 bounds 与代次可能已是新会话 B 的，A 的 toast 反而通过校验贴到 B 的位置。改为 `ExternalDictionaryLearningWatch.toastAnchor` 在建 watch 时（刚粘贴完）拍快照并随 watch 带走，publish 只负责交棒；交棒槽改为一次性消费，并发的第二条请求拿不到锚点即退回默认位置。

### Review follow-up 第六轮（757f2f60）

- **延迟提交回调未绑定呈现代次**（Greptile 置信度门禁，非 inline thread）：`pendingModifierOverlaySubmit` 的 `setImmediate` 回调只查了 `window.isDestroyed()` 与进程级 `overlayPresentationActive`。窗口跨会话复用，取消后紧接着重启会让 active 重新为 true，届时旧会话的这条回调会把刚开始录音的新会话直接提交掉。改为与 `show()` 一致，走 `isCurrentOverlayPresentation()` 校验代次 + active + 窗口同一性 + 未销毁。

### Review follow-up 第七轮（1ae05c43）

- **toast 锚点共用单槽仍会串台**（Codex P1）：renderer 并发发起 advisor，既不等待也不排队。会话 A 的请求还在跑时会话 B 发布证据会覆盖那唯一的槽，先返回的 A 消费掉 B 的锚点、且 B 的代次正好匹配从而通过校验，A 的 toast 就贴到了 B 的浮窗上。改为按证据逐条登记：`voiceInputDictionaryToastAnchorKey()` 对 `source` / `beforeText` / `afterText` 取 sha256 前 32 位作 key，发布时存 Map、建议回来时按 key 取走并删除。key 不进 IPC payload（renderer 往返只加 `context` 语言字段，main 可自行重算；被改过则查不到锚点 → 默认位置），做摘要而非拼原文以免用户听写文本留在 key 里，登记表上限 8 条防无界增长。

### Review follow-up 第八轮（c7ae7bb9）

- **源码混进真实 NUL 字节**（Copilot）：上一轮写 hash 分隔符时把字面 `\x00` 敲进了 `global.ts`，会让工具链把它当二进制（ripgrep 直接停止搜索）。已清零；那个 hash 本身也随下一条整体删掉。
- **内容派生的 key 会撞**（Codex P1）：同一处 `beforeText → afterText` 在两次会话里算出同一个 key，B 覆盖 A 后先返回的 A 会拿到 B 的锚点。改为不需要 ID 的定序办法：renderer 收到证据会立刻发起 advisor 请求，所以请求到达 main 的顺序 == 证据发布顺序；发布时把锚点 push 进 FIFO 队列，`adviseAndRecordVoiceInputDictionaryLearning` 在入口、任何 await 之前 `takeOverlayDictionaryToastAnchor()` 取走队首绑给这次请求。既避免扩 `DictationDictionaryAdviceInput`（模型输入类型），也不引入可被 renderer 改写的关联键。
- **锚点快照仍取晚了**（Codex P1）：renderer 早已收起浮窗、粘贴在后台跑，用户能在 `pasteTextToMacTarget()` 返回前开下一次会话，而快照当时是在建 watch 时才读进程级状态。改为在 `pasteTextToFocusedTarget()` 第一行、第一个 await 之前拍好，随参数传进 watch。
- **单屏也白读 AX**（Codex P1）：helper 新增 `--with-focused-frame`，传不传在 spawn 之前由 `shouldResolveFocusedDisplay()` 决定。单屏与非 macOS 下既不读那三次 AX（慢目标 App 里每次可能吃满 200ms timeout、拖慢粘贴），也不推迟显示。

### Review follow-up 第九轮（bedc4eba）

- **上一轮的「按到达顺序绑定」在 renderer 不发请求时会永久错位**（Codex P1）：refinement / 自动词典关闭时，renderer 收到证据但在调 main 之前就返回，那条锚点永不出队；重新打开开关后每次请求都取到上一次会话的过期锚点、自己那份继续留在队列，之后所有全局词典 toast 都退回鼠标所在屏直到重启。改为「代次即身份」——代次变过的锚点对任何请求都无效（那正是「期间又开过浮窗」的定义），取用时直接丢弃并继续找代次仍匹配的那个。队列位置不再参与归属判断，两种情况都不错位：旧会话的建议迟到时取不到锚点、走默认位置；残留锚点在下一次请求被当过期丢掉，请求仍拿到自己那份（自愈，无需重启）。

### Review follow-up 第十轮（d1501e54）

- **过期锚点退回默认位置仍会遮挡**（Codex P1）：默认位置就是浮窗的默认位置，所以旧会话的词典建议迟到、新会话正在同一块屏录音（且未被拖动，即常见情况）时，alwaysOnTop 的 toast 会正好压在新浮窗控件上五秒。改为在 `showDictionaryToastWindow()` 入口判断 `isOverlayPresentationOpen()`，有浮窗正在呈现就不弹（只打 debug 日志）。选 suppress 而非 defer：词条已落库，延后弹出反而与用户当下操作脱节。闸放在这个入口对所有调用方生效，不只修「过期锚点」一条路径。

### Review follow-up 第十一轮（06d53643）

- **AX 慢路径会吃掉选屏截止时间**（Codex P1）：`focusedWindowFrame` 原先先试 AX，迟钝目标上最多吃三次 200ms messaging timeout（focusedWindow / position / size），远超调用方 90ms 的截止时间，frame 到得太晚、浮窗又退回鼠标所在屏。改为先查 `CGWindowList`（窗口服务器查询，无需辅助功能授权、无 per-request 超时、Screen Recording 被拒时几何仍可用），AX 只作兜底；就「选哪块屏」而言前台 App 最前的 layer-0 窗口与 AX focused window 等价。**顺带修掉这条兜底一直是死路**：`kCGWindowOwnerPID` / `kCGWindowLayer` 是 NSNumber，原写法 `as? pid_t`（Int32）条件转换恒失败，分支永远返回 nil；改用 `NSNumber.int32Value` / `intValue`。
- **被动重现浮窗会跳屏**（Codex P1）：启动失败 / 粘贴失败都会走 `showPassiveOverlayWindow()`，它调 `positionOverlayWindow(window)` 用了新加的默认参数（鼠标所在屏），于是错误提示会从用户正在用的 B 屏跳到鼠标所在的 A 屏。改为沿用 `lastPresentedOverlayBounds`（hide 后实时 bounds 已被停到屏幕外，不可用），那块屏已不存在时才退回默认定位。

### Review follow-up 第十二轮（056b95b8）

- **锚点资格信了 renderer 自报的 source**（Codex P1，命中 AGENTS.md「Main 不信任 Renderer 自报身份」）：`adviseDictionaryLearning` 是所有 renderer 共享的桥，任何 renderer 填个 `external_overlay` 就能消费掉浮窗锚点，真正的浮窗请求反而失去锚点。改为 main 在 IPC handler 里用 `isGlobalVoiceInputOverlaySender(event.sender)` 判定，经 `options.fromOverlaySender` 传入；`payload.source` 退回只用于日志与 skip 判定。
- **流式 stdout 逐 chunk `toString()` 会截断多字节字符**（Codex P1）：跨 chunk 边界被切开的 UTF-8 字符两边各变成替换字符，而最终 JSON 仍能解析成功，损坏会静默流进 refine 与词典学习。改为对 stdout / stderr 显式 `setEncoding('utf8')`。
- **window-list 要求 `layer == 0` 会丢掉焦点浮动面板**（Codex P1）：焦点文本框可能在浮动 `NSPanel` / 工具窗口里（层级非 0），要求 layer 0 会跳过它、返回该 App 的普通文档窗口；两者在不同屏时浮窗开在错误那块屏而粘贴仍进焦点面板。改为不限层级取 front-to-back 的第一个可用窗口（顺序本身已表达「哪个窗口在最前」），只跳过全透明与退化尺寸窗口。

### Review follow-up 第十三轮（450b8262）

- **z-order 不等于焦点**（Codex P1）：去掉 layer 过滤后，App 未获焦点的置顶浮动面板 / tooltip 会排在焦点文档窗口之前而选错屏；恢复 `layer == 0` 又会漏掉「焦点确实在浮动面板里」。两种纯启发式各有失效面，改为**同时给两个答案**：helper 先吐 `CGWindowList` frame（`source=window-list`，无授权要求、无 per-request 超时，必定赶在 90ms 截止线内），随后吐权威的 AX `kAXFocusedWindow` frame（`source=ax`）；main 保留「当前最好的一条」，AX 到了立刻放行且不再被覆盖，截止线先到就用已到手的近似值而不是放弃（放弃等于退回鼠标所在屏）。`window-list` 内部恢复「优先最前面的 layer-0 窗口」，仅在 App 无 layer-0 窗口时退到任意层级，使近似值偏向文档窗口而非置顶小面板。日志记 `timedOut` 以区分用的是权威值还是近似值。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户直接报告）
- 本 PR 包含：全局语音输入浮窗的焦点屏判定与跨屏位置记忆；`capture-target` 流式返回前台窗口 frame（含 main 与 benchmark 脚本两侧的「结果取最后一行」解析）；异步定位的会话时序与「等待期算已打开」保护；双击复位与词典 toast 的落屏一致性（锚点随来源 watch 携带 + 跨会话过期抑制）；`overlayPlacement` / `globalShortcut` 单测扩充。
- 明确不包含：Windows 侧的前台窗口查询（无可用的低成本 API，那边仍按鼠标所在屏判定，位置记忆的修复在 Windows 上同样生效）；`showPassiveOverlayWindow` 的重新定位仍按鼠标所在屏（同一会话内的再次呈现，不新增异步查询）。
- 用户可见变化：多屏下浮窗出现在焦点所在的显示器上；拖动过的位置偏好会按比例跟到焦点屏。
- 是否存在 breaking change：无。`voice-input-overlay-position.v1.json` 只**新增**两个可选字段 `ratioX` / `ratioY`，双向兼容：旧记录缺字段时按坐标反推（`normalizeSavedOverlayPosition` 对非法/越界比例一律丢弃该字段），旧版本客户端读到新记录时会忽略这两个未知字段。

### UI 变化

- 引用的设计规范：不涉及：只改 main 侧的窗口定位与几何计算，浮窗自身的视觉、交互与文案均未改动，没有命中 UI 代码路径（`apps/desktop/src/renderer/`）。

## 怎么验证的

### 自动验证

首轮（26635e7c）：

```text
bash <git skill>/scripts/run-unit-gate.sh  # 仓库根 pnpm test:unit 全量
结果：GATE_EXIT=0

pnpm --filter desktop run --if-present typecheck
结果：通过
```

review follow-up 后（c46e248b）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：1290 个测试文件中 1289 通过、14648 个测试通过；唯一失败的
      src/main/learn-host/__tests__/apply.test.ts 与本 PR 无关，
      根因是它用固定共享临时目录 /tmp/xdt-learn-apply-test，被本机上一轮
      被中断的门禁留下的残留污染。清掉该目录后单独重跑：13/13 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 251 tests passed

swiftc apps/desktop/native/voice-input/macos-text-insertion-helper.swift -o /tmp/helper
结果：编译通过
```

第二轮 review follow-up 后（239eab7c）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：1290 个测试文件中 1289 通过、14654 个测试通过；唯一失败的
      src/main/file-browser/__tests__/deviceOp.test.ts 与本 PR 无关，
      是一条 vi.waitFor 时序断言（watch 立即重订阅）在本机负载下的 flake。
      单独重跑该文件：35/35 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input src/main/__tests__/appShortcuts.test.ts
结果：25 files / 277 tests passed

swiftc apps/desktop/native/voice-input/macos-text-insertion-helper.swift -o /tmp/helper
结果：编译通过；实跑 --command capture-target 确认同时返回 target 与
      frame / frameSource，且已删除的 --command focused-window-frame 报未知命令
```

第十三轮 review follow-up 后（450b8262）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 259 tests passed

swiftc apps/desktop/native/voice-input/macos-text-insertion-helper.swift -o /tmp/helper
结果：编译通过；--command capture-target --with-focused-frame 实跑 stdout 依次为
      frameSource: "window-list"、frameSource: "ax"、最终结果行
```

第十二轮 review follow-up 后（056b95b8）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 259 tests passed

swiftc apps/desktop/native/voice-input/macos-text-insertion-helper.swift -o /tmp/helper
结果：编译通过；--command capture-target --with-focused-frame 实跑输出
      frameSource: "window-list"（去掉 layer 限制后该分支首次真正命中）

多字节解码探针（分两次写出被切开的「中」的 3 个字节）
结果：旧读法得到 "\ufffd\ufffd\n"，setEncoding('utf8') 后得到 "中\n"
```

第十一轮 review follow-up 后（06d53643）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 259 tests passed

swiftc apps/desktop/native/voice-input/macos-text-insertion-helper.swift -o /tmp/helper
结果：编译通过；--command capture-target --with-focused-frame 实跑三次约 30-40ms
      （首次冷启动 ~0.5s），仍是先吐 frame 行再吐结果
```

另写了一次性探针核对 `CGWindowList` 取值：`NSNumber.int32Value` / `intValue` 能正确解析出 pid 与 layer（原 `as? pid_t` 写法恒失败）。

第十轮 review follow-up 后（d1501e54）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 259 tests passed
```

第九轮 review follow-up 后（bedc4eba）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 259 tests passed
```

第八轮 review follow-up 后（c7ae7bb9）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 259 tests passed

swiftc apps/desktop/native/voice-input/macos-text-insertion-helper.swift -o /tmp/helper
结果：编译通过；实跑核对两种调用——不带 --with-focused-frame 时 stdout 只有一行
      最终结果（完全不读 frame），带上时先吐 {"event":"focused-window-frame",...}
      再吐结果

python3 统计三个改动文件的 NUL 字节
结果：均为 0
```

第七轮 review follow-up 后（1ae05c43）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 261 tests passed
```

第六轮 review follow-up 后（757f2f60）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 258 tests passed
```

第五轮 review follow-up 后（c28ad373）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 258 tests passed

node --check scripts/voice-input-benchmark.mjs
结果：通过；另用真实 helper 的两行输出验证 parseHelperResult() 取到的是结果行
```

第四轮 review follow-up 后（da871c96）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 258 tests passed
```

第三轮 review follow-up 后（2ad0f028）：

```text
bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0（1290 个文件全绿，无需分诊）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/voice-input
结果：24 files / 257 tests passed

swiftc apps/desktop/native/voice-input/macos-text-insertion-helper.swift -o /tmp/helper
结果：编译通过；实跑 --command capture-target 确认 stdout 是两行，
      第一行 {"event":"focused-window-frame",...} 先到，第二行才是完整结果
```

`overlayPlacement.test.ts` 累计新增 22 条：跨屏按比例还原、还原后仍保持水平居中、迁到更小屏时 clamp、同屏 `workArea` 未变时还原回原坐标（1px 内）、同屏换分辨率时按比例走而不沿用旧坐标、旧快照无比例且坐标已不在归属屏内时回退默认位置、同一场景下带比例的快照仍能还原、旧坐标落进另一块屏时归属屏仍认 `displayId`、`displayId` 对应屏已拔掉时回退默认位置、保存的比例优先于坐标反推、拿不到焦点屏的防御分支，以及 `computeOverlayPositionRatio`、`isBoundsCenterOnDisplay`、`normalizeFocusedWindowFrame`、`normalizeSavedOverlayPosition`（含比例字段的降级）的校验。`globalShortcut.test.ts` 另加 3 条覆盖 `parseMacTextInsertionHelperResult`（多行取最后一行、单行保持原行为、空/非法输入抛错）。

CI 上 `verify` 失败，与本 PR 无关，是当前 `origin/main` 的基线问题：

```text
FAIL src/renderer/__tests__/composerChipPresentation.test.tsx
     > keeps the caret and prose 4px away from every composer pill
AssertionError: the given combination of arguments (undefined and string) is invalid
```

该用例用硬编码正则去匹配 `globals.css` 里 `.ProseMirror :is(...)` 的**完整选择器列表**（列到 `.slash-cmd-pill` 为止）。main 的 27e083fa（#599 快速开始预填胶囊）往这个列表里加了 `.quick-start-pill`，但没同步该测试，正则于此失配 → `gapRule` 为 `undefined` → 断言报上面这个错。`margin-inline: 4px` 规则本身仍在、仍正确，纯粹是测试正则太脆。

核实方式：用 `git show origin/main:` 取出 main 当前的 `globals.css` 与该测试文件（两份测试文件与本分支完全一致），在本地跑同一条正则——对 main 的 CSS **未命中**，对本分支的 CSS 命中。PR 的 CI 测的是与 main 的 merge 结果，所以继承了这个失败；本地对本分支跑该文件 5/5 通过。修复按仓库「无关修复拆开」的规则单独提在 #867（已先在 main 基线复现该失败、再验证修复，全量门禁绿）。#867 合并后本 PR 的 `verify` 会随之转绿。

### 手工验证

macOS 26（Darwin 27）双显示器（Pro Display XDR 主屏 + 内置 Liquid Retina XDR，内置屏在左下方，全局坐标 x 为负）。

- 从本 worktree 起 dev 实例（`pnpm restart:desktop:remote --region=global --preserve-running`），`pnpm desktop:whoami` 核对 root / commit / ready 均匹配后，由报告者在双屏上实测确认：焦点在另一块屏时浮窗开在焦点屏，跨屏位置记忆按比例跟随。
- helper 实机验证：`--command capture-target` 正确报出前台窗口 frame（`frameSource: "ax"`），且 stdout 确为两行、frame 那行先到。用 `/usr/bin/time` 各连测三次，`capture-target` 与（后来删掉的）独立 frame 命令都是约 20ms，冷启动首次约 0.5s——这是把两者合并成一次调用的依据；frame 改流式则是为了不受上下文采集慢路径拖累（见第三轮 follow-up）。
- 坐标空间前提验证：写了一次性探针比对同一批在屏窗口的 `kAXPosition` 与 `CGWindowListCopyWindowInfo` bounds，两者逐个完全一致，且与 `CGDisplayBounds`（左上原点）同空间 —— 这是「helper 返回的 frame 能直接喂给 `screen.getDisplayMatching()`」的关键前提。

### 未执行的验证

- Windows 未实机验证。该平台不发起前台窗口查询，走的是与改动前相同的鼠标所在屏路径；位置记忆的比例还原是纯几何函数，已被单测覆盖。
- 未验证 AX 被拒时的 `CGWindowList` 兜底分支（本机已授予辅助功能权限，AX 路径始终命中）。该分支只在 helper 内部，失败时统一退回鼠标所在屏。
- 五轮 review follow-up 的运行期边界行为未做实机复现，都靠单测与代码路径推导：90ms 等待期内取消会话、单屏路径下一个 tick 内取消、等待期内再按一次快捷键、外接屏拔掉后的 toast 锚点降级、跨会话延迟到达的 toast 被判过期、显示器重排 / 换分辨率后按比例恢复、frame 与粘贴目标同源。这些要么需要精确掐时序，要么需要反复插拔外接屏或改分辨率才能触发。
- `pnpm benchmark:voice-input -- --paste` 未实跑（需要真实前台输入框与粘贴授权）。只做了 `node --check` 与用真实 helper 两行输出验证 `parseHelperResult()` 取到的是结果行。
- **主路径在第二、三轮改动后未重新实机验证**：首轮的双屏实机结论覆盖的是「独立 frame 命令 + 两个进程」的版本，之后 `capture-target` 的返回内容、调用时机（提前到 `positionOverlayWindow` 之前）与 stdout 行格式都变了。helper 的两行输出与 frame 先到已用命令行实跑确认，Electron 侧的端到端行为只有单测与 typecheck 覆盖。粘贴与词典学习用的 `target` / `context` 字段未改动，缓冲式调用方仍从最后一行取结果。
- 两个 frame 来源都已实测产出，但**「AX 超时 → 用 window-list 近似值」这条降级路径未实机触发**（本机 AX 一直在几十毫秒内返回），只有代码审查覆盖；`window-list` 内部「App 无 layer-0 窗口时退到任意层级」的分支、以及浮动 `NSPanel` 与文档窗口分处两屏的具体场景，同样未构造复现。
- `spawnHelperWithProgressPromise` 的超时与非零退出分支未实机触发（正常路径都是 0 退出）。失败时抛 `PasteCommandError`，与原 execFile 路径一致，上层退回鼠标所在屏。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 全局语音输入浮窗的落屏与位置，以及 `capture-target` 的返回内容与 stdout 格式。原生层改动限于 macOS Swift helper：`capture-target` 增加只读的 `frame` / `frameSource` 字段，并在最终结果之前先流式吐一行 frame 事件（打包时由 `forge.config.ts` 的 `buildMacVoiceInputTextInsertionHelper` 从源码编译，无新依赖、无新权限声明；`paste-verified` 未改动，`capture-target` 既有字段与 AX 上下文采集逻辑不变）。stdout 从单行变多行属于 main ↔ helper 的进程内协议变化，两侧同一个 commit 内一起改，且解析改为「取最后一行」对单行输出向后兼容；仓内另一个消费方 `scripts/voice-input-benchmark.mjs` 已同步（第五轮 follow-up）。与 mobile runtime fingerprint / OTA 无关，不触发冷更。跨平台差异是有意的：焦点屏的前台窗口判定只在 macOS 生效，Windows 保持鼠标所在屏。
- 回滚 / 降级方式：整体 revert 即可，无数据迁移、无持久化格式变化。运行期已内建降级：helper 失败、超时或返回非法 frame 都退回鼠标所在屏，即改动前的行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：未新增需要成文的规则或产品行为约定）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)














