### PR TITLE
fix(anthropic-responses-bridge): 上游流内错误不再被吞成空 200 SSE

### DIFF
--- a/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
@@ -123,8 +123,50 @@ describe('createResponsesHandler', () => {
     expect(r.text).toContain('no translatable SSE events');
     // 上游正文前缀进错误信息:真实错误不再被空 200 掩盖。
     expect(r.text).toContain('prompt too large for context window');
-    expect(warns).toContain('upstream 200 with non-SSE content-type');
+    expect(warns).toContain('upstream 2xx with non-SSE content-type');
     expect(warns).toContain('upstream stream yielded no translatable events');
+  });
+
+  it('content-type 判定大小写不敏感:Text/Event-Stream 不触发 non-SSE warn', async () => {
+    const warns: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(sse(OK_SSE), {
+      status: 200,
+      headers: { 'content-type': 'Text/Event-Stream; charset=utf-8' },
+    })));
+    const handler = createResponsesHandler({
+      providers: [providerConfig()],
+      logger: { warn: (msg) => warns.push(msg) },
+    });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    expect(r.text).toContain('message_stop');
+    expect(warns).not.toContain('upstream 2xx with non-SSE content-type');
+  });
+
+  it('已写出部分事件后断流 → error 事件收尾,不补 message_stop 伪装正常完成(#941 review)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      (() => {
+        // pull 式逐块投递:start 里 enqueue 后立即 error 会按 Streams 规范丢弃整个
+        // 未读队列,前面的块根本到不了 handler。
+        let step = 0;
+        return new ReadableStream<Uint8Array>({
+          pull(c) {
+            if (step < 3) {
+              c.enqueue(new TextEncoder().encode(`data: ${OK_SSE[step]}\n\n`));
+              step += 1;
+            } else {
+              c.error(new Error('socket reset'));
+            }
+          },
+        });
+      })(),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    )));
+    const handler = createResponsesHandler({ providers: [providerConfig()] });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    expect(r.text).toContain('message_start');
+    expect(r.text).toContain('upstream stream error: socket reset');
+    // 截断响应必须以 error 事件收尾,不能以 message_stop 伪装正常完成。
+    expect(r.text).not.toContain('message_stop');
   });
 
   it('上游流内 OpenAI 风格 error 帧 → 透传为 Anthropic error 事件,不合成零事件错误(#941)', async () => {

--- a/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
@@ -102,6 +102,43 @@ describe('createResponsesHandler', () => {
     expect(seen[0].body.service_tier).toBeUndefined();
   });
 
+  it('上游 200 但整流零事件(非 SSE 正文)→ 合成带正文前缀的 error 事件而非空 200,并留 warn(#941)', async () => {
+    const warns: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('{"error":{"message":"prompt too large for context window"}}'));
+          c.close();
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )));
+    const handler = createResponsesHandler({
+      providers: [providerConfig()],
+      logger: { warn: (msg) => warns.push(msg) },
+    });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    expect(r.status).toBe(200);
+    expect(r.text).toContain('event: error');
+    expect(r.text).toContain('no translatable SSE events');
+    // 上游正文前缀进错误信息:真实错误不再被空 200 掩盖。
+    expect(r.text).toContain('prompt too large for context window');
+    expect(warns).toContain('upstream 200 with non-SSE content-type');
+    expect(warns).toContain('upstream stream yielded no translatable events');
+  });
+
+  it('上游流内 OpenAI 风格 error 帧 → 透传为 Anthropic error 事件,不合成零事件错误(#941)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      sse([JSON.stringify({ error: { message: 'boom', code: 'server_error' } })]),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    )));
+    const handler = createResponsesHandler({ providers: [providerConfig()] });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    expect(r.status).toBe(200);
+    expect(r.text).toContain('[server_error] boom');
+    expect(r.text).not.toContain('no translatable SSE events');
+  });
+
   it('wire model 带 [1m] 后缀 → 上游 model 剥后缀(目录 1M 模型经 toSdkModelString 会带)', async () => {
     const seen: Array<{ body: Record<string, unknown> }> = [];
     vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
@@ -189,6 +189,30 @@ describe('SseTranslator', () => {
     expect(byType(out, 'content_block_stop').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('OpenAI 风格流内错误帧(data 无 type,只有 error 对象)→ error 事件并透传 code(#941)', () => {
+    // `event: error` + `data: {"error":{...}}` 是 OpenAI 系上游的惯用错误形态,
+    // data 帧没有 type 字段;修复前落 default 分支被静默丢弃,整流零事件、CLI 只能
+    // 报 "empty or malformed response (HTTP 200)" 并盲目重试。
+    const out = run([
+      { type: 'response.created', response: { id: 'r', model: 'gpt-5.5' } },
+      { error: { message: 'context window exceeded', code: 'context_length_exceeded' } },
+    ]);
+    expect(types(out)).toContain('error');
+    const err = byType(out, 'error')[0];
+    expect((err.data.error as Record<string, unknown>).message).toBe(
+      '[context_length_exceeded] context window exceeded',
+    );
+  });
+
+  it('错误帧 code 缺失时用 type 字段;两者都无则只透传 message', () => {
+    const withType = run([{ error: { message: 'boom', type: 'server_error' } }]);
+    expect((byType(withType, 'error')[0].data.error as Record<string, unknown>).message).toBe(
+      '[server_error] boom',
+    );
+    const bare = run([{ error: { message: 'boom' } }]);
+    expect((byType(bare, 'error')[0].data.error as Record<string, unknown>).message).toBe('boom');
+  });
+
   it('grok 交错流:message item 挂着不关、中间穿插 function_call → 强制关块保持单开块不变量,text 不重复', () => {
     // 2026-07-08 实测 xai/grok-4.5:message(text) item 发完 delta 后不发 output_item.done,
     // 先穿插若干 function_call item,message 的 done 最后才到。修复前 text 块跨越多个

--- a/packages/anthropic-responses-bridge/src/handler.ts
+++ b/packages/anthropic-responses-bridge/src/handler.ts
@@ -327,11 +327,13 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
       }
     }
 
-    // 上游 200 但 content-type 不是 SSE(反代/网关吐 JSON 或 HTML):大概率整流翻不出
+    // 上游 2xx 但 content-type 不是 SSE(反代/网关吐 JSON 或 HTML):大概率整流翻不出
     // 任何事件,先留一条 warn ——零事件收尾时的合成 error 会带上正文前缀(#941)。
+    // 判定大小写不敏感(HTTP header 值的 media type 不区分大小写);真实状态码进日志,
+    // 本路径接受任意 2xx,不硬编码 200(review 反馈)。
     const upstreamContentType = upstream.headers.get('content-type') ?? '';
-    if (!upstreamContentType.includes('event-stream')) {
-      log.warn?.('upstream 200 with non-SSE content-type', {
+    if (!upstreamContentType.toLowerCase().includes('event-stream')) {
+      log.warn?.('upstream 2xx with non-SSE content-type', {
         reqId,
         status: upstream.status,
         contentType: upstreamContentType || '(missing)',
@@ -377,7 +379,7 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
           error: {
             type: 'api_error',
             message:
-              `upstream returned HTTP 200 but produced no translatable SSE events ` +
+              `upstream returned HTTP ${upstream.status} but produced no translatable SSE events ` +
               `(content-type: ${upstreamContentType || 'missing'}${bodyPrefix ? `; body: ${bodyPrefix}` : ''})`,
           },
         },
@@ -417,8 +419,13 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
       finalizeStream();
     } catch (err) {
       if (!abort.signal.aborted) {
-        log.warn?.('upstream stream error', { reqId, err: err instanceof Error ? err.message : String(err) });
-        finalizeStream();
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn?.('upstream stream error', { reqId, err: errMsg });
+        // 断流不走 finalizeStream:已写出部分事件后再补 message_stop,Claude Code 会
+        // 把截断响应当正常完成、上游读取错误被掩盖(review 反馈 P1)。fail() 关块后
+        // 发 error 事件收尾(错误帧已收尾时返回空,不重复报错);流失败于任何事件
+        // 之前时 error 事件同样成立,零事件合成诊断只服务「干净结束却零事件」路径。
+        for (const outEv of translator.fail(`upstream stream error: ${errMsg}`)) writeOut(outEv);
       }
     } finally {
       res.end();

--- a/packages/anthropic-responses-bridge/src/handler.ts
+++ b/packages/anthropic-responses-bridge/src/handler.ts
@@ -327,6 +327,17 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
       }
     }
 
+    // 上游 200 但 content-type 不是 SSE(反代/网关吐 JSON 或 HTML):大概率整流翻不出
+    // 任何事件,先留一条 warn ——零事件收尾时的合成 error 会带上正文前缀(#941)。
+    const upstreamContentType = upstream.headers.get('content-type') ?? '';
+    if (!upstreamContentType.includes('event-stream')) {
+      log.warn?.('upstream 200 with non-SSE content-type', {
+        reqId,
+        status: upstream.status,
+        contentType: upstreamContentType || '(missing)',
+      });
+    }
+
     // 开始流式回写。
     res.writeHead(200, {
       'content-type': 'text/event-stream; charset=utf-8',
@@ -340,11 +351,47 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
     const reader = upstream.body.getReader();
     const decoder = new TextDecoder();
     let buf = '';
+    // 零事件诊断:整流一条 Anthropic 事件都没写回时,CLI 只能报
+    // "empty or malformed response (HTTP 200)" 并盲目重试,真实错误被完全掩盖(#941)。
+    // 记录写回事件数与上游正文前缀,收尾时合成一条带上游信息的 error 事件 + warn 日志。
+    let eventsWritten = 0;
+    let rawPrefix = '';
+    const RAW_PREFIX_LIMIT = 500;
+    const writeOut = (ev: AnthropicSseEvent): void => {
+      eventsWritten += 1;
+      writeSseEvent(res, ev);
+    };
+    const finalizeStream = (): void => {
+      for (const outEv of translator.finish()) writeOut(outEv);
+      if (eventsWritten > 0) return;
+      const bodyPrefix = rawPrefix.trim().slice(0, 300);
+      log.warn?.('upstream stream yielded no translatable events', {
+        reqId,
+        contentType: upstreamContentType || '(missing)',
+        bodyPrefix,
+      });
+      writeOut({
+        event: 'error',
+        data: {
+          type: 'error',
+          error: {
+            type: 'api_error',
+            message:
+              `upstream returned HTTP 200 but produced no translatable SSE events ` +
+              `(content-type: ${upstreamContentType || 'missing'}${bodyPrefix ? `; body: ${bodyPrefix}` : ''})`,
+          },
+        },
+      });
+    };
     try {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
-        buf += decoder.decode(value, { stream: true });
+        const chunkText = decoder.decode(value, { stream: true });
+        if (rawPrefix.length < RAW_PREFIX_LIMIT) {
+          rawPrefix = (rawPrefix + chunkText).slice(0, RAW_PREFIX_LIMIT);
+        }
+        buf += chunkText;
         // SSE 事件以空行分隔;逐行取 `data:` 负载。用游标扫描、chunk 末尾一次性 slice ——
         // 避免每行 slice 整个剩余缓冲(大 chunk 数百行时是 O(n²) 拷贝,这是每 token 热路径)。
         let start = 0;
@@ -361,16 +408,17 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
           } catch {
             continue;
           }
-          for (const outEv of translator.push(ev)) writeSseEvent(res, outEv);
+          for (const outEv of translator.push(ev)) writeOut(outEv);
         }
         if (start > 0) buf = buf.slice(start);
       }
-      // 上游正常结束但没走 response.completed(极少)→ 兜底收尾。
-      for (const outEv of translator.finish()) writeSseEvent(res, outEv);
+      // 上游正常结束但没走 response.completed(极少)→ 兜底收尾;整流零事件时合成
+      // 带上游信息的 error 事件,绝不空 200 收尾。
+      finalizeStream();
     } catch (err) {
       if (!abort.signal.aborted) {
         log.warn?.('upstream stream error', { reqId, err: err instanceof Error ? err.message : String(err) });
-        for (const outEv of translator.finish()) writeSseEvent(res, outEv);
+        finalizeStream();
       }
     } finally {
       res.end();

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -222,6 +222,19 @@ export class SseTranslator {
     }
   }
 
+  /**
+   * 上游读流中途失败(reader 抛错)时的收尾:关块 + `error` 事件,**不发**
+   * message_delta/message_stop——已经写出部分内容后再补正常收尾,Claude Code 会把
+   * 截断响应当成正常完成,上游读取错误被完全掩盖(review 反馈 P1)。已收尾(错误帧
+   * 已翻译 / completed 已处理)则返回空,不重复报错。
+   */
+  fail(message: string): AnthropicSseEvent[] {
+    if (this.finished) return [];
+    const out: AnthropicSseEvent[] = [];
+    this.emitFailure(message, out);
+    return out;
+  }
+
   /** 上游流意外结束(没收到 response.completed)时兜底收尾。 */
   finish(): AnthropicSseEvent[] {
     if (this.finished) return [];
@@ -536,8 +549,14 @@ export class SseTranslator {
           ? err.type
           : '';
     const message = code && !baseMessage.includes(code) ? `[${code}] ${baseMessage}` : baseMessage;
-    // 关掉半开的块,再发一条 Anthropic error 事件(SDK 会把它当 turn 级错误处理)。
-    // 已到达的暂存内容先按原序回放,不随失败一起丢。
+    this.emitFailure(message, out);
+  }
+
+  /**
+   * 失败收尾的公共实现(流内错误帧与 fail() 共用):已到达的暂存内容先按原序回放、
+   * 关掉半开的块,再发一条 Anthropic error 事件(SDK 会把它当 turn 级错误处理)。
+   */
+  private emitFailure(message: string, out: AnthropicSseEvent[]): void {
     this.drainDeferred(out, true);
     this.closeAllOpenBlocks(out);
     out.push({

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -170,6 +170,14 @@ export class SseTranslator {
   }
 
   private handleEvent(e: Record<string, unknown>, type: string, out: AnthropicSseEvent[]): void {
+    // OpenAI 系上游流内错误的惯用形态是 `event: error` + `data: {"error":{...}}` ——
+    // data 帧本身没有 type 字段,原先落 default 分支被静默丢弃,CLI 只能拿到空 200 SSE
+    // 报 "empty or malformed response" 并盲目重试(#941)。正常 Responses 事件一律带
+    // type,无 type 且携带对象 error 字段的帧可无歧义判定为错误帧。
+    if (!type && e.error && typeof e.error === 'object') {
+      this.onFailed(e, out);
+      return;
+    }
     switch (type) {
       case 'response.created':
       case 'response.in_progress': {
@@ -518,7 +526,16 @@ export class SseTranslator {
     if (this.finished) return;
     const resp = asRecord(e.response);
     const err = asRecord(resp.error ?? e.error);
-    const message = typeof err.message === 'string' ? err.message : 'upstream response failed';
+    const baseMessage = typeof err.message === 'string' ? err.message : 'upstream response failed';
+    // 上游错误码(code / type,如 context_length_exceeded)一并透传:这是用户判断
+    // 「该压缩还是该换模型」的关键信息,也是 CLI 识别可操作错误的原料。
+    const code =
+      typeof err.code === 'string' && err.code
+        ? err.code
+        : typeof err.type === 'string' && err.type
+          ? err.type
+          : '';
+    const message = code && !baseMessage.includes(code) ? `[${code}] ${baseMessage}` : baseMessage;
     // 关掉半开的块,再发一条 Anthropic error 事件(SDK 会把它当 turn 级错误处理)。
     // 已到达的暂存内容先按原序回放,不随失败一起丢。
     this.drainDeferred(out, true);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 #941:`chatgpt/` 前缀订阅直连桥(anthropic-responses-bridge)在「上游 HTTP 200 但流内报错 / 流不可翻译」时,给 CLI 回一条零事件的空 200 SSE 流——Claude Code 只能报 "API returned an empty or malformed response (HTTP 200)" 并盲目重试,真实错误(如 context 超限)被完全掩盖,桥接层全程零日志。按 issue 定位补三处:

- **翻译器识别 OpenAI 风格流内错误帧**:`event: error` + `data: {"error":{...}}` 形态的 data 帧没有 `type` 字段,此前落 default 分支被静默丢弃;现在无 `type` 且携带对象 `error` 字段的帧翻译成 Anthropic `error` 事件,并透传上游 `code`/`type`(如 `[context_length_exceeded] ...`),给用户可操作的真实错误。
- **整流零事件不再空 200 收尾**:handler 统计写回事件数,整流一条都没写时合成一条带上游信息(content-type、正文前缀 ≤300 字符)的 `error` 事件。
- **可排障日志**:上游 200 但 content-type 非 SSE、整流零事件两种情况各留一条 warn(含状态码 / content-type / 正文前缀,截断策略与既有 non-2xx 日志一致)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#941(修复);#965 的部分症状(自定义供应商流内错误被吞)同机制受益
- 本 PR 包含:translate-sse 错误帧识别与 code 透传;handler 零事件合成 error + 诊断日志;4 个新单测
- 明确不包含:CLI 侧对 prompt-too-long 的自动压缩触发(属 Claude Code 行为,桥只负责透传真实错误);responses-chat-bridge(Chat Completions 桥)的同类审查
- 用户可见变化:订阅直连模型上游报错时,用户看到真实错误文案而非 "empty or malformed response";其余场景无变化
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/anthropic-responses-bridge exec vitest run
结果:61 passed | 3 skipped(新增 4 用例:错误帧翻译与 code 透传 ×2、
handler 零事件合成 error + warn 日志、流内错误帧端到端 ×1)

pnpm --filter @cindy/anthropic-responses-bridge run --if-present typecheck
结果:0 错误

apps/desktop 单测(pnpm test:unit 的 desktop unit 段):
结果:15666 passed | 1 failed —— 唯一失败为 updateNoticeDialogAutoLayout
(main 上游既有失败,与本 diff 无关,见「已知限制」)
```

### 手工验证

不涉及(错误路径依赖上游故障注入,已由 mock 上游的端到端单测覆盖:真实 ServerResponse 往返断言写回字节)。

### 未执行的验证

根 `pnpm test:unit` 全绿确认未执行:main HEAD(523459945)的 client-ci 本身红在 `updateNoticeDialogAutoLayout.test.tsx`(#954 的测试期望 `v旧 → v新` 徽标,已被后续 header 重构移除,语义合并冲突),本机复现与 CI 同点失败,与本 PR 的 bridge 改动无关。bridge 包与受影响路径已全量验证。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 anthropic-responses-bridge 的错误路径(正常流翻译零改动);错误帧识别条件(无 `type` 且 `error` 为对象)不与任何正常 Responses 事件形态重叠
- 回滚 / 降级方式:revert 本 PR 即回到「吞错误 → 空 200」的旧行为,无数据/协议兼容包袱

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
