### PR TITLE
test(desktop): 修 composer 胶囊间距用例的脆弱正则

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerChipPresentation.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/composerChipPresentation.test.tsx
@@ -80,8 +80,10 @@ function ComposerHarness({ onEditor }: { onEditor?: (editor: Editor) => void }) 
 
 describe('composer atomic chip presentation', () => {
   it('aligns selected-text quotes and every other atom to the same text baseline', () => {
+    // 规则体用 [^}] 界定，不假设 `}` 前面正好是换行：CSS 声明里不会出现 `}`，
+    // 所以缩进或换行风格调整不会再让这条断言失配（同下面那条间距用例）。
     const alignmentRule = globalsSource.match(
-      /\.ProseMirror :is\(\[data-mention-chip\], \[data-pasted-text-chip\], \[data-composer-quote\]\) \{([\s\S]*?)\n\}/,
+      /\.ProseMirror :is\(\[data-mention-chip\], \[data-pasted-text-chip\], \[data-composer-quote\]\)\s*\{([^}]*)\}/,
     )?.[1];
 
     expect(alignmentRule).toContain('position: relative');
@@ -94,11 +96,12 @@ describe('composer atomic chip presentation', () => {
     // （如 #599 的 .quick-start-pill）。写死完整列表会让那类改动把断言变成
     // gapRule === undefined，报出与本意无关的 "undefined and string" 断言错误。
     const gapRuleMatch = [
-      ...globalsSource.matchAll(/\.ProseMirror :is\(([^)]*)\)\s*\{([\s\S]*?)\n\}/g),
+      ...globalsSource.matchAll(/\.ProseMirror :is\(([^)]*)\)\s*\{([^}]*)\}/g),
     ].find(([, , body]) => body.includes('margin-inline'));
     const [, gapSelectors, gapRule] = gapRuleMatch ?? [];
 
     // 已知胶囊必须都在共用列表里（防的是「某个胶囊被漏掉」，而不是列表长度）。
+    // 新增胶囊时把它加进这份清单，用例才真的覆盖「每一个 composer 胶囊」。
     expect(gapSelectors).toBeDefined();
     for (const pill of [
       '[data-mention-chip]',
@@ -106,6 +109,7 @@ describe('composer atomic chip presentation', () => {
       '[data-composer-quote]',
       '.ghost-cmd-pill',
       '.slash-cmd-pill',
+      '.quick-start-pill',
     ]) {
       expect(gapSelectors).toContain(pill);
     }

--- a/apps/desktop/src/renderer/__tests__/composerChipPresentation.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/composerChipPresentation.test.tsx
@@ -89,10 +89,26 @@ describe('composer atomic chip presentation', () => {
   });
 
   it('keeps the caret and prose 4px away from every composer pill', () => {
-    const gapRule = globalsSource.match(
-      /\.ProseMirror :is\(\s*\[data-mention-chip\],\s*\[data-pasted-text-chip\],\s*\[data-composer-quote\],\s*\.ghost-cmd-pill,\s*\.slash-cmd-pill\s*\) \{([\s\S]*?)\n\}/,
-    )?.[1];
+    // 按「规则体设了 margin-inline」定位这条共用外间距规则，而不是把整份选择器
+    // 列表写死：这条 :is() 是所有 composer 胶囊共用的，新增胶囊时会往列表里加成员
+    // （如 #599 的 .quick-start-pill）。写死完整列表会让那类改动把断言变成
+    // gapRule === undefined，报出与本意无关的 "undefined and string" 断言错误。
+    const gapRuleMatch = [
+      ...globalsSource.matchAll(/\.ProseMirror :is\(([^)]*)\)\s*\{([\s\S]*?)\n\}/g),
+    ].find(([, , body]) => body.includes('margin-inline'));
+    const [, gapSelectors, gapRule] = gapRuleMatch ?? [];
 
+    // 已知胶囊必须都在共用列表里（防的是「某个胶囊被漏掉」，而不是列表长度）。
+    expect(gapSelectors).toBeDefined();
+    for (const pill of [
+      '[data-mention-chip]',
+      '[data-pasted-text-chip]',
+      '[data-composer-quote]',
+      '.ghost-cmd-pill',
+      '.slash-cmd-pill',
+    ]) {
+      expect(gapSelectors).toContain(pill);
+    }
     expect(gapRule).toContain('margin-inline: 4px');
   });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

当前 `main` 是红的：`composerChipPresentation.test.tsx` 的「keeps the caret and prose 4px away from every composer pill」失败，报错是

```text
AssertionError: the given combination of arguments (undefined and string) is invalid
for this assertion. You can use an array, a map, an object, a set, a string, or a
weakset instead of a string
```

原因是这条用例把 `globals.css` 里那条共用外间距规则的**完整选择器列表**写死进了正则（枚举到 `.slash-cmd-pill` 为止）：

```js
/\.ProseMirror :is\(\s*\[data-mention-chip\],\s*\[data-pasted-text-chip\],\s*\[data-composer-quote\],\s*\.ghost-cmd-pill,\s*\.slash-cmd-pill\s*\) \{([\s\S]*?)\n\}/
```

`27e083fa`（#599 快速开始预填文本以黑底白字胶囊样式展示）往这个共用列表里加了 `.quick-start-pill`，正则于此失配 → 匹配结果 `undefined` → `expect(undefined).toContain('margin-inline: 4px')` 报出上面那句与本意无关的类型错误。**`margin-inline: 4px` 规则本身仍在、仍正确**，是测试写法太脆，不是样式回归。

改为按「规则体设了 `margin-inline`」定位这条共用规则，再逐个断言已知胶囊都在列表里：

- 新增胶囊（往 `:is()` 列表里加成员）不再打断用例；
- 「某个已知胶囊被漏出列表」或「间距值被改掉」仍然会被抓到；
- 规则整体消失时由 `expect(gapSelectors).toBeDefined()` 给出明确失败，而不是那句令人困惑的 "undefined and string"。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无。#845 的 `verify` 门禁因继承这条基线红而无法转绿，按仓库「无关修复拆开」的规则单独提这个 PR。
- 本 PR 包含：`composerChipPresentation.test.tsx` 里一条用例的正则与断言写法。
- 明确不包含：任何样式或运行时代码改动；`globals.css` 未改。同文件另一条 alignment 用例的正则**在 review follow-up 中一起改了**规则体界定方式（原本也假设 `}` 前是换行，属于本 PR 要修的同一类脆弱），但它的选择器枚举保持原样——那三个选择器是该规则的完整列表，没有「会随新胶囊增长」的属性。
- 用户可见变化：无。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：本 PR 只改一个测试文件的断言写法（`apps/desktop/src/renderer/__tests__/composerChipPresentation.test.tsx`），`globals.css` 与任何组件、样式、文案均未改动，运行时视觉与交互零变化，因此没有可截图的界面差异。命中 UI 路径启发式仅因为该测试文件位于 `apps/desktop/src/renderer/` 下（`isUiPath` 按路径前缀判定，不区分测试与组件）；`check:pr-design-basis` 已通过。

### Review follow-up（39fbcaf8）

review 提了 4 条（3 条指向同一处），全部修掉并已 resolve：

- **已知胶囊清单漏了 `.quick-start-pill`**（Codex P1 / Greptile P2 / Copilot）：它已经在共用的 `margin-inline` 规则里，清单漏了它就等于「这个胶囊被移出共用列表」这类回归仍能让用例通过，而用例名承诺覆盖 every composer pill。已补进断言清单，并把维护约定写进注释。职责划分保持不变：正则负责「不因新增选择器而整条失配」，清单负责「已知胶囊一个都不能漏」。
- **规则体正则仍假设 `}` 前是换行**（Copilot）：改用 `[^}]` 界定规则体，对缩进 / 换行风格免疫（CSS 声明里不会出现 `}`，不会跨规则误匹配）。同文件的 alignment 用例一起改——同一类脆弱，留着等下次格式化再炸没有意义。

## 怎么验证的

### 自动验证

```text
# 先在未改动的 main 基线上复现 CI 的失败（本 worktree 基于 27e083fa）
pnpm --filter desktop exec vitest run src/renderer/__tests__/composerChipPresentation.test.tsx
结果：1 failed | 4 passed —— 报错与 CI 完全一致
       ("the given combination of arguments (undefined and string) is invalid")

# 应用本 PR 改动后
pnpm --filter desktop exec vitest run src/renderer/__tests__/composerChipPresentation.test.tsx
结果：5 passed

bash <git skill>/scripts/run-unit-gate.sh   # 仓库根 pnpm test:unit 全量
结果：GATE_EXIT=0

pnpm --filter desktop run --if-present typecheck
结果：通过
```

review follow-up 后（39fbcaf8）：

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/composerChipPresentation.test.tsx
结果：5 passed

bash <git skill>/scripts/run-unit-gate.sh
结果：GATE_EXIT=0

pnpm --filter desktop run --if-present typecheck
结果：通过
```

另做了一次反向验证：把 `globals.css` 里所有 `\n}` 换成 `\n  }`（模拟 Copilot 指出的缩进闭括号这类格式化改动）后，两条正则仍然命中，`.quick-start-pill` 在选择器列表内、`margin-inline: 4px` 断言成立。

另外用脚本反向核对了断言命中的是正确那条规则，而不是同文件前面那条 alignment 规则（两条都含 `[data-mention-chip]`）：命中的选择器列表为 `[data-mention-chip], [data-pasted-text-chip], [data-composer-quote], .ghost-cmd-pill, .slash-cmd-pill, .quick-start-pill`，规则体含 `margin-inline: 4px`，已知胶囊无缺失。

### 手工验证

不涉及：纯测试断言改动，无运行时行为。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅一条单元测试的断言写法。
- 回滚 / 降级方式：revert 即可（revert 后 `main` 会回到当前的红状态）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：未新增规则或产品行为约定）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)

