### PR TITLE
fix(mobile): keep PDF preview gestures inside WebView

### DIFF
--- a/apps/mobile/app/files/preview/[sessionId].tsx
+++ b/apps/mobile/app/files/preview/[sessionId].tsx
@@ -2,7 +2,11 @@
  * 远程文件 Quick Look 预览。
  *
  * 同目录文件横滑翻页(iOS Quick Look 心智):进入时列一次父目录,把全部文件
- * (含不可预览的,显示占位页)按浏览页同款排序装进水平 pager。
+ * (含不可预览的,显示占位页)按浏览页同款排序装进水平 pager。PDF 例外:
+ * 预览期间禁用外层横滑,把缩放后的水平拖动完整留给 WKWebView,避免 pager
+ * 抢手势后切换文件;PDF cell 离开渲染窗口时可能被回收,进而重置阅读位置
+ * 或再次加载 URL。
+ * 切换文件通过 Done 返回列表完成。
  * 文本 = readFile(acceptGzip,pako 解码)+ 行号列表;图片 = 缩略图立即显示,
  * OSS 导出原图就绪后无缝换源(不出 loading 态,规则 7);其它 = 占位 + 下载。
  *
@@ -156,8 +160,9 @@ export default function RemoteFilePreviewScreen() {
   // 熔断恢复代数(review P1):open→closed 翻转沿 +1。仅重试 getSession 不够——
   // 会话已缓存时,同目录 pager 可能已退化成单文件、文本/PDF/音视频子页已落进
   // 失败态,而子页用 requestedRef/loadedRef 防重复请求,失败后绝不自行重试。
-  // 代数驱动两件事:pager effect 重列目录;FlatList key 掺入代数让预览子页
-  // 整体重挂载(refs 归零、重新拉取)。翻转沿极少发生,重挂载代价可接受。
+  // 代数驱动两件事:pager effect 重列目录;非 PDF 子页通过 FlatList key 整体
+  // 重挂载(refs 归零、重新拉取)。PDF 保持已加载 WebView 的稳定 key,仅在
+  // 上次导出失败且代数前进时由 PdfPreviewPage 原地重试,避免恢复沿重置阅读位置。
   const [recoveryEpoch, setRecoveryEpoch] = useState(0);
   const prevBreakerStateRef = useRef({ deviceId, unresponsive: deviceUnresponsive });
   useEffect(() => {
@@ -408,7 +413,9 @@ export default function RemoteFilePreviewScreen() {
         ref={pagerRef}
         horizontal
         initialScrollIndex={pageIndex}
-        keyExtractor={(item) => `${item.key}:${recoveryEpoch}`}
+        keyExtractor={(item) => (
+          item.previewKind === 'pdf' ? item.key : `${item.key}:${recoveryEpoch}`
+        )}
         onMomentumScrollEnd={(event) => {
           const next = Math.round(event.nativeEvent.contentOffset.x / pageWidth);
           if (next !== pageIndex && next >= 0 && next < siblings.length) setPageIndex(next);
@@ -442,11 +449,13 @@ export default function RemoteFilePreviewScreen() {
               }}
               readTextFile={readTextFile}
               onOpenLightbox={setLightboxUrl}
+              recoveryEpoch={recoveryEpoch}
               targetLine={item.relPath === (singleAbsPath ?? initialRelPath) ? targetLine : null}
               workdir={workdir}
             />
           </View>
         )}
+        scrollEnabled={current.previewKind !== 'pdf'}
         showsHorizontalScrollIndicator={false}
         windowSize={3}
       />
@@ -528,6 +537,7 @@ function FilePreviewPage({
   onOpenLightbox,
   onQuoteSelection,
   readTextFile,
+  recoveryEpoch,
   targetLine,
   workdir,
 }: {
@@ -540,6 +550,7 @@ function FilePreviewPage({
   /** chat-text-quote:markdown 渲染态的选中引用回调(仅文本页消费)。 */
   onQuoteSelection?: (text: string) => void;
   readTextFile(relPath: string): Promise<FileBrowserReadFileResult>;
+  recoveryEpoch: number;
   targetLine: number | null;
   workdir: string;
 }) {
@@ -557,7 +568,7 @@ function FilePreviewPage({
     );
   }
   if (item.previewKind === 'pdf') {
-    return <PdfPreviewPage active={active} exportToUrl={exportToUrl} item={item} onDownload={onDownload} workdir={workdir} />;
+    return <PdfPreviewPage active={active} exportToUrl={exportToUrl} item={item} onDownload={onDownload} recoveryEpoch={recoveryEpoch} workdir={workdir} />;
   }
   const avKind = avKindFor(item.name);
   if (avKind) {
@@ -640,12 +651,14 @@ function PdfPreviewPage({
   exportToUrl,
   item,
   onDownload,
+  recoveryEpoch,
   workdir,
 }: {
   active: boolean;
   exportToUrl(relPath: string, mtimeMs: number): Promise<string>;
   item: FileBrowserGridItem;
   onDownload(): void;
+  recoveryEpoch: number;
   workdir: string;
 }) {
   const styles = useThemedStyles(makeStyles);
@@ -653,11 +666,28 @@ function PdfPreviewPage({
   const { t } = useTranslation();
   const [url, setUrl] = useState<string | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
+  const [requestEpoch, setRequestEpoch] = useState(0);
   const requestedRef = useRef(false);
+  const latestRecoveryEpochRef = useRef(recoveryEpoch);
+  const requestedAtRecoveryEpochRef = useRef(recoveryEpoch);
+
+  useEffect(() => {
+    latestRecoveryEpochRef.current = recoveryEpoch;
+  }, [recoveryEpoch]);
+
+  // 已成功加载的 PDF 不随设备恢复沿重挂载或重新取 URL;只有上次导出失败,
+  // 且失败尝试发生在更早的恢复代数时,才清掉一次性请求门闩原地重试。
+  useEffect(() => {
+    if (!failure || requestedAtRecoveryEpochRef.current >= recoveryEpoch) return;
+    requestedRef.current = false;
+    setFailure(null);
+    setRequestEpoch((epoch) => epoch + 1);
+  }, [failure, recoveryEpoch]);
 
   useEffect(() => {
     if (!active || requestedRef.current || !workdir) return undefined;
     requestedRef.current = true;
+    requestedAtRecoveryEpochRef.current = latestRecoveryEpochRef.current;
     let cancelled = false;
     setFailure(null);
     void exportToUrl(item.relPath, item.mtimeMs)
@@ -666,19 +696,20 @@ function PdfPreviewPage({
       })
       .catch((err) => {
         if (cancelled) return;
-        // 保持 requestedRef=true:失败态由 UnsupportedPage 呈现,靠「下载原文件」
-        // 或翻页重进重试,不在 effect 里自动循环重试。
+        // 保持 requestedRef=true:失败态由 UnsupportedPage 呈现,不在当前
+        // 恢复代数里自动循环;下一次设备恢复沿重试,或离开后重新打开。
         setFailure(formatRemoteError(err));
       });
     return () => {
       cancelled = true;
     };
-  }, [active, exportToUrl, item.mtimeMs, item.relPath, workdir]);
+  }, [active, exportToUrl, item.mtimeMs, item.relPath, requestEpoch, workdir]);
+  const pdfSource = useMemo(() => (url ? { uri: url } : null), [url]);
 
   if (failure) {
     return <UnsupportedPage item={item} onDownload={onDownload} reason={t('files.preview.fetchPdfFailed', { detail: failure })} />;
   }
-  if (!url) {
+  if (!pdfSource) {
     return (
       <View style={styles.centerFill} testID="filePreview.pdfLoading">
         <ActivityIndicator color={colors.textTertiary} />
@@ -686,7 +717,7 @@ function PdfPreviewPage({
       </View>
     );
   }
-  return <WebView source={{ uri: url }} style={styles.pdfView} testID="filePreview.pdfView" />;
+  return <WebView source={pdfSource} style={styles.pdfView} testID="filePreview.pdfView" />;
 }
 
 /** 文本/代码页:readFile(acceptGzip)→ 行号列表;OVERSIZE/BINARY 退占位。 */

--- a/apps/mobile/src/__tests__/filePreviewPagerWiring.test.ts
+++ b/apps/mobile/src/__tests__/filePreviewPagerWiring.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'app/files/preview/[sessionId].tsx'),
+  'utf8',
+);
+
+describe('remote file preview pager wiring', () => {
+  it('reserves horizontal gestures for the PDF WebView', () => {
+    expect(source).toContain("scrollEnabled={current.previewKind !== 'pdf'}");
+  });
+
+  it('keeps ordinary PDF gestures out of WebView remount and reload triggers', () => {
+    expect(source).toContain("item.previewKind === 'pdf' ? item.key : `${item.key}:${recoveryEpoch}`");
+    expect(source).not.toContain('keyExtractor={(item) => `${item.key}:${pageIndex}');
+    expect(source).not.toContain('<WebView key=');
+    expect(source).toContain('const pdfSource = useMemo(() => (url ? { uri: url } : null), [url]);');
+    expect(source).toContain('<WebView source={pdfSource}');
+  });
+
+  it('retries a failed PDF after device recovery without remounting a loaded WebView', () => {
+    expect(source).toContain('requestedAtRecoveryEpochRef.current >= recoveryEpoch');
+    expect(source).toContain('setRequestEpoch((epoch) => epoch + 1)');
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复手机版 PDF 预览中，放大后横向拖动可能被外层文件 pager 抢走，导致跳回第一页、切换文件或回收 WebView 后阅读位置/远程 URL 重置的问题。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：手机版 PDF 预览手势与重载稳定性
- 本 PR 包含：PDF 预览期间禁用外层横向 pager；已加载 PDF 在设备恢复代数变化时保持稳定 key/source；仅对恢复前失败的 PDF 原地重试；新增 wiring 回归测试。
- 明确不包含：不更换 PDF SDK；不新增原生依赖；不修改服务端、缓存或协议；不改变非 PDF 预览的恢复重挂载行为。
- 用户可见变化：PDF 内放大、横向拖动和阅读位置保持稳定；文件切换通过 Done 返回文件列表完成。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及视觉样式；仅调整 PDF 预览手势归属和生命周期，不新增 UI 组件或文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/filePreviewPagerWiring.test.ts
结果：3 tests passed

pnpm --filter mobile run --if-present typecheck
结果：passed

pnpm test:unit
结果：runner 298 passed / 1 skipped；所有 required workspace passed，包含 apps/mobile unit

pnpm check:dco
结果：passed

git diff --check
结果：passed
```

### 手工验证

- iOS Simulator：XDial-P1-P2-Validation
- 当前 worktree Metro：8081，源码指纹 `xdt/auto-6a2n14@63f4e29b1`
- 使用 512,000 bytes、18 页 PDF fixture 验证了 PDF 可加载；模拟器自动化驱动无法可靠完成真实双指手势，因此第 10 页放大后左右拖动仍需人工在 Simulator 中用 Option + 鼠标完成最终验收。

### 未执行的验证

- 未完成真实双指手势的自动化压力回放，原因是当前 CUA 驱动不能稳定注入 iOS Simulator 多点触控；保留为人工验收项。
- 未验证真机与 Android；本次改动只涉及 React Native/FlatList/WebView wiring，无原生依赖或配置变更。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：仅 `apps/mobile` 的 PDF 预览 pager；非 PDF 文件维持原有水平 pager 与恢复行为。
- 回滚 / 降级方式：回滚本 PR commit `63f4e29b` 即恢复原有行为。
- Mobile runtime fingerprint：未改变，不触发冷更新。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因

审查重点：
- PDF 外层 pager 是否在当前 previewKind 为 pdf 时始终禁用，避免缩放后的横向拖动改变 pageIndex。
- recoveryEpoch 变化时，已加载 PDF 的 cell key/source 是否保持稳定；失败 PDF 是否只重试一次而不形成同代数循环。
- 手工双指验收需确认第 10 页放大后横向拖动不会跳页或重新加载。
