### PR TITLE
fix(agents): 过载重投判定改吃结构化错误码，不再依赖 codex 英文文案

### DIFF
--- a/apps/desktop/src/main/goal-host/__tests__/usageLimit.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/usageLimit.test.ts
@@ -80,6 +80,29 @@ describe('classifyTurnOverload', () => {
     expect(classifyTurnOverload({})).toBe(false);
   });
 
+  it('结构化 codexErrorInfo 命中时不依赖文案措辞', () => {
+    // 这条锁的是「codex 改了过载文案后 goal 侧仍能自动续跑」。message 故意完全不含
+    // `at capacity`：只认文案时这里会返回 false，finalizeTurn 就把 goal 判 blocked，
+    // 而不是走 OVERLOAD_RESUME_DELAY_MS 的短窗口续跑 —— 可自愈的容量抖动变成死局。
+    expect(
+      classifyTurnOverload({
+        message: 'The upstream declined this request.',
+        codexErrorInfo: 'serverOverloaded',
+      }),
+    ).toBe(true);
+    // 连 message 都没有时同样成立（host 合成的错误可能不带文案）。
+    expect(classifyTurnOverload({ codexErrorInfo: 'serverOverloaded' })).toBe(true);
+  });
+
+  it('非过载的结构化 tag 不误判成过载', () => {
+    // usageLimitExceeded 要走限额通道等账号周期重置，不能被拽进一分钟短窗口。
+    expect(classifyTurnOverload({ message: 'boom', codexErrorInfo: 'usageLimitExceeded' })).toBe(false);
+    expect(classifyTurnOverload({ message: 'boom', codexErrorInfo: 'contextWindowExceeded' })).toBe(false);
+    expect(
+      classifyTurnOverload({ message: 'stream gone', codexErrorInfo: 'responseStreamDisconnected' }),
+    ).toBe(false);
+  });
+
   it('529 命中两条判定，靠调用方优先判过载来消歧', () => {
     // controller 必须先问 classifyTurnOverload：走限额分支会因为账号并未被限流而
     // 拿不到 resetAt，目标就停在 usageLimited 等人手动 resume。

--- a/apps/desktop/src/main/goal-host/usageLimit.ts
+++ b/apps/desktop/src/main/goal-host/usageLimit.ts
@@ -45,7 +45,12 @@ export function classifyTurnUsageLimit(data: unknown): boolean {
  */
 export function classifyTurnOverload(data: unknown): boolean {
   if (!data || typeof data !== 'object') return false;
-  const d = data as { message?: unknown; errorStatus?: unknown };
+  const d = data as { message?: unknown; errorStatus?: unknown; codexErrorInfo?: unknown };
+  // 结构化 tag 优先(与 maker-core 的 parseOverloadError 同序): Codex 的过载文案是
+  // codex 二进制里硬编码的用户可见提示语, 随版本漂移; 只靠文案判定会在某次升级后
+  // 静默失效, 而这条判定决定的是「60s 短窗口自动续跑」还是「判 blocked 交回用户」
+  // —— 漏判等于把可自愈的容量抖动变成需要人工 resume 的死局。
+  if (d.codexErrorInfo === 'serverOverloaded') return true;
   if (d.errorStatus === 529) return true;
   const msg = typeof d.message === 'string' ? d.message : '';
   // `at capacity` 要求精确短语,避免误伤业务文案里的 capacity(缓存/队列容量)。

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -878,12 +878,15 @@ export function createMakerHookSessionRunner(deps: {
             progress?.stop();
             off();
             stopListening = undefined;
-            const data = ev.data as { message?: string; errorStatus?: number } | null;
+            const data = ev.data as
+              | { message?: string; errorStatus?: number; codexErrorInfo?: string }
+              | null;
             const raw = data?.message ?? 'agent terminal error';
             // 过载重试耗尽: 渠道里发裸英文原文(server 侧再前缀成 "Task failed:")
             // 等于把内部串丢给用户, 且没说清"怎么才能真的重试"。换成可读说明,
-            // 原文留在本地日志里供排查。
-            const friendly = overloadFailureNotice(raw, data?.errorStatus);
+            // 原文留在本地日志里供排查。结构化 tag 一并传: 只认文案时 codex 改措辞
+            // 会让这条终态说明退回裸英文原文。
+            const friendly = overloadFailureNotice(raw, data?.errorStatus, data?.codexErrorInfo);
             if (friendly !== null) {
               log.warn(`hook turn failed (upstream overload): ${raw}`);
             }

--- a/apps/desktop/src/main/im/shared/__tests__/turnRetryNotice.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRetryNotice.test.ts
@@ -50,6 +50,28 @@ describe('overloadRetryNotice', () => {
     expect(overloadRetryNotice({})).toBeNull();
     expect(overloadRetryNotice({ message: 42 })).toBeNull();
   });
+
+  it('结构化 codexErrorInfo 命中时不依赖文案措辞', () => {
+    // codex 改了过载文案后, 只认文案会让整段退避窗口在渠道侧一个字都不动 —— 也就是
+    // 本文件开头描述的那个"卡死了"观感复发。
+    expect(
+      overloadRetryNotice({
+        message: 'The upstream declined this request. (auto-retry 2/4)',
+        codexErrorInfo: 'serverOverloaded',
+      }),
+    ).toBe('模型服务繁忙，正在自动重试（2/4）…');
+    // 只有 tag、没有 message 时也要出提示(空 payload 守卫不能把它挡掉)。
+    expect(overloadRetryNotice({ codexErrorInfo: 'serverOverloaded' })).toBe(
+      '模型服务繁忙，正在自动重试…',
+    );
+  });
+
+  it('非过载的结构化 tag 保持静默', () => {
+    expect(
+      overloadRetryNotice({ message: 'stream gone', codexErrorInfo: 'responseStreamDisconnected' }),
+    ).toBeNull();
+    expect(overloadRetryNotice({ message: 'boom', codexErrorInfo: 'usageLimitExceeded' })).toBeNull();
+  });
 });
 
 describe('overloadFailureNotice', () => {
@@ -79,6 +101,21 @@ describe('overloadFailureNotice', () => {
     expect(overloadFailureNotice('process exited with code 1')).toBeNull();
     expect(overloadFailureNotice('Request timed out', 504)).toBeNull();
   });
+
+  it('结构化 codexErrorInfo 命中时不依赖文案措辞', () => {
+    // 只认文案时, codex 改措辞会让这条终态说明退回裸英文原文推给渠道用户。
+    const notice = overloadFailureNotice(
+      'The upstream declined this request.',
+      undefined,
+      'serverOverloaded',
+    );
+    expect(notice).toContain('模型服务繁忙');
+    expect(notice).toContain('在这里重发这条消息');
+  });
+
+  it('非过载的结构化 tag 不改写原文', () => {
+    expect(overloadFailureNotice('stream gone', undefined, 'responseStreamDisconnected')).toBeNull();
+  });
 });
 
 describe('terminalErrorText', () => {
@@ -98,6 +135,14 @@ describe('terminalErrorText', () => {
     expect(terminalErrorText({ message: 'SDK API request failed', errorStatus: 529 })).toContain(
       '模型服务繁忙',
     );
+  });
+
+  it('结构化 codexErrorInfo 从 data 里被取出并透传(三条终态路径共用)', () => {
+    const text = terminalErrorText({
+      message: 'The upstream declined this request.',
+      codexErrorInfo: 'serverOverloaded',
+    });
+    expect(text).toContain('模型服务繁忙');
   });
 
   it('非过载终态沿用上游原文', () => {

--- a/apps/desktop/src/main/im/shared/turnRetryNotice.ts
+++ b/apps/desktop/src/main/im/shared/turnRetryNotice.ts
@@ -38,11 +38,16 @@ import { parseOverloadError, parseOverloadRetryProgress } from '@cindy/maker-cor
  */
 export function overloadRetryNotice(data: unknown): string | null {
   if (!data || typeof data !== 'object') return null;
-  const record = data as { message?: unknown; errorStatus?: unknown };
+  const record = data as { message?: unknown; errorStatus?: unknown; codexErrorInfo?: unknown };
   const message = typeof record.message === 'string' ? record.message : '';
   const errorStatus = typeof record.errorStatus === 'number' ? record.errorStatus : undefined;
-  if (message.length === 0 && errorStatus === undefined) return null;
-  if (parseOverloadError(message, errorStatus) === null) return null;
+  // 结构化 tag 一并取: codex 改过载文案后, 只认文案会让整段退避窗口(约 22-38s)在
+  // 渠道侧重新变回"一个字都不动", 也就是本文件开头描述的那个"卡死了"观感复发。
+  const codexErrorInfo =
+    typeof record.codexErrorInfo === 'string' ? record.codexErrorInfo : undefined;
+  // 空 payload 守卫也要算上 tag, 否则「无 message + 只有结构化 tag」会被提前挡掉。
+  if (message.length === 0 && errorStatus === undefined && codexErrorInfo === undefined) return null;
+  if (parseOverloadError(message, errorStatus, codexErrorInfo) === null) return null;
   const progress = parseOverloadRetryProgress(message);
   // 次数缺省(上游没带 attempt/max_retries)时不编造分母, 只说明正在重试。
   return progress
@@ -58,8 +63,12 @@ export function overloadRetryNotice(data: unknown): string | null {
  * 键, 那一轮已经收口)。所以这里必须把"在原渠道重发这条消息"说出来 —— 否则用户
  * 在桌面端点了重试、任务确实在跑, 但渠道那条消息永远停在失败上, 只能干等。
  */
-export function overloadFailureNotice(message: string, errorStatus?: number): string | null {
-  if (parseOverloadError(message, errorStatus) === null) return null;
+export function overloadFailureNotice(
+  message: string,
+  errorStatus?: number,
+  codexErrorInfo?: string,
+): string | null {
+  if (parseOverloadError(message, errorStatus, codexErrorInfo) === null) return null;
   // 刻意**不**声称"自动重试多次后仍未成功": 走到终态的原因不止预算耗尽, 还包括
   // "本 turn 已有产出所以不重投"(maker-core 的 currentTurnProducedOutput 守卫)与接管
   // 条件不满足, 那些情况下一次自动重试都没发生过(review #844 codex P1)。真重试过时
@@ -85,7 +94,7 @@ export function overloadFailureNotice(message: string, errorStatus?: number): st
 export function terminalErrorText(data: unknown): string {
   const record =
     data && typeof data === 'object'
-      ? (data as { message?: unknown; errorStatus?: unknown })
+      ? (data as { message?: unknown; errorStatus?: unknown; codexErrorInfo?: unknown })
       : null;
   // 判**值**而不是判 key 是否存在: 上游 payload 带一个 message: undefined 时, 'in' 判定
   // 会成立并 String(undefined) 出字面量 "undefined" 给用户看, 同时让过载文案映射取决于这个
@@ -95,5 +104,7 @@ export function terminalErrorText(data: unknown): string {
       ? String(record.message)
       : String(data);
   const errorStatus = typeof record?.errorStatus === 'number' ? record.errorStatus : undefined;
-  return overloadFailureNotice(message, errorStatus) ?? message;
+  const codexErrorInfo =
+    typeof record?.codexErrorInfo === 'string' ? record.codexErrorInfo : undefined;
+  return overloadFailureNotice(message, errorStatus, codexErrorInfo) ?? message;
 }

--- a/apps/desktop/src/renderer/__tests__/errorMessageRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/errorMessageRestore.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect } from 'vitest';
 import { makerChatStore } from '@/lib/makerChatStore';
 import type { Message } from '@/lib/ccAgent.types';
 import { ERROR_REASON_I18N_KEYS } from '@/components/chat/ErrorMessageCard';
+import { UPSTREAM_OVERLOAD_REASON } from '@/utils/overloadError';
 
 const SESSION_ID = 's-err';
 
@@ -34,6 +35,30 @@ describe('mapServerMessages — persisted terminal error rows', () => {
     expect(ERROR_REASON_I18N_KEYS['codex-auto-review-unavailable']).toBe(
       'logic.errors.codexAutoReviewUnavailable',
     );
+  });
+
+  it('maps upstream overload to the same copy the tail banner uses', () => {
+    // 本表注释的一致性诉求: 同一条过载错误不能出现「尾部红条本地化、历史静态卡
+    // 英文原文」的分裂。复用 banner 那条 key(不新增文案), 且 codex 改措辞也不影响
+    // —— 判定走的是稳定 reason key, 不是原文。
+    expect(ERROR_REASON_I18N_KEYS[UPSTREAM_OVERLOAD_REASON]).toBe(
+      'chat.errorBanner.overloadBusyNoRetry',
+    );
+  });
+
+  it('restores the overload reason from persisted rows so history can localize it', () => {
+    const mapped = makerChatStore.__mapServerMessagesForTest([
+      errorRow('e-overload', {
+        // 文案故意不含 `at capacity`: codex 改了措辞后历史行仍要能本地化。
+        message: 'The upstream declined this request.',
+        reason: UPSTREAM_OVERLOAD_REASON,
+      }),
+    ]);
+    expect(mapped[0]).toMatchObject({
+      clientId: 'e-overload',
+      role: 'error',
+      errorReason: UPSTREAM_OVERLOAD_REASON,
+    });
   });
 
   it('restores message text and errorReason from structured content', () => {

--- a/apps/desktop/src/renderer/__tests__/overloadError.test.ts
+++ b/apps/desktop/src/renderer/__tests__/overloadError.test.ts
@@ -20,6 +20,7 @@ import {
   parseOverloadError,
   parseOverloadRetryProgress,
   GOAL_OVERLOAD_LAST_REASON,
+  UPSTREAM_OVERLOAD_REASON,
   isGoalCapacityBackoff,
 } from '@/utils/overloadError';
 
@@ -67,6 +68,43 @@ describe('isOverloadErrorMessage', () => {
     const network = 'unexpected status 502 Bad Gateway: upstream unreachable';
     expect(isNetworkishErrorMessage(network)).toBe(true);
     expect(isOverloadErrorMessage(network)).toBe(false);
+  });
+
+  // ── 稳定 reason key 优先 ─────────────────────────────────────────────────────
+  //
+  // renderer 隔着 IPC 投影拿不到 codex 的原始 codexErrorInfo tag, 靠 maker-core 带上
+  // 的 UPSTREAM_OVERLOAD_REASON 判定。这一组锁的是「codex 改了容量文案后 banner 仍显示
+  // 本地化过载文案与重试进度, 而不是英文原文」。
+
+  it('reason key 命中时不依赖文案措辞', () => {
+    // message 故意完全不含 `at capacity`: 模拟 codex 改了措辞。
+    expect(
+      isOverloadErrorMessage('The upstream declined this request.', undefined, UPSTREAM_OVERLOAD_REASON),
+    ).toBe(true);
+    expect(
+      parseOverloadError('The upstream declined this request.', undefined, UPSTREAM_OVERLOAD_REASON),
+    ).toEqual({ kind: 'capacity' });
+    // 空文案同理(host 合成的错误可能不带 message)。
+    expect(isOverloadErrorMessage('', undefined, UPSTREAM_OVERLOAD_REASON)).toBe(true);
+  });
+
+  it('reason key 优先于 529(决定用户看到哪条文案)', () => {
+    expect(parseOverloadError('overloaded_error', 529, UPSTREAM_OVERLOAD_REASON)).toEqual({
+      kind: 'capacity',
+    });
+  });
+
+  it('其它 reason key 不误判成过载', () => {
+    for (const reason of ['silent-stop-exhausted', 'turn-failed', 'empty-response', 'app-exit-interrupted']) {
+      expect(isOverloadErrorMessage('tool failed: file not found', undefined, reason)).toBe(false);
+    }
+  });
+
+  it('reason 缺席时退回文案兜底(历史持久化错误行只有文案可用)', () => {
+    expect(
+      isOverloadErrorMessage('Selected model is at capacity.', undefined, undefined),
+    ).toBe(true);
+    expect(isOverloadErrorMessage('Selected model is at capacity.', undefined, null)).toBe(true);
   });
 });
 

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -183,7 +183,12 @@ export function ErrorBanner({
   const isNetworkishError = reconnectAttempt !== null || isNetworkishErrorMessage(error);
   // 服务过载(模型容量不足 / 上游 529):与网络类分开判定——把容量问题说成"网络
   // 异常"会让用户白折腾自己的网络。带 `(auto-retry N/M)` 后缀 = 仍在自动重试。
-  const isOverloadError = isOverloadErrorMessage(error);
+  //
+  // 判定优先吃 errorReason 的稳定 key(maker-core 的 UPSTREAM_OVERLOAD_REASON):
+  // Codex 的容量文案是它二进制里硬编码的提示语, 改一次措辞就会让这里退回英文原文,
+  // 而这条判定驱动的正是本地化文案、重试进度与 hideRetry。文案匹配保留作兜底
+  // (老 daemon / Anthropic 侧 / 历史持久化错误行 —— 后者只有文案可用)。
+  const isOverloadError = isOverloadErrorMessage(error, undefined, errorReason);
   const overloadRetryProgress = parseOverloadRetryProgress(error);
   // Retry 的显示条件与网络错误文案必须共用同一个判定。外部发起的 turn（例如
   // scheduler / goal）失败时没有安全的 recovery target，errorRetryText 会是 null；

--- a/apps/desktop/src/renderer/components/chat/ErrorMessageCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorMessageCard.tsx
@@ -20,6 +20,7 @@
 import { AlertCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { decodeRemoteErrorMessage } from '../../lib/makerChatStore';
+import { UPSTREAM_OVERLOAD_REASON } from '@/utils/overloadError';
 
 /** 稳定 reason key → i18n。error-tail-banner(CCAgentSessionView)复用同一映射,
  *  保证尾部可操作红条与历史静态卡展示同一段文案。 */
@@ -33,6 +34,10 @@ export const ERROR_REASON_I18N_KEYS: Record<string, string> = {
   // maker-core 侧 message 是英文兜底,renderer 一律走这里的本地化文案。
   upstream_response_idle_timeout: 'logic.errors.upstreamResponseIdleTimeout',
   turn_no_event_timeout: 'logic.errors.turnNoEventTimeout',
+  // 上游过载(重投预算耗尽后的终态)。**复用尾部 banner 的同一条文案**, 正是本表
+  // 注释说的那个一致性: 不映射的话同一条过载错误会出现「尾部红条本地化、历史静态
+  // 卡英文原文」的分裂 —— 而 codex 的过载原文还会随版本改措辞。
+  [UPSTREAM_OVERLOAD_REASON]: 'chat.errorBanner.overloadBusyNoRetry',
 };
 
 export function ErrorMessageCard({ message, reason }: { message: string; reason?: string }) {

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -815,7 +815,14 @@ export function useCCAgentChat(
     updateLastSystemCardData,
     updateSystemCardData,
     error: lightState.error ?? lightState.recoverableError,
-    errorReason: lightState.error != null ? (lightState.errorReason ?? null) : null,
+    // 终止型沿用原语义(reason 只在 error 非空时有意义)。非终止型此前恒给 null ——
+    // 那时 store 侧非终止分支也恒清 reason, 两边一致; 现在过载重投会在非终止态带上
+    // 稳定 reason key(ErrorBanner 靠它渲染本地化重试进度), 必须透出, 否则 UI 只能
+    // 回退到文案匹配。其它非终止 error 仍不带 reason, 取值仍是 null, 行为不变。
+    errorReason:
+      lightState.error != null
+        ? (lightState.errorReason ?? null)
+        : (lightState.recoverableError != null ? (lightState.errorReason ?? null) : null),
     // 当前 error 是非终止 recoverableError(turn 在跑,daemon 自动重试中):
     // ErrorBanner 网络分支据此显示「正在自动重试…」而非「可点击重试」。
     errorIsRecoverable: !lightState.error && lightState.recoverableError != null,

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2530,7 +2530,11 @@ export function handleStreamEvent(
         return {
           ...state,
           error: null,
-          errorReason: null,
+          // 非终止 error 此前恒清 reason(那时没有任何非终止 error 带 reason)。过载
+          // 重投是第一个需要它的: renderer 靠 reason 判定"是否过载"来渲染本地化的
+          // 重试进度, 而重投恰恰只在**非终止**态发生 —— 清掉就等于 UI 侧只能回退
+          // 文案匹配。其它非终止 error 仍不带 reason, 行为不变。
+          errorReason: reason ?? null,
           recoverableError: errMsg,
           errorRetryText: null,
           isStreaming: true,

--- a/apps/desktop/src/renderer/utils/overloadError.ts
+++ b/apps/desktop/src/renderer/utils/overloadError.ts
@@ -21,18 +21,42 @@
 
 export type OverloadErrorKind = 'capacity' | 'overloaded';
 
+/**
+ * maker-core 在过载 error 事件上带的**稳定 reason key**(见 maker-core 的
+ * `agents/shared/overload-error.ts` 的 `UPSTREAM_OVERLOAD_REASON`)。
+ *
+ * 为什么 renderer 认这个而不是 codex 的原始 `codexErrorInfo` tag: 判定依据按
+ * 进程边界分层 —— main 侧(goal-host / IM)直接消费 error data, 吃 codex 的原始
+ * 结构化 tag; renderer 隔着 IPC 投影, 吃我们自己定义的稳定 key。后者不随 vendor
+ * 协议演进而变, 也不需要把 vendor 枚举搬进 renderer bundle。
+ *
+ * 为什么两者都不能只靠文案: `Selected model is at capacity...` 是 codex 二进制里
+ * 硬编码的用户可见提示语, 不是 API 契约。只认文案时 codex 改一次措辞, 用户就会在
+ * 整段自动重试窗口(约 22-38s)里看到英文原文, 而不是本地化的重试进度与过载引导。
+ *
+ * 与 maker-core 侧同名常量两处同步(不跨 bundle 共享代码, 与本文件其它谓词同规)。
+ */
+export const UPSTREAM_OVERLOAD_REASON = 'upstream-overload';
+
 export function parseOverloadError(
   message: string,
   errorStatus?: number,
+  reason?: string | null,
 ): { kind: OverloadErrorKind } | null {
+  if (reason === UPSTREAM_OVERLOAD_REASON) return { kind: 'capacity' };
   if (errorStatus === 529) return { kind: 'overloaded' };
+  // 文案 pattern 保留作老 daemon(不发结构化标识)与 Anthropic 侧的兜底。
   if (/\bat capacity\b/i.test(message)) return { kind: 'capacity' };
   if (/\boverloaded_error\b|\b529\b/.test(message)) return { kind: 'overloaded' };
   return null;
 }
 
-export function isOverloadErrorMessage(message: string, errorStatus?: number): boolean {
-  return parseOverloadError(message, errorStatus) !== null;
+export function isOverloadErrorMessage(
+  message: string,
+  errorStatus?: number,
+  reason?: string | null,
+): boolean {
+  return parseOverloadError(message, errorStatus, reason) !== null;
 }
 
 /**

--- a/packages/maker-core/src/agents/codex/app-server/protocol.ts
+++ b/packages/maker-core/src/agents/codex/app-server/protocol.ts
@@ -791,9 +791,61 @@ export interface TurnStartedNotification {
  */
 export type TurnStatus = 'completed' | 'interrupted' | 'failed' | 'inProgress';
 
+/**
+ * v2.rs CodexErrorInfo — codex 把内部 `CodexErr` 变体翻成 camelCase 暴露出来的
+ * **结构化** 错误标识。schema 正本:
+ * `codex-rs/app-server-protocol/schema/json/v2/ErrorNotification.json`。
+ *
+ * 为什么要用它: 同一个语义错误的 `message` 是 codex 侧硬编码的**用户可见文案**
+ * (`CodexErr::ServerOverloaded` 的文案是 "Selected model is at capacity. Please
+ * try a different model.", 见 codex-rs/protocol/src/error.rs 那个变体上的
+ * `#[error(...)]`)。那是给人看的提示语、不是 API 契约, codex 改一次措辞、所有
+ * 靠文案匹配的判定就一起静默失效。本字段是 schema 承诺的稳定契约。
+ *
+ * 形态有两种: 纯枚举变体在 wire 上就是**字符串**; 只有携带 `httpStatusCode` /
+ * `turnKind` 的那几个是单键对象。取 tag 统一走 `codexErrorInfoTag()`。
+ */
+export type CodexErrorInfo =
+  | 'contextWindowExceeded'
+  | 'sessionBudgetExceeded'
+  | 'usageLimitExceeded'
+  /** 上游临时过载: HTTP 503 + `server_is_overloaded` / `slow_down`。 */
+  | 'serverOverloaded'
+  | 'cyberPolicy'
+  | 'internalServerError'
+  | 'unauthorized'
+  | 'badRequest'
+  | 'threadRollbackFailed'
+  | 'sandboxError'
+  | 'other'
+  | { httpConnectionFailed: { httpStatusCode?: number | null } }
+  | { responseStreamConnectionFailed: { httpStatusCode?: number | null } }
+  | { responseStreamDisconnected: { httpStatusCode?: number | null } }
+  | { responseTooManyFailedAttempts: { httpStatusCode?: number | null } }
+  | { activeTurnNotSteerable: { turnKind?: unknown } };
+
+/**
+ * `CodexErrorInfo` 的判别 tag。字符串变体原样返回; 单键对象取那个唯一的键。
+ *
+ * 形状不认识时返回 `undefined` 而**不是**猜一个: 上游新增变体、或某天把单键对象
+ * 改成多键结构时, 宁可退回文案兜底, 也不要把它误判成某个已知 tag 去驱动重试。
+ */
+export function codexErrorInfoTag(info: CodexErrorInfo | null | undefined): string | undefined {
+  if (typeof info === 'string') return info;
+  if (info && typeof info === 'object' && !Array.isArray(info)) {
+    const keys = Object.keys(info);
+    return keys.length === 1 ? keys[0] : undefined;
+  }
+  return undefined;
+}
+
 export interface TurnError {
   message: string;
-  codexErrorInfo?: { [k: string]: unknown } | null;
+  /**
+   * 原类型写的 `{ [k: string]: unknown } | null` 接不住实际值 —— 纯枚举变体在
+   * wire 上是字符串。这个字段此前没被任何判定消费, 所以类型不准一直没暴露。
+   */
+  codexErrorInfo?: CodexErrorInfo | null;
   additionalDetails?: string | null;
 }
 
@@ -981,7 +1033,11 @@ export interface ErrorNotification {
     willRetry: boolean;
     /** Host-synthesized transport failures are session lifecycle errors, not turn-scoped SDK errors. */
     scope?: 'turn' | 'transport';
-    error: { message?: string; [k: string]: unknown };
+    /**
+     * 形状同 `TurnError`, 但 `message` 保持 optional —— host 合成的 transport 失败
+     * 走同一个 shape 且不保证带文案, 收紧成 required 会破坏那些构造点。
+     */
+    error: { message?: string; codexErrorInfo?: CodexErrorInfo | null; [k: string]: unknown };
     [k: string]: unknown;
   };
 }

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -119,6 +119,7 @@ import {
 } from '../credential-mode.js';
 import {
   Method,
+  codexErrorInfoTag,
   type AskForApproval,
   type ApprovalsReviewer,
   type ApprovalDecision,
@@ -5970,12 +5971,15 @@ export class CodexAgent extends BaseAgent {
         // 不认 → 落到既有的 `stale codex terminal error ignored` 分支被丢掉, 这是安全的:
         // 真属于某个 turn 的话, server 随后会为那个 turn 发权威的 turn/completed(failed),
         // 收口由它完成。
+        // 判定同样优先吃结构化 codexErrorInfo, 文案只作老 daemon 兜底: 这条判据决定
+        // 空 id 的容量拒绝能不能被归属到在飞的 turn/start, 漏判 = 整轮重投预算白给。
         const idLessCapacityError =
           params.turnId === ''
           && isTerminalError
           && parseOverloadError(
             params.error?.message ?? '',
             extractNonSecretErrorSignals(params.error?.message ?? '').errorStatus,
+            codexErrorInfoTag(params.error?.codexErrorInfo),
           ) !== null;
         const idLessAttributable = inFlightStarts.size === 1;
         const targetsIdLessPendingStart =

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -21,6 +21,7 @@ import {
   translatePlanUpdatedNotification,
 } from './translator.js';
 import type { CodexRuntimeState } from './translator.js';
+import type { CodexErrorInfo } from './app-server/protocol.js';
 import { createAsyncQueue } from '../shared/async-queue.js';
 import type { AsyncQueue } from '../shared/async-queue.js';
 import type { AgentEvent } from '../../types/events.js';
@@ -46,17 +47,21 @@ function makeParams(opts: {
   message: string;
   threadId?: string;
   turnId?: string;
+  codexErrorInfo?: CodexErrorInfo;
 }): {
   threadId: string;
   turnId: string;
   willRetry: boolean;
-  error: { message: string };
+  error: { message: string; codexErrorInfo?: CodexErrorInfo };
 } {
   return {
     threadId: opts.threadId ?? 't1',
     turnId: opts.turnId ?? 'turn-a',
     willRetry: opts.willRetry,
-    error: { message: opts.message },
+    error: {
+      message: opts.message,
+      ...(opts.codexErrorInfo !== undefined ? { codexErrorInfo: opts.codexErrorInfo } : {}),
+    },
   };
 }
 
@@ -320,6 +325,103 @@ describe('translateErrorNotification', () => {
     expect((events[0].data as { message: string }).message).toBe(
       'Selected model is at capacity. Please try a different model. (auto-retry 2/4)',
     );
+  });
+
+  it('容量拒绝改了文案措辞时，结构化 tag 仍触发接管重投', async () => {
+    // 本用例锁的是这次改动的核心目标: 重投不再依赖 codex 的英文文案。
+    // message 故意完全不含 "at capacity" —— 模拟 codex 升级改了措辞。若判定回退到
+    // 文案匹配, tryTakeOverOverload 不会被调用, 这里立刻失败。
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const calls: number[] = [];
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message: 'The upstream declined this request.',
+        codexErrorInfo: 'serverOverloaded',
+      }),
+      q,
+      {
+        ...makeCtx(rt),
+        tryTakeOverOverload: () => {
+          calls.push(1);
+          return { attempt: 1, maxAttempts: 4 };
+        },
+      },
+    );
+    const events = await collect(q);
+    expect(calls).toHaveLength(1);
+    expect(events[0].data).toMatchObject({ isTerminal: false, willRetry: true });
+    expect((events[0].data as { message: string }).message).toBe(
+      'The upstream declined this request. (auto-retry 1/4)',
+    );
+  });
+
+  it('结构化 tag 透出到 error data，且不干扰既有 errorStatus 推断', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message: 'Selected model is at capacity.',
+        codexErrorInfo: 'serverOverloaded',
+      }),
+      q,
+      { ...makeCtx(rt), tryTakeOverOverload: () => null },
+    );
+    const events = await collect(q);
+    expect(events[0].data).toMatchObject({ codexErrorInfo: 'serverOverloaded' });
+    // 容量文案里没有 401/429 信号, 既有推断必须保持不变(不得被新字段带偏)。
+    expect(events[0].data).not.toHaveProperty('errorStatus');
+    expect(events[0].data).not.toHaveProperty('usageLimit');
+  });
+
+  it('对象形态的 codexErrorInfo 取单键作为 tag，且不误判成过载', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const calls: number[] = [];
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message: 'stream disconnected before completion',
+        codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: 503 } },
+      }),
+      q,
+      {
+        ...makeCtx(rt),
+        tryTakeOverOverload: () => {
+          calls.push(1);
+          return { attempt: 1, maxAttempts: 4 };
+        },
+      },
+    );
+    const events = await collect(q);
+    // 流断开不是容量拒绝: 不得接管重投(它有自己的重连路径)。
+    expect(calls).toHaveLength(0);
+    expect(events[0].data).toMatchObject({
+      codexErrorInfo: 'responseStreamDisconnected',
+      isTerminal: true,
+    });
+  });
+
+  it('老 daemon 不发 codexErrorInfo 时按文案兜底，行为不变', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const calls: number[] = [];
+    translateErrorNotification(
+      makeParams({ willRetry: false, message: 'Selected model is at capacity.' }),
+      q,
+      {
+        ...makeCtx(rt),
+        tryTakeOverOverload: () => {
+          calls.push(1);
+          return { attempt: 1, maxAttempts: 4 };
+        },
+      },
+    );
+    const events = await collect(q);
+    expect(calls).toHaveLength(1);
+    expect(events[0].data).not.toHaveProperty('codexErrorInfo');
   });
 
   it('willRetry=false 模型容量不足 + agent 层不接管 → 落回终止错误', async () => {

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -327,6 +327,57 @@ describe('translateErrorNotification', () => {
     );
   });
 
+  it('过载错误带稳定 reason key，供 renderer 隔 IPC 判定（非终止与终止两条路径）', async () => {
+    // renderer 拿不到 codexErrorInfo(跨 IPC 投影只留 message 字符串), 靠这个 key 渲染
+    // 本地化重试进度与过载引导。两条路径都必须带, 否则退避窗口内或耗尽后有一边退回
+    // 英文原文 —— 也就是本次改动要消除的依赖在 UI 侧原样残留。
+    const rt = newCodexRuntimeState();
+    const q1 = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message: 'The upstream declined this request.',
+        codexErrorInfo: 'serverOverloaded',
+      }),
+      q1,
+      { ...makeCtx(rt), tryTakeOverOverload: () => ({ attempt: 1, maxAttempts: 4 }) },
+    );
+    const nonTerminal = await collect(q1);
+    expect(nonTerminal[0]!.data).toMatchObject({
+      reason: 'upstream-overload',
+      isTerminal: false,
+    });
+
+    // 接管不成立(预算耗尽 / 本 turn 已有产出) → 终止路径, reason 同样要带。
+    const q2 = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message: 'The upstream declined this request.',
+        codexErrorInfo: 'serverOverloaded',
+      }),
+      q2,
+      { ...makeCtx(rt), tryTakeOverOverload: () => null },
+    );
+    const terminal = await collect(q2);
+    expect(terminal[0]!.data).toMatchObject({
+      reason: 'upstream-overload',
+      isTerminal: true,
+    });
+  });
+
+  it('非过载错误不得带过载 reason key', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({ willRetry: false, message: 'tool failed: file not found' }),
+      q,
+      makeCtx(rt),
+    );
+    const events = await collect(q);
+    expect(events[0]!.data).not.toHaveProperty('reason');
+  });
+
   it('容量拒绝改了文案措辞时，结构化 tag 仍触发接管重投', async () => {
     // 本用例锁的是这次改动的核心目标: 重投不再依赖 codex 的英文文案。
     // message 故意完全不含 "at capacity" —— 模拟 codex 升级改了措辞。若判定回退到

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -32,7 +32,11 @@ import { normalizeAccountRateLimitSnapshot } from '../../types/account-rate-limi
 import type { AsyncQueue } from '../shared/async-queue.js';
 import { stripTerminalControlSequences } from '../shared/terminal-output.js';
 import { parseReconnectAttemptMessage } from '../shared/network-error.js';
-import { formatOverloadRetryMessage, parseOverloadError } from '../shared/overload-error.js';
+import {
+  UPSTREAM_OVERLOAD_REASON,
+  formatOverloadRetryMessage,
+  parseOverloadError,
+} from '../shared/overload-error.js';
 import { commandExecutionDisplayInput, type CommandExecutionDisplayInput } from './command-display.js';
 import { codexErrorInfoTag } from './app-server/protocol.js';
 import type {
@@ -323,16 +327,21 @@ export function translateErrorNotification(
   // 由 agent 层接管退避重投。接管成功时透成非终止状态并带进度后缀, renderer
   // 显示"模型繁忙, 正在重试 (N/M)"; 预算耗尽或条件不满足 (本 turn 已有产出)
   // 时 tryTakeOverOverload 返回 null, 落回下面的终止错误路径。
-  if (
-    !params.willRetry &&
-    parseOverloadError(safeMessage, signals.errorStatus, errorInfoTag)?.kind === 'capacity'
-  ) {
+  const isCapacityError =
+    parseOverloadError(safeMessage, signals.errorStatus, errorInfoTag)?.kind === 'capacity';
+  // 过载错误一律带上稳定 reason key。renderer 隔着 IPC 投影拿不到 codexErrorInfo,
+  // 靠这个 key 判定"是否过载"(ErrorBanner 的本地化文案 + 重试进度 + hideRetry 都由它
+  // 驱动)。不带的话 renderer 只能回退到文案匹配 —— codex 改一次措辞, 用户就会在整段
+  // 重试窗口里看到英文原文, 也就是本次改动要消除的那个依赖在 UI 侧原样残留。
+  const overloadReason = isCapacityError ? { reason: UPSTREAM_OVERLOAD_REASON } : {};
+  if (!params.willRetry && isCapacityError) {
     const progress = ctx.tryTakeOverOverload?.();
     if (progress) {
       queue.push({
         type: 'error',
         data: {
           ...safeErrorData,
+          ...overloadReason,
           message: formatOverloadRetryMessage(safeMessage, progress.attempt, progress.maxAttempts),
           isTerminal: false,
           willRetry: true,
@@ -345,7 +354,12 @@ export function translateErrorNotification(
   ctx.log.warn('codex turn error', { message: safeMessage, willRetry: params.willRetry, isAuthMissing, threadId: params.threadId, turnId: params.turnId });
   queue.push({
     type: 'error',
-    data: { ...safeErrorData, isTerminal: !params.willRetry, willRetry: params.willRetry },
+    data: {
+      ...safeErrorData,
+      ...overloadReason,
+      isTerminal: !params.willRetry,
+      willRetry: params.willRetry,
+    },
     source: 'codex',
   });
 }

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -34,6 +34,7 @@ import { stripTerminalControlSequences } from '../shared/terminal-output.js';
 import { parseReconnectAttemptMessage } from '../shared/network-error.js';
 import { formatOverloadRetryMessage, parseOverloadError } from '../shared/overload-error.js';
 import { commandExecutionDisplayInput, type CommandExecutionDisplayInput } from './command-display.js';
+import { codexErrorInfoTag } from './app-server/protocol.js';
 import type {
   ItemCompletedNotification,
   ItemStartedNotification,
@@ -250,10 +251,15 @@ export function translateErrorNotification(
   const signals = extractNonSecretErrorSignals(message);
   const errorStatus =
     signals.errorStatus ?? (hasMissingBearer || hasAuthErrorMarker ? 401 : undefined);
+  // 结构化错误标识。过载判定优先吃它(见下方 capacity 分支), 同时透出到 error data
+  // 供诊断与下游归因。**不参与上面的 errorStatus 推断** —— 那条链路上挂着
+  // renderer 的 401 banner 与 auth 修复 UX, 改推断依据会连带改这些行为。
+  const errorInfoTag = codexErrorInfoTag(params.error?.codexErrorInfo);
   const safeErrorData = {
     message: safeMessage,
     ...(errorStatus !== undefined ? { errorStatus } : {}),
     ...(signals.usageLimit ? { usageLimit: true } : {}),
+    ...(errorInfoTag !== undefined ? { codexErrorInfo: errorInfoTag } : {}),
   };
   // willRetry=true 的暂时错误 (transient API blip / 5xx blip), server 自己会重试 — 默认
   // 不 emit error event 给 UI,否则会把瞬时错误暴露成用户可见失败。**但** auth 缺失
@@ -319,7 +325,7 @@ export function translateErrorNotification(
   // 时 tryTakeOverOverload 返回 null, 落回下面的终止错误路径。
   if (
     !params.willRetry &&
-    parseOverloadError(safeMessage, signals.errorStatus)?.kind === 'capacity'
+    parseOverloadError(safeMessage, signals.errorStatus, errorInfoTag)?.kind === 'capacity'
   ) {
     const progress = ctx.tryTakeOverOverload?.();
     if (progress) {

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -36,6 +36,7 @@ export {
 // (renderer 因跨 bundle 才另存一份镜像; main 与 maker-core 同 bundle, 直接复用
 // 同一份判定, 不再造第三份)。详见 shared/overload-error.ts 的模块注释。
 export {
+  UPSTREAM_OVERLOAD_REASON,
   parseOverloadError,
   parseOverloadRetryProgress,
   isOverloadErrorMessage,

--- a/packages/maker-core/src/agents/shared/overload-error.test.ts
+++ b/packages/maker-core/src/agents/shared/overload-error.test.ts
@@ -71,6 +71,51 @@ describe('parseOverloadError', () => {
     expect(isOverloadErrorMessage('buffer capacity dropping')).toBe(false);
     expect(isOverloadErrorMessage('upstream busy', 529)).toBe(true);
   });
+
+  // ── 结构化 codexErrorInfo 优先 ───────────────────────────────────────────────
+  //
+  // 这一组锁的是「判定不再依赖 codex 的英文文案」。`Selected model is at capacity...`
+  // 是 codex 二进制里硬编码的用户可见提示语, 不是 API 契约; 它一改, 靠文案驱动的
+  // 退避重投就静默失效, 而用同一句文案写的测试仍然全绿 —— 所以必须有用例断言
+  // **文案缺席时也能判定**, 否则等于没有解开这个依赖。
+
+  it('结构化 tag 命中时不需要文案配合（真正解开对 codex 文案的依赖）', () => {
+    // 故意给一句完全不含 "at capacity" 的文案: 模拟 codex 改了措辞。
+    expect(parseOverloadError('upstream refused the request', undefined, 'serverOverloaded')).toEqual({
+      kind: 'capacity',
+    });
+    // 空文案同理 —— host 合成的错误可能压根没有 message。
+    expect(parseOverloadError('', undefined, 'serverOverloaded')).toEqual({ kind: 'capacity' });
+  });
+
+  it('结构化 tag 优先于文案与状态码', () => {
+    // 529 会被判成 overloaded(Anthropic 语义); 有 serverOverloaded tag 时按 Codex
+    // 的 capacity 处理 —— 决定「由谁重试」, 不能弄反。
+    expect(parseOverloadError('overloaded_error', 529, 'serverOverloaded')).toEqual({
+      kind: 'capacity',
+    });
+  });
+
+  it('非过载的结构化 tag 不触发过载判定', () => {
+    for (const tag of ['usageLimitExceeded', 'contextWindowExceeded', 'unauthorized', 'other']) {
+      expect(parseOverloadError('some failure', undefined, tag)).toBeNull();
+    }
+  });
+
+  it('tag 缺席或不认识时退回文案兜底（老 daemon 不发该字段）', () => {
+    expect(parseOverloadError('Selected model is at capacity.', undefined, undefined)).toEqual({
+      kind: 'capacity',
+    });
+    // 上游将来新增的变体名: 不认识就当没有, 由文案接手, 不能因此丢掉判定。
+    expect(parseOverloadError('Selected model is at capacity.', undefined, 'someFutureVariant')).toEqual(
+      { kind: 'capacity' },
+    );
+  });
+
+  it('isOverloadErrorMessage 同样吃结构化 tag', () => {
+    expect(isOverloadErrorMessage('nothing quotable', undefined, 'serverOverloaded')).toBe(true);
+    expect(isOverloadErrorMessage('nothing quotable', undefined, 'other')).toBe(false);
+  });
 });
 
 describe('overloadRetryDelayMs', () => {

--- a/packages/maker-core/src/agents/shared/overload-error.ts
+++ b/packages/maker-core/src/agents/shared/overload-error.ts
@@ -27,6 +27,23 @@
  *    与 network-error 两端一致性同款惯例）。修改 pattern 时两处同步。
  */
 
+/**
+ * 过载 error 事件上带的**稳定 reason key**。
+ *
+ * 判定依据按进程边界分层：main 侧（goal-host / IM）直接消费 error data，吃 codex 的
+ * 原始 `codexErrorInfo` tag；renderer 隔着 IPC 投影，吃这个我们自己定义的 key。
+ * 后者不随 vendor 协议演进而变，也不用把 vendor 枚举搬进 renderer bundle。
+ *
+ * 走 `reason` 这个既有通道而不是新增字段：`reason` 本就是「maker-core 用稳定 key 告诉
+ * renderer 这是什么错误」的现成语义（`empty-response` / `turn-failed` 同款），store 侧
+ * 已随 error 一起清理，不必再引入一条平行的清理链（漏清会让过载标记残留到下一条
+ * 非过载错误上）。
+ *
+ * renderer 侧有同名常量镜像（`apps/desktop/src/renderer/utils/overloadError.ts`），
+ * 两处同步。
+ */
+export const UPSTREAM_OVERLOAD_REASON = 'upstream-overload';
+
 /** 过载形态。决定由谁重试，以及用户看到哪条文案。 */
 export type OverloadErrorKind = 'capacity' | 'overloaded';
 

--- a/packages/maker-core/src/agents/shared/overload-error.ts
+++ b/packages/maker-core/src/agents/shared/overload-error.ts
@@ -35,8 +35,23 @@ export interface OverloadError {
 }
 
 /**
- * 识别服务过载类错误。`errorStatus` 传 translator 已抽出的 HTTP 状态码时，529
- * 直接判定为 `overloaded`（比文本匹配可靠）。
+ * 识别服务过载类错误。判定依据按可靠性排序，命中即返回：
+ *
+ * 1. `codexErrorInfoTag`（最可靠）：Codex app-server 的结构化错误标识，
+ *    `serverOverloaded` 即上游临时过载。**这是 Codex 侧的首选依据** ——
+ *    详见下面「为什么不能只靠文案」。
+ * 2. `errorStatus === 529`：Anthropic 的 HTTP 状态码。
+ * 3. 文案 pattern：老 daemon（不发 `codexErrorInfo`）与 Anthropic 侧的兜底。
+ *
+ * **为什么不能只靠文案**：`Selected model is at capacity. Please try a different
+ * model.` 是 codex 二进制里硬编码的用户可见提示语（`CodexErr::ServerOverloaded`
+ * 上的 `#[error(...)]`，见 codex-rs/protocol/src/error.rs），不是 API 契约。
+ * codex 改一次措辞，靠它驱动的整套退避重投就**静默失效**：用户回到秒失败，日志
+ * 里没有任何东西指向原因，而用同一句文案写的测试仍然全绿。Cindy 捆绑 codex 并
+ * 跟着升级，所以这不是假想风险。结构化 tag 由 schema 承诺，不随文案漂移。
+ *
+ * 文案 pattern 仍然**保留**而不是删掉：远端可能跑着旧 daemon，Anthropic 侧也只有
+ * 文案和状态码可用。它从「唯一依据」降级为「兜底」。
  *
  * pattern 说明：capacity 要求 `at capacity` 精确短语，避免误伤业务文案里的
  * "capacity"（如缓存容量、队列容量）；overloaded 认 529 状态码与 Anthropic 的
@@ -46,7 +61,9 @@ export interface OverloadError {
 export function parseOverloadError(
   message: string,
   errorStatus?: number,
+  codexErrorInfoTag?: string,
 ): OverloadError | null {
+  if (codexErrorInfoTag === 'serverOverloaded') return { kind: 'capacity' };
   if (errorStatus === 529) return { kind: 'overloaded' };
   if (/\bat capacity\b/i.test(message)) return { kind: 'capacity' };
   if (/\boverloaded_error\b|\b529\b/.test(message)) return { kind: 'overloaded' };
@@ -54,8 +71,12 @@ export function parseOverloadError(
 }
 
 /** 是否是服务过载类错误。只需布尔判定时用这个，省掉解构。 */
-export function isOverloadErrorMessage(message: string, errorStatus?: number): boolean {
-  return parseOverloadError(message, errorStatus) !== null;
+export function isOverloadErrorMessage(
+  message: string,
+  errorStatus?: number,
+  codexErrorInfoTag?: string,
+): boolean {
+  return parseOverloadError(message, errorStatus, codexErrorInfoTag) !== null;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

#844 落地的上游过载自动退避重投，判定入口靠正则匹配英文文案：

```ts
if (/\bat capacity\b/i.test(message)) return { kind: 'capacity' };
```

`Selected model is at capacity. Please try a different model.` 是 codex 二进制里**硬编码的用户可见提示语**——`codex-rs/protocol/src/error.rs` 中 `CodexErr::ServerOverloaded` 变体上的 `#[error(...)]`。它是给人看的文案，不是 API 契约。

后果很具体：**codex 升级改一次措辞，整套退避重投就静默失效**。用户回到「秒失败」，日志里没有任何东西指向原因，而用同一句文案写的测试仍然全绿。Cindy 捆绑 codex 二进制并跟着升级（当前 0.145.0），所以这不是假想风险。

codex app-server 本来就在 error notification 里带了结构化标识 `error.codexErrorInfo`，过载对应字面量 `serverOverloaded`，由 schema 承诺（`codex-rs/app-server-protocol/schema/json/v2/ErrorNotification.json`）。**我们此前从没用过这个字段。**

本 PR 把消费过载语义的判定全部改成优先吃结构化标识，文案 pattern 从「唯一依据」降级为兜底。功能不变，换掉的是它依赖的那根绳子。

### 不变量与对称路径（收敛锚点）

一句话不变量：

> **凡是消费「上游过载」语义做判定的地方，都必须优先吃结构化标识，文案正则只作兜底。**

判定依据按**进程边界分层**（这是本 PR 的设计核心）：

- **main 侧**（与 maker-core 同 bundle）直接消费 error data，吃 codex 的原始 `codexErrorInfo` tag。
- **renderer 侧**隔着 IPC 投影拿不到 vendor tag，吃 maker-core 带上的稳定 key `UPSTREAM_OVERLOAD_REASON = 'upstream-overload'`。它不随 vendor 协议演进而变，也不用把 vendor 枚举搬进 renderer bundle。
- 稳定 key 走 `reason` 这个**既有通道**而非新增 state 字段：`reason` 本就是「maker-core 用稳定 key 告诉 renderer 这是什么错误」的现成语义（`empty-response` / `turn-failed` 同款），store 侧已随 error 一起清理，不必再引入一条平行清理链——那会有 14 个清理点，漏一处就让过载标记残留到下一条非过载错误上。

全部对称路径：

| 路径 | 判定 | 影响 | 依据 |
|---|---|---|---|
| `maker-core/shared/overload-error.ts` | `parseOverloadError` / `isOverloadErrorMessage` | agent 侧是否退避重投 | ✅ vendor tag |
| `maker-core/codex/translator.ts` | 重投接管主判定 | in-turn 重投 | ✅ vendor tag |
| `maker-core/codex/index.ts` | `idLessCapacityError` | 空 `turnId` 容量拒绝的归属 | ✅ vendor tag |
| `main/goal-host/usageLimit.ts` | `classifyTurnOverload` | **控制流**：60s 短窗口续跑 vs 判 blocked | ✅ vendor tag |
| `main/im/shared/turnRetryNotice.ts` | 三个渠道文案函数 | 渠道退避窗口内是否显示进度、终态是否退回裸英文 | ✅ vendor tag |
| `renderer/utils/overloadError.ts` + `ErrorBanner` | `isOverloadErrorMessage` | banner 本地化文案、重试进度、`hideRetry` | ✅ 稳定 reason key |
| `renderer/components/chat/ErrorMessageCard.tsx` | `ERROR_REASON_I18N_KEYS` | 历史静态错误卡的文案（与尾部红条保持一致） | ✅ 稳定 reason key（复用既有文案） |
| `mobile/session/remoteSessionStore.ts` | `parseReconnectAttemptMessage` | 手机端重试进度 | 不涉及：它只解析 `(auto-retry N/M)`，那是 maker-core 自己加的后缀，不随 codex 文案漂移 |
| `maker-core/claude-code/translator.ts` | Anthropic 529 / `overloaded_error` | — | 不涉及：无结构化标识可用 |

**上一轮我把 renderer 那行判为「不做」，依据是错的**（当时写「要改 desktop + mobile 共用的跨端投影协议」）。核实后：`recoverableError` 在 mobile 侧不存在，它是 desktop renderer store 的内部字段，mobile 的 `sessionTailBannerModel` 是独立实现。不需要改跨端协议，因此本轮补齐。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#988（现象来源：GPT-5.6 Sol 高/超高档秒失败）、#844（本次改的判定由它引入）
- 本 PR 包含：
  - `protocol.ts`：补 `CodexErrorInfo` 完整联合类型 + `codexErrorInfoTag()`；**修一个既存类型 bug**——`TurnError.codexErrorInfo` 原写成 `{ [k: string]: unknown } | null`，接不住实际值（纯枚举变体在 wire 上是字符串）。该字段此前无人消费，所以类型不准一直没暴露。对不认识的形状返回 `undefined` 而非猜测。
  - `overload-error.ts`：判定加结构化入参；新增稳定 key `UPSTREAM_OVERLOAD_REASON`。
  - `codex/translator.ts`：重投主判定接线；tag 透出到 error data（main 侧靠它判定）；过载错误一律带上稳定 reason key（renderer 靠它判定），非终止与终止两条路径都带。
  - `codex/index.ts`：`idLessCapacityError` 接线（漏判 = 整轮重投预算白给）。
  - `goal-host/usageLimit.ts`：`classifyTurnOverload` 接线。**控制流缺口**——漏判会让 `GoalController.finalizeTurn` 判 blocked 而非走 60s 短窗口续跑，可自愈的容量抖动变成需人工 resume 的死局。
  - `im/shared/turnRetryNotice.ts` + `hook-control/session-runner.ts`：三个渠道函数接线。漏判会让退避窗口（约 22-38s）内渠道消息一个字不动，终态说明退回裸英文原文。
  - renderer 链路：`utils/overloadError.ts` 判定加 reason 入参 + 镜像常量；`makerChatStore` 非终止分支透出 reason；`useCCAgentChat` 非终止态也透出 reason；`ErrorBanner` 判定吃 reason。漏判会让用户在整段重试窗口看到英文原文，而不是本地化的重试进度与过载引导。
- 明确不包含：
  - mobile 侧（见上表：它只解析 maker-core 自己加的 `(auto-retry N/M)` 后缀，不受 codex 文案漂移影响）。
  - Anthropic 一路（529 / `overloaded_error`）判定不动。
  - 不动 `translator.ts` 里 `errorStatus` 的推断链路——上面挂着 renderer 的 401 banner 与 auth 修复 UX。
- 用户可见变化：正常路径无变化。**codex 改过载文案后**的差异：banner 仍显示本地化的「模型服务繁忙，正在自动重试（N/M）」而不是英文原文；goal 仍自动续跑而不是判 blocked；渠道退避窗口内仍有进度提示。也就是把「将来会静默退化」提前修掉。
- 是否存在 breaking change：无。新增参数与 reason 均为可选/增量，缺席即回到原逻辑。

### UI 变化

- 引用的设计规范：**不涉及**：本 PR 未新增或修改任何视觉、布局、颜色、动效或 UI 文案。命中 UI 代码路径（`ErrorBanner.tsx` / `makerChatStore.ts` / `useCCAgentChat.ts` / `utils/overloadError.ts`）的改动只是**修正既有过载分支的触发条件**——banner 的过载样式与四语言文案都是 #844 已有的（`chat.errorBanner.overloadBusy` / `overloadBusyNoRetry`），本次没有改动它们，只是让它们在 codex 改文案后仍能正确命中。因此不涉及新的 Light/Dark 双模式实现（复用既有 themed 分支，未新增任何条件样式）。

### 后续项（不在本 PR，已通知维护者决定）

判定不变量已在本 PR 闭合——所有**做判定**的地方都吃结构化标识，文案只作兜底。剩下的是「哪些视图要**展示**本地化过载文案」，性质是 UI 覆盖面而非判定依据：

| 位置 | 缺什么 | 成本 |
|---|---|---|
| `apps/mobile/src/session/sessionTailBannerModel.ts` | 拿得到 `tail.reason`，但缺 mobile 侧四语言过载文案 | 新增 mobile i18n 文案 |
| `apps/mobile/src/session/InlineQueueSection.tsx` | 拿不到 reason——`AgentInputProjection.error` 只有 `string \| null` | 需扩跨端投影协议 |

这两处在 #844 之前和之后都显示上游原文，本 PR 未使其变差；mobile 的过载专属 UI 是 #844 当时有意未做的覆盖面。是否安排、以及是否值得为一条错误文案扩投影协议，属于覆盖面优先级判断，已单独通知仓库维护者。

边界事实：mobile 的**重试进度不受影响**——`remoteSessionStore.parseReconnectAttemptMessage` 解析的 `(auto-retry N/M)` 是 maker-core 自己追加的后缀，不随 codex 文案漂移；受影响的只有终态那条文案。

## 怎么验证的

### 自动验证

```text
bash ~/.claude/skills/git/scripts/run-unit-gate.sh <repo-root>
结果：全绿，零 FAIL（apps/desktop、apps/mobile、packages/maker-core 均 PASS）

pnpm --filter desktop run --if-present typecheck
结果：exit 0，零错误

pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/shared/overload-error.test.ts src/agents/codex/translator.test.ts
结果：Test Files 2 passed，Tests 77 passed

pnpm --filter desktop exec vitest run src/renderer/__tests__/overloadError.test.ts
结果：Test Files 1 passed，Tests 24 passed

pnpm --filter desktop exec vitest run \
  src/main/goal-host/__tests__/usageLimit.test.ts \
  src/main/im/shared/__tests__/turnRetryNotice.test.ts
结果：Test Files 2 passed，Tests 36 passed

# 改了 store / hook 的 errorReason 透出逻辑，跑受影响面确认未破坏既有行为
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts \
  src/renderer/components/chat/__tests__ src/renderer/hooks/__tests__
结果：Test Files 30 passed，Tests 263 passed

pnpm --filter @cindy/maker-core run build   # = tsc --noEmit，额外做的实际类型检查
结果：38 条 error TS，全部为 origin/main 上的预存在错误
      （已 stash 后在干净基线复现：基线 38 条、本分支 38 条、diff 无新增）
```

新增用例锁的都是「文案缺席时仍然判定」这个核心目标，每一层各有一组：

- `overload-error.test.ts`：tag 命中时不需要文案配合、tag 优先于 529、非过载 tag 不误触发、tag 缺席或不认识时退回文案。
- `codex/translator.test.ts`：改了文案措辞仍触发接管重投；tag 透出到 error data 且不干扰既有 `errorStatus` 推断；**过载错误在非终止与终止两条路径都带稳定 reason key**；非过载错误不得带该 key；对象形态 tag 取单键且不误判；老 daemon 无该字段时行为不变。
- `goal-host/usageLimit.test.ts`：tag 命中时不依赖文案（锁住「goal 走 60s 续跑而非 blocked」）；`usageLimitExceeded` / `contextWindowExceeded` / `responseStreamDisconnected` 不误判成过载。
- `im/shared/turnRetryNotice.test.ts`：三个函数各自的 tag 命中与非过载静默；含「只有 tag、没有 message」的空 payload 守卫。
- `renderer/__tests__/overloadError.test.ts`：reason key 命中时不依赖文案、优先于 529、其它 reason key（`silent-stop-exhausted` / `turn-failed` / `empty-response` / `app-exit-interrupted`）不误判、reason 缺席时退回文案（历史持久化错误行只有文案可用）。

**突变验证**（确认测试不是摆设）：

- 删掉 `parseOverloadError`（maker-core）里结构化优先那一行 → **4 个用例失败**。
- 删掉 `classifyTurnOverload` 里结构化优先那一行 → **1 个用例失败**。
- 两处恢复后全绿。

两侧镜像常量已核对逐字一致（`grep` 比对 maker-core 与 renderer 的 `UPSTREAM_OVERLOAD_REASON`）。

### 手工验证

不涉及。改动在正常路径无用户可见变化，而要观察到差异必须让上游真实返回 HTTP 503 + `server_is_overloaded`**且** codex 改掉文案，本地无法构造；正确性由上述分层单测（含端到端与突变验证）覆盖。

### 未执行的验证

- 未做真机过载复现：需要 OpenAI 侧真实容量拒绝，不可控。
- 未做 Light/Dark 实机目检：本次未新增或修改任何样式与文案（见「UI 变化」），复用 #844 既有的 themed 过载分支。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Codex error notification 路径，及其下游三层消费者（agent 侧重投、main 侧 goal/渠道分类、renderer banner）。协议侧是**只读消费** app-server 已有字段，不改任何出站请求参数，对 daemon 无兼容要求：老 daemon 不发 `codexErrorInfo` 时所有判定完整回退到原有文案 pattern。
- 需要特别注意的一处行为变更：`makerChatStore` 与 `useCCAgentChat` 现在会在**非终止** error 上透出 `errorReason`（此前恒清成 null）。核实过 codex 与 claude-code 两侧 translator：目前**没有任何非终止 error 带 reason**（claude 侧两处带 reason 的都是终止型），所以除本 PR 新增的过载 key 外取值仍是 null，行为等价。已用 263 例 store/hook/component 定向测试复核。
- 回滚 / 降级方式：revert 本 PR 的 commit 即可，无数据或状态残留。

### 核心指标评估

按 `docs/dev-rules/maker-core-and-agent-behavior.md` §3（改动落在 translator 路径，必须评估）：

- **缓存率**：不涉及。未动 prompt 拼接、tool / MCP 注册、请求前缀或其顺序。
- **性能**：不涉及。新增判定只在 error notification 路径执行（每 turn 最多数次），不在每 token 的 delta 热路径；实现是字符串比较 + 单次 `Object.keys`，无同步 IO、深拷贝或回溯正则。
- **返回内容准确性**：不涉及。translator 只新增 error data 字段（`codexErrorInfo` / 过载时的 `reason`），未改 `AgentEvent` 类型、事件顺序或合并语义；model 路由未触及。
- **system prompt**：未触及。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（命中 UI 路径但无视觉/文案变化，已按规范写明理由）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（分层依据与「为什么不能只靠文案」写进了 maker-core / main / renderer 各侧的注释，两侧镜像常量互相指向）
- [x] 已确认测试结果或说明未执行原因
