### PR TITLE
feat: 新增预制火山方舟 Agent Plan 模型供应商

### DIFF
--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -820,6 +820,34 @@
       }
     },
     {
+      "id": "volcengine-agent-plan",
+      "name": "火山方舟 Agent Plan",
+      "nameEn": "Volcengine Ark Agent Plan",
+      "docsUrl": "https://docs.volcengine.com/docs/82379/2373738",
+      "regionHint": "cn",
+      "runtimes": {
+        "claude-code": {
+          "baseUrl": "https://ark.cn-beijing.volces.com/api/plan",
+          "models": [
+            {
+              "id": "ark-code-latest",
+              "name": "Ark Code Latest"
+            }
+          ]
+        },
+        "codex": {
+          "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+          "wireProtocol": "openai-chat",
+          "models": [
+            {
+              "id": "ark-code-latest",
+              "name": "Ark Code Latest"
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "volcengine-coding-plan",
       "name": "火山方舟 Coding Plan",
       "nameEn": "Volcengine Ark Coding Plan",

--- a/packages/model-providers/src/providerBranding.ts
+++ b/packages/model-providers/src/providerBranding.ts
@@ -81,6 +81,7 @@ const PROVIDER_LOGO_KIND_BY_ID: Readonly<Record<string, ProviderLogoKind>> = {
   'xiaomi-mimo-api-cn': 'xiaomimimo',
   'xiaomi-mimo-token-plan-cn': 'xiaomimimo',
   'volcengine-coding-plan': 'volcengine',
+  'volcengine-agent-plan': 'volcengine',
   'tencentcloud-coding-plan': 'tencentcloud',
   'opencode-go': 'opencode',
   'vercel-ai-gateway': 'vercel',


### PR DESCRIPTION
## 这次改了什么
### 摘要
使用火山方舟 Agent Plan 服务（火山引擎火山方舟Agent Plan套餐），需要在 Cindy 内快速接入、切换火山方舟 Agent Plan 模型，无需手动填写完整 OpenAI 兼容接口地址、特殊请求参数、鉴权配置。
需要实现如下：
 1. 一键切换「火山方舟 Agent Plan」供应商
 2. 支持填入火山方舟 API Key，直接发起对话调用
所以本次更新实现：新增内置模型供应商：Volcano Ark Agent Plan (火山方舟 Agent Plan)

1.  实现[feat: 新增预制火山方舟 Agent Plan 模型供应商](https://github.com/makecindy/cindy/issues/993)

### 变更类型

- [x] `feat` 新功能 
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：feat: 新增预制火山方舟 Agent Plan 模型供应商
- 本 PR 包含：feat: 新增预制火山方舟 Agent Plan 模型供应商
- 明确不包含：
- 用户可见变化：添加模型供应商时，有可直接选择的 【火山方舟Agent Plan】
- 是否存在 breaking change：无 

### UI 变化

<img width="677" height="592" alt="image" src="https://github.com/user-attachments/assets/ec93cbcd-2b09-4484-b51c-0e43b4ff9076" />

- 引用的设计规范：

## 怎么验证的

### 自动验证
1. pnpm --filter desktop exec vitest run src/main/__tests__/webview-security.test.ts src/main/security/__tests__/csp.test.ts
2. pnpm --filter desktop typecheck
3. presets.test.ts 测试通过


```text
pnpm ...
结果：
```

### 手工验证


### 未执行的验证

<!-- 没有执行某项验证时，说明原因；没有则写“无”。mobile 本地验证需注明
branch/worktree、Metro 归属与 __DEV__ build label 证据。 -->

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
- 回滚 / 降级方式：
整体 revert 即可；


### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因