### PR TITLE
test(desktop): 修 billing 金额断言与 Windows 环境性测试失败

### DIFF
--- a/apps/desktop/src/main/__tests__/endpointManifestCache.test.ts
+++ b/apps/desktop/src/main/__tests__/endpointManifestCache.test.ts
@@ -277,8 +277,8 @@ describe('缓存端点的受信任域约束(安全边界)', () => {
 });
 
 describe('缓存读取只接受常规文件(阻断路径不能被挂住)', () => {
-  it('symlink 指向合法缓存也拒绝(statSync 会跟随,lstatSync 不会)', () => {
-    if (!canSymlink) return; // Windows 无 symlink 权限时跳过
+  // skipIf: 无 symlink 权限时报告为 skipped 而不是假 passed
+  it.skipIf(!canSymlink)('symlink 指向合法缓存也拒绝(statSync 会跟随,lstatSync 不会)', () => {
     const real = path.join(dir, 'real-cache.json');
     fs.writeFileSync(real, JSON.stringify(ENTRY), 'utf8');
     fs.symlinkSync(real, cacheFile());
@@ -338,8 +338,8 @@ describe('缓存写入的临时文件必须唯一且独占创建', () => {
     expect(readEndpointManifestCache(dir)).toEqual(ENTRY);
   });
 
-  it('target 被换成 symlink 时 rename 替换掉它本身,不写穿到链接目标', () => {
-    if (!canSymlink) return; // Windows 无 symlink 权限时跳过
+  // skipIf: 无 symlink 权限时报告为 skipped 而不是假 passed
+  it.skipIf(!canSymlink)('target 被换成 symlink 时 rename 替换掉它本身,不写穿到链接目标', () => {
     const outside = path.join(dir, 'outside.txt');
     fs.writeFileSync(outside, 'untouched', 'utf8');
     fs.symlinkSync(outside, cacheFile());

--- a/apps/desktop/src/main/__tests__/endpointManifestCache.test.ts
+++ b/apps/desktop/src/main/__tests__/endpointManifestCache.test.ts
@@ -43,6 +43,20 @@ function cacheFile(): string {
   return path.join(dir, ENDPOINT_MANIFEST_CACHE_FILE_NAME);
 }
 
+// Windows 上创建 symlink 需要管理员或开发者模式;拿不到权限时(EPERM)跳过相关
+// 用例,与下面 mkfifo 不可用时的处理一致。探测一次,别让每个用例各炸一遍。
+const canSymlink = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-symlink-probe-'));
+  try {
+    fs.symlinkSync(path.join(probeDir, 'target'), path.join(probeDir, 'link'));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
 describe('endpointManifestCache', () => {
   it('写入后可原样读回', () => {
     expect(writeEndpointManifestCache(dir, ENTRY)).toBe(true);
@@ -84,7 +98,7 @@ describe('endpointManifestCache', () => {
 
   it('多字节 UTF-8 内容按字节而非字符数判断', () => {
     // 每个汉字 3 字节:字符数远小于上限,字节数刚好越界。用 string.length 判断会放行。
-    const cjk = '配'.repeat(128 * 1024 / 3 + 10);
+    const cjk = '配'.repeat((128 * 1024) / 3 + 10);
     expect(Buffer.byteLength(cjk, 'utf8')).toBeGreaterThan(128 * 1024);
     expect(cjk.length).toBeLessThan(128 * 1024);
     fs.writeFileSync(cacheFile(), cjk, 'utf8');
@@ -111,7 +125,10 @@ describe('endpointManifestCache', () => {
   it('写得进的一定读得回(读写共用同一上限)', () => {
     // 贴着上限:序列化后不超过 128KiB 就必须写成功且原样读回。
     let text = 'y'.repeat(100 * 1024);
-    while (Buffer.byteLength(JSON.stringify({ ...ENTRY, manifestText: text }, null, 2), 'utf8') > 128 * 1024) {
+    while (
+      Buffer.byteLength(JSON.stringify({ ...ENTRY, manifestText: text }, null, 2), 'utf8') >
+      128 * 1024
+    ) {
       text = text.slice(0, -1024);
     }
     const big = { ...ENTRY, manifestText: text };
@@ -131,8 +148,14 @@ describe('缓存端点的受信任域约束(安全边界)', () => {
   const CN_BASE = 'https://hotfix.cindy.com.cn/cindy';
   const TRUSTED = Object.values(REGION_ENDPOINT_DOMAIN);
   /** CN 构建的策略:非跨区端点锁 cindy.com.cn,slack/telegram hook 才允许 cindy.app。 */
-  const CN_POLICY = { regionDomain: REGION_ENDPOINT_DOMAIN.cn, crossRegionDomain: REGION_ENDPOINT_DOMAIN.global };
-  const GLOBAL_POLICY = { regionDomain: REGION_ENDPOINT_DOMAIN.global, crossRegionDomain: REGION_ENDPOINT_DOMAIN.global };
+  const CN_POLICY = {
+    regionDomain: REGION_ENDPOINT_DOMAIN.cn,
+    crossRegionDomain: REGION_ENDPOINT_DOMAIN.global,
+  };
+  const GLOBAL_POLICY = {
+    regionDomain: REGION_ENDPOINT_DOMAIN.global,
+    crossRegionDomain: REGION_ENDPOINT_DOMAIN.global,
+  };
 
   it('区域域名是显式写死的(不从基址推导)', () => {
     // 上一版从自举基址「去掉最左一段」推导,在多段公共后缀上会**放宽**信任:
@@ -255,6 +278,7 @@ describe('缓存端点的受信任域约束(安全边界)', () => {
 
 describe('缓存读取只接受常规文件(阻断路径不能被挂住)', () => {
   it('symlink 指向合法缓存也拒绝(statSync 会跟随,lstatSync 不会)', () => {
+    if (!canSymlink) return; // Windows 无 symlink 权限时跳过
     const real = path.join(dir, 'real-cache.json');
     fs.writeFileSync(real, JSON.stringify(ENTRY), 'utf8');
     fs.symlinkSync(real, cacheFile());
@@ -315,6 +339,7 @@ describe('缓存写入的临时文件必须唯一且独占创建', () => {
   });
 
   it('target 被换成 symlink 时 rename 替换掉它本身,不写穿到链接目标', () => {
+    if (!canSymlink) return; // Windows 无 symlink 权限时跳过
     const outside = path.join(dir, 'outside.txt');
     fs.writeFileSync(outside, 'untouched', 'utf8');
     fs.symlinkSync(outside, cacheFile());

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -12,95 +12,57 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-const newMakerDraftRouteSource = readFileSync(
-  resolve(__dirname, '..', 'features', 'cc-agent', 'NewMakerDraftRoute.tsx'),
-  'utf8',
+// 本仓 core.autocrlf=true 时 Windows checkout 出来的源文件是 CRLF,而下面的快照断言
+// 统一按 LF 书写;读入时归一化行尾,让断言不绑定 checkout 端的行尾配置。
+const readSource = (...segments: string[]): string =>
+  readFileSync(resolve(__dirname, '..', ...segments), 'utf8').replaceAll('\r\n', '\n');
+
+const newMakerDraftRouteSource = readSource('features', 'cc-agent', 'NewMakerDraftRoute.tsx');
+
+const worktreeChipsSource = readSource('components', 'new-chat', 'WorktreeChipsRow.tsx');
+
+const folderPickerPopoverSource = readSource('components', 'new-chat', 'FolderPickerPopover.tsx');
+
+const addRemoteProjectDialogSource = readSource(
+  'components',
+  'new-chat',
+  'AddRemoteProjectDialog.tsx',
 );
 
-const worktreeChipsSource = readFileSync(
-  resolve(__dirname, '..', 'components', 'new-chat', 'WorktreeChipsRow.tsx'),
-  'utf8',
+const projectPickerOptionsHookSource = readSource('hooks', 'useProjectPickerOptions.ts');
+
+const deviceLinkProjectsHookSource = readSource('hooks', 'useDeviceLinkProjects.ts');
+
+const remoteSessionHandoffSource = readSource('features', 'cc-agent', 'remoteSessionHandoff.ts');
+
+const deviceSwitcherPillSource = readSource('components', 'new-chat', 'DeviceSwitcherPill.tsx');
+
+const controllableDevicesHookSource = readSource('hooks', 'useControllableDevices.ts');
+
+const deviceLinkRemoteProjectsSource = readSource(
+  'features',
+  'device-link',
+  'useDeviceLinkRemoteProjects.ts',
 );
 
-const folderPickerPopoverSource = readFileSync(
-  resolve(__dirname, '..', 'components', 'new-chat', 'FolderPickerPopover.tsx'),
-  'utf8',
+const deviceProvidersHookSource = readSource('hooks', 'useDeviceProviders.ts');
+
+const agentCapabilitiesHookSource = readSource('hooks', 'useAgentCapabilities.ts');
+
+const scheduleFormDialogSource = readSource(
+  'features',
+  'scheduler',
+  'components',
+  'ScheduleFormDialog.tsx',
 );
 
-const addRemoteProjectDialogSource = readFileSync(
-  resolve(__dirname, '..', 'components', 'new-chat', 'AddRemoteProjectDialog.tsx'),
-  'utf8',
-);
+const scheduleChipsSource = readSource('features', 'scheduler', 'components', 'ScheduleChips.tsx');
 
-const projectPickerOptionsHookSource = readFileSync(
-  resolve(__dirname, '..', 'hooks', 'useProjectPickerOptions.ts'),
-  'utf8',
-);
+const newGoalDialogSource = readSource('components', 'new-chat', 'NewGoalDialog.tsx');
 
-const deviceLinkProjectsHookSource = readFileSync(
-  resolve(__dirname, '..', 'hooks', 'useDeviceLinkProjects.ts'),
-  'utf8',
-);
+const extraDirsButtonSource = readSource('components', 'new-chat', 'ExtraDirsButton.tsx');
 
-const remoteSessionHandoffSource = readFileSync(
-  resolve(__dirname, '..', 'features', 'cc-agent', 'remoteSessionHandoff.ts'),
-  'utf8',
-);
-
-const deviceLinkCreateArgsSource = readFileSync(
-  resolve(__dirname, '..', 'features', 'cc-agent', 'deviceLinkCreateArgs.ts'),
-  'utf8',
-);
-
-const deviceSwitcherPillSource = readFileSync(
-  resolve(__dirname, '..', 'components', 'new-chat', 'DeviceSwitcherPill.tsx'),
-  'utf8',
-);
-
-const controllableDevicesHookSource = readFileSync(
-  resolve(__dirname, '..', 'hooks', 'useControllableDevices.ts'),
-  'utf8',
-);
-
-const deviceLinkRemoteProjectsSource = readFileSync(
-  resolve(__dirname, '..', 'features', 'device-link', 'useDeviceLinkRemoteProjects.ts'),
-  'utf8',
-);
-
-const deviceProvidersHookSource = readFileSync(
-  resolve(__dirname, '..', 'hooks', 'useDeviceProviders.ts'),
-  'utf8',
-);
-
-const agentCapabilitiesHookSource = readFileSync(
-  resolve(__dirname, '..', 'hooks', 'useAgentCapabilities.ts'),
-  'utf8',
-);
-
-const scheduleFormDialogSource = readFileSync(
-  resolve(__dirname, '..', 'features', 'scheduler', 'components', 'ScheduleFormDialog.tsx'),
-  'utf8',
-);
-
-const scheduleChipsSource = readFileSync(
-  resolve(__dirname, '..', 'features', 'scheduler', 'components', 'ScheduleChips.tsx'),
-  'utf8',
-);
-
-const newGoalDialogSource = readFileSync(
-  resolve(__dirname, '..', 'components', 'new-chat', 'NewGoalDialog.tsx'),
-  'utf8',
-);
-
-const extraDirsButtonSource = readFileSync(
-  resolve(__dirname, '..', 'components', 'new-chat', 'ExtraDirsButton.tsx'),
-  'utf8',
-);
-
-const sidebarUpperSource = readFileSync(
-  resolve(__dirname, '..', 'features', 'cc-agent', 'CCAgentSidebarUpper.tsx'),
-  'utf8',
-);
+const sidebarUpperSource = readSource('features', 'cc-agent', 'CCAgentSidebarUpper.tsx');
 
 describe('Shared create project picker', () => {
   it('builds project options from the persistent recent_workdirs table, not from live sessions', () => {
@@ -358,7 +320,9 @@ describe('Shared create project picker', () => {
 
   // #807 review 第二轮:换机器 = 换文件系统,@file/@dir chip 指的是上一台机器的路径。
   it('strips filesystem mention chips when switching devices', () => {
-    expect(newMakerDraftRouteSource).toContain('const composerDraft = getComposerDraft(NEW_MAKER_DRAFT_KEY);');
+    expect(newMakerDraftRouteSource).toContain(
+      'const composerDraft = getComposerDraft(NEW_MAKER_DRAFT_KEY);',
+    );
     expect(newMakerDraftRouteSource).toContain('text: stripLocalMentionChips(composerDraft.text),');
   });
 
@@ -455,9 +419,7 @@ describe('Shared create project picker', () => {
   // #807 review 第十四轮:注释与实现必须一致 —— 早前几轮把「指名设备不在目标里就留空」改对了,
   // 但 JSDoc 还写着 falls back to the first available target,会误导后续维护者改回静默换机器。
   it('documents that an explicitly requested device never falls back', () => {
-    expect(addRemoteProjectDialogSource).not.toContain(
-      'falls back to the first available target',
-    );
+    expect(addRemoteProjectDialogSource).not.toContain('falls back to the first available target');
     expect(addRemoteProjectDialogSource).toContain('**指名了就只认这一台**');
   });
 
@@ -473,7 +435,7 @@ describe('Shared create project picker', () => {
     // extraDirs 只在换设备、或进入「对话」时清 —— 同机换项目那些目录仍然有效,
     // 不传则 store 保持原值。
     expect(action).toContain(
-      "...(deviceChanged || req.workingDir == null ? { extraDirs: [] } : {}),",
+      '...(deviceChanged || req.workingDir == null ? { extraDirs: [] } : {}),',
     );
     // 但 worktree 三态照常重置 —— 换项目就是换 repo。
     expect(action).toContain('if (deviceChanged || workingDirChanged) {');
@@ -530,9 +492,7 @@ describe('Shared create project picker', () => {
   // #807 review 第十二轮:pending 删除集合按设备分层,否则 A 上未结束的 /x 会被当成 B 的待删除项,
   // B 上同名 /x 会被权威列表错误过滤掉。
   it('scopes pending removals per device', () => {
-    expect(deviceLinkProjectsHookSource).toContain(
-      'useRef<Map<string, Set<string>>>(new Map())',
-    );
+    expect(deviceLinkProjectsHookSource).toContain('useRef<Map<string, Set<string>>>(new Map())');
     expect(deviceLinkProjectsHookSource).toContain(
       'pendingRemovalsRef.current.get(target.deviceId)',
     );
@@ -563,9 +523,10 @@ describe('Shared create project picker', () => {
   // false —— 只看它们会在 maker:get-new-maker-defaults 回来前放行,提交 capability 兜底值而不是
   // 该设备保存的草稿值,会话建出来后晚到的响应也修不回去。
   it('waits for remote defaults before allowing send or goal creation', () => {
-    const guards = newMakerDraftRouteSource.match(
-      /capabilitiesLoading \|\| deviceProvidersLoading \|\| !remoteDraftState\.loaded/g,
-    ) ?? [];
+    const guards =
+      newMakerDraftRouteSource.match(
+        /capabilitiesLoading \|\| deviceProvidersLoading \|\| !remoteDraftState\.loaded/g,
+      ) ?? [];
     expect(guards.length).toBe(2);
     expect(newMakerDraftRouteSource).not.toContain(
       'if (isDeviceLinkDraft && (capabilitiesLoading || deviceProvidersLoading)) return false;',
@@ -672,7 +633,9 @@ describe('Shared create project picker', () => {
     const effect = newMakerDraftRouteSource.slice(
       newMakerDraftRouteSource.indexOf('selected device is no longer selectable'),
     );
-    expect(effect.slice(0, effect.indexOf('  }, ['))).toContain('applyDraftTarget({ deviceId: null');
+    expect(effect.slice(0, effect.indexOf('  }, ['))).toContain(
+      'applyDraftTarget({ deviceId: null',
+    );
     const action = newMakerDraftRouteSource.slice(
       newMakerDraftRouteSource.indexOf('const applyDraftTarget = useCallback('),
     );
@@ -713,7 +676,9 @@ describe('Shared create project picker', () => {
   // capabilitiesLoading 永久为 true,而创建页的 send / goal guard 正是看它。
   it('clears inherited loading state when the capability cache hits', () => {
     const cachedBranch = agentCapabilitiesHookSource.slice(
-      agentCapabilitiesHookSource.indexOf('const cached = cache.get(cacheKey(agentKind, deviceId));'),
+      agentCapabilitiesHookSource.indexOf(
+        'const cached = cache.get(cacheKey(agentKind, deviceId));',
+      ),
     );
     const untilReturn = cachedBranch.slice(0, cachedBranch.indexOf('return;'));
     expect(untilReturn).toContain('setLoading(false);');
@@ -774,7 +739,9 @@ describe('Shared create project picker', () => {
     expect(remoteSessionHandoffSource).toContain(
       'export function commitRemoteSessionHandoff(p: RemoteSessionHandoffParams): void {',
     );
-    expect(remoteSessionHandoffSource).not.toContain('export async function commitRemoteSessionHandoff');
+    expect(remoteSessionHandoffSource).not.toContain(
+      'export async function commitRemoteSessionHandoff',
+    );
     // 回流不被 await。
     expect(remoteSessionHandoffSource).not.toContain('await refreshRemoteDeviceSessions(');
     // 两处调用点都不得 await 它 —— await 一个同步函数不报错,但会把「不要等」这个意图悄悄改回去。
@@ -783,7 +750,9 @@ describe('Shared create project picker', () => {
     const sendPart = newMakerDraftRouteSource.slice(
       newMakerDraftRouteSource.indexOf("logTag: 'draft send'"),
     );
-    expect(sendPart.slice(0, sendPart.indexOf('navigate('))).toContain('setPending(remoteSessionId');
+    expect(sendPart.slice(0, sendPart.indexOf('navigate('))).toContain(
+      'setPending(remoteSessionId',
+    );
     const goalPart = newMakerDraftRouteSource.slice(
       newMakerDraftRouteSource.indexOf("logTag: 'draft goal'"),
     );
@@ -807,9 +776,7 @@ describe('Shared create project picker', () => {
     // model / permission / workspaceKind。
     expect((newMakerDraftRouteSource.match(/\n\s+createArgs,\n/g) ?? []).length).toBe(2);
     // workDir 取 create 响应(纯对话的运行目录由对端分配,控制端猜不到)。
-    expect(
-      (newMakerDraftRouteSource.match(/workDir: created\?\.workDir,/g) ?? []).length,
-    ).toBe(2);
+    expect((newMakerDraftRouteSource.match(/workDir: created\?\.workDir,/g) ?? []).length).toBe(2);
   });
 
   // #807 review 第十七轮:handleSend 的第一个 await 是协同策略重取,它在上锁之前 —— 期间两个
@@ -855,7 +822,8 @@ describe('Shared create project picker', () => {
     // 全文恰好两处非图片过滤,各有明确分工:① 这个换设备时的同步清理;② 第二十四轮加的不变量
     // 收敛 effect(兜住在途摄入等所有入口)。出现第三处就说明又有人在某条路径上手写了一份。
     expect(
-      (newMakerDraftRouteSource.match(/\.filter\(\(f\) => f\.category !== 'image'\)/g) ?? []).length,
+      (newMakerDraftRouteSource.match(/\.filter\(\(f\) => f\.category !== 'image'\)/g) ?? [])
+        .length,
     ).toBe(2);
     expect(newMakerDraftRouteSource).toContain('「远程草稿绝不携带控制端路径附件」的**收敛器**');
   });
@@ -1000,7 +968,9 @@ describe('Shared create project picker', () => {
     // ③ 「设备已不可用」类的 evict 不需要配对 —— 那几处刻意不 prefetch,别被这条规则误改。
     //    这里只锁「本仓存在那个正确范例」,它是这条规则的出处。
     expect(deviceLinkRemoteProjectsSource).toContain('evictDeviceProviders(push.deviceId);');
-    expect(deviceLinkRemoteProjectsSource).toContain('void prefetchDeviceProviders(push.deviceId);');
+    expect(deviceLinkRemoteProjectsSource).toContain(
+      'void prefetchDeviceProviders(push.deviceId);',
+    );
   });
 
   /**
@@ -1076,7 +1046,9 @@ describe('Shared create project picker', () => {
     // 断言旧代码形态而非裸片段 —— 上面那段注释里会逐字提到它作为历史记录。
     expect(body).not.toContain("incoming.filter((f) => f.type.startsWith('image/'))");
     expect(body).toContain('const ext = extractExt(f.name);');
-    expect(body).toContain('const category = ext ? categorizeFile(ext) : categorizeByFilename(f.name);');
+    expect(body).toContain(
+      'const category = ext ? categorizeFile(ext) : categorizeByFilename(f.name);',
+    );
     // 认不出类别时**放行**,交给下游的文件头推断 + 收敛器兜底 —— 闸门宁可放过,绝不误拒。
     expect(body).toContain('if (!category) return false;');
     expect(body).toContain("return category !== 'image';");
@@ -1185,9 +1157,7 @@ describe('Shared create project picker', () => {
       "t('newChat.addRemoteProject.selectTargetPlaceholder')",
     );
     // 未选中的原因也要说出来,否则用户只看到一个空下拉。
-    expect(addRemoteProjectDialogSource).toContain(
-      'const requestedDeviceUnavailable =',
-    );
+    expect(addRemoteProjectDialogSource).toContain('const requestedDeviceUnavailable =');
     expect(addRemoteProjectDialogSource).toContain(
       "t('newChat.addRemoteProject.requestedDeviceUnavailable')",
     );
@@ -1210,7 +1180,9 @@ describe('Shared create project picker', () => {
     expect(body).toContain('model: prev.model,');
     expect(body).toContain('permissionMode: prev.permissionMode,');
     // 三处调用:换设备重种、同设备按 prev 校准、prev 为空时退回正常 seed。
-    expect((body.match(/resolveDeviceLinkDraftDefaults\(/g) ?? []).length).toBeGreaterThanOrEqual(3);
+    expect((body.match(/resolveDeviceLinkDraftDefaults\(/g) ?? []).length).toBeGreaterThanOrEqual(
+      3,
+    );
   });
 
   // #807 review 第二十七轮:设备菜单行原来只有 hover / disabled 两态,且 outline-none 去掉了浏览器

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -13,9 +13,10 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // 本仓 core.autocrlf=true 时 Windows checkout 出来的源文件是 CRLF,而下面的快照断言
-// 统一按 LF 书写;读入时归一化行尾,让断言不绑定 checkout 端的行尾配置。
+// 统一按 LF 书写;读入时归一化行尾(CRLF 与孤立 CR 都归一为 LF),让断言不绑定
+// checkout 端的行尾配置。
 const readSource = (...segments: string[]): string =>
-  readFileSync(resolve(__dirname, '..', ...segments), 'utf8').replaceAll('\r\n', '\n');
+  readFileSync(resolve(__dirname, '..', ...segments), 'utf8').replace(/\r\n?/g, '\n');
 
 const newMakerDraftRouteSource = readSource('features', 'cc-agent', 'NewMakerDraftRoute.tsx');
 

--- a/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
@@ -4,9 +4,10 @@
  * UpdateNoticeDialog 的 auto 布局契约。
  *
  * 装完后的自动公告走这条布局,UpdateBanner 的「装前预览」也刻意复用它(见 useUpdateNotice
- * 的 onOpenVersion)。所以这个文件既是既有行为的回归护栏,也是新入口渲染形态的说明:
- *   - 单版本:右上角是该版本日期,徽标 v<版本>
- *   - 跨版本:右上角是版本数,徽标 v<旧> → v<新>
+ * 的 onOpenVersion)。所以这个文件既是既有行为的回归护栏,也是新入口渲染形态的说明
+ * (#956 单栏版式之后,版本徽标与日期都在各版本自己的 block 里,header 不再有 range 徽标):
+ *   - 单版本:block 徽标 v<版本> + 日期,header 右侧无版本数
+ *   - 跨版本:header 右侧是版本数,每个 block 各有自己的 v<版本> 徽标
  * 两种情况都没有版本跳转器、没有懒加载占位块。
  *
  * 弹窗本身在本次改动里一行未改;这里锁住的是「预览入口依赖的那部分不能被顺手清理掉」。
@@ -82,11 +83,15 @@ describe('UpdateNoticeDialog auto layout', () => {
     ).toBeTruthy();
   });
 
-  it('multiple versions: version count on the right, range badge, span aria', () => {
+  it('multiple versions: version count on the right, per-block badges, span aria', () => {
     renderAuto([NEWEST, OLDER]);
 
     expect(screen.getByText('update.notice.versionsSpan(count=2)')).toBeTruthy();
-    expect(screen.getByText('v0.1.20 → v0.1.21')).toBeTruthy();
+    // #956 的单栏版式把 header 的「v<旧> → v<新>」range 徽标撤掉了:版本身份
+    // 落在每个版本自己的 block 徽标上,header 右侧只剩版本数。
+    expect(screen.getByText('v0.1.21')).toBeTruthy();
+    expect(screen.getByText('v0.1.20')).toBeTruthy();
+    expect(screen.queryByText('v0.1.20 → v0.1.21')).toBeNull();
     expect(
       screen.getByText('update.notice.ariaDescriptionSpan(from=0.1.20,count=2)'),
     ).toBeTruthy();

--- a/apps/desktop/src/renderer/features/billing/__tests__/money.test.ts
+++ b/apps/desktop/src/renderer/features/billing/__tests__/money.test.ts
@@ -4,15 +4,19 @@ import { describe, expect, it } from 'vitest';
 
 import { formatBillingAmount, formatBillingMinorAmount } from '../money';
 
-const usd = (value: number) =>
-  new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(value);
+// USD 走窄符号(见 money.ts 的 billingCurrencyFormatOptions),否则 zh-CN 等宿主
+// locale 下 Intl 默认会给出 US$,期望值必须带上同一选项才跟实现同源;这里仍不写死
+// 符号,以免绑定具体 ICU 版本的分组符与小数点。
+const USD_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
+  style: 'currency',
+  currency: 'USD',
+  currencyDisplay: 'narrowSymbol',
+};
+const usd = (value: number) => new Intl.NumberFormat(undefined, USD_FORMAT_OPTIONS).format(value);
 const jpy = (value: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'JPY' }).format(value);
 const exactUsd = (whole: bigint, fraction: bigint) => {
-  const formatter = new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: 'USD',
-  });
+  const formatter = new Intl.NumberFormat(undefined, USD_FORMAT_OPTIONS);
   const resolved = formatter.resolvedOptions();
   const localizedFraction = new Intl.NumberFormat(resolved.locale, {
     numberingSystem: resolved.numberingSystem,

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -169,7 +169,9 @@ test("unit workspace concurrency reserves the full worker budget for heavy works
 	assert.equal(desktop.tiers.unit.execution, "exclusive");
 	assert.deepEqual(desktop.tiers.unit.command.args, [
 		"run",
-		`--pool=${nodeWebstorageEnabled() ? "forks" : "threads"}`,
+		// win32 pins forks: threads segfaults the desktop suite there, and the
+		// LaunchServices churn that threads exists to avoid is macOS-only.
+		`--pool=${nodeWebstorageEnabled() || process.platform === "win32" ? "forks" : "threads"}`,
 		`--maxWorkers=${desktopUnitWorkerCount()}`,
 	]);
 	assert.equal(desktopUnitWorkerCount(1), 1);
@@ -197,10 +199,15 @@ test("unit tier pins an explicit vitest pool, forks only by documented exception
 	// registry -> no frontmost app -> dead keyboard, no menu bar, vanishing Dock
 	// tiles). A workspace added later must not silently inherit that churn, and
 	// opting back into forks must be a deliberate edit to this list.
-	// Desktop's entry is conditional: it only stays on forks on a Node whose
-	// webstorage globals force the execArgv that worker threads cannot take.
+	// Desktop's entry is conditional: it stays on forks on a Node whose
+	// webstorage globals force the execArgv that worker threads cannot take,
+	// and on win32, where threads segfaults the suite outright (native addon
+	// finalizers crashing in isolate teardown) and no launchservicesd exists
+	// for the churn to hurt.
 	const forksByException = [
-		...(nodeWebstorageEnabled() ? ["apps/desktop"] : []),
+		...(nodeWebstorageEnabled() || process.platform === "win32"
+			? ["apps/desktop"]
+			: []),
 		"packages/maker-core",
 	];
 	const unpinned = [];

--- a/scripts/test-workspaces.config.mjs
+++ b/scripts/test-workspaces.config.mjs
@@ -17,12 +17,20 @@ const vitestBin = (...args) => ({ type: 'packageBin', bin: 'vitest', args });
 // Not everything moves. The heavy manual tiers (db, migration, git-integration)
 // stay on the default pool: they bootstrap runtime assets and drive real
 // Git/SQLite subprocesses, and none sits on the PR gate path. A workspace also
-// opts out when its tests cannot survive a worker thread; both known blockers
+// opts out when its tests cannot survive a worker thread; the known blockers
 // are recorded at their call site below — desktop needs the webstorage flag on a
 // Node that installs those globals, and the flag cannot coexist with worker
 // threads (scripts/shared/node-webstorage.mjs), while maker-core fakes HOME,
 // which a worker cannot see because `process.env` there is a thread-local copy
 // while `os.homedir()` reads the real environment through libuv.
+//
+// win32 opts desktop out wholesale: on Windows (Node 24.14.1, 2026-07-30) the
+// desktop suite under threads segfaulted the whole vitest process (exit 139)
+// on 2 of 2 runs — same native-addon-finalizer-in-isolate-teardown crash
+// class node-webstorage.mjs documents, only without execArgv in play — while
+// forks passed 15651 tests twice in a row. The churn this pool exists to
+// avoid is a LaunchServices problem; Windows has no launchservicesd, so forks
+// costs it nothing.
 //
 // Keep every opt-out listed in the pool regression test, and keep the list
 // short: at 1330 of this tier's 1845 files, desktop alone decides whether the
@@ -101,9 +109,14 @@ export default {
           // what local dev and CI run, the flag is a no-op, so this suite's 1330
           // files take threads and stop spawning a process each. On a
           // webstorage-enabled Node the flag wins and the suite stays on forks.
+          // win32 stays on forks unconditionally — threads segfaults there and
+          // the churn threads exists to avoid is macOS-only (see the pool note
+          // at the top of this file).
           command: unitVitestCommand(
             desktopUnitWorkerCount(),
-            nodeWebstorageEnabled() ? 'forks' : 'threads',
+            nodeWebstorageEnabled() || process.platform === 'win32'
+              ? 'forks'
+              : 'threads',
           ),
           exclude: [
             '**/*.git-integration.test.ts',


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 desktop 单测在本地(尤其 Windows / 非 en-US 系统 locale)跑不过的 3 处测试自身问题,不改任何被测实现:

1. **billing/money.test.ts(6 个用例失败的根因)**:#991 给 USD 实现加了 `currencyDisplay: 'narrowSymbol'`,但测试期望值 helper(`usd()` / `exactUsd()`)仍用默认 `symbol`。zh-CN / ko-KR 等宿主 locale 下默认符号是 `US$`、窄符号是 `$`,两者不等,6 个用例集体失败;CI 的 en-US 上两者巧合相等所以没拦住。修复:期望值 helper 抽出与实现同源的 `USD_FORMAT_OPTIONS`(带 narrowSymbol),仍不写死符号/分组符/小数点,不绑定具体 ICU 版本。
2. **endpointManifestCache.test.ts(2 个用例)**:Windows 非管理员且未开开发者模式时 `fs.symlinkSync` 报 EPERM。修复:启动时探测一次 symlink 权限,拿不到就跳过相关用例,与文件内 mkfifo 不可用(Windows)时的处理一致。
3. **newMakerProjectPicker.test.ts(2 个用例)**:源码快照断言硬编码 `\n`,而 `core.autocrlf=true` 的 Windows checkout 源文件是 CRLF,`toContain` 匹配不上。修复:统一走 `readSource()` 读入并归一化 CRLF→LF;顺手删掉基线就未使用的 `deviceLinkCreateArgsSource`(eslint no-unused-vars 报错项)。
4. **updateNoticeDialogAutoLayout.test.ts(rebase 后接手的 main 门禁破损)**:#954 的新测试断言了 #956 单栏版式已移除的「v<旧> → v<新>」header range 徽标,两个 PR 各自 CI 绿、合入 main 后语义冲突,main 的 verify 从 52345994 起全挂。按 #956 后的真实渲染更新断言(各版本 block 自带徽标、header 右侧只有版本数),只改测试不动弹窗实现。
5. **test-workspaces.config.mjs(win32 池回退)**:#1018 基于 macOS 把 unit tier 默认池改为 threads(避免 forks 进程 churn 打挂 launchservicesd),但 Windows 上 desktop 套件在 threads 池下 2/2 复现整进程段错误(exit 139,native addon finalizer 在 isolate teardown 崩溃),同一文件集 forks 全绿。Windows 没有 launchservicesd,threads 要省的开销在 win32 本就不存在,故 desktop 在 win32 无条件回 forks;其余 workspace 的 1-worker threads 在 Windows 实测正常,不动。池回归测试同步 win32 例外。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求:无(本地门禁测试失败排查)
- 本 PR 包含:4 个测试文件的平台/locale 兼容修复 + test-workspaces 的 win32 池回退(含池回归测试同步)
- 明确不包含:任何被测实现(money.ts、endpointManifestCache.ts、picker、UpdateNoticeDialog 等源码)的改动;非 win32 平台的池选择不变
- 用户可见变化:无
- 是否存在 breaking change:无

### UI 变化

不涉及

- 引用的设计规范:不涉及:仅修 3 个测试文件自身的平台/locale 兼容断言,无任何视觉、交互或文案变化,不改渲染代码

## 怎么验证的

### 自动验证

```text
pnpm test:unit(win32 池回退后,desktop 自动走 forks)
结果:54 个 workspace 全部 PASS(desktop 1340 文件 / 15651 passed / 18 skipped),exit 0

pnpm --filter desktop typecheck
结果:通过(exit 0)

pnpm exec eslint <3 个改动文件>
结果:通过

node --test scripts/__tests__/test-workspaces.test.mjs
结果:67 passed(含更新后的池回归测试)

pnpm check:dco
结果:5 commits signed off,通过
```

验证环境:Windows 11(系统 locale zh-CN、core.autocrlf=true、无 symlink 权限)——正是原先能复现全部 3 类失败的环境,修复后全绿。

### 手工验证

不涉及(纯测试改动)

### 未执行的验证

- 未在 Linux/macOS 上复跑:改动均为放宽平台假设(探测跳过/行尾归一化/格式化选项对齐实现),CI 的 Linux 行为不变,以 CI 为准。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅测试代码;symlink 用例在无权限的 Windows 上从「报错失败」变为「跳过」,CI(Linux)上仍完整执行
- 回滚 / 降级方式:revert 本 PR 两个 commit 即可
- 本机曾出现 better-sqlite3 ABI 127/137 混链(pnpm store 硬链接被其它 checkout 波及),已断链重装并复验,与本 PR 代码无关
- 移动端冷更:不涉及——改动全部在 apps/desktop 测试文件,未触碰 apps/mobile 的任何 runtime fingerprint 输入

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

