### PR TITLE
refactor(desktop): 图像执行通道 per-provider 派发地基

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/cindyMediaCatalog.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindyMediaCatalog.test.ts
@@ -29,9 +29,9 @@ describe('deriveCindyMediaConfig — 正常目录', () => {
   it('清单按目录序、label 取 name、providerId 记归属;draft/best 缺省回落 standard', () => {
     const image = deriveCindyMediaConfig([XD], 'image');
     expect(image.models).toEqual([
-      { id: 'gpt-image-2', label: 'GPT Image 2', providerId: 'xd' },
-      { id: 'gemini-3-pro-image', label: 'Gemini 3 Pro Image', providerId: 'xd' },
-      { id: 'gemini-3.1-flash-image', label: 'Gemini 3.1 Flash Image', providerId: 'xd' },
+      { id: 'gpt-image-2', label: 'GPT Image 2', providerId: 'xd', supportsEdit: true },
+      { id: 'gemini-3-pro-image', label: 'Gemini 3 Pro Image', providerId: 'xd', supportsEdit: true },
+      { id: 'gemini-3.1-flash-image', label: 'Gemini 3.1 Flash Image', providerId: 'xd', supportsEdit: true },
     ]);
     // best 没声明 → 回落 standard。
     expect(image.defaults).toEqual({
@@ -200,5 +200,30 @@ describe('deriveCindyMediaConfig — 就绪过滤(isProviderReady,2026-07 图像
     };
     const cfg = deriveCindyMediaConfig([XD, clash], 'image');
     expect(cfg.models.find((m) => m.id === 'gpt-image-2')?.providerId).toBe('xd');
+  });
+});
+
+describe('deriveCindyMediaConfig — supportsEdit(仅生成来源,2026-07)', () => {
+  const XAI: CindyMediaProviderSlice = {
+    id: 'xai',
+    imageModels: [{ id: 'xai/aurora', name: 'Aurora' }],
+  };
+
+  it('不传 isProviderEditReady → 所有条目 supportsEdit=true(兼容路径)', () => {
+    const cfg = deriveCindyMediaConfig([XD, XAI], 'image');
+    expect(cfg.models.every((m) => m.supportsEdit)).toBe(true);
+  });
+
+  it('isProviderEditReady 为 false 的来源条目 supportsEdit=false,仍进生成清单', () => {
+    const cfg = deriveCindyMediaConfig(
+      [XD, XAI],
+      'image',
+      undefined,
+      () => true,
+      (id) => id !== 'xai',
+    );
+    expect(cfg.models.map((m) => m.id)).toContain('xai/aurora');
+    expect(cfg.models.find((m) => m.id === 'xai/aurora')?.supportsEdit).toBe(false);
+    expect(cfg.models.find((m) => m.id === 'gpt-image-2')?.supportsEdit).toBe(true);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/cindyMediaCatalog.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindyMediaCatalog.test.ts
@@ -26,12 +26,12 @@ const XD: CindyMediaProviderSlice = {
 };
 
 describe('deriveCindyMediaConfig — 正常目录', () => {
-  it('清单按目录序、label 取 name;draft/best 缺省回落 standard', () => {
+  it('清单按目录序、label 取 name、providerId 记归属;draft/best 缺省回落 standard', () => {
     const image = deriveCindyMediaConfig([XD], 'image');
     expect(image.models).toEqual([
-      { id: 'gpt-image-2', label: 'GPT Image 2' },
-      { id: 'gemini-3-pro-image', label: 'Gemini 3 Pro Image' },
-      { id: 'gemini-3.1-flash-image', label: 'Gemini 3.1 Flash Image' },
+      { id: 'gpt-image-2', label: 'GPT Image 2', providerId: 'xd' },
+      { id: 'gemini-3-pro-image', label: 'Gemini 3 Pro Image', providerId: 'xd' },
+      { id: 'gemini-3.1-flash-image', label: 'Gemini 3.1 Flash Image', providerId: 'xd' },
     ]);
     // best 没声明 → 回落 standard。
     expect(image.defaults).toEqual({
@@ -159,5 +159,46 @@ describe('deriveCindyMediaConfig — 停用过滤(model-disable override)', () =
 
   it('不传谓词 = 不过滤(既有调用方为空的兼容路径)', () => {
     expect(deriveCindyMediaConfig([XD], 'image').models).toHaveLength(3);
+  });
+});
+
+describe('deriveCindyMediaConfig — 就绪过滤(isProviderReady,2026-07 图像多来源)', () => {
+  const GEMINI: CindyMediaProviderSlice = {
+    id: 'gemini',
+    imageModels: [{ id: 'gemini/gemini-3-pro-image', name: 'Gemini 3 Pro Image' }],
+  };
+
+  it('未就绪的供应商整段跳过(含其 defaults 声明),不长出"可选但必失败"的型号', () => {
+    const cfg = deriveCindyMediaConfig([XD, GEMINI], 'image', undefined, (id) => id === 'xd');
+    expect(cfg.models.map((m) => m.id)).toEqual([
+      'gpt-image-2',
+      'gemini-3-pro-image',
+      'gemini-3.1-flash-image',
+    ]);
+    // 未就绪供应商若声明了 defaults,同样不参与选型。
+    const withDefaults = deriveCindyMediaConfig(
+      [{ ...GEMINI, imageDefaults: { standard: 'gemini/gemini-3-pro-image' } }, XD],
+      'image',
+      undefined,
+      (id) => id === 'xd',
+    );
+    expect(withDefaults.defaults?.standard).toBe('gpt-image-2');
+  });
+
+  it('全部未就绪 → 能力不可用;不传谓词 = 全就绪(既有调用方兼容路径)', () => {
+    const none = deriveCindyMediaConfig([XD, GEMINI], 'image', undefined, () => false);
+    expect(none.models).toEqual([]);
+    expect(none.defaults).toBeNull();
+    const all = deriveCindyMediaConfig([XD, GEMINI], 'image');
+    expect(all.models.map((m) => m.providerId)).toEqual(['xd', 'xd', 'xd', 'gemini']);
+  });
+
+  it('providerId 归属按 first-wins 定格:同 id 先到者得,后来的供应商不改归属', () => {
+    const clash: CindyMediaProviderSlice = {
+      id: 'other',
+      imageModels: [{ id: 'gpt-image-2', name: '重复条目' }],
+    };
+    const cfg = deriveCindyMediaConfig([XD, clash], 'image');
+    expect(cfg.models.find((m) => m.id === 'gpt-image-2')?.providerId).toBe('xd');
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/imageChannelRegistry.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/imageChannelRegistry.test.ts
@@ -8,9 +8,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ImageChannelRegistry, type ImageChannel } from '../imageChannelRegistry';
 
-function channel(ready: boolean): ImageChannel {
+function channel(ready: boolean, supportsEdit?: boolean): ImageChannel {
   return {
     ready: () => ready,
+    ...(supportsEdit !== undefined ? { supportsEdit } : {}),
     generateImage: vi.fn(async () => ({ data: [{ b64_json: 'aGk=' }] })),
     editImage: vi.fn(async () => ({ data: [{ b64_json: 'aGk=' }] })),
   };
@@ -38,5 +39,16 @@ describe('ImageChannelRegistry', () => {
     registry.register('xd', xd);
     expect(registry.resolve('xd')).toBe(xd);
     expect(() => registry.register('xd', channel(true))).toThrow(/already registered/);
+  });
+
+  it('isProviderEditReady: supportsEdit: false 的来源不进编辑就绪', () => {
+    const registry = new ImageChannelRegistry();
+    registry.register('xd', channel(true));            // 省略 supportsEdit → true
+    registry.register('xai', channel(true, false));    // 仅生成
+    registry.register('gemini', channel(true, true));  // 明示支持编辑
+    expect(registry.isProviderEditReady('xd')).toBe(true);
+    expect(registry.isProviderEditReady('xai')).toBe(false);
+    expect(registry.isProviderEditReady('gemini')).toBe(true);
+    expect(registry.isProviderEditReady('unknown')).toBe(false);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/imageChannelRegistry.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/imageChannelRegistry.test.ts
@@ -39,4 +39,12 @@ describe('ImageChannelRegistry', () => {
     expect(registry.resolve('xd')).toBe(xd);
     expect(() => registry.register('xd', channel(true))).toThrow(/already registered/);
   });
+
+  it('supportsEdit: false 的通道 resolve 后仍携带该标记,供派发层拒改图请求', () => {
+    const registry = new ImageChannelRegistry();
+    const generateOnly: ImageChannel = { ...channel(true), supportsEdit: false };
+    registry.register('xai', generateOnly);
+    expect(registry.isProviderReady('xai')).toBe(true);
+    expect(registry.resolve('xai').supportsEdit).toBe(false);
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/imageChannelRegistry.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/imageChannelRegistry.test.ts
@@ -1,0 +1,42 @@
+/**
+ * imageChannelRegistry.test.ts — 图像执行通道注册表的纯函数单测。
+ * 重点锁住乱序安全兜底:未注册的 providerId 视为不就绪(目录数据先于通道代码
+ * 合入时,新模型只是不进白名单,绝不错发到别家通道)。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ImageChannelRegistry, type ImageChannel } from '../imageChannelRegistry';
+
+function channel(ready: boolean): ImageChannel {
+  return {
+    ready: () => ready,
+    generateImage: vi.fn(async () => ({ data: [{ b64_json: 'aGk=' }] })),
+    editImage: vi.fn(async () => ({ data: [{ b64_json: 'aGk=' }] })),
+  };
+}
+
+describe('ImageChannelRegistry', () => {
+  it('未注册的 providerId 不就绪(目录数据先行的乱序安全兜底)', () => {
+    const registry = new ImageChannelRegistry();
+    registry.register('xd', channel(true));
+    expect(registry.isProviderReady('xd')).toBe(true);
+    expect(registry.isProviderReady('gemini')).toBe(false);
+  });
+
+  it('ready() false 的通道不就绪;resolve 对未注册/未就绪都人话抛错', () => {
+    const registry = new ImageChannelRegistry();
+    registry.register('gemini', channel(false));
+    expect(registry.isProviderReady('gemini')).toBe(false);
+    expect(() => registry.resolve('gemini')).toThrow(/凭证未就绪/);
+    expect(() => registry.resolve('nonexistent')).toThrow(/没有可用的执行通道/);
+  });
+
+  it('resolve 返回就绪通道;重复注册同 providerId 抛错(装配期编程错误尽早暴露)', () => {
+    const registry = new ImageChannelRegistry();
+    const xd = channel(true);
+    registry.register('xd', xd);
+    expect(registry.resolve('xd')).toBe(xd);
+    expect(() => registry.register('xd', channel(true))).toThrow(/already registered/);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/cindyMediaCatalog.ts
+++ b/apps/desktop/src/main/cindy-brain/cindyMediaCatalog.ts
@@ -31,7 +31,13 @@ export interface CindyMediaCatalogConfig {
    * `providerId` = 该条目的归属来源(first-wins 定格)——图像多来源后派发端按它
    * 从 imageChannelRegistry 取执行通道,不再默认全部发 XD 网关(2026-07)。
    */
-  models: Array<{ id: string; label: string; providerId: string }>;
+  models: Array<{
+    id: string;
+    label: string;
+    providerId: string;
+    /** 该来源是否支持图像编辑。仅对 image 类目有意义;video 类目始终为 true。 */
+    supportsEdit: boolean;
+  }>;
   /**
    * 默认 / 档位选型。null = 目录没有该类目的任何模型(能力暂不可用);
    * 非 null 时 standard / draft / best 三个值必定在 models 里。
@@ -60,8 +66,9 @@ export function deriveCindyMediaConfig(
   kind: 'image' | 'video',
   isModelDisabled?: (providerId: string, modelId: string) => boolean,
   isProviderReady?: (providerId: string) => boolean,
+  isProviderEditReady?: (providerId: string) => boolean,
 ): CindyMediaCatalogConfig {
-  const models: Array<{ id: string; label: string; providerId: string }> = [];
+  const models: Array<{ id: string; label: string; providerId: string; supportsEdit: boolean }> = [];
   const seen = new Set<string>();
   let rawDefaults: { standard: string; draft?: string; best?: string } | undefined;
   for (const p of providers) {
@@ -71,7 +78,12 @@ export function deriveCindyMediaConfig(
       if (seen.has(m.id)) continue;
       if (isModelDisabled?.(p.id, m.id)) continue;
       seen.add(m.id);
-      models.push({ id: m.id, label: m.name, providerId: p.id });
+      models.push({
+        id: m.id,
+        label: m.name,
+        providerId: p.id,
+        supportsEdit: isProviderEditReady ? isProviderEditReady(p.id) : true,
+      });
     }
     // 多供应商时首个声明默认的生效(契约测试锁定只有 xd 声明)。
     const d = kind === 'image' ? p.imageDefaults : p.videoDefaults;

--- a/apps/desktop/src/main/cindy-brain/cindyMediaCatalog.ts
+++ b/apps/desktop/src/main/cindy-brain/cindyMediaCatalog.ts
@@ -26,8 +26,12 @@ export interface CindyMediaProviderSlice {
 }
 
 export interface CindyMediaCatalogConfig {
-  /** 可选清单 = 白名单 + 显示名(按目录出现序去重,first-wins)。 */
-  models: Array<{ id: string; label: string }>;
+  /**
+   * 可选清单 = 白名单 + 显示名(按目录出现序去重,first-wins)。
+   * `providerId` = 该条目的归属来源(first-wins 定格)——图像多来源后派发端按它
+   * 从 imageChannelRegistry 取执行通道,不再默认全部发 XD 网关(2026-07)。
+   */
+  models: Array<{ id: string; label: string; providerId: string }>;
   /**
    * 默认 / 档位选型。null = 目录没有该类目的任何模型(能力暂不可用);
    * 非 null 时 standard / draft / best 三个值必定在 models 里。
@@ -42,27 +46,34 @@ export interface CindyMediaCatalogConfig {
  * - 停用过滤:`isModelDisabled(providerId, modelId)` 为 true 的条目不进清单
  *   (用户在 设置 → 模型供应商 停用的媒体模型;缺省 = 不过滤)。被停用条目
  *   **不占** first-wins 的 seen;目录默认值指向被停用型号时同样回落清单首项。
- * - 默认:取**首个声明了默认段**的供应商(今天只有 xd 一家);目录写的默认值
- *   若不在册(型号已下架但默认没跟着改)→ 回落清单首项,不让能力卡死。
+ * - 就绪过滤:`isProviderReady(providerId)` 为 false 的供应商**整段跳过**
+ *   (含其 defaults 声明)——执行通道凭证未配置的来源(如 Gemini 没填 key)
+ *   不能进白名单,否则清单长出"可选但必失败"的型号(2026-07 图像多来源)。
+ *   缺省 = 全就绪。设置页展示不受此影响(那边走 buildRegistry,不经本函数)。
+ * - 默认:取**首个声明了默认段**的供应商(今天只有 xd 一家;契约测试锁定
+ *   非 xd 内置供应商不得声明 imageDefaults,防 BUILTIN 顺序把默认顶掉);
+ *   目录写的默认值若不在册(型号已下架但默认没跟着改)→ 回落清单首项。
  * - 清单为空 → `defaults: null`(调用方必须先判空再用 defaults)。
  */
 export function deriveCindyMediaConfig(
   providers: readonly CindyMediaProviderSlice[],
   kind: 'image' | 'video',
   isModelDisabled?: (providerId: string, modelId: string) => boolean,
+  isProviderReady?: (providerId: string) => boolean,
 ): CindyMediaCatalogConfig {
-  const models: Array<{ id: string; label: string }> = [];
+  const models: Array<{ id: string; label: string; providerId: string }> = [];
   const seen = new Set<string>();
   let rawDefaults: { standard: string; draft?: string; best?: string } | undefined;
   for (const p of providers) {
+    if (isProviderReady && !isProviderReady(p.id)) continue;
     const list = kind === 'image' ? p.imageModels : p.videoModels;
     for (const m of list ?? []) {
       if (seen.has(m.id)) continue;
       if (isModelDisabled?.(p.id, m.id)) continue;
       seen.add(m.id);
-      models.push({ id: m.id, label: m.name });
+      models.push({ id: m.id, label: m.name, providerId: p.id });
     }
-    // 多供应商时首个声明默认的生效(今天只有 xd 一家)。
+    // 多供应商时首个声明默认的生效(契约测试锁定只有 xd 声明)。
     const d = kind === 'image' ? p.imageDefaults : p.videoDefaults;
     if (!rawDefaults && d) rawDefaults = d;
   }

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -524,7 +524,12 @@ export class GhostCindySlot {
     }
     if (p.model !== undefined) {
       if (typeof p.model !== 'string' || !whitelist.has(p.model)) {
-        return { ok: false, message: '不支持的模型(不在主机白名单内)' };
+        // 拒绝话术带上当前可用清单:插件侧不再维护模型枚举(白名单单源执法,
+        // 2026-07),AI 点名失败时靠这份清单自愈,不用猜主机认哪些 id。
+        return {
+          ok: false,
+          message: `不支持的模型(不在主机白名单内)。当前可用:${cfg.models.map((m) => m.id).join(' / ')}`,
+        };
       }
       model = p.model;
     }

--- a/apps/desktop/src/main/cindy-brain/imageChannelRegistry.ts
+++ b/apps/desktop/src/main/cindy-brain/imageChannelRegistry.ts
@@ -1,0 +1,79 @@
+/**
+ * imageChannelRegistry.ts — 图像执行通道的 per-provider 注册表(2026-07 图像多来源)。
+ * [PROTOCOL]: 变更时更新此头部,然后检查 CLAUDE.md
+ *
+ * 背景:出图执行通道此前只有 XD 网关一条(gatewayImageClient 单例),目录里
+ * 却允许任何供应商声明 imageModels——数据先行、通道缺席时,新模型会被原样发到
+ * XD 网关打出确定性 4xx。本注册表把「哪个来源的模型由哪条通道、用哪份凭证执行」
+ * 收口成单点:
+ *
+ *   - `ready()`:该来源的执行凭证是否就绪(xd = 网关能力,BYO key = key 已存)。
+ *     cindyMediaCatalog 的白名单派生用它过滤——凭证未就绪的来源整段不进白名单,
+ *     清单里绝不长出「可选但必失败」的型号。
+ *   - `backend`:该来源的图像客户端(generate / edit)。派发端按白名单条目的
+ *     providerId 归属取通道;**未注册的 providerId 视为不就绪**——即使目录数据
+ *     先于通道代码合入(多 PR 乱序),新模型也只是不出现,不会错发到别家通道。
+ *
+ * 注册发生在 host 装配期(cindy-brain/index.ts);本模块零 IO、零 electron 依赖
+ * (规则 14),单测直测。
+ */
+
+import type { GhostImageAspectRatio } from '../../shared/ghost.js';
+
+/** 通道适配层的出参(与 decodeImageResponse 的入参同形:字节 + mime 由各通道自决)。 */
+export interface ImageChannelResult {
+  data: Array<{ b64_json?: string }>;
+  output_format?: string;
+}
+
+/**
+ * 单条图像执行通道。参数面收敛为「意识意图」级(aspectRatio 而非具体尺寸):
+ * 意图 → 各家 wire 参数(gpt-image 的 size 枚举 / Gemini 的 imageConfig.aspectRatio)
+ * 的翻译是通道自己的知识,不外泄给派发端。
+ */
+export interface ImageChannel {
+  /** 执行凭证是否就绪。false ⇒ 该来源整段不进 cindy 白名单。 */
+  ready(): boolean;
+  generateImage(params: {
+    model: string;
+    prompt: string;
+    aspectRatio?: GhostImageAspectRatio;
+  }): Promise<ImageChannelResult>;
+  editImage(params: {
+    model: string;
+    prompt: string;
+    imagePaths: string[];
+    aspectRatio?: GhostImageAspectRatio;
+  }): Promise<ImageChannelResult>;
+}
+
+export class ImageChannelRegistry {
+  private channels = new Map<string, ImageChannel>();
+
+  register(providerId: string, channel: ImageChannel): void {
+    if (this.channels.has(providerId)) {
+      throw new Error(`image channel already registered for provider ${providerId}`);
+    }
+    this.channels.set(providerId, channel);
+  }
+
+  /** 白名单派生用:未注册 = 不就绪(目录数据先行时的乱序安全兜底)。 */
+  isProviderReady(providerId: string): boolean {
+    return this.channels.get(providerId)?.ready() === true;
+  }
+
+  /**
+   * 派发用:取该来源的通道。未注册/未就绪时抛人话错——正常流程走不到这里
+   * (白名单派生已过滤),走到即说明白名单与派发窗口之间凭证被移除。
+   */
+  resolve(providerId: string): ImageChannel {
+    const channel = this.channels.get(providerId);
+    if (!channel) {
+      throw new Error(`图像来源 ${providerId} 没有可用的执行通道`);
+    }
+    if (!channel.ready()) {
+      throw new Error(`图像来源 ${providerId} 的凭证未就绪,请先在设置中完成配置`);
+    }
+    return channel;
+  }
+}

--- a/apps/desktop/src/main/cindy-brain/imageChannelRegistry.ts
+++ b/apps/desktop/src/main/cindy-brain/imageChannelRegistry.ts
@@ -34,6 +34,11 @@ export interface ImageChannelResult {
 export interface ImageChannel {
   /** 执行凭证是否就绪。false ⇒ 该来源整段不进 cindy 白名单。 */
   ready(): boolean;
+  /**
+   * 该来源是否支持图像编辑(editImage)。
+   * 省略视为 true;仅生成来源(xAI 等)显式设为 false 以从编辑清单排除。
+   */
+  supportsEdit?: boolean;
   generateImage(params: {
     model: string;
     prompt: string;
@@ -60,6 +65,12 @@ export class ImageChannelRegistry {
   /** 白名单派生用:未注册 = 不就绪(目录数据先行时的乱序安全兜底)。 */
   isProviderReady(providerId: string): boolean {
     return this.channels.get(providerId)?.ready() === true;
+  }
+
+  /** 编辑操作清单派生用:就绪且 supportsEdit !== false。 */
+  isProviderEditReady(providerId: string): boolean {
+    const ch = this.channels.get(providerId);
+    return ch?.ready() === true && ch.supportsEdit !== false;
   }
 
   /**

--- a/apps/desktop/src/main/cindy-brain/imageChannelRegistry.ts
+++ b/apps/desktop/src/main/cindy-brain/imageChannelRegistry.ts
@@ -34,6 +34,8 @@ export interface ImageChannelResult {
 export interface ImageChannel {
   /** 执行凭证是否就绪。false ⇒ 该来源整段不进 cindy 白名单。 */
   ready(): boolean;
+  /** 是否支持改图。undefined/true = 支持;false = 仅生成,改图派发前早失效。 */
+  supportsEdit?: boolean;
   generateImage(params: {
     model: string;
     prompt: string;

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1719,8 +1719,8 @@ function assertMediaModelStillEnabled(kind: 'image' | 'video', model: string): v
   if (!getCatalogMediaConfig(kind).models.some((m) => m.id === model)) {
     throw new Error(
       kind === 'image'
-        ? '图像模型已在设置中停用,本次生成已取消'
-        : '视频模型已在设置中停用,本次生成已取消',
+        ? '图像模型不可用(可能已停用或来源凭证未就绪),本次生成已取消'
+        : '视频模型不可用(可能已停用或来源凭证未就绪),本次生成已取消',
     );
   }
 }
@@ -1859,7 +1859,11 @@ function getImageChannelRegistry(): ImageChannelRegistry {
  */
 function resolveImageChannelForModel(model: string) {
   const entry = getCatalogMediaConfig('image').models.find((m) => m.id === model);
-  if (!entry) throw new Error('图像模型已在设置中停用,本次生成已取消');
+  if (!entry) {
+    const slash = model.indexOf('/');
+    if (slash > 0) getImageChannelRegistry().resolve(model.slice(0, slash));
+    throw new Error('图像模型不可用,本次生成已取消');
+  }
   return getImageChannelRegistry().resolve(entry.providerId);
 }
 

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1903,6 +1903,9 @@ export function getGhostCindySlot(): GhostCindySlot {
         try {
           assertMediaModelStillEnabled('image', model);
           const channel = resolveImageChannelForModel(model);
+          if (channel.supportsEdit === false) {
+            throw new Error('所选图像来源不支持改图,请改用支持改图的型号');
+          }
           return decodeImageResponse(
             await channel.editImage({
               model,

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -189,7 +189,7 @@ import {
   markGhostRecentlyUsed,
 } from './ghostRecentUsageStore.js';
 import { getCindyProxyMediaService } from '../mcp-integrations/cindyProxyMedia.js';
-import type { GatewayImageModel } from '../cindy-proxy-media/types.js';
+import { ImageChannelRegistry } from './imageChannelRegistry.js';
 import * as blobStore from '../cindy-media/blobStore.js';
 import * as ledger from '../cindy-media/ledger.js';
 import { ingestMedia, supportedMime } from '../cindy-media/ingest.js';
@@ -1692,6 +1692,10 @@ function getCatalogMediaConfig(kind: 'image' | 'video'): CindyMediaCatalogConfig
       (providerId, modelId) =>
         isProviderDisabled(access, providerId) ||
         isModelDisabled(access, providerId, modelId),
+      // 图像来源要求执行通道凭证就绪(未注册/未配置的来源整段不进白名单,
+      // 见 imageChannelRegistry 头注);视频通道今天只有 xd 一家,不做该过滤
+      // (registry 只登记图像通道,按 kind 收窄避免把视频清单误清空)。
+      kind === 'image' ? (providerId) => getImageChannelRegistry().isProviderReady(providerId) : undefined,
     );
   } catch (err) {
     // 目录读取异常 = 拿不到可用性证明,同「空清单」处理(不静默顶一份旧名单)。
@@ -1814,6 +1818,51 @@ const GHOST_ASPECT_TO_GATEWAY_SIZE: Record<GhostImageAspectRatio, string> = {
   '2:3': '1024x1536',
 };
 
+/**
+ * 图像执行通道注册表单例(见 imageChannelRegistry.ts 头注)。xd 通道在此登记:
+ * ready 跟随网关能力(canUseCindyGateway;key 缺失时 requireApiKey 在派发时人话拒,
+ * 与历史行为一致),backend 是 cindyProxyMedia 的网关客户端,aspectRatio → 网关
+ * size 枚举的翻译在适配层完成(通道各家 wire 不同,意图翻译是通道自己的知识)。
+ * 后续来源(gemini / openai / xai)在各自 PR 里追加注册。
+ */
+let imageChannelRegistrySingleton: ImageChannelRegistry | null = null;
+function getImageChannelRegistry(): ImageChannelRegistry {
+  if (!imageChannelRegistrySingleton) {
+    const registry = new ImageChannelRegistry();
+    registry.register('xd', {
+      ready: () => getAppCapabilities().canUseCindyGateway,
+      generateImage: ({ model, prompt, aspectRatio }) =>
+        getCindyProxyMediaService().backend.generateImage({
+          model,
+          prompt,
+          // 不带画幅意图时不传 size,网关缺省 'auto'(模型自定)。
+          ...(aspectRatio ? { size: GHOST_ASPECT_TO_GATEWAY_SIZE[aspectRatio] } : {}),
+        }),
+      editImage: ({ model, prompt, imagePaths, aspectRatio }) =>
+        getCindyProxyMediaService().backend.editImage({
+          model,
+          prompt,
+          imagePaths,
+          // 改图的 auto 语义 = 跟随源图画幅,与放开之前行为一致。
+          ...(aspectRatio ? { size: GHOST_ASPECT_TO_GATEWAY_SIZE[aspectRatio] } : {}),
+        }),
+    });
+    imageChannelRegistrySingleton = registry;
+  }
+  return imageChannelRegistrySingleton;
+}
+
+/**
+ * 按解析出的模型定位归属来源并取执行通道。归属 = 白名单条目的 providerId
+ * (cindyMediaCatalog first-wins 定格);白名单查无该模型时视同已停用
+ * (assertMediaModelStillEnabled 同窗口语义)。
+ */
+function resolveImageChannelForModel(model: string) {
+  const entry = getCatalogMediaConfig('image').models.find((m) => m.id === model);
+  if (!entry) throw new Error('图像模型已在设置中停用,本次生成已取消');
+  return getImageChannelRegistry().resolve(entry.providerId);
+}
+
 /** XD Gateway 图片响应 → 字节 + mime(gen / edit 同一解码口径)。 */
 function decodeImageResponse(res: {
   data: Array<{ b64_json?: string }>;
@@ -1833,17 +1882,17 @@ export function getGhostCindySlot(): GhostCindySlot {
     cindySlotSingleton = new GhostCindySlot({
       getGhost: (id) =>
         getAppCapabilities().canUseCindyGateway ? findAvailableGhost(id) : null,
-      // model 已在 modelSlot 按白名单校验(白名单 = GatewayImageModel 全集),
-      // 这里收窄类型是安全的。
+      // model 已在 modelSlot 按白名单校验;归属来源(providerId)按白名单条目
+      // 定位,经 imageChannelRegistry 取对应执行通道(2026-07 图像多来源)。
       generateImage: async ({ prompt, model, aspectRatio }) => {
         try {
           assertMediaModelStillEnabled('image', model);
+          const channel = resolveImageChannelForModel(model);
           return decodeImageResponse(
-            await getCindyProxyMediaService().backend.generateImage({
-              model: model as GatewayImageModel,
+            await channel.generateImage({
+              model,
               prompt,
-              // 不带画幅意图时不传 size,网关缺省 'auto'(模型自定)。
-              ...(aspectRatio ? { size: GHOST_ASPECT_TO_GATEWAY_SIZE[aspectRatio] } : {}),
+              ...(aspectRatio ? { aspectRatio } : {}),
             }),
           );
         } catch (err) {
@@ -1853,14 +1902,13 @@ export function getGhostCindySlot(): GhostCindySlot {
       editImage: async ({ prompt, model, imagePaths, aspectRatio }) => {
         try {
           assertMediaModelStillEnabled('image', model);
+          const channel = resolveImageChannelForModel(model);
           return decodeImageResponse(
-            await getCindyProxyMediaService().backend.editImage({
-              model: model as GatewayImageModel,
+            await channel.editImage({
+              model,
               prompt,
               imagePaths,
-              // 同 generateImage:不带画幅意图时不传 size,网关缺省 'auto'
-              // (改图的 auto 语义 = 跟随源图画幅,与放开之前行为一致)。
-              ...(aspectRatio ? { size: GHOST_ASPECT_TO_GATEWAY_SIZE[aspectRatio] } : {}),
+              ...(aspectRatio ? { aspectRatio } : {}),
             }),
           );
         } catch (err) {

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1696,6 +1696,9 @@ function getCatalogMediaConfig(kind: 'image' | 'video'): CindyMediaCatalogConfig
       // 见 imageChannelRegistry 头注);视频通道今天只有 xd 一家,不做该过滤
       // (registry 只登记图像通道,按 kind 收窄避免把视频清单误清空)。
       kind === 'image' ? (providerId) => getImageChannelRegistry().isProviderReady(providerId) : undefined,
+      // 编辑就绪过滤:仅支持生成的来源(supportsEdit: false)的模型不进编辑清单,
+      // 防用户把该型号钉到 image.edit 偏好后在 editImage 路径拿到确定性 400。
+      kind === 'image' ? (providerId) => getImageChannelRegistry().isProviderEditReady(providerId) : undefined,
     );
   } catch (err) {
     // 目录读取异常 = 拿不到可用性证明,同「空清单」处理(不静默顶一份旧名单)。
@@ -1857,12 +1860,15 @@ function getImageChannelRegistry(): ImageChannelRegistry {
  * (cindyMediaCatalog first-wins 定格);白名单查无该模型时视同已停用
  * (assertMediaModelStillEnabled 同窗口语义)。
  */
-function resolveImageChannelForModel(model: string) {
+function resolveImageChannelForModel(model: string, operation: 'generate' | 'edit' = 'generate') {
   const entry = getCatalogMediaConfig('image').models.find((m) => m.id === model);
   if (!entry) {
     const slash = model.indexOf('/');
     if (slash > 0) getImageChannelRegistry().resolve(model.slice(0, slash));
     throw new Error('图像模型不可用,本次生成已取消');
+  }
+  if (operation === 'edit' && !entry.supportsEdit) {
+    throw new Error(`图像来源 ${entry.providerId} 不支持图像编辑,请在设置中选择支持编辑的来源`);
   }
   return getImageChannelRegistry().resolve(entry.providerId);
 }
@@ -1906,7 +1912,7 @@ export function getGhostCindySlot(): GhostCindySlot {
       editImage: async ({ prompt, model, imagePaths, aspectRatio }) => {
         try {
           assertMediaModelStillEnabled('image', model);
-          const channel = resolveImageChannelForModel(model);
+          const channel = resolveImageChannelForModel(model, 'edit');
           return decodeImageResponse(
             await channel.editImage({
               model,
@@ -3532,7 +3538,8 @@ export function registerGhostIpc(): void {
     }
     // 白名单按能力键类目取(video.* 钉的是视频清单里的 alias)。
     const cfg = (capability as string).startsWith('video.') ? getCatalogVideoConfig() : getCatalogImageConfig();
-    if (model !== null && !cfg.models.some((m) => m.id === model)) {
+    const isEditCap = capability === 'image.edit';
+    if (model !== null && !cfg.models.some((m) => m.id === model && (!isEditCap || m.supportsEdit))) {
       throwIpcError('INVALID_PARAMS', 'model must be null or a catalog model of the capability category');
     }
     const overrides = writeGhostCindyOverride(

--- a/apps/desktop/src/main/cindy-proxy-media/api/__tests__/gatewayImageClient.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/api/__tests__/gatewayImageClient.test.ts
@@ -53,3 +53,95 @@ describe('gatewayImageClient error context', () => {
     expect((error as Error).message).not.toContain('test-key');
   });
 });
+
+describe('gatewayImageClient 多来源通用化选项(2026-07)', () => {
+  const okImageResponse = () =>
+    new Response(JSON.stringify({ created: 1, data: [{ b64_json: 'aGk=' }] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  const proxy = {
+    baseUrl: 'https://api.example.test',
+    generatePath: '/v1/images/generations',
+    editPath: '/v1/images/edits',
+  };
+
+  it('brandLabel 进错误话术;missingKeyMessage 替换缺凭证提示', async () => {
+    const fetchImplementation = vi.fn(
+      async () => new Response(JSON.stringify({ error: { message: 'boom' } }), { status: 500 }),
+    ) as unknown as typeof fetch;
+    const client = createGatewayImageClient({
+      getApiKey: () => 'k',
+      proxy,
+      fetchImplementation,
+      brandLabel: 'OpenAI',
+    });
+    const err = await client.generateImage({ model: 'm', prompt: 'p' }).catch((e: unknown) => e);
+    expect((err as Error).message).toContain('OpenAI image request failed');
+    expect((err as Error).message).not.toContain('XD Gateway');
+
+    const noKey = createGatewayImageClient({
+      getApiKey: () => null,
+      proxy,
+      brandLabel: 'OpenAI',
+      missingKeyMessage: '请先在设置里配置 OpenAI 图像 API key',
+    });
+    const keyErr = await noKey.generateImage({ model: 'm', prompt: 'p' }).catch((e: unknown) => e);
+    expect((keyErr as Error).message).toBe('请先在设置里配置 OpenAI 图像 API key');
+  });
+
+  it('supportsEdit:false 时 editImage 人话明拒且不发请求', async () => {
+    const fetchImplementation = vi.fn(async () => okImageResponse()) as unknown as typeof fetch;
+    const client = createGatewayImageClient({
+      getApiKey: () => 'k',
+      proxy,
+      fetchImplementation,
+      brandLabel: 'xAI',
+      supportsEdit: false,
+    });
+    const err = await client
+      .editImage({ model: 'm', prompt: 'p', imagePaths: ['/tmp/x.png'] })
+      .catch((e: unknown) => e);
+    expect((err as Error).message).toContain('不支持改图');
+    expect(fetchImplementation).not.toHaveBeenCalled();
+  });
+
+  it('allowSizeQuality:false 时显式 size/quality 明拒不静默剥掉;缺省时连 size:auto 也不发', async () => {
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => okImageResponse(),
+    );
+    const client = createGatewayImageClient({
+      getApiKey: () => 'k',
+      proxy,
+      fetchImplementation: fetchMock as unknown as typeof fetch,
+      allowSizeQuality: false,
+    });
+    const err = await client
+      .generateImage({ model: 'm', prompt: 'p', size: '1024x1024' })
+      .catch((e: unknown) => e);
+    expect((err as Error).message).toContain('不支持画幅/档位参数');
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await client.generateImage({ model: 'm', prompt: 'p' });
+    const sent = JSON.parse(
+      String(fetchMock.mock.calls[0]?.[1]?.body),
+    ) as Record<string, unknown>;
+    expect('size' in sent).toBe(false);
+  });
+
+  it('缺省选项(xd 装配零参数变化):size 缺省仍发 auto,edit 仍可用', async () => {
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => okImageResponse(),
+    );
+    const client = createGatewayImageClient({
+      getApiKey: () => 'k',
+      proxy,
+      fetchImplementation: fetchMock as unknown as typeof fetch,
+    });
+    await client.generateImage({ model: 'gpt-image-2', prompt: 'p' });
+    const sent = JSON.parse(
+      String(fetchMock.mock.calls[0]?.[1]?.body),
+    ) as Record<string, unknown>;
+    expect(sent.size).toBe('auto');
+  });
+});

--- a/apps/desktop/src/main/cindy-proxy-media/api/gatewayImageClient.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/api/gatewayImageClient.ts
@@ -29,6 +29,23 @@ export interface CreateGatewayImageClientOptions {
    * 抛错即取消本次付费提交(PR #744 review 第二十一轮)。缺席 = 不查。
    */
   beforeDispatch?(model: string): void;
+  /**
+   * 错误话术里的来源品牌名(2026-07 图像多来源:同一 OpenAI-images 兼容客户端被
+   * xd 网关之外的来源复用,报错必须说清是哪家失败)。缺省 'XD Gateway'。
+   */
+  brandLabel?: string;
+  /**
+   * 该来源是否支持改图端点。false 时 editImage 直接人话明拒(不发请求)——
+   * 不支持的来源静默把 edit 发到 generate 端点或吞参数都是错误路由。缺省 true。
+   */
+  supportsEdit?: boolean;
+  /**
+   * 该来源是否接受 size / quality 参数。false 时带这两个参数的请求明拒,
+   * 不静默剥掉——静默降级会让调用方以为画幅/档位生效了。缺省 true。
+   */
+  allowSizeQuality?: boolean;
+  /** 未配置凭证时的人话报错(各来源引导不同:xd 是登录飞书,BYO key 是去设置填 key)。 */
+  missingKeyMessage?: string;
 }
 
 function gatewayErrorCode(body: unknown): string | null {
@@ -45,6 +62,7 @@ function requestErrorMessage(params: {
   status: number;
   model: string;
   message: string;
+  brandLabel: string;
   body?: unknown;
 }): string {
   const code = gatewayErrorCode(params.body);
@@ -53,10 +71,14 @@ function requestErrorMessage(params: {
     `model ${JSON.stringify(params.model)}`,
     ...(code ? [`code ${JSON.stringify(code)}`] : []),
   ].join(', ');
-  return `XD Gateway image request failed (${context}): ${params.message}`;
+  return `${params.brandLabel} image request failed (${context}): ${params.message}`;
 }
 
-async function parseResponse(res: Response, model: string): Promise<GatewayImageResponse> {
+async function parseResponse(
+  res: Response,
+  model: string,
+  brandLabel: string,
+): Promise<GatewayImageResponse> {
   const text = await res.text();
   let parsed: unknown;
   try {
@@ -66,6 +88,7 @@ async function parseResponse(res: Response, model: string): Promise<GatewayImage
       requestErrorMessage({
         status: res.status,
         model,
+        brandLabel,
         message: `non-JSON response: ${text.slice(0, 200)}`,
       }),
       res.status,
@@ -76,9 +99,9 @@ async function parseResponse(res: Response, model: string): Promise<GatewayImage
   if (!res.ok) {
     const errMsg =
       (parsed as { error?: { message?: string } })?.error?.message ??
-      `XD Gateway HTTP ${res.status}`;
+      `${brandLabel} HTTP ${res.status}`;
     throw new GatewayImageError(
-      requestErrorMessage({ status: res.status, model, message: errMsg, body: parsed }),
+      requestErrorMessage({ status: res.status, model, brandLabel, message: errMsg, body: parsed }),
       res.status,
       parsed,
     );
@@ -90,6 +113,7 @@ async function parseResponse(res: Response, model: string): Promise<GatewayImage
       requestErrorMessage({
         status: res.status,
         model,
+        brandLabel,
         message: 'response missing data[]',
         body: parsed,
       }),
@@ -119,6 +143,9 @@ export function createGatewayImageClient(opts: CreateGatewayImageClientOptions):
   ): Promise<GatewayImageResponse>;
 } {
   const beforeDispatch = opts.beforeDispatch;
+  const brandLabel = opts.brandLabel ?? 'XD Gateway';
+  const supportsEdit = opts.supportsEdit ?? true;
+  const allowSizeQuality = opts.allowSizeQuality ?? true;
   const baseUrl = normalizeBaseUrl(opts.proxy.baseUrl);
   const generateUrl = joinProxyUrl(baseUrl, opts.proxy.generatePath);
   const editUrl = joinProxyUrl(baseUrl, opts.proxy.editPath);
@@ -128,23 +155,35 @@ export function createGatewayImageClient(opts: CreateGatewayImageClientOptions):
     const key = await Promise.resolve(opts.getApiKey());
     if (!key) {
       throw new GatewayImageError(
-        'XD Gateway api key not found - please log in via Feishu first',
+        opts.missingKeyMessage ?? 'XD Gateway api key not found - please log in via Feishu first',
         401,
       );
     }
     return key;
   }
 
+  function assertSizeQualityAllowed(params: { size?: string; quality?: string }): void {
+    if (allowSizeQuality) return;
+    if (params.size !== undefined || params.quality !== undefined) {
+      throw new GatewayImageError(
+        `${brandLabel} 图像通道不支持画幅/档位参数(size/quality),请去掉后重试`,
+        400,
+      );
+    }
+  }
+
   async function generateImage(
     params: GatewayImageGenerateParams,
     signal?: AbortSignal,
   ): Promise<GatewayImageResponse> {
+    assertSizeQualityAllowed(params);
     const apiKey = await requireApiKey();
     const body: Record<string, unknown> = {
       model: params.model,
       prompt: params.prompt,
       n: params.n ?? 1,
-      size: params.size ?? 'auto',
+      // 不接受 size 的来源连缺省 'auto' 也不发(assert 只能挡显式参数)。
+      ...(allowSizeQuality ? { size: params.size ?? 'auto' } : {}),
     };
     if (params.quality) body.quality = params.quality;
 
@@ -160,13 +199,17 @@ export function createGatewayImageClient(opts: CreateGatewayImageClientOptions):
       body: JSON.stringify(body),
       signal,
     });
-    return parseResponse(res, params.model);
+    return parseResponse(res, params.model, brandLabel);
   }
 
   async function editImage(
     params: GatewayImageEditParams,
     signal?: AbortSignal,
   ): Promise<GatewayImageResponse> {
+    if (!supportsEdit) {
+      throw new GatewayImageError(`${brandLabel} 图像通道不支持改图,请换支持改图的模型`, 400);
+    }
+    assertSizeQualityAllowed(params);
     const apiKey = await requireApiKey();
     if (params.imagePaths.length === 0) {
       throw new GatewayImageError('image_edit requires at least 1 image', 400);
@@ -176,7 +219,8 @@ export function createGatewayImageClient(opts: CreateGatewayImageClientOptions):
     form.append('model', params.model);
     form.append('prompt', params.prompt);
     form.append('n', String(params.n ?? 1));
-    form.append('size', params.size ?? 'auto');
+    // 同 generateImage:不接受 size 的来源连缺省 'auto' 也不发。
+    if (allowSizeQuality) form.append('size', params.size ?? 'auto');
     if (params.quality) form.append('quality', params.quality);
 
     for (const p of params.imagePaths) {
@@ -195,7 +239,7 @@ export function createGatewayImageClient(opts: CreateGatewayImageClientOptions):
       body: form as unknown as BodyInit,
       signal,
     });
-    return parseResponse(res, params.model);
+    return parseResponse(res, params.model, brandLabel);
   }
 
   return { generateImage, editImage };

--- a/apps/desktop/src/main/cindy-proxy-media/types.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/types.ts
@@ -83,7 +83,13 @@ export const GATEWAY_VIDEO_MODELS = [
 export type GatewayVideoModel = (typeof GATEWAY_VIDEO_MODELS)[number]['id'];
 
 export interface GatewayImageGenerateParams {
-  model: GatewayImageModel;
+  /**
+   * 模型 id。放宽为 string(2026-07 图像多来源):同一客户端实现被 xd 网关之外的
+   * 图像来源(OpenAI 平台等 OpenAI-images 兼容面)复用,白名单校验在 cindySlot /
+   * cindyMediaCatalog 层完成,客户端不再重复收窄。xd 自己的清单契约仍由
+   * GATEWAY_IMAGE_MODELS + imageModelCatalogSync 测试锁定。
+   */
+  model: string;
   prompt: string;
   size?: string;
   quality?: 'low' | 'medium' | 'high';
@@ -91,7 +97,8 @@ export interface GatewayImageGenerateParams {
 }
 
 export interface GatewayImageEditParams {
-  model: GatewayImageModel;
+  /** 同 GatewayImageGenerateParams.model。 */
+  model: string;
   prompt: string;
   imagePaths: string[];
   size?: string;

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -117,3 +117,59 @@ describe('provider access policy', () => {
     },
   );
 });
+
+describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', () => {
+  it('非 global 区域对所有供应商清空图像清单/默认,新来源不绕地区闸', () => {
+    const gemini: Provider = {
+      id: 'gemini',
+      name: 'Google Gemini',
+      source: 'builtin',
+      agents: ['claude-code'],
+      auth: { method: 'oauth' },
+      routing: {},
+      models: { 'claude-code': [] },
+      imageModels: [{ id: 'gemini/gemini-3-pro-image', name: 'Gemini 3 Pro Image' }],
+    };
+    const openai: Provider = {
+      id: 'openai',
+      name: 'OpenAI',
+      source: 'builtin',
+      agents: ['claude-code'],
+      auth: { method: 'oauth' },
+      routing: {},
+      models: { 'claude-code': [] },
+      imageModels: [{ id: 'openai/gpt-image-2', name: 'GPT Image 2' }],
+      // 防御对象:即使有人违反"只有 xd 声明 defaults"的契约,大陆闸也要剥掉。
+      imageDefaults: { standard: 'openai/gpt-image-2' },
+    };
+    const base = catalog();
+    const projected = projectProviderCatalogForBuildRegion(
+      { ...base, providers: [...base.providers, gemini, openai] },
+      'cn',
+    );
+    for (const p of projected.providers) {
+      expect(p.imageModels ?? []).toEqual([]);
+      expect(p.imageDefaults).toBeUndefined();
+    }
+    // 视频白名单维持 xd 专属:非 xd 供应商声明的视频清单一并清空。
+    const xd = projected.providers.find((p) => p.id === 'xd');
+    expect(xd?.videoModels?.map((m) => m.id)).toEqual(['seedance-fast', 'seedance-pro']);
+  });
+
+  it('global 区域原样返回(含新来源的媒体清单)', () => {
+    const gemini: Provider = {
+      id: 'gemini',
+      name: 'Google Gemini',
+      source: 'builtin',
+      agents: ['claude-code'],
+      auth: { method: 'oauth' },
+      routing: {},
+      models: { 'claude-code': [] },
+      imageModels: [{ id: 'gemini/gemini-3-pro-image', name: 'Gemini 3 Pro Image' }],
+    };
+    const base = catalog();
+    const input = { ...base, providers: [...base.providers, gemini] };
+    const projected = projectProviderCatalogForBuildRegion(input, 'global');
+    expect(projected).toBe(input);
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -156,6 +156,30 @@ describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', ()
     expect(xd?.videoModels?.map((m) => m.id)).toEqual(['seedance-fast', 'seedance-pro']);
   });
 
+  it('非 xd 供应商 models dict 中的 mainland video 型号在 cn 区域同样被剥离', () => {
+    const thirdParty: Provider = {
+      id: 'third',
+      name: 'Third Party',
+      source: 'builtin',
+      agents: ['claude-code'],
+      auth: { method: 'oauth' },
+      routing: {},
+      models: {
+        'claude-code': [
+          { ...model('seedance-fast'), group: 'video' },
+          model('chat-model'),
+        ],
+      },
+    };
+    const base = catalog();
+    const projected = projectProviderCatalogForBuildRegion(
+      { ...base, providers: [...base.providers, thirdParty] },
+      'cn',
+    );
+    const third = projected.providers.find((p) => p.id === 'third');
+    expect(third?.models['claude-code']?.map((m) => m.id)).toEqual(['chat-model']);
+  });
+
   it('global 区域原样返回(含新来源的媒体清单)', () => {
     const gemini: Provider = {
       id: 'gemini',

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -180,6 +180,30 @@ describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', ()
     expect(third?.models['claude-code']?.map((m) => m.id)).toEqual(['chat-model']);
   });
 
+  it('mode: image_generation 的模型在 cn 区域被剥离(classifyModel 权威分类,不依赖 id 关键词)', () => {
+    const modeOnly: Provider = {
+      id: 'xai',
+      name: 'xAI',
+      source: 'builtin',
+      agents: ['claude-code'],
+      auth: { method: 'oauth' },
+      routing: {},
+      models: {
+        'claude-code': [
+          { ...model('xai/aurora'), mode: 'image_generation' },
+          model('xai/grok-chat'),
+        ],
+      },
+    };
+    const base = catalog();
+    const projected = projectProviderCatalogForBuildRegion(
+      { ...base, providers: [...base.providers, modeOnly] },
+      'cn',
+    );
+    const xai = projected.providers.find((p) => p.id === 'xai');
+    expect(xai?.models['claude-code']?.map((m) => m.id)).toEqual(['xai/grok-chat']);
+  });
+
   it('global 区域原样返回(含新来源的媒体清单)', () => {
     const gemini: Provider = {
       id: 'gemini',

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -5,7 +5,7 @@
  * providers and models exposed as selectable capabilities to product surfaces.
  */
 
-import { groupOf, type Catalog, type Provider } from '@cindy/model-providers';
+import { classifyModel, type Catalog, type Provider } from '@cindy/model-providers';
 import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
 export interface ProviderAccessContext {
@@ -55,7 +55,7 @@ export function projectProviderCatalogForBuildRegion(
       (provider.videoModels?.length ?? 0) > 0 ||
       provider.videoDefaults !== undefined ||
       Object.values(provider.models).some((list) =>
-        list?.some((m) => { const g = groupOf(m); return g === 'image' || g === 'video'; }),
+        list?.some((m) => { const g = classifyModel(m); return g === 'image' || g === 'video'; }),
       );
     const isCindyAi = provider.id === CINDY_AI_PROVIDER_ID;
     if (!hasMedia && !isCindyAi) return provider;
@@ -70,7 +70,7 @@ export function projectProviderCatalogForBuildRegion(
       Object.entries(provider.models).map(([agent, list]) => [
         agent,
         list.filter((model) => {
-          const group = groupOf(model);
+          const group = classifyModel(model);
           return group !== 'image' && (group !== 'video' || (isCindyAi && MAINLAND_VIDEO_MODEL_IDS.has(model.id)));
         }),
       ]),

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -32,9 +32,14 @@ function projectVideoDefaults(
 }
 
 /**
- * Build-region projection for the Cindy AI media catalog. Global keeps the
- * catalog source verbatim; Mainland China and dev share the Mainland product
- * semantics and expose only the media capabilities supported there.
+ * Build-region projection for the media catalog. Global keeps the catalog
+ * source verbatim; Mainland China and dev share the Mainland product semantics
+ * and expose only the media capabilities supported there.
+ *
+ * 2026-07 图像多来源:投影不再只针对 xd —— 大陆版「无图像能力」是产品语义,
+ * **所有**供应商的 imageModels/imageDefaults 一律清空(新来源不得绕过地区闸);
+ * 视频白名单(seedance 两型号)维持 xd 专属逻辑,其它供应商目前不声明视频清单,
+ * 声明了也一并清空(大陆视频能力只经 xd 网关合规通道)。
  */
 export function projectProviderCatalogForBuildRegion(
   catalog: Catalog,
@@ -44,12 +49,18 @@ export function projectProviderCatalogForBuildRegion(
 
   let changed = false;
   const providers = catalog.providers.map((provider) => {
-    if (provider.id !== CINDY_AI_PROVIDER_ID) return provider;
+    const hasMedia =
+      (provider.imageModels?.length ?? 0) > 0 ||
+      provider.imageDefaults !== undefined ||
+      (provider.videoModels?.length ?? 0) > 0 ||
+      provider.videoDefaults !== undefined;
+    const isCindyAi = provider.id === CINDY_AI_PROVIDER_ID;
+    if (!hasMedia && !isCindyAi) return provider;
     changed = true;
 
-    const videoModels = (provider.videoModels ?? []).filter((model) =>
-      MAINLAND_VIDEO_MODEL_IDS.has(model.id),
-    );
+    const videoModels = isCindyAi
+      ? (provider.videoModels ?? []).filter((model) => MAINLAND_VIDEO_MODEL_IDS.has(model.id))
+      : [];
     const videoIds = new Set(videoModels.map((model) => model.id));
     const videoDefaults = projectVideoDefaults(provider.videoDefaults, videoIds);
     const models = Object.fromEntries(

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -53,7 +53,10 @@ export function projectProviderCatalogForBuildRegion(
       (provider.imageModels?.length ?? 0) > 0 ||
       provider.imageDefaults !== undefined ||
       (provider.videoModels?.length ?? 0) > 0 ||
-      provider.videoDefaults !== undefined;
+      provider.videoDefaults !== undefined ||
+      Object.values(provider.models).some((list) =>
+        list?.some((m) => { const g = groupOf(m); return g === 'image' || g === 'video'; }),
+      );
     const isCindyAi = provider.id === CINDY_AI_PROVIDER_ID;
     if (!hasMedia && !isCindyAi) return provider;
     changed = true;
@@ -68,7 +71,7 @@ export function projectProviderCatalogForBuildRegion(
         agent,
         list.filter((model) => {
           const group = groupOf(model);
-          return group !== 'image' && (group !== 'video' || MAINLAND_VIDEO_MODEL_IDS.has(model.id));
+          return group !== 'image' && (group !== 'video' || (isCindyAi && MAINLAND_VIDEO_MODEL_IDS.has(model.id)));
         }),
       ]),
     ) as Provider['models'];

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -542,3 +542,29 @@ describe('buildRegistry 的清单发现失败投影', () => {
     expect(bare.find((p) => p.id === 'anthropic')?.modelDiscoveryFailure).toBeUndefined();
   });
 });
+
+describe('媒体清单跨供应商契约(2026-07 图像多来源)', () => {
+  // deriveCindyMediaConfig(desktop 侧)按目录序 first-wins 选默认与归属:
+  // BUILTIN 顺序里 openai/xai 排在 xd 前面,任何非 xd 供应商声明 imageDefaults
+  // 都会把 xd 的出厂默认顶掉;同 id 撞车会把 xd 条目的归属抢走(派发错通道)。
+  // 这两条是数据契约,在目录层锁死,不等运行时踩雷。
+  it('声明 imageDefaults / videoDefaults 的内置供应商只能是 xd(防 first-wins 顶默认)', () => {
+    for (const p of BUNDLED_CATALOG.providers) {
+      if (p.id === 'xd') continue;
+      expect(p.imageDefaults, `${p.id} 不得声明 imageDefaults`).toBeUndefined();
+      expect(p.videoDefaults, `${p.id} 不得声明 videoDefaults`).toBeUndefined();
+    }
+  });
+
+  it('非 xd 内置供应商的媒体模型 id 必须带 "<providerId>/" 前缀(防 first-wins 归属漂移)', () => {
+    for (const p of BUNDLED_CATALOG.providers) {
+      if (p.id === 'xd') continue;
+      for (const m of [...(p.imageModels ?? []), ...(p.videoModels ?? [])]) {
+        expect(
+          m.id.startsWith(`${p.id}/`),
+          `${p.id} 的媒体模型 ${m.id} 必须带 "${p.id}/" 前缀`,
+        ).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

出图执行通道此前只有 XD 网关一条(`gatewayImageClient` 单例、xd 托管 key),而目录结构允许任何供应商声明 `imageModels`——数据先行、通道缺席时,新来源的模型会被原样发到 XD 网关打出确定性 4xx。本 PR 为「图像模型多来源接入」(用户已授权的 OpenAI / Grok / Gemini 图像模型,依赖 #905 的 mode 分类保证它们进目录后聊天选择器选不到)铺 per-provider 派发地基,**本 PR 自身零行为变化**(目录仍只有 xd 声明媒体清单)。

- 新增 `imageChannelRegistry`:`providerId → { ready(), backend }` 执行通道注册表。**未注册的来源视为不就绪**——后续目录数据 PR 与通道 PR 乱序合并时,新模型只是不进白名单,绝不错发到别家通道(这是本系列 PR 的乱序安全机制)。本 PR 只注册 xd。
- `cindyMediaCatalog`:白名单条目带 `providerId` 归属(first-wins 定格);新增 `isProviderReady` 谓词,执行凭证未就绪的来源整段跳过(含 defaults 声明),白名单里不长「可选但必失败」的型号。
- `gatewayImageClient` 通用化:`brandLabel` / `supportsEdit` / `allowSizeQuality` / `missingKeyMessage` 选项(不支持的参数**明拒**不静默降级);xd 装配零参数变化。`params.model` 从字面量联合放宽为 `string`(白名单校验在 cindySlot / cindyMediaCatalog 层;xd 清单契约仍由 `GATEWAY_IMAGE_MODELS` + `imageModelCatalogSync.test` 锁定,该测试零修改)。
- cindy-brain 派发按白名单条目的 providerId 经 registry 取通道;意识画幅意图(aspectRatio)→ 各家 wire 参数的翻译下沉进通道适配层(各家参数面不同:gpt-image 是 size 枚举,Gemini 是 imageConfig.aspectRatio)。
- 区域闸泛化:非 global 构建对**所有**供应商清空 imageModels/imageDefaults(后续新来源不得绕过地区闸);视频白名单维持 xd 专属。
- 新增数据契约测试:`imageDefaults` 唯一声明者必须是 xd(deriveCindyMediaConfig 按目录序 first-wins 取默认,BUILTIN 顺序里 openai 在 xd 前面,不锁死会被顶掉);非 xd 内置供应商媒体模型 id 必须带 `<providerId>/` 前缀(防 first-wins 归属漂移把请求派错通道)。
- `cindySlot` 显式点名模型的拒绝话术附上当前可用清单(配合后续插件侧去掉模型 enum、白名单单源执法,AI 点名失败可自愈)。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求:图像模型多来源接入系列(PR-A 地基;后续 Gemini / OpenAI / xAI 来源与 cindy-art 插件更新各自独立 PR,任意顺序可合,依赖机制见上文 registry 的未注册兜底)
- 本 PR 包含:执行通道注册表、白名单派生的归属与就绪过滤、网关客户端通用化、区域闸泛化、数据契约测试
- 明确不包含:任何新图像来源的目录数据与通道实现(Gemini/OpenAI/xAI 各自 PR)、视频多来源、cindy-art 插件改动
- 用户可见变化:无(目录只有 xd 声明媒体清单,派发行为逐字节等价;唯一文案变化是点名不在册模型时错误信息多了可用清单)
- 是否存在 breaking change:无

### UI 变化

不涉及:未触碰 renderer 代码路径。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck             结果:通过
pnpm --filter @cindy/model-providers typecheck  结果:通过
pnpm --filter @cindy/model-providers test   结果:389 passed
pnpm test:unit                              结果:desktop 外全部 PASS;desktop 在本机 8-worker 线程池偶发 SIGSEGV(基础设施抖动,非断言失败),
                                            以 --maxWorkers=4 重跑 desktop 全量:1380 test files passed
```

新增/更新用例:cindyMediaCatalog(providerId 归属、ready 过滤、first-wins 防御)13 passed;gatewayImageClient(brandLabel/supportsEdit/allowSizeQuality/缺省等价)5 passed;imageChannelRegistry 3 passed;providerAccessPolicy(全供应商 strip + global 原样)11 passed;catalog.test 媒体契约 2 条。

### 手工验证

不涉及(零行为变化重构;实机链路验证放在引入真实新来源的后续 PR 做)。

### 未执行的验证

`pnpm test:all` 未跑(与改动风险不匹配;CI verify 为准)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:cindy-brain 图像派发路径与媒体白名单派生;xd 单来源下行为逐字节等价(缺省选项 + 单测锁定)
- 回滚 / 降级方式:revert 本 PR 即回到单通道直连形态,无数据/配置迁移