### PR TITLE
fix(desktop): SSH Agent Proxy 日志脱敏

### DIFF
--- a/apps/desktop/src/main/remote-ssh/__tests__/agentProxyPrefsLog.test.ts
+++ b/apps/desktop/src/main/remote-ssh/__tests__/agentProxyPrefsLog.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  prefsFileContent: '',
+  warn: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/cindy-test-userdata',
+  },
+}));
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: () => true,
+    readFileSync: () => testState.prefsFileContent,
+    writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  },
+}));
+
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: testState.warn,
+    error: vi.fn(),
+  }),
+}));
+
+describe('ssh-host-prefs-store proxy URL logging', () => {
+  it('never copies rejected proxy credentials into the prefs-load warning', async () => {
+    testState.prefsFileContent = JSON.stringify({
+      host1: {
+        autoConnect: false,
+        agentProxy: {
+          enabled: true,
+          mode: 'env',
+          proxyUrl:
+            'http://sensitive-user:sensitive-password@proxy.example:8080/path?token=secret',
+        },
+      },
+    });
+
+    const { readSshHostPrefs } = await import('../ssh-host-prefs-store');
+    expect(readSshHostPrefs().host1?.agentProxy).toBeUndefined();
+
+    const warningContext = testState.warn.mock.calls.find(
+      ([message]) => message === 'invalid agentProxy.proxyUrl in prefs — dropping (was it hand-edited?)',
+    )?.[1];
+    expect(warningContext).toEqual({ proxyUrl: 'http://proxy.example:8080' });
+    expect(JSON.stringify(testState.warn.mock.calls)).not.toMatch(
+      /sensitive-user|sensitive-password|token|secret/,
+    );
+  });
+
+  it('does not copy a rejected tunnel target into the prefs-load warning', async () => {
+    testState.prefsFileContent = JSON.stringify({
+      host2: {
+        autoConnect: false,
+        agentProxy: {
+          enabled: true,
+          mode: 'tunnel',
+          localHost: 'sensitive internal host',
+          localPort: 7890,
+          remotePort: 17893,
+        },
+      },
+    });
+
+    vi.resetModules();
+    const { readSshHostPrefs } = await import('../ssh-host-prefs-store');
+    expect(readSshHostPrefs().host2?.agentProxy).toBeUndefined();
+
+    const warningContext = testState.warn.mock.calls.find(
+      ([message]) => message === 'invalid agentProxy.localHost in prefs — dropping (was it hand-edited?)',
+    )?.[1];
+    expect(warningContext).toEqual({ localHost: '[redacted]' });
+    expect(JSON.stringify(testState.warn.mock.calls)).not.toContain('sensitive internal host');
+  });
+});

--- a/apps/desktop/src/main/remote-ssh/ssh-host-prefs-store.ts
+++ b/apps/desktop/src/main/remote-ssh/ssh-host-prefs-store.ts
@@ -33,6 +33,7 @@ const log = createLogger('ssh-host-prefs-store');
 import {
   LEGACY_AGENT_PROXY_REMOTE_PORT,
   normalizeAgentProxyUrl,
+  redactAgentProxyUrlForLog,
   type SshHostAgentProxyPref,
 } from '../../shared/agentProxyConfig.js';
 
@@ -71,7 +72,7 @@ function normalizeAgentProxy(raw: unknown): SshHostAgentProxyPref | undefined {
     const proxyUrl = normalizeAgentProxyUrl(v.proxyUrl);
     if (!proxyUrl) {
       log.warn('invalid agentProxy.proxyUrl in prefs — dropping (was it hand-edited?)', {
-        proxyUrl: typeof v.proxyUrl === 'string' ? v.proxyUrl.slice(0, 80) : v.proxyUrl,
+        proxyUrl: redactAgentProxyUrlForLog(v.proxyUrl),
       });
       return undefined;
     }
@@ -85,7 +86,7 @@ function normalizeAgentProxy(raw: unknown): SshHostAgentProxyPref | undefined {
   // 可用 pref, 然后晚到 net.connect 才以难懂的方式失败。
   if (!localHost || /\s/.test(localHost) || localHost.includes("'") || localHost.includes('"')) {
     log.warn('invalid agentProxy.localHost in prefs — dropping (was it hand-edited?)', {
-      localHost: typeof v.localHost === 'string' ? v.localHost.slice(0, 80) : v.localHost,
+      localHost: '[redacted]',
     });
     return undefined;
   }
@@ -180,19 +181,9 @@ export function setSshHostAgentProxy(hostId: string, agentProxy: SshHostAgentPro
     target: ap
       ? ap.mode === 'tunnel'
         ? `remote:${ap.remotePort} -> ${ap.localHost}:${ap.localPort}`
-        : redactProxyUrlForLog(ap.proxyUrl)
+        : redactAgentProxyUrlForLog(ap.proxyUrl)
       : null,
   });
-}
-
-/** 日志安全的 proxy URL 形态: scheme://host:port (剥 userinfo / path / query)。 */
-function redactProxyUrlForLog(url: string): string {
-  try {
-    const u = new URL(url);
-    return `${u.protocol}//${u.host}`;
-  } catch {
-    return '(unparseable)';
-  }
 }
 
 function writePrefs(prefs: SshHostPrefs): void {

--- a/apps/desktop/src/shared/__tests__/agentProxyConfig.test.ts
+++ b/apps/desktop/src/shared/__tests__/agentProxyConfig.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactAgentProxyUrlForLog } from '../agentProxyConfig';
+
+describe('redactAgentProxyUrlForLog', () => {
+  it('removes userinfo and URL path/query/fragment from diagnostics', () => {
+    const diagnostic = redactAgentProxyUrlForLog(
+      'http://sensitive-user:sensitive-password@proxy.example:8080/path?token=secret#fragment',
+    );
+
+    expect(diagnostic).toBe('http://proxy.example:8080');
+    expect(diagnostic).not.toContain('sensitive');
+    expect(diagnostic).not.toContain('token');
+    expect(diagnostic).not.toContain('secret');
+  });
+
+  it('keeps only the scheme and endpoint for supported proxy URLs', () => {
+    expect(redactAgentProxyUrlForLog('socks5h://proxy.example:1080')).toBe(
+      'socks5h://proxy.example:1080',
+    );
+    expect(redactAgentProxyUrlForLog('https://[2001:db8::1]:8443/a')).toBe(
+      'https://[2001:db8::1]:8443',
+    );
+    expect(redactAgentProxyUrlForLog('https://proxy.example:443/path')).toBe(
+      'https://proxy.example',
+    );
+  });
+
+  it('uses a fixed placeholder for malformed or unsupported values', () => {
+    expect(redactAgentProxyUrlForLog('')).toBe('[redacted]');
+    expect(redactAgentProxyUrlForLog('http://proxy.example/\nsecret')).toBe('[redacted]');
+    expect(redactAgentProxyUrlForLog('not a URL user:password')).toBe('[redacted]');
+    expect(redactAgentProxyUrlForLog('ftp://user:password@example.com/file')).toBe('[redacted]');
+    expect(redactAgentProxyUrlForLog({ password: 'secret' })).toBe('[redacted]');
+  });
+
+  it('does not decode percent-encoded path credentials into diagnostics', () => {
+    const diagnostic = redactAgentProxyUrlForLog(
+      'http://proxy.example:8080/%75ser:%70assword?token=%73ecret',
+    );
+
+    expect(diagnostic).toBe('http://proxy.example:8080');
+    expect(diagnostic).not.toMatch(/user|password|token|secret/i);
+  });
+});

--- a/apps/desktop/src/shared/agentProxyConfig.ts
+++ b/apps/desktop/src/shared/agentProxyConfig.ts
@@ -52,6 +52,23 @@ export const LEGACY_AGENT_PROXY_REMOTE_PORT = 17893;
 const PROXY_URL_SCHEMES = new Set(['http:', 'https:', 'socks5:', 'socks5h:']);
 
 /**
+ * Produce a safe diagnostic representation of a possibly-invalid proxy URL.
+ * This is intentionally separate from validation: rejected values must still
+ * never be copied verbatim into logs because they may contain userinfo.
+ */
+export function redactAgentProxyUrlForLog(raw: unknown): string {
+  if (typeof raw !== 'string') return '[redacted]';
+  if (!raw.trim() || /\s/.test(raw)) return '[redacted]';
+  try {
+    const url = new URL(raw.trim());
+    if (!PROXY_URL_SCHEMES.has(url.protocol) || !url.hostname) return '[redacted]';
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return '[redacted]';
+  }
+}
+
+/**
  * 校验 env 模式的 proxyUrl; 非法返回 null。main 的 prefs/IPC 与 renderer
  * 表单共用同一口径 — 两套标准会让用户填了合法表象却被 IPC 打回。
  */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 SSH remote agent proxy 日志脱敏问题，并补充 IPv6、非法 prefs 与 localHost 的回归测试，避免 proxy URL 中的 userinfo、path、query、fragment 或误填凭证进入日志。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联需求：PR #992 合并后的后续修复
- 本 PR 包含：共享 proxy URL 日志脱敏函数；prefs load/write 日志修复；localHost 固定脱敏；纯函数与集成回归测试
- 明确不包含：SSH agent proxy 运行逻辑、隧道协议或 UI 行为调整
- 用户可见变化：日志中的代理地址仅保留 scheme、host 与非默认端口；不再记录凭证及其他 URL 部分
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/shared/__tests__/agentProxyConfig.test.ts src/main/remote-ssh/__tests__/agentProxyPrefsLog.test.ts
结果：通过（代理相关测试 43/43）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过

git diff --check
结果：通过

pnpm test:unit
结果：Desktop 通过；最新 upstream/main 的 Mobile 既有文本断言失败（apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts），与本 PR 文件无交集
```

### 手工验证

不涉及 UI 或需要运行时手工操作的变化。

### 未执行的验证

无。全仓单测的 Mobile 失败属于最新 `upstream/main` 基线问题，未纳入本 PR 修复范围。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：Desktop SSH remote agent proxy 的日志与 prefs 校验告警；不改变代理连接、隧道或持久化配置语义。
- 回滚方式：回滚本 PR 的单个提交 `25c6237481fb4cb965ad61c8ece1991346db9366`。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 不涉及 UI
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果，并说明全仓门禁中的基线失败
