### PR TITLE
fix(desktop): 灵动岛完成卡片不再被会话进程关闭抹掉

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -191,11 +191,11 @@ describe('maker:event hot path ordering', () => {
       /ipcMain\.handle\(MAKER_INVOKE\.CLOSE_SESSION,[\s\S]*?\n {2}\}\);/,
     )?.[0];
 
-    expect(closedBlock).toContain('handleAgentIslandSessionClosedAfterCleanup(session.id);');
+    expect(closedBlock).toContain("handleAgentIslandSessionClosedAfterCleanup(session.id, 'process-closed');");
     expectOrder(
       closedBlock,
       "cleanupPendingInteractionsForSession(session.id, 'session_closed');",
-      'handleAgentIslandSessionClosedAfterCleanup(session.id);',
+      "handleAgentIslandSessionClosedAfterCleanup(session.id, 'process-closed');",
     );
     expect(source).toContain('Agent Island session close cleanup failed after mandatory session cleanup');
     expect(closeSessionHandler).toBeTruthy();

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -4264,3 +4264,49 @@ describe('AgentIslandService session attention cleared bridge (error read semant
     expect(publishSpy.mock.calls.length).toBeGreaterThan(publishCountAfterError);
   });
 });
+
+describe('会话关闭原因决定条目去留', () => {
+  it('进程关闭保留仍在展示的完成卡片,归档/删除照常硬删', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish },
+    });
+    syncEnabledForTest(service, publish);
+    const sessions = (
+      service as unknown as { state: { sessions: Map<string, unknown> } }
+    ).state.sessions;
+
+    // 临时会话调度的真实时序:done 之后 runner 的 fire finally 立刻 closeSession。
+    // 此刻完成卡片刚弹出来,硬删条目会让它当场消失(用户看到「弹一下就收起」)。
+    service.handleAgentEvent({ sessionId: 'ephemeral' }, doneEvent());
+    expect(sessions.has('ephemeral')).toBe(true);
+    service.handleSessionClosed('ephemeral', { reason: 'process-closed' });
+    expect(sessions.has('ephemeral')).toBe(true);
+
+    // 会话被归档 / 删除(默认 reason)语义是「这条记录不该再存在」→ 照常硬删。
+    service.handleSessionClosed('ephemeral');
+    expect(sessions.has('ephemeral')).toBe(false);
+  });
+
+  it('进程关闭时若已无展示需求,条目照常删除', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish },
+    });
+    syncEnabledForTest(service, publish);
+    const sessions = (
+      service as unknown as { state: { sessions: Map<string, unknown> } }
+    ).state.sessions;
+
+    // 只是跑起来、没有任何终态未读 → 进程一关就没有保留价值。
+    service.handleUserPrompt({ sessionId: 'plain', agentKind: 'codex' }, 'hi');
+    expect(sessions.has('plain')).toBe(true);
+
+    service.handleSessionClosed('plain', { reason: 'process-closed' });
+    expect(sessions.has('plain')).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -11,9 +11,11 @@ import {
   applyAgentIslandMetadata,
   applyAgentIslandUserPrompt,
   AGENT_ISLAND_COMPLETION_DWELL_MS,
+  AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS,
   AGENT_ISLAND_MESSAGE_PREVIEW_MIN_DWELL_MS,
   AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS,
   buildAgentIslandDisplayState,
+  closeAgentIslandSessionPreservingUnread,
   createAgentIslandState,
   dismissAgentIslandActiveReveal,
   getNextAgentIslandTimerAt,
@@ -2136,5 +2138,69 @@ describe('Agent Island 未读驻留 TTL(避免几小时前完成的任务无限�
 
     const display = buildAgentIslandDisplayState(state, afterExpiry);
     expect(display.totalCount).toBe(0);
+  });
+});
+
+describe('会话进程关闭不该抹掉正在展示的通知', () => {
+  it('临时会话 run 收尾 closeSession 后,完成卡片仍能走完 dwell', () => {
+    const state = createAgentIslandState();
+    // 临时会话调度(非 heartbeat、非 persistentSession)的真实时序:done 之后 runner 的
+    // fire finally 立刻 closeSession,两者只隔毫秒级。
+    applyAgentIslandEvent(state, { sessionId: 'ephemeral', title: '每周巡检' }, doneEvent(), 2_000);
+    closeAgentIslandSessionPreservingUnread(state, 'ephemeral', 2_050);
+
+    const justAfterClose = buildAgentIslandDisplayState(state, 2_100);
+    expect(justAfterClose.totalCount).toBe(1);
+    expect(justAfterClose.mode).toBe('expanded');
+    expect(justAfterClose.displaySurface).toBe('completionCard');
+
+    // dwell 走完后照常收起,但未读条目保留(与普通完成一致)。
+    const afterDwell = buildAgentIslandDisplayState(state, 2_000 + AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS + 500);
+    expect(afterDwell.mode).toBe('compact');
+    expect(afterDwell.pillSnapshot.unreadCompletedCount).toBe(1);
+  });
+
+  it('进程关闭会落下运行态,不让 pill 一直转', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'running', title: '跑着' }, statusEvent(true, '思考中'), 1_000);
+    // 运行中的会话本来是可见的(isSessionVisible 对 running 直接放行)。
+    expect(buildAgentIslandDisplayState(state, 1_100).totalCount).toBe(1);
+
+    closeAgentIslandSessionPreservingUnread(state, 'running', 1_200);
+
+    // 没有未读终态也没有 dwell 需要保留 → 条目照常清掉。
+    expect(buildAgentIslandDisplayState(state, 1_300).totalCount).toBe(0);
+  });
+
+  it('进程关闭时还挂着 pending 交互 → 整条删掉,不留一张点不动的审批卡片', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandInteractionRequest(
+      state,
+      { sessionId: 'perm', title: '等审批' },
+      {
+        kind: 'permission',
+        requestId: 'r1',
+        toolName: 'Bash',
+        input: { command: 'rm -rf dist' },
+      },
+      1_000,
+    );
+    expect(buildAgentIslandDisplayState(state, 1_100).totalCount).toBe(1);
+
+    // 进程一关,这个权限请求永远不会再被响应(service 侧同时删掉了 permissionRequests)。
+    closeAgentIslandSessionPreservingUnread(state, 'perm', 1_200);
+
+    expect(buildAgentIslandDisplayState(state, 1_300).totalCount).toBe(0);
+  });
+
+  it('已经没有展示需求的会话,进程关闭时照常删除', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'read', title: '已读' }, doneEvent(), 2_000);
+    // 用户已经看过 → 未读清零,条目不再需要展示。
+    acknowledgeAgentIslandSessionRead(state, 'read', 3_000, { source: 'explicit' });
+
+    closeAgentIslandSessionPreservingUnread(state, 'read', 3_100);
+
+    expect(buildAgentIslandDisplayState(state, 3_200).totalCount).toBe(0);
   });
 });

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -68,6 +68,7 @@ import {
   applyAgentIslandUserPrompt,
   buildAgentIslandDisplayState,
   buildAllSessionActivitySnapshots,
+  closeAgentIslandSessionPreservingUnread,
   completeAgentIslandSessionWithoutAttention,
   createAgentIslandUserPromptRollbackToken,
   createAgentIslandState,
@@ -977,7 +978,18 @@ export class AgentIslandService {
     }
   }
 
-  handleSessionClosed(sessionId: string): void {
+  /**
+   * @param options.reason
+   *   `'discarded'`(默认)= 这条记录不该再存在(会话归档 / 删除、Orca worker 被策略
+   *   清除),条目硬删。
+   *   `'process-closed'` = 只是 agent 进程收了(典型:临时会话调度 run 终态后的
+   *   closeSession),仍在展示的完成 / 错误卡片必须留着走完 dwell,否则刚弹出的卡片会
+   *   当场消失。见 `closeAgentIslandSessionPreservingUnread`。
+   */
+  handleSessionClosed(
+    sessionId: string,
+    options: { reason?: 'discarded' | 'process-closed' } = {},
+  ): void {
     this.stoppedSessionIds.delete(sessionId);
     this.replacementTurnPendingSessionIds.delete(sessionId);
     this.replacementTurnDispatchingSessionIds.delete(sessionId);
@@ -993,7 +1005,11 @@ export class AgentIslandService {
     this.deferredCompletions.delete(sessionId);
     // Remote auth retry closes the failed session before the renderer reports
     // whether its replacement turn started, so keep that deferred error here.
-    removeAgentIslandSession(this.state, sessionId);
+    if (options.reason === 'process-closed') {
+      closeAgentIslandSessionPreservingUnread(this.state, sessionId, Date.now());
+    } else {
+      removeAgentIslandSession(this.state, sessionId);
+    }
     this.deletePermissionRequestsForSession(sessionId);
     this.publish();
   }

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -37,7 +37,10 @@ export type AgentIslandInteractionRequest =
 export const AGENT_ISLAND_COMPLETION_DWELL_MS = 5_000;
 export const AGENT_ISLAND_ERROR_DWELL_MS = 12_000;
 export const AGENT_ISLAND_REVEAL_DWELL_MS = 5_000;
-export const AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS = 12_000;
+// 12s → 8s:完成卡片的 dwell 现在能真正走完(临时会话调度 run 收尾时的 closeSession
+// 不再抹掉条目,见 closeAgentIslandSessionPreservingUnread),不需要再用更长的上限去弥补
+// 「随时可能被整条删掉」。
+export const AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS = 8_000;
 export const AGENT_ISLAND_ERROR_REVEAL_DWELL_MS = 12_000;
 export const AGENT_ISLAND_EXPANDED_MIN_DWELL_MS = 1_000;
 export const AGENT_ISLAND_HOVER_EXPAND_DELAY_MS = 500;
@@ -874,6 +877,46 @@ export function removeAgentIslandSession(state: AgentIslandState, sessionId: str
     state.pendingFocusSessionId = null;
     state.pendingFocusUntil = null;
   }
+}
+
+/**
+ * 会话**进程**关闭:落下运行态,但保留仍需展示的通知条目。
+ *
+ * 为什么不能直接删:临时会话调度(非 heartbeat、非 persistentSession)在 run 终态之后
+ * 立刻 closeSession(`scheduler-host/runner.ts` 的 fire finally),而完成卡片本该在岛上
+ * 停留数秒。直接删条目会让刚弹出的卡片当场消失 —— 而且不是被别的内容顶掉,是整条记录
+ * 没了,用户看到的就是「弹了一下就收起」。通知是**已发生事件的记录**,生命周期不该绑在
+ * agent session 句柄上。
+ *
+ * 判据复用 `isSessionVisible`:仍需展示(未读终态未过 TTL / dwell 未走完 / 有 pending
+ * 交互)就留着,由既有 lifecycle 到期或用户 ack 收掉;否则照常删除。
+ *
+ * 会话被归档 / 删除、或 Orca worker 被策略清除时**不走这里** —— 那些语义是「这条记录
+ * 不该再存在」,继续用 `removeAgentIslandSession` 硬删。
+ */
+export function closeAgentIslandSessionPreservingUnread(
+  state: AgentIslandState,
+  sessionId: string,
+  now: number,
+): void {
+  const session = state.sessions.get(sessionId);
+  if (!session) {
+    removeAgentIslandSession(state, sessionId);
+    return;
+  }
+  // 进程已经没了,运行态必须落下来,否则 pill 会一直转着 working 动画。
+  session.running = false;
+  session.currentToolUseId = null;
+  session.toolDetailUntil = null;
+  // pending 交互随进程一起失效(service 侧同时会 deletePermissionRequestsForSession)。
+  // 留着会让用户对着一张永远不会被响应的审批卡片点按钮,所以这类条目整条删掉 —— 要保的
+  // 只是「已经发生完、还没被看到」的终态通知。
+  if (session.pendingInteractionIds.size > 0) {
+    removeAgentIslandSession(state, sessionId);
+    return;
+  }
+  if (isSessionVisible(session, now)) return;
+  removeAgentIslandSession(state, sessionId);
 }
 
 export function requestAgentIslandSessionFocus(

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -2130,9 +2130,12 @@ function handleAgentIslandInteractionDismissedByRequestId(requestId: string): vo
   }
 }
 
-function handleAgentIslandSessionClosedAfterCleanup(sessionId: string): void {
+function handleAgentIslandSessionClosedAfterCleanup(
+  sessionId: string,
+  reason: 'discarded' | 'process-closed' = 'discarded',
+): void {
   try {
-    getAgentIslandService()?.handleSessionClosed(sessionId);
+    getAgentIslandService()?.handleSessionClosed(sessionId, { reason });
   } catch (error) {
     log.warn('Agent Island session close cleanup failed after mandatory session cleanup', {
       sessionId,
@@ -3418,7 +3421,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       // 后台活动检测:会话进程已关闭(closeSession / 删除),清账并广播横幅熄灭。
       clearClaudeSessionBackgroundActivity(session.id);
       clearSessionPersistState(session.id);
-      handleAgentIslandSessionClosedAfterCleanup(session.id);
+      // 进程关闭 ≠ 通知作废:临时会话调度(非 heartbeat / 非 persistentSession)在 run
+      // 终态后立刻 closeSession,此刻完成卡片刚在灵动岛上弹出来。硬删条目会让它当场
+      // 消失,所以这条路径保留仍在展示的卡片,由 dwell 到期或用户 ack 收掉。
+      handleAgentIslandSessionClosedAfterCleanup(session.id, 'process-closed');
     }
   }));
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

临时会话调度（没有 `targetSessionId` 且 `persistentSession=false`）在 run 终态之后会立刻
`closeSession`（`scheduler-host/runner.ts` 的 `fire` finally），而 `handleSessionClosed`
无条件走 `removeAgentIslandSession` —— 刚弹出来的完成卡片会在毫秒级内**整条消失**。
视觉上不是被别的内容顶掉，而是凭空收起，所以体感是「弹了一下就没了」。

修法是给 `handleSessionClosed` 加 `reason`，区分「进程关闭」与「这条记录不该再存在」：
前者保留仍需展示的终态通知，由既有 lifecycle 到期或用户 ack 收掉。顺带把完成卡片的
dwell 从 12s 降到 8s —— dwell 现在能真正走完，不需要再用更长的上限去弥补「随时可能被
整条删掉」。

命中的是非 heartbeat 调度（例如 `Cindy PR session supervisor`、每周 invoice 巡检）。
PR 心跳这类复用既有会话的 heartbeat 不走这条路径，不受影响。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实测反馈「完成卡片经常没看满就收起」）
- 本 PR 包含：
  - `handleSessionClosed` 新增 `reason`（`'process-closed'` / `'discarded'`，默认后者保持原行为）
  - 新增 `closeAgentIslandSessionPreservingUnread`：落下运行态，判据复用现成的
    `isSessionVisible` 决定条目去留；pending 交互随进程失效，这类条目仍整条删除
  - `register.ts` 的 session `closed` 事件改传 `'process-closed'`（清理顺序未变）
  - `AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS` 12s → 8s
- 明确不包含：
  - **blocking 抢占期间暂停计时**：需要引入冻结字段 + 冻结上限策略（超时是降级成 badge
    还是丢弃），属于独立决策；且 blocking 抢占有视觉替代，不属于本次要修的「凭空收起」。
  - **reveal 最小可见地板**：实现后逐条核实确认无处可用，已完整回退。`passive ack` 与
    「可见会话压制」是既有产品契约（`service.test.ts` 的
    `clears unread completion attention when focused windows report visible sessions`
    守着它），加地板会变成「打开了会话红点还挂着」；迟到的交互撤销已有
    `requirePending: true` 守卫；真正会走到清理的审批卡片被撤销后必须立刻消失，否则用户
    会点一个已失效的批准。
- 用户可见变化：临时会话调度跑完后，灵动岛完成卡片能稳定停留 8s（此前经常瞬间消失）。
  未读状态与 pill badge 语义不变。
- 是否存在 breaking change：无

### UI 变化

不涉及：改动全部在 main 进程的状态机与生命周期（`apps/desktop/src/main/`），没有视觉、
交互或文案变化。用户可感知的只是「卡片能停留满 dwell」这一行为修正。

- 引用的设计规范：不涉及（纯 main 侧通知生命周期逻辑，无视觉／交互／文案改动；
  未命中 `check-pr-design-basis.mjs` 的 UI 路径白名单）

## 怎么验证的

### 自动验证

```text
# 定向测试（灵动岛 + maker:event hot path 顺序）
npx vitest run --pool=threads src/main/__tests__/makerEventHotPathOrdering.test.ts \
  src/main/agent-island/__tests__/ --root apps/desktop
结果：7 files / 258 tests passed（新增 4 个用例，见下）

# 全量单测门禁
bash run-unit-gate.sh <worktree>
结果：GATE_EXIT=0
（第一次跑是失败的：makerEventHotPathOrdering 的源码文本断言依赖旧调用签名，
  更新期望字符串后第二次通过；清理顺序本身未改动。）

# 类型检查
npx tsc --noEmit -p apps/desktop/tsconfig.json
结果：本次改动文件 0 错误
```

新增用例：
- 临时会话 run 收尾 `closeSession` 后完成卡片仍能走完 dwell，之后照常收起并保留未读
- 进程关闭会落下运行态（不让 pill 一直转）
- 进程关闭时还挂着 pending 交互 → 整条删掉，不留一张点不动的审批卡片
- service 层 `reason` 两个分支：`'process-closed'` 保留、默认 `'discarded'` 硬删

### 手工验证

不涉及 —— 未做实机验证，原因见下。

### 未执行的验证

- **实机未验证**：没有构造一次真实的临时会话调度 run 去观察灵动岛完成卡片的实际停留。
  灵动岛是 macOS 原生 helper 渲染，需要 dev 实例 + 触发一次真实调度才能目检；本次只有
  状态机层的单测覆盖。
- 双模式（Light / Dark）目检不涉及：本次没有视觉改动。
- 门禁日志文件在第二次跑通后被临时目录清理，无法回溯核实 `GATE_STARTED`；`GATE_EXIT=0`
  不可能来自「一行没跑」（那是 exit 4/5），且第一次门禁完整跑过并定位出上述失败项。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响灵动岛条目在「会话进程关闭」这一路径下的去留，以及完成卡片的 dwell
  时长。默认 `reason` 保持原有硬删行为，归档／删除会话与 Orca worker 策略清除都不变。
  灵动岛是 macOS-only，其它平台走 headless 状态机、不受可见行为影响。
- 回滚 / 降级方式：单 commit，`git revert` 即可。也可只把
  `AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS` 调回 12_000，或把 `register.ts` 那处调用
  改回不带 `reason`（退回硬删）单独降级。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
