### PR TITLE
fix(mobile): restore Android microphone permission(重做 #610,冷更待定)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -125,7 +125,7 @@
         {
           "photosPermission": "Cindy needs photo library access to attach images to remote sessions.",
           "cameraPermission": "Cindy needs camera access to attach photos to remote sessions.",
-          "microphonePermission": false
+          "microphonePermission": "Cindy needs microphone access for voice input in remote sessions."
         }
       ],
       [

--- a/apps/mobile/src/__tests__/nativeAppConfig.test.ts
+++ b/apps/mobile/src/__tests__/nativeAppConfig.test.ts
@@ -430,6 +430,10 @@ describe('mobile native app config', () => {
     const audioPlugin = appJson.expo.plugins.find(
       (plugin: unknown) => Array.isArray(plugin) && plugin[0] === 'expo-audio',
     );
+    const imagePickerPlugin = appJson.expo.plugins.find(
+      (plugin: unknown) =>
+        Array.isArray(plugin) && plugin[0] === 'expo-image-picker',
+    );
 
     expect(audioPlugin).toEqual([
       'expo-audio',
@@ -439,6 +443,13 @@ describe('mobile native app config', () => {
         enableBackgroundPlayback: false,
         enableBackgroundRecording: false,
       },
+    ]);
+    expect(imagePickerPlugin).toEqual([
+      'expo-image-picker',
+      expect.objectContaining({
+        microphonePermission:
+          'Cindy needs microphone access for voice input in remote sessions.',
+      }),
     ]);
     const foregroundOnlyPluginIndex = appJson.expo.plugins.indexOf(
       './plugins/with-foreground-only-audio',


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 #610 的改动原样放回来，但**先挂成草稿**，等冷更把关人确认后再合。

背景：#610（合并提交 `c89df50e`）已经在 `main` 上被 revert 掉了（revert 提交
`cdcde2fc`），原因是它改了 `apps/mobile/app.json` 的 production 段，会改变 mobile
runtime fingerprint、触发冷更，而当时没有走「冷更边界」要求的把关人显式确认。

本 PR 不修改原改动的任何一行，只是把它重新提出来走正确的流程。原分支
`codex/fix-android-microphone-permission` 在合并后已被删除，且已合并的 PR 无法改回草稿、
也无法重开，所以这里新开一条草稿 PR 承接。commit 保留原作者 @xSharkM 的 author 身份与
sign-off，我作为重新提出者补了一条 sign-off。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：重做 #610（`main` 上的 revert 提交为 `cdcde2fc`）
- 本 PR 包含：`apps/mobile/app.json` 中 `expo-image-picker` 的 `microphonePermission`
  由 `false` 改为权限说明文案；`apps/mobile/src/__tests__/nativeAppConfig.test.ts` 补上
  对应断言。
- 明确不包含：不动 `expo-audio` 的 `microphonePermission`（那一条本来就有文案，与 #610
  无关）；不动任何其他指纹输入；不含 #610 之外的改动。
- 用户可见变化：Android 端远程会话使用语音输入时，麦克风权限弹窗恢复正常（带说明文案）。
- 是否存在 breaking change：无

### UI 变化

不涉及：没有仓内 UI 组件、布局、样式或应用内文案改动。改的是 Android 系统权限弹窗的
说明字符串，由操作系统呈现。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
# 指纹对比（docs/dev-rules/mobile-development.md 要求的改动前后各跑一次）
node apps/mobile/scripts/ci-fingerprint.mjs compute
  revert 后的 main（本 PR 的 base）：ios 361607e6…  android 0f634482…
  含本 PR 改动：                      ios 2b016e7e…  android e3c49d19…
  → 结论：本 PR 会改变 fingerprint，必然触发冷更。

pnpm --filter mobile run typecheck            结果：通过
pnpm --filter mobile exec vitest run          结果：259 个文件 / 2525 个测试全部通过
pnpm test:unit                                结果：全部通过（0 FAIL）
pnpm check:dco                                结果：通过
```

### 手工验证

未执行。恢复后的权限弹窗需要在真机 / 模拟器上冷更装包才能看到实际效果，而本 PR 正处于
「冷更待定」状态、还不应该出包，因此留到把关人放行、准备出包时一并验证。

### 未执行的验证

- Android 真机 / 模拟器上的麦克风权限弹窗实机目检：未执行，原因同上。
- 双模式（Light / Dark）目检：不涉及，本次无应用内 UI。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据（Android 麦克风权限声明）
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：`apps/mobile/app.json` 的 production 段，属于 runtime fingerprint 输入。
  合并即改变 ios / android 两侧指纹。
- 回滚 / 降级方式：`git revert` 本 PR 的合并提交即可，指纹会回到 base 的
  `ios 361607e6… / android 0f634482…`；不涉及数据迁移，无残留状态。

### 冷更说明（`docs/dev-rules/mobile-development.md` 冷更边界要求的三件事）

1. **为什么冷更不可避免**：Android 麦克风权限必须在原生 manifest 里声明，这个声明来自
   `app.json` 里 config plugin 的参数，进入 resolved ExpoConfig 并被哈希。没有任何纯 JS /
   OTA 写法能补上一条原生权限声明，所以指纹变化无法规避。
2. **存量装机影响范围**：所有已安装的存量用户在装上新包之前，拿不到本次以及本次之后的
   全部热更。这也是 #610 被 revert 的直接原因——它在没有确认的情况下让全体存量用户开始
   等新包。
3. **发版节奏建议**：不要单独为这一条出包。建议攒到下一次已经计划好的原生出包窗口，和
   其他必须冷更的改动一起合并、一起出包；在那之前本 PR 保持草稿 + `冷更待定` 标签挂起。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
