### PR TITLE
feat(desktop): agent 进程优先级降档与工具链限核 env(资源治理 2/3)

### DIFF
--- a/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
+++ b/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
@@ -279,16 +279,30 @@ describe('agent process discovery', () => {
   it('maps setPriority errno to apply results (default implementation)', async () => {
     const applyPriority = __testing.makeDefaultApplyPriority(fakeLog);
     const errWith = (code: string) => Object.assign(new Error(code), { code });
+    // Node 真实形态:libuv 失败被包成 SystemError,顶层 code 恒为 ERR_SYSTEM_ERROR,
+    // 真 errno 在 info.code
+    const systemErrWith = (code: string) =>
+      Object.assign(new Error(`A system error occurred: uv_os_setpriority returned ${code}`), {
+        code: 'ERR_SYSTEM_ERROR',
+        info: { code, errno: -1, syscall: 'uv_os_setpriority' },
+      });
 
-    osMock.setPriority.mockImplementationOnce(() => {
-      throw errWith('ESRCH');
-    });
-    await expect(applyPriority(11, 'low', undefined)).resolves.toBe('process-gone');
+    for (const make of [errWith, systemErrWith]) {
+      osMock.setPriority.mockImplementationOnce(() => {
+        throw make('ESRCH');
+      });
+      await expect(applyPriority(11, 'low', undefined)).resolves.toBe('process-gone');
 
-    osMock.setPriority.mockImplementationOnce(() => {
-      throw errWith('EPERM');
-    });
-    await expect(applyPriority(11, 'low', undefined)).resolves.toBe('nice-raise-refused');
+      osMock.setPriority.mockImplementationOnce(() => {
+        throw make('EPERM');
+      });
+      await expect(applyPriority(11, 'low', undefined)).resolves.toBe('nice-raise-refused');
+
+      osMock.setPriority.mockImplementationOnce(() => {
+        throw make('EACCES');
+      });
+      await expect(applyPriority(11, 'low', undefined)).resolves.toBe('nice-raise-refused');
+    }
 
     osMock.setPriority.mockImplementationOnce(() => {});
     await expect(applyPriority(11, 'low', undefined)).resolves.toBe('applied');

--- a/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
+++ b/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
@@ -25,13 +25,27 @@ vi.mock('../maker-host/logger-adapter.js', () => ({
   },
 }));
 
+const osMock = vi.hoisted(() => ({
+  setPriority: vi.fn(),
+}));
+vi.mock('node:os', () => {
+  const constants = { priority: { PRIORITY_BELOW_NORMAL: 10, PRIORITY_LOW: 19, PRIORITY_NORMAL: 0 } };
+  return {
+    default: { setPriority: osMock.setPriority, constants },
+    setPriority: osMock.setPriority,
+    constants,
+  };
+});
+
 import { allUserDataDirNames } from '@cindy/maker-shared/brand-identity';
 
 import {
+  __testing,
   classifyAgentCommandLine,
   createAgentProcessPriorityWatcher,
   parsePosixAgentProcesses,
   type AgentProcessRow,
+  type ApplyPriorityResult,
 } from '../agent-process-priority';
 import type { AgentProcessPriority } from '../maker-host/agent-resource-settings-store';
 import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
@@ -41,12 +55,15 @@ const fakeLog = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
 function makeWatcher(opts: {
   priority: () => AgentProcessPriority;
   rows: () => AgentProcessRow[];
-  applyResult?: (pid: number) => boolean;
+  applyResult?: (pid: number) => ApplyPriorityResult;
 }) {
   const scan = vi.fn(async () => opts.rows());
   const apply = vi.fn(
-    async (pid: number, _tier: AgentProcessPriority, _prev: AgentProcessPriority | undefined) =>
-      opts.applyResult ? opts.applyResult(pid) : true,
+    async (
+      pid: number,
+      _tier: AgentProcessPriority,
+      _prev: AgentProcessPriority | undefined,
+    ): Promise<ApplyPriorityResult> => (opts.applyResult ? opts.applyResult(pid) : 'applied'),
   );
   const watcher = createAgentProcessPriorityWatcher({
     readPriority: opts.priority,
@@ -129,7 +146,7 @@ describe('agent process priority watcher', () => {
     const { watcher, apply } = makeWatcher({
       priority: () => 'low',
       rows: () => rows,
-      applyResult: (pid) => pid !== 22, // 22 在 apply 时已退出
+      applyResult: (pid) => (pid === 22 ? 'process-gone' : 'applied'), // 22 在 apply 时已退出
     });
     await watcher.tickOnce();
     expect(apply).toHaveBeenCalledTimes(2);
@@ -147,9 +164,42 @@ describe('agent process priority watcher', () => {
     expect(apply).toHaveBeenLastCalledWith(11, 'low', undefined);
   });
 
+  it('records nice-stuck raises truthfully and does not retry them every tick', async () => {
+    // lowest → low 是 POSIX 升档:nice 卡在 19,只有钳制被调整
+    let tier: AgentProcessPriority = 'lowest';
+    const { watcher, apply } = makeWatcher({
+      priority: () => tier,
+      rows: () => [{ pid: 11, kind: 'claude' }],
+      applyResult: () => (tier === 'low' ? 'nice-raise-refused' : 'applied'),
+    });
+    await watcher.tickOnce();
+    expect(fakeLog.info).toHaveBeenCalledWith(
+      'agent process priority lowered',
+      expect.objectContaining({ pid: 11, tier: 'lowest' }),
+    );
+
+    tier = 'low';
+    fakeLog.info.mockClear();
+    await watcher.tickOnce();
+    // 不写"lowered"假成功日志,改记 warn 说明 nice 卡档
+    expect(fakeLog.info).not.toHaveBeenCalledWith(
+      'agent process priority lowered',
+      expect.anything(),
+    );
+    expect(fakeLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining('nice stuck'),
+      expect.objectContaining({ pid: 11, requestedTier: 'low', stuckAtTier: 'lowest' }),
+    );
+
+    // 已按目标档入账:下一 tick 不再空转重试
+    const applyCalls = apply.mock.calls.length;
+    await watcher.tickOnce();
+    expect(apply.mock.calls.length).toBe(applyCalls);
+  });
+
   it('survives a throwing scan without breaking later ticks', async () => {
     let shouldThrow = true;
-    const apply = vi.fn(async () => true);
+    const apply = vi.fn(async (): Promise<ApplyPriorityResult> => 'applied');
     const watcher = createAgentProcessPriorityWatcher({
       readPriority: () => 'low',
       scanAgentProcesses: async () => {
@@ -181,6 +231,43 @@ describe('agent process discovery', () => {
     expect(classifyAgentCommandLine(devClaudeCmd)).toBe('claude');
     expect(classifyAgentCommandLine(externalClaudeCmd)).toBeNull();
     expect(classifyAgentCommandLine('/usr/bin/node some-script.js')).toBeNull();
+  });
+
+  it('classifies packaged Linux layouts (legacy managed + agent-runtime fallback)', () => {
+    // Linux userData 在 ~/.config/<dir>/;linux-runtime-fallback 的 privateBinaryPath
+    // 布局是 <userData>/agent-runtime/<kind>/bin/<cmd>
+    expect(
+      classifyAgentCommandLine(`/home/u/.config/${userDataDir}/agent-runtime/claude-code/bin/claude`),
+    ).toBe('claude');
+    expect(
+      classifyAgentCommandLine(`/home/u/.config/${userDataDir}/agent-runtime/codex/bin/codex`),
+    ).toBe('codex');
+    expect(
+      classifyAgentCommandLine(`/home/u/.config/${userDataDir}/claude-code/2.1.219/claude`),
+    ).toBe('claude');
+    expect(
+      classifyAgentCommandLine(`/home/u/.config/${userDataDir}/codex/0.145.0/codex app-server`),
+    ).toBe('codex');
+    // 外部安装(不带 userData 目录)仍不认领
+    expect(classifyAgentCommandLine('/home/u/.local/bin/claude')).toBeNull();
+  });
+
+  it('maps setPriority errno to apply results (default implementation)', async () => {
+    const applyPriority = __testing.makeDefaultApplyPriority(fakeLog);
+    const errWith = (code: string) => Object.assign(new Error(code), { code });
+
+    osMock.setPriority.mockImplementationOnce(() => {
+      throw errWith('ESRCH');
+    });
+    await expect(applyPriority(11, 'low', undefined)).resolves.toBe('process-gone');
+
+    osMock.setPriority.mockImplementationOnce(() => {
+      throw errWith('EPERM');
+    });
+    await expect(applyPriority(11, 'low', undefined)).resolves.toBe('nice-raise-refused');
+
+    osMock.setPriority.mockImplementationOnce(() => {});
+    await expect(applyPriority(11, 'low', undefined)).resolves.toBe('applied');
   });
 
   it('parses ps output and keeps only direct children of this process', () => {

--- a/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
+++ b/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
@@ -44,6 +44,7 @@ import {
   classifyAgentCommandLine,
   createAgentProcessPriorityWatcher,
   parsePosixAgentProcesses,
+  registerUserDataMarkers,
   type AgentProcessRow,
   type ApplyPriorityResult,
 } from '../agent-process-priority';
@@ -250,6 +251,29 @@ describe('agent process discovery', () => {
     ).toBe('codex');
     // 外部安装(不带 userData 目录)仍不认领
     expect(classifyAgentCommandLine('/home/u/.local/bin/claude')).toBeNull();
+  });
+
+  it('classifies redirected userData layouts after registerUserDataMarkers (XDG/--user-data-dir)', () => {
+    // XDG_CONFIG_HOME 重定向后 userData 不在 ~/.config 下,静态品牌 marker 失配
+    const redirected = '/mnt/data/xdg-alt/CindyCustom';
+    expect(
+      classifyAgentCommandLine(`${redirected.toLowerCase()}/agent-runtime/claude-code/bin/claude`),
+    ).toBeNull(); // 注册前:不认识
+    registerUserDataMarkers(redirected);
+    expect(
+      classifyAgentCommandLine(`${redirected.toLowerCase()}/agent-runtime/claude-code/bin/claude`),
+    ).toBe('claude');
+    expect(
+      classifyAgentCommandLine(`${redirected.toLowerCase()}/agent-runtime/codex/bin/codex`),
+    ).toBe('codex');
+    expect(
+      classifyAgentCommandLine(`${redirected.toLowerCase()}/claude-code/2.1.219/claude`),
+    ).toBe('claude');
+    // 重复注册整组替换(幂等):旧路径不残留
+    registerUserDataMarkers('/somewhere/else/Cindy2');
+    expect(
+      classifyAgentCommandLine(`${redirected.toLowerCase()}/agent-runtime/claude-code/bin/claude`),
+    ).toBeNull();
   });
 
   it('maps setPriority errno to apply results (default implementation)', async () => {

--- a/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
+++ b/apps/desktop/src/main/__tests__/agentProcessPriority.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => ''),
+    isPackaged: false,
+  },
+}));
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../maker-host/logger-adapter.js', () => ({
+  desktopMakerLogger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+import { allUserDataDirNames } from '@cindy/maker-shared/brand-identity';
+
+import {
+  classifyAgentCommandLine,
+  createAgentProcessPriorityWatcher,
+  parsePosixAgentProcesses,
+  type AgentProcessRow,
+} from '../agent-process-priority';
+import type { AgentProcessPriority } from '../maker-host/agent-resource-settings-store';
+import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
+
+const fakeLog = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
+function makeWatcher(opts: {
+  priority: () => AgentProcessPriority;
+  rows: () => AgentProcessRow[];
+  applyResult?: (pid: number) => boolean;
+}) {
+  const scan = vi.fn(async () => opts.rows());
+  const apply = vi.fn(
+    async (pid: number, _tier: AgentProcessPriority, _prev: AgentProcessPriority | undefined) =>
+      opts.applyResult ? opts.applyResult(pid) : true,
+  );
+  const watcher = createAgentProcessPriorityWatcher({
+    readPriority: opts.priority,
+    scanAgentProcesses: scan,
+    applyPriority: apply,
+    log: fakeLog,
+  });
+  return { watcher, scan, apply };
+}
+
+describe('agent process priority watcher', () => {
+  it('does not even scan when priority is normal and nothing was touched', async () => {
+    const { watcher, scan, apply } = makeWatcher({
+      priority: () => 'normal',
+      rows: () => [{ pid: 1, kind: 'claude' }],
+    });
+    await watcher.tickOnce();
+    expect(scan).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('lowers discovered agent processes once and does not re-apply the same tier', async () => {
+    const { watcher, apply } = makeWatcher({
+      priority: () => 'low',
+      rows: () => [
+        { pid: 11, kind: 'claude' },
+        { pid: 22, kind: 'codex' },
+      ],
+    });
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenCalledTimes(2);
+    expect(apply).toHaveBeenCalledWith(11, 'low', undefined);
+    expect(apply).toHaveBeenCalledWith(22, 'low', undefined);
+
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenCalledTimes(2); // 已在目标档,不重复调
+  });
+
+  it('re-applies when the tier changes and passes the previous tier through', async () => {
+    let tier: AgentProcessPriority = 'lowest';
+    const { watcher, apply } = makeWatcher({
+      priority: () => tier,
+      rows: () => [{ pid: 11, kind: 'claude' }],
+    });
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenLastCalledWith(11, 'lowest', undefined);
+
+    tier = 'low';
+    await watcher.tickOnce();
+    // prevTier='lowest' 让实现知道要清 macOS taskpolicy 背景钳制
+    expect(apply).toHaveBeenLastCalledWith(11, 'low', 'lowest');
+  });
+
+  it('restores only processes it previously touched when switching back to normal', async () => {
+    let tier: AgentProcessPriority = 'low';
+    let rows: AgentProcessRow[] = [{ pid: 11, kind: 'claude' }];
+    const { watcher, apply, scan } = makeWatcher({ priority: () => tier, rows: () => rows });
+    await watcher.tickOnce();
+
+    tier = 'normal';
+    rows = [
+      { pid: 11, kind: 'claude' },
+      { pid: 33, kind: 'claude' }, // 从未被动过的进程,normal 下绝不碰
+    ];
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenCalledTimes(2);
+    expect(apply).toHaveBeenLastCalledWith(11, 'normal', 'low');
+
+    // 恢复完成后账本清空 → 回到零成本快路径
+    const scanCallsSoFar = scan.mock.calls.length;
+    await watcher.tickOnce();
+    expect(scan.mock.calls.length).toBe(scanCallsSoFar);
+  });
+
+  it('drops processes that disappeared and ones apply reports as gone', async () => {
+    let rows: AgentProcessRow[] = [
+      { pid: 11, kind: 'claude' },
+      { pid: 22, kind: 'codex' },
+    ];
+    const { watcher, apply } = makeWatcher({
+      priority: () => 'low',
+      rows: () => rows,
+      applyResult: (pid) => pid !== 22, // 22 在 apply 时已退出
+    });
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenCalledTimes(2);
+
+    // 22 未入账 → 再次出现会重试;11 已入账不重试
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenCalledTimes(3);
+    expect(apply).toHaveBeenLastCalledWith(22, 'low', undefined);
+
+    // 11 退出后从账本移除;若再回来(pid 复用)会重新降档
+    rows = [];
+    await watcher.tickOnce();
+    rows = [{ pid: 11, kind: 'claude' }];
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenLastCalledWith(11, 'low', undefined);
+  });
+
+  it('survives a throwing scan without breaking later ticks', async () => {
+    let shouldThrow = true;
+    const apply = vi.fn(async () => true);
+    const watcher = createAgentProcessPriorityWatcher({
+      readPriority: () => 'low',
+      scanAgentProcesses: async () => {
+        if (shouldThrow) throw new Error('ps blew up');
+        return [{ pid: 11, kind: 'claude' as const }];
+      },
+      applyPriority: apply,
+      log: fakeLog,
+    });
+    await watcher.tickOnce();
+    expect(fakeLog.warn).toHaveBeenCalled();
+    shouldThrow = false;
+    await watcher.tickOnce();
+    expect(apply).toHaveBeenCalledWith(11, 'low', undefined);
+  });
+});
+
+describe('agent process discovery', () => {
+  // userData 目录名按当前构建区域取(测试环境默认 global → CindyGlobal),不写死区域
+  const userDataDir = allUserDataDirNames(CURRENT_CINDY_REGION)[0].toLowerCase();
+  const claudeCmd = `/users/me/library/application support/${userDataDir}/claude-code/2.1.219/claude --setting-sources user`;
+  const codexCmd = `/users/me/library/application support/${userDataDir}/codex/0.145.0/codex app-server`;
+  const devClaudeCmd = '/repo/apps/claude-code-bin/darwin-arm64/claude';
+  const externalClaudeCmd = '/usr/local/bin/claude';
+
+  it('classifies bundled claude/codex command lines and rejects external installs', () => {
+    expect(classifyAgentCommandLine(claudeCmd)).toBe('claude');
+    expect(classifyAgentCommandLine(codexCmd)).toBe('codex');
+    expect(classifyAgentCommandLine(devClaudeCmd)).toBe('claude');
+    expect(classifyAgentCommandLine(externalClaudeCmd)).toBeNull();
+    expect(classifyAgentCommandLine('/usr/bin/node some-script.js')).toBeNull();
+  });
+
+  it('parses ps output and keeps only direct children of this process', () => {
+    const selfPid = 4242;
+    const psOutput = [
+      `  100  ${selfPid} ${claudeCmd}`,
+      `  101  ${selfPid} ${codexCmd}`,
+      `  102  9999 ${claudeCmd}`, // 别的进程的孩子(如另一个 Cindy 实例)
+      `  103  ${selfPid} ${externalClaudeCmd}`,
+      `  104  ${selfPid} /applications/cindy.app/contents/macos/cindy helper`,
+      'garbage line',
+    ].join('\n');
+    expect(parsePosixAgentProcesses(psOutput, selfPid)).toEqual([
+      { pid: 100, kind: 'claude' },
+      { pid: 101, kind: 'codex' },
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/agentResourceSettingsStore.test.ts
+++ b/apps/desktop/src/main/__tests__/agentResourceSettingsStore.test.ts
@@ -41,4 +41,19 @@ describe('agent resource settings store', () => {
       __testing.normalize({ maxConcurrentCommands: Number.POSITIVE_INFINITY }).maxConcurrentCommands,
     ).toBe(0);
   });
+
+  it('defaults process priority to normal and only accepts known tiers', () => {
+    expect(__testing.normalize({}).processPriority).toBe('normal');
+    expect(__testing.normalize({ processPriority: 'low' }).processPriority).toBe('low');
+    expect(__testing.normalize({ processPriority: 'lowest' }).processPriority).toBe('lowest');
+    expect(__testing.normalize({ processPriority: 'turbo' }).processPriority).toBe('normal');
+    expect(__testing.normalize({ processPriority: 19 }).processPriority).toBe('normal');
+  });
+
+  it('defaults toolchain thread cap to off and only accepts literal true', () => {
+    expect(__testing.normalize({}).capToolchainThreads).toBe(false);
+    expect(__testing.normalize({ capToolchainThreads: true }).capToolchainThreads).toBe(true);
+    expect(__testing.normalize({ capToolchainThreads: 'yes' }).capToolchainThreads).toBe(false);
+    expect(__testing.normalize({ capToolchainThreads: 1 }).capToolchainThreads).toBe(false);
+  });
 });

--- a/apps/desktop/src/main/agent-process-priority.ts
+++ b/apps/desktop/src/main/agent-process-priority.ts
@@ -263,6 +263,19 @@ async function taskpolicy(args: string[], log: WatcherLogger): Promise<void> {
   }
 }
 
+/**
+ * 提取 os.setPriority 失败的真实 errno。Node 把 libuv 失败包成 SystemError:
+ * 顶层 code 是 'ERR_SYSTEM_ERROR',可判定的 errno 在 err.info.code(bot review
+ * fresh evidence);plain ErrnoException 形态与 message 内的 uv 错误名做兜底。
+ */
+export function systemErrnoCode(err: unknown): string | undefined {
+  const e = err as NodeJS.ErrnoException & { info?: { code?: string } };
+  if (typeof e?.info?.code === 'string') return e.info.code;
+  if (typeof e?.code === 'string' && e.code !== 'ERR_SYSTEM_ERROR') return e.code;
+  const match = /\b(EACCES|EPERM|ESRCH)\b/.exec(String(e?.message ?? ''));
+  return match?.[1];
+}
+
 function makeDefaultApplyPriority(log: WatcherLogger) {
   return async (
     pid: number,
@@ -273,7 +286,7 @@ function makeDefaultApplyPriority(log: WatcherLogger) {
     try {
       os.setPriority(pid, priorityValue(tier));
     } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
+      const code = systemErrnoCode(err);
       if (code === 'ESRCH') return 'process-gone';
       if (code === 'EPERM' || code === 'EACCES') {
         // POSIX 非特权进程不能调高优先级(normal←low←lowest 方向都算 raise):

--- a/apps/desktop/src/main/agent-process-priority.ts
+++ b/apps/desktop/src/main/agent-process-priority.ts
@@ -1,0 +1,303 @@
+/**
+ * agent-process-priority —— agent 进程优先级降档 watcher(资源占用治理第三层)。
+ *
+ * 动机: 并发闸门与工具链限核都管不住"任意重命令抢占前台"——优先级是内核层的,
+ * 对 agent 进程树里的一切子进程(bash / 测试 / 构建)都生效:降档后 agent 照常
+ * 用满空闲核,但用户前台应用永远优先,机器不再卡顿。
+ *
+ * 实现方式: claude 子进程由 Claude SDK 内部 spawn(host 拿不到 pid),codex 由
+ * maker-core spawn —— 统一用周期扫描:找到"当前主进程直接子进程 + 命中本产品
+ * agent 二进制路径 marker"的进程,按设置档位调 os.setPriority;后续 spawn 的
+ * 子进程(bash / 测试 worker)自动继承。发现窗口 ≤ intervalMs,即会话最初几秒
+ * 启动的命令可能仍以原优先级跑完 —— 可接受,重负载通常出现在会话中后期。
+ *
+ * 档位映射:
+ *  - 'low'    → PRIORITY_BELOW_NORMAL(nice 10 / Windows BELOW_NORMAL)
+ *  - 'lowest' → PRIORITY_LOW(nice 19 / Windows IDLE);macOS 额外 taskpolicy -b
+ *               (Darwin 背景 QoS,压到能效核)
+ *  - 'normal' → 只对**曾被本 watcher 降档**的进程尝试恢复;POSIX 非特权进程
+ *               无法调回已升高的 nice(EPERM 静默接受,新进程自然是 normal),
+ *               macOS 的 taskpolicy -B 钳制清除是例外、可恢复。
+ *
+ * 安全边界: 只匹配 ppid == 本进程 且命令行带产品二进制 marker 的进程,绝不触碰
+ * 外部安装的 claude/codex 或另一个 Cindy 实例的进程(与 claude-orphan-reaper
+ * 同一套 marker 策略)。所有失败 best-effort,永不影响 agent 功能。
+ */
+
+import { execFile } from 'node:child_process';
+import os from 'node:os';
+import { promisify } from 'node:util';
+
+import { allUserDataDirNames } from '@cindy/maker-shared/brand-identity';
+
+import { CURRENT_CINDY_REGION } from '../shared/brandRegion.js';
+import { buildClaudePathMarkers } from './claude-orphan-reaper.js';
+import { createLogger } from './logger';
+import {
+  readAgentResourceSettings,
+  type AgentProcessPriority,
+} from './maker-host/agent-resource-settings-store.js';
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_INTERVAL_MS = 15_000;
+
+export interface AgentProcessRow {
+  pid: number;
+  kind: 'claude' | 'codex';
+}
+
+interface WatcherLogger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  debug(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface AgentProcessPriorityWatcherDeps {
+  readPriority: () => AgentProcessPriority;
+  scanAgentProcesses: () => Promise<AgentProcessRow[]>;
+  /**
+   * 对单个进程应用档位。返回 false = 进程已不存在(从账上移除)。
+   * 其余失败(如 POSIX 无法调回)由实现内部消化,返回 true。
+   */
+  applyPriority: (
+    pid: number,
+    tier: AgentProcessPriority,
+    prevTier: AgentProcessPriority | undefined,
+  ) => Promise<boolean>;
+  log: WatcherLogger;
+  intervalMs?: number;
+}
+
+export interface AgentProcessPriorityWatcher {
+  start(): void;
+  stop(): void;
+  /** 单次 tick(测试用;生产由内部 interval 驱动)。 */
+  tickOnce(): Promise<void>;
+}
+
+/**
+ * codex 二进制路径 marker(与 buildClaudePathMarkers 同构):
+ * <userData>/codex/<ver>/ 及 dev checkout 的 apps/codex-bin/。
+ */
+export function buildCodexPathMarkers(dirNames: readonly string[]): string[] {
+  return dirNames.flatMap((dirName) => {
+    const dir = dirName.toLowerCase();
+    return [
+      `appdata\\roaming\\${dir}\\codex\\`,
+      `appdata/roaming/${dir}/codex/`,
+      `/library/application support/${dir}/codex/`,
+    ];
+  });
+}
+
+const CLAUDE_MARKERS = [
+  ...buildClaudePathMarkers(allUserDataDirNames(CURRENT_CINDY_REGION)),
+  'apps\\claude-code-bin\\',
+  'apps/claude-code-bin/',
+];
+
+const CODEX_MARKERS = [
+  ...buildCodexPathMarkers(allUserDataDirNames(CURRENT_CINDY_REGION)),
+  'apps\\codex-bin\\',
+  'apps/codex-bin/',
+];
+
+/** 命令行(已小写)→ agent 种类;不命中任何 marker = 不是我们的 agent 进程。 */
+export function classifyAgentCommandLine(cmdLineLower: string): 'claude' | 'codex' | null {
+  if (CLAUDE_MARKERS.some((m) => cmdLineLower.includes(m))) return 'claude';
+  if (CODEX_MARKERS.some((m) => cmdLineLower.includes(m))) return 'codex';
+  return null;
+}
+
+const POSIX_PS_ROW_RE = /^(\d+)\s+(\d+)\s+(.+)$/;
+
+/** POSIX: 一次 ps 全表,过滤"本进程直接子进程 + 命中 marker"。 */
+export function parsePosixAgentProcesses(
+  psOutput: string,
+  selfPid: number,
+): AgentProcessRow[] {
+  const rows: AgentProcessRow[] = [];
+  for (const raw of psOutput.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    const match = line.match(POSIX_PS_ROW_RE);
+    if (!match) continue;
+    const pid = Number.parseInt(match[1], 10);
+    const ppid = Number.parseInt(match[2], 10);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid) || ppid !== selfPid) continue;
+    const kind = classifyAgentCommandLine(match[3].toLowerCase());
+    if (kind) rows.push({ pid, kind });
+  }
+  return rows;
+}
+
+async function scanPosix(): Promise<AgentProcessRow[]> {
+  const { stdout } = await execFileAsync('ps', ['-A', '-o', 'pid=,ppid=,command='], {
+    encoding: 'utf8',
+    timeout: 5_000,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return parsePosixAgentProcesses(stdout, process.pid);
+}
+
+async function scanWindows(): Promise<AgentProcessRow[]> {
+  // 与 claude-orphan-reaper 的 Windows 扫描同一套写法(含行尾管道符的坑,见其注释)。
+  const script = [
+    'Get-CimInstance Win32_Process -Filter "Name=\'claude.exe\' OR Name=\'codex.exe\'" |',
+    'ForEach-Object {',
+    '  $cmd = ([string]$_.CommandLine) -replace "`r|`n", " "',
+    '  Write-Output ("{0}|{1}|{2}" -f $_.ProcessId, $_.ParentProcessId, $cmd)',
+    '}',
+  ].join('\n');
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    { encoding: 'utf8', timeout: 10_000, windowsHide: true },
+  );
+  const rows: AgentProcessRow[] = [];
+  for (const raw of stdout.split(/\r?\n/)) {
+    const parts = raw.trim().split('|');
+    if (parts.length < 3) continue;
+    const pid = Number.parseInt(parts[0]?.trim() ?? '', 10);
+    const ppid = Number.parseInt(parts[1]?.trim() ?? '', 10);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid) || ppid !== process.pid) continue;
+    const kind = classifyAgentCommandLine(parts.slice(2).join('|').toLowerCase());
+    if (kind) rows.push({ pid, kind });
+  }
+  return rows;
+}
+
+function defaultScanAgentProcesses(): Promise<AgentProcessRow[]> {
+  return process.platform === 'win32' ? scanWindows() : scanPosix();
+}
+
+function priorityValue(tier: AgentProcessPriority): number {
+  switch (tier) {
+    case 'low':
+      return os.constants.priority.PRIORITY_BELOW_NORMAL;
+    case 'lowest':
+      return os.constants.priority.PRIORITY_LOW;
+    default:
+      return os.constants.priority.PRIORITY_NORMAL;
+  }
+}
+
+/** macOS taskpolicy(背景 QoS 钳制)best-effort;非 darwin no-op。 */
+async function taskpolicy(args: string[], log: WatcherLogger): Promise<void> {
+  if (process.platform !== 'darwin') return;
+  try {
+    await execFileAsync('/usr/sbin/taskpolicy', args, { timeout: 5_000 });
+  } catch (err) {
+    log.debug('taskpolicy failed (best-effort, ignored)', {
+      args,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function makeDefaultApplyPriority(log: WatcherLogger) {
+  return async (
+    pid: number,
+    tier: AgentProcessPriority,
+    prevTier: AgentProcessPriority | undefined,
+  ): Promise<boolean> => {
+    try {
+      os.setPriority(pid, priorityValue(tier));
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ESRCH') return false; // 进程已退出
+      // EPERM/EACCES: POSIX 非特权进程不能调回已升高的 nice —— 预期内,只记 debug。
+      log.debug('setPriority failed', { pid, tier, code, error: String(err) });
+    }
+    if (tier === 'lowest') {
+      await taskpolicy(['-b', '-p', String(pid)], log);
+    } else if (prevTier === 'lowest') {
+      await taskpolicy(['-B', '-p', String(pid)], log);
+    }
+    return true;
+  };
+}
+
+export function createAgentProcessPriorityWatcher(
+  deps: AgentProcessPriorityWatcherDeps,
+): AgentProcessPriorityWatcher {
+  const { readPriority, scanAgentProcesses, applyPriority, log } = deps;
+  const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+  /** 已被本 watcher 降档的进程 → 当前档位。只记非 normal 档;恢复/退出即移除。 */
+  const applied = new Map<number, AgentProcessPriority>();
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let ticking = false;
+
+  async function tickOnce(): Promise<void> {
+    if (ticking) return; // 扫描慢于 interval 时跳过本 tick,不排队叠加
+    ticking = true;
+    try {
+      const desired = readPriority();
+      // 空闲快路径:设置为 normal 且没有欠恢复的进程 → 完全不扫进程表。
+      if (desired === 'normal' && applied.size === 0) return;
+      const rows = await scanAgentProcesses();
+      const alive = new Set(rows.map((r) => r.pid));
+      for (const pid of [...applied.keys()]) {
+        if (!alive.has(pid)) applied.delete(pid);
+      }
+      for (const row of rows) {
+        const prev = applied.get(row.pid);
+        if (desired === 'normal') {
+          if (prev === undefined) continue; // 没动过的进程绝不碰
+          await applyPriority(row.pid, 'normal', prev);
+          applied.delete(row.pid); // POSIX 恢复可能无效,但重试无意义(见模块头注释)
+          log.info('agent process priority restore attempted', { pid: row.pid, kind: row.kind });
+        } else if (prev !== desired) {
+          const ok = await applyPriority(row.pid, desired, prev);
+          if (ok) {
+            applied.set(row.pid, desired);
+            log.info('agent process priority lowered', {
+              pid: row.pid,
+              kind: row.kind,
+              tier: desired,
+            });
+          } else {
+            applied.delete(row.pid);
+          }
+        }
+      }
+    } catch (err) {
+      log.warn('agent process priority tick failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      ticking = false;
+    }
+  }
+
+  return {
+    start() {
+      if (timer) return;
+      timer = setInterval(() => {
+        void tickOnce();
+      }, intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+    tickOnce,
+  };
+}
+
+/** 生产入口:默认依赖(设置 store + 平台扫描 + os.setPriority/taskpolicy)组装并启动。 */
+export function startAgentProcessPriorityWatcher(): AgentProcessPriorityWatcher {
+  const log = createLogger('agent-process-priority');
+  const watcher = createAgentProcessPriorityWatcher({
+    readPriority: () => readAgentResourceSettings().processPriority,
+    scanAgentProcesses: defaultScanAgentProcesses,
+    applyPriority: makeDefaultApplyPriority(log),
+    log,
+  });
+  watcher.start();
+  return watcher;
+}

--- a/apps/desktop/src/main/agent-process-priority.ts
+++ b/apps/desktop/src/main/agent-process-priority.ts
@@ -28,6 +28,8 @@ import { execFile } from 'node:child_process';
 import os from 'node:os';
 import { promisify } from 'node:util';
 
+import { app } from 'electron';
+
 import { allUserDataDirNames } from '@cindy/maker-shared/brand-identity';
 
 import { CURRENT_CINDY_REGION } from '../shared/brandRegion.js';
@@ -131,10 +133,47 @@ const CODEX_MARKERS = [
   'apps/codex-bin/',
 ];
 
+/**
+ * 运行时 userData 派生 marker:Linux 的 userData 可被 XDG_CONFIG_HOME /
+ * --user-data-dir 重定向,静态 ~/.config/<brand>/ 形态的 marker 会整体失配,
+ * watcher 静默失明(bot review fresh evidence)。以 app.getPath('userData') 的
+ * 实际解析值补一组 marker;静态品牌 marker 仍保留(覆盖历史目录名与另一实例
+ * 的标准布局)。start 入口注册,重复调用整组替换(幂等)。
+ */
+const runtimeUserDataMarkers: { claude: string[]; codex: string[] } = { claude: [], codex: [] };
+
+export function registerUserDataMarkers(userDataPath: string): void {
+  const markersFor = (kind: 'claude-code' | 'codex'): string[] => {
+    const lower = userDataPath.toLowerCase();
+    // 命令行里的分隔符形态可能与 app.getPath 返回值不同(Windows 下 / 与 \ 混用),
+    // 两种形态都登记;非本平台形态的变体永不命中,无害。
+    const variants = new Set([lower.replace(/\\/g, '/'), lower.replace(/\//g, '\\')]);
+    const out: string[] = [];
+    for (const v of variants) {
+      const sep = v.includes('\\') ? '\\' : '/';
+      out.push(`${v}${sep}${kind}${sep}`);
+      out.push(`${v}${sep}agent-runtime${sep}${kind}${sep}`);
+    }
+    return out;
+  };
+  runtimeUserDataMarkers.claude = markersFor('claude-code');
+  runtimeUserDataMarkers.codex = markersFor('codex');
+}
+
 /** 命令行(已小写)→ agent 种类;不命中任何 marker = 不是我们的 agent 进程。 */
 export function classifyAgentCommandLine(cmdLineLower: string): 'claude' | 'codex' | null {
-  if (CLAUDE_MARKERS.some((m) => cmdLineLower.includes(m))) return 'claude';
-  if (CODEX_MARKERS.some((m) => cmdLineLower.includes(m))) return 'codex';
+  if (
+    CLAUDE_MARKERS.some((m) => cmdLineLower.includes(m)) ||
+    runtimeUserDataMarkers.claude.some((m) => cmdLineLower.includes(m))
+  ) {
+    return 'claude';
+  }
+  if (
+    CODEX_MARKERS.some((m) => cmdLineLower.includes(m)) ||
+    runtimeUserDataMarkers.codex.some((m) => cmdLineLower.includes(m))
+  ) {
+    return 'codex';
+  }
   return null;
 }
 
@@ -351,6 +390,14 @@ export const __testing = { makeDefaultApplyPriority };
 /** 生产入口:默认依赖(设置 store + 平台扫描 + os.setPriority/taskpolicy)组装并启动。 */
 export function startAgentProcessPriorityWatcher(): AgentProcessPriorityWatcher {
   const log = createLogger('agent-process-priority');
+  try {
+    // userData 实际值派生 marker(XDG_CONFIG_HOME / --user-data-dir 重定向场景)。
+    registerUserDataMarkers(app.getPath('userData'));
+  } catch (err) {
+    log.warn('userData marker registration failed; static brand markers only', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
   const watcher = createAgentProcessPriorityWatcher({
     readPriority: () => readAgentResourceSettings().processPriority,
     scanAgentProcesses: defaultScanAgentProcesses,

--- a/apps/desktop/src/main/agent-process-priority.ts
+++ b/apps/desktop/src/main/agent-process-priority.ts
@@ -200,7 +200,9 @@ export function parsePosixAgentProcesses(
 }
 
 async function scanPosix(): Promise<AgentProcessRow[]> {
-  const { stdout } = await execFileAsync('ps', ['-A', '-o', 'pid=,ppid=,command='], {
+  // -ww: macOS ps 默认按显示宽度截断 command 列,长路径(长用户名/重定向
+  // userData)会把 /claude-code/ marker 截掉导致扫描静默漏认;重复 -w 取消截断。
+  const { stdout } = await execFileAsync('ps', ['-Aww', '-o', 'pid=,ppid=,command='], {
     encoding: 'utf8',
     timeout: 5_000,
     maxBuffer: 8 * 1024 * 1024,

--- a/apps/desktop/src/main/agent-process-priority.ts
+++ b/apps/desktop/src/main/agent-process-priority.ts
@@ -47,6 +47,15 @@ export interface AgentProcessRow {
   kind: 'claude' | 'codex';
 }
 
+/**
+ * 单进程调档结果:
+ *  - 'applied'            : 目标档已生效(或至少 setPriority 成功)
+ *  - 'process-gone'       : 进程已退出(ESRCH),从账上移除
+ *  - 'nice-raise-refused' : POSIX 拒绝调高优先级(EPERM/EACCES)——nice 停留在
+ *                           原档;darwin 的 taskpolicy 钳制部分仍按目标档调整过
+ */
+export type ApplyPriorityResult = 'applied' | 'process-gone' | 'nice-raise-refused';
+
 interface WatcherLogger {
   info(message: string, meta?: Record<string, unknown>): void;
   warn(message: string, meta?: Record<string, unknown>): void;
@@ -56,15 +65,12 @@ interface WatcherLogger {
 export interface AgentProcessPriorityWatcherDeps {
   readPriority: () => AgentProcessPriority;
   scanAgentProcesses: () => Promise<AgentProcessRow[]>;
-  /**
-   * 对单个进程应用档位。返回 false = 进程已不存在(从账上移除)。
-   * 其余失败(如 POSIX 无法调回)由实现内部消化,返回 true。
-   */
+  /** 对单个进程应用档位;结果语义见 ApplyPriorityResult。 */
   applyPriority: (
     pid: number,
     tier: AgentProcessPriority,
     prevTier: AgentProcessPriority | undefined,
-  ) => Promise<boolean>;
+  ) => Promise<ApplyPriorityResult>;
   log: WatcherLogger;
   intervalMs?: number;
 }
@@ -91,14 +97,36 @@ export function buildCodexPathMarkers(dirNames: readonly string[]): string[] {
   });
 }
 
+/**
+ * Linux 布局 marker:userData 在 ~/.config/<dir>/ 下。覆盖两种托管形态——
+ * legacy `<userData>/<kind>/<version>/` 与 linux-runtime-fallback 的
+ * `<userData>/agent-runtime/<kind>/bin/`(见 agent-binaries/linux-runtime-fallback.ts
+ * privateBinaryPath;打包 Linux 走这条,不加就整平台失明,bot review P1)。
+ * agent-runtime 布局当前仅 Linux 使用,mac/win 无需对应新增。
+ */
+export function buildLinuxPathMarkers(
+  dirNames: readonly string[],
+  kind: 'claude-code' | 'codex',
+): string[] {
+  return dirNames.flatMap((dirName) => {
+    const dir = dirName.toLowerCase();
+    return [
+      `/.config/${dir}/${kind}/`,
+      `/.config/${dir}/agent-runtime/${kind}/`,
+    ];
+  });
+}
+
 const CLAUDE_MARKERS = [
   ...buildClaudePathMarkers(allUserDataDirNames(CURRENT_CINDY_REGION)),
+  ...buildLinuxPathMarkers(allUserDataDirNames(CURRENT_CINDY_REGION), 'claude-code'),
   'apps\\claude-code-bin\\',
   'apps/claude-code-bin/',
 ];
 
 const CODEX_MARKERS = [
   ...buildCodexPathMarkers(allUserDataDirNames(CURRENT_CINDY_REGION)),
+  ...buildLinuxPathMarkers(allUserDataDirNames(CURRENT_CINDY_REGION), 'codex'),
   'apps\\codex-bin\\',
   'apps/codex-bin/',
 ];
@@ -201,21 +229,29 @@ function makeDefaultApplyPriority(log: WatcherLogger) {
     pid: number,
     tier: AgentProcessPriority,
     prevTier: AgentProcessPriority | undefined,
-  ): Promise<boolean> => {
+  ): Promise<ApplyPriorityResult> => {
+    let result: ApplyPriorityResult = 'applied';
     try {
       os.setPriority(pid, priorityValue(tier));
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ESRCH') return false; // 进程已退出
-      // EPERM/EACCES: POSIX 非特权进程不能调回已升高的 nice —— 预期内,只记 debug。
-      log.debug('setPriority failed', { pid, tier, code, error: String(err) });
+      if (code === 'ESRCH') return 'process-gone';
+      if (code === 'EPERM' || code === 'EACCES') {
+        // POSIX 非特权进程不能调高优先级(normal←low←lowest 方向都算 raise):
+        // nice 停在原档。如实上报给调用方,不装成功(bot review P1)。
+        result = 'nice-raise-refused';
+      } else {
+        log.debug('setPriority failed', { pid, tier, code, error: String(err) });
+      }
     }
+    // taskpolicy 钳制与 nice 独立:即使 nice 调不回,darwin 上仍按目标档调整钳制
+    // (lowest→low 清掉 -b 后,实际效果介于两档之间,是无特权下能达到的最优近似)。
     if (tier === 'lowest') {
       await taskpolicy(['-b', '-p', String(pid)], log);
     } else if (prevTier === 'lowest') {
       await taskpolicy(['-B', '-p', String(pid)], log);
     }
-    return true;
+    return result;
   };
 }
 
@@ -224,8 +260,14 @@ export function createAgentProcessPriorityWatcher(
 ): AgentProcessPriorityWatcher {
   const { readPriority, scanAgentProcesses, applyPriority, log } = deps;
   const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
-  /** 已被本 watcher 降档的进程 → 当前档位。只记非 normal 档;恢复/退出即移除。 */
-  const applied = new Map<number, AgentProcessPriority>();
+  /**
+   * 已被本 watcher 处理过的进程账本。只记非 normal 档;恢复/退出即移除。
+   * tier 记的是**目标档**;niceStuck = POSIX 拒绝了本次 raise,nice 实际停在
+   * 更低优先级的旧档(darwin 钳制已按目标档调整)。仍按目标档入账是有意的:
+   * 无特权下重试永远失败,每 tick 重试只会空转 + 反复 spawn taskpolicy;
+   * 账本的职责是"别重复动它",真实状态由日志如实记录。
+   */
+  const applied = new Map<number, { tier: AgentProcessPriority; niceStuck: boolean }>();
   let timer: ReturnType<typeof setInterval> | null = null;
   let ticking = false;
 
@@ -245,20 +287,35 @@ export function createAgentProcessPriorityWatcher(
         const prev = applied.get(row.pid);
         if (desired === 'normal') {
           if (prev === undefined) continue; // 没动过的进程绝不碰
-          await applyPriority(row.pid, 'normal', prev);
-          applied.delete(row.pid); // POSIX 恢复可能无效,但重试无意义(见模块头注释)
-          log.info('agent process priority restore attempted', { pid: row.pid, kind: row.kind });
-        } else if (prev !== desired) {
-          const ok = await applyPriority(row.pid, desired, prev);
-          if (ok) {
-            applied.set(row.pid, desired);
+          const result = await applyPriority(row.pid, 'normal', prev.tier);
+          applied.delete(row.pid); // POSIX 恢复注定被拒,重试无意义(见账本注释)
+          log.info('agent process priority restore attempted', {
+            pid: row.pid,
+            kind: row.kind,
+            // nice-raise-refused = nice 停在降档值直到进程退出,新进程不受影响
+            niceRestored: result === 'applied',
+          });
+        } else if (prev?.tier !== desired) {
+          const result = await applyPriority(row.pid, desired, prev?.tier);
+          if (result === 'process-gone') {
+            applied.delete(row.pid);
+          } else if (result === 'nice-raise-refused') {
+            // lowest→low 这类升档:nice 卡在旧档,只有 darwin 钳制按目标档调整了。
+            // 入账目标档防空转重试,日志如实说明(不写"lowered")。
+            applied.set(row.pid, { tier: desired, niceStuck: true });
+            log.warn('agent process priority partially applied: nice stuck at previous tier', {
+              pid: row.pid,
+              kind: row.kind,
+              requestedTier: desired,
+              stuckAtTier: prev?.tier ?? 'unknown',
+            });
+          } else {
+            applied.set(row.pid, { tier: desired, niceStuck: false });
             log.info('agent process priority lowered', {
               pid: row.pid,
               kind: row.kind,
               tier: desired,
             });
-          } else {
-            applied.delete(row.pid);
           }
         }
       }
@@ -288,6 +345,8 @@ export function createAgentProcessPriorityWatcher(
     tickOnce,
   };
 }
+
+export const __testing = { makeDefaultApplyPriority };
 
 /** 生产入口:默认依赖(设置 store + 平台扫描 + os.setPriority/taskpolicy)组装并启动。 */
 export function startAgentProcessPriorityWatcher(): AgentProcessPriorityWatcher {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -260,6 +260,7 @@ import {
   installVoiceInputPowerRelease,
 } from './voice-input/powerReleaseNotifier';
 import { reapClaudeOrphansSync } from './claude-orphan-reaper';
+import { startAgentProcessPriorityWatcher } from './agent-process-priority';
 import { initAppBadgeService, clearAllSessionAttention } from './appBadgeService';
 import { initNotificationService } from './notificationService';
 import { getAgentIslandService, initAgentIslandService } from './agent-island/service.js';
@@ -970,6 +971,15 @@ try {
   // and logs to debug. This only fires on truly unexpected throws (e.g. module
   // load failure) and must never abort bootstrap.
   createLogger('claude-orphan-reaper').warn('initial reap threw', { error: String(err) });
+}
+
+// ── agent 进程优先级降档 watcher(agent 资源占用治理)─────────────────────
+// 设置(processPriority)为 normal 且无欠恢复进程时,每 tick 零成本(不扫进程表);
+// interval 已 unref,进程退出不被它拖住。所有失败 best-effort,不影响启动。
+try {
+  startAgentProcessPriorityWatcher();
+} catch (err) {
+  createLogger('agent-process-priority').warn('watcher start threw', { error: String(err) });
 }
 
 // ── 启动诊断 (issue #758) ────────────────────────────────────────────────

--- a/apps/desktop/src/main/maker-host/__tests__/toolchainThreadCap.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/toolchainThreadCap.test.ts
@@ -44,12 +44,13 @@ describe('computeToolchainThreadCapEnv', () => {
     ).toEqual({});
   });
 
-  it('injects the full variable set when enabled', () => {
+  it('injects the full variable set when enabled (POSIX)', () => {
     expect(
       computeToolchainThreadCapEnv(
         { capToolchainThreads: true, processPriority: 'normal' },
         {},
         8,
+        'darwin',
       ),
     ).toEqual({
       VITEST_MAX_FORKS: '4',
@@ -59,11 +60,24 @@ describe('computeToolchainThreadCapEnv', () => {
     });
   });
 
+  it('skips MAKEFLAGS on Windows (nmake rejects GNU -j syntax)', () => {
+    const out = computeToolchainThreadCapEnv(
+      { capToolchainThreads: true, processPriority: 'normal' },
+      {},
+      8,
+      'win32',
+    );
+    expect(out.MAKEFLAGS).toBeUndefined();
+    expect(out.VITEST_MAX_FORKS).toBe('4');
+    expect(out.CARGO_BUILD_JOBS).toBe('4');
+  });
+
   it('never overrides variables the user already has in the base env', () => {
     const out = computeToolchainThreadCapEnv(
       { capToolchainThreads: true, processPriority: 'normal' },
       { MAKEFLAGS: '-j16', VITEST_MAX_FORKS: '9' },
       8,
+      'darwin',
     );
     expect(out).toEqual({
       VITEST_MAX_THREADS: '4',
@@ -76,6 +90,7 @@ describe('computeToolchainThreadCapEnv', () => {
       { capToolchainThreads: true, processPriority: 'lowest' },
       {},
       8,
+      'darwin',
     );
     expect(out.VITEST_MAX_FORKS).toBe('2');
     expect(out.MAKEFLAGS).toBe('-j2');

--- a/apps/desktop/src/main/maker-host/__tests__/toolchainThreadCap.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/toolchainThreadCap.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => ''),
+  },
+}));
+
+vi.mock('../logger-adapter.js', () => ({
+  desktopMakerLogger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+import {
+  computeToolchainThreadCapEnv,
+  recommendedToolchainThreads,
+} from '../toolchain-thread-cap';
+
+describe('recommendedToolchainThreads', () => {
+  it('gives half the cores for normal/low and a quarter for lowest', () => {
+    expect(recommendedToolchainThreads('normal', 10)).toBe(5);
+    expect(recommendedToolchainThreads('low', 10)).toBe(5);
+    expect(recommendedToolchainThreads('lowest', 10)).toBe(3);
+  });
+
+  it('never goes below 1', () => {
+    expect(recommendedToolchainThreads('lowest', 1)).toBe(1);
+    expect(recommendedToolchainThreads('low', 1)).toBe(1);
+  });
+});
+
+describe('computeToolchainThreadCapEnv', () => {
+  it('returns an empty object when the cap is disabled', () => {
+    expect(
+      computeToolchainThreadCapEnv(
+        { capToolchainThreads: false, processPriority: 'lowest' },
+        {},
+        10,
+      ),
+    ).toEqual({});
+  });
+
+  it('injects the full variable set when enabled', () => {
+    expect(
+      computeToolchainThreadCapEnv(
+        { capToolchainThreads: true, processPriority: 'normal' },
+        {},
+        8,
+      ),
+    ).toEqual({
+      VITEST_MAX_FORKS: '4',
+      VITEST_MAX_THREADS: '4',
+      MAKEFLAGS: '-j4',
+      CARGO_BUILD_JOBS: '4',
+    });
+  });
+
+  it('never overrides variables the user already has in the base env', () => {
+    const out = computeToolchainThreadCapEnv(
+      { capToolchainThreads: true, processPriority: 'normal' },
+      { MAKEFLAGS: '-j16', VITEST_MAX_FORKS: '9' },
+      8,
+    );
+    expect(out).toEqual({
+      VITEST_MAX_THREADS: '4',
+      CARGO_BUILD_JOBS: '4',
+    });
+  });
+
+  it('uses the lowest-tier divisor when priority is lowest', () => {
+    const out = computeToolchainThreadCapEnv(
+      { capToolchainThreads: true, processPriority: 'lowest' },
+      {},
+      8,
+    );
+    expect(out.VITEST_MAX_FORKS).toBe('2');
+    expect(out.MAKEFLAGS).toBe('-j2');
+  });
+});

--- a/apps/desktop/src/main/maker-host/agent-resource-settings-store.ts
+++ b/apps/desktop/src/main/maker-host/agent-resource-settings-store.ts
@@ -59,8 +59,8 @@ const DEFAULTS: AgentResourceSettings = {
   capToolchainThreads: false,
 };
 
-/** 上限的上限:超过这个值的并发治理已无意义,防手滑写进天文数字。 */
-const MAX_CONCURRENT_COMMANDS_CAP = 64;
+/** 上限的上限:超过这个值的并发治理已无意义,防手滑写进天文数字。IPC 写路径复用同一常量。 */
+export const MAX_CONCURRENT_COMMANDS_CAP = 64;
 
 function settingsFilePath(): string {
   return path.join(app.getPath('userData'), 'agent-resource-settings.json');

--- a/apps/desktop/src/main/maker-host/agent-resource-settings-store.ts
+++ b/apps/desktop/src/main/maker-host/agent-resource-settings-store.ts
@@ -5,6 +5,8 @@
  *
  * 默认值为「不干预」,与本设置引入前的行为完全一致:
  *  - maxConcurrentCommands: 0 (不限制 agent Bash 命令的全局并发)
+ *  - processPriority: 'normal' (不降 agent 进程优先级)
+ *  - capToolchainThreads: false (不注入工具链限核 env)
  *
  * 配置层级:当前为隐藏配置(无 Settings UI,直接改 JSON 文件或由 agent 代改)。
  * 读取入口调 invalidateIfChanged(),文件被进程外修改后下次读取即生效,不需要重启;
@@ -22,16 +24,39 @@ import {
 
 const log = desktopMakerLogger.child('agent-resource-settings-store');
 
+/**
+ * agent 进程的 OS 调度优先级档位:
+ *  - 'normal': 不干预(默认)。
+ *  - 'low'   : nice/BELOW_NORMAL —— agent 照常用满空闲核,但前台应用永远优先。
+ *  - 'lowest': nice 最低档 + macOS 上额外 taskpolicy -b(压到能效核,风扇安静),
+ *              代价是 agent 任务明显变慢,agent 起的 dev server 也会变慢。
+ *
+ * POSIX 限制:非特权进程无法把已调低的优先级调回来——从 low/lowest 切回
+ * normal 只对**新启动**的 agent 进程生效,在跑的进程保持原档直到退出
+ * (macOS 的 taskpolicy 背景钳制是例外,可以清除)。
+ */
+export type AgentProcessPriority = 'normal' | 'low' | 'lowest';
+
 export interface AgentResourceSettings {
   /**
    * 所有本地 Claude 会话(含 Orca worker、subagent)同时在跑的 Bash 命令数上限;
    * 超出的命令在启动前排队等待。0 = 不限(默认,历史行为)。
    */
   maxConcurrentCommands: number;
+  /** agent 进程(claude / codex 及其子进程)的调度优先级档位。 */
+  processPriority: AgentProcessPriority;
+  /**
+   * 是否向 agent 进程注入工具链限核 env(VITEST_MAX_FORKS / MAKEFLAGS 等),
+   * 防止单条测试/构建命令自己 fork 满全部核。只对新启动的 agent 进程生效;
+   * 用户 env 里已有的同名变量不覆盖。
+   */
+  capToolchainThreads: boolean;
 }
 
 const DEFAULTS: AgentResourceSettings = {
   maxConcurrentCommands: 0,
+  processPriority: 'normal',
+  capToolchainThreads: false,
 };
 
 /** 上限的上限:超过这个值的并发治理已无意义,防手滑写进天文数字。 */
@@ -49,6 +74,11 @@ function normalize(raw: unknown): AgentResourceSettings {
       typeof r.maxConcurrentCommands === 'number' && Number.isFinite(r.maxConcurrentCommands)
         ? clampInt(r.maxConcurrentCommands, 0, MAX_CONCURRENT_COMMANDS_CAP)
         : DEFAULTS.maxConcurrentCommands,
+    processPriority:
+      r.processPriority === 'low' || r.processPriority === 'lowest'
+        ? r.processPriority
+        : DEFAULTS.processPriority,
+    capToolchainThreads: r.capToolchainThreads === true,
   };
 }
 

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -232,9 +232,11 @@ function resolveSubagentModelForRoute(
  * developerInstructions 注入 codex 子进程 (见 codex/index.ts)。
  */
 export const desktopCodexRuntimeConfig: AgentRuntimeConfig = {
-  // 工具链限核 env(agent 资源占用治理)。codex env-builder 只在本机 spawn 时
-  // 执行(远端 daemon 不走 buildCodexEnv),无需再按 spawnMode 分流。
-  behaviorFlags: () => toolchainThreadCapEnv(),
+  // 工具链限核 env(agent 资源占用治理)。注意:远端 codex spawn 也会执行
+  // buildCodexEnv(其产物随后被远端 transport 整体丢弃,见 codex/index.ts:1917
+  // 附近注释),所以这里仍按 spawnMode 分流让代码自证,不依赖"远端不走本函数"
+  // 这种会过期的假设(对抗式预审发现)。
+  behaviorFlags: (ctx) => (ctx.spawnMode === 'remote' ? {} : toolchainThreadCapEnv()),
   // host 共用段 (host-system-prompt.md) + Codex 专属段 (codex-system-prompt.md)。
   systemPrompt: composeHostPrompt(codexSystemPrompt),
   pathPrepends: [bundledRipgrepDir()],

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -22,6 +22,7 @@ import hostSystemPrompt from './host-system-prompt.md?raw';
 import { readCompactionPct } from './compaction-settings-store.js';
 import { readMemorySettings } from './memory-settings-store.js';
 import { readSubagentModelSettings } from './subagent-model-settings-store.js';
+import { toolchainThreadCapEnv } from './toolchain-thread-cap.js';
 
 // host 层 system prompt 拼接：先 host 共用段 (host-system-prompt.md)，再 agent 专属段
 // (claude-system-prompt.md / codex-system-prompt.md)。空段被过滤，避免出现孤零零的 \n\n。
@@ -128,11 +129,15 @@ export function buildDesktopClaudeRuntimeConfig(endpointFn: () => string): Agent
     // 调用 —— gateway-key spawn(显式 XD source / SSH remote)保持禁归因且不读钥匙串,
     // 其余形态按**当时**的 Claude.ai 订阅连接态决定(判据与 proxy 同源)。会话中途
     // 连/断订阅只影响新 spawn —— 与 cc 子进程凭证冻结语义一致。
-    behaviorFlags: (ctx) =>
-      claudeBehaviorFlagsForSpawn({
+    behaviorFlags: (ctx) => ({
+      ...claudeBehaviorFlagsForSpawn({
         credentialMode: ctx.credentialMode,
         oauthConnected: hasClaudeAiOAuth,
       }),
+      // 工具链限核 env(agent 资源占用治理):只对本机 spawn 注入 —— 值按本机
+      // 核数算,远端机器的资源不归本设置管。设置关闭时为空对象,零影响。
+      ...(ctx.spawnMode === 'remote' ? {} : toolchainThreadCapEnv()),
+    }),
     // xdt-maker 产品级 system prompt 注入：host 共用段 (host-system-prompt.md)
     // + Claude 专属段 (claude-system-prompt.md)，按顺序拼接后给 maker-core append。
     systemPrompt: composeHostPrompt(claudeSystemPrompt),
@@ -222,11 +227,14 @@ function resolveSubagentModelForRoute(
 }
 
 /**
- * Codex 运行时配置：当前没有 proxy URL 覆盖，也没有业务 flag。
+ * Codex 运行时配置：当前没有 proxy URL 覆盖。
  * systemPrompt 已接通 —— codex agent 在 thread/start 时跟 engine append 拼成
  * developerInstructions 注入 codex 子进程 (见 codex/index.ts)。
  */
 export const desktopCodexRuntimeConfig: AgentRuntimeConfig = {
+  // 工具链限核 env(agent 资源占用治理)。codex env-builder 只在本机 spawn 时
+  // 执行(远端 daemon 不走 buildCodexEnv),无需再按 spawnMode 分流。
+  behaviorFlags: () => toolchainThreadCapEnv(),
   // host 共用段 (host-system-prompt.md) + Codex 专属段 (codex-system-prompt.md)。
   systemPrompt: composeHostPrompt(codexSystemPrompt),
   pathPrepends: [bundledRipgrepDir()],

--- a/apps/desktop/src/main/maker-host/toolchain-thread-cap.ts
+++ b/apps/desktop/src/main/maker-host/toolchain-thread-cap.ts
@@ -1,0 +1,72 @@
+/**
+ * toolchain-thread-cap —— 工具链限核 env 注入(agent 资源占用治理第二层)。
+ *
+ * 动机: 并发闸门(command-concurrency-gate)只管"几条命令同时跑",管不住单条
+ * 重命令自己 fork 满全部核(vitest/jest 默认按核数起 worker,一条 `pnpm test`
+ * 就能把 10 核吃满)。对认环境变量的主流工具链,在 agent 进程 env 里注入
+ * 上限值,其 spawn 的所有子命令自动继承。
+ *
+ * 边界(有意为之):
+ *  - 只注入「构建/测试并行度」类变量;不碰 GOMAXPROCS / UV_THREADPOOL_SIZE 这类
+ *    会改变被测程序运行时语义的变量(会掩盖/制造并发 bug,agent 测试结论失真)。
+ *  - 用户 env 已有的同名变量一律不覆盖(用户显式设置优先)。
+ *  - jest 等只认 CLI 参数的工具管不住 —— 那部分由进程优先级降档兜底。
+ *  - env 是 spawn 期快照:改设置只影响新启动的 agent 会话进程。
+ *  - 只对本机 spawn 注入;远端(SSH)机器的核数与资源不归本设置管。
+ */
+
+import os from 'node:os';
+
+import type {
+  AgentProcessPriority,
+  AgentResourceSettings,
+} from './agent-resource-settings-store.js';
+import { readAgentResourceSettings } from './agent-resource-settings-store.js';
+
+/**
+ * 推荐并行度: low/normal 档给一半核,lowest 档给四分之一,至少 1。
+ * 目标是"agent 干活但留出交互余量",不追求精确公平。
+ */
+export function recommendedToolchainThreads(
+  priority: AgentProcessPriority,
+  cores: number = os.availableParallelism(),
+): number {
+  const divisor = priority === 'lowest' ? 4 : 2;
+  return Math.max(1, Math.ceil(cores / divisor));
+}
+
+/**
+ * 纯函数形态(可测):按给定设置/基础 env/核数计算应注入的 env 增量。
+ * baseEnv 已有的键被跳过 —— 返回值只含"确实要新增"的变量。
+ */
+export function computeToolchainThreadCapEnv(
+  settings: Pick<AgentResourceSettings, 'capToolchainThreads' | 'processPriority'>,
+  baseEnv: NodeJS.ProcessEnv,
+  cores?: number,
+): Record<string, string> {
+  if (!settings.capToolchainThreads) return {};
+  const threads = recommendedToolchainThreads(settings.processPriority, cores);
+  const desired: Record<string, string> = {
+    // vitest: forks 池(默认)与 threads 池各有独立上限变量,都设
+    VITEST_MAX_FORKS: String(threads),
+    VITEST_MAX_THREADS: String(threads),
+    // make 系(node-gyp / 原生依赖构建等)
+    MAKEFLAGS: `-j${threads}`,
+    // cargo build 并行度
+    CARGO_BUILD_JOBS: String(threads),
+  };
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(desired)) {
+    if (baseEnv[key] === undefined) out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * 生产入口: 读当前设置,返回应合入 agent spawn env 的增量。
+ * 设置关闭时返回空对象(零行为变化)。供 runtime-configs 的 behaviorFlags 消费,
+ * Claude 与 Codex 共用;调用方负责"远端 spawn 不注入"的分流。
+ */
+export function toolchainThreadCapEnv(): Record<string, string> {
+  return computeToolchainThreadCapEnv(readAgentResourceSettings(), process.env);
+}

--- a/apps/desktop/src/main/maker-host/toolchain-thread-cap.ts
+++ b/apps/desktop/src/main/maker-host/toolchain-thread-cap.ts
@@ -43,6 +43,7 @@ export function computeToolchainThreadCapEnv(
   settings: Pick<AgentResourceSettings, 'capToolchainThreads' | 'processPriority'>,
   baseEnv: NodeJS.ProcessEnv,
   cores?: number,
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, string> {
   if (!settings.capToolchainThreads) return {};
   const threads = recommendedToolchainThreads(settings.processPriority, cores);
@@ -50,11 +51,15 @@ export function computeToolchainThreadCapEnv(
     // vitest: forks 池(默认)与 threads 池各有独立上限变量,都设
     VITEST_MAX_FORKS: String(threads),
     VITEST_MAX_THREADS: String(threads),
-    // make 系(node-gyp / 原生依赖构建等)
-    MAKEFLAGS: `-j${threads}`,
     // cargo build 并行度
     CARGO_BUILD_JOBS: String(threads),
   };
+  if (platform !== 'win32') {
+    // make 系(node-gyp / 原生依赖构建等)。Windows 跳过:MSVC 工具链下 cmake/qmake
+    // 可能生成 NMake Makefiles,nmake 不认 GNU Make 的 -j 语法,继承到会直接报错
+    // 中止构建,而不是静默忽略(对抗式预审发现)。
+    desired.MAKEFLAGS = `-j${threads}`;
+  }
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(desired)) {
     if (baseEnv[key] === undefined) out[key] = value;

--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -73,7 +73,7 @@ describe('buildClaudeEnv', () => {
     expect(env.ANTHROPIC_API_KEY).toBe('key');
   });
 
-  it('evaluates function-form behaviorFlags with the spawn credentialMode', async () => {
+  it('evaluates function-form behaviorFlags with the spawn credentialMode and spawnMode', async () => {
     const behaviorFlags = vi.fn(() => ({ CLAUDE_CODE_ATTRIBUTION_HEADER: '0' }));
 
     const env = await buildClaudeEnv(
@@ -82,8 +82,26 @@ describe('buildClaudeEnv', () => {
       { credentialMode: 'gateway-key' },
     );
 
-    expect(behaviorFlags).toHaveBeenCalledWith({ credentialMode: 'gateway-key' });
+    expect(behaviorFlags).toHaveBeenCalledWith({
+      credentialMode: 'gateway-key',
+      spawnMode: 'local',
+    });
     expect(env.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
+  });
+
+  it('marks remote spawns so hosts can skip local-only behavior flags', async () => {
+    const behaviorFlags = vi.fn(() => ({}));
+
+    await buildClaudeEnv(
+      createAuthAdapter(),
+      { behaviorFlags },
+      { credentialMode: 'gateway-key', mode: 'remote' },
+    );
+
+    expect(behaviorFlags).toHaveBeenCalledWith({
+      credentialMode: 'gateway-key',
+      spawnMode: 'remote',
+    });
   });
 
   it('lets behaviorFlags override an inherited CLAUDE_CODE_ATTRIBUTION_HEADER from the host env', async () => {

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -238,10 +238,11 @@ export async function buildClaudeEnv(
   const cleanEnv = mode === 'remote' ? {} : cleanProcessEnv();
   const env: Record<string, string> = { ...cleanEnv };
 
-  // 函数形态按本次 spawn 的凭证形态求值(如 attribution 归因块只对 gateway-key 禁用)。
+  // 函数形态按本次 spawn 的凭证形态求值(如 attribution 归因块只对 gateway-key 禁用);
+  // spawnMode 让 host 区分本机/远端(只对本机有意义的 flag 不注到远端)。
   const behaviorFlags =
     typeof runtimeConfig.behaviorFlags === 'function'
-      ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode })
+      ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode, spawnMode: mode })
       : runtimeConfig.behaviorFlags;
   if (behaviorFlags) {
     Object.assign(env, behaviorFlags);

--- a/packages/maker-core/src/agents/codex/env-builder.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.ts
@@ -45,7 +45,9 @@ export async function buildCodexEnv(
   }
 
   // 函数形态按 spawn 凭证形态求值(与 claude-code/env-builder 同语义)。
-  // spawnMode 恒为 'local':远端 codex daemon 不走本函数(见 codex/index.ts 远端路径注释)。
+  // spawnMode 恒传 'local':本函数产出的 env 只被**本地** transport 消费——远端
+  // spawn 虽也会执行到这里,但产物随后被远端 daemon transport 整体丢弃(见
+  // codex/index.ts 远端路径注释),真正落到子进程的只有本地分支。
   const behaviorFlags =
     typeof runtimeConfig.behaviorFlags === 'function'
       ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode, spawnMode: 'local' })

--- a/packages/maker-core/src/agents/codex/env-builder.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.ts
@@ -44,10 +44,11 @@ export async function buildCodexEnv(
     if (typeof v === 'string') env[k] = v;
   }
 
-  // 函数形态按 spawn 凭证形态求值(与 claude-code/env-builder 同语义;Codex 当前无业务 flag)。
+  // 函数形态按 spawn 凭证形态求值(与 claude-code/env-builder 同语义)。
+  // spawnMode 恒为 'local':远端 codex daemon 不走本函数(见 codex/index.ts 远端路径注释)。
   const behaviorFlags =
     typeof runtimeConfig.behaviorFlags === 'function'
-      ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode })
+      ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode, spawnMode: 'local' })
       : runtimeConfig.behaviorFlags;
   if (behaviorFlags) {
     Object.assign(env, behaviorFlags);

--- a/packages/maker-core/src/interfaces/runtime-config.ts
+++ b/packages/maker-core/src/interfaces/runtime-config.ts
@@ -13,6 +13,13 @@ import type { AgentCredentialMode } from './auth-adapter.js';
 /** 函数形态 behaviorFlags 的入参:本次 spawn 的凭证形态(undefined = 未显式指定,走 adapter fallback)。 */
 export interface BehaviorFlagsContext {
   credentialMode?: AgentCredentialMode;
+  /**
+   * 本次 spawn 落在哪台机器:'local' = 本机子进程,'remote' = 远端 daemon。
+   * host 据此决定"只对本机有意义"的 flag(如按本机核数算的工具链限核 env)
+   * 要不要注入 —— 本机核数注到远端机器纯属错误值。undefined 视同 'local'
+   * (未接入该字段的调用方保持旧行为)。
+   */
+  spawnMode?: 'local' | 'remote';
 }
 
 export interface AgentRuntimeConfig {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Agent 资源占用治理第二片(堆叠在 #1049 并发闸门之上):**进程优先级降档** + **工具链限核 env 注入**。并发闸门管"几条命令同时跑",但管不住单条重命令自己吃满全核(vitest 默认按核数 fork worker,一条 `pnpm test` 就能占满 10 核)——这两层分别解决"前台被抢"和"单命令满核"。默认全部关闭,零行为变化。

**意图契约**
- 目标:`processPriority`(normal/low/lowest)对 claude/codex 进程树降调度优先级;`capToolchainThreads` 向 agent env 注入 VITEST_MAX_FORKS / VITEST_MAX_THREADS / MAKEFLAGS / CARGO_BUILD_JOBS。
- 非目标:不碰 GOMAXPROCS / UV_THREADPOOL_SIZE 这类会改变被测程序运行时语义的变量(避免 agent 测试结论失真);不提供 UI(第三片)。
- 失效契约:优先级 watcher 只碰「ppid = 本进程 + 命中产品二进制路径 marker」的进程,绝不触碰外部安装的 claude/codex 或另一 Cindy 实例(与 claude-orphan-reaper 同一套 marker 策略);切回 normal 只恢复**自己降过档**的进程;env 不覆盖用户已有同名变量;远端(SSH)spawn 不注入(本机核数注到远端机器是错误值)。

实现:
- watcher(`agent-process-priority.ts`):15s 周期扫描,low → BELOW_NORMAL,lowest → 最低档 + macOS `taskpolicy -b`(压能效核);设置为 normal 且无欠恢复进程时零成本(不扫进程表);interval 已 unref。
- 诚实声明的系统限制(模块头注释 + 设置 store 注释):POSIX 非特权进程无法调回已升高的 nice,从低档切回 normal 只对新启动的 agent 进程生效(macOS taskpolicy 钳制可清除是例外);会话最初 ≤15s 启动的命令可能仍以原优先级跑完。
- env 注入走既有 `behaviorFlags` 通道;maker-core 的 `BehaviorFlagsContext` 增 `spawnMode`(local/remote,纯 additive,未接入的调用方行为不变),host 据此跳过远端注入。Windows 跳过 MAKEFLAGS(nmake 不认 GNU -j 语法,会报错中止构建)。

**堆叠依赖说明(order-safe)**:base = `agent-resource-limits`(栈底 PR)。只合栈底不合本片 → 并发闸门独立可用;合到本片为止 → 三个字段齐全(隐藏配置文件形态可全部使用);乱序合并不可能发生(GitHub 会随栈底合并自动收敛 diff)。

### 变更类型

- [x] `feat` 新功能

### 范围

- 本 PR 包含:store 增两字段、优先级 watcher、限核 env 模块、maker-core spawnMode 透传
- 明确不包含:Settings UI(下一片)
- 用户可见变化:默认无;开启后 agent 任务让路前台、重命令不再满核
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit(仓库根,清 CLAUDE* env):除 1 例与本 PR 无关的基线失败(干净 main 复现)外全绿
pnpm --filter desktop typecheck / pnpm --filter @cindy/maker-core typecheck:通过
新增单测 15 个:watcher(降档/换档 prevTier 传递/normal 只恢复动过的/pid 复用/扫描异常自愈/空闲快路径)、
限核 env(开关/除数/不覆盖用户 env/Windows 跳过 MAKEFLAGS)、store 归一化;
maker-core env-builder 测试更新为断言 spawnMode(local/remote 两向)
```

### 手工验证

不涉及(默认关闭)。

### 未执行的验证

- macOS `taskpolicy -b/-B` 实机效果未验证(best-effort,失败仅 debug 日志,不影响 nice 降档主路径)。可执行验证:设置 `processPriority:"lowest"` 后 `ps -o pid,nice,comm` 观察 claude 进程 nice 值与 `taskpolicy` 生效状态。
- Windows 全链路(powershell 扫描 + IDLE 优先级)未实机验证,扫描写法与 claude-orphan-reaper 已上线实现同构;标注待验证。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他:agent 进程调度(仅设置开启后)

### 影响与回滚

- 影响范围:默认关闭零影响。开启后 lowest 档下带超时断言的集成测试可能因跑得慢而假失败、agent 起的 dev server 也会变慢(设置文案会在 UI 片明示)。远端机器不受影响(spawnMode 分流 + 远端 transport 丢弃本地 env)。手机端无独立 agent 进程,不涉及。
- 回滚 / 降级方式:设置回 normal/false(新进程立即恢复;在跑进程受 POSIX 限制保持原档直到退出)或整 PR revert;无迁移、无协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
