### PR TITLE
fix(mobile): 热更 reload 被拒时改为引导重开 App,并暴露应急启动原因

### DIFF
--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -277,6 +277,7 @@ export default function SettingsScreen() {
         checkOtaUpdate: () => Updates.checkForUpdateAsync(),
         fetchOtaUpdate: () => Updates.fetchUpdateAsync(),
         reload: () => Updates.reloadAsync(),
+        isEmergencyLaunch: () => currentlyRunning.isEmergencyLaunch,
         onPhase: (phase) => setUpdatePhase(phase),
       });
       setUpdateOutcome(outcome);
@@ -299,7 +300,14 @@ export default function SettingsScreen() {
     } finally {
       updateCheckInFlightRef.current = false;
     }
-  }, [bundleCheckEnabled, checkBundleUpdate, t, updateCheckEnabled, updatesEnabled]);
+  }, [
+    bundleCheckEnabled,
+    checkBundleUpdate,
+    currentlyRunning.isEmergencyLaunch,
+    t,
+    updateCheckEnabled,
+    updatesEnabled,
+  ]);
 
   const updateSelfDeviceNameDraft = useCallback((value: string) => {
     selfDeviceNameDraftRef.current = value;

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -288,6 +288,9 @@ export default function SettingsScreen() {
         setUpdatePhase('uptodate');
       } else if (outcome.kind === 'reloading') {
         setUpdatePhase('downloading');
+      } else if (outcome.kind === 'restart-required') {
+        // 更新已经拿到了,只是本进程重启不了 —— 不是失败态,提示文案负责说明要手动重开。
+        setUpdatePhase('uptodate');
       } else if (outcome.kind === 'busy') {
         setUpdatePhase('idle');
       } else {

--- a/apps/mobile/src/__tests__/updateInfo.test.ts
+++ b/apps/mobile/src/__tests__/updateInfo.test.ts
@@ -48,6 +48,12 @@ describe('buildMobileUpdateInfoRows', () => {
       isEmergencyLaunch: true,
       emergencyLaunchReason: 'No launchable update was found.',
     });
+    // 运行来源不能报「OTA 热更新」:应急启动跑的是内置 bundle,否则同一区块自相矛盾。
+    expect(rows[0]).toEqual({
+      id: 'source',
+      label: '运行来源',
+      value: '内置版本(应急启动，热更未生效)',
+    });
     expect(rows.at(-1)).toEqual({
       id: 'emergencyLaunch',
       label: '应急启动',

--- a/apps/mobile/src/__tests__/updateInfo.test.ts
+++ b/apps/mobile/src/__tests__/updateInfo.test.ts
@@ -36,6 +36,49 @@ describe('buildMobileUpdateInfoRows', () => {
     });
     expect(rows.map((r) => r.value)).toEqual(['内置版本(随包)', '—', '—', '—', '1.0.0', OTA_VERIFY_MARKER]);
   });
+
+  // 应急启动是"点检查更新报 reload 被拒"的唯一现场证据,必须能在设置页直接看到原因。
+  it('appends the emergency launch reason when expo-updates fell back to the embedded bundle', () => {
+    const rows = buildMobileUpdateInfoRows({
+      isEmbeddedLaunch: false,
+      updateId: undefined,
+      channel: undefined,
+      createdAt: undefined,
+      runtimeVersion: '1.0.0',
+      isEmergencyLaunch: true,
+      emergencyLaunchReason: 'No launchable update was found.',
+    });
+    expect(rows.at(-1)).toEqual({
+      id: 'emergencyLaunch',
+      label: '应急启动',
+      value: 'No launchable update was found.',
+    });
+  });
+
+  it('falls back to a plain yes when the native layer gives no emergency launch reason', () => {
+    const rows = buildMobileUpdateInfoRows({
+      isEmbeddedLaunch: false,
+      updateId: undefined,
+      channel: undefined,
+      createdAt: undefined,
+      runtimeVersion: '1.0.0',
+      isEmergencyLaunch: true,
+      emergencyLaunchReason: null,
+    });
+    expect(rows.at(-1)?.value).toBe('是（本次运行内热更无法生效）');
+  });
+
+  it('omits the emergency launch row on a normal launch', () => {
+    const rows = buildMobileUpdateInfoRows({
+      isEmbeddedLaunch: true,
+      updateId: 'embedded-id',
+      channel: 'production',
+      createdAt: undefined,
+      runtimeVersion: '1.0.0',
+      isEmergencyLaunch: false,
+    });
+    expect(rows.map((r) => r.id)).not.toContain('emergencyLaunch');
+  });
 });
 
 describe('currentMobileOtaVersion', () => {
@@ -49,5 +92,15 @@ describe('currentMobileOtaVersion', () => {
   it('distinguishes the bundle embedded in the full app package', () => {
     expect(currentMobileOtaVersion({ isEmbeddedLaunch: true, updateId: 'embedded-id' })).toBe('随整包');
     expect(currentMobileOtaVersion({ isEmbeddedLaunch: false, updateId: undefined })).toBe('未知');
+  });
+
+  // 应急启动下 updateId 空、isEmbeddedLaunch 也是 false,但跑的确定是内置 bundle:
+  // 显示"未知"会被误读成读不到版本号,这里必须说清是内置 bundle 且热更没生效。
+  it('names the embedded fallback instead of unknown on an emergency launch', () => {
+    expect(currentMobileOtaVersion({
+      isEmbeddedLaunch: false,
+      updateId: undefined,
+      isEmergencyLaunch: true,
+    })).toBe('随整包（热更未生效）');
   });
 });

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -81,6 +81,7 @@
     "unknown": "Unknown",
     "source": "Running Source",
     "sourceEmbedded": "Embedded (with app package)",
+    "sourceEmergencyFallback": "Embedded (emergency launch; OTA not applied)",
     "sourceOta": "OTA update",
     "updateId": "Update ID",
     "updatedAt": "Updated At",

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -31,6 +31,7 @@
     "upToDate": "Already up to date",
     "bundleUpToDateNoOta": "App package is up to date; this version does not support OTA updates",
     "downloadedRestarting": "Update downloaded, restarting",
+    "downloadedRestartRequired": "Update downloaded. Fully quit the app and reopen it to apply.",
     "bundleCheckFailed": "Could not check for app package updates. Try again later.",
     "checkFailedDetail": "Update check failed: {{detail}}",
     "checkFailed": "Update check failed. Try again later."
@@ -76,6 +77,7 @@
   },
   "updateInfo": {
     "embedded": "With app package",
+    "embeddedFallback": "With app package (OTA not applied)",
     "unknown": "Unknown",
     "source": "Running Source",
     "sourceEmbedded": "Embedded (with app package)",
@@ -84,7 +86,9 @@
     "updatedAt": "Updated At",
     "channel": "Channel",
     "runtime": "Runtime",
-    "otaMarker": "OTA Marker"
+    "otaMarker": "OTA Marker",
+    "emergencyLaunch": "Emergency Launch",
+    "emergencyLaunchYes": "Yes (OTA cannot apply in this run)"
   },
   "legal": {
     "sectionTitle": "Legal",

--- a/apps/mobile/src/i18n/locales/ja/settings.json
+++ b/apps/mobile/src/i18n/locales/ja/settings.json
@@ -31,6 +31,7 @@
     "upToDate": "すでに最新の状態です",
     "bundleUpToDateNoOta": "アプリ本体は最新です。このバージョンは OTA 更新に対応していません",
     "downloadedRestarting": "更新をダウンロードしました。再起動しています",
+    "downloadedRestartRequired": "更新をダウンロードしました。アプリを完全に終了して再度開くと適用されます。",
     "bundleCheckFailed": "アプリ本体の更新を確認できませんでした。しばらくしてからもう一度お試しください。",
     "checkFailedDetail": "更新の確認に失敗しました：{{detail}}",
     "checkFailed": "更新の確認に失敗しました。しばらくしてからもう一度お試しください。"
@@ -76,6 +77,7 @@
   },
   "updateInfo": {
     "embedded": "アプリ本体と同梱",
+    "embeddedFallback": "アプリ本体と同梱（OTA 未適用）",
     "unknown": "不明",
     "source": "実行ソース",
     "sourceEmbedded": "内蔵バージョン (同梱)",
@@ -84,7 +86,9 @@
     "updatedAt": "更新日時",
     "channel": "Channel",
     "runtime": "Runtime",
-    "otaMarker": "OTA マーカー"
+    "otaMarker": "OTA マーカー",
+    "emergencyLaunch": "緊急起動",
+    "emergencyLaunchYes": "はい（この起動では OTA を適用できません）"
   },
   "legal": {
     "sectionTitle": "法的情報",

--- a/apps/mobile/src/i18n/locales/ja/settings.json
+++ b/apps/mobile/src/i18n/locales/ja/settings.json
@@ -81,6 +81,7 @@
     "unknown": "不明",
     "source": "実行ソース",
     "sourceEmbedded": "内蔵バージョン (同梱)",
+    "sourceEmergencyFallback": "内蔵バージョン (緊急起動・OTA 未適用)",
     "sourceOta": "OTA 更新",
     "updateId": "更新 ID",
     "updatedAt": "更新日時",

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -31,6 +31,7 @@
     "upToDate": "이미 최신 버전입니다",
     "bundleUpToDateNoOta": "앱 패키지는 최신입니다. 현재 버전은 OTA 업데이트를 지원하지 않습니다",
     "downloadedRestarting": "업데이트를 다운로드했습니다. 다시 시작하는 중",
+    "downloadedRestartRequired": "업데이트를 다운로드했습니다. 앱을 완전히 종료한 뒤 다시 열면 적용됩니다.",
     "bundleCheckFailed": "앱 패키지 업데이트를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.",
     "checkFailedDetail": "업데이트 확인에 실패했습니다: {{detail}}",
     "checkFailed": "업데이트 확인에 실패했습니다. 잠시 후 다시 시도해 주세요."
@@ -76,6 +77,7 @@
   },
   "updateInfo": {
     "embedded": "앱 패키지 포함",
+    "embeddedFallback": "앱 패키지 포함 (OTA 미적용)",
     "unknown": "알 수 없음",
     "source": "실행 소스",
     "sourceEmbedded": "내장 버전 (패키지 포함)",
@@ -84,7 +86,9 @@
     "updatedAt": "업데이트 시간",
     "channel": "Channel",
     "runtime": "Runtime",
-    "otaMarker": "OTA 마커"
+    "otaMarker": "OTA 마커",
+    "emergencyLaunch": "긴급 실행",
+    "emergencyLaunchYes": "예 (이번 실행에서는 OTA를 적용할 수 없음)"
   },
   "legal": {
     "sectionTitle": "법적 정보",

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -81,6 +81,7 @@
     "unknown": "알 수 없음",
     "source": "실행 소스",
     "sourceEmbedded": "내장 버전 (패키지 포함)",
+    "sourceEmergencyFallback": "내장 버전 (긴급 실행, OTA 미적용)",
     "sourceOta": "OTA 업데이트",
     "updateId": "업데이트 ID",
     "updatedAt": "업데이트 시간",

--- a/apps/mobile/src/i18n/locales/zh-CN/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/settings.json
@@ -31,6 +31,7 @@
     "upToDate": "已是最新版本",
     "bundleUpToDateNoOta": "整包已是最新，当前版本不支持热更新",
     "downloadedRestarting": "更新已下载，正在重启",
+    "downloadedRestartRequired": "更新已下载，完全退出 App 后重新打开即可生效",
     "bundleCheckFailed": "无法检查整包更新，请稍后重试",
     "checkFailedDetail": "检查更新失败：{{detail}}",
     "checkFailed": "检查更新失败，请稍后重试"
@@ -76,6 +77,7 @@
   },
   "updateInfo": {
     "embedded": "随整包",
+    "embeddedFallback": "随整包（热更未生效）",
     "unknown": "未知",
     "source": "运行来源",
     "sourceEmbedded": "内置版本(随包)",
@@ -84,7 +86,9 @@
     "updatedAt": "更新时间",
     "channel": "Channel",
     "runtime": "Runtime",
-    "otaMarker": "热更标记"
+    "otaMarker": "热更标记",
+    "emergencyLaunch": "应急启动",
+    "emergencyLaunchYes": "是（本次运行内热更无法生效）"
   },
   "legal": {
     "sectionTitle": "备案信息",

--- a/apps/mobile/src/i18n/locales/zh-CN/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/settings.json
@@ -81,6 +81,7 @@
     "unknown": "未知",
     "source": "运行来源",
     "sourceEmbedded": "内置版本(随包)",
+    "sourceEmergencyFallback": "内置版本(应急启动，热更未生效)",
     "sourceOta": "OTA 热更新",
     "updateId": "更新 ID",
     "updatedAt": "更新时间",

--- a/apps/mobile/src/settings/updateInfo.ts
+++ b/apps/mobile/src/settings/updateInfo.ts
@@ -54,9 +54,13 @@ export function buildMobileUpdateInfoRows(currentlyRunning: MobileUpdateInfoInpu
     {
       id: 'source',
       label: i18n.t('settings.updateInfo.source'),
+      // 应急启动跑的也是内置 bundle(只是没走 embedded update 记录,isEmbeddedLaunch 为 false),
+      // 报「OTA 热更新」会跟同一区块里的应急启动行、以及「热更版本」自相矛盾。
       value: currentlyRunning.isEmbeddedLaunch
         ? i18n.t('settings.updateInfo.sourceEmbedded')
-        : i18n.t('settings.updateInfo.sourceOta'),
+        : currentlyRunning.isEmergencyLaunch
+          ? i18n.t('settings.updateInfo.sourceEmergencyFallback')
+          : i18n.t('settings.updateInfo.sourceOta'),
     },
     { id: 'updateId', label: i18n.t('settings.updateInfo.updateId'), value: updateId ? updateId.slice(0, 8) : '—' },
     { id: 'updatedAt', label: i18n.t('settings.updateInfo.updatedAt'), value: createdAt ? formatMobileUpdateTime(createdAt) : '—' },

--- a/apps/mobile/src/settings/updateInfo.ts
+++ b/apps/mobile/src/settings/updateInfo.ts
@@ -17,14 +17,24 @@ export interface MobileUpdateInfoRow {
 type MobileUpdateInfoInput = Pick<
   CurrentlyRunningInfo,
   'updateId' | 'channel' | 'createdAt' | 'isEmbeddedLaunch' | 'runtimeVersion'
->;
+> & Partial<Pick<CurrentlyRunningInfo, 'isEmergencyLaunch' | 'emergencyLaunchReason'>>;
 
-/** 当前实际运行的热更版本:OTA 用短 updateId,内置 bundle 明确标成随整包。 */
+/**
+ * 当前实际运行的热更版本:OTA 用短 updateId,内置 bundle 明确标成随整包。
+ *
+ * emergency launch(expo-updates 没找到可启动 update、退回内置 bundle)下 updateId 为空且
+ * isEmbeddedLaunch 也是 false —— 这不是"未知",而是确定跑着内置 bundle 且本次运行内热更
+ * 无法生效(reload 会被原生层拒绝)。单独出文案,免得看到"未知"以为是读不到版本。
+ */
 export function currentMobileOtaVersion(
-  currentlyRunning: Pick<CurrentlyRunningInfo, 'updateId' | 'isEmbeddedLaunch'>,
+  currentlyRunning: Pick<CurrentlyRunningInfo, 'updateId' | 'isEmbeddedLaunch'>
+    & Partial<Pick<CurrentlyRunningInfo, 'isEmergencyLaunch'>>,
 ): string {
   if (currentlyRunning.isEmbeddedLaunch) return i18n.t('settings.updateInfo.embedded');
-  return currentlyRunning.updateId?.trim().slice(0, 8) || i18n.t('settings.updateInfo.unknown');
+  const shortId = currentlyRunning.updateId?.trim().slice(0, 8);
+  if (shortId) return shortId;
+  if (currentlyRunning.isEmergencyLaunch) return i18n.t('settings.updateInfo.embeddedFallback');
+  return i18n.t('settings.updateInfo.unknown');
 }
 
 /**
@@ -33,11 +43,13 @@ export function currentMobileOtaVersion(
  * - 运行来源:isEmbeddedLaunch → 内置(随包),否则 OTA 热更新;
  * - 更新 ID:有就取前 8 位(canonical UUID 全小写),无(dev / expo-updates 未启用)显示 —;
  * - 更新时间:createdAt 本地时间 YYYY-MM-DD HH:mm,无则 —;
- * - Channel / Runtime:trim 后展示,空则 —。
+ * - Channel / Runtime:trim 后展示,空则 —;
+ * - 应急启动:仅 isEmergencyLaunch 时追加一行,带上原生给的原因(诊断"热更点了没反应"的第一现场)。
  */
 export function buildMobileUpdateInfoRows(currentlyRunning: MobileUpdateInfoInput): MobileUpdateInfoRow[] {
   const updateId = currentlyRunning.updateId;
   const createdAt = currentlyRunning.createdAt;
+  const emergencyReason = currentlyRunning.emergencyLaunchReason?.trim();
   return [
     {
       id: 'source',
@@ -51,6 +63,13 @@ export function buildMobileUpdateInfoRows(currentlyRunning: MobileUpdateInfoInpu
     { id: 'channel', label: i18n.t('settings.updateInfo.channel'), value: currentlyRunning.channel?.trim() || '—' },
     { id: 'runtimeVersion', label: i18n.t('settings.updateInfo.runtime'), value: currentlyRunning.runtimeVersion?.trim() || '—' },
     { id: 'otaMarker', label: i18n.t('settings.updateInfo.otaMarker'), value: OTA_VERIFY_MARKER },
+    ...(currentlyRunning.isEmergencyLaunch
+      ? [{
+        id: 'emergencyLaunch',
+        label: i18n.t('settings.updateInfo.emergencyLaunch'),
+        value: emergencyReason || i18n.t('settings.updateInfo.emergencyLaunchYes'),
+      }]
+      : []),
   ];
 }
 

--- a/apps/mobile/src/update/manualUpdateCheck.test.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.test.ts
@@ -21,7 +21,7 @@ function deps(overrides: Partial<ManualUpdateCheckDeps> = {}): ManualUpdateCheck
   return {
     otaEnabled: true,
     checkOtaUpdate: vi.fn(async () => ({ isAvailable: false })),
-    fetchOtaUpdate: vi.fn(async () => undefined),
+    fetchOtaUpdate: vi.fn(async () => ({ isNew: true })),
     reload: vi.fn(async () => undefined),
     onPhase: vi.fn(),
     ...overrides,
@@ -87,6 +87,38 @@ describe('runManualUpdateCheck', () => {
     expect(input.checkOtaUpdate).not.toHaveBeenCalled();
   });
 
+  // emergency launch(没有 launchedUpdate)时 reloadAsync 会被原生层拒绝,但 bundle 已落盘:
+  // 这不是一次失败的检查,必须导向"重开 App 生效",否则用户只看到一条无从下手的红字报错。
+  it('asks for a manual restart when the downloaded bundle cannot reload this process', async () => {
+    const input = deps({
+      checkOtaUpdate: vi.fn(async () => ({ isAvailable: true })),
+      fetchOtaUpdate: vi.fn(async () => ({ isNew: true })),
+      reload: vi.fn(async () => {
+        throw new Error("Call to function 'ExpoUpdates.reload' has been rejected.");
+      }),
+    });
+
+    await expect(runManualUpdateCheck(input)).resolves.toEqual({ kind: 'restart-required' });
+    expect(input.fetchOtaUpdate).toHaveBeenCalledOnce();
+    expect(input.reload).toHaveBeenCalledOnce();
+  });
+
+  it('still reports a failure when reload fails without any downloaded bundle', async () => {
+    const input = deps({
+      checkOtaUpdate: vi.fn(async () => ({ isAvailable: true })),
+      fetchOtaUpdate: vi.fn(async () => ({ isNew: false })),
+      reload: vi.fn(async () => {
+        throw new Error('reload rejected');
+      }),
+    });
+
+    await expect(runManualUpdateCheck(input)).resolves.toEqual({
+      kind: 'error',
+      reason: 'ota-check',
+      detail: 'reload rejected',
+    });
+  });
+
   it('keeps OTA failure details unlocalized until the settings page renders them', async () => {
     const input = deps({
       checkOtaUpdate: vi.fn(async () => {
@@ -103,6 +135,12 @@ describe('runManualUpdateCheck', () => {
 });
 
 describe('manualUpdateCheckMessage', () => {
+  it('tells the user to fully reopen the app when reload was rejected', async () => {
+    await i18n.changeLanguage('zh-CN');
+    expect(manualUpdateCheckMessage({ kind: 'restart-required' }, { isTestFlightBuild: false, t: i18n.t }))
+      .toBe('更新已下载，完全退出 App 后重新打开即可生效');
+  });
+
   it('uses the current language for an already completed TestFlight check', async () => {
     const outcome = { kind: 'up-to-date' } as const;
 

--- a/apps/mobile/src/update/manualUpdateCheck.test.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.test.ts
@@ -23,6 +23,7 @@ function deps(overrides: Partial<ManualUpdateCheckDeps> = {}): ManualUpdateCheck
     checkOtaUpdate: vi.fn(async () => ({ isAvailable: false })),
     fetchOtaUpdate: vi.fn(async () => ({ isNew: true })),
     reload: vi.fn(async () => undefined),
+    isEmergencyLaunch: vi.fn(() => false),
     onPhase: vi.fn(),
     ...overrides,
   };
@@ -89,13 +90,14 @@ describe('runManualUpdateCheck', () => {
 
   // emergency launch(没有 launchedUpdate)时 reloadAsync 会被原生层拒绝,但 bundle 已落盘:
   // 这不是一次失败的检查,必须导向"重开 App 生效",否则用户只看到一条无从下手的红字报错。
-  it('asks for a manual restart when the downloaded bundle cannot reload this process', async () => {
+  it('asks for a manual restart when an emergency launch blocks reloading the downloaded bundle', async () => {
     const input = deps({
       checkOtaUpdate: vi.fn(async () => ({ isAvailable: true })),
       fetchOtaUpdate: vi.fn(async () => ({ isNew: true })),
       reload: vi.fn(async () => {
         throw new Error("Call to function 'ExpoUpdates.reload' has been rejected.");
       }),
+      isEmergencyLaunch: vi.fn(() => true),
     });
 
     await expect(runManualUpdateCheck(input)).resolves.toEqual({ kind: 'restart-required' });
@@ -110,12 +112,31 @@ describe('runManualUpdateCheck', () => {
       reload: vi.fn(async () => {
         throw new Error('reload rejected');
       }),
+      isEmergencyLaunch: vi.fn(() => true),
     });
 
     await expect(runManualUpdateCheck(input)).resolves.toEqual({
       kind: 'error',
       reason: 'ota-check',
       detail: 'reload rejected',
+    });
+  });
+
+  // 非应急启动下的 reload 失败原因未知,原始详情是唯一线索:不能被重启指引盖掉。
+  it('keeps the reload failure detail when the app is not in an emergency launch', async () => {
+    const input = deps({
+      checkOtaUpdate: vi.fn(async () => ({ isAvailable: true })),
+      fetchOtaUpdate: vi.fn(async () => ({ isNew: true })),
+      reload: vi.fn(async () => {
+        throw new Error('Could not reload application; activity is null');
+      }),
+      isEmergencyLaunch: vi.fn(() => false),
+    });
+
+    await expect(runManualUpdateCheck(input)).resolves.toEqual({
+      kind: 'error',
+      reason: 'ota-check',
+      detail: 'Could not reload application; activity is null',
     });
   });
 

--- a/apps/mobile/src/update/manualUpdateCheck.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.ts
@@ -31,6 +31,11 @@ export interface ManualUpdateCheckDeps {
   /** isNew 表示确实落盘了一个新 bundle(reload 失败时用它区分"已下载待重启"与"什么都没拿到")。 */
   fetchOtaUpdate: () => Promise<{ isNew: boolean }>;
   reload: () => Promise<void>;
+  /**
+   * expo-updates 是否处于 emergency launch(没有 launchedUpdate,reload 必被原生层拒绝)。
+   * 只有这个状态才把 reload 失败判成"已下载待重启";其余 reload 失败仍按失败报,保留详情。
+   */
+  isEmergencyLaunch: () => boolean;
   onPhase: (phase: ManualUpdateCheckPhase) => void;
 }
 
@@ -44,6 +49,7 @@ export async function runManualUpdateCheck({
   checkOtaUpdate,
   fetchOtaUpdate,
   reload,
+  isEmergencyLaunch,
   onPhase,
 }: ManualUpdateCheckDeps): Promise<ManualUpdateCheckOutcome> {
   onPhase('checking');
@@ -72,10 +78,10 @@ export async function runManualUpdateCheck({
     await reload();
     return { kind: 'reloading' };
   } catch (error) {
-    // reload 失败但 bundle 已落盘时不能报"检查更新失败":更新其实拿到了,只是这个进程
-    // 重启不了(如 expo-updates 处于 emergency launch、没有 launchedUpdate 可重启),
-    // 下次冷启动就会生效 —— 告诉用户重开 App,而不是把它当成一次失败的检查。
-    if (fetchedNewBundle) return { kind: 'restart-required' };
+    // emergency launch(没有 launchedUpdate)下 reload 必被原生层拒绝,而 bundle 已经落盘、
+    // 下次冷启动就会生效:这不是一次失败的检查,报"检查更新失败"只会让用户无从下手。
+    // 反过来,其它原因的 reload 失败不套用这条 —— 那种情况原始详情才是唯一线索,不能吞掉。
+    if (fetchedNewBundle && isEmergencyLaunch()) return { kind: 'restart-required' };
     const detail = error instanceof Error ? error.message.trim() : String(error).trim();
     return {
       kind: 'error',

--- a/apps/mobile/src/update/manualUpdateCheck.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.ts
@@ -17,6 +17,8 @@ export type ManualUpdateCheckOutcome =
   | { kind: 'up-to-date' }
   | { kind: 'ota-unavailable' }
   | { kind: 'reloading' }
+  /** 新 bundle 已下载但重启失败:它会在下次冷启动生效,只能引导用户手动重开。 */
+  | { kind: 'restart-required' }
   | { kind: 'busy' }
   | { kind: 'error'; reason: 'bundle-check' | 'ota-check'; detail?: string };
 
@@ -26,7 +28,8 @@ export interface ManualUpdateCheckDeps {
   checkBundleUpdate?: () => Promise<BundleUpdateCheckOutcome>;
   otaEnabled: boolean;
   checkOtaUpdate: () => Promise<{ isAvailable: boolean }>;
-  fetchOtaUpdate: () => Promise<unknown>;
+  /** isNew 表示确实落盘了一个新 bundle(reload 失败时用它区分"已下载待重启"与"什么都没拿到")。 */
+  fetchOtaUpdate: () => Promise<{ isNew: boolean }>;
   reload: () => Promise<void>;
   onPhase: (phase: ManualUpdateCheckPhase) => void;
 }
@@ -59,14 +62,20 @@ export async function runManualUpdateCheck({
 
   if (!otaEnabled) return { kind: 'ota-unavailable' };
 
+  let fetchedNewBundle = false;
   try {
     const ota = await checkOtaUpdate();
     if (!ota.isAvailable) return { kind: 'up-to-date' };
     onPhase('downloading');
-    await fetchOtaUpdate();
+    const fetched = await fetchOtaUpdate();
+    fetchedNewBundle = fetched.isNew;
     await reload();
     return { kind: 'reloading' };
   } catch (error) {
+    // reload 失败但 bundle 已落盘时不能报"检查更新失败":更新其实拿到了,只是这个进程
+    // 重启不了(如 expo-updates 处于 emergency launch、没有 launchedUpdate 可重启),
+    // 下次冷启动就会生效 —— 告诉用户重开 App,而不是把它当成一次失败的检查。
+    if (fetchedNewBundle) return { kind: 'restart-required' };
     const detail = error instanceof Error ? error.message.trim() : String(error).trim();
     return {
       kind: 'error',
@@ -97,6 +106,8 @@ export function manualUpdateCheckMessage(
         : 'settings.version.bundleUpToDateNoOta');
     case 'reloading':
       return t('settings.version.downloadedRestarting');
+    case 'restart-required':
+      return t('settings.version.downloadedRestartRequired');
     case 'error':
       if (outcome.reason === 'bundle-check') return t('settings.version.bundleCheckFailed');
       return outcome.detail


### PR DESCRIPTION
## 这次改了什么

### 摘要

安卓自建包点「检查更新」报错:`检查更新失败:Call to function 'ExpoUpdates.reload' has been rejected...`,同时设置页「热更版本」显示「未知」。排查结论是 expo-updates 处于 **emergency launch**(没有 `launchedUpdate`),`reloadAsync()` 被原生层拒绝(`Cannot relaunch without a launched update.`,`EnabledUpdatesController.kt:232`)。

成因链(依据 expo-updates 56.0.22 原生源码,即 lockfile 锁定的版本):

1. 自建线 `updates.url` 是 placeholder `https://selfhost.invalid/manifest`,真实地址靠运行时 `setUpdateURLAndRequestHeadersOverride` 写入;
2. 该 override 会落盘到 SharedPreferences,下次原生初始化被读回(`UpdatesConfiguration.kt:76`),命中 `disableAntiBrickingMeasures && configOverride != null` → `hasEmbeddedUpdate = false`(`UpdatesConfiguration.kt:183`),**内置 bundle 从此被排除出可启动候选**(`DatabaseLauncher.kt:161`);
3. `runtimeVersion` 用 fingerprint 策略,launcher 严格按 runtimeVersion 过滤(`LauncherSelectionPolicyFilterAware.kt:23`),所以**每次整包升级后旧 OTA bundle 全部失配**;
4. 于是"没有可启动 update"+"内置被排除"→ `No launchable update was found`(`DatabaseLauncher.kt:79`)→ `StartupProcedure` 兜底成 `NoDatabaseLauncher`,App 用内置 JS 正常跑但 `launchedUpdate = null`;
5. 这个状态下 `launchedUpdate == null` 还会让 check 无条件返回"有更新"(`CheckForUpdateProcedure.kt:140` 那个注释着 "this shouldn't ever happen" 的分支),于是每次检查都走到 reload 并报错。

**表现:每次整包升级后首次启动必然进这个状态,点检查更新必报这条错一次;而 bundle 其实已经下载好,完全退出重开就会生效并自愈**(已在设备上实测复现并确认自愈)。

本 PR 只修表现层(纯 JS,可热更下发),把"一条无从下手的红字报错"变成"一句正确指引",并把诊断信息暴露到设置页。**根因(build 时写入真实 `updates.url`、不再依赖运行时 override)会改原生配置、触发冷更,不在本 PR 范围**。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(设备实测报错,排查后提交)
- 本 PR 包含:
  - `manualUpdateCheck`:新增 `restart-required` 结果 —— fetch 拿到新 bundle(`isNew`)但 `reload()` 失败时返回它,文案为「更新已下载,完全退出 App 后重新打开即可生效」;`fetchOtaUpdate` 依赖类型从 `Promise<unknown>` 收紧为 `Promise<{ isNew: boolean }>`,用 `isNew` 区分"已下载待重启"与"什么都没拿到"(后者仍报失败并保留原始 detail,不把没发生的更新说成已下载);
  - 设置页「热更版本」在 emergency launch 下显示「随整包(热更未生效)」,不再显示会被误读成"读不到版本号"的「未知」;
  - 调试分组「更新信息」在 `isEmergencyLaunch` 时追加一行,值优先用原生给的 `emergencyLaunchReason`(如 `No launchable update was found.`),便于以后直接在设备上定位同类问题;
  - 四语文案(zh-CN / en / ja / ko)3 个新 key;单测 +7。
- 明确不包含:
  - 根治方案(build 时写真实 `updates.url` + URL 一致时清掉 override)—— 改原生配置会触发冷更,按 `docs/dev-rules/mobile-development.md` 的冷更边界需把关人单独确认,留待冷更窗口;
  - 启动路径(`startupOtaUpdate` / `useStartupOtaGate`)逻辑未改 —— 它本来就 fail-open、无用户可见报错;
  - 未消除 emergency launch 状态本身(那属于根因)。
- 用户可见变化:上述报错文案改为重启指引;「热更版本」在应急启动下文案变化;调试分组多一行「应急启动」。
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及:本次只改既有文本行的**文案内容**,并在既有「更新信息」只读行列表里按同一 `MobileUpdateInfoRow` 结构追加一条数据(渲染由既有组件与 `styles.rowDetail` 负责),无新组件、无布局/间距/颜色/动效改动。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:通过(exit 0,54 个 workspace 全 PASS,含 apps/mobile)。
     注:另一次运行 apps/desktop 命中 vitest worker SIGSEGV;把本改动 stash 掉后在干净树上
     同样复现,为本机既有 flake,与本改动无关(本改动只碰 apps/mobile)。

pnpm --filter mobile run --if-present typecheck
结果:通过。

pnpm check:i18n-glossary
结果:通过(术语表 27 条已裁决 / 23 条待讨论,en / zh-CN / ja / ko 无新增违规)。

pnpm check:dco
结果:通过(1 commit signed off)。
```

新增单测覆盖:reload 被拒 + 有新 bundle → `restart-required`;reload 被拒 + 无新 bundle → 仍报失败并保留 detail;应急启动行的三种情形(有 reason / 无 reason / 正常启动不出现);`currentMobileOtaVersion` 的应急启动分支;新文案的 i18n 断言。

### 手工验证

问题现象本身在真机(Android 自建包,整包 0.1.0)上复现并确认了自愈路径:点检查更新报 `ExpoUpdates.reload has been rejected` → 完全杀进程重开 → 成功吃到热更。

### 未执行的验证

- 修复后的文案与新增诊断行**未做实机目检**(未在真机上重跑一遍改后 App)。
- **Light / Dark 双模式均未实机目检**:本次只改文案与一行只读数据,复用既有 themed 样式、未新增任何颜色或样式代码,按规则如实标注两种模式都未实机验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 `apps/mobile` 的 JS 层 —— 手动更新检查的结果分类与文案、设置页两处展示。**不改任何原生配置、不改 `app.config.js`、不进 fingerprint 输入,因此不触发冷更**,可随 OTA 下发。判定 OTA 是否可用的 gate、启动/resume 检查逻辑、下载与生效时机均未改动。
- 回滚 / 降级方式:纯 JS 改动,revert 本 commit 后随下一个 OTA bundle 即可回到原状态;无数据结构或持久化变更,无需迁移。
- 遗留:emergency launch 状态本身仍会在每次整包升级后出现一次(下载成功 + 一次冷启后自愈),根治需要那次冷更改造。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
