### PR TITLE
fix(mobile): 显示自动重连过程与结果

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -3547,12 +3547,7 @@ export default function SessionScreen() {
         // remoteSessionRunning(activity 推送 / 活跃快照会先置 true,重连场景渲染先于清理)。
         buildMobileMessageRenderItems(
           messages,
-          {
-            autoResumePending: inputProjection.autoResumePending,
-            isSessionStreaming,
-            renderOrphanTaskUpdates: makerTurnRunning,
-            sessionId,
-          },
+          { autoResumePending: inputProjection.autoResumePending, isSessionStreaming, renderOrphanTaskUpdates: makerTurnRunning, sessionId },
           taskUpdates,
         ),
         forkOrigin,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -3547,7 +3547,12 @@ export default function SessionScreen() {
         // remoteSessionRunning(activity 推送 / 活跃快照会先置 true,重连场景渲染先于清理)。
         buildMobileMessageRenderItems(
           messages,
-          { isSessionStreaming, renderOrphanTaskUpdates: makerTurnRunning },
+          {
+            autoResumePending: inputProjection.autoResumePending,
+            isSessionStreaming,
+            renderOrphanTaskUpdates: makerTurnRunning,
+            sessionId,
+          },
           taskUpdates,
         ),
         forkOrigin,
@@ -3563,7 +3568,7 @@ export default function SessionScreen() {
       const reconciled = reconcileMobileMessageRenderItems(previous, items);
       return reconciled;
     },
-    [errorTailClientId, forkOrigin, isSessionStreaming, makerTurnRunning, messages, sessionId, taskUpdates],
+    [errorTailClientId, forkOrigin, inputProjection.autoResumePending, isSessionStreaming, makerTurnRunning, messages, sessionId, taskUpdates],
   );
   // 只在本次 render 真正 commit 后更新 reconcile 基准。写入 useMemo/ref 会让
   // Concurrent Mode 下被丢弃的 render 泄漏成下一轮的 previous,破坏尾行 memo 的稳定性。

--- a/apps/mobile/src/__tests__/inputProjection.test.ts
+++ b/apps/mobile/src/__tests__/inputProjection.test.ts
@@ -352,6 +352,7 @@ describe('inputProjection', () => {
       queueAbortPending: true,
       error: 'failed',
       errorRetryText: 'retry',
+      autoResumePending: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3 },
     });
 
     expect(projection).toMatchObject({
@@ -365,6 +366,7 @@ describe('inputProjection', () => {
       queueAbortPending: true,
       error: 'failed',
       errorRetryText: 'retry',
+      autoResumePending: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3 },
     });
   });
 

--- a/apps/mobile/src/__tests__/messageNormalize.test.ts
+++ b/apps/mobile/src/__tests__/messageNormalize.test.ts
@@ -941,13 +941,15 @@ describe('normalizeRemoteMessages', () => {
     expect(items[1].turnCompleted).toBeUndefined();
   });
 
-  it('renders silent-stop auto-resume rows as system cards instead of user bubbles', () => {
+  it('renders auto-resume rows as system cards with interruption outcome metadata', () => {
     const items = normalizeRemoteMessages([
       message({
         id: 'auto-resume',
         role: 'user',
         content: '继续',
-        agentMeta: { delivery: 'turn', autoResume: true },
+        agentMeta: { delivery: 'turn', autoResume: true, autoResumeInfo: {
+          error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3,
+        }, autoResumeOutcome: 'failed' },
       }),
     ]);
 
@@ -957,6 +959,7 @@ describe('normalizeRemoteMessages', () => {
       label: 'user',
       body: '',
       systemCardType: 'auto-resume',
+      systemCardData: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3, outcome: 'failed' },
       align: 'agent',
     });
   });

--- a/apps/mobile/src/__tests__/messageRenderModel.test.ts
+++ b/apps/mobile/src/__tests__/messageRenderModel.test.ts
@@ -39,12 +39,13 @@ function toolUse(id: string, toolName: string, input: unknown, seconds: number):
 }
 
 describe('messageRenderModel', () => {
-  it('appends the live auto-resume projection as an ephemeral system card', () => {
-    const items = buildMobileMessageRenderItems([message({ id: 'a', role: 'assistant', content: 'partial', agentMeta: { isStreaming: true } })], {
+  it('appends live auto-resume state while folding an earlier retry from the same interruption', () => {
+    const priorRetry = message({ id: 'retry-1', role: 'user', content: '', agentMeta: { autoResume: true } });
+    const items = buildMobileMessageRenderItems([message({ id: 'a', role: 'assistant', content: 'partial', agentMeta: { isStreaming: true } }), priorRetry], {
       isSessionStreaming: true,
       autoResumePending: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3 },
     });
-    expect(expectType(items[0], 'message').message.isTurnFinalAssistant).toBeUndefined();
+    expect(expectType(items[0], 'message').message.isTurnFinalAssistant).toBe(true);
     expect(expectType(items[1], 'message').message).toMatchObject({
       systemCardType: 'auto-resume',
       systemCardData: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3, live: true },

--- a/apps/mobile/src/__tests__/messageRenderModel.test.ts
+++ b/apps/mobile/src/__tests__/messageRenderModel.test.ts
@@ -41,7 +41,6 @@ function toolUse(id: string, toolName: string, input: unknown, seconds: number):
 describe('messageRenderModel', () => {
   it('appends the live auto-resume projection as an ephemeral system card', () => {
     const items = buildMobileMessageRenderItems([message({ id: 'a', role: 'assistant', content: 'partial', agentMeta: { isStreaming: true } })], {
-      sessionId: 's1',
       isSessionStreaming: true,
       autoResumePending: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3 },
     });
@@ -49,9 +48,9 @@ describe('messageRenderModel', () => {
     expect(expectType(items[1], 'message').message).toMatchObject({
       systemCardType: 'auto-resume',
       systemCardData: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3, live: true },
+      createdAt: '2026-01-01T00:00:00.001Z',
     });
   });
-
   it('reuses unchanged history rows and attachment view models during a streaming tail update', () => {
     const user = message({
       id: 'user-1',

--- a/apps/mobile/src/__tests__/messageRenderModel.test.ts
+++ b/apps/mobile/src/__tests__/messageRenderModel.test.ts
@@ -39,6 +39,19 @@ function toolUse(id: string, toolName: string, input: unknown, seconds: number):
 }
 
 describe('messageRenderModel', () => {
+  it('appends the live auto-resume projection as an ephemeral system card', () => {
+    const items = buildMobileMessageRenderItems([message({ id: 'a', role: 'assistant', content: 'partial', agentMeta: { isStreaming: true } })], {
+      sessionId: 's1',
+      isSessionStreaming: true,
+      autoResumePending: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3 },
+    });
+    expect(expectType(items[0], 'message').message.isTurnFinalAssistant).toBeUndefined();
+    expect(expectType(items[1], 'message').message).toMatchObject({
+      systemCardType: 'auto-resume',
+      systemCardData: { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3, live: true },
+    });
+  });
+
   it('reuses unchanged history rows and attachment view models during a streaming tail update', () => {
     const user = message({
       id: 'user-1',

--- a/apps/mobile/src/__tests__/systemCard.test.ts
+++ b/apps/mobile/src/__tests__/systemCard.test.ts
@@ -147,8 +147,9 @@ describe('formatMobileSystemCard — 中断自动重连状态', () => {
   it('shows live progress, reason, current attempt, and conversation total', () => {
     expect(formatMobileSystemCard('auto-resume', { ...info, live: true })).toEqual({
       title: 'Reconnecting 2/5…',
+      subtitle: 'Attempt 2/5 · 3 reconnects in this conversation',
       body: 'socket hang up',
-      rows: [{ label: 'Attempt 2/5 · 3 reconnects in this conversation', value: '' }],
+      rows: [],
     });
   });
 

--- a/apps/mobile/src/__tests__/systemCard.test.ts
+++ b/apps/mobile/src/__tests__/systemCard.test.ts
@@ -141,6 +141,24 @@ describe('formatMobileSystemCard — goal 续跑卡按原因分说法', () => {
   });
 });
 
+describe('formatMobileSystemCard — 中断自动重连状态', () => {
+  const info = { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3 };
+
+  it('shows live progress, reason, current attempt, and conversation total', () => {
+    expect(formatMobileSystemCard('auto-resume', { ...info, live: true })).toEqual({
+      title: 'Reconnecting 2/5…',
+      body: 'socket hang up',
+      rows: [{ label: 'Attempt 2/5 · 3 reconnects in this conversation', value: '' }],
+    });
+  });
+
+  it('uses persisted outcome while keeping silent-stop records on their original copy', () => {
+    expect(['succeeded', 'failed', undefined].map((outcome) => (
+      formatMobileSystemCard('auto-resume', outcome ? { ...info, outcome } : {}).title
+    ))).toEqual(['Reconnected', 'Reconnect failed', 'Connection interrupted — resumed automatically']);
+  });
+});
+
 describe('commandNeedsRemoteSession', () => {
   // 新建会话的几秒窗口里 composer 全程可用(本 PR 的目的),于是用户可以在会话还没
   // 在被控端建成时发出 slash 命令。要远端的必须挡住(执行只会消费草稿再糊错误卡,

--- a/apps/mobile/src/__tests__/systemCard.test.ts
+++ b/apps/mobile/src/__tests__/systemCard.test.ts
@@ -143,20 +143,17 @@ describe('formatMobileSystemCard — goal 续跑卡按原因分说法', () => {
 
 describe('formatMobileSystemCard — 中断自动重连状态', () => {
   const info = { error: 'socket hang up', attempt: 2, maxAttempts: 5, sessionTotal: 3 };
-
   it('shows live progress, reason, current attempt, and conversation total', () => {
-    expect(formatMobileSystemCard('auto-resume', { ...info, live: true })).toEqual({
+    expect(formatMobileSystemCard('auto-resume', { ...info, live: true })).toMatchObject({
       title: 'Reconnecting 2/5…',
       subtitle: 'Attempt 2/5 · 3 reconnects in this conversation',
       body: 'socket hang up',
-      rows: [],
     });
   });
-
   it('uses persisted outcome while keeping silent-stop records on their original copy', () => {
-    expect(['succeeded', 'failed', undefined].map((outcome) => (
-      formatMobileSystemCard('auto-resume', outcome ? { ...info, outcome } : {}).title
-    ))).toEqual(['Reconnected', 'Reconnect failed', 'Connection interrupted — resumed automatically']);
+    expect(['succeeded', 'failed', undefined].map((outcome) =>
+      formatMobileSystemCard('auto-resume', outcome ? { ...info, outcome } : {}).title,
+    )).toEqual(['Reconnected', 'Reconnect failed', 'Connection interrupted — resumed automatically']);
   });
 });
 

--- a/apps/mobile/src/i18n/locales/en/message.json
+++ b/apps/mobile/src/i18n/locales/en/message.json
@@ -171,7 +171,15 @@
     "goalComplete": "Goal reached · {{turns}} turns · took {{duration}}",
     "goalResumed": "Usage restored, continuing the goal",
     "goalCapacityRetry": "Model service was busy — retrying the goal",
-    "autoResume": "Connection dropped, resumed automatically",
+    "autoResume": {
+      "separator": "Connection interrupted — resumed automatically",
+      "succeeded": "Reconnected",
+      "failed": "Reconnect failed",
+      "neutral": "Reconnect",
+      "pending": "Reconnecting…",
+      "pendingWithProgress": "Reconnecting {{attempt}}/{{total}}…",
+      "details": "Attempt {{attempt}}/{{total}} · {{count}} reconnects in this conversation"
+    },
     "modelLabel": "Model",
     "sessionLabel": "Session",
     "sessionResumed": "Resumed",

--- a/apps/mobile/src/i18n/locales/ja/message.json
+++ b/apps/mobile/src/i18n/locales/ja/message.json
@@ -171,7 +171,15 @@
     "goalComplete": "目標を達成 · {{turns}} 回 · 所要 {{duration}}",
     "goalResumed": "使用量が回復、目標を継続",
     "goalCapacityRetry": "モデルサービスが混雑していました。目標を再試行します",
-    "autoResume": "接続が切断、自動的に継続しました",
+    "autoResume": {
+      "separator": "接続が中断されたため、自動的に再開しました",
+      "succeeded": "再接続しました",
+      "failed": "再接続できませんでした",
+      "neutral": "再接続",
+      "pending": "再接続中…",
+      "pendingWithProgress": "再接続中 {{attempt}}/{{total}}…",
+      "details": "今回の再試行 {{attempt}}/{{total}} · この会話での再接続 {{count}} 回"
+    },
     "modelLabel": "モデル",
     "sessionLabel": "セッション",
     "sessionResumed": "再開済み",

--- a/apps/mobile/src/i18n/locales/ko/message.json
+++ b/apps/mobile/src/i18n/locales/ko/message.json
@@ -171,7 +171,15 @@
     "goalComplete": "목표 달성 · {{turns}}회 · 소요 {{duration}}",
     "goalResumed": "사용량이 회복되어 목표를 계속합니다",
     "goalCapacityRetry": "모델 서비스가 혼잡했습니다. 목표를 다시 시도합니다",
-    "autoResume": "연결이 끊겨 자동으로 계속했습니다",
+    "autoResume": {
+      "separator": "연결이 중단되어 자동으로 재개되었습니다",
+      "succeeded": "다시 연결되었습니다",
+      "failed": "다시 연결하지 못했습니다",
+      "neutral": "다시 연결",
+      "pending": "다시 연결하는 중…",
+      "pendingWithProgress": "다시 연결하는 중 {{attempt}}/{{total}}…",
+      "details": "이번 재시도 {{attempt}}/{{total}} · 이 대화에서 재연결 {{count}}회"
+    },
     "modelLabel": "모델",
     "sessionLabel": "세션",
     "sessionResumed": "재개됨",

--- a/apps/mobile/src/i18n/locales/zh-CN/message.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/message.json
@@ -171,7 +171,15 @@
     "goalComplete": "目标已达成 · {{turns}} 轮 · 耗时 {{duration}}",
     "goalResumed": "用量已恢复，继续目标",
     "goalCapacityRetry": "模型服务繁忙，正在重试目标",
-    "autoResume": "连接中断，已自动继续",
+    "autoResume": {
+      "separator": "连接中断，已自动继续",
+      "succeeded": "已重新连接",
+      "failed": "重新连接未成功",
+      "neutral": "重新连接",
+      "pending": "重新连接中…",
+      "pendingWithProgress": "重新连接中 {{attempt}}/{{total}}…",
+      "details": "本次重试 {{attempt}}/{{total}} · 本对话累计重连 {{count}} 次"
+    },
     "modelLabel": "模型",
     "sessionLabel": "对话",
     "sessionResumed": "已续接",

--- a/apps/mobile/src/session/inputProjection.ts
+++ b/apps/mobile/src/session/inputProjection.ts
@@ -63,6 +63,7 @@ export function normalizeInputProjection(value: unknown, fallbackSessionId = '')
     error: readString(record?.error),
     recovery: record?.recovery,
     errorRetryText: readString(record?.errorRetryText),
+    autoResumePending: readRecord(record?.autoResumePending),
     credentialSwitchWait: readCredentialSwitchWait(record?.credentialSwitchWait),
   };
 }

--- a/apps/mobile/src/session/messageNormalize.ts
+++ b/apps/mobile/src/session/messageNormalize.ts
@@ -309,6 +309,8 @@ export function normalizeRemoteMessages(messages: readonly RemoteMessage[]): Nor
     // user 以保留 turn 边界(上一段被截断 turn 的工具行按历史收敛),align 'agent'
     // 让卡片走系统卡的左侧版式而不是右侧用户气泡。
     if (message.role === 'user' && message.agentMeta?.autoResume === true) {
+      const autoResumeInfo = readRecord(message.agentMeta.autoResumeInfo) ?? {};
+      const autoResumeOutcome = message.agentMeta.autoResumeOutcome;
       result.push({
         key: messageNormalizeKey(message),
         source: message,
@@ -317,7 +319,12 @@ export function normalizeRemoteMessages(messages: readonly RemoteMessage[]): Nor
         label: 'user',
         body: '',
         systemCardType: 'auto-resume',
-        systemCardData: {},
+        systemCardData: {
+          ...autoResumeInfo,
+          ...(autoResumeOutcome === 'succeeded' || autoResumeOutcome === 'failed'
+            ? { outcome: autoResumeOutcome }
+            : {}),
+        },
         align: 'agent',
         createdAt: message.createdAt,
       });

--- a/apps/mobile/src/session/messageNormalize.ts
+++ b/apps/mobile/src/session/messageNormalize.ts
@@ -319,6 +319,7 @@ export function normalizeRemoteMessages(messages: readonly RemoteMessage[]): Nor
         label: 'user',
         body: '',
         systemCardType: 'auto-resume',
+        isSyntheticTrigger: true,
         systemCardData: {
           ...autoResumeInfo,
           ...(autoResumeOutcome === 'succeeded' || autoResumeOutcome === 'failed'

--- a/apps/mobile/src/session/messageRenderModel.ts
+++ b/apps/mobile/src/session/messageRenderModel.ts
@@ -24,6 +24,8 @@ import {
   hasSubagentMessages,
 } from '@/session/subagentGrouping';
 
+const MAX_VALID_DATE_MS = 8.64e15;
+
 export type MobileTodoItem = MessageRenderTodoItem;
 export type MobileMessageItem = MessageRenderMessageItem<NormalizedRemoteMessage>;
 export type MobileThinkingItem = MessageRenderThinkingItem<NormalizedRemoteMessage>;
@@ -83,6 +85,7 @@ export function buildMobileMessageRenderItems(
   scopeUnsettledToolsToActiveTail(normalized);
   markTurnFinalAssistants(normalized, options.isSessionStreaming === true);
   if (options.autoResumePending) {
+    const pendingCreatedAtMs = messageCreatedMs(normalized.at(-1));
     normalized.push(...normalizeRemoteMessages([{
       id: 'mobile:auto-resume-pending',
       clientId: 'mobile:auto-resume-pending',
@@ -91,7 +94,7 @@ export function buildMobileMessageRenderItems(
       content: '',
       toolUseId: null,
       agentMeta: { autoResume: true, autoResumeInfo: { ...options.autoResumePending, live: true } },
-      createdAt: '9999-12-31T23:59:59.999Z',
+      createdAt: pendingCreatedAtMs === null || pendingCreatedAtMs >= MAX_VALID_DATE_MS ? '' : new Date(pendingCreatedAtMs + 1).toISOString(),
     }]));
   }
   // 无子 agent(Claude `Agent` 嵌套)→ 走原始线性路径,并接上 live agent_task 卡:

--- a/apps/mobile/src/session/messageRenderModel.ts
+++ b/apps/mobile/src/session/messageRenderModel.ts
@@ -25,7 +25,6 @@ import {
 } from '@/session/subagentGrouping';
 
 const MAX_VALID_DATE_MS = 8.64e15;
-
 export type MobileTodoItem = MessageRenderTodoItem;
 export type MobileMessageItem = MessageRenderMessageItem<NormalizedRemoteMessage>;
 export type MobileThinkingItem = MessageRenderThinkingItem<NormalizedRemoteMessage>;
@@ -97,6 +96,7 @@ export function buildMobileMessageRenderItems(
       createdAt: pendingCreatedAtMs === null || pendingCreatedAtMs >= MAX_VALID_DATE_MS ? '' : new Date(pendingCreatedAtMs + 1).toISOString(),
     }]));
   }
+  collapseConsecutiveAutoResumeCards(normalized);
   // 无子 agent(Claude `Agent` 嵌套)→ 走原始线性路径,并接上 live agent_task 卡:
   // Task / collab:* 工具调用按 toolUseId→clientId 链接;无对应工具调用的孤儿更新兜底
   // 仅在会话运行中(isSessionStreaming)生效——空闲时孤儿是 stale 残留(工具调用已滑出
@@ -122,8 +122,24 @@ export function buildMobileMessageRenderItems(
  */
 function dropSyntheticTriggerItems(items: MobileMessageRenderItem[]): MobileMessageRenderItem[] {
   return items.filter(
-    (item) => !(item.type === 'message' && item.message.isSyntheticTrigger === true),
+    (item) => !(item.type === 'message' && item.message.isSyntheticTrigger === true && !item.message.systemCardType),
   );
+}
+
+/** 同一次中断只展示最新状态；旧行仍作为 turn boundary 留在 normalized 流中。 */
+function collapseConsecutiveAutoResumeCards(messages: NormalizedRemoteMessage[]): void {
+  let hasNewerCard = false;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.systemCardType === 'auto-resume') {
+      if (hasNewerCard) delete message.systemCardType;
+      hasNewerCard = true;
+    } else if (
+      message.systemCardType
+      || (message.isSyntheticTrigger !== true && message.kind !== 'thinking'
+        && (message.kind === 'tool' || !!message.attachments?.length || /[^\s\p{Cf}\p{Cc}]/u.test(message.body)))
+    ) hasNewerCard = false;
+  }
 }
 
 export function extractTodosFromMessage(message: RemoteMessage): MobileTodoItem[] | null {

--- a/apps/mobile/src/session/messageRenderModel.ts
+++ b/apps/mobile/src/session/messageRenderModel.ts
@@ -76,12 +76,24 @@ export type MobileMessageRenderItem =
 
 export function buildMobileMessageRenderItems(
   messages: readonly RemoteMessage[],
-  options: MessageRenderOptions = {},
+  options: MessageRenderOptions & { autoResumePending?: Record<string, unknown> | null; sessionId?: string } = {},
   taskUpdates?: ReadonlyMap<string, AgentTaskUpdate>,
 ): MobileMessageRenderItem[] {
   const normalized = normalizeRemoteMessages(messages);
   scopeUnsettledToolsToActiveTail(normalized);
   markTurnFinalAssistants(normalized, options.isSessionStreaming === true);
+  if (options.autoResumePending) {
+    normalized.push(...normalizeRemoteMessages([{
+      id: 'mobile:auto-resume-pending',
+      clientId: 'mobile:auto-resume-pending',
+      sessionId: options.sessionId ?? messages[0]?.sessionId ?? '',
+      role: 'user',
+      content: '',
+      toolUseId: null,
+      agentMeta: { autoResume: true, autoResumeInfo: { ...options.autoResumePending, live: true } },
+      createdAt: '9999-12-31T23:59:59.999Z',
+    }]));
+  }
   // 无子 agent(Claude `Agent` 嵌套)→ 走原始线性路径,并接上 live agent_task 卡:
   // Task / collab:* 工具调用按 toolUseId→clientId 链接;无对应工具调用的孤儿更新兜底
   // 仅在会话运行中(isSessionStreaming)生效——空闲时孤儿是 stale 残留(工具调用已滑出

--- a/apps/mobile/src/session/systemCard.ts
+++ b/apps/mobile/src/session/systemCard.ts
@@ -124,10 +124,41 @@ export function formatMobileSystemCard(
       rows: [],
     };
   }
-  if (type === 'auto-resume') return { title: i18n.t('message.systemCard.autoResume'), rows: [] };
+  if (type === 'auto-resume') return formatAutoResumeCard(data);
   if (type === 'agent-switch') return formatAgentSwitchCard(data);
   if (type === 'learn') return formatLearnCard(data);
   return formatSystemCard(type, data);
+}
+
+function formatAutoResumeCard(data: Record<string, unknown> | undefined): SystemCardPresentation {
+  const number = (value: unknown) => (
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+  );
+  const error = typeof data?.error === 'string' && data.error.trim() ? data.error : undefined;
+  const attempt = number(data?.attempt);
+  const maxAttempts = number(data?.maxAttempts);
+  const sessionTotal = number(data?.sessionTotal);
+  const outcome = data?.outcome === 'succeeded' || data?.outcome === 'failed'
+    ? data.outcome
+    : undefined;
+  const live = data?.live === true;
+  const hasInterruptionContext = !!(live || error || attempt || maxAttempts || sessionTotal || outcome);
+  if (!hasInterruptionContext) {
+    return { title: i18n.t('message.systemCard.autoResume.separator'), rows: [] };
+  }
+  const title = live
+    ? attempt && maxAttempts
+      ? i18n.t('message.systemCard.autoResume.pendingWithProgress', { attempt, total: maxAttempts })
+      : i18n.t('message.systemCard.autoResume.pending')
+    : i18n.t(`message.systemCard.autoResume.${outcome ?? 'neutral'}`);
+  const details = attempt && maxAttempts && sessionTotal
+    ? i18n.t('message.systemCard.autoResume.details', { attempt, total: maxAttempts, count: sessionTotal })
+    : undefined;
+  return {
+    title,
+    ...(error ? { body: error } : {}),
+    rows: details ? [{ label: details, value: '' }] : [],
+  };
 }
 
 /**

--- a/apps/mobile/src/session/systemCard.ts
+++ b/apps/mobile/src/session/systemCard.ts
@@ -131,34 +131,22 @@ export function formatMobileSystemCard(
 }
 
 function formatAutoResumeCard(data: Record<string, unknown> | undefined): SystemCardPresentation {
-  const number = (value: unknown) => (
-    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
-  );
+  const number = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
   const error = typeof data?.error === 'string' && data.error.trim() ? data.error : undefined;
   const attempt = number(data?.attempt);
   const maxAttempts = number(data?.maxAttempts);
   const sessionTotal = number(data?.sessionTotal);
-  const outcome = data?.outcome === 'succeeded' || data?.outcome === 'failed'
-    ? data.outcome
-    : undefined;
+  const outcome = data?.outcome === 'succeeded' || data?.outcome === 'failed' ? data.outcome : undefined;
   const hasInterruptionContext = !!(data?.live === true || error || attempt || maxAttempts || sessionTotal || outcome);
-  if (!hasInterruptionContext) {
-    return { title: i18n.t('message.systemCard.autoResume.separator'), rows: [] };
-  }
+  if (!hasInterruptionContext) return { title: i18n.t('message.systemCard.autoResume.separator'), rows: [] };
   const title = data?.live === true
     ? attempt && maxAttempts
       ? i18n.t('message.systemCard.autoResume.pendingWithProgress', { attempt, total: maxAttempts })
       : i18n.t('message.systemCard.autoResume.pending')
     : i18n.t(`message.systemCard.autoResume.${outcome ?? 'neutral'}`);
-  const details = attempt && maxAttempts && sessionTotal
-    ? i18n.t('message.systemCard.autoResume.details', { attempt, total: maxAttempts, count: sessionTotal })
-    : undefined;
-  return {
-    title,
-    ...(error ? { body: error } : {}),
-    subtitle: details,
-    rows: [],
-  };
+  const subtitle = attempt && maxAttempts && sessionTotal
+    ? i18n.t('message.systemCard.autoResume.details', { attempt, total: maxAttempts, count: sessionTotal }) : undefined;
+  return { title, ...(error ? { body: error } : {}), subtitle, rows: [] };
 }
 
 /**

--- a/apps/mobile/src/session/systemCard.ts
+++ b/apps/mobile/src/session/systemCard.ts
@@ -141,12 +141,11 @@ function formatAutoResumeCard(data: Record<string, unknown> | undefined): System
   const outcome = data?.outcome === 'succeeded' || data?.outcome === 'failed'
     ? data.outcome
     : undefined;
-  const live = data?.live === true;
-  const hasInterruptionContext = !!(live || error || attempt || maxAttempts || sessionTotal || outcome);
+  const hasInterruptionContext = !!(data?.live === true || error || attempt || maxAttempts || sessionTotal || outcome);
   if (!hasInterruptionContext) {
     return { title: i18n.t('message.systemCard.autoResume.separator'), rows: [] };
   }
-  const title = live
+  const title = data?.live === true
     ? attempt && maxAttempts
       ? i18n.t('message.systemCard.autoResume.pendingWithProgress', { attempt, total: maxAttempts })
       : i18n.t('message.systemCard.autoResume.pending')
@@ -157,7 +156,8 @@ function formatAutoResumeCard(data: Record<string, unknown> | undefined): System
   return {
     title,
     ...(error ? { body: error } : {}),
-    rows: details ? [{ label: details, value: '' }] : [],
+    subtitle: details,
+    rows: [],
   };
 }
 

--- a/apps/mobile/src/session/types.ts
+++ b/apps/mobile/src/session/types.ts
@@ -213,6 +213,7 @@ export interface InputProjection {
   error: string | null;
   recovery?: unknown;
   errorRetryText: string | null;
+  autoResumePending?: Record<string, unknown> | null;
   /**
    * 凭证切换等待态(对齐桌面 AgentInputProjection.credentialSwitchWait):发送需要
    * 重启共享 Codex 进程,但其它本地 Codex 任务在跑;消息保留在队首,挡路任务结束后


### PR DESCRIPTION
## 这次改了什么

### 摘要

让手机端在连接中断后的自动重连退避窗口、补发后和最终结束时都能看到同一套状态：中断原因、当前尝试次数、本对话累计重连次数，以及最终成功或失败。旧的 silent-stop 自动续跑记录仍保持原分隔卡文案。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1082
- 本 PR 包含：
  - 保留 `AgentInputProjection.autoResumePending`，在退避期间于消息流末尾渲染临时重连卡。
  - 读取落库消息的 `agentMeta.autoResumeInfo` / `autoResumeOutcome`，展示原因、次数和成功/失败/中性终态。
  - 补齐 zh-CN / en / ja / ko 文案及投影、归一化、渲染回归测试。
- 明确不包含：Desktop 行为、协议、数据库 migration、系统提示词、Electron 权限、凭证存储、mobile 原生配置或 runtime fingerprint 输入。
- 用户可见变化：中断后的 3–20 秒退避不再静默；手机端可见“重新连接中 N/5”、中断原因、本对话累计次数和最终结果。
- 是否存在 breaking change：无。旧被控端缺少 pending 字段时不出临时卡；旧 silent-stop 记录继续使用原文案。
- 远程 / Mobile 适配：仅读取现有 projection 与消息 metadata；不新增 IPC、推送、allowlist、workdir 或 agent 进程访问，SSH remote 与 device-link 链路不变。

### UI 变化

- 复用现有 `MobileSystemCard` 版式与语义主题 token；没有新增硬编码颜色，Light / Dark 均走同一套 `surface`、`border`、文本语义色。
- 未附截图：未启动 Mobile dev 实例，也未做 iOS / Android 实机目检。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §2「Layer System (Light & Dark)」、§10「Light / Dark Dual-Mode Delivery Gate」、§11「Voice & Content」；`apps/mobile/docs/mobile-design-guide.md` §2「颜色 token」、§4「组件约定」。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/inputProjection.test.ts src/__tests__/messageNormalize.test.ts src/__tests__/messageRenderModel.test.ts src/__tests__/systemCard.test.ts
结果：4 files / 93 tests passed

pnpm --filter mobile typecheck
结果：通过

pnpm check:i18n
结果：通过（仅仓库既有 warning）

pnpm check:i18n-glossary
结果：通过

pnpm test:unit
结果：全部 unit tier 通过

pnpm check:dco
结果：通过
```

### 手工验证

不涉及：未启动新的 Mobile dev / Metro 实例，避免占用或顶掉现有沙盒。

### 未执行的验证

- 未做 iOS / Android 实机功能验证。
- 未做 Light / Dark 实机目检；实现复用现有 themed system card，但不将这一点等同于双模式实机验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：mobile 消息渲染状态投影

### 影响与回滚

- 影响范围：仅 Mobile 会话消息渲染。临时卡在 pending projection 清除后消失；落库卡按已有 metadata 展示。
- 回滚 / 降级方式：回滚本 PR 即恢复原固定 auto-resume 系统卡；不涉及数据格式或 migration。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
