### PR TITLE
fix(model-providers): Kimi Code 编程计划预设补齐 contextWindow,k3 不再回落 200K

### DIFF
--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -442,7 +442,8 @@
             },
             {
               "id": "k3",
-              "name": "Kimi K3"
+              "name": "Kimi K3",
+              "contextWindow": 262144
             }
           ]
         },
@@ -452,15 +453,18 @@
           "models": [
             {
               "id": "kimi-for-coding",
-              "name": "Kimi for Coding"
+              "name": "Kimi for Coding",
+              "contextWindow": 262144
             },
             {
               "id": "kimi-for-coding-highspeed",
-              "name": "Kimi for Coding 高速版"
+              "name": "Kimi for Coding 高速版",
+              "contextWindow": 262144
             },
             {
               "id": "k3",
-              "name": "Kimi K3"
+              "name": "Kimi K3",
+              "contextWindow": 262144
             }
           ]
         }

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -167,6 +167,25 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     ).toBe(1_000_000);
   });
 
+  it('Kimi Code(编程计划)预设的每个模型都带 contextWindow(k3 缺失曾回落 200K)', () => {
+    // k3 此前没带 contextWindow → buildUserProvider 回落 200K 保守默认:选择器
+    // 显示 200K 且压缩阈值过早触发(用户反馈「动不动就压缩」)。取 262144 与同
+    // 套餐 kimi-for-coding 口径一致(K3 开放平台规格 1M,但编程计划端点是否限窗
+    // 无公开文档,保守取值;实测放开后可上调)。
+    const presets = BUNDLED_CATALOG.presets ?? [];
+    const kimiCode = presets.find((p) => p.id === 'moonshot-kimi-code');
+    expect(kimiCode).toBeDefined();
+    for (const [agent, rt] of Object.entries(kimiCode!.runtimes)) {
+      for (const m of rt!.models) {
+        expect(
+          Number.isFinite(m.contextWindow) && (m.contextWindow ?? 0) > 0,
+          `${agent}/${m.id} 缺 contextWindow`,
+        ).toBe(true);
+      }
+      expect(rt!.models.find((m) => m.id === 'k3')?.contextWindow, `${agent}/k3`).toBe(262_144);
+    }
+  });
+
   it('ships Codex support metadata for the current XD gateway model set', () => {
     const metadata = BUNDLED_CATALOG.cindyModelMeta as {
       version?: unknown;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复用户反馈(TapTap 制造内测群):「Kimi Code(编程计划包月)」绑定里选 K3,上下文窗口显示 200K,且因压缩阈值按 200K 计算而频繁提前触发压缩。

根因:`moonshot-kimi-code` 预设的 `k3` 条目缺 `contextWindow`,`buildUserProvider` 回落 `DEFAULT_CUSTOM_CONTEXT_WINDOW = 200_000`。

- `k3` 补 262144:与同套餐 `kimi-for-coding` 口径一致。K3 开放平台规格是 1M(platform.kimi.com 模型卡「旗舰模型,1M token 上下文」),但**编程计划端点是否限窗无公开文档**(官方第三方接入文档未列 K3),保守取值避免「声称 1M 而端点实际限窗」导致超发硬失败;有编程计划订阅的同学实测放开后可上调,目录测试里已注明
- codex runtime 的 `kimi-for-coding` / `高速版` 一并补齐(此前仅 claude-code 侧带值;DeepSeek 预设 #735 的先例是两个 runtime 都带)
- 新增目录测试:该预设每个模型必须带 contextWindow,`k3` 钉在 262144

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#386(同类问题的内置目录实例;自定义模型可编辑 contextWindow 的根治另行提 PR)
- 本 PR 包含:catalog 两处 runtime 共 3 个模型条目补 contextWindow + 目录测试
- 明确不包含:已存在绑定实例的存量修复——预设在创建时快照进 DB、与目录脱钩,存量用户需删除重加,或等 #386 的模型级编辑能力
- 用户可见变化:新建 Kimi Code 绑定后 K3 显示 262K,压缩阈值随之修正
- 是否存在 breaking change:无

### UI 变化

不涉及:纯目录数据,无 UI 代码改动。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:通过(52 个 workspace,含新增目录测试)

pnpm --filter @cindy/model-providers run --if-present typecheck
结果:通过
```

### 手工验证

不涉及(数据条目;显示链路 catalog → buildUserProvider → UnifiedModelList 已有既有测试覆盖)。

### 未执行的验证

未对 Kimi 编程计划端点实测 K3 真实限窗(需要付费订阅),故取保守值 262144 而非规格 1M,理由见摘要。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:新建的 Kimi Code 自定义 Provider 绑定
- 回滚 / 降级方式:revert 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
