### PR TITLE
fix(mobile): coalesce session sync triggers

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -75,7 +75,7 @@ import {
 } from '@/device-link/remoteStatus';
 import { agentAuthGateHint, agentAuthGateVerdict } from '@/session/agentAuthGate';
 import { isTransientRemoteError, withTransientRemoteRetry } from '@/device-link/remoteRetry';
-import { useRemoteSyncTask } from '@/device-link/remoteSyncTask';
+import { useRemoteSyncCoordinator, type RemoteSyncRun } from '@/device-link/remoteSyncTask';
 import { useMobileMakerTransport } from '@/device-link/useMobileMakerTransport';
 import { createMobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { startFocusedTopicSubscription } from '@/device-link/focusedTopicSubscription';
@@ -2790,8 +2790,9 @@ export default function SessionScreen() {
     };
   }, [connectionEpoch, deviceId, lastSyncedAt, maker, openLink, sessionAgentSwitchSupported, sessionId]);
 
-  const syncSession = useCallback(async (options: { replaceMessages?: boolean } = {}) => {
-    if (!deviceId || !sessionId) return;
+  const syncSession = useCallback(async (syncRun: Pick<RemoteSyncRun, 'isStale' | 'replaceMessages'>) => {
+    const options = { replaceMessages: syncRun.replaceMessages };
+    if (!deviceId || !sessionId || syncRun.isStale()) return;
     // 新建会话乐观管线在途(running / create-failed):被控端可能还没有这个会话,
     // getSession 会 NOT_FOUND 报错横幅。统一在这里挡掉全部 load 触发点;管线完成
     // (task 移除)后由下方 effect 触发一轮真正的同步。
@@ -2823,6 +2824,7 @@ export default function SessionScreen() {
       const activeSessions = await maker.listActiveSessions().catch(() => []);
       return { activeSessions, activityEpochAtFetchStart };
     };
+    if (syncRun.isStale()) return;
     setLoading(true);
     setError(null);
     try {
@@ -2838,6 +2840,7 @@ export default function SessionScreen() {
             fetchActiveSessionSnapshot(),
           ]);
         });
+        if (syncRun.isStale()) return;
         remoteSessionStore.upsertDeviceSession(deviceId, deviceName, sessionMeta);
         remoteSessionStore.setActiveSessionSnapshots(
           deviceId,
@@ -2877,6 +2880,7 @@ export default function SessionScreen() {
           messageWindowSynced: remoteSessionStore.isSessionMessageWindowSynced(sessionId, sessionMeta),
           storedSession: storedSessionAtStart,
         });
+        if (syncRun.isStale()) return;
         remoteSessionStore.upsertDeviceSession(deviceId, deviceName, sessionMeta);
         remoteSessionStore.setActiveSessionSnapshots(
           deviceId,
@@ -2892,6 +2896,7 @@ export default function SessionScreen() {
               REOPEN_MESSAGE_WINDOW_LIMITS,
             ),
           );
+          if (syncRun.isStale()) return;
           const historyPage: RemoteMessage[] = Array.isArray(history.messages) ? history.messages : [];
           remoteSessionStore.setLatestMessageWindow(sessionId, historyPage);
           remoteSessionStore.markSessionMessagesSynced(sessionId, sessionMeta);
@@ -2908,6 +2913,7 @@ export default function SessionScreen() {
       // 不变量:上面 setHasOlderMessages 的校正(:806/:841/:846)与这里的 setLastSyncedAt 之间必须保持
       // 同步尾、无 await —— 否则乐观点亮 effect(依赖 lastSyncedAt===null)会在 await 间隙把刚校正成 false
       // 的「加载更早」入口重新点亮。将来切勿在两者之间插入 await。
+      if (syncRun.isStale()) return;
       setLastSyncedAt(Date.now());
       // 已读回执门槛:本会话在当前连接代完成过整窗同步。sessionId / epoch / 门槛代号
       // 都取 sync 开始时的快照——原地切 session、重连、attention 上升沿之后,启动更早
@@ -2916,12 +2922,19 @@ export default function SessionScreen() {
         setReadAckSyncedKey(`${sessionId}:${readAckEpochAtStart}`);
       }
     } catch (err) {
-      setError(formatRemoteError(err));
+      if (!syncRun.isStale()) setError(formatRemoteError(err));
     } finally {
-      setLoading(false);
+      if (!syncRun.isStale()) setLoading(false);
     }
   }, [deviceId, deviceName, maker, openLink, sessionId, subscribe]);
-  const load = useRemoteSyncTask(() => syncSession());
+  const requestSync = useRemoteSyncCoordinator(
+    (run) => syncSession(run),
+    `${deviceId}:${sessionId}`,
+  );
+  const load = useCallback(
+    () => requestSync({ reason: 'passive-refresh' }),
+    [requestSync],
+  );
 
   /** 恢复路径里装不下的附件:中转对象回收,不留无人认领的已上传对象。 */
   const discardRecoveredAttachments = (attachments: readonly RemoteSerializedAttachment[]) => {
@@ -7129,7 +7142,7 @@ export default function SessionScreen() {
       ));
       clearQuotes(sessionId);
       setRewindState({ kind: 'idle' });
-      await syncSession({ replaceMessages: true });
+      await requestSync({ reason: 'rewind-commit', replaceMessages: true });
     } catch (err) {
       if (rewindRequestSeqRef.current !== seq) return;
       setError(formatRemoteError(err));
@@ -7145,7 +7158,7 @@ export default function SessionScreen() {
     } finally {
       if (rewindRequestSeqRef.current === seq) setMessageActionBusy(null);
     }
-  }, [applyComposerDocument, deviceId, maker, messageActionBusy, rewindState, sessionId, syncSession]);
+  }, [applyComposerDocument, deviceId, maker, messageActionBusy, requestSync, rewindState, sessionId]);
 
   return (
     <View style={styles.safeArea} testID="session.screen">
@@ -7200,7 +7213,7 @@ export default function SessionScreen() {
                 issue={connectionIssue}
                 lastSyncedAt={lastSyncedAt}
                 loading={loading}
-                onSync={() => void load()}
+                onSync={() => void requestSync({ reason: 'manual', replaceMessages: false })}
                 status={status}
                 variant="inline"
               />
@@ -7461,7 +7474,7 @@ export default function SessionScreen() {
             // 设备真不可用(离线/被撤销):消息区保留阻塞占位和重试入口;底部 composer 仍可编辑草稿。
             <SessionSyncPlaceholder
               loading={loading}
-              onSync={() => void load()}
+              onSync={() => void requestSync({ reason: 'manual', replaceMessages: false })}
             />
           ) : (
             <>

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1054,7 +1054,7 @@ export default function SessionScreen() {
   const [controlBusy, setControlBusy] = useState(false);
   const [messageActionBusy, setMessageActionBusy] = useState<string | null>(null);
   const [rewindState, setRewindState] = useState<RewindPreviewState>({ kind: 'idle' });
-  // 切 session 时同步(render 阶段)重置回撤确认框 / busy 态并递增「请求代际」。SessionScreen 切
+  // 切 session 时同步(render 阶段)重置回撤确认框 / busy / loading 态并递增「请求代际」。SessionScreen 切
   // session 复用实例、不 remount,这些本地 UI state 不会自动重置,残留会让确认框跨 session 出现且
   // 无法自愈(messageActionBusy 残留还会置灰目标 session 的消息操作栏)。用 React 官方「prop 变化时
   // 调整 state」的 render 阶段模式而非 useEffect:同步生效,既无切换首帧的残留闪帧,也不留「路由已切、
@@ -1065,6 +1065,7 @@ export default function SessionScreen() {
     setPrevRewindSessionId(sessionId);
     setRewindState({ kind: 'idle' });
     setMessageActionBusy(null);
+    setLoading(false);
     rewindRequestSeqRef.current += 1;
   }
   const [contextLoading, setContextLoading] = useState(false);
@@ -2796,7 +2797,10 @@ export default function SessionScreen() {
     // 新建会话乐观管线在途(running / create-failed):被控端可能还没有这个会话,
     // getSession 会 NOT_FOUND 报错横幅。统一在这里挡掉全部 load 触发点;管线完成
     // (task 移除)后由下方 effect 触发一轮真正的同步。
-    if (shouldBlockSessionSync(sessionId)) return;
+    if (shouldBlockSessionSync(sessionId)) {
+      if (!syncRun.isStale()) setLoading(false);
+      return;
+    }
     // 已读回执门槛的 epoch 必须在 sync **开始**时捕获:重连时 connectionEpoch 先行推进,
     // 旧连接代的 in-flight load 若在尾部读 ref 的最新值,会把旧窗口数据标成新代已同步,
     // 抢在排队的 resync 之前放行回执。开始时捕获则旧 load 落的是旧代 key,门槛不放行。

--- a/apps/mobile/src/__tests__/remoteSyncTask.test.ts
+++ b/apps/mobile/src/__tests__/remoteSyncTask.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createRemoteSyncCoordinator, createRemoteSyncRunner } from '@/device-link/remoteSyncTask';
 
@@ -11,6 +13,10 @@ function deferred() {
 
 function nextTick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function readSessionScreenSource(): string {
+  return readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8').replace(/\r\n/g, '\n');
 }
 
 describe('remote sync task runner', () => {
@@ -157,5 +163,30 @@ describe('remote sync coordinator', () => {
 
     await expect(task).rejects.toThrow('first failed');
     expect(runs).toEqual([['first'], ['follow-up']]);
+  });
+
+  it('clears loading when a queued sync is blocked for a newly-created session', () => {
+    const source = readSessionScreenSource();
+    expect(source).toContain(
+      'if (shouldBlockSessionSync(sessionId)) {\n      if (!syncRun.isStale()) setLoading(false);\n      return;\n    }',
+    );
+  });
+
+  it('resets loading when the reused screen switches sessions', () => {
+    const source = readSessionScreenSource();
+    expect(source).toContain(
+      'setRewindState({ kind: \'idle\' });\n    setMessageActionBusy(null);\n    setLoading(false);',
+    );
+  });
+
+  it('applies coordinator context changes after render commits', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/device-link/remoteSyncTask.ts'),
+      'utf8',
+    ).replace(/\r\n/g, '\n');
+    expect(source).toContain(
+      'useLayoutEffect(() => {\n    coordinatorRef.current?.setContext(contextKey);\n  }, [contextKey]);',
+    );
+    expect(source).not.toContain('coordinatorRef.current.setContext(contextKey);');
   });
 });

--- a/apps/mobile/src/__tests__/remoteSyncTask.test.ts
+++ b/apps/mobile/src/__tests__/remoteSyncTask.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createRemoteSyncRunner } from '@/device-link/remoteSyncTask';
+import { createRemoteSyncCoordinator, createRemoteSyncRunner } from '@/device-link/remoteSyncTask';
 
 function deferred() {
   let resolve!: () => void;
@@ -53,5 +53,109 @@ describe('remote sync task runner', () => {
     await runner.run();
 
     expect(count).toBe(2);
+  });
+});
+
+describe('remote sync coordinator', () => {
+  it('merges repeated passive requests into one follow-up run', async () => {
+    const gates = [deferred(), deferred()];
+    const runs: Array<{ reasons: readonly string[]; replaceMessages: boolean }> = [];
+    const coordinator = createRemoteSyncCoordinator(async (run) => {
+      const index = runs.length;
+      runs.push({ reasons: run.reasons, replaceMessages: run.replaceMessages });
+      await gates[index].promise;
+    });
+    coordinator.setContext('dev-1:session-1');
+
+    const first = coordinator.request({ reason: 'mount' });
+    const second = coordinator.request({ reason: 'presence' });
+    const third = coordinator.request({ reason: 'breaker' });
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(runs).toEqual([{ reasons: ['mount'], replaceMessages: false }]);
+
+    gates[0].resolve();
+    await nextTick();
+    expect(runs).toEqual([
+      { reasons: ['mount'], replaceMessages: false },
+      { reasons: ['presence', 'breaker'], replaceMessages: false },
+    ]);
+
+    gates[1].resolve();
+    await first;
+    expect(coordinator.isRunning()).toBe(false);
+  });
+
+  it('lets an authoritative replacement invalidate an in-flight passive run', async () => {
+    const gates = [deferred(), deferred()];
+    const staleChecks: Array<() => boolean> = [];
+    const replaceModes: boolean[] = [];
+    const coordinator = createRemoteSyncCoordinator(async (run) => {
+      const index = replaceModes.length;
+      replaceModes.push(run.replaceMessages);
+      staleChecks.push(run.isStale);
+      await gates[index].promise;
+    });
+    coordinator.setContext('dev-1:session-1');
+
+    const task = coordinator.request({ reason: 'mount' });
+    expect(staleChecks[0]()).toBe(false);
+    void coordinator.request({ reason: 'rewind', replaceMessages: true });
+    expect(staleChecks[0]()).toBe(true);
+
+    gates[0].resolve();
+    await nextTick();
+    expect(replaceModes).toEqual([false, true]);
+    expect(staleChecks[1]()).toBe(false);
+
+    gates[1].resolve();
+    await task;
+  });
+
+  it('invalidates old identity runs and drops their queued follow-up', async () => {
+    const gates = [deferred(), deferred()];
+    const runs: Array<{ reasons: readonly string[]; isStale: () => boolean }> = [];
+    const coordinator = createRemoteSyncCoordinator(async (run) => {
+      const index = runs.length;
+      runs.push({ reasons: run.reasons, isStale: run.isStale });
+      await gates[index].promise;
+    });
+    coordinator.setContext('dev-1:session-a');
+
+    const task = coordinator.request({ reason: 'mount-a' });
+    void coordinator.request({ reason: 'retry-a' });
+    coordinator.setContext('dev-1:session-b');
+    void coordinator.request({ reason: 'mount-b' });
+
+    expect(runs[0].isStale()).toBe(true);
+    gates[0].resolve();
+    await nextTick();
+    expect(runs.map((run) => run.reasons)).toEqual([['mount-a'], ['mount-b']]);
+    expect(runs[1].isStale()).toBe(false);
+
+    gates[1].resolve();
+    await task;
+  });
+
+  it('continues with a queued follow-up after a failed run', async () => {
+    const runs: string[][] = [];
+    const firstStarted = deferred();
+    const coordinator = createRemoteSyncCoordinator(async (run) => {
+      runs.push([...run.reasons]);
+      if (runs.length === 1) {
+        firstStarted.resolve();
+        await nextTick();
+        throw new Error('first failed');
+      }
+    });
+    coordinator.setContext('dev-1:session-1');
+
+    const task = coordinator.request({ reason: 'first' });
+    await firstStarted.promise;
+    void coordinator.request({ reason: 'follow-up' });
+
+    await expect(task).rejects.toThrow('first failed');
+    expect(runs).toEqual([['first'], ['follow-up']]);
   });
 });

--- a/apps/mobile/src/__tests__/remoteSyncTask.test.ts
+++ b/apps/mobile/src/__tests__/remoteSyncTask.test.ts
@@ -179,13 +179,16 @@ describe('remote sync coordinator', () => {
     );
   });
 
-  it('applies coordinator context changes after render commits', () => {
+  it('applies coordinator context and task changes after render commits', () => {
     const source = readFileSync(
       resolve(process.cwd(), 'src/device-link/remoteSyncTask.ts'),
       'utf8',
     ).replace(/\r\n/g, '\n');
     expect(source).toContain(
-      'useLayoutEffect(() => {\n    coordinatorRef.current?.setContext(contextKey);\n  }, [contextKey]);',
+      'useLayoutEffect(() => {\n    taskRef.current = task;\n    coordinatorRef.current?.setContext(contextKey);\n  }, [contextKey, task]);',
+    );
+    expect(source).not.toContain(
+      '  taskRef.current = task;\n  const coordinatorRef =',
     );
     expect(source).not.toContain('coordinatorRef.current.setContext(contextKey);');
   });

--- a/apps/mobile/src/device-link/remoteSyncTask.ts
+++ b/apps/mobile/src/device-link/remoteSyncTask.ts
@@ -151,12 +151,12 @@ export function useRemoteSyncCoordinator(
   contextKey: string,
 ): (request: RemoteSyncRequest) => Promise<void> {
   const taskRef = useRef(task);
-  taskRef.current = task;
   const coordinatorRef = useRef<RemoteSyncCoordinator | null>(null);
   coordinatorRef.current ??= createRemoteSyncCoordinator((run) => taskRef.current(run));
   useLayoutEffect(() => {
+    taskRef.current = task;
     coordinatorRef.current?.setContext(contextKey);
-  }, [contextKey]);
+  }, [contextKey, task]);
 
   return useCallback(
     (request: RemoteSyncRequest) => coordinatorRef.current?.request(request) ?? Promise.resolve(),

--- a/apps/mobile/src/device-link/remoteSyncTask.ts
+++ b/apps/mobile/src/device-link/remoteSyncTask.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
 export interface RemoteSyncRunner {
   run(): Promise<void>;
@@ -154,7 +154,9 @@ export function useRemoteSyncCoordinator(
   taskRef.current = task;
   const coordinatorRef = useRef<RemoteSyncCoordinator | null>(null);
   coordinatorRef.current ??= createRemoteSyncCoordinator((run) => taskRef.current(run));
-  coordinatorRef.current.setContext(contextKey);
+  useLayoutEffect(() => {
+    coordinatorRef.current?.setContext(contextKey);
+  }, [contextKey]);
 
   return useCallback(
     (request: RemoteSyncRequest) => coordinatorRef.current?.request(request) ?? Promise.resolve(),

--- a/apps/mobile/src/device-link/remoteSyncTask.ts
+++ b/apps/mobile/src/device-link/remoteSyncTask.ts
@@ -52,3 +52,112 @@ export function useRemoteSyncTask(task: () => Promise<void>): () => Promise<void
 
   return useCallback(() => runnerRef.current?.run() ?? Promise.resolve(), []);
 }
+
+export interface RemoteSyncRequest {
+  reason: string;
+  /** 权威整窗替换(如 rewind commit):使当前在途普通读取失效,并在后续轮次胜出。 */
+  replaceMessages?: boolean;
+}
+
+export interface RemoteSyncRun {
+  reasons: readonly string[];
+  replaceMessages: boolean;
+  /** 请求发起后 sync identity / 权威替换发生变化时,旧结果不得再提交。 */
+  isStale(): boolean;
+}
+
+export interface RemoteSyncCoordinator {
+  setContext(contextKey: string): void;
+  request(request: RemoteSyncRequest): Promise<void>;
+  isRunning(): boolean;
+}
+
+interface PendingRemoteSync {
+  reasons: Set<string>;
+  replaceMessages: boolean;
+}
+
+function mergeRemoteSyncRequest(
+  current: PendingRemoteSync | null,
+  request: RemoteSyncRequest,
+): PendingRemoteSync {
+  const next = current ?? { reasons: new Set<string>(), replaceMessages: false };
+  next.reasons.add(request.reason);
+  next.replaceMessages = next.replaceMessages || request.replaceMessages === true;
+  return next;
+}
+
+/**
+ * Session sync coordinator:同一时刻最多一轮网络读取,被动触发合并成至多一轮 follow-up。
+ * context 变化会使旧轮次失效;权威整窗替换还会立即废弃同 context 的旧普通读取,
+ * 防止 rewind 后迟到的 reopen 结果把已删除消息重新写回。
+ */
+export function createRemoteSyncCoordinator(
+  task: (run: RemoteSyncRun) => Promise<void>,
+): RemoteSyncCoordinator {
+  let contextKey: string | null = null;
+  let generation = 0;
+  let inFlight: Promise<void> | null = null;
+  let pending: PendingRemoteSync | null = null;
+
+  const drain = async (): Promise<void> => {
+    let firstError: unknown = null;
+    while (pending) {
+      const next = pending;
+      pending = null;
+      const capturedGeneration = generation;
+      try {
+        await task({
+          reasons: [...next.reasons],
+          replaceMessages: next.replaceMessages,
+          isStale: () => generation !== capturedGeneration,
+        });
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+    if (firstError !== null) throw firstError;
+  };
+
+  return {
+    setContext(nextContextKey: string): void {
+      if (contextKey === nextContextKey) return;
+      contextKey = nextContextKey;
+      generation += 1;
+      // 旧 identity 尚未执行的 follow-up 没有提交资格;新 identity 的调用方会立即 request。
+      pending = null;
+    },
+    request(request: RemoteSyncRequest): Promise<void> {
+      if (request.replaceMessages === true) {
+        // 权威替换必须让已经发出的普通窗口读取失效,并独占下一轮 pending options。
+        generation += 1;
+        pending = null;
+      }
+      pending = mergeRemoteSyncRequest(pending, request);
+      if (inFlight) return inFlight;
+      inFlight = drain().finally(() => {
+        inFlight = null;
+      });
+      return inFlight;
+    },
+    isRunning(): boolean {
+      return inFlight !== null;
+    },
+  };
+}
+
+export function useRemoteSyncCoordinator(
+  task: (run: RemoteSyncRun) => Promise<void>,
+  contextKey: string,
+): (request: RemoteSyncRequest) => Promise<void> {
+  const taskRef = useRef(task);
+  taskRef.current = task;
+  const coordinatorRef = useRef<RemoteSyncCoordinator | null>(null);
+  coordinatorRef.current ??= createRemoteSyncCoordinator((run) => taskRef.current(run));
+  coordinatorRef.current.setContext(contextKey);
+
+  return useCallback(
+    (request: RemoteSyncRequest) => coordinatorRef.current?.request(request) ?? Promise.resolve(),
+    [],
+  );
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

Mobile 会话页原先把连接恢复、presence 恢复、熔断恢复、pending refresh、手动刷新和 rewind 后刷新等触发源分别直接指向 `load()`，而 rewind 的权威整窗替换甚至绕过现有单飞 runner。多个信号相邻到达时可能产生重复 follow-up，或让普通 reopen 读取与 rewind 替换并发。

本 PR 增加带 generation 与请求语义的会话同步协调器：

- 同一时刻最多执行一轮会话同步；
- 多个被动触发合并为至多一轮 follow-up；
- identity 变化使旧轮次失去提交资格；
- rewind 的整窗替换使同 identity 的旧普通读取失效，并通过同一协调器排在下一轮执行；
- stale 轮次不再写会话页通用 loading、error、lastSyncedAt 或消息镜像；
- 手动同步同样进入协调器，不再另开并发读取。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Mobile 会话多个同步触发源的进一步合并
- 本 PR 包含：Mobile 会话同步协调器、rewind/手动同步统一入口、generation stale guard、单元测试
- 明确不包含：PR #1111；增量消息游标；离线 push 队列；`openLink` 长期复用；Desktop 转录扫描优化
- 用户可见变化：弱网、重连及多恢复信号同时到达时减少重复同步和状态跳动
- 是否存在 breaking change：无

### UI 变化

不涉及：只修改同步调度与状态提交时序，无视觉、交互或文案变化。

- 引用的设计规范：不涉及：无 UI 变更。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/remoteSyncTask.test.ts
结果：1 file / 6 tests passed

pnpm --filter mobile typecheck
结果：通过

pnpm --filter mobile test:scope
结果：通过

pnpm --filter mobile test:smoke
结果：2/2 passed

pnpm test:unit -- --workspace-concurrency=1
结果：Mobile 及其它 workspace 通过；Desktop 默认 8-worker Vitest 在本机 SIGSEGV

TZ=UTC pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=1 ...unit exclusions...
结果：1380 files / 16403 tests passed（2 skipped）

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

不涉及；本 PR 无 UI 变化，行为由协调器单元测试、Mobile smoke 与完整 workspace 单测覆盖。

### 未执行的验证

未启动 Mobile 模拟器；当前会话未绑定运行中的 Metro。无 UI/原生改动，未伪称实机验证。

## 风险

### 风险分类

- [x] 其他：Mobile 会话同步并发与 generation 时序

### 影响与回滚

- 影响范围：仅 `apps/mobile` 会话页的远程同步调度；不修改协议、Desktop、服务端、原生 fingerprint 或持久化 schema。
- 回滚 / 降级方式：回滚提交 `08bacb5b` 即恢复原来的无参数 `useRemoteSyncTask` 路径。

### Remote / Mobile adaptation

- SSH 远程工作区：不涉及；未新增 workdir 文件访问或远程执行入口。
- Device Link / IPC：沿用现有 invoke/subscribe 通道与 payload，没有新增或修改 wire protocol、allowlist 或 push topic。
- Mobile：本 PR 即 Mobile 适配，统一其会话恢复触发与 stale 写入边界。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)