### PR TITLE
fix(mobile): iOS 状态栏样式改走 VC-based 通道,适配 iOS 27

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -19,6 +19,7 @@
       },
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
+        "UIViewControllerBasedStatusBarAppearance": true,
         "UISupportedInterfaceOrientations": [
           "UIInterfaceOrientationPortrait",
           "UIInterfaceOrientationPortraitUpsideDown",

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,3 +1,4 @@
+import { Stack } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Animated, Easing, Keyboard, Linking, Platform, Pressable, StyleSheet, View } from 'react-native';
@@ -5,6 +6,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { AccountDeletionStatus, SocialProvider, VerificationKind } from '@cindy/auth-client';
 
 import { useAuth } from '@/auth/AuthContext';
+import { useLoginFirstLaunchLight } from '@/auth/loginFirstLaunchGate';
+import { resolveStartupSplashHandoff } from '@/auth/startupSplashContinuity';
 import {
   CN_PHONE_PREFIX,
   isCompleteCnPhone,
@@ -87,6 +90,13 @@ export default function LoginScreen() {
   const auth = useAuth();
   const stage = useLoginSurface();
   const insets = useSafeAreaInsets();
+  // 舞台有效主题(首启亮色门可强制 light,与系统主题可能不一致):状态栏样式
+  // 必须跟舞台而不是系统,经 screen option 走 VC-based 通道(见 _layout 注释)。
+  const { mode: systemTheme } = useTheme();
+  const firstLaunchGate = useLoginFirstLaunchLight();
+  const stageTheme =
+    resolveStartupSplashHandoff(firstLaunchGate, systemTheme).targetTheme ??
+    systemTheme;
   const handoff = useLoginHandoffOptional();
   const handoffDispatch = handoff?.dispatch;
   // readiness 锚之一(v6.3):登录面板已挂载(防面板未挂载先播 panel 步)
@@ -1163,6 +1173,15 @@ export default function LoginScreen() {
       keyboardShiftPx={keyboardShift}
       testID="login.screen"
     >
+      {/* 渲染为 null,仅把状态栏样式写进本屏 screen options。iOS 专用:
+          Android 由舞台内组件式 StatusBar 控制,不走 RNS 双轨 */}
+      {Platform.OS === 'ios' ? (
+        <Stack.Screen
+          options={{
+            statusBarStyle: stageTheme === 'dark' ? 'light' : 'dark',
+          }}
+        />
+      ) : null}
       {/* 外层未变换测量 wrapper(v5 冻结拓扑):持布局基线,不参与任何 translate */}
       <View
         collapsable={false}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,7 +8,7 @@ import {
 } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useMemo, type ReactElement } from 'react';
-import { Alert, Pressable, StyleSheet, View } from 'react-native';
+import { Alert, Platform, Pressable, StyleSheet, View } from 'react-native';
 import { Text } from '@/components/AppText';
 import {
   fontWeight,
@@ -20,7 +20,9 @@ import {
 } from '@/theme';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AuthProvider, useAuth } from '@/auth/AuthContext';
+import { useLoginFirstLaunchLight } from '@/auth/loginFirstLaunchGate';
 import { loginText } from '@/auth/loginMessages';
+import { resolveStartupSplashHandoff } from '@/auth/startupSplashContinuity';
 import {
   MobileLoginHandoffProvider,
   useLoginHandoff,
@@ -54,6 +56,17 @@ function NavigationGate() {
   const segments = useSegments();
   const { mode, colors } = useTheme();
   const { releaseSplash, splashActive } = useStartupSplash();
+  // iOS 状态栏样式走 react-native-screens 的 VC-based 通道(Info.plist 已翻
+  // UIViewControllerBasedStatusBarAppearance=YES):iOS 27 起 UIKit 不再接受
+  // RN StatusBar 依赖的废弃全局 API(setStatusBarStyle),expo-status-bar 组件
+  // 在 iOS 上已失效且会触发 RCTLogError,iOS 侧不得再挂载。Android 老链路正常,
+  // 继续用组件式 StatusBar(含 Stack 未挂载的启动闸门期),不走 RNS 双轨。
+  // splash 覆盖层是登录品牌舞台(首启亮色门可能强制 light):覆盖期间随舞台
+  // 有效主题,释放后随系统主题;首启门 pending 时舞台不渲染品牌,跟系统即可。
+  const firstLaunchGate = useLoginFirstLaunchLight();
+  const stageTheme =
+    resolveStartupSplashHandoff(firstLaunchGate, mode).targetTheme ?? mode;
+  const statusBarTheme = splashActive ? stageTheme : mode;
   const navigationTheme = useMemo(
     () =>
       createNavigationTheme(
@@ -96,12 +109,19 @@ function NavigationGate() {
 
   return (
     <NavigationThemeProvider value={navigationTheme}>
-      {/* splash 覆盖层仍在时状态栏保持浅色;淡出开始后切回主题样式 */}
-      <StatusBar style={splashActive || mode === 'dark' ? 'light' : 'dark'} />
+      {/* Android 专用:splash 覆盖层仍在时状态栏保持浅色;淡出开始后切回主题样式 */}
+      {Platform.OS === 'android' ? (
+        <StatusBar
+          style={splashActive || mode === 'dark' ? 'light' : 'dark'}
+        />
+      ) : null}
       <Stack
         screenOptions={{
           headerShown: false,
           contentStyle: { backgroundColor: colors.surface },
+          ...(Platform.OS === 'ios'
+            ? { statusBarStyle: statusBarTheme === 'dark' ? 'light' : 'dark' }
+            : null),
           // iOS 26 起 react-native-screens 的返回手势默认全屏识别(fullScreenSwipe 默认 true),
           // 判定范围过大:会与消息内表格/代码块的横向 ScrollView 抢手势,拖动内容时还会误触返回。
           // 限定手势起始点在屏幕前缘 44pt 内(end = 距前缘最大 x),恢复经典边缘返回的判定范围;

--- a/apps/mobile/src/__tests__/nativeAppConfig.test.ts
+++ b/apps/mobile/src/__tests__/nativeAppConfig.test.ts
@@ -423,6 +423,23 @@ describe('mobile native app config', () => {
     expect(eas.build['production-global'].extends).toBe('store-global-base');
   });
 
+  it('keeps iOS status bar appearance view-controller based (iOS 27 requirement)', () => {
+    const appJson = JSON.parse(
+      readFileSync(resolve(process.cwd(), 'app.json'), 'utf8'),
+    );
+    const buildConfig = require(resolve(process.cwd(), 'app.config.js'));
+
+    // iOS 27 起 RN StatusBar 的废弃全局链路失效,状态栏样式依赖 VC-based 通道
+    // (react-native-screens screen options)。该键被误删/翻回 false 时,浅色模式
+    // 状态栏会停在白字且无法 JS 热修(冷更锁定),必须由本断言挡住。
+    expect(
+      appJson.expo.ios.infoPlist.UIViewControllerBasedStatusBarAppearance,
+    ).toBe(true);
+    // app.config.js 不得剥离该键:以 resolved config 为准再断言一次。
+    const cn = buildConfig({ config: appJson.expo });
+    expect(cn.ios.infoPlist.UIViewControllerBasedStatusBarAppearance).toBe(true);
+  });
+
   it('keeps audio capture foreground-only in native builds', () => {
     const appJson = JSON.parse(
       readFileSync(resolve(process.cwd(), 'app.json'), 'utf8'),

--- a/apps/mobile/src/__tests__/statusBarVcMigration.test.ts
+++ b/apps/mobile/src/__tests__/statusBarVcMigration.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * iOS 状态栏 VC-based 迁移的源码合同测试(PR #1129)。
+ *
+ * 背景:Info.plist 的 UIViewControllerBasedStatusBarAppearance=YES 后
+ * (见 nativeAppConfig.test.ts 的对应断言),RN StatusBar 的样式/隐藏调用在
+ * iOS 上失效并触发 RCTLogError;iOS 改经 react-native-screens 的
+ * statusBarStyle / statusBarHidden screen options,Android 保持组件式
+ * StatusBar 老链路。这些平台守卫分支散在 4 个文件里,merge conflict 误删
+ * 任何一个守卫都不会有类型错误——用源码合同把它们钉住。
+ */
+const read = (relativePath: string) =>
+  readFileSync(resolve(process.cwd(), relativePath), 'utf8');
+
+describe('status bar VC-based migration source contracts', () => {
+  it('_layout.tsx: Android 用组件式 StatusBar,iOS 用 Stack screenOptions statusBarStyle', () => {
+    const source = read('app/_layout.tsx');
+    // Android-only 组件式 StatusBar(覆盖 Stack 未挂载的启动闸门期)
+    expect(source).toContain("{Platform.OS === 'android' ? (");
+    expect(source).toContain(
+      "style={splashActive || mode === 'dark' ? 'light' : 'dark'}",
+    );
+    // iOS-only 的 RNS 通道:statusBarStyle 只在 iOS 进 screenOptions
+    expect(source).toContain("...(Platform.OS === 'ios'");
+    expect(source).toContain(
+      "{ statusBarStyle: statusBarTheme === 'dark' ? 'light' : 'dark' }",
+    );
+    // splash 覆盖期跟舞台有效主题(首启亮色门),释放后跟系统主题
+    expect(source).toContain(
+      'const statusBarTheme = splashActive ? stageTheme : mode;',
+    );
+  });
+
+  it('MobileLoginHandoffStage.tsx: 组件式 StatusBar 必须锁在 Android 分支内', () => {
+    const source = read('src/components/MobileLoginHandoffStage.tsx');
+    expect(source).toContain("{Platform.OS === 'android' ? (");
+    expect(source).toContain(
+      "<StatusBar style={mode === 'dark' ? 'light' : 'dark'} />",
+    );
+    // iOS 不得无守卫挂载 expo-status-bar 组件(会触发 RCTLogError):
+    // 每个 <StatusBar 出现点都要能配对到 android 守卫。
+    const statusBarUses = source.match(/<StatusBar /g) ?? [];
+    const androidGuards =
+      source.match(/Platform\.OS === 'android' \? \(\s*<StatusBar /g) ?? [];
+    expect(statusBarUses.length).toBeGreaterThan(0);
+    expect(androidGuards.length).toBe(statusBarUses.length);
+  });
+
+  it('ImageLightbox.tsx: iOS 走宿主屏 statusBarHidden option,Android 保留 Modal 内 StatusBar hidden', () => {
+    const source = read('src/session/ImageLightbox.tsx');
+    // iOS:经 navigation.setOptions 走 VC-based 通道,卸载时恢复
+    expect(source).toContain("if (Platform.OS !== 'ios') return;");
+    expect(source).toContain(
+      'navigation.setOptions({ statusBarHidden: true });',
+    );
+    expect(source).toContain(
+      'navigation.setOptions({ statusBarHidden: false });',
+    );
+    // Android:组件式 hidden 保持老链路,且必须锁在 android 守卫内
+    expect(source).toContain(
+      "{Platform.OS === 'android' ? <StatusBar hidden /> : null}",
+    );
+  });
+
+  it('login.tsx: 登录屏按舞台有效主题在 iOS 设置 statusBarStyle screen option', () => {
+    const source = read('app/(auth)/login.tsx');
+    // 首启亮色门可强制舞台为 light(系统可能是 dark):样式必须跟舞台而非系统
+    expect(source).toContain(
+      'resolveStartupSplashHandoff(firstLaunchGate, systemTheme).targetTheme',
+    );
+    expect(source).toContain("{Platform.OS === 'ios' ? (");
+    expect(source).toContain(
+      "statusBarStyle: stageTheme === 'dark' ? 'light' : 'dark',",
+    );
+  });
+});

--- a/apps/mobile/src/components/MobileLoginHandoffStage.tsx
+++ b/apps/mobile/src/components/MobileLoginHandoffStage.tsx
@@ -3,6 +3,7 @@ import {
   Animated,
   Easing,
   Image,
+  Platform,
   StyleSheet,
   useWindowDimensions,
   View,
@@ -271,8 +272,13 @@ function MobileLoginHandoffStageInner({
       style={[styles.root, { backgroundColor: colors.login.bgBase }]}
       testID={testID}
     >
-      {/* 白底体系:状态栏随主题模式(旧红底 splash 的恒 light 样式随之退役) */}
-      <StatusBar style={mode === 'dark' ? 'light' : 'dark'} />
+      {/* 白底体系:状态栏随主题模式。Android 继续走组件式 StatusBar(覆盖 Stack
+          未挂载的闸门屏);iOS 27 起 RN StatusBar 全局 API 失效,iOS 侧由 _layout /
+          login 的 statusBarStyle screen option 按舞台有效主题控制,导航器外
+          (端点闸门错误屏)由系统外观自动适配。 */}
+      {Platform.OS === 'android' ? (
+        <StatusBar style={mode === 'dark' ? 'light' : 'dark'} />
+      ) : null}
       {showBrand ? (
         // 键盘位移层(demo kb-shift 同构):品牌随面板整体上顶,根 View 纯平底不动
         <View

--- a/apps/mobile/src/session/ImageLightbox.tsx
+++ b/apps/mobile/src/session/ImageLightbox.tsx
@@ -11,12 +11,14 @@
  * 仅图片走本组件;video / audio / 文件仍走 MessagePayloadModal。
  * lightbox 是常黑沉浸语境,黑白系颜色为刻意豁免(对齐桌面 docs/design-rules/cindy-design-system.md overlay/lightbox 语义豁免),不走主题 token。
  */
+import { useNavigation } from 'expo-router';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
   FlatList,
   Modal,
+  Platform,
   Pressable,
   StatusBar,
   StyleSheet,
@@ -433,6 +435,19 @@ export const ImageLightbox = memo(function ImageLightbox({
     onClose();
   }, [annotationSubmitting, isAnnotating, exitAnnotationMode, onClose]);
 
+  // iOS 沉浸式隐藏状态栏:经宿主屏的 screen option 走 VC-based 通道(iOS 27 起
+  // RN StatusBar 全局 API 失效;transparent Modal 不接管状态栏,穿透到宿主屏)。
+  // Android 继续用 Modal 内组件式 <StatusBar hidden>,不走 RNS 双轨。
+  // 只触碰 statusBarHidden 一个键,泛型收窄到最小面。
+  const navigation = useNavigation<{
+    setOptions: (options: { statusBarHidden: boolean }) => void;
+  }>();
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return;
+    navigation.setOptions({ statusBarHidden: true });
+    return () => navigation.setOptions({ statusBarHidden: false });
+  }, [navigation]);
+
   return (
     <Modal
       animationType="fade"
@@ -442,7 +457,7 @@ export const ImageLightbox = memo(function ImageLightbox({
       transparent
       visible
     >
-      <StatusBar hidden />
+      {Platform.OS === 'android' ? <StatusBar hidden /> : null}
       <GestureHandlerRootView style={styles.root} testID="message.imageLightbox">
         <Animated.View pointerEvents="none" style={[styles.backdrop, backdropStyle]} />
         <FlatList


### PR DESCRIPTION
## 这次改了什么

### 摘要

iOS 27 上状态栏文字颜色不再随主题适配(浅色界面配白字,实机截图确认)。根因:RN `StatusBar` 在 iOS 上走的是 iOS 9 起废弃的全局 API `UIApplication.setStatusBarStyle`(`RCTStatusBarManager.mm`),该链路依赖 `UIViewControllerBasedStatusBarAppearance=NO`;iOS 27 起 UIKit 不再接受这条废弃链路,JS 侧设置的样式到不了原生层。

修复:把 iOS 状态栏控制整体迁到 VC-based 现代通道——

- `app.json` 翻转 `UIViewControllerBasedStatusBarAppearance=YES`;
- iOS 状态栏样式改由 react-native-screens 的 screen options 承载:根 Stack `statusBarStyle` 随主题(splash 覆盖期随舞台有效主题),登录屏按首启亮色门的舞台有效主题单独设置;
- 图片 lightbox 的沉浸式隐藏改经宿主屏 `statusBarHidden` screen option(transparent Modal 不接管状态栏外观,穿透到宿主屏,已核实 RN `RCTFabricModalHostViewController` 不设 `modalPresentationCapturesStatusBarAppearance`);
- **Android 零行为变化**:老链路正常,组件式 `StatusBar` 全部按 `Platform.OS === 'android'` 保留(含 Stack 未挂载的启动闸门期覆盖),iOS 的 RNS screen options 不在 Android 生效,不走双轨。

翻转后 RN `StatusBar` 的样式/隐藏调用在 iOS 会触发 `RCTLogError`,因此 iOS 侧不再挂载任何 RN `StatusBar` 组件(`StatusBar.currentHeight` 只读属性不受影响)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(实机反馈,iOS 27 状态栏白字)
- 本 PR 包含:iOS 状态栏样式/隐藏链路迁移 + Info.plist 键翻转
- 明确不包含:Android 状态栏行为改动;闸门错误屏(导航器外)的首启强亮主题下深色系统的状态栏样式微调(见「已知边角」)
- 用户可见变化:iOS 27 上状态栏文字颜色恢复随浅色/深色模式自动适配;iOS 26 及以下行为不变(换了实现通道,表现一致)
- 是否存在 breaking change:无

已知边角(如实说明):

1. 导航器外的场景(端点闸门错误屏、Stack 挂载前的启动闸门窗口)在 iOS 上回落系统外观自动适配。唯一不完美组合是「真首启(亮色门强制 light)+ 系统深色 + 停在闸门屏」,此时状态栏为白字压浅底;窗口短且仅首启一次,修复它需要原生层定制 root VC,超出本 PR 范围。
2. mermaid 图表「标注」嵌套路径:lightbox 位于 `presentationStyle="fullScreen"` 的 payload Modal 内,该 Modal 的 VC 接管状态栏且 RN 未提供设置入口,故此路径下状态栏不隐藏(仅装饰性;常规消息图 lightbox 不受影响)。根治需把 payload Modal 改为 overFullScreen+transparent(mermaid/video/audio/file 共用容器,跨平台语义),留作独立 follow-up。

### UI 变化

- 引用的设计规范:`docs/design-rules/DESIGN.md` 双模式交付门槛——本 PR 恢复的正是状态栏 Light/Dark 双模式适配,样式值全部由主题 mode/舞台有效主题推导,无硬编码单模式。视觉上无新增元素,仅状态栏文字颜色回归正确适配。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile typecheck   结果:通过
pnpm --filter mobile test        结果:268 files / 2686 tests 全部通过
pnpm test:unit(仓库根)          结果:除 apps/desktop 外全部 PASS;apps/desktop 首轮 vitest SIGSEGV(环境性段错误,发生在数百个用例通过之后),按门禁命令原样单独重跑 apps/desktop:1394 files / 16566 tests 全绿。本 PR 未触碰 desktop 代码。
指纹对比(apps/mobile/scripts/ci-fingerprint.mjs,同一 worktree 有/无本改动):
  ios     361607e6… → 98e770d2…(变化)
  android 0f634482… → 76c3c7f9…(变化,来源仅 contents:expoConfig)
```

### 手工验证

不涉及(见下)。

### 未执行的验证

- iOS 27 实机验证未执行(需出含新 Info.plist 的原生包,OTA 无法覆盖本改动)。用户可执行的验证步骤:装新包 → 浅色模式进入任意会话页,状态栏应为黑字;切深色应为白字;打开图片 lightbox 状态栏应隐藏、关闭恢复;首启(清 App 数据)深浅两种系统模式下过登录页各看一次。
- Android 实机回归未执行:代码路径按平台隔离,Android 侧 diff 为纯保留(组件相同、表达式相同),风险极低。
- iOS 26 及以下实机回归未执行:VC-based 通道是 iOS 13+ 标准机制,react-native-screens 全版本支持。

## 风险

### 风险分类

- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异

### 影响与回滚

- 影响范围:**本 PR 触发冷更(把关人请针对冷更确认)**。
  - 为什么冷更不可避免:修复必须改 Info.plist(`UIViewControllerBasedStatusBarAppearance`),这是原生构建输入;iOS 27 已把旧链路判死,不存在 JS-only 修法。
  - 存量装机影响:iOS 与 Android 的 runtime fingerprint 同时变化(`@expo/fingerprint` 将整份 resolved expoConfig 参与两端哈希,Android 也被单行 iOS 键带动)。合入后,存量装机将拿不到本次及后续 JS 热更,直到装上新原生包。
  - 发版节奏建议:合入时机与下一次整包发版对齐(或与其他待冷更改动攒同一个包),避免热更断档期拉长;iOS 27 正式发布前覆盖存量为宜。
- 回滚 / 降级方式:revert 本 PR 即可,fingerprint 回落原值,存量装机继续接收 OTA;无数据/协议影响。
- 远程连接 / 手机版适配说明:纯 mobile 改动,不涉及 desktop 与 device-link 协议;远程会话功能不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释写明通道约束;无需独立文档)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)

