### PR TITLE
feat(mobile): expose composer attachment shortcuts

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -4896,6 +4896,15 @@ export default function SessionScreen() {
     />
   ) : null);
 
+  // 收起态把附件 + 号放在输入框左侧，避免用户必须先聚焦输入框才能打开附件面板；
+  // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
+  const renderComposerCompactLeading = () => (
+    <View style={styles.composerCompactLeading}>
+      {renderComposerAttachmentButton()}
+      {renderComposerCollapsedAttachmentBadge()}
+    </View>
+  );
+
   // 停止任务按钮(实心中性方块)。两处使用:语音/发送左边的独立槽(inline)、
   // 发送位顶替(sendSlotIsStop);同一颗按钮的两个宿主位置,样式与行为一致。
   const renderComposerStopButton = () => (
@@ -7299,7 +7308,7 @@ export default function SessionScreen() {
                     inputOverlay={renderComposerInputOverlay()}
                     inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
                     inputTestID="session.composerInput"
-                    leading={renderComposerCollapsedAttachmentBadge()}
+                    leading={renderComposerCompactLeading()}
                     maxHeight={composerResize.inputMaxHeight}
                     multilineShape={!composerCardActive && composerInputIsMultiline}
                     onBlur={() => {
@@ -8492,6 +8501,12 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     justifyContent: 'center',
     height: 34,
     width: 34,
+  },
+  composerCompactLeading: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginRight: spacing.xs,
   },
   composerToolButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -2204,6 +2204,15 @@ export default function NewRemoteSessionScreen() {
       testID="newSession.attachmentCollapsedBadge"
     />
   ) : null);
+
+  // 收起态把附件 + 号放在输入框左侧，避免用户必须先聚焦输入框才能打开附件面板；
+  // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
+  const renderComposerCompactLeading = () => (
+    <View style={styles.composerCompactLeading}>
+      {renderAttachmentToggleButton()}
+      {renderComposerCollapsedAttachmentBadge()}
+    </View>
+  );
   // 面板关闭即丢弃未提交的待选(不产生任何上传副作用)。
   useEffect(() => {
     if (!contextSheetOpen) setPendingMediaAssets([]);
@@ -2878,7 +2887,7 @@ export default function NewRemoteSessionScreen() {
                   caretHidden={voiceIsListening}
                   cursorColor={colors.inputCaret}
                   inputRef={firstMessageInputRef}
-                  leading={renderComposerCollapsedAttachmentBadge()}
+                  leading={renderComposerCompactLeading()}
                   inputFrameHeight={composerResize.frameHeight}
                   // 听写期间把输入区撑到 44pt 触控目标:此时「点输入区停止听写」的命中层
                   // 是这层输入区自身(TextInput 的 onPressIn),单行时只有 28pt。
@@ -3584,6 +3593,12 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     height: MOBILE_COMPOSER_CONTROL_SIZE,
     justifyContent: 'center',
     width: MOBILE_COMPOSER_CONTROL_SIZE,
+  },
+  composerCompactLeading: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginRight: spacing.xs,
   },
   composerIconButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -294,7 +294,7 @@ export function MobileComposerInputRow({
             styles.inputFrame,
             // 收起态左侧的 34pt + 按钮会把主行撑高到控件高度；
             // 单行输入自身只有 28pt，需在主行内居中，避免 placeholder / 文本贴到顶部。
-            !cardLayout && !multilineShape && styles.inputFrameSingleLine,
+            !cardLayout && !multilineShape && inputFrameMinHeight == null && styles.inputFrameSingleLine,
             inputFrameMinHeight != null && { minHeight: inputFrameMinHeight },
             resolvedInputFrameHeight != null && { height: resolvedInputFrameHeight },
           ]}

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -292,6 +292,9 @@ export function MobileComposerInputRow({
         <Animated.View
           style={[
             styles.inputFrame,
+            // 收起态左侧的 34pt + 按钮会把主行撑高到控件高度；
+            // 单行输入自身只有 28pt，需在主行内居中，避免 placeholder / 文本贴到顶部。
+            !cardLayout && !multilineShape && styles.inputFrameSingleLine,
             inputFrameMinHeight != null && { minHeight: inputFrameMinHeight },
             resolvedInputFrameHeight != null && { height: resolvedInputFrameHeight },
           ]}
@@ -536,6 +539,9 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     flexDirection: 'row',
     minWidth: 0,
     position: 'relative',
+  },
+  inputFrameSingleLine: {
+    alignItems: 'center',
   },
   // TextInputWrapper(expo-paste-input)接管 TextInput 在 inputFrame row 里的
   // flex:1 位置;内部保持 row + stretch,TextInput 自身 flex:1 继续填满,


### PR DESCRIPTION
## 这次改了什么

### 摘要

将移动端输入框的附件 `+` 入口放到收起态输入行左侧，点击后可直接进入已有的照片、拍照、文件等附件面板；同时修正单行占位文字在 `+` 按钮撑高主行后的垂直对齐。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Closes #898
- 本 PR 包含：会话页、新建会话页的收起态附件快捷入口；共享输入行的单行垂直居中。
- 明确不包含：附件上传协议、原生依赖、runtime fingerprint、附件选择器实现。
- 用户可见变化：未聚焦输入框时即可看到并点击 `+`，一层打开附件相关入口。
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Buttons、§5 Spacing System、§5 Border Radius Scale；按钮复用现有 pill 控件和主题 token，Light/Dark 均沿用现有 themed styles。

## 怎么验证的

### 自动验证

```text
PATH="/Users/kmny/Library/pnpm/.tools/pnpm/10.33.2/bin:$PATH" pnpm test:unit
结果：通过（根 runner 311 项通过 310 项，1 项按现有配置跳过；所有 unit workspace 通过）

PATH="/Users/kmny/Library/pnpm/.tools/pnpm/10.33.2/bin:$PATH" pnpm --filter mobile run --if-present typecheck
结果：通过

相关 Mobile 单测：sessionComposerDesktopFirst.test.ts、newSession.test.ts
结果：47 项通过
```

### 手工验证

待在 iOS 模拟器保持 Metro 运行时验证：收起态输入框左侧显示 `+`；点击后可进入照片、拍照、文件入口；选择附件后进入待发送托盘并可发送；检查占位文字与左右控件垂直居中。

### 未执行的验证

本轮提交前未再次完成上述 iOS 模拟器点击回归；未改动原生配置，因此不需要重建 development client。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

仅影响 Mobile composer 的 JS/UI 布局，复用现有附件链路；回滚该 commit 即可恢复原入口位置。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
