### PR TITLE
fix(ui): 修 markdown 可读性 —— 引用块、标题层级、代码着色与行内 code 形态

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -208,6 +208,18 @@ const REHYPE_PLUGINS: PluggableList = [
   rehypeHighlight,
 ];
 const MARKDOWN_LINK_CLASS = 'text-[var(--msg-link)] underline underline-offset-2 cursor-pointer [overflow-wrap:anywhere]';
+/**
+ * markdown 行内 code —— 几何与底色对齐 GitHub(6px 圆角 + 左右内距 + 半透明淡底,
+ * 见 --msg-md-inline-code-bg 的说明)。
+ *
+ * 底色刻意用 --msg-md-inline-code-bg 而不是 --msg-code-inline-bg:后者是实色的
+ * chip / hover 底,同时被可点的 FileTargetChip 与十余处 hover:bg- 复用;行内 code
+ * 若用同一个值,就和「有底色 = 可点路径 chip」这个信号撞车了。
+ *
+ * 移动端**刻意不同形态**(零底色 + 文字压暗):那边聊天流是 RN 嵌套 Text,不认
+ * borderRadius,淡底只能是直角方块。这里是 CSS,按 GitHub 原样实现。
+ */
+const INLINE_CODE_CLASS = 'font-mono text-14 rounded-[6px] px-[0.4em] py-[0.2em] bg-[var(--msg-md-inline-code-bg)]';
 
 const WINDOWS_ABSOLUTE_HREF_RE = /^[A-Za-z]:[\\/]/;
 
@@ -1458,7 +1470,7 @@ function InlineCodeWithTarget({
   // inline <code> — same as before the markdown-target system existed.
   if (target.kind !== 'resolved-local') {
     return (
-      <code className={cn('font-mono text-14')} {...props}>
+      <code className={cn(INLINE_CODE_CLASS)} {...props}>
         {children}
       </code>
     );
@@ -1582,7 +1594,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
         const safeProps = omitMarkdownInternalProps(props as Record<string, unknown>);
         if (!allowPrivilegedLinks) {
           return (
-            <code className={cn('font-mono text-14')} {...safeProps}>
+            <code className={cn(INLINE_CODE_CLASS)} {...safeProps}>
               {children}
             </code>
           );

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -600,8 +600,13 @@ const baseComponents: Components = {
     return (
       <blockquote
         className={cn(
+          // border-l-2 + --msg-blockquote-border(= --agent-actions-rail):与
+          // WorkGroupBlock / ThinkingCard / AgentActionsBlock 的 left rail 完全
+          // 统一,宽度和颜色都不在引用块这里另搞一套。
+          // 不用斜体:中文没有真斜体,机械倾斜反而降低可读性;引用语义由 rail +
+          // 内缩表达已经足够。
           'my-2 border-l-2 border-[var(--msg-blockquote-border)] pl-4',
-          'italic text-[var(--msg-blockquote-text)]',
+          'text-[var(--msg-blockquote-text)]',
         )}
         {...props}
       >

--- a/apps/desktop/src/renderer/themes/__tests__/blockquoteTokens.test.ts
+++ b/apps/desktop/src/renderer/themes/__tests__/blockquoteTokens.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+// import 触发整表注册。
+import '../colors';
+import { builtinThemes } from '../registry';
+import { exportThemeColors } from '../theme-service';
+
+/**
+ * 引用块 token 守卫。
+ *
+ * 引用块只有一个真问题:承载的常是本轮最该看的内容(引述的原始需求、报错原文、
+ * 待确认结论),而正文却是弱化色,扫读时最先被跳过。所以 `msg-blockquote-text`
+ * 跟随该主题的 text-primary。
+ *
+ * 竖线**不是**问题,不要在这里"顺手加深"。界面里的「块引导竖线」是一套统一的
+ * 视觉语言 —— WorkGroupBlock / ThinkingCard / AgentTaskCard / AgentActionsBlock
+ * 全部是 `border-l-2` + `--agent-actions-rail`,淡是它的设计意图。引用块跟随同一
+ * 个 token,识别由「内缩 + rail + 正文主色」共同承担。
+ *
+ * 该 rail 对 surface 约 1.36:1(light)/ 1.64:1(dark),低于 WCAG 非文本 3:1。这是
+ * 全局既有设计语言的既定取舍:**要调就整套 rail 一起调**,不能只加深引用块 ——
+ * 否则引用块会比工具块更抢眼,反而破坏层级。曾经试过把竖线指到
+ * `--text-secondary-mid`(7.35:1),实机目检的结论是过重。
+ *
+ * 两条断言都是 token 身份比较,刻意不断言绝对对比度:
+ * 1. 引用正文 === 该主题 text-primary —— 主题正文本身够不够是主题自己的事
+ *    (如 solarized-light 把 text-primary override 成 #757575,该主题所有正文都是
+ *    4.27:1,见 #911),不是引用块的责任。
+ * 2. 引用竖线 === 该主题 agent-actions-rail —— 保证与全局 left rail 不分家:
+ *    将来有人调 rail,引用块自动跟随,不会悄悄留下两套竖线。
+ */
+
+/** 顺着 var(--x) 引用链解析到具体值。 */
+function resolveToken(
+  exported: Record<string, string | undefined>,
+  id: string,
+  seen = new Set<string>(),
+): string {
+  if (seen.has(id)) throw new Error(`token 引用成环:${id}`);
+  seen.add(id);
+  const raw = exported[id];
+  if (!raw) throw new Error(`主题缺少 token ${id}`);
+  const alias = /^var\(--([a-z0-9-]+)\)$/i.exec(raw.trim());
+  return alias ? resolveToken(exported, alias[1], seen) : raw.trim().toLowerCase();
+}
+
+const themeIds = Object.keys(builtinThemes);
+
+describe('引用块 token · 正文跟随正文色、竖线跟随全局 rail', () => {
+  it.each(themeIds)('%s:引用正文 === 该主题 text-primary', (themeId) => {
+    const exported = exportThemeColors(builtinThemes[themeId]) as Record<string, string>;
+    expect(resolveToken(exported, 'msg-blockquote-text')).toBe(
+      resolveToken(exported, 'text-primary'),
+    );
+  });
+
+  it.each(themeIds)('%s:引用竖线 === 该主题 agent-actions-rail', (themeId) => {
+    const exported = exportThemeColors(builtinThemes[themeId]) as Record<string, string>;
+    expect(resolveToken(exported, 'msg-blockquote-border')).toBe(
+      resolveToken(exported, 'agent-actions-rail'),
+    );
+  });
+});

--- a/apps/desktop/src/renderer/themes/__tests__/markdownColorTokens.test.ts
+++ b/apps/desktop/src/renderer/themes/__tests__/markdownColorTokens.test.ts
@@ -14,9 +14,14 @@ import { exportThemeColors } from '../theme-service';
  * 容器继承来的——`baseComponents` 只给字号字重，不给 color。
  *
  * 因此默认值必须是 `inherit` 而不是 `var(--text-primary)`：后者会让
- * blockquote / tool card / secondary 文字区里的 Markdown 标题与加粗从弱化色变回
- * 主色，那是实打实的观感改动。本文件断言这条不变量，任何把默认值改成具体色槽
- * 的改动都会在这里失败。
+ * tool card / secondary 文字区里的 Markdown 标题与加粗从弱化色变回主色，那是
+ * 实打实的观感改动。本文件断言这条不变量，任何把默认值改成具体色槽的改动都会
+ * 在这里失败。
+ *
+ * 注：blockquote 已不在上述"弱化色容器"之列 —— `msg-blockquote-text` 本身即
+ * `--text-primary`（引用常承载本轮最该看的内容，弱化会让它被扫读跳过），引用
+ * 语义由左侧竖线承担。这不影响本文件的断言：`md-*` 仍是 `inherit`，仍然继承
+ * 容器色，只是那个容器色现在是主色。
  *
  * 三条断言合起来构成机械证明：默认值恒为 `inherit` + 没有内置主题 override +
  * 每个内置主题导出后仍解析为 `inherit` ⇒ 所有内置主题渲染出的 `color:

--- a/apps/desktop/src/renderer/themes/__tests__/markdownInlineCodeTokens.test.ts
+++ b/apps/desktop/src/renderer/themes/__tests__/markdownInlineCodeTokens.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+// import 触发整表注册。
+import '../colors';
+import { builtinThemes } from '../registry';
+import { exportThemeColors } from '../theme-service';
+
+/**
+ * markdown 行内 code 底色守卫(桌面 = GitHub 形态:半透明淡底 + 6px 圆角)。
+ *
+ * 这个 token 有两条容易被"顺手"破掉的性质,都不体现在类型上:
+ *
+ * 1. **必须半透明。** 实色底一定会在某个容器底色上撞色隐形 —— 移动端就撞过:行内
+ *    code 底与消息卡片底逐字节相同,1.00:1,只剩圆角脏边。半透明的相对对比与容器
+ *    无关,所以这条是形态成立的前提,不是风格偏好。
+ *
+ * 2. **不得与 --msg-code-inline-bg 同值。** 那个 token(名字有历史包袱)是实色 chip /
+ *    hover 底,被可点的 FileTargetChip 与十余处 hover:bg- 复用。两者一旦合并,「有
+ *    底色 = 可点路径」这个信号就和普通行内 code 撞车 —— 正是 #897 里「链接附件看不
+ *    出可点」的同一类问题。
+ *
+ * 移动端刻意是另一套形态(零底色 + 文字压暗,见 mobile 的 chatInlineCodeText):那边
+ * 聊天流走 RN 嵌套 Text,不认 borderRadius,淡底只能是直角方块。两端不同是结论,
+ * 不是漏改 —— 所以这里不做跨端一致性断言。
+ */
+
+/** 顺着 var(--x) 引用链解析到具体值。 */
+function resolveToken(
+  exported: Record<string, string | undefined>,
+  id: string,
+  seen = new Set<string>(),
+): string {
+  if (seen.has(id)) throw new Error(`token 引用成环:${id}`);
+  seen.add(id);
+  const raw = exported[id];
+  if (!raw) throw new Error(`主题缺少 token ${id}`);
+  const alias = /^var\(--([a-z0-9-]+)\)$/i.exec(raw.trim());
+  return alias ? resolveToken(exported, alias[1], seen) : raw.trim().toLowerCase();
+}
+
+const themeIds = Object.keys(builtinThemes);
+
+describe('markdown 行内 code 底 · 半透明且不与可点 chip 底撞值', () => {
+  it.each(themeIds)('%s:半透明(alpha < 1,不随容器底色撞色隐形)', (themeId) => {
+    const exported = exportThemeColors(builtinThemes[themeId]) as Record<string, string>;
+    const tint = resolveToken(exported, 'msg-md-inline-code-bg');
+    const rgba = /^rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)$/.exec(tint);
+    expect(rgba, `期望 rgba(...) 半透明值,实际 ${tint}`).not.toBeNull();
+    expect(Number(rgba![1])).toBeLessThan(1);
+    expect(Number(rgba![1])).toBeGreaterThan(0);
+  });
+
+  it.each(themeIds)('%s:不与 --msg-code-inline-bg(可点 chip / hover 底)同值', (themeId) => {
+    const exported = exportThemeColors(builtinThemes[themeId]) as Record<string, string>;
+    expect(resolveToken(exported, 'msg-md-inline-code-bg')).not.toBe(
+      resolveToken(exported, 'msg-code-inline-bg'),
+    );
+  });
+});

--- a/apps/desktop/src/renderer/themes/colors.ts
+++ b/apps/desktop/src/renderer/themes/colors.ts
@@ -69,8 +69,9 @@ registerColor('md-table-bg', {
 // ── Markdown 正文语义色(标题 h1-h6 + 加粗)──
 // 默认值刻意是 `inherit` 而不是 var(--text-primary):这些元素在引入 token 之前
 // 的颜色就是从容器继承来的(baseComponents 只给字号字重,不给 color)。若默认改成
-// 具体色槽,blockquote / tool card / secondary 文字区里的 Markdown 标题与加粗会
-// 由弱化色变回主色 —— 那才是真的改动现有观感。`inherit` 让默认主题渲染结果逐
+// 具体色槽,tool card / secondary 文字区里的 Markdown 标题与加粗会由弱化色变回
+// 主色 —— 那才是真的改动现有观感。(blockquote 已不在此列:引用正文本身改为
+// --text-primary,见 msg-blockquote-text。)`inherit` 让默认主题渲染结果逐
 // 像素不变,同时给外部主题导入(VSCode markup.heading / Obsidian --hN-color)留出
 // 可覆盖的槽位。详见 docs/design-rules/DESIGN.md §10「外部主题导入」。
 registerColor('md-h1-fg', {
@@ -1154,14 +1155,24 @@ registerColor('msg-table-header-bg', {
   light: 'var(--surface)',
   dark: 'var(--surface)',
 }, 'Surface');
+// ── 引用块:正文主色 + 与全局 left rail 统一的竖线 ──
+// 模型常用 `>` 承载本轮最该看的内容(引述的原始需求、报错原文、待确认结论),
+// 弱化色让它在扫读时反而最先被跳过 —— 这是引用块唯一要修的问题,故正文改主色。
+// 竖线刻意跟随 --agent-actions-rail(WorkGroupBlock / ThinkingCard /
+// AgentTaskCard / AgentActionsBlock 都用它 + border-l-2):界面里「块引导竖线」
+// 是一套统一的视觉语言,淡是它的设计意图,不是缺陷。引用块的识别由「内缩 +
+// 这条 rail + 正文主色」共同承担,不靠加深竖线。
+// 注:该 rail 对 surface 约 1.36:1(light)/ 1.64:1(dark),低于 WCAG 非文本
+// 3:1 —— 这是全局既有设计语言的既定取舍,引用块与之统一优先;要调就整套 rail
+// 一起调,不在引用块这里单独加深(否则引用块会比工具块更抢眼)。
 registerColor('msg-blockquote-border', {
-  light: 'var(--border-default)',
-  dark: 'var(--border-default)',
-}, 'Board');
+  light: 'var(--agent-actions-rail)',
+  dark: 'var(--agent-actions-rail)',
+}, 'Left rail — 与 agent actions / thinking 卡片竖线统一');
 registerColor('msg-blockquote-text', {
-  light: 'var(--text-secondary-mid)',
-  dark: 'var(--text-secondary-mid)',
-}, 'Dark Gray — secondary');
+  light: 'var(--text-primary)',
+  dark: 'var(--text-primary)',
+}, 'Near Black — 引用正文与正文同权重');
 registerColor('msg-hr-border', {
   light: 'var(--border-default)',
   dark: 'var(--border-default)',

--- a/apps/desktop/src/renderer/themes/colors.ts
+++ b/apps/desktop/src/renderer/themes/colors.ts
@@ -1143,10 +1143,36 @@ registerColor('msg-code-block-border', {
   light: 'var(--border-default)',
   dark: 'var(--border-default)',
 }, 'Board');
+// ⚠️ 名字叫 inline-code,实际语义已经是「chip / subtle hover 底」:除了可点的
+// FileTargetChip,还有 13 处把它用作 hover:bg-(TextLightbox / AgentActionRow /
+// ToolPayloadLightbox / ToolCallCard / ChatAudioCard)。**不要**为了调 markdown
+// 行内 code 而改这里 —— 那会把那些交互反馈一起变淡。markdown 行内 code 用下面
+// 单开的 msg-md-inline-code-bg。
 registerColor('msg-code-inline-bg', {
   light: 'var(--surface-chip)',
   dark: 'var(--surface-chip)',
-}, 'Light Gray');
+}, 'Light Gray — chip / subtle hover 底(非 markdown 行内 code)');
+// markdown 行内 code 底 —— 对齐 GitHub Primer 的 bgColor-neutral-muted。
+// 半透明而非实色的两个理由:① 实色必然在某个容器底色上撞色隐形(移动端就撞过:
+// 行内 code 底与消息卡片底逐字节相同 → 1.00:1,只剩圆角脏边),半透明的相对对比
+// 与容器无关;② GitHub 这套值实测 light 仅 1.13:1,是「轻微的底色提示」而不是
+// 色块,成段中文里嵌多个标识符也不会被切碎(12% 黑那版 1.31:1 就偏重了)。
+// light / dark 刻意不同 alpha,但 dark **不照抄 GitHub 的 0.4**:
+//   GitHub 原值合成后是 light 1.132:1 / dark 1.629:1 —— dark 的抬升是 light 的近 5 倍。
+//   照抄到我们这儿(light 1.11~1.13 / dark 1.56~1.63,与 GitHub 逐值等观感)后,实机
+//   目检的结论是深色模式明显偏重:两个模式不对称,深色下一段话里嵌几个标识符就被
+//   切成一排色块。所以 dark 降到 0.22 → 1.26~1.28:1,回到「浅浅地看出有差别」。
+//   light 保留 0.2:它已经是 1.11~1.13,再降就基本看不见了。
+// 与可点 path chip 的区分:chip 用上面的实色 surface-chip(1.26:1)+ hover 变色 +
+// cursor-pointer,本 token 只作静态提示 —— 两者数值接近,区分靠 hover 与指针形状。
+//
+// 与移动端刻意**不**同形态:移动端聊天流走 RN 嵌套 Text,只认 backgroundColor 不认
+// borderRadius,淡底在那边只能是直角方块,所以它改用「零底色 + 文字压暗」
+// (chatInlineCodeText)。本路径是 CSS,圆角淡底能真正实现,按 GitHub 原样保留。
+registerColor('msg-md-inline-code-bg', {
+  light: 'rgba(175, 184, 193, 0.2)',
+  dark: 'rgba(110, 118, 129, 0.22)',
+}, 'GitHub Primer neutral-muted — markdown 行内 code 底(半透明,不随容器撞色;dark alpha 下调至 0.22)');
 registerColor('msg-table-border', {
   light: 'var(--border-default)',
   dark: 'var(--border-default)',

--- a/apps/mobile/src/__tests__/chatPathCandidate.test.ts
+++ b/apps/mobile/src/__tests__/chatPathCandidate.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -218,5 +220,33 @@ describe('canOpenChatPathChip', () => {
   it('目录仅 workdir 内可开(文件浏览器以 workdir 为根)', () => {
     expect(canOpenChatPathChip('directory', 'src/components')).toBe(true);
     expect(canOpenChatPathChip('directory', null)).toBe(false);
+  });
+});
+
+describe('路径 chip 的可点信号(源码级守卫)', () => {
+  // 行内 code 走压暗档,而路径 chip 的样式**总是**叠在 markdownInlineCode 之后:
+  //   chipStyle={[baseStyle, styles.markdownInlineCode, styles.markdownPathChip]}
+  // markdownPathChip 一旦不自带 color,就会继承那份压暗色 —— 可点的反而比不可点的
+  // 更淡,正好把「看不出可点」这个问题做反。RN 里这类静默继承没有类型保护,只能
+  // 在源码层钉住。
+  it('markdownPathChip 显式钉回正文色,不继承行内 code 的压暗', () => {
+    const src = readFileSync(
+      join(process.cwd(), 'src/session/MessageRenderer.tsx'),
+      'utf8',
+    );
+    const block = /markdownPathChip:\s*\{([^}]*)\}/.exec(src);
+    expect(block, '未找到 markdownPathChip 样式定义').not.toBeNull();
+    expect(block![1]).toMatch(/color:\s*colors\.textPrimary/);
+
+    // 叠加顺序也一并钉住:若将来有人把 markdownPathChip 挪到 markdownInlineCode
+    // 之前,上面那条 color 就会被压暗色覆盖回去。
+    const sites = src.match(/chipStyle=\{\[[^\]]*\]\}/g) ?? [];
+    expect(sites.length).toBeGreaterThan(0);
+    for (const site of sites) {
+      const inline = site.indexOf('markdownInlineCode');
+      const chip = site.indexOf('markdownPathChip');
+      if (inline === -1 || chip === -1) continue;
+      expect(chip, `叠加顺序反了:${site}`).toBeGreaterThan(inline);
+    }
   });
 });

--- a/apps/mobile/src/__tests__/codeHighlight.test.ts
+++ b/apps/mobile/src/__tests__/codeHighlight.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { tokenizeCode, type CodeToken, type CodeTokenKind } from '@/session/codeHighlight';
+import {
+  CODE_HIGHLIGHT_LIMITS,
+  tokenizeCode,
+  type CodeToken,
+  type CodeTokenKind,
+} from '@/session/codeHighlight';
 
 /** 取某 kind 的全部片段文本,便于断言"哪些东西被认成了什么"。 */
 function kindTexts(tokens: readonly CodeToken[], kind: CodeTokenKind): string[] {
@@ -146,6 +151,51 @@ describe('tokenizeCode · 属性名(hljs attr 对应类)', () => {
     const tokens = assertLossless('switch (x) { default: break; }', 'ts');
     expect(kindTexts(tokens, 'keyword')).toEqual(expect.arrayContaining(['switch', 'default', 'break']));
     expect(kindTexts(tokens, 'property')).toEqual([]);
+  });
+});
+
+/**
+ * 着色预算守护。
+ *
+ * 每个非 plain token 在聊天流都会变成一个嵌套原生 Text(iOS selectable 路径上是
+ * UITextView 家族子节点),外层横向 ScrollView 不虚拟化,所以 token 数 = 挂载成本;
+ * 流式期间整块还会随每个 chunk 重新分词并重新挂载。所以 token 数必须有上界,
+ * 而不是"通常也不会那么长"。超预算时退回纯文本 —— 那正是本 PR 之前的形态。
+ */
+describe('tokenizeCode · 大代码块的着色预算', () => {
+  it('超长源码整块退回单个 plain token(连分词都不做)', () => {
+    const long = 'const a = 1; // c\n'.repeat(
+      Math.ceil((CODE_HIGHLIGHT_LIMITS.maxSource + 1000) / 18),
+    );
+    expect(long.length).toBeGreaterThan(CODE_HIGHLIGHT_LIMITS.maxSource);
+
+    const tokens = assertLossless(long, 'ts');
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].kind).toBe('plain');
+  });
+
+  it('刚好在长度预算内的源码仍然着色(阈值不过度保守)', () => {
+    const unit = 'const a = 1;\n';
+    const within = unit.repeat(Math.floor(CODE_HIGHLIGHT_LIMITS.maxSource / unit.length / 2));
+    expect(within.length).toBeLessThanOrEqual(CODE_HIGHLIGHT_LIMITS.maxSource);
+
+    const tokens = assertLossless(within, 'ts');
+    expect(kindTexts(tokens, 'keyword').length).toBeGreaterThan(0);
+  });
+
+  it('token 极密的短源码按 token 数收口,剩余部分并成 plain', () => {
+    // 每组 `a1:1,` 都产出 property + number 等多个 token,长度远小于 maxSource,
+    // 靠 maxTokens 兜住。
+    let dense = '';
+    for (let n = 0; dense.length < CODE_HIGHLIGHT_LIMITS.maxSource - 20; n += 1) {
+      dense += `a${n}:${n},`;
+    }
+    expect(dense.length).toBeLessThanOrEqual(CODE_HIGHLIGHT_LIMITS.maxSource);
+
+    const tokens = assertLossless(dense, 'ts');
+    // 收口后允许再多一个 plain 收尾 token。
+    expect(tokens.length).toBeLessThanOrEqual(CODE_HIGHLIGHT_LIMITS.maxTokens + 1);
+    expect(tokens[tokens.length - 1].kind).toBe('plain');
   });
 });
 

--- a/apps/mobile/src/__tests__/codeHighlight.test.ts
+++ b/apps/mobile/src/__tests__/codeHighlight.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import { tokenizeCode, type CodeToken, type CodeTokenKind } from '@/session/codeHighlight';
+
+/** 取某 kind 的全部片段文本,便于断言"哪些东西被认成了什么"。 */
+function kindTexts(tokens: readonly CodeToken[], kind: CodeTokenKind): string[] {
+  return tokens.filter((t) => t.kind === kind).map((t) => t.text);
+}
+
+/** 词法不能吞字:拼回原文必须逐字节等于输入。 */
+function assertLossless(source: string, language?: string): CodeToken[] {
+  const tokens = tokenizeCode(source, language);
+  expect(tokens.map((t) => t.text).join('')).toBe(source);
+  return tokens;
+}
+
+describe('tokenizeCode · 无损与基本分类', () => {
+  it('任何语言下拼回 token 都等于原文(不吞字、不重复)', () => {
+    const samples: [string, string | undefined][] = [
+      ['const a = 1; // hi', 'ts'],
+      ['def f(x):\n    return x # c', 'python'],
+      ['SELECT * FROM t WHERE a = 1 -- c', 'sql'],
+      ['.a { color: red; /* c */ }', 'css'],
+      ['<div class="x"><!-- c --></div>', 'html'],
+      ['{"a": 1, "b": null}', 'json'],
+      ['echo "hi" # c', 'bash'],
+      ['无语言标注的文本 `x` 123', undefined],
+      ['', 'ts'],
+      ['\n\n', 'ts'],
+    ];
+    for (const [src, lang] of samples) assertLossless(src, lang);
+  });
+
+  it('js/ts:关键字、字符串、数字、注释、函数名各归其类', () => {
+    const tokens = assertLossless(
+      'const n = 42;\n// 说明\nfunction run(a) { return "s"; }',
+      'ts',
+    );
+    expect(kindTexts(tokens, 'keyword')).toEqual(expect.arrayContaining(['const', 'function', 'return']));
+    expect(kindTexts(tokens, 'number')).toContain('42');
+    expect(kindTexts(tokens, 'comment')).toContain('// 说明');
+    expect(kindTexts(tokens, 'string')).toContain('"s"');
+    expect(kindTexts(tokens, 'function')).toContain('run');
+  });
+
+  it('块注释与未闭合块注释都吃到正确边界', () => {
+    const closed = assertLossless('a /* c1 */ b', 'ts');
+    expect(kindTexts(closed, 'comment')).toEqual(['/* c1 */']);
+    const open = assertLossless('a /* 未闭合', 'ts');
+    expect(kindTexts(open, 'comment')).toEqual(['/* 未闭合']);
+  });
+
+  it('未闭合的单/双引号只吃到行尾,不把后续整块染成字符串', () => {
+    const tokens = assertLossless('a = "未闭合\nconst b = 1', 'ts');
+    const strings = kindTexts(tokens, 'string');
+    expect(strings).toEqual(['"未闭合']);
+    // 下一行仍能正常识别关键字
+    expect(kindTexts(tokens, 'keyword')).toContain('const');
+  });
+
+  it('模板字符串可以跨行', () => {
+    const tokens = assertLossless('const t = `a\nb`;', 'ts');
+    expect(kindTexts(tokens, 'string')).toEqual(['`a\nb`']);
+  });
+
+  it('转义引号不提前结束字符串', () => {
+    const tokens = assertLossless('const s = "a\\"b";', 'ts');
+    expect(kindTexts(tokens, 'string')).toEqual(['"a\\"b"']);
+  });
+
+  it('python / bash 用 # 行注释,而不是 //', () => {
+    const py = assertLossless('x = 1 # 注释', 'python');
+    expect(kindTexts(py, 'comment')).toEqual(['# 注释']);
+    const sh = assertLossless('ls -al # 注释', 'bash');
+    expect(kindTexts(sh, 'comment')).toEqual(['# 注释']);
+  });
+
+  it('sql 关键字大小写不敏感,用 -- 行注释', () => {
+    const tokens = assertLossless('select A from T -- c', 'sql');
+    expect(kindTexts(tokens, 'keyword')).toEqual(expect.arrayContaining(['select', 'from']));
+    expect(kindTexts(tokens, 'comment')).toEqual(['-- c']);
+  });
+
+  it('json 不把 // 当注释(JSON 无注释语法),url 里的 // 也不吞', () => {
+    const tokens = assertLossless('{"u": "http://a.com"}', 'json');
+    expect(kindTexts(tokens, 'comment')).toEqual([]);
+    // "u" 后紧跟 `:` → 属性名;值仍是 string(见「属性名」一组断言)。
+    expect(kindTexts(tokens, 'property')).toEqual(['"u"']);
+    expect(kindTexts(tokens, 'string')).toEqual(['"http://a.com"']);
+  });
+
+  it('未知语言退化为通用词法:仍认字符串 / 数字 / 注释', () => {
+    const tokens = assertLossless('foo "bar" 12 # c', 'no-such-lang');
+    expect(kindTexts(tokens, 'string')).toEqual(['"bar"']);
+    expect(kindTexts(tokens, 'number')).toEqual(['12']);
+    expect(kindTexts(tokens, 'comment')).toEqual(['# c']);
+  });
+
+  it('相邻同类片段被合并,不产生碎片节点', () => {
+    const tokens = tokenizeCode('a b c d', 'ts');
+    // 全是 plain,应合并成 1 个 token
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toEqual({ text: 'a b c d', kind: 'plain' });
+  });
+
+  it('中文与 emoji 不被拆坏', () => {
+    const src = 'const 名字 = "值 🎉"; // 说明';
+    const tokens = assertLossless(src, 'ts');
+    expect(kindTexts(tokens, 'string')).toEqual(['"值 🎉"']);
+  });
+});
+
+describe('tokenizeCode · 属性名(hljs attr 对应类)', () => {
+  it('对象字面量的裸 key 归为 property', () => {
+    const tokens = assertLossless(
+      'markdownInlineCode: {\n  fontFamily: monoFont,\n  fontSize: typeScale.code,\n}',
+      'ts',
+    );
+    expect(kindTexts(tokens, 'property')).toEqual(
+      expect.arrayContaining(['markdownInlineCode', 'fontFamily', 'fontSize']),
+    );
+    // 值侧的标识符不该被误染
+    expect(kindTexts(tokens, 'property')).not.toContain('monoFont');
+  });
+
+  it('JSON 的带引号 key 归为 property,值仍是 string', () => {
+    const tokens = assertLossless('{"name": "cindy", "n": 1}', 'json');
+    expect(kindTexts(tokens, 'property')).toEqual(['"name"', '"n"']);
+    expect(kindTexts(tokens, 'string')).toEqual(['"cindy"']);
+    expect(kindTexts(tokens, 'number')).toEqual(['1']);
+  });
+
+  it('css 属性名与 yaml 键都归为 property', () => {
+    const css = assertLossless('.a { color: red; }', 'css');
+    expect(kindTexts(css, 'property')).toContain('color');
+    const yaml = assertLossless('name: cindy\nport: 8081', 'yaml');
+    expect(kindTexts(yaml, 'property')).toEqual(expect.arrayContaining(['name', 'port']));
+  });
+
+  it('`::` 作用域符不算属性名(Rust / C++)', () => {
+    const tokens = assertLossless('std::vec::Vec', 'rust');
+    expect(kindTexts(tokens, 'property')).toEqual([]);
+  });
+
+  it('关键字优先于属性名(switch 的 default:)', () => {
+    const tokens = assertLossless('switch (x) { default: break; }', 'ts');
+    expect(kindTexts(tokens, 'keyword')).toEqual(expect.arrayContaining(['switch', 'default', 'break']));
+    expect(kindTexts(tokens, 'property')).toEqual([]);
+  });
+});
+
+/**
+ * 源码级守护(不是纯函数测试):代码块的语法着色 span 必须经 `spanFor()` 取组件。
+ *
+ * 为什么值得单独守:块可选中且在 iOS 时,代码块外层是原生 UITextView,它只接受
+ * UITextView 家族的子节点 —— 传普通 RN `Text` 会让所有着色 span **静默消失**
+ * (代码里的属性名、关键字直接从画面上不见,不报错、不警告)。这类问题 typecheck
+ * 与全部单测都抓不到,只有实机能发现(2026-07 实际踩过一次)。mobile 当前没有 RN
+ * 组件渲染测试设施(引入需要新 devDependency,可能动 runtime fingerprint),因此
+ * 退一步用源码断言兜住最关键的一条:调用点不许绕开 spanFor。
+ */
+describe('代码块着色 span 的取用方式(源码守护)', () => {
+  it('HighlightedCodeText 的调用点必须用 spanFor(...) 提供 SpanComponent', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const { fileURLToPath } = await import('node:url');
+    const path = fileURLToPath(new URL('../session/MessageRenderer.tsx', import.meta.url));
+    const src = await readFile(path, 'utf8');
+
+    const callSites = src.match(/<HighlightedCodeText[\s\S]*?\/>/g) ?? [];
+    expect(callSites.length, '找不到 HighlightedCodeText 的调用点(重构后请同步本测试)')
+      .toBeGreaterThan(0);
+    for (const site of callSites) {
+      expect(site, 'SpanComponent 必须来自 spanFor(...),不能直接传 RN Text')
+        .toMatch(/SpanComponent=\{spanFor\(/);
+    }
+  });
+});

--- a/apps/mobile/src/__tests__/selectableMarkdownHtml.test.ts
+++ b/apps/mobile/src/__tests__/selectableMarkdownHtml.test.ts
@@ -38,3 +38,50 @@ describe('buildSelectableMarkdownHtml 渲染态行定位', () => {
     expect(buildSelectableMarkdownHtml(DOC, { targetLine: 1.5 })).not.toContain('<script>');
   });
 });
+
+/**
+ * 代码块语法着色的 WebView 输出。
+ *
+ * 这里有两条性质必须同时成立,而且它们互相拉扯:着色要求把源码切片后**包上标签**,
+ * 而 WebView 要求每一片都**转义**。`highlightCodeHtml` 是逐 token 拼字符串的,漏掉
+ * 任何一个分支的 escapeHtml 都会变成 HTML 注入面 —— 而且注入的正是「用户/agent 贴进
+ * 聊天或文档里的代码」,这类内容里带 `<script>` 完全正常。
+ *
+ * 单测 codeHighlight.test.ts 只覆盖分词本身(kind 与无损),不看 HTML;所以这一层的
+ * 转义必须在这里钉住,不能靠"实现里写了 escapeHtml"。
+ */
+describe('buildSelectableMarkdownHtml 代码块语法着色', () => {
+  const fence = (code: string, lang = 'ts') => ['```' + lang, code, '```'].join('\n');
+
+  it('围栏代码块产出 syn-* span(着色确实接上了,不是静默退化为纯文本)', () => {
+    const html = buildSelectableMarkdownHtml(fence('const a = 1; // c'));
+    expect(html).toContain('<span class="syn-keyword">const</span>');
+    expect(html).toContain('<span class="syn-number">1</span>');
+    expect(html).toContain('<span class="syn-comment">// c</span>');
+  });
+
+  it('着色片段与 plain 片段都经过转义,原始尖括号不落地', () => {
+    // `<script>` 落在 plain 片段;`"x"` 落在 string 片段 —— 两条分支都要转义。
+    const html = buildSelectableMarkdownHtml(fence('const s = "<script>alert(1)</script>";'));
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('</script>');
+    expect(html).toContain('&lt;script&gt;');
+    // 引号也转义,避免从 span 属性里逃出去。
+    expect(html).toContain('&quot;');
+  });
+
+  it('& 只转义一次(不出现 &amp;amp; 这类双重转义)', () => {
+    const html = buildSelectableMarkdownHtml(fence('const x = a && b;'));
+    expect(html).toContain('&amp;&amp;');
+    expect(html).not.toContain('&amp;amp;');
+  });
+
+  it('超出着色预算的代码块退回纯文本,但仍然转义', () => {
+    const long = 'const a = "<b>";\n'.repeat(2000);
+    const html = buildSelectableMarkdownHtml(fence(long));
+    expect(long.length).toBeGreaterThan(20_000);
+    expect(html).not.toContain('<span class="syn-');
+    expect(html).not.toContain('<b>');
+    expect(html).toContain('&lt;b&gt;');
+  });
+});

--- a/apps/mobile/src/__tests__/themeTokens.test.ts
+++ b/apps/mobile/src/__tests__/themeTokens.test.ts
@@ -97,6 +97,25 @@ describe('theme tokens', () => {
     expect(contrastRatio(darkColors.ctaText, darkColors.cta)).toBeGreaterThanOrEqual(4.5);
   });
 
+  it('行内 code 压暗档:比正文淡但仍过 AA 4.5:1', () => {
+    // 移动端行内 code 走「零底色 + 文字压暗」形态(聊天流的 RN 嵌套 Text 做不出圆角
+    // 底);桌面端另走 GitHub 淡底 + 圆角,两端刻意不同,不要在这里做跨端一致性断言。
+    // 它承载 id / 路径 / 字段名 —— 正文流里的实义内容,所以 4.5:1 是硬线,不能为了
+    // "更像 code"继续压。
+    // 实测 light 4.56:1 / dark 5.81:1;对正文 Δ1.98 / Δ1.70(压暗肉眼可辨)。
+    expect(lightColors.chatInlineCodeText).toBe('#686B72');
+    expect(darkColors.chatInlineCodeText).toBe('#A3A3A3');
+    for (const palette of [lightColors, darkColors]) {
+      const dim = contrastRatio(palette.chatInlineCodeText, palette.surface);
+      expect(dim).toBeGreaterThanOrEqual(4.5);
+      // 方向:比正文更靠近底色 —— 是压暗,不是加重。
+      expect(dim).toBeLessThan(contrastRatio(palette.textPrimary, palette.surface));
+      // 刻意不复用 textSecondary(2.80:1 / 2.92:1,掉 AA)—— 钉住这个区别,
+      // 防止将来有人"顺手"把两者合并。
+      expect(palette.chatInlineCodeText).not.toBe(palette.textSecondary);
+    }
+  });
+
   it('毛玻璃 token 契约(R1 audit 模式1/3,E4M 新增 surfaceTranslucentSidebar / surfaceGlassPanel)', () => {
     // R1 audit:@2x 稿折半;模式1 侧栏 blur≈50 dark #120F0F@0.85 / light #F6F6F6@0.90;
     // 模式3 浮层卡 light #F8F8F8 / dark #3B3B3B@0.95。surface 不叠 blur 规避 Android 热路径。

--- a/apps/mobile/src/session/MarkdownFileReader.tsx
+++ b/apps/mobile/src/session/MarkdownFileReader.tsx
@@ -48,6 +48,7 @@ export function MarkdownFileReader({
   const html = useMemo(() => buildSelectableMarkdownHtml(markdown, {
     borderColor: colors.border,
     chipColor: colors.surfaceChip,
+    inlineCodeColor: colors.chatInlineCodeText,
     fontSize: typeScale.body,
     // body(16/22)行高比 1.375,低于 DESIGN.md §3 正文区间 1.43–1.56 下限;
     // 文档阅读是长文连续阅读场景,换 bodyRelaxed(16/24)= 1.50 落到规范值。

--- a/apps/mobile/src/session/MarkdownFileReader.tsx
+++ b/apps/mobile/src/session/MarkdownFileReader.tsx
@@ -54,9 +54,18 @@ export function MarkdownFileReader({
     // 字号不动:16 = DESIGN.md 的 Body 档。
     lineHeight: lineHeight.bodyRelaxed,
     mutedColor: colors.textSecondary,
+    // 代码块语法着色随主题走(WebView 里没有 theme context,只能显式注入)。
+    syntaxColors: {
+      comment: colors.syntaxComment,
+      function: colors.syntaxFunction,
+      keyword: colors.syntaxKeyword,
+      number: colors.syntaxNumber,
+      property: colors.syntaxProperty,
+      string: colors.syntaxString,
+    },
     textColor: colors.textPrimary,
     ...(targetLine ? { targetLine } : {}),
-  }), [colors.border, colors.surfaceChip, colors.textPrimary, colors.textSecondary, markdown, targetLine]);
+  }), [colors, markdown, targetLine]);
 
   // 回调走 ref:onQuoteSelection 引用变化(页面重渲)不应重建 handler,
   // 更不应让 WebView 重载。

--- a/apps/mobile/src/session/MarkdownFileReader.tsx
+++ b/apps/mobile/src/session/MarkdownFileReader.tsx
@@ -49,7 +49,10 @@ export function MarkdownFileReader({
     borderColor: colors.border,
     chipColor: colors.surfaceChip,
     fontSize: typeScale.body,
-    lineHeight: lineHeight.body,
+    // body(16/22)行高比 1.375,低于 DESIGN.md §3 正文区间 1.43–1.56 下限;
+    // 文档阅读是长文连续阅读场景,换 bodyRelaxed(16/24)= 1.50 落到规范值。
+    // 字号不动:16 = DESIGN.md 的 Body 档。
+    lineHeight: lineHeight.bodyRelaxed,
     mutedColor: colors.textSecondary,
     textColor: colors.textPrimary,
     ...(targetLine ? { targetLine } : {}),

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -5914,19 +5914,22 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   // 与普通强调的区别只在语义,视觉上沿用 italic 已足够。
   markdownMathInline: { fontStyle: 'italic' },
   markdownStrike: { textDecorationLine: 'line-through' },
-  // 刻意不给底色:行内 code 在中文正文里出现频率很高(id、路径、字段名),任何
-  // 底色都会把整段切成一片色块,可读性反而下降 —— 与正文同底、只用等宽字体区分
-  // (同一份文件里的 thinkingCode 也是这个形态)。也因此不需要 borderRadius /
-  // paddingHorizontal:没有底色时它们只会在字词间挤出无意义的空隙。
-  // 代码块另说:它用 chatCodeSurface + chatCodeBorder 描边成块,本来就该有底。
+  // 行内 code:零底色 + 等宽字体 + 文字压暗(参照 Codex 客户端)。
+  // 不给底色是平台约束:RN 嵌套在 Text 内的 inline 片段只认 backgroundColor,不认
+  // borderRadius(同 sessionLinkChipText 的注释),底色在这里只能是直角方块,成段
+  // 中文里一排方块比没有底色更糟。桌面走的是 GitHub 淡底 + 6px 圆角(CSS 能实现),
+  // 两端形态刻意不同 —— 取值与理由见 chatInlineCodeText。
   markdownInlineCode: {
+    color: colors.chatInlineCodeText,
     fontFamily: monoFont,
     fontSize: typeScale.code,
     lineHeight: lineHeight.code,
   },
-  // 已验证存在的文件/目录路径 chip:在 inline code 底色上加下划线示意可点
-  // (嵌套 Text 只支持有限样式,与 sessionLinkChipText 同一约束)。
+  // 已验证存在的文件/目录路径 chip:靠「正文色 + medium + 下划线」区别于普通行内
+  // code(后者压暗)。color 必须显式钉回 textPrimary —— 本样式总是叠在
+  // markdownInlineCode 之后,不写就会继承那份压暗色,可点的反而比不可点的更淡。
   markdownPathChip: {
+    color: colors.textPrimary,
     fontWeight: fontWeight.medium,
     textDecorationLine: 'underline',
   },

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -57,6 +57,7 @@ import {
 } from 'react-native';
 import { UITextView } from 'react-native-uitextview';
 import { LegendList, type LegendListRef } from '@legendapp/list/react-native';
+import { tokenizeCode, type CodeTokenKind } from '@/session/codeHighlight';
 import { buildComposerTouchLayout } from '@/session/composerTouchLayout';
 import { useFoldableExpandedState } from '@/session/expandedBlockMemory';
 import {
@@ -3290,7 +3291,7 @@ function MarkdownBody({
             );
           }
           const baseStyle: StyleProp<TextStyle> = block.type === 'heading'
-            ? [styles.markdownHeading, block.level <= 2 ? styles.markdownHeadingLarge : styles.markdownHeadingSmall]
+            ? [styles.markdownHeading, headingSizeStyle(styles, block.level)]
             : styles.messageText;
           if (block.type === 'list_item') {
             const task = typeof block.checked === 'boolean';
@@ -3363,14 +3364,15 @@ function MarkdownBody({
                   },
                 ]}
               >
-                <MarkdownSelectableText
+                <HighlightedCodeText
+                  SpanComponent={spanFor(selectable === true) ?? Text}
                   allowIosUITextView={allowIosUITextView}
+                  language={block.language}
                   selectable={selectable === true}
                   selectionColor={colors.surfaceChip}
-                  style={styles.markdownCodeText}
-                >
-                  {block.text}
-                </MarkdownSelectableText>
+                  styles={styles}
+                  text={block.text}
+                />
               </ScrollView>
             </View>
           );
@@ -3378,7 +3380,7 @@ function MarkdownBody({
         if (block.type === 'heading') {
           const headingStyle = [
             styles.markdownHeading,
-            block.level <= 2 ? styles.markdownHeadingLarge : styles.markdownHeadingSmall,
+            headingSizeStyle(styles, block.level),
           ];
           const headingSelectable = inlinesSelectable(block.inlines);
           return (
@@ -5551,6 +5553,84 @@ function messageClientId(item: MobileMessageItem): string {
   return item.message.source.clientId || item.message.source.id || item.message.key;
 }
 
+/** 语法 kind → 样式。plain 不走这里(直接当字符串塞进父 Text,少一层节点)。 */
+function syntaxStyleFor(
+  styles: ReturnType<typeof makeStyles>,
+  kind: Exclude<CodeTokenKind, 'plain'>,
+): StyleProp<TextStyle> {
+  switch (kind) {
+    case 'keyword': return styles.syntaxKeyword;
+    case 'string': return styles.syntaxString;
+    case 'comment': return styles.syntaxComment;
+    case 'number': return styles.syntaxNumber;
+    case 'function': return styles.syntaxFunction;
+    case 'property': return styles.syntaxProperty;
+  }
+}
+
+/**
+ * 代码块正文 —— 按 language 做词法着色(配色对齐桌面的 GitHub hljs 主题)。
+ *
+ * 抽成组件只为拿 useMemo:renderBlock 每次重渲都会走到,大代码块重复分词不划算。
+ * 嵌套 span 只带 color,其余样式继承外层 markdownCodeText。
+ *
+ * ⚠️ `SpanComponent` 必须由调用方经 `spanFor()` 给出,不能图省事直接用 RN 的
+ * `Text`:块可选中且在 iOS 时外层是 UITextView,而它只接受 UITextView 家族的子
+ * 节点 —— 传普通 Text 的话那些 span 会被整个丢掉(表现为代码里的属性名、关键字
+ * 直接从画面上消失,不报错)。
+ */
+function HighlightedCodeText({
+  SpanComponent,
+  allowIosUITextView,
+  language,
+  selectable,
+  selectionColor,
+  styles,
+  text,
+}: {
+  SpanComponent: typeof Text;
+  allowIosUITextView: boolean;
+  language: string | undefined;
+  selectable: boolean;
+  selectionColor: string;
+  styles: ReturnType<typeof makeStyles>;
+  text: string;
+}) {
+  const tokens = useMemo(() => tokenizeCode(text, language), [language, text]);
+  return (
+    <MarkdownSelectableText
+      allowIosUITextView={allowIosUITextView}
+      selectable={selectable}
+      selectionColor={selectionColor}
+      style={styles.markdownCodeText}
+    >
+      {tokens.map((token, index) => (
+        token.kind === 'plain'
+          ? token.text
+          : (
+            <SpanComponent key={index} style={syntaxStyleFor(styles, token.kind)}>
+              {token.text}
+            </SpanComponent>
+          )
+      ))}
+    </MarkdownSelectableText>
+  );
+}
+
+/**
+ * markdown 标题的字号档:h1 / h2 / h3+ 三档(见 markdownHeading* 的比例说明)。
+ * 两处渲染路径(text_run 合并树与独立 heading 块)共用,避免再次分叉成
+ * 「level <= 2 一刀切」那种只有两档、且第二档比正文还小的形态。
+ */
+function headingSizeStyle(
+  styles: ReturnType<typeof makeStyles>,
+  level: number,
+): StyleProp<TextStyle> {
+  if (level <= 1) return styles.markdownHeadingLarge;
+  if (level === 2) return styles.markdownHeadingMedium;
+  return styles.markdownHeadingSmall;
+}
+
 const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   messageFrame: { flex: 1, minHeight: 0 },
   messageList: { flex: 1 },
@@ -5834,13 +5914,15 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   // 与普通强调的区别只在语义,视觉上沿用 italic 已足够。
   markdownMathInline: { fontStyle: 'italic' },
   markdownStrike: { textDecorationLine: 'line-through' },
+  // 刻意不给底色:行内 code 在中文正文里出现频率很高(id、路径、字段名),任何
+  // 底色都会把整段切成一片色块,可读性反而下降 —— 与正文同底、只用等宽字体区分
+  // (同一份文件里的 thinkingCode 也是这个形态)。也因此不需要 borderRadius /
+  // paddingHorizontal:没有底色时它们只会在字词间挤出无意义的空隙。
+  // 代码块另说:它用 chatCodeSurface + chatCodeBorder 描边成块,本来就该有底。
   markdownInlineCode: {
-    backgroundColor: colors.chatCodeSurface,
-    borderRadius: radius.container,
     fontFamily: monoFont,
     fontSize: typeScale.code,
     lineHeight: lineHeight.code,
-    paddingHorizontal: 4,
   },
   // 已验证存在的文件/目录路径 chip:在 inline code 底色上加下划线示意可点
   // (嵌套 Text 只支持有限样式,与 sessionLinkChipText 同一约束)。
@@ -5856,13 +5938,24 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     color: colors.textPrimary,
     fontWeight: fontWeight.medium,
   },
+  // 三档标题,行高刻意选到能与 desktop 的相对比例对齐(desktop 正文 15:h1 20/1.4、
+  // h2 18/1.556、h3 16/1.5≈正文;mobile 正文 17):
+  //   h1  20/28 = 1.400  ← 与 desktop h1 的 1.4 相同
+  //   h2  18/28 = 1.556  ← 与 desktop h2 的 1.556 相同
+  //   h3+ 17/26          ← 与正文同字号,靠 medium 区分(同 desktop 让 h3 贴近正文)
+  // 20/28 与 18/28 都是 lineHeight 阶梯里既有的 listTitle 配对,未扩档。
+  // 改前 h1/h2 都是 bodyLarge(17)=正文字号、h3-h6 是 caption(12)——标题比正文还小。
   markdownHeadingLarge: {
-    fontSize: typeScale.bodyLarge,
-    lineHeight: lineHeight.bodyLarge,
+    fontSize: typeScale.title,
+    lineHeight: lineHeight.listTitle,
+  },
+  markdownHeadingMedium: {
+    fontSize: typeScale.subtitle,
+    lineHeight: lineHeight.listTitle,
   },
   markdownHeadingSmall: {
-    fontSize: typeScale.caption,
-    lineHeight: lineHeight.caption,
+    fontSize: typeScale.bodyLarge,
+    lineHeight: lineHeight.bodyLarge,
   },
   // 竖线对齐本文件 styles.rail(chatCodeBorder + 2px)——界面里「块引导竖线」是
   // 一套统一的视觉语言,淡是设计意图;引用块不另搞一套(desktop 侧同样跟随
@@ -5927,6 +6020,14 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     fontSize: typeScale.code,
     lineHeight: lineHeight.code,
   },
+  // 语法着色:只上 color,其余(字体/字号/行高)继承 markdownCodeText —— 嵌套 Text
+  // 只支持有限样式,且改字号会让同一行的 token 高低不齐。
+  syntaxKeyword: { color: colors.syntaxKeyword },
+  syntaxString: { color: colors.syntaxString },
+  syntaxComment: { color: colors.syntaxComment },
+  syntaxNumber: { color: colors.syntaxNumber },
+  syntaxFunction: { color: colors.syntaxFunction },
+  syntaxProperty: { color: colors.syntaxProperty },
   markdownTableScroll: {
     maxWidth: '100%',
   },

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -5864,21 +5864,30 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     fontSize: typeScale.caption,
     lineHeight: lineHeight.caption,
   },
+  // 竖线对齐本文件 styles.rail(chatCodeBorder + 2px)——界面里「块引导竖线」是
+  // 一套统一的视觉语言,淡是设计意图;引用块不另搞一套(desktop 侧同样跟随
+  // --agent-actions-rail)。
   markdownQuote: {
-    borderLeftColor: colors.borderStrong,
+    borderLeftColor: colors.chatCodeBorder,
     borderLeftWidth: 2,
     paddingLeft: spacing.sm,
   },
+  // 引用正文与正文同色:textSecondary 对 surface 仅 3.1:1(light)/ 3.4:1(dark),
+  // 低于 WCAG AA 4.5:1,而 `>` 常承载本轮最该看的内容 —— 这是引用块唯一要修的
+  // 问题。「这是引用」由 rail + 内缩表达,不靠压低正文对比度。
   markdownQuoteText: {
-    color: colors.textSecondary,
+    color: colors.textPrimary,
   },
   markdownListRow: { flexDirection: 'row', gap: spacing.sm },
-  // text_run 合并树里的列表 marker 前缀(不占固定列宽,颜色弱化与原 marker 一致)。
+  // text_run 合并树里的列表 marker 前缀(不占固定列宽,颜色与原 marker 一致)。
   markdownListMarkerInline: {
-    color: colors.textSecondary,
+    color: colors.textPrimary,
   },
+  // 编号/项目符号与列表项正文同色(对齐 desktop 的 list-decimal / list-disc:
+  // 那边 marker 本就继承正文色)。编号在实际使用中承担段落引导,弱化到
+  // 3.1:1 会让扫读整段丢失。
   markdownListMarker: {
-    color: colors.textSecondary,
+    color: colors.textPrimary,
     fontSize: typeScale.bodyLarge,
     lineHeight: lineHeight.bodyLarge,
     textAlign: 'right',

--- a/apps/mobile/src/session/codeHighlight.ts
+++ b/apps/mobile/src/session/codeHighlight.ts
@@ -1,0 +1,301 @@
+/**
+ * 代码块语法着色的轻量词法分析器。
+ *
+ * **为什么不用 highlight.js**:`apps/mobile/package.json` 的依赖是 runtime
+ * fingerprint 输入,加一个高亮库会触发冷更 —— 存量装机拿不到本次及后续热更,
+ * 代价与技术框架变动同级(见 docs/dev-rules/mobile-development.md)。为了纯观感
+ * 需求付这个代价不值,所以词法在仓内自己做:本文件是 `src/` 源码,不进依赖表,
+ * 指纹不变。
+ *
+ * 因此它**刻意不追求 hljs 的精确度**,只覆盖"扫一眼能看出结构"所需的 6 类:
+ * 注释 / 字符串 / 数字 / 关键字 / 函数名 / 属性名。语言未知或不在表内时退化为
+ * 通用词法(仍能高亮字符串、数字与 `//`、`#` 注释),不会整块变纯文本。
+ *
+ * 属性名(`key:` 形态)这一类是必须有的:配置、样式对象、YAML、JSON 这类内容里
+ * 属性名占绝大多数,少了它们整块几乎全是 plain —— 桌面 hljs 把它们归入 `attr`
+ * 并着蓝色,是那类代码块最主要的视觉信号。
+ *
+ * 输出与颜色解耦:只给 kind,配色由 theme 的 syntax* token 决定(对齐桌面所用的
+ * GitHub highlight.js 主题)。
+ */
+
+export type CodeTokenKind =
+  | 'plain'
+  | 'keyword'
+  | 'string'
+  | 'comment'
+  | 'number'
+  | 'function'
+  /** `key:` 形态的属性名 / 字段名(对齐 hljs 的 attr,GitHub 主题着蓝)。 */
+  | 'property';
+
+export interface CodeToken {
+  readonly text: string;
+  readonly kind: CodeTokenKind;
+}
+
+/** 注释与字符串的语法家族 —— 决定用哪套定界符扫描。 */
+type SyntaxFamily = 'c' | 'hash' | 'sql' | 'css' | 'markup' | 'json' | 'generic';
+
+const C_KEYWORDS = [
+  'abstract', 'as', 'async', 'await', 'boolean', 'break', 'case', 'catch', 'char', 'class',
+  'const', 'constructor', 'continue', 'debugger', 'declare', 'default', 'delete', 'do',
+  'double', 'else', 'enum', 'export', 'extends', 'false', 'final', 'finally', 'float', 'for',
+  'from', 'function', 'get', 'goto', 'if', 'implements', 'import', 'in', 'instanceof', 'int',
+  'interface', 'is', 'let', 'long', 'namespace', 'new', 'null', 'of', 'override', 'package',
+  'private', 'protected', 'public', 'readonly', 'return', 'satisfies', 'set', 'static',
+  'struct', 'super', 'switch', 'this', 'throw', 'throws', 'true', 'try', 'type', 'typeof',
+  'undefined', 'union', 'unsigned', 'var', 'void', 'while', 'with', 'yield',
+];
+
+const GO_KEYWORDS = [
+  'break', 'case', 'chan', 'const', 'continue', 'default', 'defer', 'else', 'fallthrough',
+  'false', 'for', 'func', 'go', 'goto', 'if', 'import', 'interface', 'map', 'nil', 'package',
+  'range', 'return', 'select', 'struct', 'switch', 'true', 'type', 'var',
+];
+
+const RUST_KEYWORDS = [
+  'as', 'async', 'await', 'break', 'const', 'continue', 'crate', 'dyn', 'else', 'enum',
+  'extern', 'false', 'fn', 'for', 'if', 'impl', 'in', 'let', 'loop', 'match', 'mod', 'move',
+  'mut', 'pub', 'ref', 'return', 'self', 'static', 'struct', 'super', 'trait', 'true', 'type',
+  'unsafe', 'use', 'where', 'while',
+];
+
+const PYTHON_KEYWORDS = [
+  'and', 'as', 'assert', 'async', 'await', 'break', 'class', 'continue', 'def', 'del', 'elif',
+  'else', 'except', 'False', 'finally', 'for', 'from', 'global', 'if', 'import', 'in', 'is',
+  'lambda', 'None', 'nonlocal', 'not', 'or', 'pass', 'raise', 'return', 'True', 'try',
+  'while', 'with', 'yield',
+];
+
+const SHELL_KEYWORDS = [
+  'case', 'cd', 'do', 'done', 'echo', 'elif', 'else', 'esac', 'exit', 'export', 'fi', 'for',
+  'function', 'if', 'in', 'local', 'return', 'set', 'source', 'then', 'unset', 'until',
+  'while',
+];
+
+const SQL_KEYWORDS = [
+  'and', 'alter', 'as', 'asc', 'by', 'case', 'create', 'delete', 'desc', 'distinct', 'drop',
+  'else', 'end', 'exists', 'from', 'group', 'having', 'in', 'index', 'inner', 'insert',
+  'into', 'is', 'join', 'left', 'like', 'limit', 'not', 'null', 'offset', 'on', 'or', 'order',
+  'outer', 'primary', 'select', 'set', 'table', 'then', 'union', 'update', 'values', 'when',
+  'where', 'with',
+];
+
+const RUBY_KEYWORDS = [
+  'begin', 'break', 'case', 'class', 'def', 'do', 'else', 'elsif', 'end', 'ensure', 'false',
+  'for', 'if', 'in', 'module', 'next', 'nil', 'not', 'or', 'require', 'rescue', 'return',
+  'self', 'then', 'true', 'unless', 'until', 'when', 'while', 'yield',
+];
+
+const YAML_KEYWORDS = ['false', 'no', 'null', 'true', 'yes'];
+
+interface LanguageSpec {
+  readonly family: SyntaxFamily;
+  readonly keywords: readonly string[];
+  /** 关键字是否区分大小写(SQL 惯例大写,故不区分)。 */
+  readonly caseSensitive?: boolean;
+}
+
+const C_LIKE: LanguageSpec = { family: 'c', keywords: C_KEYWORDS, caseSensitive: true };
+
+/** 语言别名 → 规格。键一律小写。 */
+const LANGUAGES: Readonly<Record<string, LanguageSpec>> = {
+  bash: { family: 'hash', keywords: SHELL_KEYWORDS, caseSensitive: true },
+  c: C_LIKE,
+  'c++': C_LIKE,
+  cjs: C_LIKE,
+  cpp: C_LIKE,
+  cs: C_LIKE,
+  csharp: C_LIKE,
+  css: { family: 'css', keywords: [], caseSensitive: false },
+  dart: C_LIKE,
+  go: { family: 'c', keywords: GO_KEYWORDS, caseSensitive: true },
+  golang: { family: 'c', keywords: GO_KEYWORDS, caseSensitive: true },
+  html: { family: 'markup', keywords: [], caseSensitive: false },
+  java: C_LIKE,
+  javascript: C_LIKE,
+  js: C_LIKE,
+  json: { family: 'json', keywords: ['false', 'null', 'true'], caseSensitive: true },
+  json5: { family: 'c', keywords: ['false', 'null', 'true'], caseSensitive: true },
+  jsonc: { family: 'c', keywords: ['false', 'null', 'true'], caseSensitive: true },
+  jsx: C_LIKE,
+  kotlin: C_LIKE,
+  kt: C_LIKE,
+  mjs: C_LIKE,
+  mysql: { family: 'sql', keywords: SQL_KEYWORDS, caseSensitive: false },
+  php: { family: 'c', keywords: C_KEYWORDS, caseSensitive: true },
+  postgres: { family: 'sql', keywords: SQL_KEYWORDS, caseSensitive: false },
+  psql: { family: 'sql', keywords: SQL_KEYWORDS, caseSensitive: false },
+  py: { family: 'hash', keywords: PYTHON_KEYWORDS, caseSensitive: true },
+  python: { family: 'hash', keywords: PYTHON_KEYWORDS, caseSensitive: true },
+  rb: { family: 'hash', keywords: RUBY_KEYWORDS, caseSensitive: true },
+  ruby: { family: 'hash', keywords: RUBY_KEYWORDS, caseSensitive: true },
+  rs: { family: 'c', keywords: RUST_KEYWORDS, caseSensitive: true },
+  rust: { family: 'c', keywords: RUST_KEYWORDS, caseSensitive: true },
+  scala: C_LIKE,
+  scss: { family: 'css', keywords: [], caseSensitive: false },
+  sh: { family: 'hash', keywords: SHELL_KEYWORDS, caseSensitive: true },
+  shell: { family: 'hash', keywords: SHELL_KEYWORDS, caseSensitive: true },
+  sql: { family: 'sql', keywords: SQL_KEYWORDS, caseSensitive: false },
+  sqlite: { family: 'sql', keywords: SQL_KEYWORDS, caseSensitive: false },
+  svelte: { family: 'markup', keywords: [], caseSensitive: false },
+  swift: C_LIKE,
+  toml: { family: 'hash', keywords: YAML_KEYWORDS, caseSensitive: true },
+  ts: C_LIKE,
+  tsx: C_LIKE,
+  typescript: C_LIKE,
+  vue: { family: 'markup', keywords: [], caseSensitive: false },
+  xml: { family: 'markup', keywords: [], caseSensitive: false },
+  yaml: { family: 'hash', keywords: YAML_KEYWORDS, caseSensitive: true },
+  yml: { family: 'hash', keywords: YAML_KEYWORDS, caseSensitive: true },
+  zsh: { family: 'hash', keywords: SHELL_KEYWORDS, caseSensitive: true },
+};
+
+const GENERIC_SPEC: LanguageSpec = { family: 'generic', keywords: [], caseSensitive: true };
+
+/** 未知语言退化为通用词法(仍高亮字符串 / 数字 / `//` 与 `#` 注释)。 */
+function resolveSpec(language: string | undefined): LanguageSpec {
+  if (!language) return GENERIC_SPEC;
+  const key = language.trim().toLowerCase();
+  return LANGUAGES[key] ?? GENERIC_SPEC;
+}
+
+const IDENT_START = /[A-Za-z_$]/;
+const IDENT_BODY = /[A-Za-z0-9_$]/;
+const DIGIT = /[0-9]/;
+
+/**
+ * 把源码切成带 kind 的 token 序列。
+ *
+ * 单趟扫描,优先级:注释 > 字符串 > 数字 > 标识符。相邻同 kind 的片段会合并,
+ * 减少渲染层要创建的 Text 节点数。
+ */
+export function tokenizeCode(source: string, language?: string): CodeToken[] {
+  const spec = resolveSpec(language);
+  const keywords = new Set(
+    spec.caseSensitive === false ? spec.keywords.map((w) => w.toLowerCase()) : spec.keywords,
+  );
+  const out: CodeToken[] = [];
+  let plain = '';
+
+  const flush = () => {
+    if (plain) {
+      out.push({ text: plain, kind: 'plain' });
+      plain = '';
+    }
+  };
+  const push = (text: string, kind: CodeTokenKind) => {
+    if (!text) return;
+    flush();
+    const last = out[out.length - 1];
+    if (last && last.kind === kind) out[out.length - 1] = { text: last.text + text, kind };
+    else out.push({ text, kind });
+  };
+
+  const { family } = spec;
+  const lineComment = family === 'c' ? '//' : family === 'hash' ? '#' : family === 'sql' ? '--' : family === 'generic' ? null : null;
+  // json5 / jsonc 的 family 已经是 'c',由第一个分支覆盖,不单列。
+  const blockComment = family === 'c' || family === 'css' || family === 'sql'
+    ? (['/*', '*/'] as const)
+    : family === 'markup'
+      ? (['<!--', '-->'] as const)
+      : null;
+
+  let i = 0;
+  while (i < source.length) {
+    const rest = source.slice(i);
+
+    // 块注释
+    if (blockComment && rest.startsWith(blockComment[0])) {
+      const end = source.indexOf(blockComment[1], i + blockComment[0].length);
+      const stop = end === -1 ? source.length : end + blockComment[1].length;
+      push(source.slice(i, stop), 'comment');
+      i = stop;
+      continue;
+    }
+    // 行注释:generic 家族同时认 `//` 与 `#`,尽量别把注释染成正文
+    const lineStarts = lineComment
+      ? [lineComment]
+      : family === 'generic'
+        ? ['//', '#']
+        : [];
+    const hitLine = lineStarts.find((mark) => rest.startsWith(mark));
+    if (hitLine) {
+      const nl = source.indexOf('\n', i);
+      const stop = nl === -1 ? source.length : nl;
+      push(source.slice(i, stop), 'comment');
+      i = stop;
+      continue;
+    }
+    // 字符串(未闭合时吃到行尾,避免整块串味)
+    const ch = source[i];
+    if (ch === '"' || ch === '\'' || ch === '`') {
+      let j = i + 1;
+      let closed = false;
+      while (j < source.length) {
+        const cj = source[j];
+        if (cj === '\\') { j += 2; continue; }
+        if (cj === ch) { closed = true; j += 1; break; }
+        if (cj === '\n' && ch !== '`') break;
+        j += 1;
+      }
+      const stop = closed ? j : Math.min(j, source.length);
+      // 带引号的 key(JSON / JS 对象字面量)算属性名,不算普通字符串 —— 与 hljs
+      // 把 JSON key 归到 attr 一致,否则 JSON 里键值同色、读不出结构。
+      push(source.slice(i, stop), closed && isPropertyKey(source, stop) ? 'property' : 'string');
+      i = stop;
+      continue;
+    }
+    // 数字
+    if (DIGIT.test(ch)) {
+      let j = i;
+      while (j < source.length && /[0-9a-fA-FxXoObB_.]/.test(source[j])) j += 1;
+      push(source.slice(i, j), 'number');
+      i = j;
+      continue;
+    }
+    // 标识符 → 关键字 / 函数名 / 普通
+    if (IDENT_START.test(ch)) {
+      let j = i + 1;
+      while (j < source.length && IDENT_BODY.test(source[j])) j += 1;
+      const word = source.slice(i, j);
+      const probe = spec.caseSensitive === false ? word.toLowerCase() : word;
+      if (keywords.has(probe)) {
+        push(word, 'keyword');
+      } else if (isCallSite(source, j)) {
+        push(word, 'function');
+      } else if (isPropertyKey(source, j)) {
+        push(word, 'property');
+      } else {
+        plain += word;
+      }
+      i = j;
+      continue;
+    }
+    plain += ch;
+    i += 1;
+  }
+  flush();
+  return out;
+}
+
+/** 标识符后跳过空格是否紧跟 `(` —— 粗略的函数名判定。 */
+function isCallSite(source: string, from: number): boolean {
+  let k = from;
+  while (k < source.length && (source[k] === ' ' || source[k] === '\t')) k += 1;
+  return source[k] === '(';
+}
+
+/**
+ * 标识符 / 字符串后跳过空格是否紧跟单个 `:` —— 粗略的属性名判定。
+ *
+ * 排除 `::`(C++ / Rust 作用域符)。三元表达式的 `a ? b : c` 会把 b 误判成属性名,
+ * 这是刻意接受的误差:代价只是多一处蓝色,而正确覆盖对象/YAML/JSON 属性名的收益
+ * 远大于此(要真正区分得做表达式级解析,那是 hljs 的量级)。
+ */
+function isPropertyKey(source: string, from: number): boolean {
+  let k = from;
+  while (k < source.length && (source[k] === ' ' || source[k] === '\t')) k += 1;
+  return source[k] === ':' && source[k + 1] !== ':';
+}

--- a/apps/mobile/src/session/codeHighlight.ts
+++ b/apps/mobile/src/session/codeHighlight.ts
@@ -166,12 +166,42 @@ const IDENT_BODY = /[A-Za-z0-9_$]/;
 const DIGIT = /[0-9]/;
 
 /**
+ * 着色预算 —— 超出就退回纯文本(整块或剩余部分并成一个 plain token)。
+ *
+ * 这不是性能洁癖,是渲染层的硬约束:每个非 plain token 在聊天流都会变成一个嵌套
+ * 原生 Text(iOS 的 selectable 路径上是 UITextView 家族子节点),外层横向 ScrollView
+ * **不做虚拟化**,所以挂载成本直接等于 token 数;而流式输出期间整块会随每个 chunk
+ * 重新分词并重新挂载。一个几千行的日志或生成文件因此能同步挂出上万个原生节点,
+ * 卡住 JS / UI 线程。
+ *
+ * 超预算时退回的正是**本 PR 之前的形态** —— 纯文本代码块,底色与描边都还在,不是
+ * 不显示。而且屏幕上本来也只看得见几十行,超过这个量级的着色没有可感知收益。
+ *
+ * 两个维度都要卡:`maxSource` 挡住长块(连分词都不做),`maxTokens` 挡住"短但 token
+ * 极密"的病态输入(比如一行几千个 `a:1,b:2,…`)。
+ */
+export const CODE_HIGHLIGHT_LIMITS = {
+  maxSource: 20_000,
+  maxTokens: 2_000,
+} as const;
+
+/** 整块退回纯文本。空串保持返回空数组(与主路径一致)。 */
+function plainOnly(source: string): CodeToken[] {
+  return source ? [{ text: source, kind: 'plain' }] : [];
+}
+
+/**
  * 把源码切成带 kind 的 token 序列。
  *
  * 单趟扫描,优先级:注释 > 字符串 > 数字 > 标识符。相邻同 kind 的片段会合并,
- * 减少渲染层要创建的 Text 节点数。
+ * 减少渲染层要创建的 Text 节点数。超出 CODE_HIGHLIGHT_LIMITS 时退回纯文本。
+ *
+ * 无论走哪条分支,输出重新拼接后必须与输入逐字节相等(由测试的 assertLossless 守卫)。
  */
 export function tokenizeCode(source: string, language?: string): CodeToken[] {
+  // 长块直接退回:流式期间每个 chunk 都会重跑本函数,所以这里连分词都不做。
+  if (source.length > CODE_HIGHLIGHT_LIMITS.maxSource) return plainOnly(source);
+
   const spec = resolveSpec(language);
   const keywords = new Set(
     spec.caseSensitive === false ? spec.keywords.map((w) => w.toLowerCase()) : spec.keywords,
@@ -202,25 +232,41 @@ export function tokenizeCode(source: string, language?: string): CodeToken[] {
       ? (['<!--', '-->'] as const)
       : null;
 
+  // 行注释起始符:generic 家族同时认 `//` 与 `#`,尽量别把注释染成正文。
+  // 与 lineComment / blockComment 一样是循环不变量,必须在循环外算 —— 放进循环
+  // 等于每个字符都新建一个数组。
+  const lineStarts = lineComment
+    ? [lineComment]
+    : family === 'generic'
+      ? ['//', '#']
+      : [];
+
   let i = 0;
   while (i < source.length) {
-    const rest = source.slice(i);
+    // token 预算用尽:剩余源码整段并入 plain 收尾(仍然无损)。
+    // 计数要带上还没 flush 的 plain,否则一轮里 flush() + push() 会连推两个 token,
+    // 上界变成 maxTokens + 2。带上之后每轮"有效 token 数"最多 +1,收口后 out 至多
+    // 为 maxTokens + 1(那个 +1 是收尾的 plain)。
+    if (out.length + (plain ? 1 : 0) >= CODE_HIGHLIGHT_LIMITS.maxTokens) {
+      plain += source.slice(i);
+      break;
+    }
 
+    // 前缀判定一律用 source.startsWith(mark, i),不要先 source.slice(i) 再判。
+    // 澄清一个容易想当然的点:slice 在 V8 里返回 SlicedString(O(1) 引用,不拷贝
+    // 字符),所以它**不是** O(n²) —— 实测 20k 字符 0.6ms vs 0.3ms、1MB 3.4ms vs
+    // 1.3ms,只是 2~3x 常数因子加一堆短命对象。之所以还是照改:同等正确、更快、
+    // 更少垃圾,而这段是同步跑在渲染路径上。真正的规模保护是上面的 token 预算。
     // 块注释
-    if (blockComment && rest.startsWith(blockComment[0])) {
+    if (blockComment && source.startsWith(blockComment[0], i)) {
       const end = source.indexOf(blockComment[1], i + blockComment[0].length);
       const stop = end === -1 ? source.length : end + blockComment[1].length;
       push(source.slice(i, stop), 'comment');
       i = stop;
       continue;
     }
-    // 行注释:generic 家族同时认 `//` 与 `#`,尽量别把注释染成正文
-    const lineStarts = lineComment
-      ? [lineComment]
-      : family === 'generic'
-        ? ['//', '#']
-        : [];
-    const hitLine = lineStarts.find((mark) => rest.startsWith(mark));
+    // 行注释
+    const hitLine = lineStarts.some((mark) => source.startsWith(mark, i));
     if (hitLine) {
       const nl = source.indexOf('\n', i);
       const stop = nl === -1 ? source.length : nl;

--- a/apps/mobile/src/session/selectableMarkdownHtml.ts
+++ b/apps/mobile/src/session/selectableMarkdownHtml.ts
@@ -22,6 +22,8 @@ export interface SelectableMarkdownHtmlOptions {
   borderColor?: string;
   chipColor?: string;
   fontSize?: number;
+  /** 行内 code 文字色(压暗档,不是底色;见 css 里的说明)。 */
+  inlineCodeColor?: string;
   lineHeight?: number;
   markerWidth?: number;
   mutedColor?: string;
@@ -154,6 +156,7 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
   const mutedColor = cssValue(options.mutedColor ?? lightColors.textSecondary);
   const borderColor = cssValue(options.borderColor ?? lightColors.border);
   const chipColor = cssValue(options.chipColor ?? lightColors.surfaceChip);
+  const inlineCodeColor = cssValue(options.inlineCodeColor ?? lightColors.chatInlineCodeText);
   const fontSize = cssNumber(options.fontSize ?? 16);
   const lineHeight = cssNumber(options.lineHeight ?? 23);
   const codeFontSize = cssNumber(typeScale.code);
@@ -279,10 +282,6 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
       padding: 10px 12px;
       white-space: pre-wrap;
     }
-    /* 行内 code 与正文同底、只用等宽字体区分(与聊天消息流的
-       markdownInlineCode 同口径):底色会把成段正文切成一片色块,而 id / 路径 /
-       字段名这类内容在文档里非常密集。不给底色也就不需要 border-radius /
-       padding —— 它们只会在字词间挤出无意义的空隙。代码块(pre)另有底色与描边。 */
     /* 语法着色只作用于代码块内(pre code):行内 code 不着色 —— 一句话里的短标识
        被染成关键字色反而更吵。与聊天消息流共用 session/codeHighlight 的分词
        结果,配色同为 GitHub 主题。
@@ -293,15 +292,20 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
     pre code .syn-number { color: ${syntax.number}; }
     pre code .syn-function { color: ${syntax.function}; }
     pre code .syn-property { color: ${syntax.property}; }
+    /* 行内 code:零底色 + 等宽字体 + 文字压暗(取值见 tokens 里 chatInlineCodeText)。
+       本文件虽然是 CSS,做得出圆角淡底,但仍跟随聊天消息流的 markdownInlineCode ——
+       同一个 App 里同一种元素不该两副样子;桌面端另走 GitHub 淡底,两端形态刻意不同。 */
     code {
+      color: ${inlineCodeColor};
       font-family: Menlo, Monaco, Consolas, monospace;
       font-size: ${codeFontSize}px;
     }
+    /* 代码块内不压暗:pre 已有底色与描边把它划成独立区块,里面还要承载语法着色,
+       正文片段必须留在正文色上。不写这条 color 就会继承上面 code 的压暗。 */
     pre code {
       background: transparent;
-      border-radius: 0;
+      color: ${textColor};
       font-size: inherit;
-      padding: 0;
     }
     a {
       color: ${textColor};

--- a/apps/mobile/src/session/selectableMarkdownHtml.ts
+++ b/apps/mobile/src/session/selectableMarkdownHtml.ts
@@ -208,9 +208,14 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
       font-weight: 500;
       line-height: ${lineHeight}px;
     }
+    /* 引用正文与列表 marker 走正文色(不用 mutedColor):mutedColor =
+       textSecondary 对底色仅 3.1:1(light)/ 3.4:1(dark),低于 WCAG AA 4.5:1。
+       引用语义由左侧竖线表达,编号与列表项正文同色。与聊天消息流
+       (MessageRenderer 的 markdownQuoteText / markdownListMarker)保持一致。
+       th 仍用 mutedColor —— 表头是元信息且有 font-weight 500 区分。 */
     blockquote {
       border-left: 2px solid ${borderColor};
-      color: ${mutedColor};
+      color: ${textColor};
       padding-left: 8px;
     }
     .list-row {
@@ -218,7 +223,7 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
       gap: 8px;
     }
     #xdt-content .list-marker {
-      color: ${mutedColor};
+      color: ${textColor};
       flex: 0 0 ${markerWidth}px;
       text-align: right;
     }

--- a/apps/mobile/src/session/selectableMarkdownHtml.ts
+++ b/apps/mobile/src/session/selectableMarkdownHtml.ts
@@ -4,9 +4,11 @@ import {
   type MobileMarkdownBlock,
   type MobileMarkdownInline,
 } from '@/session/messageMarkdown';
+import { tokenizeCode } from '@/session/codeHighlight';
 import { parseSessionDeepLinkUrl, shortSessionId } from '@/session/sessionLinks';
 import { buildKatexLoaderJs } from '@/session/mathWebViewHtml';
-import { lightColors, typeScale } from '@/theme/tokens';
+// lineHeight 取别名:本模块内 `lineHeight` 是正文行高的局部变量(来自 options)。
+import { lightColors, lineHeight as lineHeightScale, typeScale } from '@/theme/tokens';
 import { i18n } from '@/i18n';
 
 /**
@@ -28,6 +30,15 @@ export interface SelectableMarkdownHtmlOptions {
    * HTML(WebView 无法事后 patch DOM);缺失时降级「会话 <短id>」。
    */
   sessionLinkTitles?: Readonly<Record<string, string>>;
+  /** 代码块语法着色的 6 档颜色(缺省用 light 主题值)。 */
+  syntaxColors?: {
+    comment?: string;
+    function?: string;
+    keyword?: string;
+    number?: string;
+    property?: string;
+    string?: string;
+  };
   tableCellMinWidth?: number;
   textColor?: string;
   /**
@@ -146,6 +157,18 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
   const fontSize = cssNumber(options.fontSize ?? 16);
   const lineHeight = cssNumber(options.lineHeight ?? 23);
   const codeFontSize = cssNumber(typeScale.code);
+  // 标题两档大号 + 共用行高(20/28、18/28 都是 lineHeight 阶梯里的既有配对)。
+  const headingLargeFontSize = cssNumber(typeScale.title);
+  const headingMediumFontSize = cssNumber(typeScale.subtitle);
+  const headingLineHeight = cssNumber(lineHeightScale.listTitle);
+  const syntax = {
+    comment: cssValue(options.syntaxColors?.comment ?? lightColors.syntaxComment),
+    function: cssValue(options.syntaxColors?.function ?? lightColors.syntaxFunction),
+    keyword: cssValue(options.syntaxColors?.keyword ?? lightColors.syntaxKeyword),
+    number: cssValue(options.syntaxColors?.number ?? lightColors.syntaxNumber),
+    property: cssValue(options.syntaxColors?.property ?? lightColors.syntaxProperty),
+    string: cssValue(options.syntaxColors?.string ?? lightColors.syntaxString),
+  };
   const bodyGap = cssNumber(options.bodyGap ?? 10);
   const markerWidth = cssNumber(options.markerWidth ?? 24);
   const tableCellMinWidth = cssNumber(options.tableCellMinWidth ?? 112);
@@ -203,10 +226,23 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
     p, h1, h2, h3, h4, h5, h6, blockquote, pre, table, .list-row {
       margin: 0;
     }
+    /* 标题分三档。改前 h1–h6 全部等于正文字号(只有 font-weight:500 撑),文档里
+       完全读不出层级 —— 与聊天消息流同一个缺陷、同一套修法:
+         h1  20/28 = 1.400(= desktop h1 比例)
+         h2  18/28 = 1.556(= desktop h2 比例)
+         h3+ 正文字号,靠 500 字重区分(= desktop 让 h3 贴近正文的处理) */
     h1, h2, h3, h4, h5, h6 {
       font-size: ${fontSize}px;
       font-weight: 500;
       line-height: ${lineHeight}px;
+    }
+    h1 {
+      font-size: ${headingLargeFontSize}px;
+      line-height: ${headingLineHeight}px;
+    }
+    h2 {
+      font-size: ${headingMediumFontSize}px;
+      line-height: ${headingLineHeight}px;
     }
     /* 引用正文与列表 marker 走正文色(不用 mutedColor):mutedColor =
        textSecondary 对底色仅 3.1:1(light)/ 3.4:1(dark),低于 WCAG AA 4.5:1。
@@ -243,12 +279,23 @@ function buildSelectableMarkdownCss(options: SelectableMarkdownHtmlOptions): str
       padding: 10px 12px;
       white-space: pre-wrap;
     }
+    /* 行内 code 与正文同底、只用等宽字体区分(与聊天消息流的
+       markdownInlineCode 同口径):底色会把成段正文切成一片色块,而 id / 路径 /
+       字段名这类内容在文档里非常密集。不给底色也就不需要 border-radius /
+       padding —— 它们只会在字词间挤出无意义的空隙。代码块(pre)另有底色与描边。 */
+    /* 语法着色只作用于代码块内(pre code):行内 code 不着色 —— 一句话里的短标识
+       被染成关键字色反而更吵。与聊天消息流共用 session/codeHighlight 的分词
+       结果,配色同为 GitHub 主题。
+       注意:本文件是模板字符串,注释里不能出现反引号。 */
+    pre code .syn-keyword { color: ${syntax.keyword}; }
+    pre code .syn-string { color: ${syntax.string}; }
+    pre code .syn-comment { color: ${syntax.comment}; }
+    pre code .syn-number { color: ${syntax.number}; }
+    pre code .syn-function { color: ${syntax.function}; }
+    pre code .syn-property { color: ${syntax.property}; }
     code {
-      background: ${chipColor};
-      border-radius: 4px;
       font-family: Menlo, Monaco, Consolas, monospace;
       font-size: ${codeFontSize}px;
-      padding: 0 4px;
     }
     pre code {
       background: transparent;
@@ -354,7 +401,9 @@ function renderBlock(block: MobileMarkdownBlock, ctx: RenderContext): string {
       ].join('');
     }
     case 'code':
-      return `<pre><code>${escapeHtml(block.text)}</code></pre>`;
+      // 与聊天消息流同一个 tokenizer(session/codeHighlight),着色口径一致;
+      // 每个非 plain 片段包一层 <span class="syn-*">,颜色见 css 里的 .syn-* 规则。
+      return `<pre><code>${highlightCodeHtml(block.text, block.language)}</code></pre>`;
     case 'mermaid':
       return `<pre><code>${escapeHtml(`// mermaid\n${block.text}`)}</code></pre>`;
     case 'math':
@@ -431,6 +480,21 @@ function renderInline(inline: MobileMarkdownInline, ctx: RenderContext = {}): st
       return `<img src="${escapeAttribute(inline.url)}" data-xdt-src="${escapeAttribute(inline.url)}" alt="${escapeAttribute(inline.alt)}"${size}>`;
     }
   }
+}
+
+/**
+ * 代码块语法着色 → HTML。走与聊天消息流相同的 tokenizer,颜色由 css 的 .syn-*
+ * 规则给(见 buildSelectableMarkdownCss)。每个片段都经 escapeHtml,不会因为着色
+ * 引入未转义内容。
+ */
+function highlightCodeHtml(source: string, language: string | undefined): string {
+  return tokenizeCode(source, language)
+    .map((token) => (
+      token.kind === 'plain'
+        ? escapeHtml(token.text)
+        : `<span class="syn-${token.kind}">${escapeHtml(token.text)}</span>`
+    ))
+    .join('');
 }
 
 function escapeHtml(value: string): string {

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -62,7 +62,7 @@ export interface ThemeColors {
    * (light = `highlight.js/styles/github.css`,dark = globals.css 里的 GitHub Dark
    * 覆盖),两端观感一致。移动端不引入 highlight.js —— 依赖会改 runtime
    * fingerprint 触发冷更,词法分析走仓内 `session/codeHighlight.ts`。
-   * 这 5 档是语义豁免色(语法着色本身就是彩色),不受黑白系约束。
+   * 这 6 档是语义豁免色(语法着色本身就是彩色),不受黑白系约束。
    */
   syntaxKeyword: string;
   syntaxString: string;

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -41,6 +41,23 @@ export interface ThemeColors {
   /** Chat / task code card 专用描边 */
   chatCodeBorder: string;
   /**
+   * markdown 行内 code 文字色 —— 移动端走「零底色 + 文字压暗」形态(参照 Codex
+   * 客户端)。**与桌面刻意不同**:桌面是 CSS,按 GitHub 的半透明淡底 + 6px 圆角实现
+   * (--msg-md-inline-code-bg);移动端聊天流是 RN 嵌套 Text,只认 backgroundColor 不认
+   * borderRadius,淡底在那边只能是直角方块,成段中文里一排方块比没有底色更糟。
+   * 两端不同是结论,不是漏改 —— 改这里之前先看这条。
+   *
+   * 取值实测(见 themeTokens.test.ts):light #686B72 对 surface 4.56:1、对正文
+   * Δ1.98;dark #A3A3A3 对 surface 5.81:1、对正文 Δ1.70 —— 都过 AA 且压暗可辨。
+   * light 值 = textTertiary(表内 AA 中性强调灰);dark 值取自桌面基表
+   * text-secondary 的 dark 原值 —— cindy 深色批准灰阶在 #6F6F6F(2.92:1,掉 AA)与
+   * #BFC1C4(对正文 Δ1.22,压暗看不出)之间没有中间档。
+   * 刻意**不**复用 textSecondary:它是 #8C8E94 / #6F6F6F,只有 2.80:1 / 2.92:1,
+   * 用在正文流里的标识符上会直接掉出 AA(那正是本轮要修的问题)。
+   * 压暗幅度受 AA 下限约束 —— 深色底 #2A2828 比 Codex 的近黑浅得多,再压就破线。
+   */
+  chatInlineCodeText: string;
+  /**
    * 代码高亮语法色(6 档)。色值对齐桌面端所用的 GitHub highlight.js 主题
    * (light = `highlight.js/styles/github.css`,dark = globals.css 里的 GitHub Dark
    * 覆盖),两端观感一致。移动端不引入 highlight.js —— 依赖会改 runtime
@@ -360,6 +377,7 @@ export const lightColors: ThemeColors = {
   activeGlyph: '#DF0C27',
   chatCodeSurface: '#F8F8F8',
   chatCodeBorder: '#DCDFE3',
+  chatInlineCodeText: '#686B72', // = textTertiary(表内 AA 中性强调灰),对 surface 4.56:1
   // GitHub light(highlight.js github.css)原值,与桌面端逐值一致。
   syntaxKeyword: '#D73A49',
   syntaxString: '#032F62',
@@ -430,6 +448,7 @@ export const darkColors: ThemeColors = {
   activeGlyph: '#A61629',
   chatCodeSurface: '#353333',
   chatCodeBorder: '#3C3C3C',
+  chatInlineCodeText: '#A3A3A3', // = 桌面基表 text-secondary dark 原值,对 surface 5.81:1
   // GitHub Dark,取自桌面 globals.css 的 .dark .n* 覆盖(#ff7b72 / #a5d6ff /
   // #8b949e / #79c0ff / #d2a8ff)。
   syntaxKeyword: '#FF7B72',

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -40,6 +40,20 @@ export interface ThemeColors {
   chatCodeSurface: string;
   /** Chat / task code card 专用描边 */
   chatCodeBorder: string;
+  /**
+   * 代码高亮语法色(6 档)。色值对齐桌面端所用的 GitHub highlight.js 主题
+   * (light = `highlight.js/styles/github.css`,dark = globals.css 里的 GitHub Dark
+   * 覆盖),两端观感一致。移动端不引入 highlight.js —— 依赖会改 runtime
+   * fingerprint 触发冷更,词法分析走仓内 `session/codeHighlight.ts`。
+   * 这 5 档是语义豁免色(语法着色本身就是彩色),不受黑白系约束。
+   */
+  syntaxKeyword: string;
+  syntaxString: string;
+  syntaxComment: string;
+  syntaxNumber: string;
+  syntaxFunction: string;
+  /** 属性名 / 字段名(hljs 的 attr;GitHub 主题里与 number 同色)。 */
+  syntaxProperty: string;
   /** Composer / input focus caret。二次改稿 2026-07-18 晚:撤红改蓝,对齐 Mac caret-accent */
   inputCaret: string;
   /** Bottom sheet root 玻璃面 */
@@ -346,6 +360,13 @@ export const lightColors: ThemeColors = {
   activeGlyph: '#DF0C27',
   chatCodeSurface: '#F8F8F8',
   chatCodeBorder: '#DCDFE3',
+  // GitHub light(highlight.js github.css)原值,与桌面端逐值一致。
+  syntaxKeyword: '#D73A49',
+  syntaxString: '#032F62',
+  syntaxComment: '#6A737D',
+  syntaxNumber: '#005CC5',
+  syntaxFunction: '#6F42C1',
+  syntaxProperty: '#005CC5',
   inputCaret: '#417CDD',
   sheetSurface: 'rgba(248, 248, 248, 0.95)',
   sheetActionSurface: '#F6F6F6',
@@ -409,6 +430,14 @@ export const darkColors: ThemeColors = {
   activeGlyph: '#A61629',
   chatCodeSurface: '#353333',
   chatCodeBorder: '#3C3C3C',
+  // GitHub Dark,取自桌面 globals.css 的 .dark .n* 覆盖(#ff7b72 / #a5d6ff /
+  // #8b949e / #79c0ff / #d2a8ff)。
+  syntaxKeyword: '#FF7B72',
+  syntaxString: '#A5D6FF',
+  syntaxComment: '#8B949E',
+  syntaxNumber: '#79C0FF',
+  syntaxFunction: '#D2A8FF',
+  syntaxProperty: '#79C0FF',
   inputCaret: '#417CDD',
   sheetSurface: 'rgba(59, 59, 59, 0.95)',
   sheetActionSurface: 'rgba(59, 59, 59, 0.5)',


### PR DESCRIPTION
## 这次改了什么

### 摘要

聊天 markdown 渲染有一批可读性问题：引用块正文用弱化色（承载的常是本轮最该看的内容，扫读时最先被跳过）、中文被机械加斜、手机端标题三档塌成一档、手机端代码块完全没有语法着色、行内 code 与正文无法区分。这个 PR 把这些一次修掉，并把行内 code 的形态在两端定稿。

问题来源是一次产品评审的完整对话记录，整理后开在 #897。**本 PR 只做其中的排版与配色部分，不 close #897**（"白底叠白底 / 链接附件看不出可点" 与 desktop 正文 `max-width` 未做）。

行内 code 的形态**两端刻意不同**，这是结论不是漏改：

| 路径 | 形态 |
| --- | --- |
| desktop（CSS） | GitHub 淡底 + 6px 圆角 + `.2em .4em` 内距 |
| mobile 聊天流（RN 嵌套 `Text`） | 零底色 + 等宽 + 文字压暗 |
| mobile 文档阅读器（WebView CSS） | 跟随聊天流 |

原因是平台能力：RN 嵌套在 `Text` 内的 inline 片段只认 `backgroundColor`，**不认 `borderRadius`**，淡底在手机聊天流只能是直角方块，成段中文里一排方块比没有底色更糟。文档阅读器虽然是 CSS 做得出圆角，但仍跟随聊天流——同一个 App 里同种元素不该两副样子。

desktop 深色的 alpha 从 GitHub 原值 `0.4` 下调到 `0.22`：照抄 GitHub 后实测两个模式不对称，dark 的抬升（1.56~1.63:1）接近 light（1.11~1.13:1）的 5 倍，实机目检结论是深色下偏重。下调后 1.26~1.28:1。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#897（**不 close**，仅完成其中排版与配色部分）
- 本 PR 包含：
  - **引用块**（两端）：正文由弱化色改为跟随 `text-primary`；去掉中文机械斜体。竖线**刻意不动**——界面里「块引导竖线」是一套统一视觉语言（WorkGroupBlock / ThinkingCard / AgentTaskCard / AgentActionsBlock 全部 `border-l-2` + `--agent-actions-rail`），淡是设计意图，要调得整套一起调。
  - **列表编号 / 项目符号**（mobile）：由灰色改为正文色，与 desktop 对齐。
  - **标题层级**（mobile）：h1/h2/h3 三档拆开，行高按 desktop 的相对比例落位（h1 20/28=1.400、h2 18/28=1.556、h3 17/26）。
  - **代码块语法着色**（mobile，新增）：零依赖分词器 `codeHighlight.ts`，6 类 token（keyword / string / comment / number / function / property），~40 种语言别名，7 个语法族。配色逐值对齐 desktop 所用的 GitHub highlight.js 主题。聊天流与文档阅读器共用分词结果。
  - **行内 code 形态定稿**：desktop 走 GitHub 淡底（新 token `--msg-md-inline-code-bg`，dark alpha 下调）；mobile 走压暗（新 token `chatInlineCodeText`）。
  - **可点路径 chip 钉回正文色**（mobile）：`markdownPathChip` 原本不设颜色、继承 `markdownInlineCode`，压暗后会把**可点的 chip 一起压暗**，正好把 #897 的「看不出可点」做反。现在显式钉回 `textPrimary`——暗 = 普通 code，正文色 + medium + 下划线 = 可点。
  - **文档阅读器正文行高**（mobile）：`body` 16/22 = 1.375 低于 DESIGN.md §3 正文区间 1.43–1.56 下限，长文连续阅读场景换 `bodyRelaxed` 16/24 = 1.50。
- 明确不包含：
  - #897 里的「白底叠白底 / 链接附件看不出可点」与 desktop 正文 `max-width`。
  - mobile 链接色（仍是 `textPrimary` + 下划线，移动端刻意黑白系，未定）。
  - #911（solarized-light 正文自身 4.27:1）。
  - **未触碰任何 mobile runtime fingerprint 输入**，不触发冷更（见「风险」）。
- 用户可见变化：引用块正文更清楚、中文不再被加斜；手机端标题有层级、代码块有语法着色；两端行内 code 可与正文区分。
- 是否存在 breaking change：无

### UI 变化

改动覆盖 desktop 与 mobile 两端的聊天 markdown 渲染与 mobile 文档阅读器。截图未附（见「未执行的验证」）。

- 引用的设计规范：
  - **DESIGN.md §3 Typography Rules** — "Tight display, comfortable body: body text relaxes to 1.43–1.56"。据此把 mobile 文档阅读器正文行高从 1.375 提到 1.50；mobile 标题三档行高按 desktop 相对比例落位（1.400 / 1.556 / 1.500-ish），落在或贴近该区间。
  - **DESIGN.md §10 Theme System & Token Reference — hljs syntax colors 双阈裁决（2026-07-17）**："syntax colors ≥3:1, body text ≥4.5:1"。mobile 新增的 6 档语法色逐值取自 desktop 已裁决的 GitHub 主题（light `highlight.js/styles/github.css`、dark `globals.css` 的 `.dark .hljs-*`），不新造值，因此继承同一裁决。行内 code 承载 id / 路径 / 字段名，属**正文流实义内容**，按同一裁决适用 **body text ≥4.5:1**——这是压暗幅度的硬线，也是 `chatInlineCodeText` 不复用 `textSecondary` 的原因（后者 2.80:1 / 2.92:1，直接掉出 AA）。
  - **DESIGN.md §10 Light / Dark Dual-Mode Delivery Gate** — 所有新增颜色一律走语义 token（desktop 走 `registerColor`，mobile 走 `ThemeColors`），两个模式都给了值，无单模式硬编码或条件补丁。目检情况按该条款「Verification is best-effort and must be reported honestly」如实写在「未执行的验证」。
  - **DESIGN.md §10 Architecture** — "hardcoding hex / rgba inside a component is never allowed"：desktop 侧新色值只落在 `colors.ts` 的 `registerColor`，组件只引 `var(--…)`；mobile 侧只落在 `tokens.ts`，组件走 `useTheme().colors`，由 `designTokenDiscipline.test.ts` 把关。
  - **引用块竖线沿用各端既有取值，本 PR 不改颜色**：desktop 是 `--agent-actions-rail`，mobile 聊天流是 `chatCodeBorder`，mobile 文档阅读器（WebView）是注入的 `borderColor`（= `colors.border`）。全局「块引导竖线」是既定视觉语言，本 PR 只改正文色，不动竖线取值（理由与实测写在 `blockquoteTokens.test.ts` 的文件头）。
  - **已知遗留（改动前就有，本 PR 不扩范围）**：mobile 两条路径的引用竖线颜色本来就不同 ——聊天流 `chatCodeBorder`（light 对 surface 1.14:1）vs 文档阅读器 `colors.border`（1.42:1）。不在本 PR 对齐的两个原因：① WebView CSS 里那个 `borderColor` 同时供表格的 5 处边框使用，改注入值会连带改掉所有表格线；② 对齐到聊天流等于把文档阅读器的竖线**变弱**，与「竖线要调就整套 rail 一起调」的裁决方向相反。本 PR 在文档阅读器只改了宽度（统一为 2px）。

## 怎么验证的

### 自动验证

```text
# 仓库根全量单测门禁(统一脚本)
bash <git-skill>/scripts/run-unit-gate.sh <worktree>
结果：GATE_EXIT=0；日志内 GATE_STARTED 已落、not ok 0 条

# 受影响 package typecheck
pnpm --filter desktop run --if-present typecheck   # 结果：0 error
pnpm --filter mobile  run --if-present typecheck   # 结果：0 error
```

新增 / 加强的机械守卫：

- `apps/desktop/.../themes/__tests__/blockquoteTokens.test.ts`（新增）：11 主题 × 2 条 token 身份断言（引用正文 === 该主题 `text-primary`；引用竖线 === 该主题 `agent-actions-rail`）。刻意不断言绝对对比度，理由写在文件头。
- `apps/desktop/.../themes/__tests__/markdownInlineCodeTokens.test.ts`（新增，22 tests）：11 主题 × 2 条——淡底**必须半透明**（实色一定会在某个容器底上撞色隐形，mobile 已经撞过一次 1.00:1），且**不得与 `--msg-code-inline-bg` 同值**（那个是可点 `FileTargetChip` 与十余处 `hover:bg-` 的实色 chip 底，合并会毁掉「有底色 = 可点」信号）。
- `apps/mobile/src/__tests__/codeHighlight.test.ts`（新增，18 tests）：含 `assertLossless()`（重新拼接的 token 必须与输入逐字节相等），以及一条**源码级守卫**——每个 `<HighlightedCodeText` 调用点必须匹配 `SpanComponent={spanFor(`（原因见下）。
- `apps/mobile/src/__tests__/themeTokens.test.ts`：加对比度 + 压暗方向 + 「不得复用 `textSecondary`」三条断言。
- `apps/mobile/src/__tests__/chatPathCandidate.test.ts`：加源码级守卫——`markdownPathChip` 必须自带 `color`，且样式叠加顺序不能反（RN 这类静默继承没有类型保护，只能在源码层钉）。

### 手工验证

- **desktop**：`pnpm restart:desktop:remote --region=global`（global、共库、正常调度），实机目检引用块、标题、行内 code 淡底；深色 alpha 由 0.4 下调到 0.22 即是这轮目检的结论。
- **mobile**：iOS 模拟器（本 worktree 的 Metro，`pnpm mobile:sim:*`），目检引用块、标题三档、代码块语法着色、行内 code 压暗。
- 过程中修掉两个只有实机才暴露的问题：
  1. 代码块「没有语法高亮」——该样例全是属性名，分词器当时没有 `property` 类，整段落回单个 `plain` token。补了 `property` 类。
  2. 属性名**静默消失**——`react-native-uitextview` 在 iOS `selectable` 下的 wrapper 是原生 `UITextView`，只接受 UITextView 家族子节点，传普通 RN `Text` 会被静默丢弃。改用仓库已有的 `spanFor()`，并补了上面那条源码级守卫。

### 未执行的验证

- **双模式目检不完整**：desktop 与 mobile 都只在实际使用的模式下目检过，**另一种模式未逐屏目检**。按 DESIGN.md §10 双模式交付门槛「Verification is best-effort and must be reported honestly」如实登记：两个模式的**实现**都完成且全部走语义 token（由 `designTokenDiscipline.test.ts` / `markdownInlineCodeTokens.test.ts` / `themeTokens.test.ts` 机械把关），但**不把「复用了 themed 样式」当成「双模式已验证」**。
- **未附截图 / 录屏**：需要 Dash 决定是否公开上传，未自行上传。
- mobile 本地验证归属：branch `dash/msg-readability`，worktree `cindy-msg-readability`，Metro 由该 worktree 启动。
- mobile 缺 RN 组件测试设施，标题层级与压暗色只有 token 层与源码层守卫，没有渲染层断言（另开 issue 跟进，不在本 PR）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- **影响范围**：纯渲染层（颜色 token、字号行高、语法分词）。不动数据、协议、权限、system prompt。
- **不触发冷更**：改动只落在 `apps/mobile/src/**`，未触碰任何 runtime fingerprint 输入——`apps/mobile/package.json`（未加依赖，语法着色是零依赖自研分词器）、`app.json` / `app.config.js`、`eas.json`、`plugins/`、`modules/`、`fingerprint.config.cjs`、lockfile 全部未改。可走热更。
- **勾「跨平台差异」的原因**：行内 code 在 desktop 与 mobile 是**两套形态**，这是 RN 嵌套 `Text` 不支持 `borderRadius` 导致的、有意为之的分叉，已在 `--msg-md-inline-code-bg`、`chatInlineCodeText`、两侧组件注释与两个测试文件头四处写明「两端不同是结论，不是漏改」。
- **一处已知取舍**：desktop 淡底压到 1.26:1 后，与可点 `FileTargetChip` 的实色 `surface-chip`（1.26:1）数值上基本重合，「有底色 = 可点」在静态画面里分不出来，只剩 hover 变色与 `cursor-pointer` 撑着。这是压淡的代价，与 #897 里「链接附件看不出可点」是同一条，留给该项一起解（mobile 侧本 PR 已经用「正文色 + 下划线」把可点态分出来了）。
- **回滚 / 降级方式**：按 commit 回滚即可，无数据迁移、无持久化状态、无协议字段。三个 commit 各自独立可回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（规则与取舍写在 token 注释与测试文件头；未新增 docs 文件）
- [x] 已确认测试结果或说明未执行原因

