### PR TITLE
fix(desktop): allow manual compact after turn recovery

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -2079,7 +2079,7 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(projection.pendingQueue.map((q) => q.clientId)).toEqual(['q-head', 'q-second']);
   });
 
-  it('does not clear an existing recovery when compact is requested', async () => {
+  it('does not clear a queue-head recovery when compact is requested', async () => {
     const h = createHarness();
     const sid = 'compact-preserves-recovery';
     const failed = makeItem('q-failed', 'failed');
@@ -2099,6 +2099,63 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.sendToAgent).not.toHaveBeenCalled();
     expect(after.recovery).toEqual({ kind: 'queue-head', clientId: 'q-failed' });
     expect(after.errorRetryText).toBe('failed');
+  });
+
+  it('abandons an idle active-turn recovery and dispatches compact immediately', async () => {
+    const h = createHarness();
+    const sid = 'compact-abandons-idle-active-turn-recovery';
+
+    h.coordinator.enqueue(sid, makeItem('q-failed', 'failed'));
+    await flush();
+
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'context window exhausted');
+    await flush();
+    expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
+
+    await h.coordinator.compact(sid, makeItem('q-compact', 'ignored').createOpts);
+    await flush();
+
+    const projection = latestProjection(h.projections);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: '/compact' });
+    expect(projection.error).toBeNull();
+    expect(projection.recovery).toBeNull();
+
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'done');
+    await h.coordinator.retryLastError(sid);
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('queues compact after abandoning active-turn recovery while the dispatch boundary is still busy', async () => {
+    const h = createHarness();
+    const sid = 'compact-queues-after-active-turn-recovery';
+
+    h.coordinator.enqueue(sid, makeItem('q-failed', 'failed'));
+    await flush();
+
+    h.coordinator.onTurnEvent(sid, 'error', 'context window exhausted');
+    await flush();
+    expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
+
+    await h.coordinator.compact(sid, makeItem('q-compact', 'ignored').createOpts);
+    await flush();
+
+    let projection = latestProjection(h.projections);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(projection.error).toBeNull();
+    expect(projection.recovery).toBeNull();
+
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'done');
+    await flush();
+
+    projection = latestProjection(h.projections);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: '/compact' });
+    expect(projection.recovery).toBeNull();
   });
 
   it('wakes queued turns after compact dispatch failure releases the active turn', async () => {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -772,7 +772,7 @@ export class AgentInputCoordinator {
         clientId: item.clientId,
       });
     }
-    this.abandonActiveTurnRecoveryForNewInput(state);
+    this.abandonActiveTurnRecoveryForUserAction(state);
     this.clearErrorUnlessQueueHeadBlocked(state);
     // 用户点「继续任务」表达的是恢复刚才中断/失败的 turn，必须先于此前
     // 已排队的新任务执行；普通 composer / Orca / scheduler 输入仍保持 FIFO。
@@ -817,6 +817,11 @@ export class AgentInputCoordinator {
 
   async compact(sessionId: string, createOpts: AgentInputCreateOpts, opts?: { userName?: string }): Promise<AgentInputProjection> {
     const state = this.getState(sessionId);
+    // 手动压缩与发送新消息一样,都是用户对失败 turn 的明确后续选择:
+    // 放弃 active-turn retry,让 /compact 在真实 dispatch boundary 空闲时立即执行,
+    // 仍忙时则进入 pendingCompacts。queue-head recovery 表示消息从未受理且仍在
+    // 队首,不能越过它静默改变顺序,继续保留原阻塞语义。
+    this.abandonActiveTurnRecoveryForUserAction(state);
     if (state.recovery) {
       log.info('compact ignored while dispatch boundary is busy', { sessionId });
       state.error = 'Cannot compact while the session is busy';
@@ -2470,7 +2475,7 @@ export class AgentInputCoordinator {
   private fallbackPreparedAsTurn(sessionId: string, item: AgentInputQueuedMessage, removeFromQueue: boolean): void {
     const state = this.getState(sessionId);
     // 插话回落成普通派发 = 也是一条新用户输入,同 enqueue 放弃 active-turn 重试。
-    this.abandonActiveTurnRecoveryForNewInput(state);
+    this.abandonActiveTurnRecoveryForUserAction(state);
     this.clearErrorUnlessQueueHeadBlocked(state, item.clientId);
     state.queuePaused = false;
     state.steeringQueueClientIds = state.steeringQueueClientIds.filter((id) => id !== item.clientId);
@@ -2563,12 +2568,14 @@ export class AgentInputCoordinator {
   }
 
   /**
-   * 新用户输入放弃 active-turn 重试入口(2026-07-13 Lizi 拍板)。错误的本质是
+   * 用户后续动作放弃 active-turn 重试入口。错误的本质是
    * "上一条消息执行失败了",用户此后**主动发出的新消息**(composer 发送 / 插话
    * 回落派发)就是对"要不要重试"的表态 —— 清掉错误横幅与重试入口,让新消息正常
    * 派发,不再默默排队等一个可能没被注意到的重试按钮。失败消息已落库、仍在会话
    * 里可手动重发;「重试」按钮与新输入赛跑时后到的 retryLastError 读到
    * recovery=null 即 no-op,无双发风险。
+   * 手动 compact 同样表达"先压缩而非重试上一轮":必须先清 recovery,再按真实
+   * dispatch boundary 决定立即派发或排队,否则上下文耗尽后的空闲会话会被误报 busy。
    *
    * 边界(刻意不收进来的入口):
    * - resume(继续队列)**不**放弃:Stop 中断留下的 recovery 可能是"已落库但从未
@@ -2582,7 +2589,7 @@ export class AgentInputCoordinator {
    * 新消息是对会话现状的明确表态,三类来源一视同仁(2026-07-13 拍板口径
    * "上一条消息失败了 → 新消息 = 不重试",Stop/派发失败同属"没执行成功")。
    */
-  private abandonActiveTurnRecoveryForNewInput(state: SessionInputState): void {
+  private abandonActiveTurnRecoveryForUserAction(state: SessionInputState): void {
     if (state.recovery?.kind !== 'active-turn') return;
     state.error = null;
     state.stickyError = null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

允许已接受的 turn 进入 active-turn recovery 后手动压缩上下文。会话空闲时立即压缩；dispatch boundary 确实仍忙时，将压缩请求排队到本轮结束后执行。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#934
- 本 PR 包含：Desktop 输入协调器中 recovery 与 compact 的状态顺序，以及对应回归测试。
- 明确不包含：Renderer UI、Mobile、协议、持久化和服务端改动。
- 用户可见变化：上一轮失败但会话已空闲时，可以手动压缩，不再被误报为 session busy。
- 是否存在 breaking change：无。

### UI 变化

不涉及：未修改 Renderer、视觉、布局、交互入口或 UI 文案。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
结果：175 项测试通过

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

未执行。使用内存 coordinator harness 分别覆盖会话空闲和 dispatch boundary 仍忙两种状态。

### 未执行的验证

未在运行中的 Desktop 实例复现；main 进程改动位于隔离 worktree，回归测试直接覆盖受影响的状态迁移。

## 风险

### 风险分类

- [x] 其他：低风险的 Desktop 输入状态顺序调整

### 影响与回滚

- 影响范围：仅 active-turn recovery 存在时发起的手动 compact。
- queue-head recovery 仍保持阻塞，不会跳过从未派发的消息。
- 移动端冷更判断：不触发；仅修改 Desktop TypeScript 和 Desktop 单测。
- 回滚方式：revert commit 78f8869e。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试和 typecheck 结果