### PR TITLE
feat(maker-core): 智能通讯录两态 system prompt 段(开=使用规范,关=可选功能告示)

### DIFF
--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -963,9 +963,11 @@ export function getMaker(): Maker {
           });
           mcpExtraArgs = cfg.extraArgs;
           mcpExtraEnv = cfg.extraEnv;
-          // 本次 spawn 配置实际应用的通讯录开关快照 —— getContactsPromptState 用它
-          // 判定「设置已改但 app-server 失效失败」的 stale 窗口(此时不注入 enabled 段)。
-          codexAppliedContactsEnabled = readContactsSettings().enabled;
+          // 本次 spawn 配置实际应用的通讯录可用性快照 —— 从返回的 cfg 本体推导,
+          // 不另读 settings: getCodexExtraSpawnConfig 是模块级缓存, 失效失败后
+          // 命中缓存返回的还是 pre-toggle 配置, 此时 live 设置读数会谎报新状态
+          // (review: 快照必须等于 applied config, 而非 applied 时刻的旁路读数)。
+          codexAppliedContactsEnabled = cfg.bridgeServerNames.includes('cindy_contacts');
         } catch (err) {
           desktopMakerLogger.error('codex MCP bridge prep failed, continuing without lizi MCP', {
             message: err instanceof Error ? err.message : String(err),

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -107,6 +107,15 @@ import {
 } from './codex-proxy-host.js';
 import { createDesktopMcpProviders } from '../mcp-integrations/mcp-providers.js';
 import { readContactsSettings } from './contacts-settings-store.js';
+
+/**
+ * 最近一次成功构建的 codex spawn 配置里, 通讯录开关的实际取值(null = 尚未
+ * spawn 过)。codex 的 MCP flags 冻结在 cached spawn 配置且 app-server 跨会话
+ * 长活 —— 开关切换后若失效失败(busy), running 实例仍是旧工具面; codex 的
+ * getContactsPromptState 用这份快照识别该 stale 窗口, 避免 prompt 指挥模型调
+ * stale 桥里不存在的工具。在 prepareCodexExtraSpawnConfig 内更新。
+ */
+let codexAppliedContactsEnabled: boolean | null = null;
 import {
   registerCustomMcpArrays,
   refreshCustomMcpProviders,
@@ -657,9 +666,13 @@ export function getMaker(): Maker {
       resolveCcDebugFile: resolveSessionCcDebugFile,
       mcpProviders: claudeMcpProviders,
       makerMemory: makerMemoryManager,
-      // 智能通讯录两态 prompt 段的开关快照来源(session start 求值一次), 与
-      // mcp-providers.ts 的 contacts.isEnabled 同一读数, 保证工具面与 prompt 不分叉。
-      isContactsEnabled: () => readContactsSettings().enabled,
+      // 智能通讯录 prompt 段的「本会话有效状态」: 与 mcp-providers.ts 的 provider
+      // 包装同一判定链(PluginRegistry 工作区/用户覆盖 → 全局开关), 保证工具面与
+      // prompt 不分叉; agent 侧对 enabled 还会与实际注册的 server 集合取交。
+      getContactsPromptState: ({ workingDir }) => {
+        if (!getPluginRegistry().isEnabled('contacts', workingDir)) return 'unavailable';
+        return readContactsSettings().enabled ? 'enabled' : 'disabled';
+      },
       // 第一方只读工具走 SDK allowedTools, 避免 auto 模式为 discovery/read-only
       // 操作额外调用远程安全分类器; 列表按精确工具名维护, 不放行动态 call_tool。
       claudeAllowedTools: getDesktopClaudeReadOnlyAllowedTools(),
@@ -887,8 +900,17 @@ export function getMaker(): Maker {
       // 起 streamable-HTTP bridge 把 instance 通过 -c 'mcp_servers...=...' 注入。
       mcpProviders: codexMcpProviders,
       makerMemory: makerMemoryManager,
-      // 同 claude 侧: 通讯录两态 prompt 段的开关快照(session start 求值一次)。
-      isContactsEnabled: () => readContactsSettings().enabled,
+      // 通讯录 prompt 段有效状态(codex 版): 在 claude 的判定链之上再与「实际应用
+      // 到 running app-server 的 spawn 快照」对齐 —— 开关切换后失效失败(busy,
+      // contacts-ipc 折成 codexMcpRefreshed:false)时 stale 桥里没有新工具面,
+      // live=开 / applied=关 → unavailable(静默), 直到重建成功快照跟上。
+      getContactsPromptState: ({ workingDir }) => {
+        if (!getPluginRegistry().isEnabled('contacts', workingDir)) return 'unavailable';
+        const live = readContactsSettings().enabled;
+        if (!live) return 'disabled';
+        const applied = codexAppliedContactsEnabled ?? live;
+        return applied ? 'enabled' : 'unavailable';
+      },
       // 模型清单 SSoT = 目录（providers.json，OSS 运行时真源 / bundled 兜底）。maker-core 的
       // CODEX_MODELS 已删、availableModels 起始为空；host 从账号可选目录派生 codex 列表注入
       // （gpt 原生 + codex/ 折扣网关路由）。「折扣GPT」codex/ 仍是「XD 网关来源」,渲染层按
@@ -941,10 +963,15 @@ export function getMaker(): Maker {
           });
           mcpExtraArgs = cfg.extraArgs;
           mcpExtraEnv = cfg.extraEnv;
+          // 本次 spawn 配置实际应用的通讯录开关快照 —— getContactsPromptState 用它
+          // 判定「设置已改但 app-server 失效失败」的 stale 窗口(此时不注入 enabled 段)。
+          codexAppliedContactsEnabled = readContactsSettings().enabled;
         } catch (err) {
           desktopMakerLogger.error('codex MCP bridge prep failed, continuing without lizi MCP', {
             message: err instanceof Error ? err.message : String(err),
           });
+          // bridge 整体缺席 = cindy_contacts 必然不可达
+          codexAppliedContactsEnabled = false;
         }
         // API 模式: 追加 model_provider override, 让 codex app-server 走 AI Gateway
         // 而非 OAuth 订阅后端。每次 createHost 都现读 mode, 切模式后重建即生效。

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -106,6 +106,7 @@ import {
   unregister as unregisterCodexProxyPrompt,
 } from './codex-proxy-host.js';
 import { createDesktopMcpProviders } from '../mcp-integrations/mcp-providers.js';
+import { readContactsSettings } from './contacts-settings-store.js';
 import {
   registerCustomMcpArrays,
   refreshCustomMcpProviders,
@@ -656,6 +657,9 @@ export function getMaker(): Maker {
       resolveCcDebugFile: resolveSessionCcDebugFile,
       mcpProviders: claudeMcpProviders,
       makerMemory: makerMemoryManager,
+      // 智能通讯录两态 prompt 段的开关快照来源(session start 求值一次), 与
+      // mcp-providers.ts 的 contacts.isEnabled 同一读数, 保证工具面与 prompt 不分叉。
+      isContactsEnabled: () => readContactsSettings().enabled,
       // 第一方只读工具走 SDK allowedTools, 避免 auto 模式为 discovery/read-only
       // 操作额外调用远程安全分类器; 列表按精确工具名维护, 不放行动态 call_tool。
       claudeAllowedTools: getDesktopClaudeReadOnlyAllowedTools(),
@@ -883,6 +887,8 @@ export function getMaker(): Maker {
       // 起 streamable-HTTP bridge 把 instance 通过 -c 'mcp_servers...=...' 注入。
       mcpProviders: codexMcpProviders,
       makerMemory: makerMemoryManager,
+      // 同 claude 侧: 通讯录两态 prompt 段的开关快照(session start 求值一次)。
+      isContactsEnabled: () => readContactsSettings().enabled,
       // 模型清单 SSoT = 目录（providers.json，OSS 运行时真源 / bundled 兜底）。maker-core 的
       // CODEX_MODELS 已删、availableModels 起始为空；host 从账号可选目录派生 codex 列表注入
       // （gpt 原生 + codex/ 折扣网关路由）。「折扣GPT」codex/ 仍是「XD 网关来源」,渲染层按

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -59,7 +59,7 @@ translator、event loop、model 映射、usage 计量这些路径上的改动，
 
 命中依赖**请求前缀逐字节稳定**。system prompt 由多段按固定顺序拼接（SDK preset →
 `MAKER_SYSTEM_PROMPT_APPEND` → makerMemoryRules → contactsRules（智能通讯录两态段，
-session 启动时按开关快照求值一次）→ host `runtimeConfig.systemPrompt` →
+与同一次 build 的 MCP 注册同点求值、单次 build 内恒定；remote 会话缺省）→ host `runtimeConfig.systemPrompt` →
 per-workdir MEMORY.md index 快照 → per-call userPrompt，见 `claude-code/index.ts`）。禁止：
 
 - 往稳定前缀里塞每轮都变的内容（时间戳、随机文案、易变计数器）；随机／易变内容只能

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -58,7 +58,8 @@ translator、event loop、model 映射、usage 计量这些路径上的改动，
 ### 3.1 缓存率（Anthropic prompt cache）
 
 命中依赖**请求前缀逐字节稳定**。system prompt 由多段按固定顺序拼接（SDK preset →
-`MAKER_SYSTEM_PROMPT_APPEND` → makerMemoryRules → host `runtimeConfig.systemPrompt` →
+`MAKER_SYSTEM_PROMPT_APPEND` → makerMemoryRules → contactsRules（智能通讯录两态段，
+session 启动时按开关快照求值一次）→ host `runtimeConfig.systemPrompt` →
 per-workdir MEMORY.md index 快照 → per-call userPrompt，见 `claude-code/index.ts`）。禁止：
 
 - 往稳定前缀里塞每轮都变的内容（时间戳、随机文案、易变计数器）；随机／易变内容只能

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -30,6 +30,7 @@ import type { AgentKind, Effort, PermissionMode, ReasoningDisplay, UserMessage, 
 import type { Capabilities, EffortDescriptor, ModelDescriptor } from '../types/capabilities.js';
 import { NotSupportedError } from '../types/capabilities.js';
 import type { AgentCredentialMode, AuthLoginOptions } from '../interfaces/auth-adapter.js';
+import type { ContactsPromptState } from '../contacts/system-prompt.js';
 import type {
   MemoryStatus,
   MemorySetResult,
@@ -306,19 +307,22 @@ export interface AgentDeps {
   makerMemory?: MakerMemoryManager;
 
   /**
-   * 智能通讯录开关读取 (host 注入, desktop = readContactsSettings().enabled)。
-   * 决定注入哪段 contacts prompt(开 = 使用规范, 关 = 可选功能告示, 见
-   * contacts/system-prompt.ts)。求值时机与 MCP 工具注册对齐, 保证 prompt 状态
-   * 与 cindy_contacts 工具可用性不分叉:
+   * 智能通讯录「本会话有效状态」(host 注入)。决定注入哪段 contacts prompt
+   * (enabled = 使用规范, disabled = 可选功能告示, unavailable = 不注入, 语义见
+   * contacts/system-prompt.ts 的 ContactsPromptState)。host 必须按**有效策略**
+   * 计算, 不能只读全局开关: desktop 侧 = 全局开关 ∧ PluginRegistry 的
+   * 工作区/用户覆盖(workingDir 传入即为此), codex 侧还要与实际应用到 running
+   * app-server 的 spawn 快照对齐(失效失败时 stale 配置里没有新工具面)。
+   * 求值时机与 MCP 工具注册对齐, 保证 prompt 状态与工具可用性不分叉:
    *  - claude-code: 每次 buildQuery(含 rewind/fresh 重建)与 buildMcpServers
-   *    同点求值; 单次 build 内恒定, 前缀缓存不受影响。
-   *  - codex: session 启动求值一次(MCP flags 冻结在 spawn 配置, 开关变更由
-   *    host 的 app-server 失效机制兜底, 新 thread 整体按新状态重建)。
+   *    同点求值, enabled 还会与本次 build 实际注册的 server 集合取交;
+   *    单次 build 内恒定, 前缀缓存不受影响。
+   *  - codex: session 启动求值一次(MCP flags 冻结在 spawn 配置)。
    * remote 会话两端都不注入(cindy_contacts 不随远端转发)。
    *
    * 缺省 / undefined → 两段都不注入 (host 未接线, 与改造前行为一致)。
    */
-  isContactsEnabled?: () => boolean;
+  getContactsPromptState?: (ctx: { workingDir?: string }) => ContactsPromptState;
 
   /**
    * Host-side MCP approval policy, shared by **both** agents. `auto-approve`

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -306,11 +306,15 @@ export interface AgentDeps {
   makerMemory?: MakerMemoryManager;
 
   /**
-   * 智能通讯录开关快照 (host 注入, desktop = readContactsSettings().enabled)。
-   * startSession 时求值一次决定注入哪段 contacts prompt(开 = 使用规范,
-   * 关 = 可选功能告示, 见 contacts/system-prompt.ts), 会话内不再重读 —
-   * 与 MCP provider isEnabled 的 session-start 评估语义一致, 保证同一会话里
-   * prompt 状态与 cindy_contacts 工具可用性不分叉, 也不破坏前缀缓存稳定性。
+   * 智能通讯录开关读取 (host 注入, desktop = readContactsSettings().enabled)。
+   * 决定注入哪段 contacts prompt(开 = 使用规范, 关 = 可选功能告示, 见
+   * contacts/system-prompt.ts)。求值时机与 MCP 工具注册对齐, 保证 prompt 状态
+   * 与 cindy_contacts 工具可用性不分叉:
+   *  - claude-code: 每次 buildQuery(含 rewind/fresh 重建)与 buildMcpServers
+   *    同点求值; 单次 build 内恒定, 前缀缓存不受影响。
+   *  - codex: session 启动求值一次(MCP flags 冻结在 spawn 配置, 开关变更由
+   *    host 的 app-server 失效机制兜底, 新 thread 整体按新状态重建)。
+   * remote 会话两端都不注入(cindy_contacts 不随远端转发)。
    *
    * 缺省 / undefined → 两段都不注入 (host 未接线, 与改造前行为一致)。
    */

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -306,6 +306,17 @@ export interface AgentDeps {
   makerMemory?: MakerMemoryManager;
 
   /**
+   * 智能通讯录开关快照 (host 注入, desktop = readContactsSettings().enabled)。
+   * startSession 时求值一次决定注入哪段 contacts prompt(开 = 使用规范,
+   * 关 = 可选功能告示, 见 contacts/system-prompt.ts), 会话内不再重读 —
+   * 与 MCP provider isEnabled 的 session-start 评估语义一致, 保证同一会话里
+   * prompt 状态与 cindy_contacts 工具可用性不分叉, 也不破坏前缀缓存稳定性。
+   *
+   * 缺省 / undefined → 两段都不注入 (host 未接线, 与改造前行为一致)。
+   */
+  isContactsEnabled?: () => boolean;
+
+  /**
    * Host-side MCP approval policy, shared by **both** agents. `auto-approve`
    * skips the permission prompt; `prompt` preserves the normal approval UI and
    * its optional session grant; `prompt-each-time` always asks and never

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -53,6 +53,10 @@ import {
 } from '../base-agent.js';
 import { SYSTEM_PROMPT_APPEND as MAKER_SYSTEM_PROMPT_APPEND } from './system-prompt-append.js';
 import { MAKER_MEMORY_RULES } from '../../memory/system-prompt.js';
+import {
+  CONTACTS_RULES_DISABLED,
+  CONTACTS_RULES_ENABLED,
+} from '../../contacts/system-prompt.js';
 import { MemoryFlushController } from '../../memory/flush-controller.js';
 import { buildMemoryScopeKey } from '../../memory/storage.js';
 import type {
@@ -955,6 +959,15 @@ export class ClaudeCodeAgent extends BaseAgent {
         });
       }
     }
+
+    // ── 智能通讯录 prompt 段: 开关在 session 启动时求值一次(两态), host 未注入
+    // isContactsEnabled 则整段缺省 — 语义与 makerMemoryRules 同(会话内恒定,
+    // 不破坏前缀缓存; 详见 contacts/system-prompt.ts)。
+    const contactsRules = this.deps.isContactsEnabled
+      ? this.deps.isContactsEnabled()
+        ? CONTACTS_RULES_ENABLED
+        : CONTACTS_RULES_DISABLED
+      : '';
 
     const mcpProviders = this.deps.mcpProviders ?? [];
     // host-owned 只读白名单在 session 启动时快照; 与 hooks / MCP 注册同样保持整条
@@ -1921,6 +1934,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             const appendText = [
               MAKER_SYSTEM_PROMPT_APPEND,
               makerMemoryRules,
+              contactsRules,
               hostSystemPrompt,
               makerMemoryIndex,
               opts.userPrompt,
@@ -2220,16 +2234,19 @@ export class ClaudeCodeAgent extends BaseAgent {
           //   [2] MAKER_SYSTEM_PROMPT_APPEND — maker engine (system-prompt-append.md)
           //   [3] makerMemoryRules           — maker memory 写入规范 (条件式: makerMemoryEnabled
           //                                    且 manager 注入成功才注入)
-          //   [4] hostSystemPrompt           — host runtime (runtimeConfig.systemPrompt)
-          //   [5] makerMemoryIndex           — 当前 workdir MEMORY.md 内容 (条件式, 紧邻 userPrompt
+          //   [4] contactsRules              — 智能通讯录两态段 (条件式: host 注入了
+          //                                    isContactsEnabled 才有, 开/关各一份静态文案)
+          //   [5] hostSystemPrompt           — host runtime (runtimeConfig.systemPrompt)
+          //   [6] makerMemoryIndex           — 当前 workdir MEMORY.md 内容 (条件式, 紧邻 userPrompt
           //                                    高优先级, 启动时快照 — 跟 userPrompt 同语义)
-          //   [6] opts.userPrompt            — per-call 用户级 (renderer 本地 storage,
+          //   [7] opts.userPrompt            — per-call 用户级 (renderer 本地 storage,
           //                                    每次 startSession 透传, 优先级最高)
           // 空段被 .filter 跳过 (.md 文件为空 / userPrompt 为空 = 不 append).
           systemPrompt: (() => {
             const appendText = [
               MAKER_SYSTEM_PROMPT_APPEND,
               makerMemoryRules,
+              contactsRules,
               hostSystemPrompt,
               makerMemoryIndex,
               opts.userPrompt,

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -960,15 +960,6 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
     }
 
-    // ── 智能通讯录 prompt 段: 开关在 session 启动时求值一次(两态), host 未注入
-    // isContactsEnabled 则整段缺省 — 语义与 makerMemoryRules 同(会话内恒定,
-    // 不破坏前缀缓存; 详见 contacts/system-prompt.ts)。
-    const contactsRules = this.deps.isContactsEnabled
-      ? this.deps.isContactsEnabled()
-        ? CONTACTS_RULES_ENABLED
-        : CONTACTS_RULES_DISABLED
-      : '';
-
     const mcpProviders = this.deps.mcpProviders ?? [];
     // host-owned 只读白名单在 session 启动时快照; 与 hooks / MCP 注册同样保持整条
     // 会话稳定, 避免中途改数组导致 CLI 权限规则与 prompt cache 前缀漂移。
@@ -1822,6 +1813,18 @@ export class ClaudeCodeAgent extends BaseAgent {
     }): Promise<Query> => {
       const currentSdkModel = sdkModelFor(mutableModel);
       const currentSdkEffort = getSdkEffortForModel(mutableModel, mutableEffort);
+      // ── 智能通讯录两态段: 与 buildMcpServers 同点求值 —— rewind/fresh 重建时
+      // prompt 状态与 cindy_contacts 工具注册读同一份当前设置, 不分叉(否则中途
+      // 切开关再 rewind, prompt 会指挥模型用已移除的工具)。同一次 build 内只读
+      // 一次, 未 rewind 的会话与启动时快照语义等价, 前缀缓存不受影响。
+      // remote 会话不注入: in-process cindy_contacts 不随远端转发(过桥白名单只有
+      // collaboration/memory), 注入只会引导模型调不存在的工具。
+      const contactsRules =
+        opts.remoteHostId || !this.deps.isContactsEnabled
+          ? ''
+          : this.deps.isContactsEnabled()
+            ? CONTACTS_RULES_ENABLED
+            : CONTACTS_RULES_DISABLED;
       const baseResumeAt = vo.resumeSessionAt as string | undefined;
       const baseFork = vo.forkSession as boolean | undefined;
       const finalResumeAt = extra?.fresh ? undefined : (extra?.resumeSessionAt ?? baseResumeAt);
@@ -2229,7 +2232,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           includePartialMessages: true,
           ...thinkingOpts,
           pathToClaudeCodeExecutable: binaryPath,
-          // systemPrompt 六段拼接 — SDK 先输出 preset, 再追加 append 字段。
+          // systemPrompt 七段拼接(含 SDK 内嵌 preset)— SDK 先输出 preset, 再追加 append 字段。
           //   [1] cc preset                  — Claude SDK 自带 (内嵌不可见)
           //   [2] MAKER_SYSTEM_PROMPT_APPEND — maker engine (system-prompt-append.md)
           //   [3] makerMemoryRules           — maker memory 写入规范 (条件式: makerMemoryEnabled

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1813,23 +1813,24 @@ export class ClaudeCodeAgent extends BaseAgent {
     }): Promise<Query> => {
       const currentSdkModel = sdkModelFor(mutableModel);
       const currentSdkEffort = getSdkEffortForModel(mutableModel, mutableEffort);
-      // ── 智能通讯录两态段: 与 buildMcpServers 同点求值 —— rewind/fresh 重建时
-      // prompt 状态与 cindy_contacts 工具注册读同一份当前设置, 不分叉(否则中途
-      // 切开关再 rewind, prompt 会指挥模型用已移除的工具)。同一次 build 内只读
-      // 一次, 未 rewind 的会话与启动时快照语义等价, 前缀缓存不受影响。
-      // remote 会话不注入: in-process cindy_contacts 不随远端转发(过桥白名单只有
-      // collaboration/memory), 注入只会引导模型调不存在的工具。
-      const contactsRules =
-        opts.remoteHostId || !this.deps.isContactsEnabled
-          ? ''
-          : this.deps.isContactsEnabled()
-            ? CONTACTS_RULES_ENABLED
-            : CONTACTS_RULES_DISABLED;
       const baseResumeAt = vo.resumeSessionAt as string | undefined;
       const baseFork = vo.forkSession as boolean | undefined;
       const finalResumeAt = extra?.fresh ? undefined : (extra?.resumeSessionAt ?? baseResumeAt);
       const finalFork = extra?.fresh ? false : (extra?.forkSession ?? baseFork);
       const mcpServers = buildMcpServers();
+      // ── 智能通讯录两态段: 紧跟 buildMcpServers 求值, prompt 状态与本次 build
+      // 实际生效的工具面对齐(rewind/fresh 重建同步跟随), 三种去向:
+      //   host 有效状态 enabled 且 cindy_contacts 真的注册了 → 使用规范段;
+      //   disabled(功能未开) → 可选功能告示段(邀请开启);
+      //   其余(unavailable/工作区覆盖禁用/注册被跳过/remote/未接线) → 不注入 —
+      //   既不指挥模型调不可达工具, 也不邀请用户去开一个已开着的开关。
+      const contactsRules = (() => {
+        if (opts.remoteHostId) return '';
+        const state = this.deps.getContactsPromptState?.({ workingDir: opts.workingDir });
+        if (state === 'disabled') return CONTACTS_RULES_DISABLED;
+        if (state !== 'enabled') return '';
+        return registeredMcpServerNames.has('cindy_contacts') ? CONTACTS_RULES_ENABLED : '';
+      })();
       // resume 优先用当前的 sdkSessionId (rewind 重启时它指向上一轮 SDK 给的 id);
       // 缺省回到 startSession 入参的 resumeSessionId (新会话首次起 query 时用)。
       let resumeSdkSid = sdkSessionId ?? configuredResumeSessionId;
@@ -2238,7 +2239,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           //   [3] makerMemoryRules           — maker memory 写入规范 (条件式: makerMemoryEnabled
           //                                    且 manager 注入成功才注入)
           //   [4] contactsRules              — 智能通讯录两态段 (条件式: host 注入了
-          //                                    isContactsEnabled 才有, 开/关各一份静态文案)
+          //                                    getContactsPromptState 才有, 开/关各一份静态文案)
           //   [5] hostSystemPrompt           — host runtime (runtimeConfig.systemPrompt)
           //   [6] makerMemoryIndex           — 当前 workdir MEMORY.md 内容 (条件式, 紧邻 userPrompt
           //                                    高优先级, 启动时快照 — 跟 userPrompt 同语义)

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2964,18 +2964,20 @@ export class CodexAgent extends BaseAgent {
         resumeSessionId: opts.resumeSessionId,
       });
     }
-    // 智能通讯录两态段: session 启动求值一次, host 未注入 isContactsEnabled 则缺省。
-    // remote 会话不注入: 远端 spawn 不带本地 MCP flags、托管 allowlist 只有
-    // collaboration/memory, cindy_contacts 不可达, 注入只会引导模型调不存在的工具。
-    // 本地会话中途切开关的一致性由 host 侧 app-server 失效机制兜底(contacts-ipc):
-    // MCP flags 冻结在 spawn 配置, 开关变更 → 失效 app-server → 新 thread 重建时
-    // 本段与工具面一起按新状态生成。
+    // 智能通讯录两态段: session 启动求值一次, host 未注入 getContactsPromptState
+    // 则缺省。remote 会话不注入(远端 spawn 无本地 MCP flags, cindy_contacts 不可达)。
+    // host 的有效状态计算已含: 全局开关 ∧ 工作区/用户覆盖 ∧ 实际应用到 running
+    // app-server 的 spawn 快照(失效失败留下 stale 配置时返回 unavailable, 本段
+    // 静默, 不指挥模型调 stale 桥里没有的工具)。
+    const contactsState = opts.remoteHostId
+      ? undefined
+      : this.deps.getContactsPromptState?.({ workingDir: opts.workingDir });
     const contactsRules =
-      opts.remoteHostId || !this.deps.isContactsEnabled
-        ? ''
-        : this.deps.isContactsEnabled()
-          ? CONTACTS_RULES_ENABLED
-          : CONTACTS_RULES_DISABLED;
+      contactsState === 'enabled'
+        ? CONTACTS_RULES_ENABLED
+        : contactsState === 'disabled'
+          ? CONTACTS_RULES_DISABLED
+          : '';
     const developerInstructions = buildCodexDeveloperInstructions({
       makerMemoryRules,
       contactsRules,
@@ -3102,7 +3104,7 @@ export class CodexAgent extends BaseAgent {
       //   [2] MAKER_CODEX_SYSTEM_PROMPT_APPEND — maker engine (system-prompt-append.md)
       //   [3] makerMemoryRules                 — maker memory 写入规范 (条件式)
       //   [4] contactsRules                    — 智能通讯录两态段 (条件式: host 注入
-      //                                          isContactsEnabled 才有)
+      //                                          getContactsPromptState 才有)
       //   [5] runtimeConfig.systemPrompt       — host runtime (host 维护的 .md)
       //   [6] makerMemoryIndex                 — 当前 workdir MEMORY.md 内容 (条件式,
       //                                          紧邻 userPrompt 高优先级, 启动时快照)

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -109,6 +109,10 @@ import { createStdioTransport } from './app-server/stdioTransport.js';
 import { CodexInteractionBroker } from './interaction-broker.js';
 import { SYSTEM_PROMPT_APPEND as MAKER_CODEX_SYSTEM_PROMPT_APPEND } from './system-prompt-append.js';
 import { MAKER_MEMORY_RULES } from '../../memory/system-prompt.js';
+import {
+  CONTACTS_RULES_DISABLED,
+  CONTACTS_RULES_ENABLED,
+} from '../../contacts/system-prompt.js';
 import { MemoryFlushController } from '../../memory/flush-controller.js';
 import { buildMemoryScopeKey } from '../../memory/storage.js';
 import { CODEX_AGENT_COMMANDS } from './commands.js';
@@ -257,6 +261,7 @@ function hasUnsafeForkRolloutPayload(line: string): boolean {
 
 function buildCodexDeveloperInstructions(parts: {
   makerMemoryRules?: string;
+  contactsRules?: string;
   runtimeSystemPrompt?: string;
   makerMemoryIndex?: string;
   userPrompt?: string;
@@ -264,6 +269,7 @@ function buildCodexDeveloperInstructions(parts: {
   return [
     MAKER_CODEX_SYSTEM_PROMPT_APPEND,
     parts.makerMemoryRules,
+    parts.contactsRules,
     parts.runtimeSystemPrompt,
     parts.makerMemoryIndex,
     parts.userPrompt,
@@ -2958,8 +2964,16 @@ export class CodexAgent extends BaseAgent {
         resumeSessionId: opts.resumeSessionId,
       });
     }
+    // 智能通讯录两态段: session 启动求值一次, host 未注入 isContactsEnabled 则缺省。
+    // 语义与 claude-code 端一致(contacts/system-prompt.ts)。
+    const contactsRules = this.deps.isContactsEnabled
+      ? this.deps.isContactsEnabled()
+        ? CONTACTS_RULES_ENABLED
+        : CONTACTS_RULES_DISABLED
+      : '';
     const developerInstructions = buildCodexDeveloperInstructions({
       makerMemoryRules,
+      contactsRules,
       runtimeSystemPrompt: this.deps.runtimeConfig.systemPrompt,
       makerMemoryIndex,
       userPrompt: opts.userPrompt,
@@ -3079,15 +3093,17 @@ export class CodexAgent extends BaseAgent {
         throw new Error(message);
       }
     } else {
-      // developerInstructions 五段拼接 (协议见 thread/start.developerInstructions):
+      // developerInstructions 六段拼接 (协议见 thread/start.developerInstructions):
       //   [2] MAKER_CODEX_SYSTEM_PROMPT_APPEND — maker engine (system-prompt-append.md)
       //   [3] makerMemoryRules                 — maker memory 写入规范 (条件式)
-      //   [4] runtimeConfig.systemPrompt       — host runtime (host 维护的 .md)
-      //   [5] makerMemoryIndex                 — 当前 workdir MEMORY.md 内容 (条件式,
+      //   [4] contactsRules                    — 智能通讯录两态段 (条件式: host 注入
+      //                                          isContactsEnabled 才有)
+      //   [5] runtimeConfig.systemPrompt       — host runtime (host 维护的 .md)
+      //   [6] makerMemoryIndex                 — 当前 workdir MEMORY.md 内容 (条件式,
       //                                          紧邻 userPrompt 高优先级, 启动时快照)
-      //   [6] opts.userPrompt                  — per-call 用户级 (renderer 本地 storage,
+      //   [7] opts.userPrompt                  — per-call 用户级 (renderer 本地 storage,
       //                                          每次 startSession 透传, 优先级最高)
-      // 跟 claude-code 六段语义对齐。空段被 .filter 跳过,
+      // 跟 claude-code 七段语义对齐。空段被 .filter 跳过,
       // 内容为空时不发送 developerInstructions 字段。
       const params: ThreadStartParams = {
         cwd: opts.workingDir,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2965,12 +2965,17 @@ export class CodexAgent extends BaseAgent {
       });
     }
     // 智能通讯录两态段: session 启动求值一次, host 未注入 isContactsEnabled 则缺省。
-    // 语义与 claude-code 端一致(contacts/system-prompt.ts)。
-    const contactsRules = this.deps.isContactsEnabled
-      ? this.deps.isContactsEnabled()
-        ? CONTACTS_RULES_ENABLED
-        : CONTACTS_RULES_DISABLED
-      : '';
+    // remote 会话不注入: 远端 spawn 不带本地 MCP flags、托管 allowlist 只有
+    // collaboration/memory, cindy_contacts 不可达, 注入只会引导模型调不存在的工具。
+    // 本地会话中途切开关的一致性由 host 侧 app-server 失效机制兜底(contacts-ipc):
+    // MCP flags 冻结在 spawn 配置, 开关变更 → 失效 app-server → 新 thread 重建时
+    // 本段与工具面一起按新状态生成。
+    const contactsRules =
+      opts.remoteHostId || !this.deps.isContactsEnabled
+        ? ''
+        : this.deps.isContactsEnabled()
+          ? CONTACTS_RULES_ENABLED
+          : CONTACTS_RULES_DISABLED;
     const developerInstructions = buildCodexDeveloperInstructions({
       makerMemoryRules,
       contactsRules,
@@ -3103,7 +3108,8 @@ export class CodexAgent extends BaseAgent {
       //                                          紧邻 userPrompt 高优先级, 启动时快照)
       //   [7] opts.userPrompt                  — per-call 用户级 (renderer 本地 storage,
       //                                          每次 startSession 透传, 优先级最高)
-      // 跟 claude-code 七段语义对齐。空段被 .filter 跳过,
+      // 段序语义与 claude-code 对齐(claude 的 [1] 是 SDK 内嵌 preset, 此处无对应段,
+      // 故编号从 [2] 起、共六段)。空段被 .filter 跳过,
       // 内容为空时不发送 developerInstructions 字段。
       const params: ThreadStartParams = {
         cwd: opts.workingDir,

--- a/packages/maker-core/src/contacts/__tests__/system-prompt.test.ts
+++ b/packages/maker-core/src/contacts/__tests__/system-prompt.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { CONTACTS_RULES_DISABLED, CONTACTS_RULES_ENABLED } from '../system-prompt.js';
+
+/**
+ * 两态 contacts prompt 段的内容契约(防文案重构时丢关键锚点):
+ *  - 开态必须指向 cindy_contacts 工具与 resolve-first / pending 语义
+ *  - 关态必须给出确切设置路径(agent 只能口头指路), 且带防唠叨约束
+ */
+describe('contacts system prompt segments', () => {
+  it('enabled 段指向工具入口与写入纪律', () => {
+    expect(CONTACTS_RULES_ENABLED).toContain('cindy_contacts');
+    expect(CONTACTS_RULES_ENABLED).toContain('contacts_resolve');
+    expect(CONTACTS_RULES_ENABLED).toContain('status:"pending"');
+  });
+
+  it('disabled 段给出设置路径与每会话至多一次的约束', () => {
+    expect(CONTACTS_RULES_DISABLED).toContain('Settings → Personalization → Smart Contacts');
+    expect(CONTACTS_RULES_DISABLED).toContain('设置 → 个性化 → 智能通讯录');
+    expect(CONTACTS_RULES_DISABLED).toContain('At most one such reminder per session');
+  });
+
+  it('两段互斥且都非空(trim 后)', () => {
+    expect(CONTACTS_RULES_ENABLED.length).toBeGreaterThan(0);
+    expect(CONTACTS_RULES_DISABLED.length).toBeGreaterThan(0);
+    expect(CONTACTS_RULES_ENABLED).not.toBe(CONTACTS_RULES_DISABLED);
+  });
+});

--- a/packages/maker-core/src/contacts/system-prompt-disabled.md
+++ b/packages/maker-core/src/contacts/system-prompt-disabled.md
@@ -1,6 +1,6 @@
 # Smart Contacts (optional feature, currently off)
 
-Cindy has an optional Smart Contacts feature, currently disabled: a local people & organization directory the agent maintains for the user — cross-platform identity resolution, relationship context, dated interaction events. Data stays on this device only and it runs on the user's own model.
+Cindy has an optional Smart Contacts feature, currently disabled: a local people & organization directory the agent maintains for the user — cross-platform identity resolution, relationship context, dated interaction events. Data is stored on this device only and lookups run through the user's own model.
 
 When one of these comes up naturally, you may remind the user once that they can enable it in Settings → Personalization → Smart Contacts (设置 → 个性化 → 智能通讯录):
 

--- a/packages/maker-core/src/contacts/system-prompt-disabled.md
+++ b/packages/maker-core/src/contacts/system-prompt-disabled.md
@@ -1,0 +1,11 @@
+# Smart Contacts (optional feature, currently off)
+
+Cindy has an optional Smart Contacts feature, currently disabled: a local people & organization directory the agent maintains for the user — cross-platform identity resolution, relationship context, dated interaction events. Data stays on this device only and it runs on the user's own model.
+
+When one of these comes up naturally, you may remind the user once that they can enable it in Settings → Personalization → Smart Contacts (设置 → 个性化 → 智能通讯录):
+
+1. Contact information appears or changes in the conversation (a new collaborator, a changed email / title / company).
+2. You retrieve content that contains contact details (mail, messages, calendar events).
+3. The user asks you to find mail from, or look up, a specific person.
+
+At most one such reminder per session. If the user declines or shows no interest, do not bring it up again — and record that preference in memory when memory is available.

--- a/packages/maker-core/src/contacts/system-prompt-enabled.md
+++ b/packages/maker-core/src/contacts/system-prompt-enabled.md
@@ -1,6 +1,6 @@
 # Smart Contacts
 
-The user has Smart Contacts enabled: a local, cross-session people & organization directory served by the `cindy_contacts` MCP server (entry tools: `list_tools` / `call_tool`). Data stays on this device only.
+The user has Smart Contacts enabled: a local, cross-session people & organization directory served by the `cindy_contacts` MCP server (entry tools: `list_tools` / `call_tool`). Profile data is stored on this device only; entries you retrieve become part of the conversation context processed by the user's configured model.
 
 - When a person or organization comes up — an unfamiliar email address or platform id, "who is this", drafting a message to someone, prepping for a meeting — resolve first: `contacts_resolve` with the identifier or name.
 - When you learn something durable about a person the user actually works or lives with (a new contact, a changed role / company / contact detail, a notable interaction), save it: create or update the profile, and append dated events for time-sensitive facts. Uncertain or low-confidence entries must go in as `status:"pending"` for the user to confirm — never silently write confirmed records.

--- a/packages/maker-core/src/contacts/system-prompt-enabled.md
+++ b/packages/maker-core/src/contacts/system-prompt-enabled.md
@@ -1,0 +1,7 @@
+# Smart Contacts
+
+The user has Smart Contacts enabled: a local, cross-session people & organization directory served by the `cindy_contacts` MCP server (entry tools: `list_tools` / `call_tool`). Data stays on this device only.
+
+- When a person or organization comes up — an unfamiliar email address or platform id, "who is this", drafting a message to someone, prepping for a meeting — resolve first: `contacts_resolve` with the identifier or name.
+- When you learn something durable about a person the user actually works or lives with (a new contact, a changed role / company / contact detail, a notable interaction), save it: create or update the profile, and append dated events for time-sensitive facts. Uncertain or low-confidence entries must go in as `status:"pending"` for the user to confirm — never silently write confirmed records.
+- Follow the collection rules returned by `list_tools` (per-category `rules` field): no profiles for one-off senders, marketing mail, or bots; resolve before create; destructive / manage operations only on explicit user instruction.

--- a/packages/maker-core/src/contacts/system-prompt.ts
+++ b/packages/maker-core/src/contacts/system-prompt.ts
@@ -10,7 +10,7 @@
  *
  * 使用方:
  *  - claude-code/index.ts startSession 拼 systemPrompt.append 时, host 注入了
- *    deps.isContactsEnabled 才注入其一(缺省 = 两段都不注入, 与改造前行为一致)
+ *    deps.getContactsPromptState 才注入(缺省 = 两段都不注入, 与改造前行为一致)
  *  - codex/index.ts 同上, 拼 developerInstructions
  *
  * 缓存约束(maker-core-and-agent-behavior.md §3.1): 开关状态与 MCP 工具注册
@@ -23,3 +23,13 @@ import disabledText from './system-prompt-disabled.md?raw';
 
 export const CONTACTS_RULES_ENABLED = enabledText.trim();
 export const CONTACTS_RULES_DISABLED = disabledText.trim();
+
+/**
+ * host 计算的「本会话有效通讯录状态」(getContactsPromptState 返回值):
+ *  - enabled     → 注入使用规范段(agent 侧还会与实际注册的工具面取交)
+ *  - disabled    → 功能未开启, 注入「可选功能告示」段(邀请用户开启)
+ *  - unavailable → 功能开着但本会话不可用(工作区/用户覆盖禁用、codex stale
+ *                  spawn 快照等) — 什么都不注入: 既不能指挥模型用不可达的工具,
+ *                  也不该邀请用户去开一个已经开着的开关。
+ */
+export type ContactsPromptState = 'enabled' | 'disabled' | 'unavailable';

--- a/packages/maker-core/src/contacts/system-prompt.ts
+++ b/packages/maker-core/src/contacts/system-prompt.ts
@@ -1,0 +1,24 @@
+/**
+ * 智能通讯录 system prompt 段 — 两态注入, 注入点紧跟 makerMemoryRules。
+ *
+ * 真正内容在同目录两个 md, vite 编译时通过 ?raw 内联为字符串:
+ *  - CONTACTS_RULES_ENABLED  (system-prompt-enabled.md): 开关开 — 使用规范
+ *    (先 resolve 再写 / pending 语义 / 服从工具层 rules), 细则仍以 cindy_contacts
+ *    工具 rules 字段为准, 本段只负责"让 agent 想起来用"。
+ *  - CONTACTS_RULES_DISABLED (system-prompt-disabled.md): 开关关 — 让 agent 知道
+ *    功能存在, 在三类场景下可提醒用户开启(每会话至多一次, 被拒不再提)。
+ *
+ * 使用方:
+ *  - claude-code/index.ts startSession 拼 systemPrompt.append 时, host 注入了
+ *    deps.isContactsEnabled 才注入其一(缺省 = 两段都不注入, 与改造前行为一致)
+ *  - codex/index.ts 同上, 拼 developerInstructions
+ *
+ * 缓存约束(maker-core-and-agent-behavior.md §3.1): 开关状态在 session 启动时
+ * 求值一次, 会话内文案恒定, 不进任何 per-turn 易变段。
+ */
+
+import enabledText from './system-prompt-enabled.md?raw';
+import disabledText from './system-prompt-disabled.md?raw';
+
+export const CONTACTS_RULES_ENABLED = enabledText.trim();
+export const CONTACTS_RULES_DISABLED = disabledText.trim();

--- a/packages/maker-core/src/contacts/system-prompt.ts
+++ b/packages/maker-core/src/contacts/system-prompt.ts
@@ -13,8 +13,9 @@
  *    deps.isContactsEnabled 才注入其一(缺省 = 两段都不注入, 与改造前行为一致)
  *  - codex/index.ts 同上, 拼 developerInstructions
  *
- * 缓存约束(maker-core-and-agent-behavior.md §3.1): 开关状态在 session 启动时
- * 求值一次, 会话内文案恒定, 不进任何 per-turn 易变段。
+ * 缓存约束(maker-core-and-agent-behavior.md §3.1): 开关状态与 MCP 工具注册
+ * 同点求值(claude 每次 buildQuery, codex 每 session 一次), 单次 build 内文案
+ * 恒定, 不进任何 per-turn 易变段; remote 会话不注入(工具不可达)。
  */
 
 import enabledText from './system-prompt-enabled.md?raw';

--- a/packages/maker-core/src/index.ts
+++ b/packages/maker-core/src/index.ts
@@ -68,7 +68,11 @@ export { MAKER_MEMORY_RULES } from './memory/system-prompt.js';
 
 // maker contacts (agent-native 智能通讯录, 全局人物实体库)
 export * from './contacts/types.js';
-export { CONTACTS_RULES_DISABLED, CONTACTS_RULES_ENABLED } from './contacts/system-prompt.js';
+export {
+  CONTACTS_RULES_DISABLED,
+  CONTACTS_RULES_ENABLED,
+  type ContactsPromptState,
+} from './contacts/system-prompt.js';
 export { initContactsSchema, CONTACTS_SCHEMA_VERSION } from './contacts/schema.js';
 export { ContactsFts, type ContactFtsDoc } from './contacts/fts.js';
 export {

--- a/packages/maker-core/src/index.ts
+++ b/packages/maker-core/src/index.ts
@@ -68,6 +68,7 @@ export { MAKER_MEMORY_RULES } from './memory/system-prompt.js';
 
 // maker contacts (agent-native 智能通讯录, 全局人物实体库)
 export * from './contacts/types.js';
+export { CONTACTS_RULES_DISABLED, CONTACTS_RULES_ENABLED } from './contacts/system-prompt.js';
 export { initContactsSchema, CONTACTS_SCHEMA_VERSION } from './contacts/schema.js';
 export { ContactsFts, type ContactFtsDoc } from './contacts/fts.js';
 export {


### PR DESCRIPTION
## 这次改了什么

### 摘要

智能通讯录此前**零 system prompt 注入**(引导只有工具描述里一句话),agent 经常想不起来用;对比 memory 有 `MAKER_MEMORY_RULES` 注入段,这是两者采用率差距的主要原因。本 PR 补上通讯录的 prompt 段,并做成**两态**:

- **开关开**(~200 token):使用规范——遇人先 `contacts_resolve`、值得记录的信息落档、低置信写 `status:"pending"`、细则服从工具层 `rules` 字段(不重复,只负责"让 agent 想起来用")。
- **开关关**(~150 token):可选功能告示——让 agent 知道功能存在,在三类场景(对话中出现联系人信息更新 / 检索到含联系人信息的内容 / 用户点名找人或搜某人邮件)下可提醒用户一句"可在 设置→个性化→智能通讯录 开启";**每会话至多提一次,被拒不再提并记入 memory**。

接线方式:`BaseAgentDeps` 新增可选 `isContactsEnabled`(host 注入,desktop = `readContactsSettings().enabled`,与 MCP provider 的 `contacts.isEnabled` 同一读数);**缺省时两段都不注入,行为与改造前逐字节一致**。claude-code(本地 sdkQuery + remote cc-manager 两处拼接)与 codex(developerInstructions)同位注入,紧跟 makerMemoryRules 段。

意图契约:目标 = 让所有会话(不改任何渠道入口)天然获得通讯录感知;非目标 = 不改变开关语义、不新增工具、不做自动采集管道。

**system prompt 改动门禁(§4)**:本改动由仓库维护者 @zqchris 在会话中明确提出并逐字审定两态文案后实施("你也可以直接把这个'智能通讯录'的功能写在 system prompt 里面,作为一个可选功能"+ 三类触发场景由维护者本人给出),system prompt 改动已确认。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：智能通讯录采用性系列第 2 片(第 1 片 #1066,互相独立可合)
- 本 PR 包含：contacts 两态 prompt 模块、BaseAgentDeps 可选字段、两 agent 注入点、desktop host 接线、规则文档拼接顺序同步、内容契约单测
- 明确不包含：任何渠道级 prompt 定制(Telegram bot 等另行处理)、自动采集/定时任务、工具面变化
- 用户可见变化：开启通讯录的用户,agent 会更主动地反查/沉淀联系人;未开启的用户,agent 在相关场景会提一次可开启(每会话至多一次)
- 是否存在 breaking change：无(可选 deps 字段,缺省即旧行为)

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit(清除 CLAUDE* 环境变量)
结果:54 PASS / 0 FAIL(含新增 contacts/system-prompt 内容契约测试 3 例)

pnpm --filter desktop run typecheck
结果:通过

pnpm --filter @cindy/maker-core exec vitest run
结果:56 文件 990 用例全过

maker-core tsc --noEmit:38 处既有错误(全部位于 codex/index.test.ts,纯净 main 上
同样 38 处,本 PR 零新增;对比命令:两侧 `npx tsc --noEmit | grep -c "error TS"`)
```

### 核心指标评估(maker-core-and-agent-behavior.md §3.4)

- **可能影响的指标**:缓存率(§3.1,prompt 组装路径)。
- **评估方法与结论**:`isContactsEnabled` 在 startSession 顶层求值一次存入 `const`,claude 两处拼接与 codex 三处 developerInstructions 使用点均复用同一快照(rewind/fork 重建走同一闭包变量),会话内前缀逐字节恒定——与 makerMemoryRules 完全同构,新段为静态文案、无任何 per-turn 易变内容。拼接顺序变化只影响跨版本(部署后首个会话),与既有任何 prompt 文案改动同性质。热路径(§3.2)零触及:求值点在 session 启动,不在 event loop / translator。
- **未执行的实测**:未做真实会话的缓存命中率前后对比(需 live API 会话);风险面已被"同构于 makerMemoryRules + 单次求值 + const 快照"的静态论证覆盖,如需实测可在合并后用 usage-tracker 的 per-turn 命中率抽查。

### 手工验证

不涉及 UI。行为验证建议:开/关通讯录开关各起一个新会话,`/context` 或调试日志确认 system 段分别含 "Smart Contacts" 使用规范/告示段;关态会话中让 agent 查某个联系人邮件,应出现一次开启提醒且同会话不重复。

### 未执行的验证

live 会话实测(开/关两态的实际提醒行为、缓存命中率对比)未做——需要真实模型会话;验证步骤已在上方给出。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] system prompt
- [ ] 其他：

### 影响与回滚

- 影响范围:所有 desktop 会话的 system 段末尾多一小段静态文案(开态 ~200 / 关态 ~150 token);host 未接线的运行时(如 mobile 直连路径)零变化。
- 回滚方式:revert 单 commit;或 host 侧摘掉 isContactsEnabled 注入即恢复零注入。
