### PR TITLE
fix(desktop): 修复文本预览 Tooltip 被遮挡

### DIFF
--- a/apps/desktop/src/renderer/__tests__/textLightbox.test.ts
+++ b/apps/desktop/src/renderer/__tests__/textLightbox.test.ts
@@ -90,6 +90,19 @@ describe('TextLightbox — F3 overlay style', () => {
   it('overlay is rendered via createPortal to document.body', () => {
     expect(source).toMatch(/createPortal\(overlay,\s*document\.body\)/);
   });
+
+  it('keeps every toolbar tooltip above the lightbox overlay', () => {
+    expect(source).toMatch(/TEXT_LIGHTBOX_OVERLAY_Z_INDEX\s*=\s*9999/);
+    expect(source).toMatch(
+      /TEXT_LIGHTBOX_TOOLTIP_STYLE\s*=\s*\{[\s\S]*zIndex:\s*TEXT_LIGHTBOX_OVERLAY_Z_INDEX\s*\+\s*1/,
+    );
+
+    const tooltipContents = source.match(/<Tooltip\.Content\b/g) ?? [];
+    const layeredTooltipContents =
+      source.match(/<Tooltip\.Content\s+style=\{TEXT_LIGHTBOX_TOOLTIP_STYLE\}/g) ?? [];
+    expect(tooltipContents.length).toBeGreaterThan(0);
+    expect(layeredTooltipContents).toHaveLength(tooltipContents.length);
+  });
 });
 
 // ── F4: toolbar wiring ──────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/__tests__/toastZIndex.test.ts
+++ b/apps/desktop/src/renderer/__tests__/toastZIndex.test.ts
@@ -42,7 +42,7 @@ describe('Toast z-index — sits above all overlays (symptom #1)', () => {
     // The lightbox sits at 9999; the toast sits at 10000. The strict ordering
     // is what guarantees the Toast wins even when the Lightbox Portal mounts
     // later in document.body.
-    expect(textLightboxSource).toMatch(/zIndex:\s*9999/);
+    expect(textLightboxSource).toMatch(/TEXT_LIGHTBOX_OVERLAY_Z_INDEX\s*=\s*9999/);
   });
 
   it('ImageLightbox overlay still uses zIndex 9999 (below toast layer)', () => {

--- a/apps/desktop/src/renderer/__tests__/toastZIndex.test.ts
+++ b/apps/desktop/src/renderer/__tests__/toastZIndex.test.ts
@@ -7,7 +7,7 @@
  * application uses 9999 as the "max" stacking layer for overlays (TextLightbox,
  * ImageLightbox, SplashScreen). To guarantee the Toast wins the z-index race
  * even when Modals + Lightboxes are stacked in document.body via Portals,
- * ToastContainer is bumped one step higher to 10000.
+ * ToastContainer is above the z-[10000] Radix Dialog layer at 10100.
  *
  * Static-source scanning (matches the project convention used by
  * textLightbox.test.ts and imageLightboxCloseAnywhere.test.ts).
@@ -33,13 +33,14 @@ const imageLightboxSource = readFileSync(
 );
 
 describe('Toast z-index — sits above all overlays (symptom #1)', () => {
-  it('ToastContainer uses z-[10000] (one step above 9999 lightbox layer)', () => {
-    expect(toastContainerSource).toMatch(/z-\[10000\]/);
-    expect(toastContainerSource).not.toMatch(/z-\[9999\]/);
+  it('ToastContainer class uses z-[10100] (above lightboxes and Radix dialogs)', () => {
+    expect(toastContainerSource).toMatch(
+      /className="[^"]*\bz-\[10100\][^"]*"/,
+    );
   });
 
   it('TextLightbox overlay still uses zIndex 9999 (below toast layer)', () => {
-    // The lightbox sits at 9999; the toast sits at 10000. The strict ordering
+    // The lightbox sits at 9999; the toast sits at 10100. The strict ordering
     // is what guarantees the Toast wins even when the Lightbox Portal mounts
     // later in document.body.
     expect(textLightboxSource).toMatch(/TEXT_LIGHTBOX_OVERLAY_Z_INDEX\s*=\s*9999/);

--- a/apps/desktop/src/renderer/components/chat/TextLightbox.tsx
+++ b/apps/desktop/src/renderer/components/chat/TextLightbox.tsx
@@ -54,6 +54,10 @@ interface TextLightboxProps {
 // IPC response also carries `limitMb` so dynamic copy stays single-sourced.
 const OVERSIZE_LIMIT_MB = 10;
 const OVERSIZE_LIMIT = OVERSIZE_LIMIT_MB * 1024 * 1024;
+const TEXT_LIGHTBOX_OVERLAY_Z_INDEX = 9999;
+const TEXT_LIGHTBOX_TOOLTIP_STYLE = {
+  zIndex: TEXT_LIGHTBOX_OVERLAY_Z_INDEX + 1,
+} as const;
 
 /**
  * Format a byte count for display in the toolbar (`3.4 MB`, `812 KB`, `73 B`).
@@ -373,7 +377,7 @@ export function TextLightbox({ filePath, fileName, initialLine, triggerRef, onCl
       style={{
         position: 'fixed',
         inset: 0,
-        zIndex: 9999,
+        zIndex: TEXT_LIGHTBOX_OVERLAY_Z_INDEX,
         background: 'var(--overlay-lightbox)',
         display: 'flex',
         flexDirection: 'column',
@@ -467,7 +471,9 @@ export function TextLightbox({ filePath, fileName, initialLine, triggerRef, onCl
                 )}
               </button>
             </Tooltip.Trigger>
-            <Tooltip.Content>{t('chat.lightbox.clickToCopyPath')}</Tooltip.Content>
+            <Tooltip.Content style={TEXT_LIGHTBOX_TOOLTIP_STYLE}>
+              {t('chat.lightbox.clickToCopyPath')}
+            </Tooltip.Content>
           </Tooltip.Root>
 
           {/* Right — Show in folder + Copy content + Close (Open in System moved to Oversize CTA only). */}
@@ -490,7 +496,7 @@ export function TextLightbox({ filePath, fileName, initialLine, triggerRef, onCl
                   <Folder size={18} className="text-[var(--msg-tool-card-chevron)]" />
                 </button>
               </Tooltip.Trigger>
-              <Tooltip.Content>
+              <Tooltip.Content style={TEXT_LIGHTBOX_TOOLTIP_STYLE}>
                 {remoteOrigin ? t('chat.remoteFile.revealLocalCopy') : t('chat.lightbox.openInExplorer')}
               </Tooltip.Content>
             </Tooltip.Root>
@@ -511,7 +517,9 @@ export function TextLightbox({ filePath, fileName, initialLine, triggerRef, onCl
                   <Copy size={18} className="text-[var(--msg-tool-card-chevron)]" />
                 </button>
               </Tooltip.Trigger>
-              <Tooltip.Content>{t('chat.textLightbox.copyAll')}</Tooltip.Content>
+              <Tooltip.Content style={TEXT_LIGHTBOX_TOOLTIP_STYLE}>
+                {t('chat.textLightbox.copyAll')}
+              </Tooltip.Content>
             </Tooltip.Root>
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
@@ -527,7 +535,9 @@ export function TextLightbox({ filePath, fileName, initialLine, triggerRef, onCl
                   <X size={20} className="text-[var(--msg-tool-card-chevron)]" />
                 </button>
               </Tooltip.Trigger>
-              <Tooltip.Content>{t('chat.lightbox.close')}</Tooltip.Content>
+              <Tooltip.Content style={TEXT_LIGHTBOX_TOOLTIP_STYLE}>
+                {t('chat.lightbox.close')}
+              </Tooltip.Content>
             </Tooltip.Root>
           </div>
         </div>


### PR DESCRIPTION
## 这次改了什么

### 摘要

文本文件预览层与 Tooltip 都通过 Portal 挂载到 document.body，但预览遮罩位于 z-index 9999，而通用 Tooltip 默认只有 z-index 60，导致工具栏提示被遮罩覆盖。

本 PR 将 TextLightbox 的遮罩层级提取为局部常量，并让该预览层内的全部 Tooltip 始终位于遮罩上一层。全局 Tooltip 默认层级保持不变，避免影响其他页面和弹层。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #955
- 本 PR 包含：TextLightbox 工具栏 Tooltip 层级修复；TextLightbox 与 Toast 层级契约测试
- 明确不包含：全局 Tooltip 层级调整；其他 Lightbox 行为修改
- 用户可见变化：文本预览层内的文件名、在文件管理器中打开、复制全文和关闭提示可完整显示
- 是否存在 breaking change：无

### UI 变化

- 修复前：Tooltip 会被文本预览遮罩覆盖，仅露出部分文字或完全不可读。
- 修复后：Tooltip 显示在文本预览层上方。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4 Light overlay，保留现有 Tooltip 动效、主题 token 和视觉样式；本次仅修正弹层堆叠顺序。Light / Dark 共用现有语义 token，未新增颜色或单模式分支。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/textLightbox.test.ts src/renderer/__tests__/toastZIndex.test.ts --reporter=dot
结果：2 files / 41 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过（Desktop 1316 test files；其余 unit workspaces 全部通过）

pnpm check:dco
结果：通过
```

### 手工验证

- macOS：已按 Issue 路径复现修复前问题，文本预览层右上角 Tooltip 被遮罩覆盖。
- 修复后等待 PR 构建或本地运行实例进一步目检。

### 未执行的验证

- Windows 11 实机未验证；本次为 DOM Portal z-index 层级修复，逻辑不含平台分支。
- 修复后的 Light / Dark 双模式实机目检未执行。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 TextLightbox 内四处 Tooltip 的堆叠层级。
- 回滚 / 降级方式：回退本提交即可；不会影响文件读取、复制或系统打开功能。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因
