### PR TITLE
test(workspaces): unit tier 改用 threads 池,消掉打挂 launchservicesd 的进程 churn

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
@@ -15,6 +15,7 @@ import {
   startGhostOauthFlow,
   type GhostOauthBrokerClient,
   type GhostOauthClientConfig,
+  type GhostOauthFlowResult,
 } from '../ghostOauthFlow.js';
 
 const BASE_CONFIG: GhostOauthClientConfig = {
@@ -44,7 +45,7 @@ function browserRedirect(authorizeUrl: string, params: (u: URL) => Record<string
   });
 }
 
-/** 探一个当前空闲的 loopback 端口(探测与后续使用之间有极小竞态,可接受)。 */
+/** 探一个当前空闲的 loopback 端口。它只保证"探测那一刻"空闲,见 pinnedPortCase。 */
 async function probeFreePort(): Promise<number> {
   const probe = http.createServer();
   const port = await new Promise<number>((resolve) => {
@@ -55,6 +56,35 @@ async function probeFreePort(): Promise<number> {
   });
   await new Promise((r) => probe.close(r));
   return port;
+}
+
+/**
+ * 钉死端口(redirectPort)的用例统一走这里。probeFreePort 关掉探测 socket 之后,
+ * 端口在引擎真正 listen 之前可能被并发用例抢走 —— threads 池下同一进程里跑着
+ * 多个测试文件,这个窗口不再可以忽略。引擎把"钉死端口绑不上"精确报成
+ * LISTEN_FAILED,所以只在命中该错误时换端口重跑整段;其它任何失败都原样返回给
+ * 断言,不会把真实回归重试掉。body 返回本轮需要判定的全部结果。
+ */
+async function pinnedPortCase<T extends readonly unknown[]>(
+  body: (port: number) => Promise<T>,
+  attempts = 5,
+): Promise<T> {
+  let last!: T;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    last = await body(await probeFreePort());
+    if (!last.some(isListenFailed)) return last;
+  }
+  return last;
+}
+
+/** 只认引擎明确报出的 LISTEN_FAILED;形状不符的值一律不算"端口被抢"。 */
+function isListenFailed(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { ok?: unknown }).ok === false &&
+    (value as { error?: unknown }).error === 'LISTEN_FAILED'
+  );
 }
 
 describe('startGhostOauthFlow', () => {
@@ -306,25 +336,17 @@ describe('startGhostOauthFlow', () => {
   });
 
   it('redirectPort:回调钉死声明端口(Atlassian 精确匹配场景)', async () => {
-    // 先探一个空闲端口再钉给引擎(端口探测与 listen 之间有极小竞态,可接受)。
-    const probe = http.createServer();
-    const freePort = await new Promise<number>((resolve) => {
-      probe.listen(0, '127.0.0.1', () => {
-        const addr = probe.address();
-        resolve(typeof addr === 'object' && addr ? addr.port : 0);
-      });
-    });
-    await new Promise((r) => probe.close(r));
-
-    const result = await startGhostOauthFlow({
-      config: { ...BASE_CONFIG, pkce: false, redirectPort: freePort },
-      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-fixed' })) as unknown as typeof fetch,
-      openExternal: (url) => {
-        const u = new URL(url);
-        expect(u.searchParams.get('redirect_uri')).toBe(`http://127.0.0.1:${freePort}/callback`);
-        browserRedirect(url, (au) => ({ code: 'c-fixed', state: au.searchParams.get('state') ?? '' }));
-      },
-    });
+    const [result] = await pinnedPortCase(async (freePort) => [
+      await startGhostOauthFlow({
+        config: { ...BASE_CONFIG, pkce: false, redirectPort: freePort },
+        fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-fixed' })) as unknown as typeof fetch,
+        openExternal: (url) => {
+          const u = new URL(url);
+          expect(u.searchParams.get('redirect_uri')).toBe(`http://127.0.0.1:${freePort}/callback`);
+          browserRedirect(url, (au) => ({ code: 'c-fixed', state: au.searchParams.get('state') ?? '' }));
+        },
+      }),
+    ]);
     expect(result).toMatchObject({ ok: true });
   });
 
@@ -352,54 +374,60 @@ describe('startGhostOauthFlow', () => {
   });
 
   it('钉死端口:第二单顶掉第一单后立刻复用同一端口(自家僵尸监听自愈,无需回收器)', async () => {
-    const fixedPort = await probeFreePort();
-    let secondDone: Promise<unknown> = Promise.resolve();
-    const first = startGhostOauthFlow({
-      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-      fetchImpl: vi.fn() as unknown as typeof fetch,
-      openExternal: () => {
-        // 第一单占着钉死端口等回调时,第二单同端口进场——必须等到第一单的
-        // 监听真正关闭后成功 listen,而不是 LISTEN_FAILED。
-        secondDone = startGhostOauthFlow({
-          config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-heal' })) as unknown as typeof fetch,
-          openExternal: (url2) => {
-            browserRedirect(url2, (au) => ({ code: 'c-heal', state: au.searchParams.get('state') ?? '' }));
-          },
-        });
-      },
+    const [firstResult, secondResult] = await pinnedPortCase(async (fixedPort) => {
+      let secondDone: Promise<unknown> = Promise.resolve();
+      const first = await startGhostOauthFlow({
+        config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+        fetchImpl: vi.fn() as unknown as typeof fetch,
+        openExternal: () => {
+          // 第一单占着钉死端口等回调时,第二单同端口进场——必须等到第一单的
+          // 监听真正关闭后成功 listen,而不是 LISTEN_FAILED。
+          secondDone = startGhostOauthFlow({
+            config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+            fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-heal' })) as unknown as typeof fetch,
+            openExternal: (url2) => {
+              browserRedirect(url2, (au) => ({ code: 'c-heal', state: au.searchParams.get('state') ?? '' }));
+            },
+          });
+        },
+      });
+      return [first, await secondDone];
     });
-    await expect(first).resolves.toMatchObject({ ok: false, error: 'CANCELLED' });
-    await expect(secondDone).resolves.toMatchObject({ ok: true });
+    expect(firstResult).toMatchObject({ ok: false, error: 'CANCELLED' });
+    expect(secondResult).toMatchObject({ ok: true });
   });
 
   it('钉死端口:第二单还在排队时第三单进场——前两单 CANCELLED,最后一单赢', async () => {
-    const fixedPort = await probeFreePort();
-    let secondDone: Promise<unknown> = Promise.resolve();
-    let thirdDone: Promise<unknown> = Promise.resolve();
     const neverOpen = vi.fn();
-    const first = startGhostOauthFlow({
-      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-      fetchImpl: vi.fn() as unknown as typeof fetch,
-      openExternal: () => {
-        // 第二单进场(排队等第一单收尾),紧接着第三单进场顶掉排队中的第二单。
-        secondDone = startGhostOauthFlow({
+    const [firstResult, secondResult, thirdResult] = await pinnedPortCase(
+      async (fixedPort) => {
+        let secondDone: Promise<unknown> = Promise.resolve();
+        let thirdDone: Promise<unknown> = Promise.resolve();
+        const first = await startGhostOauthFlow({
           config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
           fetchImpl: vi.fn() as unknown as typeof fetch,
-          openExternal: neverOpen,
-        });
-        thirdDone = startGhostOauthFlow({
-          config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-third' })) as unknown as typeof fetch,
-          openExternal: (url3) => {
-            browserRedirect(url3, (au) => ({ code: 'c-third', state: au.searchParams.get('state') ?? '' }));
+          openExternal: () => {
+            // 第二单进场(排队等第一单收尾),紧接着第三单进场顶掉排队中的第二单。
+            secondDone = startGhostOauthFlow({
+              config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+              fetchImpl: vi.fn() as unknown as typeof fetch,
+              openExternal: neverOpen,
+            });
+            thirdDone = startGhostOauthFlow({
+              config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+              fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-third' })) as unknown as typeof fetch,
+              openExternal: (url3) => {
+                browserRedirect(url3, (au) => ({ code: 'c-third', state: au.searchParams.get('state') ?? '' }));
+              },
+            });
           },
         });
+        return [first, await secondDone, await thirdDone];
       },
-    });
-    await expect(first).resolves.toMatchObject({ ok: false, error: 'CANCELLED' });
-    await expect(secondDone).resolves.toMatchObject({ ok: false, error: 'CANCELLED' });
-    await expect(thirdDone).resolves.toMatchObject({ ok: true });
+    );
+    expect(firstResult).toMatchObject({ ok: false, error: 'CANCELLED' });
+    expect(secondResult).toMatchObject({ ok: false, error: 'CANCELLED' });
+    expect(thirdResult).toMatchObject({ ok: true });
     // 排队期即被顶掉的单不该拉起浏览器(不弹无主授权页)。
     expect(neverOpen).not.toHaveBeenCalled();
   });
@@ -560,38 +588,44 @@ describe('startGhostOauthFlow', () => {
   });
 
   it('publicRedirectUri:authorize URL 与 broker exchange 都用公网弹跳地址,本地监听仍在 loopback', async () => {
-    const fixedPort = await probeFreePort();
     const PUBLIC_URI = 'https://broker.example.com/jira/bounce';
-    let capturedRedirectParam: string | null = null;
-    const broker: GhostOauthBrokerClient = {
-      exchange: vi.fn(async (slug: string, params: { code: string; redirectUri: string }) => {
-        expect(slug).toBe('jira');
-        expect(params.code).toBe('c-pub');
-        // 双地址模型:code 交换带的 redirect_uri 必须与 authorize 时一致 = 公网弹跳地址。
-        expect(params.redirectUri).toBe(PUBLIC_URI);
-        return {
-          ok: true as const,
-          bundle: { accessToken: 'at-pub', refreshToken: 'rt-pub', expiresAt: Date.now() + 1000, grantedScope: null },
+    const [result, broker, capturedRedirectParam] = await pinnedPortCase(
+      async (
+        fixedPort,
+      ): Promise<[GhostOauthFlowResult, GhostOauthBrokerClient, string | null]> => {
+        let captured: string | null = null;
+        const brokerClient: GhostOauthBrokerClient = {
+          exchange: vi.fn(async (slug: string, params: { code: string; redirectUri: string }) => {
+            expect(slug).toBe('jira');
+            expect(params.code).toBe('c-pub');
+            // 双地址模型:code 交换带的 redirect_uri 必须与 authorize 时一致 = 公网弹跳地址。
+            expect(params.redirectUri).toBe(PUBLIC_URI);
+            return {
+              ok: true as const,
+              bundle: { accessToken: 'at-pub', refreshToken: 'rt-pub', expiresAt: Date.now() + 1000, grantedScope: null },
+            };
+          }),
+          refresh: vi.fn(),
         };
-      }),
-      refresh: vi.fn(),
-    };
-    const result = await startGhostOauthFlow({
-      config: { ...BASE_CONFIG, tokenBroker: 'jira', redirectPort: fixedPort, publicRedirectUri: PUBLIC_URI },
-      fetchImpl: vi.fn() as unknown as typeof fetch,
-      broker,
-      openExternal: (url) => {
-        capturedRedirectParam = new URL(url).searchParams.get('redirect_uri');
-        // 假浏览器模拟弹跳路由的 302:公网地址打不通,直接回打本机 loopback
-        // 缺省 /callback(未声明 callbackPath 时监听路径不变)。
-        const cb = new URL(`http://127.0.0.1:${fixedPort}/callback`);
-        cb.searchParams.set('code', 'c-pub');
-        cb.searchParams.set('state', new URL(url).searchParams.get('state') ?? '');
-        setImmediate(() => {
-          void fetch(cb.toString()).catch(() => undefined);
+        const flowResult = await startGhostOauthFlow({
+          config: { ...BASE_CONFIG, tokenBroker: 'jira', redirectPort: fixedPort, publicRedirectUri: PUBLIC_URI },
+          fetchImpl: vi.fn() as unknown as typeof fetch,
+          broker: brokerClient,
+          openExternal: (url) => {
+            captured = new URL(url).searchParams.get('redirect_uri');
+            // 假浏览器模拟弹跳路由的 302:公网地址打不通,直接回打本机 loopback
+            // 缺省 /callback(未声明 callbackPath 时监听路径不变)。
+            const cb = new URL(`http://127.0.0.1:${fixedPort}/callback`);
+            cb.searchParams.set('code', 'c-pub');
+            cb.searchParams.set('state', new URL(url).searchParams.get('state') ?? '');
+            setImmediate(() => {
+              void fetch(cb.toString()).catch(() => undefined);
+            });
+          },
         });
+        return [flowResult, brokerClient, captured];
       },
-    });
+    );
     expect(result).toMatchObject({ ok: true });
     if (result.ok) expect(result.bundle.accessToken).toBe('at-pub');
     // 报给服务商的 redirect_uri 是公网弹跳地址,而不是 loopback。

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
@@ -62,8 +62,13 @@ async function probeFreePort(): Promise<number> {
  * 钉死端口(redirectPort)的用例统一走这里。probeFreePort 关掉探测 socket 之后,
  * 端口在引擎真正 listen 之前可能被并发用例抢走 —— threads 池下同一进程里跑着
  * 多个测试文件,这个窗口不再可以忽略。引擎把"钉死端口绑不上"精确报成
- * LISTEN_FAILED,所以只在命中该错误时换端口重跑整段;其它任何失败都原样返回给
- * 断言,不会把真实回归重试掉。body 返回本轮需要判定的全部结果。
+ * LISTEN_FAILED,所以只在命中该错误时换端口重跑整段。
+ *
+ * 判据只看 body 返回的**第一单**:第一单 LISTEN_FAILED 说明这一轮连初始 bind 都
+ * 没抢到端口,换端口重来是对的。而后续单子的 LISTEN_FAILED 恰恰相反 —— 钉死端口
+ * 的交接/自愈(第二单顶掉第一单后立刻复用同一端口)本身就是被测行为,它报
+ * LISTEN_FAILED 就是回归,必须原样交给断言。若也一并重试,换个端口跑一次碰巧成功
+ * 就把回归掩盖掉了。所以 body 的第一个元素必须是"初始 bind 那一单"的结果。
  */
 async function pinnedPortCase<T extends readonly unknown[]>(
   body: (port: number) => Promise<T>,
@@ -72,7 +77,7 @@ async function pinnedPortCase<T extends readonly unknown[]>(
   let last!: T;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     last = await body(await probeFreePort());
-    if (!last.some(isListenFailed)) return last;
+    if (!isListenFailed(last[0])) return last;
   }
   return last;
 }
@@ -634,64 +639,75 @@ describe('startGhostOauthFlow', () => {
   });
 
   it('callbackPath 非默认:声明路径收回调成功,缺省 /callback 404', async () => {
-    const fixedPort = await probeFreePort();
-    let defaultPathStatus = 0;
-    const result = await startGhostOauthFlow({
-      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort, callbackPath: '/slack-mcp/callback' },
-      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-cbp' })) as unknown as typeof fetch,
-      openExternal: (url) => {
-        const u = new URL(url);
-        // 单地址模型下 redirect_uri 直接带声明的 callbackPath。
-        expect(u.searchParams.get('redirect_uri')).toBe(`http://127.0.0.1:${fixedPort}/slack-mcp/callback`);
-        const state = u.searchParams.get('state') ?? '';
-        setImmediate(() => {
-          void (async () => {
-            // 先打缺省 /callback:非声明路径 404,不结算本单。
-            const res404 = await fetch(`http://127.0.0.1:${fixedPort}/callback?code=x&state=${state}`);
-            defaultPathStatus = res404.status;
-            await fetch(`http://127.0.0.1:${fixedPort}/slack-mcp/callback?code=c-cbp&state=${state}`);
-          })().catch(() => undefined);
+    const [result, defaultPathStatus] = await pinnedPortCase(
+      async (fixedPort): Promise<[GhostOauthFlowResult, number]> => {
+        let status = 0;
+        const flow = await startGhostOauthFlow({
+          config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort, callbackPath: '/slack-mcp/callback' },
+          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-cbp' })) as unknown as typeof fetch,
+          openExternal: (url) => {
+            const u = new URL(url);
+            // 单地址模型下 redirect_uri 直接带声明的 callbackPath。
+            expect(u.searchParams.get('redirect_uri')).toBe(`http://127.0.0.1:${fixedPort}/slack-mcp/callback`);
+            const state = u.searchParams.get('state') ?? '';
+            setImmediate(() => {
+              void (async () => {
+                // 先打缺省 /callback:非声明路径 404,不结算本单。
+                const res404 = await fetch(`http://127.0.0.1:${fixedPort}/callback?code=x&state=${state}`);
+                status = res404.status;
+                await fetch(`http://127.0.0.1:${fixedPort}/slack-mcp/callback?code=c-cbp&state=${state}`);
+              })().catch(() => undefined);
+            });
+          },
         });
+        return [flow, status];
       },
-    });
+    );
     expect(result).toMatchObject({ ok: true });
     expect(defaultPathStatus).toBe(404);
   });
 
   it('跨源 code 投递(#810):声明域的 OPTIONS 预检拿到 CORS/PNA 头,GET 投递带头成功;非法来源拿不到头;无 Origin 的 302 回调不变', async () => {
-    const fixedPort = await probeFreePort();
-    let browserWork: Promise<{
+    type CorsProbes = {
       preflightAllowed: Response;
       preflightEvil: Response;
       delivery: Response;
-    }> | null = null;
-    const result = await startGhostOauthFlow({
-      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-cors' })) as unknown as typeof fetch,
-      openExternal: (url) => {
-        const state = new URL(url).searchParams.get('state') ?? '';
-        const cb = `http://127.0.0.1:${fixedPort}/callback`;
-        browserWork = (async () => {
-          // 声明域(authorizeUrl 的 origin)发预检:必须拿到 CORS + PNA 头。
-          const preflightAllowed = await fetch(cb, {
-            method: 'OPTIONS',
-            headers: { origin: 'https://auth.example.com' },
-          });
-          // 任意其它网站发预检:204 但不带 CORS 头(浏览器会拦下后续请求)。
-          const preflightEvil = await fetch(cb, {
-            method: 'OPTIONS',
-            headers: { origin: 'https://evil.example' },
-          });
-          // 声明域的页面 JS 跨源 GET 投递 code(xAI 新版流程形态)。
-          const delivery = await fetch(`${cb}?code=c-cors&state=${state}`, {
-            headers: { origin: 'https://auth.example.com' },
-          });
-          return { preflightAllowed, preflightEvil, delivery };
-        })();
+    };
+    const [result, probes] = await pinnedPortCase(
+      async (fixedPort): Promise<[GhostOauthFlowResult, CorsProbes]> => {
+        let browserWork: Promise<CorsProbes> | null = null;
+        const flow = await startGhostOauthFlow({
+          config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-cors' })) as unknown as typeof fetch,
+          openExternal: (url) => {
+            const state = new URL(url).searchParams.get('state') ?? '';
+            const cb = `http://127.0.0.1:${fixedPort}/callback`;
+            browserWork = (async () => {
+              // 声明域(authorizeUrl 的 origin)发预检:必须拿到 CORS + PNA 头。
+              const preflightAllowed = await fetch(cb, {
+                method: 'OPTIONS',
+                headers: { origin: 'https://auth.example.com' },
+              });
+              // 任意其它网站发预检:204 但不带 CORS 头(浏览器会拦下后续请求)。
+              const preflightEvil = await fetch(cb, {
+                method: 'OPTIONS',
+                headers: { origin: 'https://evil.example' },
+              });
+              // 声明域的页面 JS 跨源 GET 投递 code(xAI 新版流程形态)。
+              const delivery = await fetch(`${cb}?code=c-cors&state=${state}`, {
+                headers: { origin: 'https://auth.example.com' },
+              });
+              return { preflightAllowed, preflightEvil, delivery };
+            })();
+          },
+        });
+        // 初始 bind 就没抢到端口时 openExternal 不会被调用,browserWork 仍为 null;
+        // 这一轮的结果会被 pinnedPortCase 丢弃重跑,占位对象不会进入断言。
+        return [flow, (await browserWork) ?? ({} as CorsProbes)];
       },
-    });
+    );
     expect(result).toMatchObject({ ok: true });
-    const { preflightAllowed, preflightEvil, delivery } = await browserWork!;
+    const { preflightAllowed, preflightEvil, delivery } = probes;
 
     expect(preflightAllowed!.status).toBe(204);
     expect(preflightAllowed!.headers.get('access-control-allow-origin')).toBe(
@@ -709,39 +725,45 @@ describe('startGhostOauthFlow', () => {
   });
 
   it('consent 页与授权端点不同域:hosts 白名单命中的 https origin 也允许投递(#841 review)', async () => {
-    const fixedPort = await probeFreePort();
-    let preflightConsent: Response | null = null;
-    let preflightOther: Response | null = null;
-    const result = await startGhostOauthFlow({
-      config: {
-        ...BASE_CONFIG,
-        pkce: false,
-        redirectPort: fixedPort,
-        // xAI 形态:authorizeUrl 在 auth 域,实际投递来自 hosts 白名单里的 accounts 域。
-        corsDeliveryHosts: ['accounts.example.org', '*.wild.example.org'],
-      },
-      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-hosts' })) as unknown as typeof fetch,
-      openExternal: (url) => {
-        const state = new URL(url).searchParams.get('state') ?? '';
-        const cb = `http://127.0.0.1:${fixedPort}/callback`;
-        setImmediate(() => {
-          void (async () => {
-            preflightConsent = await fetch(cb, {
-              method: 'OPTIONS',
-              headers: { origin: 'https://accounts.example.org' },
+    const [result, preflightConsent, preflightOther] = await pinnedPortCase(
+      async (
+        fixedPort,
+      ): Promise<[GhostOauthFlowResult, Response | null, Response | null]> => {
+        let consent: Response | null = null;
+        let other: Response | null = null;
+        const flow = await startGhostOauthFlow({
+          config: {
+            ...BASE_CONFIG,
+            pkce: false,
+            redirectPort: fixedPort,
+            // xAI 形态:authorizeUrl 在 auth 域,实际投递来自 hosts 白名单里的 accounts 域。
+            corsDeliveryHosts: ['accounts.example.org', '*.wild.example.org'],
+          },
+          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-hosts' })) as unknown as typeof fetch,
+          openExternal: (url) => {
+            const state = new URL(url).searchParams.get('state') ?? '';
+            const cb = `http://127.0.0.1:${fixedPort}/callback`;
+            setImmediate(() => {
+              void (async () => {
+                consent = await fetch(cb, {
+                  method: 'OPTIONS',
+                  headers: { origin: 'https://accounts.example.org' },
+                });
+                // hosts 白名单没有的域拿不到 CORS 头;http 形态的白名单域同样不放行。
+                other = await fetch(cb, {
+                  method: 'OPTIONS',
+                  headers: { origin: 'http://accounts.example.org' },
+                });
+                await fetch(`${cb}?code=c-hosts&state=${state}`, {
+                  headers: { origin: 'https://sub.wild.example.org' },
+                });
+              })().catch(() => undefined);
             });
-            // hosts 白名单没有的域拿不到 CORS 头;http 形态的白名单域同样不放行。
-            preflightOther = await fetch(cb, {
-              method: 'OPTIONS',
-              headers: { origin: 'http://accounts.example.org' },
-            });
-            await fetch(`${cb}?code=c-hosts&state=${state}`, {
-              headers: { origin: 'https://sub.wild.example.org' },
-            });
-          })().catch(() => undefined);
+          },
         });
+        return [flow, consent, other];
       },
-    });
+    );
     expect(result).toMatchObject({ ok: true });
     expect(preflightConsent!.headers.get('access-control-allow-origin')).toBe(
       'https://accounts.example.org',
@@ -751,26 +773,30 @@ describe('startGhostOauthFlow', () => {
   });
 
   it('跨源投递的 state 校验不放松:声明域带错 state 投递 → 400 带 CORS 头且不结算,正确投递仍成功', async () => {
-    const fixedPort = await probeFreePort();
-    let badDelivery: Response | null = null;
-    const result = await startGhostOauthFlow({
-      config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-      fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'x' })) as unknown as typeof fetch,
-      openExternal: (url) => {
-        const state = new URL(url).searchParams.get('state') ?? '';
-        const cb = `http://127.0.0.1:${fixedPort}/callback`;
-        setImmediate(() => {
-          void (async () => {
-            badDelivery = await fetch(`${cb}?code=c-bad&state=WRONG`, {
-              headers: { origin: 'https://auth.example.com' },
+    const [result, badDelivery] = await pinnedPortCase(
+      async (fixedPort): Promise<[GhostOauthFlowResult, Response | null]> => {
+        let bad: Response | null = null;
+        const flow = await startGhostOauthFlow({
+          config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'x' })) as unknown as typeof fetch,
+          openExternal: (url) => {
+            const state = new URL(url).searchParams.get('state') ?? '';
+            const cb = `http://127.0.0.1:${fixedPort}/callback`;
+            setImmediate(() => {
+              void (async () => {
+                bad = await fetch(`${cb}?code=c-bad&state=WRONG`, {
+                  headers: { origin: 'https://auth.example.com' },
+                });
+                await fetch(`${cb}?code=c-ok&state=${state}`, {
+                  headers: { origin: 'https://auth.example.com' },
+                });
+              })().catch(() => undefined);
             });
-            await fetch(`${cb}?code=c-ok&state=${state}`, {
-              headers: { origin: 'https://auth.example.com' },
-            });
-          })().catch(() => undefined);
+          },
         });
+        return [flow, bad];
       },
-    });
+    );
     expect(result).toMatchObject({ ok: true });
     expect(badDelivery!.status).toBe(400);
     expect(badDelivery!.headers.get('access-control-allow-origin')).toBe('https://auth.example.com');

--- a/apps/desktop/src/main/cindy-brain/__tests__/portReclaim.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/portReclaim.test.ts
@@ -11,6 +11,15 @@ import { findPortOwnerPids, killPortOwner, reclaimLoopbackPort } from '../portRe
 /** Windows / macOS 自带查询工具,结果必须精确;其它平台(Linux CI)可能缺 lsof。 */
 const strictPlatform = process.platform === 'win32' || process.platform === 'darwin';
 
+/**
+ * 几条断言的前提是"这个端口号上没有别的 loopback 监听"。但端口号由 OS 从临时
+ * 端口段分配,探测用的 socket 一关,端口在断言之前完全可能被并发用例抢走 ——
+ * threads 池下同一进程里跑着多个测试文件,这个窗口不再可以忽略。被抢走时查出
+ * 候选是正确行为、不是回归,所以换端口重试;连着这么多个互不相同的端口都不干净,
+ * 才说明地址过滤真的坏了。
+ */
+const PORT_ATTEMPTS = 5;
+
 async function listenLoopback(srv: http.Server): Promise<number> {
   return new Promise<number>((resolve) => {
     srv.listen(0, '127.0.0.1', () => {
@@ -37,10 +46,15 @@ describe('portReclaim', () => {
   });
 
   it('findPortOwnerPids:空闲端口返回空数组', async () => {
-    const srv = http.createServer();
-    const port = await listenLoopback(srv);
-    await new Promise((r) => srv.close(r));
-    await expect(findPortOwnerPids(port)).resolves.toEqual([]);
+    for (let attempt = 1; attempt <= PORT_ATTEMPTS; attempt += 1) {
+      const srv = http.createServer();
+      const port = await listenLoopback(srv);
+      await new Promise((r) => srv.close(r));
+      const pids = await findPortOwnerPids(port);
+      if (pids.length === 0) return;
+      // 端口被并发用例抢走了(见 PORT_ATTEMPTS 说明):换一个再试。
+      if (attempt === PORT_ATTEMPTS) expect(pids).toEqual([]);
+    }
   });
 
   it('findPortOwnerPids:只认挡路地址——绑非环回 IP 的监听不列为候选(不误杀)', async () => {
@@ -50,20 +64,24 @@ describe('portReclaim', () => {
       .flat()
       .find((i) => i && i.family === 'IPv4' && !i.internal)?.address;
     if (!lanAddr) return;
-    const srv = http.createServer();
-    const port = await new Promise<number>((resolve, reject) => {
-      srv.on('error', reject);
-      srv.listen(0, lanAddr, () => {
-        const addr = srv.address();
-        resolve(typeof addr === 'object' && addr ? addr.port : 0);
-      });
-    }).catch(() => 0);
-    if (port === 0) return; // 绑 LAN IP 失败(权限/网络形态),跳过
-    try {
-      // 该端口上只有一条绑 LAN IP 的监听:不会挡 127.0.0.1 bind,必须查不出候选。
-      await expect(findPortOwnerPids(port)).resolves.toEqual([]);
-    } finally {
-      await new Promise((r) => srv.close(r));
+    for (let attempt = 1; attempt <= PORT_ATTEMPTS; attempt += 1) {
+      const srv = http.createServer();
+      const port = await new Promise<number>((resolve, reject) => {
+        srv.on('error', reject);
+        srv.listen(0, lanAddr, () => {
+          const addr = srv.address();
+          resolve(typeof addr === 'object' && addr ? addr.port : 0);
+        });
+      }).catch(() => 0);
+      if (port === 0) return; // 绑 LAN IP 失败(权限/网络形态),跳过
+      try {
+        // 该端口上只有一条绑 LAN IP 的监听:不会挡 127.0.0.1 bind,必须查不出候选。
+        const pids = await findPortOwnerPids(port);
+        if (pids.length === 0) return;
+        if (attempt === PORT_ATTEMPTS) expect(pids).toEqual([]);
+      } finally {
+        await new Promise((r) => srv.close(r));
+      }
     }
   });
 
@@ -76,17 +94,23 @@ describe('portReclaim', () => {
   });
 
   it('reclaimLoopbackPort:占用者是本进程时拒绝回收(护栏),端口空闲时放行重试', async () => {
-    const srv = http.createServer();
-    const port = await listenLoopback(srv);
-    try {
-      if (strictPlatform) {
-        // 占用者 = 自己 → killPortOwner 护栏拒杀 → 回收失败。
-        await expect(reclaimLoopbackPort(port)).resolves.toBe(false);
+    for (let attempt = 1; attempt <= PORT_ATTEMPTS; attempt += 1) {
+      const srv = http.createServer();
+      const port = await listenLoopback(srv);
+      try {
+        if (strictPlatform) {
+          // 占用者 = 自己 → killPortOwner 护栏拒杀 → 回收失败。
+          await expect(reclaimLoopbackPort(port)).resolves.toBe(false);
+        }
+      } finally {
+        await new Promise((r) => srv.close(r));
       }
-    } finally {
-      await new Promise((r) => srv.close(r));
+      // 端口已空闲:查无占用者 → 返回 true 让调用方直接重试 listen。
+      if (await reclaimLoopbackPort(port)) return;
+      // 关掉后被并发用例抢走(见 PORT_ATTEMPTS 说明):整对场景换端口重来。
+      if (attempt === PORT_ATTEMPTS) {
+        await expect(reclaimLoopbackPort(port)).resolves.toBe(true);
+      }
     }
-    // 端口已空闲:查无占用者 → 返回 true 让调用方直接重试 listen。
-    await expect(reclaimLoopbackPort(port)).resolves.toBe(true);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/portReclaim.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/portReclaim.test.ts
@@ -106,11 +106,12 @@ describe('portReclaim', () => {
         await new Promise((r) => srv.close(r));
       }
       // 端口已空闲:查无占用者 → 返回 true 让调用方直接重试 listen。
-      if (await reclaimLoopbackPort(port)) return;
+      // 只调一次并对这一次的结果下断言:reclaimLoopbackPort 依赖当次的端口归属,
+      // 重新调用会让断言看到另一个时刻的状态,既可能自己抖动、也会掩盖真正的失败态。
+      const reclaimed = await reclaimLoopbackPort(port);
+      if (reclaimed) return;
       // 关掉后被并发用例抢走(见 PORT_ATTEMPTS 说明):整对场景换端口重来。
-      if (attempt === PORT_ATTEMPTS) {
-        await expect(reclaimLoopbackPort(port)).resolves.toBe(true);
-      }
+      if (attempt === PORT_ATTEMPTS) expect(reclaimed).toBe(true);
     }
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeFastModeLog.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeFastModeLog.test.ts
@@ -160,14 +160,16 @@ describe('createClaudeFastModeResponseObserver (结尾)', () => {
     const sink = createClaudeFastModeResponseObserver(log)(ctx);
     sink!.onData?.(gzipSync(Buffer.from(`${messageStartFrame('fast')}\n\n`)));
     sink!.onEnd?.();
-    // 解压是流式异步的(zlib 线程池回调):固定两个 tick 在测试并发高、事件循环
-    // 忙时不够会 flaky,改为轮询等 debug 被调用(上限兜底防死等)。
-    for (let i = 0; i < 200 && log.debug.mock.calls.length === 0; i += 1) {
-      await new Promise((r) => setImmediate(r));
-    }
-    expect(log.debug).toHaveBeenCalledWith(
-      'claude fast mode applied (usage.speed observed)',
-      expect.objectContaining({ contentEncoding: 'gzip', responseSpeed: 'fast', appliedFast: true }),
+    // 解压是流式异步的(zlib 回调走 libuv 线程池)。原先用 setImmediate 轮询:它只
+    // 推进 tick、几乎不消耗真实时间,200 个 tick 不到 1ms 就烧完。而 vitest 的
+    // threads 池下多个测试文件共享同一个进程、也就共享同一个默认 4 线程的 libuv
+    // 线程池,回调的墙钟延迟被拉长,tick 预算根本等不到(CI 实测 debug 被调用 0 次)。
+    // 改用 vi.waitFor 按墙钟等,并且等的就是断言本身成立。
+    await vi.waitFor(() =>
+      expect(log.debug).toHaveBeenCalledWith(
+        'claude fast mode applied (usage.speed observed)',
+        expect.objectContaining({ contentEncoding: 'gzip', responseSpeed: 'fast', appliedFast: true }),
+      ),
     );
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
@@ -10,7 +10,7 @@
  *   - 首个终态结果落定后,重试回调不得覆盖 pendingRes / 登录结果。
  */
 
-import { request as httpRequest } from 'node:http';
+import { createServer, request as httpRequest } from 'node:http';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({
@@ -88,6 +88,27 @@ describe('xaiCallbackCorsHeaders', () => {
   });
 });
 
+/**
+ * close() 同步返回,端口却是异步释放的:server.close() 只停止接受新连接,监听
+ * socket 要等真正关闭才交还。而 56121 是 xAI 要求精确匹配的固定端口,换不了,
+ * 于是下一个用例的 beforeEach 会立刻重绑同一个端口 —— 上一个用例还没释放完就是
+ * 「xAI OAuth 回调端口 56121 被占用」。等到真能绑上再往下走,才是确定的。
+ * 上面 send() 里 agent:false 治的是同一个不变量的客户端那一半(死 socket 被复用)。
+ */
+async function waitForPortRelease(): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const released = await new Promise<boolean>((resolve) => {
+      const probe = createServer();
+      probe.once('error', () => resolve(false));
+      // close 的回调在 socket 完全关闭后才触发,所以探测本身不会留下占用。
+      probe.listen(PORT, '127.0.0.1', () => probe.close(() => resolve(true)));
+    });
+    if (released) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`端口 ${PORT} 在 2s 内未被释放`);
+}
+
 describe('CallbackListener(xAI loopback 回调)', () => {
   let listener: CallbackListener;
 
@@ -96,8 +117,9 @@ describe('CallbackListener(xAI loopback 回调)', () => {
     await listener.start();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     listener.close();
+    await waitForPortRelease();
   });
 
   it('OPTIONS preflight 回 204 + CORS/PNA 头,且不终止登录流', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
@@ -23,7 +23,11 @@ vi.mock('electron', () => ({
   safeStorage: { isEncryptionAvailable: vi.fn(() => false) },
 }));
 
-import { CallbackListener, xaiCallbackCorsHeaders } from '../grok-oauth-login.js';
+import {
+  CallbackListener,
+  XAI_CALLBACK_PORT_OCCUPIED_MESSAGE,
+  xaiCallbackCorsHeaders,
+} from '../grok-oauth-login.js';
 
 const PORT = 56121;
 const XAI_ORIGIN = 'https://accounts.x.ai';
@@ -101,6 +105,11 @@ describe('xaiCallbackCorsHeaders', () => {
  * 两者是同一句话,所以只留一个判据:仅在引擎明确报出「端口被占用」时短暂重试,
  * 其它启动失败原样抛出,不掩盖真正的问题。每次重试用全新实例,免得复用一个
  * listen 失败过的 server。同族的客户端那一半由 send() 的 agent:false 处理。
+ *
+ * 判据必须与生产同源:start() 把底层错误包成新 Error、丢掉了 err.code,只剩文本可看,
+ * 而按端口号做子串匹配会连 EACCES / EADDRNOTAVAIL 一起收进来(它们的原文里同样带端口
+ * 号),把真正的启动故障当成「端口被占」白重试 100 次。所以整条比对生产导出的那句
+ * EADDRINUSE 专属提示。
  */
 async function startFreshListener(): Promise<CallbackListener> {
   for (let attempt = 1; ; attempt += 1) {
@@ -110,9 +119,7 @@ async function startFreshListener(): Promise<CallbackListener> {
       return candidate;
     } catch (err) {
       candidate.close();
-      // 引擎把 EADDRINUSE 映射成带端口号的人话提示(见 grok-oauth-login.ts),
-      // 这也是本文件「端口被占用时报可读错误」那条用例依赖的同一个判据。
-      const occupied = err instanceof Error && err.message.includes(String(PORT));
+      const occupied = err instanceof Error && err.message === XAI_CALLBACK_PORT_OCCUPIED_MESSAGE;
       if (!occupied || attempt >= 100) throw err;
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
@@ -353,8 +360,12 @@ describe('CallbackListener(xAI loopback 回调)', () => {
 
   it('回调端口被占用时 start() 报可读错误', async () => {
     const blocker = new CallbackListener();
-    // beforeEach 已占 56121,新实例 start 应失败。
-    await expect(blocker.start()).rejects.toThrow('56121');
+    // beforeEach 已占 56121,新实例 start 应失败。整条比对,不按端口号做子串匹配
+    // ——后者对任何带端口号的 listen 失败都成立(见 startFreshListener 说明)。
+    await expect(blocker.start()).rejects.toThrow(XAI_CALLBACK_PORT_OCCUPIED_MESSAGE);
     blocker.close();
+    // 上面那条是同源比对,改文案不会让它失败;这句守住「用户看得见端口号」这个可读性
+    // 要求本身,顺带交叉校验测试里的 PORT 与生产的 REDIRECT_PORT 没有跑偏。
+    expect(XAI_CALLBACK_PORT_OCCUPIED_MESSAGE).toContain(String(PORT));
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
@@ -10,7 +10,7 @@
  *   - 首个终态结果落定后,重试回调不得覆盖 pendingRes / 登录结果。
  */
 
-import { createServer, request as httpRequest } from 'node:http';
+import { request as httpRequest } from 'node:http';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({
@@ -89,37 +89,45 @@ describe('xaiCallbackCorsHeaders', () => {
 });
 
 /**
- * close() 同步返回,端口却是异步释放的:server.close() 只停止接受新连接,监听
- * socket 要等真正关闭才交还。而 56121 是 xAI 要求精确匹配的固定端口,换不了,
- * 于是下一个用例的 beforeEach 会立刻重绑同一个端口 —— 上一个用例还没释放完就是
- * 「xAI OAuth 回调端口 56121 被占用」。等到真能绑上再往下走,才是确定的。
- * 上面 send() 里 agent:false 治的是同一个不变量的客户端那一半(死 socket 被复用)。
+ * 绑 56121 时它可能短暂被别人占着,有两个来源:
+ *   1. 文件内部:close() 同步返回但端口是异步释放的,上一个用例「调过 close」
+ *      不等于端口已交还,下一个用例立刻重绑就撞上;
+ *   2. 文件外部:56121 落在临时端口段内(macOS 49152–65535 / Linux 32768–60999),
+ *      任何用 listen(0) 拿端口的并发用例都可能被内核分到它。desktop unit tier
+ *      一轮 1330 个文件、threads 池下还共享同一个进程,这不是理论风险 —— CI 上
+ *      两轮分别撞在不同用例的 beforeEach 上。而 xAI 只接受
+ *      http://127.0.0.1:56121/callback,端口换不了。
+ *
+ * 两者是同一句话,所以只留一个判据:仅在引擎明确报出「端口被占用」时短暂重试,
+ * 其它启动失败原样抛出,不掩盖真正的问题。每次重试用全新实例,免得复用一个
+ * listen 失败过的 server。同族的客户端那一半由 send() 的 agent:false 处理。
  */
-async function waitForPortRelease(): Promise<void> {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
-    const released = await new Promise<boolean>((resolve) => {
-      const probe = createServer();
-      probe.once('error', () => resolve(false));
-      // close 的回调在 socket 完全关闭后才触发,所以探测本身不会留下占用。
-      probe.listen(PORT, '127.0.0.1', () => probe.close(() => resolve(true)));
-    });
-    if (released) return;
-    await new Promise((resolve) => setTimeout(resolve, 10));
+async function startFreshListener(): Promise<CallbackListener> {
+  for (let attempt = 1; ; attempt += 1) {
+    const candidate = new CallbackListener();
+    try {
+      await candidate.start();
+      return candidate;
+    } catch (err) {
+      candidate.close();
+      // 引擎把 EADDRINUSE 映射成带端口号的人话提示(见 grok-oauth-login.ts),
+      // 这也是本文件「端口被占用时报可读错误」那条用例依赖的同一个判据。
+      const occupied = err instanceof Error && err.message.includes(String(PORT));
+      if (!occupied || attempt >= 100) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
   }
-  throw new Error(`端口 ${PORT} 在 2s 内未被释放`);
 }
 
 describe('CallbackListener(xAI loopback 回调)', () => {
   let listener: CallbackListener;
 
   beforeEach(async () => {
-    listener = new CallbackListener();
-    await listener.start();
+    listener = await startFreshListener();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     listener.close();
-    await waitForPortRelease();
   });
 
   it('OPTIONS preflight 回 204 + CORS/PNA 头,且不终止登录流', async () => {

--- a/apps/desktop/src/main/maker-host/grok-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/grok-oauth-login.ts
@@ -251,6 +251,15 @@ export function xaiCallbackCorsHeaders(origin: string | undefined): Record<strin
 }
 
 // ── 回调监听(固定端口 56121)────────────────────────────────────────────────────
+/**
+ * EADDRINUSE 专属的用户可读提示。单独导出是为了让「这次失败是不是端口被占」有一个
+ * 与生产同源的判据:start() 把底层错误包成新 Error、丢掉了 err.code,调用方只剩文本
+ * 可看;而 Node 其它 listen 失败的原文里同样带端口号(实测
+ * `listen EADDRNOTAVAIL: address not available 240.0.0.1:56121`),按端口号做子串匹配
+ * 会把 EACCES / EADDRNOTAVAIL 一起误判成端口被占。
+ */
+export const XAI_CALLBACK_PORT_OCCUPIED_MESSAGE = `xAI OAuth 回调端口 ${REDIRECT_PORT} 被占用(可能有其它 Grok 登录在跑),请关掉后重试`;
+
 // 导出仅供单测(runGrokOAuthLogin 是唯一运行期使用方)。
 export class CallbackListener {
   private server: Server;
@@ -279,7 +288,7 @@ export class CallbackListener {
         reject(
           new Error(
             err.code === 'EADDRINUSE'
-              ? `xAI OAuth 回调端口 ${REDIRECT_PORT} 被占用(可能有其它 Grok 登录在跑),请关掉后重试`
+              ? XAI_CALLBACK_PORT_OCCUPIED_MESSAGE
               : `OAuth callback server failed: ${err.message}`,
           ),
         ),

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import path from 'node:path';
 import { desktopClientBuildEnv } from '../../scripts/shared/client-endpoint-build-env.mjs';
+import { nodeWebstorageEnabled } from '../../scripts/shared/node-webstorage.mjs';
 import { parseVitestCliExclude } from './src/test/vitest/cliExclude';
 
 const clientBuildEnv = desktopClientBuildEnv({ allowEnvOverride: false });
@@ -72,12 +73,20 @@ export default defineConfig({
     // --localstorage-file 时方法全缺的残缺对象:node 环境下骗过
     // `typeof localStorage !== 'undefined'` 探测,jsdom 环境下又因 key 已存在
     // 顶掉 jsdom 注入的可用实现(vitest 填充全局时跳过已存在的 key)。统一在
-    // worker 进程关掉该全局(flag 自 Node 22 起有效),恢复两种环境的原语义;
-    // CI(Node 22,webstorage 默认关)上本为 no-op。配置放这里(而非 test 脚本
-    // 注 NODE_OPTIONS)是因为根 test-workspaces runner 走 `exec vitest run`
-    // 直调、不经 package.json 脚本,只有 config 层对所有入口一致生效。
+    // worker 里关掉该全局(flag 自 Node 22 起有效),恢复两种环境的原语义。
+    // 配置放这里(而非 test 脚本注 NODE_OPTIONS)是因为根 test-workspaces runner
+    // 走 `exec vitest run` 直调、不经 package.json 脚本,只有 config 层对所有
+    // 入口一致生效。
+    //
+    // threads 池只在真的需要时才拿这个 execArgv: 给 worker thread 传自定义
+    // execArgv 会让 isolate 销毁时段错误(详见 node-webstorage.mjs 的实测数据),
+    // 而 Node 22(本机与 CI)根本没有 webstorage 全局、flag 纯属空转。两者互斥,
+    // 由 nodeWebstorageEnabled() 二选一:需要 flag 的 Node 上 manifest 会把
+    // unit tier 留在 forks,不需要的 Node 上才切 threads。
     poolOptions: {
-      threads: { execArgv: ['--no-experimental-webstorage'] },
+      ...(nodeWebstorageEnabled()
+        ? { threads: { execArgv: ['--no-experimental-webstorage'] } }
+        : {}),
       forks: { execArgv: ['--no-experimental-webstorage'] },
     },
     // Main-process code is pure Node — no DOM needed. Renderer tests (if/when

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import path from 'node:path';
 import { desktopClientBuildEnv } from '../../scripts/shared/client-endpoint-build-env.mjs';
-import { nodeWebstorageEnabled } from '../../scripts/shared/node-webstorage.mjs';
 import { parseVitestCliExclude } from './src/test/vitest/cliExclude';
 
 const clientBuildEnv = desktopClientBuildEnv({ allowEnvOverride: false });
@@ -78,15 +77,12 @@ export default defineConfig({
     // 走 `exec vitest run` 直调、不经 package.json 脚本,只有 config 层对所有
     // 入口一致生效。
     //
-    // threads 池只在真的需要时才拿这个 execArgv: 给 worker thread 传自定义
-    // execArgv 会让 isolate 销毁时段错误(详见 node-webstorage.mjs 的实测数据),
-    // 而 Node 22(本机与 CI)根本没有 webstorage 全局、flag 纯属空转。两者互斥,
-    // 由 nodeWebstorageEnabled() 二选一:需要 flag 的 Node 上 manifest 会把
-    // unit tier 留在 forks,不需要的 Node 上才切 threads。
+    // 只给 forks 池配这个 execArgv,threads 池一律不配:给 worker thread 传自定义
+    // execArgv 会让 isolate 销毁时段错误(实测数据见 scripts/shared/node-webstorage.mjs),
+    // 所以哪怕有人手动 `--pool=threads` 也不该拿到这份配置。需要这个 flag 的 Node 上,
+    // 根 manifest 会用同一个 nodeWebstorageEnabled() 判据把 unit tier 留在 forks,
+    // 两者不会同时生效;不需要 flag 的 Node(本机与 CI 的 22)上压根没有 webstorage 全局。
     poolOptions: {
-      ...(nodeWebstorageEnabled()
-        ? { threads: { execArgv: ['--no-experimental-webstorage'] } }
-        : {}),
       forks: { execArgv: ['--no-experimental-webstorage'] },
     },
     // Main-process code is pure Node — no DOM needed. Renderer tests (if/when

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import manifest, {
 	desktopUnitWorkerCount,
 } from "../test-workspaces.config.mjs";
+import { nodeWebstorageEnabled } from "../shared/node-webstorage.mjs";
 import {
 	acquireTestGateLock,
 	classifyTestGateLockProbeError,
@@ -151,7 +152,7 @@ test("orca workflow unit tier uses its own declared test runner", () => {
 	assert.deepEqual(orcaWorkspace.tiers.unit.command, {
 		type: "packageBin",
 		bin: "vitest",
-		args: ["run", "--maxWorkers=1"],
+		args: ["run", "--pool=threads", "--maxWorkers=1"],
 	});
 });
 
@@ -168,6 +169,7 @@ test("unit workspace concurrency reserves the full worker budget for heavy works
 	assert.equal(desktop.tiers.unit.execution, "exclusive");
 	assert.deepEqual(desktop.tiers.unit.command.args, [
 		"run",
+		`--pool=${nodeWebstorageEnabled() ? "forks" : "threads"}`,
 		`--maxWorkers=${desktopUnitWorkerCount()}`,
 	]);
 	assert.equal(desktopUnitWorkerCount(1), 1);
@@ -175,13 +177,58 @@ test("unit workspace concurrency reserves the full worker budget for heavy works
 	assert.equal(desktopUnitWorkerCount(32), 8);
 	assert.equal(desktopUnitWorkerCount(Number.NaN), 1);
 	assert.equal(mobile.tiers.unit.execution, "exclusive");
-	assert.deepEqual(mobile.tiers.unit.command.args, ["run", "--maxWorkers=4"]);
+	assert.deepEqual(mobile.tiers.unit.command.args, [
+		"run",
+		"--pool=threads",
+		"--maxWorkers=4",
+	]);
 	assert.equal(makerCore.tiers.unit.execution, undefined);
 	assert.deepEqual(makerCore.tiers.unit.command, {
 		type: "packageBin",
 		bin: "vitest",
-		args: ["run", "--maxWorkers=1"],
+		args: ["run", "--pool=forks", "--maxWorkers=1"],
 	});
+});
+
+test("unit tier pins an explicit vitest pool, forks only by documented exception", () => {
+	// The default forks pool recycles one child process per test file, which on
+	// 2026-07-30 sustained ~21 LaunchServices check-ins/second and took down
+	// macOS 27.0 beta's launchservicesd mid-gate (empty running-application
+	// registry -> no frontmost app -> dead keyboard, no menu bar, vanishing Dock
+	// tiles). A workspace added later must not silently inherit that churn, and
+	// opting back into forks must be a deliberate edit to this list.
+	// Desktop's entry is conditional: it only stays on forks on a Node whose
+	// webstorage globals force the execArgv that worker threads cannot take.
+	const forksByException = [
+		...(nodeWebstorageEnabled() ? ["apps/desktop"] : []),
+		"packages/maker-core",
+	];
+	const unpinned = [];
+	const onForks = [];
+	for (const workspace of manifest.workspaces) {
+		const tier = workspace.tiers?.unit;
+		if (!tier || (tier.status !== "required" && tier.status !== "manual"))
+			continue;
+		if (tier.command?.type !== "packageBin" || tier.command.bin !== "vitest")
+			continue;
+		const args = tier.command.args ?? [];
+		if (args.includes("--pool=forks")) onForks.push(workspace.cwd);
+		else if (!args.includes("--pool=threads")) unpinned.push(workspace.cwd);
+	}
+	assert.deepEqual(unpinned, []);
+	assert.deepEqual(onForks.sort(), [...forksByException].sort());
+});
+
+test("nodeWebstorageEnabled detects the globals that force the webstorage flag", () => {
+	assert.equal(nodeWebstorageEnabled({}), false);
+	assert.equal(nodeWebstorageEnabled({ localStorage: undefined }), false);
+	assert.equal(nodeWebstorageEnabled({ localStorage: {} }), true);
+	// Node 25's stub is an object whose methods are all missing; presence is what
+	// matters here, because that alone displaces jsdom's implementation.
+	assert.equal(
+		nodeWebstorageEnabled({ localStorage: Object.create(null) }),
+		true,
+	);
 });
 
 test("normalizeRelPath makes path matching independent of host path separators", () => {

--- a/scripts/shared/node-webstorage.mjs
+++ b/scripts/shared/node-webstorage.mjs
@@ -1,0 +1,29 @@
+/**
+ * Node 25 installs the WebStorage globals by default, and with no
+ * `--localstorage-file` configured `globalThis.localStorage` is a stub whose
+ * methods are all missing: under the node environment it fools a
+ * `typeof localStorage !== 'undefined'` probe, and under jsdom the pre-existing
+ * key displaces jsdom's working implementation, because Vitest skips populating
+ * globals that already exist. `--no-experimental-webstorage` restores the
+ * original semantics; on Node 22 (local dev and CI) the global never exists, so
+ * the flag is a pure no-op there.
+ *
+ * That distinction decides how apps/desktop runs its unit tests, in two places
+ * which have to agree: its Vitest config (does the worker pool need the flag)
+ * and the root test-workspaces manifest (which pool the unit tier uses). The two
+ * cannot be combined — passing custom execArgv to worker threads segfaults the
+ * isolate during teardown. Measured 2026-07-30: 2 of 10 full desktop unit runs
+ * crashed inside node::worker::WorkerThreadData::~WorkerThreadData -> final GC
+ * -> GlobalHandles::InvokeFirstPassWeakCallbacks, i.e. a native addon finalizer
+ * touching freed memory as the isolate went away; 8 further runs with the
+ * execArgv removed produced none.
+ *
+ * So the flag and the threads pool are mutually exclusive, and this predicate
+ * picks between them: where the flag is genuinely needed, keep today's
+ * behaviour (forks, flag applied); where it is a no-op, drop it and take threads
+ * instead, which spawns no process per test file (see UNIT_POOL_DEFAULT in
+ * scripts/test-workspaces.config.mjs).
+ */
+export function nodeWebstorageEnabled(globalObject = globalThis) {
+  return typeof globalObject.localStorage !== 'undefined';
+}

--- a/scripts/shared/node-webstorage.mjs
+++ b/scripts/shared/node-webstorage.mjs
@@ -8,21 +8,20 @@
  * original semantics; on Node 22 (local dev and CI) the global never exists, so
  * the flag is a pure no-op there.
  *
- * That distinction decides how apps/desktop runs its unit tests, in two places
- * which have to agree: its Vitest config (does the worker pool need the flag)
- * and the root test-workspaces manifest (which pool the unit tier uses). The two
- * cannot be combined — passing custom execArgv to worker threads segfaults the
- * isolate during teardown. Measured 2026-07-30: 2 of 10 full desktop unit runs
- * crashed inside node::worker::WorkerThreadData::~WorkerThreadData -> final GC
- * -> GlobalHandles::InvokeFirstPassWeakCallbacks, i.e. a native addon finalizer
+ * The flag and the threads pool are mutually exclusive: passing custom execArgv
+ * to worker threads segfaults the isolate during teardown. Measured 2026-07-30:
+ * 2 of 10 full desktop unit runs crashed inside
+ * node::worker::WorkerThreadData::~WorkerThreadData -> final GC ->
+ * GlobalHandles::InvokeFirstPassWeakCallbacks, i.e. a native addon finalizer
  * touching freed memory as the isolate went away; 8 further runs with the
- * execArgv removed produced none.
+ * execArgv removed produced none. apps/desktop therefore hands the flag to the
+ * forks pool only, and never to threads.
  *
- * So the flag and the threads pool are mutually exclusive, and this predicate
- * picks between them: where the flag is genuinely needed, keep today's
- * behaviour (forks, flag applied); where it is a no-op, drop it and take threads
- * instead, which spawns no process per test file (see UNIT_POOL_DEFAULT in
- * scripts/test-workspaces.config.mjs).
+ * That leaves the pool choice, which is what this predicate decides (see
+ * UNIT_POOL_DEFAULT in scripts/test-workspaces.config.mjs): where the flag is
+ * genuinely needed, apps/desktop keeps today's behaviour and stays on forks so
+ * the flag still applies; where it is a no-op, the unit tier takes threads
+ * instead, which spawns no process per test file.
  */
 export function nodeWebstorageEnabled(globalObject = globalThis) {
   return typeof globalObject.localStorage !== 'undefined';

--- a/scripts/test-workspaces.config.mjs
+++ b/scripts/test-workspaces.config.mjs
@@ -1,10 +1,38 @@
 import os from 'node:os';
 
+import { nodeWebstorageEnabled } from './shared/node-webstorage.mjs';
+
 const vitestBin = (...args) => ({ type: 'packageBin', bin: 'vitest', args });
+// The unit tier pins the threads pool. Vitest's default `forks` pool keeps
+// `isolate` on and so recycles a child process per test file: this tier's ~1845
+// files cost ~1.9k process spawns per gate run, measured at 21 LaunchServices
+// check-ins/second on an 18-core macOS host. On 2026-07-30 that sustained churn
+// took down macOS 27.0 beta's launchservicesd, which came back with an empty
+// running-application registry — leaving the session with no frontmost app at
+// all: no menu bar, no keyboard input anywhere, Dock tiles vanishing on click,
+// and only a reboot to recover. Worker threads keep the same per-file isolation
+// at zero process cost (same 180 desktop files: 189 check-ins versus 1,
+// identical results, slightly faster).
+//
+// Not everything moves. The heavy manual tiers (db, migration, git-integration)
+// stay on the default pool: they bootstrap runtime assets and drive real
+// Git/SQLite subprocesses, and none sits on the PR gate path. A workspace also
+// opts out when its tests cannot survive a worker thread; both known blockers
+// are recorded at their call site below — desktop needs the webstorage flag on a
+// Node that installs those globals, and the flag cannot coexist with worker
+// threads (scripts/shared/node-webstorage.mjs), while maker-core fakes HOME,
+// which a worker cannot see because `process.env` there is a thread-local copy
+// while `os.homedir()` reads the real environment through libuv.
+//
+// Keep every opt-out listed in the pool regression test, and keep the list
+// short: at 1330 of this tier's 1845 files, desktop alone decides whether the
+// churn is a trickle or back to where it started.
+const UNIT_POOL_DEFAULT = 'threads';
 // Workspace-level parallelism owns the global process budget. Keep ordinary
 // Vitest workspaces at one worker each so outer concurrency cannot multiply
 // every child process's default CPU-sized pool.
-const unitVitestCommand = (workers = 1) => vitestBin('run', `--maxWorkers=${workers}`);
+const unitVitestCommand = (workers = 1, pool = UNIT_POOL_DEFAULT) =>
+  vitestBin('run', `--pool=${pool}`, `--maxWorkers=${workers}`);
 const noCollectableTestsReason = 'No collectable tests yet. Add tests and mark a tier required when this workspace gains testable logic.';
 const desktopDbInclude = [
   'src/main/localDb/**/__tests__/*.test.ts',
@@ -40,7 +68,7 @@ const noCollectableWorkspace = (name, cwd, reason = noCollectableTestsReason) =>
   tiers: {},
 });
 
-const requiredUnitWorkspace = (name, cwd, { workers = 1, execution } = {}) => ({
+const requiredUnitWorkspace = (name, cwd, { workers = 1, execution, pool } = {}) => ({
   name,
   cwd,
   status: 'required',
@@ -48,7 +76,7 @@ const requiredUnitWorkspace = (name, cwd, { workers = 1, execution } = {}) => ({
     unit: {
       status: 'required',
       ...(execution ? { execution } : {}),
-      command: unitVitestCommand(workers),
+      command: unitVitestCommand(workers, pool),
     },
   },
 });
@@ -67,7 +95,16 @@ export default {
           // found eight workers to be the best complexity/resource tradeoff.
           // Lower-CPU hosts stay capped by their available parallelism.
           // It runs exclusively so these workers never overlap outer workspaces.
-          command: vitestBin('run', `--maxWorkers=${desktopUnitWorkerCount()}`),
+          // The pool follows the webstorage flag, because the flag cannot
+          // coexist with worker threads — see scripts/shared/node-webstorage.mjs
+          // for the crash it causes and the measurements. On Node 22, which is
+          // what local dev and CI run, the flag is a no-op, so this suite's 1330
+          // files take threads and stop spawning a process each. On a
+          // webstorage-enabled Node the flag wins and the suite stays on forks.
+          command: unitVitestCommand(
+            desktopUnitWorkerCount(),
+            nodeWebstorageEnabled() ? 'forks' : 'threads',
+          ),
           exclude: [
             '**/*.git-integration.test.ts',
             'src/main/localDb/**',
@@ -153,7 +190,10 @@ export default {
     requiredUnitWorkspace('@cindy/im', 'packages/lizi-im'),
     requiredUnitWorkspace('@cindy/mcps', 'packages/lizi-mcps'),
     requiredUnitWorkspace('@cindy/maker-cc-manager', 'packages/maker-cc-manager'),
-    requiredUnitWorkspace('@cindy/maker-core', 'packages/maker-core'),
+    // Stays on forks: palette-scanner's tests stub HOME and the scanner resolves
+    // it through os.homedir(), which a worker thread cannot see (see
+    // UNIT_POOL_DEFAULT above).
+    requiredUnitWorkspace('@cindy/maker-core', 'packages/maker-core', { pool: 'forks' }),
     requiredUnitWorkspace('@cindy/maker-remote-ssh', 'packages/maker-remote-ssh'),
     requiredUnitWorkspace('@cindy/maker-scheduler', 'packages/maker-scheduler'),
     requiredUnitWorkspace('@cindy/maker-shared', 'packages/maker-shared'),


### PR DESCRIPTION
## 这次改了什么

### 摘要

vitest 默认的 `forks` 池在 `isolate` 默认开启时，**每个测试文件都换一个新子进程**，而每个新进程都要向 macOS LaunchServices 注册一次。unit tier 的 1845 个测试文件因此每轮门禁要花掉约 1900 次进程注册，实测 **21 次/秒**（18 核 macOS）。

2026-07-30 这份 churn 持续几小时后压垮了本机 macOS 27.0 beta 的 `launchservicesd`：它重启后带着「运行中 App 注册表」一起清空，登录会话再也没有前台 App —— 菜单栏消失、任何 App 里键盘都失效、点 Dock 图标图标就消失，只能重启恢复。

worker thread 保持同样的每文件隔离语义，却完全不产生进程注册。**同一批 180 个 desktop 测试文件实测：forks 189 次注册，threads 1 次**，结果一致且略快。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（本机事故驱动）
- 本 PR 包含：
  - `scripts/test-workspaces.config.mjs`：unit tier 显式指定 vitest 池，默认 `threads`；`unitVitestCommand` 增加 pool 参数；desktop 改用同一 helper（消掉重复）
  - `scripts/shared/node-webstorage.mjs`（新增）：判定 Node 是否装了 webstorage 全局，供 manifest 与 desktop vitest 配置共用同一条件
  - `apps/desktop/vitest.config.ts`：只在真需要时才给 threads 传 `--no-experimental-webstorage` execArgv（forks 那份不变）
  - `scripts/__tests__/test-workspaces.test.mjs`：更新参数断言 + 新增两个测试（池例外名单回归、`nodeWebstorageEnabled` 注入式单测）
  - `apps/desktop/.../portReclaim.test.ts`、`.../ghostOauthFlow.test.ts`：治掉 threads 暴露的端口 TOCTOU 竞态
- 明确不包含：
  - `db` / `migration` / `git-integration` 等重型 manual tier 保持默认池（要 bootstrap 运行时资产、驱动真实 Git/SQLite 子进程，且都不在 PR 门禁路径上）
  - `apps/desktop` 既有的 103 个 lint error（基线 `origin/main` 上完全一样，与本 PR 无关，不混入修复）
- 用户可见变化：无（纯测试基础设施）
- 是否存在 breaking change：无

### 两处必要的例外，都写在调用点

**`apps/desktop`：池跟着 webstorage flag 走。** 给 worker thread 传自定义 `execArgv` 会在 isolate 销毁时段错误 —— 实测 10 轮里 2 轮 SIGSEGV，栈是：

```
node::worker::Worker::Run()
 └ WorkerThreadData::~WorkerThreadData()
   └ IsolateData::~IsolateData() → DetachCppHeap → CollectGarbage
     └ GlobalHandles::InvokeFirstPassWeakCallbacks()
       └ <未解析地址>            ← 原生扩展 finalizer 踩已释放内存
```

移除该 execArgv 后连跑 8 轮零崩溃。而这个 flag 在 Node 22（本机与 CI）根本是 no-op（`typeof localStorage === 'undefined'`），只为 Node 25 而存在。两者互斥，于是二选一：**需要 flag 的 Node 上留在 forks（等于今天的行为），不需要的切 threads。**

**`packages/maker-core`：留在 forks。** `palette-scanner` 的用例用 `vi.stubEnv('HOME', fixture)` 伪造 home，而实现走 `os.homedir()`；worker 里 `process.env` 只是线程内副本，`os.homedir()` 经 libuv 读真实环境，看不到伪造值。单文件复现确认（forks 通过 / threads 失败）。

### 端口竞态的加固不牺牲检测能力

threads 下并发的测试文件共享同一进程与 socket 表，「探测一个空闲端口再钉给被测代码」这种 TOCTOU 会被撞中（`ghostOauthFlow` 原有注释本就承认这个竞态「可接受」）。加固方式：

- OAuth 引擎把「钉死端口绑不上」精确报成 `LISTEN_FAILED`，helper **只对这一个错误**换端口重跑，其它任何失败原样交给断言
- `portReclaim` 同理，只在「查出候选」时换端口，连续 5 个互不相同的端口都不干净才判定地址过滤真的回归

全仓只有 5 个测试文件起真实监听、且无人绑固定端口；另外 3 个（`ghostOauthAccounts` 的端口由自己的 blocker 确定性持有、`authHostedCallback`、`transport-manager`）没有探测后重绑模式，未改动。

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
# 提交前强制门禁（本机 macOS 27.0 beta / Node v22.23.1）
bash ~/.claude/skills/git/scripts/run-unit-gate.sh <worktree>
结果：GATE_EXIT=0 —— 54 PASS / 0 FAIL / 0 SIGSEGV
      26 个 workspace 走 --pool=threads，仅 maker-core 走 --pool=forks
      apps/desktop unit 48.5s（forks 下为 70~90s）
      apps/mobile  unit 9.6s

pnpm --filter desktop run --if-present typecheck
结果：通过（根 package cindy 无 typecheck script，按规则跳过）

node --test scripts/__tests__/test-workspaces.test.mjs scripts/__tests__/desktop-worker-benchmark.test.mjs
结果：75 tests / 75 pass / 0 fail

# churn 量化：同一批 180 个 desktop 测试文件，同机对照
--pool=forks   → node CHECKIN 189 次（21 次/秒），2146 tests 全通过
--pool=threads → node CHECKIN   1 次（0 次/秒），2146 tests 全通过
空闲基线 10s   → node CHECKIN   0 次

# 单轮完整 desktop unit tier（1328 文件）
threads → node CHECKIN 1 次（forks 下约 1330 次）

# 段错误定位：移除 threads execArgv 后连跑 8 轮完整 desktop unit tier
结果：8 轮 0 次 SIGSEGV（保留 execArgv 时 10 轮出现 2 次）

# 端口竞态：改动涉及的 3 个测试文件 threads 下连跑 3 次
结果：92 tests 全通过

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

### 手工验证

不涉及（纯测试基础设施，无用户可见行为）。

### 未执行的验证

- **Node 25 路径未实机验证**：本机与 CI 都是 Node 22，`typeof localStorage === 'undefined'`，走不到「webstorage 开启 → 留在 forks」那条分支。该分支的语义是「保持改动前的行为」，因此不通过时的风险等于现状；`nodeWebstorageEnabled` 本身用注入 global 的方式做了单测覆盖，不依赖运行时 Node 版本。
- **未跑 `pnpm test:all`**：本 PR 只改 unit tier 的池与相关测试，未触碰 db / migration / git-integration tier 的配置。
- 一次门禁曾因 `apps/mobile` 的 `startupSplashOverlay.test.ts` 超时失败（该用例用 `execFileSync` 同步跑完整个 expo CLI，预算 5s）。分诊结论：负载敏感，当时机器上另有两个会话的门禁在并行。同一份代码在机器空闲时对照 `--pool=forks` 与 `--pool=threads` 各跑 3 轮，全部通过，非本 PR 引入。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅本地与 CI 的 unit tier 执行方式；不改任何产物、不改运行时代码路径。`apps/mobile` 与 24 个 packages 从 forks 换到 threads，`apps/desktop` 在 Node 22/CI 上换到 threads。
- 回滚 / 降级方式：把 `scripts/test-workspaces.config.mjs` 里的 `UNIT_POOL_DEFAULT` 改回 `'forks'` 即可整体回退；单个 workspace 回退则给它传 `{ pool: 'forks' }` 并补进测试里的例外名单。两者都不涉及数据或协议。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动理由与实测数据写在代码注释与 `scripts/shared/node-webstorage.mjs` 的模块说明里）
- [x] 已确认测试结果或说明未执行原因
