### PR TITLE
fix(claude-code): upstream-idle 看门狗分片计时,排除系统挂起时间

### DIFF
--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -124,7 +124,7 @@ export const QUEUED_DISPATCH_MAX_WAIT_MS = 30 * 60_000;
  * 排队上限用壁钟量"等了多久",而机器睡觉时进程被冻结、定时器不跑、壁钟照走:睡够 30 分钟
  * 醒来第一拍就会把一条完全健康的排队 prompt 撤掉 —— recurring 被无谓顺延,Once / manual
  * 无法顺延、直接记失败且从未执行(review #944 第十六轮 P1)。与 maker-scheduler 的
- * SUSPEND_GAP_MS、Session / codex 看门狗的分片核对同源。
+ * SUSPEND_GAP_MS、Session / codex / claude-code 看门狗的分片核对同源。
  */
 export const QUEUED_DISPATCH_SUSPEND_GAP_MS = 30_000;
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -1,0 +1,326 @@
+/**
+ * upstream-response-idle 看门狗的挂起感知回归测试(#1015,分层自愈不变量第 6 处)。
+ *
+ * 背景:PR #944 确立「壁钟差 ≠ 清醒时间」——系统挂起(合盖睡眠)期间进程被冻结,
+ * 裸 setTimeout 在唤醒后立刻到期,会把一条其实还健康的 turn 判死。前 5 处已按
+ * 分片计时修复,claude-code 的 armUpstreamResponseIdle 是漏下的第 6 处:合盖
+ * 40 分钟再打开,SDK 连接其实还活着,旧实现的 30min 裸定时器却立刻开火,推
+ * upstream_response_idle_timeout 终态 error 并 interrupt 一条健康 turn。
+ *
+ * 覆盖(假时钟 + 可控 SDK 流):
+ *  - 正常清醒静默满阈值 → 开火(interrupt + 终态 error);
+ *  - 系统挂起 8 小时 → 不开火(该片作废、额度重开);随后清醒走满仍开火
+ *    (吸收不等于豁免);
+ *  - 工具执行期间(pendingToolIds 非空)→ 停表不开火;tool_result 配对完
+ *    重新起表、走满开火;
+ *  - turn 正常结束 → 清表,不再开火。
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentDeps } from '../../base-agent.js';
+import type { AuthAdapter } from '../../../interfaces/auth-adapter.js';
+import type { AgentEvent } from '../../../types/events.js';
+import type { Logger } from '../../../interfaces/logger.js';
+
+const sdkMock = vi.hoisted(() => ({
+  forkSession: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  forkSession: sdkMock.forkSession,
+  query: sdkMock.query,
+}));
+
+import { ClaudeCodeAgent } from '../index.js';
+
+const tempDirs: string[] = [];
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+const originalIdleTimeout = process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS;
+
+function createNoopLogger(): Logger {
+  const logger: Logger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    fatal() {},
+    child() {
+      return logger;
+    },
+  };
+  return logger;
+}
+
+function createDeps(): AgentDeps {
+  const auth: AuthAdapter = {
+    async getState() {
+      return { authenticated: true };
+    },
+    async triggerLogin() {
+      return { authenticated: true };
+    },
+    async logout() {},
+    async getAuthEnv() {
+      return {};
+    },
+  };
+  return {
+    auth,
+    runtimeConfig: {},
+    binaryPath: process.execPath,
+    logger: createNoopLogger(),
+  };
+}
+
+/** 可控 SDK 消息流(与 auto-continued-turn-in-flight.test.ts 同款 harness)。 */
+function createControlledStream() {
+  const items: unknown[] = [];
+  let waiter: { resolve: (r: IteratorResult<unknown>) => void; reject: (e: unknown) => void } | null = null;
+  let ended = false;
+  let failure: unknown = null;
+
+  function pump(): void {
+    if (!waiter) return;
+    if (items.length > 0) {
+      const w = waiter;
+      waiter = null;
+      w.resolve({ done: false, value: items.shift() });
+    } else if (failure !== null) {
+      const w = waiter;
+      waiter = null;
+      w.reject(failure);
+    } else if (ended) {
+      const w = waiter;
+      waiter = null;
+      w.resolve({ done: true, value: undefined });
+    }
+  }
+
+  return {
+    emit(msg: unknown): void {
+      items.push(msg);
+      pump();
+    },
+    end(): void {
+      ended = true;
+      pump();
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next: () =>
+          new Promise<IteratorResult<unknown>>((resolve, reject) => {
+            waiter = { resolve, reject };
+            pump();
+          }),
+      };
+    },
+  };
+}
+
+function createFakeQuery(stream: ReturnType<typeof createControlledStream>) {
+  return {
+    [Symbol.asyncIterator]: () => stream[Symbol.asyncIterator](),
+    setPermissionMode: vi.fn(async () => {}),
+    setModel: vi.fn(async () => {}),
+    applyFlagSettings: vi.fn(async () => {}),
+    interrupt: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    rewindFiles: vi.fn(async () => ({ canRewind: false })),
+  };
+}
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'maker-core-claude-idle-watchdog-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function startSessionWithStream() {
+  const configDir = await makeTempDir();
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  const workingDir = await makeTempDir();
+
+  const stream = createControlledStream();
+  const fakeQuery = createFakeQuery(stream);
+  sdkMock.query.mockImplementation((options: unknown) => {
+    const prompt = (options as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
+    if (prompt) {
+      void (async () => {
+        try {
+          for await (const _ of prompt) { /* discard — 只对齐 pending 语义 */ }
+        } catch { /* end / abort 都算正常收尾 */ }
+      })();
+    }
+    return fakeQuery;
+  });
+
+  const agent = new ClaudeCodeAgent(createDeps());
+  const handle = await agent.startSession({
+    sessionId: 'session-idle-watchdog',
+    model: 'claude-opus-4-6',
+    workingDir,
+    permissionMode: 'acceptEdits',
+  });
+
+  const events: AgentEvent[] = [];
+  const collected = (async () => {
+    for await (const ev of handle.events()) {
+      events.push(ev);
+    }
+  })();
+
+  return { agent, handle, stream, fakeQuery, events, collected };
+}
+
+function successResult(): Record<string, unknown> {
+  return {
+    type: 'result',
+    is_error: false,
+    subtype: 'success',
+    result: 'ok',
+    stop_reason: 'end_turn',
+    total_cost_usd: 0,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  };
+}
+
+function assistantToolUse(id: string): Record<string, unknown> {
+  return {
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id, name: 'Bash', input: { command: 'sleep 999' } }],
+    },
+  };
+}
+
+function userToolResult(id: string): Record<string, unknown> {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: id, content: 'done' }],
+    },
+  };
+}
+
+/** 假时钟下的条件等待:每步推 1ms 假时间并排空微任务(累计消耗可忽略)。 */
+async function pumpUntil(cond: () => boolean, label: string): Promise<void> {
+  for (let i = 0; i < 300; i++) {
+    if (cond()) return;
+    await vi.advanceTimersByTimeAsync(1);
+  }
+  throw new Error(`timed out: ${label}`);
+}
+
+function idleTimeoutError(events: AgentEvent[]): AgentEvent | undefined {
+  return events.find(
+    (e) =>
+      e.type === 'error' &&
+      (e.data as Record<string, unknown> | undefined)?.reason === 'upstream_response_idle_timeout',
+  );
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  sdkMock.forkSession.mockReset();
+  sdkMock.query.mockReset();
+  if (originalClaudeConfigDir === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR;
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  }
+  if (originalIdleTimeout === undefined) {
+    delete process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS;
+  } else {
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = originalIdleTimeout;
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('upstream-response-idle watchdog suspend awareness', () => {
+  it('清醒静默满阈值 → 开火;系统挂起 8 小时 → 不开火,随后清醒走满仍开火', async () => {
+    // 150s = 60s + 60s + 30s 三个分片,覆盖"满片消耗"与"尾片短于片长"两种形态。
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '150000';
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    await handle.send({ type: 'user', content: 'long silent turn' });
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    // 模拟合盖 8 小时:壁钟猛跳但定时器只"走"一个分片 —— 片尾发现真实耗时远超
+    // 片长,判为被冻结,该片作废、完整重判(不开火、额度重开)。
+    vi.setSystemTime(Date.now() + 8 * 3_600_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(idleTimeoutError(events)).toBeUndefined();
+    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    // 吸收不等于豁免:醒来后清醒地连续静默满 150s(60+60+30)→ 仍然开火。
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(idleTimeoutError(events)).toBeUndefined(); // 120s < 150s,还差尾片
+    await vi.advanceTimersByTimeAsync(30_000);
+    await pumpUntil(() => idleTimeoutError(events) !== undefined, 'watchdog fired after awake quota');
+    expect(fakeQuery.interrupt).toHaveBeenCalled();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    vi.useRealTimers();
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('工具执行期间停表不开火;tool_result 配对完重新起表、走满才开火', async () => {
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '120000';
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    await handle.send({ type: 'user', content: 'run a long tool' });
+
+    // assistant 发起 tool_use → ball 交回客户端,watchdog 停表。
+    stream.emit(assistantToolUse('toolu_long'));
+    await vi.advanceTimersByTimeAsync(5);
+    // 远超阈值的工具执行(20 分钟)也不开火。
+    await vi.advanceTimersByTimeAsync(20 * 60_000);
+    expect(idleTimeoutError(events)).toBeUndefined();
+    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    // tool_result 配对完 → ball 回上游,立即重新起表(完整额度)。
+    stream.emit(userToolResult('toolu_long'));
+    await vi.advanceTimersByTimeAsync(5);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(idleTimeoutError(events)).toBeUndefined(); // 60s < 120s
+    await vi.advanceTimersByTimeAsync(60_000);
+    await pumpUntil(() => idleTimeoutError(events) !== undefined, 'watchdog fired after tool completion');
+    expect(fakeQuery.interrupt).toHaveBeenCalled();
+
+    vi.useRealTimers();
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('turn 正常结束 → 清表,不再开火', async () => {
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '100000';
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    await handle.send({ type: 'user', content: 'quick turn' });
+    stream.emit(successResult());
+    await pumpUntil(() => handle.isTurnRunning?.() === false, 'turn done');
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(idleTimeoutError(events)).toBeUndefined();
+    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+});

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1661,67 +1661,30 @@ export class ClaudeCodeAgent extends BaseAgent {
     function onUpstreamResponseIdleTimeout(): void {
       if (closed || !turnInFlight) return;
       const idleMs = upstreamResponseIdleTimeoutMs;
-        const msSinceLast = upstreamResponseLastEventAt > 0
-          ? Date.now() - upstreamResponseLastEventAt
-          : null;
-        log.warn('upstream-response-idle watchdog tripped — interrupting current turn', {
-          idleMs,
-          sdkSessionId,
-          lastEventType: upstreamResponseLastEventType,
-          msSinceLastEvent: msSinceLast,
-          pendingToolIdsSize: pendingToolIds.size,
-          turnInFlight,
+      const msSinceLast = upstreamResponseLastEventAt > 0
+        ? Date.now() - upstreamResponseLastEventAt
+        : null;
+      log.warn('upstream-response-idle watchdog tripped — interrupting current turn', {
+        idleMs,
+        sdkSessionId,
+        lastEventType: upstreamResponseLastEventType,
+        msSinceLastEvent: msSinceLast,
+        pendingToolIdsSize: pendingToolIds.size,
+        turnInFlight,
+      });
+      // Bridge 消费兜底 (Codex review 3535664420 / 3536509277): 若 watchdog 在
+      // bridge /compact turn 内触发(大上下文压缩容易超 idle 阈值), 语义与用户 Stop
+      // 一致:取消整条 "compact → real user message" 序列。只 inputQueue.clear()
+      // 不够,因为 SDK 可能已经 eager-drain 了后续真实用户输入;只 q.interrupt()
+      // 也可能只中断当前 /compact turn,让已 drain 的真实消息继续跑。这里走与
+      // abort() 相同的 close-and-rebuild 路径,并保留 rewind resume point 给下一次
+      // send 重建。
+      if (queuedBridgeTurns > 0 || activeBridgeRewindResumeAt !== undefined) {
+        log.warn('upstream-idle watchdog fired during bridge — closing query and preserving rewind resume point', {
+          queuedBridgeTurns,
+          queuedInput: inputQueue.pending,
+          activeBridgeRewindResumeAt,
         });
-        // Bridge 消费兜底 (Codex review 3535664420 / 3536509277): 若 watchdog 在
-        // bridge /compact turn 内触发(大上下文压缩容易超 idle 阈值), 语义与用户 Stop
-        // 一致:取消整条 "compact → real user message" 序列。只 inputQueue.clear()
-        // 不够,因为 SDK 可能已经 eager-drain 了后续真实用户输入;只 q.interrupt()
-        // 也可能只中断当前 /compact turn,让已 drain 的真实消息继续跑。这里走与
-        // abort() 相同的 close-and-rebuild 路径,并保留 rewind resume point 给下一次
-        // send 重建。
-        if (queuedBridgeTurns > 0 || activeBridgeRewindResumeAt !== undefined) {
-          log.warn('upstream-idle watchdog fired during bridge — closing query and preserving rewind resume point', {
-            queuedBridgeTurns,
-            queuedInput: inputQueue.pending,
-            activeBridgeRewindResumeAt,
-          });
-          eventQueue.push({
-            type: 'error',
-            data: {
-              message:
-                `上游 API 单次响应已静默 ${Math.round(idleMs / 1000)}s, ` +
-                `已自动中断当前 turn 防止卡死。可以直接发下一条消息继续 ` +
-                `(已完成的 tool result 都保留)。`,
-              isTerminal: true,
-              reason: 'upstream_response_idle_timeout',
-              idleMs,
-              sdkSessionId,
-              lastEventType: upstreamResponseLastEventType,
-              msSinceLastEvent: msSinceLast,
-            },
-            source: 'claude-code',
-          });
-          queuedBridgeTurns = 0;
-          restoreBridgeAutoCompactSnapshot('upstream_response_idle_timeout');
-          autoCompactController?.onCompactCanceled('upstream_response_idle_timeout');
-          inputQueue.clear();
-          try {
-            inputQueue.end();
-          } catch (e) {
-            log.warn('upstream-idle watchdog during bridge: inputQueue.end threw', { error: String(e) });
-          }
-          canceledBridgeQueries.add(q);
-          try {
-            q.close();
-          } catch (e) {
-            log.warn('upstream-idle watchdog during bridge: q.close threw', { error: String(e) });
-          }
-          turnInFlight = false;
-          turnState.interruptRequested = false;
-          pendingToolIds.clear();
-          emitTurnBoundary('upstream_response_idle_timeout', takeBridgeSuppressedDoneData());
-          return;
-        }
         eventQueue.push({
           type: 'error',
           data: {
@@ -1738,20 +1701,57 @@ export class ClaudeCodeAgent extends BaseAgent {
           },
           source: 'claude-code',
         });
-        // 先关 turn-in-flight + 清 pending 再 interrupt: 这样 SDK drain 出 ResultMessage 时,
-        // translator 的 onTurnEnd 还会再清一次 (幂等), 但中间任何 message 都不会重新 arm timer。
+        queuedBridgeTurns = 0;
+        restoreBridgeAutoCompactSnapshot('upstream_response_idle_timeout');
+        autoCompactController?.onCompactCanceled('upstream_response_idle_timeout');
+        inputQueue.clear();
+        try {
+          inputQueue.end();
+        } catch (e) {
+          log.warn('upstream-idle watchdog during bridge: inputQueue.end threw', { error: String(e) });
+        }
+        canceledBridgeQueries.add(q);
+        try {
+          q.close();
+        } catch (e) {
+          log.warn('upstream-idle watchdog during bridge: q.close threw', { error: String(e) });
+        }
         turnInFlight = false;
+        turnState.interruptRequested = false;
         pendingToolIds.clear();
-        // watchdog 上面已推过带 reason 的 terminal error, interrupt 后 drain 出的
-        // is_error result 不能再触发 translator 的失败兜底(双 error banner)。
-        turnState.interruptRequested = true;
-        turnState.interruptGeneration = turnState.generation;
-        void q.interrupt().catch((e) => {
-          // interrupt 没发出去 → 不会有被打断的 result 来消费标记, 残留会错误
-          // 抑制下一真实 turn 的 is_error 兜底 —— 立即回收。
-          turnState.interruptRequested = false;
-          log.warn('upstream-response-idle watchdog: interrupt threw', { error: String(e) });
-        });
+        emitTurnBoundary('upstream_response_idle_timeout', takeBridgeSuppressedDoneData());
+        return;
+      }
+      eventQueue.push({
+        type: 'error',
+        data: {
+          message:
+            `上游 API 单次响应已静默 ${Math.round(idleMs / 1000)}s, ` +
+            `已自动中断当前 turn 防止卡死。可以直接发下一条消息继续 ` +
+            `(已完成的 tool result 都保留)。`,
+          isTerminal: true,
+          reason: 'upstream_response_idle_timeout',
+          idleMs,
+          sdkSessionId,
+          lastEventType: upstreamResponseLastEventType,
+          msSinceLastEvent: msSinceLast,
+        },
+        source: 'claude-code',
+      });
+      // 先关 turn-in-flight + 清 pending 再 interrupt: 这样 SDK drain 出 ResultMessage 时,
+      // translator 的 onTurnEnd 还会再清一次 (幂等), 但中间任何 message 都不会重新 arm timer。
+      turnInFlight = false;
+      pendingToolIds.clear();
+      // watchdog 上面已推过带 reason 的 terminal error, interrupt 后 drain 出的
+      // is_error result 不能再触发 translator 的失败兜底(双 error banner)。
+      turnState.interruptRequested = true;
+      turnState.interruptGeneration = turnState.generation;
+      void q.interrupt().catch((e) => {
+        // interrupt 没发出去 → 不会有被打断的 result 来消费标记, 残留会错误
+        // 抑制下一真实 turn 的 is_error 兜底 —— 立即回收。
+        turnState.interruptRequested = false;
+        log.warn('upstream-response-idle watchdog: interrupt threw', { error: String(e) });
+      });
     }
     function noteUpstreamResponseActivity(eventType: string): void {
       upstreamResponseLastEventType = eventType;

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -405,6 +405,13 @@ function parseIdleTimeoutMs(raw: string | undefined): number {
   return Math.floor(n);
 }
 
+/** upstream-response-idle 看门狗的计时分片长度(见 armUpstreamResponseIdleSlice)。 */
+const CC_UPSTREAM_IDLE_SLICE_MS = 60_000;
+
+/** 分片实际耗时超出片长这么多 → 判为进程被系统挂起过,该片不计入额度。 */
+const CC_UPSTREAM_IDLE_SUSPEND_GAP_MS = 30_000;
+
+
 function mapAnthropicError(err: unknown): OneShotError {
   if (err instanceof APIError) {
     if (err.status === 401 || err.status === 403) {
@@ -1595,12 +1602,18 @@ export class ClaudeCodeAgent extends BaseAgent {
     let upstreamResponseIdleTimer: NodeJS.Timeout | null = null;
     let upstreamResponseLastEventType: string | null = null;
     let upstreamResponseLastEventAt = 0;
+    /** 还需要"清醒地"静默多久才判上游哑火;按分片递减(见 armUpstreamResponseIdleSlice)。 */
+    let upstreamResponseIdleRemainingMs = 0;
+    /** 当前分片的起始壁钟时刻;片尾据此识别系统挂起。 */
+    let upstreamResponseIdleSliceStartedAt = 0;
     const pendingToolIds: Set<string> = new Set();
     function clearUpstreamResponseIdle(): void {
       if (upstreamResponseIdleTimer) {
         clearTimeout(upstreamResponseIdleTimer);
         upstreamResponseIdleTimer = null;
       }
+      upstreamResponseIdleRemainingMs = 0;
+      upstreamResponseIdleSliceStartedAt = 0;
     }
     function armUpstreamResponseIdle(): void {
       clearUpstreamResponseIdle();
@@ -1608,10 +1621,46 @@ export class ClaudeCodeAgent extends BaseAgent {
       if (closed || !turnInFlight) return;
       // 工具执行 / 用户交互 in-flight 期间 ball 不在上游, 不计 idle 配额。
       if (pendingToolIds.size > 0) return;
+      upstreamResponseIdleRemainingMs = upstreamResponseIdleTimeoutMs;
+      armUpstreamResponseIdleSlice();
+    }
+    /**
+     * 分片计时,片尾核对真实耗时(壁钟差 ≠ 清醒时间,分层自愈不变量第 6 处;
+     * 与 codex 的 armUpstreamIdleSlice、Session 层的 armTurnStallSlice /
+     * armAbortRecoverySlice、scheduler 的 absorbSuspendGap、scheduler-host runner
+     * 的排队派发上限同源)。不能用一个 30 分钟的长定时器直接判定 —— Electron 被
+     * 系统挂起(合盖睡眠)期间没有任何事件,定时器一旦在唤醒后到期就立刻开火,
+     * 一次午休就能让看门狗中断一条其实还健康的 turn(SDK 连接可能仍活着)。
+     * 片尾判定被冻结过时走**完整重判**(armUpstreamResponseIdle)而不是直接续片:
+     * 唤醒后 turn / 工具 / 交互状态可能已经变了。
+     */
+    function armUpstreamResponseIdleSlice(): void {
+      const slice = Math.min(upstreamResponseIdleRemainingMs, CC_UPSTREAM_IDLE_SLICE_MS);
+      upstreamResponseIdleSliceStartedAt = Date.now();
       upstreamResponseIdleTimer = setTimeout(() => {
         upstreamResponseIdleTimer = null;
-        if (closed || !turnInFlight) return;
-        const idleMs = upstreamResponseIdleTimeoutMs;
+        const elapsed = Date.now() - upstreamResponseIdleSliceStartedAt;
+        if (elapsed > slice + CC_UPSTREAM_IDLE_SUSPEND_GAP_MS) {
+          log.info('upstream-response-idle watchdog skipped a suspended slice', {
+            sdkSessionId,
+            sliceMs: slice,
+            elapsedMs: elapsed,
+          });
+          armUpstreamResponseIdle();
+          return;
+        }
+        upstreamResponseIdleRemainingMs -= Math.max(0, elapsed);
+        if (upstreamResponseIdleRemainingMs > 0) {
+          armUpstreamResponseIdleSlice();
+          return;
+        }
+        onUpstreamResponseIdleTimeout();
+      }, slice);
+      (upstreamResponseIdleTimer as unknown as { unref?: () => void }).unref?.();
+    }
+    function onUpstreamResponseIdleTimeout(): void {
+      if (closed || !turnInFlight) return;
+      const idleMs = upstreamResponseIdleTimeoutMs;
         const msSinceLast = upstreamResponseLastEventAt > 0
           ? Date.now() - upstreamResponseLastEventAt
           : null;
@@ -1703,7 +1752,6 @@ export class ClaudeCodeAgent extends BaseAgent {
           turnState.interruptRequested = false;
           log.warn('upstream-response-idle watchdog: interrupt threw', { error: String(e) });
         });
-      }, upstreamResponseIdleTimeoutMs);
     }
     function noteUpstreamResponseActivity(eventType: string): void {
       upstreamResponseLastEventType = eventType;

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3773,7 +3773,8 @@ export class CodexAgent extends BaseAgent {
      * 分片计时,片尾核对真实耗时。不能用一个 30 分钟的长定时器直接判定 —— Electron 被
      * 系统挂起(合盖睡眠)期间没有任何事件,定时器一旦在唤醒后到期就立刻开火,一次午休
      * 就能让看门狗中断一条完全健康的 turn(review #944 第十二轮 P1,与 Session 层的
-     * armTurnStallSlice、scheduler 的 absorbSuspendGap 同源)。
+     * armTurnStallSlice、claude-code 的 armUpstreamResponseIdleSlice、scheduler 的
+     * absorbSuspendGap 同源)。
      */
     function armUpstreamIdleSlice(): void {
       const slice = Math.min(upstreamIdleRemainingMs, CODEX_UPSTREAM_IDLE_SLICE_MS);

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -892,7 +892,8 @@ export class Session {
    *
    * 片尾若发现壁钟走得远超本片时长,说明进程被冻结过 —— 这段不计入额度,重新起片。
    * 只有"清醒地"连续静默满 turnStallMs 才判卡死。与 scheduler 侧
-   * absorbSuspendGap / tick 的挂起处理同源。
+   * absorbSuspendGap / tick 的挂起处理,以及 codex(armUpstreamIdleSlice)、
+   * claude-code(armUpstreamResponseIdleSlice)两个 upstream-idle 看门狗同源。
    */
   private armTurnStallSlice(): void {
     const slice = Math.min(this.turnStallRemainingMs, TURN_STALL_SLICE_MS);
@@ -1001,8 +1002,8 @@ export class Session {
     // 宽限也要**排除系统挂起**:合盖睡眠期间 transport 一个字节都收不到,而裸定时器一旦在
     // 唤醒后到期就立刻开火 —— 一次午休就能让"给 interrupt 的 10s / 60s"变成 0s 有效时间,
     // 复核于是关掉一条其实还响应得动的会话(第十八轮 P1)。与 armTurnStallSlice、codex 的
-    // armUpstreamIdleSlice、scheduler 的 absorbSuspendGap、排队派发的
-    // QUEUED_DISPATCH_SUSPEND_GAP_MS 同源:壁钟差 ≠ 清醒时间。
+    // armUpstreamIdleSlice、claude-code 的 armUpstreamResponseIdleSlice、scheduler 的
+    // absorbSuspendGap、排队派发的 QUEUED_DISPATCH_SUSPEND_GAP_MS 同源:壁钟差 ≠ 清醒时间。
     this.armAbortRecoverySlice(generation, graceMs, graceMs, trigger);
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 #1015:claude-code 的 upstream-response-idle 看门狗(`armUpstreamResponseIdle`,默认 30min,env `XDT_CC_SSE_IDLE_TIMEOUT_MS`)是「壁钟差 ≠ 清醒时间」不变量(#944)漏下的第 6 处——仍是裸 `setTimeout`。系统挂起(合盖睡眠)期间进程被冻结,定时器在唤醒后立刻到期,把一条 SDK 连接仍活着的健康 turn 判死:短睡眠(如合盖 40 分钟)场景推 `upstream_response_idle_timeout` 终态 error 并 `q.interrupt()`。

按 issue 建议的四步落地:

- **先补 harness**:该看门狗触发路径此前无任何单测。新增 `upstream-idle-watchdog.test.ts`(假时钟 + 可控 SDK 流),先钉住既有行为:清醒静默满阈值 → 开火;工具执行期间(`pendingToolIds` 非空)→ 停表不开火;turn 正常结束 → 清表。
- **抽函数**:100+ 行 timeout body(含 bridge/compact 取消、rewind resume point 保留分支)原样抽成 `onUpstreamResponseIdleTimeout()`,行为零变化。
- **分片计时**:照 codex `armUpstreamIdleSlice` 同构——每片最多 60s(`CC_UPSTREAM_IDLE_SLICE_MS`),片尾核对真实壁钟耗时,超出片长 + 30s(`CC_UPSTREAM_IDLE_SUSPEND_GAP_MS`)判为被冻结 → 该片作废、走**完整重判**(`armUpstreamResponseIdle`,唤醒后 turn/工具/交互状态可能已变),只有清醒地连续静默满阈值才开火。
- **挂起断言**:`setSystemTime` 跳 8 小时 → 不开火;随后清醒走满 150s(60+60+30,覆盖满片与尾片)→ 仍开火(吸收不等于豁免)。

5 处同源注释(session.ts ×2 / codex ×1 / scheduler-host runner ×1 / 本处)补为 6 处交叉引用,不变量可整体检索。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#1015(修复);机制源自 #944 的分层自愈不变量
- 本 PR 包含:分片计时改造、timeout body 抽函数、新 harness 3 用例、同源注释交叉引用
- 明确不包含:其余 5 处(已在 #944 修复);看门狗触发后的处置逻辑变更(原样保留)
- 用户可见变化:合盖睡眠横跨 idle 窗口的 turn 不再被误判中断;真实卡死场景行为不变
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code
结果:25 files / 308 tests 全过(含新增 3 用例)

pnpm --filter @cindy/maker-core run --if-present typecheck
结果:0 错误

判别力验证:将实现改动 stash 回旧版、保留新测试重跑 —— 挂起用例如预期
失败(旧裸定时器在假时钟推进 150s 后无视挂起跳变直接开火),两条基线
用例通过;证明测试测的是本修复而非恒真。

apps/desktop 单测(pnpm test:unit 的 desktop unit 段):除 main 既有失败
updateNoticeDialogAutoLayout 外全绿(见「已知限制」)。
```

### maker-core 指标评估(dev-rules §3.4)

- **(a) 可能影响的指标**:仅 §3.2 性能/返回速度(watchdog 的 arm 在每条 SDK 消息的
  noteUpstreamResponseActivity 热路径上;分片在静默期引入周期性唤醒)。缓存率与返回内容
  准确性不涉及:不触碰 prompt 组装、tool 暴露、translator 事件映射与 model 路由。
- **(b) 实测方法**:node 微基准(200k 次迭代)对比新旧 arm 单次开销与分片唤醒 handler
  主体开销;结合假时钟 harness 抽查典型 turn 事件流的定时器行为(任意时刻至多一个
  in-flight timer;工具执行期间清表)。
- **(c) 实测结论**:arm 单次 184ns → 191ns(+7ns,分片簿记两次赋值);分片唤醒 handler
  205ns/次。**活跃 turn(事件间隔 <60s)零额外唤醒**——每条事件本就 clear+set 重挂一次,
  与旧实现完全同频,分片只是把挂的时长从 30min 换成 60s;额外唤醒仅出现在连续静默期,
  上限 29 次/完整 30 分钟窗(每次 ~205ns,合计 <6µs/30min),且工具执行期间定时器清表、
  不产生任何唤醒。结论:热路径开销变化在噪声量级,无可感知影响。

### 手工验证

不涉及(挂起时序依赖假时钟仿真,真机合盖 8 小时不可复现于 CI;假时钟对
setTimeout+Date 双假,与运行时语义一致)。

### 未执行的验证

根 `pnpm test:unit` 全绿确认未执行:main HEAD(523459945)的 client-ci 本身红在 `updateNoticeDialogAutoLayout.test.tsx`(#954 测试与后续 header 重构的语义合并冲突),与本 diff 无交集;main 修复后将 rebase 重跑确认。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] 其他:看门狗计时语义变更(dev/用户会话的 turn 中断判定)

### 影响与回滚

- 影响范围:仅 claude-code agent 的 upstream-idle 看门狗计时路径;触发后的处置逻辑逐行未动;真实卡死(清醒静默满 30min)行为不变,变化仅在「挂起期间不再计入额度」
- 回滚 / 降级方式:revert 本 PR 即回到裸定时器;或运行时设 `XDT_CC_SSE_IDLE_TIMEOUT_MS=0` 关闭该看门狗

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

