### PR TITLE
feat(desktop): 意识指令胶囊支持整体退格删除

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
@@ -52,7 +52,17 @@ describe('ChatInput list continuation wiring contract', () => {
     expect(block).toContain('!event.altKey');
     expect(block).toContain('!event.shiftKey');
     expect(block).toContain('!event.isComposing');
-    expect(block).toContain('(handleStructuredListBackspace(view) || applyListBackspace(view))');
+    // 三段 fallback 依次尝试:结构化列表 → 旧纯文本列表 → 意识指令胶囊整体删。
+    // 顺序即优先级:意识指令排最后,只在自身命中时接管,不抢列表的退格语义。
+    expect(block).toContain('handleStructuredListBackspace(view) ||');
+    expect(block).toContain('applyListBackspace(view) ||');
+    expect(block).toContain('applyGhostCommandBackspace(view)');
+    expect(block.indexOf('handleStructuredListBackspace(view)')).toBeLessThan(
+      block.indexOf('applyListBackspace(view)'),
+    );
+    expect(block.indexOf('applyListBackspace(view)')).toBeLessThan(
+      block.indexOf('applyGhostCommandBackspace(view)'),
+    );
   });
 
   it('never intercepts plain Enter — send semantics stay untouched', () => {

--- a/apps/desktop/src/renderer/__tests__/ghostCommandDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/ghostCommandDecoration.test.ts
@@ -8,15 +8,20 @@
  *   2. 前导空白 / 空段落被 trim → 仍亮;正文中段的 `$` 不亮;
  *   3. chip 在前(序列化 `@...` 前缀)/ 指令词紧贴 chip(run 未断)→ 不亮;
  *   4. 未装 / 沉睡 / 全角触发符 / 大小写折叠等与 findGhostByCommand 同判;
- *   5. roster 经 meta 推入后 plugin 重算(装/卸即时反映,不依赖 docChanged)。
+ *   5. roster 经 meta 推入后 plugin 重算(装/卸即时反映,不依赖 docChanged);
+ *   6. Backspace 整体删除只在「胶囊亮 + 光标在胶囊外(尾随空格之后)」接管,
+ *      胶囊内(含贴着词尾的位置)与其余情况一律落回原生逐字删——那里是编辑位,
+ *      改词能力不能被捷径吃掉。
  */
 import { describe, expect, it } from 'vitest';
 import { Schema, type Node as PMNode } from '@tiptap/pm/model';
-import { EditorState } from '@tiptap/pm/state';
+import { EditorState, TextSelection } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import {
+  applyGhostCommandBackspace,
   createGhostCommandPlugin,
   findGhostCommandMatch,
   ghostPillAttrs,
@@ -198,6 +203,103 @@ describe('createGhostCommandPlugin — roster meta 与 decoration 生命周期',
       class: 'ghost-cmd-pill',
       'data-ghost-cmd': 'ghost-画图',
     });
+  });
+});
+
+describe('applyGhostCommandBackspace — 整体删除的接管边界', () => {
+  const META_KEY = 'ghostCommandDecoration';
+
+  /**
+   * 在 state 层跑一次 Backspace:推 roster → 放光标 → 调用。view 只需要
+   * state / dispatch 两个面,applyGhostCommandBackspace 不碰 DOM。
+   */
+  function backspaceAt(
+    initial: PMNode,
+    ghosts: InstalledGhost[],
+    caret: number,
+    caretTo = caret,
+  ): { handled: boolean; text: string; caret: number } {
+    const plugin = createGhostCommandPlugin();
+    let state = EditorState.create({ schema, doc: initial, plugins: [plugin] });
+    state = state.apply(state.tr.setMeta(META_KEY, ghosts));
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, caret, caretTo)));
+    const view = {
+      get state() {
+        return state;
+      },
+      dispatch: (tr: ReturnType<typeof state.tr.delete>) => {
+        state = state.apply(tr);
+      },
+    } as unknown as EditorView;
+    const handled = applyGhostCommandBackspace(view);
+    return {
+      handled,
+      text: state.doc.textBetween(0, state.doc.content.size, '\n'),
+      caret: state.selection.from,
+    };
+  }
+
+  // `$画图 一只猫`:$ 在 1,词尾 4,尾随空格 4,正文自 5 起
+  const 带正文 = () => doc(p(txt('$画图 一只猫')));
+
+  it('光标在胶囊外(尾随空格之后):整体删,不留孤立空格', () => {
+    expect(backspaceAt(带正文(), [画图], 5)).toEqual({ handled: true, text: '一只猫', caret: 1 });
+  });
+
+  it('全角触发符(￥)同权整体删', () => {
+    expect(backspaceAt(doc(p(txt('￥画图 猫'))), [画图], 5)).toMatchObject({
+      handled: true,
+      text: '猫',
+    });
+  });
+
+  it('不接管:光标贴在词尾(视觉上在胶囊右内边距里)—— 那里是编辑位', () => {
+    expect(backspaceAt(带正文(), [画图], 4)).toEqual({
+      handled: false,
+      text: '$画图 一只猫',
+      caret: 4,
+    });
+  });
+
+  it('不接管:没有尾随空格时光标只可能停在胶囊内,一律逐字删', () => {
+    expect(backspaceAt(doc(p(txt('$画图'))), [画图], 4)).toMatchObject({
+      handled: false,
+      text: '$画图',
+    });
+    // 词尾是 hardBreak:光标在换行后属于下一行行首,退格该合并行而不是删引用
+    expect(backspaceAt(doc(p(txt('$画图'), br(), txt('一只猫'))), [画图], 5)).toMatchObject({
+      handled: false,
+    });
+  });
+
+  it('不接管:光标在词中间 / 触发符前 / 正文里 —— 改词能力照旧', () => {
+    expect(backspaceAt(带正文(), [画图], 3)).toMatchObject({
+      handled: false,
+      text: '$画图 一只猫',
+    });
+    expect(backspaceAt(带正文(), [画图], 1)).toMatchObject({
+      handled: false,
+      text: '$画图 一只猫',
+    });
+    expect(backspaceAt(带正文(), [画图], 8)).toMatchObject({
+      handled: false,
+      text: '$画图 一只猫',
+    });
+  });
+
+  it('不接管:选区非空(原生删选区)', () => {
+    expect(backspaceAt(带正文(), [画图], 1, 5)).toMatchObject({ handled: false });
+  });
+
+  it('不接管:胶囊没亮(roster 空 / 未装该指令 / 意识沉睡 / 位置不对)', () => {
+    expect(backspaceAt(带正文(), [], 5)).toMatchObject({ handled: false, text: '$画图 一只猫' });
+    expect(backspaceAt(doc(p(txt('$不存在 猫'))), [画图], 5)).toMatchObject({ handled: false });
+    expect(backspaceAt(带正文(), [makeGhost('画图', { enabled: false })], 5)).toMatchObject({
+      handled: false,
+      text: '$画图 一只猫',
+    });
+    // 正文中段的 `$` 不是消息起点指令,不整体删
+    expect(backspaceAt(doc(p(txt('帮我 $画图 猫'))), [画图], 8)).toMatchObject({ handled: false });
   });
 });
 

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -47,7 +47,11 @@ import {
   type VoiceInputCaretState,
 } from './VoiceInputDraftDecoration';
 import { MentionDragCaretDecoration, setMentionDragCaret } from './MentionDragCaretDecoration';
-import { GhostCommandDecoration, setGhostCommandRoster } from './GhostCommandDecoration';
+import {
+  applyGhostCommandBackspace,
+  GhostCommandDecoration,
+  setGhostCommandRoster,
+} from './GhostCommandDecoration';
 import {
   replaceSlashCommandRunWithText,
   setSlashCommandRoster,
@@ -1805,6 +1809,8 @@ export function ChatInput({
         // Backspace — structured list items exit through the schema command;
         // legacy plain Markdown rows keep the prefix-deletion fallback so
         // pasted and restored text remains editable without a migration pass.
+        // 意识指令胶囊排最后:只在胶囊亮起且光标停在胶囊外(尾随空格之后)才
+        // 接管,胶囊内一律原样落回原生逐字删。
         if (
           event.key === 'Backspace' &&
           !event.metaKey &&
@@ -1812,7 +1818,9 @@ export function ChatInput({
           !event.altKey &&
           !event.shiftKey &&
           !event.isComposing &&
-          (handleStructuredListBackspace(view) || applyListBackspace(view))
+          (handleStructuredListBackspace(view) ||
+            applyListBackspace(view) ||
+            applyGhostCommandBackspace(view))
         ) {
           event.preventDefault();
           return true;

--- a/apps/desktop/src/renderer/components/new-chat/GhostCommandDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/GhostCommandDecoration.ts
@@ -21,7 +21,7 @@
  */
 import { Extension, type Editor } from '@tiptap/core';
 import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
-import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
 import type { Node as PMNode } from '@tiptap/pm/model';
 
 import {
@@ -151,6 +151,43 @@ function buildDecorations(doc: PMNode, ghosts: InstalledGhost[]): DecorationSet 
     Decoration.inline(match.from, match.from + 1, { class: 'ghost-cmd-sigil' }),
     Decoration.inline(match.from + 1, match.to, ghostPillAttrs(match.ghost)),
   ]);
+}
+
+/** 词尾后面紧跟的分隔空白(不含换行——换行在 doc 里是 hardBreak,不是文本)。 */
+const TRAILING_SPACE_RE = /^[^\S\r\n]/;
+
+/**
+ * Backspace 整体删除:光标停在胶囊**外面**——也就是指令词后那个分隔空格之后
+ * ——时,一次删掉 `$指令` 连同那个空格,而不是逐字符啃到胶囊碎掉。
+ *
+ * **胶囊内不接管,包括贴着词尾的位置**(`$画图| 一只猫`)。那里 caret 视觉上落在
+ * 胶囊的右内边距里,是编辑位:用户是想改错字,不是想扔掉整条引用。同理光标落在
+ * 词中间(`$画|图`)也不接管——改词的能力是当初不把指令做成 atom chip 的核心
+ * 诉求,不能被这条捷径吃掉。没有尾随空格时(`$画图` 后直接是段落尾 / hardBreak)
+ * 光标只可能停在胶囊内,因此一律走原生逐字删。
+ *
+ * 判定与胶囊严格同源——同一个 findGhostCommandMatch、同一份 plugin roster,
+ * **胶囊亮才整体删**;没亮(未装/沉睡/拼错/位置不对)返回 false,原生逐字删的
+ * 行为一字不变。
+ *
+ * 纯编辑侧行为:doc 里仍是纯文本,序列化与 expandGhostCommand 发送链路零改动。
+ */
+export function applyGhostCommandBackspace(view: EditorView): boolean {
+  const { state } = view;
+  if (!state.selection.empty) return false;
+  const ghosts = PLUGIN_KEY.getState(state)?.ghosts;
+  if (!ghosts || ghosts.length === 0) return false;
+  const match = findGhostCommandMatch(state.doc, ghosts);
+  if (!match) return false;
+
+  // 面板选中时 ChatInput.insertSlashCommand 会补一个空格(`$cmd `):它既是
+  // 「胶囊外」的唯一落脚点,也随引用一起收走,免得正文前留一个孤立空格。
+  const after = state.doc.resolve(match.to).nodeAfter;
+  if (!after?.isText || !TRAILING_SPACE_RE.test(after.text ?? '')) return false;
+  if (state.selection.from !== match.to + 1) return false;
+
+  view.dispatch(state.tr.delete(match.from, match.to + 1).scrollIntoView());
+  return true;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

插件（意识）在输入框里的 `$指令` 在文档里是**纯文本**，胶囊外观由 ProseMirror decoration 叠上去（`GhostCommandDecoration`），不是 atom chip——所以删除时只能一个字一个字啃，啃到一半胶囊就碎了。

这次给它加上整体退格：**光标停在胶囊外面**（指令词后那个分隔空格之后）按 Backspace，一次删掉 `$指令` 连同那个空格。

**胶囊内不接管**：贴着词尾的位置（`$画图| 一只猫`）视觉上落在胶囊的右内边距里，那里是编辑位——用户是想改错字，不是想扔掉整条引用；词中间（`$画|图`）同样保持原生逐字删。改词能力是当初不把指令做成 atom chip 的核心诉求，不能被这条捷径吃掉。

判定复用 `findGhostCommandMatch` 与同一份 plugin roster，与胶囊渲染**严格同源**：胶囊亮才整体删，没亮（未装 / 沉睡 / 拼错 / 位置不对）一律返回 `false`，原生行为一字不变。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求：无（使用中反馈：引用只能逐字符删）
- 本 PR 包含：`applyGhostCommandBackspace` 判定、ChatInput bare-Backspace 分支接线、单测
- 明确不包含：`/` slash 命令胶囊（机制相同，但 `SlashCommandDecoration` 头部注释把「Backspace 保持逐字」写成明确的设计优点，不在本 PR 顺带改）；Delete（向前删）键；mobile（无此胶囊）
- 用户可见变化：见下「UI 变化」
- 是否存在 breaking change：无

### UI 变化

**无视觉变化**——没有新增或修改任何组件、布局、样式、动效或 UI 文案，一个色值、一处几何都没碰。变化只在交互：Backspace 在特定光标位置的语义。

**演示录屏（macOS Desktop）：**

https://github.com/user-attachments/assets/a682a461-73bd-41bc-8bc3-315e293b8f04

| 光标位置 | 行为 |
|---|---|
| `$画图 \|一只猫`（分隔空格之后，胶囊外） | **整体删** `$画图 `，留下 `一只猫` |
| `$画图\| 一只猫`（贴词尾，胶囊右内边距） | 逐字符删（编辑位） |
| `$画\|图`（词中间） | 逐字符删 |
| `$画图`（无尾随空格，后接段落尾 / hardBreak） | 逐字符删 |

最后一行顺带修掉一个边界：`$画图` 后接 hardBreak 时，光标在换行之后属于**下一行行首**，那里按退格应该合并行，不该回头删上一行的引用。

- 引用的设计规范：`docs/design-rules/DESIGN.md` **§14.3 Keyboard & IME (send-type text fields)**——接管挂在 ChatInput 既有的 bare-Backspace 分支之后，沿用同一套 `!event.isComposing` + 无修饰键守卫，IME 组字期间不触发；`Enter = submit` / `Shift+Enter = newline` 语义未动。判定集中在 `GhostCommandDecoration` 内、与胶囊渲染同源，没有在 ChatInput 里另写一套匹配，满足该节「Centralize this logic in code; do not re-implement it per field and let behavior drift」。**§10 双模式交付门槛不适用**：本次无任何色值或样式改动，两模式渲染路径完全一致。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（exit 0；apps/desktop、apps/mobile 与全部 packages 均 PASS）

pnpm --filter desktop typecheck
结果：通过

pnpm check:dco
结果：通过（1 commit signed off）

pnpm --filter desktop exec eslint <改动文件> / prettier --check <改动文件>
结果：通过
```

新增 8 条单测锁住接管边界（胶囊外整体删 / 贴词尾不接管 / 词中间不接管 / 无尾随空格不接管 / hardBreak 不接管 / 全角 `￥` 同权 / 非空选区不接管 / 胶囊没亮不接管）。`chatInputListContinuation.test.ts` 里那条锁死单行字符串的源码契约断言改成「三段 fallback + 顺序」断言，契约意图未弱化。

### 手工验证

macOS Desktop dev 实例，逐一实测上表四种光标位置，行为与表格一致（录屏见上）。

### 未执行的验证

- **Windows 未实测**：改动是纯 ProseMirror 位置计算，无平台分支、无原生调用。
- **Light / Dark 双模式目检未执行**：本次无任何色值或样式改动，不存在只适配一种模式的可能（按 §10，目检为 best-effort，此处如实说明未做，而非以「复用了 themed 样式」冒充已验证）。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop 输入框的 Backspace 行为，且只在「意识指令胶囊亮起 + 光标在胶囊外」这一个位置接管；其余情况 `applyGhostCommandBackspace` 直接返回 `false`，落回原生逐字删。doc 里仍是纯文本，**序列化与 `expandGhostCommand` 发送链路零改动**，agent 看到的 prompt 文本不受影响。
- 回滚 / 降级方式：还原本 PR 单个 commit 即可；无 migration、无协议、无持久化数据牵连。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动点的设计决策写在代码注释里，与既有 decoration 注释同处）
- [x] 已确认测试结果或说明未执行原因
