### PR TITLE
fix(desktop): open terminal links in system browser

### DIFF
--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/__tests__/xtermPool.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/__tests__/xtermPool.test.ts
@@ -4,12 +4,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { openTerminalExternalLink } from '../xtermPool';
 
+const { warn } = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ warn }),
+}));
+
 describe('openTerminalExternalLink', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
-  it('routes detected URLs through the host external-link bridge', () => {
+  it('routes detected URLs through the host external-link bridge', async () => {
     const openExternal = vi.fn().mockResolvedValue({ success: true });
     Object.defineProperty(window, 'electronAPI', {
       configurable: true,
@@ -23,5 +31,34 @@ describe('openTerminalExternalLink', () => {
 
     expect(openExternal).toHaveBeenCalledOnce();
     expect(openExternal).toHaveBeenCalledWith(url);
+    await vi.waitFor(() => expect(warn).not.toHaveBeenCalled());
+  });
+
+  it('logs when the host rejects or cannot open the URL', async () => {
+    const openExternal = vi.fn().mockResolvedValue({ success: false });
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { openExternal },
+    });
+
+    openTerminalExternalLink(new MouseEvent('click'), 'https://example.com/rejected');
+
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith('terminal link open rejected or failed');
+    });
+  });
+
+  it('logs when the external-link IPC call fails', async () => {
+    const openExternal = vi.fn().mockRejectedValue(new Error('IPC unavailable'));
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { openExternal },
+    });
+
+    openTerminalExternalLink(new MouseEvent('click'), 'https://example.com/ipc-error');
+
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith('terminal link open IPC failed');
+    });
   });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/__tests__/xtermPool.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/__tests__/xtermPool.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { openTerminalExternalLink } from '../xtermPool';
+
+describe('openTerminalExternalLink', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes detected URLs through the host external-link bridge', () => {
+    const openExternal = vi.fn().mockResolvedValue({ success: true });
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { openExternal },
+    });
+
+    const event = new MouseEvent('click');
+    const url = 'https://git.example.com/project/-/merge_requests/42';
+
+    openTerminalExternalLink(event, url);
+
+    expect(openExternal).toHaveBeenCalledOnce();
+    expect(openExternal).toHaveBeenCalledWith(url);
+  });
+});

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/xtermPool.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/xtermPool.ts
@@ -68,7 +68,11 @@ export function getOrCreateXterm(tabId: string): XtermEntry {
   if (entry) return entry;
   const terminal = new Terminal(DEFAULT_OPTIONS);
   const fitAddon = new FitAddon();
-  const webLinks = new WebLinksAddon();
+  // xterm's default link handler uses `window.open()`. In an Electron
+  // renderer that creates a popup window, which is intentionally blocked by
+  // the app's window policy and leaves terminal links inert. Route the click
+  // through the existing main-process URL allowlist instead.
+  const webLinks = new WebLinksAddon(openTerminalExternalLink);
   terminal.loadAddon(fitAddon);
   terminal.loadAddon(webLinks);
   attachSelectionCopyShortcut(terminal);
@@ -80,6 +84,17 @@ export function getOrCreateXterm(tabId: string): XtermEntry {
   };
   pool.set(tabId, entry);
   return entry;
+}
+
+/**
+ * Open a link detected in the terminal through the privileged host bridge.
+ *
+ * The main-process `shell:open-external` handler validates the URL protocol
+ * before delegating to the operating system, so the renderer never opens
+ * arbitrary terminal output directly.
+ */
+export function openTerminalExternalLink(_event: MouseEvent, uri: string): void {
+  void window.electronAPI.openExternal(uri).catch(() => undefined);
 }
 
 /**

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/xtermPool.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/terminal/lib/xtermPool.ts
@@ -24,6 +24,10 @@ import { Terminal, type ITerminalOptions } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('terminal');
+
 export interface XtermEntry {
   terminal: Terminal;
   fitAddon: FitAddon;
@@ -94,7 +98,17 @@ export function getOrCreateXterm(tabId: string): XtermEntry {
  * arbitrary terminal output directly.
  */
 export function openTerminalExternalLink(_event: MouseEvent, uri: string): void {
-  void window.electronAPI.openExternal(uri).catch(() => undefined);
+  void window.electronAPI
+    .openExternal(uri)
+    .then((result) => {
+      if (!result.success) {
+        // Do not log the URL: terminal output may contain sensitive query parameters.
+        log.warn('terminal link open rejected or failed');
+      }
+    })
+    .catch(() => {
+      log.warn('terminal link open IPC failed');
+    });
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Cindy 内置终端中已识别的 HTTP/HTTPS 链接点击无响应的问题。xterm 默认会调用 `window.open()` 创建弹窗，而 Cindy 的 Electron 窗口策略会拦截该弹窗；现在改为通过现有的 `window.electronAPI.openExternal` 宿主桥接，由 Main 进程校验协议后交给系统默认浏览器打开。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #921
- 本 PR 包含：终端链接打开处理、链接路由回归测试
- 明确不包含：URL 白名单、IPC 协议及其他终端行为变更
- 用户可见变化：点击终端中识别出的 HTTP/HTTPS 链接会打开系统默认浏览器
- 是否存在 breaking change：无

## UI 变化

无视觉样式变化；仅修复终端已识别链接的点击交互。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §交互与系统行为：外部链接通过宿主安全通道交给系统浏览器打开。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
pnpm --filter desktop exec vitest run src/renderer/features/right-sidebar/plugins/terminal/lib/__tests__/xtermPool.test.ts
pnpm test:unit
pnpm check:dco

结果：全部通过；根单测 310 passed、1 skipped。
```

### 手工验证

在 macOS Cindy Desktop 的内置 Terminal 中输出一个 HTTP/HTTPS URL，确认 URL 被下划线识别后，点击会在系统默认浏览器打开。已验证 issue #921 的必现路径已恢复。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

仅改变终端链接点击的 Renderer 路由，继续复用既有 Main 侧 HTTP/HTTPS 协议校验和 `shell.openExternal`。不改变终端输出、PTY、URL 白名单或其他外链入口；如需回滚，恢复 `WebLinksAddon` 的默认构造方式即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果
