### PR TITLE
fix(desktop): 桌面专属确认卡挂起时给飞书绑定会话发「去桌面确认」提示

### DIFF
--- a/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
@@ -72,6 +72,8 @@ export interface GhostGrantConfirmBridgeDeps {
   /** 确认超时,默认 10 分钟(对齐 permission prompt / issue 确认卡)。测试注小值。 */
   timeoutMs?: number;
   logger?: { warn: (...args: unknown[]) => void };
+  /** 同 IssueConfirmBridgeDeps.onDesktopOnlyConfirmPending(#926):IM 侧「去桌面确认」提示。 */
+  onDesktopOnlyConfirmPending?: (sessionId: string) => void;
 }
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -100,6 +102,7 @@ export class GhostGrantConfirmBridge {
         sessionId,
         request: { kind: 'ghost_grant_confirm', requestId, ...payload },
       });
+      this.deps.onDesktopOnlyConfirmPending?.(sessionId);
     });
   }
 

--- a/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
@@ -102,7 +102,16 @@ export class GhostGrantConfirmBridge {
         sessionId,
         request: { kind: 'ghost_grant_confirm', requestId, ...payload },
       });
-      this.deps.onDesktopOnlyConfirmPending?.(sessionId);
+      try {
+        this.deps.onDesktopOnlyConfirmPending?.(sessionId);
+      } catch (err) {
+        // 旁路提示绝不反噬确认流程:回调同步抛错会在 Promise executor 里把
+        // request() 直接 reject(review 反馈)——吞错只 warn。
+        this.deps.logger?.warn('onDesktopOnlyConfirmPending threw (ignored)', {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     });
   }
 

--- a/apps/desktop/src/main/github-issue/__tests__/issueConfirmBridge.test.ts
+++ b/apps/desktop/src/main/github-issue/__tests__/issueConfirmBridge.test.ts
@@ -211,3 +211,33 @@ describe('IssueConfirmBridge', () => {
     await expect(p2).resolves.toEqual({ confirmed: false, reason: 'cancelled' });
   });
 });
+
+describe('onDesktopOnlyConfirmPending(#926)', () => {
+  it('request 派发确认卡后同步触发回调,带 sessionId', async () => {
+    const onPending = vi.fn();
+    const bridge = new IssueConfirmBridge({
+      broadcast: () => {},
+      timeoutMs: 50,
+      onDesktopOnlyConfirmPending: onPending,
+    });
+    const p = bridge.request(
+      'feishu_bot_ou_1',
+      { title: 't', body: 'b', type: 'bug' },
+      { appVersion: '0.0.0', platform: 'darwin', arch: 'arm64', osVersion: '1', region: 'cn' },
+      { kind: 'platform', login: 'cindy' },
+    );
+    expect(onPending).toHaveBeenCalledWith('feishu_bot_ou_1');
+    await p; // 超时收口,不留挂起 promise
+  });
+
+  it('未注入回调时行为不变(可选依赖)', async () => {
+    const bridge = new IssueConfirmBridge({ broadcast: () => {}, timeoutMs: 50 });
+    const decision = await bridge.request(
+      's1',
+      { title: 't', body: 'b', type: 'bug' },
+      { appVersion: '0.0.0', platform: 'darwin', arch: 'arm64', osVersion: '1', region: 'cn' },
+      { kind: 'github-user', login: 'u' },
+    );
+    expect(decision.confirmed).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/github-issue/__tests__/issueConfirmBridge.test.ts
+++ b/apps/desktop/src/main/github-issue/__tests__/issueConfirmBridge.test.ts
@@ -241,3 +241,28 @@ describe('onDesktopOnlyConfirmPending(#926)', () => {
     expect(decision.confirmed).toBe(false);
   });
 });
+
+describe('onDesktopOnlyConfirmPending 抛错防护(#1059 review)', () => {
+  it('回调同步抛错被吞掉只 warn,确认流程照常走到超时收口', async () => {
+    const warn = vi.fn();
+    const bridge = new IssueConfirmBridge({
+      broadcast: () => {},
+      timeoutMs: 50,
+      logger: { warn },
+      onDesktopOnlyConfirmPending: () => {
+        throw new Error('notifier exploded');
+      },
+    });
+    const decision = await bridge.request(
+      's-throw',
+      { title: 't', body: 'b', type: 'bug' },
+      { appVersion: '0.0.0', platform: 'darwin', arch: 'arm64', osVersion: '1', region: 'cn' },
+      { kind: 'github-user', login: 'u' },
+    );
+    expect(decision.confirmed).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      'onDesktopOnlyConfirmPending threw (ignored)',
+      expect.objectContaining({ sessionId: 's-throw' }),
+    );
+  });
+});

--- a/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
+++ b/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
@@ -122,7 +122,16 @@ export class IssueConfirmBridge {
           suggestedPublicName,
         },
       });
-      this.deps.onDesktopOnlyConfirmPending?.(sessionId);
+      try {
+        this.deps.onDesktopOnlyConfirmPending?.(sessionId);
+      } catch (err) {
+        // 旁路提示绝不反噬确认流程:回调同步抛错会在 Promise executor 里把
+        // request() 直接 reject(review 反馈)——吞错只 warn。
+        this.deps.logger?.warn('onDesktopOnlyConfirmPending threw (ignored)', {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     });
   }
 

--- a/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
+++ b/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
@@ -69,6 +69,12 @@ export interface IssueConfirmBridgeDeps {
   /** 确认超时,默认 10 分钟(对齐 permission prompt 的超时语义)。测试注小值。 */
   timeoutMs?: number;
   logger?: { warn: (...args: unknown[]) => void };
+  /**
+   * 确认卡已派发的回调(#926):确认卡有意只在桌面出现,IM 绑定会话的用户可能
+   * 人在 IM 侧看不到 —— 接线方在这里给 IM 发「去桌面确认」的文字提示。
+   * fire-and-forget,不得阻塞或影响确认流程。
+   */
+  onDesktopOnlyConfirmPending?: (sessionId: string) => void;
 }
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -116,6 +122,7 @@ export class IssueConfirmBridge {
           suggestedPublicName,
         },
       });
+      this.deps.onDesktopOnlyConfirmPending?.(sessionId);
     });
   }
 

--- a/apps/desktop/src/main/im/__tests__/desktopConfirmNotice.test.ts
+++ b/apps/desktop/src/main/im/__tests__/desktopConfirmNotice.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildDesktopConfirmNoticeText,
   createDesktopConfirmNotifier,
+  resolveFeishuNoticeTarget,
 } from '../desktopConfirmNotice.js';
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
@@ -65,5 +66,36 @@ describe('createDesktopConfirmNotifier', () => {
     notify2('s1', 'x');
     await flush();
     expect(sendFail).toHaveBeenCalled();
+  });
+});
+
+describe('resolveFeishuNoticeTarget(#1059 review P1)', () => {
+  it('/ctr 接管的普通会话:session 行无 feishuOpenId,以接管绑定的 userId 为准', async () => {
+    const openId = await resolveFeishuNoticeTarget(
+      {
+        findBinding: () => ({ channel: 'feishu', userId: 'ou_takeover' }),
+        getSessionOpenId: async () => null,
+      },
+      'desktop-session',
+    );
+    expect(openId).toBe('ou_takeover');
+  });
+
+  it('非飞书渠道的接管绑定不误用,回落 session 行;两者皆无 → null', async () => {
+    expect(
+      await resolveFeishuNoticeTarget(
+        {
+          findBinding: () => ({ channel: 'slack', userId: 'U123' }),
+          getSessionOpenId: async () => 'ou_native',
+        },
+        's1',
+      ),
+    ).toBe('ou_native');
+    expect(
+      await resolveFeishuNoticeTarget(
+        { findBinding: () => null, getSessionOpenId: async () => null },
+        's2',
+      ),
+    ).toBe(null);
   });
 });

--- a/apps/desktop/src/main/im/__tests__/desktopConfirmNotice.test.ts
+++ b/apps/desktop/src/main/im/__tests__/desktopConfirmNotice.test.ts
@@ -1,0 +1,69 @@
+/**
+ * desktopConfirmNotice.test.ts — 桌面专属确认卡的 IM 侧提示(#926)。
+ * 钉死:飞书绑定会话收到「去桌面确认」提示;非 IM 会话零动作;发送失败只落
+ * warn、绝不影响确认流程(fire-and-forget)。修复前飞书驱动的会话里确认卡只在
+ * 桌面弹出,用户在 IM 侧毫无感知,只能等到 CONFIRM_TIMEOUT。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildDesktopConfirmNoticeText,
+  createDesktopConfirmNotifier,
+} from '../desktopConfirmNotice.js';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('createDesktopConfirmNotifier', () => {
+  it('飞书绑定会话 → 发送带确认卡名称的提示文本', async () => {
+    const send = vi.fn(async (_openId: string, _markdown: string) => ({}));
+    const notify = createDesktopConfirmNotifier({
+      getFeishuOpenId: async () => 'ou_123',
+      sendFeishuText: send,
+    });
+    notify('feishu_bot_ou_123', '「提交 GitHub issue」的确认卡');
+    await flush();
+    expect(send).toHaveBeenCalledWith(
+      'ou_123',
+      buildDesktopConfirmNoticeText('「提交 GitHub issue」的确认卡'),
+    );
+    expect(send.mock.calls[0][1]).toContain('提交 GitHub issue');
+    expect(send.mock.calls[0][1]).toContain('桌面端');
+  });
+
+  it('非 IM 会话(openId null)→ 零发送', async () => {
+    const send = vi.fn(async () => ({}));
+    const notify = createDesktopConfirmNotifier({
+      getFeishuOpenId: async () => null,
+      sendFeishuText: send,
+    });
+    notify('desktop-session', 'x');
+    await flush();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('查询/发送失败 → 只落 warn,不抛出(不影响确认流程)', async () => {
+    const warn = vi.fn();
+    const notify = createDesktopConfirmNotifier({
+      getFeishuOpenId: async () => {
+        throw new Error('db closed');
+      },
+      sendFeishuText: async () => ({}),
+      logWarn: warn,
+    });
+    expect(() => notify('s1', 'x')).not.toThrow();
+    await flush();
+    expect(warn).toHaveBeenCalled();
+    const sendFail = vi.fn();
+    const notify2 = createDesktopConfirmNotifier({
+      getFeishuOpenId: async () => 'ou_1',
+      sendFeishuText: async () => {
+        throw new Error('feishu 400');
+      },
+      logWarn: sendFail,
+    });
+    notify2('s1', 'x');
+    await flush();
+    expect(sendFail).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/im/desktopConfirmNotice.ts
+++ b/apps/desktop/src/main/im/desktopConfirmNotice.ts
@@ -1,0 +1,77 @@
+/**
+ * im/desktopConfirmNotice.ts — 桌面专属确认卡挂起时的 IM 侧提示(#926)。
+ *
+ * issue_confirm / rename confirm / ghost_grant_confirm 这类确认卡**有意**只在
+ * 桌面端出现(见 issueConfirmBridge 头注:它们不进 agent 的 InteractionRequest
+ * union,feishu /ctr 接管路径对未知 kind 会直接 deny)。但飞书驱动的会话里用户
+ * 人在 IM 侧,看不到卡片,只能等到 CONFIRM_TIMEOUT 才知道出了事。
+ *
+ * 这里补的是**不可交互的文字提示**:卡片仍然只在桌面(不动既有设计边界),
+ * IM 侧即时收到「有确认卡在桌面等你」。best-effort:提示失败绝不影响确认流程
+ * (fire-and-forget,桥不等待、不感知失败)。
+ */
+
+import { eq } from 'drizzle-orm';
+
+import { createLogger } from '../logger.js';
+import { getDbClient } from '../localDb/client/current.js';
+import { sessions } from '../localDb/schema.js';
+
+const log = createLogger('im-desktop-confirm-notice');
+
+export interface DesktopConfirmNoticeDeps {
+  /** 会话绑定的飞书 openId;非飞书会话返回 null(桌面本来就是唯一交互面)。 */
+  getFeishuOpenId(sessionId: string): Promise<string | null>;
+  sendFeishuText(openId: string, markdown: string): Promise<unknown>;
+  logWarn?(message: string): void;
+}
+
+/** 提示文案(纯函数,便于单测锚定)。 */
+export function buildDesktopConfirmNoticeText(what: string): string {
+  return `🔔 ${what}正在桌面端 Cindy 等待你的确认;超时将自动取消,如需继续请到桌面端操作。`;
+}
+
+/**
+ * 组装 fire-and-forget 通知函数(DI 便于单测;生产接线见
+ * createFeishuDesktopConfirmNotifier)。
+ */
+export function createDesktopConfirmNotifier(
+  deps: DesktopConfirmNoticeDeps,
+): (sessionId: string, what: string) => void {
+  return (sessionId, what) => {
+    void (async () => {
+      try {
+        const openId = await deps.getFeishuOpenId(sessionId);
+        if (!openId) return;
+        await deps.sendFeishuText(openId, buildDesktopConfirmNoticeText(what));
+      } catch (err) {
+        deps.logWarn?.(
+          `desktop-confirm IM notice failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    })();
+  };
+}
+
+/** 生产接线:sessions 表反查 feishuOpenId + 复用 im/host 的 feishuIm 实例。 */
+export function createFeishuDesktopConfirmNotifier(): (sessionId: string, what: string) => void {
+  return createDesktopConfirmNotifier({
+    async getFeishuOpenId(sessionId) {
+      const db = getDbClient().drizzle;
+      const [row] = await db
+        .select({ openId: sessions.feishuOpenId })
+        .from(sessions)
+        .where(eq(sessions.id, sessionId))
+        .limit(1);
+      const openId = row?.openId?.trim();
+      return openId ? openId : null;
+    },
+    async sendFeishuText(openId, markdown) {
+      // 动态 import 避免模块加载期就拉起 im/host(它有连接副作用;确认卡可能在
+      // IM 从未启用的会话里出现,这时根本走不到 send)。
+      const { feishuIm } = await import('./host.js');
+      return feishuIm.sendMarkdownText(openId, markdown);
+    },
+    logWarn: (m) => log.warn(m),
+  });
+}

--- a/apps/desktop/src/main/im/desktopConfirmNotice.ts
+++ b/apps/desktop/src/main/im/desktopConfirmNotice.ts
@@ -9,15 +9,10 @@
  * 这里补的是**不可交互的文字提示**:卡片仍然只在桌面(不动既有设计边界),
  * IM 侧即时收到「有确认卡在桌面等你」。best-effort:提示失败绝不影响确认流程
  * (fire-and-forget,桥不等待、不感知失败)。
+ *
+ * 本文件只放纯逻辑(零 electron / db 依赖,单测直接引);生产接线在
+ * desktopConfirmNoticeWiring.ts(按 architecture-invariants §2 顶层静态 import)。
  */
-
-import { eq } from 'drizzle-orm';
-
-import { createLogger } from '../logger.js';
-import { getDbClient } from '../localDb/client/current.js';
-import { sessions } from '../localDb/schema.js';
-
-const log = createLogger('im-desktop-confirm-notice');
 
 export interface DesktopConfirmNoticeDeps {
   /** 会话绑定的飞书 openId;非飞书会话返回 null(桌面本来就是唯一交互面)。 */
@@ -26,7 +21,7 @@ export interface DesktopConfirmNoticeDeps {
   logWarn?(message: string): void;
 }
 
-/** 飞书目标解析的注入面(纯逻辑可单测;生产接线见 createFeishuDesktopConfirmNotifier)。 */
+/** 飞书目标解析的注入面(纯逻辑可单测;生产接线见 desktopConfirmNoticeWiring.ts)。 */
 export interface FeishuNoticeTargetDeps {
   /** bindingStore.findByTarget:/ctr 接管的普通会话,接管者身份在 binding 而非 session 行。 */
   findBinding(sessionId: string): { channel: string; userId: string } | null;
@@ -55,7 +50,7 @@ export function buildDesktopConfirmNoticeText(what: string): string {
 
 /**
  * 组装 fire-and-forget 通知函数(DI 便于单测;生产接线见
- * createFeishuDesktopConfirmNotifier)。
+ * desktopConfirmNoticeWiring.ts)。
  */
 export function createDesktopConfirmNotifier(
   deps: DesktopConfirmNoticeDeps,
@@ -73,37 +68,4 @@ export function createDesktopConfirmNotifier(
       }
     })();
   };
-}
-
-/** 生产接线:sessions 表反查 feishuOpenId + 复用 im/host 的 feishuIm 实例。 */
-export function createFeishuDesktopConfirmNotifier(): (sessionId: string, what: string) => void {
-  return createDesktopConfirmNotifier({
-    async getFeishuOpenId(sessionId) {
-      // 动态 import binding:与 im 编排层解耦,确认卡可能出现在 IM 从未启用的会话里。
-      const { bindingStore } = await import('./binding.js');
-      return resolveFeishuNoticeTarget(
-        {
-          findBinding: (id) => bindingStore.findByTarget(id),
-          getSessionOpenId: async (id) => {
-            const db = getDbClient().drizzle;
-            const [row] = await db
-              .select({ openId: sessions.feishuOpenId })
-              .from(sessions)
-              .where(eq(sessions.id, id))
-              .limit(1);
-            const openId = row?.openId?.trim();
-            return openId ? openId : null;
-          },
-        },
-        sessionId,
-      );
-    },
-    async sendFeishuText(openId, markdown) {
-      // 动态 import 避免模块加载期就拉起 im/host(它有连接副作用;确认卡可能在
-      // IM 从未启用的会话里出现,这时根本走不到 send)。
-      const { feishuIm } = await import('./host.js');
-      return feishuIm.sendMarkdownText(openId, markdown);
-    },
-    logWarn: (m) => log.warn(m),
-  });
 }

--- a/apps/desktop/src/main/im/desktopConfirmNotice.ts
+++ b/apps/desktop/src/main/im/desktopConfirmNotice.ts
@@ -26,6 +26,28 @@ export interface DesktopConfirmNoticeDeps {
   logWarn?(message: string): void;
 }
 
+/** 飞书目标解析的注入面(纯逻辑可单测;生产接线见 createFeishuDesktopConfirmNotifier)。 */
+export interface FeishuNoticeTargetDeps {
+  /** bindingStore.findByTarget:/ctr 接管的普通会话,接管者身份在 binding 而非 session 行。 */
+  findBinding(sessionId: string): { channel: string; userId: string } | null;
+  /** sessions 行的 feishuOpenId(飞书原生会话)。 */
+  getSessionOpenId(sessionId: string): Promise<string | null>;
+}
+
+/**
+ * 解析确认提示应发往的飞书 openId。优先接管绑定(review P1:/ctr 接管的普通
+ * desktop 会话,session 行的 feishuOpenId 为 null,接管者身份保存在 bindingStore),
+ * 其次才是飞书原生会话的 session 行;两者皆无 → null(非飞书场景,零动作)。
+ */
+export async function resolveFeishuNoticeTarget(
+  deps: FeishuNoticeTargetDeps,
+  sessionId: string,
+): Promise<string | null> {
+  const bound = deps.findBinding(sessionId);
+  if (bound?.channel === 'feishu' && bound.userId) return bound.userId;
+  return deps.getSessionOpenId(sessionId);
+}
+
 /** 提示文案(纯函数,便于单测锚定)。 */
 export function buildDesktopConfirmNoticeText(what: string): string {
   return `🔔 ${what}正在桌面端 Cindy 等待你的确认;超时将自动取消,如需继续请到桌面端操作。`;
@@ -57,14 +79,24 @@ export function createDesktopConfirmNotifier(
 export function createFeishuDesktopConfirmNotifier(): (sessionId: string, what: string) => void {
   return createDesktopConfirmNotifier({
     async getFeishuOpenId(sessionId) {
-      const db = getDbClient().drizzle;
-      const [row] = await db
-        .select({ openId: sessions.feishuOpenId })
-        .from(sessions)
-        .where(eq(sessions.id, sessionId))
-        .limit(1);
-      const openId = row?.openId?.trim();
-      return openId ? openId : null;
+      // 动态 import binding:与 im 编排层解耦,确认卡可能出现在 IM 从未启用的会话里。
+      const { bindingStore } = await import('./binding.js');
+      return resolveFeishuNoticeTarget(
+        {
+          findBinding: (id) => bindingStore.findByTarget(id),
+          getSessionOpenId: async (id) => {
+            const db = getDbClient().drizzle;
+            const [row] = await db
+              .select({ openId: sessions.feishuOpenId })
+              .from(sessions)
+              .where(eq(sessions.id, id))
+              .limit(1);
+            const openId = row?.openId?.trim();
+            return openId ? openId : null;
+          },
+        },
+        sessionId,
+      );
     },
     async sendFeishuText(openId, markdown) {
       // 动态 import 避免模块加载期就拉起 im/host(它有连接副作用;确认卡可能在

--- a/apps/desktop/src/main/im/desktopConfirmNoticeWiring.ts
+++ b/apps/desktop/src/main/im/desktopConfirmNoticeWiring.ts
@@ -1,0 +1,52 @@
+/**
+ * im/desktopConfirmNoticeWiring.ts — desktopConfirmNotice 的生产接线(#926)。
+ *
+ * 与纯逻辑分开放的原因:
+ * - architecture-invariants §2 要求 main 进程依赖一律顶层静态 import,禁止运行时
+ *   动态 import()(codex review P1)。host / binding 本来就在 main 的静态依赖图里
+ *   (bootstrap-electron → im/index → host),这里静态引不引入新的加载时机。
+ * - desktopConfirmNotice.ts 被单测直接引入,必须保持零 electron 依赖;
+ *   host.ts 顶层 import electron,静态依赖只能落在这个不进单测图的接线文件里。
+ */
+
+import { eq } from 'drizzle-orm';
+
+import { createLogger } from '../logger.js';
+import { getDbClient } from '../localDb/client/current.js';
+import { sessions } from '../localDb/schema.js';
+import { bindingStore } from './binding.js';
+import { feishuIm } from './host.js';
+import {
+  createDesktopConfirmNotifier,
+  resolveFeishuNoticeTarget,
+} from './desktopConfirmNotice.js';
+
+const log = createLogger('im-desktop-confirm-notice');
+
+/** 生产接线:接管绑定 / sessions 行反查 feishuOpenId + 复用 im/host 的 feishuIm 实例。 */
+export function createFeishuDesktopConfirmNotifier(): (sessionId: string, what: string) => void {
+  return createDesktopConfirmNotifier({
+    async getFeishuOpenId(sessionId) {
+      return resolveFeishuNoticeTarget(
+        {
+          findBinding: (id) => bindingStore.findByTarget(id),
+          getSessionOpenId: async (id) => {
+            const db = getDbClient().drizzle;
+            const [row] = await db
+              .select({ openId: sessions.feishuOpenId })
+              .from(sessions)
+              .where(eq(sessions.id, id))
+              .limit(1);
+            const openId = row?.openId?.trim();
+            return openId ? openId : null;
+          },
+        },
+        sessionId,
+      );
+    },
+    async sendFeishuText(openId, markdown) {
+      return feishuIm.sendMarkdownText(openId, markdown);
+    },
+    logWarn: (m) => log.warn(m),
+  });
+}

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -51,6 +51,7 @@ import type { DesktopCommandContext } from '../commands/index.js';
 import { getDesktopCommandRegistry } from '../commands/index.js';
 import { initGithubIssueSubmit, IssueConfirmBridge } from '../github-issue/index.js';
 import { initGhostGrantConfirmBridge } from '../cindy-brain/ghostGrantConfirmBridge.js';
+import { createFeishuDesktopConfirmNotifier } from '../im/desktopConfirmNotice.js';
 import {
   initGhostSetupInteractionBridge,
   parseGhostSetupInteractionCommand,
@@ -1211,14 +1212,22 @@ const pendingInteractionResolvers = new Map<string, PendingInteractionEntry>();
  * 超时/会话清理由桥自己兜底。复用同一对 INTERACTION_REQUEST / RESOLVE_INTERACTION
  * channel,renderer 按 kind 分发。
  */
+// 桌面专属确认卡的 IM 侧提示(#926):卡片仍只在桌面出现(设计边界不动),
+// 但飞书绑定会话的用户会即时收到「去桌面确认」的文字提示,不再默等到超时。
+const desktopConfirmImNotifier = createFeishuDesktopConfirmNotifier();
+
 const issueConfirmBridge = new IssueConfirmBridge({
   broadcast: (channel, payload) => broadcastToAllWindows(channel, payload),
   logger: log,
+  onDesktopOnlyConfirmPending: (sessionId) =>
+    desktopConfirmImNotifier(sessionId, '「提交 GitHub issue」的确认卡'),
 });
 
 const renameSessionsConfirmBridge = new RenameSessionsConfirmBridge({
   broadcast: (channel, payload) => broadcastToAllWindows(channel, payload),
   logger: log,
+  onDesktopOnlyConfirmPending: (sessionId) =>
+    desktopConfirmImNotifier(sessionId, '「批量重命名会话」的确认卡'),
 });
 
 /**
@@ -1229,6 +1238,8 @@ const renameSessionsConfirmBridge = new RenameSessionsConfirmBridge({
 const ghostGrantConfirmBridge = initGhostGrantConfirmBridge({
   broadcast: (channel, payload) => broadcastToAllWindows(channel, payload),
   logger: log,
+  onDesktopOnlyConfirmPending: (sessionId) =>
+    desktopConfirmImNotifier(sessionId, '「插件文件授权」的确认卡'),
 });
 
 const ghostSetupInteractionBridge = initGhostSetupInteractionBridge({

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -51,7 +51,7 @@ import type { DesktopCommandContext } from '../commands/index.js';
 import { getDesktopCommandRegistry } from '../commands/index.js';
 import { initGithubIssueSubmit, IssueConfirmBridge } from '../github-issue/index.js';
 import { initGhostGrantConfirmBridge } from '../cindy-brain/ghostGrantConfirmBridge.js';
-import { createFeishuDesktopConfirmNotifier } from '../im/desktopConfirmNotice.js';
+import { createFeishuDesktopConfirmNotifier } from '../im/desktopConfirmNoticeWiring.js';
 import {
   initGhostSetupInteractionBridge,
   parseGhostSetupInteractionCommand,

--- a/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
+++ b/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
@@ -30,6 +30,8 @@ export interface RenameSessionsConfirmBridgeDeps {
   broadcast: (channel: string, payload: unknown) => void;
   timeoutMs?: number;
   logger?: { warn: (...args: unknown[]) => void };
+  /** 同 IssueConfirmBridgeDeps.onDesktopOnlyConfirmPending(#926):IM 侧「去桌面确认」提示。 */
+  onDesktopOnlyConfirmPending?: (sessionId: string) => void;
 }
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -60,6 +62,7 @@ export class RenameSessionsConfirmBridge {
         sessionId,
         request: { kind: 'rename_sessions_confirm', requestId, changes },
       });
+      this.deps.onDesktopOnlyConfirmPending?.(sessionId);
     });
   }
 

--- a/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
+++ b/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
@@ -62,7 +62,16 @@ export class RenameSessionsConfirmBridge {
         sessionId,
         request: { kind: 'rename_sessions_confirm', requestId, changes },
       });
-      this.deps.onDesktopOnlyConfirmPending?.(sessionId);
+      try {
+        this.deps.onDesktopOnlyConfirmPending?.(sessionId);
+      } catch (err) {
+        // 旁路提示绝不反噬确认流程:回调同步抛错会在 Promise executor 里把
+        // request() 直接 reject(review 反馈)——吞错只 warn。
+        this.deps.logger?.warn('onDesktopOnlyConfirmPending threw (ignored)', {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     });
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 #926:issue_confirm(提交 GitHub issue)/ rename confirm(批量重命名)/ ghost_grant_confirm(插件文件授权)这类系统确认卡**有意**只在桌面端出现(设计注释:它们不进 agent 的 InteractionRequest union,feishu /ctr 接管路径对未知 kind 会直接 deny)。但飞书驱动的会话里用户人在 IM 侧,看不到卡片,只能默等到 CONFIRM_TIMEOUT 才知道操作失败。

按 issue 的最低诉求实现(不动"卡片只在桌面"的设计边界):

- 新增 `im/desktopConfirmNotice`(DI 可单测):三个确认桥各加一个可选回调 `onDesktopOnlyConfirmPending`,派发确认卡后 fire-and-forget 地给会话绑定的飞书 openId 发一条**不可交互**文字提示("🔔 「XX」的确认卡正在桌面端 Cindy 等待你的确认;超时将自动取消,如需继续请到桌面端操作。")。
- 非 IM 会话零动作(sessions 行无 feishuOpenId 即返回);查询/发送失败只落 warn,绝不影响确认流程;回调未注入时三个桥行为逐字不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#926(修复);与 #924(超长回复不中继)同属"飞书中继覆盖不全"一族
- 本 PR 包含:通知模块 + 三个确认桥的可选回调 + register.ts 接线 + 测试
- 明确不包含:把确认卡本体中继成飞书可交互卡片(那需要重开「确认卡只在桌面」的设计决策,涉及 /ctr 搬移语义);discord/wechat 渠道的同类提示(结构已预留,按需跟进)
- 用户可见变化:飞书绑定会话在桌面弹确认卡时,飞书同步收到一条提示消息;其余场景无变化
- 是否存在 breaking change:无

### UI 变化

不涉及(飞书侧新增的是 IM 文本消息,桌面 UI 无任何变化)。

- 引用的设计规范:不涉及

### 远程与多端适配(docs/dev-rules/remote-and-mobile-adaptation.md 门禁)

- **SSH 远程工作区:不涉及**。通知逻辑全部在桌面 main 进程内完成,只读本机 DB(sessions.feishuOpenId / imBindings),不触碰 workdir 文件与 agent 进程;SSH 远程会话的确认桥本来就跑在本机 main 进程,飞书绑定的远程会话经同一路径天然覆盖,无需远程通道。
- **设备互联远程控制:不涉及**。未新增任何 IPC channel / 推送事件(onDesktopOnlyConfirmPending 是进程内回调,提示经飞书 HTTP 出站),无 allowlist 登记需求;既有确认卡 broadcast 路径逐字未动,远控端对这三类卡的可见性与改动前一致。
- **手机版:不涉及**。手机版是纯控制端,这三类确认卡改动前后都不进 agent 的 InteractionRequest union、不会作为 interaction push 到达手机/远控端(本 PR 未改变该边界);本通知是面向飞书用户的旁路文字提示,与 interaction push 无交集。若未来把确认卡纳入 InteractionRequest union,手机/远控/IM 三端应同批设计——那是 issue #926 明确排除的扩展范围。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/im/__tests__/desktopConfirmNotice.test.ts src/main/github-issue/__tests__/issueConfirmBridge.test.ts
结果:13 passed(新增 5 用例:飞书会话收到带卡名的提示文本 / 非 IM 会话零发送 /
查询与发送失败只落 warn 不抛 / 桥派发后回调携带 sessionId / 回调未注入行为不变)

pnpm --filter desktop run --if-present typecheck
结果:0 错误

根 pnpm test:unit
结果:exit 0(全绿)
```

### 手工验证

不涉及(飞书发送面由既有 sendMarkdownText 通道承载,行为由 mock 单测锚定;实机需真实飞书 bot 绑定,未执行)。

### 未执行的验证

飞书实机端到端(需已绑定的 bot 与真实会话);无其它。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅确认卡派发瞬间的旁路通知;通知失败不影响确认流程本身,非 IM 会话零行为变化
- 回滚 / 降级方式:revert 本 PR;或仅移除 register.ts 三处 onDesktopOnlyConfirmPending 接线即完全恢复旧行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

