### PR TITLE
fix(desktop): 修复 Windows 中文输入预览时标点抖动

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -284,7 +284,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
       '1. 第一项\n2. ',
     );
 
-    const indentedRows = editor.view.dom.querySelectorAll('.composer-list-line-indent');
+    const indentedRows = editor.view.dom.querySelectorAll('.composer-list-fallback-prefix');
     expect(indentedRows).toHaveLength(2);
     expect(indentedRows[1]?.textContent).toBe('2. ');
 
@@ -292,7 +292,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     expect(editor.state.doc.textBetween(0, editor.state.doc.content.size, '\n', '\n')).toBe(
       '1. 第一项\n2. 中文',
     );
-    expect(editor.view.dom.querySelectorAll('.composer-list-line-indent')).toHaveLength(2);
+    expect(editor.view.dom.querySelectorAll('.composer-list-fallback-prefix')).toHaveLength(2);
   });
 
   it('does not rewrite decoration-owned styles while laying out multiline CJK lists', () => {
@@ -660,7 +660,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
             content: [
               { type: 'text', text: 'intro' },
               { type: 'hardBreak' },
-              { type: 'text', text: '1. 中文,正文' },
+              { type: 'text', text: '1. 中文正文' },
             ],
           },
         ],
@@ -671,11 +671,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     );
     expect(prefix?.textContent).toBe('1. ');
     expect(prefix?.querySelectorAll('span[style*="font-family"]')).toHaveLength(0);
-    expect(
-      Array.from(editor.view.dom.querySelectorAll('span[style*="font-family"]')).map(
-        (node) => node.textContent,
-      ),
-    ).toContain(',');
+    expect(editor.view.dom.querySelectorAll('span[style*="font-family"]')).toHaveLength(0);
   });
 
   it('keeps slash-command pills inline inside the paragraph fallback flow', () => {
@@ -886,7 +882,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
           {
             type: 'paragraph',
             content: [
-              { type: 'text', text: '1. 有新增游戏数的用户数、占全部用户比例。' },
+              { type: 'text', text: '1. 有新增游戏数的用户数,占全部用户比例。' },
               { type: 'hardBreak' },
               { type: 'text', text: '2. 有新增游戏数的近30天、近1年活跃用户数及占比。' },
               { type: 'hardBreak' },
@@ -906,7 +902,7 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     const unindentedRows = container?.querySelectorAll('.composer-list-fallback-unindented');
     expect(container).not.toBeNull();
     expect(unindentedRows).toHaveLength(1);
-    expect(unindentedRows?.[0]?.textContent).toBe('有新增游戏数的用户数、占全部用户比例。');
+    expect(unindentedRows?.[0]?.textContent).toBe('有新增游戏数的用户数,占全部用户比例。');
     expect(unindentedRows?.[0]?.classList.contains('composer-list-cjk-font')).toBe(false);
     expect(
       unindentedRows?.[0]?.classList.contains('composer-list-cjk-punctuation-font'),
@@ -1077,7 +1073,8 @@ describe('wiring contract', () => {
     expect(css).toContain('.ProseMirror .composer-list-cjk-punctuation-font');
     expect(css).toContain("font-family: 'Cindy CJK Punctuation Local'");
     expect(css).toContain("font-family: 'Cindy CJK Punctuation Bundled'");
-    expect(css).toContain('unicode-range: U+3000-303F, U+FF00-FFEF;');
+    expect(css).toContain('U+3000-303F, U+FF00-FFEF;');
+    expect(css.match(/U\+0021-0022, U\+0027-0029/g)).toHaveLength(2);
     const punctuationFontCss = css.slice(
       css.indexOf("font-family: 'Cindy CJK Punctuation Local'"),
       css.indexOf('.ProseMirror .composer-list-cjk-punctuation-font'),

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -641,6 +641,43 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     ).toBeGreaterThan(0);
   });
 
+  it('keeps ASCII punctuation in a list prefix inside the fixed CJK font slot', () => {
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        CjkPunctDecoration,
+        ComposerListIndentDecoration,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'intro' },
+              { type: 'hardBreak' },
+              { type: 'text', text: '1. 中文,正文' },
+            ],
+          },
+        ],
+      },
+    });
+    const prefix = editor.view.dom.querySelector(
+      '.composer-list-fallback-prefix.composer-list-cjk-font',
+    );
+    expect(prefix?.textContent).toBe('1. ');
+    expect(prefix?.querySelectorAll('span[style*="font-family"]')).toHaveLength(0);
+    expect(
+      Array.from(editor.view.dom.querySelectorAll('span[style*="font-family"]')).map(
+        (node) => node.textContent,
+      ),
+    ).toContain(',');
+  });
+
   it('keeps slash-command pills inline inside the paragraph fallback flow', () => {
     editor = new Editor({
       element: document.createElement('div'),

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -461,6 +461,58 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     }
   });
 
+  it('keeps ASCII punctuation in a CJK sentence stable during IME preview', () => {
+    vi.useFakeTimers();
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [Document, Paragraph, Text, CjkPunctDecoration],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: '现代都市开放世界共创游戏。 () 在上面这个句语基础上,',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const punctuationSelector = 'span[style*="font-family"]';
+    const currentEditor = editor;
+    if (!currentEditor) throw new Error('editor failed to initialize');
+    const decoratedPunctuation = () =>
+      Array.from(currentEditor.view.dom.querySelectorAll(punctuationSelector), (node) => node.textContent);
+    expect(decoratedPunctuation()).toEqual(['。', '(', ')', ',']);
+
+    editor.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    editor.view.dispatch(
+      editor.state.tr
+        .insertText('w', editor.state.doc.content.size - 1)
+        .setMeta('composition', 1),
+    );
+    expect(editor.getText()).toBe('现代都市开放世界共创游戏。 () 在上面这个句语基础上,w');
+    expect(decoratedPunctuation()).toEqual(['。', '(', ')', ',']);
+
+    editor.view.dom.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+    vi.runOnlyPendingTimers();
+    expect(decoratedPunctuation()).toEqual(['。', '(', ')', ',']);
+  });
+
+  it('does not apply the CJK punctuation font to an isolated Latin punctuation run', () => {
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [Document, Paragraph, Text, CjkPunctDecoration],
+      content: 'hello (), world',
+    });
+
+    expect(editor.view.dom.querySelectorAll('span[style*="font-family"]')).toHaveLength(0);
+  });
+
   it('renders the indent span into the DOM for list lines', () => {
     const ed = makeEditor(['1. hello']);
     expect(ed.view.dom.querySelector('p.composer-list-block-indent')?.textContent).toBe('1. hello');

--- a/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerListIndentDecoration.test.ts
@@ -674,6 +674,57 @@ describe('ComposerListIndentDecoration in a real editor', () => {
     expect(editor.view.dom.querySelectorAll('span[style*="font-family"]')).toHaveLength(0);
   });
 
+  it('keeps fallback-owned ASCII punctuation stable while list wrappers are suspended for IME', () => {
+    vi.useFakeTimers();
+    editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        CjkPunctDecoration,
+        ComposerListIndentDecoration,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: '1. 中文正文' },
+              { type: 'hardBreak' },
+              { type: 'text', text: '中文,内容' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const punctuation = () =>
+      Array.from(editor?.view.dom.querySelectorAll('span[style*="font-family"]') ?? [], (node) =>
+        node.textContent,
+      );
+    expect(punctuation()).toEqual([]);
+    expect(editor.view.dom.querySelector('.composer-list-fallback-container')).not.toBeNull();
+
+    editor.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    expect(editor.view.composing).toBe(true);
+    expect(editor.view.dom.querySelector('.composer-list-fallback-container')).toBeNull();
+    expect(punctuation()).toEqual(['.', ',']);
+
+    editor.view.dispatch(
+      editor.state.tr.insertText('中', editor.state.doc.content.size - 1).setMeta('composition', 1),
+    );
+    expect(punctuation()).toEqual(['.', ',']);
+
+    editor.view.dom.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+    vi.runOnlyPendingTimers();
+    expect(editor.view.composing).toBe(false);
+    expect(punctuation()).toEqual([]);
+    expect(editor.view.dom.querySelector('.composer-list-fallback-container')).not.toBeNull();
+  });
+
   it('keeps slash-command pills inline inside the paragraph fallback flow', () => {
     editor = new Editor({
       element: document.createElement('div'),

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
@@ -51,6 +51,11 @@ import {
   resolveVoiceInputReplacementRange,
   type VoiceInputReplacementRange,
 } from './VoiceInputDraftDecoration';
+import {
+  hasCjkPunctuation as hasCjkPunctuationChar,
+  hasCjkContextPunctuation,
+  isCjkContextPunctuation,
+} from './CjkPunctuationUtils';
 
 type CjkDecorationPluginState = {
   decorations: DecorationSet;
@@ -60,70 +65,6 @@ type CjkDecorationPluginState = {
 type CompositionMeta = 'suspend' | 'resume';
 
 const PLUGIN_KEY = new PluginKey<CjkDecorationPluginState>('cjkPunctDecoration');
-
-/**
- * CJK 标点字符集合。覆盖最常用的几个区段,够 chat input 场景用:
- *   U+3000-303F: CJK Symbols and Punctuation (含 《》「」『』【】 等)
- *   U+FF00-FFEF: Halfwidth and Fullwidth Forms (含全角 (), !? 等)
- * 中文输入法也可能在中文语境下产出 ASCII 标点(例如 `()` / `,`)。这类字符
- * 本身是 Latin script,但在中文文本旁边仍会被 Chromium 按 composition 中的
- * 相邻 Latin 预览重新 itemize,所以下面会按 CJK 上下文一并稳定它们的字体。
- */
-const CJK_PUNCT_CHAR_REGEX = /[\u3000-\u303f\uff00-\uffef]/;
-const CJK_SCRIPT_CHAR_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/;
-const ASCII_CJK_PUNCTUATION = new Set([
-  '!',
-  '"',
-  "'",
-  '(',
-  ')',
-  ',',
-  '.',
-  ':',
-  ';',
-  '?',
-  '[',
-  ']',
-  '{',
-  '}',
-]);
-
-function isCjkChar(char: string | undefined): boolean {
-  return (
-    char !== undefined &&
-    (CJK_SCRIPT_CHAR_REGEX.test(char) || CJK_PUNCT_CHAR_REGEX.test(char))
-  );
-}
-
-/**
- * ASCII punctuation only needs the CJK font when it belongs to a CJK run.
- * Ignore whitespace and adjacent ASCII punctuation while looking either way so
- * `"中文 ()"` is covered as a group but punctuation inside an ordinary Latin
- * URL/code run is left untouched.
- */
-function isCjkContextPunctuation(text: string, index: number): boolean {
-  const char = text[index];
-  if (char === undefined) return false;
-  if (CJK_PUNCT_CHAR_REGEX.test(char)) return true;
-  if (!ASCII_CJK_PUNCTUATION.has(char)) return false;
-
-  const isContextSeparator = (value: string | undefined) =>
-    value !== undefined && (/\s/.test(value) || ASCII_CJK_PUNCTUATION.has(value));
-  let before = index - 1;
-  while (before >= 0 && isContextSeparator(text[before])) before -= 1;
-  if (before >= 0 && isCjkChar(text[before])) return true;
-
-  let after = index + 1;
-  while (after < text.length && isContextSeparator(text[after])) after += 1;
-  return after < text.length && isCjkChar(text[after]);
-}
-
-function hasCjkContextPunctuation(text: string): boolean {
-  for (let index = 0; index < text.length; index += 1) {
-    if (isCjkContextPunctuation(text, index)) return true;
-  }
-  return false;
-}
 
 const LONG_ALPHANUMERIC_BODY_RE = /^\s*[A-Za-z0-9]{12,}\s*$/;
 
@@ -195,7 +136,9 @@ function listLineRanges(
         voiceReplacementRange !== null &&
         voiceReplacementRange.from < contentBase + line.end &&
         voiceReplacementRange.to > contentBase + line.start;
-      const hasCjkPunctuation = hasCjkContextPunctuation(line.text);
+      const hasCjkPunctuation =
+        hasCjkPunctuationChar(line.text, 0, match.prefixLength) ||
+        hasCjkContextPunctuation(line.text, match.prefixLength);
       return (
         line.hasInlineAtom ||
         overlapsSlashCommandPill ||

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
@@ -52,7 +52,6 @@ import {
   type VoiceInputReplacementRange,
 } from './VoiceInputDraftDecoration';
 import {
-  hasCjkPunctuation as hasCjkPunctuationChar,
   hasCjkContextPunctuation,
   isCjkContextPunctuation,
 } from './CjkPunctuationUtils';
@@ -136,9 +135,7 @@ function listLineRanges(
         voiceReplacementRange !== null &&
         voiceReplacementRange.from < contentBase + line.end &&
         voiceReplacementRange.to > contentBase + line.start;
-      const hasCjkPunctuation =
-        hasCjkPunctuationChar(line.text, 0, match.prefixLength) ||
-        hasCjkContextPunctuation(line.text, match.prefixLength);
+      const hasCjkPunctuation = hasCjkContextPunctuation(line.text);
       return (
         line.hasInlineAtom ||
         overlapsSlashCommandPill ||

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
@@ -65,10 +65,65 @@ const PLUGIN_KEY = new PluginKey<CjkDecorationPluginState>('cjkPunctDecoration')
  * CJK 标点字符集合。覆盖最常用的几个区段,够 chat input 场景用:
  *   U+3000-303F: CJK Symbols and Punctuation (含 《》「」『』【】 等)
  *   U+FF00-FFEF: Halfwidth and Fullwidth Forms (含全角 (), !? 等)
- *
- * 不包括 ASCII 标点,因为它们 script 已经是 Latin,不会触发 itemization 错乱。
+ * 中文输入法也可能在中文语境下产出 ASCII 标点(例如 `()` / `,`)。这类字符
+ * 本身是 Latin script,但在中文文本旁边仍会被 Chromium 按 composition 中的
+ * 相邻 Latin 预览重新 itemize,所以下面会按 CJK 上下文一并稳定它们的字体。
  */
-const CJK_PUNCT_REGEX = /[\u3000-\u303f\uff00-\uffef]/g;
+const CJK_PUNCT_CHAR_REGEX = /[\u3000-\u303f\uff00-\uffef]/;
+const CJK_SCRIPT_CHAR_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/;
+const ASCII_CJK_PUNCTUATION = new Set([
+  '!',
+  '"',
+  "'",
+  '(',
+  ')',
+  ',',
+  '.',
+  ':',
+  ';',
+  '?',
+  '[',
+  ']',
+  '{',
+  '}',
+]);
+
+function isCjkChar(char: string | undefined): boolean {
+  return (
+    char !== undefined &&
+    (CJK_SCRIPT_CHAR_REGEX.test(char) || CJK_PUNCT_CHAR_REGEX.test(char))
+  );
+}
+
+/**
+ * ASCII punctuation only needs the CJK font when it belongs to a CJK run.
+ * Ignore whitespace and adjacent ASCII punctuation while looking either way so
+ * `"中文 ()"` is covered as a group but punctuation inside an ordinary Latin
+ * URL/code run is left untouched.
+ */
+function isCjkContextPunctuation(text: string, index: number): boolean {
+  const char = text[index];
+  if (char === undefined) return false;
+  if (CJK_PUNCT_CHAR_REGEX.test(char)) return true;
+  if (!ASCII_CJK_PUNCTUATION.has(char)) return false;
+
+  const isContextSeparator = (value: string | undefined) =>
+    value !== undefined && (/\s/.test(value) || ASCII_CJK_PUNCTUATION.has(value));
+  let before = index - 1;
+  while (before >= 0 && isContextSeparator(text[before])) before -= 1;
+  if (before >= 0 && isCjkChar(text[before])) return true;
+
+  let after = index + 1;
+  while (after < text.length && isContextSeparator(text[after])) after += 1;
+  return after < text.length && isCjkChar(text[after]);
+}
+
+function hasCjkContextPunctuation(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    if (isCjkContextPunctuation(text, index)) return true;
+  }
+  return false;
+}
 
 const LONG_ALPHANUMERIC_BODY_RE = /^\s*[A-Za-z0-9]{12,}\s*$/;
 
@@ -140,8 +195,7 @@ function listLineRanges(
         voiceReplacementRange !== null &&
         voiceReplacementRange.from < contentBase + line.end &&
         voiceReplacementRange.to > contentBase + line.start;
-      const hasCjkPunctuation = CJK_PUNCT_REGEX.test(line.text);
-      CJK_PUNCT_REGEX.lastIndex = 0;
+      const hasCjkPunctuation = hasCjkContextPunctuation(line.text);
       return (
         line.hasInlineAtom ||
         overlapsSlashCommandPill ||
@@ -201,7 +255,7 @@ const CJK_FONT_STACK =
 
 /**
  * 扫描整个 doc, 给所有 CJK 标点位置生成 inline decoration。
- * 用 descendants 遍历所有 text node, 对每个 text node 内的字符做正则匹配。
+ * 用 descendants 遍历所有 text node, 对每个 text node 内的字符做上下文匹配。
  * 注意 from/to 是 doc-level position, 不是 text-node-local offset。
  */
 function buildDecorations(
@@ -215,11 +269,10 @@ function buildDecorations(
   doc.descendants((node, pos) => {
     if (!node.isText || !node.text) return;
     const text = node.text;
-    CJK_PUNCT_REGEX.lastIndex = 0;
-    let m: RegExpExecArray | null;
-    while ((m = CJK_PUNCT_REGEX.exec(text)) !== null) {
-      const from = pos + m.index;
-      const to = from + m[0].length;
+    for (let index = 0; index < text.length; index += 1) {
+      if (!isCjkContextPunctuation(text, index)) continue;
+      const from = pos + index;
+      const to = from + 1;
       if (listRanges.some((range) => from >= range.from && to <= range.to)) {
         // ComposerListIndentDecoration owns the wrapping container for these
         // ranges. An overlapping inline font decoration would split fixed-width

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctDecoration.ts
@@ -202,9 +202,12 @@ function buildDecorations(
   doc: PMNode,
   slashCommandMatches: ReadonlyArray<Pick<SlashCommandMatch, 'from' | 'to'>> = [],
   voiceReplacementRange: VoiceInputReplacementRange | null = null,
+  ignoreListRanges = false,
 ): DecorationSet {
   const decorations: Decoration[] = [];
-  const listRanges = listLineRanges(doc, slashCommandMatches, voiceReplacementRange);
+  const listRanges = ignoreListRanges
+    ? []
+    : listLineRanges(doc, slashCommandMatches, voiceReplacementRange);
 
   doc.descendants((node, pos) => {
     if (!node.isText || !node.text) return;
@@ -253,8 +256,20 @@ export const CjkPunctDecoration = Extension.create({
           apply(tr: Transaction, old: CjkDecorationPluginState, oldState: EditorState) {
             const compositionMeta = tr.getMeta(PLUGIN_KEY) as CompositionMeta | undefined;
             if (compositionMeta === 'suspend') {
+              // ComposerListIndentDecoration removes its wrappers during IME
+              // composition so ProseMirror does not let native composition DOM
+              // get split by stale layout decorations. Rebuild CJK spans
+              // without the list-owned exclusions for that same window; this
+              // keeps marker dots and fallback sibling ASCII punctuation in the
+              // explicit CJK font stack while the list wrappers are absent.
+              const roster = getSlashCommandRoster(oldState);
               return {
-                decorations: old.decorations,
+                decorations: buildDecorations(
+                  tr.doc,
+                  findSlashCommandMatches(tr.doc, roster),
+                  resolveVoiceInputReplacementRange(tr, oldState).range,
+                  true,
+                ),
                 suspendedForComposition: true,
               };
             }

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctuationUtils.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctuationUtils.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared CJK-context punctuation rules for the composer decoration plugins.
+ *
+ * ASCII punctuation can take the neighboring Latin font during Windows IME
+ * composition, but only punctuation next to CJK text needs the CJK font stack.
+ * Keeping this predicate shared prevents list fallback wrappers and inline
+ * punctuation spans from disagreeing about which ranges they own.
+ */
+const CJK_PUNCT_CHAR_REGEX = /[\u3000-\u303f\uff00-\uffef]/;
+const CJK_SCRIPT_CHAR_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/;
+const ASCII_CJK_PUNCTUATION = new Set([
+  '!',
+  '"',
+  "'",
+  '(',
+  ')',
+  ',',
+  '.',
+  ':',
+  ';',
+  '?',
+  '[',
+  ']',
+  '{',
+  '}',
+]);
+
+function isCjkChar(char: string | undefined): boolean {
+  return (
+    char !== undefined &&
+    (CJK_SCRIPT_CHAR_REGEX.test(char) || CJK_PUNCT_CHAR_REGEX.test(char))
+  );
+}
+
+/**
+ * Tests one character in the full text. The optional range limits which
+ * punctuation characters are selected, while neighbor lookup still sees the
+ * complete text so a list prefix can inherit context from its body.
+ */
+export function isCjkContextPunctuation(
+  text: string,
+  index: number,
+  from = 0,
+  to = text.length,
+): boolean {
+  const char = text[index];
+  if (char === undefined || index < from || index >= to) return false;
+  if (CJK_PUNCT_CHAR_REGEX.test(char)) return true;
+  if (!ASCII_CJK_PUNCTUATION.has(char)) return false;
+
+  const isContextSeparator = (value: string | undefined) =>
+    value !== undefined && (/\s/.test(value) || ASCII_CJK_PUNCTUATION.has(value));
+  let before = index - 1;
+  while (before >= 0 && isContextSeparator(text[before])) before -= 1;
+  if (before >= 0 && isCjkChar(text[before])) return true;
+
+  let after = index + 1;
+  while (after < text.length && isContextSeparator(text[after])) after += 1;
+  return after < text.length && isCjkChar(text[after]);
+}
+
+export function hasCjkContextPunctuation(
+  text: string,
+  from = 0,
+  to = text.length,
+): boolean {
+  for (let index = from; index < to; index += 1) {
+    if (isCjkContextPunctuation(text, index, from, to)) return true;
+  }
+  return false;
+}
+
+export function hasCjkPunctuation(text: string, from = 0, to = text.length): boolean {
+  for (let index = from; index < to; index += 1) {
+    if (CJK_PUNCT_CHAR_REGEX.test(text[index] ?? '')) return true;
+  }
+  return false;
+}

--- a/apps/desktop/src/renderer/components/new-chat/CjkPunctuationUtils.ts
+++ b/apps/desktop/src/renderer/components/new-chat/CjkPunctuationUtils.ts
@@ -69,10 +69,3 @@ export function hasCjkContextPunctuation(
   }
   return false;
 }
-
-export function hasCjkPunctuation(text: string, from = 0, to = text.length): boolean {
-  for (let index = from; index < to; index += 1) {
-    if (CJK_PUNCT_CHAR_REGEX.test(text[index] ?? '')) return true;
-  }
-  return false;
-}

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
@@ -40,6 +40,10 @@ import {
   resolveVoiceInputReplacementRange,
   type VoiceInputReplacementRange,
 } from './VoiceInputDraftDecoration';
+import {
+  hasCjkContextPunctuation,
+  hasCjkPunctuation as hasCjkPunctuationChar,
+} from './CjkPunctuationUtils';
 
 const TAB_SIZE = 8;
 
@@ -56,7 +60,6 @@ const PLUGIN_STATE_KEY = new PluginKey<ListDecorationPluginState>(
 
 /** 行内一个非文本 inline 节点(mention chip 等)的占位符,与 applyListContinuation 一致。 */
 const ATOM_PLACEHOLDER = '\uFFFC';
-const CJK_PUNCTUATION_RE = /[\u3000-\u303f\uff00-\uffef]/;
 // 只有正文整体是一个没有自然断点的数字/字母串时才拆成 marker/body。
 // 普通句子里偶然出现长 token 时，交给 overflow-wrap:anywhere，保留空格
 // 的自然断词行为，避免把整句变成逐字断行。
@@ -217,7 +220,9 @@ export function buildListIndentDecorations(
         voiceReplacementRange !== null &&
         voiceReplacementRange.from < contentBase + line.end &&
         voiceReplacementRange.to > contentBase + line.start;
-      const hasCjkPunctuation = CJK_PUNCTUATION_RE.test(line.text);
+      const hasCjkPunctuation =
+        hasCjkPunctuationChar(line.text, 0, match.prefixLength) ||
+        hasCjkContextPunctuation(line.text, match.prefixLength);
       return (
         line.hasInlineAtom ||
         overlapsSlashCommandPill ||
@@ -249,7 +254,7 @@ export function buildListIndentDecorations(
       const match = compatibilityMatch(line);
       if (!match) {
         if (hasFallbackLine && lines.length > 1 && line.end > line.start) {
-          const hasCjkPunctuation = CJK_PUNCTUATION_RE.test(line.text);
+          const hasCjkPunctuation = hasCjkContextPunctuation(line.text);
           decorations.push(
             Decoration.inline(contentBase + line.start, contentBase + line.end, {
               class: [
@@ -268,7 +273,8 @@ export function buildListIndentDecorations(
       const prefix = line.text.slice(0, match.prefixLength);
       const body = line.text.slice(match.prefixLength);
       const hasTabPrefix = prefix.includes('\t');
-      const prefixHasCjkPunctuation = CJK_PUNCTUATION_RE.test(prefix);
+      const prefixHasCjkPunctuation =
+        match !== null && hasCjkContextPunctuation(line.text, 0, match.prefixLength);
       const lineClass = hasTabPrefix ? 'composer-list-tab-indent' : '';
       if (hasFallbackLine) {
         // The paragraph-level fallback supplies the available line width. The
@@ -324,7 +330,8 @@ export function buildListIndentDecorations(
       const body = line && match ? line.text.slice(match.prefixLength) : '';
       const from = line ? contentBase + line.start : contentBase;
       const hasLongAlphanumericBody = LONG_ALPHANUMERIC_BODY_RE.test(body);
-      const prefixHasCjkPunctuation = CJK_PUNCTUATION_RE.test(prefix);
+      const prefixHasCjkPunctuation =
+        match !== null && hasCjkContextPunctuation(line.text, 0, match.prefixLength);
       const hasTabPrefix = prefix.includes('\t');
       // A node decoration stays on the paragraph even when CjkPunctDecoration
       // adds nested inline spans, so punctuation cannot split the list wrapper.

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListIndentDecoration.ts
@@ -40,10 +40,7 @@ import {
   resolveVoiceInputReplacementRange,
   type VoiceInputReplacementRange,
 } from './VoiceInputDraftDecoration';
-import {
-  hasCjkContextPunctuation,
-  hasCjkPunctuation as hasCjkPunctuationChar,
-} from './CjkPunctuationUtils';
+import { hasCjkContextPunctuation } from './CjkPunctuationUtils';
 
 const TAB_SIZE = 8;
 
@@ -220,9 +217,7 @@ export function buildListIndentDecorations(
         voiceReplacementRange !== null &&
         voiceReplacementRange.from < contentBase + line.end &&
         voiceReplacementRange.to > contentBase + line.start;
-      const hasCjkPunctuation =
-        hasCjkPunctuationChar(line.text, 0, match.prefixLength) ||
-        hasCjkContextPunctuation(line.text, match.prefixLength);
+      const hasCjkPunctuation = hasCjkContextPunctuation(line.text);
       return (
         line.hasInlineAtom ||
         overlapsSlashCommandPill ||

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -463,9 +463,10 @@ html:lang(ko) {
 /* The fallback unindented row must remain one inline-block; character-scoped
    ProseMirror decorations would split it into several full-width fragments.
    The local face covers the same ranges as CjkPunctDecoration, while the
-   bundled faces cover the punctuation glyphs HarmonyOS actually ships. Latin
-   text and digits continue through the configured UI font. Keep the asset
-   names aligned with the exact-pinned font package. */
+   bundled faces cover the punctuation glyphs HarmonyOS actually ships. The
+   ASCII range is punctuation-only, so Latin letters and digits continue
+   through the configured UI font. Keep the asset names aligned with the
+   exact-pinned font package. */
 @font-face {
   font-family: 'Cindy CJK Punctuation Local';
   src:
@@ -478,7 +479,9 @@ html:lang(ko) {
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  unicode-range: U+3000-303F, U+FF00-FFEF;
+  unicode-range:
+    U+0021-0022, U+0027-0029, U+002C, U+002E, U+003A-003B, U+003F, U+005B, U+005D, U+007B, U+007D,
+    U+3000-303F, U+FF00-FFEF;
 }
 @font-face {
   font-family: 'Cindy CJK Punctuation Bundled';
@@ -517,7 +520,9 @@ html:lang(ko) {
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  unicode-range: U+FF04, U+FF0B, U+FF1C-FF1E, U+FF3E, U+FF40, U+FF5C, U+FF5E, U+FFE0-FFE5;
+  unicode-range:
+    U+0021-0022, U+0027-0029, U+002C, U+002E, U+003A-003B, U+003F, U+005B, U+005D, U+007B, U+007D,
+    U+FF04, U+FF0B, U+FF1C-FF1E, U+FF3E, U+FF40, U+FF5C, U+FF5E, U+FFE0-FFE5;
 }
 .ProseMirror .composer-list-cjk-punctuation-font {
   font-family:


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 使用系统自带微软拼音时，输入拼音进入候选预览阶段会让对话框中已有的半角括号、逗号等 ASCII 标点临时改变字形和宽度；候选确认后又恢复。本 PR 在中文语境下稳定这些标点的字体 decoration，并补充输入法 composition 生命周期回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；用户反馈的 Windows 微软拼音输入问题
- 本 PR 包含：中文语境中的 ASCII 标点识别与稳定字体 decoration；composition 前后回归测试；纯英文文本不受影响的回归测试
- 明确不包含：输入法候选窗、文档字符内容或消息正文渲染逻辑调整
- 用户可见变化：Windows 微软拼音候选预览期间，输入框内已有括号、逗号等标点不再发生字形或宽度跳变
- 是否存在 breaking change：无

### UI 变化

- 无静态截图：问题只在 Windows IME composition 候选预览期间出现，已在 Windows dev 客户端实机验证
- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 Typography Rules（保持正文排版与字体表现稳定）；§14.3 Keyboard & IME（对话输入框在 IME composition 期间保持一致的输入交互）。本次只调整现有字体 decoration 的覆盖范围，不新增颜色、布局、动效或主题分支，Light / Dark 共用同一渲染逻辑。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/composerListIndentDecoration.test.ts
结果：37/37 tests passed

pnpm test:unit
结果：通过；Desktop、Mobile 与全部配置为 required 的共享 workspace 单元测试均通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/new-chat/CjkPunctDecoration.ts src/renderer/__tests__/composerListIndentDecoration.test.ts
结果：通过

pnpm check:dco
结果：通过，1 个提交带有效 Signed-off-by

git diff --check
结果：通过
```

### 手工验证

- macOS dev：启动并检查对话输入功能，现有功能无影响
- Windows dev：使用系统自带微软拼音，在已有中文及半角 `()`、`,` 的输入框中进入拼音候选预览并确认候选；标点保持稳定，问题不再复现

### 未执行的验证

- 未分别对 Light / Dark 做独立实机目检；本次不修改颜色、主题 token 或布局，两种模式复用同一字体 decoration 路径

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Composer 渲染层。CJK 标点保持原行为；ASCII 标点仅在同一文本节点中、忽略空白与相邻 ASCII 标点后邻近 CJK 字符时应用稳定字体，普通英文标点运行不变
- 回滚 / 降级方式：回滚本提交即可恢复原有 decoration 范围；不涉及数据迁移、持久化或协议兼容

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及额外文档变更）
- [x] 已确认测试结果或说明未执行原因


## CI 结果
- 最终状态：success
- 检查项：DCO — success — https://probot.github.io/apps/dco/
- 检查项：Desktop Git integration — success — https://github.com/makecindy/cindy/actions/runs/30422133407/job/90480946286
- 检查项：Greptile Review — success — https://greptile.com/
- 检查项：check:pr-design-basis — success — https://github.com/makecindy/cindy/actions/runs/30422133416/job/90480946488
- 检查项：verify — success — https://github.com/makecindy/cindy/actions/runs/30422133407/job/90480946336
- 更新时间：2026-07-29T04:33:24Z