### PR TITLE
fix(desktop): 共享 userData 双开时不再因凭证文件格式迁移被误登出

### DIFF
--- a/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
+++ b/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
@@ -90,6 +90,59 @@ describe('legacy → v1 refresh token migration window', () => {
     );
   });
 
+  it('写侧:镜像写入失败必须如实记录,不静默当成已同步', () => {
+    const body = sliceBody(
+      'function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {',
+      '\n}\n',
+    );
+
+    // 密钥链暂时不可用 / 权限 / 磁盘满:v1 已是最新,但只读 legacy 的旧版实例这轮追不上。
+    // 忽略返回值会让「镜像已生效」成为无根据的假设。
+    expect(body).toContain('if (!writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)) {');
+    const failureIdx = body.indexOf('if (!writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY');
+    expect(body.indexOf('log.warn(', failureIdx)).toBeGreaterThan(failureIdx);
+  });
+
+  it('写侧:镜像期间 v1 被清掉 → 按 CAS 撤回刚写的从属副本', () => {
+    const body = sliceBody(
+      'function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {',
+      '\n}\n',
+    );
+
+    // 「检查存在 → 写入」不原子:另一个共享 userData 的实例可能刚好在这中间登出并删掉
+    // legacy,本次写入会把它复活。写完再看权威记录,v1 也没了就撤回——从属副本不能比
+    // 权威记录活得更久。
+    expect(body).toContain('if (isPersistedSecretAbsent(AUTH_SESSION_KEY)) {');
+    const rollbackIdx = body.indexOf('if (isPersistedSecretAbsent(AUTH_SESSION_KEY)) {');
+    // 必须 compare-and-delete:内容已变说明又有别人写过,不在本次撤回范围内。
+    expect(
+      body.indexOf('removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)'),
+    ).toBeGreaterThan(rollbackIdx);
+    expect(body).not.toContain('removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);');
+    // 撤回必须发生在写入之后,否则守的不是这枚刚镜像的 token。
+    expect(body.indexOf('writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)')).toBeLessThan(
+      rollbackIdx,
+    );
+  });
+
+  it('读侧:本轮已被拒过的 token 不再算替换候选(防两个来源来回重试)', () => {
+    const refreshSource = readFileSync(
+      resolve(process.cwd(), 'src/main/authRefreshFailure.ts'),
+      'utf8',
+    ).replace(/\r\n/g, '\n');
+
+    // v1 与 legacy 分叉时互为「对方眼里的替换 token」。只排除紧邻的上一枚会让两枚来回
+    // 被选中,耗尽 maxReplacementRetries 后以 replacement-retry 收尾 —— runtime 每 60s
+    // 重试一枚已知无效的凭证而永不过期,冷启动保留不可用凭证并以未登录启动。
+    expect(refreshSource).toContain('const rejectedTokens = new Set<string>();');
+    expect(refreshSource).toContain('rejectedTokens.has(action.refreshToken)');
+    expect(refreshSource).toContain('rejectedTokens.add(requestedToken);');
+    expect(refreshSource).toContain('const withoutRejectedCandidate = (');
+    // 主判定与 recheck 循环两处都必须过这道闸,漏一处就仍会来回重试。
+    const guardCalls = refreshSource.match(/withoutRejectedCandidate\(\n/g) ?? [];
+    expect(guardCalls.length).toBe(2);
+  });
+
   it('读侧:replacement 候选同时看 v1 与 legacy,v1 优先', () => {
     const body = sliceBody('function readLatestReplacementRefreshToken(', '\n}\n');
 

--- a/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
+++ b/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
@@ -135,18 +135,26 @@ describe('legacy → v1 refresh token migration window', () => {
     // 被选中,耗尽 maxReplacementRetries 后以 replacement-retry 收尾 —— runtime 每 60s
     // 重试一枚已知无效的凭证而永不过期,冷启动保留不可用凭证并以未登录启动。
     expect(refreshSource).toContain('const rejectedTokens = new Set<string>();');
-    expect(refreshSource).toContain('rejectedTokens.has(action.refreshToken)');
     expect(refreshSource).toContain('rejectedTokens.add(requestedToken);');
-    expect(refreshSource).toContain('const withoutRejectedCandidate = (');
+    // 筛选必须发生在「按优先级折叠成一枚」之前:先折叠后过滤会让首选来源里那枚已拒的
+    // token 挤掉次选来源里有效的那枚(codex #878 P1)。
+    const helper = refreshSource.slice(
+      refreshSource.indexOf('const nextReplacementCandidate = ('),
+      refreshSource.indexOf('while (true) {'),
+    );
+    // 全部来源先经 rejectedTokens 过滤,过滤结果才作为 pick 的候选集传进去。
+    expect(helper).toContain(
+      'opts.readLatestStoredTokens().filter((token) => !token || !rejectedTokens.has(token))',
+    );
+    expect(helper).toContain('pickRefreshTokenReplacementCandidate(');
     // 主判定与 recheck 循环两处都必须过这道闸,漏一处就仍会来回重试。
-    const guardCalls = refreshSource.match(/withoutRejectedCandidate\(\n/g) ?? [];
+    const guardCalls = refreshSource.match(/nextReplacementCandidate\(requestedToken\)/g) ?? [];
     expect(guardCalls.length).toBe(2);
   });
 
-  it('读侧:replacement 候选同时看 v1 与 legacy,v1 优先', () => {
-    const body = sliceBody('function readLatestReplacementRefreshToken(', '\n}\n');
+  it('读侧:交出 v1 与 legacy 两个来源且不在此折叠,v1 排前', () => {
+    const body = sliceBody('function readStoredRefreshTokenCandidates(', '\n}\n');
 
-    expect(body).toContain('pickRefreshTokenReplacementCandidate(requestedToken, [');
     const v1Idx = body.indexOf('readPersistedRefreshToken(realm)');
     const legacyIdx = body.indexOf('readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY)');
     expect(v1Idx).toBeGreaterThan(-1);
@@ -157,6 +165,9 @@ describe('legacy → v1 refresh token migration window', () => {
     expect(body).toContain(
       'realm === AUTH_REGION ? readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY) : null',
     );
+    // 关键:这里**不能**先挑一枚。挑选要在 runner 里做,只有它知道哪些 token 本轮已被拒;
+    // 在这里折叠会让 v1 那枚已失效的 token 挤掉 legacy 里有效的那枚,连带把有效凭证删掉。
+    expect(body).not.toContain('pickRefreshTokenReplacementCandidate');
   });
 
   it('读侧:replacement-retry 走双来源读取,不再只认 v1', () => {
@@ -165,8 +176,39 @@ describe('legacy → v1 refresh token migration window', () => {
       '});',
     );
 
-    expect(body).toContain('readLatestReplacementRefreshToken(opts.realm, requestedToken)');
-    // 直接把 readPersistedRefreshToken 当 readLatestStoredToken 用就是本次事故的成因。
+    expect(body).toContain('readLatestStoredTokens: () => readStoredRefreshTokenCandidates(');
+    // 直接把 readPersistedRefreshToken 当唯一来源用就是本次事故的成因。
     expect(body).not.toContain('readLatestStoredToken: () => readPersistedRefreshToken(');
+  });
+
+  it('确定性失效后:冷启动清掉镜像出去的 legacy 从属副本', () => {
+    // 权威记录被判失效删除后,镜像那一份不能留:只读 legacy 的旧版实例会拿它再撞一次
+    // INVALID_REFRESH_TOKEN 被强制重登,本进程读侧回退也会把它当替换候选。
+    const helper = sliceBody(
+      'function clearMirroredLegacyRefreshToken(realm: AuthRegion, expectedToken: string): void {',
+      '\n}\n',
+    );
+    expect(helper).toContain('if (realm !== AUTH_REGION) return;');
+    expect(helper).toContain(
+      'removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, expectedToken)',
+    );
+    // 必须 compare-and-delete:内容已变说明另一个实例刚写入替换凭证,不在清理范围内。
+    expect(helper).not.toContain('removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);');
+    expect(helper).toContain("if (outcome === 'changed') {");
+    expect(helper).toContain("if (outcome === 'failed') {");
+
+    // 调用点必须落在冷启动确定性失效的**非 passive** 分支里:passive 不得删整机共享凭证。
+    const coldStart = sliceBody(
+      "if (action.kind === 'definitive-failure') {",
+      "} else if (action.kind === 'replacement-retry') {",
+    );
+    const passiveIdx = coldStart.indexOf('if (isPassiveSharedUserDataInstance()) {');
+    const callIdx = coldStart.indexOf('clearMirroredLegacyRefreshToken(storedRealm, storedToken);');
+    expect(passiveIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeGreaterThan(passiveIdx);
+    // 与 v1 的 CAS 删除同处一个 else 分支,顺序在其后(先清权威,再清从属)。
+    expect(
+      coldStart.indexOf('removeSafeIfUnchanged(AUTH_SESSION_KEY, expectedSession)'),
+    ).toBeLessThan(callIdx);
   });
 });

--- a/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
+++ b/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
@@ -103,26 +103,29 @@ describe('legacy → v1 refresh token migration window', () => {
     expect(body.indexOf('log.warn(', failureIdx)).toBeGreaterThan(failureIdx);
   });
 
-  it('写侧:镜像期间 v1 被清掉 → 按 CAS 撤回刚写的从属副本', () => {
+  it('写侧:镜像期间 v1 被清掉**或已前进** → 都按 CAS 撤回刚写的从属副本', () => {
     const body = sliceBody(
       'function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {',
       '\n}\n',
     );
 
-    // 「检查存在 → 写入」不原子:另一个共享 userData 的实例可能刚好在这中间登出并删掉
-    // legacy,本次写入会把它复活。写完再看权威记录,v1 也没了就撤回——从属副本不能比
-    // 权威记录活得更久。
+    // 「检查存在 → 写入」不原子。写完必须核对权威记录仍是本次写入的那一条:
+    //  - 被清掉(登出)→ 从属副本不能比权威记录活得更久;
+    //  - 已前进到更新的一枚 → 本次镜像那枚此刻已失效,留着正是本 PR 要消灭的
+    //    「旧版只读 legacy → 拿到死 token → 被强制重登」(codex #878 P1)。
     expect(body).toContain('if (isPersistedSecretAbsent(AUTH_SESSION_KEY)) {');
-    const rollbackIdx = body.indexOf('if (isPersistedSecretAbsent(AUTH_SESSION_KEY)) {');
+    expect(body).toContain('latestSession !== serializeAuthSessionRecord(realm, refreshToken)');
     // 必须 compare-and-delete:内容已变说明又有别人写过,不在本次撤回范围内。
-    expect(
-      body.indexOf('removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)'),
-    ).toBeGreaterThan(rollbackIdx);
+    expect(body).toContain(
+      'removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)',
+    );
     expect(body).not.toContain('removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);');
     // 撤回必须发生在写入之后,否则守的不是这枚刚镜像的 token。
     expect(body.indexOf('writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)')).toBeLessThan(
-      rollbackIdx,
+      body.indexOf('const rollBackMirror = '),
     );
+    // 读不出权威记录但文件还在(密钥链抖动)属不确定状态,不得撤回。
+    expect(body).toContain('latestSession !== null');
   });
 
   it('读侧:本轮已被拒过的 token 不再算替换候选(防两个来源来回重试)', () => {
@@ -181,21 +184,30 @@ describe('legacy → v1 refresh token migration window', () => {
     expect(body).not.toContain('readLatestStoredToken: () => readPersistedRefreshToken(');
   });
 
-  it('确定性失效后:冷启动清掉镜像出去的 legacy 从属副本', () => {
-    // 权威记录被判失效删除后,镜像那一份不能留:只读 legacy 的旧版实例会拿它再撞一次
-    // INVALID_REFRESH_TOKEN 被强制重登,本进程读侧回退也会把它当替换候选。
-    const helper = sliceBody(
-      'function clearMirroredLegacyRefreshToken(realm: AuthRegion, expectedToken: string): void {',
-      '\n}\n',
-    );
-    expect(helper).toContain('if (realm !== AUTH_REGION) return;');
-    expect(helper).toContain(
-      'removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, expectedToken)',
-    );
-    // 必须 compare-and-delete:内容已变说明另一个实例刚写入替换凭证,不在清理范围内。
+  it('确定性失效后:v1 与 legacy 都按「本轮被拒过的每一枚」CAS 清理', () => {
+    // 只认最初那一枚是错的(greptile #878 P1):本轮一旦从另一个来源追赶过,磁盘上现存的
+    // 就是清单里较晚的那一枚,拿最初的 token 做 compare-and-delete 会一律 changed,把已
+    // 确认失效的凭证留在盘上,旧版实例继续拿它撞 INVALID_REFRESH_TOKEN 被强制重登。
+    const helper = sliceBody('function clearConfirmedDeadRefreshTokens(', '\n}\n');
+    // 两个文件都要遍历整份清单,而不是只比一枚。
+    expect(helper).toContain('for (const token of deadTokens) {');
+    expect(helper.match(/for \(const token of deadTokens\) \{/g)?.length).toBe(2);
+    // 断言分段写:prettier 会按行宽把这个调用拆成多行,不能锚在单行字面量上。
+    expect(helper).toContain('removeSafeIfUnchanged(');
+    expect(helper).toContain('serializeAuthSessionRecord(realm, token)');
+    expect(helper).toContain('removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, token)');
+    // 命中(deleted / failed)即停,不继续拿别的 token 去撞。
+    expect(helper).toContain("if (sessionOutcome !== 'changed') break;");
+    expect(helper).toContain("if (legacyOutcome !== 'changed') break;");
+    // 仍是 compare-and-delete,不得退回无条件删除。
     expect(helper).not.toContain('removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);');
-    expect(helper).toContain("if (outcome === 'changed') {");
-    expect(helper).toContain("if (outcome === 'failed') {");
+    expect(helper).not.toContain('removeSafe(AUTH_SESSION_KEY);');
+    // legacy 只在与安装包区域一致时由本进程解释。
+    expect(helper).toContain('if (realm !== AUTH_REGION) return;');
+    // 三种结果各自如实记日志,failed 不得报成已清理。
+    expect(helper).toContain("case 'deleted':");
+    expect(helper).toContain("case 'changed':");
+    expect(helper).toContain("case 'failed':");
 
     // 调用点必须落在冷启动确定性失效的**非 passive** 分支里:passive 不得删整机共享凭证。
     const coldStart = sliceBody(
@@ -203,12 +215,25 @@ describe('legacy → v1 refresh token migration window', () => {
       "} else if (action.kind === 'replacement-retry') {",
     );
     const passiveIdx = coldStart.indexOf('if (isPassiveSharedUserDataInstance()) {');
-    const callIdx = coldStart.indexOf('clearMirroredLegacyRefreshToken(storedRealm, storedToken);');
+    const callIdx = coldStart.indexOf('clearConfirmedDeadRefreshTokens(storedRealm,');
     expect(passiveIdx).toBeGreaterThan(-1);
     expect(callIdx).toBeGreaterThan(passiveIdx);
-    // 与 v1 的 CAS 删除同处一个 else 分支,顺序在其后(先清权威,再清从属)。
-    expect(
-      coldStart.indexOf('removeSafeIfUnchanged(AUTH_SESSION_KEY, expectedSession)'),
-    ).toBeLessThan(callIdx);
+    // 传进去的是 runner 回传的整份清单;清单为空才退回最初那一枚。
+    expect(coldStart).toContain(
+      'const confirmedDeadTokens = rejectedTokens.length > 0 ? rejectedTokens : [storedToken];',
+    );
+  });
+
+  it('runner 回传本轮被拒过的全部 token,供调用方做清理比对', () => {
+    const refreshSource = readFileSync(
+      resolve(process.cwd(), 'src/main/authRefreshFailure.ts'),
+      'utf8',
+    ).replace(/\r\n/g, '\n');
+
+    // 返回类型里必须有这份清单,且每个 return 分支都带上——漏一个分支就会让调用方在那条
+    // 路径上退回「只认最初那一枚」的错误清理。
+    expect(refreshSource).toContain('rejectedTokens: readonly string[];');
+    const returns = refreshSource.match(/rejectedTokens: \[\.\.\.rejectedTokens\],/g) ?? [];
+    expect(returns.length).toBe(3);
   });
 });

--- a/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
+++ b/apps/desktop/src/main/__tests__/authLegacyTokenMirror.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * legacy → v1 凭证格式迁移窗口内的双向追赶守卫(authManager 依赖 Electron,node 测试
+ * 环境无法直接 import,沿用 authPassiveSharedInstance.test.ts 的源码守卫模式)。
+ *
+ * 守护的契约:共享 userData 的双开实例可能一个只认 `cindy_auth_session_v1`、另一个只认
+ * legacy `cindy_auth_refresh_token`。服务端 refresh token 按 (user, device) 一对一存,
+ * 两个实例共用同一 deviceId,任一方续期都会作废对方手上那枚——只认单一凭证文件的一方
+ * 永远追不上对方轮换出的新 token,会把本可自愈的竞态判成确定性失效并强制重登。
+ *
+ * 2026-07-29 事故:packaged 0.1.20(只认 legacy)与含 #748 的 dev(只写 v1)共享 userData
+ * 双开。dev 在 07:42 续期并把新 token 写进 v1,packaged 07:46 的 refresh 拿
+ * INVALID_REFRESH_TOKEN,两次 replacement recheck 读 legacy 都只读到自己那枚已作废的
+ * token,于是弹「登录已过期 · 你的账号已在其他设备或实例上退出登录」。
+ *
+ * 两个方向都要堵:
+ *   - 写侧镜像(新版轮换 → 旧版能追上):v1 写成功后同步回写 legacy;
+ *   - 读侧回退(旧版轮换 → 新版能追上):replacement 候选同时看 v1 与 legacy。
+ */
+describe('legacy → v1 refresh token migration window', () => {
+  const authSource = readFileSync(
+    resolve(process.cwd(), 'src/main/authManager.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+
+  const sliceBody = (startAnchor: string, endAnchor: string): string => {
+    const start = authSource.indexOf(startAnchor);
+    expect(start, `anchor not found: ${startAnchor}`).toBeGreaterThan(-1);
+    const end = authSource.indexOf(endAnchor, start);
+    expect(end, `end anchor not found: ${endAnchor}`).toBeGreaterThan(start);
+    return authSource.slice(start, end);
+  };
+
+  it('写侧:v1 写成功才镜像 legacy(v1 始终是唯一权威)', () => {
+    const body = sliceBody(
+      'function writePersistedAuthSession(refreshToken: string, realm = activeAuthRealm): boolean {',
+      '\n}\n',
+    );
+
+    expect(body).toContain(
+      'writeSafe(AUTH_SESSION_KEY, serializeAuthSessionRecord(realm, refreshToken))',
+    );
+    // 镜像必须挂在写入结果之后,不能无条件执行:v1 没写成功就镜像,会让 legacy 比权威
+    // 记录更新,下次冷启动迁移反而读回一枚不该生效的 token。
+    expect(body).toContain('if (written) mirrorLegacyResourceRefreshToken(refreshToken, realm);');
+  });
+
+  it('写侧:legacy 文件不存在时不镜像(不凭空复活已清理的凭证文件)', () => {
+    const body = sliceBody(
+      'function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {',
+      '\n}\n',
+    );
+
+    // 文件不在 = 没有旧版实例在消费它(或已被独占启动的新版清掉)。凭空写回去等于把
+    // 一份本已清理的凭证复活在盘上,并让 clearAuth / 迁移路径的清理白做。
+    expect(body).toContain(
+      'if (isPersistedSecretAbsent(LEGACY_RESOURCE_REFRESH_TOKEN_KEY)) return;',
+    );
+    // 必须用 isPersistedSecretAbsent 而非 existsSync/readSafe 判缺席:后两者会把
+    // 「密钥链暂时不可用 / EPERM」误判成「文件不存在」,进而漏掉本该做的镜像。
+    expect(body).not.toContain('existsSync');
+  });
+
+  it('写侧:只镜像与安装包区域一致的 session(legacy 是裸 token,不带 realm)', () => {
+    const body = sliceBody(
+      'function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {',
+      '\n}\n',
+    );
+
+    // legacy 格式没有 realm,旧版一律按自己的构建区解释。把对端区域的 token 写进去,
+    // 旧版会拿它请求本区 auth-server —— 比不镜像更糟。
+    expect(body).toContain('if (realm !== AUTH_REGION) return;');
+    const realmGuardIdx = body.indexOf('if (realm !== AUTH_REGION) return;');
+    expect(
+      body.indexOf('writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)'),
+    ).toBeGreaterThan(realmGuardIdx);
+  });
+
+  it('写侧:值未变化则不落盘(避免无意义 mtime 变化干扰 CAS 删除的身份校验)', () => {
+    const body = sliceBody(
+      'function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {',
+      '\n}\n',
+    );
+
+    expect(body).toContain(
+      'if (readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY) === refreshToken) return;',
+    );
+  });
+
+  it('读侧:replacement 候选同时看 v1 与 legacy,v1 优先', () => {
+    const body = sliceBody('function readLatestReplacementRefreshToken(', '\n}\n');
+
+    expect(body).toContain('pickRefreshTokenReplacementCandidate(requestedToken, [');
+    const v1Idx = body.indexOf('readPersistedRefreshToken(realm)');
+    const legacyIdx = body.indexOf('readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY)');
+    expect(v1Idx).toBeGreaterThan(-1);
+    expect(legacyIdx).toBeGreaterThan(-1);
+    // v1 带 realm、是本版本权威记录,必须排在 legacy 之前。
+    expect(v1Idx).toBeLessThan(legacyIdx);
+    // legacy 同样只在与安装包区域一致时可解释。
+    expect(body).toContain(
+      'realm === AUTH_REGION ? readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY) : null',
+    );
+  });
+
+  it('读侧:replacement-retry 走双来源读取,不再只认 v1', () => {
+    const body = sliceBody(
+      'const run = await runRefreshWithReplacementRetry(initialRefreshToken, {',
+      '});',
+    );
+
+    expect(body).toContain('readLatestReplacementRefreshToken(opts.realm, requestedToken)');
+    // 直接把 readPersistedRefreshToken 当 readLatestStoredToken 用就是本次事故的成因。
+    expect(body).not.toContain('readLatestStoredToken: () => readPersistedRefreshToken(');
+  });
+});

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -22,10 +22,10 @@ import { describe, expect, it } from 'vitest';
  * 只把静默半死改成明确弹重登(正确的报警),没有堵住 passive 的写入权。
  */
 describe('passive shared-userData instance auth isolation', () => {
-  const authSource = readFileSync(resolve(process.cwd(), 'src/main/authManager.ts'), 'utf8').replace(
-    /\r\n/g,
-    '\n',
-  );
+  const authSource = readFileSync(
+    resolve(process.cwd(), 'src/main/authManager.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
 
   const sliceBody = (startAnchor: string, endAnchor: string): string => {
     const start = authSource.indexOf(startAnchor);
@@ -58,7 +58,9 @@ describe('passive shared-userData instance auth isolation', () => {
     expect(body.indexOf('removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);')).toBeGreaterThan(
       passiveIdx,
     );
-    expect(body.indexOf('removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);')).toBeGreaterThan(passiveIdx);
+    expect(body.indexOf('removeSafe(LEGACY_ACCOUNT_REFRESH_TOKEN_KEY);')).toBeGreaterThan(
+      passiveIdx,
+    );
     expect(body.indexOf('removeSafe(LEGACY_REFRESH_TOKEN_KEY);')).toBeGreaterThan(passiveIdx);
   });
 
@@ -202,16 +204,21 @@ describe('passive shared-userData instance auth isolation', () => {
 
     // passive 冷启动拿到 INVALID_REFRESH_TOKEN，最常见的原因就是 primary 刚轮换过它。
     expect(body).toContain('if (isPassiveSharedUserDataInstance()) {');
-    // 非 passive 也不能无条件删：判定与删除之间另一个实例可能写入了替换凭证。
-    expect(body).toContain(
-      'const expectedSession = serializeAuthSessionRecord(storedRealm, storedToken);',
-    );
-    expect(body).toContain('removeSafeIfUnchanged(AUTH_SESSION_KEY, expectedSession)');
+    // 删除本身抽到了 clearConfirmedDeadRefreshTokens（它同时清 v1 与 legacy 从属副本，
+    // 并逐一比对本轮被拒过的每一枚 token）。这里只守住「非 passive 分支才调它、且分支内
+    // 不出现任何无条件删除」。
+    expect(body).toContain('clearConfirmedDeadRefreshTokens(storedRealm,');
     expect(body).not.toContain('removeSafe(AUTH_SESSION_KEY);');
+    const cleanup = sliceBody('function clearConfirmedDeadRefreshTokens(', '\n}\n');
+    // 非 passive 也不能无条件删：判定与删除之间另一个实例可能写入了替换凭证。
+    // 断言分段写：prettier 会按行宽把这个调用拆成多行。
+    expect(cleanup).toContain('removeSafeIfUnchanged(');
+    expect(cleanup).toContain('serializeAuthSessionRecord(realm, token)');
+    expect(cleanup).not.toContain('removeSafe(AUTH_SESSION_KEY);');
     // 三种结果各自如实记日志，尤其 'failed' 不得报成已清理。
-    expect(body).toContain("case 'deleted':");
-    expect(body).toContain("case 'changed':");
-    expect(body).toContain("case 'failed':");
+    expect(cleanup).toContain("case 'deleted':");
+    expect(cleanup).toContain("case 'changed':");
+    expect(cleanup).toContain("case 'failed':");
 
     // compare-and-delete 读不出磁盘内容时不得删（宁留失效 token 也不误删有效凭证），
     // 并且要在内容比对前后各校验一次文件身份，收紧 read→unlink 之间的 TOCTOU。
@@ -235,7 +242,9 @@ describe('passive shared-userData instance auth isolation', () => {
     // 删除失败必须如实回报：removeSafe() 吞掉所有 unlink 错误，用它会让调用方把
     // 「没删成」当成「已清理」并据此打日志。ENOENT 例外——目标状态已达成。
     expect(helper).not.toContain('removeSafe(key);');
-    expect(helper).toContain("if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return 'deleted';");
+    expect(helper).toContain(
+      "if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return 'deleted';",
+    );
     expect(helper).toContain("return 'failed';");
   });
 

--- a/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
+++ b/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
@@ -309,6 +309,55 @@ describe('refresh token replacement detection', () => {
     expect(doRefresh).toHaveBeenNthCalledWith(1, 'rt-old');
     expect(doRefresh).toHaveBeenNthCalledWith(2, 'rt-new-1');
   });
+
+  it('两个凭证来源互指时不来回重试:已拒过的 token 不再算候选,落到确定性失效', async () => {
+    // v1 与 legacy 分叉:各自都是「对方眼里的替换 token」。只排除紧邻的上一枚会让两枚
+    // 来回被选中、耗尽重试后以 replacement-retry 收尾——runtime 于是每 60s 重试一枚
+    // 已知无效的凭证而永不过期,冷启动则保留不可用凭证并以未登录启动。
+    const doRefresh = vi.fn(async () => invalidToken);
+    const disk = { v1: 'rt-v1', legacy: 'rt-legacy' };
+
+    const result = await runRefreshWithReplacementRetry('rt-v1', {
+      doRefresh,
+      readLatestStoredToken: (requestedToken) =>
+        pickRefreshTokenReplacementCandidate(requestedToken, [disk.v1, disk.legacy]),
+      maxReplacementRetries: 5,
+    });
+
+    // 两枚都试过一次就收手,不吃满 maxReplacementRetries。
+    expect(result).toMatchObject({
+      failureAction: { kind: 'definitive-failure' },
+      replacementRetries: 1,
+      replacementRetryExhausted: false,
+    });
+    expect(doRefresh).toHaveBeenCalledTimes(2);
+    expect(doRefresh).toHaveBeenNthCalledWith(1, 'rt-v1');
+    expect(doRefresh).toHaveBeenNthCalledWith(2, 'rt-legacy');
+  });
+
+  it('replacement recheck 期间读回一枚早前已拒过的 token → 同样落到确定性失效', async () => {
+    const doRefresh = vi.fn(async () => invalidToken);
+    // 磁盘读取序列:①第一轮读到 rt-2 → 追上去重试;②第二轮读不到替换 → 进 recheck;
+    // ③recheck 期间又读回最初那枚 rt-1(例如镜像把它写进了另一个来源)。
+    const diskReads: (string | null)[] = ['rt-2', null, 'rt-1', null];
+    const sleepCalls: number[] = [];
+
+    const result = await runRefreshWithReplacementRetry('rt-1', {
+      doRefresh,
+      readLatestStoredToken: () => (diskReads.length ? (diskReads.shift() ?? null) : null),
+      maxReplacementRetries: 5,
+      replacementRecheck: {
+        delaysMs: [10, 20],
+        sleep: (ms) => (sleepCalls.push(ms), Promise.resolve()),
+      },
+    });
+
+    // recheck 读回的 rt-1 在第一轮就被拒过,不得据此再发第三次请求。
+    expect(result.failureAction).toEqual({ kind: 'definitive-failure' });
+    expect(doRefresh).toHaveBeenCalledTimes(2);
+    expect(doRefresh).toHaveBeenNthCalledWith(1, 'rt-1');
+    expect(doRefresh).toHaveBeenNthCalledWith(2, 'rt-2');
+  });
 });
 
 describe('runRefreshWithTransientRetry', () => {

--- a/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
+++ b/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
@@ -11,6 +11,7 @@ import {
   DEFINITIVE_REFRESH_FAILURE_CODES,
   getRefreshTokenReplacementCandidate,
   isDefinitiveRefreshFailure,
+  pickRefreshTokenReplacementCandidate,
   resolveRefreshFailureAction,
   resolveSessionExpiredReason,
   runRefreshWithReplacementRetry,
@@ -117,6 +118,49 @@ describe('refresh token replacement detection', () => {
     expect(getRefreshTokenReplacementCandidate('rt-old', null)).toBeNull();
     expect(getRefreshTokenReplacementCandidate('rt-old', '')).toBeNull();
     expect(getRefreshTokenReplacementCandidate('rt-old', 'rt-old')).toBeNull();
+  });
+
+  it('多来源候选:按顺序取第一枚「非空且不是本次请求那一枚」', () => {
+    // legacy → v1 迁移窗口里两个实例可能各写一个文件,只认单一来源的一方追不上对方。
+    expect(pickRefreshTokenReplacementCandidate('rt-old', ['rt-v1', 'rt-legacy'])).toBe('rt-v1');
+    // v1 还没被别人更新(仍是自己那枚)→ 回退到 legacy 里旧版实例刚轮换出的新 token。
+    expect(pickRefreshTokenReplacementCandidate('rt-old', ['rt-old', 'rt-legacy'])).toBe(
+      'rt-legacy',
+    );
+    // 空洞不阻断后续候选。
+    expect(pickRefreshTokenReplacementCandidate('rt-old', [null, undefined, '', 'rt-legacy'])).toBe(
+      'rt-legacy',
+    );
+  });
+
+  it('多来源候选:全部缺失或都等于请求 token → 没有替换候选(真确定性失效)', () => {
+    expect(pickRefreshTokenReplacementCandidate('rt-old', [])).toBeNull();
+    expect(pickRefreshTokenReplacementCandidate('rt-old', [null, undefined, ''])).toBeNull();
+    expect(pickRefreshTokenReplacementCandidate('rt-old', ['rt-old', 'rt-old'])).toBeNull();
+  });
+
+  it('readLatestStoredToken 收到本次请求所用的 token,便于跨来源挑候选', async () => {
+    const okResult: RefreshFetchResult<unknown> = {
+      ok: true,
+      status: 200,
+      data: { accessToken: 'a', refreshToken: 'rt-newer' },
+    };
+    const doRefresh = vi.fn(async (refreshToken: string) =>
+      refreshToken === 'rt-legacy' ? okResult : invalidToken,
+    );
+    const seenRequestedTokens: string[] = [];
+
+    const result = await runRefreshWithReplacementRetry('rt-old', {
+      doRefresh,
+      // 模拟 authManager 的读侧:v1 仍是自己那枚,legacy 才有旧版实例轮换出的新 token。
+      readLatestStoredToken: (requestedToken) => {
+        seenRequestedTokens.push(requestedToken);
+        return pickRefreshTokenReplacementCandidate(requestedToken, ['rt-old', 'rt-legacy']);
+      },
+    });
+
+    expect(result).toMatchObject({ result: okResult, requestedToken: 'rt-legacy' });
+    expect(seenRequestedTokens).toEqual(['rt-old']);
   });
 
   it('确定性失败且磁盘已有新 token → 用新 token 重试,不清登录态', () => {

--- a/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
+++ b/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
@@ -139,7 +139,7 @@ describe('refresh token replacement detection', () => {
     expect(pickRefreshTokenReplacementCandidate('rt-old', ['rt-old', 'rt-old'])).toBeNull();
   });
 
-  it('readLatestStoredToken 收到本次请求所用的 token,便于跨来源挑候选', async () => {
+  it('调用方交出全部来源,由 runner 跨来源挑候选', async () => {
     const okResult: RefreshFetchResult<unknown> = {
       ok: true,
       status: 200,
@@ -148,19 +148,42 @@ describe('refresh token replacement detection', () => {
     const doRefresh = vi.fn(async (refreshToken: string) =>
       refreshToken === 'rt-legacy' ? okResult : invalidToken,
     );
-    const seenRequestedTokens: string[] = [];
 
     const result = await runRefreshWithReplacementRetry('rt-old', {
       doRefresh,
       // 模拟 authManager 的读侧:v1 仍是自己那枚,legacy 才有旧版实例轮换出的新 token。
-      readLatestStoredToken: (requestedToken) => {
-        seenRequestedTokens.push(requestedToken);
-        return pickRefreshTokenReplacementCandidate(requestedToken, ['rt-old', 'rt-legacy']);
-      },
+      readLatestStoredTokens: () => ['rt-old', 'rt-legacy'],
     });
 
     expect(result).toMatchObject({ result: okResult, requestedToken: 'rt-legacy' });
-    expect(seenRequestedTokens).toEqual(['rt-old']);
+  });
+
+  it('首选来源存着已拒的 token 时,不得挤掉次选来源里有效的那枚', async () => {
+    // codex #878 P1:v1 存着已拒的 A、legacy 被并发的旧实例轮换成有效的 C。若调用方先按
+    // 优先级折叠成单个候选,交出的永远是 A;A 已被拒 → 整轮以确定性失效收场,C 从未被
+    // 试过,还会连同 C 一起被删。筛选必须在折叠之前发生。
+    const okResult: RefreshFetchResult<unknown> = {
+      ok: true,
+      status: 200,
+      data: { accessToken: 'a', refreshToken: 'rt-d' },
+    };
+    const doRefresh = vi.fn(async (refreshToken: string) =>
+      refreshToken === 'rt-c' ? okResult : invalidToken,
+    );
+
+    const result = await runRefreshWithReplacementRetry('rt-a', {
+      doRefresh,
+      // v1 始终是已被拒的 rt-a;legacy 在本进程重试期间被另一个实例换成了 rt-c。
+      readLatestStoredTokens: () => ['rt-a', 'rt-c'],
+    });
+
+    expect(result).toMatchObject({
+      result: okResult,
+      requestedToken: 'rt-c',
+      replacementRetries: 1,
+    });
+    expect(doRefresh).toHaveBeenNthCalledWith(1, 'rt-a');
+    expect(doRefresh).toHaveBeenNthCalledWith(2, 'rt-c');
   });
 
   it('确定性失败且磁盘已有新 token → 用新 token 重试,不清登录态', () => {
@@ -207,7 +230,7 @@ describe('refresh token replacement detection', () => {
 
     const result = await runRefreshWithReplacementRetry('rt-old', {
       doRefresh,
-      readLatestStoredToken: () => 'rt-new',
+      readLatestStoredTokens: () => ['rt-new'],
       onReplacementRetry: ({ replacementRetry, status, code }) =>
         replacements.push({ replacementRetry, status, code }),
     });
@@ -242,7 +265,7 @@ describe('refresh token replacement detection', () => {
 
     const result = await runRefreshWithReplacementRetry('rt-old', {
       doRefresh,
-      readLatestStoredToken: () => latestTokens.shift() ?? 'rt-new',
+      readLatestStoredTokens: () => [latestTokens.shift() ?? 'rt-new'],
       replacementRecheck: {
         delaysMs: [10],
         sleep: (ms) => (sleepCalls.push(ms), Promise.resolve()),
@@ -269,7 +292,7 @@ describe('refresh token replacement detection', () => {
 
     const result = await runRefreshWithReplacementRetry('rt-old', {
       doRefresh,
-      readLatestStoredToken: () => 'rt-new',
+      readLatestStoredTokens: () => ['rt-new'],
       replacementRecheck: {
         delaysMs: [10],
         sleep,
@@ -294,7 +317,7 @@ describe('refresh token replacement detection', () => {
 
     const result = await runRefreshWithReplacementRetry('rt-old', {
       doRefresh,
-      readLatestStoredToken: () => latestTokens.shift() ?? 'rt-new-2',
+      readLatestStoredTokens: () => [latestTokens.shift() ?? 'rt-new-2'],
       maxReplacementRetries: 1,
     });
 
@@ -319,8 +342,7 @@ describe('refresh token replacement detection', () => {
 
     const result = await runRefreshWithReplacementRetry('rt-v1', {
       doRefresh,
-      readLatestStoredToken: (requestedToken) =>
-        pickRefreshTokenReplacementCandidate(requestedToken, [disk.v1, disk.legacy]),
+      readLatestStoredTokens: () => [disk.v1, disk.legacy],
       maxReplacementRetries: 5,
     });
 
@@ -344,7 +366,7 @@ describe('refresh token replacement detection', () => {
 
     const result = await runRefreshWithReplacementRetry('rt-1', {
       doRefresh,
-      readLatestStoredToken: () => (diskReads.length ? (diskReads.shift() ?? null) : null),
+      readLatestStoredTokens: () => [diskReads.length ? (diskReads.shift() ?? null) : null],
       maxReplacementRetries: 5,
       replacementRecheck: {
         delaysMs: [10, 20],

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -48,6 +48,7 @@ import { decodeAccessTokenOrgSlug } from './authTokenClaims';
 import { getProviderSecretStore } from './secrets/providerSecretStore.js';
 import {
   runRefreshWithReplacementRetry,
+  pickRefreshTokenReplacementCandidate,
   resolveSessionExpiredReason,
   type RefreshFailureAction,
   type RefreshFailureInfo,
@@ -402,7 +403,57 @@ function readPersistedRefreshToken(realm = activeAuthRealm): string | null {
 }
 
 function writePersistedAuthSession(refreshToken: string, realm = activeAuthRealm): boolean {
-  return writeSafe(AUTH_SESSION_KEY, serializeAuthSessionRecord(realm, refreshToken));
+  const written = writeSafe(AUTH_SESSION_KEY, serializeAuthSessionRecord(realm, refreshToken));
+  // v1 记录是唯一权威;legacy 只是给尚未升级的实例看的从属副本,写成功才镜像。
+  if (written) mirrorLegacyResourceRefreshToken(refreshToken, realm);
+  return written;
+}
+
+/**
+ * 过渡期镜像:把轮换出的新 refresh token 同步回写 legacy 凭证文件。
+ *
+ * 服务端 refresh token 按 (user, device) 一对一存,共享 userData 的双开实例共用
+ * 同一 deviceId——任一实例续期,另一实例手上那枚立刻作废。这本该由
+ * replacement-retry 兜住(「磁盘上已有别人写的新 token」就追上去重试),但
+ * `LEGACY_RESOURCE_REFRESH_TOKEN_KEY` → `AUTH_SESSION_KEY` 的格式迁移打断了这条
+ * 兜底:新版轮换后只写 v1,旧版实例只会读 legacy,于是它读到的永远是自己那枚死
+ * token,把可自愈的竞态判成确定性失效并强制重登。
+ *
+ * 2026-07-29 事故:packaged 0.1.20(legacy)与含 #748 的 dev(v1)共享 userData 双开,
+ * dev 在 07:42 续期,packaged 07:46 的 refresh 拿 INVALID_REFRESH_TOKEN,两次
+ * replacement recheck 读 legacy 都读到自己那枚旧 token,弹「登录已过期」。
+ *
+ * 只在 legacy 文件**已经存在**时镜像:它不在就说明没有旧版实例在消费它(或已被
+ * 独占启动的新版清理),不要凭空复活一份凭证文件。
+ *
+ * 只镜像 realm === AUTH_REGION 的 session:legacy 格式是裸 token、不带 realm,旧版
+ * 按自己的构建区解释。把对端区域的 token 写进去,旧版会拿它去请求本区 auth-server,
+ * 比不镜像更糟。
+ */
+function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {
+  if (realm !== AUTH_REGION) return;
+  if (isPersistedSecretAbsent(LEGACY_RESOURCE_REFRESH_TOKEN_KEY)) return;
+  // 已经是同一枚就不写:省一次落盘,也不因无意义的 mtime 变化干扰 CAS 删除的身份校验。
+  if (readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY) === refreshToken) return;
+  writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken);
+}
+
+/**
+ * replacement-retry 的读侧对偶:从 v1 与 legacy 两个来源里挑出「不是本次请求那一枚」
+ * 的最新 token。
+ *
+ * 镜像只能解决「新版轮换 → 旧版追赶」;反向(旧版实例轮换后只写 legacy,本进程读 v1
+ * 读到的仍是已作废的旧值)同样会误判确定性失效,所以读侧也必须认 legacy。v1 优先:
+ * 它带 realm、是本版本的权威记录;legacy 仅在与安装包区域一致时才可解释。
+ */
+function readLatestReplacementRefreshToken(
+  realm: AuthRegion,
+  requestedToken: string,
+): string | null {
+  return pickRefreshTokenReplacementCandidate(requestedToken, [
+    readPersistedRefreshToken(realm),
+    realm === AUTH_REGION ? readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY) : null,
+  ]);
 }
 
 function readPersistedAccountDeletionReceipt() {
@@ -1000,7 +1051,8 @@ async function runAuthRefreshWithReplacementRetry(
 }> {
   const run = await runRefreshWithReplacementRetry(initialRefreshToken, {
     doRefresh: (refreshToken) => requestAuthRefresh(refreshToken, opts.realm),
-    readLatestStoredToken: () => readPersistedRefreshToken(opts.realm),
+    readLatestStoredToken: (requestedToken) =>
+      readLatestReplacementRefreshToken(opts.realm, requestedToken),
     transientRetry: opts.withTransientRetry
       ? {
           rateLimitDelayMs: opts.rateLimitDelayMs,

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -429,13 +429,34 @@ function writePersistedAuthSession(refreshToken: string, realm = activeAuthRealm
  * 只镜像 realm === AUTH_REGION 的 session:legacy 格式是裸 token、不带 realm,旧版
  * 按自己的构建区解释。把对端区域的 token 写进去,旧版会拿它去请求本区 auth-server,
  * 比不镜像更糟。
+ *
+ * 「检查存在 → 写入」不是原子的(与 writeSafe / removeSafeIfUnchanged 同一限制,见
+ * removeSafeIfUnchanged 的注释):另一个共享 userData 的实例可能刚好在这中间登出并
+ * 删掉 legacy 文件,于是本次写入把它复活。写完再看一眼权威记录——v1 也被清掉了就说明
+ * 那是一次真正的登出,把刚镜像的从属副本按 compare-and-delete 撤回。从属副本不能比
+ * 权威记录活得更久。
  */
 function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {
   if (realm !== AUTH_REGION) return;
   if (isPersistedSecretAbsent(LEGACY_RESOURCE_REFRESH_TOKEN_KEY)) return;
   // 已经是同一枚就不写:省一次落盘,也不因无意义的 mtime 变化干扰 CAS 删除的身份校验。
   if (readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY) === refreshToken) return;
-  writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken);
+  if (!writeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken)) {
+    // 密钥链暂时不可用 / 权限 / 磁盘:v1 已经是最新的,但只读 legacy 的旧版实例这轮
+    // 追不上,下次轮换会再镜像一次。如实记录,不要让它变成静默的半可用状态。
+    log.warn(
+      'failed to mirror the rotated refresh token into the legacy credential file; older shared-userData instances may not catch up until the next rotation',
+    );
+    return;
+  }
+  if (isPersistedSecretAbsent(AUTH_SESSION_KEY)) {
+    // 镜像期间权威记录被另一个实例清掉(登出 / 凭证清理)。只删自己刚写的那一枚:
+    // 内容已变说明又有别人写过,不属于本次撤回范围。
+    const rolledBack = removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken);
+    log.warn(
+      `persisted auth session disappeared while mirroring the legacy refresh token — rolled back the mirror (${rolledBack})`,
+    );
+  }
 }
 
 /**

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -430,10 +430,15 @@ function writePersistedAuthSession(refreshToken: string, realm = activeAuthRealm
  * 比不镜像更糟。
  *
  * 「检查存在 → 写入」不是原子的(与 writeSafe / removeSafeIfUnchanged 同一限制,见
- * removeSafeIfUnchanged 的注释):另一个共享 userData 的实例可能刚好在这中间登出并
- * 删掉 legacy 文件,于是本次写入把它复活。写完再看一眼权威记录——v1 也被清掉了就说明
- * 那是一次真正的登出,把刚镜像的从属副本按 compare-and-delete 撤回。从属副本不能比
- * 权威记录活得更久。
+ * removeSafeIfUnchanged 的注释):另一个共享 userData 的实例可能刚好在这中间登出、或者
+ * 再轮换一次。写完回头核对权威记录是否仍是本次写入的那一条:
+ *   - 已被清掉(登出)→ 从属副本不能比权威记录活得更久;
+ *   - 已前进到更新的一枚 → 本次镜像的那枚此刻已经失效,留着正是这个 PR 要消灭的
+ *     「旧版只读 legacy → 拿到死 token → 被强制重登」。
+ * 两种情况都按 compare-and-delete 撤回(只删自己刚写的那一枚)。
+ *
+ * 读不出权威记录但文件还在(密钥链抖动 / 瞬时 IO)时**不撤回**:那是不确定状态,而本模块
+ * 对不确定一律不做破坏性动作(同 isPersistedSecretAbsent / removeSafeIfUnchanged)。
  */
 function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegion): void {
   if (realm !== AUTH_REGION) return;
@@ -448,37 +453,82 @@ function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegio
     );
     return;
   }
-  if (isPersistedSecretAbsent(AUTH_SESSION_KEY)) {
-    // 镜像期间权威记录被另一个实例清掉(登出 / 凭证清理)。只删自己刚写的那一枚:
-    // 内容已变说明又有别人写过,不属于本次撤回范围。
+  const rollBackMirror = (reason: string): void => {
     const rolledBack = removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, refreshToken);
     log.warn(
-      `persisted auth session disappeared while mirroring the legacy refresh token — rolled back the mirror (${rolledBack})`,
+      `${reason} while mirroring the legacy refresh token — rolled back the mirror (${rolledBack})`,
     );
+  };
+  if (isPersistedSecretAbsent(AUTH_SESSION_KEY)) {
+    rollBackMirror('persisted auth session disappeared');
+    return;
+  }
+  const latestSession = readSafe(AUTH_SESSION_KEY);
+  // 读不出来(null 但文件在)→ 不确定,保留镜像。
+  if (latestSession !== null && latestSession !== serializeAuthSessionRecord(realm, refreshToken)) {
+    rollBackMirror('persisted auth session advanced past the mirrored token');
   }
 }
 
 /**
- * 确定性失效后清掉 legacy 里的从属副本。
+ * 确定性失效后清掉磁盘上所有「已确认死掉」的 refresh token —— v1 权威记录与 legacy
+ * 从属副本各清一次。
  *
- * 权威记录(v1)被判失效删除时,镜像出去的那一份不能留在盘上:只读 legacy 的旧版实例会
- * 拿它再撞一次 INVALID_REFRESH_TOKEN 并被强制重登,本进程的读侧回退也会把它当成替换
- * 候选。compare-and-delete 只删「与本次判定的那一枚相同」的内容——不同就说明另一个
- * 实例刚写入了替换凭证,不在本次清理范围内。
+ * `deadTokens` 是本轮被服务端拒过的全部 token(按首次尝试顺序)。必须逐一比对而不是只
+ * 认最初那一枚:本轮一旦从另一个来源追赶过,磁盘上现存的就是清单里较晚的那一枚,只拿
+ * 最初的 token 做 compare-and-delete 会一律 `changed`,把已确认失效的凭证留在盘上——
+ * 只读 legacy 的旧版实例继续拿它撞 INVALID_REFRESH_TOKEN 被强制重登,本进程的读侧回退
+ * 也会把它当成替换候选。
  *
- * 运行期 `clearAuth` 已经会删这个文件(那是显式登出 / 会话过期的整体清理),所以这里只
- * 补冷启动确定性失效这一条路径;passive 实例的守卫在调用点。
+ * compare-and-delete 语义不变:内容不在清单里就说明另一个实例刚写入了替换凭证,不属于
+ * 本次清理范围,保留。
+ *
+ * 运行期 `clearAuth` 已经会删这两个文件(那是显式登出 / 会话过期的整体清理),所以这里
+ * 只补冷启动确定性失效这一条路径;passive 实例的守卫在调用点。
  */
-function clearMirroredLegacyRefreshToken(realm: AuthRegion, expectedToken: string): void {
+function clearConfirmedDeadRefreshTokens(realm: AuthRegion, deadTokens: readonly string[]): void {
+  let sessionOutcome: RemoveIfUnchangedResult = 'changed';
+  for (const token of deadTokens) {
+    sessionOutcome = removeSafeIfUnchanged(
+      AUTH_SESSION_KEY,
+      serializeAuthSessionRecord(realm, token),
+    );
+    if (sessionOutcome !== 'changed') break;
+  }
+  switch (sessionOutcome) {
+    case 'deleted':
+      log.warn(
+        'cold-start refresh: definitive credential failure — cleared persisted auth session',
+      );
+      break;
+    case 'changed':
+      // 磁盘会话不是本轮判定过的任何一枚(另一个实例写入了新 token 或 realm):不能删。
+      log.warn(
+        'cold-start refresh: definitive credential failure, but the persisted auth session changed meanwhile — keeping the replacement',
+      );
+      break;
+    case 'failed':
+      // 删除真的失败了:凭证仍在盘上,下次启动会再判一次。不能报成已清理。
+      log.error(
+        'cold-start refresh: definitive credential failure, but deleting the persisted auth session failed — it is still on disk',
+      );
+      break;
+  }
+
+  // legacy 从属副本只在与安装包区域一致时才由本进程镜像 / 解释。
   if (realm !== AUTH_REGION) return;
-  const outcome = removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, expectedToken);
-  if (outcome === 'changed') {
+  let legacyOutcome: RemoveIfUnchangedResult = 'changed';
+  for (const token of deadTokens) {
+    legacyOutcome = removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, token);
+    if (legacyOutcome !== 'changed') break;
+  }
+  if (legacyOutcome === 'changed') {
     log.warn(
-      'cold-start refresh: legacy refresh token changed meanwhile — keeping the replacement written by another app instance',
+      'cold-start refresh: legacy refresh token is none of the tokens rejected this run — keeping the replacement written by another app instance',
     );
     return;
   }
-  if (outcome === 'failed') {
+  if (legacyOutcome === 'failed') {
     log.error(
       'cold-start refresh: failed to delete the mirrored legacy refresh token — it is still on disk and older instances may keep retrying it',
     );
@@ -1095,6 +1145,7 @@ async function runAuthRefreshWithReplacementRetry(
   replacementRetries: number;
   replacementRetryExhausted: boolean;
   failureAction?: RefreshFailureAction;
+  rejectedTokens: readonly string[];
 }> {
   const run = await runRefreshWithReplacementRetry(initialRefreshToken, {
     doRefresh: (refreshToken) => requestAuthRefresh(refreshToken, opts.realm),
@@ -2024,6 +2075,7 @@ async function runColdStartRefreshFlow(
       result: refreshResult,
       attempts,
       failureAction,
+      rejectedTokens,
     } = await runAuthRefreshWithReplacementRetry(storedToken, {
       phase: 'cold-start',
       realm: storedRealm,
@@ -2062,28 +2114,12 @@ async function runColdStartRefreshFlow(
             'cold-start refresh: definitive credential failure — passive shared-userData instance starts logged out and keeps the persisted refresh token',
           );
         } else {
-          const expectedSession = serializeAuthSessionRecord(storedRealm, storedToken);
-          switch (removeSafeIfUnchanged(AUTH_SESSION_KEY, expectedSession)) {
-            case 'deleted':
-              log.warn(
-                'cold-start refresh: definitive credential failure — cleared persisted auth session',
-              );
-              break;
-            case 'changed':
-              // 判定失败后磁盘会话已被换掉(另一个实例写入了新 token 或 realm):
-              // 那枚不在本次判定范围内,不能删。
-              log.warn(
-                'cold-start refresh: definitive credential failure, but the persisted auth session changed meanwhile — keeping the replacement',
-              );
-              break;
-            case 'failed':
-              // 删除真的失败了:凭证仍在盘上,下次启动会再判一次。不能报成已清理。
-              log.error(
-                'cold-start refresh: definitive credential failure, but deleting the persisted auth session failed — it is still on disk',
-              );
-              break;
-          }
-          clearMirroredLegacyRefreshToken(storedRealm, storedToken);
+          // 必须逐一比对本轮被拒过的**每一枚** token,不能只认最初那枚:一旦本轮从另一个
+          // 来源追赶过(replacement-retry),磁盘上现存的就是清单里较晚的那一枚,只拿最初
+          // 的 token 做 compare-and-delete 会一律 changed,把已确认失效的凭证留在盘上,
+          // 只读 legacy 的旧版实例继续拿它撞 INVALID_REFRESH_TOKEN 被强制重登。
+          const confirmedDeadTokens = rejectedTokens.length > 0 ? rejectedTokens : [storedToken];
+          clearConfirmedDeadRefreshTokens(storedRealm, confirmedDeadTokens);
         }
         resetActiveAuthRealmToBuild();
       } else if (action.kind === 'replacement-retry') {

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -48,7 +48,6 @@ import { decodeAccessTokenOrgSlug } from './authTokenClaims';
 import { getProviderSecretStore } from './secrets/providerSecretStore.js';
 import {
   runRefreshWithReplacementRetry,
-  pickRefreshTokenReplacementCandidate,
   resolveSessionExpiredReason,
   type RefreshFailureAction,
   type RefreshFailureInfo,
@@ -460,21 +459,48 @@ function mirrorLegacyResourceRefreshToken(refreshToken: string, realm: AuthRegio
 }
 
 /**
- * replacement-retry 的读侧对偶:从 v1 与 legacy 两个来源里挑出「不是本次请求那一枚」
- * 的最新 token。
+ * 确定性失效后清掉 legacy 里的从属副本。
+ *
+ * 权威记录(v1)被判失效删除时,镜像出去的那一份不能留在盘上:只读 legacy 的旧版实例会
+ * 拿它再撞一次 INVALID_REFRESH_TOKEN 并被强制重登,本进程的读侧回退也会把它当成替换
+ * 候选。compare-and-delete 只删「与本次判定的那一枚相同」的内容——不同就说明另一个
+ * 实例刚写入了替换凭证,不在本次清理范围内。
+ *
+ * 运行期 `clearAuth` 已经会删这个文件(那是显式登出 / 会话过期的整体清理),所以这里只
+ * 补冷启动确定性失效这一条路径;passive 实例的守卫在调用点。
+ */
+function clearMirroredLegacyRefreshToken(realm: AuthRegion, expectedToken: string): void {
+  if (realm !== AUTH_REGION) return;
+  const outcome = removeSafeIfUnchanged(LEGACY_RESOURCE_REFRESH_TOKEN_KEY, expectedToken);
+  if (outcome === 'changed') {
+    log.warn(
+      'cold-start refresh: legacy refresh token changed meanwhile — keeping the replacement written by another app instance',
+    );
+    return;
+  }
+  if (outcome === 'failed') {
+    log.error(
+      'cold-start refresh: failed to delete the mirrored legacy refresh token — it is still on disk and older instances may keep retrying it',
+    );
+  }
+}
+
+/**
+ * replacement-retry 的读侧对偶:交出磁盘上**全部**凭证来源的当前值,按优先级排列。
  *
  * 镜像只能解决「新版轮换 → 旧版追赶」;反向(旧版实例轮换后只写 legacy,本进程读 v1
- * 读到的仍是已作废的旧值)同样会误判确定性失效,所以读侧也必须认 legacy。v1 优先:
+ * 读到的仍是已作废的旧值)同样会误判确定性失效,所以读侧也必须认 legacy。v1 排前面:
  * 它带 realm、是本版本的权威记录;legacy 仅在与安装包区域一致时才可解释。
+ *
+ * 这里刻意**不**折叠成单个候选。选择要在 `runRefreshWithReplacementRetry` 里做——只有
+ * 它知道本轮哪些 token 已经被服务端拒过。在这里先按优先级挑一枚,会让 v1 里那枚已失效
+ * 的 token 挤掉 legacy 里真正有效的那枚,最终以确定性失效收场并连带删掉有效凭证。
  */
-function readLatestReplacementRefreshToken(
-  realm: AuthRegion,
-  requestedToken: string,
-): string | null {
-  return pickRefreshTokenReplacementCandidate(requestedToken, [
+function readStoredRefreshTokenCandidates(realm: AuthRegion): readonly (string | null)[] {
+  return [
     readPersistedRefreshToken(realm),
     realm === AUTH_REGION ? readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY) : null,
-  ]);
+  ];
 }
 
 function readPersistedAccountDeletionReceipt() {
@@ -1072,8 +1098,7 @@ async function runAuthRefreshWithReplacementRetry(
 }> {
   const run = await runRefreshWithReplacementRetry(initialRefreshToken, {
     doRefresh: (refreshToken) => requestAuthRefresh(refreshToken, opts.realm),
-    readLatestStoredToken: (requestedToken) =>
-      readLatestReplacementRefreshToken(opts.realm, requestedToken),
+    readLatestStoredTokens: () => readStoredRefreshTokenCandidates(opts.realm),
     transientRetry: opts.withTransientRetry
       ? {
           rateLimitDelayMs: opts.rateLimitDelayMs,
@@ -2058,6 +2083,7 @@ async function runColdStartRefreshFlow(
               );
               break;
           }
+          clearMirroredLegacyRefreshToken(storedRealm, storedToken);
         }
         resetActiveAuthRealmToBuild();
       } else if (action.kind === 'replacement-retry') {

--- a/apps/desktop/src/main/authRefreshFailure.ts
+++ b/apps/desktop/src/main/authRefreshFailure.ts
@@ -307,6 +307,22 @@ export async function runRefreshWithReplacementRetry<T>(
   const replacementRecheckDelaysMs = opts.replacementRecheck?.delaysMs ?? [];
   const replacementRecheckSleep =
     opts.replacementRecheck?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  /**
+   * 本轮已经被服务端拒过的 token。
+   *
+   * 多来源候选(v1 / legacy)可能互为「对方眼里的替换 token」:磁盘上两个文件分叉时,
+   * 只排除**紧邻的上一枚**会让两枚 token 来回被选中,耗尽 maxReplacementRetries 后
+   * 以 `replacement-retry` 收尾——runtime 于是每 60s 重试一枚已知无效的凭证而永不
+   * 过期,冷启动则保留不可用凭证并以未登录启动(既不自愈也不明确告知用户)。
+   * 已经拒过的 token 不再算替换候选,两枚都试过就如实落到 definitive-failure。
+   */
+  const rejectedTokens = new Set<string>();
+
+  /** 候选已在本轮被拒过 → 不是有效的追赶目标,按确定性失效收尾。 */
+  const withoutRejectedCandidate = (action: RefreshFailureAction): RefreshFailureAction =>
+    action.kind === 'replacement-retry' && rejectedTokens.has(action.refreshToken)
+      ? { kind: 'definitive-failure' }
+      : action;
 
   while (true) {
     const run = opts.transientRetry
@@ -327,10 +343,14 @@ export async function runRefreshWithReplacementRetry<T>(
       };
     }
 
-    let action = resolveRefreshFailureAction(
-      run.result,
-      requestedToken,
-      opts.readLatestStoredToken(requestedToken),
+    rejectedTokens.add(requestedToken);
+
+    let action = withoutRejectedCandidate(
+      resolveRefreshFailureAction(
+        run.result,
+        requestedToken,
+        opts.readLatestStoredToken(requestedToken),
+      ),
     );
 
     if (action.kind === 'definitive-failure' && isReplacementRetryEligibleFailure(run.result)) {
@@ -342,10 +362,12 @@ export async function runRefreshWithReplacementRetry<T>(
           delayMs,
         });
         if (delayMs > 0) await replacementRecheckSleep(delayMs);
-        action = resolveRefreshFailureAction(
-          run.result,
-          requestedToken,
-          opts.readLatestStoredToken(requestedToken),
+        action = withoutRejectedCandidate(
+          resolveRefreshFailureAction(
+            run.result,
+            requestedToken,
+            opts.readLatestStoredToken(requestedToken),
+          ),
         );
         if (action.kind !== 'definitive-failure') break;
       }

--- a/apps/desktop/src/main/authRefreshFailure.ts
+++ b/apps/desktop/src/main/authRefreshFailure.ts
@@ -303,6 +303,14 @@ export async function runRefreshWithReplacementRetry<T>(
   replacementRetries: number;
   replacementRetryExhausted: boolean;
   failureAction?: RefreshFailureAction;
+  /**
+   * 本轮被服务端拒过的**所有** token,按首次尝试顺序。
+   *
+   * 调用方清理磁盘凭证时必须逐一比对这份清单,而不是只认最初那一枚:一旦本轮从另一个
+   * 来源追赶过(replacement-retry),磁盘上现存的那枚就是清单里较晚的那一个,只拿最初
+   * 的 token 做 compare-and-delete 会一律 `changed`,把已确认失效的凭证留在盘上。
+   */
+  rejectedTokens: readonly string[];
 }> {
   let requestedToken = initialRefreshToken;
   let attempts = 0;
@@ -351,6 +359,7 @@ export async function runRefreshWithReplacementRetry<T>(
         requestedToken,
         replacementRetries,
         replacementRetryExhausted: false,
+        rejectedTokens: [...rejectedTokens],
       };
     }
 
@@ -388,6 +397,7 @@ export async function runRefreshWithReplacementRetry<T>(
         replacementRetries,
         replacementRetryExhausted: false,
         failureAction: action,
+        rejectedTokens: [...rejectedTokens],
       };
     }
 
@@ -399,6 +409,7 @@ export async function runRefreshWithReplacementRetry<T>(
         replacementRetries,
         replacementRetryExhausted: true,
         failureAction: action,
+        rejectedTokens: [...rejectedTokens],
       };
     }
 

--- a/apps/desktop/src/main/authRefreshFailure.ts
+++ b/apps/desktop/src/main/authRefreshFailure.ts
@@ -58,9 +58,28 @@ export function getRefreshTokenReplacementCandidate(
   requestedToken: string,
   latestStoredToken: string | null,
 ): string | null {
-  if (!latestStoredToken) return null;
-  if (latestStoredToken === requestedToken) return null;
-  return latestStoredToken;
+  return pickRefreshTokenReplacementCandidate(requestedToken, [latestStoredToken]);
+}
+
+/**
+ * 从多个磁盘凭证来源里挑出可用于追赶的替换 token —— 按传入顺序取第一枚
+ * 「非空且不等于本次请求所用」的 token。
+ *
+ * 为什么需要多来源:凭证文件正在做 legacy → v1 的格式迁移(见 authManager 的
+ * `AUTH_SESSION_KEY` / `LEGACY_RESOURCE_REFRESH_TOKEN_KEY`)。共享 userData 的
+ * 双开窗口里,两个实例可能一个写 v1、一个写 legacy;只认单一来源的一方永远追不上
+ * 另一方轮换出的新 token,会把本可自愈的竞态判成确定性失效并强制重登。
+ */
+export function pickRefreshTokenReplacementCandidate(
+  requestedToken: string,
+  candidates: readonly (string | null | undefined)[],
+): string | null {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (candidate === requestedToken) continue;
+    return candidate;
+  }
+  return null;
 }
 
 /**
@@ -248,7 +267,11 @@ export async function runRefreshWithReplacementRetry<T>(
   initialRefreshToken: string,
   opts: {
     doRefresh: (refreshToken: string) => Promise<RefreshFetchResult<T>>;
-    readLatestStoredToken: () => string | null;
+    /**
+     * 读磁盘上当前最新的 refresh token。带上本次请求所用的 token,让调用方能在
+     * 多个凭证来源(legacy / v1)之间挑出真正「不是这一枚」的替换候选。
+     */
+    readLatestStoredToken: (requestedToken: string) => string | null;
     /** 不传则单次请求;传入则每一枚 token 内部按 transient 规则重试。 */
     transientRetry?: {
       retryDelaysMs?: readonly number[];
@@ -307,7 +330,7 @@ export async function runRefreshWithReplacementRetry<T>(
     let action = resolveRefreshFailureAction(
       run.result,
       requestedToken,
-      opts.readLatestStoredToken(),
+      opts.readLatestStoredToken(requestedToken),
     );
 
     if (action.kind === 'definitive-failure' && isReplacementRetryEligibleFailure(run.result)) {
@@ -322,7 +345,7 @@ export async function runRefreshWithReplacementRetry<T>(
         action = resolveRefreshFailureAction(
           run.result,
           requestedToken,
-          opts.readLatestStoredToken(),
+          opts.readLatestStoredToken(requestedToken),
         );
         if (action.kind !== 'definitive-failure') break;
       }

--- a/apps/desktop/src/main/authRefreshFailure.ts
+++ b/apps/desktop/src/main/authRefreshFailure.ts
@@ -268,10 +268,14 @@ export async function runRefreshWithReplacementRetry<T>(
   opts: {
     doRefresh: (refreshToken: string) => Promise<RefreshFetchResult<T>>;
     /**
-     * 读磁盘上当前最新的 refresh token。带上本次请求所用的 token,让调用方能在
-     * 多个凭证来源(legacy / v1)之间挑出真正「不是这一枚」的替换候选。
+     * 读磁盘上所有凭证来源的当前值(如 v1 记录与 legacy 裸 token),按优先级排列。
+     *
+     * 必须交出**全部**来源、由本函数统一筛选,不能由调用方先折叠成单个候选:
+     * 排除「本轮已被拒过的 token」这一步只有拿到完整候选集才做得对。调用方先按
+     * 优先级折叠的话,首选来源里那枚已失效的 token 会把后面来源里真正有效的那枚
+     * 挤掉,最终以确定性失效收场并连带删掉有效凭证。
      */
-    readLatestStoredToken: (requestedToken: string) => string | null;
+    readLatestStoredTokens: () => readonly (string | null | undefined)[];
     /** 不传则单次请求;传入则每一枚 token 内部按 transient 规则重试。 */
     transientRetry?: {
       retryDelaysMs?: readonly number[];
@@ -318,11 +322,18 @@ export async function runRefreshWithReplacementRetry<T>(
    */
   const rejectedTokens = new Set<string>();
 
-  /** 候选已在本轮被拒过 → 不是有效的追赶目标,按确定性失效收尾。 */
-  const withoutRejectedCandidate = (action: RefreshFailureAction): RefreshFailureAction =>
-    action.kind === 'replacement-retry' && rejectedTokens.has(action.refreshToken)
-      ? { kind: 'definitive-failure' }
-      : action;
+  /**
+   * 读全部来源 → **先剔掉本轮已被拒过的** → 再按优先级挑替换候选。
+   *
+   * 顺序是要点:先折叠后过滤会漏掉有效凭证——v1 存着已拒的 A、legacy 存着有效的 C 时,
+   * 折叠只交出 A(v1 优先),随后 A 被判已拒,于是整轮以确定性失效收场,C 从未被试过,
+   * 还会连同 C 一起被清掉。
+   */
+  const nextReplacementCandidate = (requestedToken: string): string | null =>
+    pickRefreshTokenReplacementCandidate(
+      requestedToken,
+      opts.readLatestStoredTokens().filter((token) => !token || !rejectedTokens.has(token)),
+    );
 
   while (true) {
     const run = opts.transientRetry
@@ -345,12 +356,10 @@ export async function runRefreshWithReplacementRetry<T>(
 
     rejectedTokens.add(requestedToken);
 
-    let action = withoutRejectedCandidate(
-      resolveRefreshFailureAction(
-        run.result,
-        requestedToken,
-        opts.readLatestStoredToken(requestedToken),
-      ),
+    let action = resolveRefreshFailureAction(
+      run.result,
+      requestedToken,
+      nextReplacementCandidate(requestedToken),
     );
 
     if (action.kind === 'definitive-failure' && isReplacementRetryEligibleFailure(run.result)) {
@@ -362,12 +371,10 @@ export async function runRefreshWithReplacementRetry<T>(
           delayMs,
         });
         if (delayMs > 0) await replacementRecheckSleep(delayMs);
-        action = withoutRejectedCandidate(
-          resolveRefreshFailureAction(
-            run.result,
-            requestedToken,
-            opts.readLatestStoredToken(requestedToken),
-          ),
+        action = resolveRefreshFailureAction(
+          run.result,
+          requestedToken,
+          nextReplacementCandidate(requestedToken),
         );
         if (action.kind !== 'definitive-failure') break;
       }


### PR DESCRIPTION
## 这次改了什么

### 摘要

共享 userData 双开(`--preserve-running` / passive dev)时,一个实例续期会把另一个实例
手上的 refresh token 顶掉,再判成「确定性凭据失效」强制重登。这本该由 replacement-retry
兜住(「磁盘上已有别人写的新 token」就追上去重试),但 legacy `cindy_auth_refresh_token`
→ `cindy_auth_session_v1` 的格式迁移(#748)打断了这条兜底:两个实例各写各的凭证文件时,
只认单一来源的一方读到的永远是自己那枚已作废的 token。

本 PR 把追赶路径在迁移窗口内补成双向:

- **写侧镜像**(新版轮换 → 只认 legacy 的旧版能追上):`writePersistedAuthSession` 写成功
  v1 后,把新 token 同步回写 legacy 文件。三道守卫——legacy 文件不存在时不写(不复活已被
  清理的凭证文件)、`realm !== AUTH_REGION` 时不写(legacy 是裸 token、不带 realm,旧版会
  按自己的构建区解释)、值未变则不落盘(不让无意义的 mtime 变化干扰 `removeSafeIfUnchanged`
  的文件身份校验)。
- **读侧回退**(旧版轮换 → 只读 v1 的新版能追上):replacement 候选改为同时读 v1 与 legacy,
  v1 优先。新增纯函数 `pickRefreshTokenReplacementCandidate`,`readLatestStoredToken` 回调
  随之多收一个 `requestedToken` 参数。

复现记录(2026-07-29,本机 macOS):packaged 0.1.20(只认 legacy)与含 #748 的 dev(只写 v1)
共享 userData 双开。dev 07:42 续期并把新 token 写进 v1;packaged 07:46:32 的 runtime refresh
拿 `INVALID_REFRESH_TOKEN`,两次 replacement recheck(250ms / 1000ms)读 legacy 都只读到自己
那枚已作废的 token,07:46:33 判定 definitive 清登录态,弹「登录已过期 · 你的账号已在其他设备
或实例上退出登录」,同时中断了在跑的 scheduler run 与 IM 连接。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无(本机事故复盘)
- 本 PR 包含：legacy 凭证文件的写侧镜像与读侧回退、`pickRefreshTokenReplacementCandidate`
  纯函数、两个方向的回归测试
- 明确不包含：safeStorage 写入层的原子化(临时文件 + rename + 跨进程锁)——那是独立重构,
  现状仍沿用 `removeSafeIfUnchanged` 注释里记录的既有限制;也不包含 dev 实例默认独立
  deviceId 的取舍(会影响 device-link 联调,需单独权衡)
- 用户可见变化：共享 userData 双开且两侧凭证文件格式不同(跨 0.1.20 边界)时,不再被无故弹
  「登录已过期」。单实例、`--isolated` 沙箱与同版本双开的行为不变
- 是否存在 breaking change：无

### UI 变化

不涉及

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
bash <git-skill>/scripts/run-unit-gate.sh <worktree>   # 仓库根 pnpm test:unit 门禁
结果：GATE_EXIT=0,全部 workspace PASS

cd apps/desktop && npx vitest run --maxWorkers=2      # 格式修正后补跑 desktop workspace
结果：Test Files 1369 passed / Tests 15445 passed | 2 skipped

pnpm --filter desktop run --if-present typecheck
结果：通过

npx eslint src/main/authManager.ts src/main/authRefreshFailure.ts \
  src/main/__tests__/authLegacyTokenMirror.test.ts src/main/__tests__/authRefreshFailure.test.ts
结果：0 problems
```

新增 `authLegacyTokenMirror.test.ts`(6 条源码守卫;authManager 依赖 Electron,node 测试环境
无法直接 import,沿用 `authPassiveSharedInstance.test.ts` 的模式)与 `authRefreshFailure.test.ts`
的 3 条纯逻辑用例。守卫做过反证:把 `readLatestStoredToken` 退回 `() => readPersistedRefreshToken(...)`、
把缺席判定换成 `existsSync`,两次都如实报红,不是永真断言。

### 手工验证

不涉及。

### 未执行的验证

- **实机双开复现未执行**:要真正触发这条路径,需要同时运行 packaged 0.1.20 与本分支 dev、
  共享 userData 并等一个完整 refresh 周期;过程中会真实轮换开发者当前的登录凭证,有把自己
  登出、并连带中断在跑的 scheduler / IM / device-link 的风险,故未执行。事故侧的事实由本机
  `logs/main-2026-07-29.log` 与 `safe-storage/` 两个凭证文件的 mtime 佐证(见摘要),修复侧由
  上述单测覆盖。
- 全量 `pnpm lint` 在本仓 `origin/main` 基线上即有 98 problems(97 errors),与本 PR 无关,
  已在干净基线上核对过;本 PR 改动的 4 个文件 eslint 干净。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只触及 Electron `safeStorage` 目录下已存在的 legacy 凭证文件,不新增存储位置、
  不引入明文落盘、不把秘密下放给 renderer 或插件(符合
  `docs/dev-rules/credentials-and-local-storage.md`)。镜像写入的是刚轮换出的**有效**凭证,
  与 passive 实例照常写回 v1 同性质;`docs/dev-rules/...` 里 passive 闸门约束的是「删除 /
  作废 / 消费」共享持久状态,写入有效凭证不在约束内,`authPassiveSharedInstance.test.ts` 13
  条守卫仍全绿。
  legacy 文件的清理路径未改动:非 passive 实例冷启动迁移后仍会删掉它,删掉之后
  `isPersistedSecretAbsent` 守卫会让镜像停止,不会复活。
- 回滚 / 降级方式：单 commit revert 即可,无数据迁移、无 schema 变更、无协议变更。回滚后行为
  退回当前 main(跨版本双开仍可能被误登出)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,`pnpm check:dco` 通过)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(修复理由与事故时间线写在 `mirrorLegacyResourceRefreshToken` /
      `readLatestReplacementRefreshToken` 的函数注释与新测试文件的顶部注释里,沿用本仓
      auth 模块以代码注释承载契约的既有做法)
- [x] 已确认测试结果或说明未执行原因
