### PR TITLE
fix(desktop): 修复新对话全局技能发现

### DIFF
--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3887,7 +3887,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   ipcMain.handle(MAKER_INVOKE.LIST_AGENT_SKILLS, async (_e, agentKind: unknown, params: unknown) => {
     try {
       const kind = requireAgentKind(agentKind);
-      const skillParams = params as { workingDir: string; forceReload?: boolean };
+      const skillParams = (params ?? {}) as { workingDir?: string; forceReload?: boolean };
       const linksChanged = await prepareProjectSkillLinksFailSoft(skillParams?.workingDir);
       if (kind === 'codex' && linksChanged) {
         skillParams.forceReload = true;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3929,7 +3929,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     listAgentSkills: (
       agentKind: 'claude-code' | 'codex',
-      params: { workingDir: string; forceReload?: boolean },
+      params: { workingDir?: string; forceReload?: boolean },
     ): Promise<{
       success: boolean;
       error?: string;

--- a/apps/desktop/src/renderer/__tests__/slashCommandsDeviceId.test.ts
+++ b/apps/desktop/src/renderer/__tests__/slashCommandsDeviceId.test.ts
@@ -70,12 +70,12 @@ describe('loadAllCommands deviceId', () => {
     expect(cmds.some((x) => x.kind === 'agent-skill')).toBe(false);
   });
 
-  it('本地 Codex 新对话 workingDir=null 时保持不请求 skills/list', async () => {
+  it('本地 Codex 新对话 workingDir=null 时仍加载全局 skills', async () => {
     const s = stubElectron();
     const cmds = await loadAllCommands('codex', null);
 
-    expect(s.listAgentSkills).not.toHaveBeenCalled();
-    expect(cmds.some((x) => x.kind === 'agent-skill')).toBe(false);
+    expect(s.listAgentSkills).toHaveBeenCalledWith('codex', {});
+    expect(cmds.some((x) => x.name === 'localskill')).toBe(true);
   });
 
   it('远程会话:agent-builtin / agent-skill 走隧道,desktop 仍本地', async () => {

--- a/apps/desktop/src/renderer/__tests__/slashCommandsDeviceId.test.ts
+++ b/apps/desktop/src/renderer/__tests__/slashCommandsDeviceId.test.ts
@@ -48,6 +48,36 @@ describe('loadAllCommands deviceId', () => {
     expect(cmds.map((x) => x.name).sort()).toEqual(['compact', 'goal', 'help', 'localskill']);
   });
 
+  it('本地 Claude 新对话无 workingDir 时仍加载全局 skills', async () => {
+    const s = stubElectron();
+    const cmds = await loadAllCommands('claude-code', undefined);
+
+    expect(s.invoke).not.toHaveBeenCalled();
+    expect(s.listAgentSkills).toHaveBeenCalledWith('claude-code', {});
+    expect(cmds.some((x) => x.name === 'localskill')).toBe(true);
+  });
+
+  it('SSH remote 用 null 显式关闭控制端本机 skill 扫描', async () => {
+    const s = stubElectron();
+    const cmds = await loadAllCommands('claude-code', null);
+
+    expect(s.listAgentSkills).not.toHaveBeenCalled();
+    expect(s.invoke).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'maker:list-agent-skills',
+      expect.anything(),
+    );
+    expect(cmds.some((x) => x.kind === 'agent-skill')).toBe(false);
+  });
+
+  it('本地 Codex 新对话无 workingDir 时保持不请求 skills/list', async () => {
+    const s = stubElectron();
+    const cmds = await loadAllCommands('codex', undefined);
+
+    expect(s.listAgentSkills).not.toHaveBeenCalled();
+    expect(cmds.some((x) => x.kind === 'agent-skill')).toBe(false);
+  });
+
   it('远程会话:agent-builtin / agent-skill 走隧道,desktop 仍本地', async () => {
     const s = stubElectron();
     const cmds = await loadAllCommands('claude-code', '/host/path', undefined, 'dev-1');
@@ -59,11 +89,23 @@ describe('loadAllCommands deviceId', () => {
     expect(s.invoke).toHaveBeenCalledWith('dev-1', 'maker:list-agent-commands', ['claude-code']);
     expect(s.invoke).toHaveBeenCalledWith('dev-1', 'maker:list-agent-skills', [
       'claude-code',
-      { workingDir: '/host/path', forceReload: undefined },
+      { workingDir: '/host/path' },
     ]);
     // 结果 = 本地 desktop(help + goal,远程会话不再剔除)+ 被控端 builtin(host-cmd)+ 被控端 skill(host-skill)
     expect(cmds.map((x) => x.name).sort()).toEqual(['goal', 'help', 'host-cmd', 'host-skill']);
     // device-link 下 /goal 保留:业务体经隧道到被控端 goal-host,palette 正常展示。
     expect(cmds.some((x) => x.name === 'goal')).toBe(true);
+  });
+
+  it('device-link Claude 新对话无 workingDir 时从被控端加载全局 skills', async () => {
+    const s = stubElectron();
+    const cmds = await loadAllCommands('claude-code', undefined, undefined, 'dev-1');
+
+    expect(s.listAgentSkills).not.toHaveBeenCalled();
+    expect(s.invoke).toHaveBeenCalledWith('dev-1', 'maker:list-agent-skills', [
+      'claude-code',
+      {},
+    ]);
+    expect(cmds.some((x) => x.name === 'host-skill')).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/slashCommandsDeviceId.test.ts
+++ b/apps/desktop/src/renderer/__tests__/slashCommandsDeviceId.test.ts
@@ -48,18 +48,18 @@ describe('loadAllCommands deviceId', () => {
     expect(cmds.map((x) => x.name).sort()).toEqual(['compact', 'goal', 'help', 'localskill']);
   });
 
-  it('本地 Claude 新对话无 workingDir 时仍加载全局 skills', async () => {
+  it('本地 Claude 新对话 workingDir=null 时仍加载全局 skills', async () => {
     const s = stubElectron();
-    const cmds = await loadAllCommands('claude-code', undefined);
+    const cmds = await loadAllCommands('claude-code', null);
 
     expect(s.invoke).not.toHaveBeenCalled();
     expect(s.listAgentSkills).toHaveBeenCalledWith('claude-code', {});
     expect(cmds.some((x) => x.name === 'localskill')).toBe(true);
   });
 
-  it('SSH remote 用 null 显式关闭控制端本机 skill 扫描', async () => {
+  it('SSH remote 用 skipAgentSkills 显式关闭控制端本机 skill 扫描', async () => {
     const s = stubElectron();
-    const cmds = await loadAllCommands('claude-code', null);
+    const cmds = await loadAllCommands('claude-code', null, { skipAgentSkills: true });
 
     expect(s.listAgentSkills).not.toHaveBeenCalled();
     expect(s.invoke).not.toHaveBeenCalledWith(
@@ -70,9 +70,9 @@ describe('loadAllCommands deviceId', () => {
     expect(cmds.some((x) => x.kind === 'agent-skill')).toBe(false);
   });
 
-  it('本地 Codex 新对话无 workingDir 时保持不请求 skills/list', async () => {
+  it('本地 Codex 新对话 workingDir=null 时保持不请求 skills/list', async () => {
     const s = stubElectron();
-    const cmds = await loadAllCommands('codex', undefined);
+    const cmds = await loadAllCommands('codex', null);
 
     expect(s.listAgentSkills).not.toHaveBeenCalled();
     expect(cmds.some((x) => x.kind === 'agent-skill')).toBe(false);
@@ -97,9 +97,9 @@ describe('loadAllCommands deviceId', () => {
     expect(cmds.some((x) => x.name === 'goal')).toBe(true);
   });
 
-  it('device-link Claude 新对话无 workingDir 时从被控端加载全局 skills', async () => {
+  it('device-link Claude 新对话 workingDir=null 时从被控端加载全局 skills', async () => {
     const s = stubElectron();
-    const cmds = await loadAllCommands('claude-code', undefined, undefined, 'dev-1');
+    const cmds = await loadAllCommands('claude-code', null, undefined, 'dev-1');
 
     expect(s.listAgentSkills).not.toHaveBeenCalled();
     expect(s.invoke).toHaveBeenCalledWith('dev-1', 'maker:list-agent-skills', [

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2959,11 +2959,11 @@ export function ChatInput({
     (opts?: { forceReload?: boolean }) => {
       const seq = ++slashCommandLoadSeqRef.current;
       // device-link 远程会话:agent-builtin / agent-skill 从被控端读(deviceLinkDeviceId);
-      // workingDir 是被控端路径(SSH remoteHostId 才置 null 关扫描)。desktop 命令始终本地。
+      // workingDir 是被控端路径；SSH remote 显式关扫描。desktop 命令始终本地。
       loadAllCommands(
         paletteAgentKind,
-        isRemoteSession ? null : workingDir,
-        opts,
+        workingDir,
+        { ...opts, skipAgentSkills: isRemoteSession },
         deviceLinkDeviceId,
       )
         .then((cmds) => {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2962,7 +2962,7 @@ export function ChatInput({
       // workingDir 是被控端路径(SSH remoteHostId 才置 null 关扫描)。desktop 命令始终本地。
       loadAllCommands(
         paletteAgentKind,
-        isRemoteSession ? null : (workingDir ?? null),
+        isRemoteSession ? null : workingDir,
         opts,
         deviceLinkDeviceId,
       )

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1081,8 +1081,9 @@ export function CCAgentSessionView({
   useEffect(() => {
     let cancelled = false;
     const agentKind = session?.agentKind === 'codex' ? 'codex' : 'claude-code';
-    // remote 传 null:loadAllCommands 退化为 desktop + agent-builtin,不扫本机项目 skills。
-    const wd = isRemoteSession ? null : (session?.workingDir ?? null);
+    // SSH remote 传 null:loadAllCommands 退化为 desktop + agent-builtin,不扫控制端本机 skills。
+    // 本地无 workingDir 传 undefined:Claude 仍可扫描全局 skills。
+    const wd = isRemoteSession ? null : session?.workingDir;
     // 先同步清空:切换会话(尤其 local→remote)时 loadAllCommands 是异步的,清空可避免
     // 刷新完成前 getHelpCommandsSnapshot / desktop 命令识别复用上一个项目的本地 skills。
     setAllCommands([]);
@@ -1563,7 +1564,7 @@ export function CCAgentSessionView({
       // device-link 远程会话同源:传 remoteDeviceId,fallback 快照也从被控端读(见上方 cache effect 说明)。
       return await loadAllCommands(
         agentKind,
-        isRemoteSession ? null : (session?.workingDir ?? null),
+        isRemoteSession ? null : session?.workingDir,
         undefined,
         remoteDeviceId,
       );

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1081,9 +1081,8 @@ export function CCAgentSessionView({
   useEffect(() => {
     let cancelled = false;
     const agentKind = session?.agentKind === 'codex' ? 'codex' : 'claude-code';
-    // SSH remote 传 null:loadAllCommands 退化为 desktop + agent-builtin,不扫控制端本机 skills。
-    // 本地无 workingDir 传 undefined:Claude 仍可扫描全局 skills。
-    const wd = isRemoteSession ? null : session?.workingDir;
+    // SSH remote 显式禁用控制端本机 skill 扫描；本地无 workingDir 时 Claude 仍扫全局 skills。
+    const wd = session?.workingDir;
     // 先同步清空:切换会话(尤其 local→remote)时 loadAllCommands 是异步的,清空可避免
     // 刷新完成前 getHelpCommandsSnapshot / desktop 命令识别复用上一个项目的本地 skills。
     setAllCommands([]);
@@ -1091,7 +1090,7 @@ export function CCAgentSessionView({
     // (与 ChatInput palette 同源)。否则此 cache 取的是控制端命令,maybeDispatchDesktopSlashCommand
     // 会把被控端 skill/builtin 影子掉的 /clear、/help 等误判成 desktop 命令、在控制端执行。
     // 本机会话 remoteDeviceId=undefined → 行为不变。desktop 命令始终本地(见 loadAllCommands)。
-    loadAllCommands(agentKind, wd, undefined, remoteDeviceId)
+    loadAllCommands(agentKind, wd, { skipAgentSkills: isRemoteSession }, remoteDeviceId)
       .then((cmds) => {
         if (!cancelled) setAllCommands(cmds);
       })
@@ -1564,8 +1563,8 @@ export function CCAgentSessionView({
       // device-link 远程会话同源:传 remoteDeviceId,fallback 快照也从被控端读(见上方 cache effect 说明)。
       return await loadAllCommands(
         agentKind,
-        isRemoteSession ? null : session?.workingDir,
-        undefined,
+        session?.workingDir,
+        { skipAgentSkills: isRemoteSession },
         remoteDeviceId,
       );
     } catch {

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -85,7 +85,8 @@ export function filterSlashCommands(
  * 拉三路 IPC, 合并成 UnifiedCommand[]。
  *
  * - 任何一路失败按空列表处理(已在 main 端做 try/catch + 返回 success:false), 不阻塞 palette。
- * - workingDir 为空时不发起 agent-skill 扫描(没意义), 但 desktop / agent-builtin 仍然返回。
+ * - workingDir=undefined 表示本地无项目:Claude 仍扫描全局 skills。
+ * - workingDir=null 表示显式禁用扫描(SSH remote):避免读取控制端本机 skills。
  */
 export async function loadAllCommands(
   agentKind: AgentKind,
@@ -108,14 +109,19 @@ export async function loadAllCommands(
       ? (window.electronAPI.deviceLink.invoke(deviceId, 'maker:list-agent-commands', [agentKind]) as Promise<CmdRes>)
       : api.listAgentCommands(agentKind)
   ).catch(() => ({ success: false }));
-  const skillP: Promise<SkillRes> = workingDir
+  const shouldLoadSkills = workingDir !== null && (agentKind === 'claude-code' || Boolean(workingDir));
+  const skillParams = {
+    ...(workingDir ? { workingDir } : {}),
+    ...(opts?.forceReload !== undefined ? { forceReload: opts.forceReload } : {}),
+  };
+  const skillP: Promise<SkillRes> = shouldLoadSkills
     ? (
         deviceId
           ? (window.electronAPI.deviceLink.invoke(deviceId, 'maker:list-agent-skills', [
               agentKind,
-              { workingDir, forceReload: opts?.forceReload },
+              skillParams,
             ]) as Promise<SkillRes>)
-          : api.listAgentSkills(agentKind, { workingDir, forceReload: opts?.forceReload })
+          : api.listAgentSkills(agentKind, skillParams)
       ).catch(() => ({ success: false }))
     : Promise.resolve({ success: true, skills: [] });
 

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -85,13 +85,13 @@ export function filterSlashCommands(
  * 拉三路 IPC, 合并成 UnifiedCommand[]。
  *
  * - 任何一路失败按空列表处理(已在 main 端做 try/catch + 返回 success:false), 不阻塞 palette。
- * - workingDir=undefined 表示本地无项目:Claude 仍扫描全局 skills。
- * - workingDir=null 表示显式禁用扫描(SSH remote):避免读取控制端本机 skills。
+ * - workingDir 为空时 Claude 仍扫描全局 skills。
+ * - SSH remote 由 opts.skipAgentSkills 显式禁用扫描,避免读取控制端本机 skills。
  */
 export async function loadAllCommands(
   agentKind: AgentKind,
   workingDir: string | null | undefined,
-  opts?: { forceReload?: boolean },
+  opts?: { forceReload?: boolean; skipAgentSkills?: boolean },
   deviceId?: string,
 ): Promise<UnifiedCommand[]> {
   const api = window.electronAPI.maker;
@@ -109,7 +109,7 @@ export async function loadAllCommands(
       ? (window.electronAPI.deviceLink.invoke(deviceId, 'maker:list-agent-commands', [agentKind]) as Promise<CmdRes>)
       : api.listAgentCommands(agentKind)
   ).catch(() => ({ success: false }));
-  const shouldLoadSkills = workingDir !== null && (agentKind === 'claude-code' || Boolean(workingDir));
+  const shouldLoadSkills = !opts?.skipAgentSkills && (agentKind === 'claude-code' || Boolean(workingDir));
   const skillParams = {
     ...(workingDir ? { workingDir } : {}),
     ...(opts?.forceReload !== undefined ? { forceReload: opts.forceReload } : {}),

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -109,7 +109,7 @@ export async function loadAllCommands(
       ? (window.electronAPI.deviceLink.invoke(deviceId, 'maker:list-agent-commands', [agentKind]) as Promise<CmdRes>)
       : api.listAgentCommands(agentKind)
   ).catch(() => ({ success: false }));
-  const shouldLoadSkills = !opts?.skipAgentSkills && (agentKind === 'claude-code' || Boolean(workingDir));
+  const shouldLoadSkills = !opts?.skipAgentSkills;
   const skillParams = {
     ...(workingDir ? { workingDir } : {}),
     ...(opts?.forceReload !== undefined ? { forceReload: opts.forceReload } : {}),

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3776,7 +3776,7 @@ interface ElectronAPI {
 
     listAgentSkills: (
       agentKind: 'claude-code' | 'codex',
-      params: { workingDir: string; forceReload?: boolean },
+      params: { workingDir?: string; forceReload?: boolean },
     ) => Promise<{
       success: boolean;
       error?: string;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -470,7 +470,6 @@ import type {
   RemoteSession,
 } from '@/session/types';
 import type {
-  MobileAgentSkillListResult,
   MobileAtResourceItem,
   MobileDesktopCommandListResult,
   MobileModelPricingMap,
@@ -2282,12 +2281,10 @@ export default function SessionScreen() {
       await openLink(deviceId);
       const [builtins, skills, desktop] = await Promise.all([
         maker.listAgentCommands(agentKind),
-        currentSession.workingDir
-          ? maker.listAgentSkills(agentKind, {
-              workingDir: currentSession.workingDir,
-              forceReload: false,
-            })
-          : Promise.resolve({ success: true, skills: [] } satisfies MobileAgentSkillListResult),
+        maker.listAgentSkills(agentKind, {
+          ...(currentSession.workingDir ? { workingDir: currentSession.workingDir } : {}),
+          forceReload: false,
+        }),
         // desktop 命令是 additive 展示(白名单分流不依赖此清单,清单只参与同名 skill
         // 让行仲裁,见 desktopSlashCommands):拉取失败(含老被控端无此通道)静默降级
         // 为不展示,不能拖垮 builtin/skill 两路。

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -53,7 +53,6 @@ import { ScreenBackButton } from '@/components/MobilePrimitives';
 import { PaperPlaneIcon } from '@/components/PaperPlaneIcon';
 import { useDeviceLink } from '@/device-link/DeviceLinkContext';
 import type {
-  MobileAgentSkillListResult,
   MobileAtResourceItem,
   MobileSlashCommand,
   RemoteDirectoryEntry,
@@ -1142,12 +1141,10 @@ export default function NewRemoteSessionScreen() {
       await openLink(selectedDeviceId);
       const [builtins, skills] = await Promise.all([
         maker.listAgentCommands(agentKind),
-        workingDir
-          ? maker.listAgentSkills(agentKind, {
-              workingDir,
-              forceReload: false,
-            })
-          : Promise.resolve({ success: true, skills: [] } satisfies MobileAgentSkillListResult),
+        maker.listAgentSkills(agentKind, {
+          ...(workingDir ? { workingDir } : {}),
+          forceReload: false,
+        }),
       ]);
       return { builtins, skills };
     })

--- a/apps/mobile/src/__tests__/mobileMakerTransport.test.ts
+++ b/apps/mobile/src/__tests__/mobileMakerTransport.test.ts
@@ -271,6 +271,7 @@ describe('mobile maker transport', () => {
     await maker.setExtraDirs('s1', ['/repo/docs']);
     await maker.listAgentCommands('claude-code');
     await maker.listAgentSkills('claude-code', { workingDir: '/repo' });
+    await maker.listAgentSkills('codex', {});
     await maker.scanAtResources('claude-code', { workingDir: '/repo', cap: 2000, query: 'session' });
     await maker.fetchRemoteMedia('xdt-image://local/a.png');
     await maker.transcribeVoice({ ossKey: 'voice-key', mimeType: 'audio/mp4', fileName: 'voice.m4a' });
@@ -312,6 +313,7 @@ describe('mobile maker transport', () => {
       ['maker:set-extra-dirs', ['s1', ['/repo/docs']]],
       ['maker:list-agent-commands', ['claude-code']],
       ['maker:list-agent-skills', ['claude-code', { workingDir: '/repo' }]],
+      ['maker:list-agent-skills', ['codex', {}]],
       ['maker:scan-at-resources', ['claude-code', { workingDir: '/repo', cap: 2000, query: 'session' }]],
       ['device-link:media:fetch', [{ url: 'xdt-image://local/a.png' }]],
       ['device-link:voice:transcribe', [{ ossKey: 'voice-key', mimeType: 'audio/mp4', fileName: 'voice.m4a' }]],

--- a/apps/mobile/src/device-link/mobileMakerTransport.ts
+++ b/apps/mobile/src/device-link/mobileMakerTransport.ts
@@ -392,7 +392,7 @@ export interface MobileMakerTransport {
    * 被控端执行,这里只拿 runId;评审 UI 暂只有桌面端,移动端以系统卡提示去桌面评审。
    */
   learnStart(req: MobileLearnStartRequest): Promise<{ runId: string }>;
-  listAgentSkills(agentKind: MobileAgentKind, opts: { workingDir: string; forceReload?: boolean }): Promise<MobileAgentSkillListResult>;
+  listAgentSkills(agentKind: MobileAgentKind, opts: { workingDir?: string; forceReload?: boolean }): Promise<MobileAgentSkillListResult>;
   scanAtResources(agentKind: MobileAgentKind, opts: { workingDir: string; cap?: number; query?: string }): Promise<MobileAtResourceScanResult>;
   fetchRemoteMedia(url: string, opts?: { skipCache?: boolean; thumbnail?: boolean }): Promise<MobileRemoteMediaFetchResult>;
   transcribeVoice(input: MobileVoiceTranscribeRequest): Promise<MobileVoiceTranscribeResult>;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -2709,14 +2709,61 @@ describe('CodexAgent MCP thread context hooks', () => {
   });
 
   it('uses the home directory to list global skills for a new conversation without a cwd', async () => {
+    const home = os.homedir();
+    MockCodexTransport.onCreate = (transport) => {
+      transport.setMockResponse(Method.SkillsList, {
+        result: {
+          data: [{
+            cwd: home,
+            skills: [
+              {
+                name: 'pr-watch',
+                description: 'Watch PR feedback',
+                path: path.join(home, '.agents', 'skills', 'pr-watch', 'SKILL.md'),
+                scope: 'user',
+                enabled: true,
+              },
+              {
+                name: 'openai-templates:artifact-template-report',
+                description: 'Plugin-internal template',
+                path: path.join(
+                  home,
+                  '.codex',
+                  'plugins',
+                  'cache',
+                  'openai-curated-remote',
+                  'openai-templates',
+                  '0.1.0',
+                  'skills',
+                  'artifact-template-report',
+                  'SKILL.md',
+                ),
+                scope: 'user',
+                enabled: true,
+              },
+              {
+                name: 'skill-creator',
+                description: 'System skill',
+                path: path.join(home, '.codex', 'skills', '.system', 'skill-creator', 'SKILL.md'),
+                scope: 'system',
+                enabled: true,
+              },
+            ],
+            errors: [],
+          }],
+        },
+      });
+    };
     const agent = new CodexAgent(createDeps());
 
-    await expect(agent.listAgentSkills({})).resolves.toMatchObject({ skills: [] });
+    await expect(agent.listAgentSkills({})).resolves.toMatchObject({
+      skills: [expect.objectContaining({ name: 'pr-watch', scope: 'user' })],
+    });
 
     const request = createdTransports[0].lines
       .map((line) => JSON.parse(line) as { method?: string; params?: unknown })
       .find((line) => line.method === Method.SkillsList);
-    expect(request?.params).toMatchObject({ cwds: [os.homedir()] });
+    expect(request?.params).toMatchObject({ cwds: [home] });
 
     await agent.dispose();
   });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -2708,6 +2708,19 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('uses the home directory to list global skills for a new conversation without a cwd', async () => {
+    const agent = new CodexAgent(createDeps());
+
+    await expect(agent.listAgentSkills({})).resolves.toMatchObject({ skills: [] });
+
+    const request = createdTransports[0].lines
+      .map((line) => JSON.parse(line) as { method?: string; params?: unknown })
+      .find((line) => line.method === Method.SkillsList);
+    expect(request?.params).toMatchObject({ cwds: [os.homedir()] });
+
+    await agent.dispose();
+  });
+
   it('starts a cold OAuth host before account rate-limit RPCs', async () => {
     const rateLimits = {
       rateLimits: { planType: 'plus', primary: { usedPercent: 100, windowMinutes: 300 } },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1160,10 +1160,11 @@ export class CodexAgent extends BaseAgent {
    * 只是包成新的 AgentSkillCommand 形状(kind='agent-skill')。
    */
   override async listAgentSkills(opts: ListAgentSkillsOptions): Promise<ListAgentSkillsResult> {
-    // Codex app-server 的 skills/list 需要 cwd；无项目的新对话保持原先的空列表语义。
-    if (!opts.workingDir) return { skills: [] };
+    // Codex app-server 的 skills/list 强制要求 cwd；无项目的新对话用 HOME 作为
+    // 查询上下文，既能发现全局 skills，又不会误带任意项目的 repo skills。
+    const workingDir = opts.workingDir || os.homedir();
     try {
-      const { skills, errors } = await this.listSkillsForCwd(opts.workingDir, opts.forceReload ?? false);
+      const { skills, errors } = await this.listSkillsForCwd(workingDir, opts.forceReload ?? false);
       const out: ListAgentSkillsResult = {
         skills: skills
           .filter((skill) => skill.enabled)

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -653,6 +653,16 @@ function skillDescription(skill: SkillMetadata): string | undefined {
   );
 }
 
+function isPaletteVisibleCodexSkill(skill: SkillMetadata): boolean {
+  if (!skill.enabled || skill.scope === 'system' || skill.scope === 'admin') return false;
+
+  // Codex plugins can contribute internal skills and currently report them as scope=user.
+  // They remain available to Codex's own dispatch, but Cindy's slash palette should only
+  // expose installed user/repo skills instead of every plugin implementation detail.
+  const normalizedPath = skill.path.replace(/\\/g, '/');
+  return !/\/plugins\/cache\/[^/]+\/[^/]+\/[^/]+\/skills\//i.test(normalizedPath);
+}
+
 function parseLeadingSlashToken(text: string): { name: string; rest: string } | null {
   const match = text.match(/^\/([^\s/]+)(?:\s+([\s\S]*))?$/);
   if (!match?.[1]) return null;
@@ -1167,7 +1177,7 @@ export class CodexAgent extends BaseAgent {
       const { skills, errors } = await this.listSkillsForCwd(workingDir, opts.forceReload ?? false);
       const out: ListAgentSkillsResult = {
         skills: skills
-          .filter((skill) => skill.enabled)
+          .filter(isPaletteVisibleCodexSkill)
           .map((skill) => ({
             kind: 'agent-skill' as const,
             name: skill.name,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1160,6 +1160,8 @@ export class CodexAgent extends BaseAgent {
    * 只是包成新的 AgentSkillCommand 形状(kind='agent-skill')。
    */
   override async listAgentSkills(opts: ListAgentSkillsOptions): Promise<ListAgentSkillsResult> {
+    // Codex app-server 的 skills/list 需要 cwd；无项目的新对话保持原先的空列表语义。
+    if (!opts.workingDir) return { skills: [] };
     try {
       const { skills, errors } = await this.listSkillsForCwd(opts.workingDir, opts.forceReload ?? false);
       const out: ListAgentSkillsResult = {

--- a/packages/maker-core/src/agents/shared/palette-scanner.test.ts
+++ b/packages/maker-core/src/agents/shared/palette-scanner.test.ts
@@ -30,6 +30,45 @@ describe('scanWorkspaceFileResources', () => {
 });
 
 describe('scanClaudeSlashCommands', () => {
+  it('lists global Claude commands and skills without a working directory', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-palette-'));
+    const home = path.join(root, 'home');
+    const commandsDir = path.join(home, '.claude', 'commands');
+    const skillDir = path.join(home, '.claude', 'skills', 'global-only');
+
+    vi.stubEnv('HOME', home);
+    vi.stubEnv('USERPROFILE', home);
+    try {
+      await mkdir(commandsDir, { recursive: true });
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(path.join(commandsDir, 'global-command.md'), '# Global command\n', 'utf8');
+      await writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        '---\ndescription: available without a project\n---\n\nbody\n',
+        'utf8',
+      );
+
+      const commands = await scanClaudeSlashCommands();
+
+      expect(commands).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'global-command',
+          source: 'user',
+          scope: 'global',
+        }),
+        expect.objectContaining({
+          name: 'global-only',
+          description: 'available without a project',
+          source: 'skill',
+          scope: 'global',
+        }),
+      ]));
+    } finally {
+      vi.unstubAllEnvs();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('includes skill directories that are symlinked into the global Claude skills root', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-palette-'));
     const home = path.join(root, 'home');

--- a/packages/maker-core/src/agents/shared/palette-scanner.ts
+++ b/packages/maker-core/src/agents/shared/palette-scanner.ts
@@ -303,19 +303,19 @@ async function scanClaudeSkillDirs(
   return results;
 }
 
-export async function scanClaudeSlashCommands(workingDir: string): Promise<AgentSlashCommand[]> {
-  if (!workingDir || !path.isAbsolute(workingDir) || !(await isDirectory(workingDir))) {
-    return [];
-  }
-
+export async function scanClaudeSlashCommands(workingDir?: string): Promise<AgentSlashCommand[]> {
   const home = os.homedir();
   const merged = new Map<string, AgentSlashCommand>();
   const discovered = [
     ...(await scanClaudeCommandFiles(path.join(home, '.claude', 'commands'), 'global')),
     ...(await scanClaudeSkillDirs(path.join(home, '.claude', 'skills'), 'global')),
-    ...(await scanClaudeCommandFiles(path.join(workingDir, '.claude', 'commands'), 'project')),
-    ...(await scanClaudeSkillDirs(path.join(workingDir, '.claude', 'skills'), 'project')),
   ];
+  if (workingDir && path.isAbsolute(workingDir) && await isDirectory(workingDir)) {
+    discovered.push(
+      ...(await scanClaudeCommandFiles(path.join(workingDir, '.claude', 'commands'), 'project')),
+      ...(await scanClaudeSkillDirs(path.join(workingDir, '.claude', 'skills'), 'project')),
+    );
+  }
 
   for (const cmd of discovered) {
     merged.set(cmd.name, cmd);

--- a/packages/maker-core/src/types/palette.ts
+++ b/packages/maker-core/src/types/palette.ts
@@ -64,7 +64,8 @@ export interface AgentSkillCommand {
 export type UnifiedCommand = DesktopCommandMeta | AgentBuiltinCommand | AgentSkillCommand;
 
 export interface ListAgentSkillsOptions {
-  workingDir: string;
+  /** Omit to list only agent-global skills without a project scope. */
+  workingDir?: string;
   forceReload?: boolean;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复未绑定项目目录的新对话无法在斜杠命令面板发现全局技能的问题。Claude 在无工作目录时继续扫描全局 commands/skills；Codex 使用用户主目录查询全局 skills，并过滤 system/admin 与插件缓存内部技能，避免 `openai-templates:*` 等实现细节污染面板。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#928
- 本 PR 包含：Claude/Codex 新对话的全局技能发现、Codex 内部技能过滤、SSH/device-link 技能来源区分及回归测试。
- 明确不包含：技能执行协议、插件内部调度、界面布局与视觉样式调整。
- 用户可见变化：无项目目录的新对话可发现 `/pr-watch` 等全局技能；Codex 面板不再显示插件缓存中的 `openai-templates:*`。
- 是否存在 breaking change：无。

### UI 变化

不涉及视觉、布局、动效或文案变化；仅修正斜杠命令面板的数据来源与过滤行为。Windows CN 隔离 dev 已由用户分别验收 Claude 和 Codex。

- 引用的设计规范：不涉及；未修改样式、设计 token、布局或交互组件结构。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，Desktop、Mobile、maker-core 及 protocol 等全部 required unit workspaces 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：命令成功；该 package 当前无 typecheck script，按 --if-present 跳过。

pnpm check:dco
结果：通过，4 个 PR commit 均已签名。
```

### 手工验证

- Windows、CN、隔离 userData 的 Desktop dev。
- Claude 新对话输入 `/pr` 可发现 `pr-watch`。
- Codex 新对话输入 `/pr` 可发现 `pr-watch`。
- 真实 Codex skills/list 复查：`pr-watch` 保留，`openai-templates:*` 数量为 0。

### 未执行的验证

- 未单独目检 Dark 模式；本次没有样式、颜色、布局或文案改动。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：斜杠命令面板技能来源过滤行为。

### 影响与回滚

- 影响范围：Desktop 本地新对话、SSH/device-link 会话的技能列表发现；maker-core 的 Claude/Codex 技能枚举。Codex 插件缓存技能仅从 Cindy 的斜杠面板隐藏，仍保留给 Codex 内部调度。
- 回滚 / 降级方式：回滚本 PR 即恢复原有技能枚举行为。
- 移动端冷更：不会触发。本 PR 未修改 `apps/mobile` 原生配置、原生依赖、config plugin、原生模块或 runtime fingerprint 输入。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因