### PR TITLE
fix(desktop): 灵动岛工作态角色改为挡在键盘前

### DIFF
--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -473,6 +473,8 @@ struct PululuMascotView: View {
       let squashY: CGFloat = dy > 0.25 ? 0.98 : 1.0
 
       drawShadow(c, v: v, width: 8.1 - abs(dy) * 0.32, opacity: 0.30)
+      // 键盘先画：角色要挡在键盘前面，而不是被键盘条横切。
+      drawKeyboard(c, v: v, phase: keyPhase, dy: -0.05)
       drawPululu(
         c,
         v: v,
@@ -485,7 +487,6 @@ struct PululuMascotView: View {
         eyesBright: true,
         headAngle: headTurn
       )
-      drawKeyboard(c, v: v, phase: keyPhase, dy: -0.05)
     }
   }
 
@@ -1052,6 +1053,8 @@ struct SpriteMascotView: View {
       let v = V(sz)
       let dy = bounce - 0.25
       drawShadow(c, v: v, width: 8.4 - abs(dy) * 0.32, opacity: 0.30)
+      // 键盘先画：角色要挡在键盘前面，而不是被键盘条横切。
+      drawKeyboard(c, v: v, phase: keyPhase, dy: -0.05)
       drawSprite(
         c,
         v: v,
@@ -1064,7 +1067,6 @@ struct SpriteMascotView: View {
         eyeYOffset: 0.05,
         angle: headTurn
       )
-      drawKeyboard(c, v: v, phase: keyPhase, dy: -0.05)
     }
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

macOS 灵动岛工作态（打字动画）里，角色被下面那排键盘挡住了下半身。原因是画布的绘制顺序：先画角色、后画键盘，SwiftUI `Canvas` 后画的盖在前面，键盘条（16 格坐标系 y 13→16）正好横切在角色身体中下部。PNG 皮肤的角色下沿本来就靠近画布底部（annie ≈14.6、muffin ≈15.0），观感上就是被切平了一半。

改为先画键盘、再画角色，让角色完整站在键盘前面，键盘从身体两侧露出。`PululuMascotView`（内置矢量小人）与 `SpriteMascotView`（PNG 皮肤）两套渲染器同步调整，保持一致。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（本机 dogfood 发现）
- 本 PR 包含：`apps/desktop/native/agent-island/macos-agent-island-helper.swift` 两处工作态画布的绘制顺序调整（阴影 → 键盘 → 角色）
- 明确不包含：键盘条几何位置、角色 `bodyScale`、其它状态（idle / 待确认 / 完成）的画布；`boli` 皮肤因 `bodyScale` 0.80、本来就不与键盘相交，本次不调整它与键盘的距离
- 用户可见变化：灵动岛处于「干活中」时，角色不再被键盘条横切，改为挡在键盘前面
- 是否存在 breaking change：无

### UI 变化

灵动岛工作态角色与键盘的遮挡关系反转。逐皮肤离屏渲染核对（真实 helper 源码编译后用 `ImageRenderer` 渲染工作态静态帧）：

- annie / muffin / chaku / tarara / whitesnow / pululu：角色恢复完整，键盘从身体两侧露出
- boli：无变化（`bodyScale` 0.80，本来就不与键盘相交）
- 打字高亮闪键循环 6 个位置，最左列在所有皮肤下都可见；上排中间 2 个键会被角色身体挡住，属于「站在键盘前」的自然遮挡，键盘条本体与下排始终完整

- 引用的设计规范：`docs/design-rules/DESIGN.md` 没有灵动岛 mascot 的专章条款，本次不新增视觉规范，沿用既有 mascot 尺寸、配色与动画时序，只修正遮挡关系。双模式方面：灵动岛由原生 helper 绘制在固定深色载体上，mascot 与键盘的颜色全部来自每个皮肤的 `SpriteMascotConfig` 常量，不读系统 appearance、无 light / dark 分支，因此本改动在两种模式下表现一致。

## 怎么验证的

### 自动验证

```text
swiftc -O apps/desktop/native/agent-island/macos-agent-island-helper.swift -o /tmp/island-helper-check
结果：编译通过（与运行时 MacAgentIslandNativeHost 使用的编译参数一致）

pnpm test:unit
结果：通过（无失败项）

pnpm --filter desktop run --if-present typecheck
结果：通过
```

### 手工验证

- macOS 26（darwin arm64），从本功能 worktree 启动 dev：`pnpm restart:desktop:remote -- --preserve-running`，`pnpm desktop:whoami` 显示 `Desktop source: MATCH`（root 与 HEAD 均为本 worktree，passive 共享 userData），实机确认工作态角色挡在键盘前。
- 另用真实 helper 源码编译改前 / 改后两份离屏渲染程序，逐皮肤对比工作态静态帧（见上「UI 变化」）。

### 未执行的验证

- 未做 Windows 验证：灵动岛为 macOS 原生 helper，Windows 侧不存在该渲染路径。
- 未在 PR 中附截图：改动效果为原生窗口内的小尺寸角色动画，本地已逐皮肤目检；如需要可另行补图。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 macOS 灵动岛 helper 的工作态绘制顺序。helper 源码变更会让 `MacAgentIslandNativeHost` 按新 sha256 重新 `swiftc` 编译一次二进制（既有机制），不涉及 Electron 主进程、渲染进程、数据库或协议。不影响 mobile runtime fingerprint，不触发冷更。
- 回滚 / 降级方式：revert 本 commit 即可，helper 会按旧 sha256 重新编译回原绘制顺序。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增：未改变任何规则或契约）
- [x] 已确认测试结果或说明未执行原因
