### PR TITLE
docs(ghost-forge): clarify command is required for tool-enabled plugins

### DIFF
--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -759,7 +759,11 @@ my-ghost/
   "entry": "main.js",          // 电子脑入口(kind 字段已无需填写:意识只有芯片一种形态,缺省即 chip;写了也只认 "chip")
   "launch": "on-demand",       // 可选:电子脑启动模式。on-demand(缺省)=被需要才拉起;resident=唤醒即常驻(确认框会如实标注"常驻运行",绝大多数意识不需要,仅订阅型/需秒响应的场景用)
   "slots": ["tool", "cindy", "panel"],   // 能力白名单,没声明的槽运行时不存在
-  "command": "画图",            // 可选:用户 $画图 显式点名(与已装意识查重,冲突拒装)
+  "command": "画图",            // 推荐:用户 $画图 显式点名(与已装意识查重,冲突拒装)。
+  // 注意:不声明 command 时,插件页"使用"按钮将处于禁用状态——用户无法通过插件页
+  // 一键启用/唤起插件,也不能用 $command 显式点名;但 AI 的工具发现与调用不受影响
+  // (仅检查插件启用状态与 tools 声明)。除非你的插件完全靠 panel 或 subscribe 驱动,
+  // 否则请始终声明一个 command。
   "tools": [ /* 见 §3 */ ],
   "cindy": { "image": ["generate", "edit"] },   // 声明了 cindy 槽时必写:能力详单,见下
   // 三个类目:image / video 的动作是 "generate" | "edit";media 的动作只有
@@ -2601,6 +2605,8 @@ const ensured = await cindy.workspace({
 ## 9. 常见拒装原因速查
 
 - \`id\` 不合法(大写/下划线/超长)· 声明了 command 但没有 tools · command 与已装意识撞名
+  · **未声明 command**:不拒装,但插件页"使用"按钮禁用,用户无法通过插件页一键启用
+    或用 $command 点名;AI 工具调用不受影响(见 §2 说明)
 - 声明了 tool 槽但缺 tools(或反之)· panel.html 声明了但 slots 没有 "panel"
 - settingsHtml 路径不合法/文件不在包里 · settingsHeight 越界(160–800)或没配 settingsHtml 单独声明
 - panel.systemButtons 格式错(不是对象、未知键、值非布尔,或 position:"tab" 时声明——页签形态没有标准头)


### PR DESCRIPTION
## 这次改了什么

### 摘要

FORGE_GUIDE（`ghost_forge_guide` 返回的《意识编写手册》）此前把 `ghost.json` 的 `command` 字段标注为"可选"，但没有说明一个关键事实：**不声明 `command` 的插件，在插件页的「使用」按钮会被禁用**——即使用户启用了插件，AI 也无法通过工具调用触发它（`canUse: Boolean(manifest.command)`，见 `apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts`）。

本次在手册里补全这一因果关系，让 agent 替用户写插件时不会再踩坑：

- `ghost.json` 示例中 `command` 的注释从"可选"改为"推荐"，并明确警告未声明的后果。
- §9「常见拒装原因速查」补一条对照说明（不拒装，但按钮禁用）。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（社区用户创建插件时踩坑反馈）
- 本 PR 包含：
  - `apps/desktop/src/main/cindy-brain/forge.ts` 中 FORGE_GUIDE 模板的 `command` 注释更新（§2 ghost.json 示例）
  - §9 常见拒装原因速查补充一行对照说明
- 明确不包含：
  - 不改动 `canUse: Boolean(manifest.command)` 的实际判定逻辑（这是另一个产品决策，不在本 PR 范围）
  - 不改动任何运行时行为
- 用户可见变化：仅 `ghost_forge_guide` 工具返回的文档文本变化，agent 创建插件时能读到 `command` 缺失的真实后果
- 是否存在 breaking change：无

### UI 变化

不涉及。改动仅在 FORGE_GUIDE 模板字符串（纯文档文本），不触及任何 UI 代码路径。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
仅文档字符串改动，未执行自动测试。
forge.ts 中 FORGE_GUIDE 为模板字符串，改动不影响 TypeScript 类型或运行时逻辑。
```

### 手工验证

- 在本机通过 `sed -n '760,770p'` 与 `sed -n '2604,2612p'` 复核改动后的模板文本，确认两段注释位置与措辞正确
- 通过 `git diff` 复核完整 diff：仅 5 行新增 / 1 行删除，全部位于 FORGE_GUIDE 字符串内
- 实际复现路径（本 PR 的动机）：
  1. 用 FORGE_GUIDE 原描述创建一个无 `command` 的插件（`mail-filo`）
  2. 装入 Cindy 后插件页「使用」按钮处于禁用态
  3. 在 `ghost.json` 加上 `command` 后重新打包，按钮恢复可用

### 未执行的验证

未跑 `pnpm test` / `pnpm build`：改动为模板字符串内的注释文本，不涉及可执行逻辑。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `ghost_forge_guide` 工具返回的文档文本；不影响既有插件、不影响安装/运行链路
- 回滚 / 降级方式：revert 本 commit 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
