### PR TITLE
feat(desktop): 会话搜索记住上次排序，排序并入筛选菜单

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/ConversationSearchBox.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/ConversationSearchBox.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  ArrowDownUp,
   Check,
   ChevronDown,
   Globe,
@@ -29,6 +28,7 @@ import {
 import { cn } from '@/lib/utils';
 import { searchConversations } from '@/lib/conversationSearchService';
 import { formatSidebarTime } from '../lib/formatSidebarTime';
+import { loadSearchSortBy, persistSearchSortBy } from './conversationSearchPrefs';
 import type {
   ConversationSearchAgentFilter,
   ConversationSearchLastActivityFilter,
@@ -57,6 +57,11 @@ type Option<T extends string> = {
   labelKey: string;
 };
 
+/**
+ * 排序三选项。与其它筛选选项同款:纯文字 + 选中勾,不配图标——它们只出现在筛选菜单的
+ * 「排序」子菜单里(见 SearchFilterMenu),当前值已常显在父行右侧,图标不再承担区分职责。
+ * (曾试过靶心/时钟系与箭头排序族图标,前者读不出排序,后者在收进子菜单后成了冗余。)
+ */
 const SORT_OPTIONS: ReadonlyArray<Option<ConversationSearchSortBy>> = [
   { value: 'relevance', labelKey: 'ccAgent.search.sort.relevance' },
   { value: 'activityDesc', labelKey: 'ccAgent.search.sort.activityDesc' },
@@ -125,6 +130,7 @@ export interface UseConversationSearchParams {
  * useConversationSearch —— 会话搜索状态机(query / 排序 / 筛选 / 项目锁定 / 两段防抖搜索)。
  * 从 ConversationSearchBox 抽出,供 popover 形态(rail 图标)与内联形态(展开侧栏首行)复用,
  * 保证两处搜索行为、防抖节奏、结果口径完全一致(不复制逻辑、不引入行为漂移)。
+ * 排序选择跨会话记住(localStorage,见 conversationSearchPrefs);其余筛选每次回到默认。
  */
 export function useConversationSearch({
   enabled,
@@ -135,7 +141,8 @@ export function useConversationSearch({
   onResultChosen,
 }: UseConversationSearchParams) {
   const [query, setQuery] = useState('');
-  const [sortBy, setSortBy] = useState<ConversationSearchSortBy>('relevance');
+  // 排序读上次选择(localStorage),其余筛选每次回到默认——见 conversationSearchPrefs 的取舍说明。
+  const [sortBy, setSortByState] = useState<ConversationSearchSortBy>(() => loadSearchSortBy());
   const [statusFilter, setStatusFilter] = useState<ConversationSearchStatusFilter>('all');
   const [agentFilter, setAgentFilter] = useState<ConversationSearchAgentFilter>('all');
   const [lastActivityFilter, setLastActivityFilter] =
@@ -263,6 +270,12 @@ export function useConversationSearch({
     statusFilter,
     trimmed,
   ]);
+
+  /** 切换排序并记住选择:下次打开搜索 / 重启客户端沿用同一排序。 */
+  const setSortBy = useCallback((next: ConversationSearchSortBy) => {
+    setSortByState(next);
+    persistSearchSortBy(next);
+  }, []);
 
   /** 清空 query / 结果 / 状态(popover 关闭时调用)。项目锁定保留。 */
   const reset = useCallback(() => {
@@ -527,12 +540,12 @@ export function ConversationSearchBox({
             )}
           </div>
           <div className="mt-2 flex items-center gap-2">
-            <SearchSortMenu sortBy={search.sortBy} onChange={search.setSortBy} />
             <SearchFilterMenu
               status={search.statusFilter}
               agentKind={search.agentFilter}
               lastActivity={search.lastActivityFilter}
               projects={search.projectSelection}
+              sortBy={search.sortBy}
               allKnownProjects={allKnownProjects}
               activeCount={search.activeFilterCount}
               lockedProjectKey={search.lockedProjectKey}
@@ -541,6 +554,7 @@ export function ConversationSearchBox({
               onAgentKindChange={search.setAgentFilter}
               onLastActivityChange={search.setLastActivityFilter}
               onProjectsChange={search.setProjectSelection}
+              onSortChange={search.setSortBy}
               onReset={search.resetFilters}
             />
           </div>
@@ -557,58 +571,19 @@ export function ConversationSearchBox({
   );
 }
 
-export function SearchSortMenu({
-  sortBy,
-  onChange,
-  compact,
-  onOpenChange,
-}: {
-  sortBy: ConversationSearchSortBy;
-  onChange: (value: ConversationSearchSortBy) => void;
-  /** 内嵌在搜索框内的紧凑形态:纯图标钮,无边框 / 标签(见 SidebarInlineSearch)。 */
-  compact?: boolean;
-  /** 下拉开合上报(内联搜索框据此在菜单打开时保持展开态,不因鼠标移到菜单而收起)。 */
-  onOpenChange?: (open: boolean) => void;
-}) {
-  const { t } = useTranslation();
-  const label = optionLabel(SORT_OPTIONS, sortBy, t);
-
-  return (
-    <DropdownMenu onOpenChange={onOpenChange}>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label={t('ccAgent.search.sortAria', { sort: label })}
-          className={compact ? SEARCH_TOOL_ICON_CLASS : SEARCH_TOOL_BUTTON_CLASS}
-        >
-          <ArrowDownUp size={compact ? 14 : 13} className="shrink-0" />
-          {!compact && (
-            <>
-              <span className="truncate">{label}</span>
-              <ChevronDown size={13} className="shrink-0 text-[var(--cmd-palette-item-meta)]" />
-            </>
-          )}
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent side="bottom" align="start" sideOffset={6} className={MENU_CONTENT_CLASS}>
-        {SORT_OPTIONS.map((option) => (
-          <SelectMenuItem
-            key={option.value}
-            label={t(option.labelKey)}
-            selected={sortBy === option.value}
-            onSelect={() => onChange(option.value)}
-          />
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
+/**
+ * SearchFilterMenu —— 搜索框旁**唯一**的选项钮:排序 + 各项筛选都收在这一个菜单里。
+ * 排序曾是搜索框内并排的第二颗钮,已收进本菜单首行子菜单(2026-07 用户拍板):
+ * 搜索框里只留一颗钮更干净,排序也不必在收起态用图标自证身份。
+ * 排序**不计入** activeCount(它不收窄结果集,不该点亮「有筛选」红点);当前排序值
+ * 常显在首行右侧,不用展开子菜单就能看到——这也是排序选项不需要图标的原因。
+ */
 export function SearchFilterMenu({
   status,
   agentKind,
   lastActivity,
   projects,
+  sortBy,
   allKnownProjects,
   activeCount,
   lockedProjectKey,
@@ -617,6 +592,7 @@ export function SearchFilterMenu({
   onAgentKindChange,
   onLastActivityChange,
   onProjectsChange,
+  onSortChange,
   onReset,
   compact,
   onOpenChange,
@@ -625,6 +601,7 @@ export function SearchFilterMenu({
   agentKind: ConversationSearchAgentFilter;
   lastActivity: ConversationSearchLastActivityFilter;
   projects: ProjectSelection;
+  sortBy: ConversationSearchSortBy;
   allKnownProjects: ProjectNodeData[];
   activeCount: number;
   lockedProjectKey: string | null;
@@ -633,6 +610,7 @@ export function SearchFilterMenu({
   onAgentKindChange: (value: ConversationSearchAgentFilter) => void;
   onLastActivityChange: (value: ConversationSearchLastActivityFilter) => void;
   onProjectsChange: (value: ProjectSelection) => void;
+  onSortChange: (value: ConversationSearchSortBy) => void;
   onReset: () => void;
   /** 内嵌在搜索框内的紧凑形态:纯图标钮,无边框 / 标签,激活时右上角红点。 */
   compact?: boolean;
@@ -643,6 +621,7 @@ export function SearchFilterMenu({
   const statusValue = optionLabel(STATUS_OPTIONS, status, t);
   const agentValue = optionLabel(AGENT_OPTIONS, agentKind, t);
   const lastActivityValue = optionLabel(LAST_ACTIVITY_OPTIONS, lastActivity, t);
+  const sortValue = optionLabel(SORT_OPTIONS, sortBy, t);
   const lockedProject = lockedProjectKey
     ? allKnownProjects.find((project) => project.projectKey === lockedProjectKey) ?? null
     : null;
@@ -663,12 +642,13 @@ export function SearchFilterMenu({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          aria-label={t('ccAgent.search.filterAria', {
+          // 排序也收在本菜单里,故一并读出当前排序(两段都是既有文案,不新增 key)。
+          aria-label={`${t('ccAgent.search.filterAria', {
             status: statusValue,
             agent: agentValue,
             lastActivity: lastActivityValue,
             projects: projectValue,
-          })}
+          })} · ${t('ccAgent.search.sortAria', { sort: sortValue })}`}
           aria-pressed={activeCount > 0}
           className={
             compact
@@ -719,6 +699,18 @@ export function SearchFilterMenu({
             </button>
           )}
         </div>
+
+        {/* 排序放首行:先定「怎么排」,再谈「留哪些」;它总有值,也不参与 activeCount。 */}
+        <MenuSubRow label={t('ccAgent.sidebar.filterSortByHeading')} value={sortValue}>
+          {SORT_OPTIONS.map((option) => (
+            <SelectMenuItem
+              key={option.value}
+              label={t(option.labelKey)}
+              selected={sortBy === option.value}
+              onSelect={() => onSortChange(option.value)}
+            />
+          ))}
+        </MenuSubRow>
 
         <MenuSubRow label={t('ccAgent.sidebar.filterStatusHeading')} value={statusValue}>
           {STATUS_OPTIONS.map((option) => (

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/ConversationSearchBox.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/ConversationSearchBox.tsx
@@ -1,4 +1,12 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import {
   Check,
   ChevronDown,
@@ -28,7 +36,11 @@ import {
 import { cn } from '@/lib/utils';
 import { searchConversations } from '@/lib/conversationSearchService';
 import { formatSidebarTime } from '../lib/formatSidebarTime';
-import { loadSearchSortBy, persistSearchSortBy } from './conversationSearchPrefs';
+import {
+  getSearchSortBy,
+  setSearchSortBy,
+  subscribeSearchSortBy,
+} from './conversationSearchPrefs';
 import type {
   ConversationSearchAgentFilter,
   ConversationSearchLastActivityFilter,
@@ -141,8 +153,9 @@ export function useConversationSearch({
   onResultChosen,
 }: UseConversationSearchParams) {
   const [query, setQuery] = useState('');
-  // 排序读上次选择(localStorage),其余筛选每次回到默认——见 conversationSearchPrefs 的取舍说明。
-  const [sortBy, setSortByState] = useState<ConversationSearchSortBy>(() => loadSearchSortBy());
+  // 排序订阅共享偏好 store(持久化 + 跨实例同步),其余筛选每次回到默认
+  // ——取舍与「为什么不是各自 useState」见 conversationSearchPrefs 的文件头。
+  const sortBy = useSyncExternalStore(subscribeSearchSortBy, getSearchSortBy);
   const [statusFilter, setStatusFilter] = useState<ConversationSearchStatusFilter>('all');
   const [agentFilter, setAgentFilter] = useState<ConversationSearchAgentFilter>('all');
   const [lastActivityFilter, setLastActivityFilter] =
@@ -271,10 +284,12 @@ export function useConversationSearch({
     trimmed,
   ]);
 
-  /** 切换排序并记住选择:下次打开搜索 / 重启客户端沿用同一排序。 */
+  /**
+   * 切换排序:写共享 store —— 立刻同步到所有挂载中的搜索实例(rail / 内联),
+   * 并落 localStorage,下次打开搜索 / 重启客户端沿用同一排序。
+   */
   const setSortBy = useCallback((next: ConversationSearchSortBy) => {
-    setSortByState(next);
-    persistSearchSortBy(next);
+    setSearchSortBy(next);
   }, []);
 
   /** 清空 query / 结果 / 状态(popover 关闭时调用)。项目锁定保留。 */
@@ -642,13 +657,15 @@ export function SearchFilterMenu({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          // 排序也收在本菜单里,故一并读出当前排序(两段都是既有文案,不新增 key)。
-          aria-label={`${t('ccAgent.search.filterAria', {
+          // 排序也收在本菜单里,故 filterAria 文案本身多了 {{sort}} 段:整句由各语言自己
+          // 决定语序与标点,不在代码里拼接多段译文(PR #963 review)。
+          aria-label={t('ccAgent.search.filterAria', {
+            sort: sortValue,
             status: statusValue,
             agent: agentValue,
             lastActivity: lastActivityValue,
             projects: projectValue,
-          })} · ${t('ccAgent.search.sortAria', { sort: sortValue })}`}
+          })}
           aria-pressed={activeCount > 0}
           className={
             compact

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarInlineSearch.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarInlineSearch.tsx
@@ -21,7 +21,6 @@ import { Tip } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import {
   SearchFilterMenu,
-  SearchSortMenu,
   type useConversationSearch,
 } from './ConversationSearchBox';
 import type { ProjectNode as ProjectNodeData } from '../lib/projectGrouping';
@@ -188,19 +187,15 @@ export function SidebarInlineSearch({
               </button>
             </Tip>
           )}
-          {/* 选项钮:排序 + 筛选,紧凑纯图标形态,与搜索框合为一体(无分隔线、无文字提示)。
+          {/* 选项钮:只一颗——排序与各项筛选都收在这个菜单里(排序是它的首行子菜单)。
+               紧凑纯图标形态,与搜索框合为一体(无分隔线、无文字提示)。
                菜单开合上报 → 打开期间保持展开,不因鼠标移到菜单而收起。 */}
-          <SearchSortMenu
-            sortBy={search.sortBy}
-            onChange={search.setSortBy}
-            onOpenChange={setMenuOpen}
-            compact
-          />
           <SearchFilterMenu
             status={search.statusFilter}
             agentKind={search.agentFilter}
             lastActivity={search.lastActivityFilter}
             projects={search.projectSelection}
+            sortBy={search.sortBy}
             allKnownProjects={allKnownProjects}
             activeCount={search.activeFilterCount}
             lockedProjectKey={search.lockedProjectKey}
@@ -209,6 +204,7 @@ export function SidebarInlineSearch({
             onAgentKindChange={search.setAgentFilter}
             onLastActivityChange={search.setLastActivityFilter}
             onProjectsChange={search.setProjectSelection}
+            onSortChange={search.setSortBy}
             onReset={search.resetFilters}
             onOpenChange={setMenuOpen}
             compact

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchPrefs.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchPrefs.test.ts
@@ -1,0 +1,125 @@
+/**
+ * conversationSearchPrefs 单测 —— 会话搜索排序偏好的读写与容错。
+ * ---------------------------------------------------------------------------
+ * vitest 默认跑在 node 环境(apps/desktop/vitest.config.ts),localStorage 用内存 shim 注入,
+ * 策略同 useSidebarFilter.test.ts。覆盖:默认值、往返、非法值回落、storage 缺失、读写抛异常。
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SEARCH_SORT_BY,
+  SEARCH_SORT_BY_KEY,
+  loadSearchSortBy,
+  persistSearchSortBy,
+} from '../conversationSearchPrefs';
+
+function installMemoryLocalStorage(): Map<string, string> {
+  const store = new Map<string, string>();
+  const fakeStorage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? (store.get(key) as string) : null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    key(idx: number) {
+      return Array.from(store.keys())[idx] ?? null;
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).localStorage = fakeStorage;
+  return store;
+}
+
+function uninstallLocalStorage(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (globalThis as any).localStorage;
+}
+
+describe('loadSearchSortBy', () => {
+  beforeEach(() => installMemoryLocalStorage());
+  afterEach(() => uninstallLocalStorage());
+
+  it('defaults to relevance when nothing was persisted', () => {
+    expect(loadSearchSortBy()).toBe('relevance');
+    expect(DEFAULT_SEARCH_SORT_BY).toBe('relevance');
+  });
+
+  it('returns every persisted legal value', () => {
+    localStorage.setItem(SEARCH_SORT_BY_KEY, 'activityDesc');
+    expect(loadSearchSortBy()).toBe('activityDesc');
+    localStorage.setItem(SEARCH_SORT_BY_KEY, 'activityAsc');
+    expect(loadSearchSortBy()).toBe('activityAsc');
+    localStorage.setItem(SEARCH_SORT_BY_KEY, 'relevance');
+    expect(loadSearchSortBy()).toBe('relevance');
+  });
+
+  it('falls back to the default on an illegal value', () => {
+    localStorage.setItem(SEARCH_SORT_BY_KEY, 'bogus');
+    expect(loadSearchSortBy()).toBe('relevance');
+  });
+
+  it('falls back to the default when localStorage is unavailable', () => {
+    uninstallLocalStorage();
+    expect(loadSearchSortBy()).toBe('relevance');
+  });
+
+  it('falls back to the default when getItem throws', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).localStorage = {
+      getItem() {
+        throw new Error('security error');
+      },
+      setItem() {},
+      removeItem() {},
+      clear() {},
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+    expect(loadSearchSortBy()).toBe('relevance');
+  });
+});
+
+describe('persistSearchSortBy', () => {
+  beforeEach(() => installMemoryLocalStorage());
+  afterEach(() => uninstallLocalStorage());
+
+  it('round-trips the chosen sort', () => {
+    persistSearchSortBy('activityDesc');
+    expect(localStorage.getItem(SEARCH_SORT_BY_KEY)).toBe('activityDesc');
+    expect(loadSearchSortBy()).toBe('activityDesc');
+
+    persistSearchSortBy('relevance');
+    expect(loadSearchSortBy()).toBe('relevance');
+  });
+
+  it('is a no-op (does not throw) when localStorage is unavailable', () => {
+    uninstallLocalStorage();
+    expect(() => persistSearchSortBy('activityAsc')).not.toThrow();
+  });
+
+  it('swallows setItem failures (quota / security errors)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem() {
+        throw new Error('quota exceeded');
+      },
+      removeItem() {},
+      clear() {},
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+    expect(() => persistSearchSortBy('activityAsc')).not.toThrow();
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchSort.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchSort.test.tsx
@@ -4,13 +4,18 @@
  * 会话搜索排序 —— 「记住上次选择」+「排序收在筛选菜单里」的行为契约。
  * ---------------------------------------------------------------------------
  * 1. useConversationSearch 的初始排序读 localStorage,切换排序会写回;
- * 2. 搜索框旁只剩筛选一颗钮(排序已收进该菜单,不再单独占位),其 aria 读出当前排序。
+ * 2. rail 与内联两个**常驻挂载**的搜索实例共享同一排序,一处改动另一处即时跟随
+ *    (PR #963 review:原先各自 useState 初始值,改完要等重挂载才生效);
+ * 3. 搜索框旁只剩筛选一颗钮(排序已收进该菜单),其 aria 用单条文案读出筛选与排序。
  */
 
 import { act, cleanup, render, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { SEARCH_SORT_BY_KEY } from '../conversationSearchPrefs';
+import {
+  SEARCH_SORT_BY_KEY,
+  __resetSearchSortByStoreForTests,
+} from '../conversationSearchPrefs';
 import { SearchFilterMenu, useConversationSearch } from '../ConversationSearchBox';
 
 vi.mock('react-i18next', () => ({
@@ -31,6 +36,7 @@ vi.mock('@/lib/orcaSessionIdentity', () => ({
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  __resetSearchSortByStoreForTests();
 });
 
 function renderSearch() {
@@ -63,7 +69,51 @@ describe('useConversationSearch sort persistence', () => {
 
     // 新挂载(重开搜索 / 重启客户端)沿用上次选择。
     cleanup();
+    __resetSearchSortByStoreForTests();
     expect(renderSearch().result.current.sortBy).toBe('activityDesc');
+  });
+
+  it('keeps both mounted search instances (rail + inline) on the same sort', () => {
+    // rail 的 ConversationSearchBox 与展开态 Provider 的内联搜索都常驻挂载
+    // (CCAgentSidebarUpper 只切 opacity / hidden),两个实例必须实时同源。
+    const rail = renderSearch();
+    const inline = renderSearch();
+    expect(rail.result.current.sortBy).toBe('relevance');
+    expect(inline.result.current.sortBy).toBe('relevance');
+
+    act(() => rail.result.current.setSortBy('activityAsc'));
+    expect(rail.result.current.sortBy).toBe('activityAsc');
+    // 关键回归点:另一个已挂载实例不用重挂载就跟上,不会拿旧排序去搜。
+    expect(inline.result.current.sortBy).toBe('activityAsc');
+
+    act(() => inline.result.current.setSortBy('activityDesc'));
+    expect(rail.result.current.sortBy).toBe('activityDesc');
+    expect(inline.result.current.sortBy).toBe('activityDesc');
+  });
+
+  it('follows the sort another window wrote (storage event)', () => {
+    const { result } = renderSearch();
+    expect(result.current.sortBy).toBe('relevance');
+    act(() => {
+      localStorage.setItem(SEARCH_SORT_BY_KEY, 'activityAsc');
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: SEARCH_SORT_BY_KEY, newValue: 'activityAsc' }),
+      );
+    });
+    expect(result.current.sortBy).toBe('activityAsc');
+  });
+
+  it('ignores a storage event that carries an illegal value', () => {
+    localStorage.setItem(SEARCH_SORT_BY_KEY, 'activityDesc');
+    const { result } = renderSearch();
+    expect(result.current.sortBy).toBe('activityDesc');
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: SEARCH_SORT_BY_KEY, newValue: 'bogus' }),
+      );
+    });
+    // 非法值回落默认排序,而不是把 'bogus' 塞进请求。
+    expect(result.current.sortBy).toBe('relevance');
   });
 });
 
@@ -97,10 +147,11 @@ describe('SearchFilterMenu trigger', () => {
     // 搜索框旁只有这一颗钮:排序已收进它的菜单,不再有并排的排序钮。
     expect(buttons.length).toBe(1);
     expect(buttons[0]?.querySelector('.lucide-sliders-horizontal')).not.toBeNull();
-    // 无障碍标签同时读出筛选与当前排序。
+    // 无障碍标签是**单条**文案(整句语序交给各语言),排序作为其中一个插值传入,
+    // 不是代码里拼接的两段译文。
     const aria = buttons[0]?.getAttribute('aria-label') ?? '';
     expect(aria).toContain('ccAgent.search.filterAria');
-    expect(aria).toContain('ccAgent.search.sortAria');
+    expect(aria).not.toContain('ccAgent.search.sortAria');
     expect(aria).toContain('ccAgent.search.sort.activityDesc');
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchSort.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchSort.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+/**
+ * 会话搜索排序 —— 「记住上次选择」+「排序收在筛选菜单里」的行为契约。
+ * ---------------------------------------------------------------------------
+ * 1. useConversationSearch 的初始排序读 localStorage,切换排序会写回;
+ * 2. 搜索框旁只剩筛选一颗钮(排序已收进该菜单,不再单独占位),其 aria 读出当前排序。
+ */
+
+import { act, cleanup, render, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SEARCH_SORT_BY_KEY } from '../conversationSearchPrefs';
+import { SearchFilterMenu, useConversationSearch } from '../ConversationSearchBox';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, args?: Record<string, unknown>) =>
+      args && Object.keys(args).length > 0 ? `${key}:${JSON.stringify(args)}` : key,
+  }),
+}));
+
+vi.mock('@/lib/conversationSearchService', () => ({
+  searchConversations: vi.fn(async () => ({ results: [] })),
+}));
+
+vi.mock('@/lib/orcaSessionIdentity', () => ({
+  resolveSessionRoute: vi.fn(async () => '/'),
+}));
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+function renderSearch() {
+  return renderHook(() =>
+    useConversationSearch({
+      enabled: false,
+      navigate: vi.fn() as never,
+      allKnownProjects: [],
+    }),
+  );
+}
+
+describe('useConversationSearch sort persistence', () => {
+  it('defaults to relevance when nothing was persisted', () => {
+    const { result } = renderSearch();
+    expect(result.current.sortBy).toBe('relevance');
+  });
+
+  it('restores the sort persisted by a previous session', () => {
+    localStorage.setItem(SEARCH_SORT_BY_KEY, 'activityAsc');
+    const { result } = renderSearch();
+    expect(result.current.sortBy).toBe('activityAsc');
+  });
+
+  it('persists the sort the user picks', () => {
+    const { result } = renderSearch();
+    act(() => result.current.setSortBy('activityDesc'));
+    expect(result.current.sortBy).toBe('activityDesc');
+    expect(localStorage.getItem(SEARCH_SORT_BY_KEY)).toBe('activityDesc');
+
+    // 新挂载(重开搜索 / 重启客户端)沿用上次选择。
+    cleanup();
+    expect(renderSearch().result.current.sortBy).toBe('activityDesc');
+  });
+});
+
+describe('SearchFilterMenu trigger', () => {
+  function renderFilterMenu() {
+    return render(
+      <SearchFilterMenu
+        status="all"
+        agentKind="all"
+        lastActivity="all"
+        projects="all"
+        sortBy="activityDesc"
+        allKnownProjects={[]}
+        activeCount={0}
+        lockedProjectKey={null}
+        lockedProjectName={null}
+        onStatusChange={vi.fn()}
+        onAgentKindChange={vi.fn()}
+        onLastActivityChange={vi.fn()}
+        onProjectsChange={vi.fn()}
+        onSortChange={vi.fn()}
+        onReset={vi.fn()}
+        compact
+      />,
+    );
+  }
+
+  it('keeps a single sliders button and reads out the current sort', () => {
+    const { container } = renderFilterMenu();
+    const buttons = container.querySelectorAll('button');
+    // 搜索框旁只有这一颗钮:排序已收进它的菜单,不再有并排的排序钮。
+    expect(buttons.length).toBe(1);
+    expect(buttons[0]?.querySelector('.lucide-sliders-horizontal')).not.toBeNull();
+    // 无障碍标签同时读出筛选与当前排序。
+    const aria = buttons[0]?.getAttribute('aria-label') ?? '';
+    expect(aria).toContain('ccAgent.search.filterAria');
+    expect(aria).toContain('ccAgent.search.sortAria');
+    expect(aria).toContain('ccAgent.search.sort.activityDesc');
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/conversationSearchPrefs.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/conversationSearchPrefs.ts
@@ -8,8 +8,15 @@
  * 其余筛选(状态 / Agent / 最近活跃范围 / 项目)刻意**不**持久化:它们会静默收窄结果集,
  * 跨会话记住会让「搜不到东西」变得难以察觉。
  *
- * 纯函数化(load/persist 不依赖 React)以便在 node 环境下直接单测,
- * 策略同 sidebarFilterCore。
+ * **为什么是订阅式 store 而不是各自 useState 初始值**:搜索有两个常驻挂载的实例——
+ * rail 态的 ConversationSearchBox 与展开态 Provider 里的内联搜索(CCAgentSidebarUpper
+ * 用 opacity / hidden 切换可见性,两个视图都不卸载)。若各自只在挂载时读一次 localStorage,
+ * 在一处改排序后另一处会停在旧值,直到重挂载 / 重启才「记住」(PR #963 review)。这里把
+ * 偏好收成模块级单一真源 + useSyncExternalStore 订阅,任一处改动即时同步到所有实例;
+ * 同 origin 的其它窗口经 storage 事件跟随。
+ *
+ * load / persist 保持纯函数(不依赖 React)以便在 node 环境下直接单测,策略同
+ * sidebarFilterCore;store 层则在 jsdom 下测。
  */
 
 import { createLogger } from '@/lib/logger';
@@ -68,4 +75,69 @@ export function persistSearchSortBy(sortBy: ConversationSearchSortBy): void {
   } catch (err) {
     log.warn('failed to persist sortBy:', err);
   }
+}
+
+/* ==================== 共享 store(所有搜索实例的单一真源) ==================== */
+
+/** 进程内当前值。null = 还没读过 storage(首次 get 时惰性加载)。 */
+let cached: ConversationSearchSortBy | null = null;
+const listeners = new Set<() => void>();
+/** storage 事件监听只挂一次(模块级),用变量存 handler 以便测试重置时摘掉。 */
+let storageHandler: ((event: StorageEvent) => void) | null = null;
+
+function emit(): void {
+  for (const listener of [...listeners]) listener();
+}
+
+/** 把 storage 里的原始值收敛成合法排序值。 */
+function normalize(raw: string | null | undefined): ConversationSearchSortBy {
+  return raw && SORT_BY_VALUES.has(raw)
+    ? (raw as ConversationSearchSortBy)
+    : DEFAULT_SEARCH_SORT_BY;
+}
+
+function attachStorageListener(): void {
+  if (storageHandler || typeof window === 'undefined') return;
+  // 同 origin 的其它窗口改了排序 → 本窗口跟随(storage 事件只在**其它**窗口触发)。
+  storageHandler = (event: StorageEvent) => {
+    if (event.key !== SEARCH_SORT_BY_KEY) return;
+    const next = normalize(event.newValue);
+    if (next === cached) return;
+    cached = next;
+    emit();
+  };
+  window.addEventListener('storage', storageHandler);
+}
+
+/** 读当前排序(useSyncExternalStore 的 getSnapshot:同值必须返回同引用,字符串天然满足)。 */
+export function getSearchSortBy(): ConversationSearchSortBy {
+  if (cached === null) cached = loadSearchSortBy();
+  return cached;
+}
+
+/** 改排序:写 storage + 通知所有挂载中的搜索实例(rail 与内联即时一致)。 */
+export function setSearchSortBy(next: ConversationSearchSortBy): void {
+  if (getSearchSortBy() === next) return;
+  cached = next;
+  persistSearchSortBy(next);
+  emit();
+}
+
+/** 订阅排序变化;返回退订函数(useSyncExternalStore 契约)。 */
+export function subscribeSearchSortBy(onStoreChange: () => void): () => void {
+  attachStorageListener();
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+/** 仅测试用:清掉进程内缓存与订阅者,让下次 get 重新读 storage。 */
+export function __resetSearchSortByStoreForTests(): void {
+  cached = null;
+  listeners.clear();
+  if (storageHandler && typeof window !== 'undefined') {
+    window.removeEventListener('storage', storageHandler);
+  }
+  storageHandler = null;
 }

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/conversationSearchPrefs.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/conversationSearchPrefs.ts
@@ -1,0 +1,71 @@
+/**
+ * conversationSearchPrefs —— 会话搜索的本地偏好(目前只有排序方式)。
+ * ---------------------------------------------------------------------------
+ * 排序是「个人习惯」而不是一次性收窄条件:用户挑过「最近活跃」后,重开搜索 / 重启客户端
+ * 都应保持该选择,否则每次都要重挑一遍。故排序落 localStorage,与侧栏主列表的
+ * groupBy / sortBy 偏好同款(见 hooks/helpers/sidebarFilterCore.ts)。
+ *
+ * 其余筛选(状态 / Agent / 最近活跃范围 / 项目)刻意**不**持久化:它们会静默收窄结果集,
+ * 跨会话记住会让「搜不到东西」变得难以察觉。
+ *
+ * 纯函数化(load/persist 不依赖 React)以便在 node 环境下直接单测,
+ * 策略同 sidebarFilterCore。
+ */
+
+import { createLogger } from '@/lib/logger';
+
+import type { ConversationSearchSortBy } from '../../../../shared/conversationSearch';
+
+const log = createLogger('ConversationSearchPrefs');
+
+export const SEARCH_SORT_BY_KEY = 'cc-agent.search.sortBy';
+
+/** 未做过选择时的默认排序:相关度(混合检索的最佳匹配优先)。 */
+export const DEFAULT_SEARCH_SORT_BY: ConversationSearchSortBy = 'relevance';
+
+const SORT_BY_VALUES: ReadonlySet<string> = new Set<ConversationSearchSortBy>([
+  'relevance',
+  'activityDesc',
+  'activityAsc',
+]);
+
+/**
+ * 安全访问 localStorage —— 测试 / 非浏览器环境下可能不存在,
+ * 甚至访问即抛(security error);一律降级为 null。
+ */
+function safeStorage(): Storage | null {
+  try {
+    if (typeof globalThis !== 'undefined' && typeof globalThis.localStorage !== 'undefined') {
+      return globalThis.localStorage;
+    }
+  } catch {
+    // 某些环境访问 localStorage 即抛异常,视为不可用。
+  }
+  return null;
+}
+
+/** 读上次选择的排序;未设置 / 非法值 / 读取异常 → 默认排序。 */
+export function loadSearchSortBy(): ConversationSearchSortBy {
+  const storage = safeStorage();
+  if (!storage) return DEFAULT_SEARCH_SORT_BY;
+  let raw: string | null = null;
+  try {
+    raw = storage.getItem(SEARCH_SORT_BY_KEY);
+  } catch (err) {
+    log.warn('failed to read sortBy:', err);
+    return DEFAULT_SEARCH_SORT_BY;
+  }
+  if (raw && SORT_BY_VALUES.has(raw)) return raw as ConversationSearchSortBy;
+  return DEFAULT_SEARCH_SORT_BY;
+}
+
+/** 写入排序选择;storage 不可用或写失败只告警,不影响本次搜索。 */
+export function persistSearchSortBy(sortBy: ConversationSearchSortBy): void {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(SEARCH_SORT_BY_KEY, sortBy);
+  } catch (err) {
+    log.warn('failed to persist sortBy:', err);
+  }
+}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5816,7 +5816,7 @@
         "activityDesc": "Recently active",
         "activityAsc": "Oldest active"
       },
-      "filterAria": "Search filters (Status: {{status}}, Agent: {{agent}}, Last activity: {{lastActivity}}, Projects: {{projects}})",
+      "filterAria": "Search filters and sort (Sort: {{sort}}, Status: {{status}}, Agent: {{agent}}, Last activity: {{lastActivity}}, Projects: {{projects}})",
       "filter": {
         "label": "Filters",
         "active": "{{count}} filters",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5806,7 +5806,7 @@
         "activityDesc": "最近アクティブ",
         "activityAsc": "古いアクティブ順"
       },
-      "filterAria": "検索フィルター（状態：{{status}}、エージェント：{{agent}}、最近のアクティビティ：{{lastActivity}}、プロジェクト：{{projects}}）",
+      "filterAria": "検索フィルターと並び順（並び順：{{sort}}、状態：{{status}}、エージェント：{{agent}}、最近のアクティビティ：{{lastActivity}}、プロジェクト：{{projects}}）",
       "filter": {
         "label": "フィルター",
         "active": "フィルター {{count}} 件",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5806,7 +5806,7 @@
         "activityDesc": "최근 활성순",
         "activityAsc": "오래된 활성순"
       },
-      "filterAria": "검색 필터(상태: {{status}}, 에이전트: {{agent}}, 최근 활성: {{lastActivity}}, 프로젝트: {{projects}})",
+      "filterAria": "검색 필터 및 정렬(정렬: {{sort}}, 상태: {{status}}, 에이전트: {{agent}}, 최근 활성: {{lastActivity}}, 프로젝트: {{projects}})",
       "filter": {
         "label": "필터",
         "active": "필터 {{count}}개",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5806,7 +5806,7 @@
         "activityDesc": "最近活跃",
         "activityAsc": "最早活跃"
       },
-      "filterAria": "搜索筛选（状态：{{status}}，Agent：{{agent}}，最近活跃：{{lastActivity}}，项目：{{projects}}）",
+      "filterAria": "搜索筛选与排序（排序：{{sort}}，状态：{{status}}，Agent：{{agent}}，最近活跃：{{lastActivity}}，项目：{{projects}}）",
       "filter": {
         "label": "筛选",
         "active": "筛选 {{count}}",


### PR DESCRIPTION
## 这次改了什么

### 摘要

会话搜索的排序此前每次打开都回到「相关度」，用户挑过的排序不被记住，每次搜索都要重挑一遍。这个 PR 把排序记成个人偏好（跨会话、跨重启保留），并按用户拍板把排序从搜索框旁的独立钮收进筛选菜单——搜索框旁只留一颗选项钮，排序作为该菜单的首行子菜单，与状态 / 项目 / Agent / 最近活跃 同款。

其余筛选（状态 / Agent / 最近活跃范围 / 项目）**刻意不记忆**：它们会静默收窄结果集，跨会话记住会让「搜不到东西」难以察觉；这个取舍写在 `conversationSearchPrefs.ts` 文件头。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无 issue，用户在会话里直接提出（搜索排序要记住上次选择）
- 本 PR 包含：
  - 新增 `sidebar/conversationSearchPrefs.ts`：`loadSearchSortBy` / `persistSearchSortBy` 走 localStorage（键 `cc-agent.search.sortBy`，默认 `relevance`），非法值 / storage 缺失 / 读写抛异常一律回落默认值
  - `useConversationSearch` 的排序初始值改为读该偏好，`setSortBy` 写回；rail 弹窗与内联搜索共用同一 hook 实例，两处口径一致
  - 排序从独立的 `SearchSortMenu` 钮并入 `SearchFilterMenu` 首行子菜单，`SearchSortMenu` 组件删除；筛选钮 aria 一并读出当前排序
- 明确不包含：其余筛选维度的持久化；搜索算法 / 排序口径本身；主列表（非搜索）的排序菜单
- 用户可见变化：
  1. 选过的搜索排序会被记住，下次打开搜索 / 重启客户端沿用
  2. 搜索框旁从两颗钮（排序 + 筛选）变成一颗（筛选）；排序在该菜单第一行，右侧常显当前排序名
- 是否存在 breaking change：无

### UI 变化

搜索框内联形态（侧栏「搜索」行展开态）与 rail 弹窗形态都受影响：

- 搜索框右侧只剩筛选一颗紧凑图标钮（`SlidersHorizontal`），原先并排的排序钮移除
- 筛选菜单结构：`筛选` 标题 → **排序（新增，右侧显示当前排序）** → 状态 → 项目 → Agent → 最近活跃
- 排序子菜单三项（相关度 / 最近活跃 / 最早活跃）与其它筛选选项同款：纯文字 + 选中勾，无图标
- 排序不计入筛选激活计数，因此不会点亮 compact 钮右上角的「有筛选」红点

截图：本次未能附上最终形态的截图（见「未执行的验证」）。中间版本（排序仍为独立钮）在隔离沙箱实机跑通过搜索行展开态，最终形态只经代码与单测验证。

- 引用的设计规范：
  - `DESIGN.md` §4 Component Stylings → **Select & Dropdown**：面板与选项行样式完全复用既有 `MENU_CONTENT_CLASS` / `SUB_CONTENT_CLASS` / `MENU_ITEM_CLASS` / `MenuSubRow`，新增的排序行与既有四行逐字同款（同 padding、同内圆角、同 hover / selected 处理），没有为它另立样式
  - `DESIGN.md` §10 **Token Selection Rules for New UI**：未新增任何 token，颜色全部沿用既有 `--cmd-palette-*` / `--text-*` slot；无硬编码色值、无 `bg-[#xxx] dark:bg-[#xxx]` 对
  - `DESIGN.md` §10 **Light / Dark Dual-Mode Delivery Gate**：改动不引入任何单模式条件分支，双模式经语义 token 自动跟随（`--cmd-palette-item-*`、`--text-primary` 等在 `themes/colors.ts` 均有 light / dark 两值）；实机目检情况按该节要求如实记录在下方「未执行的验证」

## 怎么验证的

### 自动验证

```text
# 单测门禁（git skill 统一脚本，全仓 pnpm test:unit）
bash ~/.claude/skills/git/scripts/run-unit-gate.sh <worktree>
结果：GATE_EXIT=0（全部 workspace PASS）

pnpm --filter desktop typecheck
结果：通过（tsc --noEmit，无输出）

pnpm --filter desktop exec eslint <本次 5 个改动文件>
结果：通过，无告警

# 本 PR 新增的 12 个用例
pnpm --filter desktop exec vitest run \
  src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchPrefs.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchSort.test.tsx
结果：2 files / 12 tests passed

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

新增测试覆盖：

- `conversationSearchPrefs.test.ts`（8 个，node 环境 + 内存 localStorage shim）：默认值、三种合法值往返、非法值回落、storage 缺失、`getItem` 抛异常、`setItem` 抛异常（quota / security）不影响本次搜索
- `conversationSearchSort.test.tsx`（4 个，jsdom）：默认排序为 relevance、重挂载沿用上次持久化的排序、切换排序写回 localStorage 且新挂载生效、筛选钮是搜索框旁唯一一颗钮（防回归出第二颗）且 aria 同时读出筛选与当前排序

### 手工验证

在功能 worktree 起隔离沙箱实例验证（`pnpm restart:desktop:remote -- --isolated=searchsort`，`pnpm desktop:whoami` 显示 `MATCH` / `state=ready` / userData 指向 `Cindy-dev-searchsort`）：确认侧栏「搜索」行 hover / 点击展开为搜索框、选项钮渲染正常。

注：该实机走查发生在**排序仍是独立钮**的中间版本上（Light 模式）；把排序收进筛选菜单是之后按用户意见改的，未再截图复核。

首次尝试用 `--preserve-running` 共享 userData 启动被客户端按契约拒绝（`MIGRATE_FAILED`：schema-version-behind / history-entry-missing / runtime-manifest-mismatch，本机共享库领先于 `origin/main` 基线），未做任何迁移或 repair，按规则改用隔离沙箱。

### 未执行的验证

- **最终形态（排序收进筛选菜单）没有实机目检**：Light 与 Dark 两种模式都未在真机上看过新的筛选菜单，也没有截图。原因：桌面 computer-use 会话中途结束、终端无屏幕录制权限，无法再取图。按 `DESIGN.md` §10 双模式门槛的要求如实说明——本次只做到「颜色全走既有双模式语义 token、未引入单模式补丁」，不等于两种模式已验证。
- 未跑 `pnpm test:all` / e2e：改动限于 renderer 侧栏搜索的一个组件与一个新纯函数模块，单测门禁 + typecheck 已覆盖，CI 为准。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop renderer 的会话搜索 UI（`ConversationSearchBox` / `SidebarInlineSearch`）。新增的 localStorage 键 `cc-agent.search.sortBy` 只存三种枚举字符串之一，非用户数据、非凭证；键缺失或被写坏都会静默回落默认排序，不影响搜索可用性。无 DB / 协议 / 原生层改动，不触发 mobile 冷更。
- 回滚 / 降级方式：revert 本 PR 即可，无数据迁移；遗留的 localStorage 键会被旧代码忽略。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（取舍与决策记在代码注释里；未新增规则文档）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
