### PR TITLE
perf(desktop): cache Claude transcript lookups

### DIFF
--- a/apps/desktop/src/main/maker-orchestration/__tests__/claudeTranscriptAnchors.test.ts
+++ b/apps/desktop/src/main/maker-orchestration/__tests__/claudeTranscriptAnchors.test.ts
@@ -4,13 +4,13 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   findClaudeSessionJsonl,
-  resetClaudeTranscriptPathCacheForTesting,
+  __resetClaudeTranscriptPathCacheForTesting,
 } from '../claudeTranscriptAnchors';
 
 const roots: string[] = [];
 
 afterEach(async () => {
-  resetClaudeTranscriptPathCacheForTesting();
+  __resetClaudeTranscriptPathCacheForTesting();
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
@@ -64,14 +64,30 @@ describe('Claude transcript path lookup cache', () => {
     await expect(findClaudeSessionJsonl('s1', undefined, secondRoot)).resolves.toBe(second);
   });
 
-  it('prefers the direct working-directory project path', async () => {
+  it('rechecks the direct path after a cached fallback is discovered', async () => {
     const root = await createRoot();
     const workingDir = path.join(root, 'workspace');
     await mkdir(workingDir, { recursive: true });
-    await writeTranscript(root, 'fallback', 's1');
+    const fallback = await writeTranscript(root, 'fallback', 's1');
+    let now = 1_000;
+
+    await expect(findClaudeSessionJsonl('s1', workingDir, root, () => now)).resolves.toBe(fallback);
     const directProject = workingDir.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 200);
     const direct = await writeTranscript(root, directProject, 's1');
+    now += 1;
 
-    await expect(findClaudeSessionJsonl('s1', workingDir, root)).resolves.toBe(direct);
+    await expect(findClaudeSessionJsonl('s1', workingDir, root, () => now)).resolves.toBe(direct);
+  });
+
+  it('evicts the oldest cache entries at the capacity limit', async () => {
+    const root = await createRoot();
+    let now = 1_000;
+
+    for (let index = 0; index <= 500; index += 1) {
+      await expect(findClaudeSessionJsonl(`s${index}`, undefined, root, () => now)).resolves.toBeNull();
+    }
+
+    const first = await writeTranscript(root, 'first-project', 's0');
+    await expect(findClaudeSessionJsonl('s0', undefined, root, () => now)).resolves.toBe(first);
   });
 });

--- a/apps/desktop/src/main/maker-orchestration/__tests__/claudeTranscriptAnchors.test.ts
+++ b/apps/desktop/src/main/maker-orchestration/__tests__/claudeTranscriptAnchors.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, mkdir, rm, writeFile, unlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  findClaudeSessionJsonl,
+  resetClaudeTranscriptPathCacheForTesting,
+} from '../claudeTranscriptAnchors';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  resetClaudeTranscriptPathCacheForTesting();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function createRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-transcript-anchor-'));
+  roots.push(root);
+  return root;
+}
+
+async function writeTranscript(root: string, project: string, sessionId: string): Promise<string> {
+  const dir = path.join(root, project);
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${sessionId}.jsonl`);
+  await writeFile(file, '{"uuid":"u1","type":"assistant"}\n');
+  return file;
+}
+
+describe('Claude transcript path lookup cache', () => {
+  it('uses a negative cache and retries after the miss TTL', async () => {
+    const root = await createRoot();
+    let now = 1_000;
+
+    await expect(findClaudeSessionJsonl('s1', undefined, root, () => now)).resolves.toBeNull();
+    const file = await writeTranscript(root, 'project-a', 's1');
+    await expect(findClaudeSessionJsonl('s1', undefined, root, () => now)).resolves.toBeNull();
+
+    now += 5_001;
+    await expect(findClaudeSessionJsonl('s1', undefined, root, () => now)).resolves.toBe(file);
+  });
+
+  it('invalidates a cached hit when the file disappears', async () => {
+    const root = await createRoot();
+    const file = await writeTranscript(root, 'project-a', 's1');
+    let now = 1_000;
+
+    await expect(findClaudeSessionJsonl('s1', undefined, root, () => now)).resolves.toBe(file);
+    await unlink(file);
+    const replacement = await writeTranscript(root, 'nested/project-b', 's1');
+    now += 1;
+
+    await expect(findClaudeSessionJsonl('s1', undefined, root, () => now)).resolves.toBe(replacement);
+  });
+
+  it('keeps config roots isolated', async () => {
+    const firstRoot = await createRoot();
+    const secondRoot = await createRoot();
+    const first = await writeTranscript(firstRoot, 'project-a', 's1');
+    const second = await writeTranscript(secondRoot, 'project-b', 's1');
+
+    await expect(findClaudeSessionJsonl('s1', undefined, firstRoot)).resolves.toBe(first);
+    await expect(findClaudeSessionJsonl('s1', undefined, secondRoot)).resolves.toBe(second);
+  });
+
+  it('prefers the direct working-directory project path', async () => {
+    const root = await createRoot();
+    const workingDir = path.join(root, 'workspace');
+    await mkdir(workingDir, { recursive: true });
+    await writeTranscript(root, 'fallback', 's1');
+    const directProject = workingDir.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 200);
+    const direct = await writeTranscript(root, directProject, 's1');
+
+    await expect(findClaudeSessionJsonl('s1', workingDir, root)).resolves.toBe(direct);
+  });
+});

--- a/apps/desktop/src/main/maker-orchestration/__tests__/claudeTranscriptAnchors.test.ts
+++ b/apps/desktop/src/main/maker-orchestration/__tests__/claudeTranscriptAnchors.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile, unlink } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile, unlink, realpath } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -72,7 +72,8 @@ describe('Claude transcript path lookup cache', () => {
     let now = 1_000;
 
     await expect(findClaudeSessionJsonl('s1', workingDir, root, () => now)).resolves.toBe(fallback);
-    const directProject = workingDir.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 200);
+    const normalizedWorkingDir = (await realpath(workingDir)).normalize('NFC');
+    const directProject = normalizedWorkingDir.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 200);
     const direct = await writeTranscript(root, directProject, 's1');
     now += 1;
 

--- a/apps/desktop/src/main/maker-orchestration/claudeTranscriptAnchors.ts
+++ b/apps/desktop/src/main/maker-orchestration/claudeTranscriptAnchors.ts
@@ -5,6 +5,16 @@ import path from 'node:path';
 const PROJECT_KEY_MAX_LENGTH = 200;
 const SYNTHETIC_BLOCK_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-0{10}\d{2}$/i;
 const MAX_SCAN_DEPTH = 4;
+const TRANSCRIPT_PATH_CACHE_TTL_MS = 60_000;
+const TRANSCRIPT_MISS_CACHE_TTL_MS = 5_000;
+
+interface TranscriptPathCacheEntry {
+  filePath: string | null;
+  checkedAt: number;
+}
+
+const transcriptPathCache = new Map<string, TranscriptPathCacheEntry>();
+const transcriptPathInFlight = new Map<string, Promise<string | null>>();
 
 type JsonObject = Record<string, unknown>;
 
@@ -82,7 +92,7 @@ async function scanProjectDirsForSession(projectsRoot: string, filename: string)
   return visit(projectsRoot, 0);
 }
 
-async function findClaudeSessionJsonl(
+async function findClaudeSessionJsonlUncached(
   sdkSessionId: string,
   workingDir: string | null | undefined,
   projectsRoot: string,
@@ -94,6 +104,43 @@ async function findClaudeSessionJsonl(
     if (await fileExists(directPath)) return directPath;
   }
   return scanProjectDirsForSession(projectsRoot, filename);
+}
+
+/**
+ * JSONL 路径发现按 config root + workingDir + sdkSessionId 单飞并短时缓存。直接路径仍优先；
+ * 命中缓存每次先复核文件仍存在，删除/移动后立即回退扫描，不把过期绝对路径返回给 fork/rewind。
+ */
+export async function findClaudeSessionJsonl(
+  sdkSessionId: string,
+  workingDir: string | null | undefined,
+  projectsRoot: string,
+  now = Date.now,
+): Promise<string | null> {
+  const key = `${projectsRoot}\0${workingDir ?? ''}\0${sdkSessionId}`;
+  const current = transcriptPathCache.get(key);
+  const ttlMs = current?.filePath ? TRANSCRIPT_PATH_CACHE_TTL_MS : TRANSCRIPT_MISS_CACHE_TTL_MS;
+  if (current && now() - current.checkedAt < ttlMs) {
+    if (!current.filePath || await fileExists(current.filePath)) return current.filePath;
+    transcriptPathCache.delete(key);
+  }
+  const existing = transcriptPathInFlight.get(key);
+  if (existing) return existing;
+
+  const task = findClaudeSessionJsonlUncached(sdkSessionId, workingDir, projectsRoot)
+    .then((filePath) => {
+      transcriptPathCache.set(key, { filePath, checkedAt: now() });
+      return filePath;
+    })
+    .finally(() => {
+      if (transcriptPathInFlight.get(key) === task) transcriptPathInFlight.delete(key);
+    });
+  transcriptPathInFlight.set(key, task);
+  return task;
+}
+
+export function resetClaudeTranscriptPathCacheForTesting(): void {
+  transcriptPathCache.clear();
+  transcriptPathInFlight.clear();
 }
 
 function uniqueTruthy(values: Array<string | undefined>): string[] {

--- a/apps/desktop/src/main/maker-orchestration/claudeTranscriptAnchors.ts
+++ b/apps/desktop/src/main/maker-orchestration/claudeTranscriptAnchors.ts
@@ -7,6 +7,7 @@ const SYNTHETIC_BLOCK_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4
 const MAX_SCAN_DEPTH = 4;
 const TRANSCRIPT_PATH_CACHE_TTL_MS = 60_000;
 const TRANSCRIPT_MISS_CACHE_TTL_MS = 5_000;
+const MAX_TRANSCRIPT_PATH_CACHE_ENTRIES = 500;
 
 interface TranscriptPathCacheEntry {
   filePath: string | null;
@@ -92,20 +93,6 @@ async function scanProjectDirsForSession(projectsRoot: string, filename: string)
   return visit(projectsRoot, 0);
 }
 
-async function findClaudeSessionJsonlUncached(
-  sdkSessionId: string,
-  workingDir: string | null | undefined,
-  projectsRoot: string,
-): Promise<string | null> {
-  const filename = `${sdkSessionId}.jsonl`;
-  if (workingDir) {
-    const normalized = await normalizedExistingPath(workingDir);
-    const directPath = path.join(projectsRoot, sanitizeClaudeProjectKey(normalized), filename);
-    if (await fileExists(directPath)) return directPath;
-  }
-  return scanProjectDirsForSession(projectsRoot, filename);
-}
-
 /**
  * JSONL 路径发现按 config root + workingDir + sdkSessionId 单飞并短时缓存。直接路径仍优先；
  * 命中缓存每次先复核文件仍存在，删除/移动后立即回退扫描，不把过期绝对路径返回给 fork/rewind。
@@ -117,6 +104,15 @@ export async function findClaudeSessionJsonl(
   now = Date.now,
 ): Promise<string | null> {
   const key = `${projectsRoot}\0${workingDir ?? ''}\0${sdkSessionId}`;
+
+  // Direct paths are cheap to check and authoritative whenever they appear;
+  // never let a cached scan result mask a transcript restored into workingDir.
+  if (workingDir) {
+    const normalized = await normalizedExistingPath(workingDir);
+    const directPath = path.join(projectsRoot, sanitizeClaudeProjectKey(normalized), `${sdkSessionId}.jsonl`);
+    if (await fileExists(directPath)) return directPath;
+  }
+
   const current = transcriptPathCache.get(key);
   const ttlMs = current?.filePath ? TRANSCRIPT_PATH_CACHE_TTL_MS : TRANSCRIPT_MISS_CACHE_TTL_MS;
   if (current && now() - current.checkedAt < ttlMs) {
@@ -126,9 +122,14 @@ export async function findClaudeSessionJsonl(
   const existing = transcriptPathInFlight.get(key);
   if (existing) return existing;
 
-  const task = findClaudeSessionJsonlUncached(sdkSessionId, workingDir, projectsRoot)
+  const task = scanProjectDirsForSession(projectsRoot, `${sdkSessionId}.jsonl`)
     .then((filePath) => {
       transcriptPathCache.set(key, { filePath, checkedAt: now() });
+      while (transcriptPathCache.size > MAX_TRANSCRIPT_PATH_CACHE_ENTRIES) {
+        const oldestKey = transcriptPathCache.keys().next().value;
+        if (oldestKey === undefined) break;
+        transcriptPathCache.delete(oldestKey);
+      }
       return filePath;
     })
     .finally(() => {
@@ -138,7 +139,7 @@ export async function findClaudeSessionJsonl(
   return task;
 }
 
-export function resetClaudeTranscriptPathCacheForTesting(): void {
+export function __resetClaudeTranscriptPathCacheForTesting(): void {
   transcriptPathCache.clear();
   transcriptPathInFlight.clear();
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

优化 Desktop 在 fork、rewind 等路径查找 Claude Code JSONL 转录文件的性能。

原实现每次找不到按 workingDir 直达路径时，都会递归扫描所有 `~/.claude/projects` 子目录（最深 4 层）；同一会话连续执行 fork/rewind 会重复做相同文件系统遍历。

本 PR 为路径发现增加：

- 按 `projectsRoot + workingDir + sdkSessionId` 隔离的命中缓存；
- 同 key 在途请求单飞；
- 命中缓存 60 秒、miss 缓存 5 秒；
- 每次复用命中前检查文件仍存在，文件删除/移动后立即回退扫描；
- 保留 workingDir 直达路径优先、config root 候选顺序、`subagents` 排除和深度上限；
- 不改变 JSONL 解析、fork/rewind anchor 语义。

### 变更类型

- [x] `perf` 性能优化

### 范围

- 关联 Issue / 需求：Desktop 转录扫描性能
- 本 PR 包含：Claude transcript 路径发现缓存、失效策略、单测
- 明确不包含：PR #1111；Mobile 同步；Device Link 协议；JSONL 内容解析优化
- 用户可见变化：大规模 Claude projects 目录下，连续 fork/rewind 减少重复目录扫描
- 是否存在 breaking change：无

### UI 变化

不涉及：无 UI、交互或文案变化。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-orchestration/__tests__/claudeTranscriptAnchors.test.ts src/main/__tests__/fork.test.ts src/main/__tests__/rewind.test.ts
结果：3 files / 49 tests passed

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit -- --workspace-concurrency=1
结果：Mobile 和其它 workspace 通过；Desktop 默认 8-worker Vitest 本机 SIGSEGV

TZ=UTC pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=1 ...unit exclusions...
结果：1405 files / 16816 tests passed（2 skipped）

pnpm check:dco
git diff --check
结果：通过
```

### 手工验证

不涉及；未启动 Desktop 实例。

### 未执行的验证

未在 Windows 实机运行。实现仅使用 `path`、`fs` 与 Map，路径构造保持现有跨平台逻辑。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：文件路径缓存新鲜度

### 影响与回滚

- 影响范围：Desktop main 的 Claude transcript 路径发现；不修改用户文件、数据库、协议或 Renderer。
- 新鲜度：命中复用前复核文件存在；miss 仅缓存 5 秒；config root / workingDir / sessionId 均参与 key，避免跨实例串路径。
- 回滚 / 降级方式：回滚提交 `8a49d67d` 即恢复每次递归扫描。

### Remote / Mobile adaptation

- SSH 远程工作区：不新增远程 workdir 文件访问；仅优化现有本机 Claude CLI 转录查找。
- Device Link / Mobile：不涉及，无 IPC、allowlist、push 或 Mobile 入口变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)