### PR TITLE
fix(desktop): 登出后设备目录停在终态,本地模式不再卡加载中

### DIFF
--- a/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// useDeviceLinkDeviceList 是模块级共享单例(devices / started / initialRequestSettled 都在模块作用域),
+// 每个用例必须拿一份全新模块状态,否则上一个用例的 started=true 会让后面的用例不再拉取。
+beforeEach(() => {
+  vi.resetModules();
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -49,6 +55,104 @@ describe('useDeviceLinkDeviceList initial request', () => {
     expect(result.current).toEqual({ devices: null, settled: false });
 
     await act(async () => resolveRetry?.({ devices: [] }));
+    await waitFor(() => expect(result.current).toEqual({ devices: [], settled: true }));
+  });
+
+  // 回归 #797:云端登录 → 登出(relay 'stopped')→ 进入本地模式后不会再有 'online',
+  // 设备目录必须停在终态,否则 shouldWaitForRemoteSessionBootstrap 恒为 true,
+  // 侧栏「对话」分区会一直显示「加载中…」直到冷重启。
+  it('settles the directory on relay stop and stays settled without a later online', async () => {
+    let statusChanged:
+      ((payload: { status: 'stopped' | 'connecting' | 'online' }) => void) | undefined;
+    const listDevices = vi.fn().mockResolvedValue({
+      devices: [
+        {
+          deviceId: 'dev-a',
+          name: 'Mac A',
+          platform: 'darwin',
+          online: true,
+          remoteControlEnabled: true,
+          controlEnabled: true,
+          isSelf: false,
+        } as unknown as DeviceLinkDeviceView,
+      ],
+    });
+    vi.stubGlobal('electronAPI', {
+      deviceLink: {
+        listDevices,
+        onPresenceChanged: vi.fn(),
+        onStatusChanged: vi.fn(
+          (callback: (payload: { status: 'stopped' | 'connecting' | 'online' }) => void) => {
+            statusChanged = callback;
+          },
+        ),
+        onControlTargetChanged: vi.fn(),
+      },
+    });
+
+    const { useDeviceLinkDeviceList, useDeviceLinkDeviceListSettled } =
+      await import('@/features/device-link/useDeviceLinkDeviceList');
+    const useProbe = (): { devices: DeviceLinkDeviceView[] | null; settled: boolean } => ({
+      devices: useDeviceLinkDeviceList(),
+      settled: useDeviceLinkDeviceListSettled(),
+    });
+    const { result, unmount } = renderHook(useProbe);
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.devices).toHaveLength(1);
+
+    // 登出:清掉上一账号的远程机器(devices 回 null → 切换栏隐藏),但目录仍是终态。
+    act(() => statusChanged?.({ status: 'stopped' }));
+    expect(result.current).toEqual({ devices: null, settled: true });
+    expect(listDevices).toHaveBeenCalledTimes(1);
+
+    // 本地模式重挂侧栏(共享单例已 started)也不得退回未结算态。
+    unmount();
+    const local = renderHook(useProbe);
+    expect(local.result.current).toEqual({ devices: null, settled: true });
+    expect(listDevices).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-enters loading when a cloud account logs back in after a relay stop', async () => {
+    let statusChanged:
+      ((payload: { status: 'stopped' | 'connecting' | 'online' }) => void) | undefined;
+    let resolveRelogin: ((value: { devices: DeviceLinkDeviceView[] }) => void) | undefined;
+    const relogin = new Promise<{ devices: DeviceLinkDeviceView[] }>((resolve) => {
+      resolveRelogin = resolve;
+    });
+    const listDevices = vi
+      .fn()
+      .mockResolvedValueOnce({ devices: [] })
+      .mockReturnValueOnce(relogin);
+    vi.stubGlobal('electronAPI', {
+      deviceLink: {
+        listDevices,
+        onPresenceChanged: vi.fn(),
+        onStatusChanged: vi.fn(
+          (callback: (payload: { status: 'stopped' | 'connecting' | 'online' }) => void) => {
+            statusChanged = callback;
+          },
+        ),
+        onControlTargetChanged: vi.fn(),
+      },
+    });
+
+    const { useDeviceLinkDeviceList, useDeviceLinkDeviceListSettled } =
+      await import('@/features/device-link/useDeviceLinkDeviceList');
+    const { result } = renderHook(() => ({
+      devices: useDeviceLinkDeviceList(),
+      settled: useDeviceLinkDeviceListSettled(),
+    }));
+    await waitFor(() => expect(result.current).toEqual({ devices: [], settled: true }));
+
+    act(() => statusChanged?.({ status: 'stopped' }));
+    expect(result.current).toEqual({ devices: null, settled: true });
+
+    // 重新登录:relay 'online' 重新拉取,首快照落地前照旧回到 loading。
+    act(() => statusChanged?.({ status: 'online' }));
+    expect(listDevices).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ devices: null, settled: false });
+
+    await act(async () => resolveRelogin?.({ devices: [] }));
     await waitFor(() => expect(result.current).toEqual({ devices: [], settled: true }));
   });
 });

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
@@ -19,7 +19,11 @@ import { useSyncExternalStore } from 'react';
 let devices: DeviceLinkDeviceView[] | null = null;
 const subs = new Set<() => void>();
 let started = false;
-/** 当前账号 / relay 生命周期内，至少一次最新的 listDevices 请求已经 resolve 或 reject。 */
+/**
+ * 设备目录是否已进入终态 —— 上层(shouldWaitForRemoteSessionBootstrap)据此决定还要不要等。
+ * 两种终态:最新一次 listDevices 已 resolve / reject(见 setDevices / markInitialRequestSettled),
+ * 或 relay 已停(登出 / 本地模式,见 clearDevices)。false 必须意味着「还有结果会来」。
+ */
 let initialRequestSettled = false;
 /**
  * 加载代次:**每次 refresh 发起**与**每次清空(登出 / relay stop)**都自增,作废所有更早的在途
@@ -84,13 +88,23 @@ function setDevices(next: DeviceLinkDeviceView[]): void {
   subs.forEach((fn) => fn());
 }
 
-/** 清空缓存设备,回到「未加载」态(null → 切换栏隐藏)。登出 / relay 停止时调用。 */
+/**
+ * 清空缓存设备(null → 切换栏隐藏)。登出 / relay 停止时调用。
+ *
+ * `initialRequestSettled` **置 true**:link 已停 = 此刻确定没有可用的远端设备目录,而且在途
+ * 请求刚被 loadGeneration 作废、不会再有结果落地 —— 这与 refresh 失败兜底同一个终态
+ * (devices=null + settled=true)。若像早先那样置回 false,登出后进入本地模式 / 保持未登录
+ * 就再也收不到 relay 'online' 来重新结算,shouldWaitForRemoteSessionBootstrap 恒为 true,
+ * 侧栏「对话」分区卡在「加载中…」直到冷重启(#797)。
+ * 重新登录不受影响:relay 'online' → refresh() 会因 `devices === null && initialRequestSettled`
+ * 主动退回 loading,远程设备首快照的等待行为保持原样。
+ */
 function clearDevices(): void {
   loadGeneration += 1; // 作废所有在途 listDevices 响应(见 loadGeneration 注释)。
-  const changed = devices !== null || initialRequestSettled;
+  const changed = devices !== null || !initialRequestSettled;
   if (!changed) return;
   devices = null;
-  initialRequestSettled = false;
+  initialRequestSettled = true;
   subs.forEach((fn) => fn());
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

云端账号登出后点「跳过登录」进入本地模式,左侧「对话」分区会一直显示「加载中…」,重启客户端才恢复成「暂无对话」。这是错误的加载态,不是会话数据丢失。

根因在 `useDeviceLinkDeviceList` 这个模块级共享单例:relay `stopped`(登出 / 停服)时 `clearDevices()` 把 `initialRequestSettled` 置回 `false`,但 `started` 仍为 `true`,重挂侧栏时 `ensureStarted()` 直接返回、不再跑 `refresh()`。本地模式和未登录状态收不到 relay `online`,设备目录就永远无法重新结算 → `shouldWaitForRemoteSessionBootstrap()` 恒为 `true` → `CCAgentSidebarUpper` 的 `isLoadingSidebarSessions` 一直为 true。冷重启会重建模块状态并重新 `listDevices()`,请求快速失败后被标记为已结算,所以重启后显示正确空态。

修法是让「`settled=false`」重新只表示「还有结果会来」:`clearDevices()` 把设备目录标成终态(`devices=null` + `settled=true`)—— link 已停即确定没有可用的远端目录,而且在途请求刚被 `loadGeneration` 作废、不会再有结果落地,这与既有的「拉取失败兜底」是同一个终态。重新登录路径不变:relay `online` → `refresh()` 仍会因 `devices === null && initialRequestSettled` 主动退回 loading,远程设备首快照的等待行为原样保留。

`devices` 仍然回到 `null`(切换栏隐藏),上一账号的远程机器不会残留;远程会话镜像由 `useDeviceLinkRemoteProjects` 在 `isAuthenticated` 翻转时的 effect cleanup(`remoteProjectsStore.clear()`)清掉,不受本 PR 影响。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#797
- 本 PR 包含:`clearDevices()` 的终态修正(1 行语义 + 1 行判定)、相关注释,以及两个回归用例(测试文件按用例重置共享单例的模块状态)。
- 明确不包含:不改 `shouldWaitForRemoteSessionBootstrap()` 的判定口径,不改设备目录的拉取时机与事件订阅,不动 `useSelectableIdsForNormalize` 在 `devices === null` 时不裁剪持久化勾选集的现有行为(见下方备注)。
- 用户可见变化:云端登出后进入本地模式,侧栏「对话」分区立即显示本地会话;本地没有会话时显示「暂无对话」。不再卡「加载中…」,也不需要重启。
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及:仅修正加载态的判定逻辑,「加载中」与「暂无对话」两种既有状态的视觉、交互与文案均未改动,没有新增或调整任何组件与样式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
结果:3 passed(含本 PR 新增的 2 个回归用例)

pnpm --filter desktop run --if-present typecheck
结果:通过(tsc --noEmit)

pnpm test:unit
结果:全量通过,无 FAIL(desktop 与各 package 均 PASS;6 个无可收集测试的 workspace 按既有配置 SKIP)
```

新增回归用例覆盖 Issue 的验收要求:

- `online → stopped → 本地模式重挂载`(且没有后续 `online`):设备目录保持终态,且不重复 `listDevices()`;
- `stopped → 重新登录`(`online`):仍正常退回 loading,首快照落地后结算。

### 手工验证

已用 `pnpm restart:desktop:remote --isolated` 起隔离沙箱 dev(region `global`,userData `Cindy-dev`),交由提交者按 Issue 复现步骤实机走查(登录 → 登出 → 跳过登录 → 看侧栏)。实机结论以 review 期间的回帖为准,本 PR 描述不预先声称实机已通过。

### 未执行的验证

- macOS 实机未验证:本地只有 Windows 环境。改动是 renderer 的纯状态机逻辑,无平台分支,两端行为一致。
- Light / Dark 双模式目检未执行:本次没有任何颜色、样式或组件改动,沿用既有的空态与加载态渲染。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 Desktop renderer 的 device-link 设备目录加载态,以及依赖它的侧栏会话加载态。不涉及 main 进程、数据库、协议与移动端。
- 移动端冷更分析:未触碰 `apps/mobile` 的任何 runtime fingerprint 输入(`app.json` / `app.config.js` / `eas.json` / `apps/mobile/package.json` / `plugins/` / `modules/`),改动全部落在 `apps/desktop/src/renderer/`,不会触发冷更。
- 回滚 / 降级方式:revert 本 PR 即可,`clearDevices()` 回到原语义,无数据或状态残留。

### 备注

登出前只勾选了某台远程机器的用户,进入本地模式后侧栏仍会按该勾选过滤而显示空列表(`useSelectableIdsForNormalize` 在 `devices === null` 时刻意不裁剪持久化勾选集,以免出现「重启后勾选恢复成全部」)。这是本 PR 之前就存在、被错误加载态掩盖的独立行为,默认作用域「所有机器」不受影响,故不在本 PR 范围内改动。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因