### PR TITLE
fix(desktop): Anthropic 模型发现归一化 [1m] 后缀，修复顶栏误报「已断开」

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -224,6 +224,18 @@ describe('mapAnthropicSdkModels', () => {
     expect(out[0].model.name).toBe('Sonnet 5'); // dated 先出现,first-wins
   });
 
+  it('[1m] 长上下文后缀归一并去重(顶栏误报「已断开」回归):目录基线按裸 id 命中', () => {
+    const out = mapAnthropicSdkModels([
+      { value: 'claude-fable-5[1m]', displayName: 'Fable 5' },
+      { value: 'claude-fable-5', displayName: 'Fable 5 dup' },
+      { value: 'claude-opus-4-8-20260401[1m]', displayName: 'Opus 4.8' },
+    ]);
+    expect(out.map((e) => e.model.id)).toEqual(['claude-fable-5', 'claude-opus-4-8']);
+    expect(out[0].model.name).toBe('Fable 5'); // first-wins
+    // 归一化前 [1m] id 查不到 cindyModelMeta 基线,会塌回合成三档;归一化后按裸 id 命中。
+    expect(out[0].model.efforts).toContain('xhigh');
+  });
+
   it('坏输入安全:非数组 / 空条目 / 缺 value 全部跳过', () => {
     expect(mapAnthropicSdkModels(null)).toEqual([]);
     expect(mapAnthropicSdkModels([null, {}, { value: '' }, 42])).toEqual([]);
@@ -538,6 +550,47 @@ describe('noteAnthropicSdkSupportedModels(登录态门控 + 合并纪律)', () =
       releaseWrite();
       writeSpy.mockRestore();
     }
+  });
+
+  it('磁盘缓存脏 id 自愈:历史缓存里的 [1m] 后缀 id 加载时归一化 + 去重 + 记账跟随', async () => {
+    const cacheDir = path.join(TEST_USER_DATA, 'model-discovery');
+    await fsp.mkdir(cacheDir, { recursive: true });
+    const dirtyModel = (id: string, name: string, sortOrder: number) => ({
+      id,
+      name,
+      group: 'anthropic',
+      sortOrder,
+      contextWindow: 1_000_000,
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+      supportsFastMode: false,
+      status: 'active',
+    });
+    await fsp.writeFile(
+      path.join(cacheDir, 'anthropic-models.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-30T00:00:00.000Z',
+        models: [
+          dirtyModel('claude-fable-5[1m]', 'Fable 5', 0),
+          dirtyModel('claude-fable-5', 'Fable 5 dup', 1),
+          dirtyModel('claude-opus-4-8', 'Opus 4.8', 2),
+        ],
+        explicitWindows: { 'claude-fable-5[1m]': 800_000 },
+        explicitEffortModelIds: ['claude-fable-5[1m]'],
+      }),
+      'utf-8',
+    );
+
+    await loadAnthropicModelsFromDiskCache();
+    // 脏 id 归一化 + first-wins 去重:选中 claude-fable-5 的会话恢复来源匹配。
+    expect(anthropicIds()).toEqual(['claude-fable-5', 'claude-opus-4-8']);
+    expect(anthropicModel('claude-fable-5')?.name).toBe('Fable 5');
+
+    // explicitWindows / explicitEffort 记账按归一化 id 跟随:后续 SDK 捕获(注册表仍报
+    // [1m] 变体)归一化后能命中记账——精确窗口不被打回猜测值,已精化档位不被抹掉。
+    noteAnthropicSdkSupportedModels([{ value: 'claude-fable-5[1m]', displayName: 'Fable 5' }]);
+    expect(anthropicModel('claude-fable-5')?.contextWindow).toBe(800_000);
+    expect(anthropicModel('claude-fable-5')?.efforts).toEqual(['low', 'medium', 'high']);
   });
 
   it('退化捕获只合并同 id 能力、不缩减清单;正常演进照常生效', () => {

--- a/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/anthropic.ts
@@ -129,9 +129,15 @@ function generationCanApply(generation: number, models: CatalogModel[]): boolean
   return generation === authGeneration && (models.length === 0 || hasClaudeAiOAuth());
 }
 
-/** 剥掉 dated wire id 的日期后缀(claude-opus-4-8-20260401 → claude-opus-4-8)。 */
+/**
+ * wire id → 目录 id 归一化:先剥 `[1m]` 等方括号路由后缀,再剥 dated 日期后缀
+ * (claude-opus-4-8-20260401 → claude-opus-4-8)。SDK 注册表把长上下文变体报成
+ * claude-fable-5[1m],而目录与会话选中的 id 无此后缀——不剥会让该模型在
+ * sourcesForModel 的精确匹配整体 miss,顶栏误报「已断开」并禁发。口径与
+ * claude-gateway-config / usageFormat 的既有归一化一致。
+ */
 function normalizeModelId(raw: string): string {
-  return raw.replace(/-20\d{6}$/, '');
+  return raw.replace(/\[[^\]]*\]$/, '').replace(/-20\d{6}$/, '');
 }
 
 /** contextWindow 规则:HTTP 明示 > 目录已知值 > 未知模型启发式(默认 1M,Haiku 200k)。 */
@@ -547,7 +553,11 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
     const windows = (raw as { explicitWindows?: unknown }).explicitWindows;
     if (windows && typeof windows === 'object' && !Array.isArray(windows)) {
       for (const [id, win] of Object.entries(windows as Record<string, unknown>)) {
-        if (typeof win === 'number' && win > 0) explicitWindows.set(id, win);
+        // key 同样归一化:历史缓存可能以带 [1m] 后缀的脏 id 记账。归一化后撞 key 时
+        // first-wins,与下方 models 去重同口径,避免拼出「窗口来自 A、能力来自 B」的杂交态。
+        if (typeof win !== 'number' || win <= 0) continue;
+        const normalizedId = normalizeModelId(id);
+        if (!explicitWindows.has(normalizedId)) explicitWindows.set(normalizedId, win);
       }
     }
     // 恢复待确认骤减记账(跨重启累计,见 persistPendingShrink;坏字段静默忽略)。
@@ -561,7 +571,11 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
         Number.isInteger(p.streak) &&
         p.streak > 0
       ) {
-        httpShrinkSignature = p.signature;
+        // 签名按当前归一化口径重算(排序 id 集):历史签名可能含脏 id,口径漂移会让
+        // 跨重启的骤减确认计数被无声重置。
+        httpShrinkSignature = [...new Set(p.signature.split('\n').map(normalizeModelId))]
+          .sort()
+          .join('\n');
         httpShrinkStreak = Math.min(p.streak, CONFIRMED_SHRINK_STREAK);
       }
     }
@@ -576,12 +590,28 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
         Array.isArray((m as CatalogModel).efforts),
     );
     if (valid.length === 0) return;
-    const validIds = new Set(valid.map((model) => model.id));
+    // 归一化自愈:修复前的 SDK 捕获会把 claude-fable-5[1m] 这类脏 id 落盘。按当前口径
+    // 清洗 + first-wins 去重,启动加载即恢复来源匹配,不等下一次动态捕获才纠正。
+    const validIds = new Set<string>();
+    const deduped: CatalogModel[] = [];
+    for (const model of valid) {
+      const id = normalizeModelId(model.id);
+      if (validIds.has(id)) {
+        // 折叠丢弃留痕:两条脏/裸变体的能力字段可能不同,first-wins 的输者信息
+        // 会等下一次动态捕获刷新,这里记日志方便定位。
+        log.info(`anthropic disk cache entry folded by id normalization: ${model.id}`);
+        continue;
+      }
+      validIds.add(id);
+      deduped.push(id === model.id ? model : { ...model, id });
+    }
     const restoreIds = (value: unknown): Set<string> => {
       const restored = new Set<string>();
       if (Array.isArray(value)) {
         for (const id of value) {
-          if (typeof id === 'string' && validIds.has(id)) restored.add(id);
+          if (typeof id !== 'string') continue;
+          const normalizedId = normalizeModelId(id);
+          if (validIds.has(normalizedId)) restored.add(normalizedId);
         }
       }
       return restored;
@@ -598,7 +628,7 @@ export async function loadAnthropicModelsFromDiskCache(): Promise<void> {
     // mapper fallbacks from API/SDK-declared capabilities. Refresh every
     // non-explicit effort baseline and context window from the current
     // catalog so app upgrades cannot preserve stale model metadata.
-    const normalized = valid.map((model) => {
+    const normalized = deduped.map((model) => {
       const effortBaseline = restoredExplicitEffortIds.has(model.id)
         ? null
         : fallbackEffortBaseline(model.id);


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude.ai 订阅（授权）来源选中 Fable 5 的会话，顶栏模型选择器会反复误报「已断开」并禁用发送，而设置页显示连接正常。根因是 Anthropic 模型动态发现的 `normalizeModelId` 只剥日期后缀、不剥 `[1m]` 长上下文路由后缀：SDK `supportedModels()` 捕获把 `claude-fable-5[1m]` 原样写进目录并落盘，会话选中的目录 id `claude-fable-5` 在 `sourcesForModel` 的精确匹配整体 miss → 判定「该来源不提供当前模型」→ 误报断开；设置页只看 OAuth 凭证在否，所以两处口径分叉。启动时 HTTP `/v1/models` 刷新会暂时修好，下一个 cc 会话的 SDK 捕获又重新污染，症状反复出现（实机磁盘缓存 `model-discovery/anthropic-models.json` 中可见 `claude-fable-5[1m]` 脏 id）。

修复：

- `normalizeModelId` 先剥 `[1m]` 等方括号后缀再剥日期后缀，与 `claude-gateway-config` / `usageFormat` / `turnCostCalculator` 既有归一化口径对齐；
- 磁盘缓存加载时对历史脏 id 做归一化 + first-wins 去重（折叠留痕日志），`explicitWindows` / `explicitEffortModelIds` / `pendingShrink` 签名记账按归一化 id 跟随——存量用户升级后启动即自愈，不需要等下一次动态捕获；
- 新增回归测试两条：SDK 捕获 `[1m]` 变体的归一化去重 + cindyModelMeta 基线按裸 id 命中（修复前 `[1m]` id 查不到基线，Fable 会塌回合成三档丢失 xhigh/max）；磁盘缓存脏 id 自愈与记账跟随（精确窗口不被打回猜测值、已精化档位不被抹掉）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（用户实机反馈）
- 本 PR 包含：`model-discovery/anthropic.ts` 的 wire id 归一化与磁盘缓存自愈 + 回归测试
- 明确不包含：`@cindy/model-providers` 注册表匹配口径的改动；会话侧持久化 model 值的迁移（见「风险」）
- 用户可见变化：授权来源 + Fable 5 会话不再误报「已断开」/ 禁发；Fable 5 在授权来源下的 effort 档位恢复目录基线（含 xhigh/max）
- 是否存在 breaking change：无

### UI 变化

不涉及：纯 main 侧数据修复，「已断开」badge 的渲染逻辑未动，误报消失是数据被修正的结果。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
结果：68 passed（含新增 2 条回归；撤销修复后两条回归会红）

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit（仓库根，全量）
结果：通过（rc=0）
```

### 手工验证

在受影响实机上确认了故障态数据：`~/Library/Application Support/Cindy/model-discovery/anthropic-models.json` 的清单为 `['claude-fable-5[1m]', 'claude-haiku-4-5', …]`，仅 Fable 带脏后缀，与症状（仅授权 + Fable 5 组合误报断开）完全吻合。修复后的运行时行为未在打包实例验证（worktree 会话无法重启宿主），由上面的磁盘缓存自愈单测覆盖同一路径。

### 未执行的验证

未在运行中的 dev/打包实例做端到端复现-修复验证（worktree 会话限制）；升级后首次启动加载脏缓存 → 顶栏恢复，可由用户升级后直接观察确认。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他

### 影响与回滚

- 影响范围：仅 Anthropic（Claude.ai 订阅）供应商的模型清单发现与磁盘缓存加载路径；其它供应商与路由 / 计费侧不受影响（后者早有各自的 `[1m]` 归一化）。
- 回滚 / 降级方式：revert 本 commit 即可；磁盘缓存格式未变（只是值被归一化），回滚后旧代码可继续读取。
- 已知残留边缘（对抗性预审 P1，刻意不进本 PR）：如果有用户曾在污染窗口期从选择器点选过脏 id 行（会话 DB 里持久化了 `claude-fable-5[1m]`），本修复让目录侧收敛到裸 id 后，这类会话仍会显示「已断开」——用户重选一次 Fable 5 即恢复。全面处理需要动共享注册表匹配口径或会话数据迁移，影响面大于收益，如有实际反馈再作为 follow-up。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需：行为契约在代码注释与测试中）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
