### PR TITLE
feat(desktop): 插件媒体代办开放画面参数

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
@@ -61,6 +61,7 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
   getOverride: ReturnType<typeof vi.fn>;
   getImageConfig: ReturnType<typeof vi.fn>;
   getVideoConfig: ReturnType<typeof vi.fn>;
+  videoCapabilities: ReturnType<typeof vi.fn>;
   saveGhostMedia: ReturnType<typeof vi.fn>;
   sniffDepositMime: ReturnType<typeof vi.fn>;
   depositMedia: ReturnType<typeof vi.fn>;
@@ -78,11 +79,24 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
   const generateVideo = vi.fn(async () => ({
     buffer: new Uint8Array([7, 8, 9]),
     mimeType: 'video/mp4',
+    videoParams: { durationSeconds: 4, resolution: '720p', ratio: '16:9', fps: 24 },
   }));
   const editVideo = vi.fn(async () => ({
     buffer: new Uint8Array([10, 11]),
     mimeType: 'video/mp4',
+    videoParams: { durationSeconds: 4, resolution: '720p', ratio: '16:9', fps: 24 },
   }));
+  // 按型号能力校验的数据源:仿 seedance 的支持集(时长 4/6/8/10,无 5 秒)。
+  const videoCapabilities = vi.fn((model: string) =>
+    model.startsWith('seedance')
+      ? {
+          durations: [4, 6, 8, 10],
+          resolutions: ['480p', '720p', '1080p'],
+          ratios: ['16:9', '9:16', '1:1', '4:3', '3:4'],
+          fps: [24],
+        }
+      : null,
+  );
   const resolveOwnedMedia = vi.fn(async (_ghostId: string, hash: string) => `/disk/${hash}.png`);
   const getOverride = vi.fn((_ghostId: string, _capability: string) => null as string | null);
   const getImageConfig = vi.fn(() => ({
@@ -129,6 +143,7 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
     getOverride,
     getImageConfig,
     getVideoConfig,
+    videoCapabilities,
     saveGhostMedia,
     sniffDepositMime,
     depositMedia,
@@ -146,6 +161,7 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
     getOverride,
     getImageConfig,
     getVideoConfig,
+    videoCapabilities,
     saveGhostMedia,
     sniffDepositMime,
     depositMedia,
@@ -225,13 +241,28 @@ describe('载荷校验', () => {
     expect(generateImage).toHaveBeenCalledTimes(2);
   });
 
-  it('画幅意图仅生图收:改图/视频带 aspectRatio → 明拒且不触发生成', async () => {
-    const { slot, editImage, generateVideo } = makeSlot();
-    const editBad = await slot.handleModelRequest('art', { ...EDIT_REQ, aspectRatio: '1:1' });
-    expect(editBad).toMatchObject({ ok: false });
-    expect((editBad as { message: string }).message).toContain('gen_image');
-    expect(editImage).not.toHaveBeenCalled();
+  it('画幅意图图像类通吃:改图也收 aspectRatio;不传时载荷无该键', async () => {
+    const { slot, editImage } = makeSlot();
+    const ok = await slot.handleModelRequest('art', { ...EDIT_REQ, aspectRatio: '1:1' });
+    expect(ok).toMatchObject({ ok: true });
+    expect(editImage).toHaveBeenLastCalledWith({
+      prompt: '加顶帽子',
+      model: 'gpt-image-2',
+      imagePaths: [`/disk/${HASH_S}.png`],
+      aspectRatio: '1:1',
+    });
 
+    // 不传 = 与老协议同形(连键都没有),后端 auto = 跟随源图画幅。
+    await slot.handleModelRequest('art', EDIT_REQ);
+    expect(editImage).toHaveBeenLastCalledWith({
+      prompt: '加顶帽子',
+      model: 'gpt-image-2',
+      imagePaths: [`/disk/${HASH_S}.png`],
+    });
+  });
+
+  it('aspectRatio 不收视频:视频带图像画幅 → 明拒且不触发生成', async () => {
+    const { slot, generateVideo } = makeSlot();
     const videoBad = await slot.handleModelRequest('art', {
       type: 'cindy-request',
       kind: 'gen_video',
@@ -239,7 +270,112 @@ describe('载荷校验', () => {
       aspectRatio: '2:3',
     });
     expect(videoBad).toMatchObject({ ok: false });
+    expect((videoBad as { message: string }).message).toContain('ratio');
     expect(generateVideo).not.toHaveBeenCalled();
+  });
+});
+
+describe('视频画面参数', () => {
+  const VIDEO_REQ = { type: 'cindy-request', kind: 'gen_video', prompt: '一只猫奔跑' };
+  const EDIT_VIDEO_REQ = {
+    type: 'cindy-request',
+    kind: 'edit_video',
+    prompt: '让它动起来',
+    hashes: [HASH_S],
+  };
+
+  it('合法参数透传;不传时载荷与老协议同形;实际生效参数随结果回传', async () => {
+    const { slot, generateVideo } = makeSlot();
+    const ok = await slot.handleModelRequest('art', {
+      ...VIDEO_REQ,
+      ratio: '9:16',
+      resolution: '1080p',
+      duration: 8,
+      fps: 24,
+    });
+    expect(ok).toMatchObject({ ok: true });
+    expect(generateVideo).toHaveBeenLastCalledWith({
+      prompt: '一只猫奔跑',
+      model: 'seedance-fast',
+      ratio: '9:16',
+      resolution: '1080p',
+      duration: 8,
+      fps: 24,
+    });
+
+    // 一项都不传 = 老协议逐字节同形(连键都没有),后端走型号出厂默认。
+    const bare = await slot.handleModelRequest('art', VIDEO_REQ);
+    expect(generateVideo).toHaveBeenLastCalledWith({ prompt: '一只猫奔跑', model: 'seedance-fast' });
+    // 回执照样带回来(注入实现给了就透传),意识据此判断参数是否兑现。
+    expect(bare).toMatchObject({
+      ok: true,
+      videoParams: { durationSeconds: 4, resolution: '720p', ratio: '16:9', fps: 24 },
+    });
+  });
+
+  it('部分传参:只展开传了的键,其余不出现在载荷里', async () => {
+    const { slot, editVideo } = makeSlot();
+    const ok = await slot.handleModelRequest('art', { ...EDIT_VIDEO_REQ, resolution: '480p' });
+    expect(ok).toMatchObject({ ok: true });
+    expect(editVideo).toHaveBeenLastCalledWith({
+      prompt: '让它动起来',
+      model: 'seedance-fast',
+      imagePaths: [`/disk/${HASH_S}.png`],
+      resolution: '480p',
+    });
+  });
+
+  it('值域粗筛:未知比例/分辨率、非正整数时长与帧率一律拒且不触发生成', async () => {
+    const { slot, generateVideo } = makeSlot();
+    for (const bad of [
+      { ratio: '21:9' },
+      { resolution: '4k' },
+      { duration: 0 },
+      { duration: 4.5 },
+      { duration: -1 },
+      { duration: 999 },
+      { duration: '8' },
+      { fps: 0 },
+      { fps: 1000 },
+    ]) {
+      const r = await slot.handleModelRequest('art', { ...VIDEO_REQ, ...bad });
+      expect(r, JSON.stringify(bad)).toMatchObject({ ok: false });
+    }
+    expect(generateVideo).not.toHaveBeenCalled();
+  });
+
+  it('按型号二次校验:型号不支持的时长明拒,话术带该型号可用值', async () => {
+    const { slot, generateVideo } = makeSlot();
+    // 5 秒在协议层粗筛内,但仿 seedance 的支持集是 4/6/8/10。
+    const bad = await slot.handleModelRequest('art', { ...VIDEO_REQ, duration: 5 });
+    expect(bad).toMatchObject({ ok: false });
+    expect((bad as { message: string }).message).toContain('4 / 6 / 8 / 10');
+    expect(generateVideo).not.toHaveBeenCalled();
+  });
+
+  it('videoCapabilities 缺席(查无该型号)→ 跳过按型号校验,粗筛过了就放行', async () => {
+    const { slot, generateVideo } = makeSlot({
+      videoCapabilities: vi.fn(() => null) as unknown as CindySlotDeps['videoCapabilities'],
+    });
+    const ok = await slot.handleModelRequest('art', { ...VIDEO_REQ, duration: 5 });
+    expect(ok).toMatchObject({ ok: true });
+    expect(generateVideo).toHaveBeenLastCalledWith({
+      prompt: '一只猫奔跑',
+      model: 'seedance-fast',
+      duration: 5,
+    });
+  });
+
+  it('画面参数不收图像类:生图/改图带 resolution → 明拒且不触发生成', async () => {
+    const { slot, generateImage, editImage } = makeSlot();
+    const genBad = await slot.handleModelRequest('art', { ...REQ, resolution: '1080p' });
+    expect(genBad).toMatchObject({ ok: false });
+    expect((genBad as { message: string }).message).toContain('aspectRatio');
+    expect(generateImage).not.toHaveBeenCalled();
+
+    const editBad = await slot.handleModelRequest('art', { ...EDIT_REQ, duration: 4 });
+    expect(editBad).toMatchObject({ ok: false });
+    expect(editImage).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
@@ -540,6 +540,12 @@ describe('FORGE_GUIDE', () => {
       '"cindy": { "media": ["deposit"] }',
       '每意识配额 1GB',
       '寄存物不是产物',
+      // 2026-07-29 媒体代办画面参数:edit_image 放开 aspectRatio,视频四参数
+      // (ratio/resolution/duration/fps)+ 实际生效参数回执 videoParams。
+      '图像可选画幅 aspectRatio',
+      '视频画面参数(四项全可选',
+      'videoParams',
+      '各型号支持集不同',
     ]) {
       expect(FORGE_GUIDE).toContain(marker);
     }

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -11,6 +11,9 @@
  *     → 模型白名单校验(意识只能从主机菜单里挑,挑不了菜单外的任何路由;
  *       图像/视频各一份白名单与默认,同来自 providers.json 目录;该类目清单
  *       为空 = 能力暂不可用,直接拒单)
+ *     → 画面参数校验(图像 aspectRatio / 视频 ratio·resolution·duration·fps):
+ *       协议层值域粗筛 + 按解析出的型号二次校验;一项都不传 = 与老协议逐字节
+ *       同形,后端走该型号出厂默认
  *     → 吃源图的代办(改图/图生视频):指纹逐张查账验归属(只能用自己名下的媒体)
  *     → 主机走统一媒体通道干活(字节从头到尾在主机手里;视频为分钟级长任务)
  *     → 落 blob(SHA-256 主机算)+ 账本记账(出生=该意识)
@@ -46,9 +49,16 @@ import {
   GHOST_CINDY_MAX_ASYNC_JOBS,
   GHOST_IMAGE_ASPECT_RATIOS,
   GHOST_MODEL_TIERS,
+  GHOST_VIDEO_MAX_DURATION_SECONDS,
+  GHOST_VIDEO_MAX_FPS,
+  GHOST_VIDEO_RATIOS,
+  GHOST_VIDEO_RESOLUTIONS,
   type GhostImageAspectRatio,
   type GhostModelTier,
   type GhostPipeModelResult,
+  type GhostVideoRatio,
+  type GhostVideoResolution,
+  type GhostVideoResultParams,
   type InstalledGhost,
 } from '../../shared/ghost.js';
 import { probeImageSize } from './imageProbe.js';
@@ -63,6 +73,25 @@ export interface CindyMediaConfig {
   defaults: { standard: string; draft: string; best: string } | null;
 }
 
+/**
+ * 视频画面参数(意识可选传;不传的项由 provider 层填该型号的出厂默认)。
+ * 每一项都条件展开——不传时载荷里连键都没有,与老协议逐字节同形。
+ */
+export interface CindyVideoParams {
+  ratio?: GhostVideoRatio;
+  resolution?: GhostVideoResolution;
+  duration?: number;
+  fps?: number;
+}
+
+/** 某个视频型号的实际支持集(provider capabilities 的投影,用于按型号二次校验)。 */
+export interface CindyVideoCapabilities {
+  durations: readonly number[];
+  resolutions: readonly string[];
+  ratios: readonly string[];
+  fps: readonly number[];
+}
+
 export interface CindySlotDeps {
   getGhost(id: string): InstalledGhost | null;
   /** 主机统一图片通道(art 底层客户端);返回图片字节与 mime。
@@ -72,24 +101,33 @@ export interface CindySlotDeps {
     model: string;
     aspectRatio?: GhostImageAspectRatio;
   }): Promise<{ buffer: Uint8Array; mimeType: string }>;
-  /** 主机统一图片通道·改图;源图以磁盘路径喂给网关(意识摸不到路径)。 */
+  /** 主机统一图片通道·改图;源图以磁盘路径喂给网关(意识摸不到路径)。
+   *  aspectRatio 语义同 generateImage:不传 = 跟随源图画幅(后端 auto)。 */
   editImage(params: {
     prompt: string;
     model: string;
     imagePaths: string[];
+    aspectRatio?: GhostImageAspectRatio;
   }): Promise<{ buffer: Uint8Array; mimeType: string }>;
   /**
    * 主机统一视频通道·文生视频(art 视频 provider 层复用,submit→
-   * 轮询→下载一条龙在注入实现里完成);返回视频字节与 mime。长任务:
+   * 轮询→下载一条龙在注入实现里完成);返回视频字节与 mime,外加实际
+   * 生效的画面参数回执(上游上报值优先,缺项回落提交值)。长任务:
    * 分钟级才 resolve,在途名额在整个等待期占用。
    */
-  generateVideo(params: { prompt: string; model: string }): Promise<{ buffer: Uint8Array; mimeType: string }>;
+  generateVideo(
+    params: { prompt: string; model: string } & CindyVideoParams,
+  ): Promise<{ buffer: Uint8Array; mimeType: string; videoParams?: GhostVideoResultParams }>;
   /** 主机统一视频通道·参考图生视频(1 张=首帧,2 张=首尾帧;源图以磁盘路径注入)。 */
-  editVideo(params: {
-    prompt: string;
-    model: string;
-    imagePaths: string[];
-  }): Promise<{ buffer: Uint8Array; mimeType: string }>;
+  editVideo(
+    params: { prompt: string; model: string; imagePaths: string[] } & CindyVideoParams,
+  ): Promise<{ buffer: Uint8Array; mimeType: string; videoParams?: GhostVideoResultParams }>;
+  /**
+   * 该视频型号的画面参数支持集(provider capabilities;registry 缺席或查无
+   * 该型号 → null)。可选依赖:不注入 = 跳过按型号校验,只做协议层粗筛
+   * (值仍会被 provider 层自己的校验拦下,只是话术不如这里友好)。
+   */
+  videoCapabilities?(model: string): CindyVideoCapabilities | null;
   /**
    * 指纹 → 磁盘路径,且仅当该媒体在此意识名下(出生或画廊,查账本);
    * 不属于它 / 查无此账 / 文件缺失一律 null(不区分,不给探测空间)。
@@ -218,6 +256,8 @@ interface CindyAsyncJob {
     ext: string;
     model: string;
     modelLabel: string;
+    /** 实际生效的画面参数(异步代办只有视频;上游没报即缺省)。 */
+    videoParams?: GhostVideoResultParams;
   };
   /** failed:人话失败原因。 */
   error?: string;
@@ -260,6 +300,35 @@ const CATEGORY_LABEL: Record<CindyKindInfo['category'], string> = { image: '图�
 /** 指纹形状(与 blobStore 同一规则;这里先粗筛,细校验在归属解析)。 */
 const HASH_RE = /^[0-9a-f]{64}$/;
 
+/** 沙箱传来的数值粗筛:正整数且不超过上限(挡负数、小数、天文数字、NaN)。 */
+function isPositiveIntWithin(value: unknown, max: number): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= max;
+}
+
+/**
+ * 按型号能力核对画面参数,返回人话的"哪项不支持 + 该型号可用值";全部
+ * 支持返回 null。一次只报第一项不支持的——意识修一项再来即可,堆一长串
+ * 反而不好读。
+ */
+function describeUnsupportedVideoParams(
+  params: CindyVideoParams,
+  caps: CindyVideoCapabilities,
+): string | null {
+  if (params.ratio !== undefined && !caps.ratios.includes(params.ratio)) {
+    return `画幅 ${params.ratio}(可用:${caps.ratios.join(' / ')})`;
+  }
+  if (params.resolution !== undefined && !caps.resolutions.includes(params.resolution)) {
+    return `分辨率 ${params.resolution}(可用:${caps.resolutions.join(' / ')})`;
+  }
+  if (params.duration !== undefined && !caps.durations.includes(params.duration)) {
+    return `时长 ${params.duration}s(可用:${caps.durations.join(' / ')} 秒)`;
+  }
+  if (params.fps !== undefined && !caps.fps.includes(params.fps)) {
+    return `帧率 ${params.fps}fps(可用:${caps.fps.join(' / ')})`;
+  }
+  return null;
+}
+
 export class GhostCindySlot {
   private readonly inflight = new Map<string, number>();
   /** 异步代办任务表(jobId → 记录;惰性 sweep,过期即清)。 */
@@ -285,6 +354,10 @@ export class GhostCindySlot {
       tier?: unknown;
       model?: unknown;
       aspectRatio?: unknown;
+      ratio?: unknown;
+      resolution?: unknown;
+      duration?: unknown;
+      fps?: unknown;
       hashes?: unknown;
       callId?: unknown;
       mode?: unknown;
@@ -349,12 +422,12 @@ export class GhostCindySlot {
     }
     const callId = (p.callId as string | undefined) ?? 'unattributed';
 
-    // 画幅意图(可选,仅生图):意识声明比例,注入实现翻译成后端具体尺寸。
-    // 改图跟随源图画幅、视频画幅由 provider 层自治——带了就是用错协议,
-    // 明拒好过静默忽略(将来放开支持是向后兼容的放宽)。
+    // 画幅意图(可选,图像类代办):意识声明比例,注入实现翻译成后端具体
+    // 尺寸。视频类另有 ratio(值域不同)——带错了就是用错协议,明拒好过
+    // 静默忽略。不传 = 后端 auto(生图由模型自定,改图跟随源图画幅)。
     if (p.aspectRatio !== undefined) {
-      if (kind !== 'gen_image') {
-        return { ok: false, message: 'aspectRatio 仅支持 gen_image(改图跟随源图画幅,视频不收比例)' };
+      if (info.category !== 'image') {
+        return { ok: false, message: 'aspectRatio 仅支持图像类代办(视频画幅请用 ratio,值域不同)' };
       }
       if (
         typeof p.aspectRatio !== 'string' ||
@@ -364,6 +437,39 @@ export class GhostCindySlot {
       }
     }
     const aspectRatio = p.aspectRatio as GhostImageAspectRatio | undefined;
+
+    // 视频画面参数(可选,仅视频类代办):协议层只做值域/形状粗筛,按型号
+    // 的可用集在选型解析之后二次校验(各型号支持的时长差异很大)。图像类
+    // 带了这几项 = 用错协议,明拒。
+    const videoParamKeys = ['ratio', 'resolution', 'duration', 'fps'] as const;
+    const presentVideoKeys = videoParamKeys.filter((k) => p[k] !== undefined);
+    if (presentVideoKeys.length > 0 && info.category !== 'video') {
+      return {
+        ok: false,
+        message: `${presentVideoKeys.join(' / ')} 仅支持视频类代办(图像画幅请用 aspectRatio)`,
+      };
+    }
+    if (p.ratio !== undefined && !(GHOST_VIDEO_RATIOS as readonly unknown[]).includes(p.ratio)) {
+      return { ok: false, message: `未知视频画幅(可用:${GHOST_VIDEO_RATIOS.join(' / ')})` };
+    }
+    if (
+      p.resolution !== undefined &&
+      !(GHOST_VIDEO_RESOLUTIONS as readonly unknown[]).includes(p.resolution)
+    ) {
+      return { ok: false, message: `未知分辨率(可用:${GHOST_VIDEO_RESOLUTIONS.join(' / ')})` };
+    }
+    if (p.duration !== undefined && !isPositiveIntWithin(p.duration, GHOST_VIDEO_MAX_DURATION_SECONDS)) {
+      return { ok: false, message: `duration 不合法(1–${GHOST_VIDEO_MAX_DURATION_SECONDS} 的整数秒)` };
+    }
+    if (p.fps !== undefined && !isPositiveIntWithin(p.fps, GHOST_VIDEO_MAX_FPS)) {
+      return { ok: false, message: `fps 不合法(1–${GHOST_VIDEO_MAX_FPS} 的整数)` };
+    }
+    const videoParams: CindyVideoParams = {
+      ...(p.ratio !== undefined ? { ratio: p.ratio as GhostVideoRatio } : {}),
+      ...(p.resolution !== undefined ? { resolution: p.resolution as GhostVideoResolution } : {}),
+      ...(p.duration !== undefined ? { duration: p.duration as number } : {}),
+      ...(p.fps !== undefined ? { fps: p.fps as number } : {}),
+    };
 
     const ghost = this.deps.getGhost(ghostId);
     if (!ghost || !ghost.enabled) {
@@ -421,6 +527,21 @@ export class GhostCindySlot {
         return { ok: false, message: '不支持的模型(不在主机白名单内)' };
       }
       model = p.model;
+    }
+
+    // 画面参数按**解析出的型号**二次校验:协议层值域是所有 provider 的
+    // 交集,单个型号支持的时长/帧率差异很大(seedance 4/6/8/10 秒,
+    // happyhorse 只有 5 秒)。不支持即明拒并列出该型号的可用值,不做最近似
+    // 降级——静默改成别的档位会让意识以为自己的参数生效了。
+    if (info.category === 'video' && presentVideoKeys.length > 0) {
+      const caps = this.deps.videoCapabilities?.(model) ?? null;
+      if (caps) {
+        const unsupported = describeUnsupportedVideoParams(videoParams, caps);
+        if (unsupported) {
+          const label = cfg.models.find((m) => m.id === model)?.label ?? model;
+          return { ok: false, message: `模型「${label}」不支持${unsupported}` };
+        }
+      }
     }
 
     // 吃源图的代办(改图/图生视频):指纹形状先粗筛(不占在途名额),
@@ -483,21 +604,28 @@ export class GhostCindySlot {
         modelLabel: string;
         width?: number;
         height?: number;
+        videoParams?: GhostVideoResultParams;
       }> => {
-        let generated: { buffer: Uint8Array; mimeType: string };
+        // 可选参数一律条件展开:不传时载荷里连键都没有,与老协议逐字节同形
+        // (videoParams 本身就是按此规则组装的,直接摊开即可)。
+        let generated: { buffer: Uint8Array; mimeType: string; videoParams?: GhostVideoResultParams };
         if (kind === 'edit_image') {
-          generated = await this.deps.editImage({ prompt, model, imagePaths });
+          generated = await this.deps.editImage({
+            prompt,
+            model,
+            imagePaths,
+            ...(aspectRatio !== undefined ? { aspectRatio } : {}),
+          });
         } else if (kind === 'gen_image') {
-          // 画幅意图条件展开:不传时载荷里连键都没有,与老协议逐字节同形。
           generated = await this.deps.generateImage({
             prompt,
             model,
             ...(aspectRatio !== undefined ? { aspectRatio } : {}),
           });
         } else if (kind === 'edit_video') {
-          generated = await this.deps.editVideo({ prompt, model, imagePaths });
+          generated = await this.deps.editVideo({ prompt, model, imagePaths, ...videoParams });
         } else {
-          generated = await this.deps.generateVideo({ prompt, model });
+          generated = await this.deps.generateVideo({ prompt, model, ...videoParams });
         }
 
         const saved = await this.deps.saveGhostMedia({
@@ -523,7 +651,17 @@ export class GhostCindySlot {
         // 据此精确声明卡高,首帧零跳动;解析不出就缺省,意识回退估计值。
         const dims =
           kind === 'gen_image' || kind === 'edit_image' ? probeImageSize(generated.buffer) : null;
-        return { url: saved.url, hash: saved.hash, ext: saved.ext, model, modelLabel, ...(dims ?? {}) };
+        return {
+          url: saved.url,
+          hash: saved.hash,
+          ext: saved.ext,
+          model,
+          modelLabel,
+          ...(dims ?? {}),
+          // 画面参数回执(视频代办;注入实现没给就缺省):意识据此确认
+          // 自己传的参数是否被兑现——老宿主静默忽略新参数,有回执才分得清。
+          ...(generated.videoParams !== undefined ? { videoParams: generated.videoParams } : {}),
+        };
       };
 
       const expectedSeconds =
@@ -557,6 +695,7 @@ export class GhostCindySlot {
               ext: result.ext,
               model: result.model,
               modelLabel: result.modelLabel,
+              ...(result.videoParams !== undefined ? { videoParams: result.videoParams } : {}),
             };
             job.doneAt = Date.now();
           })

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1140,18 +1140,33 @@ const r = await cindy.send({ type: 'cindy-request', kind: 'gen_image', prompt: '
 //     交卷 note,让用户看得见"这单是谁画的"。
 //     width/height = 图片真实像素宽高(仅图片代办;主机解析不出时缺省)——供
 //     聊天卡片时用它按比例精确声明卡高(见 §4.5),别拿去写进交卷文案。
-// 生图可选画幅 aspectRatio:'1:1' 方图 / '3:2' 横图 / '2:3' 竖图,不传 = 模型自定:
+// 图像可选画幅 aspectRatio:'1:1' 方图 / '3:2' 横图 / '2:3' 竖图,不传 = 后端自定:
 //   { kind: 'gen_image', prompt: '一只猫', aspectRatio: '3:2' }
 //   比例是意图声明(同 tier 哲学),主机翻译成该模型支持的具体尺寸,真实像素
-//   以返回的 width/height 为准。**仅生图收**——改图跟随源图画幅、视频不收比例,
-//   带上会被拒;用户没提横竖要求时别自作主张,不传让模型自定。
+//   以返回的 width/height 为准。**图像类专用**(gen_image 与 edit_image 都收;
+//   改图不传 = 跟随源图画幅);视频画幅是另一个参数 ratio,值域不同,带错会被拒。
+//   用户没提横竖要求时别自作主张,不传让后端自定。
 // 改图(需详单含 "edit";源图必须是本意识名下的,1–4 张——含用户过户给你的
 // args.attachments 指纹):
 //   { kind: 'edit_image', prompt, hashes: ['<指纹>'] }
+//   { kind: 'edit_image', prompt, hashes: ['<指纹>'], aspectRatio: '1:1' }  // 换画幅重绘
 // 视频(需详单 video 类目;分钟级长任务,返回形态同上,url 是 .mp4。同步等待
 // 期间主机自动替你的 tool-call 续命,分钟级任务放心 await):
 //   { kind: 'gen_video', prompt }                       // 文生视频
 //   { kind: 'edit_video', prompt, hashes: ['<指纹>'] }  // 参考图生视频(1–2 张)
+// 视频画面参数(四项全可选,不传 = 该型号出厂默认,这也是最省心的用法):
+//   ratio:'16:9' | '9:16' | '1:1' | '4:3' | '3:4'(视频专用,别和图像的
+//     aspectRatio 混用)
+//   resolution:'480p' | '720p' | '1080p'
+//   duration:秒(整数)。**各型号支持集不同**——传了不支持的值会被明拒,
+//     拒绝话术里带该型号的可用值,按提示改或者干脆不传。
+//   fps:帧率(整数),同样按型号校验。
+//   例:{ kind: 'gen_video', prompt: '猫在奔跑', ratio: '9:16', resolution: '1080p' }
+//   ⚠️ 高分辨率 + 长时长明显更贵也更慢:用户没提要求时不要自作主张调高,
+//      不传让型号自己定。
+//   成功返回多带一个 videoParams: { durationSeconds, resolution, ratio, fps }
+//   = 本单**实际生效**的参数(主机权威)。老宿主会静默忽略这四项,拿 videoParams
+//   跟你传的值对一下就知道兑现没有;要在交卷 note 里报参数,以它为准别报你传的。
 // 视频异步模式(可能超过 30 分钟续命天花板,或不想吊着 tool-call 等时):
 //   加 mode:'submit' → 受理后立即返回 { ok:true, jobId, status:'running',
 //   expectedSeconds }(资格审/源图归属仍同步校验,拒绝立即可见),生成在

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -23,6 +23,7 @@ import {
   type GhostManifest,
   type GhostSetupAllowedAction,
   type GhostSetupAssessment,
+  type GhostVideoResultParams,
   type InstalledGhost,
 } from '../../shared/ghost.js';
 import { getAppCapabilities } from '../appCapabilities.js';
@@ -131,7 +132,11 @@ import { runAssistantReplyHook } from './assistantReplyHook.js';
 import { submitAndAwaitVideo } from '../cindy-proxy-media/video/run.js';
 
 import { deriveCindyMediaConfig, type CindyMediaCatalogConfig } from './cindyMediaCatalog.js';
-import { GhostCindySlot } from './cindySlot.js';
+import {
+  GhostCindySlot,
+  type CindyVideoCapabilities,
+  type CindyVideoParams,
+} from './cindySlot.js';
 import { GhostAgentSlot, type GhostAgentTurnRunner } from './agentSlot.js';
 import { GhostNodeRuntimeBroker } from './nodeRuntimeBroker.js';
 import { GhostPickSlot } from './pickSlot.js';
@@ -1751,11 +1756,13 @@ async function readImageFileAsDataUri(absPath: string): Promise<string> {
  * submit→轮询→下载一条龙在 @cindy/mcps submitAndAwaitVideo(原 lizi_art 工具层
  * 的执行链,工具壳已退役);分钟级长任务,期间 cindySlot 在途名额持续占用。
  */
-async function runGhostVideo(params: {
-  alias: string;
-  prompt: string;
-  imageDataUris?: string[];
-}): Promise<{ buffer: Buffer; mimeType: string }> {
+async function runGhostVideo(
+  params: {
+    alias: string;
+    prompt: string;
+    imageDataUris?: string[];
+  } & CindyVideoParams,
+): Promise<{ buffer: Buffer; mimeType: string; videoParams: GhostVideoResultParams }> {
   const registry = getCindyProxyMediaService().backend.videoRegistry;
   if (!registry || !registry.hasAny()) {
     throw new Error('视频能力不可用:主机未配置视频通道');
@@ -1763,7 +1770,37 @@ async function runGhostVideo(params: {
   // 提交紧前重查(第二十一轮):参考图 data URI 准备是 await,窗口内被停用即拒。
   assertMediaModelStillEnabled('video', params.alias);
   const r = await submitAndAwaitVideo(registry, params);
-  return { buffer: r.buffer, mimeType: r.mimeType };
+  return {
+    buffer: r.buffer,
+    mimeType: r.mimeType,
+    // 实际生效参数回执(执行器已把上游上报值与提交值合并过)。
+    videoParams: {
+      durationSeconds: r.effectiveParams.duration,
+      resolution: r.effectiveParams.resolution,
+      ratio: r.effectiveParams.ratio,
+      fps: r.effectiveParams.fps,
+    },
+  };
+}
+
+/**
+ * 某视频型号的画面参数支持集(cindySlot 按型号二次校验用)。registry 缺席
+ * 或 alias 查无 → null,cindySlot 据此跳过按型号校验(值仍会被执行器兜底拦下)。
+ */
+function getGhostVideoCapabilities(model: string): CindyVideoCapabilities | null {
+  try {
+    const registry = getCindyProxyMediaService().backend.videoRegistry;
+    if (!registry || !registry.hasAny()) return null;
+    const caps = registry.resolveByAlias(model).provider.capabilities;
+    return {
+      durations: caps.supportedDurations,
+      resolutions: caps.supportedResolutions,
+      ratios: caps.supportedRatios,
+      fps: caps.supportedFps,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -1813,33 +1850,42 @@ export function getGhostCindySlot(): GhostCindySlot {
           humanizeImageChannelError(err);
         }
       },
-      editImage: async ({ prompt, model, imagePaths }) => {
+      editImage: async ({ prompt, model, imagePaths, aspectRatio }) => {
         try {
           assertMediaModelStillEnabled('image', model);
           return decodeImageResponse(
-            await getCindyProxyMediaService().backend.editImage({ model: model as GatewayImageModel, prompt, imagePaths }),
+            await getCindyProxyMediaService().backend.editImage({
+              model: model as GatewayImageModel,
+              prompt,
+              imagePaths,
+              // 同 generateImage:不带画幅意图时不传 size,网关缺省 'auto'
+              // (改图的 auto 语义 = 跟随源图画幅,与放开之前行为一致)。
+              ...(aspectRatio ? { size: GHOST_ASPECT_TO_GATEWAY_SIZE[aspectRatio] } : {}),
+            }),
           );
         } catch (err) {
           humanizeImageChannelError(err);
         }
       },
-      generateVideo: async ({ prompt, model }) => {
+      generateVideo: async ({ prompt, model, ...videoParams }) => {
         try {
           assertMediaModelStillEnabled('video', model);
-          return await runGhostVideo({ alias: model, prompt });
+          return await runGhostVideo({ alias: model, prompt, ...videoParams });
         } catch (err) {
           humanizeImageChannelError(err);
         }
       },
-      editVideo: async ({ prompt, model, imagePaths }) => {
+      editVideo: async ({ prompt, model, imagePaths, ...videoParams }) => {
         try {
           assertMediaModelStillEnabled('video', model);
           const imageDataUris = await Promise.all(imagePaths.map(readImageFileAsDataUri));
-          return await runGhostVideo({ alias: model, prompt, imageDataUris });
+          return await runGhostVideo({ alias: model, prompt, imageDataUris, ...videoParams });
         } catch (err) {
           humanizeImageChannelError(err);
         }
       },
+      // 画面参数按型号二次校验的数据源(registry capabilities)。
+      videoCapabilities: getGhostVideoCapabilities,
       getOverride: (ghostId, capability) => {
         return readGhostCindyOverrides(ghostId)[capability as CindyCapabilityKey] ?? null;
       },

--- a/apps/desktop/src/main/cindy-proxy-media/video/__tests__/happyhorseProvider.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/__tests__/happyhorseProvider.test.ts
@@ -133,6 +133,40 @@ describe('happyhorse provider · submit body shape', () => {
     expect(body.parameters.resolution).toBe('1080P');
   });
 
+  it('任何比例的像素量都不超过该档 16:9 基准(不偷偷升档)', async () => {
+    // 回归:4:3 曾拿 longSide 当宽再推高(720p → 1280*960 = 基准的 1.33 倍),
+    // 等于升档出片并计费。cindy 槽放开 ratio 后这条分支才可达。
+    const cases: Array<{ resolution: string; ratio: string; size: string }> = [
+      { resolution: '720p', ratio: '4:3', size: '960*720' },
+      { resolution: '1080p', ratio: '4:3', size: '1440*1080' },
+      { resolution: '480p', ratio: '4:3', size: '640*480' },
+      { resolution: '720p', ratio: '3:4', size: '540*720' },
+      { resolution: '720p', ratio: '1:1', size: '720*720' },
+      { resolution: '720p', ratio: '16:9', size: '1280*720' },
+      { resolution: '1080p', ratio: '9:16', size: '1080*1920' },
+    ];
+    const baseline: Record<string, number> = {
+      '480p': 854 * 480,
+      '720p': 1280 * 720,
+      '1080p': 1920 * 1080,
+    };
+    for (const c of cases) {
+      const fetchMock = vi.fn(async () =>
+        new Response(
+          JSON.stringify({ output: { task_id: 't', task_status: 'PENDING' } }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch;
+      const p = makeProvider(fetchMock);
+      await p.submit({ prompt: 'x', resolution: c.resolution, ratio: c.ratio }, 'happyhorse');
+      const init = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(init.body as string);
+      expect(body.parameters.size, `${c.resolution} ${c.ratio}`).toBe(c.size);
+      const [w, h] = (body.parameters.size as string).split('*').map(Number);
+      expect(w * h, `${c.resolution} ${c.ratio} 像素量`).toBeLessThanOrEqual(baseline[c.resolution]);
+    }
+  });
+
   it('rejects unknown alias before sending', async () => {
     const fetchMock = vi.fn(async () =>
       new Response('{}', { status: 200 }),

--- a/apps/desktop/src/main/cindy-proxy-media/video/__tests__/run.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/__tests__/run.test.ts
@@ -1,0 +1,160 @@
+/**
+ * run.test.ts
+ * ---------------------------------------------------------------------------
+ * submitAndAwaitVideo 的画面参数契约(2026-07 放开细调):不传落型号出厂
+ * 默认(与放开前逐字节同形)、传了透传、型号不支持即抛(不做最近似降级)、
+ * 返回值里的实际生效参数以上游上报值优先。
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { VideoProviderRegistry } from '../registry.js';
+import { submitAndAwaitVideo } from '../run.js';
+import type {
+  VideoGenerationRequest,
+  VideoProvider,
+  VideoResultMeta,
+  VideoTaskStatus,
+} from '../types.js';
+
+function makeProvider(opts: {
+  submitted: VideoGenerationRequest[];
+  /** succeeded 时上游上报的 meta(留空 = 上游什么都没报)。 */
+  meta?: VideoResultMeta;
+  maxImages?: 0 | 1 | 2;
+}): VideoProvider {
+  return {
+    id: 'fake',
+    capabilities: {
+      modelAliases: [{ alias: 'fake-fast', internalModel: 'fake-1', summary: '' }],
+      supportedDurations: [4, 6, 8],
+      supportedResolutions: ['480p', '720p', '1080p'],
+      supportedRatios: ['16:9', '9:16'],
+      supportedFps: [24],
+      maxImages: opts.maxImages ?? 2,
+      expectedSecondsByAlias: { 'fake-fast': 1 },
+      defaults: { duration: 4, resolution: '720p', ratio: '16:9', fps: 24 },
+    },
+    submit: async (req) => {
+      opts.submitted.push(req);
+      return { providerId: 'fake', taskId: 't1', modelUsed: 'fake-1', submittedAt: 0 };
+    },
+    poll: async () => ({
+      state: 'succeeded',
+      videoUrl: 'https://example.invalid/v.mp4',
+      meta: opts.meta ?? {},
+    }),
+    download: async () => ({ buffer: Buffer.from([1, 2]), mimeType: 'video/mp4' }),
+  };
+}
+
+function makeRegistry(provider: VideoProvider): VideoProviderRegistry {
+  const r = new VideoProviderRegistry();
+  r.register(provider);
+  return r;
+}
+
+describe('submitAndAwaitVideo · 画面参数', () => {
+  it('不传任何参数 → 提交该型号的出厂默认(放开前后行为一致)', async () => {
+    const submitted: VideoGenerationRequest[] = [];
+    const registry = makeRegistry(makeProvider({ submitted }));
+    const r = await submitAndAwaitVideo(registry, { alias: 'fake-fast', prompt: 'p' });
+    expect(submitted[0]).toMatchObject({
+      prompt: 'p',
+      duration: 4,
+      resolution: '720p',
+      ratio: '16:9',
+      fps: 24,
+    });
+    // 上游没报 meta → 回执回落我们提交的值。
+    expect(r.effectiveParams).toEqual({
+      duration: 4,
+      resolution: '720p',
+      ratio: '16:9',
+      fps: 24,
+    });
+  });
+
+  it('传了的项透传,没传的项落默认', async () => {
+    const submitted: VideoGenerationRequest[] = [];
+    const registry = makeRegistry(makeProvider({ submitted }));
+    await submitAndAwaitVideo(registry, {
+      alias: 'fake-fast',
+      prompt: 'p',
+      duration: 8,
+      ratio: '9:16',
+    });
+    expect(submitted[0]).toMatchObject({
+      duration: 8,
+      ratio: '9:16',
+      resolution: '720p',
+      fps: 24,
+    });
+  });
+
+  it('型号不支持的值 → 抛错且不提交,话术带该型号可用值', async () => {
+    const submitted: VideoGenerationRequest[] = [];
+    const registry = makeRegistry(makeProvider({ submitted }));
+    await expect(
+      submitAndAwaitVideo(registry, { alias: 'fake-fast', prompt: 'p', duration: 10 }),
+    ).rejects.toThrow(/does not support duration 10 \(supported: 4, 6, 8\)/);
+    await expect(
+      submitAndAwaitVideo(registry, { alias: 'fake-fast', prompt: 'p', ratio: '1:1' }),
+    ).rejects.toThrow(/does not support ratio 1:1/);
+    expect(submitted).toHaveLength(0);
+  });
+
+  it('回执优先用上游上报的真实值,上游没报的那项回落提交值', async () => {
+    const submitted: VideoGenerationRequest[] = [];
+    const registry = makeRegistry(
+      makeProvider({
+        submitted,
+        // 上游只报了时长与分辨率(实际产出与请求不同,以上游为准)。
+        meta: { durationSec: 6, resolution: '1080p' },
+      }),
+    );
+    const r = await submitAndAwaitVideo(registry, {
+      alias: 'fake-fast',
+      prompt: 'p',
+      duration: 8,
+      resolution: '480p',
+      ratio: '9:16',
+    });
+    expect(r.effectiveParams).toEqual({
+      duration: 6,
+      resolution: '1080p',
+      ratio: '9:16',
+      fps: 24,
+    });
+  });
+
+  it('参考图超出型号上限 → 抛错且不提交', async () => {
+    const submitted: VideoGenerationRequest[] = [];
+    const registry = makeRegistry(makeProvider({ submitted, maxImages: 1 }));
+    await expect(
+      submitAndAwaitVideo(registry, {
+        alias: 'fake-fast',
+        prompt: 'p',
+        imageDataUris: ['data:image/png;base64,a', 'data:image/png;base64,b'],
+      }),
+    ).rejects.toThrow(/at most 1 reference image/);
+    expect(submitted).toHaveLength(0);
+  });
+
+  it('参考图为空时不塞 images 键(与老载荷同形)', async () => {
+    const submitted: VideoGenerationRequest[] = [];
+    const registry = makeRegistry(makeProvider({ submitted }));
+    await submitAndAwaitVideo(registry, { alias: 'fake-fast', prompt: 'p', imageDataUris: [] });
+    expect(submitted[0].images).toBeUndefined();
+  });
+
+  it('轮询失败 → 抛出上游错因', async () => {
+    const provider = makeProvider({ submitted: [] });
+    const failing: VideoProvider = {
+      ...provider,
+      poll: vi.fn(async () => ({ state: 'failed', error: 'quota exceeded' }) as VideoTaskStatus),
+    };
+    await expect(
+      submitAndAwaitVideo(makeRegistry(failing), { alias: 'fake-fast', prompt: 'p' }),
+    ).rejects.toThrow(/quota exceeded/);
+  });
+});

--- a/apps/desktop/src/main/cindy-proxy-media/video/providers/happyhorse.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/providers/happyhorse.ts
@@ -168,12 +168,19 @@ function buildParameters(
       sr === '1080p' ? 1920 : sr === '480p' ? 854 : 1280;
     const shortSide =
       sr === '1080p' ? 1080 : sr === '480p' ? 480 : 720;
+    // 每档的像素量以该档 16:9(longSide*shortSide)为上限,任何比例都不得
+    // 超过——超了就是偷偷升档:DashScope 可能直接拒,或按更高分辨率出片
+    // 并计费。4:3 原先拿 longSide 当宽再推高(720p → 1280*960 = 基准的
+    // 1.33 倍)是唯一越线的一项,改成以高锚定该档短边(960*720)。
+    // 注:3:4 与 4:3 的长边口径并不对称(540*720 vs 960*720),那是既有
+    // 映射,两者都在基准像素量之内,统一口径需要 DashScope 侧的权威依据,
+    // 不在本次范围。
     const ratioMap: Record<string, string> = {
       '16:9': `${longSide}*${shortSide}`,
       '9:16': `${shortSide}*${longSide}`,
       '1:1': `${shortSide}*${shortSide}`,
-      '4:3': `${longSide}*${Math.round(longSide * 3 / 4)}`,
-      '3:4': `${Math.round(shortSide * 3 / 4)}*${shortSide}`,
+      '4:3': `${Math.round((shortSide * 4) / 3)}*${shortSide}`,
+      '3:4': `${Math.round((shortSide * 3) / 4)}*${shortSide}`,
     };
     const size = ratioMap[req.ratio];
     if (size) params.size = size;

--- a/apps/desktop/src/main/cindy-proxy-media/video/run.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/run.ts
@@ -74,19 +74,55 @@ export interface SubmitAndAwaitVideoParams {
    * 超出目标模型的 maxImages 直接抛错(调用方折叠成结构化拒绝)。
    */
   imageDataUris?: string[];
+  /**
+   * 画面参数(全部可选,2026-07 放开):不传的项落该模型的出厂默认,
+   * 与放开之前的行为逐字节同形。传了但该模型不支持 → 抛错,不做最近似
+   * 降级(上游调用方已按型号校验过一轮,这里是执行器自己的兜底)。
+   */
+  duration?: number;
+  resolution?: string;
+  ratio?: string;
+  fps?: number;
   signal?: AbortSignal;
 }
 
+/** 本单实际提交/兑现的画面参数(上游任务上报值优先,缺项回落提交值)。 */
+export interface SubmitAndAwaitVideoEffectiveParams {
+  duration: number;
+  resolution: string;
+  ratio: string;
+  fps: number;
+}
+
+/** 逐项核对画面参数是否在该模型的支持集内;不支持即抛(话术含可用值)。 */
+function assertParamSupported<T extends string | number>(
+  alias: string,
+  name: string,
+  value: T | undefined,
+  supported: ReadonlyArray<T>,
+): void {
+  if (value === undefined || supported.includes(value)) return;
+  throw new Error(
+    `art: model '${alias}' does not support ${name} ${String(value)} (supported: ${supported.join(', ')})`,
+  );
+}
+
 /**
- * 一条龙执行一单视频生成:别名解析 → 能力校验(参考图张数)→ 用该模型的
- * 默认参数(时长/分辨率/比例/帧率)提交 → 轮询 → 下载字节。
- * cindy 槽代办走模型默认参数(时长/分辨率/比例/帧率),不开放细调——
- * 意识只表达"画什么",怎么画是主机与模型的资产。
+ * 一条龙执行一单视频生成:别名解析 → 能力校验(参考图张数 + 画面参数)→
+ * 提交 → 轮询 → 下载字节。
+ * 画面参数(时长/分辨率/比例/帧率)由调用方可选覆盖,不传的项落该模型的
+ * 出厂默认。返回值带回实际生效参数:上游任务上报的值优先(它才是真实
+ * 产出),上游没报的那项回落我们提交的值。
  */
 export async function submitAndAwaitVideo(
   registry: VideoProviderRegistry,
   params: SubmitAndAwaitVideoParams,
-): Promise<{ buffer: Buffer; mimeType: string; modelUsed: string }> {
+): Promise<{
+  buffer: Buffer;
+  mimeType: string;
+  modelUsed: string;
+  effectiveParams: SubmitAndAwaitVideoEffectiveParams;
+}> {
   const resolved = registry.resolveByAlias(params.alias);
   const caps = resolved.provider.capabilities;
   const images = params.imageDataUris ?? [];
@@ -95,12 +131,20 @@ export async function submitAndAwaitVideo(
       `art: model '${params.alias}' supports at most ${caps.maxImages} reference image(s), got ${images.length}`,
     );
   }
+  assertParamSupported(params.alias, 'duration', params.duration, caps.supportedDurations);
+  assertParamSupported(params.alias, 'resolution', params.resolution, caps.supportedResolutions);
+  assertParamSupported(params.alias, 'ratio', params.ratio, caps.supportedRatios);
+  assertParamSupported(params.alias, 'fps', params.fps, caps.supportedFps);
+
+  const submitted: SubmitAndAwaitVideoEffectiveParams = {
+    duration: params.duration ?? caps.defaults.duration,
+    resolution: params.resolution ?? caps.defaults.resolution,
+    ratio: params.ratio ?? caps.defaults.ratio,
+    fps: params.fps ?? caps.defaults.fps,
+  };
   const req: VideoGenerationRequest = {
     prompt: params.prompt,
-    duration: caps.defaults.duration,
-    resolution: caps.defaults.resolution,
-    ratio: caps.defaults.ratio,
-    fps: caps.defaults.fps,
+    ...submitted,
     images: images.length > 0 ? images : undefined,
   };
   const handle = await resolved.provider.submit(req, params.alias, params.signal);
@@ -110,5 +154,15 @@ export async function submitAndAwaitVideo(
     ...(params.signal ? { signal: params.signal } : {}),
   });
   const dl = await resolved.provider.download(status.videoUrl, params.signal);
-  return { buffer: dl.buffer, mimeType: dl.mimeType, modelUsed: handle.modelUsed };
+  return {
+    buffer: dl.buffer,
+    mimeType: dl.mimeType,
+    modelUsed: handle.modelUsed,
+    effectiveParams: {
+      duration: status.meta.durationSec ?? submitted.duration,
+      resolution: status.meta.resolution ?? submitted.resolution,
+      ratio: status.meta.ratio ?? submitted.ratio,
+      fps: status.meta.fps ?? submitted.fps,
+    },
+  };
 }

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -4639,6 +4639,29 @@ export const GHOST_IMAGE_ASPECT_RATIOS = ['1:1', '3:2', '2:3'] as const;
 export type GhostImageAspectRatio = (typeof GHOST_IMAGE_ASPECT_RATIOS)[number];
 
 /**
+ * cindy 槽视频代办的画幅比例。与生图的 aspectRatio 分开成两套值域:视频
+ * 后端(video provider 层)的公共集是 16:9 系,与图像后端的原生尺寸枚举
+ * 没有交集,合成一套只会让两边都出现"声明了却兑现不了"的值。这里登记的
+ * 是**所有已注册 provider 都支持**的交集,单个型号的实际支持集由主机在
+ * 解析出选型后二次校验(型号不支持即明拒,不做最近似降级)。
+ */
+export const GHOST_VIDEO_RATIOS = ['16:9', '9:16', '1:1', '4:3', '3:4'] as const;
+export type GhostVideoRatio = (typeof GHOST_VIDEO_RATIOS)[number];
+
+/** cindy 槽视频代办的分辨率档(同 GHOST_VIDEO_RATIOS 的口径:公共集 + 按型号二次校验)。 */
+export const GHOST_VIDEO_RESOLUTIONS = ['480p', '720p', '1080p'] as const;
+export type GhostVideoResolution = (typeof GHOST_VIDEO_RESOLUTIONS)[number];
+
+/**
+ * 视频时长/帧率的形状上限(秒 / fps)。这两项各型号差异大(如 seedance
+ * 支持 4/6/8/10 秒,happyhorse 只有 5 秒),协议层不枚举值域,只做"正整数
+ * 且不离谱"的粗筛,真正的可用集由主机按解析出的型号校验并在拒绝话术里
+ * 列出。粗筛的意义是挡住沙箱乱填(负数、小数、天文数字)。
+ */
+export const GHOST_VIDEO_MAX_DURATION_SECONDS = 60;
+export const GHOST_VIDEO_MAX_FPS = 120;
+
+/**
  * 异步代办(mode:'submit')完成结果的保留时长(毫秒,30 分钟):完成后
  * 过期即清,query_job 查无此单。TTL 之外还有每意识完成记录条数上限
  * (cindySlot 的 settled-job eviction):快速提交循环下最旧的完成记录会
@@ -4717,8 +4740,8 @@ export type GhostPipeCindyRequest =
       /**
        * 画幅比例(可选):'1:1' 方图 / '3:2' 横图 / '2:3' 竖图;不传 =
        * 后端自定(auto)。比例是意图声明,主机映射为该后端的具体尺寸,
-       * 实际像素以返回的 width/height 为准。仅生图支持——改图跟随源图
-       * 画幅,视频画幅由 provider 层自治,带了会被明拒。
+       * 实际像素以返回的 width/height 为准。图像类代办(生图/改图)专用,
+       * 视频类请改用 ratio(值域不同),带错了会被明拒。
        */
       aspectRatio?: GhostImageAspectRatio;
       /**
@@ -4739,6 +4762,11 @@ export type GhostPipeCindyRequest =
       hashes: string[];
       tier?: GhostModelTier;
       model?: string;
+      /**
+       * 画幅比例(可选,语义同 gen_image 分支)。不传 = 跟随源图画幅
+       * (后端 auto),这也是历史行为;传了则按该比例重绘。
+       */
+      aspectRatio?: GhostImageAspectRatio;
       /** 归因号(同 gen_image 分支)。 */
       callId?: string;
     }
@@ -4748,6 +4776,17 @@ export type GhostPipeCindyRequest =
       prompt: string;
       tier?: GhostModelTier;
       model?: string;
+      /**
+       * 画面参数(全部可选):不传 = 该型号的出厂默认(与历史行为逐字节
+       * 同形)。ratio/resolution 的值域见 GHOST_VIDEO_RATIOS /
+       * GHOST_VIDEO_RESOLUTIONS;duration(秒)与 fps 各型号支持集不同,
+       * 主机按解析出的选型校验,不支持即明拒并列出可用值。实际生效的
+       * 参数随结果回传(见 GhostPipeModelResult 的 videoParams)。
+       */
+      ratio?: GhostVideoRatio;
+      resolution?: GhostVideoResolution;
+      duration?: number;
+      fps?: number;
       /** 归因号(同 gen_image 分支)。 */
       callId?: string;
       /**
@@ -4769,6 +4808,11 @@ export type GhostPipeCindyRequest =
       hashes: string[];
       tier?: GhostModelTier;
       model?: string;
+      /** 画面参数(同 gen_video 分支;参考图不改变这几项的语义)。 */
+      ratio?: GhostVideoRatio;
+      resolution?: GhostVideoResolution;
+      duration?: number;
+      fps?: number;
       /** 归因号(同 gen_image 分支)。 */
       callId?: string;
       /** 异步模式(同 gen_video 分支)。 */
@@ -4822,6 +4866,22 @@ export type GhostPipeCindyRequest =
       hash: string;
     };
 
+/**
+ * 视频代办实际生效的画面参数回执(仅视频类代办)。取值优先用上游任务
+ * 上报的真实值,上游没报的那项回落主机提交值;各字段仍可能缺省(上游
+ * 没报且主机也没显式指定时)。类型是宽松的 string/number 而非请求侧的
+ * 枚举——回执是**上游说的**,不能假设它落在主机的值域里。
+ *
+ * 用途:老宿主会静默忽略请求里的新画面参数,意识拿这份回执才分得清
+ * "宿主不支持,给了默认档"与"宿主兑现了我要的档"。
+ */
+export interface GhostVideoResultParams {
+  durationSeconds?: number;
+  resolution?: string;
+  ratio?: string;
+  fps?: number;
+}
+
 /** cindy 槽代办的返回(cindy.send 的 resolve 值)。 */
 export type GhostPipeModelResult =
   | {
@@ -4843,6 +4903,8 @@ export type GhostPipeModelResult =
        */
       width?: number;
       height?: number;
+      /** 视频代办实际生效的画面参数(仅视频类代办;图像类不带此字段)。 */
+      videoParams?: GhostVideoResultParams;
     }
   | {
       ok: true;
@@ -4867,6 +4929,8 @@ export type GhostPipeModelResult =
       ext: string;
       model: string;
       modelLabel: string;
+      /** 与同步成功分支同形(异步代办只有视频,这里通常必带)。 */
+      videoParams?: GhostVideoResultParams;
     }
   | {
       /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

插件（`.cindy`）请 Cindy 代办生成媒体时，此前只有生图能声明 `aspectRatio`，改图和视频完全拿不到画面控制——视频永远是型号出厂默认的时长/分辨率/比例/帧率。

实际上 provider 层早就把这些参数实现好了（`VideoGenerationRequest` 有 `duration/resolution/ratio/fps`，两个 provider 也都声明了 `supported*` 与 `defaults`），只是 `submitAndAwaitVideo` 把 `caps.defaults` 写死，入口一直关着。这个 PR 把入口打开，并放开改图的画幅。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 视频代办（`gen_video` / `edit_video`）开放可选 `ratio` / `resolution` / `duration` / `fps`。协议层按所有 provider 的公共集粗筛（比例 5 档、分辨率 3 档、时长与帧率只筛正整数量级），再按**解析出的型号**二次校验——各型号支持集差异大（seedance 4/6/8/10 秒，happyhorse 只有 5 秒），不支持即明拒并在话术里列出该型号可用值，**不做最近似降级**（静默改档会让插件以为自己的参数生效了）。
  - 改图（`edit_image`）放开 `aspectRatio`，值域沿用生图的三档。不传 = 后端 `auto` = 跟随源图画幅，与放开前一致。
  - 视频结果回传 `videoParams`（`durationSeconds` / `resolution` / `ratio` / `fps`），取值上游任务上报优先、缺项回落主机提交值。**这一项是给兼容性用的**：老宿主会静默忽略请求里的新参数，插件靠这份回执才分得清"宿主不支持，给了默认档"和"宿主兑现了我要的档"。
  - 同步 `FORGE_GUIDE` §4 cindy 代办章节（命中作者可见契约中的「模型能力 slot 的参数」）。
- 明确不包含：
  - **图像比例值域未扩**（16:9 / 9:16 / 4:3 / 3:4）。现有三档是 gpt-image 系的原生尺寸枚举，新比例能否兑现取决于服务端网关对各图像模型的 `size` 支持，需先与服务端确认，另提。
  - **未加成本闸**。开放 `1080p × 10s` 后单次成本明显上升，目前只有 `inflightLimits`（同时几单，默认不限）和 `GHOST_CINDY_MAX_ASYNC_JOBS`，没有按参数的成本约束，安装确认框也不展示画质档。这是有意为之：当下连并发都默认不限，单独给画质加闸不成比例；成本治理的正确落点是统一配额体系，与 `media-storage-and-protocols.md` 已挂账的「插件持久引用缺 per-插件 字节配额」一起做。手册里已写明"高分辨率+长时长更贵更慢，用户没提要求时不要自作主张调高"。
  - 未开放图像的 `quality` / `n`（网关支持 `quality`，但与 `tier` 语义正交容易混；`n` 要改返回值形态与账本记账，收益不成比例）。
- 用户可见变化：插件可以生成竖屏/方屏、更长或更高清的视频了；不更新的插件行为完全不变。
- 是否存在 breaking change：无。新参数全部可选，一项不传时发给后端的载荷**连键都没有**，与老协议逐字节同形（沿用 `aspectRatio` 当初的条件展开范式，测试对这条同形性有专门断言）。

### UI 变化

不涉及。

- 引用的设计规范：不涉及（纯主进程协议与执行链路，无渲染层改动）。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：PASS，exit 0。apps/desktop (53.3s) / apps/mobile (10.6s) 及全部 packages 绿。

pnpm --filter desktop typecheck
结果：PASS（本 PR 只涉及 desktop 一个 package）。

pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/cindySlot.test.ts
结果：48 passed（其中本次新增 6 例）。

pnpm --filter desktop exec vitest run src/main/cindy-proxy-media src/main/cindy-brain/__tests__/forge.test.ts
结果：62 passed（其中新建 video/__tests__/run.test.ts 7 例、forge 章节存在性新增 4 个 marker）。
```

新增测试覆盖：合法参数透传、**不传时载荷与老协议同形**、值域粗筛（未知比例/分辨率、0/小数/负数/超大时长、非法帧率）、按型号二次校验（5 秒对 seedance 拒且话术带可用值）、`videoCapabilities` 缺席时降级放行、画面参数与 `aspectRatio` 互不串用、执行器侧默认值回落与实际参数回执优先级。

### 手工验证

不涉及（见下）。

### 未执行的验证

- **没有实机运行验证**：未真实调用过网关的 `edit_image + size`，也未真实提交过带画面参数的视频任务。这条链路需要重启宿主才能验，本次改动全部经 DI 单测覆盖。
- `edit_image` 带 `size` 时各图像模型（尤其 gpt-image-2 改图接口）的实际兑现行为，依据的是 `gatewayImageClient.ts` 中已有的 `size` 透传能力，未实际打过网关。
- `pnpm test:guard` 有 3 个失败（`makerSendToSessionOrdering.test.ts`），读的是 `maker-ipc/` / `scheduler-host/` / `goal-host/` / `im/` / `orca-workflow` / `preload.ts`，本 PR 一个都没碰（`git diff main --name-only` 只有 8 个文件），是 main 上既有的失败，未在本 PR 处理。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 其他：插件作者契约（`FORGE_GUIDE`）

### 影响与回滚

- 影响范围：插件 cindy 槽的媒体代办链路（`cindySlot` → `cindy-brain/index.ts` 注入实现 → `cindy-proxy-media/video/run.ts`）。未声明新参数的插件走的代码路径与改动前完全一致。`submitAndAwaitVideo` 的唯一消费方就是 cindy 槽，爆炸半径限于此。
- 协议兼容：纯加法。老插件 → 新宿主：不传新参数，载荷同形。新插件 → 老宿主：老宿主静默忽略未知键、给默认档，插件可通过返回值有无 `videoParams` 判别（这正是加这个回执的原因）。
- 手册同步：已同步 `FORGE_GUIDE` §4 cindy 代办章节（改图画幅、视频四参数值域与"不传=型号默认"语义、`videoParams` 回执、成本提示），并在 `forge.test.ts` 补了章节存在性 marker。
- 回滚 / 降级方式：直接 revert 本 commit 即可，无数据迁移、无持久化状态、无协议版本协商。回滚后已按新参数编写的插件退回默认档，不会报错。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`FORGE_GUIDE`）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
