### PR TITLE
fix(mobile): Agent 问题卡选项选中态改为反色实底对勾

### DIFF
--- a/apps/mobile/docs/mobile-design-guide.md
+++ b/apps/mobile/docs/mobile-design-guide.md
@@ -12,7 +12,7 @@
 
 - **iOS 优先**,触控优先,跟随系统 light / dark 自动切换(`useColorScheme`)。
 - **灰度环境**:除品牌 teal(就绪态)和 Heart Orange(运行/thinking 态)两个语义色外,界面全是黑白之间的灰阶。不引入任何品牌蓝 / 绿 / 红等装饰色。
-- **二元圆角**:`container`(12,卡片 / 容器)或 `pill`(9999,交互元素)。**禁止**中间值(0 / 3 / 4 / 8 / 28 等)。
+- **圆角走四档阶梯**(与 `src/theme/tokens.ts` 的 `radius` 一致,守护测试拦截阶梯外值):`micro`(4,缩略图内 chip、勾选指示器等微元素)/ `control`(8,卡片内层控件)/ `container`(12,卡片 / 容器)/ `pill`(9999,交互元素)。**禁止**阶梯外中间值(0 / 3 / 6 / 28 等)与字面量圆角。
 - **零阴影**:层次靠背景色差 + 1px 边框,不用 `shadow*` / `elevation`。
 - **字重克制**:只用 400 / 500,极少量大写微标签可用 600。无 700+。
 - **手机只做减法**(详见 `mobile-current-execution-plan.md`):主层信息量不超过桌面主层;视觉轻、触控够(可见图标小,hitSlop 补足热区)。
@@ -144,7 +144,7 @@ function Foo() {
 ## 5. 间距 / 圆角 / 触控 / 安全区
 
 - **间距 `spacing`**:`xs 4 · sm 8 · md 12 · lg 16 · xl 24 · xxl 32`(基数 4)。避免 `2 / 6 / 13 / 17` 这类裸数字;1-2pt 的微调若实在需要,集中、少量、写注释。
-- **圆角 `radius`**:二元——`container 12` / `pill 9999`。**禁止**中间值。
+- **圆角 `radius`**:四档阶梯——`micro 4` / `control 8` / `container 12` / `pill 9999`(定义与各档用途见 `src/theme/tokens.ts`,守护测试 `designTokenDiscipline.test.ts` 拦截字面量与 token 算术)。**禁止**阶梯外值。
 - **触控目标**:主操作命中区 ≥ 44×44(iOS HIG)。可见图标可小(14–18),用 `hitSlop` 或不可见外层把热区补到 44。
 - **安全区**:屏幕根用 `SafeAreaView`(react-native-safe-area-context);需要精确 inset 用 `useSafeAreaInsets()`。键盘遮挡用 `KeyboardAvoidingView` + inset,务必开软键盘实测。
 

--- a/apps/mobile/docs/mobile-design-guide.md
+++ b/apps/mobile/docs/mobile-design-guide.md
@@ -12,7 +12,7 @@
 
 - **iOS 优先**,触控优先,跟随系统 light / dark 自动切换(`useColorScheme`)。
 - **灰度环境**:除品牌 teal(就绪态)和 Heart Orange(运行/thinking 态)两个语义色外,界面全是黑白之间的灰阶。不引入任何品牌蓝 / 绿 / 红等装饰色。
-- **圆角走四档阶梯**(与 `src/theme/tokens.ts` 的 `radius` 一致,守护测试拦截阶梯外值):`micro`(4,缩略图内 chip、勾选指示器等微元素)/ `control`(8,卡片内层控件)/ `container`(12,卡片 / 容器)/ `pill`(9999,交互元素)。**禁止**阶梯外中间值(0 / 3 / 6 / 28 等)与字面量圆角。
+- **圆角走四档阶梯**(与 `src/theme/tokens.ts` 的 `radius` 一致,守护测试拦截阶梯外值):`micro`(4,缩略图内 chip、勾选指示器等微元素)/ `control`(8,卡片内层控件)/ `container`(12,卡片 / 容器)/ `pill`(9999,交互元素)。**禁止**阶梯外中间值(0 / 3 / 6 / 28 等)与字面量圆角。根规范 `docs/design-rules/DESIGN.md` §5 的三档制约束的是桌面 surface;其「Mobile」节明确把 §15.13 / §16 之外的 mobile 布局细节委托给 `apps/mobile` 的实现,mobile 圆角阶梯以 `tokens.ts` 为准。
 - **零阴影**:层次靠背景色差 + 1px 边框,不用 `shadow*` / `elevation`。
 - **字重克制**:只用 400 / 500,极少量大写微标签可用 600。无 700+。
 - **手机只做减法**(详见 `mobile-current-execution-plan.md`):主层信息量不超过桌面主层;视觉轻、触控够(可见图标小,hitSlop 补足热区)。

--- a/apps/mobile/src/__tests__/interactionModel.test.ts
+++ b/apps/mobile/src/__tests__/interactionModel.test.ts
@@ -199,6 +199,19 @@ describe('interactionModel', () => {
     });
   });
 
+  it('marks the selected ask option with an inverse-filled check for single and multi select', () => {
+    const interactionPanelSource = readFileSync(resolve(process.cwd(), 'src/session/InteractionPanel.tsx'), 'utf8');
+
+    // 选中态不能只靠 surfaceChip 底色:dark 下它与卡底几乎同色,单选选完看不出
+    // 选了哪个(线上截图复现)。指示器必须单选/多选都渲染,只在形状上分家。
+    expect(interactionPanelSource).toContain('isMulti ? styles.optionIndicatorSquare : styles.optionIndicatorRound');
+    // 选中 = 反色实底 + ctaText 勾,对齐桌面 ask-checkbox(accent-cta-bg 实底)与
+    // 登录 radio 的「选中反色 + 对勾」体系;不得退回描边勾叠 Square 的弱指示。
+    expect(interactionPanelSource).toContain('optionIndicatorSelected: {');
+    expect(interactionPanelSource).toContain('backgroundColor: colors.cta,');
+    expect(interactionPanelSource).not.toContain('optionCheckboxMark');
+  });
+
   it('keeps issue confirmation unsupported in the mobile adapter and panel', () => {
     const interactionPanelSource = readFileSync(resolve(process.cwd(), 'src/session/InteractionPanel.tsx'), 'utf8');
 

--- a/apps/mobile/src/session/InteractionPanel.tsx
+++ b/apps/mobile/src/session/InteractionPanel.tsx
@@ -866,7 +866,7 @@ function AskUserQuestionCard({
                     isMulti ? styles.optionIndicatorSquare : styles.optionIndicatorRound,
                     selected && styles.optionIndicatorSelected,
                   ]}
-                  testID={selected ? 'interaction.ask.checkbox.checked' : 'interaction.ask.checkbox'}
+                  testID={`interaction.ask.${isMulti ? 'checkbox' : 'radio'}${selected ? '.checked' : ''}`}
                 >
                   {selected ? (
                     <Check

--- a/apps/mobile/src/session/InteractionPanel.tsx
+++ b/apps/mobile/src/session/InteractionPanel.tsx
@@ -8,7 +8,6 @@ import {
   Minus,
   Pencil,
   Plus,
-  Square,
 } from 'lucide-react-native';
 import {
   Image,
@@ -858,23 +857,25 @@ function AskUserQuestionCard({
                 ]}
                 testID={`interaction.ask.option.${index + 1}`}
               >
-                {isMulti ? (
-                  <View style={styles.optionCheckbox} testID={selected ? 'interaction.ask.checkbox.checked' : 'interaction.ask.checkbox'}>
-                    <Square
-                      color={selected ? colors.textPrimary : colors.borderStrong}
-                      size={iconSize.xl}
-                      strokeWidth={iconStroke.regular}
+                {/* 单选也要有指示器:选中反色实底 + 对勾(对齐桌面 ask-checkbox 与登录
+                    radio 的反色勾体系)。此前单选行只靠 surfaceChip 底色,dark 下与卡底
+                    几乎同色,选中态不可见。 */}
+                <View
+                  style={[
+                    styles.optionIndicator,
+                    isMulti ? styles.optionIndicatorSquare : styles.optionIndicatorRound,
+                    selected && styles.optionIndicatorSelected,
+                  ]}
+                  testID={selected ? 'interaction.ask.checkbox.checked' : 'interaction.ask.checkbox'}
+                >
+                  {selected ? (
+                    <Check
+                      color={colors.ctaText}
+                      size={iconSize.sm}
+                      strokeWidth={iconStroke.bold}
                     />
-                    {selected ? (
-                      <Check
-                        color={colors.textPrimary}
-                        size={iconSize.sm}
-                        strokeWidth={iconStroke.bold}
-                        style={styles.optionCheckboxMark}
-                      />
-                    ) : null}
-                  </View>
-                ) : null}
+                  ) : null}
+                </View>
                 <View style={styles.optionCopy}>
                   <Text style={styles.optionTitle}>{option.label}</Text>
                   {option.description ? <Text style={styles.optionDescription}>{option.description}</Text> : null}
@@ -1961,14 +1962,24 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   optionRowSelected: {
     backgroundColor: colors.surfaceChip,
   },
-  optionCheckbox: {
+  optionIndicator: {
     alignItems: 'center',
-    height: 24,
+    borderColor: colors.borderStrong,
+    borderWidth: 2,
+    height: iconSize.xl,
     justifyContent: 'center',
-    width: 24,
+    width: iconSize.xl,
   },
-  optionCheckboxMark: {
-    position: 'absolute',
+  // 单选圆形(radio 语义)、多选圆角方形(checkbox 语义),选中都用反色实底 + 勾。
+  optionIndicatorRound: {
+    borderRadius: radius.pill,
+  },
+  optionIndicatorSquare: {
+    borderRadius: radius.micro,
+  },
+  optionIndicatorSelected: {
+    backgroundColor: colors.cta,
+    borderColor: colors.cta,
   },
   optionCopy: { flex: 1, minWidth: 0 },
   optionTitle: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端「需要回答 Agent 问题」卡片的选项选中态太不明显:单选行没有任何勾选指示器,选中态只靠把行底色换成 `surfaceChip`,而 dark 下 `surfaceChip #2F2D2D` 与卡底 `surfaceElevated #312F2F` 几乎同色,选完根本看不出选了哪个(线上截图复现)。

本 PR 让单选/多选都渲染明确的勾选指示器:未选中为 `borderStrong` 2px 描边,选中为 `cta` 反色实底 + `ctaText` 对勾;单选用圆形(radio 语义)、多选用圆角方形(checkbox 语义),替换原来「描边 Square 叠同色系细勾」的弱指示。选中行的 chip 底色保留作辅助。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无(Dash 真机截图反馈)
- 本 PR 包含：`InteractionPanel.tsx` 的 AskUserQuestionCard 选项指示器改造;`interactionModel.test.ts` 新增一条源码断言测试钉住新样式;review follow-up(0cf406af):单选指示器 testID 改用 radio 语义,并把 `mobile-design-guide.md` 过时的「二元圆角」文案同步到 tokens.ts 的四档阶梯(micro/control/container/pill)
- 明确不包含：其他 interaction 卡片(permission / plan_review / plugin_setup)样式;「输入其他回答」触发行的缩进对齐(多选模式下该行本就无指示器,维持现状);desktop 端
- 用户可见变化：手机端回答 Agent 问题时,选中的选项有清晰的反色实底对勾
- 是否存在 breaking change：无

### UI 变化

改动前(dark 单选,选中第一项——唯一信号是几乎不可见的行底色)→ 改动后(选中行左侧出现反色实底 + 对勾的圆形指示器)。实机截图暂缺:本地用真实 token 值做过 HTML mockup 目检双模式效果,真机验证由 Dash 进行(见「未执行的验证」)。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §Option rows:选中行用 chip fill、以 check 标记选中态——本 PR 保留 chip fill,并把缺失的 check 指示器补齐到单选。
  - `docs/design-rules/DESIGN.md` §协议勾选 radio(figma `radiobutton 600:627`):圈 + 2px 描边、选中为**对勾**(非圆点)、选中反色实底——单选指示器完全沿用该体系,取值走语义 token(`cta` / `ctaText` / `borderStrong`)。
  - 桌面同类组件契约 `apps/desktop/src/renderer/themes/colors.ts` 的 `ask-checkbox-*`:checked = `accent-cta-bg` 实底 + 反色勾,unchecked = 灰描边——mobile 用同源 token(`cta` / `ctaText` / `borderStrong`,tokens.ts 注释明确 `borderStrong` 与 `ask-checkbox-border` 同源)。
  - 圆角走 `radius` 阶梯(圆形 `pill`、方形 `micro`),尺寸走 `iconSize` 阶梯,无字面量颜色;Light / Dark 双模式随 token 同时生效。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile typecheck
结果:通过

pnpm --filter mobile test(vitest run)
结果:259 文件 / 2521 用例全部通过(含新增测试;follow-up commit 后复跑仍全绿)

根目录 pnpm test:unit(git skill 统一 runner 预跑,基于 c7ca9c7a)
结果:仅 1 个失败——apps/desktop composerChipPresentation.test.tsx「caret 与胶囊 4px 间距」。
本 PR 完全未触碰 desktop(diff 仅 2 个 mobile 文件),该失败在纯净 origin/main 基线可
确定性复现,属基线问题;且 origin/main 随后已合入 #867(修复该用例的脆弱正则),
未混入本 PR。

pnpm check:dco
结果:通过(1 commit signed off)
```

### 手工验证

用真实 token 值(dark/light 全套)制作 HTML mockup 目检了四种状态:dark 单选改前/改后、dark 多选改前/改后、light 单选改后。选中态在两种模式下均清晰可辨(dark:`#EEEEEE` 实底 + `#252222` 勾;light:`#3C3F43` 实底 + `#FCFCFC` 勾)。

### 未执行的验证

- 真机 / 模拟器上的实际渲染未验证:本会话无法启动 mobile 客户端(无 Metro / 真机环境),无 branch/worktree + Metro 归属 + `__DEV__` build label 证据可附。双模式为「已实现、未实机目检」,按 DESIGN.md 双模式交付门槛如实说明,待 Dash 真机确认。
- 全量 `pnpm test:unit` 未在合入 #867 后的最新基线重跑(预跑基线为 c7ca9c7a,期间新 commit 与本 PR 无关,按 git 工作流交由 CI 兜底)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 mobile 端 AskUserQuestionCard 的选项行视觉;不改任何交互逻辑、决策编码或协议字段;纯 JS/样式改动,不触碰原生配置,不改变 runtime fingerprint,不触发冷更。
- 回滚 / 降级方式：revert 本 commit 即可,无数据或协议残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
