### PR TITLE
fix(desktop): ghost TOOL_NOT_FOUND 错误自愈,补二级分派调用指引

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/pipeDispatcher.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/pipeDispatcher.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { GhostPipeDispatcher, type PipeDispatcherDeps } from '../pipeDispatcher';
+import { GhostPipeDispatcher, toolNotFoundMessage, type PipeDispatcherDeps } from '../pipeDispatcher';
 import type { GhostPipeToolCall, InstalledGhost } from '../../../shared/ghost';
 import type { GhostRuntimeState } from '../runtime/GhostRuntime';
 
@@ -82,11 +82,62 @@ describe('资格审(结构化错误分类)', () => {
     expect(r).toMatchObject({ ok: false, errorCode: 'TOOL_NOT_FOUND' });
   });
 
+  it('TOOL_NOT_FOUND 自愈文案:普通插件列出可用工具', async () => {
+    const h = makeHarness();
+    const r = await h.dispatcher.callGhostTool({ ...CALL, tool: 'nope' });
+    if (r.ok) throw new Error('应失败');
+    expect(r.message).toContain('gen_image');
+  });
+
+  it('TOOL_NOT_FOUND 自愈文案:二级分派插件回填 call_tool 正确形态', async () => {
+    const base = fakeGhost();
+    const dispatchGhost = fakeGhost({
+      manifest: {
+        ...base.manifest,
+        tools: [
+          { name: 'list_tools', description: '列操作' },
+          { name: 'call_tool', description: '分派' },
+        ],
+      },
+    });
+    const h = makeHarness({ ghost: dispatchGhost });
+    const r = await h.dispatcher.callGhostTool({ ...CALL, tool: 'create_pull_request_review' });
+    if (r.ok) throw new Error('应失败');
+    expect(r.errorCode).toBe('TOOL_NOT_FOUND');
+    expect(r.message).toContain('call_tool');
+    expect(r.message).toContain('create_pull_request_review');
+  });
+
   it('熔断中 → GHOST_CRASHED,不尝试拉起', async () => {
     const h = makeHarness({ state: 'fused' });
     const r = await h.dispatcher.callGhostTool(CALL);
     expect(r).toMatchObject({ ok: false, errorCode: 'GHOST_CRASHED' });
     expect(h.deps.spawn).not.toHaveBeenCalled();
+  });
+});
+
+describe('toolNotFoundMessage(纯函数直测)', () => {
+  it('分派型插件:回填 agent 想调的名字并给出 call_tool 形态', () => {
+    const msg = toolNotFoundMessage('cindy-github', 'create_pull_request', [
+      { name: 'list_tools', description: '' },
+      { name: 'call_tool', description: '' },
+    ]);
+    expect(msg).toContain('cindy-github');
+    expect(msg).toContain('create_pull_request');
+    expect(msg).toContain('tool:"call_tool"');
+    expect(msg).toContain('name:"create_pull_request"');
+    expect(msg).toContain('list_tools');
+  });
+
+  it('普通插件:列出可用工具名', () => {
+    const msg = toolNotFoundMessage('art', 'nope', [{ name: 'gen_image', description: '' }]);
+    expect(msg).toContain('gen_image');
+    expect(msg).not.toContain('call_tool');
+  });
+
+  it('tools 缺省/空:不崩,提示未声明任何工具', () => {
+    expect(toolNotFoundMessage('art', 'nope', undefined)).toContain('(未声明任何工具)');
+    expect(toolNotFoundMessage('art', 'nope', [])).toContain('(未声明任何工具)');
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/pipeDispatcher.ts
+++ b/apps/desktop/src/main/cindy-brain/pipeDispatcher.ts
@@ -23,6 +23,7 @@ import { randomUUID } from 'node:crypto';
 import type {
   GhostPipeToolCall,
   GhostToolCallResult,
+  GhostToolDecl,
   InstalledGhost,
 } from '../../shared/ghost.js';
 import { GHOST_PIPE_CALL_MAX_TOTAL_MS, isGhostPluginErrorCode } from '../../shared/ghost.js';
@@ -74,6 +75,32 @@ const DEFAULT_TIMEOUT_MS = 330_000;
 /** 代办收工(release)后留给意识做后处理与交卷的余量窗口。 */
 const HOLD_SETTLE_GRACE_MS = 60_000;
 
+/**
+ * TOOL_NOT_FOUND 自愈文案。只报"没有什么"会让 agent 拿同一错误形态反复重试,
+ * 甚至误判"插件没有写能力"(2026-07-30 实测:二级分派型插件 cindy-github 的
+ * 操作名被两个模型先后当作顶层 tool 直调,均在此卡死)。
+ * 分派型插件(暴露了 call_tool)把 agent 想调的名字直接回填进正确调用形态;
+ * 普通插件列出实际可用的顶层工具名。
+ * 消费方:本派发器 + ghost_call 主路径预检(mcp-integrations/ghost.ts)+
+ * setup 恢复校验(maker-ipc/register.ts validateTarget)——所有 TOOL_NOT_FOUND
+ * 返回点必须共用本函数,新增返回点不得自写文案。导出供单测直测(规则 14)。
+ */
+export function toolNotFoundMessage(
+  ghostId: string,
+  tool: string,
+  declaredTools: GhostToolDecl[] | undefined,
+): string {
+  const names = (declaredTools ?? []).map((t) => t.name);
+  if (names.includes('call_tool')) {
+    return (
+      `插件 ${ghostId} 没有名为 ${tool} 的顶层工具——它采用二级分派:具体操作经 call_tool 下发,` +
+      `正确形态 ghost_call({ghost_id:"${ghostId}",tool:"call_tool",args:{name:"${tool}",args:{...}}});` +
+      `操作名与参数先调 list_tools 查询。不要据此判定插件缺少该能力。`
+    );
+  }
+  return `插件 ${ghostId} 没有工具 ${tool};可用工具: ${names.length > 0 ? names.join(', ') : '(未声明任何工具)'}`;
+}
+
 export class GhostPipeDispatcher {
   private readonly pending = new Map<string, PendingCall>();
 
@@ -110,7 +137,7 @@ export class GhostPipeDispatcher {
     }
     const declared = ghost.manifest.tools?.some((t) => t.name === tool);
     if (!declared) {
-      return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `插件 ${ghostId} 没有工具 ${tool}` };
+      return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: toolNotFoundMessage(ghostId, tool, ghost.manifest.tools) };
     }
     if (this.deps.runtimeStateOf(ghostId) === 'fused') {
       return { ok: false, errorCode: 'GHOST_CRASHED', message: `插件 ${ghostId} 已熔断(反复崩溃),重载或重新启用后再试` };

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -61,6 +61,7 @@ import {
   type GhostSetupInteractionSnapshot,
 } from '../cindy-brain/ghostSetupInteractionBridge.js';
 import { initGhostSetupCoordinator } from '../cindy-brain/ghostSetupCoordinator.js';
+import { toolNotFoundMessage } from '../cindy-brain/pipeDispatcher.js';
 import { getGhostSetupChangeBus } from '../cindy-brain/ghostSetupChangeBus.js';
 import { isGhostDisabledForWorkdir } from '../cindy-brain/ghostWorkdirPrefs.js';
 import {
@@ -1386,7 +1387,7 @@ initGhostSetupCoordinator({
       return {
         ok: false,
         errorCode: 'TOOL_NOT_FOUND',
-        message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})`,
+        message: toolNotFoundMessage(ghostId, tool, ghost.manifest.tools),
       };
     }
     return { ok: true };

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -47,6 +47,7 @@ import {
   type GhostGrantLane,
 } from '../cindy-brain/ghostGrantConfirmBridge.js';
 import { classifyLocalAttachmentPath } from '../cindy-brain/ghostLocalPathGrant.js';
+import { toolNotFoundMessage } from '../cindy-brain/pipeDispatcher.js';
 import { getSessionFsSnapshot } from '../localDb/ipc/sessions.js';
 import { deriveGhostSessionContext, type GhostSessionContextInjected } from '../../shared/ghost.js';
 import { withCardToken } from '../cindy-brain/cardService.js';
@@ -659,7 +660,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         return {
           ok: false,
           errorCode: 'TOOL_NOT_FOUND',
-          message: `目标插件没有工具 ${tool}`,
+          message: toolNotFoundMessage(ghostId, tool, target.manifest.tools),
         };
       }
       if (grantOnly && (!attachments || attachments.length === 0)) {
@@ -708,7 +709,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         !grantOnly &&
         !(refreshed.manifest.tools ?? []).some((candidate) => candidate.name === tool)
       ) {
-        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})` };
+        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: toolNotFoundMessage(ghostId, tool, refreshed.manifest.tools) };
       }
       let finalAssessment;
       try {
@@ -884,7 +885,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         };
       }
       if (!(preDispatch.manifest.tools ?? []).some((c) => c.name === tool)) {
-        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})` };
+        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: toolNotFoundMessage(ghostId, tool, preDispatch.manifest.tools) };
       }
       try {
         const preDispatchAssessment = getGhostSetupAssessment(ghostId);
@@ -923,7 +924,7 @@ export function getCindyGhostsMcpDeps(sessionCtx?: LiziMcpSessionContext): Cindy
         return { ok: false, errorCode: 'GHOST_DISABLED_IN_WORKDIR', message: t('newChat.pluginSetup.targetDisabledInWorkdir') };
       }
       if (!(postCtx.manifest.tools ?? []).some((c) => c.name === tool)) {
-        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `${t('newChat.pluginSetup.targetToolNotFound')} (${tool})` };
+        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: toolNotFoundMessage(ghostId, tool, postCtx.manifest.tools) };
       }
       try {
         const postCtxAssessment = getGhostSetupAssessment(ghostId);

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -4287,8 +4287,7 @@
       "inlineSecretStoreFailed": "Failed to save credential",
       "targetNotFound": "The target plugin was uninstalled or is currently unavailable",
       "targetDisabled": "The target plugin has been disabled",
-      "targetDisabledInWorkdir": "The user has disabled this plugin in the current working directory; do not retry.",
-      "targetToolNotFound": "The target plugin no longer provides this tool"
+      "targetDisabledInWorkdir": "The user has disabled this plugin in the current working directory; do not retry."
     },
     "createAgent": {
       "quickStart": "Quick start",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4286,8 +4286,7 @@
       "inlineSecretStoreFailed": "認証情報の保存に失敗しました",
       "targetNotFound": "対象プラグインがアンインストールされたか現在利用不可です",
       "targetDisabled": "対象プラグインが無効化されています",
-      "targetDisabledInWorkdir": "ユーザーが現在のワーキングディレクトリでこのプラグインを無効にしています。リトライしないでください。",
-      "targetToolNotFound": "対象プラグインはこのツールを提供していません"
+      "targetDisabledInWorkdir": "ユーザーが現在のワーキングディレクトリでこのプラグインを無効にしています。リトライしないでください。"
     },
     "createAgent": {
       "quickStart": "クイックスタート",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4286,8 +4286,7 @@
       "inlineSecretStoreFailed": "자격 증명 저장에 실패했습니다",
       "targetNotFound": "대상 플러그인이 제거되었거나 현재 사용할 수 없습니다",
       "targetDisabled": "대상 플러그인이 비활성화되었습니다",
-      "targetDisabledInWorkdir": "사용자가 현재 작업 디렉토리에서 이 플러그인을 비활성화했습니다. 재시도하지 마세요.",
-      "targetToolNotFound": "대상 플러그인이 더 이상 이 도구를 제공하지 않습니다"
+      "targetDisabledInWorkdir": "사용자가 현재 작업 디렉토리에서 이 플러그인을 비활성화했습니다. 재시도하지 마세요."
     },
     "createAgent": {
       "quickStart": "빠른 시작",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4286,8 +4286,7 @@
       "inlineSecretStoreFailed": "凭证保存失败",
       "targetNotFound": "目标插件已卸载或当前不可用",
       "targetDisabled": "目标插件已被停用",
-      "targetDisabledInWorkdir": "用户已在当前工作目录停用该插件；不要重试。",
-      "targetToolNotFound": "目标插件不再提供该工具"
+      "targetDisabledInWorkdir": "用户已在当前工作目录停用该插件；不要重试。"
     },
     "createAgent": {
       "quickStart": "快速开始",

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -32,12 +32,18 @@ const D_GHOST_LIST = [
   "(例外:用户消息的[插件指令]已附带目标插件的工具清单时,可直接 ghost_call 免查)。",
   "返回条目含 id、name、command(用户显式点名用的 $指令)与 tools(名称/说明/参数)。",
   "调用具体工具用 ghost_call({ghost_id, tool, args})。清单为空 = 用户没有可用的插件工具。",
+  "若某插件 tools 仅含 list_tools / call_tool,它是二级分派型:具体操作名须作 call_tool 的",
+  "name 参数下发(args:{name:\"<操作名>\", args:{...}}),不能直接当 tool 调。",
 ].join("\n");
 
 const D_GHOST_CALL = [
   "调用某个插件(Ghost)提供的工具。ghost_id 与 tool 来自 ghost_list 的返回,",
   "或用户消息[插件指令]附带的工具清单;",
   "args 按该工具声明的参数 schema 传 JSON 对象。",
+  "部分插件(如 cindy-github / cindy-gitlab)采用二级分派:ghost_list 只暴露 list_tools 与",
+  "call_tool 两个工具,具体操作(如 create_pull_request_review)不是顶层 tool,必须经 call_tool",
+  '下发——ghost_call({ghost_id, tool:"call_tool", args:{name:"<操作名>", args:{...}}});',
+  "把操作名当 tool 直接调会返回 TOOL_NOT_FOUND,此时按上述形态改写重试,不要判定插件无此能力。",
   "执行发生在该插件的独立沙箱中(无文件/网络访问,用 AI 走主机统一通道)。",
   "用户的图片/媒体文件要交给插件处理时,把其地址放进顶层 attachments",
   "(不是塞进 args):主机会把图过户给该插件并以指纹注入 args.attachments,插件",
@@ -54,7 +60,8 @@ const D_GHOST_CALL = [
   "——用户只需在一张卡上批一次;跳过预授权会让用户被迫一张张点允许。",
   "结构化错误:GHOST_NOT_FOUND(未安装或已卸载)/ GHOST_ASLEEP(未启用,可提示用户到主界面侧边栏「插件」中启用)/",
   "GHOST_DISABLED_IN_WORKDIR(用户在当前工作目录停用了该插件——不要重试,改用其它方式完成)/",
-  "TOOL_NOT_FOUND / GHOST_CRASHED / TIMEOUT / ATTACHMENT_INVALID(附件过户失败,查 message)/",
+  "TOOL_NOT_FOUND(常见是把二级分派操作名当成了顶层 tool,按上文 call_tool 形态改写后重试)/ GHOST_CRASHED /",
+  "TIMEOUT / ATTACHMENT_INVALID(附件过户失败,查 message)/",
   "DIR_INVALID(目录过户失败,查 message)/ INTERNAL。遇到 NOT_FOUND 类错误先重新 ghost_list。",
 ].join("\n");
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

二级分派型插件（cindy-github / cindy-gitlab 等对 agent 只暴露 `list_tools` / `call_tool` 两个顶层工具的插件）的具体操作名被 agent 当作顶层 `tool` 直调时，旧 `TOOL_NOT_FOUND` 只报「没有工具 X」——agent 无从自愈，反复用同一错误形态重试，甚至误判「插件没有写能力」并把错误结论带入后续分析（2026-07-30 实测两个模型先后踩坑）。

本 PR 让错误消息自愈：分派型插件把 agent 想调的名字直接回填进 `call_tool` 正确调用形态，普通插件列出可用工具名；同时在 `ghost_list` / `ghost_call` 工具描述里补上二级分派的显式说明与示例，从「第一次就调对」和「错了能自愈」两个面解决问题。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（源自实测教训，见摘要）
- 本 PR 包含：
  - 新增 `toolNotFoundMessage()`（`pipeDispatcher.ts` 纯函数），JSDoc 约定所有 TOOL_NOT_FOUND 返回点必须共用
  - 6 处返回点统一走该函数：pipeDispatcher + `mcp-integrations/ghost.ts` 四处预检 + `maker-ipc/register.ts` validateTarget（此前主路径四处预检返回简短文案，自愈文案在 pipeDispatcher 里是死代码——经三轮独立 review 发现后修复）
  - `ghost_list` / `ghost_call` 工具描述补二级分派说明与调用示例（cindy-tools）
  - 删除不再有任何消费方的 locale key `newChat.pluginSetup.targetToolNotFound`（zh-CN/en/ja/ko）
  - pipeDispatcher 测试补 5 个用例（2 个派发路径 + 3 个纯函数直测）
- 明确不包含：各内置插件自身 `list_tools` 输出的 hint 文案（在内置插件侧，不在本仓）；`apps/mobile` 一个 CRLF 敏感的存量测试断言（见「未执行的验证」，与本 PR 无关，不在本 PR 顺手修）
- 用户可见变化：无直接 UI 变化；agent 误调插件工具时返回的错误消息变为可行动的自愈指引
- 是否存在 breaking change：无（仅错误消息与工具描述文本变化，errorCode 不变，下游均不解析 message 文本——review 已全仓核实）

### UI 变化

不涉及：locale 仅删除一个已无任何消费方的死 key（`targetToolNotFound`），无视觉/交互/文案变化；未命中任何 UI 组件路径。

- 引用的设计规范：不涉及——仅删除无任何消费方的死 locale key，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
pnpm test:unit                        # 52 PASS；apps/mobile 1 个存量失败，见下
pnpm --filter desktop typecheck       # tsc --noEmit 通过
pnpm --filter cindy-tools build       # tsc --noEmit 通过
pnpm --filter cindy-tools test        # 46/46 通过
pnpm --filter desktop exec vitest run src/main/cindy-brain   # 71 文件 991/991 通过（含新增 5 用例）
pnpm check:i18n                       # zh-CN/en/ja/ko 共 6004 key 全部一致
pnpm check:dco                        # 1 commit signed off
```

`pnpm test:unit` 中 `apps/mobile unit` 有 1 个失败（`sessionMainLayerDesktopFirst.test.ts` 对 `app/sessions/[sessionId].tsx` 做源码文本 grep，断言含 `,\n`，Windows CRLF checkout 下源码是 `,\r\n` 永不匹配）。已证实与本 PR 无关：`git diff upstream/main HEAD -- apps/mobile` 为空，失败在上游 main 本地 Windows 环境原样复现；Linux CI 为 LF checkout 不受影响。属上游存量 Windows 兼容性问题，未在本 PR 混入修复。

另经独立 reviewer 三轮审查：第一轮发现主路径四处预检导致自愈文案走不到的 P1（已修复并复审确认 6 处返回点全覆盖），契约一致性与全局回归两轮无发现。分支已 rebase 到最新 upstream/main（e2ca4d75）。

### 手工验证

错误形态经 reviewer 与 cindy-tools 注册的 ghost_call schema 逐字核对（参数名 snake_case 一致）。

### 未执行的验证

实机运行 desktop 复现 agent 误调路径：未执行（需打包运行完整应用；改动为错误文案与描述文本，逻辑由单测与 typecheck 覆盖）。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] 其他：agent 可见工具描述文本变更（cindy-tools ghost 总机的 `ghost_list` / `ghost_call` 描述，进入模型工具定义前缀；新增约 6 行，无行为契约变化，新老会话下一次查询即生效）

### 影响与回滚

- 影响范围：ghost 插件调用的 TOOL_NOT_FOUND 错误消息文本、ghost 总机两件工具的描述文本；不含协议、schema、持久化变更。
- 回滚 / 降级方式：revert 本 commit 即可，无数据或协议兼容负担。

### 手册同步声明（插件作者契约）

无需同步 FORGE_GUIDE：改动不命中作者可见契约（身份卡字段／管子协议／模型 slot／面板供片／打包限制），仅改 host 侧错误文案与 agent 工具描述。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（JSDoc 约定返回点共用）
- [x] 已确认测试结果或说明未执行原因
