### PR TITLE
fix(desktop): 空输入框全选与删空后不再留幽灵选区

### DIFF
--- a/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
@@ -140,6 +140,7 @@ describe('collapseBlankDocDomSelection', () => {
     rangeCount: number;
     isCollapsed: boolean;
     anchorNode: Node | null;
+    focusNode: Node | null;
     collapse: (node: Node, offset: number) => void;
   }
 
@@ -149,23 +150,34 @@ describe('collapseBlankDocDomSelection', () => {
       docHasText?: boolean;
       selection?: Partial<FakeSelection> | null;
       anchorInside?: boolean;
+      focusInside?: boolean;
     } = {},
   ): { view: BlankDocSelectionView; selection: FakeSelection } {
-    const { composing = false, docHasText = false, anchorInside = true } = overrides;
+    const {
+      composing = false,
+      docHasText = false,
+      anchorInside = true,
+      focusInside = true,
+    } = overrides;
     const editor = makeEditor();
     if (docHasText) editor.commands.insertContent('draft');
     const paragraph = { nodeName: 'P' } as unknown as Node;
     const anchor = { nodeName: '#text' } as unknown as Node;
+    const focus = { nodeName: '#text' } as unknown as Node;
     const selection: FakeSelection = {
       rangeCount: 1,
       isCollapsed: false,
       anchorNode: anchor,
+      focusNode: focus,
       collapse: vi.fn(),
       ...overrides.selection,
     };
+    const inside = new Set<Node>([paragraph]);
+    if (anchorInside) inside.add(anchor);
+    if (focusInside) inside.add(focus);
     const dom = {
       ownerDocument: { getSelection: () => (overrides.selection === null ? null : selection) },
-      contains: (node: Node) => anchorInside && node === anchor,
+      contains: (node: Node) => inside.has(node),
       firstChild: paragraph,
     } as unknown as HTMLElement;
     return {
@@ -198,8 +210,28 @@ describe('collapseBlankDocDomSelection', () => {
     expect(selection.collapse).not.toHaveBeenCalled();
   });
 
-  it('选区不在本 editor 内时不动作(同页多个 composer 互不干扰)', () => {
+  it('anchor 不在本 editor 内时不动作(反向拖选:从外部拖进空输入框)', () => {
     const { view, selection } = makeView({ anchorInside: false });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+
+  it('focus 不在本 editor 内时不动作(从空输入框内起手往外拖选)', () => {
+    // 只校验 anchor 会把这种跨边界选区当成自己的并折叠掉,清掉用户合法的选择
+    // (PR #896 review:copilot + greptile P2)。
+    const { view, selection } = makeView({ focusInside: false });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+
+  it('两端都不在本 editor 内时不动作(同页多个 composer 互不干扰)', () => {
+    const { view, selection } = makeView({ anchorInside: false, focusInside: false });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+
+  it('focusNode 缺失时安全返回', () => {
+    const { view, selection } = makeView({ selection: { focusNode: null } });
     expect(collapseBlankDocDomSelection(view)).toBe(false);
     expect(selection.collapse).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+// (Editor 构造需要 DOM。)
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import HardBreak from '@tiptap/extension-hard-break';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  collapseBlankDocDomSelection,
+  EmptyDocSelectionGuard,
+  isBlankParagraphDoc,
+  normalizeBlankDocSelection,
+  type BlankDocSelectionView,
+} from '@/components/new-chat/EmptyDocSelectionGuard';
+import { ComposerBulletList, ComposerListItem } from '@/components/new-chat/ComposerListNodes';
+import { MentionChipNode } from '@/components/new-chat/MentionChipNode';
+
+// Editor 必须逐个 destroy:EditorView 的异步回调会在 jsdom 环境拆除后触发
+// `document is not defined` 未处理异常,vitest 全绿也会 exit 1(CI 实撞)。
+const editors: Editor[] = [];
+afterEach(() => {
+  for (const editor of editors.splice(0)) editor.destroy();
+});
+
+function makeEditor(options: { guard?: boolean } = {}): Editor {
+  const { guard = true } = options;
+  const editor = new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      HardBreak,
+      ComposerListItem,
+      ComposerBulletList,
+      MentionChipNode,
+      ...(guard ? [EmptyDocSelectionGuard] : []),
+    ],
+    content: { type: 'doc', content: [{ type: 'paragraph', content: [] }] },
+  });
+  editors.push(editor);
+  return editor;
+}
+
+describe('isBlankParagraphDoc', () => {
+  it('只把单个空 paragraph 认作真空', () => {
+    expect(isBlankParagraphDoc(makeEditor().state.doc)).toBe(true);
+  });
+
+  it('有文本时不是真空', () => {
+    const editor = makeEditor();
+    editor.commands.insertContent('draft');
+    expect(isBlankParagraphDoc(editor.state.doc)).toBe(false);
+  });
+
+  it('多个空段落不是真空(Shift+Enter 敲出的空行是真实内容)', () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: 'doc',
+      content: [{ type: 'paragraph' }, { type: 'paragraph' }],
+    });
+    expect(isBlankParagraphDoc(editor.state.doc)).toBe(false);
+  });
+
+  it('只含 atom chip 的草稿不是真空(chip 没有文本投影)', () => {
+    const editor = makeEditor();
+    editor.commands.insertContent({
+      type: 'mentionChip',
+      attrs: { kind: 'file', label: 'main.ts', path: 'src/main.ts' },
+    });
+    expect(editor.state.doc.textContent).toBe('');
+    expect(isBlankParagraphDoc(editor.state.doc)).toBe(false);
+  });
+
+  it('空列表项不是真空', () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: 'doc',
+      content: [
+        { type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }] },
+      ],
+    });
+    expect(isBlankParagraphDoc(editor.state.doc)).toBe(false);
+  });
+});
+
+describe('normalizeBlankDocSelection', () => {
+  it('真空文档的全选被折叠成光标', () => {
+    const editor = makeEditor();
+    editor.commands.selectAll();
+    expect(editor.state.selection.empty).toBe(true);
+    expect(editor.state.selection.from).toBe(1);
+  });
+
+  it('没有 guard 时全选会框住整个空段落(回归基线)', () => {
+    // 这就是幽灵高亮的来源:AllSelection(0..2) 把空 paragraph 节点整体框进选区,
+    // Chromium 于是在行首画出一块可见高亮。
+    const editor = makeEditor({ guard: false });
+    editor.commands.selectAll();
+    expect(editor.state.selection.empty).toBe(false);
+    expect(editor.state.selection.from).toBe(0);
+    expect(editor.state.selection.to).toBe(2);
+  });
+
+  it('有内容时全选照旧生效', () => {
+    const editor = makeEditor();
+    editor.commands.insertContent('hello');
+    editor.commands.selectAll();
+    expect(editor.state.selection.empty).toBe(false);
+  });
+
+  it('多个空段落全选照旧生效', () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: 'doc',
+      content: [{ type: 'paragraph' }, { type: 'paragraph' }],
+    });
+    editor.commands.selectAll();
+    expect(editor.state.selection.empty).toBe(false);
+  });
+
+  it('全选后删空,状态层落在折叠光标上', () => {
+    const editor = makeEditor();
+    editor.commands.insertContent('123');
+    editor.commands.selectAll();
+    editor.commands.deleteSelection();
+    expect(editor.state.doc.textContent).toBe('');
+    expect(editor.state.selection.empty).toBe(true);
+  });
+
+  it('选区本就折叠时不产生多余 transaction', () => {
+    const editor = makeEditor();
+    expect(normalizeBlankDocSelection(editor.state)).toBeNull();
+  });
+});
+
+describe('collapseBlankDocDomSelection', () => {
+  interface FakeSelection {
+    rangeCount: number;
+    isCollapsed: boolean;
+    anchorNode: Node | null;
+    collapse: (node: Node, offset: number) => void;
+  }
+
+  function makeView(
+    overrides: {
+      composing?: boolean;
+      docHasText?: boolean;
+      selection?: Partial<FakeSelection> | null;
+      anchorInside?: boolean;
+    } = {},
+  ): { view: BlankDocSelectionView; selection: FakeSelection } {
+    const { composing = false, docHasText = false, anchorInside = true } = overrides;
+    const editor = makeEditor();
+    if (docHasText) editor.commands.insertContent('draft');
+    const paragraph = { nodeName: 'P' } as unknown as Node;
+    const anchor = { nodeName: '#text' } as unknown as Node;
+    const selection: FakeSelection = {
+      rangeCount: 1,
+      isCollapsed: false,
+      anchorNode: anchor,
+      collapse: vi.fn(),
+      ...overrides.selection,
+    };
+    const dom = {
+      ownerDocument: { getSelection: () => (overrides.selection === null ? null : selection) },
+      contains: (node: Node) => anchorInside && node === anchor,
+      firstChild: paragraph,
+    } as unknown as HTMLElement;
+    return {
+      view: { composing, dom, state: { doc: editor.state.doc } },
+      selection,
+    };
+  }
+
+  it('真空文档 + 跨节点 DOM 选区 → 折叠到段落起点', () => {
+    const { view, selection } = makeView();
+    expect(collapseBlankDocDomSelection(view)).toBe(true);
+    expect(selection.collapse).toHaveBeenCalledWith(view.dom.firstChild, 0);
+  });
+
+  it('DOM 选区已折叠时不动作(收敛性:第二轮直接返回)', () => {
+    const { view, selection } = makeView({ selection: { isCollapsed: true } });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+
+  it('文档非真空时不动作', () => {
+    const { view, selection } = makeView({ docHasText: true });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+
+  it('IME 组字期间不介入', () => {
+    const { view, selection } = makeView({ composing: true });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+
+  it('选区不在本 editor 内时不动作(同页多个 composer 互不干扰)', () => {
+    const { view, selection } = makeView({ anchorInside: false });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+
+  it('没有 selection 对象时安全返回', () => {
+    const { view } = makeView({ selection: null });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+  });
+
+  it('rangeCount 为 0 时不动作', () => {
+    const { view, selection } = makeView({ selection: { rangeCount: 0 } });
+    expect(collapseBlankDocDomSelection(view)).toBe(false);
+    expect(selection.collapse).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
@@ -54,7 +54,9 @@ describe('isBlankParagraphDoc', () => {
     expect(isBlankParagraphDoc(editor.state.doc)).toBe(false);
   });
 
-  it('多个空段落不是真空(Shift+Enter 敲出的空行是真实内容)', () => {
+  // 多段落来自引用回填 / 历史草稿等程序化构造与多段粘贴;Shift/Alt/Mod+Enter 是
+  // hardBreak(留在同一 paragraph 内),plain Enter 是发送,都不产生新段落。
+  it('多个空段落不是真空(多段结构本身是真实内容)', () => {
     const editor = makeEditor();
     editor.commands.setContent({
       type: 'doc',

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -41,6 +41,7 @@ import {
   promoteTrailingPlainListParagraph,
 } from './ComposerListNodes';
 import { WindowsSelectionReplacement } from './WindowsSelectionReplacement';
+import { EmptyDocSelectionGuard } from './EmptyDocSelectionGuard';
 import {
   setVoiceInputDraftDecoration,
   VoiceInputDraftDecoration,
@@ -1385,6 +1386,9 @@ export function ChatInput({
       WindowsSelectionReplacement.configure({
         enabled: window.electronAPI.platform === 'win32',
       }),
+      // 空输入框全选 / 全选后删空都会在行首留一块幽灵高亮(空 paragraph 被整体框进
+      // AllSelection,删空后 Chromium 的 DOM selection 也不跟着折叠)。见模块头注释。
+      EmptyDocSelectionGuard,
       CjkPunctDecoration,
       ComposerListIndentDecoration,
       VoiceInputDraftDecoration,

--- a/apps/desktop/src/renderer/components/new-chat/EmptyDocSelectionGuard.ts
+++ b/apps/desktop/src/renderer/components/new-chat/EmptyDocSelectionGuard.ts
@@ -52,9 +52,11 @@ export interface BlankDocSelectionView {
 /**
  * DOM 层兜底：文档已是真空、PM 状态层也已折叠，但浏览器仍持有跨节点选区时把它折叠掉。
  *
- * 只在选区确实落在本 editor 内时动手（同页可能有多个 composer，anchor 归属检查让它们
- * 互不干扰）。IME 组字期间一律不介入 —— 组字的 DOM selection 归 ProseMirror 的原生
- * composition 生命周期所有。
+ * 只在选区**两端**都落在本 editor 内时动手。只校验 anchor 不够：从空输入框内起手往外
+ * 拖选时 anchor 在 editor 内、focus 在外，折叠会清掉用户合法的跨边界选区（反向拖选时
+ * anchor 已在 editor 外，本来就不会命中）。两端都查同时也让同页多个 composer 互不干扰。
+ * IME 组字期间一律不介入 —— 组字的 DOM selection 归 ProseMirror 的原生 composition
+ * 生命周期所有。
  *
  * 收敛性：`collapse()` 触发的 selectionchange 会被 PM 的 DOMObserver 读回并 dispatch，
  * 下一轮进来时 DOM 已折叠，直接返回 false。
@@ -64,8 +66,15 @@ export function collapseBlankDocDomSelection(view: BlankDocSelectionView): boole
   if (!isBlankParagraphDoc(view.state.doc)) return false;
   const selection = view.dom.ownerDocument?.getSelection?.() ?? null;
   if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return false;
-  const anchor = selection.anchorNode;
-  if (!anchor || !view.dom.contains(anchor)) return false;
+  const { anchorNode, focusNode } = selection;
+  if (
+    !anchorNode ||
+    !focusNode ||
+    !view.dom.contains(anchorNode) ||
+    !view.dom.contains(focusNode)
+  ) {
+    return false;
+  }
   const paragraph = view.dom.firstChild;
   if (!paragraph) return false;
   selection.collapse(paragraph, 0);

--- a/apps/desktop/src/renderer/components/new-chat/EmptyDocSelectionGuard.ts
+++ b/apps/desktop/src/renderer/components/new-chat/EmptyDocSelectionGuard.ts
@@ -1,0 +1,94 @@
+/**
+ * EmptyDocSelectionGuard —— 空输入框不留可见选区。
+ *
+ * Tiptap 的「空」文档不是空字符串，而是 `doc(paragraph())`，`content.size === 2`。
+ * `Cmd+A` 走 baseKeymap 的 selectAll 得到 `AllSelection(0..2)`：它把那个空段落节点
+ * 整体框进选区，Chromium 于是在行首画出一块约半字宽、一行高的高亮。原生 `<textarea>`
+ * 空的时候全选什么都选不到，两者观感不一致。
+ *
+ * 实测（隔离沙箱 + DOM 探针）确认要治两层，缺一层都不够：
+ *
+ * - 空框按 `Cmd+A`：PM 状态层是非空的 `AllSelection`，DOM 层 `anchor=DIV:0 → focus=DIV:1`
+ *   （选中 `.ProseMirror` 的整个 `<p>`）。→ 靠 `appendTransaction` 归一化成折叠光标。
+ * - 输入文字后全选再删除：`AllSelection.replace()` 已把 PM 状态层折叠到 `TextSelection(1,1)`，
+ *   **但 Chromium 的 DOM selection 仍跨着节点**（`collapsed=false`，rect `910x22`），高亮留在屏上。
+ *   → 靠 view 层兜底折叠 DOM selection。
+ *
+ * 两层互相需要：只折叠 DOM 而把 `AllSelection` 留在状态层，PM 下一次 `selectionToDOM`
+ * 会把它重新写回 DOM，高亮复现。
+ *
+ * 只认「单个空 paragraph」这一种真空形态，其余一律不介入：多个空段落（Shift+Enter 敲出的
+ * 空行）、只含 atom chip 的草稿、结构化列表都带着真实内容，选中它们是合理的。
+ */
+import { Extension } from '@tiptap/core';
+import { Plugin, TextSelection } from '@tiptap/pm/state';
+import type { EditorState, Transaction } from '@tiptap/pm/state';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+
+/** 文档是否为「真空」——只有一个空 paragraph，没有文本也没有 atom chip。 */
+export function isBlankParagraphDoc(doc: ProseMirrorNode): boolean {
+  if (doc.childCount !== 1) return false;
+  const only = doc.firstChild;
+  return only !== null && only.type.name === 'paragraph' && only.content.size === 0;
+}
+
+/**
+ * 真空文档上的非空选区（`Cmd+A` / 菜单「编辑 → 全选」得到的 `AllSelection`）归一化为
+ * 段落内的折叠光标。非真空文档或选区本就折叠时返回 null（不产生多余 transaction）。
+ */
+export function normalizeBlankDocSelection(state: EditorState): Transaction | null {
+  if (!isBlankParagraphDoc(state.doc)) return null;
+  if (state.selection.empty) return null;
+  return state.tr.setSelection(TextSelection.create(state.doc, 1));
+}
+
+/** `collapseBlankDocDomSelection` 用到的最小 view 投影 —— 便于单测注入假对象。 */
+export interface BlankDocSelectionView {
+  readonly composing: boolean;
+  readonly dom: HTMLElement;
+  readonly state: { readonly doc: ProseMirrorNode };
+}
+
+/**
+ * DOM 层兜底：文档已是真空、PM 状态层也已折叠，但浏览器仍持有跨节点选区时把它折叠掉。
+ *
+ * 只在选区确实落在本 editor 内时动手（同页可能有多个 composer，anchor 归属检查让它们
+ * 互不干扰）。IME 组字期间一律不介入 —— 组字的 DOM selection 归 ProseMirror 的原生
+ * composition 生命周期所有。
+ *
+ * 收敛性：`collapse()` 触发的 selectionchange 会被 PM 的 DOMObserver 读回并 dispatch，
+ * 下一轮进来时 DOM 已折叠，直接返回 false。
+ */
+export function collapseBlankDocDomSelection(view: BlankDocSelectionView): boolean {
+  if (view.composing) return false;
+  if (!isBlankParagraphDoc(view.state.doc)) return false;
+  const selection = view.dom.ownerDocument?.getSelection?.() ?? null;
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return false;
+  const anchor = selection.anchorNode;
+  if (!anchor || !view.dom.contains(anchor)) return false;
+  const paragraph = view.dom.firstChild;
+  if (!paragraph) return false;
+  selection.collapse(paragraph, 0);
+  return true;
+}
+
+/** 供 ChatInput 与单测共享的 plugin 工厂。 */
+export function createEmptyDocSelectionGuardPlugin(): Plugin {
+  return new Plugin({
+    appendTransaction: (_transactions, _oldState, newState) => normalizeBlankDocSelection(newState),
+    view: (view) => ({
+      update: () => {
+        collapseBlankDocDomSelection(view);
+      },
+    }),
+  });
+}
+
+/** 空 composer 幽灵选区守卫。 */
+export const EmptyDocSelectionGuard = Extension.create({
+  name: 'emptyDocSelectionGuard',
+
+  addProseMirrorPlugins() {
+    return [createEmptyDocSelectionGuardPlugin()];
+  },
+});

--- a/apps/desktop/src/renderer/components/new-chat/EmptyDocSelectionGuard.ts
+++ b/apps/desktop/src/renderer/components/new-chat/EmptyDocSelectionGuard.ts
@@ -17,8 +17,12 @@
  * 两层互相需要：只折叠 DOM 而把 `AllSelection` 留在状态层，PM 下一次 `selectionToDOM`
  * 会把它重新写回 DOM，高亮复现。
  *
- * 只认「单个空 paragraph」这一种真空形态，其余一律不介入：多个空段落（Shift+Enter 敲出的
- * 空行）、只含 atom chip 的草稿、结构化列表都带着真实内容，选中它们是合理的。
+ * 只认「单个空 paragraph」这一种真空形态，其余一律不介入：多个空段落、只含 atom chip 的
+ * 草稿、结构化列表都带着真实内容，选中它们是合理的。
+ *
+ * 多段落文档在本 composer 里来自程序化构造（引用回填、历史草稿等，见
+ * `lib/composerQuoteDocument.ts`）与多段粘贴，**不是**敲键敲出来的：Shift / Alt / Mod+Enter
+ * 都是 hardBreak（`<br>` 留在同一个 paragraph 内），plain Enter 是发送。
  */
 import { Extension } from '@tiptap/core';
 import { Plugin, TextSelection } from '@tiptap/pm/state';


### PR DESCRIPTION
## 这次改了什么

### 摘要

空输入框按 `Cmd+A`，行首会出现一块约半字宽、一行高的高亮，像选中了什么不可见的东西；输入文字后全选再删除，同一块高亮也会残留在空框里。

根因是 Tiptap 的「空」文档不是空字符串，而是 `doc(paragraph())`、`content.size === 2`。`Cmd+A` 走 baseKeymap 的 `selectAll` 得到 `AllSelection(0..2)`，把那个空段落节点整体框进选区，Chromium 于是按内容宽度画出一块可见高亮（`ProseMirror-trailingBreak` 那个 `<br>`）。原生 `<textarea>` 空的时候全选选不到任何东西，两者观感不一致。

新增 `EmptyDocSelectionGuard` 处理两层，缺一层都不够：

1. `appendTransaction` 把真空文档上的非空选区归一化成折叠光标 —— 治空框 `Cmd+A`，也覆盖菜单「编辑 → 全选」（走原生 `selectAll`，不经过 keymap）。
2. plugin view 的 `update` 兜底折叠 DOM selection —— 治全选后删空。`AllSelection.replace()` 已经把 PM 状态层折叠到 `TextSelection(1,1)`，但 Chromium 的 DOM selection 仍跨着节点（`anchor=DIV:0 → focus=DIV:1`，`collapsed=false`），只做第 1 层治不了它。

两层互相需要：只折叠 DOM 而把 `AllSelection` 留在状态层，PM 下一次 `selectionToDOM` 会把它重新写回 DOM，高亮复现。

只认「单个空 paragraph」这一种真空形态，其余一律不介入：多个空段落、只含 atom chip 的草稿、结构化列表都带着真实内容，全选它们是合理的。多段落文档在本 composer 里来自程序化构造（引用回填、历史草稿，见 `lib/composerQuoteDocument.ts`）与多段粘贴，不是敲键敲出来的 —— Shift / Alt / Mod+Enter 都是 hardBreak（`<br>` 留在同一 paragraph 内），plain Enter 是发送。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（使用中发现并当面报告）
- 本 PR 包含：新增 `EmptyDocSelectionGuard` extension、在 `ChatInput` 的 extensions 列表接入、18 例单测
- 明确不包含：全选删空后 `<p>` 上 `is-editor-empty` 类未恢复、导致 placeholder 不回来的既有问题（与本次改动无关，修复前后日志一致，另开 PR）
- 用户可见变化：空输入框全选不再出现行首幽灵高亮；全选后删空不再残留高亮；有内容时的全选行为完全不变
- 是否存在 breaking change：无

### UI 变化

未附截图：现有对比材料是用户在本机沙箱里的界面截图，按仓库的公开写入约定不擅自上传；改动的可见效果就是「那块高亮消失」，下方以 DOM 探针的客观数据呈现，需要截图可以补。

同一探针、同样两组动作，修复前后对比：

| 时刻 | 修复前 | 修复后 |
| --- | --- | --- |
| 空框 `Cmd+A` | `collapsed=false` `rects=1[910x22]` | `collapsed=true` `rects=0[]` |
| 全选后删空 | `collapsed=false` `rects=1[910x22]` | `collapsed=true` `rects=0[]` |
| 有内容时全选 | `rects=2[687x22,19x18]` | `rects=2[687x22,19x18]`（未受影响） |

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Component Stylings / Inputs & Forms —— 输入框的 fill / border / radius / placeholder token 一处未改，本次只消除一个非预期的选区绘制产物，让空输入框回到「read as clearly empty」的状态。`docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate —— 本改动零新增样式与颜色，没有 `::selection` 之类的自定义绘制，选区高亮全部由浏览器按系统色绘制，因此两种模式表现同源；按该节要求如实说明：实机只在 Light 下目检过，Dark 未目检。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/emptyDocSelectionGuard.test.ts
结果：18 passed (18)

pnpm test:unit（经 run-unit-gate.sh 串行门禁）
结果：GATE_EXIT=0；PASS apps/desktop unit (58.4s)、PASS apps/mobile unit (11.5s)，全 workspace 无 FAIL

pnpm --filter desktop typecheck
结果：通过（无输出）

eslint src/renderer/components/new-chat/EmptyDocSelectionGuard.ts src/renderer/__tests__/emptyDocSelectionGuard.test.ts src/renderer/components/new-chat/ChatInput.tsx
结果：无告警

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

单测里保留了一条「没有 guard 时」的回归基线：不挂 extension 时全选空文档得到 `from=0 to=2` 的非空选区，锁住这次修的正是这个现象。

### 手工验证

隔离沙箱开发版（`pnpm restart:desktop:remote --region=global --isolated=selprobe`，独立 userData，不碰共享数据库），macOS，Light 模式。为取证临时挂了一个只读 DOM 探针（记录 `window.getSelection()` 的 `collapsed` / `rangeCount` / rect 与 `.ProseMirror` 的 innerHTML），定性完成后已整文件删除，不在本 PR diff 里。

覆盖三组操作：

1. 空框 `Cmd+A`
2. 输入 `23` → `Cmd+A` → `Backspace`
3. 输入含 `$taptap-maker` pill 的 26 字符内容 → `Cmd+A` → `Backspace` → 再多按一次 `Backspace`

结果：前两组的残留高亮消失（见上表）；第 3 组全选 `rects=4[...]` 正常、删空后 `collapsed=true`、多按一次 Backspace 无副作用；每次操作只产生 2–3 条 selectionchange，没有 collapse 与 DOMObserver 互相触发的循环。

### 未执行的验证

- Dark 模式未做实机目检。本改动零新增颜色与样式、选区由浏览器原生绘制，预期两模式同源，但按双模式门槛不把这一点算作「已验证」。
- Windows 未实机验证：该平台另有 `WindowsSelectionReplacement` 处理 trailing break 旁的选区错报，本 guard 与它互不重叠（一个管 beforeinput 插入替换，一个管空文档选区折叠）。
- mobile 不涉及（改动只在 `apps/desktop/src/renderer`）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop 聊天输入框（`ChatInput` 是仓库里唯一的 tiptap 编辑器实例）在「文档为单个空 paragraph」时的选区行为。文档非空时两条路径都直接返回，不产生 transaction、不碰 DOM。
- 回滚 / 降级方式：revert 本 commit；或只从 `ChatInput` 的 extensions 列表里移掉 `EmptyDocSelectionGuard` 一行即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（行为契约与取证结论写在 `EmptyDocSelectionGuard.ts` 模块头注释里，无需额外文档）
- [x] 已确认测试结果或说明未执行原因

