### PR TITLE
fix(desktop): 修复中文加粗标记紧接正文时解析失败

### DIFF
--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -238,6 +238,24 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('ignores closing brackets inside image-description URI autolinks', () => {
+    const source = '![<https://example.test/a]b> **重点。**正文](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '![<https://example.test/a]b> 重点。正文](missing.png)',
+    );
+    expect(renderMarkdown(source)).not.toContain('**');
+  });
+
+  it('ignores closing brackets inside image-description link destinations', () => {
+    const source = '![[x](https://example.test/a]b) **重点。**正文](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '![[x](https://example.test/a]b) 重点。正文](missing.png)',
+    );
+    expect(renderMarkdown(source)).not.toContain('**');
+  });
+
   it('repairs strong delimiters in CJK prose recovered from a bare URL', () => {
     const source = 'https://example.com/foo（**重点。**正文';
 
@@ -449,6 +467,14 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
     const ordinaryBackslashes = '\\x '.repeat(2_000);
     const source = `${protectedSpans} ${ordinaryBackslashes}**重点。**正文`;
+
+    expect(normalizeStrongDelimiterBoundaries(source, { preserveTexDelimiters: true })).toBe(
+      source.replace('**正文', '**<!--cindy-strong-boundary-->正文'),
+    );
+  });
+
+  it('handles a long escaped-backslash run in source-line mode', () => {
+    const source = `${'\\'.repeat(20_000)}x **重点。**正文`;
 
     expect(normalizeStrongDelimiterBoundaries(source, { preserveTexDelimiters: true })).toBe(
       source.replace('**正文', '**<!--cindy-strong-boundary-->正文'),

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -25,7 +25,7 @@ function renderMarkdownWithStrictMath(source: string): string {
     createElement(
       ReactMarkdown,
       {
-        remarkPlugins: [remarkGfm, remarkMath, remarkStrictInlineMath],
+        remarkPlugins: [remarkGfm, remarkMath, remarkStrictInlineMath, remarkTruncateCjkUrls],
         skipHtml: true,
       },
       normalizeStrongDelimiterBoundaries(source),
@@ -165,6 +165,25 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
     expect(renderMarkdown(source)).toContain(
       '<a href="https://b.test/**foo.**bar">https://b.test/**foo.**bar</a>',
+    );
+  });
+
+  it('protects math syntax recovered from CJK-truncated bare URL tails', () => {
+    const source = 'https://example.com/foo（$2**3.**x$';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      'https://example.com/foo<!--cindy-strong-boundary-->（$2**3.**x$',
+    );
+    const html = renderMarkdownWithStrictMath(source);
+    expect(html).toContain('<code class="language-math math-inline">2**3.**x</code>');
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
+  it('does not reparse unrelated math in recovered bare URL tails', () => {
+    const source = ['https://example.com/foo（$x$', '', '**重点。**正文'].join('\n');
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      ['https://example.com/foo（$x$', '', '**重点。**<!--cindy-strong-boundary-->正文'].join('\n'),
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -184,6 +184,24 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('protects TeX delimiters preserved for source-line anchors', () => {
+    const cases = ['\\[2**3.**x\\]', ['\\(', '2**3.**x', '\\)'].join('\n')];
+
+    for (const source of cases) {
+      const normalizedMath = normalizeMathDelimiters(source, { preserveLineCount: true });
+      expect(normalizedMath, source).toBe(source);
+      expect(
+        normalizeStrongDelimiterBoundaries(normalizedMath, { preserveTexDelimiters: true }),
+        source,
+      ).toBe(source);
+    }
+
+    const prose = '**重点。**正文';
+    expect(normalizeStrongDelimiterBoundaries(prose, { preserveTexDelimiters: true })).toBe(
+      '**重点。**<!--cindy-strong-boundary-->正文',
+    );
+  });
+
   it('preserves loose inline math before the strict math plugin downgrades it to text', () => {
     const source = '$2**3.**x $';
 

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -230,6 +230,21 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('ignores preserved TeX delimiters inside protected Markdown syntax', () => {
+    const cases = [
+      '[x](https://a.test/\\(foo) **重点。**正文 \\)',
+      '![x](https://a.test/\\[foo) **重点。**正文 \\]',
+      '`\\(foo` **重点。**正文 \\)',
+    ];
+
+    for (const source of cases) {
+      expect(
+        normalizeStrongDelimiterBoundaries(source, { preserveTexDelimiters: true }),
+        source,
+      ).toBe(source.replace('**正文', '**<!--cindy-strong-boundary-->正文'));
+    }
+  });
+
   it('preserves loose inline math before the strict math plugin downgrades it to text', () => {
     const source = '$2**3.**x $';
 

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -193,6 +193,15 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(html).not.toContain('cindy-strong-boundary');
   });
 
+  it('enters image isolation when protected syntax crosses the description start', () => {
+    const source = '**outer ![`code` text.**Next](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
+    const html = renderMarkdown(source);
+    expect(html).toContain('alt="code text.**Next"');
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
   it('restores an outer strong span after scanning an image description', () => {
     const source = '**See ![alt](missing.png).**Next';
 
@@ -225,6 +234,28 @@ describe('normalizeStrongDelimiterBoundaries', () => {
       '![`a]b` 重点。正文](missing.png)',
     );
     expect(renderMarkdown(source)).toContain('src="missing.png" alt="a]b 重点。正文"');
+  });
+
+  it('scans a long unmatched image-description backtick run once', () => {
+    const backticks = '`'.repeat(100_000);
+    const source = `**outer ![\`code\`${backticks} text.**Next](missing.png)`;
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
+    const html = renderMarkdown(source);
+    expect(html).toContain('src="missing.png"');
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
+  it('scans escaped runs linearly in image descriptions', () => {
+    const backslashes = '\\'.repeat(100_001);
+    const source = `![${backslashes}x **重点。**正文](missing.png)`;
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      `![${backslashes}x 重点。正文](missing.png)`,
+    );
+    const html = renderMarkdown(source);
+    expect(html).toContain('src="missing.png"');
+    expect(html).not.toContain('cindy-strong-boundary');
   });
 
   it('ignores closing brackets inside image-description inline HTML', () => {
@@ -458,6 +489,17 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(html).toContain(
       '$foo <code>**代码。**正文</code> <a href="https://a.test/**path.**next">链接</a> 标签 <strong>重点。</strong>正文 bar$',
     );
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
+  it('classifies image descriptions inside loose math downgraded to visible text', () => {
+    const source = '$foo ![**重点。**正文](missing.png) bar $';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '\\$foo ![重点。正文](missing.png) bar \\$',
+    );
+    const html = renderMarkdownWithStrictMath(source);
+    expect(html).toContain('$foo <img src="missing.png" alt="重点。正文"/> bar $');
     expect(html).not.toContain('cindy-strong-boundary');
   });
 

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -193,6 +193,17 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(html).not.toContain('cindy-strong-boundary');
   });
 
+  it('restores an outer strong span after scanning an image description', () => {
+    const source = '**See ![alt](missing.png).**Next';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '**See ![alt](missing.png).**<!--cindy-strong-boundary-->Next',
+    );
+    expect(renderMarkdown(source)).toContain(
+      '<strong>See <img src="missing.png" alt="alt"/>.</strong>Next',
+    );
+  });
+
   it('preserves protected Markdown syntax inside image descriptions', () => {
     const inlineCode = '![`**终点。**正文`](missing.png)';
 
@@ -256,6 +267,19 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(renderMarkdown(source)).toContain(
       '<a href="https://b.test/**foo.**bar">https://b.test/**foo.**bar</a>',
     );
+  });
+
+  it('classifies image descriptions recovered from CJK-truncated bare URL tails', () => {
+    const source = 'https://example.com/foo（![**重点。**正文](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      'https://example.com/foo<!--cindy-strong-boundary-->（![重点。正文](missing.png)',
+    );
+    const html = renderMarkdown(source);
+    expect(html).toContain(
+      '<a href="https://example.com/foo">https://example.com/foo</a>（<img src="missing.png" alt="重点。正文"/>',
+    );
+    expect(html).not.toContain('cindy-strong-boundary');
   });
 
   it('protects nested bare URLs regenerated inside recovered CJK tails', () => {

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -200,6 +200,13 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(renderMarkdown(inlineCode)).toContain('src="missing.png" alt="**终点。**正文"');
   });
 
+  it('preserves math syntax inside image descriptions', () => {
+    const source = '![$2**3.**x$](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
+    expect(renderMarkdown(source)).toContain('src="missing.png" alt="$2**3.**x$"');
+  });
+
   it('ignores closing brackets inside image-description code spans', () => {
     const source = '![`a]b` **重点。**正文](missing.png)';
 
@@ -248,6 +255,15 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
     expect(renderMarkdown(source)).toContain(
       '<a href="https://b.test/**foo.**bar">https://b.test/**foo.**bar</a>',
+    );
+  });
+
+  it('protects nested bare URLs regenerated inside recovered CJK tails', () => {
+    const source = 'https://a.test/x（https://b.test/y（https://c.test/**path.**more）';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
+    expect(renderMarkdown(source)).toContain(
+      '<a href="https://c.test/**path.**more">https://c.test/**path.**more</a>）',
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -159,6 +159,15 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('protects bare URLs regenerated inside recovered CJK tails', () => {
+    const source = 'https://a.test/x（https://b.test/**foo.**bar';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
+    expect(renderMarkdown(source)).toContain(
+      '<a href="https://b.test/**foo.**bar">https://b.test/**foo.**bar</a>',
+    );
+  });
+
   it('preserves an open strong span across single-star content', () => {
     expect(renderMarkdown('**This is *very* important.**Next')).toContain(
       '<strong>This is <em>very</em> important.</strong>Next',

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -359,6 +359,17 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('handles many paragraphs and preserved TeX ranges in source-line mode', () => {
+    const source = Array.from(
+      { length: 1_000 },
+      (_, index) => `\\[formula_${index}**3.**x\\]\n\n段落 ${index}：**重点。**正文`,
+    ).join('\n\n');
+
+    expect(normalizeStrongDelimiterBoundaries(source, { preserveTexDelimiters: true })).toBe(
+      source.replaceAll('**正文', '**<!--cindy-strong-boundary-->正文'),
+    );
+  });
+
   it('leaves historical bare project deep links unchanged', () => {
     const source = '打开 cindy://project/%2Ftmp%2Ffoo**bar.**baz 查看';
 

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -184,6 +184,15 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('isolates image descriptions from unmatched strong delimiters in surrounding prose', () => {
+    const source = '**outer ![text.**Next](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
+    const html = renderMarkdown(source);
+    expect(html).toContain('alt="text.**Next"');
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
   it('preserves protected Markdown syntax inside image descriptions', () => {
     const inlineCode = '![`**终点。**正文`](missing.png)';
 
@@ -239,6 +248,19 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
     const html = renderMarkdownWithStrictMath(source);
     expect(html).toContain('<code class="language-math math-inline">2**3.**x</code>');
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
+  it('escapes loose math delimiters recovered from CJK-truncated bare URL tails', () => {
+    const source = 'https://example.com/foo（$5 **重点。**正文 $10';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      'https://example.com/foo<!--cindy-strong-boundary-->（\\$5 **重点。**<!--cindy-strong-boundary-->正文 \\$10',
+    );
+    const html = renderMarkdownWithStrictMath(source);
+    expect(html).toContain(
+      '<a href="https://example.com/foo">https://example.com/foo</a>（$5 <strong>重点。</strong>正文 $10',
+    );
     expect(html).not.toContain('cindy-strong-boundary');
   });
 
@@ -375,6 +397,17 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     ).join('\n\n');
 
     expect(normalizeStrongDelimiterBoundaries(source, { preserveTexDelimiters: true })).toBe(
+      source.replaceAll('**正文', '**<!--cindy-strong-boundary-->正文'),
+    );
+  });
+
+  it('handles many loose math spans and strong-boundary repairs without cross-product scans', () => {
+    const source = [
+      ...Array.from({ length: 2_000 }, (_, index) => `$value_${index} $`),
+      ...Array.from({ length: 2_000 }, (_, index) => `段落 ${index}：**重点。**正文`),
+    ].join('\n\n');
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
       source.replaceAll('**正文', '**<!--cindy-strong-boundary-->正文'),
     );
   });

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -47,18 +47,28 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(html).not.toContain('**');
   });
 
-  it('distinguishes non-ASCII symbols from CommonMark punctuation', () => {
+  it('treats Unicode symbols as CommonMark punctuation', () => {
     const emojiAfterBoundary = '**结论。**✅继续';
     const asciiSymbolBeforeBoundary = '**总计 $**Next';
+    const unicodeSymbolBeforeBoundary = '**总计 €**Next';
+    const emojiBeforeBoundary = '**完成 ✅**继续';
 
-    expect(normalizeStrongDelimiterBoundaries(emojiAfterBoundary)).toBe(
-      '**结论。**<!--cindy-strong-boundary-->✅继续',
-    );
+    expect(normalizeStrongDelimiterBoundaries(emojiAfterBoundary)).toBe(emojiAfterBoundary);
     expect(normalizeStrongDelimiterBoundaries(asciiSymbolBeforeBoundary)).toBe(
       '**总计 $**<!--cindy-strong-boundary-->Next',
     );
+    expect(normalizeStrongDelimiterBoundaries(unicodeSymbolBeforeBoundary)).toBe(
+      '**总计 €**<!--cindy-strong-boundary-->Next',
+    );
+    expect(normalizeStrongDelimiterBoundaries(emojiBeforeBoundary)).toBe(
+      '**完成 ✅**<!--cindy-strong-boundary-->继续',
+    );
     expect(renderMarkdown(emojiAfterBoundary)).toContain('<strong>结论。</strong>✅继续');
     expect(renderMarkdown(asciiSymbolBeforeBoundary)).toContain('<strong>总计 $</strong>Next');
+    expect(renderMarkdown(unicodeSymbolBeforeBoundary)).toContain(
+      '<strong>总计 €</strong>Next',
+    );
+    expect(renderMarkdown(emojiBeforeBoundary)).toContain('<strong>完成 ✅</strong>继续');
   });
 
   it('does not rewrite boundaries that CommonMark already closes', () => {
@@ -174,6 +184,13 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('preserves protected Markdown syntax inside image descriptions', () => {
+    const inlineCode = '![`**终点。**正文`](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(inlineCode)).toBe(inlineCode);
+    expect(renderMarkdown(inlineCode)).toContain('src="missing.png" alt="**终点。**正文"');
+  });
+
   it('repairs strong delimiters in CJK prose recovered from a bare URL', () => {
     const source = 'https://example.com/foo（**重点。**正文';
 
@@ -265,6 +282,14 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(normalizeStrongDelimiterBoundaries(prose, { preserveTexDelimiters: true })).toBe(
       '**重点。**<!--cindy-strong-boundary-->正文',
     );
+  });
+
+  it('ignores escaped backslashes when pairing preserved TeX delimiters', () => {
+    const escapedDisplay = '\\\\[ **重点。**正文 \\\\]';
+
+    expect(
+      normalizeStrongDelimiterBoundaries(escapedDisplay, { preserveTexDelimiters: true }),
+    ).toBe('\\\\[ **重点。**<!--cindy-strong-boundary-->正文 \\\\]');
   });
 
   it('ignores preserved TeX delimiters inside protected Markdown syntax', () => {

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -305,6 +305,23 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(html).not.toContain('cindy-strong-boundary');
   });
 
+  it('protects nested Markdown syntax when loose inline math is downgraded to visible text', () => {
+    const codeOnly = '$foo `**重点。**正文` bar$';
+    expect(normalizeStrongDelimiterBoundaries(codeOnly)).toBe(codeOnly);
+    expect(renderMarkdownWithStrictMath(codeOnly)).not.toContain('cindy-strong-boundary');
+
+    const source =
+      '$foo `**代码。**正文` [链接](https://a.test/**path.**next) <span title="**attr.**next">标签</span> **重点。**正文 bar$';
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '\\$foo `**代码。**正文` [链接](https://a.test/**path.**next) <span title="**attr.**next">标签</span> **重点。**<!--cindy-strong-boundary-->正文 bar\\$',
+    );
+    const html = renderMarkdownWithStrictMath(source);
+    expect(html).toContain(
+      '$foo <code>**代码。**正文</code> <a href="https://a.test/**path.**next">链接</a> 标签 <strong>重点。</strong>正文 bar$',
+    );
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
   it('handles many protected spans and ordinary backslashes in source-line mode', () => {
     const protectedSpans = Array.from({ length: 2_000 }, (_, index) => `\`code-${index}\``).join(
       ' ',

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -148,6 +148,32 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('repairs strong delimiters in visible image descriptions without rewriting destinations', () => {
+    const inlineImage = '![**重点。**正文](https://example.test/**path.**next)';
+    const referenceImage = [
+      '![**重点。**正文][target]',
+      '',
+      '[target]: https://example.test/**path.**next',
+    ].join('\n');
+
+    expect(normalizeStrongDelimiterBoundaries(inlineImage)).toBe(
+      '![重点。正文](https://example.test/**path.**next)',
+    );
+    expect(normalizeStrongDelimiterBoundaries(referenceImage)).toBe(
+      [
+        '![重点。正文][target]',
+        '',
+        '[target]: https://example.test/**path.**next',
+      ].join('\n'),
+    );
+    expect(renderMarkdown(inlineImage)).toContain(
+      'src="https://example.test/**path.**next" alt="重点。正文"',
+    );
+    expect(renderMarkdown(referenceImage)).toContain(
+      'src="https://example.test/**path.**next" alt="重点。正文"',
+    );
+  });
+
   it('repairs strong delimiters in CJK prose recovered from a bare URL', () => {
     const source = 'https://example.com/foo（**重点。**正文';
 
@@ -156,6 +182,17 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
     expect(renderMarkdown(source)).toContain(
       '<a href="https://example.com/foo">https://example.com/foo</a>（<strong>重点。</strong>正文',
+    );
+  });
+
+  it('uses source offsets when a recovered bare URL tail follows a character reference', () => {
+    const source = 'https://a.test/x?a=1&amp;b=2（**重点。**正文';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      'https://a.test/x?a=1&amp;b=2<!--cindy-strong-boundary-->（**重点。**<!--cindy-strong-boundary-->正文',
+    );
+    expect(renderMarkdown(source)).toContain(
+      '<a href="https://a.test/x?a=1&amp;amp;b=2">https://a.test/x?a=1&amp;amp;b=2</a>（<strong>重点。</strong>正文',
     );
   });
 
@@ -245,11 +282,39 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     }
   });
 
-  it('preserves loose inline math before the strict math plugin downgrades it to text', () => {
+  it('repairs affected markup when loose inline math is downgraded to text', () => {
     const source = '$2**3.**x $';
 
-    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
-    expect(renderMarkdownWithStrictMath(source)).not.toContain('cindy-strong-boundary');
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '\\$2**3.**<!--cindy-strong-boundary-->x \\$',
+    );
+    const html = renderMarkdownWithStrictMath(source);
+    expect(html).toContain('$2<strong>3.</strong>x $');
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
+  it('repairs strong markup when loose inline math is downgraded to visible text', () => {
+    const source = '$5 **重点。**正文 $10';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '\\$5 **重点。**<!--cindy-strong-boundary-->正文 \\$10',
+    );
+    const html = renderMarkdownWithStrictMath(source);
+    expect(html).toContain('$5 <strong>重点。</strong>正文 $10');
+    expect(html).not.toContain('**');
+    expect(html).not.toContain('cindy-strong-boundary');
+  });
+
+  it('handles many protected spans and ordinary backslashes in source-line mode', () => {
+    const protectedSpans = Array.from({ length: 2_000 }, (_, index) => `\`code-${index}\``).join(
+      ' ',
+    );
+    const ordinaryBackslashes = '\\x '.repeat(2_000);
+    const source = `${protectedSpans} ${ordinaryBackslashes}**重点。**正文`;
+
+    expect(normalizeStrongDelimiterBoundaries(source, { preserveTexDelimiters: true })).toBe(
+      source.replace('**正文', '**<!--cindy-strong-boundary-->正文'),
+    );
   });
 
   it('leaves historical bare project deep links unchanged', () => {

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -2,16 +2,31 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
 import { describe, expect, it } from 'vitest';
 
 import { normalizeMathDelimiters } from '@cindy/maker-shared/math-markdown';
 import { normalizeStrongDelimiterBoundaries } from '@/components/chat/normalizeStrongDelimiterBoundaries';
+import remarkStrictInlineMath from '@/components/chat/remarkStrictInlineMath';
 
 function renderMarkdown(source: string): string {
   return renderToStaticMarkup(
     createElement(
       ReactMarkdown,
       { remarkPlugins: [remarkGfm], skipHtml: true },
+      normalizeStrongDelimiterBoundaries(source),
+    ),
+  );
+}
+
+function renderMarkdownWithStrictMath(source: string): string {
+  return renderToStaticMarkup(
+    createElement(
+      ReactMarkdown,
+      {
+        remarkPlugins: [remarkGfm, remarkMath, remarkStrictInlineMath],
+        skipHtml: true,
+      },
       normalizeStrongDelimiterBoundaries(source),
     ),
   );
@@ -108,6 +123,30 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
   });
 
+  it('repairs strong delimiters in visible link labels without rewriting destinations', () => {
+    const inlineLink = '[**重点。**正文](https://example.test/**path.**next)';
+    const referenceLink = ['[**重点。**正文][target]', '', '[target]: https://example.test'].join(
+      '\n',
+    );
+
+    expect(normalizeStrongDelimiterBoundaries(inlineLink)).toBe(
+      '[**重点。**<!--cindy-strong-boundary-->正文](https://example.test/**path.**next)',
+    );
+    expect(normalizeStrongDelimiterBoundaries(referenceLink)).toBe(
+      [
+        '[**重点。**<!--cindy-strong-boundary-->正文][target]',
+        '',
+        '[target]: https://example.test',
+      ].join('\n'),
+    );
+    expect(renderMarkdown(inlineLink)).toContain(
+      '<a href="https://example.test/**path.**next"><strong>重点。</strong>正文</a>',
+    );
+    expect(renderMarkdown(referenceLink)).toContain(
+      '<a href="https://example.test"><strong>重点。</strong>正文</a>',
+    );
+  });
+
   it('preserves an open strong span across single-star content', () => {
     expect(renderMarkdown('**This is *very* important.**Next')).toContain(
       '<strong>This is <em>very</em> important.</strong>Next',
@@ -131,6 +170,19 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(normalizeStrongDelimiterBoundaries('$2**3.**x$ **重点。**正文')).toBe(
       '$2**3.**x$ **重点。**<!--cindy-strong-boundary-->正文',
     );
+  });
+
+  it('preserves loose inline math before the strict math plugin downgrades it to text', () => {
+    const source = '$2**3.**x $';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
+    expect(renderMarkdownWithStrictMath(source)).not.toContain('cindy-strong-boundary');
+  });
+
+  it('leaves historical bare project deep links unchanged', () => {
+    const source = '打开 cindy://project/%2Ftmp%2Ffoo**bar.**baz 查看';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(source);
   });
 
   it('treats unmatched backticks as prose instead of suppressing later repairs', () => {

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -1,0 +1,65 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeStrongDelimiterBoundaries } from '@/components/chat/normalizeStrongDelimiterBoundaries';
+
+function renderMarkdown(source: string): string {
+  return renderToStaticMarkup(
+    createElement(
+      ReactMarkdown,
+      { remarkPlugins: [remarkGfm], skipHtml: true },
+      normalizeStrongDelimiterBoundaries(source),
+    ),
+  );
+}
+
+describe('normalizeStrongDelimiterBoundaries', () => {
+  it('repairs punctuation-ended strong spans followed immediately by word text', () => {
+    const source = '先看：**"后续不能再卖"——这就是终点站。**从第一轮；**一、设计自由。**即时生效';
+    const normalized = normalizeStrongDelimiterBoundaries(source);
+
+    expect(normalized).toContain('这就是终点站。**<!--cindy-strong-boundary-->从第一轮');
+    expect(normalized).toContain('一、设计自由。**<!--cindy-strong-boundary-->即时生效');
+
+    const html = renderMarkdown(source);
+    expect(html).toContain('<strong>&quot;后续不能再卖&quot;——这就是终点站。</strong>从第一轮');
+    expect(html).toContain('<strong>一、设计自由。</strong>即时生效');
+    expect(html).not.toContain('**');
+  });
+
+  it('does not rewrite boundaries that CommonMark already closes', () => {
+    const cases = [
+      '**终点站**从第一轮',
+      '**终点站。** 从第一轮',
+      '**终点站。**，从第一轮',
+      '**终点站。**',
+      '前文。**重点**从后面继续',
+      '前文。**未闭合',
+    ];
+
+    for (const source of cases) {
+      expect(normalizeStrongDelimiterBoundaries(source), source).toBe(source);
+    }
+  });
+
+  it('leaves escaped, triple-star, inline-code, and fenced-code content unchanged', () => {
+    const cases = [
+      '\\*\\*终点站。\\*\\*从第一轮',
+      '***终点站。***从第一轮',
+      '`**终点站。**从第一轮`',
+      ['```md', '**终点站。**从第一轮', '```'].join('\n'),
+      ['`**终点站。', '**从第一轮`'].join('\n'),
+      ['    **终点站。**从第一轮'].join('\n'),
+    ];
+
+    for (const source of cases) {
+      expect(normalizeStrongDelimiterBoundaries(source), source).toBe(source);
+    }
+
+    expect(renderMarkdown(cases[2])).toContain('<code>**终点站。**从第一轮</code>');
+    expect(renderMarkdown(cases[3])).toContain('**终点站。**从第一轮');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { describe, expect, it } from 'vitest';
 
+import { normalizeMathDelimiters } from '@cindy/maker-shared/math-markdown';
 import { normalizeStrongDelimiterBoundaries } from '@/components/chat/normalizeStrongDelimiterBoundaries';
 
 function renderMarkdown(source: string): string {
@@ -30,6 +31,20 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(html).not.toContain('**');
   });
 
+  it('distinguishes non-ASCII symbols from CommonMark punctuation', () => {
+    const emojiAfterBoundary = '**结论。**✅继续';
+    const asciiSymbolBeforeBoundary = '**总计 $**Next';
+
+    expect(normalizeStrongDelimiterBoundaries(emojiAfterBoundary)).toBe(
+      '**结论。**<!--cindy-strong-boundary-->✅继续',
+    );
+    expect(normalizeStrongDelimiterBoundaries(asciiSymbolBeforeBoundary)).toBe(
+      '**总计 $**<!--cindy-strong-boundary-->Next',
+    );
+    expect(renderMarkdown(emojiAfterBoundary)).toContain('<strong>结论。</strong>✅继续');
+    expect(renderMarkdown(asciiSymbolBeforeBoundary)).toContain('<strong>总计 $</strong>Next');
+  });
+
   it('does not rewrite boundaries that CommonMark already closes', () => {
     const cases = [
       '**终点站**从第一轮',
@@ -51,8 +66,12 @@ describe('normalizeStrongDelimiterBoundaries', () => {
       '***终点站。***从第一轮',
       '`**终点站。**从第一轮`',
       ['```md', '**终点站。**从第一轮', '```'].join('\n'),
+      ['> ```md', '> **终点站。**从第一轮', '> ```'].join('\n'),
+      ['- ```md', '  **终点站。**从第一轮', '  ```'].join('\n'),
       ['`**终点站。', '**从第一轮`'].join('\n'),
       ['    **终点站。**从第一轮'].join('\n'),
+      '>     **终点站。**从第一轮',
+      '-     **终点站。**从第一轮',
     ];
 
     for (const source of cases) {
@@ -61,5 +80,117 @@ describe('normalizeStrongDelimiterBoundaries', () => {
 
     expect(renderMarkdown(cases[2])).toContain('<code>**终点站。**从第一轮</code>');
     expect(renderMarkdown(cases[3])).toContain('**终点站。**从第一轮');
+    expect(renderMarkdown(cases[8])).toContain('<code>**终点站。**从第一轮');
+    expect(renderMarkdown(cases[9])).toContain('<code>**终点站。**从第一轮');
+  });
+
+  it('leaves link and image destinations, reference definitions, and autolinks unchanged', () => {
+    const cases = [
+      '[glob](https://example.test/**index.**html)',
+      '![glob](https://example.test/**index.**html)',
+      ['[glob]: https://example.test/**index.**html', '', '[链接][glob]'].join('\n'),
+      ['[glob]:', '  https://example.test/**index.**html', '', '[链接][glob]'].join('\n'),
+      '<https://example.test/**index.**html>',
+      '**[链接](https://example.test/。**next)',
+    ];
+
+    for (const source of cases) {
+      expect(normalizeStrongDelimiterBoundaries(source), source).toBe(source);
+    }
+
+    expect(renderMarkdown(cases[0])).toContain('href="https://example.test/**index.**html"');
+    expect(renderMarkdown(cases[1])).toContain('src="https://example.test/**index.**html"');
+    expect(renderMarkdown(cases[2])).toContain('href="https://example.test/**index.**html"');
+    expect(renderMarkdown(cases[3])).toContain('href="https://example.test/**index.**html"');
+    expect(renderMarkdown(cases[4])).toContain('href="https://example.test/**index.**html"');
+    expect(renderMarkdown('**查看 [链接](https://example.test/a)。**正文')).toContain(
+      '<strong>查看 <a href="https://example.test/a">链接</a>。</strong>正文',
+    );
+  });
+
+  it('preserves an open strong span across single-star content', () => {
+    expect(renderMarkdown('**This is *very* important.**Next')).toContain(
+      '<strong>This is <em>very</em> important.</strong>Next',
+    );
+    expect(renderMarkdown('**2 * 3.**Next')).toContain('<strong>2 * 3.</strong>Next');
+  });
+
+  it('leaves inline and display math bodies unchanged', () => {
+    const cases = [
+      '$2**3.**x$',
+      ['$$', '2**3.**x', '$$'].join('\n'),
+      '\\(2**3.**x\\)',
+      ['\\[', '2**3.**x', '\\]'].join('\n'),
+    ];
+
+    for (const source of cases) {
+      const normalizedMath = normalizeMathDelimiters(source);
+      expect(normalizeStrongDelimiterBoundaries(normalizedMath), source).toBe(normalizedMath);
+    }
+
+    expect(normalizeStrongDelimiterBoundaries('$2**3.**x$ **重点。**正文')).toBe(
+      '$2**3.**x$ **重点。**<!--cindy-strong-boundary-->正文',
+    );
+  });
+
+  it('treats unmatched backticks as prose instead of suppressing later repairs', () => {
+    const source = ['`unfinished', '**重点。**下一句'].join('\n');
+    const sameLine = '`unfinished **重点。**下一句';
+    const invalidBacktickFence = '```foo``` **重点。**下一句';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      ['`unfinished', '**重点。**<!--cindy-strong-boundary-->下一句'].join('\n'),
+    );
+    expect(normalizeStrongDelimiterBoundaries(sameLine)).toBe(
+      '`unfinished **重点。**<!--cindy-strong-boundary-->下一句',
+    );
+    expect(normalizeStrongDelimiterBoundaries(invalidBacktickFence)).toBe(
+      '```foo``` **重点。**<!--cindy-strong-boundary-->下一句',
+    );
+    expect(renderMarkdown(source)).toContain('<strong>重点。</strong>下一句');
+    expect(renderMarkdown(invalidBacktickFence)).toContain('<strong>重点。</strong>下一句');
+  });
+
+  it('normalizes indented paragraph continuations but not actual indented code blocks', () => {
+    const paragraphContinuation = ['intro', '    **重点。**下一句'].join('\n');
+    const indentedCode = ['', '    **重点。**下一句'].join('\n');
+    const mixedIndentationCode = ['', ' \t**重点。**下一句'].join('\n');
+
+    expect(normalizeStrongDelimiterBoundaries(paragraphContinuation)).toBe(
+      ['intro', '    **重点。**<!--cindy-strong-boundary-->下一句'].join('\n'),
+    );
+    expect(normalizeStrongDelimiterBoundaries(indentedCode)).toBe(indentedCode);
+    expect(normalizeStrongDelimiterBoundaries(mixedIndentationCode)).toBe(mixedIndentationCode);
+    expect(renderMarkdown(paragraphContinuation)).toContain('<strong>重点。</strong>下一句');
+    expect(renderMarkdown(indentedCode)).toContain('<code>**重点。**下一句');
+    expect(renderMarkdown(mixedIndentationCode)).toContain('<code>**重点。**下一句');
+  });
+
+  it('leaves raw HTML regions unchanged without suppressing later prose repairs', () => {
+    const cases = [
+      'prefix <!-- **hidden.**visible --> suffix',
+      '<span data-value="**hidden.**visible">正文</span>',
+      ['<script>', '**hidden.**visible', '</script>'].join('\n'),
+      ['<div>', '**hidden.**visible', '</div>'].join('\n'),
+    ];
+
+    for (const source of cases) {
+      expect(normalizeStrongDelimiterBoundaries(source), source).toBe(source);
+    }
+
+    const followedByProse = ['<!-- **hidden.**visible -->', '', '**重点。**正文'].join('\n');
+    expect(normalizeStrongDelimiterBoundaries(followedByProse)).toBe(
+      ['<!-- **hidden.**visible -->', '', '**重点。**<!--cindy-strong-boundary-->正文'].join('\n'),
+    );
+    expect(renderMarkdown(followedByProse)).toContain('<strong>重点。</strong>正文');
+  });
+
+  it('resets unmatched strong state at Markdown block boundaries', () => {
+    const source = ['**orphan', '# heading', 'x**重点。**正文'].join('\n');
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      ['**orphan', '# heading', 'x**重点。**<!--cindy-strong-boundary-->正文'].join('\n'),
+    );
+    expect(renderMarkdown(source)).toContain('<strong>重点。</strong>正文');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -8,12 +8,13 @@ import { describe, expect, it } from 'vitest';
 import { normalizeMathDelimiters } from '@cindy/maker-shared/math-markdown';
 import { normalizeStrongDelimiterBoundaries } from '@/components/chat/normalizeStrongDelimiterBoundaries';
 import remarkStrictInlineMath from '@/components/chat/remarkStrictInlineMath';
+import remarkTruncateCjkUrls from '@/components/chat/remarkTruncateCjkUrls';
 
 function renderMarkdown(source: string): string {
   return renderToStaticMarkup(
     createElement(
       ReactMarkdown,
-      { remarkPlugins: [remarkGfm], skipHtml: true },
+      { remarkPlugins: [remarkGfm, remarkTruncateCjkUrls], skipHtml: true },
       normalizeStrongDelimiterBoundaries(source),
     ),
   );
@@ -144,6 +145,17 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     );
     expect(renderMarkdown(referenceLink)).toContain(
       '<a href="https://example.test"><strong>重点。</strong>正文</a>',
+    );
+  });
+
+  it('repairs strong delimiters in CJK prose recovered from a bare URL', () => {
+    const source = 'https://example.com/foo（**重点。**正文';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      'https://example.com/foo<!--cindy-strong-boundary-->（**重点。**<!--cindy-strong-boundary-->正文',
+    );
+    expect(renderMarkdown(source)).toContain(
+      '<a href="https://example.com/foo">https://example.com/foo</a>（<strong>重点。</strong>正文',
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -209,6 +209,17 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(renderMarkdown(source)).toContain('src="missing.png" alt="a]b 重点。正文"');
   });
 
+  it('ignores closing brackets inside image-description inline HTML', () => {
+    const source = '![<span title="]">x</span> **重点。**正文](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '![<span title="]">x</span> 重点。正文](missing.png)',
+    );
+    expect(renderMarkdown(source)).toContain(
+      'src="missing.png" alt="&lt;span title=&quot;]&quot;&gt;x&lt;/span&gt; 重点。正文"',
+    );
+  });
+
   it('repairs strong delimiters in CJK prose recovered from a bare URL', () => {
     const source = 'https://example.com/foo（**重点。**正文';
 
@@ -269,6 +280,20 @@ describe('normalizeStrongDelimiterBoundaries', () => {
 
     expect(normalizeStrongDelimiterBoundaries(source)).toBe(
       ['https://example.com/foo（$x$', '', '**重点。**<!--cindy-strong-boundary-->正文'].join('\n'),
+    );
+  });
+
+  it('bounds recovered-tail reparsing to each bare URL', () => {
+    const source = [
+      ...Array.from(
+        { length: 1_000 },
+        (_, index) => `https://example-${index}.com/foo（说明 `,
+      ),
+      '**重点。**正文',
+    ].join('');
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      source.replace('**正文', '**<!--cindy-strong-boundary-->正文'),
     );
   });
 
@@ -406,6 +431,28 @@ describe('normalizeStrongDelimiterBoundaries', () => {
       ...Array.from({ length: 2_000 }, (_, index) => `$value_${index} $`),
       ...Array.from({ length: 2_000 }, (_, index) => `段落 ${index}：**重点。**正文`),
     ].join('\n\n');
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      source.replaceAll('**正文', '**<!--cindy-strong-boundary-->正文'),
+    );
+  });
+
+  it('handles many image descriptions and unrelated repairs without cross-product scans', () => {
+    const source = [
+      ...Array.from({ length: 2_000 }, (_, index) => `![图片 ${index}](missing-${index}.png)`),
+      ...Array.from({ length: 2_000 }, (_, index) => `段落 ${index}：**重点。**正文`),
+    ].join('\n\n');
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      source.replaceAll('**正文', '**<!--cindy-strong-boundary-->正文'),
+    );
+  });
+
+  it('applies many boundary repairs without repeatedly rebuilding the document', () => {
+    const source = Array.from(
+      { length: 5_000 },
+      (_, index) => `段落 ${index}：**重点。**正文`,
+    ).join('\n\n');
 
     expect(normalizeStrongDelimiterBoundaries(source)).toBe(
       source.replaceAll('**正文', '**<!--cindy-strong-boundary-->正文'),

--- a/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownStrongDelimiter.test.ts
@@ -191,6 +191,15 @@ describe('normalizeStrongDelimiterBoundaries', () => {
     expect(renderMarkdown(inlineCode)).toContain('src="missing.png" alt="**终点。**正文"');
   });
 
+  it('ignores closing brackets inside image-description code spans', () => {
+    const source = '![`a]b` **重点。**正文](missing.png)';
+
+    expect(normalizeStrongDelimiterBoundaries(source)).toBe(
+      '![`a]b` 重点。正文](missing.png)',
+    );
+    expect(renderMarkdown(source)).toContain('src="missing.png" alt="a]b 重点。正文"');
+  });
+
   it('repairs strong delimiters in CJK prose recovered from a bare URL', () => {
     const source = 'https://example.com/foo（**重点。**正文';
 

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -1521,6 +1521,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
     () =>
       normalizeStrongDelimiterBoundaries(
         normalizeMathDelimiters(throttledContent, { preserveLineCount: emitSourceLines }),
+        { preserveTexDelimiters: emitSourceLines },
       ),
     [throttledContent, emitSourceLines],
   );

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -29,6 +29,7 @@ import remarkPreserveLocalImagePaths, {
 } from './remarkPreserveLocalImagePaths';
 import remarkSessionLinks from './remarkSessionLinks';
 import { rehypeMathBlockMarker } from './rehypeMathBlockMarker';
+import { normalizeStrongDelimiterBoundaries } from './normalizeStrongDelimiterBoundaries';
 import { CopyAsImageBlock, mathBlockToLatex, tableToTsv } from './CopyAsImageBlock';
 import type { Components, UrlTransform } from 'react-markdown';
 import type { PluggableList } from 'unified';
@@ -1517,7 +1518,10 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   // 号),会插行的 display 保持源码展示。无定界符时函数原样返回原引用,
   // useMemo + react-markdown 缓存不失效。
   const renderedContent = useMemo(
-    () => normalizeMathDelimiters(throttledContent, { preserveLineCount: emitSourceLines }),
+    () =>
+      normalizeStrongDelimiterBoundaries(
+        normalizeMathDelimiters(throttledContent, { preserveLineCount: emitSourceLines }),
+      ),
     [throttledContent, emitSourceLines],
   );
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -218,12 +218,99 @@ function inlineHtmlEnd(markdown: string, start: number, end: number): number | n
   return null;
 }
 
+function uriAutolinkEnd(markdown: string, start: number, end: number): number | null {
+  const closer = markdown.indexOf('>', start + 1);
+  if (closer === -1 || closer >= end) return null;
+  const destination = markdown.slice(start + 1, closer);
+  if (!/^[A-Za-z][A-Za-z\d+.-]{1,31}:/u.test(destination)) return null;
+  const hasForbiddenCharacter = Array.from(destination).some(
+    (character) => character === '<' || character === '>' || character.charCodeAt(0) <= 0x20,
+  );
+  return hasForbiddenCharacter ? null : closer + 1;
+}
+
+function inlineLinkTailEnd(markdown: string, start: number, end: number): number | null {
+  if (markdown[start] !== '(') return null;
+
+  let cursor = start + 1;
+  while (cursor < end && /[ \t\n\r]/u.test(markdown[cursor])) cursor += 1;
+
+  if (markdown[cursor] === '<') {
+    cursor += 1;
+    while (cursor < end) {
+      if (markdown[cursor] === '\n' || markdown[cursor] === '<') return null;
+      if (markdown[cursor] === '\\' && cursor + 1 < end) {
+        cursor += 2;
+        continue;
+      }
+      if (markdown[cursor] === '>') {
+        cursor += 1;
+        break;
+      }
+      cursor += 1;
+    }
+    if (markdown[cursor - 1] !== '>') return null;
+  } else {
+    let nestedParentheses = 0;
+    while (cursor < end) {
+      const character = markdown[cursor];
+      if (character === '\\' && cursor + 1 < end) {
+        cursor += 2;
+        continue;
+      }
+      if (character === '<' || character === '\n' || character === '\r') return null;
+      if (character === '(') {
+        nestedParentheses += 1;
+        cursor += 1;
+        continue;
+      }
+      if (character === ')') {
+        if (nestedParentheses === 0) return cursor + 1;
+        nestedParentheses -= 1;
+        cursor += 1;
+        continue;
+      }
+      if (character === ' ' || character === '\t') {
+        if (nestedParentheses > 0) return null;
+        break;
+      }
+      cursor += 1;
+    }
+  }
+
+  const whitespaceStart = cursor;
+  while (cursor < end && /[ \t\n\r]/u.test(markdown[cursor])) cursor += 1;
+  if (markdown[cursor] === ')') return cursor + 1;
+  if (cursor === whitespaceStart) return null;
+
+  const titleOpener = markdown[cursor];
+  const titleCloser = titleOpener === '(' ? ')' : titleOpener;
+  if (titleOpener !== '"' && titleOpener !== "'" && titleOpener !== '(') return null;
+  cursor += 1;
+  while (cursor < end) {
+    if (markdown[cursor] === '\\' && cursor + 1 < end) {
+      cursor += 2;
+      continue;
+    }
+    if (markdown[cursor] === titleCloser) {
+      cursor += 1;
+      break;
+    }
+    if (markdown[cursor] === '\n' || markdown[cursor] === '\r') return null;
+    cursor += 1;
+  }
+  if (markdown[cursor - 1] !== titleCloser) return null;
+
+  while (cursor < end && /[ \t\n\r]/u.test(markdown[cursor])) cursor += 1;
+  return markdown[cursor] === ')' ? cursor + 1 : null;
+}
+
 function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | null {
   if (node.type !== 'image' && node.type !== 'imageReference') return null;
   const range = nodeRange(node);
   if (!range || markdown.slice(range.start, range.start + 2) !== '![') return null;
 
-  let nestedBrackets = 0;
+  const nestedBracketStarts: number[] = [];
   for (let cursor = range.start + 2; cursor < range.end; cursor += 1) {
     if (isEscaped(markdown, cursor)) continue;
     if (markdown[cursor] === '`') {
@@ -232,17 +319,23 @@ function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | nul
       continue;
     }
     if (markdown[cursor] === '<') {
-      const end = inlineHtmlEnd(markdown, cursor, range.end);
+      const end =
+        uriAutolinkEnd(markdown, cursor, range.end) ??
+        inlineHtmlEnd(markdown, cursor, range.end);
       if (end != null) cursor = end - 1;
       continue;
     }
     if (markdown[cursor] === '[') {
-      nestedBrackets += 1;
+      nestedBracketStarts.push(cursor);
       continue;
     }
     if (markdown[cursor] !== ']') continue;
-    if (nestedBrackets > 0) {
-      nestedBrackets -= 1;
+    if (nestedBracketStarts.length > 0) {
+      nestedBracketStarts.pop();
+      if (nestedBracketStarts.length === 0) {
+        const linkEnd = inlineLinkTailEnd(markdown, cursor + 1, range.end);
+        if (linkEnd != null) cursor = linkEnd - 1;
+      }
       continue;
     }
     return { start: range.start + 2, end: cursor };
@@ -552,81 +645,63 @@ function rangeContainsAnyOffset(range: OffsetRange, sortedOffsets: number[]): bo
   return offsetIndex < sortedOffsets.length && sortedOffsets[offsetIndex] < range.end;
 }
 
-function findUnprotectedDelimiter(
-  markdown: string,
-  delimiter: string,
-  start: number,
-  protectedRanges: OffsetRange[],
-): number {
-  let scan = start;
-
-  while (scan < markdown.length) {
-    const offset = markdown.indexOf(delimiter, scan);
-    if (offset === -1) return -1;
-    const rangeIndex = firstRangeEndingAfter(protectedRanges, offset);
-    const protectedRange = protectedRanges[rangeIndex];
-    if (!protectedRange || offset < protectedRange.start) return offset;
-    scan = protectedRange.end;
-  }
-
-  return -1;
-}
-
-function findUnescapedUnprotectedDelimiter(
-  markdown: string,
-  delimiter: string,
-  start: number,
-  protectedRanges: OffsetRange[],
-): number {
-  let scan = start;
-
-  while (scan < markdown.length) {
-    const offset = findUnprotectedDelimiter(markdown, delimiter, scan, protectedRanges);
-    if (offset === -1 || !isEscaped(markdown, offset)) return offset;
-    scan = offset + 1;
-  }
-
-  return -1;
-}
-
 function collectPreservedTexDelimiterRanges(
   markdown: string,
   protectedRanges: OffsetRange[],
 ): OffsetRange[] {
   const ranges: OffsetRange[] = [];
+  const openers: Array<{ offset: number; kind: '(' | '[' }> = [];
+  const parenClosers: number[] = [];
+  const bracketClosers: number[] = [];
   let scan = 0;
   let noParenCloser = false;
   let noBracketCloser = false;
 
+  // 每段连续反斜杠只检查最后一个字符一次。奇数长度时最后一个反斜杠
+  // 未被转义，偶数长度时被转义，避免对同一长序列反复向前计数。
   while (scan < markdown.length) {
-    const open = findUnescapedUnprotectedDelimiter(markdown, '\\', scan, protectedRanges);
-    if (open === -1 || open + 1 >= markdown.length) break;
-    const kind = markdown[open + 1];
-    if (kind !== '(' && kind !== '[') {
-      scan = open + 1;
+    if (markdown[scan] !== '\\') {
+      scan += 1;
       continue;
     }
 
-    const isDisplay = kind === '[';
-    if (isDisplay ? noBracketCloser : noParenCloser) {
-      scan = open + 2;
+    const runStart = scan;
+    while (scan < markdown.length && markdown[scan] === '\\') scan += 1;
+    if ((scan - runStart) % 2 === 0 || scan >= markdown.length) continue;
+
+    const delimiterOffset = scan - 1;
+    const protectedRange =
+      protectedRanges[firstRangeEndingAfter(protectedRanges, delimiterOffset)];
+    if (
+      protectedRange &&
+      protectedRange.start <= delimiterOffset &&
+      delimiterOffset < protectedRange.end
+    ) {
       continue;
     }
-    const closer = kind === '[' ? '\\]' : '\\)';
-    const close = findUnescapedUnprotectedDelimiter(
-      markdown,
-      closer,
-      open + 2,
-      protectedRanges,
-    );
+
+    const kind = markdown[scan];
+    if (kind === '(' || kind === '[') openers.push({ offset: delimiterOffset, kind });
+    else if (kind === ')') parenClosers.push(delimiterOffset);
+    else if (kind === ']') bracketClosers.push(delimiterOffset);
+  }
+
+  scan = 0;
+  for (const opener of openers) {
+    if (opener.offset < scan) continue;
+    const isDisplay = opener.kind === '[';
+    if (isDisplay ? noBracketCloser : noParenCloser) continue;
+
+    const closers = isDisplay ? bracketClosers : parenClosers;
+    const closerIndex = firstOffsetAtOrAfter(closers, opener.offset + 2);
+    const close = closers[closerIndex] ?? -1;
     if (close === -1) {
       if (isDisplay) noBracketCloser = true;
       else noParenCloser = true;
-      scan = open + 2;
       continue;
     }
 
-    ranges.push({ start: open, end: close + 2 });
+    ranges.push({ start: opener.offset, end: close + 2 });
     scan = close + 2;
   }
 

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -138,6 +138,53 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
   for (const child of node.children as Nodes[]) collectProtectedRanges(child, ranges, markdown);
 }
 
+function collectRecoveredTailLinkRanges(node: Nodes, ranges: OffsetRange[], markdown: string): void {
+  if (!('children' in node)) return;
+  const children = node.children as Nodes[];
+
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index];
+    const range = nodeRange(child);
+    const recoveredTail = range ? recoveredAutolinkTailRange(child, range, markdown) : null;
+
+    if (recoveredTail) {
+      let cursor = recoveredTail.start;
+      for (
+        let tailIndex = index + 1;
+        tailIndex < children.length && cursor < recoveredTail.end;
+        tailIndex += 1
+      ) {
+        const tailNode = children[tailIndex];
+        if (nodeRange(tailNode)) break;
+
+        let value: string | null = null;
+        let isLink = false;
+        if (tailNode.type === 'text') {
+          value = tailNode.value;
+        } else if (tailNode.type === 'link') {
+          const onlyChild = tailNode.children.length === 1 ? tailNode.children[0] : null;
+          if (onlyChild?.type === 'text' && onlyChild.value === tailNode.url) {
+            value = onlyChild.value;
+            isLink = true;
+          }
+        }
+
+        if (
+          value === null ||
+          cursor + value.length > recoveredTail.end ||
+          !markdown.startsWith(value, cursor)
+        ) {
+          break;
+        }
+        if (isLink) ranges.push({ start: cursor, end: cursor + value.length });
+        cursor += value.length;
+      }
+    }
+
+    collectRecoveredTailLinkRanges(child, ranges, markdown);
+  }
+}
+
 function collectProjectDeepLinkRanges(markdown: string, range: OffsetRange): OffsetRange[] {
   const ranges: OffsetRange[] = [];
   const source = markdown.slice(range.start, range.end);
@@ -211,6 +258,9 @@ function collectProseRanges(
     if (!range) return;
     const protectedRanges: OffsetRange[] = [];
     collectProtectedRanges(node, protectedRanges, markdown);
+    // remarkTruncateCjkUrls 会把被首个裸链接误吞的尾段重新拆成文本和链接，
+    // 这些新链接没有源码位置，需要按尾段中的实际字符位置补回保护范围。
+    collectRecoveredTailLinkRanges(node, protectedRanges, markdown);
     protectedRanges.push(...collectProjectDeepLinkRanges(markdown, range));
     protectedRanges.push(
       ...preservedTexDelimiterRanges.filter(

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -50,6 +50,14 @@ interface OffsetRange {
   end: number;
 }
 
+interface NormalizeStrongDelimiterBoundariesOptions {
+  /**
+   * 保护因行号对齐而保留源码形态的 `\[...\]` 与跨行 `\(...\)`。
+   * 普通渲染会先把它们转换成 remark-math 可识别的美元符号定界符。
+   */
+  preserveTexDelimiters?: boolean;
+}
+
 function classifyCharacter(character: string | undefined): 'whitespace' | 'punctuation' | 'other' {
   if (!character || UNICODE_WHITESPACE_RE.test(character)) return 'whitespace';
   if (UNICODE_PUNCTUATION_RE.test(character)) return 'punctuation';
@@ -146,9 +154,46 @@ function collectProjectDeepLinkRanges(markdown: string, range: OffsetRange): Off
   return ranges;
 }
 
+function collectPreservedTexDelimiterRanges(markdown: string): OffsetRange[] {
+  const ranges: OffsetRange[] = [];
+  let scan = 0;
+  let noParenCloser = false;
+  let noBracketCloser = false;
+
+  while (scan < markdown.length) {
+    const open = markdown.indexOf('\\', scan);
+    if (open === -1 || open + 1 >= markdown.length) break;
+    const kind = markdown[open + 1];
+    if (kind !== '(' && kind !== '[') {
+      scan = open + 1;
+      continue;
+    }
+
+    const isDisplay = kind === '[';
+    if (isDisplay ? noBracketCloser : noParenCloser) {
+      scan = open + 2;
+      continue;
+    }
+    const closer = kind === '[' ? '\\]' : '\\)';
+    const close = markdown.indexOf(closer, open + 2);
+    if (close === -1) {
+      if (isDisplay) noBracketCloser = true;
+      else noParenCloser = true;
+      scan = open + 2;
+      continue;
+    }
+
+    ranges.push({ start: open, end: close + 2 });
+    scan = close + 2;
+  }
+
+  return ranges;
+}
+
 function collectProseRanges(
   tree: Root,
   markdown: string,
+  preservedTexDelimiterRanges: OffsetRange[],
 ): Array<{
   range: OffsetRange;
   protectedRanges: OffsetRange[];
@@ -167,6 +212,11 @@ function collectProseRanges(
     const protectedRanges: OffsetRange[] = [];
     collectProtectedRanges(node, protectedRanges, markdown);
     protectedRanges.push(...collectProjectDeepLinkRanges(markdown, range));
+    protectedRanges.push(
+      ...preservedTexDelimiterRanges.filter(
+        (protectedRange) => protectedRange.start < range.end && protectedRange.end > range.start,
+      ),
+    );
     protectedRanges.sort((left, right) => left.start - right.start);
     proseRanges.push({ range, protectedRanges });
   });
@@ -253,11 +303,21 @@ function collectBoundaryInsertions(
  * 让“以标点结束、后面紧接正文”的加粗片段能被解析，同时不改变可见
  * 消息、链接、公式、原始 HTML 和代码示例。
  */
-export function normalizeStrongDelimiterBoundaries(markdown: string): string {
+export function normalizeStrongDelimiterBoundaries(
+  markdown: string,
+  options: NormalizeStrongDelimiterBoundariesOptions = {},
+): string {
   if (!markdown.includes('**') || !POTENTIAL_BOUNDARY_RE.test(markdown)) return markdown;
 
   const tree = markdownParser.runSync(markdownParser.parse(markdown), markdown) as Root;
-  const boundaryInsertions = collectProseRanges(tree, markdown).flatMap(({ range, protectedRanges }) =>
+  const preservedTexDelimiterRanges = options.preserveTexDelimiters
+    ? collectPreservedTexDelimiterRanges(markdown)
+    : [];
+  const boundaryInsertions = collectProseRanges(
+    tree,
+    markdown,
+    preservedTexDelimiterRanges,
+  ).flatMap(({ range, protectedRanges }) =>
     collectBoundaryInsertions(markdown, range, protectedRanges),
   );
   if (boundaryInsertions.length === 0) return markdown;

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -347,17 +347,48 @@ function collectRecoveredTailLinkRanges(node: Nodes, ranges: OffsetRange[], mark
   }
 }
 
+function expandedRecoveredTailRange(
+  siblings: Nodes[],
+  childIndex: number,
+  recoveredTail: OffsetRange,
+  markdown: string,
+): OffsetRange {
+  let cursor = recoveredTail.start;
+
+  for (let index = childIndex + 1; index < siblings.length; index += 1) {
+    const sibling = siblings[index];
+    let value: string | null = null;
+    if (sibling.type === 'text') {
+      value = sibling.value;
+    } else if (sibling.type === 'link') {
+      const onlyChild = sibling.children.length === 1 ? sibling.children[0] : null;
+      if (onlyChild?.type === 'text' && onlyChild.value === sibling.url) value = onlyChild.value;
+    }
+
+    if (value === null || !markdown.startsWith(value, cursor)) break;
+    cursor += value.length;
+  }
+
+  return { start: recoveredTail.start, end: Math.max(recoveredTail.end, cursor) };
+}
+
 function collectRecoveredTailSyntaxRanges(
   node: Nodes,
   ranges: OffsetRange[],
   mathTailStarts: number[],
+  looseMathRanges: OffsetRange[],
   markdown: string,
 ): void {
   if (!('children' in node)) return;
 
-  for (const child of node.children as Nodes[]) {
+  const children = node.children as Nodes[];
+  for (let childIndex = 0; childIndex < children.length; childIndex += 1) {
+    const child = children[childIndex];
     const range = nodeRange(child);
-    const recoveredTail = range ? recoveredAutolinkTailRange(child, range, markdown) : null;
+    const initialRecoveredTail = range ? recoveredAutolinkTailRange(child, range, markdown) : null;
+    const recoveredTail = initialRecoveredTail
+      ? expandedRecoveredTailRange(children, childIndex, initialRecoveredTail, markdown)
+      : null;
 
     if (recoveredTail) {
       const tail = markdown.slice(recoveredTail.start, recoveredTail.end);
@@ -367,12 +398,15 @@ function collectRecoveredTailSyntaxRanges(
       visit(tailTree, (tailNode) => {
         if (tailNode.type !== 'inlineMath' && tailNode.type !== 'math') return;
         const tailNodeRange = nodeRange(tailNode);
-        if (
-          tailNodeRange &&
-          POTENTIAL_BOUNDARY_RE.test(tail.slice(tailNodeRange.start, tailNodeRange.end))
-        ) {
-          mathTailStarts.push(recoveredTail.start);
+        if (!tailNodeRange) return;
+        if (tailNode.type === 'inlineMath' && isLooseInlineMath(tailNode, tail)) {
+          looseMathRanges.push({
+            start: recoveredTail.start + tailNodeRange.start,
+            end: recoveredTail.start + tailNodeRange.end,
+          });
         }
+        if (!POTENTIAL_BOUNDARY_RE.test(tail.slice(tailNodeRange.start, tailNodeRange.end))) return;
+        mathTailStarts.push(recoveredTail.start);
       });
       ranges.push(
         ...tailRanges.map((tailRange) => ({
@@ -382,7 +416,7 @@ function collectRecoveredTailSyntaxRanges(
       );
     }
 
-    collectRecoveredTailSyntaxRanges(child, ranges, mathTailStarts, markdown);
+    collectRecoveredTailSyntaxRanges(child, ranges, mathTailStarts, looseMathRanges, markdown);
   }
 }
 
@@ -519,11 +553,13 @@ function collectProseRanges(
   range: OffsetRange;
   protectedRanges: OffsetRange[];
   recoveredMathTailStarts: number[];
+  recoveredLooseMathRanges: OffsetRange[];
 }> {
   const proseRanges: Array<{
     range: OffsetRange;
     protectedRanges: OffsetRange[];
     recoveredMathTailStarts: number[];
+    recoveredLooseMathRanges: OffsetRange[];
   }> = [];
 
   visit(tree, (node, _index, parent) => {
@@ -537,11 +573,18 @@ function collectProseRanges(
     if (!range) return;
     const protectedRanges: OffsetRange[] = [];
     const recoveredMathTailStarts: number[] = [];
+    const recoveredLooseMathRanges: OffsetRange[] = [];
     collectProtectedRanges(node, protectedRanges, markdown);
     // remarkTruncateCjkUrls 会把被首个裸链接误吞的尾段重新拆成文本和链接，
     // 尾段的 Markdown 语法没有原始解析节点，需要重新解析后补回保护范围；
     // 插件新生成的链接没有源码位置，再按实际字符位置补回其范围。
-    collectRecoveredTailSyntaxRanges(node, protectedRanges, recoveredMathTailStarts, markdown);
+    collectRecoveredTailSyntaxRanges(
+      node,
+      protectedRanges,
+      recoveredMathTailStarts,
+      recoveredLooseMathRanges,
+      markdown,
+    );
     collectRecoveredTailLinkRanges(node, protectedRanges, markdown);
     protectedRanges.push(...collectProjectDeepLinkRanges(markdown, range));
     // 保留的 TeX 区间按源码顺序收集。先定位首个可能重叠的区间，再只遍历
@@ -562,6 +605,7 @@ function collectProseRanges(
       range,
       protectedRanges: mergeOffsetRanges(protectedRanges),
       recoveredMathTailStarts,
+      recoveredLooseMathRanges,
     });
   });
 
@@ -592,28 +636,40 @@ function collectLooseMathDelimiterOffsets(
   tree: Root,
   markdown: string,
   boundaryRepairs: BoundaryRepair[],
+  recoveredLooseMathRanges: OffsetRange[],
 ): number[] {
   const offsets: number[] = [];
+  const looseMathRanges = [...recoveredLooseMathRanges];
   visit(tree, 'inlineMath', (node) => {
     if (!isLooseInlineMath(node, markdown)) return;
     const range = nodeRange(node);
-    if (
-      !range ||
-      !boundaryRepairs.some(
-        (repair) =>
-          repair.separatorOffset > range.start && repair.separatorOffset < range.end,
-      )
-    ) {
-      return;
+    if (range) looseMathRanges.push(range);
+  });
+
+  const repairOffsets = boundaryRepairs
+    .map((repair) => repair.separatorOffset)
+    .sort((left, right) => left - right);
+  for (const range of looseMathRanges) {
+    let low = 0;
+    let high = repairOffsets.length;
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2);
+      if (repairOffsets[middle] <= range.start) low = middle + 1;
+      else high = middle;
     }
+    if (low >= repairOffsets.length || repairOffsets[low] >= range.end) continue;
 
     for (let cursor = range.start; cursor < range.end && markdown[cursor] === '$'; cursor += 1) {
       offsets.push(cursor);
     }
-    for (let cursor = range.end - 1; cursor >= range.start && markdown[cursor] === '$'; cursor -= 1) {
+    for (
+      let cursor = range.end - 1;
+      cursor >= range.start && markdown[cursor] === '$';
+      cursor -= 1
+    ) {
       offsets.push(cursor);
     }
-  });
+  }
   return offsets;
 }
 
@@ -621,13 +677,26 @@ function collectBoundaryRepairs(
   markdown: string,
   range: OffsetRange,
   protectedRanges: OffsetRange[],
+  isolatedRanges: OffsetRange[],
 ): BoundaryRepair[] {
   const repairs: BoundaryRepair[] = [];
   let cursor = range.start;
   const openStrongStarts: number[] = [];
   let protectedIndex = 0;
+  let isolatedIndex = firstRangeEndingAfter(isolatedRanges, range.start);
 
   while (cursor < range.end) {
+    const isolatedRange = isolatedRanges[isolatedIndex];
+    if (isolatedRange && cursor >= isolatedRange.end) {
+      openStrongStarts.length = 0;
+      isolatedIndex += 1;
+      continue;
+    }
+    if (isolatedRange && cursor === isolatedRange.start) {
+      // 图片说明的加粗标记只在说明内部配对，不能继承外层正文的未闭合状态。
+      openStrongStarts.length = 0;
+    }
+
     const protectedRange = protectedRanges[protectedIndex];
     if (protectedRange && cursor >= protectedRange.end) {
       protectedIndex += 1;
@@ -707,12 +776,16 @@ export function normalizeStrongDelimiterBoundaries(
     );
   }
   const proseRanges = collectProseRanges(tree, markdown, preservedTexDelimiterRanges);
+  const imageDescriptionRanges = collectImageDescriptionRanges(tree, markdown);
   const boundaryRepairs = proseRanges.flatMap(({ range, protectedRanges }) =>
-    collectBoundaryRepairs(markdown, range, protectedRanges),
+    collectBoundaryRepairs(markdown, range, protectedRanges, imageDescriptionRanges),
   );
   const boundaryInsertions = boundaryRepairs.map((repair) => repair.separatorOffset);
   const recoveredMathTailStarts = proseRanges.flatMap(
     ({ recoveredMathTailStarts: starts }) => starts,
+  );
+  const recoveredLooseMathRanges = proseRanges.flatMap(
+    ({ recoveredLooseMathRanges: ranges }) => ranges,
   );
   if (boundaryInsertions.length === 0 && recoveredMathTailStarts.length === 0) return markdown;
 
@@ -731,8 +804,8 @@ export function normalizeStrongDelimiterBoundaries(
     tree,
     markdown,
     boundaryRepairs,
+    recoveredLooseMathRanges,
   );
-  const imageDescriptionRanges = collectImageDescriptionRanges(tree, markdown);
   const imageRepairs = boundaryRepairs.filter((repair) =>
     imageDescriptionRanges.some(
       (range) =>

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -1,0 +1,178 @@
+/**
+ * 放宽 AI 常见的中文加粗写法。
+ *
+ * CommonMark 的双星号收尾规则要求：如果加粗内容以标点结束、而右侧
+ * 双星号后面紧接普通字符，这组双星号只能被识别为“开始”而不能被识别为
+ * “结束”。例如 `**重点。**下一句` 会整段按原文显示。
+ *
+ * 这里不改用户看到的文字，只在这类已经存在未闭合加粗起点的收尾后插入
+ * 一个会被 MarkdownRenderer 的 `skipHtml` 丢弃的 HTML 注释。代码块、行内
+ * 代码、转义星号和三颗以上的星号序列保持原样。
+ */
+
+const HIDDEN_SEPARATOR = '<!--cindy-strong-boundary-->';
+const UNICODE_WHITESPACE_RE = /^\s$/u;
+const UNICODE_PUNCTUATION_RE = /^[\p{P}\p{S}]$/u;
+
+interface NormalizationState {
+  fencedCode: { marker: '`' | '~'; length: number } | null;
+  inlineCodeLength: number | null;
+  openStrongCount: number;
+}
+
+function classifyCharacter(character: string | undefined): 'whitespace' | 'punctuation' | 'other' {
+  if (!character || UNICODE_WHITESPACE_RE.test(character)) return 'whitespace';
+  if (UNICODE_PUNCTUATION_RE.test(character)) return 'punctuation';
+  return 'other';
+}
+
+function characterBefore(text: string, index: number): string | undefined {
+  if (index === 0) return undefined;
+  const characters = Array.from(text.slice(Math.max(0, index - 2), index));
+  return characters.length > 0 ? characters[characters.length - 1] : undefined;
+}
+
+function characterAfter(text: string, index: number): string | undefined {
+  const codePoint = text.codePointAt(index);
+  return codePoint === undefined ? undefined : String.fromCodePoint(codePoint);
+}
+
+function isEscaped(text: string, index: number): boolean {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function isFenceStart(line: string): { marker: '`' | '~'; length: number } | null {
+  const match = line.match(/^ {0,3}([`~]{3,})/);
+  if (!match) return null;
+  const run = match[1];
+  if (!run || run.split('').some((character) => character !== run[0])) return null;
+  return { marker: run[0] as '`' | '~', length: run.length };
+}
+
+function isFenceEnd(line: string, fence: NonNullable<NormalizationState['fencedCode']>): boolean {
+  const match = line.match(/^ {0,3}([`~]+)[ \t]*$/);
+  if (!match || match[1][0] !== fence.marker) return false;
+  return match[1].length >= fence.length;
+}
+
+function normalizeInlineLine(line: string, state: NormalizationState): string {
+  let output = '';
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    const character = line[cursor];
+
+    if (character === '`') {
+      let runEnd = cursor + 1;
+      while (runEnd < line.length && line[runEnd] === '`') runEnd += 1;
+      const runLength = runEnd - cursor;
+
+      if (state.inlineCodeLength === null) {
+        if (!isEscaped(line, cursor)) state.inlineCodeLength = runLength;
+      } else if (state.inlineCodeLength === runLength) {
+        state.inlineCodeLength = null;
+      }
+
+      output += line.slice(cursor, runEnd);
+      cursor = runEnd;
+      continue;
+    }
+
+    if (state.inlineCodeLength !== null || character !== '*') {
+      output += character;
+      cursor += 1;
+      continue;
+    }
+
+    let runEnd = cursor + 1;
+    while (runEnd < line.length && line[runEnd] === '*') runEnd += 1;
+    const runLength = runEnd - cursor;
+
+    // `***` 及更长序列使用另一套配对规则。这里不猜测其意图，同时清掉
+    // 当前配对状态，避免后续双星号跨过不支持的序列发生误配。
+    if (runLength !== 2 || isEscaped(line, cursor)) {
+      output += line.slice(cursor, runEnd);
+      state.openStrongCount = 0;
+      cursor = runEnd;
+      continue;
+    }
+
+    const before = classifyCharacter(characterBefore(line, cursor));
+    const after = classifyCharacter(characterAfter(line, runEnd));
+    const canOpen = after !== 'whitespace' && (after !== 'punctuation' || before !== 'other');
+    const canClose = before !== 'whitespace' && (before !== 'punctuation' || after !== 'other');
+
+    if (canClose && state.openStrongCount > 0) {
+      state.openStrongCount -= 1;
+      output += '**';
+    } else if (before === 'punctuation' && after === 'other' && state.openStrongCount > 0) {
+      // CommonMark 因右侧紧接普通字符而把它视为起点；前面尚未配对的
+      // `**` 表明这其实是 AI 句子想表达的收尾。
+      state.openStrongCount -= 1;
+      output += `**${HIDDEN_SEPARATOR}`;
+    } else {
+      if (canOpen) state.openStrongCount += 1;
+      output += '**';
+    }
+
+    cursor = runEnd;
+  }
+
+  return output;
+}
+
+/**
+ * 让“以标点结束、后面紧接正文”的加粗片段能被解析，同时不改变可见
+ * 消息和代码示例。
+ */
+export function normalizeStrongDelimiterBoundaries(markdown: string): string {
+  if (!markdown.includes('**')) return markdown;
+
+  const state: NormalizationState = {
+    fencedCode: null,
+    inlineCodeLength: null,
+    openStrongCount: 0,
+  };
+  const parts = markdown.split(/(\r\n|\n|\r)/);
+  let output = '';
+
+  for (const part of parts) {
+    if (/^(?:\r\n|\n|\r)$/.test(part)) {
+      output += part;
+      continue;
+    }
+
+    if (state.fencedCode) {
+      output += part;
+      if (isFenceEnd(part, state.fencedCode)) {
+        state.fencedCode = null;
+        state.inlineCodeLength = null;
+        state.openStrongCount = 0;
+      }
+      continue;
+    }
+
+    if (part.trim() === '' || /^(?: {4}|\t)/.test(part)) {
+      output += part;
+      state.inlineCodeLength = null;
+      state.openStrongCount = 0;
+      continue;
+    }
+
+    const fence = state.inlineCodeLength === null ? isFenceStart(part) : null;
+    if (fence) {
+      output += part;
+      state.fencedCode = fence;
+      state.openStrongCount = 0;
+      continue;
+    }
+
+    output += normalizeInlineLine(part, state);
+  }
+
+  return output;
+}

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -5,7 +5,7 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 
-import remarkStrictInlineMath from './remarkStrictInlineMath';
+import { parseProjectDeepLinkHref, PROJECT_DEEP_LINK_RE_SOURCE } from '@/lib/deepLink';
 
 /**
  * 放宽 AI 常见的中文加粗写法。
@@ -16,8 +16,8 @@ import remarkStrictInlineMath from './remarkStrictInlineMath';
  *
  * 这里不改用户看到的文字，只在这类已经存在未闭合加粗起点的收尾后插入
  * 一个会被 MarkdownRenderer 的 `skipHtml` 丢弃的 HTML 注释。解析树用于
- * 限定正文段落并排除代码、公式、链接和原始 HTML，避免字符扫描改写这些
- * 语法区域。
+ * 限定正文段落并排除代码、公式、链接地址和原始 HTML，避免字符扫描改写
+ * 这些语法区域。
  */
 
 const HIDDEN_SEPARATOR = '<!--cindy-strong-boundary-->';
@@ -36,15 +36,12 @@ const PROTECTED_NODE_TYPES = new Set<Nodes['type']>([
   'imageReference',
   'inlineCode',
   'inlineMath',
-  'link',
-  'linkReference',
   'math',
 ]);
 const markdownParser = unified()
   .use(remarkParse)
   .use(remarkGfm, { singleTilde: false })
-  .use(remarkMath)
-  .use(remarkStrictInlineMath);
+  .use(remarkMath);
 
 interface OffsetRange {
   start: number;
@@ -82,7 +79,29 @@ function nodeRange(node: Nodes): OffsetRange | null {
   return start == null || end == null ? null : { start, end };
 }
 
-function collectProtectedRanges(node: Nodes, ranges: OffsetRange[]): void {
+function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: string): void {
+  if (node.type === 'link' || node.type === 'linkReference') {
+    const range = nodeRange(node);
+    if (range && markdown[range.start] !== '[') {
+      ranges.push(range);
+      return;
+    }
+    const childRanges = node.children
+      .map((child) => nodeRange(child))
+      .filter((childRange): childRange is OffsetRange => childRange !== null);
+    if (!range || childRanges.length === 0) {
+      if (range) ranges.push(range);
+      return;
+    }
+
+    // 链接文字是可见正文，需要继续扫描；只保护两侧的 Markdown 链接语法
+    // 和地址，避免在目标地址内插入隐藏分隔符。
+    ranges.push({ start: range.start, end: childRanges[0].start });
+    ranges.push({ start: childRanges[childRanges.length - 1].end, end: range.end });
+    for (const child of node.children) collectProtectedRanges(child, ranges, markdown);
+    return;
+  }
+
   if (PROTECTED_NODE_TYPES.has(node.type)) {
     const range = nodeRange(node);
     if (range) ranges.push(range);
@@ -90,10 +109,29 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[]): void {
   }
 
   if (!('children' in node)) return;
-  for (const child of node.children as Nodes[]) collectProtectedRanges(child, ranges);
+  for (const child of node.children as Nodes[]) collectProtectedRanges(child, ranges, markdown);
 }
 
-function collectProseRanges(tree: Root): Array<{
+function collectProjectDeepLinkRanges(markdown: string, range: OffsetRange): OffsetRange[] {
+  const ranges: OffsetRange[] = [];
+  const source = markdown.slice(range.start, range.end);
+  const projectLinkPattern = new RegExp(PROJECT_DEEP_LINK_RE_SOURCE, 'g');
+  let match: RegExpExecArray | null;
+
+  while ((match = projectLinkPattern.exec(source)) !== null) {
+    const value = match[0].replace(/[.,;:!?]+$/, '');
+    if (!parseProjectDeepLinkHref(value)) continue;
+    const start = range.start + match.index;
+    ranges.push({ start, end: start + value.length });
+  }
+
+  return ranges;
+}
+
+function collectProseRanges(
+  tree: Root,
+  markdown: string,
+): Array<{
   range: OffsetRange;
   protectedRanges: OffsetRange[];
 }> {
@@ -109,7 +147,8 @@ function collectProseRanges(tree: Root): Array<{
     const range = nodeRange(node);
     if (!range) return;
     const protectedRanges: OffsetRange[] = [];
-    collectProtectedRanges(node, protectedRanges);
+    collectProtectedRanges(node, protectedRanges, markdown);
+    protectedRanges.push(...collectProjectDeepLinkRanges(markdown, range));
     protectedRanges.sort((left, right) => left.start - right.start);
     proseRanges.push({ range, protectedRanges });
   });
@@ -188,8 +227,8 @@ function collectBoundaryInsertions(
 export function normalizeStrongDelimiterBoundaries(markdown: string): string {
   if (!markdown.includes('**') || !POTENTIAL_BOUNDARY_RE.test(markdown)) return markdown;
 
-  const tree = markdownParser.runSync(markdownParser.parse(markdown), markdown);
-  const insertions = collectProseRanges(tree).flatMap(({ range, protectedRanges }) =>
+  const tree = markdownParser.runSync(markdownParser.parse(markdown), markdown) as Root;
+  const insertions = collectProseRanges(tree, markdown).flatMap(({ range, protectedRanges }) =>
     collectBoundaryInsertions(markdown, range, protectedRanges),
   );
   if (insertions.length === 0) return markdown;

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -312,10 +312,21 @@ function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | nul
 
   const nestedBracketStarts: number[] = [];
   for (let cursor = range.start + 2; cursor < range.end; cursor += 1) {
-    if (isEscaped(markdown, cursor)) continue;
+    if (markdown[cursor] === '\\') {
+      const runStart = cursor;
+      while (cursor + 1 < range.end && markdown[cursor + 1] === '\\') cursor += 1;
+      // 奇数个反斜杠会转义紧随其后的字符；偶数个反斜杠则让下一字符
+      // 保持语法含义。整段一次消费，避免逐字符反向重复计数。
+      if ((cursor - runStart + 1) % 2 === 1 && cursor + 1 < range.end) cursor += 1;
+      continue;
+    }
     if (markdown[cursor] === '`') {
+      let openerEnd = cursor + 1;
+      while (openerEnd < range.end && markdown[openerEnd] === '`') openerEnd += 1;
       const end = codeSpanEnd(markdown, cursor, range.end);
-      if (end != null) cursor = end - 1;
+      // 未闭合时也一次跳过整个起始序列，避免从序列中的每个反引号
+      // 重新扫描剩余说明。
+      cursor = (end ?? openerEnd) - 1;
       continue;
     }
     if (markdown[cursor] === '<') {
@@ -354,7 +365,12 @@ function isLooseInlineMath(node: Nodes, markdown: string): boolean {
   return /^\s|\s$/u.test(inner) || inner.includes('`') || /^\d/u.test(nextCharacter);
 }
 
-function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: string): void {
+function collectProtectedRanges(
+  node: Nodes,
+  ranges: OffsetRange[],
+  markdown: string,
+  downgradedMathImageDescriptionRanges?: OffsetRange[],
+): void {
   if (node.type === 'link' || node.type === 'linkReference') {
     const range = nodeRange(node);
     if (range && markdown[range.start] !== '[') {
@@ -374,7 +390,14 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
     // 和地址，避免在目标地址内插入隐藏分隔符。
     ranges.push({ start: range.start, end: childRanges[0].start });
     ranges.push({ start: childRanges[childRanges.length - 1].end, end: range.end });
-    for (const child of node.children) collectProtectedRanges(child, ranges, markdown);
+    for (const child of node.children) {
+      collectProtectedRanges(
+        child,
+        ranges,
+        markdown,
+        downgradedMathImageDescriptionRanges,
+      );
+    }
     return;
   }
 
@@ -396,9 +419,21 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
       description,
     ) as Root;
     const nestedRanges: OffsetRange[] = [];
-    collectProtectedRanges(descriptionTree, nestedRanges, description);
+    const nestedImageDescriptionRanges: OffsetRange[] = [];
+    collectProtectedRanges(
+      descriptionTree,
+      nestedRanges,
+      description,
+      nestedImageDescriptionRanges,
+    );
     ranges.push(
       ...nestedRanges.map((nestedRange) => ({
+        start: descriptionRange.start + nestedRange.start,
+        end: descriptionRange.start + nestedRange.end,
+      })),
+    );
+    downgradedMathImageDescriptionRanges?.push(
+      ...nestedImageDescriptionRanges.map((nestedRange) => ({
         start: descriptionRange.start + nestedRange.start,
         end: descriptionRange.start + nestedRange.end,
       })),
@@ -424,6 +459,12 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
           end: range.start + nestedRange.end,
         })),
       );
+      downgradedMathImageDescriptionRanges?.push(
+        ...collectImageDescriptionRanges(proseTree, raw).map((descriptionRange) => ({
+          start: range.start + descriptionRange.start,
+          end: range.start + descriptionRange.end,
+        })),
+      );
     }
     return;
   }
@@ -435,7 +476,14 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
   }
 
   if (!('children' in node)) return;
-  for (const child of node.children as Nodes[]) collectProtectedRanges(child, ranges, markdown);
+  for (const child of node.children as Nodes[]) {
+    collectProtectedRanges(
+      child,
+      ranges,
+      markdown,
+      downgradedMathImageDescriptionRanges,
+    );
+  }
 }
 
 function collectRecoveredTailLinkRanges(node: Nodes, ranges: OffsetRange[], markdown: string): void {
@@ -537,9 +585,18 @@ function collectRecoveredTailSyntaxRanges(
       const tail = markdown.slice(recoveredTail.start, recoveredTail.end);
       const tailTree = markdownParser.runSync(markdownParser.parse(tail), tail) as Root;
       const tailRanges: OffsetRange[] = [];
-      collectProtectedRanges(tailTree, tailRanges, tail);
+      const downgradedMathImageDescriptionRanges: OffsetRange[] = [];
+      collectProtectedRanges(
+        tailTree,
+        tailRanges,
+        tail,
+        downgradedMathImageDescriptionRanges,
+      );
       imageDescriptionRanges.push(
-        ...collectImageDescriptionRanges(tailTree, tail).map((descriptionRange) => ({
+        ...[
+          ...collectImageDescriptionRanges(tailTree, tail),
+          ...downgradedMathImageDescriptionRanges,
+        ].map((descriptionRange) => ({
           start: recoveredTail.start + descriptionRange.start,
           end: recoveredTail.start + descriptionRange.end,
         })),
@@ -740,7 +797,12 @@ function collectProseRanges(
     const recoveredMathTailStarts: number[] = [];
     const recoveredLooseMathRanges: OffsetRange[] = [];
     const recoveredImageDescriptionRanges: OffsetRange[] = [];
-    collectProtectedRanges(node, protectedRanges, markdown);
+    collectProtectedRanges(
+      node,
+      protectedRanges,
+      markdown,
+      recoveredImageDescriptionRanges,
+    );
     // remarkTruncateCjkUrls 会把被首个裸链接误吞的尾段重新拆成文本和链接，
     // 尾段的 Markdown 语法没有原始解析节点，需要重新解析后补回保护范围；
     // 插件新生成的链接没有源码位置，再按实际字符位置补回其范围。
@@ -858,7 +920,11 @@ function collectBoundaryRepairs(
       isolatedIndex += 1;
       isolatedRange = isolatedRanges[isolatedIndex];
     }
-    if (isolatedRange && cursor === isolatedRange.start) {
+    if (
+      isolatedRange &&
+      savedOuterStrongStarts === null &&
+      cursor >= isolatedRange.start
+    ) {
       // 图片说明的加粗标记只在说明内部配对，不能继承外层正文的未闭合状态。
       savedOuterStrongStarts = [...openStrongStarts];
       openStrongStarts.length = 0;

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -240,14 +240,38 @@ function collectProjectDeepLinkRanges(markdown: string, range: OffsetRange): Off
   return ranges;
 }
 
-function collectPreservedTexDelimiterRanges(markdown: string): OffsetRange[] {
+function findUnprotectedDelimiter(
+  markdown: string,
+  delimiter: string,
+  start: number,
+  protectedRanges: OffsetRange[],
+): number {
+  let scan = start;
+
+  while (scan < markdown.length) {
+    const offset = markdown.indexOf(delimiter, scan);
+    if (offset === -1) return -1;
+    const protectedRange = protectedRanges.find(
+      (range) => offset >= range.start && offset < range.end,
+    );
+    if (!protectedRange) return offset;
+    scan = protectedRange.end;
+  }
+
+  return -1;
+}
+
+function collectPreservedTexDelimiterRanges(
+  markdown: string,
+  protectedRanges: OffsetRange[],
+): OffsetRange[] {
   const ranges: OffsetRange[] = [];
   let scan = 0;
   let noParenCloser = false;
   let noBracketCloser = false;
 
   while (scan < markdown.length) {
-    const open = markdown.indexOf('\\', scan);
+    const open = findUnprotectedDelimiter(markdown, '\\', scan, protectedRanges);
     if (open === -1 || open + 1 >= markdown.length) break;
     const kind = markdown[open + 1];
     if (kind !== '(' && kind !== '[') {
@@ -261,7 +285,7 @@ function collectPreservedTexDelimiterRanges(markdown: string): OffsetRange[] {
       continue;
     }
     const closer = kind === '[' ? '\\]' : '\\)';
-    const close = markdown.indexOf(closer, open + 2);
+    const close = findUnprotectedDelimiter(markdown, closer, open + 2, protectedRanges);
     if (close === -1) {
       if (isDisplay) noBracketCloser = true;
       else noParenCloser = true;
@@ -407,9 +431,15 @@ export function normalizeStrongDelimiterBoundaries(
   if (!markdown.includes('**') || !POTENTIAL_BOUNDARY_RE.test(markdown)) return markdown;
 
   const tree = markdownParser.runSync(markdownParser.parse(markdown), markdown) as Root;
-  const preservedTexDelimiterRanges = options.preserveTexDelimiters
-    ? collectPreservedTexDelimiterRanges(markdown)
-    : [];
+  const preservedTexDelimiterRanges: OffsetRange[] = [];
+  if (options.preserveTexDelimiters) {
+    const protectedSyntaxRanges: OffsetRange[] = [];
+    collectProtectedRanges(tree, protectedSyntaxRanges, markdown);
+    protectedSyntaxRanges.sort((left, right) => left.start - right.start);
+    preservedTexDelimiterRanges.push(
+      ...collectPreservedTexDelimiterRanges(markdown, protectedSyntaxRanges),
+    );
+  }
   const proseRanges = collectProseRanges(tree, markdown, preservedTexDelimiterRanges);
   const boundaryInsertions = proseRanges.flatMap(({ range, protectedRanges }) =>
     collectBoundaryInsertions(markdown, range, protectedRanges),

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -1,3 +1,12 @@
+import type { Nodes, Root } from 'mdast';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+import { visit } from 'unist-util-visit';
+
+import remarkStrictInlineMath from './remarkStrictInlineMath';
+
 /**
  * 放宽 AI 常见的中文加粗写法。
  *
@@ -6,18 +15,40 @@
  * “结束”。例如 `**重点。**下一句` 会整段按原文显示。
  *
  * 这里不改用户看到的文字，只在这类已经存在未闭合加粗起点的收尾后插入
- * 一个会被 MarkdownRenderer 的 `skipHtml` 丢弃的 HTML 注释。代码块、行内
- * 代码、转义星号和三颗以上的星号序列保持原样。
+ * 一个会被 MarkdownRenderer 的 `skipHtml` 丢弃的 HTML 注释。解析树用于
+ * 限定正文段落并排除代码、公式、链接和原始 HTML，避免字符扫描改写这些
+ * 语法区域。
  */
 
 const HIDDEN_SEPARATOR = '<!--cindy-strong-boundary-->';
+const ASCII_PUNCTUATION = '\\u0021-\\u002F\\u003A-\\u0040\\u005B-\\u0060\\u007B-\\u007E';
+const POTENTIAL_BOUNDARY_RE = new RegExp(
+  `[\\p{P}${ASCII_PUNCTUATION}]\\*\\*[^\\s\\p{P}${ASCII_PUNCTUATION}]`,
+  'u',
+);
 const UNICODE_WHITESPACE_RE = /^\s$/u;
-const UNICODE_PUNCTUATION_RE = /^[\p{P}\p{S}]$/u;
+const UNICODE_PUNCTUATION_RE = new RegExp(`^[\\p{P}${ASCII_PUNCTUATION}]$`, 'u');
+const PROTECTED_NODE_TYPES = new Set<Nodes['type']>([
+  'code',
+  'definition',
+  'html',
+  'image',
+  'imageReference',
+  'inlineCode',
+  'inlineMath',
+  'link',
+  'linkReference',
+  'math',
+]);
+const markdownParser = unified()
+  .use(remarkParse)
+  .use(remarkGfm, { singleTilde: false })
+  .use(remarkMath)
+  .use(remarkStrictInlineMath);
 
-interface NormalizationState {
-  fencedCode: { marker: '`' | '~'; length: number } | null;
-  inlineCodeLength: number | null;
-  openStrongCount: number;
+interface OffsetRange {
+  start: number;
+  end: number;
 }
 
 function classifyCharacter(character: string | undefined): 'whitespace' | 'punctuation' | 'other' {
@@ -45,134 +76,127 @@ function isEscaped(text: string, index: number): boolean {
   return slashCount % 2 === 1;
 }
 
-function isFenceStart(line: string): { marker: '`' | '~'; length: number } | null {
-  const match = line.match(/^ {0,3}([`~]{3,})/);
-  if (!match) return null;
-  const run = match[1];
-  if (!run || run.split('').some((character) => character !== run[0])) return null;
-  return { marker: run[0] as '`' | '~', length: run.length };
+function nodeRange(node: Nodes): OffsetRange | null {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  return start == null || end == null ? null : { start, end };
 }
 
-function isFenceEnd(line: string, fence: NonNullable<NormalizationState['fencedCode']>): boolean {
-  const match = line.match(/^ {0,3}([`~]+)[ \t]*$/);
-  if (!match || match[1][0] !== fence.marker) return false;
-  return match[1].length >= fence.length;
+function collectProtectedRanges(node: Nodes, ranges: OffsetRange[]): void {
+  if (PROTECTED_NODE_TYPES.has(node.type)) {
+    const range = nodeRange(node);
+    if (range) ranges.push(range);
+    return;
+  }
+
+  if (!('children' in node)) return;
+  for (const child of node.children as Nodes[]) collectProtectedRanges(child, ranges);
 }
 
-function normalizeInlineLine(line: string, state: NormalizationState): string {
-  let output = '';
-  let cursor = 0;
+function collectProseRanges(tree: Root): Array<{
+  range: OffsetRange;
+  protectedRanges: OffsetRange[];
+}> {
+  const proseRanges: Array<{ range: OffsetRange; protectedRanges: OffsetRange[] }> = [];
 
-  while (cursor < line.length) {
-    const character = line[cursor];
+  visit(tree, (node, _index, parent) => {
+    const isProseRoot =
+      node.type === 'paragraph' ||
+      node.type === 'heading' ||
+      (node.type === 'tableCell' && parent?.type === 'tableRow');
+    if (!isProseRoot) return;
 
-    if (character === '`') {
-      let runEnd = cursor + 1;
-      while (runEnd < line.length && line[runEnd] === '`') runEnd += 1;
-      const runLength = runEnd - cursor;
+    const range = nodeRange(node);
+    if (!range) return;
+    const protectedRanges: OffsetRange[] = [];
+    collectProtectedRanges(node, protectedRanges);
+    protectedRanges.sort((left, right) => left.start - right.start);
+    proseRanges.push({ range, protectedRanges });
+  });
 
-      if (state.inlineCodeLength === null) {
-        if (!isEscaped(line, cursor)) state.inlineCodeLength = runLength;
-      } else if (state.inlineCodeLength === runLength) {
-        state.inlineCodeLength = null;
-      }
+  return proseRanges;
+}
 
-      output += line.slice(cursor, runEnd);
-      cursor = runEnd;
+function collectBoundaryInsertions(
+  markdown: string,
+  range: OffsetRange,
+  protectedRanges: OffsetRange[],
+): number[] {
+  const insertions: number[] = [];
+  let cursor = range.start;
+  let openStrongCount = 0;
+  let protectedIndex = 0;
+
+  while (cursor < range.end) {
+    const protectedRange = protectedRanges[protectedIndex];
+    if (protectedRange && cursor >= protectedRange.end) {
+      protectedIndex += 1;
+      continue;
+    }
+    if (protectedRange && cursor >= protectedRange.start) {
+      cursor = protectedRange.end;
+      protectedIndex += 1;
       continue;
     }
 
-    if (state.inlineCodeLength !== null || character !== '*') {
-      output += character;
+    if (markdown[cursor] !== '*') {
       cursor += 1;
       continue;
     }
 
     let runEnd = cursor + 1;
-    while (runEnd < line.length && line[runEnd] === '*') runEnd += 1;
+    while (runEnd < range.end && markdown[runEnd] === '*') runEnd += 1;
     const runLength = runEnd - cursor;
 
-    // `***` 及更长序列使用另一套配对规则。这里不猜测其意图，同时清掉
-    // 当前配对状态，避免后续双星号跨过不支持的序列发生误配。
-    if (runLength !== 2 || isEscaped(line, cursor)) {
-      output += line.slice(cursor, runEnd);
-      state.openStrongCount = 0;
+    if (isEscaped(markdown, cursor) || runLength === 1) {
       cursor = runEnd;
       continue;
     }
 
-    const before = classifyCharacter(characterBefore(line, cursor));
-    const after = classifyCharacter(characterAfter(line, runEnd));
+    // `***` 及更长序列使用另一套配对规则。这里不猜测其意图，同时清掉
+    // 当前配对状态，避免后续双星号跨过不支持的序列发生误配。
+    if (runLength > 2) {
+      openStrongCount = 0;
+      cursor = runEnd;
+      continue;
+    }
+
+    const before = classifyCharacter(characterBefore(markdown, cursor));
+    const after = classifyCharacter(characterAfter(markdown, runEnd));
     const canOpen = after !== 'whitespace' && (after !== 'punctuation' || before !== 'other');
     const canClose = before !== 'whitespace' && (before !== 'punctuation' || after !== 'other');
 
-    if (canClose && state.openStrongCount > 0) {
-      state.openStrongCount -= 1;
-      output += '**';
-    } else if (before === 'punctuation' && after === 'other' && state.openStrongCount > 0) {
-      // CommonMark 因右侧紧接普通字符而把它视为起点；前面尚未配对的
-      // `**` 表明这其实是 AI 句子想表达的收尾。
-      state.openStrongCount -= 1;
-      output += `**${HIDDEN_SEPARATOR}`;
-    } else {
-      if (canOpen) state.openStrongCount += 1;
-      output += '**';
+    if (canClose && openStrongCount > 0) {
+      openStrongCount -= 1;
+    } else if (before === 'punctuation' && after === 'other' && openStrongCount > 0) {
+      openStrongCount -= 1;
+      insertions.push(runEnd);
+    } else if (canOpen) {
+      openStrongCount += 1;
     }
 
     cursor = runEnd;
   }
 
-  return output;
+  return insertions;
 }
 
 /**
  * 让“以标点结束、后面紧接正文”的加粗片段能被解析，同时不改变可见
- * 消息和代码示例。
+ * 消息、链接、公式、原始 HTML 和代码示例。
  */
 export function normalizeStrongDelimiterBoundaries(markdown: string): string {
-  if (!markdown.includes('**')) return markdown;
+  if (!markdown.includes('**') || !POTENTIAL_BOUNDARY_RE.test(markdown)) return markdown;
 
-  const state: NormalizationState = {
-    fencedCode: null,
-    inlineCodeLength: null,
-    openStrongCount: 0,
-  };
-  const parts = markdown.split(/(\r\n|\n|\r)/);
-  let output = '';
+  const tree = markdownParser.runSync(markdownParser.parse(markdown), markdown);
+  const insertions = collectProseRanges(tree).flatMap(({ range, protectedRanges }) =>
+    collectBoundaryInsertions(markdown, range, protectedRanges),
+  );
+  if (insertions.length === 0) return markdown;
 
-  for (const part of parts) {
-    if (/^(?:\r\n|\n|\r)$/.test(part)) {
-      output += part;
-      continue;
-    }
-
-    if (state.fencedCode) {
-      output += part;
-      if (isFenceEnd(part, state.fencedCode)) {
-        state.fencedCode = null;
-        state.inlineCodeLength = null;
-        state.openStrongCount = 0;
-      }
-      continue;
-    }
-
-    if (part.trim() === '' || /^(?: {4}|\t)/.test(part)) {
-      output += part;
-      state.inlineCodeLength = null;
-      state.openStrongCount = 0;
-      continue;
-    }
-
-    const fence = state.inlineCodeLength === null ? isFenceStart(part) : null;
-    if (fence) {
-      output += part;
-      state.fencedCode = fence;
-      state.openStrongCount = 0;
-      continue;
-    }
-
-    output += normalizeInlineLine(part, state);
+  let output = markdown;
+  for (const offset of insertions.sort((left, right) => right - left)) {
+    output = `${output.slice(0, offset)}${HIDDEN_SEPARATOR}${output.slice(offset)}`;
   }
-
   return output;
 }

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -24,11 +24,14 @@ import remarkTruncateCjkUrls from './remarkTruncateCjkUrls';
 const HIDDEN_SEPARATOR = '<!--cindy-strong-boundary-->';
 const ASCII_PUNCTUATION = '\\u0021-\\u002F\\u003A-\\u0040\\u005B-\\u0060\\u007B-\\u007E';
 const POTENTIAL_BOUNDARY_RE = new RegExp(
-  `[\\p{P}${ASCII_PUNCTUATION}]\\*\\*[^\\s\\p{P}${ASCII_PUNCTUATION}]`,
+  `[\\p{P}\\p{S}${ASCII_PUNCTUATION}]\\*\\*[^\\s\\p{P}\\p{S}${ASCII_PUNCTUATION}]`,
   'u',
 );
 const UNICODE_WHITESPACE_RE = /^\s$/u;
-const UNICODE_PUNCTUATION_RE = new RegExp(`^[\\p{P}${ASCII_PUNCTUATION}]$`, 'u');
+const UNICODE_PUNCTUATION_RE = new RegExp(
+  `^[\\p{P}\\p{S}${ASCII_PUNCTUATION}]$`,
+  'u',
+);
 const PROTECTED_NODE_TYPES = new Set<Nodes['type']>([
   'code',
   'definition',
@@ -225,6 +228,19 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
     // 目标地址与引用标签等外围语法。
     ranges.push({ start: range.start, end: descriptionRange.start });
     ranges.push({ start: descriptionRange.end, end: range.end });
+    const description = markdown.slice(descriptionRange.start, descriptionRange.end);
+    const descriptionTree = proseMarkdownParser.runSync(
+      proseMarkdownParser.parse(description),
+      description,
+    ) as Root;
+    const nestedRanges: OffsetRange[] = [];
+    collectProtectedRanges(descriptionTree, nestedRanges, description);
+    ranges.push(
+      ...nestedRanges.map((nestedRange) => ({
+        start: descriptionRange.start + nestedRange.start,
+        end: descriptionRange.start + nestedRange.end,
+      })),
+    );
     return;
   }
 
@@ -410,6 +426,23 @@ function findUnprotectedDelimiter(
   return -1;
 }
 
+function findUnescapedUnprotectedDelimiter(
+  markdown: string,
+  delimiter: string,
+  start: number,
+  protectedRanges: OffsetRange[],
+): number {
+  let scan = start;
+
+  while (scan < markdown.length) {
+    const offset = findUnprotectedDelimiter(markdown, delimiter, scan, protectedRanges);
+    if (offset === -1 || !isEscaped(markdown, offset)) return offset;
+    scan = offset + 1;
+  }
+
+  return -1;
+}
+
 function collectPreservedTexDelimiterRanges(
   markdown: string,
   protectedRanges: OffsetRange[],
@@ -420,7 +453,7 @@ function collectPreservedTexDelimiterRanges(
   let noBracketCloser = false;
 
   while (scan < markdown.length) {
-    const open = findUnprotectedDelimiter(markdown, '\\', scan, protectedRanges);
+    const open = findUnescapedUnprotectedDelimiter(markdown, '\\', scan, protectedRanges);
     if (open === -1 || open + 1 >= markdown.length) break;
     const kind = markdown[open + 1];
     if (kind !== '(' && kind !== '[') {
@@ -434,7 +467,12 @@ function collectPreservedTexDelimiterRanges(
       continue;
     }
     const closer = kind === '[' ? '\\]' : '\\)';
-    const close = findUnprotectedDelimiter(markdown, closer, open + 2, protectedRanges);
+    const close = findUnescapedUnprotectedDelimiter(
+      markdown,
+      closer,
+      open + 2,
+      protectedRanges,
+    );
     if (close === -1) {
       if (isDisplay) noBracketCloser = true;
       else noParenCloser = true;

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -185,6 +185,45 @@ function collectRecoveredTailLinkRanges(node: Nodes, ranges: OffsetRange[], mark
   }
 }
 
+function collectRecoveredTailSyntaxRanges(
+  node: Nodes,
+  ranges: OffsetRange[],
+  mathTailStarts: number[],
+  markdown: string,
+): void {
+  if (!('children' in node)) return;
+
+  for (const child of node.children as Nodes[]) {
+    const range = nodeRange(child);
+    const recoveredTail = range ? recoveredAutolinkTailRange(child, range, markdown) : null;
+
+    if (recoveredTail) {
+      const tail = markdown.slice(recoveredTail.start, recoveredTail.end);
+      const tailTree = markdownParser.runSync(markdownParser.parse(tail), tail) as Root;
+      const tailRanges: OffsetRange[] = [];
+      collectProtectedRanges(tailTree, tailRanges, tail);
+      visit(tailTree, (tailNode) => {
+        if (tailNode.type !== 'inlineMath' && tailNode.type !== 'math') return;
+        const tailNodeRange = nodeRange(tailNode);
+        if (
+          tailNodeRange &&
+          POTENTIAL_BOUNDARY_RE.test(tail.slice(tailNodeRange.start, tailNodeRange.end))
+        ) {
+          mathTailStarts.push(recoveredTail.start);
+        }
+      });
+      ranges.push(
+        ...tailRanges.map((tailRange) => ({
+          start: recoveredTail.start + tailRange.start,
+          end: recoveredTail.start + tailRange.end,
+        })),
+      );
+    }
+
+    collectRecoveredTailSyntaxRanges(child, ranges, mathTailStarts, markdown);
+  }
+}
+
 function collectProjectDeepLinkRanges(markdown: string, range: OffsetRange): OffsetRange[] {
   const ranges: OffsetRange[] = [];
   const source = markdown.slice(range.start, range.end);
@@ -244,8 +283,13 @@ function collectProseRanges(
 ): Array<{
   range: OffsetRange;
   protectedRanges: OffsetRange[];
+  recoveredMathTailStarts: number[];
 }> {
-  const proseRanges: Array<{ range: OffsetRange; protectedRanges: OffsetRange[] }> = [];
+  const proseRanges: Array<{
+    range: OffsetRange;
+    protectedRanges: OffsetRange[];
+    recoveredMathTailStarts: number[];
+  }> = [];
 
   visit(tree, (node, _index, parent) => {
     const isProseRoot =
@@ -257,9 +301,12 @@ function collectProseRanges(
     const range = nodeRange(node);
     if (!range) return;
     const protectedRanges: OffsetRange[] = [];
+    const recoveredMathTailStarts: number[] = [];
     collectProtectedRanges(node, protectedRanges, markdown);
     // remarkTruncateCjkUrls 会把被首个裸链接误吞的尾段重新拆成文本和链接，
-    // 这些新链接没有源码位置，需要按尾段中的实际字符位置补回保护范围。
+    // 尾段的 Markdown 语法没有原始解析节点，需要重新解析后补回保护范围；
+    // 插件新生成的链接没有源码位置，再按实际字符位置补回其范围。
+    collectRecoveredTailSyntaxRanges(node, protectedRanges, recoveredMathTailStarts, markdown);
     collectRecoveredTailLinkRanges(node, protectedRanges, markdown);
     protectedRanges.push(...collectProjectDeepLinkRanges(markdown, range));
     protectedRanges.push(
@@ -268,7 +315,7 @@ function collectProseRanges(
       ),
     );
     protectedRanges.sort((left, right) => left.start - right.start);
-    proseRanges.push({ range, protectedRanges });
+    proseRanges.push({ range, protectedRanges, recoveredMathTailStarts });
   });
 
   return proseRanges;
@@ -363,14 +410,14 @@ export function normalizeStrongDelimiterBoundaries(
   const preservedTexDelimiterRanges = options.preserveTexDelimiters
     ? collectPreservedTexDelimiterRanges(markdown)
     : [];
-  const boundaryInsertions = collectProseRanges(
-    tree,
-    markdown,
-    preservedTexDelimiterRanges,
-  ).flatMap(({ range, protectedRanges }) =>
+  const proseRanges = collectProseRanges(tree, markdown, preservedTexDelimiterRanges);
+  const boundaryInsertions = proseRanges.flatMap(({ range, protectedRanges }) =>
     collectBoundaryInsertions(markdown, range, protectedRanges),
   );
-  if (boundaryInsertions.length === 0) return markdown;
+  const recoveredMathTailStarts = proseRanges.flatMap(
+    ({ recoveredMathTailStarts: starts }) => starts,
+  );
+  if (boundaryInsertions.length === 0 && recoveredMathTailStarts.length === 0) return markdown;
 
   // 后续 remark 插件会把裸链接误吞的中文尾段切回 text 节点，但此时 Markdown
   // 已经解析完成，尾段里的星号不会再次解析。在需要修复的尾段起点再插入同一个
@@ -380,7 +427,9 @@ export function normalizeStrongDelimiterBoundaries(
       boundaryInsertions.some((insertion) => insertion >= range.start && insertion < range.end),
     )
     .map((range) => range.start);
-  const insertions = [...new Set([...boundaryInsertions, ...recoveredTailStarts])];
+  const insertions = [
+    ...new Set([...boundaryInsertions, ...recoveredTailStarts, ...recoveredMathTailStarts]),
+  ];
 
   let output = markdown;
   for (const offset of insertions.sort((left, right) => right - left)) {

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -426,6 +426,7 @@ function collectRecoveredTailSyntaxRanges(
   ranges: OffsetRange[],
   mathTailStarts: number[],
   looseMathRanges: OffsetRange[],
+  imageDescriptionRanges: OffsetRange[],
   markdown: string,
 ): void {
   if (!('children' in node)) return;
@@ -444,6 +445,12 @@ function collectRecoveredTailSyntaxRanges(
       const tailTree = markdownParser.runSync(markdownParser.parse(tail), tail) as Root;
       const tailRanges: OffsetRange[] = [];
       collectProtectedRanges(tailTree, tailRanges, tail);
+      imageDescriptionRanges.push(
+        ...collectImageDescriptionRanges(tailTree, tail).map((descriptionRange) => ({
+          start: recoveredTail.start + descriptionRange.start,
+          end: recoveredTail.start + descriptionRange.end,
+        })),
+      );
       visit(tailTree, (tailNode) => {
         if (tailNode.type !== 'inlineMath' && tailNode.type !== 'math') return;
         const tailNodeRange = nodeRange(tailNode);
@@ -465,7 +472,14 @@ function collectRecoveredTailSyntaxRanges(
       );
     }
 
-    collectRecoveredTailSyntaxRanges(child, ranges, mathTailStarts, looseMathRanges, markdown);
+    collectRecoveredTailSyntaxRanges(
+      child,
+      ranges,
+      mathTailStarts,
+      looseMathRanges,
+      imageDescriptionRanges,
+      markdown,
+    );
   }
 }
 
@@ -628,12 +642,14 @@ function collectProseRanges(
   protectedRanges: OffsetRange[];
   recoveredMathTailStarts: number[];
   recoveredLooseMathRanges: OffsetRange[];
+  recoveredImageDescriptionRanges: OffsetRange[];
 }> {
   const proseRanges: Array<{
     range: OffsetRange;
     protectedRanges: OffsetRange[];
     recoveredMathTailStarts: number[];
     recoveredLooseMathRanges: OffsetRange[];
+    recoveredImageDescriptionRanges: OffsetRange[];
   }> = [];
 
   visit(tree, (node, _index, parent) => {
@@ -648,6 +664,7 @@ function collectProseRanges(
     const protectedRanges: OffsetRange[] = [];
     const recoveredMathTailStarts: number[] = [];
     const recoveredLooseMathRanges: OffsetRange[] = [];
+    const recoveredImageDescriptionRanges: OffsetRange[] = [];
     collectProtectedRanges(node, protectedRanges, markdown);
     // remarkTruncateCjkUrls 会把被首个裸链接误吞的尾段重新拆成文本和链接，
     // 尾段的 Markdown 语法没有原始解析节点，需要重新解析后补回保护范围；
@@ -657,6 +674,7 @@ function collectProseRanges(
       protectedRanges,
       recoveredMathTailStarts,
       recoveredLooseMathRanges,
+      recoveredImageDescriptionRanges,
       markdown,
     );
     collectRecoveredTailLinkRanges(node, protectedRanges, markdown);
@@ -680,6 +698,7 @@ function collectProseRanges(
       protectedRanges: mergeOffsetRanges(protectedRanges),
       recoveredMathTailStarts,
       recoveredLooseMathRanges,
+      recoveredImageDescriptionRanges,
     });
   });
 
@@ -752,16 +771,21 @@ function collectBoundaryRepairs(
   const openStrongStarts: number[] = [];
   let protectedIndex = 0;
   let isolatedIndex = firstRangeEndingAfter(isolatedRanges, range.start);
+  let savedOuterStrongStarts: number[] | null = null;
 
   while (cursor < range.end) {
-    const isolatedRange = isolatedRanges[isolatedIndex];
-    if (isolatedRange && cursor >= isolatedRange.end) {
-      openStrongStarts.length = 0;
+    let isolatedRange = isolatedRanges[isolatedIndex];
+    while (isolatedRange && cursor >= isolatedRange.end) {
+      if (savedOuterStrongStarts) {
+        openStrongStarts.splice(0, openStrongStarts.length, ...savedOuterStrongStarts);
+        savedOuterStrongStarts = null;
+      }
       isolatedIndex += 1;
-      continue;
+      isolatedRange = isolatedRanges[isolatedIndex];
     }
     if (isolatedRange && cursor === isolatedRange.start) {
       // 图片说明的加粗标记只在说明内部配对，不能继承外层正文的未闭合状态。
+      savedOuterStrongStarts = [...openStrongStarts];
       openStrongStarts.length = 0;
     }
 
@@ -858,7 +882,13 @@ export function normalizeStrongDelimiterBoundaries(
     );
   }
   const proseRanges = collectProseRanges(tree, markdown, preservedTexDelimiterRanges);
-  const imageDescriptionRanges = collectImageDescriptionRanges(tree, markdown);
+  const recoveredImageDescriptionRanges = proseRanges.flatMap(
+    ({ recoveredImageDescriptionRanges: ranges }) => ranges,
+  );
+  const imageDescriptionRanges = mergeOffsetRanges([
+    ...collectImageDescriptionRanges(tree, markdown),
+    ...recoveredImageDescriptionRanges,
+  ]);
   const boundaryRepairs = proseRanges.flatMap(({ range, protectedRanges }) =>
     collectBoundaryRepairs(markdown, range, protectedRanges, imageDescriptionRanges),
   );

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -520,11 +520,20 @@ function collectProseRanges(
     collectRecoveredTailSyntaxRanges(node, protectedRanges, recoveredMathTailStarts, markdown);
     collectRecoveredTailLinkRanges(node, protectedRanges, markdown);
     protectedRanges.push(...collectProjectDeepLinkRanges(markdown, range));
-    protectedRanges.push(
-      ...preservedTexDelimiterRanges.filter(
-        (protectedRange) => protectedRange.start < range.end && protectedRange.end > range.start,
-      ),
+    // 保留的 TeX 区间按源码顺序收集。先定位首个可能重叠的区间，再只遍历
+    // 当前段落实际覆盖的部分，避免每个段落都重新扫描整份文档的公式。
+    const firstPreservedTexRange = firstRangeEndingAfter(
+      preservedTexDelimiterRanges,
+      range.start,
     );
+    for (
+      let index = firstPreservedTexRange;
+      index < preservedTexDelimiterRanges.length &&
+      preservedTexDelimiterRanges[index].start < range.end;
+      index += 1
+    ) {
+      protectedRanges.push(preservedTexDelimiterRanges[index]);
+    }
     proseRanges.push({
       range,
       protectedRanges: mergeOffsetRanges(protectedRanges),

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -6,6 +6,7 @@ import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 
 import { parseProjectDeepLinkHref, PROJECT_DEEP_LINK_RE_SOURCE } from '@/lib/deepLink';
+import remarkTruncateCjkUrls from './remarkTruncateCjkUrls';
 
 /**
  * 放宽 AI 常见的中文加粗写法。
@@ -41,7 +42,8 @@ const PROTECTED_NODE_TYPES = new Set<Nodes['type']>([
 const markdownParser = unified()
   .use(remarkParse)
   .use(remarkGfm, { singleTilde: false })
-  .use(remarkMath);
+  .use(remarkMath)
+  .use(remarkTruncateCjkUrls);
 
 interface OffsetRange {
   start: number;
@@ -79,11 +81,27 @@ function nodeRange(node: Nodes): OffsetRange | null {
   return start == null || end == null ? null : { start, end };
 }
 
+function recoveredAutolinkTailRange(
+  node: Nodes,
+  range: OffsetRange,
+  markdown: string,
+): OffsetRange | null {
+  if (node.type !== 'link' || markdown[range.start] === '[' || markdown[range.start] === '<') {
+    return null;
+  }
+  const onlyChild = node.children.length === 1 ? node.children[0] : null;
+  if (onlyChild?.type !== 'text') return null;
+
+  const tailStart = range.start + onlyChild.value.length;
+  return tailStart < range.end ? { start: tailStart, end: range.end } : null;
+}
+
 function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: string): void {
   if (node.type === 'link' || node.type === 'linkReference') {
     const range = nodeRange(node);
     if (range && markdown[range.start] !== '[') {
-      ranges.push(range);
+      const recoveredTail = recoveredAutolinkTailRange(node, range, markdown);
+      ranges.push(recoveredTail ? { start: range.start, end: recoveredTail.start } : range);
       return;
     }
     const childRanges = node.children
@@ -154,6 +172,17 @@ function collectProseRanges(
   });
 
   return proseRanges;
+}
+
+function collectRecoveredAutolinkTailRanges(tree: Root, markdown: string): OffsetRange[] {
+  const ranges: OffsetRange[] = [];
+  visit(tree, 'link', (node) => {
+    const range = nodeRange(node);
+    if (!range) return;
+    const recoveredTail = recoveredAutolinkTailRange(node, range, markdown);
+    if (recoveredTail) ranges.push(recoveredTail);
+  });
+  return ranges;
 }
 
 function collectBoundaryInsertions(
@@ -228,10 +257,20 @@ export function normalizeStrongDelimiterBoundaries(markdown: string): string {
   if (!markdown.includes('**') || !POTENTIAL_BOUNDARY_RE.test(markdown)) return markdown;
 
   const tree = markdownParser.runSync(markdownParser.parse(markdown), markdown) as Root;
-  const insertions = collectProseRanges(tree, markdown).flatMap(({ range, protectedRanges }) =>
+  const boundaryInsertions = collectProseRanges(tree, markdown).flatMap(({ range, protectedRanges }) =>
     collectBoundaryInsertions(markdown, range, protectedRanges),
   );
-  if (insertions.length === 0) return markdown;
+  if (boundaryInsertions.length === 0) return markdown;
+
+  // 后续 remark 插件会把裸链接误吞的中文尾段切回 text 节点，但此时 Markdown
+  // 已经解析完成，尾段里的星号不会再次解析。在需要修复的尾段起点再插入同一个
+  // 隐藏分隔符，让首次解析时链接先结束，尾段即可按正文解析。
+  const recoveredTailStarts = collectRecoveredAutolinkTailRanges(tree, markdown)
+    .filter((range) =>
+      boundaryInsertions.some((insertion) => insertion >= range.start && insertion < range.end),
+    )
+    .map((range) => range.start);
+  const insertions = [...new Set([...boundaryInsertions, ...recoveredTailStarts])];
 
   let output = markdown;
   for (const offset of insertions.sort((left, right) => right - left)) {

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -61,6 +61,12 @@ interface BoundaryRepair {
   separatorOffset: number;
 }
 
+interface MarkdownEdit {
+  offset: number;
+  deleteCount: number;
+  value: string;
+}
+
 interface NormalizeStrongDelimiterBoundariesOptions {
   /**
    * 保护因行号对齐而保留源码形态的 `\[...\]` 与跨行 `\(...\)`。
@@ -178,6 +184,40 @@ function codeSpanEnd(markdown: string, start: number, end: number): number | nul
   return null;
 }
 
+function inlineHtmlEnd(markdown: string, start: number, end: number): number | null {
+  const source = markdown.slice(start, end);
+  let closer = '>';
+  if (source.startsWith('<!--')) closer = '-->';
+  else if (source.startsWith('<?')) closer = '?>';
+  else if (source.startsWith('<![CDATA[')) closer = ']]>';
+  else if (
+    !/^<\/?[A-Za-z][A-Za-z\d-]*(?:[\t\n\f\r />]|$)/u.test(source) &&
+    !/^<![A-Z]/u.test(source)
+  ) {
+    return null;
+  }
+
+  if (closer !== '>') {
+    const closerStart = markdown.indexOf(closer, start + 2);
+    return closerStart === -1 || closerStart >= end ? null : closerStart + closer.length;
+  }
+
+  let quote: '"' | "'" | null = null;
+  for (let cursor = start + 1; cursor < end; cursor += 1) {
+    const character = markdown[cursor];
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === '>') return cursor + 1;
+  }
+  return null;
+}
+
 function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | null {
   if (node.type !== 'image' && node.type !== 'imageReference') return null;
   const range = nodeRange(node);
@@ -188,6 +228,11 @@ function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | nul
     if (isEscaped(markdown, cursor)) continue;
     if (markdown[cursor] === '`') {
       const end = codeSpanEnd(markdown, cursor, range.end);
+      if (end != null) cursor = end - 1;
+      continue;
+    }
+    if (markdown[cursor] === '<') {
+      const end = inlineHtmlEnd(markdown, cursor, range.end);
       if (end != null) cursor = end - 1;
       continue;
     }
@@ -357,6 +402,10 @@ function expandedRecoveredTailRange(
 
   for (let index = childIndex + 1; index < siblings.length; index += 1) {
     const sibling = siblings[index];
+    // 普通 text 可能是当前裸链接被空格截断后的剩余源码；下一个带位置的 link
+    // 已属于另一段裸链接，不能让每个尾段都重复解析后续所有链接。
+    if (sibling.type === 'link' && nodeRange(sibling)) break;
+
     let value: string | null = null;
     if (sibling.type === 'text') {
       value = sibling.value;
@@ -462,6 +511,31 @@ function firstRangeEndingAfter(ranges: OffsetRange[], offset: number): number {
     else high = middle;
   }
   return low;
+}
+
+function firstOffsetAtOrAfter(offsets: number[], offset: number): number {
+  let low = 0;
+  let high = offsets.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (offsets[middle] < offset) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function rangeContainsSpan(
+  ranges: OffsetRange[],
+  start: number,
+  end: number,
+): boolean {
+  const range = ranges[firstRangeEndingAfter(ranges, start)];
+  return range != null && range.start <= start && end <= range.end;
+}
+
+function rangeContainsAnyOffset(range: OffsetRange, sortedOffsets: number[]): boolean {
+  const offsetIndex = firstOffsetAtOrAfter(sortedOffsets, range.start);
+  return offsetIndex < sortedOffsets.length && sortedOffsets[offsetIndex] < range.end;
 }
 
 function findUnprotectedDelimiter(
@@ -629,7 +703,7 @@ function collectImageDescriptionRanges(tree: Root, markdown: string): OffsetRang
     const range = imageDescriptionRange(node, markdown);
     if (range) ranges.push(range);
   });
-  return ranges;
+  return ranges.sort((left, right) => left.start - right.start);
 }
 
 function collectLooseMathDelimiterOffsets(
@@ -650,14 +724,8 @@ function collectLooseMathDelimiterOffsets(
     .map((repair) => repair.separatorOffset)
     .sort((left, right) => left - right);
   for (const range of looseMathRanges) {
-    let low = 0;
-    let high = repairOffsets.length;
-    while (low < high) {
-      const middle = low + Math.floor((high - low) / 2);
-      if (repairOffsets[middle] <= range.start) low = middle + 1;
-      else high = middle;
-    }
-    if (low >= repairOffsets.length || repairOffsets[low] >= range.end) continue;
+    const repairIndex = firstOffsetAtOrAfter(repairOffsets, range.start + 1);
+    if (repairIndex >= repairOffsets.length || repairOffsets[repairIndex] >= range.end) continue;
 
     for (let cursor = range.start; cursor < range.end && markdown[cursor] === '$'; cursor += 1) {
       offsets.push(cursor);
@@ -756,6 +824,20 @@ function collectBoundaryRepairs(
   return repairs;
 }
 
+function applyMarkdownEdits(markdown: string, edits: MarkdownEdit[]): string {
+  if (edits.length === 0) return markdown;
+
+  const chunks: string[] = [];
+  let cursor = markdown.length;
+  const sortedEdits = [...edits].sort((left, right) => right.offset - left.offset);
+  for (const edit of sortedEdits) {
+    chunks.push(markdown.slice(edit.offset + edit.deleteCount, cursor), edit.value);
+    cursor = edit.offset;
+  }
+  chunks.push(markdown.slice(0, cursor));
+  return chunks.reverse().join('');
+}
+
 /**
  * 让“以标点结束、后面紧接正文”的加粗片段能被解析，同时不改变可见
  * 消息、链接、公式、原始 HTML 和代码示例。
@@ -792,10 +874,9 @@ export function normalizeStrongDelimiterBoundaries(
   // 后续 remark 插件会把裸链接误吞的中文尾段切回 text 节点，但此时 Markdown
   // 已经解析完成，尾段里的星号不会再次解析。在需要修复的尾段起点再插入同一个
   // 隐藏分隔符，让首次解析时链接先结束，尾段即可按正文解析。
+  const sortedBoundaryInsertions = [...boundaryInsertions].sort((left, right) => left - right);
   const recoveredTailStarts = collectRecoveredAutolinkTailRanges(tree, markdown)
-    .filter((range) =>
-      boundaryInsertions.some((insertion) => insertion >= range.start && insertion < range.end),
-    )
+    .filter((range) => rangeContainsAnyOffset(range, sortedBoundaryInsertions))
     .map((range) => range.start);
   const insertions = [
     ...new Set([...boundaryInsertions, ...recoveredTailStarts, ...recoveredMathTailStarts]),
@@ -807,15 +888,15 @@ export function normalizeStrongDelimiterBoundaries(
     recoveredLooseMathRanges,
   );
   const imageRepairs = boundaryRepairs.filter((repair) =>
-    imageDescriptionRanges.some(
-      (range) =>
-        repair.openerStart >= range.start && repair.separatorOffset <= range.end,
+    rangeContainsSpan(
+      imageDescriptionRanges,
+      repair.openerStart,
+      repair.separatorOffset,
     ),
   );
   const imageRepairOffsets = new Set(imageRepairs.map((repair) => repair.separatorOffset));
 
-  let output = markdown;
-  const edits = [
+  const edits: MarkdownEdit[] = [
     ...insertions
       .filter((offset) => !imageRepairOffsets.has(offset))
       .map((offset) => ({ offset, deleteCount: 0, value: HIDDEN_SEPARATOR })),
@@ -825,10 +906,5 @@ export function normalizeStrongDelimiterBoundaries(
       { offset: repair.closerStart, deleteCount: 2, value: '' },
     ]),
   ];
-  for (const edit of edits.sort((left, right) => right.offset - left.offset)) {
-    output = `${output.slice(0, edit.offset)}${edit.value}${output.slice(
-      edit.offset + edit.deleteCount,
-    )}`;
-  }
-  return output;
+  return applyMarkdownEdits(markdown, edits);
 }

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -159,6 +159,25 @@ function recoveredAutolinkTailRange(
   return tailStart < range.end ? { start: tailStart, end: range.end } : null;
 }
 
+function codeSpanEnd(markdown: string, start: number, end: number): number | null {
+  let openerEnd = start + 1;
+  while (openerEnd < end && markdown[openerEnd] === '`') openerEnd += 1;
+  const delimiterLength = openerEnd - start;
+  let scan = openerEnd;
+
+  // 行内代码只由等长的反引号序列闭合；较短或较长的序列属于代码内容。
+  while (scan < end) {
+    const closerStart = markdown.indexOf('`', scan);
+    if (closerStart === -1 || closerStart >= end) return null;
+    let closerEnd = closerStart + 1;
+    while (closerEnd < end && markdown[closerEnd] === '`') closerEnd += 1;
+    if (closerEnd - closerStart === delimiterLength) return closerEnd;
+    scan = closerEnd;
+  }
+
+  return null;
+}
+
 function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | null {
   if (node.type !== 'image' && node.type !== 'imageReference') return null;
   const range = nodeRange(node);
@@ -167,6 +186,11 @@ function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | nul
   let nestedBrackets = 0;
   for (let cursor = range.start + 2; cursor < range.end; cursor += 1) {
     if (isEscaped(markdown, cursor)) continue;
+    if (markdown[cursor] === '`') {
+      const end = codeSpanEnd(markdown, cursor, range.end);
+      if (end != null) cursor = end - 1;
+      continue;
+    }
     if (markdown[cursor] === '[') {
       nestedBrackets += 1;
       continue;

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -41,6 +41,10 @@ const markdownParser = unified()
   .use(remarkGfm, { singleTilde: false })
   .use(remarkMath)
   .use(remarkTruncateCjkUrls);
+const proseMarkdownParser = unified()
+  .use(remarkParse)
+  .use(remarkGfm, { singleTilde: false })
+  .use(remarkTruncateCjkUrls);
 const characterReferenceParser = unified().use(remarkParse);
 
 interface OffsetRange {
@@ -226,7 +230,23 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
 
   if (node.type === 'inlineMath') {
     const range = nodeRange(node);
-    if (range && !isLooseInlineMath(node, markdown)) ranges.push(range);
+    if (range && !isLooseInlineMath(node, markdown)) {
+      ranges.push(range);
+    } else if (range) {
+      // 宽松公式会在修复命中时转回普通文字。remark-math 把公式正文折叠成
+      // opaque 节点，必须按普通 Markdown 再解析一次，才能继续保护其中的
+      // 代码、链接和 HTML，避免隐藏分隔符进入用户可见内容。
+      const raw = markdown.slice(range.start, range.end);
+      const proseTree = proseMarkdownParser.runSync(proseMarkdownParser.parse(raw), raw) as Root;
+      const nestedRanges: OffsetRange[] = [];
+      collectProtectedRanges(proseTree, nestedRanges, raw);
+      ranges.push(
+        ...nestedRanges.map((nestedRange) => ({
+          start: range.start + nestedRange.start,
+          end: range.start + nestedRange.end,
+        })),
+      );
+    }
     return;
   }
 

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -298,8 +298,8 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
     ranges.push({ start: range.start, end: descriptionRange.start });
     ranges.push({ start: descriptionRange.end, end: range.end });
     const description = markdown.slice(descriptionRange.start, descriptionRange.end);
-    const descriptionTree = proseMarkdownParser.runSync(
-      proseMarkdownParser.parse(description),
+    const descriptionTree = markdownParser.runSync(
+      markdownParser.parse(description),
       description,
     ) as Root;
     const nestedRanges: OffsetRange[] = [];

--- a/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
+++ b/apps/desktop/src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts
@@ -33,10 +33,7 @@ const PROTECTED_NODE_TYPES = new Set<Nodes['type']>([
   'code',
   'definition',
   'html',
-  'image',
-  'imageReference',
   'inlineCode',
-  'inlineMath',
   'math',
 ]);
 const markdownParser = unified()
@@ -44,10 +41,17 @@ const markdownParser = unified()
   .use(remarkGfm, { singleTilde: false })
   .use(remarkMath)
   .use(remarkTruncateCjkUrls);
+const characterReferenceParser = unified().use(remarkParse);
 
 interface OffsetRange {
   start: number;
   end: number;
+}
+
+interface BoundaryRepair {
+  openerStart: number;
+  closerStart: number;
+  separatorOffset: number;
 }
 
 interface NormalizeStrongDelimiterBoundariesOptions {
@@ -89,6 +93,46 @@ function nodeRange(node: Nodes): OffsetRange | null {
   return start == null || end == null ? null : { start, end };
 }
 
+function decodeCharacterReference(reference: string): string | null {
+  const tree = characterReferenceParser.parse(reference) as Root;
+  const paragraph = tree.children.length === 1 ? tree.children[0] : null;
+  const text =
+    paragraph?.type === 'paragraph' && paragraph.children.length === 1
+      ? paragraph.children[0]
+      : null;
+  return text?.type === 'text' && text.value !== reference ? text.value : null;
+}
+
+function sourceOffsetAfterValue(
+  markdown: string,
+  range: OffsetRange,
+  value: string,
+): number | null {
+  let sourceCursor = range.start;
+  let valueCursor = 0;
+
+  while (valueCursor < value.length && sourceCursor < range.end) {
+    const sourceCharacter = characterAfter(markdown, sourceCursor);
+    const valueCharacter = characterAfter(value, valueCursor);
+    if (sourceCharacter === valueCharacter) {
+      sourceCursor += sourceCharacter?.length ?? 0;
+      valueCursor += valueCharacter?.length ?? 0;
+      continue;
+    }
+
+    const referenceMatch = markdown
+      .slice(sourceCursor, range.end)
+      .match(/^&(?:#[xX][\dA-Fa-f]+|#\d+|[A-Za-z][A-Za-z\d]+);/u);
+    if (!referenceMatch) return null;
+    const decoded = decodeCharacterReference(referenceMatch[0]);
+    if (!decoded || !value.startsWith(decoded, valueCursor)) return null;
+    sourceCursor += referenceMatch[0].length;
+    valueCursor += decoded.length;
+  }
+
+  return valueCursor === value.length ? sourceCursor : null;
+}
+
 function recoveredAutolinkTailRange(
   node: Nodes,
   range: OffsetRange,
@@ -100,8 +144,45 @@ function recoveredAutolinkTailRange(
   const onlyChild = node.children.length === 1 ? node.children[0] : null;
   if (onlyChild?.type !== 'text') return null;
 
-  const tailStart = range.start + onlyChild.value.length;
+  // remarkTruncateCjkUrls 会缩短节点值，但保留覆盖原始裸链接的 source position。
+  // 必须把缩短后的 head 映射回原始源码；节点值可能经过字符引用解码，不能把
+  // value.length 直接当作源码长度。无法无损映射时宁可继续保护整段链接。
+  const tailStart = sourceOffsetAfterValue(markdown, range, onlyChild.value);
+  if (tailStart == null) return null;
   return tailStart < range.end ? { start: tailStart, end: range.end } : null;
+}
+
+function imageDescriptionRange(node: Nodes, markdown: string): OffsetRange | null {
+  if (node.type !== 'image' && node.type !== 'imageReference') return null;
+  const range = nodeRange(node);
+  if (!range || markdown.slice(range.start, range.start + 2) !== '![') return null;
+
+  let nestedBrackets = 0;
+  for (let cursor = range.start + 2; cursor < range.end; cursor += 1) {
+    if (isEscaped(markdown, cursor)) continue;
+    if (markdown[cursor] === '[') {
+      nestedBrackets += 1;
+      continue;
+    }
+    if (markdown[cursor] !== ']') continue;
+    if (nestedBrackets > 0) {
+      nestedBrackets -= 1;
+      continue;
+    }
+    return { start: range.start + 2, end: cursor };
+  }
+
+  return null;
+}
+
+function isLooseInlineMath(node: Nodes, markdown: string): boolean {
+  if (node.type !== 'inlineMath') return false;
+  const range = nodeRange(node);
+  if (!range) return false;
+  const raw = markdown.slice(range.start, range.end);
+  const inner = raw.replace(/^\$+/, '').replace(/\$+$/, '');
+  const nextCharacter = markdown[range.end] ?? '';
+  return /^\s|\s$/u.test(inner) || inner.includes('`') || /^\d/u.test(nextCharacter);
 }
 
 function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: string): void {
@@ -125,6 +206,27 @@ function collectProtectedRanges(node: Nodes, ranges: OffsetRange[], markdown: st
     ranges.push({ start: range.start, end: childRanges[0].start });
     ranges.push({ start: childRanges[childRanges.length - 1].end, end: range.end });
     for (const child of node.children) collectProtectedRanges(child, ranges, markdown);
+    return;
+  }
+
+  if (node.type === 'image' || node.type === 'imageReference') {
+    const range = nodeRange(node);
+    const descriptionRange = imageDescriptionRange(node, markdown);
+    if (!range || !descriptionRange) {
+      if (range) ranges.push(range);
+      return;
+    }
+
+    // 图片说明会成为可见替代文字，需要像链接文字一样扫描；只保护 `![`、
+    // 目标地址与引用标签等外围语法。
+    ranges.push({ start: range.start, end: descriptionRange.start });
+    ranges.push({ start: descriptionRange.end, end: range.end });
+    return;
+  }
+
+  if (node.type === 'inlineMath') {
+    const range = nodeRange(node);
+    if (range && !isLooseInlineMath(node, markdown)) ranges.push(range);
     return;
   }
 
@@ -240,6 +342,34 @@ function collectProjectDeepLinkRanges(markdown: string, range: OffsetRange): Off
   return ranges;
 }
 
+function mergeOffsetRanges(ranges: OffsetRange[]): OffsetRange[] {
+  if (ranges.length < 2) return ranges;
+  const sorted = [...ranges].sort((left, right) => left.start - right.start);
+  const merged: OffsetRange[] = [{ ...sorted[0] }];
+
+  for (const range of sorted.slice(1)) {
+    const previous = merged[merged.length - 1];
+    if (range.start > previous.end) {
+      merged.push({ ...range });
+    } else if (range.end > previous.end) {
+      previous.end = range.end;
+    }
+  }
+
+  return merged;
+}
+
+function firstRangeEndingAfter(ranges: OffsetRange[], offset: number): number {
+  let low = 0;
+  let high = ranges.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (ranges[middle].end <= offset) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
 function findUnprotectedDelimiter(
   markdown: string,
   delimiter: string,
@@ -251,10 +381,9 @@ function findUnprotectedDelimiter(
   while (scan < markdown.length) {
     const offset = markdown.indexOf(delimiter, scan);
     if (offset === -1) return -1;
-    const protectedRange = protectedRanges.find(
-      (range) => offset >= range.start && offset < range.end,
-    );
-    if (!protectedRange) return offset;
+    const rangeIndex = firstRangeEndingAfter(protectedRanges, offset);
+    const protectedRange = protectedRanges[rangeIndex];
+    if (!protectedRange || offset < protectedRange.start) return offset;
     scan = protectedRange.end;
   }
 
@@ -338,8 +467,11 @@ function collectProseRanges(
         (protectedRange) => protectedRange.start < range.end && protectedRange.end > range.start,
       ),
     );
-    protectedRanges.sort((left, right) => left.start - right.start);
-    proseRanges.push({ range, protectedRanges, recoveredMathTailStarts });
+    proseRanges.push({
+      range,
+      protectedRanges: mergeOffsetRanges(protectedRanges),
+      recoveredMathTailStarts,
+    });
   });
 
   return proseRanges;
@@ -356,14 +488,52 @@ function collectRecoveredAutolinkTailRanges(tree: Root, markdown: string): Offse
   return ranges;
 }
 
-function collectBoundaryInsertions(
+function collectImageDescriptionRanges(tree: Root, markdown: string): OffsetRange[] {
+  const ranges: OffsetRange[] = [];
+  visit(tree, (node) => {
+    const range = imageDescriptionRange(node, markdown);
+    if (range) ranges.push(range);
+  });
+  return ranges;
+}
+
+function collectLooseMathDelimiterOffsets(
+  tree: Root,
+  markdown: string,
+  boundaryRepairs: BoundaryRepair[],
+): number[] {
+  const offsets: number[] = [];
+  visit(tree, 'inlineMath', (node) => {
+    if (!isLooseInlineMath(node, markdown)) return;
+    const range = nodeRange(node);
+    if (
+      !range ||
+      !boundaryRepairs.some(
+        (repair) =>
+          repair.separatorOffset > range.start && repair.separatorOffset < range.end,
+      )
+    ) {
+      return;
+    }
+
+    for (let cursor = range.start; cursor < range.end && markdown[cursor] === '$'; cursor += 1) {
+      offsets.push(cursor);
+    }
+    for (let cursor = range.end - 1; cursor >= range.start && markdown[cursor] === '$'; cursor -= 1) {
+      offsets.push(cursor);
+    }
+  });
+  return offsets;
+}
+
+function collectBoundaryRepairs(
   markdown: string,
   range: OffsetRange,
   protectedRanges: OffsetRange[],
-): number[] {
-  const insertions: number[] = [];
+): BoundaryRepair[] {
+  const repairs: BoundaryRepair[] = [];
   let cursor = range.start;
-  let openStrongCount = 0;
+  const openStrongStarts: number[] = [];
   let protectedIndex = 0;
 
   while (cursor < range.end) {
@@ -395,7 +565,7 @@ function collectBoundaryInsertions(
     // `***` 及更长序列使用另一套配对规则。这里不猜测其意图，同时清掉
     // 当前配对状态，避免后续双星号跨过不支持的序列发生误配。
     if (runLength > 2) {
-      openStrongCount = 0;
+      openStrongStarts.length = 0;
       cursor = runEnd;
       continue;
     }
@@ -405,19 +575,25 @@ function collectBoundaryInsertions(
     const canOpen = after !== 'whitespace' && (after !== 'punctuation' || before !== 'other');
     const canClose = before !== 'whitespace' && (before !== 'punctuation' || after !== 'other');
 
-    if (canClose && openStrongCount > 0) {
-      openStrongCount -= 1;
-    } else if (before === 'punctuation' && after === 'other' && openStrongCount > 0) {
-      openStrongCount -= 1;
-      insertions.push(runEnd);
+    if (canClose && openStrongStarts.length > 0) {
+      openStrongStarts.pop();
+    } else if (
+      before === 'punctuation' &&
+      after === 'other' &&
+      openStrongStarts.length > 0
+    ) {
+      const openerStart = openStrongStarts.pop();
+      if (openerStart != null) {
+        repairs.push({ openerStart, closerStart: cursor, separatorOffset: runEnd });
+      }
     } else if (canOpen) {
-      openStrongCount += 1;
+      openStrongStarts.push(cursor);
     }
 
     cursor = runEnd;
   }
 
-  return insertions;
+  return repairs;
 }
 
 /**
@@ -435,15 +611,15 @@ export function normalizeStrongDelimiterBoundaries(
   if (options.preserveTexDelimiters) {
     const protectedSyntaxRanges: OffsetRange[] = [];
     collectProtectedRanges(tree, protectedSyntaxRanges, markdown);
-    protectedSyntaxRanges.sort((left, right) => left.start - right.start);
     preservedTexDelimiterRanges.push(
-      ...collectPreservedTexDelimiterRanges(markdown, protectedSyntaxRanges),
+      ...collectPreservedTexDelimiterRanges(markdown, mergeOffsetRanges(protectedSyntaxRanges)),
     );
   }
   const proseRanges = collectProseRanges(tree, markdown, preservedTexDelimiterRanges);
-  const boundaryInsertions = proseRanges.flatMap(({ range, protectedRanges }) =>
-    collectBoundaryInsertions(markdown, range, protectedRanges),
+  const boundaryRepairs = proseRanges.flatMap(({ range, protectedRanges }) =>
+    collectBoundaryRepairs(markdown, range, protectedRanges),
   );
+  const boundaryInsertions = boundaryRepairs.map((repair) => repair.separatorOffset);
   const recoveredMathTailStarts = proseRanges.flatMap(
     ({ recoveredMathTailStarts: starts }) => starts,
   );
@@ -460,10 +636,35 @@ export function normalizeStrongDelimiterBoundaries(
   const insertions = [
     ...new Set([...boundaryInsertions, ...recoveredTailStarts, ...recoveredMathTailStarts]),
   ];
+  const looseMathDelimiterOffsets = collectLooseMathDelimiterOffsets(
+    tree,
+    markdown,
+    boundaryRepairs,
+  );
+  const imageDescriptionRanges = collectImageDescriptionRanges(tree, markdown);
+  const imageRepairs = boundaryRepairs.filter((repair) =>
+    imageDescriptionRanges.some(
+      (range) =>
+        repair.openerStart >= range.start && repair.separatorOffset <= range.end,
+    ),
+  );
+  const imageRepairOffsets = new Set(imageRepairs.map((repair) => repair.separatorOffset));
 
   let output = markdown;
-  for (const offset of insertions.sort((left, right) => right - left)) {
-    output = `${output.slice(0, offset)}${HIDDEN_SEPARATOR}${output.slice(offset)}`;
+  const edits = [
+    ...insertions
+      .filter((offset) => !imageRepairOffsets.has(offset))
+      .map((offset) => ({ offset, deleteCount: 0, value: HIDDEN_SEPARATOR })),
+    ...looseMathDelimiterOffsets.map((offset) => ({ offset, deleteCount: 0, value: '\\' })),
+    ...imageRepairs.flatMap((repair) => [
+      { offset: repair.openerStart, deleteCount: 2, value: '' },
+      { offset: repair.closerStart, deleteCount: 2, value: '' },
+    ]),
+  ];
+  for (const edit of edits.sort((left, right) => right.offset - left.offset)) {
+    output = `${output.slice(0, edit.offset)}${edit.value}${output.slice(
+      edit.offset + edit.deleteCount,
+    )}`;
   }
   return output;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 聊天中，中文加粗内容以标点或 Unicode 符号结束、且结束标记后紧接正文时，双星号被原样显示的问题。

现在会在确认存在未闭合加粗起点且命中特定边界时，插入最终不会显示的隐藏注释，让现有 Markdown 解析器正确闭合；用户看到和复制的正文不会增加空格。

预处理会保护代码、公式、链接地址、原始 HTML 和历史项目链接，只扫描实际显示的正文。图片说明会作为独立范围扫描，不继承外层正文的未闭合加粗状态；即使保护语法跨过图片说明起点，也会先进入隔离。扫描结束后会恢复外层状态，因此跨过图片的加粗内容仍能正确闭合。

宽松公式转回普通文字后重新解析出的图片说明也会纳入图片范围，避免隐藏标记进入图片替代文字。图片说明中的连续反引号和反斜杠会按完整序列一次扫描，避免长输入导致重复扫描。

裸链接截断后恢复的中文尾段会按当前链接范围重新检查，遇到下一条原始链接即停止。尾段中重新生成的多层裸链接、图片说明和宽松公式会继续按各自语法保护。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈的流式 Markdown 双星号偶发原样显示
- 本 PR 包含：
  - Desktop Markdown 渲染前的双星号边界归一化
  - 中文标点、Unicode 符号、正常闭合、未闭合和转义星号测试
  - 代码、公式、链接、原始 HTML 和历史项目链接保护
  - 图片说明内外加粗状态隔离及外层状态恢复
  - 保护语法跨过图片说明起点时的隔离修复
  - 宽松公式转回正文后的图片说明分类
  - 图片说明中长反引号和反斜杠序列的线性扫描
  - 裸链接中文尾段、多层裸链接、图片说明和宽松公式回归测试
  - 大量保护范围、段落和修复点共同出现时的回归测试
- 明确不包含：Markdown 解析库升级、Mobile 渲染逻辑、产品文案或视觉样式调整
- 用户可见变化：符合该写法的内容会正确显示为加粗；图片说明不会显示内部隐藏标记；其它 Markdown 内容保持现有行为
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：不涉及。本次不修改布局、颜色、动效、交互控件或产品文案，仅修正已有 Markdown 语义的渲染结果。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/markdownStrongDelimiter.test.ts
结果：1 个测试文件、47 项测试全部通过

pnpm --filter desktop exec eslint src/renderer/components/chat/normalizeStrongDelimiterBoundaries.ts src/renderer/__tests__/markdownStrongDelimiter.test.ts
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

git diff --check
结果：通过
```

### 手工验证

不涉及：本次未启动 Desktop 实机；渲染结果由 React Markdown 回归测试验证。

### 未执行的验证

- 尚未对本轮评审修复运行仓库根 `pnpm test:unit`，交由 PR Steward 完整门禁执行。
- 未在 Desktop 实机中分别目检亮色和暗色模式；本次没有颜色、布局或主题代码变化。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 聊天 Markdown 文本预处理；仅修正特定加粗边界，并保护图片说明、公式、链接地址、代码和原始 HTML 等语法范围。
- 回滚 / 降级方式：回滚本 PR 的提交即恢复原有 Markdown 解析行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个现有 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明不涉及的原因
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认当前定向测试结果并说明未执行项目

<!-- cindy-pr-steward:v1 -->
