### PR TITLE
fix(desktop): 更新公告改单栏版式,感谢行收到各版本末尾

### DIFF
--- a/apps/desktop/src/renderer/__tests__/updateNoticeDialogLayout.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateNoticeDialogLayout.test.tsx
@@ -84,11 +84,20 @@ describe('UpdateNoticeDialog 单栏版式', () => {
     const lines = screen.getAllByText(thanksLabel);
     expect(lines).toHaveLength(2);
 
-    // 每条感谢行所在的块里,能同时找到该版本号与该版本的名单。
+    // 每条感谢行所在的块里,必须同时能找到该版本号与该版本的名单,
+    // 且不含另一个版本的任何一项——这样才能证明名单没有跨版本漂移。
     const blockOf = (el: HTMLElement) => el.closest('div.flex.flex-col') as HTMLElement;
     const first = blockOf(lines[0].parentElement as HTMLElement);
+    expect(within(first).getByText('v0.1.21')).toBeTruthy();
     expect(within(first).getByText('Kafeifei · yan')).toBeTruthy();
+    expect(within(first).queryByText('v0.1.17')).toBeNull();
     expect(within(first).queryByText('Silas · Kmny')).toBeNull();
+
+    const second = blockOf(lines[1].parentElement as HTMLElement);
+    expect(within(second).getByText('v0.1.17')).toBeTruthy();
+    expect(within(second).getByText('Silas · Kmny')).toBeTruthy();
+    expect(within(second).queryByText('v0.1.21')).toBeNull();
+    expect(within(second).queryByText('Kafeifei · yan')).toBeNull();
   });
 
   it('旧格式(作者分组)也走单栏:两个小节标题都在,无左右分栏', () => {
@@ -110,6 +119,22 @@ describe('UpdateNoticeDialog 单栏版式', () => {
     renderDialog([notes]);
     expect(screen.queryByText(i18n.t('update.notice.newFeatures'))).toBeNull();
     expect(screen.getByText(i18n.t('update.notice.bugFixes'))).toBeTruthy();
+  });
+
+  it('未知小节标题原样透出,不被误标成「新功能」', () => {
+    const notes: ReleaseNotes = {
+      ...legacyNotes('0.1.15', ['Silas']),
+      sections: [
+        { title: 'New Features', items: [{ text: 'A', by: 'Silas' }] },
+        { title: 'Performance', items: [{ text: 'B', by: 'Silas' }] },
+        { title: 'Docs', items: [{ text: 'C', by: 'Silas' }] },
+      ],
+    };
+    renderDialog([notes]);
+    expect(screen.getByText('Performance')).toBeTruthy();
+    expect(screen.getByText('Docs')).toBeTruthy();
+    // 「新功能」只出现一次(仅 New Features 那一节),不会因多个非修复小节重复。
+    expect(screen.getAllByText(i18n.t('update.notice.newFeatures'))).toHaveLength(1);
   });
 
   it('单版本 auto 模式的版本号与日期在版本块里,不在标题栏', () => {

--- a/apps/desktop/src/renderer/__tests__/updateNoticeDialogLayout.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateNoticeDialogLayout.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+/**
+ * Layout contract for the update-notice dialog after the single-column rework.
+ *
+ * These lock the behaviours the rework exists to guarantee — every one of them
+ * was a visible defect before:
+ *   1. the contributor list is rendered ONCE per version (it used to appear in
+ *      the dialog chrome AND in the version subheader simultaneously);
+ *   2. thanks is anchored to the end of its own version block, so with several
+ *      versions on screen each list belongs to an unambiguous version;
+ *   3. legacy (author-grouped) payloads render in the same single column as v2
+ *      topic payloads instead of a two-column split;
+ *   4. a version that is merely queued (idle) does not claim to be loading.
+ */
+
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import '@/i18n';
+import i18n from '@/i18n';
+import { UpdateNoticeDialog } from '@/components/UpdateNoticeDialog';
+import type { ReleaseNotes } from '@/release-notes';
+
+function topicNotes(version: string, contributors: string[]): ReleaseNotes {
+  return {
+    version,
+    date: '2026-07-29',
+    contributors,
+    sections: [],
+    intro: '本次合并 77 个 PR。',
+    topics: [
+      {
+        emoji: '🛠️',
+        title: '后台任务面板',
+        text: '右栏新增后台任务面板。',
+        contributors: [contributors[0]],
+      },
+    ],
+  };
+}
+
+function legacyNotes(version: string, contributors: string[]): ReleaseNotes {
+  return {
+    version,
+    date: '2026-07-27',
+    contributors,
+    topics: [],
+    sections: [
+      { title: 'New Features', items: [{ text: '新增了一个东西', by: contributors[0] }] },
+      { title: 'Bug Fixes', items: [{ text: '修了一个问题', by: contributors[0] }] },
+    ],
+  };
+}
+
+function renderDialog(notes: ReleaseNotes[]) {
+  return render(
+    <UpdateNoticeDialog
+      open
+      mode="auto"
+      releaseNotes={notes}
+      allVersions={null}
+      loadVersion={vi.fn().mockResolvedValue(null)}
+      onDismiss={vi.fn()}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+describe('UpdateNoticeDialog 单栏版式', () => {
+  it('贡献者名单每个版本只渲染一次,不再 chrome 与子头各一份', () => {
+    renderDialog([topicNotes('0.1.21', ['Kafeifei', 'yan', 'Dash'])]);
+    const joined = 'Kafeifei · yan · Dash';
+    expect(screen.getAllByText(joined)).toHaveLength(1);
+  });
+
+  it('感谢行落在各自版本块内,多版本同屏时归属明确', () => {
+    renderDialog([
+      topicNotes('0.1.21', ['Kafeifei', 'yan']),
+      legacyNotes('0.1.17', ['Silas', 'Kmny']),
+    ]);
+    const thanksLabel = i18n.t('update.notice.thanksTo');
+    const lines = screen.getAllByText(thanksLabel);
+    expect(lines).toHaveLength(2);
+
+    // 每条感谢行所在的块里,能同时找到该版本号与该版本的名单。
+    const blockOf = (el: HTMLElement) => el.closest('div.flex.flex-col') as HTMLElement;
+    const first = blockOf(lines[0].parentElement as HTMLElement);
+    expect(within(first).getByText('Kafeifei · yan')).toBeTruthy();
+    expect(within(first).queryByText('Silas · Kmny')).toBeNull();
+  });
+
+  it('旧格式(作者分组)也走单栏:两个小节标题都在,无左右分栏', () => {
+    renderDialog([legacyNotes('0.1.17', ['Silas'])]);
+    expect(screen.getByText(i18n.t('update.notice.newFeatures'))).toBeTruthy();
+    expect(screen.getByText(i18n.t('update.notice.bugFixes'))).toBeTruthy();
+    expect(screen.getByText('新增了一个东西')).toBeTruthy();
+    expect(screen.getByText('修了一个问题')).toBeTruthy();
+  });
+
+  it('空小节不渲染成一个光秃秃的标题', () => {
+    const notes: ReleaseNotes = {
+      ...legacyNotes('0.1.16', ['Silas']),
+      sections: [
+        { title: 'New Features', items: [] },
+        { title: 'Bug Fixes', items: [{ text: '只有修复', by: 'Silas' }] },
+      ],
+    };
+    renderDialog([notes]);
+    expect(screen.queryByText(i18n.t('update.notice.newFeatures'))).toBeNull();
+    expect(screen.getByText(i18n.t('update.notice.bugFixes'))).toBeTruthy();
+  });
+
+  it('单版本 auto 模式的版本号与日期在版本块里,不在标题栏', () => {
+    renderDialog([topicNotes('0.1.21', ['Kafeifei'])]);
+    expect(screen.getByText('v0.1.21')).toBeTruthy();
+    // 标题栏右侧在单版本 auto 下不再显示日期或版本计数。
+    expect(screen.queryByText(i18n.t('update.notice.versionsSpan', { count: 1 }))).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
@@ -127,10 +127,21 @@ function groupItemsByAuthor(
  */
 function SectionList({ sections }: { sections: ReleaseNoteSection[] }) {
   const { t } = useTranslation();
-  const labelFor = (title: string) =>
-    title === 'Bug Fixes'
-      ? { text: t('update.notice.bugFixes'), Icon: SECTION_ICONS.wrench }
-      : { text: t('update.notice.newFeatures'), Icon: SECTION_ICONS.zap };
+  // Only the two canonical titles get translated. The legacy schema allows an
+  // arbitrary section title, and headings are now per-section rather than
+  // per-column, so mapping "anything that isn't Bug Fixes" to "New Features"
+  // would mislabel unknown sections and print the same heading twice when a
+  // payload carries several non-bugfix sections. Unknown titles pass through
+  // verbatim.
+  const labelFor = (title: string) => {
+    if (title === 'Bug Fixes') {
+      return { text: t('update.notice.bugFixes'), Icon: SECTION_ICONS.wrench };
+    }
+    if (title === 'New Features') {
+      return { text: t('update.notice.newFeatures'), Icon: SECTION_ICONS.zap };
+    }
+    return { text: title, Icon: SECTION_ICONS.zap };
+  };
   const filled = sections.filter((s) => s.items.length > 0);
   return (
     <>
@@ -376,6 +387,13 @@ interface VersionDropdownProps {
   onSelect: (version: string) => void;
   triggerLabel: string;
   /**
+   * Accessible name for the trigger. Must be given separately from
+   * `triggerLabel`: the visible chip only shows a version *count*, so reusing
+   * it as the accessible name would leave screen-reader users with no way to
+   * tell which version they are currently on without opening the menu.
+   */
+  triggerAriaLabel: string;
+  /**
    * Bubble open state up so the parent AlertDialog can guard its overlay
    * onClick — Radix outside-click closes the dropdown but the click continues
    * to propagate; without the guard it would land on `AlertDialog.Overlay`
@@ -389,6 +407,7 @@ function VersionDropdown({
   currentVersion,
   onSelect,
   triggerLabel,
+  triggerAriaLabel,
   onOpenChange,
 }: VersionDropdownProps) {
   return (
@@ -397,7 +416,7 @@ function VersionDropdown({
         <button
           type="button"
           className="inline-flex outline-none"
-          aria-label={triggerLabel}
+          aria-label={triggerAriaLabel}
         >
           {/* The trigger now reads "N versions", not a version number, so the
               flame glyph would be misleading — hence icon={false}. */}
@@ -832,6 +851,10 @@ export function UpdateNoticeDialog({
                   versions={allVersions}
                   currentVersion={stickyVersion || newest.version}
                   triggerLabel={versionCountLabel}
+                  triggerAriaLabel={t('update.notice.versionJumpAria', {
+                    count: allVersions.length,
+                    version: stickyVersion || newest.version,
+                  })}
                   onSelect={(v) => jumpRef.current?.(v)}
                   onOpenChange={(dropOpen) => {
                     dropdownOpenRef.current = dropOpen;

--- a/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
@@ -62,40 +62,8 @@ function formatDate(dateStr: string, locale: string): string {
   });
 }
 
-/** Split sections: left = New Features + other non-Bug-Fixes, right = Bug Fixes */
-function splitSections(sections: ReleaseNoteSection[]): {
-  leftSections: ReleaseNoteSection[];
-  rightSections: ReleaseNoteSection[];
-} {
-  const left: ReleaseNoteSection[] = [];
-  const right: ReleaseNoteSection[] = [];
-  for (const section of sections) {
-    if (section.title === 'Bug Fixes') {
-      right.push(section);
-    } else {
-      left.push(section);
-    }
-  }
-  return { leftSections: left, rightSections: right };
-}
-
-/**
- * Aggregate unique contributors across every currently-loaded version,
- * preserving first-appearance order. Used for the header hall-of-fame line.
- */
-function aggregateContributors(notes: ReleaseNotes[]): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const n of notes) {
-    for (const c of n.contributors) {
-      if (!seen.has(c)) {
-        seen.add(c);
-        out.push(c);
-      }
-    }
-  }
-  return out;
-}
+/** Shared content column: one reading measure for every block in the dialog. */
+const CONTENT_COLUMN = 'w-full max-w-[800px]';
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -105,34 +73,33 @@ interface VersionBadgeProps {
   label: string;
   /** Renders a small chevron on the right and hover state — used by dropdown trigger. */
   clickable?: boolean;
+  /** Leading flame glyph. Off for the header's version-jump chip, which is a count, not a version. */
+  icon?: boolean;
 }
 
-function VersionBadge({ label, clickable = false }: VersionBadgeProps) {
+function VersionBadge({ label, clickable = false, icon = true }: VersionBadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-full px-3 py-1',
+        'inline-flex items-center gap-1.5 rounded-full px-3 py-1 whitespace-nowrap',
         'bg-[var(--chat-input-chip-bg)]',
-        'text-xs font-medium text-[var(--settings-section-desc)]',
+        // Chip text must use the chip's own semantic color. The previous
+        // `--settings-section-desc` resolves to a mid grey that lands at
+        // 2.33:1 against the chip background in dark mode (fails WCAG AA);
+        // `--chat-input-chip-text` is the sanctioned pairing (7.46:1 dark,
+        // 12:1 light).
+        'text-xs font-medium text-[var(--chat-input-chip-text)]',
         clickable && 'cursor-pointer hover:bg-[var(--cmd-palette-item-hover)] transition-colors',
       )}
     >
-      <Flame className="h-[13px] w-[13px]" />
+      {icon && <Flame className="h-[13px] w-[13px] shrink-0" />}
       {label}
-      {clickable && <ChevronDown className="h-[13px] w-[13px] opacity-70" />}
+      {clickable && <ChevronDown className="h-[13px] w-[13px] shrink-0 opacity-70" />}
     </span>
   );
 }
 
 const SECTION_ICONS = { zap: Zap, wrench: Wrench } as const;
-
-interface SectionColumnProps {
-  icon: keyof typeof SECTION_ICONS;
-  title: string;
-  sections: ReleaseNoteSection[];
-  /** When false, the column doesn't own its own scroll — the outer container scrolls instead. */
-  scroll?: boolean;
-}
 
 function groupItemsByAuthor(
   items: ReleaseNoteItem[],
@@ -149,22 +116,44 @@ function groupItemsByAuthor(
   return order.map((author) => ({ author, items: buckets.get(author)! }));
 }
 
-function SectionColumn({ icon, title, sections, scroll = true }: SectionColumnProps) {
-  const Icon = SECTION_ICONS[icon];
-  const allItems = sections.flatMap((s) => s.items);
-  const groups = groupItemsByAuthor(allItems);
+/**
+ * Legacy (author-grouped) body, rendered in the SAME single column as the v2
+ * topic layout. Previously this was a two-column split (features | fixes),
+ * which left half the dialog empty on bugfix-only releases and — more
+ * importantly — made scrolling through history alternate between two very
+ * different layouts, since only the newest release uses the topic format.
+ *
+ * Empty sections are dropped rather than rendered as a bare heading.
+ */
+function SectionList({ sections }: { sections: ReleaseNoteSection[] }) {
+  const { t } = useTranslation();
+  const labelFor = (title: string) =>
+    title === 'Bug Fixes'
+      ? { text: t('update.notice.bugFixes'), Icon: SECTION_ICONS.wrench }
+      : { text: t('update.notice.newFeatures'), Icon: SECTION_ICONS.zap };
+  const filled = sections.filter((s) => s.items.length > 0);
   return (
-    <div className={cn('flex flex-1 flex-col px-7', scroll && 'overflow-y-auto')}>
-      <div className="flex items-center gap-1.5 mb-3">
-        <Icon className="h-3.5 w-3.5 text-[var(--cmd-palette-item-meta)]" />
-        <span className="text-13 font-medium text-[var(--cmd-palette-item-meta)]">{title}</span>
-      </div>
-      <div className="flex flex-col gap-3.5">
-        {groups.map((group) => (
-          <AuthorGroup key={group.author} author={group.author} items={group.items} />
-        ))}
-      </div>
-    </div>
+    <>
+      {filled.map((section, i) => {
+        const { text, Icon } = labelFor(section.title);
+        const groups = groupItemsByAuthor(section.items);
+        return (
+          <div key={`${i}-${section.title}`} className={cn(CONTENT_COLUMN, 'pt-4 pb-1')}>
+            <div className="mb-2.5 flex items-center gap-1.5">
+              <Icon className="h-3.5 w-3.5 shrink-0 text-[var(--cmd-palette-item-meta)]" />
+              <span className="text-13 font-medium text-[var(--cmd-palette-item-meta)]">
+                {text}
+              </span>
+            </div>
+            <div className="flex flex-col gap-3.5">
+              {groups.map((group) => (
+                <AuthorGroup key={group.author} author={group.author} items={group.items} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </>
   );
 }
 
@@ -195,24 +184,35 @@ function AuthorGroup({ author, items }: { author: string; items: ReleaseNoteItem
   );
 }
 
-function ContributorsLine({ contributors }: { contributors: string[] }) {
+/**
+ * Per-version thanks line, closing out that version's block like film credits.
+ *
+ * It used to live in the dialog chrome, which meant the same list was rendered
+ * twice at once (chrome + the version block's own subheader) and, at ~30
+ * contributors, turned the top of the dialog into a two-line wall of names.
+ * Anchoring it to the end of the version it belongs to removes the duplication
+ * and makes the attribution unambiguous. Regular weight + secondary color keeps
+ * it a closing note rather than a heading.
+ */
+function ThanksLine({ contributors }: { contributors: string[] }) {
   const { t } = useTranslation();
   if (contributors.length === 0) return null;
   return (
     <div
       className={cn(
-        'flex items-center justify-center gap-1.5 px-6 pb-3',
-        'text-12 leading-none select-text',
+        CONTENT_COLUMN,
+        'mt-3 flex items-start gap-1.5 border-t border-[var(--cmd-palette-border)] pt-4',
+        'text-12 leading-[1.7] select-text',
       )}
     >
-      <span className="flex h-[12px] items-center">
-        <Flower
-          className="h-3.5 w-3.5 text-[var(--status-bar-accent)] -translate-y-[2px]"
-          strokeWidth={2.25}
-        />
+      <Flower
+        className="mt-[3px] h-3.5 w-3.5 shrink-0 text-[var(--status-bar-accent)]"
+        strokeWidth={2.25}
+      />
+      <span className="shrink-0 text-[var(--cmd-palette-item-meta)]">
+        {t('update.notice.thanksTo')}
       </span>
-      <span className="text-[var(--cmd-palette-item-meta)]">{t('update.notice.thanksTo')}</span>
-      <span className="font-semibold text-[var(--msg-assistant-text)]">
+      <span className="min-w-0 break-words text-[var(--cmd-palette-item-meta)]">
         {contributors.join(' · ')}
       </span>
     </div>
@@ -227,14 +227,19 @@ function ContributorsLine({ contributors }: { contributors: string[] }) {
 
 function TopicList({ intro, topics }: { intro?: string; topics: ReleaseNoteTopic[] }) {
   return (
-    <div className="flex flex-col items-center px-7">
+    <>
       {intro && (
-        <div className="w-full max-w-[760px] pb-3 text-sm leading-[1.7] break-words text-[var(--cmd-palette-item-meta)]">
+        <div
+          className={cn(
+            CONTENT_COLUMN,
+            'pt-3 pb-1 text-sm leading-[1.7] break-words text-[var(--cmd-palette-item-meta)]',
+          )}
+        >
           {intro}
         </div>
       )}
       {topics.map((topic, i) => (
-        <div key={`${i}-${topic.title}`} className="w-full max-w-[760px] py-3">
+        <div key={`${i}-${topic.title}`} className={cn(CONTENT_COLUMN, 'py-3')}>
           {/* flex-wrap + min-w-0: long titles shrink/wrap and an overlong
               contributor list drops to its own right-aligned line instead of
               overflowing the dialog at narrow widths. */}
@@ -259,55 +264,40 @@ function TopicList({ intro, topics }: { intro?: string; topics: ReleaseNoteTopic
           </div>
         </div>
       ))}
-    </div>
+    </>
   );
 }
 
 /**
- * A loaded version's block — subheader (version badge + date + contributors)
- * on top, body below: topic list for v2 payloads, two-column
- * features/bugfixes for legacy ones. Same layout auto and manual modes
- * share; the outer container owns scrolling in both cases.
+ * One version's block, single column throughout:
+ *
+ *   [v0.1.21]  2026年7月29日      <- subheader: version + date only
+ *   intro / topics (v2)  or  sections (legacy)
+ *   ─────────────────────────
+ *   🌸 感谢 A · B · C            <- closing thanks line
+ *
+ * The subheader deliberately no longer repeats the contributor list: it is the
+ * thanks line's job, once, at the end. The outer container owns scrolling.
  */
 function VersionBlock({ notes, locale }: { notes: ReleaseNotes; locale: string }) {
-  const { t } = useTranslation();
   const isTopicFormat = notes.topics.length > 0;
-  const { leftSections, rightSections } = splitSections(notes.sections);
   const formattedDate = formatDate(notes.date, locale);
   return (
-    <div className="flex flex-col">
-      <div className="flex items-center justify-between px-7 pt-3 pb-2.5">
-        <div className="flex items-center gap-2">
-          <VersionBadge label={`v${notes.version}`} />
-          <span className="text-13 text-[var(--cmd-palette-item-meta)]">{formattedDate}</span>
-        </div>
-        {notes.contributors.length > 0 && (
-          <span className="text-12 text-[var(--cmd-palette-item-meta)]">
-            {notes.contributors.join(' · ')}
-          </span>
-        )}
+    <div className="flex flex-col items-center px-7 pb-2">
+      <div className={cn(CONTENT_COLUMN, 'flex items-center gap-2 pt-5')}>
+        <VersionBadge label={`v${notes.version}`} />
+        {/* nowrap: a long date must not be squeezed into three lines by
+            whatever sits next to it (the old subheader did exactly that). */}
+        <span className="whitespace-nowrap text-13 text-[var(--cmd-palette-item-meta)]">
+          {formattedDate}
+        </span>
       </div>
       {isTopicFormat ? (
-        <div className="py-3">
-          <TopicList intro={notes.intro} topics={notes.topics} />
-        </div>
+        <TopicList intro={notes.intro} topics={notes.topics} />
       ) : (
-        <div className="flex py-3">
-          <SectionColumn
-            icon="zap"
-            title={t('update.notice.newFeatures')}
-            sections={leftSections}
-            scroll={false}
-          />
-          <div className="w-px self-stretch bg-[var(--cmd-palette-border)]" />
-          <SectionColumn
-            icon="wrench"
-            title={t('update.notice.bugFixes')}
-            sections={rightSections}
-            scroll={false}
-          />
-        </div>
+        <SectionList sections={notes.sections} />
       )}
+      <ThanksLine contributors={notes.contributors} />
     </div>
   );
 }
@@ -328,14 +318,20 @@ function PlaceholderBlock({
   onRetry,
 }: {
   version: string;
+  /**
+   * True only while a fetch is actually in flight. `idle` (queued but not yet
+   * observed) must NOT set this: every off-screen version used to render a
+   * spinner + "loading", so a user opening the history saw a dozen versions
+   * apparently stuck loading forever when in fact nothing had been requested.
+   */
   isLoading: boolean;
   isError: boolean;
   onRetry?: () => void;
 }) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col min-h-[180px]">
-      <div className="flex items-center justify-between px-7 pt-3 pb-2.5">
+    <div className="flex min-h-[180px] flex-col items-center px-7">
+      <div className={cn(CONTENT_COLUMN, 'flex items-center gap-3 pt-5')}>
         <VersionBadge label={`v${version}`} />
         {isLoading && (
           <span className="inline-flex items-center gap-1.5 text-12 text-[var(--cmd-palette-item-meta)]">
@@ -363,13 +359,9 @@ function PlaceholderBlock({
           </span>
         )}
       </div>
-      <div className="flex flex-1 min-h-[120px] items-center justify-center px-7">
-        {!isLoading && !isError && (
-          <span className="text-12 text-[var(--cmd-palette-item-meta)] opacity-40">
-            &nbsp;
-          </span>
-        )}
-      </div>
+      {/* Idle (not yet scrolled near, nothing in flight) renders as reserved
+          blank space, not as a spinner — see PlaceholderBlock's isLoading doc. */}
+      <div className="flex min-h-[120px] flex-1 items-center justify-center" aria-hidden />
     </div>
   );
 }
@@ -407,13 +399,15 @@ function VersionDropdown({
           className="inline-flex outline-none"
           aria-label={triggerLabel}
         >
-          <VersionBadge label={triggerLabel} clickable />
+          {/* The trigger now reads "N versions", not a version number, so the
+              flame glyph would be misleading — hence icon={false}. */}
+          <VersionBadge label={triggerLabel} clickable icon={false} />
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
         <DropdownMenu.Content
           side="bottom"
-          align="start"
+          align="end"
           sideOffset={6}
           // Stop clicks inside dropdown content from bubbling — belt-and-
           // suspenders on top of `modal` prop + parent dropdownOpenRef guard.
@@ -472,7 +466,7 @@ function AutoBody({
     <div className="flex flex-1 min-h-0 flex-col overflow-y-auto py-2 select-text">
       {releaseNotes.map((notes, i) => (
         <div key={notes.version} className="flex flex-col">
-          {i > 0 && <div className="h-px mx-6 my-1 bg-[var(--cmd-palette-border)]" />}
+          {i > 0 && <div className="mx-auto h-px w-full max-w-[800px] bg-[var(--cmd-palette-border)]" />}
           <VersionBlock notes={notes} locale={locale} />
         </div>
       ))}
@@ -496,8 +490,6 @@ interface ManualBodyProps {
   onStickyChange: (version: string) => void;
   /** Setter registered by parent so `jumpToVersion` can programmatically scroll. */
   registerJump: (fn: (v: string) => void) => void;
-  /** Called each time a version's notes finish loading, so parent can aggregate contributors. */
-  onNotesLoaded?: (notes: ReleaseNotes) => void;
 }
 
 function ManualBody({
@@ -507,7 +499,6 @@ function ManualBody({
   locale,
   onStickyChange,
   registerJump,
-  onNotesLoaded,
 }: ManualBodyProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const blockRefs = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -543,7 +534,6 @@ function ManualBody({
         if (notes) {
           setNotesMap((prev) => new Map(prev).set(version, notes));
           setStateMap((prev) => new Map(prev).set(version, 'loaded'));
-          onNotesLoaded?.(notes);
         } else {
           setStateMap((prev) => new Map(prev).set(version, 'error'));
         }
@@ -553,7 +543,7 @@ function ManualBody({
         inFlightRef.current.delete(version);
       }
     },
-    [loadVersion, onNotesLoaded],
+    [loadVersion],
   );
 
   // Manual retry from the error placeholder's button. Only meaningful for
@@ -650,13 +640,13 @@ function ManualBody({
             data-version={v}
             className="flex flex-col"
           >
-            {i > 0 && <div className="h-px mx-6 my-1 bg-[var(--cmd-palette-border)]" />}
+            {i > 0 && <div className="mx-auto h-px w-full max-w-[800px] bg-[var(--cmd-palette-border)]" />}
             {notes ? (
               <VersionBlock notes={notes} locale={locale} />
             ) : (
               <PlaceholderBlock
                 version={v}
-                isLoading={state === 'loading' || state === 'idle'}
+                isLoading={state === 'loading'}
                 isError={state === 'error'}
                 onRetry={() => retryVersion(v)}
               />
@@ -695,18 +685,6 @@ export function UpdateNoticeDialog({
   // frame (no null flash while IntersectionObserver hasn't fired yet).
   const initialSticky = releaseNotes?.[0]?.version ?? '';
   const [stickyVersion, setStickyVersion] = useState<string>(initialSticky);
-
-  // Manual mode: accumulate notes as they lazy-load so contributors line
-  // reflects all visible history, not just the initial seed.
-  const [manualLoadedNotes, setManualLoadedNotes] = useState<ReleaseNotes[]>(
-    releaseNotes ?? [],
-  );
-  const handleNotesLoaded = useCallback((notes: ReleaseNotes) => {
-    setManualLoadedNotes((prev) => {
-      if (prev.some((n) => n.version === notes.version)) return prev;
-      return [...prev, notes];
-    });
-  }, []);
 
   const jumpRef = useRef<((v: string) => void) | null>(null);
   const registerJump = useCallback((fn: (v: string) => void) => {
@@ -771,36 +749,17 @@ export function UpdateNoticeDialog({
         })
       : t('update.notice.ariaDescription', { version: newest.version });
 
-  // Header badge label:
-  //   - Auto multi:  v<oldest> → v<newest>  (static)
-  //   - Auto single: v<newest>              (static)
-  //   - Manual:      v<sticky>              (dynamic, click-to-open-dropdown)
-  const badgeLabel = isManual
-    ? `v${stickyVersion || newest.version}`
-    : isAutoMulti
-      ? `v${oldestLoaded.version} → v${newest.version}`
-      : `v${newest.version}`;
-
-  // Header right column:
-  //   - Manual: total version count "N 个版本"
-  //   - Auto multi: same
-  //   - Auto single: newest's date
-  const headerRight = isManual
+  // Header's right cell — a version count, and in manual mode the entry point
+  // for jumping across history. Version number, date and contributors all moved
+  // into each version's own block, so there is nothing else left up here.
+  //   - Manual:     "N versions" + dropdown
+  //   - Auto multi: "N versions", static
+  //   - Auto single: nothing (a single version's identity is in its block)
+  const versionCountLabel = isManual
     ? t('update.notice.versionsSpan', { count: allVersions?.length ?? 1 })
     : isAutoMulti
       ? t('update.notice.versionsSpan', { count: releaseNotes.length })
-      : formatDate(newest.date, i18n.language);
-
-  // Contributors line:
-  //   - Manual: scoped to the currently visible (sticky) version only to avoid
-  //     the header overflowing as dozens of names accumulate across loaded history.
-  //   - Auto multi: aggregated from all pre-loaded diff range versions.
-  //   - Auto single: just the newest version's contributors.
-  const contributors = isManual
-    ? (manualLoadedNotes.find((n) => n.version === stickyVersion)?.contributors ?? [])
-    : isAutoMulti
-      ? aggregateContributors(releaseNotes)
-      : newest.contributors;
+      : null;
 
   return (
     <AlertDialog.Root
@@ -840,7 +799,10 @@ export function UpdateNoticeDialog({
         <AlertDialog.Content
           className={cn(
             'fixed left-1/2 top-1/2 z-[10000] -translate-x-1/2 -translate-y-1/2',
-            'w-[1240px] h-[838px] max-w-[95vw] max-h-[90vh] rounded-xl flex flex-col',
+            // 920px, not the previous 1240px: the body is a single ~800px
+            // reading column now, so the extra width only produced dead margins
+            // and made the full-width chrome visibly mismatch the narrow body.
+            'w-[920px] h-[838px] max-w-[95vw] max-h-[90vh] rounded-xl flex flex-col',
             'bg-[var(--cmd-palette-bg)]',
             'border border-[var(--cmd-palette-border)]',
             'data-[state=open]:animate-confirm-content-in',
@@ -853,21 +815,23 @@ export function UpdateNoticeDialog({
           </AlertDialog.Description>
 
           {/* ---- Header ----
-              3-column grid instead of flex-justify-between so badge width
-              changes (sticky version tracker updates as user scrolls in
-              manual mode) don't shift the centered title. Each 1fr cell is
-              exactly a third of the header width; the title always sits at
-              the horizontal midpoint of its own cell, i.e. the true middle
-              of the dialog. `min-w-0` on cells is required so long badges
-              (e.g. "v0.0.140 → v0.0.144" in auto multi mode) don't blow
-              out the grid track. */}
-          <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 px-6 pt-4 pb-2.5">
-            <div className="min-w-0 justify-self-start">
-              {isManual && allVersions && allVersions.length > 1 ? (
+              3-column grid instead of flex-justify-between so the right cell's
+              width changes never shift the centered title: each 1fr cell is
+              exactly a third of the header width, so the title always sits at
+              the true horizontal middle. The left cell is intentionally empty —
+              it exists to balance the grid. `min-w-0` keeps a long right label
+              from blowing out its track. */}
+          <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 px-6 pt-4 pb-3.5">
+            <span aria-hidden />
+            <AlertDialog.Title className="text-20 leading-[1.4] font-medium text-[var(--msg-assistant-text)] justify-self-center whitespace-nowrap">
+              {t('update.notice.title')}
+            </AlertDialog.Title>
+            <div className="min-w-0 justify-self-end">
+              {isManual && allVersions && allVersions.length > 1 && versionCountLabel ? (
                 <VersionDropdown
                   versions={allVersions}
                   currentVersion={stickyVersion || newest.version}
-                  triggerLabel={badgeLabel}
+                  triggerLabel={versionCountLabel}
                   onSelect={(v) => jumpRef.current?.(v)}
                   onOpenChange={(dropOpen) => {
                     dropdownOpenRef.current = dropOpen;
@@ -882,23 +846,20 @@ export function UpdateNoticeDialog({
                     if (!dropOpen) dropdownClosedAtRef.current = Date.now();
                   }}
                 />
-              ) : (
-                <VersionBadge label={badgeLabel} />
-              )}
+              ) : versionCountLabel ? (
+                <span className="whitespace-nowrap text-13 text-[var(--cmd-palette-item-meta)]">
+                  {versionCountLabel}
+                </span>
+              ) : null}
             </div>
-            <AlertDialog.Title className="text-20 leading-[1.4] font-medium text-[var(--msg-assistant-text)] justify-self-center whitespace-nowrap">
-              {t('update.notice.title')}
-            </AlertDialog.Title>
-            <span className="text-13 text-[var(--cmd-palette-item-meta)] min-w-0 justify-self-end whitespace-nowrap">
-              {headerRight}
-            </span>
           </div>
-
-          <ContributorsLine contributors={contributors} />
 
           <div className="h-px bg-[var(--cmd-palette-border)]" />
 
           {/* ---- Content ---- */}
+          {/* Auto single-version no longer needs its own branch: VersionBlock
+              carries the version, date and thanks itself, so one block and N
+              blocks render through the same path. */}
           {isManual && allVersions ? (
             <ManualBody
               allVersions={allVersions}
@@ -907,33 +868,7 @@ export function UpdateNoticeDialog({
               locale={i18n.language}
               onStickyChange={setStickyVersion}
               registerJump={registerJump}
-              onNotesLoaded={handleNotesLoaded}
             />
-          ) : mode === 'auto' && releaseNotes.length === 1 ? (
-            newest.topics.length > 0 ? (
-              <div className="flex flex-1 min-h-0 flex-col overflow-y-auto py-4 select-text">
-                <TopicList intro={newest.intro} topics={newest.topics} />
-              </div>
-            ) : (
-              (() => {
-                const { leftSections, rightSections } = splitSections(newest.sections);
-                return (
-                  <div className="flex flex-1 min-h-0 py-4 select-text">
-                    <SectionColumn
-                      icon="zap"
-                      title={t('update.notice.newFeatures')}
-                      sections={leftSections}
-                    />
-                    <div className="w-px self-stretch bg-[var(--cmd-palette-border)]" />
-                    <SectionColumn
-                      icon="wrench"
-                      title={t('update.notice.bugFixes')}
-                      sections={rightSections}
-                    />
-                  </div>
-                );
-              })()
-            )
           ) : (
             <AutoBody releaseNotes={releaseNotes} locale={i18n.language} />
           )}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3877,6 +3877,7 @@
       "ariaDescription": "Release notes for version {{version}}",
       "ariaDescriptionSpan": "Release notes for {{count}} versions since v{{from}}",
       "versionsSpan": "{{count}} versions",
+      "versionJumpAria": "Jump to a version — {{count}} versions, currently on v{{version}}",
       "loading": "Loading",
       "loadFailed": "Load failed",
       "retry": "Retry"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3876,6 +3876,7 @@
       "ariaDescription": "バージョン {{version}} のリリースノート",
       "ariaDescriptionSpan": "v{{from}} 以降 {{count}} バージョン分のリリースノート",
       "versionsSpan": "{{count}} バージョン",
+      "versionJumpAria": "バージョンへ移動 — 全 {{count}} バージョン、現在は v{{version}}",
       "loading": "読み込み中",
       "loadFailed": "読み込み失敗",
       "retry": "再試行"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3876,6 +3876,7 @@
       "ariaDescription": "버전 {{version}} 릴리스 노트",
       "ariaDescriptionSpan": "v{{from}} 이후 {{count}}개 버전의 릴리스 노트",
       "versionsSpan": "{{count}}개 버전",
+      "versionJumpAria": "버전으로 이동 — 전체 {{count}}개 버전, 현재 v{{version}}",
       "loading": "불러오는 중",
       "loadFailed": "불러오기 실패",
       "retry": "다시 시도"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3876,6 +3876,7 @@
       "ariaDescription": "版本 {{version}} 的更新说明",
       "ariaDescriptionSpan": "自 v{{from}} 起累计 {{count}} 个版本的更新说明",
       "versionsSpan": "{{count}} 个版本",
+      "versionJumpAria": "跳转到版本，共 {{count}} 个版本，当前 v{{version}}",
       "loading": "加载中",
       "loadFailed": "加载失败",
       "retry": "重试"


### PR DESCRIPTION
## 这次改了什么

### 摘要

更新公告弹窗改成单栏版式,贡献者感谢行从弹窗头部移到每个版本内容的末尾。

线上 v0.1.21 是第一个 v2 主题格式的公告(PR #656),实机用起来暴露出几处用户可见的缺陷:

1. **同一份名单渲染两次** —— 弹窗头部的 `ContributorsLine` 和版本子头右侧同时列当前版本的贡献者。这版有 28 位贡献者,顶部直接变成两行名字墙。
2. **日期被挤成三行** —— 子头是 `flex justify-between`,右侧长名单没有宽度约束,把左侧的徽章和日期压扁。
3. **翻历史时版式反复跳** —— CDN 上 11 个版本里只有最新的 v0.1.21 是 v2 主题格式,其余 10 个仍是旧的两栏作者分组;往下滚会在「单栏主题」和「两栏分组」之间来回切,纯修复版本还会空掉半屏(没有「新功能」内容)。
4. **徽章文字对比度不合格** —— `VersionBadge` 用 `--settings-section-desc`,暗色下解析为 `#737373`,配 chip 底色 `#3c3c3a` 只有 **2.33:1**(WCAG AA 要求 4.5:1),线上表现为版本号发灰发闷。
5. **懒加载占位块谎报加载中** —— `isLoading={state === 'loading' || state === 'idle'}` 把「排队但尚未发起请求」的 idle 也显示成转圈 +「加载中」。打开历史时十来个版本看起来全部卡死,实际什么都没在请求。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求:无(承接 #656 的 v2 主题格式改版)
- 本 PR 包含:
  - 版式统一为单栏 800px 阅读栏,v2 主题与旧格式作者分组共用同一列宽;弹窗宽度 1240 → 920px
  - 版本块结构改为「徽章 + 日期」→ 正文 → 细线 → 感谢行,名单只在自己版本末尾出现一次;日期加 `nowrap`
  - 徽章文字改用 `--chat-input-chip-text`
  - `PlaceholderBlock` 的 `isLoading` 只在真正 in-flight 时为 true
  - 空小节不再渲染成光秃秃的标题
  - 版本跳转下拉从左侧徽章移到右上角「N 个版本」,头部不再重复版本号
  - 删掉随之失效的 `splitSections` / `SectionColumn` / `aggregateContributors` 与 `ManualBody` 的 `onNotesLoaded` 管道
- 明确不包含:
  - **公告 JSON schema 完全未变**(`topics` / `intro` / `contributors` 照旧),生成端 skill 不需要改
  - 不动 CDN 拉取链路、懒加载机制、版本索引逻辑
  - 不改 `--text-tertiary-mid` token 本身(它在暗色下配任何底色都不达标,是全仓性问题,见下方「后续」)
- 用户可见变化:公告弹窗变窄、内容单栏、感谢行位置下移、版本号更清楚、历史版本不再假装加载中
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:
  - **`DESIGN.md` §2 Color Palette & Roles / §10 Theme System**:颜色全部走语义 token,无硬编码色值。徽章文字从 `--settings-section-desc` 改为 chip 的配套语义色 `--chat-input-chip-text`,修正暗色 2.33:1 → 7.46:1(亮色 6.20:1 → 12:1)。
  - **`DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate**:两种模式都已实现并**实机目检**(见下方手工验证),无单模式补丁。
  - **`DESIGN.md` §5 Layout Principles / Whitespace Philosophy**:统一单栏 800px 阅读测量,消除「通栏头部 + 窄正文」的边界错位与两栏留空。
  - **`DESIGN.md` §7 Do's and Don'ts —「Keep content density low」**:每个版本块一个清晰层次(标识 → 内容 → 致谢),名单不再重复出现。
  - **`DESIGN.md` §4 Component Stylings — Dialog & Modal**:沿用既有 12px 圆角容器、pill 按钮、1px 边框,未新造并行结构。

截图(真实组件 + 真实 theme token 渲染):

| | Dark | Light |
|---|---|---|
| v2 主题格式(28 位贡献者) | 徽章清晰、感谢行在末尾、名单一份 | 同 |
| 旧格式(纯修复版本) | 单栏作者分组,不再空半屏 | 同 |

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果:通过

pnpm test:unit
结果:exit 0,54 个包全部 PASS,无 FAIL

pnpm check:i18n
结果:✅ zh-CN / en / ja / ko 共 5800 个 key 全部一致

pnpm check:i18n-glossary
结果:✅ 术语表 27 条已裁决 / 14 条待讨论,四语言无新增违规

pnpm check:dco
结果:DCO check passed: 1 commit signed off
```

新增 `updateNoticeDialogLayout.test.tsx`,5 条契约:名单每版只渲染一次、感谢行归属正确版本、旧格式走单栏且两个小节标题都在、空小节不渲染标题、单版本 auto 模式的版本号不在标题栏。

### 手工验证

用真实组件 + 从 `ColorRegistry` 导出的真实 theme token 渲染静态 harness(Tailwind 由项目配置编译),目检覆盖:

- **Dark / Light 两模式**均已过目;
- **v2 主题格式**(3 个主题 + 28 位贡献者长名单换行)与**旧格式作者分组**(纯修复版本)两条渲染路径;
- 确认徽章文字可读、日期不换行、感谢行只出现一次且在版本末尾、旧格式不再空半屏。

### 未执行的验证

- **未在 Electron 实机内打开真实公告弹窗**。原因:auto 模式需要构造版本升级状态(改写 `localStorage` 的 `lastReadVersion`)才会弹出,manual 模式需要真实 CDN 往返;本次用静态 harness 渲染真实组件替代,覆盖了版式与双模式,但未覆盖 Radix 弹窗的开关动画、遮罩点击关闭、下拉与滚动联动这些交互行为。
- **未验证 manual 模式的懒加载时序**(IntersectionObserver + 跳转)。该逻辑本次未改动,仅改了占位块的 `isLoading` 判定。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 `apps/desktop` renderer 的更新公告弹窗一个组件。不涉及 main 进程、CDN 协议、数据持久化、原生层。公告 JSON schema 未变,旧客户端与新客户端读同一份数据。
- 回滚 / 降级方式:revert 本 commit 即恢复原两栏版式,无数据迁移、无缓存失效顾虑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(改动集中在组件内,注释已写明每处修正的原因)
- [x] 已确认测试结果或说明未执行原因

---

### 后续(不在本 PR 范围)

`--text-tertiary-mid` 在暗色下是 `#737373`,配弹窗底色 2.95:1、配 chip 底色 2.33:1,**两者都不达标**;亮色下是 `#525252`(6.2~7.8:1,正常)。仓库里其他用 `--settings-section-desc` 的地方会有同样问题。本 PR 只在公告弹窗内换成正确的语义 token,没有动 token 本身——那需要单独一个 PR 并对所有受影响界面做双模式目检。
