### PR TITLE
fix(model-providers): DeepSeek 预设补厂商确认的 1M contextWindow

### DIFF
--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -193,7 +193,8 @@
             },
             {
               "id": "deepseek/deepseek-v4-pro",
-              "name": "DeepSeek V4 Pro (OpenRouter)"
+              "name": "DeepSeek V4 Pro (OpenRouter)",
+              "contextWindow": 1000000
             }
           ]
         },
@@ -222,11 +223,13 @@
           "models": [
             {
               "id": "deepseek-v4-flash",
-              "name": "DeepSeek V4 Flash"
+              "name": "DeepSeek V4 Flash",
+              "contextWindow": 1000000
             },
             {
               "id": "deepseek-v4-pro",
-              "name": "DeepSeek V4 Pro"
+              "name": "DeepSeek V4 Pro",
+              "contextWindow": 1000000
             }
           ],
           "modelsUrl": "https://api.deepseek.com/models"
@@ -237,11 +240,13 @@
           "models": [
             {
               "id": "deepseek-v4-flash",
-              "name": "DeepSeek V4 Flash"
+              "name": "DeepSeek V4 Flash",
+              "contextWindow": 1000000
             },
             {
               "id": "deepseek-v4-pro",
-              "name": "DeepSeek V4 Pro"
+              "name": "DeepSeek V4 Pro",
+              "contextWindow": 1000000
             }
           ],
           "modelsUrl": "https://api.deepseek.com/models"

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -147,6 +147,26 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     expect(presets.map((p) => p.id)).toContain('openrouter');
   });
 
+  it('DeepSeek 预设携带厂商文档确认的 1M contextWindow (#735)', () => {
+    // 官方 V4 起全线 1M(api-docs.deepseek.com news260424);预设不带时
+    // buildUserProvider 回落 200K 保守默认,长上下文模型被错误降级。
+    const presets = BUNDLED_CATALOG.presets ?? [];
+    const deepseek = presets.find((p) => p.id === 'deepseek');
+    expect(deepseek).toBeDefined();
+    for (const [agent, rt] of Object.entries(deepseek!.runtimes)) {
+      for (const id of ['deepseek-v4-flash', 'deepseek-v4-pro']) {
+        const m = rt!.models.find((x) => x.id === id);
+        expect(m?.contextWindow, `${agent}/${id}`).toBe(1_000_000);
+      }
+    }
+    // OpenRouter 托管的同款模型页面同样标注 1,048,576,取与仓库口径一致的 1M。
+    const openrouter = presets.find((p) => p.id === 'openrouter');
+    expect(
+      openrouter?.runtimes['claude-code']?.models.find((m) => m.id === 'deepseek/deepseek-v4-pro')
+        ?.contextWindow,
+    ).toBe(1_000_000);
+  });
+
   it('ships Codex support metadata for the current XD gateway model set', () => {
     const metadata = BUNDLED_CATALOG.cindyModelMeta as {
       version?: unknown;


### PR DESCRIPTION
## 这次改了什么

### 摘要

自定义供应商预设里的 DeepSeek 模型没带 `contextWindow`,`buildUserProvider` 回落 200K 保守默认,导致通过预设接入 DeepSeek 的用户实际可用上下文被钉在 200K(#735)。而链路其余环节本来就尊重目录值:catalog → `XDT_MAKER_MODEL_CONTEXT_WINDOWS` env 透传 + claude-code translator 的 configured-window override,设置向导也会把预设的 `contextWindow` 拷进用户配置(`AddProviderWizard.tsx`)。缺的只是预设数据本身。

按厂商文档补上:DeepSeek 官方预设的 `deepseek-v4-pro` / `deepseek-v4-flash`(claude-code 与 codex 两个 runtime)与 OpenRouter 预设的 `deepseek/deepseek-v4-pro` 补 `contextWindow: 1000000`。依据:DeepSeek 官方 API 文档(api-docs.deepseek.com news260424)声明 V4 起官方服务全线 1M 上下文、384K max output;OpenRouter 模型页标注 1,048,576(取与仓库既有条目一致的 1000000 口径)。

**有意不动**:opencode-go 等第三方聚合网关的同名模型——第三方托管可能收窄窗口(如 Together 只放 512K),无法确认放通完整 1M,错标比保守默认更糟。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:fix #735
- 本 PR 包含:`packages/model-providers/catalog/providers.json` 预设数据(5 处 `contextWindow`)+ 钉住预设值的测试
- 明确不包含:表单新增 contextWindow 输入项(UI 改动,#847 的诉求);opencode-go 等第三方网关预设;`DEFAULT_CUSTOM_CONTEXT_WINDOW` 默认值调整
- 用户可见变化:通过预设**新建**的 DeepSeek 供应商,模型上下文窗口为 1M(auto-compact / memory-flush 阈值随之正确)
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

- `pnpm --filter @cindy/model-providers test`:302 passed(含新增预设值断言)
- `pnpm --filter @cindy/model-providers run typecheck`:通过
- 仓库根 `pnpm test:unit`:通过(exit 0)

### 已知限制

- 预设是快照语义(override 不回写):**已创建**的 DeepSeek 自定义供应商不会自动获得该值,需删除重建;完全手填的模型仍是 200K 保守默认(需要 #847 的表单能力)。
- 目录随 OSS 热更分发,线上生效还需服务端数据同步;本 PR 修正 bundled 权威源。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:纯预设数据(bundled providers.json)与测试,不改任何运行时逻辑;只影响预设**新建**的 DeepSeek 供应商。
- 回滚 / 降级方式:revert 本 PR 即回到 200K 保守默认,无数据残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

