### PR TITLE
fix(test): 修复测试门禁锁用例竞态与失败路径的监听泄漏

### DIFF
--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -915,10 +915,28 @@ test("test gate lock reports the holder, waits, and acquires after release", asy
 	}
 });
 
+// A real probe round connects to every candidate port, and a port that accepts
+// the connection without answering only resolves once the probe socket times
+// out. So the window that waits for the WAIT report has to be far wider than a
+// single probe round, otherwise a slow round loses the race and the assertion
+// fails for reasons unrelated to the lock protocol.
+const REAL_LOCK_WAIT_WINDOW_MS = 30_000;
+const REAL_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
+
+function raceWithDeadline(candidates, deadlineMs, deadlineValue) {
+	let timer;
+	const deadline = new Promise((resolve) => {
+		timer = setTimeout(() => resolve(deadlineValue), deadlineMs);
+	});
+	return Promise.race([...candidates, deadline]).finally(() => {
+		clearTimeout(timer);
+	});
+}
+
 test("two real test gate lock holders serialize on the same identity", async () => {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "test-gate-real-lock-"));
 	let firstLock;
-	let secondLock;
+	let secondLockPromise;
 	let reportWaiting;
 	const waiting = new Promise((resolve) => {
 		reportWaiting = resolve;
@@ -929,30 +947,39 @@ test("two real test gate lock holders serialize on the same identity", async () 
 			owner: { pid: 41, tier: "unit", cwd: path.join(root, "first") },
 			output: () => {},
 		});
-		const secondLockPromise = acquireTestGateLock({
+		secondLockPromise = acquireTestGateLock({
 			repoRoot: root,
 			owner: { pid: 42, tier: "db", cwd: path.join(root, "second") },
-			timeoutMs: 2_000,
+			timeoutMs: REAL_LOCK_ACQUIRE_TIMEOUT_MS,
 			retryDelayMs: 10,
 			output: reportWaiting,
-		}).then((lock) => {
-			secondLock = lock;
-			return lock;
 		});
-		const outcome = await Promise.race([
-			waiting.then(() => "waiting"),
-			secondLockPromise.then(() => "acquired"),
-			new Promise((resolve) => setTimeout(() => resolve("timed-out"), 1_000)),
-		]);
+		// A failing assertion below jumps straight to `finally` while this
+		// acquisition is still running. Attach a no-op handler so an eventual
+		// rejection is never unhandled; the real await and release happen in
+		// `finally`, otherwise a lock bound after the failure keeps its listener
+		// open and `node --test` never exits.
+		secondLockPromise.catch(() => {});
+
+		const outcome = await raceWithDeadline(
+			[waiting.then(() => "waiting"), secondLockPromise.then(() => "acquired")],
+			REAL_LOCK_WAIT_WINDOW_MS,
+			"timed-out",
+		);
 		assert.equal(outcome, "waiting");
 
 		await firstLock.release();
 		firstLock = undefined;
-		await secondLockPromise;
+		const secondLock = await secondLockPromise;
 		assert.ok(secondLock.port >= 49_152);
 	} finally {
-		await secondLock?.release();
+		// Order matters: releasing the first lock lets the second acquisition
+		// settle immediately instead of waiting out its own timeout.
 		await firstLock?.release();
+		await secondLockPromise?.then(
+			(lock) => lock.release(),
+			() => {},
+		);
 		fs.rmSync(root, { recursive: true, force: true });
 	}
 });

--- a/scripts/test-gate-lock.mjs
+++ b/scripts/test-gate-lock.mjs
@@ -188,6 +188,11 @@ async function listenForLock(port, banner) {
 		socket.end(`${banner}\n`);
 	});
 	await listen(server, port);
+	// The lock lives only as long as its holder has real work in flight (a child
+	// test process, a timer, a pending file operation). Keeping the listener
+	// unref'd means a holder that forgets to release still exits instead of
+	// hanging its runner until the CI job times out.
+	server.unref();
 	return {
 		port,
 		release: () => close(server),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #920 引入的 test gate lock 单测在 CI 上偶发失败并把 job 挂满 25 分钟超时的问题(实例:run 30438651583 的 job「Desktop Git integration」)。

失败链路有两环:

1. **竞态**:`two real test gate lock holders serialize on the same identity` 只给「出现 waiting 日志」1 秒窗口,而第二把锁的一轮探测要并发访问 32 个候选端口、单端口探测超时恰好也是 1 秒(`PROBE_TIMEOUT_MS`)。CI runner 上任一候选端口接受连接却不应答时,该轮探测走满 1 秒,测试先判 `timed-out`,断言失败。
2. **泄漏**:断言失败后 `finally` 只释放了第一把锁(`secondLock` 此时还是 undefined);仍在运行的第二把锁随后成功绑定 TCP server,再无人调用 `release()`,活动句柄让 `node --test` 永不退出,job 一直挂到 GitHub Actions 25 分钟超时(结尾日志 `Terminate orphan process`)。

对应修复:

- 测试:等待窗口 1s → 30s、第二把锁 `timeoutMs` 2s → 60s,并改用会 `clearTimeout` 的 `raceWithDeadline` 不留残余 timer;保留 `secondLockPromise` 引用并挂 no-op catch,`finally` 里先释放第一把锁(让第二把锁立即结算)再等其结算并释放,断言失败也不遗留监听。
- 锁实现:`listenForLock` 的 listener 加 `server.unref()` 兜底。锁只需在持有者仍有真实工作在飞(子进程/timer/文件请求)时存活;今后任何持有者忘记 release,进程也能正常退出,不会再把 runner 拖到 CI 超时。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#920 引入的 CI 稳定性回归
- 本 PR 包含:`scripts/__tests__/test-workspaces.test.mjs` 单测时序与清理修复;`scripts/test-gate-lock.mjs` listener unref 兜底
- 明确不包含:锁协议/探测逻辑本身的行为变更;CI workflow 配置调整
- 用户可见变化:无(仅测试基础设施)
- 是否存在 breaking change:无

### UI 变化

不涉及

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
node --test scripts/__tests__/test-workspaces.test.mjs
结果:65 pass / 0 fail

该用例单独连跑 20 次
结果:20/20 pass

pnpm test:unit(全仓,含 test:runner 与全部 workspace)
结果:exit 0,全部 PASS(本次运行本身完整走了一遍新锁的真实加锁/等待/释放链路)

pnpm check:dco
结果:通过
```

### 手工验证

- **对抗性复现 CI 条件**:在候选端口上放 4 个「接受连接但永不应答」的静默服务,强制探测轮走满 1 秒。实测 waiting 日志在 1015ms 到达——旧 1000ms 窗口必输(精确复现 CI 失败),新 30s 窗口通过,且串行语义(先 waiting、释放后 acquired、同端口交接)验证正确。
- **泄漏 A/B 对照**:同一泄漏场景(第二把锁绑定后不 release)下,旧锁实现进程挂死(被 timeout 杀掉,即 CI 挂 25 分钟的机制),新锁实现自行退出 exit 0。
- **unref 无副作用冒烟**:锁在持有期间(有其他活动句柄时)仍正常监听并应答 banner,release 行为不变。

### 未执行的验证

- 未在 Linux/Node 22(CI 同环境)实机复跑:本地为 Windows/Node 24,Node 24 test runner 结束后强制退出会掩盖挂死现象,故泄漏验证改用不依赖 runner 的裸脚本验证事件循环存活性,机制结论不受平台影响;最终以本 PR 的 CI 为准。
- `pnpm test:all` 未跑:改动限于 `test:runner` 已覆盖的脚本,该入口已在本地通过;git-integration job 跑的是同一份 `test:runner`。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅本地/CI 测试基础设施(test:runner 与跨 worktree 测试门禁锁);不触碰产品代码。移动端冷更分析:未改动 `apps/mobile` 任何 runtime fingerprint 输入(app.json/原生依赖/plugins/modules),不会触发冷更。`server.unref()` 的行为变化仅在「持有者已无任何活动句柄」这一本就异常的状态下生效(锁提前消失优于挂死 CI)。
- 回滚 / 降级方式:revert 本 commit 即可,无数据/协议影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因