### PR TITLE
fix(desktop): hook turn 多消息文本不再丢失, Telegram 群进度带过程时间线

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -247,6 +247,26 @@ describe('normalizeTaskSource', () => {
     expect(fr.calls[0]?.source?.userText).toHaveLength(20_000);
     fr.finish();
   });
+
+  it('laneKind 派生: telegram group/topic externalKey → group, DM 与 Slack → dm', async () => {
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({ runner: fr.runner });
+    const c = collector();
+
+    const keys = [
+      'telegram:group:bot:-900:42:9:g0',
+      'telegram:topic:bot:-900:77:9:g0',
+      'telegram:dm:bot:user:g0',
+      'team-slack:C1:1.1',
+    ];
+    for (const [i, externalKey] of keys.entries()) {
+      d.handleDispatch('conn-1', dispatch({ requestId: `req-lane-${i}`, externalKey }), c.send);
+      await tick();
+      fr.finish();
+      await tick();
+    }
+    expect(fr.calls.map((call) => call.laneKind)).toEqual(['group', 'group', 'dm', 'dm']);
+  });
 });
 
 describe('dispatcher 核心语义', () => {

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -702,6 +702,98 @@ describe('进度快照(turn.progress 链路)', () => {
     }
   });
 
+  it('续尾补推(claude result 兜底): isFinal 只含缺失尾段时与已流增量原样接上', async () => {
+    vi.useFakeTimers();
+    try {
+      fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
+        makeManualSession(opts.id ?? 'sess-x'),
+      );
+      const runner = createMakerHookSessionRunner({ log });
+      const p = runner.run(baseReq({}));
+      await flush();
+      const cb = h.eventCbs.get('sess-new')!;
+
+      // 消息 1 正常定稿。
+      cb({ type: 'text', data: { text: '旁白说明。', isFinal: true } });
+      // 消息 2 流到一半被截断, translator 用 result 兜底只补 UI 缺的尾段
+      // (fallbackTail): 该 isFinal 不含已流出的前缀。
+      cb({ type: 'text', data: { text: '最终答案是 4', isFinal: false } });
+      cb({ type: 'text', data: { text: '2。', isFinal: true } });
+      cb({ type: 'done', data: null });
+
+      const outcome = await p;
+      // 前缀不丢、正文中间不插段落分隔。
+      expect(outcome.finalText).toContain('最终答案是 42。');
+      expect(outcome.finalText).toContain('旁白说明。');
+      expect(outcome.finalText).not.toContain('4\n\n2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('未定稿流式尾巴保留首行缩进与换行(markdown 代码块不被 trim 破坏)', async () => {
+    vi.useFakeTimers();
+    try {
+      fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
+        makeManualSession(opts.id ?? 'sess-x'),
+      );
+      const runner = createMakerHookSessionRunner({ log });
+      const p = runner.run(baseReq({}));
+      await flush();
+      const cb = h.eventCbs.get('sess-new')!;
+
+      cb({ type: 'text', data: { text: '    indented code\nline2', isFinal: false } });
+      cb({ type: 'done', data: null });
+
+      const outcome = await p;
+      expect(outcome.finalText).toContain('    indented code\nline2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('Telegram 群 lane: 进度带过程时间线(时间线在上正文在下), 无正文时也有时间线', async () => {
+    vi.useFakeTimers();
+    try {
+      fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
+        makeManualSession(opts.id ?? 'sess-x'),
+      );
+      const emitted: string[] = [];
+      const runner = createMakerHookSessionRunner({ log });
+      const p = runner.run(
+        baseReq({
+          source: { im: 'telegram', userText: 'hi' },
+          laneKind: 'group',
+          onProgress: (text: string) => emitted.push(text),
+        }),
+      );
+      await flush();
+      const cb = h.eventCbs.get('sess-new')!;
+
+      // 与 DM(answer-only)不同: 群 lane 只有工具活动、还没有正文时,
+      // 也要发时间线, 群成员能看到"正在干什么"。
+      cb({
+        type: 'tool_use',
+        data: { toolUseId: 'read-1', toolName: 'Read', input: { file_path: '/repo/a.ts' } },
+      });
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(emitted.length).toBeGreaterThan(0);
+      expect(emitted.at(-1)).toContain('▸');
+
+      cb({ type: 'text', data: { text: '结论是 42。', isFinal: false } });
+      await vi.advanceTimersByTimeAsync(1_500);
+      const last = emitted.at(-1)!;
+      expect(last).toContain('结论是 42。');
+      // 合成规则与 Slack 过程卡同款: 时间线在上, 正文在下。
+      expect(last.indexOf('▸')).toBeLessThan(last.indexOf('结论是 42。'));
+
+      cb({ type: 'done', data: null });
+      await p;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('thinking/tool_use/text 驱动友好快照,过程文字持续保留;done 后停止', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -670,6 +670,38 @@ describe('进度快照(turn.progress 链路)', () => {
     for (let i = 0; i < times; i++) await Promise.resolve();
   }
 
+  it('多消息 turn: isFinal 逐条追加不整体替换, 先答一句再思考再终答两段都保留', async () => {
+    vi.useFakeTimers();
+    try {
+      fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
+        makeManualSession(opts.id ?? 'sess-x'),
+      );
+      const runner = createMakerHookSessionRunner({ log });
+      const p = runner.run(baseReq({}));
+      await flush();
+      const cb = h.eventCbs.get('sess-new')!;
+
+      // 消息 1 流式 + 完成(codex translator: 每条 agent_message completed
+      // 都发 isFinal=true 携带该条全文)
+      cb({ type: 'text', data: { text: '我正在追溯, 稍等。', isFinal: false } });
+      cb({ type: 'text', data: { text: '我正在追溯, 稍等。', isFinal: true } });
+      // 思考 + 工具
+      cb({ type: 'thinking', data: { stage: 'final', blockId: 't1', text: '检查提交记录' } });
+      // 消息 2(最终答案)流式 + 完成
+      cb({ type: 'text', data: { text: '查到了: 是 PR #527 引入的。', isFinal: false } });
+      cb({ type: 'text', data: { text: '查到了: 是 PR #527 引入的。', isFinal: true } });
+      cb({ type: 'done', data: null });
+
+      const outcome = await p;
+      expect(outcome.status).toBe('ok');
+      // 两段都在, 且以定稿顺序拼接 —— 整体替换语义会丢掉其中一段。
+      expect(outcome.finalText).toContain('我正在追溯');
+      expect(outcome.finalText).toContain('PR #527');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('thinking/tool_use/text 驱动友好快照,过程文字持续保留;done 后停止', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -53,7 +53,15 @@ const h = vi.hoisted(() => {
     readImDefaultSettings: vi.fn(),
     useActualDefaults: false,
     /** 每个 fake session 的事件监听回调(emit done 用)。 */
-    eventCbs: new Map<string, (ev: { type: string; data: unknown }) => void>(),
+    eventCbs: new Map<
+      string,
+      (ev: {
+        type: string;
+        data: unknown;
+        source?: string;
+        agentMeta?: Record<string, unknown>;
+      }) => void
+    >(),
     /** 每个 fake session 被装上的 interaction listener(交互测试驱动用)。 */
     interactionListeners: new Map<string, (req: unknown) => Promise<unknown>>(),
     headlessDuringSend: [] as boolean[],
@@ -653,7 +661,14 @@ describe('进度快照(turn.progress 链路)', () => {
     return {
       id,
       workDir: 'D:/repo',
-      onEvent(cb: (ev: { type: string; data: unknown }) => void) {
+      onEvent(
+        cb: (ev: {
+          type: string;
+          data: unknown;
+          source?: string;
+          agentMeta?: Record<string, unknown>;
+        }) => void,
+      ) {
         h.eventCbs.set(id, cb);
         return () => {
           h.eventCbs.delete(id);
@@ -726,6 +741,70 @@ describe('进度快照(turn.progress 链路)', () => {
       expect(outcome.finalText).toContain('最终答案是 42。');
       expect(outcome.finalText).toContain('旁白说明。');
       expect(outcome.finalText).not.toContain('4\n\n2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('claude 同一条消息的相邻文本块按原文连拼, 不同消息之间空行分隔', async () => {
+    vi.useFakeTimers();
+    try {
+      fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
+        makeManualSession(opts.id ?? 'sess-x'),
+      );
+      const runner = createMakerHookSessionRunner({ log });
+      const p = runner.run(baseReq({}));
+      await flush();
+      const cb = h.eventCbs.get('sess-new')!;
+
+      // 消息 m1 含两个相邻文本块(translator 逐块发 isFinal, 同 uuid)。
+      cb({
+        type: 'text',
+        data: { text: '前半', isFinal: true },
+        source: 'claude-code',
+        agentMeta: { uuid: 'm1' },
+      });
+      cb({
+        type: 'text',
+        data: { text: '后半。', isFinal: true },
+        source: 'claude-code',
+        agentMeta: { uuid: 'm1' },
+      });
+      // 消息 m2 是另一条 assistant 消息。
+      cb({
+        type: 'text',
+        data: { text: '第二条。', isFinal: true },
+        source: 'claude-code',
+        agentMeta: { uuid: 'm2' },
+      });
+      cb({ type: 'done', data: null });
+
+      const outcome = await p;
+      expect(outcome.finalText).toBe('前半后半。\n\n第二条。');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('claude 续尾与已流增量重复前缀时不误判为全文(ha→haha 不丢后半段)', async () => {
+    vi.useFakeTimers();
+    try {
+      fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
+        makeManualSession(opts.id ?? 'sess-x'),
+      );
+      const runner = createMakerHookSessionRunner({ log });
+      const p = runner.run(baseReq({}));
+      await flush();
+      const cb = h.eventCbs.get('sess-new')!;
+
+      // 流式增量 "ha" 后流被截断, result 兜底补的尾段恰好也是 "ha"
+      // (全文 "haha")。fallbackTail 契约: 不带 agentMeta。
+      cb({ type: 'text', data: { text: 'ha', isFinal: false }, source: 'claude-code' });
+      cb({ type: 'text', data: { text: 'ha', isFinal: true }, source: 'claude-code' });
+      cb({ type: 'done', data: null });
+
+      const outcome = await p;
+      expect(outcome.finalText).toBe('haha');
     } finally {
       vi.useRealTimers();
     }
@@ -929,7 +1008,14 @@ describe('交互卡链路(interaction listener 覆盖)', () => {
     return {
       id,
       workDir: 'D:/repo',
-      onEvent(cb: (ev: { type: string; data: unknown }) => void) {
+      onEvent(
+        cb: (ev: {
+          type: string;
+          data: unknown;
+          source?: string;
+          agentMeta?: Record<string, unknown>;
+        }) => void,
+      ) {
         h.eventCbs.set(id, cb);
         return () => {
           h.eventCbs.delete(id);

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -69,6 +69,12 @@ export interface HookSessionRunner {
 
 export interface HookRunRequest {
   sessionId: string;
+  /**
+   * IM lane 形态(externalKey 派生): 'group' = 群/topic, 'dm' = 私聊。
+   * runner 据此决定进度快照是否携带过程时间线(群内可编辑消息适合过程卡,
+   * DM 的 Rich draft 动画不适合反复重排)。缺省按 'dm' 保守处理。
+   */
+  laneKind?: 'dm' | 'group';
   /** true = 新建 session(workingDir/title 生效); false = 复用/接管已有。 */
   isNew: boolean;
   workingDir: string;
@@ -674,6 +680,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     /** 旧绑定作废、本次不得不新建会话时, 随 turn.end 回给渠道的说明。 */
     let recreatedNotice: string | null = null;
 
+    const laneKind: 'dm' | 'group' =
+      /^telegram:(group|topic):/.test(payload.externalKey) ? 'group' : 'dm';
     // 接管路径: server 显式指定已有 session(对话会话同样可接管)
     if (payload.sessionId !== null) {
       const info = await runner.inspect(payload.sessionId);
@@ -689,6 +697,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         run: {
           sessionId: payload.sessionId,
           isNew: false,
+          laneKind,
           workingDir: info.workingDir as string,
           agentKind,
           model,
@@ -768,6 +777,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           run: {
             sessionId: bound,
             isNew: false,
+            laneKind,
             // 尚未落库, 没有 meta 可查 —— 用建它时那个刚重新过完映射校验的目录
             workingDir: pendingDir!,
             agentKind,
@@ -807,6 +817,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           run: {
             sessionId: bound,
             isNew: false,
+            laneKind,
             workingDir,
             agentKind,
             model,
@@ -888,6 +899,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       run: {
         sessionId,
         isNew: true,
+        laneKind,
         workingDir: runDir,
         agentKind,
         model,

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -623,10 +623,26 @@ export function createMakerHookSessionRunner(deps: {
         }
       }
 
-      // turn 收口监听 —— 语义与 scheduler runner 第 5 步同源:
-      // text isFinal 替换 / delta 追加; done 时若有在途后台任务则延迟定格,
-      // 事件静默超时兜底; terminal error 即失败。
+      // turn 收口监听 —— done 时若有在途后台任务则延迟定格, 事件静默超时
+      // 兜底; terminal error 即失败。
+      //
+      // 文本累积语义(2026-07-28 修订): translator 的 isFinal 是**逐条**
+      // agent_message 的完成信号(每条完成都携带该条全文), 不是整个 turn 的
+      // 终稿 —— 用它整体替换累积文本, 会让"先回一句 → 思考 → 终答"的多消息
+      // turn 只剩最后被替换的那条(实踩: Telegram 群里最终答案丢失)。
+      // 正确姿势: isFinal 把该条追加进已定稿段, 流式增量走尾部缓冲。
+      let finalizedText = '';
+      let streamTail = '';
       let assistantText = '';
+      const recomputeAssistantText = (): void => {
+        const tail = streamTail.trim();
+        assistantText =
+          tail.length > 0
+            ? finalizedText
+              ? `${finalizedText}\n\n${tail}`
+              : tail
+            : finalizedText;
+      };
       // tool_result 旁路收集的出站图片 absPath(收口时随 turn.end 附件外发)
       const extraImageAbsPaths: string[] = [];
       // 进度快照(turn.progress 链路): 过程区时间线与 IM 流式卡同一套纯逻辑
@@ -634,14 +650,14 @@ export function createMakerHookSessionRunner(deps: {
       // 上正文在下, done/error 后 stop, 不再发射。
       const activity = createTurnActivity(Date.now());
       const isTelegram = req.source?.im === 'telegram';
+      // Telegram DM 的 Rich draft 是"部分终稿"动画, 过程时间线反复重排会导致
+      // 整段清空重播 —— DM 保持只流正文。群/topic 的进度载体是可编辑消息
+      // (无 draft 动画), 与 Slack 过程卡同款: 时间线在上正文在下, 让群成员
+      // 看到"正在干什么"而不是盯着一句旧话干等(2026-07-28 实踩)。
+      const answerOnlyProgress = isTelegram && req.laneKind !== 'group';
       const progress = req.onProgress
         ? createProgressEmitter(req.onProgress, () => {
-            // Telegram Rich Message drafts are the partial final answer, not
-            // an editable process card. turnActivity can reorder/fold as
-            // thinking and tool events arrive, which makes Telegram animate
-            // repeated full clears. Keep Slack's established process card,
-            // while Telegram streams only the monotonically growing answer.
-            if (isTelegram) return assistantText;
+            if (answerOnlyProgress) return assistantText;
             const act = renderActivity(activity, Date.now());
             if (!act) return assistantText;
             return assistantText ? `${act}\n\n${assistantText}` : act;
@@ -689,8 +705,15 @@ export function createMakerHookSessionRunner(deps: {
           if (ev.type === 'text') {
             const data = ev.data as { text?: string; isFinal?: boolean } | null;
             if (data && typeof data.text === 'string') {
-              if (data.isFinal) assistantText = data.text;
-              else assistantText += data.text;
+              if (data.isFinal) {
+                finalizedText = finalizedText
+                  ? `${finalizedText}\n\n${data.text}`
+                  : data.text;
+                streamTail = '';
+              } else {
+                streamTail += data.text;
+              }
+              recomputeAssistantText();
               markActivityWriting(activity);
               progress?.schedule();
             }

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -634,6 +634,8 @@ export function createMakerHookSessionRunner(deps: {
       let finalizedText = '';
       let streamTail = '';
       let assistantText = '';
+      /** 最近一次定稿段所属的 claude 消息 uuid(同消息相邻块连拼用)。 */
+      let lastFinalUuid: string | undefined;
       const recomputeAssistantText = (): void => {
         // trim 只用于判空(纯空白尾巴不该拼出悬空分隔), 拼接用原文 ——
         // 首行缩进/换行是内容(markdown 代码块等), 不得被裁掉。
@@ -707,17 +709,34 @@ export function createMakerHookSessionRunner(deps: {
             const data = ev.data as { text?: string; isFinal?: boolean } | null;
             if (data && typeof data.text === 'string') {
               if (data.isFinal) {
-                // isFinal 有两种形态(见 translator): ①整条全文 —— 块终稿/
-                // codex item.completed, 全文以已流增量为前缀, 丢增量取全文;
-                // ②续尾补推 —— claude result 兜底 fallbackTail 只含 UI 缺的
-                // 尾段(uiEmittedText 前缀比对), 必须与已流增量原样接上,
-                // 不能丢前缀、也不能在正文中间插段落分隔。
-                const segment = data.text.startsWith(streamTail)
-                  ? data.text
-                  : streamTail + data.text;
+                // isFinal 形态按 translator 契约区分, 不做内容猜测(前缀
+                // 启发式在"尾段恰好以已流增量开头"时会误判丢正文):
+                // ① claude 块终稿(带 agentMeta): data.text 是该块全文, 覆盖
+                //   已流增量; 同一条消息(同 uuid)的相邻文本块按原文连拼
+                //   (renderer 同款 raw concat), 不同消息之间空行分隔。
+                // ② claude result 兜底 fallbackTail(刻意不带 agentMeta):
+                //   只含 UI 缺的尾段, 与已流增量原样接上。
+                // ③ codex item.completed: 该条全文, 覆盖已流增量。
+                // ④ 未知 source: 保守用前缀启发式。
+                const src = (ev as { source?: string }).source;
+                const meta = (ev as { agentMeta?: { uuid?: unknown } }).agentMeta;
+                const claudeTail = src === 'claude-code' && meta === undefined;
+                const segment = claudeTail
+                  ? streamTail + data.text
+                  : src === 'claude-code' || src === 'codex'
+                    ? data.text
+                    : data.text.startsWith(streamTail)
+                      ? data.text
+                      : streamTail + data.text;
+                const uuid =
+                  src === 'claude-code' && typeof meta?.uuid === 'string'
+                    ? meta.uuid
+                    : undefined;
+                const sameMessage = uuid !== undefined && uuid === lastFinalUuid;
                 finalizedText = finalizedText
-                  ? `${finalizedText}\n\n${segment}`
+                  ? `${finalizedText}${sameMessage ? '' : '\n\n'}${segment}`
                   : segment;
+                lastFinalUuid = uuid;
                 streamTail = '';
               } else {
                 streamTail += data.text;

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -635,13 +635,14 @@ export function createMakerHookSessionRunner(deps: {
       let streamTail = '';
       let assistantText = '';
       const recomputeAssistantText = (): void => {
-        const tail = streamTail.trim();
-        assistantText =
-          tail.length > 0
-            ? finalizedText
-              ? `${finalizedText}\n\n${tail}`
-              : tail
-            : finalizedText;
+        // trim 只用于判空(纯空白尾巴不该拼出悬空分隔), 拼接用原文 ——
+        // 首行缩进/换行是内容(markdown 代码块等), 不得被裁掉。
+        const hasTail = streamTail.trim().length > 0;
+        assistantText = hasTail
+          ? finalizedText
+            ? `${finalizedText}\n\n${streamTail}`
+            : streamTail
+          : finalizedText;
       };
       // tool_result 旁路收集的出站图片 absPath(收口时随 turn.end 附件外发)
       const extraImageAbsPaths: string[] = [];
@@ -706,9 +707,17 @@ export function createMakerHookSessionRunner(deps: {
             const data = ev.data as { text?: string; isFinal?: boolean } | null;
             if (data && typeof data.text === 'string') {
               if (data.isFinal) {
+                // isFinal 有两种形态(见 translator): ①整条全文 —— 块终稿/
+                // codex item.completed, 全文以已流增量为前缀, 丢增量取全文;
+                // ②续尾补推 —— claude result 兜底 fallbackTail 只含 UI 缺的
+                // 尾段(uiEmittedText 前缀比对), 必须与已流增量原样接上,
+                // 不能丢前缀、也不能在正文中间插段落分隔。
+                const segment = data.text.startsWith(streamTail)
+                  ? data.text
+                  : streamTail + data.text;
                 finalizedText = finalizedText
-                  ? `${finalizedText}\n\n${data.text}`
-                  : data.text;
+                  ? `${finalizedText}\n\n${segment}`
+                  : segment;
                 streamTail = '';
               } else {
                 streamTail += data.text;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 2026-07-28 晚 Telegram 群实踩的两个生产缺陷(事故:agent 先回"稍等"、思考 1 分钟后产出的最终答案没发到群里;工作期间状态不更新)。

1. **多消息 turn 丢文本**:translator 的 `isFinal` 是**逐条**完成信号(codex 每条 agent_message completed 携带该条全文,`codex/translator.ts:520`;claude-code 每个 text block 单发 `isFinal:true`,`claude-code/translator.ts:1000`),而 hook runner 用它**整体替换**累积文本(`session-runner.ts` 旧 692 行)——"先答一句 → 思考 → 终答"只剩最后被替换的一条,两通道都中招。改为:isFinal 追加进定稿段、流式增量走尾部缓冲,永不整体替换。
2. **群内工作状态不更新**:`session-runner.ts` 对 Telegram 的进度快照被刻意降级为纯正文(旧 644 行,原因是 DM Rich draft 动画不适合过程区重排)。现按 lane 区分:群/topic(可编辑消息载体)与 Slack 对齐带 turnActivity 过程时间线;DM 维持只流正文。`laneKind` 由 dispatcher 从 externalKey 派生(`telegram:group|topic:` → group)。

流式输出的调研结论(不在本 PR 实现):机制已齐——`turn.progress` 最新快照 + 群内可编辑消息 + DM draft 流,此前被第 2 条降级卡住;本 PR 放开后,剩余优化只是服务端编辑节流(≥1.5s)与 typing keep-alive(每 4-5s 续 `sendChatAction`),归 cindy-server 侧后续 PR。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:2026-07-28 Telegram 群实踩(Dash 桌面执行)
- 本 PR 包含:runner 文本累积语义修正 + 群 lane 进度内容对齐 + laneKind 派生 + 回归测试
- 明确不包含:服务端 typing keep-alive 与编辑节流(cindy-server 后续 PR);与 #843(群窗口)相互独立
- 用户可见变化:Telegram 群里多消息回复完整送达;群任务执行中能看到过程时间线
- 是否存在 breaking change:无

### UI 变化

不涉及(main 进程逻辑;Telegram 侧呈现变化由既有 progress 消息承载)。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
apps/desktop vitest session-runner.test.ts   结果:37 passed(含新增多消息 turn 回归)
pnpm test:unit(根,全量)                    结果:通过(0 failures)
pnpm --filter desktop typecheck              结果:通过
pnpm check:dco                               结果:1 commit signed off
```

### 手工验证

不涉及(事故机器是另一位成员的桌面;修复后需在 Telegram 群实测"先回一句再思考再答"场景——见未执行的验证)。

### 未执行的验证

- Telegram 群实机复测(需部署到执行者桌面后由 Dash/任一群成员触发同场景);失败模式为回退到旧行为,无新增风险面。

## 风险

### 风险分类

- [x] 其他:hook turn 文本组装语义(Slack/Telegram 双通道共用)

### 影响与回滚

- 影响范围:所有 hook 渠道(Slack/Telegram)的 turn 文本组装与 Telegram 群进度内容。追加语义在两种 translator 语义下均验证不重复不丢段(codex 逐条全文/CC 逐块);Slack 进度行为不变。
- 回滚 / 降级方式:revert 单 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范(不涉及)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内语义注释)
- [x] 已确认测试结果或说明未执行原因
