### PR TITLE
feat(desktop): 添加 Slack 上下线通知开关

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/lifecycleAnnouncementIpc.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/lifecycleAnnouncementIpc.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SlackHookView } from '../../../shared/hookControlIpc.js';
+import { setLifecycleAnnouncementFromIpc } from '../lifecycleAnnouncementIpc.js';
+
+const HOOK_VIEW = {
+  lifecycleAnnouncement: false,
+} as SlackHookView;
+
+describe('setLifecycleAnnouncementFromIpc', () => {
+  it('returns the updated hook snapshot after persistence succeeds', () => {
+    const manager = {
+      setLifecycleAnnouncement: vi.fn(),
+      snapshot: vi.fn(() => HOOK_VIEW),
+    };
+    const log = { warn: vi.fn() };
+
+    expect(setLifecycleAnnouncementFromIpc(manager, true, log)).toEqual({ hook: HOOK_VIEW });
+    expect(manager.setLifecycleAnnouncement).toHaveBeenCalledWith(true);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs filesystem details only in Main and returns a sanitized IPC error', () => {
+    const privatePath = '/Users/private/Library/Application Support/Cindy/slack-hook.json';
+    const failure = new Error(`EROFS: read-only file system, rename '${privatePath}.tmp'`);
+    const manager = {
+      setLifecycleAnnouncement: vi.fn(() => {
+        throw failure;
+      }),
+      snapshot: vi.fn(() => HOOK_VIEW),
+    };
+    const log = { warn: vi.fn() };
+
+    expect(() => setLifecycleAnnouncementFromIpc(manager, false, log)).toThrow(
+      '[INTERNAL] failed to persist Slack lifecycle notification preference',
+    );
+    try {
+      setLifecycleAnnouncementFromIpc(manager, false, log);
+    } catch (err) {
+      expect(String(err)).not.toContain(privatePath);
+    }
+    expect(log.warn).toHaveBeenCalledWith(
+      'failed to persist Slack lifecycle notification preference',
+      failure,
+    );
+  });
+});

--- a/apps/desktop/src/main/hook-control/__tests__/store.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/store.test.ts
@@ -52,6 +52,7 @@ describe('默认态与持久化', () => {
       urlOverride: null,
       workspaces: {},
       bindingsCache: [],
+      lifecycleAnnouncementOverride: null,
       telegramBindingCache: null,
     });
     expect(store.effectiveUrl()).toBe(TEST_DEFAULT_URL);
@@ -170,8 +171,21 @@ describe('旧多连接文件迁移', () => {
       urlOverride: null,
       workspaces: {},
       bindingsCache: [],
+      lifecycleAnnouncementOverride: null,
       telegramBindingCache: null,
     });
+  });
+});
+
+describe('Slack 上下线通知偏好', () => {
+  it('默认跟随产品值，用户切换后按账号持久化显式覆写', () => {
+    expect(makeStore().get().lifecycleAnnouncementOverride).toBeNull();
+
+    makeStore().setLifecycleAnnouncementOverride(true);
+    expect(makeStore().get().lifecycleAnnouncementOverride).toBe(true);
+
+    makeStore().setLifecycleAnnouncementOverride(false);
+    expect(makeStore().get().lifecycleAnnouncementOverride).toBe(false);
   });
 });
 

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -592,6 +592,48 @@ describe('hook-control transport + manager(真实 ws server)', () => {
     expect(manager.snapshot().status).toBe('connecting');
   });
 
+  it('Slack 重连在新 welcome 前不复用旧 capability 发送偏好', () => {
+    const store = memoryStore({ url: 'wss://fake.example' });
+    const transportOpts: HookTransportOpts[] = [];
+    const sends: Array<ReturnType<typeof vi.fn>> = [];
+    const manager = makeManager(store, {
+      createTransport: (opts) => {
+        transportOpts.push(opts);
+        const send = vi.fn(() => true);
+        sends.push(send);
+        return {
+          send,
+          dispose: vi.fn(),
+        };
+      },
+    });
+    cleanups.push(() => manager.dispose());
+
+    manager.sync();
+    transportOpts[0].onWelcome?.(
+      makeWelcome({
+        serverName: 'new-server',
+        features: [HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT],
+      }).payload,
+    );
+    transportOpts[0].onStatus('connected', null);
+
+    manager.sync();
+    expect(transportOpts).toHaveLength(2);
+    transportOpts[1].onStatus('connected', null);
+    manager.setLifecycleAnnouncement(true);
+    expect(sends[1]).not.toHaveBeenCalled();
+
+    transportOpts[1].onWelcome?.(
+      makeWelcome({
+        serverName: 'old-server',
+        features: [],
+      }).payload,
+    );
+    expect(sends[1]).not.toHaveBeenCalled();
+    expect(store.get().lifecycleAnnouncementOverride).toBe(true);
+  });
+
   it('未登录(token=null): 不发起连接, 状态 error + not logged in', async () => {
     const { wss, url } = await startServer();
     let serverGotConnection = false;

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -13,6 +13,7 @@ import { WebSocketServer, type WebSocket as ServerSocket } from 'ws';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT,
   HOOK_FEATURE_MULTI_TEAM,
   HOOK_FEATURE_PROVIDER_BIND,
   HOOK_FEATURE_PROVIDER_PREFS,
@@ -58,6 +59,7 @@ function memoryStore(initial: Partial<SlackHookConfigState> & { url: string }): 
     urlOverride: initial.url,
     workspaces: initial.workspaces ?? {},
     bindingsCache: initial.bindingsCache ?? [],
+    lifecycleAnnouncementOverride: initial.lifecycleAnnouncementOverride ?? null,
     telegramBindingCache: initial.telegramBindingCache ?? null,
   };
   return {
@@ -85,6 +87,10 @@ function memoryStore(initial: Partial<SlackHookConfigState> & { url: string }): 
     },
     setBindingsCache(entries) {
       state = { ...state, bindingsCache: entries.map((e) => ({ ...e })) };
+      return state;
+    },
+    setLifecycleAnnouncementOverride(enabled) {
+      state = { ...state, lifecycleAnnouncementOverride: enabled };
       return state;
     },
     setTelegramBindingCache(entry) {
@@ -474,6 +480,7 @@ describe('hook-control transport + manager(真实 ws server)', () => {
     const hello = await server.waitFor('hello');
     if (hello.type !== 'hello') throw new Error('unreachable');
     expect(hello.payload.deviceId).toBe('dev-1');
+    expect(hello.payload.lifecycleAnnouncement).toBe(false);
     // 内置「对话」伪目录 chat 恒在清单第一位, 真实别名跟在后面
     expect(hello.payload.workspaces[0]).toBe('chat');
     expect([...hello.payload.workspaces].sort()).toEqual(['blog', 'chat', 'xdmaker']);
@@ -512,6 +519,40 @@ describe('hook-control transport + manager(真实 ws server)', () => {
       result: 'rejected',
       reason: 'disabled',
     });
+  });
+
+  it('上下线通知偏好随 hello 上报，并在能力协商后实时更新', async () => {
+    const { wss, url } = await startServer();
+    const store = memoryStore({ url });
+    const manager = makeManager(store);
+    cleanups.push(() => manager.dispose());
+
+    const connPromise = once(wss, 'connection') as Promise<[ServerSocket]>;
+    manager.sync();
+    const [sock] = await connPromise;
+    const server = collectFrames(sock);
+
+    const hello = await server.waitFor('hello');
+    if (hello.type !== 'hello') throw new Error('unreachable');
+    expect(hello.payload.lifecycleAnnouncement).toBe(false);
+
+    // 模拟 hello 已发送、welcome 尚未返回时切换。welcome 能力协商完成后
+    // 必须补发最新值，不能让 server 永久停留在 hello 的旧快照。
+    manager.setLifecycleAnnouncement(true);
+    sock.send(
+      serializeHookMessage(
+        makeWelcome({
+          serverName: 'mock',
+          features: [HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT],
+        }),
+      ),
+    );
+    const preference = await server.waitFor('lifecycle.preference');
+    if (preference.type !== 'lifecycle.preference') throw new Error('unreachable');
+    expect(preference.payload.enabled).toBe(true);
+    await expect.poll(() => manager.snapshot().status, { timeout: 3000 }).toBe('connected');
+    expect(store.get().lifecycleAnnouncementOverride).toBe(true);
+    expect(manager.snapshot().lifecycleAnnouncement).toBe(true);
   });
 
   it('未登录(token=null): 不发起连接, 状态 error + not logged in', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -555,6 +555,43 @@ describe('hook-control transport + manager(真实 ws server)', () => {
     expect(manager.snapshot().lifecycleAnnouncement).toBe(true);
   });
 
+  it('上下线通知实时更新发送失败时重建连接，并由下一次 hello 同步持久化值', () => {
+    const store = memoryStore({ url: 'wss://fake.example' });
+    const transportOpts: HookTransportOpts[] = [];
+    const disposes: Array<ReturnType<typeof vi.fn>> = [];
+    let sendOk = true;
+    const manager = makeManager(store, {
+      createTransport: (opts) => {
+        transportOpts.push(opts);
+        const dispose = vi.fn();
+        disposes.push(dispose);
+        return {
+          send: () => sendOk,
+          dispose,
+        };
+      },
+    });
+    cleanups.push(() => manager.dispose());
+
+    manager.sync();
+    const first = transportOpts[0];
+    const welcome = makeWelcome({
+      serverName: 'mock',
+      features: [HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT],
+    });
+    first.onWelcome?.(welcome.payload);
+    first.onStatus('connected', null);
+
+    sendOk = false;
+    manager.setLifecycleAnnouncement(true);
+
+    expect(store.get().lifecycleAnnouncementOverride).toBe(true);
+    expect(disposes[0]).toHaveBeenCalledOnce();
+    expect(transportOpts).toHaveLength(2);
+    expect(transportOpts[1].buildHello().lifecycleAnnouncement).toBe(true);
+    expect(manager.snapshot().status).toBe('connecting');
+  });
+
   it('未登录(token=null): 不发起连接, 状态 error + not logged in', async () => {
     const { wss, url } = await startServer();
     let serverGotConnection = false;

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -77,6 +77,7 @@ import { validateTelegramExternalUrl } from './telegramDeepLink.js';
 import { isAppContentWindow } from '../windowFocusClassifier.js';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer.js';
 import { getAgentIslandService } from '../agent-island/service.js';
+import { setLifecycleAnnouncementFromIpc } from './lifecycleAnnouncementIpc.js';
 
 const log = createLogger('hook-control');
 
@@ -496,8 +497,7 @@ export function registerHookControlIpc(): void {
       if (typeof p.enabled !== 'boolean') {
         throwIpcError('INVALID_PARAMS', 'enabled must be boolean');
       }
-      m.setLifecycleAnnouncement(p.enabled);
-      return { hook: m.snapshot() };
+      return setLifecycleAnnouncementFromIpc(m, p.enabled, log);
     },
   );
 

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -53,6 +53,7 @@ import {
   type SlackHookView,
 } from '../../shared/hookControlIpc.js';
 import {
+  DEFAULT_SLACK_LIFECYCLE_ANNOUNCEMENT,
   createSlackHookStore,
   HookConnectionValidationError,
   type SlackHookStore,
@@ -104,6 +105,7 @@ function requireHookControl(): void {
 function disabledHookView(): SlackHookView {
   return {
     enabled: false,
+    lifecycleAnnouncement: DEFAULT_SLACK_LIFECYCLE_ANNOUNCEMENT,
     url: getClientEndpoint('slackHookWsUrl'),
     workspaces: {},
     status: 'disabled',
@@ -484,6 +486,20 @@ export function registerHookControlIpc(): void {
     m.setProviderEnabled('slack', p.enabled);
     return { hook: m.snapshot() };
   });
+
+  registerTrustedHookControlHandler(
+    HOOK_CONTROL_INVOKE.SET_LIFECYCLE_ANNOUNCEMENT,
+    (_e, payload) => {
+      requireHookControl();
+      const { manager: m } = ensureInstances();
+      const p = requireObject(payload);
+      if (typeof p.enabled !== 'boolean') {
+        throwIpcError('INVALID_PARAMS', 'enabled must be boolean');
+      }
+      m.setLifecycleAnnouncement(p.enabled);
+      return { hook: m.snapshot() };
+    },
+  );
 
   registerTrustedHookControlHandler(HOOK_CONTROL_INVOKE.SET_PROVIDER_ENABLED, (_e, payload) => {
     requireHookControl();

--- a/apps/desktop/src/main/hook-control/lifecycleAnnouncementIpc.ts
+++ b/apps/desktop/src/main/hook-control/lifecycleAnnouncementIpc.ts
@@ -1,0 +1,29 @@
+import type { SlackHookView } from '../../shared/hookControlIpc.js';
+import { throwIpcError } from '../utils/ipcValidate.js';
+
+interface LifecycleAnnouncementManager {
+  setLifecycleAnnouncement(enabled: boolean): void;
+  snapshot(): SlackHookView;
+}
+
+interface LifecycleAnnouncementLogger {
+  warn(message: string, error?: unknown): void;
+}
+
+/**
+ * Persist a lifecycle-notification preference without leaking filesystem details
+ * across the Electron IPC boundary.
+ */
+export function setLifecycleAnnouncementFromIpc(
+  manager: LifecycleAnnouncementManager,
+  enabled: boolean,
+  log: LifecycleAnnouncementLogger,
+): { hook: SlackHookView } {
+  try {
+    manager.setLifecycleAnnouncement(enabled);
+  } catch (err) {
+    log.warn('failed to persist Slack lifecycle notification preference', err);
+    throwIpcError('INTERNAL', 'failed to persist Slack lifecycle notification preference');
+  }
+  return { hook: manager.snapshot() };
+}

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -18,6 +18,7 @@ import { randomUUID } from 'node:crypto';
 
 import {
   HOOK_FEATURE_GROUP_RELAY,
+  HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT,
   HOOK_FEATURE_MULTI_TEAM,
   HOOK_FEATURE_PROVIDER_BIND,
   HOOK_FEATURE_PROVIDER_PREFS,
@@ -27,6 +28,7 @@ import {
   makeBindRevoke,
   makeBindStart,
   makeHello,
+  makeLifecyclePreference,
   makePrefsGet,
   makePrefsSet,
   makeProviderBindCancel,
@@ -63,7 +65,11 @@ import type {
   HookTeamBindingView,
   SlackHookView,
 } from '../../shared/hookControlIpc.js';
-import type { ProviderBindingCacheEntry, SlackHookStore } from './store.js';
+import {
+  DEFAULT_SLACK_LIFECYCLE_ANNOUNCEMENT,
+  type ProviderBindingCacheEntry,
+  type SlackHookStore,
+} from './store.js';
 import type { HookDispatcher } from './dispatcher.js';
 import { buildQueryResponse, type AgentModelSource } from './queryResponder.js';
 import { recordGroupMessage, sweepGroupWindowExpired } from './groupWindow.js';
@@ -200,6 +206,8 @@ export interface HookControlManager {
   refreshHello(): boolean;
   /** 渲染层快照。 */
   snapshot(): SlackHookView;
+  /** 持久化并尽力实时同步 Slack 上下线通知偏好。 */
+  setLifecycleAnnouncement(enabled: boolean): void;
   /**
    * 发起 Slack 账号绑定(SIWS OIDC): 发 bind.start(无参); server 回
    * bind.update(pending, authorizeUrl), main 打开系统浏览器。false = 连接不在线。
@@ -740,6 +748,10 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
     return lane.config.requiredFeatures.every((f) => lane.serverFeatures.includes(f));
   }
 
+  function lifecycleAnnouncementEnabled(): boolean {
+    return store.get().lifecycleAnnouncementOverride ?? DEFAULT_SLACK_LIFECYCLE_ANNOUNCEMENT;
+  }
+
   function dispatchId(provider: HookProvider): string {
     const account = getAccountFingerprint?.() ?? 'no-account';
     return `${id}:${account}:${provider}`;
@@ -936,6 +948,8 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
     const config = store.get();
     return {
       enabled: config.enabled,
+      lifecycleAnnouncement:
+        config.lifecycleAnnouncementOverride ?? DEFAULT_SLACK_LIFECYCLE_ANNOUNCEMENT,
       url: store.effectiveUrl(),
       workspaces: { ...config.workspaces },
       status: toViewStatus(status, config.enabled),
@@ -1501,6 +1515,9 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       // 每条连接只声明其服务会实际使用的能力，避免把 provider-neutral wire 误投
       // 到 Slack 服务，也保持老 Slack hello 的兼容面最小。
       features: [...features],
+      ...(features === SLACK_HELLO_FEATURES
+        ? { lifecycleAnnouncement: lifecycleAnnouncementEnabled() }
+        : {}),
     };
   }
 
@@ -2171,6 +2188,15 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
         // server 能力集以最新一次握手为准(重连可能落到另一版本实例)
         serverFeatures = [...payload.features];
         serverWelcomeReceived = true;
+        // hello 发出后、welcome 返回前用户仍可能切换设置。能力协商完成时
+        // 补发当前有效值，避免 server 留在 hello 携带的旧快照。
+        if (serverFeatures.includes(HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT)) {
+          created.send(
+            makeLifecyclePreference({
+              enabled: lifecycleAnnouncementEnabled(),
+            }),
+          );
+        }
         // 落回老 server(无 multi-team): 多绑定列表与缓存作废 —— 老 server 是
         // 单绑定权威(它会经 bind.update 推现状), 残留的多绑定行会让 toView
         // 误走 multi 映射、渲染层误开列表 UI。pendingBind 无条件清: 滚动发布
@@ -2308,6 +2334,17 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       notifyStatus(toView());
     },
     snapshot: () => toView(),
+    setLifecycleAnnouncement(enabled) {
+      store.setLifecycleAnnouncementOverride(enabled);
+      if (
+        transport !== null &&
+        status === 'connected' &&
+        serverFeatures.includes(HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT)
+      ) {
+        transport.send(makeLifecyclePreference({ enabled }));
+      }
+      notifyStatus(toView());
+    },
     refreshHello() {
       let attempted = false;
       let sent = true;

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -1503,7 +1503,10 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
     HOOK_FEATURE_SESSION_PICKER,
   ];
 
-  function buildHello(features: readonly string[]): HelloInput {
+  function buildHello(
+    features: readonly string[],
+    includeLifecycleAnnouncement = false,
+  ): HelloInput {
     // 每次连接成功都重读配置 —— 别名映射变更后重连即生效
     const device = deviceInfo();
     return {
@@ -1515,7 +1518,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       // 每条连接只声明其服务会实际使用的能力，避免把 provider-neutral wire 误投
       // 到 Slack 服务，也保持老 Slack hello 的兼容面最小。
       features: [...features],
-      ...(features === SLACK_HELLO_FEATURES
+      ...(includeLifecycleAnnouncement
         ? { lifecycleAnnouncement: lifecycleAnnouncementEnabled() }
         : {}),
     };
@@ -2181,7 +2184,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       url: store.effectiveUrl(),
       getAuthToken,
       refreshAuthToken,
-      buildHello: () => buildHello(SLACK_HELLO_FEATURES),
+      buildHello: () => buildHello(SLACK_HELLO_FEATURES, true),
       onMessage: (msg, send) => handleBusinessMessage('slack', msg, send),
       onWelcome: (payload) => {
         if (created === null || transport !== created) return;
@@ -2341,7 +2344,15 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
         status === 'connected' &&
         serverFeatures.includes(HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT)
       ) {
-        transport.send(makeLifecyclePreference({ enabled }));
+        const sent = transport.send(makeLifecyclePreference({ enabled }));
+        if (!sent) {
+          // 连接状态与 socket readyState 可能在 close 回调前短暂错位。偏好已经
+          // 持久化；主动重建连接，让下一次 hello 立即携带最新值，避免等待旧
+          // transport 的退避/回调后 server 继续沿用旧偏好。
+          log.warn('lifecycle preference send failed; reconnecting to resync persisted value');
+          stopSlack();
+          startSlack();
+        }
       }
       notifyStatus(toView());
     },
@@ -2350,7 +2361,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       let sent = true;
       if (transport !== null && status === 'connected') {
         attempted = true;
-        sent = transport.send(makeHello(buildHello(SLACK_HELLO_FEATURES))) && sent;
+        sent = transport.send(makeHello(buildHello(SLACK_HELLO_FEATURES, true))) && sent;
       }
       for (const lane of lanes) {
         if (lane.transport !== null && lane.status === 'connected') {

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -2177,6 +2177,9 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
     ) {
       return;
     }
+    // serverFeatures intentionally survives reconnects for stable tool exposure,
+    // but capability-gated frames must wait for this transport's own welcome.
+    serverWelcomeReceived = false;
     // created 先声明后赋值: transport 工厂同步触发首个 onStatus(connecting),
     // 此时按"未注册"丢弃(status 随后统一置 connecting, 不丢信息)
     let created: HookTransport | null = null;
@@ -2221,6 +2224,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
         lastError = err;
         // 掉线(含退避重连中): 在途往返快速失败, 不让调用方挂满超时
         if (s !== 'connected') {
+          serverWelcomeReceived = false;
           dispatcher?.onDisconnected(dispatchId('slack'));
           drainPendingPrefs();
           drainPendingTools();
@@ -2342,6 +2346,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       if (
         transport !== null &&
         status === 'connected' &&
+        serverWelcomeReceived &&
         serverFeatures.includes(HOOK_FEATURE_LIFECYCLE_ANNOUNCEMENT)
       ) {
         const sent = transport.send(makeLifecyclePreference({ enabled }));

--- a/apps/desktop/src/main/hook-control/store.ts
+++ b/apps/desktop/src/main/hook-control/store.ts
@@ -58,8 +58,15 @@ export interface SlackHookConfigState {
   workspaces: Record<string, string>;
   /** (multi-team)本地绑定缓存; 老 server / 从未多绑定时恒空数组。 */
   bindingsCache: HookBindingCacheEntry[];
+  /**
+   * Slack 上下线通知的显式覆写。null = 跟随产品默认值，便于后续调整默认
+   * 而不把从未操作过开关的用户永久钉死在旧值。
+   */
+  lifecycleAnnouncementOverride: boolean | null;
   telegramBindingCache: ProviderBindingCacheEntry | null;
 }
+
+export const DEFAULT_SLACK_LIFECYCLE_ANNOUNCEMENT = false;
 
 export interface SlackHookStoreDeps {
   filePath: string;
@@ -151,6 +158,7 @@ export interface SlackHookStore {
   setWorkspaces(workspaces: Record<string, string>): SlackHookConfigState;
   /** (multi-team)覆写本地绑定缓存(bind.state / 绑定行变化后由 manager 调用)。 */
   setBindingsCache(entries: HookBindingCacheEntry[]): SlackHookConfigState;
+  setLifecycleAnnouncementOverride(enabled: boolean | null): SlackHookConfigState;
   setTelegramBindingCache(entry: ProviderBindingCacheEntry | null): SlackHookConfigState;
 }
 
@@ -158,7 +166,11 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
   const { filePath, legacyFilePath, cleanupLegacySecrets, log } = deps;
 
   interface AccountState {
-    slack: { enabled: boolean; bindingsCache: HookBindingCacheEntry[] };
+    slack: {
+      enabled: boolean;
+      bindingsCache: HookBindingCacheEntry[];
+      lifecycleAnnouncementOverride: boolean | null;
+    };
     telegram: { enabled: boolean; bindingCache: ProviderBindingCacheEntry | null };
   }
 
@@ -199,6 +211,7 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
         urlOverride: null, // 旧 url 是自部署地址, 不迁移 —— 新形态用内置中心服务器
         workspaces,
         bindingsCache: [], // 旧多连接时代没有绑定缓存概念
+        lifecycleAnnouncementOverride: null,
         telegramBindingCache: null,
       };
       // 清理旧文件与旧 secret(best-effort, 失败只记日志)
@@ -224,7 +237,11 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
   }
 
   const EMPTY_ACCOUNT = (): AccountState => ({
-    slack: { enabled: false, bindingsCache: [] },
+    slack: {
+      enabled: false,
+      bindingsCache: [],
+      lifecycleAnnouncementOverride: null,
+    },
     telegram: { enabled: false, bindingCache: null },
   });
 
@@ -286,6 +303,10 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
       slack: {
         enabled: slack.enabled === true,
         bindingsCache: parseBindingsCache(slack.bindingsCache),
+        lifecycleAnnouncementOverride:
+          typeof slack.lifecycleAnnouncementOverride === 'boolean'
+            ? slack.lifecycleAnnouncementOverride
+            : null,
       },
       telegram: {
         enabled: telegram.enabled === true,
@@ -317,6 +338,7 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
         slack: {
           enabled: state.enabled,
           bindingsCache: state.bindingsCache.map((e) => ({ ...e })),
+          lifecycleAnnouncementOverride: state.lifecycleAnnouncementOverride,
         },
         telegram: { enabled: false, bindingCache: null },
       },
@@ -371,6 +393,7 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
         urlOverride,
         workspaces,
         bindingsCache: parseBindingsCache(row.bindingsCache),
+        lifecycleAnnouncementOverride: null,
         telegramBindingCache: null,
       });
     } catch (err) {
@@ -408,6 +431,7 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
       urlOverride: document.urlOverride,
       workspaces: { ...document.workspaces },
       bindingsCache: account.slack.bindingsCache.map((entry) => ({ ...entry })),
+      lifecycleAnnouncementOverride: account.slack.lifecycleAnnouncementOverride,
       telegramBindingCache: account.telegram.bindingCache
         ? { ...account.telegram.bindingCache }
         : null,
@@ -458,6 +482,11 @@ export function createSlackHookStore(deps: SlackHookStoreDeps): SlackHookStore {
       // 缓存条目由 manager 从协议帧生成(形状可信), 这里只做浅拷贝防外部改动
       return mutateAccount((account) => {
         account.slack.bindingsCache = entries.map((e) => ({ ...e }));
+      });
+    },
+    setLifecycleAnnouncementOverride(enabled) {
+      return mutateAccount((account) => {
+        account.slack.lifecycleAnnouncementOverride = enabled;
       });
     },
     setTelegramBindingCache(entry) {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3221,6 +3221,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // 开关只管连接/断开; 绑定阶段 4 起走 SIWS OIDC(bindStart 单独触发)
     setEnabled: (enabled: boolean): Promise<{ hook: unknown }> =>
       ipcRenderer.invoke('maker:hook-control:set-enabled', { enabled }),
+    setLifecycleAnnouncement: (enabled: boolean): Promise<{ hook: unknown }> =>
+      ipcRenderer.invoke('maker:hook-control:set-lifecycle-announcement', { enabled }),
     setProviderEnabled: (provider: 'telegram', enabled: boolean): Promise<{ hook: unknown }> =>
       ipcRenderer.invoke('maker:hook-control:set-provider-enabled', { provider, enabled }),
     setWorkspaces: (workspaces: Record<string, string>): Promise<{ hook: unknown }> =>

--- a/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
@@ -1110,7 +1110,7 @@ export function HookConnectionsSection() {
                   <Switch
                     checked={hook.lifecycleAnnouncement}
                     onCheckedChange={handleLifecycleAnnouncementToggle}
-                    aria-label={t('settings.remoteControl.hook.lifecycleAnnouncement.cellLabel')}
+                    aria-label={t('settings.remoteControl.hook.lifecycleAnnouncement.label')}
                   />
                 </div>
               </div>

--- a/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
@@ -291,6 +291,13 @@ export function HookConnectionsSection() {
     [applyView, t],
   );
 
+  const handleLifecycleAnnouncementToggle = useCallback(
+    (enabled: boolean) => {
+      runHookAction(() => window.electronAPI.hookControl.setLifecycleAnnouncement(enabled));
+    },
+    [runHookAction],
+  );
+
   // "等安装"确认框: binding 转入 failed + not-installed(且开关开着)时弹一次 ——
   // 确认则打开安装授权页(装完 server 自动补完绑定、推 confirmed, 免二次授权);
   // 取消则关回开关(无事发生; main 的关分支会发 bind.revoke, 作废 server 侧
@@ -657,6 +664,9 @@ export function HookConnectionsSection() {
       ? t('settings.remoteControl.hook.loginRequired')
       : telegram.lastError;
   const workdirCount = Object.keys(hook.workspaces).length;
+  const hasActiveSlackBinding = multiUi
+    ? activeTeams.length > 0
+    : hook.binding?.state === 'confirmed';
 
   /**
    * 工作目录映射区块(渲染进每张渠道卡的展开区): 目录清单是设备级共享的
@@ -1079,6 +1089,32 @@ export function HookConnectionsSection() {
             <span className="text-11 leading-relaxed text-[var(--text-tertiary)]">
               {t('settings.remoteControl.hook.slackBoundHint')}
             </span>
+          ) : null}
+
+          {hasActiveSlackBinding ? (
+            <>
+              <div className="h-px w-full bg-[var(--border-default)]" />
+              <div className="flex flex-col gap-1.5">
+                <span className="text-12 font-medium text-[var(--text-secondary)]">
+                  {t('settings.remoteControl.hook.lifecycleAnnouncement.label')}
+                </span>
+                <div className="flex items-center justify-between gap-3 rounded-xl border border-[var(--border-default)] px-3 py-2.5">
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <span className="text-13 text-[var(--text-primary)]">
+                      {t('settings.remoteControl.hook.lifecycleAnnouncement.cellLabel')}
+                    </span>
+                    <span className="text-11 leading-relaxed text-[var(--text-tertiary)]">
+                      {t('settings.remoteControl.hook.lifecycleAnnouncement.hint')}
+                    </span>
+                  </div>
+                  <Switch
+                    checked={hook.lifecycleAnnouncement}
+                    onCheckedChange={handleLifecycleAnnouncementToggle}
+                    aria-label={t('settings.remoteControl.hook.lifecycleAnnouncement.cellLabel')}
+                  />
+                </div>
+              </div>
+            </>
           ) : null}
 
           {/* 工作目录映射(清单共享, 偏好取 Slack 那份) */}

--- a/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/HookConnectionsSection.tsx
@@ -276,24 +276,33 @@ export function HookConnectionsSection() {
 
   /** (multi-team)绑定动作 IPC 的统一收口(应用快照 + 失败 toast)。 */
   const runHookAction = useCallback(
-    (action: () => Promise<{ hook: SlackHookView }>) => {
+    (
+      action: () => Promise<{ hook: SlackHookView }>,
+      options?: { localizedErrorOnly?: boolean },
+    ) => {
       const requestedAtRevision = ++viewRevisionRef.current;
       void action()
         .then((res) => {
           if (viewRevisionRef.current === requestedAtRevision) applyView(res.hook);
         })
-        .catch((err: unknown) =>
+        .catch((err: unknown) => {
+          const localizedFallback = t('settings.remoteControl.hook.toast.actionFailed');
           toast.error(
-            extractIpcError(err)?.message ?? t('settings.remoteControl.hook.toast.actionFailed'),
-          ),
-        );
+            options?.localizedErrorOnly
+              ? localizedFallback
+              : (extractIpcError(err)?.message ?? localizedFallback),
+          );
+        });
     },
     [applyView, t],
   );
 
   const handleLifecycleAnnouncementToggle = useCallback(
     (enabled: boolean) => {
-      runHookAction(() => window.electronAPI.hookControl.setLifecycleAnnouncement(enabled));
+      runHookAction(
+        () => window.electronAPI.hookControl.setLifecycleAnnouncement(enabled),
+        { localizedErrorOnly: true },
+      );
     },
     [runHookAction],
   );

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
@@ -20,6 +20,7 @@ const ipc = vi.hoisted(() => ({
 }));
 const dialog = vi.hoisted(() => ({ confirm: vi.fn() }));
 const workspacePrefsEditor = vi.hoisted(() => ({ render: vi.fn() }));
+const toast = vi.hoisted(() => ({ error: vi.fn() }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -27,6 +28,10 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/components/ui/confirm-dialog-provider', () => ({
   useConfirmDialog: () => ({ confirm: dialog.confirm }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast,
 }));
 
 vi.mock('@/components/ui/switch', () => ({
@@ -215,6 +220,42 @@ describe('HookConnectionsSection Telegram binding actions', () => {
     );
 
     await waitFor(() => expect(ipc.setLifecycleAnnouncement).toHaveBeenCalledWith(true));
+  });
+
+  it('uses a localized fallback when persisting the lifecycle preference fails', async () => {
+    const boundHook: SlackHookView = {
+      ...BASE_HOOK,
+      enabled: true,
+      status: 'connected',
+      binding: {
+        state: 'confirmed',
+        slackUserId: 'U1',
+        slackUserName: 'alice',
+        message: null,
+        authorizeUrl: null,
+        reason: null,
+        installUrl: null,
+        teamName: 'Acme',
+      },
+    };
+    ipc.get.mockResolvedValue({ hook: boundHook });
+    ipc.setLifecycleAnnouncement.mockRejectedValue(
+      new Error('[INTERNAL] failed to persist Slack lifecycle notification preference'),
+    );
+
+    render(<HookConnectionsSection />);
+    await expandChannelCard(SLACK_CARD);
+    fireEvent.click(
+      await screen.findByRole('switch', {
+        name: 'settings.remoteControl.hook.lifecycleAnnouncement.label',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'settings.remoteControl.hook.toast.actionFailed',
+      ),
+    );
   });
 
   it('offers an explicit link action when Telegram is enabled but unbound', async () => {

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
@@ -9,6 +9,7 @@ const ipc = vi.hoisted(() => ({
   get: vi.fn(),
   onStatusChanged: vi.fn<(listener: (view: SlackHookView) => void) => () => void>(() => () => {}),
   setEnabled: vi.fn(),
+  setLifecycleAnnouncement: vi.fn(),
   providerBindStart: vi.fn(),
   providerBindCancel: vi.fn(),
   providerBindRevoke: vi.fn(),
@@ -84,6 +85,7 @@ const TELEGRAM_CARD = /settings\.tina\.prefs\.providerTelegram/;
 
 const BASE_HOOK: SlackHookView = {
   enabled: false,
+  lifecycleAnnouncement: false,
   url: 'wss://im.example.test',
   workspaces: {},
   status: 'disabled',
@@ -108,6 +110,7 @@ describe('HookConnectionsSection Telegram binding actions', () => {
     vi.clearAllMocks();
     ipc.onStatusChanged.mockReturnValue(() => {});
     ipc.setEnabled.mockResolvedValue({ hook: BASE_HOOK });
+    ipc.setLifecycleAnnouncement.mockResolvedValue({ hook: BASE_HOOK });
     ipc.providerBindRevoke.mockResolvedValue({ hook: BASE_HOOK });
     ipc.revokeTeam.mockResolvedValue({ hook: BASE_HOOK });
     ipc.openTelegramAction.mockResolvedValue(undefined);
@@ -117,6 +120,7 @@ describe('HookConnectionsSection Telegram binding actions', () => {
         get: ipc.get,
         onStatusChanged: ipc.onStatusChanged,
         setEnabled: ipc.setEnabled,
+        setLifecycleAnnouncement: ipc.setLifecycleAnnouncement,
         providerBindStart: ipc.providerBindStart,
         providerBindCancel: ipc.providerBindCancel,
         providerBindRevoke: ipc.providerBindRevoke,
@@ -178,6 +182,39 @@ describe('HookConnectionsSection Telegram binding actions', () => {
     expect(workspacePrefsEditor.render).toHaveBeenCalledWith(
       expect.objectContaining({ alias: 'chat', maxVisibleModelRows: undefined }),
     );
+  });
+
+  it('shows the lifecycle notification switch only after Slack is bound and persists changes', async () => {
+    const boundHook: SlackHookView = {
+      ...BASE_HOOK,
+      enabled: true,
+      status: 'connected',
+      binding: {
+        state: 'confirmed',
+        slackUserId: 'U1',
+        slackUserName: 'alice',
+        message: null,
+        authorizeUrl: null,
+        reason: null,
+        installUrl: null,
+        teamName: 'Acme',
+      },
+    };
+    ipc.get.mockResolvedValue({ hook: boundHook });
+    ipc.setLifecycleAnnouncement.mockResolvedValue({
+      hook: { ...boundHook, lifecycleAnnouncement: true },
+    });
+
+    render(<HookConnectionsSection />);
+    await expandChannelCard(SLACK_CARD);
+
+    fireEvent.click(
+      await screen.findByRole('switch', {
+        name: 'settings.remoteControl.hook.lifecycleAnnouncement.cellLabel',
+      }),
+    );
+
+    await waitFor(() => expect(ipc.setLifecycleAnnouncement).toHaveBeenCalledWith(true));
   });
 
   it('offers an explicit link action when Telegram is enabled but unbound', async () => {

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx
@@ -210,7 +210,7 @@ describe('HookConnectionsSection Telegram binding actions', () => {
 
     fireEvent.click(
       await screen.findByRole('switch', {
-        name: 'settings.remoteControl.hook.lifecycleAnnouncement.cellLabel',
+        name: 'settings.remoteControl.hook.lifecycleAnnouncement.label',
       }),
     );
 

--- a/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
@@ -16,6 +16,7 @@ import { useHookWorkspacePrefs } from '../HookWorkspacePrefsEditor';
 
 const BASE_HOOK: SlackHookView = {
   enabled: true,
+  lifecycleAnnouncement: false,
   url: 'wss://im.example.test',
   workspaces: { cindy: '/repos/cindy' },
   status: 'connected',

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2179,6 +2179,11 @@
         "slackDescription": "Bind Slack workspaces and hand tasks to Cindy from Slack.",
         "slackDisabledHint": "Turn on the switch to start Slack authorization; once bound you can dispatch tasks from Slack.",
         "slackBoundHint": "Binding complete. Turning the switch off unbinds this device; turning it back on requires authorizing again.",
+        "lifecycleAnnouncement": {
+          "label": "Online/Offline Notifications",
+          "cellLabel": "Message Notifications",
+          "hint": "Have the Slack Bot send a message when this device goes online or offline"
+        },
         "toggleAria": "Toggle the Slack connection",
         "installApp": "Install Slack App",
         "status": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2178,6 +2178,11 @@
         "slackDescription": "Slack ワークスペースを連携し、Slack から Cindy にタスクを依頼できます。",
         "slackDisabledHint": "スイッチをオンにすると Slack 認証が始まります。連携が完了すると Slack からタスクを依頼できます。",
         "slackBoundHint": "連携が完了しました。スイッチをオフにすると連携が解除され、再びオンにするには再認証が必要です。",
+        "lifecycleAnnouncement": {
+          "label": "オンライン・オフライン通知",
+          "cellLabel": "メッセージ通知",
+          "hint": "このデバイスのオンライン・オフライン時に Slack Bot から通知メッセージを送信します"
+        },
         "toggleAria": "Slack 接続の有効状態を切り替え",
         "installApp": "Slack アプリをインストール",
         "status": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2178,6 +2178,11 @@
         "slackDescription": "Slack 워크스페이스를 연결하고 Slack에서 Cindy에게 작업을 맡기세요.",
         "slackDisabledHint": "스위치를 켜면 Slack 인증이 시작됩니다. 연결이 완료되면 Slack에서 작업을 맡길 수 있습니다.",
         "slackBoundHint": "연결이 완료되었습니다. 스위치를 끄면 연결이 해제되며 다시 켜려면 재인증이 필요합니다.",
+        "lifecycleAnnouncement": {
+          "label": "온라인/오프라인 알림",
+          "cellLabel": "메시지 알림",
+          "hint": "이 기기가 온라인 또는 오프라인 상태가 되면 Slack Bot이 알림 메시지를 보냅니다"
+        },
         "toggleAria": "Slack 연결 활성 상태 전환",
         "installApp": "Slack 앱 설치",
         "status": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2178,6 +2178,11 @@
         "slackDescription": "绑定 Slack workspace，在 Slack 里 @Cindy 派发任务。",
         "slackDisabledHint": "打开开关即发起 Slack 授权，绑定完成后即可在 Slack 里派活。",
         "slackBoundHint": "已完成绑定。关闭开关将解除绑定，重新打开需再次授权。",
+        "lifecycleAnnouncement": {
+          "label": "上下线通知",
+          "cellLabel": "消息通知",
+          "hint": "设备上下线时由 Slack Bot 发送通知消息"
+        },
         "toggleAria": "切换 Slack 连接的启用状态",
         "installApp": "安装 Slack App",
         "status": {

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2985,6 +2985,9 @@ interface ElectronAPI {
     setEnabled: (
       enabled: boolean,
     ) => Promise<{ hook: import('../shared/hookControlIpc').SlackHookView }>;
+    setLifecycleAnnouncement: (
+      enabled: boolean,
+    ) => Promise<{ hook: import('../shared/hookControlIpc').SlackHookView }>;
     setProviderEnabled: (
       provider: 'telegram',
       enabled: boolean,

--- a/apps/desktop/src/shared/hookControlIpc.ts
+++ b/apps/desktop/src/shared/hookControlIpc.ts
@@ -29,6 +29,8 @@ export const HOOK_CONTROL_INVOKE = {
   GET: 'maker:hook-control:get',
   /** 总开关。 */
   SET_ENABLED: 'maker:hook-control:set-enabled',
+  /** Slack Bot 是否发送本设备上下线通知。 */
+  SET_LIFECYCLE_ANNOUNCEMENT: 'maker:hook-control:set-lifecycle-announcement',
   /** 覆写工作目录清单(别名 -> 本地绝对路径, 全量替换)。 */
   SET_WORKSPACES: 'maker:hook-control:set-workspaces',
   /** 发起 Slack 账号绑定(bind.start; SIWS OIDC, 无参数)。 */
@@ -241,6 +243,8 @@ export type HookConnectionStatus = 'disabled' | 'connecting' | 'connected' | 'st
 /** 渲染层可见的 Cindy IM 快照；顶层字段保持 Slack 兼容。 */
 export interface SlackHookView {
   enabled: boolean;
+  /** Slack Bot 是否发送本设备上下线私聊通知。 */
+  lifecycleAnnouncement: boolean;
   /** 实际生效的服务器地址(默认内置值; 被 urlOverride 覆写时为覆写值)。 */
   url: string;
   /** 工作区别名 -> 本地绝对路径。协议里只跑别名, 路径不出本机。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

为已完成 Slack 绑定的桌面客户端增加“上下线通知”开关。用户可控制 Slack Bot 是否在本设备上线或离线时发送通知消息；产品默认值为 `false`，用户操作后按账号持久化显式覆写。

客户端通过已合并的 [cindy-protocol#12](https://github.com/makecindy/cindy-protocol/pull/12) 在 `hello` 中同步当前偏好，并在服务端声明 `lifecycle-announcement` capability 后发送实时 `lifecycle.preference` 更新。旧服务端没有该 capability 时仍可正常连接，只是不发送实时偏好帧。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：[cindy-protocol#12](https://github.com/makecindy/cindy-protocol/pull/12)、服务端 [xindong/XDMaker#1011](https://github.com/xindong/XDMaker/pull/1011)
- 本 PR 包含：
  - Slack 绑定完成后展示桌面端上下线通知开关
  - `false` 产品默认值与账号级 `boolean | null` 显式覆写
  - Main / preload / renderer IPC 链路
  - `hello` 初始同步、capability 协商后的竞态补发与在线实时更新
  - zh-CN / en / ja / ko 四语文案及定向回归测试
- 明确不包含：
  - 服务端发送通知的实现（由 `xindong/XDMaker#1011` 承担）
  - Mobile 设置入口
  - 协议 submodule gitlink 变更；当前 `main` 已指向公开可达的 `cindy-protocol` main commit `2520a407`
  - 截图或录屏上传
- 用户可见变化：完成 Slack 绑定后，Slack 卡片展开区会出现“上下线通知 / 消息通知”开关；默认关闭。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4：复用现有 Settings 卡片、边框和 Switch，不新增并行组件；开关说明使用 12px container tier 与既有控件层级。
  - `DESIGN.md` §5：沿用 8px spacing scale、低密度纵向分组和既有卡片内间距；只有 Slack 已绑定时渐进展示该设置。
  - `DESIGN.md` §10：颜色全部使用 `--border-default`、`--text-primary`、`--text-secondary`、`--text-tertiary` 语义 token，无新增硬编码 Light/Dark 颜色。
  - `DESIGN.md` §11：标签和帮助文字直接描述对象与结果，无营销性或“成功”类填充文案；四种语言 key 同步落地。
- 截图 / 录屏：按需求不上传到 GitHub；已在本地 macOS 中国区开发客户端完成开关开、关与默认值恢复检查。

## 怎么验证的

### 自动验证

```text
PATH=<Node 22.22.3> pnpm test:unit
结果：通过；所有 required unit workspaces 均通过。

pnpm --filter desktop exec vitest run \
  src/main/hook-control/__tests__/store.test.ts \
  src/main/hook-control/__tests__/transport-manager.test.ts \
  src/renderer/components/settings/__tests__/HookConnectionsSection.test.tsx \
  src/renderer/components/settings/__tests__/HookWorkspacePrefsEditor.test.tsx
结果：4 个文件、119 个测试通过；rebase 后已复跑。

pnpm --filter desktop run --if-present typecheck
结果：通过；rebase 后已复跑。

pnpm check:i18n
结果：通过；zh-CN / en / ja / ko 共 5829 个 key 一致，只有仓库既有非阻塞警告。

pnpm check:i18n-glossary
结果：通过；四语无新增术语违规。

git diff --check origin/main...HEAD
结果：通过。
```

### 手工验证

- macOS，中国区开发客户端。
- 在 Slack 设置卡片中将上下线通知开关打开，确认 UI 状态更新；再关闭并确认恢复默认关闭状态。
- 本机另一份已安装 Cindy 实例占用 Slack 连接，因此没有执行真实 Slack 上下线消息投递；该发送链路属于服务端 PR。

### 未执行的验证

- 未执行真实 Slack 上下线通知投递：服务端实现位于独立 PR，且测试时 Slack 连接由另一实例持有。
- 未增加 Mobile 手工验证：本 PR 不增加 Mobile UI 或 runtime 代码。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
  - 仅 Desktop Slack 设置与 hook-control 通道。
  - 偏好保存在既有按账号配置文档中，不新增 SQLite migration；未设置时保持 `null`，有效值回落到产品默认 `false`。
  - 老服务端会忽略 `hello` 的可选字段，客户端也只在 capability 存在时发送 `lifecycle.preference`，因此滚动发布可降级。
  - SSH / 远程开发不受影响：未改工作目录、agent 进程、会话或 SSH 通道。
  - Device Link 不受影响：新增 IPC 仅供 Desktop 本地设置使用，不加入远控 allowlist。
  - Mobile 不受影响：手机版没有 Slack 设置卡片；该偏好描述当前桌面设备的连接生命周期，不增加 Mobile 入口。
- 回滚 / 降级方式：
  - 回滚本 commit 即移除客户端开关和偏好同步；服务端在没有客户端偏好时按协议默认关闭处理。
  - 连接旧服务端时自动停留在 hello 兼容路径，不发送 capability-gated 更新。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
