### PR TITLE
fix(desktop): make generated titles follow UI locale

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -350,6 +350,17 @@ describe('generateTitleViaProvider — openai(codex Responses SSE)', () => {
     expect(body.stream).toBe(true);
     expect(body.store).toBe(false);
     expect(body.reasoning).toEqual({ effort: 'low' });
+    expect(body.instructions).toBe(
+      'Output only the short conversation title requested by the user message, without quotation marks or ending punctuation.',
+    );
+    expect(body.instructions).not.toContain('Chinese');
+    expect(body.input).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: '起个标题' }],
+      },
+    ]);
   });
   it('无 codex 凭证 → null,不发请求', async () => {
     const fetchImpl = fakeFetch(() => ({ text: SSE }));

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -55,6 +55,12 @@ const log = createLogger('maker-host:title-one-shot');
 const TITLE_TIMEOUT_MS = 12_000;
 /** 标题 ≤ 20 字,32 token 足够;codex Responses 协议层不暴露 max_tokens,仅对 messages/chat 生效。 */
 const TITLE_MAX_TOKENS = 32;
+/**
+ * Codex Responses 要求 instructions 字段，但语言和长度必须由调用方 prompt 决定。
+ * 这里仅约束输出形状，避免覆盖 locale-aware 标题指令。
+ */
+const CODEX_TITLE_INSTRUCTIONS =
+  'Output only the short conversation title requested by the user message, without quotation marks or ending punctuation.';
 
 type FetchImpl = typeof undiciFetch;
 
@@ -207,7 +213,7 @@ async function fetchCodexTitle(
 ): Promise<string> {
   const body: Record<string, unknown> = {
     model: modelId,
-    instructions: 'You output only a short conversation title (<= 10 Chinese chars), no punctuation, no quotes.',
+    instructions: CODEX_TITLE_INSTRUCTIONS,
     input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: prompt }] }],
     tools: [],
     tool_choice: 'auto',

--- a/apps/desktop/src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts
@@ -2,7 +2,7 @@
  * regenerateMakerSessionTitle 单测——重命名输入框 Magic 按钮的 main 侧业务体。
  * 通过 RegenerateTitleDeps 注入内存实现,不触电 electron / DB / LLM。
  */
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }));
 vi.mock('../../logger.js', () => ({
@@ -20,6 +20,9 @@ vi.mock('../../maker-host/createDesktopProviderService.js', () => ({
 vi.mock('../../maker-host/title-one-shot.js', () => ({
   generateTitleViaProvider: vi.fn(),
 }));
+vi.mock('../../i18n.js', () => ({
+  getResolvedMainLocale: vi.fn(() => 'en'),
+}));
 
 import {
   generateMakerSessionTitle,
@@ -27,7 +30,12 @@ import {
   type RegenerateTitleDeps,
 } from '../title.js';
 import { generateTitleViaProvider } from '../../maker-host/title-one-shot.js';
+import { getResolvedMainLocale } from '../../i18n.js';
 import type { RegenerateTitleMaterial } from '../../localDb/latestMessageText.js';
+
+beforeEach(() => {
+  vi.mocked(getResolvedMainLocale).mockReturnValue('en');
+});
 
 /** 默认素材:短会话——最近窗口已覆盖会话开头(开场消息就是窗口第一条)。 */
 function makeDeps(overrides: Partial<RegenerateTitleDeps> = {}): RegenerateTitleDeps {
@@ -63,13 +71,13 @@ describe('regenerateMakerSessionTitle', () => {
     expect(sessionId).toBe('s1');
     expect(agentKind).toBe('claude-code');
     const prompt = promptOf(deps);
-    expect(prompt).toContain('用户: 帮我排查登录失败');
-    expect(prompt).toContain('助手: 已定位到 token 过期问题');
-    // 开场消息 createdAt(1000) 已在窗口内 → 不出现单独的"对话开场"段
-    expect(prompt).not.toContain('对话开场');
+    expect(prompt).toContain('User: 帮我排查登录失败');
+    expect(prompt).toContain('Assistant: 已定位到 token 过期问题');
+    // 开场消息 createdAt(1000) 已在窗口内 → 不出现单独的 opening 段
+    expect(prompt).not.toContain('Conversation opening');
     // transcript 时间正序:用户消息在助手回复之前
-    expect(prompt.indexOf('用户: 帮我排查登录失败')).toBeLessThan(
-      prompt.indexOf('助手: 已定位到 token 过期问题'),
+    expect(prompt.indexOf('User: 帮我排查登录失败')).toBeLessThan(
+      prompt.indexOf('Assistant: 已定位到 token 过期问题'),
     );
   });
 
@@ -87,11 +95,11 @@ describe('regenerateMakerSessionTitle', () => {
     await regenerateMakerSessionTitle('s1', deps);
 
     const prompt = promptOf(deps);
-    expect(prompt).toContain('对话开场: 帮我做一个跨平台的登录模块');
-    expect(prompt).toContain('用户: 继续');
-    expect(prompt).toContain('助手: 已完成 Windows 侧适配');
+    expect(prompt).toContain('Conversation opening: 帮我做一个跨平台的登录模块');
+    expect(prompt).toContain('User: 继续');
+    expect(prompt).toContain('Assistant: 已完成 Windows 侧适配');
     // 短追问兜底指令始终存在
-    expect(prompt).toContain('简短确认');
+    expect(prompt).toContain('brief confirmation');
   });
 
   it('createdAt 全为 null 时仍按 rowid 判定:开场行在窗口内 → 不重复给出', async () => {
@@ -107,7 +115,7 @@ describe('regenerateMakerSessionTitle', () => {
 
     await regenerateMakerSessionTitle('s1', deps);
 
-    expect(promptOf(deps)).not.toContain('对话开场');
+    expect(promptOf(deps)).not.toContain('Conversation opening');
   });
 
   it('同毫秒批量落库把开场行挤出窗口(时间戳与窗口首条相同但 rowid 不在窗口)→ 开场段仍单独给出', async () => {
@@ -123,7 +131,7 @@ describe('regenerateMakerSessionTitle', () => {
 
     await regenerateMakerSessionTitle('s1', deps);
 
-    expect(promptOf(deps)).toContain('对话开场: 帮我梳理导入的聊天记录');
+    expect(promptOf(deps)).toContain('Conversation opening: 帮我梳理导入的聊天记录');
   });
 
   it('超长消息按角色截断:用户 300 字符、助手 400 字符、开场 300 字符', async () => {
@@ -140,11 +148,11 @@ describe('regenerateMakerSessionTitle', () => {
     await regenerateMakerSessionTitle('s1', deps);
 
     const prompt = promptOf(deps);
-    expect(prompt).toContain(`对话开场: ${'o'.repeat(300)}\n`);
+    expect(prompt).toContain(`Conversation opening: ${'o'.repeat(300)}\n`);
     expect(prompt).not.toContain('o'.repeat(301));
-    expect(prompt).toContain(`用户: ${'u'.repeat(300)}\n`);
+    expect(prompt).toContain(`User: ${'u'.repeat(300)}\n`);
     expect(prompt).not.toContain('u'.repeat(301));
-    expect(prompt).toContain(`助手: ${'a'.repeat(400)}`);
+    expect(prompt).toContain(`Assistant: ${'a'.repeat(400)}`);
     expect(prompt).not.toContain('a'.repeat(401));
   });
 
@@ -158,8 +166,8 @@ describe('regenerateMakerSessionTitle', () => {
 
     expect(await regenerateMakerSessionTitle('s1', deps)).toBe('登录失败排查');
     const prompt = promptOf(deps);
-    expect(prompt).toContain('助手: 定时任务已执行完成');
-    expect(prompt).not.toContain('对话开场');
+    expect(prompt).toContain('Assistant: 定时任务已执行完成');
+    expect(prompt).not.toContain('Conversation opening');
   });
 
   it('空 sessionId / 会话不存在 → null 且不发起生成', async () => {
@@ -206,6 +214,20 @@ describe('regenerateMakerSessionTitle', () => {
 
     expect(await regenerateMakerSessionTitle('s1', deps)).toBeNull();
   });
+
+  it.each([
+    ['zh-CN', 'Simplified Chinese'],
+    ['en', 'English'],
+    ['ja', 'Japanese'],
+    ['ko', 'Korean'],
+  ] as const)('界面语言 %s → regenerate prompt 明确要求 %s 标题', async (locale, language) => {
+    vi.mocked(getResolvedMainLocale).mockReturnValue(locale);
+    const deps = makeDeps();
+
+    await regenerateMakerSessionTitle('s1', deps);
+
+    expect(promptOf(deps)).toContain(`Write the title in ${language}.`);
+  });
 });
 
 describe('generateMakerSessionTitle', () => {
@@ -231,5 +253,21 @@ describe('generateMakerSessionTitle', () => {
     expect(request.agentKind).toBe('claude-code');
     expect(request.prompt).toContain('帮我排查登录失败');
     expect(request.prompt).not.toContain('  帮我排查登录失败');
+  });
+
+  it.each([
+    ['zh-CN', 'Simplified Chinese'],
+    ['en', 'English'],
+    ['ja', 'Japanese'],
+    ['ko', 'Korean'],
+  ] as const)('界面语言 %s → auto-title prompt 明确要求 %s 标题', async (locale, language) => {
+    vi.mocked(getResolvedMainLocale).mockReturnValue(locale);
+    vi.mocked(generateTitleViaProvider).mockClear();
+    vi.mocked(generateTitleViaProvider).mockResolvedValueOnce('title');
+
+    await generateMakerSessionTitle('message', 'claude-code', 's1');
+
+    const request = vi.mocked(generateTitleViaProvider).mock.calls[0]?.[0];
+    expect(request?.prompt).toContain(`Write the title in ${language}.`);
   });
 });

--- a/apps/desktop/src/main/maker-ipc/title.ts
+++ b/apps/desktop/src/main/maker-ipc/title.ts
@@ -20,6 +20,8 @@ import { eq } from 'drizzle-orm';
 import { connectedProvidersForAgent, type ProviderView } from '@cindy/model-providers';
 import type { AgentKind } from '@cindy/maker-core';
 
+import type { SupportedLocale } from '../../shared/locale.js';
+import { getResolvedMainLocale } from '../i18n.js';
 import { getDbClient } from '../localDb/client/current.js';
 import { sessions } from '../localDb/schema.js';
 import { getDesktopProviderService } from '../maker-host/createDesktopProviderService.js';
@@ -41,8 +43,21 @@ import {
 
 const log = createLogger('maker-ipc/title');
 
-const TITLE_PROMPT_TEMPLATE = (msg: string) =>
-  `为以下用户消息生成一个简短的对话标题（不超过20个字，不要加引号，不要加标点，直接输出标题）：\n\n${msg.slice(0, 200)}`;
+const TITLE_LANGUAGE_BY_LOCALE: Record<SupportedLocale, string> = {
+  'zh-CN': 'Simplified Chinese',
+  en: 'English',
+  ja: 'Japanese',
+  ko: 'Korean',
+};
+
+const TITLE_PROMPT_TEMPLATE = (msg: string, locale: SupportedLocale) =>
+  [
+    'Generate a concise title for the user message below.',
+    `Write the title in ${TITLE_LANGUAGE_BY_LOCALE[locale]}.`,
+    'Use at most 20 characters. Output only the title, without quotation marks or ending punctuation.',
+    '',
+    msg.slice(0, 200),
+  ].join('\n');
 
 /** regenerate 素材窗口:最近 N 条非空 user/assistant 消息(不含被过滤的工具行)。 */
 const REGENERATE_RECENT_WINDOW = 8;
@@ -55,17 +70,23 @@ const REGENERATE_ASSISTANT_SLICE = 400;
 
 /**
  * Magic 重命名的 prompt:素材是「对话开场(第一条用户消息)+ 最近几轮 transcript」,
- * 语言跟随对话内容。开场只在最近窗口没覆盖到会话开头时单独给出(短会话不重复);
+ * 标题语言跟随界面设置。开场只在最近窗口没覆盖到会话开头时单独给出(短会话不重复);
  * transcript 按时间正序,模型能自然看出最后一条是否只是"继续"式短追问,另用一句
  * 指令兜底,避免标题被短追问带偏。
  */
-const REGENERATE_TITLE_PROMPT = (opening: string | null, transcript: string) =>
+const REGENERATE_TITLE_PROMPT = (
+  opening: string | null,
+  transcript: string,
+  locale: SupportedLocale,
+) =>
   [
-    '根据以下对话内容，用与对话相同的语言生成一个简短的对话标题（不超过20个字，不要加引号，不要加标点，直接输出标题）。',
-    '标题要概括整个对话的核心主题，并兼顾最新进展；如果用户最后的消息只是「继续」「好的」这类简短确认，不要据此起题。',
+    'Generate a concise title for the conversation below.',
+    `Write the title in ${TITLE_LANGUAGE_BY_LOCALE[locale]}.`,
+    'Use at most 20 characters. Output only the title, without quotation marks or ending punctuation.',
+    'Summarize the core topic of the whole conversation while reflecting the latest progress. If the final user message is only a brief confirmation such as "continue" or "okay", do not base the title on it.',
     '',
-    ...(opening ? [`对话开场: ${opening}`, ''] : []),
-    '最近的对话:',
+    ...(opening ? [`Conversation opening: ${opening}`, ''] : []),
+    'Recent conversation:',
     transcript,
   ].join('\n');
 
@@ -111,7 +132,7 @@ export async function generateMakerSessionTitle(
     {
       sessionId: sessionId ?? '',
       agentKind,
-      prompt: TITLE_PROMPT_TEMPLATE(trimmed),
+      prompt: TITLE_PROMPT_TEMPLATE(trimmed, getResolvedMainLocale()),
     },
     {
       readSessionProviderId: readSessionProviderIdFromDb,
@@ -178,15 +199,15 @@ export async function regenerateMakerSessionTitle(
     const transcript = recent
       .map((m) =>
         m.role === 'user'
-          ? `用户: ${m.text.slice(0, REGENERATE_USER_SLICE)}`
-          : `助手: ${m.text.slice(0, REGENERATE_ASSISTANT_SLICE)}`,
+          ? `User: ${m.text.slice(0, REGENERATE_USER_SLICE)}`
+          : `Assistant: ${m.text.slice(0, REGENERATE_ASSISTANT_SLICE)}`,
       )
       .join('\n');
     const title = (
       await deps.generateTitle(
         sessionId,
         agentKind,
-        REGENERATE_TITLE_PROMPT(openingText, transcript),
+        REGENERATE_TITLE_PROMPT(openingText, transcript, getResolvedMainLocale()),
       )
     )?.trim();
     return title || null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复自动生成标题与“重新生成标题”始终偏向中文的问题。两条标题生成路径现在都会读取主进程已解析的界面语言，并明确要求标题模型使用对应的简体中文、英文、日文或韩文输出。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#919
- 本 PR 包含：Desktop 自动起名与重新起名 prompt 的 locale 注入；四种界面语言的回归测试
- 明确不包含：独立的标题语言设置、UI 改动、移动端改动
- 用户可见变化：生成的对话标题会跟随当前界面语言
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts
结果：通过，20 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过，全部可运行 workspace 单测通过

pnpm check:dco
结果：通过，origin/main..HEAD 共 1 个 commit 且已签名
```

### 手工验证

未执行：当前 worktree 不对应正在运行的 Desktop 实例，且真实标题生成需要已连接的模型供应商。

### 未执行的验证

未在 macOS 实机验证；本次只调整平台无关的 TypeScript prompt 组装逻辑。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 自动标题与重新生成标题的模型输入。不同模型对“最多 20 个字符”的遵循程度可能略有差异。
- 回滚 / 降级方式：回退本提交即可恢复旧 prompt；模型调用失败时原有标题 fallback 行为不变。
- 移动端冷更判断：不涉及 `apps/mobile`、原生依赖或 runtime fingerprint 输入，不会触发移动端冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因