### PR TITLE
fix(desktop): 已发送消息的粘贴段可查看全文

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sentPastedTextPreview.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sentPastedTextPreview.test.ts
@@ -146,6 +146,18 @@ describe('UserMessage pasted-text chip wiring', () => {
     expect(source.match(/handlePastedTextChipClick,/g)?.length).toBe(3);
   });
 
+  it('S1b 三个调用点都拿到同一份 sessionReferences(不再有 undefined 占位)', () => {
+    // 召唤卡 prompt 曾经漏传 sessionReferences(实参列表止于 slashCommandRanges),
+    // prompt 里的会话深链 chip 因此少了 referenceMetadata 的 tooltip 明细行,与气泡
+    // 正文渲染不一致(PR #966 review)。sessionReferences 按 sessionId /
+    // messageClientId 匹配、不依赖文本偏移,三处理应拿同一份。
+    // 三个调用点的末两个实参恒为 `sessionReferences, handlePastedTextChipClick`,
+    // 一并锁住"都可点"与"都有引用元数据"。
+    expect(
+      source.match(/sessionReferences,\s*\n\s*handlePastedTextChipClick,/g)?.length,
+    ).toBe(3);
+  });
+
   it('S2 ToolPayloadLightbox 以只读 text 模式挂载', () => {
     const lightboxStart = source.indexOf('{pastedTextPreview !== null && (');
     expect(lightboxStart).toBeGreaterThan(-1);

--- a/apps/desktop/src/renderer/__tests__/sentPastedTextPreview.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sentPastedTextPreview.test.ts
@@ -1,0 +1,183 @@
+/**
+ * sentPastedTextPreview.test.ts
+ * ---------------------------------------------------------------------------
+ * Regression tests for issue #946:「粘贴大量日志后内容被静默截断，未收到任何提示」。
+ *
+ * 实测结论:发送链路并没有截断(agent 能报出 440 行粘贴文本的末行内容),真正的缺陷
+ * 在已发送气泡的渲染上 ——
+ *   1. 粘贴段胶囊没有 onClick,全文只挂在 320×256 的 hover tooltip 上,几百行日志
+ *      读不了也复制不了,用户无法核对自己发出去的内容;
+ *   2. 收起态按原文纯文本裁到 10 行、展开态换成一个胶囊,「展开」反而看得更少。
+ *
+ * 契约:
+ *   P1  projectSentPastedPlainText 把粘贴段折叠成胶囊文案,周围手打文字原样保留。
+ *   P2  range 缺失 / 越界时退化为原文,绝不截断(宁可不折叠)。
+ *   P3  「只粘一段」的消息投影后不再撞收起阈值 —— 不套第二层收起。
+ *   S1  粘贴段胶囊接 onClick → handlePastedTextChipClick(hover tooltip 不再是唯一出口)。
+ *   S2  ToolPayloadLightbox 以 kind:'text' 挂载且不传 textEdit(已发送消息只读)。
+ *   S3  测量镜像与收起态渲染共用 collapseMeasureBody(同一份投影,判定与呈现一致)。
+ *   S4  previewTitle 在四种界面语言里都有,标题不复用随消息落库的 display。
+ *
+ * 组件级契约走静态源码扫描,与 textLightbox.test.ts / imageLightboxCloseAnywhere.test.ts
+ * 同一约定:把测试留在 node 环境,不为这几条接线检查拖进 jsdom + react-dom。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { projectSentPastedPlainText } from '@/components/chat/UserMessage';
+import {
+  LONG_USER_MESSAGE_VISUAL_LINE_THRESHOLD,
+  mayExceedVisualLineThreshold,
+} from '@/components/chat/userMessageCollapse';
+import type { PastedTextRange } from '@/lib/imageRef';
+
+const sourcePath = resolve(__dirname, '..', 'components', 'chat', 'UserMessage.tsx');
+const source = readFileSync(sourcePath, 'utf8');
+
+const LOCALES = ['zh-CN', 'en', 'ja', 'ko'] as const;
+
+/** 440 行日志的最小可测替身:行数足够撞穿收起阈值。 */
+function makeLog(lines: number): string {
+  return Array.from({ length: lines }, (_, i) => `2026-07-29 log line ${i + 1}`).join('\n');
+}
+
+describe('projectSentPastedPlainText', () => {
+  it('P1 把粘贴段折叠成胶囊文案,前后手打文字原样保留', () => {
+    const log = makeLog(440);
+    const content = `帮我看这段日志\n${log}\n有什么问题`;
+    const start = content.indexOf(log);
+    const ranges: PastedTextRange[] = [
+      { start, end: start + log.length, display: '粘贴的文本(440 行)' },
+    ];
+
+    expect(projectSentPastedPlainText(content, ranges)).toBe(
+      '帮我看这段日志\n粘贴的文本(440 行)\n有什么问题',
+    );
+  });
+
+  it('P1 多段粘贴各自折叠成自己的胶囊文案', () => {
+    const first = makeLog(30);
+    const second = makeLog(40);
+    const content = `A\n${first}\nB\n${second}\nC`;
+    const firstStart = content.indexOf(first);
+    const secondStart = content.indexOf(second, firstStart + first.length);
+    const ranges: PastedTextRange[] = [
+      { start: firstStart, end: firstStart + first.length, display: '粘贴的文本(30 行)' },
+      { start: secondStart, end: secondStart + second.length, display: '粘贴的文本(40 行)' },
+    ];
+
+    expect(projectSentPastedPlainText(content, ranges)).toBe(
+      'A\n粘贴的文本(30 行)\nB\n粘贴的文本(40 行)\nC',
+    );
+  });
+
+  it('P2 没有 range 时原样返回', () => {
+    const content = makeLog(440);
+    expect(projectSentPastedPlainText(content)).toBe(content);
+    expect(projectSentPastedPlainText(content, [])).toBe(content);
+  });
+
+  it('P2 range 越界 / 逆序时退化为原文,不截断', () => {
+    const content = '帮我看这段日志';
+    // 越界(end 超出正文长度)——偏移不可信时宁可不折叠,也不能吞掉尾部内容。
+    expect(
+      projectSentPastedPlainText(content, [
+        { start: 2, end: content.length + 50, display: '粘贴的文本(440 行)' },
+      ]),
+    ).toBe(content);
+    // 逆序 / 空区间同样被丢弃。
+    expect(
+      projectSentPastedPlainText(content, [{ start: 5, end: 3, display: '粘贴的文本(2 行)' }]),
+    ).toBe(content);
+  });
+
+  it('P3 只粘一段的消息投影后不再撞收起阈值(不套第二层收起)', () => {
+    const log = makeLog(440);
+    const content = `看下这段日志\n${log}`;
+    const start = content.indexOf(log);
+    const ranges: PastedTextRange[] = [
+      { start, end: start + log.length, display: '粘贴的文本(440 行)' },
+    ];
+
+    // 修复前:拿原文测量,440 行必然收起 → 收起看 10 行原文、展开只剩胶囊。
+    expect(mayExceedVisualLineThreshold(content, LONG_USER_MESSAGE_VISUAL_LINE_THRESHOLD)).toBe(
+      true,
+    );
+    // 修复后:按胶囊文案测量,整条消息只有两行,直接以胶囊呈现。
+    expect(
+      mayExceedVisualLineThreshold(
+        projectSentPastedPlainText(content, ranges),
+        LONG_USER_MESSAGE_VISUAL_LINE_THRESHOLD,
+      ),
+    ).toBe(false);
+  });
+
+  it('P3 手打正文本身够长时仍然收起(投影只抵扣被折叠的粘贴段)', () => {
+    const typed = Array.from({ length: 40 }, (_, i) => `第 ${i + 1} 行手打说明`).join('\n');
+    const log = makeLog(200);
+    const content = `${typed}\n${log}`;
+    const start = content.indexOf(log);
+    const ranges: PastedTextRange[] = [
+      { start, end: start + log.length, display: '粘贴的文本(200 行)' },
+    ];
+
+    expect(
+      mayExceedVisualLineThreshold(
+        projectSentPastedPlainText(content, ranges),
+        LONG_USER_MESSAGE_VISUAL_LINE_THRESHOLD,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('UserMessage pasted-text chip wiring', () => {
+  it('S1 粘贴段胶囊接上 onClick,hover tooltip 不再是查看全文的唯一出口', () => {
+    const chipBlock = source.slice(
+      source.indexOf("if (token.kind === 'pasted')"),
+      source.indexOf("if (token.kind === 'pasted')") + 1200,
+    );
+    expect(chipBlock).toContain('onPastedTextChipClick');
+    expect(chipBlock).toContain('onClick:');
+    expect(chipBlock).toContain('event.currentTarget');
+    // 三个 renderContent 调用点(引用交错分段 / 普通正文 / 召唤卡 prompt)都要传,
+    // 少传一处那条路径上的粘贴段就又变回不可点。
+    expect(source.match(/handlePastedTextChipClick,/g)?.length).toBe(3);
+  });
+
+  it('S2 ToolPayloadLightbox 以只读 text 模式挂载', () => {
+    const lightboxStart = source.indexOf('{pastedTextPreview !== null && (');
+    expect(lightboxStart).toBeGreaterThan(-1);
+    const lightboxBlock = source.slice(lightboxStart, lightboxStart + 600);
+    expect(lightboxBlock).toContain('<ToolPayloadLightbox');
+    expect(lightboxBlock).toContain("kind: 'text'");
+    expect(lightboxBlock).toContain("t('newChat.pastedText.previewTitle')");
+    expect(lightboxBlock).toContain('triggerRef={activeFileChipRef}');
+    // 已发送消息不可编辑:textEdit 一旦传入,lightbox 会渲染保存按钮。
+    expect(lightboxBlock).not.toContain('textEdit');
+  });
+
+  it('S3 测量镜像与收起态渲染共用同一份投影正文', () => {
+    expect(source).toContain('mayExceedVisualLineThreshold(collapseMeasureBody, collapseThreshold)');
+    expect(source).toContain(
+      'useUserMessageAutoCollapse(collapseMeasureBody, collapseMeasureEnabled, collapseThreshold)',
+    );
+    // 测量镜像(独立 JSX 表达式)。
+    expect(source.match(/\{collapseMeasureBody\}/g)?.length).toBe(1);
+    // 收起态正文(三元分支里,不是独立表达式)。
+    expect(source).toMatch(/longMessageCollapsed\s*\n?\s*\?[\s\S]{0,400}collapseMeasureBody/);
+    // 偏移只在 bubbleBody 与 ghostBody 同源时才折叠(引用交错的消息保持原文测量)。
+    expect(source).toContain('bubbleBody === ghostBody');
+  });
+
+  it('S4 previewTitle 在四种界面语言里都有', () => {
+    for (const locale of LOCALES) {
+      const localePath = resolve(__dirname, '..', 'i18n', 'locales', locale, 'common.json');
+      const parsed = JSON.parse(readFileSync(localePath, 'utf8')) as {
+        newChat: { pastedText: { previewTitle?: string } };
+      };
+      expect(parsed.newChat.pastedText.previewTitle, locale).toBeTruthy();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -1492,7 +1492,13 @@ export function UserMessage({
                                   ghostCardPromptSourceStart,
                                   ghostCardPromptBody.length,
                                 ),
-                            undefined,
+                            // 召唤卡 prompt 与气泡正文用同一份 sessionReferences:它按
+                            // sessionId / messageClientId 匹配,不依赖文本偏移,不需要像
+                            // pastedTextRanges / slashCommandRanges 那样投影到 prompt 局部
+                            // 坐标。此前这里漏传(实参列表止于 slashCommandRanges),导致
+                            // prompt 里的会话深链 chip 少了 referenceMetadata 的 tooltip
+                            // 明细行,与正文渲染不一致(PR #966 review)。
+                            sessionReferences,
                             handlePastedTextChipClick,
                           )
                         : undefined

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -67,6 +67,7 @@ import {
 import { quoteSegmentsToComposerDocument } from '@/lib/composerQuoteDocument';
 import { ChatImageView } from './ChatImageView';
 import { TextLightbox } from './TextLightbox';
+import { ToolPayloadLightbox } from './ToolPayloadLightbox';
 import { MessageActionBar } from './MessageActionBar';
 import { ErrorMessageCard } from './ErrorMessageCard';
 import { useForkAtMessage, textToTiptapDoc } from './useForkAtMessage';
@@ -564,6 +565,28 @@ export function buildSentInlineTokens(
   return tokens;
 }
 
+/**
+ * 收起态渲染与镜像测量共用的纯文本投影:粘贴段折叠成它自己的胶囊文案。
+ *
+ * 展开态里粘贴段是一个胶囊(点击看全文),收起态却按原文纯文本裁剪 —— 用户看到的
+ * 是"收起还能看到日志前 10 行、展开只剩一个胶囊"的反向落差(issue #946)。两侧共用
+ * 同一份投影后,收起与展开只差一个 line-clamp,内容形状一致;测量也不再被折叠掉的
+ * 几百行原文顶穿阈值,「只粘一段」的消息直接以胶囊呈现,不再多套一层收起。
+ *
+ * 只在 range 偏移确定精确时调用(见 UserMessage 的 collapseMeasureBody):
+ * buildSentInlineTokens 本身会丢弃越界 / 逆序的 range,偏移不准最坏退化成"不折叠",
+ * 不会截断或错位正文。
+ */
+export function projectSentPastedPlainText(
+  content: string,
+  pastedTextRanges: readonly PastedTextRange[] = [],
+): string {
+  if (pastedTextRanges.length === 0) return content;
+  return buildSentInlineTokens(content, pastedTextRanges)
+    .map((token) => (token.kind === 'pasted' ? token.display : token.text))
+    .join('');
+}
+
 /** Locate each parsed text island in the original quote wire text. */
 export function locateChatQuoteTextSegmentStarts(
   content: string,
@@ -612,6 +635,11 @@ function renderContent(
   pastedTextRanges: readonly PastedTextRange[] = [],
   slashCommandRanges?: readonly SlashCommandRange[],
   sessionReferences?: readonly PersistedSessionReferenceMetadata[],
+  /**
+   * 粘贴段胶囊的点击入口(issue #946)。不传时胶囊退回不可交互,只剩 hover
+   * tooltip —— 那正是"发出去就再也看不到全文"的旧行为,新调用点都应该传。
+   */
+  onPastedTextChipClick?: (text: string, chip: HTMLElement) => void,
 ): React.ReactNode[] {
   const tokens = buildSentInlineTokens(content, pastedTextRanges, slashCommandRanges ?? []);
   const useLegacySlashHeuristic = slashCommandRanges === undefined;
@@ -637,6 +665,15 @@ function renderContent(
           tooltipContentClassName="max-h-64 w-80 max-w-[70vw] overflow-y-auto whitespace-pre-wrap [overflow-wrap:anywhere]"
           ariaLabel={token.display}
           className="relative top-[-1px] -my-[1px] max-w-[min(240px,55vw)] align-middle"
+          // 点击打开只读全文(与 composer 侧 pastedTextChip → ToolPayloadLightbox
+          // 对齐)。hover tooltip 是 320×256 的小浮层,几百行日志在里面读不了,
+          // 也无法选中复制,不能当作查看全文的唯一出口(issue #946)。
+          {...(onPastedTextChipClick
+            ? {
+                onClick: (event) =>
+                  onPastedTextChipClick(token.text, event.currentTarget),
+              }
+            : {})}
         />
       );
     }
@@ -724,9 +761,18 @@ export function UserMessage({
   } | null>(null);
   const [orcaExpanded, setOrcaExpanded] = useState(false);
   const [longMessageExpanded, setLongMessageExpanded] = useState(false);
+  // issue #946: 已发送消息里点粘贴段胶囊 → 只读全文 lightbox(无文件路径可给
+  // TextLightbox,与 composer 侧一样走 ToolPayloadLightbox 的 text 模式)。
+  const [pastedTextPreview, setPastedTextPreview] = useState<string | null>(null);
   // text-lightbox F6: ref to the chip currently driving the lightbox so
   // close can return focus to it (only one lightbox at a time per message).
   const activeFileChipRef = useRef<HTMLElement | null>(null);
+  // 与 file chip 共用 activeFileChipRef 的"最近一次触发者胜出"语义:同一条消息
+  // 同时只会开一个 lightbox,关闭后焦点回到真正点过的那个胶囊。
+  const handlePastedTextChipClick = useCallback((text: string, chip: HTMLElement) => {
+    activeFileChipRef.current = chip;
+    setPastedTextPreview(text);
+  }, []);
 
   // text-lightbox F1 replaces the old `@path` inline prepend. Files are now
   // rendered as a dedicated Chip-Row above the text bubble (per cc-agent-view
@@ -833,14 +879,29 @@ export function UserMessage({
   const collapseThreshold = automationOrigin
     ? AUTOMATION_USER_MESSAGE_VISUAL_LINE_THRESHOLD
     : LONG_USER_MESSAGE_VISUAL_LINE_THRESHOLD;
+  // 粘贴段在 bubbleBody 局部坐标下的 range(与下方富渲染同一份投影)。
+  const bubblePastedRanges = useMemo(
+    () => projectSentRanges(pastedTextRanges ?? [], ghostBodySourceStart, bubbleBody.length),
+    [bubbleBody.length, ghostBodySourceStart, pastedTextRanges],
+  );
+  // 测量与收起态渲染共用的投影正文:粘贴段按胶囊文案计量,不再拿被折叠掉的
+  // 几百行原文去撞收起阈值(issue #946)。偏移只在 bubbleBody 与 ghostBody 同源时
+  // 精确 —— 引用交错的消息(quote 块被 join 掉,偏移会整体前移)保持原文测量。
+  const collapseMeasureBody = useMemo(
+    () =>
+      bubbleBody === ghostBody
+        ? projectSentPastedPlainText(bubbleBody, bubblePastedRanges)
+        : bubbleBody,
+    [bubbleBody, bubblePastedRanges, ghostBody],
+  );
   // 合并形态($指令 / 软提示兑现 / 语义召唤)不渲文字气泡,镜像测量无处挂载,直接关掉。
   const collapseMeasureEnabled =
     !orcaCommunication &&
     !hookSource &&
     !ghostMergedForm &&
-    mayExceedVisualLineThreshold(bubbleBody, collapseThreshold);
+    mayExceedVisualLineThreshold(collapseMeasureBody, collapseThreshold);
   const { mirrorRef: collapseMirrorRef, shouldCollapse: shouldCollapseLongMessage } =
-    useUserMessageAutoCollapse(bubbleBody, collapseMeasureEnabled, collapseThreshold);
+    useUserMessageAutoCollapse(collapseMeasureBody, collapseMeasureEnabled, collapseThreshold);
   const longMessageCollapsed = shouldCollapseLongMessage && !longMessageExpanded;
 
   // message-actions hover state — raw hover boolean, no debounce here.
@@ -1256,7 +1317,7 @@ export function UserMessage({
                           'whitespace-pre-wrap [overflow-wrap:anywhere]',
                         )}
                       >
-                        {bubbleBody}
+                        {collapseMeasureBody}
                       </div>
                     )}
                     {inlineQuoteCount > 0 ? (
@@ -1319,6 +1380,7 @@ export function UserMessage({
                                           segment.text.length,
                                         ),
                                     sessionReferences,
+                                    handlePastedTextChipClick,
                                   )}
                             </span>
                           ),
@@ -1335,7 +1397,9 @@ export function UserMessage({
                           ? // Collapsed chips render as plain text on purpose: otherwise
                             // clipped links/file chips can remain focusable behind the
                             // visual clamp. Expanding restores the rich chip rendering.
-                            bubbleBody
+                            // 粘贴段用胶囊文案(而非原文)投影:与展开态同形状,
+                            // 且与上方测量镜像同一份文本(issue #946)。
+                            collapseMeasureBody
                           : renderContent(
                               bubbleBody,
                               workingDir,
@@ -1352,11 +1416,7 @@ export function UserMessage({
                               t,
                               sessionId,
                               isRemoteFileOrigin(sessionFileCtx.origin),
-                              projectSentRanges(
-                                pastedTextRanges ?? [],
-                                ghostBodySourceStart,
-                                bubbleBody.length,
-                              ),
+                              bubblePastedRanges,
                               slashCommandRanges === undefined
                                 ? undefined
                                 : projectSentRanges(
@@ -1365,6 +1425,7 @@ export function UserMessage({
                                     bubbleBody.length,
                                   ),
                               sessionReferences,
+                              handlePastedTextChipClick,
                             )}
                       </div>
                     )}
@@ -1431,6 +1492,8 @@ export function UserMessage({
                                   ghostCardPromptSourceStart,
                                   ghostCardPromptBody.length,
                                 ),
+                            undefined,
+                            handlePastedTextChipClick,
                           )
                         : undefined
                     }
@@ -1481,6 +1544,20 @@ export function UserMessage({
           fileName={textLightboxFile.name}
           triggerRef={activeFileChipRef}
           onClose={() => setTextLightboxFile(null)}
+        />
+      )}
+      {/* issue #946: 粘贴段全文(只读)。不传 textEdit —— 已发送的消息不可改。
+          标题用当前语言的 previewTitle,不复用随消息落库的 display(那是发送时刻
+          的语言,切换界面语言后会变成旧语种);行数仍在胶囊标签上可见。 */}
+      {pastedTextPreview !== null && (
+        <ToolPayloadLightbox
+          payload={{
+            kind: 'text',
+            title: t('newChat.pastedText.previewTitle'),
+            text: pastedTextPreview,
+          }}
+          triggerRef={activeFileChipRef}
+          onClose={() => setPastedTextPreview(null)}
         />
       )}
       {/* rewind-session: Preview Dialog. Only mounted while open so dryRun


### PR DESCRIPTION
## 这次改了什么

### 摘要

issue #946 报「粘贴约 200 行日志后内容被静默截断，且没有任何提示」。

先核验了发送链路，**没有找到任何对正文的截断**：粘贴胶囊把原文完整存在节点 attrs
（`PastedTextChipNode`），发送时按 `composerContentSerialization.ts` 原样内联，再经
`projectAgentFacingText` → `buildMakerUserMessage` → Codex `toAppServerInput` → stdio，
全程无 cap（唯一的 2,000,000 字符阈值是「超限就不折叠、走无损普通粘贴」，16MB 的
NDJSON 上限是抛错而非截断）。实测一条 440 行的粘贴，agent 能准确报出末行内容与行数。

真正的缺陷在**已发送气泡的渲染**，两条都会让用户看不到自己发出去的内容：

1. 粘贴段胶囊没有 `onClick`，全文只挂在 320×256 的 hover tooltip 上 —— 几百行日志在
   那个小浮层里读不了、也没法选中复制，鼠标一移开就消失。用户无法核对发出去的内容，
   于是把「AI 只谈前段」误判成了客户端丢内容。
2. 收起态按**原文纯文本**裁到 10 行、展开态换成**一个胶囊** —— 点「展开全文」反而看得
   更少（见 issue #946 的两张对照截图）。

对照：composer 里同一个胶囊点击是会打开 `ToolPayloadLightbox` 全屏预览的
（`ChatInput.tsx` 的 `handleClickOn`），而 `UserMessage.tsx` 压根没 import 这个组件。
这是能力遗漏，不是设计取舍。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#946
- 本 PR 包含：
  - `renderContent` 新增 `onPastedTextChipClick`，粘贴段胶囊接上点击 → 挂 `ToolPayloadLightbox`
    的 `kind:'text'` **只读**模式（不传 `textEdit`，已发送消息不可改）；三个调用点（引用
    交错分段 / 普通正文 / 召唤卡 prompt）全部接上。
  - 新增 `projectSentPastedPlainText()`：把粘贴段投影成它自己的胶囊文案。收起态渲染、
    测量镜像、`mayExceedVisualLineThreshold` 粗筛与 `useUserMessageAutoCollapse` 共用同
    一份投影。
  - 新增单测 `sentPastedTextPreview.test.ts`（10 例）。
- 明确不包含：
  - 发送链路改动 —— 本来就没截断，不需要「提高上限」。
  - Issue 诉求 ②「超限提示」：仓内确实还有三处**静默截断且不告知用户**的地方
    （`SelectionQuoteButton.tsx` 引用选中文字 4000 字符、`agentInputProjection.ts` 引用消息
    12000 字符、`sessionReferenceResolver.ts` 会话引用 8000 上限），入口与粘贴无关，
    建议另立项，不塞进本 PR。
- 用户可见变化：
  - 只粘一段的长消息**不再套两层收起**：气泡直接呈现「粘贴的文本（N 行）」胶囊，
    「展开全文 / 收起」按钮不再出现；点胶囊看全文（可滚动、可复制）。
  - 手打正文本身够长的消息**仍然收起**，但收起态里粘贴段显示为胶囊文案而非日志原文，
    与展开态形状一致。
  - 不含粘贴段的消息：投影是恒等的，收起 / 展开行为与改前逐字节一致。
- 是否存在 breaking change：无

### UI 变化

改动位于已发送用户气泡内的粘贴段：胶囊从「不可交互」变为「可点击」（获得
`cursor-pointer` 与 hover 底色），点击弹出既有的只读全文 lightbox；长消息收起态的粘贴段
文案由日志原文改为胶囊文案。没有新增任何组件、颜色值或 i18n key
（`newChat.pastedText.previewTitle` 在 zh-CN / en / ja / ko 四种语言里已存在）。

未附截图：改动的前后对照即 issue #946 正文里的那两张截图（收起态 / 展开态），修复后
展开态的胶囊变为可点并弹出全文。手工验证平台：Windows（dev cn 隔离沙箱）。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §2「Chip & Button Neutrals」：胶囊底色沿用
    `--surface-chip`，可交互态 hover 走 `--surface-hover`，未引入任何硬编码色值。
  - `DESIGN.md` §4「Dialog & Modal」：不新造弹窗，复用既有 `ToolPayloadLightbox`（与
    composer 侧粘贴预览同一个组件），满足「新弹窗复用现有结构、不另起一套」。
  - `DESIGN.md` §14.1「Text Selectability」：胶囊保持 `textSelectable` 默认（可选中），
    这样它能随消息正文一起被复制出去；lightbox 正文按「内容可选中」处理。
  - `DESIGN.md` §14.2「Focus Management」：关闭 lightbox 后焦点回到触发它的那个胶囊
    （`triggerRef={activeFileChipRef}`）；胶囊拿到 `onClick` 后由 `InlineReferenceChip` 自动补
    `role="button"` + `tabIndex=0` + Enter/Space 激活，键盘可达。
  - `DESIGN.md` §10「Light / Dark Dual-Mode Delivery Gate」：全部走语义 token，无单模式
    硬编码或条件补丁；实机目检情况见下方「未执行的验证」，未把「复用了 themed 样式」
    当成「双模式已验证」。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit，无输出）

pnpm --filter desktop exec eslint \
  src/renderer/components/chat/UserMessage.tsx \
  src/renderer/__tests__/sentPastedTextPreview.test.ts
结果：通过（无告警）

pnpm --filter desktop exec vitest run src/renderer/__tests__/sentPastedTextPreview.test.ts
结果：10 passed

定向回归（粘贴 / 收起 / 引用 / lightbox 相邻用例 8 个文件）：
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/userMessageCollapse.test.ts \
  src/renderer/__tests__/sentSlashCommandRanges.test.ts \
  src/renderer/__tests__/selectionQuoteUserMessage.test.ts \
  src/renderer/__tests__/userMessageEditBox.test.ts \
  src/renderer/__tests__/userMessageForkBlock.test.ts \
  src/renderer/__tests__/pastedTextChip.test.ts \
  src/renderer/__tests__/pastePipeline.test.ts \
  src/renderer/__tests__/textLightbox.test.ts
结果：8 files / 112 passed

pnpm test:unit
结果：26 个 workspace 全部 PASS、0 FAIL（含 apps/desktop unit 107.1s），exit 0

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range 61d39f51..aa64eec1
```

### 手工验证

平台 Windows，`pnpm restart:desktop:remote --region=cn --isolated`（独立 userData 沙箱，
与正式版数据隔离）。由仓库维护者黑盒验证以下路径并确认通过：

1. 粘 400+ 行日志发送 → 气泡直接是「粘贴的文本（N 行）」胶囊，无「展开全文」按钮；
2. 点胶囊 → 全屏只读全文，可滚动、可选中复制；Esc / 点背景关闭后焦点回到胶囊；
3. 「手打一大段 + 粘一段」的消息仍然收起，收起态显示胶囊文案，展开后内容形状一致；
4. 不含粘贴段的长消息收起 / 展开行为与改前一致。

### 未执行的验证

- **Light / Dark 双模式实机目检未单独确认**：本次改动只消费既有语义 token
  （`--surface-chip` / `--surface-hover` / lightbox 自带 token），没有新增色值，但手工验证
  时未逐一在两种模式下截图比对，不把「复用了 themed 样式」当作双模式已验证。
- macOS / Linux 未实机验证：改动是纯 renderer 展示层，无平台分支代码。
- 未做 `pnpm build` / `pnpm test:all`：改动范围限于单个 renderer 组件 + 新增单测，未触碰
  构建链、main 进程、协议或共享 package。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `apps/desktop/src/renderer/components/chat/UserMessage.tsx` 的展示层。不改
  持久化格式（`pastedTextRanges` 的读写口径未动）、不改发送内容、不改 main 侧逻辑。历史
  消息按同一份持久化数据重新渲染即可，无数据迁移。
- **移动端冷更分析：不触发。** 本 PR 只改 `apps/desktop/src/renderer/` 下 2 个文件，未触碰
  `app.json` / `app.config.js` / `eas.json` / `apps/mobile/package.json` / `plugins/` /
  `modules/` 等任何进入 mobile runtime fingerprint 的输入（已用 `git show --name-only` 核对）。
- 投影的偏移安全边界：`projectSentPastedPlainText` 只在 `bubbleBody === ghostBody`（偏移
  精确）时启用，引用交错的消息保持原文测量；`buildSentInlineTokens` 本身丢弃越界 / 逆序
  range，偏移不准最坏退化为「不折叠」，不会截断或错位正文（有单测覆盖）。
- 回滚 / 降级方式：revert 本 PR 即可，无残留状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（约束以代码注释与单测契约表达，无需新增文档）
- [x] 已确认测试结果或说明未执行原因