### PR TITLE
fix(desktop): 区分侧栏归档对话视觉

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -640,7 +640,9 @@ export const SessionItem = memo(function SessionItem({
           ? 'bg-sidebar-item-active text-sidebar-item-active-foreground shadow-[inset_0_0_0_1px_var(--sidebar-item-active-border)]'
           : isSelected
             ? 'bg-[var(--chat-input-chip-bg)] text-foreground'
-            : 'text-foreground hover:bg-sidebar-item-hover',
+            : isArchived
+              ? 'text-[var(--sidebar-list-muted)] hover:bg-sidebar-item-hover'
+              : 'text-foreground hover:bg-sidebar-item-hover',
         isSelected && 'ring-1 ring-inset ring-[var(--focus-ring-soft)]',
       )}
       aria-current={isActive ? 'page' : undefined}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -640,9 +640,7 @@ export const SessionItem = memo(function SessionItem({
           ? 'bg-sidebar-item-active text-sidebar-item-active-foreground shadow-[inset_0_0_0_1px_var(--sidebar-item-active-border)]'
           : isSelected
             ? 'bg-[var(--chat-input-chip-bg)] text-foreground'
-            : isArchived
-              ? 'text-[var(--sidebar-list-muted)] hover:bg-sidebar-item-hover'
-              : 'text-foreground hover:bg-sidebar-item-hover',
+            : 'text-foreground hover:bg-sidebar-item-hover',
         isSelected && 'ring-1 ring-inset ring-[var(--focus-ring-soft)]',
       )}
       aria-current={isActive ? 'page' : undefined}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionStatusIcon.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionStatusIcon.tsx
@@ -99,11 +99,11 @@ export function SessionStatusIcon({
       {isArchived ? (
         <Archive
           size={size ?? 12}
-          strokeWidth={1.5}
+          strokeWidth={1.75}
           className={
             isActive
               ? 'text-[var(--sidebar-item-active-foreground)]'
-              : 'text-[var(--sidebar-list-muted)]'
+              : 'text-[var(--cmd-palette-item-meta)]'
           }
         />
       ) : isOrcaLead ? (

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionStatusIcon.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionStatusIcon.tsx
@@ -100,7 +100,11 @@ export function SessionStatusIcon({
         <Archive
           size={size ?? 12}
           strokeWidth={1.5}
-          className={isActive ? 'text-[var(--sidebar-item-active-foreground)]' : 'text-[var(--cmd-palette-item-meta)]'}
+          className={
+            isActive
+              ? 'text-[var(--sidebar-item-active-foreground)]'
+              : 'text-[var(--sidebar-list-muted)]'
+          }
         />
       ) : isOrcaLead ? (
         // 常驻呼吸动画挂 HTML wrapper,SVG 保持静态(AGENTS 规则 7 SVG 动画红线,PR#226 review)

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -92,7 +92,7 @@ import { SessionItem } from '../SessionItem';
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 
-function makeSession(id: string, status: Session['status'] = 'idle'): Session {
+function makeSession(id: string, status: Session['status'] | 'idle' = 'idle'): Session {
   return {
     id,
     title: `Session ${id}`,

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -169,7 +169,7 @@ describe('SessionItem — memo 包裹', () => {
 });
 
 describe('SessionItem — 归档视觉', () => {
-  it('标题保留正文色，并用侧栏 muted Archive 图标区分归档行', () => {
+  it('标题保留正文色，并用主题感知的 Archive 图标区分归档行', () => {
     const regularSession = makeSession('regular-session');
     const archivedSession = makeSession('archived-session', 'archived');
     const { container } = render(rowsElement([regularSession, archivedSession], new Set()));
@@ -187,7 +187,8 @@ describe('SessionItem — 归档视觉', () => {
     );
     expect(archivedIconBranch).toContain('<Archive');
     expect(archivedIconBranch).toContain('text-[var(--sidebar-item-active-foreground)]');
-    expect(archivedIconBranch).toContain('text-[var(--sidebar-list-muted)]');
+    expect(archivedIconBranch).toContain('strokeWidth={1.75}');
+    expect(archivedIconBranch).toContain('text-[var(--cmd-palette-item-meta)]');
   });
 });
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -88,11 +88,11 @@ import { SessionItem } from '../SessionItem';
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 
-function makeSession(id: string): Session {
+function makeSession(id: string, status: Session['status'] = 'active'): Session {
   return {
     id,
     title: `Session ${id}`,
-    status: 'idle',
+    status,
     createdAt: '2026-07-01T00:00:00.000Z',
     updatedAt: '2026-07-01T00:00:00.000Z',
     userSendAt: '2026-07-01T00:00:00.000Z',
@@ -111,6 +111,7 @@ const noop = () => {};
 function rowsElement(
   sessions: readonly Session[],
   urgentSessionIds: ReadonlySet<string>,
+  selectedSessionIds: ReadonlySet<string> = new Set(),
 ) {
   return createElement(SessionAttentionUrgencyProvider, {
     urgentSessionIds,
@@ -124,6 +125,7 @@ function rowsElement(
           isActive: false,
           isRunning: false,
           hasAttentionNotification: false,
+          isSelected: selectedSessionIds.has(s.id),
           onClick: noop,
           onAction: noop,
           onRename: noop,
@@ -164,6 +166,33 @@ describe('SessionItem — memo 包裹', () => {
     expect(source).not.toMatch(/useSessionAttentionSnapshot\s*\(/);
     expect(source).not.toMatch(/useSessionAttentionUrgencySet\s*\(/);
     expect(source).toMatch(/useSessionAttentionKind\s*\(\s*session\.id\s*\)/);
+  });
+});
+
+describe('SessionItem — 归档视觉', () => {
+  it('用侧栏 muted token 降级归档行，同时保留选中态的前景色', () => {
+    const regularSession = makeSession('regular-session');
+    const archivedSession = makeSession('archived-session', 'archived');
+    const selectedArchivedSession = makeSession('selected-archived-session', 'archived');
+    const { container } = render(
+      rowsElement(
+        [regularSession, archivedSession, selectedArchivedSession],
+        new Set(),
+        new Set([selectedArchivedSession.id]),
+      ),
+    );
+
+    const regularRow = container.querySelector('[data-session-id="regular-session"]');
+    const archivedRow = container.querySelector('[data-session-id="archived-session"]');
+    const selectedArchivedRow = container.querySelector(
+      '[data-session-id="selected-archived-session"]',
+    );
+
+    expect(regularRow?.className).toContain('text-foreground');
+    expect(archivedRow?.className).toContain('text-[var(--sidebar-list-muted)]');
+    expect(archivedRow?.className).not.toContain('text-foreground');
+    expect(selectedArchivedRow?.className).toContain('text-foreground');
+    expect(selectedArchivedRow?.className).not.toContain('text-[var(--sidebar-list-muted)]');
   });
 });
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -33,6 +33,10 @@ import { SessionAttentionUrgencyProvider } from '../../contexts/SessionAttention
 // ── mocks:剥离与"渲染隔离"无关的重依赖,只留计数探针 ──────────────────────────
 
 const renderCounts = new Map<string, number>();
+const sessionStatusIconSource = readFileSync(
+  resolve(__dirname, '..', 'SessionStatusIcon.tsx'),
+  'utf8',
+);
 
 vi.mock('../SessionStatusIcon', () => ({
   SessionStatusIcon: ({ session }: { session: { id: string } }) => {
@@ -88,7 +92,7 @@ import { SessionItem } from '../SessionItem';
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 
-function makeSession(id: string, status: Session['status'] = 'active'): Session {
+function makeSession(id: string, status: Session['status'] = 'idle'): Session {
   return {
     id,
     title: `Session ${id}`,
@@ -108,11 +112,7 @@ function makeSession(id: string, status: Session['status'] = 'active'): Session 
 
 const noop = () => {};
 
-function rowsElement(
-  sessions: readonly Session[],
-  urgentSessionIds: ReadonlySet<string>,
-  selectedSessionIds: ReadonlySet<string> = new Set(),
-) {
+function rowsElement(sessions: readonly Session[], urgentSessionIds: ReadonlySet<string>) {
   return createElement(SessionAttentionUrgencyProvider, {
     urgentSessionIds,
     children: createElement(
@@ -125,7 +125,6 @@ function rowsElement(
           isActive: false,
           isRunning: false,
           hasAttentionNotification: false,
-          isSelected: selectedSessionIds.has(s.id),
           onClick: noop,
           onAction: noop,
           onRename: noop,
@@ -170,29 +169,25 @@ describe('SessionItem — memo 包裹', () => {
 });
 
 describe('SessionItem — 归档视觉', () => {
-  it('用侧栏 muted token 降级归档行，同时保留选中态的前景色', () => {
+  it('标题保留正文色，并用侧栏 muted Archive 图标区分归档行', () => {
     const regularSession = makeSession('regular-session');
     const archivedSession = makeSession('archived-session', 'archived');
-    const selectedArchivedSession = makeSession('selected-archived-session', 'archived');
-    const { container } = render(
-      rowsElement(
-        [regularSession, archivedSession, selectedArchivedSession],
-        new Set(),
-        new Set([selectedArchivedSession.id]),
-      ),
-    );
+    const { container } = render(rowsElement([regularSession, archivedSession], new Set()));
 
     const regularRow = container.querySelector('[data-session-id="regular-session"]');
     const archivedRow = container.querySelector('[data-session-id="archived-session"]');
-    const selectedArchivedRow = container.querySelector(
-      '[data-session-id="selected-archived-session"]',
-    );
 
     expect(regularRow?.className).toContain('text-foreground');
-    expect(archivedRow?.className).toContain('text-[var(--sidebar-list-muted)]');
-    expect(archivedRow?.className).not.toContain('text-foreground');
-    expect(selectedArchivedRow?.className).toContain('text-foreground');
-    expect(selectedArchivedRow?.className).not.toContain('text-[var(--sidebar-list-muted)]');
+    expect(archivedRow?.className).toContain('text-foreground');
+    expect(archivedRow?.className).not.toContain('text-[var(--sidebar-list-muted)]');
+
+    const archivedIconBranch = sessionStatusIconSource.slice(
+      sessionStatusIconSource.indexOf('{isArchived ? ('),
+      sessionStatusIconSource.indexOf(') : isOrcaLead ? ('),
+    );
+    expect(archivedIconBranch).toContain('<Archive');
+    expect(archivedIconBranch).toContain('text-[var(--sidebar-item-active-foreground)]');
+    expect(archivedIconBranch).toContain('text-[var(--sidebar-list-muted)]');
   });
 });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

侧栏归档对话保留正文标题颜色，并通过左侧 Archive 状态图标与现有主题感知的 secondary token 区分普通对话。Archive 图标沿用原有状态分支，仅提高笔画权重以增强状态识别；不把低对比 muted 色用于正文标题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联需求：区分侧栏归档对话视觉
- 本 PR 包含：归档 Archive 状态图标的轻量视觉强调，以及标题/图标优先级回归断言
- 明确不包含：对话数据、归档状态机、排序分组、IPC、持久化、布局和归档动作逻辑
- 用户可见变化：未激活的归档对话显示更明确的 Archive 状态图标；标题保持正文色以满足可读性
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md §10 Light / Dark Dual-Mode Delivery Gate`：颜色继续经现有主题语义 token 解析，Light / Dark 使用同一状态分支。
  - `docs/design-rules/DESIGN.md §15.10 Sidebar color hierarchy`：session title 使用 `text-foreground`；secondary gray 仅用于 leading icon、timestamp、metadata 和 group label。
- 状态优先级保持为：active 归档图标前景色 > 非 active 归档图标主题感知 secondary；标题保持正文色。
- 不新增主题覆盖；非 Cindy 内置主题继续从 `cmd-palette-item-meta` 解析自身 secondary 色。
- hover 背景、selected/active 行样式、状态机、动作和行布局均保持不变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；test runner 298 passed、1 skipped；Desktop、Mobile 和所有 required unit workspaces 均 PASS。

pnpm --filter desktop run --if-present typecheck
结果：通过（最终工作树）。

pnpm --filter desktop exec vitest run src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
结果：12/12 通过。

pnpm check:dco
结果：通过；4 个 commit 均带匹配 author 的 Signed-off-by。

node scripts/hardcoded-color-audit.mjs --base-ref origin/main
结果：PASS；unexpected=0。

git diff --check origin/main...HEAD
结果：通过。
```

### 手工验证

用户已完成 Desktop 侧栏普通/归档列表的实机验收；本次 agent 未重新启动宿主。Light / Dark 未由本次 agent 独立截图验证，颜色仍复用既有双模式主题 token。

### 未执行的验证

未重新启动宿主做第二次截图；未改变 Desktop 运行时或原生配置。

## 风险

### 风险分类

- [x] 无已知代码风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 侧栏 Archive 状态图标的视觉权重和对应回归测试。
- 回滚方式：revert 本 PR 的提交即可恢复原有图标笔画与测试断言。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增仓库文档）
- [x] 已确认测试结果或说明未执行原因

### 审查重点

- `SessionStatusIcon` 的 archived 分支：active 前景色优先，非 active 保持主题感知 secondary。
- 标题保持 `text-foreground`，避免把低对比 secondary gray 用作正文。
- 回归测试同时钉住归档状态分支、图标视觉契约和已有行渲染隔离不变量。
