### PR TITLE
fix(desktop): cc 路由识别 provider-oauth 占位 key,权限 Auto 分类器不再吃确定性 401(部分修复 #831)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -96,6 +96,30 @@ describe('cc routingTransform — xAI 会话的辅助请求回落默认路由 (i
     expect(decision).toBeNull();
   });
 
+  it('claude-haiku 分类器请求(provider-oauth spawn 带占位 x-api-key)→ 换网关 key,不 passthrough (#831)', () => {
+    // codex→cc 切换后的 openai/xai 来源会话:cc 子进程 env 里是占位 key,分类器请求带着它
+    // 落到 ② 段。占位 key 不是可用凭证,按「无凭证」处理换网关 key;此前被误判成
+    // gateway-spawn passthrough → 网关确定性 401 → 首次权限请求即 auto→ask 降级。
+    const transform = createModelRoutingTransform();
+    const decision = transform(
+      { model: 'claude-haiku-4-5-20251001' },
+      ctxWith({ ...SESSION_HEADER, 'x-api-key': 'xdt-provider-auth-placeholder-key' }),
+    );
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': 'sk-gw', authorization: 'Bearer sk-gw' },
+    });
+  });
+
+  it('占位 x-api-key 且无网关 key → 维持 passthrough(与改动前行为一致,上游 401)', () => {
+    gatewayKey = null;
+    const transform = createModelRoutingTransform();
+    const decision = transform(
+      { model: 'claude-haiku-4-5-20251001' },
+      ctxWith({ ...SESSION_HEADER, 'x-api-key': 'xdt-provider-auth-placeholder-key' }),
+    );
+    expect(decision).toBeNull();
+  });
+
   it('claude-haiku 分类器请求(无网关 key 的 oauth-spawn)→ 直连 Anthropic 订阅', () => {
     gatewayKey = null;
     const transform = createModelRoutingTransform();

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -34,7 +34,7 @@ import {
   type RoutingTransform,
 } from '@cindy/anthropic-compat-proxy';
 
-import { ANTHROPIC_DIRECT_UPSTREAM, anthropicCatalogModelIds, isAnthropicWireModel } from './claude-gateway-config.js';
+import { ANTHROPIC_DIRECT_UPSTREAM, CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY, anthropicCatalogModelIds, isAnthropicWireModel } from './claude-gateway-config.js';
 import { getActiveCatalog } from './active-catalog.js';
 import { getResponsesBridgeHandler } from './anthropic-responses-bridge-host.js';
 import { getSessionEffort, getSessionFastMode } from './session-effort-store.js';
@@ -120,11 +120,16 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 
 /** 大小写不敏感地判断请求是否带某 header(且非空)。 */
 function hasHeader(headers: Readonly<Record<string, string>>, name: string): boolean {
+  return headerValue(headers, name) !== null;
+}
+
+/** 大小写不敏感取 header 值;缺失或空串 → null。 */
+function headerValue(headers: Readonly<Record<string, string>>, name: string): string | null {
   const lower = name.toLowerCase();
   for (const [k, v] of Object.entries(headers)) {
-    if (k.toLowerCase() === lower && typeof v === 'string' && v.length > 0) return true;
+    if (k.toLowerCase() === lower && typeof v === 'string' && v.length > 0) return v;
   }
-  return false;
+  return null;
 }
 
 /**
@@ -207,7 +212,15 @@ export function createModelRoutingTransform(): RoutingTransform {
     // providerId=null 时读)——显式选了供应商但被 scope 门放下来的辅助请求(如 xai 会话
     // 的 claude-* 分类器调用)不该往表里写死记录。
     const recordDefaultRoute = sessionId !== null && getSessionProvider(sessionId) == null;
-    if (hasHeader(ctx.headers, 'x-api-key')) {
+    // provider-oauth spawn 的占位 key **不是可用凭证**:scope 门放下来的辅助请求
+    // (如 openai / xai 来源 cc 会话里 CLI 自发的 claude-* 权限分类器调用)带着它
+    // passthrough 会在网关吃确定性 401 → 误触发 auto→ask 降级(#831)。与 codex
+    // ①.5 段 #890 修复同语义:占位 key 按「无可用凭证」处理,走下方换网关 key 的
+    // 默认路由;真实 key(gateway-spawn)照旧 passthrough。
+    const apiKeyHeader = headerValue(ctx.headers, 'x-api-key');
+    const hasUsableApiKey =
+      apiKeyHeader !== null && apiKeyHeader !== CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY;
+    if (hasUsableApiKey) {
       // gateway-spawn:自带网关 key,passthrough。
       if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
       return null;
@@ -217,6 +230,12 @@ export function createModelRoutingTransform(): RoutingTransform {
       // oauth-spawn 默认:全量换网关 key(防订阅 token 泄漏到网关)。
       if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
       return decision;
+    }
+    if (apiKeyHeader !== null) {
+      // 占位 key 且无网关 key:保持改动前行为(passthrough,上游 401)——下方的
+      // Anthropic 直连支路是给 oauth-spawn 订阅 token 准备的,占位 key 不适用。
+      log.warn('provider-oauth cc spawn 占位 key 且无网关 key; passthrough (预期 401)', { wireModel });
+      return null;
     }
     // 没网关 key:Anthropic 模型只能直连(唯一出路),其余 passthrough + 记一条诊断。
     // 判据 = 前缀地板 ∪ 目录 anthropic 供应商模型集合(新家族改 OSS 目录即可,无需发版)。

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -118,11 +118,6 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-/** 大小写不敏感地判断请求是否带某 header(且非空)。 */
-function hasHeader(headers: Readonly<Record<string, string>>, name: string): boolean {
-  return headerValue(headers, name) !== null;
-}
-
 /** 大小写不敏感取 header 值;缺失或空串 → null。 */
 function headerValue(headers: Readonly<Record<string, string>>, name: string): string | null {
   const lower = name.toLowerCase();

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -89,8 +89,12 @@ const log = createLogger('auth-adapters');
  * Host-injected provider sessions only need a non-empty credential to pass Claude Code's
  * local auth preflight. The loopback proxy replaces it with the selected provider's real
  * API key / OAuth token before forwarding the request.
+ * 定义已下沉到 claude-gateway-config.ts(proxy-host 路由识别占位 key 需要它,而本
+ * 文件 import 了 proxy-host,反向 import 会成环);这里 re-export 保持既有消费点。
  */
-export const CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY = 'xdt-provider-auth-placeholder-key';
+import { CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY } from './claude-gateway-config.js';
+
+export { CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY };
 
 /** Codex CLI 的 HOME 目录, auth.json 放在根, sessions 子目录放会话 jsonl。 */
 function getCodexHome(): string {

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -53,6 +53,7 @@ import {
   terminateCodexLoginProcess,
 } from './codex-auth-state.js';
 import { CODEX_GATEWAY_ENV_KEY, CODEX_PROVIDER_OAUTH_PLACEHOLDER_KEY } from './codex-gateway-config.js';
+import { CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY } from './claude-gateway-config.js';
 import {
   clearClaudeAiOAuth,
   hasClaudeAiOAuth,
@@ -92,9 +93,7 @@ const log = createLogger('auth-adapters');
  * 定义已下沉到 claude-gateway-config.ts(proxy-host 路由识别占位 key 需要它,而本
  * 文件 import 了 proxy-host,反向 import 会成环);这里 re-export 保持既有消费点。
  */
-import { CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY } from './claude-gateway-config.js';
-
-export { CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY };
+export { CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY } from './claude-gateway-config.js';
 
 /** Codex CLI 的 HOME 目录, auth.json 放在根, sessions 子目录放会话 jsonl。 */
 function getCodexHome(): string {

--- a/apps/desktop/src/main/maker-host/claude-gateway-config.ts
+++ b/apps/desktop/src/main/maker-host/claude-gateway-config.ts
@@ -24,6 +24,14 @@ import type { Catalog } from '@cindy/model-providers';
 export const ANTHROPIC_DIRECT_UPSTREAM = 'https://api.anthropic.com';
 
 /**
+ * provider-oauth 形态 cc spawn 的占位 API key(真实凭证由 proxy 在路由时注入)。
+ * 定义放本 leaf 模块:auth-adapters(写入 env)与 anthropic-compat-proxy-host
+ * (路由时识别「这不是可用凭证」,#831)都要消费,而 auth-adapters 已 import
+ * proxy-host,反向 import 会成环。
+ */
+export const CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY = 'xdt-provider-auth-placeholder-key';
+
+/**
  * 前缀兼容地板(见文件头)。新增 Anthropic 家族名**不需要**改这里——
  * 加进 OSS 目录 anthropic 供应商名下即可;此列表只为历史裸别名与目录失效兜底而存在。
  */


### PR DESCRIPTION
## 这次改了什么

### 摘要

#831:新建 Codex 对话(ChatGPT 订阅 / xAI 来源)切到 Claude Code 后开「自动审批」,首次工具权限请求时权限档被自动降回 ask。

根因链:此类会话的 cc 子进程以 provider-oauth 形态 spawn,env 里的 `ANTHROPIC_API_KEY` 是占位值(`xdt-provider-auth-placeholder-key`,真实凭证由 proxy 在路由时注入);CLI 自发的权限 Auto 安全分类器请求(`claude-haiku-*`)被 #886 的 modelPrefixes scope 门正确放行到路由 transform 的 ② 段后,却因携带占位 `x-api-key` 被 `hasHeader` 判成 gateway-spawn 而 passthrough 到网关 → 确定性 401 → `claude-auto-permission-fallback` 的 observer 判定「分类器不可用」→ 立即 auto→ask 降级。降级逻辑本身按设计工作,缺口在路由层:占位 key 被当成了可用凭证。

修法与 codex 侧 ①.5 段的 #890 修复完全同语义:② 段以「`x-api-key` 存在**且非占位值**」判定 gateway-spawn;占位 key 按无凭证处理,换网关 key 走默认路由(分类器由此获得真正可用的通路);无网关 key 时维持改动前行为(passthrough,上游 401),不额外兜底。占位常量下沉到 `claude-gateway-config.ts`(leaf 模块),`auth-adapters` re-export 保持既有消费点,避免 proxy-host ↔ auth-adapters 环依赖。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:部分修复 #831(**不关闭**)
- 本 PR 包含:`anthropic-compat-proxy-host.ts` ② 段占位 key 判定 + `headerValue` 助手;占位常量下沉与 re-export;scope-gate 回归测试 ×2
- 明确不包含:**自定义供应商来源**的同症状那半边——其路由未声明 `modelPrefixes`(universal scope),分类器请求在 ① 段就被会话路由捕获、带用户自己的 key 打到自定义上游 4xx。这半边需要「按 provider 模型清单判定服务范围 + 重路由时的凭证替换」设计:简单跳过 ① 段会把用户自定义 provider key 透传给 XD 网关(凭证跨上游泄漏),必须单独评审,故明确不做
- 用户可见变化:ChatGPT 订阅 / xAI 来源的 cc 会话(含 codex→cc 切换场景)开自动审批后,分类器可用,权限档不再被首次请求打回 ask
- 是否存在 breaking change:无。真实网关 key 的 gateway-spawn passthrough 行为字节级不变(占位值是内部常量,不会与真实 key 冲突)

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

- `claudeProxyScopeGate.test.ts` 新增两例:占位 key + 有网关 key → 换网关 key 决策;占位 key + 无网关 key → 维持 passthrough(与改动前一致)。连同既有 scope-gate / providerRoute / authAdapter 测试共 62 passed
- `pnpm --filter desktop run typecheck`:通过
- 仓库根 `pnpm test:unit`:通过(exit 0)

### 手动验证与限制

- 未实机复现 issue 全链路(需要 ChatGPT 订阅来源会话 + agent 切换 + Auto 分类器触发);修复点按决策级单测钉住,机制链推导依据:`auth-adapters.ts` 占位注入(provider-oauth)、`credential-mode.ts` 判定、codex 侧 #890 同构修复的既有注释。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围:provider-oauth 形态 cc 会话在 ② 段的默认路由:占位 key 请求改为换网关 key(计费落网关,与 oauth-spawn 默认路由同语义);真实 key 的 gateway-spawn passthrough 字节级不变。
- 回滚 / 降级方式:revert 本 PR 即回到占位 key passthrough(上游 401、分类器降级)的旧行为,无状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

