### PR TITLE
fix(desktop): hook 重连退避加向下抖动，避免服务重启后全端齐步重连

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -45,7 +45,11 @@ import {
   providerForTaskDispatch,
   type HookControlManagerDeps,
 } from '../manager';
-import { createHookTransport, type HookTransportOpts } from '../transport';
+import {
+  computeBackoffDelayMs,
+  createHookTransport,
+  type HookTransportOpts,
+} from '../transport';
 import type { SlackHookStore, SlackHookConfigState } from '../store';
 
 const noopLog = { info: () => {}, warn: () => {} };
@@ -390,6 +394,59 @@ describe('hook-control transport handshake recovery', () => {
     await expect.poll(() => upgrades, { timeout: 3000 }).toBeGreaterThanOrEqual(2);
     expect(statuses).toContain('error');
     expect(statuses).not.toContain('standby');
+  });
+});
+
+describe('hook-control transport backoff jitter', () => {
+  const BASE = 1000;
+  const MAX = 30_000;
+
+  it('抖动落在退避值的 [0.7, 1.0] 区间内', () => {
+    // random 的两个极端决定区间端点；中点用于确认是线性插值而非跳变。
+    expect(computeBackoffDelayMs(0, BASE, MAX, () => 0)).toBe(700);
+    expect(computeBackoffDelayMs(0, BASE, MAX, () => 0.5)).toBe(850);
+    // random() 返回 [0,1)，取不到 1；逼近 1 时应逼近 base 本身且不超过它。
+    expect(computeBackoffDelayMs(0, BASE, MAX, () => 0.999999)).toBe(BASE);
+  });
+
+  it('指数增长仍然成立，且 maxMs 是真实上限（抖动只向下）', () => {
+    // 高位 attempt 会让指数项远超 MAX，封顶后再抖动，绝不越过 MAX。
+    for (const attempt of [0, 1, 2, 3, 4, 5, 10, 30]) {
+      for (const r of [0, 0.25, 0.5, 0.75, 0.999999]) {
+        const delay = computeBackoffDelayMs(attempt, BASE, MAX, () => r);
+        expect(delay).toBeLessThanOrEqual(MAX);
+        expect(delay).toBeGreaterThan(0);
+      }
+    }
+    // 同一 random 下，未封顶区间应严格递增（抖动不掩盖退避本身）。
+    const at = (n: number) => computeBackoffDelayMs(n, BASE, MAX, () => 0.5);
+    expect(at(1)).toBeGreaterThan(at(0));
+    expect(at(2)).toBeGreaterThan(at(1));
+    // 封顶后不再增长。
+    expect(computeBackoffDelayMs(30, BASE, MAX, () => 0.5)).toBe(
+      computeBackoffDelayMs(10, BASE, MAX, () => 0.5),
+    );
+  });
+
+  it('同一 attempt 的不同随机源给出不同延迟（真正打散齐步重连）', () => {
+    const spread = new Set(
+      [0, 0.2, 0.4, 0.6, 0.8].map((r) => computeBackoffDelayMs(5, BASE, MAX, () => r)),
+    );
+    expect(spread.size).toBeGreaterThan(1);
+  });
+
+  it('生产缺省不注入 random 时也能建连（Math.random 兜底）', async () => {
+    const { wss, url } = await startServer();
+    const statuses: string[] = [];
+    const transport = createHookTransport({
+      ...transportOpts(url, { onStatus: (status) => statuses.push(status) }),
+      random: undefined,
+    });
+    cleanups.push(() => transport.dispose());
+
+    const [sock] = (await once(wss, 'connection')) as [ServerSocket];
+    sock.send(serializeHookMessage(makeWelcome({ serverName: 'mock', features: [] })));
+    await expect.poll(() => statuses.at(-1), { timeout: 3000 }).toBe('connected');
   });
 });
 

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -405,7 +405,8 @@ describe('hook-control transport backoff jitter', () => {
     // random 的两个极端决定区间端点；中点用于确认是线性插值而非跳变。
     expect(computeBackoffDelayMs(0, BASE, MAX, () => 0)).toBe(700);
     expect(computeBackoffDelayMs(0, BASE, MAX, () => 0.5)).toBe(850);
-    // random() 返回 [0,1)，取不到 1；逼近 1 时应逼近 base 本身且不超过它。
+    // random() 取不到 1，但末尾 Math.round 会把逼近满值的比例舍入上去，
+    // 所以上端是闭的：延迟可以恰好等于退避值（这也是 maxMs 仍不被越过的边界）。
     expect(computeBackoffDelayMs(0, BASE, MAX, () => 0.999999)).toBe(BASE);
   });
 

--- a/apps/desktop/src/main/hook-control/transport.ts
+++ b/apps/desktop/src/main/hook-control/transport.ts
@@ -69,15 +69,19 @@ export interface HookTransport {
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_MAX_MS = 30_000;
 /**
- * 退避抖动下界：实际延迟取 [BACKOFF_JITTER_MIN_RATIO, 1.0) × 退避值。
+ * 退避抖动下界：实际延迟取 [BACKOFF_JITTER_MIN_RATIO, 1.0] × 退避值。
+ *
+ * 上端闭合是实现事实，不是笔误：注入的 random() 契约为 [0,1)、取不到 1，但
+ * computeBackoffDelayMs 末尾的 Math.round 会把逼近满值的比例舍入上去，因此实际
+ * 延迟可以恰好等于退避值本身。
  *
  * 与 device-link 同口径（`packages/device-link/src/client.ts` 的 scheduleReconnect）。
  * hook-server 是所有 desktop 共连的中心服务，而退避序列本身是确定性的
  * （1s/2s/4s…30s），一旦服务重启或中间网络恢复，全端客户端会齐步撞上来。向下
  * 抖动把这批重连打散开。
  *
- * 取向下（而非双向）抖动，是为了让 backoffMaxMs 仍然是真实上限——注释和 opts 里
- * 承诺的「30s 封顶」不能因为抖动被抬高。
+ * 取向下（而非双向）抖动，是为了让 backoffMaxMs 仍然是真实上限——闭区间的上端
+ * 恰好是 backoffMaxMs，opts 承诺的「30s 封顶」不会被抖动抬高。
  */
 const BACKOFF_JITTER_MIN_RATIO = 0.7;
 

--- a/apps/desktop/src/main/hook-control/transport.ts
+++ b/apps/desktop/src/main/hook-control/transport.ts
@@ -9,8 +9,8 @@
  *   - 协议帧: 全部经 @cindy/slack-hook-protocol —— 出帧走构造器 + serialize, 入帧
  *     一律先过 parseHookMessage, 坏帧记日志丢弃(规则 9)。
  *   - 生命周期: open -> 发 hello -> 等 welcome(此后状态才算 connected) ->
- *     心跳(定期 ping + 空闲看门狗); 断开按指数退避重连(1s -> 30s 封顶),
- *     welcome 到达后退避归零。
+ *     心跳(定期 ping + 空闲看门狗); 断开按指数退避重连(1s -> 30s 封顶, 带向下
+ *     抖动), welcome 到达后退避归零。
  *   - ping 自动回 pong 在本层处理(纯协议行为); 其余消息透传给上层
  *     (manager 决定业务响应, 如 dispatch 的 stub ack)。
  */
@@ -56,6 +56,8 @@ export interface HookTransportOpts {
   onStatus: (status: HookTransportStatus, lastError: string | null) => void;
   /** 测试注入重连时间参数；生产缺省 1s → 30s。 */
   timing?: { backoffBaseMs?: number; backoffMaxMs?: number; standbyRetryMs?: number };
+  /** 测试注入退避抖动的随机源（返回 [0,1)）；生产缺省 Math.random。 */
+  random?: () => number;
   log: { info(msg: string): void; warn(msg: string): void; debug?(msg: string): void };
 }
 
@@ -66,6 +68,37 @@ export interface HookTransport {
 
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_MAX_MS = 30_000;
+/**
+ * 退避抖动下界：实际延迟取 [BACKOFF_JITTER_MIN_RATIO, 1.0) × 退避值。
+ *
+ * 与 device-link 同口径（`packages/device-link/src/client.ts` 的 scheduleReconnect）。
+ * hook-server 是所有 desktop 共连的中心服务，而退避序列本身是确定性的
+ * （1s/2s/4s…30s），一旦服务重启或中间网络恢复，全端客户端会齐步撞上来。向下
+ * 抖动把这批重连打散开。
+ *
+ * 取向下（而非双向）抖动，是为了让 backoffMaxMs 仍然是真实上限——注释和 opts 里
+ * 承诺的「30s 封顶」不能因为抖动被抬高。
+ */
+const BACKOFF_JITTER_MIN_RATIO = 0.7;
+
+/**
+ * 计算第 `attempt` 次重连的退避延迟：指数增长 → maxMs 封顶 → 向下抖动。
+ *
+ * 抽成纯函数是为了让抖动边界能被直接断言（免 socket、免 timer）；`random` 由调用方
+ * 注入，生产传 Math.random。
+ */
+export function computeBackoffDelayMs(
+  attempt: number,
+  baseMs: number,
+  maxMs: number,
+  random: () => number,
+): number {
+  const capped = Math.min(baseMs * 2 ** attempt, maxMs);
+  return Math.round(
+    capped * (BACKOFF_JITTER_MIN_RATIO + random() * (1 - BACKOFF_JITTER_MIN_RATIO)),
+  );
+}
+
 /** 服务端 first-wins：同账号同 deviceId 的后续 hello 被此 close code 拒绝。 */
 const DUPLICATE_DEVICE_CLOSE_CODE = 4000;
 const DUPLICATE_DEVICE_CLOSE_REASON = 'device already connected';
@@ -83,6 +116,7 @@ export function createHookTransport(opts: HookTransportOpts): HookTransport {
   const backoffBaseMs = opts.timing?.backoffBaseMs ?? BACKOFF_BASE_MS;
   const backoffMaxMs = opts.timing?.backoffMaxMs ?? BACKOFF_MAX_MS;
   const standbyRetryMs = opts.timing?.standbyRetryMs ?? STANDBY_RETRY_MS;
+  const random = opts.random ?? Math.random;
 
   let ws: WebSocket | null = null;
   let stopped = false;
@@ -122,8 +156,10 @@ export function createHookTransport(opts: HookTransportOpts): HookTransport {
 
   function scheduleRetry(delayOverrideMs?: number): void {
     if (stopped || retryTimer) return;
+    // 显式周期（standby 低频探测）不抖动：它表达的是「多久探一次首实例是否退出」，
+    // 是一个产品语义上的固定节奏，不是用来防重连风暴的退避。
     const delay =
-      delayOverrideMs ?? Math.min(backoffBaseMs * 2 ** attempt, backoffMaxMs);
+      delayOverrideMs ?? computeBackoffDelayMs(attempt, backoffBaseMs, backoffMaxMs, random);
     attempt += 1;
     retryTimer = setTimeout(() => {
       retryTimer = null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

给 hook-control 的 WS 重连退避补上**向下抖动**。

hook-server 是所有 desktop 共连的中心服务，而 `transport.ts` 的退避序列是完全确定性的（1s/2s/4s…30s 封顶），服务重启或中间网络恢复时，全端客户端会齐步撞上来。`packages/device-link/src/client.ts` 的 `scheduleReconnect` 早就为同一问题加了抖动（注释原话：「打散同 deviceId 双连风暴 / 服务重启后的全端齐步重连」），hook 侧一直缺这层保护。这次把两者拉平。

背景：排查一次本机完全断网（锁屏触发 Wi-Fi 以新 MAC 重连 → VPN 隧道重建失败 → 全量默认路由 `0/1` 黑洞，只剩直连 IP 可达）时，顺带对比了仓库里两个 WS 客户端的重连实现，发现这处不对称。**断网本身与本仓代码无关**，详见「明确不包含」。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（排查本机断网时发现的实现不对称）
- 本 PR 包含：
  - 指数退避加 0.7x–1.0x 向下抖动，口径与 device-link 对齐。取向下而非双向，是为了让文件头注释与 `opts` 承诺的「30s 封顶」仍是真实上限。
  - `delayOverrideMs`（standby 低频探测）**不**抖动：它表达的是「多久探一次首实例是否退出」这个固定节奏，不是防重连风暴的退避。
  - 退避延迟计算抽成导出的纯函数 `computeBackoffDelayMs`，随机源由调用方注入，使抖动边界可被直接断言，不必靠真实 timer 去猜。
- 明确不包含：
  - **`packages/device-link` 未改** —— 核实后确认它已有抖动、有上限、且 `armReconnectStableReset` 要求 online 稳定后才归零 `attempt`，现状正确。
  - **`prStatusService.ts` 未改** —— 曾考虑给它加「连续失败熔断」，核实后放弃：`:126-132` 的「`fetch-failed` 不缓存」是注释里明确记录的既有 review 决策（让网络恢复后下次渲染立即重试），加熔断等于把该决策反过来，且它本就有 60s TTL + in-flight 去重，收益接近零、代价是 PR 徽标恢复变慢。
- 用户可见变化：无。仅改变重连发起时刻的毫秒级分布。
- 是否存在 breaking change：无

### UI 变化

不涉及（改动位于 main 进程 `hook-control/transport.ts`，未命中任何 UI 代码路径）。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过，0 error

pnpm --filter desktop exec vitest run \
  src/main/hook-control/__tests__/transport-manager.test.ts --pool=threads
结果：Test Files 1 passed，Tests 87 passed (87)
      （含既有的 standby 低频探测节奏、upgrade 503 退避重连等用例，行为未被抖动改变）

pnpm test:unit（经 run-unit-gate.sh 统一脚本执行）
结果：GATE_EXIT=0，FAIL 0
      apps/desktop unit 73.9s PASS、apps/mobile unit 12.6s PASS、
      全部 packages 与 cindy-protocol 包 PASS，6 个 SKIP 为无可收集测试的 workspace
      已确认日志含 GATE_STARTED，且无 launchservicesd 重启告警
```

新增 4 个用例：区间端点与线性插值（`random=0 → 0.7x`、`0.5 → 0.85x`、逼近 1 → 不超过 1.0x）、8×5 组合下 `maxMs` 是硬上限且未封顶区间严格递增、不同随机源确实产生不同延迟、以及不注入随机源时生产路径（`Math.random` 兜底）仍能正常建连至 `connected`。

### 手工验证

不涉及。抖动是毫秒级时序分布，单测断言区间边界比手工观察可靠；且真实效果要在多客户端齐步重连时才显现（见下）。

### 未执行的验证

- **Windows 端未实测**：本次只改纯计算逻辑（`Math.min` / `Math.round` / 注入的随机源），不含任何平台相关 API、路径或子进程行为，两端语义一致。
- **未做多客户端齐步重连的真实压测**：需要多台设备配合服务端重启窗口，本地无法构造。抖动区间与上限由单测覆盖，齐步打散的效果依赖与 device-link 相同的既有实现口径。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop 的 hook-control WS 重连发起时刻。退避上限不变（向下抖动保证 `delay ≤ backoffMaxMs`）；standby 探测节奏不变；无协议帧改动，服务端无感。
- 回滚 / 降级方式：单 commit `revert` 即可。无状态、无持久化、无迁移、无协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（同步更新了 `transport.ts` 文件头注释对退避行为的描述）
- [x] 已确认测试结果或说明未执行原因
