### PR TITLE
fix(desktop): TapDB 上报按构建区域配对项目与采集端

### DIFF
--- a/apps/desktop/src/main/security/csp.ts
+++ b/apps/desktop/src/main/security/csp.ts
@@ -119,7 +119,8 @@ export function buildContentSecurityPolicy(ctx: CspContext): string {
 
   // connect-src: most backend traffic goes through main over IPC, but the
   // renderer DOES make a few direct exits — TapDB analytics XHR to
-  // https://e.tapdb.com, model-viewer decoder fetches to https://www.gstatic.com,
+  // https://e.tapdb.com (cn) / https://e.tapdb.ap-sg.tapapis.com (global),
+  // model-viewer decoder fetches to https://www.gstatic.com,
   // and <model-viewer> fetch()-ing models over the xdt-model: / cindy-media:
   // schemes (mivo 老缓存与媒体总仓 GLB 各走各的协议). https: covers the first
   // two; the privileged schemes are listed explicitly (a privileged scheme

--- a/apps/desktop/src/renderer/__tests__/tapdbConsentGate.test.ts
+++ b/apps/desktop/src/renderer/__tests__/tapdbConsentGate.test.ts
@@ -53,7 +53,13 @@ vi.mock('@/lib/logger', () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
 }));
 vi.mock('@/lib/makerChatStore', () => ({ makerChatStore: workingStore.makerChatStore }));
-vi.mock('../../shared/endpoints', () => ({ TAPDB_EVENT_URL: 'https://example.invalid/event' }));
+vi.mock('../../shared/endpoints', () => ({
+  TAPDB_EVENT_URL_BY_REGION: {
+    cn: 'https://example.invalid/event',
+    global: 'https://example.invalid/event',
+    dev: 'https://example.invalid/event',
+  },
+}));
 
 type SettingsPayload = {
   privacyConsentAccepted: boolean;

--- a/apps/desktop/src/renderer/__tests__/tapdbRegionProject.test.ts
+++ b/apps/desktop/src/renderer/__tests__/tapdbRegionProject.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+/**
+ * tapdbRegionProject.test.ts
+ * ---------------------------------------------------------------------------
+ * TapDB 项目与构建区域的配对不变量。
+ *
+ * 背景事故:客户端曾把 cn / global 两个区域都报进国内项目(appId 写死 +
+ * 端点写死),国际项目因此没有任何 user_login,服务端按区域上报的充值(charge)
+ * 事件全部因 user_id 无效不计入收入统计。
+ *
+ * 这里把「appId 与采集端点同区配对、且与服务端 model-access-server 的
+ * TAPDB_PROJECTS 一致」钉成回归测试:两侧任何一侧单改 ID 都会先在这里爆掉。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/vendor/tapdb/tapdb.esm.min.js', () => ({ default: {} }));
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+}));
+vi.mock('@/lib/makerChatStore', () => ({
+  makerChatStore: { subscribeAll: () => () => {}, getRunningSnapshot: () => new Map() },
+}));
+
+describe('TAPDB_PROJECT_BY_REGION', () => {
+  it('cn 区配对国内项目与国内采集端', async () => {
+    const { TAPDB_PROJECT_BY_REGION } = await import('../analytics/tapdbClient');
+    expect(TAPDB_PROJECT_BY_REGION.cn).toEqual({
+      appId: 'gczef0ey3e8ogpmizs',
+      serverUrl: 'https://e.tapdb.com/event',
+    });
+  });
+
+  it('global 区配对国际项目与国际采集端(不得再落回国内项目)', async () => {
+    const { TAPDB_PROJECT_BY_REGION } = await import('../analytics/tapdbClient');
+    expect(TAPDB_PROJECT_BY_REGION.global).toEqual({
+      appId: 'h08anxdfrvfocfs894',
+      serverUrl: 'https://e.tapdb.ap-sg.tapapis.com/event',
+    });
+    expect(TAPDB_PROJECT_BY_REGION.global.appId).not.toBe(TAPDB_PROJECT_BY_REGION.cn.appId);
+    expect(TAPDB_PROJECT_BY_REGION.global.serverUrl).not.toBe(
+      TAPDB_PROJECT_BY_REGION.cn.serverUrl,
+    );
+  });
+
+  it('dev 为内部构建身份,行为语义归 cn 系,复用国内项目', async () => {
+    const { TAPDB_PROJECT_BY_REGION } = await import('../analytics/tapdbClient');
+    expect(TAPDB_PROJECT_BY_REGION.dev).toEqual(TAPDB_PROJECT_BY_REGION.cn);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/tapdbRegionProject.test.ts
+++ b/apps/desktop/src/renderer/__tests__/tapdbRegionProject.test.ts
@@ -9,8 +9,9 @@
  * 端点写死),国际项目因此没有任何 user_login,服务端按区域上报的充值(charge)
  * 事件全部因 user_id 无效不计入收入统计。
  *
- * 这里把「appId 与采集端点同区配对、且与服务端 model-access-server 的
- * TAPDB_PROJECTS 一致」钉成回归测试:两侧任何一侧单改 ID 都会先在这里爆掉。
+ * 这里把 desktop 侧「appId 与采集端点同区配对」钉成回归测试。配对值需与服务端
+ * model-access-server 的 TAPDB_PROJECTS 人工同步维护——本仓测试无法校验服务端
+ * 常量,它只保证 desktop 内部不再出现"global 落回国内项目"的回退。
  */
 
 import { describe, expect, it, vi } from 'vitest';

--- a/apps/desktop/src/renderer/analytics/tapdbClient.ts
+++ b/apps/desktop/src/renderer/analytics/tapdbClient.ts
@@ -60,20 +60,38 @@
  * 避免一次浮窗弹出被算成一次 PV。
  */
 
+import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 import TapDBAPI from '@/vendor/tapdb/tapdb.esm.min.js';
 import { createLogger } from '@/lib/logger';
 import { makerChatStore } from '@/lib/makerChatStore';
-import { TAPDB_EVENT_URL } from '../../shared/endpoints';
+import { CURRENT_CINDY_REGION } from '../../shared/brandRegion';
+import { TAPDB_EVENT_URL_BY_REGION } from '../../shared/endpoints';
 
 const log = createLogger('tapdb');
 
 // ── Config ──────────────────────────────────────────────────────────────────
 //
-// serverUrl 是上报全量 URL(SDK 会直接 POST 到这个地址,不会再追加路径)。
-const TAPDB_CONFIG = {
-  appId: 'gczef0ey3e8ogpmizs',
-  serverUrl: TAPDB_EVENT_URL,
-} as const;
+// TapDB 项目按构建区域二选一,appId 与采集端点(serverUrl,SDK 直接 POST、不再
+// 追加路径)必须同区配对。appId 是公开应用标识(服务端 tapdbChargeReporter 同样
+// 硬编码同一对 ID),不属于凭证。
+//
+// ⚠️ 服务端把充值(charge)事件按部署区域报进对应 TapDB 项目,而 TapDB 只统计
+// 「同一项目里通过 SDK 上报过 user_login 的 user_id」的充值。客户端曾把两个区域
+// 都报进国内项目,导致国际项目全部充值因 user_id 无效不计入收入——这里的区域
+// 配对就是那次事故的修复,两侧 ID 必须与服务端 model-access-server 的
+// TAPDB_PROJECTS 保持一致。
+//
+// dev 是内部构建身份,行为语义归 cn 系(region-and-editions.md §1.1);其上报
+// 本身已被 isReportingBuild 闸住,仅 XDT_TAPDB_DEV=1 逃生口可达。
+export const TAPDB_PROJECT_BY_REGION: Readonly<
+  Record<CindyRegion, { appId: string; serverUrl: string }>
+> = Object.freeze({
+  cn: { appId: 'gczef0ey3e8ogpmizs', serverUrl: TAPDB_EVENT_URL_BY_REGION.cn },
+  global: { appId: 'h08anxdfrvfocfs894', serverUrl: TAPDB_EVENT_URL_BY_REGION.global },
+  dev: { appId: 'gczef0ey3e8ogpmizs', serverUrl: TAPDB_EVENT_URL_BY_REGION.dev },
+});
+
+const TAPDB_CONFIG = TAPDB_PROJECT_BY_REGION[CURRENT_CINDY_REGION];
 
 // ── Internal state ──────────────────────────────────────────────────────────
 
@@ -477,7 +495,7 @@ function initSdk(): void {
     sdkInitialized = true;
     applySuperProperties();
     reportActive('app_start');
-    log.info(`initialized, appId=${TAPDB_CONFIG.appId}`);
+    log.info(`initialized, region=${CURRENT_CINDY_REGION}, appId=${TAPDB_CONFIG.appId}`);
   } catch (err) {
     // SDK 自身崩溃绝不能影响主流程
     log.error('init failed (non-fatal)', err);

--- a/apps/desktop/src/shared/endpoints.ts
+++ b/apps/desktop/src/shared/endpoints.ts
@@ -11,6 +11,8 @@
  * 生产地址。空值表示当前构建未配置,消费方(clientEndpointsService)会阻断暴露。
  */
 
+import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
+
 function injectedEndpoint(value: string | undefined): string {
   return value?.trim().replace(/\/+$/, '') ?? '';
 }
@@ -28,5 +30,18 @@ export const ENDPOINT_MANIFEST_PEER_BASE_URL = injectedEndpoint(
   import.meta.env.VITE_ENDPOINT_MANIFEST_PEER_BASE_URL,
 );
 
-/** TapDB 埋点上报端点;第三方固定协议地址不属于生产端点私有配置。 */
-export const TAPDB_EVENT_URL = 'https://e.tapdb.com/event';
+/**
+ * TapDB 埋点上报端点,按构建区域二选一;第三方固定协议地址不属于生产端点私有配置。
+ *
+ * 与 TapDB 项目(appId)必须同区配对——global 构建报进国内采集端曾导致国际项目
+ * 缺失全部客户端行为数据,进而让服务端充值事件因 user_id 无效不计入收入统计。
+ * 配对关系的唯一消费点是 renderer/analytics/tapdbClient.ts 的 TAPDB_PROJECT_BY_REGION。
+ *
+ * dev 是内部构建身份,行为语义归 cn 系(region-and-editions.md §1.1),复用国内端点。
+ * Record 按 CindyRegion 穷举:新增区域时编译期强制在此决定采集端归属。
+ */
+export const TAPDB_EVENT_URL_BY_REGION: Readonly<Record<CindyRegion, string>> = Object.freeze({
+  cn: 'https://e.tapdb.com/event',
+  global: 'https://e.tapdb.ap-sg.tapapis.com/event',
+  dev: 'https://e.tapdb.com/event',
+});

--- a/scripts/check-endpoint-literals.mjs
+++ b/scripts/check-endpoint-literals.mjs
@@ -44,7 +44,11 @@ const ALLOWED_NON_PRODUCTION_ORIGINS = new Set([
   'http://localhost:3335',
   // model-access-server 本地开发兜底(服务端仓,端口 3339)
   'http://localhost:3339',
+  // TapDB 埋点采集端(cn / global 各一),第三方固定协议地址而非本产品生产端点,
+  // 不进入 config/endpoint*.json;与项目 appId 的区域配对见
+  // renderer/analytics/tapdbClient.ts 的 TAPDB_PROJECT_BY_REGION。
   'https://e.tapdb.com',
+  'https://e.tapdb.ap-sg.tapapis.com',
 ]);
 
 /** 解析单个 EAS profile 的继承 env，供门禁测试复用。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

Global 构建的 TapDB 上报此前与 cn 共用国内项目:`tapdbClient.ts` 写死国内 appId(`gczef0ey3e8ogpmizs`),`endpoints.ts` 写死国内采集端点(`e.tapdb.com`)。后果是国际 TapDB 项目里没有任何 `user_login` / `setUser` 数据,而服务端(model-access-server,global 部署)把充值 `charge` 事件按区域报进国际项目——TapDB 只统计「同一项目里通过 SDK 上报过的有效 user_id」的充值,国际项目的全部充值因 user_id 无效不计入收入统计(国内支付宝可见、国际 Stripe 不可见的根因)。

本 PR 把 TapDB 项目(appId)与采集端点按 `CindyRegion` 穷举配对:cn/dev → 国内项目,global → 国际项目(`h08anxdfrvfocfs894` + `e.tapdb.ap-sg.tapapis.com`),与服务端 `tapdbChargeReporter` 的 `TAPDB_PROJECTS` 保持一致,并用回归测试钉住配对关系。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无(排查国际版 TapDB 看不到充值统计时定位)
- 本 PR 包含：desktop TapDB appId/采集端点按区域配对;CSP 注释更新;回归测试
- 明确不包含：mobile(机制已区域化,global 构建的 clientId/clientToken 实际值在 gitignored self-host 配置,需另行人工核对);服务端(无需改动);历史充值数据回补
- 用户可见变化：无(纯统计上报通道修正)
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及:改动仅为 renderer 内 TapDB 统计上报的项目配对配置与对应测试,无任何视觉、交互或 UI 文案变化,未触碰组件、样式与布局代码。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/tapdbRegionProject.test.ts src/renderer/__tests__/tapdbConsentGate.test.ts
结果：2 files, 37 tests passed(含新增区域配对回归 3 条)

pnpm --filter desktop exec vitest run src/main/__tests__/webview-security.test.ts src/main/security/__tests__/csp.test.ts
结果：2 files, 52 tests passed(CSP/webview 安全门禁)

pnpm --filter desktop typecheck
结果：4 个既有错误(maker-host 的 @cindy/responses-anthropic-bridge 模块解析),在干净工作区(origin/main)同样失败,与本 PR 无关;本 PR 改动文件无类型错误
```

### 手工验证

- 对国际采集端点做过探活:`POST https://e.tapdb.ap-sg.tapapis.com/event?APIVersion=0.6.0` 返回 200,伪路径返回 403,证明采集路由存在(Web SDK 上报即拼接该形态 URL)。
- 以服务端同款 payload 向国际项目发送 `charge` 事件返回 200,验证国际项目 client_id 可接收数据。

### 未执行的验证

- 国际版 Web SDK serverUrl 无公开文档(SDK 为内部仓 vendored),`e.tapdb.ap-sg.tapapis.com/event` 为按服务端 REST 域名推导 + 探活验证的推定值;建议发布前用 global 测试构建在 TapDB 国际项目「埋点概览」确认 `device_login` / `user_login` 真实到达,或向 TapDB 支持核实。
- 未跑 desktop 全量测试(改动面为 TapDB 上报配置与注释,已跑受影响测试与安全门禁)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 global 构建的 TapDB 上报去向(cn/dev 构建行为与现状完全一致,配对值不变)。global 构建发布后,国际用户行为数据开始进入国际项目;此前误入国内项目的国际用户行为数据不迁移,国内项目的 DAU/新增设备口径会相应回落。充值统计在国际用户活跃一次(触发 user_login + setUser)后开始计入,历史 charge 一般不回溯。
- 回滚 / 降级方式：revert 本 commit 即回到全部报国内项目的旧行为;CSP 未放宽(生产 connect-src 本就含 https: 通配),无安全面回滚需求。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件（appId 为公开应用标识,客户端与服务端均硬编码）
- [x] 已补充必要文档（代码内注释记录事故背景与配对约束;无对外契约变更）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)

