### PR TITLE
fix(desktop): 插件详情页顶栏吸顶,补回 mac 缺失的窗口拖拽区

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
@@ -2,7 +2,8 @@
  * Plugin detail presentation for configuration, Tools, permissions, and factual metadata.
  *
  * Inputs: the renderer-safe Plugin detail model plus the installed Ghost when available.
- * Outputs: accessible detail interactions and a single-row responsive action hero.
+ * Outputs: accessible detail interactions, a single-row responsive action hero, and the sticky
+ * top bar that carries the back affordance plus this page's macOS window-drag region.
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -11,7 +12,6 @@ import * as Dialog from '@radix-ui/react-dialog';
 import {
   AppWindow,
   Bot,
-  ArrowLeft,
   ChevronDown,
   Copy,
   Cpu,
@@ -58,6 +58,7 @@ import type { GhostPermissionItem, GhostToolDecl, InstalledGhost } from '../../.
 import { type GhostPluginDetail } from './lib/ghostPluginViewModel';
 import { GhostPluginIcon } from './GhostPluginIcon';
 import { ghostPluginSummary } from './lib/ghostPluginDetailModel';
+import { PluginDetailTopBar, usePluginDetailScrolled } from './PluginDetailTopBar';
 import './plugin-motion.css';
 
 interface GhostPluginDetailViewProps {
@@ -141,6 +142,7 @@ export function GhostPluginDetailView({
   onIconLoadError,
 }: GhostPluginDetailViewProps) {
   const { t } = useTranslation();
+  const { scrolled, onScroll } = usePluginDetailScrolled();
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [descriptionOverflows, setDescriptionOverflows] = useState(false);
   const descriptionRef = useRef<HTMLParagraphElement>(null);
@@ -194,18 +196,16 @@ export function GhostPluginDetailView({
   }, [detail.id, summary]);
 
   return (
-    <main className="plugin-motion-root h-full min-h-0 w-full overflow-y-auto bg-[var(--surface)] [scrollbar-gutter:stable_both-edges]">
+    <main
+      className="plugin-motion-root h-full min-h-0 w-full overflow-y-auto bg-[var(--surface)] [scrollbar-gutter:stable_both-edges]"
+      onScroll={onScroll}
+    >
+      <PluginDetailTopBar
+        label={t('settings.ghosts.detail.backToList')}
+        onBack={onBack}
+        scrolled={scrolled}
+      />
       <article className="plugin-detail-frame mx-auto w-full max-w-[824px] px-8 pb-16 pt-5 max-[760px]:px-6">
-        <button
-          type="button"
-          onClick={onBack}
-          className="-ml-3 mb-7 inline-flex h-9 w-fit select-none items-center gap-2 rounded-full px-3 text-13 text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
-          style={WINDOW_NO_DRAG_STYLE}
-        >
-          <ArrowLeft size={16} aria-hidden="true" />
-          {t('settings.ghosts.detail.backToList')}
-        </button>
-
         <header>
           <div className="plugin-detail-hero grid grid-cols-[64px_minmax(0,1fr)_auto] items-center gap-3">
             <GhostPluginIcon

--- a/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
@@ -1,12 +1,12 @@
-import { ArrowLeft, Download, ShieldCheck } from 'lucide-react';
+import { Download, ShieldCheck } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { WINDOW_NO_DRAG_STYLE } from '@/components/layout/windowDrag';
 import { cn } from '@/lib/utils';
 import { ghostPermissionItems } from '../../../shared/ghost';
 import type { PluginMarketDetail } from '../../../shared/pluginMarket';
 import { GhostPluginIcon } from './GhostPluginIcon';
 import { pluginPresentationOrigin } from './lib/pluginMarketPresentation';
+import { PluginDetailTopBar, usePluginDetailScrolled } from './PluginDetailTopBar';
 
 interface MarketPluginDetailViewProps {
   detail: PluginMarketDetail;
@@ -24,6 +24,7 @@ export function MarketPluginDetailView({
   onIconLoadError,
 }: MarketPluginDetailViewProps) {
   const { t } = useTranslation();
+  const { scrolled, onScroll } = usePluginDetailScrolled();
   const permissions = ghostPermissionItems(detail.manifest);
   const presentationOrigin = pluginPresentationOrigin(detail);
   const actionKey =
@@ -38,18 +39,16 @@ export function MarketPluginDetailView({
     busy || detail.installState === 'installed' || detail.installState === 'conflict';
 
   return (
-    <main className="plugin-motion-root h-full min-h-0 w-full overflow-y-auto bg-[var(--surface)] [scrollbar-gutter:stable_both-edges]">
+    <main
+      className="plugin-motion-root h-full min-h-0 w-full overflow-y-auto bg-[var(--surface)] [scrollbar-gutter:stable_both-edges]"
+      onScroll={onScroll}
+    >
+      <PluginDetailTopBar
+        label={t('settings.ghosts.detail.backToList')}
+        onBack={onBack}
+        scrolled={scrolled}
+      />
       <article className="plugin-detail-frame mx-auto w-full max-w-[824px] px-8 pb-16 pt-5 max-[760px]:px-6">
-        <button
-          type="button"
-          onClick={onBack}
-          className="-ml-3 mb-7 inline-flex h-9 items-center gap-2 rounded-full px-3 text-13 text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
-          style={WINDOW_NO_DRAG_STYLE}
-        >
-          <ArrowLeft size={16} aria-hidden="true" />
-          {t('settings.ghosts.detail.backToList')}
-        </button>
-
         <header>
           <div className="plugin-detail-hero grid grid-cols-[64px_minmax(0,1fr)_auto] items-center gap-3">
             <GhostPluginIcon

--- a/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
+++ b/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
@@ -1,0 +1,88 @@
+/**
+ * Shared sticky top bar for both Plugin detail surfaces (installed + market).
+ *
+ * Inputs: the back affordance's label and handler, plus the owning scroll frame's scrolled flag.
+ * Outputs: the back button and, on macOS, the page's own window-drag region.
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ */
+
+import { useCallback, useState, type UIEvent } from 'react';
+import { ArrowLeft } from 'lucide-react';
+
+import { WINDOW_DRAG_STYLE, WINDOW_NO_DRAG_STYLE } from '@/components/layout/windowDrag';
+import { useMacFullscreen } from '@/hooks/useMacFullscreen';
+import { cn } from '@/lib/utils';
+
+interface PluginDetailTopBarProps {
+  label: string;
+  onBack: () => void;
+  /** 滚动帧是否已离开顶部；顶栏据此从透明切到实底 + hairline。 */
+  scrolled: boolean;
+}
+
+/**
+ * 详情页滚动帧的「已离开顶部」判定。返回的 onScroll 直接挂在滚动容器上;
+ * scrollTop > 0 是布尔量,同值 setState 由 React bail out,重渲染只发生在
+ * 跨越顶部的那一次。
+ */
+export function usePluginDetailScrolled(): {
+  scrolled: boolean;
+  onScroll: (event: UIEvent<HTMLElement>) => void;
+} {
+  const [scrolled, setScrolled] = useState(false);
+  const onScroll = useCallback((event: UIEvent<HTMLElement>) => {
+    setScrolled(event.currentTarget.scrollTop > 0);
+  }, []);
+  return { scrolled, onScroll };
+}
+
+/**
+ * 详情页顶行:返回入口 + mac 侧的窗口拖拽区。
+ *
+ * mac 上通用 ContentHeader 在「侧栏展开 + 无注入内容 + 无右栏」时整条隐藏
+ * (ContentHeader.tsx 的 useContentHeaderHidden),自带顶部内容的页面自行承担
+ * 窗口拖动(windowDrag.tsx 的约定),本行是插件详情页的那一份。Windows /
+ * Linux 的通用 header 常驻,那 46px 即窗口抓手,本行在这两端纯作视觉顶栏。
+ * 行内交互元素标 no-drag 挖洞,且必须是本行的后代 —— Electron 的挖洞只在
+ * drag 元素自身后代上生效。
+ *
+ * sticky 让拖拽区在任意滚动位置都在场。滚动态为实底:正文滚到本行下方会落进
+ * Electron 的 drag 矩形,实底背景同时把这些元素遮住,视觉与命中区一致。
+ *
+ * 高度 h-16 + 内容垂直居中,与列表页 PluginManagementHeader 同规格
+ * (PluginManagementLayout.tsx:212),列表与详情间切换时顶栏高度恒定。窄宽度
+ * 下列表页顶栏撑到 7rem 排两行(plugin-motion.css 的 container query),本行
+ * 恒为 h-16。
+ *
+ * hairline 走 after 伪元素,脱离布局流,透明态与实底态之间高度恒定;article 的
+ * pt-5 之下,hero 起点为 64 + 20 = 84px。
+ */
+export function PluginDetailTopBar({ label, onBack, scrolled }: PluginDetailTopBarProps) {
+  const { isMac } = useMacFullscreen();
+
+  return (
+    <div
+      data-testid="plugin-detail-top-bar"
+      className={cn(
+        'sticky top-0 z-20 w-full',
+        'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-[var(--border-default)]',
+        'transition-[background-color] duration-150 after:transition-opacity after:duration-150',
+        'motion-reduce:transition-none motion-reduce:after:transition-none',
+        scrolled ? 'bg-[var(--surface)] after:opacity-100' : 'bg-transparent after:opacity-0',
+      )}
+      style={isMac ? WINDOW_DRAG_STYLE : undefined}
+    >
+      <div className="mx-auto flex h-16 w-full max-w-[824px] items-center px-8 max-[760px]:px-6">
+        <button
+          type="button"
+          onClick={onBack}
+          className="-ml-3 inline-flex h-9 w-fit select-none items-center gap-2 rounded-full px-3 text-13 text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+          style={WINDOW_NO_DRAG_STYLE}
+        >
+          <ArrowLeft size={16} aria-hidden="true" />
+          {label}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
+++ b/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
@@ -49,10 +49,11 @@ export function usePluginDetailScrolled(): {
  * sticky 让拖拽区在任意滚动位置都在场。滚动态为实底:正文滚到本行下方会落进
  * Electron 的 drag 矩形,实底背景同时把这些元素遮住,视觉与命中区一致。
  *
- * 高度 h-16 + 内容垂直居中,与列表页 PluginManagementHeader 同规格
- * (PluginManagementLayout.tsx:212),列表与详情间切换时顶栏高度恒定。窄宽度
- * 下列表页顶栏撑到 7rem 排两行(plugin-motion.css 的 container query),本行
- * 恒为 h-16。
+ * 高度 h-16 + 内容垂直居中,常规宽度下与列表页 PluginManagementHeader 同规格
+ * (PluginManagementLayout.tsx:212),列表与详情切换时顶栏高度恒定。主面板窄到
+ * 720px 以内时列表页顶栏排成工具行 + 页签行、撑到 7rem(plugin-motion.css 的
+ * container query,作用域是列表页的 plugin-management-layout-root);本行只承载
+ * 返回入口一个控件,各宽度下恒为 h-16。
  *
  * hairline 走 after 伪元素,脱离布局流,透明态与实底态之间高度恒定;article 的
  * pt-5 之下,hero 起点为 64 + 20 = 84px。

--- a/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
+++ b/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
@@ -57,6 +57,12 @@ export function usePluginDetailScrolled(): {
  *
  * hairline 走 after 伪元素,脱离布局流,透明态与实底态之间高度恒定;article 的
  * pt-5 之下,hero 起点为 64 + 20 = 84px。
+ *
+ * hairline 只画在 mac:那里 ContentHeader 整条隐藏,本行的 hairline 是顶栏与正文
+ * 之间唯一的边界。Windows / Linux 的 ContentHeader 常驻且自带 border-b,其
+ * --titlebar-border 是 --border-default 的 alias(cindy-light.ts:127 /
+ * cindy-dark.ts:131,两端同值),两条线同时出现即为一片 --surface 上相隔 64px 的
+ * 两条同色平行线;那两端由 ContentHeader 的下边框充当顶部分隔,本行只留实底。
  */
 export function PluginDetailTopBar({ label, onBack, scrolled }: PluginDetailTopBarProps) {
   const { isMac } = useMacFullscreen();
@@ -66,11 +72,13 @@ export function PluginDetailTopBar({ label, onBack, scrolled }: PluginDetailTopB
       data-testid="plugin-detail-top-bar"
       className={cn(
         'sticky top-0 z-20 w-full',
-        'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-[var(--border-default)]',
-        'transition-[background-color] duration-[var(--motion-fast,150ms)]',
-        'after:transition-opacity after:duration-[var(--motion-fast,150ms)]',
-        'motion-reduce:transition-none motion-reduce:after:transition-none',
-        scrolled ? 'bg-[var(--surface)] after:opacity-100' : 'bg-transparent after:opacity-0',
+        'transition-[background-color] duration-[var(--motion-fast,150ms)] motion-reduce:transition-none',
+        scrolled ? 'bg-[var(--surface)]' : 'bg-transparent',
+        isMac && [
+          'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-[var(--border-default)]',
+          'after:transition-opacity after:duration-[var(--motion-fast,150ms)] motion-reduce:after:transition-none',
+          scrolled ? 'after:opacity-100' : 'after:opacity-0',
+        ],
       )}
       style={isMac ? WINDOW_DRAG_STYLE : undefined}
     >

--- a/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
+++ b/apps/desktop/src/renderer/features/plugin/PluginDetailTopBar.tsx
@@ -67,7 +67,8 @@ export function PluginDetailTopBar({ label, onBack, scrolled }: PluginDetailTopB
       className={cn(
         'sticky top-0 z-20 w-full',
         'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-[var(--border-default)]',
-        'transition-[background-color] duration-150 after:transition-opacity after:duration-150',
+        'transition-[background-color] duration-[var(--motion-fast,150ms)]',
+        'after:transition-opacity after:duration-[var(--motion-fast,150ms)]',
         'motion-reduce:transition-none motion-reduce:after:transition-none',
         scrolled ? 'bg-[var(--surface)] after:opacity-100' : 'bg-transparent after:opacity-0',
       )}
@@ -77,7 +78,7 @@ export function PluginDetailTopBar({ label, onBack, scrolled }: PluginDetailTopB
         <button
           type="button"
           onClick={onBack}
-          className="-ml-3 inline-flex h-9 w-fit select-none items-center gap-2 rounded-full px-3 text-13 text-[var(--text-secondary)] transition-colors duration-150 hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+          className="-ml-3 inline-flex h-9 w-fit select-none items-center gap-2 rounded-full px-3 text-13 text-[var(--text-secondary)] transition-colors duration-[var(--motion-fast,150ms)] hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
           style={WINDOW_NO_DRAG_STYLE}
         >
           <ArrowLeft size={16} aria-hidden="true" />

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
@@ -152,13 +152,20 @@ describe('Ghost plugin detail sections', () => {
 
     const scrollSurface = container.querySelector('main');
     const detailFrame = container.querySelector('article');
-    const backButton = detailFrame?.querySelector(':scope > button');
+    // 返回按钮住在吸顶顶栏里(mac 的窗口拖拽区)。顶栏内层复用同一条 824px
+    // 内容框,与正文左缘对齐。
+    const topBar = container.querySelector('[data-testid="plugin-detail-top-bar"]');
+    const topBarFrame = topBar?.querySelector(':scope > div');
+    const backButton = topBar?.querySelector('button');
     const detailHero = detailFrame?.querySelector('.plugin-detail-hero');
     const detailActions = detailFrame?.querySelector('.plugin-detail-actions');
     expect(scrollSurface?.className).toContain('[scrollbar-gutter:stable_both-edges]');
     expect(detailFrame?.className).toContain('plugin-detail-frame');
     expect(detailFrame?.className).toContain('mx-auto');
     expect(detailFrame?.className).toContain('max-w-[824px]');
+    expect(topBar?.className).toContain('sticky');
+    expect(topBarFrame?.className).toContain('mx-auto');
+    expect(topBarFrame?.className).toContain('max-w-[824px]');
     expect(backButton?.className).toContain('-ml-3');
     expect(detailHero?.className).toContain('grid-cols-[64px_minmax(0,1fr)_auto]');
     expect(detailActions?.className).toContain('flex-nowrap');

--- a/apps/desktop/src/renderer/features/plugin/__tests__/PluginDetailTopBar.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/PluginDetailTopBar.test.tsx
@@ -73,6 +73,26 @@ describe('PluginDetailTopBar', () => {
     },
   );
 
+  it.each(['win32', 'linux'] as const)(
+    'leaves the top separator to the shared ContentHeader on %s',
+    (platform) => {
+      stubPlatform(platform);
+
+      render(<Harness />);
+
+      // 这两端 ContentHeader 常驻且自带 border-b(--titlebar-border 与
+      // --border-default 同值),本行只留实底,顶部分隔由那条下边框承担。
+      const bar = screen.getByTestId('plugin-detail-top-bar');
+      expect(bar.className).not.toContain('after:');
+
+      const frame = screen.getByTestId('scroll-frame');
+      Object.defineProperty(frame, 'scrollTop', { value: 24, configurable: true });
+      fireEvent.scroll(frame);
+      expect(bar.className).toContain('bg-[var(--surface)]');
+      expect(bar.className).not.toContain('after:');
+    },
+  );
+
   it.each(['darwin', 'win32', 'linux'] as const)('sticks to the top on %s', (platform) => {
     stubPlatform(platform);
 

--- a/apps/desktop/src/renderer/features/plugin/__tests__/PluginDetailTopBar.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/PluginDetailTopBar.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Regression coverage for the Plugin detail sticky top bar.
+ *
+ * 这条顶栏是 mac 上插件详情页的窗口拖拽区(通用 ContentHeader 在「侧栏展开 +
+ * 无注入内容 + 无右栏」时整条隐藏);Windows / Linux 的通用 header 常驻,拖拽
+ * 区归它。本文件锁住这个平台分流与顶栏的吸顶几何。
+ * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PluginDetailTopBar, usePluginDetailScrolled } from '../PluginDetailTopBar';
+
+/** jsdom 下 `-webkit-app-region` 只能从 React 写进 style 对象的驼峰键读回。 */
+function appRegionOf(element: HTMLElement): string {
+  return (element.style as CSSStyleDeclaration & { WebkitAppRegion?: string }).WebkitAppRegion ?? '';
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(window, 'electronAPI');
+});
+
+function stubPlatform(platform: 'darwin' | 'win32' | 'linux') {
+  vi.stubGlobal('electronAPI', {
+    platform,
+    getFullscreenState: () => Promise.resolve(false),
+    onFullscreenChange: () => () => {},
+  });
+}
+
+/** 滚动容器 + 顶栏的最小宿主，复刻两个详情视图的接线方式。 */
+function Harness({ onBack = () => {} }: { onBack?: () => void }) {
+  const { scrolled, onScroll } = usePluginDetailScrolled();
+  return (
+    <main data-testid="scroll-frame" onScroll={onScroll}>
+      <PluginDetailTopBar label="Back" onBack={onBack} scrolled={scrolled} />
+    </main>
+  );
+}
+
+describe('PluginDetailTopBar', () => {
+  it('carries the window drag region on macOS and keeps the back button clickable', () => {
+    stubPlatform('darwin');
+    const onBack = vi.fn();
+
+    render(<Harness onBack={onBack} />);
+
+    const bar = screen.getByTestId('plugin-detail-top-bar');
+    expect(appRegionOf(bar)).toBe('drag');
+
+    // Electron 的挖洞只在 drag 元素自身后代上生效(ContentHeader.tsx /
+    // FileTabsBar.tsx 都记过这条),所以返回按钮必须落在本行内部。
+    const back = screen.getByRole('button', { name: 'Back' });
+    expect(bar.contains(back)).toBe(true);
+    expect(appRegionOf(back)).toBe('no-drag');
+
+    fireEvent.click(back);
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['win32', 'linux'] as const)(
+    'leaves the drag region to the shared ContentHeader on %s',
+    (platform) => {
+      stubPlatform(platform);
+
+      render(<Harness />);
+
+      const bar = screen.getByTestId('plugin-detail-top-bar');
+      expect(appRegionOf(bar)).toBe('');
+    },
+  );
+
+  it.each(['darwin', 'win32', 'linux'] as const)('sticks to the top on %s', (platform) => {
+    stubPlatform(platform);
+
+    render(<Harness />);
+
+    // 吸顶三端一致,返回入口常驻;平台分流只作用于 drag。
+    const bar = screen.getByTestId('plugin-detail-top-bar');
+    expect(bar.className).toContain('sticky');
+
+    const frame = screen.getByTestId('scroll-frame');
+    Object.defineProperty(frame, 'scrollTop', { value: 24, configurable: true });
+    fireEvent.scroll(frame);
+    expect(bar.className).toContain('bg-[var(--surface)]');
+  });
+
+  it('matches the catalog header geometry so the bar does not jump on entry', () => {
+    stubPlatform('darwin');
+
+    render(<Harness />);
+
+    // 列表与详情是同一条顶栏的两个状态,几何取自 PluginManagementLayout.tsx
+    // 的 PluginManagementHeader(h-16 + flex h-full items-center)。
+    const frame = screen.getByTestId('plugin-detail-top-bar').firstElementChild;
+    expect(frame?.className).toContain('h-16');
+    expect(frame?.className).toContain('items-center');
+  });
+
+  it('turns opaque only after the frame leaves the top', () => {
+    stubPlatform('darwin');
+
+    render(<Harness />);
+
+    const bar = screen.getByTestId('plugin-detail-top-bar');
+    // 顶部静止态:透明背景,hairline 隐藏。
+    expect(bar.className).toContain('bg-transparent');
+    expect(bar.className).toContain('after:opacity-0');
+
+    const frame = screen.getByTestId('scroll-frame');
+    Object.defineProperty(frame, 'scrollTop', { value: 24, configurable: true });
+    fireEvent.scroll(frame);
+
+    // 滚动态为实底:落进 drag 矩形的正文元素同时被背景遮住,视觉与命中区一致。
+    expect(bar.className).toContain('bg-[var(--surface)]');
+    expect(bar.className).toContain('after:opacity-100');
+
+    Object.defineProperty(frame, 'scrollTop', { value: 0, configurable: true });
+    fireEvent.scroll(frame);
+    expect(bar.className).toContain('bg-transparent');
+  });
+});

--- a/apps/desktop/src/renderer/features/plugin/__tests__/PluginDetailTopBar.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/PluginDetailTopBar.test.tsx
@@ -88,13 +88,15 @@ describe('PluginDetailTopBar', () => {
     expect(bar.className).toContain('bg-[var(--surface)]');
   });
 
-  it('matches the catalog header geometry so the bar does not jump on entry', () => {
+  it('matches the catalog header height at regular pane widths', () => {
     stubPlatform('darwin');
 
     render(<Harness />);
 
     // 列表与详情是同一条顶栏的两个状态,几何取自 PluginManagementLayout.tsx
-    // 的 PluginManagementHeader(h-16 + flex h-full items-center)。
+    // 的 PluginManagementHeader(h-16 + flex h-full items-center)。列表页在
+    // 720px 以内排两行撑到 7rem,那条 container query 的作用域是列表页根节点,
+    // 本行各宽度下恒为 h-16。
     const frame = screen.getByTestId('plugin-detail-top-bar').firstElementChild;
     expect(frame?.className).toContain('h-16');
     expect(frame?.className).toContain('items-center');


### PR DESCRIPTION
## 这次改了什么

### 摘要

mac 上从插件列表点进具体插件后，整页拖不动窗口。修掉这个缺陷，同时把详情页的
返回入口改成吸顶常驻。

根因：mac 的通用 ContentHeader 在「侧栏展开 + 无注入内容 + 无右栏」时整条隐藏
（`ContentHeader.tsx` 的 `useContentHeaderHidden`），自带顶部内容的页面必须自己
承担窗口拖动（`windowDrag.tsx` 开头的约定）。插件列表页由 `PluginManagementHeader`
的 h-16 顶行承担，进详情后那条 header 被整个换掉，而两个详情视图的根都是纯滚动
`<main>`，没有任何 `WINDOW_DRAG_STYLE`。技能详情页做了同样的事
（`SkillhubDetailView.tsx:1849`），插件详情是漏做。

Windows / Linux 不受该缺陷影响：那边 ContentHeader 不隐藏，46px 一直是拖拽抓手。

改法：把两个详情视图已有的「返回按钮行」抽成共享的 `PluginDetailTopBar`，sticky
吸顶，滚动后淡入实底背景；mac 上另加 1px hairline（那边 ContentHeader 隐藏，需要
自己画顶部分隔）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 补回 mac 侧插件详情页（已安装 + 市场两个视图）的窗口拖拽区
  - 返回入口改为吸顶常驻（三端一致，理由见「UI 变化」）
- 明确不包含：
  - 其他自带顶栏页面的同类排查（技能详情页已有 drag，其余未逐个核）
  - 防复发的路由级拖拽区测试（建议另开：对 `useContentHeaderHidden` 会命中的
    路由断言页面根部存在 drag 元素）
- 用户可见变化：
  - **mac**：详情页顶部恢复可拖动窗口，滚动后依然可拖；顶栏滚动后显形为实底 + hairline
  - **三端**：返回入口吸顶常驻
  - **Windows / Linux**：顶栏滚动后为实底，顶部分隔沿用上方 ContentHeader 已有的
    `border-b`
  - 未滚动时视觉与改造前一致；正文起点逐像素不变
- 是否存在 breaking change：无

### UI 变化

**macOS Light — 详情页未滚动**（顶栏透明、无边框，与改造前一致）

<img width="777" height="197" alt="drag-noscroll-light" src="https://github.com/user-attachments/assets/fc0ef666-df92-45ab-8d94-0ee2d93118f6" />

**macOS Light — 详情页滚动后**（顶栏吸顶显形：实底 + hairline，返回按钮常驻）

<img width="798" height="145" alt="drag-light" src="https://github.com/user-attachments/assets/e74f0b4e-200f-42bd-8087-09a0fe0be8b5" />

**macOS Dark — 滚动后同一位置**（双模式核对）

<img width="779" height="145" alt="drag-dark" src="https://github.com/user-attachments/assets/51f206f4-7ba1-4f64-a507-3f0ff84fe03c" />

**Windows — 详情页滚动后**（顶栏实底、单线：顶部分隔由 ContentHeader 的 `border-b` 承担）

<img width="792" height="594" alt="drag-win" src="https://github.com/user-attachments/assets/c409949a-2ba6-4c6a-89a8-15ddb4c6e258" />

两段状态（前三张截图为 macOS）：

- **未滚动**：透明、无边框，返回按钮位置与改造前完全一致。
- **滚动后**：淡入实底背景 + 1px hairline，返回按钮常驻。

**hairline 只画在 mac。** mac 上 ContentHeader 整条隐藏，本行的 hairline 是顶栏与
正文之间唯一的边界。Windows / Linux 的 ContentHeader 常驻且自带 `border-b`，而
`--titlebar-border` 是 `--border-default` 的 alias（`cindy-light.ts:127` /
`cindy-dark.ts:131`，Light / Dark 两端同值），两条线同时出现就是一片 `--surface` 上
相隔 64px 的两条同色平行线 —— Windows 实机确认这个观感确实差。那两端改为由
ContentHeader 的下边框充当顶部分隔，本行只留实底，与插件列表页顶栏（同样无下边框）
一致。

顶栏高度取 `h-16`(64px) + 内容垂直居中，常规宽度下与列表页 `PluginManagementHeader`
（`PluginManagementLayout.tsx:212`，同为 h-16 + `flex h-full items-center`）逐字
对齐 —— 列表与详情是同一条顶栏的两个状态，点进 / 退出时高度恒定。`article`
保持原本的 `pt-5`，hero 起点（64 + 20 = 84px）与改造前逐像素一致。

窄宽度是个例外，且是有意为之：主面板 ≤720px 时列表页顶栏排成「工具行 + 页签行」
两行、撑到 7rem（112px），这条 container query 的作用域是列表页根节点
`.plugin-management-layout-root`（`plugin-motion.css:144-162`），详情视图在
`GhostPluginPage.tsx:847/862` 提前 return，本就不在该容器内。列表页长高是因为
装了两行控件；详情顶栏只承载一个返回按钮，跟到 112px 会得到一整条近乎空白的
chrome。因此本行各宽度下恒为 h-16，代价是窄窗口下进出详情有一次 112 → 64 的
高度变化。

吸顶三端一致，是有意的产品选择而非拖拽修复的副产品：插件详情能拉很长（权限 /
Tools 列表），长页面的返回入口常驻在三端都是实际收益，滚到底想返回不必先滚回顶部。
代价是非 mac 顶部叠成 ContentHeader 46px + 本行 64px，与列表页现有的 46 + 64 同构。

需要说清的是：这里统一的是**视觉**，拖拽语义并未统一 —— 本行在 mac 上是窗口拖拽
区，在 Windows / Linux 上是纯视觉顶栏，那两端的窗口抓手仍是上方常驻的 ContentHeader。
所以支撑「三端都吸顶」的理由是上面那条 UX 收益，不是「避免平台间交互分叉」。

- 引用的设计规范：
  - `DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：颜色全部走语义 token
    （`--surface` / `--border-default`），无硬编码值、无只适配单模式的条件补丁
  - `DESIGN.md` §10 Token Selection Rules for New UI 第 2 条「Slots first」：背景与
    描边都取 Tier-1 slot，未引入新 alias 或 singleton
  - `DESIGN.md` §14.4 Motion & Transitions：时长引用 `--motion-fast` token
    （`duration-[var(--motion-fast,150ms)]`），跟随 `globals.css:129-141` 在
    `prefers-reduced-motion` 下的整档归零；只过渡 `background-color` / `opacity`
    （compositor 友好），未用 `transition-all`，另带 `motion-reduce:transition-none`
    兜底；无新增 `@keyframes`，不需要注册 reduced-motion 白名单
  - `DESIGN.md` §8 Window & Adaptive Behavior：吸顶栏 64px，最小窗口 800×600 下
    正文仍有可用高度；顶栏内容随窗口收窄沿用 `max-[760px]:px-6` 的既有留白规则

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部 workspace PASS（exit=0）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/features/plugin/
结果：0 问题

pnpm --filter desktop exec vitest run src/renderer/features/plugin
结果：12 files / 95 tests passed（新增 PluginDetailTopBar.test.tsx，6 个 it 块 / 10 个用例）

pnpm check:dco
结果：4 commits signed off
```

新增测试覆盖：

- mac 标 `drag`，且返回按钮是它的**后代**并标 `no-drag` —— Electron 的挖洞只在
  drag 元素的后代上可靠生效（`ContentHeader.tsx:158`、`FileTabsBar.tsx:15` 都记过
  sibling overlay 不被计入）
- Windows / Linux 上 drag 与 hairline 都归常驻的 ContentHeader（那边 46px 顶栏既是
  抓手，其 `border-b` 也是顶部分隔）
- 三端都吸顶，滚动后转实底
- 顶栏几何在常规宽度下与列表页 header 一致（h-16 + items-center），锁住进出详情的高度
- 顶栏内层复用同一条 824px 内容框，防返回按钮与正文左缘错开

### 手工验证

macOS 实机运行，主窗口侧栏展开、右栏关闭，路径：插件列表 → 点进具体插件详情页。

| 项 | 结果 |
|---|---|
| Light / 未滚动 | 顶栏透明、无边框，返回按钮位置与改造前一致（截图 1） |
| Light / 滚动后 | 顶栏吸顶显形，实底 + 1px hairline，返回按钮常驻（截图 2） |
| Dark / 滚动后 | 同一位置双模式核对，配色与 hairline 正常（截图 3） |
| 顶部按住拖动窗口 | 通过 |
| 带设置 UI 的插件详情页（内嵌 `<webview>`） | 通过：吸顶栏压在 webview 之上，返回入口未被遮 |

前三行对应「UI 变化」里的三张实机截图。

**Windows 实机**（另一台机器，插件详情页）：

| 项 | 结果 |
|---|---|
| 125% 缩放下滚动后的 1px hairline | 无闪烁、无粗细不均 |
| 窗口拉到 800×600 时的 46 + 64 双层 chrome | 空间不紧张 |
| 46px 与 64px 两条同色平行线的观感 | **不通过** —— 据此改为 hairline 只画在 mac |

### 未执行的验证

- **Linux 实机未跑**：drag 分支按 `isMac` 短路、hairline 分支同源，均由单测覆盖；
  Linux 上 ContentHeader 与 Windows 同为常驻带 `border-b`，观感等价，未单独目检。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：仅插件详情页（已安装 + 市场）两个视图的顶部区域。不涉及 main 进程、
  IPC、协议、数据库、用户数据。
- 跨平台差异说明：mac 走新增的页面级 drag 区并自画 hairline，Windows / Linux 的窗口
  抓手与顶部分隔都继续由常驻的 ContentHeader（46px + `border-b`）承担。两处分流都由
  `useMacFullscreen().isMac` 判定，与 `useContentHeaderHidden` 的平台条件同源——差异
  的根因只有一个：mac 隐藏了 ContentHeader，drag 与 hairline 是它留下的两个空缺。
- **webview 层叠（已实机确认，无需改动）**：详情页正文在插件带设置 UI 时内嵌
  Electron `<webview>`（`GhostPluginDetailView.tsx:347`，触发条件是 manifest 声明了
  `settingsHtml`）。仓库里记过同类风险——`ghostPanelBody.tsx:134-136`：「z-index
  必须压过 webview：与 lightbox / 对话框等『webview 上方浮层』同档（`z-[10000]`）；
  默认 `z-50` 会被面板 webview 的合成层盖住」。据此本行的 `z-20` 存在被遮的可能，
  已在 macOS 上用带 `settingsHtml` 的插件详情页实测：**吸顶栏压在 webview 之上，
  返回入口未被遮**，无需提层。差异原因是那条记载针对的是面板场景（body 级 portal
  对上高 z-index 的面板容器）；详情页里吸顶栏与 webview 同处一棵滚动子树，定位元素
  的 `z-20` 正常压过其后的常规流内容。
- 回滚 / 降级方式：revert 本 PR 的 commit 即可，无数据迁移、无持久化状态、无灰度开关。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`PluginDetailTopBar.tsx` 头部记录了决策依据与 Electron 约束）
- [x] 已确认测试结果或说明未执行原因

