### PR TITLE
perf(desktop): 归档会话不再等一轮全量重拉，菜单归档去掉确认框

### DIFF
--- a/apps/desktop/src/main/__tests__/setSessionsStatusInDb.test.ts
+++ b/apps/desktop/src/main/__tests__/setSessionsStatusInDb.test.ts
@@ -157,6 +157,58 @@ describe('setSessionsStatusInDb', () => {
     expect(h.recycleWorktreeForRemovedSession).toHaveBeenCalledWith('s1');
   });
 
+  it('broadcasts worktree:changed only after the recycle chain finishes', async () => {
+    // renderer 的 WorktreeContext 靠这条推送才能拿到回收后的快照 —— 回收是异步链,
+    // 状态 IPC 返回时 store 条目还在,归档动作里那次「顺手 refresh」必然是旧的。
+    h.tx.mockResolvedValueOnce([
+      { sessionId: 's1', title: 'T1', workingDir: '/repo', workspaceKind: 'project', status: 'archived' },
+    ]);
+    let finishRecycle!: () => void;
+    h.recycleWorktreeForRemovedSession.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRecycle = () => resolve();
+        }),
+    );
+
+    await setSessionsStatusInDb(['s1'], 'archived');
+    await vi.waitFor(() => {
+      expect(h.recycleWorktreeForRemovedSession).toHaveBeenCalledWith('s1');
+    });
+
+    // 回收还没结束 —— 此时只该有 sessions:patched，不能提前报 worktree 已变。
+    expect(h.webContentsSend).not.toHaveBeenCalledWith('worktree:changed', expect.anything());
+
+    finishRecycle();
+    await vi.waitFor(() => {
+      expect(h.webContentsSend).toHaveBeenCalledWith('worktree:changed', { sessionId: 's1' });
+    });
+  });
+
+  it('still broadcasts worktree:changed when the recycle chain fails', async () => {
+    // 回收失败/跳过时条目仍在 store 里，重拉拿到「徽标还在」也是真实状态。
+    h.tx.mockResolvedValueOnce([
+      { sessionId: 's1', title: 'T1', workingDir: '/repo', workspaceKind: 'project', status: 'archived' },
+    ]);
+    h.recycleWorktreeForRemovedSession.mockRejectedValueOnce(new Error('git worktree remove failed'));
+
+    await setSessionsStatusInDb(['s1'], 'archived');
+
+    await vi.waitFor(() => {
+      expect(h.webContentsSend).toHaveBeenCalledWith('worktree:changed', { sessionId: 's1' });
+    });
+  });
+
+  it('does not broadcast worktree:changed when restoring to active', async () => {
+    h.tx.mockResolvedValueOnce([
+      { sessionId: 's1', title: 'T1', workingDir: '/repo', workspaceKind: 'project', status: 'active' },
+    ]);
+
+    await setSessionsStatusInDb(['s1'], 'active');
+
+    expect(h.webContentsSend).not.toHaveBeenCalledWith('worktree:changed', expect.anything());
+  });
+
   it('keeps batch archived status wired to worktree recycle scheduling', () => {
     const source = fs.readFileSync(
       new URL('../localDb/ipc/sessions.ts', import.meta.url),

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -59,6 +59,24 @@ export function broadcastSessionPatched(sessionId: string, patch: Record<string,
 }
 
 /**
+ * worktree 回收真正跑完后通知本机所有窗口重拉 worktree 快照。
+ *
+ * 没有这条推送,renderer 只能在归档/删除动作里"顺手"刷一次 worktree map,而回收
+ * 是下面 fire-and-forget 的异步链(动态 import → 关子进程 → git worktree remove →
+ * 文件系统清理),store 条目被移除的时刻远晚于状态 IPC 返回。renderer 那次刷新会
+ * 快照到仍然存在的旧条目,归档列表上的 worktree 徽标就一直陈旧,直到某次无关的
+ * 刷新才纠正(codex review P1)。
+ *
+ * 只广播给本机窗口、不进 device-link tap:控制端(手机/另一台桌面)的远程会话
+ * worktree 元数据走 device-link 自己的镜像链路,不经本机 WorktreeContext。
+ */
+function broadcastWorktreeChanged(sessionId: string): void {
+  for (const w of BrowserWindow.getAllWindows()) {
+    if (!w.isDestroyed()) w.webContents.send('worktree:changed', { sessionId });
+  }
+}
+
+/**
  * 会话 status 显式变为 deleted / archived 后的 worktree 回收调度(P0 重构:回收
  * 唯一驱动点,从 Maker onClose 迁到这里——close 是进程生命周期事件,/clear、鉴权
  * 重连、CLI 崩溃都会触发,不能当"用户不要工作区了"的信号)。
@@ -67,6 +85,9 @@ export function broadcastSessionPatched(sessionId: string, patch: Record<string,
  * 先关子进程再回收——Windows 下 CLI 子进程 cwd 在 worktree 内会锁目录。
  * 动态 import 避免 localDb → maker-host / worktree 的静态模块环(worktreeStore
  * 反向 import 本文件的 setWorktreePathInDb)。
+ *
+ * 回收链结束后(无论成功、跳过还是失败)都广播一次 worktree:changed —— 失败/跳过
+ * 时条目仍在 store 里,重拉拿到的就是"徽标还在"这个真实状态,同样是对的。
  */
 function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unknown): void {
   if (status !== 'deleted' && status !== 'archived') return;
@@ -85,12 +106,16 @@ function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unkno
         .catch(() => undefined);
     });
     await recycle.recycleWorktreeForRemovedSession(sessionId);
-  })().catch((err) => {
-    log.warn('worktree recycle after session status change failed', {
-      sessionId,
-      err: err instanceof Error ? err.message : String(err),
+  })()
+    .catch((err) => {
+      log.warn('worktree recycle after session status change failed', {
+        sessionId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    })
+    .finally(() => {
+      broadcastWorktreeChanged(sessionId);
     });
-  });
 }
 
 /**

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -295,6 +295,9 @@ const fanOutComputerPermissionGuideStatusChanged = createIpcFanOut(
   'maker:computer:permission-guide-status-changed',
 );
 const fanOutAppUpdateProgress = createIpcFanOut('app-update-progress');
+// worktree 回收(归档/删除后的异步链)真正跑完 —— renderer 据此重拉 worktree 快照,
+// 否则徽标会停在回收前的旧条目上。只在本机窗口内广播。
+const fanOutWorktreeChanged = createIpcFanOut('worktree:changed');
 const fanOutAuthStateChange = createIpcFanOut('auth:state-change');
 const fanOutAuthSessionExpired = createIpcFanOut('auth:session-expired');
 // 使用统计(TapDB)的同意状态 / 开关变化;renderer 据此即时 init 或 opt-out
@@ -3137,6 +3140,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('worktree:restore-status', sessionId),
   worktreeRestoreForSession: (sessionId: string): Promise<{ ok: boolean; snapshotApplied?: boolean; message?: string }> =>
     ipcRenderer.invoke('worktree:restore-for-session', sessionId),
+  /**
+   * 订阅「worktree 回收链已跑完」。payload: { sessionId }。
+   * 归档/删除后 main 侧的回收是 fire-and-forget 的异步链,store 条目移除远晚于状态
+   * IPC 返回;renderer 只在动作里刷一次会拿到旧快照,徽标就一直陈旧。
+   */
+  onWorktreeChanged: fanOutWorktreeChanged,
 
   // ── Slack Hook(公司中心 slack-hook-server 接入, 单内置连接) ─────────────
   // 通道名与 shared/hookControlIpc.ts 保持一致(preload 因 vite chunking 不

--- a/apps/desktop/src/renderer/__tests__/sessionsStoreStatusBucketMigration.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/sessionsStoreStatusBucketMigration.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+/**
+ * sessionsStore 跨桶迁移（patch.status）不变量
+ * ---------------------------------------------------------------------------
+ * 回归的是「点归档后对话过半秒才消失」：早期 patchLocal 对任何桶归属不一致都
+ * drop + 重拉，当前可见桶变 null 后 useCCSessions 的 `next !== null` 守卫会跳过
+ * setState，列表停在**仍含被归档行**的陈旧快照，直到重拉的 sessions:list（LEFT
+ * JOIN messages + GROUP BY 的重查询）回来才更新，把调用方的乐观更新整段抵消。
+ *
+ * 现在的口径是不对称的：该移出的桶就地移除（本地即可定论，桶保持非 null），
+ * 只有该补进却缺 row 的桶才 drop 重拉。下面每条测试都钉这个不对称。
+ */
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Session } from '@/lib/ccAgent.types';
+
+const mocks = vi.hoisted(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {},
+  });
+  return { list: vi.fn() };
+});
+
+vi.mock('@/lib/sessionService', () => ({
+  list: mocks.list,
+  create: vi.fn(),
+}));
+
+import { useCCSessions } from '@/hooks/useCCSessions';
+import { sessionsStore } from '@/lib/sessionsStore';
+import type { ListStatusFilter } from '@/lib/sessionService';
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function session(id: string, status: Session['status'] = 'active'): Session {
+  return { id, status } as Session;
+}
+
+/** 本次 list mock 收到的 filter 参数（sessionService.list(limit, filter)）。 */
+function requestedFilters(): ListStatusFilter[] {
+  return mocks.list.mock.calls.map((call) => call[1] as ListStatusFilter);
+}
+
+describe('sessionsStore status bucket migration', () => {
+  beforeEach(() => {
+    mocks.list.mockReset();
+    sessionsStore.reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    sessionsStore.reset();
+  });
+
+  it('archiving removes the row from the active bucket in place, without dropping or refetching it', async () => {
+    mocks.list.mockResolvedValueOnce([session('archive-me'), session('keep')]);
+    await sessionsStore.ensureByFilter('active');
+    mocks.list.mockReset();
+
+    act(() => sessionsStore.patchLocal('archive-me', { status: 'archived', pinnedAt: null }));
+
+    // 桶必须仍是数组（非 null）—— null 才是订阅者跳过 setState 的根因。
+    expect(sessionsStore.getByFilter('active')?.map(({ id }) => id)).toEqual(['keep']);
+    expect(mocks.list).not.toHaveBeenCalled();
+  });
+
+  it('drops the archived row from a mounted list synchronously, before any IPC resolves', async () => {
+    mocks.list.mockResolvedValueOnce([session('archive-me'), session('keep')]);
+    await sessionsStore.ensureByFilter('active');
+    // 归档后若有任何重拉，让它永远悬着：断言必须在没有 IPC 回包的前提下成立。
+    mocks.list.mockReset();
+    mocks.list.mockImplementation(() => deferred<Session[]>().promise);
+
+    const view = renderHook(() => useCCSessions());
+    expect(view.result.current.sessions.map(({ id }) => id)).toEqual(['archive-me', 'keep']);
+
+    act(() => sessionsStore.patchLocal('archive-me', { status: 'archived', pinnedAt: null }));
+
+    expect(view.result.current.sessions.map(({ id }) => id)).toEqual(['keep']);
+    expect(view.result.current.isLoading).toBe(false);
+  });
+
+  it('refetches only the bucket that is missing the row after archiving', async () => {
+    mocks.list
+      .mockResolvedValueOnce([session('archive-me'), session('keep-active')])
+      .mockResolvedValueOnce([session('already-archived', 'archived')]);
+    await sessionsStore.ensureByFilter('active');
+    await sessionsStore.ensureByFilter('archived');
+    mocks.list.mockReset();
+    mocks.list.mockResolvedValue([
+      session('archive-me', 'archived'),
+      session('already-archived', 'archived'),
+    ]);
+
+    act(() => sessionsStore.patchLocal('archive-me', { status: 'archived' }));
+
+    // active 桶就地移除，不重拉；archived 桶缺这一条 row，只能问 DB。
+    expect(sessionsStore.getByFilter('active')?.map(({ id }) => id)).toEqual(['keep-active']);
+    expect(requestedFilters()).toEqual(['archived']);
+    await waitFor(() => {
+      expect(sessionsStore.getByFilter('archived')?.map(({ id }) => id)).toEqual([
+        'archive-me',
+        'already-archived',
+      ]);
+    });
+  });
+
+  it('keeps the row in the all bucket with the new status', async () => {
+    mocks.list.mockResolvedValueOnce([session('archive-me'), session('keep')]);
+    await sessionsStore.ensureByFilter('all');
+    mocks.list.mockReset();
+
+    act(() => sessionsStore.patchLocal('archive-me', { status: 'archived' }));
+
+    expect(sessionsStore.getByFilter('all')).toEqual([
+      expect.objectContaining({ id: 'archive-me', status: 'archived' }),
+      expect.objectContaining({ id: 'keep' }),
+    ]);
+    expect(mocks.list).not.toHaveBeenCalled();
+  });
+
+  it('unarchiving removes the row from the archived bucket in place', async () => {
+    mocks.list.mockResolvedValueOnce([
+      session('restore-me', 'archived'),
+      session('stay-archived', 'archived'),
+    ]);
+    await sessionsStore.ensureByFilter('archived');
+    mocks.list.mockReset();
+
+    act(() => sessionsStore.patchLocal('restore-me', { status: 'active' }));
+
+    expect(sessionsStore.getByFilter('archived')?.map(({ id }) => id)).toEqual(['stay-archived']);
+    expect(mocks.list).not.toHaveBeenCalled();
+  });
+
+  it('does not let a list request started before the archive write the row back', async () => {
+    const staleRequest = deferred<Session[]>();
+    const replacementRequest = deferred<Session[]>();
+    mocks.list
+      .mockImplementationOnce(() => staleRequest.promise)
+      .mockImplementationOnce(() => replacementRequest.promise);
+
+    // 请求在途、桶还没进 cache 时归档：旧响应整桶 cache.set 会把被归档行带回来。
+    const staleLoad = sessionsStore.ensureByFilter('active');
+    act(() => sessionsStore.patchLocal('archive-me', { status: 'archived' }));
+
+    expect(requestedFilters()).toEqual(['active', 'active']);
+    replacementRequest.resolve([session('keep')]);
+    await waitFor(() => {
+      expect(sessionsStore.getByFilter('active')?.map(({ id }) => id)).toEqual(['keep']);
+    });
+
+    staleRequest.resolve([session('archive-me'), session('keep')]);
+    await staleLoad;
+
+    expect(sessionsStore.getByFilter('active')?.map(({ id }) => id)).toEqual(['keep']);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
@@ -109,23 +109,26 @@ describe('Project 行内 + 也对标统一 New(delayed-create)', () => {
 });
 
 describe('archive dirty-worktree warning', () => {
-  it('preflights both archive entries and only opens a dialog for a dirty worktree', () => {
-    // 钉的是预检顺序,不是排版:末段用 [\s\S]*? 容忍换行。
+  it('only skips the archive dialog when the preflight confirms the worktree is clean', () => {
+    // 钉的是预检顺序与放行判据,不是排版:末段用 [\s\S]*? 容忍换行。
     //   · 菜单归档与行内 archive-now 共用 isArchiveLike 这一条无弹窗路径 ——
-    //     归档可逆,只有 dirty worktree 才升级到 ConfirmDialog;
-    //   · 走 resolveDirtyWorktreeForRemoval(而非直调 fetch)才吃得到菜单打开 /
+    //     归档可逆,只有 worktree 有情况才升级到 ConfirmDialog;
+    //   · 判据必须是 `preflight !== 'clean'`,**不能**退回布尔的「不是脏的就放行」:
+    //     预检失败是 'unknown',塌成放行就会静默回收带未提交改动的 worktree
+    //     (greptile review);
+    //   · 走 resolveWorktreeRemovalPreflight(而非直调 fetch)才吃得到菜单打开 /
     //     亮出 Confirm 胶囊时的预取,见 worktreeRemovalWarning 的预取缓存;
     //   · activeSessionId 取 viewedSessionIdRef.current(而非 viewedSessionId)是为了
     //     让 handleActionClick 的 useCallback deps 保持稳定,见 sessionRowRenderIsolation
     //     的行渲染隔离不变量。
     expect(sidebarSource).toMatch(
-      /if \(isArchiveLike\) \{[\s\S]*?resolveDirtyWorktreeForRemoval\([\s\S]*?if \(dirtyWorktree\) \{[\s\S]*?setConfirm\(\{ open: true, sessionId, action: 'archive', dirtyWorktree: true \}\);[\s\S]*?return;[\s\S]*?await runSessionAction\(sessionId, 'archive', \{[\s\S]*?activeSessionId: viewedSessionIdRef\.current,[\s\S]*?\}\);/,
+      /if \(isArchiveLike\) \{[\s\S]*?resolveWorktreeRemovalPreflight\([\s\S]*?if \(preflight !== 'clean'\) \{[\s\S]*?setConfirm\(\{[\s\S]*?action: 'archive',[\s\S]*?dirtyWorktree: preflight === 'dirty',[\s\S]*?\}\);[\s\S]*?return;[\s\S]*?await runSessionAction\(sessionId, 'archive', \{[\s\S]*?activeSessionId: viewedSessionIdRef\.current,[\s\S]*?\}\);/,
     );
   });
 
   it('keeps the delete confirm dialog — deletion is irreversible', () => {
     expect(sidebarSource).toMatch(
-      /if \(action === 'delete'\) \{[\s\S]*?resolveDirtyWorktreeForRemoval\([\s\S]*?setConfirm\(\{ open: true, sessionId, action, dirtyWorktree \}\);/,
+      /if \(action === 'delete'\) \{[\s\S]*?resolveWorktreeRemovalPreflight\([\s\S]*?setConfirm\(\{ open: true, sessionId, action, dirtyWorktree \}\);/,
     );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
@@ -108,13 +108,24 @@ describe('Project 行内 + 也对标统一 New(delayed-create)', () => {
   });
 });
 
-describe('inline archive dirty-worktree warning', () => {
-  it('preflights archive-now and opens the warning dialog before archiving a dirty worktree', () => {
-    // 钉的是预检顺序,不是排版:末段用 [\s\S]*? 容忍换行。activeSessionId 取
-    // viewedSessionIdRef.current(而非 viewedSessionId)是为了让 handleActionClick
-    // 的 useCallback deps 保持稳定,见 sessionRowRenderIsolation 的行渲染隔离不变量。
+describe('archive dirty-worktree warning', () => {
+  it('preflights both archive entries and only opens a dialog for a dirty worktree', () => {
+    // 钉的是预检顺序,不是排版:末段用 [\s\S]*? 容忍换行。
+    //   · 菜单归档与行内 archive-now 共用 isArchiveLike 这一条无弹窗路径 ——
+    //     归档可逆,只有 dirty worktree 才升级到 ConfirmDialog;
+    //   · 走 resolveDirtyWorktreeForRemoval(而非直调 fetch)才吃得到菜单打开 /
+    //     亮出 Confirm 胶囊时的预取,见 worktreeRemovalWarning 的预取缓存;
+    //   · activeSessionId 取 viewedSessionIdRef.current(而非 viewedSessionId)是为了
+    //     让 handleActionClick 的 useCallback deps 保持稳定,见 sessionRowRenderIsolation
+    //     的行渲染隔离不变量。
     expect(sidebarSource).toMatch(
-      /if \(action === 'archive-now'\) \{[\s\S]*?fetchDirtyWorktreeForRemoval\([\s\S]*?if \(dirtyWorktree\) \{[\s\S]*?setConfirm\(\{ open: true, sessionId, action: 'archive', dirtyWorktree: true \}\);[\s\S]*?return;[\s\S]*?await runSessionAction\(sessionId, 'archive', \{[\s\S]*?activeSessionId: viewedSessionIdRef\.current,[\s\S]*?\}\);/,
+      /if \(isArchiveLike\) \{[\s\S]*?resolveDirtyWorktreeForRemoval\([\s\S]*?if \(dirtyWorktree\) \{[\s\S]*?setConfirm\(\{ open: true, sessionId, action: 'archive', dirtyWorktree: true \}\);[\s\S]*?return;[\s\S]*?await runSessionAction\(sessionId, 'archive', \{[\s\S]*?activeSessionId: viewedSessionIdRef\.current,[\s\S]*?\}\);/,
+    );
+  });
+
+  it('keeps the delete confirm dialog — deletion is irreversible', () => {
+    expect(sidebarSource).toMatch(
+      /if \(action === 'delete'\) \{[\s\S]*?resolveDirtyWorktreeForRemoval\([\s\S]*?setConfirm\(\{ open: true, sessionId, action, dirtyWorktree \}\);/,
     );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarUpperSingleButton.test.ts
@@ -126,6 +126,18 @@ describe('archive dirty-worktree warning', () => {
     );
   });
 
+  it('resolves the worktree preflight last, after the attachment gate', () => {
+    // 预检之后再 await 任何东西都会给 clean 结论留失效窗口(codex review):
+    // 接管查询必须先结算,worktree 预检是最后一个前置条件。
+    const archiveBranch = sidebarSource.match(
+      /if \(isArchiveLike\) \{[\s\S]*?await runSessionAction\(sessionId, 'archive'/,
+    )?.[0];
+    expect(archiveBranch).toBeTruthy();
+    expect(archiveBranch!.indexOf('blockedByAttachment()')).toBeLessThan(
+      archiveBranch!.indexOf('resolveWorktreeRemovalPreflight('),
+    );
+  });
+
   it('keeps the delete confirm dialog — deletion is irreversible', () => {
     expect(sidebarSource).toMatch(
       /if \(action === 'delete'\) \{[\s\S]*?resolveWorktreeRemovalPreflight\([\s\S]*?setConfirm\(\{ open: true, sessionId, action, dirtyWorktree \}\);/,

--- a/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+/**
+ * WorktreeContext 必须等 main 的 worktree:changed 推送才能拿到回收后的真实快照。
+ *
+ * 归档/删除后 main 侧的回收是 fire-and-forget 的异步链（关子进程 → git worktree
+ * remove → 文件系统清理），store 条目被移除的时刻远晚于状态 IPC 返回。调用方在
+ * 动作里那次「顺手 refresh」几乎必然快照到仍然存在的旧条目，徽标会一直停在回收前
+ * 的状态，直到某次无关刷新才纠正（codex review P1）。
+ */
+
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WorktreeProvider, useWorktrees } from '@/contexts/WorktreeContext';
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() }),
+}));
+
+const mocks = {
+  worktreeListAll: vi.fn(),
+  listeners: new Set<(payload: { sessionId: string }) => void>(),
+};
+
+function emitWorktreeChanged(sessionId: string): void {
+  mocks.listeners.forEach((cb) => cb({ sessionId }));
+}
+
+function Probe() {
+  const metas = useWorktrees();
+  return <span data-testid="ids">{Object.keys(metas).sort().join(',')}</span>;
+}
+
+beforeEach(() => {
+  mocks.worktreeListAll.mockReset();
+  mocks.listeners.clear();
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      worktreeListAll: mocks.worktreeListAll,
+      onWorktreeChanged: (cb: (payload: { sessionId: string }) => void) => {
+        mocks.listeners.add(cb);
+        return () => mocks.listeners.delete(cb);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('WorktreeContext recycle refresh', () => {
+  it('re-pulls the snapshot when main reports the recycle finished', async () => {
+    // 归档动作那一刻回收还没跑完 —— listAll 仍然带着即将被回收的条目。
+    mocks.worktreeListAll.mockResolvedValueOnce([
+      { sessionId: 'archived-one', path: '/tmp/wt/archived-one' },
+      { sessionId: 'other', path: '/tmp/wt/other' },
+    ]);
+    const view = render(
+      <WorktreeProvider>
+        <Probe />
+      </WorktreeProvider>,
+    );
+    await waitFor(() => {
+      expect(view.getByTestId('ids').textContent).toBe('archived-one,other');
+    });
+
+    // 回收链跑完，store 里已经没有那条了。
+    mocks.worktreeListAll.mockResolvedValueOnce([
+      { sessionId: 'other', path: '/tmp/wt/other' },
+    ]);
+    await act(async () => {
+      emitWorktreeChanged('archived-one');
+    });
+
+    await waitFor(() => {
+      expect(view.getByTestId('ids').textContent).toBe('other');
+    });
+    expect(mocks.worktreeListAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribes on unmount so a later push cannot refresh a dead tree', async () => {
+    mocks.worktreeListAll.mockResolvedValue([]);
+    const view = render(
+      <WorktreeProvider>
+        <Probe />
+      </WorktreeProvider>,
+    );
+    await waitFor(() => expect(mocks.worktreeListAll).toHaveBeenCalledTimes(1));
+
+    view.unmount();
+    expect(mocks.listeners.size).toBe(0);
+
+    emitWorktreeChanged('archived-one');
+    expect(mocks.worktreeListAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('still mounts when the push channel is unavailable', async () => {
+    // 老 preload / 非 Electron 宿主下 onWorktreeChanged 可能缺失，不能让 Provider 崩。
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { worktreeListAll: mocks.worktreeListAll },
+    });
+    mocks.worktreeListAll.mockResolvedValue([
+      { sessionId: 'only', path: '/tmp/wt/only' },
+    ]);
+
+    const view = render(
+      <WorktreeProvider>
+        <Probe />
+      </WorktreeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(view.getByTestId('ids').textContent).toBe('only');
+    });
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/worktreeRemovalPreflightPrefetch.test.ts
+++ b/apps/desktop/src/renderer/__tests__/worktreeRemovalPreflightPrefetch.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+/**
+ * 归档/删除 dirty 预检的预取缓存
+ * ---------------------------------------------------------------------------
+ * 这次查询要在 main 侧跑 git status，是「点了归档、行还没消失」里剩下的最大一块
+ * 等待。归档入口在执行前都有一段人类操作空窗（行内两步确认 / 先开菜单再点条目），
+ * 预取就是把查询挪进那段空窗，执行时命中缓存。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  worktreeRemovalPreview: vi.fn(),
+  deviceLinkInvoke: vi.fn(),
+}));
+
+import {
+  prefetchDirtyWorktreeForRemoval,
+  resetDirtyWorktreePreflightCache,
+  resolveDirtyWorktreeForRemoval,
+} from '@/lib/worktreeRemovalWarning';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.worktreeRemovalPreview.mockReset();
+  mocks.deviceLinkInvoke.mockReset();
+  resetDirtyWorktreePreflightCache();
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      worktreeRemovalPreview: mocks.worktreeRemovalPreview,
+      deviceLink: { invoke: mocks.deviceLinkInvoke },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetDirtyWorktreePreflightCache();
+});
+
+describe('dirty worktree preflight prefetch', () => {
+  it('serves the prefetched result without querying main again', async () => {
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
+
+    prefetchDirtyWorktreeForRemoval('session-1');
+    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(true);
+
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes repeated prefetches for the same session', async () => {
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: false, dirty: false });
+
+    prefetchDirtyWorktreeForRemoval('session-1');
+    prefetchDirtyWorktreeForRemoval('session-1');
+    prefetchDirtyWorktreeForRemoval('session-1');
+    await resolveDirtyWorktreeForRemoval('session-1');
+
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps buckets per session rather than sharing one result', async () => {
+    mocks.worktreeRemovalPreview.mockImplementation((sessionId: string) =>
+      Promise.resolve({ hasWorktree: true, dirty: sessionId === 'dirty-one' }),
+    );
+
+    prefetchDirtyWorktreeForRemoval('dirty-one');
+    prefetchDirtyWorktreeForRemoval('clean-one');
+
+    await expect(resolveDirtyWorktreeForRemoval('dirty-one')).resolves.toBe(true);
+    await expect(resolveDirtyWorktreeForRemoval('clean-one')).resolves.toBe(false);
+  });
+
+  it('re-queries once the prefetch has gone stale', async () => {
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
+
+    prefetchDirtyWorktreeForRemoval('session-1');
+    await resolveDirtyWorktreeForRemoval('session-1');
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
+
+    // TTL 是 8s：略长于行内 Confirm 胶囊 4s 的自动撤回窗口，又不会把
+    // 「用户刚提交完改动」的旧结论留太久。
+    vi.advanceTimersByTime(8_001);
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: false });
+    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(false);
+
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves without a prefetch by querying directly', async () => {
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
+
+    await expect(resolveDirtyWorktreeForRemoval('never-prefetched')).resolves.toBe(true);
+
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes device-link sessions through the tunnel and degrades to no warning on failure', async () => {
+    mocks.deviceLinkInvoke.mockRejectedValue(new Error('tunnel down'));
+
+    await expect(resolveDirtyWorktreeForRemoval('remote-1', 'device-a')).resolves.toBe(false);
+
+    expect(mocks.deviceLinkInvoke).toHaveBeenCalledWith(
+      'device-a',
+      'worktree:removal-preview',
+      ['remote-1'],
+    );
+    expect(mocks.worktreeRemovalPreview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/worktreeRemovalPreflightPrefetch.test.ts
+++ b/apps/desktop/src/renderer/__tests__/worktreeRemovalPreflightPrefetch.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
 /**
- * 归档/删除 dirty 预检的预取缓存
- * ---------------------------------------------------------------------------
- * 这次查询要在 main 侧跑 git status，是「点了归档、行还没消失」里剩下的最大一块
- * 等待。归档入口在执行前都有一段人类操作空窗（行内两步确认 / 先开菜单再点条目），
- * 预取就是把查询挪进那段空窗，执行时命中缓存。
+ * 归档/删除前 worktree 预检的三态语义 + 预取缓存。
+ *
+ * 两条不变量：
+ *   1. **三态**：查询失败必须是 `'unknown'`，不能塌成 `'clean'`。归档改成「干净就免
+ *      确认」之后，把失败当干净就等于静默回收可能带着未提交改动的 worktree。
+ *   2. **只复用 dirty**：`'clean'` / `'unknown'` 一律在执行前重新查。复用 clean 会让
+ *      预取之后被写脏的工作区跳过确认；复用 unknown 只会把保守分支多留 8 秒。
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,9 +18,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 import {
+  fetchDirtyWorktreeForRemoval,
   prefetchDirtyWorktreeForRemoval,
   resetDirtyWorktreePreflightCache,
-  resolveDirtyWorktreeForRemoval,
+  resolveWorktreeRemovalPreflight,
 } from '@/lib/worktreeRemovalWarning';
 
 beforeEach(() => {
@@ -40,10 +43,52 @@ afterEach(() => {
   resetDirtyWorktreePreflightCache();
 });
 
-describe('dirty worktree preflight prefetch', () => {
+describe('worktree removal preflight — three states', () => {
+  it('reports unknown (not clean) when the query fails', async () => {
+    // 这是关键的安全语义:失败塌成 clean 就会让归档静默放行。
+    mocks.worktreeRemovalPreview.mockRejectedValue(new Error('ipc exploded'));
+
+    await expect(resolveWorktreeRemovalPreflight('session-1')).resolves.toBe('unknown');
+  });
+
+  it('maps a session without a worktree to clean', async () => {
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: false, dirty: false });
+
+    await expect(resolveWorktreeRemovalPreflight('session-1')).resolves.toBe('clean');
+  });
+
+  it('maps a dirty worktree to dirty', async () => {
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
+
+    await expect(resolveWorktreeRemovalPreflight('session-1')).resolves.toBe('dirty');
+  });
+
+  it('keeps the boolean helper false on failure for always-confirm callers', async () => {
+    // 批量计数 / doc 模式关闭标签页 / 删除都必然弹确认框,那里 false 只影响
+    // 文案是否追加警告,不会变成静默放行。
+    mocks.worktreeRemovalPreview.mockRejectedValue(new Error('ipc exploded'));
+
+    await expect(fetchDirtyWorktreeForRemoval('session-1')).resolves.toBe(false);
+  });
+
+  it('routes device-link sessions through the tunnel and reports unknown on tunnel failure', async () => {
+    mocks.deviceLinkInvoke.mockRejectedValue(new Error('tunnel down'));
+
+    await expect(resolveWorktreeRemovalPreflight('remote-1', 'device-a')).resolves.toBe('unknown');
+
+    expect(mocks.deviceLinkInvoke).toHaveBeenCalledWith(
+      'device-a',
+      'worktree:removal-preview',
+      ['remote-1'],
+    );
+    expect(mocks.worktreeRemovalPreview).not.toHaveBeenCalled();
+  });
+});
+
+describe('worktree removal preflight — prefetch cache', () => {
   // prefetch 是 fire-and-forget，测试里用同一入口 await 一次代表「预取已落地」
   // （结论回填发生在内部 then 里，先于测试的 await 执行）。
-  const settledPrefetch = (sessionId: string) => resolveDirtyWorktreeForRemoval(sessionId);
+  const settledPrefetch = (sessionId: string) => resolveWorktreeRemovalPreflight(sessionId);
 
   it('serves a prefetched dirty result without querying main again', async () => {
     // dirty 复用是安全侧的:最坏只是确认弹窗多出现一次。
@@ -52,7 +97,7 @@ describe('dirty worktree preflight prefetch', () => {
     await settledPrefetch('session-1');
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
 
-    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(true);
+    await expect(resolveWorktreeRemovalPreflight('session-1')).resolves.toBe('dirty');
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
   });
 
@@ -63,14 +108,23 @@ describe('dirty worktree preflight prefetch', () => {
     await settledPrefetch('session-1');
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
 
-    // 预取之后工作区变脏 —— 执行时必须重新查到这个新结论。
     mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
-    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(true);
+    await expect(resolveWorktreeRemovalPreflight('session-1')).resolves.toBe('dirty');
 
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(2);
   });
 
-  it('does not reuse a clean result even while the prefetch is still in flight', async () => {
+  it('does not cache unknown — retries instead of pinning the conservative branch', async () => {
+    mocks.worktreeRemovalPreview.mockRejectedValueOnce(new Error('transient'));
+    await settledPrefetch('session-1');
+
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: false, dirty: false });
+    await expect(resolveWorktreeRemovalPreflight('session-1')).resolves.toBe('clean');
+
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reuse a non-dirty result even while the prefetch is still in flight', async () => {
     let resolveFirst: ((value: { hasWorktree: boolean; dirty: boolean }) => void) | undefined;
     mocks.worktreeRemovalPreview.mockImplementationOnce(
       () =>
@@ -82,10 +136,10 @@ describe('dirty worktree preflight prefetch', () => {
 
     prefetchDirtyWorktreeForRemoval('session-1');
     // 预取还没回来就点了归档:in-flight 的结论同样可能是 clean，不能拿来放行。
-    const resolved = resolveDirtyWorktreeForRemoval('session-1');
+    const resolved = resolveWorktreeRemovalPreflight('session-1');
     resolveFirst?.({ hasWorktree: true, dirty: false });
 
-    await expect(resolved).resolves.toBe(true);
+    await expect(resolved).resolves.toBe('dirty');
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(2);
   });
 
@@ -97,22 +151,22 @@ describe('dirty worktree preflight prefetch', () => {
     await settledPrefetch('dirty-one');
     await settledPrefetch('clean-one');
 
-    await expect(resolveDirtyWorktreeForRemoval('dirty-one')).resolves.toBe(true);
-    await expect(resolveDirtyWorktreeForRemoval('clean-one')).resolves.toBe(false);
+    await expect(resolveWorktreeRemovalPreflight('dirty-one')).resolves.toBe('dirty');
+    await expect(resolveWorktreeRemovalPreflight('clean-one')).resolves.toBe('clean');
   });
 
   it('re-queries once the prefetched dirty result has gone stale', async () => {
     mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
 
     await settledPrefetch('session-1');
-    await resolveDirtyWorktreeForRemoval('session-1');
+    await resolveWorktreeRemovalPreflight('session-1');
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
 
     // TTL 是 8s：略长于行内 Confirm 胶囊 4s 的自动撤回窗口。只对 dirty 结论生效 ——
-    // clean 从不复用，所以不存在「过期的 clean 被用来放行归档」。
+    // clean / unknown 从不复用，所以不存在「过期结论被用来放行归档」。
     vi.advanceTimersByTime(8_001);
     mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: false });
-    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(false);
+    await expect(resolveWorktreeRemovalPreflight('session-1')).resolves.toBe('clean');
 
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(2);
   });
@@ -120,21 +174,8 @@ describe('dirty worktree preflight prefetch', () => {
   it('resolves without a prefetch by querying directly', async () => {
     mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
 
-    await expect(resolveDirtyWorktreeForRemoval('never-prefetched')).resolves.toBe(true);
+    await expect(resolveWorktreeRemovalPreflight('never-prefetched')).resolves.toBe('dirty');
 
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes device-link sessions through the tunnel and degrades to no warning on failure', async () => {
-    mocks.deviceLinkInvoke.mockRejectedValue(new Error('tunnel down'));
-
-    await expect(resolveDirtyWorktreeForRemoval('remote-1', 'device-a')).resolves.toBe(false);
-
-    expect(mocks.deviceLinkInvoke).toHaveBeenCalledWith(
-      'device-a',
-      'worktree:removal-preview',
-      ['remote-1'],
-    );
-    expect(mocks.worktreeRemovalPreview).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/worktreeRemovalPreflightPrefetch.test.ts
+++ b/apps/desktop/src/renderer/__tests__/worktreeRemovalPreflightPrefetch.test.ts
@@ -41,24 +41,52 @@ afterEach(() => {
 });
 
 describe('dirty worktree preflight prefetch', () => {
-  it('serves the prefetched result without querying main again', async () => {
+  // prefetch 是 fire-and-forget，测试里用同一入口 await 一次代表「预取已落地」
+  // （结论回填发生在内部 then 里，先于测试的 await 执行）。
+  const settledPrefetch = (sessionId: string) => resolveDirtyWorktreeForRemoval(sessionId);
+
+  it('serves a prefetched dirty result without querying main again', async () => {
+    // dirty 复用是安全侧的:最坏只是确认弹窗多出现一次。
     mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
 
-    prefetchDirtyWorktreeForRemoval('session-1');
-    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(true);
+    await settledPrefetch('session-1');
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
 
+    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(true);
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
   });
 
-  it('dedupes repeated prefetches for the same session', async () => {
-    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: false, dirty: false });
-
-    prefetchDirtyWorktreeForRemoval('session-1');
-    prefetchDirtyWorktreeForRemoval('session-1');
-    prefetchDirtyWorktreeForRemoval('session-1');
-    await resolveDirtyWorktreeForRemoval('session-1');
-
+  it('never reuses a clean prefetch — revalidates at execution time', async () => {
+    // 归档会顺带回收 worktree。预取到 clean 之后工作区被写脏时,复用旧结论会整个
+    // 跳过 dirty 确认,用户拿不到「先提交或取消」的机会(greptile / codex 的 P1)。
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: false });
+    await settledPrefetch('session-1');
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
+
+    // 预取之后工作区变脏 —— 执行时必须重新查到这个新结论。
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
+    await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(true);
+
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reuse a clean result even while the prefetch is still in flight', async () => {
+    let resolveFirst: ((value: { hasWorktree: boolean; dirty: boolean }) => void) | undefined;
+    mocks.worktreeRemovalPreview.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
+
+    prefetchDirtyWorktreeForRemoval('session-1');
+    // 预取还没回来就点了归档:in-flight 的结论同样可能是 clean，不能拿来放行。
+    const resolved = resolveDirtyWorktreeForRemoval('session-1');
+    resolveFirst?.({ hasWorktree: true, dirty: false });
+
+    await expect(resolved).resolves.toBe(true);
+    expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(2);
   });
 
   it('keeps buckets per session rather than sharing one result', async () => {
@@ -66,22 +94,22 @@ describe('dirty worktree preflight prefetch', () => {
       Promise.resolve({ hasWorktree: true, dirty: sessionId === 'dirty-one' }),
     );
 
-    prefetchDirtyWorktreeForRemoval('dirty-one');
-    prefetchDirtyWorktreeForRemoval('clean-one');
+    await settledPrefetch('dirty-one');
+    await settledPrefetch('clean-one');
 
     await expect(resolveDirtyWorktreeForRemoval('dirty-one')).resolves.toBe(true);
     await expect(resolveDirtyWorktreeForRemoval('clean-one')).resolves.toBe(false);
   });
 
-  it('re-queries once the prefetch has gone stale', async () => {
+  it('re-queries once the prefetched dirty result has gone stale', async () => {
     mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: true });
 
-    prefetchDirtyWorktreeForRemoval('session-1');
+    await settledPrefetch('session-1');
     await resolveDirtyWorktreeForRemoval('session-1');
     expect(mocks.worktreeRemovalPreview).toHaveBeenCalledTimes(1);
 
-    // TTL 是 8s：略长于行内 Confirm 胶囊 4s 的自动撤回窗口，又不会把
-    // 「用户刚提交完改动」的旧结论留太久。
+    // TTL 是 8s：略长于行内 Confirm 胶囊 4s 的自动撤回窗口。只对 dirty 结论生效 ——
+    // clean 从不复用，所以不存在「过期的 clean 被用来放行归档」。
     vi.advanceTimersByTime(8_001);
     mocks.worktreeRemovalPreview.mockResolvedValue({ hasWorktree: true, dirty: false });
     await expect(resolveDirtyWorktreeForRemoval('session-1')).resolves.toBe(false);

--- a/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
+++ b/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
@@ -5,7 +5,8 @@
  * worktree-parallel-sessions 前端方案 M2：
  *   - mount 时拉一次 listAll
  *   - create 成功 / close 完成后由调用方主动 refresh()
- *   - V1 不订阅 main 推送（main 不广播）
+ *   - 归档/删除的 worktree 回收跑完后，由 main 的 `worktree:changed` 推送触发重拉
+ *     （回收是异步链，调用方那次主动 refresh 会拿到回收前的旧快照）
  *
  * 与项目内 AuthContext / EnvCheckContext 同
  * Provider+hooks 范式，不引入新状态库。
@@ -63,10 +64,22 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
   }, [refresh]);
 
   // 复用 sessionsBus 的 refresh 事件 —— delete / archive 完成后会触发一次，
-  // 顺手刷 worktree map，让徽标在删除会话后立刻消失（main 此时已自动收尾
-  // 对应 worktree 目录，但 renderer 的 Context 还需要拉一次新数据）。
+  // 顺手刷一次 worktree map。
   useEffect(() => {
     return onSessionsRefresh(() => {
+      void refresh();
+    });
+  }, [refresh]);
+
+  // 权威时机在这条推送上：main 侧的 worktree 回收是 fire-and-forget 的异步链
+  // （关子进程 → git worktree remove → 文件系统清理），store 条目被移除的时刻
+  // 远晚于归档/删除的状态 IPC 返回。上面那次「顺手刷」几乎必然快照到仍然存在的
+  // 旧条目，徽标会一直停在回收前的状态，直到某次无关刷新才纠正（codex review P1）。
+  // main 在回收链结束后广播 worktree:changed，这里再拉一次拿到真实结果。
+  useEffect(() => {
+    const subscribe = window.electronAPI?.onWorktreeChanged;
+    if (!subscribe) return;
+    return subscribe(() => {
       void refresh();
     });
   }, [refresh]);

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -47,7 +47,7 @@ import { clearDraft as clearComposerDraft } from '@/lib/composerDraftStore';
 import { cleanupSessionLayoutPrefs } from '@/lib/sessionLayoutPrefs';
 import {
   countDirtyWorktreesForRemoval,
-  fetchDirtyWorktreeForRemoval,
+  resolveDirtyWorktreeForRemoval,
 } from '@/lib/worktreeRemovalWarning';
 import { useSessionRunningStatus } from '@/hooks/useSessionRunningStatus';
 import { useBackgroundActivitySessionIds } from '@/lib/sessionBackgroundActivityStore';
@@ -1276,6 +1276,10 @@ function ExpandedView({
   // 重建自身 —— 否则 SessionItem 的 memo 会被整表打穿(SessionItem.tsx 不变量第 3 条)。
   const sessionsByIdRef = useRef(sessionsById);
   sessionsByIdRef.current = sessionsById;
+  // 同理:归档预检只在点击那一刻查一次 attached 集合。每次 binding:changed 都会
+  // 换一个新 Set 引用,放进 handleActionClick 的 deps 会让整表行 handler 重建。
+  const attachedSessionIdsRef = useRef(attachedSessionIds);
+  attachedSessionIdsRef.current = attachedSessionIds;
   const selectedSessions = useMemo(
     () =>
       [...selectedSessionIds]
@@ -1767,9 +1771,11 @@ function ExpandedView({
   );
 
   /* ---- Delete / Archive / Unarchive action handlers ----
-   * delete & archive（菜单触发）走 ConfirmDialog（不可逆 / 移出当前列表）；
-   * archive-now（行内 Confirm 触发）走 runSessionAction，跳过弹窗 —— 等价于
-   *   用户在快捷按钮上完成了两步行内确认，不再二次弹窗；
+   * delete 走 ConfirmDialog —— 不可逆，必须确认；
+   * archive / archive-now 都直接执行，不弹确认框：归档可逆（菜单里就有「恢复」），
+   *   行内入口本身已经是两步确认，菜单入口再弹一次纯属多余摩擦。唯一例外是
+   *   worktree 有未提交改动 —— 归档会顺带回收 worktree，这时升级到 ConfirmDialog
+   *   展示 dirty warning；
    * unarchive 是 archive 的反向操作，无副作用，直接 patch 即可，不弹确认。
    *
    * 执行序列（关子进程 / 写库 / 乐观补丁 / 释放内存 / refresh / 跳转）抽在
@@ -1795,25 +1801,41 @@ function ExpandedView({
         toast.warning(t('ccAgent.sidebar.archiveBlocked.running'));
         return;
       }
-      // 被 IM 接管中的 session 不允许归档 —— 接管方还在操控，先收回再归档
-      if (isArchiveLike) {
-        try {
-          const binding = await window.electronAPI.binding.resolveSession(sessionId);
-          if (binding.attached) {
-            toast.warning(t('ccAgent.sidebar.archiveBlocked.attached'));
-            return;
-          }
-        } catch {
-          // resolveSession 失败时不阻断归档，直接继续
-        }
+      // 被 IM 接管中的 session 不允许归档 —— 接管方还在操控，先收回再归档。
+      // sidebar 常驻订阅的 attached 集合与 binding:resolve-session 同源
+      // (binding:list-attached = 全量 resolve, binding:changed 驱动 refresh),
+      // 命中就直接拦，连 IPC 都不用发。
+      if (isArchiveLike && attachedSessionIdsRef.current.has(sessionId)) {
+        toast.warning(t('ccAgent.sidebar.archiveBlocked.attached'));
+        return;
       }
-      // 行内 Confirm 触发：干净 worktree 保持两步快捷确认；若有未提交改动，
-      // 升级到现有确认弹窗展示 dirty warning，避免绕过归档预检。
-      if (action === 'archive-now') {
-        const dirtyWorktree = await fetchDirtyWorktreeForRemoval(
+      // 本地集合没命中仍问一次 main 兜底(刚 attach 而 binding:changed 尚未到达
+      // 时不能漏拦)。**先发不 await**:它与下面的 dirty 预检互不依赖,让两次 IPC
+      // 在链路上重叠,归档前的等待从 sum(两次往返) 降到 max —— dirty 预检要在
+      // main 侧跑 git status,串行叠加会明显拖长"点了归档、列表还没反应"的时间。
+      // 失败降级为「未接管」(与改造前 catch 后继续归档同口径)。
+      const attachedPromise = isArchiveLike
+        ? window.electronAPI.binding
+            .resolveSession(sessionId)
+            .then((binding) => binding.attached)
+            .catch(() => false)
+        : null;
+      const blockedByAttachment = async (): Promise<boolean> => {
+        if (!(await attachedPromise)) return false;
+        toast.warning(t('ccAgent.sidebar.archiveBlocked.attached'));
+        return true;
+      };
+      // 归档一律不弹确认框:它是可逆的(菜单里就有「恢复」),菜单入口与行内
+      // 快捷按钮同一口径直接执行 —— 行内那个本身已经是两步确认。
+      // 唯一例外是 worktree 有未提交改动:归档会顺带回收 worktree,这时升级到
+      // 确认弹窗展示 dirty warning,不让改动被静默带走。
+      if (isArchiveLike) {
+        const dirtyWorktree = await resolveDirtyWorktreeForRemoval(
           sessionId,
           session?.deviceLinkDeviceId,
         );
+        // 接管拦截优先于 dirty 弹窗:被接管时不该弹任何归档确认。
+        if (await blockedByAttachment()) return;
         if (dirtyWorktree) {
           setConfirm({ open: true, sessionId, action: 'archive', dirtyWorktree: true });
           return;
@@ -1826,9 +1848,10 @@ function ExpandedView({
         });
         return;
       }
-      if (action !== 'unarchive') {
+      if (action === 'delete') {
+        // 删除不可逆,始终弹确认框。
         // P1 预检:worktree 有未提交更改时确认文案追加警告(查询失败降级为不提示)
-        const dirtyWorktree = await fetchDirtyWorktreeForRemoval(
+        const dirtyWorktree = await resolveDirtyWorktreeForRemoval(
           sessionId,
           session?.deviceLinkDeviceId,
         );

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -47,7 +47,7 @@ import { clearDraft as clearComposerDraft } from '@/lib/composerDraftStore';
 import { cleanupSessionLayoutPrefs } from '@/lib/sessionLayoutPrefs';
 import {
   countDirtyWorktreesForRemoval,
-  resolveDirtyWorktreeForRemoval,
+  resolveWorktreeRemovalPreflight,
 } from '@/lib/worktreeRemovalWarning';
 import { useSessionRunningStatus } from '@/hooks/useSessionRunningStatus';
 import { useBackgroundActivitySessionIds } from '@/lib/sessionBackgroundActivityStore';
@@ -1830,14 +1830,23 @@ function ExpandedView({
       // 唯一例外是 worktree 有未提交改动:归档会顺带回收 worktree,这时升级到
       // 确认弹窗展示 dirty warning,不让改动被静默带走。
       if (isArchiveLike) {
-        const dirtyWorktree = await resolveDirtyWorktreeForRemoval(
+        const preflight = await resolveWorktreeRemovalPreflight(
           sessionId,
           session?.deviceLinkDeviceId,
         );
         // 接管拦截优先于 dirty 弹窗:被接管时不该弹任何归档确认。
         if (await blockedByAttachment()) return;
-        if (dirtyWorktree) {
-          setConfirm({ open: true, sessionId, action: 'archive', dirtyWorktree: true });
+        // 免确认的判据是「**确认**干净」,不是「不是脏的」:'unknown'(预检失败)
+        // 同样要弹确认框,否则归档会静默回收可能带着未提交改动的 worktree
+        // (greptile review)。'unknown' 时不摆 dirty 警告文案 —— 那会谎称有改动,
+        // 走的是普通归档确认。
+        if (preflight !== 'clean') {
+          setConfirm({
+            open: true,
+            sessionId,
+            action: 'archive',
+            dirtyWorktree: preflight === 'dirty',
+          });
           return;
         }
         // 重定向判定用 viewedSessionId:files 路由下归档「正在浏览的会话」也要
@@ -1849,12 +1858,12 @@ function ExpandedView({
         return;
       }
       if (action === 'delete') {
-        // 删除不可逆,始终弹确认框。
+        // 删除不可逆,始终弹确认框 —— 所以这里用不到三态:预检失败时少一行警告文案,
+        // 不会变成静默放行。
         // P1 预检:worktree 有未提交更改时确认文案追加警告(查询失败降级为不提示)
-        const dirtyWorktree = await resolveDirtyWorktreeForRemoval(
-          sessionId,
-          session?.deviceLinkDeviceId,
-        );
+        const dirtyWorktree =
+          (await resolveWorktreeRemovalPreflight(sessionId, session?.deviceLinkDeviceId)) ===
+          'dirty';
         setConfirm({ open: true, sessionId, action, dirtyWorktree });
         return;
       }

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -1830,12 +1830,23 @@ function ExpandedView({
       // 唯一例外是 worktree 有未提交改动:归档会顺带回收 worktree,这时升级到
       // 确认弹窗展示 dirty warning,不让改动被静默带走。
       if (isArchiveLike) {
+        // 接管拦截先结算:被接管时不该弹任何归档确认。
+        if (await blockedByAttachment()) return;
+        // **worktree 预检必须是最后一个前置条件**(codex review):它之后再 await
+        // 任何东西(比如原来排在后面的接管查询),都会给「clean 结论」留一段失效
+        // 窗口 —— 编辑器或收尾中的 agent 在那段时间写脏工作区,归档就不带警告地
+        // 过去了。并行没有丢:菜单打开 / 亮出 Confirm 胶囊时的 prefetch 已经把查询
+        // 发出去并热了 git cache,而这里 resolve 对 clean 一律重查(见
+        // worktreeRemovalWarning 的非对称复用),拿到的是此刻的结论。
+        //
+        // 窗口不可能压到零 —— 从这次查询返回到 main 侧真正 `git worktree remove`
+        // 之间还有写库和回收链;那一段由 main 在删除前重新检测 + auto-stash 兜住
+        // (WorktreeManager.removeWorktreeForSession),renderer 这层负责的是「别拿
+        // 明显过期的结论免掉确认」。
         const preflight = await resolveWorktreeRemovalPreflight(
           sessionId,
           session?.deviceLinkDeviceId,
         );
-        // 接管拦截优先于 dirty 弹窗:被接管时不该弹任何归档确认。
-        if (await blockedByAttachment()) return;
         // 免确认的判据是「**确认**干净」,不是「不是脏的」:'unknown'(预检失败)
         // 同样要弹确认框,否则归档会静默回收可能带着未提交改动的 worktree
         // (greptile review)。'unknown' 时不摆 dirty 警告文案 —— 那会谎称有改动,

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -383,20 +383,24 @@ export function SessionContentHeader({
       toast.warning(t('ccAgent.sidebar.archiveBlocked.running'));
       return;
     }
-    // 两个预检互不依赖 → 并行发,别串行叠加两次 IPC 往返。worktree 预检走 resolve:
-    // 菜单打开时已经 prefetch 过,dirty 会命中缓存。resolveSession 失败降级
-    // 为「未接管」,不阻断归档(与 sidebar 的 handleActionClick 同口径)。
-    const [attached, preflight] = await Promise.all([
-      window.electronAPI.binding
-        .resolveSession(session.id)
-        .then((binding) => binding.attached)
-        .catch(() => false),
-      resolveWorktreeRemovalPreflight(session.id, session.deviceLinkDeviceId),
-    ]);
-    if (attached) {
+    // 接管查询先发不 await,让它与菜单打开时那次 prefetch 在链路上重叠;
+    // resolveSession 失败降级为「未接管」,不阻断归档(与 sidebar 同口径)。
+    const attachedPromise = window.electronAPI.binding
+      .resolveSession(session.id)
+      .then((binding) => binding.attached)
+      .catch(() => false);
+    if (await attachedPromise) {
       toast.warning(t('ccAgent.sidebar.archiveBlocked.attached'));
       return;
     }
+    // **worktree 预检必须是最后一个前置条件**(codex review):原来这里用 Promise.all
+    // 一起等,dirty 先返回 clean、接管查询还在飞的那段时间就是 clean 结论的失效窗口。
+    // 改成接管结算之后再 resolve —— clean 一律重查(见 worktreeRemovalWarning),
+    // 拿到的是此刻的结论;菜单打开时的 prefetch 仍然热了 git cache。
+    const preflight = await resolveWorktreeRemovalPreflight(
+      session.id,
+      session.deviceLinkDeviceId,
+    );
     // 归档不弹确认框 —— 可逆操作(菜单里就有「恢复」),与 sidebar 同口径。
     // 免确认的判据是「**确认**干净」:worktree 脏、或预检失败拿不到结论('unknown')
     // 都要确认 —— 归档会顺带回收 worktree,不能静默带走改动(greptile review)。

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -30,7 +30,10 @@ import type { Session } from '@/lib/ccAgent.types';
 import * as sessionService from '@/lib/sessionService';
 import { buildSessionDeepLink } from '@/lib/deepLink';
 import { createLogger } from '@/lib/logger';
-import { fetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
+import {
+  prefetchDirtyWorktreeForRemoval,
+  resolveDirtyWorktreeForRemoval,
+} from '@/lib/worktreeRemovalWarning';
 import { useCCSessions } from '@/hooks/useCCSessions';
 import { useProjectPickerOptions } from '@/hooks/useProjectPickerOptions';
 import { useSessionRunningStatus } from '@/hooks/useSessionRunningStatus';
@@ -380,28 +383,34 @@ export function SessionContentHeader({
       toast.warning(t('ccAgent.sidebar.archiveBlocked.running'));
       return;
     }
-    try {
-      const binding = await window.electronAPI.binding.resolveSession(session.id);
-      if (binding.attached) {
-        toast.warning(t('ccAgent.sidebar.archiveBlocked.attached'));
-        return;
-      }
-    } catch {
-      // resolveSession 失败时不阻断归档
+    // 两个预检互不依赖 → 并行发,别串行叠加两次 IPC 往返。dirty 预检走 resolve:
+    // 菜单打开时已经 prefetch 过,这里通常直接命中缓存。resolveSession 失败降级
+    // 为「未接管」,不阻断归档(与 sidebar 的 handleActionClick 同口径)。
+    const [attached, dirtyWorktree] = await Promise.all([
+      window.electronAPI.binding
+        .resolveSession(session.id)
+        .then((binding) => binding.attached)
+        .catch(() => false),
+      resolveDirtyWorktreeForRemoval(session.id, session.deviceLinkDeviceId),
+    ]);
+    if (attached) {
+      toast.warning(t('ccAgent.sidebar.archiveBlocked.attached'));
+      return;
     }
-    const dirtyWorktree = await fetchDirtyWorktreeForRemoval(
-      session.id,
-      session.deviceLinkDeviceId,
-    );
-    const ok = await confirmDialog({
-      title: t('ccAgent.sidebar.confirmArchive.title'),
-      description:
-        t('ccAgent.sidebar.confirmArchive.description') +
-        (dirtyWorktree ? ' ' + t('ccAgent.sidebar.confirmArchive.dirtyWorktreeWarning') : ''),
-      confirmText: t('ccAgent.sidebar.confirmArchive.confirm'),
-      cancelText: t('ccAgent.sidebar.confirmArchive.cancel'),
-    });
-    if (!ok) return;
+    // 归档不弹确认框 —— 可逆操作(菜单里就有「恢复」),与 sidebar 同口径。
+    // 只有 worktree 有未提交改动才确认:归档会顺带回收 worktree,不能静默带走改动。
+    if (dirtyWorktree) {
+      const ok = await confirmDialog({
+        title: t('ccAgent.sidebar.confirmArchive.title'),
+        description:
+          t('ccAgent.sidebar.confirmArchive.description') +
+          ' ' +
+          t('ccAgent.sidebar.confirmArchive.dirtyWorktreeWarning'),
+        confirmText: t('ccAgent.sidebar.confirmArchive.confirm'),
+        cancelText: t('ccAgent.sidebar.confirmArchive.cancel'),
+      });
+      if (!ok) return;
+    }
     await runSessionAction(session.id, 'archive', { activeSessionId: session.id });
   }, [
     confirmDialog,
@@ -428,7 +437,7 @@ export function SessionContentHeader({
       return;
     }
     // P1 预检:worktree 有未提交更改时确认文案追加警告(查询失败降级为不提示)
-    const dirtyWorktree = await fetchDirtyWorktreeForRemoval(
+    const dirtyWorktree = await resolveDirtyWorktreeForRemoval(
       session.id,
       session.deviceLinkDeviceId,
     );
@@ -529,7 +538,13 @@ export function SessionContentHeader({
       )}
 
       {!isEditing && (
-        <DropdownMenu>
+        // 菜单打开就把归档/删除的 dirty 预检发出去:用户从展开菜单到点条目至少
+        // 一次反应时间,足够这次 git status 跑完,点下去时命中缓存、零等待。
+        <DropdownMenu
+          onOpenChange={(open) => {
+            if (open) prefetchDirtyWorktreeForRemoval(session.id, session.deviceLinkDeviceId);
+          }}
+        >
           <DropdownMenuTrigger asChild>
             <button
               className={cn(

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -32,7 +32,7 @@ import { buildSessionDeepLink } from '@/lib/deepLink';
 import { createLogger } from '@/lib/logger';
 import {
   prefetchDirtyWorktreeForRemoval,
-  resolveDirtyWorktreeForRemoval,
+  resolveWorktreeRemovalPreflight,
 } from '@/lib/worktreeRemovalWarning';
 import { useCCSessions } from '@/hooks/useCCSessions';
 import { useProjectPickerOptions } from '@/hooks/useProjectPickerOptions';
@@ -383,29 +383,32 @@ export function SessionContentHeader({
       toast.warning(t('ccAgent.sidebar.archiveBlocked.running'));
       return;
     }
-    // 两个预检互不依赖 → 并行发,别串行叠加两次 IPC 往返。dirty 预检走 resolve:
-    // 菜单打开时已经 prefetch 过,这里通常直接命中缓存。resolveSession 失败降级
+    // 两个预检互不依赖 → 并行发,别串行叠加两次 IPC 往返。worktree 预检走 resolve:
+    // 菜单打开时已经 prefetch 过,dirty 会命中缓存。resolveSession 失败降级
     // 为「未接管」,不阻断归档(与 sidebar 的 handleActionClick 同口径)。
-    const [attached, dirtyWorktree] = await Promise.all([
+    const [attached, preflight] = await Promise.all([
       window.electronAPI.binding
         .resolveSession(session.id)
         .then((binding) => binding.attached)
         .catch(() => false),
-      resolveDirtyWorktreeForRemoval(session.id, session.deviceLinkDeviceId),
+      resolveWorktreeRemovalPreflight(session.id, session.deviceLinkDeviceId),
     ]);
     if (attached) {
       toast.warning(t('ccAgent.sidebar.archiveBlocked.attached'));
       return;
     }
     // 归档不弹确认框 —— 可逆操作(菜单里就有「恢复」),与 sidebar 同口径。
-    // 只有 worktree 有未提交改动才确认:归档会顺带回收 worktree,不能静默带走改动。
-    if (dirtyWorktree) {
+    // 免确认的判据是「**确认**干净」:worktree 脏、或预检失败拿不到结论('unknown')
+    // 都要确认 —— 归档会顺带回收 worktree,不能静默带走改动(greptile review)。
+    // 'unknown' 只弹普通归档确认,不摆 dirty 警告文案(那会谎称有未提交改动)。
+    if (preflight !== 'clean') {
       const ok = await confirmDialog({
         title: t('ccAgent.sidebar.confirmArchive.title'),
         description:
           t('ccAgent.sidebar.confirmArchive.description') +
-          ' ' +
-          t('ccAgent.sidebar.confirmArchive.dirtyWorktreeWarning'),
+          (preflight === 'dirty'
+            ? ' ' + t('ccAgent.sidebar.confirmArchive.dirtyWorktreeWarning')
+            : ''),
         confirmText: t('ccAgent.sidebar.confirmArchive.confirm'),
         cancelText: t('ccAgent.sidebar.confirmArchive.cancel'),
       });
@@ -436,11 +439,10 @@ export function SessionContentHeader({
       showRemoteWriteBlockedToast();
       return;
     }
-    // P1 预检:worktree 有未提交更改时确认文案追加警告(查询失败降级为不提示)
-    const dirtyWorktree = await resolveDirtyWorktreeForRemoval(
-      session.id,
-      session.deviceLinkDeviceId,
-    );
+    // P1 预检:worktree 有未提交更改时确认文案追加警告。删除始终弹确认框,所以
+    // 用不到三态 —— 预检失败时少一行警告文案,不会变成静默放行。
+    const dirtyWorktree =
+      (await resolveWorktreeRemovalPreflight(session.id, session.deviceLinkDeviceId)) === 'dirty';
     const ok = await confirmDialog({
       title: t('ccAgent.sidebar.confirmDelete.title'),
       description:

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useSessionLifecycleActions.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useSessionLifecycleActions.test.tsx
@@ -80,6 +80,85 @@ beforeEach(() => {
   });
 });
 
+describe('useSessionLifecycleActions archive optimistic ordering', () => {
+  it('drops the row before navigating away when the row leaves the list', async () => {
+    // active 桶:store 已把行就地移出,高亮随行消失 → 先让行消失,别把
+    // navigate 的整屏视图切换同步渲染堵在前面。
+    const { result } = renderHook(() =>
+      useSessionLifecycleActions({ includeArchived: 'active' }),
+    );
+
+    await act(async () => {
+      await result.current.runSessionAction('session-1', 'archive', {
+        activeSessionId: 'session-1',
+      });
+    });
+
+    expect(mocks.patchLocal).toHaveBeenCalledWith('session-1', {
+      status: 'archived',
+      pinnedAt: null,
+    });
+    expect(mocks.patchLocal.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.navigate.mock.invocationCallOrder[0],
+    );
+    expect(mocks.navigate).toHaveBeenCalledWith('/cc-agent/new');
+  });
+
+  it('navigates first when the archived row stays visible in the all bucket', async () => {
+    // 'all' 桶:行只是重排到归档段,还在列表里 → 必须先 paint 掉 isActive 高亮,
+    // 否则会看到"归档后的行在新位置还高亮"。
+    const { result } = renderHook(() => useSessionLifecycleActions({ includeArchived: 'all' }));
+
+    await act(async () => {
+      await result.current.runSessionAction('session-1', 'archive', {
+        activeSessionId: 'session-1',
+      });
+    });
+
+    expect(mocks.navigate.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.patchLocal.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not navigate when archiving a session that is not the active one', async () => {
+    const { result } = renderHook(() =>
+      useSessionLifecycleActions({ includeArchived: 'active' }),
+    );
+
+    await act(async () => {
+      await result.current.runSessionAction('session-1', 'archive', {
+        activeSessionId: 'other-session',
+      });
+    });
+
+    expect(mocks.patchLocal).toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it('patches optimistically before the status write, and rolls back when it fails', async () => {
+    mocks.setStatus.mockRejectedValueOnce(new Error('write failed'));
+    const { result } = renderHook(() =>
+      useSessionLifecycleActions({ includeArchived: 'active' }),
+    );
+
+    await act(async () => {
+      await result.current.runSessionAction('session-1', 'archive', {
+        activeSessionId: null,
+      });
+    });
+
+    expect(mocks.patchLocal.mock.calls).toEqual([
+      ['session-1', { status: 'archived', pinnedAt: null }],
+      ['session-1', { status: 'active' }],
+    ]);
+    expect(mocks.patchLocal.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.setStatus.mock.invocationCallOrder[0],
+    );
+    expect(mocks.toastError).toHaveBeenCalledWith('ccAgent.sidebar.archiveFailed');
+    expect(mocks.purgeSession).not.toHaveBeenCalled();
+  });
+});
+
 describe('useSessionLifecycleActions delete cache invalidation', () => {
   it('patches every loaded status bucket only after the delete write succeeds', async () => {
     const { result } = renderHook(() => useSessionLifecycleActions({ includeArchived: 'all' }));

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useSessionLifecycleActions.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useSessionLifecycleActions.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   setStatus: vi.fn(),
   refreshSessions: vi.fn(),
+  emitRefresh: vi.fn(),
   patchLocal: vi.fn(),
   closeSessionQuery: vi.fn(),
   purgeSession: vi.fn(),
@@ -49,7 +50,7 @@ vi.mock('@/lib/sessionLayoutPrefs', () => ({
 }));
 
 vi.mock('@/lib/sessionsBus', () => ({
-  emitRefresh: vi.fn(),
+  emitRefresh: mocks.emitRefresh,
 }));
 
 vi.mock('@/hooks/useCCSessions', () => ({
@@ -172,9 +173,12 @@ describe('useSessionLifecycleActions delete cache invalidation', () => {
     expect(mocks.setStatus.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.patchLocal.mock.invocationCallOrder[0],
     );
+    // 兜底重拉走 emitRefresh(强制重拉所有已加载桶),不是只刷当前桶的
+    // refreshSessions —— 见 hook 里关于 archived 目标桶的注释。
     expect(mocks.patchLocal.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.refreshSessions.mock.invocationCallOrder[0],
+      mocks.emitRefresh.mock.invocationCallOrder[0],
     );
+    expect(mocks.refreshSessions).not.toHaveBeenCalled();
   });
 
   it('keeps cached sessions unchanged when the delete write fails', async () => {
@@ -186,7 +190,7 @@ describe('useSessionLifecycleActions delete cache invalidation', () => {
     });
 
     expect(mocks.patchLocal).not.toHaveBeenCalled();
-    expect(mocks.refreshSessions).not.toHaveBeenCalled();
+    expect(mocks.emitRefresh).not.toHaveBeenCalled();
     expect(mocks.purgeSession).not.toHaveBeenCalled();
     expect(mocks.toastError).toHaveBeenCalledWith('ccAgent.sidebar.deleteFailed');
   });

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useSessionLifecycleActions.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useSessionLifecycleActions.ts
@@ -14,7 +14,7 @@
  * activeSessionId 由调用方传入：sidebar 是当前路由解析出的活跃会话（可能
  * 操作非活跃行）；header 操作的恒为当前打开的会话（传 session.id 即可）。
  *
- * includeArchived 必须与调用方自己的 useCCSessions 桶一致：refreshSessions
+ * includeArchived 必须与调用方自己的 useCCSessions 桶一致：unarchive 的 refreshSessions
  * 只刷当前桶，sidebar 处于 archived / all 桶时删除行后若刷的是默认 active
  * 桶，已删行会在当前列表残留（Codex review P2）。header 始终展示 active
  * 会话语境，用默认值即可。
@@ -98,7 +98,7 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
         //
         // Delete 仍走原来的"先 DB 后清理"流程:delete 不可逆,乐观删除如果 DB 失
         // 败会让用户看到"行消失又出现"的诡异闪烁,代价比 archive 大。写库成功
-        // 后再用 patchLocal 从所有桶移除,并由 refreshSessions 刷新当前桶兜底。
+        // 后再用 patchLocal 从所有桶移除,并由 emitRefresh 强制重拉所有桶兜底。
         const archivedRowStaysInList = listFilter === 'all';
         const leaveArchivedSession = () => {
           if (sessionId === activeSessionId) navigate('/cc-agent/new');
@@ -162,18 +162,24 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
         cleanupSessionLayoutPrefs(sessionId);
       }
 
-      // 兜底重拉当前桶,但**不 await**:上面的 patchLocal 已经把所有已加载桶修到
-      // 正确状态(该移出的就地移除),列表视觉不依赖这次 IPC。sessions:list 是
+      // 写库成功后强制重拉**所有已加载桶**。不 await —— 列表视觉已由上面的
+      // patchLocal 就地改好,这里只是让缓存跟 DB 对齐;sessions:list 是
       // LEFT JOIN messages + GROUP BY + latest-message 子查询的重查询,await 它
       // 只会把后面的 refreshWorktrees / delete 跳转推迟几百毫秒。
-      void refreshSessions().catch((err: unknown) => {
-        log.warn('[session action] refresh sessions failed', err);
-      });
+      //
+      // 为什么必须全桶、不能只刷当前桶(codex review):归档时 patchLocal 会 drop
+      // 目标桶(archived,本地没有这条的完整 row)并立刻重拉,而那次重拉发生在
+      // setStatus 写库**之前**,拿回来的是「还没归档」的快照。本机
+      // local-db:sessions:update 又只在 title / settings / project 变化时才广播
+      // sessions:patched(status 不在其中),archived 桶再没有别的修正机会 —— 用户
+      // 切到「已归档」筛选会看不到刚归档的这条,直到某次无关刷新。
+      // 与 unarchiveSession 末尾的 emitRefresh 同口径。
+      emitRefresh();
       // 远程会话从侧边栏消失由被控端 sessions:patched{status} 回流(applyPatch 移出分片)驱动,
       // 控制端不再主动重拉 / 不再埋「主动移除」标记(掉线 vs 删除的区分见 CCAgentSessionView 优雅退出)。
-      // I-2: delete/archive 都要顺手刷一次 worktree map —— main 此时已自动收尾
-      // 对应 worktree 目录，但 WorktreeContext 不会因 refreshSessions() 自动更新
-      // (它只订阅 sessionsBus.onRefresh，而 refreshSessions 不发该事件)。
+      // I-2: delete/archive 都要顺手刷一次 worktree map。上面的 emitRefresh 已经会
+      // 触发 WorktreeContext(它订阅 sessionsBus.onRefresh),这里再显式刷一次是为了
+      // 不依赖那条链;worktree 回收真正跑完后 main 还会广播 worktree:changed。
       void refreshWorktrees();
 
       // Archive 已在前面乐观跳到 /cc-agent/new,这里只处理 delete。调用方有列表
@@ -183,7 +189,7 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
         navigate(deleteRedirectRoute ?? '/cc-agent');
       }
     },
-    [navigate, refreshSessions, refreshWorktrees, patchLocal, listFilter, t],
+    [navigate, refreshWorktrees, patchLocal, listFilter, t],
   );
 
   /**

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useSessionLifecycleActions.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useSessionLifecycleActions.ts
@@ -57,6 +57,10 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
   // includeArchived 跟随调用方的桶（见文件头注释）。
   const { refreshSessions, patchLocal } = useCCSessions(options);
   const refreshWorktrees = useRefreshWorktrees();
+  // 取成 string 再进 deps —— options 是调用方每次渲染新建的字面量对象,直接放进
+  // runSessionAction 的 deps 会让它每次重建,打穿 sidebar 的行 handler memo
+  // (行渲染隔离不变量,见 SessionItem.tsx)。
+  const listFilter: ListStatusFilter = options?.includeArchived ?? 'active';
 
   /**
    * archive / delete 实际执行序列。不关心确认弹窗的开合状态——由调用方负责。
@@ -71,21 +75,22 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
       // device-link 远程会话:status 写经隧道(setStatus 内部按来源路由 patch-meta),被控端写库后
       // 广播 sessions:patched{status} → 控制端 applyPatch 把它移出分片(纯镜像,无需乐观/重拉)。
 
-      // Close the SDK query subprocess before archiving/deleting
-      makerChatStore.closeSessionQuery(sessionId);
-
       if (action === 'archive') {
-        // 这里**顺序 + 两次 flushSync 都不能省**,任意一个错了都会有"100ms 延迟还
-        // 高亮被归档行"的视觉:
+        // 乐观更新的顺序取决于**被归档的行还会不会留在当前列表里**,两种情况相反:
         //
-        // patchLocal 触发 sessions list 重排(归档项移到下方);navigate 触发
-        // activeSessionId 失效。如果 patchLocal 先生效(或两个被同一 commit 渲染
-        // 到 paint),被归档的行已经移到新位置但还挂着 isActive bg → 用户看到的
-        // 就是"那行被归档后还在新位置短暂高亮"。
+        //   · 会留下(调用方在 'all' 桶):patchLocal 只是把它重排到归档段,行还在。
+        //     必须先让 navigate commit + paint 掉 isActive 高亮,再重排,否则会看到
+        //     "那行被归档后还在新位置短暂高亮"。两次独立 flushSync 就是为这个。
+        //   · 会消失(active 桶,最常见):store 已经把它从桶里就地移除,高亮随行一起
+        //     消失,不存在残留问题。这时**不能**让 navigate 先跑 —— flushSync 里的
+        //     navigate 要同步渲染整个主视图切换(卸下会话视图、挂上新建页),那一帧
+        //     几十毫秒全堵在"行消失"之前。改成先 flushSync 掉行(只重渲染 sidebar,
+        //     便宜),navigate 不加 flushSync 让它排到后面的帧。
         //
-        // 用两次独立的 flushSync 强制 navigate 先 commit + paint,让 isActive 高
-        // 亮在 list 重排之前就消失;再 patchLocal 让 list 重排。两帧渲染,但用户
-        // 视觉是干净的:第 1 帧高亮消失、行位置不变;第 2 帧行移到归档段。
+        // 乐观更新还**依赖 sessionsStore.patchLocal 就地移除、不 drop 桶**:早期 store
+        // 对跨桶迁移一律 drop + 重拉,桶变 null 会让 useCCSessions 跳过 setState,
+        // 本段全部白做,行要等 sessions:list 回来(数百毫秒)才消失。改 store 那段
+        // 逻辑前先看它的 patchLocal 注释。
         //
         // 借鉴 Codex 的 onArchivedCurrentThread 思路 navigate 到 /cc-agent/new
         // 空白态,而不是 /cc-agent 让 CCAgentIndexRedirect 挑下一条 —— 后者会按
@@ -94,15 +99,24 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
         // Delete 仍走原来的"先 DB 后清理"流程:delete 不可逆,乐观删除如果 DB 失
         // 败会让用户看到"行消失又出现"的诡异闪烁,代价比 archive 大。写库成功
         // 后再用 patchLocal 从所有桶移除,并由 refreshSessions 刷新当前桶兜底。
-        if (sessionId === activeSessionId) {
-          flushSync(() => {
-            navigate('/cc-agent/new');
-          });
+        const archivedRowStaysInList = listFilter === 'all';
+        const leaveArchivedSession = () => {
+          if (sessionId === activeSessionId) navigate('/cc-agent/new');
+        };
+        if (archivedRowStaysInList) {
+          flushSync(leaveArchivedSession);
         }
         flushSync(() => {
           patchLocal(sessionId, { status: 'archived', pinnedAt: null });
         });
+        if (!archivedRowStaysInList) {
+          leaveArchivedSession();
+        }
       }
+
+      // 关子进程:排在乐观更新之后 —— 它只是 fire-and-forget 地通知 main 收掉 SDK
+      // query,不影响列表,没有理由挤在用户等着看到行消失的那一段前面。
+      makerChatStore.closeSessionQuery(sessionId);
 
       try {
         // setStatus 按来源路由(远程走隧道 set-status,本机走原 update);archive 时
@@ -148,7 +162,13 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
         cleanupSessionLayoutPrefs(sessionId);
       }
 
-      await refreshSessions();
+      // 兜底重拉当前桶,但**不 await**:上面的 patchLocal 已经把所有已加载桶修到
+      // 正确状态(该移出的就地移除),列表视觉不依赖这次 IPC。sessions:list 是
+      // LEFT JOIN messages + GROUP BY + latest-message 子查询的重查询,await 它
+      // 只会把后面的 refreshWorktrees / delete 跳转推迟几百毫秒。
+      void refreshSessions().catch((err: unknown) => {
+        log.warn('[session action] refresh sessions failed', err);
+      });
       // 远程会话从侧边栏消失由被控端 sessions:patched{status} 回流(applyPatch 移出分片)驱动,
       // 控制端不再主动重拉 / 不再埋「主动移除」标记(掉线 vs 删除的区分见 CCAgentSessionView 优雅退出)。
       // I-2: delete/archive 都要顺手刷一次 worktree map —— main 此时已自动收尾
@@ -163,7 +183,7 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
         navigate(deleteRedirectRoute ?? '/cc-agent');
       }
     },
-    [navigate, refreshSessions, refreshWorktrees, patchLocal, t],
+    [navigate, refreshSessions, refreshWorktrees, patchLocal, listFilter, t],
   );
 
   /**

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -67,6 +67,7 @@ import { SessionRenameInput } from '../SessionRenameInput';
 import type { SessionItemProps } from './SessionItem';
 import { RemoteProjectIcon } from './RemoteProjectIcon';
 import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
+import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
 import { useSessionBoundSchedules, scheduleFocusPath } from '@/features/scheduler/lib/scheduleSessionBinding';
 import { loadScheduleSidebarIndexRuns } from '@/features/scheduler/lib/scheduleSidebarIndexRuns';
 
@@ -180,6 +181,21 @@ export function SessionCard({
   const [archivePending, setArchivePending] = useState(false);
   const confirmPillRef = useRef<HTMLButtonElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
+
+  // 归档/删除前那次 dirty-worktree 预检要在 main 侧跑 git status,是"点了归档、
+  // 卡片还没消失"里剩下的最大一块等待。亮出 Confirm 胶囊 / 打开菜单到用户点下去
+  // 之间隔着一次反应时间,足够它跑完 —— 那一刻先发,执行时命中缓存。
+  // 包在 setter 上而不是逐个 onClick:本卡片与下面的 compact 变体共用这个 setter。
+  const prefetchRemovalPreflight = useCallback(() => {
+    prefetchDirtyWorktreeForRemoval(session.id, session.deviceLinkDeviceId);
+  }, [session.id, session.deviceLinkDeviceId]);
+  const beginArchivePending = useCallback(
+    (pending: boolean) => {
+      if (pending) prefetchRemovalPreflight();
+      setArchivePending(pending);
+    },
+    [prefetchRemovalPreflight],
+  );
 
   // 运行结束:仅做一次卡片底色 settle 闪动作为完成提示。运行中的活动感由标题左侧
   // SessionStatusIcon 呼吸 + 底部短扫动进度条表达;完成提醒继续走 SessionStatusIcon 状态点(绿/蓝/红)。
@@ -473,6 +489,7 @@ export function SessionCard({
         if (isEditing) return;
         e.preventDefault();
         e.stopPropagation();
+        prefetchRemovalPreflight();
         setMenuPos({ x: e.clientX, y: e.clientY });
       }}
       className={cn(
@@ -583,11 +600,12 @@ export function SessionCard({
                 isArchived={isArchived}
                 canQuickArchive={canQuickArchive}
                 archivePending={archivePending}
-                setArchivePending={setArchivePending}
+                setArchivePending={beginArchivePending}
                 confirmPillRef={confirmPillRef}
                 menuOpen={menuPos !== null}
                 onOpenMenu={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect();
+                  prefetchRemovalPreflight();
                   setMenuPos({ x: rect.left, y: rect.bottom + 2 });
                 }}
                 onArchiveNow={() => onAction(session.id, 'archive-now')}
@@ -633,6 +651,7 @@ export function SessionCard({
               label={t('ccAgent.sidebar.sessionMenu.moreActions')}
               onClick={(e) => {
                 const rect = e.currentTarget.getBoundingClientRect();
+                prefetchRemovalPreflight();
                 setMenuPos({ x: rect.left, y: rect.bottom + 2 });
               }}
             >
@@ -648,7 +667,7 @@ export function SessionCard({
             ) : canQuickArchive ? (
               <CardAction
                 label={t('ccAgent.sidebar.sessionMenu.archived')}
-                onClick={() => setArchivePending(true)}
+                onClick={() => beginArchivePending(true)}
               >
                 <Archive size={13} strokeWidth={2} />
               </CardAction>

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -82,6 +82,7 @@ import type { FolderPickerOption } from '@/components/new-chat/FolderPickerPopov
 import { RemoteProjectIcon } from './RemoteProjectIcon';
 import { SessionShareExportDialog } from './SessionShareExportDialog';
 import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
+import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
 import { useSessionAttentionKind } from '@/lib/sessionAttentionStore';
 import { useSessionAttentionUrgency } from '../contexts/SessionAttentionUrgencyContext';
 import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionActivityStore';
@@ -342,6 +343,14 @@ export const SessionItem = memo(function SessionItem({
   const [archivePending, setArchivePending] = useState(false);
   // confirm 胶囊 DOM 引用——outside-mousedown 用它判断点击是否落在自己身上。
   const confirmPillRef = useRef<HTMLButtonElement>(null);
+
+  // 归档/删除前那次 dirty-worktree 预检要在 main 侧跑 git status,是"点了归档、
+  // 行还没消失"里剩下的最大一块等待。每个入口真正执行前都隔着一次人类操作
+  // (亮出 Confirm 胶囊后再点一下 / 打开菜单后再点条目),在那一刻先发出去,
+  // 执行时命中缓存即可。TTL 与去重都在 worktreeRemovalWarning 里。
+  const prefetchRemovalPreflight = useCallback(() => {
+    prefetchDirtyWorktreeForRemoval(session.id, session.deviceLinkDeviceId);
+  }, [session.id, session.deviceLinkDeviceId]);
 
   // 行容器 ref:在 isActive 切到 true 时把当前行滚进 viewport。
   //
@@ -614,6 +623,7 @@ export const SessionItem = memo(function SessionItem({
         if (isEditing) return;
         e.preventDefault();
         e.stopPropagation();
+        prefetchRemovalPreflight();
         setMenuPos({ x: e.clientX, y: e.clientY });
       }}
       className={cn(
@@ -888,6 +898,7 @@ export const SessionItem = memo(function SessionItem({
                 label={t('ccAgent.sidebar.sessionMenu.moreActions')}
                 onClick={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect();
+                  prefetchRemovalPreflight();
                   setMenuPos({ x: rect.left, y: rect.bottom + 2 });
                 }}
                 isActive={isActive}
@@ -905,7 +916,12 @@ export const SessionItem = memo(function SessionItem({
               ) : canQuickArchive ? (
                 <SessionAction
                   label={t('ccAgent.sidebar.sessionMenu.archived')}
-                  onClick={() => setArchivePending(true)}
+                  onClick={() => {
+                    // 第一步:亮出 Confirm 胶囊,同时把 dirty 预检发出去。用户抬手
+                    // 再点第二下的间隔足够那次 git status 跑完 → 归档零等待。
+                    prefetchRemovalPreflight();
+                    setArchivePending(true);
+                  }}
                   isActive={isActive}
                 >
                   <Archive size={14} strokeWidth={2} />

--- a/apps/desktop/src/renderer/lib/sessionsStore.ts
+++ b/apps/desktop/src/renderer/lib/sessionsStore.ts
@@ -20,7 +20,9 @@
  * 写策略：
  *   - patchLocal(id, patch)        遍历所有桶就地合并字段，保留排序与位置；
  *                                   _count 浅合并，避免 { messages: 1 } 把
- *                                   同级计数清掉。
+ *                                   同级计数清掉。patch.status 会顺带修正桶
+ *                                   归属：该移出的桶就地移除（不 drop，见
+ *                                   patchLocal 注释），该补进的桶才重拉。
  *   - prependCreated(session)      新建时本地插入：active / all 桶头部插入；
  *                                   archived 桶按业务永远不应包含新建项，跳过。
  *                                   保留旧 createSession 的"省一次 IPC"优化。
@@ -193,13 +195,20 @@ export const sessionsStore = {
    * "字段变化"全部走这里）。遍历所有桶：命中即合并字段，保留位置不重排序。
    *
    * 跨桶迁移特例：当 patch.status 出现时，session 的桶归属可能变化。
-   * deleted 的归属是确定的，直接从所有已加载桶移除，不依赖后台重拉；
-   * active ↔ archived 既要移出旧桶、又可能加入已加载的新桶，仍需 drop 不一致的桶重拉。
    * 如果只就地改字段而不修正归属，会导致：
    *   1. 旧桶里"假活着"（status 已变但条目仍在）
    *   2. 新桶 cache 命中但缺这一条（用户切桶后看不到）
-   * 因此 status 变更后,把所有桶归属判定与实际不符的桶 drop 掉,下次
-   * ensureByFilter 重拉获取一致的数据。'all' 桶仅排除 deleted。
+   *
+   * 两种不一致的修正方式**不对称**，别退回"一律 drop 重拉"：
+   *   - 「在桶里但已不该在」（归档时的 active 桶）→ **就地移除**。归属判定是
+   *     确定的（status 已经变了），本地就能得出正确结果，无需等 IPC。
+   *     这里 drop 桶是曾经的性能陷阱：桶变 null 后 useCCSessions 的
+   *     `next !== null` 守卫会跳过 setState，视图停在**仍含该行**的陈旧快照，
+   *     一直等到重拉的 sessions:list 回来才更新 —— 表现为"点归档后半秒对话
+   *     才消失"，把调用方 useSessionLifecycleActions 的乐观更新整段抵消掉。
+   *   - 「不在桶里但该在」（归档时的 archived 桶）→ drop + 重拉。本地没有这条
+   *     的完整 row，构造不出来，只能问 DB。这类桶通常不是当前可见桶。
+   * deleted 走前面的独立分支：归属确定，从所有桶移除即可。'all' 桶仅排除 deleted。
    */
   patchLocal(id: string, patch: Partial<Session>): void {
     if (!id || !patch) return;
@@ -253,16 +262,32 @@ export const sessionsStore = {
         if (filter === 'all') return true;
         return filter === newStatus;
       };
+      // 进行中的 list 请求发起于本次 status 变更之前,回来会把旧归属整桶写回
+      // (cache.set 覆盖,连就地移除也会被撤销)。先解除这些 request 对桶的认领,
+      // 循环后统一重发 —— 与 deleted 分支同口径。稳态下 inflight 为空:桶进
+      // cache 时 ensureByFilter 会同时清掉 inflight,故与下面的 cache 循环无交集。
+      for (const filter of Array.from(inflight.keys())) {
+        inflight.delete(filter);
+        toRefetch.push(filter);
+      }
       for (const filter of Array.from(cache.keys())) {
         const list = cache.get(filter);
         if (!list) continue;
         const has = list.some((s) => s.id === id);
-        if (has !== belongsIn(filter)) {
+        if (has === belongsIn(filter)) continue;
+        if (has) {
+          // 已不该在本桶:本地即可得出正确结果,就地移除,桶保持非 null,
+          // 订阅者当帧就能拿到不含该行的新快照(见上方注释的性能陷阱)。
+          cache.set(
+            filter,
+            list.filter((session) => session.id !== id),
+          );
+        } else {
+          // 本桶缺这一条且本地没有它的 row → 只能 drop 后问 DB。
           cache.delete(filter);
-          inflight.delete(filter);
           toRefetch.push(filter);
-          touched = true;
         }
+        touched = true;
       }
     }
     if (touched) notify();

--- a/apps/desktop/src/renderer/lib/worktreeRemovalWarning.ts
+++ b/apps/desktop/src/renderer/lib/worktreeRemovalWarning.ts
@@ -1,14 +1,22 @@
 /**
- * 删除/归档确认框的 worktree 脏状态预检(P1)。
+ * 删除/归档前的 worktree 脏状态预检(P1)。
  *
  * 本机会话直调 preload；device-link 远程会话把同名只读 IPC 隧道到被控端，
- * 由持有 worktree store 的设备返回真实状态。查询失败(老被控端 / IPC 异常)
- * 一律降级为"无警告",不阻塞确认流程。
+ * 由持有 worktree store 的设备返回真实状态。
+ *
+ * **三态,不是布尔**(greptile review):查询失败(老被控端 / IPC 异常 / 隧道断)
+ * 必须与「确认干净」区分开。早期只有布尔,失败降级成 `false`,那时所有入口都一定
+ * 会弹确认框,`false` 的后果只是文案里少一行警告;但归档改成「干净就免确认」之后,
+ * 同一个 `false` 会变成**静默放行** —— 预检失败时归档会不打招呼地回收带未提交改动
+ * 的 worktree(main 侧只会 auto-stash 兜底,用户拿不到告警和取消机会)。
+ * 所以免确认的判据必须是「确认干净」,而不是「不是脏的」。
  */
-export async function fetchDirtyWorktreeForRemoval(
+export type WorktreeRemovalPreflight = 'clean' | 'dirty' | 'unknown';
+
+async function queryWorktreeRemovalPreflight(
   sessionId: string,
   deviceLinkDeviceId?: string | null,
-): Promise<boolean> {
+): Promise<WorktreeRemovalPreflight> {
   try {
     const preview = deviceLinkDeviceId
       ? await window.electronAPI.deviceLink.invoke(
@@ -17,84 +25,100 @@ export async function fetchDirtyWorktreeForRemoval(
           [sessionId],
         ) as { hasWorktree: boolean; dirty: boolean }
       : await window.electronAPI.worktreeRemovalPreview(sessionId);
-    return preview.hasWorktree && preview.dirty;
+    return preview.hasWorktree && preview.dirty ? 'dirty' : 'clean';
   } catch {
-    return false;
+    return 'unknown';
   }
 }
 
 /**
- * 预取窗口内的预检结果缓存 —— **只复用 dirty=true,clean 一律重新查**。
+ * 布尔版:仅供**总是会弹确认框**的路径用(批量计数、doc 模式关闭标签页、删除),
+ * 那里 `false` 只影响文案是否追加警告,不会变成静默放行。
+ * 会跳过确认的路径必须用 `resolveWorktreeRemovalPreflight` 的三态。
+ */
+export async function fetchDirtyWorktreeForRemoval(
+  sessionId: string,
+  deviceLinkDeviceId?: string | null,
+): Promise<boolean> {
+  return (await queryWorktreeRemovalPreflight(sessionId, deviceLinkDeviceId)) === 'dirty';
+}
+
+/**
+ * 预取窗口内的预检结果缓存 —— **只复用 'dirty',clean 与 unknown 一律重新查**。
  *
  * 每个归档入口在真正执行前都有一段人类操作空窗:列表行内是两步确认(点归档
  * 图标 → 点 Confirm 胶囊),菜单入口是先打开菜单再点条目。在那一刻 prefetch,
  * 可以把 main 侧那次 git status 挪出用户等待。
  *
  * 但复用**必须是非对称的**(greptile / codex 都按 P1 指出过):
- *   - cached dirty=true → 安全。这个结论只会让确认弹窗多出现一次;就算 worktree
+ *   - cached 'dirty' → 安全。这个结论只会让确认弹窗多出现一次;就算 worktree
  *     期间被清干净了,用户看到警告仍可取消或继续,保护不会失效。
- *   - cached clean → **不安全,不能复用**。归档会顺带回收 worktree,如果预取之后
+ *   - cached 'clean' → **不安全,不能复用**。归档会顺带回收 worktree,如果预取之后
  *     外部编辑器或收尾中的 agent 写脏了工作区,复用 clean 就会整个跳过 dirty 确认,
  *     用户拿不到承诺的「先提交或取消」机会(main 侧回收前会 auto-stash 兜住数据,
  *     所以不至于丢改动,但用户不会知道改动已被 stash 带走)。
+ *   - cached 'unknown' → 不复用。它代表查询失败,重试一次可能就拿到真结论了,
+ *     把失败缓存起来只会让保守分支多留 8 秒。
  *
- * 因此 clean 结论从不被复用,连仍在飞的预取也不复用其 clean 结果。这几乎不损失
+ * 因此只有 'dirty' 被复用,连仍在飞的预取也不复用其非 dirty 结果。这几乎不损失
  * 收益:实测本仓 `git status --porcelain` 只要 20~40ms,加 IPC 往返远低于感知阈值;
- * 预取真正的价值变成「去重 + 提前把 git 的索引/文件系统 cache 热起来 + dirty 会话
- * 零等待」。TTL 8s 略长于行内 Confirm 胶囊 4s 自动撤回窗口,只对 dirty 生效。
+ * 预取真正的价值变成「提前把 git 的索引/文件系统 cache 热起来 + dirty 会话零等待」。
+ * TTL 8s 略长于行内 Confirm 胶囊 4s 自动撤回窗口,只对 'dirty' 生效。
  */
 const DIRTY_PREFLIGHT_TTL_MS = 8_000;
 
-interface DirtyPreflightEntry {
+interface PreflightEntry {
   at: number;
-  promise: Promise<boolean>;
-  /** promise 已 settle 时的结论；undefined = 仍在飞。只有 true 允许被复用。 */
-  dirty?: boolean;
+  promise: Promise<WorktreeRemovalPreflight>;
+  /** promise 已 settle 时的结论；undefined = 仍在飞。只有 'dirty' 允许被复用。 */
+  result?: WorktreeRemovalPreflight;
 }
 
-const dirtyPreflightCache = new Map<string, DirtyPreflightEntry>();
+const preflightCache = new Map<string, PreflightEntry>();
 
-/** 预热某个会话的 dirty 预检。 */
+/** 预热某个会话的 worktree 预检。 */
 export function prefetchDirtyWorktreeForRemoval(
   sessionId: string,
   deviceLinkDeviceId?: string | null,
 ): void {
-  void resolveDirtyWorktreeForRemoval(sessionId, deviceLinkDeviceId);
+  void resolveWorktreeRemovalPreflight(sessionId, deviceLinkDeviceId);
 }
 
 /**
- * 取 dirty 预检结论：只有未过期且为 dirty 的预取结果会被复用，其余情况(无缓存 /
- * 已过期 / 结论是 clean / 仍在飞)一律重新查询，理由见上方注释。
- * 归档/删除的执行路径都应该走这个而不是直调 fetch。
+ * 取 worktree 预检三态：只有未过期且为 'dirty' 的预取结果会被复用，其余情况
+ * (无缓存 / 已过期 / 'clean' / 'unknown' / 仍在飞)一律重新查询，理由见上方注释。
+ *
+ * **会跳过确认的路径必须用这个,并且只在结论为 'clean' 时才免确认** ——
+ * `'unknown'` 要和 `'dirty'` 一样走确认框(见类型定义处的说明)。
  */
-export function resolveDirtyWorktreeForRemoval(
+export function resolveWorktreeRemovalPreflight(
   sessionId: string,
   deviceLinkDeviceId?: string | null,
-): Promise<boolean> {
+): Promise<WorktreeRemovalPreflight> {
   const now = Date.now();
-  const cached = dirtyPreflightCache.get(sessionId);
-  if (cached && cached.dirty === true && now - cached.at < DIRTY_PREFLIGHT_TTL_MS) {
+  const cached = preflightCache.get(sessionId);
+  if (cached && cached.result === 'dirty' && now - cached.at < DIRTY_PREFLIGHT_TTL_MS) {
     return cached.promise;
   }
-  const promise = fetchDirtyWorktreeForRemoval(sessionId, deviceLinkDeviceId);
-  const entry: DirtyPreflightEntry = { at: now, promise };
-  dirtyPreflightCache.set(sessionId, entry);
-  // 回填结论:只有 dirty 会被后续 resolve 复用。用 entry 身份守卫,避免旧查询
-  // 覆盖同一会话更新的那次(fetch 内部已 swallow 异常,不会 reject)。
-  void promise.then((dirty) => {
-    if (dirtyPreflightCache.get(sessionId) === entry) entry.dirty = dirty;
+  const promise = queryWorktreeRemovalPreflight(sessionId, deviceLinkDeviceId);
+  const entry: PreflightEntry = { at: now, promise };
+  preflightCache.set(sessionId, entry);
+  // 回填结论:只有 'dirty' 会被后续 resolve 复用。用 entry 身份守卫,避免旧查询
+  // 覆盖同一会话更新的那次(query 内部已 swallow 异常,不会 reject)。
+  void promise.then((result) => {
+    if (preflightCache.get(sessionId) === entry) entry.result = result;
   });
   // 过期条目没有别的清理时机(会话可能已经被归档/删除),顺手扫一遍,
   // 别让 Map 随会话数无限长大。
-  for (const [id, item] of dirtyPreflightCache) {
-    if (now - item.at >= DIRTY_PREFLIGHT_TTL_MS) dirtyPreflightCache.delete(id);
+  for (const [id, item] of preflightCache) {
+    if (now - item.at >= DIRTY_PREFLIGHT_TTL_MS) preflightCache.delete(id);
   }
   return promise;
 }
 
 /** 仅供测试：清掉预取缓存。 */
 export function resetDirtyWorktreePreflightCache(): void {
-  dirtyPreflightCache.clear();
+  preflightCache.clear();
 }
 
 export interface WorktreeRemovalTarget {

--- a/apps/desktop/src/renderer/lib/worktreeRemovalWarning.ts
+++ b/apps/desktop/src/renderer/lib/worktreeRemovalWarning.ts
@@ -23,6 +23,57 @@ export async function fetchDirtyWorktreeForRemoval(
   }
 }
 
+/**
+ * 预取窗口内的预检结果缓存。
+ *
+ * 这次查询是「点了归档、行还没消失」里剩下的最大一块等待:有 worktree 的会话
+ * 要在 main 侧跑一次 git status。但每个归档入口在真正执行前都有一段人类操作
+ * 空窗 —— 列表行内是两步确认(点归档图标 → 点 Confirm 胶囊),菜单入口是先
+ * 打开菜单再点条目 —— 空窗至少一次反应时间(数百毫秒),足够预检跑完。于是在
+ * 进入空窗时就 prefetch,真正执行时 resolve 命中缓存,await 只花一个 microtask。
+ *
+ * TTL 取 8s:略长于行内 Confirm 胶囊 4s 自动撤回的窗口,又短到不会把「用户刚
+ * 提交/stash 完改动」的旧结论留太久。这个结论只决定确认文案里是否追加一行未
+ * 提交改动警告,过期读到旧值的代价很低。
+ */
+const DIRTY_PREFLIGHT_TTL_MS = 8_000;
+
+const dirtyPreflightCache = new Map<string, { at: number; promise: Promise<boolean> }>();
+
+/** 预热某个会话的 dirty 预检；重复调用在 TTL 内只发一次查询。 */
+export function prefetchDirtyWorktreeForRemoval(
+  sessionId: string,
+  deviceLinkDeviceId?: string | null,
+): void {
+  void resolveDirtyWorktreeForRemoval(sessionId, deviceLinkDeviceId);
+}
+
+/**
+ * 取 dirty 预检结论：命中未过期的预取则直接复用，否则即时查询。
+ * 归档/删除的执行路径都应该走这个而不是 fetch，才能吃到预取的收益。
+ */
+export function resolveDirtyWorktreeForRemoval(
+  sessionId: string,
+  deviceLinkDeviceId?: string | null,
+): Promise<boolean> {
+  const now = Date.now();
+  const cached = dirtyPreflightCache.get(sessionId);
+  if (cached && now - cached.at < DIRTY_PREFLIGHT_TTL_MS) return cached.promise;
+  const promise = fetchDirtyWorktreeForRemoval(sessionId, deviceLinkDeviceId);
+  dirtyPreflightCache.set(sessionId, { at: now, promise });
+  // 过期条目没有别的清理时机(会话可能已经被归档/删除),顺手扫一遍,
+  // 别让 Map 随会话数无限长大。
+  for (const [id, entry] of dirtyPreflightCache) {
+    if (now - entry.at >= DIRTY_PREFLIGHT_TTL_MS) dirtyPreflightCache.delete(id);
+  }
+  return promise;
+}
+
+/** 仅供测试：清掉预取缓存。 */
+export function resetDirtyWorktreePreflightCache(): void {
+  dirtyPreflightCache.clear();
+}
+
 export interface WorktreeRemovalTarget {
   id: string;
   deviceLinkDeviceId?: string | null;

--- a/apps/desktop/src/renderer/lib/worktreeRemovalWarning.ts
+++ b/apps/desktop/src/renderer/lib/worktreeRemovalWarning.ts
@@ -24,23 +24,37 @@ export async function fetchDirtyWorktreeForRemoval(
 }
 
 /**
- * 预取窗口内的预检结果缓存。
+ * 预取窗口内的预检结果缓存 —— **只复用 dirty=true,clean 一律重新查**。
  *
- * 这次查询是「点了归档、行还没消失」里剩下的最大一块等待:有 worktree 的会话
- * 要在 main 侧跑一次 git status。但每个归档入口在真正执行前都有一段人类操作
- * 空窗 —— 列表行内是两步确认(点归档图标 → 点 Confirm 胶囊),菜单入口是先
- * 打开菜单再点条目 —— 空窗至少一次反应时间(数百毫秒),足够预检跑完。于是在
- * 进入空窗时就 prefetch,真正执行时 resolve 命中缓存,await 只花一个 microtask。
+ * 每个归档入口在真正执行前都有一段人类操作空窗:列表行内是两步确认(点归档
+ * 图标 → 点 Confirm 胶囊),菜单入口是先打开菜单再点条目。在那一刻 prefetch,
+ * 可以把 main 侧那次 git status 挪出用户等待。
  *
- * TTL 取 8s:略长于行内 Confirm 胶囊 4s 自动撤回的窗口,又短到不会把「用户刚
- * 提交/stash 完改动」的旧结论留太久。这个结论只决定确认文案里是否追加一行未
- * 提交改动警告,过期读到旧值的代价很低。
+ * 但复用**必须是非对称的**(greptile / codex 都按 P1 指出过):
+ *   - cached dirty=true → 安全。这个结论只会让确认弹窗多出现一次;就算 worktree
+ *     期间被清干净了,用户看到警告仍可取消或继续,保护不会失效。
+ *   - cached clean → **不安全,不能复用**。归档会顺带回收 worktree,如果预取之后
+ *     外部编辑器或收尾中的 agent 写脏了工作区,复用 clean 就会整个跳过 dirty 确认,
+ *     用户拿不到承诺的「先提交或取消」机会(main 侧回收前会 auto-stash 兜住数据,
+ *     所以不至于丢改动,但用户不会知道改动已被 stash 带走)。
+ *
+ * 因此 clean 结论从不被复用,连仍在飞的预取也不复用其 clean 结果。这几乎不损失
+ * 收益:实测本仓 `git status --porcelain` 只要 20~40ms,加 IPC 往返远低于感知阈值;
+ * 预取真正的价值变成「去重 + 提前把 git 的索引/文件系统 cache 热起来 + dirty 会话
+ * 零等待」。TTL 8s 略长于行内 Confirm 胶囊 4s 自动撤回窗口,只对 dirty 生效。
  */
 const DIRTY_PREFLIGHT_TTL_MS = 8_000;
 
-const dirtyPreflightCache = new Map<string, { at: number; promise: Promise<boolean> }>();
+interface DirtyPreflightEntry {
+  at: number;
+  promise: Promise<boolean>;
+  /** promise 已 settle 时的结论；undefined = 仍在飞。只有 true 允许被复用。 */
+  dirty?: boolean;
+}
 
-/** 预热某个会话的 dirty 预检；重复调用在 TTL 内只发一次查询。 */
+const dirtyPreflightCache = new Map<string, DirtyPreflightEntry>();
+
+/** 预热某个会话的 dirty 预检。 */
 export function prefetchDirtyWorktreeForRemoval(
   sessionId: string,
   deviceLinkDeviceId?: string | null,
@@ -49,8 +63,9 @@ export function prefetchDirtyWorktreeForRemoval(
 }
 
 /**
- * 取 dirty 预检结论：命中未过期的预取则直接复用，否则即时查询。
- * 归档/删除的执行路径都应该走这个而不是 fetch，才能吃到预取的收益。
+ * 取 dirty 预检结论：只有未过期且为 dirty 的预取结果会被复用，其余情况(无缓存 /
+ * 已过期 / 结论是 clean / 仍在飞)一律重新查询，理由见上方注释。
+ * 归档/删除的执行路径都应该走这个而不是直调 fetch。
  */
 export function resolveDirtyWorktreeForRemoval(
   sessionId: string,
@@ -58,13 +73,21 @@ export function resolveDirtyWorktreeForRemoval(
 ): Promise<boolean> {
   const now = Date.now();
   const cached = dirtyPreflightCache.get(sessionId);
-  if (cached && now - cached.at < DIRTY_PREFLIGHT_TTL_MS) return cached.promise;
+  if (cached && cached.dirty === true && now - cached.at < DIRTY_PREFLIGHT_TTL_MS) {
+    return cached.promise;
+  }
   const promise = fetchDirtyWorktreeForRemoval(sessionId, deviceLinkDeviceId);
-  dirtyPreflightCache.set(sessionId, { at: now, promise });
+  const entry: DirtyPreflightEntry = { at: now, promise };
+  dirtyPreflightCache.set(sessionId, entry);
+  // 回填结论:只有 dirty 会被后续 resolve 复用。用 entry 身份守卫,避免旧查询
+  // 覆盖同一会话更新的那次(fetch 内部已 swallow 异常,不会 reject)。
+  void promise.then((dirty) => {
+    if (dirtyPreflightCache.get(sessionId) === entry) entry.dirty = dirty;
+  });
   // 过期条目没有别的清理时机(会话可能已经被归档/删除),顺手扫一遍,
   // 别让 Map 随会话数无限长大。
-  for (const [id, entry] of dirtyPreflightCache) {
-    if (now - entry.at >= DIRTY_PREFLIGHT_TTL_MS) dirtyPreflightCache.delete(id);
+  for (const [id, item] of dirtyPreflightCache) {
+    if (now - item.at >= DIRTY_PREFLIGHT_TTL_MS) dirtyPreflightCache.delete(id);
   }
   return promise;
 }

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2910,6 +2910,13 @@ interface ElectronAPI {
     reason?: 'gone' | 'no-worktree' | 'git-error';
     detail?: string;
   }>;
+  /**
+   * 「worktree 回收链已跑完」推送。归档/删除后 main 侧的回收是 fire-and-forget 的
+   * 异步链，store 条目移除远晚于状态 IPC 返回，renderer 必须等这条才能拿到真实快照。
+   */
+  onWorktreeChanged: (
+    callback: (payload: { sessionId: string }) => void,
+  ) => () => void;
 
   // ── Slack Hook(中心 slack-hook-server 接入) ── 类型正本在 shared/hookControlIpc.ts
   hookControl: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

在对话列表里归档一条会话，点下去要等大约半秒行才消失。

根因是 `sessionsStore.patchLocal` 处理 `status` 跨桶迁移的方式：它把「桶归属与实际不符」的桶**整个 drop 掉**再重拉。归档时当前可见的 `active` 桶正好命中这条，桶变成 `null` 后 `useCCSessions` 订阅回调里的 `next !== null` 守卫会跳过 `setState`，列表就停在**仍然含有被归档行**的陈旧快照上，一直等到重拉的 `local-db:sessions:list` 回来才更新。而那个查询是 `LEFT JOIN messages` + `GROUP BY` + 两个 latest-message 子查询、`limit 1000`，在真实数据量下几百毫秒很正常 —— 调用方 `useSessionLifecycleActions` 里那段「两次 flushSync 保证乐观更新」因此完全白做。

顺着关键路径把剩下几层等待也一起清了，并按要求去掉了菜单归档的确认框。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（使用中反馈的归档响应慢）
- 本 PR 包含：
  1. **`sessionsStore.patchLocal` 的 status 迁移改为不对称处理**：「在桶里但已不该在」（归档时的 `active` 桶）就地 filter 移除，桶保持非 `null`，订阅者当帧就能拿到不含该行的快照；只有「不在桶里但该在」（`archived` 桶，本地没有它的完整 row）才 drop + 后台重拉。
  2. **顺带修一个既有竞态**：status 迁移时解除在途 list 请求对桶的认领并重发。否则那些发起于变更之前的响应回来会整桶 `cache.set`，把被归档行写回来（`deleted` 分支早就这么处理了，status 迁移一直漏着）。
  3. **去掉归档/删除后阻塞式的全量重拉**：`patchLocal` 已把当前可见桶就地改好，原来的 `await refreshSessions()` 改成不阻塞的后台兜底，delete 的跳转也不再排在那次重查询后面。
     兜底本身从「只刷当前桶」升级成 `emitRefresh()`（强制重拉所有已加载桶，codex review，`7a8cdcd3`）：`patchLocal` 对目标桶（`archived`）是 drop + 立刻重拉，而那次重拉发生在 `setStatus` 写库**之前**，拿到的是「还没归档」的快照；本机 `local-db:sessions:update` 又只在 title / settings / project 变化时才广播 `sessions:patched`（status 不在其中），`archived` 桶再没有别的修正机会 —— 用户切「已归档」会看不到刚归档的会话。代价是后台跑 N 次 `sessions:list`（N = 已加载桶数，通常 1~2），都不在用户等待路径上。
  4. **dirty-worktree 预检预取**：这次预检要在 main 侧跑 `git status`。改为在「行内两步确认亮出 Confirm 胶囊」「菜单打开」这些人类操作空窗里预热（`worktreeRemovalWarning` 新增预取缓存），接了 6 个入口：列表行的归档图标 / 右键菜单 / ⋮ 菜单、卡片模式的两个入口、header 的 ··· 菜单。
     **复用是非对称的**（greptile / codex 都按 P1 指出过，已在 `66a67d1f` 修正）：`dirty` 在 8s TTL 内复用（这个结论只会让确认弹窗多出现一次，保护不会失效）；**`clean` 与 `unknown` 从不复用**，连仍在飞的预取也不复用其非 dirty 结果，执行时一律重新验证 —— 否则预取之后工作区被写脏就会整个跳过 dirty 确认。实测本仓 `git status --porcelain` 只要 20~40ms，所以这个安全侧取舍几乎不损失收益，预取的价值收窄为「提前热 git 的索引/文件系统 cache + dirty 会话零等待」。
  5. **预检改成三态，免确认的判据是「确认干净」而不是「不是脏的」**（greptile review，`3fdc273c`）：原来的预检是布尔，查询失败（IPC 异常 / 老被控端 / device-link 隧道断）在 `catch` 里降级成 `false`。在「所有入口都一定弹确认框」的旧世界里，这个降级只意味着文案少一行警告；但归档改成「干净就免确认」之后，同一个 `false` 就变成**静默放行** —— 预检失败时归档会不打招呼地回收带未提交改动的 worktree（main 侧只会 auto-stash 兜底，用户拿不到告警和取消机会）。改成 `'clean' | 'dirty' | 'unknown'`：只有 `'clean'` 免确认，`'unknown'` 与 `'dirty'` 一样弹确认框（`'unknown'` 走普通归档确认、不摆 dirty 警告文案，否则会谎称有未提交改动）。布尔版 `fetchDirtyWorktreeForRemoval` 保留给**总是弹确认框**的路径（批量计数、doc 模式关闭标签页），那里 `false` 不会变成放行。
  6. **归档预检不再串行叠加两次 IPC 往返**：IM 接管查询先发不 await，与「菜单打开 / 亮出 Confirm 胶囊」时那次 worktree 预检 prefetch 在链路上重叠；另外 sidebar 常驻订阅的 attached 集合（`binding:list-attached` = 全量 resolve，`binding:changed` 驱动 refresh，与 `binding:resolve-session` 同源）命中时直接拦截，连 IPC 都不发。
     **但 worktree 预检必须是最后一个前置条件**（codex review，`e0aa3841`）：早期版本先拿 preflight、再 await 接管查询（header 用 `Promise.all` 一起等），那段等待就是 clean 结论的失效窗口 —— 编辑器或收尾中的 agent 在那期间写脏工作区，归档就不带警告地过去了。现在接管先结算、预检最后 resolve；clean 一律重查，所以判据是此刻的结论。窗口压不到零（从查询返回到 main 真正 `git worktree remove` 之间还有写库与回收链），那一段由 `removeWorktreeForSession` 删除前重新检测 + auto-stash 兜住。
  7. **乐观更新顺序按桶区分**：行会被移出列表时（`active` 桶，最常见）先 `flushSync` 掉行、`navigate` 不加 `flushSync`，别让整屏视图切换的同步渲染堵在「行消失」之前；`all` 桶下行只是重排、仍在列表里，保持原来的 navigate 优先，否则会看到「归档后的行在新位置还高亮」。
  8. **菜单归档不再弹确认框**：sidebar 菜单归档与行内快捷归档合并为同一条无弹窗路径，header ··· 菜单同样。
  9. **worktree 徽标不再停在回收前的旧快照**（codex review P1，`b7fcef42`）：main 侧的 worktree 回收是 fire-and-forget 的异步链（关子进程 → `git worktree remove` → 文件系统清理），store 条目被移除远晚于状态 IPC 返回。原先 renderer 只在归档/删除动作里「顺手」刷一次 `worktreeListAll`，`await refreshSessions()` 那几百毫秒只是碰巧掩盖了这个竞态；本 PR 去掉那次 await 后它就暴露了，徽标会一直陈旧到某次无关刷新。修法是让 main 在回收链结束后广播 `worktree:changed`，`WorktreeContext` 订阅它再拉一次（失败/跳过时也广播 —— 那时条目仍在 store 里，重拉拿到「徽标还在」同样是真实状态）。

### 远程 / 手机适配（新增推送事件，按 `docs/dev-rules/remote-and-mobile-adaptation.md` 门禁逐项回答）

1. **SSH 远程工作区**：不涉及。本 PR 不新增 workdir 文件访问；唯一的文件系统动作是既有的 `worktree:removal-preview`（main 侧 `git status`），路径与执行位置都没改。
2. **device-link / 手机控制端是否需要新 channel**：**不需要，故未登记 allowlist**。`worktree:changed` 只广播给本机窗口（不进 `tapWindowBroadcast`），消费方是本机 `WorktreeContext` 的 `worktreeListAll` 快照；控制端看被控端会话时，worktree 元数据走 device-link 自己的镜像链路（远程会话不进本地 `sessionsStore` / `WorktreeContext`，dirty 预检也已经是隧道到被控端的 `worktree:removal-preview`）。登记它反而会把被控端的本机 store 事件泄进控制端的本地上下文。
3. **手机版入口 / UI**：不涉及。归档交互与 worktree 徽标都是 desktop sidebar 的形态，mobile 有自己的会话行实现，本 PR 未触及 `apps/mobile`。

preload 侧按 `docs/dev-rules/electron-security-and-process-boundaries.md` §4：固定 channel 字面量（不让 renderer 自选）、经 `createIpcFanOut` 在 preload 内丢弃 `IpcRendererEvent` 只传业务 payload（`{ sessionId }`）、单一具名方法 `onWorktreeChanged`、`vite-env.d.ts` 类型与测试同步。

- 明确不包含：
  - doc 模式（工作目录浏览）关闭会话标签页时的归档确认框**保留**。那不是菜单，是 tab 上的关闭按钮，弹框是它唯一的确认手段，去掉会变成「点一下直接没了」——属于另一个交互决定，没有一并改。
  - 没有量化计时/性能基准，只做了前后手感对比。
- 用户可见变化：
  - 归档后对话从列表消失基本变成当帧，不再有等待感。
  - **菜单里归档不再弹确认框**（可逆操作，菜单里就有「恢复」；行内入口本身已是两步确认）。**唯一例外**：worktree 有未提交改动时仍然弹 —— 归档会顺带回收 worktree，不能静默带走改动。
  - 删除的确认框**不变**（不可逆）。
- 是否存在 breaking change：无

### UI 变化

去掉了一次确认步骤（菜单归档），没有任何视觉层改动：不新增/修改 dialog，不动样式、token、布局或动效。dirty-worktree 例外路径复用既有 `ConfirmDialog` 与既有 i18n 文案（`ccAgent.sidebar.confirmArchive.*`），一个字没改。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.2（ConfirmDialog 焦点与按钮语义）与 §「Actions = verb + object」——本次沿用既有确认弹窗，其焦点行为与带宾语的确认按钮文案均未改动，故不引入新的规范落地项。视觉规范层面为「不涉及：无视觉/样式/文案变更，纯交互步骤减法 + 时序优化」。

## 怎么验证的

### 自动验证

```text
# 仓库根全量单测门禁
bash <git-skill>/scripts/run-unit-gate.sh <worktree>
结果：GATE_EXIT=0，0 个 FAIL（含 apps/desktop unit PASS）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --dir apps/desktop exec vitest run
结果：1370 files / 15453 passed | 2 skipped
```

新增与更新的断言：

- `sessionsStoreStatusBucketMigration.test.tsx`（新增 6 例）：就地移除且不重拉、**已挂载列表在没有任何 IPC 回包的前提下同步去掉该行**（这条正对根因）、只重拉缺 row 的桶、`all` 桶保留并更新 status、unarchive 反向、在途旧响应不把该行写回。
  - 回归价值已核对：把这个文件拿到未改动的 `main` 上跑，6 例里 5 例失败。
- `worktreeRemovalPreflightPrefetch.test.ts`（新增 12 例）：三态语义 5 例（**查询失败是 `unknown` 而不是 clean**、无 worktree → clean、脏 → dirty、布尔版对总弹框路径仍降级为 false、device-link 隧道失败 → unknown）+ 预取缓存 7 例（dirty 命中不重查、**预取到 clean 后工作区变脏时执行前必须重新查到新结论**、**unknown 不缓存而是重试**、**in-flight 的非 dirty 结果同样不放行**、按会话隔离、dirty 结论 TTL 过期后重查、无预取时直查）。
- `useSessionLifecycleActions.test.tsx`（新增 4 例 + 更新 2 例）：两种桶各自的 patch/navigate 先后、非活跃会话不跳转、乐观 patch 早于写库且失败回滚；delete 的兜底断言改为钉 `emitRefresh`（写库成功后调用、失败时不调用）并显式断言不再走只刷一桶的 `refreshSessions`。
- `worktreeContextRecycleRefresh.test.tsx`（新增 3 例）：收到 `worktree:changed` 后重拉并让回收掉的条目消失、unmount 后取消订阅、推送 channel 缺失时 Provider 仍能挂载。
- `setSessionsStatusInDb.test.ts`（新增 3 例）：`worktree:changed` **只在回收链结束后**广播（回收未完成时断言没提前广播）、回收失败时也广播、恢复为 active 时不广播。
- `sidebarUpperSingleButton.test.ts`（更新 + 新增 2 例）：源码结构断言改为钉 `isArchiveLike` 这条无弹窗路径 + 走 `resolveWorktreeRemovalPreflight` + 放行判据是 `preflight !== 'clean'`（防止退回布尔的「不是脏的就放行」）；新增「删除仍保留确认框」与「**`blockedByAttachment` 结算早于 `resolveWorktreeRemovalPreflight`**」（防止预检又被挪到别的 await 前面）。

### 手工验证

macOS，在功能 worktree 直接起开发版（`pnpm restart:desktop:remote -- --preserve-running`，remote / passive、共享登录态与 userData，`pnpm desktop:whoami` 为 `MATCH`），在真实会话数据上走查：列表行内两步确认归档、右键菜单归档、⋮ 菜单归档、header ··· 菜单归档，以及归档后切「已归档」筛选确认会话在、恢复正常。归档后行消失的等待感前后对比明显下降。

### 未执行的验证

- 未做量化计时或性能基准，「半秒 → 当帧」是链路分析 + 手感对比的结论，不是测量值。
- dirty-worktree 例外路径（归档一个有未提交改动的 worktree 会话时仍弹确认框）只有单测覆盖，未在实机构造脏 worktree 走查。
- 未在 Windows 上验证。改动全在 renderer 时序与 store 缓存语义，不含平台分支代码。
- 双 Light / Dark 模式未做实机目检 —— 本次无任何颜色/样式改动，dirty 例外弹窗复用既有 themed 组件；按 `DESIGN.md` 双模式交付门槛如实标注为未目检，而不是当作已验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：desktop 的会话列表归档/删除链路 —— `sessionsStore` 的 status 跨桶迁移语义、`useSessionLifecycleActions` 的乐观更新时序、归档预检的发起时机与确认框编排，以及 main 侧新增的一条本机单向推送 `worktree:changed`（只用于让 `WorktreeContext` 在回收真正完成后重拉快照）。不碰 DB schema、协议与既有 IPC 契约。
- 需要注意的三点行为取舍：
  1. **归档失败回滚会退化一次重拉**。行现在是就地移除的，`setStatus` 写库失败时回滚 `patchLocal({status:'active'})` 在桶里找不到它，会走「缺 row → drop 重拉」补回来。DB 写失败本身是极罕见路径，换来的是常规路径当帧响应。
  2. **预检的窗口压不到零，只是不再跨 await**。从预检返回到 main 侧真正 `git worktree remove` 之间还有状态写库与整条回收链，这一段无法在 renderer 消除 —— 由 `WorktreeManager.removeWorktreeForSession` 在删除前重新检测 dirty + auto-stash 兜住（数据不丢，但用户是事后才知道改动进了 stash）。要做到「用户一定先看到告警」得让 main 在回收前回传结论、由 renderer 决定是否继续，那是另一个交互决策，不在本 PR 范围。
  3. **预检的不确定性一律偏向「多弹一次确认」**。`dirty` 复用最长 8s，所以预取之后用户刚好提交/stash 完改动时，可能多弹一次未提交改动警告；预检失败（`unknown`）也会弹一次普通归档确认。反方向（预取 clean 后工作区变脏、或失败被当成干净）都已堵掉 —— 免确认只认「确认干净」。
- 回滚 / 降级方式：整体 revert 即可，无数据迁移、无持久化状态、无协议约定。单独回退某一层也可以：store 的迁移语义、预取缓存、确认框编排三者互相独立。
