### PR TITLE
ci: 接入 Claude Code 自动 code review

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -60,6 +60,18 @@ jobs:
     # tag 可被上游重新指向,而这份 workflow 持有 pull-requests:write 并决定
     # 喂给模型的 prompt。dependabot(github-actions 生态,见 .github/dependabot.yml)
     # 会照常提交升级 PR。
+    #
+    # 已知残余风险(有意接受,不是疏漏):钉这一行锁住的是「跑哪份 workflow 文件、
+    # 什么 prompt、什么权限声明、什么工具白名单」,锁不住「该文件在运行期拉取
+    # 并执行哪个版本的 action」。截至 0838103,被调用文件内部是两个浮动 tag——
+    # actions/checkout@v6 与 anthropics/claude-code-action@v1——它们运行在持有
+    # ANTHROPIC_API_KEY 与 pull-requests:write 的 job 里。
+    # 接受的理由:这两个分别是 GitHub 与 Anthropic 的第一方 action,tag 被恶意
+    # 重指向属于行业级事件,不构成本仓特有的暴露面。代价是与本仓「全部 action
+    # 钉 40 位 SHA」的惯例留了一处不一致。
+    # 真正的修法在上游:让 krosdai/.github 把内部 action 钉到 SHA,本仓再 re-pin
+    # 到新的上游 SHA。届时删掉本段注释。
+    # 背景见 PR #985 与安全门 issue #999。
     uses: krosdai/.github/.github/workflows/code-review.yml@0838103fffe7d4c38247050098defc8ae47b8355 # v1
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -6,9 +6,10 @@ name: pr-code-review
 # 定位：**建议性**检查，不替代人工 review，也不替代 client-ci 的机器门禁。
 # 仓库侧的审阅口径写在根目录 REVIEW.md（复用 workflow 的 prompt 会主动读取）。
 #
-# 前置配置（缺任一项本 workflow 会失败，代码里无法兜底）：
-#   - repository secret `ANTHROPIC_API_KEY`（复用 workflow 声明为 required）
-#   - 可选 repository variable `ANTHROPIC_BASE_URL`,不设则走 api.anthropic.com
+# 前置配置：
+#   - repository secret `ANTHROPIC_API_KEY`(必需)。复用 workflow 声明为 required,
+#     缺了本 workflow 每次都失败,代码里无法兜底。
+#   - repository variable `ANTHROPIC_BASE_URL`(可选)。不设则走 api.anthropic.com。
 
 on:
   pull_request:

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -33,10 +33,29 @@ jobs:
     # 连 job 都不启动。fork PR 一律不 review:一是 fork 触发的 pull_request 事件
     # 取不到 secrets,二是外部分支内容进 prompt 有注入面。外部贡献者的 PR 因此
     # 只有 client-ci 与人工 review 把关,这是有意的取舍。
+    #
+    # 排除 dependabot:它的分支在本仓,同仓判断拦不住,但 GitHub 把 Dependabot 触发的
+    # pull_request 当 fork 处理——GITHUB_TOKEN 只读、Actions secrets 一律不可见(只有
+    # Dependabot secrets 可见)。于是 job 会照常启动然后必然失败:拿不到
+    # ANTHROPIC_API_KEY,也拿不到 pull-requests:write 去发评论。本仓 dependabot 每周
+    # 巡检 github-actions 与 npm 两个生态(上限 5 个 PR,见 .github/dependabot.yml),
+    # 不排除就是每周固定几条红。
+    #
+    # 被调用 workflow 的 allowed_bots 输入解决不了这个:它管的是 claude-code-action
+    # 自己的 bot 作者校验,与 GitHub 扣发 secrets 是两层;上游注释也明确写了要禁 bot
+    # 就在调用方 gate。
+    #
+    # 判定用 github.actor 而不是 pull_request.user.login:约束的实质是「谁触发了这次
+    # run」。人往 dependabot 分支上推一个 commit 时,run 由该人触发,secrets 与写权限
+    # 都正常,那次 review 应该照跑——用 user.login 会把这种情况一并误杀。
+    #
+    # 若以后希望 dependabot PR 也过 review,把 ANTHROPIC_API_KEY 以同名加到
+    # Dependabot secrets,再删掉这一行条件。
     if: >-
       github.event.pull_request &&
       !github.event.pull_request.draft &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     # 跨 org 复用 workflow,按本仓惯例钉死 commit SHA 而不是 @v1 浮动 tag:
     # tag 可被上游重新指向,而这份 workflow 持有 pull-requests:write 并决定
     # 喂给模型的 prompt。dependabot(github-actions 生态,见 .github/dependabot.yml)

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -1,0 +1,49 @@
+name: pr-code-review
+
+# Claude Code 自动 code review。审阅逻辑、prompt 与工具白名单都在被调用的
+# krosdai/.github 复用 workflow 里，本文件只负责传 PR 上下文与凭证。
+#
+# 定位：**建议性**检查，不替代人工 review，也不替代 client-ci 的机器门禁。
+# 仓库侧的审阅口径写在根目录 REVIEW.md（复用 workflow 的 prompt 会主动读取）。
+#
+# 前置配置（缺任一项本 workflow 会失败，代码里无法兜底）：
+#   - repository secret `ANTHROPIC_API_KEY`（复用 workflow 声明为 required）
+#   - 可选 repository variable `ANTHROPIC_BASE_URL`,不设则走 api.anthropic.com
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+# 被调用 workflow 自己声明了 actions:read / contents:read / id-token:write /
+# pull-requests:write。调用方授予的权限必须 >= 这四项,否则整个 run 直接报错;
+# 这里按最小集给齐,不多给 issues:write 之类用不到的权限。
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: write
+
+# 刻意不在调用方设 concurrency:被调用 workflow 已按 repo + PR number 分组并
+# cancel-in-progress,再套一层只会让取消粒度重复。
+
+jobs:
+  code-review:
+    # 与被调用 workflow 内部的 if 重复是有意的——在调用方就短路,fork PR 与 draft
+    # 连 job 都不启动。fork PR 一律不 review:一是 fork 触发的 pull_request 事件
+    # 取不到 secrets,二是外部分支内容进 prompt 有注入面。外部贡献者的 PR 因此
+    # 只有 client-ci 与人工 review 把关,这是有意的取舍。
+    if: >-
+      github.event.pull_request &&
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    # 跨 org 复用 workflow,按本仓惯例钉死 commit SHA 而不是 @v1 浮动 tag:
+    # tag 可被上游重新指向,而这份 workflow 持有 pull-requests:write 并决定
+    # 喂给模型的 prompt。dependabot(github-actions 生态,见 .github/dependabot.yml)
+    # 会照常提交升级 PR。
+    uses: krosdai/.github/.github/workflows/code-review.yml@0838103fffe7d4c38247050098defc8ae47b8355 # v1
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      is_draft: ${{ github.event.pull_request.draft }}
+      head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -35,11 +35,15 @@ jobs:
     # 只有 client-ci 与人工 review 把关,这是有意的取舍。
     #
     # 排除 dependabot:它的分支在本仓,同仓判断拦不住,但 GitHub 把 Dependabot 触发的
-    # pull_request 当 fork 处理——GITHUB_TOKEN 只读、Actions secrets 一律不可见(只有
-    # Dependabot secrets 可见)。于是 job 会照常启动然后必然失败:拿不到
-    # ANTHROPIC_API_KEY,也拿不到 pull-requests:write 去发评论。本仓 dependabot 每周
-    # 巡检 github-actions 与 npm 两个生态(上限 5 个 PR,见 .github/dependabot.yml),
-    # 不排除就是每周固定几条红。
+    # pull_request 当 fork 处理——Actions secrets 一律不可见,只有 Dependabot secrets
+    # 可见。于是 job 会照常启动,然后在拿不到 ANTHROPIC_API_KEY 这一步必然失败。
+    # 本仓 dependabot 每周巡检 github-actions 与 npm 两个生态(上限 5 个 PR,见
+    # .github/dependabot.yml),不排除就是每周固定几条红。
+    #
+    # 注意别把这里的原因记成「拿不到 pull-requests:write」:GITHUB_TOKEN 对 Dependabot
+    # 触发的 run 确实默认只读,但那只是**默认值**——自 2021-10 起这类 run 会遵循
+    # workflow 的 permissions key,而本文件上面已经声明了 pull-requests:write。
+    # 也就是说唯一真正卡住的是 secrets,不是权限。
     #
     # 被调用 workflow 的 allowed_bots 输入解决不了这个:它管的是 claude-code-action
     # 自己的 bot 作者校验,与 GitHub 扣发 secrets 是两层;上游注释也明确写了要禁 bot
@@ -50,7 +54,9 @@ jobs:
     # 都正常,那次 review 应该照跑——用 user.login 会把这种情况一并误杀。
     #
     # 若以后希望 dependabot PR 也过 review,把 ANTHROPIC_API_KEY 以同名加到
-    # Dependabot secrets,再删掉这一行条件。
+    # Dependabot secrets,再删掉这一行条件。上面那段说明了权限侧不需要额外动作,
+    # 但这条链路(Dependabot + reusable workflow + permissions key)没有实机验证过,
+    # 真要恢复时先拿一个 dependabot PR 实跑确认,别只依赖文档推断。
     if: >-
       github.event.pull_request &&
       !github.event.pull_request.draft &&

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,9 @@
 - commit、push 和创建 PR 的执行时机由开发者或 Codex、Claude Code、Cindy 等宿主
   工作流决定；仓库规则本身不额外授权外部写操作。
 - 提交 PR 时遵循 `.github/PULL_REQUEST_TEMPLATE.md`，如实说明改动、验证和风险。
+- 非 fork 的非 draft PR 会触发自动 code review（`.github/workflows/pr-code-review.yml`），
+  审阅口径见根目录 `REVIEW.md`。它是**建议性**检查，不替代人工 review，也不替代
+  `client-ci` 的机器门禁；改动上述两份文件前先读 `REVIEW.md` 开头的说明。
 - **DCO 签名（硬性要求）**：本仓每个 commit 都必须带 `Signed-off-by` trailer，且其中的
   名字与邮箱都要与 commit 的 author（或 committer）一致，用 `git commit -s` 生成；
   agent 的自动提交同样适用。PR 上的 DCO check（DCO GitHub App，配置见

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -39,9 +39,16 @@ P1／P2。按下表转换，**不要**把仓库口径的 P2 改写成评论里�
 - scheduler 反向依赖、cron 三方库、scheduler renderer 色值白名单
   （`ci:scheduler-guard`）。
 - mobile 的 Issue Confirm 范围守门（`mobile test:scope`）。
-- typecheck、单测、DCO 签名、PR 模板结构、PR 正文「引用的设计规范」字段。
+- typecheck、单测、DCO 签名、PR 正文「引用的设计规范」字段（`pr-design-basis`，
+  仅在变更命中 UI 路径时校验该字段）。
 
-同理，**不要**因为「PR 正文没写清楚」「commit message 格式」这类流程问题开评论。
+另外，**不要**因为「PR 正文没写清楚」「commit message 格式」这类流程问题开评论。
+注意这一条与上面那张清单的理由不同：它**不是**因为有机器门禁覆盖。`pr-template-rules`
+只校验 `.github/PULL_REQUEST_TEMPLATE.md` 这个模板文件本身的二级标题，且只在模板、
+校验脚本或该 workflow 自身变动时触发，从不读取任何具体 PR 的正文；也就是说「摘要、
+怎么验证的、风险」这些必填段落缺失时，机器不会拦。这里仍然让自动 reviewer 略过，
+是因为 PR 叙述质量属于人工 review 的范围，不该占用有限的 finding 名额——这是范围
+划分，不是覆盖声明。
 
 ## 4. 重点看机器查不到的部分
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,84 @@
+# 自动 Code Review 审阅口径
+
+本文件供 `.github/workflows/pr-code-review.yml` 触发的自动 reviewer 读取。人工
+review 的完整口径见 `docs/dev-rules/development-workflow.md` §3，本文件不另立标准，
+只把它翻译成自动 reviewer 能直接执行的形式。
+
+## 1. 先读规则再评审
+
+本仓的规则是正本，不要凭通用最佳实践判断对错：
+
+- `AGENTS.md` —— 规则索引与触发条件，先看它决定该读哪几份。
+- `docs/dev-rules/` —— 工程规则；`docs/product-rules/` —— 产品行为规则；
+  `docs/design-rules/DESIGN.md` —— 权威视觉规范。
+- `.github/PULL_REQUEST_TEMPLATE.md` —— 风险分类的口径。
+
+diff 命中哪个模块，就读 `AGENTS.md` 索引里对应那条指向的规则文件，再评审。
+
+## 2. 严重度映射
+
+`docs/dev-rules/development-workflow.md` §3 用 P0／P1／P2，本 workflow 的评论用
+P1／P2。按下表转换，**不要**把仓库口径的 P2 改写成评论里的 P2 上报：
+
+| 仓库口径 | 评论标记 | 含义 |
+| --- | --- | --- |
+| P0：红线／崩溃／数据丢失／跨平台失效／安全 | `P1` | 不改不能合 |
+| P1：明显 bug／规范违反／影响面没处理干净 | `P2` | 本次必须修 |
+| P2：可选优化／风格偏好 | 不上报 | 整条略过，不降级也不换个说法上报 |
+
+## 3. 不要重复机器门禁
+
+以下问题 `client-ci` 与其他 workflow 已经逐条断言，命中即红，自动 reviewer 报了
+只是占用有限的 finding 名额：
+
+- 四语言 i18n key 结构、术语表译法、品牌名占位符（`check:i18n` /
+  `check:i18n-glossary` / `check:brand-terminology`）。
+- 受控源文件里的生产端点与飞书 App ID 字面量（`check:endpoints`）。
+- migration 序号连续性、journal／snapshot 对齐、历史 migration 冻结
+  （`desktop db:validate`）。
+- scheduler 反向依赖、cron 三方库、scheduler renderer 色值白名单
+  （`ci:scheduler-guard`）。
+- mobile 的 Issue Confirm 范围守门（`mobile test:scope`）。
+- typecheck、单测、DCO 签名、PR 模板结构、PR 正文「引用的设计规范」字段。
+
+同理，**不要**因为「PR 正文没写清楚」「commit message 格式」这类流程问题开评论。
+
+## 4. 重点看机器查不到的部分
+
+按 PR 模板的风险分类，优先看这些：
+
+- **凭证与本地存储**：凭证、令牌、授权文件是否写进了仓库或可能被 Git 跟踪的路径；
+  用户数据落盘位置是否越界。见 `docs/dev-rules/credentials-and-local-storage.md`。
+- **Electron 进程边界**：renderer／preload／IPC／CSP／WebView／导航与特权能力的改动
+  是否扩大了攻击面。见 `docs/dev-rules/electron-security-and-process-boundaries.md`。
+- **数据库**：新 migration 的正确性与可回滚性、companion 脚本必须是 CommonJS
+  （生产 Electron 用 `require()` 加载，ESM 语法只在用户端炸）。见
+  `docs/dev-rules/database-and-migrations.md`。
+- **mobile 冷更边界**：改动是否触碰 `app.json`／`app.config.js`／`eas.json`／
+  `apps/mobile/package.json`／`plugins/`／`modules/` 等进入 runtime fingerprint 的输入。
+  命中就在评论里点名——这类 PR 需要把关人对冷更单独确认。见
+  `docs/dev-rules/mobile-development.md`。
+- **协议兼容**：`cindy-protocol` 升级、device-link／relay／隧道 payload、IPC allowlist
+  等跨端 wire protocol 的向后兼容性。见 `docs/dev-rules/protocol-and-submodules.md`。
+- **system prompt 与 Agent 行为**：进入模型 system 段的提示词、tool／MCP 暴露、
+  usage 计量。见 `docs/dev-rules/maker-core-and-agent-behavior.md`。
+- **插件沙箱**：`.cindy` 运行时的权限、能力 slot、网络／凭证／文件交接。见
+  `docs/dev-rules/plugin-security-and-authoring.md`。
+- **UI 双模式**：新增或修改的界面必须同时实现 Light 与 Dark，颜色走语义 token；
+  只适配一种模式的硬编码或条件补丁视为未完成。见 `docs/design-rules/DESIGN.md`。
+- **跨平台**：macOS 与 Windows 的路径、进程、文件系统差异。
+- **测试**：是否通过 skip、删除或弱化断言制造通过。
+
+## 5. 评审环境的已知限制
+
+- `cindy-protocol` submodule **未** checkout，该目录下的文件读不到。不要据此推断
+  文件缺失或引用失效。
+- 只 checkout 了 PR 的 merge ref 与最近 100 条历史，更早的 `git log`／`git blame`
+  会不完整。
+- 依赖未安装，无法运行测试或构建；结论只能来自静态阅读。
+
+拿不准的地方，宁可不报，也不要用推测填空——上报前先把相关源文件读到能确认为止。
+
+## 6. 评论语言
+
+用中文写评论，与仓库文档保持一致；PR 正文为英文时用英文。


### PR DESCRIPTION
## 这次改了什么

### 摘要

给非 fork、非 draft、非 Dependabot 的 PR 接一条 Claude Code 自动 code review。审阅逻辑、prompt 与工具白名单都在 `krosdai/.github` 的复用 workflow 里，本仓只加一个调用方 + 一份审阅口径文档。用法参照 `krosdai/scaffold` 的调用方。

定位是**建议性**检查：不替代人工 review，也不替代 `client-ci` 的机器门禁，不建议设为 required check（理由见「风险」）。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [x] 其他：`ci`

### 范围

- 关联 Issue / 需求：安全门讨论 #999
- 本 PR 包含：
  - 新增 `.github/workflows/pr-code-review.yml`，调用 `krosdai/.github/.github/workflows/code-review.yml`。相对 scaffold 的调用方按本仓惯例做了四处收紧：
    - **钉死 commit SHA 而非浮动 tag `@v1`**。本仓所有 action 都是 `uses: xxx@<40 位 SHA> # vN`（见 `ci.yml:31`）。已核对 `v1` 当前指向 `0838103` 并回读确认内容一致。**注意这一行锁住的边界**：它锁的是「跑哪份 workflow 文件、什么 prompt、什么权限声明、什么工具白名单」，锁不住「该文件在运行期拉取执行哪个版本的 action」—— 详见「风险」里的残余风险条目。
    - **权限收到最小集**。被调用 workflow 声明的是 `actions:read` / `contents:read` / `id-token:write` / `pull-requests:write`，调用方权限只需 ≥ 这四项；scaffold 里的 `issues: write` 用不到，去掉。
    - **不在调用方设 `concurrency`**。被调用 workflow 已按 repo + PR number 分组并 `cancel-in-progress`，再套一层只是重复取消粒度。
    - **排除 Dependabot 触发的 run**（`github.actor != 'dependabot[bot]'`）。Dependabot 的分支在本仓，同仓判断拦不住它，但 GitHub 把 Dependabot 触发的 `pull_request` 当 fork 处理：**Actions secrets 一律不可见**（只有 Dependabot secrets 可见），于是 job 会照常启动、然后在拿不到 `ANTHROPIC_API_KEY` 这一步必然失败。不排除的话每周的 dependabot PR 都会固定红几条。（注意原因不是「拿不到 `pull-requests: write`」—— 只读只是默认值，自 2021-10 起这类 run 会遵循 `permissions` key，见 `25ef6ad` 与 [#discussion_r3682661980](https://github.com/makecindy/cindy/pull/985#discussion_r3682661980)。）
  - 新增根目录 `REVIEW.md` 作为审阅口径。被调用 workflow 的 prompt 写死在上游文件里，其中 `Follow the guidelines in REVIEW.md if present` 是本仓唯一的定制入口。主要解决三件事：
    - **严重度映射**。上游 prompt 用 P1/P2 且 P3 不报；本仓 `docs/dev-rules/development-workflow.md` §3 用 P0/P1/P2 且 P2 不报。两套词表撞了，不映射会把本仓口径的「可选优化」当成上游 P2 报上来，等于悄悄降低上报门槛。表里写明：仓库 P0→评论 P1，仓库 P1→评论 P2，仓库 P2→整条略过。
    - **划掉与机器门禁重合的检查项**（i18n 三道、端点字面量、migration 冻结、scheduler 反向依赖、mobile scope、typecheck / 单测 / DCO、以及 `pr-design-basis` 校验的「引用的设计规范」字段），把 10 条 finding 名额留给凭证落盘、Electron 进程边界、migration companion 脚本必须 CJS、mobile 冷更 fingerprint、协议兼容、UI 双模式这些机器查不到的部分。清单里**不含 PR 模板结构** —— `pr-template-rules` 只校验模板文件本身的二级标题、且带 `paths:` 过滤，从不读取具体 PR 的正文；`REVIEW.md` 里对这点单独做了说明，让 bot 略过 PR 叙述质量是**范围划分**（属人工 review），不是覆盖声明。
    - **写明评审环境限制**：`cindy-protocol` submodule 不会被 checkout、`fetch-depth: 100`、依赖未安装。不写清楚 reviewer 容易据此误报「文件缺失 / 引用失效」。
  - `AGENTS.md`「Git 与交付」加三行索引，保持规则正本的可发现性。
- 明确不包含：分支保护规则的改动（required check 与否需要在仓库设置里定，代码侧不涉及）。
- 用户可见变化：无（仅 CI 与仓库文档）。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：本 PR 只新增 CI workflow 与仓库文档，无任何界面、组件、样式或 UI 文案改动。

## 怎么验证的

### 自动验证

```text
node -e "require('yaml').parse(...)"   # 每次改动后解析 .github/workflows/pr-code-review.yml
结果：通过，jobs=['code-review']，uses/with/secrets/permissions 结构符合 workflow_call 契约

pnpm test:unit（四轮，分别对应 6587787 / c0344d3 / 900bd6c / 25ef6ad 前后）
结果：EXIT=1，每轮失败项完全一致的 2 项，其余全部 PASS / SKIP：
      1) apps/desktop unit —— TEST_COLLECT_FAILED
      2) packages/maker-remote-ssh unit —— 1 条断言失败
      两项都是评审容器的环境产物，判定依据见下方「未执行的验证」；
      四轮失败集合稳定不变，本 PR 未引入任何新增失败。

node scripts/check-dco.mjs
结果：通过
```

本次改动不涉及任何 package 源码，`pnpm --filter <包名> run --if-present typecheck` 无适用对象。

**端到端已验证**：`code-review / review` 实际跑通**五轮，全部 success**（`452fa87` 2m12s、`6587787` 1m49s、转 ready 后 2m12s、`c0344d3` 1m44s、`25ef6ad` 2m07s），五轮均未产生 finding。这同时验证了跨 org `uses:` 的 SHA 可解析、`krosdai/.github` 对本仓可达、`ANTHROPIC_API_KEY` 能正确传入。

### 手工验证

不涉及。

### 未执行的验证

本地 `pnpm test:unit` 的 2 项失败**都在本次改动之前就存在，且都是评审容器的环境产物，不是仓库缺陷**。共同前提：本 PR 只动 `.github/`、`REVIEW.md`、`AGENTS.md`，与这两个 workspace 没有任何交集；`git stash -u` 清空工作区后复现结果一致。

1. **`apps/desktop unit` —— TEST_COLLECT_FAILED**。日志里是 `Bundled ripgrep not found for linux-x64`，即 `ci.yml` 第 78–85 行注释描述的那条：`XDT_SKIP_AGENT_BIN_INSTALL` 跳过了全部 agent 二进制，`runtime-configs.ts` 模块顶层的 `bundledRipgrepDir()` 缺 rg 时直接 throw，desktop 单测在收集阶段整体挂掉。本环境无法补装：`pnpm install:ripgrep` 走 upstream 得到 GitHub API 401、走 CDN 得到 404。
2. **`packages/maker-remote-ssh` —— `hostKeys.test.ts > FileHostKeyStore > rolls back in-memory cache when first-use key cannot be persisted`**。该用例靠 `fs.chmod(scratchDir, 0o555)` 制造写失败，再断言 `store.set()` reject。本容器以 **root（uid 0）** 运行，`CAP_DAC_OVERRIDE` 绕过 DAC 权限位，写入照样成功。已用最小复现确认：root 下往 `0555` 目录 `writeFileSync` 成功。

两项在 CI 上**均未复现** —— `verify` job 有独立的 `Install bundled ripgrep` 步骤，且以非 root 的 `runner` 用户运行，三轮（`6587787` / `c0344d3` / `25ef6ad`）都是 success。此外没有跑 `pnpm test:all`、lint 与任何构建。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
  - **新引入一个跨 org 的第三方复用 workflow**，它在本仓上下文里持有 `pull-requests: write`，并会把 PR diff 与被它读取的仓库文件送到 Anthropic API。这是勾选「权限 / 安全」的原因。缓解措施：SHA 钉死、权限收到最小集、fork PR 与 Dependabot 一律不跑、上游 workflow 内部已把 action 强制走 job 级 `GITHUB_TOKEN` 而非可写的 App token、工具白名单无 `Write`/`Edit`/任意 `Bash`。
  - **⚠️ 已知残余风险（有意接受）：内层 action 未 pin。** 钉 `uses:` 那一行锁不住被调用文件运行期拉取的 action。截至 `0838103`，被调用文件内部是两个浮动 tag —— `actions/checkout@v6` 与 `anthropics/claude-code-action@v1` —— 它们运行在持有 `ANTHROPIC_API_KEY` 与 `pull-requests: write` 的 job 里。由 Codex 在 [#discussion_r3682601024](https://github.com/makecindy/cindy/pull/985#discussion_r3682601024) 指出并已逐行核实。**接受理由**：这两个分别是 GitHub 与 Anthropic 的第一方 action，tag 被恶意重指向属于行业级事件，不构成本仓特有暴露面。**代价**：与本仓「全部 action 钉 40 位 SHA」的惯例留了一处不一致。**真正的修法在上游**（`krosdai/.github` 把内部 action 钉到 SHA，本仓再 re-pin），本仓改不掉，故在 `c0344d3` 里显式记录进 workflow 注释。详见 #999。
  - **fork PR 不会被 review**。fork 触发的 `pull_request` 取不到 secrets，外部分支内容进 prompt 也有注入面。后果是外部贡献者的 PR 只有 `client-ci` 与人工 review 把关 —— 有意取舍，但会造成内外两条不同的合并路径。
  - **Dependabot PR 不会被 review**（原因同上）。若希望覆盖，把 `ANTHROPIC_API_KEY` 以同名加到 **Dependabot secrets**，再删掉 workflow 里那一行条件即可；权限侧不需要额外动作，但该链路未实机验证，恢复时建议先拿一个 dependabot PR 实跑确认。
  - **合入后本仓会有四个自动 reviewer**：`copilot-pull-request-reviewer`、`Greptile Review`、`chatgpt-codex-connector`、以及本 PR 新加的 `code-review / review`（后三者仅在非 draft 时触发）。**本 PR 自身就是一份样本**：Codex 提了 4 条，其中 3 条促成实际改动（Dependabot 密钥、内层 action 未 pin、`REVIEW.md` 谎报机器门禁覆盖），第 4 条结论虽不成立但间接暴露了 workflow 注释里的同一处错误；Copilot 提了 1 条（注释自相矛盾，成立）；Greptile 六轮均 5/5 无 finding；新加的 `code-review / review` 五轮均无 finding。四个 bot 在同一个 PR 上提重复或矛盾建议是现实风险，**是否精简建议一并决定**；本 PR 没有动任何现有 reviewer。
  - 因此**不建议把它设为 required check**：它是 LLM 判断，在 fork / Dependabot PR 上是跳过状态，且它的产出是 inline 评论而非通过/不通过 —— 即使提出 10 条 P1，job 依然是 success，job 失败只发生在 API 报错或超时这类基础设施问题上。
- 前置配置：
  - organization secret `ANTHROPIC_API_KEY`（**必需**，被调用 workflow 声明为 `required`）。已确认本仓可读取 —— 五轮 `code-review / review` 实跑通过即为证据。
  - repository variable `ANTHROPIC_BASE_URL`（可选，不设则走 `api.anthropic.com`）
- 回滚 / 降级方式：删除 `.github/workflows/pr-code-review.yml` 即可完全停用，不留任何运行期依赖；`REVIEW.md` 与 `AGENTS.md` 的改动是纯文档，可独立保留或一并回退。临时停用也可以直接在仓库设置里 disable 该 workflow。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGFHz5VqmoRC73g72KJYET