### PR TITLE
fix(desktop): make browser comments resilient to WebView lifecycle

### DIFF
--- a/apps/desktop/src/preload/__tests__/browserCommentPreload.test.ts
+++ b/apps/desktop/src/preload/__tests__/browserCommentPreload.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BROWSER_COMMENT_COMMAND_RESULT_CHANNEL,
+  BROWSER_COMMENT_ENTER_MODE_CHANNEL,
+  BROWSER_COMMENT_EXIT_MODE_CHANNEL,
+  BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
+  type BrowserCommentCommandEnvelope,
+  type BrowserCommentCommandResult,
+} from '../../shared/browserComment';
+
+type IpcHandler = (event: unknown, payload: unknown) => void;
+
+const ipcMocks = vi.hoisted(() => ({
+  listeners: new Map<string, IpcHandler>(),
+  sendToHost: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    on: vi.fn((channel: string, handler: IpcHandler) => {
+      ipcMocks.listeners.set(channel, handler);
+    }),
+    sendToHost: ipcMocks.sendToHost,
+  },
+}));
+
+async function loadPreload(): Promise<void> {
+  vi.resetModules();
+  await import('../browserCommentPreload');
+}
+
+function dispatchCommand(command: string, envelope: BrowserCommentCommandEnvelope): void {
+  const handler = ipcMocks.listeners.get(command);
+  if (!handler) throw new Error(`missing preload handler: ${command}`);
+  handler({}, envelope);
+}
+
+async function expectCommandResult(
+  requestId: string,
+  ok: boolean,
+): Promise<BrowserCommentCommandResult> {
+  await vi.waitFor(() => {
+    expect(ipcMocks.sendToHost).toHaveBeenCalledWith(
+      BROWSER_COMMENT_COMMAND_RESULT_CHANNEL,
+      expect.objectContaining({ requestId, ok }),
+    );
+  });
+  const match = ipcMocks.sendToHost.mock.calls.find(
+    ([channel, result]) =>
+      channel === BROWSER_COMMENT_COMMAND_RESULT_CHANNEL &&
+      (result as BrowserCommentCommandResult).requestId === requestId,
+  );
+  return match?.[1] as BrowserCommentCommandResult;
+}
+
+describe('browserCommentPreload command protocol', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    ipcMocks.listeners.clear();
+    ipcMocks.sendToHost.mockReset();
+  });
+
+  it('acknowledges enter and exit only after the guest command succeeds', async () => {
+    await loadPreload();
+
+    dispatchCommand(BROWSER_COMMENT_ENTER_MODE_CHANNEL, {
+      requestId: 'enter-1',
+      payload: { markerNumber: 1 },
+    });
+    expect(await expectCommandResult('enter-1', true)).toMatchObject({
+      command: BROWSER_COMMENT_ENTER_MODE_CHANNEL,
+    });
+
+    dispatchCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL, {
+      requestId: 'exit-1',
+    });
+    expect(await expectCommandResult('exit-1', true)).toMatchObject({
+      command: BROWSER_COMMENT_EXIT_MODE_CHANNEL,
+    });
+  });
+
+  it('rejects malformed enter commands instead of silently entering a divergent state', async () => {
+    await loadPreload();
+
+    dispatchCommand(BROWSER_COMMENT_ENTER_MODE_CHANNEL, {
+      requestId: 'enter-invalid',
+      payload: { markerNumber: 0 },
+    });
+
+    expect(await expectCommandResult('enter-invalid', false)).toMatchObject({
+      command: BROWSER_COMMENT_ENTER_MODE_CHANNEL,
+    });
+  });
+
+  it('rejects screenshot preparation when there is no pending marker', async () => {
+    await loadPreload();
+
+    dispatchCommand(BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL, {
+      requestId: 'prepare-without-pending',
+      payload: { validMarkerNumbers: [] },
+    });
+
+    expect(await expectCommandResult('prepare-without-pending', false)).toMatchObject({
+      command: BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
+    });
+  });
+});

--- a/apps/desktop/src/preload/__tests__/browserCommentPreload.test.ts
+++ b/apps/desktop/src/preload/__tests__/browserCommentPreload.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   BROWSER_COMMENT_COMMAND_RESULT_CHANNEL,
+  BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL,
   BROWSER_COMMENT_ENTER_MODE_CHANNEL,
   BROWSER_COMMENT_EXIT_MODE_CHANNEL,
   BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
@@ -17,6 +18,8 @@ const ipcMocks = vi.hoisted(() => ({
   listeners: new Map<string, IpcHandler>(),
   sendToHost: vi.fn(),
 }));
+
+let latestOverlayShadow: ShadowRoot | null = null;
 
 vi.mock('electron', () => ({
   ipcRenderer: {
@@ -61,6 +64,20 @@ describe('browserCommentPreload command protocol', () => {
     document.body.replaceChildren();
     ipcMocks.listeners.clear();
     ipcMocks.sendToHost.mockReset();
+    latestOverlayShadow = null;
+    const attachShadow = Element.prototype.attachShadow;
+    vi.spyOn(Element.prototype, 'attachShadow').mockImplementation(function (
+      this: Element,
+      init: ShadowRootInit,
+    ) {
+      const shadow = attachShadow.call(this, init);
+      latestOverlayShadow = shadow;
+      return shadow;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('acknowledges enter and exit only after the guest command succeeds', async () => {
@@ -106,5 +123,48 @@ describe('browserCommentPreload command protocol', () => {
     expect(await expectCommandResult('prepare-without-pending', false)).toMatchObject({
       command: BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
     });
+  });
+
+  it('keeps the transparent input blocker active while preparing a pending screenshot', async () => {
+    const target = document.createElement('button');
+    target.textContent = 'Save';
+    document.body.appendChild(target);
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: vi.fn(() => [target]),
+    });
+    await loadPreload();
+
+    dispatchCommand(BROWSER_COMMENT_ENTER_MODE_CHANNEL, {
+      requestId: 'enter-for-prepare',
+      payload: { markerNumber: 1 },
+    });
+    await expectCommandResult('enter-for-prepare', true);
+
+    const blocker = latestOverlayShadow?.querySelector<HTMLElement>('.blocker');
+    expect(blocker).not.toBeNull();
+    blocker?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, clientX: 20, clientY: 30 }),
+    );
+    await vi.waitFor(() => {
+      expect(ipcMocks.sendToHost).toHaveBeenCalledWith(
+        BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL,
+        expect.objectContaining({ markerNumber: 1 }),
+      );
+    });
+
+    dispatchCommand(BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL, {
+      requestId: 'prepare-pending',
+      payload: { validMarkerNumbers: [] },
+    });
+    await expectCommandResult('prepare-pending', true);
+
+    expect(blocker?.style.display).not.toBe('none');
+    expect(latestOverlayShadow?.querySelector<HTMLElement>('.highlight')?.style.display).toBe(
+      'none',
+    );
+    expect(latestOverlayShadow?.querySelector<HTMLElement>('.drag-rect')?.style.display).toBe(
+      'none',
+    );
   });
 });

--- a/apps/desktop/src/preload/browserCommentPreload.ts
+++ b/apps/desktop/src/preload/browserCommentPreload.ts
@@ -993,11 +993,22 @@ function exitMode(): void {
   state = null;
 }
 
-/** 恢复交互层可见 + crosshair(prepare-screenshot 之后 commit / cancel 共用)。 */
+/** 恢复点选态的 crosshair 与输入拦截(commit / cancel 共用)。 */
 function showInteraction(): void {
   if (!state) return;
   state.blocker.style.display = 'block';
   state.blocker.style.cursor = 'crosshair';
+}
+
+/**
+ * 截图只需要隐藏会留下像素的临时交互反馈。透明 blocker 必须继续接管输入：
+ * capture / cache 失败时 host 会保留 pending Popover，若这里释放 pointer events，
+ * 底层网页会在评论仍待处理时直接响应点击，造成 host / guest 交互语义分叉。
+ */
+function hideTransientInteractionVisuals(): void {
+  if (!state) return;
+  state.highlight.style.display = 'none';
+  state.dragRect.style.display = 'none';
 }
 
 /** 取消当前 pending:marker 与附加可视整组撤除,样式预览还原,回到点选状态。 */
@@ -1065,9 +1076,7 @@ async function prepareScreenshot(payload?: BrowserCommentPrepareScreenshotPayloa
     });
     pruneCommittedDesignForInvalidMarkers(valid);
   }
-  state.blocker.style.display = 'none';
-  state.highlight.style.display = 'none';
-  state.dragRect.style.display = 'none';
+  hideTransientInteractionVisuals();
   await new Promise<void>((resolve) => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => resolve());

--- a/apps/desktop/src/preload/browserCommentPreload.ts
+++ b/apps/desktop/src/preload/browserCommentPreload.ts
@@ -27,6 +27,7 @@ import { ipcRenderer } from 'electron';
 
 import {
   BROWSER_COMMENT_CANCEL_PENDING_CHANNEL,
+  BROWSER_COMMENT_COMMAND_RESULT_CHANNEL,
   BROWSER_COMMENT_COMMIT_PENDING_CHANNEL,
   BROWSER_COMMENT_DESIGN_PREVIEW_CHANNEL,
   BROWSER_COMMENT_DESIGN_PROPS,
@@ -36,7 +37,9 @@ import {
   BROWSER_COMMENT_EXIT_MODE_CHANNEL,
   BROWSER_COMMENT_MODE_EXITED_CHANNEL,
   BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
-  BROWSER_COMMENT_SCREENSHOT_PREPARED_CHANNEL,
+  type BrowserCommentCommandChannel,
+  type BrowserCommentCommandEnvelope,
+  type BrowserCommentCommandResult,
   type BrowserCommentCommitPendingPayload,
   type BrowserCommentDesignBaseline,
   type BrowserCommentDesignPreviewPayload,
@@ -874,10 +877,10 @@ function trySelectExistingTextSelection(): boolean {
 
 function enterMode(payload: BrowserCommentEnterModePayload): void {
   exitMode(); // 幂等:重复 enter 先拆旧的。
-  const markerNumber =
-    Number.isInteger(payload?.markerNumber) && payload.markerNumber > 0
-      ? payload.markerNumber
-      : 1;
+  if (!Number.isInteger(payload?.markerNumber) || payload.markerNumber <= 0) {
+    throw new Error('invalid marker number');
+  }
+  const markerNumber = payload.markerNumber;
   state = buildOverlay(markerNumber);
   const s = state;
   syncDocLayerScroll();
@@ -1015,7 +1018,7 @@ function cancelPending(): void {
 /** 提交成功:pending marker 转常驻(附加可视撤除),样式预览转入 committed
  *  组保留在页面上(与截图所见一致),编号推进,继续点选。 */
 function commitPending(payload: BrowserCommentCommitPendingPayload): void {
-  if (!state) return;
+  if (!state?.pending) throw new Error('missing pending comment');
   // 设计预览记录打上归属评论编号:截图前对账时,归属已删除 chip 的预览
   // 要与常驻 marker 一起被剪除 / 还原。
   const commitNumber = state.pending?.number;
@@ -1045,12 +1048,10 @@ function commitPending(payload: BrowserCommentCommitPendingPayload): void {
 
 /** 截图前置:隐藏交互 UI,保留有效标注(常驻 marker 先按草稿白名单对账剪除
  *  + pending 组);两帧后回执。 */
-function prepareScreenshot(payload?: BrowserCommentPrepareScreenshotPayload): void {
-  if (!state) {
-    // 模式已丢(页面刚导航等)—— 仍回执,host 侧靠超时/空图兜底。
-    ipcRenderer.sendToHost(BROWSER_COMMENT_SCREENSHOT_PREPARED_CHANNEL);
-    return;
-  }
+async function prepareScreenshot(payload?: BrowserCommentPrepareScreenshotPayload): Promise<void> {
+  // 没有 pending 时截图不可能代表 host 正在提交的评论。明确失败，让 host
+  // 保留输入并等待用户重试；不能回一张无 marker 的“成功”截图。
+  if (!state?.pending) throw new Error('missing pending comment');
   // 对账:composer 里 chip 被单删 / 清空 / 随发送清草稿后,对应常驻 marker
   // 已无 `## Comment N` 块与之对应,截图前剪除,防孤儿 / 重号 marker 入图;
   // 归属这些评论的样式 / 文本预览同步还原(或做原值链拼接),防止截图展示
@@ -1067,51 +1068,60 @@ function prepareScreenshot(payload?: BrowserCommentPrepareScreenshotPayload): vo
   state.blocker.style.display = 'none';
   state.highlight.style.display = 'none';
   state.dragRect.style.display = 'none';
-  requestAnimationFrame(() => {
+  await new Promise<void>((resolve) => {
     requestAnimationFrame(() => {
-      ipcRenderer.sendToHost(BROWSER_COMMENT_SCREENSHOT_PREPARED_CHANNEL);
+      requestAnimationFrame(() => resolve());
     });
   });
 }
 
 // ── 入口:只注册监听,零 DOM 副作用 ─────────────────────────────────────────
 
-ipcRenderer.on(BROWSER_COMMENT_ENTER_MODE_CHANNEL, (_e, payload) => {
-  try {
-    enterMode(payload as BrowserCommentEnterModePayload);
-  } catch {
-    // guest 页面环境千奇百怪(CSP 不拦 preload,但 DOM 可能被页面脚本魔改),
-    // 任何异常都不能溢出到页面 console 之外的行为。
-  }
-});
-ipcRenderer.on(BROWSER_COMMENT_EXIT_MODE_CHANNEL, () => {
-  try {
-    exitMode();
-  } catch {
-    // see above
-  }
-});
-ipcRenderer.on(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL, () => {
-  try {
-    cancelPending();
-  } catch {
-    // see above
-  }
-});
-ipcRenderer.on(BROWSER_COMMENT_COMMIT_PENDING_CHANNEL, (_e, payload) => {
-  try {
-    commitPending(payload as BrowserCommentCommitPendingPayload);
-  } catch {
-    // see above
-  }
-});
-ipcRenderer.on(BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL, (_e, payload) => {
-  try {
-    prepareScreenshot(payload as BrowserCommentPrepareScreenshotPayload | undefined);
-  } catch {
-    // see above
-  }
-});
+/**
+ * 注册一条带 request/ack 的关键命令。handler 可以等待动画帧；无论同步异常还是
+ * Promise rejection 都只向 host 返回 ok=false，不把不可信页面的错误细节带出去。
+ */
+function registerCommand<T>(
+  command: BrowserCommentCommandChannel,
+  handler: (payload: T) => void | Promise<void>,
+): void {
+  ipcRenderer.on(command, (_e, rawEnvelope) => {
+    const envelope = rawEnvelope as BrowserCommentCommandEnvelope<T> | undefined;
+    if (!envelope || typeof envelope.requestId !== 'string' || !envelope.requestId) return;
+    void Promise.resolve()
+      .then(() => handler(envelope.payload as T))
+      .then(
+        () => {
+          const result: BrowserCommentCommandResult = {
+            requestId: envelope.requestId,
+            command,
+            ok: true,
+          };
+          ipcRenderer.sendToHost(BROWSER_COMMENT_COMMAND_RESULT_CHANNEL, result);
+        },
+        () => {
+          const result: BrowserCommentCommandResult = {
+            requestId: envelope.requestId,
+            command,
+            ok: false,
+          };
+          ipcRenderer.sendToHost(BROWSER_COMMENT_COMMAND_RESULT_CHANNEL, result);
+        },
+      );
+  });
+}
+
+registerCommand<BrowserCommentEnterModePayload>(BROWSER_COMMENT_ENTER_MODE_CHANNEL, enterMode);
+registerCommand<void>(BROWSER_COMMENT_EXIT_MODE_CHANNEL, exitMode);
+registerCommand<void>(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL, cancelPending);
+registerCommand<BrowserCommentCommitPendingPayload>(
+  BROWSER_COMMENT_COMMIT_PENDING_CHANNEL,
+  commitPending,
+);
+registerCommand<BrowserCommentPrepareScreenshotPayload | undefined>(
+  BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
+  prepareScreenshot,
+);
 ipcRenderer.on(BROWSER_COMMENT_DESIGN_PREVIEW_CHANNEL, (_e, payload) => {
   try {
     applyDesignPreview(payload as BrowserCommentDesignPreviewPayload);

--- a/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
@@ -4,10 +4,9 @@
  * UpdateNoticeDialog 的 auto 布局契约。
  *
  * 装完后的自动公告走这条布局,UpdateBanner 的「装前预览」也刻意复用它(见 useUpdateNotice
- * 的 onOpenVersion)。所以这个文件既是既有行为的回归护栏,也是新入口渲染形态的说明
- * (#956 单栏版式之后,版本徽标与日期都在各版本自己的 block 里,header 不再有 range 徽标):
- *   - 单版本:block 徽标 v<版本> + 日期,header 右侧无版本数
- *   - 跨版本:header 右侧是版本数,每个 block 各有自己的 v<版本> 徽标
+ * 的 onOpenVersion)。所以这个文件既是既有行为的回归护栏,也是新入口渲染形态的说明:
+ *   - 单版本:右上角是该版本日期,徽标 v<版本>
+ *   - 跨版本:右上角是版本数,每个版本内容块各自展示 v<版本> 徽标
  * 两种情况都没有版本跳转器、没有懒加载占位块。
  *
  * 弹窗本身在本次改动里一行未改;这里锁住的是「预览入口依赖的那部分不能被顺手清理掉」。
@@ -83,15 +82,12 @@ describe('UpdateNoticeDialog auto layout', () => {
     ).toBeTruthy();
   });
 
-  it('multiple versions: version count on the right, per-block badges, span aria', () => {
+  it('multiple versions: version count on the right, per-version badges, span aria', () => {
     renderAuto([NEWEST, OLDER]);
 
     expect(screen.getByText('update.notice.versionsSpan(count=2)')).toBeTruthy();
-    // #956 的单栏版式把 header 的「v<旧> → v<新>」range 徽标撤掉了:版本身份
-    // 落在每个版本自己的 block 徽标上,header 右侧只剩版本数。
     expect(screen.getByText('v0.1.21')).toBeTruthy();
     expect(screen.getByText('v0.1.20')).toBeTruthy();
-    expect(screen.queryByText('v0.1.20 → v0.1.21')).toBeNull();
     expect(
       screen.getByText('update.notice.ariaDescriptionSpan(from=0.1.20,count=2)'),
     ).toBeTruthy();

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
@@ -158,6 +158,7 @@ describe('useBrowserWebview', () => {
 
     expect(acquire).not.toHaveBeenCalled();
     expect(result!.wrapper).toBeNull();
+    expect(result!.webview).toBeNull();
   });
 
   it('does not materialize a hidden tab until it becomes visible', async () => {
@@ -177,6 +178,7 @@ describe('useBrowserWebview', () => {
 
     expect(acquire).toHaveBeenCalledTimes(1);
     expect(result!.wrapper).not.toBeNull();
+    expect(result!.webview).toBe(mockWebview);
   });
 
   it('touches an existing entry through acquire when it becomes visible', async () => {
@@ -196,6 +198,7 @@ describe('useBrowserWebview', () => {
 
     expect(browserWebviewPool.acquire).toHaveBeenCalledOnce();
     expect(result!.wrapper).toBe(existing.wrapper);
+    expect(result!.webview).toBe(mockWebview);
   });
 
   it('observes an entry explicitly created while hidden without navigating it', async () => {
@@ -212,6 +215,7 @@ describe('useBrowserWebview', () => {
 
     expect(browserWebviewPool.acquire).toHaveBeenCalledOnce();
     expect(result!.wrapper).toBeNull();
+    expect(result!.webview).toBe(mockWebview);
     expect(mockWebview.addEventListener).toHaveBeenCalledWith(
       'render-process-gone',
       expect.any(Function),
@@ -435,6 +439,7 @@ describe('useBrowserWebview', () => {
     );
     expect(acquire).toHaveBeenCalledTimes(1);
     const firstWrapper = result!.wrapper;
+    const firstWebview = result!.webview;
 
     act(() => {
       for (let i = 0; i <= BROWSER_NAVIGATION_FUSE_LIMIT; i += 1) {
@@ -450,6 +455,7 @@ describe('useBrowserWebview', () => {
     // 后台淘汰(资源看门狗 / LRU):entry 被 release,不可见期间不得重建。
     act(() => poolMocks.fireRelease('tab-a'));
     expect(acquire).toHaveBeenCalledTimes(1);
+    expect(result!.webview).toBeNull();
 
     // 重新可见 → 重新 acquire,拿到新一代 entry,观测 state 复位。
     mockWebview = makeMockWebview('');
@@ -458,6 +464,8 @@ describe('useBrowserWebview', () => {
     );
     expect(acquire).toHaveBeenCalledTimes(2);
     expect(result!.wrapper).not.toBe(firstWrapper);
+    expect(result!.webview).not.toBe(firstWebview);
+    expect(result!.webview).toBe(mockWebview);
     expect(result!.url).toBe('');
     expect(result!.crash).toBeNull();
 

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
@@ -55,6 +55,12 @@ function isSameNavigationUrl(a: string, b: string): boolean {
 export interface UseBrowserWebviewResult {
   /** webview 外层 wrapper DOM;caller appendChild 到自己的 body slot。 */
   wrapper: HTMLDivElement | null;
+  /**
+   * 当前 Pool entry 的 WebView 代际句柄。隐藏但仍由 Pool 保活时保持非空；
+   * entry 被淘汰 / 释放时变 null，重建后变为新的对象。依赖 guest 事件或
+   * 通信的功能必须以它为 effect dependency，不能只按 tabId 绑定。
+   */
+  webview: WebviewTag | null;
   /** 当前页面 URL(`did-navigate` / `did-navigate-in-page` 同步)。 */
   url: string;
   /** 当前页面 title(`page-title-updated`)。 */
@@ -485,11 +491,14 @@ export function useBrowserWebview(
     }
   }, []);
   const dismissResourceAlert = useCallback(() => setResourceAlert(null), []);
+  const currentEntry = browserWebviewPool.peek(tabId);
+  const currentWebview = currentEntry?.wrapper === wrapper ? currentEntry.webview : null;
 
   return {
     // 隐藏时仍观察已有 entry 的 guest 生命周期，但不把 wrapper 交给 caller，
     // 避免隐藏 Body 把它移出停车区并触发首次导航。
     wrapper: visible === true ? wrapper : null,
+    webview: currentWebview,
     url,
     title,
     favicon,

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserCommentPopover.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserCommentPopover.tsx
@@ -34,6 +34,7 @@ import {
   type BrowserCommentDesignPreviewPayload,
   type BrowserCommentStyleChange,
 } from '../../../../../shared/browserComment';
+import type { BrowserCommentEditorDraft } from './browserCommentEditorDraft';
 
 interface BrowserCommentPopoverProps {
   /** 锚点(slot 内坐标,px)。 */
@@ -41,6 +42,9 @@ interface BrowserCommentPopoverProps {
   submitting: boolean;
   /** 样式编辑基线(元素点选才有;null = 不显示样式编辑入口)。 */
   designBaseline: BrowserCommentDesignBaseline | null;
+  /** 由稳定的 Host 控制器持有，避免 WebView LRU 换代卸载气泡时丢失输入。 */
+  editorDraft: BrowserCommentEditorDraft;
+  onEditorDraftChange: (draft: BrowserCommentEditorDraft) => void;
   onSubmit: (text: string, styleChanges?: BrowserCommentStyleChange[]) => void;
   onCancel: () => void;
   /** 样式编辑实时预览(全量当前编辑状态)。 */
@@ -105,17 +109,17 @@ export function BrowserCommentPopover({
   anchor,
   submitting,
   designBaseline,
+  editorDraft,
+  onEditorDraftChange,
   onSubmit,
   onCancel,
   onPreviewDesign,
   onResetDesign,
 }: BrowserCommentPopoverProps) {
   const { t } = useTranslation();
-  const [text, setText] = useState('');
-  // 样式编辑状态:只存"被用户改过"的属性(与 baseline 的 diff)。
+  // 展开 / 收起只影响本次挂载的布局；真正的文本与样式草稿由 Host 控制器持有。
   const [showStyles, setShowStyles] = useState(false);
-  const [styleEdits, setStyleEdits] = useState<Record<string, string>>({});
-  const [textEdit, setTextEdit] = useState<string | null>(null);
+  const { text, styleEdits, textEdit } = editorDraft;
   const rootRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   // 初始按锚点下方摆;useLayoutEffect 量完实际尺寸后 clamp,一次到位。
@@ -187,28 +191,32 @@ export function BrowserCommentPopover({
 
   const setStyleEdit = useCallback(
     (property: string, value: string) => {
-      setStyleEdits((prev) => {
-        const next = { ...prev, [property]: value };
-        pushPreview(next, textEdit);
-        return next;
+      const next = { ...styleEdits, [property]: value };
+      onEditorDraftChange({
+        ...editorDraft,
+        styleEdits: next,
       });
+      pushPreview(next, textEdit);
     },
-    [pushPreview, textEdit],
+    [editorDraft, onEditorDraftChange, pushPreview, styleEdits, textEdit],
   );
 
   const handleTextEdit = useCallback(
     (value: string) => {
-      setTextEdit(value);
+      onEditorDraftChange({ ...editorDraft, textEdit: value });
       pushPreview(styleEdits, value);
     },
-    [pushPreview, styleEdits],
+    [editorDraft, onEditorDraftChange, pushPreview, styleEdits],
   );
 
   const handleResetStyles = useCallback(() => {
-    setStyleEdits({});
-    setTextEdit(null);
+    onEditorDraftChange({
+      ...editorDraft,
+      styleEdits: {},
+      textEdit: null,
+    });
     onResetDesign();
-  }, [onResetDesign]);
+  }, [editorDraft, onEditorDraftChange, onResetDesign]);
 
   const changes = buildChanges();
   const canSubmit = (text.trim().length > 0 || changes.length > 0) && !submitting;
@@ -249,7 +257,7 @@ export function BrowserCommentPopover({
       <textarea
         ref={textareaRef}
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => onEditorDraftChange({ ...editorDraft, text: e.target.value })}
         onKeyDown={handleKeyDown}
         rows={3}
         disabled={submitting}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserCommentPopover.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserCommentPopover.tsx
@@ -154,10 +154,14 @@ export function BrowserCommentPopover({
   const buildChanges = useCallback((): BrowserCommentStyleChange[] => {
     if (!designBaseline) return [];
     const changes: BrowserCommentStyleChange[] = [];
-    if (textEdit !== null && textEdit !== (designBaseline.editableText ?? '')) {
+    if (
+      designBaseline.editableText !== null &&
+      textEdit !== null &&
+      textEdit !== designBaseline.editableText
+    ) {
       changes.push({
         property: 'text content',
-        previousValue: designBaseline.editableText ?? '',
+        previousValue: designBaseline.editableText,
         value: textEdit,
       });
     }
@@ -183,11 +187,23 @@ export function BrowserCommentPopover({
         }
       }
       const textChanged =
-        nextText !== null && nextText !== (designBaseline.editableText ?? '');
+        designBaseline.editableText !== null &&
+        nextText !== null &&
+        nextText !== designBaseline.editableText;
       onPreviewDesign({ styles, text: textChanged ? nextText : null });
     },
     [designBaseline, onPreviewDesign],
   );
+
+  /**
+   * LRU 恢复草稿可能绑定到一个包含子元素、不能安全改写 textContent 的新
+   * target。此时旧 textEdit 与新 baseline 不兼容：预览必须发 null，并从
+   * Host 草稿中删除该字段，避免稍后提交虚假的文本变更或破坏子 DOM。
+   */
+  useEffect(() => {
+    if (!designBaseline || designBaseline.editableText !== null || textEdit === null) return;
+    onEditorDraftChange({ ...editorDraft, textEdit: null });
+  }, [designBaseline, editorDraft, onEditorDraftChange, textEdit]);
 
   /**
    * 预览由受控草稿派生，而不是只在 input handler 内发送。这样 WebView LRU

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserCommentPopover.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserCommentPopover.tsx
@@ -21,7 +21,7 @@
  * useLayoutEffect(paint 前),不会闪一帧再跳位(规则 7)。
  */
 
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { SlidersHorizontal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -189,6 +189,15 @@ export function BrowserCommentPopover({
     [designBaseline, onPreviewDesign],
   );
 
+  /**
+   * 预览由受控草稿派生，而不是只在 input handler 内发送。这样 WebView LRU
+   * 换代后，Popover 绑定新 target 的首次挂载也会自动重放恢复的文本 / CSS
+   * 编辑，保证页面截图与最终提交的 styleChanges 始终一致。
+   */
+  useEffect(() => {
+    pushPreview(styleEdits, textEdit);
+  }, [pushPreview, styleEdits, textEdit]);
+
   const setStyleEdit = useCallback(
     (property: string, value: string) => {
       const next = { ...styleEdits, [property]: value };
@@ -196,17 +205,15 @@ export function BrowserCommentPopover({
         ...editorDraft,
         styleEdits: next,
       });
-      pushPreview(next, textEdit);
     },
-    [editorDraft, onEditorDraftChange, pushPreview, styleEdits, textEdit],
+    [editorDraft, onEditorDraftChange, styleEdits],
   );
 
   const handleTextEdit = useCallback(
     (value: string) => {
       onEditorDraftChange({ ...editorDraft, textEdit: value });
-      pushPreview(styleEdits, value);
     },
-    [editorDraft, onEditorDraftChange, pushPreview, styleEdits],
+    [editorDraft, onEditorDraftChange],
   );
 
   const handleResetStyles = useCallback(() => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
@@ -361,7 +361,7 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
   // (SidebarWindowLayout)只挂 RightSidebarShell、不挂 ChatInput,评论写进
   // 子窗口自己的 composerDraftStore 无处可发(还会误报成功 toast),故子窗口里
   // 不提供评论入口。内嵌侧栏(主窗)与副窗口(MainLayout,自带 composer)不受影响。
-  const commentSupported = !isSidebarWindow() && Boolean(sessionId);
+  const commentSupported = !isSidebarWindow() && Boolean(sessionId) && Boolean(browser.webview);
 
   // 崩溃恢复 —— banner 上的 "重新加载" 按钮:对 unresponsive 走 reload(让 guest
   // 主线程被打断重启),对 crashed/killed/oom 走 navigate(等价于 reload,但能
@@ -508,6 +508,8 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
               anchor={comment.pendingTarget.point}
               submitting={comment.mode === 'submitting'}
               designBaseline={comment.pendingTarget.designBaseline}
+              editorDraft={comment.editorDraft}
+              onEditorDraftChange={comment.updateEditorDraft}
               onSubmit={comment.submit}
               onCancel={comment.cancelPending}
               onPreviewDesign={comment.previewDesign}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
@@ -502,11 +502,13 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
           </div>
         )}
         {/* 评论输入气泡:锚在 guest 上报的点选坐标。 */}
-        {(comment.mode === 'pending' || comment.mode === 'submitting') &&
+        {(comment.mode === 'pending' ||
+          comment.mode === 'cancelling' ||
+          comment.mode === 'submitting') &&
           comment.pendingTarget && (
             <BrowserCommentPopover
               anchor={comment.pendingTarget.point}
-              submitting={comment.mode === 'submitting'}
+              submitting={comment.mode !== 'pending'}
               designBaseline={comment.pendingTarget.designBaseline}
               editorDraft={comment.editorDraft}
               onEditorDraftChange={comment.updateEditorDraft}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
@@ -356,12 +356,12 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
   const pageUrlRef = useRef(browser.url || state.url || 'about:blank');
   pageUrlRef.current = browser.url || state.url || 'about:blank';
   const getPageUrl = useCallback(() => pageUrlRef.current, []);
-  const comment = useBrowserComment(tabId, sessionId, getPageUrl);
+  const comment = useBrowserComment(tabId, sessionId, browser.webview, getPageUrl);
   // 页面评论的落点是主窗 composer 的「N 条注释」胶囊。detached 独立子窗口
   // (SidebarWindowLayout)只挂 RightSidebarShell、不挂 ChatInput,评论写进
   // 子窗口自己的 composerDraftStore 无处可发(还会误报成功 toast),故子窗口里
   // 不提供评论入口。内嵌侧栏(主窗)与副窗口(MainLayout,自带 composer)不受影响。
-  const commentSupported = !isSidebarWindow();
+  const commentSupported = !isSidebarWindow() && Boolean(sessionId);
 
   // 崩溃恢复 —— banner 上的 "重新加载" 按钮:对 unresponsive 走 reload(让 guest
   // 主线程被打断重启),对 crashed/killed/oom 走 navigate(等价于 reload,但能

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserCommentPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserCommentPopover.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { BrowserCommentEditorDraft } from '../browserCommentEditorDraft';
+import { BrowserCommentPopover } from '../BrowserCommentPopover';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const EMPTY_DRAFT: BrowserCommentEditorDraft = {
+  text: '',
+  styleEdits: {},
+  textEdit: null,
+};
+
+describe('BrowserCommentPopover', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('writes comment text into the controlled Host draft', () => {
+    const onEditorDraftChange = vi.fn();
+    render(
+      <div>
+        <BrowserCommentPopover
+          anchor={{ x: 120, y: 80 }}
+          submitting={false}
+          designBaseline={null}
+          editorDraft={EMPTY_DRAFT}
+          onEditorDraftChange={onEditorDraftChange}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          onPreviewDesign={vi.fn()}
+          onResetDesign={vi.fn()}
+        />
+      </div>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('rightSidebar.browser.commentPlaceholder'), {
+      target: { value: 'Preserve this comment across WebView replacement' },
+    });
+
+    expect(onEditorDraftChange).toHaveBeenCalledWith({
+      text: 'Preserve this comment across WebView replacement',
+      styleEdits: {},
+      textEdit: null,
+    });
+  });
+
+  it('writes style text edits into the same controlled draft', () => {
+    const onEditorDraftChange = vi.fn();
+    const onPreviewDesign = vi.fn();
+    render(
+      <div>
+        <BrowserCommentPopover
+          anchor={{ x: 120, y: 80 }}
+          submitting={false}
+          designBaseline={{
+            styles: {},
+            editableText: 'Save',
+            provenance: {},
+          }}
+          editorDraft={EMPTY_DRAFT}
+          onEditorDraftChange={onEditorDraftChange}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          onPreviewDesign={onPreviewDesign}
+          onResetDesign={vi.fn()}
+        />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'rightSidebar.browser.styleTweaks' }));
+    fireEvent.change(screen.getByDisplayValue('Save'), {
+      target: { value: 'Save changes' },
+    });
+
+    expect(onEditorDraftChange).toHaveBeenCalledWith({
+      text: '',
+      styleEdits: {},
+      textEdit: 'Save changes',
+    });
+    expect(onPreviewDesign).toHaveBeenCalledWith({
+      styles: {},
+      text: 'Save changes',
+    });
+  });
+});

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserCommentPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserCommentPopover.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { BrowserCommentDesignBaseline } from '../../../../../../shared/browserComment';
 import type { BrowserCommentEditorDraft } from '../browserCommentEditorDraft';
 import { BrowserCommentPopover } from '../BrowserCommentPopover';
 
@@ -16,6 +18,38 @@ const EMPTY_DRAFT: BrowserCommentEditorDraft = {
   textEdit: null,
 };
 
+function ControlledPopover({
+  initialDraft = EMPTY_DRAFT,
+  designBaseline = null,
+  onEditorDraftChange = vi.fn(),
+  onPreviewDesign = vi.fn(),
+}: {
+  initialDraft?: BrowserCommentEditorDraft;
+  designBaseline?: BrowserCommentDesignBaseline | null;
+  onEditorDraftChange?: (draft: BrowserCommentEditorDraft) => void;
+  onPreviewDesign?: (payload: { styles: Record<string, string>; text: string | null }) => void;
+}) {
+  const [draft, setDraft] = useState(initialDraft);
+  return (
+    <div>
+      <BrowserCommentPopover
+        anchor={{ x: 120, y: 80 }}
+        submitting={false}
+        designBaseline={designBaseline}
+        editorDraft={draft}
+        onEditorDraftChange={(next) => {
+          onEditorDraftChange(next);
+          setDraft(next);
+        }}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        onPreviewDesign={onPreviewDesign}
+        onResetDesign={vi.fn()}
+      />
+    </div>
+  );
+}
+
 describe('BrowserCommentPopover', () => {
   afterEach(() => {
     cleanup();
@@ -24,21 +58,7 @@ describe('BrowserCommentPopover', () => {
 
   it('writes comment text into the controlled Host draft', () => {
     const onEditorDraftChange = vi.fn();
-    render(
-      <div>
-        <BrowserCommentPopover
-          anchor={{ x: 120, y: 80 }}
-          submitting={false}
-          designBaseline={null}
-          editorDraft={EMPTY_DRAFT}
-          onEditorDraftChange={onEditorDraftChange}
-          onSubmit={vi.fn()}
-          onCancel={vi.fn()}
-          onPreviewDesign={vi.fn()}
-          onResetDesign={vi.fn()}
-        />
-      </div>,
-    );
+    render(<ControlledPopover onEditorDraftChange={onEditorDraftChange} />);
 
     fireEvent.change(screen.getByPlaceholderText('rightSidebar.browser.commentPlaceholder'), {
       target: { value: 'Preserve this comment across WebView replacement' },
@@ -55,23 +75,15 @@ describe('BrowserCommentPopover', () => {
     const onEditorDraftChange = vi.fn();
     const onPreviewDesign = vi.fn();
     render(
-      <div>
-        <BrowserCommentPopover
-          anchor={{ x: 120, y: 80 }}
-          submitting={false}
-          designBaseline={{
-            styles: {},
-            editableText: 'Save',
-            provenance: {},
-          }}
-          editorDraft={EMPTY_DRAFT}
-          onEditorDraftChange={onEditorDraftChange}
-          onSubmit={vi.fn()}
-          onCancel={vi.fn()}
-          onPreviewDesign={onPreviewDesign}
-          onResetDesign={vi.fn()}
-        />
-      </div>,
+      <ControlledPopover
+        designBaseline={{
+          styles: {},
+          editableText: 'Save',
+          provenance: {},
+        }}
+        onEditorDraftChange={onEditorDraftChange}
+        onPreviewDesign={onPreviewDesign}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'rightSidebar.browser.styleTweaks' }));
@@ -87,6 +99,32 @@ describe('BrowserCommentPopover', () => {
     expect(onPreviewDesign).toHaveBeenCalledWith({
       styles: {},
       text: 'Save changes',
+    });
+  });
+
+  it('replays restored design edits when it binds to a replacement target', async () => {
+    const onPreviewDesign = vi.fn();
+    render(
+      <ControlledPopover
+        initialDraft={{
+          text: 'Keep the host comment',
+          styleEdits: { color: '#ff0000' },
+          textEdit: 'Save changes',
+        }}
+        designBaseline={{
+          styles: { color: 'rgb(0, 0, 0)' },
+          editableText: 'Save',
+          provenance: {},
+        }}
+        onPreviewDesign={onPreviewDesign}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onPreviewDesign).toHaveBeenCalledWith({
+        styles: { color: '#ff0000' },
+        text: 'Save changes',
+      });
     });
   });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserCommentPopover.test.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserCommentPopover.test.tsx
@@ -127,4 +127,37 @@ describe('BrowserCommentPopover', () => {
       });
     });
   });
+
+  it('drops a restored text edit when the replacement target is not safely editable', async () => {
+    const onEditorDraftChange = vi.fn();
+    const onPreviewDesign = vi.fn();
+    render(
+      <ControlledPopover
+        initialDraft={{
+          text: 'Keep the host comment',
+          styleEdits: { color: '#ff0000' },
+          textEdit: 'Do not replace child DOM',
+        }}
+        designBaseline={{
+          styles: { color: 'rgb(0, 0, 0)' },
+          editableText: null,
+          provenance: {},
+        }}
+        onEditorDraftChange={onEditorDraftChange}
+        onPreviewDesign={onPreviewDesign}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onEditorDraftChange).toHaveBeenCalledWith({
+        text: 'Keep the host comment',
+        styleEdits: { color: '#ff0000' },
+        textEdit: null,
+      });
+    });
+    expect(onPreviewDesign).toHaveBeenCalledWith({
+      styles: { color: '#ff0000' },
+      text: null,
+    });
+  });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
@@ -2,6 +2,7 @@
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { createElement, type ReactElement } from 'react';
+import type { WebviewTag } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { UseBrowserWebviewResult } from '../../../hooks/useBrowserWebview';
@@ -163,6 +164,27 @@ describe('BrowserTabBody navigation', () => {
     expect(sharedWrapper.isConnected).toBe(false);
     expect(replacement.isConnected).toBe(true);
     expect(replacement.parentElement).not.toBe(parking);
+  });
+
+  it('only exposes page comments while a WebView generation exists', () => {
+    browserState = makeBrowserState({ webview: null });
+    const view = render(renderBrowserTab('https://www.taptap.cn/'));
+
+    expect(
+      screen.queryByRole('button', { name: 'rightSidebar.browser.comment' }),
+    ).toBeNull();
+
+    const webview = {
+      send: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as WebviewTag;
+    browserState = makeBrowserState({ webview });
+    view.rerender(renderBrowserTab('https://www.taptap.cn/'));
+
+    expect(
+      screen.getByRole('button', { name: 'rightSidebar.browser.comment' }),
+    ).toBeTruthy();
   });
 
   it('does not patch the old webview URL back over a user-entered navigation while loading', () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
@@ -28,9 +28,8 @@ vi.mock('../../../hooks/useBrowserWebview', () => ({
 vi.mock('../../../lib/browserWebviewPool', () => ({
   browserWebviewPool: {
     release: vi.fn(),
-    // BrowserTabBody 还会调用 useBrowserComment；该 hook 经 peek 获取 webview
-    // 并监听 ipc-message。导航测试没有真 webview，wrapper 仅用于验证 layout
-    // cleanup 的 Pool 代际归属。
+    // Navigation tests do not create a real WebView. The wrapper is only used
+    // to verify that layout cleanup respects the current Pool generation.
     peek: vi.fn(() => poolMocks.currentWrapper
       ? { wrapper: poolMocks.currentWrapper, webview: null }
       : null),
@@ -47,6 +46,7 @@ function makeBrowserState(
 ): UseBrowserWebviewResult {
   return {
     wrapper: sharedWrapper,
+    webview: null,
     url: 'https://www.taptap.cn/',
     title: '',
     favicon: '',
@@ -365,7 +365,6 @@ describe('BrowserTabBody navigation', () => {
 
     expect(patchState).toHaveBeenCalledWith({ url: 'https://www.google.com/' });
   });
-
 
   it('does not patch about:blank back over a user-entered navigation before loading flips true', () => {
     browserState = makeBrowserState({

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -6,10 +6,12 @@ import type { WebviewTag } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  BROWSER_COMMENT_CANCEL_PENDING_CHANNEL,
   BROWSER_COMMENT_COMMAND_RESULT_CHANNEL,
   BROWSER_COMMENT_COMMIT_PENDING_CHANNEL,
   BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL,
   BROWSER_COMMENT_ENTER_MODE_CHANNEL,
+  BROWSER_COMMENT_EXIT_MODE_CHANNEL,
   BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
   type BrowserCommentCommandEnvelope,
   type BrowserCommentCommandResult,
@@ -252,6 +254,7 @@ describe('useBrowserComment', () => {
     });
 
     expect(result!.mode).toBe('off');
+    expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
     expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
   });
 
@@ -275,6 +278,68 @@ describe('useBrowserComment', () => {
 
     expect(result!.mode).toBe('pending');
     expect(result!.pendingTarget).toEqual(TARGET);
+    expect(draftMocks.append).not.toHaveBeenCalled();
+    expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
+  });
+
+  it('keeps the pending target mounted when capture fails after preparation', async () => {
+    vi.mocked(window.electronAPI.rsbBrowserBridge.captureScreenshotData).mockRejectedValueOnce(
+      new Error('capture failed'),
+    );
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+
+    act(() => result!.submit('Keep this draft in the popover'));
+    await acknowledgeLastCommand(webview);
+
+    await waitFor(() => expect(result!.mode).toBe('pending'));
+    expect(result!.pendingTarget).toEqual(TARGET);
+    expect(draftMocks.append).not.toHaveBeenCalled();
+    expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL);
+    expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
+  });
+
+  it('cancels an immediate marker and resumes selecting when capture fails', async () => {
+    vi.mocked(window.electronAPI.rsbBrowserBridge.captureScreenshotData).mockRejectedValueOnce(
+      new Error('capture failed'),
+    );
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+    act(() =>
+      webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, {
+        ...TARGET,
+        immediate: true,
+      }),
+    );
+
+    expect(result!.mode).toBe('submitting');
+    await acknowledgeLastCommand(webview);
+    await waitFor(() => {
+      expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL);
+    });
+    await acknowledgeLastCommand(webview);
+
+    expect(result!.mode).toBe('selecting');
+    expect(result!.pendingTarget).toBeNull();
     expect(draftMocks.append).not.toHaveBeenCalled();
     expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
   });

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -537,6 +537,48 @@ describe('useBrowserComment', () => {
     expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
   });
 
+  it('opens the Popover instead of discarding a recovered draft on immediate selection', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    act(() =>
+      result!.updateEditorDraft({
+        text: 'Recovered comment',
+        styleEdits: { color: '#ff0000' },
+        textEdit: null,
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+    const callsBeforeSelection = webview.send.mock.calls.length;
+
+    act(() =>
+      webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, {
+        ...TARGET,
+        immediate: true,
+      }),
+    );
+
+    expect(result!.mode).toBe('pending');
+    expect(result!.pendingTarget).toEqual({
+      ...TARGET,
+      immediate: false,
+    });
+    expect(result!.editorDraft).toEqual({
+      text: 'Recovered comment',
+      styleEdits: { color: '#ff0000' },
+      textEdit: null,
+    });
+    expect(webview.send).toHaveBeenCalledTimes(callsBeforeSelection);
+    expect(draftMocks.append).not.toHaveBeenCalled();
+  });
+
   it('writes the Composer draft once and waits for guest commit acknowledgement', async () => {
     const webview = makeWebview();
     let result: UseBrowserCommentResult | null = null;

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, render, waitFor } from '@testing-library/react';
-import { createElement } from 'react';
+import { createElement, useLayoutEffect, useRef } from 'react';
 import type { WebviewTag } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -119,6 +119,26 @@ function HookProbe({
 }) {
   const result = useBrowserComment('tab-a', 'session-a', webview, () => 'https://example.com/');
   onResult(result);
+  return null;
+}
+
+function LayoutToggleProbe({
+  webview,
+  armed,
+  onResult,
+}: {
+  webview: WebviewTag | null;
+  armed: boolean;
+  onResult: (result: UseBrowserCommentResult) => void;
+}) {
+  const result = useBrowserComment('tab-a', 'session-a', webview, () => 'https://example.com/');
+  const toggledRef = useRef(false);
+  onResult(result);
+  useLayoutEffect(() => {
+    if (!armed || toggledRef.current) return;
+    toggledRef.current = true;
+    result.toggle();
+  }, [armed, result]);
   return null;
 }
 
@@ -271,6 +291,35 @@ describe('useBrowserComment', () => {
     expect(result!.mode).toBe('off');
     expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
     expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+
+  it('uses the replacement WebView for commands issued from the same layout commit', () => {
+    const first = makeWebview();
+    const second = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    const view = render(
+      createElement(LayoutToggleProbe, {
+        webview: first.value,
+        armed: false,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    view.rerender(
+      createElement(LayoutToggleProbe, {
+        webview: second.value,
+        armed: true,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    expect(result!.mode).toBe('starting');
+    expect(first.send).not.toHaveBeenCalled();
+    expect(lastCommand(second).command).toBe(BROWSER_COMMENT_ENTER_MODE_CHANNEL);
   });
 
   it('preserves an existing text selection emitted before the enter ACK', async () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -260,6 +260,64 @@ describe('useBrowserComment', () => {
     expect(toastMocks.error).not.toHaveBeenCalled();
   });
 
+  it('preserves an existing text selection emitted before the enter ACK', async () => {
+    const webview = makeWebview();
+    const textTarget: BrowserCommentTargetInfo = {
+      ...TARGET,
+      kind: 'text',
+      selectedText: 'Already selected before comment mode opened',
+      targetTag: 'p',
+      targetLabel: 'Already selected before comment mode opened',
+      targetRole: null,
+      targetSelector: 'p:nth-of-type(1)',
+      targetPath: 'html > body > p:nth-of-type(1)',
+    };
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    act(() => result!.toggle());
+    expect(result!.mode).toBe('starting');
+
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, textTarget));
+    expect(result!.mode).toBe('starting');
+    expect(result!.pendingTarget).toBeNull();
+
+    await acknowledgeLastCommand(webview);
+
+    expect(result!.mode).toBe('pending');
+    expect(result!.pendingTarget).toEqual(textTarget);
+  });
+
+  it('discards a startup selection when enter-mode is rejected', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    act(() => result!.toggle());
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+    await acknowledgeLastCommand(webview, false);
+
+    expect(result!.mode).toBe('off');
+    expect(result!.pendingTarget).toBeNull();
+
+    await enterSelecting(webview, () => result!);
+    expect(result!.pendingTarget).toBeNull();
+  });
+
   it('returns to off when a delivered enter command is never acknowledged', async () => {
     vi.useFakeTimers();
     const webview = makeWebview();

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -241,6 +241,15 @@ describe('useBrowserComment', () => {
       textEdit: 'Updated label',
     });
 
+    act(() => result!.toggle());
+    await acknowledgeLastCommand(second, false);
+    expect(result!.mode).toBe('off');
+    expect(result!.editorDraft).toEqual({
+      text: 'Keep this unsent comment',
+      styleEdits: { color: '#ff0000' },
+      textEdit: 'Updated label',
+    });
+
     await enterSelecting(second, () => result!);
     act(() => second.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
     expect(result!.mode).toBe('pending');
@@ -644,10 +653,18 @@ describe('useBrowserComment', () => {
       }),
     );
     await enterSelecting(webview, () => result!);
+    act(() =>
+      result!.updateEditorDraft({
+        text: 'Recover after navigation',
+        styleEdits: {},
+        textEdit: null,
+      }),
+    );
 
     act(() => webview.dispatch('did-navigate'));
 
     expect(result!.mode).toBe('off');
+    expect(result!.editorDraft.text).toBe('Recover after navigation');
     act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
     expect(result!.pendingTarget).toBeNull();
   });

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -62,7 +62,7 @@ interface MockWebview {
 }
 
 function makeWebview(
-  sendImpl: (channel: string, payload: unknown) => Promise<void> = async () => undefined,
+  sendImpl: (channel: string, payload: unknown) => void | Promise<void> = async () => undefined,
 ): MockWebview {
   const listeners = new Map<string, Set<WebviewListener>>();
   const send = vi.fn(sendImpl);
@@ -234,6 +234,32 @@ describe('useBrowserComment', () => {
     expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
   });
 
+  it('waits for ACKs when WebView send returns void', async () => {
+    const webview = makeWebview(() => undefined);
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    act(() => result!.toggle());
+    expect(result!.mode).toBe('starting');
+    expect(toastMocks.error).not.toHaveBeenCalled();
+
+    await acknowledgeLastCommand(webview);
+    expect(result!.mode).toBe('selecting');
+
+    act(() => result!.resetDesign());
+    act(() => result!.toggle());
+    expect(result!.mode).toBe('off');
+    expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+
   it('returns to off when a delivered enter command is never acknowledged', async () => {
     vi.useFakeTimers();
     const webview = makeWebview();
@@ -402,6 +428,45 @@ describe('useBrowserComment', () => {
     expect(result!.mode).toBe('off');
     expect(result!.pendingTarget).toBeNull();
     expect(toastMocks.success).toHaveBeenCalledWith('rightSidebar.browser.commentAdded');
+  });
+
+  it('reports a committed draft as success when the WebView is replaced before commit ACK', async () => {
+    const first = makeWebview();
+    const second = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    const view = render(
+      createElement(HookProbe, {
+        webview: first.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(first, () => result!);
+    act(() => first.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+
+    act(() => result!.submit('Keep the committed draft'));
+    await acknowledgeLastCommand(first);
+    await waitFor(() => {
+      expect(lastCommand(first).command).toBe(BROWSER_COMMENT_COMMIT_PENDING_CHANNEL);
+    });
+    expect(draftMocks.append).toHaveBeenCalledOnce();
+
+    view.rerender(
+      createElement(HookProbe, {
+        webview: second.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    await waitFor(() => expect(result!.mode).toBe('off'));
+    expect(result!.pendingTarget).toBeNull();
+    expect(draftMocks.append).toHaveBeenCalledOnce();
+    expect(toastMocks.success).toHaveBeenCalledOnce();
+    expect(toastMocks.success).toHaveBeenCalledWith('rightSidebar.browser.commentAdded');
+    expect(toastMocks.error).not.toHaveBeenCalled();
   });
 
   it('exits on navigation and ignores the old generation afterwards', async () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -106,7 +106,11 @@ const TARGET: BrowserCommentTargetInfo = {
   targetPath: 'html > body > button#save',
   nearbyText: 'Save changes',
   themeVariant: 'light',
-  designBaseline: null,
+  designBaseline: {
+    styles: { color: 'rgb(0, 0, 0)' },
+    editableText: 'Save',
+    provenance: {},
+  },
   markerNumber: 1,
 };
 
@@ -342,6 +346,7 @@ describe('useBrowserComment', () => {
       targetRole: null,
       targetSelector: 'p:nth-of-type(1)',
       targetPath: 'html > body > p:nth-of-type(1)',
+      designBaseline: null,
     };
     let result: UseBrowserCommentResult | null = null;
     render(
@@ -576,6 +581,81 @@ describe('useBrowserComment', () => {
       textEdit: null,
     });
     expect(webview.send).toHaveBeenCalledTimes(callsBeforeSelection);
+    expect(draftMocks.append).not.toHaveBeenCalled();
+  });
+
+  it('preserves recovered design edits until a compatible target is selected', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    const recoveredDraft = {
+      text: 'Keep the comment too',
+      styleEdits: { color: '#ff0000' },
+      textEdit: 'Recovered label',
+    };
+    act(() => result!.updateEditorDraft(recoveredDraft));
+    await enterSelecting(webview, () => result!);
+
+    act(() =>
+      webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, {
+        ...TARGET,
+        kind: 'region',
+        designBaseline: null,
+      }),
+    );
+
+    expect(result!.mode).toBe('cancelling');
+    expect(result!.pendingTarget).toBeNull();
+    expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL);
+    await acknowledgeLastCommand(webview);
+
+    expect(result!.mode).toBe('selecting');
+    expect(result!.editorDraft).toEqual(recoveredDraft);
+    expect(draftMocks.append).not.toHaveBeenCalled();
+
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+    expect(result!.mode).toBe('pending');
+    expect(result!.pendingTarget).toEqual(TARGET);
+    expect(result!.editorDraft).toEqual(recoveredDraft);
+  });
+
+  it('keeps recovered design edits when incompatible-target cleanup fails', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    const recoveredDraft = {
+      text: '',
+      styleEdits: { color: '#ff0000' },
+      textEdit: 'Recovered label',
+    };
+    act(() => result!.updateEditorDraft(recoveredDraft));
+    await enterSelecting(webview, () => result!);
+
+    act(() =>
+      webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, {
+        ...TARGET,
+        designBaseline: null,
+      }),
+    );
+    await acknowledgeLastCommand(webview, false);
+
+    expect(result!.mode).toBe('off');
+    expect(result!.editorDraft).toEqual(recoveredDraft);
+    expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
     expect(draftMocks.append).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -450,7 +450,11 @@ describe('useBrowserComment', () => {
     );
 
     act(() => result!.cancelPending());
+    expect(result!.mode).toBe('cancelling');
     expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL);
+    const callsBeforeSubmit = webview.send.mock.calls.length;
+    act(() => result!.submit('Must not race the pending cancellation'));
+    expect(webview.send).toHaveBeenCalledTimes(callsBeforeSubmit);
     await acknowledgeLastCommand(webview);
 
     expect(result!.mode).toBe('selecting');

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -1,0 +1,361 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import type { WebviewTag } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BROWSER_COMMENT_COMMAND_RESULT_CHANNEL,
+  BROWSER_COMMENT_COMMIT_PENDING_CHANNEL,
+  BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL,
+  BROWSER_COMMENT_ENTER_MODE_CHANNEL,
+  BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
+  type BrowserCommentCommandEnvelope,
+  type BrowserCommentCommandResult,
+  type BrowserCommentTargetInfo,
+} from '../../../../../../shared/browserComment';
+import { useBrowserComment, type UseBrowserCommentResult } from '../useBrowserComment';
+
+const draftMocks = vi.hoisted(() => ({
+  append: vi.fn(),
+  getDraft: vi.fn(() => ({
+    text: null,
+    attachments: [],
+    quotes: [],
+    browserComments: [],
+  })),
+}));
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/lib/composerDraftStore', () => ({
+  appendBrowserCommentToDraft: draftMocks.append,
+  getDraft: draftMocks.getDraft,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: toastMocks,
+}));
+
+vi.mock('@/features/cc-agent/newMakerDraftRightSidebar', () => ({
+  composerDraftKeyForRightSidebarSession: (sessionId: string) => sessionId,
+}));
+
+type WebviewListener = (event: { channel?: string; args?: unknown[] }) => void;
+
+interface MockWebview {
+  value: WebviewTag;
+  send: ReturnType<typeof vi.fn>;
+  dispatchIpc: (channel: string, ...args: unknown[]) => void;
+  dispatch: (type: string) => void;
+  listenerCount: (type: string) => number;
+}
+
+function makeWebview(
+  sendImpl: (channel: string, payload: unknown) => Promise<void> = async () => undefined,
+): MockWebview {
+  const listeners = new Map<string, Set<WebviewListener>>();
+  const send = vi.fn(sendImpl);
+  const value = {
+    send,
+    addEventListener: (type: string, listener: WebviewListener) => {
+      const current = listeners.get(type) ?? new Set<WebviewListener>();
+      current.add(listener);
+      listeners.set(type, current);
+    },
+    removeEventListener: (type: string, listener: WebviewListener) => {
+      listeners.get(type)?.delete(listener);
+    },
+  } as unknown as WebviewTag;
+  return {
+    value,
+    send,
+    dispatchIpc: (channel, ...args) => {
+      for (const listener of listeners.get('ipc-message') ?? []) {
+        listener({ channel, args });
+      }
+    },
+    dispatch: (type) => {
+      for (const listener of listeners.get(type) ?? []) listener({});
+    },
+    listenerCount: (type) => listeners.get(type)?.size ?? 0,
+  };
+}
+
+const TARGET: BrowserCommentTargetInfo = {
+  kind: 'element',
+  point: { x: 120, y: 80 },
+  viewport: { width: 1280, height: 720 },
+  region: null,
+  selectedText: null,
+  immediate: false,
+  targetTag: 'button',
+  targetLabel: 'Save',
+  targetRole: 'button',
+  targetSelector: '#save',
+  targetPath: 'html > body > button#save',
+  nearbyText: 'Save changes',
+  themeVariant: 'light',
+  designBaseline: null,
+  markerNumber: 1,
+};
+
+function HookProbe({
+  webview,
+  onResult,
+}: {
+  webview: WebviewTag | null;
+  onResult: (result: UseBrowserCommentResult) => void;
+}) {
+  const result = useBrowserComment('tab-a', 'session-a', webview, () => 'https://example.com/');
+  onResult(result);
+  return null;
+}
+
+function lastCommand(mock: MockWebview): {
+  command: string;
+  envelope: BrowserCommentCommandEnvelope;
+} {
+  const call = mock.send.mock.calls.at(-1);
+  if (!call) throw new Error('expected a WebView command');
+  return {
+    command: call[0] as string,
+    envelope: call[1] as BrowserCommentCommandEnvelope,
+  };
+}
+
+async function acknowledgeLastCommand(mock: MockWebview, ok = true): Promise<void> {
+  const { command, envelope } = lastCommand(mock);
+  const result: BrowserCommentCommandResult = {
+    requestId: envelope.requestId,
+    command: command as BrowserCommentCommandResult['command'],
+    ok,
+  };
+  await act(async () => {
+    mock.dispatchIpc(BROWSER_COMMENT_COMMAND_RESULT_CHANNEL, result);
+  });
+}
+
+async function enterSelecting(
+  mock: MockWebview,
+  getResult: () => UseBrowserCommentResult,
+): Promise<void> {
+  act(() => getResult().toggle());
+  expect(lastCommand(mock).command).toBe(BROWSER_COMMENT_ENTER_MODE_CHANNEL);
+  await acknowledgeLastCommand(mock);
+  expect(getResult().mode).toBe('selecting');
+}
+
+describe('useBrowserComment', () => {
+  beforeEach(() => {
+    draftMocks.append.mockReset();
+    draftMocks.getDraft.mockClear();
+    toastMocks.success.mockReset();
+    toastMocks.error.mockReset();
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        rsbBrowserBridge: {
+          captureScreenshotData: vi.fn(async () => ({ data: new Uint8Array([1, 2, 3]) })),
+        },
+        cacheImageFromBuffer: vi.fn(async () => ({ url: 'xdt-image://cached/comment.png' })),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('binds events to each WebView generation and accepts selections after replacement', async () => {
+    const first = makeWebview();
+    const second = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    const view = render(
+      createElement(HookProbe, {
+        webview: first.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    await enterSelecting(first, () => result!);
+    act(() => first.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+    expect(result!.mode).toBe('pending');
+
+    view.rerender(
+      createElement(HookProbe, {
+        webview: second.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    expect(result!.mode).toBe('off');
+    expect(first.listenerCount('ipc-message')).toBe(0);
+    expect(second.listenerCount('ipc-message')).toBe(1);
+
+    await enterSelecting(second, () => result!);
+    act(() => second.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+    expect(result!.mode).toBe('pending');
+  });
+
+  it('does not claim comment mode when enter-mode delivery fails', async () => {
+    const webview = makeWebview(async () => {
+      throw new Error('detached');
+    });
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    act(() => result!.toggle());
+    expect(result!.mode).toBe('starting');
+    await waitFor(() => expect(result!.mode).toBe('off'));
+    expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
+  });
+
+  it('returns to off when a delivered enter command is never acknowledged', async () => {
+    vi.useFakeTimers();
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+
+    act(() => result!.toggle());
+    expect(result!.mode).toBe('starting');
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(result!.mode).toBe('off');
+    expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
+  });
+
+  it('keeps the pending target mounted when screenshot preparation fails', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+
+    act(() => result!.submit('Do not lose this comment'));
+    expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL);
+    await acknowledgeLastCommand(webview, false);
+
+    expect(result!.mode).toBe('pending');
+    expect(result!.pendingTarget).toEqual(TARGET);
+    expect(draftMocks.append).not.toHaveBeenCalled();
+    expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
+  });
+
+  it('writes the Composer draft once and waits for guest commit acknowledgement', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+
+    act(() => result!.submit('Move this button'));
+    await acknowledgeLastCommand(webview);
+    await waitFor(() => {
+      expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_COMMIT_PENDING_CHANNEL);
+    });
+
+    expect(draftMocks.append).toHaveBeenCalledOnce();
+    expect(draftMocks.append.mock.calls[0]?.[1]).toMatchObject({
+      comment: 'Move this button',
+      target: TARGET,
+    });
+    expect(result!.mode).toBe('submitting');
+
+    await acknowledgeLastCommand(webview);
+    expect(result!.mode).toBe('selecting');
+    expect(result!.pendingTarget).toBeNull();
+    expect(toastMocks.success).toHaveBeenCalledWith('rightSidebar.browser.commentAdded');
+  });
+
+  it('keeps an already-written comment and exits cleanly when guest commit fails', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+
+    act(() => result!.submit('Preserve the committed draft'));
+    await acknowledgeLastCommand(webview);
+    await waitFor(() => {
+      expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_COMMIT_PENDING_CHANNEL);
+    });
+    await acknowledgeLastCommand(webview, false);
+
+    expect(draftMocks.append).toHaveBeenCalledOnce();
+    expect(result!.mode).toBe('off');
+    expect(result!.pendingTarget).toBeNull();
+    expect(toastMocks.success).toHaveBeenCalledWith('rightSidebar.browser.commentAdded');
+  });
+
+  it('exits on navigation and ignores the old generation afterwards', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+
+    act(() => webview.dispatch('did-navigate'));
+
+    expect(result!.mode).toBe('off');
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+    expect(result!.pendingTarget).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts
@@ -195,6 +195,13 @@ describe('useBrowserComment', () => {
     await enterSelecting(first, () => result!);
     act(() => first.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
     expect(result!.mode).toBe('pending');
+    act(() =>
+      result!.updateEditorDraft({
+        text: 'Keep this unsent comment',
+        styleEdits: { color: '#ff0000' },
+        textEdit: 'Updated label',
+      }),
+    );
 
     view.rerender(
       createElement(HookProbe, {
@@ -208,10 +215,16 @@ describe('useBrowserComment', () => {
     expect(result!.mode).toBe('off');
     expect(first.listenerCount('ipc-message')).toBe(0);
     expect(second.listenerCount('ipc-message')).toBe(1);
+    expect(result!.editorDraft).toEqual({
+      text: 'Keep this unsent comment',
+      styleEdits: { color: '#ff0000' },
+      textEdit: 'Updated label',
+    });
 
     await enterSelecting(second, () => result!);
     act(() => second.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
     expect(result!.mode).toBe('pending');
+    expect(result!.editorDraft.text).toBe('Keep this unsent comment');
   });
 
   it('does not claim comment mode when enter-mode delivery fails', async () => {
@@ -366,6 +379,40 @@ describe('useBrowserComment', () => {
     expect(toastMocks.error).toHaveBeenCalledWith('rightSidebar.browser.commentFailed');
   });
 
+  it('clears the recoverable editor draft after an explicit cancel', async () => {
+    const webview = makeWebview();
+    let result: UseBrowserCommentResult | null = null;
+    render(
+      createElement(HookProbe, {
+        webview: webview.value,
+        onResult: (next) => {
+          result = next;
+        },
+      }),
+    );
+    await enterSelecting(webview, () => result!);
+    act(() => webview.dispatchIpc(BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL, TARGET));
+    act(() =>
+      result!.updateEditorDraft({
+        text: 'Discard me',
+        styleEdits: { color: '#ff0000' },
+        textEdit: 'Discarded label',
+      }),
+    );
+
+    act(() => result!.cancelPending());
+    expect(lastCommand(webview).command).toBe(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL);
+    await acknowledgeLastCommand(webview);
+
+    expect(result!.mode).toBe('selecting');
+    expect(result!.pendingTarget).toBeNull();
+    expect(result!.editorDraft).toEqual({
+      text: '',
+      styleEdits: {},
+      textEdit: null,
+    });
+  });
+
   it('keeps the pending target mounted when capture fails after preparation', async () => {
     vi.mocked(window.electronAPI.rsbBrowserBridge.captureScreenshotData).mockRejectedValueOnce(
       new Error('capture failed'),
@@ -458,6 +505,11 @@ describe('useBrowserComment', () => {
     await acknowledgeLastCommand(webview);
     expect(result!.mode).toBe('selecting');
     expect(result!.pendingTarget).toBeNull();
+    expect(result!.editorDraft).toEqual({
+      text: '',
+      styleEdits: {},
+      textEdit: null,
+    });
     expect(toastMocks.success).toHaveBeenCalledWith('rightSidebar.browser.commentAdded');
   });
 

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserCommentEditorDraft.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserCommentEditorDraft.ts
@@ -22,15 +22,16 @@ export function createEmptyBrowserCommentEditorDraft(): BrowserCommentEditorDraf
   };
 }
 
+/** 是否包含必须绑定到可用 design baseline 才能预览 / 提交的编辑。 */
+export function hasBrowserCommentDesignDraft(draft: BrowserCommentEditorDraft): boolean {
+  return draft.textEdit !== null || Object.keys(draft.styleEdits).length > 0;
+}
+
 /**
  * 是否存在不能被 immediate 空评论路径静默覆盖的 Host 编辑内容。
  * 使用原始编辑状态而非提交时的 trimmed diff：即使用户暂时输入空白或尚未
  * 绑定兼容 baseline，这仍是需要回到 Popover 明确处理的恢复草稿。
  */
 export function hasBrowserCommentEditorDraft(draft: BrowserCommentEditorDraft): boolean {
-  return (
-    draft.text.length > 0 ||
-    draft.textEdit !== null ||
-    Object.keys(draft.styleEdits).length > 0
-  );
+  return draft.text.length > 0 || hasBrowserCommentDesignDraft(draft);
 }

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserCommentEditorDraft.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserCommentEditorDraft.ts
@@ -21,3 +21,16 @@ export function createEmptyBrowserCommentEditorDraft(): BrowserCommentEditorDraf
     textEdit: null,
   };
 }
+
+/**
+ * 是否存在不能被 immediate 空评论路径静默覆盖的 Host 编辑内容。
+ * 使用原始编辑状态而非提交时的 trimmed diff：即使用户暂时输入空白或尚未
+ * 绑定兼容 baseline，这仍是需要回到 Popover 明确处理的恢复草稿。
+ */
+export function hasBrowserCommentEditorDraft(draft: BrowserCommentEditorDraft): boolean {
+  return (
+    draft.text.length > 0 ||
+    draft.textEdit !== null ||
+    Object.keys(draft.styleEdits).length > 0
+  );
+}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserCommentEditorDraft.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserCommentEditorDraft.ts
@@ -1,0 +1,23 @@
+/**
+ * 浏览器评论气泡中尚未提交的 Host 编辑状态。
+ *
+ * 这份状态不能归 BrowserCommentPopover 本地所有：后台 tab 的 WebView 会被
+ * Pool 按 LRU 自动淘汰并重建，Popover 随 pending target 卸载；若编辑内容只
+ * 存在组件内部，生命周期换代就会直接丢失用户输入。由 useBrowserComment
+ * 持有后，WebView 代际可以退出，用户重新点选目标时仍能恢复原草稿。
+ */
+export interface BrowserCommentEditorDraft {
+  text: string;
+  /** 只记录用户改过的 CSS 属性值；与 design baseline 的 diff 在 Popover 计算。 */
+  styleEdits: Record<string, string>;
+  /** 元素可编辑文本的候选值；null 表示仍使用 design baseline。 */
+  textEdit: string | null;
+}
+
+export function createEmptyBrowserCommentEditorDraft(): BrowserCommentEditorDraft {
+  return {
+    text: '',
+    styleEdits: {},
+    textEdit: null,
+  };
+}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -53,6 +53,7 @@ import {
 import { composerDraftKeyForRightSidebarSession } from '@/features/cc-agent/newMakerDraftRightSidebar';
 import {
   createEmptyBrowserCommentEditorDraft,
+  hasBrowserCommentDesignDraft,
   hasBrowserCommentEditorDraft,
   type BrowserCommentEditorDraft,
 } from './browserCommentEditorDraft';
@@ -88,12 +89,7 @@ function observeSendRejection(result: unknown, onRejected: (reason: unknown) => 
 }
 
 export type BrowserCommentMode =
-  | 'off'
-  | 'starting'
-  | 'selecting'
-  | 'pending'
-  | 'cancelling'
-  | 'submitting';
+  'off' | 'starting' | 'selecting' | 'pending' | 'cancelling' | 'submitting';
 
 interface PendingBrowserCommentCommand {
   webview: WebviewTag;
@@ -308,27 +304,44 @@ export function useBrowserComment(
   const abortModePreservingDraftRef = useRef(abortModePreservingDraft);
   abortModePreservingDraftRef.current = abortModePreservingDraft;
 
+  /**
+   * 撤销 Guest 已建立的 pending target。显式取消会丢弃 Host 草稿；自动拒绝
+   * 一个无法承载恢复中 design edits 的 target 时只撤 marker，保留草稿继续
+   * 点选。两条路径共用 ACK 状态机，避免 Host 提前回 selecting 而 Guest 仍
+   * 卡在 pending。
+   */
+  const cancelGuestPending = useCallback(
+    (discardEditorDraft: boolean) => {
+      const epoch = submitEpochRef.current;
+      setMode('cancelling');
+      void sendCommand(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL).then(
+        () => {
+          if (submitEpochRef.current !== epoch) return;
+          setPendingTarget(null);
+          if (discardEditorDraft) clearEditorDraft();
+          setMode('selecting');
+        },
+        () => {
+          if (submitEpochRef.current !== epoch) return;
+          // 无法确认 guest 已撤掉 pending 时整体退出；下次 enter 会先幂等拆旧 overlay。
+          if (discardEditorDraft) {
+            exitMode();
+          } else {
+            abortModePreservingDraft();
+          }
+          toast.error(tRef.current('rightSidebar.browser.commentFailed'));
+        },
+      );
+    },
+    [abortModePreservingDraft, clearEditorDraft, exitMode, sendCommand],
+  );
+
   const cancelPending = useCallback(() => {
     if (modeRef.current !== 'pending') return;
-    const epoch = submitEpochRef.current;
     // 立即离开 pending，序列化 cancel 与 submit：ACK 前 submit() 不再能够
     // 启动 prepare-screenshot，避免 guest 已撤销 target 后 host 又进提交态。
-    setMode('cancelling');
-    void sendCommand(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL).then(
-      () => {
-        if (submitEpochRef.current !== epoch) return;
-        setPendingTarget(null);
-        clearEditorDraft();
-        setMode('selecting');
-      },
-      () => {
-        if (submitEpochRef.current !== epoch) return;
-        // 无法确认 guest 已撤掉 pending 时整体退出；下次 enter 会先幂等拆旧 overlay。
-        exitMode();
-        toast.error(tRef.current('rightSidebar.browser.commentFailed'));
-      },
-    );
-  }, [clearEditorDraft, exitMode, sendCommand]);
+    cancelGuestPending(true);
+  }, [cancelGuestPending]);
 
   /**
    * 提交主流程(气泡提交与 immediate 共用)。commentText 允许为空(immediate:
@@ -472,19 +485,30 @@ export function useBrowserComment(
   const doSubmitRef = useRef(doSubmit);
   doSubmitRef.current = doSubmit;
 
-  const acceptSelectedTarget = useCallback((info: BrowserCommentTargetInfo) => {
-    if (info.immediate && !hasBrowserCommentEditorDraft(editorDraftRef.current)) {
-      // Cmd/Ctrl+点击「立即添加」:跳过气泡,空评论文本直接提交。
-      doSubmitRef.current(info, '');
-      return;
-    }
-    // 生命周期恢复后若仍有 Host 草稿，即使用户 Cmd/Ctrl+点击也必须重新打开
-    // Popover，让恢复的正文 / 样式明确绑定当前 target；不能提交空评论后清空。
-    // 同时归一化为普通 pending，后续截图失败应保留 Popover，而不是走 immediate
-    // 的无编辑器取消路径。
-    setPendingTarget(info.immediate ? { ...info, immediate: false } : info);
-    setMode('pending');
-  }, []);
+  const acceptSelectedTarget = useCallback(
+    (info: BrowserCommentTargetInfo) => {
+      const editorDraft = editorDraftRef.current;
+      if (!info.designBaseline && hasBrowserCommentDesignDraft(editorDraft)) {
+        // 恢复中的 CSS / text edit 不能绑定到 region、文本选区或 baseline
+        // 采集失败的元素。Guest 此时已经建立 pending marker，先经 ACK 撤销，
+        // Host 草稿保持不变，让用户继续选择一个兼容元素。
+        cancelGuestPending(false);
+        return;
+      }
+      if (info.immediate && !hasBrowserCommentEditorDraft(editorDraft)) {
+        // Cmd/Ctrl+点击「立即添加」:跳过气泡,空评论文本直接提交。
+        doSubmitRef.current(info, '');
+        return;
+      }
+      // 生命周期恢复后若仍有 Host 草稿，即使用户 Cmd/Ctrl+点击也必须重新打开
+      // Popover，让恢复的正文 / 样式明确绑定当前 target；不能提交空评论后清空。
+      // 同时归一化为普通 pending，后续截图失败应保留 Popover，而不是走 immediate
+      // 的无编辑器取消路径。
+      setPendingTarget(info.immediate ? { ...info, immediate: false } : info);
+      setMode('pending');
+    },
+    [cancelGuestPending],
+  );
 
   const toggle = useCallback(() => {
     if (modeRef.current !== 'off') {
@@ -503,11 +527,7 @@ export function useBrowserComment(
         if (submitEpochRef.current !== epoch) return;
         const buffered = bufferedStartupSelectionRef.current;
         bufferedStartupSelectionRef.current = null;
-        if (
-          buffered &&
-          buffered.epoch === epoch &&
-          buffered.webview === webviewRef.current
-        ) {
+        if (buffered && buffered.epoch === epoch && buffered.webview === webviewRef.current) {
           acceptSelectedTarget(buffered.target);
           return;
         }
@@ -522,13 +542,7 @@ export function useBrowserComment(
         toast.error(tRef.current('rightSidebar.browser.commentFailed'));
       },
     );
-  }, [
-    abortModePreservingDraft,
-    acceptSelectedTarget,
-    composerDraftKey,
-    exitMode,
-    sendCommand,
-  ]);
+  }, [abortModePreservingDraft, acceptSelectedTarget, composerDraftKey, exitMode, sendCommand]);
 
   const submit = useCallback(
     (commentText: string, styleChanges?: BrowserCommentStyleChange[]) => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -17,6 +17,7 @@
  *
  * 状态机:off → starting(等待 guest 确认)→ selecting(点选中)→ pending(气泡打开)→
  *          submitting(截图 + 入草稿)→ selecting(连续标注)。
+ *          pending → cancelling(等待 guest 撤销)→ selecting。
  *          若 enter 时页面已有文本选区:starting 暂存选择,ACK 后直接进 pending。
  *          immediate 路径:selecting → submitting → selecting(不经 pending)。
  *          任何态可被 exit 打断回 off。
@@ -85,7 +86,13 @@ function observeSendRejection(result: unknown, onRejected: (reason: unknown) => 
   void Promise.resolve(result).catch(onRejected);
 }
 
-export type BrowserCommentMode = 'off' | 'starting' | 'selecting' | 'pending' | 'submitting';
+export type BrowserCommentMode =
+  | 'off'
+  | 'starting'
+  | 'selecting'
+  | 'pending'
+  | 'cancelling'
+  | 'submitting';
 
 interface PendingBrowserCommentCommand {
   webview: WebviewTag;
@@ -286,6 +293,9 @@ export function useBrowserComment(
   const cancelPending = useCallback(() => {
     if (modeRef.current !== 'pending') return;
     const epoch = submitEpochRef.current;
+    // 立即离开 pending，序列化 cancel 与 submit：ACK 前 submit() 不再能够
+    // 启动 prepare-screenshot，避免 guest 已撤销 target 后 host 又进提交态。
+    setMode('cancelling');
     void sendCommand(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL).then(
       () => {
         if (submitEpochRef.current !== epoch) return;

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -53,6 +53,7 @@ import {
 import { composerDraftKeyForRightSidebarSession } from '@/features/cc-agent/newMakerDraftRightSidebar';
 import {
   createEmptyBrowserCommentEditorDraft,
+  hasBrowserCommentEditorDraft,
   type BrowserCommentEditorDraft,
 } from './browserCommentEditorDraft';
 
@@ -146,6 +147,8 @@ export function useBrowserComment(
   const [mode, setMode] = useState<BrowserCommentMode>('off');
   const [pendingTarget, setPendingTarget] = useState<BrowserCommentTargetInfo | null>(null);
   const [editorDraft, setEditorDraft] = useState(createEmptyBrowserCommentEditorDraft);
+  const editorDraftRef = useRef(editorDraft);
+  editorDraftRef.current = editorDraft;
   const modeRef = useRef(mode);
   modeRef.current = mode;
   const pendingTargetRef = useRef(pendingTarget);
@@ -470,12 +473,16 @@ export function useBrowserComment(
   doSubmitRef.current = doSubmit;
 
   const acceptSelectedTarget = useCallback((info: BrowserCommentTargetInfo) => {
-    if (info.immediate) {
+    if (info.immediate && !hasBrowserCommentEditorDraft(editorDraftRef.current)) {
       // Cmd/Ctrl+点击「立即添加」:跳过气泡,空评论文本直接提交。
       doSubmitRef.current(info, '');
       return;
     }
-    setPendingTarget(info);
+    // 生命周期恢复后若仍有 Host 草稿，即使用户 Cmd/Ctrl+点击也必须重新打开
+    // Popover，让恢复的正文 / 样式明确绑定当前 target；不能提交空评论后清空。
+    // 同时归一化为普通 pending，后续截图失败应保留 Popover，而不是走 immediate
+    // 的无编辑器取消路径。
+    setPendingTarget(info.immediate ? { ...info, immediate: false } : info);
     setMode('pending');
   }, []);
 

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -277,18 +277,33 @@ export function useBrowserComment(
     }
   }, []);
 
+  /**
+   * 统一退出 Guest 评论状态。用户主动关闭 / 取消时 discardEditorDraft=true；
+   * WebView 导航、enter 失败等非用户故障只拆 overlay、保留可恢复的 Host 草稿。
+   */
+  const leaveMode = useCallback(
+    (discardEditorDraft: boolean) => {
+      const committedEpoch = committedSubmissionEpochRef.current;
+      submitEpochRef.current += 1; // 作废任何挂起中的提交
+      bufferedStartupSelectionRef.current = null;
+      if (discardEditorDraft) clearEditorDraft();
+      sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
+      if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
+      setMode('off');
+      setPendingTarget(null);
+    },
+    [clearEditorDraft, sendBestEffortCommand, settleCommittedSubmission],
+  );
   const exitMode = useCallback(() => {
-    const committedEpoch = committedSubmissionEpochRef.current;
-    submitEpochRef.current += 1; // 作废任何挂起中的提交
-    bufferedStartupSelectionRef.current = null;
-    clearEditorDraft();
-    sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
-    if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
-    setMode('off');
-    setPendingTarget(null);
-  }, [clearEditorDraft, sendBestEffortCommand, settleCommittedSubmission]);
+    leaveMode(true);
+  }, [leaveMode]);
+  const abortModePreservingDraft = useCallback(() => {
+    leaveMode(false);
+  }, [leaveMode]);
   const exitModeRef = useRef(exitMode);
   exitModeRef.current = exitMode;
+  const abortModePreservingDraftRef = useRef(abortModePreservingDraft);
+  abortModePreservingDraftRef.current = abortModePreservingDraft;
 
   const cancelPending = useCallback(() => {
     if (modeRef.current !== 'pending') return;
@@ -427,7 +442,7 @@ export function useBrowserComment(
             } catch {
               if (isStale()) return;
               // 无法确认 pending marker 已撤除时，整体退出比继续展示失配状态安全。
-              exitMode();
+              abortModePreservingDraft();
             }
             toast.error(t('rightSidebar.browser.commentFailed'));
             return;
@@ -442,6 +457,7 @@ export function useBrowserComment(
     },
     [
       composerDraftKey,
+      abortModePreservingDraft,
       exitMode,
       sendBestEffortCommand,
       sendCommand,
@@ -495,11 +511,17 @@ export function useBrowserComment(
         bufferedStartupSelectionRef.current = null;
         // send 已到 guest 但 ACK 丢失时，guest 可能已经挂上 overlay。失败路径
         // 必须与用户主动退出走同一套清理，不能只关闭 host 按钮状态。
-        exitMode();
+        abortModePreservingDraft();
         toast.error(tRef.current('rightSidebar.browser.commentFailed'));
       },
     );
-  }, [acceptSelectedTarget, composerDraftKey, exitMode, sendCommand]);
+  }, [
+    abortModePreservingDraft,
+    acceptSelectedTarget,
+    composerDraftKey,
+    exitMode,
+    sendCommand,
+  ]);
 
   const submit = useCallback(
     (commentText: string, styleChanges?: BrowserCommentStyleChange[]) => {
@@ -609,7 +631,7 @@ export function useBrowserComment(
     };
     const onNavigate = () => {
       if (modeRef.current === 'off') return;
-      exitModeRef.current();
+      abortModePreservingDraftRef.current();
     };
     webview.addEventListener('ipc-message', onIpcMessage);
     webview.addEventListener('did-navigate', onNavigate);

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -17,6 +17,7 @@
  *
  * 状态机:off → starting(等待 guest 确认)→ selecting(点选中)→ pending(气泡打开)→
  *          submitting(截图 + 入草稿)→ selecting(连续标注)。
+ *          若 enter 时页面已有文本选区:starting 暂存选择,ACK 后直接进 pending。
  *          immediate 路径:selecting → submitting → selecting(不经 pending)。
  *          任何态可被 exit 打断回 off。
  */
@@ -90,6 +91,12 @@ interface PendingBrowserCommentCommand {
   reject: (reason: Error) => void;
 }
 
+interface BufferedStartupSelection {
+  webview: WebviewTag;
+  epoch: number;
+  target: BrowserCommentTargetInfo;
+}
+
 export interface UseBrowserCommentResult {
   /** 当前状态;BrowserChrome 按钮 active 态 = mode !== 'off'。 */
   mode: BrowserCommentMode;
@@ -135,6 +142,13 @@ export function useBrowserComment(
   const webviewRef = useRef<WebviewTag | null>(null);
   const requestSequenceRef = useRef(0);
   const pendingCommandsRef = useRef(new Map<string, PendingBrowserCommentCommand>());
+  /**
+   * Guest 在 enter-mode 内会同步识别页面已有文本选区，而统一 command ACK
+   * 要等 handler 返回后才发送。starting 期间收到的 selection 先按 WebView
+   * 代际与提交纪元暂存，ACK 后再原子地推进到 pending / submitting，避免
+   * guest 已被 blocker 锁成 pending、host 却把事件丢掉。
+   */
+  const bufferedStartupSelectionRef = useRef<BufferedStartupSelection | null>(null);
   /**
    * 提交纪元:每次退出模式 / 导航 / guest 内 Esc 都自增,使正在挂起的异步提交
    * (prepare → capture → cache)在恢复后察觉自己已被作废并静默中止,避免把一个
@@ -244,6 +258,7 @@ export function useBrowserComment(
   const exitMode = useCallback(() => {
     const committedEpoch = committedSubmissionEpochRef.current;
     submitEpochRef.current += 1; // 作废任何挂起中的提交
+    bufferedStartupSelectionRef.current = null;
     sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
     if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
     setMode('off');
@@ -251,32 +266,6 @@ export function useBrowserComment(
   }, [sendBestEffortCommand, settleCommittedSubmission]);
   const exitModeRef = useRef(exitMode);
   exitModeRef.current = exitMode;
-
-  const toggle = useCallback(() => {
-    if (modeRef.current !== 'off') {
-      exitMode();
-      return;
-    }
-    if (!composerDraftKey) return;
-    // 编号 = 草稿里已有 marker 编号的最大值 + 1(删 chip 后长度与最大编号会脱节)。
-    const epoch = submitEpochRef.current;
-    setMode('starting');
-    void sendCommand(BROWSER_COMMENT_ENTER_MODE_CHANNEL, {
-      markerNumber: computeNextMarkerNumber(getDraft(composerDraftKey)?.browserComments),
-    }).then(
-      () => {
-        if (submitEpochRef.current !== epoch) return;
-        setMode('selecting');
-      },
-      () => {
-        if (submitEpochRef.current !== epoch) return;
-        // send 已到 guest 但 ACK 丢失时，guest 可能已经挂上 overlay。失败路径
-        // 必须与用户主动退出走同一套清理，不能只关闭 host 按钮状态。
-        exitMode();
-        toast.error(tRef.current('rightSidebar.browser.commentFailed'));
-      },
-    );
-  }, [composerDraftKey, exitMode, sendCommand]);
 
   const cancelPending = useCallback(() => {
     if (modeRef.current !== 'pending') return;
@@ -437,6 +426,54 @@ export function useBrowserComment(
   const doSubmitRef = useRef(doSubmit);
   doSubmitRef.current = doSubmit;
 
+  const acceptSelectedTarget = useCallback((info: BrowserCommentTargetInfo) => {
+    if (info.immediate) {
+      // Cmd/Ctrl+点击「立即添加」:跳过气泡,空评论文本直接提交。
+      doSubmitRef.current(info, '');
+      return;
+    }
+    setPendingTarget(info);
+    setMode('pending');
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (modeRef.current !== 'off') {
+      exitMode();
+      return;
+    }
+    if (!composerDraftKey) return;
+    // 编号 = 草稿里已有 marker 编号的最大值 + 1(删 chip 后长度与最大编号会脱节)。
+    const epoch = submitEpochRef.current;
+    bufferedStartupSelectionRef.current = null;
+    setMode('starting');
+    void sendCommand(BROWSER_COMMENT_ENTER_MODE_CHANNEL, {
+      markerNumber: computeNextMarkerNumber(getDraft(composerDraftKey)?.browserComments),
+    }).then(
+      () => {
+        if (submitEpochRef.current !== epoch) return;
+        const buffered = bufferedStartupSelectionRef.current;
+        bufferedStartupSelectionRef.current = null;
+        if (
+          buffered &&
+          buffered.epoch === epoch &&
+          buffered.webview === webviewRef.current
+        ) {
+          acceptSelectedTarget(buffered.target);
+          return;
+        }
+        setMode('selecting');
+      },
+      () => {
+        if (submitEpochRef.current !== epoch) return;
+        bufferedStartupSelectionRef.current = null;
+        // send 已到 guest 但 ACK 丢失时，guest 可能已经挂上 overlay。失败路径
+        // 必须与用户主动退出走同一套清理，不能只关闭 host 按钮状态。
+        exitMode();
+        toast.error(tRef.current('rightSidebar.browser.commentFailed'));
+      },
+    );
+  }, [acceptSelectedTarget, composerDraftKey, exitMode, sendCommand]);
+
   const submit = useCallback(
     (commentText: string, styleChanges?: BrowserCommentStyleChange[]) => {
       const target = pendingTarget;
@@ -469,6 +506,7 @@ export function useBrowserComment(
     if (previousWebview && previousWebview !== webview) {
       const committedEpoch = committedSubmissionEpochRef.current;
       submitEpochRef.current += 1;
+      bufferedStartupSelectionRef.current = null;
       if (committedEpoch !== null) {
         settleCommittedSubmission(committedEpoch, 'off');
       } else if (
@@ -509,22 +547,28 @@ export function useBrowserComment(
           return;
         }
         case BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL: {
-          if (modeRef.current !== 'selecting') return;
+          const currentMode = modeRef.current;
+          if (currentMode !== 'starting' && currentMode !== 'selecting') return;
           const info = e.args[0] as BrowserCommentTargetInfo | undefined;
           if (!info || typeof info !== 'object') return;
-          if (info.immediate) {
-            // Cmd/Ctrl+点击「立即添加」:跳过气泡,空评论文本直接提交。
-            doSubmitRef.current(info, '');
+          if (currentMode === 'starting') {
+            // enterMode 会在统一 ACK 前同步上报页面已有文本选区。只保留当前
+            // generation / epoch 的第一条选择；guest 一旦 pending 不会再发第二条。
+            bufferedStartupSelectionRef.current ??= {
+              webview,
+              epoch: submitEpochRef.current,
+              target: info,
+            };
             return;
           }
-          setPendingTarget(info);
-          setMode('pending');
+          acceptSelectedTarget(info);
           return;
         }
         case BROWSER_COMMENT_MODE_EXITED_CHANNEL: {
           // guest 内按了 Esc,overlay 已自拆 —— host 只同步状态。
           const committedEpoch = committedSubmissionEpochRef.current;
           submitEpochRef.current += 1; // 作废任何挂起中的提交
+          bufferedStartupSelectionRef.current = null;
           if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
           setMode('off');
           setPendingTarget(null);
@@ -546,7 +590,7 @@ export function useBrowserComment(
       webview.removeEventListener('did-navigate-in-page', onNavigate);
       rejectCommandsForWebview(webview);
     };
-  }, [rejectCommandsForWebview, settleCommittedSubmission, webview]);
+  }, [acceptSelectedTarget, rejectCommandsForWebview, settleCommittedSubmission, webview]);
 
   // tab 卸载 / 切走时若模式仍开着,通知 guest 拆 overlay(webview 被 pool 保活,
   // 不通知的话 overlay 会一直趴在页面上)。

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -22,7 +22,7 @@
  *          任何态可被 exit 打断回 off。
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { WebviewTag } from 'electron';
 
@@ -147,7 +147,7 @@ export function useBrowserComment(
   tRef.current = t;
   const getPageUrlRef = useRef(getPageUrl);
   getPageUrlRef.current = getPageUrl;
-  const webviewRef = useRef<WebviewTag | null>(null);
+  const webviewRef = useRef<WebviewTag | null>(webview);
   const requestSequenceRef = useRef(0);
   const pendingCommandsRef = useRef(new Map<string, PendingBrowserCommentCommand>());
   /**
@@ -515,9 +515,11 @@ export function useBrowserComment(
 
   /**
    * 当前 WebView 代际的唯一事件绑定点。useBrowserWebview 在延迟创建、LRU
-   * 淘汰和崩溃重建时都会发布新对象，因此 effect 会精确拆旧挂新。
+   * 淘汰和崩溃重建时都会发布新对象，因此 layout effect 会在浏览器可交互
+   * 之前精确拆旧挂新并更新 send target，消除普通 effect 前 ref 仍指向旧
+   * generation 的点击窗口。
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     const previousWebview = webviewRef.current;
     webviewRef.current = webview;
     if (previousWebview && previousWebview !== webview) {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -50,6 +50,10 @@ import {
   type BrowserCommentTargetInfo,
 } from '../../../../../shared/browserComment';
 import { composerDraftKeyForRightSidebarSession } from '@/features/cc-agent/newMakerDraftRightSidebar';
+import {
+  createEmptyBrowserCommentEditorDraft,
+  type BrowserCommentEditorDraft,
+} from './browserCommentEditorDraft';
 
 /** 关键 guest 命令的完成回执等待上限；超时保持用户输入并允许重试。 */
 const COMMAND_TIMEOUT_MS = 2_000;
@@ -102,6 +106,9 @@ export interface UseBrowserCommentResult {
   mode: BrowserCommentMode;
   /** 已点选的目标信息(pending / submitting 态非空),气泡定位与提交都用它。 */
   pendingTarget: BrowserCommentTargetInfo | null;
+  /** Host 侧未提交编辑草稿；WebView 自动换代时保留，显式取消 / 成功后清空。 */
+  editorDraft: BrowserCommentEditorDraft;
+  updateEditorDraft: (draft: BrowserCommentEditorDraft) => void;
   /** 工具栏按钮:off → 进入点选;其它态 → 整体退出。 */
   toggle: () => void;
   /** 气泡取消:回到点选态(marker 清除、样式预览还原,评论模式保持)。 */
@@ -131,6 +138,7 @@ export function useBrowserComment(
     sessionId === undefined ? undefined : composerDraftKeyForRightSidebarSession(sessionId);
   const [mode, setMode] = useState<BrowserCommentMode>('off');
   const [pendingTarget, setPendingTarget] = useState<BrowserCommentTargetInfo | null>(null);
+  const [editorDraft, setEditorDraft] = useState(createEmptyBrowserCommentEditorDraft);
   const modeRef = useRef(mode);
   modeRef.current = mode;
   const pendingTargetRef = useRef(pendingTarget);
@@ -161,6 +169,12 @@ export function useBrowserComment(
    * 用 lifecycle failure 诱导用户重试并重复写入同一条评论。
    */
   const committedSubmissionEpochRef = useRef<number | null>(null);
+  const clearEditorDraft = useCallback(() => {
+    setEditorDraft(createEmptyBrowserCommentEditorDraft());
+  }, []);
+  const updateEditorDraft = useCallback((draft: BrowserCommentEditorDraft) => {
+    setEditorDraft(draft);
+  }, []);
 
   const rejectCommandsForWebview = useCallback((target: WebviewTag) => {
     for (const [requestId, pending] of pendingCommandsRef.current) {
@@ -176,11 +190,12 @@ export function useBrowserComment(
       if (committedSubmissionEpochRef.current !== epoch) return false;
       committedSubmissionEpochRef.current = null;
       setPendingTarget(null);
+      clearEditorDraft();
       setMode(nextMode);
       toast.success(tRef.current('rightSidebar.browser.commentAdded'));
       return true;
     },
-    [],
+    [clearEditorDraft],
   );
 
   /**
@@ -259,11 +274,12 @@ export function useBrowserComment(
     const committedEpoch = committedSubmissionEpochRef.current;
     submitEpochRef.current += 1; // 作废任何挂起中的提交
     bufferedStartupSelectionRef.current = null;
+    clearEditorDraft();
     sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
     if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
     setMode('off');
     setPendingTarget(null);
-  }, [sendBestEffortCommand, settleCommittedSubmission]);
+  }, [clearEditorDraft, sendBestEffortCommand, settleCommittedSubmission]);
   const exitModeRef = useRef(exitMode);
   exitModeRef.current = exitMode;
 
@@ -274,6 +290,7 @@ export function useBrowserComment(
       () => {
         if (submitEpochRef.current !== epoch) return;
         setPendingTarget(null);
+        clearEditorDraft();
         setMode('selecting');
       },
       () => {
@@ -283,7 +300,7 @@ export function useBrowserComment(
         toast.error(tRef.current('rightSidebar.browser.commentFailed'));
       },
     );
-  }, [exitMode, sendCommand]);
+  }, [clearEditorDraft, exitMode, sendCommand]);
 
   /**
    * 提交主流程(气泡提交与 immediate 共用)。commentText 允许为空(immediate:
@@ -569,6 +586,7 @@ export function useBrowserComment(
           const committedEpoch = committedSubmissionEpochRef.current;
           submitEpochRef.current += 1; // 作废任何挂起中的提交
           bufferedStartupSelectionRef.current = null;
+          clearEditorDraft();
           if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
           setMode('off');
           setPendingTarget(null);
@@ -590,7 +608,13 @@ export function useBrowserComment(
       webview.removeEventListener('did-navigate-in-page', onNavigate);
       rejectCommandsForWebview(webview);
     };
-  }, [acceptSelectedTarget, rejectCommandsForWebview, settleCommittedSubmission, webview]);
+  }, [
+    acceptSelectedTarget,
+    clearEditorDraft,
+    rejectCommandsForWebview,
+    settleCommittedSubmission,
+    webview,
+  ]);
 
   // tab 卸载 / 切走时若模式仍开着,通知 guest 拆 overlay(webview 被 pool 保活,
   // 不通知的话 overlay 会一直趴在页面上)。
@@ -600,5 +624,15 @@ export function useBrowserComment(
     };
   }, [tabId]);
 
-  return { mode, pendingTarget, toggle, cancelPending, submit, previewDesign, resetDesign };
+  return {
+    mode,
+    pendingTarget,
+    editorDraft,
+    updateEditorDraft,
+    toggle,
+    cancelPending,
+    submit,
+    previewDesign,
+    resetDesign,
+  };
 }

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -5,17 +5,17 @@
  *  - 模式开关:toggle 后向 guest 发 enter-mode / exit-mode(经 `webview.send`,
  *    guest 是 webview-security 强制注入的 browserCommentPreload)。
  *  - 订阅 webview `ipc-message`:element-selected(弹输入气泡;`immediate` 标记
- *    时跳过气泡直接空评论提交)、screenshot-prepared(截图前置回执)、
+ *    时跳过气泡直接空评论提交)、command-result(关键命令回执)与
  *    mode-exited(guest 内 Esc)。
  *  - 提交流程:prepare-screenshot → main capturePage 拿 PNG 字节 →
  *    cacheImageFromBuffer 进会话图片缓存 → 组 BrowserCommentDraftItem 追加进
  *    ComposerDraft.browserComments(browser-comment-chip:ChatInput 渲染为
  *    「N 条注释」胶囊,发送时才序列化文本块 + 截图并入 filesToSend)。
  *  - Phase 2 多评论:提交成功后**不退出模式**,发 commit-pending 让 pending
- *    marker 转常驻、编号推进,可连续标注;失败则 cancel-pending 回点选态。
+ *    marker 转常驻、编号推进,可连续标注;提交点之前失败则保留气泡供重试。
  *  - 导航 / 页面刷新时 guest 上下文销毁,host 侧同步退出评论模式。
  *
- * 状态机:off → selecting(点选中)→ pending(已选定,气泡打开)→
+ * 状态机:off → starting(等待 guest 确认)→ selecting(点选中)→ pending(气泡打开)→
  *          submitting(截图 + 入草稿)→ selecting(连续标注)。
  *          immediate 路径:selecting → submitting → selecting(不经 pending)。
  *          任何态可被 exit 打断回 off。
@@ -23,6 +23,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { WebviewTag } from 'electron';
 
 import type { BrowserCommentDraftItem } from '@/lib/browserComments';
 import { appendBrowserCommentToDraft, getDraft } from '@/lib/composerDraftStore';
@@ -31,6 +32,7 @@ import { toast } from '@/lib/toast';
 
 import {
   BROWSER_COMMENT_CANCEL_PENDING_CHANNEL,
+  BROWSER_COMMENT_COMMAND_RESULT_CHANNEL,
   BROWSER_COMMENT_COMMIT_PENDING_CHANNEL,
   BROWSER_COMMENT_DESIGN_PREVIEW_CHANNEL,
   BROWSER_COMMENT_DESIGN_RESET_CHANNEL,
@@ -39,17 +41,17 @@ import {
   BROWSER_COMMENT_EXIT_MODE_CHANNEL,
   BROWSER_COMMENT_MODE_EXITED_CHANNEL,
   BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL,
-  BROWSER_COMMENT_SCREENSHOT_PREPARED_CHANNEL,
+  type BrowserCommentCommandChannel,
+  type BrowserCommentCommandEnvelope,
+  type BrowserCommentCommandResult,
   type BrowserCommentDesignPreviewPayload,
   type BrowserCommentStyleChange,
   type BrowserCommentTargetInfo,
 } from '../../../../../shared/browserComment';
 import { composerDraftKeyForRightSidebarSession } from '@/features/cc-agent/newMakerDraftRightSidebar';
 
-import { browserWebviewPool } from '../../lib/browserWebviewPool';
-
-/** guest 回执 screenshot-prepared 的等待上限;超时按失败处理(guest 可能已导航走)。 */
-const PREPARE_SCREENSHOT_TIMEOUT_MS = 2000;
+/** 关键 guest 命令的完成回执等待上限；超时保持用户输入并允许重试。 */
+const COMMAND_TIMEOUT_MS = 2_000;
 
 /**
  * 下一个 marker 编号 = 草稿里已有 marker 编号的最大值 + 1。
@@ -57,14 +59,20 @@ const PREPARE_SCREENSHOT_TIMEOUT_MS = 2000;
  * 编号脱节(如删了 ②,剩 ①③ 时 length=2 → 会复用 ③),导致重复的 marker 与
  * `## Comment N` 块。取 max 保证编号单调、永不重号。
  */
-function computeNextMarkerNumber(
-  items: readonly { markerNumber: number }[] | undefined,
-): number {
+function computeNextMarkerNumber(items: readonly { markerNumber: number }[] | undefined): number {
   if (!items || items.length === 0) return 1;
   return items.reduce((max, item) => Math.max(max, item.markerNumber), 0) + 1;
 }
 
-export type BrowserCommentMode = 'off' | 'selecting' | 'pending' | 'submitting';
+export type BrowserCommentMode = 'off' | 'starting' | 'selecting' | 'pending' | 'submitting';
+
+interface PendingBrowserCommentCommand {
+  webview: WebviewTag;
+  command: BrowserCommentCommandChannel;
+  timer: ReturnType<typeof setTimeout>;
+  resolve: () => void;
+  reject: (reason: Error) => void;
+}
 
 export interface UseBrowserCommentResult {
   /** 当前状态;BrowserChrome 按钮 active 态 = mode !== 'off'。 */
@@ -86,6 +94,8 @@ export interface UseBrowserCommentResult {
 export function useBrowserComment(
   tabId: string,
   sessionId: string | undefined,
+  /** useBrowserWebview 暴露的当前 WebView 代际句柄。 */
+  webview: WebviewTag | null,
   /** 提交时刻的页面 URL 取值器(immediate 路径由 hook 自己触发提交,拿不到
    *  调用方参数,统一走 getter;需引用稳定或由调用方 useCallback 包裹)。 */
   getPageUrl: () => string,
@@ -100,10 +110,15 @@ export function useBrowserComment(
   const [pendingTarget, setPendingTarget] = useState<BrowserCommentTargetInfo | null>(null);
   const modeRef = useRef(mode);
   modeRef.current = mode;
+  const pendingTargetRef = useRef(pendingTarget);
+  pendingTargetRef.current = pendingTarget;
+  const tRef = useRef(t);
+  tRef.current = t;
   const getPageUrlRef = useRef(getPageUrl);
   getPageUrlRef.current = getPageUrl;
-  /** screenshot-prepared 回执的一次性 resolver(提交流程挂起等待用)。 */
-  const prepareResolverRef = useRef<(() => void) | null>(null);
+  const webviewRef = useRef<WebviewTag | null>(null);
+  const requestSequenceRef = useRef(0);
+  const pendingCommandsRef = useRef(new Map<string, PendingBrowserCommentCommand>());
   /**
    * 提交纪元:每次退出模式 / 导航 / guest 内 Esc 都自增,使正在挂起的异步提交
    * (prepare → capture → cache)在恢复后察觉自己已被作废并静默中止,避免把一个
@@ -111,27 +126,95 @@ export function useBrowserComment(
    */
   const submitEpochRef = useRef(0);
 
-  const sendToGuest = useCallback(
-    (channel: string, payload?: unknown) => {
-      const webview = browserWebviewPool.peek(tabId)?.webview;
-      if (!webview) return;
+  const rejectCommandsForWebview = useCallback((target: WebviewTag) => {
+    for (const [requestId, pending] of pendingCommandsRef.current) {
+      if (pending.webview !== target) continue;
+      clearTimeout(pending.timer);
+      pendingCommandsRef.current.delete(requestId);
+      pending.reject(new Error('browser comment WebView changed'));
+    }
+  }, []);
+
+  /**
+   * 向当前 WebView 发送一条必须确认完成的命令。requestId resolver 与具体
+   * WebView 对象绑定，旧代际回执不可能推进新代际的状态机。
+   */
+  const sendCommand = useCallback(
+    <T>(command: BrowserCommentCommandChannel, payload?: T): Promise<void> => {
+      const target = webviewRef.current;
+      if (!target) return Promise.reject(new Error('browser comment WebView unavailable'));
+      const requestId = `${tabId}:${++requestSequenceRef.current}`;
+      const envelope: BrowserCommentCommandEnvelope<T> = { requestId, payload };
+
+      return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const pending = pendingCommandsRef.current.get(requestId);
+          if (!pending) return;
+          pendingCommandsRef.current.delete(requestId);
+          reject(new Error(`browser comment command timed out: ${command}`));
+        }, COMMAND_TIMEOUT_MS);
+        pendingCommandsRef.current.set(requestId, {
+          webview: target,
+          command,
+          timer,
+          resolve,
+          reject,
+        });
+
+        try {
+          void target.send(command, envelope).catch((reason: unknown) => {
+            const pending = pendingCommandsRef.current.get(requestId);
+            if (!pending) return;
+            clearTimeout(pending.timer);
+            pendingCommandsRef.current.delete(requestId);
+            reject(reason instanceof Error ? reason : new Error('browser comment send failed'));
+          });
+        } catch (reason) {
+          const pending = pendingCommandsRef.current.get(requestId);
+          if (!pending) return;
+          clearTimeout(pending.timer);
+          pendingCommandsRef.current.delete(requestId);
+          reject(reason instanceof Error ? reason : new Error('browser comment send failed'));
+        }
+      });
+    },
+    [tabId],
+  );
+
+  /** 无需等待状态推进的通知；仍使用信封，guest 可统一执行同一套命令 handler。 */
+  const sendBestEffortCommand = useCallback(
+    <T>(command: BrowserCommentCommandChannel, payload?: T) => {
+      const target = webviewRef.current;
+      if (!target) return;
+      const envelope: BrowserCommentCommandEnvelope<T> = {
+        requestId: `${tabId}:${++requestSequenceRef.current}`,
+        payload,
+      };
       try {
-        void webview.send(channel, payload);
+        void target.send(command, envelope).catch(() => undefined);
       } catch {
-        // webContents 未 attach / 已销毁时 send 抛错 —— 评论模式对这类窗口期
-        // 一律静默(用户看到的是按钮点了没进入模式,可重试)。
+        // WebView 正在 detach / destroy；host 仍可安全完成本地退出。
       }
     },
     [tabId],
   );
 
+  const sendNotification = useCallback((channel: string, payload?: unknown) => {
+    const target = webviewRef.current;
+    if (!target) return;
+    try {
+      void target.send(channel, payload).catch(() => undefined);
+    } catch {
+      // 实时预览是非关键通知；关键状态转换全部走 sendCommand。
+    }
+  }, []);
+
   const exitMode = useCallback(() => {
     submitEpochRef.current += 1; // 作废任何挂起中的提交
-    sendToGuest(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
+    sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
     setMode('off');
     setPendingTarget(null);
-    prepareResolverRef.current = null;
-  }, [sendToGuest]);
+  }, [sendBestEffortCommand]);
   const exitModeRef = useRef(exitMode);
   exitModeRef.current = exitMode;
 
@@ -142,18 +225,40 @@ export function useBrowserComment(
     }
     if (!composerDraftKey) return;
     // 编号 = 草稿里已有 marker 编号的最大值 + 1(删 chip 后长度与最大编号会脱节)。
-    sendToGuest(BROWSER_COMMENT_ENTER_MODE_CHANNEL, {
+    const epoch = submitEpochRef.current;
+    setMode('starting');
+    void sendCommand(BROWSER_COMMENT_ENTER_MODE_CHANNEL, {
       markerNumber: computeNextMarkerNumber(getDraft(composerDraftKey)?.browserComments),
-    });
-    setMode('selecting');
-  }, [composerDraftKey, exitMode, sendToGuest]);
+    }).then(
+      () => {
+        if (submitEpochRef.current !== epoch) return;
+        setMode('selecting');
+      },
+      () => {
+        if (submitEpochRef.current !== epoch) return;
+        setMode('off');
+        toast.error(tRef.current('rightSidebar.browser.commentFailed'));
+      },
+    );
+  }, [composerDraftKey, exitMode, sendCommand]);
 
   const cancelPending = useCallback(() => {
     if (modeRef.current !== 'pending') return;
-    sendToGuest(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL);
-    setPendingTarget(null);
-    setMode('selecting');
-  }, [sendToGuest]);
+    const epoch = submitEpochRef.current;
+    void sendCommand(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL).then(
+      () => {
+        if (submitEpochRef.current !== epoch) return;
+        setPendingTarget(null);
+        setMode('selecting');
+      },
+      () => {
+        if (submitEpochRef.current !== epoch) return;
+        // 无法确认 guest 已撤掉 pending 时整体退出；下次 enter 会先幂等拆旧 overlay。
+        exitMode();
+        toast.error(tRef.current('rightSidebar.browser.commentFailed'));
+      },
+    );
+  }, [exitMode, sendCommand]);
 
   /**
    * 提交主流程(气泡提交与 immediate 共用)。commentText 允许为空(immediate:
@@ -177,27 +282,17 @@ export function useBrowserComment(
       const isStale = () => submitEpochRef.current !== epoch;
 
       void (async () => {
+        let draftCommitted = false;
         try {
-          // 1) guest 隐藏交互层只留标注,回执后再截图。
-          const prepared = new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(
-              () => reject(new Error('prepare-screenshot timeout')),
-              PREPARE_SCREENSHOT_TIMEOUT_MS,
-            );
-            prepareResolverRef.current = () => {
-              clearTimeout(timer);
-              resolve();
-            };
-          });
-          // 随 prepare 下发草稿现存 marker 编号白名单:chip 单删 / 清空 / 发送
+          // 1) guest 隐藏交互层只留标注，并明确确认两帧渲染已经完成。
+          // 随命令下发草稿现存 marker 编号白名单:chip 单删 / 清空 / 发送
           // 清草稿都是 silent 写入无法事件通知,截图前对账是唯一可靠时机 ——
           // guest 据此剪除已无对应 `## Comment N` 块的常驻 marker。
-          sendToGuest(BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL, {
+          await sendCommand(BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL, {
             validMarkerNumbers: (getDraft(composerDraftKey)?.browserComments ?? []).map(
               (c) => c.markerNumber,
             ),
           });
-          await prepared;
           if (isStale()) return; // 已退出 / 导航,放弃本次提交
 
           // 2) main capturePage → PNG 字节(标注是页内 DOM,天然在图里)。
@@ -244,28 +339,37 @@ export function useBrowserComment(
             ...(styleChanges && styleChanges.length > 0 ? { styleChanges } : {}),
           };
           appendBrowserCommentToDraft(composerDraftKey, item);
+          draftCommitted = true;
 
           // 5) Phase 2 连续标注:pending marker 转常驻,编号按草稿最大编号推进,
           //    回点选态继续标注(不退出模式,与 Codex 一致)。
-          sendToGuest(BROWSER_COMMENT_COMMIT_PENDING_CHANNEL, {
+          await sendCommand(BROWSER_COMMENT_COMMIT_PENDING_CHANNEL, {
             nextMarkerNumber: computeNextMarkerNumber(getDraft(composerDraftKey)?.browserComments),
           });
+          if (isStale()) return;
           setPendingTarget(null);
           setMode('selecting');
           toast.success(t('rightSidebar.browser.commentAdded'));
         } catch {
           // 已退出 / 导航:模式与 marker 已由打断方复位,静默(不报错、不拨回)。
           if (isStale()) return;
-          // 真失败:撤掉本条 pending 标注、回点选态(模式保持,可直接重试)。
-          prepareResolverRef.current = null;
-          sendToGuest(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL);
-          setPendingTarget(null);
-          setMode('selecting');
+          if (draftCommitted) {
+            // Composer 已经是用户数据的提交点。guest 收尾失败时不能把同一条评论
+            // 留在气泡里让用户重试并重复 append；退出本次 overlay，保留已写草稿。
+            sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
+            setPendingTarget(null);
+            setMode('off');
+            toast.success(t('rightSidebar.browser.commentAdded'));
+            return;
+          }
+          // 截图 / 缓存 / guest 准备失败：pendingTarget 与 Popover 实例都保留，
+          // 用户输入不会卸载丢失，可直接修订后重试或主动取消。
+          setMode('pending');
           toast.error(t('rightSidebar.browser.commentFailed'));
         }
       })();
     },
-    [composerDraftKey, sendToGuest, t, tabId],
+    [composerDraftKey, sendBestEffortCommand, sendCommand, t, tabId],
   );
   const doSubmitRef = useRef(doSubmit);
   doSubmitRef.current = doSubmit;
@@ -284,21 +388,60 @@ export function useBrowserComment(
   const previewDesign = useCallback(
     (payload: BrowserCommentDesignPreviewPayload) => {
       if (modeRef.current !== 'pending') return;
-      sendToGuest(BROWSER_COMMENT_DESIGN_PREVIEW_CHANNEL, payload);
+      sendNotification(BROWSER_COMMENT_DESIGN_PREVIEW_CHANNEL, payload);
     },
-    [sendToGuest],
+    [sendNotification],
   );
   const resetDesign = useCallback(() => {
-    sendToGuest(BROWSER_COMMENT_DESIGN_RESET_CHANNEL);
-  }, [sendToGuest]);
+    sendNotification(BROWSER_COMMENT_DESIGN_RESET_CHANNEL);
+  }, [sendNotification]);
 
-  // guest → host 消息:webview `ipc-message` 按 channel 分发。webview DOM 节点
-  // 由 pool 保活,监听挂在节点上、按 tabId 重挂。
+  /**
+   * 当前 WebView 代际的唯一事件绑定点。useBrowserWebview 在延迟创建、LRU
+   * 淘汰和崩溃重建时都会发布新对象，因此 effect 会精确拆旧挂新。
+   */
   useEffect(() => {
-    const webview = browserWebviewPool.peek(tabId)?.webview;
+    const previousWebview = webviewRef.current;
+    webviewRef.current = webview;
+    if (previousWebview && previousWebview !== webview) {
+      submitEpochRef.current += 1;
+      if (
+        modeRef.current === 'pending' ||
+        modeRef.current === 'submitting' ||
+        pendingTargetRef.current
+      ) {
+        toast.error(tRef.current('rightSidebar.browser.commentFailed'));
+      }
+      setMode('off');
+      setPendingTarget(null);
+    }
     if (!webview) return;
+
     const onIpcMessage = (e: Electron.IpcMessageEvent) => {
       switch (e.channel) {
+        case BROWSER_COMMENT_COMMAND_RESULT_CHANNEL: {
+          const result = e.args[0] as BrowserCommentCommandResult | undefined;
+          if (
+            !result ||
+            typeof result.requestId !== 'string' ||
+            typeof result.command !== 'string' ||
+            typeof result.ok !== 'boolean'
+          ) {
+            return;
+          }
+          const pending = pendingCommandsRef.current.get(result.requestId);
+          if (!pending || pending.webview !== webview || pending.command !== result.command) {
+            return;
+          }
+          clearTimeout(pending.timer);
+          pendingCommandsRef.current.delete(result.requestId);
+          if (result.ok) {
+            pending.resolve();
+          } else {
+            pending.reject(new Error(`browser comment guest rejected: ${result.command}`));
+          }
+          return;
+        }
         case BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL: {
           if (modeRef.current !== 'selecting') return;
           const info = e.args[0] as BrowserCommentTargetInfo | undefined;
@@ -312,52 +455,30 @@ export function useBrowserComment(
           setMode('pending');
           return;
         }
-        case BROWSER_COMMENT_SCREENSHOT_PREPARED_CHANNEL: {
-          prepareResolverRef.current?.();
-          prepareResolverRef.current = null;
-          return;
-        }
         case BROWSER_COMMENT_MODE_EXITED_CHANNEL: {
           // guest 内按了 Esc,overlay 已自拆 —— host 只同步状态。
           submitEpochRef.current += 1; // 作废任何挂起中的提交
           setMode('off');
           setPendingTarget(null);
-          prepareResolverRef.current = null;
           return;
         }
         default:
       }
     };
-    webview.addEventListener('ipc-message', onIpcMessage);
-    return () => {
-      webview.removeEventListener('ipc-message', onIpcMessage);
-    };
-  }, [tabId]);
-
-  // 页面导航 / 刷新 → host 状态必须复位,否则气泡悬在已失效的 marker 上。
-  // did-navigate 与 did-navigate-in-page 都算,但两者对 guest overlay 的影响不同:
-  //  - did-navigate(整页导航 / 刷新):guest 文档连同 overlay 一起销毁重建,
-  //    只复位 host 状态即可;
-  //  - did-navigate-in-page(SPA / hash 路由):guest 文档**存活**,注入的
-  //    blocker / marker 不会自动消失。若只清 host 状态,overlay 会一直趴在页面上
-  //    (工具栏已 inactive、element-selected 因 mode=off 被忽略),页面卡死直到 reload。
-  // 故统一走 exitMode() —— 它在复位 host 状态之外还向 guest 发 exit-mode 拆 overlay;
-  // 对整页导航,新文档的 guest 默认休眠,exitMode 是幂等 no-op(guest 侧 `if (!state) return`),
-  // 无副作用。
-  useEffect(() => {
-    const webview = browserWebviewPool.peek(tabId)?.webview;
-    if (!webview) return;
     const onNavigate = () => {
       if (modeRef.current === 'off') return;
       exitModeRef.current();
     };
+    webview.addEventListener('ipc-message', onIpcMessage);
     webview.addEventListener('did-navigate', onNavigate);
     webview.addEventListener('did-navigate-in-page', onNavigate);
     return () => {
+      webview.removeEventListener('ipc-message', onIpcMessage);
       webview.removeEventListener('did-navigate', onNavigate);
       webview.removeEventListener('did-navigate-in-page', onNavigate);
+      rejectCommandsForWebview(webview);
     };
-  }, [tabId]);
+  }, [rejectCommandsForWebview, webview]);
 
   // tab 卸载 / 切走时若模式仍开着,通知 guest 拆 overlay(webview 被 pool 保活,
   // 不通知的话 overlay 会一直趴在页面上)。

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -64,6 +64,22 @@ function computeNextMarkerNumber(items: readonly { markerNumber: number }[] | un
   return items.reduce((max, item) => Math.max(max, item.markerNumber), 0) + 1;
 }
 
+/**
+ * Electron 当前类型把 WebviewTag.send 标成 Promise<void>，但不同 Electron
+ * 版本 / 测试替身可能仍返回 void。状态机只能观察真实 thenable 的异步失败，
+ * 不能因对 undefined 调用 .catch 而把已经投递的命令误判成发送失败。
+ */
+function observeSendRejection(result: unknown, onRejected: (reason: unknown) => void): void {
+  if (
+    result === null ||
+    (typeof result !== 'object' && typeof result !== 'function') ||
+    typeof (result as PromiseLike<unknown>).then !== 'function'
+  ) {
+    return;
+  }
+  void Promise.resolve(result).catch(onRejected);
+}
+
 export type BrowserCommentMode = 'off' | 'starting' | 'selecting' | 'pending' | 'submitting';
 
 interface PendingBrowserCommentCommand {
@@ -125,6 +141,12 @@ export function useBrowserComment(
    * 已取消 / 已失效的选择追加进草稿(或把已退出的模式又拨回 selecting)。
    */
   const submitEpochRef = useRef(0);
+  /**
+   * appendBrowserCommentToDraft 是用户数据的提交点。其后的 guest ACK 只负责
+   * 收尾 overlay；若此时 WebView 导航 / 崩溃 / 换代，仍必须按成功上报，不能
+   * 用 lifecycle failure 诱导用户重试并重复写入同一条评论。
+   */
+  const committedSubmissionEpochRef = useRef<number | null>(null);
 
   const rejectCommandsForWebview = useCallback((target: WebviewTag) => {
     for (const [requestId, pending] of pendingCommandsRef.current) {
@@ -134,6 +156,18 @@ export function useBrowserComment(
       pending.reject(new Error('browser comment WebView changed'));
     }
   }, []);
+
+  const settleCommittedSubmission = useCallback(
+    (epoch: number, nextMode: Extract<BrowserCommentMode, 'off' | 'selecting'>): boolean => {
+      if (committedSubmissionEpochRef.current !== epoch) return false;
+      committedSubmissionEpochRef.current = null;
+      setPendingTarget(null);
+      setMode(nextMode);
+      toast.success(tRef.current('rightSidebar.browser.commentAdded'));
+      return true;
+    },
+    [],
+  );
 
   /**
    * 向当前 WebView 发送一条必须确认完成的命令。requestId resolver 与具体
@@ -161,20 +195,18 @@ export function useBrowserComment(
           reject,
         });
 
-        try {
-          void target.send(command, envelope).catch((reason: unknown) => {
-            const pending = pendingCommandsRef.current.get(requestId);
-            if (!pending) return;
-            clearTimeout(pending.timer);
-            pendingCommandsRef.current.delete(requestId);
-            reject(reason instanceof Error ? reason : new Error('browser comment send failed'));
-          });
-        } catch (reason) {
+        const rejectDelivery = (reason: unknown) => {
           const pending = pendingCommandsRef.current.get(requestId);
           if (!pending) return;
           clearTimeout(pending.timer);
           pendingCommandsRef.current.delete(requestId);
           reject(reason instanceof Error ? reason : new Error('browser comment send failed'));
+        };
+
+        try {
+          observeSendRejection(target.send(command, envelope), rejectDelivery);
+        } catch (reason) {
+          rejectDelivery(reason);
         }
       });
     },
@@ -191,7 +223,7 @@ export function useBrowserComment(
         payload,
       };
       try {
-        void target.send(command, envelope).catch(() => undefined);
+        observeSendRejection(target.send(command, envelope), () => undefined);
       } catch {
         // WebView 正在 detach / destroy；host 仍可安全完成本地退出。
       }
@@ -203,18 +235,20 @@ export function useBrowserComment(
     const target = webviewRef.current;
     if (!target) return;
     try {
-      void target.send(channel, payload).catch(() => undefined);
+      observeSendRejection(target.send(channel, payload), () => undefined);
     } catch {
       // 实时预览是非关键通知；关键状态转换全部走 sendCommand。
     }
   }, []);
 
   const exitMode = useCallback(() => {
+    const committedEpoch = committedSubmissionEpochRef.current;
     submitEpochRef.current += 1; // 作废任何挂起中的提交
     sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
+    if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
     setMode('off');
     setPendingTarget(null);
-  }, [sendBestEffortCommand]);
+  }, [sendBestEffortCommand, settleCommittedSubmission]);
   const exitModeRef = useRef(exitMode);
   exitModeRef.current = exitMode;
 
@@ -342,28 +376,29 @@ export function useBrowserComment(
           };
           appendBrowserCommentToDraft(composerDraftKey, item);
           draftCommitted = true;
+          committedSubmissionEpochRef.current = epoch;
 
           // 5) Phase 2 连续标注:pending marker 转常驻,编号按草稿最大编号推进,
           //    回点选态继续标注(不退出模式,与 Codex 一致)。
           await sendCommand(BROWSER_COMMENT_COMMIT_PENDING_CHANNEL, {
             nextMarkerNumber: computeNextMarkerNumber(getDraft(composerDraftKey)?.browserComments),
           });
-          if (isStale()) return;
-          setPendingTarget(null);
-          setMode('selecting');
-          toast.success(t('rightSidebar.browser.commentAdded'));
-        } catch {
-          // 已退出 / 导航:模式与 marker 已由打断方复位,静默(不报错、不拨回)。
-          if (isStale()) return;
-          if (draftCommitted) {
-            // Composer 已经是用户数据的提交点。guest 收尾失败时不能把同一条评论
-            // 留在气泡里让用户重试并重复 append；退出本次 overlay，保留已写草稿。
-            sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
-            setPendingTarget(null);
-            setMode('off');
-            toast.success(t('rightSidebar.browser.commentAdded'));
+          if (isStale()) {
+            settleCommittedSubmission(epoch, 'off');
             return;
           }
+          settleCommittedSubmission(epoch, 'selecting');
+        } catch {
+          if (draftCommitted) {
+            // Composer 已经是用户数据的提交点。guest 收尾失败时不能把同一条评论
+            // 留在气泡里让用户重试并重复 append。即使 lifecycle 已作废本纪元，
+            // 也先结算成功；若 lifecycle 已抢先结算，epoch guard 会避免重复 toast。
+            if (!isStale()) sendBestEffortCommand(BROWSER_COMMENT_EXIT_MODE_CHANNEL);
+            settleCommittedSubmission(epoch, 'off');
+            return;
+          }
+          // 已退出 / 导航:模式与 marker 已由打断方复位,静默(不报错、不拨回)。
+          if (isStale()) return;
           if (target.immediate) {
             // immediate 没有 Popover / 用户输入可保留。失败时撤掉本次 pending
             // marker 并回点选态，用户可以直接重新 Cmd/Ctrl+点击；不能把 host
@@ -389,7 +424,15 @@ export function useBrowserComment(
         }
       })();
     },
-    [composerDraftKey, exitMode, sendBestEffortCommand, sendCommand, t, tabId],
+    [
+      composerDraftKey,
+      exitMode,
+      sendBestEffortCommand,
+      sendCommand,
+      settleCommittedSubmission,
+      t,
+      tabId,
+    ],
   );
   const doSubmitRef = useRef(doSubmit);
   doSubmitRef.current = doSubmit;
@@ -424,8 +467,11 @@ export function useBrowserComment(
     const previousWebview = webviewRef.current;
     webviewRef.current = webview;
     if (previousWebview && previousWebview !== webview) {
+      const committedEpoch = committedSubmissionEpochRef.current;
       submitEpochRef.current += 1;
-      if (
+      if (committedEpoch !== null) {
+        settleCommittedSubmission(committedEpoch, 'off');
+      } else if (
         modeRef.current === 'pending' ||
         modeRef.current === 'submitting' ||
         pendingTargetRef.current
@@ -477,7 +523,9 @@ export function useBrowserComment(
         }
         case BROWSER_COMMENT_MODE_EXITED_CHANNEL: {
           // guest 内按了 Esc,overlay 已自拆 —— host 只同步状态。
+          const committedEpoch = committedSubmissionEpochRef.current;
           submitEpochRef.current += 1; // 作废任何挂起中的提交
+          if (committedEpoch !== null && settleCommittedSubmission(committedEpoch, 'off')) return;
           setMode('off');
           setPendingTarget(null);
           return;
@@ -498,7 +546,7 @@ export function useBrowserComment(
       webview.removeEventListener('did-navigate-in-page', onNavigate);
       rejectCommandsForWebview(webview);
     };
-  }, [rejectCommandsForWebview, webview]);
+  }, [rejectCommandsForWebview, settleCommittedSubmission, webview]);
 
   // tab 卸载 / 切走时若模式仍开着,通知 guest 拆 overlay(webview 被 pool 保活,
   // 不通知的话 overlay 会一直趴在页面上)。

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/useBrowserComment.ts
@@ -236,7 +236,9 @@ export function useBrowserComment(
       },
       () => {
         if (submitEpochRef.current !== epoch) return;
-        setMode('off');
+        // send 已到 guest 但 ACK 丢失时，guest 可能已经挂上 overlay。失败路径
+        // 必须与用户主动退出走同一套清理，不能只关闭 host 按钮状态。
+        exitMode();
         toast.error(tRef.current('rightSidebar.browser.commentFailed'));
       },
     );
@@ -362,14 +364,32 @@ export function useBrowserComment(
             toast.success(t('rightSidebar.browser.commentAdded'));
             return;
           }
-          // 截图 / 缓存 / guest 准备失败：pendingTarget 与 Popover 实例都保留，
-          // 用户输入不会卸载丢失，可直接修订后重试或主动取消。
+          if (target.immediate) {
+            // immediate 没有 Popover / 用户输入可保留。失败时撤掉本次 pending
+            // marker 并回点选态，用户可以直接重新 Cmd/Ctrl+点击；不能把 host
+            // 留在一个没有 pendingTarget、也没有取消入口的 pending 状态。
+            try {
+              await sendCommand(BROWSER_COMMENT_CANCEL_PENDING_CHANNEL);
+              if (isStale()) return;
+              setPendingTarget(null);
+              setMode('selecting');
+            } catch {
+              if (isStale()) return;
+              // 无法确认 pending marker 已撤除时，整体退出比继续展示失配状态安全。
+              exitMode();
+            }
+            toast.error(t('rightSidebar.browser.commentFailed'));
+            return;
+          }
+          // 普通气泡提交失败：pendingTarget 与 Popover 实例都保留，用户输入不会
+          // 卸载丢失，可直接修订后重试或主动取消。guest 在截图准备期间始终保有
+          // 透明 blocker，因此底层网页也不会抢走点击。
           setMode('pending');
           toast.error(t('rightSidebar.browser.commentFailed'));
         }
       })();
     },
-    [composerDraftKey, sendBestEffortCommand, sendCommand, t, tabId],
+    [composerDraftKey, exitMode, sendBestEffortCommand, sendCommand, t, tabId],
   );
   const doSubmitRef = useRef(doSubmit);
   doSubmitRef.current = doSubmit;

--- a/apps/desktop/src/shared/browserComment.ts
+++ b/apps/desktop/src/shared/browserComment.ts
@@ -26,9 +26,11 @@ export const BROWSER_COMMENT_EXIT_MODE_CHANNEL = 'browser-comment:exit-mode';
 export const BROWSER_COMMENT_CANCEL_PENDING_CHANNEL = 'browser-comment:cancel-pending';
 /**
  * 截图前置:guest 隐藏交互层与 hover 高亮,只保留蓝色 marker(含已提交的常驻
- * marker)与当前 pending 的区域框 / 文本高亮,待页面完成两帧渲染后回
- * `screenshot-prepared`。host 收到后再调 main capturePage,保证截图里只有
- * 标注、没有交互 UI。无 payload。
+ * marker)与当前 pending 的区域框 / 文本高亮,并继续保留透明 blocker 隔离
+ * 页面输入。页面完成两帧渲染后,guest 通过统一的
+ * {@link BROWSER_COMMENT_COMMAND_RESULT_CHANNEL} 回执当前 requestId；host
+ * 收到 matching ACK 后再调 main capturePage,保证截图里只有标注、没有可见
+ * 交互 UI。
  */
 export const BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL = 'browser-comment:prepare-screenshot';
 /**

--- a/apps/desktop/src/shared/browserComment.ts
+++ b/apps/desktop/src/shared/browserComment.ts
@@ -50,14 +50,38 @@ export const BROWSER_COMMENT_DESIGN_RESET_CHANNEL = 'browser-comment:design-rese
 
 // ── guest → host ───────────────────────────────────────────────────────────
 
+/**
+ * 关键 host → guest 命令的统一完成回执。host 只在收到当前 WebView 代际发回的
+ * matching requestId 后推进评论状态机，避免 `webview.send()` 丢失时两端状态分叉。
+ */
+export const BROWSER_COMMENT_COMMAND_RESULT_CHANNEL = 'browser-comment:command-result';
 /** 用户在页面里点选了一个元素。payload: {@link BrowserCommentTargetInfo} */
 export const BROWSER_COMMENT_ELEMENT_SELECTED_CHANNEL = 'browser-comment:element-selected';
-/** prepare-screenshot 完成(交互层已隐藏、marker 已渲染稳定)。无 payload。 */
-export const BROWSER_COMMENT_SCREENSHOT_PREPARED_CHANNEL = 'browser-comment:screenshot-prepared';
 /** guest 侧主动退出评论模式(用户在页面里按 Esc)。无 payload。 */
 export const BROWSER_COMMENT_MODE_EXITED_CHANNEL = 'browser-comment:mode-exited';
 
 // ── payload 类型 ────────────────────────────────────────────────────────────
+
+/** 需要确认完成的 host → guest 命令集合。高频样式预览仍走无回执通知。 */
+export type BrowserCommentCommandChannel =
+  | typeof BROWSER_COMMENT_ENTER_MODE_CHANNEL
+  | typeof BROWSER_COMMENT_EXIT_MODE_CHANNEL
+  | typeof BROWSER_COMMENT_CANCEL_PENDING_CHANNEL
+  | typeof BROWSER_COMMENT_PREPARE_SCREENSHOT_CHANNEL
+  | typeof BROWSER_COMMENT_COMMIT_PENDING_CHANNEL;
+
+/** host 包裹关键命令的传输信封；requestId 在单个评论控制器生命周期内唯一。 */
+export interface BrowserCommentCommandEnvelope<T = unknown> {
+  requestId: string;
+  payload?: T;
+}
+
+/** guest 执行关键命令后的统一结果；不把第三方页面异常细节跨边界返回 host。 */
+export interface BrowserCommentCommandResult {
+  requestId: string;
+  command: BrowserCommentCommandChannel;
+  ok: boolean;
+}
 
 /** host → guest enter-mode 的参数。 */
 export interface BrowserCommentEnterModePayload {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 内置浏览器页面评论偶发无法打开、提交后不进入 Composer、随后无法再次评论且输入丢失的问题。

根因是评论 Hook 只按 `tabId` 绑定事件，而 WebView Pool 会延迟创建、LRU 淘汰并重建 WebView。新一代 WebView 没有重新绑定评论消息监听；同时关键命令使用 fire-and-forget `webview.send()`，Host 会在 Guest 未实际进入评论模式时提前推进本地状态，提交失败后又会卸载 Popover，导致两端状态分叉和用户输入丢失。

本 PR 将评论链路重构为 WebView 代际感知、request/ack 驱动的状态机：

- `useBrowserWebview` 显式暴露当前 WebView 代际句柄，评论 Hook 按对象代际拆旧挂新，不再自行从 Pool 临时 `peek`。
- enter / prepare screenshot / cancel / commit 使用统一 command envelope 和 matching requestId 回执；旧代际或错误命令的回执不能推进当前状态。
- `webview.send()` 同步异常、Promise rejection、Guest 拒绝和 2 秒无回执都会进入一致的失败路径。
- 只有 Guest 确认 `enter-mode` 后 Host 才进入 selecting。
- 截图或缓存失败时保留 pending target 和原 Popover 实例，用户输入可直接重试或取消，不再卸载丢失。
- Composer 写入作为用户数据提交点；写入后 Guest 收尾失败会退出失配 overlay，但不会让用户重复提交同一条评论。
- 无有效 Composer session 时不再展示评论入口。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈；已确认开放的 #216 是“已有评论无法二次编辑”，不覆盖本次 WebView 生命周期竞态。
- 本 PR 包含：Desktop Renderer 评论状态机、WebView generation handle、Browser Comment preload 内部协议及回归测试。
- 明确不包含：已有评论二次编辑、评论图片输入、评论 UI 视觉调整。
- 用户可见变化：评论入口只在 Guest 真正就绪后进入激活态；提交前失败保留原输入并允许重试；WebView 重建后评论功能可重新正常使用。
- 是否存在 breaking change：无。协议仅在同一个 Desktop 构建内的 Renderer 与强制注入 preload 之间使用，并随应用原子发布。

### UI 变化

不涉及：未修改布局、视觉样式、动效或 UI 文案；仅修正既有评论交互的状态同步与失败恢复。

- 引用的设计规范：不涉及视觉设计变更。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；runner 310 passed / 1 expected skip，全部 workspace unit tests 通过（rebase 到最新 upstream/main 后重新执行）。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec vitest run \
  src/preload/__tests__/browserCommentPreload.test.ts \
  src/renderer/features/right-sidebar/plugins/web-browser/__tests__/useBrowserComment.test.ts \
  src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts \
  src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
结果：6 files / 62 tests passed。

pnpm --filter desktop exec eslint <本 PR 涉及的 9 个 TS/TSX 文件>
结果：通过。

pnpm check:dco
结果：通过；10 个 commits 均已签名。
```

新增回归覆盖：隐藏 Tab 延迟创建、LRU 重建、新旧 listener 拆挂、send rejection、无 ACK 超时、Guest 拒绝、prepare 失败保留输入、Composer 单次写入、Guest commit 失败的数据保留、preload command ACK 契约和导航退出。

### 手工验证

未执行实机重启验证。该改动包含 preload，需要完整重启 Desktop；当前环境不主动停止用户正在运行的 Cindy 实例。关键交互与故障窗口由 jsdom WebView/IPC harness 和全仓单测覆盖。

### 未执行的验证

- 未在 Windows 实机验证；改动不包含平台分支、路径或原生 API，WebView command/ack 语义两端一致。
- 未启动隔离 Desktop 实例，原因见上。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 内置浏览器页面评论的 Renderer ↔ guest preload 内部消息协议。未新增 main IPC、权限、文件路径或远程能力。
- 用户数据：提交前失败不再丢弃输入；Composer append 是提交点，之后的 Guest 同步失败不会触发重复 append。
- 协议兼容：Renderer 与 browserCommentPreload 同包发布，不存在跨版本独立部署；malformed request 不执行命令，失败只返回布尔结果，不回传第三方页面异常细节。
- 回滚 / 降级方式：整体回滚本 commit，恢复旧的 fire-and-forget 评论协议。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及视觉变化）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因



### 主线测试基线说明

`8b4c59a1` 只修正 `updateNoticeDialogAutoLayout.test.tsx` 的既有测试契约，不修改更新公告 UI 或本 PR 的浏览器评论行为。分支同步到 `upstream/main@9f67c102` 后，当前 `UpdateNoticeDialog` 已由每个 `VersionBlock` 分别渲染版本徽标，但旧断言仍期待单个 `v<oldest> → v<newest>` range badge，导致 Desktop 门禁在与本 PR 无关的断言上失败。该提交将测试对齐主线实际渲染结果，避免用过期契约阻塞本 PR；生产代码无变化。





