### PR TITLE
fix(desktop): restore browser loading and favicon feedback

### DIFF
--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
@@ -309,6 +309,123 @@ describe('useBrowserWebview', () => {
     expect(mockWebview.loadURL).toHaveBeenCalledTimes(BROWSER_NAVIGATION_FUSE_LIMIT + 1);
   });
 
+  it('shows loading immediately on reload and resets after stop-loading', () => {
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: true,
+      onResult: (next) => { result = next; },
+    }));
+
+    act(() => result!.reload());
+    expect(mockWebview.reload).toHaveBeenCalledOnce();
+    expect(result!.isLoading).toBe(true);
+
+    act(() => mockWebview.dispatch('did-stop-loading'));
+    expect(result!.isLoading).toBe(false);
+  });
+
+  it('rolls back optimistic loading when reload throws', () => {
+    mockWebview.reload.mockImplementationOnce(() => {
+      throw new Error('detached');
+    });
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: true,
+      onResult: (next) => { result = next; },
+    }));
+
+    act(() => result!.reload());
+    expect(result!.isLoading).toBe(false);
+  });
+
+  it('leaves loading immediately when the user stops the page', () => {
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: true,
+      onResult: (next) => { result = next; },
+    }));
+
+    act(() => result!.reload());
+    expect(result!.isLoading).toBe(true);
+
+    act(() => result!.stop());
+    expect(mockWebview.stop).toHaveBeenCalledOnce();
+    expect(result!.isLoading).toBe(false);
+  });
+
+  it('distinguishes an unobserved favicon from an explicitly missing favicon', () => {
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: true,
+      onResult: (next) => { result = next; },
+    }));
+
+    expect(result!.favicon).toBeNull();
+
+    act(() => {
+      mockWebview.dispatch('page-favicon-updated', {
+        favicons: ['', 'https://www.taptap.cn/favicon.ico'],
+      });
+    });
+    expect(result!.favicon).toBe('https://www.taptap.cn/favicon.ico');
+
+    act(() => {
+      mockWebview.dispatch('page-favicon-updated', { favicons: [] });
+    });
+    expect(result!.favicon).toBe('');
+  });
+
+  it('does not treat a suppressed stale navigation report as a missing favicon', () => {
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: true,
+      onResult: (next) => { result = next; },
+    }));
+
+    act(() => {
+      mockWebview.dispatch('page-favicon-updated', {
+        favicons: ['https://www.taptap.cn/favicon.ico'],
+      });
+      result!.navigate('https://example.com/');
+    });
+    expect(result!.favicon).toBeNull();
+
+    act(() => {
+      mockWebview.dispatch('did-navigate', { url: 'https://www.taptap.cn/' });
+    });
+    expect(result!.favicon).toBeNull();
+    expect(result!.url).toBe('https://example.com/');
+  });
+
+  it('clears a stale favicon after guest navigation but keeps reload state independent', () => {
+    let result: UseBrowserWebviewResult | null = null;
+    render(createElement(HookProbe, {
+      visible: true,
+      onResult: (next) => { result = next; },
+    }));
+
+    act(() => {
+      mockWebview.dispatch('page-favicon-updated', {
+        favicons: ['https://www.taptap.cn/favicon.ico'],
+      });
+    });
+    expect(result!.favicon).toBe('https://www.taptap.cn/favicon.ico');
+
+    act(() => {
+      mockWebview.dispatch('did-navigate', { url: 'https://example.com/' });
+    });
+    expect(result!.favicon).toBe('');
+
+    act(() => {
+      mockWebview.dispatch('page-favicon-updated', {
+        favicons: ['https://example.com/favicon.ico'],
+      });
+      result!.reload();
+    });
+    expect(result!.favicon).toBe('https://example.com/favicon.ico');
+    expect(result!.isLoading).toBe(true);
+  });
+
   it('re-acquires a fresh pool entry when an evicted tab becomes visible again', async () => {
     const { browserWebviewPool } = await import('../../lib/browserWebviewPool');
     const acquire = vi.mocked(browserWebviewPool.acquire);

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
@@ -59,8 +59,11 @@ export interface UseBrowserWebviewResult {
   url: string;
   /** 当前页面 title(`page-title-updated`)。 */
   title: string;
-  /** 当前页面 favicon URL,无则空串(`page-favicon-updated`)。 */
-  favicon: string;
+  /**
+   * 当前页面 favicon URL。null = 当前 webview 代际尚未观测到 favicon；
+   * 空串 = 已明确观测到页面没有 favicon。
+   */
+  favicon: string | null;
   /** 正在加载中(`did-start-loading` 翻 true,`did-stop-loading` 翻 false)。 */
   isLoading: boolean;
   /** webview 导航历史里有"上一页"。 */
@@ -108,7 +111,7 @@ export function useBrowserWebview(
   const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null);
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
-  const [favicon, setFavicon] = useState('');
+  const [favicon, setFavicon] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
@@ -165,12 +168,13 @@ export function useBrowserWebview(
         !isSameNavigationUrl(nextUrl, suppress.targetUrl)
       ) {
         suppressStaleUrlRef.current = null;
-        return;
+        return false;
       }
       suppressStaleUrlRef.current = null;
     }
     urlRef.current = nextUrl;
     setUrl(nextUrl);
+    return true;
   }, []);
 
   useEffect(() => {
@@ -195,7 +199,7 @@ export function useBrowserWebview(
       suppressStaleUrlRef.current = null;
       setUrl('');
       setTitle('');
-      setFavicon('');
+      setFavicon(null);
       setIsLoading(false);
       setCanGoBack(false);
       setCanGoForward(false);
@@ -232,10 +236,16 @@ export function useBrowserWebview(
 
     const onTitle = (e: Electron.PageTitleUpdatedEvent) => setTitle(e.title);
     const onFavicon = (e: Electron.PageFaviconUpdatedEvent) => {
-      setFavicon(e.favicons[0] ?? '');
+      setFavicon(e.favicons.find((candidate) => candidate.trim().length > 0) ?? '');
     };
     const onDidNavigate = (e: Electron.DidNavigateEvent) => {
-      setObservedUrl(e.url);
+      const previousUrl = urlRef.current;
+      const accepted = setObservedUrl(e.url);
+      // 网页自身发起的跨页导航没有走 navigate(),必须在提交新 URL 时清掉旧站图标；
+      // 初次 attach / 被抑制的旧 URL 回报都保持 "尚未观测" 语义,避免抹掉持久化 favicon。
+      if (accepted && previousUrl && !isSameNavigationUrl(previousUrl, e.url)) {
+        setFavicon('');
+      }
       refreshNav();
     };
     const onDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
@@ -432,6 +442,9 @@ export function useBrowserWebview(
     }
     urlRef.current = nextUrl;
     setUrl(nextUrl);
+    // 主动导航后旧页 favicon 已不再可信，但这里用 null 表示 "等待新页观测"；
+    // BrowserTabBody 会保留持久化 fallback，显式用户导航则由调用方同步清空。
+    setFavicon(null);
     setIsLoading(true);
     if (!wv) return;
     try {
@@ -447,11 +460,30 @@ export function useBrowserWebview(
     navigationAttemptsRef.current = [];
     navigationFuseTrippedRef.current = false;
     setCrash(null);
-    webviewRef.current?.reload();
+    setResourceAlert(null);
+    const wv = webviewRef.current;
+    if (!wv) return;
+    // 不等 did-start-loading 才反馈；Electron 事件有异步间隙，用户点击后应立即看到
+    // BrowserChrome 的 loading 动画。调用失败时回滚，避免 UI 永久卡住。
+    setIsLoading(true);
+    try {
+      wv.reload();
+    } catch {
+      setIsLoading(false);
+    }
   }, []);
   const goBack = useCallback(() => webviewRef.current?.goBack(), []);
   const goForward = useCallback(() => webviewRef.current?.goForward(), []);
-  const stop = useCallback(() => webviewRef.current?.stop(), []);
+  const stop = useCallback(() => {
+    try {
+      webviewRef.current?.stop();
+    } catch {
+      // detach / crash 窗口内 stop 可能抛；UI 仍应退出 loading，等待后续事件恢复。
+    } finally {
+      // stop 也是用户发起的即时动作；不必再等 did-stop-loading 才恢复刷新按钮。
+      setIsLoading(false);
+    }
+  }, []);
   const dismissResourceAlert = useCallback(() => setResourceAlert(null), []);
 
   return {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
@@ -216,7 +216,9 @@ export const BrowserChrome = forwardRef<BrowserChromeHandle, BrowserChromeProps>
         tooltip={t('rightSidebar.browser.goForward')}
       />
       <ChromeIconButton
-        icon={isLoading ? XIcon : RotateCw}
+        icon={RotateCw}
+        reducedMotionIcon={isLoading ? XIcon : undefined}
+        spinning={isLoading}
         onClick={isLoading ? onStop : onReload}
         tooltip={
           isLoading
@@ -322,19 +324,29 @@ export const BrowserChrome = forwardRef<BrowserChromeHandle, BrowserChromeProps>
  */
 function ChromeIconButton({
   icon: Icon,
+  reducedMotionIcon: ReducedMotionIcon,
   size = 14,
   inlinePill = false,
   disabled = false,
   active = false,
+  spinning = false,
   onClick,
   tooltip,
 }: {
   icon: React.ComponentType<{ size?: number; strokeWidth?: number; className?: string }>;
+  /** reduced-motion 下用静态动作图标表达 loading 状态，避免刷新/空闲态无法区分。 */
+  reducedMotionIcon?: React.ComponentType<{
+    size?: number;
+    strokeWidth?: number;
+    className?: string;
+  }>;
   size?: number;
   inlinePill?: boolean;
   disabled?: boolean;
   /** 常亮 active 态(如评论模式进行中):反色底,提示当前处于该工具的模式里。 */
   active?: boolean;
+  /** 加载态旋转放在 HTML wrapper 上,避免 SVG 常驻动画触发主线程重绘。 */
+  spinning?: boolean;
   onClick: () => void;
   tooltip: string;
 }) {
@@ -345,6 +357,7 @@ function ChromeIconButton({
       onClick={onClick}
       title={tooltip}
       aria-label={tooltip}
+      aria-busy={spinning || undefined}
       className={cn(
         'flex shrink-0 items-center justify-center rounded-md transition-colors',
         inlinePill ? 'size-[18px]' : 'size-6',
@@ -355,7 +368,25 @@ function ChromeIconButton({
             : 'text-sidebar-action-icon hover:bg-sidebar-item-active hover:text-sidebar-item-active-foreground',
       )}
     >
-      <Icon size={size} strokeWidth={2} />
+      {spinning && ReducedMotionIcon ? (
+        <>
+          <span className="inline-flex animate-spin motion-reduce:hidden">
+            <Icon size={size} strokeWidth={2} />
+          </span>
+          <span className="hidden motion-reduce:inline-flex">
+            <ReducedMotionIcon size={size} strokeWidth={2} />
+          </span>
+        </>
+      ) : (
+        <span
+          className={cn(
+            'inline-flex',
+            spinning && 'animate-spin motion-reduce:animate-none',
+          )}
+        >
+          <Icon size={size} strokeWidth={2} />
+        </span>
+      )}
     </button>
   );
 }

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
@@ -370,7 +370,7 @@ function ChromeIconButton({
     >
       {spinning && ReducedMotionIcon ? (
         <>
-          <span className="inline-flex animate-spin motion-reduce:hidden">
+          <span className="inline-flex animate-spinner motion-reduce:hidden">
             <Icon size={size} strokeWidth={2} />
           </span>
           <span className="hidden motion-reduce:inline-flex">
@@ -381,7 +381,7 @@ function ChromeIconButton({
         <span
           className={cn(
             'inline-flex',
-            spinning && 'animate-spin motion-reduce:animate-none',
+            spinning && 'animate-spinner motion-reduce:animate-none',
           )}
         >
           <Icon size={size} strokeWidth={2} />

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
@@ -157,8 +157,12 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
   }, [browser.title, ctx, state.title]);
 
   useEffect(() => {
-    if (browser.favicon === state.favicon) return;
-    ctx.patchState({ favicon: browser.favicon || null });
+    // null 表示当前 webview 代际尚未观测到 favicon，不能据此清掉持久化图标；
+    // 空串才是 page-favicon-updated 明确报告 "无图标"。
+    if (browser.favicon === null) return;
+    const nextFavicon = browser.favicon || null;
+    if (nextFavicon === state.favicon) return;
+    ctx.patchState({ favicon: nextFavicon });
   }, [browser.favicon, ctx, state.favicon]);
 
   // isAudible 同步:webview audio-state-changed → patchState({isAudible}),

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
@@ -44,7 +44,12 @@ vi.mock('@/components/ui/dropdown-menu', () => {
 
 function renderChrome(
   url = 'https://www.taptap.cn/',
-  extra: { commentSupported?: boolean } = {},
+  extra: {
+    commentSupported?: boolean;
+    isLoading?: boolean;
+    onReload?: () => void;
+    onStop?: () => void;
+  } = {},
 ) {
   const onNavigate = vi.fn();
   const onOpenInSystemBrowser = vi.fn();
@@ -54,12 +59,12 @@ function renderChrome(
     createElement(BrowserChrome, {
       ref,
       url,
-      isLoading: false,
+      isLoading: extra.isLoading ?? false,
       canGoBack: false,
       canGoForward: false,
       onNavigate,
-      onReload: vi.fn(),
-      onStop: vi.fn(),
+      onReload: extra.onReload ?? vi.fn(),
+      onStop: extra.onStop ?? vi.fn(),
       onGoBack: vi.fn(),
       onGoForward: vi.fn(),
       onCaptureScreenshot: vi.fn(),
@@ -67,7 +72,7 @@ function renderChrome(
       onToggleComment: vi.fn(),
       onOpenInSystemBrowser,
       onCopyLink,
-      ...extra,
+      commentSupported: extra.commentSupported,
     }),
   );
   return { onNavigate, onOpenInSystemBrowser, onCopyLink, ref };
@@ -104,6 +109,46 @@ describe('BrowserChrome', () => {
     expect(
       screen.queryByRole('button', { name: 'rightSidebar.browser.comment' }),
     ).toBeNull();
+  });
+
+  it('shows a compositor-friendly refresh animation while loading and stops on click', () => {
+    const onReload = vi.fn();
+    const onStop = vi.fn();
+    renderChrome('https://www.taptap.cn/', {
+      isLoading: true,
+      onReload,
+      onStop,
+    });
+
+    const button = screen.getByRole('button', { name: 'rightSidebar.browser.stop' });
+    const spinner = button.querySelector('span');
+    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(spinner?.classList.contains('animate-spin')).toBe(true);
+    expect(spinner?.classList.contains('motion-reduce:hidden')).toBe(true);
+    expect(button.querySelector('.lucide-rotate-cw')).toBeTruthy();
+    expect(
+      button.querySelector('.lucide-x')?.parentElement?.classList.contains(
+        'motion-reduce:inline-flex',
+      ),
+    ).toBe(true);
+
+    fireEvent.click(button);
+    expect(onStop).toHaveBeenCalledOnce();
+    expect(onReload).not.toHaveBeenCalled();
+  });
+
+  it('keeps the idle refresh icon static and reloads on click', () => {
+    const onReload = vi.fn();
+    const onStop = vi.fn();
+    renderChrome('https://www.taptap.cn/', { onReload, onStop });
+
+    const button = screen.getByRole('button', { name: 'rightSidebar.browser.reload' });
+    expect(button.hasAttribute('aria-busy')).toBe(false);
+    expect(button.querySelector('span')?.classList.contains('animate-spin')).toBe(false);
+
+    fireEvent.click(button);
+    expect(onReload).toHaveBeenCalledOnce();
+    expect(onStop).not.toHaveBeenCalled();
   });
 
   it('fires open-in-system-browser and copy-link from the more menu when the link is valid', () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createElement, createRef } from 'react';
 
+import tailwindConfig from '../../../../../../../tailwind.config';
 import { BrowserChrome, type BrowserChromeHandle } from '../BrowserChrome';
 
 vi.mock('react-i18next', () => ({
@@ -123,7 +124,8 @@ describe('BrowserChrome', () => {
     const button = screen.getByRole('button', { name: 'rightSidebar.browser.stop' });
     const spinner = button.querySelector('span');
     expect(button.getAttribute('aria-busy')).toBe('true');
-    expect(spinner?.classList.contains('animate-spin')).toBe(true);
+    expect(spinner?.classList.contains('animate-spinner')).toBe(true);
+    expect(spinner?.classList.contains('animate-spin')).toBe(false);
     expect(spinner?.classList.contains('motion-reduce:hidden')).toBe(true);
     expect(button.querySelector('.lucide-rotate-cw')).toBeTruthy();
     expect(
@@ -144,11 +146,20 @@ describe('BrowserChrome', () => {
 
     const button = screen.getByRole('button', { name: 'rightSidebar.browser.reload' });
     expect(button.hasAttribute('aria-busy')).toBe(false);
-    expect(button.querySelector('span')?.classList.contains('animate-spin')).toBe(false);
+    expect(button.querySelector('span')?.classList.contains('animate-spinner')).toBe(false);
 
     fireEvent.click(button);
     expect(onReload).toHaveBeenCalledOnce();
     expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('routes the refresh spinner timing through the approved motion tier', () => {
+    const animation = (
+      tailwindConfig.theme?.extend?.animation as Record<string, string> | undefined
+    )?.spinner;
+
+    expect(animation).toContain('var(--motion-enter, 250ms)');
+    expect(animation).not.toContain('spin 1s');
   });
 
   it('fires open-in-system-browser and copy-link from the more menu when the link is valid', () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
@@ -153,12 +153,13 @@ describe('BrowserChrome', () => {
     expect(onStop).not.toHaveBeenCalled();
   });
 
-  it('routes the refresh spinner timing through the approved motion tier', () => {
+  it('routes the refresh spinner through the approved semantic cycle token', () => {
     const animation = (
       tailwindConfig.theme?.extend?.animation as Record<string, string> | undefined
     )?.spinner;
 
-    expect(animation).toContain('var(--motion-enter, 250ms)');
+    expect(animation).toContain('var(--motion-spinner-cycle, 1000ms)');
+    expect(animation).not.toContain('--motion-enter');
     expect(animation).not.toContain('spin 1s');
   });
 

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
@@ -70,6 +70,11 @@ function renderBrowserTab(
   stateUrl: string,
   patchState = vi.fn(),
   active = true,
+  statePatch: Partial<{
+    title: string;
+    favicon: string | null;
+    isAudible: boolean;
+  }> = {},
 ): ReactElement {
   const ctx: TabKindHostContext = {
     tabId: 'tab-browser',
@@ -88,6 +93,7 @@ function renderBrowserTab(
       title: '',
       favicon: null,
       isAudible: false,
+      ...statePatch,
     },
   });
 }
@@ -224,6 +230,34 @@ describe('BrowserTabBody navigation', () => {
     view.rerender(renderBrowserTab('https://www.google.com/', patchState));
 
     expect(browserNavigate).not.toHaveBeenCalled();
+  });
+
+  it('keeps a persisted favicon while the new webview has not observed one yet', () => {
+    browserState = makeBrowserState({ favicon: null });
+    const patchState = vi.fn();
+
+    render(renderBrowserTab(
+      'https://www.taptap.cn/',
+      patchState,
+      true,
+      { favicon: 'https://www.taptap.cn/favicon.ico' },
+    ));
+
+    expect(patchState).not.toHaveBeenCalledWith({ favicon: null });
+  });
+
+  it('clears a persisted favicon after the webview explicitly reports none', () => {
+    browserState = makeBrowserState({ favicon: '' });
+    const patchState = vi.fn();
+
+    render(renderBrowserTab(
+      'https://www.taptap.cn/',
+      patchState,
+      true,
+      { favicon: 'https://www.taptap.cn/favicon.ico' },
+    ));
+
+    expect(patchState).toHaveBeenCalledWith({ favicon: null });
   });
 
   it('does not run browser shortcuts while an editable target has focus', () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/WebBrowserTabPillIcon.test.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/WebBrowserTabPillIcon.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { WebBrowserTabPillIcon, type WebBrowserState } from '../index';
+
+function browserState(favicon: string | null): WebBrowserState {
+  return {
+    url: 'https://example.com/',
+    title: 'Example',
+    favicon,
+    isAudible: false,
+  };
+}
+
+describe('WebBrowserTabPillIcon', () => {
+  afterEach(cleanup);
+
+  it('renders the observed page favicon', () => {
+    const view = render(
+      <WebBrowserTabPillIcon state={browserState('https://example.com/favicon.ico')} />,
+    );
+
+    const image = view.container.querySelector('img');
+    expect(image?.getAttribute('src')).toBe('https://example.com/favicon.ico');
+    expect(view.container.querySelector('.lucide-globe')).toBeNull();
+  });
+
+  it('falls back to Globe when the favicon cannot load', () => {
+    const view = render(
+      <WebBrowserTabPillIcon state={browserState('https://example.com/missing.ico')} />,
+    );
+
+    fireEvent.error(view.container.querySelector('img')!);
+
+    expect(view.container.querySelector('img')).toBeNull();
+    expect(view.container.querySelector('.lucide-globe')).toBeTruthy();
+  });
+
+  it('retries with a new favicon URL after an earlier URL failed', () => {
+    const view = render(
+      <WebBrowserTabPillIcon state={browserState('https://example.com/missing.ico')} />,
+    );
+    fireEvent.error(view.container.querySelector('img')!);
+
+    view.rerender(
+      <WebBrowserTabPillIcon state={browserState('https://example.com/favicon-v2.ico')} />,
+    );
+
+    expect(view.container.querySelector('img')?.getAttribute('src'))
+      .toBe('https://example.com/favicon-v2.ico');
+    expect(view.container.querySelector('.lucide-globe')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/index.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/index.tsx
@@ -17,6 +17,7 @@
 
 import { Globe, Volume2 } from 'lucide-react';
 import type { TFunction } from 'i18next';
+import { useState } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -67,17 +68,11 @@ function WebBrowserTabPillTitle({
  * tab pill 行为一致 —— 用户能从图标一眼看出哪个 tab 在发声)。
  * favicon onError(404 / 取不到)→ 也走 fallback,不让破图占位。
  */
-function WebBrowserTabPillIcon({ state }: { state: WebBrowserState }) {
+export function WebBrowserTabPillIcon({ state }: { state: WebBrowserState }) {
   const base = state.favicon ? (
-    <img
+    <FaviconImage
+      key={state.favicon}
       src={state.favicon}
-      alt=""
-      width={13}
-      height={13}
-      onError={(e) => {
-        (e.currentTarget as HTMLImageElement).style.visibility = 'hidden';
-      }}
-      style={{ objectFit: 'contain' }}
     />
   ) : (
     <Globe size={13} />
@@ -95,6 +90,27 @@ function WebBrowserTabPillIcon({ state }: { state: WebBrowserState }) {
         aria-label="audible"
       />
     </span>
+  );
+}
+
+/**
+ * favicon URL 可能来自独立 webview partition、临时 blob 或需要登录态的资源。
+ * host renderer 加载失败时保留稳定的 Globe fallback；src 变化通过 key 重建本组件，
+ * 让新站点图标拥有独立的错误状态。
+ */
+function FaviconImage({ src }: { src: string }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return <Globe size={13} />;
+  return (
+    <img
+      src={src}
+      alt=""
+      width={13}
+      height={13}
+      draggable={false}
+      onError={() => setFailed(true)}
+      style={{ objectFit: 'contain' }}
+    />
   );
 }
 

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -47,13 +47,14 @@
     --text-28: 28px;
 
     /* Motion token(全局动效档位,规范见 DESIGN.md §14.4):新增过渡/动画一律
-       引用这些 token,不要再各处硬编码时长和 cubic-bezier。5 档时长 + 3 条
-       曲线,与三档圆角同一哲学——档位之外的值先过设计评审再加。 */
+       引用这些 token,不要再各处硬编码时长和 cubic-bezier。5 档交互时长 +
+       spinner 语义循环例外 + 3 条曲线,与三档圆角同一哲学。 */
     --motion-instant: 80ms; /* hover 即时反馈、轻浮层退场 */
     --motion-fast: 150ms; /* 颜色/透明度状态切换、轻浮层入场(§14.4 功能性过渡上限) */
     --motion-base: 200ms; /* 尺寸变化:展开折叠、面板收展 */
     --motion-enter: 250ms; /* 重浮层(弹窗)入场 */
     --motion-exit: 150ms; /* 重浮层(弹窗)退场 */
+    --motion-spinner-cycle: 1000ms; /* 功能性 loading spinner 完整一圈(§14.4 窄例外) */
     --motion-ease-out: cubic-bezier(0.16, 1, 0.3, 1); /* 入场/展开 */
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1); /* 退场 */
     --motion-ease-move: cubic-bezier(0.4, 0, 0.2, 1); /* 位置/尺寸插值 */
@@ -137,6 +138,7 @@
       --motion-base: 0ms;
       --motion-enter: 0ms;
       --motion-exit: 0ms;
+      --motion-spinner-cycle: 0ms;
     }
 
     [class*='animate-spinner'] {

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -139,6 +139,10 @@
       --motion-exit: 0ms;
     }
 
+    [class*='animate-spinner'] {
+      animation: none !important;
+    }
+
     .animate-confirm-overlay-in,
     .animate-confirm-overlay-out,
     .animate-confirm-content-in,
@@ -944,6 +948,7 @@ body.resizing-pane [data-ghost-webview] {
 [data-app-hidden='true'] .agent-island-mascot-key,
 [data-app-hidden='true'] .agent-island-mascot-eyes,
 [data-app-hidden='true'] .agent-island-mascot-sparkle,
+[data-app-hidden='true'] [class*='animate-spinner'],
 [data-app-hidden='true'] [class*='animate-spin'],
 [data-app-hidden='true'] [class*='animate-pulse'],
 [data-app-hidden='true'] [class*='infinite'],

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -121,11 +121,10 @@ const config: Config = {
         },
       },
       animation: {
-        // 持续 spinner 的一圈时长由既有 enter 档派生(4 × 250ms),不再使用
-        // Tailwind animate-spin 内置的硬编码 1s。重复相加保持标准 calc() 兼容性,
-        // 同时让全局 motion token 调整能同步影响 spinner 节奏。
+        // 功能性 loading spinner 使用 DESIGN.md §14.4 明确登记的语义循环 token；
+        // 不复用 Tailwind animate-spin 的硬编码 1s,也不耦合 enter/exit 交互档位。
         spinner:
-          'spin calc(var(--motion-enter, 250ms) + var(--motion-enter, 250ms) + var(--motion-enter, 250ms) + var(--motion-enter, 250ms)) linear infinite',
+          'spin var(--motion-spinner-cycle, 1000ms) linear infinite',
         // float-out 需要 forwards:Radix 等 animationend 才卸载,fill 不驻留
         // 会在动画结束到卸载之间闪回原状。
         'float-in':

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -121,6 +121,11 @@ const config: Config = {
         },
       },
       animation: {
+        // 持续 spinner 的一圈时长由既有 enter 档派生(4 × 250ms),不再使用
+        // Tailwind animate-spin 内置的硬编码 1s。重复相加保持标准 calc() 兼容性,
+        // 同时让全局 motion token 调整能同步影响 spinner 节奏。
+        spinner:
+          'spin calc(var(--motion-enter, 250ms) + var(--motion-enter, 250ms) + var(--motion-enter, 250ms) + var(--motion-enter, 250ms)) linear infinite',
         // float-out 需要 forwards:Radix 等 animationend 才卸载,fill 不驻留
         // 会在动画结束到卸载之间闪回原状。
         'float-in':

--- a/apps/mobile/src/__tests__/themeTokens.test.ts
+++ b/apps/mobile/src/__tests__/themeTokens.test.ts
@@ -5,6 +5,7 @@ import {
   iconSize,
   lightColors,
   lineHeight,
+  motionDuration,
   palettes,
   textStyles,
   typeScale,
@@ -41,6 +42,10 @@ describe('theme tokens', () => {
   it('palettes 指向同一份 light / dark 对象', () => {
     expect(palettes.light).toBe(lightColors);
     expect(palettes.dark).toBe(darkColors);
+  });
+
+  it('spinner 语义循环例外与 DESIGN.md §14.4 保持一致', () => {
+    expect(motionDuration.spinnerCycle).toBe(1000);
   });
 
   it('每个颜色 token 都是非空字符串(login 登录皮嵌套组下钻)', () => {

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -652,6 +652,7 @@ export const loginSizes = {
 /**
  * Motion token(全局动效档位,ms)——与桌面端 DESIGN.md §14.4 的 --motion-* 同名
  * 同值,双端同构。新增动效一律引用这些档位,不要在组件里硬编码时长。
+ * spinnerCycle 是功能性 loading spinner 的语义循环例外,不是第六档交互时长。
  */
 export const motionDuration = {
   /** hover / 即时反馈、轻浮层退场 */
@@ -664,6 +665,8 @@ export const motionDuration = {
   enter: 250,
   /** 重浮层(弹窗 / sheet)退场 */
   exit: 150,
+  /** 功能性 loading spinner 完整一圈(§14.4 窄例外) */
+  spinnerCycle: 1000,
 } as const;
 
 /**

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -547,7 +547,7 @@ Applies to submit-on-Enter fields: the chat composer, goal input, ask input, etc
 
 #### Motion tokens (the only tier source)
 
-Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`; mobile (`apps/mobile`) mirrors same-name same-value constants in `src/theme/tokens.ts` (dual-platform isomorphism, same policy as color tokens, landing with the mobile motion overhaul). **New transitions/animations must reference tokens — no hardcoded durations or cubic-beziers**; 5 duration tiers + 3 curves, the same philosophy as the §5 three-tier radius. Values outside the tiers require design review first.
+Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`; mobile (`apps/mobile`) mirrors same-name same-value constants in `src/theme/tokens.ts` (dual-platform isomorphism, same policy as color tokens, landing with the mobile motion overhaul). **New transitions/animations must reference tokens — no hardcoded durations or cubic-beziers**; 5 interaction-duration tiers + 3 curves, the same philosophy as the §5 three-tier radius. Values outside the tiers require design review first. The single semantic loop-cycle exception is recorded directly below.
 
 | Token | Value | Use |
 |---|---|---|
@@ -560,6 +560,14 @@ Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`;
 | `--motion-ease-in` | `cubic-bezier(0.4, 0, 1, 1)` | Exit |
 | `--motion-ease-move` | `cubic-bezier(0.4, 0, 0.2, 1)` | Position/size interpolation |
 
+**Semantic loop-cycle exception:** `--motion-spinner-cycle` = `1000ms` is the
+full-turn duration for functional loading spinners. It is not a sixth interaction
+tier and must not be used for enter/exit, hover, resize, or decorative motion.
+Spinner rotation remains linear, transform-only, mounted on an HTML wrapper, and
+must become static under reduced motion. This exception keeps loading rotation
+readable without coupling it to dialog timing or copying a hardcoded Tailwind
+default into components.
+
 #### Semantics → motion prototypes (one semantic, one motion, app-wide)
 
 | Semantic | Spec | Reference implementation |
@@ -571,6 +579,7 @@ Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`;
 | Press | `active:scale-[0.98]` (all interactive pills/buttons) | ConfirmDialog buttons |
 | Done | **the app's only sanctioned overshoot** (`status-done-pop`) | `globals.css` |
 | Running | Opacity breathing; must sit on an HTML wrapper (`docs/dev-rules/engineering-conventions.md` §7) | `session-breathing` |
+| Loading spinner | `animate-spinner` (`--motion-spinner-cycle`, linear full turn); HTML wrapper only, static under reduced motion | `tailwind.config.ts` |
 | Hover / state colors | `transition-colors`, ≤ fast (150ms) | App-wide status quo |
 | Container transform (chip grows into panel) | 220ms — see the dedicated category below (explicit exception) | Composer permission/model selectors |
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Cindy Desktop 内置浏览器中两处用户可见的反馈缺失：点击刷新后立即展示旋转加载状态，并在加载期间允许点击停止；网页 Tab 能持续展示页面 favicon，图片不可用时稳定回退到 Globe，而不是留下空白图标。

根因有两部分：

1. 刷新按钮只依赖 Electron 异步发送的 `did-start-loading`，`reload()` 到事件到达之间 UI 没有任何状态变化；刷新图标也没有加载动画。
2. favicon 状态此前只有字符串一种语义，WebView 重建时的“尚未观测”与页面明确“无 favicon”都被折叠为空串，导致持久化 favicon 被过早清空；`img` 加载失败又通过 `visibility: hidden` 隐藏自身，默认 Globe 无法接管显示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Desktop 内置浏览器刷新反馈与 Tab favicon 缺失
- 本 PR 包含：刷新即时 loading/stop 状态、reduced-motion 静态停止图标、favicon 三态同步、跨页导航清理、图片失败 fallback，以及相应单元测试
- 明确不包含：浏览器进程、网络栈、缓存策略、OAuth popup 或 session 归属逻辑
- 用户可见变化：刷新后图标立即旋转；加载中按钮可停止；Tab 显示网页 favicon，加载失败时显示 Globe
- 是否存在 breaking change：无

### UI 变化

- Desktop macOS / Windows 共用 Renderer 路径；未新增颜色或硬编码样式，沿用现有 sidebar token
- 正常 motion 下仅在 HTML wrapper 使用 compositor-friendly `animate-spinner`；完整一圈消费 §14.4 明确登记的 `--motion-spinner-cycle` 语义例外；`prefers-reduced-motion` 下不旋转，改为静态 X 图标，并保留 `aria-busy`
- 引用的设计规范：`docs/design-rules/DESIGN.md` 的 Light/Dark token 约束及 §14.4 动效规范；本 PR 记录 `--motion-spinner-cycle=1000ms` 为仅限功能性 loading spinner 的语义循环例外，禁止用于 enter/exit、hover、resize 或装饰动画

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run 
  src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts 
  src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts 
  src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts 
  src/renderer/features/right-sidebar/plugins/web-browser/__tests__/WebBrowserTabPillIcon.test.tsx
结果：4 files passed，46 tests passed

pnpm --filter desktop run --if-present typecheck
pnpm --filter mobile run --if-present typecheck
结果：均通过

pnpm --filter mobile exec vitest run src/__tests__/themeTokens.test.ts
结果：1 file passed，14 tests passed

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/hiddenAnimationGate.test.ts \
  src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
结果：2 files passed，31 tests passed

pnpm exec tailwindcss -c tailwind.config.ts -i src/renderer/styles/globals.css -o /dev/null
结果：实际编译通过

pnpm test:unit
结果：根目录完整 unit 门禁通过；Desktop、Mobile、共享 packages 与 cindy-protocol 全部通过

git diff --check
结果：通过

改动文件定向 ESLint
结果：通过
```

额外执行 `pnpm --filter desktop lint`：未通过，来自当前 `upstream/main` 的全仓既存欠债，共 101 errors + 1 warning，分布于大量无关文件；本 PR 改动文件的定向 ESLint 已通过。

### 手工验证

未启动独立 Electron 实例。当前工作位于 Cindy Desktop 自身的隔离 worktree，为避免重启或干扰正在使用的宿主应用，本轮以 Renderer 单元测试、状态事件测试、DOM fallback 测试和 typecheck 验证。

### 未执行的验证

- 未做 macOS / Windows 打包产物实机回归；两端共用本次修改的 Renderer 路径。
- 未附运行时截图；刷新旋转、reduced-motion 与 favicon fallback 均有 DOM/交互测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：WebView 事件时序与 favicon 资源加载失败

### 影响与回滚

- 影响范围：运行时变化仅限 Desktop 右侧内置浏览器 Renderer UI 与 WebView 状态同步；Mobile 只同步 `motionDuration.spinnerCycle` 设计 token，当前无组件消费。不修改 preload、IPC 权限、partition 或网络行为。
- 风险控制：favicon 使用 `null` 表示“当前 WebView 代际尚未观测”，空串表示“明确无图标”；stale `did-navigate` 不会误清状态，真实跨页提交会移除旧站图标；reload/stop 异常会回滚 loading 状态。
- 跨平台：macOS 与 Windows 共享相同 React Renderer 实现，无平台条件分支。
- 回滚 / 降级方式：回滚本提交即可恢复原有行为；不涉及数据迁移或持久化结构变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；不需要用户文档变更
- [x] 已确认测试结果或说明未执行原因