### PR TITLE
fix(desktop): isolate cross-realm sessions and CN media catalog

### DIFF
--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -160,6 +160,38 @@ describe('auth login-flow reset', () => {
     expect(initializeBody.slice(localGuard, refreshTokenRead)).toContain('return snapshotAuthState();');
   });
 
+  it('activates a restored realm only after the refreshed membership passes build policy', () => {
+    const initializeStart = source.indexOf('export async function initialize(');
+    const initializeEnd = source.indexOf('\n}\n\n/**\n * 冷启动 refresh 流程本体', initializeStart);
+    const initializeBody = source.slice(initializeStart, initializeEnd);
+    expect(initializeBody).toContain('await loadClientEndpointsForRealm(persistedSession.realm);');
+    expect(initializeBody).not.toContain('activateClientEndpointRealm(persistedSession.realm);');
+
+    const coldStart = source.indexOf('async function runColdStartRefreshFlow(');
+    const coldEnd = source.indexOf('\n}\n\nasync function loadLoginProviders()', coldStart);
+    const coldBody = source.slice(coldStart, coldEnd);
+    const coldPolicyGuard = coldBody.indexOf('!canRestoreAuthSessionForMembership(');
+    const coldRealmActivation = coldBody.indexOf('activateClientEndpointRealm(storedRealm);');
+    expect(coldPolicyGuard).toBeGreaterThan(-1);
+    expect(coldRealmActivation).toBeGreaterThan(coldPolicyGuard);
+    expect(coldBody).toContain('writePersistedAuthSession(refreshData.refreshToken, storedRealm);');
+
+    const refreshStart = source.indexOf('export async function refresh(): Promise<boolean> {');
+    const refreshEnd = source.indexOf('\n}\n\nexport async function logout()', refreshStart);
+    const refreshBody = source.slice(refreshStart, refreshEnd);
+    const runtimePolicyGuard = refreshBody.indexOf('!canRestoreAuthSessionForMembership(');
+    const runtimeRealmActivation = refreshBody.indexOf(
+      'activateClientEndpointRealm(refreshRealm);',
+    );
+    expect(runtimePolicyGuard).toBeGreaterThan(-1);
+    expect(runtimeRealmActivation).toBeGreaterThan(runtimePolicyGuard);
+    expect(refreshBody).toContain('writePersistedAuthSession(data.refreshToken, refreshRealm);');
+    expect(refreshBody).toContain(
+      "await expireRuntimeAuth(currentUser.id, 'replaced-elsewhere', {",
+    );
+    expect(refreshBody).toContain('preservePersistedRefreshToken: true');
+  });
+
   it('drops a runtime refresh result after logout or a newer login changes auth generation', () => {
     const refreshStart = source.indexOf('export async function refresh(): Promise<boolean> {');
     const refreshEnd = source.indexOf('\n}\n\nexport async function logout()', refreshStart);

--- a/apps/desktop/src/main/__tests__/authRealmPolicy.test.ts
+++ b/apps/desktop/src/main/__tests__/authRealmPolicy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { canRestoreAuthSessionForMembership } from '../authRealmPolicy';
+
+describe('canRestoreAuthSessionForMembership', () => {
+  it.each([
+    ['cn', 'cn'],
+    ['global', 'global'],
+  ] as const)('allows a personal session in its build realm (%s)', (buildRegion, sessionRealm) => {
+    expect(canRestoreAuthSessionForMembership(buildRegion, sessionRealm, 'personal')).toBe(true);
+  });
+
+  it.each([
+    ['cn', 'global'],
+    ['global', 'cn'],
+  ] as const)(
+    'rejects a personal session outside its build realm (%s build, %s session)',
+    (buildRegion, sessionRealm) => {
+      expect(canRestoreAuthSessionForMembership(buildRegion, sessionRealm, 'personal')).toBe(false);
+    },
+  );
+
+  it.each([
+    ['cn', 'cn'],
+    ['cn', 'global'],
+    ['global', 'cn'],
+    ['global', 'global'],
+  ] as const)(
+    'allows an organization session to follow its realm (%s build, %s session)',
+    (buildRegion, sessionRealm) => {
+      expect(canRestoreAuthSessionForMembership(buildRegion, sessionRealm, 'org')).toBe(true);
+    },
+  );
+});

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -56,6 +56,7 @@ import {
 } from './authRefreshFailure';
 import { awaitWithStartupTimeout } from './authStartupGate';
 import { syncCanaryFlagAfterAuth } from './canaryFlagSync';
+import { canRestoreAuthSessionForMembership } from './authRealmPolicy';
 import {
   createAuthBrowserAuthorizationSlot,
   createAuthLoopbackDevBridgeSlot,
@@ -1876,8 +1877,6 @@ export async function initialize(options: AuthInitializeOptions = {}): Promise<A
   }
   try {
     await loadClientEndpointsForRealm(persistedSession.realm);
-    activateClientEndpointRealm(persistedSession.realm);
-    activeAuthRealm = persistedSession.realm;
   } catch (error) {
     // 对端区域清单暂不可用时保留原子凭据；退回构建区 refresh 会把有效 token
     // 当成非法凭据，因此本次仅以未登录放行 UI，下一次 initialize/重启可重试。
@@ -2024,6 +2023,19 @@ async function runColdStartRefreshFlow(
     }
 
     const refreshData = refreshResult.data as RefreshResponse;
+    if (
+      !canRestoreAuthSessionForMembership(AUTH_REGION, storedRealm, refreshData.membership.kind)
+    ) {
+      // refresh token 可能已由 auth-server 轮换。即使当前构建不能接受这枚个人
+      // 会话，也必须把新 token 写回原 realm，供拥有该 realm 的实例继续使用。
+      writePersistedAuthSession(refreshData.refreshToken, storedRealm);
+      resetActiveAuthRealmToBuild();
+      log.warn(
+        `cold-start refresh rejected cross-realm personal session realm=${storedRealm} buildRegion=${AUTH_REGION}`,
+      );
+      commitActiveAppSession('signed-out');
+      return snapshotLoggedOutAuthState();
+    }
     if (accountSwitchTeardown) {
       // Cold-start refresh may outlive initialize()'s startup timeout. Keep
       // the owner boundary held for the entire late commit sequence so stale
@@ -2046,7 +2058,11 @@ async function runColdStartRefreshFlow(
       releaseBoundary = null;
       return snapshotAuthState();
     }
-    writePersistedAuthSession(refreshData.refreshToken);
+    if (storedRealm !== activeAuthRealm) {
+      activateClientEndpointRealm(storedRealm);
+      activeAuthRealm = storedRealm;
+    }
+    writePersistedAuthSession(refreshData.refreshToken, storedRealm);
     lastAcceptedRefreshToken = refreshData.refreshToken;
 
     accessToken = refreshData.accessToken;
@@ -2090,6 +2106,7 @@ async function runColdStartRefreshFlow(
         clearTimeout(refreshTimer);
         refreshTimer = null;
       }
+      resetActiveAuthRealmToBuild();
     }
     releaseBoundary?.();
     releaseBoundary = null;
@@ -2716,6 +2733,23 @@ export async function refresh(): Promise<boolean> {
 
       const authRealmChanged = refreshRealm !== activeAuthRealm;
       const data = result.data as RefreshResponse;
+      if (!canRestoreAuthSessionForMembership(AUTH_REGION, refreshRealm, data.membership.kind)) {
+        // Preserve a rotated token in the realm that issued it, but never publish
+        // the incompatible personal identity or activate that realm's business endpoints.
+        writePersistedAuthSession(data.refreshToken, refreshRealm);
+        log.warn(
+          `runtime refresh rejected cross-realm personal session realm=${refreshRealm} buildRegion=${AUTH_REGION}`,
+        );
+        if (currentUser !== null) {
+          await expireRuntimeAuth(currentUser.id, 'replaced-elsewhere', {
+            preservePersistedRefreshToken: true,
+          });
+        } else {
+          resetActiveAuthRealmToBuild();
+          commitActiveAppSession('signed-out');
+        }
+        return false;
+      }
       const needsIdentityCheck =
         replacementRetries > 0 ||
         persistedRefreshTokenNeedsIdentityCheck ||

--- a/apps/desktop/src/main/authRealmPolicy.ts
+++ b/apps/desktop/src/main/authRealmPolicy.ts
@@ -1,0 +1,13 @@
+import type { AuthMembership, AuthRegion } from '@cindy/auth-client';
+
+/**
+ * Organization sessions may follow their server-side realm, while personal
+ * accounts remain scoped to the installed build region.
+ */
+export function canRestoreAuthSessionForMembership(
+  buildRegion: AuthRegion,
+  sessionRealm: AuthRegion,
+  membershipKind: AuthMembership['kind'],
+): boolean {
+  return membershipKind === 'org' || sessionRealm === buildRegion;
+}

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -162,6 +162,7 @@ import {
   storeGhostSecret,
 } from '../secrets/providerSecretStore.js';
 import { getActiveCatalog } from '../maker-host/active-catalog.js';
+import { projectProviderCatalogForBuildRegion } from '../maker-host/provider-access-policy.js';
 import { isModelDisabled, isProviderDisabled } from '@cindy/model-providers';
 import { readModelDisableOverrides } from '../maker-host/model-disable-store.js';
 import { outboundFetch } from '../maker-host/outbound-fetch.js';
@@ -1675,8 +1676,12 @@ function getCatalogMediaConfig(kind: 'image' | 'video'): CindyMediaCatalogConfig
     // 停用过滤:用户在 设置 → 模型供应商 停用的媒体模型 / 供应商不进候选清单
     // (与对话模型的准入口径同源,见 model-disable-store)。
     const access = readModelDisableOverrides();
+    const catalog = projectProviderCatalogForBuildRegion(
+      getActiveCatalog(),
+      CURRENT_CINDY_REGION,
+    );
     return deriveCindyMediaConfig(
-      getActiveCatalog().providers,
+      catalog.providers,
       kind,
       (providerId, modelId) =>
         isProviderDisabled(access, providerId) ||

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -6,6 +6,7 @@ import { deriveAvailableModels } from '../catalog-to-descriptors.js';
 import {
   filterProviderCatalogForAccount,
   isProviderSelectable,
+  projectProviderCatalogForBuildRegion,
 } from '../provider-access-policy.js';
 
 function model(id: string): CatalogModel {
@@ -31,11 +32,27 @@ function provider(id: string, models: CatalogModel[]): Provider {
 }
 
 function catalog(): Catalog {
+  const xd = provider('xd', [model('shared-model'), model('xd-only-model')]);
+  xd.imageModels = [
+    { id: 'gpt-image-2', name: 'GPT Image 2' },
+    { id: 'gemini-image', name: 'Gemini Image' },
+  ];
+  xd.imageDefaults = { standard: 'gpt-image-2', draft: 'gemini-image' };
+  xd.videoModels = [
+    { id: 'seedance-fast', name: 'Seedance Fast' },
+    { id: 'seedance-pro', name: 'Seedance Pro' },
+    { id: 'happyhorse', name: 'HappyHorse' },
+  ];
+  xd.videoDefaults = {
+    standard: 'seedance-fast',
+    draft: 'happyhorse',
+    best: 'seedance-pro',
+  };
   return {
     version: 'test',
     providers: [
       provider('anthropic', [model('shared-model')]),
-      provider('xd', [model('shared-model'), model('xd-only-model')]),
+      xd,
     ],
   };
 }
@@ -62,4 +79,28 @@ describe('provider access policy', () => {
     expect(filterProviderCatalogForAccount(input, { canUseCindyGateway: true })).toBe(input);
     expect(filterProviderCatalogForAccount(input, {})).toBe(input);
   });
+
+  it('preserves the full media catalog and object identity for Global', () => {
+    const input = catalog();
+    expect(projectProviderCatalogForBuildRegion(input, 'global')).toBe(input);
+  });
+
+  it.each(['cn', 'dev'] as const)(
+    'projects the Cindy AI media catalog to Mainland capabilities for %s',
+    (region) => {
+      const projected = projectProviderCatalogForBuildRegion(catalog(), region);
+      const xd = projected.providers.find((item) => item.id === 'xd');
+
+      expect(xd?.imageModels).toEqual([]);
+      expect(xd?.imageDefaults).toBeUndefined();
+      expect(xd?.videoModels?.map((item) => item.id)).toEqual([
+        'seedance-fast',
+        'seedance-pro',
+      ]);
+      expect(xd?.videoDefaults).toEqual({
+        standard: 'seedance-fast',
+        best: 'seedance-pro',
+      });
+    },
+  );
 });

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -32,7 +32,14 @@ function provider(id: string, models: CatalogModel[]): Provider {
 }
 
 function catalog(): Catalog {
-  const xd = provider('xd', [model('shared-model'), model('xd-only-model')]);
+  const xd = provider('xd', [
+    model('shared-model'),
+    model('xd-only-model'),
+    { ...model('gpt-image-2'), group: 'image' },
+    { ...model('seedance-fast'), group: 'video' },
+    { ...model('seedance-pro'), group: 'video' },
+    { ...model('happyhorse'), group: 'video' },
+  ]);
   xd.imageModels = [
     { id: 'gpt-image-2', name: 'GPT Image 2' },
     { id: 'gemini-image', name: 'Gemini Image' },
@@ -101,6 +108,12 @@ describe('provider access policy', () => {
         standard: 'seedance-fast',
         best: 'seedance-pro',
       });
+      expect(xd?.models['claude-code']?.map((item) => item.id)).toEqual([
+        'shared-model',
+        'xd-only-model',
+        'seedance-fast',
+        'seedance-pro',
+      ]);
     },
   );
 });

--- a/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { BUNDLED_CATALOG, connectedProvidersForAgent } from '@cindy/model-providers';
 
+import { checkModelRoute } from '../model-route-guard.js';
 import { createProviderService } from '../provider-service.js';
 
 /** 注入内置 bundled 目录作为「当前生效目录」(桌面端真实注入的是 active-catalog 的 getActiveCatalog)。 */
@@ -31,6 +32,65 @@ describe('createProviderService', () => {
     expect((await svc.listProviders()).find((p) => p.id === 'xd')!.connected).toBe(true);
     // 目录每次现读(active-catalog 已持有进程级单例,零额外 IO);连接态实时反映。
     expect(getCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts an internal full-catalog override for route-guard capability rejection', async () => {
+    const xd = BUNDLED_CATALOG.providers.find((provider) => provider.id === 'xd')!;
+    const agent = xd.agents[0]!;
+    const capabilityModel = {
+      ...xd.models[agent]![0]!,
+      id: 'route-only-image',
+      name: 'Route-only image',
+      group: 'image',
+    };
+    const fullCatalog = {
+      ...BUNDLED_CATALOG,
+      providers: BUNDLED_CATALOG.providers.map((provider) =>
+        provider.id === 'xd'
+          ? {
+              ...provider,
+              models: {
+                ...provider.models,
+                [agent]: [...(provider.models[agent] ?? []), capabilityModel],
+              },
+            }
+          : provider,
+      ),
+    };
+    const selectable = {
+      ...fullCatalog,
+      providers: fullCatalog.providers.map((provider) =>
+        provider.id === 'xd'
+          ? {
+              ...provider,
+              models: Object.fromEntries(
+                Object.entries(provider.models).map(([agent, models]) => [
+                  agent,
+                  models.filter((model) => model.id !== capabilityModel.id),
+                ]),
+              ),
+            }
+          : provider,
+      ),
+    };
+    const svc = createProviderService({
+      getCatalog: () => selectable,
+      connection: { xd: () => true, anthropic: () => false, openai: () => false, xai: () => false },
+    });
+
+    const selectableXd = (await svc.listProviders()).find((provider) => provider.id === 'xd');
+    const routingXd = (
+      await svc.listProviders({ catalog: fullCatalog })
+    ).find((provider) => provider.id === 'xd');
+
+    expect(
+      Object.values(selectableXd?.models ?? {}).flat().some((model) => model.id === capabilityModel.id),
+    ).toBe(false);
+    expect(
+      Object.values(routingXd?.models ?? {}).flat().some((model) => model.id === capabilityModel.id),
+    ).toBe(true);
+    expect(checkModelRoute(await svc.listProviders({ catalog: fullCatalog }), agent, capabilityModel.id, 'xd'))
+      .toEqual({ kind: 'reject', reason: 'capability-model' });
   });
 
   it('supports async connection readers (codex oauth)', async () => {

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -72,8 +72,12 @@ import {
 } from './grok-oauth-login.js';
 import { getAuthState } from '../authManager.js';
 import { getActiveAppSession } from '../appSessionState.js';
-import { filterProviderCatalogForAccount } from './provider-access-policy.js';
+import {
+  filterProviderCatalogForAccount,
+  projectProviderCatalogForBuildRegion,
+} from './provider-access-policy.js';
 import { getAppCapabilities } from '../appCapabilities.js';
+import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
 import {
   claimDetectedNativeProviderAuth,
   migrateLegacyNativeProviderAuthBindings,
@@ -432,7 +436,11 @@ let singleton: ProviderService | null = null;
  * Cindy account session keeps the full active catalog.
  */
 export function getDesktopSelectableCatalog(): Catalog {
-  return filterProviderCatalogForAccount(getActiveCatalog(), {
+  const regionCatalog = projectProviderCatalogForBuildRegion(
+    getActiveCatalog(),
+    CURRENT_CINDY_REGION,
+  );
+  return filterProviderCatalogForAccount(regionCatalog, {
     canUseCindyGateway: getAppCapabilities().canUseCindyGateway,
   });
 }

--- a/apps/desktop/src/main/maker-host/model-route-guard-live.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard-live.ts
@@ -23,12 +23,22 @@ import {
 } from '@cindy/model-providers';
 
 import { getDesktopProviderService } from './createDesktopProviderService.js';
+import { getActiveCatalog } from './active-catalog.js';
 import { readModelDisableOverrides } from './model-disable-store.js';
 import {
   checkModelRoute,
   resolveLenientRoute,
   type ModelRouteVerdict,
 } from './model-route-guard.js';
+
+/**
+ * Route admission must retain capability entries that selectable build-region
+ * projections intentionally hide. Otherwise an old controller can name a
+ * hidden media model and make checkModelRoute treat it as catalog-unknown.
+ */
+async function listRouteGuardProviders(): Promise<ProviderView[]> {
+  return getDesktopProviderService().listProviders({ catalog: getActiveCatalog() });
+}
 
 /** 该 agent 的静态原生默认来源偏好(nativeDefaultSourceId 的无 rail 近似)。 */
 function staticNativeDefaults(agent: AgentKind): readonly string[] {
@@ -82,7 +92,7 @@ export async function verdictForModelRoute(
 ): Promise<ModelRouteVerdict> {
   let views: ProviderView[];
   try {
-    views = await getDesktopProviderService().listProviders();
+    views = await listRouteGuardProviders();
   } catch {
     return overrideOnlyVerdict(agent, model, providerId);
   }
@@ -108,7 +118,7 @@ export async function resolveLenientSessionRoute(
 }> {
   let views: ProviderView[];
   try {
-    views = await getDesktopProviderService().listProviders();
+    views = await listRouteGuardProviders();
   } catch {
     // 目录故障降级:override-only 保守裁决(同 overrideOnlyVerdict 语义)。命中即
     // 逐级丢弃;目录不可得时没有 pick 兜底可用,model 置空由调用方失败收口。
@@ -161,7 +171,7 @@ export async function resolveRouteCopyCapabilities(
 } | null> {
   let views: ProviderView[];
   try {
-    views = await getDesktopProviderService().listProviders();
+    views = await listRouteGuardProviders();
   } catch {
     return null;
   }
@@ -206,7 +216,7 @@ export async function isAgentOneShotRouteDisabled(
   }
   let views: ProviderView[];
   try {
-    views = await getDesktopProviderService().listProviders();
+    views = await listRouteGuardProviders();
   } catch {
     // 目录故障降级:静态原生默认来源被 override 停用即视为不可发(同
     // overrideOnlyVerdict 的隐式近似;override 也读不了则按无停用证据放行)。

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -5,7 +5,8 @@
  * providers and models exposed as selectable capabilities to product surfaces.
  */
 
-import type { Catalog } from '@cindy/model-providers';
+import type { Catalog, Provider } from '@cindy/model-providers';
+import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
 export interface ProviderAccessContext {
   /** False for account-free local sessions, in every build flavor. */
@@ -13,6 +14,57 @@ export interface ProviderAccessContext {
 }
 
 const CINDY_AI_PROVIDER_ID = 'xd';
+const MAINLAND_VIDEO_MODEL_IDS: ReadonlySet<string> = new Set([
+  'seedance-fast',
+  'seedance-pro',
+]);
+
+function projectVideoDefaults(
+  defaults: Provider['videoDefaults'],
+  allowedIds: ReadonlySet<string>,
+): Provider['videoDefaults'] | undefined {
+  if (!defaults || !allowedIds.has(defaults.standard)) return undefined;
+  return {
+    standard: defaults.standard,
+    ...(defaults.draft && allowedIds.has(defaults.draft) ? { draft: defaults.draft } : {}),
+    ...(defaults.best && allowedIds.has(defaults.best) ? { best: defaults.best } : {}),
+  };
+}
+
+/**
+ * Build-region projection for the Cindy AI media catalog. Global keeps the
+ * catalog source verbatim; Mainland China and dev share the Mainland product
+ * semantics and expose only the media capabilities supported there.
+ */
+export function projectProviderCatalogForBuildRegion(
+  catalog: Catalog,
+  region: CindyRegion,
+): Catalog {
+  if (region === 'global') return catalog;
+
+  let changed = false;
+  const providers = catalog.providers.map((provider) => {
+    if (provider.id !== CINDY_AI_PROVIDER_ID) return provider;
+    changed = true;
+
+    const videoModels = (provider.videoModels ?? []).filter((model) =>
+      MAINLAND_VIDEO_MODEL_IDS.has(model.id),
+    );
+    const videoIds = new Set(videoModels.map((model) => model.id));
+    const videoDefaults = projectVideoDefaults(provider.videoDefaults, videoIds);
+    const projected: Provider = {
+      ...provider,
+      imageModels: [],
+      videoModels,
+    };
+    delete projected.imageDefaults;
+    delete projected.videoDefaults;
+    if (videoDefaults) projected.videoDefaults = videoDefaults;
+    return projected;
+  });
+
+  return changed ? { ...catalog, providers } : catalog;
+}
 
 /** Cindy AI requires a Cindy account session; every membership kind may select it. */
 export function isProviderSelectable(providerId: string, context: ProviderAccessContext): boolean {

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -5,7 +5,7 @@
  * providers and models exposed as selectable capabilities to product surfaces.
  */
 
-import type { Catalog, Provider } from '@cindy/model-providers';
+import { groupOf, type Catalog, type Provider } from '@cindy/model-providers';
 import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
 export interface ProviderAccessContext {
@@ -52,8 +52,18 @@ export function projectProviderCatalogForBuildRegion(
     );
     const videoIds = new Set(videoModels.map((model) => model.id));
     const videoDefaults = projectVideoDefaults(provider.videoDefaults, videoIds);
+    const models = Object.fromEntries(
+      Object.entries(provider.models).map(([agent, list]) => [
+        agent,
+        list.filter((model) => {
+          const group = groupOf(model);
+          return group !== 'image' && (group !== 'video' || MAINLAND_VIDEO_MODEL_IDS.has(model.id));
+        }),
+      ]),
+    ) as Provider['models'];
     const projected: Provider = {
       ...provider,
+      models,
       imageModels: [],
       videoModels,
     };

--- a/apps/desktop/src/main/maker-host/provider-service.ts
+++ b/apps/desktop/src/main/maker-host/provider-service.ts
@@ -33,6 +33,14 @@ export interface ConnectionReadOptions {
   allowSideEffects: boolean;
 }
 
+export interface ProviderListOptions extends ConnectionReadOptions {
+  /**
+   * Internal catalog override for policy consumers that need the routing truth
+   * rather than the user-selectable projection. Never sourced from IPC input.
+   */
+  catalog?: Catalog;
+}
+
 /** 内置三家供应商「是否已连接」的判定器（由 host 注入，读各自凭证存储）。 */
 export interface ProviderConnectionReaders {
   /** XD 网关：托管 api_key 是否存在。 */
@@ -88,7 +96,7 @@ export interface ProviderService {
    *   · 跨进程边界进来的（renderer IPC、device-link 合成 event）按 sender 可信度决定，
    *     见 providerHandlers 的 isTrustedSender。
    */
-  listProviders(opts?: Partial<ConnectionReadOptions>): Promise<ProviderView[]>;
+  listProviders(opts?: Partial<ProviderListOptions>): Promise<ProviderView[]>;
 }
 
 /**
@@ -96,7 +104,7 @@ export interface ProviderService {
  * 连接状态每次实时读（凭证变化要立即反映）。
  */
 export function createProviderService(deps: ProviderServiceDeps): ProviderService {
-  async function listProviders(opts?: Partial<ConnectionReadOptions>): Promise<ProviderView[]> {
+  async function listProviders(opts?: Partial<ProviderListOptions>): Promise<ProviderView[]> {
     const readOpts: ConnectionReadOptions = { allowSideEffects: opts?.allowSideEffects === true };
     const [xd, anthropic, openai, xai] = await Promise.all([
       Promise.resolve(deps.connection.xd(readOpts)),
@@ -104,7 +112,7 @@ export function createProviderService(deps: ProviderServiceDeps): ProviderServic
       Promise.resolve(deps.connection.openai(readOpts)),
       Promise.resolve(deps.connection.xai(readOpts)),
     ]);
-    const catalog = deps.getCatalog();
+    const catalog = opts?.catalog ?? deps.getCatalog();
     const connected: ConnectionState = { xd, anthropic, openai, xai };
     // 自定义（user）供应商：存在于目录即视为「已连接」——用「编辑 / 删除」替代「连接 / 断开」，
     // 没有独立鉴权握手（密钥缺失则请求失败，但 UI 连接态为已配置）。

--- a/apps/desktop/src/main/model-access/__tests__/authSessionIdentity.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/authSessionIdentity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { hasAuthSessionIdentityChanged } from '../authSessionIdentity';
+import { hasAuthSessionIdentityChanged } from '../authSessionIdentity.js';
 
 describe('hasAuthSessionIdentityChanged', () => {
   it('treats user or realm changes as an authentication boundary', () => {

--- a/apps/desktop/src/main/model-access/__tests__/authSessionIdentity.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/authSessionIdentity.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasAuthSessionIdentityChanged } from '../authSessionIdentity';
+
+describe('hasAuthSessionIdentityChanged', () => {
+  it('treats user or realm changes as an authentication boundary', () => {
+    expect(
+      hasAuthSessionIdentityChanged(
+        { userId: 'user-a', realm: 'cn' },
+        { userId: 'user-b', realm: 'cn' },
+      ),
+    ).toBe(true);
+    expect(
+      hasAuthSessionIdentityChanged(
+        { userId: 'user-a', realm: 'cn' },
+        { userId: 'user-a', realm: 'global' },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not treat the first known identity or an unchanged identity as a switch', () => {
+    expect(
+      hasAuthSessionIdentityChanged(
+        { userId: null, realm: null },
+        { userId: 'user-a', realm: 'cn' },
+      ),
+    ).toBe(false);
+    expect(
+      hasAuthSessionIdentityChanged(
+        { userId: 'user-a', realm: 'cn' },
+        { userId: 'user-a', realm: 'cn' },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/model-access/__tests__/credentialsSync.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/credentialsSync.test.ts
@@ -284,6 +284,34 @@ describe('credentialsSync', () => {
     expect(h.store.getServerEndpoint()).toBe('https://tenant-b.test.invalid');
   });
 
+  it('同账号跨区作废旧 realm 的在途响应,并从新 realm 重新同步', async () => {
+    const h = makeHarness();
+    const resolvers: Array<(v: CredentialsPayload) => void> = [];
+    h.fetchMock.mockImplementation(
+      () => new Promise<CredentialsPayload>((resolve) => resolvers.push(resolve)),
+    );
+
+    h.sync.handleAuthChange({ isAuthenticated: true, userId: 'user-a', realm: 'cn' });
+    await Promise.resolve();
+    expect(h.fetchMock).toHaveBeenCalledTimes(1);
+
+    h.sync.handleAuthChange({ isAuthenticated: true, userId: 'user-a', realm: 'global' });
+    await Promise.resolve();
+    expect(h.fetchMock).toHaveBeenCalledTimes(2);
+
+    resolvers[0]({ endpoint: 'https://cn.test.invalid', apiKey: 'sk-cn' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.written).toEqual([]);
+
+    resolvers[1]({ endpoint: 'https://global.test.invalid', apiKey: 'sk-global' });
+    await vi.waitFor(() => {
+      expect(h.sync.getStatus().state).toBe('ok');
+    });
+    expect(h.written).toEqual(['sk-global']);
+    expect(h.store.getServerEndpoint()).toBe('https://global.test.invalid');
+  });
+
   it('登录触发 handleAuthChange(true) 自动同步', async () => {
     const h = makeHarness();
     h.fetchMock.mockResolvedValue({ endpoint: 'https://laxa.test.invalid', apiKey: 'sk-u1' });

--- a/apps/desktop/src/main/model-access/authSessionIdentity.ts
+++ b/apps/desktop/src/main/model-access/authSessionIdentity.ts
@@ -1,0 +1,20 @@
+import type { AuthRegion } from '@cindy/auth-client';
+
+export interface AuthSessionIdentity {
+  userId: string | null;
+  realm: AuthRegion | null;
+}
+
+/**
+ * 已建立身份的 userId 或 realm 任一变化都跨越认证边界。首次获知身份不算切换，
+ * 避免初始化订阅与补读当前状态时重复作废同一轮请求。
+ */
+export function hasAuthSessionIdentityChanged(
+  previous: AuthSessionIdentity,
+  next: AuthSessionIdentity,
+): boolean {
+  return (
+    (previous.userId !== null && next.userId !== null && previous.userId !== next.userId) ||
+    (previous.realm !== null && next.realm !== null && previous.realm !== next.realm)
+  );
+}

--- a/apps/desktop/src/main/model-access/credentialsSync.ts
+++ b/apps/desktop/src/main/model-access/credentialsSync.ts
@@ -1,4 +1,7 @@
+import type { AuthRegion } from '@cindy/auth-client';
+
 import type { ModelAccessStatus } from '../../shared/modelAccess.js';
+import { hasAuthSessionIdentityChanged } from './authSessionIdentity.js';
 import type { ModelAccessCredentialsStore } from './credentialsStore.js';
 
 /**
@@ -94,11 +97,14 @@ export interface CredentialsSync {
   rotate(): Promise<ModelAccessStatus>;
   /**
    * 登录/登出/切账号入口(authManager.onAuthStateChange)。
-   * userId 用于账号边界:runtime refresh 换号**不经过** isAuthenticated:false,
-   * 只有携带身份才能作废旧账号的在途请求(PR review P1:A 的在途凭据请求
-   * 不得在切到 B 后写回)。
+   * userId + realm 构成身份边界:runtime refresh 换号或同账号跨区都可能
+   * **不经过** isAuthenticated:false,只有携带完整身份才能作废旧请求。
    */
-  handleAuthChange(state: { isAuthenticated: boolean; userId?: string | null }): void;
+  handleAuthChange(state: {
+    isAuthenticated: boolean;
+    userId?: string | null;
+    realm?: AuthRegion | null;
+  }): void;
   /** 手填保存成功(safe-storage IPC 层通知):source 翻 manual。 */
   noteManualKeySaved(): void;
   /** 手填 key 被删除:清来源标记。 */
@@ -114,15 +120,15 @@ export function createCredentialsSync(deps: CredentialsSyncDeps): CredentialsSyn
   let status: ModelAccessStatus = snapshot('idle');
   let inflight: Promise<ModelAccessStatus> | null = null;
   /**
-   * 认证世代号:登出/**换账号**(userId 变化)自增。所有写盘(key/endpoint/状态)
-   * 都以发起时捕获的世代为闸——旧账号的在途请求在世代变更后一律作废,绝不写回
-   * (PR review P1:runtime refresh 换号不经过 isAuthenticated:false)。
+   * 认证世代号:登出、换账号或同账号跨区时自增。所有写盘(key/endpoint/状态)
+   * 都以发起时捕获的世代为闸——旧身份的在途请求在世代变更后一律作废。
    */
   let epoch = 0;
   /** 在途同步所属的世代;世代变更后旧 inflight 不再被复用。 */
   let inflightEpoch = -1;
   /** 当前登录身份(handleAuthChange 维护),null = 未登录/未知。 */
   let currentUserId: string | null = null;
+  let currentRealm: AuthRegion | null = null;
 
   function snapshot(
     state: ModelAccessStatus['state'],
@@ -269,16 +275,24 @@ export function createCredentialsSync(deps: CredentialsSyncDeps): CredentialsSyn
     handleAuthChange(state) {
       if (state.isAuthenticated) {
         const userId = state.userId ?? null;
-        if (userId !== null && currentUserId !== null && userId !== currentUserId) {
-          // runtime refresh 换号(A→B 不经过登出):作废 A 的在途请求与终态。
+        const realm = state.realm ?? null;
+        if (
+          hasAuthSessionIdentityChanged(
+            { userId: currentUserId, realm: currentRealm },
+            { userId, realm },
+          )
+        ) {
+          // runtime refresh 换号或同账号跨区(均可能不经过登出):作废旧请求与终态。
           epoch++;
         }
         if (userId !== null) currentUserId = userId;
+        if (realm !== null) currentRealm = realm;
         void startSync().catch(() => undefined);
       } else {
         // 登出/会话失效:复位状态机(含 unsupported 终态),不动本地 key/元数据。
         epoch++;
         currentUserId = null;
+        currentRealm = null;
         setStatus('idle');
       }
     },

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -39,6 +39,7 @@ import {
   waitForModelsSyncRefresh,
 } from './modelsSyncRefresh.js';
 import { getGhostSetupChangeBus } from '../cindy-brain/ghostSetupChangeBus.js';
+import { hasAuthSessionIdentityChanged } from './authSessionIdentity.js';
 export { isModelAccessReady } from './readiness.js';
 
 const log = createLogger('modelAccess');
@@ -141,12 +142,13 @@ let modelsSyncGen = -1;
 /** 旧世代请求在途时新账号的补发标记。 */
 let modelsSyncRerunQueued = false;
 /**
- * 认证世代:登出或 userId 变化时自增(与 credentialsSync 的 epoch 同语义)。
- * 目录请求以发起时世代为闸——A 账号的在途 /models 响应在切到 B 后一律丢弃,
- * 且 B 会补发自己的请求(PR review P1:旧账号目录不得覆盖新账号)。
+ * 认证世代:登出或 userId / realm 变化时自增(与 credentialsSync 的 epoch 同语义)。
+ * 目录请求以发起时世代为闸——旧身份的在途 /models 响应在换号或同账号跨区后
+ * 一律丢弃,且新身份会补发自己的请求。
  */
 let authGeneration = 0;
 let lastAuthUserId: string | null = null;
+let lastAuthRealm: ReturnType<typeof authManager.getActiveAuthRealm> | null = null;
 
 function applyGatewayModels(
   models: ModelAccessGatewayModel[],
@@ -353,24 +355,39 @@ function mapServerError(err: unknown): never {
 export function initModelAccess(): void {
   const sync = getSync();
 
-  const noteAuthState = (isAuthenticated: boolean, userId: string | null) => {
-    // 认证世代:登出或换号自增,作废旧账号在途的目录请求(runModelsSync 世代闸)。
-    if (!isAuthenticated || (userId !== null && lastAuthUserId !== null && userId !== lastAuthUserId)) {
+  const noteAuthState = (
+    isAuthenticated: boolean,
+    userId: string | null,
+    realm: ReturnType<typeof authManager.getActiveAuthRealm> | null,
+  ) => {
+    // 认证世代:登出、换号或同账号跨区均自增,作废旧身份在途的目录请求。
+    if (
+      !isAuthenticated ||
+      hasAuthSessionIdentityChanged(
+        { userId: lastAuthUserId, realm: lastAuthRealm },
+        { userId, realm },
+      )
+    ) {
       authGeneration++;
-      // 旧账号模型清单不能跨账号继续显示;新账号凭据 / 模型拉取成功后再注入。
+      // 旧身份模型清单不能跨账号/区域继续显示;新身份拉取成功后再注入。
       applyGatewayModels([]);
     }
     lastAuthUserId = isAuthenticated ? (userId ?? lastAuthUserId) : null;
-    sync.handleAuthChange({ isAuthenticated, userId });
+    lastAuthRealm = isAuthenticated ? (realm ?? lastAuthRealm) : null;
+    sync.handleAuthChange({ isAuthenticated, userId, realm });
   };
 
   authManager.onAuthStateChange((state) => {
-    noteAuthState(state.isAuthenticated, state.user?.id ?? null);
+    noteAuthState(
+      state.isAuthenticated,
+      state.user?.id ?? null,
+      state.isAuthenticated ? authManager.getActiveAuthRealm() : null,
+    );
   });
   // 订阅挂载时可能已错过冷启动的首次 notify(初始化顺序取决于 bootstrap),补一次。
   const initial = authManager.getAuthState();
   if (initial.isAuthenticated) {
-    noteAuthState(true, initial.user?.id ?? null);
+    noteAuthState(true, initial.user?.id ?? null, authManager.getActiveAuthRealm());
   }
   ipcMain.handle('model-access:get-status', () => sync.getStatus());
 
@@ -403,5 +420,6 @@ export function resetModelAccessForTest(): void {
   lastModelsSyncSucceededAttempt = 0;
   authGeneration = 0;
   lastAuthUserId = null;
+  lastAuthRealm = null;
   applyGatewayModels([]);
 }

--- a/docs/auth-realm-routing.md
+++ b/docs/auth-realm-routing.md
@@ -74,10 +74,11 @@ Desktop 的 model-access 身份由 `(userId, sessionRealm)` 共同确定。登�
 同账号切换 realm 时，客户端立即清空旧 XD 动态模型清单，作废旧身份在途的凭据与
 `/models` 响应，并从当前 realm 重新同步；迟到响应不得写回凭据或覆盖新区域模型。
 
-XD 静态媒体能力属于 `buildRegion` 产品能力，不随组织 `sessionRealm` 跨区扩张。
-Global 构建保留目录中的完整图像与视频清单；中国大陆和 dev 构建不暴露图像模型，
-视频仅暴露 `seedance-fast` 与 `seedance-pro`。设置页、模型停用成员校验和 Cindy
-媒体运行时都消费 main 侧同一投影策略，Renderer 不另做隐藏。
+XD 媒体能力属于 `buildRegion` 产品能力，不随组织 `sessionRealm` 跨区扩张。
+Global 构建保留目录中的完整图像与视频清单；中国大陆和 dev 构建会同时投影动态
+agent 清单里的媒体能力组与静态媒体清单：不暴露图像模型，视频仅暴露
+`seedance-fast` 与 `seedance-pro`。设置页、模型停用成员校验和 Cindy 媒体运行时
+都消费 main 侧同一投影策略，Renderer 不另做隐藏。
 
 ## Mobile 推送撤销
 

--- a/docs/auth-realm-routing.md
+++ b/docs/auth-realm-routing.md
@@ -59,7 +59,11 @@ Desktop safeStorage 和 Mobile SecureStore 都只保存一个加密的原子记�
 
 旧版裸 refresh token 只在一次性迁移时按 `buildRegion` 解释。冷启动先加载并核验记录中
 区域的端点清单，再向该区域 refresh；对端清单暂不可用时保留记录供重试，禁止退回
-`buildRegion` 发送 token。登出会清除记录和 `sessionRealm`，业务端点恢复安装包区域。
+`buildRegion` 发送 token。Desktop 在 refresh 返回组织 membership 后才允许激活跨区业务
+端点；个人 membership 只有在 `sessionRealm === buildRegion` 时才能恢复。跨区个人
+session 被拒绝时，Desktop 仍把轮换后的 refresh token 写回原 realm，但保持未登录且不
+删除记录，避免破坏共享 userData 中另一实例仍在使用的会话。登出会清除记录和
+`sessionRealm`，业务端点恢复安装包区域。
 
 Mobile 的 Pending OAuth 同时保存 `realm`，但 redirect scheme 始终使用当前安装包的
 scheme。个人验证码和社交登录不做跨区域发现，也不合并两区 passport。

--- a/docs/auth-realm-routing.md
+++ b/docs/auth-realm-routing.md
@@ -68,6 +68,17 @@ session 被拒绝时，Desktop 仍把轮换后的 refresh token 写回原 realm�
 Mobile 的 Pending OAuth 同时保存 `realm`，但 redirect scheme 始终使用当前安装包的
 scheme。个人验证码和社交登录不做跨区域发现，也不合并两区 passport。
 
+## 模型访问与媒体目录边界
+
+Desktop 的 model-access 身份由 `(userId, sessionRealm)` 共同确定。登出、换账号或
+同账号切换 realm 时，客户端立即清空旧 XD 动态模型清单，作废旧身份在途的凭据与
+`/models` 响应，并从当前 realm 重新同步；迟到响应不得写回凭据或覆盖新区域模型。
+
+XD 静态媒体能力属于 `buildRegion` 产品能力，不随组织 `sessionRealm` 跨区扩张。
+Global 构建保留目录中的完整图像与视频清单；中国大陆和 dev 构建不暴露图像模型，
+视频仅暴露 `seedance-fast` 与 `seedance-pro`。设置页、模型停用成员校验和 Cindy
+媒体运行时都消费 main 侧同一投影策略，Renderer 不另做隐藏。
+
 ## Mobile 推送撤销
 
 Mobile 按 `sessionRealm` 分别保存推送注册与待注销状态。登出、换账号或换区域时，


### PR DESCRIPTION
## 这次改了什么

### 摘要

Fixes the two independent realm leaks tracked by #910:

- Personal persisted sessions are restored only when the saved session realm matches the Desktop build region; organization sessions may still follow their legitimate realm.
- Model and credential synchronization now treats `(userId, realm)` as the authentication boundary so stale responses from the previous realm cannot overwrite current state.
- The Desktop main process projects the Cindy AI media catalog by build region for every consumer. CN/dev exposes no image models and only `seedance-fast` / `seedance-pro`; Global remains unchanged.
- Documents the session persistence, realm-switch invalidation, and media projection contract.

### 变更类型

- [ ] `feat`
- [x] `fix`
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore`
- [ ] Other

### 范围

- Related issue: #910
- Included: Desktop persisted auth restoration policy, realm-aware model/credential epochs, build-region media projection, tests, and documentation.
- Excluded: server changes, Mobile behavior, protocol changes, and model catalog source data changes.
- User-visible change: CN model-provider settings no longer show image models or HappyHorse; Global remains complete.
- Breaking change: none.

### UI 变化

- 不涉及：No Renderer component, layout, style, copy, or interaction was changed. Existing model-list UI now receives the corrected main-process catalog.
- Design basis: not applicable because there is no visual or interaction implementation change.

## 怎么验证的

### 自动验证

```text
pnpm test:unit
Result: passed for every applicable workspace; Desktop unit suite passed.

pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed for all 3 PR commits.

git diff --check origin/main...HEAD
Result: passed.
```

Focused Desktop tests for the auth policy, auth identity, credential synchronization, provider projection, provider handlers, and Cindy media catalog also passed during development.

### 手工验证

- Windows isolated Desktop sandbox `issue910`, CN build: Cindy AI showed 59 models, no image group, and exactly `Seedance 快速` / `Seedance Pro`; HappyHorse was absent.
- The CN catalog was checked in both Light and Dark modes.
- Same sandbox, Global build: full catalog remained available (70 models, image 4, video 9, including HappyHorse). An organization session remained signed in across regions.
- CN personal session -> Global cold start: Global stayed logged out and did not publish the CN identity. Without touching the Global login page, restarting CN restored the original personal session automatically, confirming that the original-realm refresh token was preserved.

### 未执行的验证

- The inverse Global-personal -> CN black-box flow was not repeated; the policy is symmetric and both directions are covered by unit tests.
- No end-to-end network fault injection was used for late `/models` or credential responses; deterministic unit tests cover stale-response rejection.
- Mobile validation was not run because no Mobile source, native configuration, dependency, or runtime fingerprint input changed.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] Other

### 影响与回滚

- Impact: Desktop cold-start authentication, runtime realm switches, and Cindy AI media capability visibility. Main-process logic is shared across Desktop platforms; black-box validation was performed on Windows.
- Rollback: revert the three PR commits to restore the previous auth/session and catalog behavior.
- Mobile cold-update analysis: no Mobile files, native configuration, dependencies, config plugins, native modules, or fingerprint inputs changed, so this PR cannot trigger a Mobile cold update.

### 提交前检查

- [x] Reviewed the complete diff.
- [x] Every commit has a matching DCO sign-off.
- [x] UI design basis recorded above; no UI implementation changed.
- [x] No credentials, tokens, authorization files, or local databases are included.
- [x] Documentation and regression tests are included.
- [x] Test results and unexecuted checks are accurately documented.