### PR TITLE
fix(im): 个人 Telegram 相册 in-flight 游标封顶 + 同 chat 消息保序(#1078 跟进)

### DIFF
--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -461,6 +461,47 @@ describe('TelegramIM', () => {
     expect(events[1].text).toBe('顺便再查个东西');
   });
 
+  it('相册处理(附件下载)未收口前, 持久化游标不越过相册首条 update', async () => {
+    const events: IMMessageEvent[] = [];
+    im.onMessage((e) => events.push(e));
+    await connect();
+    // 让 getFile 悬住 — 模拟 settle 已触发、附件仍在下载的处理窗口
+    let releaseGetFile!: () => void;
+    const gate = new Promise<void>((r) => (releaseGetFile = r));
+    const origCall = api.call.bind(api);
+    api.call = (async (method: string, params?: Record<string, unknown>, signal?: AbortSignal) => {
+      if (method === 'getFile') {
+        await gate;
+      }
+      return origCall(method, params, signal);
+    }) as typeof api.call;
+    const member = (messageId: number): TgUpdate => ({
+      update_id: messageId,
+      message: {
+        message_id: messageId,
+        from: { id: 111, is_bot: false, first_name: 'U' },
+        chat: { id: 111, type: 'private' },
+        date: 1_753_000_000,
+        media_group_id: 'album-cap',
+        ...(messageId === 45 ? { caption: '慢速相册' } : {}),
+        photo: [{ file_id: `f${messageId}`, file_unique_id: `u${messageId}`, width: 10, height: 10 }],
+      },
+    });
+    api.pushUpdates([member(45), member(46)]);
+    // 等 settle 触发进入下载(getFile 悬住), 此时游标不得越过 45
+    await new Promise((r) => setTimeout(r, 1400));
+    expect(events).toHaveLength(0);
+    const persistedDuring = Number((ctx.secrets.get('telegram-updates-offset') ?? ':0').split(':')[1]);
+    expect(persistedDuring).toBeLessThanOrEqual(45);
+    // 放行下载 → 相册收口 → 游标补写越过整组
+    releaseGetFile();
+    await vi.waitFor(() => expect(events).toHaveLength(1), { timeout: 4000 });
+    await vi.waitFor(() => {
+      const persisted = Number((ctx.secrets.get('telegram-updates-offset') ?? ':0').split(':')[1]);
+      expect(persisted).toBeGreaterThanOrEqual(47);
+    });
+  });
+
   it('相册(media_group)聚合为单个事件, 不各起一轮 turn', async () => {
     const events: IMMessageEvent[] = [];
     im.onMessage((e) => events.push(e));

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -438,6 +438,29 @@ describe('TelegramIM', () => {
     });
   });
 
+  it('相册 settle 期间同 chat 的后续消息保序: 先答相册再答追问', async () => {
+    const events: IMMessageEvent[] = [];
+    im.onMessage((e) => events.push(e));
+    await connect();
+    const member = (messageId: number, caption?: string): TgUpdate => ({
+      update_id: messageId,
+      message: {
+        message_id: messageId,
+        from: { id: 111, is_bot: false, first_name: 'U' },
+        chat: { id: 111, type: 'private' },
+        date: 1_753_000_000,
+        media_group_id: 'album-ord',
+        ...(caption ? { caption } : {}),
+        photo: [{ file_id: `f${messageId}`, file_unique_id: `u${messageId}`, width: 10, height: 10 }],
+      },
+    });
+    // 同一批次: 相册两张 + 紧跟的追问文本 — 追问必须排在相册事件之后
+    api.pushUpdates([member(35, '看这组图'), member(36), privateMessage('顺便再查个东西', 111, 37)]);
+    await vi.waitFor(() => expect(events).toHaveLength(2), { timeout: 5000 });
+    expect(events[0].text).toBe('看这组图');
+    expect(events[1].text).toBe('顺便再查个东西');
+  });
+
   it('相册(media_group)聚合为单个事件, 不各起一轮 turn', async () => {
     const events: IMMessageEvent[] = [];
     im.onMessage((e) => events.push(e));

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -108,7 +108,8 @@ type GroupWindowHandler = (entry: TelegramGroupWindowEntry) => void;
 /** settle 缓冲/处理中的相册(见 albumsInFlight 注释)。 */
 interface PendingAlbum {
   messages: TgMessage[];
-  timer: ReturnType<typeof setTimeout>;
+  /** settle 定时器; null = 尚未挂上(构造与 setTimeout 之间的窗口)。 */
+  timer: ReturnType<typeof setTimeout> | null;
   firstUpdateId: number;
   chatId: string;
   /** 处理收口(或被丢弃)时 resolve — 同 chat 后续消息的顺序门在等它。 */
@@ -215,6 +216,14 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   private readonly albumsInFlight = new Set<PendingAlbum>();
   /** 本连接见过的最大 offset(update_id+1) — 相册 flush 后补写持久化游标用。 */
   private lastSeenOffset = 0;
+  /**
+   * per-chat 串行处理链(chatKey → 链尾 promise): 轮询循环只做分发不等待 —
+   * 同 chat 内保序(相册门只挡自己 chat), 跨 chat 并行, 无队头阻塞
+   * (2026-07-30 #1098 review: 全局 await 会让一个 chat 的相册下载拖住全部)。
+   */
+  private readonly chatQueues = new Map<string, Promise<void>>();
+  /** 已分发未收口的 update_id — 持久化游标的低水位以它为准, 掉线不丢任何在途消息。 */
+  private readonly inflightUpdateIds = new Set<number>();
   /**
    * 待配对的回挂触发队列(laneUserId → 原生 message_id FIFO): 多条消息在上一
    * 轮还没出话时先后触发同一 lane, 各自的答案必须挂回各自的提问 — 单值会被
@@ -711,16 +720,13 @@ export class TelegramIM extends BaseIM implements ChannelIM {
           offset = Math.max(offset, update.update_id + 1);
           this.lastSeenOffset = offset;
           if (abort.signal.aborted || this.configVersion !== generation) return;
-          try {
-            await this.handleUpdate(update);
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            this.log.warn(`telegram update handling failed: ${msg}`);
-          }
+          // 只分发不等待: 处理进 per-chat 串行链, 循环立即消费下一条 —
+          // 一个 chat 的相册下载/顺序门不会拖住其它 chat(#1098 review P1/P2)。
+          this.dispatchUpdate(update, generation);
         }
-        // 持久化游标不越过仍在缓冲的相册成员: settle 窗口内断开/换 token 时,
-        // 下次连接从相册首条重放, 不丢用户的图(getUpdates 的内存 offset 照常
-        // 前进, 本连接内不重复拉取)。flush 完成后由 persistOffsetCapped 补写。
+        // 持久化游标走低水位: 不越过任何在途(分发未收口)update 与缓冲中
+        // 相册 — 各任务收口时在 finally 里自行补写(getUpdates 的内存 offset
+        // 照常前进, 本连接内不重复拉取)。
         if (updates.length > 0) this.persistOffsetCapped();
       } catch (err) {
         if (abort.signal.aborted || this.configVersion !== generation) return;
@@ -758,6 +764,36 @@ export class TelegramIM extends BaseIM implements ChannelIM {
 
   // ── update handling ────────────────────────────────────────────────────────
 
+  /**
+   * 把 update 挂进所属 chat 的串行处理链并登记在途 id。链尾即序: 同 chat
+   * 严格按到达顺序处理; 不同 chat 各自成链互不等待。收口(成功/失败/跳过)
+   * 时移除在途 id 并补写低水位游标 — 进程在任何点退出, 重启都从"最早未
+   * 完成的 update"续读, 不丢消息(at-least-once)。
+   */
+  private dispatchUpdate(update: TgUpdate, generation: number): void {
+    const chatId =
+      update.message?.chat.id ?? update.callback_query?.message?.chat.id ?? 'global';
+    const key = String(chatId);
+    this.inflightUpdateIds.add(update.update_id);
+    const prev = this.chatQueues.get(key) ?? Promise.resolve();
+    const next = prev
+      .then(async () => {
+        if (this.disposing || this.configVersion !== generation) return;
+        try {
+          await this.handleUpdate(update);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.log.warn(`telegram update handling failed: ${msg}`);
+        }
+      })
+      .finally(() => {
+        this.inflightUpdateIds.delete(update.update_id);
+        if (this.chatQueues.get(key) === next) this.chatQueues.delete(key);
+        if (!this.disposing && this.configVersion === generation) this.persistOffsetCapped();
+      });
+    this.chatQueues.set(key, next);
+  }
+
   private async handleUpdate(update: TgUpdate): Promise<void> {
     if (this.disposing) return;
     if (update.callback_query) {
@@ -778,8 +814,8 @@ export class TelegramIM extends BaseIM implements ChannelIM {
     }
 
     // 顺序门: 同 chat 有相册在 settle/处理中时, 后续消息等它收口再进 turn —
-    // 否则同批次里"相册 + 追问"会被倒序回答(review P1)。handleUpdate 在
-    // 轮询循环里被串行 await, 这里等待即全链路保序; settle 定时器照常触发。
+    // 否则"相册 + 追问"会被倒序回答。本方法跑在该 chat 自己的串行链里
+    // (dispatchUpdate), 等待只挡本 chat, 其它 chat 的链照常并行。
     const gates = [...this.albumsInFlight]
       .filter((album) => album.chatId === String(m.chat.id))
       .map((album) => album.done);
@@ -800,7 +836,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
     let album: PendingAlbum;
     if (existing && !existing.settled) {
       existing.messages.push(m);
-      clearTimeout(existing.timer);
+      if (existing.timer) clearTimeout(existing.timer);
       album = existing;
     } else {
       let resolveDone!: () => void;
@@ -809,7 +845,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       });
       album = {
         messages: [m],
-        timer: undefined as unknown as ReturnType<typeof setTimeout>,
+        timer: null,
         firstUpdateId: updateId,
         chatId: String(m.chat.id),
         done,
@@ -849,7 +885,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
 
   private clearPendingAlbums(): void {
     for (const album of this.albumsInFlight) {
-      clearTimeout(album.timer);
+      if (album.timer) clearTimeout(album.timer);
       album.resolveDone(); // 解开顺序门, 不留悬挂 await
     }
     this.pendingAlbums.clear();
@@ -1475,11 +1511,15 @@ export class TelegramIM extends BaseIM implements ChannelIM {
    * 补写时相册会重放一次, 比丢图可取。
    */
   private persistOffsetCapped(): void {
-    // 以 albumsInFlight 为准(含 settle 后仍在处理中的相册): pendingAlbums
-    // 的键在定时器触发即摘除, 只看它会在处理窗口内提前放开 cap(review P1)。
+    // 低水位 = min(在途 update, 缓冲/处理中相册的首条): 顺序门里等待的追问、
+    // 处理中的消息、settle 后仍在下载附件的相册都算未完成 — 游标一律不越过
+    // (#1098 review: 只看相册会把门里等待的追问永久跳过)。
     let floor = Number.POSITIVE_INFINITY;
     for (const album of this.albumsInFlight) {
       floor = Math.min(floor, album.firstUpdateId);
+    }
+    for (const updateId of this.inflightUpdateIds) {
+      floor = Math.min(floor, updateId);
     }
     this.persistOffset(Math.min(this.lastSeenOffset, floor));
   }

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -105,6 +105,19 @@ type CardActionHandler = (e: IMCardActionEvent) => void;
 type StatusHandler = (s: IMStatus) => void;
 type GroupWindowHandler = (entry: TelegramGroupWindowEntry) => void;
 
+/** settle 缓冲/处理中的相册(见 albumsInFlight 注释)。 */
+interface PendingAlbum {
+  messages: TgMessage[];
+  timer: ReturnType<typeof setTimeout>;
+  firstUpdateId: number;
+  chatId: string;
+  /** 处理收口(或被丢弃)时 resolve — 同 chat 后续消息的顺序门在等它。 */
+  done: Promise<void>;
+  resolveDone: () => void;
+  /** settle 定时器已触发, 不再接受追加成员。 */
+  settled: boolean;
+}
+
 /** 行为配置(设置卡可视化, 实时生效 — host 以 getter 注入, transport 每次使用时读)。 */
 export interface TelegramBehaviorConfig {
   /**
@@ -192,10 +205,14 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   private richSendDisabled = false;
   private readonly mediaDir: string;
   /** 相册聚合缓冲 — key `${chatId}:${mediaGroupId}`。 */
-  private readonly pendingAlbums = new Map<
-    string,
-    { messages: TgMessage[]; timer: ReturnType<typeof setTimeout>; firstUpdateId: number }
-  >();
+  private readonly pendingAlbums = new Map<string, PendingAlbum>();
+  /**
+   * 缓冲或处理中的相册(settle 定时器一响就从 pendingAlbums 摘键关闭追加,
+   * 但要留在这里直到 processInboundMessage 收口): 持久化游标 cap 与同
+   * chat 的顺序门都看本集合 — 摘早了, 处理途中到达的批次会把游标推过
+   * 未完成的相册(review P1)。
+   */
+  private readonly albumsInFlight = new Set<PendingAlbum>();
   /** 本连接见过的最大 offset(update_id+1) — 相册 flush 后补写持久化游标用。 */
   private lastSeenOffset = 0;
   /**
@@ -760,6 +777,18 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       return;
     }
 
+    // 顺序门: 同 chat 有相册在 settle/处理中时, 后续消息等它收口再进 turn —
+    // 否则同批次里"相册 + 追问"会被倒序回答(review P1)。handleUpdate 在
+    // 轮询循环里被串行 await, 这里等待即全链路保序; settle 定时器照常触发。
+    const gates = [...this.albumsInFlight]
+      .filter((album) => album.chatId === String(m.chat.id))
+      .map((album) => album.done);
+    if (gates.length > 0) {
+      const generation = this.configVersion;
+      await Promise.all(gates);
+      if (this.disposing || this.configVersion !== generation) return;
+    }
+
     await this.processInboundMessage(m);
   }
 
@@ -768,36 +797,63 @@ export class TelegramIM extends BaseIM implements ChannelIM {
     const key = `${m.chat.id}:${m.media_group_id}`;
     const generation = this.configVersion;
     const existing = this.pendingAlbums.get(key);
-    if (existing) {
+    let album: PendingAlbum;
+    if (existing && !existing.settled) {
       existing.messages.push(m);
       clearTimeout(existing.timer);
+      album = existing;
+    } else {
+      let resolveDone!: () => void;
+      const done = new Promise<void>((resolve) => {
+        resolveDone = resolve;
+      });
+      album = {
+        messages: [m],
+        timer: undefined as unknown as ReturnType<typeof setTimeout>,
+        firstUpdateId: updateId,
+        chatId: String(m.chat.id),
+        done,
+        resolveDone,
+        settled: false,
+      };
+      this.pendingAlbums.set(key, album);
+      this.albumsInFlight.add(album);
     }
-    const messages = existing?.messages ?? [m];
-    const firstUpdateId = existing?.firstUpdateId ?? updateId;
-    const timer = setTimeout(() => {
+    album.timer = setTimeout(() => {
+      // 关闭追加(摘 append 键), 但留在 albumsInFlight 直到处理收口 —
+      // 游标 cap 与顺序门在处理期间必须仍然生效(review P1)。
+      album.settled = true;
       this.pendingAlbums.delete(key);
-      if (this.disposing || this.configVersion !== generation) return;
+      const finish = () => {
+        this.albumsInFlight.delete(album);
+        album.resolveDone();
+        if (!this.disposing && this.configVersion === generation) this.persistOffsetCapped();
+      };
+      if (this.disposing || this.configVersion !== generation) {
+        finish();
+        return;
+      }
       // 有正文/引用的成员当主消息(caption 通常只挂在其中一条上)。
       const primary =
-        messages.find((x) => (x.text ?? x.caption ?? '') !== '' || x.reply_to_message) ??
-        messages[0];
-      const siblings = messages.filter((x) => x !== primary);
+        album.messages.find((x) => (x.text ?? x.caption ?? '') !== '' || x.reply_to_message) ??
+        album.messages[0];
+      const siblings = album.messages.filter((x) => x !== primary);
       void this.processInboundMessage(primary, siblings, { skipGroupWindow: true })
         .catch((err) => {
           const msg = err instanceof Error ? err.message : String(err);
           this.log.warn(`telegram album handling failed: ${msg}`);
         })
-        .finally(() => {
-          // 相册已处理(或确定失败) — 持久化游标此刻才允许越过它。
-          if (!this.disposing && this.configVersion === generation) this.persistOffsetCapped();
-        });
+        .finally(finish);
     }, ALBUM_SETTLE_MS);
-    this.pendingAlbums.set(key, { messages, timer, firstUpdateId });
   }
 
   private clearPendingAlbums(): void {
-    for (const { timer } of this.pendingAlbums.values()) clearTimeout(timer);
+    for (const album of this.albumsInFlight) {
+      clearTimeout(album.timer);
+      album.resolveDone(); // 解开顺序门, 不留悬挂 await
+    }
     this.pendingAlbums.clear();
+    this.albumsInFlight.clear();
   }
 
   private async processInboundMessage(
@@ -1419,8 +1475,10 @@ export class TelegramIM extends BaseIM implements ChannelIM {
    * 补写时相册会重放一次, 比丢图可取。
    */
   private persistOffsetCapped(): void {
+    // 以 albumsInFlight 为准(含 settle 后仍在处理中的相册): pendingAlbums
+    // 的键在定时器触发即摘除, 只看它会在处理窗口内提前放开 cap(review P1)。
     let floor = Number.POSITIVE_INFINITY;
-    for (const album of this.pendingAlbums.values()) {
+    for (const album of this.albumsInFlight) {
       floor = Math.min(floor, album.firstUpdateId);
     }
     this.persistOffset(Math.min(this.lastSeenOffset, floor));


### PR DESCRIPTION
## 这次改了什么

### 摘要

#1078(个人 Telegram bot)合并前 bot 最后一轮 review 留下的 2 条 P1 跟进——修复完成时 PR 已被 auto-merge,转本 follow-up:

1. **相册处理窗口内游标越界**:相册 settle 定时器一触发就从 pending 表摘键,`persistOffsetCapped()` 在附件下载等待期间会误判"无相册在途",把持久化游标推过未完成的相册——此时退出/换 token,那组图永久丢失。改为相册留在 `albumsInFlight` 集合直到 `processInboundMessage` 收口,游标 cap 与顺序门都以它为准。
2. **同批次乱序回答**:相册要等 1 秒 settle,同一批 getUpdates 里紧跟的文本消息会先进 turn——"发一组图+追问"被倒序回答。改为 **per-chat 串行处理链**(review 第二轮定稿):轮询循环只分发不等待,同 chat 严格保序、跨 chat 并行无队头阻塞;持久化游标走低水位(在途 update ∪ 缓冲相册),任何点退出都从最早未完成的 update 续读;dispose/换代 resolve 全部门,不留悬挂 await。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#1078 的 review threads 跟进(两条 chatgpt-codex-connector P1,已在原 PR 回复指向本 PR)
- 本 PR 包含：`packages/lizi-im/src/telegram/index.ts` 相册缓冲/游标/顺序门 + 保序回归测试
- 明确不包含：其它任何面
- 用户可见变化：相册 settle 窗口内断开不丢图;"图组+追问"按发送顺序回答
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
packages/lizi-im: vitest 233 全绿(含新增保序回归测试) + tsc --noEmit 通过
仓库根 pnpm test:unit(CLAUDE* 环境变量已清): GATE_EXIT=0
```

### 手工验证

不涉及(纯时序/游标逻辑,单测覆盖:in-flight cap、保序、dispose 解门)。

### 未执行的验证

真机相册+追问连发实测未做(需真 bot 场景);单测已覆盖同批次保序路径。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅个人 Telegram 通道的相册接收路径;顺序门只在"同 chat 有相册在途"时生效(≤1 秒 settle + 处理时长),其它 chat 不受影响
- 回滚 / 降级方式：revert 本 PR 即可,无持久化格式变更(游标语义仍为 at-least-once)

远程连接/手机版适配说明(规则 26):不涉及。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

