### PR TITLE
fix(hook-control): 渠道说明声明为系统提示,避免被模型当成用户消息

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/outbound.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/outbound.test.ts
@@ -32,6 +32,16 @@ describe('buildHookPromptNote', () => {
     expect(telegram).not.toContain('静默丢弃');
     expect(buildHookPromptNote('slack')).not.toContain('[Telegram 回复格式]');
   });
+
+  it('两个平台都在开头声明「不是用户消息」,防止模型把渠道说明当成用户请求(2026-07 实踩)', () => {
+    for (const im of ['telegram', 'slack'] as const) {
+      const note = buildHookPromptNote(im);
+      // guard 必须在附件正文之前出现,才能在模型读到附件指令前先定性。
+      expect(note).toContain('不是用户发来的消息');
+      expect(note).toContain('不要把它当作用户的请求');
+      expect(note.indexOf('不是用户发来的消息')).toBeLessThan(note.indexOf('要把文件发给用户'));
+    }
+  });
 });
 
 function deps(

--- a/apps/desktop/src/main/hook-control/outbound.ts
+++ b/apps/desktop/src/main/hook-control/outbound.ts
@@ -40,11 +40,20 @@ const MAX_OUT_TOTAL_BYTES = 30 * 1024 * 1024;
  * 发给我」路由到 cindy_feishu_bot(hook 会话里唯一可见的推送工具)并失败。
  * 固定文本、逐 turn 追加,保证行为确定(规则 9);修改措辞时同步
  * collectOutboundAttachments 的实际语义,别让说明和收集器漂移。
+ *
+ * 关键约束:这段说明由 session-runner 用 `${prompt}\n\n${note}` 拼在用户原话
+ * 之后,和用户内容同处一个 user turn —— 模型无法从消息角色上区分二者。实踩
+ * (2026-07)里,用户只发了极短内容(群里 @机器人 带一句话)时,模型把这段
+ * 附件说明误当成"用户要我检查附件",回了"你的消息里说'请检查这些附件',但我
+ * 没收到"。因此开头必须显式声明「这是系统规范、不是用户消息」,禁止当作用户
+ * 请求或加以引用/臆测。删改这句 guard 会让该误读复发。
  */
 export function buildHookPromptNote(im: string | undefined): string {
   const platform = im === 'telegram' ? 'Telegram' : 'Slack';
   const attachmentNote =
-    `[渠道说明] 本会话来自 ${platform}。要把文件发给用户:在最终回复文本里写 ` +
+    '[渠道说明] 以下为系统每轮自动追加的投递与格式规范,不是用户发来的消息;' +
+    '回复时不要把它当作用户的请求,也不要引用、复述或据此臆测用户意图。' +
+    `本会话来自 ${platform}。要把文件发给用户:在最终回复文本里写 ` +
     '`[文件名](xdt-file:///绝对路径)`;图片直接引用其地址 ' +
     '`![说明](cindy-media://… 或 xdt-image://…)`,无需复制文件。' +
     `系统会在回复结束后自动把它们作为 ${platform} 附件发回,无需调用任何工具;` +


### PR DESCRIPTION
## 这次改了什么

### 摘要

hook(Slack/Telegram)派发每个 turn 时,用 `${prompt}\n\n${note}` 把「渠道说明」拼在用户原话之后,二者作为**同一个 user turn** 一起喂给模型(`apps/desktop/src/main/hook-control/session-runner.ts:956`)。模型无法从消息角色上区分哪部分是用户说的、哪部分是系统追加的。

当用户实际内容很短时(例如群里 `@机器人` 只带一句「63」),这段讲附件投递的说明就成了消息主体,模型把它误当成用户诉求,去翻工作目录找附件、发现为空,回出「你的消息里说"请检查这些附件",但我没收到」这类答复——而用户从没提过附件。这不是幻觉:那段附件文字确实在模型输入里,只是它来自系统注入的渠道说明,不是用户。

修复:`buildHookPromptNote` 开头显式声明「这是系统每轮追加的规范、不是用户消息,不要当作用户请求或加以引用/臆测」,在模型读到附件指令前先定性,消除误读。纯文案改动,不改 `${prompt}\n\n${note}` 拼接结构,也不改 `collectOutboundAttachments` 出站收集语义。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(用户实测反馈)
- 本 PR 包含:`buildHookPromptNote` 增加 guard 声明句 + `outbound.test.ts` 断言
- 明确不包含:未改注入结构 / 出站收集;未改 Slack 专属文案语义
- 用户可见变化:hook 会话下,用户发极短消息时不再收到"你让我检查附件"这类臆测回复
- 是否存在 breaking change:无

### UI 变化

不涉及

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run src/main/hook-control/__tests__/outbound.test.ts src/main/hook-control/__tests__/session-runner.test.ts
结果:2 files, 49 passed(outbound 13 / session-runner 36)

pnpm --filter desktop run typecheck
结果:通过(exit 0)

pnpm test:unit(仓库根,全部单元测试)
结果:0 failed,52 passed / 6 skipped(含 apps/desktop 70.6s)
```

### 手工验证

不涉及(纯提示文案改动,由单测覆盖 note 内容与拼接顺序)

### 未执行的验证

无

## 风险

### 风险分类

- [x] system prompt

### 影响与回滚

- 影响范围:仅 hook(Slack/Telegram)会话逐 turn 注入给 agent 的渠道说明文案。严格说该说明拼在 user turn 而非 system 段,但因其塑造模型行为,归入此类以便 review。不入库、不影响历史消息。
- 回滚 / 降级方式:还原 `outbound.ts` 中 `buildHookPromptNote` 的该句 guard 即可,无数据 / 协议迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(相关注释已随代码更新)
- [x] 已确认测试结果或说明未执行原因

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
