### PR TITLE
fix(desktop): skill 打包 zip 条目时间戳固定,消除 sha256 时间漂移

### DIFF
--- a/apps/desktop/src/main/skillhub/__tests__/zipPacker.test.ts
+++ b/apps/desktop/src/main/skillhub/__tests__/zipPacker.test.ts
@@ -9,7 +9,7 @@
  *   - zip 根直接是文件（无顶层目录包裹）
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -250,6 +250,27 @@ describe('skillhub/zipPacker.pack', () => {
     const r2 = await pack(dir2);
     // Same content, different path → only content matters → same sha256
     expect(r1.sha256).toBe(r2.sha256);
+  });
+
+  it('打包时刻不进 zip 字节:跨秒界两次 pack 仍同 sha256(条目时间戳已固定)', async () => {
+    // 回归背景:JSZip 缺省给条目盖打包瞬间墙钟(DOS 2 秒精度),两次 pack 跨过
+    // 秒界即 sha 漂移,上面的 determinism 用例在 CI 上随机红。用假时钟制造
+    // 远大于精度的墙钟差,锁住"时间不参与包字节"。
+    const dir1 = path.join(tmpDir, 'clock1');
+    const dir2 = path.join(tmpDir, 'clock2');
+    writeFile(dir1, 'SKILL.md', Buffer.from('clock-free', 'utf8'));
+    writeFile(dir2, 'SKILL.md', Buffer.from('clock-free', 'utf8'));
+
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      vi.setSystemTime(new Date('2026-07-30T20:42:59.900Z'));
+      const r1 = await pack(dir1);
+      vi.setSystemTime(new Date('2026-07-30T20:43:07.100Z'));
+      const r2 = await pack(dir2);
+      expect(r1.sha256).toBe(r2.sha256);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('aborts before reading files when the signal is already cancelled', async () => {

--- a/apps/desktop/src/main/skillhub/__tests__/zipPacker.test.ts
+++ b/apps/desktop/src/main/skillhub/__tests__/zipPacker.test.ts
@@ -255,11 +255,13 @@ describe('skillhub/zipPacker.pack', () => {
   it('打包时刻不进 zip 字节:跨秒界两次 pack 仍同 sha256(条目时间戳已固定)', async () => {
     // 回归背景:JSZip 缺省给条目盖打包瞬间墙钟(DOS 2 秒精度),两次 pack 跨过
     // 秒界即 sha 漂移,上面的 determinism 用例在 CI 上随机红。用假时钟制造
-    // 远大于精度的墙钟差,锁住"时间不参与包字节"。
+    // 远大于精度的墙钟差,锁住"时间不参与包字节";带子目录层级,覆盖 walk 递归路径。
     const dir1 = path.join(tmpDir, 'clock1');
     const dir2 = path.join(tmpDir, 'clock2');
-    writeFile(dir1, 'SKILL.md', Buffer.from('clock-free', 'utf8'));
-    writeFile(dir2, 'SKILL.md', Buffer.from('clock-free', 'utf8'));
+    for (const dir of [dir1, dir2]) {
+      writeFile(dir, 'SKILL.md', Buffer.from('clock-free', 'utf8'));
+      writeFile(dir, 'scripts/run.sh', Buffer.from('#!/bin/sh\necho ok\n', 'utf8'));
+    }
 
     vi.useFakeTimers({ toFake: ['Date'] });
     try {
@@ -268,8 +270,34 @@ describe('skillhub/zipPacker.pack', () => {
       vi.setSystemTime(new Date('2026-07-30T20:43:07.100Z'));
       const r2 = await pack(dir2);
       expect(r1.sha256).toBe(r2.sha256);
+      expect(r1.manifest.files.map((f) => f.relPath)).toContain('scripts/run.sh');
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it('时区不进 zip 字节:不同 TZ 下两次 pack 仍同 sha256(本地分量构造的条目时间戳)', async () => {
+    // zip 的 DOS 时间字段无时区,JSZip 用本地 getters 写分量——固定 UTC 瞬间在
+    // 不同时区会写出不同分量。锁住"本地分量构造"后任何时区字节一致。
+    // (POSIX Node 运行中改 process.env.TZ 即生效;不生效的平台上两次 pack
+    // 同时区,断言退化为原确定性语义,仍成立。)
+    const dir1 = path.join(tmpDir, 'tz1');
+    const dir2 = path.join(tmpDir, 'tz2');
+    for (const dir of [dir1, dir2]) {
+      writeFile(dir, 'SKILL.md', Buffer.from('tz-free', 'utf8'));
+      writeFile(dir, 'scripts/run.sh', Buffer.from('#!/bin/sh\necho ok\n', 'utf8'));
+    }
+
+    const prevTz = process.env.TZ;
+    try {
+      process.env.TZ = 'Asia/Shanghai';
+      const r1 = await pack(dir1);
+      process.env.TZ = 'America/New_York';
+      const r2 = await pack(dir2);
+      expect(r1.sha256).toBe(r2.sha256);
+    } finally {
+      if (prevTz === undefined) delete process.env.TZ;
+      else process.env.TZ = prevTz;
     }
   });
 

--- a/apps/desktop/src/main/skillhub/zipPacker.ts
+++ b/apps/desktop/src/main/skillhub/zipPacker.ts
@@ -19,13 +19,18 @@ import { isIgnoredSkillPackagePath } from './packageIgnore';
 const log = createLogger('skillhub:zipPacker');
 
 /**
- * zip 条目时间戳固定为常量:JSZip 缺省给每个条目盖打包瞬间的墙钟(DOS 时间
- * 2 秒精度),同一内容两次打包跨过秒界 sha256 即漂移——"内容相同 ⇒ 包字节相同"
- * 的确定性契约破产(publish 重试缓存与 server 端校验都以包 sha 为锚,CI 上
- * determinism 用例也会随机红)。取 2020-01-01(zip 的 DOS 时间下限是 1980,
- * 不能用 Unix epoch);条目真实 mtime 本就不进 manifest,无信息损失。
+ * zip 条目时间戳固定为常量 UTC 瞬间:JSZip 缺省给每个条目盖打包瞬间的墙钟
+ * (DOS 时间 2 秒精度),同一内容两次打包跨过秒界 sha256 即漂移——"内容相同 ⇒
+ * 包字节相同"的确定性契约破产(publish 重试缓存与 server 端校验都以包 sha
+ * 为锚,CI 上 determinism 用例也会随机红)。
+ *
+ * 时区无关性:本仓 JSZip 3.10 写 DOS 字段用的是 **UTC getters**
+ * (generate/ZipFileWorker.js: getUTCHours / getUTCFullYear),固定 UTC 瞬间
+ * 在任何进程时区下写出的字节都相同;回归用例用 TZ 翻转锁住这一点,若未来
+ * 升级 JSZip 改回本地 getters,该用例会红。(zip DOS 时间下限 1980,不能用
+ * Unix epoch;条目真实 mtime 本就不进 manifest,无信息损失。)
  */
-const ZIP_ENTRY_DATE = new Date('2020-01-01T00:00:00Z');
+const ZIP_ENTRY_DATE = new Date(Date.UTC(2020, 0, 1));
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -117,7 +122,10 @@ async function walk(
 
     const content = await fs.promises.readFile(fullPath);
     checkPackState();
-    zip.file(relPath, content, { date: ZIP_ENTRY_DATE });
+    // createFolders: false —— JSZip 缺省会为子目录隐式生成文件夹条目,且该条目
+    // 盖打包瞬间墙钟(date 选项只作用于本文件),确定性再度破口;省略文件夹条目
+    // 是可复现打包的标准做法,解压工具一律按文件路径自建目录,语义无损。
+    zip.file(relPath, content, { date: ZIP_ENTRY_DATE, createFolders: false });
 
     const fileSha256 = await streamSha256(fullPath);
     checkPackState();

--- a/apps/desktop/src/main/skillhub/zipPacker.ts
+++ b/apps/desktop/src/main/skillhub/zipPacker.ts
@@ -18,6 +18,15 @@ import { isIgnoredSkillPackagePath } from './packageIgnore';
 
 const log = createLogger('skillhub:zipPacker');
 
+/**
+ * zip 条目时间戳固定为常量:JSZip 缺省给每个条目盖打包瞬间的墙钟(DOS 时间
+ * 2 秒精度),同一内容两次打包跨过秒界 sha256 即漂移——"内容相同 ⇒ 包字节相同"
+ * 的确定性契约破产(publish 重试缓存与 server 端校验都以包 sha 为锚,CI 上
+ * determinism 用例也会随机红)。取 2020-01-01(zip 的 DOS 时间下限是 1980,
+ * 不能用 Unix epoch);条目真实 mtime 本就不进 manifest,无信息损失。
+ */
+const ZIP_ENTRY_DATE = new Date('2020-01-01T00:00:00Z');
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface PackResult {
@@ -108,7 +117,7 @@ async function walk(
 
     const content = await fs.promises.readFile(fullPath);
     checkPackState();
-    zip.file(relPath, content);
+    zip.file(relPath, content, { date: ZIP_ENTRY_DATE });
 
     const fileSha256 = await streamSha256(fullPath);
     checkPackState();


### PR DESCRIPTION
## 这次改了什么

### 摘要

`zipPacker.pack()`(skill 发布打包)此前 `zip.file()` 不传 `date`,JSZip 给每个条目盖打包瞬间的墙钟(zip DOS 时间 2 秒精度)——同一内容两次打包跨过秒界,包字节即不同、sha256 漂移:publish 链路的重试缓存与 server 端校验都以包 sha 为锚,"内容相同 ⇒ 包相同"的确定性契约实际不成立;自带的 determinism 用例在 CI 上随机红(实例:#1117 的 verify run 30580184936,与该 PR 改动无交集)。

修复(实测校准过两轮):
1. 条目时间戳固定为常量 UTC 瞬间 `Date.UTC(2020,0,1)`——对照本仓 JSZip 3.10 源码,`generate/ZipFileWorker.js` 写 DOS 字段用 **UTC getters**,固定 UTC 瞬间即时区无关(review 曾建议本地分量构造,实测反而在 TZ 翻转下漂移,已用回归用例锁死);
2. `createFolders: false`——JSZip 缺省为子目录隐式生成文件夹条目,该条目盖的仍是墙钟(`date` 选项只作用于本文件),含子目录的 skill 依旧不确定;省略文件夹条目是可复现打包的标准做法,解压工具按文件路径自建目录,语义无损。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1117 CI 红排查时发现的全仓级 flaky(自开源首次提交即存在)
- 本 PR 包含：zipPacker 条目时间戳/文件夹条目确定性修复;3 个回归用例(跨秒界含子目录 / TZ 翻转 / 原 determinism 用例由"通常过"变"必然过")
- 明确不包含：publish 链路其它环节、folderHash(独立体系,本就内容寻址)
- 用户可见变化：无(skill 发布产物字节从"随打包时刻/时区变化"变为"仅随内容变化")
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
apps/desktop: npx vitest run src/main/skillhub/__tests__/zipPacker.test.ts
结果：15 tests passed(新增:跨秒界含子目录同 sha / TZ 翻转 Asia/Shanghai→America/New_York 同 sha)

仓库根: pnpm test:unit
结果：全部 workspace PASS(EXIT:0)

pnpm --filter desktop run typecheck
结果：通过(0 error)
```

### 手工验证

不涉及:纯打包逻辑,确定性由单测锁定。

### 未执行的验证

未实际发布一个 skill 到 server 端做端到端验证——server 不读取 zip 条目时间戳(解压检视按文件内容),且已发布 skill 的历史包按上传时字节存档不受影响。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：skill 发布打包产物的字节构成(时间戳段);消费方(publish PUT / server 解压检视)不读条目时间戳,行为无变化
- 回滚 / 降级方式：revert 本 PR,打包回到时间敏感行为(仅 CI flake 回归,无数据影响)

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)