### PR TITLE
test(desktop): 更新公告 auto 布局测试对齐单栏版式

### DIFF
--- a/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
@@ -6,7 +6,8 @@
  * 装完后的自动公告走这条布局,UpdateBanner 的「装前预览」也刻意复用它(见 useUpdateNotice
  * 的 onOpenVersion)。所以这个文件既是既有行为的回归护栏,也是新入口渲染形态的说明:
  *   - 单版本:右上角是该版本日期,徽标 v<版本>
- *   - 跨版本:右上角是版本数,徽标 v<旧> → v<新>
+ *   - 跨版本:右上角是版本数,各版本块顶部自带 v<版本> 徽标(单栏版式起
+ *     不再有 v<旧> → v<新> 区间徽标,见 #956)
  * 两种情况都没有版本跳转器、没有懒加载占位块。
  *
  * 弹窗本身在本次改动里一行未改;这里锁住的是「预览入口依赖的那部分不能被顺手清理掉」。
@@ -82,11 +83,13 @@ describe('UpdateNoticeDialog auto layout', () => {
     ).toBeTruthy();
   });
 
-  it('multiple versions: version count on the right, range badge, span aria', () => {
+  it('multiple versions: version count on the right, per-block version badges, span aria', () => {
     renderAuto([NEWEST, OLDER]);
 
     expect(screen.getByText('update.notice.versionsSpan(count=2)')).toBeTruthy();
-    expect(screen.getByText('v0.1.20 → v0.1.21')).toBeTruthy();
+    // 单栏版式(#956)后 auto 模式不再有区间徽标,版本身份落在各版本块的徽标上。
+    expect(screen.getByText('v0.1.21')).toBeTruthy();
+    expect(screen.getByText('v0.1.20')).toBeTruthy();
     expect(
       screen.getByText('update.notice.ariaDescriptionSpan(from=0.1.20,count=2)'),
     ).toBeTruthy();


### PR DESCRIPTION
## 这次改了什么

### 摘要

主干 verify 目前持续红灯,卡在 `updateNoticeDialogAutoLayout.test.tsx` 的跨版本用例:它断言 auto 模式存在 `v0.1.20 → v0.1.21` 区间徽标,而该徽标已被 #956(更新公告改单栏版式)从组件中移除。该用例随 #954 合入——#954 的检查开跑于 #956 合入之前(09:39 vs 10:31),当时的通过是真实的;17 小时后带着过期绿色标记合入,与新版组件形成语义冲突。本 PR 把该用例对齐到组件现行行为,让主干恢复绿色。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：主干 verify 红灯(最近失败 run:30512567161,错误 `Unable to find an element with the text: v0.1.20 → v0.1.21`)
- 本 PR 包含：一个测试文件的断言与文件头说明更新
- 明确不包含：恢复区间徽标(单栏版式是 #956 的既定改动;如产品上希望恢复,应单开 PR 改组件而不是改这个测试)
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及:仅修改测试断言,组件一行未改,无视觉/交互/文案变化。

- 引用的设计规范：不涉及:仅测试文件,无 UI 代码变更

## 怎么验证的

### 自动验证

```text
corepack pnpm exec vitest run src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
结果：3 个用例全部通过(修复前复现了与主干 CI 完全一致的失败)

corepack pnpm exec vitest run src/renderer/__tests__ -t "UpdateNotice"
结果：21 个相关用例全部通过

corepack pnpm --filter desktop run typecheck
结果：通过

corepack pnpm test:unit(仓库根全量)
结果：本文件在全量中通过;desktop 另有 13 个失败为本机既有环境问题(已在干净 upstream/main 上复跑验证失败集合一致:newMakerProjectPicker、endpointManifestCache symlink、scriptRunnerPythonProtocol、billing money),与本 PR 无关;mobile 及全部 packages 通过
```

### 手工验证

不涉及(纯测试断言变更)

### 未执行的验证

无

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 `updateNoticeDialogAutoLayout.test.tsx`;断言收紧方向不变(仍锁定 auto 布局契约:头部版本数、各版本块徽标、aria、无跳转器),不是削弱检查,是对齐 #956 之后的组件真实行为
- 回滚 / 降级方式：revert 本 PR(回滚后主干 verify 会重新红在该用例上)

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(测试文件头说明已同步更新)
- [x] 已确认测试结果或说明未执行原因
