### PR TITLE
fix(desktop): 修复 CJK 全角标点相邻时加粗星号解析失败

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -153,6 +153,7 @@
     "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",
+    "remark-cjk-friendly": "^2.3.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "sharp": "^0.35.0",

--- a/apps/desktop/resources/THIRD-PARTY-NOTICES.txt
+++ b/apps/desktop/resources/THIRD-PARTY-NOTICES.txt
@@ -3968,7 +3968,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (801 packages)
+SECTION 2: npm packages (806 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
@@ -4385,6 +4385,7 @@ SECTION 2: npm packages (801 packages)
 - gcp-metadata@8.1.2 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gcp-metadata@8.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - get-caller-file@2.0.5 — ISC — https://github.com/stefanpenner/get-caller-file
+- get-east-asian-width@1.6.0 — MIT — https://github.com/sindresorhus/get-east-asian-width
 - get-intrinsic@1.3.0 — MIT — https://github.com/ljharb/get-intrinsic
 - get-nonce@1.0.1 — MIT — https://github.com/theKashey/get-nonce
 - get-proto@1.0.1 — MIT — https://github.com/ljharb/get-proto
@@ -4520,6 +4521,7 @@ SECTION 2: npm packages (801 packages)
 - mdast-util-phrasing@4.1.0 — MIT — https://github.com/syntax-tree/mdast-util-phrasing
 - mdast-util-to-hast@13.2.1 — MIT — https://github.com/syntax-tree/mdast-util-to-hast
 - mdast-util-to-markdown@2.1.2 — MIT — https://github.com/syntax-tree/mdast-util-to-markdown
+- mdast-util-to-markdown-cjk-friendly@1.0.0 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - mdast-util-to-string@4.0.0 — MIT — https://github.com/syntax-tree/mdast-util-to-string
 - media-typer@1.1.0 — MIT — https://github.com/jshttp/media-typer
 - merge-descriptors@2.0.0 — MIT — https://github.com/sindresorhus/merge-descriptors
@@ -4527,6 +4529,8 @@ SECTION 2: npm packages (801 packages)
 - mermaid@11.16.0 — MIT — https://github.com/mermaid-js/mermaid
 - micromark@4.0.2 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark
 - micromark-core-commonmark@2.0.3 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark-core-commonmark
+- micromark-extension-cjk-friendly@2.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
+- micromark-extension-cjk-friendly-util@3.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - micromark-extension-gfm@3.0.0 — MIT — https://github.com/micromark/micromark-extension-gfm
 - micromark-extension-gfm-autolink-literal@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-autolink-literal
 - micromark-extension-gfm-footnote@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-footnote
@@ -4651,6 +4655,7 @@ SECTION 2: npm packages (801 packages)
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
+- remark-cjk-friendly@2.3.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - remark-gfm@4.0.1 — MIT — https://github.com/remarkjs/remark-gfm
 - remark-math@6.0.0 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/remark-math
 - remark-parse@11.0.0 — MIT — https://github.com/remarkjs/remark/tree/main/packages/remark-parse
@@ -28359,7 +28364,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[174] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35308,7 +35313,39 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[356] Applies to: npm:merge-descriptors@2.0.0
+[356] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on remark-gfm:
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[357] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35323,7 +35360,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[357] Applies to: npm:merge-stream@2.0.0
+[358] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35348,7 +35385,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[358] Applies to: npm:mermaid@11.16.0
+[359] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35373,7 +35410,71 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[359] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[360] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark and micromark-core-commonmark
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[361] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark's sub-packages (micromark-util-character, micromark-util-symbol, and micromark-util-classify-character)
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[362] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35399,7 +35500,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[360] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[363] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35426,7 +35527,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[361] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[364] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -35445,7 +35546,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[362] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
+[365] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -35504,7 +35605,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[363] Applies to: npm:mkdirp@0.5.6
+[366] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -35529,7 +35630,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[364] Applies to: npm:mkdirp-classic@0.5.3
+[367] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35554,7 +35655,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[365] Applies to: npm:ms@2.0.0
+[368] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35579,7 +35680,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[366] Applies to: npm:ms@2.1.3
+[369] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35604,7 +35705,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[367] Applies to: npm:nan@2.28.0
+[370] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35617,7 +35718,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[368] Applies to: npm:napi-build-utils@2.0.0
+[371] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35642,7 +35743,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[369] Applies to: npm:negotiator@1.0.0
+[372] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35670,7 +35771,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[370] Applies to: npm:node-abi@3.94.0
+[373] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35695,7 +35796,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[371] Applies to: npm:node-addon-api@7.1.1
+[374] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35708,7 +35809,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[372] Applies to: npm:node-domexception@1.0.0
+[375] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35733,7 +35834,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[373] Applies to: npm:node-fetch@3.3.2
+[376] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35758,7 +35859,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[374] Applies to: npm:node-machine-id@1.1.12
+[377] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35783,7 +35884,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[375] Applies to: npm:node-pty@1.1.0
+[378] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -35856,7 +35957,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[376] Applies to: npm:object-inspect@1.13.4
+[379] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35881,7 +35982,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[377] Applies to: npm:on-finished@2.4.1
+[380] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35908,7 +36009,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[378] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[381] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -35931,7 +36032,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[379] Applies to: npm:package-json-from-dist@1.0.1
+[382] Applies to: npm:package-json-from-dist@1.0.1
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -35998,7 +36099,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[380] Applies to: npm:package-manager-detector@1.7.0
+[383] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36023,7 +36124,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[381] Applies to: npm:pako@1.0.11
+[384] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36048,7 +36149,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[382] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[385] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36074,7 +36175,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[383] Applies to: npm:parse5@7.3.0
+[386] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -36097,7 +36198,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[384] Applies to: npm:parseurl@1.3.3
+[387] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36124,7 +36225,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[385] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[388] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36149,7 +36250,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[386] Applies to: npm:path-to-regexp@8.4.2
+[389] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36174,7 +36275,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[387] Applies to: npm:pdfjs-dist@5.7.284
+[390] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -36354,7 +36455,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[388] Applies to: npm:picomatch@4.0.5
+[391] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36379,7 +36480,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[389] Applies to: npm:pkce-challenge@5.0.1
+[392] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36404,7 +36505,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[390] Applies to: npm:playwright-core@1.60.0
+[393] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -36610,7 +36711,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[391] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[394] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -36621,7 +36722,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[392] Applies to: npm:pngjs@5.0.0
+[395] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -36645,7 +36746,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[393] Applies to: npm:points-on-path@0.2.1
+[396] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36670,7 +36771,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[394] Applies to: npm:prebuild-install@7.1.3
+[397] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36695,7 +36796,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[395] Applies to: npm:process-nextick-args@2.0.1
+[398] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -36718,7 +36819,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[396] Applies to: npm:promise-worker-transferable@1.0.4
+[399] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -36923,7 +37024,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[397] Applies to: npm:prosemirror-changeset@2.4.1
+[400] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -36946,7 +37047,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[398] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[401] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -36969,7 +37070,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[399] Applies to: npm:prosemirror-tables@1.8.5
+[402] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -36992,7 +37093,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[400] Applies to: npm:protobufjs@7.6.5
+[403] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -37035,7 +37136,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[401] Applies to: npm:proxy-from-env@2.1.0
+[404] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -37059,7 +37160,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[402] Applies to: npm:qrcode@1.5.4
+[405] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37072,7 +37173,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[403] Applies to: npm:qs@6.15.3
+[406] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -37105,7 +37206,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[404] Applies to: npm:range-parser@1.3.0
+[407] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37132,7 +37233,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[405] Applies to: npm:raw-body@3.0.2
+[408] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37158,7 +37259,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[406] Applies to: npm:rc@1.2.8
+[409] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -37229,7 +37330,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[407] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[410] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37254,7 +37355,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[408] Applies to: npm:react-i18next@17.0.10
+[411] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37279,7 +37380,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[409] Applies to: npm:react-markdown@10.1.0
+[412] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37304,7 +37405,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[410] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[413] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37331,7 +37432,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[411] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[414] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -37382,7 +37483,7 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[412] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[415] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37407,7 +37508,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[413] Applies to: npm:require-directory@2.1.1
+[416] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37433,7 +37534,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[414] Applies to: npm:require-from-string@2.0.2
+[417] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37458,7 +37559,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[415] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[418] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -37476,7 +37577,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[416] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+[419] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -37504,7 +37605,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 ------------------------------------------------------------------------------
-[417] Applies to: npm:rope-sequence@1.3.4
+[420] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -37527,7 +37628,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[418] Applies to: npm:roughjs@4.6.6
+[421] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37552,7 +37653,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[419] Applies to: npm:router@2.2.0
+[422] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37579,7 +37680,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[420] Applies to: npm:rw@1.3.3
+[423] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -37609,7 +37710,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[421] Applies to: npm:safer-buffer@2.1.2
+[424] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37634,7 +37735,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[422] Applies to: npm:section-matter@1.0.0
+[425] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37659,7 +37760,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[423] Applies to: npm:send@1.2.1
+[426] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37686,7 +37787,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[424] Applies to: npm:serve-static@2.2.1
+[427] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37715,7 +37816,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[425] Applies to: npm:set-cookie-parser@2.7.2
+[428] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37740,7 +37841,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[426] Applies to: npm:setimmediate@1.0.5
+[429] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -37764,7 +37865,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[427] Applies to: npm:setprototypeof@1.2.0
+[430] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -37781,7 +37882,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[428] Applies to: npm:shebang-command@2.0.0
+[431] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37794,7 +37895,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[429] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[432] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37819,7 +37920,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[430] Applies to: npm:signal-exit@3.0.7
+[433] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -37839,7 +37940,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[431] Applies to: npm:signal-exit@4.1.0
+[434] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -37859,7 +37960,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[432] Applies to: npm:silk-wasm@3.7.1
+[435] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37884,7 +37985,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[433] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[436] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37908,7 +38009,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[434] Applies to: npm:smol-toml@1.7.0
+[437] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -37936,7 +38037,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[435] Applies to: npm:sortablejs@1.15.7
+[438] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37961,7 +38062,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[436] Applies to: npm:sprintf-js@1.0.3
+[439] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -37989,7 +38090,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[437] Applies to: npm:ssh-config@5.2.0
+[440] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38014,7 +38115,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[438] Applies to: npm:statuses@2.0.2
+[441] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38040,7 +38141,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[439] Applies to: npm:strip-bom-string@1.0.0
+[442] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38065,7 +38166,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[440] Applies to: npm:style-mod@4.1.3
+[443] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -38088,7 +38189,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[441] Applies to: npm:style-to-js@1.1.21
+[444] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38114,7 +38215,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[442] Applies to: npm:style-to-object@1.0.14
+[445] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38140,7 +38241,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[443] Applies to: npm:stylis@4.4.0
+[446] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38165,7 +38266,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[444] Applies to: npm:tailwind-merge@2.6.1
+[447] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38190,7 +38291,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[445] Applies to: npm:tinyexec@1.2.4
+[448] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38215,7 +38316,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[446] Applies to: npm:toidentifier@1.0.1
+[449] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38240,7 +38341,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[447] Applies to: npm:trough@2.2.0
+[450] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38265,7 +38366,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[448] Applies to: npm:ts-dedent@2.3.0
+[451] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38290,7 +38391,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[449] Applies to: npm:ts-mixer@6.0.4
+[452] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38315,7 +38416,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[450] Applies to: npm:tslib@2.8.1
+[453] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -38331,7 +38432,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[451] Applies to: npm:tslog@4.11.0
+[454] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38356,7 +38457,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[452] Applies to: npm:tunnel-agent@0.6.0
+[455] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -38415,7 +38516,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[453] Applies to: npm:type-fest@0.20.2
+[456] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38428,7 +38529,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[454] Applies to: npm:typebox@1.1.39
+[457] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -38455,7 +38556,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[455] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[458] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38480,7 +38581,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[456] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[459] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38505,7 +38606,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[457] Applies to: npm:unist-util-is@6.0.1
+[460] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -38531,7 +38632,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[458] Applies to: npm:universalify@2.0.1
+[461] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38555,7 +38656,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[459] Applies to: npm:unpipe@1.0.0
+[462] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38581,7 +38682,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[460] Applies to: npm:uri-js@4.4.1
+[463] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -38596,7 +38697,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[461] Applies to: npm:url-template@2.0.8
+[464] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -38625,7 +38726,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[462] Applies to: npm:util-deprecate@1.0.2
+[465] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38653,7 +38754,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[463] Applies to: npm:uuid@14.0.1
+[466] Applies to: npm:uuid@14.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38666,7 +38767,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[464] Applies to: npm:void-elements@3.1.0
+[467] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38692,7 +38793,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[465] Applies to: npm:web-streams-polyfill@3.3.3
+[468] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38718,7 +38819,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[466] Applies to: npm:which-module@2.0.1
+[469] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -38735,7 +38836,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[467] Applies to: npm:workerpool@9.1.1
+[470] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -38940,7 +39041,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[468] Applies to: npm:ws@8.21.1
+[471] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -38964,7 +39065,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[469] Applies to: npm:y18n@4.0.3
+[472] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -38981,7 +39082,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[470] Applies to: npm:yargs@15.4.1
+[473] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -39006,7 +39107,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[471] Applies to: npm:zod@4.3.6
+[474] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -39031,7 +39132,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[472] Applies to: npm:zod-to-json-schema@3.25.2
+[475] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 

--- a/apps/desktop/src/renderer/__tests__/markdownCjkStrongDelimiter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownCjkStrongDelimiter.test.ts
@@ -1,0 +1,112 @@
+/**
+ * markdownCjkStrongDelimiter.test.ts
+ * ---------------------------------------------------------------------------
+ * CJK 全角标点相邻时 `**` 加粗定界失效的修复回归:
+ *
+ * CommonMark 的 emphasis 侧翼(flanking)规则把全角标点(。：，“”（）等)算作
+ * 「标点」:`**` 内侧挨全角标点、外侧挨普通字符时,开/闭侧翼不成立,整对星号
+ * 退化成字面量。AI 中文输出的高频写法——「**小标题：**正文」「**“术语”**」
+ * 「**（注）**」——全部中招,正文里残留原始 `**`。mobile 自研 parser
+ * (messageMarkdown.ts 用正则配对)不受该规则约束,desktop 是唯一例外端。
+ *
+ * 修复:MarkdownRenderer 两条插件链在 remarkGfm 之后注册 remarkCjkFriendly
+ * (官方示例顺序),放宽侧翼判定——全角标点不再当「标点」。只影响
+ * emphasis/strong 定界,不碰 `~~` 删除线与公式。
+ *
+ * 1. 管线级真实渲染:镜像 MarkdownRenderer 的插件配置,验证历史失败样例产出
+ *    <strong>,且字面量/代码/链接/删除线/公式行为不回退。
+ * 2. source-contract 锚定:grep MarkdownRenderer 源码,确保两条插件链都注册
+ *    remarkCjkFriendly(静默回退时 typecheck / lint 都拦不住)。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkCjkFriendly from 'remark-cjk-friendly';
+import remarkMath from 'remark-math';
+
+function renderMarkdown(markdown: string): string {
+  return renderToStaticMarkup(
+    createElement(ReactMarkdown, {
+      remarkPlugins: [[remarkGfm, { singleTilde: false }], remarkCjkFriendly, remarkMath],
+      children: markdown,
+    }),
+  );
+}
+
+describe('CJK 加粗定界(remarkCjkFriendly)', () => {
+  it.each([
+    ['全角冒号收尾', '这是**重点：**内容', '重点：'],
+    ['全角句号收尾', '这是**重点。**内容', '重点。'],
+    ['全角括号包裹', '这是**（重点）**内容', '（重点）'],
+    ['中文引号包裹', '这是**“重点”**内容', '“重点”'],
+    ['全角逗号开头', '这是**，重点**内容', '，重点'],
+    ['引号包词嵌句中', '称**“双循环”**为', '“双循环”'],
+    ['行首小标题', '**注意：**内容', '注意：'],
+    ['混合长句', '先看：**“后续不能再卖”——这就是终点站。**从第一轮', '“后续不能再卖”——这就是终点站。'],
+  ])('历史失败样例可解析为 <strong>:%s', (_name, input, strongText) => {
+    const html = renderMarkdown(input);
+    expect(html).toContain(`<strong>${strongText}</strong>`);
+  });
+
+  it.each([
+    ['纯中文', '这是**重点**内容'],
+    ['英文', 'this is **bold** text'],
+    ['英文加粗后跟半角逗号', 'this is **bold**, text'],
+    ['全角括号在外侧', '（**重点**）内容'],
+  ])('原本可解析的写法不回退:%s', (_name, input) => {
+    expect(renderMarkdown(input)).toContain('<strong>');
+  });
+
+  it('两侧带空格的星号保持字面量(「2 ** 3 ** 4」不误判)', () => {
+    const html = renderMarkdown('计算 2 ** 3 ** 4 的结果');
+    expect(html).not.toContain('<strong>');
+  });
+
+  it('转义的星号保持字面量', () => {
+    const html = renderMarkdown('\\*\\*转义\\*\\*');
+    expect(html).not.toContain('<strong>');
+  });
+
+  it('行内代码里的星号保持字面量', () => {
+    const html = renderMarkdown('`**code**`');
+    expect(html).toContain('<code>**code**</code>');
+    expect(html).not.toContain('<strong>');
+  });
+
+  it('链接地址里的星号不参与加粗判定', () => {
+    const html = renderMarkdown('[glob](https://example.test/**index.**html)');
+    expect(html).toContain('href="https://example.test/**index.**html"');
+    expect(html).not.toContain('<strong>');
+  });
+
+  it('`~~` 删除线行为不受影响', () => {
+    const html = renderMarkdown('这段 ~~已废弃~~ 的说法');
+    expect(html).toContain('<del>已废弃</del>');
+  });
+
+  it('公式里的星号不参与加粗判定', () => {
+    const html = renderMarkdown('公式 $a**b$ 结束');
+    expect(html).not.toContain('<strong>');
+  });
+});
+
+describe('MarkdownRenderer — remarkCjkFriendly source contract', () => {
+  const source = readFileSync(
+    resolve(__dirname, '..', 'components', 'chat', 'MarkdownRenderer.tsx'),
+    'utf8',
+  );
+
+  it('两条 remark 插件链都在 remarkGfm 之后注册 remarkCjkFriendly', () => {
+    const pluginArrays = source.match(/const REMARK_PLUGINS\b[^=]*= \[[\s\S]*?\];/)?.[0] ?? '';
+    const privilegedArrays = source.match(/const REMARK_PLUGINS_PRIVILEGED\b[^=]*= \[[\s\S]*?\];/)?.[0] ?? '';
+    for (const plugins of [pluginArrays, privilegedArrays]) {
+      expect(plugins).toContain('remarkCjkFriendly');
+      expect(plugins.indexOf('remarkGfm')).toBeLessThan(plugins.indexOf('remarkCjkFriendly'));
+    }
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -14,6 +14,7 @@
 import { createElement, memo, useEffect, useRef, useState, useMemo, isValidElement, type HTMLAttributes, type ReactNode } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkCjkFriendly from 'remark-cjk-friendly';
 import remarkMath from 'remark-math';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeKatex from 'rehype-katex';
@@ -172,8 +173,16 @@ function isMermaidCodeChild(child: ReactNode): boolean {
 // remarkGfm singleTilde:false — 删除线只认标准 GFM 的 `~~text~~`,单个 `~` 保持
 // 字面量。默认 singleTilde:true 会把「4~6……4~6」这类区间写法中间整段划成删除线,
 // mobile 自研 parser(messageMarkdown.ts)本就只匹配 `~~`,此处对齐。
+// remarkCjkFriendly 紧随 remarkGfm 注册(官方示例顺序):放宽 CommonMark 加粗
+// 定界的侧翼(flanking)规则——CJK 全角标点(。：，“”（）等)不再被当作
+// 「标点」参与判定。原生规则下 `**` 内侧挨全角标点时开/闭侧翼不成立,整对
+// 星号退化成字面量(AI 高频写法「**小标题：**正文」「**“术语”**」「**（注）**」
+// 全中招);mobile 自研 parser 用正则配对本就能渲染这些写法,此处对齐。只放宽
+// emphasis/strong 的定界判定,不碰 `~~` 删除线(gfm strikethrough 有独立定界
+// 逻辑,行为不变),也不影响带空格的 `2 ** 3 ** 4` 这类本应保持字面量的写法。
 const REMARK_PLUGINS: PluggableList = [
   [remarkGfm, { singleTilde: false }],
+  remarkCjkFriendly,
   remarkMath,
   remarkStrictInlineMath,
   remarkTruncateCjkUrls,
@@ -183,6 +192,7 @@ const REMARK_PLUGINS: PluggableList = [
 ];
 const REMARK_PLUGINS_PRIVILEGED: PluggableList = [
   [remarkGfm, { singleTilde: false }],
+  remarkCjkFriendly,
   remarkMath,
   remarkStrictInlineMath,
   remarkTruncateCjkUrls,

--- a/docs/legal/notices/THIRD-PARTY-NOTICES.txt
+++ b/docs/legal/notices/THIRD-PARTY-NOTICES.txt
@@ -4299,7 +4299,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (1311 packages)
+SECTION 2: npm packages (1316 packages)
 ==============================================================================
 
 - @adobe/css-tools@4.5.0 — MIT — https://github.com/adobe/css-tools
@@ -5013,6 +5013,7 @@ SECTION 2: npm packages (1311 packages)
 - gcp-metadata@8.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gensync@1.0.0-beta.2 — MIT — https://github.com/loganfsmyth/gensync
 - get-caller-file@2.0.5 — ISC — https://github.com/stefanpenner/get-caller-file
+- get-east-asian-width@1.6.0 — MIT — https://github.com/sindresorhus/get-east-asian-width
 - get-intrinsic@1.3.0 — MIT — https://github.com/ljharb/get-intrinsic
 - get-nonce@1.0.1 — MIT — https://github.com/theKashey/get-nonce
 - get-proto@1.0.1 — MIT — https://github.com/ljharb/get-proto
@@ -5199,6 +5200,7 @@ SECTION 2: npm packages (1311 packages)
 - mdast-util-phrasing@4.1.0 — MIT — https://github.com/syntax-tree/mdast-util-phrasing
 - mdast-util-to-hast@13.2.1 — MIT — https://github.com/syntax-tree/mdast-util-to-hast
 - mdast-util-to-markdown@2.1.2 — MIT — https://github.com/syntax-tree/mdast-util-to-markdown
+- mdast-util-to-markdown-cjk-friendly@1.0.0 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - mdast-util-to-string@4.0.0 — MIT — https://github.com/syntax-tree/mdast-util-to-string
 - mdn-data@2.0.14 — CC0-1.0 — https://github.com/mdn/data
 - media-typer@1.1.0 — MIT — https://github.com/jshttp/media-typer
@@ -5224,6 +5226,8 @@ SECTION 2: npm packages (1311 packages)
 - metro-transform-worker@0.84.4 — MIT — https://github.com/facebook/metro
 - micromark@4.0.2 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark
 - micromark-core-commonmark@2.0.3 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark-core-commonmark
+- micromark-extension-cjk-friendly@2.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
+- micromark-extension-cjk-friendly-util@3.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - micromark-extension-gfm@3.0.0 — MIT — https://github.com/micromark/micromark-extension-gfm
 - micromark-extension-gfm-autolink-literal@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-autolink-literal
 - micromark-extension-gfm-footnote@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-footnote
@@ -5415,6 +5419,7 @@ SECTION 2: npm packages (1311 packages)
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
+- remark-cjk-friendly@2.3.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - remark-gfm@4.0.1 — MIT — https://github.com/remarkjs/remark-gfm
 - remark-math@6.0.0 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/remark-math
 - remark-parse@11.0.0 — MIT — https://github.com/remarkjs/remark/tree/main/packages/remark-parse
@@ -29879,7 +29884,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[202] Applies to: npm:ansi-escapes@4.3.2, npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:camelcase@6.3.0, npm:chalk@5.6.2, npm:cli-spinners@2.9.2, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@4.0.0, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-docker@2.2.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:open@7.4.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:supports-color@8.1.1, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[202] Applies to: npm:ansi-escapes@4.3.2, npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:camelcase@6.3.0, npm:chalk@5.6.2, npm:cli-spinners@2.9.2, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@4.0.0, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-docker@2.2.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:open@7.4.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:supports-color@8.1.1, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -39872,7 +39877,39 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[448] Applies to: npm:mdn-data@2.0.14
+[448] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on remark-gfm:
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[449] Applies to: npm:mdn-data@2.0.14
 ------------------------------------------------------------------------------
 CC0 1.0 Universal
 
@@ -39992,7 +40029,7 @@ For more information, please see
 <http://creativecommons.org/publicdomain/zero/1.0/>
 
 ------------------------------------------------------------------------------
-[449] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
+[450] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40017,7 +40054,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[450] Applies to: npm:merge-descriptors@2.0.0
+[451] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40032,7 +40069,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[451] Applies to: npm:merge-options@3.0.4
+[452] Applies to: npm:merge-options@3.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40057,7 +40094,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[452] Applies to: npm:merge-stream@2.0.0
+[453] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40082,7 +40119,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[453] Applies to: npm:mermaid@11.16.0
+[454] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40107,7 +40144,71 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[454] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[455] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark and micromark-core-commonmark
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[456] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark's sub-packages (micromark-util-character, micromark-util-symbol, and micromark-util-classify-character)
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[457] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -40133,7 +40234,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[455] Applies to: npm:mime@1.6.0
+[458] Applies to: npm:mime@1.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40158,7 +40259,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[456] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[459] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -40185,7 +40286,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[457] Applies to: npm:min-indent@1.0.1
+[460] Applies to: npm:min-indent@1.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40210,7 +40311,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[458] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[461] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -40229,7 +40330,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[459] Applies to: npm:mkdirp@0.5.6
+[462] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -40254,7 +40355,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[460] Applies to: npm:mkdirp@1.0.4
+[463] Applies to: npm:mkdirp@1.0.4
 ------------------------------------------------------------------------------
 Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
 
@@ -40279,7 +40380,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[461] Applies to: npm:mkdirp-classic@0.5.3
+[464] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40304,7 +40405,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[462] Applies to: npm:ms@2.0.0
+[465] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40329,7 +40430,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[463] Applies to: npm:ms@2.1.3
+[466] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40354,7 +40455,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[464] Applies to: npm:nan@2.28.0
+[467] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40367,7 +40468,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[465] Applies to: npm:nanoid@3.3.16
+[468] Applies to: npm:nanoid@3.3.16
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40391,7 +40492,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[466] Applies to: npm:napi-build-utils@2.0.0
+[469] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40416,7 +40517,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[467] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
+[470] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -40444,7 +40545,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[468] Applies to: npm:node-abi@3.94.0
+[471] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40469,7 +40570,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[469] Applies to: npm:node-addon-api@7.1.1
+[472] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40482,7 +40583,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[470] Applies to: npm:node-domexception@1.0.0
+[473] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40507,7 +40608,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[471] Applies to: npm:node-fetch@2.7.0
+[474] Applies to: npm:node-fetch@2.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40532,7 +40633,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[472] Applies to: npm:node-fetch@3.3.2
+[475] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40557,7 +40658,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[473] Applies to: npm:node-forge@1.4.0
+[476] Applies to: npm:node-forge@1.4.0
 ------------------------------------------------------------------------------
 You may use the Forge project under the terms of either the BSD License or the
 GNU General Public License (GPL) Version 2.
@@ -40891,7 +40992,7 @@ PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
 ------------------------------------------------------------------------------
-[474] Applies to: npm:node-int64@0.4.0
+[477] Applies to: npm:node-int64@0.4.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Robert Kieffer
 
@@ -40914,7 +41015,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[475] Applies to: npm:node-machine-id@1.1.12
+[478] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40939,7 +41040,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[476] Applies to: npm:node-pty@1.1.0
+[479] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -41012,7 +41113,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[477] Applies to: npm:node-releases@2.0.51
+[480] Applies to: npm:node-releases@2.0.51
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -41037,7 +41138,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[478] Applies to: npm:npm-package-arg@11.0.3
+[481] Applies to: npm:npm-package-arg@11.0.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -41056,7 +41157,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[479] Applies to: npm:nullthrows@1.1.1
+[482] Applies to: npm:nullthrows@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2016 Andres Suarez
@@ -41068,7 +41169,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[480] Applies to: npm:object-inspect@1.13.4
+[483] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41093,7 +41194,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[481] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
+[484] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41120,7 +41221,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[482] Applies to: npm:on-headers@1.1.0
+[485] Applies to: npm:on-headers@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41146,7 +41247,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[483] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[486] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -41169,7 +41270,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[484] Applies to: npm:package-manager-detector@1.7.0
+[487] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41194,7 +41295,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[485] Applies to: npm:pako@1.0.11, npm:pako@2.2.0
+[488] Applies to: npm:pako@1.0.11, npm:pako@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41219,7 +41320,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[486] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[489] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41245,7 +41346,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[487] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
+[490] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41258,7 +41359,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[488] Applies to: npm:parse5@7.3.0
+[491] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -41281,7 +41382,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[489] Applies to: npm:parseurl@1.3.3
+[492] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41308,7 +41409,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[490] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[493] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41333,7 +41434,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[491] Applies to: npm:path-parse@1.0.7
+[494] Applies to: npm:path-parse@1.0.7
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41358,7 +41459,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[492] Applies to: npm:path-to-regexp@8.4.2
+[495] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41383,7 +41484,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[493] Applies to: npm:pdfjs-dist@5.7.284
+[496] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -41563,7 +41664,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[494] Applies to: npm:picocolors@1.1.1
+[497] Applies to: npm:picocolors@1.1.1
 ------------------------------------------------------------------------------
 ISC License
 
@@ -41582,7 +41683,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[495] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
+[498] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41607,7 +41708,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[496] Applies to: npm:pkce-challenge@5.0.1
+[499] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41632,7 +41733,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[497] Applies to: npm:playwright-core@1.60.0
+[500] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -41838,7 +41939,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[498] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[501] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -41849,7 +41950,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[499] Applies to: npm:plist@3.1.1
+[502] Applies to: npm:plist@3.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41877,7 +41978,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[500] Applies to: npm:pngjs@3.4.0, npm:pngjs@5.0.0
+[503] Applies to: npm:pngjs@3.4.0, npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -41901,7 +42002,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[501] Applies to: npm:points-on-path@0.2.1
+[504] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41926,7 +42027,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[502] Applies to: npm:postcss@8.5.19
+[505] Applies to: npm:postcss@8.5.19
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41950,7 +42051,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[503] Applies to: npm:postcss-value-parser@4.2.0
+[506] Applies to: npm:postcss-value-parser@4.2.0
 ------------------------------------------------------------------------------
 Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
 
@@ -41976,7 +42077,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[504] Applies to: npm:prebuild-install@7.1.3
+[507] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42001,7 +42102,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[505] Applies to: npm:proc-log@4.2.0
+[508] Applies to: npm:proc-log@4.2.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -42020,7 +42121,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[506] Applies to: npm:process-nextick-args@2.0.1
+[509] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -42043,7 +42144,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[507] Applies to: npm:progress@2.0.3
+[510] Applies to: npm:progress@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -42069,7 +42170,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[508] Applies to: npm:promise-worker-transferable@1.0.4
+[511] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -42274,7 +42375,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[509] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
+[512] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42299,7 +42400,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[510] Applies to: npm:prosemirror-changeset@2.4.1
+[513] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -42322,7 +42423,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[511] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[514] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -42345,7 +42446,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[512] Applies to: npm:prosemirror-tables@1.8.5
+[515] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -42368,7 +42469,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[513] Applies to: npm:protobufjs@7.6.5
+[516] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -42411,7 +42512,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[514] Applies to: npm:proxy-from-env@2.1.0
+[517] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -42435,7 +42536,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[515] Applies to: npm:qrcode@1.5.4
+[518] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42448,7 +42549,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[516] Applies to: npm:qs@6.15.3
+[519] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -42481,7 +42582,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[517] Applies to: npm:query-string@7.1.3
+[520] Applies to: npm:query-string@7.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42494,7 +42595,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[518] Applies to: npm:queue@6.0.2
+[521] Applies to: npm:queue@6.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
@@ -42506,7 +42607,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[519] Applies to: npm:range-parser@1.2.1, npm:range-parser@1.3.0
+[522] Applies to: npm:range-parser@1.2.1, npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -42533,7 +42634,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[520] Applies to: npm:raw-body@3.0.2
+[523] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42559,7 +42660,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[521] Applies to: npm:rc@1.2.8
+[524] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -42630,7 +42731,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[522] Applies to: npm:react-fast-compare@3.2.2
+[525] Applies to: npm:react-fast-compare@3.2.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42656,7 +42757,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[523] Applies to: npm:react-freeze@1.0.4
+[526] Applies to: npm:react-freeze@1.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42681,7 +42782,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[524] Applies to: npm:react-i18next@17.0.10
+[527] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42706,7 +42807,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[525] Applies to: npm:react-markdown@10.1.0
+[528] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42731,7 +42832,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[526] Applies to: npm:react-native-drawer-layout@4.2.7
+[529] Applies to: npm:react-native-drawer-layout@4.2.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42756,7 +42857,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[527] Applies to: npm:react-native-gesture-handler@3.0.2, npm:react-native-reanimated@4.3.1
+[530] Applies to: npm:react-native-gesture-handler@3.0.2, npm:react-native-reanimated@4.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42781,7 +42882,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[528] Applies to: npm:react-native-is-edge-to-edge@1.3.1
+[531] Applies to: npm:react-native-is-edge-to-edge@1.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42806,7 +42907,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[529] Applies to: npm:react-native-safe-area-context@5.7.0
+[532] Applies to: npm:react-native-safe-area-context@5.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42831,7 +42932,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[530] Applies to: npm:react-native-screens@4.25.2
+[533] Applies to: npm:react-native-screens@4.25.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42856,7 +42957,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[531] Applies to: npm:react-native-svg@15.15.4
+[534] Applies to: npm:react-native-svg@15.15.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42881,7 +42982,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[532] Applies to: npm:react-native-uitextview@2.2.0
+[535] Applies to: npm:react-native-uitextview@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42905,7 +43006,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[533] Applies to: npm:react-native-web@0.21.2
+[536] Applies to: npm:react-native-web@0.21.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42931,7 +43032,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[534] Applies to: npm:react-native-worklets@0.8.3
+[537] Applies to: npm:react-native-worklets@0.8.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42955,7 +43056,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[535] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[538] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42982,7 +43083,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[536] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[539] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -43033,7 +43134,7 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[537] Applies to: npm:regenerator-runtime@0.13.11
+[540] Applies to: npm:regenerator-runtime@0.13.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43058,7 +43159,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[538] Applies to: npm:regjsgen@0.8.0
+[541] Applies to: npm:regjsgen@0.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43084,7 +43185,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[539] Applies to: npm:regjsparser@0.13.2
+[542] Applies to: npm:regjsparser@0.13.2
 ------------------------------------------------------------------------------
 Copyright (c) Julian Viereck and Contributors, All Rights Reserved.
 
@@ -43109,7 +43210,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[540] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[543] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43134,7 +43235,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[541] Applies to: npm:require-directory@2.1.1
+[544] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43160,7 +43261,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[542] Applies to: npm:require-from-string@2.0.2
+[545] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43185,7 +43286,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[543] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3, npm:yargs-parser@21.1.1
+[546] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3, npm:yargs-parser@21.1.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -43203,7 +43304,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[544] Applies to: npm:resolve@1.22.12
+[547] Applies to: npm:resolve@1.22.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43228,7 +43329,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[545] Applies to: npm:resolve-workspace-root@2.0.1
+[548] Applies to: npm:resolve-workspace-root@2.0.1
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -43253,7 +43354,7 @@ Copyright (c) 2024-present Cedric van Putten <me@cedric.dev>
 > THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[546] Applies to: npm:rope-sequence@1.3.4
+[549] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -43276,7 +43377,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[547] Applies to: npm:roughjs@4.6.6
+[550] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43301,7 +43402,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[548] Applies to: npm:router@2.2.0
+[551] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43328,7 +43429,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[549] Applies to: npm:rtl-detect@1.1.2
+[552] Applies to: npm:rtl-detect@1.1.2
 ------------------------------------------------------------------------------
 Copyright 2015 Yahoo Inc.
 All rights reserved.
@@ -43359,7 +43460,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[550] Applies to: npm:rw@1.3.3
+[553] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -43389,7 +43490,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[551] Applies to: npm:safer-buffer@2.1.2
+[554] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43414,7 +43515,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[552] Applies to: npm:section-matter@1.0.0
+[555] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43439,7 +43540,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[553] Applies to: npm:send@0.19.2, npm:send@1.2.1
+[556] Applies to: npm:send@0.19.2, npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43466,7 +43567,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[554] Applies to: npm:serve-static@1.16.3, npm:serve-static@2.2.1
+[557] Applies to: npm:serve-static@1.16.3, npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43495,7 +43596,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[555] Applies to: npm:set-cookie-parser@2.7.2
+[558] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43520,7 +43621,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[556] Applies to: npm:setimmediate@1.0.5
+[559] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -43544,7 +43645,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[557] Applies to: npm:setprototypeof@1.2.0
+[560] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -43561,7 +43662,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[558] Applies to: npm:sf-symbols-typescript@2.2.0
+[561] Applies to: npm:sf-symbols-typescript@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43586,7 +43687,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[559] Applies to: npm:shallowequal@1.1.0
+[562] Applies to: npm:shallowequal@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43611,7 +43712,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[560] Applies to: npm:shell-quote@1.10.0
+[563] Applies to: npm:shell-quote@1.10.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -43639,7 +43740,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[561] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[564] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43664,7 +43765,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[562] Applies to: npm:signal-exit@3.0.7
+[565] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -43684,7 +43785,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[563] Applies to: npm:signal-exit@4.1.0
+[566] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -43704,7 +43805,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[564] Applies to: npm:silk-wasm@3.7.1
+[567] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43729,7 +43830,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[565] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[568] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43753,7 +43854,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[566] Applies to: npm:simple-plist@1.3.1
+[569] Applies to: npm:simple-plist@1.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43777,7 +43878,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[567] Applies to: npm:simple-swizzle@0.2.4
+[570] Applies to: npm:simple-swizzle@0.2.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43802,7 +43903,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[568] Applies to: npm:slugify@1.6.9
+[571] Applies to: npm:slugify@1.6.9
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43827,7 +43928,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[569] Applies to: npm:smol-toml@1.7.0
+[572] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -43855,7 +43956,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[570] Applies to: npm:sortablejs@1.15.7
+[573] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43880,7 +43981,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[571] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
+[574] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
 ------------------------------------------------------------------------------
 Copyright (c) 2009-2011, Mozilla Foundation and contributors
 All rights reserved.
@@ -43911,7 +44012,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[572] Applies to: npm:source-map-support@0.5.21
+[575] Applies to: npm:source-map-support@0.5.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43936,7 +44037,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[573] Applies to: npm:sprintf-js@1.0.3
+[576] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -43964,7 +44065,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[574] Applies to: npm:ssh-config@5.2.0
+[577] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43989,7 +44090,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[575] Applies to: npm:stacktrace-parser@0.1.11
+[578] Applies to: npm:stacktrace-parser@0.1.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44014,7 +44115,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[576] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
+[579] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44040,7 +44141,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[577] Applies to: npm:stream-buffers@2.2.0
+[580] Applies to: npm:stream-buffers@2.2.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -44068,7 +44169,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 
 ------------------------------------------------------------------------------
-[578] Applies to: npm:strict-uri-encode@2.0.0
+[581] Applies to: npm:strict-uri-encode@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44093,7 +44194,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[579] Applies to: npm:strip-bom-string@1.0.0
+[582] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44118,7 +44219,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[580] Applies to: npm:style-mod@4.1.3
+[583] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -44141,7 +44242,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[581] Applies to: npm:style-to-js@1.1.21
+[584] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44167,7 +44268,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[582] Applies to: npm:style-to-object@1.0.14
+[585] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44193,7 +44294,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[583] Applies to: npm:styleq@0.1.3
+[586] Applies to: npm:styleq@0.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44218,7 +44319,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[584] Applies to: npm:stylis@4.4.0
+[587] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44243,7 +44344,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[585] Applies to: npm:supports-hyperlinks@2.3.0
+[588] Applies to: npm:supports-hyperlinks@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44256,7 +44357,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[586] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
+[589] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44281,7 +44382,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[587] Applies to: npm:tailwind-merge@2.6.1
+[590] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44306,7 +44407,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[588] Applies to: npm:terser@5.49.0
+[591] Applies to: npm:terser@5.49.0
 ------------------------------------------------------------------------------
 Copyright 2012-2018 (c) Mihai Bazon <mihai.bazon@gmail.com>
 
@@ -44337,7 +44438,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[589] Applies to: npm:throat@5.0.0
+[592] Applies to: npm:throat@5.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Forbes Lindesay
 
@@ -44360,7 +44461,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[590] Applies to: npm:tinyexec@1.2.4
+[593] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44385,7 +44486,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[591] Applies to: npm:tinyglobby@0.2.17
+[594] Applies to: npm:tinyglobby@0.2.17
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44410,7 +44511,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[592] Applies to: npm:to-regex-range@5.0.1
+[595] Applies to: npm:to-regex-range@5.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44435,7 +44536,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[593] Applies to: npm:toidentifier@1.0.1
+[596] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44460,7 +44561,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[594] Applies to: npm:trough@2.2.0
+[597] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -44485,7 +44586,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[595] Applies to: npm:ts-dedent@2.3.0
+[598] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44510,7 +44611,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[596] Applies to: npm:ts-mixer@6.0.4
+[599] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44535,7 +44636,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[597] Applies to: npm:tslib@2.8.1
+[600] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -44551,7 +44652,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[598] Applies to: npm:tslog@4.11.0
+[601] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44576,7 +44677,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[599] Applies to: npm:tunnel-agent@0.6.0
+[602] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -44635,7 +44736,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[600] Applies to: npm:type-fest@0.20.2, npm:type-fest@0.21.3
+[603] Applies to: npm:type-fest@0.20.2, npm:type-fest@0.21.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44648,7 +44749,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[601] Applies to: npm:typebox@1.1.39
+[604] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -44675,7 +44776,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[602] Applies to: npm:ua-parser-js@1.0.41
+[605] Applies to: npm:ua-parser-js@1.0.41
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44700,7 +44801,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[603] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[606] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44725,7 +44826,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[604] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[607] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -44750,7 +44851,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[605] Applies to: npm:unist-util-is@6.0.1
+[608] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -44776,7 +44877,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[606] Applies to: npm:universalify@2.0.1
+[609] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -44800,7 +44901,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[607] Applies to: npm:unpipe@1.0.0
+[610] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -44826,7 +44927,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[608] Applies to: npm:update-browserslist-db@1.2.3
+[611] Applies to: npm:update-browserslist-db@1.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44850,7 +44951,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[609] Applies to: npm:uri-js@4.4.1
+[612] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -44865,7 +44966,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[610] Applies to: npm:url-template@2.0.8
+[613] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -44894,7 +44995,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[611] Applies to: npm:use-latest-callback@0.2.6
+[614] Applies to: npm:use-latest-callback@0.2.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44919,7 +45020,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[612] Applies to: npm:util-deprecate@1.0.2
+[615] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -44947,7 +45048,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[613] Applies to: npm:utils-merge@1.0.1
+[616] Applies to: npm:utils-merge@1.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44971,7 +45072,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[614] Applies to: npm:uuid@14.0.1
+[617] Applies to: npm:uuid@14.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44984,7 +45085,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[615] Applies to: npm:uuid@7.0.3
+[618] Applies to: npm:uuid@7.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45009,7 +45110,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[616] Applies to: npm:validate-npm-package-name@5.0.1
+[619] Applies to: npm:validate-npm-package-name@5.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2015, npm, Inc
 
@@ -45019,7 +45120,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[617] Applies to: npm:vaul@1.1.2
+[620] Applies to: npm:vaul@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45032,7 +45133,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[618] Applies to: npm:vlq@1.0.1
+[621] Applies to: npm:vlq@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2017 [these people](https://github.com/Rich-Harris/vlq/graphs/contributors)
 
@@ -45043,7 +45144,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[619] Applies to: npm:void-elements@3.1.0
+[622] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -45069,7 +45170,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[620] Applies to: npm:walker@1.0.8
+[623] Applies to: npm:walker@1.0.8
 ------------------------------------------------------------------------------
 Copyright 2013 Naitik Shah
 
@@ -45086,7 +45187,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[621] Applies to: npm:warn-once@0.1.1
+[624] Applies to: npm:warn-once@0.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45111,7 +45212,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[622] Applies to: npm:wcwidth@1.0.1
+[625] Applies to: npm:wcwidth@1.0.1
 ------------------------------------------------------------------------------
 wcwidth.js: JavaScript Portng of Markus Kuhn's wcwidth() Implementation
 =======================================================================
@@ -45144,7 +45245,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[623] Applies to: npm:web-streams-polyfill@3.3.3
+[626] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45170,7 +45271,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[624] Applies to: npm:webidl-conversions@3.0.1
+[627] Applies to: npm:webidl-conversions@3.0.1
 ------------------------------------------------------------------------------
 # The BSD 2-Clause License
 
@@ -45186,7 +45287,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[625] Applies to: npm:whatwg-fetch@3.6.20
+[628] Applies to: npm:whatwg-fetch@3.6.20
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2023 GitHub, Inc.
 
@@ -45210,7 +45311,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[626] Applies to: npm:whatwg-url@5.0.0
+[629] Applies to: npm:whatwg-url@5.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45235,7 +45336,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[627] Applies to: npm:whatwg-url-minimum@0.1.2
+[630] Applies to: npm:whatwg-url-minimum@0.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45262,7 +45363,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[628] Applies to: npm:which-module@2.0.1
+[631] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -45279,7 +45380,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[629] Applies to: npm:workerpool@9.1.1
+[632] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -45484,7 +45585,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[630] Applies to: npm:ws@7.5.12
+[633] Applies to: npm:ws@7.5.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45509,7 +45610,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[631] Applies to: npm:ws@8.21.1
+[634] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -45533,7 +45634,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[632] Applies to: npm:xcode@3.0.1 (NOTICE)
+[635] Applies to: npm:xcode@3.0.1 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:xcode@3.0.1:
 
@@ -45544,7 +45645,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------
-[633] Applies to: npm:xml2js@0.6.0
+[636] Applies to: npm:xml2js@0.6.0
 ------------------------------------------------------------------------------
 Copyright 2010, 2011, 2012, 2013. All rights reserved.
 
@@ -45567,7 +45668,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[634] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
+[637] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45592,7 +45693,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[635] Applies to: npm:y18n@4.0.3, npm:y18n@5.0.8
+[638] Applies to: npm:y18n@4.0.3, npm:y18n@5.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -45609,7 +45710,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[636] Applies to: npm:yaml@2.9.0
+[639] Applies to: npm:yaml@2.9.0
 ------------------------------------------------------------------------------
 Copyright Eemeli Aro <eemeli@gmail.com>
 
@@ -45626,7 +45727,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[637] Applies to: npm:yargs@15.4.1, npm:yargs@17.7.3
+[640] Applies to: npm:yargs@15.4.1, npm:yargs@17.7.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45651,7 +45752,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[638] Applies to: npm:zod@4.3.6
+[641] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45676,7 +45777,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[639] Applies to: npm:zod-to-json-schema@3.25.2
+[642] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 

--- a/docs/legal/notices/desktop-linux.txt
+++ b/docs/legal/notices/desktop-linux.txt
@@ -1025,7 +1025,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (782 packages)
+SECTION 2: npm packages (787 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
@@ -1423,6 +1423,7 @@ SECTION 2: npm packages (782 packages)
 - gcp-metadata@8.1.2 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gcp-metadata@8.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - get-caller-file@2.0.5 — ISC — https://github.com/stefanpenner/get-caller-file
+- get-east-asian-width@1.6.0 — MIT — https://github.com/sindresorhus/get-east-asian-width
 - get-intrinsic@1.3.0 — MIT — https://github.com/ljharb/get-intrinsic
 - get-nonce@1.0.1 — MIT — https://github.com/theKashey/get-nonce
 - get-proto@1.0.1 — MIT — https://github.com/ljharb/get-proto
@@ -1558,6 +1559,7 @@ SECTION 2: npm packages (782 packages)
 - mdast-util-phrasing@4.1.0 — MIT — https://github.com/syntax-tree/mdast-util-phrasing
 - mdast-util-to-hast@13.2.1 — MIT — https://github.com/syntax-tree/mdast-util-to-hast
 - mdast-util-to-markdown@2.1.2 — MIT — https://github.com/syntax-tree/mdast-util-to-markdown
+- mdast-util-to-markdown-cjk-friendly@1.0.0 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - mdast-util-to-string@4.0.0 — MIT — https://github.com/syntax-tree/mdast-util-to-string
 - media-typer@1.1.0 — MIT — https://github.com/jshttp/media-typer
 - merge-descriptors@2.0.0 — MIT — https://github.com/sindresorhus/merge-descriptors
@@ -1565,6 +1567,8 @@ SECTION 2: npm packages (782 packages)
 - mermaid@11.16.0 — MIT — https://github.com/mermaid-js/mermaid
 - micromark@4.0.2 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark
 - micromark-core-commonmark@2.0.3 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark-core-commonmark
+- micromark-extension-cjk-friendly@2.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
+- micromark-extension-cjk-friendly-util@3.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - micromark-extension-gfm@3.0.0 — MIT — https://github.com/micromark/micromark-extension-gfm
 - micromark-extension-gfm-autolink-literal@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-autolink-literal
 - micromark-extension-gfm-footnote@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-footnote
@@ -1689,6 +1693,7 @@ SECTION 2: npm packages (782 packages)
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
+- remark-cjk-friendly@2.3.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - remark-gfm@4.0.1 — MIT — https://github.com/remarkjs/remark-gfm
 - remark-math@6.0.0 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/remark-math
 - remark-parse@11.0.0 — MIT — https://github.com/remarkjs/remark/tree/main/packages/remark-parse
@@ -4563,7 +4568,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[56] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[56] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11512,7 +11517,39 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:merge-descriptors@2.0.0
+[238] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on remark-gfm:
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[239] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11527,7 +11564,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:merge-stream@2.0.0
+[240] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11552,7 +11589,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:mermaid@11.16.0
+[241] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11577,7 +11614,71 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[242] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark and micromark-core-commonmark
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[243] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark's sub-packages (micromark-util-character, micromark-util-symbol, and micromark-util-classify-character)
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[244] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11603,7 +11704,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[245] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11630,7 +11731,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[246] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -11649,7 +11750,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
+[247] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -11708,7 +11809,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:mkdirp@0.5.6
+[248] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -11733,7 +11834,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:mkdirp-classic@0.5.3
+[249] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11758,7 +11859,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:ms@2.0.0
+[250] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11783,7 +11884,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:ms@2.1.3
+[251] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11808,7 +11909,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:nan@2.28.0
+[252] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11821,7 +11922,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:napi-build-utils@2.0.0
+[253] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11846,7 +11947,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:negotiator@1.0.0
+[254] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11874,7 +11975,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:node-abi@3.94.0
+[255] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11899,7 +12000,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:node-addon-api@7.1.1
+[256] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11912,7 +12013,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:node-domexception@1.0.0
+[257] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11937,7 +12038,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:node-fetch@3.3.2
+[258] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11962,7 +12063,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[256] Applies to: npm:node-machine-id@1.1.12
+[259] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11987,7 +12088,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[257] Applies to: npm:node-pty@1.1.0
+[260] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -12060,7 +12161,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[258] Applies to: npm:object-inspect@1.13.4
+[261] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12085,7 +12186,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[259] Applies to: npm:on-finished@2.4.1
+[262] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12112,7 +12213,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[260] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[263] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -12135,7 +12236,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[261] Applies to: npm:package-json-from-dist@1.0.1
+[264] Applies to: npm:package-json-from-dist@1.0.1
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -12202,7 +12303,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[262] Applies to: npm:package-manager-detector@1.7.0
+[265] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12227,7 +12328,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[263] Applies to: npm:pako@1.0.11
+[266] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12252,7 +12353,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[264] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[267] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12278,7 +12379,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[265] Applies to: npm:parse5@7.3.0
+[268] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -12301,7 +12402,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[266] Applies to: npm:parseurl@1.3.3
+[269] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12328,7 +12429,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[267] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[270] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12353,7 +12454,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[268] Applies to: npm:path-to-regexp@8.4.2
+[271] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12378,7 +12479,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[269] Applies to: npm:pdfjs-dist@5.7.284
+[272] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -12558,7 +12659,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[270] Applies to: npm:picomatch@4.0.5
+[273] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12583,7 +12684,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[271] Applies to: npm:pkce-challenge@5.0.1
+[274] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12608,7 +12709,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[272] Applies to: npm:playwright-core@1.60.0
+[275] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -12814,7 +12915,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[273] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[276] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -12825,7 +12926,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[274] Applies to: npm:pngjs@5.0.0
+[277] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -12849,7 +12950,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[275] Applies to: npm:points-on-path@0.2.1
+[278] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12874,7 +12975,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[276] Applies to: npm:prebuild-install@7.1.3
+[279] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12899,7 +13000,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[277] Applies to: npm:process-nextick-args@2.0.1
+[280] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -12922,7 +13023,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[278] Applies to: npm:promise-worker-transferable@1.0.4
+[281] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -13127,7 +13228,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[279] Applies to: npm:prosemirror-changeset@2.4.1
+[282] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13150,7 +13251,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[280] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[283] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13173,7 +13274,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[281] Applies to: npm:prosemirror-tables@1.8.5
+[284] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -13196,7 +13297,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[282] Applies to: npm:protobufjs@7.6.5
+[285] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -13239,7 +13340,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[283] Applies to: npm:proxy-from-env@2.1.0
+[286] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -13263,7 +13364,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[284] Applies to: npm:qrcode@1.5.4
+[287] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13276,7 +13377,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[285] Applies to: npm:qs@6.15.3
+[288] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -13309,7 +13410,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[286] Applies to: npm:range-parser@1.3.0
+[289] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13336,7 +13437,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[287] Applies to: npm:raw-body@3.0.2
+[290] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13362,7 +13463,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[288] Applies to: npm:rc@1.2.8
+[291] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -13433,7 +13534,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[289] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[292] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13458,7 +13559,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[290] Applies to: npm:react-i18next@17.0.10
+[293] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13483,7 +13584,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[291] Applies to: npm:react-markdown@10.1.0
+[294] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13508,7 +13609,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[292] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[295] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13535,7 +13636,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[293] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[296] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -13586,7 +13687,7 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[294] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[297] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13611,7 +13712,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[295] Applies to: npm:require-directory@2.1.1
+[298] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13637,7 +13738,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[296] Applies to: npm:require-from-string@2.0.2
+[299] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13662,7 +13763,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[297] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[300] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -13680,7 +13781,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[298] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+[301] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -13708,7 +13809,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 ------------------------------------------------------------------------------
-[299] Applies to: npm:rope-sequence@1.3.4
+[302] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -13731,7 +13832,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[300] Applies to: npm:roughjs@4.6.6
+[303] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13756,7 +13857,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[301] Applies to: npm:router@2.2.0
+[304] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13783,7 +13884,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[302] Applies to: npm:rw@1.3.3
+[305] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -13813,7 +13914,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[303] Applies to: npm:safer-buffer@2.1.2
+[306] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13838,7 +13939,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[304] Applies to: npm:section-matter@1.0.0
+[307] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13863,7 +13964,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[305] Applies to: npm:send@1.2.1
+[308] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13890,7 +13991,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[306] Applies to: npm:serve-static@2.2.1
+[309] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13919,7 +14020,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[307] Applies to: npm:set-cookie-parser@2.7.2
+[310] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13944,7 +14045,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[308] Applies to: npm:setimmediate@1.0.5
+[311] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -13968,7 +14069,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[309] Applies to: npm:setprototypeof@1.2.0
+[312] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -13985,7 +14086,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[310] Applies to: npm:shebang-command@2.0.0
+[313] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13998,7 +14099,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[311] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[314] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14023,7 +14124,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[312] Applies to: npm:signal-exit@3.0.7
+[315] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14043,7 +14144,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[313] Applies to: npm:signal-exit@4.1.0
+[316] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14063,7 +14164,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[314] Applies to: npm:silk-wasm@3.7.1
+[317] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14088,7 +14189,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[315] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[318] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14112,7 +14213,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[316] Applies to: npm:smol-toml@1.7.0
+[319] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -14140,7 +14241,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[317] Applies to: npm:sortablejs@1.15.7
+[320] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14165,7 +14266,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[318] Applies to: npm:sprintf-js@1.0.3
+[321] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -14193,7 +14294,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[319] Applies to: npm:ssh-config@5.2.0
+[322] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14218,7 +14319,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[320] Applies to: npm:statuses@2.0.2
+[323] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14244,7 +14345,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[321] Applies to: npm:strip-bom-string@1.0.0
+[324] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14269,7 +14370,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[322] Applies to: npm:style-mod@4.1.3
+[325] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -14292,7 +14393,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[323] Applies to: npm:style-to-js@1.1.21
+[326] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14318,7 +14419,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[324] Applies to: npm:style-to-object@1.0.14
+[327] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14344,7 +14445,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[325] Applies to: npm:stylis@4.4.0
+[328] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14369,7 +14470,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[326] Applies to: npm:tailwind-merge@2.6.1
+[329] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14394,7 +14495,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[327] Applies to: npm:tinyexec@1.2.4
+[330] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14419,7 +14520,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[328] Applies to: npm:toidentifier@1.0.1
+[331] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14444,7 +14545,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[329] Applies to: npm:trough@2.2.0
+[332] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14469,7 +14570,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[330] Applies to: npm:ts-dedent@2.3.0
+[333] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14494,7 +14595,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[331] Applies to: npm:ts-mixer@6.0.4
+[334] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14519,7 +14620,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[332] Applies to: npm:tslib@2.8.1
+[335] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -14535,7 +14636,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[333] Applies to: npm:tslog@4.11.0
+[336] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14560,7 +14661,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[334] Applies to: npm:tunnel-agent@0.6.0
+[337] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -14619,7 +14720,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[335] Applies to: npm:type-fest@0.20.2
+[338] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14632,7 +14733,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[336] Applies to: npm:typebox@1.1.39
+[339] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -14659,7 +14760,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[337] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[340] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14684,7 +14785,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[338] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[341] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14709,7 +14810,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[339] Applies to: npm:unist-util-is@6.0.1
+[342] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -14735,7 +14836,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[340] Applies to: npm:universalify@2.0.1
+[343] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14759,7 +14860,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[341] Applies to: npm:unpipe@1.0.0
+[344] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14785,7 +14886,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[342] Applies to: npm:uri-js@4.4.1
+[345] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -14800,7 +14901,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[343] Applies to: npm:url-template@2.0.8
+[346] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -14829,7 +14930,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[344] Applies to: npm:util-deprecate@1.0.2
+[347] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14857,7 +14958,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[345] Applies to: npm:uuid@14.0.1
+[348] Applies to: npm:uuid@14.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14870,7 +14971,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[346] Applies to: npm:void-elements@3.1.0
+[349] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14896,7 +14997,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[347] Applies to: npm:web-streams-polyfill@3.3.3
+[350] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14922,7 +15023,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[348] Applies to: npm:which-module@2.0.1
+[351] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -14939,7 +15040,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[349] Applies to: npm:workerpool@9.1.1
+[352] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -15144,7 +15245,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[350] Applies to: npm:ws@8.21.1
+[353] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -15168,7 +15269,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[351] Applies to: npm:y18n@4.0.3
+[354] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -15185,7 +15286,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[352] Applies to: npm:yargs@15.4.1
+[355] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15210,7 +15311,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[353] Applies to: npm:zod@4.3.6
+[356] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15235,7 +15336,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[354] Applies to: npm:zod-to-json-schema@3.25.2
+[357] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 

--- a/docs/legal/notices/desktop-macos.txt
+++ b/docs/legal/notices/desktop-macos.txt
@@ -1052,7 +1052,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (782 packages)
+SECTION 2: npm packages (787 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
@@ -1450,6 +1450,7 @@ SECTION 2: npm packages (782 packages)
 - gcp-metadata@8.1.2 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gcp-metadata@8.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - get-caller-file@2.0.5 — ISC — https://github.com/stefanpenner/get-caller-file
+- get-east-asian-width@1.6.0 — MIT — https://github.com/sindresorhus/get-east-asian-width
 - get-intrinsic@1.3.0 — MIT — https://github.com/ljharb/get-intrinsic
 - get-nonce@1.0.1 — MIT — https://github.com/theKashey/get-nonce
 - get-proto@1.0.1 — MIT — https://github.com/ljharb/get-proto
@@ -1585,6 +1586,7 @@ SECTION 2: npm packages (782 packages)
 - mdast-util-phrasing@4.1.0 — MIT — https://github.com/syntax-tree/mdast-util-phrasing
 - mdast-util-to-hast@13.2.1 — MIT — https://github.com/syntax-tree/mdast-util-to-hast
 - mdast-util-to-markdown@2.1.2 — MIT — https://github.com/syntax-tree/mdast-util-to-markdown
+- mdast-util-to-markdown-cjk-friendly@1.0.0 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - mdast-util-to-string@4.0.0 — MIT — https://github.com/syntax-tree/mdast-util-to-string
 - media-typer@1.1.0 — MIT — https://github.com/jshttp/media-typer
 - merge-descriptors@2.0.0 — MIT — https://github.com/sindresorhus/merge-descriptors
@@ -1592,6 +1594,8 @@ SECTION 2: npm packages (782 packages)
 - mermaid@11.16.0 — MIT — https://github.com/mermaid-js/mermaid
 - micromark@4.0.2 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark
 - micromark-core-commonmark@2.0.3 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark-core-commonmark
+- micromark-extension-cjk-friendly@2.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
+- micromark-extension-cjk-friendly-util@3.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - micromark-extension-gfm@3.0.0 — MIT — https://github.com/micromark/micromark-extension-gfm
 - micromark-extension-gfm-autolink-literal@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-autolink-literal
 - micromark-extension-gfm-footnote@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-footnote
@@ -1716,6 +1720,7 @@ SECTION 2: npm packages (782 packages)
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
+- remark-cjk-friendly@2.3.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - remark-gfm@4.0.1 — MIT — https://github.com/remarkjs/remark-gfm
 - remark-math@6.0.0 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/remark-math
 - remark-parse@11.0.0 — MIT — https://github.com/remarkjs/remark/tree/main/packages/remark-parse
@@ -4590,7 +4595,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[56] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[56] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11539,7 +11544,39 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:merge-descriptors@2.0.0
+[238] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on remark-gfm:
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[239] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11554,7 +11591,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:merge-stream@2.0.0
+[240] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11579,7 +11616,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:mermaid@11.16.0
+[241] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11604,7 +11641,71 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[242] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark and micromark-core-commonmark
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[243] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark's sub-packages (micromark-util-character, micromark-util-symbol, and micromark-util-classify-character)
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[244] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11630,7 +11731,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[245] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11657,7 +11758,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[246] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -11676,7 +11777,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
+[247] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -11735,7 +11836,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:mkdirp@0.5.6
+[248] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -11760,7 +11861,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:mkdirp-classic@0.5.3
+[249] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11785,7 +11886,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:ms@2.0.0
+[250] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11810,7 +11911,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:ms@2.1.3
+[251] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11835,7 +11936,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:nan@2.28.0
+[252] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11848,7 +11949,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:napi-build-utils@2.0.0
+[253] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11873,7 +11974,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:negotiator@1.0.0
+[254] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11901,7 +12002,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:node-abi@3.94.0
+[255] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11926,7 +12027,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:node-addon-api@7.1.1
+[256] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11939,7 +12040,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:node-domexception@1.0.0
+[257] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11964,7 +12065,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:node-fetch@3.3.2
+[258] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11989,7 +12090,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[256] Applies to: npm:node-machine-id@1.1.12
+[259] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12014,7 +12115,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[257] Applies to: npm:node-pty@1.1.0
+[260] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -12087,7 +12188,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[258] Applies to: npm:object-inspect@1.13.4
+[261] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12112,7 +12213,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[259] Applies to: npm:on-finished@2.4.1
+[262] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12139,7 +12240,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[260] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[263] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -12162,7 +12263,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[261] Applies to: npm:package-json-from-dist@1.0.1
+[264] Applies to: npm:package-json-from-dist@1.0.1
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -12229,7 +12330,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[262] Applies to: npm:package-manager-detector@1.7.0
+[265] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12254,7 +12355,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[263] Applies to: npm:pako@1.0.11
+[266] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12279,7 +12380,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[264] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[267] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12305,7 +12406,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[265] Applies to: npm:parse5@7.3.0
+[268] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -12328,7 +12429,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[266] Applies to: npm:parseurl@1.3.3
+[269] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12355,7 +12456,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[267] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[270] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12380,7 +12481,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[268] Applies to: npm:path-to-regexp@8.4.2
+[271] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12405,7 +12506,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[269] Applies to: npm:pdfjs-dist@5.7.284
+[272] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -12585,7 +12686,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[270] Applies to: npm:picomatch@4.0.5
+[273] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12610,7 +12711,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[271] Applies to: npm:pkce-challenge@5.0.1
+[274] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12635,7 +12736,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[272] Applies to: npm:playwright-core@1.60.0
+[275] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -12841,7 +12942,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[273] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[276] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -12852,7 +12953,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[274] Applies to: npm:pngjs@5.0.0
+[277] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -12876,7 +12977,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[275] Applies to: npm:points-on-path@0.2.1
+[278] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12901,7 +13002,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[276] Applies to: npm:prebuild-install@7.1.3
+[279] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12926,7 +13027,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[277] Applies to: npm:process-nextick-args@2.0.1
+[280] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -12949,7 +13050,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[278] Applies to: npm:promise-worker-transferable@1.0.4
+[281] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -13154,7 +13255,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[279] Applies to: npm:prosemirror-changeset@2.4.1
+[282] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13177,7 +13278,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[280] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[283] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13200,7 +13301,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[281] Applies to: npm:prosemirror-tables@1.8.5
+[284] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -13223,7 +13324,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[282] Applies to: npm:protobufjs@7.6.5
+[285] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -13266,7 +13367,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[283] Applies to: npm:proxy-from-env@2.1.0
+[286] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -13290,7 +13391,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[284] Applies to: npm:qrcode@1.5.4
+[287] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13303,7 +13404,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[285] Applies to: npm:qs@6.15.3
+[288] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -13336,7 +13437,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[286] Applies to: npm:range-parser@1.3.0
+[289] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13363,7 +13464,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[287] Applies to: npm:raw-body@3.0.2
+[290] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13389,7 +13490,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[288] Applies to: npm:rc@1.2.8
+[291] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -13460,7 +13561,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[289] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[292] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13485,7 +13586,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[290] Applies to: npm:react-i18next@17.0.10
+[293] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13510,7 +13611,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[291] Applies to: npm:react-markdown@10.1.0
+[294] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13535,7 +13636,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[292] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[295] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13562,7 +13663,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[293] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[296] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -13613,7 +13714,7 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[294] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[297] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13638,7 +13739,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[295] Applies to: npm:require-directory@2.1.1
+[298] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13664,7 +13765,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[296] Applies to: npm:require-from-string@2.0.2
+[299] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13689,7 +13790,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[297] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[300] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -13707,7 +13808,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[298] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+[301] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -13735,7 +13836,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 ------------------------------------------------------------------------------
-[299] Applies to: npm:rope-sequence@1.3.4
+[302] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -13758,7 +13859,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[300] Applies to: npm:roughjs@4.6.6
+[303] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13783,7 +13884,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[301] Applies to: npm:router@2.2.0
+[304] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13810,7 +13911,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[302] Applies to: npm:rw@1.3.3
+[305] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -13840,7 +13941,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[303] Applies to: npm:safer-buffer@2.1.2
+[306] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13865,7 +13966,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[304] Applies to: npm:section-matter@1.0.0
+[307] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13890,7 +13991,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[305] Applies to: npm:send@1.2.1
+[308] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13917,7 +14018,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[306] Applies to: npm:serve-static@2.2.1
+[309] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13946,7 +14047,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[307] Applies to: npm:set-cookie-parser@2.7.2
+[310] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13971,7 +14072,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[308] Applies to: npm:setimmediate@1.0.5
+[311] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -13995,7 +14096,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[309] Applies to: npm:setprototypeof@1.2.0
+[312] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -14012,7 +14113,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[310] Applies to: npm:shebang-command@2.0.0
+[313] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14025,7 +14126,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[311] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[314] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14050,7 +14151,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[312] Applies to: npm:signal-exit@3.0.7
+[315] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14070,7 +14171,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[313] Applies to: npm:signal-exit@4.1.0
+[316] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14090,7 +14191,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[314] Applies to: npm:silk-wasm@3.7.1
+[317] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14115,7 +14216,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[315] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[318] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14139,7 +14240,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[316] Applies to: npm:smol-toml@1.7.0
+[319] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -14167,7 +14268,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[317] Applies to: npm:sortablejs@1.15.7
+[320] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14192,7 +14293,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[318] Applies to: npm:sprintf-js@1.0.3
+[321] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -14220,7 +14321,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[319] Applies to: npm:ssh-config@5.2.0
+[322] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14245,7 +14346,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[320] Applies to: npm:statuses@2.0.2
+[323] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14271,7 +14372,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[321] Applies to: npm:strip-bom-string@1.0.0
+[324] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14296,7 +14397,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[322] Applies to: npm:style-mod@4.1.3
+[325] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -14319,7 +14420,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[323] Applies to: npm:style-to-js@1.1.21
+[326] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14345,7 +14446,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[324] Applies to: npm:style-to-object@1.0.14
+[327] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14371,7 +14472,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[325] Applies to: npm:stylis@4.4.0
+[328] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14396,7 +14497,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[326] Applies to: npm:tailwind-merge@2.6.1
+[329] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14421,7 +14522,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[327] Applies to: npm:tinyexec@1.2.4
+[330] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14446,7 +14547,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[328] Applies to: npm:toidentifier@1.0.1
+[331] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14471,7 +14572,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[329] Applies to: npm:trough@2.2.0
+[332] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14496,7 +14597,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[330] Applies to: npm:ts-dedent@2.3.0
+[333] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14521,7 +14622,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[331] Applies to: npm:ts-mixer@6.0.4
+[334] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14546,7 +14647,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[332] Applies to: npm:tslib@2.8.1
+[335] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -14562,7 +14663,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[333] Applies to: npm:tslog@4.11.0
+[336] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14587,7 +14688,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[334] Applies to: npm:tunnel-agent@0.6.0
+[337] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -14646,7 +14747,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[335] Applies to: npm:type-fest@0.20.2
+[338] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14659,7 +14760,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[336] Applies to: npm:typebox@1.1.39
+[339] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -14686,7 +14787,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[337] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[340] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14711,7 +14812,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[338] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[341] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14736,7 +14837,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[339] Applies to: npm:unist-util-is@6.0.1
+[342] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -14762,7 +14863,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[340] Applies to: npm:universalify@2.0.1
+[343] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14786,7 +14887,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[341] Applies to: npm:unpipe@1.0.0
+[344] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14812,7 +14913,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[342] Applies to: npm:uri-js@4.4.1
+[345] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -14827,7 +14928,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[343] Applies to: npm:url-template@2.0.8
+[346] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -14856,7 +14957,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[344] Applies to: npm:util-deprecate@1.0.2
+[347] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14884,7 +14985,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[345] Applies to: npm:uuid@14.0.1
+[348] Applies to: npm:uuid@14.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14897,7 +14998,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[346] Applies to: npm:void-elements@3.1.0
+[349] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14923,7 +15024,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[347] Applies to: npm:web-streams-polyfill@3.3.3
+[350] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14949,7 +15050,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[348] Applies to: npm:which-module@2.0.1
+[351] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -14966,7 +15067,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[349] Applies to: npm:workerpool@9.1.1
+[352] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -15171,7 +15272,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[350] Applies to: npm:ws@8.21.1
+[353] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -15195,7 +15296,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[351] Applies to: npm:y18n@4.0.3
+[354] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -15212,7 +15313,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[352] Applies to: npm:yargs@15.4.1
+[355] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15237,7 +15338,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[353] Applies to: npm:zod@4.3.6
+[356] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15262,7 +15363,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[354] Applies to: npm:zod-to-json-schema@3.25.2
+[357] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 

--- a/docs/legal/notices/desktop-win.txt
+++ b/docs/legal/notices/desktop-win.txt
@@ -3597,7 +3597,7 @@ necessary.  Here is a sample; alter the names:
 That's all there is to it!
 
 ==============================================================================
-SECTION 2: npm packages (773 packages)
+SECTION 2: npm packages (778 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
@@ -3986,6 +3986,7 @@ SECTION 2: npm packages (773 packages)
 - gcp-metadata@8.1.2 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gcp-metadata@8.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - get-caller-file@2.0.5 — ISC — https://github.com/stefanpenner/get-caller-file
+- get-east-asian-width@1.6.0 — MIT — https://github.com/sindresorhus/get-east-asian-width
 - get-intrinsic@1.3.0 — MIT — https://github.com/ljharb/get-intrinsic
 - get-nonce@1.0.1 — MIT — https://github.com/theKashey/get-nonce
 - get-proto@1.0.1 — MIT — https://github.com/ljharb/get-proto
@@ -4121,6 +4122,7 @@ SECTION 2: npm packages (773 packages)
 - mdast-util-phrasing@4.1.0 — MIT — https://github.com/syntax-tree/mdast-util-phrasing
 - mdast-util-to-hast@13.2.1 — MIT — https://github.com/syntax-tree/mdast-util-to-hast
 - mdast-util-to-markdown@2.1.2 — MIT — https://github.com/syntax-tree/mdast-util-to-markdown
+- mdast-util-to-markdown-cjk-friendly@1.0.0 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - mdast-util-to-string@4.0.0 — MIT — https://github.com/syntax-tree/mdast-util-to-string
 - media-typer@1.1.0 — MIT — https://github.com/jshttp/media-typer
 - merge-descriptors@2.0.0 — MIT — https://github.com/sindresorhus/merge-descriptors
@@ -4128,6 +4130,8 @@ SECTION 2: npm packages (773 packages)
 - mermaid@11.16.0 — MIT — https://github.com/mermaid-js/mermaid
 - micromark@4.0.2 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark
 - micromark-core-commonmark@2.0.3 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark-core-commonmark
+- micromark-extension-cjk-friendly@2.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
+- micromark-extension-cjk-friendly-util@3.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - micromark-extension-gfm@3.0.0 — MIT — https://github.com/micromark/micromark-extension-gfm
 - micromark-extension-gfm-autolink-literal@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-autolink-literal
 - micromark-extension-gfm-footnote@2.1.0 — MIT — https://github.com/micromark/micromark-extension-gfm-footnote
@@ -4252,6 +4256,7 @@ SECTION 2: npm packages (773 packages)
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
+- remark-cjk-friendly@2.3.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
 - remark-gfm@4.0.1 — MIT — https://github.com/remarkjs/remark-gfm
 - remark-math@6.0.0 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/remark-math
 - remark-parse@11.0.0 — MIT — https://github.com/remarkjs/remark/tree/main/packages/remark-parse
@@ -27960,7 +27965,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[174] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34909,7 +34914,39 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[356] Applies to: npm:merge-descriptors@2.0.0
+[356] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on remark-gfm:
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[357] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34924,7 +34961,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[357] Applies to: npm:merge-stream@2.0.0
+[358] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34949,7 +34986,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[358] Applies to: npm:mermaid@11.16.0
+[359] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34974,7 +35011,71 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[359] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[360] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark and micromark-core-commonmark
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[361] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
+
+MIT LICENSE
+
+Based on micromark's sub-packages (micromark-util-character, micromark-util-symbol, and micromark-util-classify-character)
+
+(The MIT License)
+
+Copyright (c) Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[362] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35000,7 +35101,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[360] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[363] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35027,7 +35128,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[361] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[364] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -35046,7 +35147,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[362] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
+[365] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -35105,7 +35206,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[363] Applies to: npm:mkdirp@0.5.6
+[366] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -35130,7 +35231,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[364] Applies to: npm:mkdirp-classic@0.5.3
+[367] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35155,7 +35256,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[365] Applies to: npm:ms@2.0.0
+[368] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35180,7 +35281,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[366] Applies to: npm:ms@2.1.3
+[369] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35205,7 +35306,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[367] Applies to: npm:nan@2.28.0
+[370] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35218,7 +35319,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[368] Applies to: npm:napi-build-utils@2.0.0
+[371] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35243,7 +35344,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[369] Applies to: npm:negotiator@1.0.0
+[372] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35271,7 +35372,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[370] Applies to: npm:node-abi@3.94.0
+[373] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35296,7 +35397,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[371] Applies to: npm:node-addon-api@7.1.1
+[374] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35309,7 +35410,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[372] Applies to: npm:node-domexception@1.0.0
+[375] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35334,7 +35435,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[373] Applies to: npm:node-fetch@3.3.2
+[376] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35359,7 +35460,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[374] Applies to: npm:node-machine-id@1.1.12
+[377] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35384,7 +35485,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[375] Applies to: npm:node-pty@1.1.0
+[378] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -35457,7 +35558,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[376] Applies to: npm:object-inspect@1.13.4
+[379] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35482,7 +35583,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[377] Applies to: npm:on-finished@2.4.1
+[380] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35509,7 +35610,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[378] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[381] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -35532,7 +35633,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[379] Applies to: npm:package-json-from-dist@1.0.1
+[382] Applies to: npm:package-json-from-dist@1.0.1
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -35599,7 +35700,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[380] Applies to: npm:package-manager-detector@1.7.0
+[383] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35624,7 +35725,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[381] Applies to: npm:pako@1.0.11
+[384] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35649,7 +35750,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[382] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[385] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35675,7 +35776,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[383] Applies to: npm:parse5@7.3.0
+[386] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -35698,7 +35799,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[384] Applies to: npm:parseurl@1.3.3
+[387] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35725,7 +35826,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[385] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[388] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35750,7 +35851,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[386] Applies to: npm:path-to-regexp@8.4.2
+[389] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35775,7 +35876,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[387] Applies to: npm:pdfjs-dist@5.7.284
+[390] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -35955,7 +36056,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[388] Applies to: npm:picomatch@4.0.5
+[391] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35980,7 +36081,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[389] Applies to: npm:pkce-challenge@5.0.1
+[392] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36005,7 +36106,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[390] Applies to: npm:playwright-core@1.60.0
+[393] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -36211,7 +36312,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[391] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[394] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -36222,7 +36323,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[392] Applies to: npm:pngjs@5.0.0
+[395] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -36246,7 +36347,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[393] Applies to: npm:points-on-path@0.2.1
+[396] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36271,7 +36372,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[394] Applies to: npm:prebuild-install@7.1.3
+[397] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36296,7 +36397,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[395] Applies to: npm:process-nextick-args@2.0.1
+[398] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -36319,7 +36420,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[396] Applies to: npm:promise-worker-transferable@1.0.4
+[399] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -36524,7 +36625,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[397] Applies to: npm:prosemirror-changeset@2.4.1
+[400] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -36547,7 +36648,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[398] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[401] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -36570,7 +36671,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[399] Applies to: npm:prosemirror-tables@1.8.5
+[402] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -36593,7 +36694,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[400] Applies to: npm:protobufjs@7.6.5
+[403] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -36636,7 +36737,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[401] Applies to: npm:proxy-from-env@2.1.0
+[404] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -36660,7 +36761,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[402] Applies to: npm:qrcode@1.5.4
+[405] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36673,7 +36774,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[403] Applies to: npm:qs@6.15.3
+[406] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -36706,7 +36807,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[404] Applies to: npm:range-parser@1.3.0
+[407] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36733,7 +36834,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[405] Applies to: npm:raw-body@3.0.2
+[408] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36759,7 +36860,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[406] Applies to: npm:rc@1.2.8
+[409] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -36830,7 +36931,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[407] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[410] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36855,7 +36956,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[408] Applies to: npm:react-i18next@17.0.10
+[411] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36880,7 +36981,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[409] Applies to: npm:react-markdown@10.1.0
+[412] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36905,7 +37006,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[410] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[413] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36932,7 +37033,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[411] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[414] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -36983,7 +37084,7 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[412] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[415] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37008,7 +37109,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[413] Applies to: npm:require-directory@2.1.1
+[416] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37034,7 +37135,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[414] Applies to: npm:require-from-string@2.0.2
+[417] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37059,7 +37160,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[415] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[418] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -37077,7 +37178,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[416] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+[419] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -37105,7 +37206,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 ------------------------------------------------------------------------------
-[417] Applies to: npm:rope-sequence@1.3.4
+[420] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -37128,7 +37229,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[418] Applies to: npm:roughjs@4.6.6
+[421] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37153,7 +37254,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[419] Applies to: npm:router@2.2.0
+[422] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37180,7 +37281,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[420] Applies to: npm:rw@1.3.3
+[423] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -37210,7 +37311,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[421] Applies to: npm:safer-buffer@2.1.2
+[424] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37235,7 +37336,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[422] Applies to: npm:section-matter@1.0.0
+[425] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37260,7 +37361,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[423] Applies to: npm:send@1.2.1
+[426] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37287,7 +37388,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[424] Applies to: npm:serve-static@2.2.1
+[427] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37316,7 +37417,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[425] Applies to: npm:set-cookie-parser@2.7.2
+[428] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37341,7 +37442,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[426] Applies to: npm:setimmediate@1.0.5
+[429] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -37365,7 +37466,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[427] Applies to: npm:setprototypeof@1.2.0
+[430] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -37382,7 +37483,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[428] Applies to: npm:shebang-command@2.0.0
+[431] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37395,7 +37496,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[429] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[432] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37420,7 +37521,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[430] Applies to: npm:signal-exit@3.0.7
+[433] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -37440,7 +37541,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[431] Applies to: npm:signal-exit@4.1.0
+[434] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -37460,7 +37561,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[432] Applies to: npm:silk-wasm@3.7.1
+[435] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37485,7 +37586,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[433] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[436] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37509,7 +37610,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[434] Applies to: npm:smol-toml@1.7.0
+[437] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -37537,7 +37638,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[435] Applies to: npm:sortablejs@1.15.7
+[438] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37562,7 +37663,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[436] Applies to: npm:sprintf-js@1.0.3
+[439] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -37590,7 +37691,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[437] Applies to: npm:ssh-config@5.2.0
+[440] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37615,7 +37716,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[438] Applies to: npm:statuses@2.0.2
+[441] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37641,7 +37742,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[439] Applies to: npm:strip-bom-string@1.0.0
+[442] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37666,7 +37767,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[440] Applies to: npm:style-mod@4.1.3
+[443] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -37689,7 +37790,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[441] Applies to: npm:style-to-js@1.1.21
+[444] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37715,7 +37816,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[442] Applies to: npm:style-to-object@1.0.14
+[445] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37741,7 +37842,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[443] Applies to: npm:stylis@4.4.0
+[446] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37766,7 +37867,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[444] Applies to: npm:tailwind-merge@2.6.1
+[447] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37791,7 +37892,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[445] Applies to: npm:tinyexec@1.2.4
+[448] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37816,7 +37917,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[446] Applies to: npm:toidentifier@1.0.1
+[449] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37841,7 +37942,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[447] Applies to: npm:trough@2.2.0
+[450] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37866,7 +37967,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[448] Applies to: npm:ts-dedent@2.3.0
+[451] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37891,7 +37992,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[449] Applies to: npm:ts-mixer@6.0.4
+[452] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37916,7 +38017,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[450] Applies to: npm:tslib@2.8.1
+[453] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -37932,7 +38033,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[451] Applies to: npm:tslog@4.11.0
+[454] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37957,7 +38058,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[452] Applies to: npm:tunnel-agent@0.6.0
+[455] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -38016,7 +38117,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[453] Applies to: npm:type-fest@0.20.2
+[456] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38029,7 +38130,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[454] Applies to: npm:typebox@1.1.39
+[457] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -38056,7 +38157,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[455] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[458] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38081,7 +38182,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[456] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[459] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38106,7 +38207,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[457] Applies to: npm:unist-util-is@6.0.1
+[460] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -38132,7 +38233,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[458] Applies to: npm:universalify@2.0.1
+[461] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38156,7 +38257,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[459] Applies to: npm:unpipe@1.0.0
+[462] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38182,7 +38283,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[460] Applies to: npm:uri-js@4.4.1
+[463] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -38197,7 +38298,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[461] Applies to: npm:url-template@2.0.8
+[464] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -38226,7 +38327,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[462] Applies to: npm:util-deprecate@1.0.2
+[465] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38254,7 +38355,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[463] Applies to: npm:uuid@14.0.1
+[466] Applies to: npm:uuid@14.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38267,7 +38368,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[464] Applies to: npm:void-elements@3.1.0
+[467] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38293,7 +38394,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[465] Applies to: npm:web-streams-polyfill@3.3.3
+[468] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38319,7 +38420,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[466] Applies to: npm:which-module@2.0.1
+[469] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -38336,7 +38437,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[467] Applies to: npm:workerpool@9.1.1
+[470] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -38541,7 +38642,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[468] Applies to: npm:ws@8.21.1
+[471] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -38565,7 +38666,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[469] Applies to: npm:y18n@4.0.3
+[472] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -38582,7 +38683,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[470] Applies to: npm:yargs@15.4.1
+[473] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38607,7 +38708,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[471] Applies to: npm:zod@4.3.6
+[474] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38632,7 +38733,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[472] Applies to: npm:zod-to-json-schema@3.25.2
+[475] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 

--- a/docs/legal/notices/sbom/desktop-linux.spdx.json
+++ b/docs/legal/notices/sbom/desktop-linux.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-desktop-linux",
-  "documentNamespace": "https://cindy.app/spdx/desktop-linux/464bff7eabf005aa01e25a654671aa5dede2568cb57ada4e9a58a912d0b71fbf",
+  "documentNamespace": "https://cindy.app/spdx/desktop-linux/3de28c6999b2a84a3b7670006064475e8501052279f386fa3792034e4013eac8",
   "creationInfo": {
-    "created": "2026-07-27T21:02:23Z",
+    "created": "2026-07-30T07:20:40Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -6857,6 +6857,23 @@
       ]
     },
     {
+      "name": "get-east-asian-width",
+      "SPDXID": "SPDXRef-Package-d60bc4ed2cc53300",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "https://github.com/sindresorhus/get-east-asian-width",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/get-east-asian-width@1.6.0"
+        }
+      ]
+    },
+    {
       "name": "get-intrinsic",
       "SPDXID": "SPDXRef-Package-5646ad7136ae8877",
       "versionInfo": "1.3.0",
@@ -9152,6 +9169,23 @@
       ]
     },
     {
+      "name": "mdast-util-to-markdown-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-d34528f8f0b2d6a4",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mdast-util-to-markdown-cjk-friendly@1.0.0"
+        }
+      ]
+    },
+    {
       "name": "mdast-util-to-string",
       "SPDXID": "SPDXRef-Package-236fb819698c71e4",
       "versionInfo": "4.0.0",
@@ -9267,6 +9301,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/micromark-core-commonmark@2.0.3"
+        }
+      ]
+    },
+    {
+      "name": "micromark-extension-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-c36e3ff21cfabdb2",
+      "versionInfo": "2.0.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/micromark-extension-cjk-friendly@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "micromark-extension-cjk-friendly-util",
+      "SPDXID": "SPDXRef-Package-6210e203ddfb6030",
+      "versionInfo": "3.0.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/micromark-extension-cjk-friendly-util@3.0.1"
         }
       ]
     },
@@ -11375,6 +11443,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/rehype-slug@6.0.0"
+        }
+      ]
+    },
+    {
+      "name": "remark-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-0265a938fcf75432",
+      "versionInfo": "2.3.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/remark-cjk-friendly@2.3.1"
         }
       ]
     },
@@ -15480,6 +15565,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d60bc4ed2cc53300"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5646ad7136ae8877"
     },
     {
@@ -16155,6 +16245,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d34528f8f0b2d6a4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-236fb819698c71e4"
     },
     {
@@ -16186,6 +16281,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-6537e377a4711f98"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c36e3ff21cfabdb2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6210e203ddfb6030"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16806,6 +16911,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-649883e5ac9fe55a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0265a938fcf75432"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/desktop-macos.spdx.json
+++ b/docs/legal/notices/sbom/desktop-macos.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-desktop-macos",
-  "documentNamespace": "https://cindy.app/spdx/desktop-macos/432b125431404c6ce264d111cde2d5409419e399c9da0fa3969567775906926a",
+  "documentNamespace": "https://cindy.app/spdx/desktop-macos/903c5e1fd554ff11270f5a1fba34a763bb9baf433fe133dd4beea0cadb98c5b6",
   "creationInfo": {
-    "created": "2026-07-27T21:02:23Z",
+    "created": "2026-07-30T07:20:40Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -6867,6 +6867,23 @@
       ]
     },
     {
+      "name": "get-east-asian-width",
+      "SPDXID": "SPDXRef-Package-d60bc4ed2cc53300",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "https://github.com/sindresorhus/get-east-asian-width",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/get-east-asian-width@1.6.0"
+        }
+      ]
+    },
+    {
       "name": "get-intrinsic",
       "SPDXID": "SPDXRef-Package-5646ad7136ae8877",
       "versionInfo": "1.3.0",
@@ -9162,6 +9179,23 @@
       ]
     },
     {
+      "name": "mdast-util-to-markdown-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-d34528f8f0b2d6a4",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mdast-util-to-markdown-cjk-friendly@1.0.0"
+        }
+      ]
+    },
+    {
       "name": "mdast-util-to-string",
       "SPDXID": "SPDXRef-Package-236fb819698c71e4",
       "versionInfo": "4.0.0",
@@ -9277,6 +9311,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/micromark-core-commonmark@2.0.3"
+        }
+      ]
+    },
+    {
+      "name": "micromark-extension-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-c36e3ff21cfabdb2",
+      "versionInfo": "2.0.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/micromark-extension-cjk-friendly@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "micromark-extension-cjk-friendly-util",
+      "SPDXID": "SPDXRef-Package-6210e203ddfb6030",
+      "versionInfo": "3.0.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/micromark-extension-cjk-friendly-util@3.0.1"
         }
       ]
     },
@@ -11385,6 +11453,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/rehype-slug@6.0.0"
+        }
+      ]
+    },
+    {
+      "name": "remark-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-0265a938fcf75432",
+      "versionInfo": "2.3.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/remark-cjk-friendly@2.3.1"
         }
       ]
     },
@@ -15495,6 +15580,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d60bc4ed2cc53300"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5646ad7136ae8877"
     },
     {
@@ -16170,6 +16260,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d34528f8f0b2d6a4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-236fb819698c71e4"
     },
     {
@@ -16201,6 +16296,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-6537e377a4711f98"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c36e3ff21cfabdb2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6210e203ddfb6030"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16821,6 +16926,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-649883e5ac9fe55a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0265a938fcf75432"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/desktop-win.spdx.json
+++ b/docs/legal/notices/sbom/desktop-win.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-desktop-win",
-  "documentNamespace": "https://cindy.app/spdx/desktop-win/ce1be7eb8491943fe65d6e6cde3b22c6b5cba437a6692a63582e116ce015fe07",
+  "documentNamespace": "https://cindy.app/spdx/desktop-win/cac6bea59faf65f498869b210fd6bf72b54a9e892163061b10e522f8ffb5284a",
   "creationInfo": {
-    "created": "2026-07-27T21:02:23Z",
+    "created": "2026-07-30T07:20:40Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -11226,6 +11226,23 @@
       ]
     },
     {
+      "name": "get-east-asian-width",
+      "SPDXID": "SPDXRef-Package-d60bc4ed2cc53300",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "https://github.com/sindresorhus/get-east-asian-width",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/get-east-asian-width@1.6.0"
+        }
+      ]
+    },
+    {
       "name": "get-intrinsic",
       "SPDXID": "SPDXRef-Package-5646ad7136ae8877",
       "versionInfo": "1.3.0",
@@ -13521,6 +13538,23 @@
       ]
     },
     {
+      "name": "mdast-util-to-markdown-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-d34528f8f0b2d6a4",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mdast-util-to-markdown-cjk-friendly@1.0.0"
+        }
+      ]
+    },
+    {
       "name": "mdast-util-to-string",
       "SPDXID": "SPDXRef-Package-236fb819698c71e4",
       "versionInfo": "4.0.0",
@@ -13636,6 +13670,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/micromark-core-commonmark@2.0.3"
+        }
+      ]
+    },
+    {
+      "name": "micromark-extension-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-c36e3ff21cfabdb2",
+      "versionInfo": "2.0.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/micromark-extension-cjk-friendly@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "micromark-extension-cjk-friendly-util",
+      "SPDXID": "SPDXRef-Package-6210e203ddfb6030",
+      "versionInfo": "3.0.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/micromark-extension-cjk-friendly-util@3.0.1"
         }
       ]
     },
@@ -15744,6 +15812,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/rehype-slug@6.0.0"
+        }
+      ]
+    },
+    {
+      "name": "remark-cjk-friendly",
+      "SPDXID": "SPDXRef-Package-0265a938fcf75432",
+      "versionInfo": "2.3.1",
+      "downloadLocation": "https://github.com/tats-u/markdown-cjk-friendly",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/remark-cjk-friendly@2.3.1"
         }
       ]
     },
@@ -21134,6 +21219,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d60bc4ed2cc53300"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5646ad7136ae8877"
     },
     {
@@ -21809,6 +21899,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d34528f8f0b2d6a4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-236fb819698c71e4"
     },
     {
@@ -21840,6 +21935,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-6537e377a4711f98"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c36e3ff21cfabdb2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6210e203ddfb6030"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -22460,6 +22565,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-649883e5ac9fe55a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0265a938fcf75432"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/mobile-android.spdx.json
+++ b/docs/legal/notices/sbom/mobile-android.spdx.json
@@ -5,7 +5,7 @@
   "name": "cindy-mobile-android",
   "documentNamespace": "https://cindy.app/spdx/mobile-android/05efd357f74ac207a075699dbbd457afe65ed99fd574ee594be1d4bb651dc49a",
   "creationInfo": {
-    "created": "2026-07-27T21:02:23Z",
+    "created": "2026-07-30T07:20:40Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]

--- a/docs/legal/notices/sbom/mobile-ios.spdx.json
+++ b/docs/legal/notices/sbom/mobile-ios.spdx.json
@@ -5,7 +5,7 @@
   "name": "cindy-mobile-ios",
   "documentNamespace": "https://cindy.app/spdx/mobile-ios/9cae3d29bee1df233432e6dd0978265ea2d61b380b2e50bf92a64c3516a1cccf",
   "creationInfo": {
-    "created": "2026-07-27T21:02:23Z",
+    "created": "2026-07-30T07:20:40Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
+      remark-cjk-friendly:
+        specifier: ^2.3.1
+        version: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -6892,6 +6895,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-folder-size@2.0.1:
     resolution: {integrity: sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==}
     hasBin: true
@@ -7891,6 +7898,15 @@ packages:
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
+  mdast-util-to-markdown-cjk-friendly@1.0.0:
+    resolution: {integrity: sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': '*'
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
 
@@ -7998,6 +8014,25 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-cjk-friendly-util@3.0.1:
+    resolution: {integrity: sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark-util-types: '*'
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
+
+  micromark-extension-cjk-friendly@2.0.1:
+    resolution: {integrity: sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark: ^4.0.0
+      micromark-util-types: ^2.0.0
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -9128,6 +9163,16 @@ packages:
 
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+
+  remark-cjk-friendly@2.3.1:
+    resolution: {integrity: sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': ^4.0.0
+      unified: ^11.0.0
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -17077,6 +17122,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-folder-size@2.0.1:
     dependencies:
       gar: 1.0.4
@@ -18220,6 +18267,16 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  mdast-util-to-markdown-cjk-friendly@1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2):
+    dependencies:
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark-util-types
+
   mdast-util-to-markdown@2.1.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -18479,6 +18536,25 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly-util@3.0.1(micromark-util-types@2.0.2):
+    dependencies:
+      get-east-asian-width: 1.6.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2):
+    dependencies:
+      devlop: 1.1.0
+      micromark: 4.0.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
       micromark-util-types: 2.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
@@ -19741,6 +19817,17 @@ snapshots:
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.1
       unist-util-visit: 5.1.0
+
+  remark-cjk-friendly@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
+    dependencies:
+      mdast-util-to-markdown-cjk-friendly: 1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2)
+      micromark-extension-cjk-friendly: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2)
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## 这次改了什么

### 摘要

桌面端聊天消息里,AI 输出的加粗标记 `**` 在紧贴中文全角标点时无法解析,正文残留原始星号(如 `**注意：**`、`**“术语”**`、`**（注）**`)。原因是 CommonMark 的 emphasis 侧翼(flanking)规则把全角标点算作「标点」:加粗内容以标点结尾、右侧 `**` 后又紧跟普通字符时,闭判定不成立(开判定对称),整对星号退化成字面量。本 PR 在 MarkdownRenderer 的两条 remark 插件链中、于 remarkGfm 之后注册 `remark-cjk-friendly`(micromark 语法扩展,放宽该判定:全角标点不再当标点),修复全部此类写法,并与 mobile 自研 parser 的既有行为对齐(端间差异消除)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无(用户反馈:流式输出正文残留原始 `**`)
- 本 PR 包含：desktop 新增依赖 `remark-cjk-friendly@^2.3.1`;MarkdownRenderer 普通/受信任两条插件链注册该插件;新增 19 个单元测试
- 明确不包含：`~~` 删除线的同类全角标点问题(gfm strikethrough 有独立定界逻辑,本 PR 前后行为一致,保持现状);mobile 无改动(其 parser 本就能解析这些写法)
- 用户可见变化：中文回复里紧贴全角标点的加粗现在正确渲染为加粗,不再显示原始 `**` 字符
- 是否存在 breaking change：无

### UI 变化

before:正文残留字面 `**注意：**`;after:渲染为加粗「注意：」。仅修复解析,无新增视觉样式、交互或文案变化。未附截图——本次在 worktree 会话内开发,改动不进入运行中的 dev 实例,无法实机截图;解析结果已由管线级渲染测试覆盖(见下)。

- 引用的设计规范：docs/design-rules/DESIGN.md 的 Markdown 文本色条款(`--md-strong-fg`,strong 的既有渲染规范);本 PR 只是让命中文本恢复进入该既有样式

## 怎么验证的

### 自动验证

```text
corepack pnpm exec vitest run src/renderer/__tests__/markdownCjkStrongDelimiter.test.ts src/renderer/__tests__/markdownStrikethrough.test.ts
结果：2 个文件 23 个测试全部通过(新增 19 个:8 个历史失败样例 → <strong>;其余为守卫:带空格/转义/行内代码/链接地址内的星号保持字面量,~~ 删除线与公式行为不变,source-contract 锚定两条插件链的注册)

corepack pnpm --filter desktop run typecheck
结果：通过,无错误

corepack pnpm test:unit(仓库根全量)
结果：rebase 到含 #1034 的最新主干后复跑——runner 自测全过;mobile 及全部 packages workspace 通过;desktop 仅 scriptRunnerPythonProtocol 3 个失败(本机 Python 环境问题,干净 upstream/main 上复跑同样失败,与本 PR 无关;#1034 已修复此前其余 Windows 本机环境用例);本次新增的 19 个测试在全量中全部通过

补充:首次全量跑于旧主干时另有 13 个本机环境失败(newMakerProjectPicker、endpointManifestCache、money 等),已在干净主干验证为既有问题,且已被上游 #1034 修复

corepack pnpm install --frozen-lockfile
结果：通过,lockfile 与 package.json 一致
```

### 手工验证

不涉及(worktree 会话内改动不进入运行中的 dev 实例,无法实机目检;建议合并前在 dev 实例发送含 `**注意：**` 的消息复核)

### 未执行的验证

- 实机渲染目检:原因如上,已由管线级 renderToStaticMarkup 测试覆盖解析结果
- mobile 验证:mobile 无改动

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：desktop 所有走 MarkdownRenderer 的 Markdown 渲染(聊天气泡、计划卡片等)。remark-cjk-friendly 仅放宽 emphasis/strong 的定界判定,不碰 `~~` 删除线、公式、代码、链接(均有测试守卫);不改动源文本,doc 模式行号锚点不受影响
- 回滚 / 降级方式：revert 本 PR 即可恢复原行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码注释与测试文件头说明,无需额外文档)
- [x] 已确认测试结果或说明未执行原因

