### PR TITLE
fix: 交付正文不再因收尾动作被折进「已工作」

### DIFF
--- a/apps/desktop/src/renderer/__tests__/workGroupDeliveryProse.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workGroupDeliveryProse.test.ts
@@ -1,0 +1,180 @@
+/**
+ * workGroupDeliveryProse.test.ts
+ * ---------------------------------------------------------------------------
+ * 回归:交付正文(简报 / 分析 / 总结)不能因为后面还跟了一个收尾动作就被折进
+ * 「已工作 Xs」。
+ *
+ * 背景(2026-07-31 定时巡检实例):agent 先输出 3250 字的产品决策简报,再调
+ * schedule_notify_current_run 发通知,最后说一句 110 字的「已触发通知」。SDK 的
+ * done seal 只盖在 turn 最后一条 assistant 上,而「最终答复」的回溯遇到任何工具
+ * 动作就停 —— 于是简报排在收尾动作之前,被整段折进「已工作 3m 4s」,消息流里只
+ * 剩那句收尾元数据。
+ *
+ * 修复口径(isDeliveryProseItem → maker-shared 的 isDeliveryProseText):正文达到
+ * 长度阈值、或带块级 markdown 结构(标题 / 表格 / ≥3 项列表)时,与位置无关一律
+ * 平铺。短进度旁白照旧折叠,不把消息流撑长。
+ *
+ * Node 环境(buildRenderItems / groupWorkRuns 都是纯函数)。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildRenderItems, groupWorkRuns } from '../components/chat/MessageStream';
+import type { ChatMessage } from '@/lib/makerChatStore';
+
+// ── 工厂 ───────────────────────────────────────────────────────────────────
+
+const mkUser = (id: string, content = '巡检待放行的 PR,给一份产品决策简报'): ChatMessage => ({
+  clientId: id,
+  role: 'user',
+  content,
+});
+
+const mkAssistant = (id: string, content: string, turnCompleted = false): ChatMessage => ({
+  clientId: id,
+  role: 'assistant',
+  content,
+  ...(turnCompleted ? { turnCompleted: true } : {}),
+});
+
+const mkThinking = (id: string, content = 'Thought'): ChatMessage => ({
+  clientId: id,
+  role: 'thinking',
+  content,
+});
+
+const mkTool = (id: string, toolName = 'Bash'): ChatMessage => ({
+  clientId: id,
+  role: 'tool_use',
+  content: '',
+  toolUseId: `tu-${id}`,
+  toolName,
+  toolInput: { command: 'gh pr diff 1111' },
+});
+
+const mkResult = (id: string, toolUseId: string, content = 'ok'): ChatMessage => ({
+  clientId: id,
+  role: 'tool_result',
+  content,
+  toolUseId,
+});
+
+// ── 断言小工具 ───────────────────────────────────────────────────────────────
+
+type RenderItems = ReturnType<typeof groupWorkRuns>;
+
+function topLevelMessageIds(items: RenderItems): string[] {
+  return items
+    .filter((item) => item.type === 'message')
+    .map((item) => item.message.clientId);
+}
+
+/** 是否有任一层 work_group 的 children 里含这条 assistant 正文。 */
+function isFoldedIntoWorkGroup(items: RenderItems, clientId: string): boolean {
+  const containsMessage = (item: RenderItems[number]): boolean => {
+    if (item.type === 'message') return item.message.clientId === clientId;
+    return item.type === 'work_group' && item.children.some(containsMessage);
+  };
+  return items.some(
+    (item) => item.type === 'work_group' && item.children.some(containsMessage),
+  );
+}
+
+function workGroups(items: RenderItems) {
+  return items.filter((it) => it.type === 'work_group');
+}
+
+/** 只靠长度过阈值的正文(无标题 / 无列表 / 无表格),用来单独覆盖长度信号。 */
+const longPlainProse = `本轮 7 条有活动,3 条首次亮相。${'逐条核对了改动落在哪些产品面。'.repeat(50)}`;
+
+/**
+ * 「正文 → 收尾副作用动作 → 一句话收尾」——被折叠问题的原始形状。
+ * `body` 是要检验的那条正文,收尾句带 seal。
+ */
+function briefThenNotifyTurn(body: string): ChatMessage[] {
+  return [
+    mkUser('u1'),
+    mkThinking('th1'),
+    mkTool('diff', 'Bash'),
+    mkResult('diff-result', 'tu-diff', 'diff --git a/apps/mobile/app/devices/index.tsx'),
+    mkAssistant('brief', body),
+    mkTool('notify', 'mcp__cindy_scheduler__schedule_notify_current_run'),
+    mkResult('notify-result', 'tu-notify', '{"ok":true}'),
+    mkAssistant('wrap', '本轮有 3 条首次亮相的 PR 需要你决策,已触发通知。', true),
+  ];
+}
+
+// ── 主 case ────────────────────────────────────────────────────────────────
+
+describe('交付正文不被收尾动作顶进「已工作 Xs」', () => {
+  it('长正文排在收尾动作之前也平铺可见', () => {
+    expect(longPlainProse.length).toBeGreaterThanOrEqual(600);
+
+    const items = groupWorkRuns(buildRenderItems(briefThenNotifyTurn(longPlainProse)).items, false);
+
+    expect(topLevelMessageIds(items)).toEqual(['u1', 'brief', 'wrap']);
+    expect(isFoldedIntoWorkGroup(items, 'brief')).toBe(false);
+    // 修复不是「整 turn 不折」:正文之前的工作过程照旧折成工作组。
+    expect(workGroups(items).length).toBeGreaterThan(0);
+    expect(isFoldedIntoWorkGroup(items, 'th1')).toBe(true);
+  });
+
+  it('带 markdown 标题的短正文同样平铺(结构信号,不靠长度)', () => {
+    const headed = '## 产品决策简报\n\n本轮 7 条有活动。';
+    expect(headed.length).toBeLessThan(600);
+
+    const items = groupWorkRuns(buildRenderItems(briefThenNotifyTurn(headed)).items, false);
+
+    expect(topLevelMessageIds(items)).toEqual(['u1', 'brief', 'wrap']);
+    expect(isFoldedIntoWorkGroup(items, 'brief')).toBe(false);
+  });
+
+  it('≥3 项列表算交付结构,平铺', () => {
+    const listed = '需要你决定的三条:\n- #1111 手机离线缓存\n- #692 effort 阻断发送\n- #1080 插件授权重构';
+
+    const items = groupWorkRuns(buildRenderItems(briefThenNotifyTurn(listed)).items, false);
+
+    expect(topLevelMessageIds(items)).toEqual(['u1', 'brief', 'wrap']);
+  });
+
+  it('表格正文平铺', () => {
+    const tabled = 'PR 一览:\n\n| PR | 建议 |\n| --- | --- |\n| #1111 | 放行 |';
+
+    const items = groupWorkRuns(buildRenderItems(briefThenNotifyTurn(tabled)).items, false);
+
+    expect(topLevelMessageIds(items)).toEqual(['u1', 'brief', 'wrap']);
+  });
+});
+
+// ── 不回归:短进度旁白照旧折叠 ────────────────────────────────────────────────
+
+describe('进度旁白仍然折进「已工作 Xs」', () => {
+  it('一句话旁白被折叠,消息流不因此变长', () => {
+    const items = groupWorkRuns(
+      buildRenderItems(briefThenNotifyTurn('我已经读完所有必要信息,现在写简报。')).items,
+      false,
+    );
+
+    expect(topLevelMessageIds(items)).toEqual(['u1', 'wrap']);
+    expect(isFoldedIntoWorkGroup(items, 'brief')).toBe(true);
+  });
+
+  it('只有 2 项列表的旁白不算交付,仍折叠', () => {
+    const items = groupWorkRuns(
+      buildRenderItems(briefThenNotifyTurn('接下来两件事:\n- 读 diff\n- 写简报')).items,
+      false,
+    );
+
+    expect(topLevelMessageIds(items)).toEqual(['u1', 'wrap']);
+    expect(isFoldedIntoWorkGroup(items, 'brief')).toBe(true);
+  });
+
+  it('单独的 --- 水平线不被误判成表格', () => {
+    const items = groupWorkRuns(
+      buildRenderItems(briefThenNotifyTurn('先跑脚本生成简报数据。\n\n---\n\n然后读结果。')).items,
+      false,
+    );
+
+    expect(topLevelMessageIds(items)).toEqual(['u1', 'wrap']);
+    expect(isFoldedIntoWorkGroup(items, 'brief')).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -31,7 +31,11 @@ import { createPortal } from 'react-dom';
 import { GitFork } from 'lucide-react';
 import { SelectionQuoteButton } from './SelectionQuoteButton';
 import { useTranslation } from 'react-i18next';
-import { findMessageTodoInsertions, isAgentPlanToolName } from '@cindy/maker-shared/message-render';
+import {
+  findMessageTodoInsertions,
+  isAgentPlanToolName,
+  isDeliveryProseText,
+} from '@cindy/maker-shared/message-render';
 
 import type { AgentTaskUpdate, ChatMessage } from '@/hooks/useCCAgentChat';
 import { Spinner } from '@/components/ui/spinner';
@@ -1406,6 +1410,27 @@ function isWorkActivityItem(it: RenderItem): it is WorkChildItem {
   );
 }
 
+/**
+ * 交付正文 item —— 无论落在 turn 的哪个位置都不折进「已工作 Xs」。
+ *
+ * 为什么只靠 seal 位置不够:「最终答复」只认最后一次动作之后的正文,而 agent
+ * 常见「先输出正文 → 再执行一个收尾副作用(发通知 / 落库 / 提交) → 再说一句
+ * 已完成」。这时真正的交付内容排在收尾动作之前,会被整段折起来,只剩收尾那句
+ * 元数据留在消息流里(实例:2026-07-31 定时巡检的产品决策简报 3250 字被折,
+ * 外面只剩 110 字的「已触发通知」)。
+ *
+ * 判据(长度 / 块级 markdown 结构)由 maker-shared 的 isDeliveryProseText 单一
+ * 提供,两端不各写一份。
+ */
+function isDeliveryProseItem(it: RenderItem): boolean {
+  return (
+    it.type === 'message' &&
+    it.message.role === 'assistant' &&
+    !it.message.systemCardType &&
+    isDeliveryProseText(it.message.content)
+  );
+}
+
 /** 最终可见正文候选:同一用户 turn 内最后一条普通 assistant 文本。 */
 function isAssistantAnswerCandidate(it: RenderItem): it is MessageRenderItem {
   return (
@@ -1810,6 +1835,9 @@ function groupActiveWorkRuns(items: RenderItem[], turnStartTs: number | null = n
  * 连续输出的 assistant 文字视为最终答复阶段,留在组外;若整轮没有真实动作,
  * 只保留最后一条 assistant 正文,此前文字仍视作工作过程。
  *
+ * 位置判定之外还有一条位置无关的兜底:交付正文(见 isDeliveryProseItem)即使排在
+ * 收尾动作之前也不折叠,免得「先出简报 → 再发通知 → 再说一句已完成」把产出藏进组里。
+ *
  * 没有最终正文(被中断 / 停在工具)或最终正文后仍有已完成动作时返回
  * handled:false,交回 groupLegacyWorkRuns 按连续动作折叠。tool_media /
  * agent_plan /运行中子 Agent 等非可归档项保持可见,并作为顺序锚点切开工作组。
@@ -1906,6 +1934,7 @@ function groupAnsweredTurnItems(
       !sealedAnswers.has(i) &&
       !isRunningAgentTask(it) &&
       !isWorkflowTaskItem(it) &&
+      !isDeliveryProseItem(it) &&
       isWorkChild(it)
     ) {
       run.push(it);

--- a/packages/maker-shared/src/__tests__/messageRender.test.ts
+++ b/packages/maker-shared/src/__tests__/messageRender.test.ts
@@ -250,6 +250,82 @@ describe('message render shared model', () => {
     expect(items.map((item) => item.type)).toEqual(['work_group', 'message', 'message']);
   });
 
+  // 交付正文与位置无关地留在折叠组外。原始形状(2026-07-31 定时巡检):agent 先输出
+  // 长篇简报,再调 notify 发通知,最后说一句「已触发通知」——SDK seal 只盖最后那句,
+  // 「最终答复」回溯又遇工具即停,简报会被整段折进「工作过程」。
+  it('keeps delivery prose outside the work fold even before a trailing side-effect tool', () => {
+    const brief = `本轮 7 条有活动。${'逐条核对了改动落在哪些产品面。'.repeat(50)}`;
+    expect(brief.length).toBeGreaterThanOrEqual(600);
+
+    const items = buildMessageRenderItems([
+      message({ kind: 'user', source: source('user', 'brief me', 1), body: 'brief me', label: 'user' }),
+      message({
+        kind: 'tool',
+        source: source('diff', { toolName: 'Bash', input: { command: 'gh pr diff' } }, 2),
+        body: 'Bash(gh pr diff)',
+        label: 'Bash',
+      }),
+      message({ kind: 'assistant', source: source('brief', brief, 3), body: brief, label: 'assistant' }),
+      message({
+        kind: 'tool',
+        source: source('notify', { toolName: 'schedule_notify_current_run', input: {} }, 4),
+        body: 'schedule_notify_current_run()',
+        label: 'schedule_notify_current_run',
+      }),
+      message({
+        kind: 'assistant',
+        source: source('wrap', 'notified', 5),
+        body: '本轮有 3 条需要你决策,已触发通知。',
+        label: 'assistant',
+        turnCompleted: true,
+      }),
+    ]);
+
+    expect(items.map((item) => item.type)).toEqual([
+      'message',
+      'work_group',
+      'message',
+      'work_group',
+      'message',
+    ]);
+    expect(expectType(items[2], 'message').message.key).toBe('brief');
+    expect(expectType(items[4], 'message').message.key).toBe('wrap');
+  });
+
+  it('still folds short progress narration that precedes a trailing side-effect tool', () => {
+    const items = buildMessageRenderItems([
+      message({ kind: 'user', source: source('user', 'brief me', 1), body: 'brief me', label: 'user' }),
+      message({
+        kind: 'tool',
+        source: source('diff', { toolName: 'Bash', input: { command: 'gh pr diff' } }, 2),
+        body: 'Bash(gh pr diff)',
+        label: 'Bash',
+      }),
+      message({
+        kind: 'assistant',
+        source: source('narration', 'reading', 3),
+        body: '读完了,现在写简报。',
+        label: 'assistant',
+      }),
+      message({
+        kind: 'tool',
+        source: source('notify', { toolName: 'schedule_notify_current_run', input: {} }, 4),
+        body: 'schedule_notify_current_run()',
+        label: 'schedule_notify_current_run',
+      }),
+      message({
+        kind: 'assistant',
+        source: source('wrap', 'notified', 5),
+        body: '本轮有 3 条需要你决策,已触发通知。',
+        label: 'assistant',
+        turnCompleted: true,
+      }),
+    ]);
+
+    expect(items.map((item) => item.type)).toEqual(['message', 'work_group', 'message']);
+    expect(expectType(items[2], 'message').message.key).toBe('wrap');
+  });
+
   it('surfaces tool result media as a standalone tool_media item that stays outside the work fold', () => {
     const items = buildMessageRenderItems([
       message({ kind: 'user', source: source('user', 'draw it', 1), body: 'draw it', label: 'user' }),

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -940,7 +940,12 @@ function groupAnsweredTurnItems<
 
   for (let index = 0; index < items.length; index++) {
     const item = items[index];
-    if (!sealedAnswers.has(index) && !isRunningAgentTaskItem(item) && isWorkChild(item)) {
+    if (
+      !sealedAnswers.has(index)
+      && !isRunningAgentTaskItem(item)
+      && !isDeliveryProseItem(item)
+      && isWorkChild(item)
+    ) {
       run.push(item);
     } else {
       flushRun(item);
@@ -1041,6 +1046,62 @@ function isCompactBoundaryItem<TMessage extends MessageRenderNormalizedMessage>(
   return item.type === 'message'
     && item.message.kind === 'system'
     && item.message.label === 'system:compact';
+}
+
+/**
+ * 「交付正文」长度阈值:超过它的 assistant 正文一律当本轮产出,不折进「工作过程」。
+ * 取 600 字符 —— 进度旁白（「先运行脚本」「继续读剩余 diff」）都在几十字量级,
+ * 而值得留在消息流里的简报、分析、总结普遍远超它。
+ */
+const DELIVERY_PROSE_MIN_LENGTH = 600;
+
+/** 块级 markdown 标题:交付正文最强的结构信号,进度旁白不会给自己写标题。 */
+const MARKDOWN_HEADING_RE = /^[ \t]{0,3}#{1,6}[ \t]+\S/m;
+
+/**
+ * 表格分隔行(`| --- | :-: |`)。刻意要求同一行里既有 `-{3,}` 又有 `|`:
+ * 只有成型的表格会这样,单独的 `---` 水平线不算交付信号。
+ */
+const MARKDOWN_TABLE_DIVIDER_RE = /^[ \t]{0,3}\|?[ \t]*:?-{3,}:?[ \t]*\|[-:| \t]*$/m;
+
+/** 块级列表项(无序 / 有序)。 */
+const MARKDOWN_LIST_ITEM_RE = /^[ \t]{0,3}(?:[-*+][ \t]+|\d{1,3}[.)][ \t]+)\S/gm;
+
+/** 列表要 ≥3 项才算交付结构:「我要做两件事」这类旁白也会顺手列两条。 */
+const DELIVERY_PROSE_MIN_LIST_ITEMS = 3;
+
+/**
+ * 这段 assistant 正文是不是「交付内容」(而非进度旁白)。
+ *
+ * 判据刻意与位置无关:长度达阈值,或带块级 markdown 结构(标题 / 表格 /
+ * ≥3 项列表)。两端共用这一份口径,不各自实现。
+ */
+export function isDeliveryProseText(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.length >= DELIVERY_PROSE_MIN_LENGTH) return true;
+  if (MARKDOWN_HEADING_RE.test(trimmed)) return true;
+  if (MARKDOWN_TABLE_DIVIDER_RE.test(trimmed)) return true;
+  // /g 正则不用 test():lastIndex 会在调用之间残留。
+  const listItems = trimmed.match(MARKDOWN_LIST_ITEM_RE);
+  return (listItems?.length ?? 0) >= DELIVERY_PROSE_MIN_LIST_ITEMS;
+}
+
+/**
+ * 交付正文 item —— 无论落在 turn 的哪个位置都不折进「工作过程」。
+ *
+ * 为什么只靠 seal 位置不够:「最终答复」只认最后一次动作之后的正文,而 agent
+ * 常见「先输出正文 → 再执行一个收尾副作用(发通知 / 落库 / 提交) → 再说一句
+ * 已完成」。这时真正的交付内容排在收尾动作之前,会被整段折起来,只剩收尾那句
+ * 元数据留在消息流里(实例:2026-07-31 定时巡检的产品决策简报 3250 字被折,
+ * 外面只剩 110 字的「已触发通知」)。
+ */
+function isDeliveryProseItem<TMessage extends MessageRenderNormalizedMessage>(
+  item: MessageRenderItem<TMessage>,
+): boolean {
+  return item.type === 'message'
+    && item.message.kind === 'assistant'
+    && isDeliveryProseText(item.message.body);
 }
 
 function isWorkChild<


### PR DESCRIPTION
## 这次改了什么

### 摘要

Agent 输出的交付内容(简报、分析、总结)会因为后面还跟了一个收尾动作而被整段折进「已工作 Xs」,消息流里只剩收尾那句元数据。

根因是「最终答复」的判定纯粹是位置性的:SDK 的 done seal 只盖在一个 turn 最后一条 assistant 上,而从 seal 向前回溯「同属答复阶段」的正文时,遇到任何一次工具动作就立刻停。于是「先输出正文 → 再执行一个收尾副作用(发通知 / 落库 / 提交) → 再说一句已完成」这个很常见的形状里,真正的产出排在收尾动作之前,被判成工作过程折起来。

实测实例:一个定时巡检会话输出 3250 字的产品决策简报,随后调 `schedule_notify_current_run` 发通知,最后说一句 110 字的「已触发通知」。打开会话只看到那 110 字,简报本体藏在「已工作 3m 4s」里。

修法是在位置判定之外加一条**位置无关**的判据:正文长度达阈值,或带块级 markdown 结构(标题 / 表格 / ≥3 项列表),即视为本轮交付,一律平铺。短进度旁白照旧折叠。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无(从实际会话里发现)
- 本 PR 包含：
  - `packages/maker-shared/src/messageRender.ts` 新增 `isDeliveryProseText`(单一口径,导出)+ `isDeliveryProseItem`,接入 `groupAnsweredTurnItems` 的收集循环
  - `apps/desktop/.../MessageStream.tsx` 直接 import 复用同一判据,不另写一份口径
  - 两端回归测试:desktop 7 个、共享包 2 个
- 明确不包含：
  - 不改折叠机制本身(工作组的分组、时长、展开记忆都不动)
  - 不改 seal 的产生与写入(`markAssistantTurnCompleted` 未动)
  - 不动 legacy / 流式两条分组路径 —— 它们本来就不折 assistant 正文
  - 折叠块标题不带被折正文的摘要(另一个可选改进,不在本 PR)
- 用户可见变化：达到「交付正文」判据的 assistant 正文一律留在消息流里,不再被折叠;短进度旁白的折叠行为不变。Desktop、Mobile、远控同步生效(共用 `buildMessageRenderItems`)。
- 是否存在 breaking change：无

判据细节(都写进了代码注释):

| 信号 | 阈值 | 为什么这样定 |
| --- | --- | --- |
| 长度 | ≥ 600 字符 | 进度旁白都在几十字量级;值得留在消息流的简报、分析普遍远超它 |
| markdown 标题 | 出现 `^#{1,6} ` | 最强结构信号,旁白不会给自己写标题 |
| 表格 | 同一行内既有 `-{3,}` 又有 `\|` | 只有成型表格会这样;单独的 `---` 水平线不算(有专门测试防误判) |
| 列表 | ≥ 3 项 | 「我要做两件事」这类旁白也会顺手列两条,2 项不算 |

刻意排除的信号:围栏代码块 —— 进度叙述里也常见,且工具卡已经展示了命令,单独用它做信号误伤面太大。

### UI 变化

不涉及视觉变化:没有引入任何新组件、样式、颜色、动效或文案,改的是「哪些 item 平铺、哪些进折叠组」的分组判定,平铺出来的正文仍由既有 `MessageItem` 渲染。因此双模式(Light / Dark)不涉及 —— 未新增任何颜色或硬编码样式。

- 引用的设计规范：
  - **DESIGN.md §5 Layout Principles / Whitespace Philosophy**:"Content density is low by design: one clear idea per surface. When a screen needs more, split it into progressive disclosure (§14) instead of packing it tighter." 「已工作 Xs」折叠正是这里说的 progressive disclosure。本改动不改这个机制,只修正**什么该被降级进去**:一轮的交付产出属于主层级内容,把它藏进渐进披露等于让用户找不到本轮的答案;而进度旁白继续折叠,正是为了守住低密度。
  - **DESIGN.md §7 Do — "Keep content density low — each section should present one clear idea"**:所以没有采用「所有 assistant 正文都平铺」的粗暴修法,而是设了长度 + 结构双阈值,只让达标的交付正文上浮,避免把每句旁白都推到主层级把密度顶高。上面表格里的每条阈值都是按这一条来定的。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/workGroupDeliveryProse.test.ts --pool=threads
结果：7 passed (7) — 新增回归测试

pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/messageRender.test.ts --pool=threads
结果：35 passed (35) — 含新增 2 个

pnpm --filter desktop exec vitest run src/renderer/__tests__/workGroup --pool=threads
结果：6 files / 49 passed — 相邻工作组测试无回归

pnpm test:unit（仓库级门禁）
结果：54 workspace PASS / 0 FAIL，GATE_EXIT=0（含 apps/desktop unit、packages/maker-shared unit）

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit）

pnpm --filter @cindy/maker-shared run --if-present typecheck
结果：该 package 无 typecheck script，按规则跳过

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

新增测试覆盖的场景:长正文 / 带标题的短正文 / ≥3 项列表 / 表格在收尾动作之前都平铺;一句话旁白、2 项列表、单独 `---` 水平线仍折叠。

### 手工验证

在功能 worktree 启动 desktop 开发实例(`pnpm restart:desktop:remote -- --preserve-running`),`pnpm desktop:whoami` 返回 `Desktop source: MATCH`,root / HEAD commit 一致、`state=ready`、`passive=true`、共享 userData。UI 目检由 Dash 本人在该实例上完成并确认。

### 未执行的验证

- **我没有自己做截图目检**:上面那次实机启动只由我核对了运行来源(whoami MATCH),界面确认是 Dash 本人做的,本 PR 不附截图。
- **Mobile 没跑模拟器**:共享包这一改按逻辑同时覆盖 Mobile 与远控(同一份 `buildMessageRenderItems`),已由共享包单测覆盖,但没有在 iOS Simulator 上实机确认。本 PR 未改任何 mobile 原生输入(`app.json` / `app.config.js` / `eas.json` / `apps/mobile/package.json` / `plugins/` / `modules/` 都未触碰),不改变 runtime fingerprint,不触发冷更。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：纯渲染层,只影响已结束 turn 的消息流折叠边界(`groupAnsweredTurnItems` 一条路径),Desktop / Mobile / 远控同步生效。不读写任何持久数据,不改协议,不改 system prompt。历史会话重新打开即按新判据渲染。
- 可以想到的取舍:阈值是启发式的,某些「较长但确实只是过程叙述」的正文会因此平铺出来,消息流比以前长一点。这是刻意选的方向 —— 交付内容被藏起来的代价远大于多显示一段过程叙述。阈值集中在 `messageRender.ts` 顶部的常量里,要调只改一处、两端同时生效。
- 回滚 / 降级方式：直接 revert 本 PR 即可,无数据迁移、无兼容包袱。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`,见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（判据与背景写在代码注释里,含复现实例;无独立文档需要改）
- [x] 已确认测试结果或说明未执行原因
