### PR TITLE
fix(billing): 区分无订阅与账本历史不完整

### DIFF
--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -1487,20 +1487,22 @@ function BillingOfferDialog({
                         )}
                       >
                         <div className="min-w-0 flex-1">
-                          <div className="flex flex-wrap items-center gap-2">
+                          <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-center gap-2">
                             <p className="truncate text-13 font-medium text-[var(--text-primary)]">
                               {product.name}
                             </p>
-                            {currentPlan && (
-                              <span className="rounded-full bg-[var(--surface)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
-                                {t('billing.catalog.currentPlan')}
-                              </span>
-                            )}
-                            {unavailableReason && (
-                              <span className="rounded-full bg-[var(--surface-chip)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
-                                {t(`billing.catalog.unavailableReasons.${unavailableReason}`)}
-                              </span>
-                            )}
+                            <div className="min-w-0">
+                              {currentPlan && (
+                                <span className="rounded-full bg-[var(--surface)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
+                                  {t('billing.catalog.currentPlan')}
+                                </span>
+                              )}
+                              {unavailableReason && (
+                                <span className="rounded-full bg-[var(--surface-chip)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
+                                  {t(`billing.catalog.unavailableReasons.${unavailableReason}`)}
+                                </span>
+                              )}
+                            </div>
                           </div>
                         </div>
                         <div className="flex shrink-0 items-center gap-3">

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -784,7 +784,13 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
                 usageDetailsUnavailable ? t('billing.usage.detailsUnavailable') : undefined
               }
             >
-              <UsageBreakdownCard usage={creditUsage} balance={balance} />
+              <UsageBreakdownCard
+                usage={creditUsage}
+                balance={balance}
+                hasNoActiveSubscription={
+                  !loadingSubscription && !subscriptionError && currentSubscription === null
+                }
+              />
             </BillingGroup>
           )}
 
@@ -1161,9 +1167,11 @@ function BalanceOverviewCard({
 function UsageBreakdownCard({
   usage,
   balance,
+  hasNoActiveSubscription,
 }: {
   usage: ModelAccessCreditUsage | null;
   balance: ModelAccessBalance | null;
+  hasNoActiveSubscription: boolean;
 }) {
   const { t, i18n } = useTranslation();
   const billingLocale = i18n.resolvedLanguage ?? i18n.language;
@@ -1181,7 +1189,14 @@ function UsageBreakdownCard({
               ['purchased', usage.purchased],
               ['promotional', usage.promotional],
             ] as const
-          ).map(([key, pool]) => <CreditPoolRow key={key} label={poolLabels[key]} pool={pool} />)
+          ).map(([key, pool]) => (
+            <CreditPoolRow
+              key={key}
+              label={poolLabels[key]}
+              pool={pool}
+              noActiveSubscription={key === 'plan' && hasNoActiveSubscription}
+            />
+          ))
         : balance
           ? (
               [
@@ -1205,7 +1220,15 @@ function UsageBreakdownCard({
   );
 }
 
-function CreditPoolRow({ label, pool }: { label: string; pool: ModelAccessCreditPoolUsage }) {
+function CreditPoolRow({
+  label,
+  pool,
+  noActiveSubscription,
+}: {
+  label: string;
+  pool: ModelAccessCreditPoolUsage;
+  noActiveSubscription: boolean;
+}) {
   const { t, i18n } = useTranslation();
   const billingLocale = i18n.resolvedLanguage ?? i18n.language;
   const percent = usagePercent(pool);
@@ -1215,7 +1238,9 @@ function CreditPoolRow({ label, pool }: { label: string; pool: ModelAccessCredit
           used: formatMoney(pool.used, BILLING_CURRENCY, billingLocale),
           total: formatMoney(pool.total, BILLING_CURRENCY, billingLocale),
         })
-      : t('billing.usage.historyUnavailable');
+      : noActiveSubscription
+        ? t('billing.usage.noPlanCredits')
+        : t('billing.usage.historyUnavailable');
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 px-5 py-3.5">
       <div className="min-w-0">

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -1220,6 +1220,10 @@ function UsageBreakdownCard({
   );
 }
 
+function isZeroCreditAmount(amount: string): boolean {
+  return /^[+-]?0+(?:\.0+)?$/.test(amount.trim());
+}
+
 function CreditPoolRow({
   label,
   pool,
@@ -1238,7 +1242,7 @@ function CreditPoolRow({
           used: formatMoney(pool.used, BILLING_CURRENCY, billingLocale),
           total: formatMoney(pool.total, BILLING_CURRENCY, billingLocale),
         })
-      : noActiveSubscription
+      : noActiveSubscription && isZeroCreditAmount(pool.remaining)
         ? t('billing.usage.noPlanCredits')
         : t('billing.usage.historyUnavailable');
   return (
@@ -1636,7 +1640,7 @@ function StateCard({
 }: {
   icon: React.ReactNode;
   title: string;
-  description: string;
+  description?: string;
   action?: React.ReactNode;
 }) {
   return (
@@ -1645,7 +1649,7 @@ function StateCard({
         {icon}
       </div>
       <p className="mt-4 text-sm font-medium">{title}</p>
-      <p className="mt-1 text-12 text-[var(--text-secondary)]">{description}</p>
+      {description && <p className="mt-1 text-12 text-[var(--text-secondary)]">{description}</p>}
       {action}
     </div>
   );

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -1487,22 +1487,31 @@ function BillingOfferDialog({
                         )}
                       >
                         <div className="min-w-0 flex-1">
-                          <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-center gap-2">
+                          <div
+                            className={cn(
+                              'grid items-center gap-2',
+                              currentPlan || unavailableReason
+                                ? 'grid-cols-[6rem_minmax(0,1fr)]'
+                                : 'grid-cols-[minmax(0,1fr)]',
+                            )}
+                          >
                             <p className="truncate text-13 font-medium text-[var(--text-primary)]">
                               {product.name}
                             </p>
-                            <div className="min-w-0">
-                              {currentPlan && (
-                                <span className="rounded-full bg-[var(--surface)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
-                                  {t('billing.catalog.currentPlan')}
-                                </span>
-                              )}
-                              {unavailableReason && (
-                                <span className="rounded-full bg-[var(--surface-chip)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
-                                  {t(`billing.catalog.unavailableReasons.${unavailableReason}`)}
-                                </span>
-                              )}
-                            </div>
+                            {(currentPlan || unavailableReason) && (
+                              <div className="min-w-0">
+                                {currentPlan && (
+                                  <span className="rounded-full bg-[var(--surface)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
+                                    {t('billing.catalog.currentPlan')}
+                                  </span>
+                                )}
+                                {unavailableReason && (
+                                  <span className="rounded-full bg-[var(--surface-chip)] px-2 py-0.5 text-10 font-medium text-[var(--text-secondary)]">
+                                    {t(`billing.catalog.unavailableReasons.${unavailableReason}`)}
+                                  </span>
+                                )}
+                              </div>
+                            )}
                           </div>
                         </div>
                         <div className="flex shrink-0 items-center gap-3">

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -1450,7 +1450,6 @@ function BillingOfferDialog({
               <StateCard
                 icon={<PackageOpen size={22} />}
                 title={t('billing.catalog.emptyTitle')}
-                description={t('billing.catalog.emptyDescription')}
               />
             ) : (
               <>

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -363,6 +363,26 @@ describe('BillingPage remote catalog rendering', () => {
     expect(screen.getByText('billing.usage.detailsUnavailable')).toBeTruthy();
   });
 
+  it('does not describe missing plan credits as incomplete history when there is no subscription', async () => {
+    window.electronAPI.billing.getCreditUsage = vi.fn(async () => ({
+      available: '3',
+      plan: { remaining: '0', used: null, total: null },
+      purchased: { remaining: '0', used: '0', total: '0' },
+      promotional: { remaining: '3', used: '0', total: '3' },
+      promotionalGrants: [],
+      promotionalGrantsComplete: true,
+      promotionalGrantConsistency: 'OBSERVED' as const,
+      ledgerUpdatedAt: null,
+      scale: 9 as const,
+      observedAt: '2026-07-23T12:00:00Z',
+    }));
+
+    render(<BillingPage />);
+
+    expect(await screen.findByText('billing.usage.noPlanCredits')).toBeTruthy();
+    expect(screen.queryByText('billing.usage.historyUnavailable')).toBeNull();
+  });
+
   it('shows current plan price, included credits, status, and renewal date', async () => {
     i18n.resolvedLanguage = 'ja';
     window.electronAPI.billing.getCurrentSubscription = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -383,6 +383,26 @@ describe('BillingPage remote catalog rendering', () => {
     expect(screen.queryByText('billing.usage.historyUnavailable')).toBeNull();
   });
 
+  it('keeps nonzero plan balances truthful when there is no subscription', async () => {
+    window.electronAPI.billing.getCreditUsage = vi.fn(async () => ({
+      available: '3',
+      plan: { remaining: '3', used: null, total: null },
+      purchased: { remaining: '0', used: '0', total: '0' },
+      promotional: { remaining: '0', used: '0', total: '0' },
+      promotionalGrants: [],
+      promotionalGrantsComplete: true,
+      promotionalGrantConsistency: 'OBSERVED' as const,
+      ledgerUpdatedAt: null,
+      scale: 9 as const,
+      observedAt: '2026-07-23T12:00:00Z',
+    }));
+
+    render(<BillingPage />);
+
+    expect(await screen.findByText('billing.usage.historyUnavailable')).toBeTruthy();
+    expect(screen.queryByText('billing.usage.noPlanCredits')).toBeNull();
+  });
+
   it('shows current plan price, included credits, status, and renewal date', async () => {
     i18n.resolvedLanguage = 'ja';
     window.electronAPI.billing.getCurrentSubscription = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/features/billing/__tests__/money.test.ts
+++ b/apps/desktop/src/renderer/features/billing/__tests__/money.test.ts
@@ -50,6 +50,10 @@ describe('formatBillingAmount', () => {
   it('falls back to the raw amount when the value is not numeric', () => {
     expect(formatBillingAmount('not-a-number', 'usd')).toBe('not-a-number USD');
   });
+
+  it('uses the dollar symbol for USD in Chinese', () => {
+    expect(formatBillingAmount('3', 'usd', 'zh-CN')).toBe('$3.00');
+  });
 });
 
 describe('formatBillingMinorAmount', () => {

--- a/apps/desktop/src/renderer/features/billing/money.ts
+++ b/apps/desktop/src/renderer/features/billing/money.ts
@@ -6,6 +6,15 @@
 
 const DECIMAL_PATTERN = /^([+-]?)(\d+)(?:\.(\d+))?$/;
 
+function billingCurrencyFormatOptions(currency: string): Intl.NumberFormatOptions {
+  const normalizedCurrency = currency.toUpperCase();
+  return {
+    style: 'currency',
+    currency: normalizedCurrency,
+    ...(normalizedCurrency === 'USD' ? { currencyDisplay: 'narrowSymbol' } : {}),
+  };
+}
+
 function roundToMinorUnits(amount: string, digits: number): bigint | null {
   const matched = DECIMAL_PATTERN.exec(amount.trim());
   if (!matched) return null;
@@ -50,10 +59,7 @@ function formatMinorUnits(
 
 export function formatBillingAmount(amount: string, currency: string, locale?: string): string {
   try {
-    const fmt = new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: currency.toUpperCase(),
-    });
+    const fmt = new Intl.NumberFormat(locale, billingCurrencyFormatOptions(currency));
     const digits = fmt.resolvedOptions().maximumFractionDigits ?? 2;
     const minor = roundToMinorUnits(amount, digits);
     return minor === null
@@ -71,10 +77,7 @@ export function formatBillingMinorAmount(
 ): string {
   try {
     if (!Number.isSafeInteger(minor)) return `${minor} ${currency.toUpperCase()}`;
-    const fmt = new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: currency.toUpperCase(),
-    });
+    const fmt = new Intl.NumberFormat(locale, billingCurrencyFormatOptions(currency));
     const digits = fmt.resolvedOptions().maximumFractionDigits ?? 2;
     return formatMinorUnits(BigInt(minor), fmt, digits);
   } catch {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7226,6 +7226,7 @@
       "poolDetail": "Used {{used}} · Total {{total}}",
       "remaining": "Remaining",
       "progressLabel": "{{label}} usage",
+      "noPlanCredits": "No subscription credits because there is no active subscription.",
       "historyUnavailable": "Usage history is incomplete. Only the remaining balance is available.",
       "detailsUnavailable": "Usage details are temporarily unavailable. Current balances are shown instead.",
       "promotionalDetails": {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7270,8 +7270,7 @@
     "catalog": {
       "errorTitle": "Plans are temporarily unavailable",
       "errorDescription": "Check your connection and retry. Local fallback plans will not be used.",
-      "emptyTitle": "No Plans Available",
-      "emptyDescription": "The server has not published any plans yet.",
+      "emptyTitle": "Coming soon. Stay tuned.",
       "currentPlan": "Current Plan",
       "unavailableReasons": {
         "OFFER_COMING_SOON": "Coming Soon",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7259,8 +7259,7 @@
     "catalog": {
       "errorTitle": "プランを取得できません",
       "errorDescription": "接続を確認して再試行してください。ローカルの代替プランは表示しません。",
-      "emptyTitle": "プランはまだありません",
-      "emptyDescription": "サーバーで公開中のプランはまだありません。",
+      "emptyTitle": "近日公開予定です。お楽しみに。",
       "currentPlan": "現在のプラン",
       "unavailableReasons": {
         "OFFER_COMING_SOON": "近日提供",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7215,6 +7215,7 @@
       "poolDetail": "使用済み {{used}} · 合計 {{total}}",
       "remaining": "残り",
       "progressLabel": "{{label}}の使用量",
+      "noPlanCredits": "有効なサブスクリプションがないため、サブスクリプションクレジットはありません。",
       "historyUnavailable": "使用履歴が完全ではないため、残りのクレジットのみ表示しています。",
       "detailsUnavailable": "使用量の詳細を取得できないため、現在の残高のみ表示しています。",
       "promotionalDetails": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7259,8 +7259,7 @@
     "catalog": {
       "errorTitle": "요금제를 불러올 수 없습니다",
       "errorDescription": "네트워크를 확인하고 다시 시도하세요. 로컬 대체 요금제는 표시하지 않습니다.",
-      "emptyTitle": "요금제가 없습니다",
-      "emptyDescription": "서버에서 공개한 요금제가 아직 없습니다.",
+      "emptyTitle": "곧 출시됩니다. 기대해 주세요.",
       "currentPlan": "현재 요금제",
       "unavailableReasons": {
         "OFFER_COMING_SOON": "출시 예정",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7215,6 +7215,7 @@
       "poolDetail": "사용 {{used}} · 전체 {{total}}",
       "remaining": "잔여",
       "progressLabel": "{{label}} 사용량",
+      "noPlanCredits": "활성 구독이 없어 구독 크레딧이 없습니다.",
       "historyUnavailable": "사용 기록이 완전하지 않아 잔여 크레딧만 표시합니다.",
       "detailsUnavailable": "사용량 상세를 불러올 수 없어 현재 잔액만 표시합니다.",
       "promotionalDetails": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7216,6 +7216,7 @@
       "poolDetail": "已用 {{used}} · 总额 {{total}}",
       "remaining": "剩余",
       "progressLabel": "{{label}}使用进度",
+      "noPlanCredits": "当前无生效订阅，因此没有订阅点数。",
       "historyUnavailable": "历史记录不完整，暂时仅显示剩余余额。",
       "detailsUnavailable": "用量明细暂时不可用，当前仅显示各类余额。",
       "promotionalDetails": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7260,8 +7260,7 @@
     "catalog": {
       "errorTitle": "暂时无法获取套餐",
       "errorDescription": "请检查网络后重试。不会使用本地套餐替代。",
-      "emptyTitle": "当前暂无套餐",
-      "emptyDescription": "服务端尚未配置公开的套餐。",
+      "emptyTitle": "即将上线，敬请期待",
       "currentPlan": "当前套餐",
       "unavailableReasons": {
         "OFFER_COMING_SOON": "敬请期待",


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 Desktop Billing 设置页的三个展示问题：新账号无订阅且订阅点数为零时不再误提示“历史记录不完整”；没有可购买套餐时显示“即将上线，敬请期待”；USD 金额统一显示为 `$` 而不是 `US$`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：新注册账号的订阅点数文案误导、套餐空态文案与 USD 金额显示
- 本 PR 包含：无订阅零余额的专用文案与四语种翻译；订阅和点数套餐共用的标题式“即将上线”空态；USD 窄货币符号；相应回归测试
- 明确不包含：服务端账本、套餐目录和余额计算逻辑变更
- 用户可见变化：无订阅但存在非零订阅点数余额时仍如实提示历史不完整；没有套餐时仅显示“即将上线，敬请期待”；USD 显示为 `$3.00`
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：遵循 `docs/design-rules/DESIGN.md` §10 的主题 token 约束；空态沿用既有 `StateCard`、语义色 token、间距与排版，只移除次级说明文本，不引入新的视觉样式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：通过

pnpm --dir apps/desktop exec vitest run src/renderer/features/billing/__tests__/BillingPage.test.tsx src/renderer/features/billing/__tests__/money.test.ts --reporter=dot
结果：2 个测试文件、56 个测试全部通过
```

### 手工验证

- 未执行：当前会话没有可用的 Desktop UI 控制通道，未对 Light / Dark 模式作实机目检。

### 未执行的验证

- 未启动 Desktop 进行 Light / Dark 双主题实机验收。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop 设置页的计费文案、空态和 USD 金额格式。
- 回滚 / 降级方式：回退本 PR 的相关 commit 即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因