### PR TITLE
fix(cindy-tools): ghost_forge_guide 分章按需返回，修复整本必超结果上限

### DIFF
--- a/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
+++ b/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
@@ -909,6 +909,19 @@ describe("cindy_ghosts · ghost_forge(锻造)", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("forge_guide 退化手册 + 传 section 仍整本原样返回,不报未命中", async () => {
+    const result = await handleForgeGuide(fakeDeps(), { section: "4.7" });
+    expect(result.content[0].text).toBe("# 手册");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("forge_guide 空串/纯空白 section 视为未传,返回目录而非报错", async () => {
+    const blank = await handleForgeGuide(sectionedDeps(), { section: "   " });
+    expect(blank.isError).toBeUndefined();
+    expect(blank.content[0].text).toContain("## 目录");
+    expect(blank.content[0].text).not.toContain("net-body");
+  });
+
   // 分章手册:开场白 + 4 章,其中 4.6.1 也是 ## 级(与真实手册一致)
   const SECTIONED_GUIDE = [
     "# 手册",

--- a/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
+++ b/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
@@ -903,10 +903,84 @@ describe("ghost_call · setup_plan MCP 边界", () => {
 });
 
 describe("cindy_ghosts · ghost_forge(锻造)", () => {
-  it("forge_guide 原文返回手册(不 JSON 包裹,agent 直接读 markdown)", async () => {
+  it("forge_guide 无 ## 标题的短手册整本原样返回(退化路径,不 JSON 包裹)", async () => {
     const result = await handleForgeGuide(fakeDeps());
     expect(result.content[0].text).toBe("# 手册");
     expect(result.isError).toBeUndefined();
+  });
+
+  // 分章手册:开场白 + 4 章,其中 4.6.1 也是 ## 级(与真实手册一致)
+  const SECTIONED_GUIDE = [
+    "# 手册",
+    "开场白一句。",
+    "## 1. 起步",
+    "one-body",
+    "## 4.6 订阅(subscribe 槽)",
+    "sub-body",
+    "## 4.6.1 出口钩子",
+    "hook-body",
+    "## 4.7 网络代发(network 槽)",
+    "net-body",
+  ].join("\n");
+  const sectionedDeps = () =>
+    fakeDeps({ forgeGuide: async () => SECTIONED_GUIDE });
+
+  it("forge_guide 无参返回目录:含开场白与全部章节标题,不含章节正文", async () => {
+    const result = await handleForgeGuide(sectionedDeps());
+    const text = result.content[0].text;
+    expect(result.isError).toBeUndefined();
+    expect(text).toContain("开场白一句。");
+    expect(text).toContain("## 目录");
+    expect(text).toContain("- 4.7 网络代发(network 槽)");
+    expect(text).toContain("- 4.6.1 出口钩子");
+    expect(text).not.toContain("net-body");
+    expect(text).not.toContain("one-body");
+  });
+
+  it("forge_guide 按章号取正文:含本章标题与正文,止于下一个 ## 标题", async () => {
+    const result = await handleForgeGuide(sectionedDeps(), { section: "4.6" });
+    const text = result.content[0].text;
+    expect(result.isError).toBeUndefined();
+    expect(text).toContain("## 4.6 订阅(subscribe 槽)");
+    expect(text).toContain("sub-body");
+    expect(text).not.toContain("hook-body");
+  });
+
+  it("forge_guide 按标题关键词取正文(大小写不敏感,唯一命中)", async () => {
+    const result = await handleForgeGuide(sectionedDeps(), {
+      section: "NETWORK",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("net-body");
+  });
+
+  it("forge_guide 关键词命中多章标 isError 并列出歧义候选", async () => {
+    const result = await handleForgeGuide(sectionedDeps(), { section: "4.6" });
+    expect(result.isError).toBeUndefined(); // 章号精确匹配优先,不歧义
+    const ambiguous = await handleForgeGuide(sectionedDeps(), {
+      section: "钩子",
+    });
+    expect(ambiguous.isError).toBeUndefined(); // 唯一命中
+    const multi = await handleForgeGuide(sectionedDeps(), { section: "槽" });
+    expect(multi.isError).toBe(true);
+    expect(parsePayload(multi)).toMatchObject({
+      ok: false,
+      errorCode: "SECTION_NOT_FOUND",
+    });
+    expect((parsePayload(multi) as { message: string }).message).toContain(
+      "4.6 订阅(subscribe 槽)",
+    );
+  });
+
+  it("forge_guide 零命中标 isError 并列出全部可用章节", async () => {
+    const result = await handleForgeGuide(sectionedDeps(), {
+      section: "不存在的章",
+    });
+    expect(result.isError).toBe(true);
+    const payload = parsePayload(result) as { message: string };
+    expect(payload).toMatchObject({ ok: false, errorCode: "SECTION_NOT_FOUND" });
+    expect(payload.message).toContain("1. 起步");
+    expect(payload.message).toContain("4.7 网络代发(network 槽)");
   });
 
   it("forge_scaffold 透传模板和创建文件；目标存在时标 isError", async () => {

--- a/packages/cindy-tools/src/ghost/forgeGuideSections.ts
+++ b/packages/cindy-tools/src/ghost/forgeGuideSections.ts
@@ -61,6 +61,7 @@ export function buildForgeGuideToc(guide: string): string {
  * 取单章正文:从命中的 `## ` 标题行(含)到下一个 `## ` 标题行(不含)。
  * 匹配优先级:章号精确匹配(允许末尾多一个点) > 标题关键词包含(大小写不敏感)。
  * 关键词命中多章返回歧义候选;零命中返回全部章节标题。
+ * 没有任何 `## ` 标题的退化手册无章可取,任何 query 都整本原样返回。
  */
 export function extractForgeGuideSection(
   guide: string,
@@ -71,10 +72,13 @@ export function extractForgeGuideSection(
   lines.forEach((l, i) => {
     if (l.startsWith(HEADER_PREFIX)) headerIdx.push(i);
   });
+  if (headerIdx.length === 0) {
+    return { ok: true, text: guide };
+  }
   const allTitles = headerIdx.map((i) => headerTitle(lines[i]));
 
   const q = query.trim().replace(/\.$/, "");
-  if (!q || headerIdx.length === 0) {
+  if (!q) {
     return { ok: false, candidates: allTitles, ambiguous: false };
   }
 

--- a/packages/cindy-tools/src/ghost/forgeGuideSections.ts
+++ b/packages/cindy-tools/src/ghost/forgeGuideSections.ts
@@ -1,0 +1,101 @@
+/**
+ * ghost_forge_guide 的分章投递。
+ *
+ * 手册整本 ~120KB,必超单次 MCP 工具结果上限(见 #890),因此:
+ * 无参调用返回目录(开场白 + 全部章节标题 + 取章提示),传 section(章号或
+ * 标题关键词)返回单章正文。章 = 手册里的 `## ` 标题行,单章体量均在安全范围。
+ *
+ * 纯函数,不依赖 deps;对"没有任何 ## 标题"的退化输入按整本原样返回,
+ * 保持旧行为(短手册无需分章)。
+ */
+
+export interface ForgeGuideSectionHit {
+  ok: true;
+  text: string;
+}
+
+export interface ForgeGuideSectionMiss {
+  ok: false;
+  /** ambiguous=true 时是歧义候选,否则是全部可用章节标题 */
+  candidates: string[];
+  ambiguous: boolean;
+}
+
+export type ForgeGuideSectionResult = ForgeGuideSectionHit | ForgeGuideSectionMiss;
+
+const HEADER_PREFIX = "## ";
+
+/** 全部 `## ` 章节标题行(含前缀)。 */
+function headerLines(guide: string): string[] {
+  return guide.split("\n").filter((l) => l.startsWith(HEADER_PREFIX));
+}
+
+/** "## 4.7 网络代发(network 槽)" → "4.7";无章号返回 null。 */
+function headerNumber(header: string): string | null {
+  const m = header.match(/^## ([0-9]+(?:\.[0-9]+)*)\.?(?:\s|$)/);
+  return m ? m[1] : null;
+}
+
+/** 去掉 `## ` 前缀的标题文本,用于目录与错误提示。 */
+function headerTitle(header: string): string {
+  return header.slice(HEADER_PREFIX.length);
+}
+
+/** 目录:开场白 + 章节标题列表 + 取章提示。没有 ## 标题时整本原样返回。 */
+export function buildForgeGuideToc(guide: string): string {
+  const headers = headerLines(guide);
+  if (headers.length === 0) return guide;
+  const firstHeaderAt = guide.indexOf(`\n${HEADER_PREFIX}`);
+  const preamble = firstHeaderAt >= 0 ? guide.slice(0, firstHeaderAt).trimEnd() : "";
+  return [
+    ...(preamble ? [preamble, ""] : []),
+    "## 目录",
+    "",
+    ...headers.map((h) => `- ${headerTitle(h)}`),
+    "",
+    '整本手册超出单次工具结果上限,按需取章:再次调用并传 section,章号(如 {"section":"4.7"})或标题关键词(如 {"section":"network"})均可。',
+  ].join("\n");
+}
+
+/**
+ * 取单章正文:从命中的 `## ` 标题行(含)到下一个 `## ` 标题行(不含)。
+ * 匹配优先级:章号精确匹配(允许末尾多一个点) > 标题关键词包含(大小写不敏感)。
+ * 关键词命中多章返回歧义候选;零命中返回全部章节标题。
+ */
+export function extractForgeGuideSection(
+  guide: string,
+  query: string,
+): ForgeGuideSectionResult {
+  const lines = guide.split("\n");
+  const headerIdx: number[] = [];
+  lines.forEach((l, i) => {
+    if (l.startsWith(HEADER_PREFIX)) headerIdx.push(i);
+  });
+  const allTitles = headerIdx.map((i) => headerTitle(lines[i]));
+
+  const q = query.trim().replace(/\.$/, "");
+  if (!q || headerIdx.length === 0) {
+    return { ok: false, candidates: allTitles, ambiguous: false };
+  }
+
+  const sliceAt = (pos: number): ForgeGuideSectionHit => {
+    const start = headerIdx[pos];
+    const end = pos + 1 < headerIdx.length ? headerIdx[pos + 1] : lines.length;
+    return { ok: true, text: lines.slice(start, end).join("\n").trimEnd() };
+  };
+
+  // 章号精确匹配
+  const byNumber = headerIdx.findIndex((i) => headerNumber(lines[i]) === q);
+  if (byNumber >= 0) return sliceAt(byNumber);
+
+  // 标题关键词包含
+  const ql = q.toLowerCase();
+  const byKeyword = headerIdx
+    .map((i, pos) => ({ pos, title: headerTitle(lines[i]) }))
+    .filter(({ title }) => title.toLowerCase().includes(ql));
+  if (byKeyword.length === 1) return sliceAt(byKeyword[0].pos);
+  if (byKeyword.length > 1) {
+    return { ok: false, candidates: byKeyword.map((k) => k.title), ambiguous: true };
+  }
+  return { ok: false, candidates: allTitles, ambiguous: false };
+}

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -621,10 +621,12 @@ export async function handleForgeGuide(
 ): Promise<McpTextResult> {
   try {
     const guide = await deps.forgeGuide();
-    if (!input?.section) {
+    // 空串/纯空白与未传等价:与工具描述"不传返回目录"一致
+    const section = input?.section?.trim();
+    if (!section) {
       return { content: [{ type: "text", text: buildForgeGuideToc(guide) }] };
     }
-    const hit = extractForgeGuideSection(guide, input.section);
+    const hit = extractForgeGuideSection(guide, section);
     if (hit.ok) {
       return { content: [{ type: "text", text: hit.text }] };
     }
@@ -633,8 +635,8 @@ export async function handleForgeGuide(
         ok: false,
         errorCode: "SECTION_NOT_FOUND",
         message: hit.ambiguous
-          ? `section "${input.section}" 命中多章,换更精确的章号:\n${hit.candidates.join("\n")}`
-          : `section "${input.section}" 未命中任何章节,可用章节:\n${hit.candidates.join("\n")}`,
+          ? `section "${section}" 命中多章,换更精确的章号:\n${hit.candidates.join("\n")}`
+          : `section "${section}" 未命中任何章节,可用章节:\n${hit.candidates.join("\n")}`,
       },
       true,
     );

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -9,6 +9,10 @@ import type {
   CindyGhostSetupPlan,
   CindyGhostsMcpDeps,
 } from "../types.js";
+import {
+  buildForgeGuideToc,
+  extractForgeGuideSection,
+} from "./forgeGuideSections.js";
 
 /**
  * ghost 总机(docs/dev-rules/plugin-security-and-authoring.md 的网关模式):
@@ -57,9 +61,10 @@ const D_GHOST_CALL = [
 const D_GHOST_FORGE_GUIDE = [
   "获取《插件(Ghost)编写手册》——为用户制作/修改插件(.cindy 能力包)前必读。",
   "手册随主机版本走,包含:ghost.json 身份卡全字段、十个卡槽、管子 API(cindy.send)、",
-  '面板与主题、沙箱红线、打包与测试流程。用户说"帮我做一个 XX 插件 / 改一下某插件"时,',
-  "先调本工具拿手册,新插件可用 ghost_forge_scaffold 生成骨架,修改完成后再用",
-  "ghost_forge_pack 打包装入。",
+  "面板与主题、沙箱红线、打包与测试流程。整本超出单次工具结果上限,分章取用:",
+  '不传参数返回目录,传 section(章号如 "4.7" 或章标题关键词如 "network")返回单章正文。',
+  '用户说"帮我做一个 XX 插件 / 改一下某插件"时,先取目录、按需读相关章,',
+  "新插件可用 ghost_forge_scaffold 生成骨架,修改完成后再用 ghost_forge_pack 打包装入。",
 ].join("\n");
 
 const D_GHOST_FORGE_SCAFFOLD = [
@@ -612,10 +617,27 @@ export async function handleGhostCall(
 /** ghost_forge_guide 的 handler 主体(导出供单测)。 */
 export async function handleForgeGuide(
   deps: CindyGhostsMcpDeps,
+  input?: { section?: string },
 ): Promise<McpTextResult> {
   try {
     const guide = await deps.forgeGuide();
-    return { content: [{ type: "text", text: guide }] };
+    if (!input?.section) {
+      return { content: [{ type: "text", text: buildForgeGuideToc(guide) }] };
+    }
+    const hit = extractForgeGuideSection(guide, input.section);
+    if (hit.ok) {
+      return { content: [{ type: "text", text: hit.text }] };
+    }
+    return textResult(
+      {
+        ok: false,
+        errorCode: "SECTION_NOT_FOUND",
+        message: hit.ambiguous
+          ? `section "${input.section}" 命中多章,换更精确的章号:\n${hit.candidates.join("\n")}`
+          : `section "${input.section}" 未命中任何章节,可用章节:\n${hit.candidates.join("\n")}`,
+      },
+      true,
+    );
   } catch (err) {
     return textResult(
       {
@@ -752,8 +774,16 @@ export function createCindyGhostsMcpServer(
       handleGhostCall(deps, input, extractAgentToolUseId(extra)),
   );
 
-  server.tool("ghost_forge_guide", D_GHOST_FORGE_GUIDE, {}, async () =>
-    handleForgeGuide(deps),
+  server.tool(
+    "ghost_forge_guide",
+    D_GHOST_FORGE_GUIDE,
+    {
+      section: z
+        .string()
+        .optional()
+        .describe('章号(如 "4.7")或章标题关键词(如 "network");不传返回目录'),
+    },
+    async (input) => handleForgeGuide(deps, input),
   );
 
   server.tool(


### PR DESCRIPTION
## 这次改了什么

### 摘要

《插件编写手册》整本 ~120KB，`ghost_forge_guide` 一次性返回必超单次 MCP 工具结果上限，agent 任何调用都拿不到内容。本 PR 改为分章投递：无参返回目录（开场白 + 章节标题 + 取章提示，实测 ~1.9KB），传 `section`（章号如 "4.7" 或标题关键词如 "network"）返回单章正文；关键词命中多章报歧义候选，零命中报可用章节；无 `## ` 标题的退化输入保持整本原样返回。对齐仓内插件已确立的两段式渐进发现范式（list_tools → call_tool）。

Fixes #890

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#890
- 本 PR 包含：`forgeGuideSections.ts` 目录/切章纯函数；`handleForgeGuide` 加 `section` 入参与分派；工具注册加 zod 参数与描述更新；下游文案同步（手册开场白与四语 createPrompt 从"读完整规范"改为"取目录后按 section 读透相关章"）；desktop 侧分章体量守卫测试（每章 ≤32KB）；7 个新单测
- 明确不包含：手册内容本身（`FORGE_GUIDE` 文本未动）
- 用户可见变化：无 UI 变化；agent 调用 `ghost_forge_guide` 的返回契约变化（无参：整本→目录），工具描述已同步更新引导分章取用
- 是否存在 breaking change：工具层契约变化如上；旧契约在超限环境下本就不可用，且调用方引导文本（工具描述）随本 PR 同步

### UI 变化

不涉及。

- 引用的设计规范：不涉及（未命中 UI 代码路径）

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：exit 0，全部工作区 PASS（含 cindy-tools 43 个用例，其中本 PR 新增 6 个：目录/按章号/按关键词/歧义/零命中/退化路径）

pnpm --filter desktop typecheck
结果：通过，无错误

pnpm check:i18n && pnpm check:i18n-glossary
结果：四语言 5665 个 key 全部一致；术语无新增违规

pnpm check:dco
结果：通过
```

### 手工验证

用真实手册文本（124,653 字节）离线跑纯函数：目录 1,895 字节 / 25 章；全部章节按章号提取成功，最大章 4.7（network 槽） 21,872 字节，均在单次结果安全体量内；关键词 "network" 唯一命中 4.7；关键词 "槽" 报歧义（13 候选）。

### 未执行的验证

未在实机 dev 实例聊天中调用：分章逻辑为纯函数且已用真实手册全量验证，handler 接线路径由单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：工具返回契约变化（无参调用：整本→目录）

### 影响与回滚

- 影响范围：仅 `ghost_forge_guide` 工具（packages/cindy-tools）；依赖旧"无参返整本"行为的调用方会改收目录——但旧行为在超限环境下实际不可用，且工具描述（调用方的唯一引导）随本 PR 同步更新
- 回滚 / 降级方式：revert 本 PR 单个 commit 即可，无状态残留

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（设计依据在代码注释中，无需额外文档）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)