### PR TITLE
fix(maker-core): 避免同轮重复询问已回答问题

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -10063,21 +10063,29 @@ describe('CodexAgent MCP thread context hooks', () => {
     const iterator = handle.events()[Symbol.asyncIterator]();
     const handlers = host.getThreadHandlers();
     if (!handlers?.requestUserInput || !handlers.serverRequestResolved) throw new Error('expected handlers');
-    const pendingDecision = deferred<InteractionDecision>();
-    handle.setInteractionResolver(async () => pendingDecision.promise);
+    const cancelledDecision = deferred<InteractionDecision>();
+    const retryDecision = deferred<InteractionDecision>();
+    let requestCount = 0;
+    handle.setInteractionResolver(async (req) => {
+      requestCount += 1;
+      return req.requestId === 'req-resolved'
+        ? cancelledDecision.promise
+        : retryDecision.promise;
+    });
 
+    const question = {
+      id: 'q1',
+      header: 'Question',
+      question: 'Pick one',
+      isOther: false,
+      isSecret: false,
+      options: null,
+    };
     const responsePromise = handlers.requestUserInput({
       threadId: 'start-thread-id',
       turnId: 'turn-1',
       itemId: 'item-1',
-      questions: [{
-        id: 'q1',
-        header: 'Question',
-        question: 'Pick one',
-        isOther: false,
-        isSecret: false,
-        options: null,
-      }],
+      questions: [question],
     }, { requestId: 'req-resolved' });
 
     handlers.serverRequestResolved({ threadId: 'start-thread-id', requestId: 'req-resolved' });
@@ -10091,7 +10099,37 @@ describe('CodexAgent MCP thread context hooks', () => {
         resolvedAs: 'deny',
       },
     });
-    pendingDecision.resolve({ kind: 'ask_user_question', answers: { q1: 'late' } });
+
+    const retryResponsePromise = handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-2',
+      questions: [question],
+    }, { requestId: 'req-retry' });
+    expect(requestCount).toBe(2);
+    retryDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'fresh' },
+    });
+    await expect(retryResponsePromise).resolves.toEqual({
+      answers: { q1: { answers: ['fresh'] } },
+    });
+
+    cancelledDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'late' },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await expect(handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-3',
+      questions: [question],
+    }, { requestId: 'req-replay' })).resolves.toEqual({
+      answers: { q1: { answers: ['fresh'] } },
+    });
+    expect(requestCount).toBe(2);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -9983,6 +9983,75 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('preserves submitted answers from different concurrent user input prompts', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-concurrent-user-input',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.dynamicToolCall) throw new Error('expected dynamicToolCall handler');
+
+    const firstDecision = deferred<InteractionDecision>();
+    const secondDecision = deferred<InteractionDecision>();
+    let requestCount = 0;
+    handle.setInteractionResolver(async (req) => {
+      if (req.kind !== 'ask_user_question') throw new Error('expected ask_user_question');
+      requestCount += 1;
+      if (req.requestId === 'req-first') return firstDecision.promise;
+      if (req.requestId === 'req-second') return secondDecision.promise;
+      return {
+        kind: 'ask_user_question',
+        answers: { [req.questions[0]?.question ?? '']: 'Unexpected repeat' },
+      };
+    });
+
+    const callQuestion = (
+      requestId: string,
+      callId: string,
+      questionId: string,
+      question: string,
+    ) => handlers.dynamicToolCall?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      callId,
+      namespace: 'cindy',
+      tool: 'ask_user_question',
+      arguments: {
+        questions: [{ id: questionId, header: 'Direction', question }],
+      },
+    }, { requestId });
+
+    const firstResultPromise = callQuestion('req-first', 'call-first', 'first', 'First question?');
+    const secondResultPromise = callQuestion('req-second', 'call-second', 'second', 'Second question?');
+    if (!firstResultPromise || !secondResultPromise) throw new Error('expected dynamic tool results');
+    expect(requestCount).toBe(2);
+
+    secondDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Second question?': 'Second answer' },
+    });
+    await secondResultPromise;
+    firstDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'First question?': 'First answer' },
+    });
+    await firstResultPromise;
+
+    const firstReplay = await callQuestion('req-first-replay', 'call-first-replay', 'first', 'First question?');
+    const secondReplay = await callQuestion('req-second-replay', 'call-second-replay', 'second', 'Second question?');
+    expect(firstReplay?.contentItems).toEqual([
+      { type: 'inputText', text: JSON.stringify({ first: { answers: ['First answer'] } }) },
+    ]);
+    expect(secondReplay?.contentItems).toEqual([
+      { type: 'inputText', text: JSON.stringify({ second: { answers: ['Second answer'] } }) },
+    ]);
+    expect(requestCount).toBe(2);
+    await handle.close();
+  });
+
   it('cancels pending user input when serverRequest/resolved arrives', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -10239,6 +10239,105 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it.each([
+    {
+      lifecycle: 'turn completion',
+      reason: 'turn_completed',
+      trigger: (_handle: AgentSessionHandle, handlers: ThreadEventHandlers) => {
+        handlers.turnCompleted?.({
+          threadId: 'start-thread-id',
+          turn: { id: 'turn-1', status: 'completed' },
+        });
+      },
+    },
+    {
+      lifecycle: 'transport failure',
+      reason: 'transport_error',
+      trigger: (_handle: AgentSessionHandle, handlers: ThreadEventHandlers) => {
+        handlers.error?.({
+          threadId: 'start-thread-id',
+          turnId: '',
+          willRetry: false,
+          scope: 'transport',
+          error: { message: 'transport closed' },
+        });
+      },
+    },
+    {
+      lifecycle: 'session close',
+      reason: 'session_closed',
+      trigger: async (handle: AgentSessionHandle) => {
+        await handle.close();
+      },
+    },
+  ])('wakes joined user-input requests during $lifecycle cleanup', async ({ lifecycle, reason, trigger }) => {
+    const logger = createNoopLogger();
+    const debug = vi.spyOn(logger, 'debug');
+    const agent = new CodexAgent(createDeps({}, { logger }));
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: `session-user-input-cleanup-${lifecycle.replaceAll(' ', '-')}`,
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.requestUserInput || !handlers.dynamicToolCall) {
+      throw new Error('expected user input handlers');
+    }
+    const ownerDecision = deferred<InteractionDecision>();
+    let requestCount = 0;
+    handle.setInteractionResolver(async () => {
+      requestCount += 1;
+      return ownerDecision.promise;
+    });
+
+    const ownerResponsePromise = handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-owner',
+      questions: [{
+        id: 'native-q1',
+        header: 'Question',
+        question: 'Pick one',
+        isOther: false,
+        isSecret: false,
+        options: null,
+      }],
+    }, { requestId: 'req-owner' });
+    const joinedResponsePromise = handlers.dynamicToolCall({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      callId: 'item-joined',
+      namespace: 'cindy',
+      tool: 'ask_user_question',
+      arguments: {
+        questions: [{
+          id: 'dynamic-q1',
+          header: 'Question',
+          question: 'Pick one',
+          isOther: false,
+          options: null,
+        }],
+      },
+    }, { requestId: 'req-joined' });
+    expect(requestCount).toBe(1);
+
+    await trigger(handle, handlers);
+
+    await expect(ownerResponsePromise).resolves.toEqual({ answers: {} });
+    await expect(joinedResponsePromise).resolves.toEqual({
+      success: false,
+      contentItems: [{ type: 'inputText', text: `Request cancelled: ${reason}` }],
+    });
+    await waitForExpectation(() => {
+      expect(debug).toHaveBeenCalledWith(
+        'joined duplicate same-turn user input request cancelled',
+        { requestId: 'req-joined', turnId: 'turn-1' },
+      );
+    });
+    if (lifecycle !== 'session close') await handle.close();
+  });
+
   it('updates the registered vendorOptions object by reference on setVendorOptions', async () => {
     const registerCodexMcpThreadContext = vi.fn();
     const agent = new CodexAgent(createDeps({}, {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -9895,13 +9895,15 @@ describe('CodexAgent MCP thread context hooks', () => {
       workingDir: '/repo',
     });
     const handlers = host.getThreadHandlers();
-    if (!handlers?.dynamicToolCall) throw new Error('expected dynamicToolCall handler');
+    if (!handlers?.dynamicToolCall || !handlers.requestUserInput) {
+      throw new Error('expected user input handlers');
+    }
     let requestCount = 0;
     handle.setInteractionResolver(async (req) => {
       requestCount += 1;
       expect(req).toMatchObject({
         kind: 'ask_user_question',
-        requestId: requestCount === 1 ? 'req-dynamic' : 'req-dynamic-legacy',
+        requestId: 'req-dynamic',
       });
       return { kind: 'ask_user_question', answers: { 'What next?': 'Keep going' } };
     });
@@ -9927,6 +9929,23 @@ describe('CodexAgent MCP thread context hooks', () => {
       { type: 'inputText', text: JSON.stringify({ q1: { answers: ['Keep going'] } }) },
     ]);
 
+    const nativeDuplicateResult = await handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'native-call-duplicate',
+      questions: [{
+        id: 'q1',
+        header: 'Direction',
+        question: 'What next?',
+        isOther: false,
+        isSecret: false,
+        options: [{ label: 'Keep going', description: 'Continue current work' }],
+      }],
+    }, { requestId: 'req-native-duplicate' });
+    expect(nativeDuplicateResult).toEqual({
+      answers: { q1: { answers: ['Keep going'] } },
+    });
+
     const legacyResult = await handlers.dynamicToolCall({
       threadId: 'start-thread-id',
       turnId: 'turn-1',
@@ -9943,7 +9962,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       },
     }, { requestId: 'req-dynamic-legacy' });
     expect(legacyResult).toEqual(result);
-    expect(requestCount).toBe(2);
+    expect(requestCount).toBe(1);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -10133,6 +10133,78 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('does not cache a late user-input answer after local turn interruption', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      if (method === Method.TurnInterrupt) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-user-input-local-interrupt',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    await handle.send({ type: 'user', content: 'ask me a question' });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.requestUserInput) throw new Error('expected requestUserInput handler');
+    const interruptedDecision = deferred<InteractionDecision>();
+    const replacementDecision = deferred<InteractionDecision>();
+    let requestCount = 0;
+    handle.setInteractionResolver(async () => {
+      requestCount += 1;
+      return requestCount === 1
+        ? interruptedDecision.promise
+        : replacementDecision.promise;
+    });
+
+    const question = {
+      id: 'q1',
+      header: 'Question',
+      question: 'Pick one',
+      isOther: false,
+      isSecret: false,
+      options: null,
+    };
+    const interruptedResponsePromise = handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-interrupted',
+      questions: [question],
+    }, { requestId: 'req-interrupted' });
+
+    await handle.abort();
+    await expect(interruptedResponsePromise).resolves.toEqual({ answers: {} });
+
+    interruptedDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'late' },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const replacementResponsePromise = handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-replacement',
+      questions: [question],
+    }, { requestId: 'req-replacement' });
+    expect(requestCount).toBe(2);
+    replacementDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'fresh' },
+    });
+    await expect(replacementResponsePromise).resolves.toEqual({
+      answers: { q1: { answers: ['fresh'] } },
+    });
+
+    handlers.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'interrupted' },
+    });
+    await handle.close();
+  });
+
   it('reassigns a joined duplicate when the interaction owner is cancelled', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -9899,16 +9899,17 @@ describe('CodexAgent MCP thread context hooks', () => {
       throw new Error('expected user input handlers');
     }
     let requestCount = 0;
+    const pendingDecision = deferred<InteractionDecision>();
     handle.setInteractionResolver(async (req) => {
       requestCount += 1;
       expect(req).toMatchObject({
         kind: 'ask_user_question',
         requestId: 'req-dynamic',
       });
-      return { kind: 'ask_user_question', answers: { 'What next?': 'Keep going' } };
+      return pendingDecision.promise;
     });
 
-    const result = await handlers.dynamicToolCall({
+    const resultPromise = handlers.dynamicToolCall({
       threadId: 'start-thread-id',
       turnId: 'turn-1',
       callId: 'dynamic-call-1',
@@ -9916,34 +9917,45 @@ describe('CodexAgent MCP thread context hooks', () => {
       tool: 'ask_user_question',
       arguments: {
         questions: [{
-          id: 'q1',
           header: 'Direction',
           question: 'What next?',
-          options: [{ label: 'Keep going', description: 'Continue current work' }],
         }],
       },
     }, { requestId: 'req-dynamic' });
 
-    expect(result.success).toBe(true);
-    expect(result.contentItems).toEqual([
-      { type: 'inputText', text: JSON.stringify({ q1: { answers: ['Keep going'] } }) },
-    ]);
-
-    const nativeDuplicateResult = await handlers.requestUserInput({
+    const nativeDuplicateResultPromise = handlers.requestUserInput({
       threadId: 'start-thread-id',
       turnId: 'turn-1',
       itemId: 'native-call-duplicate',
       questions: [{
-        id: 'q1',
+        id: 'native-q1',
         header: 'Direction',
         question: 'What next?',
         isOther: false,
         isSecret: false,
-        options: [{ label: 'Keep going', description: 'Continue current work' }],
+        options: [],
       }],
     }, { requestId: 'req-native-duplicate' });
+
+    expect(requestCount).toBe(1);
+    pendingDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'What next?': 'Keep going' },
+    });
+
+    const [result, nativeDuplicateResult] = await Promise.all([
+      resultPromise,
+      nativeDuplicateResultPromise,
+    ]);
+    expect(result.success).toBe(true);
+    expect(result.contentItems).toEqual([
+      {
+        type: 'inputText',
+        text: JSON.stringify({ 'question-1': { answers: ['Keep going'] } }),
+      },
+    ]);
     expect(nativeDuplicateResult).toEqual({
-      answers: { q1: { answers: ['Keep going'] } },
+      answers: { 'native-q1': { answers: ['Keep going'] } },
     });
 
     const legacyResult = await handlers.dynamicToolCall({
@@ -9954,14 +9966,19 @@ describe('CodexAgent MCP thread context hooks', () => {
       tool: 'ask_user_question',
       arguments: {
         questions: [{
-          id: 'q1',
+          id: 'legacy-q1',
           header: 'Direction',
           question: 'What next?',
-          options: [{ label: 'Keep going', description: 'Continue current work' }],
+          options: null,
         }],
       },
     }, { requestId: 'req-dynamic-legacy' });
-    expect(legacyResult).toEqual(result);
+    expect(legacyResult.contentItems).toEqual([
+      {
+        type: 'inputText',
+        text: JSON.stringify({ 'legacy-q1': { answers: ['Keep going'] } }),
+      },
+    ]);
     expect(requestCount).toBe(1);
     await handle.close();
   });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -10133,6 +10133,112 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('reassigns a joined duplicate when the interaction owner is cancelled', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-user-input-owner-cancelled',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.requestUserInput || !handlers.dynamicToolCall || !handlers.serverRequestResolved) {
+      throw new Error('expected handlers');
+    }
+    const ownerDecision = deferred<InteractionDecision>();
+    const joinedDecision = deferred<InteractionDecision>();
+    let requestCount = 0;
+    handle.setInteractionResolver(async (req) => {
+      requestCount += 1;
+      return req.requestId === 'req-owner'
+        ? ownerDecision.promise
+        : joinedDecision.promise;
+    });
+
+    const ownerResponsePromise = handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-owner',
+      questions: [{
+        id: 'native-q1',
+        header: 'Question',
+        question: 'Pick one',
+        isOther: false,
+        isSecret: false,
+        options: null,
+      }],
+    }, { requestId: 'req-owner' });
+    const joinedResponsePromise = handlers.dynamicToolCall({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      callId: 'item-joined',
+      namespace: 'cindy',
+      tool: 'ask_user_question',
+      arguments: {
+        questions: [{
+          id: 'dynamic-q1',
+          header: 'Question',
+          question: 'Pick one',
+          isOther: false,
+          options: null,
+        }],
+      },
+    }, { requestId: 'req-joined' });
+    expect(requestCount).toBe(1);
+
+    handlers.serverRequestResolved({ threadId: 'start-thread-id', requestId: 'req-owner' });
+
+    await expect(ownerResponsePromise).resolves.toEqual({ answers: {} });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: 'interaction_dismissed',
+      data: {
+        requestId: 'req-owner',
+        reason: 'server_request_resolved',
+        resolvedAs: 'deny',
+      },
+    });
+    await waitForExpectation(() => {
+      expect(requestCount).toBe(2);
+    });
+
+    joinedDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'fresh' },
+    });
+    await expect(joinedResponsePromise).resolves.toEqual({
+      success: true,
+      contentItems: [{
+        type: 'inputText',
+        text: JSON.stringify({ 'dynamic-q1': { answers: ['fresh'] } }),
+      }],
+    });
+
+    ownerDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'late' },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await expect(handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-replay',
+      questions: [{
+        id: 'replay-q1',
+        header: 'Question',
+        question: 'Pick one',
+        isOther: false,
+        isSecret: false,
+        options: null,
+      }],
+    }, { requestId: 'req-replay' })).resolves.toEqual({
+      answers: { 'replay-q1': { answers: ['fresh'] } },
+    });
+    expect(requestCount).toBe(2);
+    await handle.close();
+  });
+
   it('updates the registered vendorOptions object by reference on setVendorOptions', async () => {
     const registerCodexMcpThreadContext = vi.fn();
     const agent = new CodexAgent(createDeps({}, {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -643,6 +643,18 @@ function dynamicToolResponseFromUserInput(response: ToolRequestUserInputResponse
   };
 }
 
+function userInputQuestionsFingerprint(
+  questions: readonly ToolRequestUserInputQuestion[],
+): string {
+  return JSON.stringify(questions);
+}
+
+function hasSubmittedUserInput(response: ToolRequestUserInputResponse): boolean {
+  return Object.values(response.answers).some((answer) =>
+    answer?.answers.some((value) => value.trim().length > 0) === true,
+  );
+}
+
 function normalizeServiceTier(serviceTier: ServiceTier | null | undefined): ServiceTier | null | undefined {
   return serviceTier === 'priority' ? 'fast' : serviceTier;
 }
@@ -3490,6 +3502,14 @@ export class CodexAgent extends BaseAgent {
     const userInputBroker = new CodexInteractionBroker<ToolRequestUserInputResponse>();
     const dynamicToolBroker = new CodexInteractionBroker<DynamicToolCallResponse>();
     const activeToolContexts = new Map<string, ActiveToolContext>();
+    // A single model turn can surface the same question through both the
+    // native requestUserInput request and the dynamic-tool compatibility
+    // path. Once the user has submitted a real answer, replay it for an exact
+    // same-turn duplicate instead of asking them a second time.
+    const submittedUserInputByTurn = new Map<
+      string,
+      Map<string, ToolRequestUserInputResponse>
+    >();
     registerCodexMcpContext(threadId);
     let mcpElicitationSeq = 0;
 
@@ -4417,6 +4437,7 @@ export class CodexAgent extends BaseAgent {
       for (const [itemId, ctx] of activeToolContexts) {
         if (ctx.turnId === turnId) activeToolContexts.delete(itemId);
       }
+      submittedUserInputByTurn.delete(turnId);
     }
 
     function classifyUserInputRequest(params: ToolRequestUserInputParams): 'ask_user_question' | 'permission' {
@@ -4434,6 +4455,7 @@ export class CodexAgent extends BaseAgent {
     async function askUserViaInteraction(
       requestId: string,
       questions: ToolRequestUserInputQuestion[],
+      turnId?: string | null,
     ): Promise<ToolRequestUserInputResponse> {
       if (questions.some((q) => q.isSecret)) {
         log.warn('requestUserInput secret question refused', {
@@ -4441,6 +4463,17 @@ export class CodexAgent extends BaseAgent {
           questionCount: questions.length,
         });
         return emptyUserInputResponse(questions);
+      }
+      const fingerprint = turnId ? userInputQuestionsFingerprint(questions) : null;
+      const submittedForTurn = turnId ? submittedUserInputByTurn.get(turnId) : undefined;
+      const replay = fingerprint ? submittedForTurn?.get(fingerprint) : undefined;
+      if (replay) {
+        log.info('reusing submitted answer for duplicate same-turn user input request', {
+          requestId,
+          turnId,
+          questionCount: questions.length,
+        });
+        return replay;
       }
       const decision = await dispatchInteraction({
         kind: 'ask_user_question',
@@ -4451,7 +4484,13 @@ export class CodexAgent extends BaseAgent {
         log.warn('requestUserInput got mismatched ask decision', { requestId, decKind: decision.kind });
         return emptyUserInputResponse(questions);
       }
-      return responseFromAskUserAnswers(questions, decision.answers);
+      const response = responseFromAskUserAnswers(questions, decision.answers);
+      if (turnId && fingerprint && hasSubmittedUserInput(response)) {
+        const nextSubmittedForTurn = submittedForTurn ?? new Map<string, ToolRequestUserInputResponse>();
+        nextSubmittedForTurn.set(fingerprint, response);
+        if (!submittedForTurn) submittedUserInputByTurn.set(turnId, nextSubmittedForTurn);
+      }
+      return response;
     }
 
     async function requestUserInputAsPermission(
@@ -4530,7 +4569,7 @@ export class CodexAgent extends BaseAgent {
         async (settle) => {
           const response = kind === 'permission'
             ? await requestUserInputAsPermission(requestId, params, questions)
-            : await askUserViaInteraction(requestId, questions);
+            : await askUserViaInteraction(requestId, questions, params.turnId);
           settle(response);
         },
       );
@@ -4590,7 +4629,7 @@ export class CodexAgent extends BaseAgent {
           itemId: params.callId,
         },
         async (settle) => {
-          const response = await askUserViaInteraction(requestId, questions);
+          const response = await askUserViaInteraction(requestId, questions, params.turnId);
           settle(dynamicToolResponseFromUserInput(response));
         },
       );
@@ -6173,6 +6212,7 @@ export class CodexAgent extends BaseAgent {
           subscriptionInvalidatedByTransport = true;
           dismissAllPendingUserInput('transport_error');
           activeToolContexts.clear();
+          submittedUserInputByTurn.clear();
         }
         const targetsPendingTurn = isTurnStartPending && currentTurnId === null && Boolean(params.turnId);
         // 空 turnId 的容量拒绝: 过载重投的 RPC 还在飞、而它的 turnStarted 尚未到达时,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4555,10 +4555,12 @@ export class CodexAgent extends BaseAgent {
           && pendingUserInputByTurn.get(turnId) === pendingForTurn
           && hasSubmittedUserInput(answersByPosition)
         ) {
-          const nextSubmittedForTurn = submittedForTurn
+          const nextSubmittedForTurn = submittedUserInputByTurn.get(turnId)
             ?? new Map<string, UserInputAnswersByPosition>();
           nextSubmittedForTurn.set(fingerprint, answersByPosition);
-          if (!submittedForTurn) submittedUserInputByTurn.set(turnId, nextSubmittedForTurn);
+          if (!submittedUserInputByTurn.has(turnId)) {
+            submittedUserInputByTurn.set(turnId, nextSubmittedForTurn);
+          }
         }
         return responseFromUserInputAnswersByPosition(questions, answersByPosition);
       } finally {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -659,6 +659,12 @@ function userInputQuestionsFingerprint(
 
 type UserInputAnswersByPosition = string[][];
 
+interface PendingUserInputInteraction {
+  interactionPromise: Promise<UserInputAnswersByPosition>;
+  cancelledPromise: Promise<void>;
+  cancel: () => void;
+}
+
 function userInputAnswersByPosition(
   questions: readonly ToolRequestUserInputQuestion[],
   response: ToolRequestUserInputResponse,
@@ -3542,13 +3548,13 @@ export class CodexAgent extends BaseAgent {
     >();
     const pendingUserInputByTurn = new Map<
       string,
-      Map<string, Promise<UserInputAnswersByPosition>>
+      Map<string, PendingUserInputInteraction>
     >();
     const pendingUserInputOwnerByRequestId = new Map<string, {
       turnId: string;
       fingerprint: string;
-      pendingForTurn: Map<string, Promise<UserInputAnswersByPosition>>;
-      interactionPromise: Promise<UserInputAnswersByPosition>;
+      pendingForTurn: Map<string, PendingUserInputInteraction>;
+      pendingInteraction: PendingUserInputInteraction;
     }>();
     registerCodexMcpContext(threadId);
     let mcpElicitationSeq = 0;
@@ -4488,7 +4494,8 @@ export class CodexAgent extends BaseAgent {
       const pending = pendingUserInputOwnerByRequestId.get(requestId);
       if (!pending) return;
       pendingUserInputOwnerByRequestId.delete(requestId);
-      if (pending.pendingForTurn.get(pending.fingerprint) !== pending.interactionPromise) return;
+      pending.pendingInteraction.cancel();
+      if (pending.pendingForTurn.get(pending.fingerprint) !== pending.pendingInteraction) return;
       pending.pendingForTurn.delete(pending.fingerprint);
       if (
         pending.pendingForTurn.size === 0
@@ -4514,6 +4521,7 @@ export class CodexAgent extends BaseAgent {
       requestId: string,
       questions: ToolRequestUserInputQuestion[],
       turnId?: string | null,
+      isRequestPending: () => boolean = () => true,
     ): Promise<ToolRequestUserInputResponse> {
       if (questions.some((q) => q.isSecret)) {
         log.warn('requestUserInput secret question refused', {
@@ -4542,8 +4550,19 @@ export class CodexAgent extends BaseAgent {
           turnId,
           questionCount: questions.length,
         });
-        const answersByPosition = await pendingReplay;
-        return responseFromUserInputAnswersByPosition(questions, answersByPosition);
+        const joined = await Promise.race([
+          pendingReplay.interactionPromise.then((answersByPosition) => ({
+            kind: 'answered' as const,
+            answersByPosition,
+          })),
+          pendingReplay.cancelledPromise.then(() => ({ kind: 'cancelled' as const })),
+        ]);
+        if (joined.kind === 'cancelled') {
+          return isRequestPending()
+            ? askUserViaInteraction(requestId, questions, turnId, isRequestPending)
+            : emptyUserInputResponse(questions);
+        }
+        return responseFromUserInputAnswersByPosition(questions, joined.answersByPosition);
       }
 
       const interactionPromise = (async (): Promise<UserInputAnswersByPosition> => {
@@ -4562,9 +4581,19 @@ export class CodexAgent extends BaseAgent {
         );
       })();
 
+      let cancelPendingInteraction!: () => void;
+      const cancelledPromise = new Promise<void>((resolve) => {
+        cancelPendingInteraction = resolve;
+      });
+      const pendingInteraction: PendingUserInputInteraction = {
+        interactionPromise,
+        cancelledPromise,
+        cancel: cancelPendingInteraction,
+      };
+
       if (turnId && fingerprint) {
-        pendingForTurn ??= new Map<string, Promise<UserInputAnswersByPosition>>();
-        pendingForTurn.set(fingerprint, interactionPromise);
+        pendingForTurn ??= new Map<string, PendingUserInputInteraction>();
+        pendingForTurn.set(fingerprint, pendingInteraction);
         if (!pendingUserInputByTurn.has(turnId)) {
           pendingUserInputByTurn.set(turnId, pendingForTurn);
         }
@@ -4572,7 +4601,7 @@ export class CodexAgent extends BaseAgent {
           turnId,
           fingerprint,
           pendingForTurn,
-          interactionPromise,
+          pendingInteraction,
         });
       }
 
@@ -4582,7 +4611,7 @@ export class CodexAgent extends BaseAgent {
           turnId
           && fingerprint
           && pendingUserInputByTurn.get(turnId) === pendingForTurn
-          && pendingForTurn?.get(fingerprint) === interactionPromise
+          && pendingForTurn?.get(fingerprint) === pendingInteraction
           && hasSubmittedUserInput(answersByPosition)
         ) {
           const nextSubmittedForTurn = submittedUserInputByTurn.get(turnId)
@@ -4595,10 +4624,10 @@ export class CodexAgent extends BaseAgent {
         return responseFromUserInputAnswersByPosition(questions, answersByPosition);
       } finally {
         const ownedPending = pendingUserInputOwnerByRequestId.get(requestId);
-        if (ownedPending?.interactionPromise === interactionPromise) {
+        if (ownedPending?.pendingInteraction === pendingInteraction) {
           pendingUserInputOwnerByRequestId.delete(requestId);
         }
-        if (turnId && fingerprint && pendingForTurn?.get(fingerprint) === interactionPromise) {
+        if (turnId && fingerprint && pendingForTurn?.get(fingerprint) === pendingInteraction) {
           pendingForTurn.delete(fingerprint);
           if (
             pendingForTurn.size === 0
@@ -4686,7 +4715,12 @@ export class CodexAgent extends BaseAgent {
         async (settle) => {
           const response = kind === 'permission'
             ? await requestUserInputAsPermission(requestId, params, questions)
-            : await askUserViaInteraction(requestId, questions, params.turnId);
+            : await askUserViaInteraction(
+                requestId,
+                questions,
+                params.turnId,
+                () => userInputBroker.has({ connectionId, requestId: meta.requestId }),
+              );
           settle(response);
         },
       );
@@ -4746,7 +4780,12 @@ export class CodexAgent extends BaseAgent {
           itemId: params.callId,
         },
         async (settle) => {
-          const response = await askUserViaInteraction(requestId, questions, params.turnId);
+          const response = await askUserViaInteraction(
+            requestId,
+            questions,
+            params.turnId,
+            () => dynamicToolBroker.has({ connectionId, requestId: meta.requestId }),
+          );
           settle(dynamicToolResponseFromUserInput(response));
         },
       );

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3544,6 +3544,12 @@ export class CodexAgent extends BaseAgent {
       string,
       Map<string, Promise<UserInputAnswersByPosition>>
     >();
+    const pendingUserInputOwnerByRequestId = new Map<string, {
+      turnId: string;
+      fingerprint: string;
+      pendingForTurn: Map<string, Promise<UserInputAnswersByPosition>>;
+      interactionPromise: Promise<UserInputAnswersByPosition>;
+    }>();
     registerCodexMcpContext(threadId);
     let mcpElicitationSeq = 0;
 
@@ -4471,8 +4477,25 @@ export class CodexAgent extends BaseAgent {
       for (const [itemId, ctx] of activeToolContexts) {
         if (ctx.turnId === turnId) activeToolContexts.delete(itemId);
       }
+      for (const [requestId, pending] of pendingUserInputOwnerByRequestId) {
+        if (pending.turnId === turnId) pendingUserInputOwnerByRequestId.delete(requestId);
+      }
       submittedUserInputByTurn.delete(turnId);
       pendingUserInputByTurn.delete(turnId);
+    }
+
+    function forgetPendingUserInputRequest(requestId: string): void {
+      const pending = pendingUserInputOwnerByRequestId.get(requestId);
+      if (!pending) return;
+      pendingUserInputOwnerByRequestId.delete(requestId);
+      if (pending.pendingForTurn.get(pending.fingerprint) !== pending.interactionPromise) return;
+      pending.pendingForTurn.delete(pending.fingerprint);
+      if (
+        pending.pendingForTurn.size === 0
+        && pendingUserInputByTurn.get(pending.turnId) === pending.pendingForTurn
+      ) {
+        pendingUserInputByTurn.delete(pending.turnId);
+      }
     }
 
     function classifyUserInputRequest(params: ToolRequestUserInputParams): 'ask_user_question' | 'permission' {
@@ -4545,6 +4568,12 @@ export class CodexAgent extends BaseAgent {
         if (!pendingUserInputByTurn.has(turnId)) {
           pendingUserInputByTurn.set(turnId, pendingForTurn);
         }
+        pendingUserInputOwnerByRequestId.set(requestId, {
+          turnId,
+          fingerprint,
+          pendingForTurn,
+          interactionPromise,
+        });
       }
 
       try {
@@ -4553,6 +4582,7 @@ export class CodexAgent extends BaseAgent {
           turnId
           && fingerprint
           && pendingUserInputByTurn.get(turnId) === pendingForTurn
+          && pendingForTurn?.get(fingerprint) === interactionPromise
           && hasSubmittedUserInput(answersByPosition)
         ) {
           const nextSubmittedForTurn = submittedUserInputByTurn.get(turnId)
@@ -4564,6 +4594,10 @@ export class CodexAgent extends BaseAgent {
         }
         return responseFromUserInputAnswersByPosition(questions, answersByPosition);
       } finally {
+        const ownedPending = pendingUserInputOwnerByRequestId.get(requestId);
+        if (ownedPending?.interactionPromise === interactionPromise) {
+          pendingUserInputOwnerByRequestId.delete(requestId);
+        }
         if (turnId && fingerprint && pendingForTurn?.get(fingerprint) === interactionPromise) {
           pendingForTurn.delete(fingerprint);
           if (
@@ -4732,6 +4766,7 @@ export class CodexAgent extends BaseAgent {
         },
       );
       if (userInputCancelled || dynamicCancelled) {
+        forgetPendingUserInputRequest(requestId);
         eventQueue.push({
           type: 'interaction_dismissed',
           data: { requestId, reason: 'server_request_resolved', resolvedAs: 'deny' },
@@ -6297,6 +6332,7 @@ export class CodexAgent extends BaseAgent {
           activeToolContexts.clear();
           submittedUserInputByTurn.clear();
           pendingUserInputByTurn.clear();
+          pendingUserInputOwnerByRequestId.clear();
         }
         const targetsPendingTurn = isTurnStartPending && currentTurnId === null && Boolean(params.turnId);
         // 空 turnId 的容量拒绝: 过载重投的 RPC 还在飞、而它的 turnStarted 尚未到达时,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3844,6 +3844,7 @@ export class CodexAgent extends BaseAgent {
         const requestId = String(meta.requestId);
         if (dismissed.has(requestId)) continue;
         dismissed.add(requestId);
+        forgetPendingUserInputRequest(requestId);
         eventQueue.push({
           type: 'interaction_dismissed',
           data: { requestId, reason, resolvedAs: 'deny' },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4818,19 +4818,27 @@ export class CodexAgent extends BaseAgent {
 
     function handleServerRequestResolved(params: ServerRequestResolvedNotification['params']): void {
       const requestId = String(params.requestId);
+      const brokerKey = { connectionId, requestId: params.requestId };
+      const userInputPending = userInputBroker.has(brokerKey);
+      const dynamicPending = dynamicToolBroker.has(brokerKey);
+      if (userInputPending || dynamicPending) {
+        // Wake joined duplicates before settling the owner's outer broker
+        // response. This keeps them on the cancellation/reassignment path even
+        // if a resolver starts mirroring broker settlement in the future.
+        forgetPendingUserInputRequest(requestId);
+      }
       const userInputCancelled = userInputBroker.cancel(
-        { connectionId, requestId: params.requestId },
+        brokerKey,
         { answers: {} },
       );
       const dynamicCancelled = dynamicToolBroker.cancel(
-        { connectionId, requestId: params.requestId },
+        brokerKey,
         {
           contentItems: [{ type: 'inputText', text: 'Request was resolved before user input was submitted.' }],
           success: false,
         },
       );
       if (userInputCancelled || dynamicCancelled) {
-        forgetPendingUserInputRequest(requestId);
         eventQueue.push({
           type: 'interaction_dismissed',
           data: { requestId, reason: 'server_request_resolved', resolvedAs: 'deny' },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -646,12 +646,42 @@ function dynamicToolResponseFromUserInput(response: ToolRequestUserInputResponse
 function userInputQuestionsFingerprint(
   questions: readonly ToolRequestUserInputQuestion[],
 ): string {
-  return JSON.stringify(questions);
+  return JSON.stringify(questions.map((question) => ({
+    header: question.header,
+    question: question.question,
+    isOther: question.isOther === true,
+    options: (question.options ?? []).map((option) => ({
+      label: option.label,
+      description: option.description,
+    })),
+  })));
 }
 
-function hasSubmittedUserInput(response: ToolRequestUserInputResponse): boolean {
-  return Object.values(response.answers).some((answer) =>
-    answer?.answers.some((value) => value.trim().length > 0) === true,
+type UserInputAnswersByPosition = string[][];
+
+function userInputAnswersByPosition(
+  questions: readonly ToolRequestUserInputQuestion[],
+  response: ToolRequestUserInputResponse,
+): UserInputAnswersByPosition {
+  return questions.map((question) =>
+    response.answers[question.id]?.answers.slice() ?? [],
+  );
+}
+
+function responseFromUserInputAnswersByPosition(
+  questions: readonly ToolRequestUserInputQuestion[],
+  answersByPosition: readonly (readonly string[])[],
+): ToolRequestUserInputResponse {
+  const answers: ToolRequestUserInputResponse['answers'] = {};
+  questions.forEach((question, index) => {
+    answers[question.id] = { answers: [...(answersByPosition[index] ?? [])] };
+  });
+  return { answers };
+}
+
+function hasSubmittedUserInput(answersByPosition: readonly (readonly string[])[]): boolean {
+  return answersByPosition.some((answers) =>
+    answers.some((value) => value.trim().length > 0),
   );
 }
 
@@ -3502,13 +3532,17 @@ export class CodexAgent extends BaseAgent {
     const userInputBroker = new CodexInteractionBroker<ToolRequestUserInputResponse>();
     const dynamicToolBroker = new CodexInteractionBroker<DynamicToolCallResponse>();
     const activeToolContexts = new Map<string, ActiveToolContext>();
-    // A single model turn can surface the same question through both the
-    // native requestUserInput request and the dynamic-tool compatibility
-    // path. Once the user has submitted a real answer, replay it for an exact
-    // same-turn duplicate instead of asking them a second time.
+    // A single model turn can surface the same visible question through both
+    // the native requestUserInput request and the dynamic-tool compatibility
+    // path. Join an in-flight interaction, then replay its submitted answers
+    // by question position so protocol-specific ids can still differ.
     const submittedUserInputByTurn = new Map<
       string,
-      Map<string, ToolRequestUserInputResponse>
+      Map<string, UserInputAnswersByPosition>
+    >();
+    const pendingUserInputByTurn = new Map<
+      string,
+      Map<string, Promise<UserInputAnswersByPosition>>
     >();
     registerCodexMcpContext(threadId);
     let mcpElicitationSeq = 0;
@@ -4438,6 +4472,7 @@ export class CodexAgent extends BaseAgent {
         if (ctx.turnId === turnId) activeToolContexts.delete(itemId);
       }
       submittedUserInputByTurn.delete(turnId);
+      pendingUserInputByTurn.delete(turnId);
     }
 
     function classifyUserInputRequest(params: ToolRequestUserInputParams): 'ask_user_question' | 'permission' {
@@ -4473,24 +4508,70 @@ export class CodexAgent extends BaseAgent {
           turnId,
           questionCount: questions.length,
         });
-        return replay;
+        return responseFromUserInputAnswersByPosition(questions, replay);
       }
-      const decision = await dispatchInteraction({
-        kind: 'ask_user_question',
-        requestId,
-        questions: questionsToAskUserItems(questions),
-      });
-      if (decision.kind !== 'ask_user_question') {
-        log.warn('requestUserInput got mismatched ask decision', { requestId, decKind: decision.kind });
-        return emptyUserInputResponse(questions);
+
+      let pendingForTurn = turnId ? pendingUserInputByTurn.get(turnId) : undefined;
+      const pendingReplay = fingerprint ? pendingForTurn?.get(fingerprint) : undefined;
+      if (pendingReplay) {
+        log.info('joining duplicate same-turn user input request', {
+          requestId,
+          turnId,
+          questionCount: questions.length,
+        });
+        const answersByPosition = await pendingReplay;
+        return responseFromUserInputAnswersByPosition(questions, answersByPosition);
       }
-      const response = responseFromAskUserAnswers(questions, decision.answers);
-      if (turnId && fingerprint && hasSubmittedUserInput(response)) {
-        const nextSubmittedForTurn = submittedForTurn ?? new Map<string, ToolRequestUserInputResponse>();
-        nextSubmittedForTurn.set(fingerprint, response);
-        if (!submittedForTurn) submittedUserInputByTurn.set(turnId, nextSubmittedForTurn);
+
+      const interactionPromise = (async (): Promise<UserInputAnswersByPosition> => {
+        const decision = await dispatchInteraction({
+          kind: 'ask_user_question',
+          requestId,
+          questions: questionsToAskUserItems(questions),
+        });
+        if (decision.kind !== 'ask_user_question') {
+          log.warn('requestUserInput got mismatched ask decision', { requestId, decKind: decision.kind });
+          return questions.map(() => []);
+        }
+        return userInputAnswersByPosition(
+          questions,
+          responseFromAskUserAnswers(questions, decision.answers),
+        );
+      })();
+
+      if (turnId && fingerprint) {
+        pendingForTurn ??= new Map<string, Promise<UserInputAnswersByPosition>>();
+        pendingForTurn.set(fingerprint, interactionPromise);
+        if (!pendingUserInputByTurn.has(turnId)) {
+          pendingUserInputByTurn.set(turnId, pendingForTurn);
+        }
       }
-      return response;
+
+      try {
+        const answersByPosition = await interactionPromise;
+        if (
+          turnId
+          && fingerprint
+          && pendingUserInputByTurn.get(turnId) === pendingForTurn
+          && hasSubmittedUserInput(answersByPosition)
+        ) {
+          const nextSubmittedForTurn = submittedForTurn
+            ?? new Map<string, UserInputAnswersByPosition>();
+          nextSubmittedForTurn.set(fingerprint, answersByPosition);
+          if (!submittedForTurn) submittedUserInputByTurn.set(turnId, nextSubmittedForTurn);
+        }
+        return responseFromUserInputAnswersByPosition(questions, answersByPosition);
+      } finally {
+        if (turnId && fingerprint && pendingForTurn?.get(fingerprint) === interactionPromise) {
+          pendingForTurn.delete(fingerprint);
+          if (
+            pendingForTurn.size === 0
+            && pendingUserInputByTurn.get(turnId) === pendingForTurn
+          ) {
+            pendingUserInputByTurn.delete(turnId);
+          }
+        }
+      }
     }
 
     async function requestUserInputAsPermission(
@@ -6213,6 +6294,7 @@ export class CodexAgent extends BaseAgent {
           dismissAllPendingUserInput('transport_error');
           activeToolContexts.clear();
           submittedUserInputByTurn.clear();
+          pendingUserInputByTurn.clear();
         }
         const targetsPendingTurn = isTurnStartPending && currentTurnId === null && Boolean(params.turnId);
         // 空 turnId 的容量拒绝: 过载重投的 RPC 还在飞、而它的 turnStarted 尚未到达时,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4483,11 +4483,31 @@ export class CodexAgent extends BaseAgent {
       for (const [itemId, ctx] of activeToolContexts) {
         if (ctx.turnId === turnId) activeToolContexts.delete(itemId);
       }
+      // Lifecycle callers dismiss the broker entries first. Wake joined waiters
+      // before dropping the lookup maps so they can observe that their request
+      // is no longer pending instead of reopening the interaction.
+      const pendingForTurn = pendingUserInputByTurn.get(turnId);
+      if (pendingForTurn) {
+        for (const pendingInteraction of pendingForTurn.values()) {
+          pendingInteraction.cancel();
+        }
+      }
       for (const [requestId, pending] of pendingUserInputOwnerByRequestId) {
         if (pending.turnId === turnId) pendingUserInputOwnerByRequestId.delete(requestId);
       }
       submittedUserInputByTurn.delete(turnId);
       pendingUserInputByTurn.delete(turnId);
+    }
+
+    function clearAllPendingUserInputInteractions(): void {
+      // Keep the same broker-dismiss-before-wake ordering as the per-turn path.
+      for (const pendingForTurn of pendingUserInputByTurn.values()) {
+        for (const pendingInteraction of pendingForTurn.values()) {
+          pendingInteraction.cancel();
+        }
+      }
+      pendingUserInputByTurn.clear();
+      pendingUserInputOwnerByRequestId.clear();
     }
 
     function forgetPendingUserInputRequest(requestId: string): void {
@@ -4558,6 +4578,10 @@ export class CodexAgent extends BaseAgent {
           pendingReplay.cancelledPromise.then(() => ({ kind: 'cancelled' as const })),
         ]);
         if (joined.kind === 'cancelled') {
+          log.debug('joined duplicate same-turn user input request cancelled', {
+            requestId,
+            turnId,
+          });
           return isRequestPending()
             ? askUserViaInteraction(requestId, questions, turnId, isRequestPending)
             : emptyUserInputResponse(questions);
@@ -6370,8 +6394,7 @@ export class CodexAgent extends BaseAgent {
           dismissAllPendingUserInput('transport_error');
           activeToolContexts.clear();
           submittedUserInputByTurn.clear();
-          pendingUserInputByTurn.clear();
-          pendingUserInputOwnerByRequestId.clear();
+          clearAllPendingUserInputInteractions();
         }
         const targetsPendingTurn = isTurnStartPending && currentTurnId === null && Boolean(params.turnId);
         // 空 turnId 的容量拒绝: 过载重投的 RPC 还在飞、而它的 turnStarted 尚未到达时,
@@ -7453,6 +7476,7 @@ export class CodexAgent extends BaseAgent {
         // 否则 server 那边没回 response 会卡; UI 上的 PermissionPrompt 也会留尸
         try { dismissAllPending('session_closed', 'deny'); } catch (e) { log.warn('dismissAllPending threw', { error: String(e) }); }
         try { dismissAllPendingUserInput('session_closed'); } catch (e) { log.warn('dismissAllPendingUserInput threw', { error: String(e) }); }
+        try { clearAllPendingUserInputInteractions(); } catch (e) { log.warn('clear pending user input threw', { error: String(e) }); }
         try { stopActiveRolloutPlanFallback(); } catch (e) { log.warn('stop rollout plan fallback threw', { error: String(e) }); }
         // 挂起的过载重投计时器必须清掉：否则会话已关，计时器到点仍会对已释放的
         // thread 发 turn/start（assertCurrentHost 会抛，但那是在无人接收的


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 同一轮可能通过原生 `requestUserInput` 与动态工具兼容路径重复提交完全相同的问题。现在会在用户已经给出有效答案后，按“同一 turn + 归一化问题内容”复用首次答案，避免再次弹出提问；turn 结束或传输异常时会清理缓存。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#922
- 本 PR 包含：maker-core 的 Codex 用户提问去重、turn/transport 清理，以及跨原生/动态工具路径的回归测试。
- 明确不包含：Renderer 卡片样式修改、跨 turn 去重、权限提问去重。
- 用户可见变化：同一轮中已经回答过的完全相同问题不再重复出现；新一轮仍可再次询问。
- 是否存在 breaking change：无。

### UI 变化

不涉及视觉、布局、组件或 UI 文案修改；仅修正重复展示的交互行为。用户已确认该行为调整。

- 引用的设计规范：`DESIGN.md` §14 Interaction Conventions：可由代码统一保证的交互行为应集中实现；本次在 maker-core 的两条协议入口汇合处去重。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts -t "routes dynamic ask_user_question tool calls through ask_user_question"
结果：通过，1 passed。

pnpm --filter @cindy/maker-core test
结果：通过，51 个测试文件、818 个测试全部通过。

pnpm test:unit
结果：通过，Desktop、Mobile、maker-core 及协议子模块全部可运行的 unit workspace 通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：该 package 未定义 typecheck script，按仓库门禁约定跳过。
```

额外检查：

- `pnpm --filter @cindy/maker-core build`：未通过；仅报告 `index.test.ts:480` 与 `index.test.ts:4342` 两处 origin/main 已存在、且不在本次 diff 的元组类型错误。
- `pnpm --filter @cindy/maker-core lint`：未通过；报告 14 项 origin/main 已存在、且不在本次修改行的 lint 错误。

### 手工验证

未执行 macOS 实机交互验证；本次回归测试直接覆盖动态工具与原生请求在同一 turn 重复到达的路径。

### 未执行的验证

- 未执行 Desktop 实机目检：本次没有视觉、布局、文案或主题样式改动。
- 未执行 Mobile 实机验证：未修改 Mobile 代码、原生配置、原生依赖、config plugin 或 runtime fingerprint 输入。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：同一 turn 内完全相同的业务提问会复用首次有效答案。

### 影响与回滚

- 影响范围：仅 Codex ask-user-question 业务提问；秘密问题与权限提问维持原行为。完全相同的问题若确需重新询问，应在下一 turn 发起。
- 回滚 / 降级方式：回滚本提交即可恢复原有逐请求询问行为。
- Mobile 冷更判断：不会触发。改动只涉及 `packages/maker-core` 的 TypeScript 运行逻辑与测试，没有触及 Mobile 原生配置、原生依赖、config plugin 或 runtime fingerprint 输入。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因