### PR TITLE
fix(desktop): 让问答卡中的链接可点击

### DIFF
--- a/apps/desktop/src/renderer/__tests__/askUserQuestionLinks.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionLinks.test.tsx
@@ -75,4 +75,39 @@ describe('AskUserQuestionPrompt question links', () => {
 
     await waitFor(() => expect(openExternal).toHaveBeenCalledWith(url));
   });
+
+  it('resets link-local menu state when the wizard advances to a different URL', async () => {
+    const nextUrl = 'https://example.com/base?table=tbl456';
+    render(
+      <AskUserQuestionPrompt
+        sessionId="session-a"
+        pending={{
+          requestId: 'req-link-steps',
+          questions: [
+            {
+              question: url,
+              options: [{ label: '继续' }],
+            },
+            {
+              question: nextUrl,
+              options: [{ label: '完成' }],
+            },
+          ],
+        }}
+        onAnswer={vi.fn()}
+        viewerState="expanded"
+        onViewerStateChange={vi.fn()}
+        draft={null}
+        onDraftChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('link', { name: url }));
+    expect(screen.getByText('chat.markdownRenderer.copyLink')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('继续').closest('button')!);
+
+    await waitFor(() => expect(screen.getByRole('link', { name: nextUrl })).toBeTruthy());
+    expect(screen.queryByText('chat.markdownRenderer.copyLink')).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionLinks.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionLinks.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <>{children}</> : null,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuItem: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/features/right-sidebar/lib/openInSidebarBrowser', () => ({
+  openUrlInSidebarBrowser: vi.fn(async () => undefined),
+  pathToFileUrl: (path: string) => `file://${path}`,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { AskUserQuestionPrompt } from '../components/new-chat/AskUserQuestionPrompt';
+
+const url = 'https://example.com/base?table=tbl123';
+const openExternal = vi.fn(async () => ({ success: true }));
+
+beforeEach(() => {
+  openExternal.mockClear();
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: { openExternal },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AskUserQuestionPrompt question links', () => {
+  it('opens an http URL from the question text', async () => {
+    render(
+      <AskUserQuestionPrompt
+        pending={{
+          requestId: 'req-link',
+          questions: [
+            {
+              question: `请打开项目 Base (${url}), 进入“高级权限”。`,
+              options: [{ label: '我现在检查' }],
+            },
+          ],
+        }}
+        onAnswer={vi.fn()}
+        viewerState="expanded"
+        onViewerStateChange={vi.fn()}
+        draft={null}
+        onDraftChange={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: url });
+    expect(link.getAttribute('href')).toBe(url);
+
+    fireEvent.click(link);
+
+    await waitFor(() => expect(openExternal).toHaveBeenCalledWith(url));
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -21,6 +21,8 @@ import {
   type TextareaHTMLAttributes,
 } from 'react';
 
+import { UserMessageUrlLink } from '@/components/chat/UserMessageUrlLink';
+import { findLinkifyMatches } from '@/components/chat/userMessageLinkify';
 import { InteractionPromptCardShell } from '@/components/interaction-portal';
 import { useAutoResize } from '@/hooks/useAutoResize';
 import { cn } from '@/lib/utils';
@@ -60,11 +62,36 @@ function AutoGrowingAnswerTextarea({
   );
 }
 
+/** Preserve plain question text while making its http(s) URLs actionable. */
+function QuestionTextWithLinks({ text, sessionId }: { text: string; sessionId?: string }) {
+  const result: React.ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of findLinkifyMatches(text)) {
+    if (match.kind !== 'url') continue;
+    if (match.index > lastIndex) result.push(text.slice(lastIndex, match.index));
+    result.push(
+      <UserMessageUrlLink
+        key={`question-url-${match.index}`}
+        url={match.text}
+        sessionId={sessionId}
+      />,
+    );
+    lastIndex = match.index + match.length;
+  }
+
+  if (lastIndex === 0) return text;
+  if (lastIndex < text.length) result.push(text.slice(lastIndex));
+  return <>{result}</>;
+}
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
 interface AskUserQuestionPromptProps {
+  /** Current session; lets question links honor the configured opening preference. */
+  sessionId?: string;
   pending: PendingAskUser;
   onAnswer: (requestId: string, answers: Record<string, string>) => void;
   /**
@@ -98,6 +125,7 @@ interface AskUserQuestionPromptProps {
 // ---------------------------------------------------------------------------
 
 export function AskUserQuestionPrompt({
+  sessionId,
   pending,
   onAnswer,
   viewerState,
@@ -533,8 +561,10 @@ export function AskUserQuestionPrompt({
         {/* Question Row (header chip moved to top header bar above) */}
         <div className="flex flex-col gap-[8px]">
           <div className="flex items-center justify-between">
-            <span className="text-15 font-medium text-[var(--ask-header-text)]">
-              {currentQ?.question}
+            <span className="text-15 font-medium text-[var(--ask-header-text)] [overflow-wrap:anywhere]">
+              {currentQ?.question ? (
+                <QuestionTextWithLinks text={currentQ.question} sessionId={sessionId} />
+              ) : null}
             </span>
             {pageIndicator && (
               <span className="ml-4 shrink-0 text-13 text-[var(--ask-page-text)]">

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -72,7 +72,7 @@ function QuestionTextWithLinks({ text, sessionId }: { text: string; sessionId?: 
     if (match.index > lastIndex) result.push(text.slice(lastIndex, match.index));
     result.push(
       <UserMessageUrlLink
-        key={`question-url-${match.index}`}
+        key={`question-url-${match.index}-${match.text}`}
         url={match.text}
         sessionId={sessionId}
       />,

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3137,6 +3137,7 @@ export function CCAgentSessionView({
                   />
                 ) : pendingAskUser ? (
                   <AskUserQuestionPrompt
+                    sessionId={sessionId}
                     pending={pendingAskUser}
                     onAnswer={answerUserQuestion}
                     viewerState={askUserViewerState}


### PR DESCRIPTION
## 这次改了什么

### 摘要

AskUserQuestion 卡片的问题文本原本始终按纯文本渲染，里面的 `http://` / `https://` URL 无法点击。本 PR 复用用户消息已有的 URL 边界识别与安全打开组件，把问题文本中的 Web URL 渲染为链接，并传入当前会话以遵循用户的链接打开偏好。

同时补充回归测试，覆盖括号包裹、带 query 的 URL 以及点击打开行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈的 AskUserQuestion 问题链接无法点击
- 本 PR 包含：问题文本中的 `http(s)` URL 识别、可点击渲染、会话链接打开偏好接线、回归测试
- 明确不包含：Markdown 链接语法、Cindy 深链、图片路径或其他协议的渲染扩展
- 用户可见变化：问答卡问题文本中的 Web URL 可直接点击；超长 URL 可在卡片内断行
- 是否存在 breaking change：无

### UI 变化

- 修复前：问题文本中的 URL 与普通文字相同，无法点击（原始复现截图由反馈者提供，未提交包含个人会话信息的截图）
- 修复后：URL 使用现有 `--msg-link` 语义色并支持 hover 下划线，点击按当前会话偏好打开
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light/Dark 与语义色——复用现有 `--msg-link` token，不新增硬编码颜色；§14.1 可选择内容——保留问题文本的原始顺序和纯文本片段，仅将 URL 转为原生可聚焦链接。交互复用现有 `UserMessageUrlLink`，不新增视觉模式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/askUserQuestionLinks.test.tsx
结果：1 个文件、1 个测试通过；实现前同一测试因找不到 link 失败。

pnpm --filter desktop exec vitest run src/renderer/__tests__/askUserQuestionLinks.test.tsx src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx src/renderer/__tests__/imeEnterCompositionGuard.test.tsx src/renderer/components/chat/__tests__/UserMessageUrlLink.test.tsx src/renderer/components/chat/__tests__/userMessageLinkify.test.ts
结果：5 个文件、42 个测试通过。

env GIT_CONFIG_GLOBAL=/dev/null pnpm test:unit
结果：runner 302 通过、1 跳过；所有可运行 workspace unit tier 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm exec eslint apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx apps/desktop/src/renderer/__tests__/askUserQuestionLinks.test.tsx
结果：通过。

pnpm check:dco --base upstream/main
结果：1 个提交通过 DCO 校验。

git diff --check
结果：通过。
```

### 手工验证

未启动 Desktop GUI。用户提供的截图已确认修复前复现路径；DOM 回归测试验证修复后存在可访问链接并触发既有外链打开 API。

### 未执行的验证

未做 Desktop 可见界面截图：当前为隔离 worktree，避免接管或干扰用户正在使用的 Cindy；改动复用既有链接样式与交互，完整单测、类型检查和 ESLint 已通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop AskUserQuestion 卡片的问题标题。只识别 `http://` / `https://`，并复用现有 renderer 链接组件和 main-process 协议校验；没有新增 IPC、权限或数据读写。
- 回滚 / 降级方式：revert 本 PR 提交即可恢复纯文本渲染。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需文档变更：行为与既有用户消息链接一致）
- [x] 已确认测试结果或说明未执行原因