### PR TITLE
feat(desktop): 自定义 Provider 模型支持 contextWindow 编辑与发现填充

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
@@ -201,6 +201,9 @@ describe('parseModelsListResponse contextWindow 提取(#386)', () => {
           { id: 'f', max_input_tokens: 200_000 },
           { id: 'd', context_length: -5 },
           { id: 'e' },
+          // 0 < v < 1 会通过 v > 0 但 Math.floor 取整成 0——按取整后的值校验
+          // 才不会漏这个区间(review P2)。
+          { id: 'g', context_length: 0.5 },
         ],
       }),
     ).toEqual([
@@ -210,6 +213,7 @@ describe('parseModelsListResponse contextWindow 提取(#386)', () => {
       { id: 'f', name: 'f', contextWindow: 200_000 },
       { id: 'd', name: 'd' },
       { id: 'e', name: 'e' },
+      { id: 'g', name: 'g' },
     ]);
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
@@ -204,6 +204,10 @@ describe('parseModelsListResponse contextWindow 提取(#386)', () => {
           // 0 < v < 1 会通过 v > 0 但 Math.floor 取整成 0——按取整后的值校验
           // 才不会漏这个区间(review P2)。
           { id: 'g', context_length: 0.5 },
+          // 超出安全整数范围的异常值同样要拒绝,否则落盘后 Main 的正数校验会
+          // 因超界拒绝整份供应商配置,内置 OAuth 发现分支则会把这个失真值当
+          // 真实窗口注入目录(review P2)。
+          { id: 'h', context_length: 1e20 },
         ],
       }),
     ).toEqual([
@@ -214,6 +218,7 @@ describe('parseModelsListResponse contextWindow 提取(#386)', () => {
       { id: 'd', name: 'd' },
       { id: 'e', name: 'e' },
       { id: 'g', name: 'g' },
+      { id: 'h', name: 'h' },
     ]);
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
@@ -190,13 +190,15 @@ describe('mergeDiscoveredModelsIntoConfig（发现结果持久化的 additions-o
 });
 
 describe('parseModelsListResponse contextWindow 提取(#386)', () => {
-  it('从 context_length / context_window / max_context_length 尽力提取,非法值缺省', () => {
+  it('从 context_length / context_window / max_context_length / max_input_tokens 尽力提取,非法值缺省', () => {
     expect(
       parseModelsListResponse({
         data: [
           { id: 'a', context_length: 1_048_576 },
           { id: 'b', name: 'B', context_window: 262144.9 },
           { id: 'c', max_context_length: 131072 },
+          // Anthropic 兼容端点的字段口径(与 model-discovery/anthropic.ts 对齐,review P1)。
+          { id: 'f', max_input_tokens: 200_000 },
           { id: 'd', context_length: -5 },
           { id: 'e' },
         ],
@@ -205,6 +207,7 @@ describe('parseModelsListResponse contextWindow 提取(#386)', () => {
       { id: 'a', name: 'a', contextWindow: 1_048_576 },
       { id: 'b', name: 'B', contextWindow: 262144 },
       { id: 'c', name: 'c', contextWindow: 131072 },
+      { id: 'f', name: 'f', contextWindow: 200_000 },
       { id: 'd', name: 'd' },
       { id: 'e', name: 'e' },
     ]);

--- a/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/customProviderOAuth.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from 'vitest';
 import { buildUserProvider, type CustomProviderConfig } from '@cindy/model-providers';
 
 import { mergeDiscoveredModelsIntoConfig, validateCustomProviderConfig } from '../custom-provider-store.js';
+import { parseModelsListResponse } from '../generic-oauth.js';
 import { createProviderService } from '../provider-service.js';
 
 const OAUTH = {
@@ -173,6 +174,44 @@ describe('mergeDiscoveredModelsIntoConfig（发现结果持久化的 additions-o
 
     expect(mergeDiscoveredModelsIntoConfig(BASE, 'claude-code', [{ id: 'm1', name: 'M1' }])).toBeNull();
     expect(mergeDiscoveredModelsIntoConfig(BASE, 'codex', [{ id: 'x', name: 'X' }])).toBeNull();
+  });
+
+  it('端点声明的 contextWindow 随发现落盘,非法值丢弃回落默认(#386)', () => {
+    const merged = mergeDiscoveredModelsIntoConfig(BASE, 'claude-code', [
+      { id: 'big', name: 'Big', contextWindow: 1_000_000 },
+      { id: 'bogus', name: 'Bogus', contextWindow: 0 },
+    ]);
+    expect(merged?.runtimes['claude-code']?.models).toEqual([
+      { id: 'm1', name: 'M1' },
+      { id: 'big', name: 'Big', contextWindow: 1_000_000 },
+      { id: 'bogus', name: 'Bogus' },
+    ]);
+  });
+});
+
+describe('parseModelsListResponse contextWindow 提取(#386)', () => {
+  it('从 context_length / context_window / max_context_length 尽力提取,非法值缺省', () => {
+    expect(
+      parseModelsListResponse({
+        data: [
+          { id: 'a', context_length: 1_048_576 },
+          { id: 'b', name: 'B', context_window: 262144.9 },
+          { id: 'c', max_context_length: 131072 },
+          { id: 'd', context_length: -5 },
+          { id: 'e' },
+        ],
+      }),
+    ).toEqual([
+      { id: 'a', name: 'a', contextWindow: 1_048_576 },
+      { id: 'b', name: 'B', contextWindow: 262144 },
+      { id: 'c', name: 'c', contextWindow: 131072 },
+      { id: 'd', name: 'd' },
+      { id: 'e', name: 'e' },
+    ]);
+  });
+
+  it('字符串数组形状不携带 contextWindow', () => {
+    expect(parseModelsListResponse({ models: ['m1'] })).toEqual([{ id: 'm1', name: 'm1' }]);
   });
 });
 

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -387,7 +387,7 @@ function normalizeConfig(config: CustomProviderConfig): CustomProviderConfig {
 export function mergeDiscoveredModelsIntoConfig(
   config: CustomProviderConfig,
   agent: AgentKind,
-  discovered: { id: string; name: string }[],
+  discovered: { id: string; name: string; contextWindow?: number }[],
 ): CustomProviderConfig | null {
   const rt = config.runtimes[agent];
   if (!rt) return null;
@@ -398,7 +398,20 @@ export function mergeDiscoveredModelsIntoConfig(
     ...config,
     runtimes: {
       ...config.runtimes,
-      [agent]: { ...rt, models: [...rt.models, ...fresh.map((m) => ({ id: m.id, name: m.name }))] },
+      [agent]: {
+        ...rt,
+        models: [
+          ...rt.models,
+          // 端点声明了上下文长度就随发现落盘,缺省则回落保守默认(#386)。
+          ...fresh.map((m) => ({
+            id: m.id,
+            name: m.name,
+            ...(typeof m.contextWindow === 'number' && Number.isFinite(m.contextWindow) && m.contextWindow > 0
+              ? { contextWindow: Math.floor(m.contextWindow) }
+              : {}),
+          })),
+        ],
+      },
     },
   };
 }

--- a/apps/desktop/src/main/maker-host/generic-oauth.ts
+++ b/apps/desktop/src/main/maker-host/generic-oauth.ts
@@ -831,11 +831,15 @@ export async function discoverGenericOAuthModels(
 
 /**
  * 解析 OpenAI / Anthropic「列模型」响应的三种形状（`{data:[{id}]}` / `{models:[{id}]}` /
- * 字符串数组）为去重后的 `{id, name}[]`；无法识别返回 null。显示名优先取条目的
- * `display_name`（Anthropic 形状）/ `name` 字段，缺省回退 id。
+ * 字符串数组）为去重后的 `{id, name, contextWindow?}[]`；无法识别返回 null。显示名优先取
+ * 条目的 `display_name`（Anthropic 形状）/ `name` 字段，缺省回退 id。
+ * contextWindow 尽力从常见字段读取（OpenRouter `context_length` / 通用 `context_window` /
+ * Moonshot 等 `max_context_length`），无或非法时缺省——缺省的模型仍会回落保守默认(#386)。
  * 纯函数——OAuth 自动发现（本模块）与 API key 表单「获取模型列表」（provider-model-fetch）共用。
  */
-export function parseModelsListResponse(json: unknown): { id: string; name: string }[] | null {
+export function parseModelsListResponse(
+  json: unknown,
+): { id: string; name: string; contextWindow?: number }[] | null {
   const list = (() => {
     if (!json || typeof json !== 'object') return null;
     const o = json as { data?: unknown; models?: unknown };
@@ -844,7 +848,7 @@ export function parseModelsListResponse(json: unknown): { id: string; name: stri
     return null;
   })();
   if (!list) return null;
-  const out: { id: string; name: string }[] = [];
+  const out: { id: string; name: string; contextWindow?: number }[] = [];
   const seen = new Set<string>();
   for (const item of list) {
     const id =
@@ -857,7 +861,13 @@ export function parseModelsListResponse(json: unknown): { id: string; name: stri
     seen.add(id);
     const rec =
       item && typeof item === 'object'
-        ? (item as { display_name?: unknown; name?: unknown })
+        ? (item as {
+            display_name?: unknown;
+            name?: unknown;
+            context_length?: unknown;
+            context_window?: unknown;
+            max_context_length?: unknown;
+          })
         : null;
     const name =
       rec && typeof rec.display_name === 'string' && rec.display_name.length > 0
@@ -865,7 +875,16 @@ export function parseModelsListResponse(json: unknown): { id: string; name: stri
         : rec && typeof rec.name === 'string' && rec.name.length > 0
           ? rec.name
           : id;
-    out.push({ id, name });
+    const rawWindow = rec
+      ? [rec.context_length, rec.context_window, rec.max_context_length].find(
+          (v) => typeof v === 'number' && Number.isFinite(v) && v > 0,
+        )
+      : undefined;
+    out.push({
+      id,
+      name,
+      ...(typeof rawWindow === 'number' ? { contextWindow: Math.floor(rawWindow) } : {}),
+    });
   }
   return out;
 }

--- a/apps/desktop/src/main/maker-host/generic-oauth.ts
+++ b/apps/desktop/src/main/maker-host/generic-oauth.ts
@@ -880,7 +880,10 @@ export function parseModelsListResponse(
           : id;
     const rawWindow = rec
       ? [rec.context_length, rec.context_window, rec.max_context_length, rec.max_input_tokens].find(
-          (v) => typeof v === 'number' && Number.isFinite(v) && v > 0,
+          // Math.floor(v) > 0 而非 v > 0:0 < v < 1(如 context_length: 0.5)会通过
+          // v > 0 但取整成 contextWindow: 0——按取整后的值校验才不会漏这个区间
+          // (review P2)。
+          (v) => typeof v === 'number' && Number.isFinite(v) && Math.floor(v) > 0,
         )
       : undefined;
     out.push({

--- a/apps/desktop/src/main/maker-host/generic-oauth.ts
+++ b/apps/desktop/src/main/maker-host/generic-oauth.ts
@@ -803,7 +803,7 @@ export async function discoverGenericOAuthModels(
   oauth: OAuthProviderDescriptor,
   discoveryUrl?: string,
   agent?: AgentKind,
-): Promise<{ id: string; name: string }[] | null> {
+): Promise<{ id: string; name: string; contextWindow?: number }[] | null> {
   const url = discoveryUrl ?? oauth.modelsDiscoveryUrl;
   if (!url) return null;
   const token = readCachedGenericOAuthAccessToken(providerId, oauth);

--- a/apps/desktop/src/main/maker-host/generic-oauth.ts
+++ b/apps/desktop/src/main/maker-host/generic-oauth.ts
@@ -882,8 +882,11 @@ export function parseModelsListResponse(
       ? [rec.context_length, rec.context_window, rec.max_context_length, rec.max_input_tokens].find(
           // Math.floor(v) > 0 而非 v > 0:0 < v < 1(如 context_length: 0.5)会通过
           // v > 0 但取整成 contextWindow: 0——按取整后的值校验才不会漏这个区间
-          // (review P2)。
-          (v) => typeof v === 'number' && Number.isFinite(v) && Math.floor(v) > 0,
+          // (review P2)。Number.isSafeInteger(Math.floor(v)) 拒绝超出安全整数范围的
+          // 异常值(如 context_length: 1e20)——这类值会通过取整后为正的校验,但落盘后
+          // Main 的正数校验反而会因为超界而拒绝整份供应商配置,内置 OAuth 发现分支则会
+          // 把这个失真值当真实窗口注入目录(review P2)。
+          (v) => typeof v === 'number' && Number.isFinite(v) && Math.floor(v) > 0 && Number.isSafeInteger(Math.floor(v)),
         )
       : undefined;
     out.push({

--- a/apps/desktop/src/main/maker-host/generic-oauth.ts
+++ b/apps/desktop/src/main/maker-host/generic-oauth.ts
@@ -834,7 +834,9 @@ export async function discoverGenericOAuthModels(
  * 字符串数组）为去重后的 `{id, name, contextWindow?}[]`；无法识别返回 null。显示名优先取
  * 条目的 `display_name`（Anthropic 形状）/ `name` 字段，缺省回退 id。
  * contextWindow 尽力从常见字段读取（OpenRouter `context_length` / 通用 `context_window` /
- * Moonshot 等 `max_context_length`），无或非法时缺省——缺省的模型仍会回落保守默认(#386)。
+ * Moonshot 等 `max_context_length` / Anthropic 兼容端点 `max_input_tokens`,与
+ * model-discovery/anthropic.ts 认的字段对齐），无或非法时缺省——缺省的模型仍会
+ * 回落保守默认(#386)。
  * 纯函数——OAuth 自动发现（本模块）与 API key 表单「获取模型列表」（provider-model-fetch）共用。
  */
 export function parseModelsListResponse(
@@ -867,6 +869,7 @@ export function parseModelsListResponse(
             context_length?: unknown;
             context_window?: unknown;
             max_context_length?: unknown;
+            max_input_tokens?: unknown;
           })
         : null;
     const name =
@@ -876,7 +879,7 @@ export function parseModelsListResponse(
           ? rec.name
           : id;
     const rawWindow = rec
-      ? [rec.context_length, rec.context_window, rec.max_context_length].find(
+      ? [rec.context_length, rec.context_window, rec.max_context_length, rec.max_input_tokens].find(
           (v) => typeof v === 'number' && Number.isFinite(v) && v > 0,
         )
       : undefined;

--- a/apps/desktop/src/main/maker-host/provider-model-fetch.ts
+++ b/apps/desktop/src/main/maker-host/provider-model-fetch.ts
@@ -48,8 +48,8 @@ export interface ProviderModelsFetchSpec {
 /** 结构化结果（查询型返回：renderer 需要 code 渲染分类文案，不走 throwIpcError）。 */
 export interface ProviderModelsFetchResult {
   ok: boolean;
-  /** 拉到的模型清单（ok=true 时给出；已按 id 去重）。 */
-  models?: { id: string; name: string }[];
+  /** 拉到的模型清单（ok=true 时给出；已按 id 去重;contextWindow 为端点声明的上下文长度,尽力提取）。 */
+  models?: { id: string; name: string; contextWindow?: number }[];
   /** 失败分类码（ok=false 时给出）。 */
   code?: ProviderErrorCode;
   /** HTTP 状态码（网络层失败时缺省）。 */

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3914,6 +3914,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                   // 端点上报的窗口值优先,缺省才落 200K 保守默认(review P1):
                   // 之前无条件写死 200K,发现的 1M 模型仍会显示并按 200K 压缩。
                   contextWindow: m.contextWindow ?? 200_000,
+                  // 只有端点真给了才算已核实,可以拿去收敛运行期上报窗口;落 200K
+                  // 兜底的不标记 —— 否则 resolveVerifiedContextWindow 会拒收缺失
+                  // 标记的条目,inflate 的运行期值压不下来(review P1)。
+                  ...(m.contextWindow !== undefined ? { contextWindowVerified: true } : {}),
                   efforts: [],
                   defaultEffort: null,
                   group: `custom:${providerId}`,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3876,7 +3876,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         // 自定义供应商的发现结果 additions-only 持久化进配置（重启后仍在）;内置供应商走
         // 内存 augment（静态目录 first-wins）。任何一步失败都只降级为纯静态,不影响登录结果。
         try {
-          const fetched = new Map<string, { id: string; name: string }[] | null>();
+          const fetched = new Map<
+            string,
+            { id: string; name: string; contextWindow?: number }[] | null
+          >();
           let customChanged = false;
           for (const agent of provider.agents) {
             if (!isCurrent()) break;
@@ -3908,7 +3911,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                 models.map((m) => ({
                   id: m.id,
                   name: m.name,
-                  contextWindow: 200_000,
+                  // 端点上报的窗口值优先,缺省才落 200K 保守默认(review P1):
+                  // 之前无条件写死 200K,发现的 1M 模型仍会显示并按 200K 压缩。
+                  contextWindow: m.contextWindow ?? 200_000,
                   efforts: [],
                   defaultEffort: null,
                   group: `custom:${providerId}`,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3969,7 +3969,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       headers?: Record<string, string>;
     }): Promise<{
       ok: boolean;
-      models?: { id: string; name: string }[];
+      models?: { id: string; name: string; contextWindow?: number }[];
       code?: import('../shared/providerErrors').ProviderErrorCode;
       status?: number;
       detail?: string;

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
@@ -110,6 +110,23 @@ const openCodePreset = {
   },
 };
 
+const dualDiscoveryPreset = {
+  id: 'dual-endpoints',
+  name: 'Dual Endpoints',
+  runtimes: {
+    'claude-code': {
+      baseUrl: 'https://dual.example/anthropic',
+      modelsUrl: 'https://dual.example/anthropic/v1/models',
+      models: [],
+    },
+    codex: {
+      baseUrl: 'https://dual.example/openai/v1',
+      modelsUrl: 'https://dual.example/openai/v1/models',
+      models: [],
+    },
+  },
+};
+
 function renderWizard(presetId: string) {
   return render(
     React.createElement(AddProviderWizard, {
@@ -131,6 +148,7 @@ beforeEach(() => {
           liteLlmPreset,
           unsafeNoAuthDiscoveryPreset,
           openCodePreset,
+          dualDiscoveryPreset,
         ],
       })),
       // 列模型失败场景兜底(Greptile P1 回归):官方 API 预设必须靠推荐模型仍可完成。
@@ -396,6 +414,41 @@ describe('AddProviderWizard — preset 直达', () => {
     const config = vi.mocked(createCustomProvider).mock.calls[0][0];
     expect(config.runtimes['claude-code']?.models).toEqual([
       expect.objectContaining({ id: 'deepseek-v4', contextWindow: 262_144 }),
+    ]);
+  });
+
+  it('双 runtime 各自端点发现同一模型不同窗口时按 runtime 分别入库(Codex P1 回归)', async () => {
+    // 同一 model id 在两端窗口可以不同(如 cc=1M / codex=272K):共享一个发现值
+    // 会让其中一端显示与压缩阈值双错,必须按 agent 分槽各取各的端点上报值。
+    vi.mocked(window.electronAPI.maker.fetchProviderModels).mockImplementation(
+      async ({ agent }: { agent: 'claude-code' | 'codex' }) => ({
+        ok: true,
+        models: [
+          {
+            id: 'shared-model',
+            name: 'Shared Model',
+            contextWindow: agent === 'claude-code' ? 1_000_000 : 272_000,
+          },
+        ],
+      }),
+    );
+    renderWizard('dual-endpoints');
+
+    await waitFor(() =>
+      expect(screen.getByText('settings.providers.wizard.nameLabel')).not.toBeNull(),
+    );
+    fireEvent.change(screen.getByPlaceholderText('sk-…'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByText('settings.providers.wizard.next'));
+    fireEvent.click(await screen.findByText('Shared Model'));
+    fireEvent.click(screen.getByText('settings.providers.wizard.finish'));
+
+    await waitFor(() => expect(createCustomProvider).toHaveBeenCalledTimes(1));
+    const config = vi.mocked(createCustomProvider).mock.calls[0][0];
+    expect(config.runtimes['claude-code']?.models).toEqual([
+      expect.objectContaining({ id: 'shared-model', contextWindow: 1_000_000 }),
+    ]);
+    expect(config.runtimes.codex?.models).toEqual([
+      expect.objectContaining({ id: 'shared-model', contextWindow: 272_000 }),
     ]);
   });
 

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
@@ -374,6 +374,31 @@ describe('AddProviderWizard — preset 直达', () => {
     expect(config.runtimes.codex?.models.map((model) => model.id)).toEqual(['glm-5.2']);
   });
 
+  it('拉取新增模型带端点上报的 contextWindow 入库(Codex P1 回归)', async () => {
+    // 预设未收录的发现模型没有预设窗口可回填:丢弃端点上报值会让它落 200K
+    // 默认,显示与压缩阈值双错——完成创建必须把发现值写进配置。
+    vi.mocked(window.electronAPI.maker.fetchProviderModels).mockResolvedValue({
+      ok: true,
+      models: [{ id: 'deepseek-v4', name: 'DeepSeek V4', contextWindow: 262_144 }],
+    });
+    renderWizard('deepseek');
+
+    await waitFor(() =>
+      expect(screen.getByText('settings.providers.wizard.nameLabel')).not.toBeNull(),
+    );
+    fireEvent.change(screen.getByPlaceholderText('sk-…'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByText('settings.providers.wizard.next'));
+    // 拉取新增模型默认不勾选,点选后完成。
+    fireEvent.click(await screen.findByText('DeepSeek V4'));
+    fireEvent.click(screen.getByText('settings.providers.wizard.finish'));
+
+    await waitFor(() => expect(createCustomProvider).toHaveBeenCalledTimes(1));
+    const config = vi.mocked(createCustomProvider).mock.calls[0][0];
+    expect(config.runtimes['claude-code']?.models).toEqual([
+      expect.objectContaining({ id: 'deepseek-v4', contextWindow: 262_144 }),
+    ]);
+  });
+
   it('LiteLLM:清空可编辑端点后不回退预设地址，也不能继续', async () => {
     renderWizard('litellm');
 

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -341,8 +341,9 @@ export function AddProviderWizard({
         checked: boolean;
         recommended: boolean;
         agents: AgentKind[];
-        /** 列模型端点上报的上下文窗口(拉取新增/回填);完成创建时预设值优先、本值兜底。 */
-        contextWindow?: number;
+        /** 列模型端点上报的上下文窗口,**按 agent 分槽**(同一 id 双端可不同,如
+         *  cc=1M / codex=272K);完成创建时按所属 runtime 取值,预设值优先、本值兜底。 */
+        contextWindows?: Partial<Record<AgentKind, number>>;
       }
     >
   >(new Map());
@@ -569,7 +570,7 @@ export function AddProviderWizard({
         checked: boolean;
         recommended: boolean;
         agents: AgentKind[];
-        contextWindow?: number;
+        contextWindows?: Partial<Record<AgentKind, number>>;
       }
     >();
     for (const agent of Object.keys(preset.runtimes) as AgentKind[]) {
@@ -658,15 +659,18 @@ export function AddProviderWizard({
               !preservePresetOwnership && !existing.agents.includes(agent)
                 ? [...existing.agents, agent]
                 : existing.agents;
-            // 端点上报的窗口只补空,不覆盖已有值(预设推荐模型的窗口在完成创建时
-            // 以预设为准,这里补的是「预设没写窗口」的兜底)。
+            // 端点上报的窗口按 agent 分槽、只补该槽的空(同一 id 双端窗口可以不同,
+            // 不能共享一个值;预设推荐模型的窗口在完成创建时以预设为准,这里补的是
+            // 「预设没写窗口」的兜底)。
             const backfillWindow =
-              existing.contextWindow === undefined && m.contextWindow !== undefined;
+              existing.contextWindows?.[agent] === undefined && m.contextWindow !== undefined;
             if (mergedAgents !== existing.agents || backfillWindow) {
               next.set(m.id, {
                 ...existing,
                 agents: mergedAgents,
-                ...(backfillWindow ? { contextWindow: m.contextWindow } : {}),
+                ...(backfillWindow
+                  ? { contextWindows: { ...existing.contextWindows, [agent]: m.contextWindow } }
+                  : {}),
               });
             }
           } else if (!preservePresetOwnership) {
@@ -675,7 +679,9 @@ export function AddProviderWizard({
               checked: false,
               recommended: false,
               agents: [agent],
-              ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+              ...(m.contextWindow !== undefined
+                ? { contextWindows: { [agent]: m.contextWindow } }
+                : {}),
             });
           }
         }
@@ -762,7 +768,7 @@ export function AddProviderWizard({
     const preset = sel.preset;
     const selected = [...picks.entries()]
       .filter(([, v]) => v.checked)
-      .map(([id, v]) => ({ id, name: v.name, agents: v.agents, contextWindow: v.contextWindow }));
+      .map(([id, v]) => ({ id, name: v.name, agents: v.agents, contextWindows: v.contextWindows }));
     if (selected.length === 0) {
       toast.error(t('settings.providers.wizard.noModelSelected'));
       return;
@@ -785,9 +791,9 @@ export function AddProviderWizard({
           .filter((m) => m.agents.includes(agent))
           .map((m) => {
             const presetModel = rt.models.find((candidate) => candidate.id === m.id);
-            // 预设策展值优先;拉取新增模型没有预设条目,落端点上报的发现值,
-            // 不再无窗口入库退回 200K 默认。
-            const contextWindow = presetModel?.contextWindow ?? m.contextWindow;
+            // 预设策展值优先;拉取新增模型没有预设条目,落**该 runtime 端点**上报的
+            // 发现值(按 agent 分槽,双端窗口可不同),不再无窗口入库退回 200K 默认。
+            const contextWindow = presetModel?.contextWindow ?? m.contextWindows?.[agent];
             return {
               id: m.id,
               name: m.name,

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -334,7 +334,17 @@ export function AddProviderWizard({
    * 每个 runtime(双 runtime 预设两端模型集可以不同,cc-only 模型不能写进 codex,反之亦然)。
    */
   const [picks, setPicks] = useState<
-    Map<string, { name: string; checked: boolean; recommended: boolean; agents: AgentKind[] }>
+    Map<
+      string,
+      {
+        name: string;
+        checked: boolean;
+        recommended: boolean;
+        agents: AgentKind[];
+        /** 列模型端点上报的上下文窗口(拉取新增/回填);完成创建时预设值优先、本值兜底。 */
+        contextWindow?: number;
+      }
+    >
   >(new Map());
 
   useEffect(() => {
@@ -554,7 +564,13 @@ export function AddProviderWizard({
     // 预设推荐模型先入清单(预勾);归属 = 预设里列出该模型的全部 runtime。
     const initial = new Map<
       string,
-      { name: string; checked: boolean; recommended: boolean; agents: AgentKind[] }
+      {
+        name: string;
+        checked: boolean;
+        recommended: boolean;
+        agents: AgentKind[];
+        contextWindow?: number;
+      }
     >();
     for (const agent of Object.keys(preset.runtimes) as AgentKind[]) {
       for (const m of preset.runtimes[agent]?.models ?? []) {
@@ -601,7 +617,13 @@ export function AddProviderWizard({
     const results = await Promise.all(
       agents.map(async (agent) => {
         const rt = preset.runtimes[agent];
-        if (!rt) return { agent, ok: false, models: [] as { id: string; name: string }[] };
+        if (!rt) {
+          return {
+            agent,
+            ok: false,
+            models: [] as { id: string; name: string; contextWindow?: number }[],
+          };
+        }
         try {
           const r = await window.electronAPI.maker.fetchProviderModels({
             agent,
@@ -614,7 +636,11 @@ export function AddProviderWizard({
           });
           return { agent, ok: !!(r.ok && r.models), models: r.models ?? [] };
         } catch {
-          return { agent, ok: false, models: [] as { id: string; name: string }[] };
+          return {
+            agent,
+            ok: false,
+            models: [] as { id: string; name: string; contextWindow?: number }[],
+          };
         }
       }),
     );
@@ -628,11 +654,29 @@ export function AddProviderWizard({
         for (const m of models) {
           const existing = next.get(m.id);
           if (existing) {
-            if (!preservePresetOwnership && !existing.agents.includes(agent)) {
-              next.set(m.id, { ...existing, agents: [...existing.agents, agent] });
+            const mergedAgents =
+              !preservePresetOwnership && !existing.agents.includes(agent)
+                ? [...existing.agents, agent]
+                : existing.agents;
+            // 端点上报的窗口只补空,不覆盖已有值(预设推荐模型的窗口在完成创建时
+            // 以预设为准,这里补的是「预设没写窗口」的兜底)。
+            const backfillWindow =
+              existing.contextWindow === undefined && m.contextWindow !== undefined;
+            if (mergedAgents !== existing.agents || backfillWindow) {
+              next.set(m.id, {
+                ...existing,
+                agents: mergedAgents,
+                ...(backfillWindow ? { contextWindow: m.contextWindow } : {}),
+              });
             }
           } else if (!preservePresetOwnership) {
-            next.set(m.id, { name: m.name, checked: false, recommended: false, agents: [agent] });
+            next.set(m.id, {
+              name: m.name,
+              checked: false,
+              recommended: false,
+              agents: [agent],
+              ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+            });
           }
         }
       }
@@ -718,7 +762,7 @@ export function AddProviderWizard({
     const preset = sel.preset;
     const selected = [...picks.entries()]
       .filter(([, v]) => v.checked)
-      .map(([id, v]) => ({ id, name: v.name, agents: v.agents }));
+      .map(([id, v]) => ({ id, name: v.name, agents: v.agents, contextWindow: v.contextWindow }));
     if (selected.length === 0) {
       toast.error(t('settings.providers.wizard.noModelSelected'));
       return;
@@ -741,12 +785,13 @@ export function AddProviderWizard({
           .filter((m) => m.agents.includes(agent))
           .map((m) => {
             const presetModel = rt.models.find((candidate) => candidate.id === m.id);
+            // 预设策展值优先;拉取新增模型没有预设条目,落端点上报的发现值,
+            // 不再无窗口入库退回 200K 默认。
+            const contextWindow = presetModel?.contextWindow ?? m.contextWindow;
             return {
               id: m.id,
               name: m.name,
-              ...(presetModel?.contextWindow !== undefined
-                ? { contextWindow: presetModel.contextWindow }
-                : {}),
+              ...(contextWindow !== undefined ? { contextWindow } : {}),
             };
           });
         if (agentModels.length === 0) continue;

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -163,12 +163,14 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
 function TextInput({
   value,
   onChange,
+  onBlur,
   placeholder,
   type = 'text',
   trailing,
 }: {
   value: string;
   onChange: (v: string) => void;
+  onBlur?: () => void;
   placeholder?: string;
   type?: string;
   trailing?: React.ReactNode;
@@ -179,6 +181,7 @@ function TextInput({
         type={type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
         placeholder={placeholder}
         className={cn(
           'h-[40px] w-full rounded-[10px] pl-[12px] text-14 outline-none transition-colors',
@@ -335,6 +338,11 @@ export function CustomProviderDialog({
   });
   // OAuth 模式下模型 / 请求头收进默认折叠的「高级配置」——模型授权后自动发现,普通用户无需碰。
   const [showAdvanced, setShowAdvanced] = useState(false);
+  // 上下文窗口输入的行级草稿:受控输入若只回显已提交值,逐字符键入 `1,` 这类
+  // 合法中间态会被整体校验拒绝后回滚,声明支持的分组格式只能粘贴、无法键入
+  // (review P1)。草稿承载显示文本;合法完整值仍即时提交,失焦丢弃未提交
+  // 草稿回落已提交值。key = `agent:行号`,行增删后索引漂移,统一清空。
+  const [windowDrafts, setWindowDrafts] = useState<Record<string, string>>({});
   // 预设模板（仅新建态展示；目录 presets 段，随 OSS 热更）。
   const [presets, setPresets] = useState<ProviderPreset[]>([]);
   const [appliedPreset, setAppliedPreset] = useState<string | null>(null);
@@ -1235,8 +1243,19 @@ export function CustomProviderDialog({
                             拒绝本次变更(保持原值)——绝不剥字符再拼数字,-5 / 1e6 /
                             262144.9 这类输入不得被静默纠正成另一个合法值(review P1)。 */}
                         <TextInput
-                          value={m.contextWindow != null ? String(m.contextWindow) : ''}
-                          onChange={(v) =>
+                          value={
+                            windowDrafts[`${activeTab}:${i}`]
+                            ?? (m.contextWindow != null ? String(m.contextWindow) : '')
+                          }
+                          onBlur={() =>
+                            setWindowDrafts((drafts) => {
+                              if (!(`${activeTab}:${i}` in drafts)) return drafts;
+                              const { [`${activeTab}:${i}`]: _drop, ...rest } = drafts;
+                              return rest;
+                            })
+                          }
+                          onChange={(v) => {
+                            setWindowDrafts((drafts) => ({ ...drafts, [`${activeTab}:${i}`]: v }));
                             patch(activeTab, (x) => ({
                               ...x,
                               models: x.models.map((y, j) => {
@@ -1259,8 +1278,8 @@ export function CustomProviderDialog({
                                 }
                                 return { ...y, contextWindow: Number(parsed) };
                               }),
-                            }))
-                          }
+                            }));
+                          }}
                           placeholder={t(
                             'settings.providers.custom.fields.modelContextWindowPlaceholder',
                           )}
@@ -1268,12 +1287,13 @@ export function CustomProviderDialog({
                       </div>
                       <button
                         type="button"
-                        onClick={() =>
+                        onClick={() => {
+                          setWindowDrafts({});
                           patch(activeTab, (x) => ({
                             ...x,
                             models: x.models.filter((_, j) => j !== i),
-                          }))
-                        }
+                          }));
+                        }}
                         className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-hover)]"
                         aria-label={t('settings.providers.custom.fields.removeRow')}
                       >
@@ -1283,12 +1303,13 @@ export function CustomProviderDialog({
                   ))}
                   <button
                     type="button"
-                    onClick={() =>
+                    onClick={() => {
+                      setWindowDrafts({});
                       patch(activeTab, (x) => ({
                         ...x,
                         models: [...x.models, { id: '', name: '' }],
-                      }))
-                    }
+                      }));
+                    }}
                     className="flex items-center gap-1.5 self-start py-0.5 text-13 font-medium text-[var(--settings-section-title)]"
                   >
                     <Plus size={14} className="text-[var(--settings-section-desc)]" />

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -1269,7 +1269,13 @@ export function CustomProviderDialog({
                           }
                           onBlur={() =>
                             setWindowDrafts((drafts) => {
-                              if (!(`${activeTab}:${i}` in drafts)) return drafts;
+                              const draftText = drafts[`${activeTab}:${i}`];
+                              // 只清可提交草稿(显示回落到已提交规范值);不可提交
+                              // 草稿必须保留——输入框失焦先于保存按钮 click,清掉
+                              // 会让保存守卫看不到非法文本、静默存旧值(review P1)。
+                              if (draftText === undefined || !isCommittableWindowText(draftText)) {
+                                return drafts;
+                              }
                               const { [`${activeTab}:${i}`]: _drop, ...rest } = drafts;
                               return rest;
                             })

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -709,6 +709,11 @@ export function CustomProviderDialog({
     mergedModels.forEach((m, i) => {
       if (!newIndexById.has(m.id)) newIndexById.set(m.id, i);
     });
+    // 每个新行号只认领一次:空 id(未填完的手填行)没有稳定身份可追踪,直接丢弃
+    // 草稿(该行本就会在保存时因 id/name 为空被过滤掉);多条旧行共享同一个非空 id
+    // 时(picker 合并对重复 id 本就只保留第一条落进 merged),只让第一条旧草稿
+    // 认领对应新行,避免后一行的草稿被错配、顶替掉别的模型的草稿(review P1)。
+    const claimedNewIndices = new Set<number>();
     setWindowDrafts((drafts) => {
       const next: Record<string, string> = {};
       for (const [key, text] of Object.entries(drafts)) {
@@ -721,8 +726,11 @@ export function CustomProviderDialog({
         // 仍保留的行(id 未变)把草稿迁到新行号;被 picker 移出的行(取消勾选)
         // 丢弃草稿——不合法草稿只应因它对应的行真的消失才清除。
         const id = oldIndexToId.get(Number(key.slice(sep + 1)));
-        const newIdx = id !== undefined ? newIndexById.get(id) : undefined;
-        if (newIdx !== undefined) next[`${agent}:${newIdx}`] = text;
+        if (!id) continue;
+        const newIdx = newIndexById.get(id);
+        if (newIdx === undefined || claimedNewIndices.has(newIdx)) continue;
+        claimedNewIndices.add(newIdx);
+        next[`${agent}:${newIdx}`] = text;
       }
       return next;
     });
@@ -741,8 +749,20 @@ export function CustomProviderDialog({
     // 改掉用户显式输入(review P1 ×2)。定位到首个问题 tab 并报错拦下。
     for (const [draftKey, draftText] of Object.entries(windowDrafts)) {
       if (isCommittableWindowText(draftText)) continue;
-      const draftAgent = draftKey.split(':')[0] as AgentKind;
-      if (VISIBLE_AGENTS.includes(draftAgent)) setActiveTab(draftAgent);
+      const sep = draftKey.lastIndexOf(':');
+      const draftAgent = draftKey.slice(0, sep) as AgentKind;
+      if (!VISIBLE_AGENTS.includes(draftAgent)) continue;
+      // 该 runtime 未配置 baseUrl、或该行 id/name 为空:两者都会在下面序列化时
+      // 被丢弃,不会写进最终配置,草稿再非法也不该挡住一个原本有效的保存
+      // (review P1)。
+      const rf = rt[draftAgent];
+      if (!rf.baseUrl.trim()) continue;
+      const row = rf.models[Number(draftKey.slice(sep + 1))];
+      if (!row || !row.id.trim() || !row.name.trim()) continue;
+      setActiveTab(draftAgent);
+      // OAuth 鉴权模式下模型列表(含窗口输入)折在「高级」里;不展开的话用户看不到
+      // 需要修的这个输入框,报错后无从下手,只能瞎猜着点开(review P1)。
+      if (authMode === 'oauth' && !showAdvanced) setShowAdvanced(true);
       toast.error(t('settings.providers.custom.errors.contextWindowInvalid'));
       return;
     }
@@ -919,6 +939,7 @@ export function CustomProviderDialog({
     existingIds,
     onSaved,
     windowDrafts,
+    showAdvanced,
     t,
   ]);
 

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -1249,11 +1249,15 @@ export function CustomProviderDialog({
                                 // 分隔符只允许单个、且夹在数字组之间:`1,,2` / `1_ 2` /
                                 // 尾随分隔符等无效位置不得被剥掉后当 `12` 保存(review P1)。
                                 if (!/^[0-9]+(?:[,_ ][0-9]+)*$/.test(trimmed)) return y;
-                                const parsed = Number.parseInt(trimmed.replace(/[,_ ]/g, ''), 10);
-                                // isSafeInteger:超出安全整数会被 parseInt 静默舍入,
-                                // 落盘值与用户输入不一致(review P1)。
-                                if (!Number.isSafeInteger(parsed) || parsed <= 0) return y;
-                                return { ...y, contextWindow: parsed };
+                                // BigInt 精确校验上界:parseInt 会把超安全整数先舍入
+                                // (9007199254740993 → …992)再通过 isSafeInteger,落盘值
+                                // 与用户输入不一致(review P1);正则已保证纯数字,BigInt
+                                // 不会抛。
+                                const parsed = BigInt(trimmed.replace(/[,_ ]/g, ''));
+                                if (parsed <= 0n || parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
+                                  return y;
+                                }
+                                return { ...y, contextWindow: Number(parsed) };
                               }),
                             }))
                           }

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -662,6 +662,12 @@ export function CustomProviderDialog({
     const chosen = picker.models.filter((m) => picker.selected.has(m.id));
     if (chosen.length === 0) return;
     const pickerIds = new Set(picker.models.map((m) => m.id));
+    // 重映射靠 id 而不是行号:picker 确认会任意增删/重排该 runtime 的行,旧行号
+    // 不能直接套到新数组。rtRef 是 setRtSynced 在状态计算的同一刻同步镜像的最新
+    // 值(见上方注释),patch() 调用后立即读取即可拿到刚提交的 merged 数组,不必
+    // 在 patch 外重复一遍合并逻辑(review P1:全量清空会连还在编辑、仍保留的行
+    // 一并清掉)。
+    const previousModels = rtRef.current[picker.agent].models;
     patch(picker.agent, (x) => {
       const latestById = new Map<string, ModelRow>();
       for (const m of x.models) {
@@ -692,14 +698,26 @@ export function CustomProviderDialog({
       }
       return { ...x, models: merged };
     });
-    // picker 重写该 runtime 的整个 models 数组(勾选/取消勾选可任意增删重排),
-    // 旧行号不可用简单映射对应新行——按 agent 整体清空该 runtime 的窗口草稿,
-    // 不留指向已不存在的行的陈旧非法草稿(否则会一直挡住保存、toast 报错却
-    // 找不到对应输入框,见 review P1)。
+    const mergedModels = rtRef.current[picker.agent].models;
+    const oldIndexToId = new Map(previousModels.map((m, i) => [i, m.id.trim()]));
+    const newIndexById = new Map<string, number>();
+    mergedModels.forEach((m, i) => {
+      if (!newIndexById.has(m.id)) newIndexById.set(m.id, i);
+    });
     setWindowDrafts((drafts) => {
       const next: Record<string, string> = {};
       for (const [key, text] of Object.entries(drafts)) {
-        if (!key.startsWith(`${picker.agent}:`)) next[key] = text;
+        const sep = key.lastIndexOf(':');
+        const agent = key.slice(0, sep);
+        if (agent !== picker.agent) {
+          next[key] = text;
+          continue;
+        }
+        // 仍保留的行(id 未变)把草稿迁到新行号;被 picker 移出的行(取消勾选)
+        // 丢弃草稿——不合法草稿只应因它对应的行真的消失才清除。
+        const id = oldIndexToId.get(Number(key.slice(sep + 1)));
+        const newIdx = id !== undefined ? newIndexById.get(id) : undefined;
+        if (newIdx !== undefined) next[`${agent}:${newIdx}`] = text;
       }
       return next;
     });

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -692,6 +692,17 @@ export function CustomProviderDialog({
       }
       return { ...x, models: merged };
     });
+    // picker 重写该 runtime 的整个 models 数组(勾选/取消勾选可任意增删重排),
+    // 旧行号不可用简单映射对应新行——按 agent 整体清空该 runtime 的窗口草稿,
+    // 不留指向已不存在的行的陈旧非法草稿(否则会一直挡住保存、toast 报错却
+    // 找不到对应输入框,见 review P1)。
+    setWindowDrafts((drafts) => {
+      const next: Record<string, string> = {};
+      for (const [key, text] of Object.entries(drafts)) {
+        if (!key.startsWith(`${picker.agent}:`)) next[key] = text;
+      }
+      return next;
+    });
     setPicker(null);
   }, [picker, patch]);
 

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -601,10 +601,13 @@ export function CustomProviderDialog({
             .map((m) => ({ ...m, name: m.name || m.id })),
           ...result.models.map((m) => {
             const cur = currentById.get(m.id);
+            // contextWindow:用户已填的优先;新模型带上端点声明的发现值(review P1:
+            // 只从 cur 拷会把发现值丢掉,保存后又回落 200K)。
+            const contextWindow = cur?.contextWindow ?? m.contextWindow;
             return {
               id: m.id,
               name: cur?.name || m.name,
-              ...(cur?.contextWindow !== undefined ? { contextWindow: cur.contextWindow } : {}),
+              ...(contextWindow !== undefined ? { contextWindow } : {}),
               ...(cur?.defaultEnabled === false ? { defaultEnabled: false } : {}),
             };
           }),
@@ -1226,8 +1229,10 @@ export function CustomProviderDialog({
                         className="w-28 shrink-0"
                         title={t('settings.providers.custom.fields.modelContextWindowTitle')}
                       >
-                        {/* 上下文窗口(tokens):留空 = 保守默认 200K(#386)。只收数字;
-                            非法输入不落盘,交给 buildUserProvider 回落默认。 */}
+                        {/* 上下文窗口(tokens):留空 = 保守默认 200K(#386)。整体校验:
+                            只接受正整数(允许逗号/下划线/空格做分隔),其它字符直接
+                            拒绝本次变更(保持原值)——绝不剥字符再拼数字,-5 / 1e6 /
+                            262144.9 这类输入不得被静默纠正成另一个合法值(review P1)。 */}
                         <TextInput
                           value={m.contextWindow != null ? String(m.contextWindow) : ''}
                           onChange={(v) =>
@@ -1235,12 +1240,15 @@ export function CustomProviderDialog({
                               ...x,
                               models: x.models.map((y, j) => {
                                 if (j !== i) return y;
-                                const digits = v.replace(/[^0-9]/g, '');
-                                const parsed = digits ? Number.parseInt(digits, 10) : NaN;
-                                const { contextWindow: _drop, ...rest } = y;
-                                return Number.isFinite(parsed) && parsed > 0
-                                  ? { ...rest, contextWindow: parsed }
-                                  : rest;
+                                const trimmed = v.trim();
+                                if (trimmed === '') {
+                                  const { contextWindow: _drop, ...rest } = y;
+                                  return rest;
+                                }
+                                if (!/^[0-9][0-9,_ ]*$/.test(trimmed)) return y;
+                                const parsed = Number.parseInt(trimmed.replace(/[,_ ]/g, ''), 10);
+                                if (!Number.isFinite(parsed) || parsed <= 0) return y;
+                                return { ...y, contextWindow: parsed };
                               }),
                             }))
                           }

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -193,7 +193,8 @@ function TextInput({
         onBlur={onBlur}
         placeholder={placeholder}
         className={cn(
-          'h-[40px] w-full rounded-[10px] pl-[12px] text-14 outline-none transition-colors',
+          // 单行输入按设计规范走药丸圆角(DESIGN.md §4-5:9999px,明令禁止 10px)。
+          'h-[40px] w-full rounded-full pl-[12px] text-14 outline-none transition-colors',
           trailing ? 'pr-9' : 'pr-[12px]',
           'text-[var(--settings-input-text)] placeholder:text-[var(--settings-input-placeholder)]',
           'border border-[var(--settings-input-border)] bg-[var(--settings-input-bg)] focus:border-[var(--settings-input-border-focus)]',
@@ -349,8 +350,8 @@ export function CustomProviderDialog({
   const [showAdvanced, setShowAdvanced] = useState(false);
   // 上下文窗口输入的行级草稿:受控输入若只回显已提交值,逐字符键入 `1,` 这类
   // 合法中间态会被整体校验拒绝后回滚,声明支持的分组格式只能粘贴、无法键入
-  // (review P1)。草稿承载显示文本;合法完整值仍即时提交,失焦丢弃未提交
-  // 草稿回落已提交值。key = `agent:行号`,行增删后索引漂移,统一清空。
+  // (review P1)。草稿承载显示文本;合法完整值仍即时提交,失焦只清可提交
+  // 草稿。key = `agent:行号`;删行时只重映射该 runtime 的行号,别行草稿保留。
   const [windowDrafts, setWindowDrafts] = useState<Record<string, string>>({});
   // 预设模板（仅新建态展示；目录 presets 段，随 OSS 热更）。
   const [presets, setPresets] = useState<ProviderPreset[]>([]);
@@ -1310,7 +1311,26 @@ export function CustomProviderDialog({
                       <button
                         type="button"
                         onClick={() => {
-                          setWindowDrafts({});
+                          // 只重映射受影响 runtime 的草稿键(删行后同 tab 后续行号
+                          // 前移),其它行/另一 runtime 的未提交草稿必须原样保留——
+                          // 全量清空会让保存守卫看不到别行的非法文本而静默存旧值
+                          // (review P1)。
+                          setWindowDrafts((drafts) => {
+                            const next: Record<string, string> = {};
+                            for (const [key, text] of Object.entries(drafts)) {
+                              const sep = key.lastIndexOf(':');
+                              const agent = key.slice(0, sep);
+                              const idx = Number(key.slice(sep + 1));
+                              if (agent !== activeTab) {
+                                next[key] = text;
+                              } else if (idx < i) {
+                                next[key] = text;
+                              } else if (idx > i) {
+                                next[`${agent}:${idx - 1}`] = text;
+                              }
+                            }
+                            return next;
+                          });
                           patch(activeTab, (x) => ({
                             ...x,
                             models: x.models.filter((_, j) => j !== i),
@@ -1325,13 +1345,13 @@ export function CustomProviderDialog({
                   ))}
                   <button
                     type="button"
-                    onClick={() => {
-                      setWindowDrafts({});
+                    onClick={() =>
+                      // 追加在末尾不移动既有行号,别行草稿无需动(review P1)。
                       patch(activeTab, (x) => ({
                         ...x,
                         models: [...x.models, { id: '', name: '' }],
-                      }));
-                    }}
+                      }))
+                    }
                     className="flex items-center gap-1.5 self-start py-0.5 text-13 font-medium text-[var(--settings-section-title)]"
                   >
                     <Plus size={14} className="text-[var(--settings-section-desc)]" />

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -668,51 +668,50 @@ export function CustomProviderDialog({
     if (chosen.length === 0) return;
     const pickerIds = new Set(picker.models.map((m) => m.id));
     // 重映射靠 id 而不是行号:picker 确认会任意增删/重排该 runtime 的行,旧行号
-    // 不能直接套到新数组。rtRef 是 setRtSynced 在状态计算的同一刻同步镜像的最新
-    // 值(见上方注释),patch() 调用后立即读取即可拿到刚提交的 merged 数组,不必
-    // 在 patch 外重复一遍合并逻辑(review P1:全量清空会连还在编辑、仍保留的行
-    // 一并清掉)。
+    // 不能直接套到新数组。合并结果必须同步算出一份普通数组,同时喂给状态更新和
+    // 草稿重映射——不能指望 patch() 调用后立即读 rtRef 拿到刚提交的值:rtRef 只
+    // 在 setRtSynced 传给 setRt 的函数式 updater**内部**才写,而 React 不保证这个
+    // updater 会在 setRt() 调用后的下一行同步跑完;picker 移除/重排行、且 setRt
+    // 已有排队工作时,这次读到的可能仍是 previousModels,导致草稿按旧下标错配到
+    // 一个已经不存在的行上(review P1)。
     const previousModels = rtRef.current[picker.agent].models;
-    patch(picker.agent, (x) => {
-      const latestById = new Map<string, ModelRow>();
-      for (const m of x.models) {
-        const id = m.id.trim();
-        if (id && !latestById.has(id)) latestById.set(id, m);
-      }
-      const merged: ModelRow[] = chosen.map((m) => {
-        const latest = latestById.get(m.id);
-        const contextWindow = latest?.contextWindow ?? m.contextWindow;
-        const defaultEnabled = latest?.defaultEnabled ?? m.defaultEnabled;
-        return {
-          id: m.id,
-          name: latest?.name.trim() ? latest.name.trim() : m.name,
-          ...(contextWindow !== undefined ? { contextWindow } : {}),
-          ...(defaultEnabled === false ? { defaultEnabled: false } : {}),
-        };
-      });
-      for (const m of x.models) {
-        const id = m.id.trim();
-        if (id && !pickerIds.has(id) && !merged.some((r) => r.id === id)) {
-          merged.push({
-            id,
-            name: m.name.trim() || id,
-            ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
-            ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
-          });
-        }
-      }
-      return { ...x, models: merged };
+    const latestById = new Map<string, ModelRow>();
+    for (const pm of previousModels) {
+      const id = pm.id.trim();
+      if (id && !latestById.has(id)) latestById.set(id, pm);
+    }
+    const merged: ModelRow[] = chosen.map((m) => {
+      const latest = latestById.get(m.id);
+      const contextWindow = latest?.contextWindow ?? m.contextWindow;
+      const defaultEnabled = latest?.defaultEnabled ?? m.defaultEnabled;
+      return {
+        id: m.id,
+        name: latest?.name.trim() ? latest.name.trim() : m.name,
+        ...(contextWindow !== undefined ? { contextWindow } : {}),
+        ...(defaultEnabled === false ? { defaultEnabled: false } : {}),
+      };
     });
-    const mergedModels = rtRef.current[picker.agent].models;
+    for (const m of previousModels) {
+      const id = m.id.trim();
+      if (id && !pickerIds.has(id) && !merged.some((r) => r.id === id)) {
+        merged.push({
+          id,
+          name: m.name.trim() || id,
+          ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+          ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
+        });
+      }
+    }
+    patch(picker.agent, (x) => ({ ...x, models: merged }));
     const oldIndexToId = new Map(previousModels.map((m, i) => [i, m.id.trim()]));
     const newIndexById = new Map<string, number>();
-    mergedModels.forEach((m, i) => {
+    merged.forEach((m, i) => {
       if (!newIndexById.has(m.id)) newIndexById.set(m.id, i);
     });
     // 合并逻辑(上面的 latestById / 第二个 for 循环)对重复 id 都是「先遇到的旧行
-    // 赢」——按 x.models(= previousModels)的原始顺序扫到的第一条。存活进 merged
-    // 的就是那一条,不是随便哪条同 id 旧行。草稿重映射必须认准同一条,否则会把
-    // 已被丢弃的重复行的草稿错配到存活行上(review P1 ×2)。
+    // 赢」——按 previousModels 的原始顺序扫到的第一条。存活进 merged 的就是那
+    // 一条,不是随便哪条同 id 旧行。草稿重映射必须认准同一条,否则会把已被丢弃的
+    // 重复行的草稿错配到存活行上(review P1 ×2)。
     const survivingOldIndexById = new Map<string, number>();
     previousModels.forEach((m, i) => {
       const id = m.id.trim();

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -709,11 +709,15 @@ export function CustomProviderDialog({
     mergedModels.forEach((m, i) => {
       if (!newIndexById.has(m.id)) newIndexById.set(m.id, i);
     });
-    // 每个新行号只认领一次:空 id(未填完的手填行)没有稳定身份可追踪,直接丢弃
-    // 草稿(该行本就会在保存时因 id/name 为空被过滤掉);多条旧行共享同一个非空 id
-    // 时(picker 合并对重复 id 本就只保留第一条落进 merged),只让第一条旧草稿
-    // 认领对应新行,避免后一行的草稿被错配、顶替掉别的模型的草稿(review P1)。
-    const claimedNewIndices = new Set<number>();
+    // 合并逻辑(上面的 latestById / 第二个 for 循环)对重复 id 都是「先遇到的旧行
+    // 赢」——按 x.models(= previousModels)的原始顺序扫到的第一条。存活进 merged
+    // 的就是那一条,不是随便哪条同 id 旧行。草稿重映射必须认准同一条,否则会把
+    // 已被丢弃的重复行的草稿错配到存活行上(review P1 ×2)。
+    const survivingOldIndexById = new Map<string, number>();
+    previousModels.forEach((m, i) => {
+      const id = m.id.trim();
+      if (id && !survivingOldIndexById.has(id)) survivingOldIndexById.set(id, i);
+    });
     setWindowDrafts((drafts) => {
       const next: Record<string, string> = {};
       for (const [key, text] of Object.entries(drafts)) {
@@ -725,11 +729,14 @@ export function CustomProviderDialog({
         }
         // 仍保留的行(id 未变)把草稿迁到新行号;被 picker 移出的行(取消勾选)
         // 丢弃草稿——不合法草稿只应因它对应的行真的消失才清除。
-        const id = oldIndexToId.get(Number(key.slice(sep + 1)));
-        if (!id) continue;
+        const oldIdx = Number(key.slice(sep + 1));
+        const id = oldIndexToId.get(oldIdx);
+        // 空 id(未填完的手填行)没有稳定身份可追踪,直接丢弃;非空 id 只有
+        // 「合并时实际存活的那条旧行」的草稿才允许迁移——同 id 的其它旧行本就
+        // 在合并时被丢弃,它们的草稿也该丢弃,不能顶替到存活行上。
+        if (!id || survivingOldIndexById.get(id) !== oldIdx) continue;
         const newIdx = newIndexById.get(id);
-        if (newIdx === undefined || claimedNewIndices.has(newIdx)) continue;
-        claimedNewIndices.add(newIdx);
+        if (newIdx === undefined) continue;
         next[`${agent}:${newIdx}`] = text;
       }
       return next;

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -1246,7 +1246,9 @@ export function CustomProviderDialog({
                                   const { contextWindow: _drop, ...rest } = y;
                                   return rest;
                                 }
-                                if (!/^[0-9][0-9,_ ]*$/.test(trimmed)) return y;
+                                // 分隔符只允许单个、且夹在数字组之间:`1,,2` / `1_ 2` /
+                                // 尾随分隔符等无效位置不得被剥掉后当 `12` 保存(review P1)。
+                                if (!/^[0-9]+(?:[,_ ][0-9]+)*$/.test(trimmed)) return y;
                                 const parsed = Number.parseInt(trimmed.replace(/[,_ ]/g, ''), 10);
                                 // isSafeInteger:超出安全整数会被 parseInt 静默舍入,
                                 // 落盘值与用户输入不一致(review P1)。

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -601,9 +601,10 @@ export function CustomProviderDialog({
             .map((m) => ({ ...m, name: m.name || m.id })),
           ...result.models.map((m) => {
             const cur = currentById.get(m.id);
-            // contextWindow:用户已填的优先;新模型带上端点声明的发现值(review P1:
-            // 只从 cur 拷会把发现值丢掉,保存后又回落 200K)。
-            const contextWindow = cur?.contextWindow ?? m.contextWindow;
+            // contextWindow:表单已有的行以用户当前值为准——包括「显式清空」
+            // (cur 存在但无值时不得被发现值回填,review P1);只有表单没见过的
+            // 新模型才带上端点声明的发现值(否则保存后回落 200K,review P1)。
+            const contextWindow = cur ? cur.contextWindow : m.contextWindow;
             return {
               id: m.id,
               name: cur?.name || m.name,
@@ -1247,7 +1248,9 @@ export function CustomProviderDialog({
                                 }
                                 if (!/^[0-9][0-9,_ ]*$/.test(trimmed)) return y;
                                 const parsed = Number.parseInt(trimmed.replace(/[,_ ]/g, ''), 10);
-                                if (!Number.isFinite(parsed) || parsed <= 0) return y;
+                                // isSafeInteger:超出安全整数会被 parseInt 静默舍入,
+                                // 落盘值与用户输入不一致(review P1)。
+                                if (!Number.isSafeInteger(parsed) || parsed <= 0) return y;
                                 return { ...y, contextWindow: parsed };
                               }),
                             }))

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -1222,6 +1222,33 @@ export function CustomProviderDialog({
                           placeholder={t('settings.providers.custom.fields.modelNamePlaceholder')}
                         />
                       </div>
+                      <div
+                        className="w-28 shrink-0"
+                        title={t('settings.providers.custom.fields.modelContextWindowTitle')}
+                      >
+                        {/* 上下文窗口(tokens):留空 = 保守默认 200K(#386)。只收数字;
+                            非法输入不落盘,交给 buildUserProvider 回落默认。 */}
+                        <TextInput
+                          value={m.contextWindow != null ? String(m.contextWindow) : ''}
+                          onChange={(v) =>
+                            patch(activeTab, (x) => ({
+                              ...x,
+                              models: x.models.map((y, j) => {
+                                if (j !== i) return y;
+                                const digits = v.replace(/[^0-9]/g, '');
+                                const parsed = digits ? Number.parseInt(digits, 10) : NaN;
+                                const { contextWindow: _drop, ...rest } = y;
+                                return Number.isFinite(parsed) && parsed > 0
+                                  ? { ...rest, contextWindow: parsed }
+                                  : rest;
+                              }),
+                            }))
+                          }
+                          placeholder={t(
+                            'settings.providers.custom.fields.modelContextWindowPlaceholder',
+                          )}
+                        />
+                      </div>
                       <button
                         type="button"
                         onClick={() =>

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -440,6 +440,11 @@ export function CustomProviderDialog({
         return next;
       });
       setTest({ 'claude-code': IDLE_TEST, codex: IDLE_TEST });
+      // 预设整体替换所有 runtime 的 models 数组(含清空未声明的 runtime),旧行号
+      // 全部失效——不清空的话陈旧草稿(如 -5)会挂在无关的新行、或挂在被预设清空
+      // 的 runtime 上,handleSave 的守卫拦不住"用户已经看不到"的这条草稿,表单
+      // 卡死报错却找不到对应输入框(review P1)。
+      setWindowDrafts({});
       const first = AGENTS.find((a) => p.runtimes[a]);
       if (first) setActiveTab(first);
     },

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -160,6 +160,15 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+/** 上下文窗口文本是否可提交:空 = 清除窗口;非空须整体合法(分组分隔符 + BigInt 上界)。 */
+function isCommittableWindowText(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed === '') return true;
+  if (!/^[0-9]+(?:[,_ ][0-9]+)*$/.test(trimmed)) return false;
+  const parsed = BigInt(trimmed.replace(/[,_ ]/g, ''));
+  return parsed > 0n && parsed <= BigInt(Number.MAX_SAFE_INTEGER);
+}
+
 function TextInput({
   value,
   onChange,
@@ -692,6 +701,16 @@ export function CustomProviderDialog({
       toast.error(t('settings.providers.custom.errors.nameRequired'));
       return;
     }
+    // 上下文窗口草稿必须已可提交:输入框还挂着 `1,` / `-5` 这类未完成/非法文本时
+    // 点保存,已提交值(或隐式 200K 默认)与用户可见文本不一致——静默存旧值等于
+    // 改掉用户显式输入(review P1 ×2)。定位到首个问题 tab 并报错拦下。
+    for (const [draftKey, draftText] of Object.entries(windowDrafts)) {
+      if (isCommittableWindowText(draftText)) continue;
+      const draftAgent = draftKey.split(':')[0] as AgentKind;
+      if (VISIBLE_AGENTS.includes(draftAgent)) setActiveTab(draftAgent);
+      toast.error(t('settings.providers.custom.errors.contextWindowInvalid'));
+      return;
+    }
     const runtimes: CustomProviderConfig['runtimes'] = {};
     const keys: RuntimeKeys = {};
     for (const a of VISIBLE_AGENTS) {
@@ -864,6 +883,7 @@ export function CustomProviderDialog({
     initial,
     existingIds,
     onSaved,
+    windowDrafts,
     t,
   ]);
 
@@ -1265,18 +1285,14 @@ export function CustomProviderDialog({
                                   const { contextWindow: _drop, ...rest } = y;
                                   return rest;
                                 }
-                                // 分隔符只允许单个、且夹在数字组之间:`1,,2` / `1_ 2` /
-                                // 尾随分隔符等无效位置不得被剥掉后当 `12` 保存(review P1)。
-                                if (!/^[0-9]+(?:[,_ ][0-9]+)*$/.test(trimmed)) return y;
-                                // BigInt 精确校验上界:parseInt 会把超安全整数先舍入
-                                // (9007199254740993 → …992)再通过 isSafeInteger,落盘值
-                                // 与用户输入不一致(review P1);正则已保证纯数字,BigInt
-                                // 不会抛。
-                                const parsed = BigInt(trimmed.replace(/[,_ ]/g, ''));
-                                if (parsed <= 0n || parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
-                                  return y;
-                                }
-                                return { ...y, contextWindow: Number(parsed) };
+                                // 整体校验(分隔符只允许单个、夹在数字组之间;BigInt 精确
+                                // 校验上界防 parseInt 先舍入):不合法的中间态/非法值只
+                                // 留在草稿,不提交、不剥字符拼数字(review P1 ×2)。
+                                if (!isCommittableWindowText(trimmed)) return y;
+                                return {
+                                  ...y,
+                                  contextWindow: Number(BigInt(trimmed.replace(/[,_ ]/g, ''))),
+                                };
                               }),
                             }));
                           }}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1286,6 +1286,8 @@
           "models": "Models",
           "modelIdPlaceholder": "model-id",
           "modelNamePlaceholder": "Display name",
+          "modelContextWindowPlaceholder": "Context (tokens)",
+          "modelContextWindowTitle": "Context window in tokens. Leave empty for the conservative 200K default; affects the window display and compaction threshold.",
           "addModel": "Add model",
           "headers": "Headers (optional)",
           "headerNamePlaceholder": "Header-Name",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1313,6 +1313,7 @@
           "nameRequired": "Display name is required",
           "runtimeRequired": "Configure at least one runtime (its base URL and models)",
           "baseUrlInvalid": "Base URL must be a valid http(s) address",
+          "contextWindowInvalid": "Context window must be a valid positive integer (separators allowed between digit groups)",
           "requestPathInvalid": "Begin the exact request path with a single /. Do not use fragments or . and .. path segments; percent-encode spaces and unsafe characters.",
           "modelRequired": "Add at least one model",
           "oauthInvalid": "Incomplete OAuth config: all fields are required and both endpoints must be secure https URLs"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1313,6 +1313,7 @@
           "nameRequired": "表示名を入力してください",
           "runtimeRequired": "Runtime を 1 つ以上設定してください（ベース URL とモデル）",
           "baseUrlInvalid": "ベース URL は有効な http(s) アドレスである必要があります",
+          "contextWindowInvalid": "コンテキストウィンドウは有効な正の整数である必要があります（数字グループの間に区切り記号を使用できます）",
           "requestPathInvalid": "正確なリクエストパスは 1 つの / で始め、フラグメントや .、.. のパスセグメントを含めないでください。空白や安全でない文字はパーセントエンコードしてください。",
           "modelRequired": "モデルを 1 つ以上追加してください",
           "oauthInvalid": "OAuth 設定が不完全です。すべての項目が必須で、両方のエンドポイントは安全な https URL である必要があります"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1286,6 +1286,8 @@
           "models": "モデル",
           "modelIdPlaceholder": "model-id",
           "modelNamePlaceholder": "表示名",
+          "modelContextWindowPlaceholder": "コンテキスト(tokens)",
+          "modelContextWindowTitle": "コンテキストウィンドウ(トークン数)。空欄の場合は保守的な既定値 200K。ウィンドウ表示と圧縮しきい値に影響します。",
           "addModel": "モデルを追加",
           "headers": "リクエストヘッダー(任意)",
           "headerNamePlaceholder": "Header-Name",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1286,6 +1286,8 @@
           "models": "모델",
           "modelIdPlaceholder": "model-id",
           "modelNamePlaceholder": "표시 이름",
+          "modelContextWindowPlaceholder": "컨텍스트(tokens)",
+          "modelContextWindowTitle": "컨텍스트 윈도우(토큰 수). 비워 두면 보수적 기본값 200K가 적용되며, 윈도우 표시와 압축 임계값에 영향을 줍니다.",
           "addModel": "모델 추가",
           "headers": "요청 헤더(선택)",
           "headerNamePlaceholder": "Header-Name",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1313,6 +1313,7 @@
           "nameRequired": "표시 이름을 입력하세요",
           "runtimeRequired": "Runtime을 하나 이상 구성하세요(기본 URL과 모델)",
           "baseUrlInvalid": "기본 URL은 유효한 http(s) 주소여야 합니다",
+          "contextWindowInvalid": "컨텍스트 윈도우는 유효한 양의 정수여야 합니다(숫자 그룹 사이에 구분 기호 사용 가능)",
           "requestPathInvalid": "정확한 요청 경로는 단일 /로 시작해야 하며 프래그먼트나 . 또는 .. 경로 세그먼트를 포함하면 안 됩니다. 공백과 안전하지 않은 문자는 퍼센트 인코딩하세요.",
           "modelRequired": "모델을 하나 이상 추가하세요",
           "oauthInvalid": "OAuth 설정이 불완전합니다. 모든 필드는 필수이며 두 엔드포인트는 안전한 https URL이어야 합니다"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1313,6 +1313,7 @@
           "nameRequired": "请填写显示名称",
           "runtimeRequired": "请至少配置一个 Runtime（填写它的基础 URL 和模型）",
           "baseUrlInvalid": "基础 URL 必须是合法的 http(s) 地址",
+          "contextWindowInvalid": "上下文窗口必须是合法的正整数（数字组之间可用分隔符）",
           "requestPathInvalid": "精确请求路径需以单个 / 开头，不含片段标识或 .、.. 路径段；空格和不安全字符请使用百分号编码",
           "modelRequired": "请至少添加一个模型",
           "oauthInvalid": "OAuth 配置不完整：所有字段均必填，且两个端点必须是安全的 https 地址"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1286,6 +1286,8 @@
           "models": "模型",
           "modelIdPlaceholder": "model-id",
           "modelNamePlaceholder": "显示名称",
+          "modelContextWindowPlaceholder": "上下文(tokens)",
+          "modelContextWindowTitle": "上下文窗口(tokens)。留空按 200K 保守默认；影响窗口显示与压缩阈值。",
           "addModel": "添加模型",
           "headers": "请求头(可选)",
           "headerNamePlaceholder": "Header-Name",

--- a/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
@@ -139,6 +139,23 @@ describe('appendDiscoveredCustomProviderModels', () => {
       addedIds: ['new'],
     });
   });
+
+  it('carries the endpoint-declared contextWindow into appended models (#386)', () => {
+    const result = appendDiscoveredCustomProviderModels(
+      [],
+      [
+        { id: 'big', name: 'Big', contextWindow: 1_000_000 },
+        { id: 'plain', name: 'Plain' },
+        { id: 'bogus', name: 'Bogus', contextWindow: -1 },
+      ],
+    );
+    expect(result.models).toEqual([
+      { id: 'big', name: 'Big', contextWindow: 1_000_000, defaultEnabled: false },
+      { id: 'plain', name: 'Plain', defaultEnabled: false },
+      // 非法值不落盘,回落保守默认
+      { id: 'bogus', name: 'Bogus', defaultEnabled: false },
+    ]);
+  });
 });
 
 describe('custom provider credential lifecycle', () => {

--- a/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
@@ -59,6 +59,21 @@ describe('customProviderModelConfigFromCatalogModel', () => {
     });
   });
 
+  it('preserves an explicit override equal to the current default (explicit flag wins)', () => {
+    // 用户显式填了 200000:值恰好等于当前默认,但显式覆盖必须在未来默认升级后
+    // 原样保留——不能靠等值推断丢掉字段(PR review P1)。
+    expect(customProviderModelConfigFromCatalogModel({
+      id: 'pinned-default',
+      name: 'Pinned',
+      contextWindow: 200_000,
+      contextWindowExplicit: true,
+    })).toEqual({
+      id: 'pinned-default',
+      name: 'Pinned',
+      contextWindow: 200_000,
+    });
+  });
+
   it('preserves hidden defaults while round-tripping catalog models', () => {
     expect(customProviderModelConfigFromCatalogModel({
       id: 'discovered',

--- a/apps/desktop/src/renderer/lib/customProviders.ts
+++ b/apps/desktop/src/renderer/lib/customProviders.ts
@@ -81,17 +81,26 @@ export function providerViewToCustomProviderConfig(p: ProviderView): CustomProvi
   };
 }
 
-/** 刷新时只追加接口新发现的模型，并让新增模型默认隐藏。 */
+/** 刷新时只追加接口新发现的模型，并让新增模型默认隐藏。端点声明的 contextWindow 随发现带入(#386)。 */
 export function appendDiscoveredCustomProviderModels(
   existing: readonly ProviderRuntimeModelConfig[],
-  discovered: readonly Pick<ProviderRuntimeModelConfig, 'id' | 'name'>[],
+  discovered: readonly Pick<ProviderRuntimeModelConfig, 'id' | 'name' | 'contextWindow'>[],
 ): { models: ProviderRuntimeModelConfig[]; addedIds: string[] } {
   const known = new Set(existing.map((m) => m.id));
   const models = [...existing];
   const addedIds: string[] = [];
   for (const model of discovered) {
     if (!model.id || !model.name || known.has(model.id)) continue;
-    models.push({ id: model.id, name: model.name, defaultEnabled: false });
+    models.push({
+      id: model.id,
+      name: model.name,
+      ...(typeof model.contextWindow === 'number' &&
+      Number.isFinite(model.contextWindow) &&
+      model.contextWindow > 0
+        ? { contextWindow: Math.floor(model.contextWindow) }
+        : {}),
+      defaultEnabled: false,
+    });
     known.add(model.id);
     addedIds.push(model.id);
   }

--- a/apps/desktop/src/renderer/lib/customProviders.ts
+++ b/apps/desktop/src/renderer/lib/customProviders.ts
@@ -37,15 +37,17 @@ export function replaceCustomProviderModelId(
 
 /**
  * 运行期 CatalogModel 已把缺省 contextWindow 物化为通用默认值；转回用户配置时不能把该
- * 默认快照写成 override，否则未来默认升级后老配置无法跟随。厂商明确的非默认值则保留。
+ * 默认快照写成 override，否则未来默认升级后老配置无法跟随。判据以 contextWindowExplicit
+ * 标记为准——用户显式填的值哪怕恰好等于当前默认（如 200K）也必须原样保留，不能靠等值
+ * 推断（PR review P1）；无标记的旧视图快照回退等值判断,行为不变。
  */
 export function customProviderModelConfigFromCatalogModel(
-  model: Pick<CatalogModel, 'id' | 'name' | 'contextWindow' | 'defaultEnabled'>,
+  model: Pick<CatalogModel, 'id' | 'name' | 'contextWindow' | 'contextWindowExplicit' | 'defaultEnabled'>,
 ): ProviderRuntimeModelConfig {
   return {
     id: model.id,
     name: model.name,
-    ...(model.contextWindow !== DEFAULT_CUSTOM_CONTEXT_WINDOW
+    ...(model.contextWindowExplicit === true || model.contextWindow !== DEFAULT_CUSTOM_CONTEXT_WINDOW
       ? { contextWindow: model.contextWindow }
       : {}),
     ...(model.defaultEnabled === false ? { defaultEnabled: false } : {}),

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3764,7 +3764,7 @@ interface ElectronAPI {
       headers?: Record<string, string>;
     }) => Promise<{
       ok: boolean;
-      models?: { id: string; name: string }[];
+      models?: { id: string; name: string; contextWindow?: number }[];
       code?: import('../shared/providerErrors').ProviderErrorCode;
       status?: number;
       detail?: string;

--- a/i18n/GLOSSARY.md
+++ b/i18n/GLOSSARY.md
@@ -144,6 +144,10 @@ Anthropic Messages API / wire protocol 的用户可见名称。四语统一保�
 
 指不更换 TestFlight 或商店安装包、可通过 OTA 下发的 JS 与资源更新。当前先采用四语直译并登记为待讨论术语，避免与整包更新或测试版本更新混称。
 
+### Context window
+
+模型一次请求可容纳的 token 上限。自定义 Provider 的窗口编辑字段(#386)与用量/压缩相关文案使用;空间紧的 placeholder 可缩写为「上下文 / Context / コンテキスト / 컨텍스트」+ (tokens)。
+
 ### Device
 
 device-link 里「可以选择在哪台机器上运行」这一维度，两端统一叫「设备」。desktop 的 machineSwitcher 本来就是 This device / このデバイス / 이 기기，mobile 原先用 computer 系（选择电脑 / パソコンを選択 / 컴퓨터 선택），2026-07 裁决为向 device 系对齐，与既有 device-code（设备码 / デバイスコード / 기기 코드）同口径。alsoAllowed 保留「电脑」系：指代桌面端物理机的文案（安装、导出、等待确认）换成「设备」反而不通中文，那是 desktop/PC 的意思，不是这里的目标维度。

--- a/i18n/glossary.json
+++ b/i18n/glossary.json
@@ -1060,6 +1060,17 @@
         "ko": "압축"
       },
       "note": "issue #882：模型管理/新对话选择器的分类标签，对应网关的文档压缩类模型（如 ai-gateway-doc）。此前被硬编码为笼统的 other 分类。"
+    },
+    {
+      "id": "context-window",
+      "status": "proposed",
+      "en": "Context window",
+      "translations": {
+        "zh-CN": "上下文窗口",
+        "ja": "コンテキストウィンドウ",
+        "ko": "컨텍스트 윈도우"
+      },
+      "note": "模型一次请求可容纳的 token 上限。自定义 Provider 的窗口编辑字段(#386)与用量/压缩相关文案使用;空间紧的 placeholder 可缩写为「上下文 / Context / コンテキスト / 컨텍스트」+ (tokens)。"
     }
   ]
 }

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -142,6 +142,31 @@ describe('buildUserProvider (per-runtime)', () => {
       ['long-context', true],
       ['default-context', undefined],
     ]);
+    // 显式配置打标、缺省物化不打标:编辑表单靠它区分「显式 200K」与「默认 200K」,
+    // 不能靠与默认等值推断(显式覆盖必须在默认升级后原样保留)。
+    expect(p.models.codex?.map((m) => [m.id, m.contextWindowExplicit ?? null])).toEqual([
+      ['long-context', true],
+      ['default-context', null],
+    ]);
+  });
+
+  it('marks an explicit contextWindow equal to the current default as explicit', () => {
+    const p = buildUserProvider({
+      ...codexOnly,
+      runtimes: {
+        codex: {
+          ...codexOnly.runtimes.codex!,
+          models: [
+            { id: 'pinned-default', name: 'Pinned', contextWindow: DEFAULT_CUSTOM_CONTEXT_WINDOW },
+          ],
+        },
+      },
+    });
+    expect(p.models.codex?.[0]).toMatchObject({
+      contextWindow: DEFAULT_CUSTOM_CONTEXT_WINDOW,
+      contextWindowVerified: true,
+      contextWindowExplicit: true,
+    });
   });
 
   it('attaches per-runtime custom headers (still no api key)', () => {

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -260,6 +260,16 @@ export interface CatalogModel {
    * (providerId, modelId) 解析。
    */
   contextWindowVerified?: boolean;
+  /**
+   * 该窗口值是否来自用户/预设**显式配置**（仅 buildUserProvider 生成；内置目录不设）。
+   * 编辑表单回转配置时据此区分「显式填了 200K」与「缺省物化成的 200K」——不能靠与
+   * 当前默认值等值判断：显式覆盖必须在未来默认升级后原样保留（PR review P1）。
+   * 故意不纳入 modelSignature 一致性校验（固定 key 序里没有它）。与
+   * `contextWindowVerified` 是两份独立的 provenance:后者只活在 host 目录里、供
+   * `resolveVerifiedContextWindow` 收敛运行期窗口用,不进跨端 `ModelDescriptor`；
+   * 这个字段专供 desktop 自定义 Provider 编辑表单的回转判定用。
+   */
+  contextWindowExplicit?: boolean;
   maxOutput?: number;
   /** 支持的 effort 档；空数组 = 不支持切换（如 Haiku / 部分 provider-managed 模型）。 */
   efforts: Effort[];

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -57,6 +57,9 @@ function toCatalogModel(
     // 用户自己填了才算显式声明;走 DEFAULT_CUSTOM_CONTEXT_WINDOW 兜底的不标记 ——
     // 那是「仅用于展示」的保守默认,不能拿去收敛运行期上报的窗口。
     ...(m.contextWindow !== undefined ? { contextWindowVerified: true } : {}),
+    // 显式配置的窗口打标:编辑表单回转配置时必须与「缺省物化成的默认值」可区分,
+    // 哪怕用户显式填的恰好等于当前默认(未来默认升级后显式值要原样保留)。
+    ...(m.contextWindow !== undefined ? { contextWindowExplicit: true } : {}),
     efforts,
     defaultEffort: efforts.length > 0 ? DEFAULT_CUSTOM_EFFORT : null,
     // 选择器右栏按 group 聚合：同一自定义来源的模型聚成一组（渲染层用 provider 名兜底标签）。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #386:自定义 Provider 里没带 `contextWindow` 的模型一律回落 `DEFAULT_CUSTOM_CONTEXT_WINDOW = 200K`——窗口显示错标之外,压缩阈值也按 200K 提前触发(用户反馈「动不动就压缩」);而发现链路(modelsUrl `/models`)即使端点声明了上下文长度也从不读取。

两条修复路径:

1. **可编辑**:自定义 Provider 编辑弹窗的模型行新增「上下文(tokens)」输入。留空 = 保守默认 200K(占位符与悬浮说明写明);只收正整数,非法输入不落盘。`ProviderRuntimeModelConfig.contextWindow` 在类型/存储校验/`buildUserProvider`/env 序列化全链路本就存在,无 DB 迁移。
2. **可发现**:`parseModelsListResponse` 尽力提取端点声明的上下文长度(OpenRouter `context_length` / 通用 `context_window` / `max_context_length`);OAuth 自动发现落盘(`mergeDiscoveredModelsIntoConfig`)与手动「刷新模型列表」追加(`appendDiscoveredCustomProviderModels`)都携带该值;勾选弹层(`applyPicker`)既有的 contextWindow 合并逻辑自动受益。

已知边界(维持既有语义,未改动):
- `replaceCustomProviderModelId` 在模型 id 变更时仍清空 contextWindow(既有设计:换 id 即换模型身份,旧元数据不可信;字段现在可见,清空对用户可感知、可重填)
- 显式填入恰好等于默认值 200000 时不会持久化为 override(`customProviderModelConfigFromCatalogModel` 既有语义:让未来默认升级可跟随)

配套:内置目录侧的同类实例(Kimi Code 编程计划 k3)已在 #939 单独修复。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #386
- 本 PR 包含:模型行 contextWindow 输入、发现链路提取与落盘、四语言文案、单测
- 明确不包含:UnifiedModelList 行内编辑(列表仍只读展示);codex agent 自身计量(其窗口来自 app-server 协议,目录值只影响展示/选择器,与 claude-code 路径不同,维持现状)
- 用户可见变化:自定义 Provider 编辑弹窗模型行多一个可选输入;从声明上下文长度的端点发现/刷新模型时自动带值
- 是否存在 breaking change:无

### UI 变化

模型行在 id / 显示名之后新增一个 `w-28` 的 TextInput(复用弹窗内既有 `TextInput` 组件与行布局,无新样式/新配色);placeholder「上下文(tokens)」,悬浮提示说明默认值与影响。双模式经既有组件的语义 token 实现,两种模式未做实机目检(无新增配色,纯组件复用)。

- 引用的设计规范:`docs/design-rules/DESIGN.md` §输入控件(复用既有 TextInput 形态与 40px 行高);文案术语过 `pnpm check:i18n-glossary`(中文标点全角规则已修正)

### 远程 / 手机适配

按 `docs/dev-rules/remote-and-mobile-adaptation.md` 三问结论(均为「不涉及」,理由如下):

1. **SSH 远程工作区**:本 PR 不涉及 workdir 文件、agent 进程或会话数据。`fetchProviderModels`(IPC `maker:provider:models-fetch`)只是设置页「获取模型列表」动作——用弹窗里当场填写的表单值(baseUrl / authMethod / apiKey / headers)直接 GET 供应商的 `/models` 端点,不读写 workdir、不驱动 agent 进程。
2. **设备互联 / 手机 IPC 白名单**:`maker:provider:models-fetch` 是 Settings 页专用的 invoke,仅在本机编辑「自定义 Provider」弹窗时一次性拉取,不广播、无推送事件。手机 / 远程控制端目前只*消费*已落盘的供应商目录做模型选择(`apps/mobile/src/session/modelPickerRows.ts`),不提供创建 / 编辑自定义 Provider 的入口,因此不需要登记进 `packages/device-link/src/allowlist.ts`。
3. **手机版入口**:手机版没有「自定义 Provider」配置入口(与现状一致,配置仍只能在桌面 Settings 完成);已发现 / 编辑的 contextWindow 值经既有的供应商目录同步机制,会自然反映到手机模型选择器的展示上,无需额外适配。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:通过(52 个 workspace;含新增 4 组单测:parse 提取/合并落盘/刷新追加/非法值回落)

pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm check:i18n-glossary
结果:通过
```

### 手工验证

未做实机目检(编辑弹窗需要运行 app;本机为企业账号环境)。行为由单测锚定:输入解析(正整数/清空)、发现提取三种字段名、additions-only 合并不覆盖已有条目。

### 未执行的验证

- 实机操作编辑弹窗与真实 OpenRouter `/models` 端到端未验证,原因同上;
- Light/Dark 实机目检未做(见 UI 变化)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:自定义 Provider 编辑弹窗、模型发现链路(additions-only,不覆盖既有条目)
- 回滚 / 降级方式:revert 即可;已落盘的 contextWindow 是既有 schema 字段,revert 后仅回到不可编辑状态,数据无损

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
