### PR TITLE
feat(desktop): 完善订阅与充值信息披露

### DIFF
--- a/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingCheckoutDialog.tsx
@@ -83,6 +83,8 @@ export function BillingCheckoutDialog({
     if (state.phase === 'CREATING') return t('billing.checkout.creatingTitle');
     if (state.phase === 'AWAITING_PAYMENT') return t('billing.checkout.awaitingTitle');
     if (state.phase === 'COMPLETED') return t('billing.checkout.completedTitle');
+    if (state.phase === 'FULFILLMENT_PENDING') return t('billing.checkout.fulfillmentPendingTitle');
+    if (state.phase === 'FULFILLMENT_FAILED') return t('billing.checkout.fulfillmentFailedTitle');
     if (state.phase === 'EXPIRED') return t('billing.checkout.expiredTitle');
     if (state.phase === 'CANCELED') return t('billing.checkout.canceledTitle');
     return t('billing.checkout.failedTitle');
@@ -236,6 +238,29 @@ export function BillingCheckoutDialog({
                   <Check size={24} />
                 </div>
                 <p className="mt-4 text-sm font-medium">{t('billing.checkout.paymentCompleted')}</p>
+                <p className="mt-2 max-w-[360px] text-12 text-[var(--text-secondary)]">
+                  {t('billing.checkout.fulfillmentSucceeded')}
+                </p>
+              </>
+            )}
+
+            {state.phase === 'FULFILLMENT_PENDING' && (
+              <>
+                <Spinner size={26} className="text-[var(--text-secondary)]" />
+                <p className="mt-4 max-w-[360px] text-sm text-[var(--text-secondary)]">
+                  {t('billing.checkout.fulfillmentPendingBody')}
+                </p>
+              </>
+            )}
+
+            {state.phase === 'FULFILLMENT_FAILED' && (
+              <>
+                <div className="grid size-14 place-items-center rounded-full bg-[var(--surface-chip)]">
+                  <CircleAlert size={23} />
+                </div>
+                <p className="mt-4 max-w-[360px] text-sm text-[var(--text-secondary)]">
+                  {t('billing.checkout.fulfillmentFailedBody')}
+                </p>
               </>
             )}
 
@@ -261,7 +286,9 @@ export function BillingCheckoutDialog({
 
           <div className="flex min-h-16 items-center justify-end gap-3 border-t border-[var(--border-default)] px-6 py-3">
             <div className="flex items-center gap-2">
-              {state.phase === 'AWAITING_PAYMENT' && (
+              {(state.phase === 'AWAITING_PAYMENT' ||
+                state.phase === 'FULFILLMENT_PENDING' ||
+                state.phase === 'FULFILLMENT_FAILED') && (
                 <button
                   type="button"
                   onClick={onRefresh}
@@ -299,5 +326,11 @@ export function BillingCheckoutDialog({
 }
 
 function isTerminalPhase(phase: BillingCheckoutState['phase']): boolean {
-  return phase === 'COMPLETED' || phase === 'FAILED' || phase === 'EXPIRED' || phase === 'CANCELED';
+  return (
+    phase === 'COMPLETED' ||
+    phase === 'FULFILLMENT_FAILED' ||
+    phase === 'FAILED' ||
+    phase === 'EXPIRED' ||
+    phase === 'CANCELED'
+  );
 }

--- a/apps/desktop/src/renderer/features/billing/__tests__/presentation.test.ts
+++ b/apps/desktop/src/renderer/features/billing/__tests__/presentation.test.ts
@@ -1,0 +1,128 @@
+import type {
+  BillingCatalogOffer,
+  BillingCatalogProduct,
+  BillingPaymentOrder,
+  BillingPurchaseOption,
+  BillingSubscription,
+} from '../../../../shared/billing';
+import {
+  orderPurchaseType,
+  productNameForOffer,
+  purchaseTypeForOffer,
+  purchaseTypeForSubscription,
+  purchaseTypeOf,
+  rolloverProjection,
+} from '../presentation';
+
+function option(capability: BillingPurchaseOption['capability']): BillingPurchaseOption {
+  return {
+    id: `option-${capability}`,
+    provider: 'stripe',
+    paymentAction: 'REDIRECT',
+    capability,
+  };
+}
+
+function offer(
+  capability: BillingPurchaseOption['capability'],
+  overrides: Partial<BillingCatalogOffer> = {},
+): BillingCatalogOffer {
+  return {
+    code: 'plus-monthly',
+    interval: 'MONTH',
+    currency: 'USD',
+    amount: '10',
+    minAmount: null,
+    maxAmount: null,
+    creditAmount: '100',
+    rolloverCap: '20',
+    purchaseOptions: [option(capability)],
+    ...overrides,
+  };
+}
+
+function subscription(overrides: Partial<BillingSubscription> = {}): BillingSubscription {
+  return {
+    subscriptionId: 'sub-1',
+    purchaseAttemptId: null,
+    status: 'ACTIVE',
+    provider: 'stripe',
+    cancelAtPeriodEnd: false,
+    currentPeriodStartAt: '2026-07-01T00:00:00.000Z',
+    currentPeriodEndAt: '2026-08-01T00:00:00.000Z',
+    entitlementValidUntil: '2026-08-01T00:00:00.000Z',
+    entitlementStatus: 'SUCCEEDED',
+    effectivePlan: {
+      product: { code: 'plus', level: 1 },
+      offer: { code: 'plus-monthly', interval: 'MONTH' },
+      terms: {
+        amount: '10',
+        currency: 'USD',
+        creditAmount: '100',
+        rolloverCap: '20',
+      },
+    },
+    pendingPlanChange: null,
+    paymentAction: null,
+    ...overrides,
+  };
+}
+
+test('classifies one-time and recurring capabilities', () => {
+  expect(purchaseTypeOf(option('ONE_TIME_PAYMENT'))).toBe('ONE_TIME');
+  expect(purchaseTypeOf(option('MERCHANT_INITIATED_MANDATE'))).toBe('RECURRING');
+  expect(purchaseTypeOf(option('PROVIDER_MANAGED_SUBSCRIPTION'))).toBe('RECURRING');
+});
+
+test('does not infer recurring purchase type for canceled subscription without offer', () => {
+  expect(purchaseTypeForSubscription(subscription({ cancelAtPeriodEnd: true }), null)).toBe('UNKNOWN');
+  expect(purchaseTypeForSubscription(subscription({ status: 'PAST_DUE' }), null)).toBe('UNKNOWN');
+});
+
+test('uses offer capabilities and returns unknown for mixed options', () => {
+  expect(purchaseTypeForOffer(offer('ONE_TIME_PAYMENT'))).toBe('ONE_TIME');
+  expect(
+    purchaseTypeForOffer(
+      offer('ONE_TIME_PAYMENT', {
+        purchaseOptions: [option('ONE_TIME_PAYMENT'), option('PROVIDER_MANAGED_SUBSCRIPTION')],
+      }),
+    ),
+  ).toBe('UNKNOWN');
+});
+
+test('calculates rollover estimates with exact decimal units', () => {
+  expect(rolloverProjection('25.125000001', '20.5', '2026-08-01T00:00:00.000Z')).toEqual({
+    cap: '20.5',
+    eligibleToCarryOver: '20.5',
+    estimatedExpired: '4.625000001',
+    settlementAt: '2026-08-01T00:00:00.000Z',
+  });
+  expect(rolloverProjection('10', '20', '2026-08-01T00:00:00.000Z')?.estimatedExpired).toBe('0');
+});
+
+test('omits derived rollover estimates when trusted inputs are missing or malformed', () => {
+  expect(rolloverProjection(null, '20', '2026-08-01T00:00:00.000Z')).toMatchObject({
+    cap: '20',
+    eligibleToCarryOver: null,
+    estimatedExpired: null,
+  });
+  expect(rolloverProjection('invalid', '20', '2026-08-01T00:00:00.000Z')?.estimatedExpired).toBeNull();
+  expect(rolloverProjection('10', '20', null)?.eligibleToCarryOver).toBeNull();
+});
+
+test('resolves product and order purchase type from catalog', () => {
+  const products: BillingCatalogProduct[] = [
+    {
+      code: 'plus',
+      name: 'Plus',
+      kind: 'SUBSCRIPTION',
+      level: 1,
+      sortOrder: 1,
+      offers: [offer('PROVIDER_MANAGED_SUBSCRIPTION')],
+    },
+  ];
+  const order = { offerCode: 'plus-monthly' } as BillingPaymentOrder;
+  expect(productNameForOffer(products, 'plus-monthly')).toBe('Plus');
+  expect(orderPurchaseType(order, products)).toBe('RECURRING');
+  expect(orderPurchaseType({ offerCode: 'unknown' } as BillingPaymentOrder, products)).toBe('UNKNOWN');
+});

--- a/apps/desktop/src/renderer/features/billing/presentation.ts
+++ b/apps/desktop/src/renderer/features/billing/presentation.ts
@@ -1,0 +1,99 @@
+import type {
+  BillingCatalogOffer,
+  BillingCatalogProduct,
+  BillingPaymentOrder,
+  BillingPurchaseOption,
+  BillingSubscription,
+} from '../../../shared/billing';
+
+export type BillingPurchaseType = 'ONE_TIME' | 'RECURRING' | 'UNKNOWN';
+
+export type RolloverProjection = {
+  cap: string;
+  eligibleToCarryOver: string | null;
+  estimatedExpired: string | null;
+  settlementAt: string | null;
+};
+
+export function purchaseTypeOf(option: Pick<BillingPurchaseOption, 'capability'>): BillingPurchaseType {
+  if (option.capability === 'ONE_TIME_PAYMENT') return 'ONE_TIME';
+  if (
+    option.capability === 'MERCHANT_INITIATED_MANDATE' ||
+    option.capability === 'PROVIDER_MANAGED_SUBSCRIPTION'
+  ) {
+    return 'RECURRING';
+  }
+  return 'UNKNOWN';
+}
+
+export function purchaseTypeForOffer(offer: BillingCatalogOffer): BillingPurchaseType {
+  const types = new Set(offer.purchaseOptions.map(purchaseTypeOf));
+  if (types.size !== 1) return 'UNKNOWN';
+  return [...types][0] ?? 'UNKNOWN';
+}
+
+export function purchaseTypeForSubscription(
+  subscription: BillingSubscription,
+  offer: BillingCatalogOffer | null,
+): BillingPurchaseType {
+  if (offer) return purchaseTypeForOffer(offer);
+  if (subscription.status === 'ACTIVE' && !subscription.cancelAtPeriodEnd) return 'RECURRING';
+  return 'UNKNOWN';
+}
+
+export function rolloverProjection(
+  planRemaining: string | null,
+  rolloverCap: string | null,
+  settlementAt: string | null,
+): RolloverProjection | null {
+  if (!rolloverCap) return null;
+  if (planRemaining === null || settlementAt === null) {
+    return { cap: rolloverCap, eligibleToCarryOver: null, estimatedExpired: null, settlementAt };
+  }
+  const remaining = decimalUnits(planRemaining);
+  const cap = decimalUnits(rolloverCap);
+  if (remaining === null || cap === null || remaining < 0n || cap < 0n) {
+    return { cap: rolloverCap, eligibleToCarryOver: null, estimatedExpired: null, settlementAt };
+  }
+  const carry = remaining < cap ? remaining : cap;
+  const expired = remaining > cap ? remaining - cap : 0n;
+  return {
+    cap: rolloverCap,
+    eligibleToCarryOver: formatUnits(carry),
+    estimatedExpired: formatUnits(expired),
+    settlementAt,
+  };
+}
+
+export function productNameForOffer(
+  products: BillingCatalogProduct[],
+  offerCode: string | null | undefined,
+): string | null {
+  if (!offerCode) return null;
+  for (const product of products) {
+    if (product.offers.some((offer) => offer.code === offerCode)) return product.name;
+  }
+  return null;
+}
+
+export function orderPurchaseType(
+  order: BillingPaymentOrder,
+  products: BillingCatalogProduct[],
+): BillingPurchaseType {
+  const offer = products
+    .flatMap((product) => product.offers)
+    .find((candidate) => candidate.code === order.offerCode);
+  return offer ? purchaseTypeForOffer(offer) : 'UNKNOWN';
+}
+
+function decimalUnits(value: string): bigint | null {
+  const match = /^(0|[1-9]\d{0,14})(?:\.(\d{1,9}))?$/.exec(value);
+  if (!match) return null;
+  return BigInt(match[1]) * 1_000_000_000n + BigInt((match[2] ?? '').padEnd(9, '0') || '0');
+}
+
+function formatUnits(value: bigint): string {
+  const whole = value / 1_000_000_000n;
+  const fraction = (value % 1_000_000_000n).toString().padStart(9, '0').replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction}` : whole.toString();
+}

--- a/apps/desktop/src/renderer/features/billing/useBillingCheckout.ts
+++ b/apps/desktop/src/renderer/features/billing/useBillingCheckout.ts
@@ -10,7 +10,15 @@ import { billingApi } from './api';
 import { clearLegacyBillingIntentStorage, newBillingIdempotencyKey } from './checkoutIntent';
 
 export type BillingCheckoutPhase =
-  'IDLE' | 'CREATING' | 'AWAITING_PAYMENT' | 'COMPLETED' | 'FAILED' | 'EXPIRED' | 'CANCELED';
+  | 'IDLE'
+  | 'CREATING'
+  | 'AWAITING_PAYMENT'
+  | 'COMPLETED'
+  | 'FULFILLMENT_PENDING'
+  | 'FULFILLMENT_FAILED'
+  | 'FAILED'
+  | 'EXPIRED'
+  | 'CANCELED';
 
 /**
  * In-memory only. A checkout session belongs to the open dialog: closing it
@@ -46,7 +54,13 @@ function phaseForOrder(order: BillingPaymentOrder): BillingCheckoutPhase {
   if (order.status === 'FAILED') return 'FAILED';
   if (order.status === 'EXPIRED') return 'EXPIRED';
   if (order.status === 'CANCELED') return 'CANCELED';
-  if (order.status === 'SUCCEEDED') return 'COMPLETED';
+  if (order.status === 'SUCCEEDED') {
+    if (order.fulfillmentStatus === 'PENDING' || order.fulfillmentStatus === 'NOT_STARTED') {
+      return 'FULFILLMENT_PENDING';
+    }
+    if (order.fulfillmentStatus === 'FAILED') return 'FULFILLMENT_FAILED';
+    return 'COMPLETED';
+  }
   return 'AWAITING_PAYMENT';
 }
 
@@ -54,7 +68,13 @@ function phaseForSubscription(subscription: BillingSubscription): BillingCheckou
   if (subscription.status === 'INCOMPLETE') return 'AWAITING_PAYMENT';
   if (subscription.status === 'INCOMPLETE_EXPIRED') return 'EXPIRED';
   if (subscription.status === 'CANCELED') return 'CANCELED';
-  if (subscription.status === 'TRIALING' || subscription.status === 'ACTIVE') return 'COMPLETED';
+  if (subscription.status === 'TRIALING' || subscription.status === 'ACTIVE') {
+    if (subscription.entitlementStatus === 'PENDING' || subscription.entitlementStatus === 'NOT_STARTED') {
+      return 'FULFILLMENT_PENDING';
+    }
+    if (subscription.entitlementStatus === 'FAILED') return 'FULFILLMENT_FAILED';
+    return 'COMPLETED';
+  }
   return 'FAILED';
 }
 
@@ -327,7 +347,9 @@ export function useBillingCheckout(accountId: string | null) {
   }, [accountId]);
 
   useEffect(() => {
-    const shouldPoll = state.open && state.phase === 'AWAITING_PAYMENT';
+    const shouldPoll =
+      state.open &&
+      (state.phase === 'AWAITING_PAYMENT' || state.phase === 'FULFILLMENT_PENDING');
     if (!shouldPoll) return;
     const session = sessionRef.current;
     const timer = window.setInterval(() => {


### PR DESCRIPTION
## Summary

- 将设置中的「用量和消耗」升级为「订阅与充值」信息展示。
- 区分一次性充值、一次性购买与自动续费订阅，并展示套餐、周期、有效期、服务商和状态。
- 分离订阅、充值和赠送点数，披露赠送点数有效期及套餐滚存规则。
- 区分支付成功与权益发放状态，支持履约处理中/失败状态展示和轮询。
- 保持 Stripe 支付跳转的安全校验和人工打开回退路径。
- 补充 en、zh-CN、ja、ko 四种语言文案与覆盖测试。

## Issue

Closes #648

## Scope and exclusions

本 PR 仅实现 issue #648 所需的客户端订阅与充值信息披露、滚存说明和支付履约状态展示。不包含支付服务商页面重做、退款、发票/税务、TEAM/ENTERPRISE、外部 API Key/Coding Plan 授权流程或完整订单历史 UX。

## Validation

通过：

- `pnpm --filter desktop typecheck`
- Desktop billing renderer focused tests：4 个测试文件，71 个测试通过
- Main billing focused tests：4 个测试文件，102 个测试通过
- `pnpm check:i18n`
- `pnpm check:i18n-glossary`
- Changed billing files 的定向 ESLint
- `node scripts/check-dco.mjs --base origin/main`

已知限制：

- 全量 `pnpm --filter desktop lint` 仍受仓库既有的非本次改动 lint 问题影响。
- 全量 `pnpm test:unit` 在本次会话中已启动，但未取得最终汇总结果，因此不宣称全量单测通过。
- 未进行人工 Light/Dark mode 运行时视觉回归。

## Risk and rollback

- 客户端仅消费服务端已提供的套餐、能力、滚存上限和履约状态，不硬编码价格或额度。
- 缺少可信数据时使用中性/不可用状态，不推算服务端未提供的续费动作或历史用量。
- 如需回滚，可关闭此 PR或回退本 PR 提交，不涉及数据库迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)