### PR TITLE
fix(desktop): restore create page scrolling

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -49,6 +49,12 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
 
   it('centers the CREATE AGENT content group without reintroducing route chrome', () => {
     expect(source).toContain('items-center justify-start');
+    const shellBlock = source.slice(
+      source.indexOf('data-testid="create-agent-shell"'),
+      source.indexOf('data-testid="create-agent-main"'),
+    );
+    expect(shellBlock).toContain('overflow-x-hidden overflow-y-auto');
+    expect(shellBlock).not.toContain('overflow-hidden');
     // 用户改稿 2026-07-21:摘掉 268px 封顶(Figma 定稿画框高度的遗留),大窗口下顶距随 28vh
     // 等比增长,内容组不再"偏高";96px 下限保留,小窗口行为不变。比例为可调参数。
     // 用户改稿 2026-07-21 二连:①摘 268px 封顶(顶距随 28vh 等比);②叠加 --content-header-h

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2847,7 +2847,7 @@ export function NewMakerDraftRoute() {
         <div
           data-testid="create-agent-shell"
           className={cn(
-            'relative flex h-full w-full items-center justify-center overflow-hidden bg-[var(--surface)] px-3 py-8', // px-3:外壳12+main32=44,与技能页(32+12滚动条槽)对齐(实测定稿 2026-07-19)
+            'relative flex h-full w-full items-center justify-center overflow-x-hidden overflow-y-auto bg-[var(--surface)] px-3 py-8', // px-3:外壳12+main32=44,与技能页(32+12滚动条槽)对齐(实测定稿 2026-07-19)
           )}
         >
           {/* 整页拖入遮罩(与 CCAgentSessionView 聊天区同款 token):提示文案由


### PR DESCRIPTION
## 这次改了什么

### 1. 摘要

CREATE AGENT 页（`/cc-agent/new`）外壳原先用 `overflow-hidden`，小窗口或内容变高（如 Provider 引导卡）时下半截会被裁掉且无法滚动。本次把 `create-agent-shell` 改为横向裁切、纵向可滚（`overflow-x-hidden overflow-y-auto`），并在视觉契约测试里锁住该约定，防止再退回 `overflow-hidden`。

### 2. 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 3. 范围

- 关联 Issue / 需求：（无则写「无」）
- 本 PR 包含：
  - `NewMakerDraftRoute` 中 `create-agent-shell` 的 overflow 修正
  - `newMakerCreateAgentVisualContract` 增加 shell 滚动契约断言
- 明确不包含：
  - 创建页布局、顶距公式、ChatInput / 快速开始样式调整
  - Mobile / 其他路由
- 用户可见变化：创建页内容超出视口时可纵向滚动，不再被外壳静默裁切
- 是否存在 breaking change：无

### 4. UI 变化

Desktop：CREATE AGENT 页在内容超高时可纵向滚动（建议附小窗口 / 引导卡场景截图或录屏）。无文案与配色改动。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §15.15 Create-Page Content Position（CREATE AGENT 内容组须按顶距公式可见可达；外壳不再用 `overflow-hidden` 把超出视口的内容裁掉）。颜色仍走既有 `--surface`，无新增硬编码色，符合 §10 Light / Dark 双模式交付门槛。契约由 `newMakerCreateAgentVisualContract.test.ts` 锁定 `overflow-x-hidden overflow-y-auto` 且禁止 shell 上的 `overflow-hidden`。

## 怎么验证的

### 5. 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：（请补：通过 / 失败）

pnpm --filter desktop exec vitest run src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
结果：（请补：通过 / 失败）

pnpm test:unit
结果：（请补：通过 / 失败；提交前门禁要求）
```

### 手工验证

Desktop（macOS）：

1. 打开 `/cc-agent/new`（CREATE AGENT）
2. 缩到较矮窗口，或进入会展示 Provider 引导卡的状态
3. 确认内容超出视口时可纵向滚动，底部内容可达，横向不出现多余滚动
4. （建议）Light / Dark 各看一眼：仅滚动行为变化，表面颜色无异常

### 未执行的验证

- Mobile：不涉及
- （若未跑 `pnpm test:unit` / typecheck，在此写明原因）

## 6. 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop CREATE AGENT 页外壳滚动行为；可能在内容超高时出现纵向滚动条
- 回滚 / 降级方式：revert 本 commit，或将 shell class 改回 `overflow-hidden`
