### PR TITLE
test: 修复 Windows 下两处跨平台单测误报

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/mirrorCachePurgeQueue.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCachePurgeQueue.test.ts
@@ -841,10 +841,27 @@ describe('落盘失败', () => {
   // review(codex P1):唯一的持久重试记录写不下去却报成功 = 静默丢失。
   it('队列文件写不下去时 enqueuePurge 抛错,但条目留在内存里仍会被 drain 重试', async () => {
     const root = await makeOwnerCache('owner-1');
-    // 把队列文件位置占成目录:writeFile 必然 EISDIR。
-    await fsp.mkdir(queueFile(), { recursive: true });
-
-    await expect(enqueuePurge(root)).rejects.toThrow();
+    // 不用 chmod 或把目标占成目录来模拟不可写:Windows 会忽略前者,而原子落位退路会把
+    // 后者改名成 .bak 后继续成功。精确让本次队列临时文件写入失败,跨平台语义一致。
+    const originalWriteFile = fsp.writeFile;
+    const spy = vi.spyOn(fsp, 'writeFile').mockImplementation((async (
+      target: unknown,
+      ...rest: unknown[]
+    ) => {
+      if (
+        typeof target === 'string' &&
+        target.startsWith(`${queueFile()}.`) &&
+        target.endsWith('.tmp')
+      ) {
+        throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      }
+      return (originalWriteFile as (...args: unknown[]) => Promise<void>)(target, ...rest);
+    }) as unknown as typeof fsp.writeFile);
+    try {
+      await expect(enqueuePurge(root)).rejects.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
     expect(__testing.memoryQueueSize()).toBe(1);
 
     const result = await drainPurgeQueue();

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -75,7 +75,9 @@ describe('mobile session main layer desktop-first noise budget', () => {
   });
 
   it('lets Lead sessions compose messages while gating write-orchestration on the write read-only reason', () => {
-    const source = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8');
+    // Windows checkout 使用 CRLF；源码契约中的多行 LF 片段必须先统一行尾再比较。
+    const source = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8')
+      .replace(/\r\n/g, '\n');
 
     // composer 能力(buildSessionOperationLayout)与 header 徽标走 composer-only reason(Lead=可发消息)。
     expect(source).toContain('const composerReadOnlyReason = useMemo(');


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复两个只在 Windows checkout / 文件系统语义下触发的既有单测误报：

- Desktop 的 mirror cache purge queue 测试不再用“目标路径占成目录”模拟落盘失败，改为精确注入队列临时文件写入失败，避免 Windows 原子落位退路把目录改名后继续成功。
- Mobile 的跨端源码契约测试在比较包含换行的多行片段前统一将 CRLF 归一化为 LF。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Desktop 落盘失败测试夹具、Mobile 源码契约测试行尾归一化
- 明确不包含：生产逻辑、UI、协议、数据库或原生配置变更
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/device-link/__tests__/mirrorCachePurgeQueue.test.ts --reporter=basic
结果：42 passed，3 skipped

pnpm --filter mobile exec vitest run src/__tests__/sessionMainLayerDesktopFirst.test.ts --reporter=basic
结果：10 passed

pnpm --filter desktop typecheck
结果：通过

pnpm --filter mobile typecheck
结果：通过

pnpm test:unit
结果：全部可运行 workspace 通过，包含 apps/desktop、apps/mobile 与 packages/lizi-mcps

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅测试代码；修复 Windows 与 LF checkout 之间的测试行为差异。
- 回滚 / 降级方式：回滚本提交即可恢复原测试夹具与断言。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因