### PR TITLE
fix(test): 串行同仓跨 worktree 重型测试门禁

### DIFF
--- a/docs/dev-rules/development-workflow.md
+++ b/docs/dev-rules/development-workflow.md
@@ -79,6 +79,12 @@ worktree 会话契约、直推 `main` 的额外门禁与 review 严重度口径�
     排查并发相关问题时可用
     `pnpm test:unit -- --workspace-concurrency=1` 临时退回 workspace 串行；该参数只改变
     workspace 调度，不减少测试覆盖。
+  - **跨 worktree 重型门禁串行**：本地运行 `unit`、`all`、`db`、`git-integration`
+    tier 时，`test-workspaces.mjs` 会按 Git common-dir 获取同仓共享的 loopback TCP 锁；
+    同一 clone 的后到进程会打印持有者 PID、tier 与 worktree 路径并排队，不同 clone
+    互不影响。`guard` tier 和 CI／GitHub Actions 不参与。等待超过 15 分钟以退出码 `75`
+    结束，表示测试尚未运行，不得当作测试失败排查；排队是正常状态，不要 kill 后重跑。
+    只有明确确认资源足够且需要有意重叠时，才可追加 `--no-lock` 作为逃生口。
 - **在门禁之上按风险追加验证**：跨模块、高风险或基础设施改动追加更广泛验证（如仓库根
   `pnpm test:all`），**最终以 CI 门禁为准**。不得通过 skip、删除或弱化测试制造通过；
   PR「怎么验证的」一节必须**如实**填写，没跑不许写已跑。

--- a/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
@@ -4,11 +4,19 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  classifySubagentEntry,
   SubagentScanBudgetError,
   discoverSubagentDefinitions,
 } from '../subagent-definitions.js';
 
 let root: string;
+const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir';
+
+const symbolicLinkDirent = {
+  isDirectory: () => false,
+  isFile: () => false,
+  isSymbolicLink: () => true,
+};
 
 // cc 的加载条件是 name + description 都必须是非空字符串(见 subagent-definitions.ts 里
 // readSubagentFile 的反编译依据)。固件默认补上 description,让它们代表「cc 真的会加载」的
@@ -218,6 +226,19 @@ describe('discoverSubagentDefinitions', () => {
   // 回归:本仓建 worktree 时刻意保留 .claude/agents 里的软链(WorktreeManager 用
   // dereference: false)。软链的 Dirent 既非 file 也非 dir,漏掉它 = 误判「没人声明 model」。
   it('跟随软链的 agent 定义文件', async () => {
+    if (process.platform === 'win32') {
+      const link = path.join(root, 'repo', '.claude', 'agents', 'reviewer.md');
+      const visited: string[] = [];
+      const kind = await classifySubagentEntry(symbolicLinkDirent, link, async (entryPath) => {
+        visited.push(entryPath);
+        return { isDirectory: () => false, isFile: () => true };
+      });
+
+      expect(visited).toEqual([link]);
+      expect(kind).toBe('file');
+      return;
+    }
+
     const real = path.join(root, 'shared');
     await writeAgent(real, 'reviewer.md', 'name: reviewer\nmodel: xai/grok-4.5');
     const agents = path.join(root, 'repo', '.claude', 'agents');
@@ -238,7 +259,7 @@ describe('discoverSubagentDefinitions', () => {
     await writeAgent(real, 'a.md', 'name: linked-dir-agent\nmodel: opus');
     const agents = path.join(root, 'repo', '.claude', 'agents');
     await fs.mkdir(agents, { recursive: true });
-    await fs.symlink(real, path.join(agents, 'shared'), 'dir');
+    await fs.symlink(real, path.join(agents, 'shared'), directoryLinkType);
 
     const found = await discoverSubagentDefinitions({
       workingDir: path.join(root, 'repo'),
@@ -251,7 +272,11 @@ describe('discoverSubagentDefinitions', () => {
   it('悬空软链跳过,不影响同目录其它定义', async () => {
     const agents = path.join(root, 'repo', '.claude', 'agents');
     await writeAgent(agents, 'ok.md', 'name: ok\nmodel: opus');
-    await fs.symlink(path.join(root, 'gone', 'nothing.md'), path.join(agents, 'dead.md'));
+    await fs.symlink(
+      path.join(root, 'gone', 'nothing.md'),
+      path.join(agents, 'dead.md'),
+      directoryLinkType,
+    );
 
     const found = await discoverSubagentDefinitions({
       workingDir: path.join(root, 'repo'),
@@ -265,7 +290,7 @@ describe('discoverSubagentDefinitions', () => {
     const agents = path.join(root, 'repo', '.claude', 'agents');
     await writeAgent(agents, 'a.md', 'name: a\nmodel: opus');
     // agents/loop -> agents 自己
-    await fs.symlink(agents, path.join(agents, 'loop'), 'dir');
+    await fs.symlink(agents, path.join(agents, 'loop'), directoryLinkType);
 
     const found = await discoverSubagentDefinitions({
       workingDir: path.join(root, 'repo'),
@@ -352,7 +377,7 @@ describe('discoverSubagentDefinitions', () => {
     const linkParent = path.join(root, 'elsewhere');
     await fs.mkdir(linkParent, { recursive: true });
     const link = path.join(linkParent, 'app-link');
-    await fs.symlink(workSub, link, 'dir');
+    await fs.symlink(workSub, link, directoryLinkType);
 
     const found = await discoverSubagentDefinitions({
       workingDir: link,

--- a/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
@@ -272,10 +272,26 @@ describe('discoverSubagentDefinitions', () => {
   it('悬空软链跳过,不影响同目录其它定义', async () => {
     const agents = path.join(root, 'repo', '.claude', 'agents');
     await writeAgent(agents, 'ok.md', 'name: ok\nmodel: opus');
+    if (process.platform === 'win32') {
+      // 未开启 Developer Mode 时不能可靠创建文件软链，而 junction 对悬空目标的要求也因
+      // Windows / Node 版本而异。直接覆盖生产代码使用的 follow-stat 失败分支。
+      const link = path.join(agents, 'dead.md');
+      const kind = await classifySubagentEntry(symbolicLinkDirent, link, async () => {
+        throw Object.assign(new Error('missing target'), { code: 'ENOENT' });
+      });
+      expect(kind).toBeUndefined();
+
+      const found = await discoverSubagentDefinitions({
+        workingDir: path.join(root, 'repo'),
+        env: { CLAUDE_CONFIG_DIR: path.join(root, 'empty-home') },
+      });
+      expect(found.map((f) => f.name)).toEqual(['ok']);
+      return;
+    }
+
     await fs.symlink(
       path.join(root, 'gone', 'nothing.md'),
       path.join(agents, 'dead.md'),
-      directoryLinkType,
     );
 
     const found = await discoverSubagentDefinitions({

--- a/packages/maker-core/src/agents/claude-code/subagent-definitions.ts
+++ b/packages/maker-core/src/agents/claude-code/subagent-definitions.ts
@@ -51,7 +51,7 @@
  *     prompt 的合法定义,同样退化成上一条那个 bug。
  */
 
-import type { Dirent } from 'node:fs';
+import type { Dirent, Stats } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -224,6 +224,37 @@ async function readDirEntriesBounded(dir: string, budget: ScanBudget): Promise<D
   return entries;
 }
 
+type EntryKind = 'directory' | 'file' | 'other';
+
+/**
+ * 把目录条目按跟随软链后的目标分类。
+ *
+ * `statEntry` 可注入是为了让 Windows 在未开启 Developer Mode、无法创建文件软链时，
+ * 仍能真实覆盖 Dirent 的软链分支；目录 junction 则继续走端到端测试。
+ */
+export async function classifySubagentEntry(
+  ent: Pick<Dirent, 'isDirectory' | 'isFile' | 'isSymbolicLink'>,
+  fullPath: string,
+  statEntry: (entryPath: string) => Promise<Pick<Stats, 'isDirectory' | 'isFile'>> = (entryPath) =>
+    fs.stat(entryPath),
+): Promise<EntryKind | undefined> {
+  let isDir = ent.isDirectory();
+  let isFile = ent.isFile();
+  if (ent.isSymbolicLink()) {
+    // follow: stat 走目标。悬空 / 无权限的链直接跳过这一条。
+    try {
+      const st = await statEntry(fullPath);
+      isDir = st.isDirectory();
+      isFile = st.isFile();
+    } catch {
+      return undefined;
+    }
+  }
+  if (isDir) return 'directory';
+  if (isFile) return 'file';
+  return 'other';
+}
+
 /**
  * 递归收集目录下的 .md 文件。单个坏目录只跳过它自己,不影响其余扫描;超预算则整趟抛出。
  *
@@ -270,24 +301,14 @@ async function collectMarkdownFiles(
     // 以为「有人声明了 model」从而删掉 env —— 用户配的默认值对真正的 agent 反而失效了。
     if (ent.name.startsWith('.') || /\.bak\.\d+$/.test(ent.name)) continue;
     const full = path.join(dir, ent.name);
-    let isDir = ent.isDirectory();
-    let isFile = ent.isFile();
-    if (ent.isSymbolicLink()) {
-      // follow: stat 走目标。悬空 / 无权限的链直接跳过这一条。
-      try {
-        const st = await fs.stat(full);
-        isDir = st.isDirectory();
-        isFile = st.isFile();
-      } catch {
-        continue;
-      }
-    }
-    if (isDir) {
+    const kind = await classifySubagentEntry(ent, full);
+    if (kind === undefined) continue;
+    if (kind === 'directory') {
       files.push(...(await collectMarkdownFiles(full, budget, visitedDirs, depth + 1)));
       // 扩展名大小写不敏感:`reviewer.MD` 在大小写保留的文件系统上照样是一份定义,
       // 本仓既有的 customization-scanner 也是 `toLowerCase().endsWith('.md')`。
       // 大小写敏感地漏掉一份声明了 model 的定义 = 又把覆盖用的 env 设回去。
-    } else if (isFile && ent.name.toLowerCase().endsWith('.md')) {
+    } else if (kind === 'file' && ent.name.toLowerCase().endsWith('.md')) {
       budget.countFile();
       files.push(full);
     }

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -915,6 +915,76 @@ test("test gate lock reports the holder, waits, and acquires after release", asy
 	}
 });
 
+test("two real test gate lock holders serialize on the same identity", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "test-gate-real-lock-"));
+	let firstLock;
+	let secondLock;
+	let reportWaiting;
+	const waiting = new Promise((resolve) => {
+		reportWaiting = resolve;
+	});
+	try {
+		firstLock = await acquireTestGateLock({
+			repoRoot: root,
+			owner: { pid: 41, tier: "unit", cwd: path.join(root, "first") },
+			output: () => {},
+		});
+		const secondLockPromise = acquireTestGateLock({
+			repoRoot: root,
+			owner: { pid: 42, tier: "db", cwd: path.join(root, "second") },
+			timeoutMs: 2_000,
+			retryDelayMs: 10,
+			output: reportWaiting,
+		}).then((lock) => {
+			secondLock = lock;
+			return lock;
+		});
+		const outcome = await Promise.race([
+			waiting.then(() => "waiting"),
+			secondLockPromise.then(() => "acquired"),
+			new Promise((resolve) => setTimeout(() => resolve("timed-out"), 1_000)),
+		]);
+		assert.equal(outcome, "waiting");
+
+		await firstLock.release();
+		firstLock = undefined;
+		await secondLockPromise;
+		assert.ok(secondLock.port >= 49_152);
+	} finally {
+		await secondLock?.release();
+		await firstLock?.release();
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("test gate lock skips ports denied at bind time", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "test-gate-bind-denied-"));
+	const attemptedPorts = [];
+	try {
+		const lock = await acquireTestGateLock({
+			repoRoot: root,
+			owner: { pid: 99, tier: "unit", cwd: root },
+			probeCandidatesImpl: async (ports) =>
+				ports.map((port) => ({ port, result: "available" })),
+			listenImpl: async (port) => {
+				attemptedPorts.push(port);
+				if (attemptedPorts.length === 1) {
+					throw Object.assign(new Error("bind denied"), { code: "EACCES" });
+				}
+				return { port, release: async () => {} };
+			},
+			output: () => {},
+		});
+
+		assert.equal(attemptedPorts.length, 2);
+		assert.notEqual(attemptedPorts[0], attemptedPorts[1]);
+		assert.equal(lock.port, attemptedPorts[1]);
+		await lock.release();
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("test gate lock timeout uses a distinct temporary-failure exit code", async () => {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "test-gate-timeout-"));
 	let now = 0;

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -9,6 +9,15 @@ import manifest, {
 	desktopUnitWorkerCount,
 } from "../test-workspaces.config.mjs";
 import {
+	acquireTestGateLock,
+	classifyTestGateLockProbeError,
+	decideTestGateLock,
+	resolveTestGateCommonDir,
+	shouldUseTestGateLock,
+	TEST_GATE_LOCK_TIMEOUT_EXIT_CODE,
+	testGateLockIdentity,
+} from "../test-gate-lock.mjs";
+import {
 	buildPnpmArgs,
 	checkIncludeCoverage,
 	checkTestFiles,
@@ -704,6 +713,7 @@ test("parseCliOptions rejects --tier without a value", () => {
 		workspaces: [],
 		excludeWorkspaces: [],
 		workspaceConcurrency: undefined,
+		noLock: false,
 	});
 });
 
@@ -725,6 +735,7 @@ test("parseCliOptions supports workspace include and exclude selectors", () => {
 			workspaces: ["desktop", "apps/server", "@cindy/maker-core"],
 			excludeWorkspaces: ["packages/orca-workflow"],
 			workspaceConcurrency: undefined,
+			noLock: false,
 		},
 	);
 	assert.deepEqual(parseWorkspaceSelectorValue(" desktop, apps/server "), [
@@ -761,6 +772,186 @@ test("workspace concurrency defaults to a bounded CPU count and accepts both CLI
 		() => parseCliOptions(["--workspace-concurrency"]),
 		/requires a positive integer/,
 	);
+	assert.equal(parseCliOptions(["--no-lock"]).noLock, true);
+});
+
+test("test gate lock covers heavy local tiers but skips guard, CI, and explicit bypass", () => {
+	for (const tier of ["unit", "db", "git-integration"]) {
+		assert.equal(shouldUseTestGateLock({ tier, env: {} }), true);
+	}
+	assert.equal(shouldUseTestGateLock({ all: true, env: {} }), true);
+	assert.equal(shouldUseTestGateLock({ tier: "guard", env: {} }), false);
+	assert.equal(
+		shouldUseTestGateLock({ tier: "unit", noLock: true, env: {} }),
+		false,
+	);
+	for (const env of [{ CI: "1" }, { CI: "true" }, { GITHUB_ACTIONS: "true" }]) {
+		assert.equal(shouldUseTestGateLock({ tier: "unit", env }), false);
+	}
+	assert.equal(
+		shouldUseTestGateLock({ tier: "unit", env: { CI: "false" } }),
+		true,
+	);
+});
+
+test("test gate lock identity is stable per clone and normalizes Windows case", () => {
+	assert.equal(
+		testGateLockIdentity("C:\\Repo\\.git", "win32"),
+		testGateLockIdentity("c:\\repo\\.git", "win32"),
+	);
+	assert.notEqual(
+		testGateLockIdentity("/repo-a/.git", "linux"),
+		testGateLockIdentity("/repo-b/.git", "linux"),
+	);
+});
+
+test("test gate common-dir resolver joins worktrees from one clone without joining separate roots", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "test-gate-common-dir-"));
+	try {
+		const commonDir = path.join(root, "common.git");
+		const firstGitDir = path.join(commonDir, "worktrees", "first");
+		const secondGitDir = path.join(commonDir, "worktrees", "second");
+		const firstWorktree = path.join(root, "first");
+		const secondWorktree = path.join(root, "second");
+		const separateRoot = path.join(root, "separate");
+		for (const directory of [
+			firstGitDir,
+			secondGitDir,
+			firstWorktree,
+			secondWorktree,
+			separateRoot,
+		]) {
+			fs.mkdirSync(directory, { recursive: true });
+		}
+		fs.writeFileSync(path.join(firstWorktree, ".git"), `gitdir: ${firstGitDir}\n`);
+		fs.writeFileSync(
+			path.join(secondWorktree, ".git"),
+			`gitdir: ${secondGitDir}\n`,
+		);
+		for (const gitDir of [firstGitDir, secondGitDir]) {
+			fs.writeFileSync(path.join(gitDir, "commondir"), "../..\n");
+		}
+
+		const firstResolved = await resolveTestGateCommonDir(firstWorktree);
+		const secondResolved = await resolveTestGateCommonDir(secondWorktree);
+		const separateResolved = await resolveTestGateCommonDir(separateRoot);
+		assert.equal(firstResolved, secondResolved);
+		assert.notEqual(firstResolved, separateResolved);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("test gate lock decision prefers an existing owner over an earlier free port", () => {
+	const owner = { pid: 42, tier: "unit", cwd: "/repo/worktree-a" };
+	assert.deepEqual(
+		decideTestGateLock([
+			{ port: 50_000, result: "available" },
+			{ port: 50_001, result: "owner", owner },
+		]),
+		{ type: "wait", owner },
+	);
+	assert.deepEqual(
+		decideTestGateLock([
+			{ port: 50_000, result: "collision" },
+			{ port: 50_001, result: "available" },
+		]),
+		{ type: "acquire", port: 50_001 },
+	);
+	assert.deepEqual(
+		decideTestGateLock([{ port: 50_000, result: "collision" }]),
+		{ type: "unavailable" },
+	);
+	assert.equal(classifyTestGateLockProbeError("ECONNREFUSED"), "available");
+	assert.equal(classifyTestGateLockProbeError("ETIMEDOUT"), "collision");
+});
+
+test("test gate lock reports the holder, waits, and acquires after release", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "test-gate-lock-"));
+	let probeRound = 0;
+	let now = 0;
+	let listenedPort;
+	const output = [];
+	try {
+		const lock = await acquireTestGateLock({
+			repoRoot: root,
+			owner: { pid: 99, tier: "db", cwd: root },
+			timeoutMs: 1_000,
+			retryDelayMs: 100,
+			now: () => now,
+			sleep: async (durationMs) => {
+				now += durationMs;
+			},
+			probeCandidatesImpl: async (ports) => {
+				probeRound += 1;
+				if (probeRound === 1) {
+					return [
+						{ port: ports[0], result: "available" },
+						{
+							port: ports[1],
+							result: "owner",
+							owner: {
+								pid: 42,
+								tier: "unit",
+								cwd: "/repo/worktree-a",
+							},
+						},
+					];
+				}
+				return [{ port: ports[0], result: "available" }];
+			},
+			listenImpl: async (port) => {
+				listenedPort = port;
+				return { port, release: async () => {} };
+			},
+			output: (message) => output.push(message),
+		});
+		assert.equal(probeRound, 2);
+		assert.equal(lock.port, listenedPort);
+		assert.match(output.join("\n"), /pid 42, tier unit, cwd \/repo\/worktree-a/);
+		await lock.release();
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("test gate lock timeout uses a distinct temporary-failure exit code", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "test-gate-timeout-"));
+	let now = 0;
+	try {
+		await assert.rejects(
+			() =>
+				acquireTestGateLock({
+					repoRoot: root,
+					owner: { pid: 99, tier: "unit", cwd: root },
+					timeoutMs: 100,
+					retryDelayMs: 100,
+					now: () => now,
+					sleep: async (durationMs) => {
+						now += durationMs;
+					},
+					probeCandidatesImpl: async (ports) => [
+						{
+							port: ports[0],
+							result: "owner",
+							owner: {
+								pid: 42,
+								tier: "unit",
+								cwd: "/repo/worktree-a",
+							},
+						},
+					],
+					output: () => {},
+				}),
+			(error) => {
+				assert.equal(error.exitCode, TEST_GATE_LOCK_TIMEOUT_EXIT_CODE);
+				assert.match(error.message, /tests did not run/);
+				return true;
+			},
+		);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("resolvePnpmInvocation uses current pnpm through node when npm_execpath is present on any platform", () => {

--- a/scripts/test-gate-lock.mjs
+++ b/scripts/test-gate-lock.mjs
@@ -12,6 +12,7 @@ const PROBE_TIMEOUT_MS = 1_000;
 const RETRY_DELAY_MS = 500;
 const WAIT_REPORT_INTERVAL_MS = 60_000;
 const HEAVY_TEST_TIERS = new Set(["unit", "db", "git-integration"]);
+const BIND_DENIED_ERROR_CODES = new Set(["EACCES", "EPERM"]);
 
 export const TEST_GATE_LOCK_TIMEOUT_EXIT_CODE = 75;
 export const DEFAULT_TEST_GATE_LOCK_TIMEOUT_MS = 15 * 60_000;
@@ -245,9 +246,14 @@ export async function acquireTestGateLock({
 	});
 	const startedAt = now();
 	let lastReportAt = Number.NEGATIVE_INFINITY;
+	const bindDeniedPorts = new Set();
 
 	while (true) {
-		const probes = await probeCandidatesImpl(ports, identity);
+		const probes = (await probeCandidatesImpl(ports, identity)).map((probe) =>
+			bindDeniedPorts.has(probe.port)
+				? { port: probe.port, result: "collision" }
+				: probe,
+		);
 		const decision = decideTestGateLock(probes);
 		if (decision.type === "unavailable") {
 			throw new Error(
@@ -258,6 +264,10 @@ export async function acquireTestGateLock({
 			try {
 				return await listenImpl(decision.port, banner);
 			} catch (error) {
+				if (BIND_DENIED_ERROR_CODES.has(error?.code)) {
+					bindDeniedPorts.add(decision.port);
+					continue;
+				}
 				if (error?.code !== "EADDRINUSE") throw error;
 				const waitedMs = now() - startedAt;
 				if (waitedMs >= timeoutMs) throw createTimeoutError(waitedMs);

--- a/scripts/test-gate-lock.mjs
+++ b/scripts/test-gate-lock.mjs
@@ -1,0 +1,281 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+
+const LOCK_HOST = "127.0.0.1";
+const LOCK_PORT_START = 49_152;
+const LOCK_PORT_COUNT = 16_000;
+const LOCK_PORT_CANDIDATES = 32;
+const LOCK_PROTOCOL = "cindy-test-workspaces-lock-v1";
+const PROBE_TIMEOUT_MS = 1_000;
+const RETRY_DELAY_MS = 500;
+const WAIT_REPORT_INTERVAL_MS = 60_000;
+const HEAVY_TEST_TIERS = new Set(["unit", "db", "git-integration"]);
+
+export const TEST_GATE_LOCK_TIMEOUT_EXIT_CODE = 75;
+export const DEFAULT_TEST_GATE_LOCK_TIMEOUT_MS = 15 * 60_000;
+
+export class TestGateLockTimeoutError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = "TestGateLockTimeoutError";
+		this.exitCode = TEST_GATE_LOCK_TIMEOUT_EXIT_CODE;
+	}
+}
+
+function delay(durationMs) {
+	return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+function enabledEnvironmentFlag(value) {
+	if (value === undefined || value === null) return false;
+	const normalized = String(value).trim().toLowerCase();
+	return normalized !== "" && normalized !== "0" && normalized !== "false";
+}
+
+export function isTestGateCiEnvironment(env = process.env) {
+	return (
+		enabledEnvironmentFlag(env.CI) ||
+		enabledEnvironmentFlag(env.GITHUB_ACTIONS)
+	);
+}
+
+export function shouldUseTestGateLock({
+	all = false,
+	tier = "unit",
+	noLock = false,
+	env = process.env,
+} = {}) {
+	if (noLock || isTestGateCiEnvironment(env)) return false;
+	return all || HEAVY_TEST_TIERS.has(tier);
+}
+
+export async function resolveTestGateCommonDir(repoRoot) {
+	const dotGitPath = path.join(repoRoot, ".git");
+	let dotGitStat;
+	try {
+		dotGitStat = await fs.stat(dotGitPath);
+	} catch (error) {
+		if (error?.code !== "ENOENT") throw error;
+		return fs.realpath(repoRoot);
+	}
+	if (dotGitStat.isDirectory()) return fs.realpath(dotGitPath);
+
+	const gitDirLine = (await fs.readFile(dotGitPath, "utf8")).trim();
+	const gitDirMatch = /^gitdir:\s*(.+)$/i.exec(gitDirLine);
+	if (!gitDirMatch) throw new Error(`Invalid gitdir file: ${dotGitPath}`);
+	const gitDir = path.resolve(repoRoot, gitDirMatch[1]);
+	try {
+		const commonDir = (await fs.readFile(path.join(gitDir, "commondir"), "utf8"))
+			.trim();
+		return fs.realpath(path.resolve(gitDir, commonDir));
+	} catch (error) {
+		if (error?.code !== "ENOENT") throw error;
+		return fs.realpath(gitDir);
+	}
+}
+
+export function testGateLockIdentity(commonDir, platform = process.platform) {
+	const normalized = platform === "win32" ? commonDir.toLowerCase() : commonDir;
+	return createHash("sha256")
+		.update(`${LOCK_PROTOCOL}\0${normalized}`)
+		.digest("hex");
+}
+
+function lockPort(identity, candidate) {
+	const baseOffset = Number.parseInt(identity.slice(0, 8), 16) % LOCK_PORT_COUNT;
+	return LOCK_PORT_START + ((baseOffset + candidate) % LOCK_PORT_COUNT);
+}
+
+export function classifyTestGateLockProbeError(code) {
+	return code === "ECONNREFUSED" ? "available" : "collision";
+}
+
+export function decideTestGateLock(probes) {
+	const owner = probes.find((probe) => probe.result === "owner");
+	if (owner) return { type: "wait", owner: owner.owner };
+	const available = probes.find((probe) => probe.result === "available");
+	return available
+		? { type: "acquire", port: available.port }
+		: { type: "unavailable" };
+}
+
+function parseOwnerBanner(response, identity) {
+	try {
+		const parsed = JSON.parse(response);
+		if (
+			parsed?.protocol !== LOCK_PROTOCOL ||
+			parsed?.identity !== identity ||
+			!parsed.owner ||
+			typeof parsed.owner !== "object"
+		) {
+			return null;
+		}
+		return parsed.owner;
+	} catch {
+		return null;
+	}
+}
+
+function probeLock(port, identity) {
+	return new Promise((resolve) => {
+		const socket = net.createConnection({ host: LOCK_HOST, port });
+		let response = "";
+		let settled = false;
+		const finish = (result, owner) => {
+			if (settled) return;
+			settled = true;
+			socket.destroy();
+			resolve({ port, result, ...(owner ? { owner } : {}) });
+		};
+
+		socket.setEncoding("utf8");
+		socket.setTimeout(PROBE_TIMEOUT_MS);
+		socket.on("data", (chunk) => {
+			response += chunk;
+			if (response.length > 16 * 1024) {
+				finish("collision");
+				return;
+			}
+			if (!response.includes("\n")) return;
+			const owner = parseOwnerBanner(response.trim(), identity);
+			finish(owner ? "owner" : "collision", owner);
+		});
+		socket.on("end", () => {
+			const owner = parseOwnerBanner(response.trim(), identity);
+			finish(owner ? "owner" : "collision", owner);
+		});
+		socket.on("timeout", () => finish("collision"));
+		socket.on("error", (error) =>
+			finish(classifyTestGateLockProbeError(error?.code)),
+		);
+	});
+}
+
+async function probeCandidates(ports, identity) {
+	return Promise.all(ports.map((port) => probeLock(port, identity)));
+}
+
+function listen(server, port) {
+	return new Promise((resolve, reject) => {
+		const onError = (error) => {
+			server.off("listening", onListening);
+			reject(error);
+		};
+		const onListening = () => {
+			server.off("error", onError);
+			resolve();
+		};
+		server.once("error", onError);
+		server.once("listening", onListening);
+		server.listen({ host: LOCK_HOST, port, exclusive: true });
+	});
+}
+
+function close(server) {
+	return new Promise((resolve, reject) => {
+		server.close((error) => {
+			if (error) reject(error);
+			else resolve();
+		});
+	});
+}
+
+async function listenForLock(port, banner) {
+	const server = net.createServer((socket) => {
+		socket.end(`${banner}\n`);
+	});
+	await listen(server, port);
+	return {
+		port,
+		release: () => close(server),
+	};
+}
+
+function formatWaitDuration(durationMs) {
+	if (durationMs < 60_000) return `${Math.ceil(durationMs / 1_000)}s`;
+	return `${Math.ceil(durationMs / 60_000)}m`;
+}
+
+function describeOwner(owner) {
+	const pid = Number.isInteger(owner?.pid) ? owner.pid : "unknown";
+	const tier = owner?.tier || "unknown";
+	const cwd = owner?.cwd || "unknown";
+	return `pid ${pid}, tier ${tier}, cwd ${cwd}`;
+}
+
+function createTimeoutError(waitedMs, owner) {
+	const holder = owner
+		? ` held by ${describeOwner(owner)}`
+		: " because another process kept winning the local lock race";
+	return new TestGateLockTimeoutError(
+		`Timed out after ${formatWaitDuration(waitedMs)} waiting for the local test gate${holder}. Exit ${TEST_GATE_LOCK_TIMEOUT_EXIT_CODE} means the tests did not run.`,
+	);
+}
+
+/**
+ * Acquires one repository-wide local test budget. Every deterministic port is
+ * probed before listening so an owner on a fallback port cannot be missed.
+ */
+export async function acquireTestGateLock({
+	repoRoot,
+	owner,
+	timeoutMs = DEFAULT_TEST_GATE_LOCK_TIMEOUT_MS,
+	retryDelayMs = RETRY_DELAY_MS,
+	waitReportIntervalMs = WAIT_REPORT_INTERVAL_MS,
+	now = Date.now,
+	sleep = delay,
+	probeCandidatesImpl = probeCandidates,
+	listenImpl = listenForLock,
+	output = (message) => console.log(message),
+} = {}) {
+	if (!repoRoot) throw new Error("repoRoot is required");
+	if (!owner || typeof owner !== "object") throw new Error("owner is required");
+	const commonDir = await resolveTestGateCommonDir(repoRoot);
+	const identity = testGateLockIdentity(commonDir);
+	const ports = Array.from(
+		{ length: LOCK_PORT_CANDIDATES },
+		(_, candidate) => lockPort(identity, candidate),
+	);
+	const banner = JSON.stringify({
+		protocol: LOCK_PROTOCOL,
+		identity,
+		owner,
+	});
+	const startedAt = now();
+	let lastReportAt = Number.NEGATIVE_INFINITY;
+
+	while (true) {
+		const probes = await probeCandidatesImpl(ports, identity);
+		const decision = decideTestGateLock(probes);
+		if (decision.type === "unavailable") {
+			throw new Error(
+				`All ${LOCK_PORT_CANDIDATES} test gate lock ports are occupied by unrelated local services`,
+			);
+		}
+		if (decision.type === "acquire") {
+			try {
+				return await listenImpl(decision.port, banner);
+			} catch (error) {
+				if (error?.code !== "EADDRINUSE") throw error;
+				const waitedMs = now() - startedAt;
+				if (waitedMs >= timeoutMs) throw createTimeoutError(waitedMs);
+				await sleep(Math.min(retryDelayMs, timeoutMs - waitedMs));
+				continue;
+			}
+		}
+
+		const waitedMs = now() - startedAt;
+		if (waitedMs >= timeoutMs) {
+			throw createTimeoutError(waitedMs, decision.owner);
+		}
+		if (now() - lastReportAt >= waitReportIntervalMs) {
+			output(
+				`WAIT test gate: ${describeOwner(decision.owner)}; waited ${formatWaitDuration(waitedMs)} (timeout ${formatWaitDuration(timeoutMs)}). Do not kill and restart; use --no-lock only when intentional overlap is safe.`,
+			);
+			lastReportAt = now();
+		}
+		await sleep(Math.min(retryDelayMs, timeoutMs - waitedMs));
+	}
+}

--- a/scripts/test-workspaces.mjs
+++ b/scripts/test-workspaces.mjs
@@ -4,6 +4,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	acquireTestGateLock,
+	shouldUseTestGateLock,
+} from "./test-gate-lock.mjs";
 
 const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const IGNORED_PARTS = new Set([
@@ -46,12 +50,17 @@ export function parseCliOptions(args) {
 		workspaces: [],
 		excludeWorkspaces: [],
 		workspaceConcurrency: undefined,
+		noLock: false,
 	};
 	for (let index = 0; index < args.length; index += 1) {
 		const arg = args[index];
 		if (arg === "--") continue;
 		if (arg === "--all") {
 			options.all = true;
+			continue;
+		}
+		if (arg === "--no-lock") {
+			options.noLock = true;
 			continue;
 		}
 		if (arg === "--tier") {
@@ -903,20 +912,36 @@ async function main() {
 		workspaces,
 		excludeWorkspaces,
 		workspaceConcurrency,
+		noLock,
 	} = parseCliOptions(process.argv.slice(2));
-	const manifest = (await import("./test-workspaces.config.mjs")).default;
-	const results = await runPlannedTests({
-		root: ROOT,
-		manifest,
-		tier,
-		all,
-		workspaces,
-		excludeWorkspaces,
-		workspaceConcurrency,
-		reporter: createWorkspaceRunReporter(),
-	});
-	printSummary(results, manifest);
-	if (results.some((result) => result.exitCode !== 0)) process.exitCode = 1;
+	const lock = shouldUseTestGateLock({ all, tier, noLock })
+		? await acquireTestGateLock({
+				repoRoot: ROOT,
+				owner: {
+					pid: process.pid,
+					tier: all ? "all" : tier,
+					cwd: ROOT,
+					startedAt: new Date().toISOString(),
+				},
+			})
+		: null;
+	try {
+		const manifest = (await import("./test-workspaces.config.mjs")).default;
+		const results = await runPlannedTests({
+			root: ROOT,
+			manifest,
+			tier,
+			all,
+			workspaces,
+			excludeWorkspaces,
+			workspaceConcurrency,
+			reporter: createWorkspaceRunReporter(),
+		});
+		printSummary(results, manifest);
+		if (results.some((result) => result.exitCode !== 0)) process.exitCode = 1;
+	} finally {
+		await lock?.release();
+	}
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
@@ -930,6 +955,6 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
 	}
 	main().catch((error) => {
 		console.error(error);
-		process.exitCode = 1;
+		process.exitCode = error?.exitCode ?? 1;
 	});
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

为同一 clone 下并发运行的本地重型测试门禁增加跨 worktree 的 loopback TCP 锁，避免多个 Vitest worker 池相乘导致整机过载。锁默认覆盖 `unit`、`all`、`db`、`git-integration`，跳过 `guard` 与 CI，并提供 `--no-lock` 显式逃生口；等待超过 15 分钟以独立退出码 `75` 结束。

rebase 最新 main 后发现 maker-core 有 5 个依赖 Windows 文件软链权限的存量测试失败，本 PR 同步将目录场景改为 junction 端到端验证，并把文件软链目标分类提取为可注入的小函数，保证未开启 Developer Mode 的 Windows 也能覆盖同一逻辑分支，不跳过测试、不改变运行期行为。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#875
- 本 PR 包含：跨 worktree 重型测试门禁锁、排队诊断与超时退出码、`--no-lock`、规则文档、锁逻辑单测、Windows 符号链接测试兼容
- 明确不包含：跨机器锁、CI 锁、`guard` tier 锁、测试 worker 配额调整
- 用户可见变化：本地同仓重型门禁重叠时，后到进程会显示持有者信息并排队
- 是否存在 breaking change：无；需要有意并发时可显式传 `--no-lock`

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（rebase 最新 origin/main 后完整复跑）

pnpm --filter @cindy/maker-core test
结果：通过，809/809

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/subagent-definitions.test.ts
结果：通过，32/32

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（该 package 无 typecheck script，按门禁规则自动跳过）

pnpm --filter @cindy/maker-core exec eslint src/agents/claude-code/subagent-definitions.ts src/agents/claude-code/__tests__/subagent-definitions.test.ts
结果：通过

pnpm check:dco
结果：通过，2/2 commits
```

补充检查：`pnpm --filter @cindy/maker-core build` 在最新 main 的 4 个存量测试类型错误处失败（`mcp-approval-policy.test.ts` 2 处、`codex/index.test.ts` 2 处），与本 PR 改动无关；改动文件 lint 与完整单测均通过。

### 手工验证

- Windows 本地验证真实 TCP 双持有者竞争、排队、释放后接管
- Windows 本地验证目录 junction、悬空 junction、junction 环与 junction workingDir
- 对比单 workspace 与两个轻量 workspace：单任务锁开销落在测量噪声内；并发轻量任务会因串行增加墙钟，符合默认保护整机资源的预期

### 未执行的验证

- 未在 macOS / Linux 实机复跑；POSIX 文件软链仍保留真实端到端用例，由 CI 覆盖
- 未修复上述最新 main 的 4 个存量 TypeScript build 错误，避免扩大本 PR 范围

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：本地测试调度行为

### 影响与回滚

- 影响范围：仅本地运行仓库测试脚本时的跨 worktree 调度；不影响产品运行期、CI、UI、数据库、协议或用户数据
- 回滚 / 降级方式：单次可传 `--no-lock`；完整回滚可移除 `test-gate-lock.mjs` 及 `test-workspaces.mjs` 的接入
- 移动端冷更：不会触发；未修改 mobile 原生配置、原生依赖、config plugin、原生模块或 runtime fingerprint 输入

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因