### PR TITLE
fix(mobile): 点开图片不再先黑屏,看过的原图再次打开秒出

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -425,7 +425,6 @@ import type {
   MobileSessionAgentSwitchIntent,
 } from '@cindy/maker-shared/device-link-contract';
 import {
-  REMOTE_MEDIA_LOCAL_COPY_WAIT_MS,
   REMOTE_MEDIA_NEVER_EXPIRES,
   localCopyResolvedMedia,
   resolveMobileRemoteMedia,
@@ -436,6 +435,7 @@ import {
   createRemoteMediaResolveQueue,
   type RemoteMediaRequest,
   type RemoteMediaRequestOptions,
+  type RemoteMediaResolveHooks,
 } from '@/session/remoteMediaResolveQueue';
 import { ChatFilePathContext, type ChatFilePathContextValue, type ChatFilePathTarget } from '@/session/chatFilePathContext';
 import { pathDisplayName } from '@/session/chatPathCandidate';
@@ -1190,7 +1190,11 @@ export default function SessionScreen() {
   // 队列工厂:本屏切 sessionId 不重挂载,换会话时旧队列 releaseAll 后必须换全新
   // 实例(released 标志一次性,释放过的队列不再回填缓存)。
   const createRemoteMediaQueue = useCallback(() => createRemoteMediaResolveQueue({
-      resolve: async (media: RemoteMediaRequest, opts?: { skipCache?: boolean }) => {
+      resolve: async (
+        media: RemoteMediaRequest,
+        opts?: { skipCache?: boolean },
+        hooks?: RemoteMediaResolveHooks,
+      ) => {
         const deps = remoteMediaDepsRef.current;
         const diskCache = remoteMediaDiskCacheRef.current;
         // 命名空间键与 deps 同一时刻捕获(首个 await 之前):切设备/账号时在飞的
@@ -1247,39 +1251,32 @@ export default function SessionScreen() {
           // 走到这里的都是完整原图字节(inline 缩略图已在上面 return):即便请求方
           // 要的是缩略图(被控端缩不了回落原图),也落**裸键**——lightbox 后续按裸键
           // 取原图直接磁盘命中,不再对同一张原图二次下载、双份落盘。
-          const store = diskCache.store(bareDiskSource, resolved.url, resolved.mimeType, resolved.size).catch(() => undefined);
+          const store = diskCache.store(bareDiskSource, resolved.url, resolved.mimeType, resolved.size)
+            .catch(() => false);
           if (resolved.ossKey) {
             const key = resolved.ossKey;
             pendingDiskStoresRef.current.set(key, store.finally(() => {
               pendingDiskStoresRef.current.delete(key);
             }));
           }
-          // 原图请求(查看器点开):等落盘结束,回本地 file:// 而不是 presign 地址。
-          //   - 同一个对象此前会被下载**两遍**(store 落盘一遍、<Image> 按 presign
-          //     地址再下一遍),两条下载还互相抢带宽;现在只下一遍,渲染读本地文件。
-          //   - 关掉查看器再打开时,队列内存缓存里存的是本地文件:presign 地址在有效期
-          //     内会被当 fresh 命中直接复用,于是每次点开都从 OSS 重新拉整张原图
-          //     (用户实测:「已经打开过原图,关闭再打开又从黑屏开始」)。换成本地
-          //     文件后再次点开直接满清晰度秒出,零网络。
-          // 落盘被跳过(单对象超缓存预算)或失败时回落 presign 地址,行为与此前一致。
-          // 缩略图请求不等:它可能是老被控端「缩不动回落原图」的整图下载,聊天列表
-          // 首帧不该为此多等一整个下载(且它本就已按裸键复用原图字节)。
-          if (!media.thumbnail) {
-            let waitTimer: ReturnType<typeof setTimeout> | undefined;
-            const stored = await Promise.race([
-              store.then(() => true),
-              new Promise<false>((settle) => {
-                waitTimer = setTimeout(() => settle(false), REMOTE_MEDIA_LOCAL_COPY_WAIT_MS);
-              }),
-            ]).finally(() => {
-              if (waitTimer) clearTimeout(waitTimer);
-            });
-            if (stored) {
+          // 落盘成功后把队列缓存条目升级成本地 file://:presign 地址会被队列当 fresh
+          // 结果缓存,在有效期内同键请求一律直接命中它、再也不会重进磁盘 lookup,
+          // 于是「已经打开过的原图,关掉再打开又从 OSS 重下一整张」,盘上那份副本
+          // 永远轮不到用(用户实测 + PR #1125 review)。
+          // 这里刻意**不同步等待**落盘:调用方立即拿到可渲染的 presign 地址。取件队列
+          // maxConcurrent=2 且看不到 front,同步等待会让 lightbox 的相邻页预取同样
+          // 占住槽位,把用户正在看的那张排到已翻过去的图的后台下载之后。
+          // store 的返回值是「本次是否真的写入了新字节」:超预算跳过 / 下载失败(现存
+          // 同名旧文件被刻意保留)/ 落成 0 字节都为 false,此时绝不能改用本地文件——
+          // 否则会把**已被 onError 证伪的旧文件**当本次结果并标成永不过期。
+          void store
+            .then(async (stored) => {
+              if (!stored) return;
               const hit = await diskCache.lookup(bareDiskSource).catch(() => null);
               const local = localCopyResolvedMedia(resolved, hit);
-              if (local) return local;
-            }
-          }
+              if (local) hooks?.onLocalCopy(local);
+            })
+            .catch(() => undefined);
         }
         return resolved;
       },

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -425,6 +425,9 @@ import type {
   MobileSessionAgentSwitchIntent,
 } from '@cindy/maker-shared/device-link-contract';
 import {
+  REMOTE_MEDIA_LOCAL_COPY_WAIT_MS,
+  REMOTE_MEDIA_NEVER_EXPIRES,
+  localCopyResolvedMedia,
   resolveMobileRemoteMedia,
   type MobileRemoteMediaPresignResult,
   type MobileResolvedRemoteMedia,
@@ -1209,7 +1212,7 @@ export default function SessionScreen() {
               mimeType: hit.mimeType,
               size: hit.size,
               // 本地文件不过期;若被 LRU/OS 清掉,Image onError → forceRefresh 重取自愈。
-              expiresAt: '9999-12-31T00:00:00.000Z',
+              expiresAt: REMOTE_MEDIA_NEVER_EXPIRES,
               previewable: hit.mimeType.startsWith('image/'),
             };
           }
@@ -1250,6 +1253,32 @@ export default function SessionScreen() {
             pendingDiskStoresRef.current.set(key, store.finally(() => {
               pendingDiskStoresRef.current.delete(key);
             }));
+          }
+          // 原图请求(查看器点开):等落盘结束,回本地 file:// 而不是 presign 地址。
+          //   - 同一个对象此前会被下载**两遍**(store 落盘一遍、<Image> 按 presign
+          //     地址再下一遍),两条下载还互相抢带宽;现在只下一遍,渲染读本地文件。
+          //   - 关掉查看器再打开时,队列内存缓存里存的是本地文件:presign 地址在有效期
+          //     内会被当 fresh 命中直接复用,于是每次点开都从 OSS 重新拉整张原图
+          //     (用户实测:「已经打开过原图,关闭再打开又从黑屏开始」)。换成本地
+          //     文件后再次点开直接满清晰度秒出,零网络。
+          // 落盘被跳过(单对象超缓存预算)或失败时回落 presign 地址,行为与此前一致。
+          // 缩略图请求不等:它可能是老被控端「缩不动回落原图」的整图下载,聊天列表
+          // 首帧不该为此多等一整个下载(且它本就已按裸键复用原图字节)。
+          if (!media.thumbnail) {
+            let waitTimer: ReturnType<typeof setTimeout> | undefined;
+            const stored = await Promise.race([
+              store.then(() => true),
+              new Promise<false>((settle) => {
+                waitTimer = setTimeout(() => settle(false), REMOTE_MEDIA_LOCAL_COPY_WAIT_MS);
+              }),
+            ]).finally(() => {
+              if (waitTimer) clearTimeout(waitTimer);
+            });
+            if (stored) {
+              const hit = await diskCache.lookup(bareDiskSource).catch(() => null);
+              const local = localCopyResolvedMedia(resolved, hit);
+              if (local) return local;
+            }
           }
         }
         return resolved;

--- a/apps/mobile/src/__tests__/imageLightboxModel.test.ts
+++ b/apps/mobile/src/__tests__/imageLightboxModel.test.ts
@@ -76,7 +76,7 @@ describe('imageLightboxModel', () => {
     // 出来了,点开反而先黑一段」。
     it('keeps the thumbnail while the original is still fetching', () => {
       expect(lightboxImageLayers({ fullUri: null, previewUri: 'file:///thumb.webp', fullLoaded: false }))
-        .toEqual({ showPreview: true, showSpinner: false });
+        .toEqual({ showPreview: true, showSpinner: false, showFailure: false });
     });
 
     it('keeps the thumbnail after the original url arrives but before it paints', () => {
@@ -85,7 +85,7 @@ describe('imageLightboxModel', () => {
         fullUri: 'https://oss.example/full.png',
         previewUri: 'file:///thumb.webp',
         fullLoaded: false,
-      })).toEqual({ showPreview: true, showSpinner: false });
+      })).toEqual({ showPreview: true, showSpinner: false, showFailure: false });
     });
 
     it('drops both layers only once the original has actually loaded', () => {
@@ -93,26 +93,84 @@ describe('imageLightboxModel', () => {
         fullUri: 'https://oss.example/full.png',
         previewUri: 'file:///thumb.webp',
         fullLoaded: true,
-      })).toEqual({ showPreview: false, showSpinner: false });
+      })).toEqual({ showPreview: false, showSpinner: false, showFailure: false });
     });
 
     it('falls back to a spinner when no thumbnail is available', () => {
       // 直连 http 图没有缩略图可垫:给转圈,不留纯黑无反馈。
       expect(lightboxImageLayers({ fullUri: null, previewUri: null, fullLoaded: false }))
-        .toEqual({ showPreview: false, showSpinner: true });
+        .toEqual({ showPreview: false, showSpinner: true, showFailure: false });
       expect(lightboxImageLayers({
         fullUri: 'https://oss.example/full.png',
         previewUri: null,
         fullLoaded: false,
-      })).toEqual({ showPreview: false, showSpinner: true });
+      })).toEqual({ showPreview: false, showSpinner: true, showFailure: false });
+    });
+
+    it('ends in a failure state instead of spinning forever when the original cannot be retried', () => {
+      // 直连 http 图没有 forceRefresh 自愈也没有重试按钮:一直转圈等于一直谎报
+      // "还在加载"(本次之前这条路径是一直纯黑)。
+      expect(lightboxImageLayers({
+        fullUri: 'https://cdn.example/broken.png',
+        previewUri: null,
+        fullLoaded: false,
+        fullFailedTerminally: true,
+      })).toEqual({ showPreview: false, showSpinner: false, showFailure: true });
+    });
+
+    it('prefers a usable thumbnail over the failure text', () => {
+      // 有内容可展示(软图也是内容)就不要给失败文案。
+      expect(lightboxImageLayers({
+        fullUri: 'https://oss.example/full.png',
+        previewUri: 'file:///thumb.webp',
+        fullLoaded: false,
+        fullFailedTerminally: true,
+      })).toEqual({ showPreview: true, showSpinner: false, showFailure: false });
+    });
+
+    it('keeps spinning while a retryable original is still self-healing', () => {
+      // 可重取的图不传 fullFailedTerminally:失败终态由父层 resolveMap 接管(带重试按钮),
+      // 本页在自愈窗口内应继续给转圈,不能提前宣告失败。
+      expect(lightboxImageLayers({
+        fullUri: 'https://oss.example/stale.png',
+        previewUri: null,
+        fullLoaded: false,
+        fullFailedTerminally: false,
+      })).toEqual({ showPreview: false, showSpinner: true, showFailure: false });
+    });
+
+    it('restores the spinner when the thumbnail itself failed to load', () => {
+      // 回归点:缩略图的磁盘文件被 LRU / 系统清掉后,队列内存缓存仍会回一个永不过期
+      // 的 file://。只看「有地址」会把没有像素当成已出图,于是 spinner 被藏掉、垫底
+      // 又画不出东西,整段退回纯黑,反而比旧实现少了转圈反馈。
+      expect(lightboxImageLayers({
+        fullUri: null,
+        previewUri: 'file:///thumb.webp',
+        fullLoaded: false,
+        previewFailed: true,
+      })).toEqual({ showPreview: false, showSpinner: true, showFailure: false });
+      // 原图地址已到、字节仍在下载的那段同样要有反馈
+      expect(lightboxImageLayers({
+        fullUri: 'https://oss.example/full.png',
+        previewUri: 'file:///thumb.webp',
+        fullLoaded: false,
+        previewFailed: true,
+      })).toEqual({ showPreview: false, showSpinner: true, showFailure: false });
+      // 原图已出图后不该再有任何附加层
+      expect(lightboxImageLayers({
+        fullUri: 'https://oss.example/full.png',
+        previewUri: 'file:///thumb.webp',
+        fullLoaded: true,
+        previewFailed: true,
+      })).toEqual({ showPreview: false, showSpinner: false, showFailure: false });
     });
 
     it('never trusts fullLoaded without a full uri', () => {
       // 调用方漏复位 loaded 标记时不能把两层同时撤掉(又回到纯黑)。
       expect(lightboxImageLayers({ fullUri: null, previewUri: 'file:///thumb.webp', fullLoaded: true }))
-        .toEqual({ showPreview: true, showSpinner: false });
+        .toEqual({ showPreview: true, showSpinner: false, showFailure: false });
       expect(lightboxImageLayers({ fullUri: null, previewUri: null, fullLoaded: true }))
-        .toEqual({ showPreview: false, showSpinner: true });
+        .toEqual({ showPreview: false, showSpinner: true, showFailure: false });
     });
   });
 

--- a/apps/mobile/src/__tests__/imageLightboxModel.test.ts
+++ b/apps/mobile/src/__tests__/imageLightboxModel.test.ts
@@ -7,6 +7,7 @@ import {
   clampLightboxScale,
   clampLightboxTranslation,
   lightboxBackgroundOpacity,
+  lightboxImageLayers,
   lightboxInitialIndex,
   lightboxPageIndex,
   lightboxPageLabel,
@@ -68,6 +69,51 @@ describe('imageLightboxModel', () => {
   it('hides the page label for single images', () => {
     expect(lightboxPageLabel(0, 1)).toBeNull();
     expect(lightboxPageLabel(1, 5)).toBe('2 / 5');
+  });
+
+  describe('lightboxImageLayers', () => {
+    // 打开图片的两段空档窗口都必须被垫住,否则用户看到的就是「列表里图明明已经
+    // 出来了,点开反而先黑一段」。
+    it('keeps the thumbnail while the original is still fetching', () => {
+      expect(lightboxImageLayers({ fullUri: null, previewUri: 'file:///thumb.webp', fullLoaded: false }))
+        .toEqual({ showPreview: true, showSpinner: false });
+    });
+
+    it('keeps the thumbnail after the original url arrives but before it paints', () => {
+      // 回归点:旧实现把垫底挂在取件态里,取件一完成(ready)就撤,这一段裸露成黑屏。
+      expect(lightboxImageLayers({
+        fullUri: 'https://oss.example/full.png',
+        previewUri: 'file:///thumb.webp',
+        fullLoaded: false,
+      })).toEqual({ showPreview: true, showSpinner: false });
+    });
+
+    it('drops both layers only once the original has actually loaded', () => {
+      expect(lightboxImageLayers({
+        fullUri: 'https://oss.example/full.png',
+        previewUri: 'file:///thumb.webp',
+        fullLoaded: true,
+      })).toEqual({ showPreview: false, showSpinner: false });
+    });
+
+    it('falls back to a spinner when no thumbnail is available', () => {
+      // 直连 http 图没有缩略图可垫:给转圈,不留纯黑无反馈。
+      expect(lightboxImageLayers({ fullUri: null, previewUri: null, fullLoaded: false }))
+        .toEqual({ showPreview: false, showSpinner: true });
+      expect(lightboxImageLayers({
+        fullUri: 'https://oss.example/full.png',
+        previewUri: null,
+        fullLoaded: false,
+      })).toEqual({ showPreview: false, showSpinner: true });
+    });
+
+    it('never trusts fullLoaded without a full uri', () => {
+      // 调用方漏复位 loaded 标记时不能把两层同时撤掉(又回到纯黑)。
+      expect(lightboxImageLayers({ fullUri: null, previewUri: 'file:///thumb.webp', fullLoaded: true }))
+        .toEqual({ showPreview: true, showSpinner: false });
+      expect(lightboxImageLayers({ fullUri: null, previewUri: null, fullLoaded: true }))
+        .toEqual({ showPreview: false, showSpinner: true });
+    });
   });
 
   it('allows sharing only for file and http(s) uris', () => {

--- a/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
+++ b/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
@@ -102,9 +102,15 @@ describe('mobile message media thumbnail wiring', () => {
 
   it('wires stale-key self-heal: lightbox onError force refresh and orphan release DELETE', () => {
     const lightboxSource = readTextLf(resolve(process.cwd(), 'src/session/ImageLightbox.tsx'), 'utf8');
-    // 悬空 key 404 → 一次性 forceRefresh 自愈;重试按钮也走 forceRefresh(穿透负缓存)
-    expect(lightboxSource).toContain('onError={onImageError && retryable');
+    // 悬空 key 404 → 一次性 forceRefresh 自愈;重试按钮也走 forceRefresh(穿透负缓存)。
+    // 自愈仍按 retryable 门控(只有桌面取件图能重取),但 onError 本身对**所有**图接线:
+    // 直连图没有重取入口,要靠它记下"确证没有像素"才能收敛到失败终态、不永久转圈。
+    expect(lightboxSource).toContain('onImageError && retryable');
+    expect(lightboxSource).toContain('setFailedFullUri(uri)');
+    expect(lightboxSource).toContain('fullFailedTerminally');
     expect(lightboxSource).toContain('handleImageLoadError');
+    // 垫底层同样要接失败路径:缩略图文件被 LRU/系统清掉后不能停在纯黑(少了转圈反馈)
+    expect(lightboxSource).toContain('setFailedPreviewUri(previewUri)');
     // 重试 / onError 都是带 image 参数的稳定回调,不被内联闭包击穿 LightboxPage memo
     expect(lightboxSource).toContain('handleRetryPage');
     expect(lightboxSource).toContain('resolveImage(image, true, true)');

--- a/apps/mobile/src/__tests__/remoteMedia.test.ts
+++ b/apps/mobile/src/__tests__/remoteMedia.test.ts
@@ -4,6 +4,8 @@ import {
   formatRemoteMediaSize,
   isDesktopLocalMediaUrl,
   isResolvedRemoteMediaFresh,
+  localCopyResolvedMedia,
+  REMOTE_MEDIA_NEVER_EXPIRES,
   resolveMobileRemoteMedia,
 } from '@/session/remoteMedia';
 
@@ -100,6 +102,56 @@ describe('mobile remote media', () => {
     expect(isResolvedRemoteMediaFresh({ expiresAt: '2026-06-16T10:02:00.000Z' }, now)).toBe(true);
     expect(isResolvedRemoteMediaFresh({ expiresAt: '2026-06-16T10:00:30.000Z' }, now)).toBe(false);
     expect(isResolvedRemoteMediaFresh({ expiresAt: 'bad-date' }, now)).toBe(false);
+  });
+
+  describe('localCopyResolvedMedia', () => {
+    const resolved = {
+      url: 'https://oss.example/obj?sig=abc',
+      ossKey: 'user/obj-1',
+      mimeType: 'image/png',
+      size: 3_000_000,
+      expiresAt: '2026-06-16T11:00:00.000Z',
+      previewable: true,
+    };
+
+    it('swaps the presigned url for the local file and keeps the oss key', () => {
+      // 保留 ossKey 是硬要求:对象仍在世,退屏清理靠它 DELETE。
+      expect(localCopyResolvedMedia(resolved, {
+        uri: 'file:///cache/obj-1.png',
+        mimeType: 'image/png',
+        size: 2_999_888,
+      })).toEqual({
+        url: 'file:///cache/obj-1.png',
+        ossKey: 'user/obj-1',
+        mimeType: 'image/png',
+        size: 2_999_888,
+        expiresAt: REMOTE_MEDIA_NEVER_EXPIRES,
+        previewable: true,
+      });
+    });
+
+    it('falls back to the presigned entry when the disk copy is unusable', () => {
+      // 落盘被跳过(单对象超预算)/ 失败 / 落成了非图片:回落原条目,不能返回坏地址。
+      expect(localCopyResolvedMedia(resolved, null)).toBeNull();
+      expect(localCopyResolvedMedia(resolved, undefined)).toBeNull();
+      expect(localCopyResolvedMedia(resolved, { uri: '', mimeType: 'image/png', size: 1 })).toBeNull();
+      expect(localCopyResolvedMedia(resolved, {
+        uri: 'file:///cache/obj-1.bin',
+        mimeType: 'application/octet-stream',
+        size: 1,
+      })).toBeNull();
+    });
+
+    it('marks the local copy as non-expiring so reopening skips the network', () => {
+      const local = localCopyResolvedMedia(resolved, {
+        uri: 'file:///cache/obj-1.png',
+        mimeType: 'image/png',
+        size: 10,
+      });
+      // 队列按 isResolvedRemoteMediaFresh 判缓存可用性:本地文件必须恒 fresh,
+      // 否则再次点开又会回到「重新取件 + 重新下载」。
+      expect(local && isResolvedRemoteMediaFresh(local, Date.parse('2030-01-01T00:00:00.000Z'))).toBe(true);
+    });
   });
 
   it('formats byte sizes compactly', () => {

--- a/apps/mobile/src/__tests__/remoteMediaDiskCache.test.ts
+++ b/apps/mobile/src/__tests__/remoteMediaDiskCache.test.ts
@@ -76,13 +76,14 @@ describe('remoteMediaDiskCache', () => {
     // IO 不支持(memoryIO 默认不带 writeFileBase64):静默跳过。
     const base = memoryIO();
     const cacheNoIo = createRemoteMediaDiskCache(base.io);
-    await expect(cacheNoIo.storeBytes(URL_A, 'aGVsbG8=', 'image/webp')).resolves.toBeUndefined();
+    // 返回 false = 本次没写入新字节(见 store 返回值契约)。
+    await expect(cacheNoIo.storeBytes(URL_A, 'aGVsbG8=', 'image/webp')).resolves.toBe(false);
     expect(await cacheNoIo.lookup(URL_A)).toBeNull();
 
     // 写失败(返回 null,契约保证不动现有文件):不登记条目。
     const failing = memoryIO({ writeFileBase64: vi.fn(() => null) });
     const cacheFail = createRemoteMediaDiskCache(failing.io);
-    await cacheFail.storeBytes(URL_B, 'aGVsbG8=', 'image/webp');
+    await expect(cacheFail.storeBytes(URL_B, 'aGVsbG8=', 'image/webp')).resolves.toBe(false);
     expect(await cacheFail.lookup(URL_B)).toBeNull();
   });
 
@@ -275,5 +276,63 @@ describe('remoteMediaDiskCache', () => {
     expect(cacheKeyOf(URL_A)).toBe(cacheKeyOf(URL_A));
     expect(cacheKeyOf(URL_A)).not.toBe(cacheKeyOf(URL_B));
     expect(cacheKeyOf(URL_A)).toMatch(/^[0-9a-f]{18}$/);
+  });
+
+  // store 的返回值是「本次是否真的写入了新字节」。调用方靠它决定能否改用本地文件;
+  // 只看 promise resolve 会把**已被证伪的旧文件**当成本次结果(PR #1125 review)。
+  describe('store reports whether new bytes actually landed', () => {
+    it('reports true only when the write is registered', async () => {
+      const { io } = memoryIO();
+      const cache = createRemoteMediaDiskCache(io);
+      await expect(cache.store(URL_A, 'https://oss.example/a?sig=1', 'image/png')).resolves.toBe(true);
+      await expect(cache.storeBytes(URL_B, 'YWJj', 'image/webp')).resolves.toBe(false); // 无 writeFileBase64
+    });
+
+    it('reports false when the object alone exceeds the budget (nothing downloaded)', async () => {
+      const { io } = memoryIO();
+      const cache = createRemoteMediaDiskCache(io, { maxBytes: 100 });
+      await expect(cache.store(URL_A, 'https://oss.example/a?sig=1', 'image/png', 1_000)).resolves.toBe(false);
+      expect(io.download).not.toHaveBeenCalled();
+    });
+
+    it('reports false when the download fails and the existing good file is kept', async () => {
+      // 这是 review 指出的坏路径:强制重取下载失败时旧文件被刻意保留,若报 true
+      // 调用方就会把刚刚加载失败的同一个文件当本次结果、还标成永不过期。
+      let failNext = false;
+      const { io, files } = memoryIO({
+        download: vi.fn(async (_url: string, name: string) => {
+          // 契约:失败时原子落位失败,不得破坏已存在的同名好文件。
+          if (failNext) return null;
+          files.set(name, 1000);
+          return 1000;
+        }),
+      });
+      const cache = createRemoteMediaDiskCache(io);
+      await expect(cache.store(URL_A, 'https://oss.example/a?sig=1', 'image/png')).resolves.toBe(true);
+
+      failNext = true;
+      await expect(cache.store(URL_A, 'https://oss.example/a?sig=2', 'image/png')).resolves.toBe(false);
+      // 旧条目仍可命中(不误删),但调用方已被告知本次没写成功
+      expect(await cache.lookup(URL_A)).not.toBeNull();
+    });
+
+    it('reports false when the write lands as a zero-byte file', async () => {
+      const { io } = memoryIO({
+        download: vi.fn(async (_url: string, name: string) => 0),
+      });
+      const cache = createRemoteMediaDiskCache(io);
+      await expect(cache.store(URL_A, 'https://oss.example/a?sig=1', 'image/png')).resolves.toBe(false);
+      expect(await cache.lookup(URL_A)).toBeNull();
+    });
+
+    it('reports false when quota reclaim evicts the very entry just written', async () => {
+      // 单对象接近 maxBytes 时可能刚登记就被自己触发的 LRU 逐出,盘上已无本次字节。
+      const { io } = memoryIO({
+        download: vi.fn(async (_url: string, _name: string) => 1000),
+      });
+      const cache = createRemoteMediaDiskCache(io, { maxBytes: 500 });
+      await expect(cache.store(URL_C, 'https://oss.example/c?sig=1', 'image/png')).resolves.toBe(false);
+      expect(await cache.lookup(URL_C)).toBeNull();
+    });
   });
 });

--- a/apps/mobile/src/__tests__/remoteMediaResolveQueue.test.ts
+++ b/apps/mobile/src/__tests__/remoteMediaResolveQueue.test.ts
@@ -1,6 +1,10 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { i18n } from '@/i18n';
-import { createRemoteMediaResolveQueue, type RemoteMediaRequest } from '@/session/remoteMediaResolveQueue';
+import {
+  createRemoteMediaResolveQueue,
+  type RemoteMediaRequest,
+  type RemoteMediaResolveHooks,
+} from '@/session/remoteMediaResolveQueue';
 import type { MobileResolvedRemoteMedia } from '@/session/remoteMedia';
 
 // 文案已 i18n 化;固定 zh-CN 让字面量断言与语言环境解耦(全局 mock 默认 en-US)。
@@ -30,9 +34,15 @@ function manualResolver() {
     media: RemoteMediaRequest;
     resolve: (m: MobileResolvedRemoteMedia) => void;
     reject: (e: unknown) => void;
+    /** 队列绑定到本次请求缓存键的落盘回写钩子(见 RemoteMediaResolveHooks)。 */
+    hooks?: RemoteMediaResolveHooks;
   }> = [];
-  const resolve = vi.fn((media: RemoteMediaRequest, _opts?: { skipCache?: boolean }) => new Promise<MobileResolvedRemoteMedia>((res, rej) => {
-    pending.push({ media, resolve: res, reject: rej });
+  const resolve = vi.fn((
+    media: RemoteMediaRequest,
+    _opts?: { skipCache?: boolean },
+    hooks?: RemoteMediaResolveHooks,
+  ) => new Promise<MobileResolvedRemoteMedia>((res, rej) => {
+    pending.push({ media, resolve: res, reject: rej, hooks });
   }));
   return { pending, resolve };
 }
@@ -257,10 +267,12 @@ describe('remoteMediaResolveQueue', () => {
 
     const first = await queue.request(imageRequest('a.png'));
     expect(first.url).toBe('https://oss.example/v1');
-    expect(resolve).toHaveBeenNthCalledWith(1, expect.objectContaining({ url: 'xdt-image://cache/a.png' }), undefined);
+    // 第三参是队列绑定的落盘回写钩子,每次 resolve 都带(见 RemoteMediaResolveHooks)。
+    const localCopyHooks = expect.objectContaining({ onLocalCopy: expect.any(Function) });
+    expect(resolve).toHaveBeenNthCalledWith(1, expect.objectContaining({ url: 'xdt-image://cache/a.png' }), undefined, localCopyHooks);
     const refreshed = await queue.request(imageRequest('a.png'), { forceRefresh: true });
     expect(refreshed.url).toBe('https://oss.example/v2');
-    expect(resolve).toHaveBeenNthCalledWith(2, expect.objectContaining({ url: 'xdt-image://cache/a.png' }), { skipCache: true });
+    expect(resolve).toHaveBeenNthCalledWith(2, expect.objectContaining({ url: 'xdt-image://cache/a.png' }), { skipCache: true }, localCopyHooks);
     expect(queue.peekFresh('xdt-image://cache/a.png')?.url).toBe('https://oss.example/v2');
   });
 
@@ -439,5 +451,106 @@ describe('remoteMediaResolveQueue', () => {
     expect(onOrphanResolved).toHaveBeenCalledTimes(1);
     expect(onOrphanResolved).toHaveBeenCalledWith(expect.objectContaining({ ossKey: 'key/a.png' }));
     expect(queue.peekFresh('xdt-image://cache/a.png')).toBeNull();
+  });
+
+  // 落盘完成后的缓存升级(PR #1125 review):presign 会被当 fresh 缓存反复命中,
+  // 同键请求再也不会重进磁盘 lookup,盘上的本地副本永远轮不到用。
+  describe('local-copy upgrade', () => {
+    const localCopy = (ossKey: string): MobileResolvedRemoteMedia => ({
+      url: 'file:///cache/a.png',
+      ossKey,
+      mimeType: 'image/png',
+      size: 1024,
+      expiresAt: '9999-12-31T00:00:00.000Z',
+      previewable: true,
+    });
+
+    it('serves the local file to later requests without re-resolving', async () => {
+      const { pending, resolve } = manualResolver();
+      const queue = createRemoteMediaResolveQueue({ resolve });
+
+      const p1 = queue.request(imageRequest('a.png'));
+      await flush();
+      pending[0]?.resolve(resolvedMedia('a.png'));
+      await expect(p1).resolves.toMatchObject({ url: 'https://oss.example/a.png?sig=1' });
+
+      // 后台落盘完成 → 队列条目升级成本地文件
+      pending[0]?.hooks?.onLocalCopy(localCopy('key/a.png'));
+
+      await expect(queue.request(imageRequest('a.png'))).resolves.toMatchObject({
+        url: 'file:///cache/a.png',
+      });
+      // 关键:没有再次进入取件(否则就等于每次点开都重下一整张原图)
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(queue.peekFresh('xdt-image://cache/a.png')?.url).toBe('file:///cache/a.png');
+    });
+
+    it('keeps the oss key so leaving the screen still deletes the object', async () => {
+      const { pending, resolve } = manualResolver();
+      const queue = createRemoteMediaResolveQueue({ resolve });
+
+      const p1 = queue.request(imageRequest('a.png'));
+      await flush();
+      pending[0]?.resolve(resolvedMedia('a.png'));
+      await p1;
+      pending[0]?.hooks?.onLocalCopy(localCopy('key/a.png'));
+
+      // 升级后对象仍在世,必须照常出现在退屏清理里
+      expect(queue.releaseAll()).toEqual([
+        expect.objectContaining({ url: 'file:///cache/a.png', ossKey: 'key/a.png' }),
+      ]);
+    });
+
+    it('drops an upgrade whose object was already replaced by a forced refresh', async () => {
+      const { pending, resolve } = manualResolver();
+      const queue = createRemoteMediaResolveQueue({ resolve });
+
+      const p1 = queue.request(imageRequest('a.png'));
+      await flush();
+      pending[0]?.resolve(resolvedMedia('a.png', { ossKey: 'key/old' }));
+      await p1;
+
+      // 强制重取换到新对象
+      const p2 = queue.request(imageRequest('a.png'), { forceRefresh: true });
+      await flush();
+      pending[1]?.resolve(resolvedMedia('a.png', { ossKey: 'key/new' }));
+      await p2;
+
+      // 旧对象的落盘迟到:ossKey 不匹配,必须丢弃,不能把新条目覆盖成旧字节
+      pending[0]?.hooks?.onLocalCopy(localCopy('key/old'));
+      expect(queue.peekFresh('xdt-image://cache/a.png')).toMatchObject({
+        ossKey: 'key/new',
+        url: 'https://oss.example/a.png?sig=1',
+      });
+    });
+
+    it('drops an upgrade that lands after releaseAll instead of reviving the entry', async () => {
+      const { pending, resolve } = manualResolver();
+      const queue = createRemoteMediaResolveQueue({ resolve });
+
+      const p1 = queue.request(imageRequest('a.png'));
+      await flush();
+      pending[0]?.resolve(resolvedMedia('a.png'));
+      await p1;
+      queue.releaseAll();
+
+      pending[0]?.hooks?.onLocalCopy(localCopy('key/a.png'));
+      // 退屏后缓存归统一清理接管,升级不得凭空复活条目
+      expect(queue.peekFresh('xdt-image://cache/a.png')).toBeNull();
+    });
+
+    it('does not create a cache entry when the key was never cached', async () => {
+      const { pending, resolve } = manualResolver();
+      const queue = createRemoteMediaResolveQueue({ resolve });
+
+      const p1 = queue.request(imageRequest('a.png'));
+      await flush();
+      pending[0]?.reject(new Error('boom'));
+      await expect(p1).rejects.toThrow('boom');
+
+      // 取件失败没有缓存条目;迟到的落盘升级不得凭空建一条
+      pending[0]?.hooks?.onLocalCopy(localCopy('key/a.png'));
+      expect(queue.peekFresh('xdt-image://cache/a.png')).toBeNull();
+    });
   });
 });

--- a/apps/mobile/src/session/ImageLightbox.tsx
+++ b/apps/mobile/src/session/ImageLightbox.tsx
@@ -742,10 +742,28 @@ const LightboxPage = memo(function LightboxPage({
    * 天然失效,不需要额外 effect 复位(漏复位就会让新图那段又回到纯黑)。
    */
   const [loadedUri, setLoadedUri] = useState<string | null>(null);
+  /**
+   * 已确认加载失败的垫底图地址(同样存地址,换图天然失效)。
+   * 缩略图的磁盘文件可能被 150MB LRU 或系统清理掉,而取件队列的内存缓存仍持有那个
+   * 永不过期的 file:// —— 光看 URI 存在会把"没有像素"当成"已经出图",于是 spinner
+   * 被藏掉、垫底层又画不出东西,整段退回纯黑(PR #1125 review)。
+   */
+  const [failedPreviewUri, setFailedPreviewUri] = useState<string | null>(null);
+  /**
+   * 已确证 onError 的原图地址(同样存地址,换图 / 重取换 url 天然失效)。
+   * 桌面取件图有 forceRefresh 自愈 + 重试按钮兜底,失败终态由父层的 resolveMap 接管;
+   * 直连 http 图两者都没有,必须在本页给失败终态,否则会永远转圈谎报"还在加载"。
+   */
+  const [failedFullUri, setFailedFullUri] = useState<string | null>(null);
+  const media = image.payload.media;
+  // 可重取 = 桌面取件图:失败有 forceRefresh 自愈与重试按钮。直连 http / data 图两者皆无。
+  const retryable = !media.previewable && isDesktopLocalMediaUrl(media.url);
   const layers = lightboxImageLayers({
     fullUri: uri,
     previewUri,
     fullLoaded: !!uri && loadedUri === uri,
+    previewFailed: !!previewUri && failedPreviewUri === previewUri,
+    fullFailedTerminally: !retryable && !!uri && failedFullUri === uri,
   });
 
   const setZoomedBoth = useCallback((value: boolean) => {
@@ -875,8 +893,6 @@ const LightboxPage = memo(function LightboxPage({
     ],
   }));
 
-  const media = image.payload.media;
-  const retryable = !media.previewable && isDesktopLocalMediaUrl(media.url);
   // 取件成功但 mime 非图片(unsupported)时 displayUriFor 恒为 null,若只认
   // status==='error' 会永远停在 spinner —— 一并视为失败,给到重试按钮。
   const resolvedUnsupported = resolveState?.status === 'ready' && !resolveState.media.previewable;
@@ -910,6 +926,11 @@ const LightboxPage = memo(function LightboxPage({
             */}
             {layers.showPreview && previewUri ? (
               <Animated.Image
+                // 垫底图画不出来时必须撤掉并让 spinner 回来,不能停在纯黑(见
+                // failedPreviewUri)。乐观先渲染而不是等它 onLoad:本地文件解码只要
+                // 一两帧,为它先挂一帧 spinner 反而每次打开都闪一下,与本次「让用户
+                // 感知不到」的目标相反。
+                onError={() => setFailedPreviewUri(previewUri)}
                 resizeMode="contain"
                 source={{ uri: previewUri }}
                 style={[styles.pagePreviewLayer, imageStyle]}
@@ -917,7 +938,14 @@ const LightboxPage = memo(function LightboxPage({
               />
             ) : null}
             <Animated.Image
-              onError={onImageError && retryable ? () => onImageError(image) : undefined}
+              // 两条失败路径都要接:可重取的图交父层做一次 forceRefresh 自愈(再失败
+              // 落父层 error 态给重试按钮);直连图没有任何重取入口,只能在本页记下
+              // "这个地址确证没有像素",由 lightboxImageLayers 给失败终态——否则会
+              // 一直转圈谎报"还在加载"(此前是一直纯黑)。
+              onError={() => {
+                setFailedFullUri(uri);
+                if (onImageError && retryable) onImageError(image);
+              }}
               onLoad={(event) => {
                 // 撤垫底的唯一依据:原图真的有像素了。早于此撤(例如取件一完成
                 // 就撤)就会把下载窗口裸露成黑屏,正是本次修复的起因。
@@ -935,6 +963,12 @@ const LightboxPage = memo(function LightboxPage({
             {layers.showSpinner ? (
               <View pointerEvents="none" style={styles.pageSpinnerLayer}>
                 <ActivityIndicator color="#ffffff" testID="message.imageLightboxLoading" />
+              </View>
+            ) : null}
+            {/* 直连图加载失败:没有重取入口,给失败终态而不是永远转圈。单击关闭仍由手势层接管。 */}
+            {layers.showFailure ? (
+              <View pointerEvents="none" style={styles.pageSpinnerLayer}>
+                <Text style={styles.stateText}>{t('message.lightbox.loadFailed')}</Text>
               </View>
             ) : null}
             {overlayVisible ? (
@@ -1014,6 +1048,8 @@ const LightboxPage = memo(function LightboxPage({
                 // Pressable 单击关闭接管):首开不黑屏,原图到达切上面手势分支时
                 // 那边继续垫同一张图,两段之间不留空档。
                 <Animated.Image
+                  // 同上:垫底失败要退回 spinner,不能让取件在途这段变成纯黑。
+                  onError={() => setFailedPreviewUri(previewUri)}
                   resizeMode="contain"
                   source={{ uri: previewUri }}
                   style={StyleSheet.absoluteFill}

--- a/apps/mobile/src/session/ImageLightbox.tsx
+++ b/apps/mobile/src/session/ImageLightbox.tsx
@@ -49,6 +49,7 @@ import {
   clampLightboxScale,
   clampLightboxTranslation,
   lightboxBackgroundOpacity,
+  lightboxImageLayers,
   lightboxInitialIndex,
   lightboxPageIndex,
   lightboxPageLabel,
@@ -69,8 +70,11 @@ import {
   type AnnotationStroke,
 } from '@/session/imageAnnotationModel';
 
+// 缩略图垫底**不**挂在取件态里:它要跨过 loading → ready 的边界继续垫住原图
+// 下载那一段(见 lightboxImageLayers),挂进 loading 分支会在取件完成的瞬间
+// 结构性丢失,把第二段空档裸露成纯黑。垫底地址单独存 previewMap。
 type PageResolveState =
-  | { status: 'loading'; previewUri?: string }
+  | { status: 'loading' }
   | { status: 'ready'; media: MobileResolvedRemoteMedia }
   | { status: 'error' };
 
@@ -165,6 +169,11 @@ export const ImageLightbox = memo(function ImageLightbox({
   const [activeIndex, setActiveIndex] = useState(() => lightboxInitialIndex(urls, initialUrl));
   const [zoomed, setZoomed] = useState(false);
   const [resolveMap, setResolveMap] = useState<Record<string, PageResolveState>>({});
+  /**
+   * trimmed url → 列表缩略图地址(渐进出图的垫底层)。独立于 resolveMap:
+   * 一旦拿到就长期有效,取件态怎么流转都不丢,直到原图 onLoad 才停止使用。
+   */
+  const [previewMap, setPreviewMap] = useState<Record<string, string>>({});
   /** 下滑拖动量(当前活跃页写入),驱动背景与 chrome 渐隐。 */
   const dismissY = useSharedValue(0);
 
@@ -296,23 +305,22 @@ export const ImageLightbox = memo(function ImageLightbox({
       .catch(() => {
         setResolveMap((prev) => ({ ...prev, [key]: { status: 'error' } }));
       });
-    // 原图取件期间先垫列表缩略图:首开不黑屏转圈,原图到达后由 ready 态整体替换
-    // (规则 7)。cachedOnly:只复用列表已取过的缩略图缓存,绝不触发新取件——对
-    // gif/老被控端,thumbnail 请求会回落成整张原图下载,装饰性垫底叠加原图主取件
-    // 就是双下载。forceRefresh 是坏对象自愈路径,不垫可能同源的旧缩略图;取不到
-    // 缩略图保持纯 spinner,不影响原图路径。
+    // 垫底缩略图:列表里这张图已经解码好了,拿来从打开那一刻接住画面,一直垫到
+    // 原图 onLoad(见 lightboxImageLayers)。写入**不看取件态** —— 原图可能在同
+    // 一批微任务里就从内存/磁盘缓存返回,旧实现要求"当前必须是 loading"才写垫底,
+    // 这条竞态下垫底被直接丢弃,画面又退回纯黑。
+    // cachedOnly:只复用列表已取过的缩略图缓存,绝不触发新取件——对 gif/老被控端,
+    // thumbnail 请求会回落成整张原图下载,装饰性垫底叠加原图主取件就是双下载。
+    // forceRefresh 是坏对象自愈路径,不垫可能同源的旧缩略图;取不到缩略图退回
+    // spinner(lightboxImageLayers 兜底),不影响原图路径。
     if (!forceRefresh) {
       void onResolveRemoteMedia(
         { kind: media.kind, url: media.url, previewable: media.previewable, thumbnail: true },
         { front: false, cachedOnly: true },
       )
         .then((thumb) => {
-          if (!thumb.previewable) return;
-          setResolveMap((prev) => {
-            const state = prev[key];
-            if (!state || state.status !== 'loading' || state.previewUri) return prev;
-            return { ...prev, [key]: { status: 'loading', previewUri: thumb.url } };
-          });
+          if (!thumb.previewable || !thumb.url) return;
+          setPreviewMap((prev) => (prev[key] ? prev : { ...prev, [key]: thumb.url }));
         })
         .catch(() => undefined);
     }
@@ -354,6 +362,17 @@ export const ImageLightbox = memo(function ImageLightbox({
     if (state?.status === 'ready' && state.media.previewable) return state.media.url;
     return null;
   }, [resolveMap]);
+
+  /**
+   * 该页的垫底缩略图。与原图地址相同时返回 null:磁盘缓存命中会让缩略图与
+   * 原图落到同一个 file://(缩不动的图按裸键落盘),此时垫同一张图纯属多解码
+   * 一份,且原图本就秒出。
+   */
+  const previewUriFor = useCallback((image: MobileMessageGalleryImage): string | null => {
+    const preview = previewMap[image.url];
+    if (!preview) return null;
+    return preview === displayUriFor(image) ? null : preview;
+  }, [previewMap, displayUriFor]);
 
   const backdropStyle = useAnimatedStyle(() => ({
     opacity: lightboxBackgroundOpacity(dismissY.value, height),
@@ -459,6 +478,7 @@ export const ImageLightbox = memo(function ImageLightbox({
               onRequestClose={onClose}
               onRetry={handleRetryPage}
               onZoomChange={setZoomed}
+              previewUri={previewUriFor(item)}
               resolveState={item.payload.media.previewable ? null : resolveMap[item.url] ?? null}
               uri={displayUriFor(item)}
               width={width}
@@ -669,6 +689,7 @@ const LightboxPage = memo(function LightboxPage({
   onRequestClose,
   onRetry,
   onZoomChange,
+  previewUri,
   resolveState,
   uri,
   width,
@@ -701,6 +722,8 @@ const LightboxPage = memo(function LightboxPage({
   onRequestClose(): void;
   onRetry(image: MobileMessageGalleryImage): void;
   onZoomChange(zoomed: boolean): void;
+  /** 列表缩略图(渐进出图的垫底层);无则退 spinner。见 lightboxImageLayers。 */
+  previewUri: string | null;
   resolveState: PageResolveState | null;
   uri: string | null;
   width: number;
@@ -714,6 +737,16 @@ const LightboxPage = memo(function LightboxPage({
   const savedTranslateY = useSharedValue(0);
   const dragY = useSharedValue(0);
   const [pageZoomed, setPageZoomed] = useState(false);
+  /**
+   * 已 onLoad 成功的原图地址。存地址而不是 boolean:换图 / 强制重取换 url 后
+   * 天然失效,不需要额外 effect 复位(漏复位就会让新图那段又回到纯黑)。
+   */
+  const [loadedUri, setLoadedUri] = useState<string | null>(null);
+  const layers = lightboxImageLayers({
+    fullUri: uri,
+    previewUri,
+    fullLoaded: !!uri && loadedUri === uri,
+  });
 
   const setZoomedBoth = useCallback((value: boolean) => {
     setPageZoomed(value);
@@ -868,9 +901,27 @@ const LightboxPage = memo(function LightboxPage({
       {uri ? (
         <GestureDetector gesture={gesture}>
           <Animated.View collapsable={false} style={styles.pageFill}>
+            {/*
+              渐进出图的垫底层:原图字节还在下载时,先用列表已解码的缩略图占住
+              整屏(此前这一段是裸黑屏——用户在列表已经看过这张图,点开反而先黑
+              一段)。共用同一份 imageStyle transform + contain,与原图几何完全
+              一致,原图 onLoad 后本层卸掉,视觉上无跳变。
+              绝对定位而非参与 flex:与原图同为 flex 子节点会被 Yoga 各分一半高度。
+            */}
+            {layers.showPreview && previewUri ? (
+              <Animated.Image
+                resizeMode="contain"
+                source={{ uri: previewUri }}
+                style={[styles.pagePreviewLayer, imageStyle]}
+                testID="message.imageLightboxPreviewLayer"
+              />
+            ) : null}
             <Animated.Image
               onError={onImageError && retryable ? () => onImageError(image) : undefined}
               onLoad={(event) => {
+                // 撤垫底的唯一依据:原图真的有像素了。早于此撤(例如取件一完成
+                // 就撤)就会把下载窗口裸露成黑屏,正是本次修复的起因。
+                setLoadedUri(uri);
                 const source = event.nativeEvent?.source;
                 if (source && source.width > 0 && source.height > 0) {
                   onNaturalSize(image.key, { width: source.width, height: source.height });
@@ -880,6 +931,12 @@ const LightboxPage = memo(function LightboxPage({
               source={{ uri }}
               style={[styles.pageFill, imageStyle]}
             />
+            {/* 连缩略图都没有(直连 http 图 / 缓存未命中):至少给转圈,不留纯黑无反馈。 */}
+            {layers.showSpinner ? (
+              <View pointerEvents="none" style={styles.pageSpinnerLayer}>
+                <ActivityIndicator color="#ffffff" testID="message.imageLightboxLoading" />
+              </View>
+            ) : null}
             {overlayVisible ? (
               // 两遍绘制(先全部白描边、再全部红线):交叉处不会出现白边压
               // 红线的断裂感,与桌面 / 烧录一致。
@@ -952,16 +1009,20 @@ const LightboxPage = memo(function LightboxPage({
             </>
           ) : (
             <>
-              {resolveState?.status === 'loading' && resolveState.previewUri ? (
-                // 原图在途时垫列表缩略图(静态 contain,无缩放手势,点击仍由外层
-                // Pressable 单击关闭接管):首开不黑屏,原图到达切上面手势分支无缝替换。
+              {layers.showPreview && previewUri ? (
+                // 取件在途时垫列表缩略图(静态 contain,无缩放手势,点击仍由外层
+                // Pressable 单击关闭接管):首开不黑屏,原图到达切上面手势分支时
+                // 那边继续垫同一张图,两段之间不留空档。
                 <Animated.Image
                   resizeMode="contain"
-                  source={{ uri: resolveState.previewUri }}
+                  source={{ uri: previewUri }}
                   style={StyleSheet.absoluteFill}
+                  testID="message.imageLightboxPreviewLayer"
                 />
               ) : null}
-              <ActivityIndicator color="#ffffff" testID="message.imageLightboxLoading" />
+              {layers.showSpinner ? (
+                <ActivityIndicator color="#ffffff" testID="message.imageLightboxLoading" />
+              ) : null}
             </>
           )}
         </Pressable>
@@ -978,6 +1039,9 @@ const styles = StyleSheet.create({
   chrome: { ...absoluteFill, alignItems: 'center' },
   pageFill: { flex: 1, height: '100%', width: '100%' },
   pageCenter: { alignItems: 'center', gap: 16, justifyContent: 'center' },
+  // 垫底缩略图 / 转圈都脱离 flex 流:与原图同为 flex 子节点会被各分一半高度。
+  pagePreviewLayer: { ...absoluteFill },
+  pageSpinnerLayer: { ...absoluteFill, alignItems: 'center', justifyContent: 'center' },
   pageLabel: {
     color: 'rgba(255, 255, 255, 0.85)',
     fontSize: typeScale.footnote,

--- a/apps/mobile/src/session/imageLightboxModel.ts
+++ b/apps/mobile/src/session/imageLightboxModel.ts
@@ -87,6 +87,8 @@ export interface LightboxImageLayers {
   showPreview: boolean;
   /** 是否渲染转圈(仅在连缩略图都没有、否则就是纯黑时)。 */
   showSpinner: boolean;
+  /** 是否渲染失败终态文案(原图已确证失败且没有重试路径,不能永远转圈)。 */
+  showFailure: boolean;
 }
 
 /**
@@ -101,6 +103,12 @@ export interface LightboxImageLayers {
  * 拿不到缩略图时(直连 http 图、缓存未命中)退一步给转圈:宁可有反馈,
  * 不要纯黑无提示。有缩略图时**不叠**转圈 —— 画面已经完整可读(只是软),
  * 再压一个转圈反而制造"还在加载"的噪声,对齐主流 IM 的渐进出图观感。
+ *
+ * 但「有地址」不等于「有像素」:缩略图的磁盘文件可能被 LRU / 系统清理掉,而取件
+ * 队列的内存缓存仍持有那个永不过期的 file://。这种垫底图根本画不出来,若仍据此
+ * 隐藏转圈,整段就退回纯黑、还比旧实现少了转圈反馈,所以 previewFailed 必须参与
+ * 判定(PR #1125 review;DESIGN.md 双模式门槛也要求改动触及的 loading / error 态
+ * 都被覆盖)。
  */
 export function lightboxImageLayers(input: {
   /** 原图可渲染地址;取件完成前为 null。 */
@@ -109,12 +117,27 @@ export function lightboxImageLayers(input: {
   previewUri: string | null;
   /** 原图是否已 onLoad。仅在与当前 fullUri 对应时为 true(换图即失效)。 */
   fullLoaded: boolean;
+  /** 垫底图是否已确认 onError(文件被清理等);失败的垫底不能顶替转圈。 */
+  previewFailed?: boolean;
+  /**
+   * 原图已确证 onError,且这条路径没有自动重取 / 重试入口(直连 http 图)。
+   * 此时既没有像素也不会再有,必须给失败终态——转圈会一直谎报"还在加载"。
+   */
+  fullFailedTerminally?: boolean;
 }): LightboxImageLayers {
   // fullUri 为空时 fullLoaded 一律不成立:防调用方漏重置造成"已加载"的假阳性
   // (会把垫底和转圈同时撤掉,又回到纯黑)。
-  if (input.fullUri && input.fullLoaded) return { showPreview: false, showSpinner: false };
-  if (input.previewUri) return { showPreview: true, showSpinner: false };
-  return { showPreview: false, showSpinner: true };
+  if (input.fullUri && input.fullLoaded) {
+    return { showPreview: false, showSpinner: false, showFailure: false };
+  }
+  // 垫底可用时优先给内容(软图也是内容),胜过失败文案与转圈。
+  if (input.previewUri && !input.previewFailed) {
+    return { showPreview: true, showSpinner: false, showFailure: false };
+  }
+  if (input.fullFailedTerminally) {
+    return { showPreview: false, showSpinner: false, showFailure: true };
+  }
+  return { showPreview: false, showSpinner: true, showFailure: false };
 }
 
 /** 可分享判定:本地 file:// 直接分享;http(s) 可下载后分享;data: 不支持。 */

--- a/apps/mobile/src/session/imageLightboxModel.ts
+++ b/apps/mobile/src/session/imageLightboxModel.ts
@@ -81,6 +81,42 @@ export function lightboxPageLabel(index: number, count: number): string | null {
   return `${index + 1} / ${count}`;
 }
 
+/** 单页的图像层可见性(见 {@link lightboxImageLayers})。 */
+export interface LightboxImageLayers {
+  /** 是否渲染缩略图垫底层(在原图层之下)。 */
+  showPreview: boolean;
+  /** 是否渲染转圈(仅在连缩略图都没有、否则就是纯黑时)。 */
+  showSpinner: boolean;
+}
+
+/**
+ * 渐进出图的层决策:打开瞬间必须有像素接住画面。
+ *
+ * 点开的图在聊天列表里已经解码好了,所以缩略图从**打开那一刻**就垫在底下,
+ * 一直垫到原图 `onLoad` 真正落地(有像素)才撤 —— 空档窗口有两段,取件在途
+ * (还没有原图地址)与原图地址已拿到、字节仍在下载,两段都必须被垫住。
+ * 此前只垫住了第一段(且垫底状态挂在取件态里,取件一完成就连带丢失),于是
+ * 第二段裸露成纯黑:用户已经在列表看过这张图,点开反而先黑一段再跳出来。
+ *
+ * 拿不到缩略图时(直连 http 图、缓存未命中)退一步给转圈:宁可有反馈,
+ * 不要纯黑无提示。有缩略图时**不叠**转圈 —— 画面已经完整可读(只是软),
+ * 再压一个转圈反而制造"还在加载"的噪声,对齐主流 IM 的渐进出图观感。
+ */
+export function lightboxImageLayers(input: {
+  /** 原图可渲染地址;取件完成前为 null。 */
+  fullUri: string | null;
+  /** 列表缩略图地址;取不到为 null。 */
+  previewUri: string | null;
+  /** 原图是否已 onLoad。仅在与当前 fullUri 对应时为 true(换图即失效)。 */
+  fullLoaded: boolean;
+}): LightboxImageLayers {
+  // fullUri 为空时 fullLoaded 一律不成立:防调用方漏重置造成"已加载"的假阳性
+  // (会把垫底和转圈同时撤掉,又回到纯黑)。
+  if (input.fullUri && input.fullLoaded) return { showPreview: false, showSpinner: false };
+  if (input.previewUri) return { showPreview: true, showSpinner: false };
+  return { showPreview: false, showSpinner: true };
+}
+
 /** 可分享判定:本地 file:// 直接分享;http(s) 可下载后分享;data: 不支持。 */
 export function canShareLightboxImage(displayUri: string | null): boolean {
   if (!displayUri) return false;

--- a/apps/mobile/src/session/remoteMedia.ts
+++ b/apps/mobile/src/session/remoteMedia.ts
@@ -77,6 +77,42 @@ export function canPreviewResolvedRemoteMedia(
   return false;
 }
 
+/**
+ * 原图请求等待落盘的上限。expo 的下载没有显式 deadline,不能无界地等——它会
+ * 占住取件队列的并发槽位,并把查看器一直吊在垫底缩略图上。超时即回落 presign
+ * 地址(= 本机制引入前的行为),后台落盘照常继续,下次点开走磁盘命中。
+ * 取 30s 与 `device-link:media:fetch` 的执行预算同量级:合法的慢下载仍能吃到
+ * 「只下载一遍」的收益,只有真卡住才回落。
+ */
+export const REMOTE_MEDIA_LOCAL_COPY_WAIT_MS = 30_000;
+
+/**
+ * 原图落盘成功后的条目升级:把渲染地址从 presign OSS 换成本地 file://。
+ *
+ * 为什么必须换:presign 地址在有效期内会被取件队列当 fresh 缓存命中反复复用,
+ * 于是每次点开查看器都从 OSS 重新拉整张原图(用户实测「已经打开过原图,关闭再
+ * 打开又从黑屏开始」);同一个对象还会被下载两遍(落盘一遍、渲染一遍)。换成
+ * 本地文件后再次点开零网络秒出。
+ *
+ * ossKey 必须保留:OSS 对象仍在世,退屏清理要靠它 DELETE(空 key 才跳过)。
+ * hit 为空(落盘被跳过 / 失败)或 mime 不是图片时返回 null,由调用方回落原条目。
+ */
+export function localCopyResolvedMedia(
+  resolved: MobileResolvedRemoteMedia,
+  hit: { uri: string; mimeType: string; size: number } | null | undefined,
+): MobileResolvedRemoteMedia | null {
+  if (!hit || !hit.uri || !hit.mimeType.startsWith('image/')) return null;
+  return {
+    url: hit.uri,
+    ossKey: resolved.ossKey,
+    mimeType: hit.mimeType,
+    size: hit.size,
+    // 本地文件不过期;被 LRU/OS 清掉时 Image onError → forceRefresh 重取自愈。
+    expiresAt: REMOTE_MEDIA_NEVER_EXPIRES,
+    previewable: true,
+  };
+}
+
 export function isResolvedRemoteMediaFresh(
   media: Pick<MobileResolvedRemoteMedia, 'expiresAt'>,
   now = Date.now(),

--- a/apps/mobile/src/session/remoteMedia.ts
+++ b/apps/mobile/src/session/remoteMedia.ts
@@ -78,24 +78,20 @@ export function canPreviewResolvedRemoteMedia(
 }
 
 /**
- * 原图请求等待落盘的上限。expo 的下载没有显式 deadline,不能无界地等——它会
- * 占住取件队列的并发槽位,并把查看器一直吊在垫底缩略图上。超时即回落 presign
- * 地址(= 本机制引入前的行为),后台落盘照常继续,下次点开走磁盘命中。
- * 取 30s 与 `device-link:media:fetch` 的执行预算同量级:合法的慢下载仍能吃到
- * 「只下载一遍」的收益,只有真卡住才回落。
- */
-export const REMOTE_MEDIA_LOCAL_COPY_WAIT_MS = 30_000;
-
-/**
  * 原图落盘成功后的条目升级:把渲染地址从 presign OSS 换成本地 file://。
  *
  * 为什么必须换:presign 地址在有效期内会被取件队列当 fresh 缓存命中反复复用,
- * 于是每次点开查看器都从 OSS 重新拉整张原图(用户实测「已经打开过原图,关闭再
- * 打开又从黑屏开始」);同一个对象还会被下载两遍(落盘一遍、渲染一遍)。换成
- * 本地文件后再次点开零网络秒出。
+ * 同键请求再也不会重进磁盘 lookup,于是每次点开查看器都从 OSS 重新拉整张原图
+ * (用户实测「已经打开过原图,关闭再打开又从黑屏开始」),盘上那份副本永远轮不
+ * 到用。换成本地文件后再次点开零网络秒出。
  *
- * ossKey 必须保留:OSS 对象仍在世,退屏清理要靠它 DELETE(空 key 才跳过)。
- * hit 为空(落盘被跳过 / 失败)或 mime 不是图片时返回 null,由调用方回落原条目。
+ * 升级是**事件驱动**的(落盘完成后经 RemoteMediaResolveHooks 回写队列缓存),不让
+ * 调用方同步等待落盘——取件队列并发上限只有 2 且看不到 front,同步等待会让相邻页
+ * 预取占住槽位,把用户正在看的那张饿住(PR #1125 review)。
+ *
+ * ossKey 必须保留:OSS 对象仍在世,退屏清理要靠它 DELETE(空 key 才跳过),队列也
+ * 靠它识别「升级迟到、对象已被 forceRefresh 换掉」并丢弃本次升级。
+ * hit 为空(落盘被跳过 / 失败)或 mime 不是图片时返回 null,由调用方放弃升级。
  */
 export function localCopyResolvedMedia(
   resolved: MobileResolvedRemoteMedia,

--- a/apps/mobile/src/session/remoteMediaDiskCache.ts
+++ b/apps/mobile/src/session/remoteMediaDiskCache.ts
@@ -58,13 +58,19 @@ export interface RemoteMediaDiskCache {
    * 把已取件成功的图片落盘(同 url 并发只下载一次;失败静默,缓存是纯优化)。
    * expectedSize(已知对象字节数)超过 maxBytes 时直接跳过——落盘只会立刻被
    * LRU 逐出,没必要为此把整个对象下载到手机。
+   *
+   * 返回值 = **本次是否真的写入了新字节**。false 覆盖三种"promise 正常完成但盘上
+   * 不是本次对象"的情形:超预算跳过、下载失败(按 IO 契约原子落位失败,现存同名
+   * 好文件被刻意保留)、落成 0 字节被作废。调用方据此决定能否改用本地文件——
+   * 只看 promise resolve 会把**已被证伪的旧文件**当成本次结果(PR #1125 review)。
    */
-  store(sourceUrl: string, downloadUrl: string, mimeType: string, expectedSize?: number): Promise<void>;
+  store(sourceUrl: string, downloadUrl: string, mimeType: string, expectedSize?: number): Promise<boolean>;
   /**
    * 把已在内存里的字节(base64,inline 缩略图回包)落盘,不经网络下载。
    * 与 store 共用同键串行化,防止同源并发写撕;IO 不支持 writeFileBase64 时静默跳过。
+   * 返回值语义同 store。
    */
-  storeBytes(sourceUrl: string, base64: string, mimeType: string): Promise<void>;
+  storeBytes(sourceUrl: string, base64: string, mimeType: string): Promise<boolean>;
 }
 
 const DEFAULT_MAX_BYTES = 150 * 1024 * 1024;
@@ -92,7 +98,7 @@ export function createRemoteMediaDiskCache(
   let entries: Map<string, IndexEntry> | null = null;
   let initPromise: Promise<void> | null = null;
   /** 进行中的落盘任务(按缓存键):记录 downloadUrl,同源不同地址不共用结果。 */
-  const downloading = new Map<string, { downloadUrl: string; task: Promise<void> }>();
+  const downloading = new Map<string, { downloadUrl: string; task: Promise<boolean> }>();
 
   async function init(): Promise<void> {
     if (entries) return;
@@ -125,6 +131,7 @@ export function createRemoteMediaDiskCache(
    *     刷新场景下 name 就是现存条目的好文件,不能误删;只清理并非现存条目的半成品;
    *   - size <= 0:0 字节文件已落位顶替,文件与同名旧条目一并作废,下次 lookup 重取;
    *   - 成功:mime 变化换扩展名时删除不再被引用的旧文件,登记条目并做配额回收。
+   * 返回 true 仅当本次确实登记了新写入的字节(见 store 返回值契约)。
    */
   async function commitWrittenFile(
     key: string,
@@ -132,12 +139,12 @@ export function createRemoteMediaDiskCache(
     prev: IndexEntry | undefined,
     size: number | null,
     mimeType: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (size === null) {
       if (!prev || prev.name !== name) {
         await Promise.resolve(io.deleteFile(name)).catch(() => undefined);
       }
-      return;
+      return false;
     }
     if (size <= 0 || !entries) {
       await Promise.resolve(io.deleteFile(name)).catch(() => undefined);
@@ -145,7 +152,7 @@ export function createRemoteMediaDiskCache(
         entries.delete(key);
         await persistIndex().catch(() => undefined);
       }
-      return;
+      return false;
     }
     if (prev && prev.name !== name) {
       await Promise.resolve(io.deleteFile(prev.name)).catch(() => undefined);
@@ -153,6 +160,9 @@ export function createRemoteMediaDiskCache(
     entries.set(key, { name, mimeType, size, lastUsedAt: now() });
     await evictOverBudget();
     await persistIndex().catch(() => undefined);
+    // 配额回收可能把刚写入的条目本身逐出(单对象接近 maxBytes 时);此时盘上已无
+    // 本次字节,不能报 true 让调用方改用本地文件。
+    return entries.get(key)?.name === name;
   }
 
   /** 超出预算按 lastUsedAt 淘汰最旧(调用方随后统一 persistIndex)。 */
@@ -189,13 +199,13 @@ export function createRemoteMediaDiskCache(
     async store(sourceUrl, downloadUrl, mimeType, expectedSize) {
       await init();
       // 单对象就超预算:落盘立刻会被 LRU 逐出,整个下载都是白费,直接跳过。
-      if (expectedSize !== undefined && expectedSize > maxBytes) return;
+      if (expectedSize !== undefined && expectedSize > maxBytes) return false;
       const key = cacheKeyOf(sourceUrl);
-      const run = async (): Promise<void> => {
+      const run = async (): Promise<boolean> => {
         const name = `${key}.${extOfMime(mimeType)}`;
         const prev = entries?.get(key);
         const size = await io.download(downloadUrl, name);
-        await commitWrittenFile(key, name, prev, size, mimeType);
+        return commitWrittenFile(key, name, prev, size, mimeType);
       };
       const pending = downloading.get(key);
       // 只合并**同一下载地址**的并发 store。forceRefresh 自愈会带全新 presign 地址,
@@ -203,7 +213,9 @@ export function createRemoteMediaDiskCache(
       // 不落盘——退屏清理还会删掉新 OSS 对象,下次进会话被迫重传。不同地址排在
       // 旧任务之后串行执行(旧任务成败都不影响新写入)。
       if (pending && pending.downloadUrl === downloadUrl) return pending.task;
-      const base = pending ? pending.task.catch(() => undefined).then(run) : run();
+      const base: Promise<boolean> = pending
+        ? pending.task.catch(() => undefined).then(run)
+        : run();
       const entry = { downloadUrl, task: base };
       entry.task = base.finally(() => {
         if (downloading.get(key) === entry) downloading.delete(key);
@@ -213,19 +225,21 @@ export function createRemoteMediaDiskCache(
     },
 
     async storeBytes(sourceUrl, base64, mimeType) {
-      if (!io.writeFileBase64 || !base64) return;
+      if (!io.writeFileBase64 || !base64) return false;
       await init();
       const key = cacheKeyOf(sourceUrl);
-      const run = async (): Promise<void> => {
+      const run = async (): Promise<boolean> => {
         const name = `${key}.${extOfMime(mimeType)}`;
         const prev = entries?.get(key);
         const size = await Promise.resolve(io.writeFileBase64!(name, base64)).catch(() => null);
-        await commitWrittenFile(key, name, prev, size, mimeType);
+        return commitWrittenFile(key, name, prev, size, mimeType);
       };
       // 与 store 共用同键串行化(防写撕);inline 写入无下载地址概念,不合并任何
       // 既有任务,一律排在其后执行(旧任务成败都不影响本次写入)。
       const pending = downloading.get(key);
-      const base = pending ? pending.task.catch(() => undefined).then(run) : run();
+      const base: Promise<boolean> = pending
+        ? pending.task.catch(() => undefined).then(run)
+        : run();
       const entry = { downloadUrl: 'inline:bytes', task: base };
       entry.task = base.finally(() => {
         if (downloading.get(key) === entry) downloading.delete(key);

--- a/apps/mobile/src/session/remoteMediaResolveQueue.ts
+++ b/apps/mobile/src/session/remoteMediaResolveQueue.ts
@@ -39,10 +39,29 @@ function requestKeyOf(media: RemoteMediaRequest): string {
   return media.thumbnail ? `thumb\u0000${media.url}` : media.url;
 }
 
+/**
+ * 单次 resolve 的回写钩子(队列绑定到该次请求的缓存键)。
+ * 取件方拿到 presign 结果后仍在后台落盘,落盘成功时经此把缓存条目升级成本地
+ * file://,不必让调用方同步等待落盘。
+ */
+export interface RemoteMediaResolveHooks {
+  /**
+   * 本地副本已确证就绪(字节确实写进磁盘缓存)。队列据此把自己的缓存条目换成
+   * 本地地址,后续同键请求直接命中本地文件、零网络。
+   * 迟到 / 已退屏 / 条目已被更新的对象替换等情形由队列自行丢弃,取件方无需判断。
+   */
+  onLocalCopy(media: MobileResolvedRemoteMedia): void;
+}
+
 export interface RemoteMediaResolveQueueDeps {
   /** 真正的取件实现(fetchRemoteMedia + presignGet)。skipCache 随 forceRefresh 请求透传,
-   *  让下游(磁盘缓存 / 被控端上传去重缓存)一并绕过,保证强制重取真的取到新对象。 */
-  resolve(media: RemoteMediaRequest, opts?: { skipCache?: boolean }): Promise<MobileResolvedRemoteMedia>;
+   *  让下游(磁盘缓存 / 被控端上传去重缓存)一并绕过,保证强制重取真的取到新对象。
+   *  hooks 见 {@link RemoteMediaResolveHooks}。 */
+  resolve(
+    media: RemoteMediaRequest,
+    opts?: { skipCache?: boolean },
+    hooks?: RemoteMediaResolveHooks,
+  ): Promise<MobileResolvedRemoteMedia>;
   /** presign 是否仍然新鲜;默认 isResolvedRemoteMediaFresh。 */
   isFresh?(media: MobileResolvedRemoteMedia, now: number): boolean;
   /** 时钟注入,测试用;默认 Date.now。 */
@@ -146,6 +165,28 @@ export function createRemoteMediaResolveQueue(
     entry.waiters.length = 0;
   }
 
+  /**
+   * 后台落盘完成后把缓存条目升级成本地 file://(见 RemoteMediaResolveHooks)。
+   *
+   * 为什么必须有这一步:取件返回的 presign 地址会被当 fresh 结果缓存,在有效期内
+   * 同键请求一律直接命中它,**再也不会重新进入磁盘 lookup**。于是「已经打开过的
+   * 原图,关掉再打开又要从 OSS 重下一整张」——盘上那份副本永远轮不到用
+   * (PR #1125 review)。事件驱动的升级取代了此前"同步等落盘"的做法:调用方不必
+   * 等待,预取也就不会占住并发槽位把用户正在看的那张饿住。
+   *
+   * 三条丢弃路径(乱序 / 迟到的升级绝不能污染缓存):
+   *   - 已 releaseAll:缓存归退屏清理接管,升级会凭空复活一个条目;
+   *   - 条目不存在:被 evict / 从未落缓存(如缩略图回落原图落的是裸键),不创建;
+   *   - ossKey 已变:forceRefresh 换过对象,本次升级对应的是旧对象,已过期。
+   */
+  function upgradeToLocalCopy(key: string, local: MobileResolvedRemoteMedia): void {
+    if (released) return;
+    const current = cache.get(key);
+    if (!current) return;
+    if (current.ossKey !== local.ossKey) return;
+    cache.set(key, local);
+  }
+
   function pump(): void {
     while (inFlightCount < maxConcurrent && pendingOrder.length > 0) {
       const key = pendingOrder.shift();
@@ -154,7 +195,11 @@ export function createRemoteMediaResolveQueue(
       if (!entry || entry.inFlight || entry.waiters.length === 0) continue;
       entry.inFlight = true;
       inFlightCount += 1;
-      void deps.resolve(entry.media, entry.skipCache ? { skipCache: true } : undefined)
+      void deps.resolve(
+        entry.media,
+        entry.skipCache ? { skipCache: true } : undefined,
+        { onLocalCopy: (local) => upgradeToLocalCopy(key, local) },
+      )
         .then((resolved) => {
           if (released) {
             // 退屏后没人关心新旧,follow-up 一并按本轮结果 settle。


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端点开图片会先黑一段再"跳"出图，而这张图在聊天列表里明明已经显示出来了；已经看过原图的，关掉再打开又从黑屏重来一遍。两个都是取件链路的问题，不是下载慢。

**一、垫底缩略图的生命周期挂错了地方**

`ImageLightbox` 原本把 `previewUri` 塞在 `PageResolveState` 的 `loading` 分支里。但从点开到出图其实有**两段**空档，只垫住了第一段：

| 空档 | 旧行为 |
|---|---|
| 取件在途（还没有原图地址） | 垫列表缩略图 ✅ |
| 原图地址已拿到、字节还在下载 | 状态切 `ready`，垫底连同 spinner 一起被卸掉 → **裸黑屏** ❌ |

而原图取件常常在同一批微任务里就从内存/磁盘缓存返回，第一段几乎不存在，用户看到的基本全是第二段的纯黑。叠加第二个缺陷：垫底写入要求"当前必须是 `loading`"，这条竞态下缩略图连写都写不进去。

改法：垫底地址搬到独立的 `previewMap`（不随取件态流转而丢失），**撤垫底的唯一依据改成原图真的 `onLoad`**。两段空档连成一段被完整垫住。垫底层与原图共用同一份 transform + `contain`，几何一致，撤除时无跳变；判定抽成 `lightboxImageLayers()` 纯函数。

顺带：连缩略图都没有时（直连 http 图 / 缓存未命中）退一步给 spinner，不再纯黑无反馈。有缩略图时不叠 spinner —— 画面已完整可读，再压个转圈反而制造"还在加载"的噪声。

**二、落盘的原图永远轮不到用**

取件成功后代码会把原图落盘，但返回给渲染的是 presign OSS 地址。这个地址在有效期内会被取件队列当 fresh 缓存命中反复复用，**同键请求再也不会重进磁盘 lookup**，于是磁盘上那份文件永远用不上，每次点开都从 OSS 重拉整张原图。

改法：落盘成功后**事件驱动**地把队列缓存条目升级成本地 `file://`（新增 `RemoteMediaResolveHooks`，由队列绑定到该次请求的缓存键回写；`localCopyResolvedMedia()` 负责构造升级后的条目，保留 `ossKey` 让退屏清理照常 DELETE、`expiresAt` 设为永不过期让队列恒命中）。首次打开照常用 presign 渲染，**再次打开零网络、直接满清晰度**。

`store` / `storeBytes` 的返回值改为「本次是否真的写入了新字节」：超预算跳过、下载失败（按 IO 契约原子落位失败、现存同名好文件被刻意保留）、落成 0 字节、以及配额回收把刚写入的条目本身逐出，四种情形都为 `false`。只有 `true` 才升级 —— 否则会把**已被 `onError` 证伪的旧文件**当成本次结果并标成永不过期。

升级的三条丢弃路径（乱序 / 迟到的升级绝不能污染缓存）：已 `releaseAll`（不复活被退屏清理接管的条目）、条目不存在（被 `evict` / 从未落缓存，不创建）、`ossKey` 已变（`forceRefresh` 换过对象，本次升级对应旧对象）。

> 演进说明：初版（`658867b4`）用「同步等落盘后返回本地 `file://`」实现第二点，被 review 指出三条 P2 —— 预取也会占住 `maxConcurrent=2` 的槽位把用户正在看的那张饿住、落盘超 30s 后 presign 被永久钉在缓存里、以及把 `store` 的 promise 完成误当写入成功。三条都源于「用同步等待这一种手段换取缓存正确性」，`7845b0b8` 换成上述事件驱动机制一并消除，并删掉了那个只为兜同步等待风险而存在的 `REMOTE_MEDIA_LOCAL_COPY_WAIT_MS`。
>
> 第三轮：codex 指出垫底层没有 `onError` —— 缩略图文件被 LRU/系统清理后，队列内存缓存仍回那个永不过期的 `file://`，我只凭 URI 存在就隐藏了转圈，于是这段**比旧实现更差**（旧实现至少一直有转圈）。这是「上一轮只接了成功路径、漏了失败路径」的对称缺口，触发了一次收敛检查点，产出上方的不变量清单，并顺带闭合了直连图的永久转圈。

### 图层不变量清单

第三轮 review 暴露「上一轮修复漏了对称的另一半」（给垫底层接了成功路径 `onLoad`、漏了失败路径 `onError`），按收敛止损做了一次检查点，把判定收敛成一句不变量并枚举全部对称路径。后续改动请对着这张表看：

> **查看器任一时刻都必须呈现「确证有像素」的一层；没有任何一层确证有像素时必须给出反馈，且反馈必须收敛到终态 —— 绝不允许纯黑无提示，也绝不允许永久转圈。**

「是否有像素」的判定只有一处：`lightboxImageLayers()`。它只吃**确证信号**，不再把「有 URI」当成「有像素」。

| 层 | 有地址 | 确证有像素 | 确证无像素 | 失败后归宿 |
|---|---|---|---|---|
| 原图 · 桌面取件图 | `uri` | `loadedUri === uri` | `onError` → 父层 `forceRefresh` 自愈一次 | 再失败落父层 error 态（「加载失败 + 重试」） |
| 原图 · 直连 http/data | `uri` | 同上 | `onError` → `failedFullUri` | 本页失败终态文案（无重取入口，不能转圈） |
| 垫底缩略图 | `previewUri` | 乐观渲染（不等 `onLoad`，见下） | `onError` → `failedPreviewUri` | 撤垫底并恢复转圈 |

配套判据全部统一成「存地址而非 boolean」（`loadedUri` / `failedPreviewUri` / `failedFullUri`）：换图、翻页、`forceRefresh` 换 URL 时天然失效，不需要额外 effect 复位——漏复位正是会让新图那段又退回纯黑的那类 bug。

一处刻意的取舍：垫底层**乐观渲染**而不等它自己 `onLoad`。本地文件解码只要一两帧，为它先挂一帧转圈会让每次打开都闪一下，与本 PR「让用户感知不到」的目标相反；失败路径由 `onError` 兜住。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实测反馈）
- 本 PR 包含：
  - `imageLightboxModel.ts`：新增 `lightboxImageLayers()` 纯函数（层可见性决策）
  - `ImageLightbox.tsx`：`previewMap` 独立于取件态；垫底层跨 `loading → ready` 边界并渲染在原图之下，原图 `onLoad` 才撤；无缩略图时退 spinner
  - `remoteMedia.ts`：新增 `localCopyResolvedMedia()`
  - `remoteMediaResolveQueue.ts`：新增 `RemoteMediaResolveHooks` 与 `upgradeToLocalCopy()`（含三条丢弃路径）
  - `remoteMediaDiskCache.ts`：`store` / `storeBytes` 返回「是否真的写入了新字节」
  - `app/sessions/[sessionId].tsx`：落盘成功后经 hook 升级队列缓存；顺手把一处重复的 `'9999-12-31T00:00:00.000Z'` 字面量换成已导出的 `REMOTE_MEDIA_NEVER_EXPIRES`
  - 第三轮补：垫底层接 `onError`（失败即撤垫底、恢复转圈）；原图 `onError` 对直连图也接线并给失败终态，`lightboxImageLayers` 增加 `previewFailed` / `fullFailedTerminally` 与 `showFailure`
  - 四个测试文件共补 22 个用例
- 明确不包含：无。（初版曾把「直连 http 图加载失败没有失败态」列为不包含，但本 PR 给该路径新增了转圈，等于把「永久纯黑」换成「永久转圈」——那是我引入的不诚实反馈，第三轮已一并闭合，见上方不变量清单。）
- 用户可见变化：点开图片全程不黑屏（先出缩略图、原地变清晰）；已看过的原图再次打开满清晰度秒出；无缩略图可垫时显示转圈而非纯黑；缩略图文件被清理掉时退回转圈而非纯黑；直连图确实加载不出来时给「加载失败」终态而非一直转圈。
- 是否存在 breaking change：无

### UI 变化

**不涉及**：改动命中 UI 代码路径（`apps/mobile/app/sessions/[sessionId].tsx`、`ImageLightbox.tsx`），但没有视觉、交互或文案变化 —— 只改了加载过程的时序衔接。

- **没有做任何设计决策**：没有新颜色、新 token、新组件、新布局、新字号。垫底层用的就是聊天列表里已经在显示的同一张缩略图；转圈与失败文案都是既有的（失败文案复用既有 i18n key `message.lightbox.loadFailed`，未新增任何文案）。
- 变的只是这些**既有状态在什么时候出现**：出图路径从「黑屏 → 跳出原图」改为「缩略图 → 原地变清晰」；失败反馈从「永久纯黑」「永久转圈」收敛到既有的失败终态。
- 因此也没有可附的界面效果证据：改动前后的终帧完全相同（都是全屏原图），静态截图或 HTML 体现不出时序差异。实机验证证据见下方「手工验证」的 build label 与 bundle 核验。

> 更正说明：`check:pr-design-basis` 与 auto-review 的 UI 证据提示都是**按文件路径**触发的启发式，不判断改动性质。本描述初版顺着它写成了设计改动的口径、引了 `DESIGN.md` 章节并讨论双模式目检，是过度解读；也因此把「是否公开上传录屏」错误地当成了待决事项——本次没有视觉变化要证明，就不存在视觉证据与授权问题。现按 PR 模板本身的口径更正：「命中 UI 代码路径但确无视觉/交互/文案变化时，写不涉及 + 理由」。全程未做任何公开素材上传。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run typecheck
结果：通过（无输出）

pnpm --filter mobile exec vitest run --pool=threads
结果：Test Files 268 passed (268) / Tests 2682 passed (2682)

仓库根单测门禁（经 run-unit-gate.sh 统一入口，判据为日志含 GATE_STARTED）
结果：GATE_EXIT=0，54 PASS / 0 FAIL

pnpm check:dco
结果：DCO check passed: 3 commits signed off

新增用例（共 22）：
  imageLightboxModel.test.ts   lightboxImageLayers ×8（含三个回归点：原图地址已到、
    尚未 onLoad 时垫底必须保留；垫底自身 onError 后必须恢复转圈；直连图确证失败后
    必须收敛到失败终态而不是永久转圈）
  remoteMedia.test.ts          localCopyResolvedMedia ×3
  remoteMediaResolveQueue.test.ts  local-copy upgrade ×5（升级后同键请求命中本地
    且不再取件 / 保留 ossKey 使退屏仍 DELETE / 三条丢弃路径）
  remoteMediaDiskCache.test.ts store 返回值 ×5（写入成功 / 超预算跳过未下载 /
    下载失败但旧好文件被保留 / 落成 0 字节 / 配额回收逐出刚写入的条目）
  另更新 3 个既有用例以匹配新契约（store 返回 boolean、resolve 多一个 hooks 参数、
    messageMediaThumbnailWiring 的源码扫描断言改为「自愈仍按 retryable 门控、但
    onError 对所有图接线」并加断言钉住两条新失败路径）

注：commit 81771211 的 message 里把用例总数写成了 2684，实际是 2682（上面为实测值）。
不值得为一处计数笔误 force-push 覆盖已被 review 锚定的 commit，在此更正。
```

### 手工验证

iOS 模拟器（iPhone 17 Pro / iOS 26.5），国服 `cn`，与远端被控桌面配对的真实会话：

- 点开桌面端生成的图片：立即显示列表缩略图，原图到位后原地变清晰，全程无黑屏。
- 关闭后再次打开同一张：直接满清晰度显示。

验证链证据：

- `pnpm mobile:sim:whoami -- --region=cn` → `✓ PASS：booted dev client、8081 Metro 归属和源码指纹一致`
- worktree / branch：`cindy-mobile-lightbox-progressive-open` / `dash/mobile-lightbox-progressive-open`
- Metro 归属：`:8081 → /Users/dash/Code/Cindy/cindy-mobile-lightbox-progressive-open`
- `__DEV__` build label 指纹：`dash/mobile-lightbox-progressive-open@42f21153f`
- 安装包：`com.xd.cindycn`（国服）
- 另经 Metro 打包端点核验代码确实进入 bundle：`HTTP=200`、无 `UnableToResolveError`

### 未执行的验证

- **手工验证跑在初版 `658867b4` 上**，`7845b0b8` 的机制改动（事件驱动升级）只有单测覆盖，未再上真机复测。两版的用户可见行为一致（首开垫缩略图、再开秒出），但"再开秒出"在新机制下依赖后台落盘已完成，慢网下首开后立刻重开可能仍走 presign —— 这一时序差异未实测。
- **Android 未验证**：只在 iOS 模拟器跑过。改动为纯 JS/TS，不含平台分支代码；但「绝对定位的垫底层 + RN `Image` 的 `onLoad` 时序」在 Android（Fresco）上的表现未实测。
- **Light/Dark 未分别目检**：本次无视觉变化、未引入受主题影响的颜色，双模式差异不适用（lightbox 本身也是常黑沉浸语境）；未做分别目检。
- **未实测的边界**：落盘超预算被跳过、下载失败、0 字节、配额逐出这四条 `store` 返回 false 的路径，以及三条升级丢弃路径，都只有单测覆盖，未在真机构造超大图 / 慢网 / 并发翻页复现。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：取件缓存一致性与 OSS 对象生命周期

### 影响与回滚

- 影响范围：仅手机端图片取件与查看链路（聊天 lightbox + 会话屏 remote-media resolver + 取件队列 + 图片磁盘缓存）。视频/音频/文件取件未改动。
- **不触发冷更**：改动全为 `apps/mobile` 下的 JS/TS，未碰 `app.json` / `app.config.js` / `eas.json` / `apps/mobile/package.json` / `plugins/` / `modules/`，runtime fingerprint 输入不变。
- **首开时序与改动前一致**：`resolve` 仍立即返回 presign，不再有任何同步等待，也不多占取件队列的并发槽位。
- OSS 对象生命周期不变：升级后的条目保留 `ossKey`，退屏 `releaseAll` 与 `onOrphanResolved` 的 DELETE 编排照旧（空 `ossKey` 才跳过删除）；落盘 promise 仍登记进 `pendingDiskStores`，DELETE 依然会等落盘结束。已补单测钉住「升级后 `releaseAll` 仍返回带 `ossKey` 的条目」。
- 缓存一致性的新面：队列缓存条目现在可被后台事件改写。三条丢弃路径（released / 条目不存在 / `ossKey` 不匹配）各有单测；`ossKey` 比对同时挡住「迟到的旧对象升级覆盖 `forceRefresh` 后的新条目」这条乱序路径。
- 回滚 / 降级方式：两处修复互相独立，可单独 revert。取件层单独降级也无需改代码 —— 移除 `upgradeToLocalCopy` 里的 `cache.set` 一行即退回「presign 一直用到过期」的改动前行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动意图与取舍写在代码注释里，无独立文档需要更新）
- [x] 已确认测试结果或说明未执行原因

