### PR TITLE
test(desktop): 公告 auto 布局契约对齐 #956 单栏头部,修复 main verify 红

### DIFF
--- a/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
@@ -5,9 +5,13 @@
  *
  * 装完后的自动公告走这条布局,UpdateBanner 的「装前预览」也刻意复用它(见 useUpdateNotice
  * 的 onOpenVersion)。所以这个文件既是既有行为的回归护栏,也是新入口渲染形态的说明:
- *   - 单版本:右上角是该版本日期,徽标 v<版本>
- *   - 跨版本:右上角是版本数,徽标 v<旧> → v<新>
+ *   - 单版本:版本号与日期在版本块内,头部右上无内容
+ *   - 跨版本:右上角只有版本数;**没有 v<旧> → v<新> 区间徽标**——#956 单栏改版把
+ *     版本身份(版本号/日期/贡献者)全部收进各版本自己的块,头部不再重复报幕
  * 两种情况都没有版本跳转器、没有懒加载占位块。
+ *
+ * (初版按 #956 之前的旧头部设计写了区间徽标断言,落地即把 main verify 打红;
+ * 本文件以现行单栏设计为准,并反向锁住"头部不得再出现区间徽标"。)
  *
  * 弹窗本身在本次改动里一行未改;这里锁住的是「预览入口依赖的那部分不能被顺手清理掉」。
  */
@@ -82,11 +86,12 @@ describe('UpdateNoticeDialog auto layout', () => {
     ).toBeTruthy();
   });
 
-  it('multiple versions: version count on the right, range badge, span aria', () => {
+  it('multiple versions: version count on the right, no range badge, span aria', () => {
     renderAuto([NEWEST, OLDER]);
 
     expect(screen.getByText('update.notice.versionsSpan(count=2)')).toBeTruthy();
-    expect(screen.getByText('v0.1.20 → v0.1.21')).toBeTruthy();
+    // 版本身份在各版本块内(见下一个用例),头部不再渲 v<旧> → v<新> 区间徽标。
+    expect(screen.queryByText('v0.1.20 → v0.1.21')).toBeNull();
     expect(
       screen.getByText('update.notice.ariaDescriptionSpan(from=0.1.20,count=2)'),
     ).toBeTruthy();

--- a/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateNoticeDialog.tsx
@@ -470,8 +470,8 @@ function VersionDropdown({
 }
 
 // ---------------------------------------------------------------------------
-// Auto-mode body: static header badge (v<oldest> → v<newest>), preloaded
-// blocks stacked.
+// Auto-mode body: preloaded blocks stacked (version identity lives inside each
+// block since #956; the header has no range badge).
 // ---------------------------------------------------------------------------
 
 function AutoBody({


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 main 分支 verify 全红:#954(今晨合入)新建的 `updateNoticeDialogAutoLayout` 契约测试是按 #956 改版**之前**的旧头部设计写的,断言跨版本时头部渲「v<旧> → v<新>」区间徽章;而 #956(昨日合入)已把版本身份(版本号/日期/贡献者)全部收进各版本自己的块、头部只留版本数。两个 PR 各自 CI 绿、按此顺序合入后互斥,#954 落地即把 main 的 verify 打红(自 5234599 起,所有 open PR 的 verify 连带被殃及)。

对齐现行单栏设计:跨版本用例改为断言区间徽章**不**渲染(反向锁死,防止头部重复报幕回潮),版本身份展示由既有的 per-block 用例(`条目 0.1.20/0.1.21`)覆盖;同步纠正测试文件头注与 `UpdateNoticeDialog.tsx` 里过时的 badge 注释。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求:main verify 红(#954 × #956 合序冲突)
- 本 PR 包含:测试断言对齐 + 两处过时注释纠正
- 明确不包含:任何组件行为改动(`UpdateNoticeDialog` 仅动注释)
- 用户可见变化:无
- 是否存在 breaking change:无

### UI 变化

不涉及:纯测试与注释修正,无任何渲染改动。

- 引用的设计规范:不涉及:无视觉/交互/文案变化。

## 怎么验证的

### 自动验证

```text
npx vitest run src/renderer/__tests__/updateNoticeDialogAutoLayout.test.tsx
结果:3 passed(修复前 1 failed)
pnpm test:unit          结果:exit 0(全仓恢复全绿)
pnpm --filter desktop typecheck   结果:exit 0
pnpm check:dco          结果:1 commit signed off
```

### 手工验证

不涉及(无行为改动)。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅一个测试文件的断言与两处注释;合入后 main verify 恢复绿,所有 open PR 的 CI 解除连带阻塞。
- 回滚 / 降级方式:revert 单 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
