### PR TITLE
feat(desktop): 支持 Git/本地自定义插件市场源

### DIFF
--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -537,11 +537,16 @@ export async function scaffoldGhostDir(
 }
 
 /**
- * 校验 + 打包一个意识源码目录。产物写到源码目录自身(<id>-<version>.cindy,
- * 同名覆盖——同 id 同版本重打包语义上就是同一个包),用户在自己的意识目录里
- * 就能拿到成品;出错返回结构化分类,agent 按 message 修源码即可,不抛异常。
+ * 打包核心:校验 + 收集 + 生成 zip buffer,不写盘。packGhostDir(产物进源码目录)
+ * 与 packGhostDirToFile(产物去调用方指定路径,自定义市场安装管道用)共用,
+ * 保证两条路径的校验与打包规则永远一致。
  */
-export async function packGhostDir(dir: string): Promise<ForgePackResult> {
+async function buildGhostPackage(
+  dir: string,
+): Promise<
+  | { ok: true; buf: Buffer; manifest: GhostManifest }
+  | Exclude<ForgePackResult, { ok: true }>
+> {
   try {
     let stat: fs.Stats;
     try {
@@ -636,7 +641,7 @@ export async function packGhostDir(dir: string): Promise<ForgePackResult> {
     const maxFiles = manifest.node ? MAX_NODE_FILES : MAX_BASIC_FILES;
     const maxTotalBytes = manifest.node ? MAX_NODE_TOTAL_BYTES : MAX_BASIC_TOTAL_BYTES;
     const seenPackPaths = new Set<string>();
-    const walk = async (cur: string, relBase: string): Promise<ForgePackResult | null> => {
+    const walk = async (cur: string, relBase: string): Promise<Exclude<ForgePackResult, { ok: true }> | null> => {
       const entries = await fs.promises.readdir(cur, { withFileTypes: true });
       for (const e of entries) {
         if (shouldSkip(e.name)) continue;
@@ -674,9 +679,9 @@ export async function packGhostDir(dir: string): Promise<ForgePackResult> {
     const tooLarge = await walk(dir, '');
     if (tooLarge) return tooLarge;
 
-    // 5) 打包到源码目录自身(2026-07 Lizi 定案:产物跟源码住一起,拿取直观)。
-    // 文件收集在写盘之前完成 + shouldSkip 跳过 *.cindy,自身产物不会进包;
-    // 同名覆盖:同 id 同版本重打包语义上就是同一个包。
+    // 5) 生成 zip buffer。文件收集在此之前完成 + shouldSkip 跳过 *.cindy,
+    // 产物自身不会进包;写盘位置由调用方决定(packGhostDir 进源码目录,
+    // packGhostDirToFile 进调用方指定路径)。
     const zip = new JSZip();
     for (const f of files) {
       zip.file(f.rel, await fs.promises.readFile(f.abs));
@@ -690,9 +695,7 @@ export async function packGhostDir(dir: string): Promise<ForgePackResult> {
         message: `压缩包体积超上限(${maxCindyBytes} 字节)`,
       };
     }
-    const cindyPath = path.join(dir, `${manifest.id}-${manifest.version}.cindy`);
-    await fs.promises.writeFile(cindyPath, buf);
-    return { ok: true, cindyPath, manifest };
+    return { ok: true, buf, manifest };
   } catch (err) {
     return {
       ok: false,
@@ -700,6 +703,35 @@ export async function packGhostDir(dir: string): Promise<ForgePackResult> {
       message: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+/**
+ * 校验 + 打包一个意识源码目录。产物写到源码目录自身(<id>-<version>.cindy,
+ * 同名覆盖——同 id 同版本重打包语义上就是同一个包),用户在自己的意识目录里
+ * 就能拿到成品;出错返回结构化分类,agent 按 message 修源码即可,不抛异常。
+ */
+export async function packGhostDir(dir: string): Promise<ForgePackResult> {
+  const built = await buildGhostPackage(dir);
+  if (!built.ok) return built;
+  // 产物跟源码住一起(2026-07 Lizi 定案:拿取直观);文件收集在写盘之前完成
+  // + shouldSkip 跳过 *.cindy,自身产物不会进包;同名覆盖。
+  const cindyPath = path.join(dir, `${built.manifest.id}-${built.manifest.version}.cindy`);
+  await fs.promises.writeFile(cindyPath, built.buf);
+  return { ok: true, cindyPath, manifest: built.manifest };
+}
+
+/**
+ * 打包到调用方指定的绝对路径。自定义市场安装管道用:市场克隆缓存是只读事实,
+ * 产物落到临时目录,装完即删。校验与打包规则与 packGhostDir 完全一致。
+ */
+export async function packGhostDirToFile(
+  dir: string,
+  destPath: string,
+): Promise<ForgePackResult> {
+  const built = await buildGhostPackage(dir);
+  if (!built.ok) return built;
+  await fs.promises.writeFile(destPath, built.buf, { flag: 'wx' });
+  return { ok: true, cindyPath: destPath, manifest: built.manifest };
 }
 
 /**

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -2574,6 +2574,14 @@ function rejectReservedGhostId(id: string): void {
 }
 
 /**
+ * 自定义市场（Git / 本地源）装入前的保留前缀闸。与服务端市场不同，自定义源
+ * 的包字节未经 plugin-server 绑定，不享受官方前缀豁免，语义同本地 .cindy 装入。
+ */
+export function rejectReservedGhostIdForCustomMarket(id: string): void {
+  rejectReservedGhostId(id);
+}
+
+/**
  * tokenBroker 第一方门控·装入闸:oauth 详单声明了 tokenBroker 的意识,XDT
  * server 的授权 broker(带用户登录 JWT 的服务端资产)只对官方前缀 id 开放,
  * 第三方包声明即拒装(连接闸在 /oauth connect 端点二次兜底)。不区分

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -25,7 +25,7 @@ describe('Plugin Market IPC error boundary', () => {
 
     expect(body).toContain('if (isIpcError(error)) throw error;');
     expect(body).toContain("throwIpcError('INTERNAL', 'Plugin market operation failed');");
-    expect(registerSource.match(/return invokePluginMarket\(/g)?.length).toBe(4);
+    expect(registerSource.match(/return invokePluginMarket\(/g)?.length).toBe(9);
   });
 
   it('does not throw user-visible plain errors from the market service', () => {

--- a/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
@@ -1,0 +1,386 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({
+  ghosts: [] as Array<{
+    manifest: Record<string, unknown>;
+    dir: string;
+    enabled: boolean;
+  }>,
+  install: vi.fn(),
+  uninstall: vi.fn(),
+  builtinRemoved: new Set<string>(),
+  accountGhostAvailable: true,
+  boundaryPending: false,
+  pluginApiBaseUrl: 'https://plugin.test.invalid' as string | null,
+  session: {
+    mode: 'cloud' as 'signed-out' | 'local' | 'cloud',
+    dataOwnerId: 'user-1' as string | null,
+    generation: 1,
+  },
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => os.tmpdir()) },
+}));
+vi.mock('../../authManager.js', () => ({
+  getCurrentUserId: vi.fn(() =>
+    runtime.session.mode === 'cloud' ? runtime.session.dataOwnerId : null,
+  ),
+}));
+vi.mock('../../appSessionState.js', () => ({
+  getActiveAppSession: vi.fn(() => ({ ...runtime.session })),
+  isAppSessionBoundaryPending: vi.fn(() => runtime.boundaryPending),
+  ownerScopedUserDataPath: vi.fn((...parts: string[]) =>
+    path.join(os.tmpdir(), 'owners', runtime.session.dataOwnerId ?? 'local', ...parts),
+  ),
+}));
+vi.mock('../../clientEndpointsService.js', () => ({
+  getClientEndpoint: vi.fn(() => runtime.pluginApiBaseUrl),
+}));
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../../cindy-brain/index.js', () => ({
+  getGhostManager: () => ({ list: () => runtime.ghosts }),
+  isGhostAvailableForActiveSession: vi.fn(() => runtime.accountGhostAvailable),
+  installOrUpdateMarketGhostPackage: runtime.install,
+  rejectReservedGhostIdForCustomMarket: vi.fn(),
+  isBuiltinGhostRemovedByUser: (id: string) => runtime.builtinRemoved.has(id),
+  uninstallGhostAndCleanup: runtime.uninstall,
+}));
+vi.mock('../download.js', () => ({
+  downloadVerifiedPlugin: vi.fn(async () => undefined),
+}));
+
+import type { VisiblePluginSummary } from '@cindy/plugin-protocol';
+
+import { customMarketPluginId, customMarketReleaseId } from '../../../shared/pluginMarket';
+import { PluginMarketLedger } from '../ledger';
+import { PluginMarketService } from '../service';
+import { MarketSourceStore } from '../sources/store';
+import type { PluginMarketApi } from '../api';
+
+const roots: string[] = [];
+const PLUGIN_ID = `c${'a'.repeat(24)}`;
+
+afterEach(() => {
+  runtime.ghosts = [];
+  runtime.install.mockReset();
+  runtime.uninstall.mockReset();
+  runtime.builtinRemoved.clear();
+  runtime.accountGhostAvailable = true;
+  runtime.boundaryPending = false;
+  runtime.pluginApiBaseUrl = 'https://plugin.test.invalid';
+  runtime.session = { mode: 'cloud', dataOwnerId: 'user-1', generation: 1 };
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function ghostManifest(id: string, version = '1.0.0') {
+  return {
+    schemaVersion: 2 as const,
+    id,
+    name: `Plugin ${id}`,
+    description: 'Custom market plugin',
+    author: 'Community',
+    version,
+    kind: 'chip' as const,
+    entry: 'main.js',
+    slots: ['notify'],
+  };
+}
+
+function serverSummary(overrides: Partial<VisiblePluginSummary> = {}): VisiblePluginSummary {
+  return {
+    id: PLUGIN_ID,
+    ghostId: 'server-plugin',
+    name: 'Server Plugin',
+    description: 'Server description',
+    author: 'Cindy',
+    scope: 'public',
+    organizationId: null,
+    defaultInstall: false,
+    currentRelease: {
+      id: 'release-1',
+      version: '1.0.0',
+      sha256: 'a'.repeat(64),
+      sizeBytes: 42,
+      publishedAt: '2026-07-23T00:00:00.000Z',
+      icon: null,
+    },
+    ...overrides,
+  };
+}
+
+/** 在临时目录造一个本地市场夹具（marketplace.json + 插件目录）。 */
+function writeLocalMarket(
+  root: string,
+  marketName: string,
+  plugins: Array<{ rel: string; id: string; version?: string }>,
+): string {
+  const dir = path.join(root, marketName);
+  for (const plugin of plugins) {
+    const pluginDir = path.join(dir, ...plugin.rel.split('/'));
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, 'ghost.json'),
+      JSON.stringify(ghostManifest(plugin.id, plugin.version ?? '1.0.0')),
+    );
+    fs.writeFileSync(path.join(pluginDir, 'main.js'), '// entry');
+  }
+  fs.mkdirSync(path.join(dir, '.agents', 'plugins'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.agents', 'plugins', 'marketplace.json'),
+    JSON.stringify({
+      name: marketName,
+      plugins: plugins.map((plugin) => ({ name: plugin.id, source: plugin.rel })),
+    }),
+  );
+  return dir;
+}
+
+function harness(items: VisiblePluginSummary[], marketDirs: Array<{ name: string; dir: string }>) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-plugin-custom-'));
+  roots.push(root);
+  const ledger = new PluginMarketLedger(path.join(root, 'ledger.json'));
+  const sourceStore = new MarketSourceStore(path.join(root, 'sources.v1.json'));
+  for (const market of marketDirs) {
+    sourceStore.add({
+      name: market.name,
+      addedAt: '2026-07-30T00:00:00.000Z',
+      lastSyncedAt: '2026-07-30T01:00:00.000Z',
+      lastRevision: null,
+      source: { type: 'local', path: market.dir },
+    });
+  }
+  const api = {
+    listAll: vi.fn(async () => items),
+    detail: vi.fn(),
+    download: vi.fn(),
+  };
+  return {
+    api,
+    ledger,
+    sourceStore,
+    service: new PluginMarketService(
+      api as unknown as PluginMarketApi,
+      ledger,
+      sourceStore,
+    ),
+  };
+}
+
+describe('PluginMarketService 自定义市场聚合', () => {
+  it('appends custom market items after server items with source identity', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/alpha', id: 'alpha' }]);
+    const h = harness([serverSummary()], [{ name: 'team-lib', dir }]);
+
+    const snapshot = await h.service.snapshot();
+    expect(snapshot.unavailableReason).toBeNull();
+    expect(snapshot.customSourceNames).toEqual(['team-lib']);
+    expect(snapshot.items).toHaveLength(2);
+    const [server, custom] = snapshot.items;
+    expect(server?.sourceType).toBe('server');
+    expect(server?.sourceMarketName).toBeNull();
+    expect(custom).toMatchObject({
+      pluginId: customMarketPluginId('team-lib', 'alpha'),
+      ghostId: 'alpha',
+      releaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
+      installState: 'not-installed',
+      sourceType: 'local-market',
+      sourceMarketName: 'team-lib',
+    });
+  });
+
+  it('keeps custom items available when the server market is not configured', async () => {
+    runtime.pluginApiBaseUrl = null;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/alpha', id: 'alpha' }]);
+    const h = harness([], [{ name: 'team-lib', dir }]);
+
+    const snapshot = await h.service.snapshot();
+    expect(snapshot.unavailableReason).toBeNull();
+    expect(snapshot.items).toHaveLength(1);
+    expect(snapshot.items[0]?.sourceType).toBe('local-market');
+  });
+
+  it('keeps the not-configured reason when neither source has anything', async () => {
+    runtime.pluginApiBaseUrl = null;
+    const h = harness([], []);
+    const snapshot = await h.service.snapshot();
+    expect(snapshot).toEqual({
+      items: [],
+      unavailableReason: 'not-configured',
+      customSourceNames: [],
+    });
+  });
+
+  it('marks cross-source ghostId duplicates as conflict on both sides', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/x', id: 'server-plugin' }]);
+    const h = harness([serverSummary()], [{ name: 'team-lib', dir }]);
+
+    const snapshot = await h.service.snapshot();
+    expect(snapshot.items.find((item) => item.sourceType === 'server')?.installState).toBe(
+      'conflict',
+    );
+    expect(snapshot.items.find((item) => item.sourceType === 'local-market')?.installState).toBe(
+      'conflict',
+    );
+  });
+
+  it('reports update-available when the marketplace version moved past the install', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [
+      { rel: 'plugins/alpha', id: 'alpha', version: '2.0.0' },
+    ]);
+    const h = harness([], [{ name: 'team-lib', dir }]);
+    runtime.ghosts = [
+      { manifest: ghostManifest('alpha', '1.0.0'), dir: '/ghosts/alpha', enabled: true },
+    ];
+    h.ledger.upsertInstallation({
+      pluginId: customMarketPluginId('team-lib', 'alpha'),
+      ghostId: 'alpha',
+      releaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
+      version: '1.0.0',
+      sha256: 'custom-unverified',
+      scope: 'public',
+      organizationId: null,
+      source: 'local-market',
+      installed: true,
+      updatedAt: '2026-07-30T02:00:00.000Z',
+    });
+
+    const snapshot = await h.service.snapshot();
+    expect(snapshot.items[0]).toMatchObject({
+      installState: 'update-available',
+      version: '2.0.0',
+      enabled: true,
+    });
+  });
+});
+
+describe('PluginMarketService 自定义市场 detail/install', () => {
+  it('returns the validated manifest for custom plugin detail', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/alpha', id: 'alpha' }]);
+    const h = harness([], [{ name: 'team-lib', dir }]);
+
+    const detail = await h.service.detail(customMarketPluginId('team-lib', 'alpha'));
+    expect(detail.manifest.id).toBe('alpha');
+    expect(detail.sourceType).toBe('local-market');
+    await expect(h.service.detail(customMarketPluginId('team-lib', 'missing'))).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    await expect(h.service.detail(customMarketPluginId('no-such-market', 'alpha'))).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('installs a custom market plugin and records local-market provenance', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/alpha', id: 'alpha' }]);
+    const h = harness([], [{ name: 'team-lib', dir }]);
+    runtime.install.mockResolvedValue({
+      manifest: ghostManifest('alpha'),
+      dir: '/ghosts/alpha',
+      enabled: true,
+    });
+
+    const pluginId = customMarketPluginId('team-lib', 'alpha');
+    const result = await h.service.install(pluginId, {
+      expectedReleaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
+    });
+    expect(result.ghost.manifest.id).toBe('alpha');
+    expect(runtime.install).toHaveBeenCalledTimes(1);
+    // 打包产物是临时文件，装完即删
+    expect(runtime.install.mock.calls[0]?.[0]).toMatch(/cindy-custom-market-alpha-.*\.cindy$/);
+    expect(fs.existsSync(runtime.install.mock.calls[0]?.[0] as string)).toBe(false);
+
+    const record = h.ledger.installationForGhost('alpha');
+    expect(record).toMatchObject({
+      pluginId,
+      source: 'local-market',
+      installed: true,
+      version: '1.0.0',
+    });
+  });
+
+  it('rejects install when the reviewed release no longer matches', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/alpha', id: 'alpha' }]);
+    const h = harness([], [{ name: 'team-lib', dir }]);
+
+    await expect(
+      h.service.install(customMarketPluginId('team-lib', 'alpha'), {
+        expectedReleaseId: 'custom:stale',
+      }),
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it('rejects install when another source already owns the ghostId', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/alpha', id: 'alpha' }]);
+    const h = harness([], [{ name: 'team-lib', dir }]);
+    runtime.ghosts = [
+      { manifest: ghostManifest('alpha'), dir: '/ghosts/alpha', enabled: true },
+    ];
+    // 服务端市场装过同 id 插件
+    h.ledger.upsertInstallation({
+      pluginId: PLUGIN_ID,
+      ghostId: 'alpha',
+      releaseId: 'release-1',
+      version: '1.0.0',
+      sha256: 'a'.repeat(64),
+      scope: 'public',
+      organizationId: null,
+      source: 'market',
+      installed: true,
+      updatedAt: '2026-07-30T02:00:00.000Z',
+    });
+
+    await expect(
+      h.service.install(customMarketPluginId('team-lib', 'alpha'), {
+        expectedReleaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
+      }),
+    ).rejects.toMatchObject({ code: 'ALREADY_EXISTS' });
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it('uninstalls a custom market plugin through the shared uninstall path', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
+    roots.push(root);
+    const dir = writeLocalMarket(root, 'team-lib', [{ rel: 'plugins/alpha', id: 'alpha' }]);
+    const h = harness([], [{ name: 'team-lib', dir }]);
+    const pluginId = customMarketPluginId('team-lib', 'alpha');
+    h.ledger.upsertInstallation({
+      pluginId,
+      ghostId: 'alpha',
+      releaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
+      version: '1.0.0',
+      sha256: 'custom-unverified',
+      scope: 'public',
+      organizationId: null,
+      source: 'local-market',
+      installed: true,
+      updatedAt: '2026-07-30T02:00:00.000Z',
+    });
+
+    await expect(h.service.uninstall(pluginId)).resolves.toEqual({ ok: true });
+    expect(runtime.uninstall).toHaveBeenCalledWith('alpha', { skipMarketLedger: true });
+    expect(h.ledger.installationForGhost('alpha')?.installed).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -269,6 +269,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await expect(h.service.snapshot()).resolves.toEqual({
       items: [],
       unavailableReason: 'authentication-required',
+      customSourceNames: [],
     });
     expect(h.api.listAll).not.toHaveBeenCalled();
   });
@@ -285,6 +286,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await expect(h.service.snapshot()).resolves.toEqual({
       items: [],
       unavailableReason: 'not-configured',
+      customSourceNames: [],
     });
     expect(h.api.listAll).not.toHaveBeenCalled();
   });
@@ -296,6 +298,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await expect(h.service.snapshot()).resolves.toEqual({
       items: [],
       unavailableReason: 'session-switching',
+      customSourceNames: [],
     });
     expect(h.api.listAll).not.toHaveBeenCalled();
   });
@@ -496,6 +499,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await expect(h.service.snapshot()).resolves.toEqual({
       items: [],
       unavailableReason: null,
+      customSourceNames: [],
     });
     expect(h.api.listAll).toHaveBeenCalledOnce();
   });

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
@@ -1,0 +1,159 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { discoverMarketplace } from '../sources/discover';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-discover-'));
+  roots.push(root);
+  return root;
+}
+
+function ghostJson(id: string, version = '1.0.0') {
+  return JSON.stringify({
+    schemaVersion: 2,
+    id,
+    name: `Plugin ${id}`,
+    version,
+    entry: 'main.js',
+    slots: ['notify'],
+  });
+}
+
+function writePlugin(root: string, rel: string, id: string, version = '1.0.0') {
+  const dir = path.join(root, ...rel.split('/'));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'ghost.json'), ghostJson(id, version));
+  fs.writeFileSync(path.join(dir, 'main.js'), '// entry');
+}
+
+function writeManifest(root: string, manifest: unknown, rel = '.agents/plugins/marketplace.json') {
+  const file = path.join(root, ...rel.split('/'));
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, typeof manifest === 'string' ? manifest : JSON.stringify(manifest));
+}
+
+describe('discoverMarketplace', () => {
+  it('discovers plugins from the primary manifest location', async () => {
+    const root = makeRoot();
+    writePlugin(root, 'plugins/alpha', 'alpha');
+    writePlugin(root, 'plugins/beta', 'beta', '2.0.0');
+    writeManifest(root, {
+      name: 'team-market',
+      interface: { displayName: 'Team Market' },
+      plugins: [{ name: 'alpha', source: './plugins/alpha' }, { name: 'beta', source: 'plugins/beta' }],
+    });
+
+    const result = await discoverMarketplace(root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.marketplace.name).toBe('team-market');
+    expect(result.marketplace.displayName).toBe('Team Market');
+    expect(result.marketplace.plugins.map((plugin) => plugin.ghostId)).toEqual([
+      'alpha',
+      'beta',
+    ]);
+    expect(result.marketplace.plugins[1]?.version).toBe('2.0.0');
+    expect(result.marketplace.skippedCount).toBe(0);
+  });
+
+  it.each([
+    '.claude-plugin/marketplace.json',
+    '.cursor-plugin/marketplace.json',
+    '.agents/plugins/api_marketplace.json',
+  ])('falls back to the alternate manifest location %s', async (rel) => {
+    const root = makeRoot();
+    writePlugin(root, 'p', 'solo');
+    writeManifest(root, { name: 'alt', plugins: [{ name: 'solo', source: 'p' }] }, rel);
+    const result = await discoverMarketplace(root);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.marketplace.name).toBe('alt');
+  });
+
+  it('prefers the primary manifest when several locations exist', async () => {
+    const root = makeRoot();
+    writePlugin(root, 'p', 'solo');
+    writeManifest(root, { name: 'primary', plugins: [] });
+    writeManifest(root, { name: 'secondary', plugins: [] }, '.claude-plugin/marketplace.json');
+    const result = await discoverMarketplace(root);
+    expect(result.ok && result.marketplace.name).toBe('primary');
+  });
+
+  it('supports the object form of local sources', async () => {
+    const root = makeRoot();
+    writePlugin(root, 'p', 'solo');
+    writeManifest(root, {
+      name: 'obj',
+      plugins: [{ name: 'solo', source: { source: 'local', path: 'p' } }],
+    });
+    const result = await discoverMarketplace(root);
+    expect(result.ok && result.marketplace.plugins).toHaveLength(1);
+  });
+
+  it('reports a missing manifest distinctly from a malformed one', async () => {
+    const empty = makeRoot();
+    expect(await discoverMarketplace(empty)).toEqual({ ok: false, code: 'MARKET_MANIFEST_MISSING' });
+
+    const malformed = makeRoot();
+    writeManifest(malformed, '{ not json');
+    const result = await discoverMarketplace(malformed);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('MARKET_SOURCE_INVALID');
+  });
+
+  it('skips unsupported remote plugin sources and invalid entries', async () => {
+    const root = makeRoot();
+    writePlugin(root, 'ok', 'good-one');
+    writeManifest(root, {
+      name: 'mixed',
+      plugins: [
+        { name: 'good', source: 'ok' },
+        { name: 'remote', source: { source: 'url', url: 'https://x.test/r.git' } },
+        { name: 'npm', source: { source: 'npm', package: '@x/y' } },
+        { name: 'escapes', source: '../outside' },
+        { name: 'absolute', source: '/etc/passwd' },
+        { name: 'missing-ghost', source: 'nowhere' },
+        'not-an-object',
+      ],
+    });
+    const result = await discoverMarketplace(root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.marketplace.plugins.map((plugin) => plugin.ghostId)).toEqual(['good-one']);
+    expect(result.marketplace.skippedCount).toBe(6);
+  });
+
+  it('skips duplicate ghostIds keeping the first occurrence', async () => {
+    const root = makeRoot();
+    writePlugin(root, 'a', 'dup-id', '1.0.0');
+    writePlugin(root, 'b', 'dup-id', '9.9.9');
+    writeManifest(root, {
+      name: 'dup',
+      plugins: [{ name: 'a', source: 'a' }, { name: 'b', source: 'b' }],
+    });
+    const result = await discoverMarketplace(root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.marketplace.plugins).toHaveLength(1);
+    expect(result.marketplace.plugins[0]?.version).toBe('1.0.0');
+  });
+
+  it('rejects manifests without a name or with a non-array plugins field', async () => {
+    const root = makeRoot();
+    writeManifest(root, { plugins: [] });
+    expect((await discoverMarketplace(root)).ok).toBe(false);
+
+    const root2 = makeRoot();
+    writeManifest(root2, { name: 'x', plugins: {} });
+    expect((await discoverMarketplace(root2)).ok).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-git.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-git.test.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  classifyGitFailure,
+  cloneMarketplace,
+  fetchMarketplace,
+  gitVersion,
+  isGitVersionSupported,
+  type GitExecutor,
+} from '../sources/git';
+import { checkGitPreflight } from '../sources/preflight';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function destPath(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-git-'));
+  roots.push(root);
+  return path.join(root, 'clone');
+}
+
+/** 记录调用并按需造出克隆目录的假执行器。 */
+function fakeExecutor(
+  handler?: (args: readonly string[], cwd?: string) => { stdout?: string; stderr?: string },
+): { executor: GitExecutor; calls: Array<{ args: readonly string[]; cwd?: string }> } {
+  const calls: Array<{ args: readonly string[]; cwd?: string }> = [];
+  const executor: GitExecutor = async (args, options) => {
+    calls.push({ args, ...(options.cwd ? { cwd: options.cwd } : {}) });
+    if (args[0] === 'clone') {
+      fs.mkdirSync(String(args[args.length - 1]), { recursive: true });
+    }
+    const result = handler?.(args, options.cwd) ?? {};
+    return { stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  };
+  return { executor, calls };
+}
+
+describe('cloneMarketplace', () => {
+  it('clones plainly without ref or sparse paths', async () => {
+    const { executor, calls } = fakeExecutor((_args) => ({ stdout: 'abc123\n' }));
+    const dest = destPath();
+    const revision = await cloneMarketplace(
+      { url: 'https://x.test/r.git', sparsePaths: [] },
+      dest,
+      executor,
+    );
+    expect(calls[0]?.args.slice(0, 1)).toEqual(['clone']);
+    expect(calls[0]?.args).not.toContain('--filter=blob:none');
+    expect(calls[0]?.args).not.toContain('--branch');
+    expect(revision).toBe('abc123');
+    expect(fs.existsSync(dest)).toBe(true);
+  });
+
+  it('passes --branch for ref checkouts on the plain path', async () => {
+    const { executor, calls } = fakeExecutor(() => ({ stdout: 'abc123\n' }));
+    await cloneMarketplace(
+      { url: 'https://x.test/r.git', ref: 'v1.2', sparsePaths: [] },
+      destPath(),
+      executor,
+    );
+    expect(calls[0]?.args).toEqual(
+      expect.arrayContaining(['clone', '--branch', 'v1.2']),
+    );
+  });
+
+  it('uses blobless clone + sparse-checkout when sparse paths are given', async () => {
+    const { executor, calls } = fakeExecutor(() => ({ stdout: 'abc123\n' }));
+    await cloneMarketplace(
+      { url: 'https://x.test/r.git', ref: 'main', sparsePaths: ['plugins/a', 'plugins/b'] },
+      destPath(),
+      executor,
+    );
+    expect(calls[0]?.args).toContain('--filter=blob:none');
+    expect(calls[0]?.args).toContain('--no-checkout');
+    expect(calls[1]?.args).toEqual(['sparse-checkout', 'set', 'plugins/a', 'plugins/b']);
+    expect(calls[2]?.args).toEqual(['checkout', 'main']);
+  });
+
+  it('cleans the staging directory and classifies auth failures', async () => {
+    const { executor } = fakeExecutor(() => {
+      throw Object.assign(new Error('fatal: Authentication failed'), {
+        stderr: 'fatal: Authentication failed',
+      });
+    });
+    const dest = destPath();
+    await expect(
+      cloneMarketplace({ url: 'https://x.test/r.git', sparsePaths: [] }, dest, executor),
+    ).rejects.toMatchObject({ code: 'MARKET_CLONE_AUTH_FAILED' });
+    expect(fs.readdirSync(path.dirname(dest)).filter((n) => n.includes('staging'))).toEqual([]);
+  });
+});
+
+describe('fetchMarketplace', () => {
+  it('pulls fast-forward when no ref is pinned', async () => {
+    const { executor, calls } = fakeExecutor(() => ({ stdout: 'def456\n' }));
+    const dir = destPath();
+    fs.mkdirSync(dir, { recursive: true });
+    const revision = await fetchMarketplace(dir, undefined, executor);
+    expect(calls.map((call) => call.args[0])).toEqual(['pull', 'rev-parse']);
+    expect(calls[0]?.args).toContain('--ff-only');
+    expect(revision).toBe('def456');
+  });
+
+  it('resets to FETCH_HEAD when a ref is pinned', async () => {
+    const { executor, calls } = fakeExecutor(() => ({ stdout: 'def456\n' }));
+    const dir = destPath();
+    fs.mkdirSync(dir, { recursive: true });
+    await fetchMarketplace(dir, 'v1.2', executor);
+    expect(calls.map((call) => call.args[0])).toEqual(['fetch', 'reset', 'rev-parse']);
+    expect(calls[1]?.args).toEqual(['reset', '--hard', 'FETCH_HEAD']);
+  });
+});
+
+describe('git environment', () => {
+  it('parses git versions and enforces the sparse-checkout floor', async () => {
+    const { executor } = fakeExecutor(() => ({ stdout: 'git version 2.43.0\n' }));
+    expect(await gitVersion(executor)).toEqual({ major: 2, minor: 43 });
+    expect(isGitVersionSupported({ major: 2, minor: 25 })).toBe(true);
+    expect(isGitVersionSupported({ major: 2, minor: 24 })).toBe(false);
+    expect(isGitVersionSupported({ major: 3, minor: 0 })).toBe(true);
+  });
+
+  it('preflight fails closed when git cannot execute', async () => {
+    const executor: GitExecutor = async () => {
+      throw new Error('spawn git ENOENT');
+    };
+    expect(await checkGitPreflight(executor)).toEqual({ ok: false, version: null });
+  });
+
+  it('preflight reports versions below the floor', async () => {
+    const { executor } = fakeExecutor(() => ({ stdout: 'git version 2.20.1\n' }));
+    expect(await checkGitPreflight(executor)).toEqual({ ok: false, version: '2.20' });
+  });
+});
+
+describe('classifyGitFailure', () => {
+  it.each([
+    'fatal: Authentication failed',
+    'fatal: could not read Username for https://github.com: terminal prompts disabled',
+    'ERROR: Repository not found.',
+    'git@github.com: Permission denied (publickey).',
+  ])('classifies %s as an auth failure', (message) => {
+    expect(classifyGitFailure(new Error(message)).code).toBe('MARKET_CLONE_AUTH_FAILED');
+  });
+
+  it('classifies other failures as generic clone failures', () => {
+    expect(classifyGitFailure(new Error('Could not resolve host')).code).toBe(
+      'MARKET_CLONE_FAILED',
+    );
+  });
+});

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-manager.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-manager.test.ts
@@ -1,0 +1,250 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MarketSourceManager, marketCloneSlug } from '../sources/index';
+import type { GitExecutor } from '../sources/git';
+import { MarketSourceStore } from '../sources/store';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-manager-'));
+  roots.push(root);
+  return root;
+}
+
+function writeMarketplace(dir: string, name: string, plugins: Array<{ rel: string; id: string }>) {
+  for (const plugin of plugins) {
+    const pluginDir = path.join(dir, ...plugin.rel.split('/'));
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, 'ghost.json'),
+      JSON.stringify({ schemaVersion: 2, id: plugin.id, name: `Plugin ${plugin.id}`, version: '1.0.0', entry: 'main.js', slots: ['notify'] }),
+    );
+    fs.writeFileSync(path.join(pluginDir, 'main.js'), '// entry');
+  }
+  const manifestDir = path.join(dir, '.agents', 'plugins');
+  fs.mkdirSync(manifestDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(manifestDir, 'marketplace.json'),
+    JSON.stringify({
+      name,
+      plugins: plugins.map((plugin) => ({ name: plugin.id, source: plugin.rel })),
+    }),
+  );
+}
+
+function makeManager(root: string, gitExecutor?: GitExecutor) {
+  return new MarketSourceManager({
+    store: new MarketSourceStore(path.join(root, 'sources.v1.json')),
+    cloneRoot: path.join(root, 'sources'),
+    homeDir: root,
+    ...(gitExecutor ? { gitExecutor } : {}),
+  });
+}
+
+/** Git 假执行器：版本探测通过，clone 时向目标目录写入一个市场夹具。 */
+function fakeGit(marketName: string, plugins: Array<{ rel: string; id: string }>) {
+  const calls: string[][] = [];
+  const executor: GitExecutor = async (args) => {
+    calls.push([...args]);
+    if (args[0] === '--version') return { stdout: 'git version 2.43.0\n', stderr: '' };
+    if (args[0] === 'clone') {
+      const dest = String(args[args.length - 1]);
+      writeMarketplace(dest, marketName, plugins);
+      return { stdout: '', stderr: '' };
+    }
+    if (args[0] === 'rev-parse') return { stdout: 'abc123\n', stderr: '' };
+    return { stdout: '', stderr: '' };
+  };
+  return { executor, calls };
+}
+
+describe('MarketSourceManager local sources', () => {
+  it('adds a local marketplace and lists it with the plugin count', async () => {
+    const root = makeRoot();
+    const market = path.join(root, 'my-market');
+    writeMarketplace(market, 'local-lib', [{ rel: 'plugins/a', id: 'alpha' }]);
+    const manager = makeManager(root);
+
+    const added = await manager.addSource({ source: market });
+    expect(added).toMatchObject({
+      name: 'local-lib',
+      pluginCount: 1,
+      status: 'ok',
+    });
+    expect(added.source).toEqual({ type: 'local', path: market });
+
+    const list = await manager.listSources();
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe('local-lib');
+  });
+
+  it('rejects a local source that is not a directory', async () => {
+    const manager = makeManager(makeRoot());
+    await expect(
+      manager.addSource({ source: path.join(makeRoot(), 'missing') }),
+    ).rejects.toMatchObject({ code: 'MARKET_SOURCE_INVALID' });
+  });
+
+  it('rejects duplicate sources and duplicate marketplace names', async () => {
+    const root = makeRoot();
+    const market = path.join(root, 'my-market');
+    writeMarketplace(market, 'local-lib', []);
+    const manager = makeManager(root);
+
+    await manager.addSource({ source: market });
+    await expect(manager.addSource({ source: market })).rejects.toMatchObject({
+      code: 'ALREADY_EXISTS',
+    });
+
+    const other = path.join(root, 'other-market');
+    writeMarketplace(other, 'local-lib', []);
+    await expect(manager.addSource({ source: other })).rejects.toMatchObject({
+      code: 'ALREADY_EXISTS',
+    });
+  });
+
+  it('removes sources and keeps local directories untouched', async () => {
+    const root = makeRoot();
+    const market = path.join(root, 'my-market');
+    writeMarketplace(market, 'local-lib', []);
+    const manager = makeManager(root);
+
+    await manager.addSource({ source: market });
+    await expect(manager.removeSource('local-lib')).resolves.toEqual({ ok: true });
+    expect(await manager.listSources()).toEqual([]);
+    expect(fs.existsSync(path.join(market, '.agents', 'plugins', 'marketplace.json'))).toBe(true);
+    await expect(manager.removeSource('local-lib')).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('marks sources with vanished roots as errors in the list view', async () => {
+    const root = makeRoot();
+    const market = path.join(root, 'my-market');
+    writeMarketplace(market, 'local-lib', [{ rel: 'p', id: 'alpha' }]);
+    const manager = makeManager(root);
+    await manager.addSource({ source: market });
+
+    fs.rmSync(market, { recursive: true, force: true });
+    const list = await manager.listSources();
+    expect(list[0]?.status).toBe('error');
+    expect(list[0]?.errorCode).toBe('MARKET_SOURCE_INVALID');
+  });
+
+  it('refreshes local sources by rescanning the manifest', async () => {
+    const root = makeRoot();
+    const market = path.join(root, 'my-market');
+    writeMarketplace(market, 'local-lib', []);
+    const manager = makeManager(root);
+    await manager.addSource({ source: market });
+
+    writeMarketplace(market, 'local-lib', [{ rel: 'p', id: 'alpha' }]);
+    const refreshed = await manager.refreshSource('local-lib');
+    expect(refreshed.pluginCount).toBe(1);
+    expect(refreshed.lastSyncedAt).not.toBeNull();
+  });
+});
+
+describe('MarketSourceManager git sources', () => {
+  it('clones into the derived cache directory on add', async () => {
+    const root = makeRoot();
+    const { executor } = fakeGit('hub', [{ rel: 'plugins/a', id: 'alpha' }]);
+    const manager = makeManager(root, executor);
+
+    const added = await manager.addSource({ source: 'openai/plugins' });
+    expect(added).toMatchObject({ name: 'hub', pluginCount: 1, lastRevision: 'abc123' });
+
+    const cloneDir = path.join(
+      root,
+      'sources',
+      marketCloneSlug('hub', {
+        type: 'git',
+        url: 'https://github.com/openai/plugins.git',
+        sparsePaths: [],
+      }),
+    );
+    expect(fs.existsSync(path.join(cloneDir, '.agents', 'plugins', 'marketplace.json'))).toBe(true);
+    // 临时 incoming 目录不残留
+    expect(
+      fs.readdirSync(path.join(root, 'sources')).filter((name) => name.startsWith('.incoming')),
+    ).toEqual([]);
+  });
+
+  it('blocks git sources when git is unavailable', async () => {
+    const root = makeRoot();
+    const executor: GitExecutor = async () => {
+      throw new Error('spawn git ENOENT');
+    };
+    const manager = makeManager(root, executor);
+    await expect(manager.addSource({ source: 'openai/plugins' })).rejects.toMatchObject({
+      code: 'MARKET_GIT_UNAVAILABLE',
+    });
+    expect(await manager.listSources()).toEqual([]);
+  });
+
+  it('rolls back the clone when the marketplace name conflicts', async () => {
+    const root = makeRoot();
+    const local = path.join(root, 'local-market');
+    writeMarketplace(local, 'hub', []);
+    const { executor } = fakeGit('hub', []);
+    const manager = makeManager(root, executor);
+
+    await manager.addSource({ source: local });
+    await expect(manager.addSource({ source: 'openai/plugins' })).rejects.toMatchObject({
+      code: 'ALREADY_EXISTS',
+    });
+    expect(fs.readdirSync(path.join(root, 'sources'))).toEqual([]);
+  });
+
+  it('removes the clone cache when the source is removed', async () => {
+    const root = makeRoot();
+    const { executor } = fakeGit('hub', []);
+    const manager = makeManager(root, executor);
+    await manager.addSource({ source: 'openai/plugins' });
+
+    const cloneDir = path.join(
+      root,
+      'sources',
+      marketCloneSlug('hub', {
+        type: 'git',
+        url: 'https://github.com/openai/plugins.git',
+        sparsePaths: [],
+      }),
+    );
+    expect(fs.existsSync(cloneDir)).toBe(true);
+    await manager.removeSource('hub');
+    expect(fs.existsSync(cloneDir)).toBe(false);
+  });
+
+  it('re-clones when fast-forward refresh fails', async () => {
+    const root = makeRoot();
+    let failFetch = false;
+    const executor: GitExecutor = async (args) => {
+      if (args[0] === '--version') return { stdout: 'git version 2.43.0\n', stderr: '' };
+      if (args[0] === 'clone') {
+        writeMarketplace(String(args[args.length - 1]), 'hub', [{ rel: 'p', id: 'alpha' }]);
+        return { stdout: '', stderr: '' };
+      }
+      if (args[0] === 'pull' || args[0] === 'fetch') {
+        if (failFetch) throw Object.assign(new Error('rejected'), { stderr: 'non-fast-forward' });
+        return { stdout: '', stderr: '' };
+      }
+      if (args[0] === 'rev-parse') return { stdout: 'def456\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    };
+    const manager = makeManager(root, executor);
+    await manager.addSource({ source: 'openai/plugins' });
+
+    failFetch = true;
+    const refreshed = await manager.refreshSource('hub');
+    expect(refreshed.lastRevision).toBe('def456');
+    expect(refreshed.pluginCount).toBe(1);
+  });
+});

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-parse.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-parse.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMarketSource, resolveLocalSourcePath } from '../sources/parse';
+
+const HOME = '/home/tester';
+
+function parse(input: { source: string; ref?: string; sparsePaths?: string[] }) {
+  return parseMarketSource(input, HOME);
+}
+
+describe('parseMarketSource', () => {
+  it('parses GitHub shorthand into an https git source', () => {
+    const result = parse({ source: 'openai/plugins' });
+    expect(result).toEqual({
+      ok: true,
+      source: {
+        type: 'git',
+        url: 'https://github.com/openai/plugins.git',
+        sparsePaths: [],
+      },
+    });
+  });
+
+  it('keeps ref and sparse paths on git sources', () => {
+    const result = parse({
+      source: 'openai/plugins',
+      ref: 'v1.2',
+      sparsePaths: ['plugins/codex', ' plugins/extra ', ''],
+    });
+    expect(result).toEqual({
+      ok: true,
+      source: {
+        type: 'git',
+        url: 'https://github.com/openai/plugins.git',
+        ref: 'v1.2',
+        sparsePaths: ['plugins/codex', 'plugins/extra'],
+      },
+    });
+  });
+
+  it.each([
+    'https://github.com/org/repo.git',
+    'ssh://git@example.com/org/repo.git',
+    'git@github.com:org/repo.git',
+  ])('accepts full git URL %s', (source) => {
+    const result = parse({ source });
+    expect(result).toEqual({
+      ok: true,
+      source: { type: 'git', url: source, sparsePaths: [] },
+    });
+  });
+
+  it('resolves ~ against the injected home directory', () => {
+    const result = parse({ source: '~/team/plugins' });
+    expect(result).toEqual({
+      ok: true,
+      source: { type: 'local', path: `${HOME}/team/plugins` },
+    });
+  });
+
+  it.each(['/abs/path', './rel/path', '../up/path'])(
+    'treats %s as a local path',
+    (source) => {
+      const result = parse({ source });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.source.type).toBe('local');
+    },
+  );
+
+  it('rejects ref and sparse paths for local sources', () => {
+    expect(parse({ source: '~/x', ref: 'main' })).toEqual({
+      ok: false,
+      code: 'REF_NOT_ALLOWED_FOR_LOCAL',
+    });
+    expect(parse({ source: '~/x', sparsePaths: ['a'] })).toEqual({
+      ok: false,
+      code: 'SPARSE_NOT_ALLOWED_FOR_LOCAL',
+    });
+  });
+
+  it('rejects empty and unrecognizable sources', () => {
+    expect(parse({ source: '   ' })).toEqual({ ok: false, code: 'EMPTY_SOURCE' });
+    expect(parse({ source: 'just-a-word' })).toEqual({
+      ok: false,
+      code: 'INVALID_SOURCE_FORMAT',
+    });
+    expect(parse({ source: 'a/b/c' })).toEqual({
+      ok: false,
+      code: 'INVALID_SOURCE_FORMAT',
+    });
+  });
+
+  it('rejects option-injection shaped refs', () => {
+    expect(parse({ source: 'openai/plugins', ref: '--upload-pack=evil' })).toEqual({
+      ok: false,
+      code: 'INVALID_REF',
+    });
+  });
+
+  it('rejects sparse paths escaping the repository', () => {
+    expect(parse({ source: 'openai/plugins', sparsePaths: ['../outside'] })).toEqual({
+      ok: false,
+      code: 'INVALID_SPARSE_PATH',
+    });
+    expect(parse({ source: 'openai/plugins', sparsePaths: ['/abs'] })).toEqual({
+      ok: false,
+      code: 'INVALID_SPARSE_PATH',
+    });
+  });
+
+  it('resolves local paths without touching the filesystem', () => {
+    expect(resolveLocalSourcePath('~/a/b', HOME)).toBe(`${HOME}/a/b`);
+  });
+});

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-store.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-store.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { MarketSourceConfig } from '../../../shared/pluginMarket';
+import { MarketSourceStore, sourcesEqual } from '../sources/store';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function makeStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-store-'));
+  roots.push(root);
+  return new MarketSourceStore(path.join(root, 'sources.v1.json'));
+}
+
+function config(overrides: Partial<MarketSourceConfig> = {}): MarketSourceConfig {
+  return {
+    name: 'openai/plugins',
+    addedAt: '2026-07-31T00:00:00.000Z',
+    lastSyncedAt: null,
+    lastRevision: null,
+    source: { type: 'git', url: 'https://github.com/openai/plugins.git', sparsePaths: [] },
+    ...overrides,
+  };
+}
+
+describe('MarketSourceStore', () => {
+  it('returns an empty list when the file does not exist', () => {
+    expect(makeStore().list()).toEqual([]);
+  });
+
+  it('persists configs across instances (atomic write + read back)', () => {
+    const store = makeStore();
+    store.add(config());
+    store.add(config({ name: 'local-lib', source: { type: 'local', path: '/x' } }));
+
+    const reread = new MarketSourceStore(
+      (store as unknown as { filePathSource: string }).filePathSource,
+    );
+    expect(reread.list().map((source) => source.name)).toEqual([
+      'openai/plugins',
+      'local-lib',
+    ]);
+  });
+
+  it('add replaces a same-name config instead of duplicating it', () => {
+    const store = makeStore();
+    store.add(config());
+    store.add(config({ lastSyncedAt: '2026-07-31T01:00:00.000Z' }));
+    expect(store.list()).toHaveLength(1);
+    expect(store.get('openai/plugins')?.lastSyncedAt).toBe('2026-07-31T01:00:00.000Z');
+  });
+
+  it('updates sync metadata without touching identity fields', () => {
+    const store = makeStore();
+    store.add(config());
+    store.update('openai/plugins', {
+      lastSyncedAt: '2026-07-31T02:00:00.000Z',
+      lastRevision: 'abc123',
+    });
+    const updated = store.get('openai/plugins');
+    expect(updated?.lastRevision).toBe('abc123');
+    expect(updated?.source).toEqual(config().source);
+    expect(store.update('missing', { lastRevision: 'x' })).toBeUndefined();
+  });
+
+  it('removes configs and reports what was removed', () => {
+    const store = makeStore();
+    store.add(config());
+    expect(store.remove('openai/plugins')?.name).toBe('openai/plugins');
+    expect(store.remove('openai/plugins')).toBeNull();
+    expect(store.list()).toEqual([]);
+  });
+
+  it('drops malformed entries instead of failing the whole file', () => {
+    const store = makeStore();
+    store.add(config());
+    const file = (store as unknown as { filePathSource: string }).filePathSource;
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: 1,
+        sources: [config(), { name: '' }, { name: 'bad', source: { type: 'other' } }],
+      }),
+    );
+    expect(store.list().map((source) => source.name)).toEqual(['openai/plugins']);
+  });
+
+  it('detects equivalent sources by type + location + ref + sparse paths', () => {
+    const store = makeStore();
+    store.add(config({ source: { type: 'git', url: 'https://x.test/r.git', ref: 'v1', sparsePaths: ['a'] } }));
+    expect(
+      store.hasEquivalent({ type: 'git', url: 'https://x.test/r.git', ref: 'v1', sparsePaths: ['a'] }),
+    ).toBe(true);
+    expect(
+      store.hasEquivalent({ type: 'git', url: 'https://x.test/r.git', sparsePaths: ['a'] }),
+    ).toBe(false);
+    expect(store.hasEquivalent({ type: 'local', path: 'https://x.test/r.git' })).toBe(false);
+  });
+
+  it('sourcesEqual treats undefined and empty ref as identical', () => {
+    expect(
+      sourcesEqual(
+        { type: 'git', url: 'u', sparsePaths: [] },
+        { type: 'git', url: 'u', ref: undefined, sparsePaths: [] },
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/plugin-market/install.ts
+++ b/apps/desktop/src/main/plugin-market/install.ts
@@ -1,0 +1,85 @@
+/**
+ * 自定义市场插件的安装管道。
+ *
+ * 复用服务端市场的装入出口（installOrUpdateMarketGhostPackage）：打包 →
+ * inspect 校验 → 原子换目录 → 布局停靠，全部走同一条已验证路径。差异只在
+ * 包来源与信任闸：
+ * - 包字节来自用户添加的 Git/本地源，未经 plugin-server 校验，因此保留前缀
+ *   闸（cindy- 等官方 id）与服务端市场相反——按本地 .cindy 装入语义拒绝。
+ * - 打包产物落系统临时目录（唯一文件名），装完即删，不污染市场克隆缓存。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import { app } from 'electron';
+
+import {
+  validateGhostManifest,
+  type InstalledGhost,
+} from '../../shared/ghost.js';
+import {
+  installOrUpdateMarketGhostPackage,
+  rejectReservedGhostIdForCustomMarket,
+} from '../cindy-brain/index.js';
+import { packGhostDirToFile } from '../cindy-brain/forge.js';
+import { throwIpcError } from '../utils/ipcValidate.js';
+
+/**
+ * 把插件目录装成运行中的 Ghost。
+ *
+ * expected 是 Renderer 确认框实际审阅过的 id + version；这里重读 ghost.json
+ * 逐字比对，确认到打包之间目录被改动时拒绝滑入（与服务端市场的
+ * expectedReleaseId 同一防线）。
+ */
+export async function installCustomMarketPlugin(input: {
+  pluginDir: string;
+  expected: { ghostId: string; version: string };
+}): Promise<InstalledGhost> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(
+      await fs.promises.readFile(path.join(input.pluginDir, 'ghost.json'), 'utf8'),
+    );
+  } catch {
+    throwIpcError('GHOST_FILE_INVALID', 'The Plugin manifest is missing or unreadable');
+  }
+  const validated = validateGhostManifest(raw);
+  if (!validated.ok) {
+    throwIpcError('GHOST_FILE_INVALID', validated.reason);
+  }
+  if (
+    validated.manifest.id !== input.expected.ghostId ||
+    validated.manifest.version !== input.expected.version
+  ) {
+    throwIpcError(
+      'PRECONDITION_FAILED',
+      'Plugin changed after permission review',
+    );
+  }
+  rejectReservedGhostIdForCustomMarket(validated.manifest.id);
+
+  const tempPath = path.join(
+    app.getPath('temp'),
+    `cindy-custom-market-${validated.manifest.id}-${crypto.randomUUID()}.cindy`,
+  );
+  try {
+    const packed = await packGhostDirToFile(input.pluginDir, tempPath);
+    if (!packed.ok) {
+      throwIpcError(
+        packed.errorCode === 'TOO_LARGE' || packed.errorCode === 'MANIFEST_INVALID'
+          ? 'GHOST_FILE_INVALID'
+          : packed.errorCode === 'DIR_NOT_FOUND'
+            ? 'NOT_FOUND'
+            : 'INTERNAL',
+        packed.message,
+      );
+    }
+    return await installOrUpdateMarketGhostPackage(tempPath, {
+      ghostId: validated.manifest.id,
+      version: validated.manifest.version,
+    });
+  } finally {
+    await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
+  }
+}

--- a/apps/desktop/src/main/plugin-market/ledger.ts
+++ b/apps/desktop/src/main/plugin-market/ledger.ts
@@ -14,7 +14,7 @@ export interface PluginMarketInstallationRecord {
   sha256: string;
   scope: PluginScope;
   organizationId: string | null;
-  source: 'market' | 'legacy-adopted';
+  source: 'market' | 'legacy-adopted' | 'git-market' | 'local-market';
   installed: boolean;
   updatedAt: string;
 }
@@ -46,7 +46,10 @@ function validRecord(value: unknown): value is PluginMarketInstallationRecord {
       record.scope === 'organization' ||
       record.scope === 'personal') &&
     (record.organizationId === null || typeof record.organizationId === 'string') &&
-    (record.source === 'market' || record.source === 'legacy-adopted') &&
+    (record.source === 'market' ||
+      record.source === 'legacy-adopted' ||
+      record.source === 'git-market' ||
+      record.source === 'local-market') &&
     typeof record.installed === 'boolean' &&
     typeof record.updatedAt === 'string'
   );

--- a/apps/desktop/src/main/plugin-market/registerIpc.ts
+++ b/apps/desktop/src/main/plugin-market/registerIpc.ts
@@ -4,7 +4,7 @@ import { isIpcError } from '../../shared/ipc-errors.js';
 import { setGhostUninstallLedgerPreparer } from '../cindy-brain/index.js';
 import { createLogger } from '../logger.js';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer.js';
-import { requireString, throwIpcError } from '../utils/ipcValidate.js';
+import { requireObject, requireString, throwIpcError } from '../utils/ipcValidate.js';
 import { PluginMarketService } from './service.js';
 
 const log = createLogger('plugin-market-ipc');
@@ -76,5 +76,59 @@ export function registerPluginMarketIpc(): void {
     return invokePluginMarket(() =>
       service().uninstall(requireString(pluginId, 'pluginId')),
     );
+  });
+
+  /* ------------------------- 自定义市场源管理 ------------------------- */
+
+  ipcMain.handle('plugin-market:list-sources', (event) => {
+    assertTrustedAppRendererEvent(event);
+    return invokePluginMarket(() => service().listSources());
+  });
+  ipcMain.handle('plugin-market:add-source', (event, payload: unknown) => {
+    assertTrustedAppRendererEvent(event);
+    const obj = requireObject(payload);
+    const source = requireString(obj.source, 'source');
+    if (source.length > 512) throwIpcError('INVALID_PARAMS', 'source is too long');
+    const ref =
+      obj.ref === undefined || obj.ref === null
+        ? undefined
+        : requireString(obj.ref, 'ref');
+    if (ref !== undefined && ref.length > 128) {
+      throwIpcError('INVALID_PARAMS', 'ref is too long');
+    }
+    let sparsePaths: string[] | undefined;
+    if (obj.sparsePaths !== undefined && obj.sparsePaths !== null) {
+      if (!Array.isArray(obj.sparsePaths) || obj.sparsePaths.length > 32) {
+        throwIpcError('INVALID_PARAMS', 'sparsePaths must be an array of at most 32 entries');
+      }
+      sparsePaths = obj.sparsePaths.map((entry) => {
+        const value = requireString(entry, 'sparsePaths entry');
+        if (value.length > 256) throwIpcError('INVALID_PARAMS', 'sparsePaths entry is too long');
+        return value;
+      });
+    }
+    return invokePluginMarket(() =>
+      service().addSource({
+        source,
+        ...(ref !== undefined ? { ref } : {}),
+        ...(sparsePaths !== undefined ? { sparsePaths } : {}),
+      }),
+    );
+  });
+  ipcMain.handle('plugin-market:remove-source', (event, name: unknown) => {
+    assertTrustedAppRendererEvent(event);
+    return invokePluginMarket(() =>
+      service().removeSource(requireString(name, 'name')),
+    );
+  });
+  ipcMain.handle('plugin-market:refresh-source', (event, name: unknown) => {
+    assertTrustedAppRendererEvent(event);
+    return invokePluginMarket(() =>
+      service().refreshSource(requireString(name, 'name')),
+    );
+  });
+  ipcMain.handle('plugin-market:git-preflight', (event) => {
+    assertTrustedAppRendererEvent(event);
+    return invokePluginMarket(() => service().gitPreflight());
   });
 }

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -16,9 +16,16 @@ import {
   type InstalledGhost,
 } from '../../shared/ghost.js';
 import type {
+  MarketSourceConfig,
+  MarketSourceSummary,
   PluginMarketDetail,
   PluginMarketItem,
   PluginMarketSnapshot,
+} from '../../shared/pluginMarket.js';
+import {
+  customMarketPluginId,
+  customMarketReleaseId,
+  parseCustomMarketPluginId,
 } from '../../shared/pluginMarket.js';
 import { getCurrentUserId } from '../authManager.js';
 import {
@@ -39,10 +46,15 @@ import { createLogger } from '../logger.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
 import { PluginMarketApi } from './api.js';
 import { downloadVerifiedPlugin } from './download.js';
+import { installCustomMarketPlugin } from './install.js';
 import {
   PluginMarketLedger,
   type PluginMarketInstallationRecord,
 } from './ledger.js';
+import type { DiscoveredMarketPlugin } from './sources/discover.js';
+import { checkGitPreflight, type GitPreflightResult } from './sources/preflight.js';
+import { MarketSourceManager } from './sources/index.js';
+import { MarketSourceStore } from './sources/store.js';
 
 const log = createLogger('plugin-market');
 const NO_DUPLICATE_GHOST_IDS: ReadonlySet<string> = new Set();
@@ -143,6 +155,26 @@ function ghostIdCounts(
   return counts;
 }
 
+/** 自定义市场发现到的单个插件条目（快照投影的原料）。 */
+interface CustomMarketEntry {
+  config: MarketSourceConfig;
+  plugin: DiscoveredMarketPlugin;
+}
+
+/** 服务端目录 + 自定义市场合并后的重复 ghostId 集合。 */
+function combinedDuplicateGhostIds(
+  plugins: readonly VisiblePluginSummary[],
+  customEntries: readonly CustomMarketEntry[],
+): ReadonlySet<string> {
+  const counts = ghostIdCounts(plugins);
+  for (const entry of customEntries) {
+    counts.set(entry.plugin.ghostId, (counts.get(entry.plugin.ghostId) ?? 0) + 1);
+  }
+  return new Set(
+    [...counts.entries()].filter(([, count]) => count > 1).map(([ghostId]) => ghostId),
+  );
+}
+
 /** Stable local facts reused while projecting one market catalog response. */
 interface LocalInstallSnapshot {
   /** Installed Ghost runtime facts indexed once for one market operation. */
@@ -164,21 +196,33 @@ export class PluginMarketService {
     private readonly ledger = new PluginMarketLedger(() =>
       ownerScopedUserDataPath('plugin-market', 'ledger.v1.json'),
     ),
+    private readonly sourceStore = new MarketSourceStore(() =>
+      ownerScopedUserDataPath('plugin-market', 'sources.v1.json'),
+    ),
   ) {}
 
   async snapshot(): Promise<PluginMarketSnapshot> {
+    // 自定义市场项完全来自本地数据，不依赖服务端与登录态；服务端不可用时
+    // 仍然返回，unavailableReason 只表达服务端部分的不可用。
+    const customEntries = await this.discoverCustomEntriesSafe();
+    const customSourceNames = this.customSourceNamesSafe();
     if (!getClientEndpoint('pluginApiBaseUrl')) {
-      return { items: [], unavailableReason: 'not-configured' };
+      return {
+        items: this.projectCustomItems(customEntries),
+        unavailableReason: customEntries.length > 0 ? null : 'not-configured',
+        customSourceNames,
+      };
     }
     let owner: ActiveAppSession;
     try {
       owner = captureMarketOwner();
     } catch {
       return {
-        items: [],
+        items: this.projectCustomItems(customEntries),
         unavailableReason: isAppSessionBoundaryPending()
           ? 'session-switching'
           : 'authentication-required',
+        customSourceNames,
       };
     }
     let plugins: VisiblePluginSummary[];
@@ -189,8 +233,9 @@ export class PluginMarketService {
         error: error instanceof Error ? error.message : String(error),
       });
       return {
-        items: [],
+        items: this.projectCustomItems(customEntries),
         unavailableReason: error instanceof Error ? error.message : String(error),
+        customSourceNames,
       };
     }
 
@@ -200,10 +245,23 @@ export class PluginMarketService {
     await this.reconcileRemovedInstallations(ledger, owner);
     await this.applyDefaultInstalls(plugins, owner, ledger);
     requireSameMarketOwner(owner);
-    return { items: this.toItems(plugins, ledger), unavailableReason: null };
+    // ghostId 冲突判定跨服务端与自定义市场合并计算（全局唯一、先装先得）。
+    const duplicateGhostIds = combinedDuplicateGhostIds(plugins, customEntries);
+    const local = this.localInstallSnapshot(ledger);
+    const serverItems = plugins.map((plugin) =>
+      this.toItem(plugin, duplicateGhostIds, local),
+    );
+    return {
+      items: [...serverItems, ...this.projectCustomItems(customEntries, duplicateGhostIds, local)],
+      unavailableReason: null,
+      customSourceNames,
+    };
   }
 
   async detail(pluginId: string): Promise<PluginMarketDetail> {
+    // 自定义市场插件走本地发现，不要求服务端可用，也不受 CUID 形状约束。
+    const customRef = parseCustomMarketPluginId(pluginId);
+    if (customRef) return this.customDetail(customRef);
     if (!isValidPluginResourceId(pluginId)) {
       throwIpcError('INVALID_PARAMS', 'Invalid Plugin ID');
     }
@@ -237,6 +295,8 @@ export class PluginMarketService {
       allowPermissionExpansion?: boolean;
     },
   ): Promise<{ ghost: InstalledGhost }> {
+    const customRef = parseCustomMarketPluginId(pluginId);
+    if (customRef) return this.customInstall(customRef, options);
     if (!isValidPluginResourceId(pluginId)) {
       throwIpcError('INVALID_PARAMS', 'Invalid Plugin ID');
     }
@@ -282,7 +342,11 @@ export class PluginMarketService {
   }
 
   async uninstall(pluginId: string): Promise<{ ok: true }> {
-    if (!isValidPluginResourceId(pluginId)) {
+    // 自定义市场插件的卸载走同一账本路径，仅跳过服务端 CUID 形状校验。
+    if (
+      !parseCustomMarketPluginId(pluginId) &&
+      !isValidPluginResourceId(pluginId)
+    ) {
       throwIpcError('INVALID_PARAMS', 'Invalid Plugin ID');
     }
     const owner = captureMarketOwner();
@@ -338,6 +402,250 @@ export class PluginMarketService {
         ledger.markRemoved(ghostId, installSubject);
       });
     };
+  }
+
+  /* ---------------------------------------------------------------------- */
+  /* 自定义市场源（Git / 本地文件夹）                                         */
+  /* ---------------------------------------------------------------------- */
+
+  async listSources(): Promise<MarketSourceSummary[]> {
+    const owner = captureMarketOwner();
+    return this.sourceManagerForOwner(owner).listSources();
+  }
+
+  async addSource(input: {
+    source: string;
+    ref?: string;
+    sparsePaths?: string[];
+  }): Promise<MarketSourceSummary> {
+    const owner = captureMarketOwner();
+    // 源管理操作全局串行：添加期间发现的市场名必须唯一，并行添加会互相覆盖。
+    return this.withMutation('market-sources', async () => {
+      requireSameMarketOwner(owner);
+      return this.sourceManagerForOwner(owner).addSource(input);
+    });
+  }
+
+  async removeSource(name: string): Promise<{ ok: true }> {
+    const owner = captureMarketOwner();
+    return this.withMutation('market-sources', async () => {
+      requireSameMarketOwner(owner);
+      return this.sourceManagerForOwner(owner).removeSource(name);
+    });
+  }
+
+  async refreshSource(name: string): Promise<MarketSourceSummary> {
+    const owner = captureMarketOwner();
+    return this.withMutation('market-sources', async () => {
+      requireSameMarketOwner(owner);
+      return this.sourceManagerForOwner(owner).refreshSource(name);
+    });
+  }
+
+  async gitPreflight(): Promise<GitPreflightResult> {
+    return checkGitPreflight();
+  }
+
+  /** 自定义市场插件详情：本地发现现查，不要求服务端市场可用。 */
+  private async customDetail(ref: {
+    marketName: string;
+    ghostId: string;
+  }): Promise<PluginMarketDetail> {
+    const owner = captureMarketOwner();
+    const manager = this.sourceManagerForOwner(owner);
+    const discovered = await manager.discoverSource(ref.marketName);
+    if (!discovered.result.ok) {
+      throwIpcError(discovered.result.code, discovered.result.detail ?? discovered.result.code);
+    }
+    const plugin = discovered.result.marketplace.plugins.find(
+      (candidate) => candidate.ghostId === ref.ghostId,
+    );
+    if (!plugin) {
+      throwIpcError('NOT_FOUND', 'The Plugin is no longer listed by this marketplace');
+    }
+    return {
+      ...this.customToItem(
+        { config: discovered.config, plugin },
+        NO_DUPLICATE_GHOST_IDS,
+        this.localInstallSnapshot(this.ledgerForOwner(owner)),
+      ),
+      manifest: plugin.manifest,
+    };
+  }
+
+  /**
+   * 自定义市场插件安装/更新。与服务端 installDetail 同一组防线：
+   * release 一致性（重发现后比对 expectedReleaseId）、冲突先装先得、
+   * 权限扩张显式确认；打包与装入复用 installOrUpdateMarketGhostPackage。
+   */
+  private async customInstall(
+    ref: { marketName: string; ghostId: string },
+    options: { expectedReleaseId: string; allowPermissionExpansion?: boolean },
+  ): Promise<{ ghost: InstalledGhost }> {
+    const owner = captureMarketOwner();
+    const ledger = this.ledgerForOwner(owner);
+    const manager = this.sourceManagerForOwner(owner);
+    return this.withMutation(`custom-market:${ref.marketName}/${ref.ghostId}`, async () => {
+      requireSameMarketOwner(owner);
+      const discovered = await manager.discoverSource(ref.marketName);
+      if (!discovered.result.ok) {
+        throwIpcError(discovered.result.code, discovered.result.detail ?? discovered.result.code);
+      }
+      const plugin = discovered.result.marketplace.plugins.find(
+        (candidate) => candidate.ghostId === ref.ghostId,
+      );
+      if (!plugin) {
+        throwIpcError('NOT_FOUND', 'The Plugin is no longer listed by this marketplace');
+      }
+      const pluginId = customMarketPluginId(ref.marketName, plugin.ghostId);
+      const releaseId = customMarketReleaseId(ref.marketName, plugin.ghostId, plugin.version);
+      if (releaseId !== options.expectedReleaseId) {
+        throwIpcError(
+          'PRECONDITION_FAILED',
+          'Plugin release changed after permission review',
+        );
+      }
+      const existing = getGhostManager()
+        .list()
+        .find((ghost) => ghost.manifest.id === plugin.ghostId);
+      const currentRecord = ledger.installationForGhost(plugin.ghostId);
+      if (existing && (!currentRecord?.installed || currentRecord.pluginId !== pluginId)) {
+        throwIpcError('ALREADY_EXISTS', 'A local Plugin already uses this Plugin ID');
+      }
+      if (
+        existing &&
+        diffGhostPermissionItems(existing.manifest, plugin.manifest).added.length > 0 &&
+        options.allowPermissionExpansion !== true
+      ) {
+        throwIpcError('PRECONDITION_FAILED', 'Plugin permissions changed and require review');
+      }
+      requireSameMarketOwner(owner);
+      const ghost = await installCustomMarketPlugin({
+        pluginDir: plugin.dir,
+        expected: { ghostId: plugin.ghostId, version: plugin.version },
+      });
+      // 包目录落位后,溯源写入操作开始时捕获的 owner 账本(与服务端安装同款)。
+      await this.withCapturedLedgerMutation(ledger, () => {
+        ledger.upsertInstallation({
+          pluginId,
+          ghostId: plugin.ghostId,
+          releaseId,
+          version: plugin.version,
+          // 自定义源没有服务端内容哈希;占位值如实表达"未经内容校验"。
+          sha256: 'custom-unverified',
+          scope: 'public',
+          organizationId: null,
+          source: discovered.config.source.type === 'git' ? 'git-market' : 'local-market',
+          installed: true,
+          updatedAt: new Date().toISOString(),
+        });
+      });
+      return { ghost };
+    });
+  }
+
+  /** 已配置来源名（按添加顺序）；存储读取失败时降级为空数组。 */
+  private customSourceNamesSafe(): string[] {
+    try {
+      return this.sourceStore.list().map((source) => source.name);
+    } catch {
+      return [];
+    }
+  }
+
+  /** 快照聚合用：发现全部自定义市场条目。任何失败都降级为空，不拖垮快照。 */
+  private async discoverCustomEntriesSafe(): Promise<CustomMarketEntry[]> {
+    try {
+      const discovered = await new MarketSourceManager({
+        store: this.sourceStore,
+        cloneRoot: ownerScopedUserDataPath('plugin-market', 'sources'),
+      }).discoverAll();
+      const entries: CustomMarketEntry[] = [];
+      for (const { config, result } of discovered) {
+        if (!result.ok) {
+          log.warn('custom marketplace discovery failed', {
+            market: config.name,
+            code: result.code,
+          });
+          continue;
+        }
+        for (const plugin of result.marketplace.plugins) {
+          entries.push({ config, plugin });
+        }
+      }
+      return entries;
+    } catch (error) {
+      log.warn('custom marketplace enumeration failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  private projectCustomItems(
+    entries: readonly CustomMarketEntry[],
+    duplicateGhostIds?: ReadonlySet<string>,
+    local?: LocalInstallSnapshot,
+  ): PluginMarketItem[] {
+    const duplicates =
+      duplicateGhostIds ?? combinedDuplicateGhostIds([], entries);
+    const snapshot = local ?? this.localInstallSnapshot();
+    return entries.map((entry) => this.customToItem(entry, duplicates, snapshot));
+  }
+
+  /** 自定义市场项的状态机与服务端 toItem 完全一致（冲突 / 首装 / 更新 / 已装）。 */
+  private customToItem(
+    entry: CustomMarketEntry,
+    duplicateGhostIds: ReadonlySet<string>,
+    local: LocalInstallSnapshot,
+  ): PluginMarketItem {
+    const { config, plugin } = entry;
+    const pluginId = customMarketPluginId(config.name, plugin.ghostId);
+    const releaseId = customMarketReleaseId(config.name, plugin.ghostId, plugin.version);
+    const ghost = local.ghostsById.get(plugin.ghostId);
+    const record = local.installations[plugin.ghostId];
+    const ownsInstall = Boolean(
+      ghost && record?.installed && record.pluginId === pluginId,
+    );
+    const conflict = Boolean(
+      duplicateGhostIds.has(plugin.ghostId) || (ghost && !ownsInstall),
+    );
+    const installState: PluginMarketItem['installState'] = conflict
+      ? 'conflict'
+      : !ownsInstall
+        ? 'not-installed'
+        : record?.releaseId === releaseId
+          ? 'installed'
+          : 'update-available';
+    return {
+      pluginId,
+      ghostId: plugin.ghostId,
+      name: plugin.manifest.name,
+      description: plugin.manifest.description ?? null,
+      author: plugin.manifest.author ?? null,
+      // scope 是服务端授权概念，自定义市场项无服务端身份;展示层按 sourceType 分流。
+      scope: 'public',
+      organizationId: null,
+      defaultInstall: false,
+      releaseId,
+      version: plugin.version,
+      publishedAt: config.lastSyncedAt ?? config.addedAt,
+      icon: null,
+      installState,
+      enabled: ownsInstall ? (ghost?.enabled ?? null) : null,
+      sourceType: config.source.type === 'git' ? 'git-market' : 'local-market',
+      sourceMarketName: config.name,
+    };
+  }
+
+  private sourceManagerForOwner(owner: ActiveAppSession): MarketSourceManager {
+    requireSameMarketOwner(owner);
+    return new MarketSourceManager({
+      store: this.sourceStore.bind(
+        ownerScopedUserDataPath('plugin-market', 'sources.v1.json'),
+      ),
+      cloneRoot: ownerScopedUserDataPath('plugin-market', 'sources'),
+    });
   }
 
   private async installDetail(
@@ -430,20 +738,6 @@ export class PluginMarketService {
     }
   }
 
-  private toItems(
-    plugins: readonly VisiblePluginSummary[],
-    ledger = this.ledger,
-  ): PluginMarketItem[] {
-    const counts = ghostIdCounts(plugins);
-    const duplicateGhostIds = new Set(
-      plugins
-        .filter((plugin) => (counts.get(plugin.ghostId) ?? 0) > 1)
-        .map((plugin) => plugin.ghostId),
-    );
-    const local = this.localInstallSnapshot(ledger);
-    return plugins.map((plugin) => this.toItem(plugin, duplicateGhostIds, local));
-  }
-
   private toItem(
     plugin: VisiblePluginSummary | VisiblePluginDetail,
     duplicateGhostIds: ReadonlySet<string> = NO_DUPLICATE_GHOST_IDS,
@@ -480,6 +774,8 @@ export class PluginMarketService {
       icon: plugin.currentRelease.icon,
       installState,
       enabled: ownsInstall ? (ghost?.enabled ?? null) : null,
+      sourceType: 'server',
+      sourceMarketName: null,
     };
   }
 

--- a/apps/desktop/src/main/plugin-market/sources/discover.ts
+++ b/apps/desktop/src/main/plugin-market/sources/discover.ts
@@ -1,0 +1,156 @@
+/**
+ * 自定义市场发现：在市场根目录查找 Codex 兼容的 marketplace.json 并解析插件列表。
+ *
+ * 兼容 Codex 的清单位置与基础 schema（name + plugins[]，source 为相对路径或
+ * {source:"local",path}），但插件本体必须是 Cindy 插件（目录内含合法 ghost.json）。
+ * 清单里的描述性字段不作为事实来源——展示与安装一律以 ghost.json 为准。
+ *
+ * 容错策略与 Codex 一致：单个插件条目非法只跳过并记日志，不让整个市场不可用。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { validateGhostManifest, type GhostManifest } from '../../../shared/ghost.js';
+
+/** 与 Codex 相同的清单位置，按优先级查找。 */
+export const MARKETPLACE_MANIFEST_PATHS = [
+  '.agents/plugins/marketplace.json',
+  '.agents/plugins/api_marketplace.json',
+  '.claude-plugin/marketplace.json',
+  '.cursor-plugin/marketplace.json',
+] as const;
+
+export type DiscoverError =
+  | 'MARKET_MANIFEST_MISSING'
+  | 'MARKET_SOURCE_INVALID';
+
+export interface DiscoveredMarketPlugin {
+  ghostId: string;
+  version: string;
+  /** 插件目录的绝对路径（已校验不越出市场根目录）。 */
+  dir: string;
+  manifest: GhostManifest;
+}
+
+export interface DiscoveredMarketplace {
+  name: string;
+  displayName: string | null;
+  plugins: DiscoveredMarketPlugin[];
+  /** 被跳过的插件条目数（非法 source / 缺 ghost.json / 校验失败）。 */
+  skippedCount: number;
+}
+
+export type DiscoverResult =
+  | { ok: true; marketplace: DiscoveredMarketplace }
+  | { ok: false; code: DiscoverError; detail?: string };
+
+interface RawMarketplaceManifest {
+  name?: unknown;
+  interface?: unknown;
+  plugins?: unknown;
+}
+
+/** 解析插件条目的 source 字段为市场内相对路径；不支持的形态返回 null。 */
+function pluginEntryRelativePath(source: unknown): string | null {
+  if (typeof source === 'string') return source;
+  if (source && typeof source === 'object' && !Array.isArray(source)) {
+    const record = source as Record<string, unknown>;
+    if (record.source === 'local' && typeof record.path === 'string') return record.path;
+    // url / git-subdir / npm 形态的远程插件源 Phase 1 不支持。
+    return null;
+  }
+  return null;
+}
+
+/** 解析并校验单个插件目录；非法时返回 null（调用方计数跳过）。 */
+function resolvePluginDir(
+  marketRoot: string,
+  relPath: string,
+): DiscoveredMarketPlugin | null {
+  const trimmed = relPath.trim();
+  if (!trimmed || path.isAbsolute(trimmed) || /^[A-Za-z]:/.test(trimmed)) return null;
+  const dir = path.resolve(marketRoot, trimmed);
+  const rootWithSep = marketRoot.endsWith(path.sep) ? marketRoot : `${marketRoot}${path.sep}`;
+  if (dir !== marketRoot && !dir.startsWith(rootWithSep)) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(path.join(dir, 'ghost.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+  const validated = validateGhostManifest(raw);
+  if (!validated.ok) return null;
+  return {
+    ghostId: validated.manifest.id,
+    version: validated.manifest.version,
+    dir,
+    manifest: validated.manifest,
+  };
+}
+
+/**
+ * 在市场根目录发现插件。marketRoot 必须已存在（调用方负责克隆/路径校验）。
+ */
+export async function discoverMarketplace(marketRoot: string): Promise<DiscoverResult> {
+  let manifestPath: string | null = null;
+  for (const relPath of MARKETPLACE_MANIFEST_PATHS) {
+    const candidate = path.join(marketRoot, ...relPath.split('/'));
+    if (fs.existsSync(candidate)) {
+      manifestPath = candidate;
+      break;
+    }
+  }
+  if (!manifestPath) return { ok: false, code: 'MARKET_MANIFEST_MISSING' };
+
+  let raw: RawMarketplaceManifest;
+  try {
+    raw = JSON.parse(await fs.promises.readFile(manifestPath, 'utf8')) as RawMarketplaceManifest;
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'MARKET_SOURCE_INVALID',
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (!raw || typeof raw.name !== 'string' || raw.name.trim().length === 0) {
+    return { ok: false, code: 'MARKET_SOURCE_INVALID', detail: 'marketplace.json missing name' };
+  }
+  if (!Array.isArray(raw.plugins)) {
+    return { ok: false, code: 'MARKET_SOURCE_INVALID', detail: 'marketplace.json plugins must be an array' };
+  }
+
+  const displayName =
+    raw.interface &&
+    typeof raw.interface === 'object' &&
+    !Array.isArray(raw.interface) &&
+    typeof (raw.interface as Record<string, unknown>).displayName === 'string'
+      ? ((raw.interface as Record<string, unknown>).displayName as string)
+      : null;
+
+  const plugins: DiscoveredMarketPlugin[] = [];
+  const seenGhostIds = new Set<string>();
+  let skippedCount = 0;
+  for (const entry of raw.plugins) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      skippedCount += 1;
+      continue;
+    }
+    const relPath = pluginEntryRelativePath((entry as Record<string, unknown>).source);
+    if (!relPath) {
+      skippedCount += 1;
+      continue;
+    }
+    const plugin = resolvePluginDir(marketRoot, relPath);
+    if (!plugin || seenGhostIds.has(plugin.ghostId)) {
+      skippedCount += 1;
+      continue;
+    }
+    seenGhostIds.add(plugin.ghostId);
+    plugins.push(plugin);
+  }
+
+  return {
+    ok: true,
+    marketplace: { name: raw.name.trim(), displayName, plugins, skippedCount },
+  };
+}

--- a/apps/desktop/src/main/plugin-market/sources/git.ts
+++ b/apps/desktop/src/main/plugin-market/sources/git.ts
@@ -1,0 +1,179 @@
+/**
+ * 自定义市场的 Git 操作。
+ *
+ * 与 Codex 同一策略：私有仓库认证完全交给用户系统级 Git 配置
+ * （credential helper / SSH agent / gh auth），客户端不做任何特殊处理。
+ * 唯一的强约束是 GIT_TERMINAL_PROMPT=0 —— Electron 主进程没有 TTY，
+ * 缺少凭证的克隆必须立即失败并分类引导，绝不能挂在隐形的密码提示上。
+ */
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import type { IpcErrorCode } from '../../../shared/ipc-errors.js';
+
+/** 克隆/拉取超时：大仓库给足窗口，但绝不无限挂起。 */
+const GIT_OPERATION_TIMEOUT_MS = 5 * 60 * 1000;
+/** sparse-checkout 需要 Git >= 2.25。 */
+export const MIN_GIT_VERSION = { major: 2, minor: 25 } as const;
+
+/** 带 IPC 错误码的市场 Git 失败；service 层原样转成 throwIpcError。 */
+export class MarketGitError extends Error {
+  constructor(
+    readonly code: Extract<
+      IpcErrorCode,
+      'MARKET_GIT_UNAVAILABLE' | 'MARKET_CLONE_AUTH_FAILED' | 'MARKET_CLONE_FAILED'
+    >,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'MarketGitError';
+  }
+}
+
+export interface GitExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+/** 可注入的 git 执行器：单测用 fake，生产走 execFile。 */
+export type GitExecutor = (
+  args: readonly string[],
+  options: { cwd?: string; timeoutMs: number },
+) => Promise<GitExecResult>;
+
+const defaultExecutor: GitExecutor = (args, options) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      [...args],
+      {
+        cwd: options.cwd,
+        timeout: options.timeoutMs,
+        maxBuffer: 16 * 1024 * 1024,
+        env: {
+          ...process.env,
+          GIT_TERMINAL_PROMPT: '0',
+          // Windows 上凭据管理器可能尝试弹 UI；与 TERMINAL_PROMPT 一起双保险。
+          GCM_INTERACTIVE: 'never',
+        },
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(Object.assign(error, { stderr }));
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+
+function errorText(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const stderr = 'stderr' in error ? String((error as { stderr?: unknown }).stderr ?? '') : '';
+    const message = error instanceof Error ? error.message : String(error);
+    return `${message}\n${stderr}`;
+  }
+  return String(error);
+}
+
+/** 把 git 失败分类成可引导的 IPC 错误码；认证与网络之外的保留原始信息进日志。 */
+export function classifyGitFailure(error: unknown): MarketGitError {
+  const text = errorText(error);
+  if (/Authentication failed|could not read Username|Repository not found|Permission denied \(publickey\)|Host key verification failed/i.test(text)) {
+    return new MarketGitError('MARKET_CLONE_AUTH_FAILED', text.slice(0, 512));
+  }
+  return new MarketGitError('MARKET_CLONE_FAILED', text.slice(0, 512));
+}
+
+export async function gitVersion(
+  executor: GitExecutor = defaultExecutor,
+): Promise<{ major: number; minor: number } | null> {
+  try {
+    const { stdout } = await executor(['--version'], { timeoutMs: 10_000 });
+    const match = /git version (\d+)\.(\d+)/.exec(stdout);
+    if (!match) return null;
+    return { major: Number(match[1]), minor: Number(match[2]) };
+  } catch {
+    return null;
+  }
+}
+
+export function isGitVersionSupported(version: { major: number; minor: number }): boolean {
+  if (version.major !== MIN_GIT_VERSION.major) return version.major > MIN_GIT_VERSION.major;
+  return version.minor >= MIN_GIT_VERSION.minor;
+}
+
+/**
+ * 克隆市场仓库到 destPath（staging + rename 原子替换；Windows 不允许 rename
+ * 覆盖非空目录，因此调用方需保证 destPath 不存在或先移除）。
+ */
+export async function cloneMarketplace(
+  input: { url: string; ref?: string; sparsePaths: readonly string[] },
+  destPath: string,
+  executor: GitExecutor = defaultExecutor,
+): Promise<string> {
+  const stagingPath = `${destPath}.staging-${crypto.randomUUID()}`;
+  const timeoutMs = GIT_OPERATION_TIMEOUT_MS;
+  try {
+    if (input.sparsePaths.length === 0) {
+      const args = ['clone'];
+      if (input.ref) args.push('--branch', input.ref);
+      args.push(input.url, stagingPath);
+      await executor(args, { timeoutMs });
+    } else {
+      await executor(
+        ['clone', '--filter=blob:none', '--no-checkout', input.url, stagingPath],
+        { timeoutMs },
+      );
+      await executor(['sparse-checkout', 'set', ...input.sparsePaths], {
+        cwd: stagingPath,
+        timeoutMs,
+      });
+      await executor(['checkout', input.ref ?? 'HEAD'], { cwd: stagingPath, timeoutMs });
+    }
+    await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+    await fs.promises.rename(stagingPath, destPath);
+    return await currentRevision(destPath, executor);
+  } catch (error) {
+    await fs.promises.rm(stagingPath, { recursive: true, force: true }).catch(() => undefined);
+    throw classifyGitFailure(error);
+  }
+}
+
+/**
+ * 刷新已克隆市场：fetch + 快进到上游。返回新 HEAD SHA。
+ * 用户在克隆目录里的本地改动不属于支持场景——市场目录是客户端管理的缓存，
+ * 快进失败按刷新失败处理，由调用方决定重克隆。
+ */
+export async function fetchMarketplace(
+  marketPath: string,
+  ref: string | undefined,
+  executor: GitExecutor = defaultExecutor,
+): Promise<string> {
+  const timeoutMs = GIT_OPERATION_TIMEOUT_MS;
+  try {
+    if (ref) {
+      // 显式引用：对齐远端该 ref（branch/tag/commit 统一用 FETCH_HEAD 落位）。
+      await executor(['fetch', 'origin', ref], { cwd: marketPath, timeoutMs });
+      await executor(['reset', '--hard', 'FETCH_HEAD'], { cwd: marketPath, timeoutMs });
+    } else {
+      await executor(['pull', '--ff-only'], { cwd: marketPath, timeoutMs });
+    }
+    return await currentRevision(marketPath, executor);
+  } catch (error) {
+    throw classifyGitFailure(error);
+  }
+}
+
+export async function currentRevision(
+  marketPath: string,
+  executor: GitExecutor = defaultExecutor,
+): Promise<string> {
+  const { stdout } = await executor(['rev-parse', 'HEAD'], {
+    cwd: marketPath,
+    timeoutMs: 10_000,
+  });
+  return stdout.trim();
+}

--- a/apps/desktop/src/main/plugin-market/sources/index.ts
+++ b/apps/desktop/src/main/plugin-market/sources/index.ts
@@ -1,0 +1,317 @@
+/**
+ * 自定义市场源管理器：添加 / 移除 / 刷新 / 发现的统一入口。
+ *
+ * 实例按 owner 构造（store 与 cloneRoot 已由调用方绑定到操作开始时的
+ * dataOwner），与 PluginMarketService 的 ledger 同一套 owner 捕获语义。
+ *
+ * 不变量：
+ * - Git 克隆目录是客户端管理的缓存，路径只由 (name, source) 派生，用户不应
+ *   手动编辑；刷新失败时整目录重克隆 + 原子替换，不留半拉子状态。
+ * - 市场名来自 marketplace.json，全局唯一；同名不同源拒绝添加。
+ * - 移除来源只删配置与克隆缓存，已安装插件的包目录与 ledger 记录保留。
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import type {
+  MarketSource,
+  MarketSourceConfig,
+  MarketSourceSummary,
+} from '../../../shared/pluginMarket.js';
+import { throwIpcError } from '../../utils/ipcValidate.js';
+import { discoverMarketplace, type DiscoveredMarketplace, type DiscoverError } from './discover.js';
+import {
+  MarketGitError,
+  cloneMarketplace,
+  fetchMarketplace,
+  type GitExecutor,
+} from './git.js';
+import { checkGitPreflight as checkGitPreflightImpl } from './preflight.js';
+import { parseMarketSource } from './parse.js';
+import { MarketSourceStore } from './store.js';
+
+export interface MarketSourceManagerDeps {
+  store: MarketSourceStore;
+  /** Git 克隆缓存根目录（owner 作用域）。 */
+  cloneRoot: string;
+  gitExecutor?: GitExecutor;
+  homeDir?: string;
+  now?: () => string;
+}
+
+export interface DiscoveredSource {
+  config: MarketSourceConfig;
+  result:
+    | { ok: true; marketplace: DiscoveredMarketplace }
+    | { ok: false; code: DiscoverError; detail?: string };
+}
+
+/** 克隆目录名：可读的市场名片段 + 来源指纹，避免同名不同源互相覆盖。 */
+export function marketCloneSlug(name: string, source: MarketSource): string {
+  const key =
+    source.type === 'local'
+      ? `local:${source.path}`
+      : `git:${source.url}#${source.ref ?? ''}:${source.sparsePaths.join(',')}`;
+  const hash = crypto.createHash('sha256').update(key).digest('hex').slice(0, 10);
+  const base =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40) || 'market';
+  return `${base}-${hash}`;
+}
+
+export class MarketSourceManager {
+  constructor(private readonly deps: MarketSourceManagerDeps) {}
+
+  private now(): string {
+    return this.deps.now?.() ?? new Date().toISOString();
+  }
+
+  private cloneDir(config: Pick<MarketSourceConfig, 'name' | 'source'>): string {
+    return path.join(this.deps.cloneRoot, marketCloneSlug(config.name, config.source));
+  }
+
+  /** 来源的市场根目录：Git 源指向克隆缓存，本地源指向用户目录。 */
+  private marketRoot(config: MarketSourceConfig): string {
+    return config.source.type === 'local' ? config.source.path : this.cloneDir(config);
+  }
+
+  async addSource(input: {
+    source: string;
+    ref?: string;
+    sparsePaths?: string[];
+  }): Promise<MarketSourceSummary> {
+    const parsed = parseMarketSource(input, this.deps.homeDir ?? os.homedir());
+    if (!parsed.ok) {
+      throwIpcError('MARKET_SOURCE_INVALID', parsed.code);
+    }
+    const source = parsed.source;
+
+    if (this.deps.store.hasEquivalent(source)) {
+      throwIpcError('ALREADY_EXISTS', 'This marketplace source has already been added');
+    }
+
+    if (source.type === 'local') {
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(source.path);
+      } catch {
+        throwIpcError('MARKET_SOURCE_INVALID', 'LOCAL_SOURCE_NOT_DIRECTORY');
+      }
+      if (!stat!.isDirectory()) {
+        throwIpcError('MARKET_SOURCE_INVALID', 'LOCAL_SOURCE_NOT_DIRECTORY');
+      }
+      return this.commitDiscoveredSource(source, source.path, null);
+    }
+
+    // Git 源：前置检测 → 克隆到临时目录 → 发现 → 更名进正式缓存目录。
+    const preflight = await checkGitPreflightImpl(this.deps.gitExecutor);
+    if (!preflight.ok) {
+      throwIpcError('MARKET_GIT_UNAVAILABLE', preflight.version ?? 'git not found');
+    }
+    const incoming = path.join(this.deps.cloneRoot, `.incoming-${crypto.randomUUID()}`);
+    let revision: string;
+    try {
+      revision = await cloneMarketplace(
+        { url: source.url, ...(source.ref ? { ref: source.ref } : {}), sparsePaths: source.sparsePaths },
+        incoming,
+        this.deps.gitExecutor,
+      );
+    } catch (error) {
+      if (error instanceof MarketGitError) throwIpcError(error.code, error.message);
+      throw error;
+    }
+    try {
+      return await this.commitDiscoveredSource(source, incoming, revision);
+    } catch (error) {
+      await fs.promises.rm(incoming, { recursive: true, force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  /**
+   * 发现 + 校验 + 落盘。Git 源的 discoveredRoot 先落在临时目录，持久化成功后
+   * 才更名为正式克隆目录（按 slug 派生）；名称冲突等失败由调用方清理临时目录。
+   */
+  private async commitDiscoveredSource(
+    source: MarketSource,
+    discoveredRoot: string,
+    revision: string | null,
+  ): Promise<MarketSourceSummary> {
+    const discovered = await discoverMarketplace(discoveredRoot);
+    if (!discovered.ok) {
+      throwIpcError(discovered.code, discovered.detail ?? discovered.code);
+    }
+    const name = discovered.marketplace.name;
+    if (this.deps.store.get(name)) {
+      throwIpcError('ALREADY_EXISTS', `A marketplace named "${name}" has already been added`);
+    }
+    const config: MarketSourceConfig = {
+      name,
+      addedAt: this.now(),
+      lastSyncedAt: this.now(),
+      lastRevision: revision,
+      source,
+    };
+    if (source.type === 'git') {
+      const finalDir = this.cloneDir(config);
+      await fs.promises.rm(finalDir, { recursive: true, force: true }).catch(() => undefined);
+      await fs.promises.rename(discoveredRoot, finalDir);
+    }
+    this.deps.store.add(config);
+    return this.toSummary(config, discovered.marketplace);
+  }
+
+  async removeSource(name: string): Promise<{ ok: true }> {
+    const removed = this.deps.store.remove(name);
+    if (!removed) {
+      throwIpcError('NOT_FOUND', 'The marketplace source is not added');
+    }
+    if (removed.source.type === 'git') {
+      await fs.promises
+        .rm(this.cloneDir(removed), { recursive: true, force: true })
+        .catch(() => undefined);
+    }
+    return { ok: true };
+  }
+
+  async refreshSource(name: string): Promise<MarketSourceSummary> {
+    const config = this.deps.store.get(name);
+    if (!config) {
+      throwIpcError('NOT_FOUND', 'The marketplace source is not added');
+    }
+
+    if (config.source.type === 'local') {
+      if (!fs.existsSync(config.source.path)) {
+        throwIpcError('MARKET_SOURCE_INVALID', 'LOCAL_SOURCE_NOT_DIRECTORY');
+      }
+      const discovered = await discoverMarketplace(config.source.path);
+      if (!discovered.ok) {
+        throwIpcError(discovered.code, discovered.detail ?? discovered.code);
+      }
+      this.deps.store.update(name, { lastSyncedAt: this.now() });
+      return this.toSummary({ ...config, lastSyncedAt: this.now() }, discovered.marketplace);
+    }
+
+    const preflight = await checkGitPreflightImpl(this.deps.gitExecutor);
+    if (!preflight.ok) {
+      throwIpcError('MARKET_GIT_UNAVAILABLE', preflight.version ?? 'git not found');
+    }
+    const cloneDir = this.cloneDir(config);
+    const gitSource = config.source;
+    let revision: string;
+    try {
+      revision = await fetchMarketplace(cloneDir, gitSource.ref, this.deps.gitExecutor);
+    } catch {
+      // 快进失败（历史改写 / 缓存损坏）：整目录重克隆 + 原子替换。
+      const staging = `${cloneDir}.restage-${crypto.randomUUID()}`;
+      try {
+        revision = await cloneMarketplace(
+          {
+            url: gitSource.url,
+            ...(gitSource.ref ? { ref: gitSource.ref } : {}),
+            sparsePaths: gitSource.sparsePaths,
+          },
+          staging,
+          this.deps.gitExecutor,
+        );
+      } catch (error) {
+        if (error instanceof MarketGitError) throwIpcError(error.code, error.message);
+        throw error;
+      }
+      await fs.promises.rm(cloneDir, { recursive: true, force: true }).catch(() => undefined);
+      await fs.promises.rename(staging, cloneDir);
+    }
+    const discovered = await discoverMarketplace(cloneDir);
+    if (!discovered.ok) {
+      throwIpcError(discovered.code, discovered.detail ?? discovered.code);
+    }
+    const syncedAt = this.now();
+    this.deps.store.update(name, { lastSyncedAt: syncedAt, lastRevision: revision });
+    return this.toSummary(
+      { ...config, lastSyncedAt: syncedAt, lastRevision: revision },
+      discovered.marketplace,
+    );
+  }
+
+  getConfig(name: string): MarketSourceConfig | null {
+    return this.deps.store.get(name);
+  }
+
+  /** 发现单个来源（详情 / 安装入口现查事实用）。 */
+  async discoverSource(name: string): Promise<DiscoveredSource> {
+    const config = this.deps.store.get(name);
+    if (!config) {
+      throwIpcError('NOT_FOUND', 'The marketplace source is not added');
+    }
+    const root = this.marketRoot(config!);
+    if (!fs.existsSync(root)) {
+      return {
+        config: config!,
+        result: { ok: false, code: 'MARKET_SOURCE_INVALID', detail: 'market root missing' },
+      };
+    }
+    const discovered = await discoverMarketplace(root);
+    return {
+      config: config!,
+      result: discovered.ok
+        ? { ok: true, marketplace: discovered.marketplace }
+        : { ok: false, code: discovered.code, ...(discovered.detail ? { detail: discovered.detail } : {}) },
+    };
+  }
+
+  /** 管理视图用：全部来源 + 实时发现状态。单个源失败不影响其它源。 */
+  async listSources(): Promise<MarketSourceSummary[]> {
+    const discovered = await this.discoverAll();
+    return discovered.map((entry) =>
+      entry.result.ok
+        ? this.toSummary(entry.config, entry.result.marketplace)
+        : {
+            ...entry.config,
+            pluginCount: 0,
+            status: 'error' as const,
+            errorCode: entry.result.code,
+          },
+    );
+  }
+
+  /** 快照聚合用：全部来源的发现结果（含失败）。 */
+  async discoverAll(): Promise<DiscoveredSource[]> {
+    const configs = this.deps.store.list();
+    const results: DiscoveredSource[] = [];
+    for (const config of configs) {
+      const root = this.marketRoot(config);
+      if (!fs.existsSync(root)) {
+        results.push({
+          config,
+          result: { ok: false, code: 'MARKET_SOURCE_INVALID', detail: 'market root missing' },
+        });
+        continue;
+      }
+      const discovered = await discoverMarketplace(root);
+      results.push({
+        config,
+        result: discovered.ok
+          ? { ok: true, marketplace: discovered.marketplace }
+          : { ok: false, code: discovered.code, ...(discovered.detail ? { detail: discovered.detail } : {}) },
+      });
+    }
+    return results;
+  }
+
+  private toSummary(
+    config: MarketSourceConfig,
+    marketplace: DiscoveredMarketplace,
+  ): MarketSourceSummary {
+    return {
+      ...config,
+      pluginCount: marketplace.plugins.length,
+      status: 'ok',
+      errorCode: null,
+    };
+  }
+}

--- a/apps/desktop/src/main/plugin-market/sources/parse.ts
+++ b/apps/desktop/src/main/plugin-market/sources/parse.ts
@@ -1,0 +1,102 @@
+/**
+ * 自定义插件市场来源解析。
+ *
+ * 把用户输入（GitHub shorthand / Git URL / 本地路径）归一成 MarketSource。
+ * 纯函数、无副作用：本地路径只做形状判断，存在性检查由 SourceManager 在
+ * 添加时执行（parse 阶段不碰文件系统，便于单测与 Renderer 即时校验复用）。
+ */
+import path from 'node:path';
+
+import type { MarketSource } from '../../../shared/pluginMarket.js';
+
+export type MarketSourceParseError =
+  | 'EMPTY_SOURCE'
+  | 'REF_NOT_ALLOWED_FOR_LOCAL'
+  | 'SPARSE_NOT_ALLOWED_FOR_LOCAL'
+  | 'INVALID_SOURCE_FORMAT'
+  | 'INVALID_REF'
+  | 'INVALID_SPARSE_PATH';
+
+export type MarketSourceParseResult =
+  | { ok: true; source: MarketSource }
+  | { ok: false; code: MarketSourceParseError };
+
+/** Git 引用（branch / tag / commit）允许的字符集；拒绝选项注入（- 开头）与路径穿越。 */
+const REF_PATTERN = /^(?!-)[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
+/** GitHub shorthand：owner/repo，各段为常见 GitHub 命名字符。 */
+const GITHUB_SHORTHAND_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+const GIT_URL_PATTERN = /^(https:\/\/|ssh:\/\/|git:\/\/|git@)[^\s]+$/i;
+
+function looksLikeLocalPath(input: string): boolean {
+  if (input.startsWith('~')) return true;
+  if (path.isAbsolute(input)) return true;
+  // Windows 盘符路径（C:\... / C:/...）。
+  if (/^[A-Za-z]:[\\/]/.test(input)) return true;
+  // 显式相对路径（./plugins、../shared）按本地路径对待。
+  if (input.startsWith('./') || input.startsWith('../') || input.startsWith('.\\') || input.startsWith('..\\')) {
+    return true;
+  }
+  return false;
+}
+
+/** 展开 ~ 并归一化；不解析符号链接（归属判断由安装管道负责）。 */
+export function resolveLocalSourcePath(input: string, homeDir: string): string {
+  const expanded = input.startsWith('~')
+    ? path.join(homeDir, input.slice(1).replace(/^[/\\]/, ''))
+    : input;
+  return path.resolve(expanded);
+}
+
+function validSparsePaths(paths: readonly string[]): boolean {
+  return paths.every((entry) => {
+    const trimmed = entry.trim();
+    if (!trimmed || trimmed.length > 256) return false;
+    if (trimmed.startsWith('/') || trimmed.startsWith('\\')) return false;
+    if (/^[A-Za-z]:/.test(trimmed)) return false;
+    // 拒绝路径穿越；sparse-checkout 只允许仓库内相对目录。
+    return !trimmed.split(/[/\\]/).includes('..');
+  });
+}
+
+/**
+ * 解析用户输入的市场来源。`homeDir` 由调用方注入（Main 取 os.homedir()，
+ * 测试注入固定值），保持本模块不直接读进程环境。
+ */
+export function parseMarketSource(
+  input: { source: string; ref?: string; sparsePaths?: string[] },
+  homeDir: string,
+): MarketSourceParseResult {
+  const trimmed = input.source.trim();
+  const ref = input.ref?.trim() || undefined;
+  const sparsePaths = (input.sparsePaths ?? [])
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (!trimmed) return { ok: false, code: 'EMPTY_SOURCE' };
+  if (ref && !REF_PATTERN.test(ref)) return { ok: false, code: 'INVALID_REF' };
+  if (!validSparsePaths(sparsePaths)) return { ok: false, code: 'INVALID_SPARSE_PATH' };
+
+  if (looksLikeLocalPath(trimmed)) {
+    if (ref) return { ok: false, code: 'REF_NOT_ALLOWED_FOR_LOCAL' };
+    if (sparsePaths.length > 0) return { ok: false, code: 'SPARSE_NOT_ALLOWED_FOR_LOCAL' };
+    return { ok: true, source: { type: 'local', path: resolveLocalSourcePath(trimmed, homeDir) } };
+  }
+
+  if (GIT_URL_PATTERN.test(trimmed)) {
+    return { ok: true, source: { type: 'git', url: trimmed, ...(ref ? { ref } : {}), sparsePaths } };
+  }
+
+  if (GITHUB_SHORTHAND_PATTERN.test(trimmed)) {
+    return {
+      ok: true,
+      source: {
+        type: 'git',
+        url: `https://github.com/${trimmed}.git`,
+        ...(ref ? { ref } : {}),
+        sparsePaths,
+      },
+    };
+  }
+
+  return { ok: false, code: 'INVALID_SOURCE_FORMAT' };
+}

--- a/apps/desktop/src/main/plugin-market/sources/preflight.ts
+++ b/apps/desktop/src/main/plugin-market/sources/preflight.ts
@@ -1,0 +1,28 @@
+/**
+ * Git 环境前置检测。
+ *
+ * 打开添加市场对话框时调用一次：Git 缺失或版本过低时禁用 Git 来源的添加
+ * （本地来源不受影响）。结果不缓存——用户可能在会话中途装好 Git。
+ */
+import {
+  gitVersion,
+  isGitVersionSupported,
+  type GitExecutor,
+} from './git.js';
+
+export interface GitPreflightResult {
+  ok: boolean;
+  /** 检测到的版本文本（如 "2.43.0"）；未安装/执行失败为 null。 */
+  version: string | null;
+}
+
+export async function checkGitPreflight(
+  executor?: GitExecutor,
+): Promise<GitPreflightResult> {
+  const version = await gitVersion(executor);
+  if (!version) return { ok: false, version: null };
+  return {
+    ok: isGitVersionSupported(version),
+    version: `${version.major}.${version.minor}`,
+  };
+}

--- a/apps/desktop/src/main/plugin-market/sources/store.ts
+++ b/apps/desktop/src/main/plugin-market/sources/store.ts
@@ -1,0 +1,164 @@
+/**
+ * 自定义市场来源配置的持久化（sources.v1.json）。
+ *
+ * 与 PluginMarketLedger 同一套约定：schemaVersion 闸、逐条校验、原子写
+ * （临时文件 + rename，Windows 下先删目标重试）、0o600。只存来源配置，
+ * 不复制发现到的插件数据——快照时重新发现，磁盘上的克隆目录才是事实。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import type { MarketSource, MarketSourceConfig } from '../../../shared/pluginMarket.js';
+
+const SOURCES_SCHEMA_VERSION = 1;
+
+interface MarketSourcesData {
+  schemaVersion: typeof SOURCES_SCHEMA_VERSION;
+  sources: MarketSourceConfig[];
+}
+
+function emptySources(): MarketSourcesData {
+  return { schemaVersion: SOURCES_SCHEMA_VERSION, sources: [] };
+}
+
+function validSource(value: unknown): value is MarketSource {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const source = value as Record<string, unknown>;
+  if (source.type === 'local') {
+    return typeof source.path === 'string' && source.path.length > 0;
+  }
+  if (source.type === 'git') {
+    return (
+      typeof source.url === 'string' &&
+      source.url.length > 0 &&
+      (source.ref === undefined || typeof source.ref === 'string') &&
+      Array.isArray(source.sparsePaths) &&
+      (source.sparsePaths as unknown[]).every((entry) => typeof entry === 'string')
+    );
+  }
+  return false;
+}
+
+function validConfig(value: unknown): value is MarketSourceConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const config = value as Record<string, unknown>;
+  return (
+    typeof config.name === 'string' &&
+    config.name.length > 0 &&
+    typeof config.addedAt === 'string' &&
+    (config.lastSyncedAt === null || typeof config.lastSyncedAt === 'string') &&
+    (config.lastRevision === null || typeof config.lastRevision === 'string') &&
+    validSource(config.source)
+  );
+}
+
+export class MarketSourceStore {
+  constructor(private readonly filePathSource: string | (() => string)) {}
+
+  /**
+   * Binds a dynamic owner-scoped store to the path captured at operation start.
+   * Mirrors PluginMarketLedger.bind so owner switches never cross-write state.
+   */
+  bind(filePath: string): MarketSourceStore {
+    return typeof this.filePathSource === 'function'
+      ? new MarketSourceStore(filePath)
+      : this;
+  }
+
+  private filePath(): string {
+    return typeof this.filePathSource === 'function'
+      ? this.filePathSource()
+      : this.filePathSource;
+  }
+
+  list(): MarketSourceConfig[] {
+    return this.read().sources;
+  }
+
+  get(name: string): MarketSourceConfig | null {
+    return this.read().sources.find((source) => source.name === name) ?? null;
+  }
+
+  /** 追加新来源；调用方负责先完成名称与重复来源校验。 */
+  add(config: MarketSourceConfig): void {
+    const data = this.read();
+    data.sources = [...data.sources.filter((source) => source.name !== config.name), config];
+    this.write(data);
+  }
+
+  update(name: string, patch: Partial<Pick<MarketSourceConfig, 'lastSyncedAt' | 'lastRevision'>>): void {
+    const data = this.read();
+    const index = data.sources.findIndex((source) => source.name === name);
+    if (index < 0) return;
+    data.sources[index] = { ...data.sources[index]!, ...patch };
+    this.write(data);
+  }
+
+  remove(name: string): MarketSourceConfig | null {
+    const data = this.read();
+    const existing = data.sources.find((source) => source.name === name) ?? null;
+    if (!existing) return null;
+    data.sources = data.sources.filter((source) => source.name !== name);
+    this.write(data);
+    return existing;
+  }
+
+  /** 重复添加判定：来源类型 + 定位 + 引用 + 稀疏路径全部一致视为同一来源。 */
+  hasEquivalent(source: MarketSource): boolean {
+    return this.read().sources.some((config) => sourcesEqual(config.source, source));
+  }
+
+  private read(): MarketSourcesData {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(fs.readFileSync(this.filePath(), 'utf8'));
+    } catch {
+      return emptySources();
+    }
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return emptySources();
+    const value = raw as Record<string, unknown>;
+    if (value.schemaVersion !== SOURCES_SCHEMA_VERSION) return emptySources();
+    if (!Array.isArray(value.sources)) return emptySources();
+    return { schemaVersion: SOURCES_SCHEMA_VERSION, sources: value.sources.filter(validConfig) };
+  }
+
+  private write(data: MarketSourcesData): void {
+    const filePath = this.filePath();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const tempPath = `${filePath}.${crypto.randomUUID()}.tmp`;
+    try {
+      fs.writeFileSync(tempPath, `${JSON.stringify(data, null, 2)}\n`, {
+        mode: 0o600,
+        flag: 'wx',
+      });
+      try {
+        fs.renameSync(tempPath, filePath);
+      } catch (error) {
+        const code = error && typeof error === 'object' && 'code' in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+        if (process.platform !== 'win32' || (code !== 'EPERM' && code !== 'EEXIST')) {
+          throw error;
+        }
+        fs.rmSync(filePath, { force: true });
+        fs.renameSync(tempPath, filePath);
+      }
+    } finally {
+      fs.rmSync(tempPath, { force: true });
+    }
+  }
+}
+
+export function sourcesEqual(a: MarketSource, b: MarketSource): boolean {
+  if (a.type !== b.type) return false;
+  if (a.type === 'local' && b.type === 'local') return a.path === b.path;
+  if (a.type === 'git' && b.type === 'git') {
+    return (
+      a.url === b.url &&
+      (a.ref ?? null) === (b.ref ?? null) &&
+      a.sparsePaths.join('\n') === b.sparsePaths.join('\n')
+    );
+  }
+  return false;
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -989,6 +989,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('plugin-market:install', pluginId, options),
     uninstall: (pluginId: string): Promise<{ ok: true }> =>
       ipcRenderer.invoke('plugin-market:uninstall', pluginId),
+    listSources: (): Promise<import('../shared/pluginMarket').MarketSourceSummary[]> =>
+      ipcRenderer.invoke('plugin-market:list-sources'),
+    addSource: (input: {
+      source: string;
+      ref?: string;
+      sparsePaths?: string[];
+    }): Promise<import('../shared/pluginMarket').MarketSourceSummary> =>
+      ipcRenderer.invoke('plugin-market:add-source', input),
+    removeSource: (name: string): Promise<{ ok: true }> =>
+      ipcRenderer.invoke('plugin-market:remove-source', name),
+    refreshSource: (
+      name: string,
+    ): Promise<import('../shared/pluginMarket').MarketSourceSummary> =>
+      ipcRenderer.invoke('plugin-market:refresh-source', name),
+    gitPreflight: (): Promise<{ ok: boolean; version: string | null }> =>
+      ipcRenderer.invoke('plugin-market:git-preflight'),
   },
   voiceInput: {
     prewarm: (payload?: { sourceLanguage?: string; refinementEnabled?: boolean }): Promise<{ ok: true }> =>

--- a/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
@@ -71,6 +71,8 @@ function marketItem(overrides: Partial<PluginMarketItem> = {}): PluginMarketItem
     releaseId: 'release-1',
     version: '1.5.10',
     publishedAt: '2026-07-27T00:00:00.000Z',
+    sourceType: 'server',
+    sourceMarketName: null,
     icon: {
       mimeType: 'image/png',
       sha256: 'a'.repeat(64),

--- a/apps/desktop/src/renderer/features/plugin/AddMarketplaceDialog.tsx
+++ b/apps/desktop/src/renderer/features/plugin/AddMarketplaceDialog.tsx
@@ -1,0 +1,375 @@
+/**
+ * 添加插件市场对话框：上半部分添加表单（来源 / Git 引用 / 稀疏路径），
+ * 下半部分已添加源列表（刷新 / 移除）。
+ *
+ * 视觉规格遵循 DESIGN.md §4 Dialog & Modal：overlay 用 --overlay-modal token，
+ * 容器 12px radius + --confirm-bg + --confirm-shadow，表单对话框放宽到 460px；
+ * 单行输入 pill、多行输入 8px 内层 radius，按钮全部 pill。
+ */
+import { useCallback, useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { RefreshCw, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
+import { Spinner } from '@/components/ui/spinner';
+import { toast } from '@/lib/toast';
+import { cn } from '@/lib/utils';
+import { extractIpcError } from '@/utils/ipcError';
+import type { MarketSourceSummary } from '../../../shared/pluginMarket';
+
+import { marketplaceSourceErrorKey } from './lib/pluginMarketErrorKey';
+
+export interface AddMarketplaceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 来源增删 / 刷新成功后通知父级重拉市场快照。 */
+  onSourcesChanged: () => void;
+}
+
+/** 与 main 侧 parse.ts 同形状的前置判断：仅用于决定 Git 不可用时要不要禁用添加。 */
+function looksLikeLocalPath(input: string): boolean {
+  const trimmed = input.trim();
+  return (
+    trimmed.startsWith('~') ||
+    trimmed.startsWith('/') ||
+    /^[A-Za-z]:[\\/]/.test(trimmed) ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../') ||
+    trimmed.startsWith('.\\') ||
+    trimmed.startsWith('..\\')
+  );
+}
+
+function sourceSummary(source: MarketSourceSummary['source']): string {
+  if (source.type === 'local') return source.path;
+  return source.url.replace(/\.git$/, '').replace(/^https:\/\//, '');
+}
+
+export function AddMarketplaceDialog({
+  open,
+  onOpenChange,
+  onSourcesChanged,
+}: AddMarketplaceDialogProps) {
+  const { t, i18n } = useTranslation();
+  const { confirm } = useConfirmDialog();
+  const [sources, setSources] = useState<MarketSourceSummary[] | null>(null);
+  const [gitReady, setGitReady] = useState<boolean | null>(null);
+  const [sourceInput, setSourceInput] = useState('');
+  const [refInput, setRefInput] = useState('');
+  const [sparseInput, setSparseInput] = useState('');
+  const [adding, setAdding] = useState(false);
+  const [busySource, setBusySource] = useState<string | null>(null);
+
+  const loadSources = useCallback(async () => {
+    try {
+      const list = await window.electronAPI.pluginMarket.listSources();
+      setSources(list);
+    } catch {
+      // 会话切换中等场景下读取失败：保持上一次列表，下次打开再试。
+      setSources((current) => current ?? []);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setSourceInput('');
+    setRefInput('');
+    setSparseInput('');
+    void loadSources();
+    void window.electronAPI.pluginMarket
+      .gitPreflight()
+      .then((result) => setGitReady(result.ok))
+      .catch(() => setGitReady(null));
+  }, [open, loadSources]);
+
+  const sourceIsLocal = looksLikeLocalPath(sourceInput);
+  const addDisabled =
+    adding ||
+    sourceInput.trim().length === 0 ||
+    (gitReady === false && !sourceIsLocal);
+
+  const handleAdd = useCallback(async () => {
+    if (addDisabled) return;
+    setAdding(true);
+    try {
+      const sparsePaths = sparseInput
+        .split('\n')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+      await window.electronAPI.pluginMarket.addSource({
+        source: sourceInput.trim(),
+        ...(refInput.trim() ? { ref: refInput.trim() } : {}),
+        ...(sparsePaths.length > 0 ? { sparsePaths } : {}),
+      });
+      setSourceInput('');
+      setRefInput('');
+      setSparseInput('');
+      await loadSources();
+      onSourcesChanged();
+    } catch (error) {
+      toast.error(t(marketplaceSourceErrorKey(error)));
+    } finally {
+      setAdding(false);
+    }
+  }, [addDisabled, loadSources, onSourcesChanged, refInput, sourceInput, sparseInput, t]);
+
+  const handleRefresh = useCallback(
+    async (name: string) => {
+      setBusySource(name);
+      try {
+        await window.electronAPI.pluginMarket.refreshSource(name);
+        await loadSources();
+        onSourcesChanged();
+      } catch (error) {
+        toast.error(t(marketplaceSourceErrorKey(error)));
+      } finally {
+        setBusySource(null);
+      }
+    },
+    [loadSources, onSourcesChanged, t],
+  );
+
+  const handleRemove = useCallback(
+    async (source: MarketSourceSummary) => {
+      const confirmed = await confirm({
+        title: t('settings.ghosts.market.sources.removeConfirmTitle', {
+          name: source.name,
+        }),
+        description: t('settings.ghosts.market.sources.removeConfirmDescription'),
+        confirmText: t('settings.ghosts.market.sources.remove'),
+      });
+      if (!confirmed) return;
+      setBusySource(source.name);
+      try {
+        await window.electronAPI.pluginMarket.removeSource(source.name);
+        await loadSources();
+        onSourcesChanged();
+      } catch (error) {
+        toast.error(t(marketplaceSourceErrorKey(error)));
+      } finally {
+        setBusySource(null);
+      }
+    },
+    [confirm, loadSources, onSourcesChanged, t],
+  );
+
+  const formatSyncedAt = (iso: string | null): string => {
+    if (!iso) return t('settings.ghosts.market.sources.neverSynced');
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return iso;
+    return new Intl.DateTimeFormat(i18n.resolvedLanguage ?? i18n.language, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => !adding && onOpenChange(next)}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className={cn(
+            'fixed inset-0 z-[10000] bg-[var(--overlay-modal)]',
+            'data-[state=open]:animate-confirm-overlay-in',
+            'data-[state=closed]:animate-confirm-overlay-out',
+          )}
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        />
+        <Dialog.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[10000] -translate-x-1/2 -translate-y-1/2',
+            'flex max-h-[85vh] w-full select-none flex-col rounded-xl p-4',
+            'bg-[var(--confirm-bg)] shadow-[var(--confirm-shadow)]',
+            'data-[state=open]:animate-confirm-content-in',
+            'data-[state=closed]:animate-confirm-content-out',
+          )}
+          style={
+            {
+              WebkitAppRegion: 'no-drag',
+              maxWidth: 'min(460px, 100vw - 32px)',
+            } as React.CSSProperties
+          }
+        >
+          <Dialog.Title className="shrink-0 text-lg font-medium text-[var(--confirm-title)]">
+            {t('settings.ghosts.market.sources.dialogTitle')}
+          </Dialog.Title>
+          <Dialog.Description className="mt-2 shrink-0 text-base text-[var(--confirm-desc)]">
+            {t('settings.ghosts.market.sources.dialogDescription')}
+          </Dialog.Description>
+
+          <div className="mt-3 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+            {gitReady === false ? (
+              <p className="mb-3 rounded-xl border border-[var(--border-default)] bg-[var(--surface-chip)] px-4 py-3 text-12 text-[var(--text-secondary)]">
+                {t('settings.ghosts.market.sources.gitUnavailable')}
+              </p>
+            ) : null}
+
+            <div className="flex flex-col gap-3">
+              <label className="flex flex-col gap-1.5">
+                <span className="text-12 text-[var(--text-secondary)]">
+                  {t('settings.ghosts.market.sources.sourceLabel')}
+                </span>
+                <input
+                  value={sourceInput}
+                  onChange={(event) => setSourceInput(event.target.value)}
+                  placeholder={t('settings.ghosts.market.sources.sourcePlaceholder')}
+                  spellCheck={false}
+                  className={cn(
+                    'h-10 rounded-full border border-[var(--border-default)] bg-[var(--surface-elevated)] px-4',
+                    'text-13 text-[var(--text-primary)] placeholder:text-[var(--text-placeholder)]',
+                    'focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring-soft)]',
+                  )}
+                />
+              </label>
+              <label className="flex flex-col gap-1.5">
+                <span className="text-12 text-[var(--text-secondary)]">
+                  {t('settings.ghosts.market.sources.refLabel')}
+                </span>
+                <input
+                  value={refInput}
+                  onChange={(event) => setRefInput(event.target.value)}
+                  placeholder={t('settings.ghosts.market.sources.refPlaceholder')}
+                  spellCheck={false}
+                  disabled={sourceIsLocal}
+                  className={cn(
+                    'h-10 rounded-full border border-[var(--border-default)] bg-[var(--surface-elevated)] px-4',
+                    'text-13 text-[var(--text-primary)] placeholder:text-[var(--text-placeholder)]',
+                    'focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring-soft)]',
+                    'disabled:cursor-not-allowed disabled:opacity-50',
+                  )}
+                />
+              </label>
+              <label className="flex flex-col gap-1.5">
+                <span className="text-12 text-[var(--text-secondary)]">
+                  {t('settings.ghosts.market.sources.sparseLabel')}
+                </span>
+                <textarea
+                  value={sparseInput}
+                  onChange={(event) => setSparseInput(event.target.value)}
+                  placeholder={t('settings.ghosts.market.sources.sparsePlaceholder')}
+                  spellCheck={false}
+                  rows={2}
+                  disabled={sourceIsLocal}
+                  className={cn(
+                    'resize-none rounded-lg border border-[var(--border-default)] bg-[var(--surface-elevated)] px-4 py-2.5',
+                    'text-13 text-[var(--text-primary)] placeholder:text-[var(--text-placeholder)]',
+                    'focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring-soft)]',
+                    'disabled:cursor-not-allowed disabled:opacity-50',
+                  )}
+                />
+              </label>
+            </div>
+
+            {sources && sources.length > 0 ? (
+              <div className="mt-5">
+                <h3 className="text-13 font-medium text-[var(--text-primary)]">
+                  {t('settings.ghosts.market.sources.listTitle')}
+                </h3>
+                <div className="mt-2 flex flex-col gap-2">
+                  {sources.map((source) => (
+                    <div
+                      key={source.name}
+                      className="rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] px-4 py-3"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="min-w-0 truncate text-13 font-medium text-[var(--text-primary)]">
+                          {source.name}
+                        </span>
+                        <span className="shrink-0 text-12 tabular-nums text-[var(--text-tertiary)]">
+                          {source.status === 'ok'
+                            ? t('settings.ghosts.market.sources.pluginCount', {
+                                count: source.pluginCount,
+                              })
+                            : t('settings.ghosts.market.sources.sourceError')}
+                        </span>
+                      </div>
+                      <div className="mt-1 flex min-w-0 items-center gap-1.5 text-11 text-[var(--text-tertiary)]">
+                        <span className="shrink-0">
+                          {source.source.type === 'local'
+                            ? t('settings.ghosts.market.sources.localBadge')
+                            : (source.source.ref ??
+                              t('settings.ghosts.market.sources.defaultRef'))}
+                        </span>
+                        <span aria-hidden="true">·</span>
+                        <span className="min-w-0 truncate">{sourceSummary(source.source)}</span>
+                        <span aria-hidden="true">·</span>
+                        <span className="shrink-0">
+                          {formatSyncedAt(source.lastSyncedAt)}
+                        </span>
+                      </div>
+                      <div className="mt-2.5 flex items-center justify-end gap-2">
+                        <button
+                          type="button"
+                          disabled={busySource !== null}
+                          onClick={() => void handleRefresh(source.name)}
+                          className={cn(
+                            'inline-flex h-8 items-center gap-1.5 rounded-full border border-[var(--border-default)] px-3 text-12 font-medium text-[var(--text-primary)]',
+                            'transition-colors hover:bg-[var(--surface-hover-soft)]',
+                            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                            'disabled:cursor-not-allowed disabled:opacity-40',
+                          )}
+                        >
+                          {busySource === source.name ? (
+                            <Spinner size={12} />
+                          ) : (
+                            <RefreshCw size={12} aria-hidden="true" />
+                          )}
+                          {t('settings.ghosts.market.sources.refresh')}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={busySource !== null}
+                          onClick={() => void handleRemove(source)}
+                          className={cn(
+                            'inline-flex h-8 items-center gap-1.5 rounded-full border border-[var(--border-default)] px-3 text-12 font-medium text-[var(--text-primary)]',
+                            'transition-colors hover:bg-[var(--surface-hover-soft)]',
+                            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                            'disabled:cursor-not-allowed disabled:opacity-40',
+                          )}
+                        >
+                          <Trash2 size={12} aria-hidden="true" />
+                          {t('settings.ghosts.market.sources.remove')}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-6 flex shrink-0 justify-end gap-2.5">
+            <button
+              type="button"
+              disabled={adding}
+              onClick={() => onOpenChange(false)}
+              className={cn(
+                'inline-flex min-w-[96px] items-center justify-center rounded-full border px-6 py-2.5 text-13 font-medium',
+                'border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)]',
+                'transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--confirm-btn-secondary-border)]',
+                'active:scale-[0.98] disabled:opacity-50',
+              )}
+            >
+              {t('settings.ghosts.market.sources.close')}
+            </button>
+            <button
+              type="button"
+              disabled={addDisabled}
+              onClick={() => void handleAdd()}
+              className={cn(
+                'inline-flex min-w-[96px] items-center justify-center rounded-full px-6 py-2.5 text-13 font-medium',
+                'bg-[var(--confirm-btn-primary-bg)] text-[var(--confirm-btn-primary-text)]',
+                'transition-colors hover:bg-[var(--confirm-btn-primary-hover)]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--confirm-btn-primary-bg)]',
+                'active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100',
+              )}
+            >
+              {adding ? <Spinner size={14} /> : t('settings.ghosts.market.sources.add')}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronDown, ChevronRight, ChevronUp, Plus, Sparkles, Upload } from 'lucide-react';
+import { ChevronDown, ChevronRight, ChevronUp, Plus, Sparkles, Store, Upload } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { WINDOW_NO_DRAG_STYLE } from '@/components/layout/windowDrag';
@@ -74,8 +74,10 @@ import {
   orderPluginCatalogItems,
   pluginPresentationOrigin,
   pluginUpdateForInstalledVersion,
+  type PluginCatalogPresentationItem,
   type PluginPresentationOrigin,
 } from './lib/pluginMarketPresentation';
+import { AddMarketplaceDialog } from './AddMarketplaceDialog';
 import { pluginMarketErrorKey } from './lib/pluginMarketErrorKey';
 import { usePluginIconRefresh } from './lib/usePluginIconRefresh';
 import { usePluginMarketForegroundRefresh } from './lib/usePluginMarketForegroundRefresh';
@@ -97,6 +99,7 @@ const PRESENTATION_FILTERS: readonly PluginPresentationFilter[] = [
   'public',
   'organization',
   'local',
+  'custom',
 ];
 
 /**
@@ -180,6 +183,7 @@ export function GhostPluginPage() {
           : {
               items: [],
               unavailableReason: error instanceof Error ? error.message : String(error),
+              customSourceNames: [],
             },
       );
       // Background icon renewal keeps the current snapshot visible, but must still report
@@ -289,6 +293,11 @@ export function GhostPluginPage() {
     setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams]);
   const marketItems = marketSnapshot?.items ?? [];
+  const customSourceNames = useMemo(
+    () => marketSnapshot?.customSourceNames ?? [],
+    [marketSnapshot?.customSourceNames],
+  );
+  const [addMarketplaceOpen, setAddMarketplaceOpen] = useState(false);
   const marketByGhostId = useMemo(() => {
     const map = new Map<string, PluginMarketItem>();
     for (const item of marketItems) {
@@ -348,13 +357,20 @@ export function GhostPluginPage() {
   }, [marketItems, query, showEnterprise]);
   const originFilters = useMemo(
     () =>
-      showEnterprise
-        ? PRESENTATION_FILTERS
-        : PRESENTATION_FILTERS.filter((filter) => filter !== 'organization'),
-    [showEnterprise],
+      PRESENTATION_FILTERS.filter((filter) => {
+        if (filter === 'organization') return showEnterprise;
+        // 未添加任何自定义市场时不显示"自定义"tab（与组织 tab 的隐藏模式一致）。
+        if (filter === 'custom') return customSourceNames.length > 0;
+        return true;
+      }),
+    [customSourceNames.length, showEnterprise],
   );
   const effectiveOriginFilter =
-    !showEnterprise && originFilter === 'organization' ? 'all' : originFilter;
+    !showEnterprise && originFilter === 'organization'
+      ? 'all'
+      : originFilter === 'custom' && customSourceNames.length === 0
+        ? 'all'
+        : originFilter;
   const items = useMemo(
     () =>
       effectiveOriginFilter === 'all'
@@ -375,11 +391,38 @@ export function GhostPluginPage() {
     () => orderPluginCatalogItems(marketItems, items, availableMarketItems),
     [availableMarketItems, items, marketItems],
   );
+  // "自定义" tab 内按来源市场分组（≥2 个源时展示小标题）；组顺序沿用市场添加顺序。
+  const customGroups = useMemo(() => {
+    if (effectiveOriginFilter !== 'custom') return null;
+    const groups = new Map<string, typeof catalogItems>();
+    for (const catalogItem of catalogItems) {
+      const marketName =
+        catalogItem.kind === 'market'
+          ? catalogItem.item.sourceMarketName
+          : (marketByGhostId.get(catalogItem.item.id)?.sourceMarketName ?? null);
+      const key = marketName ?? '';
+      const list = groups.get(key);
+      if (list) {
+        list.push(catalogItem);
+      } else {
+        groups.set(key, [catalogItem]);
+      }
+    }
+    return [...groups.entries()].sort((a, b) => {
+      const aIndex = customSourceNames.indexOf(a[0]);
+      const bIndex = customSourceNames.indexOf(b[0]);
+      return (
+        (aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex) -
+        (bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex)
+      );
+    });
+  }, [catalogItems, customSourceNames, effectiveOriginFilter, marketByGhostId]);
   const originCounts = useMemo(() => {
     const counts: Record<PluginPresentationOrigin, number> = {
       public: 0,
       organization: 0,
       local: 0,
+      custom: 0,
     };
     for (const item of searchedInstalledItems) counts[item.origin] += 1;
     for (const item of searchedAvailableMarketItems) {
@@ -769,7 +812,10 @@ export function GhostPluginPage() {
             }),
         description: isUpdate
           ? t('settings.ghosts.market.updateConfirmDescription')
-          : t('settings.ghosts.market.installConfirmDescription'),
+          : // 自定义市场未经服务端完整性校验，确认文案必须如实区分。
+            marketDetail.sourceType !== 'server'
+            ? t('settings.ghosts.market.customInstallConfirmDescription')
+            : t('settings.ghosts.market.installConfirmDescription'),
         // 限高与滚动交给共享 ConfirmDialog(max-h-[85vh] + 内部滚动区 + 打开时
         // 闪一下滚动条),这里不再自套一层 min(56vh,520px) —— 两层限高会让
         // "到底了没有"取决于内外层谁先触底(2026-07-27 收口)。
@@ -874,6 +920,45 @@ export function GhostPluginPage() {
     );
   }
 
+  const renderCatalogItem = (
+    catalogItem: PluginCatalogPresentationItem<PresentedGhostPluginItem>,
+  ) =>
+    catalogItem.kind === 'installed' ? (
+      <GhostPluginCard
+        key={`installed:${catalogItem.item.id}`}
+        item={catalogItem.item}
+        sourceLabel={t(`settings.ghosts.page.origin.${catalogItem.item.origin}`)}
+        onSelect={() => setSelectedId(catalogItem.item.id)}
+        onAction={() =>
+          void handleUseGhost(catalogItem.item.id, catalogItem.item.name)
+        }
+        updateVersion={catalogItem.item.marketUpdate?.version}
+        updateBusy={catalogItem.item.marketUpdate !== null && marketBusyId !== null}
+        onUpdate={
+          catalogItem.item.marketUpdate
+            ? () => void handleMarketUpdate(catalogItem.item.id)
+            : undefined
+        }
+        effectiveEnabled={effectiveEnabled(
+          catalogItem.item.id,
+          catalogItem.item.enabled,
+        )}
+        toggleDisabled={scopeDir !== null && !catalogItem.item.enabled}
+        onToggle={(enabled) =>
+          void handleToggle(catalogItem.item.id, enabled, catalogItem.item.name)
+        }
+        onIconLoadError={handleMarketIconLoadError}
+      />
+    ) : (
+      <MarketPluginCard
+        key={`market:${catalogItem.item.pluginId}`}
+        item={catalogItem.item}
+        busy={marketBusyId !== null}
+        onSelect={() => void handleSelectMarket(catalogItem.item.pluginId)}
+        onIconLoadError={handleMarketIconLoadError}
+      />
+    );
+
   return (
     <PluginManagementLayout
       activeTab="plugins"
@@ -885,6 +970,7 @@ export function GhostPluginPage() {
         <GhostPluginActions
           onInstall={() => void handleInstall()}
           onCreateWithCindy={handleCreateWithCindy}
+          onAddMarketplace={() => setAddMarketplaceOpen(true)}
         />
       }
     >
@@ -1015,45 +1101,34 @@ export function GhostPluginPage() {
             ) : null}
 
             {catalogItems.length > 0 ? (
-              <div className={cn('plugin-motion-stagger', PLUGIN_MANAGEMENT_CARD_GRID_CLASS)}>
-                {catalogItems.map((catalogItem) =>
-                  catalogItem.kind === 'installed' ? (
-                    <GhostPluginCard
-                      key={`installed:${catalogItem.item.id}`}
-                      item={catalogItem.item}
-                      sourceLabel={t(`settings.ghosts.page.origin.${catalogItem.item.origin}`)}
-                      onSelect={() => setSelectedId(catalogItem.item.id)}
-                      onAction={() =>
-                        void handleUseGhost(catalogItem.item.id, catalogItem.item.name)
-                      }
-                      updateVersion={catalogItem.item.marketUpdate?.version}
-                      updateBusy={catalogItem.item.marketUpdate !== null && marketBusyId !== null}
-                      onUpdate={
-                        catalogItem.item.marketUpdate
-                          ? () => void handleMarketUpdate(catalogItem.item.id)
-                          : undefined
-                      }
-                      effectiveEnabled={effectiveEnabled(
-                        catalogItem.item.id,
-                        catalogItem.item.enabled,
-                      )}
-                      toggleDisabled={scopeDir !== null && !catalogItem.item.enabled}
-                      onToggle={(enabled) =>
-                        void handleToggle(catalogItem.item.id, enabled, catalogItem.item.name)
-                      }
-                      onIconLoadError={handleMarketIconLoadError}
-                    />
-                  ) : (
-                    <MarketPluginCard
-                      key={`market:${catalogItem.item.pluginId}`}
-                      item={catalogItem.item}
-                      busy={marketBusyId !== null}
-                      onSelect={() => void handleSelectMarket(catalogItem.item.pluginId)}
-                      onIconLoadError={handleMarketIconLoadError}
-                    />
-                  ),
-                )}
-              </div>
+              customGroups && customGroups.length > 1 ? (
+                <div className="flex flex-col gap-6">
+                  {customGroups.map(([marketName, groupItems]) => (
+                    <section key={marketName || 'unknown-source'}>
+                      <header className="mb-3 flex items-baseline gap-2">
+                        <h3 className="text-14 font-medium text-[var(--text-primary)]">
+                          {marketName || t('settings.ghosts.page.origin.custom')}
+                        </h3>
+                        <span className="text-12 tabular-nums text-[var(--text-tertiary)]">
+                          {groupItems.length}
+                        </span>
+                      </header>
+                      <div
+                        className={cn(
+                          'plugin-motion-stagger',
+                          PLUGIN_MANAGEMENT_CARD_GRID_CLASS,
+                        )}
+                      >
+                        {groupItems.map(renderCatalogItem)}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+              ) : (
+                <div className={cn('plugin-motion-stagger', PLUGIN_MANAGEMENT_CARD_GRID_CLASS)}>
+                  {catalogItems.map(renderCatalogItem)}
+                </div>
+              )
             ) : !legacyRecoveryStatus ? (
               <div className="rounded-xl border-[0.5px] border-[var(--border-default)] px-5 py-10 text-center">
                 <p className="text-13 text-[var(--text-secondary)]">
@@ -1071,6 +1146,11 @@ export function GhostPluginPage() {
           </section>
         </PluginManagementPage>
       </main>
+      <AddMarketplaceDialog
+        open={addMarketplaceOpen}
+        onOpenChange={setAddMarketplaceOpen}
+        onSourcesChanged={() => void refreshMarket()}
+      />
     </PluginManagementLayout>
   );
 }
@@ -1218,9 +1298,11 @@ export function MarketPluginCard({
 function GhostPluginActions({
   onInstall,
   onCreateWithCindy,
+  onAddMarketplace,
 }: {
   onInstall: () => void;
   onCreateWithCindy: () => void;
+  onAddMarketplace: () => void;
 }) {
   const { t } = useTranslation();
 
@@ -1280,6 +1362,19 @@ function GhostPluginActions({
             aria-hidden="true"
           />
           {t('settings.ghosts.install')}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator className="mx-2 my-1 h-px bg-[var(--border-default)]" />
+        <DropdownMenuItem
+          onSelect={onAddMarketplace}
+          className="h-10 gap-3 rounded-lg px-3 text-13 focus:bg-[var(--surface-hover-soft)] focus:text-[var(--text-primary)]"
+        >
+          <Store
+            size={16}
+            strokeWidth={1.7}
+            className="text-[var(--text-secondary)]"
+            aria-hidden="true"
+          />
+          {t('settings.ghosts.market.sources.addMarketplace')}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
@@ -26,6 +26,8 @@ export function MarketPluginDetailView({
   const { t } = useTranslation();
   const permissions = ghostPermissionItems(detail.manifest);
   const presentationOrigin = pluginPresentationOrigin(detail);
+  // 自定义市场（Git/本地源）的包字节未经服务端校验，安全说明必须如实区分。
+  const isCustomSource = detail.sourceType !== 'server';
   const actionKey =
     detail.installState === 'update-available'
       ? 'settings.ghosts.market.update'
@@ -110,7 +112,11 @@ export function MarketPluginDetailView({
               aria-hidden="true"
             />
             <p className="text-13 leading-5 text-[var(--text-secondary)]">
-              {t('settings.ghosts.market.securityDescription')}
+              {t(
+                isCustomSource
+                  ? 'settings.ghosts.market.customSecurityDescription'
+                  : 'settings.ghosts.market.securityDescription',
+              )}
             </p>
           </div>
         </section>

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -54,6 +54,8 @@ const marketPlugin: PluginMarketItem = {
   icon: null,
   installState: 'not-installed',
   enabled: null,
+  sourceType: 'server',
+  sourceMarketName: null,
 };
 
 function InstalledQueueHarness({ items }: { items: readonly GhostPluginListItem[] }) {

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
@@ -26,20 +26,33 @@ function marketItem(
     icon: null,
     installState,
     enabled: installState === 'not-installed' ? null : true,
+    sourceType: 'server',
+    sourceMarketName: null,
   };
 }
 
 describe('pluginPresentationOrigin', () => {
   it('maps public plugins independently of their default-install policy', () => {
-    expect(pluginPresentationOrigin({ scope: 'public' })).toBe('public');
+    expect(pluginPresentationOrigin({ scope: 'public', sourceType: 'server' })).toBe('public');
   });
 
   it('maps organization plugins to their organization source', () => {
-    expect(pluginPresentationOrigin({ scope: 'organization' })).toBe('organization');
+    expect(
+      pluginPresentationOrigin({ scope: 'organization', sourceType: 'server' }),
+    ).toBe('organization');
   });
 
   it('keeps personal plugins out of the client-facing market taxonomy', () => {
-    expect(pluginPresentationOrigin({ scope: 'personal' })).toBe('local');
+    expect(pluginPresentationOrigin({ scope: 'personal', sourceType: 'server' })).toBe('local');
+  });
+
+  it('maps custom market sources to the custom origin regardless of scope', () => {
+    expect(pluginPresentationOrigin({ scope: 'public', sourceType: 'git-market' })).toBe(
+      'custom',
+    );
+    expect(pluginPresentationOrigin({ scope: 'public', sourceType: 'local-market' })).toBe(
+      'custom',
+    );
   });
 
   it.each([null, undefined])('keeps unmatched installed plugins local', (item) => {

--- a/apps/desktop/src/renderer/features/plugin/lib/pluginMarketErrorKey.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/pluginMarketErrorKey.ts
@@ -21,3 +21,25 @@ export function pluginMarketErrorKey(error: unknown): string {
       return 'settings.ghosts.market.errors.generic';
   }
 }
+
+/** 自定义市场源管理（添加 / 刷新 / 移除）的 IPC 错误码 → 本地化文案 key。 */
+export function marketplaceSourceErrorKey(error: unknown): string {
+  switch (extractIpcError(error)?.code) {
+    case 'MARKET_SOURCE_INVALID':
+      return 'settings.ghosts.market.sources.errors.invalidSource';
+    case 'MARKET_GIT_UNAVAILABLE':
+      return 'settings.ghosts.market.sources.errors.gitUnavailable';
+    case 'MARKET_CLONE_AUTH_FAILED':
+      return 'settings.ghosts.market.sources.errors.cloneAuthFailed';
+    case 'MARKET_CLONE_FAILED':
+      return 'settings.ghosts.market.sources.errors.cloneFailed';
+    case 'MARKET_MANIFEST_MISSING':
+      return 'settings.ghosts.market.sources.errors.manifestMissing';
+    case 'ALREADY_EXISTS':
+      return 'settings.ghosts.market.sources.errors.duplicate';
+    case 'NOT_FOUND':
+      return 'settings.ghosts.market.sources.errors.notFound';
+    default:
+      return pluginMarketErrorKey(error);
+  }
+}

--- a/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
@@ -10,14 +10,17 @@ import type { PluginMarketItem } from '../../../../shared/pluginMarket';
 export type PluginPresentationOrigin =
   | 'public'
   | 'organization'
-  | 'local';
+  | 'local'
+  | 'custom';
 
 export type PluginCatalogPresentationItem<TInstalled> =
   { kind: 'installed'; item: TInstalled } | { kind: 'market'; item: PluginMarketItem };
 
 export function pluginPresentationOrigin(
-  item: Pick<PluginMarketItem, 'scope'> | null | undefined,
+  item: Pick<PluginMarketItem, 'scope' | 'sourceType'> | null | undefined,
 ): PluginPresentationOrigin {
+  // 自定义市场（Git / 本地源）归 'custom'，与服务端 scope 正交。
+  if (item && item.sourceType !== 'server') return 'custom';
   if (item?.scope === 'public' || item?.scope === 'organization') {
     return item.scope;
   }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2741,7 +2741,8 @@
         "origin": {
           "public": "Public",
           "organization": "Team shared",
-          "local": "Local"
+          "local": "Local",
+          "custom": "Custom"
         },
         "emptyFiltered": "No matching plugins",
         "useAction": "Use",
@@ -2754,7 +2755,8 @@
           "public": "Public",
           "organization": "Organization",
           "personal": "Personal",
-          "local": "Local"
+          "local": "Local",
+          "custom": "Custom"
         },
         "install": "Install",
         "details": "Details",
@@ -2780,10 +2782,45 @@
         },
         "securityTitle": "Install and permissions",
         "securityDescription": "Cindy verifies package size and SHA-256 in the main process, validates the plugin manifest, then installs atomically. First-time installs are enabled automatically and can be disabled anytime on the Plugins page; updates keep the current enabled state.",
+        "customSecurityDescription": "This plugin comes from a custom marketplace you added and has not been verified by the Cindy server. Its manifest is validated in the main process before install. First-time installs are enabled automatically and can be disabled anytime on the Plugins page.",
         "noPermissions": "This plugin declares no additional capabilities.",
         "installConfirmTitle": "Install “{{name}}”?",
         "installConfirmDescription": "The package will be verified for integrity and manifest compatibility. The plugin is enabled automatically after install; you can disable it or adjust its setup anytime.",
-        "updateConfirmDescription": "The package will be verified for integrity and manifest compatibility, then replace the installed version. Its current enabled state stays unchanged."
+        "customInstallConfirmDescription": "This plugin comes from a custom marketplace and has not been verified for integrity by the server; its manifest will be validated before install. The plugin is enabled automatically after install; you can disable it or adjust its setup anytime.",
+        "updateConfirmDescription": "The package will be verified for integrity and manifest compatibility, then replace the installed version. Its current enabled state stays unchanged.",
+        "sources": {
+          "addMarketplace": "Add Plugin Marketplace…",
+          "dialogTitle": "Add Plugin Marketplace",
+          "dialogDescription": "Add a plugin marketplace from a GitHub repository, Git URL, or local folder.",
+          "sourceLabel": "Source",
+          "sourcePlaceholder": "openai/plugins or git@github.com:org/repo.git",
+          "refLabel": "Git Ref",
+          "refPlaceholder": "Main branch",
+          "sparseLabel": "Sparse Paths",
+          "sparsePlaceholder": "One path per line, e.g. plugins/codex",
+          "gitUnavailable": "Git is not installed or is older than 2.25. Git sources are unavailable; local folder sources still work.",
+          "listTitle": "Added Marketplaces",
+          "pluginCount": "{{count}} plugins",
+          "sourceError": "Unavailable",
+          "localBadge": "Local",
+          "defaultRef": "Default branch",
+          "neverSynced": "Never synced",
+          "refresh": "Refresh",
+          "remove": "Remove",
+          "removeConfirmTitle": "Remove marketplace \"{{name}}\"?",
+          "removeConfirmDescription": "Plugins from this marketplace will no longer be listed. Installed plugins are kept.",
+          "close": "Close",
+          "add": "Add Marketplace",
+          "errors": {
+            "invalidSource": "Invalid source. Use a GitHub owner/repo, a Git URL, or a local folder path.",
+            "gitUnavailable": "Git is not installed or is older than 2.25, so Git sources cannot be added.",
+            "cloneAuthFailed": "Cannot access this repository. For private repositories, configure Git authentication on this machine first (credential helper or SSH key).",
+            "cloneFailed": "Failed to clone the repository. Check your network or proxy settings and try again.",
+            "manifestMissing": "No supported marketplace.json manifest was found in this source.",
+            "duplicate": "This marketplace has already been added.",
+            "notFound": "This marketplace does not exist or has been removed."
+          }
+        }
       },
       "install": "Install Plugin…",
       "empty": "No plugins installed yet",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2740,7 +2740,8 @@
         "origin": {
           "public": "公開",
           "organization": "チーム共有",
-          "local": "ローカル"
+          "local": "ローカル",
+          "custom": "カスタム"
         },
         "emptyFiltered": "一致するプラグインがありません",
         "useAction": "使用",
@@ -2753,7 +2754,8 @@
           "public": "公開",
           "organization": "組織",
           "personal": "個人",
-          "local": "ローカル"
+          "local": "ローカル",
+          "custom": "カスタム"
         },
         "install": "インストール",
         "details": "詳細",
@@ -2779,10 +2781,45 @@
         },
         "securityTitle": "インストールと権限",
         "securityDescription": "メインプロセスでサイズと SHA-256、プラグインマニフェストを検証してからアトミックにインストールします。初回インストール後は自動的に有効になり、プラグインページからいつでも無効化できます。更新では現在の有効/無効の状態が維持されます。",
+        "customSecurityDescription": "このプラグインは追加したカスタムマーケット由来で、Cindy サーバーによる整合性検証は行われていません。インストール前にメインプロセスでマニフェストを検証します。初回インストール後は自動で有効になり、プラグインページでいつでも無効化できます。",
         "noPermissions": "このプラグインは追加機能を宣言していません。",
         "installConfirmTitle": "「{{name}}」をインストールしますか？",
         "installConfirmDescription": "パッケージの整合性とマニフェスト互換性を確認してからインストールします。インストール完了後は自動的に有効になり、いつでも無効化や設定の変更ができます。",
-        "updateConfirmDescription": "パッケージの整合性とマニフェスト互換性を確認してから、既存のバージョンを置き換えます。現在の有効/無効の状態は変わりません。"
+        "customInstallConfirmDescription": "カスタムマーケット由来のプラグインのため、サーバーによる整合性検証は行われません。インストール前にマニフェストを検証します。インストール後は自動で有効になり、プラグインページでいつでも無効化・設定変更ができます。",
+        "updateConfirmDescription": "パッケージの整合性とマニフェスト互換性を確認してから、既存のバージョンを置き換えます。現在の有効/無効の状態は変わりません。",
+        "sources": {
+          "addMarketplace": "プラグインマーケットを追加…",
+          "dialogTitle": "プラグインマーケットを追加",
+          "dialogDescription": "GitHub リポジトリ、Git URL、またはローカルフォルダーからプラグインマーケットを追加します。",
+          "sourceLabel": "ソース",
+          "sourcePlaceholder": "openai/plugins または git@github.com:org/repo.git",
+          "refLabel": "Git 参照",
+          "refPlaceholder": "メインブランチ",
+          "sparseLabel": "スパースパス",
+          "sparsePlaceholder": "1 行に 1 パス（例: plugins/codex）",
+          "gitUnavailable": "Git がインストールされていないか、バージョンが 2.25 未満です。Git ソースは利用できません。ローカルフォルダーのソースは引き続き利用できます。",
+          "listTitle": "追加済みのマーケット",
+          "pluginCount": "{{count}} 個のプラグイン",
+          "sourceError": "読み込み失敗",
+          "localBadge": "ローカル",
+          "defaultRef": "デフォルトブランチ",
+          "neverSynced": "未同期",
+          "refresh": "更新",
+          "remove": "削除",
+          "removeConfirmTitle": "マーケット「{{name}}」を削除しますか？",
+          "removeConfirmDescription": "削除すると、このマーケットのプラグインは表示されなくなります。インストール済みのプラグインは保持されます。",
+          "close": "閉じる",
+          "add": "マーケットを追加",
+          "errors": {
+            "invalidSource": "ソースの形式が無効です。GitHub の owner/repo、Git URL、またはローカルフォルダーのパスを指定してください。",
+            "gitUnavailable": "Git がインストールされていないか、バージョンが 2.25 未満のため、Git ソースを追加できません。",
+            "cloneAuthFailed": "このリポジトリにアクセスできません。プライベートリポジトリの場合は、先にシステムで Git 認証（credential helper または SSH key）を設定してください。",
+            "cloneFailed": "リポジトリのクローンに失敗しました。ネットワークまたはプロキシ設定を確認してから再試行してください。",
+            "manifestMissing": "このソースに対応する marketplace.json マニフェストが見つかりません。",
+            "duplicate": "このマーケットはすでに追加されています。",
+            "notFound": "このマーケットは存在しないか、すでに削除されています。"
+          }
+        }
       },
       "install": "プラグインをインストール…",
       "empty": "まだプラグインがインストールされていません",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2740,7 +2740,8 @@
         "origin": {
           "public": "공개",
           "organization": "팀 공유",
-          "local": "로컬"
+          "local": "로컬",
+          "custom": "사용자 지정"
         },
         "emptyFiltered": "일치하는 플러그인이 없습니다",
         "useAction": "사용",
@@ -2753,7 +2754,8 @@
           "public": "공개",
           "organization": "조직",
           "personal": "개인",
-          "local": "로컬"
+          "local": "로컬",
+          "custom": "사용자 지정"
         },
         "install": "설치",
         "details": "상세",
@@ -2779,10 +2781,45 @@
         },
         "securityTitle": "설치 및 권한",
         "securityDescription": "메인 프로세스에서 크기와 SHA-256 및 플러그인 매니페스트를 검증한 뒤 원자적으로 설치합니다. 최초 설치 후 자동으로 활성화되며 플러그인 페이지에서 언제든지 비활성화할 수 있습니다. 업데이트 시 현재 활성화 상태가 유지됩니다.",
+        "customSecurityDescription": "이 플러그인은 추가한 사용자 지정 마켓에서 제공되며 Cindy 서버의 무결성 검증을 거치지 않았습니다. 설치 전에 메인 프로세스에서 매니페스트를 검증합니다. 처음 설치하면 자동으로 활성화되며 플러그인 페이지에서 언제든 비활성화할 수 있습니다.",
         "noPermissions": "이 플러그인은 추가 기능을 선언하지 않았습니다.",
         "installConfirmTitle": "‘{{name}}’을(를) 설치할까요?",
         "installConfirmDescription": "패키지 무결성과 매니페스트 호환성을 확인한 뒤 설치합니다. 설치가 완료되면 자동으로 활성화되며, 언제든지 비활성화하거나 설정을 변경할 수 있습니다.",
-        "updateConfirmDescription": "패키지 무결성과 매니페스트 호환성을 확인한 뒤 기존 버전을 교체합니다. 현재 활성화 상태는 그대로 유지됩니다."
+        "customInstallConfirmDescription": "사용자 지정 마켓의 플러그인으로 서버 무결성 검증을 거치지 않았으며, 설치 전에 매니페스트를 검증합니다. 설치 후 플러그인이 자동으로 활성화되며 언제든 비활성화하거나 설정을 변경할 수 있습니다.",
+        "updateConfirmDescription": "패키지 무결성과 매니페스트 호환성을 확인한 뒤 기존 버전을 교체합니다. 현재 활성화 상태는 그대로 유지됩니다.",
+        "sources": {
+          "addMarketplace": "플러그인 마켓 추가…",
+          "dialogTitle": "플러그인 마켓 추가",
+          "dialogDescription": "GitHub 리포지토리, Git URL 또는 로컬 폴더에서 플러그인 마켓을 추가합니다.",
+          "sourceLabel": "소스",
+          "sourcePlaceholder": "openai/plugins 또는 git@github.com:org/repo.git",
+          "refLabel": "Git 참조",
+          "refPlaceholder": "기본 브랜치",
+          "sparseLabel": "스파스 경로",
+          "sparsePlaceholder": "한 줄에 하나의 경로(예: plugins/codex)",
+          "gitUnavailable": "Git이 설치되어 있지 않거나 버전이 2.25 미만입니다. Git 소스는 사용할 수 없으며 로컬 폴더 소스는 계속 사용할 수 있습니다.",
+          "listTitle": "추가된 마켓",
+          "pluginCount": "플러그인 {{count}}개",
+          "sourceError": "읽기 실패",
+          "localBadge": "로컬",
+          "defaultRef": "기본 브랜치",
+          "neverSynced": "동기화되지 않음",
+          "refresh": "새로고침",
+          "remove": "제거",
+          "removeConfirmTitle": "마켓 \"{{name}}\"을(를) 제거할까요?",
+          "removeConfirmDescription": "제거하면 이 마켓의 플러그인이 더 이상 표시되지 않습니다. 설치된 플러그인은 유지됩니다.",
+          "close": "닫기",
+          "add": "마켓 추가",
+          "errors": {
+            "invalidSource": "소스 형식이 올바르지 않습니다. GitHub owner/repo, Git URL 또는 로컬 폴더 경로를 사용하세요.",
+            "gitUnavailable": "Git이 설치되어 있지 않거나 버전이 2.25 미만이므로 Git 소스를 추가할 수 없습니다.",
+            "cloneAuthFailed": "이 리포지토리에 접근할 수 없습니다. 비공개 리포지토리의 경우 먼저 시스템에 Git 인증(credential helper 또는 SSH key)을 구성하세요.",
+            "cloneFailed": "리포지토리를 클론하지 못했습니다. 네트워크 또는 프록시 설정을 확인한 후 다시 시도하세요.",
+            "manifestMissing": "이 소스에서 지원되는 marketplace.json 매니페스트를 찾을 수 없습니다.",
+            "duplicate": "이 마켓은 이미 추가되어 있습니다.",
+            "notFound": "이 마켓이 존재하지 않거나 이미 제거되었습니다."
+          }
+        }
       },
       "install": "플러그인 설치…",
       "empty": "아직 설치된 플러그인이 없습니다",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2740,7 +2740,8 @@
         "origin": {
           "public": "公开",
           "organization": "团队共享",
-          "local": "本地"
+          "local": "本地",
+          "custom": "自定义"
         },
         "emptyFiltered": "没有找到匹配的插件",
         "useAction": "使用",
@@ -2753,7 +2754,8 @@
           "public": "公开",
           "organization": "组织",
           "personal": "个人",
-          "local": "本地"
+          "local": "本地",
+          "custom": "自定义"
         },
         "install": "安装",
         "details": "详情",
@@ -2779,10 +2781,45 @@
         },
         "securityTitle": "安装与权限",
         "securityDescription": "安装包会在主进程中校验大小与 SHA-256，再经 Cindy 插件清单校验后原子安装。首次安装完成后即自动开启，可随时在插件页停用；更新会保留当前生效状态。",
+        "customSecurityDescription": "该插件来自你添加的自定义市场，未经 Cindy 服务端完整性校验。安装前会在主进程校验插件清单；首次安装完成后即自动开启，可随时在插件页停用。",
         "noPermissions": "此插件未声明额外能力。",
         "installConfirmTitle": "安装「{{name}}」？",
         "installConfirmDescription": "安装包将经过完整性与清单校验。安装完成后插件将自动开启，你可以随时在插件页停用或调整配置。",
-        "updateConfirmDescription": "安装包将经过完整性与清单校验，并替换现有版本。当前生效状态保持不变。"
+        "customInstallConfirmDescription": "插件来自自定义市场，未经服务端完整性校验，安装前将校验插件清单。安装完成后插件将自动开启，你可以随时在插件页停用或调整配置。",
+        "updateConfirmDescription": "安装包将经过完整性与清单校验，并替换现有版本。当前生效状态保持不变。",
+        "sources": {
+          "addMarketplace": "添加插件市场…",
+          "dialogTitle": "添加插件市场",
+          "dialogDescription": "从 GitHub 仓库、Git URL 或本地文件夹添加插件市场。",
+          "sourceLabel": "来源",
+          "sourcePlaceholder": "owner/repo 或 git@github.com:org/repo.git",
+          "refLabel": "Git 引用",
+          "refPlaceholder": "主分支",
+          "sparseLabel": "稀疏路径",
+          "sparsePlaceholder": "每行一个路径，如 team/tools",
+          "gitUnavailable": "未检测到 Git 或版本低于 2.25。Git 来源不可用，本地文件夹来源不受影响。",
+          "listTitle": "已添加的市场",
+          "pluginCount": "{{count}} 个插件",
+          "sourceError": "读取失败",
+          "localBadge": "本地",
+          "defaultRef": "默认分支",
+          "neverSynced": "尚未同步",
+          "refresh": "刷新",
+          "remove": "移除",
+          "removeConfirmTitle": "移除市场「{{name}}」？",
+          "removeConfirmDescription": "移除后，来自该市场的插件将不再显示；已安装的插件保留。",
+          "close": "关闭",
+          "add": "添加市场",
+          "errors": {
+            "invalidSource": "来源格式无效。支持 GitHub owner/repo、Git URL 或本地文件夹路径。",
+            "gitUnavailable": "未检测到 Git 或版本低于 2.25，无法添加 Git 来源。",
+            "cloneAuthFailed": "无法访问该仓库。私有仓库需要先在系统中配置 Git 认证（credential helper 或 SSH key）。",
+            "cloneFailed": "克隆仓库失败，请检查网络连接后重试。",
+            "manifestMissing": "该来源中找不到受支持的 marketplace.json 清单。",
+            "duplicate": "该市场已添加。",
+            "notFound": "该市场不存在或已被移除。"
+          }
+        }
       },
       "install": "安装插件…",
       "empty": "还没有安装任何插件",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1322,6 +1322,17 @@ interface ElectronAPI {
       options: { expectedReleaseId: string; allowPermissionExpansion?: boolean },
     ) => Promise<{ ghost: import('../shared/ghost').InstalledGhost }>;
     uninstall: (pluginId: string) => Promise<{ ok: true }>;
+    listSources: () => Promise<import('../shared/pluginMarket').MarketSourceSummary[]>;
+    addSource: (input: {
+      source: string;
+      ref?: string;
+      sparsePaths?: string[];
+    }) => Promise<import('../shared/pluginMarket').MarketSourceSummary>;
+    removeSource: (name: string) => Promise<{ ok: true }>;
+    refreshSource: (
+      name: string,
+    ) => Promise<import('../shared/pluginMarket').MarketSourceSummary>;
+    gitPreflight: () => Promise<{ ok: boolean; version: string | null }>;
   };
   voiceInput: {
     prewarm: (payload?: { sourceLanguage?: string; refinementEnabled?: boolean }) => Promise<{ ok: true }>;

--- a/apps/desktop/src/shared/ipc-errors.ts
+++ b/apps/desktop/src/shared/ipc-errors.ts
@@ -113,6 +113,12 @@ export type IpcErrorCode =
   | 'GHOST_FILE_INVALID' // 不是合法 zip / 缺 ghost.json / 清单不合格 / 超限
   | 'GHOST_COMMAND_CONFLICT' // 显式指令与已装意识撞名(装入拒绝)
   | 'GHOST_ID_RESERVED' // id 属官方保留前缀(cindy-),用户通道拒装(防抢注蹭凭证别名)
+  // 自定义插件市场源(Git / 本地文件夹)
+  | 'MARKET_SOURCE_INVALID' // 来源格式非法 / 本地路径不是目录 / 参数组合不允许
+  | 'MARKET_GIT_UNAVAILABLE' // 未安装 Git 或版本 < 2.25(稀疏检出下限)
+  | 'MARKET_CLONE_AUTH_FAILED' // 克隆被拒绝:私有仓库未配置认证
+  | 'MARKET_CLONE_FAILED' // 克隆/拉取失败:网络、代理或远端其它错误
+  | 'MARKET_MANIFEST_MISSING' // 来源内找不到受支持的 marketplace.json
   // 网关凭据自动下发(model-access)
   | 'MODEL_ACCESS_FAILED' // 拉取/轮换失败(网络或服务端错误),可重试
   | 'MODEL_ACCESS_DISABLED' // 服务端灰度未启用(503)——走手填兜底
@@ -229,6 +235,11 @@ const IPC_ERROR_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
   'GHOST_FILE_INVALID',
   'GHOST_COMMAND_CONFLICT',
   'GHOST_ID_RESERVED',
+  'MARKET_SOURCE_INVALID',
+  'MARKET_GIT_UNAVAILABLE',
+  'MARKET_CLONE_AUTH_FAILED',
+  'MARKET_CLONE_FAILED',
+  'MARKET_MANIFEST_MISSING',
   'MODEL_ACCESS_FAILED',
   'MODEL_ACCESS_DISABLED',
   'MODEL_ACCESS_UNSUPPORTED',

--- a/apps/desktop/src/shared/pluginMarket.ts
+++ b/apps/desktop/src/shared/pluginMarket.ts
@@ -8,6 +8,9 @@ export type PluginMarketInstallState =
   | 'update-available'
   | 'conflict';
 
+/** 市场项来源：服务端市场，或用户添加的 Git / 本地自定义市场。 */
+export type PluginMarketItemSource = 'server' | 'git-market' | 'local-market';
+
 /** Renderer-safe Plugin 市场列表项；所有字段都来自协议或本地安装事实。 */
 export interface PluginMarketItem {
   pluginId: string;
@@ -24,14 +27,84 @@ export interface PluginMarketItem {
   icon: PluginIconMetadata | null;
   installState: PluginMarketInstallState;
   enabled: boolean | null;
+  /** 来源类型；服务端市场项为 'server'。 */
+  sourceType: PluginMarketItemSource;
+  /** 来源市场名（自定义市场项必填；服务端项为 null）。 */
+  sourceMarketName: string | null;
 }
 /** 市场快照。服务不可用时 renderer 保留本地插件并只展示非阻断提示。 */
 export interface PluginMarketSnapshot {
   items: PluginMarketItem[];
   unavailableReason: string | null;
+  /** 已添加的自定义市场名（按添加顺序）；驱动"自定义"筛选 tab 的可见性。 */
+  customSourceNames: string[];
 }
 
 /** 详情额外携带经 Desktop 当前 runtime validator 验证过的完整清单。 */
 export interface PluginMarketDetail extends PluginMarketItem {
   manifest: GhostManifest;
+}
+
+/* ------------------------------------------------------------------------ */
+/* 自定义市场源（Git / 本地文件夹）                                           */
+/* ------------------------------------------------------------------------ */
+
+/** 用户添加的市场来源。Git 源支持可选引用与稀疏检出；本地源指向文件夹。 */
+export type MarketSource =
+  | { type: 'git'; url: string; ref?: string; sparsePaths: string[] }
+  | { type: 'local'; path: string };
+
+/** 持久化的市场来源配置（sources.v1.json）。 */
+export interface MarketSourceConfig {
+  /** 市场名，来自 marketplace.json 的 name；全局唯一，作为管理主键。 */
+  name: string;
+  addedAt: string;
+  lastSyncedAt: string | null;
+  /** 最近一次同步到的 Git commit SHA；本地源为 null。 */
+  lastRevision: string | null;
+  source: MarketSource;
+}
+
+/** Renderer 管理视图使用的来源摘要。 */
+export interface MarketSourceSummary extends MarketSourceConfig {
+  /** 最近一次发现到的插件数；发现失败时为 0 并携带 status。 */
+  pluginCount: number;
+  status: 'ok' | 'error';
+  /** status === 'error' 时的 IPC 错误码（Renderer 按码本地化）。 */
+  errorCode: string | null;
+}
+
+/**
+ * 自定义市场插件的合成 pluginId。与服务端 CUID（^c[a-z0-9]{24}$）互不相交，
+ * Main 在 detail/install/uninstall 入口据此分流，Renderer 无需感知差异。
+ */
+export const CUSTOM_MARKET_PLUGIN_ID_PREFIX = 'custom:';
+
+export function customMarketPluginId(marketName: string, ghostId: string): string {
+  return `${CUSTOM_MARKET_PLUGIN_ID_PREFIX}${encodeURIComponent(marketName)}/${encodeURIComponent(ghostId)}`;
+}
+
+export function parseCustomMarketPluginId(
+  pluginId: string,
+): { marketName: string; ghostId: string } | null {
+  if (!pluginId.startsWith(CUSTOM_MARKET_PLUGIN_ID_PREFIX)) return null;
+  const rest = pluginId.slice(CUSTOM_MARKET_PLUGIN_ID_PREFIX.length);
+  const slash = rest.indexOf('/');
+  if (slash <= 0 || slash === rest.length - 1) return null;
+  try {
+    return {
+      marketName: decodeURIComponent(rest.slice(0, slash)),
+      ghostId: decodeURIComponent(rest.slice(slash + 1)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 自定义市场插件的合成 releaseId。版本变化即产生新 releaseId，
+ * 从而复用服务端市场既有的 update-available / expectedReleaseId 机制。
+ */
+export function customMarketReleaseId(marketName: string, ghostId: string, version: string): string {
+  return `custom:${encodeURIComponent(marketName)}:${encodeURIComponent(ghostId)}:${encodeURIComponent(version)}`;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Cindy 客户端增加「自定义插件市场」能力：用户可以把 GitHub 仓库（`owner/repo`）、任意 Git URL 或本地文件夹添加为插件市场来源，浏览其中的插件并安装、更新、卸载，与现有服务端市场并行共存。清单格式兼容 Codex 的 `marketplace.json`（`.agents/plugins/marketplace.json` 等 4 个位置），插件本体为 Cindy 插件（目录内含合法 `ghost.json`）。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求：自定义插件市场（Git 源）——对齐 Codex 的插件市场能力
- 本 PR 包含：
  - `plugin-market/sources/`：来源解析、Git 克隆（稀疏检出 / staging 原子替换 / `GIT_TERMINAL_PROMPT=0` / 认证与网络错误分类）、Codex 兼容清单发现、`sources.v1.json` 持久化、`MarketSourceManager`（添加 / 移除 / 刷新 / 列表）
  - 市场快照聚合：自定义来源插件以合成 pluginId（`custom:<market>/<ghostId>`）与合成 releaseId 接入既有 detail / install / uninstall / update-available 机制；ghostId 冲突跨服务端与自定义源全局判定（先装先得，冲突明示）；服务端不可用 / 未登录时自定义市场仍可用
  - 目录插件安装管道：复用 forge 打包核心（新抽 `packGhostDirToFile`，与 `packGhostDir` 同一校验与打包规则）+ `installOrUpdateMarketGhostPackage`；自定义源**不享受**官方前缀豁免（`cindy-` 等保留 id 拒装），安装前重读 `ghost.json` 逐字比对 id+version 防确认后篡改
  - UI：筛选 tab 新增「自定义」（未添加源时隐藏；≥2 个源时按市场分小标题，单源平铺）；「添加插件」下拉菜单新增「添加插件市场…」对话框（添加表单 + 已添加源列表 + 单源刷新/移除 + Git ≥2.25 前置检测警告条）
  - 文案真实性：自定义来源的详情页安全说明与安装确认文案与服务端市场明确区分（如实说明未经服务端 SHA-256 完整性校验），4 语言 i18n
- 明确不包含：
  - 插件条目的远程源（marketplace.json 里 `url` / `git-subdir` / `npm` 形态的 source 跳过不计）
  - 市场自动定时刷新、企业来源白名单、CN 区域 GitHub 访问引导（后续阶段）
  - Agent 对话管理市场源（规划中，独立 PR）
  - 私有仓库认证的任何特殊处理——与 Codex 同策略，完全依赖用户系统级 Git 配置（credential helper / SSH agent），克隆失败时分类引导
- 用户可见变化：插件页新增「自定义」分类与「添加插件市场…」入口
- 是否存在 breaking change：无

### UI 变化

涉及 UI 的平台：Desktop（macOS 开发环境）。worktree 会话无法重启运行中的宿主应用，**Light/Dark 两种模式均未实机目检**——全部样式走语义 token（`--confirm-*` / `--surface-*` / `--text-*` / `--border-default` / `--overlay-modal`），无双模式硬编码。

- 引用的设计规范：
  - DESIGN.md §4 Dialog & Modal：新对话框 overlay 用 `--overlay-modal` token、容器 `rounded-xl` + `--confirm-bg` + `--confirm-shadow` + `p-4`、表单对话框宽度 `min(460px, 100vw-32px)`、按钮 pill + `--confirm-btn-primary/secondary-*`
  - DESIGN.md §4 Inputs & Forms：单行输入 pill、多行输入（稀疏路径）8px 内层 radius、placeholder 走 `--text-placeholder`
  - DESIGN.md §4 Select & Dropdown：新菜单项复用现有下拉面板的行样式（`rounded-lg` 行 + `focus:bg-[var(--surface-hover-soft)]`）
  - DESIGN.md §4 Tabs：「自定义」筛选 tab 复用现有 pill tab 样式与计数徽标
  - DESIGN.md §5 Border Radius Scale：仅使用 12px 容器 / 8px 内层 / pill 三档

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/plugin-market
结果：11 个文件 112 个测试全过（含新增 57 个用例：sources-parse / sources-store /
sources-discover / sources-git / sources-manager / service-custom-sources）

pnpm --filter desktop exec vitest run src/main/cindy-brain
结果：75 个文件 1035 个测试全过（forge.ts 重构零回归）

pnpm --filter desktop typecheck
结果：通过

pnpm check:i18n / pnpm check:i18n-glossary
结果：6098 个 key 四语言一致；术语与标点无新增违规

pnpm test:unit（全仓）
结果：16919 通过 / 4 失败——4 个失败均为本机环境问题，与本次改动无关（详见下）
```

全仓 `pnpm test:unit` 的 4 个失败：
- `scriptRunnerPythonProtocol.test.ts` ×3：本机 `python` 为 Python 2.7.13，测试脚本含 Python 3 类型标注语法必然失败。已在干净 main checkout（latest-main-preview worktree）复现同样失败，确认为存量环境问题
- `ghostOauthFlow.test.ts` 端口复用用例 ×1：单独跑 41/41 全过，只在全量并发下因端口竞争失败；本次改动不涉及 oauth 流程

### 手工验证

未实机验证（worktree 会话无法重启宿主应用，见 development-workflow.md §1）。建议合并前在本机 dev 实例过一遍：添加本地文件夹市场 → 列表出现「自定义」tab → 安装插件 → 停用/卸载；添加 GitHub 市场（如 `owner/repo`）→ 刷新 / 移除。

### 未执行的验证

- Windows 实测：未执行。跨平台点已按规范处理（`path.join`/`path.resolve`、execFile 不走 shell、Windows rename 覆盖限制在 store/ledger 同款兜底、staging 目录先删后换），待 CI / 实机验证
- Light/Dark 实机目检：未执行（原因见「UI 变化」），样式全部走语义 token

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 影响范围：
  - 新增安装入口的信任边界：自定义源插件未经服务端校验。防线上对齐既有市场安装——确认框如实展示权限清单、保留前缀拒装、tokenBroker 门控（`installOrUpdateMarketGhostPackage` 内既有）、打包/解包/装入全套校验、安装前重读清单比对防 TOCTOU。首装「装完即开」沿用 2026-07-26 服务端市场同款定案（确认框已展示权限清单，确认即授权）；如需对自定义源改为默认沉睡，是一行策略调整，请 review 时裁决
  - `forge.ts` 重构：`packGhostDir` 行为不变（打包核心抽为共用函数），已有 1035 个 cindy-brain 测试全过；**手册无需同步**——打包限制与作者可见契约未变，仅抽出共用实现
  - 持久化新增 `sources.v1.json`（owner 作用域，原子写），ledger `source` 枚举扩展两个值（旧版本读到新枚举值会丢弃该条记录，仅降级场景受影响）
  - 新 IPC 通道 5 个（`plugin-market:list-sources/add-source/remove-source/refresh-source/git-preflight`），sender 校验 + payload 长度上限；**不登记 device-link 白名单**——与现有 plugin-market 通道一致（市场管理是桌面主机本地能力）
- 回滚 / 降级方式：revert 本 PR 即可；`sources.v1.json` 与克隆缓存为新增数据，删除不影响既有功能；ledger 新枚举值在旧版本下被忽略（自定义来源安装记录退化为本地插件展示）

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
