### PR TITLE
fix(desktop): 静默自动任务的多 turn run 不再漏发系统通知

### DIFF
--- a/apps/desktop/src/main/maker-ipc/schedule.ts
+++ b/apps/desktop/src/main/maker-ipc/schedule.ts
@@ -484,8 +484,15 @@ export function registerScheduleHandlers(getMaker?: () => Maker | null): void {
     return withScheduler(({ scheduler }) => scheduler.listRuns(id, lim));
   });
 
+  // 一并回传引擎的 in-flight runId 快照:renderer 的通知抑制标记要靠它区分「DB 里查不到
+  // 这条 run」的两种含义 —— 已结束并被清理,还是自删除场景下行已消失却仍在跑(见
+  // scheduler.listInflightRunIds 的注释)。同一次 invoke 取两份数据,天然是一致快照;
+  // runId 本身不是特权数据(renderer 的标记里就存着它)。
   ipcMain.handle(MAKER_INVOKE.SCHEDULE_LIST_SIDEBAR_INDEX_RUNS, async () =>
-    withScheduler(({ storage }) => storage.listSidebarIndexRuns()),
+    withScheduler(async ({ storage, scheduler }) => ({
+      runs: await storage.listSidebarIndexRuns(),
+      inflightRunIds: scheduler.listInflightRunIds(),
+    })),
   );
 
   ipcMain.handle(MAKER_INVOKE.SCHEDULE_LIST_COST_SUMMARIES, async () =>

--- a/apps/desktop/src/main/maker-ipc/schedule.ts
+++ b/apps/desktop/src/main/maker-ipc/schedule.ts
@@ -486,8 +486,12 @@ export function registerScheduleHandlers(getMaker?: () => Maker | null): void {
 
   // 一并回传引擎的 in-flight runId 快照:renderer 的通知抑制标记要靠它区分「DB 里查不到
   // 这条 run」的两种含义 —— 已结束并被清理,还是自删除场景下行已消失却仍在跑(见
-  // scheduler.listInflightRunIds 的注释)。同一次 invoke 取两份数据,天然是一致快照;
-  // runId 本身不是特权数据(renderer 的标记里就存着它)。
+  // scheduler.listInflightRunIds 的注释)。runId 本身不是特权数据(renderer 的标记里就
+  // 存着它)。
+  //
+  // 注意这**不是**原子快照:两次读之间隔着 DB 查询的 await,run 恰好在那个窗口内结束时
+  // 会出现「行还是 running、controller 已注销」。消费方(reconcileRunMarkers)能识别这种
+  // 不一致并安排一次重查,所以这里不为它忙等重采样。
   ipcMain.handle(MAKER_INVOKE.SCHEDULE_LIST_SIDEBAR_INDEX_RUNS, async () =>
     withScheduler(async ({ storage, scheduler }) => ({
       runs: await storage.listSidebarIndexRuns(),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -4772,7 +4772,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       } | UtilityTextFailure> => ipcRenderer.invoke('maker:schedule:generate-pre-run-hook', params),
       listRuns: (id: string, limit?: number): Promise<unknown[]> =>
         ipcRenderer.invoke('maker:schedule:list-runs', id, limit),
-      listSidebarIndexRuns: (): Promise<unknown[]> =>
+      // 回传 { runs, inflightRunIds }:后者是引擎内存里的权威 in-flight 集合,renderer 的
+      // 通知抑制标记对账靠它区分「runs 里查不到 = 跑完了」与「= 自删除后行已级联删除、
+      // run 仍在跑」。runId 不是特权数据(renderer 的标记里就存着它)。
+      listSidebarIndexRuns: (): Promise<unknown> =>
         ipcRenderer.invoke('maker:schedule:list-sidebar-index-runs'),
       listCostSummaries: (): Promise<unknown[]> =>
         ipcRenderer.invoke('maker:schedule:list-cost-summaries'),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -4774,7 +4774,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('maker:schedule:list-runs', id, limit),
       // 回传 { runs, inflightRunIds }:后者是引擎内存里的权威 in-flight 集合,renderer 的
       // 通知抑制标记对账靠它区分「runs 里查不到 = 跑完了」与「= 自删除后行已级联删除、
-      // run 仍在跑」。runId 不是特权数据(renderer 的标记里就存着它)。
+      // run 仍在跑」。两者不是原子快照,不一致由消费方重查收口(见 main 侧 handler 注释)。
+      // runId 不是特权数据(renderer 的标记里就存着它)。
       listSidebarIndexRuns: (): Promise<unknown> =>
         ipcRenderer.invoke('maker:schedule:list-sidebar-index-runs'),
       listCostSummaries: (): Promise<unknown[]> =>

--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -865,7 +865,10 @@ describe('automation-generated sessions', () => {
     );
     const preloadSource = readTextLf(new URL('../../preload/preload.ts', import.meta.url), 'utf8');
 
-    expect(scheduleIndexHookSource).toContain('loadScheduleSidebarIndexRuns()');
+    // 这个 hook 取 snapshot 变体:除了 run 列表还要引擎的 in-flight 集合,用于通知抑制
+    // 标记的对账(见 scheduleSidebarIndexRuns 与 scheduler.listInflightRunIds)。两者是
+    // 同一条 sidebar index IPC,本用例要锁的「不走 per-schedule history limit」不变。
+    expect(scheduleIndexHookSource).toContain('loadScheduleSidebarIndexSnapshot()');
     expect(scheduleIndexHookSource).not.toContain('RUNS_PER_SCHEDULE_LIMIT');
     expect(scheduleIndexHookSource).not.toContain('listRuns(');
     expect(unreadCountsHookSource).toContain('loadScheduleSidebarIndexRuns()');

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -283,6 +283,47 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
     }
   });
 
+  /**
+   * 回归(greptile review P1):退避档位用尽后如果彻底停手,「scheduler / IPC / DB 连续
+   * 不可用超过三档窗口 + 此后再无事件」就会让标记永久残留。仍有标记待对账时按最后一档
+   * 持续重试。
+   */
+  it('keeps retrying past the backoff table while markers still await reconciliation', async () => {
+    vi.useFakeTimers();
+    try {
+      const listSidebarIndexRuns = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('e1'))
+        .mockRejectedValueOnce(new Error('e2'))
+        .mockRejectedValueOnce(new Error('e3'))
+        .mockRejectedValueOnce(new Error('e4'))
+        .mockResolvedValue([indexRun({ runId: 'run-lost', status: 'success' })]);
+      vi.stubGlobal('electronAPI', {
+        maker: { schedule: { listSidebarIndexRuns, onEvent: vi.fn(() => () => undefined) } },
+        notificationMarkSessionAttention: vi.fn().mockResolvedValue(undefined),
+        notificationClearSessionAttention: vi.fn().mockResolvedValue(undefined),
+      });
+      markNextSessionDoneSilenced('run-lost', 'session-1');
+
+      renderHook(() => useAutomationScheduleSessionIndex());
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // 2s / 8s / 30s 三档全部失败后，第四次失败仍应排下一次（降频持续）。
+      for (const delay of [2_000, 8_000, 30_000, 30_000]) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(delay);
+        });
+      }
+
+      expect(listSidebarIndexRuns).toHaveBeenCalledTimes(5);
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps markers whose run is still in flight', async () => {
     stubApiWithRuns([
       indexRun({ runId: 'run-live', status: 'running' }),

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -10,8 +10,8 @@ import {
   hasSessionAttention,
 } from '@/lib/sessionAttentionStore';
 import {
-  observeNextSessionTerminalNotificationOwnedByScheduler,
-  observeNextSessionDoneSilenced,
+  isSessionTerminalNotificationOwnedByScheduler,
+  isSessionDoneSilenced,
   resetSilencedSessionDoneStoreForTests,
 } from '@/lib/silencedSessionDoneStore';
 
@@ -56,7 +56,7 @@ describe('useAutomationScheduleSessionIndex silence events', () => {
       });
     });
 
-    expect(observeNextSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
+    expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
   });
 
   it('registers silenced runs without clearing older session attention', () => {
@@ -86,7 +86,7 @@ describe('useAutomationScheduleSessionIndex silence events', () => {
     });
 
     expect(hasSessionAttention('session-1')).toBe(true);
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
   });
 
   it('clears silenced done suppression when the run requests notification', () => {
@@ -113,8 +113,8 @@ describe('useAutomationScheduleSessionIndex silence events', () => {
       });
     });
 
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(false);
-    expect(observeNextSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(false);
+    expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
   });
 
   it('clears only attention that could have been created by the silenced run fallback', () => {
@@ -165,7 +165,7 @@ describe('useAutomationScheduleSessionIndex silence events', () => {
       });
     });
 
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
   });
 
   it('does not clear older attention when completed supplies the first silenced sessionId', () => {
@@ -189,6 +189,6 @@ describe('useAutomationScheduleSessionIndex silence events', () => {
     });
 
     expect(hasSessionAttention('session-1')).toBe(true);
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   isSessionTerminalNotificationOwnedByScheduler,
   isSessionDoneSilenced,
+  MARKER_TERMINAL_LINGER_MS,
   markNextSessionDoneSilenced,
   markNextSessionTerminalNotificationOwnedByScheduler,
   resetSilencedSessionDoneStoreForTests,
@@ -229,20 +230,32 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
   }
 
   it('clears markers whose run already reached a terminal status', async () => {
-    stubApiWithRuns([
-      indexRun({ runId: 'run-lost', status: 'success' }),
-    ]);
-    // 标记建立后 completed / failed 事件都没送到(广播断链、或事件早于消费方挂载)。
-    markNextSessionDoneSilenced('run-lost', 'session-1');
-    markNextSessionTerminalNotificationOwnedByScheduler('run-lost', 'session-1');
-    expect(isSessionDoneSilenced('session-1')).toBe(true);
+    vi.useFakeTimers();
+    try {
+      stubApiWithRuns([
+        indexRun({ runId: 'run-lost', status: 'success' }),
+      ]);
+      // 标记建立后 completed / failed 事件都没送到(广播断链、或事件早于消费方挂载)。
+      markNextSessionDoneSilenced('run-lost', 'session-1');
+      markNextSessionTerminalNotificationOwnedByScheduler('run-lost', 'session-1');
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
 
-    renderHook(() => useAutomationScheduleSessionIndex());
-    await waitFor(() => {
+      renderHook(() => useAutomationScheduleSessionIndex());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      // 对账只排下 linger,窗口内标记仍在 —— 留给可能尚未处理的 done transition。
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MARKER_TERMINAL_LINGER_MS + 1);
+      });
+
       expect(isSessionDoneSilenced('session-1')).toBe(false);
-    });
-
-    expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(false);
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   /**
@@ -271,9 +284,12 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
       });
       expect(isSessionDoneSilenced('session-1')).toBe(true);
 
-      // 退避重试到来，对账完成，标记自愈。
+      // 退避重试到来，对账排下 linger；再等 linger 到点标记才真正退场。
       await act(async () => {
         await vi.advanceTimersByTimeAsync(2_000);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MARKER_TERMINAL_LINGER_MS + 1);
       });
 
       expect(listSidebarIndexRuns).toHaveBeenCalledTimes(2);
@@ -316,6 +332,10 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
           await vi.advanceTimersByTimeAsync(delay);
         });
       }
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MARKER_TERMINAL_LINGER_MS + 1);
+      });
 
       expect(listSidebarIndexRuns).toHaveBeenCalledTimes(5);
       expect(isSessionDoneSilenced('session-1')).toBe(false);

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -245,6 +245,44 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
     expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(false);
   });
 
+  /**
+   * 回归(greptile review P1):这次拉取同时是标记对账的载体,失败路径原本只 log。
+   * 「卸载期间丢终态事件 + 重新挂载时首次拉取 reject(scheduler 未 ready / 临时 IPC 或
+   * DB 错误)+ 此后再无任何 scheduler / read-sync 事件」这条链上,标记会永久残留。
+   */
+  it('retries the reconciliation after a failed refresh', async () => {
+    vi.useFakeTimers();
+    try {
+      const listSidebarIndexRuns = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('scheduler not ready'))
+        .mockResolvedValue([indexRun({ runId: 'run-lost', status: 'success' })]);
+      vi.stubGlobal('electronAPI', {
+        maker: { schedule: { listSidebarIndexRuns, onEvent: vi.fn(() => () => undefined) } },
+        notificationMarkSessionAttention: vi.fn().mockResolvedValue(undefined),
+        notificationClearSessionAttention: vi.fn().mockResolvedValue(undefined),
+      });
+      markNextSessionDoneSilenced('run-lost', 'session-1');
+
+      renderHook(() => useAutomationScheduleSessionIndex());
+      // 首次拉取 reject —— 此时标记还留着，且不会再有 scheduler 事件来触发第二次。
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+
+      // 退避重试到来，对账完成，标记自愈。
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+
+      expect(listSidebarIndexRuns).toHaveBeenCalledTimes(2);
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps markers whose run is still in flight', async () => {
     stubApiWithRuns([
       indexRun({ runId: 'run-live', status: 'running' }),

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -203,11 +203,11 @@ describe('useAutomationScheduleSessionIndex silence events', () => {
  * 固定时长)都被证明会误判,见 silencedSessionDoneStore 的文件头注释。
  */
 describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
-  function stubApiWithRuns(runs: unknown[]): void {
+  function stubApiWithRuns(runs: unknown[], inflightRunIds: string[] = []): void {
     vi.stubGlobal('electronAPI', {
       maker: {
         schedule: {
-          listSidebarIndexRuns: vi.fn().mockResolvedValue(runs),
+          listSidebarIndexRuns: vi.fn().mockResolvedValue({ runs, inflightRunIds }),
           onEvent: vi.fn(() => () => undefined),
         },
       },
@@ -269,7 +269,7 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
       const listSidebarIndexRuns = vi
         .fn()
         .mockRejectedValueOnce(new Error('scheduler not ready'))
-        .mockResolvedValue([indexRun({ runId: 'run-lost', status: 'success' })]);
+        .mockResolvedValue({ runs: [indexRun({ runId: 'run-lost', status: 'success' })], inflightRunIds: [] });
       vi.stubGlobal('electronAPI', {
         maker: { schedule: { listSidebarIndexRuns, onEvent: vi.fn(() => () => undefined) } },
         notificationMarkSessionAttention: vi.fn().mockResolvedValue(undefined),
@@ -313,7 +313,7 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
         .mockRejectedValueOnce(new Error('e2'))
         .mockRejectedValueOnce(new Error('e3'))
         .mockRejectedValueOnce(new Error('e4'))
-        .mockResolvedValue([indexRun({ runId: 'run-lost', status: 'success' })]);
+        .mockResolvedValue({ runs: [indexRun({ runId: 'run-lost', status: 'success' })], inflightRunIds: [] });
       vi.stubGlobal('electronAPI', {
         maker: { schedule: { listSidebarIndexRuns, onEvent: vi.fn(() => () => undefined) } },
         notificationMarkSessionAttention: vi.fn().mockResolvedValue(undefined),
@@ -339,6 +339,30 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
 
       expect(listSidebarIndexRuns).toHaveBeenCalledTimes(5);
       expect(isSessionDoneSilenced('session-1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * 回归(codex review P1):自删除 run 的行已随 schedule 级联删除,DB 快照里查不到它,
+   * 但引擎的 in-flight 快照说它还在跑 —— 标记必须保住。
+   */
+  it('keeps markers for a self-deleting run reported in-flight though absent from runs', async () => {
+    vi.useFakeTimers();
+    try {
+      stubApiWithRuns([], ['run-self-delete']);
+      markNextSessionDoneSilenced('run-self-delete', 'session-1');
+
+      renderHook(() => useAutomationScheduleSessionIndex());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MARKER_TERMINAL_LINGER_MS * 3);
+      });
+
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SchedulerEvent } from '@cindy/maker-scheduler';
 
@@ -12,6 +12,8 @@ import {
 import {
   isSessionTerminalNotificationOwnedByScheduler,
   isSessionDoneSilenced,
+  markNextSessionDoneSilenced,
+  markNextSessionTerminalNotificationOwnedByScheduler,
   resetSilencedSessionDoneStoreForTests,
 } from '@/lib/silencedSessionDoneStore';
 
@@ -189,6 +191,77 @@ describe('useAutomationScheduleSessionIndex silence events', () => {
     });
 
     expect(hasSessionAttention('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
+  });
+});
+
+/**
+ * 事件丢失的自愈:refresh 拉到的 sidebar run 列表就是 scheduler 落库的权威状态
+ * (且包含所有带 sessionId 的 run,没有 history limit),据它对账标记。
+ * 刻意不用定时器猜 run 是否还在飞行 —— 三种判据(事件序 / renderer running 快照 /
+ * 固定时长)都被证明会误判,见 silencedSessionDoneStore 的文件头注释。
+ */
+describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
+  function stubApiWithRuns(runs: unknown[]): void {
+    vi.stubGlobal('electronAPI', {
+      maker: {
+        schedule: {
+          listSidebarIndexRuns: vi.fn().mockResolvedValue(runs),
+          onEvent: vi.fn(() => () => undefined),
+        },
+      },
+      notificationMarkSessionAttention: vi.fn().mockResolvedValue(undefined),
+      notificationClearSessionAttention: vi.fn().mockResolvedValue(undefined),
+    });
+  }
+
+  function indexRun(overrides: Record<string, unknown>): Record<string, unknown> {
+    return {
+      runId: 'run-x',
+      scheduleId: 'schedule-1',
+      scheduleName: '定时任务',
+      scheduleStatus: 'active',
+      sessionId: 'session-1',
+      status: 'running',
+      readAt: 1,
+      ...overrides,
+    };
+  }
+
+  it('clears markers whose run already reached a terminal status', async () => {
+    stubApiWithRuns([
+      indexRun({ runId: 'run-lost', status: 'success' }),
+    ]);
+    // 标记建立后 completed / failed 事件都没送到(广播断链、或事件早于消费方挂载)。
+    markNextSessionDoneSilenced('run-lost', 'session-1');
+    markNextSessionTerminalNotificationOwnedByScheduler('run-lost', 'session-1');
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
+
+    renderHook(() => useAutomationScheduleSessionIndex());
+    await waitFor(() => {
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    });
+
+    expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(false);
+  });
+
+  it('keeps markers whose run is still in flight', async () => {
+    stubApiWithRuns([
+      indexRun({ runId: 'run-live', status: 'running' }),
+    ]);
+    markNextSessionDoneSilenced('run-live', 'session-1');
+
+    renderHook(() => useAutomationScheduleSessionIndex());
+    // 等 refresh 落地后再断言，否则可能在对账发生前就通过。
+    await waitFor(() => {
+      expect(
+        vi.mocked(window.electronAPI.maker.schedule.listSidebarIndexRuns),
+      ).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     expect(isSessionDoneSilenced('session-1')).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -368,10 +368,57 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
     }
   });
 
+  /**
+   * 回归(codex review P1):DB 说 running、引擎的 in-flight 快照里却没有 —— 两份读之间那个
+   * await 窗口里 run 刚好结束了。本轮保守保持标记,但必须自己排一次重查,否则若该 run 的
+   * 终态事件正是丢掉的那个就再没信号来清它。下一轮 DB 已落终态,标记正常退场。
+   */
+  it('rechecks by itself when the two reads disagree, then clears on the next round', async () => {
+    vi.useFakeTimers();
+    try {
+      const listSidebarIndexRuns = vi
+        .fn()
+        // 第一轮:行还是 running,但 controller 已注销 → 不一致。
+        .mockResolvedValueOnce({
+          runs: [indexRun({ runId: 'run-racing', status: 'running' })],
+          inflightRunIds: [],
+        })
+        // 重查:DB 已落终态。
+        .mockResolvedValue({
+          runs: [indexRun({ runId: 'run-racing', status: 'success' })],
+          inflightRunIds: [],
+        });
+      vi.stubGlobal('electronAPI', {
+        maker: { schedule: { listSidebarIndexRuns, onEvent: vi.fn(() => () => undefined) } },
+        notificationMarkSessionAttention: vi.fn().mockResolvedValue(undefined),
+        notificationClearSessionAttention: vi.fn().mockResolvedValue(undefined),
+      });
+      markNextSessionDoneSilenced('run-racing', 'session-1');
+
+      renderHook(() => useAutomationScheduleSessionIndex());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      // 第一轮不清 —— 无法区分它是否真的还在跑。
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+
+      // 重查 + 退场 linger。
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MARKER_TERMINAL_LINGER_MS + 1);
+      });
+
+      expect(listSidebarIndexRuns.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps markers whose run is still in flight', async () => {
-    stubApiWithRuns([
-      indexRun({ runId: 'run-live', status: 'running' }),
-    ]);
+    stubApiWithRuns([indexRun({ runId: 'run-live', status: 'running' })], ['run-live']);
     markNextSessionDoneSilenced('run-live', 'session-1');
 
     renderHook(() => useAutomationScheduleSessionIndex());

--- a/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationScheduleSilenceHook.test.ts
@@ -417,6 +417,48 @@ describe('useAutomationScheduleSessionIndex marker reconciliation', () => {
     }
   });
 
+  /**
+   * 回归(codex review P1):卸载时拉取仍 pending,它之后 reject(如撞上 scheduler readiness
+   * 的 30s 超时)会走 catch 再排新定时器 —— cleanup 只清得掉「那一刻已存在」的定时器。有
+   * 标记时退避耗尽后会每 30s 无限重试,拖着已卸载的 hook 持续发无用 IPC/DB 读。
+   */
+  it('does not schedule any retry after the hook unmounts', async () => {
+    vi.useFakeTimers();
+    try {
+      let rejectPending!: (err: Error) => void;
+      const listSidebarIndexRuns = vi.fn(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectPending = reject;
+          }),
+      );
+      vi.stubGlobal('electronAPI', {
+        maker: { schedule: { listSidebarIndexRuns, onEvent: vi.fn(() => () => undefined) } },
+        notificationMarkSessionAttention: vi.fn().mockResolvedValue(undefined),
+        notificationClearSessionAttention: vi.fn().mockResolvedValue(undefined),
+      });
+      // 留一个标记：否则退避耗尽后本来就会停手，测不出问题。
+      markNextSessionDoneSilenced('run-x', 'session-1');
+
+      const { unmount } = renderHook(() => useAutomationScheduleSessionIndex());
+      unmount();
+
+      // 卸载之后 pending 的那次拉取才失败。
+      await act(async () => {
+        rejectPending(new Error('scheduler not ready'));
+        await Promise.resolve();
+      });
+      // 远超所有退避档位：不该再有任何一次拉取。
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120_000);
+      });
+
+      expect(listSidebarIndexRuns).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps markers whose run is still in flight', async () => {
     stubApiWithRuns([indexRun({ runId: 'run-live', status: 'running' })], ['run-live']);
     markNextSessionDoneSilenced('run-live', 'session-1');

--- a/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
@@ -11,6 +11,7 @@ import {
   isSessionDoneSilenced,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
+  MARKER_TERMINAL_LINGER_MS,
   reconcileRunMarkers,
   rememberScheduleRunSessionAttentionBaseline,
   resetSilencedSessionDoneStoreForTests,
@@ -155,19 +156,35 @@ describe('silencedSessionDoneStore', () => {
    * 都被证明会误判,详见 store 的文件头注释。
    */
   describe('reconciliation against authoritative run status', () => {
-    it('clears markers whose run already reached a terminal status', () => {
-      markNextSessionDoneSilenced('run-s', 'session-silenced');
-      markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
+    /**
+     * 回归(codex review P1):对账清除必须走同一段 linger,不能立即删。终态事件丢了的
+     * 标记从未排过 linger,而 DB 可能已报终态、React 却还没处理该 session 的
+     * running→done —— 立刻删会让那次 transition 看不到标记、发出不该发的通知。
+     */
+    it('lets terminal markers linger so a pending done transition still sees them', () => {
+      vi.useFakeTimers();
+      try {
+        markNextSessionDoneSilenced('run-s', 'session-silenced');
+        markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
 
-      reconcileRunMarkers(
-        new Map([
-          ['run-s', 'terminal' as const],
-          ['run-o', 'terminal' as const],
-        ]),
-      );
+        reconcileRunMarkers(
+          new Map([
+            ['run-s', 'terminal' as const],
+            ['run-o', 'terminal' as const],
+          ]),
+        );
 
-      expect(isSessionDoneSilenced('session-silenced')).toBe(false);
-      expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+        // 对账当拍不删:还在 linger 窗口内,pending 的 done transition 仍看得到标记。
+        expect(isSessionDoneSilenced('session-silenced')).toBe(true);
+        expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
+
+        vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS + 1);
+
+        expect(isSessionDoneSilenced('session-silenced')).toBe(false);
+        expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     /**
@@ -198,22 +215,42 @@ describe('silencedSessionDoneStore', () => {
      * 就保持」会让标记永久残留。
      */
     it('clears markers whose run no longer exists in the snapshot', () => {
-      markNextSessionDoneSilenced('run-deleted', 'session-silenced');
-      markNextSessionTerminalNotificationOwnedByScheduler('run-gone', 'session-owned');
+      vi.useFakeTimers();
+      try {
+        markNextSessionDoneSilenced('run-deleted', 'session-silenced');
+        markNextSessionTerminalNotificationOwnedByScheduler('run-gone', 'session-owned');
 
-      // 快照非空,但完全不含这两个 run —— 它们已经被删掉了。
-      reconcileRunMarkers(new Map([['some-live-run', 'running' as const]]));
+        // 快照非空,但完全不含这两个 run —— 它们已经被删掉了。
+        reconcileRunMarkers(new Map([['some-live-run', 'running' as const]]));
+        vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS + 1);
 
-      expect(isSessionDoneSilenced('session-silenced')).toBe(false);
-      expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+        expect(isSessionDoneSilenced('session-silenced')).toBe(false);
+        expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
-    it('treats an empty snapshot as a query anomaly and changes nothing', () => {
-      markNextSessionDoneSilenced('run-s', 'session-silenced');
+    /**
+     * 回归(codex + greptile review P1):权威查询在库里没有匹配行时**合法**返回空数组
+     * (删掉最后一个 schedule、或唯一的 run 被 defer 后删除),查询失败走的是 reject +
+     * 调用方 catch,不会以空映射到这里。早先那个「空映射当异常整体跳过」的守卫会把这种
+     * 情况下的标记永久留住。
+     */
+    it('reconciles absent runs even when the snapshot is legitimately empty', () => {
+      vi.useFakeTimers();
+      try {
+        markNextSessionDoneSilenced('run-deleted', 'session-silenced');
+        markNextSessionTerminalNotificationOwnedByScheduler('run-gone', 'session-owned');
 
-      reconcileRunMarkers(new Map());
+        reconcileRunMarkers(new Map());
+        vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS + 1);
 
-      expect(isSessionDoneSilenced('session-silenced')).toBe(true);
+        expect(isSessionDoneSilenced('session-silenced')).toBe(false);
+        expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     /**
@@ -251,15 +288,21 @@ describe('silencedSessionDoneStore', () => {
       markNextSessionDoneSilenced('run-a', 'session-a');
       markNextSessionDoneSilenced('run-b', 'session-b');
 
-      reconcileRunMarkers(
-        new Map([
-          ['run-a', 'terminal' as const],
-          ['run-b', 'running' as const],
-        ]),
-      );
+      vi.useFakeTimers();
+      try {
+        reconcileRunMarkers(
+          new Map([
+            ['run-a', 'terminal' as const],
+            ['run-b', 'running' as const],
+          ]),
+        );
+        vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS + 1);
 
-      expect(isSessionDoneSilenced('session-a')).toBe(false);
-      expect(isSessionDoneSilenced('session-b')).toBe(true);
+        expect(isSessionDoneSilenced('session-a')).toBe(false);
+        expect(isSessionDoneSilenced('session-b')).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
@@ -214,6 +214,28 @@ describe('silencedSessionDoneStore', () => {
      * 若对应的 failed / deferred 事件正好丢了(对账要治的正是事件丢失),「不在快照里
      * 就保持」会让标记永久残留。
      */
+    /**
+     * 回归(codex review P1):自删除场景 —— agent 在任务 run 内调 schedule_delete 删掉
+     * 自己的 schedule,引擎用 exemptRunId 豁免 caller run 不 abort,它的 run 行随 schedule
+     * 级联删除后仍继续跑到底(通常还要产出最终回复)。此时「不在 DB 快照里」不等于
+     * 「跑完了」,调用方会把引擎的 in-flight 快照覆盖成 running,标记必须保住 —— 否则
+     * 最终 done 又会漏出通知。这正是心跳类任务的标准收口路径。
+     */
+    it('keeps a marker for a self-deleting run that is gone from the DB but still in flight', () => {
+      vi.useFakeTimers();
+      try {
+        markNextSessionDoneSilenced('run-self-delete', 'session-1');
+
+        // DB 里已无此 run,但引擎报它仍 in-flight → 调用方覆盖为 running。
+        reconcileRunMarkers(new Map([['run-self-delete', 'running' as const]]));
+        vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS * 3);
+
+        expect(isSessionDoneSilenced('session-1')).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('clears markers whose run no longer exists in the snapshot', () => {
       vi.useFakeTimers();
       try {

--- a/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
@@ -9,15 +9,15 @@ import {
   getSilencedRunSessionIdForAttentionFallback,
   isSessionTerminalNotificationOwnedByScheduler,
   isSessionDoneSilenced,
+  listRunMarkerSessionIds,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
-  noteSchedulerOwnedRunStillActive,
-  noteSilencedRunStillActive,
   rememberScheduleRunSessionAttentionBaseline,
   resetSilencedSessionDoneStoreForTests,
+  RUN_MARKER_IDLE_FALLBACK_MS,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
-  SILENCED_RUN_IDLE_FALLBACK_MS,
+  syncRunMarkerFallback,
 } from '@/lib/silencedSessionDoneStore';
 
 describe('silencedSessionDoneStore', () => {
@@ -118,6 +118,30 @@ describe('silencedSessionDoneStore', () => {
    * silent-stop 守卫自动续跑)。标记以前被第一次中间 done 消费掉,最终那次真 done
    * 就走了普通完成路径,把 macOS toast / 飞书 / 手机推送全发一遍。
    */
+  it('clears the attention baseline of a run replaced by a newer one', () => {
+    // 被顶替的 run 之后不会再有人调 clearSilencedRun(scheduleClearSilencedRun 的
+    // has 检查会直接 return),baseline 必须在顶替时就清掉,否则随 session 复用无界增长。
+    rememberScheduleRunSessionAttentionBaseline('run-1', 'session-1', true);
+    markNextSessionDoneSilenced('run-1', 'session-1', true);
+
+    markNextSessionDoneSilenced('run-2', 'session-1', false);
+
+    expect(getScheduleRunSessionAttentionBaseline('run-1')).toBeUndefined();
+  });
+
+  it('lists sessions holding either marker for fallback reconciliation', () => {
+    markNextSessionDoneSilenced('run-s', 'session-silenced');
+    markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
+
+    expect([...listRunMarkerSessionIds()].sort()).toEqual([
+      'session-owned',
+      'session-silenced',
+    ]);
+
+    clearSilencedRun('run-s');
+    expect(listRunMarkerSessionIds()).toEqual(['session-owned']);
+  });
+
   describe('multi-turn run (regression: silenced automation leaked a system push)', () => {
     it('keeps suppressing after an intermediate done and a resumed turn', () => {
       markNextSessionDoneSilenced('run-1', 'session-1');
@@ -125,7 +149,7 @@ describe('silencedSessionDoneStore', () => {
       // 主 turn done —— 只是中间态,runner 仍在等在途 subagent。
       expect(isSessionDoneSilenced('session-1')).toBe(true);
       // subagent 完成 → SDK 自动续 turn。
-      noteSilencedRunStillActive('session-1');
+      syncRunMarkerFallback('session-1', true);
       clearCompletedSilencedRunForNewActivity('session-1');
       // 最终 done 必须仍然静默。
       expect(isSessionDoneSilenced('session-1')).toBe(true);
@@ -135,7 +159,7 @@ describe('silencedSessionDoneStore', () => {
       markNextSessionTerminalNotificationOwnedByScheduler('run-1', 'session-1');
 
       expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
-      noteSchedulerOwnedRunStillActive('session-1');
+      syncRunMarkerFallback('session-1', true);
       clearCompletedSchedulerOwnedRunForNewActivity('session-1');
       // 漏了这条会变成 renderer + scheduler notifier 各发一条,用户收到两次通知。
       expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
@@ -153,50 +177,102 @@ describe('silencedSessionDoneStore', () => {
 
     it('drops a silenced marker whose completed event never arrived', () => {
       markNextSessionDoneSilenced('run-1', 'session-1');
-      expect(isSessionDoneSilenced('session-1')).toBe(true);
+      syncRunMarkerFallback('session-1', false);
 
-      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS + 1);
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
 
       expect(isSessionDoneSilenced('session-1')).toBe(false);
     });
 
     it('drops a scheduler-owned marker whose completed event never arrived', () => {
       markNextSessionTerminalNotificationOwnedByScheduler('run-1', 'session-1');
-      expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
+      syncRunMarkerFallback('session-1', false);
 
-      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS + 1);
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
 
       expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(false);
     });
 
-    it('does not self-heal a long single turn: new-turn activity disarms the fallback', () => {
+    it('never arms the fallback while the session is running, however long the turn', () => {
       markNextSessionDoneSilenced('run-1', 'session-1');
-      // turn 起跑 —— run 明显活着,兜底必须撤掉,否则跑得久的 turn 会被误清。
-      noteSilencedRunStillActive('session-1');
+      syncRunMarkerFallback('session-1', true);
 
-      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS * 3);
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS * 3);
 
       expect(isSessionDoneSilenced('session-1')).toBe(true);
     });
 
-    it('re-arms the fallback on each observed done so a stalled run still heals', () => {
+    /**
+     * 回归(codex review P1):agent 在自己 turn 内调 schedule_silence_current_run
+     * 时,标记建立时该 turn 已经 running、renderer 早过了 rising edge,之后不会再有
+     * 新 turn 起始信号。若在 mark 时就武装兜底,便再没有任何信号能撤销它,turn 只要
+     * 还剩 12 分钟以上就会被误清、最终 done 又走普通通知路径。
+     */
+    it('does not self-heal a marker created mid-turn until that turn actually ends', () => {
       markNextSessionDoneSilenced('run-1', 'session-1');
-      noteSilencedRunStillActive('session-1');
+      // 对账发现 session 仍在跑 —— 不武装。
+      syncRunMarkerFallback('session-1', true);
 
-      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS * 2);
-      // 中间 done:重新武装兜底。
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS * 2);
       expect(isSessionDoneSilenced('session-1')).toBe(true);
 
-      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS + 1);
+      // turn 真的结束后才开始计时。
+      syncRunMarkerFallback('session-1', false);
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
+
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    });
+
+    /**
+     * 消费方每次 running 快照变化都会对账,重复的 idle 对账绝不能重置计时 ——
+     * 否则频繁的快照更新会让兜底永远不 fire,自愈失效。
+     */
+    it('does not restart the countdown on repeated idle syncs', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+      syncRunMarkerFallback('session-1', false);
+
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS - 1000);
+      syncRunMarkerFallback('session-1', false);
+      syncRunMarkerFallback('session-1', false);
+      vi.advanceTimersByTime(2000);
+
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    });
+
+    it('re-arms after the session goes idle again following a resumed turn', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+      syncRunMarkerFallback('session-1', false);
+
+      // subagent 续 turn:撤掉兜底。
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS - 1000);
+      syncRunMarkerFallback('session-1', true);
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS * 2);
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+
+      // 再次 idle:重新计时,满窗后自愈。
+      syncRunMarkerFallback('session-1', false);
+      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
 
       expect(isSessionDoneSilenced('session-1')).toBe(false);
     });
 
     it('lets the completed linger win over the fallback', () => {
       markNextSessionDoneSilenced('run-1', 'session-1');
+      syncRunMarkerFallback('session-1', false);
       // completed 到达 → 2s linger,兜底应被撤掉,清理由 linger 负责。
       scheduleClearSilencedRun('run-1', 2000);
 
+      vi.advanceTimersByTime(2001);
+
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    });
+
+    it('does not re-arm the fallback while a completed linger is pending', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+      scheduleClearSilencedRun('run-1', 2000);
+
+      // linger 期间的对账不能武装兜底,否则会把 linger 语义搅乱。
+      syncRunMarkerFallback('session-1', false);
       vi.advanceTimersByTime(2001);
 
       expect(isSessionDoneSilenced('session-1')).toBe(false);

--- a/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
@@ -172,6 +172,7 @@ describe('silencedSessionDoneStore', () => {
             ['run-s', 'terminal' as const],
             ['run-o', 'terminal' as const],
           ]),
+          new Set(),
         );
 
         // 对账当拍不删:还在 linger 窗口内,pending 的 done transition 仍看得到标记。
@@ -202,6 +203,7 @@ describe('silencedSessionDoneStore', () => {
           ['run-s', 'running' as const],
           ['run-o', 'running' as const],
         ]),
+        new Set(['run-s', 'run-o']),
       );
 
       expect(isSessionDoneSilenced('session-silenced')).toBe(true);
@@ -226,14 +228,54 @@ describe('silencedSessionDoneStore', () => {
       try {
         markNextSessionDoneSilenced('run-self-delete', 'session-1');
 
-        // DB 里已无此 run,但引擎报它仍 in-flight → 调用方覆盖为 running。
-        reconcileRunMarkers(new Map([['run-self-delete', 'running' as const]]));
+        // DB 里已无此 run(行随 schedule 级联删除),但引擎报它仍 in-flight。
+        reconcileRunMarkers(new Map(), new Set(['run-self-delete']));
         vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS * 3);
 
         expect(isSessionDoneSilenced('session-1')).toBe(true);
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    /**
+     * 回归(codex review P1):两份读之间隔着 DB 查询的 await,run 恰好在那个窗口内结束时
+     * DB 行还是 running、controller 已注销。本轮只能保守保持标记(无法区分它是否真的还在
+     * 跑),但必须报告 needsRecheck —— 否则若该 run 的终态事件正是丢掉的那个,就再没有信号
+     * 来清这个标记,自愈保证被打破。
+     */
+    it('reports needsRecheck when the DB says running but the engine does not', () => {
+      vi.useFakeTimers();
+      try {
+        markNextSessionDoneSilenced('run-racing', 'session-1');
+
+        const result = reconcileRunMarkers(
+          new Map([['run-racing', 'running' as const]]),
+          new Set(),
+        );
+
+        expect(result.needsRecheck).toBe(true);
+        // 保守保持,不清。
+        vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS * 3);
+        expect(isSessionDoneSilenced('session-1')).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not report needsRecheck when both reads agree', () => {
+      markNextSessionDoneSilenced('run-live', 'session-1');
+      markNextSessionTerminalNotificationOwnedByScheduler('run-done', 'session-2');
+
+      const result = reconcileRunMarkers(
+        new Map([
+          ['run-live', 'running' as const],
+          ['run-done', 'terminal' as const],
+        ]),
+        new Set(['run-live']),
+      );
+
+      expect(result.needsRecheck).toBe(false);
     });
 
     it('clears markers whose run no longer exists in the snapshot', () => {
@@ -243,7 +285,10 @@ describe('silencedSessionDoneStore', () => {
         markNextSessionTerminalNotificationOwnedByScheduler('run-gone', 'session-owned');
 
         // 快照非空,但完全不含这两个 run —— 它们已经被删掉了。
-        reconcileRunMarkers(new Map([['some-live-run', 'running' as const]]));
+        reconcileRunMarkers(
+          new Map([['some-live-run', 'running' as const]]),
+          new Set(['some-live-run']),
+        );
         vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS + 1);
 
         expect(isSessionDoneSilenced('session-silenced')).toBe(false);
@@ -265,7 +310,7 @@ describe('silencedSessionDoneStore', () => {
         markNextSessionDoneSilenced('run-deleted', 'session-silenced');
         markNextSessionTerminalNotificationOwnedByScheduler('run-gone', 'session-owned');
 
-        reconcileRunMarkers(new Map());
+        reconcileRunMarkers(new Map(), new Set());
         vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS + 1);
 
         expect(isSessionDoneSilenced('session-silenced')).toBe(false);
@@ -294,6 +339,7 @@ describe('silencedSessionDoneStore', () => {
             ['run-s', 'terminal' as const],
             ['run-o', 'terminal' as const],
           ]),
+          new Set(),
         );
         expect(isSessionDoneSilenced('session-silenced')).toBe(true);
         expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
@@ -317,6 +363,7 @@ describe('silencedSessionDoneStore', () => {
             ['run-a', 'terminal' as const],
             ['run-b', 'running' as const],
           ]),
+          new Set(['run-b']),
         );
         vi.advanceTimersByTime(MARKER_TERMINAL_LINGER_MS + 1);
 

--- a/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   clearCompletedSchedulerOwnedRunForNewActivity,
@@ -7,14 +7,17 @@ import {
   clearSilencedRun,
   getScheduleRunSessionAttentionBaseline,
   getSilencedRunSessionIdForAttentionFallback,
+  isSessionTerminalNotificationOwnedByScheduler,
+  isSessionDoneSilenced,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
-  observeNextSessionTerminalNotificationOwnedByScheduler,
-  observeNextSessionDoneSilenced,
+  noteSchedulerOwnedRunStillActive,
+  noteSilencedRunStillActive,
   rememberScheduleRunSessionAttentionBaseline,
   resetSilencedSessionDoneStoreForTests,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
+  SILENCED_RUN_IDLE_FALLBACK_MS,
 } from '@/lib/silencedSessionDoneStore';
 
 describe('silencedSessionDoneStore', () => {
@@ -22,19 +25,19 @@ describe('silencedSessionDoneStore', () => {
     resetSilencedSessionDoneStoreForTests();
   });
 
-  it('suppresses exactly one done transition for the marked session', () => {
+  it('suppresses every done transition while the run is still in flight', () => {
     markNextSessionDoneSilenced('run-1', 'session-1');
 
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
     clearSilencedRun('run-1');
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(false);
+    expect(isSessionDoneSilenced('session-1')).toBe(false);
   });
 
   it('clears a silenced run after failure/defer without suppressing a later done', () => {
     markNextSessionDoneSilenced('run-1', 'session-1');
 
     expect(clearSilencedRun('run-1')).toBe('session-1');
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(false);
+    expect(isSessionDoneSilenced('session-1')).toBe(false);
   });
 
   it('replaces older pending silence for the same session', () => {
@@ -43,17 +46,17 @@ describe('silencedSessionDoneStore', () => {
 
     expect(clearSilencedRun('run-1')).toBeUndefined();
     expect(getSilencedRunSessionIdForAttentionFallback('run-1')).toBeUndefined();
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
     expect(clearSilencedRun('run-2')).toBe('session-1');
   });
 
   it('lets multiple hook instances observe the same silenced done before cleanup', () => {
     markNextSessionDoneSilenced('run-1', 'session-1');
 
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
     clearSilencedRun('run-1');
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(false);
+    expect(isSessionDoneSilenced('session-1')).toBe(false);
   });
 
   it('allows attention fallback only when the session had no prior attention', () => {
@@ -70,7 +73,7 @@ describe('silencedSessionDoneStore', () => {
 
     clearCompletedSilencedRunForNewActivity('session-1');
 
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(false);
+    expect(isSessionDoneSilenced('session-1')).toBe(false);
   });
 
   it('does not clear an in-flight silenced run before completed linger starts', () => {
@@ -78,7 +81,7 @@ describe('silencedSessionDoneStore', () => {
 
     clearCompletedSilencedRunForNewActivity('session-1');
 
-    expect(observeNextSessionDoneSilenced('session-1')).toBe(true);
+    expect(isSessionDoneSilenced('session-1')).toBe(true);
   });
 
   it('tracks and clears run attention baselines', () => {
@@ -95,10 +98,10 @@ describe('silencedSessionDoneStore', () => {
   it('tracks scheduler notification ownership separately from full silence', () => {
     markNextSessionTerminalNotificationOwnedByScheduler('run-owned', 'session-owned');
 
-    expect(observeNextSessionDoneSilenced('session-owned')).toBe(false);
-    expect(observeNextSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
+    expect(isSessionDoneSilenced('session-owned')).toBe(false);
+    expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
     expect(clearSchedulerOwnedRun('run-owned')).toBe('session-owned');
-    expect(observeNextSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+    expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
   });
 
   it('clears completed scheduler ownership before a later ordinary turn', () => {
@@ -107,6 +110,96 @@ describe('silencedSessionDoneStore', () => {
 
     clearCompletedSchedulerOwnedRunForNewActivity('session-owned');
 
-    expect(observeNextSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+    expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+  });
+
+  /**
+   * 回归:一个 run 内 running→done 会翻转多次(后台 subagent 完成后续 turn、
+   * silent-stop 守卫自动续跑)。标记以前被第一次中间 done 消费掉,最终那次真 done
+   * 就走了普通完成路径,把 macOS toast / 飞书 / 手机推送全发一遍。
+   */
+  describe('multi-turn run (regression: silenced automation leaked a system push)', () => {
+    it('keeps suppressing after an intermediate done and a resumed turn', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+
+      // 主 turn done —— 只是中间态,runner 仍在等在途 subagent。
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+      // subagent 完成 → SDK 自动续 turn。
+      noteSilencedRunStillActive('session-1');
+      clearCompletedSilencedRunForNewActivity('session-1');
+      // 最终 done 必须仍然静默。
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+    });
+
+    it('keeps scheduler notification ownership across the same multi-turn shape', () => {
+      markNextSessionTerminalNotificationOwnedByScheduler('run-1', 'session-1');
+
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
+      noteSchedulerOwnedRunStillActive('session-1');
+      clearCompletedSchedulerOwnedRunForNewActivity('session-1');
+      // 漏了这条会变成 renderer + scheduler notifier 各发一条,用户收到两次通知。
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
+    });
+  });
+
+  describe('idle fallback self-heal', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('drops a silenced marker whose completed event never arrived', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+
+      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS + 1);
+
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    });
+
+    it('drops a scheduler-owned marker whose completed event never arrived', () => {
+      markNextSessionTerminalNotificationOwnedByScheduler('run-1', 'session-1');
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
+
+      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS + 1);
+
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(false);
+    });
+
+    it('does not self-heal a long single turn: new-turn activity disarms the fallback', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+      // turn 起跑 —— run 明显活着,兜底必须撤掉,否则跑得久的 turn 会被误清。
+      noteSilencedRunStillActive('session-1');
+
+      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS * 3);
+
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+    });
+
+    it('re-arms the fallback on each observed done so a stalled run still heals', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+      noteSilencedRunStillActive('session-1');
+
+      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS * 2);
+      // 中间 done:重新武装兜底。
+      expect(isSessionDoneSilenced('session-1')).toBe(true);
+
+      vi.advanceTimersByTime(SILENCED_RUN_IDLE_FALLBACK_MS + 1);
+
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    });
+
+    it('lets the completed linger win over the fallback', () => {
+      markNextSessionDoneSilenced('run-1', 'session-1');
+      // completed 到达 → 2s linger,兜底应被撤掉,清理由 linger 负责。
+      scheduleClearSilencedRun('run-1', 2000);
+
+      vi.advanceTimersByTime(2001);
+
+      expect(isSessionDoneSilenced('session-1')).toBe(false);
+    });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
@@ -9,15 +9,13 @@ import {
   getSilencedRunSessionIdForAttentionFallback,
   isSessionTerminalNotificationOwnedByScheduler,
   isSessionDoneSilenced,
-  listRunMarkerSessionIds,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
+  reconcileRunMarkersWithTerminalRuns,
   rememberScheduleRunSessionAttentionBaseline,
   resetSilencedSessionDoneStoreForTests,
-  RUN_MARKER_IDLE_FALLBACK_MS,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
-  syncRunMarkerFallback,
 } from '@/lib/silencedSessionDoneStore';
 
 describe('silencedSessionDoneStore', () => {
@@ -113,11 +111,6 @@ describe('silencedSessionDoneStore', () => {
     expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
   });
 
-  /**
-   * 回归:一个 run 内 running→done 会翻转多次(后台 subagent 完成后续 turn、
-   * silent-stop 守卫自动续跑)。标记以前被第一次中间 done 消费掉,最终那次真 done
-   * 就走了普通完成路径,把 macOS toast / 飞书 / 手机推送全发一遍。
-   */
   it('clears the attention baseline of a run replaced by a newer one', () => {
     // 被顶替的 run 之后不会再有人调 clearSilencedRun(scheduleClearSilencedRun 的
     // has 检查会直接 return),baseline 必须在顶替时就清掉,否则随 session 复用无界增长。
@@ -129,19 +122,11 @@ describe('silencedSessionDoneStore', () => {
     expect(getScheduleRunSessionAttentionBaseline('run-1')).toBeUndefined();
   });
 
-  it('lists sessions holding either marker for fallback reconciliation', () => {
-    markNextSessionDoneSilenced('run-s', 'session-silenced');
-    markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
-
-    expect([...listRunMarkerSessionIds()].sort()).toEqual([
-      'session-owned',
-      'session-silenced',
-    ]);
-
-    clearSilencedRun('run-s');
-    expect(listRunMarkerSessionIds()).toEqual(['session-owned']);
-  });
-
+  /**
+   * 回归:一个 run 内 running→done 会翻转多次(后台 subagent 完成后续 turn、
+   * silent-stop 守卫自动续跑)。标记以前被第一次中间 done 消费掉,最终那次真 done
+   * 就走了普通完成路径,把 macOS toast / 飞书 / 手机推送全发一遍。
+   */
   describe('multi-turn run (regression: silenced automation leaked a system push)', () => {
     it('keeps suppressing after an intermediate done and a resumed turn', () => {
       markNextSessionDoneSilenced('run-1', 'session-1');
@@ -149,7 +134,6 @@ describe('silencedSessionDoneStore', () => {
       // 主 turn done —— 只是中间态,runner 仍在等在途 subagent。
       expect(isSessionDoneSilenced('session-1')).toBe(true);
       // subagent 完成 → SDK 自动续 turn。
-      syncRunMarkerFallback('session-1', true);
       clearCompletedSilencedRunForNewActivity('session-1');
       // 最终 done 必须仍然静默。
       expect(isSessionDoneSilenced('session-1')).toBe(true);
@@ -159,123 +143,87 @@ describe('silencedSessionDoneStore', () => {
       markNextSessionTerminalNotificationOwnedByScheduler('run-1', 'session-1');
 
       expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
-      syncRunMarkerFallback('session-1', true);
       clearCompletedSchedulerOwnedRunForNewActivity('session-1');
       // 漏了这条会变成 renderer + scheduler notifier 各发一条,用户收到两次通知。
       expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(true);
     });
   });
 
-  describe('idle fallback self-heal', () => {
-    beforeEach(() => {
+  /**
+   * 事件丢失的自愈:靠 scheduler 落库的权威 run 状态对账,而不是任何定时器。
+   * 三种「猜 run 还在不在飞行」的判据(事件序 / renderer running 快照 / 固定时长)
+   * 都被证明会误判,详见 store 的文件头注释。
+   */
+  describe('reconciliation against authoritative run status', () => {
+    it('clears markers whose run already reached a terminal status', () => {
+      markNextSessionDoneSilenced('run-s', 'session-silenced');
+      markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
+
+      reconcileRunMarkersWithTerminalRuns(new Set(['run-s', 'run-o']));
+
+      expect(isSessionDoneSilenced('session-silenced')).toBe(false);
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+    });
+
+    /**
+     * 关键:run 仍在飞行时绝不能清。这覆盖了 renderer running 快照不可信的那些
+     * 情形 —— remote_agent / local_bash / 未知 task_type 的后台任务在跑时快照
+     * 刻意为 false,device-link 远程会话整体豁免;runner 的 10 分钟兜底也只是事件
+     * 静默超时、不是最大 run 时长,所以 run 可以合法飞行任意长。
+     */
+    it('keeps markers whose run is still in flight, however long it runs', () => {
+      markNextSessionDoneSilenced('run-s', 'session-silenced');
+      markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
+
+      // 终态集合里只有别的 run。
+      reconcileRunMarkersWithTerminalRuns(new Set(['some-other-run']));
+
+      expect(isSessionDoneSilenced('session-silenced')).toBe(true);
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
+    });
+
+    it('is a no-op for an empty terminal set', () => {
+      markNextSessionDoneSilenced('run-s', 'session-silenced');
+
+      reconcileRunMarkersWithTerminalRuns(new Set());
+
+      expect(isSessionDoneSilenced('session-silenced')).toBe(true);
+    });
+
+    /**
+     * completed 已到达并排了 linger 时,对账不能抢在 linger 前面清 —— 那段 linger
+     * 正是留给 renderer 的 done transition 消费标记用的,提前清掉这次终态又会走
+     * 普通通知路径。
+     */
+    it('defers to a pending completed linger instead of clearing early', () => {
       vi.useFakeTimers();
+      try {
+        markNextSessionDoneSilenced('run-s', 'session-silenced');
+        markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
+        scheduleClearSilencedRun('run-s', 2000);
+        scheduleClearSchedulerOwnedRun('run-o', 2000);
+
+        // run 确实已终态,但 linger 在跑 → 本轮对账必须放过。
+        reconcileRunMarkersWithTerminalRuns(new Set(['run-s', 'run-o']));
+        expect(isSessionDoneSilenced('session-silenced')).toBe(true);
+        expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
+
+        vi.advanceTimersByTime(2001);
+        expect(isSessionDoneSilenced('session-silenced')).toBe(false);
+        expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
-    afterEach(() => {
-      vi.useRealTimers();
-    });
+    it('leaves an unrelated session untouched', () => {
+      markNextSessionDoneSilenced('run-a', 'session-a');
+      markNextSessionDoneSilenced('run-b', 'session-b');
 
-    it('drops a silenced marker whose completed event never arrived', () => {
-      markNextSessionDoneSilenced('run-1', 'session-1');
-      syncRunMarkerFallback('session-1', false);
+      reconcileRunMarkersWithTerminalRuns(new Set(['run-a']));
 
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
-
-      expect(isSessionDoneSilenced('session-1')).toBe(false);
-    });
-
-    it('drops a scheduler-owned marker whose completed event never arrived', () => {
-      markNextSessionTerminalNotificationOwnedByScheduler('run-1', 'session-1');
-      syncRunMarkerFallback('session-1', false);
-
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
-
-      expect(isSessionTerminalNotificationOwnedByScheduler('session-1')).toBe(false);
-    });
-
-    it('never arms the fallback while the session is running, however long the turn', () => {
-      markNextSessionDoneSilenced('run-1', 'session-1');
-      syncRunMarkerFallback('session-1', true);
-
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS * 3);
-
-      expect(isSessionDoneSilenced('session-1')).toBe(true);
-    });
-
-    /**
-     * 回归(codex review P1):agent 在自己 turn 内调 schedule_silence_current_run
-     * 时,标记建立时该 turn 已经 running、renderer 早过了 rising edge,之后不会再有
-     * 新 turn 起始信号。若在 mark 时就武装兜底,便再没有任何信号能撤销它,turn 只要
-     * 还剩 12 分钟以上就会被误清、最终 done 又走普通通知路径。
-     */
-    it('does not self-heal a marker created mid-turn until that turn actually ends', () => {
-      markNextSessionDoneSilenced('run-1', 'session-1');
-      // 对账发现 session 仍在跑 —— 不武装。
-      syncRunMarkerFallback('session-1', true);
-
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS * 2);
-      expect(isSessionDoneSilenced('session-1')).toBe(true);
-
-      // turn 真的结束后才开始计时。
-      syncRunMarkerFallback('session-1', false);
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
-
-      expect(isSessionDoneSilenced('session-1')).toBe(false);
-    });
-
-    /**
-     * 消费方每次 running 快照变化都会对账,重复的 idle 对账绝不能重置计时 ——
-     * 否则频繁的快照更新会让兜底永远不 fire,自愈失效。
-     */
-    it('does not restart the countdown on repeated idle syncs', () => {
-      markNextSessionDoneSilenced('run-1', 'session-1');
-      syncRunMarkerFallback('session-1', false);
-
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS - 1000);
-      syncRunMarkerFallback('session-1', false);
-      syncRunMarkerFallback('session-1', false);
-      vi.advanceTimersByTime(2000);
-
-      expect(isSessionDoneSilenced('session-1')).toBe(false);
-    });
-
-    it('re-arms after the session goes idle again following a resumed turn', () => {
-      markNextSessionDoneSilenced('run-1', 'session-1');
-      syncRunMarkerFallback('session-1', false);
-
-      // subagent 续 turn:撤掉兜底。
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS - 1000);
-      syncRunMarkerFallback('session-1', true);
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS * 2);
-      expect(isSessionDoneSilenced('session-1')).toBe(true);
-
-      // 再次 idle:重新计时,满窗后自愈。
-      syncRunMarkerFallback('session-1', false);
-      vi.advanceTimersByTime(RUN_MARKER_IDLE_FALLBACK_MS + 1);
-
-      expect(isSessionDoneSilenced('session-1')).toBe(false);
-    });
-
-    it('lets the completed linger win over the fallback', () => {
-      markNextSessionDoneSilenced('run-1', 'session-1');
-      syncRunMarkerFallback('session-1', false);
-      // completed 到达 → 2s linger,兜底应被撤掉,清理由 linger 负责。
-      scheduleClearSilencedRun('run-1', 2000);
-
-      vi.advanceTimersByTime(2001);
-
-      expect(isSessionDoneSilenced('session-1')).toBe(false);
-    });
-
-    it('does not re-arm the fallback while a completed linger is pending', () => {
-      markNextSessionDoneSilenced('run-1', 'session-1');
-      scheduleClearSilencedRun('run-1', 2000);
-
-      // linger 期间的对账不能武装兜底,否则会把 linger 语义搅乱。
-      syncRunMarkerFallback('session-1', false);
-      vi.advanceTimersByTime(2001);
-
-      expect(isSessionDoneSilenced('session-1')).toBe(false);
+      expect(isSessionDoneSilenced('session-a')).toBe(false);
+      expect(isSessionDoneSilenced('session-b')).toBe(true);
     });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/silencedSessionDoneStore.test.ts
@@ -11,7 +11,7 @@ import {
   isSessionDoneSilenced,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
-  reconcileRunMarkersWithTerminalRuns,
+  reconcileRunMarkers,
   rememberScheduleRunSessionAttentionBaseline,
   resetSilencedSessionDoneStoreForTests,
   scheduleClearSchedulerOwnedRun,
@@ -159,7 +159,12 @@ describe('silencedSessionDoneStore', () => {
       markNextSessionDoneSilenced('run-s', 'session-silenced');
       markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
 
-      reconcileRunMarkersWithTerminalRuns(new Set(['run-s', 'run-o']));
+      reconcileRunMarkers(
+        new Map([
+          ['run-s', 'terminal' as const],
+          ['run-o', 'terminal' as const],
+        ]),
+      );
 
       expect(isSessionDoneSilenced('session-silenced')).toBe(false);
       expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
@@ -175,17 +180,38 @@ describe('silencedSessionDoneStore', () => {
       markNextSessionDoneSilenced('run-s', 'session-silenced');
       markNextSessionTerminalNotificationOwnedByScheduler('run-o', 'session-owned');
 
-      // 终态集合里只有别的 run。
-      reconcileRunMarkersWithTerminalRuns(new Set(['some-other-run']));
+      reconcileRunMarkers(
+        new Map([
+          ['run-s', 'running' as const],
+          ['run-o', 'running' as const],
+        ]),
+      );
 
       expect(isSessionDoneSilenced('session-silenced')).toBe(true);
       expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
     });
 
-    it('is a no-op for an empty terminal set', () => {
+    /**
+     * 回归(codex review P1):run 被删除而不是落终态时,它永远不会出现在权威快照里
+     * —— 删除 schedule 会级联删掉 schedule_runs 行,deferred run 也会被显式删除。
+     * 若对应的 failed / deferred 事件正好丢了(对账要治的正是事件丢失),「不在快照里
+     * 就保持」会让标记永久残留。
+     */
+    it('clears markers whose run no longer exists in the snapshot', () => {
+      markNextSessionDoneSilenced('run-deleted', 'session-silenced');
+      markNextSessionTerminalNotificationOwnedByScheduler('run-gone', 'session-owned');
+
+      // 快照非空,但完全不含这两个 run —— 它们已经被删掉了。
+      reconcileRunMarkers(new Map([['some-live-run', 'running' as const]]));
+
+      expect(isSessionDoneSilenced('session-silenced')).toBe(false);
+      expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(false);
+    });
+
+    it('treats an empty snapshot as a query anomaly and changes nothing', () => {
       markNextSessionDoneSilenced('run-s', 'session-silenced');
 
-      reconcileRunMarkersWithTerminalRuns(new Set());
+      reconcileRunMarkers(new Map());
 
       expect(isSessionDoneSilenced('session-silenced')).toBe(true);
     });
@@ -204,7 +230,12 @@ describe('silencedSessionDoneStore', () => {
         scheduleClearSchedulerOwnedRun('run-o', 2000);
 
         // run 确实已终态,但 linger 在跑 → 本轮对账必须放过。
-        reconcileRunMarkersWithTerminalRuns(new Set(['run-s', 'run-o']));
+        reconcileRunMarkers(
+          new Map([
+            ['run-s', 'terminal' as const],
+            ['run-o', 'terminal' as const],
+          ]),
+        );
         expect(isSessionDoneSilenced('session-silenced')).toBe(true);
         expect(isSessionTerminalNotificationOwnedByScheduler('session-owned')).toBe(true);
 
@@ -220,7 +251,12 @@ describe('silencedSessionDoneStore', () => {
       markNextSessionDoneSilenced('run-a', 'session-a');
       markNextSessionDoneSilenced('run-b', 'session-b');
 
-      reconcileRunMarkersWithTerminalRuns(new Set(['run-a']));
+      reconcileRunMarkers(
+        new Map([
+          ['run-a', 'terminal' as const],
+          ['run-b', 'running' as const],
+        ]),
+      );
 
       expect(isSessionDoneSilenced('session-a')).toBe(false);
       expect(isSessionDoneSilenced('session-b')).toBe(true);

--- a/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
@@ -7,6 +7,7 @@ import {
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
   resetSilencedSessionDoneStoreForTests,
+  scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
 } from '@/lib/silencedSessionDoneStore';
 import { useSessionRunningStatus } from '@/hooks/useSessionRunningStatus';
@@ -122,7 +123,14 @@ describe('useSessionRunningStatus silenced completion handling', () => {
     expect(onSessionDone).not.toHaveBeenCalled();
   });
 
-  it('does not suppress a later ordinary turn in the same scheduler-bound session', async () => {
+  it('does not suppress a later ordinary turn once the scheduler run has completed', async () => {
+    // run 终态之后同 session 的 turn 属于用户手动对话,照常通知。
+    //
+    // `completed` 是这条断言的**必要前提**,不是可省略的布景:run 仍在飞行时,
+    // 「用户插话的 turn」和「后台 subagent 续 turn」在 renderer 侧是同一个信号
+    // (running=true → done),无从区分。标记因此在 run 飞行期间对每次 done 都有效
+    // (见文件末尾的 multi-turn 回归),run 终态后才交回普通通知路径 —— 判据就是
+    // scheduler 的 completed/failed 事件排下的 linger 定时器。
     vi.useFakeTimers();
     const onSessionDone = vi.fn();
     markNextSessionTerminalNotificationOwnedByScheduler('run-owned', 'session-reused');
@@ -135,6 +143,9 @@ describe('useSessionRunningStatus silenced completion handling', () => {
       await vi.advanceTimersByTimeAsync(500);
     });
     expect(onSessionDone).not.toHaveBeenCalled();
+
+    // scheduler 发出 completed → 排 linger,标记进入「run 已终态」。
+    scheduleClearSchedulerOwnedRun('run-owned', 2000);
 
     await emitSnapshot(new Map([['session-reused', status(true)]]));
     await emitSnapshot(new Map([['session-reused', status(false)]]));
@@ -366,5 +377,65 @@ describe('useSessionRunningStatus silenced completion handling', () => {
     expect(vi.mocked(clearSessionAttention)).not.toHaveBeenCalledWith('s-real', { intent: 'explicit' });
     vi.mocked(getSessionAttentionKind).mockReturnValue(undefined);
     storeMock.terminalErrorSessions.delete('s-real');
+  });
+
+  // 回归:静默 run 仍在飞行(还没 completed)时,session 的 running→done 会翻转多次
+  // —— 主 turn done 只是中间态,runner 还在等在途后台 subagent;subagent 完成后 SDK
+  // 自动续 turn,silent-stop 守卫也会在 1.5s 后自动续跑。标记以前被第一次中间 done
+  // 消费掉,最终那次真 done 就走了普通完成路径,把 macOS toast / 飞书 / 手机推送全发
+  // 一遍。上面那些静默用例都先调了 scheduleClearSilencedRun(即 completed 已到),
+  // 正好绕开了这个缝隙,所以长期没被抓到。
+  it('never fires the done callback across a multi-turn silenced run', async () => {
+    vi.useFakeTimers();
+    const onSessionDone = vi.fn();
+    // 只有 silenced,没有 scheduleClearSilencedRun —— run 仍在飞行。
+    markNextSessionDoneSilenced('run-multi', 'session-multi');
+
+    renderHook(() => useSessionRunningStatus(undefined, { onSessionDone }));
+
+    // 主 turn 跑完(中间态)。
+    await emitSnapshot(new Map([['session-multi', status(true)]]));
+    await emitSnapshot(new Map([['session-multi', status(false)]]));
+    // 推过 debounce:标记若被第一次 done 消费掉,这里还不会响 —— 真正漏出的是下一次。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(onSessionDone).not.toHaveBeenCalled();
+
+    // 后台 subagent 完成 → 自动续 turn，产出最终 summary 后再次 done。
+    await emitSnapshot(new Map([['session-multi', status(true)]]));
+    await emitSnapshot(new Map([['session-multi', status(false)]]));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(onSessionDone).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('keeps scheduler notification ownership across a multi-turn run', async () => {
+    // 同根因的第二个症状:标记被中间 done 消费后,最终 done 时 renderer 又发一条,
+    // 与 scheduler notifier 自己那条叠成两次通知。
+    vi.useFakeTimers();
+    const onSessionDone = vi.fn();
+    markNextSessionTerminalNotificationOwnedByScheduler('run-owned-multi', 'session-owned-multi');
+
+    renderHook(() => useSessionRunningStatus(undefined, { onSessionDone }));
+
+    await emitSnapshot(new Map([['session-owned-multi', status(true)]]));
+    await emitSnapshot(new Map([['session-owned-multi', status(false)]]));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    await emitSnapshot(new Map([['session-owned-multi', status(true)]]));
+    await emitSnapshot(new Map([['session-owned-multi', status(false)]]));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    // attention 仍照常挂(schedulerOwned 只抑制外发通知,不抑制角标)。
+    expect(vi.mocked(addSessionAttention)).toHaveBeenCalledWith('session-owned-multi', 'done');
+    expect(onSessionDone).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
@@ -4,9 +4,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SessionStatusInfo } from '@/lib/makerChatStore';
 import {
+  isSessionDoneSilenced,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
   resetSilencedSessionDoneStoreForTests,
+  RUN_MARKER_IDLE_FALLBACK_MS,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
 } from '@/lib/silencedSessionDoneStore';
@@ -436,6 +438,60 @@ describe('useSessionRunningStatus silenced completion handling', () => {
     // attention 仍照常挂(schedulerOwned 只抑制外发通知,不抑制角标)。
     expect(vi.mocked(addSessionAttention)).toHaveBeenCalledWith('session-owned-multi', 'done');
     expect(onSessionDone).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  // 回归(codex review P1):agent 在自己 turn 内调 schedule_silence_current_run 时,
+  // 标记建立时该 turn 已经 running、renderer 早过了 rising edge。兜底若在建标记时
+  // 就武装,就再没有信号能撤销它,该 turn 只要还剩一个窗口期以上就会被误清,最终
+  // done 又走普通通知路径。兜底的判据必须是当前 running 状态。
+  it('keeps suppressing when the marker is created mid-turn and that turn runs long', async () => {
+    vi.useFakeTimers();
+    const onSessionDone = vi.fn();
+    renderHook(() => useSessionRunningStatus(undefined, { onSessionDone }));
+
+    // turn 先跑起来，之后 agent 才在 turn 内部请求静默。
+    await emitSnapshot(new Map([['session-mid', status(true)]]));
+    markNextSessionDoneSilenced('run-mid', 'session-mid');
+    // 刻意不再 emit 任何快照：agent 请求静默后继续跑一个很长的工具调用，running
+    // 状态毫无变化，effect 不会重跑、也就没有任何对账机会。这正是「mark 时就武装
+    // 兜底」会失守的最坏情形。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_MARKER_IDLE_FALLBACK_MS * 2);
+    });
+    expect(isSessionDoneSilenced('session-mid')).toBe(true);
+
+    // turn 真正结束。
+    await emitSnapshot(new Map([['session-mid', status(false)]]));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(onSessionDone).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  // 回归(greptile review P1):新 turn 启动后本 hook 卸载,done 与 scheduler 终态事件
+  // 都落在卸载期间且不回放 —— 那时没有任何人重新武装兜底。重新挂载时的第一次 effect
+  // 必须完成一次全量对账,否则标记永久残留,该 session 后续手动对话的完成通知会一直
+  // 被静默。
+  it('re-arms the fallback after remount so an orphaned marker still self-heals', async () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useSessionRunningStatus(undefined));
+
+    markNextSessionDoneSilenced('run-orphan', 'session-orphan');
+    await emitSnapshot(new Map([['session-orphan', status(true)]]));
+    unmount();
+
+    // 卸载期间 turn 结束、completed 事件也丢了：没有人观察到这次终态。
+    storeMock.snapshot = new Map([['session-orphan', status(false)]]);
+
+    renderHook(() => useSessionRunningStatus(undefined));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_MARKER_IDLE_FALLBACK_MS + 1);
+    });
+
+    expect(isSessionDoneSilenced('session-orphan')).toBe(false);
     vi.useRealTimers();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
@@ -8,7 +8,6 @@ import {
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
   resetSilencedSessionDoneStoreForTests,
-  RUN_MARKER_IDLE_FALLBACK_MS,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
 } from '@/lib/silencedSessionDoneStore';
@@ -442,9 +441,8 @@ describe('useSessionRunningStatus silenced completion handling', () => {
   });
 
   // 回归(codex review P1):agent 在自己 turn 内调 schedule_silence_current_run 时,
-  // 标记建立时该 turn 已经 running、renderer 早过了 rising edge。兜底若在建标记时
-  // 就武装,就再没有信号能撤销它,该 turn 只要还剩一个窗口期以上就会被误清,最终
-  // done 又走普通通知路径。兜底的判据必须是当前 running 状态。
+  // 标记建立时该 turn 已经 running、renderer 早过了 rising edge —— 任何依赖「事件序」
+  // 建立/撤销兜底的方案都会在这条路径上失守。标记的存续不能与时间挂钩。
   it('keeps suppressing when the marker is created mid-turn and that turn runs long', async () => {
     vi.useFakeTimers();
     const onSessionDone = vi.fn();
@@ -453,11 +451,11 @@ describe('useSessionRunningStatus silenced completion handling', () => {
     // turn 先跑起来，之后 agent 才在 turn 内部请求静默。
     await emitSnapshot(new Map([['session-mid', status(true)]]));
     markNextSessionDoneSilenced('run-mid', 'session-mid');
-    // 刻意不再 emit 任何快照：agent 请求静默后继续跑一个很长的工具调用，running
-    // 状态毫无变化，effect 不会重跑、也就没有任何对账机会。这正是「mark 时就武装
-    // 兜底」会失守的最坏情形。
+    // agent 请求静默后继续跑一个很长的工具调用：running 状态毫无变化，也没有任何
+    // scheduler 事件。跑多久都不该影响标记 —— run 的存活只由 scheduler 的权威状态
+    // 决定，不由挂钟决定。
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(RUN_MARKER_IDLE_FALLBACK_MS * 2);
+      await vi.advanceTimersByTimeAsync(30 * 60_000);
     });
     expect(isSessionDoneSilenced('session-mid')).toBe(true);
 
@@ -471,27 +469,4 @@ describe('useSessionRunningStatus silenced completion handling', () => {
     vi.useRealTimers();
   });
 
-  // 回归(greptile review P1):新 turn 启动后本 hook 卸载,done 与 scheduler 终态事件
-  // 都落在卸载期间且不回放 —— 那时没有任何人重新武装兜底。重新挂载时的第一次 effect
-  // 必须完成一次全量对账,否则标记永久残留,该 session 后续手动对话的完成通知会一直
-  // 被静默。
-  it('re-arms the fallback after remount so an orphaned marker still self-heals', async () => {
-    vi.useFakeTimers();
-    const { unmount } = renderHook(() => useSessionRunningStatus(undefined));
-
-    markNextSessionDoneSilenced('run-orphan', 'session-orphan');
-    await emitSnapshot(new Map([['session-orphan', status(true)]]));
-    unmount();
-
-    // 卸载期间 turn 结束、completed 事件也丢了：没有人观察到这次终态。
-    storeMock.snapshot = new Map([['session-orphan', status(false)]]);
-
-    renderHook(() => useSessionRunningStatus(undefined));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(RUN_MARKER_IDLE_FALLBACK_MS + 1);
-    });
-
-    expect(isSessionDoneSilenced('session-orphan')).toBe(false);
-    vi.useRealTimers();
-  });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -6,6 +6,7 @@ import {
   clearSessionAttention,
   hasSessionAttention,
 } from '@/lib/sessionAttentionStore';
+import type { RunLivenessStatus } from '@/lib/silencedSessionDoneStore';
 import {
   clearSchedulerOwnedRun,
   clearSilencedRun,
@@ -14,7 +15,8 @@ import {
   getSilencedRunSessionIdForAttentionFallback,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
-  reconcileRunMarkersWithTerminalRuns,
+  hasAnyRunMarker,
+  reconcileRunMarkers,
   rememberScheduleRunSessionAttentionBaseline,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
@@ -52,14 +54,14 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
       if (refreshSeqRef.current !== seq) return;
 
       // 抑制标记的事件丢失自愈:这份列表是 scheduler 落库的权威 run 状态(且包含所有
-      // 带 sessionId 的 run,没有 history limit),凡是标记指向的 run 已经终态,就说明
-      // 它的 completed / failed 事件没送到,清掉标记。RunStatus 里只有 'running' 不是
-      // 终态。刻意不用定时器猜 —— 见 silencedSessionDoneStore 的文件头注释。
-      const terminalRunIds = new Set<string>();
+      // 带 sessionId 的 run,没有 history limit),据它清掉「已终态」和「已不存在」的
+      // 标记。RunStatus 里只有 'running' 不是终态。刻意不用定时器猜 run 还在不在飞行
+      // —— 见 silencedSessionDoneStore 的文件头与 reconcileRunMarkers 注释。
+      const runStatusByRunId = new Map<string, RunLivenessStatus>();
       for (const run of runs) {
-        if (run.status !== 'running') terminalRunIds.add(run.runId);
+        runStatusByRunId.set(run.runId, run.status === 'running' ? 'running' : 'terminal');
       }
-      reconcileRunMarkersWithTerminalRuns(terminalRunIds);
+      reconcileRunMarkers(runStatusByRunId);
 
       const next = new Map<string, AutomationScheduleSessionInfo>();
       for (const run of runs) {
@@ -94,8 +96,15 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
         error: error instanceof Error ? error.message : String(error),
       });
       // 见 REFRESH_RETRY_DELAYS_MS:这次拉取也是标记对账的载体,失败不能只 log。
+      // 退避档位用尽后:仍有标记待对账就按最后一档持续重试(否则 scheduler / IPC / DB
+      // 连续不可用超过三档窗口、且此后再无事件时,标记会永久残留);没有标记则停手,
+      // 侧栏索引本身是 best-effort,交给后续事件。
       const attempt = retryAttemptRef.current;
-      const delayMs = REFRESH_RETRY_DELAYS_MS[attempt];
+      const delayMs =
+        REFRESH_RETRY_DELAYS_MS[attempt] ??
+        (hasAnyRunMarker()
+          ? REFRESH_RETRY_DELAYS_MS[REFRESH_RETRY_DELAYS_MS.length - 1]
+          : undefined);
       if (delayMs === undefined) return;
 
       retryAttemptRef.current = attempt + 1;

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SchedulerEvent } from '@cindy/maker-scheduler';
 
 import { createLogger } from '@/lib/logger';
-import { makerChatStore } from '@/lib/makerChatStore';
 import {
   clearSessionAttention,
   hasSessionAttention,
@@ -15,10 +14,10 @@ import {
   getSilencedRunSessionIdForAttentionFallback,
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
+  reconcileRunMarkersWithTerminalRuns,
   rememberScheduleRunSessionAttentionBaseline,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
-  syncRunMarkerFallback,
 } from '@/lib/silencedSessionDoneStore';
 import type { AutomationScheduleSessionInfo } from '../lib/automationSidebarGrouping';
 import { isUnreadScheduleRun } from '../../scheduler/lib/runUnread';
@@ -39,6 +38,16 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
     try {
       const runs = await loadScheduleSidebarIndexRuns();
       if (refreshSeqRef.current !== seq) return;
+
+      // 抑制标记的事件丢失自愈:这份列表是 scheduler 落库的权威 run 状态(且包含所有
+      // 带 sessionId 的 run,没有 history limit),凡是标记指向的 run 已经终态,就说明
+      // 它的 completed / failed 事件没送到,清掉标记。RunStatus 里只有 'running' 不是
+      // 终态。刻意不用定时器猜 —— 见 silencedSessionDoneStore 的文件头注释。
+      const terminalRunIds = new Set<string>();
+      for (const run of runs) {
+        if (run.status !== 'running') terminalRunIds.add(run.runId);
+      }
+      reconcileRunMarkersWithTerminalRuns(terminalRunIds);
 
       const next = new Map<string, AutomationScheduleSessionInfo>();
       for (const run of runs) {
@@ -76,19 +85,6 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
 
   useEffect(() => {
     void refresh();
-    /**
-     * 标记刚开始生效时立刻按当前 running 状态对账一次兜底自愈定时器。
-     * scheduler 事件不改 makerChatStore 的 running 快照,useSessionRunningStatus 的
-     * effect 未必会因此重跑,所以不能只靠它那边的对账 —— 否则标记可能一直没有兜底
-     * 看护。running 判定与 deriveRunningSet 同口径(info.isRunning)。
-     */
-    const syncFallbackForSession = (sessionId: string): void => {
-      if (!sessionId) return;
-      syncRunMarkerFallback(
-        sessionId,
-        makerChatStore.getRunningSnapshot().get(sessionId)?.isRunning === true,
-      );
-    };
     const off = window.electronAPI.maker.schedule.onEvent((raw) => {
       const event = raw as SchedulerEvent;
       if (event.type === 'session-bound') {
@@ -100,7 +96,6 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
           event.sessionId,
           hasSessionAttention(event.sessionId),
         );
-        syncFallbackForSession(event.sessionId);
       }
       if (event.type === 'silenced') {
         const baseline = getScheduleRunSessionAttentionBaseline(event.runId);
@@ -111,11 +106,6 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
             ? baseline.hadSessionAttention
             : hasSessionAttention(event.sessionId),
         );
-        // 两条来源在这里汇合,且 running 状态截然不同:silentWhenIdle 预设静默时
-        // turn 还没起(not-running → 武装兜底);agent 在自己 turn 内调
-        // schedule_silence_current_run 时该 turn 正在跑(running → 不武装,避免
-        // 长 turn 被误清)。
-        syncFallbackForSession(event.sessionId);
         return;
       }
       if (event.type === 'notified') {

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -24,7 +24,7 @@ import {
 } from '@/lib/silencedSessionDoneStore';
 import type { AutomationScheduleSessionInfo } from '../lib/automationSidebarGrouping';
 import { isUnreadScheduleRun } from '../../scheduler/lib/runUnread';
-import { loadScheduleSidebarIndexRuns } from '../../scheduler/lib/scheduleSidebarIndexRuns';
+import { loadScheduleSidebarIndexSnapshot } from '../../scheduler/lib/scheduleSidebarIndexRuns';
 import { subscribeScheduleRunReadSync } from '../../scheduler/lib/scheduleRunReadSync';
 
 const log = createLogger('AutomationScheduleSessionIndex');
@@ -51,7 +51,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
     const seq = refreshSeqRef.current + 1;
     refreshSeqRef.current = seq;
     try {
-      const runs = await loadScheduleSidebarIndexRuns();
+      const { runs, inflightRunIds } = await loadScheduleSidebarIndexSnapshot();
       if (refreshSeqRef.current !== seq) return;
 
       // 抑制标记的事件丢失自愈:这份列表是 scheduler 落库的权威 run 状态(且包含所有
@@ -62,6 +62,10 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
       for (const run of runs) {
         runStatusByRunId.set(run.runId, run.status === 'running' ? 'running' : 'terminal');
       }
+      // 引擎的 in-flight 快照优先级最高,覆盖 DB 状态:自删除场景下(agent 在 run 内调
+      // schedule_delete 删自己的 schedule)run 行已随 schedule 级联删除、run 却仍在跑,
+      // 只有这份内存态能说明它还活着。见 scheduler.listInflightRunIds。
+      for (const runId of inflightRunIds) runStatusByRunId.set(runId, 'running');
       reconcileRunMarkers(runStatusByRunId);
 
       const next = new Map<string, AutomationScheduleSessionInfo>();

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -26,11 +26,23 @@ import { subscribeScheduleRunReadSync } from '../../scheduler/lib/scheduleRunRea
 
 const log = createLogger('AutomationScheduleSessionIndex');
 
+/**
+ * refresh 失败后的退避重试节奏。这次拉取同时承担抑制标记的对账(见 refresh 内注释),
+ * 而失败路径原本只 log —— 于是「消费方卸载期间丢了终态事件 + 重新挂载时首次拉取又
+ * 因 scheduler 未 ready / 临时 IPC 或 DB 错误 reject + 此后再没有任何 scheduler 或
+ * read-sync 事件」这条链上,标记会永久残留,该 session 后续手动对话的完成通知会一直
+ * 被静默。有限重试给自愈留出第二次机会;重试耗尽后仍靠后续事件兜。
+ */
+const REFRESH_RETRY_DELAYS_MS = [2_000, 8_000, 30_000] as const;
+
 export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, AutomationScheduleSessionInfo> {
   const [index, setIndex] = useState<ReadonlyMap<string, AutomationScheduleSessionInfo>>(
     () => new Map(),
   );
   const refreshSeqRef = useRef(0);
+  const refreshRef = useRef<() => Promise<void>>(async () => undefined);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryAttemptRef = useRef(0);
 
   const refresh = useCallback(async () => {
     const seq = refreshSeqRef.current + 1;
@@ -76,12 +88,26 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
         });
       }
       setIndex(next);
+      retryAttemptRef.current = 0;
     } catch (error) {
       log.warn('failed to build automation schedule session index', {
         error: error instanceof Error ? error.message : String(error),
       });
+      // 见 REFRESH_RETRY_DELAYS_MS:这次拉取也是标记对账的载体,失败不能只 log。
+      const attempt = retryAttemptRef.current;
+      const delayMs = REFRESH_RETRY_DELAYS_MS[attempt];
+      if (delayMs === undefined) return;
+
+      retryAttemptRef.current = attempt + 1;
+      if (retryTimerRef.current !== null) clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null;
+        void refreshRef.current();
+      }, delayMs);
     }
   }, []);
+
+  refreshRef.current = refresh;
 
   useEffect(() => {
     void refresh();
@@ -157,6 +183,10 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
     return () => {
       off();
       offReadSync();
+      if (retryTimerRef.current !== null) {
+        clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
     };
   }, [refresh]);
 

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SchedulerEvent } from '@cindy/maker-scheduler';
 
 import { createLogger } from '@/lib/logger';
+import { makerChatStore } from '@/lib/makerChatStore';
 import {
   clearSessionAttention,
   hasSessionAttention,
@@ -17,6 +18,7 @@ import {
   rememberScheduleRunSessionAttentionBaseline,
   scheduleClearSchedulerOwnedRun,
   scheduleClearSilencedRun,
+  syncRunMarkerFallback,
 } from '@/lib/silencedSessionDoneStore';
 import type { AutomationScheduleSessionInfo } from '../lib/automationSidebarGrouping';
 import { isUnreadScheduleRun } from '../../scheduler/lib/runUnread';
@@ -74,6 +76,19 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
 
   useEffect(() => {
     void refresh();
+    /**
+     * 标记刚开始生效时立刻按当前 running 状态对账一次兜底自愈定时器。
+     * scheduler 事件不改 makerChatStore 的 running 快照,useSessionRunningStatus 的
+     * effect 未必会因此重跑,所以不能只靠它那边的对账 —— 否则标记可能一直没有兜底
+     * 看护。running 判定与 deriveRunningSet 同口径(info.isRunning)。
+     */
+    const syncFallbackForSession = (sessionId: string): void => {
+      if (!sessionId) return;
+      syncRunMarkerFallback(
+        sessionId,
+        makerChatStore.getRunningSnapshot().get(sessionId)?.isRunning === true,
+      );
+    };
     const off = window.electronAPI.maker.schedule.onEvent((raw) => {
       const event = raw as SchedulerEvent;
       if (event.type === 'session-bound') {
@@ -85,6 +100,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
           event.sessionId,
           hasSessionAttention(event.sessionId),
         );
+        syncFallbackForSession(event.sessionId);
       }
       if (event.type === 'silenced') {
         const baseline = getScheduleRunSessionAttentionBaseline(event.runId);
@@ -95,6 +111,11 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
             ? baseline.hadSessionAttention
             : hasSessionAttention(event.sessionId),
         );
+        // 两条来源在这里汇合,且 running 状态截然不同:silentWhenIdle 预设静默时
+        // turn 还没起(not-running → 武装兜底);agent 在自己 turn 内调
+        // schedule_silence_current_run 时该 turn 正在跑(running → 不武装,避免
+        // 长 turn 被误清)。
+        syncFallbackForSession(event.sessionId);
         return;
       }
       if (event.type === 'notified') {

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -16,6 +16,7 @@ import {
   markNextSessionTerminalNotificationOwnedByScheduler,
   markNextSessionDoneSilenced,
   hasAnyRunMarker,
+  MARKER_TERMINAL_LINGER_MS,
   reconcileRunMarkers,
   rememberScheduleRunSessionAttentionBaseline,
   scheduleClearSchedulerOwnedRun,
@@ -161,7 +162,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
           sessionId = getSilencedRunSessionIdForAttentionFallback(event.runId);
         }
         if (sessionId) clearSessionAttention(sessionId);
-        scheduleClearSilencedRun(event.runId, 2000);
+        scheduleClearSilencedRun(event.runId, MARKER_TERMINAL_LINGER_MS);
       } else if (event.type === 'completed') {
         clearSilencedRun(event.runId);
       } else if (event.type === 'failed' || event.type === 'deferred') {
@@ -170,7 +171,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
       // completed / failed 可能早于 React transition effect 消费终态，延迟清理；
       // deferred / skipped 没有可接管的 session 终态，立即释放，避免误伤后续 turn。
       if (event.type === 'completed' || event.type === 'failed') {
-        scheduleClearSchedulerOwnedRun(event.runId, 2000);
+        scheduleClearSchedulerOwnedRun(event.runId, MARKER_TERMINAL_LINGER_MS);
       } else if (event.type === 'deferred' || event.type === 'skipped') {
         clearSchedulerOwnedRun(event.runId);
       }

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -38,6 +38,14 @@ const log = createLogger('AutomationScheduleSessionIndex');
  */
 const REFRESH_RETRY_DELAYS_MS = [2_000, 8_000, 30_000] as const;
 
+/**
+ * 快照内部不一致时的重查延迟。见 `ReconcileRunMarkersResult.needsRecheck`:run 恰好在
+ * DB 查询的 await 窗口内结束时,DB 行还是 running 而 controller 已注销,本轮只能保守保持
+ * 标记;若该 run 的终态事件正是丢掉的那个,就要靠这次重查来清。与失败重试分开计时,也不
+ * 占用它的退避配额 —— 这不是失败,只是需要一份更新的快照。
+ */
+const RECONCILE_RECHECK_DELAY_MS = 1_500;
+
 export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, AutomationScheduleSessionInfo> {
   const [index, setIndex] = useState<ReadonlyMap<string, AutomationScheduleSessionInfo>>(
     () => new Map(),
@@ -46,6 +54,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
   const refreshRef = useRef<() => Promise<void>>(async () => undefined);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryAttemptRef = useRef(0);
+  const recheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const refresh = useCallback(async () => {
     const seq = refreshSeqRef.current + 1;
@@ -58,15 +67,19 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
       // 带 sessionId 的 run,没有 history limit),据它清掉「已终态」和「已不存在」的
       // 标记。RunStatus 里只有 'running' 不是终态。刻意不用定时器猜 run 还在不在飞行
       // —— 见 silencedSessionDoneStore 的文件头与 reconcileRunMarkers 注释。
-      const runStatusByRunId = new Map<string, RunLivenessStatus>();
+      const dbRunStatus = new Map<string, RunLivenessStatus>();
       for (const run of runs) {
-        runStatusByRunId.set(run.runId, run.status === 'running' ? 'running' : 'terminal');
+        dbRunStatus.set(run.runId, run.status === 'running' ? 'running' : 'terminal');
       }
-      // 引擎的 in-flight 快照优先级最高,覆盖 DB 状态:自删除场景下(agent 在 run 内调
-      // schedule_delete 删自己的 schedule)run 行已随 schedule 级联删除、run 却仍在跑,
-      // 只有这份内存态能说明它还活着。见 scheduler.listInflightRunIds。
-      for (const runId of inflightRunIds) runStatusByRunId.set(runId, 'running');
-      reconcileRunMarkers(runStatusByRunId);
+      // 两份数据分别传进去 —— 对账内部让 in-flight 优先(自删除场景下 run 行已消失却仍
+      // 在跑),并识别「DB 说 running、引擎说没在跑」的不一致,交由下面的重查收口。
+      const { needsRecheck } = reconcileRunMarkers(dbRunStatus, new Set(inflightRunIds));
+      if (needsRecheck && recheckTimerRef.current === null) {
+        recheckTimerRef.current = setTimeout(() => {
+          recheckTimerRef.current = null;
+          void refreshRef.current();
+        }, RECONCILE_RECHECK_DELAY_MS);
+      }
 
       const next = new Map<string, AutomationScheduleSessionInfo>();
       for (const run of runs) {
@@ -200,6 +213,10 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
       if (retryTimerRef.current !== null) {
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;
+      }
+      if (recheckTimerRef.current !== null) {
+        clearTimeout(recheckTimerRef.current);
+        recheckTimerRef.current = null;
       }
     };
   }, [refresh]);

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -55,13 +55,21 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryAttemptRef = useRef(0);
   const recheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /**
+   * 已卸载标记。cleanup 只能清掉「那一刻已存在」的定时器,但卸载时若拉取仍 pending,
+   * 它之后 reject(例如撞上 scheduler readiness 的 30s 超时)会走 catch 再排一个新定时器
+   * —— 于是退避耗尽后每 30s 无限重试,把已卸载的 hook 一直留着、持续发无用 IPC/DB 读,
+   * 重挂载后还会叠加出多条轮询。所有排定时器的地方都必须先看这个标记。
+   * StrictMode 下 mount→unmount→mount,所以在 effect 开头重置。
+   */
+  const cancelledRef = useRef(false);
 
   const refresh = useCallback(async () => {
     const seq = refreshSeqRef.current + 1;
     refreshSeqRef.current = seq;
     try {
       const { runs, inflightRunIds } = await loadScheduleSidebarIndexSnapshot();
-      if (refreshSeqRef.current !== seq) return;
+      if (refreshSeqRef.current !== seq || cancelledRef.current) return;
 
       // 抑制标记的事件丢失自愈:这份列表是 scheduler 落库的权威 run 状态(且包含所有
       // 带 sessionId 的 run,没有 history limit),据它清掉「已终态」和「已不存在」的
@@ -113,6 +121,8 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
       log.warn('failed to build automation schedule session index', {
         error: error instanceof Error ? error.message : String(error),
       });
+      // 卸载后到达的 rejection 不再排新定时器,见 cancelledRef。
+      if (cancelledRef.current) return;
       // 见 REFRESH_RETRY_DELAYS_MS:这次拉取也是标记对账的载体,失败不能只 log。
       // 退避档位用尽后:仍有标记待对账就按最后一档持续重试(否则 scheduler / IPC / DB
       // 连续不可用超过三档窗口、且此后再无事件时,标记会永久残留);没有标记则停手,
@@ -137,6 +147,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
   refreshRef.current = refresh;
 
   useEffect(() => {
+    cancelledRef.current = false;
     void refresh();
     const off = window.electronAPI.maker.schedule.onEvent((raw) => {
       const event = raw as SchedulerEvent;
@@ -208,6 +219,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
     // (见 scheduleRunReadSync 模块注释)。
     const offReadSync = subscribeScheduleRunReadSync(() => void refresh());
     return () => {
+      cancelledRef.current = true;
       off();
       offReadSync();
       if (retryTimerRef.current !== null) {

--- a/apps/desktop/src/renderer/features/scheduler/lib/scheduleSidebarIndexRuns.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/scheduleSidebarIndexRuns.ts
@@ -15,6 +15,30 @@ export interface ScheduleSidebarIndexRun {
   readAt?: number;
 }
 
+/**
+ * 一次 invoke 返回的侧栏索引快照。
+ *
+ * `inflightRunIds` 是引擎内存里的权威 in-flight 集合,和 `runs` 取自同一次调用、天然
+ * 一致。通知抑制标记的对账必须靠它区分「`runs` 里查不到某条 run」的两种含义:已结束并
+ * 被清理,还是自删除场景下 run 行已随 schedule 级联删除、run 却仍在跑
+ * (见 `scheduler.listInflightRunIds` 的注释)。
+ */
+export interface ScheduleSidebarIndexSnapshot {
+  runs: ScheduleSidebarIndexRun[];
+  inflightRunIds: string[];
+}
+
+export async function loadScheduleSidebarIndexSnapshot(): Promise<ScheduleSidebarIndexSnapshot> {
+  // main 与 renderer 同包发布,不存在版本 skew,所以这里不做跨形态兼容 —— 形态不符就是
+  // bug,应该暴露出来而不是静默降级成「没有 in-flight 信息」(那会让对账去误清仍在跑的
+  // 自删除 run)。`?? []` 只兜 undefined。
+  const raw = (await window.electronAPI.maker.schedule.listSidebarIndexRuns()) as
+    | ScheduleSidebarIndexSnapshot
+    | undefined;
+  return { runs: raw?.runs ?? [], inflightRunIds: raw?.inflightRunIds ?? [] };
+}
+
+/** 只要 run 列表的调用方(侧栏卡片、未读计数等)继续用这个。 */
 export async function loadScheduleSidebarIndexRuns(): Promise<ScheduleSidebarIndexRun[]> {
-  return (await window.electronAPI.maker.schedule.listSidebarIndexRuns()) as ScheduleSidebarIndexRun[];
+  return (await loadScheduleSidebarIndexSnapshot()).runs;
 }

--- a/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
@@ -50,8 +50,10 @@ import {
 import {
   clearCompletedSchedulerOwnedRunForNewActivity,
   clearCompletedSilencedRunForNewActivity,
-  observeNextSessionTerminalNotificationOwnedByScheduler,
-  observeNextSessionDoneSilenced,
+  isSessionTerminalNotificationOwnedByScheduler,
+  isSessionDoneSilenced,
+  noteSchedulerOwnedRunStillActive,
+  noteSilencedRunStillActive,
 } from '@/lib/silencedSessionDoneStore';
 
 // Codex maker 化后, codex session 也走 makerChatStore;
@@ -147,6 +149,11 @@ export function useSessionRunningStatus(
       if (!prevRunning.has(sessionId)) {
         clearCompletedSilencedRunForNewActivity(sessionId);
         clearCompletedSchedulerOwnedRunForNewActivity(sessionId);
+        // 上面两行只清「run 已终态」的标记(用户手动起的新对话)。run 还在跑时这里
+        // 是另一层意思:后台 subagent 续 turn / silent-stop 自动续跑 —— run 显然
+        // 活着,撤掉标记的兜底自愈定时器,别让它在长 run 中途把标记清了。
+        noteSilencedRunStillActive(sessionId);
+        noteSchedulerOwnedRunStillActive(sessionId);
         // error 红角标与真实错误态同步:新 turn 启动会清掉 store 的终止错误
         // (staleErrorClearedOnTurnStart),若此时角标还是 'error' 就成了 orphan——
         // 活跃会话的 done 分支不覆写它,角标会永久残留。错误已不存在,这里显式清除
@@ -188,14 +195,16 @@ export function useSessionRunningStatus(
         // `false` here was the root cause of failed turns being notified as
         // "done"; always resolve errors against the authoritative store.
         const hasError = info?.hasError ?? makerChatStore.hasSessionTerminalError(sessionId);
-        // observeNextSessionDoneSilenced 有副作用(消费一次静默 slot),必须在这里
-        // 读一次,不能推迟到定时器里 —— 否则 debounce 期间 session 又起新 turn 时
-        // 静默 slot 会被跳过。
-        const isSilencedDone = !hasError && observeNextSessionDoneSilenced(sessionId);
+        // 两个查询都无副作用、且在 run 存续期间对每次 done 转换都成立:一个静默
+        // run 内 running→done 会翻转多次(后台 subagent 续 turn、silent-stop 自动
+        // 续跑),标记若被第一次中间 done 消费掉,最终那次真 done 就会当成普通完成
+        // 把系统通知发出去。标记的清除只由 scheduler 事件驱动,见
+        // silencedSessionDoneStore 的文件头注释。
+        const isSilencedDone = !hasError && isSessionDoneSilenced(sessionId);
         // Scheduler 已按 schedule.notify 接管这次终态的桌面 / 飞书通知。这里只
         // 抑制 callback，侧栏 / Dock attention 仍按普通 done/error 逻辑保留。
         const notificationOwnedByScheduler =
-          observeNextSessionTerminalNotificationOwnedByScheduler(sessionId);
+          isSessionTerminalNotificationOwnedByScheduler(sessionId);
         const isActive = sessionId === activeSessionId;
 
         // error 立刻处理:队列会被 abort,不存在"下一条自动接着跑"的场景;红角标 +
@@ -211,7 +220,7 @@ export function useSessionRunningStatus(
         }
 
         // 静默完成(scheduled automation 等):既不亮角标也不发系统通知,直接跳过、
-        // 不进 debounce 调度(静默 slot 副作用已在上面消费完毕)。
+        // 不进 debounce 调度。中间 done 与最终 done 都会走到这里。
         if (isSilencedDone) continue;
 
         // 正常 done:走 debounce。QUEUE_DEBOUNCE_MS 内若同 session 又变 running

--- a/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
@@ -52,8 +52,6 @@ import {
   clearCompletedSilencedRunForNewActivity,
   isSessionTerminalNotificationOwnedByScheduler,
   isSessionDoneSilenced,
-  listRunMarkerSessionIds,
-  syncRunMarkerFallback,
 } from '@/lib/silencedSessionDoneStore';
 
 // Codex maker 化后, codex session 也走 makerChatStore;
@@ -304,17 +302,6 @@ export function useSessionRunningStatus(
         // error 终止,branch 2 刚挂上的红角标不能被这条自动清理吞掉)。
         clearSessionAttention(sessionId);
       }
-    }
-
-    // --- 5. 自动任务标记的兜底自愈对账 ---
-    // 兜底定时器只有一个含义:「标记还在、session 当前 not-running」持续超过窗口期
-    // → scheduler 的终态事件丢了,自愈清掉标记。判据必须取**当前** running 状态,
-    // 不能靠事件先后顺序推断(agent 在 turn 内调 schedule_silence_current_run 时,
-    // 标记建立时该 turn 已经 running;而只在新 turn 起时撤销兜底的话,本 hook 卸载
-    // 后就再没人重新武装)。放在 effect 末尾:section 1/2 可能刚清掉标记,对账要基于
-    // 最终状态。挂载后的第一次 effect 天然完成一次全量对账。
-    for (const markedSessionId of listRunMarkerSessionIds()) {
-      syncRunMarkerFallback(markedSessionId, currentRunningSet.has(markedSessionId));
     }
 
     prevRunningRef.current = new Set(currentRunningSet);

--- a/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
@@ -52,8 +52,8 @@ import {
   clearCompletedSilencedRunForNewActivity,
   isSessionTerminalNotificationOwnedByScheduler,
   isSessionDoneSilenced,
-  noteSchedulerOwnedRunStillActive,
-  noteSilencedRunStillActive,
+  listRunMarkerSessionIds,
+  syncRunMarkerFallback,
 } from '@/lib/silencedSessionDoneStore';
 
 // Codex maker 化后, codex session 也走 makerChatStore;
@@ -147,13 +147,11 @@ export function useSessionRunningStatus(
     // --- 1. Detect new turn starts ---
     for (const sessionId of currentRunningSet) {
       if (!prevRunning.has(sessionId)) {
+        // 只清「run 已终态」的标记(用户手动起的新对话或下一个 run);run 还在跑时
+        // 是 subagent 续 turn / silent-stop 自动续跑,标记必须留着。兜底定时器不在
+        // 这里动 —— 统一由本 effect 末尾的对账按当前 running 状态处理。
         clearCompletedSilencedRunForNewActivity(sessionId);
         clearCompletedSchedulerOwnedRunForNewActivity(sessionId);
-        // 上面两行只清「run 已终态」的标记(用户手动起的新对话)。run 还在跑时这里
-        // 是另一层意思:后台 subagent 续 turn / silent-stop 自动续跑 —— run 显然
-        // 活着,撤掉标记的兜底自愈定时器,别让它在长 run 中途把标记清了。
-        noteSilencedRunStillActive(sessionId);
-        noteSchedulerOwnedRunStillActive(sessionId);
         // error 红角标与真实错误态同步:新 turn 启动会清掉 store 的终止错误
         // (staleErrorClearedOnTurnStart),若此时角标还是 'error' 就成了 orphan——
         // 活跃会话的 done 分支不覆写它,角标会永久残留。错误已不存在,这里显式清除
@@ -306,6 +304,17 @@ export function useSessionRunningStatus(
         // error 终止,branch 2 刚挂上的红角标不能被这条自动清理吞掉)。
         clearSessionAttention(sessionId);
       }
+    }
+
+    // --- 5. 自动任务标记的兜底自愈对账 ---
+    // 兜底定时器只有一个含义:「标记还在、session 当前 not-running」持续超过窗口期
+    // → scheduler 的终态事件丢了,自愈清掉标记。判据必须取**当前** running 状态,
+    // 不能靠事件先后顺序推断(agent 在 turn 内调 schedule_silence_current_run 时,
+    // 标记建立时该 turn 已经 running;而只在新 turn 起时撤销兜底的话,本 hook 卸载
+    // 后就再没人重新武装)。放在 effect 末尾:section 1/2 可能刚清掉标记,对账要基于
+    // 最终状态。挂载后的第一次 effect 天然完成一次全量对账。
+    for (const markedSessionId of listRunMarkerSessionIds()) {
+      syncRunMarkerFallback(markedSessionId, currentRunningSet.has(markedSessionId));
     }
 
     prevRunningRef.current = new Set(currentRunningSet);

--- a/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
+++ b/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
@@ -2,8 +2,10 @@
  * 自动任务(scheduler)终态通知的抑制标记。
  *
  * 两组标记语义刻意分开:
- *   - silenced:静默运行(`Schedule.silentWhenIdle`)的成功 run —— 完全不发通知、
- *     不亮角标。
+ *   - silenced:静默运行的成功 run —— 完全不发通知、不亮角标。来源有两条:
+ *     `Schedule.silentWhenIdle` 预设(run 开始、session-bound 时就静默),以及 agent
+ *     在自己 turn 内调 `schedule_silence_current_run`(引擎 `silenceRun`)。两条都走
+ *     `silenced` 事件,但**建立标记的时机相对 turn 完全不同**,见下方兜底注释。
  *   - schedulerOwned:普通自动任务 —— scheduler notifier 已按 `schedule.notify`
  *     发过这次终态通知,renderer 不能再发第二条;但侧栏 / Dock attention 仍按
  *     普通 done/error 逻辑保留。
@@ -38,7 +40,7 @@ const silencedFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const schedulerOwnedFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 /**
- * 兜底自愈窗口:只防 scheduler 事件丢失(广播断链、事件早于 renderer 挂载等)导致
+ * 兜底自愈窗口:只防 scheduler 事件丢失(广播断链、renderer 在 run 中途重载等)导致
  * 标记永久残留,把该 session 后续**手动**对话的 done 也误静默。正常路径不依赖它。
  *
  * 12 分钟是有依据的下限,不要随意缩短:main 侧 runner 对「主 turn 已 done 但后台
@@ -47,10 +49,9 @@ const schedulerOwnedFallbackTimers = new Map<string, ReturnType<typeof setTimeou
  * completed;否则慢 subagent 续 turn 时标记已被自愈清掉,最终 done 又会弹系统
  * 通知 —— 正是本模块要防的那个 bug。改动 runner 那个常量时一并复核这里。
  *
- * 定时器在 session 起新 turn 时取消(run 明显还活着)、在每次 done 转换时重置,
- * 所以跑很久的单个 turn 不会被它误清。
+ * 命名刻意中性:两类标记共用这一个窗口,不要改回带 silenced 字样的名字。
  */
-export const SILENCED_RUN_IDLE_FALLBACK_MS = 12 * 60_000;
+export const RUN_MARKER_IDLE_FALLBACK_MS = 12 * 60_000;
 
 export function rememberScheduleRunSessionAttentionBaseline(
   runId: string,
@@ -78,33 +79,23 @@ export function markNextSessionDoneSilenced(
     silencedRunSessionIds.delete(previousRunId);
     silencedRunHadAttention.delete(previousRunId);
     clearSilencedFallbackTimer(previousRunId);
+    // 被顶替的 run 不会再有人调 clearSilencedRun(它已不在 silencedRunSessionIds
+    // 里,scheduleClearSilencedRun 会直接 return),baseline 必须在这里一起清,
+    // 否则 runAttentionBaselines 会随 session 复用无界增长。
+    runAttentionBaselines.delete(previousRunId);
   }
   clearPendingTimer(previousRunId);
   clearPendingTimer(runId);
   silencedRunSessionIds.set(runId, sessionId);
   silencedSessionRunIds.set(sessionId, runId);
   silencedRunHadAttention.set(runId, hadSessionAttention);
-  // run 若从此再没产生任何 turn(创建后就崩/被杀),标记不能永久占住这个 session。
-  armSilencedFallbackTimer(runId);
+  // 兜底定时器不在这里武装 —— 由 syncRunMarkerFallback 按 session 的**当前**
+  // running 状态决定,见该函数注释。
 }
 
-/**
- * 纯查询,无副作用:同一个 run 内每次 done 转换都要得到 true(见文件头注释)。
- * 顺带重置兜底定时器 —— 刚观察到一次终态,说明 run 仍在正常产出事件。
- */
+/** 纯查询:同一个 run 内每次 done 转换都要得到 true(见文件头注释)。 */
 export function isSessionDoneSilenced(sessionId: string): boolean {
-  const runId = silencedSessionRunIds.get(sessionId);
-  if (!runId) return false;
-  // 已进入 completed linger 的标记不再续期,否则兜底会把 linger 往后推。
-  if (!clearTimers.has(runId)) armSilencedFallbackTimer(runId);
-  return true;
-}
-
-/** session 起了新 turn:run 显然还活着,撤掉兜底自愈,交回事件驱动。 */
-export function noteSilencedRunStillActive(sessionId: string): void {
-  const runId = silencedSessionRunIds.get(sessionId);
-  if (!runId) return;
-  clearSilencedFallbackTimer(runId);
+  return silencedSessionRunIds.has(sessionId);
 }
 
 export function markNextSessionTerminalNotificationOwnedByScheduler(
@@ -121,24 +112,59 @@ export function markNextSessionTerminalNotificationOwnedByScheduler(
   clearSchedulerOwnedTimer(runId);
   schedulerOwnedRunSessionIds.set(runId, sessionId);
   schedulerOwnedSessionRunIds.set(sessionId, runId);
-  armSchedulerOwnedFallbackTimer(runId);
 }
 
 /** 与 `isSessionDoneSilenced` 同款语义:纯查询,run 内多次 done 都命中。 */
 export function isSessionTerminalNotificationOwnedByScheduler(
   sessionId: string,
 ): boolean {
-  const runId = schedulerOwnedSessionRunIds.get(sessionId);
-  if (!runId) return false;
-  if (!schedulerOwnedClearTimers.has(runId)) armSchedulerOwnedFallbackTimer(runId);
-  return true;
+  return schedulerOwnedSessionRunIds.has(sessionId);
 }
 
-/** 与 `noteSilencedRunStillActive` 对称。 */
-export function noteSchedulerOwnedRunStillActive(sessionId: string): void {
-  const runId = schedulerOwnedSessionRunIds.get(sessionId);
-  if (!runId) return;
-  clearSchedulerOwnedFallbackTimer(runId);
+/** 当前持有任一标记的 sessionId。供消费方逐个对账兜底定时器。 */
+export function listRunMarkerSessionIds(): string[] {
+  if (silencedSessionRunIds.size === 0 && schedulerOwnedSessionRunIds.size === 0) return [];
+  const ids = new Set<string>(silencedSessionRunIds.keys());
+  for (const id of schedulerOwnedSessionRunIds.keys()) ids.add(id);
+  return [...ids];
+}
+
+/**
+ * 按 session 的**当前** running 状态对账兜底定时器 —— 这是兜底唯一的武装/撤销入口。
+ *
+ * 为什么不能靠「事件先后顺序」推断 run 是否活着(两个方向都会错):
+ *   - agent 在自己 turn 内调 `schedule_silence_current_run` 时,标记建立时该 turn
+ *     已经 running、renderer 早过了 rising edge。若在建立标记时就武装兜底,便再没有
+ *     任何信号来撤销它,turn 只要还剩 12 分钟以上就会被误清、通知照旧漏出。
+ *   - 反过来,若只在「新 turn 起」时撤销兜底,消费方组件在那之后卸载(done 与
+ *     scheduler 终态事件都落在卸载期间,且事件不回放)就永远没有兜底,标记永久残留。
+ *
+ * 所以判据取当前 running 状态,而不是事件序:running → 撤掉(run 活着,长 turn 也
+ * 不会被误清);not-running → 武装(若尚未武装)。消费方在每次 running 快照变化时
+ * 逐个 session 调一次即可,挂载后的第一次调用天然完成对账。
+ *
+ * 已进入 completed linger 的标记不武装:清理由 linger 定时器负责。
+ */
+export function syncRunMarkerFallback(sessionId: string, isRunning: boolean): void {
+  const silencedRunId = silencedSessionRunIds.get(sessionId);
+  if (silencedRunId) {
+    if (isRunning) {
+      clearSilencedFallbackTimer(silencedRunId);
+    } else if (!silencedFallbackTimers.has(silencedRunId) && !clearTimers.has(silencedRunId)) {
+      armSilencedFallbackTimer(silencedRunId);
+    }
+  }
+  const ownedRunId = schedulerOwnedSessionRunIds.get(sessionId);
+  if (ownedRunId) {
+    if (isRunning) {
+      clearSchedulerOwnedFallbackTimer(ownedRunId);
+    } else if (
+      !schedulerOwnedFallbackTimers.has(ownedRunId) &&
+      !schedulerOwnedClearTimers.has(ownedRunId)
+    ) {
+      armSchedulerOwnedFallbackTimer(ownedRunId);
+    }
+  }
 }
 
 export function scheduleClearSchedulerOwnedRun(runId: string, delayMs: number): void {
@@ -258,7 +284,7 @@ function armSilencedFallbackTimer(runId: string): void {
   const timer = setTimeout(() => {
     silencedFallbackTimers.delete(runId);
     clearSilencedRun(runId);
-  }, SILENCED_RUN_IDLE_FALLBACK_MS);
+  }, RUN_MARKER_IDLE_FALLBACK_MS);
   silencedFallbackTimers.set(runId, timer);
 }
 
@@ -275,7 +301,7 @@ function armSchedulerOwnedFallbackTimer(runId: string): void {
   const timer = setTimeout(() => {
     schedulerOwnedFallbackTimers.delete(runId);
     clearSchedulerOwnedRun(runId);
-  }, SILENCED_RUN_IDLE_FALLBACK_MS);
+  }, RUN_MARKER_IDLE_FALLBACK_MS);
   schedulerOwnedFallbackTimers.set(runId, timer);
 }
 

--- a/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
+++ b/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
@@ -151,6 +151,12 @@ export function hasAnyRunMarker(): boolean {
  *     所有带 sessionId 的 run,所以标记存在就意味着该 run 当时已进入快照范围。异步
  *     拉取的过期结果由调用方的 seq 守卫挡掉,不会走到这里。
  *
+ * **调用方必须先把引擎的 in-flight 快照覆盖成 `running` 再传进来**(见
+ * `scheduler.listInflightRunIds`)。「行不在库里」并不等于「跑完了」:agent 在任务 run
+ * 内调 `schedule_delete` 删自己的 schedule 时,引擎用 `exemptRunId` 豁免 caller run 不
+ * abort,它的行随 schedule 级联删除后仍继续跑到底 —— 那期间把标记清掉,最终 done 就会
+ * 漏出通知。引擎内存态是这件事唯一的权威来源,优先级高于 DB 状态。
+ *
  * **空映射不是异常,一样要对账**:权威查询在库里没有匹配行时合法返回空数组(删掉了
  * 最后一个 schedule、或唯一的 run 被 defer 后删除),而查询失败是 reject、走调用方的
  * catch 与重试,根本不会以空映射的形式到这里。早先那个「空映射整体跳过」的守卫会把

--- a/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
+++ b/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
@@ -14,10 +14,13 @@
  * **标记的生命周期跟随 run,不是「被第一次 done 消费掉」**:一个 run 内 session
  * 的 running→done 会翻转多次(后台 subagent 完成后 SDK 自动续 turn、silent-stop
  * 守卫 1.5s 后自动续跑、队列自动衔接),标记必须活过每一次中间 done,否则最终那
- * 次真 done 会当成普通完成,把 macOS toast / 飞书 / 手机推送全发一遍。清除只来自
- * scheduler 的 completed / failed / notified 事件(linger 定时器),或 run 已终态后
- * 该 session 又起新 turn。main 侧灵动岛(`main/agent-island/service.ts` 的
- * `isCompletionEventSilenced`)是同一套语义,两边不要再分叉。
+ * 次真 done 会当成普通完成,把 macOS toast / 飞书 / 手机推送全发一遍。
+ *
+ * 清除只有三条路径:scheduler 的 completed / failed / notified 事件、run 已终态后该
+ * session 又起新 turn、以及对账权威 run 状态(`reconcileRunMarkers`,治事件丢失)。前两条
+ * 与第三条统一走 `MARKER_TERMINAL_LINGER_MS` 的退场窗口。main 侧灵动岛
+ * (`main/agent-island/service.ts` 的 `isCompletionEventSilenced`)是同一套语义,
+ * 两边不要再分叉。
  */
 
 const silencedRunSessionIds = new Map<string, string>();
@@ -115,6 +118,19 @@ export function isSessionTerminalNotificationOwnedByScheduler(
 /** 对账用的 run 存活态:只关心「还在飞行」与「不再飞行」。 */
 export type RunLivenessStatus = 'running' | 'terminal';
 
+/**
+ * 标记从「run 已终态」到真正删除之间的退场窗口。
+ *
+ * 这段延迟是留给 renderer 的 done transition 的:scheduler 的终态事件可能早于 React
+ * 处理该 session 的 running→done,立刻删标记会让那次 transition 看不到标记、于是发出
+ * 不该发的(或重复的)通知。事件路径与对账路径都必须走这段 linger —— 对账遇到的恰恰是
+ * 「终态事件丢了、从未排过 linger」的标记,直接清就会踩到同一个坑。
+ *
+ * 于是全模块只有一个统一语义:**linger 定时器存在 = run 已终态、标记进入退场倒计时**,
+ * 不论这个判定来自事件还是来自对账。`clearCompleted*ForNewActivity` 正是拿它当终态判据。
+ */
+export const MARKER_TERMINAL_LINGER_MS = 2000;
+
 /** 是否还有任何标记等待对账。消费方据此决定要不要继续重试拉取快照。 */
 export function hasAnyRunMarker(): boolean {
   return silencedRunSessionIds.size > 0 || schedulerOwnedRunSessionIds.size > 0;
@@ -126,27 +142,30 @@ export function hasAnyRunMarker(): boolean {
  * 误判,见上方「事件丢失的自愈不用定时器」注释。
  *
  * 三种情形:
- *   - 映射里是 `terminal` → 清。它的 completed / failed 事件没送到。
+ *   - 映射里是 `terminal` → 排 linger 退场。它的 completed / failed 事件没送到。
  *   - 映射里是 `running` → 保持。仍在飞行,飞多久都不清。
- *   - **不在映射里** → 清。该 run 已经不存在了:删除 schedule 会级联删掉它的
- *     `schedule_runs` 行,deferred run 也会被显式删除,这两种情况永远等不到一个终态
- *     状态。这里不可能是「标记建好但 run 还没落库」的极早期 —— 引擎先 `updateRun`
- *     写 sessionId、再 emit `session-bound` / `silenced`,而权威快照包含所有带
- *     sessionId 的 run,所以标记存在就意味着该 run 当时已进入快照范围。异步拉取的
- *     过期结果由调用方的 seq 守卫挡掉,不会走到这里。
+ *   - **不在映射里** → 同样排 linger 退场。该 run 已经不存在了:删除 schedule 会级联
+ *     删掉它的 `schedule_runs` 行,deferred run 也会被显式删除,这两种情况永远等不到
+ *     一个终态状态。这里不可能是「标记建好但 run 还没落库」的极早期 —— 引擎先
+ *     `updateRun` 写 sessionId、再 emit `session-bound` / `silenced`,而权威快照包含
+ *     所有带 sessionId 的 run,所以标记存在就意味着该 run 当时已进入快照范围。异步
+ *     拉取的过期结果由调用方的 seq 守卫挡掉,不会走到这里。
  *
- * 空映射当作查询异常(而不是「一条 run 都没有」)整体跳过,避免把所有标记误清。
+ * **空映射不是异常,一样要对账**:权威查询在库里没有匹配行时合法返回空数组(删掉了
+ * 最后一个 schedule、或唯一的 run 被 defer 后删除),而查询失败是 reject、走调用方的
+ * catch 与重试,根本不会以空映射的形式到这里。早先那个「空映射整体跳过」的守卫会把
+ * 这种情况下的标记永久留住。
  *
- * 跳过已排 linger 的标记:那段 linger 正是留给 renderer 的 done transition 消费标记
- * 用的,对账不能抢在它前面清、否则那次终态又会走普通通知路径。
+ * 清除统一走 `MARKER_TERMINAL_LINGER_MS` 的 linger,不立即删 —— 对账面对的正是「终态
+ * 事件丢了、从未排过 linger」的标记,而 DB 可能已报终态、React 却还没处理该 session 的
+ * running→done。已排 linger 的标记跳过,避免重置它的倒计时。
  */
 export function reconcileRunMarkers(
   runStatusByRunId: ReadonlyMap<string, RunLivenessStatus>,
 ): void {
-  if (runStatusByRunId.size === 0) return;
   for (const runId of [...silencedRunSessionIds.keys()]) {
     if (clearTimers.has(runId) || runStatusByRunId.get(runId) === 'running') continue;
-    clearSilencedRun(runId);
+    scheduleClearSilencedRun(runId, MARKER_TERMINAL_LINGER_MS);
   }
   for (const runId of [...schedulerOwnedRunSessionIds.keys()]) {
     if (
@@ -155,7 +174,7 @@ export function reconcileRunMarkers(
     ) {
       continue;
     }
-    clearSchedulerOwnedRun(runId);
+    scheduleClearSchedulerOwnedRun(runId, MARKER_TERMINAL_LINGER_MS);
   }
 }
 

--- a/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
+++ b/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
@@ -47,7 +47,7 @@ const clearTimers = new Map<string, ReturnType<typeof setTimeout>>();
  *      任意长,任何固定窗口都必然误清。
  *
  * 现在改为向权威来源对账:scheduler 落库的 run 状态(见
- * `reconcileRunMarkersWithTerminalRuns`)。不猜,只问。
+ * `reconcileRunMarkers`)。不猜,只问。
  */
 
 export function rememberScheduleRunSessionAttentionBaseline(
@@ -112,29 +112,49 @@ export function isSessionTerminalNotificationOwnedByScheduler(
   return schedulerOwnedSessionRunIds.has(sessionId);
 }
 
+/** 对账用的 run 存活态:只关心「还在飞行」与「不再飞行」。 */
+export type RunLivenessStatus = 'running' | 'terminal';
+
+/** 是否还有任何标记等待对账。消费方据此决定要不要继续重试拉取快照。 */
+export function hasAnyRunMarker(): boolean {
+  return silencedRunSessionIds.size > 0 || schedulerOwnedRunSessionIds.size > 0;
+}
+
 /**
- * 用 scheduler 落库的**权威** run 状态对账标记:标记指向的 run 已经是终态却还留着
- * 标记,说明它的 completed / failed 事件丢了(广播断链、事件早于消费方挂载等),清掉。
- * 这是事件丢失的唯一自愈路径 —— 不猜时间、也不看 renderer 的 running 快照,那几种
- * 判据都会误判,见上方「事件丢失的自愈不用定时器」注释。
+ * 用 scheduler 落库的**权威** run 状态对账标记 —— 事件丢失(广播断链、事件早于消费方
+ * 挂载等)的唯一自愈路径。不猜时间、也不看 renderer 的 running 快照,那几种判据都会
+ * 误判,见上方「事件丢失的自愈不用定时器」注释。
  *
- * 传入的是**终态** runId 集合(`RunStatus` 里只有 `running` 不是终态)。不在集合里的
- * runId 一律保持:可能仍在飞行,也可能是刚建立标记、sessionId 还没落库的极早期,
- * 两种都不能清。
+ * 三种情形:
+ *   - 映射里是 `terminal` → 清。它的 completed / failed 事件没送到。
+ *   - 映射里是 `running` → 保持。仍在飞行,飞多久都不清。
+ *   - **不在映射里** → 清。该 run 已经不存在了:删除 schedule 会级联删掉它的
+ *     `schedule_runs` 行,deferred run 也会被显式删除,这两种情况永远等不到一个终态
+ *     状态。这里不可能是「标记建好但 run 还没落库」的极早期 —— 引擎先 `updateRun`
+ *     写 sessionId、再 emit `session-bound` / `silenced`,而权威快照包含所有带
+ *     sessionId 的 run,所以标记存在就意味着该 run 当时已进入快照范围。异步拉取的
+ *     过期结果由调用方的 seq 守卫挡掉,不会走到这里。
  *
- * 跳过已排 linger 的标记:completed 到达时刻意留了一段 linger,让 renderer 的 done
- * transition 先消费掉标记,对账不能抢在它前面清、否则那次终态又会走普通通知路径。
+ * 空映射当作查询异常(而不是「一条 run 都没有」)整体跳过,避免把所有标记误清。
+ *
+ * 跳过已排 linger 的标记:那段 linger 正是留给 renderer 的 done transition 消费标记
+ * 用的,对账不能抢在它前面清、否则那次终态又会走普通通知路径。
  */
-export function reconcileRunMarkersWithTerminalRuns(
-  terminalRunIds: ReadonlySet<string>,
+export function reconcileRunMarkers(
+  runStatusByRunId: ReadonlyMap<string, RunLivenessStatus>,
 ): void {
-  if (terminalRunIds.size === 0) return;
+  if (runStatusByRunId.size === 0) return;
   for (const runId of [...silencedRunSessionIds.keys()]) {
-    if (!terminalRunIds.has(runId) || clearTimers.has(runId)) continue;
+    if (clearTimers.has(runId) || runStatusByRunId.get(runId) === 'running') continue;
     clearSilencedRun(runId);
   }
   for (const runId of [...schedulerOwnedRunSessionIds.keys()]) {
-    if (!terminalRunIds.has(runId) || schedulerOwnedClearTimers.has(runId)) continue;
+    if (
+      schedulerOwnedClearTimers.has(runId) ||
+      runStatusByRunId.get(runId) === 'running'
+    ) {
+      continue;
+    }
     clearSchedulerOwnedRun(runId);
   }
 }

--- a/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
+++ b/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
@@ -5,7 +5,8 @@
  *   - silenced:静默运行的成功 run —— 完全不发通知、不亮角标。来源有两条:
  *     `Schedule.silentWhenIdle` 预设(run 开始、session-bound 时就静默),以及 agent
  *     在自己 turn 内调 `schedule_silence_current_run`(引擎 `silenceRun`)。两条都走
- *     `silenced` 事件,但**建立标记的时机相对 turn 完全不同**,见下方兜底注释。
+ *     `silenced` 事件,但**建立标记的时机相对 turn 完全不同**(一条在 turn 之前、
+ *     一条在 turn 中间),任何依赖「事件序」的判断都会在其中一条上翻车。
  *   - schedulerOwned:普通自动任务 —— scheduler notifier 已按 `schedule.notify`
  *     发过这次终态通知,renderer 不能再发第二条;但侧栏 / Dock attention 仍按
  *     普通 done/error 逻辑保留。
@@ -32,26 +33,22 @@ const runAttentionBaselines = new Map<
 const clearTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 /**
- * 兜底自愈定时器。与上面两张 `*ClearTimers` **刻意分开**:那两张表示「run 已终
- * 态、正在 linger 清理」,`clearCompleted*ForNewActivity` 拿它当终态判据,兜底
- * 定时器混进去会让「run 还在跑」被误判成终态,新 turn 一起就把标记清了。
- */
-const silencedFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
-const schedulerOwnedFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
-/**
- * 兜底自愈窗口:只防 scheduler 事件丢失(广播断链、renderer 在 run 中途重载等)导致
- * 标记永久残留,把该 session 后续**手动**对话的 done 也误静默。正常路径不依赖它。
+ * 事件丢失的自愈**不用定时器**。历史上试过三种「猜 run 还在不在飞行」的判据,
+ * 每一种都被证明会误判,不要再往回走:
  *
- * 12 分钟是有依据的下限,不要随意缩短:main 侧 runner 对「主 turn 已 done 但后台
- * subagent 仍在途」的兜底是 `BG_TASK_IDLE_FALLBACK_MS = 10 分钟`
- * (`main/scheduler-host/runner.ts`)。标记必须活过它,runner 才总是先收尾并发出
- * completed;否则慢 subagent 续 turn 时标记已被自愈清掉,最终 done 又会弹系统
- * 通知 —— 正是本模块要防的那个 bug。改动 runner 那个常量时一并复核这里。
+ *   1. 事件先后顺序(建标记时武装、新 turn 起时撤销):agent 在自己 turn 内调
+ *      `schedule_silence_current_run` 时,标记建立时该 turn 已经 running,此后再没
+ *      有信号能撤销;反过来只在新 turn 起时撤销,消费方随后卸载就永远没有兜底。
+ *   2. renderer 的 running 快照:`makerChatStore` 的折算**刻意**把 `remote_agent`、
+ *      `local_bash`、未知 task_type 排除在 `WAKE_AGENT_TASK_TYPES` 之外,device-link
+ *      远程会话整体豁免 —— run 仍在飞行而快照为 false 是设计内行为。
+ *   3. 固定时长上限:runner 的 `BG_TASK_IDLE_FALLBACK_MS` 是**事件静默**超时,每个
+ *      事件都会重新武装,不是最大 run 时长。持续产出事件的后台任务可以合法飞行
+ *      任意长,任何固定窗口都必然误清。
  *
- * 命名刻意中性:两类标记共用这一个窗口,不要改回带 silenced 字样的名字。
+ * 现在改为向权威来源对账:scheduler 落库的 run 状态(见
+ * `reconcileRunMarkersWithTerminalRuns`)。不猜,只问。
  */
-export const RUN_MARKER_IDLE_FALLBACK_MS = 12 * 60_000;
 
 export function rememberScheduleRunSessionAttentionBaseline(
   runId: string,
@@ -78,7 +75,6 @@ export function markNextSessionDoneSilenced(
   if (previousRunId) {
     silencedRunSessionIds.delete(previousRunId);
     silencedRunHadAttention.delete(previousRunId);
-    clearSilencedFallbackTimer(previousRunId);
     // 被顶替的 run 不会再有人调 clearSilencedRun(它已不在 silencedRunSessionIds
     // 里,scheduleClearSilencedRun 会直接 return),baseline 必须在这里一起清,
     // 否则 runAttentionBaselines 会随 session 复用无界增长。
@@ -89,8 +85,6 @@ export function markNextSessionDoneSilenced(
   silencedRunSessionIds.set(runId, sessionId);
   silencedSessionRunIds.set(sessionId, runId);
   silencedRunHadAttention.set(runId, hadSessionAttention);
-  // 兜底定时器不在这里武装 —— 由 syncRunMarkerFallback 按 session 的**当前**
-  // running 状态决定,见该函数注释。
 }
 
 /** 纯查询:同一个 run 内每次 done 转换都要得到 true(见文件头注释)。 */
@@ -104,10 +98,7 @@ export function markNextSessionTerminalNotificationOwnedByScheduler(
 ): void {
   if (!runId || !sessionId) return;
   const previousRunId = schedulerOwnedSessionRunIds.get(sessionId);
-  if (previousRunId) {
-    schedulerOwnedRunSessionIds.delete(previousRunId);
-    clearSchedulerOwnedFallbackTimer(previousRunId);
-  }
+  if (previousRunId) schedulerOwnedRunSessionIds.delete(previousRunId);
   clearSchedulerOwnedTimer(previousRunId);
   clearSchedulerOwnedTimer(runId);
   schedulerOwnedRunSessionIds.set(runId, sessionId);
@@ -121,57 +112,36 @@ export function isSessionTerminalNotificationOwnedByScheduler(
   return schedulerOwnedSessionRunIds.has(sessionId);
 }
 
-/** 当前持有任一标记的 sessionId。供消费方逐个对账兜底定时器。 */
-export function listRunMarkerSessionIds(): string[] {
-  if (silencedSessionRunIds.size === 0 && schedulerOwnedSessionRunIds.size === 0) return [];
-  const ids = new Set<string>(silencedSessionRunIds.keys());
-  for (const id of schedulerOwnedSessionRunIds.keys()) ids.add(id);
-  return [...ids];
-}
-
 /**
- * 按 session 的**当前** running 状态对账兜底定时器 —— 这是兜底唯一的武装/撤销入口。
+ * 用 scheduler 落库的**权威** run 状态对账标记:标记指向的 run 已经是终态却还留着
+ * 标记,说明它的 completed / failed 事件丢了(广播断链、事件早于消费方挂载等),清掉。
+ * 这是事件丢失的唯一自愈路径 —— 不猜时间、也不看 renderer 的 running 快照,那几种
+ * 判据都会误判,见上方「事件丢失的自愈不用定时器」注释。
  *
- * 为什么不能靠「事件先后顺序」推断 run 是否活着(两个方向都会错):
- *   - agent 在自己 turn 内调 `schedule_silence_current_run` 时,标记建立时该 turn
- *     已经 running、renderer 早过了 rising edge。若在建立标记时就武装兜底,便再没有
- *     任何信号来撤销它,turn 只要还剩 12 分钟以上就会被误清、通知照旧漏出。
- *   - 反过来,若只在「新 turn 起」时撤销兜底,消费方组件在那之后卸载(done 与
- *     scheduler 终态事件都落在卸载期间,且事件不回放)就永远没有兜底,标记永久残留。
+ * 传入的是**终态** runId 集合(`RunStatus` 里只有 `running` 不是终态)。不在集合里的
+ * runId 一律保持:可能仍在飞行,也可能是刚建立标记、sessionId 还没落库的极早期,
+ * 两种都不能清。
  *
- * 所以判据取当前 running 状态,而不是事件序:running → 撤掉(run 活着,长 turn 也
- * 不会被误清);not-running → 武装(若尚未武装)。消费方在每次 running 快照变化时
- * 逐个 session 调一次即可,挂载后的第一次调用天然完成对账。
- *
- * 已进入 completed linger 的标记不武装:清理由 linger 定时器负责。
+ * 跳过已排 linger 的标记:completed 到达时刻意留了一段 linger,让 renderer 的 done
+ * transition 先消费掉标记,对账不能抢在它前面清、否则那次终态又会走普通通知路径。
  */
-export function syncRunMarkerFallback(sessionId: string, isRunning: boolean): void {
-  const silencedRunId = silencedSessionRunIds.get(sessionId);
-  if (silencedRunId) {
-    if (isRunning) {
-      clearSilencedFallbackTimer(silencedRunId);
-    } else if (!silencedFallbackTimers.has(silencedRunId) && !clearTimers.has(silencedRunId)) {
-      armSilencedFallbackTimer(silencedRunId);
-    }
+export function reconcileRunMarkersWithTerminalRuns(
+  terminalRunIds: ReadonlySet<string>,
+): void {
+  if (terminalRunIds.size === 0) return;
+  for (const runId of [...silencedRunSessionIds.keys()]) {
+    if (!terminalRunIds.has(runId) || clearTimers.has(runId)) continue;
+    clearSilencedRun(runId);
   }
-  const ownedRunId = schedulerOwnedSessionRunIds.get(sessionId);
-  if (ownedRunId) {
-    if (isRunning) {
-      clearSchedulerOwnedFallbackTimer(ownedRunId);
-    } else if (
-      !schedulerOwnedFallbackTimers.has(ownedRunId) &&
-      !schedulerOwnedClearTimers.has(ownedRunId)
-    ) {
-      armSchedulerOwnedFallbackTimer(ownedRunId);
-    }
+  for (const runId of [...schedulerOwnedRunSessionIds.keys()]) {
+    if (!terminalRunIds.has(runId) || schedulerOwnedClearTimers.has(runId)) continue;
+    clearSchedulerOwnedRun(runId);
   }
 }
 
 export function scheduleClearSchedulerOwnedRun(runId: string, delayMs: number): void {
   if (!schedulerOwnedRunSessionIds.has(runId)) return;
   clearSchedulerOwnedTimer(runId);
-  // 进入终态 linger 后不再需要兜底,否则两个定时器互相打架。
-  clearSchedulerOwnedFallbackTimer(runId);
   const timer = setTimeout(() => {
     schedulerOwnedClearTimers.delete(runId);
     clearSchedulerOwnedRun(runId);
@@ -181,7 +151,6 @@ export function scheduleClearSchedulerOwnedRun(runId: string, delayMs: number): 
 
 export function clearSchedulerOwnedRun(runId: string): string | undefined {
   clearSchedulerOwnedTimer(runId);
-  clearSchedulerOwnedFallbackTimer(runId);
   const sessionId = schedulerOwnedRunSessionIds.get(runId);
   if (!sessionId) return undefined;
   schedulerOwnedRunSessionIds.delete(runId);
@@ -194,7 +163,7 @@ export function clearSchedulerOwnedRun(runId: string): string | undefined {
 /**
  * run 已终态(completed/failed 排了 linger)后该 session 又起新 turn:那是用户手动
  * 对话或下一个 run,立刻交回普通通知路径。run 还在跑时不清 —— 判据是
- * `schedulerOwnedClearTimers`,见 `schedulerOwnedFallbackTimers` 的注释。
+ * `schedulerOwnedClearTimers` 有没有 linger 定时器,而不是任何时间或 running 推断。
  */
 export function clearCompletedSchedulerOwnedRunForNewActivity(sessionId: string): void {
   const runId = schedulerOwnedSessionRunIds.get(sessionId);
@@ -205,7 +174,6 @@ export function clearCompletedSchedulerOwnedRunForNewActivity(sessionId: string)
 export function scheduleClearSilencedRun(runId: string, delayMs: number): void {
   if (!silencedRunSessionIds.has(runId)) return;
   clearPendingTimer(runId);
-  clearSilencedFallbackTimer(runId);
   const timer = setTimeout(() => {
     clearTimers.delete(runId);
     clearSilencedRun(runId);
@@ -222,7 +190,6 @@ export function clearCompletedSilencedRunForNewActivity(sessionId: string): void
 
 export function clearSilencedRun(runId: string): string | undefined {
   clearPendingTimer(runId);
-  clearSilencedFallbackTimer(runId);
   const sessionId = silencedRunSessionIds.get(runId);
   if (!sessionId) {
     runAttentionBaselines.delete(runId);
@@ -249,16 +216,12 @@ export function getSilencedRunSessionIdForAttentionFallback(runId: string): stri
 export function resetSilencedSessionDoneStoreForTests(): void {
   for (const timer of clearTimers.values()) clearTimeout(timer);
   clearTimers.clear();
-  for (const timer of silencedFallbackTimers.values()) clearTimeout(timer);
-  silencedFallbackTimers.clear();
   silencedRunSessionIds.clear();
   silencedSessionRunIds.clear();
   silencedRunHadAttention.clear();
   runAttentionBaselines.clear();
   for (const timer of schedulerOwnedClearTimers.values()) clearTimeout(timer);
   schedulerOwnedClearTimers.clear();
-  for (const timer of schedulerOwnedFallbackTimers.values()) clearTimeout(timer);
-  schedulerOwnedFallbackTimers.clear();
   schedulerOwnedRunSessionIds.clear();
   schedulerOwnedSessionRunIds.clear();
 }
@@ -279,36 +242,6 @@ function clearSchedulerOwnedTimer(runId: string | undefined): void {
   schedulerOwnedClearTimers.delete(runId);
 }
 
-function armSilencedFallbackTimer(runId: string): void {
-  clearSilencedFallbackTimer(runId);
-  const timer = setTimeout(() => {
-    silencedFallbackTimers.delete(runId);
-    clearSilencedRun(runId);
-  }, RUN_MARKER_IDLE_FALLBACK_MS);
-  silencedFallbackTimers.set(runId, timer);
-}
 
-function clearSilencedFallbackTimer(runId: string | undefined): void {
-  if (!runId) return;
-  const timer = silencedFallbackTimers.get(runId);
-  if (!timer) return;
-  clearTimeout(timer);
-  silencedFallbackTimers.delete(runId);
-}
 
-function armSchedulerOwnedFallbackTimer(runId: string): void {
-  clearSchedulerOwnedFallbackTimer(runId);
-  const timer = setTimeout(() => {
-    schedulerOwnedFallbackTimers.delete(runId);
-    clearSchedulerOwnedRun(runId);
-  }, RUN_MARKER_IDLE_FALLBACK_MS);
-  schedulerOwnedFallbackTimers.set(runId, timer);
-}
 
-function clearSchedulerOwnedFallbackTimer(runId: string | undefined): void {
-  if (!runId) return;
-  const timer = schedulerOwnedFallbackTimers.get(runId);
-  if (!timer) return;
-  clearTimeout(timer);
-  schedulerOwnedFallbackTimers.delete(runId);
-}

--- a/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
+++ b/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
@@ -136,52 +136,77 @@ export function hasAnyRunMarker(): boolean {
   return silencedRunSessionIds.size > 0 || schedulerOwnedRunSessionIds.size > 0;
 }
 
+export interface ReconcileRunMarkersResult {
+  /**
+   * 本轮出现了「DB 说还在跑、引擎的 in-flight 快照里却没有」的持标记 run,说明这两份读
+   * 拿到的不是同一时刻的状态。
+   *
+   * 它们由同一次 IPC 取回,但中间隔着 DB 查询的 `await`:run 恰好在那个窗口内结束时,
+   * SQLite 返回的行还是 `running`,而 controller 已被注销 —— 于是本轮只能保守保持标记
+   * (它也可能真的还在跑,无法区分)。问题在于:**如果该 run 的终态事件正是丢掉的那个,
+   * 就再没有任何信号来清这个标记**,自愈保证被打破。
+   *
+   * 所以消费方拿到 true 时必须安排一次快速重新对账 —— 下一轮 DB 已落到终态,不一致自然
+   * 消解。这是 review 指出的竞态的收口方式(race-safe 快照需要在 main 侧忙等重采样,
+   * 代价更大;这里用一次重查换同样的正确性)。
+   */
+  needsRecheck: boolean;
+}
+
 /**
  * 用 scheduler 落库的**权威** run 状态对账标记 —— 事件丢失(广播断链、事件早于消费方
  * 挂载等)的唯一自愈路径。不猜时间、也不看 renderer 的 running 快照,那几种判据都会
  * 误判,见上方「事件丢失的自愈不用定时器」注释。
  *
- * 三种情形:
- *   - 映射里是 `terminal` → 排 linger 退场。它的 completed / failed 事件没送到。
- *   - 映射里是 `running` → 保持。仍在飞行,飞多久都不清。
- *   - **不在映射里** → 同样排 linger 退场。该 run 已经不存在了:删除 schedule 会级联
- *     删掉它的 `schedule_runs` 行,deferred run 也会被显式删除,这两种情况永远等不到
- *     一个终态状态。这里不可能是「标记建好但 run 还没落库」的极早期 —— 引擎先
- *     `updateRun` 写 sessionId、再 emit `session-bound` / `silenced`,而权威快照包含
- *     所有带 sessionId 的 run,所以标记存在就意味着该 run 当时已进入快照范围。异步
- *     拉取的过期结果由调用方的 seq 守卫挡掉,不会走到这里。
+ * **两份数据缺一不可**,且**引擎的 in-flight 快照优先级更高**:
+ *   - `inflightRunIds` 有 → 保持。仍在飞行,飞多久都不清。「行不在库里」并不等于
+ *     「跑完了」——agent 在任务 run 内调 `schedule_delete` 删自己的 schedule 时,引擎用
+ *     `exemptRunId` 豁免 caller run 不 abort,它的行随 schedule 级联删除后仍继续跑到底。
+ *     引擎内存态是这件事唯一的权威来源。
+ *   - `dbRunStatus` 是 `terminal` → 排 linger 退场。它的 completed / failed 事件没送到。
+ *   - 两份都没有 → 同样排 linger 退场。该 run 已经不存在了:删除 schedule 会级联删掉
+ *     它的 `schedule_runs` 行,deferred run 也会被显式删除,这两种情况永远等不到一个终态
+ *     状态。这里不可能是「标记建好但 run 还没落库」的极早期 —— 引擎先 `updateRun` 写
+ *     sessionId、再 emit `session-bound` / `silenced`,而权威快照包含所有带 sessionId 的
+ *     run,所以标记存在就意味着该 run 当时已进入快照范围。异步拉取的过期结果由调用方的
+ *     seq 守卫挡掉,不会走到这里。
  *
- * **调用方必须先把引擎的 in-flight 快照覆盖成 `running` 再传进来**(见
- * `scheduler.listInflightRunIds`)。「行不在库里」并不等于「跑完了」:agent 在任务 run
- * 内调 `schedule_delete` 删自己的 schedule 时,引擎用 `exemptRunId` 豁免 caller run 不
- * abort,它的行随 schedule 级联删除后仍继续跑到底 —— 那期间把标记清掉,最终 done 就会
- * 漏出通知。引擎内存态是这件事唯一的权威来源,优先级高于 DB 状态。
- *
- * **空映射不是异常,一样要对账**:权威查询在库里没有匹配行时合法返回空数组(删掉了
- * 最后一个 schedule、或唯一的 run 被 defer 后删除),而查询失败是 reject、走调用方的
- * catch 与重试,根本不会以空映射的形式到这里。早先那个「空映射整体跳过」的守卫会把
- * 这种情况下的标记永久留住。
+ * **空的 dbRunStatus 不是异常,一样要对账**:权威查询在库里没有匹配行时合法返回空数组
+ * (删掉了最后一个 schedule、或唯一的 run 被 defer 后删除),而查询失败是 reject、走调用方
+ * 的 catch 与重试,根本不会以空映射的形式到这里。
  *
  * 清除统一走 `MARKER_TERMINAL_LINGER_MS` 的 linger,不立即删 —— 对账面对的正是「终态
  * 事件丢了、从未排过 linger」的标记,而 DB 可能已报终态、React 却还没处理该 session 的
  * running→done。已排 linger 的标记跳过,避免重置它的倒计时。
+ *
+ * 返回 `needsRecheck`:见 `ReconcileRunMarkersResult`。
  */
 export function reconcileRunMarkers(
-  runStatusByRunId: ReadonlyMap<string, RunLivenessStatus>,
-): void {
+  dbRunStatus: ReadonlyMap<string, RunLivenessStatus>,
+  inflightRunIds: ReadonlySet<string>,
+): ReconcileRunMarkersResult {
+  let needsRecheck = false;
+  const resolve = (runId: string): 'running' | 'terminal' | 'inconsistent' => {
+    if (inflightRunIds.has(runId)) return 'running';
+    // DB 说还在跑、引擎却说没在跑 —— 两份读之间那个 await 窗口里 run 刚好结束了。
+    if (dbRunStatus.get(runId) === 'running') return 'inconsistent';
+    return 'terminal';
+  };
   for (const runId of [...silencedRunSessionIds.keys()]) {
-    if (clearTimers.has(runId) || runStatusByRunId.get(runId) === 'running') continue;
+    if (clearTimers.has(runId)) continue;
+    const state = resolve(runId);
+    if (state === 'inconsistent') needsRecheck = true;
+    if (state !== 'terminal') continue;
     scheduleClearSilencedRun(runId, MARKER_TERMINAL_LINGER_MS);
   }
   for (const runId of [...schedulerOwnedRunSessionIds.keys()]) {
-    if (
-      schedulerOwnedClearTimers.has(runId) ||
-      runStatusByRunId.get(runId) === 'running'
-    ) {
-      continue;
-    }
+    if (schedulerOwnedClearTimers.has(runId)) continue;
+    const state = resolve(runId);
+    if (state === 'inconsistent') needsRecheck = true;
+    if (state !== 'terminal') continue;
     scheduleClearSchedulerOwnedRun(runId, MARKER_TERMINAL_LINGER_MS);
   }
+  return { needsRecheck };
 }
 
 export function scheduleClearSchedulerOwnedRun(runId: string, delayMs: number): void {

--- a/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
+++ b/apps/desktop/src/renderer/lib/silencedSessionDoneStore.ts
@@ -1,9 +1,25 @@
+/**
+ * 自动任务(scheduler)终态通知的抑制标记。
+ *
+ * 两组标记语义刻意分开:
+ *   - silenced:静默运行(`Schedule.silentWhenIdle`)的成功 run —— 完全不发通知、
+ *     不亮角标。
+ *   - schedulerOwned:普通自动任务 —— scheduler notifier 已按 `schedule.notify`
+ *     发过这次终态通知,renderer 不能再发第二条;但侧栏 / Dock attention 仍按
+ *     普通 done/error 逻辑保留。
+ *
+ * **标记的生命周期跟随 run,不是「被第一次 done 消费掉」**:一个 run 内 session
+ * 的 running→done 会翻转多次(后台 subagent 完成后 SDK 自动续 turn、silent-stop
+ * 守卫 1.5s 后自动续跑、队列自动衔接),标记必须活过每一次中间 done,否则最终那
+ * 次真 done 会当成普通完成,把 macOS toast / 飞书 / 手机推送全发一遍。清除只来自
+ * scheduler 的 completed / failed / notified 事件(linger 定时器),或 run 已终态后
+ * 该 session 又起新 turn。main 侧灵动岛(`main/agent-island/service.ts` 的
+ * `isCompletionEventSilenced`)是同一套语义,两边不要再分叉。
+ */
+
 const silencedRunSessionIds = new Map<string, string>();
 const silencedSessionRunIds = new Map<string, string>();
 const silencedRunHadAttention = new Map<string, boolean>();
-// Scheduler 自己按 schedule.notify 发送终态通知时，普通 session transition 仍需
-// 保留侧栏 / Dock attention，但不能再走一次 renderer 外发通知。该标记与上面的
-// “整次完成静默”语义刻意分开。
 const schedulerOwnedRunSessionIds = new Map<string, string>();
 const schedulerOwnedSessionRunIds = new Map<string, string>();
 const schedulerOwnedClearTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -12,6 +28,29 @@ const runAttentionBaselines = new Map<
   { sessionId: string; hadSessionAttention: boolean }
 >();
 const clearTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * 兜底自愈定时器。与上面两张 `*ClearTimers` **刻意分开**:那两张表示「run 已终
+ * 态、正在 linger 清理」,`clearCompleted*ForNewActivity` 拿它当终态判据,兜底
+ * 定时器混进去会让「run 还在跑」被误判成终态,新 turn 一起就把标记清了。
+ */
+const silencedFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const schedulerOwnedFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * 兜底自愈窗口:只防 scheduler 事件丢失(广播断链、事件早于 renderer 挂载等)导致
+ * 标记永久残留,把该 session 后续**手动**对话的 done 也误静默。正常路径不依赖它。
+ *
+ * 12 分钟是有依据的下限,不要随意缩短:main 侧 runner 对「主 turn 已 done 但后台
+ * subagent 仍在途」的兜底是 `BG_TASK_IDLE_FALLBACK_MS = 10 分钟`
+ * (`main/scheduler-host/runner.ts`)。标记必须活过它,runner 才总是先收尾并发出
+ * completed;否则慢 subagent 续 turn 时标记已被自愈清掉,最终 done 又会弹系统
+ * 通知 —— 正是本模块要防的那个 bug。改动 runner 那个常量时一并复核这里。
+ *
+ * 定时器在 session 起新 turn 时取消(run 明显还活着)、在每次 done 转换时重置,
+ * 所以跑很久的单个 turn 不会被它误清。
+ */
+export const SILENCED_RUN_IDLE_FALLBACK_MS = 12 * 60_000;
 
 export function rememberScheduleRunSessionAttentionBaseline(
   runId: string,
@@ -38,19 +77,34 @@ export function markNextSessionDoneSilenced(
   if (previousRunId) {
     silencedRunSessionIds.delete(previousRunId);
     silencedRunHadAttention.delete(previousRunId);
+    clearSilencedFallbackTimer(previousRunId);
   }
   clearPendingTimer(previousRunId);
   clearPendingTimer(runId);
   silencedRunSessionIds.set(runId, sessionId);
   silencedSessionRunIds.set(sessionId, runId);
   silencedRunHadAttention.set(runId, hadSessionAttention);
+  // run 若从此再没产生任何 turn(创建后就崩/被杀),标记不能永久占住这个 session。
+  armSilencedFallbackTimer(runId);
 }
 
-export function observeNextSessionDoneSilenced(sessionId: string): boolean {
+/**
+ * 纯查询,无副作用:同一个 run 内每次 done 转换都要得到 true(见文件头注释)。
+ * 顺带重置兜底定时器 —— 刚观察到一次终态,说明 run 仍在正常产出事件。
+ */
+export function isSessionDoneSilenced(sessionId: string): boolean {
   const runId = silencedSessionRunIds.get(sessionId);
   if (!runId) return false;
-  scheduleClearSilencedRun(runId, 0);
+  // 已进入 completed linger 的标记不再续期,否则兜底会把 linger 往后推。
+  if (!clearTimers.has(runId)) armSilencedFallbackTimer(runId);
   return true;
+}
+
+/** session 起了新 turn:run 显然还活着,撤掉兜底自愈,交回事件驱动。 */
+export function noteSilencedRunStillActive(sessionId: string): void {
+  const runId = silencedSessionRunIds.get(sessionId);
+  if (!runId) return;
+  clearSilencedFallbackTimer(runId);
 }
 
 export function markNextSessionTerminalNotificationOwnedByScheduler(
@@ -59,29 +113,39 @@ export function markNextSessionTerminalNotificationOwnedByScheduler(
 ): void {
   if (!runId || !sessionId) return;
   const previousRunId = schedulerOwnedSessionRunIds.get(sessionId);
-  if (previousRunId) schedulerOwnedRunSessionIds.delete(previousRunId);
+  if (previousRunId) {
+    schedulerOwnedRunSessionIds.delete(previousRunId);
+    clearSchedulerOwnedFallbackTimer(previousRunId);
+  }
   clearSchedulerOwnedTimer(previousRunId);
   clearSchedulerOwnedTimer(runId);
   schedulerOwnedRunSessionIds.set(runId, sessionId);
   schedulerOwnedSessionRunIds.set(sessionId, runId);
+  armSchedulerOwnedFallbackTimer(runId);
 }
 
-/**
- * 多个 useSessionRunningStatus 实例可能在同一轮 effect 中观察同一 transition，
- * 因此不立即 delete；排到下一个 task 清理，让所有同步 observer 得到一致结果。
- */
-export function observeNextSessionTerminalNotificationOwnedByScheduler(
+/** 与 `isSessionDoneSilenced` 同款语义:纯查询,run 内多次 done 都命中。 */
+export function isSessionTerminalNotificationOwnedByScheduler(
   sessionId: string,
 ): boolean {
   const runId = schedulerOwnedSessionRunIds.get(sessionId);
   if (!runId) return false;
-  scheduleClearSchedulerOwnedRun(runId, 0);
+  if (!schedulerOwnedClearTimers.has(runId)) armSchedulerOwnedFallbackTimer(runId);
   return true;
+}
+
+/** 与 `noteSilencedRunStillActive` 对称。 */
+export function noteSchedulerOwnedRunStillActive(sessionId: string): void {
+  const runId = schedulerOwnedSessionRunIds.get(sessionId);
+  if (!runId) return;
+  clearSchedulerOwnedFallbackTimer(runId);
 }
 
 export function scheduleClearSchedulerOwnedRun(runId: string, delayMs: number): void {
   if (!schedulerOwnedRunSessionIds.has(runId)) return;
   clearSchedulerOwnedTimer(runId);
+  // 进入终态 linger 后不再需要兜底,否则两个定时器互相打架。
+  clearSchedulerOwnedFallbackTimer(runId);
   const timer = setTimeout(() => {
     schedulerOwnedClearTimers.delete(runId);
     clearSchedulerOwnedRun(runId);
@@ -91,6 +155,7 @@ export function scheduleClearSchedulerOwnedRun(runId: string, delayMs: number): 
 
 export function clearSchedulerOwnedRun(runId: string): string | undefined {
   clearSchedulerOwnedTimer(runId);
+  clearSchedulerOwnedFallbackTimer(runId);
   const sessionId = schedulerOwnedRunSessionIds.get(runId);
   if (!sessionId) return undefined;
   schedulerOwnedRunSessionIds.delete(runId);
@@ -100,6 +165,11 @@ export function clearSchedulerOwnedRun(runId: string): string | undefined {
   return sessionId;
 }
 
+/**
+ * run 已终态(completed/failed 排了 linger)后该 session 又起新 turn:那是用户手动
+ * 对话或下一个 run,立刻交回普通通知路径。run 还在跑时不清 —— 判据是
+ * `schedulerOwnedClearTimers`,见 `schedulerOwnedFallbackTimers` 的注释。
+ */
 export function clearCompletedSchedulerOwnedRunForNewActivity(sessionId: string): void {
   const runId = schedulerOwnedSessionRunIds.get(sessionId);
   if (!runId || !schedulerOwnedClearTimers.has(runId)) return;
@@ -109,6 +179,7 @@ export function clearCompletedSchedulerOwnedRunForNewActivity(sessionId: string)
 export function scheduleClearSilencedRun(runId: string, delayMs: number): void {
   if (!silencedRunSessionIds.has(runId)) return;
   clearPendingTimer(runId);
+  clearSilencedFallbackTimer(runId);
   const timer = setTimeout(() => {
     clearTimers.delete(runId);
     clearSilencedRun(runId);
@@ -116,6 +187,7 @@ export function scheduleClearSilencedRun(runId: string, delayMs: number): void {
   clearTimers.set(runId, timer);
 }
 
+/** 与 `clearCompletedSchedulerOwnedRunForNewActivity` 对称。 */
 export function clearCompletedSilencedRunForNewActivity(sessionId: string): void {
   const runId = silencedSessionRunIds.get(sessionId);
   if (!runId || !clearTimers.has(runId)) return;
@@ -124,6 +196,7 @@ export function clearCompletedSilencedRunForNewActivity(sessionId: string): void
 
 export function clearSilencedRun(runId: string): string | undefined {
   clearPendingTimer(runId);
+  clearSilencedFallbackTimer(runId);
   const sessionId = silencedRunSessionIds.get(runId);
   if (!sessionId) {
     runAttentionBaselines.delete(runId);
@@ -150,12 +223,16 @@ export function getSilencedRunSessionIdForAttentionFallback(runId: string): stri
 export function resetSilencedSessionDoneStoreForTests(): void {
   for (const timer of clearTimers.values()) clearTimeout(timer);
   clearTimers.clear();
+  for (const timer of silencedFallbackTimers.values()) clearTimeout(timer);
+  silencedFallbackTimers.clear();
   silencedRunSessionIds.clear();
   silencedSessionRunIds.clear();
   silencedRunHadAttention.clear();
   runAttentionBaselines.clear();
   for (const timer of schedulerOwnedClearTimers.values()) clearTimeout(timer);
   schedulerOwnedClearTimers.clear();
+  for (const timer of schedulerOwnedFallbackTimers.values()) clearTimeout(timer);
+  schedulerOwnedFallbackTimers.clear();
   schedulerOwnedRunSessionIds.clear();
   schedulerOwnedSessionRunIds.clear();
 }
@@ -174,4 +251,38 @@ function clearSchedulerOwnedTimer(runId: string | undefined): void {
   if (!timer) return;
   clearTimeout(timer);
   schedulerOwnedClearTimers.delete(runId);
+}
+
+function armSilencedFallbackTimer(runId: string): void {
+  clearSilencedFallbackTimer(runId);
+  const timer = setTimeout(() => {
+    silencedFallbackTimers.delete(runId);
+    clearSilencedRun(runId);
+  }, SILENCED_RUN_IDLE_FALLBACK_MS);
+  silencedFallbackTimers.set(runId, timer);
+}
+
+function clearSilencedFallbackTimer(runId: string | undefined): void {
+  if (!runId) return;
+  const timer = silencedFallbackTimers.get(runId);
+  if (!timer) return;
+  clearTimeout(timer);
+  silencedFallbackTimers.delete(runId);
+}
+
+function armSchedulerOwnedFallbackTimer(runId: string): void {
+  clearSchedulerOwnedFallbackTimer(runId);
+  const timer = setTimeout(() => {
+    schedulerOwnedFallbackTimers.delete(runId);
+    clearSchedulerOwnedRun(runId);
+  }, SILENCED_RUN_IDLE_FALLBACK_MS);
+  schedulerOwnedFallbackTimers.set(runId, timer);
+}
+
+function clearSchedulerOwnedFallbackTimer(runId: string | undefined): void {
+  if (!runId) return;
+  const timer = schedulerOwnedFallbackTimers.get(runId);
+  if (!timer) return;
+  clearTimeout(timer);
+  schedulerOwnedFallbackTimers.delete(runId);
 }

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -4557,7 +4557,8 @@ interface ElectronAPI {
         };
       } | UtilityTextFailure>;
       listRuns: (id: string, limit?: number) => Promise<unknown[]>;
-      listSidebarIndexRuns: () => Promise<unknown[]>;
+      /** { runs, inflightRunIds } —— 形态见 features/scheduler/lib/scheduleSidebarIndexRuns。 */
+      listSidebarIndexRuns: () => Promise<unknown>;
       listCostSummaries: () => Promise<unknown[]>;
       deleteRun: (runId: string) => Promise<void>;
       getInflightCount: (id: string) => Promise<number>;

--- a/packages/maker-scheduler/src/__tests__/scheduler.test.ts
+++ b/packages/maker-scheduler/src/__tests__/scheduler.test.ts
@@ -1119,11 +1119,15 @@ describe('Scheduler', () => {
     expect(await local.storage.get(sch.id)).toBeNull();
     // caller run 仍在 in-flight(fireOne 还没走完 finally)
     expect(local.scheduler.getInflightCount(sch.id)).toBe(1);
+    // run 行已随 schedule 级联删除,但引擎内存仍报它在跑 —— renderer 的通知抑制标记
+    // 对账靠这份快照区分「查不到 = 跑完了」与「查不到 = 自删除后仍在跑」。
+    expect(local.scheduler.listInflightRunIds()).toContain(callerRunId);
 
     // caller run 自然跑完:fireOne 收尾不抛错,run 走 success 分支
     resolveRunner({ sessionId: 'sess-caller' });
     await tickPromise;
     expect(local.scheduler.getInflightCount(sch.id)).toBe(0);
+    expect(local.scheduler.listInflightRunIds()).not.toContain(callerRunId);
     const run = local.storage.runs.get(callerRunId);
     expect(run?.status).toBe('success');
     // schedule 行已删,fireOne 尾部重排的 storage.update 是 no-op,不会复活 schedule

--- a/packages/maker-scheduler/src/engine/scheduler.ts
+++ b/packages/maker-scheduler/src/engine/scheduler.ts
@@ -1206,6 +1206,21 @@ export class Scheduler extends EventEmitter {
   }
 
   /**
+   * 当前所有 in-flight run 的 runId(跨 schedule)。这是「某个 run 还在不在跑」的**权威
+   * 来源** —— 引擎内存态,不依赖 run 行是否还在库里。
+   *
+   * 为什么需要它:自删除场景下 run 行会先消失、run 却仍在跑。agent 在任务 run 内调
+   * `schedule_delete` 删自己的 schedule 时,`deleteUnlocked` 用 `exemptRunId` 豁免 caller
+   * run 不 abort,该 run 的行随 schedule 级联删除后它继续跑到底(见那里的注释与
+   * `delete with exemptRunId leaves caller run running` 用例)。因此「DB 里查不到这条
+   * run」既可能是「已结束并被清理」,也可能是「正在跑的自删除 run」,只有这份 in-flight
+   * 快照能区分。消费方(renderer 的抑制标记对账)据此决定能不能清标记。
+   */
+  listInflightRunIds(): string[] {
+    return [...this.inflightControllers.keys()];
+  }
+
+  /**
    * 把**指定的单条 in-flight run** 标记为"静默":任务内 agent 确认本轮无需用户
    * 关注(如 PR 巡检无新动态)时,经 MCP 工具传自己这一轮的 runId 调用本方法。
    * 静默的 run 在 success 落库时直接置 readAt(生而已读,小红点天然排除),且


### PR DESCRIPTION
## 这次改了什么

### 摘要

静默运行（`silentWhenIdle`）的自动任务跑完后，仍然会弹 macOS 系统通知（以及飞书、手机推送）。

**根因**：renderer 的抑制标记被「第一次 done」消费掉，而**一个 run 内 session 的 `running→done` 会翻转多次**：主 turn 的 done 只是中间态（runner 仍在等在途后台 subagent），subagent 完成后 SDK 会自动续 turn，silent-stop 守卫也会在 1.5s 后自动续跑。第一次中间 done 吃掉标记后，最终那次真 done 就走了普通完成路径把通知发出去；silent-stop 的 1.5s 间隔大于 `QUEUE_DEBOUNCE_MS`（500ms），debounce 也兜不住。单 turn 的静默 run 一直是好的，所以表现为间歇性漏出。

`schedulerOwned` 标记（「本次终态通知由 scheduler notifier 负责」）是同一套消费语义，于是**普通自动任务在多 turn run 上会收到两条通知** —— renderer 一条、notifier 一条。同根因，一并修掉。

**主体改法**：对齐 main 侧灵动岛本来就正确的语义（`main/agent-island/service.ts` 的 `isCompletionEventSilenced`，纯查询、不消费）——两个 `observe*` 改成纯查询并改名 `isSessionDoneSilenced` / `isSessionTerminalNotificationOwnedByScheduler`（旧名字里的 "observe" 正是诱导出「消费一次」心智模型的源头），标记生命周期跟随 run。

**事件丢失的自愈：不猜，只问。** 标记的正常清除靠 scheduler 的 `completed` / `failed` / `notified` 事件，但事件可能丢（广播断链、事件早于消费方挂载）。review 过程中三种「猜 run 还在不在飞行」的判据被逐一证伪，最终改成向权威来源对账：

| 判据 | 为什么不行 |
|---|---|
| 事件先后顺序 | agent 在自己 turn 内调 `schedule_silence_current_run` 时标记建立时该 turn 已 running，此后无信号可撤销；反过来只在新 turn 起时撤销，消费方随后卸载就永远没有兜底 |
| renderer 的 running 快照 | `makerChatStore` **刻意**把 `remote_agent` / `local_bash` / 未知 task_type 排除在 `WAKE_AGENT_TASK_TYPES` 之外，device-link 远程会话整体豁免——run 在飞行而快照为 false 是设计内行为 |
| 固定时长上限 | runner 的 `BG_TASK_IDLE_FALLBACK_MS` 是**事件静默**超时（每个事件都重新武装），不是最大 run 时长，持续产出事件的任务可合法飞行任意长 |

现在由 `reconcileRunMarkers` 拿 scheduler 落库的 run 状态 + **引擎内存里的 in-flight 集合**对账。后者不可省略：自删除场景下（agent 在任务 run 内调 `schedule_delete` 删自己的 schedule，引擎用 `exemptRunId` 豁免 caller run 不 abort）run 行会随 schedule 级联删除、run 却仍在跑到底，所以「行没了」≠「跑完了」——这正是心跳类任务的标准收口路径。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实机反馈：静默自动任务仍收到 macOS 通知）
- 本 PR 包含：
  - `silencedSessionDoneStore`：标记语义从「一次性消费」改为「跟随 run 生命周期」；两个查询函数改名去掉误导性的 `observe` 前缀；新增 `reconcileRunMarkers`（权威状态对账）、`hasAnyRunMarker`、`MARKER_TERMINAL_LINGER_MS`（事件与对账两条清除路径共享同一段退场窗口）
  - `useSessionRunningStatus`：相应更新调用与注释
  - `useAutomationScheduleSessionIndex`：refresh 时对账；失败时有限退避重试（2s/8s/30s），仍有标记待对账则按最后一档持续重试
  - **`packages/maker-scheduler`**：新增 `Scheduler.listInflightRunIds()`，暴露引擎内存里的 in-flight runId 集合
  - **IPC / preload**：`SCHEDULE_LIST_SIDEBAR_INDEX_RUNS` 的返回值扩成 `{ runs, inflightRunIds }`（未新增 channel）；preload 与 `vite-env.d.ts` 声明同步更新；renderer 侧新增 `loadScheduleSidebarIndexSnapshot()`，只要 run 列表的既有调用方继续用 `loadScheduleSidebarIndexRuns()`、签名不变
  - 顺手修掉 `markNextSessionDoneSilenced` 顶替同 session 旧 run 时漏清 `runAttentionBaselines` 的无界增长
- 明确不包含：
  - **`needs-reply` 不静默**（产品决定保持现状）：静默任务卡在 ask-user / permission / plan-review / plugin-setup 时照常提醒
  - 失败终态照常通知（既有 fail-safe 设计，未改动）
  - main 侧灵动岛未改：它本来就是查询式语义，本次是让 renderer 与它对齐
  - 「区分用户插话的 turn 与 subagent 续 turn」未做，见下方用户可见变化
- 用户可见变化：
  - 静默自动任务的多 turn run 不再弹系统通知 / 飞书 / 手机推送（本 PR 目标）
  - 普通自动任务的多 turn run 不再收到两条重复通知
  - **反向的小代价**：自动任务的 run 仍在飞行时，用户在该会话里插话的那条 turn 结束后不再发系统通知。原因是 run 未终态时，「用户插话的 turn」与「后台 subagent 续 turn」在 renderer 侧是同一个信号（`running=true → done`），无从区分。已与需求方确认接受该取舍（宁可偶尔漏一条，也不要静默任务反复打扰；且该场景下用户人就在会话里）。真要区分需在 renderer 发送路径加「本 turn 由用户发起」的标记，超出本 PR 范围。
- 是否存在 breaking change：无（IPC 返回值变更是同包内部契约，main 与 renderer 一起发布，无版本 skew）

### UI 变化

不涉及。

- 引用的设计规范：不涉及：本次只改「是否发出系统通知 / 是否亮角标」的判定时序与自愈机制，属于纯逻辑修复，没有任何视觉、布局、交互或文案变化，也未新增或修改任何组件与样式；因改动路径落在 `apps/desktop/src/renderer/` 而命中 CI 的 UI 路径判定。

## 怎么验证的

### 自动验证

```text
bash <git-skill>/scripts/run-unit-gate.sh <worktree>   # 仓库根 pnpm test:unit 全量门禁
结果：GATE_EXIT=0；PASS apps/desktop unit (63.7s)、PASS packages/maker-scheduler unit

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm --filter desktop exec vitest run \
  src/main/__tests__/webview-security.test.ts src/main/security/__tests__/csp.test.ts
结果：2 files / 41 tests passed（electron-security 规则要求的最小验证入口）

npx vitest run src/renderer/__tests__/{silencedSessionDoneStore,useSessionRunningStatusSilence,automationScheduleSilenceHook}.test.ts
结果：3 files / 51 tests passed

npx vitest run --root packages/maker-scheduler src/__tests__/scheduler.test.ts
结果：92 tests passed（含 listInflightRunIds 在 exemptRunId 场景下的新断言）

pnpm check:dco
结果：DCO check passed: 7 commits signed off
```

**每条回归都做过反证**：把对应的错误实现临时放回（一次性消费语义 / 建标记即武装兜底 / 去掉对账 / 去掉退避重试 / 不在映射里就保持 / 对账立即清 / 去掉 in-flight 覆盖），确认目标用例精确失败、其余全过，随后还原并 `grep` 确认无临时代码残留。这些回归不是空转的断言。

### 手工验证

不涉及 —— 见「未执行的验证」。

### 未执行的验证

- **未做实机运行时验证**：改动在 worktree 内，Vite HMR 只 watch 启动 dev 实例的那个 checkout，worktree 的改动既不热更也不随重启生效（`docs/dev-rules/development-workflow.md` §1）。要看真机行为需在本 worktree 跑 `pnpm restart:desktop:remote -- --preserve-running`，由需求方触发。
- 触发路径本身难以手工构造：需要一个静默自动任务恰好派出后台 subagent（或撞上 silent-stop 自动续跑）。因此以 hook 级测试模拟 `running→done→running→done` 的 snapshot 序列、以及事件丢失 / 自删除 / 重试耗尽等分支来锁定行为。
- Windows 未实测：改动是 renderer 内存标记、`setTimeout` 时序与一次只读 IPC，两端同构，不含路径、子进程或原生调用；用户报告的 macOS toast 与 Windows toast 走同一条 renderer 判定路径。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：自动任务终态「发不发系统通知 / 亮不亮角标」的判定与自愈。新增的 IPC 返回字段是同包内部契约（不是 device-link 等跨端 wire protocol，不涉及协议兼容），且只回传 runId 列表——runId 本身不是特权数据，renderer 的标记里本来就存着它；未新增 IPC channel，未放宽 CSP / Fuses / preload 暴露面。不触及数据库、凭证、用户数据。
- 已知的方向性代价：见「用户可见变化」最后一条（run 飞行期间用户插话的 turn 不再发通知），以及事件与 in-flight 都拿不到时标记会多留一段 linger（只影响该 session 的手动完成通知，不影响任何操作或数据）。
- 回滚 / 降级方式：`git revert` 本分支的 7 个 commit 即可完整回到旧行为，无数据迁移与状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，按豁免格式填写理由）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（bug 根因、三种被证伪的判据、in-flight 权威来源的理由都写进了 `silencedSessionDoneStore` 的文件头与 `scheduler.listInflightRunIds` 的注释，防回归）
- [x] 已确认测试结果或说明未执行原因
