### PR TITLE
fix(mobile): avoid false unresponsive trips on link churn

### DIFF
--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -324,12 +324,13 @@ describe('rehydrateDeviceLinkTopics', () => {
       ),
     });
 
-    await rehydrateDeviceLinkTopics([
+    const result = await rehydrateDeviceLinkTopics([
       { deviceId: 'dev-1', openLink: true, topics: ['sessions'] },
     ], harness);
 
     expect(onDeviceRemoteDisabled).not.toHaveBeenCalled();
     expect(harness.subscribe).toHaveBeenCalledOnce();
+    expect(result.transientFailures).toBe(1);
   });
 
   it('does not count other permanent failures (retrying them is pointless)', async () => {

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -6,9 +6,15 @@ function deps() {
   const calls: string[] = [];
   let nextCohort = 0;
   const harness: DeviceLinkRehydrateDeps = {
+    capturePresenceEpoch: vi.fn(() => 0),
+    isPresenceEpochCurrent: vi.fn(() => true),
     createDeviceSendCohort: vi.fn(() => ++nextCohort),
-    openLink: vi.fn(async (deviceId: string) => {
+    openLink: vi.fn((deviceId: string) => {
       calls.push(`open:${deviceId}`);
+      return {
+        capturedPresenceEpoch: 0,
+        request: Promise.resolve(),
+      };
     }),
     subscribe: vi.fn(async (deviceId: string, topics) => {
       calls.push(`subscribe:${deviceId}:${topics.join(',')}`);
@@ -71,9 +77,12 @@ describe('rehydrateDeviceLinkTopics', () => {
     const { harness } = deps();
     const onDeviceUnavailable = vi.fn();
     harness.onDeviceUnavailable = onDeviceUnavailable;
-    vi.mocked(harness.openLink).mockRejectedValueOnce(
-      Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
-    );
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      request: Promise.reject(
+        Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
+      ),
+    });
 
     const result = await rehydrateDeviceLinkTopics([
       { deviceId: 'dev-1', openLink: true, topics: [] },
@@ -102,6 +111,27 @@ describe('rehydrateDeviceLinkTopics', () => {
     expect(onDeviceUnavailable).toHaveBeenCalledWith('dev-1');
   });
 
+  it('ignores a stale offline verdict after a newer presence delta', async () => {
+    const { harness } = deps();
+    const onDeviceUnavailable = vi.fn();
+    harness.onDeviceUnavailable = onDeviceUnavailable;
+    vi.mocked(harness.isPresenceEpochCurrent).mockReturnValue(false);
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      request: Promise.reject(
+        Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
+      ),
+    });
+
+    const result = await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['sessions'] },
+    ], harness);
+
+    expect(onDeviceUnavailable).not.toHaveBeenCalled();
+    expect(harness.subscribe).toHaveBeenCalledOnce();
+    expect(result.transientFailures).toBe(1);
+  });
+
   it('does not treat transport failures as an unavailable presence verdict', async () => {
     const { harness } = deps();
     const onDeviceUnavailable = vi.fn();
@@ -119,7 +149,10 @@ describe('rehydrateDeviceLinkTopics', () => {
 
   it('continues rebuilding other devices and sessions when one replay step fails', async () => {
     const { calls, harness } = deps();
-    vi.mocked(harness.openLink).mockRejectedValueOnce(new Error('open failed'));
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      request: Promise.reject(new Error('open failed')),
+    });
     vi.mocked(harness.subscribe).mockRejectedValueOnce(new Error('subscribe failed'));
     vi.mocked(harness.rebuildSessionSnapshot).mockRejectedValueOnce(new Error('rebuild failed'));
 
@@ -158,9 +191,12 @@ describe('rehydrateDeviceLinkTopics', () => {
 
   it('does not count permanent failures (retrying them is pointless)', async () => {
     const { harness } = deps();
-    vi.mocked(harness.openLink).mockRejectedValueOnce(
-      Object.assign(new Error('disabled'), { code: 'REMOTE_DISABLED' }),
-    );
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      request: Promise.reject(
+        Object.assign(new Error('disabled'), { code: 'REMOTE_DISABLED' }),
+      ),
+    });
     vi.mocked(harness.rebuildSessionSnapshot).mockRejectedValueOnce(new Error('unexpected'));
 
     const result = await rehydrateDeviceLinkTopics([

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -7,12 +7,15 @@ function deps() {
   let nextCohort = 0;
   const harness: DeviceLinkRehydrateDeps = {
     capturePresenceEpoch: vi.fn(() => 0),
+    captureResponseEvidenceEpoch: vi.fn(() => 0),
     isPresenceEpochCurrent: vi.fn(() => true),
+    isResponseEvidenceEpochCurrent: vi.fn(() => true),
     createDeviceSendCohort: vi.fn(() => ++nextCohort),
     openLink: vi.fn((deviceId: string) => {
       calls.push(`open:${deviceId}`);
       return {
         capturedPresenceEpoch: 0,
+        capturedResponseEvidenceEpoch: 0,
         request: Promise.resolve(),
       };
     }),
@@ -104,6 +107,7 @@ describe('rehydrateDeviceLinkTopics', () => {
     harness.onDeviceUnavailable = onDeviceUnavailable;
     vi.mocked(harness.openLink).mockReturnValueOnce({
       capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
       request: Promise.reject(
         Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
       ),
@@ -143,6 +147,7 @@ describe('rehydrateDeviceLinkTopics', () => {
     vi.mocked(harness.isPresenceEpochCurrent).mockReturnValue(false);
     vi.mocked(harness.openLink).mockReturnValueOnce({
       capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
       request: Promise.reject(
         Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
       ),
@@ -153,6 +158,50 @@ describe('rehydrateDeviceLinkTopics', () => {
     ], harness);
 
     expect(onDeviceUnavailable).not.toHaveBeenCalled();
+    expect(harness.subscribe).toHaveBeenCalledOnce();
+    expect(result.transientFailures).toBe(1);
+  });
+
+  it('downgrades offline after a concurrent send proves the device reachable', async () => {
+    const { harness } = deps();
+    const onDeviceUnavailable = vi.fn();
+    harness.onDeviceUnavailable = onDeviceUnavailable;
+    vi.mocked(harness.isResponseEvidenceEpochCurrent).mockReturnValue(false);
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
+      request: Promise.reject(
+        Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
+      ),
+    });
+
+    const result = await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['sessions'] },
+    ], harness);
+
+    expect(onDeviceUnavailable).not.toHaveBeenCalled();
+    expect(harness.subscribe).toHaveBeenCalledOnce();
+    expect(result.transientFailures).toBe(1);
+  });
+
+  it('downgrades remote-disabled after a concurrent send proves reachability', async () => {
+    const { harness } = deps();
+    const onDeviceRemoteDisabled = vi.fn();
+    harness.onDeviceRemoteDisabled = onDeviceRemoteDisabled;
+    vi.mocked(harness.isResponseEvidenceEpochCurrent).mockReturnValue(false);
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
+      request: Promise.reject(
+        Object.assign(new Error('disabled'), { code: 'REMOTE_DISABLED' }),
+      ),
+    });
+
+    const result = await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['sessions'] },
+    ], harness);
+
+    expect(onDeviceRemoteDisabled).not.toHaveBeenCalled();
     expect(harness.subscribe).toHaveBeenCalledOnce();
     expect(result.transientFailures).toBe(1);
   });
@@ -176,6 +225,7 @@ describe('rehydrateDeviceLinkTopics', () => {
     const { calls, harness } = deps();
     vi.mocked(harness.openLink).mockReturnValueOnce({
       capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
       request: Promise.reject(new Error('open failed')),
     });
     vi.mocked(harness.subscribe).mockRejectedValueOnce(new Error('subscribe failed'));
@@ -220,6 +270,7 @@ describe('rehydrateDeviceLinkTopics', () => {
     harness.onDeviceRemoteDisabled = onDeviceRemoteDisabled;
     vi.mocked(harness.openLink).mockReturnValueOnce({
       capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
       request: Promise.reject(
         Object.assign(new Error('disabled'), { code: 'REMOTE_DISABLED' }),
       ),
@@ -242,6 +293,7 @@ describe('rehydrateDeviceLinkTopics', () => {
     vi.mocked(harness.isPresenceEpochCurrent).mockReturnValue(false);
     vi.mocked(harness.openLink).mockReturnValueOnce({
       capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
       request: Promise.reject(
         Object.assign(new Error('disabled'), { code: 'REMOTE_DISABLED' }),
       ),
@@ -259,6 +311,7 @@ describe('rehydrateDeviceLinkTopics', () => {
     const { harness } = deps();
     vi.mocked(harness.openLink).mockReturnValueOnce({
       capturedPresenceEpoch: 0,
+      capturedResponseEvidenceEpoch: 0,
       request: Promise.reject(
         Object.assign(new Error('unsupported'), { code: 'CHANNEL_NOT_ALLOWED' }),
       ),

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -67,6 +67,56 @@ describe('rehydrateDeviceLinkTopics', () => {
     expect(dev2).not.toBe(dev1Second);
   });
 
+  it('restores unavailable state after an authoritative offline failure', async () => {
+    const { harness } = deps();
+    const onDeviceUnavailable = vi.fn();
+    harness.onDeviceUnavailable = onDeviceUnavailable;
+    vi.mocked(harness.openLink).mockRejectedValueOnce(
+      Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
+    );
+
+    const result = await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: [] },
+    ], harness);
+
+    expect(harness.subscribe).not.toHaveBeenCalled();
+    expect(harness.rebuildSessionSnapshot).not.toHaveBeenCalled();
+    expect(onDeviceUnavailable).toHaveBeenCalledOnce();
+    expect(onDeviceUnavailable).toHaveBeenCalledWith('dev-1');
+    expect(result.transientFailures).toBe(0);
+  });
+
+  it('stops the current device plan when a snapshot confirms it is offline', async () => {
+    const { harness } = deps();
+    const onDeviceUnavailable = vi.fn();
+    harness.onDeviceUnavailable = onDeviceUnavailable;
+    vi.mocked(harness.rebuildSessionSnapshot).mockRejectedValueOnce(
+      Object.assign(new Error('target offline'), { code: 'DEVICE_OFFLINE' }),
+    );
+
+    await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: false, topics: ['session:s1', 'session:s2'] },
+    ], harness);
+
+    expect(harness.rebuildSessionSnapshot).toHaveBeenCalledTimes(1);
+    expect(onDeviceUnavailable).toHaveBeenCalledWith('dev-1');
+  });
+
+  it('does not treat transport failures as an unavailable presence verdict', async () => {
+    const { harness } = deps();
+    const onDeviceUnavailable = vi.fn();
+    harness.onDeviceUnavailable = onDeviceUnavailable;
+    vi.mocked(harness.subscribe).mockRejectedValueOnce(
+      Object.assign(new Error('not connected'), { code: 'NOT_CONNECTED' }),
+    );
+
+    await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: false, topics: ['sessions'] },
+    ], harness);
+
+    expect(onDeviceUnavailable).not.toHaveBeenCalled();
+  });
+
   it('continues rebuilding other devices and sessions when one replay step fails', async () => {
     const { calls, harness } = deps();
     vi.mocked(harness.openLink).mockRejectedValueOnce(new Error('open failed'));

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -73,6 +73,31 @@ describe('rehydrateDeviceLinkTopics', () => {
     expect(dev2).not.toBe(dev1Second);
   });
 
+  it('reports a successful remote step as reachable so stale cleanup can be cancelled', async () => {
+    const { harness } = deps();
+    const onDeviceReachable = vi.fn();
+    harness.onDeviceReachable = onDeviceReachable;
+
+    await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['sessions'] },
+    ], harness);
+
+    expect(onDeviceReachable).toHaveBeenCalledWith('dev-1');
+  });
+
+  it('ignores stale reachable evidence after a newer offline presence delta', async () => {
+    const { harness } = deps();
+    const onDeviceReachable = vi.fn();
+    harness.onDeviceReachable = onDeviceReachable;
+    vi.mocked(harness.isPresenceEpochCurrent).mockReturnValue(false);
+
+    await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: [] },
+    ], harness);
+
+    expect(onDeviceReachable).not.toHaveBeenCalled();
+  });
+
   it('restores unavailable state after an authoritative offline failure', async () => {
     const { harness } = deps();
     const onDeviceUnavailable = vi.fn();

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -4,7 +4,14 @@ import type { DeviceLinkRehydrateDeps } from '@/device-link/rehydrate';
 
 function deps() {
   const calls: string[] = [];
+  const cohorts = new Map<string, number>();
+  let nextCohort = 0;
   const harness: DeviceLinkRehydrateDeps = {
+    createDeviceSendCohort: vi.fn((deviceId: string) => {
+      const cohort = ++nextCohort;
+      cohorts.set(deviceId, cohort);
+      return cohort;
+    }),
     openLink: vi.fn(async (deviceId: string) => {
       calls.push(`open:${deviceId}`);
     }),
@@ -38,6 +45,25 @@ describe('rehydrateDeviceLinkTopics', () => {
       'subscribe:dev-2:session:s2',
       'rebuild:dev-2:s2',
     ]);
+  });
+
+  it('shares one responsiveness cohort across every step for a device', async () => {
+    const { harness } = deps();
+
+    await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['session:s1', 'session:s2'] },
+      { deviceId: 'dev-2', openLink: true, topics: ['session:s3'] },
+    ], harness);
+
+    expect(harness.createDeviceSendCohort).toHaveBeenCalledWith('dev-1');
+    expect(harness.createDeviceSendCohort).toHaveBeenCalledWith('dev-2');
+    expect(harness.createDeviceSendCohort).toHaveBeenCalledTimes(2);
+    const dev1Cohort = vi.mocked(harness.openLink).mock.calls[0][1]?.responsivenessCohort;
+    expect(dev1Cohort).toBeDefined();
+    expect(vi.mocked(harness.subscribe).mock.calls[0][2]?.responsivenessCohort).toBe(dev1Cohort);
+    expect(vi.mocked(harness.rebuildSessionSnapshot).mock.calls[0][2]?.responsivenessCohort).toBe(dev1Cohort);
+    expect(vi.mocked(harness.rebuildSessionSnapshot).mock.calls[1][2]?.responsivenessCohort).toBe(dev1Cohort);
+    expect(vi.mocked(harness.rebuildSessionSnapshot).mock.calls[2][2]?.responsivenessCohort).not.toBe(dev1Cohort);
   });
 
   it('continues rebuilding other devices and sessions when one replay step fails', async () => {

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -214,12 +214,53 @@ describe('rehydrateDeviceLinkTopics', () => {
     expect(result.transientFailures).toBe(2);
   });
 
-  it('does not count permanent failures (retrying them is pointless)', async () => {
+  it('treats remote-disabled as authoritative and stops the device plan', async () => {
     const { harness } = deps();
+    const onDeviceRemoteDisabled = vi.fn();
+    harness.onDeviceRemoteDisabled = onDeviceRemoteDisabled;
     vi.mocked(harness.openLink).mockReturnValueOnce({
       capturedPresenceEpoch: 0,
       request: Promise.reject(
         Object.assign(new Error('disabled'), { code: 'REMOTE_DISABLED' }),
+      ),
+    });
+
+    const result = await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['session:s1'] },
+    ], harness);
+
+    expect(onDeviceRemoteDisabled).toHaveBeenCalledWith('dev-1');
+    expect(harness.subscribe).not.toHaveBeenCalled();
+    expect(harness.rebuildSessionSnapshot).not.toHaveBeenCalled();
+    expect(result.transientFailures).toBe(0);
+  });
+
+  it('ignores stale remote-disabled after a newer presence delta', async () => {
+    const { harness } = deps();
+    const onDeviceRemoteDisabled = vi.fn();
+    harness.onDeviceRemoteDisabled = onDeviceRemoteDisabled;
+    vi.mocked(harness.isPresenceEpochCurrent).mockReturnValue(false);
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      request: Promise.reject(
+        Object.assign(new Error('disabled'), { code: 'REMOTE_DISABLED' }),
+      ),
+    });
+
+    await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['sessions'] },
+    ], harness);
+
+    expect(onDeviceRemoteDisabled).not.toHaveBeenCalled();
+    expect(harness.subscribe).toHaveBeenCalledOnce();
+  });
+
+  it('does not count other permanent failures (retrying them is pointless)', async () => {
+    const { harness } = deps();
+    vi.mocked(harness.openLink).mockReturnValueOnce({
+      capturedPresenceEpoch: 0,
+      request: Promise.reject(
+        Object.assign(new Error('unsupported'), { code: 'CHANNEL_NOT_ALLOWED' }),
       ),
     });
     vi.mocked(harness.rebuildSessionSnapshot).mockRejectedValueOnce(new Error('unexpected'));

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -4,14 +4,9 @@ import type { DeviceLinkRehydrateDeps } from '@/device-link/rehydrate';
 
 function deps() {
   const calls: string[] = [];
-  const cohorts = new Map<string, number>();
   let nextCohort = 0;
   const harness: DeviceLinkRehydrateDeps = {
-    createDeviceSendCohort: vi.fn((deviceId: string) => {
-      const cohort = ++nextCohort;
-      cohorts.set(deviceId, cohort);
-      return cohort;
-    }),
+    createDeviceSendCohort: vi.fn(() => ++nextCohort),
     openLink: vi.fn(async (deviceId: string) => {
       calls.push(`open:${deviceId}`);
     }),
@@ -47,7 +42,7 @@ describe('rehydrateDeviceLinkTopics', () => {
     ]);
   });
 
-  it('shares one responsiveness cohort across every step for a device', async () => {
+  it('uses independent cohorts for each concurrent snapshot batch', async () => {
     const { harness } = deps();
 
     await rehydrateDeviceLinkTopics([
@@ -57,13 +52,19 @@ describe('rehydrateDeviceLinkTopics', () => {
 
     expect(harness.createDeviceSendCohort).toHaveBeenCalledWith('dev-1');
     expect(harness.createDeviceSendCohort).toHaveBeenCalledWith('dev-2');
-    expect(harness.createDeviceSendCohort).toHaveBeenCalledTimes(2);
-    const dev1Cohort = vi.mocked(harness.openLink).mock.calls[0][1]?.responsivenessCohort;
-    expect(dev1Cohort).toBeDefined();
-    expect(vi.mocked(harness.subscribe).mock.calls[0][2]?.responsivenessCohort).toBe(dev1Cohort);
-    expect(vi.mocked(harness.rebuildSessionSnapshot).mock.calls[0][2]?.responsivenessCohort).toBe(dev1Cohort);
-    expect(vi.mocked(harness.rebuildSessionSnapshot).mock.calls[1][2]?.responsivenessCohort).toBe(dev1Cohort);
-    expect(vi.mocked(harness.rebuildSessionSnapshot).mock.calls[2][2]?.responsivenessCohort).not.toBe(dev1Cohort);
+    expect(harness.createDeviceSendCohort).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(harness.openLink).mock.calls[0]).toEqual(['dev-1']);
+    expect(vi.mocked(harness.subscribe).mock.calls[0]).toEqual([
+      'dev-1',
+      ['session:s1', 'session:s2'],
+    ]);
+    const dev1First = vi.mocked(harness.rebuildSessionSnapshot).mock.calls[0][2]?.responsivenessCohort;
+    const dev1Second = vi.mocked(harness.rebuildSessionSnapshot).mock.calls[1][2]?.responsivenessCohort;
+    const dev2 = vi.mocked(harness.rebuildSessionSnapshot).mock.calls[2][2]?.responsivenessCohort;
+    expect(dev1First).toBeDefined();
+    expect(dev1Second).not.toBe(dev1First);
+    expect(dev2).not.toBe(dev1First);
+    expect(dev2).not.toBe(dev1Second);
   });
 
   it('continues rebuilding other devices and sessions when one replay step fails', async () => {

--- a/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
+++ b/apps/mobile/src/__tests__/deviceLinkRehydrate.test.ts
@@ -51,6 +51,31 @@ describe('rehydrateDeviceLinkTopics', () => {
     ]);
   });
 
+  it('stops the remaining sweep when background release cancels it', async () => {
+    const { calls, harness } = deps();
+    let cancelled = false;
+    harness.isCancelled = vi.fn(() => cancelled);
+    vi.mocked(harness.openLink).mockImplementationOnce((deviceId: string) => {
+      calls.push(`open:${deviceId}`);
+      cancelled = true;
+      return {
+        capturedPresenceEpoch: 0,
+        capturedResponseEvidenceEpoch: 0,
+        request: Promise.resolve(),
+      };
+    });
+
+    const result = await rehydrateDeviceLinkTopics([
+      { deviceId: 'dev-1', openLink: true, topics: ['session:s1'] },
+      { deviceId: 'dev-2', openLink: true, topics: ['session:s2'] },
+    ], harness);
+
+    expect(calls).toEqual(['open:dev-1']);
+    expect(harness.subscribe).not.toHaveBeenCalled();
+    expect(harness.rebuildSessionSnapshot).not.toHaveBeenCalled();
+    expect(result.transientFailures).toBe(0);
+  });
+
   it('uses independent cohorts for each concurrent snapshot batch', async () => {
     const { harness } = deps();
 

--- a/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
@@ -65,6 +65,52 @@ describe('deviceResponsivenessBreaker', () => {
     expect(h.breaker.acquire(DEV).decision).toBe('reject');
   });
 
+  it('同一显式 fan-out 一起超时只贡献一次 strike,不会误判为三轮故障', () => {
+    const h = harness();
+    const cohort = h.breaker.createCohort(DEV);
+    const batch = [
+      h.breaker.acquire(DEV, cohort),
+      h.breaker.acquire(DEV, cohort),
+      h.breaker.acquire(DEV, cohort),
+      h.breaker.acquire(DEV, cohort),
+    ];
+    expect(new Set(batch.map((slot) => slot.cohort))).toEqual(new Set([cohort]));
+
+    for (const slot of batch) h.breaker.settle(DEV, slot, 'timeout');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+
+    // 后续普通请求没有显式共享 cohort,各自代表新的独立故障观测。
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+  });
+
+  it('未显式分组的同步请求各自使用独立 cohort', () => {
+    const h = harness();
+    const slots = [
+      h.breaker.acquire(DEV),
+      h.breaker.acquire(DEV),
+      h.breaker.acquire(DEV),
+    ];
+    expect(new Set(slots.map((slot) => slot.cohort)).size).toBe(3);
+
+    for (const slot of slots) h.breaker.settle(DEV, slot, 'timeout');
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+  });
+
+  it('每轮 acquire→timeout 的顺序故障仍按独立 cohort 连续累计', () => {
+    const h = harness();
+    const cohorts: number[] = [];
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) {
+      const slot = h.breaker.acquire(DEV);
+      cohorts.push(slot.cohort);
+      h.breaker.settle(DEV, slot, 'timeout');
+    }
+    expect(new Set(cohorts).size).toBe(BREAKER_FAILURE_THRESHOLD);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
+  });
+
   it('真实回包(即使是业务错误应答)重置连续计数', () => {
     const h = harness();
     timeoutOnce(h.breaker);
@@ -211,29 +257,41 @@ describe('generation:恢复前派出的旧请求结果不采信(review P1)', () 
     expect(h.breaker.isOpen(DEV)).toBe(false); // 新代只累计了 2 次
   });
 
-  it('无状态时的 responded 不翻篇:健康并发下同期超时照常累计(review)', () => {
-    // 若每次 responded 都翻代,健康并发里一个较快回包会把同期在途请求随后的
-    // 超时全部作废——连续超时被低估,设备真卡死时熔断反而难打开。
+  it('健康并发里一个快回包后,同批慢请求一起超时仍只算一个故障批次', () => {
     const h = harness();
-    const slow1 = h.breaker.acquire(DEV);
-    const slow2 = h.breaker.acquire(DEV);
-    const slow3 = h.breaker.acquire(DEV);
-    settleOnce(h.breaker, 'responded'); // 快请求先回包:无状态,不翻代
+    const cohort = h.breaker.createCohort(DEV);
+    const slow1 = h.breaker.acquire(DEV, cohort);
+    const slow2 = h.breaker.acquire(DEV, cohort);
+    const slow3 = h.breaker.acquire(DEV, cohort);
+    const fast = h.breaker.acquire(DEV, cohort);
+    h.breaker.settle(DEV, fast, 'responded'); // 设备当时没有失败状态,不翻代
     h.breaker.settle(DEV, slow1, 'timeout');
     h.breaker.settle(DEV, slow2, 'timeout');
     h.breaker.settle(DEV, slow3, 'timeout');
-    expect(h.breaker.isOpen(DEV)).toBe(true); // 3 条同期超时照常开断路器
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    // 后续两轮独立超时仍会补足三次阈值,没有把真实持续卡死静默掉。
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
   });
 
-  it('clear(撤权)翻篇:清除前在途请求的超时不会重建计数', () => {
+  it('clear(权威 offline / 撤权)翻篇:整批在途超时不会重建计数', () => {
     const h = harness();
-    const stale = h.breaker.acquire(DEV);
+    const stale = [
+      h.breaker.acquire(DEV),
+      h.breaker.acquire(DEV),
+      h.breaker.acquire(DEV),
+    ];
     timeoutOnce(h.breaker);
     h.breaker.clear(DEV);
-    h.breaker.settle(DEV, stale, 'timeout');
-    h.breaker.settle(DEV, stale, 'timeout');
-    h.breaker.settle(DEV, stale, 'timeout');
+    for (const slot of stale) h.breaker.settle(DEV, slot, 'timeout');
     expect(h.breaker.isOpen(DEV)).toBe(false);
+    // 清理不影响之后真正的独立故障检测。
+    timeoutOnce(h.breaker);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+    timeoutOnce(h.breaker);
+    expect(h.breaker.isOpen(DEV)).toBe(true);
   });
 
   it('旧代 responded 同样不采信(不会误关新一代已 open 的熔断)', () => {

--- a/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessBreaker.test.ts
@@ -111,6 +111,19 @@ describe('deviceResponsivenessBreaker', () => {
     expect(h.breaker.isOpen(DEV)).toBe(true);
   });
 
+  it('preserves cohort id uniqueness after a generation bump', () => {
+    const h = harness();
+    const first = h.breaker.createCohort(DEV);
+    const stale = h.breaker.acquire(DEV, first);
+    timeoutOnce(h.breaker);
+    h.breaker.settle(DEV, stale, 'responded');
+
+    const next = h.breaker.acquire(DEV);
+    expect(next.cohort).not.toBe(first);
+    h.breaker.settle(DEV, next, 'timeout');
+    expect(h.breaker.isOpen(DEV)).toBe(false);
+  });
+
   it('真实回包(即使是业务错误应答)重置连续计数', () => {
     const h = harness();
     timeoutOnce(h.breaker);

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -73,10 +73,22 @@ describe('updatePresenceAvailability', () => {
     });
     expect(isPresenceEligibleForRemoteRequest(states, 'dev-1')).toBe(false);
 
-    expect(resetPresenceAvailabilityForConnection(states)).toEqual(['dev-1']);
+    const pendingRecovery = new Set<string>();
+    expect(resetPresenceAvailabilityForConnection(states, pendingRecovery)).toEqual(['dev-1']);
 
     expect(states.size).toBe(0);
+    expect(pendingRecovery).toEqual(new Set(['dev-1']));
     expect(isPresenceEligibleForRemoteRequest(states, 'dev-1')).toBe(true);
     expect(isPresenceEligibleForRemoteRequest(states, 'dev-2')).toBe(true);
+
+    expect(updatePresenceAvailability(states, {
+      deviceId: 'dev-1',
+      online: true,
+      remoteControlEnabled: true,
+    }, pendingRecovery)).toEqual({
+      available: true,
+      recovered: true,
+    });
+    expect(pendingRecovery.size).toBe(0);
   });
 });

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -8,6 +8,9 @@ import {
   isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
   markPresenceAvailabilityEpoch,
+  PRESENCE_WIPE_MAX_LIFETIME_MS,
+  reconcileOfflineVerdictAfterResponse,
+  type PresenceUnavailableVerdict,
   type PresenceWipeTimerEntry,
   resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
@@ -150,6 +153,26 @@ describe('unavailable mirror wipe timer', () => {
     vi.useRealTimers();
   });
 
+  it('caps repeated reconnect extensions at the first-offline lifetime', () => {
+    const { deps, states, timers, wipe } = timerHarness();
+    resetPresenceAvailabilityForConnection(states, new Set());
+
+    for (let step = 2_500; step < PRESENCE_WIPE_MAX_LIFETIME_MS; step += 2_500) {
+      const advanceBy = Math.min(
+        2_500,
+        PRESENCE_WIPE_MAX_LIFETIME_MS - Date.now() - 1,
+      );
+      if (advanceBy <= 0) break;
+      vi.advanceTimersByTime(advanceBy);
+      extendPresenceWipeTimerFloor(timers, states, 'dev-1', 3_000, deps);
+      expect(wipe).not.toHaveBeenCalled();
+    }
+
+    vi.advanceTimersByTime(PRESENCE_WIPE_MAX_LIFETIME_MS - Date.now());
+    expect(wipe).toHaveBeenCalledWith('dev-1');
+    vi.useRealTimers();
+  });
+
   it('cancels cleanup after a near-expiry reconnect proves the device reachable', () => {
     const { deps, states, timers, wipe } = timerHarness();
     vi.advanceTimersByTime(4_900);
@@ -163,6 +186,64 @@ describe('unavailable mirror wipe timer', () => {
     expect(wipe).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
+});
+
+describe('late response verdict reconciliation', () => {
+  function harness(kind: PresenceUnavailableVerdict['kind'], responseEvidenceEpoch: number) {
+    const states = new Map<string, boolean>([['dev-1', false]]);
+    const pendingRecovery = new Set<string>();
+    const verdicts = new Map<string, PresenceUnavailableVerdict>([[
+      'dev-1',
+      { kind, responseEvidenceEpoch },
+    ]]);
+    return { pendingRecovery, states, verdicts };
+  }
+
+  it('returns a superseded rehydrate-offline verdict to unknown', () => {
+    const { pendingRecovery, states, verdicts } = harness('offline', 3);
+
+    expect(reconcileOfflineVerdictAfterResponse(
+      states,
+      pendingRecovery,
+      verdicts,
+      'dev-1',
+      4,
+    )).toBe(true);
+    expect(states.has('dev-1')).toBe(false);
+    expect(pendingRecovery).toEqual(new Set(['dev-1']));
+    expect(verdicts.has('dev-1')).toBe(false);
+  });
+
+  it('keeps an offline verdict when response evidence is not newer', () => {
+    const { pendingRecovery, states, verdicts } = harness('offline', 3);
+
+    expect(reconcileOfflineVerdictAfterResponse(
+      states,
+      pendingRecovery,
+      verdicts,
+      'dev-1',
+      3,
+    )).toBe(false);
+    expect(states.get('dev-1')).toBe(false);
+    expect(pendingRecovery.size).toBe(0);
+  });
+
+  it.each(['disabled', 'presence'] as const)(
+    'does not let a raw response clear an authoritative %s verdict',
+    (kind) => {
+      const { pendingRecovery, states, verdicts } = harness(kind, 3);
+
+      expect(reconcileOfflineVerdictAfterResponse(
+        states,
+        pendingRecovery,
+        verdicts,
+        'dev-1',
+        4,
+      )).toBe(false);
+      expect(states.get('dev-1')).toBe(false);
+      expect(verdicts.get('dev-1')?.kind).toBe(kind);
+    },
+  );
 });
 
 describe('presence availability epochs', () => {

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -119,6 +119,7 @@ describe('unavailable mirror wipe timer', () => {
       setTimer: (callback: () => void, delayMs: number) => setTimeout(callback, delayMs),
       clearTimer: clearTimeout,
       wipe,
+      isConfirmationInFlight: undefined as (() => boolean) | undefined,
     };
     schedulePresenceWipeTimer(timers, states, 'dev-1', 5_000, deps);
     return { deps, states, timers, wipe };
@@ -185,6 +186,39 @@ describe('unavailable mirror wipe timer', () => {
     vi.advanceTimersByTime(2_000);
 
     expect(wipe).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('defers cleanup past the reconnect floor while confirmation is in flight', () => {
+    const { deps, states, timers, wipe } = timerHarness();
+    let confirming = true;
+    deps.isConfirmationInFlight = () => confirming;
+    vi.advanceTimersByTime(4_900);
+    resetPresenceAvailabilityForConnection(states, new Set());
+    extendPresenceWipeTimerFloor(timers, states, 'dev-1', 3_000, deps);
+
+    vi.advanceTimersByTime(3_000);
+    expect(wipe).not.toHaveBeenCalled();
+    confirming = false;
+    clearPresenceWipeTimer(timers, 'dev-1', deps.clearTimer);
+    vi.advanceTimersByTime(1_000);
+
+    expect(wipe).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('allows only an active confirmation to cross the maximum lifetime', () => {
+    const { deps, states, timers, wipe } = timerHarness();
+    let confirming = true;
+    deps.isConfirmationInFlight = () => confirming;
+    resetPresenceAvailabilityForConnection(states, new Set());
+
+    vi.advanceTimersByTime(PRESENCE_WIPE_MAX_LIFETIME_MS);
+    expect(wipe).not.toHaveBeenCalled();
+    confirming = false;
+    vi.advanceTimersByTime(1_000);
+
+    expect(wipe).toHaveBeenCalledWith('dev-1');
     vi.useRealTimers();
   });
 });

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -5,6 +5,7 @@ import {
   createPresenceAvailabilityEpochs,
   extendPresenceWipeTimerFloor,
   getOrCreatePresenceTrackedRequest,
+  isInvokeResultReachabilityEvidence,
   isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
   markPresenceAvailabilityEpoch,
@@ -185,6 +186,34 @@ describe('unavailable mirror wipe timer', () => {
 
     expect(wipe).not.toHaveBeenCalled();
     vi.useRealTimers();
+  });
+});
+
+describe('invoke reachability evidence', () => {
+  it('counts successful and non-availability error results as target responses', () => {
+    expect(isInvokeResultReachabilityEvidence({
+      ok: true,
+      result: null,
+    })).toBe(true);
+    expect(isInvokeResultReachabilityEvidence({
+      ok: false,
+      error: { code: 'IPC_ERROR', message: 'boom' },
+    })).toBe(true);
+    expect(isInvokeResultReachabilityEvidence({
+      ok: false,
+      error: { code: 'CHANNEL_NOT_ALLOWED', message: 'unsupported' },
+    })).toBe(true);
+  });
+
+  it('does not count disabled or revoked results as reachability', () => {
+    expect(isInvokeResultReachabilityEvidence({
+      ok: false,
+      error: { code: 'REMOTE_DISABLED', message: 'disabled' },
+    })).toBe(false);
+    expect(isInvokeResultReachabilityEvidence({
+      ok: false,
+      error: { code: 'ACCESS_REVOKED', message: 'revoked' },
+    })).toBe(false);
   });
 });
 

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   capturePresenceAvailabilityEpoch,
+  clearPresenceWipeTimer,
   createPresenceAvailabilityEpochs,
   getOrCreatePresenceTrackedRequest,
   isPresenceAvailabilityEpochCurrent,
@@ -8,6 +9,7 @@ import {
   markPresenceAvailabilityEpoch,
   resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
+  schedulePresenceWipeTimer,
   updatePresenceAvailability,
 } from '@/device-link/presenceRecovery';
 
@@ -96,6 +98,48 @@ describe('updatePresenceAvailability', () => {
       recovered: true,
     });
     expect(pendingRecovery.size).toBe(0);
+  });
+});
+
+describe('unavailable mirror wipe timer', () => {
+  function timerHarness() {
+    vi.useFakeTimers();
+    const timers = new Map<string, ReturnType<typeof setTimeout>>();
+    const states = new Map<string, boolean>([['dev-1', false]]);
+    const wipe = vi.fn();
+    const deps = {
+      setTimer: (callback: () => void, delayMs: number) => setTimeout(callback, delayMs),
+      clearTimer: clearTimeout,
+      wipe,
+    };
+    schedulePresenceWipeTimer(timers, states, 'dev-1', 5_000, deps);
+    return { deps, states, timers, wipe };
+  }
+
+  it('preserves the original deadline across reconnect and then cleans an unconfirmed device', () => {
+    const { states, wipe } = timerHarness();
+    vi.advanceTimersByTime(2_000);
+
+    resetPresenceAvailabilityForConnection(states, new Set());
+    expect(wipe).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2_999);
+    expect(wipe).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(wipe).toHaveBeenCalledWith('dev-1');
+    vi.useRealTimers();
+  });
+
+  it('cancels the original cleanup when the new connection proves the device reachable', () => {
+    const { deps, states, timers, wipe } = timerHarness();
+    vi.advanceTimersByTime(2_000);
+    resetPresenceAvailabilityForConnection(states, new Set());
+
+    clearPresenceWipeTimer(timers, 'dev-1', deps.clearTimer);
+    vi.advanceTimersByTime(3_000);
+
+    expect(wipe).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });
 

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { updatePresenceAvailability } from '@/device-link/presenceRecovery';
+import {
+  isPresenceEligibleForRemoteRequest,
+  resetPresenceAvailabilityForConnection,
+  updatePresenceAvailability,
+} from '@/device-link/presenceRecovery';
 
 describe('updatePresenceAvailability', () => {
   it('does not treat the first available snapshot as a recovery', () => {
@@ -53,5 +57,26 @@ describe('updatePresenceAvailability', () => {
       available: true,
       recovered: false,
     });
+  });
+
+  it('forgets delta-only verdicts at a new connection epoch so stale offline cannot block rehydrate', () => {
+    const states = new Map<string, boolean>();
+    updatePresenceAvailability(states, {
+      deviceId: 'dev-1',
+      online: false,
+      remoteControlEnabled: true,
+    });
+    updatePresenceAvailability(states, {
+      deviceId: 'dev-2',
+      online: true,
+      remoteControlEnabled: true,
+    });
+    expect(isPresenceEligibleForRemoteRequest(states, 'dev-1')).toBe(false);
+
+    expect(resetPresenceAvailabilityForConnection(states)).toEqual(['dev-1']);
+
+    expect(states.size).toBe(0);
+    expect(isPresenceEligibleForRemoteRequest(states, 'dev-1')).toBe(true);
+    expect(isPresenceEligibleForRemoteRequest(states, 'dev-2')).toBe(true);
   });
 });

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -3,10 +3,12 @@ import {
   capturePresenceAvailabilityEpoch,
   clearPresenceWipeTimer,
   createPresenceAvailabilityEpochs,
+  extendPresenceWipeTimerFloor,
   getOrCreatePresenceTrackedRequest,
   isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
   markPresenceAvailabilityEpoch,
+  type PresenceWipeTimerEntry,
   resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
   schedulePresenceWipeTimer,
@@ -104,10 +106,12 @@ describe('updatePresenceAvailability', () => {
 describe('unavailable mirror wipe timer', () => {
   function timerHarness() {
     vi.useFakeTimers();
-    const timers = new Map<string, ReturnType<typeof setTimeout>>();
+    vi.setSystemTime(0);
+    const timers = new Map<string, PresenceWipeTimerEntry>();
     const states = new Map<string, boolean>([['dev-1', false]]);
     const wipe = vi.fn();
     const deps = {
+      now: Date.now,
       setTimer: (callback: () => void, delayMs: number) => setTimeout(callback, delayMs),
       clearTimer: clearTimeout,
       wipe,
@@ -116,12 +120,12 @@ describe('unavailable mirror wipe timer', () => {
     return { deps, states, timers, wipe };
   }
 
-  it('preserves the original deadline across reconnect and then cleans an unconfirmed device', () => {
-    const { states, wipe } = timerHarness();
+  it('keeps the original deadline when reconnect leaves enough confirmation time', () => {
+    const { deps, states, timers, wipe } = timerHarness();
     vi.advanceTimersByTime(2_000);
 
     resetPresenceAvailabilityForConnection(states, new Set());
-    expect(wipe).not.toHaveBeenCalled();
+    extendPresenceWipeTimerFloor(timers, states, 'dev-1', 3_000, deps);
 
     vi.advanceTimersByTime(2_999);
     expect(wipe).not.toHaveBeenCalled();
@@ -130,13 +134,31 @@ describe('unavailable mirror wipe timer', () => {
     vi.useRealTimers();
   });
 
-  it('cancels the original cleanup when the new connection proves the device reachable', () => {
+  it('extends a near-expiry deadline to leave reconnect time for reachability proof', () => {
     const { deps, states, timers, wipe } = timerHarness();
-    vi.advanceTimersByTime(2_000);
+    vi.advanceTimersByTime(4_900);
+
     resetPresenceAvailabilityForConnection(states, new Set());
+    extendPresenceWipeTimerFloor(timers, states, 'dev-1', 3_000, deps);
+
+    vi.advanceTimersByTime(100);
+    expect(wipe).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2_899);
+    expect(wipe).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(wipe).toHaveBeenCalledWith('dev-1');
+    vi.useRealTimers();
+  });
+
+  it('cancels cleanup after a near-expiry reconnect proves the device reachable', () => {
+    const { deps, states, timers, wipe } = timerHarness();
+    vi.advanceTimersByTime(4_900);
+    resetPresenceAvailabilityForConnection(states, new Set());
+    extendPresenceWipeTimerFloor(timers, states, 'dev-1', 3_000, deps);
+    vi.advanceTimersByTime(1_000);
 
     clearPresenceWipeTimer(timers, 'dev-1', deps.clearTimer);
-    vi.advanceTimersByTime(3_000);
+    vi.advanceTimersByTime(2_000);
 
     expect(wipe).not.toHaveBeenCalled();
     vi.useRealTimers();

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -177,8 +177,9 @@ describe('presence availability epochs', () => {
     expect(isPresenceAvailabilityEpochCurrent(epochs, 'dev-2', dev2ProbeEpoch)).toBe(true);
   });
 
-  it('keeps the request-creation epoch when callers share an in-flight request', async () => {
+  it('keeps both request-creation epochs when callers share an in-flight request', async () => {
     const epochs = createPresenceAvailabilityEpochs();
+    const responseEvidenceEpochs = createPresenceAvailabilityEpochs();
     const inFlight = new Map();
     let resolveRequest!: () => void;
     const request = new Promise<void>((resolve) => {
@@ -188,23 +189,32 @@ describe('presence availability epochs', () => {
     const first = getOrCreatePresenceTrackedRequest(
       inFlight,
       epochs,
+      responseEvidenceEpochs,
       'dev-1',
       () => request,
     );
     markPresenceAvailabilityEpoch(epochs, 'dev-1');
+    markPresenceAvailabilityEpoch(responseEvidenceEpochs, 'dev-1');
     const deduped = getOrCreatePresenceTrackedRequest(
       inFlight,
       epochs,
+      responseEvidenceEpochs,
       'dev-1',
       () => Promise.resolve(),
     );
 
     expect(deduped).toBe(first);
     expect(deduped.capturedPresenceEpoch).toBe(0);
+    expect(deduped.capturedResponseEvidenceEpoch).toBe(0);
     expect(isPresenceAvailabilityEpochCurrent(
       epochs,
       'dev-1',
       deduped.capturedPresenceEpoch,
+    )).toBe(false);
+    expect(isPresenceAvailabilityEpochCurrent(
+      responseEvidenceEpochs,
+      'dev-1',
+      deduped.capturedResponseEvidenceEpoch,
     )).toBe(false);
 
     resolveRequest();

--- a/apps/mobile/src/__tests__/presenceRecovery.test.ts
+++ b/apps/mobile/src/__tests__/presenceRecovery.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  capturePresenceAvailabilityEpoch,
+  createPresenceAvailabilityEpochs,
+  getOrCreatePresenceTrackedRequest,
+  isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
+  markPresenceAvailabilityEpoch,
+  resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
   updatePresenceAvailability,
 } from '@/device-link/presenceRecovery';
@@ -90,5 +96,61 @@ describe('updatePresenceAvailability', () => {
       recovered: true,
     });
     expect(pendingRecovery.size).toBe(0);
+  });
+});
+
+describe('presence availability epochs', () => {
+  it('invalidates an older probe only when that device receives a newer presence delta', () => {
+    const epochs = createPresenceAvailabilityEpochs();
+    const dev1ProbeEpoch = capturePresenceAvailabilityEpoch(epochs, 'dev-1');
+    const dev2ProbeEpoch = capturePresenceAvailabilityEpoch(epochs, 'dev-2');
+
+    markPresenceAvailabilityEpoch(epochs, 'dev-1');
+
+    expect(isPresenceAvailabilityEpochCurrent(epochs, 'dev-1', dev1ProbeEpoch)).toBe(false);
+    expect(isPresenceAvailabilityEpochCurrent(epochs, 'dev-2', dev2ProbeEpoch)).toBe(true);
+  });
+
+  it('keeps the request-creation epoch when callers share an in-flight request', async () => {
+    const epochs = createPresenceAvailabilityEpochs();
+    const inFlight = new Map();
+    let resolveRequest!: () => void;
+    const request = new Promise<void>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const first = getOrCreatePresenceTrackedRequest(
+      inFlight,
+      epochs,
+      'dev-1',
+      () => request,
+    );
+    markPresenceAvailabilityEpoch(epochs, 'dev-1');
+    const deduped = getOrCreatePresenceTrackedRequest(
+      inFlight,
+      epochs,
+      'dev-1',
+      () => Promise.resolve(),
+    );
+
+    expect(deduped).toBe(first);
+    expect(deduped.capturedPresenceEpoch).toBe(0);
+    expect(isPresenceAvailabilityEpochCurrent(
+      epochs,
+      'dev-1',
+      deduped.capturedPresenceEpoch,
+    )).toBe(false);
+
+    resolveRequest();
+    await request;
+  });
+
+  it('resets epochs on logout or account change', () => {
+    const epochs = createPresenceAvailabilityEpochs();
+    markPresenceAvailabilityEpoch(epochs, 'dev-1');
+    resetPresenceAvailabilityEpochs(epochs);
+
+    expect(capturePresenceAvailabilityEpoch(epochs, 'dev-1')).toBe(0);
+    expect(epochs.next).toBe(0);
   });
 });

--- a/apps/mobile/src/__tests__/reconnectHeal.test.ts
+++ b/apps/mobile/src/__tests__/reconnectHeal.test.ts
@@ -93,8 +93,13 @@ describe('reconnect host-authoritative healing', () => {
     expect(remoteSessionStore.getMessages(SESSION_ID).map((item) => item.id)).toEqual(['m1', 'm2']);
 
     await rehydrateDeviceLinkTopics(registry.snapshot(), {
+      capturePresenceEpoch: vi.fn(() => 0),
+      isPresenceEpochCurrent: vi.fn(() => true),
       createDeviceSendCohort: vi.fn(() => 1),
-      openLink: vi.fn(async () => undefined),
+      openLink: vi.fn(() => ({
+        capturedPresenceEpoch: 0,
+        request: Promise.resolve(),
+      })),
       subscribe: vi.fn(async () => undefined),
       requestSessionsReseed,
       rebuildSessionSnapshot: vi.fn(async (_deviceId, sessionId) => {

--- a/apps/mobile/src/__tests__/reconnectHeal.test.ts
+++ b/apps/mobile/src/__tests__/reconnectHeal.test.ts
@@ -94,10 +94,13 @@ describe('reconnect host-authoritative healing', () => {
 
     await rehydrateDeviceLinkTopics(registry.snapshot(), {
       capturePresenceEpoch: vi.fn(() => 0),
+      captureResponseEvidenceEpoch: vi.fn(() => 0),
       isPresenceEpochCurrent: vi.fn(() => true),
+      isResponseEvidenceEpochCurrent: vi.fn(() => true),
       createDeviceSendCohort: vi.fn(() => 1),
       openLink: vi.fn(() => ({
         capturedPresenceEpoch: 0,
+        capturedResponseEvidenceEpoch: 0,
         request: Promise.resolve(),
       })),
       subscribe: vi.fn(async () => undefined),

--- a/apps/mobile/src/__tests__/reconnectHeal.test.ts
+++ b/apps/mobile/src/__tests__/reconnectHeal.test.ts
@@ -93,6 +93,7 @@ describe('reconnect host-authoritative healing', () => {
     expect(remoteSessionStore.getMessages(SESSION_ID).map((item) => item.id)).toEqual(['m1', 'm2']);
 
     await rehydrateDeviceLinkTopics(registry.snapshot(), {
+      createDeviceSendCohort: vi.fn(() => 1),
       openLink: vi.fn(async () => undefined),
       subscribe: vi.fn(async () => undefined),
       requestSessionsReseed,

--- a/apps/mobile/src/__tests__/snapshotBatchFailure.test.ts
+++ b/apps/mobile/src/__tests__/snapshotBatchFailure.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { classifySnapshotBatchFailure } from '@/device-link/rehydrate';
+
+function fulfilled(value: unknown = undefined): PromiseFulfilledResult<unknown> {
+  return { status: 'fulfilled', value };
+}
+
+function rejected(code: string): PromiseRejectedResult {
+  return {
+    status: 'rejected',
+    reason: Object.assign(new Error(code), { code }),
+  };
+}
+
+describe('classifySnapshotBatchFailure', () => {
+  it('downgrades mixed availability errors when a sibling proves target reachability', () => {
+    expect(classifySnapshotBatchFailure([
+      fulfilled([]),
+      rejected('DEVICE_OFFLINE'),
+      rejected('REMOTE_DISABLED'),
+      rejected('DEVICE_OFFLINE'),
+    ])).toEqual({ kind: 'partial-transient' });
+  });
+
+  it('preserves an all-offline batch as an authoritative verdict', () => {
+    const offline = rejected('DEVICE_OFFLINE');
+    expect(classifySnapshotBatchFailure([
+      offline,
+      rejected('DEVICE_OFFLINE'),
+      rejected('DEVICE_OFFLINE'),
+      rejected('DEVICE_OFFLINE'),
+    ])).toEqual({ kind: 'reject', error: offline.reason });
+  });
+
+  it('downgrades availability and other transient siblings after a target response', () => {
+    expect(classifySnapshotBatchFailure([
+      fulfilled([]),
+      rejected('DEVICE_OFFLINE'),
+      rejected('INVOKE_TIMEOUT'),
+      rejected('REMOTE_DISABLED'),
+    ])).toEqual({ kind: 'partial-transient' });
+  });
+
+  it('surfaces an all-disabled batch as authoritative unavailable', () => {
+    const disabled = rejected('REMOTE_DISABLED');
+    expect(classifySnapshotBatchFailure([
+      disabled,
+      rejected('REMOTE_DISABLED'),
+      rejected('REMOTE_DISABLED'),
+      rejected('REMOTE_DISABLED'),
+    ])).toEqual({ kind: 'reject', error: disabled.reason });
+  });
+
+  it('preserves offline evidence over an unrelated transient when no sibling answered', () => {
+    const offline = rejected('DEVICE_OFFLINE');
+    expect(classifySnapshotBatchFailure([
+      offline,
+      rejected('DEVICE_OFFLINE'),
+      rejected('INVOKE_TIMEOUT'),
+      rejected('DEVICE_OFFLINE'),
+    ])).toEqual({ kind: 'reject', error: offline.reason });
+  });
+
+  it('prefers remote-disabled when no sibling answered and availability markers conflict', () => {
+    const disabled = rejected('REMOTE_DISABLED');
+    expect(classifySnapshotBatchFailure([
+      rejected('DEVICE_OFFLINE'),
+      disabled,
+      rejected('DEVICE_OFFLINE'),
+      rejected('INVOKE_TIMEOUT'),
+    ])).toEqual({ kind: 'reject', error: disabled.reason });
+  });
+
+  it('ignores permanent-only failures', () => {
+    expect(classifySnapshotBatchFailure([
+      rejected('CHANNEL_NOT_ALLOWED'),
+      rejected('ACCESS_REVOKED'),
+    ])).toEqual({ kind: 'none' });
+  });
+});

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -817,18 +817,16 @@ function ensureOnlineForRequest(client: DeviceLinkClient): Promise<void> {
 function sendOpenLinkWithAccessHandling(
   client: DeviceLinkClient,
   deviceId: string,
-  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<LinkAcceptPayload> {
-  return withAccessRevokedHandling(deviceId, () => sendOpenLink(client, deviceId, opts));
+  return withAccessRevokedHandling(deviceId, () => sendOpenLink(client, deviceId));
 }
 
 async function sendOpenLink(
   client: DeviceLinkClient,
   deviceId: string,
-  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<LinkAcceptPayload> {
   // 熔断门禁放在连接等待之前:open 时快速失败,不消耗 1.5s 重连等待也不上管道。
-  const slot = acquireDeviceSendSlot(deviceId, opts?.responsivenessCohort);
+  const slot = acquireDeviceSendSlot(deviceId);
   try {
     await ensureOnlineForRequest(client);
   } catch (err) {
@@ -922,19 +920,17 @@ function sendSubscribeWithAccessHandling(
   client: DeviceLinkClient,
   deviceId: string,
   topics: readonly string[],
-  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<void> {
-  return withAccessRevokedHandling(deviceId, () => sendSubscribe(client, deviceId, topics, opts));
+  return withAccessRevokedHandling(deviceId, () => sendSubscribe(client, deviceId, topics));
 }
 
 async function sendSubscribe(
   client: DeviceLinkClient,
   deviceId: string,
   topics: readonly string[],
-  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<void> {
   // subscribe 同样走隧道请求超时等待(默认 15s),一样计入并受熔断限制(见 sendInvoke 注释)。
-  const slot = acquireDeviceSendSlot(deviceId, opts?.responsivenessCohort);
+  const slot = acquireDeviceSendSlot(deviceId);
   try {
     await ensureOnlineForRequest(client);
   } catch (err) {

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -165,6 +165,8 @@ const REHYDRATE_RETRY_MAX_MS = 30_000;
  * 断连 → 重连 → 补齐,弱网下这套循环的代价远高于让 socket 多活两秒。
  */
 const BACKGROUND_STOP_GRACE_MS = 2_500;
+/** 断开前最多等最后一轮 heavy unsubscribe 应答;超时仍停止,避免后台 socket 久留。 */
+const BACKGROUND_FINAL_UNSUBSCRIBE_WAIT_MS = 1_000;
 /**
  * 回前台时若「宽限计时器还挂着」但后台时长已超过此阈值,说明 JS 在计时器触发前
  * 被 iOS 挂起——socket 大概率已被系统回收,但状态机还认为 online。此时主动换新
@@ -315,6 +317,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
           invalidateTransientScheduleIndexFailures();
           do {
             state.rerun = false;
+            if (backgroundReleaseInFlightRef.current) break;
             if (client.getStatus() !== 'online') return;
             const allPlans = registryRef.current.snapshot();
             // 撤权设备直接出局(review P1):撤权是终态,openLink 只会等来
@@ -368,6 +371,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
               }
             })();
             const result = await rehydrateDeviceLinkTopics(plans, {
+              isCancelled: () => backgroundReleaseInFlightRef.current,
               capturePresenceEpoch: (deviceId) =>
                 capturePresenceAvailabilityEpoch(
                   presenceAvailabilityEpochsRef.current,
@@ -702,6 +706,18 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         backgroundState.stopTimer = null;
       }
     };
+    const releaseHeavyTopics = (): Promise<void>[] => {
+      const releases: Promise<void>[] = [];
+      for (const plan of registryRef.current.snapshot()) {
+        const heavy = plan.topics.filter((topic) => topic.startsWith('session:'));
+        if (heavy.length === 0) continue;
+        markRemoteTopicsUnsubscribed(remoteSubscribedTopicsRef.current, plan.deviceId, heavy);
+        if (client.getStatus() === 'online') {
+          releases.push(sendUnsubscribe(client, plan.deviceId, heavy));
+        }
+      }
+      return releases;
+    };
     const sub = AppState.addEventListener('change', (next) => {
       if (next === 'active') {
         backgroundReleaseInFlightRef.current = false;
@@ -728,14 +744,8 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         // 后若订阅残留(宽限窗、挂起延迟最长可拖到 server 60s 空闲清扫),恰好在
         // 用户离开的瞬间完成的任务就永远收不到通知。只动远端订阅与 ack 簿记,
         // registry 所有权保留 —— 回前台的 rehydrate 会因 ack 已清而重新订阅。
-        const registrySnapshot = registryRef.current.snapshot();
-        for (const plan of registrySnapshot) {
-          const heavy = plan.topics.filter((topic) => topic.startsWith('session:'));
-          if (heavy.length === 0) continue;
-          markRemoteTopicsUnsubscribed(remoteSubscribedTopicsRef.current, plan.deviceId, heavy);
-          if (client.getStatus() === 'online') {
-            void sendUnsubscribe(client, plan.deviceId, heavy).catch(() => undefined);
-          }
+        for (const release of releaseHeavyTopics()) {
+          void release.catch(() => undefined);
         }
         // 短暂宽限再断:几秒内切回的快速 App 切换不触发整套断连/重连/补齐。
         // iOS 挂起后计时器不再运行,恢复时由上面的 active 分支收拾残局。
@@ -743,7 +753,16 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         clearBackgroundStopTimer();
         backgroundState.stopTimer = setTimeout(() => {
           backgroundState.stopTimer = null;
-          if (AppState.currentState === 'background') client.stop();
+          if (AppState.currentState !== 'background') return;
+          // 已发出的 stale subscribe 无法撤回;断开前再幂等释放一次并等待已发出的
+          // unsubscribe 收尾,确保最后落到桌面端的 session topic 状态仍是释放。
+          const finalRelease = Promise.allSettled(releaseHeavyTopics());
+          const boundedWait = new Promise<void>((resolve) => {
+            setTimeout(resolve, BACKGROUND_FINAL_UNSUBSCRIBE_WAIT_MS);
+          });
+          void Promise.race([finalRelease, boundedWait]).finally(() => {
+            if (AppState.currentState === 'background') client.stop();
+          });
         }, BACKGROUND_STOP_GRACE_MS);
       }
     });

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -126,6 +126,10 @@ export interface DeviceLinkContextValue {
 
 const DeviceLinkContext = createContext<DeviceLinkContextValue | null>(null);
 
+// 任意目标端真实应答的独立时序证据。它不等同于 presence verdict,也不参与 IPC/DB
+// 响应性熔断;只用于判定并发返回的 unavailable 是否已被更晚目标应答推翻。
+const remoteResponseEvidenceEpochs = createPresenceAvailabilityEpochs();
+
 interface RehydrateState {
   inFlight: Promise<void> | null;
   rerun: boolean;
@@ -196,6 +200,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     return getOrCreatePresenceTrackedRequest(
       openLinkInFlightRef.current,
       presenceAvailabilityEpochsRef.current,
+      remoteResponseEvidenceEpochs,
       deviceId,
       () => sendOpenLinkWithAccessHandling(client, deviceId),
     );
@@ -343,12 +348,25 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
                   presenceAvailabilityEpochsRef.current,
                   deviceId,
                 ),
+              captureResponseEvidenceEpoch: (deviceId) =>
+                capturePresenceAvailabilityEpoch(
+                  remoteResponseEvidenceEpochs,
+                  deviceId,
+                ),
               isPresenceEpochCurrent: (deviceId, capturedPresenceEpoch) =>
                 isPresenceAvailabilityEpochCurrent(
                   presenceAvailabilityEpochsRef.current,
                   deviceId,
                   capturedPresenceEpoch,
                 ),
+              isResponseEvidenceEpochCurrent: (
+                deviceId,
+                capturedResponseEvidenceEpoch,
+              ) => isPresenceAvailabilityEpochCurrent(
+                remoteResponseEvidenceEpochs,
+                deviceId,
+                capturedResponseEvidenceEpoch,
+              ),
               createDeviceSendCohort: (deviceId) => createDeviceSendCohort(deviceId),
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
@@ -431,6 +449,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       openLinkInFlightRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
       resetPresenceAvailabilityEpochs(presenceAvailabilityEpochsRef.current);
+      resetPresenceAvailabilityEpochs(remoteResponseEvidenceEpochs);
       presencePendingRecoveryDeviceIdsRef.current.clear();
       setStatus('stopped');
       setConnectionIssue(null);
@@ -666,6 +685,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       remoteSubscribedTopicsRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
       resetPresenceAvailabilityEpochs(presenceAvailabilityEpochsRef.current);
+      resetPresenceAvailabilityEpochs(remoteResponseEvidenceEpochs);
       presencePendingRecoveryDeviceIdsRef.current.clear();
       if (clientRef.current === client) clientRef.current = null;
     };
@@ -922,6 +942,7 @@ async function sendOpenLink(
     // openLink 若是探测,单飞席位随之释放、退避窗口不动,紧随其后的 subscribe
     // (真实 invoke 通道)会立即接棒成为新探测,由它的回包决定开合。
     settleDeviceSend(deviceId, slot, 'inconclusive');
+    markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
     return accepted;
   } catch (err) {
     // 超时仍计失败:link-open 都等不到回包说明被控端连链路层都没在应答。
@@ -988,6 +1009,7 @@ async function sendInvoke<T>(
   // 只有指定探测通道能关熔断(纯内存 IPC handler 的回包不算)——按通道 +
   // 席位分类收尾(review P1 多轮收敛,见 classifyDeviceSendSuccess)。
   settleDeviceSend(deviceId, slot, classifyDeviceSendSuccess(channel, slot.decision === 'probe'));
+  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
   return unwrapInvoke<T>(result);
 }
 
@@ -1031,6 +1053,7 @@ async function sendSubscribe(
   // 到点时页面卸载恰好发的一条控制帧会抢占探测席位并误关熔断。与 openLink
   // 同语义:成功按不定论,超时仍计失败(连控制帧都不应答 = 彻底无响应)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
+  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
   unwrapInvoke(result);
 }
 
@@ -1058,6 +1081,7 @@ async function sendUnsubscribe(
   }
   // 控制帧成功按不定论,不作熔断恢复证据(同 sendSubscribe,review P1)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
+  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
   unwrapInvoke(result);
 }
 

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -76,7 +76,14 @@ import {
 import { remoteScheduleEventStore } from '@/scheduler/remoteScheduleEvents';
 import { buildMobileDeviceName } from '@/device-link/mobileDeviceIdentity';
 import {
+  capturePresenceAvailabilityEpoch,
+  createPresenceAvailabilityEpochs,
+  getOrCreatePresenceTrackedRequest,
+  isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
+  markPresenceAvailabilityEpoch,
+  type PresenceTrackedRequest,
+  resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
   updatePresenceAvailability,
 } from '@/device-link/presenceRecovery';
@@ -159,8 +166,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   // 供退避计时器回调拿到最新的 rehydrateWithClient(二者互相引用,用 ref 解环)
   const rehydrateFnRef = useRef<(client: DeviceLinkClient) => Promise<void>>(() => Promise.resolve());
   const presenceWipeTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
-  const openLinkInFlightRef = useRef(new Map<string, Promise<LinkAcceptPayload>>());
+  const openLinkInFlightRef = useRef(
+    new Map<string, PresenceTrackedRequest<LinkAcceptPayload>>(),
+  );
   const presenceAvailableByDeviceRef = useRef(new Map<string, boolean>());
+  const presenceAvailabilityEpochsRef = useRef(createPresenceAvailabilityEpochs());
   const presencePendingRecoveryDeviceIdsRef = useRef(new Set<string>());
   const [status, setStatus] = useState<DeviceLinkStatus>('stopped');
   const [connectionIssue, setConnectionIssue] = useState<DeviceLinkConnectionIssue | null>(null);
@@ -169,18 +179,12 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const [lastPresenceSnapshot, setLastPresenceSnapshot] = useState<PresenceSnapshot | null>(null);
 
   const sendOpenLinkOnce = useCallback((client: DeviceLinkClient, deviceId: string) => {
-    const existing = openLinkInFlightRef.current.get(deviceId);
-    if (existing) return existing;
-
-    const request = sendOpenLinkWithAccessHandling(client, deviceId);
-    openLinkInFlightRef.current.set(deviceId, request);
-    const cleanup = (): void => {
-      if (openLinkInFlightRef.current.get(deviceId) === request) {
-        openLinkInFlightRef.current.delete(deviceId);
-      }
-    };
-    void request.then(cleanup, cleanup);
-    return request;
+    return getOrCreatePresenceTrackedRequest(
+      openLinkInFlightRef.current,
+      presenceAvailabilityEpochsRef.current,
+      deviceId,
+      () => sendOpenLinkWithAccessHandling(client, deviceId),
+    );
   }, []);
 
   const sendTrackedSubscribe = useCallback(async (
@@ -201,7 +205,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const probeUnresponsiveDevice = useCallback(
     async (client: DeviceLinkClient, deviceId: string): Promise<void> => {
       try {
-        await sendOpenLinkOnce(client, deviceId);
+        await sendOpenLinkOnce(client, deviceId).request;
         await sendInvokeWithAccessHandling(
           client,
           deviceId,
@@ -320,6 +324,17 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
               }
             })();
             const result = await rehydrateDeviceLinkTopics(plans, {
+              capturePresenceEpoch: (deviceId) =>
+                capturePresenceAvailabilityEpoch(
+                  presenceAvailabilityEpochsRef.current,
+                  deviceId,
+                ),
+              isPresenceEpochCurrent: (deviceId, capturedPresenceEpoch) =>
+                isPresenceAvailabilityEpochCurrent(
+                  presenceAvailabilityEpochsRef.current,
+                  deviceId,
+                  capturedPresenceEpoch,
+                ),
               createDeviceSendCohort: (deviceId) => createDeviceSendCohort(deviceId),
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
@@ -327,6 +342,8 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
               onDeviceUnavailable: (deviceId) => {
                 // 新连接按 unknown 乐观探测一次;relay 明确回 DEVICE_OFFLINE 后恢复
                 // 当前代 false verdict,让退避重跑过滤该设备而不是持续重放整套计划。
+                // rehydrate 已按请求发起时的 presence epoch 丢弃旧路由离线回包,
+                // 因此这里不会覆盖更晚的 available=true。
                 presenceAvailableByDeviceRef.current.set(deviceId, false);
                 presencePendingRecoveryDeviceIdsRef.current.add(deviceId);
                 clearDeviceResponsivenessTrackingFor(deviceId);
@@ -380,6 +397,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       clearPresenceWipeTimers(presenceWipeTimersRef.current);
       openLinkInFlightRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
+      resetPresenceAvailabilityEpochs(presenceAvailabilityEpochsRef.current);
       presencePendingRecoveryDeviceIdsRef.current.clear();
       setStatus('stopped');
       setConnectionIssue(null);
@@ -456,6 +474,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       void rehydrateWithClient(client);
     });
     const offPresence = client.onPresenceChanged((snap) => {
+      markPresenceAvailabilityEpoch(presenceAvailabilityEpochsRef.current, snap.deviceId);
       setLastPresenceSnapshot(snap);
       setPresenceVersion((n) => n + 1);
       const presence = updatePresenceAvailability(
@@ -608,6 +627,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       openLinkInFlightRef.current.clear();
       remoteSubscribedTopicsRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
+      resetPresenceAvailabilityEpochs(presenceAvailabilityEpochsRef.current);
       presencePendingRecoveryDeviceIdsRef.current.clear();
       if (clientRef.current === client) clientRef.current = null;
     };
@@ -616,7 +636,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const openLink = useCallback(
     async (deviceId: string) => {
       registryRef.current.trackOpenLink(deviceId);
-      return sendOpenLinkOnce(requireClient(clientRef.current), deviceId);
+      return sendOpenLinkOnce(requireClient(clientRef.current), deviceId).request;
     },
     [sendOpenLinkOnce],
   );

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -324,6 +324,19 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
+              onDeviceUnavailable: (deviceId) => {
+                // 新连接按 unknown 乐观探测一次;relay 明确回 DEVICE_OFFLINE 后恢复
+                // 当前代 false verdict,让退避重跑过滤该设备而不是持续重放整套计划。
+                presenceAvailableByDeviceRef.current.set(deviceId, false);
+                presencePendingRecoveryDeviceIdsRef.current.add(deviceId);
+                clearDeviceResponsivenessTrackingFor(deviceId);
+                remoteSubscribedTopicsRef.current.delete(deviceId);
+                scheduleUnavailableDeviceMirrorWipe(
+                  presenceWipeTimersRef.current,
+                  presenceAvailableByDeviceRef.current,
+                  deviceId,
+                );
+              },
               rebuildSessionSnapshot: (deviceId, sessionId, opts) => rebuildSessionSnapshot(client, deviceId, sessionId, opts),
             });
             await probeRun;
@@ -472,15 +485,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         // 桌面端离线:给一个短宽限。弱网下桌面端会反复闪断,每次都立即清空
         // 会话镜像 + 能力缓存会让手机端界面整片消失重建、随后一轮 re-fetch 风暴;
         // 宽限内恢复在线则取消清理(presence.recovered 分支照常触发补齐)。
-        if (!wipeTimers.has(snap.deviceId)) {
-          wipeTimers.set(snap.deviceId, setTimeout(() => {
-            wipeTimers.delete(snap.deviceId);
-            // 宽限到点仍不可用才真正清(期间可能已恢复又再次离线,以 ref 里的现值为准)
-            if (presenceAvailableByDeviceRef.current.get(snap.deviceId) === false) {
-              wipeUnavailableDeviceMirror(snap.deviceId);
-            }
-          }, PRESENCE_OFFLINE_WIPE_GRACE_MS));
-        }
+        scheduleUnavailableDeviceMirrorWipe(
+          wipeTimers,
+          presenceAvailableByDeviceRef.current,
+          snap.deviceId,
+        );
         return;
       }
       clearPresenceWipeTimer(wipeTimers, snap.deviceId);
@@ -1008,6 +1017,21 @@ function wipeUnavailableDeviceMirror(deviceId: string): void {
   // 否则模型 / 权限 / plan 支持度会先按旧能力渲染并接受点击。
   evictAgentCapabilitiesForDevice(deviceId);
   evictComposerPaletteCacheForDevice(deviceId);
+}
+
+function scheduleUnavailableDeviceMirrorWipe(
+  timers: Map<string, ReturnType<typeof setTimeout>>,
+  availabilityByDevice: ReadonlyMap<string, boolean>,
+  deviceId: string,
+): void {
+  if (timers.has(deviceId)) return;
+  timers.set(deviceId, setTimeout(() => {
+    timers.delete(deviceId);
+    // 宽限到点仍不可用才真正清(期间可能已恢复又再次离线,以 ref 里的现值为准)
+    if (availabilityByDevice.get(deviceId) === false) {
+      wipeUnavailableDeviceMirror(deviceId);
+    }
+  }, PRESENCE_OFFLINE_WIPE_GRACE_MS));
 }
 
 function clearPresenceWipeTimer(

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -86,7 +86,9 @@ import {
   isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
   markPresenceAvailabilityEpoch,
+  reconcileOfflineVerdictAfterResponse,
   type PresenceTrackedRequest,
+  type PresenceUnavailableVerdict,
   type PresenceWipeTimerEntry,
   resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
@@ -129,6 +131,19 @@ const DeviceLinkContext = createContext<DeviceLinkContextValue | null>(null);
 // 任意目标端真实应答的独立时序证据。它不等同于 presence verdict,也不参与 IPC/DB
 // 响应性熔断;只用于判定并发返回的 unavailable 是否已被更晚目标应答推翻。
 const remoteResponseEvidenceEpochs = createPresenceAvailabilityEpochs();
+const remoteResponseEvidenceListeners = new Set<(deviceId: string) => void>();
+
+function markRemoteResponseEvidence(deviceId: string): void {
+  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
+  for (const listener of remoteResponseEvidenceListeners) listener(deviceId);
+}
+
+function subscribeRemoteResponseEvidence(
+  listener: (deviceId: string) => void,
+): () => void {
+  remoteResponseEvidenceListeners.add(listener);
+  return () => remoteResponseEvidenceListeners.delete(listener);
+}
 
 interface RehydrateState {
   inFlight: Promise<void> | null;
@@ -190,6 +205,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const presenceAvailableByDeviceRef = useRef(new Map<string, boolean>());
   const presenceAvailabilityEpochsRef = useRef(createPresenceAvailabilityEpochs());
   const presencePendingRecoveryDeviceIdsRef = useRef(new Set<string>());
+  const presenceUnavailableVerdictsRef = useRef(
+    new Map<string, PresenceUnavailableVerdict>(),
+  );
   const [status, setStatus] = useState<DeviceLinkStatus>('stopped');
   const [connectionIssue, setConnectionIssue] = useState<DeviceLinkConnectionIssue | null>(null);
   const [presenceVersion, setPresenceVersion] = useState(0);
@@ -385,6 +403,13 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
                   deviceId,
                 );
                 presenceAvailableByDeviceRef.current.set(deviceId, false);
+                presenceUnavailableVerdictsRef.current.set(deviceId, {
+                  kind: 'disabled',
+                  responseEvidenceEpoch: capturePresenceAvailabilityEpoch(
+                    remoteResponseEvidenceEpochs,
+                    deviceId,
+                  ),
+                });
                 presencePendingRecoveryDeviceIdsRef.current.add(deviceId);
                 clearDeviceResponsivenessTrackingFor(deviceId);
                 remoteSubscribedTopicsRef.current.delete(deviceId);
@@ -396,6 +421,13 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
                 // rehydrate 已按请求发起时的 presence epoch 丢弃旧路由离线回包,
                 // 因此这里不会覆盖更晚的 available=true。
                 presenceAvailableByDeviceRef.current.set(deviceId, false);
+                presenceUnavailableVerdictsRef.current.set(deviceId, {
+                  kind: 'offline',
+                  responseEvidenceEpoch: capturePresenceAvailabilityEpoch(
+                    remoteResponseEvidenceEpochs,
+                    deviceId,
+                  ),
+                });
                 presencePendingRecoveryDeviceIdsRef.current.add(deviceId);
                 clearDeviceResponsivenessTrackingFor(deviceId);
                 remoteSubscribedTopicsRef.current.delete(deviceId);
@@ -451,6 +483,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       resetPresenceAvailabilityEpochs(presenceAvailabilityEpochsRef.current);
       resetPresenceAvailabilityEpochs(remoteResponseEvidenceEpochs);
       presencePendingRecoveryDeviceIdsRef.current.clear();
+      presenceUnavailableVerdictsRef.current.clear();
       setStatus('stopped');
       setConnectionIssue(null);
       remoteSessionStore.clear();
@@ -518,6 +551,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         presenceAvailableByDeviceRef.current,
         presencePendingRecoveryDeviceIdsRef.current,
       );
+      // 上一连接代的 rehydrate verdict 已被降为 unknown;新连接的 late response
+      // 不能再借旧 verdict 清理当前代状态。权威 presence 会在 delta 到达时重建。
+      for (const deviceId of staleUnavailableDeviceIds) {
+        presenceUnavailableVerdictsRef.current.delete(deviceId);
+      }
       for (const deviceId of staleUnavailableDeviceIds) {
         extendPresenceWipeTimerFloor(
           presenceWipeTimersRef.current,
@@ -539,6 +577,18 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         snap,
         presencePendingRecoveryDeviceIdsRef.current,
       );
+      if (presence.available) {
+        presenceUnavailableVerdictsRef.current.delete(snap.deviceId);
+      } else {
+        // Relay presence 是权威 availability verdict,普通目标应答不能推翻。
+        presenceUnavailableVerdictsRef.current.set(snap.deviceId, {
+          kind: 'presence',
+          responseEvidenceEpoch: capturePresenceAvailabilityEpoch(
+            remoteResponseEvidenceEpochs,
+            snap.deviceId,
+          ),
+        });
+      }
       const wipeTimers = presenceWipeTimersRef.current;
       if (!presence.available) {
         // Relay 的权威 presence 已说明目标离线或关闭远控:此前 INVOKE_TIMEOUT
@@ -595,6 +645,25 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       },
     }));
     client.start();
+
+    const offResponseEvidence = subscribeRemoteResponseEvidence((deviceId) => {
+      const currentEpoch = capturePresenceAvailabilityEpoch(
+        remoteResponseEvidenceEpochs,
+        deviceId,
+      );
+      if (!reconcileOfflineVerdictAfterResponse(
+        presenceAvailableByDeviceRef.current,
+        presencePendingRecoveryDeviceIdsRef.current,
+        presenceUnavailableVerdictsRef.current,
+        deviceId,
+        currentEpoch,
+      )) {
+        return;
+      }
+
+      clearOnePresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
+      void rehydrateWithClient(client);
+    });
 
     // 熔断状态变化触发 rehydrate:unresponsive 集合的新增与移除都各触发一次
     // (review P1 + 注释勘误):
@@ -673,6 +742,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       sub.remove();
       clearBackgroundStopTimer();
       offUnresponsive();
+      offResponseEvidence();
       offFrame();
       offPresence();
       offStatus();
@@ -687,6 +757,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       resetPresenceAvailabilityEpochs(presenceAvailabilityEpochsRef.current);
       resetPresenceAvailabilityEpochs(remoteResponseEvidenceEpochs);
       presencePendingRecoveryDeviceIdsRef.current.clear();
+      presenceUnavailableVerdictsRef.current.clear();
       if (clientRef.current === client) clientRef.current = null;
     };
   }, [auth.getAccessToken, auth.isAuthenticated, clearRehydrateRetry, rehydrateWithClient]);
@@ -942,7 +1013,7 @@ async function sendOpenLink(
     // openLink 若是探测,单飞席位随之释放、退避窗口不动,紧随其后的 subscribe
     // (真实 invoke 通道)会立即接棒成为新探测,由它的回包决定开合。
     settleDeviceSend(deviceId, slot, 'inconclusive');
-    markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
+    markRemoteResponseEvidence(deviceId);
     return accepted;
   } catch (err) {
     // 超时仍计失败:link-open 都等不到回包说明被控端连链路层都没在应答。
@@ -1010,7 +1081,7 @@ async function sendInvoke<T>(
   // 席位分类收尾(review P1 多轮收敛,见 classifyDeviceSendSuccess)。
   settleDeviceSend(deviceId, slot, classifyDeviceSendSuccess(channel, slot.decision === 'probe'));
   const value = unwrapInvoke<T>(result);
-  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
+  markRemoteResponseEvidence(deviceId);
   return value;
 }
 
@@ -1055,7 +1126,7 @@ async function sendSubscribe(
   // 同语义:成功按不定论,超时仍计失败(连控制帧都不应答 = 彻底无响应)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
   unwrapInvoke(result);
-  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
+  markRemoteResponseEvidence(deviceId);
 }
 
 async function sendUnsubscribe(
@@ -1083,7 +1154,7 @@ async function sendUnsubscribe(
   // 控制帧成功按不定论,不作熔断恢复证据(同 sendSubscribe,review P1)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
   unwrapInvoke(result);
-  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
+  markRemoteResponseEvidence(deviceId);
 }
 
 function unwrapInvoke<T = unknown>(result: InvokeResultPayload): T {

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -42,7 +42,10 @@ import { evictComposerPaletteCacheForDevice, resetComposerPaletteCache } from '@
 import { clearAllDeviceModelMeta, evictDeviceModelMeta } from '@/device-link/deviceModelMetaCache';
 import { dispatchFileBrowserWatchEvent } from '@/device-link/fileBrowserWatch';
 import { resolveMobileInvokeTimeoutMs } from '@/device-link/invokeTimeouts';
-import { rehydrateDeviceLinkTopics } from '@/device-link/rehydrate';
+import {
+  rehydrateDeviceLinkTopics,
+  type DeviceLinkRehydrateSendOptions,
+} from '@/device-link/rehydrate';
 import { invalidateOfflineScheduleIndexFailureFor, invalidateTransientScheduleIndexFailures } from '@/session/scheduleIndex';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 import { createRnWebSocket } from '@/device-link/rnWebSocket';
@@ -165,11 +168,15 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const [connectionEpoch, setConnectionEpoch] = useState(0);
   const [lastPresenceSnapshot, setLastPresenceSnapshot] = useState<PresenceSnapshot | null>(null);
 
-  const sendOpenLinkOnce = useCallback((client: DeviceLinkClient, deviceId: string) => {
+  const sendOpenLinkOnce = useCallback((
+    client: DeviceLinkClient,
+    deviceId: string,
+    opts?: DeviceLinkRehydrateSendOptions,
+  ) => {
     const existing = openLinkInFlightRef.current.get(deviceId);
     if (existing) return existing;
 
-    const request = sendOpenLinkWithAccessHandling(client, deviceId);
+    const request = sendOpenLinkWithAccessHandling(client, deviceId, opts);
     openLinkInFlightRef.current.set(deviceId, request);
     const cleanup = (): void => {
       if (openLinkInFlightRef.current.get(deviceId) === request) {
@@ -184,10 +191,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     client: DeviceLinkClient,
     deviceId: string,
     topics: readonly Topic[],
+    opts?: DeviceLinkRehydrateSendOptions,
   ) => {
     const toSend = topicsMissingRemoteAck(remoteSubscribedTopicsRef.current, deviceId, topics);
     if (toSend.length === 0) return;
-    await sendSubscribeWithAccessHandling(client, deviceId, toSend);
+    await sendSubscribeWithAccessHandling(client, deviceId, toSend, opts);
     markHeldRemoteTopicsSubscribed(remoteSubscribedTopicsRef.current, registryRef.current, deviceId, toSend);
   }, []);
 
@@ -317,10 +325,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
               }
             })();
             const result = await rehydrateDeviceLinkTopics(plans, {
-              openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
-              subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
+              createDeviceSendCohort: (deviceId) => createDeviceSendCohort(deviceId),
+              openLink: (deviceId, opts) => sendOpenLinkOnce(client, deviceId, opts),
+              subscribe: (deviceId, topics, opts) => sendTrackedSubscribe(client, deviceId, topics, opts),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
-              rebuildSessionSnapshot: (deviceId, sessionId) => rebuildSessionSnapshot(client, deviceId, sessionId),
+              rebuildSessionSnapshot: (deviceId, sessionId, opts) => rebuildSessionSnapshot(client, deviceId, sessionId, opts),
             });
             await probeRun;
             // 探测后仍 open 的设备持续计入"未完成"信号(review P1:不能在探测
@@ -736,11 +745,11 @@ async function rebuildSessionSnapshot(
   client: DeviceLinkClient,
   deviceId: string,
   sessionId: string,
+  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<void> {
   // 这四个并发请求是同一轮补齐:一次路由抖动可能让它们同时等满超时,但这只
   // 代表一个独立故障观测。共享显式 cohort,避免单轮 fan-out 直接凑满 3 次阈值。
-  const responsivenessCohort = createDeviceSendCohort(deviceId);
-  const sendOpts = { responsivenessCohort };
+  const sendOpts = opts ?? { responsivenessCohort: createDeviceSendCohort(deviceId) };
   // 四路快照独立拉取、独立落库:断连补齐窗口本就脆弱,一个子请求失败不应拖垮
   // 其余(旧实现共用一个 catch,任一失败三份快照全丢)。goal 覆盖断连窗口内
   // 丢失的 maker:goal:status-changed push;model-pref / turn-cost 无对应查询通道,
@@ -810,13 +819,18 @@ function ensureOnlineForRequest(client: DeviceLinkClient): Promise<void> {
 function sendOpenLinkWithAccessHandling(
   client: DeviceLinkClient,
   deviceId: string,
+  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<LinkAcceptPayload> {
-  return withAccessRevokedHandling(deviceId, () => sendOpenLink(client, deviceId));
+  return withAccessRevokedHandling(deviceId, () => sendOpenLink(client, deviceId, opts));
 }
 
-async function sendOpenLink(client: DeviceLinkClient, deviceId: string): Promise<LinkAcceptPayload> {
+async function sendOpenLink(
+  client: DeviceLinkClient,
+  deviceId: string,
+  opts?: DeviceLinkRehydrateSendOptions,
+): Promise<LinkAcceptPayload> {
   // 熔断门禁放在连接等待之前:open 时快速失败,不消耗 1.5s 重连等待也不上管道。
-  const slot = acquireDeviceSendSlot(deviceId);
+  const slot = acquireDeviceSendSlot(deviceId, opts?.responsivenessCohort);
   try {
     await ensureOnlineForRequest(client);
   } catch (err) {
@@ -910,17 +924,19 @@ function sendSubscribeWithAccessHandling(
   client: DeviceLinkClient,
   deviceId: string,
   topics: readonly string[],
+  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<void> {
-  return withAccessRevokedHandling(deviceId, () => sendSubscribe(client, deviceId, topics));
+  return withAccessRevokedHandling(deviceId, () => sendSubscribe(client, deviceId, topics, opts));
 }
 
 async function sendSubscribe(
   client: DeviceLinkClient,
   deviceId: string,
   topics: readonly string[],
+  opts?: DeviceLinkRehydrateSendOptions,
 ): Promise<void> {
   // subscribe 同样走隧道请求超时等待(默认 15s),一样计入并受熔断限制(见 sendInvoke 注释)。
-  const slot = acquireDeviceSendSlot(deviceId);
+  const slot = acquireDeviceSendSlot(deviceId, opts?.responsivenessCohort);
   try {
     await ensureOnlineForRequest(client);
   } catch (err) {

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -83,6 +83,7 @@ import {
   createPresenceAvailabilityEpochs,
   extendPresenceWipeTimerFloor,
   getOrCreatePresenceTrackedRequest,
+  isInvokeResultReachabilityEvidence,
   isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
   markPresenceAvailabilityEpoch,
@@ -1080,9 +1081,10 @@ async function sendInvoke<T>(
   // 只有指定探测通道能关熔断(纯内存 IPC handler 的回包不算)——按通道 +
   // 席位分类收尾(review P1 多轮收敛,见 classifyDeviceSendSuccess)。
   settleDeviceSend(deviceId, slot, classifyDeviceSendSuccess(channel, slot.decision === 'probe'));
-  const value = unwrapInvoke<T>(result);
-  markRemoteResponseEvidence(deviceId);
-  return value;
+  if (isInvokeResultReachabilityEvidence(result)) {
+    markRemoteResponseEvidence(deviceId);
+  }
+  return unwrapInvoke<T>(result);
 }
 
 function sendSubscribeWithAccessHandling(
@@ -1125,8 +1127,10 @@ async function sendSubscribe(
   // 到点时页面卸载恰好发的一条控制帧会抢占探测席位并误关熔断。与 openLink
   // 同语义:成功按不定论,超时仍计失败(连控制帧都不应答 = 彻底无响应)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
+  if (isInvokeResultReachabilityEvidence(result)) {
+    markRemoteResponseEvidence(deviceId);
+  }
   unwrapInvoke(result);
-  markRemoteResponseEvidence(deviceId);
 }
 
 async function sendUnsubscribe(
@@ -1153,8 +1157,10 @@ async function sendUnsubscribe(
   }
   // 控制帧成功按不定论,不作熔断恢复证据(同 sendSubscribe,review P1)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
+  if (isInvokeResultReachabilityEvidence(result)) {
+    markRemoteResponseEvidence(deviceId);
+  }
   unwrapInvoke(result);
-  markRemoteResponseEvidence(deviceId);
 }
 
 function unwrapInvoke<T = unknown>(result: InvokeResultPayload): T {

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -1009,8 +1009,9 @@ async function sendInvoke<T>(
   // 只有指定探测通道能关熔断(纯内存 IPC handler 的回包不算)——按通道 +
   // 席位分类收尾(review P1 多轮收敛,见 classifyDeviceSendSuccess)。
   settleDeviceSend(deviceId, slot, classifyDeviceSendSuccess(channel, slot.decision === 'probe'));
+  const value = unwrapInvoke<T>(result);
   markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
-  return unwrapInvoke<T>(result);
+  return value;
 }
 
 function sendSubscribeWithAccessHandling(
@@ -1053,8 +1054,8 @@ async function sendSubscribe(
   // 到点时页面卸载恰好发的一条控制帧会抢占探测席位并误关熔断。与 openLink
   // 同语义:成功按不定论,超时仍计失败(连控制帧都不应答 = 彻底无响应)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
-  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
   unwrapInvoke(result);
+  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
 }
 
 async function sendUnsubscribe(
@@ -1081,8 +1082,8 @@ async function sendUnsubscribe(
   }
   // 控制帧成功按不定论,不作熔断恢复证据(同 sendSubscribe,review P1)。
   settleDeviceSend(deviceId, slot, 'inconclusive');
-  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
   unwrapInvoke(result);
+  markPresenceAvailabilityEpoch(remoteResponseEvidenceEpochs, deviceId);
 }
 
 function unwrapInvoke<T = unknown>(result: InvokeResultPayload): T {

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -209,6 +209,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const presenceUnavailableVerdictsRef = useRef(
     new Map<string, PresenceUnavailableVerdict>(),
   );
+  // 后台释放 heavy session 订阅期间仍保留 registry 所有权;此时 unsubscribe ack
+  // 可以修正 stale offline verdict,但不能顺带触发 rehydrate 把刚释放的订阅加回来。
+  const backgroundReleaseInFlightRef = useRef(false);
   const [status, setStatus] = useState<DeviceLinkStatus>('stopped');
   const [connectionIssue, setConnectionIssue] = useState<DeviceLinkConnectionIssue | null>(null);
   const [presenceVersion, setPresenceVersion] = useState(0);
@@ -293,6 +296,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const rehydrateWithClient = useCallback(
     (client: DeviceLinkClient): Promise<void> => {
       if (client.getStatus() !== 'online') return Promise.resolve();
+      // 退后台时 unsubscribe 的 ack 仍可作为可达性证据修正 stale offline,
+      // 但宽限 socket 尚在线期间禁止自动补齐,否则会立即订回刚释放的 heavy topics。
+      if (backgroundReleaseInFlightRef.current) return Promise.resolve();
       const state = rehydrateStateRef.current;
       if (state.inFlight) {
         state.rerun = true;
@@ -485,6 +491,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       resetPresenceAvailabilityEpochs(remoteResponseEvidenceEpochs);
       presencePendingRecoveryDeviceIdsRef.current.clear();
       presenceUnavailableVerdictsRef.current.clear();
+      backgroundReleaseInFlightRef.current = false;
       setStatus('stopped');
       setConnectionIssue(null);
       remoteSessionStore.clear();
@@ -697,6 +704,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     };
     const sub = AppState.addEventListener('change', (next) => {
       if (next === 'active') {
+        backgroundReleaseInFlightRef.current = false;
         const heldConnection = backgroundState.stopTimer !== null;
         clearBackgroundStopTimer();
         const backgroundedForMs = backgroundState.backgroundAt > 0 ? Date.now() - backgroundState.backgroundAt : 0;
@@ -714,6 +722,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         void rehydrateWithClient(client);
       }
       if (next === 'background') {
+        backgroundReleaseInFlightRef.current = true;
         // 立即释放重量级 session:<id> 订阅(趁 socket 还活着、iOS 尚未挂起 JS):
         // 被控桌面以「有人订阅该会话流」为防打扰信号压制手机系统推送,锁屏/切后台
         // 后若订阅残留(宽限窗、挂起延迟最长可拖到 server 60s 空闲清扫),恰好在
@@ -759,6 +768,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       resetPresenceAvailabilityEpochs(remoteResponseEvidenceEpochs);
       presencePendingRecoveryDeviceIdsRef.current.clear();
       presenceUnavailableVerdictsRef.current.clear();
+      backgroundReleaseInFlightRef.current = false;
       if (clientRef.current === client) clientRef.current = null;
     };
   }, [auth.getAccessToken, auth.isAuthenticated, clearRehydrateRetry, rehydrateWithClient]);

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -168,15 +168,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const [connectionEpoch, setConnectionEpoch] = useState(0);
   const [lastPresenceSnapshot, setLastPresenceSnapshot] = useState<PresenceSnapshot | null>(null);
 
-  const sendOpenLinkOnce = useCallback((
-    client: DeviceLinkClient,
-    deviceId: string,
-    opts?: DeviceLinkRehydrateSendOptions,
-  ) => {
+  const sendOpenLinkOnce = useCallback((client: DeviceLinkClient, deviceId: string) => {
     const existing = openLinkInFlightRef.current.get(deviceId);
     if (existing) return existing;
 
-    const request = sendOpenLinkWithAccessHandling(client, deviceId, opts);
+    const request = sendOpenLinkWithAccessHandling(client, deviceId);
     openLinkInFlightRef.current.set(deviceId, request);
     const cleanup = (): void => {
       if (openLinkInFlightRef.current.get(deviceId) === request) {
@@ -191,11 +187,10 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     client: DeviceLinkClient,
     deviceId: string,
     topics: readonly Topic[],
-    opts?: DeviceLinkRehydrateSendOptions,
   ) => {
     const toSend = topicsMissingRemoteAck(remoteSubscribedTopicsRef.current, deviceId, topics);
     if (toSend.length === 0) return;
-    await sendSubscribeWithAccessHandling(client, deviceId, toSend, opts);
+    await sendSubscribeWithAccessHandling(client, deviceId, toSend);
     markHeldRemoteTopicsSubscribed(remoteSubscribedTopicsRef.current, registryRef.current, deviceId, toSend);
   }, []);
 
@@ -326,8 +321,8 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
             })();
             const result = await rehydrateDeviceLinkTopics(plans, {
               createDeviceSendCohort: (deviceId) => createDeviceSendCohort(deviceId),
-              openLink: (deviceId, opts) => sendOpenLinkOnce(client, deviceId, opts),
-              subscribe: (deviceId, topics, opts) => sendTrackedSubscribe(client, deviceId, topics, opts),
+              openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
+              subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
               rebuildSessionSnapshot: (deviceId, sessionId, opts) => rebuildSessionSnapshot(client, deviceId, sessionId, opts),
             });
@@ -749,7 +744,10 @@ async function rebuildSessionSnapshot(
 ): Promise<void> {
   // 这四个并发请求是同一轮补齐:一次路由抖动可能让它们同时等满超时,但这只
   // 代表一个独立故障观测。共享显式 cohort,避免单轮 fan-out 直接凑满 3 次阈值。
-  const sendOpts = opts ?? { responsivenessCohort: createDeviceSendCohort(deviceId) };
+  const sendOpts: SendInvokeOptions = {
+    responsivenessCohort:
+      opts?.responsivenessCohort ?? createDeviceSendCohort(deviceId),
+  };
   // 四路快照独立拉取、独立落库:断连补齐窗口本就脆弱,一个子请求失败不应拖垮
   // 其余(旧实现共用一个 catch,任一失败三份快照全丢)。goal 覆盖断连窗口内
   // 丢失的 maker:goal:status-changed push;model-pref / turn-cost 无对应查询通道,

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -205,6 +205,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const openLinkInFlightRef = useRef(
     new Map<string, PresenceTrackedRequest<LinkAcceptPayload>>(),
   );
+  const presenceWipeTimerDeps = useMemo(() => ({
+    ...basePresenceWipeTimerDeps,
+    isConfirmationInFlight: (deviceId: string) =>
+      openLinkInFlightRef.current.has(deviceId),
+  }), []);
   const presenceAvailableByDeviceRef = useRef(new Map<string, boolean>());
   const presenceAvailabilityEpochsRef = useRef(createPresenceAvailabilityEpochs());
   const presencePendingRecoveryDeviceIdsRef = useRef(new Set<string>());
@@ -214,6 +219,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   // 后台释放 heavy session 订阅期间仍保留 registry 所有权;此时 unsubscribe ack
   // 可以修正 stale offline verdict,但不能顺带触发 rehydrate 把刚释放的订阅加回来。
   const backgroundReleaseInFlightRef = useRef(false);
+  // 每次后台释放都翻代。subscribe 即使跨 background→active 才收到 ACK,也只能在
+  // 发起代仍为当前代时登记远端 ACK,避免迟到成功覆盖较新的 unsubscribe。
+  const backgroundReleaseGenerationRef = useRef(0);
   const [status, setStatus] = useState<DeviceLinkStatus>('stopped');
   const [connectionIssue, setConnectionIssue] = useState<DeviceLinkConnectionIssue | null>(null);
   const [presenceVersion, setPresenceVersion] = useState(0);
@@ -235,9 +243,21 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     deviceId: string,
     topics: readonly Topic[],
   ) => {
+    if (backgroundReleaseInFlightRef.current) return;
+    const releaseGeneration = backgroundReleaseGenerationRef.current;
     const toSend = topicsMissingRemoteAck(remoteSubscribedTopicsRef.current, deviceId, topics);
     if (toSend.length === 0) return;
-    await sendSubscribeWithAccessHandling(client, deviceId, toSend);
+    const sent = await sendSubscribeWithAccessHandling(
+      client,
+      deviceId,
+      toSend,
+      () => !backgroundReleaseInFlightRef.current,
+    );
+    if (
+      !sent
+      || backgroundReleaseInFlightRef.current
+      || backgroundReleaseGenerationRef.current !== releaseGeneration
+    ) return;
     markHeldRemoteTopicsSubscribed(remoteSubscribedTopicsRef.current, registryRef.current, deviceId, toSend);
   }, []);
 
@@ -446,6 +466,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
                   presenceWipeTimersRef.current,
                   presenceAvailableByDeviceRef.current,
                   deviceId,
+                  presenceWipeTimerDeps,
                 );
               },
               rebuildSessionSnapshot: (deviceId, sessionId, opts) => rebuildSessionSnapshot(client, deviceId, sessionId, opts),
@@ -627,6 +648,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
           wipeTimers,
           presenceAvailableByDeviceRef.current,
           snap.deviceId,
+          presenceWipeTimerDeps,
         );
         return;
       }
@@ -739,6 +761,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       }
       if (next === 'background') {
         backgroundReleaseInFlightRef.current = true;
+        backgroundReleaseGenerationRef.current += 1;
         // 立即释放重量级 session:<id> 订阅(趁 socket 还活着、iOS 尚未挂起 JS):
         // 被控桌面以「有人订阅该会话流」为防打扰信号压制手机系统推送,锁屏/切后台
         // 后若订阅残留(宽限窗、挂起延迟最长可拖到 server 60s 空闲清扫),恰好在
@@ -1116,19 +1139,41 @@ async function sendInvoke<T>(
   return unwrapInvoke<T>(result);
 }
 
-function sendSubscribeWithAccessHandling(
+async function sendSubscribeWithAccessHandling(
   client: DeviceLinkClient,
   deviceId: string,
   topics: readonly string[],
-): Promise<void> {
-  return withAccessRevokedHandling(deviceId, () => sendSubscribe(client, deviceId, topics));
+  shouldSend?: () => boolean,
+): Promise<boolean> {
+  if (!shouldSend) {
+    await withAccessRevokedHandling(
+      deviceId,
+      () => sendSubscribe(client, deviceId, topics),
+    );
+    return true;
+  }
+
+  // 本地取消不能穿过 withAccessRevokedHandling 的成功路径:该 wrapper 会把任何
+  // fulfilled operation 当作目标端可达证据并清掉 revoked。用不属于协议错误的
+  // sentinel 退出 wrapper,只有实际 invoke 的结果才允许更新撤权状态。
+  const notSent = Symbol('subscribe-not-sent');
+  try {
+    await withAccessRevokedHandling(deviceId, async () => {
+      if (!await sendSubscribe(client, deviceId, topics, shouldSend)) throw notSent;
+    });
+    return true;
+  } catch (err) {
+    if (err === notSent) return false;
+    throw err;
+  }
 }
 
 async function sendSubscribe(
   client: DeviceLinkClient,
   deviceId: string,
   topics: readonly string[],
-): Promise<void> {
+  shouldSend?: () => boolean,
+): Promise<boolean> {
   // subscribe 同样走隧道请求超时等待(默认 15s),一样计入并受熔断限制(见 sendInvoke 注释)。
   const slot = acquireDeviceSendSlot(deviceId);
   try {
@@ -1136,6 +1181,12 @@ async function sendSubscribe(
   } catch (err) {
     settleDeviceSend(deviceId, slot, 'inconclusive');
     throw err;
+  }
+  // ensureOnlineForRequest 最长等待 1.5s;期间 App 可能已退后台并开始释放
+  // heavy topics。真正 invoke 前再检查一次,避免迟到 subscribe 覆盖 unsubscribe。
+  if (shouldSend && !shouldSend()) {
+    settleDeviceSend(deviceId, slot, 'inconclusive');
+    return false;
   }
   let result: InvokeResultPayload;
   try {
@@ -1160,6 +1211,7 @@ async function sendSubscribe(
     markRemoteResponseEvidence(deviceId);
   }
   unwrapInvoke(result);
+  return true;
 }
 
 async function sendUnsubscribe(
@@ -1216,7 +1268,7 @@ function wipeUnavailableDeviceMirror(deviceId: string): void {
   evictComposerPaletteCacheForDevice(deviceId);
 }
 
-const presenceWipeTimerDeps = {
+const basePresenceWipeTimerDeps = {
   now: Date.now,
   setTimer: (callback: () => void, delayMs: number) =>
     setTimeout(callback, delayMs),
@@ -1228,13 +1280,14 @@ function scheduleUnavailableDeviceMirrorWipe(
   timers: Map<string, PresenceWipeTimerEntry>,
   availabilityByDevice: ReadonlyMap<string, boolean>,
   deviceId: string,
+  deps: typeof basePresenceWipeTimerDeps,
 ): void {
   schedulePresenceWipeTimer(
     timers,
     availabilityByDevice,
     deviceId,
     PRESENCE_OFFLINE_WIPE_GRACE_MS,
-    presenceWipeTimerDeps,
+    deps,
   );
 }
 

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -275,7 +275,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
             // presence 已权威声明 unavailable 的设备不进入本轮 rehydrate。熔断
             // clear 会触发 store 订阅补跑一轮,若这里仍对离线设备重放 openLink /
             // subscribe / snapshot,只会制造一簇 DEVICE_OFFLINE 并放大弱网抖动。
-            // 首次尚无 presence(map=undefined)仍允许尝试;恢复快照会显式触发下一轮。
+            // 当前连接尚无该设备的 presence 记录(unknown)仍允许尝试;恢复快照会显式触发下一轮。
             const availablePlans = grantedPlans.filter(
               (plan) => isPresenceEligibleForRemoteRequest(presenceAvailableByDeviceRef.current, plan.deviceId),
             );

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -62,6 +62,8 @@ import {
   classifyDeviceSendFailure,
   classifyDeviceSendSuccess,
   classifyLinkOpenFailure,
+  clearDeviceResponsivenessTrackingFor,
+  createDeviceSendCohort,
   DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
   isDeviceProbeDue,
   resetDeviceResponsivenessTracking,
@@ -70,7 +72,11 @@ import {
 } from '@/device-link/unresponsiveDevicesStore';
 import { remoteScheduleEventStore } from '@/scheduler/remoteScheduleEvents';
 import { buildMobileDeviceName } from '@/device-link/mobileDeviceIdentity';
-import { updatePresenceAvailability } from '@/device-link/presenceRecovery';
+import {
+  isPresenceEligibleForRemoteRequest,
+  resetPresenceAvailabilityForConnection,
+  updatePresenceAvailability,
+} from '@/device-link/presenceRecovery';
 import type { InputProjection, PendingInteraction, RemoteMessage } from '@/session/types';
 import { createVisualMockDeviceLinkContext, seedVisualMockStore } from '@/debug/visualMock';
 
@@ -266,7 +272,13 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
             const grantedPlans = allPlans.filter(
               (plan) => !revokedDevicesStore.has(plan.deviceId),
             );
-            // 熔断 open 的设备整体退出常规 rehydrate(每一步都会本地快速失败),
+            // presence 已权威声明 unavailable 的设备不进入本轮 rehydrate。熔断
+            // clear 会触发 store 订阅补跑一轮,若这里仍对离线设备重放 openLink /
+            // subscribe / snapshot,只会制造一簇 DEVICE_OFFLINE 并放大弱网抖动。
+            // 首次尚无 presence(map=undefined)仍允许尝试;恢复快照会显式触发下一轮。
+            const availablePlans = grantedPlans.filter(
+              (plan) => isPresenceEligibleForRemoteRequest(presenceAvailableByDeviceRef.current, plan.deviceId),
+            );
             // 改走显式代表性探测(review P1 多轮收敛):不能依赖 openLink /
             // subscribe 顺带探测——link-accept 与 subscribe 都在被控端 dispatch
             // 里于 runInvoke 之前特判应答,IPC/DB 卡死时照常回包会误关熔断;
@@ -279,13 +291,18 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
             // 首页的设备行)不在 registry 里,熔断 open 后若不纳入,它既收不到
             // 探测也不占未完成信号,会在没有业务流量时永久停留在未响应态。
             const openDeviceIds = new Set<string>();
-            for (const plan of grantedPlans) {
+            for (const plan of availablePlans) {
               if (unresponsiveDevicesStore.has(plan.deviceId)) openDeviceIds.add(plan.deviceId);
             }
             for (const deviceId of unresponsiveDevicesStore.getSnapshot()) {
-              if (!revokedDevicesStore.has(deviceId)) openDeviceIds.add(deviceId);
+              if (
+                !revokedDevicesStore.has(deviceId)
+                && isPresenceEligibleForRemoteRequest(presenceAvailableByDeviceRef.current, deviceId)
+              ) {
+                openDeviceIds.add(deviceId);
+              }
             }
-            const plans = grantedPlans.filter(
+            const plans = availablePlans.filter(
               (plan) => !unresponsiveDevicesStore.has(plan.deviceId),
             );
             // 探测与健康设备的 rehydrate 并发跑(review P1):探测一台死设备最长
@@ -403,6 +420,18 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         clearRehydrateRetry(true);
         return;
       }
+      // presence 是当前在线控制端收到的 delta,server 不会在 hello-ack 后重放
+      // 全量快照。进入新连接代际先丢弃旧 verdict:后台期间若设备从 unavailable
+      // 恢复,旧 false 不能永久挡住本轮 rehydrate。上一代仍 pending 的离线镜像
+      // 清理在清空 verdict 前立即结算,否则其 timer 随后看到 undefined 会静默跳过,
+      // 真离线设备的 stale mirror 将永久残留。已恢复设备由紧随其后的 rehydrate 重建。
+      const staleUnavailableDeviceIds = resetPresenceAvailabilityForConnection(
+        presenceAvailableByDeviceRef.current,
+      );
+      for (const deviceId of staleUnavailableDeviceIds) {
+        clearPresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
+        wipeUnavailableDeviceMirror(deviceId);
+      }
       setConnectionEpoch((n) => n + 1);
       void rehydrateWithClient(client);
     });
@@ -412,27 +441,21 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       const presence = updatePresenceAvailability(presenceAvailableByDeviceRef.current, snap);
       const wipeTimers = presenceWipeTimersRef.current;
       if (!presence.available) {
+        // Relay 的权威 presence 已说明目标离线或关闭远控:此前 INVOKE_TIMEOUT
+        // 只能视为这次可用性变化的下游症状,不再代表桌面 IPC/DB 卡死。立即清除
+        // 响应性计数并翻代,让在途请求随后到达的 timeout 也无法重建误熔断。
+        // 清理响应性状态会触发 rehydrate,但 presence 仍是 unavailable 时该设备会被
+        // availablePlans 过滤,不再立即重放一批注定 DEVICE_OFFLINE 的请求。
+        clearDeviceResponsivenessTrackingFor(snap.deviceId);
         // 订阅跟踪必须立即失效(不进宽限):桌面端断开可能已丢失订阅者状态,
         // 恢复后的 rehydrate 靠 topicsMissingRemoteAck 判断要不要重发 subscribe,
         // 跟踪不清会误判「已订阅」而跳过重订阅,push 流静默断掉。重订阅本身
         // 便宜且服务端幂等;需要宽限的只是下面会引起界面闪烁的缓存清理。
         remoteSubscribedTopicsRef.current.delete(snap.deviceId);
-        const wipeDevice = () => {
-          remoteSessionStore.removeDevice(snap.deviceId);
-          remoteScheduleEventStore.clearDevice(snap.deviceId);
-          // Drop the cached provider catalog so a returning/re-granted device re-fetches it
-          // instead of serving a list frozen from a previous connection.
-          evictDeviceProviders(snap.deviceId);
-          evictDeviceModelMeta(snap.deviceId);
-          // 能力表与供应商目录同时机驱逐:桌面端重连 / 升级 / 重新授权后必须重取,
-          // 否则模型 / 权限 / plan 支持度会先按旧能力渲染并接受点击。
-          evictAgentCapabilitiesForDevice(snap.deviceId);
-          evictComposerPaletteCacheForDevice(snap.deviceId);
-        };
         if (snap.online && !snap.remoteControlEnabled) {
           // 用户在桌面端显式关闭了远控:立即清,镜像不该多留一秒
           clearPresenceWipeTimer(wipeTimers, snap.deviceId);
-          wipeDevice();
+          wipeUnavailableDeviceMirror(snap.deviceId);
           return;
         }
         // 桌面端离线:给一个短宽限。弱网下桌面端会反复闪断,每次都立即清空
@@ -442,7 +465,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
           wipeTimers.set(snap.deviceId, setTimeout(() => {
             wipeTimers.delete(snap.deviceId);
             // 宽限到点仍不可用才真正清(期间可能已恢复又再次离线,以 ref 里的现值为准)
-            if (presenceAvailableByDeviceRef.current.get(snap.deviceId) === false) wipeDevice();
+            if (presenceAvailableByDeviceRef.current.get(snap.deviceId) === false) {
+              wipeUnavailableDeviceMirror(snap.deviceId);
+            }
           }, PRESENCE_OFFLINE_WIPE_GRACE_MS));
         }
         return;
@@ -704,6 +729,10 @@ async function rebuildSessionSnapshot(
   deviceId: string,
   sessionId: string,
 ): Promise<void> {
+  // 这四个并发请求是同一轮补齐:一次路由抖动可能让它们同时等满超时,但这只
+  // 代表一个独立故障观测。共享显式 cohort,避免单轮 fan-out 直接凑满 3 次阈值。
+  const responsivenessCohort = createDeviceSendCohort(deviceId);
+  const sendOpts = { responsivenessCohort };
   // 四路快照独立拉取、独立落库:断连补齐窗口本就脆弱,一个子请求失败不应拖垮
   // 其余(旧实现共用一个 catch,任一失败三份快照全丢)。goal 覆盖断连窗口内
   // 丢失的 maker:goal:status-changed push;model-pref / turn-cost 无对应查询通道,
@@ -712,24 +741,27 @@ async function rebuildSessionSnapshot(
     sendInvokeWithAccessHandling<RemoteMessage[]>(client, deviceId, 'local-db:messages:list', [
       sessionId,
       { limit: 80 },
-    ]),
+    ], sendOpts),
     sendInvokeWithAccessHandling<PendingInteraction[]>(
       client,
       deviceId,
       'maker:get-pending-interactions',
       [sessionId],
+      sendOpts,
     ),
     sendInvokeWithAccessHandling<InputProjection>(
       client,
       deviceId,
       'maker:input:get-projection',
       [sessionId],
+      sendOpts,
     ),
     sendInvokeWithAccessHandling<MobileGoalStatusPayload | null | undefined>(
       client,
       deviceId,
       'maker:goal:get-status',
       [sessionId],
+      sendOpts,
     ),
   ]);
   if (history.status === 'fulfilled' && Array.isArray(history.value)) {
@@ -807,12 +839,18 @@ async function sendOpenLink(client: DeviceLinkClient, deviceId: string): Promise
   }
 }
 
+interface SendInvokeOptions {
+  preSend?: () => void;
+  /** 同一轮明确 fan-out 共享;普通独立请求省略。 */
+  responsivenessCohort?: number;
+}
+
 function sendInvokeWithAccessHandling<T>(
   client: DeviceLinkClient,
   deviceId: string,
   channel: string,
   args: unknown[],
-  opts?: { preSend?: () => void },
+  opts?: SendInvokeOptions,
 ): Promise<T> {
   return withAccessRevokedHandling(deviceId, () => sendInvoke<T>(client, deviceId, channel, args, opts));
 }
@@ -822,10 +860,11 @@ async function sendInvoke<T>(
   deviceId: string,
   channel: string,
   args: unknown[],
-  opts?: { preSend?: () => void },
+  opts?: SendInvokeOptions,
 ): Promise<T> {
   // 熔断门禁放在连接等待之前:open 时快速失败,不消耗 1.5s 重连等待也不上管道。
-  const slot = acquireDeviceSendSlot(deviceId);
+  // 同一轮显式 fan-out 复用 cohort;普通调用省略时每次 acquire 都是独立观测。
+  const slot = acquireDeviceSendSlot(deviceId, opts?.responsivenessCohort);
   try {
     await ensureOnlineForRequest(client);
     // 连接就绪后、真正发送前的最后检查点:重连等待期间调用方状态可能已失效
@@ -938,6 +977,19 @@ function unwrapInvoke<T = unknown>(result: InvokeResultPayload): T {
 function requireClient(client: DeviceLinkClient | null): DeviceLinkClient {
   if (!client) throw new DeviceLinkError('NOT_CONNECTED', 'device-link client is not ready');
   return client;
+}
+
+function wipeUnavailableDeviceMirror(deviceId: string): void {
+  remoteSessionStore.removeDevice(deviceId);
+  remoteScheduleEventStore.clearDevice(deviceId);
+  // Drop the cached provider catalog so a returning/re-granted device re-fetches it
+  // instead of serving a list frozen from a previous connection.
+  evictDeviceProviders(deviceId);
+  evictDeviceModelMeta(deviceId);
+  // 能力表与供应商目录同时机驱逐:桌面端重连 / 升级 / 重新授权后必须重取,
+  // 否则模型 / 权限 / plan 支持度会先按旧能力渲染并接受点击。
+  evictAgentCapabilitiesForDevice(deviceId);
+  evictComposerPaletteCacheForDevice(deviceId);
 }
 
 function clearPresenceWipeTimer(

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -77,6 +77,8 @@ import { remoteScheduleEventStore } from '@/scheduler/remoteScheduleEvents';
 import { buildMobileDeviceName } from '@/device-link/mobileDeviceIdentity';
 import {
   capturePresenceAvailabilityEpoch,
+  clearPresenceWipeTimer,
+  clearPresenceWipeTimers,
   createPresenceAvailabilityEpochs,
   getOrCreatePresenceTrackedRequest,
   isPresenceAvailabilityEpochCurrent,
@@ -85,6 +87,7 @@ import {
   type PresenceTrackedRequest,
   resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
+  schedulePresenceWipeTimer,
   updatePresenceAvailability,
 } from '@/device-link/presenceRecovery';
 import type { InputProjection, PendingInteraction, RemoteMessage } from '@/session/types';
@@ -339,6 +342,12 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
               openLink: (deviceId) => sendOpenLinkOnce(client, deviceId),
               subscribe: (deviceId, topics) => sendTrackedSubscribe(client, deviceId, topics),
               requestSessionsReseed: (deviceId) => remoteSessionStore.requestReseed(deviceId),
+              onDeviceReachable: (deviceId) => {
+                // 重连后 presence 是 unknown 且 server 不重放全量快照。补齐步骤已收到
+                // 目标端真实应答即可证明设备可达,取消上一代 unavailable 留下的宽限清理;
+                // 不伪造 presence=true,后续权威 false delta 仍可照常过滤并重新计时。
+                clearOnePresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
+              },
               onDeviceUnavailable: (deviceId) => {
                 // 新连接按 unknown 乐观探测一次;relay 明确回 DEVICE_OFFLINE 后恢复
                 // 当前代 false verdict,让退避重跑过滤该设备而不是持续重放整套计划。
@@ -394,7 +403,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       rehydrateStateRef.current.inFlight = null;
       rehydrateStateRef.current.rerun = false;
       clearRehydrateRetry(true);
-      clearPresenceWipeTimers(presenceWipeTimersRef.current);
+      clearAllPresenceWipeTimers(presenceWipeTimersRef.current);
       openLinkInFlightRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
       resetPresenceAvailabilityEpochs(presenceAvailabilityEpochsRef.current);
@@ -459,17 +468,13 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       }
       // presence 是当前在线控制端收到的 delta,server 不会在 hello-ack 后重放
       // 全量快照。进入新连接代际先丢弃旧 verdict:后台期间若设备从 unavailable
-      // 恢复,旧 false 不能永久挡住本轮 rehydrate。上一代仍 pending 的离线镜像
-      // 清理在清空 verdict 前立即结算,否则其 timer 随后看到 undefined 会静默跳过,
-      // 真离线设备的 stale mirror 将永久残留。已恢复设备由紧随其后的 rehydrate 重建。
-      const staleUnavailableDeviceIds = resetPresenceAvailabilityForConnection(
+      // 恢复,旧 false 不能永久挡住本轮 rehydrate。上一代仍 pending 的镜像清理
+      // 保留原宽限截止点:计时器把新连接尚无 verdict 的 unknown 当作未确认恢复,
+      // 只有当前代明确 available=true 才取消,避免重连瞬间按旧 false 提前清空镜像。
+      resetPresenceAvailabilityForConnection(
         presenceAvailableByDeviceRef.current,
         presencePendingRecoveryDeviceIdsRef.current,
       );
-      for (const deviceId of staleUnavailableDeviceIds) {
-        clearPresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
-        wipeUnavailableDeviceMirror(deviceId);
-      }
       setConnectionEpoch((n) => n + 1);
       void rehydrateWithClient(client);
     });
@@ -497,7 +502,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         remoteSubscribedTopicsRef.current.delete(snap.deviceId);
         if (snap.online && !snap.remoteControlEnabled) {
           // 用户在桌面端显式关闭了远控:立即清,镜像不该多留一秒
-          clearPresenceWipeTimer(wipeTimers, snap.deviceId);
+          clearOnePresenceWipeTimer(wipeTimers, snap.deviceId);
           wipeUnavailableDeviceMirror(snap.deviceId);
           return;
         }
@@ -511,7 +516,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         );
         return;
       }
-      clearPresenceWipeTimer(wipeTimers, snap.deviceId);
+      clearOnePresenceWipeTimer(wipeTimers, snap.deviceId);
       // 每个「可用」快照都清该设备的 DEVICE_OFFLINE 负缓存(review P1 ×2):
       // 主机在手机连上 relay 之前就离线时,presence 只在变化时广播,首个在线
       // 快照 recovered=false——只挂 recovered 会漏掉这次恢复,徽标停留到无关
@@ -623,7 +628,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       client.stop();
       rehydrateStateRef.current.rerun = false;
       clearRehydrateRetry(true);
-      clearPresenceWipeTimers(presenceWipeTimersRef.current);
+      clearAllPresenceWipeTimers(presenceWipeTimersRef.current);
       openLinkInFlightRef.current.clear();
       remoteSubscribedTopicsRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
@@ -1044,30 +1049,30 @@ function scheduleUnavailableDeviceMirrorWipe(
   availabilityByDevice: ReadonlyMap<string, boolean>,
   deviceId: string,
 ): void {
-  if (timers.has(deviceId)) return;
-  timers.set(deviceId, setTimeout(() => {
-    timers.delete(deviceId);
-    // 宽限到点仍不可用才真正清(期间可能已恢复又再次离线,以 ref 里的现值为准)
-    if (availabilityByDevice.get(deviceId) === false) {
-      wipeUnavailableDeviceMirror(deviceId);
-    }
-  }, PRESENCE_OFFLINE_WIPE_GRACE_MS));
+  schedulePresenceWipeTimer(
+    timers,
+    availabilityByDevice,
+    deviceId,
+    PRESENCE_OFFLINE_WIPE_GRACE_MS,
+    {
+      setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
+      clearTimer: clearTimeout,
+      wipe: wipeUnavailableDeviceMirror,
+    },
+  );
 }
 
-function clearPresenceWipeTimer(
+function clearOnePresenceWipeTimer(
   timers: Map<string, ReturnType<typeof setTimeout>>,
   deviceId: string,
 ): void {
-  const timer = timers.get(deviceId);
-  if (timer) {
-    clearTimeout(timer);
-    timers.delete(deviceId);
-  }
+  clearPresenceWipeTimer(timers, deviceId, clearTimeout);
 }
 
-function clearPresenceWipeTimers(timers: Map<string, ReturnType<typeof setTimeout>>): void {
-  for (const timer of timers.values()) clearTimeout(timer);
-  timers.clear();
+function clearAllPresenceWipeTimers(
+  timers: Map<string, ReturnType<typeof setTimeout>>,
+): void {
+  clearPresenceWipeTimers(timers, clearTimeout);
 }
 
 function isDeviceLinkTopic(topic: string): boolean {

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -43,6 +43,7 @@ import { clearAllDeviceModelMeta, evictDeviceModelMeta } from '@/device-link/dev
 import { dispatchFileBrowserWatchEvent } from '@/device-link/fileBrowserWatch';
 import { resolveMobileInvokeTimeoutMs } from '@/device-link/invokeTimeouts';
 import {
+  classifySnapshotBatchFailure,
   rehydrateDeviceLinkTopics,
   type DeviceLinkRehydrateSendOptions,
 } from '@/device-link/rehydrate';
@@ -80,11 +81,13 @@ import {
   clearPresenceWipeTimer,
   clearPresenceWipeTimers,
   createPresenceAvailabilityEpochs,
+  extendPresenceWipeTimerFloor,
   getOrCreatePresenceTrackedRequest,
   isPresenceAvailabilityEpochCurrent,
   isPresenceEligibleForRemoteRequest,
   markPresenceAvailabilityEpoch,
   type PresenceTrackedRequest,
+  type PresenceWipeTimerEntry,
   resetPresenceAvailabilityEpochs,
   resetPresenceAvailabilityForConnection,
   schedulePresenceWipeTimer,
@@ -152,6 +155,12 @@ const BACKGROUND_SUSPEND_SUSPECT_MS = 10_000;
 /** 桌面端 presence 闪断宽限:短暂离线不立刻清空该设备的会话镜像与能力缓存。 */
 const PRESENCE_OFFLINE_WIPE_GRACE_MS = 5_000;
 
+/**
+ * 重连刚 online 时给乐观补齐留出的最小确认窗:覆盖连接就绪等待(1.5s)与
+ * 一次普通 invoke 往返,但只在旧 timer 剩余时间更短时向后延,不随抖动无限重置。
+ */
+const RECONNECT_MIN_WIPE_GRACE_MS = 3_000;
+
 export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   if (MOBILE_VISUAL_MOCK_ENABLED) {
     return <VisualMockDeviceLinkProvider>{children}</VisualMockDeviceLinkProvider>;
@@ -168,7 +177,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const rehydrateRetryRef = useRef<RehydrateRetryState>({ timer: null, attempt: 0 });
   // 供退避计时器回调拿到最新的 rehydrateWithClient(二者互相引用,用 ref 解环)
   const rehydrateFnRef = useRef<(client: DeviceLinkClient) => Promise<void>>(() => Promise.resolve());
-  const presenceWipeTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const presenceWipeTimersRef = useRef(
+    new Map<string, PresenceWipeTimerEntry>(),
+  );
   const openLinkInFlightRef = useRef(
     new Map<string, PresenceTrackedRequest<LinkAcceptPayload>>(),
   );
@@ -348,6 +359,19 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
                 // 不伪造 presence=true,后续权威 false delta 仍可照常过滤并重新计时。
                 clearOnePresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
               },
+              onDeviceRemoteDisabled: (deviceId) => {
+                // 被控端实时设置已明确关闭远控:这是当前 epoch 的权威终态,
+                // 与 presence 的 remoteControlEnabled=false 一样立即清理,不留宽限。
+                clearOnePresenceWipeTimer(
+                  presenceWipeTimersRef.current,
+                  deviceId,
+                );
+                presenceAvailableByDeviceRef.current.set(deviceId, false);
+                presencePendingRecoveryDeviceIdsRef.current.add(deviceId);
+                clearDeviceResponsivenessTrackingFor(deviceId);
+                remoteSubscribedTopicsRef.current.delete(deviceId);
+                wipeUnavailableDeviceMirror(deviceId);
+              },
               onDeviceUnavailable: (deviceId) => {
                 // 新连接按 unknown 乐观探测一次;relay 明确回 DEVICE_OFFLINE 后恢复
                 // 当前代 false verdict,让退避重跑过滤该设备而不是持续重放整套计划。
@@ -471,10 +495,19 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       // 恢复,旧 false 不能永久挡住本轮 rehydrate。上一代仍 pending 的镜像清理
       // 保留原宽限截止点:计时器把新连接尚无 verdict 的 unknown 当作未确认恢复,
       // 只有当前代明确 available=true 才取消,避免重连瞬间按旧 false 提前清空镜像。
-      resetPresenceAvailabilityForConnection(
+      const staleUnavailableDeviceIds = resetPresenceAvailabilityForConnection(
         presenceAvailableByDeviceRef.current,
         presencePendingRecoveryDeviceIdsRef.current,
       );
+      for (const deviceId of staleUnavailableDeviceIds) {
+        extendPresenceWipeTimerFloor(
+          presenceWipeTimersRef.current,
+          presenceAvailableByDeviceRef.current,
+          deviceId,
+          RECONNECT_MIN_WIPE_GRACE_MS,
+          presenceWipeTimerDeps,
+        );
+      }
       setConnectionEpoch((n) => n + 1);
       void rehydrateWithClient(client);
     });
@@ -828,12 +861,20 @@ async function rebuildSessionSnapshot(
     remoteSessionStore.setGoalStatus(sessionId, goal.value);
   }
   // 任一子快照瞬时失败 → 上抛让 rehydrate 计入重试;永久失败(老被控端无 goal
-  // 通道的 CHANNEL_NOT_ALLOWED、权限撤销等)吞掉,重试没有意义。
-  const results = [history, pending, projection, goal] as const;
-  const transient = results.find(
-    (r): r is PromiseRejectedResult => r.status === 'rejected' && isTransientRemoteError(r.reason),
-  );
-  if (transient) throw transient.reason;
+  // 通道的 CHANNEL_NOT_ALLOWED、权限撤销等)吞掉,重试没有意义。同批若已有
+  // fulfilled 目标应答,兄弟 unavailable 只能算局部瞬态,不能升级为整机 verdict。
+  const batchFailure = classifySnapshotBatchFailure([
+    history,
+    pending,
+    projection,
+    goal,
+  ]);
+  if (batchFailure.kind === 'partial-transient') {
+    throw Object.assign(new Error('partial snapshot needs retry'), {
+      code: 'INVOKE_TIMEOUT',
+    });
+  }
+  if (batchFailure.kind === 'reject') throw batchFailure.error;
 }
 
 // 掉线/重连窗口里发起请求时,先有界等待连接就绪的上限。够一次健康重连握手完成
@@ -1044,8 +1085,16 @@ function wipeUnavailableDeviceMirror(deviceId: string): void {
   evictComposerPaletteCacheForDevice(deviceId);
 }
 
+const presenceWipeTimerDeps = {
+  now: Date.now,
+  setTimer: (callback: () => void, delayMs: number) =>
+    setTimeout(callback, delayMs),
+  clearTimer: clearTimeout,
+  wipe: wipeUnavailableDeviceMirror,
+};
+
 function scheduleUnavailableDeviceMirrorWipe(
-  timers: Map<string, ReturnType<typeof setTimeout>>,
+  timers: Map<string, PresenceWipeTimerEntry>,
   availabilityByDevice: ReadonlyMap<string, boolean>,
   deviceId: string,
 ): void {
@@ -1054,23 +1103,19 @@ function scheduleUnavailableDeviceMirrorWipe(
     availabilityByDevice,
     deviceId,
     PRESENCE_OFFLINE_WIPE_GRACE_MS,
-    {
-      setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
-      clearTimer: clearTimeout,
-      wipe: wipeUnavailableDeviceMirror,
-    },
+    presenceWipeTimerDeps,
   );
 }
 
 function clearOnePresenceWipeTimer(
-  timers: Map<string, ReturnType<typeof setTimeout>>,
+  timers: Map<string, PresenceWipeTimerEntry>,
   deviceId: string,
 ): void {
   clearPresenceWipeTimer(timers, deviceId, clearTimeout);
 }
 
 function clearAllPresenceWipeTimers(
-  timers: Map<string, ReturnType<typeof setTimeout>>,
+  timers: Map<string, PresenceWipeTimerEntry>,
 ): void {
   clearPresenceWipeTimers(timers, clearTimeout);
 }

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -158,6 +158,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const presenceWipeTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   const openLinkInFlightRef = useRef(new Map<string, Promise<LinkAcceptPayload>>());
   const presenceAvailableByDeviceRef = useRef(new Map<string, boolean>());
+  const presencePendingRecoveryDeviceIdsRef = useRef(new Set<string>());
   const [status, setStatus] = useState<DeviceLinkStatus>('stopped');
   const [connectionIssue, setConnectionIssue] = useState<DeviceLinkConnectionIssue | null>(null);
   const [presenceVersion, setPresenceVersion] = useState(0);
@@ -362,6 +363,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       clearPresenceWipeTimers(presenceWipeTimersRef.current);
       openLinkInFlightRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
+      presencePendingRecoveryDeviceIdsRef.current.clear();
       setStatus('stopped');
       setConnectionIssue(null);
       remoteSessionStore.clear();
@@ -427,6 +429,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       // 真离线设备的 stale mirror 将永久残留。已恢复设备由紧随其后的 rehydrate 重建。
       const staleUnavailableDeviceIds = resetPresenceAvailabilityForConnection(
         presenceAvailableByDeviceRef.current,
+        presencePendingRecoveryDeviceIdsRef.current,
       );
       for (const deviceId of staleUnavailableDeviceIds) {
         clearPresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
@@ -438,7 +441,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     const offPresence = client.onPresenceChanged((snap) => {
       setLastPresenceSnapshot(snap);
       setPresenceVersion((n) => n + 1);
-      const presence = updatePresenceAvailability(presenceAvailableByDeviceRef.current, snap);
+      const presence = updatePresenceAvailability(
+        presenceAvailableByDeviceRef.current,
+        snap,
+        presencePendingRecoveryDeviceIdsRef.current,
+      );
       const wipeTimers = presenceWipeTimersRef.current;
       if (!presence.available) {
         // Relay 的权威 presence 已说明目标离线或关闭远控:此前 INVOKE_TIMEOUT
@@ -588,6 +595,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       openLinkInFlightRef.current.clear();
       remoteSubscribedTopicsRef.current.clear();
       presenceAvailableByDeviceRef.current.clear();
+      presencePendingRecoveryDeviceIdsRef.current.clear();
       if (clientRef.current === client) clientRef.current = null;
     };
   }, [auth.getAccessToken, auth.isAuthenticated, clearRehydrateRetry, rehydrateWithClient]);

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -11,7 +11,7 @@
  *     ACCESS_REVOKED 等目标设备正常应答的错误)都重置计数并关熔断;
  *   - NOT_CONNECTED / relay 层错误 / 发送前本地中止是本机链路问题,不定论
  *     (inconclusive):既不计失败,也不当作设备健康的证据;
- *   - 连续 failureThreshold 次超时 → open:该设备的新请求快速失败
+ *   - 连续 failureThreshold 个独立超时批次 → open:该设备的新请求快速失败
  *     (DEVICE_UNRESPONSIVE,permanent 不重试);
  *   - half-open:open 后按退避窗口(10s 起 ×2,封顶 120s)放行**单个**探测请求
  *     (单飞),真实回包即 close,再超时回 open 并加深退避。
@@ -28,12 +28,13 @@ export type BreakerAcquireDecision = 'allow' | 'probe' | 'reject';
  * settle 时代数不匹配 = 这是恢复(或清除)之前派出的旧请求,其结果一律不采信
  * (review P1:熔断 open 前派出的 30/40s 长超时请求,会在探测成功关熔断之后
  * 才陆续超时,若照常计数,3 条陈旧超时会立刻把刚恢复的熔断重新打开)。
- * 无状态时的 responded 不翻代(review:否则健康并发下一个快回包会作废同期
- * 在途请求的超时,连续超时被低估、熔断反而难打开)。
+ * cohort 由已知 fan-out 调用方显式分配并传入:同一批请求因一次链路抖动一起
+ * 超时只贡献一次 strike;未传 cohort 的普通请求各自创建独立观测。
  */
 export interface BreakerSendSlot {
   decision: BreakerAcquireDecision;
   generation: number;
+  cohort: number;
 }
 
 export type BreakerSettleOutcome =
@@ -49,7 +50,7 @@ export const BREAKER_PROBE_BACKOFF_BASE_MS = 10_000;
 export const BREAKER_PROBE_BACKOFF_MAX_MS = 120_000;
 
 export interface DeviceResponsivenessBreakerOptions {
-  /** 连续超时多少次进入 open;默认 3。 */
+  /** 连续多少个独立超时批次进入 open;默认 3。 */
   failureThreshold?: number;
   /** open 后首个探测窗口;默认 10s。 */
   probeBackoffBaseMs?: number;
@@ -62,12 +63,13 @@ export interface DeviceResponsivenessBreakerOptions {
 }
 
 export interface DeviceResponsivenessBreaker {
+  /** 为一轮明确的 fan-out 批次分配共享 id;该批 acquire 必须原样传回。 */
+  createCohort(deviceId: string): number;
   /**
-   * 发送前门禁:closed → 'allow';open 且探测窗口已到、无在途探测 → 'probe'
-   * (调用方必须把返回的票据原样带给 settle 以释放单飞);其余 → 'reject'
-   * (调用方应快速失败,不上管道)。
+   * 发送前门禁:closed → 'allow';同一 fan-out 可传共享 cohort,省略则每次调用
+   * 创建独立 cohort。open 且探测窗口已到、无在途探测 → 'probe';其余 → 'reject'。
    */
-  acquire(deviceId: string): BreakerSendSlot;
+  acquire(deviceId: string, cohort?: number): BreakerSendSlot;
   /** 请求收尾上报。slot 必须是 acquire 返回的票据;代数不匹配的旧请求被忽略。 */
   settle(deviceId: string, slot: BreakerSendSlot, outcome: BreakerSettleOutcome): void;
   isOpen(deviceId: string): boolean;
@@ -108,23 +110,34 @@ export function createDeviceResponsivenessBreaker(
   // 采信「派发时代数仍是当前代」的结果——恢复前派出的长超时请求晚到的超时
   // 不再污染新一代计数。
   const generations = new Map<string, number>();
+  const nextCohorts = new Map<string, number>();
+  const countedTimeoutCohorts = new Map<string, Set<number>>();
   const generationOf = (deviceId: string): number => generations.get(deviceId) ?? 0;
   const bumpGeneration = (deviceId: string): void => {
     generations.set(deviceId, generationOf(deviceId) + 1);
+    nextCohorts.delete(deviceId);
+    countedTimeoutCohorts.delete(deviceId);
+  };
+  const newCohort = (deviceId: string): number => {
+    const next = (nextCohorts.get(deviceId) ?? 0) + 1;
+    nextCohorts.set(deviceId, next);
+    return next;
   };
 
-  const acquire = (deviceId: string): BreakerSendSlot => {
+  const acquire = (deviceId: string, cohort?: number): BreakerSendSlot => {
     // 首次发放即登记(review):仅 acquire 过、还没有任何 settle/state 的设备也
     // 必须被 resetAll 的全量翻篇覆盖,否则登出前的在途请求会在切号后按当前代
     // 被采信,把旧账号的超时累进新账号的计数。
     if (!generations.has(deviceId)) generations.set(deviceId, 0);
     const generation = generationOf(deviceId);
     const state = states.get(deviceId);
-    if (!state?.open) return { decision: 'allow', generation };
-    if (state.probeInFlight) return { decision: 'reject', generation };
-    if (now() - state.openedAt < state.probeBackoffMs) return { decision: 'reject', generation };
+    if (!state?.open) return { decision: 'allow', generation, cohort: cohort ?? newCohort(deviceId) };
+    if (state.probeInFlight) return { decision: 'reject', generation, cohort: 0 };
+    if (now() - state.openedAt < state.probeBackoffMs) {
+      return { decision: 'reject', generation, cohort: 0 };
+    }
     state.probeInFlight = true;
-    return { decision: 'probe', generation };
+    return { decision: 'probe', generation, cohort: 0 };
   };
 
   const settle = (deviceId: string, slot: BreakerSendSlot, outcome: BreakerSettleOutcome): void => {
@@ -159,6 +172,10 @@ export function createDeviceResponsivenessBreaker(
       }
       return;
     }
+    const counted = countedTimeoutCohorts.get(deviceId) ?? new Set<number>();
+    if (counted.has(slot.cohort)) return;
+    counted.add(slot.cohort);
+    countedTimeoutCohorts.set(deviceId, counted);
     const next = state ?? {
       consecutiveTimeouts: 0,
       open: false,
@@ -177,6 +194,7 @@ export function createDeviceResponsivenessBreaker(
   };
 
   return {
+    createCohort: newCohort,
     acquire,
     settle,
     isOpen: (deviceId) => states.get(deviceId)?.open === true,
@@ -200,6 +218,8 @@ export function createDeviceResponsivenessBreaker(
       }
       const openIds = [...states.entries()].filter(([, s]) => s.open).map(([id]) => id);
       states.clear();
+      nextCohorts.clear();
+      countedTimeoutCohorts.clear();
       for (const deviceId of openIds) options.onOpenChanged?.(deviceId, false);
     },
   };

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -115,6 +115,8 @@ export function createDeviceResponsivenessBreaker(
   const generationOf = (deviceId: string): number => generations.get(deviceId) ?? 0;
   const bumpGeneration = (deviceId: string): void => {
     generations.set(deviceId, generationOf(deviceId) + 1);
+    // cohort id 保持单调递增:它可能先于 acquire 被补齐流程暂存,翻代后若从 1
+    // 重新发号,会与新一代普通请求碰撞并把独立 timeout 误判成已计数。
     countedTimeoutCohorts.delete(deviceId);
   };
   const newCohort = (deviceId: string): number => {

--- a/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
+++ b/apps/mobile/src/device-link/deviceResponsivenessBreaker.ts
@@ -115,7 +115,6 @@ export function createDeviceResponsivenessBreaker(
   const generationOf = (deviceId: string): number => generations.get(deviceId) ?? 0;
   const bumpGeneration = (deviceId: string): void => {
     generations.set(deviceId, generationOf(deviceId) + 1);
-    nextCohorts.delete(deviceId);
     countedTimeoutCohorts.delete(deviceId);
   };
   const newCohort = (deviceId: string): number => {

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -72,6 +72,56 @@ export function getOrCreatePresenceTrackedRequest<T>(
   return tracked;
 }
 
+export interface PresenceWipeTimerDeps {
+  setTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimer(timer: ReturnType<typeof setTimeout>): void;
+  wipe(deviceId: string): void;
+}
+
+export function schedulePresenceWipeTimer(
+  timers: Map<string, ReturnType<typeof setTimeout>>,
+  availabilityByDevice: ReadonlyMap<string, boolean>,
+  deviceId: string,
+  delayMs: number,
+  deps: PresenceWipeTimerDeps,
+): void {
+  if (timers.has(deviceId)) return;
+  timers.set(deviceId, deps.setTimer(() => {
+    timers.delete(deviceId);
+    if (shouldWipeUnavailableDeviceMirror(availabilityByDevice, deviceId)) {
+      deps.wipe(deviceId);
+    }
+  }, delayMs));
+}
+
+export function clearPresenceWipeTimer(
+  timers: Map<string, ReturnType<typeof setTimeout>>,
+  deviceId: string,
+  clearTimer: PresenceWipeTimerDeps['clearTimer'],
+): void {
+  const timer = timers.get(deviceId);
+  if (!timer) return;
+  clearTimer(timer);
+  timers.delete(deviceId);
+}
+
+export function clearPresenceWipeTimers(
+  timers: Map<string, ReturnType<typeof setTimeout>>,
+  clearTimer: PresenceWipeTimerDeps['clearTimer'],
+): void {
+  for (const timer of timers.values()) clearTimer(timer);
+  timers.clear();
+}
+
+export function shouldWipeUnavailableDeviceMirror(
+  availabilityByDevice: ReadonlyMap<string, boolean>,
+  deviceId: string,
+): boolean {
+  // 新连接不会重放全量 presence,因此 reconnect 清掉旧 verdict 后的 unknown
+  // 仍需让原宽限计时器按期回收;只有当前代已明确 available 才取消清理。
+  return availabilityByDevice.get(deviceId) !== true;
+}
+
 export function isPresenceEligibleForRemoteRequest(
   availabilityByDevice: ReadonlyMap<string, boolean>,
   deviceId: string,

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -81,6 +81,7 @@ export function getOrCreatePresenceTrackedRequest<T>(
 export interface PresenceWipeTimerEntry {
   timer: ReturnType<typeof setTimeout>;
   deadlineAt: number;
+  firstScheduledAt: number;
 }
 
 export interface PresenceWipeTimerDeps {
@@ -90,6 +91,8 @@ export interface PresenceWipeTimerDeps {
   wipe(deviceId: string): void;
 }
 
+export const PRESENCE_WIPE_MAX_LIFETIME_MS = 30_000;
+
 export function schedulePresenceWipeTimer(
   timers: Map<string, PresenceWipeTimerEntry>,
   availabilityByDevice: ReadonlyMap<string, boolean>,
@@ -98,11 +101,13 @@ export function schedulePresenceWipeTimer(
   deps: PresenceWipeTimerDeps,
 ): void {
   if (timers.has(deviceId)) return;
+  const now = deps.now();
   schedulePresenceWipeAt(
     timers,
     availabilityByDevice,
     deviceId,
-    deps.now() + delayMs,
+    now,
+    now + delayMs,
     deps,
   );
 }
@@ -116,7 +121,10 @@ export function extendPresenceWipeTimerFloor(
 ): void {
   const entry = timers.get(deviceId);
   if (!entry) return;
-  const minimumDeadlineAt = deps.now() + minimumDelayMs;
+  const minimumDeadlineAt = Math.min(
+    deps.now() + minimumDelayMs,
+    entry.firstScheduledAt + PRESENCE_WIPE_MAX_LIFETIME_MS,
+  );
   if (entry.deadlineAt >= minimumDeadlineAt) return;
 
   deps.clearTimer(entry.timer);
@@ -124,6 +132,7 @@ export function extendPresenceWipeTimerFloor(
     timers,
     availabilityByDevice,
     deviceId,
+    entry.firstScheduledAt,
     minimumDeadlineAt,
     deps,
   );
@@ -152,12 +161,14 @@ function schedulePresenceWipeAt(
   timers: Map<string, PresenceWipeTimerEntry>,
   availabilityByDevice: ReadonlyMap<string, boolean>,
   deviceId: string,
+  firstScheduledAt: number,
   deadlineAt: number,
   deps: PresenceWipeTimerDeps,
 ): void {
   const delayMs = Math.max(0, deadlineAt - deps.now());
   const entry: PresenceWipeTimerEntry = {
     deadlineAt,
+    firstScheduledAt,
     timer: deps.setTimer(() => {
       if (timers.get(deviceId) !== entry) return;
       timers.delete(deviceId);
@@ -176,6 +187,36 @@ export function shouldWipeUnavailableDeviceMirror(
   // 新连接不会重放全量 presence,因此 reconnect 清掉旧 verdict 后的 unknown
   // 仍需让原宽限计时器按期回收;只有当前代已明确 available 才取消清理。
   return availabilityByDevice.get(deviceId) !== true;
+}
+
+export type PresenceUnavailableVerdictKind = 'offline' | 'disabled' | 'presence';
+
+export interface PresenceUnavailableVerdict {
+  kind: PresenceUnavailableVerdictKind;
+  responseEvidenceEpoch: number;
+}
+
+export function reconcileOfflineVerdictAfterResponse(
+  availabilityByDevice: Map<string, boolean>,
+  pendingRecoveryDeviceIds: Set<string>,
+  verdicts: Map<string, PresenceUnavailableVerdict>,
+  deviceId: string,
+  currentResponseEvidenceEpoch: number,
+): boolean {
+  const verdict = verdicts.get(deviceId);
+  if (
+    verdict?.kind !== 'offline'
+    || currentResponseEvidenceEpoch <= verdict.responseEvidenceEpoch
+  ) {
+    return false;
+  }
+
+  // 真实目标应答只推翻 rehydrate 的路由离线推断,回到 unknown 乐观补齐;
+  // 显式 disabled verdict 永远不在此清除,只能由权威 presence 恢复。
+  availabilityByDevice.delete(deviceId);
+  pendingRecoveryDeviceIds.add(deviceId);
+  verdicts.delete(deviceId);
+  return true;
 }
 
 export function isPresenceEligibleForRemoteRequest(

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -72,45 +72,95 @@ export function getOrCreatePresenceTrackedRequest<T>(
   return tracked;
 }
 
+export interface PresenceWipeTimerEntry {
+  timer: ReturnType<typeof setTimeout>;
+  deadlineAt: number;
+}
+
 export interface PresenceWipeTimerDeps {
+  now(): number;
   setTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
   clearTimer(timer: ReturnType<typeof setTimeout>): void;
   wipe(deviceId: string): void;
 }
 
 export function schedulePresenceWipeTimer(
-  timers: Map<string, ReturnType<typeof setTimeout>>,
+  timers: Map<string, PresenceWipeTimerEntry>,
   availabilityByDevice: ReadonlyMap<string, boolean>,
   deviceId: string,
   delayMs: number,
   deps: PresenceWipeTimerDeps,
 ): void {
   if (timers.has(deviceId)) return;
-  timers.set(deviceId, deps.setTimer(() => {
-    timers.delete(deviceId);
-    if (shouldWipeUnavailableDeviceMirror(availabilityByDevice, deviceId)) {
-      deps.wipe(deviceId);
-    }
-  }, delayMs));
+  schedulePresenceWipeAt(
+    timers,
+    availabilityByDevice,
+    deviceId,
+    deps.now() + delayMs,
+    deps,
+  );
+}
+
+export function extendPresenceWipeTimerFloor(
+  timers: Map<string, PresenceWipeTimerEntry>,
+  availabilityByDevice: ReadonlyMap<string, boolean>,
+  deviceId: string,
+  minimumDelayMs: number,
+  deps: PresenceWipeTimerDeps,
+): void {
+  const entry = timers.get(deviceId);
+  if (!entry) return;
+  const minimumDeadlineAt = deps.now() + minimumDelayMs;
+  if (entry.deadlineAt >= minimumDeadlineAt) return;
+
+  deps.clearTimer(entry.timer);
+  schedulePresenceWipeAt(
+    timers,
+    availabilityByDevice,
+    deviceId,
+    minimumDeadlineAt,
+    deps,
+  );
 }
 
 export function clearPresenceWipeTimer(
-  timers: Map<string, ReturnType<typeof setTimeout>>,
+  timers: Map<string, PresenceWipeTimerEntry>,
   deviceId: string,
   clearTimer: PresenceWipeTimerDeps['clearTimer'],
 ): void {
-  const timer = timers.get(deviceId);
-  if (!timer) return;
-  clearTimer(timer);
+  const entry = timers.get(deviceId);
+  if (!entry) return;
+  clearTimer(entry.timer);
   timers.delete(deviceId);
 }
 
 export function clearPresenceWipeTimers(
-  timers: Map<string, ReturnType<typeof setTimeout>>,
+  timers: Map<string, PresenceWipeTimerEntry>,
   clearTimer: PresenceWipeTimerDeps['clearTimer'],
 ): void {
-  for (const timer of timers.values()) clearTimer(timer);
+  for (const entry of timers.values()) clearTimer(entry.timer);
   timers.clear();
+}
+
+function schedulePresenceWipeAt(
+  timers: Map<string, PresenceWipeTimerEntry>,
+  availabilityByDevice: ReadonlyMap<string, boolean>,
+  deviceId: string,
+  deadlineAt: number,
+  deps: PresenceWipeTimerDeps,
+): void {
+  const delayMs = Math.max(0, deadlineAt - deps.now());
+  const entry: PresenceWipeTimerEntry = {
+    deadlineAt,
+    timer: deps.setTimer(() => {
+      if (timers.get(deviceId) !== entry) return;
+      timers.delete(deviceId);
+      if (shouldWipeUnavailableDeviceMirror(availabilityByDevice, deviceId)) {
+        deps.wipe(deviceId);
+      }
+    }, delayMs),
+  };
+  timers.set(deviceId, entry);
 }
 
 export function shouldWipeUnavailableDeviceMirror(

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -18,14 +18,16 @@ export function isPresenceEligibleForRemoteRequest(
 
 export function resetPresenceAvailabilityForConnection(
   availabilityByDevice: Map<string, boolean>,
+  pendingRecoveryDeviceIds: Set<string>,
 ): string[] {
   // presence-changed 是只发给「当时在线控制端」的增量广播,新连接没有全量重放。
   // 每个连接代际都必须丢弃旧 verdict,否则后台期间漏掉的恢复事件会让 stale false
-  // 永久挡住该设备的 rehydrate。返回上一代明确 unavailable 的设备,让调用方在
-  // 清空 verdict 的同时结算其 pending mirror wipe;随后本轮 rehydrate 会重建已恢复设备。
+  // 永久挡住该设备的 rehydrate。上一代明确 unavailable 的设备另存为 pending
+  // recovery:当前连接按 unknown 乐观尝试,而它稍后首个 available 快照仍能形成恢复边。
   const unavailableDeviceIds = [...availabilityByDevice.entries()]
     .filter(([, available]) => !available)
     .map(([deviceId]) => deviceId);
+  for (const deviceId of unavailableDeviceIds) pendingRecoveryDeviceIds.add(deviceId);
   availabilityByDevice.clear();
   return unavailableDeviceIds;
 }
@@ -33,12 +35,15 @@ export function resetPresenceAvailabilityForConnection(
 export function updatePresenceAvailability(
   availabilityByDevice: Map<string, boolean>,
   snap: PresenceAvailabilitySnapshot,
+  pendingRecoveryDeviceIds?: Set<string>,
 ): PresenceAvailabilityUpdate {
   const available = snap.online && snap.remoteControlEnabled;
   const wasAvailable = availabilityByDevice.get(snap.deviceId);
   availabilityByDevice.set(snap.deviceId, available);
+  const recoveredAcrossConnection = available && pendingRecoveryDeviceIds?.delete(snap.deviceId) === true;
+  if (!available) pendingRecoveryDeviceIds?.add(snap.deviceId);
   return {
     available,
-    recovered: available && wasAvailable === false,
+    recovered: available && (wasAvailable === false || recoveredAcrossConnection),
   };
 }

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -7,6 +7,71 @@ export interface PresenceAvailabilityUpdate {
   recovered: boolean;
 }
 
+export interface PresenceAvailabilityEpochs {
+  next: number;
+  byDevice: Map<string, number>;
+}
+
+export function createPresenceAvailabilityEpochs(): PresenceAvailabilityEpochs {
+  return { next: 0, byDevice: new Map() };
+}
+
+export function markPresenceAvailabilityEpoch(
+  epochs: PresenceAvailabilityEpochs,
+  deviceId: string,
+): void {
+  epochs.next += 1;
+  epochs.byDevice.set(deviceId, epochs.next);
+}
+
+export function capturePresenceAvailabilityEpoch(
+  epochs: PresenceAvailabilityEpochs,
+  deviceId: string,
+): number {
+  return epochs.byDevice.get(deviceId) ?? 0;
+}
+
+export function isPresenceAvailabilityEpochCurrent(
+  epochs: PresenceAvailabilityEpochs,
+  deviceId: string,
+  capturedEpoch: number,
+): boolean {
+  return capturePresenceAvailabilityEpoch(epochs, deviceId) === capturedEpoch;
+}
+
+export function resetPresenceAvailabilityEpochs(
+  epochs: PresenceAvailabilityEpochs,
+): void {
+  epochs.next = 0;
+  epochs.byDevice.clear();
+}
+
+export interface PresenceTrackedRequest<T> {
+  capturedPresenceEpoch: number;
+  request: Promise<T>;
+}
+
+export function getOrCreatePresenceTrackedRequest<T>(
+  inFlight: Map<string, PresenceTrackedRequest<T>>,
+  epochs: PresenceAvailabilityEpochs,
+  deviceId: string,
+  createRequest: () => Promise<T>,
+): PresenceTrackedRequest<T> {
+  const existing = inFlight.get(deviceId);
+  if (existing) return existing;
+
+  const tracked = {
+    capturedPresenceEpoch: capturePresenceAvailabilityEpoch(epochs, deviceId),
+    request: createRequest(),
+  };
+  inFlight.set(deviceId, tracked);
+  const cleanup = (): void => {
+    if (inFlight.get(deviceId) === tracked) inFlight.delete(deviceId);
+  };
+  void tracked.request.then(cleanup, cleanup);
+  return tracked;
+}
+
 export function isPresenceEligibleForRemoteRequest(
   availabilityByDevice: ReadonlyMap<string, boolean>,
   deviceId: string,

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -89,9 +89,11 @@ export interface PresenceWipeTimerDeps {
   setTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
   clearTimer(timer: ReturnType<typeof setTimeout>): void;
   wipe(deviceId: string): void;
+  isConfirmationInFlight?(deviceId: string): boolean;
 }
 
 export const PRESENCE_WIPE_MAX_LIFETIME_MS = 30_000;
+const PRESENCE_WIPE_CONFIRMATION_POLL_MS = 1_000;
 
 export function schedulePresenceWipeTimer(
   timers: Map<string, PresenceWipeTimerEntry>,
@@ -171,6 +173,17 @@ function schedulePresenceWipeAt(
     firstScheduledAt,
     timer: deps.setTimer(() => {
       if (timers.get(deviceId) !== entry) return;
+      if (deps.isConfirmationInFlight?.(deviceId)) {
+        schedulePresenceWipeAt(
+          timers,
+          availabilityByDevice,
+          deviceId,
+          firstScheduledAt,
+          deps.now() + PRESENCE_WIPE_CONFIRMATION_POLL_MS,
+          deps,
+        );
+        return;
+      }
       timers.delete(deviceId);
       if (shouldWipeUnavailableDeviceMirror(availabilityByDevice, deviceId)) {
         deps.wipe(deviceId);

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -48,12 +48,14 @@ export function resetPresenceAvailabilityEpochs(
 
 export interface PresenceTrackedRequest<T> {
   capturedPresenceEpoch: number;
+  capturedResponseEvidenceEpoch: number;
   request: Promise<T>;
 }
 
 export function getOrCreatePresenceTrackedRequest<T>(
   inFlight: Map<string, PresenceTrackedRequest<T>>,
   epochs: PresenceAvailabilityEpochs,
+  responseEvidenceEpochs: PresenceAvailabilityEpochs,
   deviceId: string,
   createRequest: () => Promise<T>,
 ): PresenceTrackedRequest<T> {
@@ -62,6 +64,10 @@ export function getOrCreatePresenceTrackedRequest<T>(
 
   const tracked = {
     capturedPresenceEpoch: capturePresenceAvailabilityEpoch(epochs, deviceId),
+    capturedResponseEvidenceEpoch: capturePresenceAvailabilityEpoch(
+      responseEvidenceEpochs,
+      deviceId,
+    ),
     request: createRequest(),
   };
   inFlight.set(deviceId, tracked);

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -7,6 +7,29 @@ export interface PresenceAvailabilityUpdate {
   recovered: boolean;
 }
 
+export function isPresenceEligibleForRemoteRequest(
+  availabilityByDevice: ReadonlyMap<string, boolean>,
+  deviceId: string,
+): boolean {
+  // 首次尚未收到 presence 时保留既有乐观尝试;只有 relay 已明确声明 unavailable
+  // 才拦住 rehydrate / half-open probe,避免对离线设备立即重放请求风暴。
+  return availabilityByDevice.get(deviceId) !== false;
+}
+
+export function resetPresenceAvailabilityForConnection(
+  availabilityByDevice: Map<string, boolean>,
+): string[] {
+  // presence-changed 是只发给「当时在线控制端」的增量广播,新连接没有全量重放。
+  // 每个连接代际都必须丢弃旧 verdict,否则后台期间漏掉的恢复事件会让 stale false
+  // 永久挡住该设备的 rehydrate。返回上一代明确 unavailable 的设备,让调用方在
+  // 清空 verdict 的同时结算其 pending mirror wipe;随后本轮 rehydrate 会重建已恢复设备。
+  const unavailableDeviceIds = [...availabilityByDevice.entries()]
+    .filter(([, available]) => !available)
+    .map(([deviceId]) => deviceId);
+  availabilityByDevice.clear();
+  return unavailableDeviceIds;
+}
+
 export function updatePresenceAvailability(
   availabilityByDevice: Map<string, boolean>,
   snap: PresenceAvailabilitySnapshot,

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -1,4 +1,4 @@
-import type { PresenceSnapshot } from '@cindy/device-link';
+import type { InvokeResultPayload, PresenceSnapshot } from '@cindy/device-link';
 
 type PresenceAvailabilitySnapshot = Pick<PresenceSnapshot, 'deviceId' | 'online' | 'remoteControlEnabled'>;
 
@@ -194,6 +194,16 @@ export type PresenceUnavailableVerdictKind = 'offline' | 'disabled' | 'presence'
 export interface PresenceUnavailableVerdict {
   kind: PresenceUnavailableVerdictKind;
   responseEvidenceEpoch: number;
+}
+
+export function isInvokeResultReachabilityEvidence(
+  result: InvokeResultPayload,
+): boolean {
+  return result.ok
+    || (
+      result.error.code !== 'REMOTE_DISABLED'
+      && result.error.code !== 'ACCESS_REVOKED'
+    );
 }
 
 export function reconcileOfflineVerdictAfterResponse(

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -9,13 +9,19 @@ export interface DeviceLinkRehydrateSendOptions {
 
 export interface PresenceTrackedRehydrateStep {
   capturedPresenceEpoch: number;
+  capturedResponseEvidenceEpoch: number;
   request: Promise<unknown>;
 }
 
 export interface DeviceLinkRehydrateDeps {
   createDeviceSendCohort(deviceId: string): number;
   capturePresenceEpoch(deviceId: string): number;
+  captureResponseEvidenceEpoch(deviceId: string): number;
   isPresenceEpochCurrent(deviceId: string, capturedPresenceEpoch: number): boolean;
+  isResponseEvidenceEpochCurrent(
+    deviceId: string,
+    capturedResponseEvidenceEpoch: number,
+  ): boolean;
   openLink(deviceId: string): PresenceTrackedRehydrateStep;
   subscribe(deviceId: string, topics: readonly Topic[]): Promise<unknown>;
   requestSessionsReseed(deviceId: string): void;
@@ -54,6 +60,7 @@ export async function rehydrateDeviceLinkTopics(
   const track = async (
     deviceId: string,
     capturedPresenceEpoch: number,
+    capturedResponseEvidenceEpoch: number,
     step: Promise<unknown>,
   ): Promise<'continue' | 'unavailable'> => {
     try {
@@ -69,9 +76,16 @@ export async function rehydrateDeviceLinkTopics(
       );
       const offlineVerdict = isDeviceOfflineError(err);
       const remoteDisabledVerdict = isRemoteDisabledError(err);
-      const unavailable = epochCurrent && (
-        offlineVerdict || remoteDisabledVerdict
-      );
+      const availabilityVerdict = offlineVerdict || remoteDisabledVerdict;
+      const supersededByConcurrentResponse = epochCurrent
+        && availabilityVerdict
+        && !deps.isResponseEvidenceEpochCurrent(
+          deviceId,
+          capturedResponseEvidenceEpoch,
+        );
+      const unavailable = epochCurrent
+        && availabilityVerdict
+        && !supersededByConcurrentResponse;
       if (unavailable) {
         if (remoteDisabledVerdict) {
           deps.onDeviceRemoteDisabled?.(deviceId);
@@ -79,7 +93,12 @@ export async function rehydrateDeviceLinkTopics(
           deps.onDeviceUnavailable?.(deviceId);
         }
       }
-      if (!unavailable && isTransientRemoteError(err)) transientFailures += 1;
+      if (
+        !unavailable
+        && (isTransientRemoteError(err) || supersededByConcurrentResponse)
+      ) {
+        transientFailures += 1;
+      }
       return unavailable ? 'unavailable' : 'continue';
     }
   };
@@ -92,6 +111,7 @@ export async function rehydrateDeviceLinkTopics(
       if (await track(
         plan.deviceId,
         openLinkStep.capturedPresenceEpoch,
+        openLinkStep.capturedResponseEvidenceEpoch,
         openLinkStep.request,
       ) === 'unavailable') {
         continue;
@@ -103,6 +123,7 @@ export async function rehydrateDeviceLinkTopics(
       await track(
         plan.deviceId,
         deps.capturePresenceEpoch(plan.deviceId),
+        deps.captureResponseEvidenceEpoch(plan.deviceId),
         deps.subscribe(plan.deviceId, plan.topics),
       ) === 'unavailable'
     ) {
@@ -121,6 +142,7 @@ export async function rehydrateDeviceLinkTopics(
         if (await track(
           plan.deviceId,
           deps.capturePresenceEpoch(plan.deviceId),
+          deps.captureResponseEvidenceEpoch(plan.deviceId),
           deps.rebuildSessionSnapshot(plan.deviceId, sessionId, {
             responsivenessCohort: deps.createDeviceSendCohort(plan.deviceId),
           }),

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -14,6 +14,7 @@ export interface PresenceTrackedRehydrateStep {
 }
 
 export interface DeviceLinkRehydrateDeps {
+  isCancelled?(): boolean;
   createDeviceSendCohort(deviceId: string): number;
   capturePresenceEpoch(deviceId: string): number;
   captureResponseEvidenceEpoch(deviceId: string): number;
@@ -104,6 +105,7 @@ export async function rehydrateDeviceLinkTopics(
   };
 
   for (const plan of plans) {
+    if (deps.isCancelled?.()) return { transientFailures };
     if (plan.openLink) {
       // openLink 可能与页面请求共用一条在途请求;它必须连同底层请求真正创建时
       // 捕获的 epoch 一起复用,不能在 dedupe 时补拍一个更新的 epoch。
@@ -119,6 +121,7 @@ export async function rehydrateDeviceLinkTopics(
     }
 
     if (plan.topics.length === 0) continue;
+    if (deps.isCancelled?.()) return { transientFailures };
     if (
       await track(
         plan.deviceId,
@@ -131,6 +134,7 @@ export async function rehydrateDeviceLinkTopics(
     }
 
     for (const topic of plan.topics) {
+      if (deps.isCancelled?.()) return { transientFailures };
       if (topic === 'sessions') {
         deps.requestSessionsReseed(plan.deviceId);
         continue;

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -7,9 +7,16 @@ export interface DeviceLinkRehydrateSendOptions {
   responsivenessCohort?: number;
 }
 
+export interface PresenceTrackedRehydrateStep {
+  capturedPresenceEpoch: number;
+  request: Promise<unknown>;
+}
+
 export interface DeviceLinkRehydrateDeps {
   createDeviceSendCohort(deviceId: string): number;
-  openLink(deviceId: string): Promise<unknown>;
+  capturePresenceEpoch(deviceId: string): number;
+  isPresenceEpochCurrent(deviceId: string, capturedPresenceEpoch: number): boolean;
+  openLink(deviceId: string): PresenceTrackedRehydrateStep;
   subscribe(deviceId: string, topics: readonly Topic[]): Promise<unknown>;
   requestSessionsReseed(deviceId: string): void;
   onDeviceUnavailable?(deviceId: string): void;
@@ -44,13 +51,16 @@ export async function rehydrateDeviceLinkTopics(
   let transientFailures = 0;
   const track = async (
     deviceId: string,
+    capturedPresenceEpoch: number,
     step: Promise<unknown>,
   ): Promise<'continue' | 'unavailable'> => {
     try {
       await step;
       return 'continue';
     } catch (err) {
-      const unavailable = isDeviceOfflineError(err);
+      const offlineVerdict = isDeviceOfflineError(err);
+      const unavailable = offlineVerdict
+        && deps.isPresenceEpochCurrent(deviceId, capturedPresenceEpoch);
       if (unavailable) {
         deps.onDeviceUnavailable?.(deviceId);
       }
@@ -60,17 +70,26 @@ export async function rehydrateDeviceLinkTopics(
   };
 
   for (const plan of plans) {
-    if (
-      plan.openLink
-      && await track(plan.deviceId, deps.openLink(plan.deviceId)) === 'unavailable'
-    ) {
-      continue;
+    if (plan.openLink) {
+      // openLink 可能与页面请求共用一条在途请求;它必须连同底层请求真正创建时
+      // 捕获的 epoch 一起复用,不能在 dedupe 时补拍一个更新的 epoch。
+      const openLinkStep = deps.openLink(plan.deviceId);
+      if (await track(
+        plan.deviceId,
+        openLinkStep.capturedPresenceEpoch,
+        openLinkStep.request,
+      ) === 'unavailable') {
+        continue;
+      }
     }
 
     if (plan.topics.length === 0) continue;
     if (
-      await track(plan.deviceId, deps.subscribe(plan.deviceId, plan.topics))
-      === 'unavailable'
+      await track(
+        plan.deviceId,
+        deps.capturePresenceEpoch(plan.deviceId),
+        deps.subscribe(plan.deviceId, plan.topics),
+      ) === 'unavailable'
     ) {
       continue;
     }
@@ -84,9 +103,13 @@ export async function rehydrateDeviceLinkTopics(
       if (sessionId) {
         // 每个 session snapshot 自身包含四路 Promise.allSettled fan-out;只把
         // 同一批真正并发的请求合并,不要把多个串行 session 的超时压成一次观测。
-        if (await track(plan.deviceId, deps.rebuildSessionSnapshot(plan.deviceId, sessionId, {
-          responsivenessCohort: deps.createDeviceSendCohort(plan.deviceId),
-        })) === 'unavailable') {
+        if (await track(
+          plan.deviceId,
+          deps.capturePresenceEpoch(plan.deviceId),
+          deps.rebuildSessionSnapshot(plan.deviceId, sessionId, {
+            responsivenessCohort: deps.createDeviceSendCohort(plan.deviceId),
+          }),
+        ) === 'unavailable') {
           break;
         }
       }

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -20,6 +20,7 @@ export interface DeviceLinkRehydrateDeps {
   subscribe(deviceId: string, topics: readonly Topic[]): Promise<unknown>;
   requestSessionsReseed(deviceId: string): void;
   onDeviceReachable?(deviceId: string): void;
+  onDeviceRemoteDisabled?(deviceId: string): void;
   onDeviceUnavailable?(deviceId: string): void;
   rebuildSessionSnapshot(
     deviceId: string,
@@ -62,11 +63,21 @@ export async function rehydrateDeviceLinkTopics(
       }
       return 'continue';
     } catch (err) {
+      const epochCurrent = deps.isPresenceEpochCurrent(
+        deviceId,
+        capturedPresenceEpoch,
+      );
       const offlineVerdict = isDeviceOfflineError(err);
-      const unavailable = offlineVerdict
-        && deps.isPresenceEpochCurrent(deviceId, capturedPresenceEpoch);
+      const remoteDisabledVerdict = isRemoteDisabledError(err);
+      const unavailable = epochCurrent && (
+        offlineVerdict || remoteDisabledVerdict
+      );
       if (unavailable) {
-        deps.onDeviceUnavailable?.(deviceId);
+        if (remoteDisabledVerdict) {
+          deps.onDeviceRemoteDisabled?.(deviceId);
+        } else {
+          deps.onDeviceUnavailable?.(deviceId);
+        }
       }
       if (!unavailable && isTransientRemoteError(err)) transientFailures += 1;
       return unavailable ? 'unavailable' : 'continue';
@@ -122,13 +133,70 @@ export async function rehydrateDeviceLinkTopics(
   return { transientFailures };
 }
 
-function isDeviceOfflineError(error: unknown): boolean {
-  if (typeof error === 'string') return error.includes('DEVICE_OFFLINE');
+export function hasDeviceLinkErrorCode(
+  error: unknown,
+  expectedCode: string,
+): boolean {
+  if (typeof error === 'string') return error.includes(expectedCode);
   if (!error || typeof error !== 'object') return false;
   const code = (error as { code?: unknown }).code;
-  if (code === 'DEVICE_OFFLINE') return true;
+  if (code === expectedCode) return true;
   const message = error instanceof Error ? error.message : '';
-  return message.includes('DEVICE_OFFLINE');
+  return message.includes(expectedCode);
+}
+
+function isDeviceOfflineError(error: unknown): boolean {
+  return hasDeviceLinkErrorCode(error, 'DEVICE_OFFLINE');
+}
+
+function isRemoteDisabledError(error: unknown): boolean {
+  return hasDeviceLinkErrorCode(error, 'REMOTE_DISABLED');
+}
+
+export type SnapshotBatchFailure =
+  | { kind: 'none' }
+  | { kind: 'partial-transient' }
+  | { kind: 'reject'; error: unknown };
+
+export function classifySnapshotBatchFailure(
+  results: readonly PromiseSettledResult<unknown>[],
+): SnapshotBatchFailure {
+  const rejections = results.filter(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  const availabilityRejections = rejections.filter(
+    (result) =>
+      isDeviceOfflineError(result.reason)
+      || isRemoteDisabledError(result.reason),
+  );
+  const otherTransient = rejections.find(
+    (result) =>
+      isTransientRemoteError(result.reason)
+      && !isDeviceOfflineError(result.reason)
+      && !isRemoteDisabledError(result.reason),
+  );
+  if (availabilityRejections.length === 0) {
+    return otherTransient
+      ? { kind: 'reject', error: otherTransient.reason }
+      : { kind: 'none' };
+  }
+
+  const hasTargetResponse = results.some((result) => result.status === 'fulfilled');
+  if (hasTargetResponse) {
+    // 同批已有目标端应答时,兄弟请求的 unavailable 不能升级为整机 verdict;
+    // 仍作为普通瞬时失败退避重试,补齐缺失的子快照。
+    return { kind: 'partial-transient' };
+  }
+
+  // 无任何目标应答时保留 unavailable verdict;两种标记混合时优先被控端
+  // 实时返回的 REMOTE_DISABLED,而不是可能来自 relay 路由窗口的 DEVICE_OFFLINE。
+  const remoteDisabled = availabilityRejections.find(
+    (result) => isRemoteDisabledError(result.reason),
+  );
+  return {
+    kind: 'reject',
+    error: (remoteDisabled ?? availabilityRejections[0]).reason,
+  };
 }
 
 function readSessionTopic(topic: Topic): string | null {

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -2,11 +2,25 @@ import type { Topic } from '@cindy/device-link';
 import type { RehydratePlan } from '@/device-link/topicRegistry';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 
+export interface DeviceLinkRehydrateSendOptions {
+  /** 同一设备的一轮补齐共享一个响应性观测 cohort。 */
+  responsivenessCohort?: number;
+}
+
 export interface DeviceLinkRehydrateDeps {
-  openLink(deviceId: string): Promise<unknown>;
-  subscribe(deviceId: string, topics: readonly Topic[]): Promise<unknown>;
+  createDeviceSendCohort(deviceId: string): number;
+  openLink(deviceId: string, opts?: DeviceLinkRehydrateSendOptions): Promise<unknown>;
+  subscribe(
+    deviceId: string,
+    topics: readonly Topic[],
+    opts?: DeviceLinkRehydrateSendOptions,
+  ): Promise<unknown>;
   requestSessionsReseed(deviceId: string): void;
-  rebuildSessionSnapshot(deviceId: string, sessionId: string): Promise<unknown>;
+  rebuildSessionSnapshot(
+    deviceId: string,
+    sessionId: string,
+    opts?: DeviceLinkRehydrateSendOptions,
+  ): Promise<unknown>;
 }
 
 export interface DeviceLinkRehydrateResult {
@@ -40,12 +54,15 @@ export async function rehydrateDeviceLinkTopics(
   };
 
   for (const plan of plans) {
+    const sendOpts: DeviceLinkRehydrateSendOptions = {
+      responsivenessCohort: deps.createDeviceSendCohort(plan.deviceId),
+    };
     if (plan.openLink) {
-      await track(deps.openLink(plan.deviceId));
+      await track(deps.openLink(plan.deviceId, sendOpts));
     }
 
     if (plan.topics.length === 0) continue;
-    await track(deps.subscribe(plan.deviceId, plan.topics));
+    await track(deps.subscribe(plan.deviceId, plan.topics, sendOpts));
 
     for (const topic of plan.topics) {
       if (topic === 'sessions') {
@@ -54,7 +71,7 @@ export async function rehydrateDeviceLinkTopics(
       }
       const sessionId = readSessionTopic(topic);
       if (sessionId) {
-        await track(deps.rebuildSessionSnapshot(plan.deviceId, sessionId));
+        await track(deps.rebuildSessionSnapshot(plan.deviceId, sessionId, sendOpts));
       }
     }
   }

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -12,6 +12,7 @@ export interface DeviceLinkRehydrateDeps {
   openLink(deviceId: string): Promise<unknown>;
   subscribe(deviceId: string, topics: readonly Topic[]): Promise<unknown>;
   requestSessionsReseed(deviceId: string): void;
+  onDeviceUnavailable?(deviceId: string): void;
   rebuildSessionSnapshot(
     deviceId: string,
     sessionId: string,
@@ -41,21 +42,38 @@ export async function rehydrateDeviceLinkTopics(
   deps: DeviceLinkRehydrateDeps,
 ): Promise<DeviceLinkRehydrateResult> {
   let transientFailures = 0;
-  const track = async (step: Promise<unknown>): Promise<void> => {
+  const track = async (
+    deviceId: string,
+    step: Promise<unknown>,
+  ): Promise<'continue' | 'unavailable'> => {
     try {
       await step;
+      return 'continue';
     } catch (err) {
-      if (isTransientRemoteError(err)) transientFailures += 1;
+      const unavailable = isDeviceOfflineError(err);
+      if (unavailable) {
+        deps.onDeviceUnavailable?.(deviceId);
+      }
+      if (!unavailable && isTransientRemoteError(err)) transientFailures += 1;
+      return unavailable ? 'unavailable' : 'continue';
     }
   };
 
   for (const plan of plans) {
-    if (plan.openLink) {
-      await track(deps.openLink(plan.deviceId));
+    if (
+      plan.openLink
+      && await track(plan.deviceId, deps.openLink(plan.deviceId)) === 'unavailable'
+    ) {
+      continue;
     }
 
     if (plan.topics.length === 0) continue;
-    await track(deps.subscribe(plan.deviceId, plan.topics));
+    if (
+      await track(plan.deviceId, deps.subscribe(plan.deviceId, plan.topics))
+      === 'unavailable'
+    ) {
+      continue;
+    }
 
     for (const topic of plan.topics) {
       if (topic === 'sessions') {
@@ -66,13 +84,24 @@ export async function rehydrateDeviceLinkTopics(
       if (sessionId) {
         // 每个 session snapshot 自身包含四路 Promise.allSettled fan-out;只把
         // 同一批真正并发的请求合并,不要把多个串行 session 的超时压成一次观测。
-        await track(deps.rebuildSessionSnapshot(plan.deviceId, sessionId, {
+        if (await track(plan.deviceId, deps.rebuildSessionSnapshot(plan.deviceId, sessionId, {
           responsivenessCohort: deps.createDeviceSendCohort(plan.deviceId),
-        }));
+        })) === 'unavailable') {
+          break;
+        }
       }
     }
   }
   return { transientFailures };
+}
+
+function isDeviceOfflineError(error: unknown): boolean {
+  if (typeof error === 'string') return error.includes('DEVICE_OFFLINE');
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  if (code === 'DEVICE_OFFLINE') return true;
+  const message = error instanceof Error ? error.message : '';
+  return message.includes('DEVICE_OFFLINE');
 }
 
 function readSessionTopic(topic: Topic): string | null {

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -78,6 +78,7 @@ export async function rehydrateDeviceLinkTopics(
       const offlineVerdict = isDeviceOfflineError(err);
       const remoteDisabledVerdict = isRemoteDisabledError(err);
       const availabilityVerdict = offlineVerdict || remoteDisabledVerdict;
+      const staleAvailabilityVerdict = availabilityVerdict && !epochCurrent;
       const supersededByConcurrentResponse = epochCurrent
         && availabilityVerdict
         && !deps.isResponseEvidenceEpochCurrent(
@@ -96,7 +97,11 @@ export async function rehydrateDeviceLinkTopics(
       }
       if (
         !unavailable
-        && (isTransientRemoteError(err) || supersededByConcurrentResponse)
+        && (
+          isTransientRemoteError(err)
+          || staleAvailabilityVerdict
+          || supersededByConcurrentResponse
+        )
       ) {
         transientFailures += 1;
       }

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -3,18 +3,14 @@ import type { RehydratePlan } from '@/device-link/topicRegistry';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 
 export interface DeviceLinkRehydrateSendOptions {
-  /** 同一设备的一轮补齐共享一个响应性观测 cohort。 */
+  /** 同一设备的一轮快照 fan-out 共享一个响应性观测 cohort。 */
   responsivenessCohort?: number;
 }
 
 export interface DeviceLinkRehydrateDeps {
   createDeviceSendCohort(deviceId: string): number;
-  openLink(deviceId: string, opts?: DeviceLinkRehydrateSendOptions): Promise<unknown>;
-  subscribe(
-    deviceId: string,
-    topics: readonly Topic[],
-    opts?: DeviceLinkRehydrateSendOptions,
-  ): Promise<unknown>;
+  openLink(deviceId: string): Promise<unknown>;
+  subscribe(deviceId: string, topics: readonly Topic[]): Promise<unknown>;
   requestSessionsReseed(deviceId: string): void;
   rebuildSessionSnapshot(
     deviceId: string,
@@ -54,15 +50,12 @@ export async function rehydrateDeviceLinkTopics(
   };
 
   for (const plan of plans) {
-    const sendOpts: DeviceLinkRehydrateSendOptions = {
-      responsivenessCohort: deps.createDeviceSendCohort(plan.deviceId),
-    };
     if (plan.openLink) {
-      await track(deps.openLink(plan.deviceId, sendOpts));
+      await track(deps.openLink(plan.deviceId));
     }
 
     if (plan.topics.length === 0) continue;
-    await track(deps.subscribe(plan.deviceId, plan.topics, sendOpts));
+    await track(deps.subscribe(plan.deviceId, plan.topics));
 
     for (const topic of plan.topics) {
       if (topic === 'sessions') {
@@ -71,7 +64,11 @@ export async function rehydrateDeviceLinkTopics(
       }
       const sessionId = readSessionTopic(topic);
       if (sessionId) {
-        await track(deps.rebuildSessionSnapshot(plan.deviceId, sessionId, sendOpts));
+        // 每个 session snapshot 自身包含四路 Promise.allSettled fan-out;只把
+        // 同一批真正并发的请求合并,不要把多个串行 session 的超时压成一次观测。
+        await track(deps.rebuildSessionSnapshot(plan.deviceId, sessionId, {
+          responsivenessCohort: deps.createDeviceSendCohort(plan.deviceId),
+        }));
       }
     }
   }

--- a/apps/mobile/src/device-link/rehydrate.ts
+++ b/apps/mobile/src/device-link/rehydrate.ts
@@ -19,6 +19,7 @@ export interface DeviceLinkRehydrateDeps {
   openLink(deviceId: string): PresenceTrackedRehydrateStep;
   subscribe(deviceId: string, topics: readonly Topic[]): Promise<unknown>;
   requestSessionsReseed(deviceId: string): void;
+  onDeviceReachable?(deviceId: string): void;
   onDeviceUnavailable?(deviceId: string): void;
   rebuildSessionSnapshot(
     deviceId: string,
@@ -56,6 +57,9 @@ export async function rehydrateDeviceLinkTopics(
   ): Promise<'continue' | 'unavailable'> => {
     try {
       await step;
+      if (deps.isPresenceEpochCurrent(deviceId, capturedPresenceEpoch)) {
+        deps.onDeviceReachable?.(deviceId);
+      }
       return 'continue';
     } catch (err) {
       const offlineVerdict = isDeviceOfflineError(err);

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -114,8 +114,12 @@ export function buildDeviceResponsivenessProbeArgs(): unknown[] {
  * (含探测标记与设备代数)必须原样回传给 settleDeviceSend——代数不匹配的
  * 旧请求结果会被忽略(review P1:恢复前派出的长超时请求不再污染新一代计数)。
  */
-export function acquireDeviceSendSlot(deviceId: string): BreakerSendSlot {
-  const slot = breaker.acquire(deviceId);
+export function createDeviceSendCohort(deviceId: string): number {
+  return breaker.createCohort(deviceId);
+}
+
+export function acquireDeviceSendSlot(deviceId: string, cohort?: number): BreakerSendSlot {
+  const slot = breaker.acquire(deviceId, cohort);
   if (slot.decision === 'reject') throw createDeviceUnresponsiveError(deviceId);
   return slot;
 }
@@ -135,8 +139,9 @@ export function settleDeviceSend(
 }
 
 /**
- * 清除单个设备的熔断状态与 UI 镜像。撤权时调用:设备的「响应性」已无意义,
- * 且撤权有自己的专属 UI,不应再叠加「电脑端未响应」降级态。
+ * 清除单个设备的熔断状态与 UI 镜像。撤权或权威 presence 不可用时调用:
+ * 设备的「响应性」已无意义,且对应状态有自己的专属 UI,不应再叠加
+ * 「电脑端未响应」降级态。clear 会翻代,此前在途请求的晚到超时不再重建计数。
  */
 export function clearDeviceResponsivenessTrackingFor(deviceId: string): void {
   breaker.clear(deviceId);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Mobile 在 Device Link 链路短暂抖动时过早显示“电脑端未响应”的误判。

会话重连补齐会并发读取消息、待处理交互、输入投影和 goal 状态。此前这四个请求若因同一次路由中断同时超时，会各自贡献一次熔断失败，单轮 fan-out 就能超过 3 次阈值。现在由调用方为这一轮明确 fan-out 分配共享 timeout cohort，同批超时只记一次；普通独立请求仍各自计数，不削弱持续无响应检测。

同时，Relay 的权威 presence 已明确设备离线或关闭远控时，清除并代际失效此前的响应性证据，并从 rehydrate/half-open probe 中过滤该设备，避免继续重放注定失败的 openLink、订阅和快照请求。设备重新可用后，既有 presence recovery 路径会重新补齐。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：跟进 #716、#728 的 Mobile 响应性熔断与恢复机制
- 本 PR 包含：Mobile 端显式超时 cohort、presence unavailable 清理/过滤、相应回归测试
- 明确不包含：Relay、Device Link 协议、Desktop dispatch/IPC、服务端、UI 文案、通用 Desktop handler 超时
- 用户可见变化：短暂断线或同一轮并发请求共同超时时，不再过早显示“电脑端未响应”；明确离线时不再持续制造请求重放
- 是否存在 breaking change：无

### UI 变化

不涉及：没有修改组件、布局、视觉样式或文案；仅修正现有连接状态的触发条件与恢复流量。

- 引用的设计规范：不涉及视觉或交互设计变更

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/deviceResponsivenessBreaker.test.ts src/__tests__/presenceRecovery.test.ts
结果：2 files / 26 tests passed

pnpm --filter mobile typecheck
结果：passed

pnpm --filter mobile test:scope
结果：mobile-scope-guard passed

pnpm --filter mobile test:smoke
结果：2 files / 2 tests passed

pnpm --filter mobile test
结果：259 files / 2534 tests passed

TZ=UTC pnpm test:unit
结果：所有必需 workspace unit tiers passed（包括 apps/desktop、apps/mobile、packages/device-link 等）

git diff --check
结果：passed
```

### 手工验证

不涉及：本改动是 Mobile Device Link 状态机与请求分组逻辑，已由纯逻辑回归测试、Mobile 全量单测、remote-flow smoke 和仓库根级单元门禁覆盖；未启动真机/Metro。

### 未执行的验证

- 未执行原生 Maestro E2E：没有修改原生代码、fingerprint 输入、UI 或导航；本 PR 不触发冷更边界。
- 未执行真机弱网复现：生产日志用于定位事故链，本地回归通过确定性状态机测试覆盖同批并发超时、独立超时累计、presence 离线清理和恢复过滤。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Mobile Device Link 恢复与熔断判定

### 影响与回滚

- 影响范围：仅 Mobile 控制端本地的 per-device 响应性计数与 rehydrate 选择；协议帧、Desktop 行为及数据格式不变。
- 回滚 / 降级方式：回滚本提交即可恢复原有逐请求计数与 rehydrate 行为；无数据迁移或持久化格式变化。
- Remote / Mobile 适配：首次尚未收到 presence 的设备继续采用既有乐观请求，只有 Relay 明确给出 unavailable 才过滤；恢复为 available 时仍由既有 recovery 路径触发补齐。多设备状态按 deviceId 隔离。
- Fingerprint / OTA：没有修改 `app.json`、Expo/native 配置、依赖锁文件或 `ios`/`android`/native modules，不改变 Mobile runtime fingerprint。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需独立文档变更，行为与边界在代码注释和测试中固化）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
