### PR TITLE
test(desktop): 跳过无符号链接权限环境的导出用例

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
@@ -13,6 +13,25 @@ import { signGhostPackage } from '../ghostSignature';
 /** 测试用发布者密钥对(每次进程一对,签名/验签都走真实 ed25519)。 */
 const { privateKey: publisherKey } = crypto.generateKeyPairSync('ed25519');
 
+// Windows 未开启开发者模式且进程无特权时创建 symlink 会 EPERM。精确探测本用例
+// 需要的目录/文件两种链接能力,不可用时只跳过 symlink 专属覆盖。
+const canSymlink = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-ghost-export-symlink-probe-'));
+  try {
+    const targetDir = path.join(probeDir, 'target-dir');
+    const targetFile = path.join(targetDir, 'target.txt');
+    fs.mkdirSync(targetDir);
+    fs.writeFileSync(targetFile, 'probe');
+    fs.symlinkSync(targetDir, path.join(probeDir, 'linked-dir'));
+    fs.symlinkSync(targetFile, path.join(probeDir, 'linked-file'));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
 /** 每个用例独立的临时安装目录(规则 23:测试路径一律 os.tmpdir)。 */
 let workDir: string;
 let ghostDir: string;
@@ -298,7 +317,7 @@ describe('exportGhostPackage', () => {
     expect(signedZip.files['templates/empty/']?.dir).toBe(true);
   });
 
-  it('symlink 条目不跟随,不打进导出包', async () => {
+  it.skipIf(!canSymlink)('symlink 条目不跟随,不打进导出包', async () => {
     const outside = path.join(workDir, 'outside-secret');
     await fs.promises.mkdir(outside);
     await fs.promises.writeFile(path.join(outside, 'secret.txt'), 'secret');


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 未开启开发者模式且当前进程没有符号链接权限时，`exportGhostPackage` 的 symlink 回归用例会在创建夹具阶段报 `EPERM`，导致全量单测门禁失败。

本 PR 在测试文件中精确探测目录与文件 symlink 能力；能力不足时只跳过该专属用例，具备能力的平台继续执行原有“不跟随 symlink”断言。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Desktop 插件导出测试的 symlink 能力探测与条件跳过
- 明确不包含：插件导出生产逻辑、打包格式或安全策略调整
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=1 src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
结果：通过（25 passed，1 skipped；当前 Windows 环境无 symlink 权限）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过，全部必跑 workspace 通过

pnpm check:dco
结果：通过，1 个提交已签名
```

### 手工验证

在未开启 Windows symlink 权限的本机复现修复前 `EPERM`，修复后定向测试与全量单测均正常完成。

### 未执行的验证

未在 macOS 实机单独执行；具备 symlink 能力的平台仍运行原测试逻辑，Linux CI 会继续覆盖该断言。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅测试运行行为；不改变生产代码。无 symlink 权限时少执行一条无法建立夹具的用例，有权限平台覆盖不变。
- 回滚 / 降级方式：revert 本提交即可恢复原测试行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因